### PR TITLE
Implement loading of array elements.

### DIFF
--- a/include/Reader/reader.h
+++ b/include/Reader/reader.h
@@ -2014,10 +2014,10 @@ public:
   virtual IRNode *loadConstantR4(float Value) = 0;
   virtual IRNode *loadConstantR8(double Value) = 0;
   virtual IRNode *loadElem(ReaderBaseNS::LdElemOpcode Opcode,
-                           CORINFO_RESOLVED_TOKEN *ResolvedToken, IRNode *Arg1,
-                           IRNode *Arg2) = 0;
-  virtual IRNode *loadElemA(CORINFO_RESOLVED_TOKEN *ResolvedToken, IRNode *Arg1,
-                            IRNode *Arg2, bool IsReadOnly) = 0;
+                           CORINFO_RESOLVED_TOKEN *ResolvedToken, IRNode *Index,
+                           IRNode *Array) = 0;
+  virtual IRNode *loadElemA(CORINFO_RESOLVED_TOKEN *ResolvedToken, IRNode *Index,
+                            IRNode *Array, bool IsReadOnly) = 0;
   virtual IRNode *loadField(CORINFO_RESOLVED_TOKEN *ResolvedToken, IRNode *Arg1,
                             ReaderAlignType Alignment, bool IsVolatile) = 0;
   virtual IRNode *loadIndir(ReaderBaseNS::LdIndirOpcode Opcode, IRNode *Address,

--- a/lib/Reader/reader.cpp
+++ b/lib/Reader/reader.cpp
@@ -4066,17 +4066,17 @@ IRNode *ReaderBase::loadIndir(ReaderBaseNS::LdIndirOpcode Opcode,
                               bool IsVolatile, bool IsInterfReadOnly,
                               bool AddressMayBeNull) {
   static const CorInfoType Map[ReaderBaseNS::LastLdindOpcode] = {
-      CORINFO_TYPE_BYTE,      // STIND_I1
-      CORINFO_TYPE_UBYTE,     // STIND_U1
-      CORINFO_TYPE_SHORT,     // STIND_I2
-      CORINFO_TYPE_USHORT,    // STIND_U2
-      CORINFO_TYPE_INT,       // STIND_I4
-      CORINFO_TYPE_UINT,      // STIND_U4
-      CORINFO_TYPE_LONG,      // STIND_I8
-      CORINFO_TYPE_NATIVEINT, // STIND_I
-      CORINFO_TYPE_FLOAT,     // STIND_R4
-      CORINFO_TYPE_DOUBLE,    // STIND_R8
-      CORINFO_TYPE_REFANY     // STIND_REF
+      CORINFO_TYPE_BYTE,      // LDIND_I1
+      CORINFO_TYPE_UBYTE,     // LDIND_U1
+      CORINFO_TYPE_SHORT,     // LDIND_I2
+      CORINFO_TYPE_USHORT,    // LDIND_U2
+      CORINFO_TYPE_INT,       // LDIND_I4
+      CORINFO_TYPE_UINT,      // LDIND_U4
+      CORINFO_TYPE_LONG,      // LDIND_I8
+      CORINFO_TYPE_NATIVEINT, // LDIND_I
+      CORINFO_TYPE_FLOAT,     // LDIND_R4
+      CORINFO_TYPE_DOUBLE,    // LDIND_R8
+      CORINFO_TYPE_REFANY     // LDIND_REF
   };
 
   ASSERTNR(Opcode >= ReaderBaseNS::LdindI1 &&

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Add1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Add1.error.txt
@@ -25,8 +25,8 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
@@ -40,8 +40,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
   %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
@@ -75,7 +75,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -90,8 +90,8 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %NullCheck = icmp ne i8 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = load i8, i8 addrspace(1)* %0, align 8
@@ -125,8 +125,8 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
@@ -159,8 +159,8 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -184,8 +184,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
   store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
@@ -195,8 +195,8 @@ entry:
 ; <label>:4                                       ; preds = %1
   %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
   %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
@@ -206,8 +206,8 @@ entry:
   %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
@@ -221,14 +221,14 @@ entry:
 
 ; <label>:17                                      ; preds = %14
   %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
   %21 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
@@ -238,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -249,8 +249,8 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
@@ -261,27 +261,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %30
+ThrowNullRef10:                                   ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -301,7 +301,89 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
-Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
+Successfully read AppDomainSetup.GetUnsecureApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.GetUnsecureApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %NullCheck = icmp eq %"System.String[]" addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %BoundsCheck = icmp uge i64 0, %5
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %6
+
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 3, i32 0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
+  ret %System.String addrspace(1)* %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_Value using LLILCJit
+Successfully read AppDomainSetup.get_Value
+
+define %"System.String[]" addrspace(1)* @AppDomainSetup.get_Value(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.String[]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 18)
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.String[]" addrspace(1)* addrspace(1)*, %"System.String[]" addrspace(1)*)*)(%"System.String[]" addrspace(1)* addrspace(1)* %9, %"System.String[]" addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %11, i32 0, i32 1
+  %14 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %13, align 8
+  ret %"System.String[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -319,8 +401,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -368,16 +450,16 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
   %5 = load i32, i32 addrspace(1)* %4
   %6 = sub i32 %5, 1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -389,7 +471,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -421,8 +503,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
@@ -456,8 +538,8 @@ entry:
 ; <label>:27                                      ; preds = %19
   %28 = load i32, i32* %arg1
   %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
-  br i1 %NullCheck2, label %30, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %29, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %30
 
 ; <label>:30                                      ; preds = %27
   %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
@@ -493,8 +575,8 @@ entry:
 ; <label>:49                                      ; preds = %46
   %50 = load i32, i32* %arg2
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck4, label %52, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
@@ -517,11 +599,11 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %27
+ThrowNullRef2:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %49
+ThrowNullRef4:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -544,16 +626,16 @@ entry:
   %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %0)
   store %System.String addrspace(1)* %1, %System.String addrspace(1)** %loc0
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 2
   %5 = bitcast [0 x i16] addrspace(1)* %4 to i16 addrspace(1)*
   store i16 addrspace(1)* %5, i16 addrspace(1)** %loc1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %3
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2
@@ -580,7 +662,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -691,15 +773,15 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %NullCheck132 = icmp ne i8* %21, null
-  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+  %NullCheck131 = icmp eq i8* %21, null
+  br i1 %NullCheck131, label %ThrowNullRef132, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = load i8, i8* %21, align 8
   %24 = zext i8 %23 to i32
   %25 = trunc i32 %24 to i8
-  %NullCheck134 = icmp ne i8* %20, null
-  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+  %NullCheck133 = icmp eq i8* %20, null
+  br i1 %NullCheck133, label %ThrowNullRef134, label %26
 
 ; <label>:26                                      ; preds = %22
   store i8 %25, i8* %20, align 8
@@ -709,16 +791,16 @@ entry:
   %28 = load i8*, i8** %arg0
   %29 = load i8*, i8** %arg1
   %30 = bitcast i8* %29 to i16*
-  %NullCheck128 = icmp ne i16* %30, null
-  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+  %NullCheck127 = icmp eq i16* %30, null
+  br i1 %NullCheck127, label %ThrowNullRef128, label %31
 
 ; <label>:31                                      ; preds = %27
   %32 = load i16, i16* %30, align 8
   %33 = sext i16 %32 to i32
   %34 = bitcast i8* %28 to i16*
   %35 = trunc i32 %33 to i16
-  %NullCheck130 = icmp ne i16* %34, null
-  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+  %NullCheck129 = icmp eq i16* %34, null
+  br i1 %NullCheck129, label %ThrowNullRef130, label %36
 
 ; <label>:36                                      ; preds = %31
   store i16 %35, i16* %34, align 8
@@ -728,16 +810,16 @@ entry:
   %38 = load i8*, i8** %arg0
   %39 = load i8*, i8** %arg1
   %40 = bitcast i8* %39 to i16*
-  %NullCheck120 = icmp ne i16* %40, null
-  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+  %NullCheck119 = icmp eq i16* %40, null
+  br i1 %NullCheck119, label %ThrowNullRef120, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i16, i16* %40, align 8
   %43 = sext i16 %42 to i32
   %44 = bitcast i8* %38 to i16*
   %45 = trunc i32 %43 to i16
-  %NullCheck122 = icmp ne i16* %44, null
-  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+  %NullCheck121 = icmp eq i16* %44, null
+  br i1 %NullCheck121, label %ThrowNullRef122, label %46
 
 ; <label>:46                                      ; preds = %41
   store i16 %45, i16* %44, align 8
@@ -745,15 +827,15 @@ entry:
   %48 = getelementptr inbounds i8, i8* %47, i64 2
   %49 = load i8*, i8** %arg1
   %50 = getelementptr inbounds i8, i8* %49, i64 2
-  %NullCheck124 = icmp ne i8* %50, null
-  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+  %NullCheck123 = icmp eq i8* %50, null
+  br i1 %NullCheck123, label %ThrowNullRef124, label %51
 
 ; <label>:51                                      ; preds = %46
   %52 = load i8, i8* %50, align 8
   %53 = zext i8 %52 to i32
   %54 = trunc i32 %53 to i8
-  %NullCheck126 = icmp ne i8* %48, null
-  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+  %NullCheck125 = icmp eq i8* %48, null
+  br i1 %NullCheck125, label %ThrowNullRef126, label %55
 
 ; <label>:55                                      ; preds = %51
   store i8 %54, i8* %48, align 8
@@ -763,14 +845,14 @@ entry:
   %57 = load i8*, i8** %arg0
   %58 = load i8*, i8** %arg1
   %59 = bitcast i8* %58 to i32*
-  %NullCheck116 = icmp ne i32* %59, null
-  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+  %NullCheck115 = icmp eq i32* %59, null
+  br i1 %NullCheck115, label %ThrowNullRef116, label %60
 
 ; <label>:60                                      ; preds = %56
   %61 = load i32, i32* %59, align 8
   %62 = bitcast i8* %57 to i32*
-  %NullCheck118 = icmp ne i32* %62, null
-  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+  %NullCheck117 = icmp eq i32* %62, null
+  br i1 %NullCheck117, label %ThrowNullRef118, label %63
 
 ; <label>:63                                      ; preds = %60
   store i32 %61, i32* %62, align 8
@@ -780,14 +862,14 @@ entry:
   %65 = load i8*, i8** %arg0
   %66 = load i8*, i8** %arg1
   %67 = bitcast i8* %66 to i32*
-  %NullCheck108 = icmp ne i32* %67, null
-  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+  %NullCheck107 = icmp eq i32* %67, null
+  br i1 %NullCheck107, label %ThrowNullRef108, label %68
 
 ; <label>:68                                      ; preds = %64
   %69 = load i32, i32* %67, align 8
   %70 = bitcast i8* %65 to i32*
-  %NullCheck110 = icmp ne i32* %70, null
-  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+  %NullCheck109 = icmp eq i32* %70, null
+  br i1 %NullCheck109, label %ThrowNullRef110, label %71
 
 ; <label>:71                                      ; preds = %68
   store i32 %69, i32* %70, align 8
@@ -795,15 +877,15 @@ entry:
   %73 = getelementptr inbounds i8, i8* %72, i64 4
   %74 = load i8*, i8** %arg1
   %75 = getelementptr inbounds i8, i8* %74, i64 4
-  %NullCheck112 = icmp ne i8* %75, null
-  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+  %NullCheck111 = icmp eq i8* %75, null
+  br i1 %NullCheck111, label %ThrowNullRef112, label %76
 
 ; <label>:76                                      ; preds = %71
   %77 = load i8, i8* %75, align 8
   %78 = zext i8 %77 to i32
   %79 = trunc i32 %78 to i8
-  %NullCheck114 = icmp ne i8* %73, null
-  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+  %NullCheck113 = icmp eq i8* %73, null
+  br i1 %NullCheck113, label %ThrowNullRef114, label %80
 
 ; <label>:80                                      ; preds = %76
   store i8 %79, i8* %73, align 8
@@ -813,14 +895,14 @@ entry:
   %82 = load i8*, i8** %arg0
   %83 = load i8*, i8** %arg1
   %84 = bitcast i8* %83 to i32*
-  %NullCheck100 = icmp ne i32* %84, null
-  br i1 %NullCheck100, label %85, label %ThrowNullRef99
+  %NullCheck99 = icmp eq i32* %84, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %85
 
 ; <label>:85                                      ; preds = %81
   %86 = load i32, i32* %84, align 8
   %87 = bitcast i8* %82 to i32*
-  %NullCheck102 = icmp ne i32* %87, null
-  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+  %NullCheck101 = icmp eq i32* %87, null
+  br i1 %NullCheck101, label %ThrowNullRef102, label %88
 
 ; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
@@ -829,16 +911,16 @@ entry:
   %91 = load i8*, i8** %arg1
   %92 = getelementptr inbounds i8, i8* %91, i64 4
   %93 = bitcast i8* %92 to i16*
-  %NullCheck104 = icmp ne i16* %93, null
-  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+  %NullCheck103 = icmp eq i16* %93, null
+  br i1 %NullCheck103, label %ThrowNullRef104, label %94
 
 ; <label>:94                                      ; preds = %88
   %95 = load i16, i16* %93, align 8
   %96 = sext i16 %95 to i32
   %97 = bitcast i8* %90 to i16*
   %98 = trunc i32 %96 to i16
-  %NullCheck106 = icmp ne i16* %97, null
-  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+  %NullCheck105 = icmp eq i16* %97, null
+  br i1 %NullCheck105, label %ThrowNullRef106, label %99
 
 ; <label>:99                                      ; preds = %94
   store i16 %98, i16* %97, align 8
@@ -848,14 +930,14 @@ entry:
   %101 = load i8*, i8** %arg0
   %102 = load i8*, i8** %arg1
   %103 = bitcast i8* %102 to i32*
-  %NullCheck88 = icmp ne i32* %103, null
-  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+  %NullCheck87 = icmp eq i32* %103, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %104
 
 ; <label>:104                                     ; preds = %100
   %105 = load i32, i32* %103, align 8
   %106 = bitcast i8* %101 to i32*
-  %NullCheck90 = icmp ne i32* %106, null
-  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+  %NullCheck89 = icmp eq i32* %106, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %107
 
 ; <label>:107                                     ; preds = %104
   store i32 %105, i32* %106, align 8
@@ -864,16 +946,16 @@ entry:
   %110 = load i8*, i8** %arg1
   %111 = getelementptr inbounds i8, i8* %110, i64 4
   %112 = bitcast i8* %111 to i16*
-  %NullCheck92 = icmp ne i16* %112, null
-  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+  %NullCheck91 = icmp eq i16* %112, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %113
 
 ; <label>:113                                     ; preds = %107
   %114 = load i16, i16* %112, align 8
   %115 = sext i16 %114 to i32
   %116 = bitcast i8* %109 to i16*
   %117 = trunc i32 %115 to i16
-  %NullCheck94 = icmp ne i16* %116, null
-  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+  %NullCheck93 = icmp eq i16* %116, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %118
 
 ; <label>:118                                     ; preds = %113
   store i16 %117, i16* %116, align 8
@@ -881,15 +963,15 @@ entry:
   %120 = getelementptr inbounds i8, i8* %119, i64 6
   %121 = load i8*, i8** %arg1
   %122 = getelementptr inbounds i8, i8* %121, i64 6
-  %NullCheck96 = icmp ne i8* %122, null
-  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+  %NullCheck95 = icmp eq i8* %122, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %123
 
 ; <label>:123                                     ; preds = %118
   %124 = load i8, i8* %122, align 8
   %125 = zext i8 %124 to i32
   %126 = trunc i32 %125 to i8
-  %NullCheck98 = icmp ne i8* %120, null
-  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+  %NullCheck97 = icmp eq i8* %120, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %127
 
 ; <label>:127                                     ; preds = %123
   store i8 %126, i8* %120, align 8
@@ -899,14 +981,14 @@ entry:
   %129 = load i8*, i8** %arg0
   %130 = load i8*, i8** %arg1
   %131 = bitcast i8* %130 to i64*
-  %NullCheck84 = icmp ne i64* %131, null
-  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+  %NullCheck83 = icmp eq i64* %131, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %132
 
 ; <label>:132                                     ; preds = %128
   %133 = load i64, i64* %131, align 8
   %134 = bitcast i8* %129 to i64*
-  %NullCheck86 = icmp ne i64* %134, null
-  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+  %NullCheck85 = icmp eq i64* %134, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %135
 
 ; <label>:135                                     ; preds = %132
   store i64 %133, i64* %134, align 8
@@ -916,14 +998,14 @@ entry:
   %137 = load i8*, i8** %arg0
   %138 = load i8*, i8** %arg1
   %139 = bitcast i8* %138 to i64*
-  %NullCheck76 = icmp ne i64* %139, null
-  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+  %NullCheck75 = icmp eq i64* %139, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %140
 
 ; <label>:140                                     ; preds = %136
   %141 = load i64, i64* %139, align 8
   %142 = bitcast i8* %137 to i64*
-  %NullCheck78 = icmp ne i64* %142, null
-  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+  %NullCheck77 = icmp eq i64* %142, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %143
 
 ; <label>:143                                     ; preds = %140
   store i64 %141, i64* %142, align 8
@@ -931,15 +1013,15 @@ entry:
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %NullCheck80 = icmp ne i8* %147, null
-  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+  %NullCheck79 = icmp eq i8* %147, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %148
 
 ; <label>:148                                     ; preds = %143
   %149 = load i8, i8* %147, align 8
   %150 = zext i8 %149 to i32
   %151 = trunc i32 %150 to i8
-  %NullCheck82 = icmp ne i8* %145, null
-  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+  %NullCheck81 = icmp eq i8* %145, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %152
 
 ; <label>:152                                     ; preds = %148
   store i8 %151, i8* %145, align 8
@@ -949,14 +1031,14 @@ entry:
   %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
   %156 = bitcast i8* %155 to i64*
-  %NullCheck68 = icmp ne i64* %156, null
-  br i1 %NullCheck68, label %157, label %ThrowNullRef67
+  %NullCheck67 = icmp eq i64* %156, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %157
 
 ; <label>:157                                     ; preds = %153
   %158 = load i64, i64* %156, align 8
   %159 = bitcast i8* %154 to i64*
-  %NullCheck70 = icmp ne i64* %159, null
-  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+  %NullCheck69 = icmp eq i64* %159, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %160
 
 ; <label>:160                                     ; preds = %157
   store i64 %158, i64* %159, align 8
@@ -965,16 +1047,16 @@ entry:
   %163 = load i8*, i8** %arg1
   %164 = getelementptr inbounds i8, i8* %163, i64 8
   %165 = bitcast i8* %164 to i16*
-  %NullCheck72 = icmp ne i16* %165, null
-  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+  %NullCheck71 = icmp eq i16* %165, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %166
 
 ; <label>:166                                     ; preds = %160
   %167 = load i16, i16* %165, align 8
   %168 = sext i16 %167 to i32
   %169 = bitcast i8* %162 to i16*
   %170 = trunc i32 %168 to i16
-  %NullCheck74 = icmp ne i16* %169, null
-  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+  %NullCheck73 = icmp eq i16* %169, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %171
 
 ; <label>:171                                     ; preds = %166
   store i16 %170, i16* %169, align 8
@@ -984,14 +1066,14 @@ entry:
   %173 = load i8*, i8** %arg0
   %174 = load i8*, i8** %arg1
   %175 = bitcast i8* %174 to i64*
-  %NullCheck56 = icmp ne i64* %175, null
-  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+  %NullCheck55 = icmp eq i64* %175, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %176
 
 ; <label>:176                                     ; preds = %172
   %177 = load i64, i64* %175, align 8
   %178 = bitcast i8* %173 to i64*
-  %NullCheck58 = icmp ne i64* %178, null
-  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+  %NullCheck57 = icmp eq i64* %178, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %179
 
 ; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
@@ -1000,16 +1082,16 @@ entry:
   %182 = load i8*, i8** %arg1
   %183 = getelementptr inbounds i8, i8* %182, i64 8
   %184 = bitcast i8* %183 to i16*
-  %NullCheck60 = icmp ne i16* %184, null
-  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+  %NullCheck59 = icmp eq i16* %184, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %185
 
 ; <label>:185                                     ; preds = %179
   %186 = load i16, i16* %184, align 8
   %187 = sext i16 %186 to i32
   %188 = bitcast i8* %181 to i16*
   %189 = trunc i32 %187 to i16
-  %NullCheck62 = icmp ne i16* %188, null
-  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+  %NullCheck61 = icmp eq i16* %188, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %190
 
 ; <label>:190                                     ; preds = %185
   store i16 %189, i16* %188, align 8
@@ -1017,15 +1099,15 @@ entry:
   %192 = getelementptr inbounds i8, i8* %191, i64 10
   %193 = load i8*, i8** %arg1
   %194 = getelementptr inbounds i8, i8* %193, i64 10
-  %NullCheck64 = icmp ne i8* %194, null
-  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+  %NullCheck63 = icmp eq i8* %194, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %195
 
 ; <label>:195                                     ; preds = %190
   %196 = load i8, i8* %194, align 8
   %197 = zext i8 %196 to i32
   %198 = trunc i32 %197 to i8
-  %NullCheck66 = icmp ne i8* %192, null
-  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+  %NullCheck65 = icmp eq i8* %192, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %199
 
 ; <label>:199                                     ; preds = %195
   store i8 %198, i8* %192, align 8
@@ -1035,14 +1117,14 @@ entry:
   %201 = load i8*, i8** %arg0
   %202 = load i8*, i8** %arg1
   %203 = bitcast i8* %202 to i64*
-  %NullCheck48 = icmp ne i64* %203, null
-  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+  %NullCheck47 = icmp eq i64* %203, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %204
 
 ; <label>:204                                     ; preds = %200
   %205 = load i64, i64* %203, align 8
   %206 = bitcast i8* %201 to i64*
-  %NullCheck50 = icmp ne i64* %206, null
-  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+  %NullCheck49 = icmp eq i64* %206, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %207
 
 ; <label>:207                                     ; preds = %204
   store i64 %205, i64* %206, align 8
@@ -1051,14 +1133,14 @@ entry:
   %210 = load i8*, i8** %arg1
   %211 = getelementptr inbounds i8, i8* %210, i64 8
   %212 = bitcast i8* %211 to i32*
-  %NullCheck52 = icmp ne i32* %212, null
-  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+  %NullCheck51 = icmp eq i32* %212, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %213
 
 ; <label>:213                                     ; preds = %207
   %214 = load i32, i32* %212, align 8
   %215 = bitcast i8* %209 to i32*
-  %NullCheck54 = icmp ne i32* %215, null
-  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+  %NullCheck53 = icmp eq i32* %215, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %216
 
 ; <label>:216                                     ; preds = %213
   store i32 %214, i32* %215, align 8
@@ -1068,14 +1150,14 @@ entry:
   %218 = load i8*, i8** %arg0
   %219 = load i8*, i8** %arg1
   %220 = bitcast i8* %219 to i64*
-  %NullCheck36 = icmp ne i64* %220, null
-  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64* %220, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %221
 
 ; <label>:221                                     ; preds = %217
   %222 = load i64, i64* %220, align 8
   %223 = bitcast i8* %218 to i64*
-  %NullCheck38 = icmp ne i64* %223, null
-  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+  %NullCheck37 = icmp eq i64* %223, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %224
 
 ; <label>:224                                     ; preds = %221
   store i64 %222, i64* %223, align 8
@@ -1084,14 +1166,14 @@ entry:
   %227 = load i8*, i8** %arg1
   %228 = getelementptr inbounds i8, i8* %227, i64 8
   %229 = bitcast i8* %228 to i32*
-  %NullCheck40 = icmp ne i32* %229, null
-  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i32* %229, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %230
 
 ; <label>:230                                     ; preds = %224
   %231 = load i32, i32* %229, align 8
   %232 = bitcast i8* %226 to i32*
-  %NullCheck42 = icmp ne i32* %232, null
-  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+  %NullCheck41 = icmp eq i32* %232, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %233
 
 ; <label>:233                                     ; preds = %230
   store i32 %231, i32* %232, align 8
@@ -1099,15 +1181,15 @@ entry:
   %235 = getelementptr inbounds i8, i8* %234, i64 12
   %236 = load i8*, i8** %arg1
   %237 = getelementptr inbounds i8, i8* %236, i64 12
-  %NullCheck44 = icmp ne i8* %237, null
-  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i8* %237, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %238
 
 ; <label>:238                                     ; preds = %233
   %239 = load i8, i8* %237, align 8
   %240 = zext i8 %239 to i32
   %241 = trunc i32 %240 to i8
-  %NullCheck46 = icmp ne i8* %235, null
-  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+  %NullCheck45 = icmp eq i8* %235, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %242
 
 ; <label>:242                                     ; preds = %238
   store i8 %241, i8* %235, align 8
@@ -1117,14 +1199,14 @@ entry:
   %244 = load i8*, i8** %arg0
   %245 = load i8*, i8** %arg1
   %246 = bitcast i8* %245 to i64*
-  %NullCheck24 = icmp ne i64* %246, null
-  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64* %246, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %247
 
 ; <label>:247                                     ; preds = %243
   %248 = load i64, i64* %246, align 8
   %249 = bitcast i8* %244 to i64*
-  %NullCheck26 = icmp ne i64* %249, null
-  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64* %249, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %250
 
 ; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
@@ -1133,14 +1215,14 @@ entry:
   %253 = load i8*, i8** %arg1
   %254 = getelementptr inbounds i8, i8* %253, i64 8
   %255 = bitcast i8* %254 to i32*
-  %NullCheck28 = icmp ne i32* %255, null
-  br i1 %NullCheck28, label %256, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i32* %255, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %256
 
 ; <label>:256                                     ; preds = %250
   %257 = load i32, i32* %255, align 8
   %258 = bitcast i8* %252 to i32*
-  %NullCheck30 = icmp ne i32* %258, null
-  br i1 %NullCheck30, label %259, label %ThrowNullRef29
+  %NullCheck29 = icmp eq i32* %258, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %259
 
 ; <label>:259                                     ; preds = %256
   store i32 %257, i32* %258, align 8
@@ -1149,16 +1231,16 @@ entry:
   %262 = load i8*, i8** %arg1
   %263 = getelementptr inbounds i8, i8* %262, i64 12
   %264 = bitcast i8* %263 to i16*
-  %NullCheck32 = icmp ne i16* %264, null
-  br i1 %NullCheck32, label %265, label %ThrowNullRef31
+  %NullCheck31 = icmp eq i16* %264, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %265
 
 ; <label>:265                                     ; preds = %259
   %266 = load i16, i16* %264, align 8
   %267 = sext i16 %266 to i32
   %268 = bitcast i8* %261 to i16*
   %269 = trunc i32 %267 to i16
-  %NullCheck34 = icmp ne i16* %268, null
-  br i1 %NullCheck34, label %270, label %ThrowNullRef33
+  %NullCheck33 = icmp eq i16* %268, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %270
 
 ; <label>:270                                     ; preds = %265
   store i16 %269, i16* %268, align 8
@@ -1168,14 +1250,14 @@ entry:
   %272 = load i8*, i8** %arg0
   %273 = load i8*, i8** %arg1
   %274 = bitcast i8* %273 to i64*
-  %NullCheck8 = icmp ne i64* %274, null
-  br i1 %NullCheck8, label %275, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64* %274, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %275
 
 ; <label>:275                                     ; preds = %271
   %276 = load i64, i64* %274, align 8
   %277 = bitcast i8* %272 to i64*
-  %NullCheck10 = icmp ne i64* %277, null
-  br i1 %NullCheck10, label %278, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %277, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %278
 
 ; <label>:278                                     ; preds = %275
   store i64 %276, i64* %277, align 8
@@ -1184,14 +1266,14 @@ entry:
   %281 = load i8*, i8** %arg1
   %282 = getelementptr inbounds i8, i8* %281, i64 8
   %283 = bitcast i8* %282 to i32*
-  %NullCheck12 = icmp ne i32* %283, null
-  br i1 %NullCheck12, label %284, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i32* %283, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %284
 
 ; <label>:284                                     ; preds = %278
   %285 = load i32, i32* %283, align 8
   %286 = bitcast i8* %280 to i32*
-  %NullCheck14 = icmp ne i32* %286, null
-  br i1 %NullCheck14, label %287, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i32* %286, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %287
 
 ; <label>:287                                     ; preds = %284
   store i32 %285, i32* %286, align 8
@@ -1200,16 +1282,16 @@ entry:
   %290 = load i8*, i8** %arg1
   %291 = getelementptr inbounds i8, i8* %290, i64 12
   %292 = bitcast i8* %291 to i16*
-  %NullCheck16 = icmp ne i16* %292, null
-  br i1 %NullCheck16, label %293, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i16* %292, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %293
 
 ; <label>:293                                     ; preds = %287
   %294 = load i16, i16* %292, align 8
   %295 = sext i16 %294 to i32
   %296 = bitcast i8* %289 to i16*
   %297 = trunc i32 %295 to i16
-  %NullCheck18 = icmp ne i16* %296, null
-  br i1 %NullCheck18, label %298, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i16* %296, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %298
 
 ; <label>:298                                     ; preds = %293
   store i16 %297, i16* %296, align 8
@@ -1217,15 +1299,15 @@ entry:
   %300 = getelementptr inbounds i8, i8* %299, i64 14
   %301 = load i8*, i8** %arg1
   %302 = getelementptr inbounds i8, i8* %301, i64 14
-  %NullCheck20 = icmp ne i8* %302, null
-  br i1 %NullCheck20, label %303, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i8* %302, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %303
 
 ; <label>:303                                     ; preds = %298
   %304 = load i8, i8* %302, align 8
   %305 = zext i8 %304 to i32
   %306 = trunc i32 %305 to i8
-  %NullCheck22 = icmp ne i8* %300, null
-  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i8* %300, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %307
 
 ; <label>:307                                     ; preds = %303
   store i8 %306, i8* %300, align 8
@@ -1235,14 +1317,14 @@ entry:
   %309 = load i8*, i8** %arg0
   %310 = load i8*, i8** %arg1
   %311 = bitcast i8* %310 to i64*
-  %NullCheck = icmp ne i64* %311, null
-  br i1 %NullCheck, label %312, label %ThrowNullRef
+  %NullCheck = icmp eq i64* %311, null
+  br i1 %NullCheck, label %ThrowNullRef, label %312
 
 ; <label>:312                                     ; preds = %308
   %313 = load i64, i64* %311, align 8
   %314 = bitcast i8* %309 to i64*
-  %NullCheck2 = icmp ne i64* %314, null
-  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64* %314, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %315
 
 ; <label>:315                                     ; preds = %312
   store i64 %313, i64* %314, align 8
@@ -1251,14 +1333,14 @@ entry:
   %318 = load i8*, i8** %arg1
   %319 = getelementptr inbounds i8, i8* %318, i64 8
   %320 = bitcast i8* %319 to i64*
-  %NullCheck4 = icmp ne i64* %320, null
-  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64* %320, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %321
 
 ; <label>:321                                     ; preds = %315
   %322 = load i64, i64* %320, align 8
   %323 = bitcast i8* %317 to i64*
-  %NullCheck6 = icmp ne i64* %323, null
-  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64* %323, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %324
 
 ; <label>:324                                     ; preds = %321
   store i64 %322, i64* %323, align 8
@@ -1286,15 +1368,15 @@ entry:
 ; <label>:338                                     ; preds = %333
   %339 = load i8*, i8** %arg0
   %340 = load i8*, i8** %arg1
-  %NullCheck136 = icmp ne i8* %340, null
-  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+  %NullCheck135 = icmp eq i8* %340, null
+  br i1 %NullCheck135, label %ThrowNullRef136, label %341
 
 ; <label>:341                                     ; preds = %338
   %342 = load i8, i8* %340, align 8
   %343 = zext i8 %342 to i32
   %344 = trunc i32 %343 to i8
-  %NullCheck138 = icmp ne i8* %339, null
-  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+  %NullCheck137 = icmp eq i8* %339, null
+  br i1 %NullCheck137, label %ThrowNullRef138, label %345
 
 ; <label>:345                                     ; preds = %341
   store i8 %344, i8* %339, align 8
@@ -1317,16 +1399,16 @@ entry:
   %357 = load i8*, i8** %arg0
   %358 = load i8*, i8** %arg1
   %359 = bitcast i8* %358 to i16*
-  %NullCheck140 = icmp ne i16* %359, null
-  br i1 %NullCheck140, label %360, label %ThrowNullRef139
+  %NullCheck139 = icmp eq i16* %359, null
+  br i1 %NullCheck139, label %ThrowNullRef140, label %360
 
 ; <label>:360                                     ; preds = %356
   %361 = load i16, i16* %359, align 8
   %362 = sext i16 %361 to i32
   %363 = bitcast i8* %357 to i16*
   %364 = trunc i32 %362 to i16
-  %NullCheck142 = icmp ne i16* %363, null
-  br i1 %NullCheck142, label %365, label %ThrowNullRef141
+  %NullCheck141 = icmp eq i16* %363, null
+  br i1 %NullCheck141, label %ThrowNullRef142, label %365
 
 ; <label>:365                                     ; preds = %360
   store i16 %364, i16* %363, align 8
@@ -1352,14 +1434,14 @@ entry:
   %378 = load i8*, i8** %arg0
   %379 = load i8*, i8** %arg1
   %380 = bitcast i8* %379 to i32*
-  %NullCheck144 = icmp ne i32* %380, null
-  br i1 %NullCheck144, label %381, label %ThrowNullRef143
+  %NullCheck143 = icmp eq i32* %380, null
+  br i1 %NullCheck143, label %ThrowNullRef144, label %381
 
 ; <label>:381                                     ; preds = %377
   %382 = load i32, i32* %380, align 8
   %383 = bitcast i8* %378 to i32*
-  %NullCheck146 = icmp ne i32* %383, null
-  br i1 %NullCheck146, label %384, label %ThrowNullRef145
+  %NullCheck145 = icmp eq i32* %383, null
+  br i1 %NullCheck145, label %ThrowNullRef146, label %384
 
 ; <label>:384                                     ; preds = %381
   store i32 %382, i32* %383, align 8
@@ -1384,14 +1466,14 @@ entry:
   %395 = load i8*, i8** %arg0
   %396 = load i8*, i8** %arg1
   %397 = bitcast i8* %396 to i64*
-  %NullCheck164 = icmp ne i64* %397, null
-  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+  %NullCheck163 = icmp eq i64* %397, null
+  br i1 %NullCheck163, label %ThrowNullRef164, label %398
 
 ; <label>:398                                     ; preds = %394
   %399 = load i64, i64* %397, align 8
   %400 = bitcast i8* %395 to i64*
-  %NullCheck166 = icmp ne i64* %400, null
-  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+  %NullCheck165 = icmp eq i64* %400, null
+  br i1 %NullCheck165, label %ThrowNullRef166, label %401
 
 ; <label>:401                                     ; preds = %398
   store i64 %399, i64* %400, align 8
@@ -1400,14 +1482,14 @@ entry:
   %404 = load i8*, i8** %arg1
   %405 = getelementptr inbounds i8, i8* %404, i64 8
   %406 = bitcast i8* %405 to i64*
-  %NullCheck168 = icmp ne i64* %406, null
-  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+  %NullCheck167 = icmp eq i64* %406, null
+  br i1 %NullCheck167, label %ThrowNullRef168, label %407
 
 ; <label>:407                                     ; preds = %401
   %408 = load i64, i64* %406, align 8
   %409 = bitcast i8* %403 to i64*
-  %NullCheck170 = icmp ne i64* %409, null
-  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+  %NullCheck169 = icmp eq i64* %409, null
+  br i1 %NullCheck169, label %ThrowNullRef170, label %410
 
 ; <label>:410                                     ; preds = %407
   store i64 %408, i64* %409, align 8
@@ -1437,14 +1519,14 @@ entry:
   %425 = load i8*, i8** %arg0
   %426 = load i8*, i8** %arg1
   %427 = bitcast i8* %426 to i64*
-  %NullCheck148 = icmp ne i64* %427, null
-  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+  %NullCheck147 = icmp eq i64* %427, null
+  br i1 %NullCheck147, label %ThrowNullRef148, label %428
 
 ; <label>:428                                     ; preds = %424
   %429 = load i64, i64* %427, align 8
   %430 = bitcast i8* %425 to i64*
-  %NullCheck150 = icmp ne i64* %430, null
-  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+  %NullCheck149 = icmp eq i64* %430, null
+  br i1 %NullCheck149, label %ThrowNullRef150, label %431
 
 ; <label>:431                                     ; preds = %428
   store i64 %429, i64* %430, align 8
@@ -1466,14 +1548,14 @@ entry:
   %441 = load i8*, i8** %arg0
   %442 = load i8*, i8** %arg1
   %443 = bitcast i8* %442 to i32*
-  %NullCheck152 = icmp ne i32* %443, null
-  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+  %NullCheck151 = icmp eq i32* %443, null
+  br i1 %NullCheck151, label %ThrowNullRef152, label %444
 
 ; <label>:444                                     ; preds = %440
   %445 = load i32, i32* %443, align 8
   %446 = bitcast i8* %441 to i32*
-  %NullCheck154 = icmp ne i32* %446, null
-  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+  %NullCheck153 = icmp eq i32* %446, null
+  br i1 %NullCheck153, label %ThrowNullRef154, label %447
 
 ; <label>:447                                     ; preds = %444
   store i32 %445, i32* %446, align 8
@@ -1495,16 +1577,16 @@ entry:
   %457 = load i8*, i8** %arg0
   %458 = load i8*, i8** %arg1
   %459 = bitcast i8* %458 to i16*
-  %NullCheck156 = icmp ne i16* %459, null
-  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+  %NullCheck155 = icmp eq i16* %459, null
+  br i1 %NullCheck155, label %ThrowNullRef156, label %460
 
 ; <label>:460                                     ; preds = %456
   %461 = load i16, i16* %459, align 8
   %462 = sext i16 %461 to i32
   %463 = bitcast i8* %457 to i16*
   %464 = trunc i32 %462 to i16
-  %NullCheck158 = icmp ne i16* %463, null
-  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+  %NullCheck157 = icmp eq i16* %463, null
+  br i1 %NullCheck157, label %ThrowNullRef158, label %465
 
 ; <label>:465                                     ; preds = %460
   store i16 %464, i16* %463, align 8
@@ -1525,15 +1607,15 @@ entry:
 ; <label>:474                                     ; preds = %470
   %475 = load i8*, i8** %arg0
   %476 = load i8*, i8** %arg1
-  %NullCheck160 = icmp ne i8* %476, null
-  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+  %NullCheck159 = icmp eq i8* %476, null
+  br i1 %NullCheck159, label %ThrowNullRef160, label %477
 
 ; <label>:477                                     ; preds = %474
   %478 = load i8, i8* %476, align 8
   %479 = zext i8 %478 to i32
   %480 = trunc i32 %479 to i8
-  %NullCheck162 = icmp ne i8* %475, null
-  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+  %NullCheck161 = icmp eq i8* %475, null
+  br i1 %NullCheck161, label %ThrowNullRef162, label %481
 
 ; <label>:481                                     ; preds = %477
   store i8 %480, i8* %475, align 8
@@ -1553,343 +1635,343 @@ ThrowNullRef:                                     ; preds = %308
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %312
+ThrowNullRef2:                                    ; preds = %312
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %315
+ThrowNullRef4:                                    ; preds = %315
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %321
+ThrowNullRef6:                                    ; preds = %321
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %271
+ThrowNullRef8:                                    ; preds = %271
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %275
+ThrowNullRef10:                                   ; preds = %275
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %278
+ThrowNullRef12:                                   ; preds = %278
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %284
+ThrowNullRef14:                                   ; preds = %284
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %287
+ThrowNullRef16:                                   ; preds = %287
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %293
+ThrowNullRef18:                                   ; preds = %293
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %298
+ThrowNullRef20:                                   ; preds = %298
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %303
+ThrowNullRef22:                                   ; preds = %303
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %243
+ThrowNullRef24:                                   ; preds = %243
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %247
+ThrowNullRef26:                                   ; preds = %247
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %250
+ThrowNullRef28:                                   ; preds = %250
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %256
+ThrowNullRef30:                                   ; preds = %256
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %259
+ThrowNullRef32:                                   ; preds = %259
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %265
+ThrowNullRef34:                                   ; preds = %265
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %217
+ThrowNullRef36:                                   ; preds = %217
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %221
+ThrowNullRef38:                                   ; preds = %221
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %224
+ThrowNullRef40:                                   ; preds = %224
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %230
+ThrowNullRef42:                                   ; preds = %230
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %233
+ThrowNullRef44:                                   ; preds = %233
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %238
+ThrowNullRef46:                                   ; preds = %238
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %200
+ThrowNullRef48:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %204
+ThrowNullRef50:                                   ; preds = %204
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %207
+ThrowNullRef52:                                   ; preds = %207
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %213
+ThrowNullRef54:                                   ; preds = %213
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %172
+ThrowNullRef56:                                   ; preds = %172
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %176
+ThrowNullRef58:                                   ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %179
+ThrowNullRef60:                                   ; preds = %179
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %185
+ThrowNullRef62:                                   ; preds = %185
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %190
+ThrowNullRef64:                                   ; preds = %190
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %195
+ThrowNullRef66:                                   ; preds = %195
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %153
+ThrowNullRef68:                                   ; preds = %153
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %157
+ThrowNullRef70:                                   ; preds = %157
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %160
+ThrowNullRef72:                                   ; preds = %160
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %166
+ThrowNullRef74:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %136
+ThrowNullRef76:                                   ; preds = %136
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %140
+ThrowNullRef78:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %143
+ThrowNullRef80:                                   ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %148
+ThrowNullRef82:                                   ; preds = %148
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %128
+ThrowNullRef84:                                   ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %132
+ThrowNullRef86:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %100
+ThrowNullRef88:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %104
+ThrowNullRef90:                                   ; preds = %104
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %107
+ThrowNullRef92:                                   ; preds = %107
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %113
+ThrowNullRef94:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %118
+ThrowNullRef96:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %123
+ThrowNullRef98:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %81
+ThrowNullRef100:                                  ; preds = %81
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef101:                                  ; preds = %85
+ThrowNullRef102:                                  ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef103:                                  ; preds = %88
+ThrowNullRef104:                                  ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef105:                                  ; preds = %94
+ThrowNullRef106:                                  ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef107:                                  ; preds = %64
+ThrowNullRef108:                                  ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef109:                                  ; preds = %68
+ThrowNullRef110:                                  ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef111:                                  ; preds = %71
+ThrowNullRef112:                                  ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef113:                                  ; preds = %76
+ThrowNullRef114:                                  ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef115:                                  ; preds = %56
+ThrowNullRef116:                                  ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef117:                                  ; preds = %60
+ThrowNullRef118:                                  ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef119:                                  ; preds = %37
+ThrowNullRef120:                                  ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef121:                                  ; preds = %41
+ThrowNullRef122:                                  ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef123:                                  ; preds = %46
+ThrowNullRef124:                                  ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef125:                                  ; preds = %51
+ThrowNullRef126:                                  ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef127:                                  ; preds = %27
+ThrowNullRef128:                                  ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef129:                                  ; preds = %31
+ThrowNullRef130:                                  ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef131:                                  ; preds = %19
+ThrowNullRef132:                                  ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef133:                                  ; preds = %22
+ThrowNullRef134:                                  ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef135:                                  ; preds = %338
+ThrowNullRef136:                                  ; preds = %338
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef137:                                  ; preds = %341
+ThrowNullRef138:                                  ; preds = %341
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef139:                                  ; preds = %356
+ThrowNullRef140:                                  ; preds = %356
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef141:                                  ; preds = %360
+ThrowNullRef142:                                  ; preds = %360
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef143:                                  ; preds = %377
+ThrowNullRef144:                                  ; preds = %377
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef145:                                  ; preds = %381
+ThrowNullRef146:                                  ; preds = %381
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef147:                                  ; preds = %424
+ThrowNullRef148:                                  ; preds = %424
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef149:                                  ; preds = %428
+ThrowNullRef150:                                  ; preds = %428
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef151:                                  ; preds = %440
+ThrowNullRef152:                                  ; preds = %440
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef153:                                  ; preds = %444
+ThrowNullRef154:                                  ; preds = %444
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef155:                                  ; preds = %456
+ThrowNullRef156:                                  ; preds = %456
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef157:                                  ; preds = %460
+ThrowNullRef158:                                  ; preds = %460
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef159:                                  ; preds = %474
+ThrowNullRef160:                                  ; preds = %474
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef161:                                  ; preds = %477
+ThrowNullRef162:                                  ; preds = %477
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef163:                                  ; preds = %394
+ThrowNullRef164:                                  ; preds = %394
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef165:                                  ; preds = %398
+ThrowNullRef166:                                  ; preds = %398
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef167:                                  ; preds = %401
+ThrowNullRef168:                                  ; preds = %401
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef169:                                  ; preds = %407
+ThrowNullRef170:                                  ; preds = %407
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1939,8 +2021,8 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
-  br i1 %NullCheck, label %22, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %ThrowNullRef, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
@@ -1948,8 +2030,8 @@ entry:
   store i32 %24, i32* %loc0
   %25 = load i32, i32* %loc0
   %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %26, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %27
 
 ; <label>:27                                      ; preds = %22
   %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
@@ -1971,7 +2053,7 @@ ThrowNullRef:                                     ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1989,8 +2071,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -2022,15 +2104,15 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2048,16 +2130,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
   %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
   store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %15
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
@@ -2072,8 +2154,8 @@ entry:
   %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
   %29 = ptrtoint i16 addrspace(1)* %28 to i64
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %19
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
@@ -2089,19 +2171,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2114,8 +2196,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
@@ -2128,7 +2210,7 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[loadElem]
+Failed to read AppDomain.PrepareDataForSetup[storeElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
@@ -2202,8 +2284,8 @@ entry:
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
-  br i1 %NullCheck24, label %27, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = load i64, i64 addrspace(1)* %26
@@ -2218,8 +2300,8 @@ entry:
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
-  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
   %41 = load i64, i64 addrspace(1)* %39
@@ -2236,8 +2318,8 @@ entry:
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
-  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
   %54 = load i64, i64 addrspace(1)* %52
@@ -2252,8 +2334,8 @@ entry:
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
   %67 = load i64, i64 addrspace(1)* %65
@@ -2270,8 +2352,8 @@ entry:
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
-  br i1 %NullCheck16, label %79, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
   %80 = load i64, i64 addrspace(1)* %78
@@ -2286,8 +2368,8 @@ entry:
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
-  br i1 %NullCheck18, label %92, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
   %93 = load i64, i64 addrspace(1)* %91
@@ -2304,8 +2386,8 @@ entry:
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
-  br i1 %NullCheck12, label %105, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = load i64, i64 addrspace(1)* %104
@@ -2320,8 +2402,8 @@ entry:
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
-  br i1 %NullCheck14, label %118, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
   %119 = load i64, i64 addrspace(1)* %117
@@ -2337,8 +2419,8 @@ entry:
 
 ; <label>:128                                     ; preds = %20
   %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
-  br i1 %NullCheck4, label %130, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %129, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %130
 
 ; <label>:130                                     ; preds = %128
   %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
@@ -2346,8 +2428,8 @@ entry:
   %133 = load i16, i16 addrspace(1)* %132, align 8
   %134 = zext i16 %133 to i32
   %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
-  br i1 %NullCheck6, label %136, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %135, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %136
 
 ; <label>:136                                     ; preds = %130
   %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
@@ -2360,8 +2442,8 @@ entry:
 
 ; <label>:143                                     ; preds = %136
   %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
-  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %144, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %145
 
 ; <label>:145                                     ; preds = %143
   %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
@@ -2369,8 +2451,8 @@ entry:
   %148 = load i16, i16 addrspace(1)* %147, align 8
   %149 = zext i16 %148 to i32
   %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %150, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %151
 
 ; <label>:151                                     ; preds = %145
   %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
@@ -2388,8 +2470,8 @@ entry:
 
 ; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
-  br i1 %NullCheck, label %163, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %ThrowNullRef, label %163
 
 ; <label>:163                                     ; preds = %161
   %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
@@ -2399,8 +2481,8 @@ entry:
 
 ; <label>:167                                     ; preds = %163
   %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
-  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %168, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %169
 
 ; <label>:169                                     ; preds = %167
   %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
@@ -2432,55 +2514,55 @@ ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %167
+ThrowNullRef2:                                    ; preds = %167
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %128
+ThrowNullRef4:                                    ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %130
+ThrowNullRef6:                                    ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %143
+ThrowNullRef8:                                    ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %145
+ThrowNullRef10:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %102
+ThrowNullRef12:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %105
+ThrowNullRef14:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %76
+ThrowNullRef16:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %79
+ThrowNullRef18:                                   ; preds = %79
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %50
+ThrowNullRef20:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %53
+ThrowNullRef22:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %24
+ThrowNullRef24:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %27
+ThrowNullRef26:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2503,15 +2585,15 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2519,16 +2601,16 @@ entry:
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
   store i32 %8, i32* %loc0
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
   %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
   store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
@@ -2546,16 +2628,16 @@ entry:
 
 ; <label>:23                                      ; preds = %64
   %24 = load i16*, i16** %loc3
-  %NullCheck12 = icmp ne i16* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i16* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
   store i32 %27, i32* %loc5
   %28 = load i16*, i16** %loc4
-  %NullCheck14 = icmp ne i16* %28, null
-  br i1 %NullCheck14, label %29, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %28, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = load i16, i16* %28, align 8
@@ -2620,15 +2702,15 @@ entry:
 
 ; <label>:67                                      ; preds = %64
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
-  br i1 %NullCheck8, label %69, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %68, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %69
 
 ; <label>:69                                      ; preds = %67
   %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
   %71 = load i32, i32 addrspace(1)* %70
   %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
-  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %73
 
 ; <label>:73                                      ; preds = %69
   %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
@@ -2645,31 +2727,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %67
+ThrowNullRef8:                                    ; preds = %67
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %69
+ThrowNullRef10:                                   ; preds = %69
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2710,14 +2792,14 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
   %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
@@ -2730,14 +2812,14 @@ entry:
 
 ; <label>:11                                      ; preds = %4
   %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
   %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
@@ -2749,14 +2831,14 @@ entry:
 
 ; <label>:22                                      ; preds = %16
   %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
   %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
-  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
-  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
@@ -2804,23 +2886,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2836,7 +2918,280 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[loadElem]
+Successfully read RuntimeType.IsAssignableFrom
+
+define i8 @RuntimeType.IsAssignableFrom(%System.RuntimeType addrspace(1)* %param0, %System.Type addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.RuntimeType addrspace(1)*
+  %arg1 = alloca %System.Type addrspace(1)*
+  %loc0 = alloca %System.RuntimeType addrspace(1)*
+  %loc1 = alloca %"System.Type[]" addrspace(1)*
+  %loc2 = alloca i32
+  store %System.RuntimeType addrspace(1)* %param0, %System.RuntimeType addrspace(1)** %this
+  store %System.Type addrspace(1)* %param1, %System.Type addrspace(1)** %arg1
+  %0 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %1 = icmp ne %System.Type addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i8 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %5 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %6 = bitcast %System.Type addrspace(1)* %4 to %System.Object addrspace(1)*
+  %7 = bitcast %System.RuntimeType addrspace(1)* %5 to %System.Object addrspace(1)*
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %6, %System.Object addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %3
+  ret i8 1
+
+; <label>:12                                      ; preds = %3
+  %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 152
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 32
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
+  %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
+  %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
+  store %System.RuntimeType addrspace(1)* %25, %System.RuntimeType addrspace(1)** %loc0
+  %26 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %27 = icmp eq %System.RuntimeType addrspace(1)* %26, null
+  br i1 %27, label %34, label %28
+
+; <label>:28                                      ; preds = %15
+  %29 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %30 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)*)*)(%System.RuntimeType addrspace(1)* %29, %System.RuntimeType addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+; <label>:34                                      ; preds = %15
+  %35 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %36 = call %System.Reflection.Emit.TypeBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Reflection.Emit.TypeBuilder addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %35)
+  %37 = icmp eq %System.Reflection.Emit.TypeBuilder addrspace(1)* %36, null
+  br i1 %37, label %139, label %38
+
+; <label>:38                                      ; preds = %34
+  %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %42
+
+; <label>:42                                      ; preds = %38
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 152
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 40
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
+  %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
+  %53 = zext i8 %52 to i32
+  %54 = icmp eq i32 %53, 0
+  br i1 %54, label %56, label %55
+
+; <label>:55                                      ; preds = %42
+  ret i8 1
+
+; <label>:56                                      ; preds = %42
+  %57 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %58 = bitcast %System.RuntimeType addrspace(1)* %57 to %System.Type addrspace(1)*
+  %59 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %58)
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %64 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.Type addrspace(1)* %63, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = bitcast %System.RuntimeType addrspace(1)* %64 to %System.Type addrspace(1)*
+  %67 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %63, %System.Type addrspace(1)* %66)
+  %68 = zext i8 %67 to i32
+  %69 = trunc i32 %68 to i8
+  ret i8 %69
+
+; <label>:70                                      ; preds = %56
+  %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
+  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %73
+
+; <label>:73                                      ; preds = %70
+  %74 = load i64, i64 addrspace(1)* %72
+  %75 = add i64 %74, 128
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = add i64 %77, 0
+  %79 = inttoptr i64 %78 to i64*
+  %80 = load i64, i64* %79
+  %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
+  %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
+  %83 = call i8 %82(%System.Type addrspace(1)* %81)
+  %84 = zext i8 %83 to i32
+  %85 = icmp eq i32 %84, 0
+  br i1 %85, label %139, label %86
+
+; <label>:86                                      ; preds = %73
+  %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
+  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %89
+
+; <label>:89                                      ; preds = %86
+  %90 = load i64, i64 addrspace(1)* %88
+  %91 = add i64 %90, 128
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = add i64 %93, 24
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
+  %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
+  %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
+  store %"System.Type[]" addrspace(1)* %99, %"System.Type[]" addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %129
+
+; <label>:100                                     ; preds = %132
+  %101 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %102 = load i32, i32* %loc2
+  %NullCheck11 = icmp eq %"System.Type[]" addrspace(1)* %101, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %103
+
+; <label>:103                                     ; preds = %100
+  %104 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 1
+  %105 = load i32, i32 addrspace(1)* %104
+  %106 = zext i32 %105 to i64
+  %107 = zext i32 %102 to i64
+  %BoundsCheck = icmp uge i64 %107, %106
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %108
+
+; <label>:108                                     ; preds = %103
+  %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
+  %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
+  %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
+  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %113
+
+; <label>:113                                     ; preds = %108
+  %114 = load i64, i64 addrspace(1)* %112
+  %115 = add i64 %114, 152
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = add i64 %117, 56
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
+  %123 = zext i8 %122 to i32
+  %124 = icmp ne i32 %123, 0
+  br i1 %124, label %126, label %125
+
+; <label>:125                                     ; preds = %113
+  ret i8 0
+
+; <label>:126                                     ; preds = %113
+  %127 = load i32, i32* %loc2
+  %128 = add i32 %127, 1
+  store i32 %128, i32* %loc2
+  br label %129
+
+; <label>:129                                     ; preds = %89, %126
+  %130 = load i32, i32* %loc2
+  %131 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %NullCheck9 = icmp eq %"System.Type[]" addrspace(1)* %131, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %132
+
+; <label>:132                                     ; preds = %129
+  %133 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %131, i32 0, i32 1
+  %134 = load i32, i32 addrspace(1)* %133
+  %135 = zext i32 %134 to i64
+  %136 = trunc i64 %135 to i32
+  %137 = icmp slt i32 %130, %136
+  br i1 %137, label %100, label %138
+
+; <label>:138                                     ; preds = %132
+  ret i8 1
+
+; <label>:139                                     ; preds = %34, %73
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %129
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %103
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -2893,7 +3248,7 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElem]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -2904,8 +3259,8 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -2997,8 +3352,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
@@ -3059,8 +3414,8 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -3087,8 +3442,8 @@ entry:
 
 ; <label>:17                                      ; preds = %5, %11
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
@@ -3097,8 +3452,8 @@ entry:
 
 ; <label>:22                                      ; preds = %1, %11
   %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
@@ -3109,11 +3464,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %17
+ThrowNullRef2:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %22
+ThrowNullRef4:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3167,15 +3522,15 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
   %15 = load i32, i32 addrspace(1)* %14
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
@@ -3198,7 +3553,7 @@ ThrowNullRef:                                     ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef2:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3232,8 +3587,8 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
@@ -3312,8 +3667,8 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -3327,8 +3682,8 @@ entry:
 ; <label>:5                                       ; preds = %43
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %7 = load i32, i32* %loc1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck6, label %8, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
@@ -3366,8 +3721,8 @@ entry:
 ; <label>:32                                      ; preds = %21, %25
   %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
   %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
-  br i1 %NullCheck8, label %35, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = trunc i32 %34 to i16
@@ -3380,8 +3735,8 @@ entry:
 ; <label>:40                                      ; preds = %1, %35
   %41 = load i32, i32* %loc1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
-  br i1 %NullCheck2, label %43, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %42, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
@@ -3392,8 +3747,8 @@ entry:
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
   %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
-  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
   %51 = load i64, i64 addrspace(1)* %49
@@ -3412,19 +3767,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %40
+ThrowNullRef2:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %47
+ThrowNullRef4:                                    ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %5
+ThrowNullRef6:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %32
+ThrowNullRef8:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3467,8 +3822,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
@@ -3492,11 +3847,391 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(i16* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store i16* %param0, i16** %arg0
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load i32, i32* %arg3
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %42, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %37, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg2
+  %13 = load i32, i32* %arg3
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %37, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %24 = load i32, i32* %arg2
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load i16*, i16** %arg0
+  %35 = load i32, i32* %arg3
+  %36 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %36, i16* %34, i32 %35)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:37                                      ; preds = %5, %16
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %39)
+  %41 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41, %System.String addrspace(1)* %38, %System.String addrspace(1)* %40)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41) #0
+  unreachable
+
+; <label>:42                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
-Failed to read StringBuilder.ToString[loadElemA]
+Successfully read StringBuilder.ToString
+
+define %System.String addrspace(1)* @StringBuilder.ToString(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i16*
+  %loc3 = alloca %"System.Char[]" addrspace(1)*
+  %loc4 = alloca i32
+  %loc5 = alloca i32
+  %loc6 = alloca i16 addrspace(1)*
+  %loc7 = alloca %System.String addrspace(1)*
+  %loc8 = alloca %"System.Char[]" addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %0)
+  %2 = icmp ne i32 %1, 0
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %4
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %6)
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %7)
+  store %System.String addrspace(1)* %8, %System.String addrspace(1)** %loc0
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.Text.StringBuilder addrspace(1)* %9, %System.Text.StringBuilder addrspace(1)** %loc1
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  store %System.String addrspace(1)* %10, %System.String addrspace(1)** %loc7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc7
+  %12 = ptrtoint %System.String addrspace(1)* %11 to i64
+  %13 = icmp eq i64 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %5
+  %15 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %16 = sext i32 %15 to i64
+  %17 = add i64 %12, %16
+  br label %18
+
+; <label>:18                                      ; preds = %5, %14
+  %19 = phi i64 [ %12, %5 ], [ %17, %14 ]
+  %20 = inttoptr i64 %19 to i16*
+  store i16* %20, i16** %loc2
+  br label %21
+
+; <label>:21                                      ; preds = %98, %18
+  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %22, null
+  br i1 %NullCheck, label %ThrowNullRef, label %23
+
+; <label>:23                                      ; preds = %21
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 3
+  %25 = load i32, i32 addrspace(1)* %24, align 8
+  %26 = icmp sle i32 %25, 0
+  br i1 %26, label %96, label %27
+
+; <label>:27                                      ; preds = %23
+  %28 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %28, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %29
+
+; <label>:29                                      ; preds = %27
+  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %28, i32 0, i32 1
+  %31 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %30, align 8
+  store %"System.Char[]" addrspace(1)* %31, %"System.Char[]" addrspace(1)** %loc3
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %33
+
+; <label>:33                                      ; preds = %29
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  store i32 %35, i32* %loc4
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  %39 = load i32, i32 addrspace(1)* %38, align 8
+  store i32 %39, i32* %loc5
+  %40 = load i32, i32* %loc5
+  %41 = load i32, i32* %loc4
+  %42 = add i32 %40, %41
+  %43 = zext i32 %42 to i64
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %45
+
+; <label>:45                                      ; preds = %37
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = sext i32 %47 to i64
+  %49 = icmp sgt i64 %43, %48
+  br i1 %49, label %91, label %50
+
+; <label>:50                                      ; preds = %45
+  %51 = load i32, i32* %loc5
+  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %52, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %53
+
+; <label>:53                                      ; preds = %50
+  %54 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %52, i32 0, i32 1
+  %55 = load i32, i32 addrspace(1)* %54
+  %56 = zext i32 %55 to i64
+  %57 = trunc i64 %56 to i32
+  %58 = icmp ugt i32 %51, %57
+  br i1 %58, label %91, label %59
+
+; <label>:59                                      ; preds = %53
+  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  store %"System.Char[]" addrspace(1)* %60, %"System.Char[]" addrspace(1)** %loc8
+  %61 = icmp eq %"System.Char[]" addrspace(1)* %60, null
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %63, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %64
+
+; <label>:64                                      ; preds = %62
+  %65 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %63, i32 0, i32 1
+  %66 = load i32, i32 addrspace(1)* %65
+  %67 = zext i32 %66 to i64
+  %68 = trunc i64 %67 to i32
+  %69 = icmp ne i32 %68, 0
+  br i1 %69, label %71, label %70
+
+; <label>:70                                      ; preds = %59, %64
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:71                                      ; preds = %64
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %73
+
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %BoundsCheck = icmp uge i64 0, %76
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %77
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %78, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:79                                      ; preds = %70, %77
+  %80 = load i16*, i16** %loc2
+  %81 = load i32, i32* %loc4
+  %82 = sext i32 %81 to i64
+  %83 = mul i64 %82, 2
+  %84 = bitcast i16* %80 to i8*
+  %85 = getelementptr inbounds i8, i8* %84, i64 %83
+  %86 = load i16 addrspace(1)*, i16 addrspace(1)** %loc6
+  %87 = ptrtoint i16 addrspace(1)* %86 to i64
+  %88 = load i32, i32* %loc5
+  %89 = bitcast i8* %85 to i16*
+  %90 = inttoptr i64 %87 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %89, i16* %90, i32 %88)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %96
+
+; <label>:91                                      ; preds = %45, %53
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %94 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %93)
+  %95 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95, %System.String addrspace(1)* %92, %System.String addrspace(1)* %94)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95) #0
+  unreachable
+
+; <label>:96                                      ; preds = %23, %79
+  %97 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %97, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %98
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %97, i32 0, i32 2
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  store %System.Text.StringBuilder addrspace(1)* %100, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %102 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %102, label %21, label %103
+
+; <label>:103                                     ; preds = %98
+  store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc7
+  %104 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  ret %System.String addrspace(1)* %104
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method StringBuilder::get_Length using LLILCJit
+Successfully read StringBuilder.get_Length
+
+define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
+Successfully read RuntimeHelpers.get_OffsetToStringData
+
+define i32 @RuntimeHelpers.get_OffsetToStringData() {
+entry:
+  ret i32 12
+}
+
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
 Successfully read CultureData.CreateCultureData
 
@@ -3514,23 +4249,23 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
   store i8 %4, i8 addrspace(1)* %6
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
@@ -3549,11 +4284,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3566,50 +4301,50 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
   store i32 -1, i32 addrspace(1)* %2
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
   store i32 -1, i32 addrspace(1)* %8
   %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
   store i32 -1, i32 addrspace(1)* %14
   %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
   store i32 -1, i32 addrspace(1)* %17
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
@@ -3623,27 +4358,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3675,7 +4410,136 @@ Failed to read Dictionary`2.Insert[non-const derefAddress]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
 Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
-Failed to read HashHelpers.GetPrime[loadElem]
+Successfully read HashHelpers.GetPrime
+
+define i32 @HashHelpers.GetPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %6, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5, %System.String addrspace(1)* %4)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5) #0
+  unreachable
+
+; <label>:6                                       ; preds = %entry
+  store i32 0, i32* %loc0
+  br label %29
+
+; <label>:7                                       ; preds = %35
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 1296
+  %10 = addrspacecast i8 addrspace(1)* %9 to %"System.Int32[]" addrspace(1)**
+  %11 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %10
+  %12 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Int32[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = zext i32 %15 to i64
+  %17 = zext i32 %12 to i64
+  %BoundsCheck = icmp uge i64 %17, %16
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 3, i32 %12
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  store i32 %20, i32* %loc1
+  %21 = load i32, i32* %loc1
+  %22 = load i32, i32* %arg0
+  %23 = icmp slt i32 %21, %22
+  br i1 %23, label %26, label %24
+
+; <label>:24                                      ; preds = %18
+  %25 = load i32, i32* %loc1
+  ret i32 %25
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %loc0
+  %28 = add i32 %27, 1
+  store i32 %28, i32* %loc0
+  br label %29
+
+; <label>:29                                      ; preds = %6, %26
+  %30 = load i32, i32* %loc0
+  %31 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %32 = getelementptr inbounds i8, i8 addrspace(1)* %31, i64 1296
+  %33 = addrspacecast i8 addrspace(1)* %32 to %"System.Int32[]" addrspace(1)**
+  %34 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %33
+  %NullCheck = icmp eq %"System.Int32[]" addrspace(1)* %34, null
+  br i1 %NullCheck, label %ThrowNullRef, label %35
+
+; <label>:35                                      ; preds = %29
+  %36 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %34, i32 0, i32 1
+  %37 = load i32, i32 addrspace(1)* %36
+  %38 = zext i32 %37 to i64
+  %39 = trunc i64 %38 to i32
+  %40 = icmp slt i32 %30, %39
+  br i1 %40, label %7, label %41
+
+; <label>:41                                      ; preds = %35
+  %42 = load i32, i32* %arg0
+  %43 = or i32 %42, 1
+  store i32 %43, i32* %loc2
+  br label %59
+
+; <label>:44                                      ; preds = %59
+  %45 = load i32, i32* %loc2
+  %46 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %45)
+  %47 = zext i8 %46 to i32
+  %48 = icmp eq i32 %47, 0
+  br i1 %48, label %56, label %49
+
+; <label>:49                                      ; preds = %44
+  %50 = load i32, i32* %loc2
+  %51 = sub i32 %50, 1
+  %52 = srem i32 %51, 101
+  %53 = icmp eq i32 %52, 0
+  br i1 %53, label %56, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = load i32, i32* %loc2
+  ret i32 %55
+
+; <label>:56                                      ; preds = %44, %49
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %57, 2
+  store i32 %58, i32* %loc2
+  br label %59
+
+; <label>:59                                      ; preds = %41, %56
+  %60 = load i32, i32* %loc2
+  %61 = icmp slt i32 %60, 2147483647
+  br i1 %61, label %44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load i32, i32* %arg0
+  ret i32 %63
+
+ThrowNullRef:                                     ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
 Successfully read GenericEqualityComparer`1.GetHashCode
 
@@ -3694,14 +4558,14 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
   %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load i64, i64 addrspace(1)* %7
@@ -3720,7 +4584,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3750,8 +4614,8 @@ entry:
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
@@ -3796,8 +4660,8 @@ entry:
   %35 = bitcast i16* %34 to i8*
   %36 = getelementptr inbounds i8, i8* %35, i64 2
   %37 = bitcast i8* %36 to i16*
-  %NullCheck4 = icmp ne i16* %37, null
-  br i1 %NullCheck4, label %38, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %37, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %38
 
 ; <label>:38                                      ; preds = %27
   %39 = load i16, i16* %37, align 8
@@ -3824,8 +4688,8 @@ entry:
 
 ; <label>:54                                      ; preds = %22, %43
   %55 = load i16*, i16** %loc4
-  %NullCheck2 = icmp ne i16* %55, null
-  br i1 %NullCheck2, label %56, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i16* %55, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %56
 
 ; <label>:56                                      ; preds = %54
   %57 = load i16, i16* %55, align 8
@@ -3850,11 +4714,11 @@ ThrowNullRef:                                     ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %54
+ThrowNullRef2:                                    ; preds = %54
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %27
+ThrowNullRef4:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3871,8 +4735,8 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -3907,8 +4771,8 @@ entry:
 
 ; <label>:26                                      ; preds = %19
   %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
-  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %28
 
 ; <label>:28                                      ; preds = %26
   %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
@@ -3920,7 +4784,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3972,8 +4836,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
@@ -3984,26 +4848,26 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
-  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
@@ -4014,8 +4878,8 @@ entry:
 ; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
@@ -4024,8 +4888,8 @@ entry:
 
 ; <label>:25                                      ; preds = %1, %16, %23
   %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
-  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
@@ -4036,27 +4900,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %20
+ThrowNullRef10:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4069,8 +4933,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -4081,8 +4945,8 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
@@ -4091,8 +4955,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1, %8
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
@@ -4103,11 +4967,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4128,24 +4992,24 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   store i32 %3, i32* %loc0
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
   %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
   store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck4, label %9, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
@@ -4164,15 +5028,15 @@ entry:
 ; <label>:18                                      ; preds = %70
   %19 = load i16*, i16** %loc3
   %20 = bitcast i16* %19 to i64*
-  %NullCheck10 = icmp ne i64* %20, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %20, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = load i64, i64* %20, align 8
   %23 = load i16*, i16** %loc4
   %24 = bitcast i16* %23 to i64*
-  %NullCheck12 = icmp ne i64* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = load i64, i64* %24, align 8
@@ -4188,8 +5052,8 @@ entry:
   %31 = bitcast i16* %30 to i8*
   %32 = getelementptr inbounds i8, i8* %31, i64 8
   %33 = bitcast i8* %32 to i64*
-  %NullCheck14 = icmp ne i64* %33, null
-  br i1 %NullCheck14, label %34, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = load i64, i64* %33, align 8
@@ -4197,8 +5061,8 @@ entry:
   %37 = bitcast i16* %36 to i8*
   %38 = getelementptr inbounds i8, i8* %37, i64 8
   %39 = bitcast i8* %38 to i64*
-  %NullCheck16 = icmp ne i64* %39, null
-  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %40
 
 ; <label>:40                                      ; preds = %34
   %41 = load i64, i64* %39, align 8
@@ -4214,8 +5078,8 @@ entry:
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %NullCheck18 = icmp ne i64* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = load i64, i64* %48, align 8
@@ -4223,8 +5087,8 @@ entry:
   %52 = bitcast i16* %51 to i8*
   %53 = getelementptr inbounds i8, i8* %52, i64 16
   %54 = bitcast i8* %53 to i64*
-  %NullCheck20 = icmp ne i64* %54, null
-  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64* %54, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %55
 
 ; <label>:55                                      ; preds = %49
   %56 = load i64, i64* %54, align 8
@@ -4262,15 +5126,15 @@ entry:
 ; <label>:74                                      ; preds = %95
   %75 = load i16*, i16** %loc3
   %76 = bitcast i16* %75 to i32*
-  %NullCheck6 = icmp ne i32* %76, null
-  br i1 %NullCheck6, label %77, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32* %76, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %77
 
 ; <label>:77                                      ; preds = %74
   %78 = load i32, i32* %76, align 8
   %79 = load i16*, i16** %loc4
   %80 = bitcast i16* %79 to i32*
-  %NullCheck8 = icmp ne i32* %80, null
-  br i1 %NullCheck8, label %81, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i32* %80, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %81
 
 ; <label>:81                                      ; preds = %77
   %82 = load i32, i32* %80, align 8
@@ -4318,43 +5182,43 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %74
+ThrowNullRef6:                                    ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %77
+ThrowNullRef8:                                    ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %29
+ThrowNullRef14:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %34
+ThrowNullRef16:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4376,8 +5240,8 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load i64, i64 addrspace(1)* %4
@@ -4389,8 +5253,8 @@ entry:
   %12 = load i64, i64* %11
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %5
   %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
@@ -4399,8 +5263,8 @@ entry:
   %18 = load i8, i8* %arg2
   %19 = zext i8 %18 to i32
   %20 = trunc i32 %19 to i8
-  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %15
   %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
@@ -4411,11 +5275,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4442,8 +5306,8 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
@@ -4466,16 +5330,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
   %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = load i64, i64 addrspace(1)* %19
@@ -4500,8 +5364,8 @@ entry:
 ; <label>:35                                      ; preds = %30
   %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
@@ -4514,8 +5378,8 @@ entry:
 
 ; <label>:42                                      ; preds = %1, %38
   %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
-  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
@@ -4526,19 +5390,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %35
+ThrowNullRef2:                                    ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %42
+ThrowNullRef8:                                    ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4551,14 +5415,14 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
@@ -4570,7 +5434,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4583,8 +5447,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
@@ -4613,51 +5477,51 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
   %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
   %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
   %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
   %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
-  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
   store i64 %21, i64 addrspace(1)* %23
   %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %25 = load i64, i64* %loc0
-  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
@@ -4668,27 +5532,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %22
+ThrowNullRef12:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4701,8 +5565,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
@@ -4713,19 +5577,19 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
@@ -4734,8 +5598,8 @@ entry:
 
 ; <label>:15                                      ; preds = %1, %13
   %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
@@ -4746,19 +5610,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %15
+ThrowNullRef8:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4771,8 +5635,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -4831,8 +5695,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
@@ -4882,8 +5746,8 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
-  br i1 %NullCheck, label %17, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %ThrowNullRef, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
@@ -4894,15 +5758,15 @@ entry:
 
 ; <label>:22                                      ; preds = %17
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
-  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
   %26 = load i32, i32 addrspace(1)* %25
   %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
-  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %27, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
@@ -4925,8 +5789,8 @@ entry:
 ; <label>:40                                      ; preds = %17
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
-  br i1 %NullCheck6, label %43, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %41, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
@@ -4938,34 +5802,17 @@ ThrowNullRef:                                     ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %24
+ThrowNullRef4:                                    ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %40
+ThrowNullRef6:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
-}
-
-INFO:  jitting method Object::ReferenceEquals using LLILCJit
-Successfully read Object.ReferenceEquals
-
-define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
-entry:
-  %arg0 = alloca %System.Object addrspace(1)*
-  %arg1 = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
-  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
-  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = icmp eq %System.Object addrspace(1)* %0, %1
-  %3 = sext i1 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
 }
 
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
@@ -4978,21 +5825,21 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
   %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
-  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
@@ -5007,28 +5854,28 @@ entry:
 ; <label>:13                                      ; preds = %8, %12
   %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
   %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
   %21 = load i32, i32 addrspace(1)* %20, align 8
   %22 = add i32 %21, 1
-  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
   store i32 %22, i32 addrspace(1)* %24
   %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
@@ -5039,27 +5886,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5077,7 +5924,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::Setup using LLILCJit
-Failed to read AppDomain.Setup[loadElem]
+Failed to read AppDomain.Setup[unbox]
 INFO:  jitting method Thread::GetDomain using LLILCJit
 Successfully read Thread.GetDomain
 
@@ -5108,8 +5955,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
@@ -5122,14 +5969,14 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
   %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
@@ -5141,11 +5988,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5173,8 +6020,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -5189,7 +6036,328 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
 Failed to read KeyCollection.System.Collections.Generic.IEnumerable<TKey>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Successfully read Enumerator.MoveNext
+
+define i8 @Enumerator.MoveNext(%"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.RuntimeTypeHandle* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*
+  %"$TypeArg" = alloca %System.RuntimeTypeHandle*
+  store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
+  %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 8
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %76, label %12
+
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
+  br label %76
+
+; <label>:13                                      ; preds = %85
+  %14 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck19 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %15
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, i32 0, i32 0
+  %17 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %16, align 8
+  %NullCheck21 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, i32 0, i32 2
+  %20 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %19, align 8
+  %21 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck23 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %22
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, i32 0, i32 2
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %NullCheck25 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 3, i32 %24
+  %NullCheck27 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %32
+
+; <label>:32                                      ; preds = %30
+  %33 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, i32 0, i32 2
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = icmp slt i32 %34, 0
+  br i1 %35, label %68, label %36
+
+; <label>:36                                      ; preds = %32
+  %37 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %38 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck29 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %39
+
+; <label>:39                                      ; preds = %36
+  %40 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, i32 0, i32 0
+  %41 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %40, align 8
+  %NullCheck31 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, i32 0, i32 2
+  %44 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %43, align 8
+  %45 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck33 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, i32 0, i32 2
+  %48 = load i32, i32 addrspace(1)* %47, align 8
+  %NullCheck35 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %49
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = zext i32 %51 to i64
+  %53 = zext i32 %48 to i64
+  %BoundsCheck37 = icmp uge i64 %53, %52
+  br i1 %BoundsCheck37, label %ThrowIndexOutOfRange38, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 3, i32 %48
+  %NullCheck39 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %56
+
+; <label>:56                                      ; preds = %54
+  %57 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, i32 0, i32 0
+  %58 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck41 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %59
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %60, %System.__Canon addrspace(1)* %58)
+  %61 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck43 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  %64 = load i32, i32 addrspace(1)* %63, align 8
+  %65 = add i32 %64, 1
+  %NullCheck45 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  store i32 %65, i32 addrspace(1)* %67
+  ret i8 1
+
+; <label>:68                                      ; preds = %32
+  %69 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck47 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %73 = add i32 %72, 1
+  %NullCheck49 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %74
+
+; <label>:74                                      ; preds = %70
+  %75 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  store i32 %73, i32 addrspace(1)* %75
+  br label %76
+
+; <label>:76                                      ; preds = %8, %12, %74
+  %77 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %78
+
+; <label>:78                                      ; preds = %76
+  %79 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, i32 0, i32 2
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck7 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %82
+
+; <label>:82                                      ; preds = %78
+  %83 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, i32 0, i32 0
+  %84 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %83, align 8
+  %NullCheck9 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %85
+
+; <label>:85                                      ; preds = %82
+  %86 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, i32 0, i32 7
+  %87 = load i32, i32 addrspace(1)* %86, align 8
+  %88 = icmp ult i32 %80, %87
+  br i1 %88, label %13, label %89
+
+; <label>:89                                      ; preds = %85
+  %90 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %91 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck11 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %92
+
+; <label>:92                                      ; preds = %89
+  %93 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, i32 0, i32 0
+  %94 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck13 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %95
+
+; <label>:95                                      ; preds = %92
+  %96 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, i32 0, i32 7
+  %97 = load i32, i32 addrspace(1)* %96, align 8
+  %98 = add i32 %97, 1
+  %NullCheck15 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %99
+
+; <label>:99                                      ; preds = %95
+  %100 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, i32 0, i32 2
+  store i32 %98, i32 addrspace(1)* %100
+  %101 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck17 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %102
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %103, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %92
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef22:                                   ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef24:                                   ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef26:                                   ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef28:                                   ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef30:                                   ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef32:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef34:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef36:                                   ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange38:                           ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef40:                                   ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef42:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef44:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef46:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef48:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef50:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -5200,8 +6368,8 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -5232,9 +6400,9 @@ Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
 Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
-Failed to read String.MakeSeparatorList[loadElemA]
+Failed to read String.MakeSeparatorList[storeElem]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
-Failed to read String.InternalSplitKeepEmptyEntries[loadElem]
+Failed to read String.InternalSplitKeepEmptyEntries[storeElem]
 INFO:  jitting method Path::IsRelative using LLILCJit
 Successfully read Path.IsRelative
 
@@ -5243,8 +6411,8 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -5254,8 +6422,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
@@ -5271,8 +6439,8 @@ entry:
 
 ; <label>:17                                      ; preds = %7
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
@@ -5288,8 +6456,8 @@ entry:
 
 ; <label>:29                                      ; preds = %19
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %31
 
 ; <label>:31                                      ; preds = %29
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
@@ -5300,8 +6468,8 @@ entry:
 
 ; <label>:36                                      ; preds = %31
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
-  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %37, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
@@ -5312,8 +6480,8 @@ entry:
 
 ; <label>:43                                      ; preds = %31, %38
   %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
-  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %45
 
 ; <label>:45                                      ; preds = %43
   %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
@@ -5324,8 +6492,8 @@ entry:
 
 ; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %50
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
@@ -5336,8 +6504,8 @@ entry:
 
 ; <label>:57                                      ; preds = %1, %7, %19, %45, %52
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
-  br i1 %NullCheck14, label %59, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %59
 
 ; <label>:59                                      ; preds = %57
   %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
@@ -5347,8 +6515,8 @@ entry:
 
 ; <label>:63                                      ; preds = %59
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
@@ -5359,8 +6527,8 @@ entry:
 
 ; <label>:70                                      ; preds = %65
   %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
-  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.String addrspace(1)* %71, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %72
 
 ; <label>:72                                      ; preds = %70
   %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
@@ -5379,39 +6547,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %17
+ThrowNullRef4:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %29
+ThrowNullRef6:                                    ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %36
+ThrowNullRef8:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %43
+ThrowNullRef10:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %50
+ThrowNullRef12:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %57
+ThrowNullRef14:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %63
+ThrowNullRef16:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %70
+ThrowNullRef18:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5419,7 +6587,293 @@ ThrowNullRef17:                                   ; preds = %70
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
-Failed to read String.TrimHelper[loadElem]
+Successfully read String.TrimHelper
+
+define %System.String addrspace(1)* @String.TrimHelper(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i16
+  %loc4 = alloca i32
+  %loc5 = alloca i16
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = sub i32 %3, 1
+  store i32 %4, i32* %loc0
+  store i32 0, i32* %loc1
+  %5 = load i32, i32* %arg2
+  %6 = icmp eq i32 %5, 1
+  br i1 %6, label %62, label %7
+
+; <label>:7                                       ; preds = %1
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:8                                       ; preds = %58
+  store i32 0, i32* %loc2
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load i32, i32* %loc1
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2, i32 %10
+  %13 = load i16, i16 addrspace(1)* %12
+  %14 = zext i16 %13 to i32
+  %15 = trunc i32 %14 to i16
+  store i16 %15, i16* %loc3
+  store i32 0, i32* %loc2
+  br label %34
+
+; <label>:16                                      ; preds = %37
+  %17 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %18 = load i32, i32* %loc2
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %17, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %19
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = zext i32 %18 to i64
+  %BoundsCheck = icmp uge i64 %23, %22
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %24
+
+; <label>:24                                      ; preds = %19
+  %25 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 3, i32 %18
+  %26 = load i16, i16 addrspace(1)* %25, align 8
+  %27 = zext i16 %26 to i32
+  %28 = load i16, i16* %loc3
+  %29 = zext i16 %28 to i32
+  %30 = icmp eq i32 %27, %29
+  br i1 %30, label %43, label %31
+
+; <label>:31                                      ; preds = %24
+  %32 = load i32, i32* %loc2
+  %33 = add i32 %32, 1
+  store i32 %33, i32* %loc2
+  br label %34
+
+; <label>:34                                      ; preds = %11, %31
+  %35 = load i32, i32* %loc2
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = icmp slt i32 %35, %41
+  br i1 %42, label %16, label %43
+
+; <label>:43                                      ; preds = %24, %37
+  %44 = load i32, i32* %loc2
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %45, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp eq i32 %44, %50
+  br i1 %51, label %62, label %52
+
+; <label>:52                                      ; preds = %46
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %7, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %57, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %58
+
+; <label>:58                                      ; preds = %55
+  %59 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %60 = load i32, i32 addrspace(1)* %59
+  %61 = icmp slt i32 %56, %60
+  br i1 %61, label %8, label %62
+
+; <label>:62                                      ; preds = %1, %46, %58
+  %63 = load i32, i32* %arg2
+  %64 = icmp eq i32 %63, 0
+  br i1 %64, label %122, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %66, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %67
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %66, i32 0, i32 1
+  %69 = load i32, i32 addrspace(1)* %68
+  %70 = sub i32 %69, 1
+  store i32 %70, i32* %loc0
+  br label %118
+
+; <label>:71                                      ; preds = %118
+  store i32 0, i32* %loc4
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %73 = load i32, i32* %loc0
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %74
+
+; <label>:74                                      ; preds = %71
+  %75 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 2, i32 %73
+  %76 = load i16, i16 addrspace(1)* %75
+  %77 = zext i16 %76 to i32
+  %78 = trunc i32 %77 to i16
+  store i16 %78, i16* %loc5
+  store i32 0, i32* %loc4
+  br label %97
+
+; <label>:79                                      ; preds = %100
+  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %81 = load i32, i32* %loc4
+  %NullCheck19 = icmp eq %"System.Char[]" addrspace(1)* %80, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
+
+; <label>:82                                      ; preds = %79
+  %83 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 1
+  %84 = load i32, i32 addrspace(1)* %83
+  %85 = zext i32 %84 to i64
+  %86 = zext i32 %81 to i64
+  %BoundsCheck21 = icmp uge i64 %86, %85
+  br i1 %BoundsCheck21, label %ThrowIndexOutOfRange22, label %87
+
+; <label>:87                                      ; preds = %82
+  %88 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 3, i32 %81
+  %89 = load i16, i16 addrspace(1)* %88, align 8
+  %90 = zext i16 %89 to i32
+  %91 = load i16, i16* %loc5
+  %92 = zext i16 %91 to i32
+  %93 = icmp eq i32 %90, %92
+  br i1 %93, label %106, label %94
+
+; <label>:94                                      ; preds = %87
+  %95 = load i32, i32* %loc4
+  %96 = add i32 %95, 1
+  store i32 %96, i32* %loc4
+  br label %97
+
+; <label>:97                                      ; preds = %74, %94
+  %98 = load i32, i32* %loc4
+  %99 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck15 = icmp eq %"System.Char[]" addrspace(1)* %99, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %100
+
+; <label>:100                                     ; preds = %97
+  %101 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %99, i32 0, i32 1
+  %102 = load i32, i32 addrspace(1)* %101
+  %103 = zext i32 %102 to i64
+  %104 = trunc i64 %103 to i32
+  %105 = icmp slt i32 %98, %104
+  br i1 %105, label %79, label %106
+
+; <label>:106                                     ; preds = %87, %100
+  %107 = load i32, i32* %loc4
+  %108 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck17 = icmp eq %"System.Char[]" addrspace(1)* %108, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %109
+
+; <label>:109                                     ; preds = %106
+  %110 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %108, i32 0, i32 1
+  %111 = load i32, i32 addrspace(1)* %110
+  %112 = zext i32 %111 to i64
+  %113 = trunc i64 %112 to i32
+  %114 = icmp eq i32 %107, %113
+  br i1 %114, label %122, label %115
+
+; <label>:115                                     ; preds = %109
+  %116 = load i32, i32* %loc0
+  %117 = sub i32 %116, 1
+  store i32 %117, i32* %loc0
+  br label %118
+
+; <label>:118                                     ; preds = %67, %115
+  %119 = load i32, i32* %loc0
+  %120 = load i32, i32* %loc1
+  %121 = icmp sge i32 %119, %120
+  br i1 %121, label %71, label %122
+
+; <label>:122                                     ; preds = %62, %109, %118
+  %123 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %124 = load i32, i32* %loc1
+  %125 = load i32, i32* %loc0
+  %126 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %123, i32 %124, i32 %125)
+  ret %System.String addrspace(1)* %126
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %97
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange22:                           ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
 Successfully read String.CreateTrimmedString
 
@@ -5439,8 +6893,8 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
@@ -5535,8 +6989,8 @@ entry:
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i64 2872
   %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
   %8 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %7
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %3
   %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
@@ -5553,8 +7007,8 @@ entry:
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 2864
   %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
   %21 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %20
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
-  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %22
 
 ; <label>:22                                      ; preds = %16
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
@@ -5569,7 +7023,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %16
+ThrowNullRef2:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5586,8 +7040,8 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5613,8 +7067,8 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
@@ -5632,8 +7086,8 @@ entry:
 
 ; <label>:12                                      ; preds = %4
   %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
@@ -5644,8 +7098,8 @@ entry:
 
 ; <label>:19                                      ; preds = %14
   %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %19
   %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
@@ -5660,21 +7114,21 @@ entry:
   %31 = zext i16 %30 to i32
   %32 = bitcast i8* %29 to i16*
   %33 = trunc i32 %31 to i16
-  %NullCheck6 = icmp ne i16* %32, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i16* %32, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %21
   store i16 %33, i16* %32, align 8
   %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %36
 
 ; <label>:36                                      ; preds = %34
   %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
   %38 = load i32, i32 addrspace(1)* %37, align 8
   %39 = add i32 %38, 1
-  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %40
 
 ; <label>:40                                      ; preds = %36
   %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
@@ -5683,16 +7137,16 @@ entry:
 
 ; <label>:42                                      ; preds = %14
   %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
-  br i1 %NullCheck12, label %44, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
   %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
   %47 = load i16, i16* %arg1
   %48 = zext i16 %47 to i32
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = trunc i32 %48 to i16
@@ -5703,31 +7157,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %19
+ThrowNullRef4:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %21
+ThrowNullRef6:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %36
+ThrowNullRef10:                                   ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %42
+ThrowNullRef12:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %44
+ThrowNullRef14:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5740,8 +7194,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -5752,8 +7206,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
@@ -5762,14 +7216,14 @@ entry:
 
 ; <label>:11                                      ; preds = %1
   %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
@@ -5779,15 +7233,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5808,8 +7262,8 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5822,8 +7276,8 @@ entry:
 
 ; <label>:8                                       ; preds = %3
   %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
@@ -5842,15 +7296,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
-  br i1 %NullCheck4, label %22, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
   %24 = load i16*, i16* addrspace(1)* %23, align 8
   %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %25, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
@@ -5859,8 +7313,8 @@ entry:
   store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
@@ -5874,8 +7328,8 @@ entry:
 
 ; <label>:37                                      ; preds = %65
   %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %37
   %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
@@ -5886,16 +7340,16 @@ entry:
   %45 = bitcast i16* %41 to i8*
   %46 = getelementptr inbounds i8, i8* %45, i64 %44
   %47 = bitcast i8* %46 to i16*
-  %NullCheck14 = icmp ne i16* %47, null
-  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %47, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %48
 
 ; <label>:48                                      ; preds = %39
   %49 = load i16, i16* %47, align 8
   %50 = zext i16 %49 to i32
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %52 = load i32, i32* %loc1
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %53
 
 ; <label>:53                                      ; preds = %48
   %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
@@ -5916,8 +7370,8 @@ entry:
 ; <label>:62                                      ; preds = %36, %59
   %63 = load i32, i32* %loc1
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck10, label %65, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %65
 
 ; <label>:65                                      ; preds = %62
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
@@ -5936,15 +7390,15 @@ entry:
 
 ; <label>:74                                      ; preds = %70
   %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
-  br i1 %NullCheck18, label %76, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %76
 
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
   %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
-  br i1 %NullCheck20, label %80, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
   %81 = load i64, i64 addrspace(1)* %79
@@ -5958,8 +7412,8 @@ entry:
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
   %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
-  br i1 %NullCheck22, label %92, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.String addrspace(1)* %90, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %92
 
 ; <label>:92                                      ; preds = %80
   %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
@@ -5969,15 +7423,15 @@ entry:
 
 ; <label>:96                                      ; preds = %70
   %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
-  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %98
 
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
   %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
-  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
   %103 = load i64, i64 addrspace(1)* %101
@@ -5991,8 +7445,8 @@ entry:
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
   %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
-  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.String addrspace(1)* %112, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %114
 
 ; <label>:114                                     ; preds = %102
   %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
@@ -6004,59 +7458,59 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %20
+ThrowNullRef4:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %22
+ThrowNullRef6:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %26
+ThrowNullRef8:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %62
+ThrowNullRef10:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %48
+ThrowNullRef16:                                   ; preds = %48
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %74
+ThrowNullRef18:                                   ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %76
+ThrowNullRef20:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %80
+ThrowNullRef22:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %96
+ThrowNullRef24:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %98
+ThrowNullRef26:                                   ; preds = %98
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %102
+ThrowNullRef28:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6069,15 +7523,15 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
   %3 = load i16*, i16* addrspace(1)* %2, align 8
   %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
@@ -6087,8 +7541,8 @@ entry:
   %10 = bitcast i16* %3 to i8*
   %11 = getelementptr inbounds i8, i8* %10, i64 %9
   %12 = bitcast i8* %11 to i16*
-  %NullCheck4 = icmp ne i16* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %5
   store i16 0, i16* %12, align 8
@@ -6098,11 +7552,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6119,8 +7573,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -6131,8 +7585,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
@@ -6144,15 +7598,15 @@ entry:
 
 ; <label>:14                                      ; preds = %1
   %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
   %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
   %21 = load i64, i64 addrspace(1)* %19
@@ -6171,15 +7625,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %14
+ThrowNullRef4:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %16
+ThrowNullRef6:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6302,14 +7756,6 @@ entry:
   ret %System.String addrspace(1)* %57
 }
 
-INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
-Successfully read RuntimeHelpers.get_OffsetToStringData
-
-define i32 @RuntimeHelpers.get_OffsetToStringData() {
-entry:
-  ret i32 12
-}
-
 INFO:  jitting method String::Equals using LLILCJit
 Successfully read String.Equals
 
@@ -6381,8 +7827,8 @@ entry:
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
-  br i1 %NullCheck24, label %29, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
   %30 = load i64, i64 addrspace(1)* %28
@@ -6397,8 +7843,8 @@ entry:
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
-  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
   %43 = load i64, i64 addrspace(1)* %41
@@ -6418,8 +7864,8 @@ entry:
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
   %59 = load i64, i64 addrspace(1)* %57
@@ -6434,8 +7880,8 @@ entry:
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck22, label %71, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
   %72 = load i64, i64 addrspace(1)* %70
@@ -6455,8 +7901,8 @@ entry:
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
-  br i1 %NullCheck16, label %87, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = load i64, i64 addrspace(1)* %86
@@ -6471,8 +7917,8 @@ entry:
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck18, label %100, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
   %101 = load i64, i64 addrspace(1)* %99
@@ -6492,8 +7938,8 @@ entry:
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
-  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
   %117 = load i64, i64 addrspace(1)* %115
@@ -6508,8 +7954,8 @@ entry:
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
-  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
   %130 = load i64, i64 addrspace(1)* %128
@@ -6528,15 +7974,15 @@ entry:
 
 ; <label>:142                                     ; preds = %22
   %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
-  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %143, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %144
 
 ; <label>:144                                     ; preds = %142
   %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
   %146 = load i32, i32 addrspace(1)* %145
   %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
-  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %147, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %148
 
 ; <label>:148                                     ; preds = %144
   %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
@@ -6557,15 +8003,15 @@ entry:
 
 ; <label>:159                                     ; preds = %22
   %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
-  br i1 %NullCheck, label %161, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %ThrowNullRef, label %161
 
 ; <label>:161                                     ; preds = %159
   %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
   %163 = load i32, i32 addrspace(1)* %162
   %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
-  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %164, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %165
 
 ; <label>:165                                     ; preds = %161
   %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
@@ -6578,8 +8024,8 @@ entry:
 
 ; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
-  br i1 %NullCheck4, label %172, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %171, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %172
 
 ; <label>:172                                     ; preds = %170
   %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
@@ -6589,8 +8035,8 @@ entry:
 
 ; <label>:176                                     ; preds = %172
   %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
-  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %177, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %178
 
 ; <label>:178                                     ; preds = %176
   %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
@@ -6629,55 +8075,55 @@ ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %161
+ThrowNullRef2:                                    ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %170
+ThrowNullRef4:                                    ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %176
+ThrowNullRef6:                                    ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %142
+ThrowNullRef8:                                    ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %144
+ThrowNullRef10:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %113
+ThrowNullRef12:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %116
+ThrowNullRef14:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %84
+ThrowNullRef16:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %87
+ThrowNullRef18:                                   ; preds = %87
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %55
+ThrowNullRef20:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %58
+ThrowNullRef22:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %26
+ThrowNullRef24:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %29
+ThrowNullRef26:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,8 +8161,8 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck, label %14, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %ThrowNullRef, label %14
 
 ; <label>:14                                      ; preds = %8
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
@@ -6760,8 +8206,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
@@ -6770,14 +8216,14 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32, i32* %loc0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %10
   %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
   %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
@@ -6790,15 +8236,15 @@ entry:
 ; <label>:25                                      ; preds = %19
   %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
-  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
   %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
@@ -6807,8 +8253,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %37 = load i32, i32* %loc0
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %38, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %38
 
 ; <label>:38                                      ; preds = %32
   %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
@@ -6817,14 +8263,14 @@ entry:
 
 ; <label>:40                                      ; preds = %19
   %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %40
   %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
   %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
-  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
-  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
@@ -6832,8 +8278,8 @@ entry:
   %48 = zext i32 %47 to i64
   %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
-  br i1 %NullCheck16, label %51, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %51
 
 ; <label>:51                                      ; preds = %45
   %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
@@ -6847,15 +8293,15 @@ entry:
 ; <label>:57                                      ; preds = %51
   %58 = load i16*, i16** %arg1
   %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
-  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %60
 
 ; <label>:60                                      ; preds = %57
   %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
   %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
-  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %64
 
 ; <label>:64                                      ; preds = %60
   %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
@@ -6864,22 +8310,22 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
   %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
-  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %70
 
 ; <label>:70                                      ; preds = %64
   %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
   %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
-  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
-  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
   %75 = load i32, i32 addrspace(1)* %74
   %76 = zext i32 %75 to i64
   %77 = trunc i64 %76 to i32
-  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
-  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %78
 
 ; <label>:78                                      ; preds = %73
   %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
@@ -6901,8 +8347,8 @@ entry:
   %90 = bitcast i16* %86 to i8*
   %91 = getelementptr inbounds i8, i8* %90, i64 %89
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %93
 
 ; <label>:93                                      ; preds = %80
   %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
@@ -6912,8 +8358,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %99 = load i32, i32* %loc2
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %100
 
 ; <label>:100                                     ; preds = %93
   %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
@@ -6928,63 +8374,63 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %25
+ThrowNullRef6:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %32
+ThrowNullRef10:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %40
+ThrowNullRef12:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %45
+ThrowNullRef16:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %57
+ThrowNullRef18:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %60
+ThrowNullRef20:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %64
+ThrowNullRef22:                                   ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %70
+ThrowNullRef24:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %73
+ThrowNullRef26:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %80
+ThrowNullRef28:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %93
+ThrowNullRef30:                                   ; preds = %93
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7004,8 +8450,8 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
@@ -7033,43 +8479,43 @@ entry:
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %14
   %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
   %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   %28 = load i32, i32 addrspace(1)* %27, align 8
   %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
-  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %30
 
 ; <label>:30                                      ; preds = %26
   %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
   %32 = load i32, i32 addrspace(1)* %31, align 8
   %33 = add i32 %28, %32
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %34
 
 ; <label>:34                                      ; preds = %30
   %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   store i32 %33, i32 addrspace(1)* %35
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
   store i32 0, i32 addrspace(1)* %38
   %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %40
 
 ; <label>:40                                      ; preds = %37
   %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
@@ -7082,8 +8528,8 @@ entry:
 
 ; <label>:47                                      ; preds = %40
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
@@ -7098,8 +8544,8 @@ entry:
   %54 = load i32, i32* %loc0
   %55 = sext i32 %54 to i64
   %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
-  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %57
 
 ; <label>:57                                      ; preds = %52
   %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
@@ -7110,68 +8556,35 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %14
+ThrowNullRef2:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %23
+ThrowNullRef4:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %26
+ThrowNullRef6:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %30
+ThrowNullRef8:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %34
+ThrowNullRef10:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %47
+ThrowNullRef14:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %52
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-}
-
-INFO:  jitting method StringBuilder::get_Length using LLILCJit
-Successfully read StringBuilder.get_Length
-
-define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.StringBuilder addrspace(1)*
-  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
-  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
-
-; <label>:1                                       ; preds = %entry
-  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %3 = load i32, i32 addrspace(1)* %2, align 8
-  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
-
-; <label>:5                                       ; preds = %1
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = add i32 %3, %7
-  ret i32 %8
-
-ThrowNullRef:                                     ; preds = %entry
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef16:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7213,70 +8626,70 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
   %6 = load i32, i32 addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
   store i32 %6, i32 addrspace(1)* %8
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
   %13 = load i32, i32 addrspace(1)* %12, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
   store i32 %13, i32 addrspace(1)* %15
   %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
-  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %18
 
 ; <label>:18                                      ; preds = %14
   %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
   %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
   %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
   %34 = load i32, i32 addrspace(1)* %33, align 8
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
-  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
@@ -7287,39 +8700,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %28
+ThrowNullRef16:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %32
+ThrowNullRef18:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7455,13 +8868,13 @@ entry:
 ; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
@@ -7477,16 +8890,16 @@ entry:
 
 ; <label>:18                                      ; preds = %15
   %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
   store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
   %22 = load i32, i32* %loc0
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %24
 
 ; <label>:24                                      ; preds = %20
   %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
@@ -7498,13 +8911,13 @@ entry:
 ; <label>:28                                      ; preds = %15, %24
   %29 = load i32, i32* %arg1
   %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %31
   %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
@@ -7517,20 +8930,20 @@ entry:
   %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
-  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
   %46 = load i32, i32 addrspace(1)* %45, align 8
   %47 = sub i32 %40, %46
-  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
-  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i32 addrspace(1)* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %48
 
 ; <label>:48                                      ; preds = %44
   store i32 %47, i32 addrspace(1)* %39, align 8
@@ -7538,21 +8951,21 @@ entry:
 
 ; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
-  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %51
 
 ; <label>:51                                      ; preds = %49
   %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %53
 
 ; <label>:53                                      ; preds = %51
   %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
   %55 = load i32, i32 addrspace(1)* %54, align 8
   %56 = load i32, i32* %arg2
   %57 = sub i32 %55, %56
-  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %58
 
 ; <label>:58                                      ; preds = %53
   %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
@@ -7562,13 +8975,13 @@ entry:
 ; <label>:60                                      ; preds = %33, %58
   %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
   %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
-  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %63
 
 ; <label>:63                                      ; preds = %60
   %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
-  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
-  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
@@ -7578,15 +8991,15 @@ entry:
 
 ; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
-  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i32 addrspace(1)* %69, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %70
 
 ; <label>:70                                      ; preds = %68
   %71 = load i32, i32 addrspace(1)* %69, align 8
   store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
-  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
@@ -7596,8 +9009,8 @@ entry:
   store i32 %77, i32* %loc4
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
-  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %80
 
 ; <label>:80                                      ; preds = %73
   %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
@@ -7607,71 +9020,71 @@ entry:
 ; <label>:83                                      ; preds = %80
   store i32 0, i32* %loc3
   %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
-  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
-  br i1 %NullCheck26, label %88, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i32 addrspace(1)* %87, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %88
 
 ; <label>:88                                      ; preds = %85
   %89 = load i32, i32 addrspace(1)* %87, align 8
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
-  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %90
 
 ; <label>:90                                      ; preds = %88
   %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
   store i32 %89, i32 addrspace(1)* %91
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
-  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
-  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %96
 
 ; <label>:96                                      ; preds = %94
   %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
-  br i1 %NullCheck34, label %100, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %100
 
 ; <label>:100                                     ; preds = %96
   %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
-  br i1 %NullCheck36, label %102, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %102
 
 ; <label>:102                                     ; preds = %100
   %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
   %104 = load i32, i32 addrspace(1)* %103, align 8
   %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
-  br i1 %NullCheck38, label %106, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %106
 
 ; <label>:106                                     ; preds = %102
   %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
-  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
-  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %108
 
 ; <label>:108                                     ; preds = %106
   %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
   %110 = load i32, i32 addrspace(1)* %109, align 8
   %111 = add i32 %104, %110
-  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %112
 
 ; <label>:112                                     ; preds = %108
   %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
   store i32 %111, i32 addrspace(1)* %113
   %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
-  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i32 addrspace(1)* %114, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %115
 
 ; <label>:115                                     ; preds = %112
   %116 = load i32, i32 addrspace(1)* %114, align 8
@@ -7681,19 +9094,19 @@ entry:
 ; <label>:118                                     ; preds = %115
   %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
-  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %121
 
 ; <label>:121                                     ; preds = %118
   %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
-  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
-  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %123
 
 ; <label>:123                                     ; preds = %121
   %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
   %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
-  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
-  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %126
 
 ; <label>:126                                     ; preds = %123
   %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
@@ -7705,8 +9118,8 @@ entry:
 
 ; <label>:130                                     ; preds = %80, %115, %126
   %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %132
 
 ; <label>:132                                     ; preds = %130
   %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7715,8 +9128,8 @@ entry:
   %136 = load i32, i32* %loc3
   %137 = sub i32 %135, %136
   %138 = sub i32 %134, %137
-  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %139
 
 ; <label>:139                                     ; preds = %132
   %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7728,16 +9141,16 @@ entry:
 
 ; <label>:144                                     ; preds = %139
   %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
-  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %146
 
 ; <label>:146                                     ; preds = %144
   %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
   %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
   %149 = load i32, i32* %loc2
   %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
-  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %151
 
 ; <label>:151                                     ; preds = %146
   %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
@@ -7754,145 +9167,249 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %18
+ThrowNullRef4:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %31
+ThrowNullRef10:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %44
+ThrowNullRef16:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %68
+ThrowNullRef18:                                   ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %70
+ThrowNullRef20:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %73
+ThrowNullRef22:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %83
+ThrowNullRef24:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %85
+ThrowNullRef26:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %88
+ThrowNullRef28:                                   ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %90
+ThrowNullRef30:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %94
+ThrowNullRef32:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %96
+ThrowNullRef34:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %100
+ThrowNullRef36:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %102
+ThrowNullRef38:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %106
+ThrowNullRef40:                                   ; preds = %106
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %108
+ThrowNullRef42:                                   ; preds = %108
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %112
+ThrowNullRef44:                                   ; preds = %112
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %118
+ThrowNullRef46:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %121
+ThrowNullRef48:                                   ; preds = %121
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %123
+ThrowNullRef50:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %130
+ThrowNullRef52:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %132
+ThrowNullRef54:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %144
+ThrowNullRef56:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %146
+ThrowNullRef58:                                   ; preds = %146
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %60
+ThrowNullRef60:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %63
+ThrowNullRef62:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %49
+ThrowNullRef64:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %51
+ThrowNullRef66:                                   ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %53
+ThrowNullRef68:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(%"System.Char[]" addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %arg0 = alloca %"System.Char[]" addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store %"System.Char[]" addrspace(1)* %param0, %"System.Char[]" addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load i32, i32* %arg4
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %43, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %38, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg1
+  %13 = load i32, i32* %arg4
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %38, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %24 = load i32, i32* %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %35 = load i32, i32* %arg3
+  %36 = load i32, i32* %arg4
+  %37 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %37, %"System.Char[]" addrspace(1)* %34, i32 %35, i32 %36)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:38                                      ; preds = %5, %16
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Successfully read Buffer._Memmove
 
@@ -7914,7 +9431,7 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[loadElem]
+Failed to read AppDomain.SetDataHelper[storeElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -7923,8 +9440,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
@@ -7934,8 +9451,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
@@ -7947,15 +9464,15 @@ entry:
   %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
   %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
@@ -7966,15 +9483,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7992,7 +9509,79 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
-Failed to read Dictionary`2.TryGetValue[loadElemA]
+Successfully read Dictionary`2.TryGetValue
+
+define i8 @"Dictionary`2.TryGetValue"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)* addrspace(1)* %param2) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  %arg2 = alloca %System.__Canon addrspace(1)* addrspace(1)*
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  store %System.__Canon addrspace(1)* addrspace(1)* %param2, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  store i32 %2, i32* %loc0
+  %3 = load i32, i32* %loc0
+  %4 = icmp slt i32 %3, 0
+  br i1 %4, label %22, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 2
+  %10 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %9, align 8
+  %11 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = zext i32 %11 to i64
+  %BoundsCheck = icmp uge i64 %16, %15
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 3, i32 %11
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %20, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %6, %System.__Canon addrspace(1)* %21)
+  ret i8 1
+
+; <label>:22                                      ; preds = %entry
+  %23 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %23, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -8058,8 +9647,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
@@ -8091,8 +9680,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
@@ -8171,15 +9760,15 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck, label %19, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %ThrowNullRef, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
   %21 = load i32, i32 addrspace(1)* %20
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
@@ -8202,7 +9791,7 @@ ThrowNullRef:                                     ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %19
+ThrowNullRef2:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8248,8 +9837,8 @@ entry:
   %0 = alloca %System.AppDomainHandle
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %1 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %1, i32 0, i32 15
@@ -8269,8 +9858,8 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
@@ -8286,7 +9875,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -8299,8 +9888,8 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -8327,8 +9916,8 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
@@ -8352,8 +9941,8 @@ entry:
   %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
   store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
@@ -8363,8 +9952,8 @@ entry:
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
@@ -8374,8 +9963,8 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %9
   %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
@@ -8384,8 +9973,8 @@ entry:
 
 ; <label>:18                                      ; preds = %3, %16
   %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
@@ -8397,15 +9986,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %18
+ThrowNullRef6:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8418,8 +10007,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
@@ -8453,15 +10042,15 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
@@ -8473,7 +10062,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8481,7 +10070,7 @@ ThrowNullRef1:                                    ; preds = %1
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
 Failed to read Dictionary`2.System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
@@ -8506,8 +10095,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
@@ -8524,8 +10113,8 @@ entry:
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -8544,7 +10133,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8577,8 +10166,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = load i64, i64* %arg2
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = trunc i32 %3 to i8
@@ -8634,46 +10223,46 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
   %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
-  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
-  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
-  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
@@ -8684,27 +10273,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %20
+ThrowNullRef12:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8717,8 +10306,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -8756,22 +10345,22 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
   %9 = load i64, i64 addrspace(1)* %8, align 8
   %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
   %13 = load i64, i64 addrspace(1)* %12, align 8
   %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %11
   %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
@@ -8788,11 +10377,11 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8882,8 +10471,8 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
@@ -8900,8 +10489,8 @@ entry:
 ; <label>:8                                       ; preds = %1
   %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
   %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
@@ -8911,15 +10500,15 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
   %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
   %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
-  br i1 %NullCheck6, label %21, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
@@ -8946,15 +10535,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8992,15 +10581,15 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
   store i8 %3, i8 addrspace(1)* %5
   %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
@@ -9011,7 +10600,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9027,8 +10616,8 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -9041,8 +10630,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
@@ -9058,7 +10647,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9080,8 +10669,8 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
@@ -9096,8 +10685,8 @@ entry:
 ; <label>:12                                      ; preds = %6
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
@@ -9112,8 +10701,8 @@ entry:
 ; <label>:21                                      ; preds = %15
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
@@ -9128,8 +10717,8 @@ entry:
 ; <label>:30                                      ; preds = %24
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %31, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
@@ -9144,8 +10733,8 @@ entry:
 ; <label>:39                                      ; preds = %33
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
-  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %40, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %42
 
 ; <label>:42                                      ; preds = %39
   %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
@@ -9164,19 +10753,19 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %21
+ThrowNullRef4:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %30
+ThrowNullRef6:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %39
+ThrowNullRef8:                                    ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9243,8 +10832,8 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
@@ -9264,57 +10853,57 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
   store i8 0, i8 addrspace(1)* %2
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
   store i8 0, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
   store i8 0, i8 addrspace(1)* %17
   %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
   store i8 0, i8 addrspace(1)* %20
   %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
-  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
@@ -9325,31 +10914,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %19
+ThrowNullRef14:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9367,8 +10956,8 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
@@ -9380,8 +10969,8 @@ entry:
 
 ; <label>:9                                       ; preds = %4
   %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %9
   %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
@@ -9395,7 +10984,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef2:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9420,8 +11009,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
@@ -9512,8 +11101,8 @@ entry:
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
@@ -9524,8 +11113,8 @@ entry:
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = load i64, i64 addrspace(1)* %12
@@ -9537,8 +11126,8 @@ entry:
   %20 = load i64, i64* %19
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
-  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %13
   %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
@@ -9555,8 +11144,8 @@ entry:
 ; <label>:30                                      ; preds = %25
   %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %32 = load i32, i32* %arg2
-  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
-  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
@@ -9570,15 +11159,15 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %30
+ThrowNullRef2:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9622,87 +11211,87 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
   %10 = load i8, i8 addrspace(1)* %9, align 8
   %11 = zext i8 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %8
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
   store i8 %12, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
   %19 = load i8, i8 addrspace(1)* %18, align 8
   %20 = zext i8 %19 to i32
   %21 = trunc i32 %20 to i8
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
   store i8 %21, i8 addrspace(1)* %23
   %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
   %28 = load i8, i8 addrspace(1)* %27, align 8
   %29 = zext i8 %28 to i32
   %30 = trunc i32 %29 to i8
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
-  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %31
 
 ; <label>:31                                      ; preds = %26
   %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
   store i8 %30, i8 addrspace(1)* %32
   %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
-  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
-  br i1 %NullCheck14, label %40, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %40
 
 ; <label>:40                                      ; preds = %35
   %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
   store i8 %39, i8 addrspace(1)* %41
   %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
-  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %44
 
 ; <label>:44                                      ; preds = %40
   %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
   %46 = load i8, i8 addrspace(1)* %45, align 8
   %47 = zext i8 %46 to i32
   %48 = trunc i32 %47 to i8
-  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
   store i8 %48, i8 addrspace(1)* %50
   %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
-  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
@@ -9713,29 +11302,29 @@ entry:
 ; <label>:56                                      ; preds = %52
   %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
-  br i1 %NullCheck22, label %59, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
   %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
   %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
-  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
-  br i1 %NullCheck24, label %63, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
   %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
-  br i1 %NullCheck26, label %66, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
   %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
-  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
-  br i1 %NullCheck28, label %69, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %69
 
 ; <label>:69                                      ; preds = %66
   %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
@@ -9744,15 +11333,15 @@ entry:
 
 ; <label>:71                                      ; preds = %105
   %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
-  br i1 %NullCheck34, label %73, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %73
 
 ; <label>:73                                      ; preds = %71
   %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
   %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
   %76 = load i32, i32* %loc0
-  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
-  br i1 %NullCheck36, label %77, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
@@ -9766,8 +11355,8 @@ entry:
 
 ; <label>:83                                      ; preds = %77
   %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
-  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
@@ -9775,14 +11364,14 @@ entry:
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
   %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
-  br i1 %NullCheck40, label %91, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
 ; <label>:91                                      ; preds = %85
   %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
   %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
-  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck42, label %94, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %94
 
 ; <label>:94                                      ; preds = %91
   %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
@@ -9798,14 +11387,14 @@ entry:
 ; <label>:99                                      ; preds = %69, %96
   %100 = load i32, i32* %loc0
   %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
-  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %102
 
 ; <label>:102                                     ; preds = %99
   %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
   %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
-  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
-  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
@@ -9819,87 +11408,87 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %26
+ThrowNullRef10:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %31
+ThrowNullRef12:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %35
+ThrowNullRef14:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %40
+ThrowNullRef16:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %56
+ThrowNullRef22:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %59
+ThrowNullRef24:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %63
+ThrowNullRef26:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %66
+ThrowNullRef28:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %102
+ThrowNullRef32:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %71
+ThrowNullRef34:                                   ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %73
+ThrowNullRef36:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %83
+ThrowNullRef38:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %85
+ThrowNullRef40:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %91
+ThrowNullRef42:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9943,15 +11532,15 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
   %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
@@ -9961,28 +11550,28 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
   %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %12
   %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
   %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
   %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
-  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
@@ -9993,23 +11582,23 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %12
+ThrowNullRef6:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10031,15 +11620,15 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
   %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = load i64, i64 addrspace(1)* %7
@@ -10077,13 +11666,13 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[loadElem]
+Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -10111,8 +11700,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1

--- a/test/BaseLine/JIT/CodeGenBringUpTests/And1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/And1.error.txt
@@ -25,8 +25,8 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
@@ -40,8 +40,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
   %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
@@ -75,7 +75,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -90,8 +90,8 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %NullCheck = icmp ne i8 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = load i8, i8 addrspace(1)* %0, align 8
@@ -125,8 +125,8 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
@@ -159,8 +159,8 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -184,8 +184,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
   store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
@@ -195,8 +195,8 @@ entry:
 ; <label>:4                                       ; preds = %1
   %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
   %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
@@ -206,8 +206,8 @@ entry:
   %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
@@ -221,14 +221,14 @@ entry:
 
 ; <label>:17                                      ; preds = %14
   %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
   %21 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
@@ -238,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -249,8 +249,8 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
@@ -261,27 +261,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %30
+ThrowNullRef10:                                   ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -301,7 +301,89 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
-Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
+Successfully read AppDomainSetup.GetUnsecureApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.GetUnsecureApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %NullCheck = icmp eq %"System.String[]" addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %BoundsCheck = icmp uge i64 0, %5
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %6
+
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 3, i32 0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
+  ret %System.String addrspace(1)* %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_Value using LLILCJit
+Successfully read AppDomainSetup.get_Value
+
+define %"System.String[]" addrspace(1)* @AppDomainSetup.get_Value(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.String[]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 18)
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.String[]" addrspace(1)* addrspace(1)*, %"System.String[]" addrspace(1)*)*)(%"System.String[]" addrspace(1)* addrspace(1)* %9, %"System.String[]" addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %11, i32 0, i32 1
+  %14 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %13, align 8
+  ret %"System.String[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -319,8 +401,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -368,16 +450,16 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
   %5 = load i32, i32 addrspace(1)* %4
   %6 = sub i32 %5, 1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -389,7 +471,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -421,8 +503,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
@@ -456,8 +538,8 @@ entry:
 ; <label>:27                                      ; preds = %19
   %28 = load i32, i32* %arg1
   %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
-  br i1 %NullCheck2, label %30, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %29, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %30
 
 ; <label>:30                                      ; preds = %27
   %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
@@ -493,8 +575,8 @@ entry:
 ; <label>:49                                      ; preds = %46
   %50 = load i32, i32* %arg2
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck4, label %52, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
@@ -517,11 +599,11 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %27
+ThrowNullRef2:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %49
+ThrowNullRef4:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -544,16 +626,16 @@ entry:
   %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %0)
   store %System.String addrspace(1)* %1, %System.String addrspace(1)** %loc0
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 2
   %5 = bitcast [0 x i16] addrspace(1)* %4 to i16 addrspace(1)*
   store i16 addrspace(1)* %5, i16 addrspace(1)** %loc1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %3
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2
@@ -580,7 +662,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -691,15 +773,15 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %NullCheck132 = icmp ne i8* %21, null
-  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+  %NullCheck131 = icmp eq i8* %21, null
+  br i1 %NullCheck131, label %ThrowNullRef132, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = load i8, i8* %21, align 8
   %24 = zext i8 %23 to i32
   %25 = trunc i32 %24 to i8
-  %NullCheck134 = icmp ne i8* %20, null
-  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+  %NullCheck133 = icmp eq i8* %20, null
+  br i1 %NullCheck133, label %ThrowNullRef134, label %26
 
 ; <label>:26                                      ; preds = %22
   store i8 %25, i8* %20, align 8
@@ -709,16 +791,16 @@ entry:
   %28 = load i8*, i8** %arg0
   %29 = load i8*, i8** %arg1
   %30 = bitcast i8* %29 to i16*
-  %NullCheck128 = icmp ne i16* %30, null
-  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+  %NullCheck127 = icmp eq i16* %30, null
+  br i1 %NullCheck127, label %ThrowNullRef128, label %31
 
 ; <label>:31                                      ; preds = %27
   %32 = load i16, i16* %30, align 8
   %33 = sext i16 %32 to i32
   %34 = bitcast i8* %28 to i16*
   %35 = trunc i32 %33 to i16
-  %NullCheck130 = icmp ne i16* %34, null
-  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+  %NullCheck129 = icmp eq i16* %34, null
+  br i1 %NullCheck129, label %ThrowNullRef130, label %36
 
 ; <label>:36                                      ; preds = %31
   store i16 %35, i16* %34, align 8
@@ -728,16 +810,16 @@ entry:
   %38 = load i8*, i8** %arg0
   %39 = load i8*, i8** %arg1
   %40 = bitcast i8* %39 to i16*
-  %NullCheck120 = icmp ne i16* %40, null
-  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+  %NullCheck119 = icmp eq i16* %40, null
+  br i1 %NullCheck119, label %ThrowNullRef120, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i16, i16* %40, align 8
   %43 = sext i16 %42 to i32
   %44 = bitcast i8* %38 to i16*
   %45 = trunc i32 %43 to i16
-  %NullCheck122 = icmp ne i16* %44, null
-  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+  %NullCheck121 = icmp eq i16* %44, null
+  br i1 %NullCheck121, label %ThrowNullRef122, label %46
 
 ; <label>:46                                      ; preds = %41
   store i16 %45, i16* %44, align 8
@@ -745,15 +827,15 @@ entry:
   %48 = getelementptr inbounds i8, i8* %47, i64 2
   %49 = load i8*, i8** %arg1
   %50 = getelementptr inbounds i8, i8* %49, i64 2
-  %NullCheck124 = icmp ne i8* %50, null
-  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+  %NullCheck123 = icmp eq i8* %50, null
+  br i1 %NullCheck123, label %ThrowNullRef124, label %51
 
 ; <label>:51                                      ; preds = %46
   %52 = load i8, i8* %50, align 8
   %53 = zext i8 %52 to i32
   %54 = trunc i32 %53 to i8
-  %NullCheck126 = icmp ne i8* %48, null
-  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+  %NullCheck125 = icmp eq i8* %48, null
+  br i1 %NullCheck125, label %ThrowNullRef126, label %55
 
 ; <label>:55                                      ; preds = %51
   store i8 %54, i8* %48, align 8
@@ -763,14 +845,14 @@ entry:
   %57 = load i8*, i8** %arg0
   %58 = load i8*, i8** %arg1
   %59 = bitcast i8* %58 to i32*
-  %NullCheck116 = icmp ne i32* %59, null
-  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+  %NullCheck115 = icmp eq i32* %59, null
+  br i1 %NullCheck115, label %ThrowNullRef116, label %60
 
 ; <label>:60                                      ; preds = %56
   %61 = load i32, i32* %59, align 8
   %62 = bitcast i8* %57 to i32*
-  %NullCheck118 = icmp ne i32* %62, null
-  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+  %NullCheck117 = icmp eq i32* %62, null
+  br i1 %NullCheck117, label %ThrowNullRef118, label %63
 
 ; <label>:63                                      ; preds = %60
   store i32 %61, i32* %62, align 8
@@ -780,14 +862,14 @@ entry:
   %65 = load i8*, i8** %arg0
   %66 = load i8*, i8** %arg1
   %67 = bitcast i8* %66 to i32*
-  %NullCheck108 = icmp ne i32* %67, null
-  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+  %NullCheck107 = icmp eq i32* %67, null
+  br i1 %NullCheck107, label %ThrowNullRef108, label %68
 
 ; <label>:68                                      ; preds = %64
   %69 = load i32, i32* %67, align 8
   %70 = bitcast i8* %65 to i32*
-  %NullCheck110 = icmp ne i32* %70, null
-  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+  %NullCheck109 = icmp eq i32* %70, null
+  br i1 %NullCheck109, label %ThrowNullRef110, label %71
 
 ; <label>:71                                      ; preds = %68
   store i32 %69, i32* %70, align 8
@@ -795,15 +877,15 @@ entry:
   %73 = getelementptr inbounds i8, i8* %72, i64 4
   %74 = load i8*, i8** %arg1
   %75 = getelementptr inbounds i8, i8* %74, i64 4
-  %NullCheck112 = icmp ne i8* %75, null
-  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+  %NullCheck111 = icmp eq i8* %75, null
+  br i1 %NullCheck111, label %ThrowNullRef112, label %76
 
 ; <label>:76                                      ; preds = %71
   %77 = load i8, i8* %75, align 8
   %78 = zext i8 %77 to i32
   %79 = trunc i32 %78 to i8
-  %NullCheck114 = icmp ne i8* %73, null
-  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+  %NullCheck113 = icmp eq i8* %73, null
+  br i1 %NullCheck113, label %ThrowNullRef114, label %80
 
 ; <label>:80                                      ; preds = %76
   store i8 %79, i8* %73, align 8
@@ -813,14 +895,14 @@ entry:
   %82 = load i8*, i8** %arg0
   %83 = load i8*, i8** %arg1
   %84 = bitcast i8* %83 to i32*
-  %NullCheck100 = icmp ne i32* %84, null
-  br i1 %NullCheck100, label %85, label %ThrowNullRef99
+  %NullCheck99 = icmp eq i32* %84, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %85
 
 ; <label>:85                                      ; preds = %81
   %86 = load i32, i32* %84, align 8
   %87 = bitcast i8* %82 to i32*
-  %NullCheck102 = icmp ne i32* %87, null
-  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+  %NullCheck101 = icmp eq i32* %87, null
+  br i1 %NullCheck101, label %ThrowNullRef102, label %88
 
 ; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
@@ -829,16 +911,16 @@ entry:
   %91 = load i8*, i8** %arg1
   %92 = getelementptr inbounds i8, i8* %91, i64 4
   %93 = bitcast i8* %92 to i16*
-  %NullCheck104 = icmp ne i16* %93, null
-  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+  %NullCheck103 = icmp eq i16* %93, null
+  br i1 %NullCheck103, label %ThrowNullRef104, label %94
 
 ; <label>:94                                      ; preds = %88
   %95 = load i16, i16* %93, align 8
   %96 = sext i16 %95 to i32
   %97 = bitcast i8* %90 to i16*
   %98 = trunc i32 %96 to i16
-  %NullCheck106 = icmp ne i16* %97, null
-  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+  %NullCheck105 = icmp eq i16* %97, null
+  br i1 %NullCheck105, label %ThrowNullRef106, label %99
 
 ; <label>:99                                      ; preds = %94
   store i16 %98, i16* %97, align 8
@@ -848,14 +930,14 @@ entry:
   %101 = load i8*, i8** %arg0
   %102 = load i8*, i8** %arg1
   %103 = bitcast i8* %102 to i32*
-  %NullCheck88 = icmp ne i32* %103, null
-  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+  %NullCheck87 = icmp eq i32* %103, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %104
 
 ; <label>:104                                     ; preds = %100
   %105 = load i32, i32* %103, align 8
   %106 = bitcast i8* %101 to i32*
-  %NullCheck90 = icmp ne i32* %106, null
-  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+  %NullCheck89 = icmp eq i32* %106, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %107
 
 ; <label>:107                                     ; preds = %104
   store i32 %105, i32* %106, align 8
@@ -864,16 +946,16 @@ entry:
   %110 = load i8*, i8** %arg1
   %111 = getelementptr inbounds i8, i8* %110, i64 4
   %112 = bitcast i8* %111 to i16*
-  %NullCheck92 = icmp ne i16* %112, null
-  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+  %NullCheck91 = icmp eq i16* %112, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %113
 
 ; <label>:113                                     ; preds = %107
   %114 = load i16, i16* %112, align 8
   %115 = sext i16 %114 to i32
   %116 = bitcast i8* %109 to i16*
   %117 = trunc i32 %115 to i16
-  %NullCheck94 = icmp ne i16* %116, null
-  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+  %NullCheck93 = icmp eq i16* %116, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %118
 
 ; <label>:118                                     ; preds = %113
   store i16 %117, i16* %116, align 8
@@ -881,15 +963,15 @@ entry:
   %120 = getelementptr inbounds i8, i8* %119, i64 6
   %121 = load i8*, i8** %arg1
   %122 = getelementptr inbounds i8, i8* %121, i64 6
-  %NullCheck96 = icmp ne i8* %122, null
-  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+  %NullCheck95 = icmp eq i8* %122, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %123
 
 ; <label>:123                                     ; preds = %118
   %124 = load i8, i8* %122, align 8
   %125 = zext i8 %124 to i32
   %126 = trunc i32 %125 to i8
-  %NullCheck98 = icmp ne i8* %120, null
-  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+  %NullCheck97 = icmp eq i8* %120, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %127
 
 ; <label>:127                                     ; preds = %123
   store i8 %126, i8* %120, align 8
@@ -899,14 +981,14 @@ entry:
   %129 = load i8*, i8** %arg0
   %130 = load i8*, i8** %arg1
   %131 = bitcast i8* %130 to i64*
-  %NullCheck84 = icmp ne i64* %131, null
-  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+  %NullCheck83 = icmp eq i64* %131, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %132
 
 ; <label>:132                                     ; preds = %128
   %133 = load i64, i64* %131, align 8
   %134 = bitcast i8* %129 to i64*
-  %NullCheck86 = icmp ne i64* %134, null
-  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+  %NullCheck85 = icmp eq i64* %134, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %135
 
 ; <label>:135                                     ; preds = %132
   store i64 %133, i64* %134, align 8
@@ -916,14 +998,14 @@ entry:
   %137 = load i8*, i8** %arg0
   %138 = load i8*, i8** %arg1
   %139 = bitcast i8* %138 to i64*
-  %NullCheck76 = icmp ne i64* %139, null
-  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+  %NullCheck75 = icmp eq i64* %139, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %140
 
 ; <label>:140                                     ; preds = %136
   %141 = load i64, i64* %139, align 8
   %142 = bitcast i8* %137 to i64*
-  %NullCheck78 = icmp ne i64* %142, null
-  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+  %NullCheck77 = icmp eq i64* %142, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %143
 
 ; <label>:143                                     ; preds = %140
   store i64 %141, i64* %142, align 8
@@ -931,15 +1013,15 @@ entry:
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %NullCheck80 = icmp ne i8* %147, null
-  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+  %NullCheck79 = icmp eq i8* %147, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %148
 
 ; <label>:148                                     ; preds = %143
   %149 = load i8, i8* %147, align 8
   %150 = zext i8 %149 to i32
   %151 = trunc i32 %150 to i8
-  %NullCheck82 = icmp ne i8* %145, null
-  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+  %NullCheck81 = icmp eq i8* %145, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %152
 
 ; <label>:152                                     ; preds = %148
   store i8 %151, i8* %145, align 8
@@ -949,14 +1031,14 @@ entry:
   %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
   %156 = bitcast i8* %155 to i64*
-  %NullCheck68 = icmp ne i64* %156, null
-  br i1 %NullCheck68, label %157, label %ThrowNullRef67
+  %NullCheck67 = icmp eq i64* %156, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %157
 
 ; <label>:157                                     ; preds = %153
   %158 = load i64, i64* %156, align 8
   %159 = bitcast i8* %154 to i64*
-  %NullCheck70 = icmp ne i64* %159, null
-  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+  %NullCheck69 = icmp eq i64* %159, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %160
 
 ; <label>:160                                     ; preds = %157
   store i64 %158, i64* %159, align 8
@@ -965,16 +1047,16 @@ entry:
   %163 = load i8*, i8** %arg1
   %164 = getelementptr inbounds i8, i8* %163, i64 8
   %165 = bitcast i8* %164 to i16*
-  %NullCheck72 = icmp ne i16* %165, null
-  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+  %NullCheck71 = icmp eq i16* %165, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %166
 
 ; <label>:166                                     ; preds = %160
   %167 = load i16, i16* %165, align 8
   %168 = sext i16 %167 to i32
   %169 = bitcast i8* %162 to i16*
   %170 = trunc i32 %168 to i16
-  %NullCheck74 = icmp ne i16* %169, null
-  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+  %NullCheck73 = icmp eq i16* %169, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %171
 
 ; <label>:171                                     ; preds = %166
   store i16 %170, i16* %169, align 8
@@ -984,14 +1066,14 @@ entry:
   %173 = load i8*, i8** %arg0
   %174 = load i8*, i8** %arg1
   %175 = bitcast i8* %174 to i64*
-  %NullCheck56 = icmp ne i64* %175, null
-  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+  %NullCheck55 = icmp eq i64* %175, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %176
 
 ; <label>:176                                     ; preds = %172
   %177 = load i64, i64* %175, align 8
   %178 = bitcast i8* %173 to i64*
-  %NullCheck58 = icmp ne i64* %178, null
-  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+  %NullCheck57 = icmp eq i64* %178, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %179
 
 ; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
@@ -1000,16 +1082,16 @@ entry:
   %182 = load i8*, i8** %arg1
   %183 = getelementptr inbounds i8, i8* %182, i64 8
   %184 = bitcast i8* %183 to i16*
-  %NullCheck60 = icmp ne i16* %184, null
-  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+  %NullCheck59 = icmp eq i16* %184, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %185
 
 ; <label>:185                                     ; preds = %179
   %186 = load i16, i16* %184, align 8
   %187 = sext i16 %186 to i32
   %188 = bitcast i8* %181 to i16*
   %189 = trunc i32 %187 to i16
-  %NullCheck62 = icmp ne i16* %188, null
-  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+  %NullCheck61 = icmp eq i16* %188, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %190
 
 ; <label>:190                                     ; preds = %185
   store i16 %189, i16* %188, align 8
@@ -1017,15 +1099,15 @@ entry:
   %192 = getelementptr inbounds i8, i8* %191, i64 10
   %193 = load i8*, i8** %arg1
   %194 = getelementptr inbounds i8, i8* %193, i64 10
-  %NullCheck64 = icmp ne i8* %194, null
-  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+  %NullCheck63 = icmp eq i8* %194, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %195
 
 ; <label>:195                                     ; preds = %190
   %196 = load i8, i8* %194, align 8
   %197 = zext i8 %196 to i32
   %198 = trunc i32 %197 to i8
-  %NullCheck66 = icmp ne i8* %192, null
-  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+  %NullCheck65 = icmp eq i8* %192, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %199
 
 ; <label>:199                                     ; preds = %195
   store i8 %198, i8* %192, align 8
@@ -1035,14 +1117,14 @@ entry:
   %201 = load i8*, i8** %arg0
   %202 = load i8*, i8** %arg1
   %203 = bitcast i8* %202 to i64*
-  %NullCheck48 = icmp ne i64* %203, null
-  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+  %NullCheck47 = icmp eq i64* %203, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %204
 
 ; <label>:204                                     ; preds = %200
   %205 = load i64, i64* %203, align 8
   %206 = bitcast i8* %201 to i64*
-  %NullCheck50 = icmp ne i64* %206, null
-  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+  %NullCheck49 = icmp eq i64* %206, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %207
 
 ; <label>:207                                     ; preds = %204
   store i64 %205, i64* %206, align 8
@@ -1051,14 +1133,14 @@ entry:
   %210 = load i8*, i8** %arg1
   %211 = getelementptr inbounds i8, i8* %210, i64 8
   %212 = bitcast i8* %211 to i32*
-  %NullCheck52 = icmp ne i32* %212, null
-  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+  %NullCheck51 = icmp eq i32* %212, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %213
 
 ; <label>:213                                     ; preds = %207
   %214 = load i32, i32* %212, align 8
   %215 = bitcast i8* %209 to i32*
-  %NullCheck54 = icmp ne i32* %215, null
-  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+  %NullCheck53 = icmp eq i32* %215, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %216
 
 ; <label>:216                                     ; preds = %213
   store i32 %214, i32* %215, align 8
@@ -1068,14 +1150,14 @@ entry:
   %218 = load i8*, i8** %arg0
   %219 = load i8*, i8** %arg1
   %220 = bitcast i8* %219 to i64*
-  %NullCheck36 = icmp ne i64* %220, null
-  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64* %220, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %221
 
 ; <label>:221                                     ; preds = %217
   %222 = load i64, i64* %220, align 8
   %223 = bitcast i8* %218 to i64*
-  %NullCheck38 = icmp ne i64* %223, null
-  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+  %NullCheck37 = icmp eq i64* %223, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %224
 
 ; <label>:224                                     ; preds = %221
   store i64 %222, i64* %223, align 8
@@ -1084,14 +1166,14 @@ entry:
   %227 = load i8*, i8** %arg1
   %228 = getelementptr inbounds i8, i8* %227, i64 8
   %229 = bitcast i8* %228 to i32*
-  %NullCheck40 = icmp ne i32* %229, null
-  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i32* %229, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %230
 
 ; <label>:230                                     ; preds = %224
   %231 = load i32, i32* %229, align 8
   %232 = bitcast i8* %226 to i32*
-  %NullCheck42 = icmp ne i32* %232, null
-  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+  %NullCheck41 = icmp eq i32* %232, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %233
 
 ; <label>:233                                     ; preds = %230
   store i32 %231, i32* %232, align 8
@@ -1099,15 +1181,15 @@ entry:
   %235 = getelementptr inbounds i8, i8* %234, i64 12
   %236 = load i8*, i8** %arg1
   %237 = getelementptr inbounds i8, i8* %236, i64 12
-  %NullCheck44 = icmp ne i8* %237, null
-  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i8* %237, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %238
 
 ; <label>:238                                     ; preds = %233
   %239 = load i8, i8* %237, align 8
   %240 = zext i8 %239 to i32
   %241 = trunc i32 %240 to i8
-  %NullCheck46 = icmp ne i8* %235, null
-  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+  %NullCheck45 = icmp eq i8* %235, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %242
 
 ; <label>:242                                     ; preds = %238
   store i8 %241, i8* %235, align 8
@@ -1117,14 +1199,14 @@ entry:
   %244 = load i8*, i8** %arg0
   %245 = load i8*, i8** %arg1
   %246 = bitcast i8* %245 to i64*
-  %NullCheck24 = icmp ne i64* %246, null
-  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64* %246, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %247
 
 ; <label>:247                                     ; preds = %243
   %248 = load i64, i64* %246, align 8
   %249 = bitcast i8* %244 to i64*
-  %NullCheck26 = icmp ne i64* %249, null
-  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64* %249, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %250
 
 ; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
@@ -1133,14 +1215,14 @@ entry:
   %253 = load i8*, i8** %arg1
   %254 = getelementptr inbounds i8, i8* %253, i64 8
   %255 = bitcast i8* %254 to i32*
-  %NullCheck28 = icmp ne i32* %255, null
-  br i1 %NullCheck28, label %256, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i32* %255, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %256
 
 ; <label>:256                                     ; preds = %250
   %257 = load i32, i32* %255, align 8
   %258 = bitcast i8* %252 to i32*
-  %NullCheck30 = icmp ne i32* %258, null
-  br i1 %NullCheck30, label %259, label %ThrowNullRef29
+  %NullCheck29 = icmp eq i32* %258, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %259
 
 ; <label>:259                                     ; preds = %256
   store i32 %257, i32* %258, align 8
@@ -1149,16 +1231,16 @@ entry:
   %262 = load i8*, i8** %arg1
   %263 = getelementptr inbounds i8, i8* %262, i64 12
   %264 = bitcast i8* %263 to i16*
-  %NullCheck32 = icmp ne i16* %264, null
-  br i1 %NullCheck32, label %265, label %ThrowNullRef31
+  %NullCheck31 = icmp eq i16* %264, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %265
 
 ; <label>:265                                     ; preds = %259
   %266 = load i16, i16* %264, align 8
   %267 = sext i16 %266 to i32
   %268 = bitcast i8* %261 to i16*
   %269 = trunc i32 %267 to i16
-  %NullCheck34 = icmp ne i16* %268, null
-  br i1 %NullCheck34, label %270, label %ThrowNullRef33
+  %NullCheck33 = icmp eq i16* %268, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %270
 
 ; <label>:270                                     ; preds = %265
   store i16 %269, i16* %268, align 8
@@ -1168,14 +1250,14 @@ entry:
   %272 = load i8*, i8** %arg0
   %273 = load i8*, i8** %arg1
   %274 = bitcast i8* %273 to i64*
-  %NullCheck8 = icmp ne i64* %274, null
-  br i1 %NullCheck8, label %275, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64* %274, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %275
 
 ; <label>:275                                     ; preds = %271
   %276 = load i64, i64* %274, align 8
   %277 = bitcast i8* %272 to i64*
-  %NullCheck10 = icmp ne i64* %277, null
-  br i1 %NullCheck10, label %278, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %277, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %278
 
 ; <label>:278                                     ; preds = %275
   store i64 %276, i64* %277, align 8
@@ -1184,14 +1266,14 @@ entry:
   %281 = load i8*, i8** %arg1
   %282 = getelementptr inbounds i8, i8* %281, i64 8
   %283 = bitcast i8* %282 to i32*
-  %NullCheck12 = icmp ne i32* %283, null
-  br i1 %NullCheck12, label %284, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i32* %283, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %284
 
 ; <label>:284                                     ; preds = %278
   %285 = load i32, i32* %283, align 8
   %286 = bitcast i8* %280 to i32*
-  %NullCheck14 = icmp ne i32* %286, null
-  br i1 %NullCheck14, label %287, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i32* %286, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %287
 
 ; <label>:287                                     ; preds = %284
   store i32 %285, i32* %286, align 8
@@ -1200,16 +1282,16 @@ entry:
   %290 = load i8*, i8** %arg1
   %291 = getelementptr inbounds i8, i8* %290, i64 12
   %292 = bitcast i8* %291 to i16*
-  %NullCheck16 = icmp ne i16* %292, null
-  br i1 %NullCheck16, label %293, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i16* %292, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %293
 
 ; <label>:293                                     ; preds = %287
   %294 = load i16, i16* %292, align 8
   %295 = sext i16 %294 to i32
   %296 = bitcast i8* %289 to i16*
   %297 = trunc i32 %295 to i16
-  %NullCheck18 = icmp ne i16* %296, null
-  br i1 %NullCheck18, label %298, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i16* %296, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %298
 
 ; <label>:298                                     ; preds = %293
   store i16 %297, i16* %296, align 8
@@ -1217,15 +1299,15 @@ entry:
   %300 = getelementptr inbounds i8, i8* %299, i64 14
   %301 = load i8*, i8** %arg1
   %302 = getelementptr inbounds i8, i8* %301, i64 14
-  %NullCheck20 = icmp ne i8* %302, null
-  br i1 %NullCheck20, label %303, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i8* %302, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %303
 
 ; <label>:303                                     ; preds = %298
   %304 = load i8, i8* %302, align 8
   %305 = zext i8 %304 to i32
   %306 = trunc i32 %305 to i8
-  %NullCheck22 = icmp ne i8* %300, null
-  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i8* %300, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %307
 
 ; <label>:307                                     ; preds = %303
   store i8 %306, i8* %300, align 8
@@ -1235,14 +1317,14 @@ entry:
   %309 = load i8*, i8** %arg0
   %310 = load i8*, i8** %arg1
   %311 = bitcast i8* %310 to i64*
-  %NullCheck = icmp ne i64* %311, null
-  br i1 %NullCheck, label %312, label %ThrowNullRef
+  %NullCheck = icmp eq i64* %311, null
+  br i1 %NullCheck, label %ThrowNullRef, label %312
 
 ; <label>:312                                     ; preds = %308
   %313 = load i64, i64* %311, align 8
   %314 = bitcast i8* %309 to i64*
-  %NullCheck2 = icmp ne i64* %314, null
-  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64* %314, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %315
 
 ; <label>:315                                     ; preds = %312
   store i64 %313, i64* %314, align 8
@@ -1251,14 +1333,14 @@ entry:
   %318 = load i8*, i8** %arg1
   %319 = getelementptr inbounds i8, i8* %318, i64 8
   %320 = bitcast i8* %319 to i64*
-  %NullCheck4 = icmp ne i64* %320, null
-  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64* %320, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %321
 
 ; <label>:321                                     ; preds = %315
   %322 = load i64, i64* %320, align 8
   %323 = bitcast i8* %317 to i64*
-  %NullCheck6 = icmp ne i64* %323, null
-  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64* %323, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %324
 
 ; <label>:324                                     ; preds = %321
   store i64 %322, i64* %323, align 8
@@ -1286,15 +1368,15 @@ entry:
 ; <label>:338                                     ; preds = %333
   %339 = load i8*, i8** %arg0
   %340 = load i8*, i8** %arg1
-  %NullCheck136 = icmp ne i8* %340, null
-  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+  %NullCheck135 = icmp eq i8* %340, null
+  br i1 %NullCheck135, label %ThrowNullRef136, label %341
 
 ; <label>:341                                     ; preds = %338
   %342 = load i8, i8* %340, align 8
   %343 = zext i8 %342 to i32
   %344 = trunc i32 %343 to i8
-  %NullCheck138 = icmp ne i8* %339, null
-  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+  %NullCheck137 = icmp eq i8* %339, null
+  br i1 %NullCheck137, label %ThrowNullRef138, label %345
 
 ; <label>:345                                     ; preds = %341
   store i8 %344, i8* %339, align 8
@@ -1317,16 +1399,16 @@ entry:
   %357 = load i8*, i8** %arg0
   %358 = load i8*, i8** %arg1
   %359 = bitcast i8* %358 to i16*
-  %NullCheck140 = icmp ne i16* %359, null
-  br i1 %NullCheck140, label %360, label %ThrowNullRef139
+  %NullCheck139 = icmp eq i16* %359, null
+  br i1 %NullCheck139, label %ThrowNullRef140, label %360
 
 ; <label>:360                                     ; preds = %356
   %361 = load i16, i16* %359, align 8
   %362 = sext i16 %361 to i32
   %363 = bitcast i8* %357 to i16*
   %364 = trunc i32 %362 to i16
-  %NullCheck142 = icmp ne i16* %363, null
-  br i1 %NullCheck142, label %365, label %ThrowNullRef141
+  %NullCheck141 = icmp eq i16* %363, null
+  br i1 %NullCheck141, label %ThrowNullRef142, label %365
 
 ; <label>:365                                     ; preds = %360
   store i16 %364, i16* %363, align 8
@@ -1352,14 +1434,14 @@ entry:
   %378 = load i8*, i8** %arg0
   %379 = load i8*, i8** %arg1
   %380 = bitcast i8* %379 to i32*
-  %NullCheck144 = icmp ne i32* %380, null
-  br i1 %NullCheck144, label %381, label %ThrowNullRef143
+  %NullCheck143 = icmp eq i32* %380, null
+  br i1 %NullCheck143, label %ThrowNullRef144, label %381
 
 ; <label>:381                                     ; preds = %377
   %382 = load i32, i32* %380, align 8
   %383 = bitcast i8* %378 to i32*
-  %NullCheck146 = icmp ne i32* %383, null
-  br i1 %NullCheck146, label %384, label %ThrowNullRef145
+  %NullCheck145 = icmp eq i32* %383, null
+  br i1 %NullCheck145, label %ThrowNullRef146, label %384
 
 ; <label>:384                                     ; preds = %381
   store i32 %382, i32* %383, align 8
@@ -1384,14 +1466,14 @@ entry:
   %395 = load i8*, i8** %arg0
   %396 = load i8*, i8** %arg1
   %397 = bitcast i8* %396 to i64*
-  %NullCheck164 = icmp ne i64* %397, null
-  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+  %NullCheck163 = icmp eq i64* %397, null
+  br i1 %NullCheck163, label %ThrowNullRef164, label %398
 
 ; <label>:398                                     ; preds = %394
   %399 = load i64, i64* %397, align 8
   %400 = bitcast i8* %395 to i64*
-  %NullCheck166 = icmp ne i64* %400, null
-  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+  %NullCheck165 = icmp eq i64* %400, null
+  br i1 %NullCheck165, label %ThrowNullRef166, label %401
 
 ; <label>:401                                     ; preds = %398
   store i64 %399, i64* %400, align 8
@@ -1400,14 +1482,14 @@ entry:
   %404 = load i8*, i8** %arg1
   %405 = getelementptr inbounds i8, i8* %404, i64 8
   %406 = bitcast i8* %405 to i64*
-  %NullCheck168 = icmp ne i64* %406, null
-  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+  %NullCheck167 = icmp eq i64* %406, null
+  br i1 %NullCheck167, label %ThrowNullRef168, label %407
 
 ; <label>:407                                     ; preds = %401
   %408 = load i64, i64* %406, align 8
   %409 = bitcast i8* %403 to i64*
-  %NullCheck170 = icmp ne i64* %409, null
-  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+  %NullCheck169 = icmp eq i64* %409, null
+  br i1 %NullCheck169, label %ThrowNullRef170, label %410
 
 ; <label>:410                                     ; preds = %407
   store i64 %408, i64* %409, align 8
@@ -1437,14 +1519,14 @@ entry:
   %425 = load i8*, i8** %arg0
   %426 = load i8*, i8** %arg1
   %427 = bitcast i8* %426 to i64*
-  %NullCheck148 = icmp ne i64* %427, null
-  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+  %NullCheck147 = icmp eq i64* %427, null
+  br i1 %NullCheck147, label %ThrowNullRef148, label %428
 
 ; <label>:428                                     ; preds = %424
   %429 = load i64, i64* %427, align 8
   %430 = bitcast i8* %425 to i64*
-  %NullCheck150 = icmp ne i64* %430, null
-  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+  %NullCheck149 = icmp eq i64* %430, null
+  br i1 %NullCheck149, label %ThrowNullRef150, label %431
 
 ; <label>:431                                     ; preds = %428
   store i64 %429, i64* %430, align 8
@@ -1466,14 +1548,14 @@ entry:
   %441 = load i8*, i8** %arg0
   %442 = load i8*, i8** %arg1
   %443 = bitcast i8* %442 to i32*
-  %NullCheck152 = icmp ne i32* %443, null
-  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+  %NullCheck151 = icmp eq i32* %443, null
+  br i1 %NullCheck151, label %ThrowNullRef152, label %444
 
 ; <label>:444                                     ; preds = %440
   %445 = load i32, i32* %443, align 8
   %446 = bitcast i8* %441 to i32*
-  %NullCheck154 = icmp ne i32* %446, null
-  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+  %NullCheck153 = icmp eq i32* %446, null
+  br i1 %NullCheck153, label %ThrowNullRef154, label %447
 
 ; <label>:447                                     ; preds = %444
   store i32 %445, i32* %446, align 8
@@ -1495,16 +1577,16 @@ entry:
   %457 = load i8*, i8** %arg0
   %458 = load i8*, i8** %arg1
   %459 = bitcast i8* %458 to i16*
-  %NullCheck156 = icmp ne i16* %459, null
-  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+  %NullCheck155 = icmp eq i16* %459, null
+  br i1 %NullCheck155, label %ThrowNullRef156, label %460
 
 ; <label>:460                                     ; preds = %456
   %461 = load i16, i16* %459, align 8
   %462 = sext i16 %461 to i32
   %463 = bitcast i8* %457 to i16*
   %464 = trunc i32 %462 to i16
-  %NullCheck158 = icmp ne i16* %463, null
-  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+  %NullCheck157 = icmp eq i16* %463, null
+  br i1 %NullCheck157, label %ThrowNullRef158, label %465
 
 ; <label>:465                                     ; preds = %460
   store i16 %464, i16* %463, align 8
@@ -1525,15 +1607,15 @@ entry:
 ; <label>:474                                     ; preds = %470
   %475 = load i8*, i8** %arg0
   %476 = load i8*, i8** %arg1
-  %NullCheck160 = icmp ne i8* %476, null
-  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+  %NullCheck159 = icmp eq i8* %476, null
+  br i1 %NullCheck159, label %ThrowNullRef160, label %477
 
 ; <label>:477                                     ; preds = %474
   %478 = load i8, i8* %476, align 8
   %479 = zext i8 %478 to i32
   %480 = trunc i32 %479 to i8
-  %NullCheck162 = icmp ne i8* %475, null
-  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+  %NullCheck161 = icmp eq i8* %475, null
+  br i1 %NullCheck161, label %ThrowNullRef162, label %481
 
 ; <label>:481                                     ; preds = %477
   store i8 %480, i8* %475, align 8
@@ -1553,343 +1635,343 @@ ThrowNullRef:                                     ; preds = %308
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %312
+ThrowNullRef2:                                    ; preds = %312
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %315
+ThrowNullRef4:                                    ; preds = %315
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %321
+ThrowNullRef6:                                    ; preds = %321
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %271
+ThrowNullRef8:                                    ; preds = %271
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %275
+ThrowNullRef10:                                   ; preds = %275
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %278
+ThrowNullRef12:                                   ; preds = %278
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %284
+ThrowNullRef14:                                   ; preds = %284
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %287
+ThrowNullRef16:                                   ; preds = %287
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %293
+ThrowNullRef18:                                   ; preds = %293
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %298
+ThrowNullRef20:                                   ; preds = %298
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %303
+ThrowNullRef22:                                   ; preds = %303
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %243
+ThrowNullRef24:                                   ; preds = %243
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %247
+ThrowNullRef26:                                   ; preds = %247
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %250
+ThrowNullRef28:                                   ; preds = %250
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %256
+ThrowNullRef30:                                   ; preds = %256
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %259
+ThrowNullRef32:                                   ; preds = %259
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %265
+ThrowNullRef34:                                   ; preds = %265
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %217
+ThrowNullRef36:                                   ; preds = %217
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %221
+ThrowNullRef38:                                   ; preds = %221
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %224
+ThrowNullRef40:                                   ; preds = %224
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %230
+ThrowNullRef42:                                   ; preds = %230
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %233
+ThrowNullRef44:                                   ; preds = %233
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %238
+ThrowNullRef46:                                   ; preds = %238
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %200
+ThrowNullRef48:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %204
+ThrowNullRef50:                                   ; preds = %204
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %207
+ThrowNullRef52:                                   ; preds = %207
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %213
+ThrowNullRef54:                                   ; preds = %213
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %172
+ThrowNullRef56:                                   ; preds = %172
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %176
+ThrowNullRef58:                                   ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %179
+ThrowNullRef60:                                   ; preds = %179
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %185
+ThrowNullRef62:                                   ; preds = %185
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %190
+ThrowNullRef64:                                   ; preds = %190
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %195
+ThrowNullRef66:                                   ; preds = %195
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %153
+ThrowNullRef68:                                   ; preds = %153
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %157
+ThrowNullRef70:                                   ; preds = %157
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %160
+ThrowNullRef72:                                   ; preds = %160
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %166
+ThrowNullRef74:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %136
+ThrowNullRef76:                                   ; preds = %136
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %140
+ThrowNullRef78:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %143
+ThrowNullRef80:                                   ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %148
+ThrowNullRef82:                                   ; preds = %148
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %128
+ThrowNullRef84:                                   ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %132
+ThrowNullRef86:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %100
+ThrowNullRef88:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %104
+ThrowNullRef90:                                   ; preds = %104
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %107
+ThrowNullRef92:                                   ; preds = %107
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %113
+ThrowNullRef94:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %118
+ThrowNullRef96:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %123
+ThrowNullRef98:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %81
+ThrowNullRef100:                                  ; preds = %81
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef101:                                  ; preds = %85
+ThrowNullRef102:                                  ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef103:                                  ; preds = %88
+ThrowNullRef104:                                  ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef105:                                  ; preds = %94
+ThrowNullRef106:                                  ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef107:                                  ; preds = %64
+ThrowNullRef108:                                  ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef109:                                  ; preds = %68
+ThrowNullRef110:                                  ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef111:                                  ; preds = %71
+ThrowNullRef112:                                  ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef113:                                  ; preds = %76
+ThrowNullRef114:                                  ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef115:                                  ; preds = %56
+ThrowNullRef116:                                  ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef117:                                  ; preds = %60
+ThrowNullRef118:                                  ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef119:                                  ; preds = %37
+ThrowNullRef120:                                  ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef121:                                  ; preds = %41
+ThrowNullRef122:                                  ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef123:                                  ; preds = %46
+ThrowNullRef124:                                  ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef125:                                  ; preds = %51
+ThrowNullRef126:                                  ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef127:                                  ; preds = %27
+ThrowNullRef128:                                  ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef129:                                  ; preds = %31
+ThrowNullRef130:                                  ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef131:                                  ; preds = %19
+ThrowNullRef132:                                  ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef133:                                  ; preds = %22
+ThrowNullRef134:                                  ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef135:                                  ; preds = %338
+ThrowNullRef136:                                  ; preds = %338
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef137:                                  ; preds = %341
+ThrowNullRef138:                                  ; preds = %341
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef139:                                  ; preds = %356
+ThrowNullRef140:                                  ; preds = %356
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef141:                                  ; preds = %360
+ThrowNullRef142:                                  ; preds = %360
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef143:                                  ; preds = %377
+ThrowNullRef144:                                  ; preds = %377
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef145:                                  ; preds = %381
+ThrowNullRef146:                                  ; preds = %381
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef147:                                  ; preds = %424
+ThrowNullRef148:                                  ; preds = %424
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef149:                                  ; preds = %428
+ThrowNullRef150:                                  ; preds = %428
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef151:                                  ; preds = %440
+ThrowNullRef152:                                  ; preds = %440
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef153:                                  ; preds = %444
+ThrowNullRef154:                                  ; preds = %444
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef155:                                  ; preds = %456
+ThrowNullRef156:                                  ; preds = %456
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef157:                                  ; preds = %460
+ThrowNullRef158:                                  ; preds = %460
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef159:                                  ; preds = %474
+ThrowNullRef160:                                  ; preds = %474
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef161:                                  ; preds = %477
+ThrowNullRef162:                                  ; preds = %477
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef163:                                  ; preds = %394
+ThrowNullRef164:                                  ; preds = %394
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef165:                                  ; preds = %398
+ThrowNullRef166:                                  ; preds = %398
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef167:                                  ; preds = %401
+ThrowNullRef168:                                  ; preds = %401
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef169:                                  ; preds = %407
+ThrowNullRef170:                                  ; preds = %407
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1939,8 +2021,8 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
-  br i1 %NullCheck, label %22, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %ThrowNullRef, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
@@ -1948,8 +2030,8 @@ entry:
   store i32 %24, i32* %loc0
   %25 = load i32, i32* %loc0
   %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %26, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %27
 
 ; <label>:27                                      ; preds = %22
   %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
@@ -1971,7 +2053,7 @@ ThrowNullRef:                                     ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1989,8 +2071,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -2022,15 +2104,15 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2048,16 +2130,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
   %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
   store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %15
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
@@ -2072,8 +2154,8 @@ entry:
   %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
   %29 = ptrtoint i16 addrspace(1)* %28 to i64
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %19
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
@@ -2089,19 +2171,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2114,8 +2196,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
@@ -2128,7 +2210,7 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[loadElem]
+Failed to read AppDomain.PrepareDataForSetup[storeElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
@@ -2202,8 +2284,8 @@ entry:
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
-  br i1 %NullCheck24, label %27, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = load i64, i64 addrspace(1)* %26
@@ -2218,8 +2300,8 @@ entry:
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
-  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
   %41 = load i64, i64 addrspace(1)* %39
@@ -2236,8 +2318,8 @@ entry:
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
-  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
   %54 = load i64, i64 addrspace(1)* %52
@@ -2252,8 +2334,8 @@ entry:
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
   %67 = load i64, i64 addrspace(1)* %65
@@ -2270,8 +2352,8 @@ entry:
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
-  br i1 %NullCheck16, label %79, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
   %80 = load i64, i64 addrspace(1)* %78
@@ -2286,8 +2368,8 @@ entry:
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
-  br i1 %NullCheck18, label %92, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
   %93 = load i64, i64 addrspace(1)* %91
@@ -2304,8 +2386,8 @@ entry:
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
-  br i1 %NullCheck12, label %105, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = load i64, i64 addrspace(1)* %104
@@ -2320,8 +2402,8 @@ entry:
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
-  br i1 %NullCheck14, label %118, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
   %119 = load i64, i64 addrspace(1)* %117
@@ -2337,8 +2419,8 @@ entry:
 
 ; <label>:128                                     ; preds = %20
   %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
-  br i1 %NullCheck4, label %130, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %129, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %130
 
 ; <label>:130                                     ; preds = %128
   %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
@@ -2346,8 +2428,8 @@ entry:
   %133 = load i16, i16 addrspace(1)* %132, align 8
   %134 = zext i16 %133 to i32
   %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
-  br i1 %NullCheck6, label %136, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %135, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %136
 
 ; <label>:136                                     ; preds = %130
   %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
@@ -2360,8 +2442,8 @@ entry:
 
 ; <label>:143                                     ; preds = %136
   %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
-  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %144, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %145
 
 ; <label>:145                                     ; preds = %143
   %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
@@ -2369,8 +2451,8 @@ entry:
   %148 = load i16, i16 addrspace(1)* %147, align 8
   %149 = zext i16 %148 to i32
   %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %150, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %151
 
 ; <label>:151                                     ; preds = %145
   %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
@@ -2388,8 +2470,8 @@ entry:
 
 ; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
-  br i1 %NullCheck, label %163, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %ThrowNullRef, label %163
 
 ; <label>:163                                     ; preds = %161
   %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
@@ -2399,8 +2481,8 @@ entry:
 
 ; <label>:167                                     ; preds = %163
   %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
-  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %168, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %169
 
 ; <label>:169                                     ; preds = %167
   %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
@@ -2432,55 +2514,55 @@ ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %167
+ThrowNullRef2:                                    ; preds = %167
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %128
+ThrowNullRef4:                                    ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %130
+ThrowNullRef6:                                    ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %143
+ThrowNullRef8:                                    ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %145
+ThrowNullRef10:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %102
+ThrowNullRef12:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %105
+ThrowNullRef14:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %76
+ThrowNullRef16:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %79
+ThrowNullRef18:                                   ; preds = %79
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %50
+ThrowNullRef20:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %53
+ThrowNullRef22:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %24
+ThrowNullRef24:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %27
+ThrowNullRef26:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2503,15 +2585,15 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2519,16 +2601,16 @@ entry:
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
   store i32 %8, i32* %loc0
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
   %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
   store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
@@ -2546,16 +2628,16 @@ entry:
 
 ; <label>:23                                      ; preds = %64
   %24 = load i16*, i16** %loc3
-  %NullCheck12 = icmp ne i16* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i16* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
   store i32 %27, i32* %loc5
   %28 = load i16*, i16** %loc4
-  %NullCheck14 = icmp ne i16* %28, null
-  br i1 %NullCheck14, label %29, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %28, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = load i16, i16* %28, align 8
@@ -2620,15 +2702,15 @@ entry:
 
 ; <label>:67                                      ; preds = %64
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
-  br i1 %NullCheck8, label %69, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %68, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %69
 
 ; <label>:69                                      ; preds = %67
   %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
   %71 = load i32, i32 addrspace(1)* %70
   %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
-  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %73
 
 ; <label>:73                                      ; preds = %69
   %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
@@ -2645,31 +2727,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %67
+ThrowNullRef8:                                    ; preds = %67
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %69
+ThrowNullRef10:                                   ; preds = %69
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2710,14 +2792,14 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
   %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
@@ -2730,14 +2812,14 @@ entry:
 
 ; <label>:11                                      ; preds = %4
   %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
   %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
@@ -2749,14 +2831,14 @@ entry:
 
 ; <label>:22                                      ; preds = %16
   %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
   %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
-  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
-  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
@@ -2804,23 +2886,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2836,7 +2918,280 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[loadElem]
+Successfully read RuntimeType.IsAssignableFrom
+
+define i8 @RuntimeType.IsAssignableFrom(%System.RuntimeType addrspace(1)* %param0, %System.Type addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.RuntimeType addrspace(1)*
+  %arg1 = alloca %System.Type addrspace(1)*
+  %loc0 = alloca %System.RuntimeType addrspace(1)*
+  %loc1 = alloca %"System.Type[]" addrspace(1)*
+  %loc2 = alloca i32
+  store %System.RuntimeType addrspace(1)* %param0, %System.RuntimeType addrspace(1)** %this
+  store %System.Type addrspace(1)* %param1, %System.Type addrspace(1)** %arg1
+  %0 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %1 = icmp ne %System.Type addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i8 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %5 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %6 = bitcast %System.Type addrspace(1)* %4 to %System.Object addrspace(1)*
+  %7 = bitcast %System.RuntimeType addrspace(1)* %5 to %System.Object addrspace(1)*
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %6, %System.Object addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %3
+  ret i8 1
+
+; <label>:12                                      ; preds = %3
+  %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 152
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 32
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
+  %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
+  %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
+  store %System.RuntimeType addrspace(1)* %25, %System.RuntimeType addrspace(1)** %loc0
+  %26 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %27 = icmp eq %System.RuntimeType addrspace(1)* %26, null
+  br i1 %27, label %34, label %28
+
+; <label>:28                                      ; preds = %15
+  %29 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %30 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)*)*)(%System.RuntimeType addrspace(1)* %29, %System.RuntimeType addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+; <label>:34                                      ; preds = %15
+  %35 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %36 = call %System.Reflection.Emit.TypeBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Reflection.Emit.TypeBuilder addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %35)
+  %37 = icmp eq %System.Reflection.Emit.TypeBuilder addrspace(1)* %36, null
+  br i1 %37, label %139, label %38
+
+; <label>:38                                      ; preds = %34
+  %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %42
+
+; <label>:42                                      ; preds = %38
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 152
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 40
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
+  %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
+  %53 = zext i8 %52 to i32
+  %54 = icmp eq i32 %53, 0
+  br i1 %54, label %56, label %55
+
+; <label>:55                                      ; preds = %42
+  ret i8 1
+
+; <label>:56                                      ; preds = %42
+  %57 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %58 = bitcast %System.RuntimeType addrspace(1)* %57 to %System.Type addrspace(1)*
+  %59 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %58)
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %64 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.Type addrspace(1)* %63, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = bitcast %System.RuntimeType addrspace(1)* %64 to %System.Type addrspace(1)*
+  %67 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %63, %System.Type addrspace(1)* %66)
+  %68 = zext i8 %67 to i32
+  %69 = trunc i32 %68 to i8
+  ret i8 %69
+
+; <label>:70                                      ; preds = %56
+  %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
+  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %73
+
+; <label>:73                                      ; preds = %70
+  %74 = load i64, i64 addrspace(1)* %72
+  %75 = add i64 %74, 128
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = add i64 %77, 0
+  %79 = inttoptr i64 %78 to i64*
+  %80 = load i64, i64* %79
+  %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
+  %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
+  %83 = call i8 %82(%System.Type addrspace(1)* %81)
+  %84 = zext i8 %83 to i32
+  %85 = icmp eq i32 %84, 0
+  br i1 %85, label %139, label %86
+
+; <label>:86                                      ; preds = %73
+  %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
+  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %89
+
+; <label>:89                                      ; preds = %86
+  %90 = load i64, i64 addrspace(1)* %88
+  %91 = add i64 %90, 128
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = add i64 %93, 24
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
+  %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
+  %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
+  store %"System.Type[]" addrspace(1)* %99, %"System.Type[]" addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %129
+
+; <label>:100                                     ; preds = %132
+  %101 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %102 = load i32, i32* %loc2
+  %NullCheck11 = icmp eq %"System.Type[]" addrspace(1)* %101, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %103
+
+; <label>:103                                     ; preds = %100
+  %104 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 1
+  %105 = load i32, i32 addrspace(1)* %104
+  %106 = zext i32 %105 to i64
+  %107 = zext i32 %102 to i64
+  %BoundsCheck = icmp uge i64 %107, %106
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %108
+
+; <label>:108                                     ; preds = %103
+  %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
+  %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
+  %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
+  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %113
+
+; <label>:113                                     ; preds = %108
+  %114 = load i64, i64 addrspace(1)* %112
+  %115 = add i64 %114, 152
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = add i64 %117, 56
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
+  %123 = zext i8 %122 to i32
+  %124 = icmp ne i32 %123, 0
+  br i1 %124, label %126, label %125
+
+; <label>:125                                     ; preds = %113
+  ret i8 0
+
+; <label>:126                                     ; preds = %113
+  %127 = load i32, i32* %loc2
+  %128 = add i32 %127, 1
+  store i32 %128, i32* %loc2
+  br label %129
+
+; <label>:129                                     ; preds = %89, %126
+  %130 = load i32, i32* %loc2
+  %131 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %NullCheck9 = icmp eq %"System.Type[]" addrspace(1)* %131, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %132
+
+; <label>:132                                     ; preds = %129
+  %133 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %131, i32 0, i32 1
+  %134 = load i32, i32 addrspace(1)* %133
+  %135 = zext i32 %134 to i64
+  %136 = trunc i64 %135 to i32
+  %137 = icmp slt i32 %130, %136
+  br i1 %137, label %100, label %138
+
+; <label>:138                                     ; preds = %132
+  ret i8 1
+
+; <label>:139                                     ; preds = %34, %73
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %129
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %103
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -2893,7 +3248,7 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElem]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -2904,8 +3259,8 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -2997,8 +3352,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
@@ -3059,8 +3414,8 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -3087,8 +3442,8 @@ entry:
 
 ; <label>:17                                      ; preds = %5, %11
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
@@ -3097,8 +3452,8 @@ entry:
 
 ; <label>:22                                      ; preds = %1, %11
   %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
@@ -3109,11 +3464,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %17
+ThrowNullRef2:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %22
+ThrowNullRef4:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3167,15 +3522,15 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
   %15 = load i32, i32 addrspace(1)* %14
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
@@ -3198,7 +3553,7 @@ ThrowNullRef:                                     ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef2:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3232,8 +3587,8 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
@@ -3312,8 +3667,8 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -3327,8 +3682,8 @@ entry:
 ; <label>:5                                       ; preds = %43
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %7 = load i32, i32* %loc1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck6, label %8, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
@@ -3366,8 +3721,8 @@ entry:
 ; <label>:32                                      ; preds = %21, %25
   %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
   %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
-  br i1 %NullCheck8, label %35, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = trunc i32 %34 to i16
@@ -3380,8 +3735,8 @@ entry:
 ; <label>:40                                      ; preds = %1, %35
   %41 = load i32, i32* %loc1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
-  br i1 %NullCheck2, label %43, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %42, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
@@ -3392,8 +3747,8 @@ entry:
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
   %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
-  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
   %51 = load i64, i64 addrspace(1)* %49
@@ -3412,19 +3767,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %40
+ThrowNullRef2:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %47
+ThrowNullRef4:                                    ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %5
+ThrowNullRef6:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %32
+ThrowNullRef8:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3467,8 +3822,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
@@ -3492,11 +3847,391 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(i16* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store i16* %param0, i16** %arg0
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load i32, i32* %arg3
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %42, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %37, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg2
+  %13 = load i32, i32* %arg3
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %37, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %24 = load i32, i32* %arg2
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load i16*, i16** %arg0
+  %35 = load i32, i32* %arg3
+  %36 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %36, i16* %34, i32 %35)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:37                                      ; preds = %5, %16
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %39)
+  %41 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41, %System.String addrspace(1)* %38, %System.String addrspace(1)* %40)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41) #0
+  unreachable
+
+; <label>:42                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
-Failed to read StringBuilder.ToString[loadElemA]
+Successfully read StringBuilder.ToString
+
+define %System.String addrspace(1)* @StringBuilder.ToString(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i16*
+  %loc3 = alloca %"System.Char[]" addrspace(1)*
+  %loc4 = alloca i32
+  %loc5 = alloca i32
+  %loc6 = alloca i16 addrspace(1)*
+  %loc7 = alloca %System.String addrspace(1)*
+  %loc8 = alloca %"System.Char[]" addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %0)
+  %2 = icmp ne i32 %1, 0
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %4
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %6)
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %7)
+  store %System.String addrspace(1)* %8, %System.String addrspace(1)** %loc0
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.Text.StringBuilder addrspace(1)* %9, %System.Text.StringBuilder addrspace(1)** %loc1
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  store %System.String addrspace(1)* %10, %System.String addrspace(1)** %loc7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc7
+  %12 = ptrtoint %System.String addrspace(1)* %11 to i64
+  %13 = icmp eq i64 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %5
+  %15 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %16 = sext i32 %15 to i64
+  %17 = add i64 %12, %16
+  br label %18
+
+; <label>:18                                      ; preds = %5, %14
+  %19 = phi i64 [ %12, %5 ], [ %17, %14 ]
+  %20 = inttoptr i64 %19 to i16*
+  store i16* %20, i16** %loc2
+  br label %21
+
+; <label>:21                                      ; preds = %98, %18
+  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %22, null
+  br i1 %NullCheck, label %ThrowNullRef, label %23
+
+; <label>:23                                      ; preds = %21
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 3
+  %25 = load i32, i32 addrspace(1)* %24, align 8
+  %26 = icmp sle i32 %25, 0
+  br i1 %26, label %96, label %27
+
+; <label>:27                                      ; preds = %23
+  %28 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %28, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %29
+
+; <label>:29                                      ; preds = %27
+  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %28, i32 0, i32 1
+  %31 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %30, align 8
+  store %"System.Char[]" addrspace(1)* %31, %"System.Char[]" addrspace(1)** %loc3
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %33
+
+; <label>:33                                      ; preds = %29
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  store i32 %35, i32* %loc4
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  %39 = load i32, i32 addrspace(1)* %38, align 8
+  store i32 %39, i32* %loc5
+  %40 = load i32, i32* %loc5
+  %41 = load i32, i32* %loc4
+  %42 = add i32 %40, %41
+  %43 = zext i32 %42 to i64
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %45
+
+; <label>:45                                      ; preds = %37
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = sext i32 %47 to i64
+  %49 = icmp sgt i64 %43, %48
+  br i1 %49, label %91, label %50
+
+; <label>:50                                      ; preds = %45
+  %51 = load i32, i32* %loc5
+  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %52, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %53
+
+; <label>:53                                      ; preds = %50
+  %54 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %52, i32 0, i32 1
+  %55 = load i32, i32 addrspace(1)* %54
+  %56 = zext i32 %55 to i64
+  %57 = trunc i64 %56 to i32
+  %58 = icmp ugt i32 %51, %57
+  br i1 %58, label %91, label %59
+
+; <label>:59                                      ; preds = %53
+  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  store %"System.Char[]" addrspace(1)* %60, %"System.Char[]" addrspace(1)** %loc8
+  %61 = icmp eq %"System.Char[]" addrspace(1)* %60, null
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %63, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %64
+
+; <label>:64                                      ; preds = %62
+  %65 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %63, i32 0, i32 1
+  %66 = load i32, i32 addrspace(1)* %65
+  %67 = zext i32 %66 to i64
+  %68 = trunc i64 %67 to i32
+  %69 = icmp ne i32 %68, 0
+  br i1 %69, label %71, label %70
+
+; <label>:70                                      ; preds = %59, %64
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:71                                      ; preds = %64
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %73
+
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %BoundsCheck = icmp uge i64 0, %76
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %77
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %78, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:79                                      ; preds = %70, %77
+  %80 = load i16*, i16** %loc2
+  %81 = load i32, i32* %loc4
+  %82 = sext i32 %81 to i64
+  %83 = mul i64 %82, 2
+  %84 = bitcast i16* %80 to i8*
+  %85 = getelementptr inbounds i8, i8* %84, i64 %83
+  %86 = load i16 addrspace(1)*, i16 addrspace(1)** %loc6
+  %87 = ptrtoint i16 addrspace(1)* %86 to i64
+  %88 = load i32, i32* %loc5
+  %89 = bitcast i8* %85 to i16*
+  %90 = inttoptr i64 %87 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %89, i16* %90, i32 %88)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %96
+
+; <label>:91                                      ; preds = %45, %53
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %94 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %93)
+  %95 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95, %System.String addrspace(1)* %92, %System.String addrspace(1)* %94)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95) #0
+  unreachable
+
+; <label>:96                                      ; preds = %23, %79
+  %97 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %97, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %98
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %97, i32 0, i32 2
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  store %System.Text.StringBuilder addrspace(1)* %100, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %102 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %102, label %21, label %103
+
+; <label>:103                                     ; preds = %98
+  store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc7
+  %104 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  ret %System.String addrspace(1)* %104
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method StringBuilder::get_Length using LLILCJit
+Successfully read StringBuilder.get_Length
+
+define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
+Successfully read RuntimeHelpers.get_OffsetToStringData
+
+define i32 @RuntimeHelpers.get_OffsetToStringData() {
+entry:
+  ret i32 12
+}
+
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
 Successfully read CultureData.CreateCultureData
 
@@ -3514,23 +4249,23 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
   store i8 %4, i8 addrspace(1)* %6
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
@@ -3549,11 +4284,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3566,50 +4301,50 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
   store i32 -1, i32 addrspace(1)* %2
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
   store i32 -1, i32 addrspace(1)* %8
   %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
   store i32 -1, i32 addrspace(1)* %14
   %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
   store i32 -1, i32 addrspace(1)* %17
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
@@ -3623,27 +4358,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3675,7 +4410,136 @@ Failed to read Dictionary`2.Insert[non-const derefAddress]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
 Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
-Failed to read HashHelpers.GetPrime[loadElem]
+Successfully read HashHelpers.GetPrime
+
+define i32 @HashHelpers.GetPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %6, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5, %System.String addrspace(1)* %4)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5) #0
+  unreachable
+
+; <label>:6                                       ; preds = %entry
+  store i32 0, i32* %loc0
+  br label %29
+
+; <label>:7                                       ; preds = %35
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 1296
+  %10 = addrspacecast i8 addrspace(1)* %9 to %"System.Int32[]" addrspace(1)**
+  %11 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %10
+  %12 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Int32[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = zext i32 %15 to i64
+  %17 = zext i32 %12 to i64
+  %BoundsCheck = icmp uge i64 %17, %16
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 3, i32 %12
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  store i32 %20, i32* %loc1
+  %21 = load i32, i32* %loc1
+  %22 = load i32, i32* %arg0
+  %23 = icmp slt i32 %21, %22
+  br i1 %23, label %26, label %24
+
+; <label>:24                                      ; preds = %18
+  %25 = load i32, i32* %loc1
+  ret i32 %25
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %loc0
+  %28 = add i32 %27, 1
+  store i32 %28, i32* %loc0
+  br label %29
+
+; <label>:29                                      ; preds = %6, %26
+  %30 = load i32, i32* %loc0
+  %31 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %32 = getelementptr inbounds i8, i8 addrspace(1)* %31, i64 1296
+  %33 = addrspacecast i8 addrspace(1)* %32 to %"System.Int32[]" addrspace(1)**
+  %34 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %33
+  %NullCheck = icmp eq %"System.Int32[]" addrspace(1)* %34, null
+  br i1 %NullCheck, label %ThrowNullRef, label %35
+
+; <label>:35                                      ; preds = %29
+  %36 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %34, i32 0, i32 1
+  %37 = load i32, i32 addrspace(1)* %36
+  %38 = zext i32 %37 to i64
+  %39 = trunc i64 %38 to i32
+  %40 = icmp slt i32 %30, %39
+  br i1 %40, label %7, label %41
+
+; <label>:41                                      ; preds = %35
+  %42 = load i32, i32* %arg0
+  %43 = or i32 %42, 1
+  store i32 %43, i32* %loc2
+  br label %59
+
+; <label>:44                                      ; preds = %59
+  %45 = load i32, i32* %loc2
+  %46 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %45)
+  %47 = zext i8 %46 to i32
+  %48 = icmp eq i32 %47, 0
+  br i1 %48, label %56, label %49
+
+; <label>:49                                      ; preds = %44
+  %50 = load i32, i32* %loc2
+  %51 = sub i32 %50, 1
+  %52 = srem i32 %51, 101
+  %53 = icmp eq i32 %52, 0
+  br i1 %53, label %56, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = load i32, i32* %loc2
+  ret i32 %55
+
+; <label>:56                                      ; preds = %44, %49
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %57, 2
+  store i32 %58, i32* %loc2
+  br label %59
+
+; <label>:59                                      ; preds = %41, %56
+  %60 = load i32, i32* %loc2
+  %61 = icmp slt i32 %60, 2147483647
+  br i1 %61, label %44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load i32, i32* %arg0
+  ret i32 %63
+
+ThrowNullRef:                                     ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
 Successfully read GenericEqualityComparer`1.GetHashCode
 
@@ -3694,14 +4558,14 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
   %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load i64, i64 addrspace(1)* %7
@@ -3720,7 +4584,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3750,8 +4614,8 @@ entry:
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
@@ -3796,8 +4660,8 @@ entry:
   %35 = bitcast i16* %34 to i8*
   %36 = getelementptr inbounds i8, i8* %35, i64 2
   %37 = bitcast i8* %36 to i16*
-  %NullCheck4 = icmp ne i16* %37, null
-  br i1 %NullCheck4, label %38, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %37, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %38
 
 ; <label>:38                                      ; preds = %27
   %39 = load i16, i16* %37, align 8
@@ -3824,8 +4688,8 @@ entry:
 
 ; <label>:54                                      ; preds = %22, %43
   %55 = load i16*, i16** %loc4
-  %NullCheck2 = icmp ne i16* %55, null
-  br i1 %NullCheck2, label %56, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i16* %55, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %56
 
 ; <label>:56                                      ; preds = %54
   %57 = load i16, i16* %55, align 8
@@ -3850,11 +4714,11 @@ ThrowNullRef:                                     ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %54
+ThrowNullRef2:                                    ; preds = %54
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %27
+ThrowNullRef4:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3871,8 +4735,8 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -3907,8 +4771,8 @@ entry:
 
 ; <label>:26                                      ; preds = %19
   %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
-  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %28
 
 ; <label>:28                                      ; preds = %26
   %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
@@ -3920,7 +4784,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3972,8 +4836,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
@@ -3984,26 +4848,26 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
-  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
@@ -4014,8 +4878,8 @@ entry:
 ; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
@@ -4024,8 +4888,8 @@ entry:
 
 ; <label>:25                                      ; preds = %1, %16, %23
   %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
-  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
@@ -4036,27 +4900,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %20
+ThrowNullRef10:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4069,8 +4933,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -4081,8 +4945,8 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
@@ -4091,8 +4955,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1, %8
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
@@ -4103,11 +4967,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4128,24 +4992,24 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   store i32 %3, i32* %loc0
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
   %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
   store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck4, label %9, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
@@ -4164,15 +5028,15 @@ entry:
 ; <label>:18                                      ; preds = %70
   %19 = load i16*, i16** %loc3
   %20 = bitcast i16* %19 to i64*
-  %NullCheck10 = icmp ne i64* %20, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %20, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = load i64, i64* %20, align 8
   %23 = load i16*, i16** %loc4
   %24 = bitcast i16* %23 to i64*
-  %NullCheck12 = icmp ne i64* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = load i64, i64* %24, align 8
@@ -4188,8 +5052,8 @@ entry:
   %31 = bitcast i16* %30 to i8*
   %32 = getelementptr inbounds i8, i8* %31, i64 8
   %33 = bitcast i8* %32 to i64*
-  %NullCheck14 = icmp ne i64* %33, null
-  br i1 %NullCheck14, label %34, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = load i64, i64* %33, align 8
@@ -4197,8 +5061,8 @@ entry:
   %37 = bitcast i16* %36 to i8*
   %38 = getelementptr inbounds i8, i8* %37, i64 8
   %39 = bitcast i8* %38 to i64*
-  %NullCheck16 = icmp ne i64* %39, null
-  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %40
 
 ; <label>:40                                      ; preds = %34
   %41 = load i64, i64* %39, align 8
@@ -4214,8 +5078,8 @@ entry:
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %NullCheck18 = icmp ne i64* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = load i64, i64* %48, align 8
@@ -4223,8 +5087,8 @@ entry:
   %52 = bitcast i16* %51 to i8*
   %53 = getelementptr inbounds i8, i8* %52, i64 16
   %54 = bitcast i8* %53 to i64*
-  %NullCheck20 = icmp ne i64* %54, null
-  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64* %54, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %55
 
 ; <label>:55                                      ; preds = %49
   %56 = load i64, i64* %54, align 8
@@ -4262,15 +5126,15 @@ entry:
 ; <label>:74                                      ; preds = %95
   %75 = load i16*, i16** %loc3
   %76 = bitcast i16* %75 to i32*
-  %NullCheck6 = icmp ne i32* %76, null
-  br i1 %NullCheck6, label %77, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32* %76, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %77
 
 ; <label>:77                                      ; preds = %74
   %78 = load i32, i32* %76, align 8
   %79 = load i16*, i16** %loc4
   %80 = bitcast i16* %79 to i32*
-  %NullCheck8 = icmp ne i32* %80, null
-  br i1 %NullCheck8, label %81, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i32* %80, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %81
 
 ; <label>:81                                      ; preds = %77
   %82 = load i32, i32* %80, align 8
@@ -4318,43 +5182,43 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %74
+ThrowNullRef6:                                    ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %77
+ThrowNullRef8:                                    ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %29
+ThrowNullRef14:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %34
+ThrowNullRef16:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4376,8 +5240,8 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load i64, i64 addrspace(1)* %4
@@ -4389,8 +5253,8 @@ entry:
   %12 = load i64, i64* %11
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %5
   %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
@@ -4399,8 +5263,8 @@ entry:
   %18 = load i8, i8* %arg2
   %19 = zext i8 %18 to i32
   %20 = trunc i32 %19 to i8
-  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %15
   %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
@@ -4411,11 +5275,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4442,8 +5306,8 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
@@ -4466,16 +5330,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
   %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = load i64, i64 addrspace(1)* %19
@@ -4500,8 +5364,8 @@ entry:
 ; <label>:35                                      ; preds = %30
   %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
@@ -4514,8 +5378,8 @@ entry:
 
 ; <label>:42                                      ; preds = %1, %38
   %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
-  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
@@ -4526,19 +5390,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %35
+ThrowNullRef2:                                    ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %42
+ThrowNullRef8:                                    ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4551,14 +5415,14 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
@@ -4570,7 +5434,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4583,8 +5447,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
@@ -4613,51 +5477,51 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
   %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
   %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
   %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
   %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
-  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
   store i64 %21, i64 addrspace(1)* %23
   %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %25 = load i64, i64* %loc0
-  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
@@ -4668,27 +5532,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %22
+ThrowNullRef12:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4701,8 +5565,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
@@ -4713,19 +5577,19 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
@@ -4734,8 +5598,8 @@ entry:
 
 ; <label>:15                                      ; preds = %1, %13
   %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
@@ -4746,19 +5610,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %15
+ThrowNullRef8:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4771,8 +5635,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -4831,8 +5695,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
@@ -4882,8 +5746,8 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
-  br i1 %NullCheck, label %17, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %ThrowNullRef, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
@@ -4894,15 +5758,15 @@ entry:
 
 ; <label>:22                                      ; preds = %17
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
-  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
   %26 = load i32, i32 addrspace(1)* %25
   %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
-  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %27, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
@@ -4925,8 +5789,8 @@ entry:
 ; <label>:40                                      ; preds = %17
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
-  br i1 %NullCheck6, label %43, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %41, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
@@ -4938,34 +5802,17 @@ ThrowNullRef:                                     ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %24
+ThrowNullRef4:                                    ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %40
+ThrowNullRef6:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
-}
-
-INFO:  jitting method Object::ReferenceEquals using LLILCJit
-Successfully read Object.ReferenceEquals
-
-define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
-entry:
-  %arg0 = alloca %System.Object addrspace(1)*
-  %arg1 = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
-  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
-  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = icmp eq %System.Object addrspace(1)* %0, %1
-  %3 = sext i1 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
 }
 
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
@@ -4978,21 +5825,21 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
   %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
-  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
@@ -5007,28 +5854,28 @@ entry:
 ; <label>:13                                      ; preds = %8, %12
   %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
   %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
   %21 = load i32, i32 addrspace(1)* %20, align 8
   %22 = add i32 %21, 1
-  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
   store i32 %22, i32 addrspace(1)* %24
   %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
@@ -5039,27 +5886,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5077,7 +5924,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::Setup using LLILCJit
-Failed to read AppDomain.Setup[loadElem]
+Failed to read AppDomain.Setup[unbox]
 INFO:  jitting method Thread::GetDomain using LLILCJit
 Successfully read Thread.GetDomain
 
@@ -5108,8 +5955,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
@@ -5122,14 +5969,14 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
   %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
@@ -5141,11 +5988,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5173,8 +6020,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -5189,7 +6036,328 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
 Failed to read KeyCollection.System.Collections.Generic.IEnumerable<TKey>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Successfully read Enumerator.MoveNext
+
+define i8 @Enumerator.MoveNext(%"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.RuntimeTypeHandle* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*
+  %"$TypeArg" = alloca %System.RuntimeTypeHandle*
+  store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
+  %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 8
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %76, label %12
+
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
+  br label %76
+
+; <label>:13                                      ; preds = %85
+  %14 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck19 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %15
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, i32 0, i32 0
+  %17 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %16, align 8
+  %NullCheck21 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, i32 0, i32 2
+  %20 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %19, align 8
+  %21 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck23 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %22
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, i32 0, i32 2
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %NullCheck25 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 3, i32 %24
+  %NullCheck27 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %32
+
+; <label>:32                                      ; preds = %30
+  %33 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, i32 0, i32 2
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = icmp slt i32 %34, 0
+  br i1 %35, label %68, label %36
+
+; <label>:36                                      ; preds = %32
+  %37 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %38 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck29 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %39
+
+; <label>:39                                      ; preds = %36
+  %40 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, i32 0, i32 0
+  %41 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %40, align 8
+  %NullCheck31 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, i32 0, i32 2
+  %44 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %43, align 8
+  %45 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck33 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, i32 0, i32 2
+  %48 = load i32, i32 addrspace(1)* %47, align 8
+  %NullCheck35 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %49
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = zext i32 %51 to i64
+  %53 = zext i32 %48 to i64
+  %BoundsCheck37 = icmp uge i64 %53, %52
+  br i1 %BoundsCheck37, label %ThrowIndexOutOfRange38, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 3, i32 %48
+  %NullCheck39 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %56
+
+; <label>:56                                      ; preds = %54
+  %57 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, i32 0, i32 0
+  %58 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck41 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %59
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %60, %System.__Canon addrspace(1)* %58)
+  %61 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck43 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  %64 = load i32, i32 addrspace(1)* %63, align 8
+  %65 = add i32 %64, 1
+  %NullCheck45 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  store i32 %65, i32 addrspace(1)* %67
+  ret i8 1
+
+; <label>:68                                      ; preds = %32
+  %69 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck47 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %73 = add i32 %72, 1
+  %NullCheck49 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %74
+
+; <label>:74                                      ; preds = %70
+  %75 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  store i32 %73, i32 addrspace(1)* %75
+  br label %76
+
+; <label>:76                                      ; preds = %8, %12, %74
+  %77 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %78
+
+; <label>:78                                      ; preds = %76
+  %79 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, i32 0, i32 2
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck7 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %82
+
+; <label>:82                                      ; preds = %78
+  %83 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, i32 0, i32 0
+  %84 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %83, align 8
+  %NullCheck9 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %85
+
+; <label>:85                                      ; preds = %82
+  %86 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, i32 0, i32 7
+  %87 = load i32, i32 addrspace(1)* %86, align 8
+  %88 = icmp ult i32 %80, %87
+  br i1 %88, label %13, label %89
+
+; <label>:89                                      ; preds = %85
+  %90 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %91 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck11 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %92
+
+; <label>:92                                      ; preds = %89
+  %93 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, i32 0, i32 0
+  %94 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck13 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %95
+
+; <label>:95                                      ; preds = %92
+  %96 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, i32 0, i32 7
+  %97 = load i32, i32 addrspace(1)* %96, align 8
+  %98 = add i32 %97, 1
+  %NullCheck15 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %99
+
+; <label>:99                                      ; preds = %95
+  %100 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, i32 0, i32 2
+  store i32 %98, i32 addrspace(1)* %100
+  %101 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck17 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %102
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %103, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %92
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef22:                                   ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef24:                                   ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef26:                                   ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef28:                                   ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef30:                                   ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef32:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef34:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef36:                                   ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange38:                           ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef40:                                   ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef42:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef44:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef46:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef48:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef50:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -5200,8 +6368,8 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -5232,9 +6400,9 @@ Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
 Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
-Failed to read String.MakeSeparatorList[loadElemA]
+Failed to read String.MakeSeparatorList[storeElem]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
-Failed to read String.InternalSplitKeepEmptyEntries[loadElem]
+Failed to read String.InternalSplitKeepEmptyEntries[storeElem]
 INFO:  jitting method Path::IsRelative using LLILCJit
 Successfully read Path.IsRelative
 
@@ -5243,8 +6411,8 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -5254,8 +6422,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
@@ -5271,8 +6439,8 @@ entry:
 
 ; <label>:17                                      ; preds = %7
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
@@ -5288,8 +6456,8 @@ entry:
 
 ; <label>:29                                      ; preds = %19
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %31
 
 ; <label>:31                                      ; preds = %29
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
@@ -5300,8 +6468,8 @@ entry:
 
 ; <label>:36                                      ; preds = %31
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
-  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %37, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
@@ -5312,8 +6480,8 @@ entry:
 
 ; <label>:43                                      ; preds = %31, %38
   %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
-  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %45
 
 ; <label>:45                                      ; preds = %43
   %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
@@ -5324,8 +6492,8 @@ entry:
 
 ; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %50
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
@@ -5336,8 +6504,8 @@ entry:
 
 ; <label>:57                                      ; preds = %1, %7, %19, %45, %52
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
-  br i1 %NullCheck14, label %59, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %59
 
 ; <label>:59                                      ; preds = %57
   %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
@@ -5347,8 +6515,8 @@ entry:
 
 ; <label>:63                                      ; preds = %59
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
@@ -5359,8 +6527,8 @@ entry:
 
 ; <label>:70                                      ; preds = %65
   %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
-  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.String addrspace(1)* %71, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %72
 
 ; <label>:72                                      ; preds = %70
   %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
@@ -5379,39 +6547,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %17
+ThrowNullRef4:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %29
+ThrowNullRef6:                                    ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %36
+ThrowNullRef8:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %43
+ThrowNullRef10:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %50
+ThrowNullRef12:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %57
+ThrowNullRef14:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %63
+ThrowNullRef16:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %70
+ThrowNullRef18:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5419,7 +6587,293 @@ ThrowNullRef17:                                   ; preds = %70
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
-Failed to read String.TrimHelper[loadElem]
+Successfully read String.TrimHelper
+
+define %System.String addrspace(1)* @String.TrimHelper(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i16
+  %loc4 = alloca i32
+  %loc5 = alloca i16
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = sub i32 %3, 1
+  store i32 %4, i32* %loc0
+  store i32 0, i32* %loc1
+  %5 = load i32, i32* %arg2
+  %6 = icmp eq i32 %5, 1
+  br i1 %6, label %62, label %7
+
+; <label>:7                                       ; preds = %1
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:8                                       ; preds = %58
+  store i32 0, i32* %loc2
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load i32, i32* %loc1
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2, i32 %10
+  %13 = load i16, i16 addrspace(1)* %12
+  %14 = zext i16 %13 to i32
+  %15 = trunc i32 %14 to i16
+  store i16 %15, i16* %loc3
+  store i32 0, i32* %loc2
+  br label %34
+
+; <label>:16                                      ; preds = %37
+  %17 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %18 = load i32, i32* %loc2
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %17, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %19
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = zext i32 %18 to i64
+  %BoundsCheck = icmp uge i64 %23, %22
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %24
+
+; <label>:24                                      ; preds = %19
+  %25 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 3, i32 %18
+  %26 = load i16, i16 addrspace(1)* %25, align 8
+  %27 = zext i16 %26 to i32
+  %28 = load i16, i16* %loc3
+  %29 = zext i16 %28 to i32
+  %30 = icmp eq i32 %27, %29
+  br i1 %30, label %43, label %31
+
+; <label>:31                                      ; preds = %24
+  %32 = load i32, i32* %loc2
+  %33 = add i32 %32, 1
+  store i32 %33, i32* %loc2
+  br label %34
+
+; <label>:34                                      ; preds = %11, %31
+  %35 = load i32, i32* %loc2
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = icmp slt i32 %35, %41
+  br i1 %42, label %16, label %43
+
+; <label>:43                                      ; preds = %24, %37
+  %44 = load i32, i32* %loc2
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %45, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp eq i32 %44, %50
+  br i1 %51, label %62, label %52
+
+; <label>:52                                      ; preds = %46
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %7, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %57, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %58
+
+; <label>:58                                      ; preds = %55
+  %59 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %60 = load i32, i32 addrspace(1)* %59
+  %61 = icmp slt i32 %56, %60
+  br i1 %61, label %8, label %62
+
+; <label>:62                                      ; preds = %1, %46, %58
+  %63 = load i32, i32* %arg2
+  %64 = icmp eq i32 %63, 0
+  br i1 %64, label %122, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %66, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %67
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %66, i32 0, i32 1
+  %69 = load i32, i32 addrspace(1)* %68
+  %70 = sub i32 %69, 1
+  store i32 %70, i32* %loc0
+  br label %118
+
+; <label>:71                                      ; preds = %118
+  store i32 0, i32* %loc4
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %73 = load i32, i32* %loc0
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %74
+
+; <label>:74                                      ; preds = %71
+  %75 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 2, i32 %73
+  %76 = load i16, i16 addrspace(1)* %75
+  %77 = zext i16 %76 to i32
+  %78 = trunc i32 %77 to i16
+  store i16 %78, i16* %loc5
+  store i32 0, i32* %loc4
+  br label %97
+
+; <label>:79                                      ; preds = %100
+  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %81 = load i32, i32* %loc4
+  %NullCheck19 = icmp eq %"System.Char[]" addrspace(1)* %80, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
+
+; <label>:82                                      ; preds = %79
+  %83 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 1
+  %84 = load i32, i32 addrspace(1)* %83
+  %85 = zext i32 %84 to i64
+  %86 = zext i32 %81 to i64
+  %BoundsCheck21 = icmp uge i64 %86, %85
+  br i1 %BoundsCheck21, label %ThrowIndexOutOfRange22, label %87
+
+; <label>:87                                      ; preds = %82
+  %88 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 3, i32 %81
+  %89 = load i16, i16 addrspace(1)* %88, align 8
+  %90 = zext i16 %89 to i32
+  %91 = load i16, i16* %loc5
+  %92 = zext i16 %91 to i32
+  %93 = icmp eq i32 %90, %92
+  br i1 %93, label %106, label %94
+
+; <label>:94                                      ; preds = %87
+  %95 = load i32, i32* %loc4
+  %96 = add i32 %95, 1
+  store i32 %96, i32* %loc4
+  br label %97
+
+; <label>:97                                      ; preds = %74, %94
+  %98 = load i32, i32* %loc4
+  %99 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck15 = icmp eq %"System.Char[]" addrspace(1)* %99, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %100
+
+; <label>:100                                     ; preds = %97
+  %101 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %99, i32 0, i32 1
+  %102 = load i32, i32 addrspace(1)* %101
+  %103 = zext i32 %102 to i64
+  %104 = trunc i64 %103 to i32
+  %105 = icmp slt i32 %98, %104
+  br i1 %105, label %79, label %106
+
+; <label>:106                                     ; preds = %87, %100
+  %107 = load i32, i32* %loc4
+  %108 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck17 = icmp eq %"System.Char[]" addrspace(1)* %108, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %109
+
+; <label>:109                                     ; preds = %106
+  %110 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %108, i32 0, i32 1
+  %111 = load i32, i32 addrspace(1)* %110
+  %112 = zext i32 %111 to i64
+  %113 = trunc i64 %112 to i32
+  %114 = icmp eq i32 %107, %113
+  br i1 %114, label %122, label %115
+
+; <label>:115                                     ; preds = %109
+  %116 = load i32, i32* %loc0
+  %117 = sub i32 %116, 1
+  store i32 %117, i32* %loc0
+  br label %118
+
+; <label>:118                                     ; preds = %67, %115
+  %119 = load i32, i32* %loc0
+  %120 = load i32, i32* %loc1
+  %121 = icmp sge i32 %119, %120
+  br i1 %121, label %71, label %122
+
+; <label>:122                                     ; preds = %62, %109, %118
+  %123 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %124 = load i32, i32* %loc1
+  %125 = load i32, i32* %loc0
+  %126 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %123, i32 %124, i32 %125)
+  ret %System.String addrspace(1)* %126
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %97
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange22:                           ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
 Successfully read String.CreateTrimmedString
 
@@ -5439,8 +6893,8 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
@@ -5535,8 +6989,8 @@ entry:
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i64 2872
   %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
   %8 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %7
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %3
   %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
@@ -5553,8 +7007,8 @@ entry:
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 2864
   %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
   %21 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %20
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
-  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %22
 
 ; <label>:22                                      ; preds = %16
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
@@ -5569,7 +7023,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %16
+ThrowNullRef2:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5586,8 +7040,8 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5613,8 +7067,8 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
@@ -5632,8 +7086,8 @@ entry:
 
 ; <label>:12                                      ; preds = %4
   %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
@@ -5644,8 +7098,8 @@ entry:
 
 ; <label>:19                                      ; preds = %14
   %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %19
   %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
@@ -5660,21 +7114,21 @@ entry:
   %31 = zext i16 %30 to i32
   %32 = bitcast i8* %29 to i16*
   %33 = trunc i32 %31 to i16
-  %NullCheck6 = icmp ne i16* %32, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i16* %32, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %21
   store i16 %33, i16* %32, align 8
   %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %36
 
 ; <label>:36                                      ; preds = %34
   %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
   %38 = load i32, i32 addrspace(1)* %37, align 8
   %39 = add i32 %38, 1
-  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %40
 
 ; <label>:40                                      ; preds = %36
   %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
@@ -5683,16 +7137,16 @@ entry:
 
 ; <label>:42                                      ; preds = %14
   %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
-  br i1 %NullCheck12, label %44, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
   %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
   %47 = load i16, i16* %arg1
   %48 = zext i16 %47 to i32
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = trunc i32 %48 to i16
@@ -5703,31 +7157,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %19
+ThrowNullRef4:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %21
+ThrowNullRef6:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %36
+ThrowNullRef10:                                   ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %42
+ThrowNullRef12:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %44
+ThrowNullRef14:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5740,8 +7194,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -5752,8 +7206,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
@@ -5762,14 +7216,14 @@ entry:
 
 ; <label>:11                                      ; preds = %1
   %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
@@ -5779,15 +7233,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5808,8 +7262,8 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5822,8 +7276,8 @@ entry:
 
 ; <label>:8                                       ; preds = %3
   %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
@@ -5842,15 +7296,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
-  br i1 %NullCheck4, label %22, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
   %24 = load i16*, i16* addrspace(1)* %23, align 8
   %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %25, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
@@ -5859,8 +7313,8 @@ entry:
   store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
@@ -5874,8 +7328,8 @@ entry:
 
 ; <label>:37                                      ; preds = %65
   %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %37
   %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
@@ -5886,16 +7340,16 @@ entry:
   %45 = bitcast i16* %41 to i8*
   %46 = getelementptr inbounds i8, i8* %45, i64 %44
   %47 = bitcast i8* %46 to i16*
-  %NullCheck14 = icmp ne i16* %47, null
-  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %47, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %48
 
 ; <label>:48                                      ; preds = %39
   %49 = load i16, i16* %47, align 8
   %50 = zext i16 %49 to i32
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %52 = load i32, i32* %loc1
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %53
 
 ; <label>:53                                      ; preds = %48
   %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
@@ -5916,8 +7370,8 @@ entry:
 ; <label>:62                                      ; preds = %36, %59
   %63 = load i32, i32* %loc1
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck10, label %65, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %65
 
 ; <label>:65                                      ; preds = %62
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
@@ -5936,15 +7390,15 @@ entry:
 
 ; <label>:74                                      ; preds = %70
   %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
-  br i1 %NullCheck18, label %76, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %76
 
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
   %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
-  br i1 %NullCheck20, label %80, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
   %81 = load i64, i64 addrspace(1)* %79
@@ -5958,8 +7412,8 @@ entry:
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
   %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
-  br i1 %NullCheck22, label %92, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.String addrspace(1)* %90, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %92
 
 ; <label>:92                                      ; preds = %80
   %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
@@ -5969,15 +7423,15 @@ entry:
 
 ; <label>:96                                      ; preds = %70
   %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
-  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %98
 
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
   %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
-  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
   %103 = load i64, i64 addrspace(1)* %101
@@ -5991,8 +7445,8 @@ entry:
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
   %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
-  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.String addrspace(1)* %112, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %114
 
 ; <label>:114                                     ; preds = %102
   %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
@@ -6004,59 +7458,59 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %20
+ThrowNullRef4:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %22
+ThrowNullRef6:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %26
+ThrowNullRef8:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %62
+ThrowNullRef10:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %48
+ThrowNullRef16:                                   ; preds = %48
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %74
+ThrowNullRef18:                                   ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %76
+ThrowNullRef20:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %80
+ThrowNullRef22:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %96
+ThrowNullRef24:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %98
+ThrowNullRef26:                                   ; preds = %98
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %102
+ThrowNullRef28:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6069,15 +7523,15 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
   %3 = load i16*, i16* addrspace(1)* %2, align 8
   %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
@@ -6087,8 +7541,8 @@ entry:
   %10 = bitcast i16* %3 to i8*
   %11 = getelementptr inbounds i8, i8* %10, i64 %9
   %12 = bitcast i8* %11 to i16*
-  %NullCheck4 = icmp ne i16* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %5
   store i16 0, i16* %12, align 8
@@ -6098,11 +7552,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6119,8 +7573,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -6131,8 +7585,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
@@ -6144,15 +7598,15 @@ entry:
 
 ; <label>:14                                      ; preds = %1
   %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
   %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
   %21 = load i64, i64 addrspace(1)* %19
@@ -6171,15 +7625,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %14
+ThrowNullRef4:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %16
+ThrowNullRef6:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6302,14 +7756,6 @@ entry:
   ret %System.String addrspace(1)* %57
 }
 
-INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
-Successfully read RuntimeHelpers.get_OffsetToStringData
-
-define i32 @RuntimeHelpers.get_OffsetToStringData() {
-entry:
-  ret i32 12
-}
-
 INFO:  jitting method String::Equals using LLILCJit
 Successfully read String.Equals
 
@@ -6381,8 +7827,8 @@ entry:
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
-  br i1 %NullCheck24, label %29, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
   %30 = load i64, i64 addrspace(1)* %28
@@ -6397,8 +7843,8 @@ entry:
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
-  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
   %43 = load i64, i64 addrspace(1)* %41
@@ -6418,8 +7864,8 @@ entry:
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
   %59 = load i64, i64 addrspace(1)* %57
@@ -6434,8 +7880,8 @@ entry:
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck22, label %71, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
   %72 = load i64, i64 addrspace(1)* %70
@@ -6455,8 +7901,8 @@ entry:
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
-  br i1 %NullCheck16, label %87, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = load i64, i64 addrspace(1)* %86
@@ -6471,8 +7917,8 @@ entry:
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck18, label %100, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
   %101 = load i64, i64 addrspace(1)* %99
@@ -6492,8 +7938,8 @@ entry:
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
-  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
   %117 = load i64, i64 addrspace(1)* %115
@@ -6508,8 +7954,8 @@ entry:
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
-  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
   %130 = load i64, i64 addrspace(1)* %128
@@ -6528,15 +7974,15 @@ entry:
 
 ; <label>:142                                     ; preds = %22
   %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
-  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %143, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %144
 
 ; <label>:144                                     ; preds = %142
   %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
   %146 = load i32, i32 addrspace(1)* %145
   %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
-  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %147, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %148
 
 ; <label>:148                                     ; preds = %144
   %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
@@ -6557,15 +8003,15 @@ entry:
 
 ; <label>:159                                     ; preds = %22
   %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
-  br i1 %NullCheck, label %161, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %ThrowNullRef, label %161
 
 ; <label>:161                                     ; preds = %159
   %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
   %163 = load i32, i32 addrspace(1)* %162
   %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
-  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %164, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %165
 
 ; <label>:165                                     ; preds = %161
   %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
@@ -6578,8 +8024,8 @@ entry:
 
 ; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
-  br i1 %NullCheck4, label %172, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %171, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %172
 
 ; <label>:172                                     ; preds = %170
   %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
@@ -6589,8 +8035,8 @@ entry:
 
 ; <label>:176                                     ; preds = %172
   %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
-  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %177, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %178
 
 ; <label>:178                                     ; preds = %176
   %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
@@ -6629,55 +8075,55 @@ ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %161
+ThrowNullRef2:                                    ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %170
+ThrowNullRef4:                                    ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %176
+ThrowNullRef6:                                    ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %142
+ThrowNullRef8:                                    ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %144
+ThrowNullRef10:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %113
+ThrowNullRef12:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %116
+ThrowNullRef14:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %84
+ThrowNullRef16:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %87
+ThrowNullRef18:                                   ; preds = %87
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %55
+ThrowNullRef20:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %58
+ThrowNullRef22:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %26
+ThrowNullRef24:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %29
+ThrowNullRef26:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,8 +8161,8 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck, label %14, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %ThrowNullRef, label %14
 
 ; <label>:14                                      ; preds = %8
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
@@ -6760,8 +8206,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
@@ -6770,14 +8216,14 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32, i32* %loc0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %10
   %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
   %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
@@ -6790,15 +8236,15 @@ entry:
 ; <label>:25                                      ; preds = %19
   %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
-  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
   %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
@@ -6807,8 +8253,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %37 = load i32, i32* %loc0
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %38, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %38
 
 ; <label>:38                                      ; preds = %32
   %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
@@ -6817,14 +8263,14 @@ entry:
 
 ; <label>:40                                      ; preds = %19
   %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %40
   %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
   %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
-  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
-  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
@@ -6832,8 +8278,8 @@ entry:
   %48 = zext i32 %47 to i64
   %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
-  br i1 %NullCheck16, label %51, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %51
 
 ; <label>:51                                      ; preds = %45
   %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
@@ -6847,15 +8293,15 @@ entry:
 ; <label>:57                                      ; preds = %51
   %58 = load i16*, i16** %arg1
   %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
-  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %60
 
 ; <label>:60                                      ; preds = %57
   %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
   %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
-  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %64
 
 ; <label>:64                                      ; preds = %60
   %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
@@ -6864,22 +8310,22 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
   %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
-  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %70
 
 ; <label>:70                                      ; preds = %64
   %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
   %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
-  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
-  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
   %75 = load i32, i32 addrspace(1)* %74
   %76 = zext i32 %75 to i64
   %77 = trunc i64 %76 to i32
-  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
-  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %78
 
 ; <label>:78                                      ; preds = %73
   %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
@@ -6901,8 +8347,8 @@ entry:
   %90 = bitcast i16* %86 to i8*
   %91 = getelementptr inbounds i8, i8* %90, i64 %89
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %93
 
 ; <label>:93                                      ; preds = %80
   %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
@@ -6912,8 +8358,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %99 = load i32, i32* %loc2
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %100
 
 ; <label>:100                                     ; preds = %93
   %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
@@ -6928,63 +8374,63 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %25
+ThrowNullRef6:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %32
+ThrowNullRef10:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %40
+ThrowNullRef12:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %45
+ThrowNullRef16:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %57
+ThrowNullRef18:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %60
+ThrowNullRef20:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %64
+ThrowNullRef22:                                   ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %70
+ThrowNullRef24:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %73
+ThrowNullRef26:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %80
+ThrowNullRef28:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %93
+ThrowNullRef30:                                   ; preds = %93
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7004,8 +8450,8 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
@@ -7033,43 +8479,43 @@ entry:
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %14
   %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
   %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   %28 = load i32, i32 addrspace(1)* %27, align 8
   %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
-  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %30
 
 ; <label>:30                                      ; preds = %26
   %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
   %32 = load i32, i32 addrspace(1)* %31, align 8
   %33 = add i32 %28, %32
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %34
 
 ; <label>:34                                      ; preds = %30
   %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   store i32 %33, i32 addrspace(1)* %35
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
   store i32 0, i32 addrspace(1)* %38
   %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %40
 
 ; <label>:40                                      ; preds = %37
   %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
@@ -7082,8 +8528,8 @@ entry:
 
 ; <label>:47                                      ; preds = %40
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
@@ -7098,8 +8544,8 @@ entry:
   %54 = load i32, i32* %loc0
   %55 = sext i32 %54 to i64
   %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
-  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %57
 
 ; <label>:57                                      ; preds = %52
   %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
@@ -7110,68 +8556,35 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %14
+ThrowNullRef2:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %23
+ThrowNullRef4:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %26
+ThrowNullRef6:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %30
+ThrowNullRef8:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %34
+ThrowNullRef10:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %47
+ThrowNullRef14:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %52
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-}
-
-INFO:  jitting method StringBuilder::get_Length using LLILCJit
-Successfully read StringBuilder.get_Length
-
-define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.StringBuilder addrspace(1)*
-  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
-  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
-
-; <label>:1                                       ; preds = %entry
-  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %3 = load i32, i32 addrspace(1)* %2, align 8
-  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
-
-; <label>:5                                       ; preds = %1
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = add i32 %3, %7
-  ret i32 %8
-
-ThrowNullRef:                                     ; preds = %entry
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef16:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7213,70 +8626,70 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
   %6 = load i32, i32 addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
   store i32 %6, i32 addrspace(1)* %8
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
   %13 = load i32, i32 addrspace(1)* %12, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
   store i32 %13, i32 addrspace(1)* %15
   %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
-  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %18
 
 ; <label>:18                                      ; preds = %14
   %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
   %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
   %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
   %34 = load i32, i32 addrspace(1)* %33, align 8
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
-  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
@@ -7287,39 +8700,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %28
+ThrowNullRef16:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %32
+ThrowNullRef18:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7455,13 +8868,13 @@ entry:
 ; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
@@ -7477,16 +8890,16 @@ entry:
 
 ; <label>:18                                      ; preds = %15
   %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
   store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
   %22 = load i32, i32* %loc0
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %24
 
 ; <label>:24                                      ; preds = %20
   %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
@@ -7498,13 +8911,13 @@ entry:
 ; <label>:28                                      ; preds = %15, %24
   %29 = load i32, i32* %arg1
   %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %31
   %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
@@ -7517,20 +8930,20 @@ entry:
   %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
-  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
   %46 = load i32, i32 addrspace(1)* %45, align 8
   %47 = sub i32 %40, %46
-  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
-  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i32 addrspace(1)* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %48
 
 ; <label>:48                                      ; preds = %44
   store i32 %47, i32 addrspace(1)* %39, align 8
@@ -7538,21 +8951,21 @@ entry:
 
 ; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
-  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %51
 
 ; <label>:51                                      ; preds = %49
   %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %53
 
 ; <label>:53                                      ; preds = %51
   %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
   %55 = load i32, i32 addrspace(1)* %54, align 8
   %56 = load i32, i32* %arg2
   %57 = sub i32 %55, %56
-  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %58
 
 ; <label>:58                                      ; preds = %53
   %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
@@ -7562,13 +8975,13 @@ entry:
 ; <label>:60                                      ; preds = %33, %58
   %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
   %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
-  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %63
 
 ; <label>:63                                      ; preds = %60
   %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
-  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
-  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
@@ -7578,15 +8991,15 @@ entry:
 
 ; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
-  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i32 addrspace(1)* %69, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %70
 
 ; <label>:70                                      ; preds = %68
   %71 = load i32, i32 addrspace(1)* %69, align 8
   store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
-  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
@@ -7596,8 +9009,8 @@ entry:
   store i32 %77, i32* %loc4
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
-  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %80
 
 ; <label>:80                                      ; preds = %73
   %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
@@ -7607,71 +9020,71 @@ entry:
 ; <label>:83                                      ; preds = %80
   store i32 0, i32* %loc3
   %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
-  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
-  br i1 %NullCheck26, label %88, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i32 addrspace(1)* %87, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %88
 
 ; <label>:88                                      ; preds = %85
   %89 = load i32, i32 addrspace(1)* %87, align 8
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
-  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %90
 
 ; <label>:90                                      ; preds = %88
   %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
   store i32 %89, i32 addrspace(1)* %91
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
-  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
-  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %96
 
 ; <label>:96                                      ; preds = %94
   %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
-  br i1 %NullCheck34, label %100, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %100
 
 ; <label>:100                                     ; preds = %96
   %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
-  br i1 %NullCheck36, label %102, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %102
 
 ; <label>:102                                     ; preds = %100
   %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
   %104 = load i32, i32 addrspace(1)* %103, align 8
   %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
-  br i1 %NullCheck38, label %106, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %106
 
 ; <label>:106                                     ; preds = %102
   %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
-  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
-  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %108
 
 ; <label>:108                                     ; preds = %106
   %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
   %110 = load i32, i32 addrspace(1)* %109, align 8
   %111 = add i32 %104, %110
-  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %112
 
 ; <label>:112                                     ; preds = %108
   %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
   store i32 %111, i32 addrspace(1)* %113
   %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
-  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i32 addrspace(1)* %114, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %115
 
 ; <label>:115                                     ; preds = %112
   %116 = load i32, i32 addrspace(1)* %114, align 8
@@ -7681,19 +9094,19 @@ entry:
 ; <label>:118                                     ; preds = %115
   %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
-  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %121
 
 ; <label>:121                                     ; preds = %118
   %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
-  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
-  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %123
 
 ; <label>:123                                     ; preds = %121
   %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
   %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
-  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
-  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %126
 
 ; <label>:126                                     ; preds = %123
   %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
@@ -7705,8 +9118,8 @@ entry:
 
 ; <label>:130                                     ; preds = %80, %115, %126
   %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %132
 
 ; <label>:132                                     ; preds = %130
   %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7715,8 +9128,8 @@ entry:
   %136 = load i32, i32* %loc3
   %137 = sub i32 %135, %136
   %138 = sub i32 %134, %137
-  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %139
 
 ; <label>:139                                     ; preds = %132
   %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7728,16 +9141,16 @@ entry:
 
 ; <label>:144                                     ; preds = %139
   %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
-  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %146
 
 ; <label>:146                                     ; preds = %144
   %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
   %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
   %149 = load i32, i32* %loc2
   %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
-  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %151
 
 ; <label>:151                                     ; preds = %146
   %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
@@ -7754,145 +9167,249 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %18
+ThrowNullRef4:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %31
+ThrowNullRef10:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %44
+ThrowNullRef16:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %68
+ThrowNullRef18:                                   ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %70
+ThrowNullRef20:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %73
+ThrowNullRef22:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %83
+ThrowNullRef24:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %85
+ThrowNullRef26:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %88
+ThrowNullRef28:                                   ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %90
+ThrowNullRef30:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %94
+ThrowNullRef32:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %96
+ThrowNullRef34:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %100
+ThrowNullRef36:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %102
+ThrowNullRef38:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %106
+ThrowNullRef40:                                   ; preds = %106
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %108
+ThrowNullRef42:                                   ; preds = %108
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %112
+ThrowNullRef44:                                   ; preds = %112
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %118
+ThrowNullRef46:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %121
+ThrowNullRef48:                                   ; preds = %121
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %123
+ThrowNullRef50:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %130
+ThrowNullRef52:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %132
+ThrowNullRef54:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %144
+ThrowNullRef56:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %146
+ThrowNullRef58:                                   ; preds = %146
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %60
+ThrowNullRef60:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %63
+ThrowNullRef62:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %49
+ThrowNullRef64:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %51
+ThrowNullRef66:                                   ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %53
+ThrowNullRef68:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(%"System.Char[]" addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %arg0 = alloca %"System.Char[]" addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store %"System.Char[]" addrspace(1)* %param0, %"System.Char[]" addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load i32, i32* %arg4
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %43, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %38, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg1
+  %13 = load i32, i32* %arg4
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %38, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %24 = load i32, i32* %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %35 = load i32, i32* %arg3
+  %36 = load i32, i32* %arg4
+  %37 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %37, %"System.Char[]" addrspace(1)* %34, i32 %35, i32 %36)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:38                                      ; preds = %5, %16
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Successfully read Buffer._Memmove
 
@@ -7914,7 +9431,7 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[loadElem]
+Failed to read AppDomain.SetDataHelper[storeElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -7923,8 +9440,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
@@ -7934,8 +9451,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
@@ -7947,15 +9464,15 @@ entry:
   %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
   %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
@@ -7966,15 +9483,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7992,7 +9509,79 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
-Failed to read Dictionary`2.TryGetValue[loadElemA]
+Successfully read Dictionary`2.TryGetValue
+
+define i8 @"Dictionary`2.TryGetValue"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)* addrspace(1)* %param2) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  %arg2 = alloca %System.__Canon addrspace(1)* addrspace(1)*
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  store %System.__Canon addrspace(1)* addrspace(1)* %param2, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  store i32 %2, i32* %loc0
+  %3 = load i32, i32* %loc0
+  %4 = icmp slt i32 %3, 0
+  br i1 %4, label %22, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 2
+  %10 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %9, align 8
+  %11 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = zext i32 %11 to i64
+  %BoundsCheck = icmp uge i64 %16, %15
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 3, i32 %11
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %20, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %6, %System.__Canon addrspace(1)* %21)
+  ret i8 1
+
+; <label>:22                                      ; preds = %entry
+  %23 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %23, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -8058,8 +9647,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
@@ -8091,8 +9680,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
@@ -8171,15 +9760,15 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck, label %19, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %ThrowNullRef, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
   %21 = load i32, i32 addrspace(1)* %20
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
@@ -8202,7 +9791,7 @@ ThrowNullRef:                                     ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %19
+ThrowNullRef2:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8248,8 +9837,8 @@ entry:
   %0 = alloca %System.AppDomainHandle
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %1 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %1, i32 0, i32 15
@@ -8269,8 +9858,8 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
@@ -8286,7 +9875,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -8299,8 +9888,8 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -8327,8 +9916,8 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
@@ -8352,8 +9941,8 @@ entry:
   %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
   store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
@@ -8363,8 +9952,8 @@ entry:
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
@@ -8374,8 +9963,8 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %9
   %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
@@ -8384,8 +9973,8 @@ entry:
 
 ; <label>:18                                      ; preds = %3, %16
   %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
@@ -8397,15 +9986,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %18
+ThrowNullRef6:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8418,8 +10007,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
@@ -8453,15 +10042,15 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
@@ -8473,7 +10062,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8481,7 +10070,7 @@ ThrowNullRef1:                                    ; preds = %1
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
 Failed to read Dictionary`2.System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
@@ -8506,8 +10095,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
@@ -8524,8 +10113,8 @@ entry:
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -8544,7 +10133,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8577,8 +10166,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = load i64, i64* %arg2
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = trunc i32 %3 to i8
@@ -8634,46 +10223,46 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
   %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
-  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
-  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
-  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
@@ -8684,27 +10273,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %20
+ThrowNullRef12:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8717,8 +10306,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -8756,22 +10345,22 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
   %9 = load i64, i64 addrspace(1)* %8, align 8
   %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
   %13 = load i64, i64 addrspace(1)* %12, align 8
   %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %11
   %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
@@ -8788,11 +10377,11 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8882,8 +10471,8 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
@@ -8900,8 +10489,8 @@ entry:
 ; <label>:8                                       ; preds = %1
   %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
   %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
@@ -8911,15 +10500,15 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
   %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
   %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
-  br i1 %NullCheck6, label %21, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
@@ -8946,15 +10535,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8992,15 +10581,15 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
   store i8 %3, i8 addrspace(1)* %5
   %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
@@ -9011,7 +10600,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9027,8 +10616,8 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -9041,8 +10630,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
@@ -9058,7 +10647,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9080,8 +10669,8 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
@@ -9096,8 +10685,8 @@ entry:
 ; <label>:12                                      ; preds = %6
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
@@ -9112,8 +10701,8 @@ entry:
 ; <label>:21                                      ; preds = %15
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
@@ -9128,8 +10717,8 @@ entry:
 ; <label>:30                                      ; preds = %24
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %31, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
@@ -9144,8 +10733,8 @@ entry:
 ; <label>:39                                      ; preds = %33
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
-  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %40, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %42
 
 ; <label>:42                                      ; preds = %39
   %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
@@ -9164,19 +10753,19 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %21
+ThrowNullRef4:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %30
+ThrowNullRef6:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %39
+ThrowNullRef8:                                    ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9243,8 +10832,8 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
@@ -9264,57 +10853,57 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
   store i8 0, i8 addrspace(1)* %2
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
   store i8 0, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
   store i8 0, i8 addrspace(1)* %17
   %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
   store i8 0, i8 addrspace(1)* %20
   %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
-  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
@@ -9325,31 +10914,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %19
+ThrowNullRef14:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9367,8 +10956,8 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
@@ -9380,8 +10969,8 @@ entry:
 
 ; <label>:9                                       ; preds = %4
   %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %9
   %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
@@ -9395,7 +10984,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef2:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9420,8 +11009,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
@@ -9512,8 +11101,8 @@ entry:
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
@@ -9524,8 +11113,8 @@ entry:
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = load i64, i64 addrspace(1)* %12
@@ -9537,8 +11126,8 @@ entry:
   %20 = load i64, i64* %19
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
-  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %13
   %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
@@ -9555,8 +11144,8 @@ entry:
 ; <label>:30                                      ; preds = %25
   %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %32 = load i32, i32* %arg2
-  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
-  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
@@ -9570,15 +11159,15 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %30
+ThrowNullRef2:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9622,87 +11211,87 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
   %10 = load i8, i8 addrspace(1)* %9, align 8
   %11 = zext i8 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %8
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
   store i8 %12, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
   %19 = load i8, i8 addrspace(1)* %18, align 8
   %20 = zext i8 %19 to i32
   %21 = trunc i32 %20 to i8
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
   store i8 %21, i8 addrspace(1)* %23
   %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
   %28 = load i8, i8 addrspace(1)* %27, align 8
   %29 = zext i8 %28 to i32
   %30 = trunc i32 %29 to i8
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
-  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %31
 
 ; <label>:31                                      ; preds = %26
   %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
   store i8 %30, i8 addrspace(1)* %32
   %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
-  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
-  br i1 %NullCheck14, label %40, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %40
 
 ; <label>:40                                      ; preds = %35
   %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
   store i8 %39, i8 addrspace(1)* %41
   %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
-  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %44
 
 ; <label>:44                                      ; preds = %40
   %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
   %46 = load i8, i8 addrspace(1)* %45, align 8
   %47 = zext i8 %46 to i32
   %48 = trunc i32 %47 to i8
-  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
   store i8 %48, i8 addrspace(1)* %50
   %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
-  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
@@ -9713,29 +11302,29 @@ entry:
 ; <label>:56                                      ; preds = %52
   %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
-  br i1 %NullCheck22, label %59, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
   %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
   %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
-  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
-  br i1 %NullCheck24, label %63, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
   %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
-  br i1 %NullCheck26, label %66, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
   %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
-  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
-  br i1 %NullCheck28, label %69, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %69
 
 ; <label>:69                                      ; preds = %66
   %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
@@ -9744,15 +11333,15 @@ entry:
 
 ; <label>:71                                      ; preds = %105
   %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
-  br i1 %NullCheck34, label %73, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %73
 
 ; <label>:73                                      ; preds = %71
   %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
   %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
   %76 = load i32, i32* %loc0
-  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
-  br i1 %NullCheck36, label %77, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
@@ -9766,8 +11355,8 @@ entry:
 
 ; <label>:83                                      ; preds = %77
   %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
-  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
@@ -9775,14 +11364,14 @@ entry:
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
   %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
-  br i1 %NullCheck40, label %91, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
 ; <label>:91                                      ; preds = %85
   %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
   %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
-  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck42, label %94, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %94
 
 ; <label>:94                                      ; preds = %91
   %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
@@ -9798,14 +11387,14 @@ entry:
 ; <label>:99                                      ; preds = %69, %96
   %100 = load i32, i32* %loc0
   %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
-  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %102
 
 ; <label>:102                                     ; preds = %99
   %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
   %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
-  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
-  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
@@ -9819,87 +11408,87 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %26
+ThrowNullRef10:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %31
+ThrowNullRef12:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %35
+ThrowNullRef14:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %40
+ThrowNullRef16:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %56
+ThrowNullRef22:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %59
+ThrowNullRef24:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %63
+ThrowNullRef26:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %66
+ThrowNullRef28:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %102
+ThrowNullRef32:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %71
+ThrowNullRef34:                                   ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %73
+ThrowNullRef36:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %83
+ThrowNullRef38:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %85
+ThrowNullRef40:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %91
+ThrowNullRef42:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9943,15 +11532,15 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
   %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
@@ -9961,28 +11550,28 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
   %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %12
   %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
   %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
   %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
-  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
@@ -9993,23 +11582,23 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %12
+ThrowNullRef6:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10031,15 +11620,15 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
   %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = load i64, i64 addrspace(1)* %7
@@ -10077,13 +11666,13 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[loadElem]
+Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -10111,8 +11700,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1

--- a/test/BaseLine/JIT/CodeGenBringUpTests/AndRef.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/AndRef.error.txt
@@ -25,8 +25,8 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
@@ -40,8 +40,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
   %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
@@ -75,7 +75,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -90,8 +90,8 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %NullCheck = icmp ne i8 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = load i8, i8 addrspace(1)* %0, align 8
@@ -125,8 +125,8 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
@@ -159,8 +159,8 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -184,8 +184,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
   store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
@@ -195,8 +195,8 @@ entry:
 ; <label>:4                                       ; preds = %1
   %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
   %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
@@ -206,8 +206,8 @@ entry:
   %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
@@ -221,14 +221,14 @@ entry:
 
 ; <label>:17                                      ; preds = %14
   %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
   %21 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
@@ -238,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -249,8 +249,8 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
@@ -261,27 +261,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %30
+ThrowNullRef10:                                   ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -301,7 +301,89 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
-Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
+Successfully read AppDomainSetup.GetUnsecureApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.GetUnsecureApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %NullCheck = icmp eq %"System.String[]" addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %BoundsCheck = icmp uge i64 0, %5
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %6
+
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 3, i32 0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
+  ret %System.String addrspace(1)* %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_Value using LLILCJit
+Successfully read AppDomainSetup.get_Value
+
+define %"System.String[]" addrspace(1)* @AppDomainSetup.get_Value(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.String[]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 18)
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.String[]" addrspace(1)* addrspace(1)*, %"System.String[]" addrspace(1)*)*)(%"System.String[]" addrspace(1)* addrspace(1)* %9, %"System.String[]" addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %11, i32 0, i32 1
+  %14 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %13, align 8
+  ret %"System.String[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -319,8 +401,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -368,16 +450,16 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
   %5 = load i32, i32 addrspace(1)* %4
   %6 = sub i32 %5, 1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -389,7 +471,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -421,8 +503,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
@@ -456,8 +538,8 @@ entry:
 ; <label>:27                                      ; preds = %19
   %28 = load i32, i32* %arg1
   %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
-  br i1 %NullCheck2, label %30, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %29, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %30
 
 ; <label>:30                                      ; preds = %27
   %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
@@ -493,8 +575,8 @@ entry:
 ; <label>:49                                      ; preds = %46
   %50 = load i32, i32* %arg2
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck4, label %52, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
@@ -517,11 +599,11 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %27
+ThrowNullRef2:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %49
+ThrowNullRef4:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -544,16 +626,16 @@ entry:
   %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %0)
   store %System.String addrspace(1)* %1, %System.String addrspace(1)** %loc0
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 2
   %5 = bitcast [0 x i16] addrspace(1)* %4 to i16 addrspace(1)*
   store i16 addrspace(1)* %5, i16 addrspace(1)** %loc1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %3
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2
@@ -580,7 +662,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -691,15 +773,15 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %NullCheck132 = icmp ne i8* %21, null
-  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+  %NullCheck131 = icmp eq i8* %21, null
+  br i1 %NullCheck131, label %ThrowNullRef132, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = load i8, i8* %21, align 8
   %24 = zext i8 %23 to i32
   %25 = trunc i32 %24 to i8
-  %NullCheck134 = icmp ne i8* %20, null
-  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+  %NullCheck133 = icmp eq i8* %20, null
+  br i1 %NullCheck133, label %ThrowNullRef134, label %26
 
 ; <label>:26                                      ; preds = %22
   store i8 %25, i8* %20, align 8
@@ -709,16 +791,16 @@ entry:
   %28 = load i8*, i8** %arg0
   %29 = load i8*, i8** %arg1
   %30 = bitcast i8* %29 to i16*
-  %NullCheck128 = icmp ne i16* %30, null
-  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+  %NullCheck127 = icmp eq i16* %30, null
+  br i1 %NullCheck127, label %ThrowNullRef128, label %31
 
 ; <label>:31                                      ; preds = %27
   %32 = load i16, i16* %30, align 8
   %33 = sext i16 %32 to i32
   %34 = bitcast i8* %28 to i16*
   %35 = trunc i32 %33 to i16
-  %NullCheck130 = icmp ne i16* %34, null
-  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+  %NullCheck129 = icmp eq i16* %34, null
+  br i1 %NullCheck129, label %ThrowNullRef130, label %36
 
 ; <label>:36                                      ; preds = %31
   store i16 %35, i16* %34, align 8
@@ -728,16 +810,16 @@ entry:
   %38 = load i8*, i8** %arg0
   %39 = load i8*, i8** %arg1
   %40 = bitcast i8* %39 to i16*
-  %NullCheck120 = icmp ne i16* %40, null
-  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+  %NullCheck119 = icmp eq i16* %40, null
+  br i1 %NullCheck119, label %ThrowNullRef120, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i16, i16* %40, align 8
   %43 = sext i16 %42 to i32
   %44 = bitcast i8* %38 to i16*
   %45 = trunc i32 %43 to i16
-  %NullCheck122 = icmp ne i16* %44, null
-  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+  %NullCheck121 = icmp eq i16* %44, null
+  br i1 %NullCheck121, label %ThrowNullRef122, label %46
 
 ; <label>:46                                      ; preds = %41
   store i16 %45, i16* %44, align 8
@@ -745,15 +827,15 @@ entry:
   %48 = getelementptr inbounds i8, i8* %47, i64 2
   %49 = load i8*, i8** %arg1
   %50 = getelementptr inbounds i8, i8* %49, i64 2
-  %NullCheck124 = icmp ne i8* %50, null
-  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+  %NullCheck123 = icmp eq i8* %50, null
+  br i1 %NullCheck123, label %ThrowNullRef124, label %51
 
 ; <label>:51                                      ; preds = %46
   %52 = load i8, i8* %50, align 8
   %53 = zext i8 %52 to i32
   %54 = trunc i32 %53 to i8
-  %NullCheck126 = icmp ne i8* %48, null
-  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+  %NullCheck125 = icmp eq i8* %48, null
+  br i1 %NullCheck125, label %ThrowNullRef126, label %55
 
 ; <label>:55                                      ; preds = %51
   store i8 %54, i8* %48, align 8
@@ -763,14 +845,14 @@ entry:
   %57 = load i8*, i8** %arg0
   %58 = load i8*, i8** %arg1
   %59 = bitcast i8* %58 to i32*
-  %NullCheck116 = icmp ne i32* %59, null
-  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+  %NullCheck115 = icmp eq i32* %59, null
+  br i1 %NullCheck115, label %ThrowNullRef116, label %60
 
 ; <label>:60                                      ; preds = %56
   %61 = load i32, i32* %59, align 8
   %62 = bitcast i8* %57 to i32*
-  %NullCheck118 = icmp ne i32* %62, null
-  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+  %NullCheck117 = icmp eq i32* %62, null
+  br i1 %NullCheck117, label %ThrowNullRef118, label %63
 
 ; <label>:63                                      ; preds = %60
   store i32 %61, i32* %62, align 8
@@ -780,14 +862,14 @@ entry:
   %65 = load i8*, i8** %arg0
   %66 = load i8*, i8** %arg1
   %67 = bitcast i8* %66 to i32*
-  %NullCheck108 = icmp ne i32* %67, null
-  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+  %NullCheck107 = icmp eq i32* %67, null
+  br i1 %NullCheck107, label %ThrowNullRef108, label %68
 
 ; <label>:68                                      ; preds = %64
   %69 = load i32, i32* %67, align 8
   %70 = bitcast i8* %65 to i32*
-  %NullCheck110 = icmp ne i32* %70, null
-  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+  %NullCheck109 = icmp eq i32* %70, null
+  br i1 %NullCheck109, label %ThrowNullRef110, label %71
 
 ; <label>:71                                      ; preds = %68
   store i32 %69, i32* %70, align 8
@@ -795,15 +877,15 @@ entry:
   %73 = getelementptr inbounds i8, i8* %72, i64 4
   %74 = load i8*, i8** %arg1
   %75 = getelementptr inbounds i8, i8* %74, i64 4
-  %NullCheck112 = icmp ne i8* %75, null
-  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+  %NullCheck111 = icmp eq i8* %75, null
+  br i1 %NullCheck111, label %ThrowNullRef112, label %76
 
 ; <label>:76                                      ; preds = %71
   %77 = load i8, i8* %75, align 8
   %78 = zext i8 %77 to i32
   %79 = trunc i32 %78 to i8
-  %NullCheck114 = icmp ne i8* %73, null
-  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+  %NullCheck113 = icmp eq i8* %73, null
+  br i1 %NullCheck113, label %ThrowNullRef114, label %80
 
 ; <label>:80                                      ; preds = %76
   store i8 %79, i8* %73, align 8
@@ -813,14 +895,14 @@ entry:
   %82 = load i8*, i8** %arg0
   %83 = load i8*, i8** %arg1
   %84 = bitcast i8* %83 to i32*
-  %NullCheck100 = icmp ne i32* %84, null
-  br i1 %NullCheck100, label %85, label %ThrowNullRef99
+  %NullCheck99 = icmp eq i32* %84, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %85
 
 ; <label>:85                                      ; preds = %81
   %86 = load i32, i32* %84, align 8
   %87 = bitcast i8* %82 to i32*
-  %NullCheck102 = icmp ne i32* %87, null
-  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+  %NullCheck101 = icmp eq i32* %87, null
+  br i1 %NullCheck101, label %ThrowNullRef102, label %88
 
 ; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
@@ -829,16 +911,16 @@ entry:
   %91 = load i8*, i8** %arg1
   %92 = getelementptr inbounds i8, i8* %91, i64 4
   %93 = bitcast i8* %92 to i16*
-  %NullCheck104 = icmp ne i16* %93, null
-  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+  %NullCheck103 = icmp eq i16* %93, null
+  br i1 %NullCheck103, label %ThrowNullRef104, label %94
 
 ; <label>:94                                      ; preds = %88
   %95 = load i16, i16* %93, align 8
   %96 = sext i16 %95 to i32
   %97 = bitcast i8* %90 to i16*
   %98 = trunc i32 %96 to i16
-  %NullCheck106 = icmp ne i16* %97, null
-  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+  %NullCheck105 = icmp eq i16* %97, null
+  br i1 %NullCheck105, label %ThrowNullRef106, label %99
 
 ; <label>:99                                      ; preds = %94
   store i16 %98, i16* %97, align 8
@@ -848,14 +930,14 @@ entry:
   %101 = load i8*, i8** %arg0
   %102 = load i8*, i8** %arg1
   %103 = bitcast i8* %102 to i32*
-  %NullCheck88 = icmp ne i32* %103, null
-  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+  %NullCheck87 = icmp eq i32* %103, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %104
 
 ; <label>:104                                     ; preds = %100
   %105 = load i32, i32* %103, align 8
   %106 = bitcast i8* %101 to i32*
-  %NullCheck90 = icmp ne i32* %106, null
-  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+  %NullCheck89 = icmp eq i32* %106, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %107
 
 ; <label>:107                                     ; preds = %104
   store i32 %105, i32* %106, align 8
@@ -864,16 +946,16 @@ entry:
   %110 = load i8*, i8** %arg1
   %111 = getelementptr inbounds i8, i8* %110, i64 4
   %112 = bitcast i8* %111 to i16*
-  %NullCheck92 = icmp ne i16* %112, null
-  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+  %NullCheck91 = icmp eq i16* %112, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %113
 
 ; <label>:113                                     ; preds = %107
   %114 = load i16, i16* %112, align 8
   %115 = sext i16 %114 to i32
   %116 = bitcast i8* %109 to i16*
   %117 = trunc i32 %115 to i16
-  %NullCheck94 = icmp ne i16* %116, null
-  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+  %NullCheck93 = icmp eq i16* %116, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %118
 
 ; <label>:118                                     ; preds = %113
   store i16 %117, i16* %116, align 8
@@ -881,15 +963,15 @@ entry:
   %120 = getelementptr inbounds i8, i8* %119, i64 6
   %121 = load i8*, i8** %arg1
   %122 = getelementptr inbounds i8, i8* %121, i64 6
-  %NullCheck96 = icmp ne i8* %122, null
-  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+  %NullCheck95 = icmp eq i8* %122, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %123
 
 ; <label>:123                                     ; preds = %118
   %124 = load i8, i8* %122, align 8
   %125 = zext i8 %124 to i32
   %126 = trunc i32 %125 to i8
-  %NullCheck98 = icmp ne i8* %120, null
-  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+  %NullCheck97 = icmp eq i8* %120, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %127
 
 ; <label>:127                                     ; preds = %123
   store i8 %126, i8* %120, align 8
@@ -899,14 +981,14 @@ entry:
   %129 = load i8*, i8** %arg0
   %130 = load i8*, i8** %arg1
   %131 = bitcast i8* %130 to i64*
-  %NullCheck84 = icmp ne i64* %131, null
-  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+  %NullCheck83 = icmp eq i64* %131, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %132
 
 ; <label>:132                                     ; preds = %128
   %133 = load i64, i64* %131, align 8
   %134 = bitcast i8* %129 to i64*
-  %NullCheck86 = icmp ne i64* %134, null
-  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+  %NullCheck85 = icmp eq i64* %134, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %135
 
 ; <label>:135                                     ; preds = %132
   store i64 %133, i64* %134, align 8
@@ -916,14 +998,14 @@ entry:
   %137 = load i8*, i8** %arg0
   %138 = load i8*, i8** %arg1
   %139 = bitcast i8* %138 to i64*
-  %NullCheck76 = icmp ne i64* %139, null
-  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+  %NullCheck75 = icmp eq i64* %139, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %140
 
 ; <label>:140                                     ; preds = %136
   %141 = load i64, i64* %139, align 8
   %142 = bitcast i8* %137 to i64*
-  %NullCheck78 = icmp ne i64* %142, null
-  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+  %NullCheck77 = icmp eq i64* %142, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %143
 
 ; <label>:143                                     ; preds = %140
   store i64 %141, i64* %142, align 8
@@ -931,15 +1013,15 @@ entry:
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %NullCheck80 = icmp ne i8* %147, null
-  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+  %NullCheck79 = icmp eq i8* %147, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %148
 
 ; <label>:148                                     ; preds = %143
   %149 = load i8, i8* %147, align 8
   %150 = zext i8 %149 to i32
   %151 = trunc i32 %150 to i8
-  %NullCheck82 = icmp ne i8* %145, null
-  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+  %NullCheck81 = icmp eq i8* %145, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %152
 
 ; <label>:152                                     ; preds = %148
   store i8 %151, i8* %145, align 8
@@ -949,14 +1031,14 @@ entry:
   %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
   %156 = bitcast i8* %155 to i64*
-  %NullCheck68 = icmp ne i64* %156, null
-  br i1 %NullCheck68, label %157, label %ThrowNullRef67
+  %NullCheck67 = icmp eq i64* %156, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %157
 
 ; <label>:157                                     ; preds = %153
   %158 = load i64, i64* %156, align 8
   %159 = bitcast i8* %154 to i64*
-  %NullCheck70 = icmp ne i64* %159, null
-  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+  %NullCheck69 = icmp eq i64* %159, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %160
 
 ; <label>:160                                     ; preds = %157
   store i64 %158, i64* %159, align 8
@@ -965,16 +1047,16 @@ entry:
   %163 = load i8*, i8** %arg1
   %164 = getelementptr inbounds i8, i8* %163, i64 8
   %165 = bitcast i8* %164 to i16*
-  %NullCheck72 = icmp ne i16* %165, null
-  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+  %NullCheck71 = icmp eq i16* %165, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %166
 
 ; <label>:166                                     ; preds = %160
   %167 = load i16, i16* %165, align 8
   %168 = sext i16 %167 to i32
   %169 = bitcast i8* %162 to i16*
   %170 = trunc i32 %168 to i16
-  %NullCheck74 = icmp ne i16* %169, null
-  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+  %NullCheck73 = icmp eq i16* %169, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %171
 
 ; <label>:171                                     ; preds = %166
   store i16 %170, i16* %169, align 8
@@ -984,14 +1066,14 @@ entry:
   %173 = load i8*, i8** %arg0
   %174 = load i8*, i8** %arg1
   %175 = bitcast i8* %174 to i64*
-  %NullCheck56 = icmp ne i64* %175, null
-  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+  %NullCheck55 = icmp eq i64* %175, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %176
 
 ; <label>:176                                     ; preds = %172
   %177 = load i64, i64* %175, align 8
   %178 = bitcast i8* %173 to i64*
-  %NullCheck58 = icmp ne i64* %178, null
-  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+  %NullCheck57 = icmp eq i64* %178, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %179
 
 ; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
@@ -1000,16 +1082,16 @@ entry:
   %182 = load i8*, i8** %arg1
   %183 = getelementptr inbounds i8, i8* %182, i64 8
   %184 = bitcast i8* %183 to i16*
-  %NullCheck60 = icmp ne i16* %184, null
-  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+  %NullCheck59 = icmp eq i16* %184, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %185
 
 ; <label>:185                                     ; preds = %179
   %186 = load i16, i16* %184, align 8
   %187 = sext i16 %186 to i32
   %188 = bitcast i8* %181 to i16*
   %189 = trunc i32 %187 to i16
-  %NullCheck62 = icmp ne i16* %188, null
-  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+  %NullCheck61 = icmp eq i16* %188, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %190
 
 ; <label>:190                                     ; preds = %185
   store i16 %189, i16* %188, align 8
@@ -1017,15 +1099,15 @@ entry:
   %192 = getelementptr inbounds i8, i8* %191, i64 10
   %193 = load i8*, i8** %arg1
   %194 = getelementptr inbounds i8, i8* %193, i64 10
-  %NullCheck64 = icmp ne i8* %194, null
-  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+  %NullCheck63 = icmp eq i8* %194, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %195
 
 ; <label>:195                                     ; preds = %190
   %196 = load i8, i8* %194, align 8
   %197 = zext i8 %196 to i32
   %198 = trunc i32 %197 to i8
-  %NullCheck66 = icmp ne i8* %192, null
-  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+  %NullCheck65 = icmp eq i8* %192, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %199
 
 ; <label>:199                                     ; preds = %195
   store i8 %198, i8* %192, align 8
@@ -1035,14 +1117,14 @@ entry:
   %201 = load i8*, i8** %arg0
   %202 = load i8*, i8** %arg1
   %203 = bitcast i8* %202 to i64*
-  %NullCheck48 = icmp ne i64* %203, null
-  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+  %NullCheck47 = icmp eq i64* %203, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %204
 
 ; <label>:204                                     ; preds = %200
   %205 = load i64, i64* %203, align 8
   %206 = bitcast i8* %201 to i64*
-  %NullCheck50 = icmp ne i64* %206, null
-  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+  %NullCheck49 = icmp eq i64* %206, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %207
 
 ; <label>:207                                     ; preds = %204
   store i64 %205, i64* %206, align 8
@@ -1051,14 +1133,14 @@ entry:
   %210 = load i8*, i8** %arg1
   %211 = getelementptr inbounds i8, i8* %210, i64 8
   %212 = bitcast i8* %211 to i32*
-  %NullCheck52 = icmp ne i32* %212, null
-  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+  %NullCheck51 = icmp eq i32* %212, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %213
 
 ; <label>:213                                     ; preds = %207
   %214 = load i32, i32* %212, align 8
   %215 = bitcast i8* %209 to i32*
-  %NullCheck54 = icmp ne i32* %215, null
-  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+  %NullCheck53 = icmp eq i32* %215, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %216
 
 ; <label>:216                                     ; preds = %213
   store i32 %214, i32* %215, align 8
@@ -1068,14 +1150,14 @@ entry:
   %218 = load i8*, i8** %arg0
   %219 = load i8*, i8** %arg1
   %220 = bitcast i8* %219 to i64*
-  %NullCheck36 = icmp ne i64* %220, null
-  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64* %220, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %221
 
 ; <label>:221                                     ; preds = %217
   %222 = load i64, i64* %220, align 8
   %223 = bitcast i8* %218 to i64*
-  %NullCheck38 = icmp ne i64* %223, null
-  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+  %NullCheck37 = icmp eq i64* %223, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %224
 
 ; <label>:224                                     ; preds = %221
   store i64 %222, i64* %223, align 8
@@ -1084,14 +1166,14 @@ entry:
   %227 = load i8*, i8** %arg1
   %228 = getelementptr inbounds i8, i8* %227, i64 8
   %229 = bitcast i8* %228 to i32*
-  %NullCheck40 = icmp ne i32* %229, null
-  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i32* %229, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %230
 
 ; <label>:230                                     ; preds = %224
   %231 = load i32, i32* %229, align 8
   %232 = bitcast i8* %226 to i32*
-  %NullCheck42 = icmp ne i32* %232, null
-  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+  %NullCheck41 = icmp eq i32* %232, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %233
 
 ; <label>:233                                     ; preds = %230
   store i32 %231, i32* %232, align 8
@@ -1099,15 +1181,15 @@ entry:
   %235 = getelementptr inbounds i8, i8* %234, i64 12
   %236 = load i8*, i8** %arg1
   %237 = getelementptr inbounds i8, i8* %236, i64 12
-  %NullCheck44 = icmp ne i8* %237, null
-  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i8* %237, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %238
 
 ; <label>:238                                     ; preds = %233
   %239 = load i8, i8* %237, align 8
   %240 = zext i8 %239 to i32
   %241 = trunc i32 %240 to i8
-  %NullCheck46 = icmp ne i8* %235, null
-  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+  %NullCheck45 = icmp eq i8* %235, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %242
 
 ; <label>:242                                     ; preds = %238
   store i8 %241, i8* %235, align 8
@@ -1117,14 +1199,14 @@ entry:
   %244 = load i8*, i8** %arg0
   %245 = load i8*, i8** %arg1
   %246 = bitcast i8* %245 to i64*
-  %NullCheck24 = icmp ne i64* %246, null
-  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64* %246, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %247
 
 ; <label>:247                                     ; preds = %243
   %248 = load i64, i64* %246, align 8
   %249 = bitcast i8* %244 to i64*
-  %NullCheck26 = icmp ne i64* %249, null
-  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64* %249, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %250
 
 ; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
@@ -1133,14 +1215,14 @@ entry:
   %253 = load i8*, i8** %arg1
   %254 = getelementptr inbounds i8, i8* %253, i64 8
   %255 = bitcast i8* %254 to i32*
-  %NullCheck28 = icmp ne i32* %255, null
-  br i1 %NullCheck28, label %256, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i32* %255, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %256
 
 ; <label>:256                                     ; preds = %250
   %257 = load i32, i32* %255, align 8
   %258 = bitcast i8* %252 to i32*
-  %NullCheck30 = icmp ne i32* %258, null
-  br i1 %NullCheck30, label %259, label %ThrowNullRef29
+  %NullCheck29 = icmp eq i32* %258, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %259
 
 ; <label>:259                                     ; preds = %256
   store i32 %257, i32* %258, align 8
@@ -1149,16 +1231,16 @@ entry:
   %262 = load i8*, i8** %arg1
   %263 = getelementptr inbounds i8, i8* %262, i64 12
   %264 = bitcast i8* %263 to i16*
-  %NullCheck32 = icmp ne i16* %264, null
-  br i1 %NullCheck32, label %265, label %ThrowNullRef31
+  %NullCheck31 = icmp eq i16* %264, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %265
 
 ; <label>:265                                     ; preds = %259
   %266 = load i16, i16* %264, align 8
   %267 = sext i16 %266 to i32
   %268 = bitcast i8* %261 to i16*
   %269 = trunc i32 %267 to i16
-  %NullCheck34 = icmp ne i16* %268, null
-  br i1 %NullCheck34, label %270, label %ThrowNullRef33
+  %NullCheck33 = icmp eq i16* %268, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %270
 
 ; <label>:270                                     ; preds = %265
   store i16 %269, i16* %268, align 8
@@ -1168,14 +1250,14 @@ entry:
   %272 = load i8*, i8** %arg0
   %273 = load i8*, i8** %arg1
   %274 = bitcast i8* %273 to i64*
-  %NullCheck8 = icmp ne i64* %274, null
-  br i1 %NullCheck8, label %275, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64* %274, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %275
 
 ; <label>:275                                     ; preds = %271
   %276 = load i64, i64* %274, align 8
   %277 = bitcast i8* %272 to i64*
-  %NullCheck10 = icmp ne i64* %277, null
-  br i1 %NullCheck10, label %278, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %277, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %278
 
 ; <label>:278                                     ; preds = %275
   store i64 %276, i64* %277, align 8
@@ -1184,14 +1266,14 @@ entry:
   %281 = load i8*, i8** %arg1
   %282 = getelementptr inbounds i8, i8* %281, i64 8
   %283 = bitcast i8* %282 to i32*
-  %NullCheck12 = icmp ne i32* %283, null
-  br i1 %NullCheck12, label %284, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i32* %283, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %284
 
 ; <label>:284                                     ; preds = %278
   %285 = load i32, i32* %283, align 8
   %286 = bitcast i8* %280 to i32*
-  %NullCheck14 = icmp ne i32* %286, null
-  br i1 %NullCheck14, label %287, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i32* %286, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %287
 
 ; <label>:287                                     ; preds = %284
   store i32 %285, i32* %286, align 8
@@ -1200,16 +1282,16 @@ entry:
   %290 = load i8*, i8** %arg1
   %291 = getelementptr inbounds i8, i8* %290, i64 12
   %292 = bitcast i8* %291 to i16*
-  %NullCheck16 = icmp ne i16* %292, null
-  br i1 %NullCheck16, label %293, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i16* %292, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %293
 
 ; <label>:293                                     ; preds = %287
   %294 = load i16, i16* %292, align 8
   %295 = sext i16 %294 to i32
   %296 = bitcast i8* %289 to i16*
   %297 = trunc i32 %295 to i16
-  %NullCheck18 = icmp ne i16* %296, null
-  br i1 %NullCheck18, label %298, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i16* %296, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %298
 
 ; <label>:298                                     ; preds = %293
   store i16 %297, i16* %296, align 8
@@ -1217,15 +1299,15 @@ entry:
   %300 = getelementptr inbounds i8, i8* %299, i64 14
   %301 = load i8*, i8** %arg1
   %302 = getelementptr inbounds i8, i8* %301, i64 14
-  %NullCheck20 = icmp ne i8* %302, null
-  br i1 %NullCheck20, label %303, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i8* %302, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %303
 
 ; <label>:303                                     ; preds = %298
   %304 = load i8, i8* %302, align 8
   %305 = zext i8 %304 to i32
   %306 = trunc i32 %305 to i8
-  %NullCheck22 = icmp ne i8* %300, null
-  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i8* %300, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %307
 
 ; <label>:307                                     ; preds = %303
   store i8 %306, i8* %300, align 8
@@ -1235,14 +1317,14 @@ entry:
   %309 = load i8*, i8** %arg0
   %310 = load i8*, i8** %arg1
   %311 = bitcast i8* %310 to i64*
-  %NullCheck = icmp ne i64* %311, null
-  br i1 %NullCheck, label %312, label %ThrowNullRef
+  %NullCheck = icmp eq i64* %311, null
+  br i1 %NullCheck, label %ThrowNullRef, label %312
 
 ; <label>:312                                     ; preds = %308
   %313 = load i64, i64* %311, align 8
   %314 = bitcast i8* %309 to i64*
-  %NullCheck2 = icmp ne i64* %314, null
-  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64* %314, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %315
 
 ; <label>:315                                     ; preds = %312
   store i64 %313, i64* %314, align 8
@@ -1251,14 +1333,14 @@ entry:
   %318 = load i8*, i8** %arg1
   %319 = getelementptr inbounds i8, i8* %318, i64 8
   %320 = bitcast i8* %319 to i64*
-  %NullCheck4 = icmp ne i64* %320, null
-  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64* %320, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %321
 
 ; <label>:321                                     ; preds = %315
   %322 = load i64, i64* %320, align 8
   %323 = bitcast i8* %317 to i64*
-  %NullCheck6 = icmp ne i64* %323, null
-  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64* %323, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %324
 
 ; <label>:324                                     ; preds = %321
   store i64 %322, i64* %323, align 8
@@ -1286,15 +1368,15 @@ entry:
 ; <label>:338                                     ; preds = %333
   %339 = load i8*, i8** %arg0
   %340 = load i8*, i8** %arg1
-  %NullCheck136 = icmp ne i8* %340, null
-  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+  %NullCheck135 = icmp eq i8* %340, null
+  br i1 %NullCheck135, label %ThrowNullRef136, label %341
 
 ; <label>:341                                     ; preds = %338
   %342 = load i8, i8* %340, align 8
   %343 = zext i8 %342 to i32
   %344 = trunc i32 %343 to i8
-  %NullCheck138 = icmp ne i8* %339, null
-  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+  %NullCheck137 = icmp eq i8* %339, null
+  br i1 %NullCheck137, label %ThrowNullRef138, label %345
 
 ; <label>:345                                     ; preds = %341
   store i8 %344, i8* %339, align 8
@@ -1317,16 +1399,16 @@ entry:
   %357 = load i8*, i8** %arg0
   %358 = load i8*, i8** %arg1
   %359 = bitcast i8* %358 to i16*
-  %NullCheck140 = icmp ne i16* %359, null
-  br i1 %NullCheck140, label %360, label %ThrowNullRef139
+  %NullCheck139 = icmp eq i16* %359, null
+  br i1 %NullCheck139, label %ThrowNullRef140, label %360
 
 ; <label>:360                                     ; preds = %356
   %361 = load i16, i16* %359, align 8
   %362 = sext i16 %361 to i32
   %363 = bitcast i8* %357 to i16*
   %364 = trunc i32 %362 to i16
-  %NullCheck142 = icmp ne i16* %363, null
-  br i1 %NullCheck142, label %365, label %ThrowNullRef141
+  %NullCheck141 = icmp eq i16* %363, null
+  br i1 %NullCheck141, label %ThrowNullRef142, label %365
 
 ; <label>:365                                     ; preds = %360
   store i16 %364, i16* %363, align 8
@@ -1352,14 +1434,14 @@ entry:
   %378 = load i8*, i8** %arg0
   %379 = load i8*, i8** %arg1
   %380 = bitcast i8* %379 to i32*
-  %NullCheck144 = icmp ne i32* %380, null
-  br i1 %NullCheck144, label %381, label %ThrowNullRef143
+  %NullCheck143 = icmp eq i32* %380, null
+  br i1 %NullCheck143, label %ThrowNullRef144, label %381
 
 ; <label>:381                                     ; preds = %377
   %382 = load i32, i32* %380, align 8
   %383 = bitcast i8* %378 to i32*
-  %NullCheck146 = icmp ne i32* %383, null
-  br i1 %NullCheck146, label %384, label %ThrowNullRef145
+  %NullCheck145 = icmp eq i32* %383, null
+  br i1 %NullCheck145, label %ThrowNullRef146, label %384
 
 ; <label>:384                                     ; preds = %381
   store i32 %382, i32* %383, align 8
@@ -1384,14 +1466,14 @@ entry:
   %395 = load i8*, i8** %arg0
   %396 = load i8*, i8** %arg1
   %397 = bitcast i8* %396 to i64*
-  %NullCheck164 = icmp ne i64* %397, null
-  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+  %NullCheck163 = icmp eq i64* %397, null
+  br i1 %NullCheck163, label %ThrowNullRef164, label %398
 
 ; <label>:398                                     ; preds = %394
   %399 = load i64, i64* %397, align 8
   %400 = bitcast i8* %395 to i64*
-  %NullCheck166 = icmp ne i64* %400, null
-  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+  %NullCheck165 = icmp eq i64* %400, null
+  br i1 %NullCheck165, label %ThrowNullRef166, label %401
 
 ; <label>:401                                     ; preds = %398
   store i64 %399, i64* %400, align 8
@@ -1400,14 +1482,14 @@ entry:
   %404 = load i8*, i8** %arg1
   %405 = getelementptr inbounds i8, i8* %404, i64 8
   %406 = bitcast i8* %405 to i64*
-  %NullCheck168 = icmp ne i64* %406, null
-  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+  %NullCheck167 = icmp eq i64* %406, null
+  br i1 %NullCheck167, label %ThrowNullRef168, label %407
 
 ; <label>:407                                     ; preds = %401
   %408 = load i64, i64* %406, align 8
   %409 = bitcast i8* %403 to i64*
-  %NullCheck170 = icmp ne i64* %409, null
-  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+  %NullCheck169 = icmp eq i64* %409, null
+  br i1 %NullCheck169, label %ThrowNullRef170, label %410
 
 ; <label>:410                                     ; preds = %407
   store i64 %408, i64* %409, align 8
@@ -1437,14 +1519,14 @@ entry:
   %425 = load i8*, i8** %arg0
   %426 = load i8*, i8** %arg1
   %427 = bitcast i8* %426 to i64*
-  %NullCheck148 = icmp ne i64* %427, null
-  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+  %NullCheck147 = icmp eq i64* %427, null
+  br i1 %NullCheck147, label %ThrowNullRef148, label %428
 
 ; <label>:428                                     ; preds = %424
   %429 = load i64, i64* %427, align 8
   %430 = bitcast i8* %425 to i64*
-  %NullCheck150 = icmp ne i64* %430, null
-  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+  %NullCheck149 = icmp eq i64* %430, null
+  br i1 %NullCheck149, label %ThrowNullRef150, label %431
 
 ; <label>:431                                     ; preds = %428
   store i64 %429, i64* %430, align 8
@@ -1466,14 +1548,14 @@ entry:
   %441 = load i8*, i8** %arg0
   %442 = load i8*, i8** %arg1
   %443 = bitcast i8* %442 to i32*
-  %NullCheck152 = icmp ne i32* %443, null
-  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+  %NullCheck151 = icmp eq i32* %443, null
+  br i1 %NullCheck151, label %ThrowNullRef152, label %444
 
 ; <label>:444                                     ; preds = %440
   %445 = load i32, i32* %443, align 8
   %446 = bitcast i8* %441 to i32*
-  %NullCheck154 = icmp ne i32* %446, null
-  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+  %NullCheck153 = icmp eq i32* %446, null
+  br i1 %NullCheck153, label %ThrowNullRef154, label %447
 
 ; <label>:447                                     ; preds = %444
   store i32 %445, i32* %446, align 8
@@ -1495,16 +1577,16 @@ entry:
   %457 = load i8*, i8** %arg0
   %458 = load i8*, i8** %arg1
   %459 = bitcast i8* %458 to i16*
-  %NullCheck156 = icmp ne i16* %459, null
-  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+  %NullCheck155 = icmp eq i16* %459, null
+  br i1 %NullCheck155, label %ThrowNullRef156, label %460
 
 ; <label>:460                                     ; preds = %456
   %461 = load i16, i16* %459, align 8
   %462 = sext i16 %461 to i32
   %463 = bitcast i8* %457 to i16*
   %464 = trunc i32 %462 to i16
-  %NullCheck158 = icmp ne i16* %463, null
-  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+  %NullCheck157 = icmp eq i16* %463, null
+  br i1 %NullCheck157, label %ThrowNullRef158, label %465
 
 ; <label>:465                                     ; preds = %460
   store i16 %464, i16* %463, align 8
@@ -1525,15 +1607,15 @@ entry:
 ; <label>:474                                     ; preds = %470
   %475 = load i8*, i8** %arg0
   %476 = load i8*, i8** %arg1
-  %NullCheck160 = icmp ne i8* %476, null
-  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+  %NullCheck159 = icmp eq i8* %476, null
+  br i1 %NullCheck159, label %ThrowNullRef160, label %477
 
 ; <label>:477                                     ; preds = %474
   %478 = load i8, i8* %476, align 8
   %479 = zext i8 %478 to i32
   %480 = trunc i32 %479 to i8
-  %NullCheck162 = icmp ne i8* %475, null
-  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+  %NullCheck161 = icmp eq i8* %475, null
+  br i1 %NullCheck161, label %ThrowNullRef162, label %481
 
 ; <label>:481                                     ; preds = %477
   store i8 %480, i8* %475, align 8
@@ -1553,343 +1635,343 @@ ThrowNullRef:                                     ; preds = %308
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %312
+ThrowNullRef2:                                    ; preds = %312
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %315
+ThrowNullRef4:                                    ; preds = %315
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %321
+ThrowNullRef6:                                    ; preds = %321
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %271
+ThrowNullRef8:                                    ; preds = %271
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %275
+ThrowNullRef10:                                   ; preds = %275
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %278
+ThrowNullRef12:                                   ; preds = %278
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %284
+ThrowNullRef14:                                   ; preds = %284
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %287
+ThrowNullRef16:                                   ; preds = %287
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %293
+ThrowNullRef18:                                   ; preds = %293
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %298
+ThrowNullRef20:                                   ; preds = %298
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %303
+ThrowNullRef22:                                   ; preds = %303
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %243
+ThrowNullRef24:                                   ; preds = %243
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %247
+ThrowNullRef26:                                   ; preds = %247
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %250
+ThrowNullRef28:                                   ; preds = %250
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %256
+ThrowNullRef30:                                   ; preds = %256
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %259
+ThrowNullRef32:                                   ; preds = %259
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %265
+ThrowNullRef34:                                   ; preds = %265
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %217
+ThrowNullRef36:                                   ; preds = %217
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %221
+ThrowNullRef38:                                   ; preds = %221
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %224
+ThrowNullRef40:                                   ; preds = %224
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %230
+ThrowNullRef42:                                   ; preds = %230
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %233
+ThrowNullRef44:                                   ; preds = %233
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %238
+ThrowNullRef46:                                   ; preds = %238
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %200
+ThrowNullRef48:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %204
+ThrowNullRef50:                                   ; preds = %204
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %207
+ThrowNullRef52:                                   ; preds = %207
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %213
+ThrowNullRef54:                                   ; preds = %213
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %172
+ThrowNullRef56:                                   ; preds = %172
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %176
+ThrowNullRef58:                                   ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %179
+ThrowNullRef60:                                   ; preds = %179
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %185
+ThrowNullRef62:                                   ; preds = %185
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %190
+ThrowNullRef64:                                   ; preds = %190
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %195
+ThrowNullRef66:                                   ; preds = %195
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %153
+ThrowNullRef68:                                   ; preds = %153
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %157
+ThrowNullRef70:                                   ; preds = %157
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %160
+ThrowNullRef72:                                   ; preds = %160
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %166
+ThrowNullRef74:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %136
+ThrowNullRef76:                                   ; preds = %136
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %140
+ThrowNullRef78:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %143
+ThrowNullRef80:                                   ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %148
+ThrowNullRef82:                                   ; preds = %148
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %128
+ThrowNullRef84:                                   ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %132
+ThrowNullRef86:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %100
+ThrowNullRef88:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %104
+ThrowNullRef90:                                   ; preds = %104
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %107
+ThrowNullRef92:                                   ; preds = %107
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %113
+ThrowNullRef94:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %118
+ThrowNullRef96:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %123
+ThrowNullRef98:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %81
+ThrowNullRef100:                                  ; preds = %81
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef101:                                  ; preds = %85
+ThrowNullRef102:                                  ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef103:                                  ; preds = %88
+ThrowNullRef104:                                  ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef105:                                  ; preds = %94
+ThrowNullRef106:                                  ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef107:                                  ; preds = %64
+ThrowNullRef108:                                  ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef109:                                  ; preds = %68
+ThrowNullRef110:                                  ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef111:                                  ; preds = %71
+ThrowNullRef112:                                  ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef113:                                  ; preds = %76
+ThrowNullRef114:                                  ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef115:                                  ; preds = %56
+ThrowNullRef116:                                  ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef117:                                  ; preds = %60
+ThrowNullRef118:                                  ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef119:                                  ; preds = %37
+ThrowNullRef120:                                  ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef121:                                  ; preds = %41
+ThrowNullRef122:                                  ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef123:                                  ; preds = %46
+ThrowNullRef124:                                  ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef125:                                  ; preds = %51
+ThrowNullRef126:                                  ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef127:                                  ; preds = %27
+ThrowNullRef128:                                  ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef129:                                  ; preds = %31
+ThrowNullRef130:                                  ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef131:                                  ; preds = %19
+ThrowNullRef132:                                  ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef133:                                  ; preds = %22
+ThrowNullRef134:                                  ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef135:                                  ; preds = %338
+ThrowNullRef136:                                  ; preds = %338
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef137:                                  ; preds = %341
+ThrowNullRef138:                                  ; preds = %341
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef139:                                  ; preds = %356
+ThrowNullRef140:                                  ; preds = %356
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef141:                                  ; preds = %360
+ThrowNullRef142:                                  ; preds = %360
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef143:                                  ; preds = %377
+ThrowNullRef144:                                  ; preds = %377
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef145:                                  ; preds = %381
+ThrowNullRef146:                                  ; preds = %381
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef147:                                  ; preds = %424
+ThrowNullRef148:                                  ; preds = %424
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef149:                                  ; preds = %428
+ThrowNullRef150:                                  ; preds = %428
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef151:                                  ; preds = %440
+ThrowNullRef152:                                  ; preds = %440
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef153:                                  ; preds = %444
+ThrowNullRef154:                                  ; preds = %444
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef155:                                  ; preds = %456
+ThrowNullRef156:                                  ; preds = %456
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef157:                                  ; preds = %460
+ThrowNullRef158:                                  ; preds = %460
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef159:                                  ; preds = %474
+ThrowNullRef160:                                  ; preds = %474
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef161:                                  ; preds = %477
+ThrowNullRef162:                                  ; preds = %477
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef163:                                  ; preds = %394
+ThrowNullRef164:                                  ; preds = %394
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef165:                                  ; preds = %398
+ThrowNullRef166:                                  ; preds = %398
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef167:                                  ; preds = %401
+ThrowNullRef168:                                  ; preds = %401
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef169:                                  ; preds = %407
+ThrowNullRef170:                                  ; preds = %407
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1939,8 +2021,8 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
-  br i1 %NullCheck, label %22, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %ThrowNullRef, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
@@ -1948,8 +2030,8 @@ entry:
   store i32 %24, i32* %loc0
   %25 = load i32, i32* %loc0
   %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %26, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %27
 
 ; <label>:27                                      ; preds = %22
   %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
@@ -1971,7 +2053,7 @@ ThrowNullRef:                                     ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1989,8 +2071,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -2022,15 +2104,15 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2048,16 +2130,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
   %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
   store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %15
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
@@ -2072,8 +2154,8 @@ entry:
   %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
   %29 = ptrtoint i16 addrspace(1)* %28 to i64
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %19
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
@@ -2089,19 +2171,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2114,8 +2196,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
@@ -2128,7 +2210,7 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[loadElem]
+Failed to read AppDomain.PrepareDataForSetup[storeElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
@@ -2202,8 +2284,8 @@ entry:
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
-  br i1 %NullCheck24, label %27, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = load i64, i64 addrspace(1)* %26
@@ -2218,8 +2300,8 @@ entry:
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
-  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
   %41 = load i64, i64 addrspace(1)* %39
@@ -2236,8 +2318,8 @@ entry:
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
-  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
   %54 = load i64, i64 addrspace(1)* %52
@@ -2252,8 +2334,8 @@ entry:
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
   %67 = load i64, i64 addrspace(1)* %65
@@ -2270,8 +2352,8 @@ entry:
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
-  br i1 %NullCheck16, label %79, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
   %80 = load i64, i64 addrspace(1)* %78
@@ -2286,8 +2368,8 @@ entry:
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
-  br i1 %NullCheck18, label %92, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
   %93 = load i64, i64 addrspace(1)* %91
@@ -2304,8 +2386,8 @@ entry:
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
-  br i1 %NullCheck12, label %105, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = load i64, i64 addrspace(1)* %104
@@ -2320,8 +2402,8 @@ entry:
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
-  br i1 %NullCheck14, label %118, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
   %119 = load i64, i64 addrspace(1)* %117
@@ -2337,8 +2419,8 @@ entry:
 
 ; <label>:128                                     ; preds = %20
   %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
-  br i1 %NullCheck4, label %130, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %129, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %130
 
 ; <label>:130                                     ; preds = %128
   %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
@@ -2346,8 +2428,8 @@ entry:
   %133 = load i16, i16 addrspace(1)* %132, align 8
   %134 = zext i16 %133 to i32
   %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
-  br i1 %NullCheck6, label %136, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %135, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %136
 
 ; <label>:136                                     ; preds = %130
   %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
@@ -2360,8 +2442,8 @@ entry:
 
 ; <label>:143                                     ; preds = %136
   %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
-  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %144, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %145
 
 ; <label>:145                                     ; preds = %143
   %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
@@ -2369,8 +2451,8 @@ entry:
   %148 = load i16, i16 addrspace(1)* %147, align 8
   %149 = zext i16 %148 to i32
   %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %150, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %151
 
 ; <label>:151                                     ; preds = %145
   %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
@@ -2388,8 +2470,8 @@ entry:
 
 ; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
-  br i1 %NullCheck, label %163, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %ThrowNullRef, label %163
 
 ; <label>:163                                     ; preds = %161
   %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
@@ -2399,8 +2481,8 @@ entry:
 
 ; <label>:167                                     ; preds = %163
   %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
-  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %168, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %169
 
 ; <label>:169                                     ; preds = %167
   %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
@@ -2432,55 +2514,55 @@ ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %167
+ThrowNullRef2:                                    ; preds = %167
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %128
+ThrowNullRef4:                                    ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %130
+ThrowNullRef6:                                    ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %143
+ThrowNullRef8:                                    ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %145
+ThrowNullRef10:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %102
+ThrowNullRef12:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %105
+ThrowNullRef14:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %76
+ThrowNullRef16:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %79
+ThrowNullRef18:                                   ; preds = %79
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %50
+ThrowNullRef20:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %53
+ThrowNullRef22:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %24
+ThrowNullRef24:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %27
+ThrowNullRef26:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2503,15 +2585,15 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2519,16 +2601,16 @@ entry:
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
   store i32 %8, i32* %loc0
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
   %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
   store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
@@ -2546,16 +2628,16 @@ entry:
 
 ; <label>:23                                      ; preds = %64
   %24 = load i16*, i16** %loc3
-  %NullCheck12 = icmp ne i16* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i16* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
   store i32 %27, i32* %loc5
   %28 = load i16*, i16** %loc4
-  %NullCheck14 = icmp ne i16* %28, null
-  br i1 %NullCheck14, label %29, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %28, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = load i16, i16* %28, align 8
@@ -2620,15 +2702,15 @@ entry:
 
 ; <label>:67                                      ; preds = %64
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
-  br i1 %NullCheck8, label %69, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %68, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %69
 
 ; <label>:69                                      ; preds = %67
   %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
   %71 = load i32, i32 addrspace(1)* %70
   %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
-  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %73
 
 ; <label>:73                                      ; preds = %69
   %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
@@ -2645,31 +2727,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %67
+ThrowNullRef8:                                    ; preds = %67
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %69
+ThrowNullRef10:                                   ; preds = %69
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2710,14 +2792,14 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
   %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
@@ -2730,14 +2812,14 @@ entry:
 
 ; <label>:11                                      ; preds = %4
   %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
   %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
@@ -2749,14 +2831,14 @@ entry:
 
 ; <label>:22                                      ; preds = %16
   %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
   %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
-  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
-  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
@@ -2804,23 +2886,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2836,7 +2918,280 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[loadElem]
+Successfully read RuntimeType.IsAssignableFrom
+
+define i8 @RuntimeType.IsAssignableFrom(%System.RuntimeType addrspace(1)* %param0, %System.Type addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.RuntimeType addrspace(1)*
+  %arg1 = alloca %System.Type addrspace(1)*
+  %loc0 = alloca %System.RuntimeType addrspace(1)*
+  %loc1 = alloca %"System.Type[]" addrspace(1)*
+  %loc2 = alloca i32
+  store %System.RuntimeType addrspace(1)* %param0, %System.RuntimeType addrspace(1)** %this
+  store %System.Type addrspace(1)* %param1, %System.Type addrspace(1)** %arg1
+  %0 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %1 = icmp ne %System.Type addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i8 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %5 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %6 = bitcast %System.Type addrspace(1)* %4 to %System.Object addrspace(1)*
+  %7 = bitcast %System.RuntimeType addrspace(1)* %5 to %System.Object addrspace(1)*
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %6, %System.Object addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %3
+  ret i8 1
+
+; <label>:12                                      ; preds = %3
+  %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 152
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 32
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
+  %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
+  %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
+  store %System.RuntimeType addrspace(1)* %25, %System.RuntimeType addrspace(1)** %loc0
+  %26 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %27 = icmp eq %System.RuntimeType addrspace(1)* %26, null
+  br i1 %27, label %34, label %28
+
+; <label>:28                                      ; preds = %15
+  %29 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %30 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)*)*)(%System.RuntimeType addrspace(1)* %29, %System.RuntimeType addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+; <label>:34                                      ; preds = %15
+  %35 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %36 = call %System.Reflection.Emit.TypeBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Reflection.Emit.TypeBuilder addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %35)
+  %37 = icmp eq %System.Reflection.Emit.TypeBuilder addrspace(1)* %36, null
+  br i1 %37, label %139, label %38
+
+; <label>:38                                      ; preds = %34
+  %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %42
+
+; <label>:42                                      ; preds = %38
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 152
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 40
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
+  %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
+  %53 = zext i8 %52 to i32
+  %54 = icmp eq i32 %53, 0
+  br i1 %54, label %56, label %55
+
+; <label>:55                                      ; preds = %42
+  ret i8 1
+
+; <label>:56                                      ; preds = %42
+  %57 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %58 = bitcast %System.RuntimeType addrspace(1)* %57 to %System.Type addrspace(1)*
+  %59 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %58)
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %64 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.Type addrspace(1)* %63, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = bitcast %System.RuntimeType addrspace(1)* %64 to %System.Type addrspace(1)*
+  %67 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %63, %System.Type addrspace(1)* %66)
+  %68 = zext i8 %67 to i32
+  %69 = trunc i32 %68 to i8
+  ret i8 %69
+
+; <label>:70                                      ; preds = %56
+  %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
+  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %73
+
+; <label>:73                                      ; preds = %70
+  %74 = load i64, i64 addrspace(1)* %72
+  %75 = add i64 %74, 128
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = add i64 %77, 0
+  %79 = inttoptr i64 %78 to i64*
+  %80 = load i64, i64* %79
+  %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
+  %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
+  %83 = call i8 %82(%System.Type addrspace(1)* %81)
+  %84 = zext i8 %83 to i32
+  %85 = icmp eq i32 %84, 0
+  br i1 %85, label %139, label %86
+
+; <label>:86                                      ; preds = %73
+  %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
+  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %89
+
+; <label>:89                                      ; preds = %86
+  %90 = load i64, i64 addrspace(1)* %88
+  %91 = add i64 %90, 128
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = add i64 %93, 24
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
+  %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
+  %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
+  store %"System.Type[]" addrspace(1)* %99, %"System.Type[]" addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %129
+
+; <label>:100                                     ; preds = %132
+  %101 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %102 = load i32, i32* %loc2
+  %NullCheck11 = icmp eq %"System.Type[]" addrspace(1)* %101, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %103
+
+; <label>:103                                     ; preds = %100
+  %104 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 1
+  %105 = load i32, i32 addrspace(1)* %104
+  %106 = zext i32 %105 to i64
+  %107 = zext i32 %102 to i64
+  %BoundsCheck = icmp uge i64 %107, %106
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %108
+
+; <label>:108                                     ; preds = %103
+  %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
+  %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
+  %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
+  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %113
+
+; <label>:113                                     ; preds = %108
+  %114 = load i64, i64 addrspace(1)* %112
+  %115 = add i64 %114, 152
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = add i64 %117, 56
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
+  %123 = zext i8 %122 to i32
+  %124 = icmp ne i32 %123, 0
+  br i1 %124, label %126, label %125
+
+; <label>:125                                     ; preds = %113
+  ret i8 0
+
+; <label>:126                                     ; preds = %113
+  %127 = load i32, i32* %loc2
+  %128 = add i32 %127, 1
+  store i32 %128, i32* %loc2
+  br label %129
+
+; <label>:129                                     ; preds = %89, %126
+  %130 = load i32, i32* %loc2
+  %131 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %NullCheck9 = icmp eq %"System.Type[]" addrspace(1)* %131, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %132
+
+; <label>:132                                     ; preds = %129
+  %133 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %131, i32 0, i32 1
+  %134 = load i32, i32 addrspace(1)* %133
+  %135 = zext i32 %134 to i64
+  %136 = trunc i64 %135 to i32
+  %137 = icmp slt i32 %130, %136
+  br i1 %137, label %100, label %138
+
+; <label>:138                                     ; preds = %132
+  ret i8 1
+
+; <label>:139                                     ; preds = %34, %73
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %129
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %103
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -2893,7 +3248,7 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElem]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -2904,8 +3259,8 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -2997,8 +3352,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
@@ -3059,8 +3414,8 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -3087,8 +3442,8 @@ entry:
 
 ; <label>:17                                      ; preds = %5, %11
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
@@ -3097,8 +3452,8 @@ entry:
 
 ; <label>:22                                      ; preds = %1, %11
   %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
@@ -3109,11 +3464,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %17
+ThrowNullRef2:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %22
+ThrowNullRef4:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3167,15 +3522,15 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
   %15 = load i32, i32 addrspace(1)* %14
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
@@ -3198,7 +3553,7 @@ ThrowNullRef:                                     ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef2:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3232,8 +3587,8 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
@@ -3312,8 +3667,8 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -3327,8 +3682,8 @@ entry:
 ; <label>:5                                       ; preds = %43
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %7 = load i32, i32* %loc1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck6, label %8, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
@@ -3366,8 +3721,8 @@ entry:
 ; <label>:32                                      ; preds = %21, %25
   %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
   %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
-  br i1 %NullCheck8, label %35, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = trunc i32 %34 to i16
@@ -3380,8 +3735,8 @@ entry:
 ; <label>:40                                      ; preds = %1, %35
   %41 = load i32, i32* %loc1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
-  br i1 %NullCheck2, label %43, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %42, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
@@ -3392,8 +3747,8 @@ entry:
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
   %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
-  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
   %51 = load i64, i64 addrspace(1)* %49
@@ -3412,19 +3767,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %40
+ThrowNullRef2:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %47
+ThrowNullRef4:                                    ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %5
+ThrowNullRef6:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %32
+ThrowNullRef8:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3467,8 +3822,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
@@ -3492,11 +3847,391 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(i16* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store i16* %param0, i16** %arg0
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load i32, i32* %arg3
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %42, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %37, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg2
+  %13 = load i32, i32* %arg3
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %37, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %24 = load i32, i32* %arg2
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load i16*, i16** %arg0
+  %35 = load i32, i32* %arg3
+  %36 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %36, i16* %34, i32 %35)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:37                                      ; preds = %5, %16
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %39)
+  %41 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41, %System.String addrspace(1)* %38, %System.String addrspace(1)* %40)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41) #0
+  unreachable
+
+; <label>:42                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
-Failed to read StringBuilder.ToString[loadElemA]
+Successfully read StringBuilder.ToString
+
+define %System.String addrspace(1)* @StringBuilder.ToString(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i16*
+  %loc3 = alloca %"System.Char[]" addrspace(1)*
+  %loc4 = alloca i32
+  %loc5 = alloca i32
+  %loc6 = alloca i16 addrspace(1)*
+  %loc7 = alloca %System.String addrspace(1)*
+  %loc8 = alloca %"System.Char[]" addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %0)
+  %2 = icmp ne i32 %1, 0
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %4
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %6)
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %7)
+  store %System.String addrspace(1)* %8, %System.String addrspace(1)** %loc0
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.Text.StringBuilder addrspace(1)* %9, %System.Text.StringBuilder addrspace(1)** %loc1
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  store %System.String addrspace(1)* %10, %System.String addrspace(1)** %loc7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc7
+  %12 = ptrtoint %System.String addrspace(1)* %11 to i64
+  %13 = icmp eq i64 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %5
+  %15 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %16 = sext i32 %15 to i64
+  %17 = add i64 %12, %16
+  br label %18
+
+; <label>:18                                      ; preds = %5, %14
+  %19 = phi i64 [ %12, %5 ], [ %17, %14 ]
+  %20 = inttoptr i64 %19 to i16*
+  store i16* %20, i16** %loc2
+  br label %21
+
+; <label>:21                                      ; preds = %98, %18
+  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %22, null
+  br i1 %NullCheck, label %ThrowNullRef, label %23
+
+; <label>:23                                      ; preds = %21
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 3
+  %25 = load i32, i32 addrspace(1)* %24, align 8
+  %26 = icmp sle i32 %25, 0
+  br i1 %26, label %96, label %27
+
+; <label>:27                                      ; preds = %23
+  %28 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %28, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %29
+
+; <label>:29                                      ; preds = %27
+  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %28, i32 0, i32 1
+  %31 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %30, align 8
+  store %"System.Char[]" addrspace(1)* %31, %"System.Char[]" addrspace(1)** %loc3
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %33
+
+; <label>:33                                      ; preds = %29
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  store i32 %35, i32* %loc4
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  %39 = load i32, i32 addrspace(1)* %38, align 8
+  store i32 %39, i32* %loc5
+  %40 = load i32, i32* %loc5
+  %41 = load i32, i32* %loc4
+  %42 = add i32 %40, %41
+  %43 = zext i32 %42 to i64
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %45
+
+; <label>:45                                      ; preds = %37
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = sext i32 %47 to i64
+  %49 = icmp sgt i64 %43, %48
+  br i1 %49, label %91, label %50
+
+; <label>:50                                      ; preds = %45
+  %51 = load i32, i32* %loc5
+  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %52, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %53
+
+; <label>:53                                      ; preds = %50
+  %54 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %52, i32 0, i32 1
+  %55 = load i32, i32 addrspace(1)* %54
+  %56 = zext i32 %55 to i64
+  %57 = trunc i64 %56 to i32
+  %58 = icmp ugt i32 %51, %57
+  br i1 %58, label %91, label %59
+
+; <label>:59                                      ; preds = %53
+  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  store %"System.Char[]" addrspace(1)* %60, %"System.Char[]" addrspace(1)** %loc8
+  %61 = icmp eq %"System.Char[]" addrspace(1)* %60, null
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %63, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %64
+
+; <label>:64                                      ; preds = %62
+  %65 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %63, i32 0, i32 1
+  %66 = load i32, i32 addrspace(1)* %65
+  %67 = zext i32 %66 to i64
+  %68 = trunc i64 %67 to i32
+  %69 = icmp ne i32 %68, 0
+  br i1 %69, label %71, label %70
+
+; <label>:70                                      ; preds = %59, %64
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:71                                      ; preds = %64
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %73
+
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %BoundsCheck = icmp uge i64 0, %76
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %77
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %78, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:79                                      ; preds = %70, %77
+  %80 = load i16*, i16** %loc2
+  %81 = load i32, i32* %loc4
+  %82 = sext i32 %81 to i64
+  %83 = mul i64 %82, 2
+  %84 = bitcast i16* %80 to i8*
+  %85 = getelementptr inbounds i8, i8* %84, i64 %83
+  %86 = load i16 addrspace(1)*, i16 addrspace(1)** %loc6
+  %87 = ptrtoint i16 addrspace(1)* %86 to i64
+  %88 = load i32, i32* %loc5
+  %89 = bitcast i8* %85 to i16*
+  %90 = inttoptr i64 %87 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %89, i16* %90, i32 %88)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %96
+
+; <label>:91                                      ; preds = %45, %53
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %94 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %93)
+  %95 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95, %System.String addrspace(1)* %92, %System.String addrspace(1)* %94)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95) #0
+  unreachable
+
+; <label>:96                                      ; preds = %23, %79
+  %97 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %97, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %98
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %97, i32 0, i32 2
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  store %System.Text.StringBuilder addrspace(1)* %100, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %102 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %102, label %21, label %103
+
+; <label>:103                                     ; preds = %98
+  store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc7
+  %104 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  ret %System.String addrspace(1)* %104
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method StringBuilder::get_Length using LLILCJit
+Successfully read StringBuilder.get_Length
+
+define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
+Successfully read RuntimeHelpers.get_OffsetToStringData
+
+define i32 @RuntimeHelpers.get_OffsetToStringData() {
+entry:
+  ret i32 12
+}
+
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
 Successfully read CultureData.CreateCultureData
 
@@ -3514,23 +4249,23 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
   store i8 %4, i8 addrspace(1)* %6
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
@@ -3549,11 +4284,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3566,50 +4301,50 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
   store i32 -1, i32 addrspace(1)* %2
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
   store i32 -1, i32 addrspace(1)* %8
   %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
   store i32 -1, i32 addrspace(1)* %14
   %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
   store i32 -1, i32 addrspace(1)* %17
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
@@ -3623,27 +4358,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3675,7 +4410,136 @@ Failed to read Dictionary`2.Insert[non-const derefAddress]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
 Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
-Failed to read HashHelpers.GetPrime[loadElem]
+Successfully read HashHelpers.GetPrime
+
+define i32 @HashHelpers.GetPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %6, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5, %System.String addrspace(1)* %4)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5) #0
+  unreachable
+
+; <label>:6                                       ; preds = %entry
+  store i32 0, i32* %loc0
+  br label %29
+
+; <label>:7                                       ; preds = %35
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 1296
+  %10 = addrspacecast i8 addrspace(1)* %9 to %"System.Int32[]" addrspace(1)**
+  %11 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %10
+  %12 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Int32[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = zext i32 %15 to i64
+  %17 = zext i32 %12 to i64
+  %BoundsCheck = icmp uge i64 %17, %16
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 3, i32 %12
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  store i32 %20, i32* %loc1
+  %21 = load i32, i32* %loc1
+  %22 = load i32, i32* %arg0
+  %23 = icmp slt i32 %21, %22
+  br i1 %23, label %26, label %24
+
+; <label>:24                                      ; preds = %18
+  %25 = load i32, i32* %loc1
+  ret i32 %25
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %loc0
+  %28 = add i32 %27, 1
+  store i32 %28, i32* %loc0
+  br label %29
+
+; <label>:29                                      ; preds = %6, %26
+  %30 = load i32, i32* %loc0
+  %31 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %32 = getelementptr inbounds i8, i8 addrspace(1)* %31, i64 1296
+  %33 = addrspacecast i8 addrspace(1)* %32 to %"System.Int32[]" addrspace(1)**
+  %34 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %33
+  %NullCheck = icmp eq %"System.Int32[]" addrspace(1)* %34, null
+  br i1 %NullCheck, label %ThrowNullRef, label %35
+
+; <label>:35                                      ; preds = %29
+  %36 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %34, i32 0, i32 1
+  %37 = load i32, i32 addrspace(1)* %36
+  %38 = zext i32 %37 to i64
+  %39 = trunc i64 %38 to i32
+  %40 = icmp slt i32 %30, %39
+  br i1 %40, label %7, label %41
+
+; <label>:41                                      ; preds = %35
+  %42 = load i32, i32* %arg0
+  %43 = or i32 %42, 1
+  store i32 %43, i32* %loc2
+  br label %59
+
+; <label>:44                                      ; preds = %59
+  %45 = load i32, i32* %loc2
+  %46 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %45)
+  %47 = zext i8 %46 to i32
+  %48 = icmp eq i32 %47, 0
+  br i1 %48, label %56, label %49
+
+; <label>:49                                      ; preds = %44
+  %50 = load i32, i32* %loc2
+  %51 = sub i32 %50, 1
+  %52 = srem i32 %51, 101
+  %53 = icmp eq i32 %52, 0
+  br i1 %53, label %56, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = load i32, i32* %loc2
+  ret i32 %55
+
+; <label>:56                                      ; preds = %44, %49
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %57, 2
+  store i32 %58, i32* %loc2
+  br label %59
+
+; <label>:59                                      ; preds = %41, %56
+  %60 = load i32, i32* %loc2
+  %61 = icmp slt i32 %60, 2147483647
+  br i1 %61, label %44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load i32, i32* %arg0
+  ret i32 %63
+
+ThrowNullRef:                                     ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
 Successfully read GenericEqualityComparer`1.GetHashCode
 
@@ -3694,14 +4558,14 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
   %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load i64, i64 addrspace(1)* %7
@@ -3720,7 +4584,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3750,8 +4614,8 @@ entry:
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
@@ -3796,8 +4660,8 @@ entry:
   %35 = bitcast i16* %34 to i8*
   %36 = getelementptr inbounds i8, i8* %35, i64 2
   %37 = bitcast i8* %36 to i16*
-  %NullCheck4 = icmp ne i16* %37, null
-  br i1 %NullCheck4, label %38, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %37, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %38
 
 ; <label>:38                                      ; preds = %27
   %39 = load i16, i16* %37, align 8
@@ -3824,8 +4688,8 @@ entry:
 
 ; <label>:54                                      ; preds = %22, %43
   %55 = load i16*, i16** %loc4
-  %NullCheck2 = icmp ne i16* %55, null
-  br i1 %NullCheck2, label %56, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i16* %55, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %56
 
 ; <label>:56                                      ; preds = %54
   %57 = load i16, i16* %55, align 8
@@ -3850,11 +4714,11 @@ ThrowNullRef:                                     ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %54
+ThrowNullRef2:                                    ; preds = %54
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %27
+ThrowNullRef4:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3871,8 +4735,8 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -3907,8 +4771,8 @@ entry:
 
 ; <label>:26                                      ; preds = %19
   %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
-  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %28
 
 ; <label>:28                                      ; preds = %26
   %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
@@ -3920,7 +4784,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3972,8 +4836,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
@@ -3984,26 +4848,26 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
-  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
@@ -4014,8 +4878,8 @@ entry:
 ; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
@@ -4024,8 +4888,8 @@ entry:
 
 ; <label>:25                                      ; preds = %1, %16, %23
   %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
-  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
@@ -4036,27 +4900,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %20
+ThrowNullRef10:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4069,8 +4933,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -4081,8 +4945,8 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
@@ -4091,8 +4955,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1, %8
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
@@ -4103,11 +4967,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4128,24 +4992,24 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   store i32 %3, i32* %loc0
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
   %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
   store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck4, label %9, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
@@ -4164,15 +5028,15 @@ entry:
 ; <label>:18                                      ; preds = %70
   %19 = load i16*, i16** %loc3
   %20 = bitcast i16* %19 to i64*
-  %NullCheck10 = icmp ne i64* %20, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %20, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = load i64, i64* %20, align 8
   %23 = load i16*, i16** %loc4
   %24 = bitcast i16* %23 to i64*
-  %NullCheck12 = icmp ne i64* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = load i64, i64* %24, align 8
@@ -4188,8 +5052,8 @@ entry:
   %31 = bitcast i16* %30 to i8*
   %32 = getelementptr inbounds i8, i8* %31, i64 8
   %33 = bitcast i8* %32 to i64*
-  %NullCheck14 = icmp ne i64* %33, null
-  br i1 %NullCheck14, label %34, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = load i64, i64* %33, align 8
@@ -4197,8 +5061,8 @@ entry:
   %37 = bitcast i16* %36 to i8*
   %38 = getelementptr inbounds i8, i8* %37, i64 8
   %39 = bitcast i8* %38 to i64*
-  %NullCheck16 = icmp ne i64* %39, null
-  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %40
 
 ; <label>:40                                      ; preds = %34
   %41 = load i64, i64* %39, align 8
@@ -4214,8 +5078,8 @@ entry:
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %NullCheck18 = icmp ne i64* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = load i64, i64* %48, align 8
@@ -4223,8 +5087,8 @@ entry:
   %52 = bitcast i16* %51 to i8*
   %53 = getelementptr inbounds i8, i8* %52, i64 16
   %54 = bitcast i8* %53 to i64*
-  %NullCheck20 = icmp ne i64* %54, null
-  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64* %54, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %55
 
 ; <label>:55                                      ; preds = %49
   %56 = load i64, i64* %54, align 8
@@ -4262,15 +5126,15 @@ entry:
 ; <label>:74                                      ; preds = %95
   %75 = load i16*, i16** %loc3
   %76 = bitcast i16* %75 to i32*
-  %NullCheck6 = icmp ne i32* %76, null
-  br i1 %NullCheck6, label %77, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32* %76, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %77
 
 ; <label>:77                                      ; preds = %74
   %78 = load i32, i32* %76, align 8
   %79 = load i16*, i16** %loc4
   %80 = bitcast i16* %79 to i32*
-  %NullCheck8 = icmp ne i32* %80, null
-  br i1 %NullCheck8, label %81, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i32* %80, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %81
 
 ; <label>:81                                      ; preds = %77
   %82 = load i32, i32* %80, align 8
@@ -4318,43 +5182,43 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %74
+ThrowNullRef6:                                    ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %77
+ThrowNullRef8:                                    ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %29
+ThrowNullRef14:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %34
+ThrowNullRef16:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4376,8 +5240,8 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load i64, i64 addrspace(1)* %4
@@ -4389,8 +5253,8 @@ entry:
   %12 = load i64, i64* %11
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %5
   %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
@@ -4399,8 +5263,8 @@ entry:
   %18 = load i8, i8* %arg2
   %19 = zext i8 %18 to i32
   %20 = trunc i32 %19 to i8
-  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %15
   %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
@@ -4411,11 +5275,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4442,8 +5306,8 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
@@ -4466,16 +5330,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
   %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = load i64, i64 addrspace(1)* %19
@@ -4500,8 +5364,8 @@ entry:
 ; <label>:35                                      ; preds = %30
   %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
@@ -4514,8 +5378,8 @@ entry:
 
 ; <label>:42                                      ; preds = %1, %38
   %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
-  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
@@ -4526,19 +5390,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %35
+ThrowNullRef2:                                    ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %42
+ThrowNullRef8:                                    ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4551,14 +5415,14 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
@@ -4570,7 +5434,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4583,8 +5447,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
@@ -4613,51 +5477,51 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
   %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
   %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
   %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
   %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
-  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
   store i64 %21, i64 addrspace(1)* %23
   %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %25 = load i64, i64* %loc0
-  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
@@ -4668,27 +5532,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %22
+ThrowNullRef12:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4701,8 +5565,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
@@ -4713,19 +5577,19 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
@@ -4734,8 +5598,8 @@ entry:
 
 ; <label>:15                                      ; preds = %1, %13
   %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
@@ -4746,19 +5610,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %15
+ThrowNullRef8:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4771,8 +5635,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -4831,8 +5695,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
@@ -4882,8 +5746,8 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
-  br i1 %NullCheck, label %17, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %ThrowNullRef, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
@@ -4894,15 +5758,15 @@ entry:
 
 ; <label>:22                                      ; preds = %17
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
-  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
   %26 = load i32, i32 addrspace(1)* %25
   %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
-  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %27, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
@@ -4925,8 +5789,8 @@ entry:
 ; <label>:40                                      ; preds = %17
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
-  br i1 %NullCheck6, label %43, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %41, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
@@ -4938,34 +5802,17 @@ ThrowNullRef:                                     ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %24
+ThrowNullRef4:                                    ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %40
+ThrowNullRef6:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
-}
-
-INFO:  jitting method Object::ReferenceEquals using LLILCJit
-Successfully read Object.ReferenceEquals
-
-define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
-entry:
-  %arg0 = alloca %System.Object addrspace(1)*
-  %arg1 = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
-  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
-  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = icmp eq %System.Object addrspace(1)* %0, %1
-  %3 = sext i1 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
 }
 
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
@@ -4978,21 +5825,21 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
   %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
-  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
@@ -5007,28 +5854,28 @@ entry:
 ; <label>:13                                      ; preds = %8, %12
   %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
   %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
   %21 = load i32, i32 addrspace(1)* %20, align 8
   %22 = add i32 %21, 1
-  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
   store i32 %22, i32 addrspace(1)* %24
   %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
@@ -5039,27 +5886,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5077,7 +5924,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::Setup using LLILCJit
-Failed to read AppDomain.Setup[loadElem]
+Failed to read AppDomain.Setup[unbox]
 INFO:  jitting method Thread::GetDomain using LLILCJit
 Successfully read Thread.GetDomain
 
@@ -5108,8 +5955,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
@@ -5122,14 +5969,14 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
   %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
@@ -5141,11 +5988,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5173,8 +6020,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -5189,7 +6036,328 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
 Failed to read KeyCollection.System.Collections.Generic.IEnumerable<TKey>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Successfully read Enumerator.MoveNext
+
+define i8 @Enumerator.MoveNext(%"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.RuntimeTypeHandle* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*
+  %"$TypeArg" = alloca %System.RuntimeTypeHandle*
+  store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
+  %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 8
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %76, label %12
+
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
+  br label %76
+
+; <label>:13                                      ; preds = %85
+  %14 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck19 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %15
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, i32 0, i32 0
+  %17 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %16, align 8
+  %NullCheck21 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, i32 0, i32 2
+  %20 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %19, align 8
+  %21 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck23 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %22
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, i32 0, i32 2
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %NullCheck25 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 3, i32 %24
+  %NullCheck27 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %32
+
+; <label>:32                                      ; preds = %30
+  %33 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, i32 0, i32 2
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = icmp slt i32 %34, 0
+  br i1 %35, label %68, label %36
+
+; <label>:36                                      ; preds = %32
+  %37 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %38 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck29 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %39
+
+; <label>:39                                      ; preds = %36
+  %40 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, i32 0, i32 0
+  %41 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %40, align 8
+  %NullCheck31 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, i32 0, i32 2
+  %44 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %43, align 8
+  %45 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck33 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, i32 0, i32 2
+  %48 = load i32, i32 addrspace(1)* %47, align 8
+  %NullCheck35 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %49
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = zext i32 %51 to i64
+  %53 = zext i32 %48 to i64
+  %BoundsCheck37 = icmp uge i64 %53, %52
+  br i1 %BoundsCheck37, label %ThrowIndexOutOfRange38, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 3, i32 %48
+  %NullCheck39 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %56
+
+; <label>:56                                      ; preds = %54
+  %57 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, i32 0, i32 0
+  %58 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck41 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %59
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %60, %System.__Canon addrspace(1)* %58)
+  %61 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck43 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  %64 = load i32, i32 addrspace(1)* %63, align 8
+  %65 = add i32 %64, 1
+  %NullCheck45 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  store i32 %65, i32 addrspace(1)* %67
+  ret i8 1
+
+; <label>:68                                      ; preds = %32
+  %69 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck47 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %73 = add i32 %72, 1
+  %NullCheck49 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %74
+
+; <label>:74                                      ; preds = %70
+  %75 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  store i32 %73, i32 addrspace(1)* %75
+  br label %76
+
+; <label>:76                                      ; preds = %8, %12, %74
+  %77 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %78
+
+; <label>:78                                      ; preds = %76
+  %79 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, i32 0, i32 2
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck7 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %82
+
+; <label>:82                                      ; preds = %78
+  %83 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, i32 0, i32 0
+  %84 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %83, align 8
+  %NullCheck9 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %85
+
+; <label>:85                                      ; preds = %82
+  %86 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, i32 0, i32 7
+  %87 = load i32, i32 addrspace(1)* %86, align 8
+  %88 = icmp ult i32 %80, %87
+  br i1 %88, label %13, label %89
+
+; <label>:89                                      ; preds = %85
+  %90 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %91 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck11 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %92
+
+; <label>:92                                      ; preds = %89
+  %93 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, i32 0, i32 0
+  %94 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck13 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %95
+
+; <label>:95                                      ; preds = %92
+  %96 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, i32 0, i32 7
+  %97 = load i32, i32 addrspace(1)* %96, align 8
+  %98 = add i32 %97, 1
+  %NullCheck15 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %99
+
+; <label>:99                                      ; preds = %95
+  %100 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, i32 0, i32 2
+  store i32 %98, i32 addrspace(1)* %100
+  %101 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck17 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %102
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %103, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %92
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef22:                                   ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef24:                                   ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef26:                                   ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef28:                                   ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef30:                                   ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef32:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef34:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef36:                                   ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange38:                           ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef40:                                   ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef42:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef44:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef46:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef48:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef50:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -5200,8 +6368,8 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -5232,9 +6400,9 @@ Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
 Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
-Failed to read String.MakeSeparatorList[loadElemA]
+Failed to read String.MakeSeparatorList[storeElem]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
-Failed to read String.InternalSplitKeepEmptyEntries[loadElem]
+Failed to read String.InternalSplitKeepEmptyEntries[storeElem]
 INFO:  jitting method Path::IsRelative using LLILCJit
 Successfully read Path.IsRelative
 
@@ -5243,8 +6411,8 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -5254,8 +6422,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
@@ -5271,8 +6439,8 @@ entry:
 
 ; <label>:17                                      ; preds = %7
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
@@ -5288,8 +6456,8 @@ entry:
 
 ; <label>:29                                      ; preds = %19
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %31
 
 ; <label>:31                                      ; preds = %29
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
@@ -5300,8 +6468,8 @@ entry:
 
 ; <label>:36                                      ; preds = %31
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
-  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %37, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
@@ -5312,8 +6480,8 @@ entry:
 
 ; <label>:43                                      ; preds = %31, %38
   %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
-  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %45
 
 ; <label>:45                                      ; preds = %43
   %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
@@ -5324,8 +6492,8 @@ entry:
 
 ; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %50
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
@@ -5336,8 +6504,8 @@ entry:
 
 ; <label>:57                                      ; preds = %1, %7, %19, %45, %52
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
-  br i1 %NullCheck14, label %59, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %59
 
 ; <label>:59                                      ; preds = %57
   %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
@@ -5347,8 +6515,8 @@ entry:
 
 ; <label>:63                                      ; preds = %59
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
@@ -5359,8 +6527,8 @@ entry:
 
 ; <label>:70                                      ; preds = %65
   %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
-  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.String addrspace(1)* %71, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %72
 
 ; <label>:72                                      ; preds = %70
   %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
@@ -5379,39 +6547,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %17
+ThrowNullRef4:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %29
+ThrowNullRef6:                                    ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %36
+ThrowNullRef8:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %43
+ThrowNullRef10:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %50
+ThrowNullRef12:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %57
+ThrowNullRef14:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %63
+ThrowNullRef16:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %70
+ThrowNullRef18:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5419,7 +6587,293 @@ ThrowNullRef17:                                   ; preds = %70
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
-Failed to read String.TrimHelper[loadElem]
+Successfully read String.TrimHelper
+
+define %System.String addrspace(1)* @String.TrimHelper(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i16
+  %loc4 = alloca i32
+  %loc5 = alloca i16
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = sub i32 %3, 1
+  store i32 %4, i32* %loc0
+  store i32 0, i32* %loc1
+  %5 = load i32, i32* %arg2
+  %6 = icmp eq i32 %5, 1
+  br i1 %6, label %62, label %7
+
+; <label>:7                                       ; preds = %1
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:8                                       ; preds = %58
+  store i32 0, i32* %loc2
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load i32, i32* %loc1
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2, i32 %10
+  %13 = load i16, i16 addrspace(1)* %12
+  %14 = zext i16 %13 to i32
+  %15 = trunc i32 %14 to i16
+  store i16 %15, i16* %loc3
+  store i32 0, i32* %loc2
+  br label %34
+
+; <label>:16                                      ; preds = %37
+  %17 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %18 = load i32, i32* %loc2
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %17, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %19
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = zext i32 %18 to i64
+  %BoundsCheck = icmp uge i64 %23, %22
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %24
+
+; <label>:24                                      ; preds = %19
+  %25 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 3, i32 %18
+  %26 = load i16, i16 addrspace(1)* %25, align 8
+  %27 = zext i16 %26 to i32
+  %28 = load i16, i16* %loc3
+  %29 = zext i16 %28 to i32
+  %30 = icmp eq i32 %27, %29
+  br i1 %30, label %43, label %31
+
+; <label>:31                                      ; preds = %24
+  %32 = load i32, i32* %loc2
+  %33 = add i32 %32, 1
+  store i32 %33, i32* %loc2
+  br label %34
+
+; <label>:34                                      ; preds = %11, %31
+  %35 = load i32, i32* %loc2
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = icmp slt i32 %35, %41
+  br i1 %42, label %16, label %43
+
+; <label>:43                                      ; preds = %24, %37
+  %44 = load i32, i32* %loc2
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %45, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp eq i32 %44, %50
+  br i1 %51, label %62, label %52
+
+; <label>:52                                      ; preds = %46
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %7, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %57, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %58
+
+; <label>:58                                      ; preds = %55
+  %59 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %60 = load i32, i32 addrspace(1)* %59
+  %61 = icmp slt i32 %56, %60
+  br i1 %61, label %8, label %62
+
+; <label>:62                                      ; preds = %1, %46, %58
+  %63 = load i32, i32* %arg2
+  %64 = icmp eq i32 %63, 0
+  br i1 %64, label %122, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %66, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %67
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %66, i32 0, i32 1
+  %69 = load i32, i32 addrspace(1)* %68
+  %70 = sub i32 %69, 1
+  store i32 %70, i32* %loc0
+  br label %118
+
+; <label>:71                                      ; preds = %118
+  store i32 0, i32* %loc4
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %73 = load i32, i32* %loc0
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %74
+
+; <label>:74                                      ; preds = %71
+  %75 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 2, i32 %73
+  %76 = load i16, i16 addrspace(1)* %75
+  %77 = zext i16 %76 to i32
+  %78 = trunc i32 %77 to i16
+  store i16 %78, i16* %loc5
+  store i32 0, i32* %loc4
+  br label %97
+
+; <label>:79                                      ; preds = %100
+  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %81 = load i32, i32* %loc4
+  %NullCheck19 = icmp eq %"System.Char[]" addrspace(1)* %80, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
+
+; <label>:82                                      ; preds = %79
+  %83 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 1
+  %84 = load i32, i32 addrspace(1)* %83
+  %85 = zext i32 %84 to i64
+  %86 = zext i32 %81 to i64
+  %BoundsCheck21 = icmp uge i64 %86, %85
+  br i1 %BoundsCheck21, label %ThrowIndexOutOfRange22, label %87
+
+; <label>:87                                      ; preds = %82
+  %88 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 3, i32 %81
+  %89 = load i16, i16 addrspace(1)* %88, align 8
+  %90 = zext i16 %89 to i32
+  %91 = load i16, i16* %loc5
+  %92 = zext i16 %91 to i32
+  %93 = icmp eq i32 %90, %92
+  br i1 %93, label %106, label %94
+
+; <label>:94                                      ; preds = %87
+  %95 = load i32, i32* %loc4
+  %96 = add i32 %95, 1
+  store i32 %96, i32* %loc4
+  br label %97
+
+; <label>:97                                      ; preds = %74, %94
+  %98 = load i32, i32* %loc4
+  %99 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck15 = icmp eq %"System.Char[]" addrspace(1)* %99, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %100
+
+; <label>:100                                     ; preds = %97
+  %101 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %99, i32 0, i32 1
+  %102 = load i32, i32 addrspace(1)* %101
+  %103 = zext i32 %102 to i64
+  %104 = trunc i64 %103 to i32
+  %105 = icmp slt i32 %98, %104
+  br i1 %105, label %79, label %106
+
+; <label>:106                                     ; preds = %87, %100
+  %107 = load i32, i32* %loc4
+  %108 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck17 = icmp eq %"System.Char[]" addrspace(1)* %108, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %109
+
+; <label>:109                                     ; preds = %106
+  %110 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %108, i32 0, i32 1
+  %111 = load i32, i32 addrspace(1)* %110
+  %112 = zext i32 %111 to i64
+  %113 = trunc i64 %112 to i32
+  %114 = icmp eq i32 %107, %113
+  br i1 %114, label %122, label %115
+
+; <label>:115                                     ; preds = %109
+  %116 = load i32, i32* %loc0
+  %117 = sub i32 %116, 1
+  store i32 %117, i32* %loc0
+  br label %118
+
+; <label>:118                                     ; preds = %67, %115
+  %119 = load i32, i32* %loc0
+  %120 = load i32, i32* %loc1
+  %121 = icmp sge i32 %119, %120
+  br i1 %121, label %71, label %122
+
+; <label>:122                                     ; preds = %62, %109, %118
+  %123 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %124 = load i32, i32* %loc1
+  %125 = load i32, i32* %loc0
+  %126 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %123, i32 %124, i32 %125)
+  ret %System.String addrspace(1)* %126
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %97
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange22:                           ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
 Successfully read String.CreateTrimmedString
 
@@ -5439,8 +6893,8 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
@@ -5535,8 +6989,8 @@ entry:
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i64 2872
   %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
   %8 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %7
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %3
   %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
@@ -5553,8 +7007,8 @@ entry:
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 2864
   %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
   %21 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %20
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
-  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %22
 
 ; <label>:22                                      ; preds = %16
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
@@ -5569,7 +7023,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %16
+ThrowNullRef2:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5586,8 +7040,8 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5613,8 +7067,8 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
@@ -5632,8 +7086,8 @@ entry:
 
 ; <label>:12                                      ; preds = %4
   %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
@@ -5644,8 +7098,8 @@ entry:
 
 ; <label>:19                                      ; preds = %14
   %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %19
   %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
@@ -5660,21 +7114,21 @@ entry:
   %31 = zext i16 %30 to i32
   %32 = bitcast i8* %29 to i16*
   %33 = trunc i32 %31 to i16
-  %NullCheck6 = icmp ne i16* %32, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i16* %32, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %21
   store i16 %33, i16* %32, align 8
   %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %36
 
 ; <label>:36                                      ; preds = %34
   %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
   %38 = load i32, i32 addrspace(1)* %37, align 8
   %39 = add i32 %38, 1
-  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %40
 
 ; <label>:40                                      ; preds = %36
   %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
@@ -5683,16 +7137,16 @@ entry:
 
 ; <label>:42                                      ; preds = %14
   %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
-  br i1 %NullCheck12, label %44, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
   %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
   %47 = load i16, i16* %arg1
   %48 = zext i16 %47 to i32
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = trunc i32 %48 to i16
@@ -5703,31 +7157,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %19
+ThrowNullRef4:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %21
+ThrowNullRef6:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %36
+ThrowNullRef10:                                   ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %42
+ThrowNullRef12:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %44
+ThrowNullRef14:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5740,8 +7194,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -5752,8 +7206,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
@@ -5762,14 +7216,14 @@ entry:
 
 ; <label>:11                                      ; preds = %1
   %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
@@ -5779,15 +7233,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5808,8 +7262,8 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5822,8 +7276,8 @@ entry:
 
 ; <label>:8                                       ; preds = %3
   %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
@@ -5842,15 +7296,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
-  br i1 %NullCheck4, label %22, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
   %24 = load i16*, i16* addrspace(1)* %23, align 8
   %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %25, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
@@ -5859,8 +7313,8 @@ entry:
   store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
@@ -5874,8 +7328,8 @@ entry:
 
 ; <label>:37                                      ; preds = %65
   %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %37
   %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
@@ -5886,16 +7340,16 @@ entry:
   %45 = bitcast i16* %41 to i8*
   %46 = getelementptr inbounds i8, i8* %45, i64 %44
   %47 = bitcast i8* %46 to i16*
-  %NullCheck14 = icmp ne i16* %47, null
-  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %47, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %48
 
 ; <label>:48                                      ; preds = %39
   %49 = load i16, i16* %47, align 8
   %50 = zext i16 %49 to i32
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %52 = load i32, i32* %loc1
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %53
 
 ; <label>:53                                      ; preds = %48
   %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
@@ -5916,8 +7370,8 @@ entry:
 ; <label>:62                                      ; preds = %36, %59
   %63 = load i32, i32* %loc1
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck10, label %65, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %65
 
 ; <label>:65                                      ; preds = %62
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
@@ -5936,15 +7390,15 @@ entry:
 
 ; <label>:74                                      ; preds = %70
   %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
-  br i1 %NullCheck18, label %76, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %76
 
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
   %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
-  br i1 %NullCheck20, label %80, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
   %81 = load i64, i64 addrspace(1)* %79
@@ -5958,8 +7412,8 @@ entry:
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
   %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
-  br i1 %NullCheck22, label %92, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.String addrspace(1)* %90, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %92
 
 ; <label>:92                                      ; preds = %80
   %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
@@ -5969,15 +7423,15 @@ entry:
 
 ; <label>:96                                      ; preds = %70
   %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
-  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %98
 
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
   %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
-  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
   %103 = load i64, i64 addrspace(1)* %101
@@ -5991,8 +7445,8 @@ entry:
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
   %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
-  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.String addrspace(1)* %112, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %114
 
 ; <label>:114                                     ; preds = %102
   %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
@@ -6004,59 +7458,59 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %20
+ThrowNullRef4:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %22
+ThrowNullRef6:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %26
+ThrowNullRef8:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %62
+ThrowNullRef10:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %48
+ThrowNullRef16:                                   ; preds = %48
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %74
+ThrowNullRef18:                                   ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %76
+ThrowNullRef20:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %80
+ThrowNullRef22:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %96
+ThrowNullRef24:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %98
+ThrowNullRef26:                                   ; preds = %98
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %102
+ThrowNullRef28:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6069,15 +7523,15 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
   %3 = load i16*, i16* addrspace(1)* %2, align 8
   %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
@@ -6087,8 +7541,8 @@ entry:
   %10 = bitcast i16* %3 to i8*
   %11 = getelementptr inbounds i8, i8* %10, i64 %9
   %12 = bitcast i8* %11 to i16*
-  %NullCheck4 = icmp ne i16* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %5
   store i16 0, i16* %12, align 8
@@ -6098,11 +7552,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6119,8 +7573,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -6131,8 +7585,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
@@ -6144,15 +7598,15 @@ entry:
 
 ; <label>:14                                      ; preds = %1
   %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
   %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
   %21 = load i64, i64 addrspace(1)* %19
@@ -6171,15 +7625,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %14
+ThrowNullRef4:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %16
+ThrowNullRef6:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6302,14 +7756,6 @@ entry:
   ret %System.String addrspace(1)* %57
 }
 
-INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
-Successfully read RuntimeHelpers.get_OffsetToStringData
-
-define i32 @RuntimeHelpers.get_OffsetToStringData() {
-entry:
-  ret i32 12
-}
-
 INFO:  jitting method String::Equals using LLILCJit
 Successfully read String.Equals
 
@@ -6381,8 +7827,8 @@ entry:
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
-  br i1 %NullCheck24, label %29, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
   %30 = load i64, i64 addrspace(1)* %28
@@ -6397,8 +7843,8 @@ entry:
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
-  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
   %43 = load i64, i64 addrspace(1)* %41
@@ -6418,8 +7864,8 @@ entry:
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
   %59 = load i64, i64 addrspace(1)* %57
@@ -6434,8 +7880,8 @@ entry:
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck22, label %71, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
   %72 = load i64, i64 addrspace(1)* %70
@@ -6455,8 +7901,8 @@ entry:
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
-  br i1 %NullCheck16, label %87, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = load i64, i64 addrspace(1)* %86
@@ -6471,8 +7917,8 @@ entry:
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck18, label %100, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
   %101 = load i64, i64 addrspace(1)* %99
@@ -6492,8 +7938,8 @@ entry:
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
-  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
   %117 = load i64, i64 addrspace(1)* %115
@@ -6508,8 +7954,8 @@ entry:
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
-  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
   %130 = load i64, i64 addrspace(1)* %128
@@ -6528,15 +7974,15 @@ entry:
 
 ; <label>:142                                     ; preds = %22
   %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
-  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %143, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %144
 
 ; <label>:144                                     ; preds = %142
   %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
   %146 = load i32, i32 addrspace(1)* %145
   %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
-  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %147, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %148
 
 ; <label>:148                                     ; preds = %144
   %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
@@ -6557,15 +8003,15 @@ entry:
 
 ; <label>:159                                     ; preds = %22
   %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
-  br i1 %NullCheck, label %161, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %ThrowNullRef, label %161
 
 ; <label>:161                                     ; preds = %159
   %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
   %163 = load i32, i32 addrspace(1)* %162
   %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
-  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %164, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %165
 
 ; <label>:165                                     ; preds = %161
   %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
@@ -6578,8 +8024,8 @@ entry:
 
 ; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
-  br i1 %NullCheck4, label %172, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %171, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %172
 
 ; <label>:172                                     ; preds = %170
   %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
@@ -6589,8 +8035,8 @@ entry:
 
 ; <label>:176                                     ; preds = %172
   %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
-  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %177, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %178
 
 ; <label>:178                                     ; preds = %176
   %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
@@ -6629,55 +8075,55 @@ ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %161
+ThrowNullRef2:                                    ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %170
+ThrowNullRef4:                                    ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %176
+ThrowNullRef6:                                    ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %142
+ThrowNullRef8:                                    ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %144
+ThrowNullRef10:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %113
+ThrowNullRef12:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %116
+ThrowNullRef14:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %84
+ThrowNullRef16:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %87
+ThrowNullRef18:                                   ; preds = %87
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %55
+ThrowNullRef20:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %58
+ThrowNullRef22:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %26
+ThrowNullRef24:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %29
+ThrowNullRef26:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,8 +8161,8 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck, label %14, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %ThrowNullRef, label %14
 
 ; <label>:14                                      ; preds = %8
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
@@ -6760,8 +8206,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
@@ -6770,14 +8216,14 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32, i32* %loc0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %10
   %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
   %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
@@ -6790,15 +8236,15 @@ entry:
 ; <label>:25                                      ; preds = %19
   %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
-  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
   %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
@@ -6807,8 +8253,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %37 = load i32, i32* %loc0
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %38, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %38
 
 ; <label>:38                                      ; preds = %32
   %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
@@ -6817,14 +8263,14 @@ entry:
 
 ; <label>:40                                      ; preds = %19
   %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %40
   %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
   %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
-  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
-  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
@@ -6832,8 +8278,8 @@ entry:
   %48 = zext i32 %47 to i64
   %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
-  br i1 %NullCheck16, label %51, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %51
 
 ; <label>:51                                      ; preds = %45
   %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
@@ -6847,15 +8293,15 @@ entry:
 ; <label>:57                                      ; preds = %51
   %58 = load i16*, i16** %arg1
   %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
-  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %60
 
 ; <label>:60                                      ; preds = %57
   %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
   %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
-  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %64
 
 ; <label>:64                                      ; preds = %60
   %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
@@ -6864,22 +8310,22 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
   %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
-  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %70
 
 ; <label>:70                                      ; preds = %64
   %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
   %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
-  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
-  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
   %75 = load i32, i32 addrspace(1)* %74
   %76 = zext i32 %75 to i64
   %77 = trunc i64 %76 to i32
-  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
-  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %78
 
 ; <label>:78                                      ; preds = %73
   %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
@@ -6901,8 +8347,8 @@ entry:
   %90 = bitcast i16* %86 to i8*
   %91 = getelementptr inbounds i8, i8* %90, i64 %89
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %93
 
 ; <label>:93                                      ; preds = %80
   %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
@@ -6912,8 +8358,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %99 = load i32, i32* %loc2
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %100
 
 ; <label>:100                                     ; preds = %93
   %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
@@ -6928,63 +8374,63 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %25
+ThrowNullRef6:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %32
+ThrowNullRef10:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %40
+ThrowNullRef12:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %45
+ThrowNullRef16:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %57
+ThrowNullRef18:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %60
+ThrowNullRef20:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %64
+ThrowNullRef22:                                   ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %70
+ThrowNullRef24:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %73
+ThrowNullRef26:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %80
+ThrowNullRef28:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %93
+ThrowNullRef30:                                   ; preds = %93
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7004,8 +8450,8 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
@@ -7033,43 +8479,43 @@ entry:
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %14
   %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
   %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   %28 = load i32, i32 addrspace(1)* %27, align 8
   %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
-  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %30
 
 ; <label>:30                                      ; preds = %26
   %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
   %32 = load i32, i32 addrspace(1)* %31, align 8
   %33 = add i32 %28, %32
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %34
 
 ; <label>:34                                      ; preds = %30
   %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   store i32 %33, i32 addrspace(1)* %35
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
   store i32 0, i32 addrspace(1)* %38
   %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %40
 
 ; <label>:40                                      ; preds = %37
   %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
@@ -7082,8 +8528,8 @@ entry:
 
 ; <label>:47                                      ; preds = %40
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
@@ -7098,8 +8544,8 @@ entry:
   %54 = load i32, i32* %loc0
   %55 = sext i32 %54 to i64
   %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
-  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %57
 
 ; <label>:57                                      ; preds = %52
   %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
@@ -7110,68 +8556,35 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %14
+ThrowNullRef2:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %23
+ThrowNullRef4:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %26
+ThrowNullRef6:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %30
+ThrowNullRef8:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %34
+ThrowNullRef10:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %47
+ThrowNullRef14:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %52
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-}
-
-INFO:  jitting method StringBuilder::get_Length using LLILCJit
-Successfully read StringBuilder.get_Length
-
-define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.StringBuilder addrspace(1)*
-  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
-  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
-
-; <label>:1                                       ; preds = %entry
-  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %3 = load i32, i32 addrspace(1)* %2, align 8
-  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
-
-; <label>:5                                       ; preds = %1
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = add i32 %3, %7
-  ret i32 %8
-
-ThrowNullRef:                                     ; preds = %entry
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef16:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7213,70 +8626,70 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
   %6 = load i32, i32 addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
   store i32 %6, i32 addrspace(1)* %8
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
   %13 = load i32, i32 addrspace(1)* %12, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
   store i32 %13, i32 addrspace(1)* %15
   %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
-  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %18
 
 ; <label>:18                                      ; preds = %14
   %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
   %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
   %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
   %34 = load i32, i32 addrspace(1)* %33, align 8
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
-  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
@@ -7287,39 +8700,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %28
+ThrowNullRef16:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %32
+ThrowNullRef18:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7455,13 +8868,13 @@ entry:
 ; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
@@ -7477,16 +8890,16 @@ entry:
 
 ; <label>:18                                      ; preds = %15
   %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
   store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
   %22 = load i32, i32* %loc0
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %24
 
 ; <label>:24                                      ; preds = %20
   %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
@@ -7498,13 +8911,13 @@ entry:
 ; <label>:28                                      ; preds = %15, %24
   %29 = load i32, i32* %arg1
   %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %31
   %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
@@ -7517,20 +8930,20 @@ entry:
   %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
-  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
   %46 = load i32, i32 addrspace(1)* %45, align 8
   %47 = sub i32 %40, %46
-  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
-  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i32 addrspace(1)* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %48
 
 ; <label>:48                                      ; preds = %44
   store i32 %47, i32 addrspace(1)* %39, align 8
@@ -7538,21 +8951,21 @@ entry:
 
 ; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
-  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %51
 
 ; <label>:51                                      ; preds = %49
   %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %53
 
 ; <label>:53                                      ; preds = %51
   %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
   %55 = load i32, i32 addrspace(1)* %54, align 8
   %56 = load i32, i32* %arg2
   %57 = sub i32 %55, %56
-  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %58
 
 ; <label>:58                                      ; preds = %53
   %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
@@ -7562,13 +8975,13 @@ entry:
 ; <label>:60                                      ; preds = %33, %58
   %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
   %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
-  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %63
 
 ; <label>:63                                      ; preds = %60
   %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
-  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
-  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
@@ -7578,15 +8991,15 @@ entry:
 
 ; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
-  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i32 addrspace(1)* %69, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %70
 
 ; <label>:70                                      ; preds = %68
   %71 = load i32, i32 addrspace(1)* %69, align 8
   store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
-  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
@@ -7596,8 +9009,8 @@ entry:
   store i32 %77, i32* %loc4
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
-  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %80
 
 ; <label>:80                                      ; preds = %73
   %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
@@ -7607,71 +9020,71 @@ entry:
 ; <label>:83                                      ; preds = %80
   store i32 0, i32* %loc3
   %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
-  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
-  br i1 %NullCheck26, label %88, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i32 addrspace(1)* %87, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %88
 
 ; <label>:88                                      ; preds = %85
   %89 = load i32, i32 addrspace(1)* %87, align 8
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
-  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %90
 
 ; <label>:90                                      ; preds = %88
   %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
   store i32 %89, i32 addrspace(1)* %91
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
-  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
-  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %96
 
 ; <label>:96                                      ; preds = %94
   %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
-  br i1 %NullCheck34, label %100, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %100
 
 ; <label>:100                                     ; preds = %96
   %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
-  br i1 %NullCheck36, label %102, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %102
 
 ; <label>:102                                     ; preds = %100
   %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
   %104 = load i32, i32 addrspace(1)* %103, align 8
   %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
-  br i1 %NullCheck38, label %106, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %106
 
 ; <label>:106                                     ; preds = %102
   %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
-  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
-  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %108
 
 ; <label>:108                                     ; preds = %106
   %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
   %110 = load i32, i32 addrspace(1)* %109, align 8
   %111 = add i32 %104, %110
-  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %112
 
 ; <label>:112                                     ; preds = %108
   %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
   store i32 %111, i32 addrspace(1)* %113
   %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
-  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i32 addrspace(1)* %114, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %115
 
 ; <label>:115                                     ; preds = %112
   %116 = load i32, i32 addrspace(1)* %114, align 8
@@ -7681,19 +9094,19 @@ entry:
 ; <label>:118                                     ; preds = %115
   %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
-  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %121
 
 ; <label>:121                                     ; preds = %118
   %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
-  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
-  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %123
 
 ; <label>:123                                     ; preds = %121
   %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
   %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
-  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
-  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %126
 
 ; <label>:126                                     ; preds = %123
   %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
@@ -7705,8 +9118,8 @@ entry:
 
 ; <label>:130                                     ; preds = %80, %115, %126
   %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %132
 
 ; <label>:132                                     ; preds = %130
   %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7715,8 +9128,8 @@ entry:
   %136 = load i32, i32* %loc3
   %137 = sub i32 %135, %136
   %138 = sub i32 %134, %137
-  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %139
 
 ; <label>:139                                     ; preds = %132
   %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7728,16 +9141,16 @@ entry:
 
 ; <label>:144                                     ; preds = %139
   %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
-  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %146
 
 ; <label>:146                                     ; preds = %144
   %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
   %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
   %149 = load i32, i32* %loc2
   %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
-  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %151
 
 ; <label>:151                                     ; preds = %146
   %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
@@ -7754,145 +9167,249 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %18
+ThrowNullRef4:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %31
+ThrowNullRef10:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %44
+ThrowNullRef16:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %68
+ThrowNullRef18:                                   ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %70
+ThrowNullRef20:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %73
+ThrowNullRef22:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %83
+ThrowNullRef24:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %85
+ThrowNullRef26:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %88
+ThrowNullRef28:                                   ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %90
+ThrowNullRef30:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %94
+ThrowNullRef32:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %96
+ThrowNullRef34:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %100
+ThrowNullRef36:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %102
+ThrowNullRef38:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %106
+ThrowNullRef40:                                   ; preds = %106
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %108
+ThrowNullRef42:                                   ; preds = %108
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %112
+ThrowNullRef44:                                   ; preds = %112
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %118
+ThrowNullRef46:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %121
+ThrowNullRef48:                                   ; preds = %121
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %123
+ThrowNullRef50:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %130
+ThrowNullRef52:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %132
+ThrowNullRef54:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %144
+ThrowNullRef56:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %146
+ThrowNullRef58:                                   ; preds = %146
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %60
+ThrowNullRef60:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %63
+ThrowNullRef62:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %49
+ThrowNullRef64:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %51
+ThrowNullRef66:                                   ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %53
+ThrowNullRef68:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(%"System.Char[]" addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %arg0 = alloca %"System.Char[]" addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store %"System.Char[]" addrspace(1)* %param0, %"System.Char[]" addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load i32, i32* %arg4
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %43, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %38, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg1
+  %13 = load i32, i32* %arg4
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %38, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %24 = load i32, i32* %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %35 = load i32, i32* %arg3
+  %36 = load i32, i32* %arg4
+  %37 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %37, %"System.Char[]" addrspace(1)* %34, i32 %35, i32 %36)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:38                                      ; preds = %5, %16
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Successfully read Buffer._Memmove
 
@@ -7914,7 +9431,7 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[loadElem]
+Failed to read AppDomain.SetDataHelper[storeElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -7923,8 +9440,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
@@ -7934,8 +9451,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
@@ -7947,15 +9464,15 @@ entry:
   %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
   %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
@@ -7966,15 +9483,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7992,7 +9509,79 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
-Failed to read Dictionary`2.TryGetValue[loadElemA]
+Successfully read Dictionary`2.TryGetValue
+
+define i8 @"Dictionary`2.TryGetValue"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)* addrspace(1)* %param2) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  %arg2 = alloca %System.__Canon addrspace(1)* addrspace(1)*
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  store %System.__Canon addrspace(1)* addrspace(1)* %param2, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  store i32 %2, i32* %loc0
+  %3 = load i32, i32* %loc0
+  %4 = icmp slt i32 %3, 0
+  br i1 %4, label %22, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 2
+  %10 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %9, align 8
+  %11 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = zext i32 %11 to i64
+  %BoundsCheck = icmp uge i64 %16, %15
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 3, i32 %11
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %20, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %6, %System.__Canon addrspace(1)* %21)
+  ret i8 1
+
+; <label>:22                                      ; preds = %entry
+  %23 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %23, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -8058,8 +9647,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
@@ -8091,8 +9680,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
@@ -8171,15 +9760,15 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck, label %19, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %ThrowNullRef, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
   %21 = load i32, i32 addrspace(1)* %20
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
@@ -8202,7 +9791,7 @@ ThrowNullRef:                                     ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %19
+ThrowNullRef2:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8248,8 +9837,8 @@ entry:
   %0 = alloca %System.AppDomainHandle
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %1 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %1, i32 0, i32 15
@@ -8269,8 +9858,8 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
@@ -8286,7 +9875,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -8299,8 +9888,8 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -8327,8 +9916,8 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
@@ -8352,8 +9941,8 @@ entry:
   %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
   store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
@@ -8363,8 +9952,8 @@ entry:
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
@@ -8374,8 +9963,8 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %9
   %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
@@ -8384,8 +9973,8 @@ entry:
 
 ; <label>:18                                      ; preds = %3, %16
   %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
@@ -8397,15 +9986,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %18
+ThrowNullRef6:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8418,8 +10007,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
@@ -8453,15 +10042,15 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
@@ -8473,7 +10062,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8481,7 +10070,7 @@ ThrowNullRef1:                                    ; preds = %1
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
 Failed to read Dictionary`2.System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
@@ -8506,8 +10095,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
@@ -8524,8 +10113,8 @@ entry:
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -8544,7 +10133,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8577,8 +10166,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = load i64, i64* %arg2
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = trunc i32 %3 to i8
@@ -8634,46 +10223,46 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
   %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
-  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
-  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
-  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
@@ -8684,27 +10273,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %20
+ThrowNullRef12:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8717,8 +10306,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -8756,22 +10345,22 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
   %9 = load i64, i64 addrspace(1)* %8, align 8
   %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
   %13 = load i64, i64 addrspace(1)* %12, align 8
   %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %11
   %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
@@ -8788,11 +10377,11 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8882,8 +10471,8 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
@@ -8900,8 +10489,8 @@ entry:
 ; <label>:8                                       ; preds = %1
   %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
   %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
@@ -8911,15 +10500,15 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
   %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
   %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
-  br i1 %NullCheck6, label %21, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
@@ -8946,15 +10535,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8992,15 +10581,15 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
   store i8 %3, i8 addrspace(1)* %5
   %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
@@ -9011,7 +10600,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9027,8 +10616,8 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -9041,8 +10630,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
@@ -9058,7 +10647,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9080,8 +10669,8 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
@@ -9096,8 +10685,8 @@ entry:
 ; <label>:12                                      ; preds = %6
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
@@ -9112,8 +10701,8 @@ entry:
 ; <label>:21                                      ; preds = %15
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
@@ -9128,8 +10717,8 @@ entry:
 ; <label>:30                                      ; preds = %24
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %31, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
@@ -9144,8 +10733,8 @@ entry:
 ; <label>:39                                      ; preds = %33
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
-  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %40, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %42
 
 ; <label>:42                                      ; preds = %39
   %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
@@ -9164,19 +10753,19 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %21
+ThrowNullRef4:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %30
+ThrowNullRef6:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %39
+ThrowNullRef8:                                    ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9243,8 +10832,8 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
@@ -9264,57 +10853,57 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
   store i8 0, i8 addrspace(1)* %2
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
   store i8 0, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
   store i8 0, i8 addrspace(1)* %17
   %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
   store i8 0, i8 addrspace(1)* %20
   %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
-  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
@@ -9325,31 +10914,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %19
+ThrowNullRef14:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9367,8 +10956,8 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
@@ -9380,8 +10969,8 @@ entry:
 
 ; <label>:9                                       ; preds = %4
   %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %9
   %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
@@ -9395,7 +10984,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef2:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9420,8 +11009,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
@@ -9512,8 +11101,8 @@ entry:
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
@@ -9524,8 +11113,8 @@ entry:
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = load i64, i64 addrspace(1)* %12
@@ -9537,8 +11126,8 @@ entry:
   %20 = load i64, i64* %19
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
-  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %13
   %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
@@ -9555,8 +11144,8 @@ entry:
 ; <label>:30                                      ; preds = %25
   %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %32 = load i32, i32* %arg2
-  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
-  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
@@ -9570,15 +11159,15 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %30
+ThrowNullRef2:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9622,87 +11211,87 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
   %10 = load i8, i8 addrspace(1)* %9, align 8
   %11 = zext i8 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %8
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
   store i8 %12, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
   %19 = load i8, i8 addrspace(1)* %18, align 8
   %20 = zext i8 %19 to i32
   %21 = trunc i32 %20 to i8
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
   store i8 %21, i8 addrspace(1)* %23
   %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
   %28 = load i8, i8 addrspace(1)* %27, align 8
   %29 = zext i8 %28 to i32
   %30 = trunc i32 %29 to i8
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
-  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %31
 
 ; <label>:31                                      ; preds = %26
   %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
   store i8 %30, i8 addrspace(1)* %32
   %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
-  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
-  br i1 %NullCheck14, label %40, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %40
 
 ; <label>:40                                      ; preds = %35
   %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
   store i8 %39, i8 addrspace(1)* %41
   %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
-  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %44
 
 ; <label>:44                                      ; preds = %40
   %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
   %46 = load i8, i8 addrspace(1)* %45, align 8
   %47 = zext i8 %46 to i32
   %48 = trunc i32 %47 to i8
-  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
   store i8 %48, i8 addrspace(1)* %50
   %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
-  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
@@ -9713,29 +11302,29 @@ entry:
 ; <label>:56                                      ; preds = %52
   %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
-  br i1 %NullCheck22, label %59, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
   %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
   %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
-  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
-  br i1 %NullCheck24, label %63, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
   %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
-  br i1 %NullCheck26, label %66, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
   %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
-  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
-  br i1 %NullCheck28, label %69, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %69
 
 ; <label>:69                                      ; preds = %66
   %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
@@ -9744,15 +11333,15 @@ entry:
 
 ; <label>:71                                      ; preds = %105
   %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
-  br i1 %NullCheck34, label %73, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %73
 
 ; <label>:73                                      ; preds = %71
   %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
   %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
   %76 = load i32, i32* %loc0
-  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
-  br i1 %NullCheck36, label %77, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
@@ -9766,8 +11355,8 @@ entry:
 
 ; <label>:83                                      ; preds = %77
   %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
-  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
@@ -9775,14 +11364,14 @@ entry:
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
   %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
-  br i1 %NullCheck40, label %91, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
 ; <label>:91                                      ; preds = %85
   %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
   %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
-  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck42, label %94, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %94
 
 ; <label>:94                                      ; preds = %91
   %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
@@ -9798,14 +11387,14 @@ entry:
 ; <label>:99                                      ; preds = %69, %96
   %100 = load i32, i32* %loc0
   %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
-  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %102
 
 ; <label>:102                                     ; preds = %99
   %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
   %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
-  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
-  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
@@ -9819,87 +11408,87 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %26
+ThrowNullRef10:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %31
+ThrowNullRef12:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %35
+ThrowNullRef14:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %40
+ThrowNullRef16:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %56
+ThrowNullRef22:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %59
+ThrowNullRef24:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %63
+ThrowNullRef26:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %66
+ThrowNullRef28:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %102
+ThrowNullRef32:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %71
+ThrowNullRef34:                                   ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %73
+ThrowNullRef36:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %83
+ThrowNullRef38:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %85
+ThrowNullRef40:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %91
+ThrowNullRef42:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9943,15 +11532,15 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
   %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
@@ -9961,28 +11550,28 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
   %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %12
   %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
   %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
   %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
-  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
@@ -9993,23 +11582,23 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %12
+ThrowNullRef6:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10031,15 +11620,15 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
   %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = load i64, i64 addrspace(1)* %7
@@ -10077,13 +11666,13 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[loadElem]
+Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -10111,8 +11700,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -10184,8 +11773,8 @@ entry:
   store i32 addrspace(1)* %param1, i32 addrspace(1)** %arg1
   %0 = load i32, i32* %arg0
   %1 = load i32 addrspace(1)*, i32 addrspace(1)** %arg1
-  %NullCheck = icmp ne i32 addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq i32 addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load i32, i32 addrspace(1)* %1, align 8

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Args4.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Args4.error.txt
@@ -25,8 +25,8 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
@@ -40,8 +40,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
   %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
@@ -75,7 +75,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -90,8 +90,8 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %NullCheck = icmp ne i8 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = load i8, i8 addrspace(1)* %0, align 8
@@ -125,8 +125,8 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
@@ -159,8 +159,8 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -184,8 +184,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
   store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
@@ -195,8 +195,8 @@ entry:
 ; <label>:4                                       ; preds = %1
   %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
   %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
@@ -206,8 +206,8 @@ entry:
   %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
@@ -221,14 +221,14 @@ entry:
 
 ; <label>:17                                      ; preds = %14
   %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
   %21 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
@@ -238,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -249,8 +249,8 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
@@ -261,27 +261,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %30
+ThrowNullRef10:                                   ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -301,7 +301,89 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
-Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
+Successfully read AppDomainSetup.GetUnsecureApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.GetUnsecureApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %NullCheck = icmp eq %"System.String[]" addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %BoundsCheck = icmp uge i64 0, %5
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %6
+
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 3, i32 0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
+  ret %System.String addrspace(1)* %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_Value using LLILCJit
+Successfully read AppDomainSetup.get_Value
+
+define %"System.String[]" addrspace(1)* @AppDomainSetup.get_Value(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.String[]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 18)
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.String[]" addrspace(1)* addrspace(1)*, %"System.String[]" addrspace(1)*)*)(%"System.String[]" addrspace(1)* addrspace(1)* %9, %"System.String[]" addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %11, i32 0, i32 1
+  %14 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %13, align 8
+  ret %"System.String[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -319,8 +401,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -368,16 +450,16 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
   %5 = load i32, i32 addrspace(1)* %4
   %6 = sub i32 %5, 1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -389,7 +471,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -421,8 +503,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
@@ -456,8 +538,8 @@ entry:
 ; <label>:27                                      ; preds = %19
   %28 = load i32, i32* %arg1
   %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
-  br i1 %NullCheck2, label %30, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %29, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %30
 
 ; <label>:30                                      ; preds = %27
   %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
@@ -493,8 +575,8 @@ entry:
 ; <label>:49                                      ; preds = %46
   %50 = load i32, i32* %arg2
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck4, label %52, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
@@ -517,11 +599,11 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %27
+ThrowNullRef2:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %49
+ThrowNullRef4:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -544,16 +626,16 @@ entry:
   %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %0)
   store %System.String addrspace(1)* %1, %System.String addrspace(1)** %loc0
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 2
   %5 = bitcast [0 x i16] addrspace(1)* %4 to i16 addrspace(1)*
   store i16 addrspace(1)* %5, i16 addrspace(1)** %loc1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %3
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2
@@ -580,7 +662,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -691,15 +773,15 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %NullCheck132 = icmp ne i8* %21, null
-  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+  %NullCheck131 = icmp eq i8* %21, null
+  br i1 %NullCheck131, label %ThrowNullRef132, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = load i8, i8* %21, align 8
   %24 = zext i8 %23 to i32
   %25 = trunc i32 %24 to i8
-  %NullCheck134 = icmp ne i8* %20, null
-  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+  %NullCheck133 = icmp eq i8* %20, null
+  br i1 %NullCheck133, label %ThrowNullRef134, label %26
 
 ; <label>:26                                      ; preds = %22
   store i8 %25, i8* %20, align 8
@@ -709,16 +791,16 @@ entry:
   %28 = load i8*, i8** %arg0
   %29 = load i8*, i8** %arg1
   %30 = bitcast i8* %29 to i16*
-  %NullCheck128 = icmp ne i16* %30, null
-  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+  %NullCheck127 = icmp eq i16* %30, null
+  br i1 %NullCheck127, label %ThrowNullRef128, label %31
 
 ; <label>:31                                      ; preds = %27
   %32 = load i16, i16* %30, align 8
   %33 = sext i16 %32 to i32
   %34 = bitcast i8* %28 to i16*
   %35 = trunc i32 %33 to i16
-  %NullCheck130 = icmp ne i16* %34, null
-  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+  %NullCheck129 = icmp eq i16* %34, null
+  br i1 %NullCheck129, label %ThrowNullRef130, label %36
 
 ; <label>:36                                      ; preds = %31
   store i16 %35, i16* %34, align 8
@@ -728,16 +810,16 @@ entry:
   %38 = load i8*, i8** %arg0
   %39 = load i8*, i8** %arg1
   %40 = bitcast i8* %39 to i16*
-  %NullCheck120 = icmp ne i16* %40, null
-  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+  %NullCheck119 = icmp eq i16* %40, null
+  br i1 %NullCheck119, label %ThrowNullRef120, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i16, i16* %40, align 8
   %43 = sext i16 %42 to i32
   %44 = bitcast i8* %38 to i16*
   %45 = trunc i32 %43 to i16
-  %NullCheck122 = icmp ne i16* %44, null
-  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+  %NullCheck121 = icmp eq i16* %44, null
+  br i1 %NullCheck121, label %ThrowNullRef122, label %46
 
 ; <label>:46                                      ; preds = %41
   store i16 %45, i16* %44, align 8
@@ -745,15 +827,15 @@ entry:
   %48 = getelementptr inbounds i8, i8* %47, i64 2
   %49 = load i8*, i8** %arg1
   %50 = getelementptr inbounds i8, i8* %49, i64 2
-  %NullCheck124 = icmp ne i8* %50, null
-  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+  %NullCheck123 = icmp eq i8* %50, null
+  br i1 %NullCheck123, label %ThrowNullRef124, label %51
 
 ; <label>:51                                      ; preds = %46
   %52 = load i8, i8* %50, align 8
   %53 = zext i8 %52 to i32
   %54 = trunc i32 %53 to i8
-  %NullCheck126 = icmp ne i8* %48, null
-  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+  %NullCheck125 = icmp eq i8* %48, null
+  br i1 %NullCheck125, label %ThrowNullRef126, label %55
 
 ; <label>:55                                      ; preds = %51
   store i8 %54, i8* %48, align 8
@@ -763,14 +845,14 @@ entry:
   %57 = load i8*, i8** %arg0
   %58 = load i8*, i8** %arg1
   %59 = bitcast i8* %58 to i32*
-  %NullCheck116 = icmp ne i32* %59, null
-  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+  %NullCheck115 = icmp eq i32* %59, null
+  br i1 %NullCheck115, label %ThrowNullRef116, label %60
 
 ; <label>:60                                      ; preds = %56
   %61 = load i32, i32* %59, align 8
   %62 = bitcast i8* %57 to i32*
-  %NullCheck118 = icmp ne i32* %62, null
-  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+  %NullCheck117 = icmp eq i32* %62, null
+  br i1 %NullCheck117, label %ThrowNullRef118, label %63
 
 ; <label>:63                                      ; preds = %60
   store i32 %61, i32* %62, align 8
@@ -780,14 +862,14 @@ entry:
   %65 = load i8*, i8** %arg0
   %66 = load i8*, i8** %arg1
   %67 = bitcast i8* %66 to i32*
-  %NullCheck108 = icmp ne i32* %67, null
-  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+  %NullCheck107 = icmp eq i32* %67, null
+  br i1 %NullCheck107, label %ThrowNullRef108, label %68
 
 ; <label>:68                                      ; preds = %64
   %69 = load i32, i32* %67, align 8
   %70 = bitcast i8* %65 to i32*
-  %NullCheck110 = icmp ne i32* %70, null
-  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+  %NullCheck109 = icmp eq i32* %70, null
+  br i1 %NullCheck109, label %ThrowNullRef110, label %71
 
 ; <label>:71                                      ; preds = %68
   store i32 %69, i32* %70, align 8
@@ -795,15 +877,15 @@ entry:
   %73 = getelementptr inbounds i8, i8* %72, i64 4
   %74 = load i8*, i8** %arg1
   %75 = getelementptr inbounds i8, i8* %74, i64 4
-  %NullCheck112 = icmp ne i8* %75, null
-  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+  %NullCheck111 = icmp eq i8* %75, null
+  br i1 %NullCheck111, label %ThrowNullRef112, label %76
 
 ; <label>:76                                      ; preds = %71
   %77 = load i8, i8* %75, align 8
   %78 = zext i8 %77 to i32
   %79 = trunc i32 %78 to i8
-  %NullCheck114 = icmp ne i8* %73, null
-  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+  %NullCheck113 = icmp eq i8* %73, null
+  br i1 %NullCheck113, label %ThrowNullRef114, label %80
 
 ; <label>:80                                      ; preds = %76
   store i8 %79, i8* %73, align 8
@@ -813,14 +895,14 @@ entry:
   %82 = load i8*, i8** %arg0
   %83 = load i8*, i8** %arg1
   %84 = bitcast i8* %83 to i32*
-  %NullCheck100 = icmp ne i32* %84, null
-  br i1 %NullCheck100, label %85, label %ThrowNullRef99
+  %NullCheck99 = icmp eq i32* %84, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %85
 
 ; <label>:85                                      ; preds = %81
   %86 = load i32, i32* %84, align 8
   %87 = bitcast i8* %82 to i32*
-  %NullCheck102 = icmp ne i32* %87, null
-  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+  %NullCheck101 = icmp eq i32* %87, null
+  br i1 %NullCheck101, label %ThrowNullRef102, label %88
 
 ; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
@@ -829,16 +911,16 @@ entry:
   %91 = load i8*, i8** %arg1
   %92 = getelementptr inbounds i8, i8* %91, i64 4
   %93 = bitcast i8* %92 to i16*
-  %NullCheck104 = icmp ne i16* %93, null
-  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+  %NullCheck103 = icmp eq i16* %93, null
+  br i1 %NullCheck103, label %ThrowNullRef104, label %94
 
 ; <label>:94                                      ; preds = %88
   %95 = load i16, i16* %93, align 8
   %96 = sext i16 %95 to i32
   %97 = bitcast i8* %90 to i16*
   %98 = trunc i32 %96 to i16
-  %NullCheck106 = icmp ne i16* %97, null
-  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+  %NullCheck105 = icmp eq i16* %97, null
+  br i1 %NullCheck105, label %ThrowNullRef106, label %99
 
 ; <label>:99                                      ; preds = %94
   store i16 %98, i16* %97, align 8
@@ -848,14 +930,14 @@ entry:
   %101 = load i8*, i8** %arg0
   %102 = load i8*, i8** %arg1
   %103 = bitcast i8* %102 to i32*
-  %NullCheck88 = icmp ne i32* %103, null
-  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+  %NullCheck87 = icmp eq i32* %103, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %104
 
 ; <label>:104                                     ; preds = %100
   %105 = load i32, i32* %103, align 8
   %106 = bitcast i8* %101 to i32*
-  %NullCheck90 = icmp ne i32* %106, null
-  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+  %NullCheck89 = icmp eq i32* %106, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %107
 
 ; <label>:107                                     ; preds = %104
   store i32 %105, i32* %106, align 8
@@ -864,16 +946,16 @@ entry:
   %110 = load i8*, i8** %arg1
   %111 = getelementptr inbounds i8, i8* %110, i64 4
   %112 = bitcast i8* %111 to i16*
-  %NullCheck92 = icmp ne i16* %112, null
-  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+  %NullCheck91 = icmp eq i16* %112, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %113
 
 ; <label>:113                                     ; preds = %107
   %114 = load i16, i16* %112, align 8
   %115 = sext i16 %114 to i32
   %116 = bitcast i8* %109 to i16*
   %117 = trunc i32 %115 to i16
-  %NullCheck94 = icmp ne i16* %116, null
-  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+  %NullCheck93 = icmp eq i16* %116, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %118
 
 ; <label>:118                                     ; preds = %113
   store i16 %117, i16* %116, align 8
@@ -881,15 +963,15 @@ entry:
   %120 = getelementptr inbounds i8, i8* %119, i64 6
   %121 = load i8*, i8** %arg1
   %122 = getelementptr inbounds i8, i8* %121, i64 6
-  %NullCheck96 = icmp ne i8* %122, null
-  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+  %NullCheck95 = icmp eq i8* %122, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %123
 
 ; <label>:123                                     ; preds = %118
   %124 = load i8, i8* %122, align 8
   %125 = zext i8 %124 to i32
   %126 = trunc i32 %125 to i8
-  %NullCheck98 = icmp ne i8* %120, null
-  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+  %NullCheck97 = icmp eq i8* %120, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %127
 
 ; <label>:127                                     ; preds = %123
   store i8 %126, i8* %120, align 8
@@ -899,14 +981,14 @@ entry:
   %129 = load i8*, i8** %arg0
   %130 = load i8*, i8** %arg1
   %131 = bitcast i8* %130 to i64*
-  %NullCheck84 = icmp ne i64* %131, null
-  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+  %NullCheck83 = icmp eq i64* %131, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %132
 
 ; <label>:132                                     ; preds = %128
   %133 = load i64, i64* %131, align 8
   %134 = bitcast i8* %129 to i64*
-  %NullCheck86 = icmp ne i64* %134, null
-  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+  %NullCheck85 = icmp eq i64* %134, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %135
 
 ; <label>:135                                     ; preds = %132
   store i64 %133, i64* %134, align 8
@@ -916,14 +998,14 @@ entry:
   %137 = load i8*, i8** %arg0
   %138 = load i8*, i8** %arg1
   %139 = bitcast i8* %138 to i64*
-  %NullCheck76 = icmp ne i64* %139, null
-  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+  %NullCheck75 = icmp eq i64* %139, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %140
 
 ; <label>:140                                     ; preds = %136
   %141 = load i64, i64* %139, align 8
   %142 = bitcast i8* %137 to i64*
-  %NullCheck78 = icmp ne i64* %142, null
-  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+  %NullCheck77 = icmp eq i64* %142, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %143
 
 ; <label>:143                                     ; preds = %140
   store i64 %141, i64* %142, align 8
@@ -931,15 +1013,15 @@ entry:
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %NullCheck80 = icmp ne i8* %147, null
-  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+  %NullCheck79 = icmp eq i8* %147, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %148
 
 ; <label>:148                                     ; preds = %143
   %149 = load i8, i8* %147, align 8
   %150 = zext i8 %149 to i32
   %151 = trunc i32 %150 to i8
-  %NullCheck82 = icmp ne i8* %145, null
-  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+  %NullCheck81 = icmp eq i8* %145, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %152
 
 ; <label>:152                                     ; preds = %148
   store i8 %151, i8* %145, align 8
@@ -949,14 +1031,14 @@ entry:
   %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
   %156 = bitcast i8* %155 to i64*
-  %NullCheck68 = icmp ne i64* %156, null
-  br i1 %NullCheck68, label %157, label %ThrowNullRef67
+  %NullCheck67 = icmp eq i64* %156, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %157
 
 ; <label>:157                                     ; preds = %153
   %158 = load i64, i64* %156, align 8
   %159 = bitcast i8* %154 to i64*
-  %NullCheck70 = icmp ne i64* %159, null
-  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+  %NullCheck69 = icmp eq i64* %159, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %160
 
 ; <label>:160                                     ; preds = %157
   store i64 %158, i64* %159, align 8
@@ -965,16 +1047,16 @@ entry:
   %163 = load i8*, i8** %arg1
   %164 = getelementptr inbounds i8, i8* %163, i64 8
   %165 = bitcast i8* %164 to i16*
-  %NullCheck72 = icmp ne i16* %165, null
-  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+  %NullCheck71 = icmp eq i16* %165, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %166
 
 ; <label>:166                                     ; preds = %160
   %167 = load i16, i16* %165, align 8
   %168 = sext i16 %167 to i32
   %169 = bitcast i8* %162 to i16*
   %170 = trunc i32 %168 to i16
-  %NullCheck74 = icmp ne i16* %169, null
-  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+  %NullCheck73 = icmp eq i16* %169, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %171
 
 ; <label>:171                                     ; preds = %166
   store i16 %170, i16* %169, align 8
@@ -984,14 +1066,14 @@ entry:
   %173 = load i8*, i8** %arg0
   %174 = load i8*, i8** %arg1
   %175 = bitcast i8* %174 to i64*
-  %NullCheck56 = icmp ne i64* %175, null
-  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+  %NullCheck55 = icmp eq i64* %175, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %176
 
 ; <label>:176                                     ; preds = %172
   %177 = load i64, i64* %175, align 8
   %178 = bitcast i8* %173 to i64*
-  %NullCheck58 = icmp ne i64* %178, null
-  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+  %NullCheck57 = icmp eq i64* %178, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %179
 
 ; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
@@ -1000,16 +1082,16 @@ entry:
   %182 = load i8*, i8** %arg1
   %183 = getelementptr inbounds i8, i8* %182, i64 8
   %184 = bitcast i8* %183 to i16*
-  %NullCheck60 = icmp ne i16* %184, null
-  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+  %NullCheck59 = icmp eq i16* %184, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %185
 
 ; <label>:185                                     ; preds = %179
   %186 = load i16, i16* %184, align 8
   %187 = sext i16 %186 to i32
   %188 = bitcast i8* %181 to i16*
   %189 = trunc i32 %187 to i16
-  %NullCheck62 = icmp ne i16* %188, null
-  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+  %NullCheck61 = icmp eq i16* %188, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %190
 
 ; <label>:190                                     ; preds = %185
   store i16 %189, i16* %188, align 8
@@ -1017,15 +1099,15 @@ entry:
   %192 = getelementptr inbounds i8, i8* %191, i64 10
   %193 = load i8*, i8** %arg1
   %194 = getelementptr inbounds i8, i8* %193, i64 10
-  %NullCheck64 = icmp ne i8* %194, null
-  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+  %NullCheck63 = icmp eq i8* %194, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %195
 
 ; <label>:195                                     ; preds = %190
   %196 = load i8, i8* %194, align 8
   %197 = zext i8 %196 to i32
   %198 = trunc i32 %197 to i8
-  %NullCheck66 = icmp ne i8* %192, null
-  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+  %NullCheck65 = icmp eq i8* %192, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %199
 
 ; <label>:199                                     ; preds = %195
   store i8 %198, i8* %192, align 8
@@ -1035,14 +1117,14 @@ entry:
   %201 = load i8*, i8** %arg0
   %202 = load i8*, i8** %arg1
   %203 = bitcast i8* %202 to i64*
-  %NullCheck48 = icmp ne i64* %203, null
-  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+  %NullCheck47 = icmp eq i64* %203, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %204
 
 ; <label>:204                                     ; preds = %200
   %205 = load i64, i64* %203, align 8
   %206 = bitcast i8* %201 to i64*
-  %NullCheck50 = icmp ne i64* %206, null
-  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+  %NullCheck49 = icmp eq i64* %206, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %207
 
 ; <label>:207                                     ; preds = %204
   store i64 %205, i64* %206, align 8
@@ -1051,14 +1133,14 @@ entry:
   %210 = load i8*, i8** %arg1
   %211 = getelementptr inbounds i8, i8* %210, i64 8
   %212 = bitcast i8* %211 to i32*
-  %NullCheck52 = icmp ne i32* %212, null
-  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+  %NullCheck51 = icmp eq i32* %212, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %213
 
 ; <label>:213                                     ; preds = %207
   %214 = load i32, i32* %212, align 8
   %215 = bitcast i8* %209 to i32*
-  %NullCheck54 = icmp ne i32* %215, null
-  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+  %NullCheck53 = icmp eq i32* %215, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %216
 
 ; <label>:216                                     ; preds = %213
   store i32 %214, i32* %215, align 8
@@ -1068,14 +1150,14 @@ entry:
   %218 = load i8*, i8** %arg0
   %219 = load i8*, i8** %arg1
   %220 = bitcast i8* %219 to i64*
-  %NullCheck36 = icmp ne i64* %220, null
-  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64* %220, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %221
 
 ; <label>:221                                     ; preds = %217
   %222 = load i64, i64* %220, align 8
   %223 = bitcast i8* %218 to i64*
-  %NullCheck38 = icmp ne i64* %223, null
-  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+  %NullCheck37 = icmp eq i64* %223, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %224
 
 ; <label>:224                                     ; preds = %221
   store i64 %222, i64* %223, align 8
@@ -1084,14 +1166,14 @@ entry:
   %227 = load i8*, i8** %arg1
   %228 = getelementptr inbounds i8, i8* %227, i64 8
   %229 = bitcast i8* %228 to i32*
-  %NullCheck40 = icmp ne i32* %229, null
-  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i32* %229, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %230
 
 ; <label>:230                                     ; preds = %224
   %231 = load i32, i32* %229, align 8
   %232 = bitcast i8* %226 to i32*
-  %NullCheck42 = icmp ne i32* %232, null
-  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+  %NullCheck41 = icmp eq i32* %232, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %233
 
 ; <label>:233                                     ; preds = %230
   store i32 %231, i32* %232, align 8
@@ -1099,15 +1181,15 @@ entry:
   %235 = getelementptr inbounds i8, i8* %234, i64 12
   %236 = load i8*, i8** %arg1
   %237 = getelementptr inbounds i8, i8* %236, i64 12
-  %NullCheck44 = icmp ne i8* %237, null
-  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i8* %237, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %238
 
 ; <label>:238                                     ; preds = %233
   %239 = load i8, i8* %237, align 8
   %240 = zext i8 %239 to i32
   %241 = trunc i32 %240 to i8
-  %NullCheck46 = icmp ne i8* %235, null
-  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+  %NullCheck45 = icmp eq i8* %235, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %242
 
 ; <label>:242                                     ; preds = %238
   store i8 %241, i8* %235, align 8
@@ -1117,14 +1199,14 @@ entry:
   %244 = load i8*, i8** %arg0
   %245 = load i8*, i8** %arg1
   %246 = bitcast i8* %245 to i64*
-  %NullCheck24 = icmp ne i64* %246, null
-  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64* %246, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %247
 
 ; <label>:247                                     ; preds = %243
   %248 = load i64, i64* %246, align 8
   %249 = bitcast i8* %244 to i64*
-  %NullCheck26 = icmp ne i64* %249, null
-  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64* %249, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %250
 
 ; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
@@ -1133,14 +1215,14 @@ entry:
   %253 = load i8*, i8** %arg1
   %254 = getelementptr inbounds i8, i8* %253, i64 8
   %255 = bitcast i8* %254 to i32*
-  %NullCheck28 = icmp ne i32* %255, null
-  br i1 %NullCheck28, label %256, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i32* %255, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %256
 
 ; <label>:256                                     ; preds = %250
   %257 = load i32, i32* %255, align 8
   %258 = bitcast i8* %252 to i32*
-  %NullCheck30 = icmp ne i32* %258, null
-  br i1 %NullCheck30, label %259, label %ThrowNullRef29
+  %NullCheck29 = icmp eq i32* %258, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %259
 
 ; <label>:259                                     ; preds = %256
   store i32 %257, i32* %258, align 8
@@ -1149,16 +1231,16 @@ entry:
   %262 = load i8*, i8** %arg1
   %263 = getelementptr inbounds i8, i8* %262, i64 12
   %264 = bitcast i8* %263 to i16*
-  %NullCheck32 = icmp ne i16* %264, null
-  br i1 %NullCheck32, label %265, label %ThrowNullRef31
+  %NullCheck31 = icmp eq i16* %264, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %265
 
 ; <label>:265                                     ; preds = %259
   %266 = load i16, i16* %264, align 8
   %267 = sext i16 %266 to i32
   %268 = bitcast i8* %261 to i16*
   %269 = trunc i32 %267 to i16
-  %NullCheck34 = icmp ne i16* %268, null
-  br i1 %NullCheck34, label %270, label %ThrowNullRef33
+  %NullCheck33 = icmp eq i16* %268, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %270
 
 ; <label>:270                                     ; preds = %265
   store i16 %269, i16* %268, align 8
@@ -1168,14 +1250,14 @@ entry:
   %272 = load i8*, i8** %arg0
   %273 = load i8*, i8** %arg1
   %274 = bitcast i8* %273 to i64*
-  %NullCheck8 = icmp ne i64* %274, null
-  br i1 %NullCheck8, label %275, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64* %274, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %275
 
 ; <label>:275                                     ; preds = %271
   %276 = load i64, i64* %274, align 8
   %277 = bitcast i8* %272 to i64*
-  %NullCheck10 = icmp ne i64* %277, null
-  br i1 %NullCheck10, label %278, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %277, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %278
 
 ; <label>:278                                     ; preds = %275
   store i64 %276, i64* %277, align 8
@@ -1184,14 +1266,14 @@ entry:
   %281 = load i8*, i8** %arg1
   %282 = getelementptr inbounds i8, i8* %281, i64 8
   %283 = bitcast i8* %282 to i32*
-  %NullCheck12 = icmp ne i32* %283, null
-  br i1 %NullCheck12, label %284, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i32* %283, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %284
 
 ; <label>:284                                     ; preds = %278
   %285 = load i32, i32* %283, align 8
   %286 = bitcast i8* %280 to i32*
-  %NullCheck14 = icmp ne i32* %286, null
-  br i1 %NullCheck14, label %287, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i32* %286, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %287
 
 ; <label>:287                                     ; preds = %284
   store i32 %285, i32* %286, align 8
@@ -1200,16 +1282,16 @@ entry:
   %290 = load i8*, i8** %arg1
   %291 = getelementptr inbounds i8, i8* %290, i64 12
   %292 = bitcast i8* %291 to i16*
-  %NullCheck16 = icmp ne i16* %292, null
-  br i1 %NullCheck16, label %293, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i16* %292, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %293
 
 ; <label>:293                                     ; preds = %287
   %294 = load i16, i16* %292, align 8
   %295 = sext i16 %294 to i32
   %296 = bitcast i8* %289 to i16*
   %297 = trunc i32 %295 to i16
-  %NullCheck18 = icmp ne i16* %296, null
-  br i1 %NullCheck18, label %298, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i16* %296, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %298
 
 ; <label>:298                                     ; preds = %293
   store i16 %297, i16* %296, align 8
@@ -1217,15 +1299,15 @@ entry:
   %300 = getelementptr inbounds i8, i8* %299, i64 14
   %301 = load i8*, i8** %arg1
   %302 = getelementptr inbounds i8, i8* %301, i64 14
-  %NullCheck20 = icmp ne i8* %302, null
-  br i1 %NullCheck20, label %303, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i8* %302, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %303
 
 ; <label>:303                                     ; preds = %298
   %304 = load i8, i8* %302, align 8
   %305 = zext i8 %304 to i32
   %306 = trunc i32 %305 to i8
-  %NullCheck22 = icmp ne i8* %300, null
-  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i8* %300, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %307
 
 ; <label>:307                                     ; preds = %303
   store i8 %306, i8* %300, align 8
@@ -1235,14 +1317,14 @@ entry:
   %309 = load i8*, i8** %arg0
   %310 = load i8*, i8** %arg1
   %311 = bitcast i8* %310 to i64*
-  %NullCheck = icmp ne i64* %311, null
-  br i1 %NullCheck, label %312, label %ThrowNullRef
+  %NullCheck = icmp eq i64* %311, null
+  br i1 %NullCheck, label %ThrowNullRef, label %312
 
 ; <label>:312                                     ; preds = %308
   %313 = load i64, i64* %311, align 8
   %314 = bitcast i8* %309 to i64*
-  %NullCheck2 = icmp ne i64* %314, null
-  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64* %314, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %315
 
 ; <label>:315                                     ; preds = %312
   store i64 %313, i64* %314, align 8
@@ -1251,14 +1333,14 @@ entry:
   %318 = load i8*, i8** %arg1
   %319 = getelementptr inbounds i8, i8* %318, i64 8
   %320 = bitcast i8* %319 to i64*
-  %NullCheck4 = icmp ne i64* %320, null
-  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64* %320, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %321
 
 ; <label>:321                                     ; preds = %315
   %322 = load i64, i64* %320, align 8
   %323 = bitcast i8* %317 to i64*
-  %NullCheck6 = icmp ne i64* %323, null
-  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64* %323, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %324
 
 ; <label>:324                                     ; preds = %321
   store i64 %322, i64* %323, align 8
@@ -1286,15 +1368,15 @@ entry:
 ; <label>:338                                     ; preds = %333
   %339 = load i8*, i8** %arg0
   %340 = load i8*, i8** %arg1
-  %NullCheck136 = icmp ne i8* %340, null
-  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+  %NullCheck135 = icmp eq i8* %340, null
+  br i1 %NullCheck135, label %ThrowNullRef136, label %341
 
 ; <label>:341                                     ; preds = %338
   %342 = load i8, i8* %340, align 8
   %343 = zext i8 %342 to i32
   %344 = trunc i32 %343 to i8
-  %NullCheck138 = icmp ne i8* %339, null
-  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+  %NullCheck137 = icmp eq i8* %339, null
+  br i1 %NullCheck137, label %ThrowNullRef138, label %345
 
 ; <label>:345                                     ; preds = %341
   store i8 %344, i8* %339, align 8
@@ -1317,16 +1399,16 @@ entry:
   %357 = load i8*, i8** %arg0
   %358 = load i8*, i8** %arg1
   %359 = bitcast i8* %358 to i16*
-  %NullCheck140 = icmp ne i16* %359, null
-  br i1 %NullCheck140, label %360, label %ThrowNullRef139
+  %NullCheck139 = icmp eq i16* %359, null
+  br i1 %NullCheck139, label %ThrowNullRef140, label %360
 
 ; <label>:360                                     ; preds = %356
   %361 = load i16, i16* %359, align 8
   %362 = sext i16 %361 to i32
   %363 = bitcast i8* %357 to i16*
   %364 = trunc i32 %362 to i16
-  %NullCheck142 = icmp ne i16* %363, null
-  br i1 %NullCheck142, label %365, label %ThrowNullRef141
+  %NullCheck141 = icmp eq i16* %363, null
+  br i1 %NullCheck141, label %ThrowNullRef142, label %365
 
 ; <label>:365                                     ; preds = %360
   store i16 %364, i16* %363, align 8
@@ -1352,14 +1434,14 @@ entry:
   %378 = load i8*, i8** %arg0
   %379 = load i8*, i8** %arg1
   %380 = bitcast i8* %379 to i32*
-  %NullCheck144 = icmp ne i32* %380, null
-  br i1 %NullCheck144, label %381, label %ThrowNullRef143
+  %NullCheck143 = icmp eq i32* %380, null
+  br i1 %NullCheck143, label %ThrowNullRef144, label %381
 
 ; <label>:381                                     ; preds = %377
   %382 = load i32, i32* %380, align 8
   %383 = bitcast i8* %378 to i32*
-  %NullCheck146 = icmp ne i32* %383, null
-  br i1 %NullCheck146, label %384, label %ThrowNullRef145
+  %NullCheck145 = icmp eq i32* %383, null
+  br i1 %NullCheck145, label %ThrowNullRef146, label %384
 
 ; <label>:384                                     ; preds = %381
   store i32 %382, i32* %383, align 8
@@ -1384,14 +1466,14 @@ entry:
   %395 = load i8*, i8** %arg0
   %396 = load i8*, i8** %arg1
   %397 = bitcast i8* %396 to i64*
-  %NullCheck164 = icmp ne i64* %397, null
-  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+  %NullCheck163 = icmp eq i64* %397, null
+  br i1 %NullCheck163, label %ThrowNullRef164, label %398
 
 ; <label>:398                                     ; preds = %394
   %399 = load i64, i64* %397, align 8
   %400 = bitcast i8* %395 to i64*
-  %NullCheck166 = icmp ne i64* %400, null
-  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+  %NullCheck165 = icmp eq i64* %400, null
+  br i1 %NullCheck165, label %ThrowNullRef166, label %401
 
 ; <label>:401                                     ; preds = %398
   store i64 %399, i64* %400, align 8
@@ -1400,14 +1482,14 @@ entry:
   %404 = load i8*, i8** %arg1
   %405 = getelementptr inbounds i8, i8* %404, i64 8
   %406 = bitcast i8* %405 to i64*
-  %NullCheck168 = icmp ne i64* %406, null
-  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+  %NullCheck167 = icmp eq i64* %406, null
+  br i1 %NullCheck167, label %ThrowNullRef168, label %407
 
 ; <label>:407                                     ; preds = %401
   %408 = load i64, i64* %406, align 8
   %409 = bitcast i8* %403 to i64*
-  %NullCheck170 = icmp ne i64* %409, null
-  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+  %NullCheck169 = icmp eq i64* %409, null
+  br i1 %NullCheck169, label %ThrowNullRef170, label %410
 
 ; <label>:410                                     ; preds = %407
   store i64 %408, i64* %409, align 8
@@ -1437,14 +1519,14 @@ entry:
   %425 = load i8*, i8** %arg0
   %426 = load i8*, i8** %arg1
   %427 = bitcast i8* %426 to i64*
-  %NullCheck148 = icmp ne i64* %427, null
-  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+  %NullCheck147 = icmp eq i64* %427, null
+  br i1 %NullCheck147, label %ThrowNullRef148, label %428
 
 ; <label>:428                                     ; preds = %424
   %429 = load i64, i64* %427, align 8
   %430 = bitcast i8* %425 to i64*
-  %NullCheck150 = icmp ne i64* %430, null
-  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+  %NullCheck149 = icmp eq i64* %430, null
+  br i1 %NullCheck149, label %ThrowNullRef150, label %431
 
 ; <label>:431                                     ; preds = %428
   store i64 %429, i64* %430, align 8
@@ -1466,14 +1548,14 @@ entry:
   %441 = load i8*, i8** %arg0
   %442 = load i8*, i8** %arg1
   %443 = bitcast i8* %442 to i32*
-  %NullCheck152 = icmp ne i32* %443, null
-  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+  %NullCheck151 = icmp eq i32* %443, null
+  br i1 %NullCheck151, label %ThrowNullRef152, label %444
 
 ; <label>:444                                     ; preds = %440
   %445 = load i32, i32* %443, align 8
   %446 = bitcast i8* %441 to i32*
-  %NullCheck154 = icmp ne i32* %446, null
-  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+  %NullCheck153 = icmp eq i32* %446, null
+  br i1 %NullCheck153, label %ThrowNullRef154, label %447
 
 ; <label>:447                                     ; preds = %444
   store i32 %445, i32* %446, align 8
@@ -1495,16 +1577,16 @@ entry:
   %457 = load i8*, i8** %arg0
   %458 = load i8*, i8** %arg1
   %459 = bitcast i8* %458 to i16*
-  %NullCheck156 = icmp ne i16* %459, null
-  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+  %NullCheck155 = icmp eq i16* %459, null
+  br i1 %NullCheck155, label %ThrowNullRef156, label %460
 
 ; <label>:460                                     ; preds = %456
   %461 = load i16, i16* %459, align 8
   %462 = sext i16 %461 to i32
   %463 = bitcast i8* %457 to i16*
   %464 = trunc i32 %462 to i16
-  %NullCheck158 = icmp ne i16* %463, null
-  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+  %NullCheck157 = icmp eq i16* %463, null
+  br i1 %NullCheck157, label %ThrowNullRef158, label %465
 
 ; <label>:465                                     ; preds = %460
   store i16 %464, i16* %463, align 8
@@ -1525,15 +1607,15 @@ entry:
 ; <label>:474                                     ; preds = %470
   %475 = load i8*, i8** %arg0
   %476 = load i8*, i8** %arg1
-  %NullCheck160 = icmp ne i8* %476, null
-  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+  %NullCheck159 = icmp eq i8* %476, null
+  br i1 %NullCheck159, label %ThrowNullRef160, label %477
 
 ; <label>:477                                     ; preds = %474
   %478 = load i8, i8* %476, align 8
   %479 = zext i8 %478 to i32
   %480 = trunc i32 %479 to i8
-  %NullCheck162 = icmp ne i8* %475, null
-  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+  %NullCheck161 = icmp eq i8* %475, null
+  br i1 %NullCheck161, label %ThrowNullRef162, label %481
 
 ; <label>:481                                     ; preds = %477
   store i8 %480, i8* %475, align 8
@@ -1553,343 +1635,343 @@ ThrowNullRef:                                     ; preds = %308
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %312
+ThrowNullRef2:                                    ; preds = %312
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %315
+ThrowNullRef4:                                    ; preds = %315
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %321
+ThrowNullRef6:                                    ; preds = %321
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %271
+ThrowNullRef8:                                    ; preds = %271
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %275
+ThrowNullRef10:                                   ; preds = %275
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %278
+ThrowNullRef12:                                   ; preds = %278
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %284
+ThrowNullRef14:                                   ; preds = %284
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %287
+ThrowNullRef16:                                   ; preds = %287
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %293
+ThrowNullRef18:                                   ; preds = %293
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %298
+ThrowNullRef20:                                   ; preds = %298
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %303
+ThrowNullRef22:                                   ; preds = %303
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %243
+ThrowNullRef24:                                   ; preds = %243
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %247
+ThrowNullRef26:                                   ; preds = %247
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %250
+ThrowNullRef28:                                   ; preds = %250
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %256
+ThrowNullRef30:                                   ; preds = %256
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %259
+ThrowNullRef32:                                   ; preds = %259
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %265
+ThrowNullRef34:                                   ; preds = %265
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %217
+ThrowNullRef36:                                   ; preds = %217
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %221
+ThrowNullRef38:                                   ; preds = %221
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %224
+ThrowNullRef40:                                   ; preds = %224
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %230
+ThrowNullRef42:                                   ; preds = %230
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %233
+ThrowNullRef44:                                   ; preds = %233
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %238
+ThrowNullRef46:                                   ; preds = %238
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %200
+ThrowNullRef48:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %204
+ThrowNullRef50:                                   ; preds = %204
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %207
+ThrowNullRef52:                                   ; preds = %207
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %213
+ThrowNullRef54:                                   ; preds = %213
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %172
+ThrowNullRef56:                                   ; preds = %172
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %176
+ThrowNullRef58:                                   ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %179
+ThrowNullRef60:                                   ; preds = %179
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %185
+ThrowNullRef62:                                   ; preds = %185
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %190
+ThrowNullRef64:                                   ; preds = %190
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %195
+ThrowNullRef66:                                   ; preds = %195
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %153
+ThrowNullRef68:                                   ; preds = %153
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %157
+ThrowNullRef70:                                   ; preds = %157
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %160
+ThrowNullRef72:                                   ; preds = %160
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %166
+ThrowNullRef74:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %136
+ThrowNullRef76:                                   ; preds = %136
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %140
+ThrowNullRef78:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %143
+ThrowNullRef80:                                   ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %148
+ThrowNullRef82:                                   ; preds = %148
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %128
+ThrowNullRef84:                                   ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %132
+ThrowNullRef86:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %100
+ThrowNullRef88:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %104
+ThrowNullRef90:                                   ; preds = %104
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %107
+ThrowNullRef92:                                   ; preds = %107
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %113
+ThrowNullRef94:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %118
+ThrowNullRef96:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %123
+ThrowNullRef98:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %81
+ThrowNullRef100:                                  ; preds = %81
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef101:                                  ; preds = %85
+ThrowNullRef102:                                  ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef103:                                  ; preds = %88
+ThrowNullRef104:                                  ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef105:                                  ; preds = %94
+ThrowNullRef106:                                  ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef107:                                  ; preds = %64
+ThrowNullRef108:                                  ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef109:                                  ; preds = %68
+ThrowNullRef110:                                  ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef111:                                  ; preds = %71
+ThrowNullRef112:                                  ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef113:                                  ; preds = %76
+ThrowNullRef114:                                  ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef115:                                  ; preds = %56
+ThrowNullRef116:                                  ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef117:                                  ; preds = %60
+ThrowNullRef118:                                  ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef119:                                  ; preds = %37
+ThrowNullRef120:                                  ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef121:                                  ; preds = %41
+ThrowNullRef122:                                  ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef123:                                  ; preds = %46
+ThrowNullRef124:                                  ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef125:                                  ; preds = %51
+ThrowNullRef126:                                  ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef127:                                  ; preds = %27
+ThrowNullRef128:                                  ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef129:                                  ; preds = %31
+ThrowNullRef130:                                  ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef131:                                  ; preds = %19
+ThrowNullRef132:                                  ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef133:                                  ; preds = %22
+ThrowNullRef134:                                  ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef135:                                  ; preds = %338
+ThrowNullRef136:                                  ; preds = %338
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef137:                                  ; preds = %341
+ThrowNullRef138:                                  ; preds = %341
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef139:                                  ; preds = %356
+ThrowNullRef140:                                  ; preds = %356
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef141:                                  ; preds = %360
+ThrowNullRef142:                                  ; preds = %360
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef143:                                  ; preds = %377
+ThrowNullRef144:                                  ; preds = %377
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef145:                                  ; preds = %381
+ThrowNullRef146:                                  ; preds = %381
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef147:                                  ; preds = %424
+ThrowNullRef148:                                  ; preds = %424
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef149:                                  ; preds = %428
+ThrowNullRef150:                                  ; preds = %428
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef151:                                  ; preds = %440
+ThrowNullRef152:                                  ; preds = %440
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef153:                                  ; preds = %444
+ThrowNullRef154:                                  ; preds = %444
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef155:                                  ; preds = %456
+ThrowNullRef156:                                  ; preds = %456
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef157:                                  ; preds = %460
+ThrowNullRef158:                                  ; preds = %460
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef159:                                  ; preds = %474
+ThrowNullRef160:                                  ; preds = %474
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef161:                                  ; preds = %477
+ThrowNullRef162:                                  ; preds = %477
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef163:                                  ; preds = %394
+ThrowNullRef164:                                  ; preds = %394
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef165:                                  ; preds = %398
+ThrowNullRef166:                                  ; preds = %398
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef167:                                  ; preds = %401
+ThrowNullRef168:                                  ; preds = %401
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef169:                                  ; preds = %407
+ThrowNullRef170:                                  ; preds = %407
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1939,8 +2021,8 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
-  br i1 %NullCheck, label %22, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %ThrowNullRef, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
@@ -1948,8 +2030,8 @@ entry:
   store i32 %24, i32* %loc0
   %25 = load i32, i32* %loc0
   %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %26, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %27
 
 ; <label>:27                                      ; preds = %22
   %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
@@ -1971,7 +2053,7 @@ ThrowNullRef:                                     ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1989,8 +2071,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -2022,15 +2104,15 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2048,16 +2130,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
   %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
   store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %15
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
@@ -2072,8 +2154,8 @@ entry:
   %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
   %29 = ptrtoint i16 addrspace(1)* %28 to i64
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %19
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
@@ -2089,19 +2171,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2114,8 +2196,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
@@ -2128,7 +2210,7 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[loadElem]
+Failed to read AppDomain.PrepareDataForSetup[storeElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
@@ -2202,8 +2284,8 @@ entry:
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
-  br i1 %NullCheck24, label %27, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = load i64, i64 addrspace(1)* %26
@@ -2218,8 +2300,8 @@ entry:
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
-  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
   %41 = load i64, i64 addrspace(1)* %39
@@ -2236,8 +2318,8 @@ entry:
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
-  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
   %54 = load i64, i64 addrspace(1)* %52
@@ -2252,8 +2334,8 @@ entry:
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
   %67 = load i64, i64 addrspace(1)* %65
@@ -2270,8 +2352,8 @@ entry:
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
-  br i1 %NullCheck16, label %79, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
   %80 = load i64, i64 addrspace(1)* %78
@@ -2286,8 +2368,8 @@ entry:
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
-  br i1 %NullCheck18, label %92, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
   %93 = load i64, i64 addrspace(1)* %91
@@ -2304,8 +2386,8 @@ entry:
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
-  br i1 %NullCheck12, label %105, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = load i64, i64 addrspace(1)* %104
@@ -2320,8 +2402,8 @@ entry:
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
-  br i1 %NullCheck14, label %118, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
   %119 = load i64, i64 addrspace(1)* %117
@@ -2337,8 +2419,8 @@ entry:
 
 ; <label>:128                                     ; preds = %20
   %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
-  br i1 %NullCheck4, label %130, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %129, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %130
 
 ; <label>:130                                     ; preds = %128
   %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
@@ -2346,8 +2428,8 @@ entry:
   %133 = load i16, i16 addrspace(1)* %132, align 8
   %134 = zext i16 %133 to i32
   %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
-  br i1 %NullCheck6, label %136, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %135, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %136
 
 ; <label>:136                                     ; preds = %130
   %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
@@ -2360,8 +2442,8 @@ entry:
 
 ; <label>:143                                     ; preds = %136
   %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
-  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %144, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %145
 
 ; <label>:145                                     ; preds = %143
   %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
@@ -2369,8 +2451,8 @@ entry:
   %148 = load i16, i16 addrspace(1)* %147, align 8
   %149 = zext i16 %148 to i32
   %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %150, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %151
 
 ; <label>:151                                     ; preds = %145
   %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
@@ -2388,8 +2470,8 @@ entry:
 
 ; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
-  br i1 %NullCheck, label %163, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %ThrowNullRef, label %163
 
 ; <label>:163                                     ; preds = %161
   %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
@@ -2399,8 +2481,8 @@ entry:
 
 ; <label>:167                                     ; preds = %163
   %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
-  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %168, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %169
 
 ; <label>:169                                     ; preds = %167
   %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
@@ -2432,55 +2514,55 @@ ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %167
+ThrowNullRef2:                                    ; preds = %167
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %128
+ThrowNullRef4:                                    ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %130
+ThrowNullRef6:                                    ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %143
+ThrowNullRef8:                                    ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %145
+ThrowNullRef10:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %102
+ThrowNullRef12:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %105
+ThrowNullRef14:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %76
+ThrowNullRef16:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %79
+ThrowNullRef18:                                   ; preds = %79
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %50
+ThrowNullRef20:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %53
+ThrowNullRef22:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %24
+ThrowNullRef24:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %27
+ThrowNullRef26:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2503,15 +2585,15 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2519,16 +2601,16 @@ entry:
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
   store i32 %8, i32* %loc0
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
   %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
   store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
@@ -2546,16 +2628,16 @@ entry:
 
 ; <label>:23                                      ; preds = %64
   %24 = load i16*, i16** %loc3
-  %NullCheck12 = icmp ne i16* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i16* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
   store i32 %27, i32* %loc5
   %28 = load i16*, i16** %loc4
-  %NullCheck14 = icmp ne i16* %28, null
-  br i1 %NullCheck14, label %29, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %28, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = load i16, i16* %28, align 8
@@ -2620,15 +2702,15 @@ entry:
 
 ; <label>:67                                      ; preds = %64
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
-  br i1 %NullCheck8, label %69, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %68, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %69
 
 ; <label>:69                                      ; preds = %67
   %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
   %71 = load i32, i32 addrspace(1)* %70
   %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
-  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %73
 
 ; <label>:73                                      ; preds = %69
   %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
@@ -2645,31 +2727,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %67
+ThrowNullRef8:                                    ; preds = %67
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %69
+ThrowNullRef10:                                   ; preds = %69
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2710,14 +2792,14 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
   %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
@@ -2730,14 +2812,14 @@ entry:
 
 ; <label>:11                                      ; preds = %4
   %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
   %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
@@ -2749,14 +2831,14 @@ entry:
 
 ; <label>:22                                      ; preds = %16
   %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
   %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
-  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
-  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
@@ -2804,23 +2886,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2836,7 +2918,280 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[loadElem]
+Successfully read RuntimeType.IsAssignableFrom
+
+define i8 @RuntimeType.IsAssignableFrom(%System.RuntimeType addrspace(1)* %param0, %System.Type addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.RuntimeType addrspace(1)*
+  %arg1 = alloca %System.Type addrspace(1)*
+  %loc0 = alloca %System.RuntimeType addrspace(1)*
+  %loc1 = alloca %"System.Type[]" addrspace(1)*
+  %loc2 = alloca i32
+  store %System.RuntimeType addrspace(1)* %param0, %System.RuntimeType addrspace(1)** %this
+  store %System.Type addrspace(1)* %param1, %System.Type addrspace(1)** %arg1
+  %0 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %1 = icmp ne %System.Type addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i8 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %5 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %6 = bitcast %System.Type addrspace(1)* %4 to %System.Object addrspace(1)*
+  %7 = bitcast %System.RuntimeType addrspace(1)* %5 to %System.Object addrspace(1)*
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %6, %System.Object addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %3
+  ret i8 1
+
+; <label>:12                                      ; preds = %3
+  %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 152
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 32
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
+  %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
+  %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
+  store %System.RuntimeType addrspace(1)* %25, %System.RuntimeType addrspace(1)** %loc0
+  %26 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %27 = icmp eq %System.RuntimeType addrspace(1)* %26, null
+  br i1 %27, label %34, label %28
+
+; <label>:28                                      ; preds = %15
+  %29 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %30 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)*)*)(%System.RuntimeType addrspace(1)* %29, %System.RuntimeType addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+; <label>:34                                      ; preds = %15
+  %35 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %36 = call %System.Reflection.Emit.TypeBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Reflection.Emit.TypeBuilder addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %35)
+  %37 = icmp eq %System.Reflection.Emit.TypeBuilder addrspace(1)* %36, null
+  br i1 %37, label %139, label %38
+
+; <label>:38                                      ; preds = %34
+  %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %42
+
+; <label>:42                                      ; preds = %38
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 152
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 40
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
+  %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
+  %53 = zext i8 %52 to i32
+  %54 = icmp eq i32 %53, 0
+  br i1 %54, label %56, label %55
+
+; <label>:55                                      ; preds = %42
+  ret i8 1
+
+; <label>:56                                      ; preds = %42
+  %57 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %58 = bitcast %System.RuntimeType addrspace(1)* %57 to %System.Type addrspace(1)*
+  %59 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %58)
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %64 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.Type addrspace(1)* %63, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = bitcast %System.RuntimeType addrspace(1)* %64 to %System.Type addrspace(1)*
+  %67 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %63, %System.Type addrspace(1)* %66)
+  %68 = zext i8 %67 to i32
+  %69 = trunc i32 %68 to i8
+  ret i8 %69
+
+; <label>:70                                      ; preds = %56
+  %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
+  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %73
+
+; <label>:73                                      ; preds = %70
+  %74 = load i64, i64 addrspace(1)* %72
+  %75 = add i64 %74, 128
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = add i64 %77, 0
+  %79 = inttoptr i64 %78 to i64*
+  %80 = load i64, i64* %79
+  %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
+  %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
+  %83 = call i8 %82(%System.Type addrspace(1)* %81)
+  %84 = zext i8 %83 to i32
+  %85 = icmp eq i32 %84, 0
+  br i1 %85, label %139, label %86
+
+; <label>:86                                      ; preds = %73
+  %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
+  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %89
+
+; <label>:89                                      ; preds = %86
+  %90 = load i64, i64 addrspace(1)* %88
+  %91 = add i64 %90, 128
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = add i64 %93, 24
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
+  %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
+  %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
+  store %"System.Type[]" addrspace(1)* %99, %"System.Type[]" addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %129
+
+; <label>:100                                     ; preds = %132
+  %101 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %102 = load i32, i32* %loc2
+  %NullCheck11 = icmp eq %"System.Type[]" addrspace(1)* %101, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %103
+
+; <label>:103                                     ; preds = %100
+  %104 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 1
+  %105 = load i32, i32 addrspace(1)* %104
+  %106 = zext i32 %105 to i64
+  %107 = zext i32 %102 to i64
+  %BoundsCheck = icmp uge i64 %107, %106
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %108
+
+; <label>:108                                     ; preds = %103
+  %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
+  %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
+  %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
+  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %113
+
+; <label>:113                                     ; preds = %108
+  %114 = load i64, i64 addrspace(1)* %112
+  %115 = add i64 %114, 152
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = add i64 %117, 56
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
+  %123 = zext i8 %122 to i32
+  %124 = icmp ne i32 %123, 0
+  br i1 %124, label %126, label %125
+
+; <label>:125                                     ; preds = %113
+  ret i8 0
+
+; <label>:126                                     ; preds = %113
+  %127 = load i32, i32* %loc2
+  %128 = add i32 %127, 1
+  store i32 %128, i32* %loc2
+  br label %129
+
+; <label>:129                                     ; preds = %89, %126
+  %130 = load i32, i32* %loc2
+  %131 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %NullCheck9 = icmp eq %"System.Type[]" addrspace(1)* %131, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %132
+
+; <label>:132                                     ; preds = %129
+  %133 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %131, i32 0, i32 1
+  %134 = load i32, i32 addrspace(1)* %133
+  %135 = zext i32 %134 to i64
+  %136 = trunc i64 %135 to i32
+  %137 = icmp slt i32 %130, %136
+  br i1 %137, label %100, label %138
+
+; <label>:138                                     ; preds = %132
+  ret i8 1
+
+; <label>:139                                     ; preds = %34, %73
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %129
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %103
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -2893,7 +3248,7 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElem]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -2904,8 +3259,8 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -2997,8 +3352,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
@@ -3059,8 +3414,8 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -3087,8 +3442,8 @@ entry:
 
 ; <label>:17                                      ; preds = %5, %11
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
@@ -3097,8 +3452,8 @@ entry:
 
 ; <label>:22                                      ; preds = %1, %11
   %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
@@ -3109,11 +3464,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %17
+ThrowNullRef2:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %22
+ThrowNullRef4:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3167,15 +3522,15 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
   %15 = load i32, i32 addrspace(1)* %14
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
@@ -3198,7 +3553,7 @@ ThrowNullRef:                                     ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef2:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3232,8 +3587,8 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
@@ -3312,8 +3667,8 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -3327,8 +3682,8 @@ entry:
 ; <label>:5                                       ; preds = %43
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %7 = load i32, i32* %loc1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck6, label %8, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
@@ -3366,8 +3721,8 @@ entry:
 ; <label>:32                                      ; preds = %21, %25
   %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
   %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
-  br i1 %NullCheck8, label %35, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = trunc i32 %34 to i16
@@ -3380,8 +3735,8 @@ entry:
 ; <label>:40                                      ; preds = %1, %35
   %41 = load i32, i32* %loc1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
-  br i1 %NullCheck2, label %43, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %42, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
@@ -3392,8 +3747,8 @@ entry:
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
   %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
-  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
   %51 = load i64, i64 addrspace(1)* %49
@@ -3412,19 +3767,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %40
+ThrowNullRef2:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %47
+ThrowNullRef4:                                    ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %5
+ThrowNullRef6:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %32
+ThrowNullRef8:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3467,8 +3822,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
@@ -3492,11 +3847,391 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(i16* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store i16* %param0, i16** %arg0
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load i32, i32* %arg3
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %42, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %37, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg2
+  %13 = load i32, i32* %arg3
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %37, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %24 = load i32, i32* %arg2
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load i16*, i16** %arg0
+  %35 = load i32, i32* %arg3
+  %36 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %36, i16* %34, i32 %35)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:37                                      ; preds = %5, %16
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %39)
+  %41 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41, %System.String addrspace(1)* %38, %System.String addrspace(1)* %40)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41) #0
+  unreachable
+
+; <label>:42                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
-Failed to read StringBuilder.ToString[loadElemA]
+Successfully read StringBuilder.ToString
+
+define %System.String addrspace(1)* @StringBuilder.ToString(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i16*
+  %loc3 = alloca %"System.Char[]" addrspace(1)*
+  %loc4 = alloca i32
+  %loc5 = alloca i32
+  %loc6 = alloca i16 addrspace(1)*
+  %loc7 = alloca %System.String addrspace(1)*
+  %loc8 = alloca %"System.Char[]" addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %0)
+  %2 = icmp ne i32 %1, 0
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %4
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %6)
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %7)
+  store %System.String addrspace(1)* %8, %System.String addrspace(1)** %loc0
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.Text.StringBuilder addrspace(1)* %9, %System.Text.StringBuilder addrspace(1)** %loc1
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  store %System.String addrspace(1)* %10, %System.String addrspace(1)** %loc7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc7
+  %12 = ptrtoint %System.String addrspace(1)* %11 to i64
+  %13 = icmp eq i64 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %5
+  %15 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %16 = sext i32 %15 to i64
+  %17 = add i64 %12, %16
+  br label %18
+
+; <label>:18                                      ; preds = %5, %14
+  %19 = phi i64 [ %12, %5 ], [ %17, %14 ]
+  %20 = inttoptr i64 %19 to i16*
+  store i16* %20, i16** %loc2
+  br label %21
+
+; <label>:21                                      ; preds = %98, %18
+  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %22, null
+  br i1 %NullCheck, label %ThrowNullRef, label %23
+
+; <label>:23                                      ; preds = %21
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 3
+  %25 = load i32, i32 addrspace(1)* %24, align 8
+  %26 = icmp sle i32 %25, 0
+  br i1 %26, label %96, label %27
+
+; <label>:27                                      ; preds = %23
+  %28 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %28, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %29
+
+; <label>:29                                      ; preds = %27
+  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %28, i32 0, i32 1
+  %31 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %30, align 8
+  store %"System.Char[]" addrspace(1)* %31, %"System.Char[]" addrspace(1)** %loc3
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %33
+
+; <label>:33                                      ; preds = %29
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  store i32 %35, i32* %loc4
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  %39 = load i32, i32 addrspace(1)* %38, align 8
+  store i32 %39, i32* %loc5
+  %40 = load i32, i32* %loc5
+  %41 = load i32, i32* %loc4
+  %42 = add i32 %40, %41
+  %43 = zext i32 %42 to i64
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %45
+
+; <label>:45                                      ; preds = %37
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = sext i32 %47 to i64
+  %49 = icmp sgt i64 %43, %48
+  br i1 %49, label %91, label %50
+
+; <label>:50                                      ; preds = %45
+  %51 = load i32, i32* %loc5
+  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %52, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %53
+
+; <label>:53                                      ; preds = %50
+  %54 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %52, i32 0, i32 1
+  %55 = load i32, i32 addrspace(1)* %54
+  %56 = zext i32 %55 to i64
+  %57 = trunc i64 %56 to i32
+  %58 = icmp ugt i32 %51, %57
+  br i1 %58, label %91, label %59
+
+; <label>:59                                      ; preds = %53
+  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  store %"System.Char[]" addrspace(1)* %60, %"System.Char[]" addrspace(1)** %loc8
+  %61 = icmp eq %"System.Char[]" addrspace(1)* %60, null
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %63, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %64
+
+; <label>:64                                      ; preds = %62
+  %65 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %63, i32 0, i32 1
+  %66 = load i32, i32 addrspace(1)* %65
+  %67 = zext i32 %66 to i64
+  %68 = trunc i64 %67 to i32
+  %69 = icmp ne i32 %68, 0
+  br i1 %69, label %71, label %70
+
+; <label>:70                                      ; preds = %59, %64
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:71                                      ; preds = %64
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %73
+
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %BoundsCheck = icmp uge i64 0, %76
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %77
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %78, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:79                                      ; preds = %70, %77
+  %80 = load i16*, i16** %loc2
+  %81 = load i32, i32* %loc4
+  %82 = sext i32 %81 to i64
+  %83 = mul i64 %82, 2
+  %84 = bitcast i16* %80 to i8*
+  %85 = getelementptr inbounds i8, i8* %84, i64 %83
+  %86 = load i16 addrspace(1)*, i16 addrspace(1)** %loc6
+  %87 = ptrtoint i16 addrspace(1)* %86 to i64
+  %88 = load i32, i32* %loc5
+  %89 = bitcast i8* %85 to i16*
+  %90 = inttoptr i64 %87 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %89, i16* %90, i32 %88)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %96
+
+; <label>:91                                      ; preds = %45, %53
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %94 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %93)
+  %95 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95, %System.String addrspace(1)* %92, %System.String addrspace(1)* %94)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95) #0
+  unreachable
+
+; <label>:96                                      ; preds = %23, %79
+  %97 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %97, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %98
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %97, i32 0, i32 2
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  store %System.Text.StringBuilder addrspace(1)* %100, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %102 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %102, label %21, label %103
+
+; <label>:103                                     ; preds = %98
+  store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc7
+  %104 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  ret %System.String addrspace(1)* %104
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method StringBuilder::get_Length using LLILCJit
+Successfully read StringBuilder.get_Length
+
+define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
+Successfully read RuntimeHelpers.get_OffsetToStringData
+
+define i32 @RuntimeHelpers.get_OffsetToStringData() {
+entry:
+  ret i32 12
+}
+
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
 Successfully read CultureData.CreateCultureData
 
@@ -3514,23 +4249,23 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
   store i8 %4, i8 addrspace(1)* %6
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
@@ -3549,11 +4284,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3566,50 +4301,50 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
   store i32 -1, i32 addrspace(1)* %2
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
   store i32 -1, i32 addrspace(1)* %8
   %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
   store i32 -1, i32 addrspace(1)* %14
   %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
   store i32 -1, i32 addrspace(1)* %17
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
@@ -3623,27 +4358,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3675,7 +4410,136 @@ Failed to read Dictionary`2.Insert[non-const derefAddress]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
 Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
-Failed to read HashHelpers.GetPrime[loadElem]
+Successfully read HashHelpers.GetPrime
+
+define i32 @HashHelpers.GetPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %6, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5, %System.String addrspace(1)* %4)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5) #0
+  unreachable
+
+; <label>:6                                       ; preds = %entry
+  store i32 0, i32* %loc0
+  br label %29
+
+; <label>:7                                       ; preds = %35
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 1296
+  %10 = addrspacecast i8 addrspace(1)* %9 to %"System.Int32[]" addrspace(1)**
+  %11 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %10
+  %12 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Int32[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = zext i32 %15 to i64
+  %17 = zext i32 %12 to i64
+  %BoundsCheck = icmp uge i64 %17, %16
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 3, i32 %12
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  store i32 %20, i32* %loc1
+  %21 = load i32, i32* %loc1
+  %22 = load i32, i32* %arg0
+  %23 = icmp slt i32 %21, %22
+  br i1 %23, label %26, label %24
+
+; <label>:24                                      ; preds = %18
+  %25 = load i32, i32* %loc1
+  ret i32 %25
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %loc0
+  %28 = add i32 %27, 1
+  store i32 %28, i32* %loc0
+  br label %29
+
+; <label>:29                                      ; preds = %6, %26
+  %30 = load i32, i32* %loc0
+  %31 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %32 = getelementptr inbounds i8, i8 addrspace(1)* %31, i64 1296
+  %33 = addrspacecast i8 addrspace(1)* %32 to %"System.Int32[]" addrspace(1)**
+  %34 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %33
+  %NullCheck = icmp eq %"System.Int32[]" addrspace(1)* %34, null
+  br i1 %NullCheck, label %ThrowNullRef, label %35
+
+; <label>:35                                      ; preds = %29
+  %36 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %34, i32 0, i32 1
+  %37 = load i32, i32 addrspace(1)* %36
+  %38 = zext i32 %37 to i64
+  %39 = trunc i64 %38 to i32
+  %40 = icmp slt i32 %30, %39
+  br i1 %40, label %7, label %41
+
+; <label>:41                                      ; preds = %35
+  %42 = load i32, i32* %arg0
+  %43 = or i32 %42, 1
+  store i32 %43, i32* %loc2
+  br label %59
+
+; <label>:44                                      ; preds = %59
+  %45 = load i32, i32* %loc2
+  %46 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %45)
+  %47 = zext i8 %46 to i32
+  %48 = icmp eq i32 %47, 0
+  br i1 %48, label %56, label %49
+
+; <label>:49                                      ; preds = %44
+  %50 = load i32, i32* %loc2
+  %51 = sub i32 %50, 1
+  %52 = srem i32 %51, 101
+  %53 = icmp eq i32 %52, 0
+  br i1 %53, label %56, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = load i32, i32* %loc2
+  ret i32 %55
+
+; <label>:56                                      ; preds = %44, %49
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %57, 2
+  store i32 %58, i32* %loc2
+  br label %59
+
+; <label>:59                                      ; preds = %41, %56
+  %60 = load i32, i32* %loc2
+  %61 = icmp slt i32 %60, 2147483647
+  br i1 %61, label %44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load i32, i32* %arg0
+  ret i32 %63
+
+ThrowNullRef:                                     ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
 Successfully read GenericEqualityComparer`1.GetHashCode
 
@@ -3694,14 +4558,14 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
   %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load i64, i64 addrspace(1)* %7
@@ -3720,7 +4584,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3750,8 +4614,8 @@ entry:
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
@@ -3796,8 +4660,8 @@ entry:
   %35 = bitcast i16* %34 to i8*
   %36 = getelementptr inbounds i8, i8* %35, i64 2
   %37 = bitcast i8* %36 to i16*
-  %NullCheck4 = icmp ne i16* %37, null
-  br i1 %NullCheck4, label %38, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %37, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %38
 
 ; <label>:38                                      ; preds = %27
   %39 = load i16, i16* %37, align 8
@@ -3824,8 +4688,8 @@ entry:
 
 ; <label>:54                                      ; preds = %22, %43
   %55 = load i16*, i16** %loc4
-  %NullCheck2 = icmp ne i16* %55, null
-  br i1 %NullCheck2, label %56, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i16* %55, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %56
 
 ; <label>:56                                      ; preds = %54
   %57 = load i16, i16* %55, align 8
@@ -3850,11 +4714,11 @@ ThrowNullRef:                                     ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %54
+ThrowNullRef2:                                    ; preds = %54
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %27
+ThrowNullRef4:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3871,8 +4735,8 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -3907,8 +4771,8 @@ entry:
 
 ; <label>:26                                      ; preds = %19
   %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
-  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %28
 
 ; <label>:28                                      ; preds = %26
   %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
@@ -3920,7 +4784,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3972,8 +4836,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
@@ -3984,26 +4848,26 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
-  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
@@ -4014,8 +4878,8 @@ entry:
 ; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
@@ -4024,8 +4888,8 @@ entry:
 
 ; <label>:25                                      ; preds = %1, %16, %23
   %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
-  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
@@ -4036,27 +4900,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %20
+ThrowNullRef10:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4069,8 +4933,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -4081,8 +4945,8 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
@@ -4091,8 +4955,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1, %8
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
@@ -4103,11 +4967,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4128,24 +4992,24 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   store i32 %3, i32* %loc0
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
   %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
   store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck4, label %9, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
@@ -4164,15 +5028,15 @@ entry:
 ; <label>:18                                      ; preds = %70
   %19 = load i16*, i16** %loc3
   %20 = bitcast i16* %19 to i64*
-  %NullCheck10 = icmp ne i64* %20, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %20, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = load i64, i64* %20, align 8
   %23 = load i16*, i16** %loc4
   %24 = bitcast i16* %23 to i64*
-  %NullCheck12 = icmp ne i64* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = load i64, i64* %24, align 8
@@ -4188,8 +5052,8 @@ entry:
   %31 = bitcast i16* %30 to i8*
   %32 = getelementptr inbounds i8, i8* %31, i64 8
   %33 = bitcast i8* %32 to i64*
-  %NullCheck14 = icmp ne i64* %33, null
-  br i1 %NullCheck14, label %34, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = load i64, i64* %33, align 8
@@ -4197,8 +5061,8 @@ entry:
   %37 = bitcast i16* %36 to i8*
   %38 = getelementptr inbounds i8, i8* %37, i64 8
   %39 = bitcast i8* %38 to i64*
-  %NullCheck16 = icmp ne i64* %39, null
-  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %40
 
 ; <label>:40                                      ; preds = %34
   %41 = load i64, i64* %39, align 8
@@ -4214,8 +5078,8 @@ entry:
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %NullCheck18 = icmp ne i64* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = load i64, i64* %48, align 8
@@ -4223,8 +5087,8 @@ entry:
   %52 = bitcast i16* %51 to i8*
   %53 = getelementptr inbounds i8, i8* %52, i64 16
   %54 = bitcast i8* %53 to i64*
-  %NullCheck20 = icmp ne i64* %54, null
-  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64* %54, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %55
 
 ; <label>:55                                      ; preds = %49
   %56 = load i64, i64* %54, align 8
@@ -4262,15 +5126,15 @@ entry:
 ; <label>:74                                      ; preds = %95
   %75 = load i16*, i16** %loc3
   %76 = bitcast i16* %75 to i32*
-  %NullCheck6 = icmp ne i32* %76, null
-  br i1 %NullCheck6, label %77, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32* %76, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %77
 
 ; <label>:77                                      ; preds = %74
   %78 = load i32, i32* %76, align 8
   %79 = load i16*, i16** %loc4
   %80 = bitcast i16* %79 to i32*
-  %NullCheck8 = icmp ne i32* %80, null
-  br i1 %NullCheck8, label %81, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i32* %80, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %81
 
 ; <label>:81                                      ; preds = %77
   %82 = load i32, i32* %80, align 8
@@ -4318,43 +5182,43 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %74
+ThrowNullRef6:                                    ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %77
+ThrowNullRef8:                                    ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %29
+ThrowNullRef14:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %34
+ThrowNullRef16:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4376,8 +5240,8 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load i64, i64 addrspace(1)* %4
@@ -4389,8 +5253,8 @@ entry:
   %12 = load i64, i64* %11
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %5
   %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
@@ -4399,8 +5263,8 @@ entry:
   %18 = load i8, i8* %arg2
   %19 = zext i8 %18 to i32
   %20 = trunc i32 %19 to i8
-  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %15
   %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
@@ -4411,11 +5275,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4442,8 +5306,8 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
@@ -4466,16 +5330,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
   %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = load i64, i64 addrspace(1)* %19
@@ -4500,8 +5364,8 @@ entry:
 ; <label>:35                                      ; preds = %30
   %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
@@ -4514,8 +5378,8 @@ entry:
 
 ; <label>:42                                      ; preds = %1, %38
   %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
-  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
@@ -4526,19 +5390,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %35
+ThrowNullRef2:                                    ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %42
+ThrowNullRef8:                                    ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4551,14 +5415,14 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
@@ -4570,7 +5434,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4583,8 +5447,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
@@ -4613,51 +5477,51 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
   %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
   %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
   %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
   %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
-  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
   store i64 %21, i64 addrspace(1)* %23
   %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %25 = load i64, i64* %loc0
-  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
@@ -4668,27 +5532,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %22
+ThrowNullRef12:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4701,8 +5565,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
@@ -4713,19 +5577,19 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
@@ -4734,8 +5598,8 @@ entry:
 
 ; <label>:15                                      ; preds = %1, %13
   %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
@@ -4746,19 +5610,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %15
+ThrowNullRef8:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4771,8 +5635,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -4831,8 +5695,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
@@ -4882,8 +5746,8 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
-  br i1 %NullCheck, label %17, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %ThrowNullRef, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
@@ -4894,15 +5758,15 @@ entry:
 
 ; <label>:22                                      ; preds = %17
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
-  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
   %26 = load i32, i32 addrspace(1)* %25
   %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
-  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %27, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
@@ -4925,8 +5789,8 @@ entry:
 ; <label>:40                                      ; preds = %17
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
-  br i1 %NullCheck6, label %43, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %41, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
@@ -4938,34 +5802,17 @@ ThrowNullRef:                                     ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %24
+ThrowNullRef4:                                    ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %40
+ThrowNullRef6:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
-}
-
-INFO:  jitting method Object::ReferenceEquals using LLILCJit
-Successfully read Object.ReferenceEquals
-
-define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
-entry:
-  %arg0 = alloca %System.Object addrspace(1)*
-  %arg1 = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
-  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
-  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = icmp eq %System.Object addrspace(1)* %0, %1
-  %3 = sext i1 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
 }
 
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
@@ -4978,21 +5825,21 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
   %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
-  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
@@ -5007,28 +5854,28 @@ entry:
 ; <label>:13                                      ; preds = %8, %12
   %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
   %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
   %21 = load i32, i32 addrspace(1)* %20, align 8
   %22 = add i32 %21, 1
-  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
   store i32 %22, i32 addrspace(1)* %24
   %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
@@ -5039,27 +5886,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5077,7 +5924,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::Setup using LLILCJit
-Failed to read AppDomain.Setup[loadElem]
+Failed to read AppDomain.Setup[unbox]
 INFO:  jitting method Thread::GetDomain using LLILCJit
 Successfully read Thread.GetDomain
 
@@ -5108,8 +5955,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
@@ -5122,14 +5969,14 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
   %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
@@ -5141,11 +5988,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5173,8 +6020,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -5189,7 +6036,328 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
 Failed to read KeyCollection.System.Collections.Generic.IEnumerable<TKey>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Successfully read Enumerator.MoveNext
+
+define i8 @Enumerator.MoveNext(%"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.RuntimeTypeHandle* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*
+  %"$TypeArg" = alloca %System.RuntimeTypeHandle*
+  store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
+  %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 8
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %76, label %12
+
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
+  br label %76
+
+; <label>:13                                      ; preds = %85
+  %14 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck19 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %15
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, i32 0, i32 0
+  %17 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %16, align 8
+  %NullCheck21 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, i32 0, i32 2
+  %20 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %19, align 8
+  %21 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck23 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %22
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, i32 0, i32 2
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %NullCheck25 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 3, i32 %24
+  %NullCheck27 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %32
+
+; <label>:32                                      ; preds = %30
+  %33 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, i32 0, i32 2
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = icmp slt i32 %34, 0
+  br i1 %35, label %68, label %36
+
+; <label>:36                                      ; preds = %32
+  %37 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %38 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck29 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %39
+
+; <label>:39                                      ; preds = %36
+  %40 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, i32 0, i32 0
+  %41 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %40, align 8
+  %NullCheck31 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, i32 0, i32 2
+  %44 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %43, align 8
+  %45 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck33 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, i32 0, i32 2
+  %48 = load i32, i32 addrspace(1)* %47, align 8
+  %NullCheck35 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %49
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = zext i32 %51 to i64
+  %53 = zext i32 %48 to i64
+  %BoundsCheck37 = icmp uge i64 %53, %52
+  br i1 %BoundsCheck37, label %ThrowIndexOutOfRange38, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 3, i32 %48
+  %NullCheck39 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %56
+
+; <label>:56                                      ; preds = %54
+  %57 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, i32 0, i32 0
+  %58 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck41 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %59
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %60, %System.__Canon addrspace(1)* %58)
+  %61 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck43 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  %64 = load i32, i32 addrspace(1)* %63, align 8
+  %65 = add i32 %64, 1
+  %NullCheck45 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  store i32 %65, i32 addrspace(1)* %67
+  ret i8 1
+
+; <label>:68                                      ; preds = %32
+  %69 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck47 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %73 = add i32 %72, 1
+  %NullCheck49 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %74
+
+; <label>:74                                      ; preds = %70
+  %75 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  store i32 %73, i32 addrspace(1)* %75
+  br label %76
+
+; <label>:76                                      ; preds = %8, %12, %74
+  %77 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %78
+
+; <label>:78                                      ; preds = %76
+  %79 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, i32 0, i32 2
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck7 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %82
+
+; <label>:82                                      ; preds = %78
+  %83 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, i32 0, i32 0
+  %84 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %83, align 8
+  %NullCheck9 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %85
+
+; <label>:85                                      ; preds = %82
+  %86 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, i32 0, i32 7
+  %87 = load i32, i32 addrspace(1)* %86, align 8
+  %88 = icmp ult i32 %80, %87
+  br i1 %88, label %13, label %89
+
+; <label>:89                                      ; preds = %85
+  %90 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %91 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck11 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %92
+
+; <label>:92                                      ; preds = %89
+  %93 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, i32 0, i32 0
+  %94 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck13 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %95
+
+; <label>:95                                      ; preds = %92
+  %96 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, i32 0, i32 7
+  %97 = load i32, i32 addrspace(1)* %96, align 8
+  %98 = add i32 %97, 1
+  %NullCheck15 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %99
+
+; <label>:99                                      ; preds = %95
+  %100 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, i32 0, i32 2
+  store i32 %98, i32 addrspace(1)* %100
+  %101 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck17 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %102
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %103, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %92
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef22:                                   ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef24:                                   ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef26:                                   ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef28:                                   ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef30:                                   ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef32:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef34:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef36:                                   ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange38:                           ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef40:                                   ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef42:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef44:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef46:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef48:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef50:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -5200,8 +6368,8 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -5232,9 +6400,9 @@ Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
 Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
-Failed to read String.MakeSeparatorList[loadElemA]
+Failed to read String.MakeSeparatorList[storeElem]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
-Failed to read String.InternalSplitKeepEmptyEntries[loadElem]
+Failed to read String.InternalSplitKeepEmptyEntries[storeElem]
 INFO:  jitting method Path::IsRelative using LLILCJit
 Successfully read Path.IsRelative
 
@@ -5243,8 +6411,8 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -5254,8 +6422,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
@@ -5271,8 +6439,8 @@ entry:
 
 ; <label>:17                                      ; preds = %7
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
@@ -5288,8 +6456,8 @@ entry:
 
 ; <label>:29                                      ; preds = %19
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %31
 
 ; <label>:31                                      ; preds = %29
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
@@ -5300,8 +6468,8 @@ entry:
 
 ; <label>:36                                      ; preds = %31
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
-  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %37, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
@@ -5312,8 +6480,8 @@ entry:
 
 ; <label>:43                                      ; preds = %31, %38
   %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
-  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %45
 
 ; <label>:45                                      ; preds = %43
   %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
@@ -5324,8 +6492,8 @@ entry:
 
 ; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %50
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
@@ -5336,8 +6504,8 @@ entry:
 
 ; <label>:57                                      ; preds = %1, %7, %19, %45, %52
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
-  br i1 %NullCheck14, label %59, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %59
 
 ; <label>:59                                      ; preds = %57
   %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
@@ -5347,8 +6515,8 @@ entry:
 
 ; <label>:63                                      ; preds = %59
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
@@ -5359,8 +6527,8 @@ entry:
 
 ; <label>:70                                      ; preds = %65
   %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
-  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.String addrspace(1)* %71, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %72
 
 ; <label>:72                                      ; preds = %70
   %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
@@ -5379,39 +6547,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %17
+ThrowNullRef4:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %29
+ThrowNullRef6:                                    ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %36
+ThrowNullRef8:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %43
+ThrowNullRef10:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %50
+ThrowNullRef12:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %57
+ThrowNullRef14:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %63
+ThrowNullRef16:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %70
+ThrowNullRef18:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5419,7 +6587,293 @@ ThrowNullRef17:                                   ; preds = %70
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
-Failed to read String.TrimHelper[loadElem]
+Successfully read String.TrimHelper
+
+define %System.String addrspace(1)* @String.TrimHelper(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i16
+  %loc4 = alloca i32
+  %loc5 = alloca i16
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = sub i32 %3, 1
+  store i32 %4, i32* %loc0
+  store i32 0, i32* %loc1
+  %5 = load i32, i32* %arg2
+  %6 = icmp eq i32 %5, 1
+  br i1 %6, label %62, label %7
+
+; <label>:7                                       ; preds = %1
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:8                                       ; preds = %58
+  store i32 0, i32* %loc2
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load i32, i32* %loc1
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2, i32 %10
+  %13 = load i16, i16 addrspace(1)* %12
+  %14 = zext i16 %13 to i32
+  %15 = trunc i32 %14 to i16
+  store i16 %15, i16* %loc3
+  store i32 0, i32* %loc2
+  br label %34
+
+; <label>:16                                      ; preds = %37
+  %17 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %18 = load i32, i32* %loc2
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %17, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %19
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = zext i32 %18 to i64
+  %BoundsCheck = icmp uge i64 %23, %22
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %24
+
+; <label>:24                                      ; preds = %19
+  %25 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 3, i32 %18
+  %26 = load i16, i16 addrspace(1)* %25, align 8
+  %27 = zext i16 %26 to i32
+  %28 = load i16, i16* %loc3
+  %29 = zext i16 %28 to i32
+  %30 = icmp eq i32 %27, %29
+  br i1 %30, label %43, label %31
+
+; <label>:31                                      ; preds = %24
+  %32 = load i32, i32* %loc2
+  %33 = add i32 %32, 1
+  store i32 %33, i32* %loc2
+  br label %34
+
+; <label>:34                                      ; preds = %11, %31
+  %35 = load i32, i32* %loc2
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = icmp slt i32 %35, %41
+  br i1 %42, label %16, label %43
+
+; <label>:43                                      ; preds = %24, %37
+  %44 = load i32, i32* %loc2
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %45, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp eq i32 %44, %50
+  br i1 %51, label %62, label %52
+
+; <label>:52                                      ; preds = %46
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %7, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %57, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %58
+
+; <label>:58                                      ; preds = %55
+  %59 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %60 = load i32, i32 addrspace(1)* %59
+  %61 = icmp slt i32 %56, %60
+  br i1 %61, label %8, label %62
+
+; <label>:62                                      ; preds = %1, %46, %58
+  %63 = load i32, i32* %arg2
+  %64 = icmp eq i32 %63, 0
+  br i1 %64, label %122, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %66, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %67
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %66, i32 0, i32 1
+  %69 = load i32, i32 addrspace(1)* %68
+  %70 = sub i32 %69, 1
+  store i32 %70, i32* %loc0
+  br label %118
+
+; <label>:71                                      ; preds = %118
+  store i32 0, i32* %loc4
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %73 = load i32, i32* %loc0
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %74
+
+; <label>:74                                      ; preds = %71
+  %75 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 2, i32 %73
+  %76 = load i16, i16 addrspace(1)* %75
+  %77 = zext i16 %76 to i32
+  %78 = trunc i32 %77 to i16
+  store i16 %78, i16* %loc5
+  store i32 0, i32* %loc4
+  br label %97
+
+; <label>:79                                      ; preds = %100
+  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %81 = load i32, i32* %loc4
+  %NullCheck19 = icmp eq %"System.Char[]" addrspace(1)* %80, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
+
+; <label>:82                                      ; preds = %79
+  %83 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 1
+  %84 = load i32, i32 addrspace(1)* %83
+  %85 = zext i32 %84 to i64
+  %86 = zext i32 %81 to i64
+  %BoundsCheck21 = icmp uge i64 %86, %85
+  br i1 %BoundsCheck21, label %ThrowIndexOutOfRange22, label %87
+
+; <label>:87                                      ; preds = %82
+  %88 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 3, i32 %81
+  %89 = load i16, i16 addrspace(1)* %88, align 8
+  %90 = zext i16 %89 to i32
+  %91 = load i16, i16* %loc5
+  %92 = zext i16 %91 to i32
+  %93 = icmp eq i32 %90, %92
+  br i1 %93, label %106, label %94
+
+; <label>:94                                      ; preds = %87
+  %95 = load i32, i32* %loc4
+  %96 = add i32 %95, 1
+  store i32 %96, i32* %loc4
+  br label %97
+
+; <label>:97                                      ; preds = %74, %94
+  %98 = load i32, i32* %loc4
+  %99 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck15 = icmp eq %"System.Char[]" addrspace(1)* %99, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %100
+
+; <label>:100                                     ; preds = %97
+  %101 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %99, i32 0, i32 1
+  %102 = load i32, i32 addrspace(1)* %101
+  %103 = zext i32 %102 to i64
+  %104 = trunc i64 %103 to i32
+  %105 = icmp slt i32 %98, %104
+  br i1 %105, label %79, label %106
+
+; <label>:106                                     ; preds = %87, %100
+  %107 = load i32, i32* %loc4
+  %108 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck17 = icmp eq %"System.Char[]" addrspace(1)* %108, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %109
+
+; <label>:109                                     ; preds = %106
+  %110 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %108, i32 0, i32 1
+  %111 = load i32, i32 addrspace(1)* %110
+  %112 = zext i32 %111 to i64
+  %113 = trunc i64 %112 to i32
+  %114 = icmp eq i32 %107, %113
+  br i1 %114, label %122, label %115
+
+; <label>:115                                     ; preds = %109
+  %116 = load i32, i32* %loc0
+  %117 = sub i32 %116, 1
+  store i32 %117, i32* %loc0
+  br label %118
+
+; <label>:118                                     ; preds = %67, %115
+  %119 = load i32, i32* %loc0
+  %120 = load i32, i32* %loc1
+  %121 = icmp sge i32 %119, %120
+  br i1 %121, label %71, label %122
+
+; <label>:122                                     ; preds = %62, %109, %118
+  %123 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %124 = load i32, i32* %loc1
+  %125 = load i32, i32* %loc0
+  %126 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %123, i32 %124, i32 %125)
+  ret %System.String addrspace(1)* %126
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %97
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange22:                           ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
 Successfully read String.CreateTrimmedString
 
@@ -5439,8 +6893,8 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
@@ -5535,8 +6989,8 @@ entry:
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i64 2872
   %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
   %8 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %7
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %3
   %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
@@ -5553,8 +7007,8 @@ entry:
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 2864
   %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
   %21 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %20
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
-  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %22
 
 ; <label>:22                                      ; preds = %16
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
@@ -5569,7 +7023,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %16
+ThrowNullRef2:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5586,8 +7040,8 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5613,8 +7067,8 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
@@ -5632,8 +7086,8 @@ entry:
 
 ; <label>:12                                      ; preds = %4
   %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
@@ -5644,8 +7098,8 @@ entry:
 
 ; <label>:19                                      ; preds = %14
   %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %19
   %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
@@ -5660,21 +7114,21 @@ entry:
   %31 = zext i16 %30 to i32
   %32 = bitcast i8* %29 to i16*
   %33 = trunc i32 %31 to i16
-  %NullCheck6 = icmp ne i16* %32, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i16* %32, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %21
   store i16 %33, i16* %32, align 8
   %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %36
 
 ; <label>:36                                      ; preds = %34
   %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
   %38 = load i32, i32 addrspace(1)* %37, align 8
   %39 = add i32 %38, 1
-  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %40
 
 ; <label>:40                                      ; preds = %36
   %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
@@ -5683,16 +7137,16 @@ entry:
 
 ; <label>:42                                      ; preds = %14
   %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
-  br i1 %NullCheck12, label %44, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
   %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
   %47 = load i16, i16* %arg1
   %48 = zext i16 %47 to i32
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = trunc i32 %48 to i16
@@ -5703,31 +7157,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %19
+ThrowNullRef4:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %21
+ThrowNullRef6:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %36
+ThrowNullRef10:                                   ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %42
+ThrowNullRef12:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %44
+ThrowNullRef14:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5740,8 +7194,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -5752,8 +7206,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
@@ -5762,14 +7216,14 @@ entry:
 
 ; <label>:11                                      ; preds = %1
   %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
@@ -5779,15 +7233,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5808,8 +7262,8 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5822,8 +7276,8 @@ entry:
 
 ; <label>:8                                       ; preds = %3
   %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
@@ -5842,15 +7296,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
-  br i1 %NullCheck4, label %22, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
   %24 = load i16*, i16* addrspace(1)* %23, align 8
   %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %25, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
@@ -5859,8 +7313,8 @@ entry:
   store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
@@ -5874,8 +7328,8 @@ entry:
 
 ; <label>:37                                      ; preds = %65
   %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %37
   %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
@@ -5886,16 +7340,16 @@ entry:
   %45 = bitcast i16* %41 to i8*
   %46 = getelementptr inbounds i8, i8* %45, i64 %44
   %47 = bitcast i8* %46 to i16*
-  %NullCheck14 = icmp ne i16* %47, null
-  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %47, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %48
 
 ; <label>:48                                      ; preds = %39
   %49 = load i16, i16* %47, align 8
   %50 = zext i16 %49 to i32
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %52 = load i32, i32* %loc1
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %53
 
 ; <label>:53                                      ; preds = %48
   %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
@@ -5916,8 +7370,8 @@ entry:
 ; <label>:62                                      ; preds = %36, %59
   %63 = load i32, i32* %loc1
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck10, label %65, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %65
 
 ; <label>:65                                      ; preds = %62
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
@@ -5936,15 +7390,15 @@ entry:
 
 ; <label>:74                                      ; preds = %70
   %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
-  br i1 %NullCheck18, label %76, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %76
 
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
   %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
-  br i1 %NullCheck20, label %80, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
   %81 = load i64, i64 addrspace(1)* %79
@@ -5958,8 +7412,8 @@ entry:
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
   %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
-  br i1 %NullCheck22, label %92, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.String addrspace(1)* %90, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %92
 
 ; <label>:92                                      ; preds = %80
   %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
@@ -5969,15 +7423,15 @@ entry:
 
 ; <label>:96                                      ; preds = %70
   %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
-  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %98
 
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
   %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
-  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
   %103 = load i64, i64 addrspace(1)* %101
@@ -5991,8 +7445,8 @@ entry:
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
   %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
-  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.String addrspace(1)* %112, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %114
 
 ; <label>:114                                     ; preds = %102
   %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
@@ -6004,59 +7458,59 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %20
+ThrowNullRef4:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %22
+ThrowNullRef6:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %26
+ThrowNullRef8:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %62
+ThrowNullRef10:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %48
+ThrowNullRef16:                                   ; preds = %48
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %74
+ThrowNullRef18:                                   ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %76
+ThrowNullRef20:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %80
+ThrowNullRef22:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %96
+ThrowNullRef24:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %98
+ThrowNullRef26:                                   ; preds = %98
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %102
+ThrowNullRef28:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6069,15 +7523,15 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
   %3 = load i16*, i16* addrspace(1)* %2, align 8
   %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
@@ -6087,8 +7541,8 @@ entry:
   %10 = bitcast i16* %3 to i8*
   %11 = getelementptr inbounds i8, i8* %10, i64 %9
   %12 = bitcast i8* %11 to i16*
-  %NullCheck4 = icmp ne i16* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %5
   store i16 0, i16* %12, align 8
@@ -6098,11 +7552,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6119,8 +7573,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -6131,8 +7585,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
@@ -6144,15 +7598,15 @@ entry:
 
 ; <label>:14                                      ; preds = %1
   %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
   %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
   %21 = load i64, i64 addrspace(1)* %19
@@ -6171,15 +7625,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %14
+ThrowNullRef4:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %16
+ThrowNullRef6:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6302,14 +7756,6 @@ entry:
   ret %System.String addrspace(1)* %57
 }
 
-INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
-Successfully read RuntimeHelpers.get_OffsetToStringData
-
-define i32 @RuntimeHelpers.get_OffsetToStringData() {
-entry:
-  ret i32 12
-}
-
 INFO:  jitting method String::Equals using LLILCJit
 Successfully read String.Equals
 
@@ -6381,8 +7827,8 @@ entry:
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
-  br i1 %NullCheck24, label %29, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
   %30 = load i64, i64 addrspace(1)* %28
@@ -6397,8 +7843,8 @@ entry:
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
-  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
   %43 = load i64, i64 addrspace(1)* %41
@@ -6418,8 +7864,8 @@ entry:
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
   %59 = load i64, i64 addrspace(1)* %57
@@ -6434,8 +7880,8 @@ entry:
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck22, label %71, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
   %72 = load i64, i64 addrspace(1)* %70
@@ -6455,8 +7901,8 @@ entry:
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
-  br i1 %NullCheck16, label %87, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = load i64, i64 addrspace(1)* %86
@@ -6471,8 +7917,8 @@ entry:
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck18, label %100, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
   %101 = load i64, i64 addrspace(1)* %99
@@ -6492,8 +7938,8 @@ entry:
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
-  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
   %117 = load i64, i64 addrspace(1)* %115
@@ -6508,8 +7954,8 @@ entry:
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
-  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
   %130 = load i64, i64 addrspace(1)* %128
@@ -6528,15 +7974,15 @@ entry:
 
 ; <label>:142                                     ; preds = %22
   %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
-  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %143, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %144
 
 ; <label>:144                                     ; preds = %142
   %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
   %146 = load i32, i32 addrspace(1)* %145
   %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
-  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %147, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %148
 
 ; <label>:148                                     ; preds = %144
   %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
@@ -6557,15 +8003,15 @@ entry:
 
 ; <label>:159                                     ; preds = %22
   %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
-  br i1 %NullCheck, label %161, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %ThrowNullRef, label %161
 
 ; <label>:161                                     ; preds = %159
   %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
   %163 = load i32, i32 addrspace(1)* %162
   %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
-  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %164, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %165
 
 ; <label>:165                                     ; preds = %161
   %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
@@ -6578,8 +8024,8 @@ entry:
 
 ; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
-  br i1 %NullCheck4, label %172, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %171, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %172
 
 ; <label>:172                                     ; preds = %170
   %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
@@ -6589,8 +8035,8 @@ entry:
 
 ; <label>:176                                     ; preds = %172
   %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
-  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %177, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %178
 
 ; <label>:178                                     ; preds = %176
   %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
@@ -6629,55 +8075,55 @@ ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %161
+ThrowNullRef2:                                    ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %170
+ThrowNullRef4:                                    ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %176
+ThrowNullRef6:                                    ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %142
+ThrowNullRef8:                                    ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %144
+ThrowNullRef10:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %113
+ThrowNullRef12:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %116
+ThrowNullRef14:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %84
+ThrowNullRef16:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %87
+ThrowNullRef18:                                   ; preds = %87
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %55
+ThrowNullRef20:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %58
+ThrowNullRef22:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %26
+ThrowNullRef24:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %29
+ThrowNullRef26:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,8 +8161,8 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck, label %14, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %ThrowNullRef, label %14
 
 ; <label>:14                                      ; preds = %8
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
@@ -6760,8 +8206,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
@@ -6770,14 +8216,14 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32, i32* %loc0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %10
   %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
   %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
@@ -6790,15 +8236,15 @@ entry:
 ; <label>:25                                      ; preds = %19
   %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
-  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
   %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
@@ -6807,8 +8253,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %37 = load i32, i32* %loc0
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %38, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %38
 
 ; <label>:38                                      ; preds = %32
   %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
@@ -6817,14 +8263,14 @@ entry:
 
 ; <label>:40                                      ; preds = %19
   %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %40
   %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
   %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
-  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
-  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
@@ -6832,8 +8278,8 @@ entry:
   %48 = zext i32 %47 to i64
   %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
-  br i1 %NullCheck16, label %51, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %51
 
 ; <label>:51                                      ; preds = %45
   %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
@@ -6847,15 +8293,15 @@ entry:
 ; <label>:57                                      ; preds = %51
   %58 = load i16*, i16** %arg1
   %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
-  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %60
 
 ; <label>:60                                      ; preds = %57
   %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
   %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
-  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %64
 
 ; <label>:64                                      ; preds = %60
   %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
@@ -6864,22 +8310,22 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
   %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
-  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %70
 
 ; <label>:70                                      ; preds = %64
   %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
   %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
-  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
-  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
   %75 = load i32, i32 addrspace(1)* %74
   %76 = zext i32 %75 to i64
   %77 = trunc i64 %76 to i32
-  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
-  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %78
 
 ; <label>:78                                      ; preds = %73
   %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
@@ -6901,8 +8347,8 @@ entry:
   %90 = bitcast i16* %86 to i8*
   %91 = getelementptr inbounds i8, i8* %90, i64 %89
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %93
 
 ; <label>:93                                      ; preds = %80
   %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
@@ -6912,8 +8358,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %99 = load i32, i32* %loc2
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %100
 
 ; <label>:100                                     ; preds = %93
   %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
@@ -6928,63 +8374,63 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %25
+ThrowNullRef6:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %32
+ThrowNullRef10:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %40
+ThrowNullRef12:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %45
+ThrowNullRef16:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %57
+ThrowNullRef18:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %60
+ThrowNullRef20:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %64
+ThrowNullRef22:                                   ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %70
+ThrowNullRef24:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %73
+ThrowNullRef26:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %80
+ThrowNullRef28:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %93
+ThrowNullRef30:                                   ; preds = %93
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7004,8 +8450,8 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
@@ -7033,43 +8479,43 @@ entry:
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %14
   %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
   %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   %28 = load i32, i32 addrspace(1)* %27, align 8
   %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
-  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %30
 
 ; <label>:30                                      ; preds = %26
   %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
   %32 = load i32, i32 addrspace(1)* %31, align 8
   %33 = add i32 %28, %32
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %34
 
 ; <label>:34                                      ; preds = %30
   %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   store i32 %33, i32 addrspace(1)* %35
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
   store i32 0, i32 addrspace(1)* %38
   %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %40
 
 ; <label>:40                                      ; preds = %37
   %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
@@ -7082,8 +8528,8 @@ entry:
 
 ; <label>:47                                      ; preds = %40
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
@@ -7098,8 +8544,8 @@ entry:
   %54 = load i32, i32* %loc0
   %55 = sext i32 %54 to i64
   %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
-  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %57
 
 ; <label>:57                                      ; preds = %52
   %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
@@ -7110,68 +8556,35 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %14
+ThrowNullRef2:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %23
+ThrowNullRef4:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %26
+ThrowNullRef6:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %30
+ThrowNullRef8:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %34
+ThrowNullRef10:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %47
+ThrowNullRef14:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %52
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-}
-
-INFO:  jitting method StringBuilder::get_Length using LLILCJit
-Successfully read StringBuilder.get_Length
-
-define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.StringBuilder addrspace(1)*
-  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
-  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
-
-; <label>:1                                       ; preds = %entry
-  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %3 = load i32, i32 addrspace(1)* %2, align 8
-  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
-
-; <label>:5                                       ; preds = %1
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = add i32 %3, %7
-  ret i32 %8
-
-ThrowNullRef:                                     ; preds = %entry
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef16:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7213,70 +8626,70 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
   %6 = load i32, i32 addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
   store i32 %6, i32 addrspace(1)* %8
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
   %13 = load i32, i32 addrspace(1)* %12, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
   store i32 %13, i32 addrspace(1)* %15
   %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
-  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %18
 
 ; <label>:18                                      ; preds = %14
   %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
   %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
   %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
   %34 = load i32, i32 addrspace(1)* %33, align 8
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
-  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
@@ -7287,39 +8700,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %28
+ThrowNullRef16:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %32
+ThrowNullRef18:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7455,13 +8868,13 @@ entry:
 ; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
@@ -7477,16 +8890,16 @@ entry:
 
 ; <label>:18                                      ; preds = %15
   %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
   store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
   %22 = load i32, i32* %loc0
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %24
 
 ; <label>:24                                      ; preds = %20
   %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
@@ -7498,13 +8911,13 @@ entry:
 ; <label>:28                                      ; preds = %15, %24
   %29 = load i32, i32* %arg1
   %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %31
   %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
@@ -7517,20 +8930,20 @@ entry:
   %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
-  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
   %46 = load i32, i32 addrspace(1)* %45, align 8
   %47 = sub i32 %40, %46
-  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
-  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i32 addrspace(1)* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %48
 
 ; <label>:48                                      ; preds = %44
   store i32 %47, i32 addrspace(1)* %39, align 8
@@ -7538,21 +8951,21 @@ entry:
 
 ; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
-  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %51
 
 ; <label>:51                                      ; preds = %49
   %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %53
 
 ; <label>:53                                      ; preds = %51
   %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
   %55 = load i32, i32 addrspace(1)* %54, align 8
   %56 = load i32, i32* %arg2
   %57 = sub i32 %55, %56
-  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %58
 
 ; <label>:58                                      ; preds = %53
   %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
@@ -7562,13 +8975,13 @@ entry:
 ; <label>:60                                      ; preds = %33, %58
   %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
   %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
-  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %63
 
 ; <label>:63                                      ; preds = %60
   %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
-  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
-  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
@@ -7578,15 +8991,15 @@ entry:
 
 ; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
-  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i32 addrspace(1)* %69, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %70
 
 ; <label>:70                                      ; preds = %68
   %71 = load i32, i32 addrspace(1)* %69, align 8
   store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
-  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
@@ -7596,8 +9009,8 @@ entry:
   store i32 %77, i32* %loc4
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
-  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %80
 
 ; <label>:80                                      ; preds = %73
   %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
@@ -7607,71 +9020,71 @@ entry:
 ; <label>:83                                      ; preds = %80
   store i32 0, i32* %loc3
   %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
-  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
-  br i1 %NullCheck26, label %88, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i32 addrspace(1)* %87, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %88
 
 ; <label>:88                                      ; preds = %85
   %89 = load i32, i32 addrspace(1)* %87, align 8
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
-  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %90
 
 ; <label>:90                                      ; preds = %88
   %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
   store i32 %89, i32 addrspace(1)* %91
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
-  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
-  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %96
 
 ; <label>:96                                      ; preds = %94
   %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
-  br i1 %NullCheck34, label %100, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %100
 
 ; <label>:100                                     ; preds = %96
   %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
-  br i1 %NullCheck36, label %102, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %102
 
 ; <label>:102                                     ; preds = %100
   %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
   %104 = load i32, i32 addrspace(1)* %103, align 8
   %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
-  br i1 %NullCheck38, label %106, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %106
 
 ; <label>:106                                     ; preds = %102
   %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
-  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
-  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %108
 
 ; <label>:108                                     ; preds = %106
   %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
   %110 = load i32, i32 addrspace(1)* %109, align 8
   %111 = add i32 %104, %110
-  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %112
 
 ; <label>:112                                     ; preds = %108
   %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
   store i32 %111, i32 addrspace(1)* %113
   %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
-  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i32 addrspace(1)* %114, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %115
 
 ; <label>:115                                     ; preds = %112
   %116 = load i32, i32 addrspace(1)* %114, align 8
@@ -7681,19 +9094,19 @@ entry:
 ; <label>:118                                     ; preds = %115
   %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
-  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %121
 
 ; <label>:121                                     ; preds = %118
   %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
-  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
-  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %123
 
 ; <label>:123                                     ; preds = %121
   %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
   %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
-  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
-  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %126
 
 ; <label>:126                                     ; preds = %123
   %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
@@ -7705,8 +9118,8 @@ entry:
 
 ; <label>:130                                     ; preds = %80, %115, %126
   %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %132
 
 ; <label>:132                                     ; preds = %130
   %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7715,8 +9128,8 @@ entry:
   %136 = load i32, i32* %loc3
   %137 = sub i32 %135, %136
   %138 = sub i32 %134, %137
-  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %139
 
 ; <label>:139                                     ; preds = %132
   %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7728,16 +9141,16 @@ entry:
 
 ; <label>:144                                     ; preds = %139
   %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
-  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %146
 
 ; <label>:146                                     ; preds = %144
   %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
   %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
   %149 = load i32, i32* %loc2
   %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
-  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %151
 
 ; <label>:151                                     ; preds = %146
   %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
@@ -7754,145 +9167,249 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %18
+ThrowNullRef4:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %31
+ThrowNullRef10:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %44
+ThrowNullRef16:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %68
+ThrowNullRef18:                                   ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %70
+ThrowNullRef20:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %73
+ThrowNullRef22:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %83
+ThrowNullRef24:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %85
+ThrowNullRef26:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %88
+ThrowNullRef28:                                   ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %90
+ThrowNullRef30:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %94
+ThrowNullRef32:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %96
+ThrowNullRef34:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %100
+ThrowNullRef36:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %102
+ThrowNullRef38:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %106
+ThrowNullRef40:                                   ; preds = %106
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %108
+ThrowNullRef42:                                   ; preds = %108
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %112
+ThrowNullRef44:                                   ; preds = %112
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %118
+ThrowNullRef46:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %121
+ThrowNullRef48:                                   ; preds = %121
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %123
+ThrowNullRef50:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %130
+ThrowNullRef52:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %132
+ThrowNullRef54:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %144
+ThrowNullRef56:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %146
+ThrowNullRef58:                                   ; preds = %146
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %60
+ThrowNullRef60:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %63
+ThrowNullRef62:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %49
+ThrowNullRef64:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %51
+ThrowNullRef66:                                   ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %53
+ThrowNullRef68:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(%"System.Char[]" addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %arg0 = alloca %"System.Char[]" addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store %"System.Char[]" addrspace(1)* %param0, %"System.Char[]" addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load i32, i32* %arg4
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %43, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %38, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg1
+  %13 = load i32, i32* %arg4
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %38, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %24 = load i32, i32* %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %35 = load i32, i32* %arg3
+  %36 = load i32, i32* %arg4
+  %37 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %37, %"System.Char[]" addrspace(1)* %34, i32 %35, i32 %36)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:38                                      ; preds = %5, %16
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Successfully read Buffer._Memmove
 
@@ -7914,7 +9431,7 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[loadElem]
+Failed to read AppDomain.SetDataHelper[storeElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -7923,8 +9440,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
@@ -7934,8 +9451,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
@@ -7947,15 +9464,15 @@ entry:
   %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
   %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
@@ -7966,15 +9483,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7992,7 +9509,79 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
-Failed to read Dictionary`2.TryGetValue[loadElemA]
+Successfully read Dictionary`2.TryGetValue
+
+define i8 @"Dictionary`2.TryGetValue"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)* addrspace(1)* %param2) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  %arg2 = alloca %System.__Canon addrspace(1)* addrspace(1)*
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  store %System.__Canon addrspace(1)* addrspace(1)* %param2, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  store i32 %2, i32* %loc0
+  %3 = load i32, i32* %loc0
+  %4 = icmp slt i32 %3, 0
+  br i1 %4, label %22, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 2
+  %10 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %9, align 8
+  %11 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = zext i32 %11 to i64
+  %BoundsCheck = icmp uge i64 %16, %15
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 3, i32 %11
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %20, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %6, %System.__Canon addrspace(1)* %21)
+  ret i8 1
+
+; <label>:22                                      ; preds = %entry
+  %23 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %23, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -8058,8 +9647,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
@@ -8091,8 +9680,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
@@ -8171,15 +9760,15 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck, label %19, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %ThrowNullRef, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
   %21 = load i32, i32 addrspace(1)* %20
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
@@ -8202,7 +9791,7 @@ ThrowNullRef:                                     ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %19
+ThrowNullRef2:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8248,8 +9837,8 @@ entry:
   %0 = alloca %System.AppDomainHandle
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %1 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %1, i32 0, i32 15
@@ -8269,8 +9858,8 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
@@ -8286,7 +9875,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -8299,8 +9888,8 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -8327,8 +9916,8 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
@@ -8352,8 +9941,8 @@ entry:
   %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
   store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
@@ -8363,8 +9952,8 @@ entry:
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
@@ -8374,8 +9963,8 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %9
   %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
@@ -8384,8 +9973,8 @@ entry:
 
 ; <label>:18                                      ; preds = %3, %16
   %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
@@ -8397,15 +9986,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %18
+ThrowNullRef6:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8418,8 +10007,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
@@ -8453,15 +10042,15 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
@@ -8473,7 +10062,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8481,7 +10070,7 @@ ThrowNullRef1:                                    ; preds = %1
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
 Failed to read Dictionary`2.System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
@@ -8506,8 +10095,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
@@ -8524,8 +10113,8 @@ entry:
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -8544,7 +10133,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8577,8 +10166,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = load i64, i64* %arg2
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = trunc i32 %3 to i8
@@ -8634,46 +10223,46 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
   %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
-  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
-  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
-  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
@@ -8684,27 +10273,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %20
+ThrowNullRef12:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8717,8 +10306,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -8756,22 +10345,22 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
   %9 = load i64, i64 addrspace(1)* %8, align 8
   %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
   %13 = load i64, i64 addrspace(1)* %12, align 8
   %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %11
   %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
@@ -8788,11 +10377,11 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8882,8 +10471,8 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
@@ -8900,8 +10489,8 @@ entry:
 ; <label>:8                                       ; preds = %1
   %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
   %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
@@ -8911,15 +10500,15 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
   %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
   %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
-  br i1 %NullCheck6, label %21, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
@@ -8946,15 +10535,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8992,15 +10581,15 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
   store i8 %3, i8 addrspace(1)* %5
   %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
@@ -9011,7 +10600,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9027,8 +10616,8 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -9041,8 +10630,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
@@ -9058,7 +10647,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9080,8 +10669,8 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
@@ -9096,8 +10685,8 @@ entry:
 ; <label>:12                                      ; preds = %6
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
@@ -9112,8 +10701,8 @@ entry:
 ; <label>:21                                      ; preds = %15
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
@@ -9128,8 +10717,8 @@ entry:
 ; <label>:30                                      ; preds = %24
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %31, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
@@ -9144,8 +10733,8 @@ entry:
 ; <label>:39                                      ; preds = %33
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
-  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %40, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %42
 
 ; <label>:42                                      ; preds = %39
   %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
@@ -9164,19 +10753,19 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %21
+ThrowNullRef4:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %30
+ThrowNullRef6:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %39
+ThrowNullRef8:                                    ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9243,8 +10832,8 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
@@ -9264,57 +10853,57 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
   store i8 0, i8 addrspace(1)* %2
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
   store i8 0, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
   store i8 0, i8 addrspace(1)* %17
   %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
   store i8 0, i8 addrspace(1)* %20
   %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
-  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
@@ -9325,31 +10914,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %19
+ThrowNullRef14:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9367,8 +10956,8 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
@@ -9380,8 +10969,8 @@ entry:
 
 ; <label>:9                                       ; preds = %4
   %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %9
   %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
@@ -9395,7 +10984,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef2:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9420,8 +11009,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
@@ -9512,8 +11101,8 @@ entry:
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
@@ -9524,8 +11113,8 @@ entry:
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = load i64, i64 addrspace(1)* %12
@@ -9537,8 +11126,8 @@ entry:
   %20 = load i64, i64* %19
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
-  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %13
   %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
@@ -9555,8 +11144,8 @@ entry:
 ; <label>:30                                      ; preds = %25
   %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %32 = load i32, i32* %arg2
-  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
-  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
@@ -9570,15 +11159,15 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %30
+ThrowNullRef2:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9622,87 +11211,87 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
   %10 = load i8, i8 addrspace(1)* %9, align 8
   %11 = zext i8 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %8
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
   store i8 %12, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
   %19 = load i8, i8 addrspace(1)* %18, align 8
   %20 = zext i8 %19 to i32
   %21 = trunc i32 %20 to i8
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
   store i8 %21, i8 addrspace(1)* %23
   %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
   %28 = load i8, i8 addrspace(1)* %27, align 8
   %29 = zext i8 %28 to i32
   %30 = trunc i32 %29 to i8
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
-  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %31
 
 ; <label>:31                                      ; preds = %26
   %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
   store i8 %30, i8 addrspace(1)* %32
   %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
-  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
-  br i1 %NullCheck14, label %40, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %40
 
 ; <label>:40                                      ; preds = %35
   %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
   store i8 %39, i8 addrspace(1)* %41
   %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
-  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %44
 
 ; <label>:44                                      ; preds = %40
   %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
   %46 = load i8, i8 addrspace(1)* %45, align 8
   %47 = zext i8 %46 to i32
   %48 = trunc i32 %47 to i8
-  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
   store i8 %48, i8 addrspace(1)* %50
   %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
-  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
@@ -9713,29 +11302,29 @@ entry:
 ; <label>:56                                      ; preds = %52
   %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
-  br i1 %NullCheck22, label %59, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
   %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
   %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
-  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
-  br i1 %NullCheck24, label %63, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
   %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
-  br i1 %NullCheck26, label %66, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
   %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
-  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
-  br i1 %NullCheck28, label %69, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %69
 
 ; <label>:69                                      ; preds = %66
   %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
@@ -9744,15 +11333,15 @@ entry:
 
 ; <label>:71                                      ; preds = %105
   %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
-  br i1 %NullCheck34, label %73, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %73
 
 ; <label>:73                                      ; preds = %71
   %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
   %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
   %76 = load i32, i32* %loc0
-  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
-  br i1 %NullCheck36, label %77, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
@@ -9766,8 +11355,8 @@ entry:
 
 ; <label>:83                                      ; preds = %77
   %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
-  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
@@ -9775,14 +11364,14 @@ entry:
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
   %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
-  br i1 %NullCheck40, label %91, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
 ; <label>:91                                      ; preds = %85
   %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
   %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
-  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck42, label %94, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %94
 
 ; <label>:94                                      ; preds = %91
   %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
@@ -9798,14 +11387,14 @@ entry:
 ; <label>:99                                      ; preds = %69, %96
   %100 = load i32, i32* %loc0
   %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
-  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %102
 
 ; <label>:102                                     ; preds = %99
   %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
   %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
-  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
-  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
@@ -9819,87 +11408,87 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %26
+ThrowNullRef10:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %31
+ThrowNullRef12:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %35
+ThrowNullRef14:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %40
+ThrowNullRef16:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %56
+ThrowNullRef22:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %59
+ThrowNullRef24:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %63
+ThrowNullRef26:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %66
+ThrowNullRef28:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %102
+ThrowNullRef32:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %71
+ThrowNullRef34:                                   ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %73
+ThrowNullRef36:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %83
+ThrowNullRef38:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %85
+ThrowNullRef40:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %91
+ThrowNullRef42:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9943,15 +11532,15 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
   %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
@@ -9961,28 +11550,28 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
   %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %12
   %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
   %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
   %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
-  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
@@ -9993,23 +11582,23 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %12
+ThrowNullRef6:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10031,15 +11620,15 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
   %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = load i64, i64 addrspace(1)* %7
@@ -10077,13 +11666,13 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[loadElem]
+Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -10111,8 +11700,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Args5.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Args5.error.txt
@@ -25,8 +25,8 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
@@ -40,8 +40,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
   %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
@@ -75,7 +75,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -90,8 +90,8 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %NullCheck = icmp ne i8 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = load i8, i8 addrspace(1)* %0, align 8
@@ -125,8 +125,8 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
@@ -159,8 +159,8 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -184,8 +184,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
   store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
@@ -195,8 +195,8 @@ entry:
 ; <label>:4                                       ; preds = %1
   %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
   %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
@@ -206,8 +206,8 @@ entry:
   %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
@@ -221,14 +221,14 @@ entry:
 
 ; <label>:17                                      ; preds = %14
   %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
   %21 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
@@ -238,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -249,8 +249,8 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
@@ -261,27 +261,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %30
+ThrowNullRef10:                                   ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -301,7 +301,89 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
-Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
+Successfully read AppDomainSetup.GetUnsecureApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.GetUnsecureApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %NullCheck = icmp eq %"System.String[]" addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %BoundsCheck = icmp uge i64 0, %5
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %6
+
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 3, i32 0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
+  ret %System.String addrspace(1)* %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_Value using LLILCJit
+Successfully read AppDomainSetup.get_Value
+
+define %"System.String[]" addrspace(1)* @AppDomainSetup.get_Value(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.String[]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 18)
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.String[]" addrspace(1)* addrspace(1)*, %"System.String[]" addrspace(1)*)*)(%"System.String[]" addrspace(1)* addrspace(1)* %9, %"System.String[]" addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %11, i32 0, i32 1
+  %14 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %13, align 8
+  ret %"System.String[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -319,8 +401,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -368,16 +450,16 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
   %5 = load i32, i32 addrspace(1)* %4
   %6 = sub i32 %5, 1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -389,7 +471,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -421,8 +503,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
@@ -456,8 +538,8 @@ entry:
 ; <label>:27                                      ; preds = %19
   %28 = load i32, i32* %arg1
   %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
-  br i1 %NullCheck2, label %30, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %29, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %30
 
 ; <label>:30                                      ; preds = %27
   %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
@@ -493,8 +575,8 @@ entry:
 ; <label>:49                                      ; preds = %46
   %50 = load i32, i32* %arg2
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck4, label %52, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
@@ -517,11 +599,11 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %27
+ThrowNullRef2:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %49
+ThrowNullRef4:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -544,16 +626,16 @@ entry:
   %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %0)
   store %System.String addrspace(1)* %1, %System.String addrspace(1)** %loc0
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 2
   %5 = bitcast [0 x i16] addrspace(1)* %4 to i16 addrspace(1)*
   store i16 addrspace(1)* %5, i16 addrspace(1)** %loc1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %3
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2
@@ -580,7 +662,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -691,15 +773,15 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %NullCheck132 = icmp ne i8* %21, null
-  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+  %NullCheck131 = icmp eq i8* %21, null
+  br i1 %NullCheck131, label %ThrowNullRef132, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = load i8, i8* %21, align 8
   %24 = zext i8 %23 to i32
   %25 = trunc i32 %24 to i8
-  %NullCheck134 = icmp ne i8* %20, null
-  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+  %NullCheck133 = icmp eq i8* %20, null
+  br i1 %NullCheck133, label %ThrowNullRef134, label %26
 
 ; <label>:26                                      ; preds = %22
   store i8 %25, i8* %20, align 8
@@ -709,16 +791,16 @@ entry:
   %28 = load i8*, i8** %arg0
   %29 = load i8*, i8** %arg1
   %30 = bitcast i8* %29 to i16*
-  %NullCheck128 = icmp ne i16* %30, null
-  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+  %NullCheck127 = icmp eq i16* %30, null
+  br i1 %NullCheck127, label %ThrowNullRef128, label %31
 
 ; <label>:31                                      ; preds = %27
   %32 = load i16, i16* %30, align 8
   %33 = sext i16 %32 to i32
   %34 = bitcast i8* %28 to i16*
   %35 = trunc i32 %33 to i16
-  %NullCheck130 = icmp ne i16* %34, null
-  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+  %NullCheck129 = icmp eq i16* %34, null
+  br i1 %NullCheck129, label %ThrowNullRef130, label %36
 
 ; <label>:36                                      ; preds = %31
   store i16 %35, i16* %34, align 8
@@ -728,16 +810,16 @@ entry:
   %38 = load i8*, i8** %arg0
   %39 = load i8*, i8** %arg1
   %40 = bitcast i8* %39 to i16*
-  %NullCheck120 = icmp ne i16* %40, null
-  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+  %NullCheck119 = icmp eq i16* %40, null
+  br i1 %NullCheck119, label %ThrowNullRef120, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i16, i16* %40, align 8
   %43 = sext i16 %42 to i32
   %44 = bitcast i8* %38 to i16*
   %45 = trunc i32 %43 to i16
-  %NullCheck122 = icmp ne i16* %44, null
-  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+  %NullCheck121 = icmp eq i16* %44, null
+  br i1 %NullCheck121, label %ThrowNullRef122, label %46
 
 ; <label>:46                                      ; preds = %41
   store i16 %45, i16* %44, align 8
@@ -745,15 +827,15 @@ entry:
   %48 = getelementptr inbounds i8, i8* %47, i64 2
   %49 = load i8*, i8** %arg1
   %50 = getelementptr inbounds i8, i8* %49, i64 2
-  %NullCheck124 = icmp ne i8* %50, null
-  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+  %NullCheck123 = icmp eq i8* %50, null
+  br i1 %NullCheck123, label %ThrowNullRef124, label %51
 
 ; <label>:51                                      ; preds = %46
   %52 = load i8, i8* %50, align 8
   %53 = zext i8 %52 to i32
   %54 = trunc i32 %53 to i8
-  %NullCheck126 = icmp ne i8* %48, null
-  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+  %NullCheck125 = icmp eq i8* %48, null
+  br i1 %NullCheck125, label %ThrowNullRef126, label %55
 
 ; <label>:55                                      ; preds = %51
   store i8 %54, i8* %48, align 8
@@ -763,14 +845,14 @@ entry:
   %57 = load i8*, i8** %arg0
   %58 = load i8*, i8** %arg1
   %59 = bitcast i8* %58 to i32*
-  %NullCheck116 = icmp ne i32* %59, null
-  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+  %NullCheck115 = icmp eq i32* %59, null
+  br i1 %NullCheck115, label %ThrowNullRef116, label %60
 
 ; <label>:60                                      ; preds = %56
   %61 = load i32, i32* %59, align 8
   %62 = bitcast i8* %57 to i32*
-  %NullCheck118 = icmp ne i32* %62, null
-  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+  %NullCheck117 = icmp eq i32* %62, null
+  br i1 %NullCheck117, label %ThrowNullRef118, label %63
 
 ; <label>:63                                      ; preds = %60
   store i32 %61, i32* %62, align 8
@@ -780,14 +862,14 @@ entry:
   %65 = load i8*, i8** %arg0
   %66 = load i8*, i8** %arg1
   %67 = bitcast i8* %66 to i32*
-  %NullCheck108 = icmp ne i32* %67, null
-  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+  %NullCheck107 = icmp eq i32* %67, null
+  br i1 %NullCheck107, label %ThrowNullRef108, label %68
 
 ; <label>:68                                      ; preds = %64
   %69 = load i32, i32* %67, align 8
   %70 = bitcast i8* %65 to i32*
-  %NullCheck110 = icmp ne i32* %70, null
-  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+  %NullCheck109 = icmp eq i32* %70, null
+  br i1 %NullCheck109, label %ThrowNullRef110, label %71
 
 ; <label>:71                                      ; preds = %68
   store i32 %69, i32* %70, align 8
@@ -795,15 +877,15 @@ entry:
   %73 = getelementptr inbounds i8, i8* %72, i64 4
   %74 = load i8*, i8** %arg1
   %75 = getelementptr inbounds i8, i8* %74, i64 4
-  %NullCheck112 = icmp ne i8* %75, null
-  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+  %NullCheck111 = icmp eq i8* %75, null
+  br i1 %NullCheck111, label %ThrowNullRef112, label %76
 
 ; <label>:76                                      ; preds = %71
   %77 = load i8, i8* %75, align 8
   %78 = zext i8 %77 to i32
   %79 = trunc i32 %78 to i8
-  %NullCheck114 = icmp ne i8* %73, null
-  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+  %NullCheck113 = icmp eq i8* %73, null
+  br i1 %NullCheck113, label %ThrowNullRef114, label %80
 
 ; <label>:80                                      ; preds = %76
   store i8 %79, i8* %73, align 8
@@ -813,14 +895,14 @@ entry:
   %82 = load i8*, i8** %arg0
   %83 = load i8*, i8** %arg1
   %84 = bitcast i8* %83 to i32*
-  %NullCheck100 = icmp ne i32* %84, null
-  br i1 %NullCheck100, label %85, label %ThrowNullRef99
+  %NullCheck99 = icmp eq i32* %84, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %85
 
 ; <label>:85                                      ; preds = %81
   %86 = load i32, i32* %84, align 8
   %87 = bitcast i8* %82 to i32*
-  %NullCheck102 = icmp ne i32* %87, null
-  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+  %NullCheck101 = icmp eq i32* %87, null
+  br i1 %NullCheck101, label %ThrowNullRef102, label %88
 
 ; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
@@ -829,16 +911,16 @@ entry:
   %91 = load i8*, i8** %arg1
   %92 = getelementptr inbounds i8, i8* %91, i64 4
   %93 = bitcast i8* %92 to i16*
-  %NullCheck104 = icmp ne i16* %93, null
-  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+  %NullCheck103 = icmp eq i16* %93, null
+  br i1 %NullCheck103, label %ThrowNullRef104, label %94
 
 ; <label>:94                                      ; preds = %88
   %95 = load i16, i16* %93, align 8
   %96 = sext i16 %95 to i32
   %97 = bitcast i8* %90 to i16*
   %98 = trunc i32 %96 to i16
-  %NullCheck106 = icmp ne i16* %97, null
-  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+  %NullCheck105 = icmp eq i16* %97, null
+  br i1 %NullCheck105, label %ThrowNullRef106, label %99
 
 ; <label>:99                                      ; preds = %94
   store i16 %98, i16* %97, align 8
@@ -848,14 +930,14 @@ entry:
   %101 = load i8*, i8** %arg0
   %102 = load i8*, i8** %arg1
   %103 = bitcast i8* %102 to i32*
-  %NullCheck88 = icmp ne i32* %103, null
-  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+  %NullCheck87 = icmp eq i32* %103, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %104
 
 ; <label>:104                                     ; preds = %100
   %105 = load i32, i32* %103, align 8
   %106 = bitcast i8* %101 to i32*
-  %NullCheck90 = icmp ne i32* %106, null
-  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+  %NullCheck89 = icmp eq i32* %106, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %107
 
 ; <label>:107                                     ; preds = %104
   store i32 %105, i32* %106, align 8
@@ -864,16 +946,16 @@ entry:
   %110 = load i8*, i8** %arg1
   %111 = getelementptr inbounds i8, i8* %110, i64 4
   %112 = bitcast i8* %111 to i16*
-  %NullCheck92 = icmp ne i16* %112, null
-  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+  %NullCheck91 = icmp eq i16* %112, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %113
 
 ; <label>:113                                     ; preds = %107
   %114 = load i16, i16* %112, align 8
   %115 = sext i16 %114 to i32
   %116 = bitcast i8* %109 to i16*
   %117 = trunc i32 %115 to i16
-  %NullCheck94 = icmp ne i16* %116, null
-  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+  %NullCheck93 = icmp eq i16* %116, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %118
 
 ; <label>:118                                     ; preds = %113
   store i16 %117, i16* %116, align 8
@@ -881,15 +963,15 @@ entry:
   %120 = getelementptr inbounds i8, i8* %119, i64 6
   %121 = load i8*, i8** %arg1
   %122 = getelementptr inbounds i8, i8* %121, i64 6
-  %NullCheck96 = icmp ne i8* %122, null
-  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+  %NullCheck95 = icmp eq i8* %122, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %123
 
 ; <label>:123                                     ; preds = %118
   %124 = load i8, i8* %122, align 8
   %125 = zext i8 %124 to i32
   %126 = trunc i32 %125 to i8
-  %NullCheck98 = icmp ne i8* %120, null
-  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+  %NullCheck97 = icmp eq i8* %120, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %127
 
 ; <label>:127                                     ; preds = %123
   store i8 %126, i8* %120, align 8
@@ -899,14 +981,14 @@ entry:
   %129 = load i8*, i8** %arg0
   %130 = load i8*, i8** %arg1
   %131 = bitcast i8* %130 to i64*
-  %NullCheck84 = icmp ne i64* %131, null
-  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+  %NullCheck83 = icmp eq i64* %131, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %132
 
 ; <label>:132                                     ; preds = %128
   %133 = load i64, i64* %131, align 8
   %134 = bitcast i8* %129 to i64*
-  %NullCheck86 = icmp ne i64* %134, null
-  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+  %NullCheck85 = icmp eq i64* %134, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %135
 
 ; <label>:135                                     ; preds = %132
   store i64 %133, i64* %134, align 8
@@ -916,14 +998,14 @@ entry:
   %137 = load i8*, i8** %arg0
   %138 = load i8*, i8** %arg1
   %139 = bitcast i8* %138 to i64*
-  %NullCheck76 = icmp ne i64* %139, null
-  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+  %NullCheck75 = icmp eq i64* %139, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %140
 
 ; <label>:140                                     ; preds = %136
   %141 = load i64, i64* %139, align 8
   %142 = bitcast i8* %137 to i64*
-  %NullCheck78 = icmp ne i64* %142, null
-  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+  %NullCheck77 = icmp eq i64* %142, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %143
 
 ; <label>:143                                     ; preds = %140
   store i64 %141, i64* %142, align 8
@@ -931,15 +1013,15 @@ entry:
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %NullCheck80 = icmp ne i8* %147, null
-  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+  %NullCheck79 = icmp eq i8* %147, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %148
 
 ; <label>:148                                     ; preds = %143
   %149 = load i8, i8* %147, align 8
   %150 = zext i8 %149 to i32
   %151 = trunc i32 %150 to i8
-  %NullCheck82 = icmp ne i8* %145, null
-  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+  %NullCheck81 = icmp eq i8* %145, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %152
 
 ; <label>:152                                     ; preds = %148
   store i8 %151, i8* %145, align 8
@@ -949,14 +1031,14 @@ entry:
   %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
   %156 = bitcast i8* %155 to i64*
-  %NullCheck68 = icmp ne i64* %156, null
-  br i1 %NullCheck68, label %157, label %ThrowNullRef67
+  %NullCheck67 = icmp eq i64* %156, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %157
 
 ; <label>:157                                     ; preds = %153
   %158 = load i64, i64* %156, align 8
   %159 = bitcast i8* %154 to i64*
-  %NullCheck70 = icmp ne i64* %159, null
-  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+  %NullCheck69 = icmp eq i64* %159, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %160
 
 ; <label>:160                                     ; preds = %157
   store i64 %158, i64* %159, align 8
@@ -965,16 +1047,16 @@ entry:
   %163 = load i8*, i8** %arg1
   %164 = getelementptr inbounds i8, i8* %163, i64 8
   %165 = bitcast i8* %164 to i16*
-  %NullCheck72 = icmp ne i16* %165, null
-  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+  %NullCheck71 = icmp eq i16* %165, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %166
 
 ; <label>:166                                     ; preds = %160
   %167 = load i16, i16* %165, align 8
   %168 = sext i16 %167 to i32
   %169 = bitcast i8* %162 to i16*
   %170 = trunc i32 %168 to i16
-  %NullCheck74 = icmp ne i16* %169, null
-  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+  %NullCheck73 = icmp eq i16* %169, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %171
 
 ; <label>:171                                     ; preds = %166
   store i16 %170, i16* %169, align 8
@@ -984,14 +1066,14 @@ entry:
   %173 = load i8*, i8** %arg0
   %174 = load i8*, i8** %arg1
   %175 = bitcast i8* %174 to i64*
-  %NullCheck56 = icmp ne i64* %175, null
-  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+  %NullCheck55 = icmp eq i64* %175, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %176
 
 ; <label>:176                                     ; preds = %172
   %177 = load i64, i64* %175, align 8
   %178 = bitcast i8* %173 to i64*
-  %NullCheck58 = icmp ne i64* %178, null
-  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+  %NullCheck57 = icmp eq i64* %178, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %179
 
 ; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
@@ -1000,16 +1082,16 @@ entry:
   %182 = load i8*, i8** %arg1
   %183 = getelementptr inbounds i8, i8* %182, i64 8
   %184 = bitcast i8* %183 to i16*
-  %NullCheck60 = icmp ne i16* %184, null
-  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+  %NullCheck59 = icmp eq i16* %184, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %185
 
 ; <label>:185                                     ; preds = %179
   %186 = load i16, i16* %184, align 8
   %187 = sext i16 %186 to i32
   %188 = bitcast i8* %181 to i16*
   %189 = trunc i32 %187 to i16
-  %NullCheck62 = icmp ne i16* %188, null
-  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+  %NullCheck61 = icmp eq i16* %188, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %190
 
 ; <label>:190                                     ; preds = %185
   store i16 %189, i16* %188, align 8
@@ -1017,15 +1099,15 @@ entry:
   %192 = getelementptr inbounds i8, i8* %191, i64 10
   %193 = load i8*, i8** %arg1
   %194 = getelementptr inbounds i8, i8* %193, i64 10
-  %NullCheck64 = icmp ne i8* %194, null
-  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+  %NullCheck63 = icmp eq i8* %194, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %195
 
 ; <label>:195                                     ; preds = %190
   %196 = load i8, i8* %194, align 8
   %197 = zext i8 %196 to i32
   %198 = trunc i32 %197 to i8
-  %NullCheck66 = icmp ne i8* %192, null
-  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+  %NullCheck65 = icmp eq i8* %192, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %199
 
 ; <label>:199                                     ; preds = %195
   store i8 %198, i8* %192, align 8
@@ -1035,14 +1117,14 @@ entry:
   %201 = load i8*, i8** %arg0
   %202 = load i8*, i8** %arg1
   %203 = bitcast i8* %202 to i64*
-  %NullCheck48 = icmp ne i64* %203, null
-  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+  %NullCheck47 = icmp eq i64* %203, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %204
 
 ; <label>:204                                     ; preds = %200
   %205 = load i64, i64* %203, align 8
   %206 = bitcast i8* %201 to i64*
-  %NullCheck50 = icmp ne i64* %206, null
-  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+  %NullCheck49 = icmp eq i64* %206, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %207
 
 ; <label>:207                                     ; preds = %204
   store i64 %205, i64* %206, align 8
@@ -1051,14 +1133,14 @@ entry:
   %210 = load i8*, i8** %arg1
   %211 = getelementptr inbounds i8, i8* %210, i64 8
   %212 = bitcast i8* %211 to i32*
-  %NullCheck52 = icmp ne i32* %212, null
-  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+  %NullCheck51 = icmp eq i32* %212, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %213
 
 ; <label>:213                                     ; preds = %207
   %214 = load i32, i32* %212, align 8
   %215 = bitcast i8* %209 to i32*
-  %NullCheck54 = icmp ne i32* %215, null
-  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+  %NullCheck53 = icmp eq i32* %215, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %216
 
 ; <label>:216                                     ; preds = %213
   store i32 %214, i32* %215, align 8
@@ -1068,14 +1150,14 @@ entry:
   %218 = load i8*, i8** %arg0
   %219 = load i8*, i8** %arg1
   %220 = bitcast i8* %219 to i64*
-  %NullCheck36 = icmp ne i64* %220, null
-  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64* %220, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %221
 
 ; <label>:221                                     ; preds = %217
   %222 = load i64, i64* %220, align 8
   %223 = bitcast i8* %218 to i64*
-  %NullCheck38 = icmp ne i64* %223, null
-  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+  %NullCheck37 = icmp eq i64* %223, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %224
 
 ; <label>:224                                     ; preds = %221
   store i64 %222, i64* %223, align 8
@@ -1084,14 +1166,14 @@ entry:
   %227 = load i8*, i8** %arg1
   %228 = getelementptr inbounds i8, i8* %227, i64 8
   %229 = bitcast i8* %228 to i32*
-  %NullCheck40 = icmp ne i32* %229, null
-  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i32* %229, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %230
 
 ; <label>:230                                     ; preds = %224
   %231 = load i32, i32* %229, align 8
   %232 = bitcast i8* %226 to i32*
-  %NullCheck42 = icmp ne i32* %232, null
-  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+  %NullCheck41 = icmp eq i32* %232, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %233
 
 ; <label>:233                                     ; preds = %230
   store i32 %231, i32* %232, align 8
@@ -1099,15 +1181,15 @@ entry:
   %235 = getelementptr inbounds i8, i8* %234, i64 12
   %236 = load i8*, i8** %arg1
   %237 = getelementptr inbounds i8, i8* %236, i64 12
-  %NullCheck44 = icmp ne i8* %237, null
-  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i8* %237, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %238
 
 ; <label>:238                                     ; preds = %233
   %239 = load i8, i8* %237, align 8
   %240 = zext i8 %239 to i32
   %241 = trunc i32 %240 to i8
-  %NullCheck46 = icmp ne i8* %235, null
-  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+  %NullCheck45 = icmp eq i8* %235, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %242
 
 ; <label>:242                                     ; preds = %238
   store i8 %241, i8* %235, align 8
@@ -1117,14 +1199,14 @@ entry:
   %244 = load i8*, i8** %arg0
   %245 = load i8*, i8** %arg1
   %246 = bitcast i8* %245 to i64*
-  %NullCheck24 = icmp ne i64* %246, null
-  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64* %246, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %247
 
 ; <label>:247                                     ; preds = %243
   %248 = load i64, i64* %246, align 8
   %249 = bitcast i8* %244 to i64*
-  %NullCheck26 = icmp ne i64* %249, null
-  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64* %249, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %250
 
 ; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
@@ -1133,14 +1215,14 @@ entry:
   %253 = load i8*, i8** %arg1
   %254 = getelementptr inbounds i8, i8* %253, i64 8
   %255 = bitcast i8* %254 to i32*
-  %NullCheck28 = icmp ne i32* %255, null
-  br i1 %NullCheck28, label %256, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i32* %255, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %256
 
 ; <label>:256                                     ; preds = %250
   %257 = load i32, i32* %255, align 8
   %258 = bitcast i8* %252 to i32*
-  %NullCheck30 = icmp ne i32* %258, null
-  br i1 %NullCheck30, label %259, label %ThrowNullRef29
+  %NullCheck29 = icmp eq i32* %258, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %259
 
 ; <label>:259                                     ; preds = %256
   store i32 %257, i32* %258, align 8
@@ -1149,16 +1231,16 @@ entry:
   %262 = load i8*, i8** %arg1
   %263 = getelementptr inbounds i8, i8* %262, i64 12
   %264 = bitcast i8* %263 to i16*
-  %NullCheck32 = icmp ne i16* %264, null
-  br i1 %NullCheck32, label %265, label %ThrowNullRef31
+  %NullCheck31 = icmp eq i16* %264, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %265
 
 ; <label>:265                                     ; preds = %259
   %266 = load i16, i16* %264, align 8
   %267 = sext i16 %266 to i32
   %268 = bitcast i8* %261 to i16*
   %269 = trunc i32 %267 to i16
-  %NullCheck34 = icmp ne i16* %268, null
-  br i1 %NullCheck34, label %270, label %ThrowNullRef33
+  %NullCheck33 = icmp eq i16* %268, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %270
 
 ; <label>:270                                     ; preds = %265
   store i16 %269, i16* %268, align 8
@@ -1168,14 +1250,14 @@ entry:
   %272 = load i8*, i8** %arg0
   %273 = load i8*, i8** %arg1
   %274 = bitcast i8* %273 to i64*
-  %NullCheck8 = icmp ne i64* %274, null
-  br i1 %NullCheck8, label %275, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64* %274, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %275
 
 ; <label>:275                                     ; preds = %271
   %276 = load i64, i64* %274, align 8
   %277 = bitcast i8* %272 to i64*
-  %NullCheck10 = icmp ne i64* %277, null
-  br i1 %NullCheck10, label %278, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %277, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %278
 
 ; <label>:278                                     ; preds = %275
   store i64 %276, i64* %277, align 8
@@ -1184,14 +1266,14 @@ entry:
   %281 = load i8*, i8** %arg1
   %282 = getelementptr inbounds i8, i8* %281, i64 8
   %283 = bitcast i8* %282 to i32*
-  %NullCheck12 = icmp ne i32* %283, null
-  br i1 %NullCheck12, label %284, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i32* %283, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %284
 
 ; <label>:284                                     ; preds = %278
   %285 = load i32, i32* %283, align 8
   %286 = bitcast i8* %280 to i32*
-  %NullCheck14 = icmp ne i32* %286, null
-  br i1 %NullCheck14, label %287, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i32* %286, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %287
 
 ; <label>:287                                     ; preds = %284
   store i32 %285, i32* %286, align 8
@@ -1200,16 +1282,16 @@ entry:
   %290 = load i8*, i8** %arg1
   %291 = getelementptr inbounds i8, i8* %290, i64 12
   %292 = bitcast i8* %291 to i16*
-  %NullCheck16 = icmp ne i16* %292, null
-  br i1 %NullCheck16, label %293, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i16* %292, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %293
 
 ; <label>:293                                     ; preds = %287
   %294 = load i16, i16* %292, align 8
   %295 = sext i16 %294 to i32
   %296 = bitcast i8* %289 to i16*
   %297 = trunc i32 %295 to i16
-  %NullCheck18 = icmp ne i16* %296, null
-  br i1 %NullCheck18, label %298, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i16* %296, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %298
 
 ; <label>:298                                     ; preds = %293
   store i16 %297, i16* %296, align 8
@@ -1217,15 +1299,15 @@ entry:
   %300 = getelementptr inbounds i8, i8* %299, i64 14
   %301 = load i8*, i8** %arg1
   %302 = getelementptr inbounds i8, i8* %301, i64 14
-  %NullCheck20 = icmp ne i8* %302, null
-  br i1 %NullCheck20, label %303, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i8* %302, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %303
 
 ; <label>:303                                     ; preds = %298
   %304 = load i8, i8* %302, align 8
   %305 = zext i8 %304 to i32
   %306 = trunc i32 %305 to i8
-  %NullCheck22 = icmp ne i8* %300, null
-  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i8* %300, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %307
 
 ; <label>:307                                     ; preds = %303
   store i8 %306, i8* %300, align 8
@@ -1235,14 +1317,14 @@ entry:
   %309 = load i8*, i8** %arg0
   %310 = load i8*, i8** %arg1
   %311 = bitcast i8* %310 to i64*
-  %NullCheck = icmp ne i64* %311, null
-  br i1 %NullCheck, label %312, label %ThrowNullRef
+  %NullCheck = icmp eq i64* %311, null
+  br i1 %NullCheck, label %ThrowNullRef, label %312
 
 ; <label>:312                                     ; preds = %308
   %313 = load i64, i64* %311, align 8
   %314 = bitcast i8* %309 to i64*
-  %NullCheck2 = icmp ne i64* %314, null
-  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64* %314, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %315
 
 ; <label>:315                                     ; preds = %312
   store i64 %313, i64* %314, align 8
@@ -1251,14 +1333,14 @@ entry:
   %318 = load i8*, i8** %arg1
   %319 = getelementptr inbounds i8, i8* %318, i64 8
   %320 = bitcast i8* %319 to i64*
-  %NullCheck4 = icmp ne i64* %320, null
-  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64* %320, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %321
 
 ; <label>:321                                     ; preds = %315
   %322 = load i64, i64* %320, align 8
   %323 = bitcast i8* %317 to i64*
-  %NullCheck6 = icmp ne i64* %323, null
-  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64* %323, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %324
 
 ; <label>:324                                     ; preds = %321
   store i64 %322, i64* %323, align 8
@@ -1286,15 +1368,15 @@ entry:
 ; <label>:338                                     ; preds = %333
   %339 = load i8*, i8** %arg0
   %340 = load i8*, i8** %arg1
-  %NullCheck136 = icmp ne i8* %340, null
-  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+  %NullCheck135 = icmp eq i8* %340, null
+  br i1 %NullCheck135, label %ThrowNullRef136, label %341
 
 ; <label>:341                                     ; preds = %338
   %342 = load i8, i8* %340, align 8
   %343 = zext i8 %342 to i32
   %344 = trunc i32 %343 to i8
-  %NullCheck138 = icmp ne i8* %339, null
-  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+  %NullCheck137 = icmp eq i8* %339, null
+  br i1 %NullCheck137, label %ThrowNullRef138, label %345
 
 ; <label>:345                                     ; preds = %341
   store i8 %344, i8* %339, align 8
@@ -1317,16 +1399,16 @@ entry:
   %357 = load i8*, i8** %arg0
   %358 = load i8*, i8** %arg1
   %359 = bitcast i8* %358 to i16*
-  %NullCheck140 = icmp ne i16* %359, null
-  br i1 %NullCheck140, label %360, label %ThrowNullRef139
+  %NullCheck139 = icmp eq i16* %359, null
+  br i1 %NullCheck139, label %ThrowNullRef140, label %360
 
 ; <label>:360                                     ; preds = %356
   %361 = load i16, i16* %359, align 8
   %362 = sext i16 %361 to i32
   %363 = bitcast i8* %357 to i16*
   %364 = trunc i32 %362 to i16
-  %NullCheck142 = icmp ne i16* %363, null
-  br i1 %NullCheck142, label %365, label %ThrowNullRef141
+  %NullCheck141 = icmp eq i16* %363, null
+  br i1 %NullCheck141, label %ThrowNullRef142, label %365
 
 ; <label>:365                                     ; preds = %360
   store i16 %364, i16* %363, align 8
@@ -1352,14 +1434,14 @@ entry:
   %378 = load i8*, i8** %arg0
   %379 = load i8*, i8** %arg1
   %380 = bitcast i8* %379 to i32*
-  %NullCheck144 = icmp ne i32* %380, null
-  br i1 %NullCheck144, label %381, label %ThrowNullRef143
+  %NullCheck143 = icmp eq i32* %380, null
+  br i1 %NullCheck143, label %ThrowNullRef144, label %381
 
 ; <label>:381                                     ; preds = %377
   %382 = load i32, i32* %380, align 8
   %383 = bitcast i8* %378 to i32*
-  %NullCheck146 = icmp ne i32* %383, null
-  br i1 %NullCheck146, label %384, label %ThrowNullRef145
+  %NullCheck145 = icmp eq i32* %383, null
+  br i1 %NullCheck145, label %ThrowNullRef146, label %384
 
 ; <label>:384                                     ; preds = %381
   store i32 %382, i32* %383, align 8
@@ -1384,14 +1466,14 @@ entry:
   %395 = load i8*, i8** %arg0
   %396 = load i8*, i8** %arg1
   %397 = bitcast i8* %396 to i64*
-  %NullCheck164 = icmp ne i64* %397, null
-  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+  %NullCheck163 = icmp eq i64* %397, null
+  br i1 %NullCheck163, label %ThrowNullRef164, label %398
 
 ; <label>:398                                     ; preds = %394
   %399 = load i64, i64* %397, align 8
   %400 = bitcast i8* %395 to i64*
-  %NullCheck166 = icmp ne i64* %400, null
-  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+  %NullCheck165 = icmp eq i64* %400, null
+  br i1 %NullCheck165, label %ThrowNullRef166, label %401
 
 ; <label>:401                                     ; preds = %398
   store i64 %399, i64* %400, align 8
@@ -1400,14 +1482,14 @@ entry:
   %404 = load i8*, i8** %arg1
   %405 = getelementptr inbounds i8, i8* %404, i64 8
   %406 = bitcast i8* %405 to i64*
-  %NullCheck168 = icmp ne i64* %406, null
-  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+  %NullCheck167 = icmp eq i64* %406, null
+  br i1 %NullCheck167, label %ThrowNullRef168, label %407
 
 ; <label>:407                                     ; preds = %401
   %408 = load i64, i64* %406, align 8
   %409 = bitcast i8* %403 to i64*
-  %NullCheck170 = icmp ne i64* %409, null
-  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+  %NullCheck169 = icmp eq i64* %409, null
+  br i1 %NullCheck169, label %ThrowNullRef170, label %410
 
 ; <label>:410                                     ; preds = %407
   store i64 %408, i64* %409, align 8
@@ -1437,14 +1519,14 @@ entry:
   %425 = load i8*, i8** %arg0
   %426 = load i8*, i8** %arg1
   %427 = bitcast i8* %426 to i64*
-  %NullCheck148 = icmp ne i64* %427, null
-  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+  %NullCheck147 = icmp eq i64* %427, null
+  br i1 %NullCheck147, label %ThrowNullRef148, label %428
 
 ; <label>:428                                     ; preds = %424
   %429 = load i64, i64* %427, align 8
   %430 = bitcast i8* %425 to i64*
-  %NullCheck150 = icmp ne i64* %430, null
-  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+  %NullCheck149 = icmp eq i64* %430, null
+  br i1 %NullCheck149, label %ThrowNullRef150, label %431
 
 ; <label>:431                                     ; preds = %428
   store i64 %429, i64* %430, align 8
@@ -1466,14 +1548,14 @@ entry:
   %441 = load i8*, i8** %arg0
   %442 = load i8*, i8** %arg1
   %443 = bitcast i8* %442 to i32*
-  %NullCheck152 = icmp ne i32* %443, null
-  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+  %NullCheck151 = icmp eq i32* %443, null
+  br i1 %NullCheck151, label %ThrowNullRef152, label %444
 
 ; <label>:444                                     ; preds = %440
   %445 = load i32, i32* %443, align 8
   %446 = bitcast i8* %441 to i32*
-  %NullCheck154 = icmp ne i32* %446, null
-  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+  %NullCheck153 = icmp eq i32* %446, null
+  br i1 %NullCheck153, label %ThrowNullRef154, label %447
 
 ; <label>:447                                     ; preds = %444
   store i32 %445, i32* %446, align 8
@@ -1495,16 +1577,16 @@ entry:
   %457 = load i8*, i8** %arg0
   %458 = load i8*, i8** %arg1
   %459 = bitcast i8* %458 to i16*
-  %NullCheck156 = icmp ne i16* %459, null
-  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+  %NullCheck155 = icmp eq i16* %459, null
+  br i1 %NullCheck155, label %ThrowNullRef156, label %460
 
 ; <label>:460                                     ; preds = %456
   %461 = load i16, i16* %459, align 8
   %462 = sext i16 %461 to i32
   %463 = bitcast i8* %457 to i16*
   %464 = trunc i32 %462 to i16
-  %NullCheck158 = icmp ne i16* %463, null
-  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+  %NullCheck157 = icmp eq i16* %463, null
+  br i1 %NullCheck157, label %ThrowNullRef158, label %465
 
 ; <label>:465                                     ; preds = %460
   store i16 %464, i16* %463, align 8
@@ -1525,15 +1607,15 @@ entry:
 ; <label>:474                                     ; preds = %470
   %475 = load i8*, i8** %arg0
   %476 = load i8*, i8** %arg1
-  %NullCheck160 = icmp ne i8* %476, null
-  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+  %NullCheck159 = icmp eq i8* %476, null
+  br i1 %NullCheck159, label %ThrowNullRef160, label %477
 
 ; <label>:477                                     ; preds = %474
   %478 = load i8, i8* %476, align 8
   %479 = zext i8 %478 to i32
   %480 = trunc i32 %479 to i8
-  %NullCheck162 = icmp ne i8* %475, null
-  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+  %NullCheck161 = icmp eq i8* %475, null
+  br i1 %NullCheck161, label %ThrowNullRef162, label %481
 
 ; <label>:481                                     ; preds = %477
   store i8 %480, i8* %475, align 8
@@ -1553,343 +1635,343 @@ ThrowNullRef:                                     ; preds = %308
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %312
+ThrowNullRef2:                                    ; preds = %312
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %315
+ThrowNullRef4:                                    ; preds = %315
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %321
+ThrowNullRef6:                                    ; preds = %321
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %271
+ThrowNullRef8:                                    ; preds = %271
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %275
+ThrowNullRef10:                                   ; preds = %275
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %278
+ThrowNullRef12:                                   ; preds = %278
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %284
+ThrowNullRef14:                                   ; preds = %284
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %287
+ThrowNullRef16:                                   ; preds = %287
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %293
+ThrowNullRef18:                                   ; preds = %293
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %298
+ThrowNullRef20:                                   ; preds = %298
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %303
+ThrowNullRef22:                                   ; preds = %303
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %243
+ThrowNullRef24:                                   ; preds = %243
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %247
+ThrowNullRef26:                                   ; preds = %247
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %250
+ThrowNullRef28:                                   ; preds = %250
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %256
+ThrowNullRef30:                                   ; preds = %256
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %259
+ThrowNullRef32:                                   ; preds = %259
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %265
+ThrowNullRef34:                                   ; preds = %265
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %217
+ThrowNullRef36:                                   ; preds = %217
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %221
+ThrowNullRef38:                                   ; preds = %221
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %224
+ThrowNullRef40:                                   ; preds = %224
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %230
+ThrowNullRef42:                                   ; preds = %230
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %233
+ThrowNullRef44:                                   ; preds = %233
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %238
+ThrowNullRef46:                                   ; preds = %238
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %200
+ThrowNullRef48:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %204
+ThrowNullRef50:                                   ; preds = %204
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %207
+ThrowNullRef52:                                   ; preds = %207
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %213
+ThrowNullRef54:                                   ; preds = %213
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %172
+ThrowNullRef56:                                   ; preds = %172
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %176
+ThrowNullRef58:                                   ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %179
+ThrowNullRef60:                                   ; preds = %179
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %185
+ThrowNullRef62:                                   ; preds = %185
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %190
+ThrowNullRef64:                                   ; preds = %190
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %195
+ThrowNullRef66:                                   ; preds = %195
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %153
+ThrowNullRef68:                                   ; preds = %153
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %157
+ThrowNullRef70:                                   ; preds = %157
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %160
+ThrowNullRef72:                                   ; preds = %160
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %166
+ThrowNullRef74:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %136
+ThrowNullRef76:                                   ; preds = %136
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %140
+ThrowNullRef78:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %143
+ThrowNullRef80:                                   ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %148
+ThrowNullRef82:                                   ; preds = %148
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %128
+ThrowNullRef84:                                   ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %132
+ThrowNullRef86:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %100
+ThrowNullRef88:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %104
+ThrowNullRef90:                                   ; preds = %104
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %107
+ThrowNullRef92:                                   ; preds = %107
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %113
+ThrowNullRef94:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %118
+ThrowNullRef96:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %123
+ThrowNullRef98:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %81
+ThrowNullRef100:                                  ; preds = %81
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef101:                                  ; preds = %85
+ThrowNullRef102:                                  ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef103:                                  ; preds = %88
+ThrowNullRef104:                                  ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef105:                                  ; preds = %94
+ThrowNullRef106:                                  ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef107:                                  ; preds = %64
+ThrowNullRef108:                                  ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef109:                                  ; preds = %68
+ThrowNullRef110:                                  ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef111:                                  ; preds = %71
+ThrowNullRef112:                                  ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef113:                                  ; preds = %76
+ThrowNullRef114:                                  ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef115:                                  ; preds = %56
+ThrowNullRef116:                                  ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef117:                                  ; preds = %60
+ThrowNullRef118:                                  ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef119:                                  ; preds = %37
+ThrowNullRef120:                                  ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef121:                                  ; preds = %41
+ThrowNullRef122:                                  ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef123:                                  ; preds = %46
+ThrowNullRef124:                                  ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef125:                                  ; preds = %51
+ThrowNullRef126:                                  ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef127:                                  ; preds = %27
+ThrowNullRef128:                                  ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef129:                                  ; preds = %31
+ThrowNullRef130:                                  ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef131:                                  ; preds = %19
+ThrowNullRef132:                                  ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef133:                                  ; preds = %22
+ThrowNullRef134:                                  ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef135:                                  ; preds = %338
+ThrowNullRef136:                                  ; preds = %338
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef137:                                  ; preds = %341
+ThrowNullRef138:                                  ; preds = %341
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef139:                                  ; preds = %356
+ThrowNullRef140:                                  ; preds = %356
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef141:                                  ; preds = %360
+ThrowNullRef142:                                  ; preds = %360
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef143:                                  ; preds = %377
+ThrowNullRef144:                                  ; preds = %377
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef145:                                  ; preds = %381
+ThrowNullRef146:                                  ; preds = %381
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef147:                                  ; preds = %424
+ThrowNullRef148:                                  ; preds = %424
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef149:                                  ; preds = %428
+ThrowNullRef150:                                  ; preds = %428
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef151:                                  ; preds = %440
+ThrowNullRef152:                                  ; preds = %440
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef153:                                  ; preds = %444
+ThrowNullRef154:                                  ; preds = %444
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef155:                                  ; preds = %456
+ThrowNullRef156:                                  ; preds = %456
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef157:                                  ; preds = %460
+ThrowNullRef158:                                  ; preds = %460
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef159:                                  ; preds = %474
+ThrowNullRef160:                                  ; preds = %474
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef161:                                  ; preds = %477
+ThrowNullRef162:                                  ; preds = %477
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef163:                                  ; preds = %394
+ThrowNullRef164:                                  ; preds = %394
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef165:                                  ; preds = %398
+ThrowNullRef166:                                  ; preds = %398
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef167:                                  ; preds = %401
+ThrowNullRef168:                                  ; preds = %401
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef169:                                  ; preds = %407
+ThrowNullRef170:                                  ; preds = %407
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1939,8 +2021,8 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
-  br i1 %NullCheck, label %22, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %ThrowNullRef, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
@@ -1948,8 +2030,8 @@ entry:
   store i32 %24, i32* %loc0
   %25 = load i32, i32* %loc0
   %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %26, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %27
 
 ; <label>:27                                      ; preds = %22
   %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
@@ -1971,7 +2053,7 @@ ThrowNullRef:                                     ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1989,8 +2071,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -2022,15 +2104,15 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2048,16 +2130,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
   %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
   store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %15
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
@@ -2072,8 +2154,8 @@ entry:
   %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
   %29 = ptrtoint i16 addrspace(1)* %28 to i64
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %19
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
@@ -2089,19 +2171,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2114,8 +2196,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
@@ -2128,7 +2210,7 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[loadElem]
+Failed to read AppDomain.PrepareDataForSetup[storeElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
@@ -2202,8 +2284,8 @@ entry:
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
-  br i1 %NullCheck24, label %27, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = load i64, i64 addrspace(1)* %26
@@ -2218,8 +2300,8 @@ entry:
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
-  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
   %41 = load i64, i64 addrspace(1)* %39
@@ -2236,8 +2318,8 @@ entry:
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
-  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
   %54 = load i64, i64 addrspace(1)* %52
@@ -2252,8 +2334,8 @@ entry:
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
   %67 = load i64, i64 addrspace(1)* %65
@@ -2270,8 +2352,8 @@ entry:
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
-  br i1 %NullCheck16, label %79, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
   %80 = load i64, i64 addrspace(1)* %78
@@ -2286,8 +2368,8 @@ entry:
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
-  br i1 %NullCheck18, label %92, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
   %93 = load i64, i64 addrspace(1)* %91
@@ -2304,8 +2386,8 @@ entry:
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
-  br i1 %NullCheck12, label %105, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = load i64, i64 addrspace(1)* %104
@@ -2320,8 +2402,8 @@ entry:
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
-  br i1 %NullCheck14, label %118, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
   %119 = load i64, i64 addrspace(1)* %117
@@ -2337,8 +2419,8 @@ entry:
 
 ; <label>:128                                     ; preds = %20
   %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
-  br i1 %NullCheck4, label %130, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %129, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %130
 
 ; <label>:130                                     ; preds = %128
   %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
@@ -2346,8 +2428,8 @@ entry:
   %133 = load i16, i16 addrspace(1)* %132, align 8
   %134 = zext i16 %133 to i32
   %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
-  br i1 %NullCheck6, label %136, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %135, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %136
 
 ; <label>:136                                     ; preds = %130
   %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
@@ -2360,8 +2442,8 @@ entry:
 
 ; <label>:143                                     ; preds = %136
   %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
-  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %144, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %145
 
 ; <label>:145                                     ; preds = %143
   %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
@@ -2369,8 +2451,8 @@ entry:
   %148 = load i16, i16 addrspace(1)* %147, align 8
   %149 = zext i16 %148 to i32
   %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %150, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %151
 
 ; <label>:151                                     ; preds = %145
   %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
@@ -2388,8 +2470,8 @@ entry:
 
 ; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
-  br i1 %NullCheck, label %163, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %ThrowNullRef, label %163
 
 ; <label>:163                                     ; preds = %161
   %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
@@ -2399,8 +2481,8 @@ entry:
 
 ; <label>:167                                     ; preds = %163
   %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
-  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %168, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %169
 
 ; <label>:169                                     ; preds = %167
   %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
@@ -2432,55 +2514,55 @@ ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %167
+ThrowNullRef2:                                    ; preds = %167
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %128
+ThrowNullRef4:                                    ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %130
+ThrowNullRef6:                                    ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %143
+ThrowNullRef8:                                    ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %145
+ThrowNullRef10:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %102
+ThrowNullRef12:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %105
+ThrowNullRef14:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %76
+ThrowNullRef16:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %79
+ThrowNullRef18:                                   ; preds = %79
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %50
+ThrowNullRef20:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %53
+ThrowNullRef22:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %24
+ThrowNullRef24:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %27
+ThrowNullRef26:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2503,15 +2585,15 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2519,16 +2601,16 @@ entry:
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
   store i32 %8, i32* %loc0
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
   %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
   store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
@@ -2546,16 +2628,16 @@ entry:
 
 ; <label>:23                                      ; preds = %64
   %24 = load i16*, i16** %loc3
-  %NullCheck12 = icmp ne i16* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i16* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
   store i32 %27, i32* %loc5
   %28 = load i16*, i16** %loc4
-  %NullCheck14 = icmp ne i16* %28, null
-  br i1 %NullCheck14, label %29, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %28, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = load i16, i16* %28, align 8
@@ -2620,15 +2702,15 @@ entry:
 
 ; <label>:67                                      ; preds = %64
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
-  br i1 %NullCheck8, label %69, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %68, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %69
 
 ; <label>:69                                      ; preds = %67
   %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
   %71 = load i32, i32 addrspace(1)* %70
   %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
-  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %73
 
 ; <label>:73                                      ; preds = %69
   %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
@@ -2645,31 +2727,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %67
+ThrowNullRef8:                                    ; preds = %67
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %69
+ThrowNullRef10:                                   ; preds = %69
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2710,14 +2792,14 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
   %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
@@ -2730,14 +2812,14 @@ entry:
 
 ; <label>:11                                      ; preds = %4
   %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
   %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
@@ -2749,14 +2831,14 @@ entry:
 
 ; <label>:22                                      ; preds = %16
   %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
   %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
-  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
-  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
@@ -2804,23 +2886,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2836,7 +2918,280 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[loadElem]
+Successfully read RuntimeType.IsAssignableFrom
+
+define i8 @RuntimeType.IsAssignableFrom(%System.RuntimeType addrspace(1)* %param0, %System.Type addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.RuntimeType addrspace(1)*
+  %arg1 = alloca %System.Type addrspace(1)*
+  %loc0 = alloca %System.RuntimeType addrspace(1)*
+  %loc1 = alloca %"System.Type[]" addrspace(1)*
+  %loc2 = alloca i32
+  store %System.RuntimeType addrspace(1)* %param0, %System.RuntimeType addrspace(1)** %this
+  store %System.Type addrspace(1)* %param1, %System.Type addrspace(1)** %arg1
+  %0 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %1 = icmp ne %System.Type addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i8 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %5 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %6 = bitcast %System.Type addrspace(1)* %4 to %System.Object addrspace(1)*
+  %7 = bitcast %System.RuntimeType addrspace(1)* %5 to %System.Object addrspace(1)*
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %6, %System.Object addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %3
+  ret i8 1
+
+; <label>:12                                      ; preds = %3
+  %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 152
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 32
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
+  %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
+  %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
+  store %System.RuntimeType addrspace(1)* %25, %System.RuntimeType addrspace(1)** %loc0
+  %26 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %27 = icmp eq %System.RuntimeType addrspace(1)* %26, null
+  br i1 %27, label %34, label %28
+
+; <label>:28                                      ; preds = %15
+  %29 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %30 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)*)*)(%System.RuntimeType addrspace(1)* %29, %System.RuntimeType addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+; <label>:34                                      ; preds = %15
+  %35 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %36 = call %System.Reflection.Emit.TypeBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Reflection.Emit.TypeBuilder addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %35)
+  %37 = icmp eq %System.Reflection.Emit.TypeBuilder addrspace(1)* %36, null
+  br i1 %37, label %139, label %38
+
+; <label>:38                                      ; preds = %34
+  %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %42
+
+; <label>:42                                      ; preds = %38
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 152
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 40
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
+  %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
+  %53 = zext i8 %52 to i32
+  %54 = icmp eq i32 %53, 0
+  br i1 %54, label %56, label %55
+
+; <label>:55                                      ; preds = %42
+  ret i8 1
+
+; <label>:56                                      ; preds = %42
+  %57 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %58 = bitcast %System.RuntimeType addrspace(1)* %57 to %System.Type addrspace(1)*
+  %59 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %58)
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %64 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.Type addrspace(1)* %63, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = bitcast %System.RuntimeType addrspace(1)* %64 to %System.Type addrspace(1)*
+  %67 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %63, %System.Type addrspace(1)* %66)
+  %68 = zext i8 %67 to i32
+  %69 = trunc i32 %68 to i8
+  ret i8 %69
+
+; <label>:70                                      ; preds = %56
+  %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
+  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %73
+
+; <label>:73                                      ; preds = %70
+  %74 = load i64, i64 addrspace(1)* %72
+  %75 = add i64 %74, 128
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = add i64 %77, 0
+  %79 = inttoptr i64 %78 to i64*
+  %80 = load i64, i64* %79
+  %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
+  %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
+  %83 = call i8 %82(%System.Type addrspace(1)* %81)
+  %84 = zext i8 %83 to i32
+  %85 = icmp eq i32 %84, 0
+  br i1 %85, label %139, label %86
+
+; <label>:86                                      ; preds = %73
+  %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
+  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %89
+
+; <label>:89                                      ; preds = %86
+  %90 = load i64, i64 addrspace(1)* %88
+  %91 = add i64 %90, 128
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = add i64 %93, 24
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
+  %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
+  %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
+  store %"System.Type[]" addrspace(1)* %99, %"System.Type[]" addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %129
+
+; <label>:100                                     ; preds = %132
+  %101 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %102 = load i32, i32* %loc2
+  %NullCheck11 = icmp eq %"System.Type[]" addrspace(1)* %101, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %103
+
+; <label>:103                                     ; preds = %100
+  %104 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 1
+  %105 = load i32, i32 addrspace(1)* %104
+  %106 = zext i32 %105 to i64
+  %107 = zext i32 %102 to i64
+  %BoundsCheck = icmp uge i64 %107, %106
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %108
+
+; <label>:108                                     ; preds = %103
+  %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
+  %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
+  %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
+  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %113
+
+; <label>:113                                     ; preds = %108
+  %114 = load i64, i64 addrspace(1)* %112
+  %115 = add i64 %114, 152
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = add i64 %117, 56
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
+  %123 = zext i8 %122 to i32
+  %124 = icmp ne i32 %123, 0
+  br i1 %124, label %126, label %125
+
+; <label>:125                                     ; preds = %113
+  ret i8 0
+
+; <label>:126                                     ; preds = %113
+  %127 = load i32, i32* %loc2
+  %128 = add i32 %127, 1
+  store i32 %128, i32* %loc2
+  br label %129
+
+; <label>:129                                     ; preds = %89, %126
+  %130 = load i32, i32* %loc2
+  %131 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %NullCheck9 = icmp eq %"System.Type[]" addrspace(1)* %131, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %132
+
+; <label>:132                                     ; preds = %129
+  %133 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %131, i32 0, i32 1
+  %134 = load i32, i32 addrspace(1)* %133
+  %135 = zext i32 %134 to i64
+  %136 = trunc i64 %135 to i32
+  %137 = icmp slt i32 %130, %136
+  br i1 %137, label %100, label %138
+
+; <label>:138                                     ; preds = %132
+  ret i8 1
+
+; <label>:139                                     ; preds = %34, %73
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %129
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %103
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -2893,7 +3248,7 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElem]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -2904,8 +3259,8 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -2997,8 +3352,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
@@ -3059,8 +3414,8 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -3087,8 +3442,8 @@ entry:
 
 ; <label>:17                                      ; preds = %5, %11
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
@@ -3097,8 +3452,8 @@ entry:
 
 ; <label>:22                                      ; preds = %1, %11
   %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
@@ -3109,11 +3464,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %17
+ThrowNullRef2:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %22
+ThrowNullRef4:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3167,15 +3522,15 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
   %15 = load i32, i32 addrspace(1)* %14
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
@@ -3198,7 +3553,7 @@ ThrowNullRef:                                     ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef2:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3232,8 +3587,8 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
@@ -3312,8 +3667,8 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -3327,8 +3682,8 @@ entry:
 ; <label>:5                                       ; preds = %43
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %7 = load i32, i32* %loc1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck6, label %8, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
@@ -3366,8 +3721,8 @@ entry:
 ; <label>:32                                      ; preds = %21, %25
   %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
   %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
-  br i1 %NullCheck8, label %35, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = trunc i32 %34 to i16
@@ -3380,8 +3735,8 @@ entry:
 ; <label>:40                                      ; preds = %1, %35
   %41 = load i32, i32* %loc1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
-  br i1 %NullCheck2, label %43, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %42, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
@@ -3392,8 +3747,8 @@ entry:
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
   %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
-  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
   %51 = load i64, i64 addrspace(1)* %49
@@ -3412,19 +3767,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %40
+ThrowNullRef2:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %47
+ThrowNullRef4:                                    ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %5
+ThrowNullRef6:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %32
+ThrowNullRef8:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3467,8 +3822,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
@@ -3492,11 +3847,391 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(i16* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store i16* %param0, i16** %arg0
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load i32, i32* %arg3
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %42, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %37, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg2
+  %13 = load i32, i32* %arg3
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %37, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %24 = load i32, i32* %arg2
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load i16*, i16** %arg0
+  %35 = load i32, i32* %arg3
+  %36 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %36, i16* %34, i32 %35)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:37                                      ; preds = %5, %16
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %39)
+  %41 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41, %System.String addrspace(1)* %38, %System.String addrspace(1)* %40)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41) #0
+  unreachable
+
+; <label>:42                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
-Failed to read StringBuilder.ToString[loadElemA]
+Successfully read StringBuilder.ToString
+
+define %System.String addrspace(1)* @StringBuilder.ToString(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i16*
+  %loc3 = alloca %"System.Char[]" addrspace(1)*
+  %loc4 = alloca i32
+  %loc5 = alloca i32
+  %loc6 = alloca i16 addrspace(1)*
+  %loc7 = alloca %System.String addrspace(1)*
+  %loc8 = alloca %"System.Char[]" addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %0)
+  %2 = icmp ne i32 %1, 0
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %4
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %6)
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %7)
+  store %System.String addrspace(1)* %8, %System.String addrspace(1)** %loc0
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.Text.StringBuilder addrspace(1)* %9, %System.Text.StringBuilder addrspace(1)** %loc1
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  store %System.String addrspace(1)* %10, %System.String addrspace(1)** %loc7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc7
+  %12 = ptrtoint %System.String addrspace(1)* %11 to i64
+  %13 = icmp eq i64 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %5
+  %15 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %16 = sext i32 %15 to i64
+  %17 = add i64 %12, %16
+  br label %18
+
+; <label>:18                                      ; preds = %5, %14
+  %19 = phi i64 [ %12, %5 ], [ %17, %14 ]
+  %20 = inttoptr i64 %19 to i16*
+  store i16* %20, i16** %loc2
+  br label %21
+
+; <label>:21                                      ; preds = %98, %18
+  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %22, null
+  br i1 %NullCheck, label %ThrowNullRef, label %23
+
+; <label>:23                                      ; preds = %21
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 3
+  %25 = load i32, i32 addrspace(1)* %24, align 8
+  %26 = icmp sle i32 %25, 0
+  br i1 %26, label %96, label %27
+
+; <label>:27                                      ; preds = %23
+  %28 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %28, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %29
+
+; <label>:29                                      ; preds = %27
+  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %28, i32 0, i32 1
+  %31 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %30, align 8
+  store %"System.Char[]" addrspace(1)* %31, %"System.Char[]" addrspace(1)** %loc3
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %33
+
+; <label>:33                                      ; preds = %29
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  store i32 %35, i32* %loc4
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  %39 = load i32, i32 addrspace(1)* %38, align 8
+  store i32 %39, i32* %loc5
+  %40 = load i32, i32* %loc5
+  %41 = load i32, i32* %loc4
+  %42 = add i32 %40, %41
+  %43 = zext i32 %42 to i64
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %45
+
+; <label>:45                                      ; preds = %37
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = sext i32 %47 to i64
+  %49 = icmp sgt i64 %43, %48
+  br i1 %49, label %91, label %50
+
+; <label>:50                                      ; preds = %45
+  %51 = load i32, i32* %loc5
+  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %52, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %53
+
+; <label>:53                                      ; preds = %50
+  %54 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %52, i32 0, i32 1
+  %55 = load i32, i32 addrspace(1)* %54
+  %56 = zext i32 %55 to i64
+  %57 = trunc i64 %56 to i32
+  %58 = icmp ugt i32 %51, %57
+  br i1 %58, label %91, label %59
+
+; <label>:59                                      ; preds = %53
+  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  store %"System.Char[]" addrspace(1)* %60, %"System.Char[]" addrspace(1)** %loc8
+  %61 = icmp eq %"System.Char[]" addrspace(1)* %60, null
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %63, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %64
+
+; <label>:64                                      ; preds = %62
+  %65 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %63, i32 0, i32 1
+  %66 = load i32, i32 addrspace(1)* %65
+  %67 = zext i32 %66 to i64
+  %68 = trunc i64 %67 to i32
+  %69 = icmp ne i32 %68, 0
+  br i1 %69, label %71, label %70
+
+; <label>:70                                      ; preds = %59, %64
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:71                                      ; preds = %64
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %73
+
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %BoundsCheck = icmp uge i64 0, %76
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %77
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %78, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:79                                      ; preds = %70, %77
+  %80 = load i16*, i16** %loc2
+  %81 = load i32, i32* %loc4
+  %82 = sext i32 %81 to i64
+  %83 = mul i64 %82, 2
+  %84 = bitcast i16* %80 to i8*
+  %85 = getelementptr inbounds i8, i8* %84, i64 %83
+  %86 = load i16 addrspace(1)*, i16 addrspace(1)** %loc6
+  %87 = ptrtoint i16 addrspace(1)* %86 to i64
+  %88 = load i32, i32* %loc5
+  %89 = bitcast i8* %85 to i16*
+  %90 = inttoptr i64 %87 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %89, i16* %90, i32 %88)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %96
+
+; <label>:91                                      ; preds = %45, %53
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %94 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %93)
+  %95 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95, %System.String addrspace(1)* %92, %System.String addrspace(1)* %94)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95) #0
+  unreachable
+
+; <label>:96                                      ; preds = %23, %79
+  %97 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %97, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %98
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %97, i32 0, i32 2
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  store %System.Text.StringBuilder addrspace(1)* %100, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %102 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %102, label %21, label %103
+
+; <label>:103                                     ; preds = %98
+  store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc7
+  %104 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  ret %System.String addrspace(1)* %104
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method StringBuilder::get_Length using LLILCJit
+Successfully read StringBuilder.get_Length
+
+define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
+Successfully read RuntimeHelpers.get_OffsetToStringData
+
+define i32 @RuntimeHelpers.get_OffsetToStringData() {
+entry:
+  ret i32 12
+}
+
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
 Successfully read CultureData.CreateCultureData
 
@@ -3514,23 +4249,23 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
   store i8 %4, i8 addrspace(1)* %6
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
@@ -3549,11 +4284,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3566,50 +4301,50 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
   store i32 -1, i32 addrspace(1)* %2
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
   store i32 -1, i32 addrspace(1)* %8
   %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
   store i32 -1, i32 addrspace(1)* %14
   %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
   store i32 -1, i32 addrspace(1)* %17
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
@@ -3623,27 +4358,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3675,7 +4410,136 @@ Failed to read Dictionary`2.Insert[non-const derefAddress]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
 Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
-Failed to read HashHelpers.GetPrime[loadElem]
+Successfully read HashHelpers.GetPrime
+
+define i32 @HashHelpers.GetPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %6, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5, %System.String addrspace(1)* %4)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5) #0
+  unreachable
+
+; <label>:6                                       ; preds = %entry
+  store i32 0, i32* %loc0
+  br label %29
+
+; <label>:7                                       ; preds = %35
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 1296
+  %10 = addrspacecast i8 addrspace(1)* %9 to %"System.Int32[]" addrspace(1)**
+  %11 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %10
+  %12 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Int32[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = zext i32 %15 to i64
+  %17 = zext i32 %12 to i64
+  %BoundsCheck = icmp uge i64 %17, %16
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 3, i32 %12
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  store i32 %20, i32* %loc1
+  %21 = load i32, i32* %loc1
+  %22 = load i32, i32* %arg0
+  %23 = icmp slt i32 %21, %22
+  br i1 %23, label %26, label %24
+
+; <label>:24                                      ; preds = %18
+  %25 = load i32, i32* %loc1
+  ret i32 %25
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %loc0
+  %28 = add i32 %27, 1
+  store i32 %28, i32* %loc0
+  br label %29
+
+; <label>:29                                      ; preds = %6, %26
+  %30 = load i32, i32* %loc0
+  %31 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %32 = getelementptr inbounds i8, i8 addrspace(1)* %31, i64 1296
+  %33 = addrspacecast i8 addrspace(1)* %32 to %"System.Int32[]" addrspace(1)**
+  %34 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %33
+  %NullCheck = icmp eq %"System.Int32[]" addrspace(1)* %34, null
+  br i1 %NullCheck, label %ThrowNullRef, label %35
+
+; <label>:35                                      ; preds = %29
+  %36 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %34, i32 0, i32 1
+  %37 = load i32, i32 addrspace(1)* %36
+  %38 = zext i32 %37 to i64
+  %39 = trunc i64 %38 to i32
+  %40 = icmp slt i32 %30, %39
+  br i1 %40, label %7, label %41
+
+; <label>:41                                      ; preds = %35
+  %42 = load i32, i32* %arg0
+  %43 = or i32 %42, 1
+  store i32 %43, i32* %loc2
+  br label %59
+
+; <label>:44                                      ; preds = %59
+  %45 = load i32, i32* %loc2
+  %46 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %45)
+  %47 = zext i8 %46 to i32
+  %48 = icmp eq i32 %47, 0
+  br i1 %48, label %56, label %49
+
+; <label>:49                                      ; preds = %44
+  %50 = load i32, i32* %loc2
+  %51 = sub i32 %50, 1
+  %52 = srem i32 %51, 101
+  %53 = icmp eq i32 %52, 0
+  br i1 %53, label %56, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = load i32, i32* %loc2
+  ret i32 %55
+
+; <label>:56                                      ; preds = %44, %49
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %57, 2
+  store i32 %58, i32* %loc2
+  br label %59
+
+; <label>:59                                      ; preds = %41, %56
+  %60 = load i32, i32* %loc2
+  %61 = icmp slt i32 %60, 2147483647
+  br i1 %61, label %44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load i32, i32* %arg0
+  ret i32 %63
+
+ThrowNullRef:                                     ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
 Successfully read GenericEqualityComparer`1.GetHashCode
 
@@ -3694,14 +4558,14 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
   %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load i64, i64 addrspace(1)* %7
@@ -3720,7 +4584,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3750,8 +4614,8 @@ entry:
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
@@ -3796,8 +4660,8 @@ entry:
   %35 = bitcast i16* %34 to i8*
   %36 = getelementptr inbounds i8, i8* %35, i64 2
   %37 = bitcast i8* %36 to i16*
-  %NullCheck4 = icmp ne i16* %37, null
-  br i1 %NullCheck4, label %38, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %37, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %38
 
 ; <label>:38                                      ; preds = %27
   %39 = load i16, i16* %37, align 8
@@ -3824,8 +4688,8 @@ entry:
 
 ; <label>:54                                      ; preds = %22, %43
   %55 = load i16*, i16** %loc4
-  %NullCheck2 = icmp ne i16* %55, null
-  br i1 %NullCheck2, label %56, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i16* %55, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %56
 
 ; <label>:56                                      ; preds = %54
   %57 = load i16, i16* %55, align 8
@@ -3850,11 +4714,11 @@ ThrowNullRef:                                     ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %54
+ThrowNullRef2:                                    ; preds = %54
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %27
+ThrowNullRef4:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3871,8 +4735,8 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -3907,8 +4771,8 @@ entry:
 
 ; <label>:26                                      ; preds = %19
   %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
-  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %28
 
 ; <label>:28                                      ; preds = %26
   %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
@@ -3920,7 +4784,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3972,8 +4836,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
@@ -3984,26 +4848,26 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
-  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
@@ -4014,8 +4878,8 @@ entry:
 ; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
@@ -4024,8 +4888,8 @@ entry:
 
 ; <label>:25                                      ; preds = %1, %16, %23
   %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
-  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
@@ -4036,27 +4900,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %20
+ThrowNullRef10:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4069,8 +4933,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -4081,8 +4945,8 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
@@ -4091,8 +4955,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1, %8
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
@@ -4103,11 +4967,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4128,24 +4992,24 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   store i32 %3, i32* %loc0
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
   %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
   store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck4, label %9, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
@@ -4164,15 +5028,15 @@ entry:
 ; <label>:18                                      ; preds = %70
   %19 = load i16*, i16** %loc3
   %20 = bitcast i16* %19 to i64*
-  %NullCheck10 = icmp ne i64* %20, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %20, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = load i64, i64* %20, align 8
   %23 = load i16*, i16** %loc4
   %24 = bitcast i16* %23 to i64*
-  %NullCheck12 = icmp ne i64* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = load i64, i64* %24, align 8
@@ -4188,8 +5052,8 @@ entry:
   %31 = bitcast i16* %30 to i8*
   %32 = getelementptr inbounds i8, i8* %31, i64 8
   %33 = bitcast i8* %32 to i64*
-  %NullCheck14 = icmp ne i64* %33, null
-  br i1 %NullCheck14, label %34, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = load i64, i64* %33, align 8
@@ -4197,8 +5061,8 @@ entry:
   %37 = bitcast i16* %36 to i8*
   %38 = getelementptr inbounds i8, i8* %37, i64 8
   %39 = bitcast i8* %38 to i64*
-  %NullCheck16 = icmp ne i64* %39, null
-  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %40
 
 ; <label>:40                                      ; preds = %34
   %41 = load i64, i64* %39, align 8
@@ -4214,8 +5078,8 @@ entry:
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %NullCheck18 = icmp ne i64* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = load i64, i64* %48, align 8
@@ -4223,8 +5087,8 @@ entry:
   %52 = bitcast i16* %51 to i8*
   %53 = getelementptr inbounds i8, i8* %52, i64 16
   %54 = bitcast i8* %53 to i64*
-  %NullCheck20 = icmp ne i64* %54, null
-  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64* %54, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %55
 
 ; <label>:55                                      ; preds = %49
   %56 = load i64, i64* %54, align 8
@@ -4262,15 +5126,15 @@ entry:
 ; <label>:74                                      ; preds = %95
   %75 = load i16*, i16** %loc3
   %76 = bitcast i16* %75 to i32*
-  %NullCheck6 = icmp ne i32* %76, null
-  br i1 %NullCheck6, label %77, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32* %76, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %77
 
 ; <label>:77                                      ; preds = %74
   %78 = load i32, i32* %76, align 8
   %79 = load i16*, i16** %loc4
   %80 = bitcast i16* %79 to i32*
-  %NullCheck8 = icmp ne i32* %80, null
-  br i1 %NullCheck8, label %81, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i32* %80, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %81
 
 ; <label>:81                                      ; preds = %77
   %82 = load i32, i32* %80, align 8
@@ -4318,43 +5182,43 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %74
+ThrowNullRef6:                                    ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %77
+ThrowNullRef8:                                    ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %29
+ThrowNullRef14:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %34
+ThrowNullRef16:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4376,8 +5240,8 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load i64, i64 addrspace(1)* %4
@@ -4389,8 +5253,8 @@ entry:
   %12 = load i64, i64* %11
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %5
   %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
@@ -4399,8 +5263,8 @@ entry:
   %18 = load i8, i8* %arg2
   %19 = zext i8 %18 to i32
   %20 = trunc i32 %19 to i8
-  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %15
   %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
@@ -4411,11 +5275,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4442,8 +5306,8 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
@@ -4466,16 +5330,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
   %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = load i64, i64 addrspace(1)* %19
@@ -4500,8 +5364,8 @@ entry:
 ; <label>:35                                      ; preds = %30
   %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
@@ -4514,8 +5378,8 @@ entry:
 
 ; <label>:42                                      ; preds = %1, %38
   %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
-  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
@@ -4526,19 +5390,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %35
+ThrowNullRef2:                                    ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %42
+ThrowNullRef8:                                    ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4551,14 +5415,14 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
@@ -4570,7 +5434,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4583,8 +5447,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
@@ -4613,51 +5477,51 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
   %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
   %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
   %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
   %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
-  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
   store i64 %21, i64 addrspace(1)* %23
   %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %25 = load i64, i64* %loc0
-  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
@@ -4668,27 +5532,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %22
+ThrowNullRef12:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4701,8 +5565,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
@@ -4713,19 +5577,19 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
@@ -4734,8 +5598,8 @@ entry:
 
 ; <label>:15                                      ; preds = %1, %13
   %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
@@ -4746,19 +5610,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %15
+ThrowNullRef8:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4771,8 +5635,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -4831,8 +5695,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
@@ -4882,8 +5746,8 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
-  br i1 %NullCheck, label %17, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %ThrowNullRef, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
@@ -4894,15 +5758,15 @@ entry:
 
 ; <label>:22                                      ; preds = %17
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
-  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
   %26 = load i32, i32 addrspace(1)* %25
   %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
-  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %27, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
@@ -4925,8 +5789,8 @@ entry:
 ; <label>:40                                      ; preds = %17
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
-  br i1 %NullCheck6, label %43, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %41, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
@@ -4938,34 +5802,17 @@ ThrowNullRef:                                     ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %24
+ThrowNullRef4:                                    ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %40
+ThrowNullRef6:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
-}
-
-INFO:  jitting method Object::ReferenceEquals using LLILCJit
-Successfully read Object.ReferenceEquals
-
-define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
-entry:
-  %arg0 = alloca %System.Object addrspace(1)*
-  %arg1 = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
-  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
-  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = icmp eq %System.Object addrspace(1)* %0, %1
-  %3 = sext i1 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
 }
 
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
@@ -4978,21 +5825,21 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
   %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
-  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
@@ -5007,28 +5854,28 @@ entry:
 ; <label>:13                                      ; preds = %8, %12
   %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
   %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
   %21 = load i32, i32 addrspace(1)* %20, align 8
   %22 = add i32 %21, 1
-  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
   store i32 %22, i32 addrspace(1)* %24
   %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
@@ -5039,27 +5886,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5077,7 +5924,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::Setup using LLILCJit
-Failed to read AppDomain.Setup[loadElem]
+Failed to read AppDomain.Setup[unbox]
 INFO:  jitting method Thread::GetDomain using LLILCJit
 Successfully read Thread.GetDomain
 
@@ -5108,8 +5955,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
@@ -5122,14 +5969,14 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
   %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
@@ -5141,11 +5988,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5173,8 +6020,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -5189,7 +6036,328 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
 Failed to read KeyCollection.System.Collections.Generic.IEnumerable<TKey>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Successfully read Enumerator.MoveNext
+
+define i8 @Enumerator.MoveNext(%"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.RuntimeTypeHandle* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*
+  %"$TypeArg" = alloca %System.RuntimeTypeHandle*
+  store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
+  %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 8
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %76, label %12
+
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
+  br label %76
+
+; <label>:13                                      ; preds = %85
+  %14 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck19 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %15
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, i32 0, i32 0
+  %17 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %16, align 8
+  %NullCheck21 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, i32 0, i32 2
+  %20 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %19, align 8
+  %21 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck23 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %22
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, i32 0, i32 2
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %NullCheck25 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 3, i32 %24
+  %NullCheck27 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %32
+
+; <label>:32                                      ; preds = %30
+  %33 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, i32 0, i32 2
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = icmp slt i32 %34, 0
+  br i1 %35, label %68, label %36
+
+; <label>:36                                      ; preds = %32
+  %37 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %38 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck29 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %39
+
+; <label>:39                                      ; preds = %36
+  %40 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, i32 0, i32 0
+  %41 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %40, align 8
+  %NullCheck31 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, i32 0, i32 2
+  %44 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %43, align 8
+  %45 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck33 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, i32 0, i32 2
+  %48 = load i32, i32 addrspace(1)* %47, align 8
+  %NullCheck35 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %49
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = zext i32 %51 to i64
+  %53 = zext i32 %48 to i64
+  %BoundsCheck37 = icmp uge i64 %53, %52
+  br i1 %BoundsCheck37, label %ThrowIndexOutOfRange38, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 3, i32 %48
+  %NullCheck39 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %56
+
+; <label>:56                                      ; preds = %54
+  %57 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, i32 0, i32 0
+  %58 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck41 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %59
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %60, %System.__Canon addrspace(1)* %58)
+  %61 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck43 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  %64 = load i32, i32 addrspace(1)* %63, align 8
+  %65 = add i32 %64, 1
+  %NullCheck45 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  store i32 %65, i32 addrspace(1)* %67
+  ret i8 1
+
+; <label>:68                                      ; preds = %32
+  %69 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck47 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %73 = add i32 %72, 1
+  %NullCheck49 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %74
+
+; <label>:74                                      ; preds = %70
+  %75 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  store i32 %73, i32 addrspace(1)* %75
+  br label %76
+
+; <label>:76                                      ; preds = %8, %12, %74
+  %77 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %78
+
+; <label>:78                                      ; preds = %76
+  %79 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, i32 0, i32 2
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck7 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %82
+
+; <label>:82                                      ; preds = %78
+  %83 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, i32 0, i32 0
+  %84 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %83, align 8
+  %NullCheck9 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %85
+
+; <label>:85                                      ; preds = %82
+  %86 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, i32 0, i32 7
+  %87 = load i32, i32 addrspace(1)* %86, align 8
+  %88 = icmp ult i32 %80, %87
+  br i1 %88, label %13, label %89
+
+; <label>:89                                      ; preds = %85
+  %90 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %91 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck11 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %92
+
+; <label>:92                                      ; preds = %89
+  %93 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, i32 0, i32 0
+  %94 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck13 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %95
+
+; <label>:95                                      ; preds = %92
+  %96 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, i32 0, i32 7
+  %97 = load i32, i32 addrspace(1)* %96, align 8
+  %98 = add i32 %97, 1
+  %NullCheck15 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %99
+
+; <label>:99                                      ; preds = %95
+  %100 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, i32 0, i32 2
+  store i32 %98, i32 addrspace(1)* %100
+  %101 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck17 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %102
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %103, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %92
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef22:                                   ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef24:                                   ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef26:                                   ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef28:                                   ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef30:                                   ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef32:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef34:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef36:                                   ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange38:                           ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef40:                                   ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef42:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef44:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef46:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef48:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef50:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -5200,8 +6368,8 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -5232,9 +6400,9 @@ Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
 Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
-Failed to read String.MakeSeparatorList[loadElemA]
+Failed to read String.MakeSeparatorList[storeElem]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
-Failed to read String.InternalSplitKeepEmptyEntries[loadElem]
+Failed to read String.InternalSplitKeepEmptyEntries[storeElem]
 INFO:  jitting method Path::IsRelative using LLILCJit
 Successfully read Path.IsRelative
 
@@ -5243,8 +6411,8 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -5254,8 +6422,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
@@ -5271,8 +6439,8 @@ entry:
 
 ; <label>:17                                      ; preds = %7
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
@@ -5288,8 +6456,8 @@ entry:
 
 ; <label>:29                                      ; preds = %19
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %31
 
 ; <label>:31                                      ; preds = %29
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
@@ -5300,8 +6468,8 @@ entry:
 
 ; <label>:36                                      ; preds = %31
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
-  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %37, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
@@ -5312,8 +6480,8 @@ entry:
 
 ; <label>:43                                      ; preds = %31, %38
   %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
-  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %45
 
 ; <label>:45                                      ; preds = %43
   %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
@@ -5324,8 +6492,8 @@ entry:
 
 ; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %50
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
@@ -5336,8 +6504,8 @@ entry:
 
 ; <label>:57                                      ; preds = %1, %7, %19, %45, %52
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
-  br i1 %NullCheck14, label %59, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %59
 
 ; <label>:59                                      ; preds = %57
   %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
@@ -5347,8 +6515,8 @@ entry:
 
 ; <label>:63                                      ; preds = %59
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
@@ -5359,8 +6527,8 @@ entry:
 
 ; <label>:70                                      ; preds = %65
   %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
-  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.String addrspace(1)* %71, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %72
 
 ; <label>:72                                      ; preds = %70
   %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
@@ -5379,39 +6547,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %17
+ThrowNullRef4:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %29
+ThrowNullRef6:                                    ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %36
+ThrowNullRef8:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %43
+ThrowNullRef10:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %50
+ThrowNullRef12:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %57
+ThrowNullRef14:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %63
+ThrowNullRef16:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %70
+ThrowNullRef18:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5419,7 +6587,293 @@ ThrowNullRef17:                                   ; preds = %70
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
-Failed to read String.TrimHelper[loadElem]
+Successfully read String.TrimHelper
+
+define %System.String addrspace(1)* @String.TrimHelper(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i16
+  %loc4 = alloca i32
+  %loc5 = alloca i16
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = sub i32 %3, 1
+  store i32 %4, i32* %loc0
+  store i32 0, i32* %loc1
+  %5 = load i32, i32* %arg2
+  %6 = icmp eq i32 %5, 1
+  br i1 %6, label %62, label %7
+
+; <label>:7                                       ; preds = %1
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:8                                       ; preds = %58
+  store i32 0, i32* %loc2
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load i32, i32* %loc1
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2, i32 %10
+  %13 = load i16, i16 addrspace(1)* %12
+  %14 = zext i16 %13 to i32
+  %15 = trunc i32 %14 to i16
+  store i16 %15, i16* %loc3
+  store i32 0, i32* %loc2
+  br label %34
+
+; <label>:16                                      ; preds = %37
+  %17 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %18 = load i32, i32* %loc2
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %17, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %19
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = zext i32 %18 to i64
+  %BoundsCheck = icmp uge i64 %23, %22
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %24
+
+; <label>:24                                      ; preds = %19
+  %25 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 3, i32 %18
+  %26 = load i16, i16 addrspace(1)* %25, align 8
+  %27 = zext i16 %26 to i32
+  %28 = load i16, i16* %loc3
+  %29 = zext i16 %28 to i32
+  %30 = icmp eq i32 %27, %29
+  br i1 %30, label %43, label %31
+
+; <label>:31                                      ; preds = %24
+  %32 = load i32, i32* %loc2
+  %33 = add i32 %32, 1
+  store i32 %33, i32* %loc2
+  br label %34
+
+; <label>:34                                      ; preds = %11, %31
+  %35 = load i32, i32* %loc2
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = icmp slt i32 %35, %41
+  br i1 %42, label %16, label %43
+
+; <label>:43                                      ; preds = %24, %37
+  %44 = load i32, i32* %loc2
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %45, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp eq i32 %44, %50
+  br i1 %51, label %62, label %52
+
+; <label>:52                                      ; preds = %46
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %7, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %57, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %58
+
+; <label>:58                                      ; preds = %55
+  %59 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %60 = load i32, i32 addrspace(1)* %59
+  %61 = icmp slt i32 %56, %60
+  br i1 %61, label %8, label %62
+
+; <label>:62                                      ; preds = %1, %46, %58
+  %63 = load i32, i32* %arg2
+  %64 = icmp eq i32 %63, 0
+  br i1 %64, label %122, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %66, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %67
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %66, i32 0, i32 1
+  %69 = load i32, i32 addrspace(1)* %68
+  %70 = sub i32 %69, 1
+  store i32 %70, i32* %loc0
+  br label %118
+
+; <label>:71                                      ; preds = %118
+  store i32 0, i32* %loc4
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %73 = load i32, i32* %loc0
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %74
+
+; <label>:74                                      ; preds = %71
+  %75 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 2, i32 %73
+  %76 = load i16, i16 addrspace(1)* %75
+  %77 = zext i16 %76 to i32
+  %78 = trunc i32 %77 to i16
+  store i16 %78, i16* %loc5
+  store i32 0, i32* %loc4
+  br label %97
+
+; <label>:79                                      ; preds = %100
+  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %81 = load i32, i32* %loc4
+  %NullCheck19 = icmp eq %"System.Char[]" addrspace(1)* %80, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
+
+; <label>:82                                      ; preds = %79
+  %83 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 1
+  %84 = load i32, i32 addrspace(1)* %83
+  %85 = zext i32 %84 to i64
+  %86 = zext i32 %81 to i64
+  %BoundsCheck21 = icmp uge i64 %86, %85
+  br i1 %BoundsCheck21, label %ThrowIndexOutOfRange22, label %87
+
+; <label>:87                                      ; preds = %82
+  %88 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 3, i32 %81
+  %89 = load i16, i16 addrspace(1)* %88, align 8
+  %90 = zext i16 %89 to i32
+  %91 = load i16, i16* %loc5
+  %92 = zext i16 %91 to i32
+  %93 = icmp eq i32 %90, %92
+  br i1 %93, label %106, label %94
+
+; <label>:94                                      ; preds = %87
+  %95 = load i32, i32* %loc4
+  %96 = add i32 %95, 1
+  store i32 %96, i32* %loc4
+  br label %97
+
+; <label>:97                                      ; preds = %74, %94
+  %98 = load i32, i32* %loc4
+  %99 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck15 = icmp eq %"System.Char[]" addrspace(1)* %99, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %100
+
+; <label>:100                                     ; preds = %97
+  %101 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %99, i32 0, i32 1
+  %102 = load i32, i32 addrspace(1)* %101
+  %103 = zext i32 %102 to i64
+  %104 = trunc i64 %103 to i32
+  %105 = icmp slt i32 %98, %104
+  br i1 %105, label %79, label %106
+
+; <label>:106                                     ; preds = %87, %100
+  %107 = load i32, i32* %loc4
+  %108 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck17 = icmp eq %"System.Char[]" addrspace(1)* %108, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %109
+
+; <label>:109                                     ; preds = %106
+  %110 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %108, i32 0, i32 1
+  %111 = load i32, i32 addrspace(1)* %110
+  %112 = zext i32 %111 to i64
+  %113 = trunc i64 %112 to i32
+  %114 = icmp eq i32 %107, %113
+  br i1 %114, label %122, label %115
+
+; <label>:115                                     ; preds = %109
+  %116 = load i32, i32* %loc0
+  %117 = sub i32 %116, 1
+  store i32 %117, i32* %loc0
+  br label %118
+
+; <label>:118                                     ; preds = %67, %115
+  %119 = load i32, i32* %loc0
+  %120 = load i32, i32* %loc1
+  %121 = icmp sge i32 %119, %120
+  br i1 %121, label %71, label %122
+
+; <label>:122                                     ; preds = %62, %109, %118
+  %123 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %124 = load i32, i32* %loc1
+  %125 = load i32, i32* %loc0
+  %126 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %123, i32 %124, i32 %125)
+  ret %System.String addrspace(1)* %126
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %97
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange22:                           ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
 Successfully read String.CreateTrimmedString
 
@@ -5439,8 +6893,8 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
@@ -5535,8 +6989,8 @@ entry:
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i64 2872
   %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
   %8 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %7
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %3
   %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
@@ -5553,8 +7007,8 @@ entry:
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 2864
   %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
   %21 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %20
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
-  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %22
 
 ; <label>:22                                      ; preds = %16
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
@@ -5569,7 +7023,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %16
+ThrowNullRef2:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5586,8 +7040,8 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5613,8 +7067,8 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
@@ -5632,8 +7086,8 @@ entry:
 
 ; <label>:12                                      ; preds = %4
   %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
@@ -5644,8 +7098,8 @@ entry:
 
 ; <label>:19                                      ; preds = %14
   %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %19
   %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
@@ -5660,21 +7114,21 @@ entry:
   %31 = zext i16 %30 to i32
   %32 = bitcast i8* %29 to i16*
   %33 = trunc i32 %31 to i16
-  %NullCheck6 = icmp ne i16* %32, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i16* %32, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %21
   store i16 %33, i16* %32, align 8
   %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %36
 
 ; <label>:36                                      ; preds = %34
   %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
   %38 = load i32, i32 addrspace(1)* %37, align 8
   %39 = add i32 %38, 1
-  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %40
 
 ; <label>:40                                      ; preds = %36
   %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
@@ -5683,16 +7137,16 @@ entry:
 
 ; <label>:42                                      ; preds = %14
   %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
-  br i1 %NullCheck12, label %44, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
   %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
   %47 = load i16, i16* %arg1
   %48 = zext i16 %47 to i32
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = trunc i32 %48 to i16
@@ -5703,31 +7157,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %19
+ThrowNullRef4:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %21
+ThrowNullRef6:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %36
+ThrowNullRef10:                                   ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %42
+ThrowNullRef12:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %44
+ThrowNullRef14:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5740,8 +7194,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -5752,8 +7206,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
@@ -5762,14 +7216,14 @@ entry:
 
 ; <label>:11                                      ; preds = %1
   %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
@@ -5779,15 +7233,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5808,8 +7262,8 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5822,8 +7276,8 @@ entry:
 
 ; <label>:8                                       ; preds = %3
   %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
@@ -5842,15 +7296,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
-  br i1 %NullCheck4, label %22, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
   %24 = load i16*, i16* addrspace(1)* %23, align 8
   %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %25, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
@@ -5859,8 +7313,8 @@ entry:
   store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
@@ -5874,8 +7328,8 @@ entry:
 
 ; <label>:37                                      ; preds = %65
   %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %37
   %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
@@ -5886,16 +7340,16 @@ entry:
   %45 = bitcast i16* %41 to i8*
   %46 = getelementptr inbounds i8, i8* %45, i64 %44
   %47 = bitcast i8* %46 to i16*
-  %NullCheck14 = icmp ne i16* %47, null
-  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %47, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %48
 
 ; <label>:48                                      ; preds = %39
   %49 = load i16, i16* %47, align 8
   %50 = zext i16 %49 to i32
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %52 = load i32, i32* %loc1
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %53
 
 ; <label>:53                                      ; preds = %48
   %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
@@ -5916,8 +7370,8 @@ entry:
 ; <label>:62                                      ; preds = %36, %59
   %63 = load i32, i32* %loc1
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck10, label %65, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %65
 
 ; <label>:65                                      ; preds = %62
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
@@ -5936,15 +7390,15 @@ entry:
 
 ; <label>:74                                      ; preds = %70
   %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
-  br i1 %NullCheck18, label %76, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %76
 
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
   %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
-  br i1 %NullCheck20, label %80, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
   %81 = load i64, i64 addrspace(1)* %79
@@ -5958,8 +7412,8 @@ entry:
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
   %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
-  br i1 %NullCheck22, label %92, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.String addrspace(1)* %90, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %92
 
 ; <label>:92                                      ; preds = %80
   %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
@@ -5969,15 +7423,15 @@ entry:
 
 ; <label>:96                                      ; preds = %70
   %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
-  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %98
 
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
   %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
-  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
   %103 = load i64, i64 addrspace(1)* %101
@@ -5991,8 +7445,8 @@ entry:
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
   %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
-  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.String addrspace(1)* %112, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %114
 
 ; <label>:114                                     ; preds = %102
   %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
@@ -6004,59 +7458,59 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %20
+ThrowNullRef4:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %22
+ThrowNullRef6:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %26
+ThrowNullRef8:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %62
+ThrowNullRef10:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %48
+ThrowNullRef16:                                   ; preds = %48
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %74
+ThrowNullRef18:                                   ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %76
+ThrowNullRef20:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %80
+ThrowNullRef22:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %96
+ThrowNullRef24:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %98
+ThrowNullRef26:                                   ; preds = %98
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %102
+ThrowNullRef28:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6069,15 +7523,15 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
   %3 = load i16*, i16* addrspace(1)* %2, align 8
   %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
@@ -6087,8 +7541,8 @@ entry:
   %10 = bitcast i16* %3 to i8*
   %11 = getelementptr inbounds i8, i8* %10, i64 %9
   %12 = bitcast i8* %11 to i16*
-  %NullCheck4 = icmp ne i16* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %5
   store i16 0, i16* %12, align 8
@@ -6098,11 +7552,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6119,8 +7573,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -6131,8 +7585,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
@@ -6144,15 +7598,15 @@ entry:
 
 ; <label>:14                                      ; preds = %1
   %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
   %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
   %21 = load i64, i64 addrspace(1)* %19
@@ -6171,15 +7625,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %14
+ThrowNullRef4:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %16
+ThrowNullRef6:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6302,14 +7756,6 @@ entry:
   ret %System.String addrspace(1)* %57
 }
 
-INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
-Successfully read RuntimeHelpers.get_OffsetToStringData
-
-define i32 @RuntimeHelpers.get_OffsetToStringData() {
-entry:
-  ret i32 12
-}
-
 INFO:  jitting method String::Equals using LLILCJit
 Successfully read String.Equals
 
@@ -6381,8 +7827,8 @@ entry:
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
-  br i1 %NullCheck24, label %29, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
   %30 = load i64, i64 addrspace(1)* %28
@@ -6397,8 +7843,8 @@ entry:
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
-  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
   %43 = load i64, i64 addrspace(1)* %41
@@ -6418,8 +7864,8 @@ entry:
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
   %59 = load i64, i64 addrspace(1)* %57
@@ -6434,8 +7880,8 @@ entry:
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck22, label %71, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
   %72 = load i64, i64 addrspace(1)* %70
@@ -6455,8 +7901,8 @@ entry:
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
-  br i1 %NullCheck16, label %87, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = load i64, i64 addrspace(1)* %86
@@ -6471,8 +7917,8 @@ entry:
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck18, label %100, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
   %101 = load i64, i64 addrspace(1)* %99
@@ -6492,8 +7938,8 @@ entry:
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
-  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
   %117 = load i64, i64 addrspace(1)* %115
@@ -6508,8 +7954,8 @@ entry:
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
-  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
   %130 = load i64, i64 addrspace(1)* %128
@@ -6528,15 +7974,15 @@ entry:
 
 ; <label>:142                                     ; preds = %22
   %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
-  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %143, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %144
 
 ; <label>:144                                     ; preds = %142
   %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
   %146 = load i32, i32 addrspace(1)* %145
   %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
-  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %147, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %148
 
 ; <label>:148                                     ; preds = %144
   %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
@@ -6557,15 +8003,15 @@ entry:
 
 ; <label>:159                                     ; preds = %22
   %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
-  br i1 %NullCheck, label %161, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %ThrowNullRef, label %161
 
 ; <label>:161                                     ; preds = %159
   %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
   %163 = load i32, i32 addrspace(1)* %162
   %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
-  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %164, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %165
 
 ; <label>:165                                     ; preds = %161
   %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
@@ -6578,8 +8024,8 @@ entry:
 
 ; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
-  br i1 %NullCheck4, label %172, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %171, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %172
 
 ; <label>:172                                     ; preds = %170
   %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
@@ -6589,8 +8035,8 @@ entry:
 
 ; <label>:176                                     ; preds = %172
   %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
-  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %177, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %178
 
 ; <label>:178                                     ; preds = %176
   %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
@@ -6629,55 +8075,55 @@ ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %161
+ThrowNullRef2:                                    ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %170
+ThrowNullRef4:                                    ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %176
+ThrowNullRef6:                                    ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %142
+ThrowNullRef8:                                    ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %144
+ThrowNullRef10:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %113
+ThrowNullRef12:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %116
+ThrowNullRef14:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %84
+ThrowNullRef16:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %87
+ThrowNullRef18:                                   ; preds = %87
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %55
+ThrowNullRef20:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %58
+ThrowNullRef22:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %26
+ThrowNullRef24:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %29
+ThrowNullRef26:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,8 +8161,8 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck, label %14, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %ThrowNullRef, label %14
 
 ; <label>:14                                      ; preds = %8
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
@@ -6760,8 +8206,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
@@ -6770,14 +8216,14 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32, i32* %loc0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %10
   %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
   %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
@@ -6790,15 +8236,15 @@ entry:
 ; <label>:25                                      ; preds = %19
   %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
-  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
   %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
@@ -6807,8 +8253,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %37 = load i32, i32* %loc0
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %38, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %38
 
 ; <label>:38                                      ; preds = %32
   %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
@@ -6817,14 +8263,14 @@ entry:
 
 ; <label>:40                                      ; preds = %19
   %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %40
   %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
   %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
-  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
-  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
@@ -6832,8 +8278,8 @@ entry:
   %48 = zext i32 %47 to i64
   %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
-  br i1 %NullCheck16, label %51, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %51
 
 ; <label>:51                                      ; preds = %45
   %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
@@ -6847,15 +8293,15 @@ entry:
 ; <label>:57                                      ; preds = %51
   %58 = load i16*, i16** %arg1
   %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
-  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %60
 
 ; <label>:60                                      ; preds = %57
   %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
   %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
-  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %64
 
 ; <label>:64                                      ; preds = %60
   %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
@@ -6864,22 +8310,22 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
   %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
-  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %70
 
 ; <label>:70                                      ; preds = %64
   %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
   %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
-  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
-  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
   %75 = load i32, i32 addrspace(1)* %74
   %76 = zext i32 %75 to i64
   %77 = trunc i64 %76 to i32
-  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
-  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %78
 
 ; <label>:78                                      ; preds = %73
   %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
@@ -6901,8 +8347,8 @@ entry:
   %90 = bitcast i16* %86 to i8*
   %91 = getelementptr inbounds i8, i8* %90, i64 %89
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %93
 
 ; <label>:93                                      ; preds = %80
   %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
@@ -6912,8 +8358,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %99 = load i32, i32* %loc2
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %100
 
 ; <label>:100                                     ; preds = %93
   %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
@@ -6928,63 +8374,63 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %25
+ThrowNullRef6:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %32
+ThrowNullRef10:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %40
+ThrowNullRef12:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %45
+ThrowNullRef16:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %57
+ThrowNullRef18:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %60
+ThrowNullRef20:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %64
+ThrowNullRef22:                                   ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %70
+ThrowNullRef24:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %73
+ThrowNullRef26:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %80
+ThrowNullRef28:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %93
+ThrowNullRef30:                                   ; preds = %93
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7004,8 +8450,8 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
@@ -7033,43 +8479,43 @@ entry:
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %14
   %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
   %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   %28 = load i32, i32 addrspace(1)* %27, align 8
   %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
-  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %30
 
 ; <label>:30                                      ; preds = %26
   %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
   %32 = load i32, i32 addrspace(1)* %31, align 8
   %33 = add i32 %28, %32
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %34
 
 ; <label>:34                                      ; preds = %30
   %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   store i32 %33, i32 addrspace(1)* %35
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
   store i32 0, i32 addrspace(1)* %38
   %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %40
 
 ; <label>:40                                      ; preds = %37
   %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
@@ -7082,8 +8528,8 @@ entry:
 
 ; <label>:47                                      ; preds = %40
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
@@ -7098,8 +8544,8 @@ entry:
   %54 = load i32, i32* %loc0
   %55 = sext i32 %54 to i64
   %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
-  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %57
 
 ; <label>:57                                      ; preds = %52
   %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
@@ -7110,68 +8556,35 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %14
+ThrowNullRef2:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %23
+ThrowNullRef4:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %26
+ThrowNullRef6:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %30
+ThrowNullRef8:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %34
+ThrowNullRef10:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %47
+ThrowNullRef14:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %52
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-}
-
-INFO:  jitting method StringBuilder::get_Length using LLILCJit
-Successfully read StringBuilder.get_Length
-
-define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.StringBuilder addrspace(1)*
-  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
-  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
-
-; <label>:1                                       ; preds = %entry
-  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %3 = load i32, i32 addrspace(1)* %2, align 8
-  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
-
-; <label>:5                                       ; preds = %1
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = add i32 %3, %7
-  ret i32 %8
-
-ThrowNullRef:                                     ; preds = %entry
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef16:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7213,70 +8626,70 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
   %6 = load i32, i32 addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
   store i32 %6, i32 addrspace(1)* %8
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
   %13 = load i32, i32 addrspace(1)* %12, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
   store i32 %13, i32 addrspace(1)* %15
   %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
-  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %18
 
 ; <label>:18                                      ; preds = %14
   %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
   %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
   %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
   %34 = load i32, i32 addrspace(1)* %33, align 8
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
-  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
@@ -7287,39 +8700,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %28
+ThrowNullRef16:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %32
+ThrowNullRef18:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7455,13 +8868,13 @@ entry:
 ; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
@@ -7477,16 +8890,16 @@ entry:
 
 ; <label>:18                                      ; preds = %15
   %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
   store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
   %22 = load i32, i32* %loc0
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %24
 
 ; <label>:24                                      ; preds = %20
   %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
@@ -7498,13 +8911,13 @@ entry:
 ; <label>:28                                      ; preds = %15, %24
   %29 = load i32, i32* %arg1
   %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %31
   %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
@@ -7517,20 +8930,20 @@ entry:
   %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
-  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
   %46 = load i32, i32 addrspace(1)* %45, align 8
   %47 = sub i32 %40, %46
-  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
-  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i32 addrspace(1)* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %48
 
 ; <label>:48                                      ; preds = %44
   store i32 %47, i32 addrspace(1)* %39, align 8
@@ -7538,21 +8951,21 @@ entry:
 
 ; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
-  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %51
 
 ; <label>:51                                      ; preds = %49
   %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %53
 
 ; <label>:53                                      ; preds = %51
   %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
   %55 = load i32, i32 addrspace(1)* %54, align 8
   %56 = load i32, i32* %arg2
   %57 = sub i32 %55, %56
-  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %58
 
 ; <label>:58                                      ; preds = %53
   %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
@@ -7562,13 +8975,13 @@ entry:
 ; <label>:60                                      ; preds = %33, %58
   %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
   %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
-  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %63
 
 ; <label>:63                                      ; preds = %60
   %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
-  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
-  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
@@ -7578,15 +8991,15 @@ entry:
 
 ; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
-  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i32 addrspace(1)* %69, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %70
 
 ; <label>:70                                      ; preds = %68
   %71 = load i32, i32 addrspace(1)* %69, align 8
   store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
-  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
@@ -7596,8 +9009,8 @@ entry:
   store i32 %77, i32* %loc4
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
-  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %80
 
 ; <label>:80                                      ; preds = %73
   %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
@@ -7607,71 +9020,71 @@ entry:
 ; <label>:83                                      ; preds = %80
   store i32 0, i32* %loc3
   %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
-  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
-  br i1 %NullCheck26, label %88, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i32 addrspace(1)* %87, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %88
 
 ; <label>:88                                      ; preds = %85
   %89 = load i32, i32 addrspace(1)* %87, align 8
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
-  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %90
 
 ; <label>:90                                      ; preds = %88
   %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
   store i32 %89, i32 addrspace(1)* %91
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
-  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
-  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %96
 
 ; <label>:96                                      ; preds = %94
   %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
-  br i1 %NullCheck34, label %100, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %100
 
 ; <label>:100                                     ; preds = %96
   %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
-  br i1 %NullCheck36, label %102, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %102
 
 ; <label>:102                                     ; preds = %100
   %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
   %104 = load i32, i32 addrspace(1)* %103, align 8
   %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
-  br i1 %NullCheck38, label %106, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %106
 
 ; <label>:106                                     ; preds = %102
   %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
-  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
-  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %108
 
 ; <label>:108                                     ; preds = %106
   %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
   %110 = load i32, i32 addrspace(1)* %109, align 8
   %111 = add i32 %104, %110
-  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %112
 
 ; <label>:112                                     ; preds = %108
   %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
   store i32 %111, i32 addrspace(1)* %113
   %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
-  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i32 addrspace(1)* %114, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %115
 
 ; <label>:115                                     ; preds = %112
   %116 = load i32, i32 addrspace(1)* %114, align 8
@@ -7681,19 +9094,19 @@ entry:
 ; <label>:118                                     ; preds = %115
   %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
-  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %121
 
 ; <label>:121                                     ; preds = %118
   %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
-  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
-  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %123
 
 ; <label>:123                                     ; preds = %121
   %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
   %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
-  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
-  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %126
 
 ; <label>:126                                     ; preds = %123
   %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
@@ -7705,8 +9118,8 @@ entry:
 
 ; <label>:130                                     ; preds = %80, %115, %126
   %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %132
 
 ; <label>:132                                     ; preds = %130
   %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7715,8 +9128,8 @@ entry:
   %136 = load i32, i32* %loc3
   %137 = sub i32 %135, %136
   %138 = sub i32 %134, %137
-  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %139
 
 ; <label>:139                                     ; preds = %132
   %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7728,16 +9141,16 @@ entry:
 
 ; <label>:144                                     ; preds = %139
   %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
-  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %146
 
 ; <label>:146                                     ; preds = %144
   %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
   %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
   %149 = load i32, i32* %loc2
   %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
-  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %151
 
 ; <label>:151                                     ; preds = %146
   %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
@@ -7754,145 +9167,249 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %18
+ThrowNullRef4:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %31
+ThrowNullRef10:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %44
+ThrowNullRef16:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %68
+ThrowNullRef18:                                   ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %70
+ThrowNullRef20:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %73
+ThrowNullRef22:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %83
+ThrowNullRef24:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %85
+ThrowNullRef26:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %88
+ThrowNullRef28:                                   ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %90
+ThrowNullRef30:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %94
+ThrowNullRef32:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %96
+ThrowNullRef34:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %100
+ThrowNullRef36:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %102
+ThrowNullRef38:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %106
+ThrowNullRef40:                                   ; preds = %106
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %108
+ThrowNullRef42:                                   ; preds = %108
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %112
+ThrowNullRef44:                                   ; preds = %112
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %118
+ThrowNullRef46:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %121
+ThrowNullRef48:                                   ; preds = %121
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %123
+ThrowNullRef50:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %130
+ThrowNullRef52:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %132
+ThrowNullRef54:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %144
+ThrowNullRef56:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %146
+ThrowNullRef58:                                   ; preds = %146
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %60
+ThrowNullRef60:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %63
+ThrowNullRef62:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %49
+ThrowNullRef64:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %51
+ThrowNullRef66:                                   ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %53
+ThrowNullRef68:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(%"System.Char[]" addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %arg0 = alloca %"System.Char[]" addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store %"System.Char[]" addrspace(1)* %param0, %"System.Char[]" addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load i32, i32* %arg4
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %43, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %38, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg1
+  %13 = load i32, i32* %arg4
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %38, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %24 = load i32, i32* %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %35 = load i32, i32* %arg3
+  %36 = load i32, i32* %arg4
+  %37 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %37, %"System.Char[]" addrspace(1)* %34, i32 %35, i32 %36)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:38                                      ; preds = %5, %16
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Successfully read Buffer._Memmove
 
@@ -7914,7 +9431,7 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[loadElem]
+Failed to read AppDomain.SetDataHelper[storeElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -7923,8 +9440,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
@@ -7934,8 +9451,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
@@ -7947,15 +9464,15 @@ entry:
   %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
   %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
@@ -7966,15 +9483,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7992,7 +9509,79 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
-Failed to read Dictionary`2.TryGetValue[loadElemA]
+Successfully read Dictionary`2.TryGetValue
+
+define i8 @"Dictionary`2.TryGetValue"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)* addrspace(1)* %param2) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  %arg2 = alloca %System.__Canon addrspace(1)* addrspace(1)*
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  store %System.__Canon addrspace(1)* addrspace(1)* %param2, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  store i32 %2, i32* %loc0
+  %3 = load i32, i32* %loc0
+  %4 = icmp slt i32 %3, 0
+  br i1 %4, label %22, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 2
+  %10 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %9, align 8
+  %11 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = zext i32 %11 to i64
+  %BoundsCheck = icmp uge i64 %16, %15
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 3, i32 %11
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %20, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %6, %System.__Canon addrspace(1)* %21)
+  ret i8 1
+
+; <label>:22                                      ; preds = %entry
+  %23 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %23, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -8058,8 +9647,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
@@ -8091,8 +9680,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
@@ -8171,15 +9760,15 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck, label %19, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %ThrowNullRef, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
   %21 = load i32, i32 addrspace(1)* %20
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
@@ -8202,7 +9791,7 @@ ThrowNullRef:                                     ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %19
+ThrowNullRef2:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8248,8 +9837,8 @@ entry:
   %0 = alloca %System.AppDomainHandle
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %1 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %1, i32 0, i32 15
@@ -8269,8 +9858,8 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
@@ -8286,7 +9875,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -8299,8 +9888,8 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -8327,8 +9916,8 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
@@ -8352,8 +9941,8 @@ entry:
   %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
   store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
@@ -8363,8 +9952,8 @@ entry:
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
@@ -8374,8 +9963,8 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %9
   %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
@@ -8384,8 +9973,8 @@ entry:
 
 ; <label>:18                                      ; preds = %3, %16
   %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
@@ -8397,15 +9986,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %18
+ThrowNullRef6:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8418,8 +10007,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
@@ -8453,15 +10042,15 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
@@ -8473,7 +10062,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8481,7 +10070,7 @@ ThrowNullRef1:                                    ; preds = %1
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
 Failed to read Dictionary`2.System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
@@ -8506,8 +10095,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
@@ -8524,8 +10113,8 @@ entry:
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -8544,7 +10133,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8577,8 +10166,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = load i64, i64* %arg2
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = trunc i32 %3 to i8
@@ -8634,46 +10223,46 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
   %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
-  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
-  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
-  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
@@ -8684,27 +10273,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %20
+ThrowNullRef12:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8717,8 +10306,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -8756,22 +10345,22 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
   %9 = load i64, i64 addrspace(1)* %8, align 8
   %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
   %13 = load i64, i64 addrspace(1)* %12, align 8
   %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %11
   %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
@@ -8788,11 +10377,11 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8882,8 +10471,8 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
@@ -8900,8 +10489,8 @@ entry:
 ; <label>:8                                       ; preds = %1
   %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
   %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
@@ -8911,15 +10500,15 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
   %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
   %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
-  br i1 %NullCheck6, label %21, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
@@ -8946,15 +10535,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8992,15 +10581,15 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
   store i8 %3, i8 addrspace(1)* %5
   %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
@@ -9011,7 +10600,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9027,8 +10616,8 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -9041,8 +10630,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
@@ -9058,7 +10647,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9080,8 +10669,8 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
@@ -9096,8 +10685,8 @@ entry:
 ; <label>:12                                      ; preds = %6
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
@@ -9112,8 +10701,8 @@ entry:
 ; <label>:21                                      ; preds = %15
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
@@ -9128,8 +10717,8 @@ entry:
 ; <label>:30                                      ; preds = %24
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %31, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
@@ -9144,8 +10733,8 @@ entry:
 ; <label>:39                                      ; preds = %33
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
-  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %40, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %42
 
 ; <label>:42                                      ; preds = %39
   %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
@@ -9164,19 +10753,19 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %21
+ThrowNullRef4:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %30
+ThrowNullRef6:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %39
+ThrowNullRef8:                                    ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9243,8 +10832,8 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
@@ -9264,57 +10853,57 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
   store i8 0, i8 addrspace(1)* %2
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
   store i8 0, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
   store i8 0, i8 addrspace(1)* %17
   %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
   store i8 0, i8 addrspace(1)* %20
   %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
-  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
@@ -9325,31 +10914,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %19
+ThrowNullRef14:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9367,8 +10956,8 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
@@ -9380,8 +10969,8 @@ entry:
 
 ; <label>:9                                       ; preds = %4
   %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %9
   %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
@@ -9395,7 +10984,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef2:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9420,8 +11009,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
@@ -9512,8 +11101,8 @@ entry:
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
@@ -9524,8 +11113,8 @@ entry:
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = load i64, i64 addrspace(1)* %12
@@ -9537,8 +11126,8 @@ entry:
   %20 = load i64, i64* %19
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
-  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %13
   %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
@@ -9555,8 +11144,8 @@ entry:
 ; <label>:30                                      ; preds = %25
   %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %32 = load i32, i32* %arg2
-  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
-  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
@@ -9570,15 +11159,15 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %30
+ThrowNullRef2:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9622,87 +11211,87 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
   %10 = load i8, i8 addrspace(1)* %9, align 8
   %11 = zext i8 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %8
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
   store i8 %12, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
   %19 = load i8, i8 addrspace(1)* %18, align 8
   %20 = zext i8 %19 to i32
   %21 = trunc i32 %20 to i8
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
   store i8 %21, i8 addrspace(1)* %23
   %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
   %28 = load i8, i8 addrspace(1)* %27, align 8
   %29 = zext i8 %28 to i32
   %30 = trunc i32 %29 to i8
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
-  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %31
 
 ; <label>:31                                      ; preds = %26
   %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
   store i8 %30, i8 addrspace(1)* %32
   %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
-  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
-  br i1 %NullCheck14, label %40, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %40
 
 ; <label>:40                                      ; preds = %35
   %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
   store i8 %39, i8 addrspace(1)* %41
   %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
-  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %44
 
 ; <label>:44                                      ; preds = %40
   %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
   %46 = load i8, i8 addrspace(1)* %45, align 8
   %47 = zext i8 %46 to i32
   %48 = trunc i32 %47 to i8
-  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
   store i8 %48, i8 addrspace(1)* %50
   %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
-  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
@@ -9713,29 +11302,29 @@ entry:
 ; <label>:56                                      ; preds = %52
   %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
-  br i1 %NullCheck22, label %59, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
   %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
   %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
-  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
-  br i1 %NullCheck24, label %63, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
   %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
-  br i1 %NullCheck26, label %66, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
   %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
-  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
-  br i1 %NullCheck28, label %69, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %69
 
 ; <label>:69                                      ; preds = %66
   %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
@@ -9744,15 +11333,15 @@ entry:
 
 ; <label>:71                                      ; preds = %105
   %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
-  br i1 %NullCheck34, label %73, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %73
 
 ; <label>:73                                      ; preds = %71
   %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
   %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
   %76 = load i32, i32* %loc0
-  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
-  br i1 %NullCheck36, label %77, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
@@ -9766,8 +11355,8 @@ entry:
 
 ; <label>:83                                      ; preds = %77
   %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
-  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
@@ -9775,14 +11364,14 @@ entry:
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
   %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
-  br i1 %NullCheck40, label %91, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
 ; <label>:91                                      ; preds = %85
   %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
   %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
-  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck42, label %94, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %94
 
 ; <label>:94                                      ; preds = %91
   %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
@@ -9798,14 +11387,14 @@ entry:
 ; <label>:99                                      ; preds = %69, %96
   %100 = load i32, i32* %loc0
   %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
-  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %102
 
 ; <label>:102                                     ; preds = %99
   %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
   %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
-  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
-  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
@@ -9819,87 +11408,87 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %26
+ThrowNullRef10:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %31
+ThrowNullRef12:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %35
+ThrowNullRef14:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %40
+ThrowNullRef16:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %56
+ThrowNullRef22:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %59
+ThrowNullRef24:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %63
+ThrowNullRef26:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %66
+ThrowNullRef28:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %102
+ThrowNullRef32:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %71
+ThrowNullRef34:                                   ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %73
+ThrowNullRef36:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %83
+ThrowNullRef38:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %85
+ThrowNullRef40:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %91
+ThrowNullRef42:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9943,15 +11532,15 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
   %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
@@ -9961,28 +11550,28 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
   %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %12
   %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
   %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
   %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
-  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
@@ -9993,23 +11582,23 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %12
+ThrowNullRef6:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10031,15 +11620,15 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
   %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = load i64, i64 addrspace(1)* %7
@@ -10077,13 +11666,13 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[loadElem]
+Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -10111,8 +11700,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1

--- a/test/BaseLine/JIT/CodeGenBringUpTests/AsgAdd1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/AsgAdd1.error.txt
@@ -25,8 +25,8 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
@@ -40,8 +40,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
   %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
@@ -75,7 +75,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -90,8 +90,8 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %NullCheck = icmp ne i8 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = load i8, i8 addrspace(1)* %0, align 8
@@ -125,8 +125,8 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
@@ -159,8 +159,8 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -184,8 +184,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
   store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
@@ -195,8 +195,8 @@ entry:
 ; <label>:4                                       ; preds = %1
   %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
   %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
@@ -206,8 +206,8 @@ entry:
   %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
@@ -221,14 +221,14 @@ entry:
 
 ; <label>:17                                      ; preds = %14
   %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
   %21 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
@@ -238,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -249,8 +249,8 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
@@ -261,27 +261,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %30
+ThrowNullRef10:                                   ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -301,7 +301,89 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
-Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
+Successfully read AppDomainSetup.GetUnsecureApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.GetUnsecureApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %NullCheck = icmp eq %"System.String[]" addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %BoundsCheck = icmp uge i64 0, %5
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %6
+
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 3, i32 0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
+  ret %System.String addrspace(1)* %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_Value using LLILCJit
+Successfully read AppDomainSetup.get_Value
+
+define %"System.String[]" addrspace(1)* @AppDomainSetup.get_Value(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.String[]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 18)
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.String[]" addrspace(1)* addrspace(1)*, %"System.String[]" addrspace(1)*)*)(%"System.String[]" addrspace(1)* addrspace(1)* %9, %"System.String[]" addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %11, i32 0, i32 1
+  %14 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %13, align 8
+  ret %"System.String[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -319,8 +401,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -368,16 +450,16 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
   %5 = load i32, i32 addrspace(1)* %4
   %6 = sub i32 %5, 1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -389,7 +471,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -421,8 +503,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
@@ -456,8 +538,8 @@ entry:
 ; <label>:27                                      ; preds = %19
   %28 = load i32, i32* %arg1
   %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
-  br i1 %NullCheck2, label %30, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %29, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %30
 
 ; <label>:30                                      ; preds = %27
   %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
@@ -493,8 +575,8 @@ entry:
 ; <label>:49                                      ; preds = %46
   %50 = load i32, i32* %arg2
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck4, label %52, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
@@ -517,11 +599,11 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %27
+ThrowNullRef2:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %49
+ThrowNullRef4:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -544,16 +626,16 @@ entry:
   %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %0)
   store %System.String addrspace(1)* %1, %System.String addrspace(1)** %loc0
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 2
   %5 = bitcast [0 x i16] addrspace(1)* %4 to i16 addrspace(1)*
   store i16 addrspace(1)* %5, i16 addrspace(1)** %loc1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %3
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2
@@ -580,7 +662,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -691,15 +773,15 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %NullCheck132 = icmp ne i8* %21, null
-  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+  %NullCheck131 = icmp eq i8* %21, null
+  br i1 %NullCheck131, label %ThrowNullRef132, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = load i8, i8* %21, align 8
   %24 = zext i8 %23 to i32
   %25 = trunc i32 %24 to i8
-  %NullCheck134 = icmp ne i8* %20, null
-  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+  %NullCheck133 = icmp eq i8* %20, null
+  br i1 %NullCheck133, label %ThrowNullRef134, label %26
 
 ; <label>:26                                      ; preds = %22
   store i8 %25, i8* %20, align 8
@@ -709,16 +791,16 @@ entry:
   %28 = load i8*, i8** %arg0
   %29 = load i8*, i8** %arg1
   %30 = bitcast i8* %29 to i16*
-  %NullCheck128 = icmp ne i16* %30, null
-  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+  %NullCheck127 = icmp eq i16* %30, null
+  br i1 %NullCheck127, label %ThrowNullRef128, label %31
 
 ; <label>:31                                      ; preds = %27
   %32 = load i16, i16* %30, align 8
   %33 = sext i16 %32 to i32
   %34 = bitcast i8* %28 to i16*
   %35 = trunc i32 %33 to i16
-  %NullCheck130 = icmp ne i16* %34, null
-  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+  %NullCheck129 = icmp eq i16* %34, null
+  br i1 %NullCheck129, label %ThrowNullRef130, label %36
 
 ; <label>:36                                      ; preds = %31
   store i16 %35, i16* %34, align 8
@@ -728,16 +810,16 @@ entry:
   %38 = load i8*, i8** %arg0
   %39 = load i8*, i8** %arg1
   %40 = bitcast i8* %39 to i16*
-  %NullCheck120 = icmp ne i16* %40, null
-  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+  %NullCheck119 = icmp eq i16* %40, null
+  br i1 %NullCheck119, label %ThrowNullRef120, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i16, i16* %40, align 8
   %43 = sext i16 %42 to i32
   %44 = bitcast i8* %38 to i16*
   %45 = trunc i32 %43 to i16
-  %NullCheck122 = icmp ne i16* %44, null
-  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+  %NullCheck121 = icmp eq i16* %44, null
+  br i1 %NullCheck121, label %ThrowNullRef122, label %46
 
 ; <label>:46                                      ; preds = %41
   store i16 %45, i16* %44, align 8
@@ -745,15 +827,15 @@ entry:
   %48 = getelementptr inbounds i8, i8* %47, i64 2
   %49 = load i8*, i8** %arg1
   %50 = getelementptr inbounds i8, i8* %49, i64 2
-  %NullCheck124 = icmp ne i8* %50, null
-  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+  %NullCheck123 = icmp eq i8* %50, null
+  br i1 %NullCheck123, label %ThrowNullRef124, label %51
 
 ; <label>:51                                      ; preds = %46
   %52 = load i8, i8* %50, align 8
   %53 = zext i8 %52 to i32
   %54 = trunc i32 %53 to i8
-  %NullCheck126 = icmp ne i8* %48, null
-  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+  %NullCheck125 = icmp eq i8* %48, null
+  br i1 %NullCheck125, label %ThrowNullRef126, label %55
 
 ; <label>:55                                      ; preds = %51
   store i8 %54, i8* %48, align 8
@@ -763,14 +845,14 @@ entry:
   %57 = load i8*, i8** %arg0
   %58 = load i8*, i8** %arg1
   %59 = bitcast i8* %58 to i32*
-  %NullCheck116 = icmp ne i32* %59, null
-  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+  %NullCheck115 = icmp eq i32* %59, null
+  br i1 %NullCheck115, label %ThrowNullRef116, label %60
 
 ; <label>:60                                      ; preds = %56
   %61 = load i32, i32* %59, align 8
   %62 = bitcast i8* %57 to i32*
-  %NullCheck118 = icmp ne i32* %62, null
-  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+  %NullCheck117 = icmp eq i32* %62, null
+  br i1 %NullCheck117, label %ThrowNullRef118, label %63
 
 ; <label>:63                                      ; preds = %60
   store i32 %61, i32* %62, align 8
@@ -780,14 +862,14 @@ entry:
   %65 = load i8*, i8** %arg0
   %66 = load i8*, i8** %arg1
   %67 = bitcast i8* %66 to i32*
-  %NullCheck108 = icmp ne i32* %67, null
-  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+  %NullCheck107 = icmp eq i32* %67, null
+  br i1 %NullCheck107, label %ThrowNullRef108, label %68
 
 ; <label>:68                                      ; preds = %64
   %69 = load i32, i32* %67, align 8
   %70 = bitcast i8* %65 to i32*
-  %NullCheck110 = icmp ne i32* %70, null
-  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+  %NullCheck109 = icmp eq i32* %70, null
+  br i1 %NullCheck109, label %ThrowNullRef110, label %71
 
 ; <label>:71                                      ; preds = %68
   store i32 %69, i32* %70, align 8
@@ -795,15 +877,15 @@ entry:
   %73 = getelementptr inbounds i8, i8* %72, i64 4
   %74 = load i8*, i8** %arg1
   %75 = getelementptr inbounds i8, i8* %74, i64 4
-  %NullCheck112 = icmp ne i8* %75, null
-  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+  %NullCheck111 = icmp eq i8* %75, null
+  br i1 %NullCheck111, label %ThrowNullRef112, label %76
 
 ; <label>:76                                      ; preds = %71
   %77 = load i8, i8* %75, align 8
   %78 = zext i8 %77 to i32
   %79 = trunc i32 %78 to i8
-  %NullCheck114 = icmp ne i8* %73, null
-  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+  %NullCheck113 = icmp eq i8* %73, null
+  br i1 %NullCheck113, label %ThrowNullRef114, label %80
 
 ; <label>:80                                      ; preds = %76
   store i8 %79, i8* %73, align 8
@@ -813,14 +895,14 @@ entry:
   %82 = load i8*, i8** %arg0
   %83 = load i8*, i8** %arg1
   %84 = bitcast i8* %83 to i32*
-  %NullCheck100 = icmp ne i32* %84, null
-  br i1 %NullCheck100, label %85, label %ThrowNullRef99
+  %NullCheck99 = icmp eq i32* %84, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %85
 
 ; <label>:85                                      ; preds = %81
   %86 = load i32, i32* %84, align 8
   %87 = bitcast i8* %82 to i32*
-  %NullCheck102 = icmp ne i32* %87, null
-  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+  %NullCheck101 = icmp eq i32* %87, null
+  br i1 %NullCheck101, label %ThrowNullRef102, label %88
 
 ; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
@@ -829,16 +911,16 @@ entry:
   %91 = load i8*, i8** %arg1
   %92 = getelementptr inbounds i8, i8* %91, i64 4
   %93 = bitcast i8* %92 to i16*
-  %NullCheck104 = icmp ne i16* %93, null
-  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+  %NullCheck103 = icmp eq i16* %93, null
+  br i1 %NullCheck103, label %ThrowNullRef104, label %94
 
 ; <label>:94                                      ; preds = %88
   %95 = load i16, i16* %93, align 8
   %96 = sext i16 %95 to i32
   %97 = bitcast i8* %90 to i16*
   %98 = trunc i32 %96 to i16
-  %NullCheck106 = icmp ne i16* %97, null
-  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+  %NullCheck105 = icmp eq i16* %97, null
+  br i1 %NullCheck105, label %ThrowNullRef106, label %99
 
 ; <label>:99                                      ; preds = %94
   store i16 %98, i16* %97, align 8
@@ -848,14 +930,14 @@ entry:
   %101 = load i8*, i8** %arg0
   %102 = load i8*, i8** %arg1
   %103 = bitcast i8* %102 to i32*
-  %NullCheck88 = icmp ne i32* %103, null
-  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+  %NullCheck87 = icmp eq i32* %103, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %104
 
 ; <label>:104                                     ; preds = %100
   %105 = load i32, i32* %103, align 8
   %106 = bitcast i8* %101 to i32*
-  %NullCheck90 = icmp ne i32* %106, null
-  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+  %NullCheck89 = icmp eq i32* %106, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %107
 
 ; <label>:107                                     ; preds = %104
   store i32 %105, i32* %106, align 8
@@ -864,16 +946,16 @@ entry:
   %110 = load i8*, i8** %arg1
   %111 = getelementptr inbounds i8, i8* %110, i64 4
   %112 = bitcast i8* %111 to i16*
-  %NullCheck92 = icmp ne i16* %112, null
-  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+  %NullCheck91 = icmp eq i16* %112, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %113
 
 ; <label>:113                                     ; preds = %107
   %114 = load i16, i16* %112, align 8
   %115 = sext i16 %114 to i32
   %116 = bitcast i8* %109 to i16*
   %117 = trunc i32 %115 to i16
-  %NullCheck94 = icmp ne i16* %116, null
-  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+  %NullCheck93 = icmp eq i16* %116, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %118
 
 ; <label>:118                                     ; preds = %113
   store i16 %117, i16* %116, align 8
@@ -881,15 +963,15 @@ entry:
   %120 = getelementptr inbounds i8, i8* %119, i64 6
   %121 = load i8*, i8** %arg1
   %122 = getelementptr inbounds i8, i8* %121, i64 6
-  %NullCheck96 = icmp ne i8* %122, null
-  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+  %NullCheck95 = icmp eq i8* %122, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %123
 
 ; <label>:123                                     ; preds = %118
   %124 = load i8, i8* %122, align 8
   %125 = zext i8 %124 to i32
   %126 = trunc i32 %125 to i8
-  %NullCheck98 = icmp ne i8* %120, null
-  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+  %NullCheck97 = icmp eq i8* %120, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %127
 
 ; <label>:127                                     ; preds = %123
   store i8 %126, i8* %120, align 8
@@ -899,14 +981,14 @@ entry:
   %129 = load i8*, i8** %arg0
   %130 = load i8*, i8** %arg1
   %131 = bitcast i8* %130 to i64*
-  %NullCheck84 = icmp ne i64* %131, null
-  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+  %NullCheck83 = icmp eq i64* %131, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %132
 
 ; <label>:132                                     ; preds = %128
   %133 = load i64, i64* %131, align 8
   %134 = bitcast i8* %129 to i64*
-  %NullCheck86 = icmp ne i64* %134, null
-  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+  %NullCheck85 = icmp eq i64* %134, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %135
 
 ; <label>:135                                     ; preds = %132
   store i64 %133, i64* %134, align 8
@@ -916,14 +998,14 @@ entry:
   %137 = load i8*, i8** %arg0
   %138 = load i8*, i8** %arg1
   %139 = bitcast i8* %138 to i64*
-  %NullCheck76 = icmp ne i64* %139, null
-  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+  %NullCheck75 = icmp eq i64* %139, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %140
 
 ; <label>:140                                     ; preds = %136
   %141 = load i64, i64* %139, align 8
   %142 = bitcast i8* %137 to i64*
-  %NullCheck78 = icmp ne i64* %142, null
-  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+  %NullCheck77 = icmp eq i64* %142, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %143
 
 ; <label>:143                                     ; preds = %140
   store i64 %141, i64* %142, align 8
@@ -931,15 +1013,15 @@ entry:
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %NullCheck80 = icmp ne i8* %147, null
-  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+  %NullCheck79 = icmp eq i8* %147, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %148
 
 ; <label>:148                                     ; preds = %143
   %149 = load i8, i8* %147, align 8
   %150 = zext i8 %149 to i32
   %151 = trunc i32 %150 to i8
-  %NullCheck82 = icmp ne i8* %145, null
-  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+  %NullCheck81 = icmp eq i8* %145, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %152
 
 ; <label>:152                                     ; preds = %148
   store i8 %151, i8* %145, align 8
@@ -949,14 +1031,14 @@ entry:
   %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
   %156 = bitcast i8* %155 to i64*
-  %NullCheck68 = icmp ne i64* %156, null
-  br i1 %NullCheck68, label %157, label %ThrowNullRef67
+  %NullCheck67 = icmp eq i64* %156, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %157
 
 ; <label>:157                                     ; preds = %153
   %158 = load i64, i64* %156, align 8
   %159 = bitcast i8* %154 to i64*
-  %NullCheck70 = icmp ne i64* %159, null
-  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+  %NullCheck69 = icmp eq i64* %159, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %160
 
 ; <label>:160                                     ; preds = %157
   store i64 %158, i64* %159, align 8
@@ -965,16 +1047,16 @@ entry:
   %163 = load i8*, i8** %arg1
   %164 = getelementptr inbounds i8, i8* %163, i64 8
   %165 = bitcast i8* %164 to i16*
-  %NullCheck72 = icmp ne i16* %165, null
-  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+  %NullCheck71 = icmp eq i16* %165, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %166
 
 ; <label>:166                                     ; preds = %160
   %167 = load i16, i16* %165, align 8
   %168 = sext i16 %167 to i32
   %169 = bitcast i8* %162 to i16*
   %170 = trunc i32 %168 to i16
-  %NullCheck74 = icmp ne i16* %169, null
-  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+  %NullCheck73 = icmp eq i16* %169, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %171
 
 ; <label>:171                                     ; preds = %166
   store i16 %170, i16* %169, align 8
@@ -984,14 +1066,14 @@ entry:
   %173 = load i8*, i8** %arg0
   %174 = load i8*, i8** %arg1
   %175 = bitcast i8* %174 to i64*
-  %NullCheck56 = icmp ne i64* %175, null
-  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+  %NullCheck55 = icmp eq i64* %175, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %176
 
 ; <label>:176                                     ; preds = %172
   %177 = load i64, i64* %175, align 8
   %178 = bitcast i8* %173 to i64*
-  %NullCheck58 = icmp ne i64* %178, null
-  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+  %NullCheck57 = icmp eq i64* %178, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %179
 
 ; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
@@ -1000,16 +1082,16 @@ entry:
   %182 = load i8*, i8** %arg1
   %183 = getelementptr inbounds i8, i8* %182, i64 8
   %184 = bitcast i8* %183 to i16*
-  %NullCheck60 = icmp ne i16* %184, null
-  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+  %NullCheck59 = icmp eq i16* %184, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %185
 
 ; <label>:185                                     ; preds = %179
   %186 = load i16, i16* %184, align 8
   %187 = sext i16 %186 to i32
   %188 = bitcast i8* %181 to i16*
   %189 = trunc i32 %187 to i16
-  %NullCheck62 = icmp ne i16* %188, null
-  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+  %NullCheck61 = icmp eq i16* %188, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %190
 
 ; <label>:190                                     ; preds = %185
   store i16 %189, i16* %188, align 8
@@ -1017,15 +1099,15 @@ entry:
   %192 = getelementptr inbounds i8, i8* %191, i64 10
   %193 = load i8*, i8** %arg1
   %194 = getelementptr inbounds i8, i8* %193, i64 10
-  %NullCheck64 = icmp ne i8* %194, null
-  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+  %NullCheck63 = icmp eq i8* %194, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %195
 
 ; <label>:195                                     ; preds = %190
   %196 = load i8, i8* %194, align 8
   %197 = zext i8 %196 to i32
   %198 = trunc i32 %197 to i8
-  %NullCheck66 = icmp ne i8* %192, null
-  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+  %NullCheck65 = icmp eq i8* %192, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %199
 
 ; <label>:199                                     ; preds = %195
   store i8 %198, i8* %192, align 8
@@ -1035,14 +1117,14 @@ entry:
   %201 = load i8*, i8** %arg0
   %202 = load i8*, i8** %arg1
   %203 = bitcast i8* %202 to i64*
-  %NullCheck48 = icmp ne i64* %203, null
-  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+  %NullCheck47 = icmp eq i64* %203, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %204
 
 ; <label>:204                                     ; preds = %200
   %205 = load i64, i64* %203, align 8
   %206 = bitcast i8* %201 to i64*
-  %NullCheck50 = icmp ne i64* %206, null
-  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+  %NullCheck49 = icmp eq i64* %206, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %207
 
 ; <label>:207                                     ; preds = %204
   store i64 %205, i64* %206, align 8
@@ -1051,14 +1133,14 @@ entry:
   %210 = load i8*, i8** %arg1
   %211 = getelementptr inbounds i8, i8* %210, i64 8
   %212 = bitcast i8* %211 to i32*
-  %NullCheck52 = icmp ne i32* %212, null
-  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+  %NullCheck51 = icmp eq i32* %212, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %213
 
 ; <label>:213                                     ; preds = %207
   %214 = load i32, i32* %212, align 8
   %215 = bitcast i8* %209 to i32*
-  %NullCheck54 = icmp ne i32* %215, null
-  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+  %NullCheck53 = icmp eq i32* %215, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %216
 
 ; <label>:216                                     ; preds = %213
   store i32 %214, i32* %215, align 8
@@ -1068,14 +1150,14 @@ entry:
   %218 = load i8*, i8** %arg0
   %219 = load i8*, i8** %arg1
   %220 = bitcast i8* %219 to i64*
-  %NullCheck36 = icmp ne i64* %220, null
-  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64* %220, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %221
 
 ; <label>:221                                     ; preds = %217
   %222 = load i64, i64* %220, align 8
   %223 = bitcast i8* %218 to i64*
-  %NullCheck38 = icmp ne i64* %223, null
-  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+  %NullCheck37 = icmp eq i64* %223, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %224
 
 ; <label>:224                                     ; preds = %221
   store i64 %222, i64* %223, align 8
@@ -1084,14 +1166,14 @@ entry:
   %227 = load i8*, i8** %arg1
   %228 = getelementptr inbounds i8, i8* %227, i64 8
   %229 = bitcast i8* %228 to i32*
-  %NullCheck40 = icmp ne i32* %229, null
-  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i32* %229, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %230
 
 ; <label>:230                                     ; preds = %224
   %231 = load i32, i32* %229, align 8
   %232 = bitcast i8* %226 to i32*
-  %NullCheck42 = icmp ne i32* %232, null
-  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+  %NullCheck41 = icmp eq i32* %232, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %233
 
 ; <label>:233                                     ; preds = %230
   store i32 %231, i32* %232, align 8
@@ -1099,15 +1181,15 @@ entry:
   %235 = getelementptr inbounds i8, i8* %234, i64 12
   %236 = load i8*, i8** %arg1
   %237 = getelementptr inbounds i8, i8* %236, i64 12
-  %NullCheck44 = icmp ne i8* %237, null
-  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i8* %237, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %238
 
 ; <label>:238                                     ; preds = %233
   %239 = load i8, i8* %237, align 8
   %240 = zext i8 %239 to i32
   %241 = trunc i32 %240 to i8
-  %NullCheck46 = icmp ne i8* %235, null
-  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+  %NullCheck45 = icmp eq i8* %235, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %242
 
 ; <label>:242                                     ; preds = %238
   store i8 %241, i8* %235, align 8
@@ -1117,14 +1199,14 @@ entry:
   %244 = load i8*, i8** %arg0
   %245 = load i8*, i8** %arg1
   %246 = bitcast i8* %245 to i64*
-  %NullCheck24 = icmp ne i64* %246, null
-  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64* %246, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %247
 
 ; <label>:247                                     ; preds = %243
   %248 = load i64, i64* %246, align 8
   %249 = bitcast i8* %244 to i64*
-  %NullCheck26 = icmp ne i64* %249, null
-  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64* %249, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %250
 
 ; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
@@ -1133,14 +1215,14 @@ entry:
   %253 = load i8*, i8** %arg1
   %254 = getelementptr inbounds i8, i8* %253, i64 8
   %255 = bitcast i8* %254 to i32*
-  %NullCheck28 = icmp ne i32* %255, null
-  br i1 %NullCheck28, label %256, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i32* %255, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %256
 
 ; <label>:256                                     ; preds = %250
   %257 = load i32, i32* %255, align 8
   %258 = bitcast i8* %252 to i32*
-  %NullCheck30 = icmp ne i32* %258, null
-  br i1 %NullCheck30, label %259, label %ThrowNullRef29
+  %NullCheck29 = icmp eq i32* %258, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %259
 
 ; <label>:259                                     ; preds = %256
   store i32 %257, i32* %258, align 8
@@ -1149,16 +1231,16 @@ entry:
   %262 = load i8*, i8** %arg1
   %263 = getelementptr inbounds i8, i8* %262, i64 12
   %264 = bitcast i8* %263 to i16*
-  %NullCheck32 = icmp ne i16* %264, null
-  br i1 %NullCheck32, label %265, label %ThrowNullRef31
+  %NullCheck31 = icmp eq i16* %264, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %265
 
 ; <label>:265                                     ; preds = %259
   %266 = load i16, i16* %264, align 8
   %267 = sext i16 %266 to i32
   %268 = bitcast i8* %261 to i16*
   %269 = trunc i32 %267 to i16
-  %NullCheck34 = icmp ne i16* %268, null
-  br i1 %NullCheck34, label %270, label %ThrowNullRef33
+  %NullCheck33 = icmp eq i16* %268, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %270
 
 ; <label>:270                                     ; preds = %265
   store i16 %269, i16* %268, align 8
@@ -1168,14 +1250,14 @@ entry:
   %272 = load i8*, i8** %arg0
   %273 = load i8*, i8** %arg1
   %274 = bitcast i8* %273 to i64*
-  %NullCheck8 = icmp ne i64* %274, null
-  br i1 %NullCheck8, label %275, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64* %274, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %275
 
 ; <label>:275                                     ; preds = %271
   %276 = load i64, i64* %274, align 8
   %277 = bitcast i8* %272 to i64*
-  %NullCheck10 = icmp ne i64* %277, null
-  br i1 %NullCheck10, label %278, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %277, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %278
 
 ; <label>:278                                     ; preds = %275
   store i64 %276, i64* %277, align 8
@@ -1184,14 +1266,14 @@ entry:
   %281 = load i8*, i8** %arg1
   %282 = getelementptr inbounds i8, i8* %281, i64 8
   %283 = bitcast i8* %282 to i32*
-  %NullCheck12 = icmp ne i32* %283, null
-  br i1 %NullCheck12, label %284, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i32* %283, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %284
 
 ; <label>:284                                     ; preds = %278
   %285 = load i32, i32* %283, align 8
   %286 = bitcast i8* %280 to i32*
-  %NullCheck14 = icmp ne i32* %286, null
-  br i1 %NullCheck14, label %287, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i32* %286, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %287
 
 ; <label>:287                                     ; preds = %284
   store i32 %285, i32* %286, align 8
@@ -1200,16 +1282,16 @@ entry:
   %290 = load i8*, i8** %arg1
   %291 = getelementptr inbounds i8, i8* %290, i64 12
   %292 = bitcast i8* %291 to i16*
-  %NullCheck16 = icmp ne i16* %292, null
-  br i1 %NullCheck16, label %293, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i16* %292, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %293
 
 ; <label>:293                                     ; preds = %287
   %294 = load i16, i16* %292, align 8
   %295 = sext i16 %294 to i32
   %296 = bitcast i8* %289 to i16*
   %297 = trunc i32 %295 to i16
-  %NullCheck18 = icmp ne i16* %296, null
-  br i1 %NullCheck18, label %298, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i16* %296, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %298
 
 ; <label>:298                                     ; preds = %293
   store i16 %297, i16* %296, align 8
@@ -1217,15 +1299,15 @@ entry:
   %300 = getelementptr inbounds i8, i8* %299, i64 14
   %301 = load i8*, i8** %arg1
   %302 = getelementptr inbounds i8, i8* %301, i64 14
-  %NullCheck20 = icmp ne i8* %302, null
-  br i1 %NullCheck20, label %303, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i8* %302, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %303
 
 ; <label>:303                                     ; preds = %298
   %304 = load i8, i8* %302, align 8
   %305 = zext i8 %304 to i32
   %306 = trunc i32 %305 to i8
-  %NullCheck22 = icmp ne i8* %300, null
-  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i8* %300, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %307
 
 ; <label>:307                                     ; preds = %303
   store i8 %306, i8* %300, align 8
@@ -1235,14 +1317,14 @@ entry:
   %309 = load i8*, i8** %arg0
   %310 = load i8*, i8** %arg1
   %311 = bitcast i8* %310 to i64*
-  %NullCheck = icmp ne i64* %311, null
-  br i1 %NullCheck, label %312, label %ThrowNullRef
+  %NullCheck = icmp eq i64* %311, null
+  br i1 %NullCheck, label %ThrowNullRef, label %312
 
 ; <label>:312                                     ; preds = %308
   %313 = load i64, i64* %311, align 8
   %314 = bitcast i8* %309 to i64*
-  %NullCheck2 = icmp ne i64* %314, null
-  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64* %314, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %315
 
 ; <label>:315                                     ; preds = %312
   store i64 %313, i64* %314, align 8
@@ -1251,14 +1333,14 @@ entry:
   %318 = load i8*, i8** %arg1
   %319 = getelementptr inbounds i8, i8* %318, i64 8
   %320 = bitcast i8* %319 to i64*
-  %NullCheck4 = icmp ne i64* %320, null
-  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64* %320, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %321
 
 ; <label>:321                                     ; preds = %315
   %322 = load i64, i64* %320, align 8
   %323 = bitcast i8* %317 to i64*
-  %NullCheck6 = icmp ne i64* %323, null
-  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64* %323, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %324
 
 ; <label>:324                                     ; preds = %321
   store i64 %322, i64* %323, align 8
@@ -1286,15 +1368,15 @@ entry:
 ; <label>:338                                     ; preds = %333
   %339 = load i8*, i8** %arg0
   %340 = load i8*, i8** %arg1
-  %NullCheck136 = icmp ne i8* %340, null
-  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+  %NullCheck135 = icmp eq i8* %340, null
+  br i1 %NullCheck135, label %ThrowNullRef136, label %341
 
 ; <label>:341                                     ; preds = %338
   %342 = load i8, i8* %340, align 8
   %343 = zext i8 %342 to i32
   %344 = trunc i32 %343 to i8
-  %NullCheck138 = icmp ne i8* %339, null
-  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+  %NullCheck137 = icmp eq i8* %339, null
+  br i1 %NullCheck137, label %ThrowNullRef138, label %345
 
 ; <label>:345                                     ; preds = %341
   store i8 %344, i8* %339, align 8
@@ -1317,16 +1399,16 @@ entry:
   %357 = load i8*, i8** %arg0
   %358 = load i8*, i8** %arg1
   %359 = bitcast i8* %358 to i16*
-  %NullCheck140 = icmp ne i16* %359, null
-  br i1 %NullCheck140, label %360, label %ThrowNullRef139
+  %NullCheck139 = icmp eq i16* %359, null
+  br i1 %NullCheck139, label %ThrowNullRef140, label %360
 
 ; <label>:360                                     ; preds = %356
   %361 = load i16, i16* %359, align 8
   %362 = sext i16 %361 to i32
   %363 = bitcast i8* %357 to i16*
   %364 = trunc i32 %362 to i16
-  %NullCheck142 = icmp ne i16* %363, null
-  br i1 %NullCheck142, label %365, label %ThrowNullRef141
+  %NullCheck141 = icmp eq i16* %363, null
+  br i1 %NullCheck141, label %ThrowNullRef142, label %365
 
 ; <label>:365                                     ; preds = %360
   store i16 %364, i16* %363, align 8
@@ -1352,14 +1434,14 @@ entry:
   %378 = load i8*, i8** %arg0
   %379 = load i8*, i8** %arg1
   %380 = bitcast i8* %379 to i32*
-  %NullCheck144 = icmp ne i32* %380, null
-  br i1 %NullCheck144, label %381, label %ThrowNullRef143
+  %NullCheck143 = icmp eq i32* %380, null
+  br i1 %NullCheck143, label %ThrowNullRef144, label %381
 
 ; <label>:381                                     ; preds = %377
   %382 = load i32, i32* %380, align 8
   %383 = bitcast i8* %378 to i32*
-  %NullCheck146 = icmp ne i32* %383, null
-  br i1 %NullCheck146, label %384, label %ThrowNullRef145
+  %NullCheck145 = icmp eq i32* %383, null
+  br i1 %NullCheck145, label %ThrowNullRef146, label %384
 
 ; <label>:384                                     ; preds = %381
   store i32 %382, i32* %383, align 8
@@ -1384,14 +1466,14 @@ entry:
   %395 = load i8*, i8** %arg0
   %396 = load i8*, i8** %arg1
   %397 = bitcast i8* %396 to i64*
-  %NullCheck164 = icmp ne i64* %397, null
-  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+  %NullCheck163 = icmp eq i64* %397, null
+  br i1 %NullCheck163, label %ThrowNullRef164, label %398
 
 ; <label>:398                                     ; preds = %394
   %399 = load i64, i64* %397, align 8
   %400 = bitcast i8* %395 to i64*
-  %NullCheck166 = icmp ne i64* %400, null
-  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+  %NullCheck165 = icmp eq i64* %400, null
+  br i1 %NullCheck165, label %ThrowNullRef166, label %401
 
 ; <label>:401                                     ; preds = %398
   store i64 %399, i64* %400, align 8
@@ -1400,14 +1482,14 @@ entry:
   %404 = load i8*, i8** %arg1
   %405 = getelementptr inbounds i8, i8* %404, i64 8
   %406 = bitcast i8* %405 to i64*
-  %NullCheck168 = icmp ne i64* %406, null
-  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+  %NullCheck167 = icmp eq i64* %406, null
+  br i1 %NullCheck167, label %ThrowNullRef168, label %407
 
 ; <label>:407                                     ; preds = %401
   %408 = load i64, i64* %406, align 8
   %409 = bitcast i8* %403 to i64*
-  %NullCheck170 = icmp ne i64* %409, null
-  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+  %NullCheck169 = icmp eq i64* %409, null
+  br i1 %NullCheck169, label %ThrowNullRef170, label %410
 
 ; <label>:410                                     ; preds = %407
   store i64 %408, i64* %409, align 8
@@ -1437,14 +1519,14 @@ entry:
   %425 = load i8*, i8** %arg0
   %426 = load i8*, i8** %arg1
   %427 = bitcast i8* %426 to i64*
-  %NullCheck148 = icmp ne i64* %427, null
-  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+  %NullCheck147 = icmp eq i64* %427, null
+  br i1 %NullCheck147, label %ThrowNullRef148, label %428
 
 ; <label>:428                                     ; preds = %424
   %429 = load i64, i64* %427, align 8
   %430 = bitcast i8* %425 to i64*
-  %NullCheck150 = icmp ne i64* %430, null
-  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+  %NullCheck149 = icmp eq i64* %430, null
+  br i1 %NullCheck149, label %ThrowNullRef150, label %431
 
 ; <label>:431                                     ; preds = %428
   store i64 %429, i64* %430, align 8
@@ -1466,14 +1548,14 @@ entry:
   %441 = load i8*, i8** %arg0
   %442 = load i8*, i8** %arg1
   %443 = bitcast i8* %442 to i32*
-  %NullCheck152 = icmp ne i32* %443, null
-  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+  %NullCheck151 = icmp eq i32* %443, null
+  br i1 %NullCheck151, label %ThrowNullRef152, label %444
 
 ; <label>:444                                     ; preds = %440
   %445 = load i32, i32* %443, align 8
   %446 = bitcast i8* %441 to i32*
-  %NullCheck154 = icmp ne i32* %446, null
-  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+  %NullCheck153 = icmp eq i32* %446, null
+  br i1 %NullCheck153, label %ThrowNullRef154, label %447
 
 ; <label>:447                                     ; preds = %444
   store i32 %445, i32* %446, align 8
@@ -1495,16 +1577,16 @@ entry:
   %457 = load i8*, i8** %arg0
   %458 = load i8*, i8** %arg1
   %459 = bitcast i8* %458 to i16*
-  %NullCheck156 = icmp ne i16* %459, null
-  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+  %NullCheck155 = icmp eq i16* %459, null
+  br i1 %NullCheck155, label %ThrowNullRef156, label %460
 
 ; <label>:460                                     ; preds = %456
   %461 = load i16, i16* %459, align 8
   %462 = sext i16 %461 to i32
   %463 = bitcast i8* %457 to i16*
   %464 = trunc i32 %462 to i16
-  %NullCheck158 = icmp ne i16* %463, null
-  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+  %NullCheck157 = icmp eq i16* %463, null
+  br i1 %NullCheck157, label %ThrowNullRef158, label %465
 
 ; <label>:465                                     ; preds = %460
   store i16 %464, i16* %463, align 8
@@ -1525,15 +1607,15 @@ entry:
 ; <label>:474                                     ; preds = %470
   %475 = load i8*, i8** %arg0
   %476 = load i8*, i8** %arg1
-  %NullCheck160 = icmp ne i8* %476, null
-  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+  %NullCheck159 = icmp eq i8* %476, null
+  br i1 %NullCheck159, label %ThrowNullRef160, label %477
 
 ; <label>:477                                     ; preds = %474
   %478 = load i8, i8* %476, align 8
   %479 = zext i8 %478 to i32
   %480 = trunc i32 %479 to i8
-  %NullCheck162 = icmp ne i8* %475, null
-  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+  %NullCheck161 = icmp eq i8* %475, null
+  br i1 %NullCheck161, label %ThrowNullRef162, label %481
 
 ; <label>:481                                     ; preds = %477
   store i8 %480, i8* %475, align 8
@@ -1553,343 +1635,343 @@ ThrowNullRef:                                     ; preds = %308
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %312
+ThrowNullRef2:                                    ; preds = %312
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %315
+ThrowNullRef4:                                    ; preds = %315
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %321
+ThrowNullRef6:                                    ; preds = %321
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %271
+ThrowNullRef8:                                    ; preds = %271
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %275
+ThrowNullRef10:                                   ; preds = %275
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %278
+ThrowNullRef12:                                   ; preds = %278
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %284
+ThrowNullRef14:                                   ; preds = %284
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %287
+ThrowNullRef16:                                   ; preds = %287
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %293
+ThrowNullRef18:                                   ; preds = %293
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %298
+ThrowNullRef20:                                   ; preds = %298
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %303
+ThrowNullRef22:                                   ; preds = %303
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %243
+ThrowNullRef24:                                   ; preds = %243
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %247
+ThrowNullRef26:                                   ; preds = %247
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %250
+ThrowNullRef28:                                   ; preds = %250
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %256
+ThrowNullRef30:                                   ; preds = %256
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %259
+ThrowNullRef32:                                   ; preds = %259
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %265
+ThrowNullRef34:                                   ; preds = %265
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %217
+ThrowNullRef36:                                   ; preds = %217
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %221
+ThrowNullRef38:                                   ; preds = %221
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %224
+ThrowNullRef40:                                   ; preds = %224
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %230
+ThrowNullRef42:                                   ; preds = %230
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %233
+ThrowNullRef44:                                   ; preds = %233
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %238
+ThrowNullRef46:                                   ; preds = %238
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %200
+ThrowNullRef48:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %204
+ThrowNullRef50:                                   ; preds = %204
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %207
+ThrowNullRef52:                                   ; preds = %207
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %213
+ThrowNullRef54:                                   ; preds = %213
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %172
+ThrowNullRef56:                                   ; preds = %172
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %176
+ThrowNullRef58:                                   ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %179
+ThrowNullRef60:                                   ; preds = %179
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %185
+ThrowNullRef62:                                   ; preds = %185
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %190
+ThrowNullRef64:                                   ; preds = %190
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %195
+ThrowNullRef66:                                   ; preds = %195
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %153
+ThrowNullRef68:                                   ; preds = %153
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %157
+ThrowNullRef70:                                   ; preds = %157
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %160
+ThrowNullRef72:                                   ; preds = %160
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %166
+ThrowNullRef74:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %136
+ThrowNullRef76:                                   ; preds = %136
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %140
+ThrowNullRef78:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %143
+ThrowNullRef80:                                   ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %148
+ThrowNullRef82:                                   ; preds = %148
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %128
+ThrowNullRef84:                                   ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %132
+ThrowNullRef86:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %100
+ThrowNullRef88:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %104
+ThrowNullRef90:                                   ; preds = %104
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %107
+ThrowNullRef92:                                   ; preds = %107
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %113
+ThrowNullRef94:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %118
+ThrowNullRef96:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %123
+ThrowNullRef98:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %81
+ThrowNullRef100:                                  ; preds = %81
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef101:                                  ; preds = %85
+ThrowNullRef102:                                  ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef103:                                  ; preds = %88
+ThrowNullRef104:                                  ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef105:                                  ; preds = %94
+ThrowNullRef106:                                  ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef107:                                  ; preds = %64
+ThrowNullRef108:                                  ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef109:                                  ; preds = %68
+ThrowNullRef110:                                  ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef111:                                  ; preds = %71
+ThrowNullRef112:                                  ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef113:                                  ; preds = %76
+ThrowNullRef114:                                  ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef115:                                  ; preds = %56
+ThrowNullRef116:                                  ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef117:                                  ; preds = %60
+ThrowNullRef118:                                  ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef119:                                  ; preds = %37
+ThrowNullRef120:                                  ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef121:                                  ; preds = %41
+ThrowNullRef122:                                  ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef123:                                  ; preds = %46
+ThrowNullRef124:                                  ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef125:                                  ; preds = %51
+ThrowNullRef126:                                  ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef127:                                  ; preds = %27
+ThrowNullRef128:                                  ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef129:                                  ; preds = %31
+ThrowNullRef130:                                  ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef131:                                  ; preds = %19
+ThrowNullRef132:                                  ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef133:                                  ; preds = %22
+ThrowNullRef134:                                  ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef135:                                  ; preds = %338
+ThrowNullRef136:                                  ; preds = %338
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef137:                                  ; preds = %341
+ThrowNullRef138:                                  ; preds = %341
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef139:                                  ; preds = %356
+ThrowNullRef140:                                  ; preds = %356
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef141:                                  ; preds = %360
+ThrowNullRef142:                                  ; preds = %360
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef143:                                  ; preds = %377
+ThrowNullRef144:                                  ; preds = %377
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef145:                                  ; preds = %381
+ThrowNullRef146:                                  ; preds = %381
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef147:                                  ; preds = %424
+ThrowNullRef148:                                  ; preds = %424
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef149:                                  ; preds = %428
+ThrowNullRef150:                                  ; preds = %428
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef151:                                  ; preds = %440
+ThrowNullRef152:                                  ; preds = %440
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef153:                                  ; preds = %444
+ThrowNullRef154:                                  ; preds = %444
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef155:                                  ; preds = %456
+ThrowNullRef156:                                  ; preds = %456
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef157:                                  ; preds = %460
+ThrowNullRef158:                                  ; preds = %460
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef159:                                  ; preds = %474
+ThrowNullRef160:                                  ; preds = %474
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef161:                                  ; preds = %477
+ThrowNullRef162:                                  ; preds = %477
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef163:                                  ; preds = %394
+ThrowNullRef164:                                  ; preds = %394
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef165:                                  ; preds = %398
+ThrowNullRef166:                                  ; preds = %398
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef167:                                  ; preds = %401
+ThrowNullRef168:                                  ; preds = %401
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef169:                                  ; preds = %407
+ThrowNullRef170:                                  ; preds = %407
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1939,8 +2021,8 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
-  br i1 %NullCheck, label %22, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %ThrowNullRef, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
@@ -1948,8 +2030,8 @@ entry:
   store i32 %24, i32* %loc0
   %25 = load i32, i32* %loc0
   %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %26, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %27
 
 ; <label>:27                                      ; preds = %22
   %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
@@ -1971,7 +2053,7 @@ ThrowNullRef:                                     ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1989,8 +2071,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -2022,15 +2104,15 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2048,16 +2130,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
   %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
   store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %15
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
@@ -2072,8 +2154,8 @@ entry:
   %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
   %29 = ptrtoint i16 addrspace(1)* %28 to i64
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %19
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
@@ -2089,19 +2171,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2114,8 +2196,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
@@ -2128,7 +2210,7 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[loadElem]
+Failed to read AppDomain.PrepareDataForSetup[storeElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
@@ -2202,8 +2284,8 @@ entry:
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
-  br i1 %NullCheck24, label %27, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = load i64, i64 addrspace(1)* %26
@@ -2218,8 +2300,8 @@ entry:
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
-  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
   %41 = load i64, i64 addrspace(1)* %39
@@ -2236,8 +2318,8 @@ entry:
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
-  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
   %54 = load i64, i64 addrspace(1)* %52
@@ -2252,8 +2334,8 @@ entry:
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
   %67 = load i64, i64 addrspace(1)* %65
@@ -2270,8 +2352,8 @@ entry:
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
-  br i1 %NullCheck16, label %79, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
   %80 = load i64, i64 addrspace(1)* %78
@@ -2286,8 +2368,8 @@ entry:
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
-  br i1 %NullCheck18, label %92, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
   %93 = load i64, i64 addrspace(1)* %91
@@ -2304,8 +2386,8 @@ entry:
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
-  br i1 %NullCheck12, label %105, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = load i64, i64 addrspace(1)* %104
@@ -2320,8 +2402,8 @@ entry:
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
-  br i1 %NullCheck14, label %118, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
   %119 = load i64, i64 addrspace(1)* %117
@@ -2337,8 +2419,8 @@ entry:
 
 ; <label>:128                                     ; preds = %20
   %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
-  br i1 %NullCheck4, label %130, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %129, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %130
 
 ; <label>:130                                     ; preds = %128
   %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
@@ -2346,8 +2428,8 @@ entry:
   %133 = load i16, i16 addrspace(1)* %132, align 8
   %134 = zext i16 %133 to i32
   %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
-  br i1 %NullCheck6, label %136, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %135, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %136
 
 ; <label>:136                                     ; preds = %130
   %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
@@ -2360,8 +2442,8 @@ entry:
 
 ; <label>:143                                     ; preds = %136
   %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
-  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %144, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %145
 
 ; <label>:145                                     ; preds = %143
   %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
@@ -2369,8 +2451,8 @@ entry:
   %148 = load i16, i16 addrspace(1)* %147, align 8
   %149 = zext i16 %148 to i32
   %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %150, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %151
 
 ; <label>:151                                     ; preds = %145
   %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
@@ -2388,8 +2470,8 @@ entry:
 
 ; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
-  br i1 %NullCheck, label %163, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %ThrowNullRef, label %163
 
 ; <label>:163                                     ; preds = %161
   %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
@@ -2399,8 +2481,8 @@ entry:
 
 ; <label>:167                                     ; preds = %163
   %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
-  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %168, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %169
 
 ; <label>:169                                     ; preds = %167
   %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
@@ -2432,55 +2514,55 @@ ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %167
+ThrowNullRef2:                                    ; preds = %167
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %128
+ThrowNullRef4:                                    ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %130
+ThrowNullRef6:                                    ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %143
+ThrowNullRef8:                                    ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %145
+ThrowNullRef10:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %102
+ThrowNullRef12:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %105
+ThrowNullRef14:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %76
+ThrowNullRef16:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %79
+ThrowNullRef18:                                   ; preds = %79
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %50
+ThrowNullRef20:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %53
+ThrowNullRef22:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %24
+ThrowNullRef24:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %27
+ThrowNullRef26:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2503,15 +2585,15 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2519,16 +2601,16 @@ entry:
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
   store i32 %8, i32* %loc0
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
   %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
   store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
@@ -2546,16 +2628,16 @@ entry:
 
 ; <label>:23                                      ; preds = %64
   %24 = load i16*, i16** %loc3
-  %NullCheck12 = icmp ne i16* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i16* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
   store i32 %27, i32* %loc5
   %28 = load i16*, i16** %loc4
-  %NullCheck14 = icmp ne i16* %28, null
-  br i1 %NullCheck14, label %29, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %28, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = load i16, i16* %28, align 8
@@ -2620,15 +2702,15 @@ entry:
 
 ; <label>:67                                      ; preds = %64
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
-  br i1 %NullCheck8, label %69, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %68, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %69
 
 ; <label>:69                                      ; preds = %67
   %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
   %71 = load i32, i32 addrspace(1)* %70
   %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
-  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %73
 
 ; <label>:73                                      ; preds = %69
   %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
@@ -2645,31 +2727,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %67
+ThrowNullRef8:                                    ; preds = %67
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %69
+ThrowNullRef10:                                   ; preds = %69
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2710,14 +2792,14 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
   %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
@@ -2730,14 +2812,14 @@ entry:
 
 ; <label>:11                                      ; preds = %4
   %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
   %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
@@ -2749,14 +2831,14 @@ entry:
 
 ; <label>:22                                      ; preds = %16
   %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
   %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
-  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
-  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
@@ -2804,23 +2886,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2836,7 +2918,280 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[loadElem]
+Successfully read RuntimeType.IsAssignableFrom
+
+define i8 @RuntimeType.IsAssignableFrom(%System.RuntimeType addrspace(1)* %param0, %System.Type addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.RuntimeType addrspace(1)*
+  %arg1 = alloca %System.Type addrspace(1)*
+  %loc0 = alloca %System.RuntimeType addrspace(1)*
+  %loc1 = alloca %"System.Type[]" addrspace(1)*
+  %loc2 = alloca i32
+  store %System.RuntimeType addrspace(1)* %param0, %System.RuntimeType addrspace(1)** %this
+  store %System.Type addrspace(1)* %param1, %System.Type addrspace(1)** %arg1
+  %0 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %1 = icmp ne %System.Type addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i8 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %5 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %6 = bitcast %System.Type addrspace(1)* %4 to %System.Object addrspace(1)*
+  %7 = bitcast %System.RuntimeType addrspace(1)* %5 to %System.Object addrspace(1)*
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %6, %System.Object addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %3
+  ret i8 1
+
+; <label>:12                                      ; preds = %3
+  %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 152
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 32
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
+  %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
+  %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
+  store %System.RuntimeType addrspace(1)* %25, %System.RuntimeType addrspace(1)** %loc0
+  %26 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %27 = icmp eq %System.RuntimeType addrspace(1)* %26, null
+  br i1 %27, label %34, label %28
+
+; <label>:28                                      ; preds = %15
+  %29 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %30 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)*)*)(%System.RuntimeType addrspace(1)* %29, %System.RuntimeType addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+; <label>:34                                      ; preds = %15
+  %35 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %36 = call %System.Reflection.Emit.TypeBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Reflection.Emit.TypeBuilder addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %35)
+  %37 = icmp eq %System.Reflection.Emit.TypeBuilder addrspace(1)* %36, null
+  br i1 %37, label %139, label %38
+
+; <label>:38                                      ; preds = %34
+  %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %42
+
+; <label>:42                                      ; preds = %38
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 152
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 40
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
+  %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
+  %53 = zext i8 %52 to i32
+  %54 = icmp eq i32 %53, 0
+  br i1 %54, label %56, label %55
+
+; <label>:55                                      ; preds = %42
+  ret i8 1
+
+; <label>:56                                      ; preds = %42
+  %57 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %58 = bitcast %System.RuntimeType addrspace(1)* %57 to %System.Type addrspace(1)*
+  %59 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %58)
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %64 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.Type addrspace(1)* %63, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = bitcast %System.RuntimeType addrspace(1)* %64 to %System.Type addrspace(1)*
+  %67 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %63, %System.Type addrspace(1)* %66)
+  %68 = zext i8 %67 to i32
+  %69 = trunc i32 %68 to i8
+  ret i8 %69
+
+; <label>:70                                      ; preds = %56
+  %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
+  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %73
+
+; <label>:73                                      ; preds = %70
+  %74 = load i64, i64 addrspace(1)* %72
+  %75 = add i64 %74, 128
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = add i64 %77, 0
+  %79 = inttoptr i64 %78 to i64*
+  %80 = load i64, i64* %79
+  %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
+  %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
+  %83 = call i8 %82(%System.Type addrspace(1)* %81)
+  %84 = zext i8 %83 to i32
+  %85 = icmp eq i32 %84, 0
+  br i1 %85, label %139, label %86
+
+; <label>:86                                      ; preds = %73
+  %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
+  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %89
+
+; <label>:89                                      ; preds = %86
+  %90 = load i64, i64 addrspace(1)* %88
+  %91 = add i64 %90, 128
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = add i64 %93, 24
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
+  %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
+  %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
+  store %"System.Type[]" addrspace(1)* %99, %"System.Type[]" addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %129
+
+; <label>:100                                     ; preds = %132
+  %101 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %102 = load i32, i32* %loc2
+  %NullCheck11 = icmp eq %"System.Type[]" addrspace(1)* %101, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %103
+
+; <label>:103                                     ; preds = %100
+  %104 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 1
+  %105 = load i32, i32 addrspace(1)* %104
+  %106 = zext i32 %105 to i64
+  %107 = zext i32 %102 to i64
+  %BoundsCheck = icmp uge i64 %107, %106
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %108
+
+; <label>:108                                     ; preds = %103
+  %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
+  %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
+  %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
+  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %113
+
+; <label>:113                                     ; preds = %108
+  %114 = load i64, i64 addrspace(1)* %112
+  %115 = add i64 %114, 152
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = add i64 %117, 56
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
+  %123 = zext i8 %122 to i32
+  %124 = icmp ne i32 %123, 0
+  br i1 %124, label %126, label %125
+
+; <label>:125                                     ; preds = %113
+  ret i8 0
+
+; <label>:126                                     ; preds = %113
+  %127 = load i32, i32* %loc2
+  %128 = add i32 %127, 1
+  store i32 %128, i32* %loc2
+  br label %129
+
+; <label>:129                                     ; preds = %89, %126
+  %130 = load i32, i32* %loc2
+  %131 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %NullCheck9 = icmp eq %"System.Type[]" addrspace(1)* %131, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %132
+
+; <label>:132                                     ; preds = %129
+  %133 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %131, i32 0, i32 1
+  %134 = load i32, i32 addrspace(1)* %133
+  %135 = zext i32 %134 to i64
+  %136 = trunc i64 %135 to i32
+  %137 = icmp slt i32 %130, %136
+  br i1 %137, label %100, label %138
+
+; <label>:138                                     ; preds = %132
+  ret i8 1
+
+; <label>:139                                     ; preds = %34, %73
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %129
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %103
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -2893,7 +3248,7 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElem]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -2904,8 +3259,8 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -2997,8 +3352,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
@@ -3059,8 +3414,8 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -3087,8 +3442,8 @@ entry:
 
 ; <label>:17                                      ; preds = %5, %11
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
@@ -3097,8 +3452,8 @@ entry:
 
 ; <label>:22                                      ; preds = %1, %11
   %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
@@ -3109,11 +3464,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %17
+ThrowNullRef2:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %22
+ThrowNullRef4:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3167,15 +3522,15 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
   %15 = load i32, i32 addrspace(1)* %14
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
@@ -3198,7 +3553,7 @@ ThrowNullRef:                                     ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef2:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3232,8 +3587,8 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
@@ -3312,8 +3667,8 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -3327,8 +3682,8 @@ entry:
 ; <label>:5                                       ; preds = %43
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %7 = load i32, i32* %loc1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck6, label %8, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
@@ -3366,8 +3721,8 @@ entry:
 ; <label>:32                                      ; preds = %21, %25
   %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
   %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
-  br i1 %NullCheck8, label %35, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = trunc i32 %34 to i16
@@ -3380,8 +3735,8 @@ entry:
 ; <label>:40                                      ; preds = %1, %35
   %41 = load i32, i32* %loc1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
-  br i1 %NullCheck2, label %43, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %42, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
@@ -3392,8 +3747,8 @@ entry:
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
   %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
-  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
   %51 = load i64, i64 addrspace(1)* %49
@@ -3412,19 +3767,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %40
+ThrowNullRef2:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %47
+ThrowNullRef4:                                    ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %5
+ThrowNullRef6:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %32
+ThrowNullRef8:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3467,8 +3822,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
@@ -3492,11 +3847,391 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(i16* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store i16* %param0, i16** %arg0
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load i32, i32* %arg3
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %42, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %37, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg2
+  %13 = load i32, i32* %arg3
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %37, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %24 = load i32, i32* %arg2
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load i16*, i16** %arg0
+  %35 = load i32, i32* %arg3
+  %36 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %36, i16* %34, i32 %35)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:37                                      ; preds = %5, %16
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %39)
+  %41 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41, %System.String addrspace(1)* %38, %System.String addrspace(1)* %40)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41) #0
+  unreachable
+
+; <label>:42                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
-Failed to read StringBuilder.ToString[loadElemA]
+Successfully read StringBuilder.ToString
+
+define %System.String addrspace(1)* @StringBuilder.ToString(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i16*
+  %loc3 = alloca %"System.Char[]" addrspace(1)*
+  %loc4 = alloca i32
+  %loc5 = alloca i32
+  %loc6 = alloca i16 addrspace(1)*
+  %loc7 = alloca %System.String addrspace(1)*
+  %loc8 = alloca %"System.Char[]" addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %0)
+  %2 = icmp ne i32 %1, 0
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %4
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %6)
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %7)
+  store %System.String addrspace(1)* %8, %System.String addrspace(1)** %loc0
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.Text.StringBuilder addrspace(1)* %9, %System.Text.StringBuilder addrspace(1)** %loc1
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  store %System.String addrspace(1)* %10, %System.String addrspace(1)** %loc7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc7
+  %12 = ptrtoint %System.String addrspace(1)* %11 to i64
+  %13 = icmp eq i64 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %5
+  %15 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %16 = sext i32 %15 to i64
+  %17 = add i64 %12, %16
+  br label %18
+
+; <label>:18                                      ; preds = %5, %14
+  %19 = phi i64 [ %12, %5 ], [ %17, %14 ]
+  %20 = inttoptr i64 %19 to i16*
+  store i16* %20, i16** %loc2
+  br label %21
+
+; <label>:21                                      ; preds = %98, %18
+  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %22, null
+  br i1 %NullCheck, label %ThrowNullRef, label %23
+
+; <label>:23                                      ; preds = %21
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 3
+  %25 = load i32, i32 addrspace(1)* %24, align 8
+  %26 = icmp sle i32 %25, 0
+  br i1 %26, label %96, label %27
+
+; <label>:27                                      ; preds = %23
+  %28 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %28, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %29
+
+; <label>:29                                      ; preds = %27
+  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %28, i32 0, i32 1
+  %31 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %30, align 8
+  store %"System.Char[]" addrspace(1)* %31, %"System.Char[]" addrspace(1)** %loc3
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %33
+
+; <label>:33                                      ; preds = %29
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  store i32 %35, i32* %loc4
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  %39 = load i32, i32 addrspace(1)* %38, align 8
+  store i32 %39, i32* %loc5
+  %40 = load i32, i32* %loc5
+  %41 = load i32, i32* %loc4
+  %42 = add i32 %40, %41
+  %43 = zext i32 %42 to i64
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %45
+
+; <label>:45                                      ; preds = %37
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = sext i32 %47 to i64
+  %49 = icmp sgt i64 %43, %48
+  br i1 %49, label %91, label %50
+
+; <label>:50                                      ; preds = %45
+  %51 = load i32, i32* %loc5
+  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %52, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %53
+
+; <label>:53                                      ; preds = %50
+  %54 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %52, i32 0, i32 1
+  %55 = load i32, i32 addrspace(1)* %54
+  %56 = zext i32 %55 to i64
+  %57 = trunc i64 %56 to i32
+  %58 = icmp ugt i32 %51, %57
+  br i1 %58, label %91, label %59
+
+; <label>:59                                      ; preds = %53
+  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  store %"System.Char[]" addrspace(1)* %60, %"System.Char[]" addrspace(1)** %loc8
+  %61 = icmp eq %"System.Char[]" addrspace(1)* %60, null
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %63, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %64
+
+; <label>:64                                      ; preds = %62
+  %65 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %63, i32 0, i32 1
+  %66 = load i32, i32 addrspace(1)* %65
+  %67 = zext i32 %66 to i64
+  %68 = trunc i64 %67 to i32
+  %69 = icmp ne i32 %68, 0
+  br i1 %69, label %71, label %70
+
+; <label>:70                                      ; preds = %59, %64
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:71                                      ; preds = %64
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %73
+
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %BoundsCheck = icmp uge i64 0, %76
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %77
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %78, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:79                                      ; preds = %70, %77
+  %80 = load i16*, i16** %loc2
+  %81 = load i32, i32* %loc4
+  %82 = sext i32 %81 to i64
+  %83 = mul i64 %82, 2
+  %84 = bitcast i16* %80 to i8*
+  %85 = getelementptr inbounds i8, i8* %84, i64 %83
+  %86 = load i16 addrspace(1)*, i16 addrspace(1)** %loc6
+  %87 = ptrtoint i16 addrspace(1)* %86 to i64
+  %88 = load i32, i32* %loc5
+  %89 = bitcast i8* %85 to i16*
+  %90 = inttoptr i64 %87 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %89, i16* %90, i32 %88)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %96
+
+; <label>:91                                      ; preds = %45, %53
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %94 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %93)
+  %95 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95, %System.String addrspace(1)* %92, %System.String addrspace(1)* %94)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95) #0
+  unreachable
+
+; <label>:96                                      ; preds = %23, %79
+  %97 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %97, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %98
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %97, i32 0, i32 2
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  store %System.Text.StringBuilder addrspace(1)* %100, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %102 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %102, label %21, label %103
+
+; <label>:103                                     ; preds = %98
+  store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc7
+  %104 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  ret %System.String addrspace(1)* %104
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method StringBuilder::get_Length using LLILCJit
+Successfully read StringBuilder.get_Length
+
+define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
+Successfully read RuntimeHelpers.get_OffsetToStringData
+
+define i32 @RuntimeHelpers.get_OffsetToStringData() {
+entry:
+  ret i32 12
+}
+
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
 Successfully read CultureData.CreateCultureData
 
@@ -3514,23 +4249,23 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
   store i8 %4, i8 addrspace(1)* %6
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
@@ -3549,11 +4284,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3566,50 +4301,50 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
   store i32 -1, i32 addrspace(1)* %2
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
   store i32 -1, i32 addrspace(1)* %8
   %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
   store i32 -1, i32 addrspace(1)* %14
   %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
   store i32 -1, i32 addrspace(1)* %17
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
@@ -3623,27 +4358,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3675,7 +4410,136 @@ Failed to read Dictionary`2.Insert[non-const derefAddress]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
 Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
-Failed to read HashHelpers.GetPrime[loadElem]
+Successfully read HashHelpers.GetPrime
+
+define i32 @HashHelpers.GetPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %6, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5, %System.String addrspace(1)* %4)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5) #0
+  unreachable
+
+; <label>:6                                       ; preds = %entry
+  store i32 0, i32* %loc0
+  br label %29
+
+; <label>:7                                       ; preds = %35
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 1296
+  %10 = addrspacecast i8 addrspace(1)* %9 to %"System.Int32[]" addrspace(1)**
+  %11 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %10
+  %12 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Int32[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = zext i32 %15 to i64
+  %17 = zext i32 %12 to i64
+  %BoundsCheck = icmp uge i64 %17, %16
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 3, i32 %12
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  store i32 %20, i32* %loc1
+  %21 = load i32, i32* %loc1
+  %22 = load i32, i32* %arg0
+  %23 = icmp slt i32 %21, %22
+  br i1 %23, label %26, label %24
+
+; <label>:24                                      ; preds = %18
+  %25 = load i32, i32* %loc1
+  ret i32 %25
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %loc0
+  %28 = add i32 %27, 1
+  store i32 %28, i32* %loc0
+  br label %29
+
+; <label>:29                                      ; preds = %6, %26
+  %30 = load i32, i32* %loc0
+  %31 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %32 = getelementptr inbounds i8, i8 addrspace(1)* %31, i64 1296
+  %33 = addrspacecast i8 addrspace(1)* %32 to %"System.Int32[]" addrspace(1)**
+  %34 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %33
+  %NullCheck = icmp eq %"System.Int32[]" addrspace(1)* %34, null
+  br i1 %NullCheck, label %ThrowNullRef, label %35
+
+; <label>:35                                      ; preds = %29
+  %36 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %34, i32 0, i32 1
+  %37 = load i32, i32 addrspace(1)* %36
+  %38 = zext i32 %37 to i64
+  %39 = trunc i64 %38 to i32
+  %40 = icmp slt i32 %30, %39
+  br i1 %40, label %7, label %41
+
+; <label>:41                                      ; preds = %35
+  %42 = load i32, i32* %arg0
+  %43 = or i32 %42, 1
+  store i32 %43, i32* %loc2
+  br label %59
+
+; <label>:44                                      ; preds = %59
+  %45 = load i32, i32* %loc2
+  %46 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %45)
+  %47 = zext i8 %46 to i32
+  %48 = icmp eq i32 %47, 0
+  br i1 %48, label %56, label %49
+
+; <label>:49                                      ; preds = %44
+  %50 = load i32, i32* %loc2
+  %51 = sub i32 %50, 1
+  %52 = srem i32 %51, 101
+  %53 = icmp eq i32 %52, 0
+  br i1 %53, label %56, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = load i32, i32* %loc2
+  ret i32 %55
+
+; <label>:56                                      ; preds = %44, %49
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %57, 2
+  store i32 %58, i32* %loc2
+  br label %59
+
+; <label>:59                                      ; preds = %41, %56
+  %60 = load i32, i32* %loc2
+  %61 = icmp slt i32 %60, 2147483647
+  br i1 %61, label %44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load i32, i32* %arg0
+  ret i32 %63
+
+ThrowNullRef:                                     ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
 Successfully read GenericEqualityComparer`1.GetHashCode
 
@@ -3694,14 +4558,14 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
   %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load i64, i64 addrspace(1)* %7
@@ -3720,7 +4584,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3750,8 +4614,8 @@ entry:
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
@@ -3796,8 +4660,8 @@ entry:
   %35 = bitcast i16* %34 to i8*
   %36 = getelementptr inbounds i8, i8* %35, i64 2
   %37 = bitcast i8* %36 to i16*
-  %NullCheck4 = icmp ne i16* %37, null
-  br i1 %NullCheck4, label %38, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %37, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %38
 
 ; <label>:38                                      ; preds = %27
   %39 = load i16, i16* %37, align 8
@@ -3824,8 +4688,8 @@ entry:
 
 ; <label>:54                                      ; preds = %22, %43
   %55 = load i16*, i16** %loc4
-  %NullCheck2 = icmp ne i16* %55, null
-  br i1 %NullCheck2, label %56, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i16* %55, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %56
 
 ; <label>:56                                      ; preds = %54
   %57 = load i16, i16* %55, align 8
@@ -3850,11 +4714,11 @@ ThrowNullRef:                                     ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %54
+ThrowNullRef2:                                    ; preds = %54
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %27
+ThrowNullRef4:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3871,8 +4735,8 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -3907,8 +4771,8 @@ entry:
 
 ; <label>:26                                      ; preds = %19
   %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
-  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %28
 
 ; <label>:28                                      ; preds = %26
   %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
@@ -3920,7 +4784,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3972,8 +4836,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
@@ -3984,26 +4848,26 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
-  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
@@ -4014,8 +4878,8 @@ entry:
 ; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
@@ -4024,8 +4888,8 @@ entry:
 
 ; <label>:25                                      ; preds = %1, %16, %23
   %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
-  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
@@ -4036,27 +4900,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %20
+ThrowNullRef10:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4069,8 +4933,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -4081,8 +4945,8 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
@@ -4091,8 +4955,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1, %8
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
@@ -4103,11 +4967,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4128,24 +4992,24 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   store i32 %3, i32* %loc0
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
   %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
   store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck4, label %9, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
@@ -4164,15 +5028,15 @@ entry:
 ; <label>:18                                      ; preds = %70
   %19 = load i16*, i16** %loc3
   %20 = bitcast i16* %19 to i64*
-  %NullCheck10 = icmp ne i64* %20, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %20, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = load i64, i64* %20, align 8
   %23 = load i16*, i16** %loc4
   %24 = bitcast i16* %23 to i64*
-  %NullCheck12 = icmp ne i64* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = load i64, i64* %24, align 8
@@ -4188,8 +5052,8 @@ entry:
   %31 = bitcast i16* %30 to i8*
   %32 = getelementptr inbounds i8, i8* %31, i64 8
   %33 = bitcast i8* %32 to i64*
-  %NullCheck14 = icmp ne i64* %33, null
-  br i1 %NullCheck14, label %34, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = load i64, i64* %33, align 8
@@ -4197,8 +5061,8 @@ entry:
   %37 = bitcast i16* %36 to i8*
   %38 = getelementptr inbounds i8, i8* %37, i64 8
   %39 = bitcast i8* %38 to i64*
-  %NullCheck16 = icmp ne i64* %39, null
-  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %40
 
 ; <label>:40                                      ; preds = %34
   %41 = load i64, i64* %39, align 8
@@ -4214,8 +5078,8 @@ entry:
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %NullCheck18 = icmp ne i64* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = load i64, i64* %48, align 8
@@ -4223,8 +5087,8 @@ entry:
   %52 = bitcast i16* %51 to i8*
   %53 = getelementptr inbounds i8, i8* %52, i64 16
   %54 = bitcast i8* %53 to i64*
-  %NullCheck20 = icmp ne i64* %54, null
-  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64* %54, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %55
 
 ; <label>:55                                      ; preds = %49
   %56 = load i64, i64* %54, align 8
@@ -4262,15 +5126,15 @@ entry:
 ; <label>:74                                      ; preds = %95
   %75 = load i16*, i16** %loc3
   %76 = bitcast i16* %75 to i32*
-  %NullCheck6 = icmp ne i32* %76, null
-  br i1 %NullCheck6, label %77, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32* %76, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %77
 
 ; <label>:77                                      ; preds = %74
   %78 = load i32, i32* %76, align 8
   %79 = load i16*, i16** %loc4
   %80 = bitcast i16* %79 to i32*
-  %NullCheck8 = icmp ne i32* %80, null
-  br i1 %NullCheck8, label %81, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i32* %80, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %81
 
 ; <label>:81                                      ; preds = %77
   %82 = load i32, i32* %80, align 8
@@ -4318,43 +5182,43 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %74
+ThrowNullRef6:                                    ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %77
+ThrowNullRef8:                                    ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %29
+ThrowNullRef14:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %34
+ThrowNullRef16:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4376,8 +5240,8 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load i64, i64 addrspace(1)* %4
@@ -4389,8 +5253,8 @@ entry:
   %12 = load i64, i64* %11
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %5
   %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
@@ -4399,8 +5263,8 @@ entry:
   %18 = load i8, i8* %arg2
   %19 = zext i8 %18 to i32
   %20 = trunc i32 %19 to i8
-  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %15
   %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
@@ -4411,11 +5275,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4442,8 +5306,8 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
@@ -4466,16 +5330,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
   %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = load i64, i64 addrspace(1)* %19
@@ -4500,8 +5364,8 @@ entry:
 ; <label>:35                                      ; preds = %30
   %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
@@ -4514,8 +5378,8 @@ entry:
 
 ; <label>:42                                      ; preds = %1, %38
   %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
-  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
@@ -4526,19 +5390,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %35
+ThrowNullRef2:                                    ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %42
+ThrowNullRef8:                                    ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4551,14 +5415,14 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
@@ -4570,7 +5434,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4583,8 +5447,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
@@ -4613,51 +5477,51 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
   %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
   %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
   %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
   %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
-  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
   store i64 %21, i64 addrspace(1)* %23
   %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %25 = load i64, i64* %loc0
-  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
@@ -4668,27 +5532,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %22
+ThrowNullRef12:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4701,8 +5565,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
@@ -4713,19 +5577,19 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
@@ -4734,8 +5598,8 @@ entry:
 
 ; <label>:15                                      ; preds = %1, %13
   %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
@@ -4746,19 +5610,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %15
+ThrowNullRef8:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4771,8 +5635,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -4831,8 +5695,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
@@ -4882,8 +5746,8 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
-  br i1 %NullCheck, label %17, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %ThrowNullRef, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
@@ -4894,15 +5758,15 @@ entry:
 
 ; <label>:22                                      ; preds = %17
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
-  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
   %26 = load i32, i32 addrspace(1)* %25
   %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
-  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %27, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
@@ -4925,8 +5789,8 @@ entry:
 ; <label>:40                                      ; preds = %17
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
-  br i1 %NullCheck6, label %43, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %41, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
@@ -4938,34 +5802,17 @@ ThrowNullRef:                                     ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %24
+ThrowNullRef4:                                    ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %40
+ThrowNullRef6:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
-}
-
-INFO:  jitting method Object::ReferenceEquals using LLILCJit
-Successfully read Object.ReferenceEquals
-
-define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
-entry:
-  %arg0 = alloca %System.Object addrspace(1)*
-  %arg1 = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
-  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
-  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = icmp eq %System.Object addrspace(1)* %0, %1
-  %3 = sext i1 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
 }
 
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
@@ -4978,21 +5825,21 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
   %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
-  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
@@ -5007,28 +5854,28 @@ entry:
 ; <label>:13                                      ; preds = %8, %12
   %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
   %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
   %21 = load i32, i32 addrspace(1)* %20, align 8
   %22 = add i32 %21, 1
-  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
   store i32 %22, i32 addrspace(1)* %24
   %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
@@ -5039,27 +5886,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5077,7 +5924,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::Setup using LLILCJit
-Failed to read AppDomain.Setup[loadElem]
+Failed to read AppDomain.Setup[unbox]
 INFO:  jitting method Thread::GetDomain using LLILCJit
 Successfully read Thread.GetDomain
 
@@ -5108,8 +5955,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
@@ -5122,14 +5969,14 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
   %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
@@ -5141,11 +5988,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5173,8 +6020,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -5189,7 +6036,328 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
 Failed to read KeyCollection.System.Collections.Generic.IEnumerable<TKey>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Successfully read Enumerator.MoveNext
+
+define i8 @Enumerator.MoveNext(%"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.RuntimeTypeHandle* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*
+  %"$TypeArg" = alloca %System.RuntimeTypeHandle*
+  store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
+  %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 8
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %76, label %12
+
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
+  br label %76
+
+; <label>:13                                      ; preds = %85
+  %14 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck19 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %15
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, i32 0, i32 0
+  %17 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %16, align 8
+  %NullCheck21 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, i32 0, i32 2
+  %20 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %19, align 8
+  %21 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck23 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %22
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, i32 0, i32 2
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %NullCheck25 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 3, i32 %24
+  %NullCheck27 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %32
+
+; <label>:32                                      ; preds = %30
+  %33 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, i32 0, i32 2
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = icmp slt i32 %34, 0
+  br i1 %35, label %68, label %36
+
+; <label>:36                                      ; preds = %32
+  %37 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %38 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck29 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %39
+
+; <label>:39                                      ; preds = %36
+  %40 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, i32 0, i32 0
+  %41 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %40, align 8
+  %NullCheck31 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, i32 0, i32 2
+  %44 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %43, align 8
+  %45 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck33 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, i32 0, i32 2
+  %48 = load i32, i32 addrspace(1)* %47, align 8
+  %NullCheck35 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %49
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = zext i32 %51 to i64
+  %53 = zext i32 %48 to i64
+  %BoundsCheck37 = icmp uge i64 %53, %52
+  br i1 %BoundsCheck37, label %ThrowIndexOutOfRange38, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 3, i32 %48
+  %NullCheck39 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %56
+
+; <label>:56                                      ; preds = %54
+  %57 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, i32 0, i32 0
+  %58 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck41 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %59
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %60, %System.__Canon addrspace(1)* %58)
+  %61 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck43 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  %64 = load i32, i32 addrspace(1)* %63, align 8
+  %65 = add i32 %64, 1
+  %NullCheck45 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  store i32 %65, i32 addrspace(1)* %67
+  ret i8 1
+
+; <label>:68                                      ; preds = %32
+  %69 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck47 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %73 = add i32 %72, 1
+  %NullCheck49 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %74
+
+; <label>:74                                      ; preds = %70
+  %75 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  store i32 %73, i32 addrspace(1)* %75
+  br label %76
+
+; <label>:76                                      ; preds = %8, %12, %74
+  %77 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %78
+
+; <label>:78                                      ; preds = %76
+  %79 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, i32 0, i32 2
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck7 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %82
+
+; <label>:82                                      ; preds = %78
+  %83 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, i32 0, i32 0
+  %84 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %83, align 8
+  %NullCheck9 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %85
+
+; <label>:85                                      ; preds = %82
+  %86 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, i32 0, i32 7
+  %87 = load i32, i32 addrspace(1)* %86, align 8
+  %88 = icmp ult i32 %80, %87
+  br i1 %88, label %13, label %89
+
+; <label>:89                                      ; preds = %85
+  %90 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %91 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck11 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %92
+
+; <label>:92                                      ; preds = %89
+  %93 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, i32 0, i32 0
+  %94 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck13 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %95
+
+; <label>:95                                      ; preds = %92
+  %96 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, i32 0, i32 7
+  %97 = load i32, i32 addrspace(1)* %96, align 8
+  %98 = add i32 %97, 1
+  %NullCheck15 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %99
+
+; <label>:99                                      ; preds = %95
+  %100 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, i32 0, i32 2
+  store i32 %98, i32 addrspace(1)* %100
+  %101 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck17 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %102
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %103, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %92
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef22:                                   ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef24:                                   ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef26:                                   ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef28:                                   ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef30:                                   ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef32:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef34:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef36:                                   ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange38:                           ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef40:                                   ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef42:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef44:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef46:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef48:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef50:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -5200,8 +6368,8 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -5232,9 +6400,9 @@ Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
 Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
-Failed to read String.MakeSeparatorList[loadElemA]
+Failed to read String.MakeSeparatorList[storeElem]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
-Failed to read String.InternalSplitKeepEmptyEntries[loadElem]
+Failed to read String.InternalSplitKeepEmptyEntries[storeElem]
 INFO:  jitting method Path::IsRelative using LLILCJit
 Successfully read Path.IsRelative
 
@@ -5243,8 +6411,8 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -5254,8 +6422,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
@@ -5271,8 +6439,8 @@ entry:
 
 ; <label>:17                                      ; preds = %7
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
@@ -5288,8 +6456,8 @@ entry:
 
 ; <label>:29                                      ; preds = %19
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %31
 
 ; <label>:31                                      ; preds = %29
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
@@ -5300,8 +6468,8 @@ entry:
 
 ; <label>:36                                      ; preds = %31
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
-  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %37, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
@@ -5312,8 +6480,8 @@ entry:
 
 ; <label>:43                                      ; preds = %31, %38
   %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
-  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %45
 
 ; <label>:45                                      ; preds = %43
   %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
@@ -5324,8 +6492,8 @@ entry:
 
 ; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %50
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
@@ -5336,8 +6504,8 @@ entry:
 
 ; <label>:57                                      ; preds = %1, %7, %19, %45, %52
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
-  br i1 %NullCheck14, label %59, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %59
 
 ; <label>:59                                      ; preds = %57
   %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
@@ -5347,8 +6515,8 @@ entry:
 
 ; <label>:63                                      ; preds = %59
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
@@ -5359,8 +6527,8 @@ entry:
 
 ; <label>:70                                      ; preds = %65
   %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
-  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.String addrspace(1)* %71, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %72
 
 ; <label>:72                                      ; preds = %70
   %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
@@ -5379,39 +6547,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %17
+ThrowNullRef4:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %29
+ThrowNullRef6:                                    ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %36
+ThrowNullRef8:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %43
+ThrowNullRef10:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %50
+ThrowNullRef12:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %57
+ThrowNullRef14:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %63
+ThrowNullRef16:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %70
+ThrowNullRef18:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5419,7 +6587,293 @@ ThrowNullRef17:                                   ; preds = %70
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
-Failed to read String.TrimHelper[loadElem]
+Successfully read String.TrimHelper
+
+define %System.String addrspace(1)* @String.TrimHelper(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i16
+  %loc4 = alloca i32
+  %loc5 = alloca i16
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = sub i32 %3, 1
+  store i32 %4, i32* %loc0
+  store i32 0, i32* %loc1
+  %5 = load i32, i32* %arg2
+  %6 = icmp eq i32 %5, 1
+  br i1 %6, label %62, label %7
+
+; <label>:7                                       ; preds = %1
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:8                                       ; preds = %58
+  store i32 0, i32* %loc2
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load i32, i32* %loc1
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2, i32 %10
+  %13 = load i16, i16 addrspace(1)* %12
+  %14 = zext i16 %13 to i32
+  %15 = trunc i32 %14 to i16
+  store i16 %15, i16* %loc3
+  store i32 0, i32* %loc2
+  br label %34
+
+; <label>:16                                      ; preds = %37
+  %17 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %18 = load i32, i32* %loc2
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %17, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %19
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = zext i32 %18 to i64
+  %BoundsCheck = icmp uge i64 %23, %22
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %24
+
+; <label>:24                                      ; preds = %19
+  %25 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 3, i32 %18
+  %26 = load i16, i16 addrspace(1)* %25, align 8
+  %27 = zext i16 %26 to i32
+  %28 = load i16, i16* %loc3
+  %29 = zext i16 %28 to i32
+  %30 = icmp eq i32 %27, %29
+  br i1 %30, label %43, label %31
+
+; <label>:31                                      ; preds = %24
+  %32 = load i32, i32* %loc2
+  %33 = add i32 %32, 1
+  store i32 %33, i32* %loc2
+  br label %34
+
+; <label>:34                                      ; preds = %11, %31
+  %35 = load i32, i32* %loc2
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = icmp slt i32 %35, %41
+  br i1 %42, label %16, label %43
+
+; <label>:43                                      ; preds = %24, %37
+  %44 = load i32, i32* %loc2
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %45, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp eq i32 %44, %50
+  br i1 %51, label %62, label %52
+
+; <label>:52                                      ; preds = %46
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %7, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %57, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %58
+
+; <label>:58                                      ; preds = %55
+  %59 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %60 = load i32, i32 addrspace(1)* %59
+  %61 = icmp slt i32 %56, %60
+  br i1 %61, label %8, label %62
+
+; <label>:62                                      ; preds = %1, %46, %58
+  %63 = load i32, i32* %arg2
+  %64 = icmp eq i32 %63, 0
+  br i1 %64, label %122, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %66, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %67
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %66, i32 0, i32 1
+  %69 = load i32, i32 addrspace(1)* %68
+  %70 = sub i32 %69, 1
+  store i32 %70, i32* %loc0
+  br label %118
+
+; <label>:71                                      ; preds = %118
+  store i32 0, i32* %loc4
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %73 = load i32, i32* %loc0
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %74
+
+; <label>:74                                      ; preds = %71
+  %75 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 2, i32 %73
+  %76 = load i16, i16 addrspace(1)* %75
+  %77 = zext i16 %76 to i32
+  %78 = trunc i32 %77 to i16
+  store i16 %78, i16* %loc5
+  store i32 0, i32* %loc4
+  br label %97
+
+; <label>:79                                      ; preds = %100
+  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %81 = load i32, i32* %loc4
+  %NullCheck19 = icmp eq %"System.Char[]" addrspace(1)* %80, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
+
+; <label>:82                                      ; preds = %79
+  %83 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 1
+  %84 = load i32, i32 addrspace(1)* %83
+  %85 = zext i32 %84 to i64
+  %86 = zext i32 %81 to i64
+  %BoundsCheck21 = icmp uge i64 %86, %85
+  br i1 %BoundsCheck21, label %ThrowIndexOutOfRange22, label %87
+
+; <label>:87                                      ; preds = %82
+  %88 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 3, i32 %81
+  %89 = load i16, i16 addrspace(1)* %88, align 8
+  %90 = zext i16 %89 to i32
+  %91 = load i16, i16* %loc5
+  %92 = zext i16 %91 to i32
+  %93 = icmp eq i32 %90, %92
+  br i1 %93, label %106, label %94
+
+; <label>:94                                      ; preds = %87
+  %95 = load i32, i32* %loc4
+  %96 = add i32 %95, 1
+  store i32 %96, i32* %loc4
+  br label %97
+
+; <label>:97                                      ; preds = %74, %94
+  %98 = load i32, i32* %loc4
+  %99 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck15 = icmp eq %"System.Char[]" addrspace(1)* %99, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %100
+
+; <label>:100                                     ; preds = %97
+  %101 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %99, i32 0, i32 1
+  %102 = load i32, i32 addrspace(1)* %101
+  %103 = zext i32 %102 to i64
+  %104 = trunc i64 %103 to i32
+  %105 = icmp slt i32 %98, %104
+  br i1 %105, label %79, label %106
+
+; <label>:106                                     ; preds = %87, %100
+  %107 = load i32, i32* %loc4
+  %108 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck17 = icmp eq %"System.Char[]" addrspace(1)* %108, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %109
+
+; <label>:109                                     ; preds = %106
+  %110 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %108, i32 0, i32 1
+  %111 = load i32, i32 addrspace(1)* %110
+  %112 = zext i32 %111 to i64
+  %113 = trunc i64 %112 to i32
+  %114 = icmp eq i32 %107, %113
+  br i1 %114, label %122, label %115
+
+; <label>:115                                     ; preds = %109
+  %116 = load i32, i32* %loc0
+  %117 = sub i32 %116, 1
+  store i32 %117, i32* %loc0
+  br label %118
+
+; <label>:118                                     ; preds = %67, %115
+  %119 = load i32, i32* %loc0
+  %120 = load i32, i32* %loc1
+  %121 = icmp sge i32 %119, %120
+  br i1 %121, label %71, label %122
+
+; <label>:122                                     ; preds = %62, %109, %118
+  %123 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %124 = load i32, i32* %loc1
+  %125 = load i32, i32* %loc0
+  %126 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %123, i32 %124, i32 %125)
+  ret %System.String addrspace(1)* %126
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %97
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange22:                           ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
 Successfully read String.CreateTrimmedString
 
@@ -5439,8 +6893,8 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
@@ -5535,8 +6989,8 @@ entry:
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i64 2872
   %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
   %8 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %7
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %3
   %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
@@ -5553,8 +7007,8 @@ entry:
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 2864
   %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
   %21 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %20
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
-  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %22
 
 ; <label>:22                                      ; preds = %16
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
@@ -5569,7 +7023,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %16
+ThrowNullRef2:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5586,8 +7040,8 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5613,8 +7067,8 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
@@ -5632,8 +7086,8 @@ entry:
 
 ; <label>:12                                      ; preds = %4
   %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
@@ -5644,8 +7098,8 @@ entry:
 
 ; <label>:19                                      ; preds = %14
   %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %19
   %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
@@ -5660,21 +7114,21 @@ entry:
   %31 = zext i16 %30 to i32
   %32 = bitcast i8* %29 to i16*
   %33 = trunc i32 %31 to i16
-  %NullCheck6 = icmp ne i16* %32, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i16* %32, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %21
   store i16 %33, i16* %32, align 8
   %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %36
 
 ; <label>:36                                      ; preds = %34
   %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
   %38 = load i32, i32 addrspace(1)* %37, align 8
   %39 = add i32 %38, 1
-  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %40
 
 ; <label>:40                                      ; preds = %36
   %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
@@ -5683,16 +7137,16 @@ entry:
 
 ; <label>:42                                      ; preds = %14
   %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
-  br i1 %NullCheck12, label %44, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
   %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
   %47 = load i16, i16* %arg1
   %48 = zext i16 %47 to i32
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = trunc i32 %48 to i16
@@ -5703,31 +7157,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %19
+ThrowNullRef4:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %21
+ThrowNullRef6:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %36
+ThrowNullRef10:                                   ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %42
+ThrowNullRef12:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %44
+ThrowNullRef14:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5740,8 +7194,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -5752,8 +7206,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
@@ -5762,14 +7216,14 @@ entry:
 
 ; <label>:11                                      ; preds = %1
   %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
@@ -5779,15 +7233,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5808,8 +7262,8 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5822,8 +7276,8 @@ entry:
 
 ; <label>:8                                       ; preds = %3
   %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
@@ -5842,15 +7296,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
-  br i1 %NullCheck4, label %22, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
   %24 = load i16*, i16* addrspace(1)* %23, align 8
   %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %25, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
@@ -5859,8 +7313,8 @@ entry:
   store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
@@ -5874,8 +7328,8 @@ entry:
 
 ; <label>:37                                      ; preds = %65
   %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %37
   %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
@@ -5886,16 +7340,16 @@ entry:
   %45 = bitcast i16* %41 to i8*
   %46 = getelementptr inbounds i8, i8* %45, i64 %44
   %47 = bitcast i8* %46 to i16*
-  %NullCheck14 = icmp ne i16* %47, null
-  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %47, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %48
 
 ; <label>:48                                      ; preds = %39
   %49 = load i16, i16* %47, align 8
   %50 = zext i16 %49 to i32
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %52 = load i32, i32* %loc1
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %53
 
 ; <label>:53                                      ; preds = %48
   %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
@@ -5916,8 +7370,8 @@ entry:
 ; <label>:62                                      ; preds = %36, %59
   %63 = load i32, i32* %loc1
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck10, label %65, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %65
 
 ; <label>:65                                      ; preds = %62
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
@@ -5936,15 +7390,15 @@ entry:
 
 ; <label>:74                                      ; preds = %70
   %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
-  br i1 %NullCheck18, label %76, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %76
 
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
   %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
-  br i1 %NullCheck20, label %80, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
   %81 = load i64, i64 addrspace(1)* %79
@@ -5958,8 +7412,8 @@ entry:
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
   %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
-  br i1 %NullCheck22, label %92, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.String addrspace(1)* %90, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %92
 
 ; <label>:92                                      ; preds = %80
   %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
@@ -5969,15 +7423,15 @@ entry:
 
 ; <label>:96                                      ; preds = %70
   %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
-  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %98
 
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
   %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
-  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
   %103 = load i64, i64 addrspace(1)* %101
@@ -5991,8 +7445,8 @@ entry:
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
   %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
-  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.String addrspace(1)* %112, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %114
 
 ; <label>:114                                     ; preds = %102
   %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
@@ -6004,59 +7458,59 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %20
+ThrowNullRef4:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %22
+ThrowNullRef6:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %26
+ThrowNullRef8:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %62
+ThrowNullRef10:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %48
+ThrowNullRef16:                                   ; preds = %48
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %74
+ThrowNullRef18:                                   ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %76
+ThrowNullRef20:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %80
+ThrowNullRef22:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %96
+ThrowNullRef24:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %98
+ThrowNullRef26:                                   ; preds = %98
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %102
+ThrowNullRef28:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6069,15 +7523,15 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
   %3 = load i16*, i16* addrspace(1)* %2, align 8
   %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
@@ -6087,8 +7541,8 @@ entry:
   %10 = bitcast i16* %3 to i8*
   %11 = getelementptr inbounds i8, i8* %10, i64 %9
   %12 = bitcast i8* %11 to i16*
-  %NullCheck4 = icmp ne i16* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %5
   store i16 0, i16* %12, align 8
@@ -6098,11 +7552,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6119,8 +7573,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -6131,8 +7585,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
@@ -6144,15 +7598,15 @@ entry:
 
 ; <label>:14                                      ; preds = %1
   %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
   %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
   %21 = load i64, i64 addrspace(1)* %19
@@ -6171,15 +7625,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %14
+ThrowNullRef4:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %16
+ThrowNullRef6:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6302,14 +7756,6 @@ entry:
   ret %System.String addrspace(1)* %57
 }
 
-INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
-Successfully read RuntimeHelpers.get_OffsetToStringData
-
-define i32 @RuntimeHelpers.get_OffsetToStringData() {
-entry:
-  ret i32 12
-}
-
 INFO:  jitting method String::Equals using LLILCJit
 Successfully read String.Equals
 
@@ -6381,8 +7827,8 @@ entry:
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
-  br i1 %NullCheck24, label %29, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
   %30 = load i64, i64 addrspace(1)* %28
@@ -6397,8 +7843,8 @@ entry:
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
-  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
   %43 = load i64, i64 addrspace(1)* %41
@@ -6418,8 +7864,8 @@ entry:
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
   %59 = load i64, i64 addrspace(1)* %57
@@ -6434,8 +7880,8 @@ entry:
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck22, label %71, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
   %72 = load i64, i64 addrspace(1)* %70
@@ -6455,8 +7901,8 @@ entry:
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
-  br i1 %NullCheck16, label %87, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = load i64, i64 addrspace(1)* %86
@@ -6471,8 +7917,8 @@ entry:
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck18, label %100, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
   %101 = load i64, i64 addrspace(1)* %99
@@ -6492,8 +7938,8 @@ entry:
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
-  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
   %117 = load i64, i64 addrspace(1)* %115
@@ -6508,8 +7954,8 @@ entry:
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
-  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
   %130 = load i64, i64 addrspace(1)* %128
@@ -6528,15 +7974,15 @@ entry:
 
 ; <label>:142                                     ; preds = %22
   %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
-  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %143, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %144
 
 ; <label>:144                                     ; preds = %142
   %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
   %146 = load i32, i32 addrspace(1)* %145
   %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
-  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %147, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %148
 
 ; <label>:148                                     ; preds = %144
   %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
@@ -6557,15 +8003,15 @@ entry:
 
 ; <label>:159                                     ; preds = %22
   %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
-  br i1 %NullCheck, label %161, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %ThrowNullRef, label %161
 
 ; <label>:161                                     ; preds = %159
   %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
   %163 = load i32, i32 addrspace(1)* %162
   %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
-  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %164, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %165
 
 ; <label>:165                                     ; preds = %161
   %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
@@ -6578,8 +8024,8 @@ entry:
 
 ; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
-  br i1 %NullCheck4, label %172, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %171, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %172
 
 ; <label>:172                                     ; preds = %170
   %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
@@ -6589,8 +8035,8 @@ entry:
 
 ; <label>:176                                     ; preds = %172
   %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
-  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %177, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %178
 
 ; <label>:178                                     ; preds = %176
   %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
@@ -6629,55 +8075,55 @@ ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %161
+ThrowNullRef2:                                    ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %170
+ThrowNullRef4:                                    ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %176
+ThrowNullRef6:                                    ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %142
+ThrowNullRef8:                                    ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %144
+ThrowNullRef10:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %113
+ThrowNullRef12:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %116
+ThrowNullRef14:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %84
+ThrowNullRef16:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %87
+ThrowNullRef18:                                   ; preds = %87
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %55
+ThrowNullRef20:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %58
+ThrowNullRef22:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %26
+ThrowNullRef24:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %29
+ThrowNullRef26:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,8 +8161,8 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck, label %14, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %ThrowNullRef, label %14
 
 ; <label>:14                                      ; preds = %8
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
@@ -6760,8 +8206,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
@@ -6770,14 +8216,14 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32, i32* %loc0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %10
   %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
   %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
@@ -6790,15 +8236,15 @@ entry:
 ; <label>:25                                      ; preds = %19
   %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
-  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
   %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
@@ -6807,8 +8253,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %37 = load i32, i32* %loc0
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %38, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %38
 
 ; <label>:38                                      ; preds = %32
   %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
@@ -6817,14 +8263,14 @@ entry:
 
 ; <label>:40                                      ; preds = %19
   %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %40
   %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
   %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
-  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
-  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
@@ -6832,8 +8278,8 @@ entry:
   %48 = zext i32 %47 to i64
   %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
-  br i1 %NullCheck16, label %51, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %51
 
 ; <label>:51                                      ; preds = %45
   %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
@@ -6847,15 +8293,15 @@ entry:
 ; <label>:57                                      ; preds = %51
   %58 = load i16*, i16** %arg1
   %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
-  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %60
 
 ; <label>:60                                      ; preds = %57
   %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
   %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
-  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %64
 
 ; <label>:64                                      ; preds = %60
   %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
@@ -6864,22 +8310,22 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
   %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
-  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %70
 
 ; <label>:70                                      ; preds = %64
   %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
   %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
-  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
-  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
   %75 = load i32, i32 addrspace(1)* %74
   %76 = zext i32 %75 to i64
   %77 = trunc i64 %76 to i32
-  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
-  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %78
 
 ; <label>:78                                      ; preds = %73
   %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
@@ -6901,8 +8347,8 @@ entry:
   %90 = bitcast i16* %86 to i8*
   %91 = getelementptr inbounds i8, i8* %90, i64 %89
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %93
 
 ; <label>:93                                      ; preds = %80
   %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
@@ -6912,8 +8358,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %99 = load i32, i32* %loc2
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %100
 
 ; <label>:100                                     ; preds = %93
   %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
@@ -6928,63 +8374,63 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %25
+ThrowNullRef6:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %32
+ThrowNullRef10:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %40
+ThrowNullRef12:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %45
+ThrowNullRef16:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %57
+ThrowNullRef18:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %60
+ThrowNullRef20:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %64
+ThrowNullRef22:                                   ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %70
+ThrowNullRef24:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %73
+ThrowNullRef26:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %80
+ThrowNullRef28:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %93
+ThrowNullRef30:                                   ; preds = %93
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7004,8 +8450,8 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
@@ -7033,43 +8479,43 @@ entry:
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %14
   %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
   %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   %28 = load i32, i32 addrspace(1)* %27, align 8
   %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
-  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %30
 
 ; <label>:30                                      ; preds = %26
   %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
   %32 = load i32, i32 addrspace(1)* %31, align 8
   %33 = add i32 %28, %32
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %34
 
 ; <label>:34                                      ; preds = %30
   %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   store i32 %33, i32 addrspace(1)* %35
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
   store i32 0, i32 addrspace(1)* %38
   %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %40
 
 ; <label>:40                                      ; preds = %37
   %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
@@ -7082,8 +8528,8 @@ entry:
 
 ; <label>:47                                      ; preds = %40
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
@@ -7098,8 +8544,8 @@ entry:
   %54 = load i32, i32* %loc0
   %55 = sext i32 %54 to i64
   %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
-  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %57
 
 ; <label>:57                                      ; preds = %52
   %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
@@ -7110,68 +8556,35 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %14
+ThrowNullRef2:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %23
+ThrowNullRef4:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %26
+ThrowNullRef6:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %30
+ThrowNullRef8:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %34
+ThrowNullRef10:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %47
+ThrowNullRef14:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %52
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-}
-
-INFO:  jitting method StringBuilder::get_Length using LLILCJit
-Successfully read StringBuilder.get_Length
-
-define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.StringBuilder addrspace(1)*
-  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
-  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
-
-; <label>:1                                       ; preds = %entry
-  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %3 = load i32, i32 addrspace(1)* %2, align 8
-  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
-
-; <label>:5                                       ; preds = %1
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = add i32 %3, %7
-  ret i32 %8
-
-ThrowNullRef:                                     ; preds = %entry
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef16:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7213,70 +8626,70 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
   %6 = load i32, i32 addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
   store i32 %6, i32 addrspace(1)* %8
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
   %13 = load i32, i32 addrspace(1)* %12, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
   store i32 %13, i32 addrspace(1)* %15
   %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
-  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %18
 
 ; <label>:18                                      ; preds = %14
   %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
   %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
   %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
   %34 = load i32, i32 addrspace(1)* %33, align 8
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
-  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
@@ -7287,39 +8700,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %28
+ThrowNullRef16:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %32
+ThrowNullRef18:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7455,13 +8868,13 @@ entry:
 ; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
@@ -7477,16 +8890,16 @@ entry:
 
 ; <label>:18                                      ; preds = %15
   %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
   store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
   %22 = load i32, i32* %loc0
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %24
 
 ; <label>:24                                      ; preds = %20
   %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
@@ -7498,13 +8911,13 @@ entry:
 ; <label>:28                                      ; preds = %15, %24
   %29 = load i32, i32* %arg1
   %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %31
   %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
@@ -7517,20 +8930,20 @@ entry:
   %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
-  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
   %46 = load i32, i32 addrspace(1)* %45, align 8
   %47 = sub i32 %40, %46
-  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
-  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i32 addrspace(1)* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %48
 
 ; <label>:48                                      ; preds = %44
   store i32 %47, i32 addrspace(1)* %39, align 8
@@ -7538,21 +8951,21 @@ entry:
 
 ; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
-  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %51
 
 ; <label>:51                                      ; preds = %49
   %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %53
 
 ; <label>:53                                      ; preds = %51
   %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
   %55 = load i32, i32 addrspace(1)* %54, align 8
   %56 = load i32, i32* %arg2
   %57 = sub i32 %55, %56
-  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %58
 
 ; <label>:58                                      ; preds = %53
   %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
@@ -7562,13 +8975,13 @@ entry:
 ; <label>:60                                      ; preds = %33, %58
   %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
   %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
-  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %63
 
 ; <label>:63                                      ; preds = %60
   %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
-  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
-  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
@@ -7578,15 +8991,15 @@ entry:
 
 ; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
-  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i32 addrspace(1)* %69, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %70
 
 ; <label>:70                                      ; preds = %68
   %71 = load i32, i32 addrspace(1)* %69, align 8
   store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
-  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
@@ -7596,8 +9009,8 @@ entry:
   store i32 %77, i32* %loc4
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
-  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %80
 
 ; <label>:80                                      ; preds = %73
   %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
@@ -7607,71 +9020,71 @@ entry:
 ; <label>:83                                      ; preds = %80
   store i32 0, i32* %loc3
   %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
-  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
-  br i1 %NullCheck26, label %88, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i32 addrspace(1)* %87, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %88
 
 ; <label>:88                                      ; preds = %85
   %89 = load i32, i32 addrspace(1)* %87, align 8
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
-  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %90
 
 ; <label>:90                                      ; preds = %88
   %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
   store i32 %89, i32 addrspace(1)* %91
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
-  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
-  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %96
 
 ; <label>:96                                      ; preds = %94
   %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
-  br i1 %NullCheck34, label %100, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %100
 
 ; <label>:100                                     ; preds = %96
   %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
-  br i1 %NullCheck36, label %102, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %102
 
 ; <label>:102                                     ; preds = %100
   %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
   %104 = load i32, i32 addrspace(1)* %103, align 8
   %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
-  br i1 %NullCheck38, label %106, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %106
 
 ; <label>:106                                     ; preds = %102
   %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
-  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
-  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %108
 
 ; <label>:108                                     ; preds = %106
   %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
   %110 = load i32, i32 addrspace(1)* %109, align 8
   %111 = add i32 %104, %110
-  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %112
 
 ; <label>:112                                     ; preds = %108
   %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
   store i32 %111, i32 addrspace(1)* %113
   %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
-  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i32 addrspace(1)* %114, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %115
 
 ; <label>:115                                     ; preds = %112
   %116 = load i32, i32 addrspace(1)* %114, align 8
@@ -7681,19 +9094,19 @@ entry:
 ; <label>:118                                     ; preds = %115
   %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
-  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %121
 
 ; <label>:121                                     ; preds = %118
   %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
-  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
-  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %123
 
 ; <label>:123                                     ; preds = %121
   %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
   %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
-  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
-  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %126
 
 ; <label>:126                                     ; preds = %123
   %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
@@ -7705,8 +9118,8 @@ entry:
 
 ; <label>:130                                     ; preds = %80, %115, %126
   %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %132
 
 ; <label>:132                                     ; preds = %130
   %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7715,8 +9128,8 @@ entry:
   %136 = load i32, i32* %loc3
   %137 = sub i32 %135, %136
   %138 = sub i32 %134, %137
-  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %139
 
 ; <label>:139                                     ; preds = %132
   %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7728,16 +9141,16 @@ entry:
 
 ; <label>:144                                     ; preds = %139
   %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
-  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %146
 
 ; <label>:146                                     ; preds = %144
   %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
   %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
   %149 = load i32, i32* %loc2
   %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
-  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %151
 
 ; <label>:151                                     ; preds = %146
   %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
@@ -7754,145 +9167,249 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %18
+ThrowNullRef4:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %31
+ThrowNullRef10:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %44
+ThrowNullRef16:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %68
+ThrowNullRef18:                                   ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %70
+ThrowNullRef20:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %73
+ThrowNullRef22:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %83
+ThrowNullRef24:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %85
+ThrowNullRef26:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %88
+ThrowNullRef28:                                   ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %90
+ThrowNullRef30:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %94
+ThrowNullRef32:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %96
+ThrowNullRef34:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %100
+ThrowNullRef36:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %102
+ThrowNullRef38:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %106
+ThrowNullRef40:                                   ; preds = %106
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %108
+ThrowNullRef42:                                   ; preds = %108
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %112
+ThrowNullRef44:                                   ; preds = %112
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %118
+ThrowNullRef46:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %121
+ThrowNullRef48:                                   ; preds = %121
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %123
+ThrowNullRef50:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %130
+ThrowNullRef52:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %132
+ThrowNullRef54:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %144
+ThrowNullRef56:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %146
+ThrowNullRef58:                                   ; preds = %146
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %60
+ThrowNullRef60:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %63
+ThrowNullRef62:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %49
+ThrowNullRef64:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %51
+ThrowNullRef66:                                   ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %53
+ThrowNullRef68:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(%"System.Char[]" addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %arg0 = alloca %"System.Char[]" addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store %"System.Char[]" addrspace(1)* %param0, %"System.Char[]" addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load i32, i32* %arg4
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %43, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %38, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg1
+  %13 = load i32, i32* %arg4
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %38, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %24 = load i32, i32* %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %35 = load i32, i32* %arg3
+  %36 = load i32, i32* %arg4
+  %37 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %37, %"System.Char[]" addrspace(1)* %34, i32 %35, i32 %36)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:38                                      ; preds = %5, %16
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Successfully read Buffer._Memmove
 
@@ -7914,7 +9431,7 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[loadElem]
+Failed to read AppDomain.SetDataHelper[storeElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -7923,8 +9440,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
@@ -7934,8 +9451,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
@@ -7947,15 +9464,15 @@ entry:
   %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
   %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
@@ -7966,15 +9483,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7992,7 +9509,79 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
-Failed to read Dictionary`2.TryGetValue[loadElemA]
+Successfully read Dictionary`2.TryGetValue
+
+define i8 @"Dictionary`2.TryGetValue"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)* addrspace(1)* %param2) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  %arg2 = alloca %System.__Canon addrspace(1)* addrspace(1)*
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  store %System.__Canon addrspace(1)* addrspace(1)* %param2, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  store i32 %2, i32* %loc0
+  %3 = load i32, i32* %loc0
+  %4 = icmp slt i32 %3, 0
+  br i1 %4, label %22, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 2
+  %10 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %9, align 8
+  %11 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = zext i32 %11 to i64
+  %BoundsCheck = icmp uge i64 %16, %15
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 3, i32 %11
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %20, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %6, %System.__Canon addrspace(1)* %21)
+  ret i8 1
+
+; <label>:22                                      ; preds = %entry
+  %23 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %23, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -8058,8 +9647,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
@@ -8091,8 +9680,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
@@ -8171,15 +9760,15 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck, label %19, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %ThrowNullRef, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
   %21 = load i32, i32 addrspace(1)* %20
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
@@ -8202,7 +9791,7 @@ ThrowNullRef:                                     ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %19
+ThrowNullRef2:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8248,8 +9837,8 @@ entry:
   %0 = alloca %System.AppDomainHandle
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %1 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %1, i32 0, i32 15
@@ -8269,8 +9858,8 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
@@ -8286,7 +9875,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -8299,8 +9888,8 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -8327,8 +9916,8 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
@@ -8352,8 +9941,8 @@ entry:
   %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
   store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
@@ -8363,8 +9952,8 @@ entry:
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
@@ -8374,8 +9963,8 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %9
   %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
@@ -8384,8 +9973,8 @@ entry:
 
 ; <label>:18                                      ; preds = %3, %16
   %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
@@ -8397,15 +9986,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %18
+ThrowNullRef6:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8418,8 +10007,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
@@ -8453,15 +10042,15 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
@@ -8473,7 +10062,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8481,7 +10070,7 @@ ThrowNullRef1:                                    ; preds = %1
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
 Failed to read Dictionary`2.System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
@@ -8506,8 +10095,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
@@ -8524,8 +10113,8 @@ entry:
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -8544,7 +10133,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8577,8 +10166,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = load i64, i64* %arg2
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = trunc i32 %3 to i8
@@ -8634,46 +10223,46 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
   %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
-  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
-  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
-  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
@@ -8684,27 +10273,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %20
+ThrowNullRef12:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8717,8 +10306,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -8756,22 +10345,22 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
   %9 = load i64, i64 addrspace(1)* %8, align 8
   %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
   %13 = load i64, i64 addrspace(1)* %12, align 8
   %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %11
   %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
@@ -8788,11 +10377,11 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8882,8 +10471,8 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
@@ -8900,8 +10489,8 @@ entry:
 ; <label>:8                                       ; preds = %1
   %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
   %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
@@ -8911,15 +10500,15 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
   %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
   %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
-  br i1 %NullCheck6, label %21, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
@@ -8946,15 +10535,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8992,15 +10581,15 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
   store i8 %3, i8 addrspace(1)* %5
   %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
@@ -9011,7 +10600,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9027,8 +10616,8 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -9041,8 +10630,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
@@ -9058,7 +10647,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9080,8 +10669,8 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
@@ -9096,8 +10685,8 @@ entry:
 ; <label>:12                                      ; preds = %6
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
@@ -9112,8 +10701,8 @@ entry:
 ; <label>:21                                      ; preds = %15
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
@@ -9128,8 +10717,8 @@ entry:
 ; <label>:30                                      ; preds = %24
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %31, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
@@ -9144,8 +10733,8 @@ entry:
 ; <label>:39                                      ; preds = %33
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
-  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %40, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %42
 
 ; <label>:42                                      ; preds = %39
   %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
@@ -9164,19 +10753,19 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %21
+ThrowNullRef4:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %30
+ThrowNullRef6:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %39
+ThrowNullRef8:                                    ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9243,8 +10832,8 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
@@ -9264,57 +10853,57 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
   store i8 0, i8 addrspace(1)* %2
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
   store i8 0, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
   store i8 0, i8 addrspace(1)* %17
   %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
   store i8 0, i8 addrspace(1)* %20
   %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
-  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
@@ -9325,31 +10914,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %19
+ThrowNullRef14:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9367,8 +10956,8 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
@@ -9380,8 +10969,8 @@ entry:
 
 ; <label>:9                                       ; preds = %4
   %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %9
   %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
@@ -9395,7 +10984,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef2:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9420,8 +11009,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
@@ -9512,8 +11101,8 @@ entry:
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
@@ -9524,8 +11113,8 @@ entry:
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = load i64, i64 addrspace(1)* %12
@@ -9537,8 +11126,8 @@ entry:
   %20 = load i64, i64* %19
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
-  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %13
   %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
@@ -9555,8 +11144,8 @@ entry:
 ; <label>:30                                      ; preds = %25
   %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %32 = load i32, i32* %arg2
-  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
-  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
@@ -9570,15 +11159,15 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %30
+ThrowNullRef2:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9622,87 +11211,87 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
   %10 = load i8, i8 addrspace(1)* %9, align 8
   %11 = zext i8 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %8
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
   store i8 %12, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
   %19 = load i8, i8 addrspace(1)* %18, align 8
   %20 = zext i8 %19 to i32
   %21 = trunc i32 %20 to i8
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
   store i8 %21, i8 addrspace(1)* %23
   %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
   %28 = load i8, i8 addrspace(1)* %27, align 8
   %29 = zext i8 %28 to i32
   %30 = trunc i32 %29 to i8
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
-  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %31
 
 ; <label>:31                                      ; preds = %26
   %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
   store i8 %30, i8 addrspace(1)* %32
   %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
-  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
-  br i1 %NullCheck14, label %40, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %40
 
 ; <label>:40                                      ; preds = %35
   %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
   store i8 %39, i8 addrspace(1)* %41
   %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
-  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %44
 
 ; <label>:44                                      ; preds = %40
   %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
   %46 = load i8, i8 addrspace(1)* %45, align 8
   %47 = zext i8 %46 to i32
   %48 = trunc i32 %47 to i8
-  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
   store i8 %48, i8 addrspace(1)* %50
   %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
-  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
@@ -9713,29 +11302,29 @@ entry:
 ; <label>:56                                      ; preds = %52
   %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
-  br i1 %NullCheck22, label %59, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
   %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
   %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
-  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
-  br i1 %NullCheck24, label %63, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
   %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
-  br i1 %NullCheck26, label %66, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
   %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
-  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
-  br i1 %NullCheck28, label %69, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %69
 
 ; <label>:69                                      ; preds = %66
   %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
@@ -9744,15 +11333,15 @@ entry:
 
 ; <label>:71                                      ; preds = %105
   %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
-  br i1 %NullCheck34, label %73, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %73
 
 ; <label>:73                                      ; preds = %71
   %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
   %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
   %76 = load i32, i32* %loc0
-  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
-  br i1 %NullCheck36, label %77, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
@@ -9766,8 +11355,8 @@ entry:
 
 ; <label>:83                                      ; preds = %77
   %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
-  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
@@ -9775,14 +11364,14 @@ entry:
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
   %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
-  br i1 %NullCheck40, label %91, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
 ; <label>:91                                      ; preds = %85
   %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
   %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
-  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck42, label %94, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %94
 
 ; <label>:94                                      ; preds = %91
   %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
@@ -9798,14 +11387,14 @@ entry:
 ; <label>:99                                      ; preds = %69, %96
   %100 = load i32, i32* %loc0
   %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
-  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %102
 
 ; <label>:102                                     ; preds = %99
   %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
   %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
-  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
-  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
@@ -9819,87 +11408,87 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %26
+ThrowNullRef10:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %31
+ThrowNullRef12:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %35
+ThrowNullRef14:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %40
+ThrowNullRef16:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %56
+ThrowNullRef22:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %59
+ThrowNullRef24:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %63
+ThrowNullRef26:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %66
+ThrowNullRef28:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %102
+ThrowNullRef32:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %71
+ThrowNullRef34:                                   ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %73
+ThrowNullRef36:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %83
+ThrowNullRef38:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %85
+ThrowNullRef40:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %91
+ThrowNullRef42:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9943,15 +11532,15 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
   %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
@@ -9961,28 +11550,28 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
   %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %12
   %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
   %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
   %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
-  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
@@ -9993,23 +11582,23 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %12
+ThrowNullRef6:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10031,15 +11620,15 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
   %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = load i64, i64 addrspace(1)* %7
@@ -10077,13 +11666,13 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[loadElem]
+Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -10111,8 +11700,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1

--- a/test/BaseLine/JIT/CodeGenBringUpTests/AsgAnd1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/AsgAnd1.error.txt
@@ -25,8 +25,8 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
@@ -40,8 +40,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
   %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
@@ -75,7 +75,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -90,8 +90,8 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %NullCheck = icmp ne i8 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = load i8, i8 addrspace(1)* %0, align 8
@@ -125,8 +125,8 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
@@ -159,8 +159,8 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -184,8 +184,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
   store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
@@ -195,8 +195,8 @@ entry:
 ; <label>:4                                       ; preds = %1
   %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
   %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
@@ -206,8 +206,8 @@ entry:
   %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
@@ -221,14 +221,14 @@ entry:
 
 ; <label>:17                                      ; preds = %14
   %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
   %21 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
@@ -238,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -249,8 +249,8 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
@@ -261,27 +261,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %30
+ThrowNullRef10:                                   ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -301,7 +301,89 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
-Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
+Successfully read AppDomainSetup.GetUnsecureApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.GetUnsecureApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %NullCheck = icmp eq %"System.String[]" addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %BoundsCheck = icmp uge i64 0, %5
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %6
+
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 3, i32 0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
+  ret %System.String addrspace(1)* %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_Value using LLILCJit
+Successfully read AppDomainSetup.get_Value
+
+define %"System.String[]" addrspace(1)* @AppDomainSetup.get_Value(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.String[]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 18)
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.String[]" addrspace(1)* addrspace(1)*, %"System.String[]" addrspace(1)*)*)(%"System.String[]" addrspace(1)* addrspace(1)* %9, %"System.String[]" addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %11, i32 0, i32 1
+  %14 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %13, align 8
+  ret %"System.String[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -319,8 +401,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -368,16 +450,16 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
   %5 = load i32, i32 addrspace(1)* %4
   %6 = sub i32 %5, 1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -389,7 +471,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -421,8 +503,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
@@ -456,8 +538,8 @@ entry:
 ; <label>:27                                      ; preds = %19
   %28 = load i32, i32* %arg1
   %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
-  br i1 %NullCheck2, label %30, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %29, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %30
 
 ; <label>:30                                      ; preds = %27
   %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
@@ -493,8 +575,8 @@ entry:
 ; <label>:49                                      ; preds = %46
   %50 = load i32, i32* %arg2
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck4, label %52, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
@@ -517,11 +599,11 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %27
+ThrowNullRef2:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %49
+ThrowNullRef4:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -544,16 +626,16 @@ entry:
   %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %0)
   store %System.String addrspace(1)* %1, %System.String addrspace(1)** %loc0
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 2
   %5 = bitcast [0 x i16] addrspace(1)* %4 to i16 addrspace(1)*
   store i16 addrspace(1)* %5, i16 addrspace(1)** %loc1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %3
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2
@@ -580,7 +662,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -691,15 +773,15 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %NullCheck132 = icmp ne i8* %21, null
-  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+  %NullCheck131 = icmp eq i8* %21, null
+  br i1 %NullCheck131, label %ThrowNullRef132, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = load i8, i8* %21, align 8
   %24 = zext i8 %23 to i32
   %25 = trunc i32 %24 to i8
-  %NullCheck134 = icmp ne i8* %20, null
-  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+  %NullCheck133 = icmp eq i8* %20, null
+  br i1 %NullCheck133, label %ThrowNullRef134, label %26
 
 ; <label>:26                                      ; preds = %22
   store i8 %25, i8* %20, align 8
@@ -709,16 +791,16 @@ entry:
   %28 = load i8*, i8** %arg0
   %29 = load i8*, i8** %arg1
   %30 = bitcast i8* %29 to i16*
-  %NullCheck128 = icmp ne i16* %30, null
-  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+  %NullCheck127 = icmp eq i16* %30, null
+  br i1 %NullCheck127, label %ThrowNullRef128, label %31
 
 ; <label>:31                                      ; preds = %27
   %32 = load i16, i16* %30, align 8
   %33 = sext i16 %32 to i32
   %34 = bitcast i8* %28 to i16*
   %35 = trunc i32 %33 to i16
-  %NullCheck130 = icmp ne i16* %34, null
-  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+  %NullCheck129 = icmp eq i16* %34, null
+  br i1 %NullCheck129, label %ThrowNullRef130, label %36
 
 ; <label>:36                                      ; preds = %31
   store i16 %35, i16* %34, align 8
@@ -728,16 +810,16 @@ entry:
   %38 = load i8*, i8** %arg0
   %39 = load i8*, i8** %arg1
   %40 = bitcast i8* %39 to i16*
-  %NullCheck120 = icmp ne i16* %40, null
-  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+  %NullCheck119 = icmp eq i16* %40, null
+  br i1 %NullCheck119, label %ThrowNullRef120, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i16, i16* %40, align 8
   %43 = sext i16 %42 to i32
   %44 = bitcast i8* %38 to i16*
   %45 = trunc i32 %43 to i16
-  %NullCheck122 = icmp ne i16* %44, null
-  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+  %NullCheck121 = icmp eq i16* %44, null
+  br i1 %NullCheck121, label %ThrowNullRef122, label %46
 
 ; <label>:46                                      ; preds = %41
   store i16 %45, i16* %44, align 8
@@ -745,15 +827,15 @@ entry:
   %48 = getelementptr inbounds i8, i8* %47, i64 2
   %49 = load i8*, i8** %arg1
   %50 = getelementptr inbounds i8, i8* %49, i64 2
-  %NullCheck124 = icmp ne i8* %50, null
-  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+  %NullCheck123 = icmp eq i8* %50, null
+  br i1 %NullCheck123, label %ThrowNullRef124, label %51
 
 ; <label>:51                                      ; preds = %46
   %52 = load i8, i8* %50, align 8
   %53 = zext i8 %52 to i32
   %54 = trunc i32 %53 to i8
-  %NullCheck126 = icmp ne i8* %48, null
-  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+  %NullCheck125 = icmp eq i8* %48, null
+  br i1 %NullCheck125, label %ThrowNullRef126, label %55
 
 ; <label>:55                                      ; preds = %51
   store i8 %54, i8* %48, align 8
@@ -763,14 +845,14 @@ entry:
   %57 = load i8*, i8** %arg0
   %58 = load i8*, i8** %arg1
   %59 = bitcast i8* %58 to i32*
-  %NullCheck116 = icmp ne i32* %59, null
-  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+  %NullCheck115 = icmp eq i32* %59, null
+  br i1 %NullCheck115, label %ThrowNullRef116, label %60
 
 ; <label>:60                                      ; preds = %56
   %61 = load i32, i32* %59, align 8
   %62 = bitcast i8* %57 to i32*
-  %NullCheck118 = icmp ne i32* %62, null
-  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+  %NullCheck117 = icmp eq i32* %62, null
+  br i1 %NullCheck117, label %ThrowNullRef118, label %63
 
 ; <label>:63                                      ; preds = %60
   store i32 %61, i32* %62, align 8
@@ -780,14 +862,14 @@ entry:
   %65 = load i8*, i8** %arg0
   %66 = load i8*, i8** %arg1
   %67 = bitcast i8* %66 to i32*
-  %NullCheck108 = icmp ne i32* %67, null
-  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+  %NullCheck107 = icmp eq i32* %67, null
+  br i1 %NullCheck107, label %ThrowNullRef108, label %68
 
 ; <label>:68                                      ; preds = %64
   %69 = load i32, i32* %67, align 8
   %70 = bitcast i8* %65 to i32*
-  %NullCheck110 = icmp ne i32* %70, null
-  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+  %NullCheck109 = icmp eq i32* %70, null
+  br i1 %NullCheck109, label %ThrowNullRef110, label %71
 
 ; <label>:71                                      ; preds = %68
   store i32 %69, i32* %70, align 8
@@ -795,15 +877,15 @@ entry:
   %73 = getelementptr inbounds i8, i8* %72, i64 4
   %74 = load i8*, i8** %arg1
   %75 = getelementptr inbounds i8, i8* %74, i64 4
-  %NullCheck112 = icmp ne i8* %75, null
-  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+  %NullCheck111 = icmp eq i8* %75, null
+  br i1 %NullCheck111, label %ThrowNullRef112, label %76
 
 ; <label>:76                                      ; preds = %71
   %77 = load i8, i8* %75, align 8
   %78 = zext i8 %77 to i32
   %79 = trunc i32 %78 to i8
-  %NullCheck114 = icmp ne i8* %73, null
-  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+  %NullCheck113 = icmp eq i8* %73, null
+  br i1 %NullCheck113, label %ThrowNullRef114, label %80
 
 ; <label>:80                                      ; preds = %76
   store i8 %79, i8* %73, align 8
@@ -813,14 +895,14 @@ entry:
   %82 = load i8*, i8** %arg0
   %83 = load i8*, i8** %arg1
   %84 = bitcast i8* %83 to i32*
-  %NullCheck100 = icmp ne i32* %84, null
-  br i1 %NullCheck100, label %85, label %ThrowNullRef99
+  %NullCheck99 = icmp eq i32* %84, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %85
 
 ; <label>:85                                      ; preds = %81
   %86 = load i32, i32* %84, align 8
   %87 = bitcast i8* %82 to i32*
-  %NullCheck102 = icmp ne i32* %87, null
-  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+  %NullCheck101 = icmp eq i32* %87, null
+  br i1 %NullCheck101, label %ThrowNullRef102, label %88
 
 ; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
@@ -829,16 +911,16 @@ entry:
   %91 = load i8*, i8** %arg1
   %92 = getelementptr inbounds i8, i8* %91, i64 4
   %93 = bitcast i8* %92 to i16*
-  %NullCheck104 = icmp ne i16* %93, null
-  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+  %NullCheck103 = icmp eq i16* %93, null
+  br i1 %NullCheck103, label %ThrowNullRef104, label %94
 
 ; <label>:94                                      ; preds = %88
   %95 = load i16, i16* %93, align 8
   %96 = sext i16 %95 to i32
   %97 = bitcast i8* %90 to i16*
   %98 = trunc i32 %96 to i16
-  %NullCheck106 = icmp ne i16* %97, null
-  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+  %NullCheck105 = icmp eq i16* %97, null
+  br i1 %NullCheck105, label %ThrowNullRef106, label %99
 
 ; <label>:99                                      ; preds = %94
   store i16 %98, i16* %97, align 8
@@ -848,14 +930,14 @@ entry:
   %101 = load i8*, i8** %arg0
   %102 = load i8*, i8** %arg1
   %103 = bitcast i8* %102 to i32*
-  %NullCheck88 = icmp ne i32* %103, null
-  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+  %NullCheck87 = icmp eq i32* %103, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %104
 
 ; <label>:104                                     ; preds = %100
   %105 = load i32, i32* %103, align 8
   %106 = bitcast i8* %101 to i32*
-  %NullCheck90 = icmp ne i32* %106, null
-  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+  %NullCheck89 = icmp eq i32* %106, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %107
 
 ; <label>:107                                     ; preds = %104
   store i32 %105, i32* %106, align 8
@@ -864,16 +946,16 @@ entry:
   %110 = load i8*, i8** %arg1
   %111 = getelementptr inbounds i8, i8* %110, i64 4
   %112 = bitcast i8* %111 to i16*
-  %NullCheck92 = icmp ne i16* %112, null
-  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+  %NullCheck91 = icmp eq i16* %112, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %113
 
 ; <label>:113                                     ; preds = %107
   %114 = load i16, i16* %112, align 8
   %115 = sext i16 %114 to i32
   %116 = bitcast i8* %109 to i16*
   %117 = trunc i32 %115 to i16
-  %NullCheck94 = icmp ne i16* %116, null
-  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+  %NullCheck93 = icmp eq i16* %116, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %118
 
 ; <label>:118                                     ; preds = %113
   store i16 %117, i16* %116, align 8
@@ -881,15 +963,15 @@ entry:
   %120 = getelementptr inbounds i8, i8* %119, i64 6
   %121 = load i8*, i8** %arg1
   %122 = getelementptr inbounds i8, i8* %121, i64 6
-  %NullCheck96 = icmp ne i8* %122, null
-  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+  %NullCheck95 = icmp eq i8* %122, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %123
 
 ; <label>:123                                     ; preds = %118
   %124 = load i8, i8* %122, align 8
   %125 = zext i8 %124 to i32
   %126 = trunc i32 %125 to i8
-  %NullCheck98 = icmp ne i8* %120, null
-  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+  %NullCheck97 = icmp eq i8* %120, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %127
 
 ; <label>:127                                     ; preds = %123
   store i8 %126, i8* %120, align 8
@@ -899,14 +981,14 @@ entry:
   %129 = load i8*, i8** %arg0
   %130 = load i8*, i8** %arg1
   %131 = bitcast i8* %130 to i64*
-  %NullCheck84 = icmp ne i64* %131, null
-  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+  %NullCheck83 = icmp eq i64* %131, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %132
 
 ; <label>:132                                     ; preds = %128
   %133 = load i64, i64* %131, align 8
   %134 = bitcast i8* %129 to i64*
-  %NullCheck86 = icmp ne i64* %134, null
-  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+  %NullCheck85 = icmp eq i64* %134, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %135
 
 ; <label>:135                                     ; preds = %132
   store i64 %133, i64* %134, align 8
@@ -916,14 +998,14 @@ entry:
   %137 = load i8*, i8** %arg0
   %138 = load i8*, i8** %arg1
   %139 = bitcast i8* %138 to i64*
-  %NullCheck76 = icmp ne i64* %139, null
-  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+  %NullCheck75 = icmp eq i64* %139, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %140
 
 ; <label>:140                                     ; preds = %136
   %141 = load i64, i64* %139, align 8
   %142 = bitcast i8* %137 to i64*
-  %NullCheck78 = icmp ne i64* %142, null
-  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+  %NullCheck77 = icmp eq i64* %142, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %143
 
 ; <label>:143                                     ; preds = %140
   store i64 %141, i64* %142, align 8
@@ -931,15 +1013,15 @@ entry:
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %NullCheck80 = icmp ne i8* %147, null
-  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+  %NullCheck79 = icmp eq i8* %147, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %148
 
 ; <label>:148                                     ; preds = %143
   %149 = load i8, i8* %147, align 8
   %150 = zext i8 %149 to i32
   %151 = trunc i32 %150 to i8
-  %NullCheck82 = icmp ne i8* %145, null
-  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+  %NullCheck81 = icmp eq i8* %145, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %152
 
 ; <label>:152                                     ; preds = %148
   store i8 %151, i8* %145, align 8
@@ -949,14 +1031,14 @@ entry:
   %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
   %156 = bitcast i8* %155 to i64*
-  %NullCheck68 = icmp ne i64* %156, null
-  br i1 %NullCheck68, label %157, label %ThrowNullRef67
+  %NullCheck67 = icmp eq i64* %156, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %157
 
 ; <label>:157                                     ; preds = %153
   %158 = load i64, i64* %156, align 8
   %159 = bitcast i8* %154 to i64*
-  %NullCheck70 = icmp ne i64* %159, null
-  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+  %NullCheck69 = icmp eq i64* %159, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %160
 
 ; <label>:160                                     ; preds = %157
   store i64 %158, i64* %159, align 8
@@ -965,16 +1047,16 @@ entry:
   %163 = load i8*, i8** %arg1
   %164 = getelementptr inbounds i8, i8* %163, i64 8
   %165 = bitcast i8* %164 to i16*
-  %NullCheck72 = icmp ne i16* %165, null
-  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+  %NullCheck71 = icmp eq i16* %165, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %166
 
 ; <label>:166                                     ; preds = %160
   %167 = load i16, i16* %165, align 8
   %168 = sext i16 %167 to i32
   %169 = bitcast i8* %162 to i16*
   %170 = trunc i32 %168 to i16
-  %NullCheck74 = icmp ne i16* %169, null
-  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+  %NullCheck73 = icmp eq i16* %169, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %171
 
 ; <label>:171                                     ; preds = %166
   store i16 %170, i16* %169, align 8
@@ -984,14 +1066,14 @@ entry:
   %173 = load i8*, i8** %arg0
   %174 = load i8*, i8** %arg1
   %175 = bitcast i8* %174 to i64*
-  %NullCheck56 = icmp ne i64* %175, null
-  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+  %NullCheck55 = icmp eq i64* %175, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %176
 
 ; <label>:176                                     ; preds = %172
   %177 = load i64, i64* %175, align 8
   %178 = bitcast i8* %173 to i64*
-  %NullCheck58 = icmp ne i64* %178, null
-  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+  %NullCheck57 = icmp eq i64* %178, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %179
 
 ; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
@@ -1000,16 +1082,16 @@ entry:
   %182 = load i8*, i8** %arg1
   %183 = getelementptr inbounds i8, i8* %182, i64 8
   %184 = bitcast i8* %183 to i16*
-  %NullCheck60 = icmp ne i16* %184, null
-  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+  %NullCheck59 = icmp eq i16* %184, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %185
 
 ; <label>:185                                     ; preds = %179
   %186 = load i16, i16* %184, align 8
   %187 = sext i16 %186 to i32
   %188 = bitcast i8* %181 to i16*
   %189 = trunc i32 %187 to i16
-  %NullCheck62 = icmp ne i16* %188, null
-  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+  %NullCheck61 = icmp eq i16* %188, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %190
 
 ; <label>:190                                     ; preds = %185
   store i16 %189, i16* %188, align 8
@@ -1017,15 +1099,15 @@ entry:
   %192 = getelementptr inbounds i8, i8* %191, i64 10
   %193 = load i8*, i8** %arg1
   %194 = getelementptr inbounds i8, i8* %193, i64 10
-  %NullCheck64 = icmp ne i8* %194, null
-  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+  %NullCheck63 = icmp eq i8* %194, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %195
 
 ; <label>:195                                     ; preds = %190
   %196 = load i8, i8* %194, align 8
   %197 = zext i8 %196 to i32
   %198 = trunc i32 %197 to i8
-  %NullCheck66 = icmp ne i8* %192, null
-  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+  %NullCheck65 = icmp eq i8* %192, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %199
 
 ; <label>:199                                     ; preds = %195
   store i8 %198, i8* %192, align 8
@@ -1035,14 +1117,14 @@ entry:
   %201 = load i8*, i8** %arg0
   %202 = load i8*, i8** %arg1
   %203 = bitcast i8* %202 to i64*
-  %NullCheck48 = icmp ne i64* %203, null
-  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+  %NullCheck47 = icmp eq i64* %203, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %204
 
 ; <label>:204                                     ; preds = %200
   %205 = load i64, i64* %203, align 8
   %206 = bitcast i8* %201 to i64*
-  %NullCheck50 = icmp ne i64* %206, null
-  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+  %NullCheck49 = icmp eq i64* %206, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %207
 
 ; <label>:207                                     ; preds = %204
   store i64 %205, i64* %206, align 8
@@ -1051,14 +1133,14 @@ entry:
   %210 = load i8*, i8** %arg1
   %211 = getelementptr inbounds i8, i8* %210, i64 8
   %212 = bitcast i8* %211 to i32*
-  %NullCheck52 = icmp ne i32* %212, null
-  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+  %NullCheck51 = icmp eq i32* %212, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %213
 
 ; <label>:213                                     ; preds = %207
   %214 = load i32, i32* %212, align 8
   %215 = bitcast i8* %209 to i32*
-  %NullCheck54 = icmp ne i32* %215, null
-  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+  %NullCheck53 = icmp eq i32* %215, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %216
 
 ; <label>:216                                     ; preds = %213
   store i32 %214, i32* %215, align 8
@@ -1068,14 +1150,14 @@ entry:
   %218 = load i8*, i8** %arg0
   %219 = load i8*, i8** %arg1
   %220 = bitcast i8* %219 to i64*
-  %NullCheck36 = icmp ne i64* %220, null
-  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64* %220, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %221
 
 ; <label>:221                                     ; preds = %217
   %222 = load i64, i64* %220, align 8
   %223 = bitcast i8* %218 to i64*
-  %NullCheck38 = icmp ne i64* %223, null
-  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+  %NullCheck37 = icmp eq i64* %223, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %224
 
 ; <label>:224                                     ; preds = %221
   store i64 %222, i64* %223, align 8
@@ -1084,14 +1166,14 @@ entry:
   %227 = load i8*, i8** %arg1
   %228 = getelementptr inbounds i8, i8* %227, i64 8
   %229 = bitcast i8* %228 to i32*
-  %NullCheck40 = icmp ne i32* %229, null
-  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i32* %229, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %230
 
 ; <label>:230                                     ; preds = %224
   %231 = load i32, i32* %229, align 8
   %232 = bitcast i8* %226 to i32*
-  %NullCheck42 = icmp ne i32* %232, null
-  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+  %NullCheck41 = icmp eq i32* %232, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %233
 
 ; <label>:233                                     ; preds = %230
   store i32 %231, i32* %232, align 8
@@ -1099,15 +1181,15 @@ entry:
   %235 = getelementptr inbounds i8, i8* %234, i64 12
   %236 = load i8*, i8** %arg1
   %237 = getelementptr inbounds i8, i8* %236, i64 12
-  %NullCheck44 = icmp ne i8* %237, null
-  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i8* %237, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %238
 
 ; <label>:238                                     ; preds = %233
   %239 = load i8, i8* %237, align 8
   %240 = zext i8 %239 to i32
   %241 = trunc i32 %240 to i8
-  %NullCheck46 = icmp ne i8* %235, null
-  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+  %NullCheck45 = icmp eq i8* %235, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %242
 
 ; <label>:242                                     ; preds = %238
   store i8 %241, i8* %235, align 8
@@ -1117,14 +1199,14 @@ entry:
   %244 = load i8*, i8** %arg0
   %245 = load i8*, i8** %arg1
   %246 = bitcast i8* %245 to i64*
-  %NullCheck24 = icmp ne i64* %246, null
-  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64* %246, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %247
 
 ; <label>:247                                     ; preds = %243
   %248 = load i64, i64* %246, align 8
   %249 = bitcast i8* %244 to i64*
-  %NullCheck26 = icmp ne i64* %249, null
-  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64* %249, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %250
 
 ; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
@@ -1133,14 +1215,14 @@ entry:
   %253 = load i8*, i8** %arg1
   %254 = getelementptr inbounds i8, i8* %253, i64 8
   %255 = bitcast i8* %254 to i32*
-  %NullCheck28 = icmp ne i32* %255, null
-  br i1 %NullCheck28, label %256, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i32* %255, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %256
 
 ; <label>:256                                     ; preds = %250
   %257 = load i32, i32* %255, align 8
   %258 = bitcast i8* %252 to i32*
-  %NullCheck30 = icmp ne i32* %258, null
-  br i1 %NullCheck30, label %259, label %ThrowNullRef29
+  %NullCheck29 = icmp eq i32* %258, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %259
 
 ; <label>:259                                     ; preds = %256
   store i32 %257, i32* %258, align 8
@@ -1149,16 +1231,16 @@ entry:
   %262 = load i8*, i8** %arg1
   %263 = getelementptr inbounds i8, i8* %262, i64 12
   %264 = bitcast i8* %263 to i16*
-  %NullCheck32 = icmp ne i16* %264, null
-  br i1 %NullCheck32, label %265, label %ThrowNullRef31
+  %NullCheck31 = icmp eq i16* %264, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %265
 
 ; <label>:265                                     ; preds = %259
   %266 = load i16, i16* %264, align 8
   %267 = sext i16 %266 to i32
   %268 = bitcast i8* %261 to i16*
   %269 = trunc i32 %267 to i16
-  %NullCheck34 = icmp ne i16* %268, null
-  br i1 %NullCheck34, label %270, label %ThrowNullRef33
+  %NullCheck33 = icmp eq i16* %268, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %270
 
 ; <label>:270                                     ; preds = %265
   store i16 %269, i16* %268, align 8
@@ -1168,14 +1250,14 @@ entry:
   %272 = load i8*, i8** %arg0
   %273 = load i8*, i8** %arg1
   %274 = bitcast i8* %273 to i64*
-  %NullCheck8 = icmp ne i64* %274, null
-  br i1 %NullCheck8, label %275, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64* %274, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %275
 
 ; <label>:275                                     ; preds = %271
   %276 = load i64, i64* %274, align 8
   %277 = bitcast i8* %272 to i64*
-  %NullCheck10 = icmp ne i64* %277, null
-  br i1 %NullCheck10, label %278, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %277, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %278
 
 ; <label>:278                                     ; preds = %275
   store i64 %276, i64* %277, align 8
@@ -1184,14 +1266,14 @@ entry:
   %281 = load i8*, i8** %arg1
   %282 = getelementptr inbounds i8, i8* %281, i64 8
   %283 = bitcast i8* %282 to i32*
-  %NullCheck12 = icmp ne i32* %283, null
-  br i1 %NullCheck12, label %284, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i32* %283, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %284
 
 ; <label>:284                                     ; preds = %278
   %285 = load i32, i32* %283, align 8
   %286 = bitcast i8* %280 to i32*
-  %NullCheck14 = icmp ne i32* %286, null
-  br i1 %NullCheck14, label %287, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i32* %286, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %287
 
 ; <label>:287                                     ; preds = %284
   store i32 %285, i32* %286, align 8
@@ -1200,16 +1282,16 @@ entry:
   %290 = load i8*, i8** %arg1
   %291 = getelementptr inbounds i8, i8* %290, i64 12
   %292 = bitcast i8* %291 to i16*
-  %NullCheck16 = icmp ne i16* %292, null
-  br i1 %NullCheck16, label %293, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i16* %292, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %293
 
 ; <label>:293                                     ; preds = %287
   %294 = load i16, i16* %292, align 8
   %295 = sext i16 %294 to i32
   %296 = bitcast i8* %289 to i16*
   %297 = trunc i32 %295 to i16
-  %NullCheck18 = icmp ne i16* %296, null
-  br i1 %NullCheck18, label %298, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i16* %296, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %298
 
 ; <label>:298                                     ; preds = %293
   store i16 %297, i16* %296, align 8
@@ -1217,15 +1299,15 @@ entry:
   %300 = getelementptr inbounds i8, i8* %299, i64 14
   %301 = load i8*, i8** %arg1
   %302 = getelementptr inbounds i8, i8* %301, i64 14
-  %NullCheck20 = icmp ne i8* %302, null
-  br i1 %NullCheck20, label %303, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i8* %302, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %303
 
 ; <label>:303                                     ; preds = %298
   %304 = load i8, i8* %302, align 8
   %305 = zext i8 %304 to i32
   %306 = trunc i32 %305 to i8
-  %NullCheck22 = icmp ne i8* %300, null
-  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i8* %300, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %307
 
 ; <label>:307                                     ; preds = %303
   store i8 %306, i8* %300, align 8
@@ -1235,14 +1317,14 @@ entry:
   %309 = load i8*, i8** %arg0
   %310 = load i8*, i8** %arg1
   %311 = bitcast i8* %310 to i64*
-  %NullCheck = icmp ne i64* %311, null
-  br i1 %NullCheck, label %312, label %ThrowNullRef
+  %NullCheck = icmp eq i64* %311, null
+  br i1 %NullCheck, label %ThrowNullRef, label %312
 
 ; <label>:312                                     ; preds = %308
   %313 = load i64, i64* %311, align 8
   %314 = bitcast i8* %309 to i64*
-  %NullCheck2 = icmp ne i64* %314, null
-  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64* %314, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %315
 
 ; <label>:315                                     ; preds = %312
   store i64 %313, i64* %314, align 8
@@ -1251,14 +1333,14 @@ entry:
   %318 = load i8*, i8** %arg1
   %319 = getelementptr inbounds i8, i8* %318, i64 8
   %320 = bitcast i8* %319 to i64*
-  %NullCheck4 = icmp ne i64* %320, null
-  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64* %320, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %321
 
 ; <label>:321                                     ; preds = %315
   %322 = load i64, i64* %320, align 8
   %323 = bitcast i8* %317 to i64*
-  %NullCheck6 = icmp ne i64* %323, null
-  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64* %323, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %324
 
 ; <label>:324                                     ; preds = %321
   store i64 %322, i64* %323, align 8
@@ -1286,15 +1368,15 @@ entry:
 ; <label>:338                                     ; preds = %333
   %339 = load i8*, i8** %arg0
   %340 = load i8*, i8** %arg1
-  %NullCheck136 = icmp ne i8* %340, null
-  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+  %NullCheck135 = icmp eq i8* %340, null
+  br i1 %NullCheck135, label %ThrowNullRef136, label %341
 
 ; <label>:341                                     ; preds = %338
   %342 = load i8, i8* %340, align 8
   %343 = zext i8 %342 to i32
   %344 = trunc i32 %343 to i8
-  %NullCheck138 = icmp ne i8* %339, null
-  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+  %NullCheck137 = icmp eq i8* %339, null
+  br i1 %NullCheck137, label %ThrowNullRef138, label %345
 
 ; <label>:345                                     ; preds = %341
   store i8 %344, i8* %339, align 8
@@ -1317,16 +1399,16 @@ entry:
   %357 = load i8*, i8** %arg0
   %358 = load i8*, i8** %arg1
   %359 = bitcast i8* %358 to i16*
-  %NullCheck140 = icmp ne i16* %359, null
-  br i1 %NullCheck140, label %360, label %ThrowNullRef139
+  %NullCheck139 = icmp eq i16* %359, null
+  br i1 %NullCheck139, label %ThrowNullRef140, label %360
 
 ; <label>:360                                     ; preds = %356
   %361 = load i16, i16* %359, align 8
   %362 = sext i16 %361 to i32
   %363 = bitcast i8* %357 to i16*
   %364 = trunc i32 %362 to i16
-  %NullCheck142 = icmp ne i16* %363, null
-  br i1 %NullCheck142, label %365, label %ThrowNullRef141
+  %NullCheck141 = icmp eq i16* %363, null
+  br i1 %NullCheck141, label %ThrowNullRef142, label %365
 
 ; <label>:365                                     ; preds = %360
   store i16 %364, i16* %363, align 8
@@ -1352,14 +1434,14 @@ entry:
   %378 = load i8*, i8** %arg0
   %379 = load i8*, i8** %arg1
   %380 = bitcast i8* %379 to i32*
-  %NullCheck144 = icmp ne i32* %380, null
-  br i1 %NullCheck144, label %381, label %ThrowNullRef143
+  %NullCheck143 = icmp eq i32* %380, null
+  br i1 %NullCheck143, label %ThrowNullRef144, label %381
 
 ; <label>:381                                     ; preds = %377
   %382 = load i32, i32* %380, align 8
   %383 = bitcast i8* %378 to i32*
-  %NullCheck146 = icmp ne i32* %383, null
-  br i1 %NullCheck146, label %384, label %ThrowNullRef145
+  %NullCheck145 = icmp eq i32* %383, null
+  br i1 %NullCheck145, label %ThrowNullRef146, label %384
 
 ; <label>:384                                     ; preds = %381
   store i32 %382, i32* %383, align 8
@@ -1384,14 +1466,14 @@ entry:
   %395 = load i8*, i8** %arg0
   %396 = load i8*, i8** %arg1
   %397 = bitcast i8* %396 to i64*
-  %NullCheck164 = icmp ne i64* %397, null
-  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+  %NullCheck163 = icmp eq i64* %397, null
+  br i1 %NullCheck163, label %ThrowNullRef164, label %398
 
 ; <label>:398                                     ; preds = %394
   %399 = load i64, i64* %397, align 8
   %400 = bitcast i8* %395 to i64*
-  %NullCheck166 = icmp ne i64* %400, null
-  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+  %NullCheck165 = icmp eq i64* %400, null
+  br i1 %NullCheck165, label %ThrowNullRef166, label %401
 
 ; <label>:401                                     ; preds = %398
   store i64 %399, i64* %400, align 8
@@ -1400,14 +1482,14 @@ entry:
   %404 = load i8*, i8** %arg1
   %405 = getelementptr inbounds i8, i8* %404, i64 8
   %406 = bitcast i8* %405 to i64*
-  %NullCheck168 = icmp ne i64* %406, null
-  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+  %NullCheck167 = icmp eq i64* %406, null
+  br i1 %NullCheck167, label %ThrowNullRef168, label %407
 
 ; <label>:407                                     ; preds = %401
   %408 = load i64, i64* %406, align 8
   %409 = bitcast i8* %403 to i64*
-  %NullCheck170 = icmp ne i64* %409, null
-  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+  %NullCheck169 = icmp eq i64* %409, null
+  br i1 %NullCheck169, label %ThrowNullRef170, label %410
 
 ; <label>:410                                     ; preds = %407
   store i64 %408, i64* %409, align 8
@@ -1437,14 +1519,14 @@ entry:
   %425 = load i8*, i8** %arg0
   %426 = load i8*, i8** %arg1
   %427 = bitcast i8* %426 to i64*
-  %NullCheck148 = icmp ne i64* %427, null
-  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+  %NullCheck147 = icmp eq i64* %427, null
+  br i1 %NullCheck147, label %ThrowNullRef148, label %428
 
 ; <label>:428                                     ; preds = %424
   %429 = load i64, i64* %427, align 8
   %430 = bitcast i8* %425 to i64*
-  %NullCheck150 = icmp ne i64* %430, null
-  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+  %NullCheck149 = icmp eq i64* %430, null
+  br i1 %NullCheck149, label %ThrowNullRef150, label %431
 
 ; <label>:431                                     ; preds = %428
   store i64 %429, i64* %430, align 8
@@ -1466,14 +1548,14 @@ entry:
   %441 = load i8*, i8** %arg0
   %442 = load i8*, i8** %arg1
   %443 = bitcast i8* %442 to i32*
-  %NullCheck152 = icmp ne i32* %443, null
-  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+  %NullCheck151 = icmp eq i32* %443, null
+  br i1 %NullCheck151, label %ThrowNullRef152, label %444
 
 ; <label>:444                                     ; preds = %440
   %445 = load i32, i32* %443, align 8
   %446 = bitcast i8* %441 to i32*
-  %NullCheck154 = icmp ne i32* %446, null
-  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+  %NullCheck153 = icmp eq i32* %446, null
+  br i1 %NullCheck153, label %ThrowNullRef154, label %447
 
 ; <label>:447                                     ; preds = %444
   store i32 %445, i32* %446, align 8
@@ -1495,16 +1577,16 @@ entry:
   %457 = load i8*, i8** %arg0
   %458 = load i8*, i8** %arg1
   %459 = bitcast i8* %458 to i16*
-  %NullCheck156 = icmp ne i16* %459, null
-  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+  %NullCheck155 = icmp eq i16* %459, null
+  br i1 %NullCheck155, label %ThrowNullRef156, label %460
 
 ; <label>:460                                     ; preds = %456
   %461 = load i16, i16* %459, align 8
   %462 = sext i16 %461 to i32
   %463 = bitcast i8* %457 to i16*
   %464 = trunc i32 %462 to i16
-  %NullCheck158 = icmp ne i16* %463, null
-  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+  %NullCheck157 = icmp eq i16* %463, null
+  br i1 %NullCheck157, label %ThrowNullRef158, label %465
 
 ; <label>:465                                     ; preds = %460
   store i16 %464, i16* %463, align 8
@@ -1525,15 +1607,15 @@ entry:
 ; <label>:474                                     ; preds = %470
   %475 = load i8*, i8** %arg0
   %476 = load i8*, i8** %arg1
-  %NullCheck160 = icmp ne i8* %476, null
-  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+  %NullCheck159 = icmp eq i8* %476, null
+  br i1 %NullCheck159, label %ThrowNullRef160, label %477
 
 ; <label>:477                                     ; preds = %474
   %478 = load i8, i8* %476, align 8
   %479 = zext i8 %478 to i32
   %480 = trunc i32 %479 to i8
-  %NullCheck162 = icmp ne i8* %475, null
-  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+  %NullCheck161 = icmp eq i8* %475, null
+  br i1 %NullCheck161, label %ThrowNullRef162, label %481
 
 ; <label>:481                                     ; preds = %477
   store i8 %480, i8* %475, align 8
@@ -1553,343 +1635,343 @@ ThrowNullRef:                                     ; preds = %308
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %312
+ThrowNullRef2:                                    ; preds = %312
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %315
+ThrowNullRef4:                                    ; preds = %315
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %321
+ThrowNullRef6:                                    ; preds = %321
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %271
+ThrowNullRef8:                                    ; preds = %271
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %275
+ThrowNullRef10:                                   ; preds = %275
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %278
+ThrowNullRef12:                                   ; preds = %278
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %284
+ThrowNullRef14:                                   ; preds = %284
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %287
+ThrowNullRef16:                                   ; preds = %287
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %293
+ThrowNullRef18:                                   ; preds = %293
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %298
+ThrowNullRef20:                                   ; preds = %298
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %303
+ThrowNullRef22:                                   ; preds = %303
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %243
+ThrowNullRef24:                                   ; preds = %243
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %247
+ThrowNullRef26:                                   ; preds = %247
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %250
+ThrowNullRef28:                                   ; preds = %250
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %256
+ThrowNullRef30:                                   ; preds = %256
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %259
+ThrowNullRef32:                                   ; preds = %259
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %265
+ThrowNullRef34:                                   ; preds = %265
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %217
+ThrowNullRef36:                                   ; preds = %217
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %221
+ThrowNullRef38:                                   ; preds = %221
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %224
+ThrowNullRef40:                                   ; preds = %224
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %230
+ThrowNullRef42:                                   ; preds = %230
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %233
+ThrowNullRef44:                                   ; preds = %233
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %238
+ThrowNullRef46:                                   ; preds = %238
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %200
+ThrowNullRef48:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %204
+ThrowNullRef50:                                   ; preds = %204
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %207
+ThrowNullRef52:                                   ; preds = %207
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %213
+ThrowNullRef54:                                   ; preds = %213
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %172
+ThrowNullRef56:                                   ; preds = %172
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %176
+ThrowNullRef58:                                   ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %179
+ThrowNullRef60:                                   ; preds = %179
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %185
+ThrowNullRef62:                                   ; preds = %185
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %190
+ThrowNullRef64:                                   ; preds = %190
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %195
+ThrowNullRef66:                                   ; preds = %195
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %153
+ThrowNullRef68:                                   ; preds = %153
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %157
+ThrowNullRef70:                                   ; preds = %157
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %160
+ThrowNullRef72:                                   ; preds = %160
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %166
+ThrowNullRef74:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %136
+ThrowNullRef76:                                   ; preds = %136
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %140
+ThrowNullRef78:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %143
+ThrowNullRef80:                                   ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %148
+ThrowNullRef82:                                   ; preds = %148
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %128
+ThrowNullRef84:                                   ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %132
+ThrowNullRef86:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %100
+ThrowNullRef88:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %104
+ThrowNullRef90:                                   ; preds = %104
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %107
+ThrowNullRef92:                                   ; preds = %107
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %113
+ThrowNullRef94:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %118
+ThrowNullRef96:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %123
+ThrowNullRef98:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %81
+ThrowNullRef100:                                  ; preds = %81
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef101:                                  ; preds = %85
+ThrowNullRef102:                                  ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef103:                                  ; preds = %88
+ThrowNullRef104:                                  ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef105:                                  ; preds = %94
+ThrowNullRef106:                                  ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef107:                                  ; preds = %64
+ThrowNullRef108:                                  ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef109:                                  ; preds = %68
+ThrowNullRef110:                                  ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef111:                                  ; preds = %71
+ThrowNullRef112:                                  ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef113:                                  ; preds = %76
+ThrowNullRef114:                                  ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef115:                                  ; preds = %56
+ThrowNullRef116:                                  ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef117:                                  ; preds = %60
+ThrowNullRef118:                                  ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef119:                                  ; preds = %37
+ThrowNullRef120:                                  ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef121:                                  ; preds = %41
+ThrowNullRef122:                                  ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef123:                                  ; preds = %46
+ThrowNullRef124:                                  ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef125:                                  ; preds = %51
+ThrowNullRef126:                                  ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef127:                                  ; preds = %27
+ThrowNullRef128:                                  ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef129:                                  ; preds = %31
+ThrowNullRef130:                                  ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef131:                                  ; preds = %19
+ThrowNullRef132:                                  ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef133:                                  ; preds = %22
+ThrowNullRef134:                                  ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef135:                                  ; preds = %338
+ThrowNullRef136:                                  ; preds = %338
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef137:                                  ; preds = %341
+ThrowNullRef138:                                  ; preds = %341
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef139:                                  ; preds = %356
+ThrowNullRef140:                                  ; preds = %356
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef141:                                  ; preds = %360
+ThrowNullRef142:                                  ; preds = %360
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef143:                                  ; preds = %377
+ThrowNullRef144:                                  ; preds = %377
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef145:                                  ; preds = %381
+ThrowNullRef146:                                  ; preds = %381
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef147:                                  ; preds = %424
+ThrowNullRef148:                                  ; preds = %424
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef149:                                  ; preds = %428
+ThrowNullRef150:                                  ; preds = %428
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef151:                                  ; preds = %440
+ThrowNullRef152:                                  ; preds = %440
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef153:                                  ; preds = %444
+ThrowNullRef154:                                  ; preds = %444
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef155:                                  ; preds = %456
+ThrowNullRef156:                                  ; preds = %456
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef157:                                  ; preds = %460
+ThrowNullRef158:                                  ; preds = %460
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef159:                                  ; preds = %474
+ThrowNullRef160:                                  ; preds = %474
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef161:                                  ; preds = %477
+ThrowNullRef162:                                  ; preds = %477
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef163:                                  ; preds = %394
+ThrowNullRef164:                                  ; preds = %394
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef165:                                  ; preds = %398
+ThrowNullRef166:                                  ; preds = %398
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef167:                                  ; preds = %401
+ThrowNullRef168:                                  ; preds = %401
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef169:                                  ; preds = %407
+ThrowNullRef170:                                  ; preds = %407
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1939,8 +2021,8 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
-  br i1 %NullCheck, label %22, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %ThrowNullRef, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
@@ -1948,8 +2030,8 @@ entry:
   store i32 %24, i32* %loc0
   %25 = load i32, i32* %loc0
   %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %26, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %27
 
 ; <label>:27                                      ; preds = %22
   %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
@@ -1971,7 +2053,7 @@ ThrowNullRef:                                     ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1989,8 +2071,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -2022,15 +2104,15 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2048,16 +2130,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
   %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
   store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %15
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
@@ -2072,8 +2154,8 @@ entry:
   %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
   %29 = ptrtoint i16 addrspace(1)* %28 to i64
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %19
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
@@ -2089,19 +2171,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2114,8 +2196,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
@@ -2128,7 +2210,7 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[loadElem]
+Failed to read AppDomain.PrepareDataForSetup[storeElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
@@ -2202,8 +2284,8 @@ entry:
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
-  br i1 %NullCheck24, label %27, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = load i64, i64 addrspace(1)* %26
@@ -2218,8 +2300,8 @@ entry:
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
-  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
   %41 = load i64, i64 addrspace(1)* %39
@@ -2236,8 +2318,8 @@ entry:
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
-  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
   %54 = load i64, i64 addrspace(1)* %52
@@ -2252,8 +2334,8 @@ entry:
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
   %67 = load i64, i64 addrspace(1)* %65
@@ -2270,8 +2352,8 @@ entry:
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
-  br i1 %NullCheck16, label %79, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
   %80 = load i64, i64 addrspace(1)* %78
@@ -2286,8 +2368,8 @@ entry:
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
-  br i1 %NullCheck18, label %92, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
   %93 = load i64, i64 addrspace(1)* %91
@@ -2304,8 +2386,8 @@ entry:
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
-  br i1 %NullCheck12, label %105, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = load i64, i64 addrspace(1)* %104
@@ -2320,8 +2402,8 @@ entry:
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
-  br i1 %NullCheck14, label %118, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
   %119 = load i64, i64 addrspace(1)* %117
@@ -2337,8 +2419,8 @@ entry:
 
 ; <label>:128                                     ; preds = %20
   %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
-  br i1 %NullCheck4, label %130, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %129, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %130
 
 ; <label>:130                                     ; preds = %128
   %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
@@ -2346,8 +2428,8 @@ entry:
   %133 = load i16, i16 addrspace(1)* %132, align 8
   %134 = zext i16 %133 to i32
   %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
-  br i1 %NullCheck6, label %136, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %135, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %136
 
 ; <label>:136                                     ; preds = %130
   %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
@@ -2360,8 +2442,8 @@ entry:
 
 ; <label>:143                                     ; preds = %136
   %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
-  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %144, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %145
 
 ; <label>:145                                     ; preds = %143
   %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
@@ -2369,8 +2451,8 @@ entry:
   %148 = load i16, i16 addrspace(1)* %147, align 8
   %149 = zext i16 %148 to i32
   %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %150, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %151
 
 ; <label>:151                                     ; preds = %145
   %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
@@ -2388,8 +2470,8 @@ entry:
 
 ; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
-  br i1 %NullCheck, label %163, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %ThrowNullRef, label %163
 
 ; <label>:163                                     ; preds = %161
   %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
@@ -2399,8 +2481,8 @@ entry:
 
 ; <label>:167                                     ; preds = %163
   %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
-  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %168, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %169
 
 ; <label>:169                                     ; preds = %167
   %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
@@ -2432,55 +2514,55 @@ ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %167
+ThrowNullRef2:                                    ; preds = %167
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %128
+ThrowNullRef4:                                    ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %130
+ThrowNullRef6:                                    ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %143
+ThrowNullRef8:                                    ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %145
+ThrowNullRef10:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %102
+ThrowNullRef12:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %105
+ThrowNullRef14:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %76
+ThrowNullRef16:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %79
+ThrowNullRef18:                                   ; preds = %79
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %50
+ThrowNullRef20:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %53
+ThrowNullRef22:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %24
+ThrowNullRef24:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %27
+ThrowNullRef26:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2503,15 +2585,15 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2519,16 +2601,16 @@ entry:
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
   store i32 %8, i32* %loc0
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
   %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
   store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
@@ -2546,16 +2628,16 @@ entry:
 
 ; <label>:23                                      ; preds = %64
   %24 = load i16*, i16** %loc3
-  %NullCheck12 = icmp ne i16* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i16* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
   store i32 %27, i32* %loc5
   %28 = load i16*, i16** %loc4
-  %NullCheck14 = icmp ne i16* %28, null
-  br i1 %NullCheck14, label %29, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %28, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = load i16, i16* %28, align 8
@@ -2620,15 +2702,15 @@ entry:
 
 ; <label>:67                                      ; preds = %64
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
-  br i1 %NullCheck8, label %69, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %68, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %69
 
 ; <label>:69                                      ; preds = %67
   %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
   %71 = load i32, i32 addrspace(1)* %70
   %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
-  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %73
 
 ; <label>:73                                      ; preds = %69
   %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
@@ -2645,31 +2727,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %67
+ThrowNullRef8:                                    ; preds = %67
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %69
+ThrowNullRef10:                                   ; preds = %69
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2710,14 +2792,14 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
   %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
@@ -2730,14 +2812,14 @@ entry:
 
 ; <label>:11                                      ; preds = %4
   %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
   %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
@@ -2749,14 +2831,14 @@ entry:
 
 ; <label>:22                                      ; preds = %16
   %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
   %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
-  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
-  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
@@ -2804,23 +2886,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2836,7 +2918,280 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[loadElem]
+Successfully read RuntimeType.IsAssignableFrom
+
+define i8 @RuntimeType.IsAssignableFrom(%System.RuntimeType addrspace(1)* %param0, %System.Type addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.RuntimeType addrspace(1)*
+  %arg1 = alloca %System.Type addrspace(1)*
+  %loc0 = alloca %System.RuntimeType addrspace(1)*
+  %loc1 = alloca %"System.Type[]" addrspace(1)*
+  %loc2 = alloca i32
+  store %System.RuntimeType addrspace(1)* %param0, %System.RuntimeType addrspace(1)** %this
+  store %System.Type addrspace(1)* %param1, %System.Type addrspace(1)** %arg1
+  %0 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %1 = icmp ne %System.Type addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i8 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %5 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %6 = bitcast %System.Type addrspace(1)* %4 to %System.Object addrspace(1)*
+  %7 = bitcast %System.RuntimeType addrspace(1)* %5 to %System.Object addrspace(1)*
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %6, %System.Object addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %3
+  ret i8 1
+
+; <label>:12                                      ; preds = %3
+  %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 152
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 32
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
+  %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
+  %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
+  store %System.RuntimeType addrspace(1)* %25, %System.RuntimeType addrspace(1)** %loc0
+  %26 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %27 = icmp eq %System.RuntimeType addrspace(1)* %26, null
+  br i1 %27, label %34, label %28
+
+; <label>:28                                      ; preds = %15
+  %29 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %30 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)*)*)(%System.RuntimeType addrspace(1)* %29, %System.RuntimeType addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+; <label>:34                                      ; preds = %15
+  %35 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %36 = call %System.Reflection.Emit.TypeBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Reflection.Emit.TypeBuilder addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %35)
+  %37 = icmp eq %System.Reflection.Emit.TypeBuilder addrspace(1)* %36, null
+  br i1 %37, label %139, label %38
+
+; <label>:38                                      ; preds = %34
+  %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %42
+
+; <label>:42                                      ; preds = %38
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 152
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 40
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
+  %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
+  %53 = zext i8 %52 to i32
+  %54 = icmp eq i32 %53, 0
+  br i1 %54, label %56, label %55
+
+; <label>:55                                      ; preds = %42
+  ret i8 1
+
+; <label>:56                                      ; preds = %42
+  %57 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %58 = bitcast %System.RuntimeType addrspace(1)* %57 to %System.Type addrspace(1)*
+  %59 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %58)
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %64 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.Type addrspace(1)* %63, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = bitcast %System.RuntimeType addrspace(1)* %64 to %System.Type addrspace(1)*
+  %67 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %63, %System.Type addrspace(1)* %66)
+  %68 = zext i8 %67 to i32
+  %69 = trunc i32 %68 to i8
+  ret i8 %69
+
+; <label>:70                                      ; preds = %56
+  %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
+  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %73
+
+; <label>:73                                      ; preds = %70
+  %74 = load i64, i64 addrspace(1)* %72
+  %75 = add i64 %74, 128
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = add i64 %77, 0
+  %79 = inttoptr i64 %78 to i64*
+  %80 = load i64, i64* %79
+  %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
+  %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
+  %83 = call i8 %82(%System.Type addrspace(1)* %81)
+  %84 = zext i8 %83 to i32
+  %85 = icmp eq i32 %84, 0
+  br i1 %85, label %139, label %86
+
+; <label>:86                                      ; preds = %73
+  %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
+  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %89
+
+; <label>:89                                      ; preds = %86
+  %90 = load i64, i64 addrspace(1)* %88
+  %91 = add i64 %90, 128
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = add i64 %93, 24
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
+  %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
+  %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
+  store %"System.Type[]" addrspace(1)* %99, %"System.Type[]" addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %129
+
+; <label>:100                                     ; preds = %132
+  %101 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %102 = load i32, i32* %loc2
+  %NullCheck11 = icmp eq %"System.Type[]" addrspace(1)* %101, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %103
+
+; <label>:103                                     ; preds = %100
+  %104 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 1
+  %105 = load i32, i32 addrspace(1)* %104
+  %106 = zext i32 %105 to i64
+  %107 = zext i32 %102 to i64
+  %BoundsCheck = icmp uge i64 %107, %106
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %108
+
+; <label>:108                                     ; preds = %103
+  %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
+  %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
+  %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
+  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %113
+
+; <label>:113                                     ; preds = %108
+  %114 = load i64, i64 addrspace(1)* %112
+  %115 = add i64 %114, 152
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = add i64 %117, 56
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
+  %123 = zext i8 %122 to i32
+  %124 = icmp ne i32 %123, 0
+  br i1 %124, label %126, label %125
+
+; <label>:125                                     ; preds = %113
+  ret i8 0
+
+; <label>:126                                     ; preds = %113
+  %127 = load i32, i32* %loc2
+  %128 = add i32 %127, 1
+  store i32 %128, i32* %loc2
+  br label %129
+
+; <label>:129                                     ; preds = %89, %126
+  %130 = load i32, i32* %loc2
+  %131 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %NullCheck9 = icmp eq %"System.Type[]" addrspace(1)* %131, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %132
+
+; <label>:132                                     ; preds = %129
+  %133 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %131, i32 0, i32 1
+  %134 = load i32, i32 addrspace(1)* %133
+  %135 = zext i32 %134 to i64
+  %136 = trunc i64 %135 to i32
+  %137 = icmp slt i32 %130, %136
+  br i1 %137, label %100, label %138
+
+; <label>:138                                     ; preds = %132
+  ret i8 1
+
+; <label>:139                                     ; preds = %34, %73
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %129
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %103
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -2893,7 +3248,7 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElem]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -2904,8 +3259,8 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -2997,8 +3352,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
@@ -3059,8 +3414,8 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -3087,8 +3442,8 @@ entry:
 
 ; <label>:17                                      ; preds = %5, %11
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
@@ -3097,8 +3452,8 @@ entry:
 
 ; <label>:22                                      ; preds = %1, %11
   %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
@@ -3109,11 +3464,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %17
+ThrowNullRef2:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %22
+ThrowNullRef4:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3167,15 +3522,15 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
   %15 = load i32, i32 addrspace(1)* %14
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
@@ -3198,7 +3553,7 @@ ThrowNullRef:                                     ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef2:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3232,8 +3587,8 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
@@ -3312,8 +3667,8 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -3327,8 +3682,8 @@ entry:
 ; <label>:5                                       ; preds = %43
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %7 = load i32, i32* %loc1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck6, label %8, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
@@ -3366,8 +3721,8 @@ entry:
 ; <label>:32                                      ; preds = %21, %25
   %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
   %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
-  br i1 %NullCheck8, label %35, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = trunc i32 %34 to i16
@@ -3380,8 +3735,8 @@ entry:
 ; <label>:40                                      ; preds = %1, %35
   %41 = load i32, i32* %loc1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
-  br i1 %NullCheck2, label %43, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %42, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
@@ -3392,8 +3747,8 @@ entry:
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
   %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
-  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
   %51 = load i64, i64 addrspace(1)* %49
@@ -3412,19 +3767,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %40
+ThrowNullRef2:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %47
+ThrowNullRef4:                                    ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %5
+ThrowNullRef6:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %32
+ThrowNullRef8:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3467,8 +3822,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
@@ -3492,11 +3847,391 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(i16* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store i16* %param0, i16** %arg0
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load i32, i32* %arg3
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %42, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %37, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg2
+  %13 = load i32, i32* %arg3
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %37, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %24 = load i32, i32* %arg2
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load i16*, i16** %arg0
+  %35 = load i32, i32* %arg3
+  %36 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %36, i16* %34, i32 %35)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:37                                      ; preds = %5, %16
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %39)
+  %41 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41, %System.String addrspace(1)* %38, %System.String addrspace(1)* %40)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41) #0
+  unreachable
+
+; <label>:42                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
-Failed to read StringBuilder.ToString[loadElemA]
+Successfully read StringBuilder.ToString
+
+define %System.String addrspace(1)* @StringBuilder.ToString(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i16*
+  %loc3 = alloca %"System.Char[]" addrspace(1)*
+  %loc4 = alloca i32
+  %loc5 = alloca i32
+  %loc6 = alloca i16 addrspace(1)*
+  %loc7 = alloca %System.String addrspace(1)*
+  %loc8 = alloca %"System.Char[]" addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %0)
+  %2 = icmp ne i32 %1, 0
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %4
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %6)
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %7)
+  store %System.String addrspace(1)* %8, %System.String addrspace(1)** %loc0
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.Text.StringBuilder addrspace(1)* %9, %System.Text.StringBuilder addrspace(1)** %loc1
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  store %System.String addrspace(1)* %10, %System.String addrspace(1)** %loc7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc7
+  %12 = ptrtoint %System.String addrspace(1)* %11 to i64
+  %13 = icmp eq i64 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %5
+  %15 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %16 = sext i32 %15 to i64
+  %17 = add i64 %12, %16
+  br label %18
+
+; <label>:18                                      ; preds = %5, %14
+  %19 = phi i64 [ %12, %5 ], [ %17, %14 ]
+  %20 = inttoptr i64 %19 to i16*
+  store i16* %20, i16** %loc2
+  br label %21
+
+; <label>:21                                      ; preds = %98, %18
+  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %22, null
+  br i1 %NullCheck, label %ThrowNullRef, label %23
+
+; <label>:23                                      ; preds = %21
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 3
+  %25 = load i32, i32 addrspace(1)* %24, align 8
+  %26 = icmp sle i32 %25, 0
+  br i1 %26, label %96, label %27
+
+; <label>:27                                      ; preds = %23
+  %28 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %28, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %29
+
+; <label>:29                                      ; preds = %27
+  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %28, i32 0, i32 1
+  %31 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %30, align 8
+  store %"System.Char[]" addrspace(1)* %31, %"System.Char[]" addrspace(1)** %loc3
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %33
+
+; <label>:33                                      ; preds = %29
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  store i32 %35, i32* %loc4
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  %39 = load i32, i32 addrspace(1)* %38, align 8
+  store i32 %39, i32* %loc5
+  %40 = load i32, i32* %loc5
+  %41 = load i32, i32* %loc4
+  %42 = add i32 %40, %41
+  %43 = zext i32 %42 to i64
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %45
+
+; <label>:45                                      ; preds = %37
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = sext i32 %47 to i64
+  %49 = icmp sgt i64 %43, %48
+  br i1 %49, label %91, label %50
+
+; <label>:50                                      ; preds = %45
+  %51 = load i32, i32* %loc5
+  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %52, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %53
+
+; <label>:53                                      ; preds = %50
+  %54 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %52, i32 0, i32 1
+  %55 = load i32, i32 addrspace(1)* %54
+  %56 = zext i32 %55 to i64
+  %57 = trunc i64 %56 to i32
+  %58 = icmp ugt i32 %51, %57
+  br i1 %58, label %91, label %59
+
+; <label>:59                                      ; preds = %53
+  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  store %"System.Char[]" addrspace(1)* %60, %"System.Char[]" addrspace(1)** %loc8
+  %61 = icmp eq %"System.Char[]" addrspace(1)* %60, null
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %63, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %64
+
+; <label>:64                                      ; preds = %62
+  %65 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %63, i32 0, i32 1
+  %66 = load i32, i32 addrspace(1)* %65
+  %67 = zext i32 %66 to i64
+  %68 = trunc i64 %67 to i32
+  %69 = icmp ne i32 %68, 0
+  br i1 %69, label %71, label %70
+
+; <label>:70                                      ; preds = %59, %64
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:71                                      ; preds = %64
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %73
+
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %BoundsCheck = icmp uge i64 0, %76
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %77
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %78, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:79                                      ; preds = %70, %77
+  %80 = load i16*, i16** %loc2
+  %81 = load i32, i32* %loc4
+  %82 = sext i32 %81 to i64
+  %83 = mul i64 %82, 2
+  %84 = bitcast i16* %80 to i8*
+  %85 = getelementptr inbounds i8, i8* %84, i64 %83
+  %86 = load i16 addrspace(1)*, i16 addrspace(1)** %loc6
+  %87 = ptrtoint i16 addrspace(1)* %86 to i64
+  %88 = load i32, i32* %loc5
+  %89 = bitcast i8* %85 to i16*
+  %90 = inttoptr i64 %87 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %89, i16* %90, i32 %88)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %96
+
+; <label>:91                                      ; preds = %45, %53
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %94 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %93)
+  %95 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95, %System.String addrspace(1)* %92, %System.String addrspace(1)* %94)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95) #0
+  unreachable
+
+; <label>:96                                      ; preds = %23, %79
+  %97 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %97, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %98
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %97, i32 0, i32 2
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  store %System.Text.StringBuilder addrspace(1)* %100, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %102 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %102, label %21, label %103
+
+; <label>:103                                     ; preds = %98
+  store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc7
+  %104 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  ret %System.String addrspace(1)* %104
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method StringBuilder::get_Length using LLILCJit
+Successfully read StringBuilder.get_Length
+
+define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
+Successfully read RuntimeHelpers.get_OffsetToStringData
+
+define i32 @RuntimeHelpers.get_OffsetToStringData() {
+entry:
+  ret i32 12
+}
+
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
 Successfully read CultureData.CreateCultureData
 
@@ -3514,23 +4249,23 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
   store i8 %4, i8 addrspace(1)* %6
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
@@ -3549,11 +4284,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3566,50 +4301,50 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
   store i32 -1, i32 addrspace(1)* %2
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
   store i32 -1, i32 addrspace(1)* %8
   %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
   store i32 -1, i32 addrspace(1)* %14
   %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
   store i32 -1, i32 addrspace(1)* %17
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
@@ -3623,27 +4358,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3675,7 +4410,136 @@ Failed to read Dictionary`2.Insert[non-const derefAddress]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
 Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
-Failed to read HashHelpers.GetPrime[loadElem]
+Successfully read HashHelpers.GetPrime
+
+define i32 @HashHelpers.GetPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %6, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5, %System.String addrspace(1)* %4)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5) #0
+  unreachable
+
+; <label>:6                                       ; preds = %entry
+  store i32 0, i32* %loc0
+  br label %29
+
+; <label>:7                                       ; preds = %35
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 1296
+  %10 = addrspacecast i8 addrspace(1)* %9 to %"System.Int32[]" addrspace(1)**
+  %11 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %10
+  %12 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Int32[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = zext i32 %15 to i64
+  %17 = zext i32 %12 to i64
+  %BoundsCheck = icmp uge i64 %17, %16
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 3, i32 %12
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  store i32 %20, i32* %loc1
+  %21 = load i32, i32* %loc1
+  %22 = load i32, i32* %arg0
+  %23 = icmp slt i32 %21, %22
+  br i1 %23, label %26, label %24
+
+; <label>:24                                      ; preds = %18
+  %25 = load i32, i32* %loc1
+  ret i32 %25
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %loc0
+  %28 = add i32 %27, 1
+  store i32 %28, i32* %loc0
+  br label %29
+
+; <label>:29                                      ; preds = %6, %26
+  %30 = load i32, i32* %loc0
+  %31 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %32 = getelementptr inbounds i8, i8 addrspace(1)* %31, i64 1296
+  %33 = addrspacecast i8 addrspace(1)* %32 to %"System.Int32[]" addrspace(1)**
+  %34 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %33
+  %NullCheck = icmp eq %"System.Int32[]" addrspace(1)* %34, null
+  br i1 %NullCheck, label %ThrowNullRef, label %35
+
+; <label>:35                                      ; preds = %29
+  %36 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %34, i32 0, i32 1
+  %37 = load i32, i32 addrspace(1)* %36
+  %38 = zext i32 %37 to i64
+  %39 = trunc i64 %38 to i32
+  %40 = icmp slt i32 %30, %39
+  br i1 %40, label %7, label %41
+
+; <label>:41                                      ; preds = %35
+  %42 = load i32, i32* %arg0
+  %43 = or i32 %42, 1
+  store i32 %43, i32* %loc2
+  br label %59
+
+; <label>:44                                      ; preds = %59
+  %45 = load i32, i32* %loc2
+  %46 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %45)
+  %47 = zext i8 %46 to i32
+  %48 = icmp eq i32 %47, 0
+  br i1 %48, label %56, label %49
+
+; <label>:49                                      ; preds = %44
+  %50 = load i32, i32* %loc2
+  %51 = sub i32 %50, 1
+  %52 = srem i32 %51, 101
+  %53 = icmp eq i32 %52, 0
+  br i1 %53, label %56, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = load i32, i32* %loc2
+  ret i32 %55
+
+; <label>:56                                      ; preds = %44, %49
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %57, 2
+  store i32 %58, i32* %loc2
+  br label %59
+
+; <label>:59                                      ; preds = %41, %56
+  %60 = load i32, i32* %loc2
+  %61 = icmp slt i32 %60, 2147483647
+  br i1 %61, label %44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load i32, i32* %arg0
+  ret i32 %63
+
+ThrowNullRef:                                     ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
 Successfully read GenericEqualityComparer`1.GetHashCode
 
@@ -3694,14 +4558,14 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
   %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load i64, i64 addrspace(1)* %7
@@ -3720,7 +4584,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3750,8 +4614,8 @@ entry:
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
@@ -3796,8 +4660,8 @@ entry:
   %35 = bitcast i16* %34 to i8*
   %36 = getelementptr inbounds i8, i8* %35, i64 2
   %37 = bitcast i8* %36 to i16*
-  %NullCheck4 = icmp ne i16* %37, null
-  br i1 %NullCheck4, label %38, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %37, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %38
 
 ; <label>:38                                      ; preds = %27
   %39 = load i16, i16* %37, align 8
@@ -3824,8 +4688,8 @@ entry:
 
 ; <label>:54                                      ; preds = %22, %43
   %55 = load i16*, i16** %loc4
-  %NullCheck2 = icmp ne i16* %55, null
-  br i1 %NullCheck2, label %56, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i16* %55, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %56
 
 ; <label>:56                                      ; preds = %54
   %57 = load i16, i16* %55, align 8
@@ -3850,11 +4714,11 @@ ThrowNullRef:                                     ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %54
+ThrowNullRef2:                                    ; preds = %54
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %27
+ThrowNullRef4:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3871,8 +4735,8 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -3907,8 +4771,8 @@ entry:
 
 ; <label>:26                                      ; preds = %19
   %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
-  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %28
 
 ; <label>:28                                      ; preds = %26
   %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
@@ -3920,7 +4784,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3972,8 +4836,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
@@ -3984,26 +4848,26 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
-  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
@@ -4014,8 +4878,8 @@ entry:
 ; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
@@ -4024,8 +4888,8 @@ entry:
 
 ; <label>:25                                      ; preds = %1, %16, %23
   %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
-  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
@@ -4036,27 +4900,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %20
+ThrowNullRef10:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4069,8 +4933,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -4081,8 +4945,8 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
@@ -4091,8 +4955,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1, %8
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
@@ -4103,11 +4967,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4128,24 +4992,24 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   store i32 %3, i32* %loc0
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
   %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
   store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck4, label %9, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
@@ -4164,15 +5028,15 @@ entry:
 ; <label>:18                                      ; preds = %70
   %19 = load i16*, i16** %loc3
   %20 = bitcast i16* %19 to i64*
-  %NullCheck10 = icmp ne i64* %20, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %20, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = load i64, i64* %20, align 8
   %23 = load i16*, i16** %loc4
   %24 = bitcast i16* %23 to i64*
-  %NullCheck12 = icmp ne i64* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = load i64, i64* %24, align 8
@@ -4188,8 +5052,8 @@ entry:
   %31 = bitcast i16* %30 to i8*
   %32 = getelementptr inbounds i8, i8* %31, i64 8
   %33 = bitcast i8* %32 to i64*
-  %NullCheck14 = icmp ne i64* %33, null
-  br i1 %NullCheck14, label %34, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = load i64, i64* %33, align 8
@@ -4197,8 +5061,8 @@ entry:
   %37 = bitcast i16* %36 to i8*
   %38 = getelementptr inbounds i8, i8* %37, i64 8
   %39 = bitcast i8* %38 to i64*
-  %NullCheck16 = icmp ne i64* %39, null
-  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %40
 
 ; <label>:40                                      ; preds = %34
   %41 = load i64, i64* %39, align 8
@@ -4214,8 +5078,8 @@ entry:
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %NullCheck18 = icmp ne i64* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = load i64, i64* %48, align 8
@@ -4223,8 +5087,8 @@ entry:
   %52 = bitcast i16* %51 to i8*
   %53 = getelementptr inbounds i8, i8* %52, i64 16
   %54 = bitcast i8* %53 to i64*
-  %NullCheck20 = icmp ne i64* %54, null
-  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64* %54, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %55
 
 ; <label>:55                                      ; preds = %49
   %56 = load i64, i64* %54, align 8
@@ -4262,15 +5126,15 @@ entry:
 ; <label>:74                                      ; preds = %95
   %75 = load i16*, i16** %loc3
   %76 = bitcast i16* %75 to i32*
-  %NullCheck6 = icmp ne i32* %76, null
-  br i1 %NullCheck6, label %77, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32* %76, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %77
 
 ; <label>:77                                      ; preds = %74
   %78 = load i32, i32* %76, align 8
   %79 = load i16*, i16** %loc4
   %80 = bitcast i16* %79 to i32*
-  %NullCheck8 = icmp ne i32* %80, null
-  br i1 %NullCheck8, label %81, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i32* %80, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %81
 
 ; <label>:81                                      ; preds = %77
   %82 = load i32, i32* %80, align 8
@@ -4318,43 +5182,43 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %74
+ThrowNullRef6:                                    ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %77
+ThrowNullRef8:                                    ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %29
+ThrowNullRef14:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %34
+ThrowNullRef16:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4376,8 +5240,8 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load i64, i64 addrspace(1)* %4
@@ -4389,8 +5253,8 @@ entry:
   %12 = load i64, i64* %11
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %5
   %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
@@ -4399,8 +5263,8 @@ entry:
   %18 = load i8, i8* %arg2
   %19 = zext i8 %18 to i32
   %20 = trunc i32 %19 to i8
-  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %15
   %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
@@ -4411,11 +5275,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4442,8 +5306,8 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
@@ -4466,16 +5330,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
   %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = load i64, i64 addrspace(1)* %19
@@ -4500,8 +5364,8 @@ entry:
 ; <label>:35                                      ; preds = %30
   %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
@@ -4514,8 +5378,8 @@ entry:
 
 ; <label>:42                                      ; preds = %1, %38
   %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
-  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
@@ -4526,19 +5390,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %35
+ThrowNullRef2:                                    ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %42
+ThrowNullRef8:                                    ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4551,14 +5415,14 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
@@ -4570,7 +5434,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4583,8 +5447,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
@@ -4613,51 +5477,51 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
   %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
   %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
   %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
   %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
-  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
   store i64 %21, i64 addrspace(1)* %23
   %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %25 = load i64, i64* %loc0
-  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
@@ -4668,27 +5532,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %22
+ThrowNullRef12:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4701,8 +5565,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
@@ -4713,19 +5577,19 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
@@ -4734,8 +5598,8 @@ entry:
 
 ; <label>:15                                      ; preds = %1, %13
   %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
@@ -4746,19 +5610,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %15
+ThrowNullRef8:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4771,8 +5635,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -4831,8 +5695,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
@@ -4882,8 +5746,8 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
-  br i1 %NullCheck, label %17, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %ThrowNullRef, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
@@ -4894,15 +5758,15 @@ entry:
 
 ; <label>:22                                      ; preds = %17
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
-  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
   %26 = load i32, i32 addrspace(1)* %25
   %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
-  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %27, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
@@ -4925,8 +5789,8 @@ entry:
 ; <label>:40                                      ; preds = %17
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
-  br i1 %NullCheck6, label %43, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %41, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
@@ -4938,34 +5802,17 @@ ThrowNullRef:                                     ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %24
+ThrowNullRef4:                                    ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %40
+ThrowNullRef6:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
-}
-
-INFO:  jitting method Object::ReferenceEquals using LLILCJit
-Successfully read Object.ReferenceEquals
-
-define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
-entry:
-  %arg0 = alloca %System.Object addrspace(1)*
-  %arg1 = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
-  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
-  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = icmp eq %System.Object addrspace(1)* %0, %1
-  %3 = sext i1 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
 }
 
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
@@ -4978,21 +5825,21 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
   %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
-  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
@@ -5007,28 +5854,28 @@ entry:
 ; <label>:13                                      ; preds = %8, %12
   %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
   %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
   %21 = load i32, i32 addrspace(1)* %20, align 8
   %22 = add i32 %21, 1
-  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
   store i32 %22, i32 addrspace(1)* %24
   %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
@@ -5039,27 +5886,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5077,7 +5924,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::Setup using LLILCJit
-Failed to read AppDomain.Setup[loadElem]
+Failed to read AppDomain.Setup[unbox]
 INFO:  jitting method Thread::GetDomain using LLILCJit
 Successfully read Thread.GetDomain
 
@@ -5108,8 +5955,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
@@ -5122,14 +5969,14 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
   %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
@@ -5141,11 +5988,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5173,8 +6020,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -5189,7 +6036,328 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
 Failed to read KeyCollection.System.Collections.Generic.IEnumerable<TKey>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Successfully read Enumerator.MoveNext
+
+define i8 @Enumerator.MoveNext(%"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.RuntimeTypeHandle* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*
+  %"$TypeArg" = alloca %System.RuntimeTypeHandle*
+  store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
+  %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 8
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %76, label %12
+
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
+  br label %76
+
+; <label>:13                                      ; preds = %85
+  %14 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck19 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %15
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, i32 0, i32 0
+  %17 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %16, align 8
+  %NullCheck21 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, i32 0, i32 2
+  %20 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %19, align 8
+  %21 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck23 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %22
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, i32 0, i32 2
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %NullCheck25 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 3, i32 %24
+  %NullCheck27 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %32
+
+; <label>:32                                      ; preds = %30
+  %33 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, i32 0, i32 2
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = icmp slt i32 %34, 0
+  br i1 %35, label %68, label %36
+
+; <label>:36                                      ; preds = %32
+  %37 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %38 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck29 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %39
+
+; <label>:39                                      ; preds = %36
+  %40 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, i32 0, i32 0
+  %41 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %40, align 8
+  %NullCheck31 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, i32 0, i32 2
+  %44 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %43, align 8
+  %45 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck33 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, i32 0, i32 2
+  %48 = load i32, i32 addrspace(1)* %47, align 8
+  %NullCheck35 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %49
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = zext i32 %51 to i64
+  %53 = zext i32 %48 to i64
+  %BoundsCheck37 = icmp uge i64 %53, %52
+  br i1 %BoundsCheck37, label %ThrowIndexOutOfRange38, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 3, i32 %48
+  %NullCheck39 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %56
+
+; <label>:56                                      ; preds = %54
+  %57 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, i32 0, i32 0
+  %58 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck41 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %59
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %60, %System.__Canon addrspace(1)* %58)
+  %61 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck43 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  %64 = load i32, i32 addrspace(1)* %63, align 8
+  %65 = add i32 %64, 1
+  %NullCheck45 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  store i32 %65, i32 addrspace(1)* %67
+  ret i8 1
+
+; <label>:68                                      ; preds = %32
+  %69 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck47 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %73 = add i32 %72, 1
+  %NullCheck49 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %74
+
+; <label>:74                                      ; preds = %70
+  %75 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  store i32 %73, i32 addrspace(1)* %75
+  br label %76
+
+; <label>:76                                      ; preds = %8, %12, %74
+  %77 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %78
+
+; <label>:78                                      ; preds = %76
+  %79 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, i32 0, i32 2
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck7 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %82
+
+; <label>:82                                      ; preds = %78
+  %83 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, i32 0, i32 0
+  %84 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %83, align 8
+  %NullCheck9 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %85
+
+; <label>:85                                      ; preds = %82
+  %86 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, i32 0, i32 7
+  %87 = load i32, i32 addrspace(1)* %86, align 8
+  %88 = icmp ult i32 %80, %87
+  br i1 %88, label %13, label %89
+
+; <label>:89                                      ; preds = %85
+  %90 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %91 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck11 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %92
+
+; <label>:92                                      ; preds = %89
+  %93 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, i32 0, i32 0
+  %94 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck13 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %95
+
+; <label>:95                                      ; preds = %92
+  %96 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, i32 0, i32 7
+  %97 = load i32, i32 addrspace(1)* %96, align 8
+  %98 = add i32 %97, 1
+  %NullCheck15 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %99
+
+; <label>:99                                      ; preds = %95
+  %100 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, i32 0, i32 2
+  store i32 %98, i32 addrspace(1)* %100
+  %101 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck17 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %102
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %103, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %92
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef22:                                   ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef24:                                   ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef26:                                   ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef28:                                   ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef30:                                   ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef32:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef34:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef36:                                   ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange38:                           ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef40:                                   ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef42:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef44:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef46:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef48:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef50:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -5200,8 +6368,8 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -5232,9 +6400,9 @@ Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
 Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
-Failed to read String.MakeSeparatorList[loadElemA]
+Failed to read String.MakeSeparatorList[storeElem]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
-Failed to read String.InternalSplitKeepEmptyEntries[loadElem]
+Failed to read String.InternalSplitKeepEmptyEntries[storeElem]
 INFO:  jitting method Path::IsRelative using LLILCJit
 Successfully read Path.IsRelative
 
@@ -5243,8 +6411,8 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -5254,8 +6422,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
@@ -5271,8 +6439,8 @@ entry:
 
 ; <label>:17                                      ; preds = %7
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
@@ -5288,8 +6456,8 @@ entry:
 
 ; <label>:29                                      ; preds = %19
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %31
 
 ; <label>:31                                      ; preds = %29
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
@@ -5300,8 +6468,8 @@ entry:
 
 ; <label>:36                                      ; preds = %31
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
-  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %37, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
@@ -5312,8 +6480,8 @@ entry:
 
 ; <label>:43                                      ; preds = %31, %38
   %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
-  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %45
 
 ; <label>:45                                      ; preds = %43
   %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
@@ -5324,8 +6492,8 @@ entry:
 
 ; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %50
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
@@ -5336,8 +6504,8 @@ entry:
 
 ; <label>:57                                      ; preds = %1, %7, %19, %45, %52
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
-  br i1 %NullCheck14, label %59, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %59
 
 ; <label>:59                                      ; preds = %57
   %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
@@ -5347,8 +6515,8 @@ entry:
 
 ; <label>:63                                      ; preds = %59
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
@@ -5359,8 +6527,8 @@ entry:
 
 ; <label>:70                                      ; preds = %65
   %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
-  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.String addrspace(1)* %71, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %72
 
 ; <label>:72                                      ; preds = %70
   %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
@@ -5379,39 +6547,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %17
+ThrowNullRef4:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %29
+ThrowNullRef6:                                    ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %36
+ThrowNullRef8:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %43
+ThrowNullRef10:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %50
+ThrowNullRef12:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %57
+ThrowNullRef14:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %63
+ThrowNullRef16:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %70
+ThrowNullRef18:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5419,7 +6587,293 @@ ThrowNullRef17:                                   ; preds = %70
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
-Failed to read String.TrimHelper[loadElem]
+Successfully read String.TrimHelper
+
+define %System.String addrspace(1)* @String.TrimHelper(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i16
+  %loc4 = alloca i32
+  %loc5 = alloca i16
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = sub i32 %3, 1
+  store i32 %4, i32* %loc0
+  store i32 0, i32* %loc1
+  %5 = load i32, i32* %arg2
+  %6 = icmp eq i32 %5, 1
+  br i1 %6, label %62, label %7
+
+; <label>:7                                       ; preds = %1
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:8                                       ; preds = %58
+  store i32 0, i32* %loc2
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load i32, i32* %loc1
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2, i32 %10
+  %13 = load i16, i16 addrspace(1)* %12
+  %14 = zext i16 %13 to i32
+  %15 = trunc i32 %14 to i16
+  store i16 %15, i16* %loc3
+  store i32 0, i32* %loc2
+  br label %34
+
+; <label>:16                                      ; preds = %37
+  %17 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %18 = load i32, i32* %loc2
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %17, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %19
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = zext i32 %18 to i64
+  %BoundsCheck = icmp uge i64 %23, %22
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %24
+
+; <label>:24                                      ; preds = %19
+  %25 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 3, i32 %18
+  %26 = load i16, i16 addrspace(1)* %25, align 8
+  %27 = zext i16 %26 to i32
+  %28 = load i16, i16* %loc3
+  %29 = zext i16 %28 to i32
+  %30 = icmp eq i32 %27, %29
+  br i1 %30, label %43, label %31
+
+; <label>:31                                      ; preds = %24
+  %32 = load i32, i32* %loc2
+  %33 = add i32 %32, 1
+  store i32 %33, i32* %loc2
+  br label %34
+
+; <label>:34                                      ; preds = %11, %31
+  %35 = load i32, i32* %loc2
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = icmp slt i32 %35, %41
+  br i1 %42, label %16, label %43
+
+; <label>:43                                      ; preds = %24, %37
+  %44 = load i32, i32* %loc2
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %45, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp eq i32 %44, %50
+  br i1 %51, label %62, label %52
+
+; <label>:52                                      ; preds = %46
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %7, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %57, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %58
+
+; <label>:58                                      ; preds = %55
+  %59 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %60 = load i32, i32 addrspace(1)* %59
+  %61 = icmp slt i32 %56, %60
+  br i1 %61, label %8, label %62
+
+; <label>:62                                      ; preds = %1, %46, %58
+  %63 = load i32, i32* %arg2
+  %64 = icmp eq i32 %63, 0
+  br i1 %64, label %122, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %66, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %67
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %66, i32 0, i32 1
+  %69 = load i32, i32 addrspace(1)* %68
+  %70 = sub i32 %69, 1
+  store i32 %70, i32* %loc0
+  br label %118
+
+; <label>:71                                      ; preds = %118
+  store i32 0, i32* %loc4
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %73 = load i32, i32* %loc0
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %74
+
+; <label>:74                                      ; preds = %71
+  %75 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 2, i32 %73
+  %76 = load i16, i16 addrspace(1)* %75
+  %77 = zext i16 %76 to i32
+  %78 = trunc i32 %77 to i16
+  store i16 %78, i16* %loc5
+  store i32 0, i32* %loc4
+  br label %97
+
+; <label>:79                                      ; preds = %100
+  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %81 = load i32, i32* %loc4
+  %NullCheck19 = icmp eq %"System.Char[]" addrspace(1)* %80, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
+
+; <label>:82                                      ; preds = %79
+  %83 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 1
+  %84 = load i32, i32 addrspace(1)* %83
+  %85 = zext i32 %84 to i64
+  %86 = zext i32 %81 to i64
+  %BoundsCheck21 = icmp uge i64 %86, %85
+  br i1 %BoundsCheck21, label %ThrowIndexOutOfRange22, label %87
+
+; <label>:87                                      ; preds = %82
+  %88 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 3, i32 %81
+  %89 = load i16, i16 addrspace(1)* %88, align 8
+  %90 = zext i16 %89 to i32
+  %91 = load i16, i16* %loc5
+  %92 = zext i16 %91 to i32
+  %93 = icmp eq i32 %90, %92
+  br i1 %93, label %106, label %94
+
+; <label>:94                                      ; preds = %87
+  %95 = load i32, i32* %loc4
+  %96 = add i32 %95, 1
+  store i32 %96, i32* %loc4
+  br label %97
+
+; <label>:97                                      ; preds = %74, %94
+  %98 = load i32, i32* %loc4
+  %99 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck15 = icmp eq %"System.Char[]" addrspace(1)* %99, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %100
+
+; <label>:100                                     ; preds = %97
+  %101 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %99, i32 0, i32 1
+  %102 = load i32, i32 addrspace(1)* %101
+  %103 = zext i32 %102 to i64
+  %104 = trunc i64 %103 to i32
+  %105 = icmp slt i32 %98, %104
+  br i1 %105, label %79, label %106
+
+; <label>:106                                     ; preds = %87, %100
+  %107 = load i32, i32* %loc4
+  %108 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck17 = icmp eq %"System.Char[]" addrspace(1)* %108, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %109
+
+; <label>:109                                     ; preds = %106
+  %110 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %108, i32 0, i32 1
+  %111 = load i32, i32 addrspace(1)* %110
+  %112 = zext i32 %111 to i64
+  %113 = trunc i64 %112 to i32
+  %114 = icmp eq i32 %107, %113
+  br i1 %114, label %122, label %115
+
+; <label>:115                                     ; preds = %109
+  %116 = load i32, i32* %loc0
+  %117 = sub i32 %116, 1
+  store i32 %117, i32* %loc0
+  br label %118
+
+; <label>:118                                     ; preds = %67, %115
+  %119 = load i32, i32* %loc0
+  %120 = load i32, i32* %loc1
+  %121 = icmp sge i32 %119, %120
+  br i1 %121, label %71, label %122
+
+; <label>:122                                     ; preds = %62, %109, %118
+  %123 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %124 = load i32, i32* %loc1
+  %125 = load i32, i32* %loc0
+  %126 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %123, i32 %124, i32 %125)
+  ret %System.String addrspace(1)* %126
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %97
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange22:                           ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
 Successfully read String.CreateTrimmedString
 
@@ -5439,8 +6893,8 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
@@ -5535,8 +6989,8 @@ entry:
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i64 2872
   %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
   %8 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %7
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %3
   %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
@@ -5553,8 +7007,8 @@ entry:
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 2864
   %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
   %21 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %20
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
-  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %22
 
 ; <label>:22                                      ; preds = %16
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
@@ -5569,7 +7023,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %16
+ThrowNullRef2:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5586,8 +7040,8 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5613,8 +7067,8 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
@@ -5632,8 +7086,8 @@ entry:
 
 ; <label>:12                                      ; preds = %4
   %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
@@ -5644,8 +7098,8 @@ entry:
 
 ; <label>:19                                      ; preds = %14
   %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %19
   %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
@@ -5660,21 +7114,21 @@ entry:
   %31 = zext i16 %30 to i32
   %32 = bitcast i8* %29 to i16*
   %33 = trunc i32 %31 to i16
-  %NullCheck6 = icmp ne i16* %32, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i16* %32, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %21
   store i16 %33, i16* %32, align 8
   %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %36
 
 ; <label>:36                                      ; preds = %34
   %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
   %38 = load i32, i32 addrspace(1)* %37, align 8
   %39 = add i32 %38, 1
-  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %40
 
 ; <label>:40                                      ; preds = %36
   %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
@@ -5683,16 +7137,16 @@ entry:
 
 ; <label>:42                                      ; preds = %14
   %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
-  br i1 %NullCheck12, label %44, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
   %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
   %47 = load i16, i16* %arg1
   %48 = zext i16 %47 to i32
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = trunc i32 %48 to i16
@@ -5703,31 +7157,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %19
+ThrowNullRef4:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %21
+ThrowNullRef6:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %36
+ThrowNullRef10:                                   ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %42
+ThrowNullRef12:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %44
+ThrowNullRef14:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5740,8 +7194,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -5752,8 +7206,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
@@ -5762,14 +7216,14 @@ entry:
 
 ; <label>:11                                      ; preds = %1
   %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
@@ -5779,15 +7233,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5808,8 +7262,8 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5822,8 +7276,8 @@ entry:
 
 ; <label>:8                                       ; preds = %3
   %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
@@ -5842,15 +7296,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
-  br i1 %NullCheck4, label %22, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
   %24 = load i16*, i16* addrspace(1)* %23, align 8
   %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %25, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
@@ -5859,8 +7313,8 @@ entry:
   store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
@@ -5874,8 +7328,8 @@ entry:
 
 ; <label>:37                                      ; preds = %65
   %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %37
   %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
@@ -5886,16 +7340,16 @@ entry:
   %45 = bitcast i16* %41 to i8*
   %46 = getelementptr inbounds i8, i8* %45, i64 %44
   %47 = bitcast i8* %46 to i16*
-  %NullCheck14 = icmp ne i16* %47, null
-  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %47, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %48
 
 ; <label>:48                                      ; preds = %39
   %49 = load i16, i16* %47, align 8
   %50 = zext i16 %49 to i32
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %52 = load i32, i32* %loc1
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %53
 
 ; <label>:53                                      ; preds = %48
   %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
@@ -5916,8 +7370,8 @@ entry:
 ; <label>:62                                      ; preds = %36, %59
   %63 = load i32, i32* %loc1
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck10, label %65, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %65
 
 ; <label>:65                                      ; preds = %62
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
@@ -5936,15 +7390,15 @@ entry:
 
 ; <label>:74                                      ; preds = %70
   %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
-  br i1 %NullCheck18, label %76, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %76
 
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
   %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
-  br i1 %NullCheck20, label %80, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
   %81 = load i64, i64 addrspace(1)* %79
@@ -5958,8 +7412,8 @@ entry:
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
   %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
-  br i1 %NullCheck22, label %92, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.String addrspace(1)* %90, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %92
 
 ; <label>:92                                      ; preds = %80
   %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
@@ -5969,15 +7423,15 @@ entry:
 
 ; <label>:96                                      ; preds = %70
   %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
-  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %98
 
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
   %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
-  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
   %103 = load i64, i64 addrspace(1)* %101
@@ -5991,8 +7445,8 @@ entry:
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
   %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
-  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.String addrspace(1)* %112, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %114
 
 ; <label>:114                                     ; preds = %102
   %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
@@ -6004,59 +7458,59 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %20
+ThrowNullRef4:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %22
+ThrowNullRef6:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %26
+ThrowNullRef8:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %62
+ThrowNullRef10:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %48
+ThrowNullRef16:                                   ; preds = %48
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %74
+ThrowNullRef18:                                   ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %76
+ThrowNullRef20:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %80
+ThrowNullRef22:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %96
+ThrowNullRef24:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %98
+ThrowNullRef26:                                   ; preds = %98
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %102
+ThrowNullRef28:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6069,15 +7523,15 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
   %3 = load i16*, i16* addrspace(1)* %2, align 8
   %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
@@ -6087,8 +7541,8 @@ entry:
   %10 = bitcast i16* %3 to i8*
   %11 = getelementptr inbounds i8, i8* %10, i64 %9
   %12 = bitcast i8* %11 to i16*
-  %NullCheck4 = icmp ne i16* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %5
   store i16 0, i16* %12, align 8
@@ -6098,11 +7552,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6119,8 +7573,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -6131,8 +7585,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
@@ -6144,15 +7598,15 @@ entry:
 
 ; <label>:14                                      ; preds = %1
   %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
   %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
   %21 = load i64, i64 addrspace(1)* %19
@@ -6171,15 +7625,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %14
+ThrowNullRef4:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %16
+ThrowNullRef6:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6302,14 +7756,6 @@ entry:
   ret %System.String addrspace(1)* %57
 }
 
-INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
-Successfully read RuntimeHelpers.get_OffsetToStringData
-
-define i32 @RuntimeHelpers.get_OffsetToStringData() {
-entry:
-  ret i32 12
-}
-
 INFO:  jitting method String::Equals using LLILCJit
 Successfully read String.Equals
 
@@ -6381,8 +7827,8 @@ entry:
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
-  br i1 %NullCheck24, label %29, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
   %30 = load i64, i64 addrspace(1)* %28
@@ -6397,8 +7843,8 @@ entry:
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
-  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
   %43 = load i64, i64 addrspace(1)* %41
@@ -6418,8 +7864,8 @@ entry:
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
   %59 = load i64, i64 addrspace(1)* %57
@@ -6434,8 +7880,8 @@ entry:
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck22, label %71, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
   %72 = load i64, i64 addrspace(1)* %70
@@ -6455,8 +7901,8 @@ entry:
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
-  br i1 %NullCheck16, label %87, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = load i64, i64 addrspace(1)* %86
@@ -6471,8 +7917,8 @@ entry:
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck18, label %100, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
   %101 = load i64, i64 addrspace(1)* %99
@@ -6492,8 +7938,8 @@ entry:
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
-  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
   %117 = load i64, i64 addrspace(1)* %115
@@ -6508,8 +7954,8 @@ entry:
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
-  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
   %130 = load i64, i64 addrspace(1)* %128
@@ -6528,15 +7974,15 @@ entry:
 
 ; <label>:142                                     ; preds = %22
   %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
-  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %143, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %144
 
 ; <label>:144                                     ; preds = %142
   %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
   %146 = load i32, i32 addrspace(1)* %145
   %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
-  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %147, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %148
 
 ; <label>:148                                     ; preds = %144
   %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
@@ -6557,15 +8003,15 @@ entry:
 
 ; <label>:159                                     ; preds = %22
   %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
-  br i1 %NullCheck, label %161, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %ThrowNullRef, label %161
 
 ; <label>:161                                     ; preds = %159
   %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
   %163 = load i32, i32 addrspace(1)* %162
   %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
-  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %164, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %165
 
 ; <label>:165                                     ; preds = %161
   %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
@@ -6578,8 +8024,8 @@ entry:
 
 ; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
-  br i1 %NullCheck4, label %172, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %171, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %172
 
 ; <label>:172                                     ; preds = %170
   %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
@@ -6589,8 +8035,8 @@ entry:
 
 ; <label>:176                                     ; preds = %172
   %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
-  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %177, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %178
 
 ; <label>:178                                     ; preds = %176
   %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
@@ -6629,55 +8075,55 @@ ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %161
+ThrowNullRef2:                                    ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %170
+ThrowNullRef4:                                    ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %176
+ThrowNullRef6:                                    ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %142
+ThrowNullRef8:                                    ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %144
+ThrowNullRef10:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %113
+ThrowNullRef12:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %116
+ThrowNullRef14:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %84
+ThrowNullRef16:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %87
+ThrowNullRef18:                                   ; preds = %87
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %55
+ThrowNullRef20:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %58
+ThrowNullRef22:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %26
+ThrowNullRef24:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %29
+ThrowNullRef26:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,8 +8161,8 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck, label %14, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %ThrowNullRef, label %14
 
 ; <label>:14                                      ; preds = %8
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
@@ -6760,8 +8206,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
@@ -6770,14 +8216,14 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32, i32* %loc0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %10
   %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
   %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
@@ -6790,15 +8236,15 @@ entry:
 ; <label>:25                                      ; preds = %19
   %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
-  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
   %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
@@ -6807,8 +8253,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %37 = load i32, i32* %loc0
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %38, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %38
 
 ; <label>:38                                      ; preds = %32
   %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
@@ -6817,14 +8263,14 @@ entry:
 
 ; <label>:40                                      ; preds = %19
   %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %40
   %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
   %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
-  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
-  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
@@ -6832,8 +8278,8 @@ entry:
   %48 = zext i32 %47 to i64
   %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
-  br i1 %NullCheck16, label %51, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %51
 
 ; <label>:51                                      ; preds = %45
   %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
@@ -6847,15 +8293,15 @@ entry:
 ; <label>:57                                      ; preds = %51
   %58 = load i16*, i16** %arg1
   %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
-  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %60
 
 ; <label>:60                                      ; preds = %57
   %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
   %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
-  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %64
 
 ; <label>:64                                      ; preds = %60
   %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
@@ -6864,22 +8310,22 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
   %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
-  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %70
 
 ; <label>:70                                      ; preds = %64
   %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
   %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
-  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
-  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
   %75 = load i32, i32 addrspace(1)* %74
   %76 = zext i32 %75 to i64
   %77 = trunc i64 %76 to i32
-  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
-  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %78
 
 ; <label>:78                                      ; preds = %73
   %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
@@ -6901,8 +8347,8 @@ entry:
   %90 = bitcast i16* %86 to i8*
   %91 = getelementptr inbounds i8, i8* %90, i64 %89
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %93
 
 ; <label>:93                                      ; preds = %80
   %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
@@ -6912,8 +8358,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %99 = load i32, i32* %loc2
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %100
 
 ; <label>:100                                     ; preds = %93
   %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
@@ -6928,63 +8374,63 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %25
+ThrowNullRef6:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %32
+ThrowNullRef10:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %40
+ThrowNullRef12:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %45
+ThrowNullRef16:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %57
+ThrowNullRef18:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %60
+ThrowNullRef20:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %64
+ThrowNullRef22:                                   ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %70
+ThrowNullRef24:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %73
+ThrowNullRef26:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %80
+ThrowNullRef28:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %93
+ThrowNullRef30:                                   ; preds = %93
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7004,8 +8450,8 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
@@ -7033,43 +8479,43 @@ entry:
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %14
   %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
   %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   %28 = load i32, i32 addrspace(1)* %27, align 8
   %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
-  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %30
 
 ; <label>:30                                      ; preds = %26
   %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
   %32 = load i32, i32 addrspace(1)* %31, align 8
   %33 = add i32 %28, %32
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %34
 
 ; <label>:34                                      ; preds = %30
   %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   store i32 %33, i32 addrspace(1)* %35
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
   store i32 0, i32 addrspace(1)* %38
   %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %40
 
 ; <label>:40                                      ; preds = %37
   %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
@@ -7082,8 +8528,8 @@ entry:
 
 ; <label>:47                                      ; preds = %40
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
@@ -7098,8 +8544,8 @@ entry:
   %54 = load i32, i32* %loc0
   %55 = sext i32 %54 to i64
   %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
-  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %57
 
 ; <label>:57                                      ; preds = %52
   %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
@@ -7110,68 +8556,35 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %14
+ThrowNullRef2:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %23
+ThrowNullRef4:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %26
+ThrowNullRef6:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %30
+ThrowNullRef8:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %34
+ThrowNullRef10:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %47
+ThrowNullRef14:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %52
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-}
-
-INFO:  jitting method StringBuilder::get_Length using LLILCJit
-Successfully read StringBuilder.get_Length
-
-define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.StringBuilder addrspace(1)*
-  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
-  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
-
-; <label>:1                                       ; preds = %entry
-  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %3 = load i32, i32 addrspace(1)* %2, align 8
-  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
-
-; <label>:5                                       ; preds = %1
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = add i32 %3, %7
-  ret i32 %8
-
-ThrowNullRef:                                     ; preds = %entry
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef16:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7213,70 +8626,70 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
   %6 = load i32, i32 addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
   store i32 %6, i32 addrspace(1)* %8
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
   %13 = load i32, i32 addrspace(1)* %12, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
   store i32 %13, i32 addrspace(1)* %15
   %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
-  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %18
 
 ; <label>:18                                      ; preds = %14
   %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
   %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
   %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
   %34 = load i32, i32 addrspace(1)* %33, align 8
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
-  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
@@ -7287,39 +8700,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %28
+ThrowNullRef16:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %32
+ThrowNullRef18:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7455,13 +8868,13 @@ entry:
 ; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
@@ -7477,16 +8890,16 @@ entry:
 
 ; <label>:18                                      ; preds = %15
   %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
   store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
   %22 = load i32, i32* %loc0
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %24
 
 ; <label>:24                                      ; preds = %20
   %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
@@ -7498,13 +8911,13 @@ entry:
 ; <label>:28                                      ; preds = %15, %24
   %29 = load i32, i32* %arg1
   %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %31
   %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
@@ -7517,20 +8930,20 @@ entry:
   %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
-  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
   %46 = load i32, i32 addrspace(1)* %45, align 8
   %47 = sub i32 %40, %46
-  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
-  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i32 addrspace(1)* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %48
 
 ; <label>:48                                      ; preds = %44
   store i32 %47, i32 addrspace(1)* %39, align 8
@@ -7538,21 +8951,21 @@ entry:
 
 ; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
-  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %51
 
 ; <label>:51                                      ; preds = %49
   %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %53
 
 ; <label>:53                                      ; preds = %51
   %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
   %55 = load i32, i32 addrspace(1)* %54, align 8
   %56 = load i32, i32* %arg2
   %57 = sub i32 %55, %56
-  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %58
 
 ; <label>:58                                      ; preds = %53
   %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
@@ -7562,13 +8975,13 @@ entry:
 ; <label>:60                                      ; preds = %33, %58
   %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
   %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
-  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %63
 
 ; <label>:63                                      ; preds = %60
   %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
-  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
-  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
@@ -7578,15 +8991,15 @@ entry:
 
 ; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
-  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i32 addrspace(1)* %69, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %70
 
 ; <label>:70                                      ; preds = %68
   %71 = load i32, i32 addrspace(1)* %69, align 8
   store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
-  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
@@ -7596,8 +9009,8 @@ entry:
   store i32 %77, i32* %loc4
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
-  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %80
 
 ; <label>:80                                      ; preds = %73
   %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
@@ -7607,71 +9020,71 @@ entry:
 ; <label>:83                                      ; preds = %80
   store i32 0, i32* %loc3
   %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
-  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
-  br i1 %NullCheck26, label %88, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i32 addrspace(1)* %87, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %88
 
 ; <label>:88                                      ; preds = %85
   %89 = load i32, i32 addrspace(1)* %87, align 8
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
-  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %90
 
 ; <label>:90                                      ; preds = %88
   %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
   store i32 %89, i32 addrspace(1)* %91
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
-  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
-  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %96
 
 ; <label>:96                                      ; preds = %94
   %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
-  br i1 %NullCheck34, label %100, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %100
 
 ; <label>:100                                     ; preds = %96
   %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
-  br i1 %NullCheck36, label %102, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %102
 
 ; <label>:102                                     ; preds = %100
   %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
   %104 = load i32, i32 addrspace(1)* %103, align 8
   %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
-  br i1 %NullCheck38, label %106, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %106
 
 ; <label>:106                                     ; preds = %102
   %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
-  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
-  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %108
 
 ; <label>:108                                     ; preds = %106
   %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
   %110 = load i32, i32 addrspace(1)* %109, align 8
   %111 = add i32 %104, %110
-  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %112
 
 ; <label>:112                                     ; preds = %108
   %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
   store i32 %111, i32 addrspace(1)* %113
   %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
-  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i32 addrspace(1)* %114, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %115
 
 ; <label>:115                                     ; preds = %112
   %116 = load i32, i32 addrspace(1)* %114, align 8
@@ -7681,19 +9094,19 @@ entry:
 ; <label>:118                                     ; preds = %115
   %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
-  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %121
 
 ; <label>:121                                     ; preds = %118
   %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
-  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
-  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %123
 
 ; <label>:123                                     ; preds = %121
   %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
   %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
-  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
-  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %126
 
 ; <label>:126                                     ; preds = %123
   %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
@@ -7705,8 +9118,8 @@ entry:
 
 ; <label>:130                                     ; preds = %80, %115, %126
   %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %132
 
 ; <label>:132                                     ; preds = %130
   %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7715,8 +9128,8 @@ entry:
   %136 = load i32, i32* %loc3
   %137 = sub i32 %135, %136
   %138 = sub i32 %134, %137
-  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %139
 
 ; <label>:139                                     ; preds = %132
   %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7728,16 +9141,16 @@ entry:
 
 ; <label>:144                                     ; preds = %139
   %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
-  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %146
 
 ; <label>:146                                     ; preds = %144
   %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
   %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
   %149 = load i32, i32* %loc2
   %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
-  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %151
 
 ; <label>:151                                     ; preds = %146
   %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
@@ -7754,145 +9167,249 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %18
+ThrowNullRef4:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %31
+ThrowNullRef10:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %44
+ThrowNullRef16:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %68
+ThrowNullRef18:                                   ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %70
+ThrowNullRef20:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %73
+ThrowNullRef22:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %83
+ThrowNullRef24:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %85
+ThrowNullRef26:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %88
+ThrowNullRef28:                                   ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %90
+ThrowNullRef30:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %94
+ThrowNullRef32:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %96
+ThrowNullRef34:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %100
+ThrowNullRef36:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %102
+ThrowNullRef38:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %106
+ThrowNullRef40:                                   ; preds = %106
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %108
+ThrowNullRef42:                                   ; preds = %108
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %112
+ThrowNullRef44:                                   ; preds = %112
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %118
+ThrowNullRef46:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %121
+ThrowNullRef48:                                   ; preds = %121
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %123
+ThrowNullRef50:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %130
+ThrowNullRef52:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %132
+ThrowNullRef54:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %144
+ThrowNullRef56:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %146
+ThrowNullRef58:                                   ; preds = %146
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %60
+ThrowNullRef60:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %63
+ThrowNullRef62:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %49
+ThrowNullRef64:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %51
+ThrowNullRef66:                                   ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %53
+ThrowNullRef68:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(%"System.Char[]" addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %arg0 = alloca %"System.Char[]" addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store %"System.Char[]" addrspace(1)* %param0, %"System.Char[]" addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load i32, i32* %arg4
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %43, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %38, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg1
+  %13 = load i32, i32* %arg4
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %38, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %24 = load i32, i32* %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %35 = load i32, i32* %arg3
+  %36 = load i32, i32* %arg4
+  %37 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %37, %"System.Char[]" addrspace(1)* %34, i32 %35, i32 %36)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:38                                      ; preds = %5, %16
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Successfully read Buffer._Memmove
 
@@ -7914,7 +9431,7 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[loadElem]
+Failed to read AppDomain.SetDataHelper[storeElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -7923,8 +9440,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
@@ -7934,8 +9451,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
@@ -7947,15 +9464,15 @@ entry:
   %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
   %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
@@ -7966,15 +9483,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7992,7 +9509,79 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
-Failed to read Dictionary`2.TryGetValue[loadElemA]
+Successfully read Dictionary`2.TryGetValue
+
+define i8 @"Dictionary`2.TryGetValue"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)* addrspace(1)* %param2) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  %arg2 = alloca %System.__Canon addrspace(1)* addrspace(1)*
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  store %System.__Canon addrspace(1)* addrspace(1)* %param2, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  store i32 %2, i32* %loc0
+  %3 = load i32, i32* %loc0
+  %4 = icmp slt i32 %3, 0
+  br i1 %4, label %22, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 2
+  %10 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %9, align 8
+  %11 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = zext i32 %11 to i64
+  %BoundsCheck = icmp uge i64 %16, %15
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 3, i32 %11
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %20, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %6, %System.__Canon addrspace(1)* %21)
+  ret i8 1
+
+; <label>:22                                      ; preds = %entry
+  %23 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %23, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -8058,8 +9647,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
@@ -8091,8 +9680,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
@@ -8171,15 +9760,15 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck, label %19, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %ThrowNullRef, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
   %21 = load i32, i32 addrspace(1)* %20
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
@@ -8202,7 +9791,7 @@ ThrowNullRef:                                     ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %19
+ThrowNullRef2:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8248,8 +9837,8 @@ entry:
   %0 = alloca %System.AppDomainHandle
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %1 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %1, i32 0, i32 15
@@ -8269,8 +9858,8 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
@@ -8286,7 +9875,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -8299,8 +9888,8 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -8327,8 +9916,8 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
@@ -8352,8 +9941,8 @@ entry:
   %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
   store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
@@ -8363,8 +9952,8 @@ entry:
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
@@ -8374,8 +9963,8 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %9
   %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
@@ -8384,8 +9973,8 @@ entry:
 
 ; <label>:18                                      ; preds = %3, %16
   %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
@@ -8397,15 +9986,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %18
+ThrowNullRef6:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8418,8 +10007,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
@@ -8453,15 +10042,15 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
@@ -8473,7 +10062,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8481,7 +10070,7 @@ ThrowNullRef1:                                    ; preds = %1
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
 Failed to read Dictionary`2.System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
@@ -8506,8 +10095,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
@@ -8524,8 +10113,8 @@ entry:
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -8544,7 +10133,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8577,8 +10166,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = load i64, i64* %arg2
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = trunc i32 %3 to i8
@@ -8634,46 +10223,46 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
   %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
-  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
-  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
-  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
@@ -8684,27 +10273,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %20
+ThrowNullRef12:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8717,8 +10306,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -8756,22 +10345,22 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
   %9 = load i64, i64 addrspace(1)* %8, align 8
   %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
   %13 = load i64, i64 addrspace(1)* %12, align 8
   %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %11
   %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
@@ -8788,11 +10377,11 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8882,8 +10471,8 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
@@ -8900,8 +10489,8 @@ entry:
 ; <label>:8                                       ; preds = %1
   %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
   %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
@@ -8911,15 +10500,15 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
   %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
   %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
-  br i1 %NullCheck6, label %21, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
@@ -8946,15 +10535,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8992,15 +10581,15 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
   store i8 %3, i8 addrspace(1)* %5
   %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
@@ -9011,7 +10600,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9027,8 +10616,8 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -9041,8 +10630,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
@@ -9058,7 +10647,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9080,8 +10669,8 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
@@ -9096,8 +10685,8 @@ entry:
 ; <label>:12                                      ; preds = %6
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
@@ -9112,8 +10701,8 @@ entry:
 ; <label>:21                                      ; preds = %15
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
@@ -9128,8 +10717,8 @@ entry:
 ; <label>:30                                      ; preds = %24
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %31, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
@@ -9144,8 +10733,8 @@ entry:
 ; <label>:39                                      ; preds = %33
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
-  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %40, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %42
 
 ; <label>:42                                      ; preds = %39
   %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
@@ -9164,19 +10753,19 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %21
+ThrowNullRef4:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %30
+ThrowNullRef6:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %39
+ThrowNullRef8:                                    ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9243,8 +10832,8 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
@@ -9264,57 +10853,57 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
   store i8 0, i8 addrspace(1)* %2
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
   store i8 0, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
   store i8 0, i8 addrspace(1)* %17
   %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
   store i8 0, i8 addrspace(1)* %20
   %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
-  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
@@ -9325,31 +10914,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %19
+ThrowNullRef14:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9367,8 +10956,8 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
@@ -9380,8 +10969,8 @@ entry:
 
 ; <label>:9                                       ; preds = %4
   %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %9
   %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
@@ -9395,7 +10984,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef2:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9420,8 +11009,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
@@ -9512,8 +11101,8 @@ entry:
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
@@ -9524,8 +11113,8 @@ entry:
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = load i64, i64 addrspace(1)* %12
@@ -9537,8 +11126,8 @@ entry:
   %20 = load i64, i64* %19
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
-  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %13
   %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
@@ -9555,8 +11144,8 @@ entry:
 ; <label>:30                                      ; preds = %25
   %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %32 = load i32, i32* %arg2
-  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
-  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
@@ -9570,15 +11159,15 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %30
+ThrowNullRef2:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9622,87 +11211,87 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
   %10 = load i8, i8 addrspace(1)* %9, align 8
   %11 = zext i8 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %8
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
   store i8 %12, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
   %19 = load i8, i8 addrspace(1)* %18, align 8
   %20 = zext i8 %19 to i32
   %21 = trunc i32 %20 to i8
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
   store i8 %21, i8 addrspace(1)* %23
   %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
   %28 = load i8, i8 addrspace(1)* %27, align 8
   %29 = zext i8 %28 to i32
   %30 = trunc i32 %29 to i8
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
-  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %31
 
 ; <label>:31                                      ; preds = %26
   %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
   store i8 %30, i8 addrspace(1)* %32
   %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
-  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
-  br i1 %NullCheck14, label %40, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %40
 
 ; <label>:40                                      ; preds = %35
   %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
   store i8 %39, i8 addrspace(1)* %41
   %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
-  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %44
 
 ; <label>:44                                      ; preds = %40
   %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
   %46 = load i8, i8 addrspace(1)* %45, align 8
   %47 = zext i8 %46 to i32
   %48 = trunc i32 %47 to i8
-  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
   store i8 %48, i8 addrspace(1)* %50
   %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
-  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
@@ -9713,29 +11302,29 @@ entry:
 ; <label>:56                                      ; preds = %52
   %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
-  br i1 %NullCheck22, label %59, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
   %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
   %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
-  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
-  br i1 %NullCheck24, label %63, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
   %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
-  br i1 %NullCheck26, label %66, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
   %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
-  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
-  br i1 %NullCheck28, label %69, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %69
 
 ; <label>:69                                      ; preds = %66
   %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
@@ -9744,15 +11333,15 @@ entry:
 
 ; <label>:71                                      ; preds = %105
   %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
-  br i1 %NullCheck34, label %73, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %73
 
 ; <label>:73                                      ; preds = %71
   %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
   %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
   %76 = load i32, i32* %loc0
-  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
-  br i1 %NullCheck36, label %77, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
@@ -9766,8 +11355,8 @@ entry:
 
 ; <label>:83                                      ; preds = %77
   %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
-  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
@@ -9775,14 +11364,14 @@ entry:
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
   %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
-  br i1 %NullCheck40, label %91, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
 ; <label>:91                                      ; preds = %85
   %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
   %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
-  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck42, label %94, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %94
 
 ; <label>:94                                      ; preds = %91
   %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
@@ -9798,14 +11387,14 @@ entry:
 ; <label>:99                                      ; preds = %69, %96
   %100 = load i32, i32* %loc0
   %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
-  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %102
 
 ; <label>:102                                     ; preds = %99
   %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
   %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
-  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
-  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
@@ -9819,87 +11408,87 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %26
+ThrowNullRef10:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %31
+ThrowNullRef12:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %35
+ThrowNullRef14:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %40
+ThrowNullRef16:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %56
+ThrowNullRef22:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %59
+ThrowNullRef24:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %63
+ThrowNullRef26:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %66
+ThrowNullRef28:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %102
+ThrowNullRef32:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %71
+ThrowNullRef34:                                   ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %73
+ThrowNullRef36:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %83
+ThrowNullRef38:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %85
+ThrowNullRef40:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %91
+ThrowNullRef42:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9943,15 +11532,15 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
   %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
@@ -9961,28 +11550,28 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
   %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %12
   %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
   %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
   %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
-  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
@@ -9993,23 +11582,23 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %12
+ThrowNullRef6:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10031,15 +11620,15 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
   %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = load i64, i64 addrspace(1)* %7
@@ -10077,13 +11666,13 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[loadElem]
+Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -10111,8 +11700,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1

--- a/test/BaseLine/JIT/CodeGenBringUpTests/AsgOr1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/AsgOr1.error.txt
@@ -25,8 +25,8 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
@@ -40,8 +40,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
   %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
@@ -75,7 +75,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -90,8 +90,8 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %NullCheck = icmp ne i8 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = load i8, i8 addrspace(1)* %0, align 8
@@ -125,8 +125,8 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
@@ -159,8 +159,8 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -184,8 +184,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
   store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
@@ -195,8 +195,8 @@ entry:
 ; <label>:4                                       ; preds = %1
   %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
   %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
@@ -206,8 +206,8 @@ entry:
   %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
@@ -221,14 +221,14 @@ entry:
 
 ; <label>:17                                      ; preds = %14
   %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
   %21 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
@@ -238,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -249,8 +249,8 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
@@ -261,27 +261,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %30
+ThrowNullRef10:                                   ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -301,7 +301,89 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
-Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
+Successfully read AppDomainSetup.GetUnsecureApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.GetUnsecureApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %NullCheck = icmp eq %"System.String[]" addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %BoundsCheck = icmp uge i64 0, %5
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %6
+
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 3, i32 0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
+  ret %System.String addrspace(1)* %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_Value using LLILCJit
+Successfully read AppDomainSetup.get_Value
+
+define %"System.String[]" addrspace(1)* @AppDomainSetup.get_Value(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.String[]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 18)
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.String[]" addrspace(1)* addrspace(1)*, %"System.String[]" addrspace(1)*)*)(%"System.String[]" addrspace(1)* addrspace(1)* %9, %"System.String[]" addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %11, i32 0, i32 1
+  %14 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %13, align 8
+  ret %"System.String[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -319,8 +401,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -368,16 +450,16 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
   %5 = load i32, i32 addrspace(1)* %4
   %6 = sub i32 %5, 1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -389,7 +471,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -421,8 +503,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
@@ -456,8 +538,8 @@ entry:
 ; <label>:27                                      ; preds = %19
   %28 = load i32, i32* %arg1
   %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
-  br i1 %NullCheck2, label %30, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %29, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %30
 
 ; <label>:30                                      ; preds = %27
   %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
@@ -493,8 +575,8 @@ entry:
 ; <label>:49                                      ; preds = %46
   %50 = load i32, i32* %arg2
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck4, label %52, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
@@ -517,11 +599,11 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %27
+ThrowNullRef2:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %49
+ThrowNullRef4:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -544,16 +626,16 @@ entry:
   %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %0)
   store %System.String addrspace(1)* %1, %System.String addrspace(1)** %loc0
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 2
   %5 = bitcast [0 x i16] addrspace(1)* %4 to i16 addrspace(1)*
   store i16 addrspace(1)* %5, i16 addrspace(1)** %loc1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %3
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2
@@ -580,7 +662,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -691,15 +773,15 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %NullCheck132 = icmp ne i8* %21, null
-  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+  %NullCheck131 = icmp eq i8* %21, null
+  br i1 %NullCheck131, label %ThrowNullRef132, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = load i8, i8* %21, align 8
   %24 = zext i8 %23 to i32
   %25 = trunc i32 %24 to i8
-  %NullCheck134 = icmp ne i8* %20, null
-  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+  %NullCheck133 = icmp eq i8* %20, null
+  br i1 %NullCheck133, label %ThrowNullRef134, label %26
 
 ; <label>:26                                      ; preds = %22
   store i8 %25, i8* %20, align 8
@@ -709,16 +791,16 @@ entry:
   %28 = load i8*, i8** %arg0
   %29 = load i8*, i8** %arg1
   %30 = bitcast i8* %29 to i16*
-  %NullCheck128 = icmp ne i16* %30, null
-  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+  %NullCheck127 = icmp eq i16* %30, null
+  br i1 %NullCheck127, label %ThrowNullRef128, label %31
 
 ; <label>:31                                      ; preds = %27
   %32 = load i16, i16* %30, align 8
   %33 = sext i16 %32 to i32
   %34 = bitcast i8* %28 to i16*
   %35 = trunc i32 %33 to i16
-  %NullCheck130 = icmp ne i16* %34, null
-  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+  %NullCheck129 = icmp eq i16* %34, null
+  br i1 %NullCheck129, label %ThrowNullRef130, label %36
 
 ; <label>:36                                      ; preds = %31
   store i16 %35, i16* %34, align 8
@@ -728,16 +810,16 @@ entry:
   %38 = load i8*, i8** %arg0
   %39 = load i8*, i8** %arg1
   %40 = bitcast i8* %39 to i16*
-  %NullCheck120 = icmp ne i16* %40, null
-  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+  %NullCheck119 = icmp eq i16* %40, null
+  br i1 %NullCheck119, label %ThrowNullRef120, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i16, i16* %40, align 8
   %43 = sext i16 %42 to i32
   %44 = bitcast i8* %38 to i16*
   %45 = trunc i32 %43 to i16
-  %NullCheck122 = icmp ne i16* %44, null
-  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+  %NullCheck121 = icmp eq i16* %44, null
+  br i1 %NullCheck121, label %ThrowNullRef122, label %46
 
 ; <label>:46                                      ; preds = %41
   store i16 %45, i16* %44, align 8
@@ -745,15 +827,15 @@ entry:
   %48 = getelementptr inbounds i8, i8* %47, i64 2
   %49 = load i8*, i8** %arg1
   %50 = getelementptr inbounds i8, i8* %49, i64 2
-  %NullCheck124 = icmp ne i8* %50, null
-  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+  %NullCheck123 = icmp eq i8* %50, null
+  br i1 %NullCheck123, label %ThrowNullRef124, label %51
 
 ; <label>:51                                      ; preds = %46
   %52 = load i8, i8* %50, align 8
   %53 = zext i8 %52 to i32
   %54 = trunc i32 %53 to i8
-  %NullCheck126 = icmp ne i8* %48, null
-  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+  %NullCheck125 = icmp eq i8* %48, null
+  br i1 %NullCheck125, label %ThrowNullRef126, label %55
 
 ; <label>:55                                      ; preds = %51
   store i8 %54, i8* %48, align 8
@@ -763,14 +845,14 @@ entry:
   %57 = load i8*, i8** %arg0
   %58 = load i8*, i8** %arg1
   %59 = bitcast i8* %58 to i32*
-  %NullCheck116 = icmp ne i32* %59, null
-  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+  %NullCheck115 = icmp eq i32* %59, null
+  br i1 %NullCheck115, label %ThrowNullRef116, label %60
 
 ; <label>:60                                      ; preds = %56
   %61 = load i32, i32* %59, align 8
   %62 = bitcast i8* %57 to i32*
-  %NullCheck118 = icmp ne i32* %62, null
-  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+  %NullCheck117 = icmp eq i32* %62, null
+  br i1 %NullCheck117, label %ThrowNullRef118, label %63
 
 ; <label>:63                                      ; preds = %60
   store i32 %61, i32* %62, align 8
@@ -780,14 +862,14 @@ entry:
   %65 = load i8*, i8** %arg0
   %66 = load i8*, i8** %arg1
   %67 = bitcast i8* %66 to i32*
-  %NullCheck108 = icmp ne i32* %67, null
-  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+  %NullCheck107 = icmp eq i32* %67, null
+  br i1 %NullCheck107, label %ThrowNullRef108, label %68
 
 ; <label>:68                                      ; preds = %64
   %69 = load i32, i32* %67, align 8
   %70 = bitcast i8* %65 to i32*
-  %NullCheck110 = icmp ne i32* %70, null
-  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+  %NullCheck109 = icmp eq i32* %70, null
+  br i1 %NullCheck109, label %ThrowNullRef110, label %71
 
 ; <label>:71                                      ; preds = %68
   store i32 %69, i32* %70, align 8
@@ -795,15 +877,15 @@ entry:
   %73 = getelementptr inbounds i8, i8* %72, i64 4
   %74 = load i8*, i8** %arg1
   %75 = getelementptr inbounds i8, i8* %74, i64 4
-  %NullCheck112 = icmp ne i8* %75, null
-  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+  %NullCheck111 = icmp eq i8* %75, null
+  br i1 %NullCheck111, label %ThrowNullRef112, label %76
 
 ; <label>:76                                      ; preds = %71
   %77 = load i8, i8* %75, align 8
   %78 = zext i8 %77 to i32
   %79 = trunc i32 %78 to i8
-  %NullCheck114 = icmp ne i8* %73, null
-  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+  %NullCheck113 = icmp eq i8* %73, null
+  br i1 %NullCheck113, label %ThrowNullRef114, label %80
 
 ; <label>:80                                      ; preds = %76
   store i8 %79, i8* %73, align 8
@@ -813,14 +895,14 @@ entry:
   %82 = load i8*, i8** %arg0
   %83 = load i8*, i8** %arg1
   %84 = bitcast i8* %83 to i32*
-  %NullCheck100 = icmp ne i32* %84, null
-  br i1 %NullCheck100, label %85, label %ThrowNullRef99
+  %NullCheck99 = icmp eq i32* %84, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %85
 
 ; <label>:85                                      ; preds = %81
   %86 = load i32, i32* %84, align 8
   %87 = bitcast i8* %82 to i32*
-  %NullCheck102 = icmp ne i32* %87, null
-  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+  %NullCheck101 = icmp eq i32* %87, null
+  br i1 %NullCheck101, label %ThrowNullRef102, label %88
 
 ; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
@@ -829,16 +911,16 @@ entry:
   %91 = load i8*, i8** %arg1
   %92 = getelementptr inbounds i8, i8* %91, i64 4
   %93 = bitcast i8* %92 to i16*
-  %NullCheck104 = icmp ne i16* %93, null
-  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+  %NullCheck103 = icmp eq i16* %93, null
+  br i1 %NullCheck103, label %ThrowNullRef104, label %94
 
 ; <label>:94                                      ; preds = %88
   %95 = load i16, i16* %93, align 8
   %96 = sext i16 %95 to i32
   %97 = bitcast i8* %90 to i16*
   %98 = trunc i32 %96 to i16
-  %NullCheck106 = icmp ne i16* %97, null
-  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+  %NullCheck105 = icmp eq i16* %97, null
+  br i1 %NullCheck105, label %ThrowNullRef106, label %99
 
 ; <label>:99                                      ; preds = %94
   store i16 %98, i16* %97, align 8
@@ -848,14 +930,14 @@ entry:
   %101 = load i8*, i8** %arg0
   %102 = load i8*, i8** %arg1
   %103 = bitcast i8* %102 to i32*
-  %NullCheck88 = icmp ne i32* %103, null
-  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+  %NullCheck87 = icmp eq i32* %103, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %104
 
 ; <label>:104                                     ; preds = %100
   %105 = load i32, i32* %103, align 8
   %106 = bitcast i8* %101 to i32*
-  %NullCheck90 = icmp ne i32* %106, null
-  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+  %NullCheck89 = icmp eq i32* %106, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %107
 
 ; <label>:107                                     ; preds = %104
   store i32 %105, i32* %106, align 8
@@ -864,16 +946,16 @@ entry:
   %110 = load i8*, i8** %arg1
   %111 = getelementptr inbounds i8, i8* %110, i64 4
   %112 = bitcast i8* %111 to i16*
-  %NullCheck92 = icmp ne i16* %112, null
-  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+  %NullCheck91 = icmp eq i16* %112, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %113
 
 ; <label>:113                                     ; preds = %107
   %114 = load i16, i16* %112, align 8
   %115 = sext i16 %114 to i32
   %116 = bitcast i8* %109 to i16*
   %117 = trunc i32 %115 to i16
-  %NullCheck94 = icmp ne i16* %116, null
-  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+  %NullCheck93 = icmp eq i16* %116, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %118
 
 ; <label>:118                                     ; preds = %113
   store i16 %117, i16* %116, align 8
@@ -881,15 +963,15 @@ entry:
   %120 = getelementptr inbounds i8, i8* %119, i64 6
   %121 = load i8*, i8** %arg1
   %122 = getelementptr inbounds i8, i8* %121, i64 6
-  %NullCheck96 = icmp ne i8* %122, null
-  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+  %NullCheck95 = icmp eq i8* %122, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %123
 
 ; <label>:123                                     ; preds = %118
   %124 = load i8, i8* %122, align 8
   %125 = zext i8 %124 to i32
   %126 = trunc i32 %125 to i8
-  %NullCheck98 = icmp ne i8* %120, null
-  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+  %NullCheck97 = icmp eq i8* %120, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %127
 
 ; <label>:127                                     ; preds = %123
   store i8 %126, i8* %120, align 8
@@ -899,14 +981,14 @@ entry:
   %129 = load i8*, i8** %arg0
   %130 = load i8*, i8** %arg1
   %131 = bitcast i8* %130 to i64*
-  %NullCheck84 = icmp ne i64* %131, null
-  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+  %NullCheck83 = icmp eq i64* %131, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %132
 
 ; <label>:132                                     ; preds = %128
   %133 = load i64, i64* %131, align 8
   %134 = bitcast i8* %129 to i64*
-  %NullCheck86 = icmp ne i64* %134, null
-  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+  %NullCheck85 = icmp eq i64* %134, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %135
 
 ; <label>:135                                     ; preds = %132
   store i64 %133, i64* %134, align 8
@@ -916,14 +998,14 @@ entry:
   %137 = load i8*, i8** %arg0
   %138 = load i8*, i8** %arg1
   %139 = bitcast i8* %138 to i64*
-  %NullCheck76 = icmp ne i64* %139, null
-  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+  %NullCheck75 = icmp eq i64* %139, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %140
 
 ; <label>:140                                     ; preds = %136
   %141 = load i64, i64* %139, align 8
   %142 = bitcast i8* %137 to i64*
-  %NullCheck78 = icmp ne i64* %142, null
-  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+  %NullCheck77 = icmp eq i64* %142, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %143
 
 ; <label>:143                                     ; preds = %140
   store i64 %141, i64* %142, align 8
@@ -931,15 +1013,15 @@ entry:
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %NullCheck80 = icmp ne i8* %147, null
-  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+  %NullCheck79 = icmp eq i8* %147, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %148
 
 ; <label>:148                                     ; preds = %143
   %149 = load i8, i8* %147, align 8
   %150 = zext i8 %149 to i32
   %151 = trunc i32 %150 to i8
-  %NullCheck82 = icmp ne i8* %145, null
-  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+  %NullCheck81 = icmp eq i8* %145, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %152
 
 ; <label>:152                                     ; preds = %148
   store i8 %151, i8* %145, align 8
@@ -949,14 +1031,14 @@ entry:
   %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
   %156 = bitcast i8* %155 to i64*
-  %NullCheck68 = icmp ne i64* %156, null
-  br i1 %NullCheck68, label %157, label %ThrowNullRef67
+  %NullCheck67 = icmp eq i64* %156, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %157
 
 ; <label>:157                                     ; preds = %153
   %158 = load i64, i64* %156, align 8
   %159 = bitcast i8* %154 to i64*
-  %NullCheck70 = icmp ne i64* %159, null
-  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+  %NullCheck69 = icmp eq i64* %159, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %160
 
 ; <label>:160                                     ; preds = %157
   store i64 %158, i64* %159, align 8
@@ -965,16 +1047,16 @@ entry:
   %163 = load i8*, i8** %arg1
   %164 = getelementptr inbounds i8, i8* %163, i64 8
   %165 = bitcast i8* %164 to i16*
-  %NullCheck72 = icmp ne i16* %165, null
-  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+  %NullCheck71 = icmp eq i16* %165, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %166
 
 ; <label>:166                                     ; preds = %160
   %167 = load i16, i16* %165, align 8
   %168 = sext i16 %167 to i32
   %169 = bitcast i8* %162 to i16*
   %170 = trunc i32 %168 to i16
-  %NullCheck74 = icmp ne i16* %169, null
-  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+  %NullCheck73 = icmp eq i16* %169, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %171
 
 ; <label>:171                                     ; preds = %166
   store i16 %170, i16* %169, align 8
@@ -984,14 +1066,14 @@ entry:
   %173 = load i8*, i8** %arg0
   %174 = load i8*, i8** %arg1
   %175 = bitcast i8* %174 to i64*
-  %NullCheck56 = icmp ne i64* %175, null
-  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+  %NullCheck55 = icmp eq i64* %175, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %176
 
 ; <label>:176                                     ; preds = %172
   %177 = load i64, i64* %175, align 8
   %178 = bitcast i8* %173 to i64*
-  %NullCheck58 = icmp ne i64* %178, null
-  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+  %NullCheck57 = icmp eq i64* %178, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %179
 
 ; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
@@ -1000,16 +1082,16 @@ entry:
   %182 = load i8*, i8** %arg1
   %183 = getelementptr inbounds i8, i8* %182, i64 8
   %184 = bitcast i8* %183 to i16*
-  %NullCheck60 = icmp ne i16* %184, null
-  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+  %NullCheck59 = icmp eq i16* %184, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %185
 
 ; <label>:185                                     ; preds = %179
   %186 = load i16, i16* %184, align 8
   %187 = sext i16 %186 to i32
   %188 = bitcast i8* %181 to i16*
   %189 = trunc i32 %187 to i16
-  %NullCheck62 = icmp ne i16* %188, null
-  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+  %NullCheck61 = icmp eq i16* %188, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %190
 
 ; <label>:190                                     ; preds = %185
   store i16 %189, i16* %188, align 8
@@ -1017,15 +1099,15 @@ entry:
   %192 = getelementptr inbounds i8, i8* %191, i64 10
   %193 = load i8*, i8** %arg1
   %194 = getelementptr inbounds i8, i8* %193, i64 10
-  %NullCheck64 = icmp ne i8* %194, null
-  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+  %NullCheck63 = icmp eq i8* %194, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %195
 
 ; <label>:195                                     ; preds = %190
   %196 = load i8, i8* %194, align 8
   %197 = zext i8 %196 to i32
   %198 = trunc i32 %197 to i8
-  %NullCheck66 = icmp ne i8* %192, null
-  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+  %NullCheck65 = icmp eq i8* %192, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %199
 
 ; <label>:199                                     ; preds = %195
   store i8 %198, i8* %192, align 8
@@ -1035,14 +1117,14 @@ entry:
   %201 = load i8*, i8** %arg0
   %202 = load i8*, i8** %arg1
   %203 = bitcast i8* %202 to i64*
-  %NullCheck48 = icmp ne i64* %203, null
-  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+  %NullCheck47 = icmp eq i64* %203, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %204
 
 ; <label>:204                                     ; preds = %200
   %205 = load i64, i64* %203, align 8
   %206 = bitcast i8* %201 to i64*
-  %NullCheck50 = icmp ne i64* %206, null
-  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+  %NullCheck49 = icmp eq i64* %206, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %207
 
 ; <label>:207                                     ; preds = %204
   store i64 %205, i64* %206, align 8
@@ -1051,14 +1133,14 @@ entry:
   %210 = load i8*, i8** %arg1
   %211 = getelementptr inbounds i8, i8* %210, i64 8
   %212 = bitcast i8* %211 to i32*
-  %NullCheck52 = icmp ne i32* %212, null
-  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+  %NullCheck51 = icmp eq i32* %212, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %213
 
 ; <label>:213                                     ; preds = %207
   %214 = load i32, i32* %212, align 8
   %215 = bitcast i8* %209 to i32*
-  %NullCheck54 = icmp ne i32* %215, null
-  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+  %NullCheck53 = icmp eq i32* %215, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %216
 
 ; <label>:216                                     ; preds = %213
   store i32 %214, i32* %215, align 8
@@ -1068,14 +1150,14 @@ entry:
   %218 = load i8*, i8** %arg0
   %219 = load i8*, i8** %arg1
   %220 = bitcast i8* %219 to i64*
-  %NullCheck36 = icmp ne i64* %220, null
-  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64* %220, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %221
 
 ; <label>:221                                     ; preds = %217
   %222 = load i64, i64* %220, align 8
   %223 = bitcast i8* %218 to i64*
-  %NullCheck38 = icmp ne i64* %223, null
-  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+  %NullCheck37 = icmp eq i64* %223, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %224
 
 ; <label>:224                                     ; preds = %221
   store i64 %222, i64* %223, align 8
@@ -1084,14 +1166,14 @@ entry:
   %227 = load i8*, i8** %arg1
   %228 = getelementptr inbounds i8, i8* %227, i64 8
   %229 = bitcast i8* %228 to i32*
-  %NullCheck40 = icmp ne i32* %229, null
-  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i32* %229, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %230
 
 ; <label>:230                                     ; preds = %224
   %231 = load i32, i32* %229, align 8
   %232 = bitcast i8* %226 to i32*
-  %NullCheck42 = icmp ne i32* %232, null
-  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+  %NullCheck41 = icmp eq i32* %232, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %233
 
 ; <label>:233                                     ; preds = %230
   store i32 %231, i32* %232, align 8
@@ -1099,15 +1181,15 @@ entry:
   %235 = getelementptr inbounds i8, i8* %234, i64 12
   %236 = load i8*, i8** %arg1
   %237 = getelementptr inbounds i8, i8* %236, i64 12
-  %NullCheck44 = icmp ne i8* %237, null
-  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i8* %237, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %238
 
 ; <label>:238                                     ; preds = %233
   %239 = load i8, i8* %237, align 8
   %240 = zext i8 %239 to i32
   %241 = trunc i32 %240 to i8
-  %NullCheck46 = icmp ne i8* %235, null
-  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+  %NullCheck45 = icmp eq i8* %235, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %242
 
 ; <label>:242                                     ; preds = %238
   store i8 %241, i8* %235, align 8
@@ -1117,14 +1199,14 @@ entry:
   %244 = load i8*, i8** %arg0
   %245 = load i8*, i8** %arg1
   %246 = bitcast i8* %245 to i64*
-  %NullCheck24 = icmp ne i64* %246, null
-  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64* %246, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %247
 
 ; <label>:247                                     ; preds = %243
   %248 = load i64, i64* %246, align 8
   %249 = bitcast i8* %244 to i64*
-  %NullCheck26 = icmp ne i64* %249, null
-  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64* %249, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %250
 
 ; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
@@ -1133,14 +1215,14 @@ entry:
   %253 = load i8*, i8** %arg1
   %254 = getelementptr inbounds i8, i8* %253, i64 8
   %255 = bitcast i8* %254 to i32*
-  %NullCheck28 = icmp ne i32* %255, null
-  br i1 %NullCheck28, label %256, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i32* %255, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %256
 
 ; <label>:256                                     ; preds = %250
   %257 = load i32, i32* %255, align 8
   %258 = bitcast i8* %252 to i32*
-  %NullCheck30 = icmp ne i32* %258, null
-  br i1 %NullCheck30, label %259, label %ThrowNullRef29
+  %NullCheck29 = icmp eq i32* %258, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %259
 
 ; <label>:259                                     ; preds = %256
   store i32 %257, i32* %258, align 8
@@ -1149,16 +1231,16 @@ entry:
   %262 = load i8*, i8** %arg1
   %263 = getelementptr inbounds i8, i8* %262, i64 12
   %264 = bitcast i8* %263 to i16*
-  %NullCheck32 = icmp ne i16* %264, null
-  br i1 %NullCheck32, label %265, label %ThrowNullRef31
+  %NullCheck31 = icmp eq i16* %264, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %265
 
 ; <label>:265                                     ; preds = %259
   %266 = load i16, i16* %264, align 8
   %267 = sext i16 %266 to i32
   %268 = bitcast i8* %261 to i16*
   %269 = trunc i32 %267 to i16
-  %NullCheck34 = icmp ne i16* %268, null
-  br i1 %NullCheck34, label %270, label %ThrowNullRef33
+  %NullCheck33 = icmp eq i16* %268, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %270
 
 ; <label>:270                                     ; preds = %265
   store i16 %269, i16* %268, align 8
@@ -1168,14 +1250,14 @@ entry:
   %272 = load i8*, i8** %arg0
   %273 = load i8*, i8** %arg1
   %274 = bitcast i8* %273 to i64*
-  %NullCheck8 = icmp ne i64* %274, null
-  br i1 %NullCheck8, label %275, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64* %274, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %275
 
 ; <label>:275                                     ; preds = %271
   %276 = load i64, i64* %274, align 8
   %277 = bitcast i8* %272 to i64*
-  %NullCheck10 = icmp ne i64* %277, null
-  br i1 %NullCheck10, label %278, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %277, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %278
 
 ; <label>:278                                     ; preds = %275
   store i64 %276, i64* %277, align 8
@@ -1184,14 +1266,14 @@ entry:
   %281 = load i8*, i8** %arg1
   %282 = getelementptr inbounds i8, i8* %281, i64 8
   %283 = bitcast i8* %282 to i32*
-  %NullCheck12 = icmp ne i32* %283, null
-  br i1 %NullCheck12, label %284, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i32* %283, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %284
 
 ; <label>:284                                     ; preds = %278
   %285 = load i32, i32* %283, align 8
   %286 = bitcast i8* %280 to i32*
-  %NullCheck14 = icmp ne i32* %286, null
-  br i1 %NullCheck14, label %287, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i32* %286, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %287
 
 ; <label>:287                                     ; preds = %284
   store i32 %285, i32* %286, align 8
@@ -1200,16 +1282,16 @@ entry:
   %290 = load i8*, i8** %arg1
   %291 = getelementptr inbounds i8, i8* %290, i64 12
   %292 = bitcast i8* %291 to i16*
-  %NullCheck16 = icmp ne i16* %292, null
-  br i1 %NullCheck16, label %293, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i16* %292, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %293
 
 ; <label>:293                                     ; preds = %287
   %294 = load i16, i16* %292, align 8
   %295 = sext i16 %294 to i32
   %296 = bitcast i8* %289 to i16*
   %297 = trunc i32 %295 to i16
-  %NullCheck18 = icmp ne i16* %296, null
-  br i1 %NullCheck18, label %298, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i16* %296, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %298
 
 ; <label>:298                                     ; preds = %293
   store i16 %297, i16* %296, align 8
@@ -1217,15 +1299,15 @@ entry:
   %300 = getelementptr inbounds i8, i8* %299, i64 14
   %301 = load i8*, i8** %arg1
   %302 = getelementptr inbounds i8, i8* %301, i64 14
-  %NullCheck20 = icmp ne i8* %302, null
-  br i1 %NullCheck20, label %303, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i8* %302, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %303
 
 ; <label>:303                                     ; preds = %298
   %304 = load i8, i8* %302, align 8
   %305 = zext i8 %304 to i32
   %306 = trunc i32 %305 to i8
-  %NullCheck22 = icmp ne i8* %300, null
-  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i8* %300, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %307
 
 ; <label>:307                                     ; preds = %303
   store i8 %306, i8* %300, align 8
@@ -1235,14 +1317,14 @@ entry:
   %309 = load i8*, i8** %arg0
   %310 = load i8*, i8** %arg1
   %311 = bitcast i8* %310 to i64*
-  %NullCheck = icmp ne i64* %311, null
-  br i1 %NullCheck, label %312, label %ThrowNullRef
+  %NullCheck = icmp eq i64* %311, null
+  br i1 %NullCheck, label %ThrowNullRef, label %312
 
 ; <label>:312                                     ; preds = %308
   %313 = load i64, i64* %311, align 8
   %314 = bitcast i8* %309 to i64*
-  %NullCheck2 = icmp ne i64* %314, null
-  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64* %314, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %315
 
 ; <label>:315                                     ; preds = %312
   store i64 %313, i64* %314, align 8
@@ -1251,14 +1333,14 @@ entry:
   %318 = load i8*, i8** %arg1
   %319 = getelementptr inbounds i8, i8* %318, i64 8
   %320 = bitcast i8* %319 to i64*
-  %NullCheck4 = icmp ne i64* %320, null
-  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64* %320, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %321
 
 ; <label>:321                                     ; preds = %315
   %322 = load i64, i64* %320, align 8
   %323 = bitcast i8* %317 to i64*
-  %NullCheck6 = icmp ne i64* %323, null
-  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64* %323, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %324
 
 ; <label>:324                                     ; preds = %321
   store i64 %322, i64* %323, align 8
@@ -1286,15 +1368,15 @@ entry:
 ; <label>:338                                     ; preds = %333
   %339 = load i8*, i8** %arg0
   %340 = load i8*, i8** %arg1
-  %NullCheck136 = icmp ne i8* %340, null
-  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+  %NullCheck135 = icmp eq i8* %340, null
+  br i1 %NullCheck135, label %ThrowNullRef136, label %341
 
 ; <label>:341                                     ; preds = %338
   %342 = load i8, i8* %340, align 8
   %343 = zext i8 %342 to i32
   %344 = trunc i32 %343 to i8
-  %NullCheck138 = icmp ne i8* %339, null
-  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+  %NullCheck137 = icmp eq i8* %339, null
+  br i1 %NullCheck137, label %ThrowNullRef138, label %345
 
 ; <label>:345                                     ; preds = %341
   store i8 %344, i8* %339, align 8
@@ -1317,16 +1399,16 @@ entry:
   %357 = load i8*, i8** %arg0
   %358 = load i8*, i8** %arg1
   %359 = bitcast i8* %358 to i16*
-  %NullCheck140 = icmp ne i16* %359, null
-  br i1 %NullCheck140, label %360, label %ThrowNullRef139
+  %NullCheck139 = icmp eq i16* %359, null
+  br i1 %NullCheck139, label %ThrowNullRef140, label %360
 
 ; <label>:360                                     ; preds = %356
   %361 = load i16, i16* %359, align 8
   %362 = sext i16 %361 to i32
   %363 = bitcast i8* %357 to i16*
   %364 = trunc i32 %362 to i16
-  %NullCheck142 = icmp ne i16* %363, null
-  br i1 %NullCheck142, label %365, label %ThrowNullRef141
+  %NullCheck141 = icmp eq i16* %363, null
+  br i1 %NullCheck141, label %ThrowNullRef142, label %365
 
 ; <label>:365                                     ; preds = %360
   store i16 %364, i16* %363, align 8
@@ -1352,14 +1434,14 @@ entry:
   %378 = load i8*, i8** %arg0
   %379 = load i8*, i8** %arg1
   %380 = bitcast i8* %379 to i32*
-  %NullCheck144 = icmp ne i32* %380, null
-  br i1 %NullCheck144, label %381, label %ThrowNullRef143
+  %NullCheck143 = icmp eq i32* %380, null
+  br i1 %NullCheck143, label %ThrowNullRef144, label %381
 
 ; <label>:381                                     ; preds = %377
   %382 = load i32, i32* %380, align 8
   %383 = bitcast i8* %378 to i32*
-  %NullCheck146 = icmp ne i32* %383, null
-  br i1 %NullCheck146, label %384, label %ThrowNullRef145
+  %NullCheck145 = icmp eq i32* %383, null
+  br i1 %NullCheck145, label %ThrowNullRef146, label %384
 
 ; <label>:384                                     ; preds = %381
   store i32 %382, i32* %383, align 8
@@ -1384,14 +1466,14 @@ entry:
   %395 = load i8*, i8** %arg0
   %396 = load i8*, i8** %arg1
   %397 = bitcast i8* %396 to i64*
-  %NullCheck164 = icmp ne i64* %397, null
-  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+  %NullCheck163 = icmp eq i64* %397, null
+  br i1 %NullCheck163, label %ThrowNullRef164, label %398
 
 ; <label>:398                                     ; preds = %394
   %399 = load i64, i64* %397, align 8
   %400 = bitcast i8* %395 to i64*
-  %NullCheck166 = icmp ne i64* %400, null
-  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+  %NullCheck165 = icmp eq i64* %400, null
+  br i1 %NullCheck165, label %ThrowNullRef166, label %401
 
 ; <label>:401                                     ; preds = %398
   store i64 %399, i64* %400, align 8
@@ -1400,14 +1482,14 @@ entry:
   %404 = load i8*, i8** %arg1
   %405 = getelementptr inbounds i8, i8* %404, i64 8
   %406 = bitcast i8* %405 to i64*
-  %NullCheck168 = icmp ne i64* %406, null
-  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+  %NullCheck167 = icmp eq i64* %406, null
+  br i1 %NullCheck167, label %ThrowNullRef168, label %407
 
 ; <label>:407                                     ; preds = %401
   %408 = load i64, i64* %406, align 8
   %409 = bitcast i8* %403 to i64*
-  %NullCheck170 = icmp ne i64* %409, null
-  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+  %NullCheck169 = icmp eq i64* %409, null
+  br i1 %NullCheck169, label %ThrowNullRef170, label %410
 
 ; <label>:410                                     ; preds = %407
   store i64 %408, i64* %409, align 8
@@ -1437,14 +1519,14 @@ entry:
   %425 = load i8*, i8** %arg0
   %426 = load i8*, i8** %arg1
   %427 = bitcast i8* %426 to i64*
-  %NullCheck148 = icmp ne i64* %427, null
-  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+  %NullCheck147 = icmp eq i64* %427, null
+  br i1 %NullCheck147, label %ThrowNullRef148, label %428
 
 ; <label>:428                                     ; preds = %424
   %429 = load i64, i64* %427, align 8
   %430 = bitcast i8* %425 to i64*
-  %NullCheck150 = icmp ne i64* %430, null
-  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+  %NullCheck149 = icmp eq i64* %430, null
+  br i1 %NullCheck149, label %ThrowNullRef150, label %431
 
 ; <label>:431                                     ; preds = %428
   store i64 %429, i64* %430, align 8
@@ -1466,14 +1548,14 @@ entry:
   %441 = load i8*, i8** %arg0
   %442 = load i8*, i8** %arg1
   %443 = bitcast i8* %442 to i32*
-  %NullCheck152 = icmp ne i32* %443, null
-  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+  %NullCheck151 = icmp eq i32* %443, null
+  br i1 %NullCheck151, label %ThrowNullRef152, label %444
 
 ; <label>:444                                     ; preds = %440
   %445 = load i32, i32* %443, align 8
   %446 = bitcast i8* %441 to i32*
-  %NullCheck154 = icmp ne i32* %446, null
-  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+  %NullCheck153 = icmp eq i32* %446, null
+  br i1 %NullCheck153, label %ThrowNullRef154, label %447
 
 ; <label>:447                                     ; preds = %444
   store i32 %445, i32* %446, align 8
@@ -1495,16 +1577,16 @@ entry:
   %457 = load i8*, i8** %arg0
   %458 = load i8*, i8** %arg1
   %459 = bitcast i8* %458 to i16*
-  %NullCheck156 = icmp ne i16* %459, null
-  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+  %NullCheck155 = icmp eq i16* %459, null
+  br i1 %NullCheck155, label %ThrowNullRef156, label %460
 
 ; <label>:460                                     ; preds = %456
   %461 = load i16, i16* %459, align 8
   %462 = sext i16 %461 to i32
   %463 = bitcast i8* %457 to i16*
   %464 = trunc i32 %462 to i16
-  %NullCheck158 = icmp ne i16* %463, null
-  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+  %NullCheck157 = icmp eq i16* %463, null
+  br i1 %NullCheck157, label %ThrowNullRef158, label %465
 
 ; <label>:465                                     ; preds = %460
   store i16 %464, i16* %463, align 8
@@ -1525,15 +1607,15 @@ entry:
 ; <label>:474                                     ; preds = %470
   %475 = load i8*, i8** %arg0
   %476 = load i8*, i8** %arg1
-  %NullCheck160 = icmp ne i8* %476, null
-  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+  %NullCheck159 = icmp eq i8* %476, null
+  br i1 %NullCheck159, label %ThrowNullRef160, label %477
 
 ; <label>:477                                     ; preds = %474
   %478 = load i8, i8* %476, align 8
   %479 = zext i8 %478 to i32
   %480 = trunc i32 %479 to i8
-  %NullCheck162 = icmp ne i8* %475, null
-  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+  %NullCheck161 = icmp eq i8* %475, null
+  br i1 %NullCheck161, label %ThrowNullRef162, label %481
 
 ; <label>:481                                     ; preds = %477
   store i8 %480, i8* %475, align 8
@@ -1553,343 +1635,343 @@ ThrowNullRef:                                     ; preds = %308
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %312
+ThrowNullRef2:                                    ; preds = %312
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %315
+ThrowNullRef4:                                    ; preds = %315
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %321
+ThrowNullRef6:                                    ; preds = %321
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %271
+ThrowNullRef8:                                    ; preds = %271
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %275
+ThrowNullRef10:                                   ; preds = %275
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %278
+ThrowNullRef12:                                   ; preds = %278
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %284
+ThrowNullRef14:                                   ; preds = %284
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %287
+ThrowNullRef16:                                   ; preds = %287
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %293
+ThrowNullRef18:                                   ; preds = %293
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %298
+ThrowNullRef20:                                   ; preds = %298
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %303
+ThrowNullRef22:                                   ; preds = %303
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %243
+ThrowNullRef24:                                   ; preds = %243
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %247
+ThrowNullRef26:                                   ; preds = %247
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %250
+ThrowNullRef28:                                   ; preds = %250
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %256
+ThrowNullRef30:                                   ; preds = %256
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %259
+ThrowNullRef32:                                   ; preds = %259
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %265
+ThrowNullRef34:                                   ; preds = %265
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %217
+ThrowNullRef36:                                   ; preds = %217
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %221
+ThrowNullRef38:                                   ; preds = %221
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %224
+ThrowNullRef40:                                   ; preds = %224
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %230
+ThrowNullRef42:                                   ; preds = %230
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %233
+ThrowNullRef44:                                   ; preds = %233
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %238
+ThrowNullRef46:                                   ; preds = %238
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %200
+ThrowNullRef48:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %204
+ThrowNullRef50:                                   ; preds = %204
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %207
+ThrowNullRef52:                                   ; preds = %207
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %213
+ThrowNullRef54:                                   ; preds = %213
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %172
+ThrowNullRef56:                                   ; preds = %172
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %176
+ThrowNullRef58:                                   ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %179
+ThrowNullRef60:                                   ; preds = %179
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %185
+ThrowNullRef62:                                   ; preds = %185
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %190
+ThrowNullRef64:                                   ; preds = %190
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %195
+ThrowNullRef66:                                   ; preds = %195
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %153
+ThrowNullRef68:                                   ; preds = %153
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %157
+ThrowNullRef70:                                   ; preds = %157
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %160
+ThrowNullRef72:                                   ; preds = %160
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %166
+ThrowNullRef74:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %136
+ThrowNullRef76:                                   ; preds = %136
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %140
+ThrowNullRef78:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %143
+ThrowNullRef80:                                   ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %148
+ThrowNullRef82:                                   ; preds = %148
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %128
+ThrowNullRef84:                                   ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %132
+ThrowNullRef86:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %100
+ThrowNullRef88:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %104
+ThrowNullRef90:                                   ; preds = %104
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %107
+ThrowNullRef92:                                   ; preds = %107
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %113
+ThrowNullRef94:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %118
+ThrowNullRef96:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %123
+ThrowNullRef98:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %81
+ThrowNullRef100:                                  ; preds = %81
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef101:                                  ; preds = %85
+ThrowNullRef102:                                  ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef103:                                  ; preds = %88
+ThrowNullRef104:                                  ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef105:                                  ; preds = %94
+ThrowNullRef106:                                  ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef107:                                  ; preds = %64
+ThrowNullRef108:                                  ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef109:                                  ; preds = %68
+ThrowNullRef110:                                  ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef111:                                  ; preds = %71
+ThrowNullRef112:                                  ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef113:                                  ; preds = %76
+ThrowNullRef114:                                  ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef115:                                  ; preds = %56
+ThrowNullRef116:                                  ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef117:                                  ; preds = %60
+ThrowNullRef118:                                  ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef119:                                  ; preds = %37
+ThrowNullRef120:                                  ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef121:                                  ; preds = %41
+ThrowNullRef122:                                  ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef123:                                  ; preds = %46
+ThrowNullRef124:                                  ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef125:                                  ; preds = %51
+ThrowNullRef126:                                  ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef127:                                  ; preds = %27
+ThrowNullRef128:                                  ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef129:                                  ; preds = %31
+ThrowNullRef130:                                  ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef131:                                  ; preds = %19
+ThrowNullRef132:                                  ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef133:                                  ; preds = %22
+ThrowNullRef134:                                  ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef135:                                  ; preds = %338
+ThrowNullRef136:                                  ; preds = %338
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef137:                                  ; preds = %341
+ThrowNullRef138:                                  ; preds = %341
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef139:                                  ; preds = %356
+ThrowNullRef140:                                  ; preds = %356
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef141:                                  ; preds = %360
+ThrowNullRef142:                                  ; preds = %360
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef143:                                  ; preds = %377
+ThrowNullRef144:                                  ; preds = %377
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef145:                                  ; preds = %381
+ThrowNullRef146:                                  ; preds = %381
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef147:                                  ; preds = %424
+ThrowNullRef148:                                  ; preds = %424
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef149:                                  ; preds = %428
+ThrowNullRef150:                                  ; preds = %428
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef151:                                  ; preds = %440
+ThrowNullRef152:                                  ; preds = %440
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef153:                                  ; preds = %444
+ThrowNullRef154:                                  ; preds = %444
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef155:                                  ; preds = %456
+ThrowNullRef156:                                  ; preds = %456
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef157:                                  ; preds = %460
+ThrowNullRef158:                                  ; preds = %460
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef159:                                  ; preds = %474
+ThrowNullRef160:                                  ; preds = %474
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef161:                                  ; preds = %477
+ThrowNullRef162:                                  ; preds = %477
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef163:                                  ; preds = %394
+ThrowNullRef164:                                  ; preds = %394
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef165:                                  ; preds = %398
+ThrowNullRef166:                                  ; preds = %398
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef167:                                  ; preds = %401
+ThrowNullRef168:                                  ; preds = %401
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef169:                                  ; preds = %407
+ThrowNullRef170:                                  ; preds = %407
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1939,8 +2021,8 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
-  br i1 %NullCheck, label %22, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %ThrowNullRef, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
@@ -1948,8 +2030,8 @@ entry:
   store i32 %24, i32* %loc0
   %25 = load i32, i32* %loc0
   %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %26, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %27
 
 ; <label>:27                                      ; preds = %22
   %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
@@ -1971,7 +2053,7 @@ ThrowNullRef:                                     ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1989,8 +2071,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -2022,15 +2104,15 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2048,16 +2130,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
   %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
   store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %15
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
@@ -2072,8 +2154,8 @@ entry:
   %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
   %29 = ptrtoint i16 addrspace(1)* %28 to i64
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %19
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
@@ -2089,19 +2171,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2114,8 +2196,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
@@ -2128,7 +2210,7 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[loadElem]
+Failed to read AppDomain.PrepareDataForSetup[storeElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
@@ -2202,8 +2284,8 @@ entry:
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
-  br i1 %NullCheck24, label %27, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = load i64, i64 addrspace(1)* %26
@@ -2218,8 +2300,8 @@ entry:
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
-  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
   %41 = load i64, i64 addrspace(1)* %39
@@ -2236,8 +2318,8 @@ entry:
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
-  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
   %54 = load i64, i64 addrspace(1)* %52
@@ -2252,8 +2334,8 @@ entry:
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
   %67 = load i64, i64 addrspace(1)* %65
@@ -2270,8 +2352,8 @@ entry:
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
-  br i1 %NullCheck16, label %79, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
   %80 = load i64, i64 addrspace(1)* %78
@@ -2286,8 +2368,8 @@ entry:
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
-  br i1 %NullCheck18, label %92, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
   %93 = load i64, i64 addrspace(1)* %91
@@ -2304,8 +2386,8 @@ entry:
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
-  br i1 %NullCheck12, label %105, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = load i64, i64 addrspace(1)* %104
@@ -2320,8 +2402,8 @@ entry:
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
-  br i1 %NullCheck14, label %118, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
   %119 = load i64, i64 addrspace(1)* %117
@@ -2337,8 +2419,8 @@ entry:
 
 ; <label>:128                                     ; preds = %20
   %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
-  br i1 %NullCheck4, label %130, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %129, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %130
 
 ; <label>:130                                     ; preds = %128
   %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
@@ -2346,8 +2428,8 @@ entry:
   %133 = load i16, i16 addrspace(1)* %132, align 8
   %134 = zext i16 %133 to i32
   %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
-  br i1 %NullCheck6, label %136, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %135, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %136
 
 ; <label>:136                                     ; preds = %130
   %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
@@ -2360,8 +2442,8 @@ entry:
 
 ; <label>:143                                     ; preds = %136
   %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
-  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %144, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %145
 
 ; <label>:145                                     ; preds = %143
   %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
@@ -2369,8 +2451,8 @@ entry:
   %148 = load i16, i16 addrspace(1)* %147, align 8
   %149 = zext i16 %148 to i32
   %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %150, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %151
 
 ; <label>:151                                     ; preds = %145
   %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
@@ -2388,8 +2470,8 @@ entry:
 
 ; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
-  br i1 %NullCheck, label %163, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %ThrowNullRef, label %163
 
 ; <label>:163                                     ; preds = %161
   %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
@@ -2399,8 +2481,8 @@ entry:
 
 ; <label>:167                                     ; preds = %163
   %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
-  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %168, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %169
 
 ; <label>:169                                     ; preds = %167
   %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
@@ -2432,55 +2514,55 @@ ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %167
+ThrowNullRef2:                                    ; preds = %167
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %128
+ThrowNullRef4:                                    ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %130
+ThrowNullRef6:                                    ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %143
+ThrowNullRef8:                                    ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %145
+ThrowNullRef10:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %102
+ThrowNullRef12:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %105
+ThrowNullRef14:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %76
+ThrowNullRef16:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %79
+ThrowNullRef18:                                   ; preds = %79
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %50
+ThrowNullRef20:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %53
+ThrowNullRef22:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %24
+ThrowNullRef24:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %27
+ThrowNullRef26:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2503,15 +2585,15 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2519,16 +2601,16 @@ entry:
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
   store i32 %8, i32* %loc0
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
   %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
   store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
@@ -2546,16 +2628,16 @@ entry:
 
 ; <label>:23                                      ; preds = %64
   %24 = load i16*, i16** %loc3
-  %NullCheck12 = icmp ne i16* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i16* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
   store i32 %27, i32* %loc5
   %28 = load i16*, i16** %loc4
-  %NullCheck14 = icmp ne i16* %28, null
-  br i1 %NullCheck14, label %29, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %28, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = load i16, i16* %28, align 8
@@ -2620,15 +2702,15 @@ entry:
 
 ; <label>:67                                      ; preds = %64
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
-  br i1 %NullCheck8, label %69, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %68, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %69
 
 ; <label>:69                                      ; preds = %67
   %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
   %71 = load i32, i32 addrspace(1)* %70
   %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
-  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %73
 
 ; <label>:73                                      ; preds = %69
   %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
@@ -2645,31 +2727,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %67
+ThrowNullRef8:                                    ; preds = %67
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %69
+ThrowNullRef10:                                   ; preds = %69
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2710,14 +2792,14 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
   %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
@@ -2730,14 +2812,14 @@ entry:
 
 ; <label>:11                                      ; preds = %4
   %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
   %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
@@ -2749,14 +2831,14 @@ entry:
 
 ; <label>:22                                      ; preds = %16
   %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
   %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
-  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
-  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
@@ -2804,23 +2886,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2836,7 +2918,280 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[loadElem]
+Successfully read RuntimeType.IsAssignableFrom
+
+define i8 @RuntimeType.IsAssignableFrom(%System.RuntimeType addrspace(1)* %param0, %System.Type addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.RuntimeType addrspace(1)*
+  %arg1 = alloca %System.Type addrspace(1)*
+  %loc0 = alloca %System.RuntimeType addrspace(1)*
+  %loc1 = alloca %"System.Type[]" addrspace(1)*
+  %loc2 = alloca i32
+  store %System.RuntimeType addrspace(1)* %param0, %System.RuntimeType addrspace(1)** %this
+  store %System.Type addrspace(1)* %param1, %System.Type addrspace(1)** %arg1
+  %0 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %1 = icmp ne %System.Type addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i8 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %5 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %6 = bitcast %System.Type addrspace(1)* %4 to %System.Object addrspace(1)*
+  %7 = bitcast %System.RuntimeType addrspace(1)* %5 to %System.Object addrspace(1)*
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %6, %System.Object addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %3
+  ret i8 1
+
+; <label>:12                                      ; preds = %3
+  %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 152
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 32
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
+  %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
+  %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
+  store %System.RuntimeType addrspace(1)* %25, %System.RuntimeType addrspace(1)** %loc0
+  %26 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %27 = icmp eq %System.RuntimeType addrspace(1)* %26, null
+  br i1 %27, label %34, label %28
+
+; <label>:28                                      ; preds = %15
+  %29 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %30 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)*)*)(%System.RuntimeType addrspace(1)* %29, %System.RuntimeType addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+; <label>:34                                      ; preds = %15
+  %35 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %36 = call %System.Reflection.Emit.TypeBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Reflection.Emit.TypeBuilder addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %35)
+  %37 = icmp eq %System.Reflection.Emit.TypeBuilder addrspace(1)* %36, null
+  br i1 %37, label %139, label %38
+
+; <label>:38                                      ; preds = %34
+  %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %42
+
+; <label>:42                                      ; preds = %38
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 152
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 40
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
+  %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
+  %53 = zext i8 %52 to i32
+  %54 = icmp eq i32 %53, 0
+  br i1 %54, label %56, label %55
+
+; <label>:55                                      ; preds = %42
+  ret i8 1
+
+; <label>:56                                      ; preds = %42
+  %57 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %58 = bitcast %System.RuntimeType addrspace(1)* %57 to %System.Type addrspace(1)*
+  %59 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %58)
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %64 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.Type addrspace(1)* %63, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = bitcast %System.RuntimeType addrspace(1)* %64 to %System.Type addrspace(1)*
+  %67 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %63, %System.Type addrspace(1)* %66)
+  %68 = zext i8 %67 to i32
+  %69 = trunc i32 %68 to i8
+  ret i8 %69
+
+; <label>:70                                      ; preds = %56
+  %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
+  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %73
+
+; <label>:73                                      ; preds = %70
+  %74 = load i64, i64 addrspace(1)* %72
+  %75 = add i64 %74, 128
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = add i64 %77, 0
+  %79 = inttoptr i64 %78 to i64*
+  %80 = load i64, i64* %79
+  %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
+  %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
+  %83 = call i8 %82(%System.Type addrspace(1)* %81)
+  %84 = zext i8 %83 to i32
+  %85 = icmp eq i32 %84, 0
+  br i1 %85, label %139, label %86
+
+; <label>:86                                      ; preds = %73
+  %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
+  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %89
+
+; <label>:89                                      ; preds = %86
+  %90 = load i64, i64 addrspace(1)* %88
+  %91 = add i64 %90, 128
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = add i64 %93, 24
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
+  %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
+  %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
+  store %"System.Type[]" addrspace(1)* %99, %"System.Type[]" addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %129
+
+; <label>:100                                     ; preds = %132
+  %101 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %102 = load i32, i32* %loc2
+  %NullCheck11 = icmp eq %"System.Type[]" addrspace(1)* %101, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %103
+
+; <label>:103                                     ; preds = %100
+  %104 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 1
+  %105 = load i32, i32 addrspace(1)* %104
+  %106 = zext i32 %105 to i64
+  %107 = zext i32 %102 to i64
+  %BoundsCheck = icmp uge i64 %107, %106
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %108
+
+; <label>:108                                     ; preds = %103
+  %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
+  %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
+  %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
+  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %113
+
+; <label>:113                                     ; preds = %108
+  %114 = load i64, i64 addrspace(1)* %112
+  %115 = add i64 %114, 152
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = add i64 %117, 56
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
+  %123 = zext i8 %122 to i32
+  %124 = icmp ne i32 %123, 0
+  br i1 %124, label %126, label %125
+
+; <label>:125                                     ; preds = %113
+  ret i8 0
+
+; <label>:126                                     ; preds = %113
+  %127 = load i32, i32* %loc2
+  %128 = add i32 %127, 1
+  store i32 %128, i32* %loc2
+  br label %129
+
+; <label>:129                                     ; preds = %89, %126
+  %130 = load i32, i32* %loc2
+  %131 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %NullCheck9 = icmp eq %"System.Type[]" addrspace(1)* %131, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %132
+
+; <label>:132                                     ; preds = %129
+  %133 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %131, i32 0, i32 1
+  %134 = load i32, i32 addrspace(1)* %133
+  %135 = zext i32 %134 to i64
+  %136 = trunc i64 %135 to i32
+  %137 = icmp slt i32 %130, %136
+  br i1 %137, label %100, label %138
+
+; <label>:138                                     ; preds = %132
+  ret i8 1
+
+; <label>:139                                     ; preds = %34, %73
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %129
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %103
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -2893,7 +3248,7 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElem]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -2904,8 +3259,8 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -2997,8 +3352,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
@@ -3059,8 +3414,8 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -3087,8 +3442,8 @@ entry:
 
 ; <label>:17                                      ; preds = %5, %11
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
@@ -3097,8 +3452,8 @@ entry:
 
 ; <label>:22                                      ; preds = %1, %11
   %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
@@ -3109,11 +3464,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %17
+ThrowNullRef2:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %22
+ThrowNullRef4:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3167,15 +3522,15 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
   %15 = load i32, i32 addrspace(1)* %14
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
@@ -3198,7 +3553,7 @@ ThrowNullRef:                                     ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef2:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3232,8 +3587,8 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
@@ -3312,8 +3667,8 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -3327,8 +3682,8 @@ entry:
 ; <label>:5                                       ; preds = %43
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %7 = load i32, i32* %loc1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck6, label %8, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
@@ -3366,8 +3721,8 @@ entry:
 ; <label>:32                                      ; preds = %21, %25
   %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
   %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
-  br i1 %NullCheck8, label %35, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = trunc i32 %34 to i16
@@ -3380,8 +3735,8 @@ entry:
 ; <label>:40                                      ; preds = %1, %35
   %41 = load i32, i32* %loc1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
-  br i1 %NullCheck2, label %43, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %42, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
@@ -3392,8 +3747,8 @@ entry:
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
   %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
-  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
   %51 = load i64, i64 addrspace(1)* %49
@@ -3412,19 +3767,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %40
+ThrowNullRef2:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %47
+ThrowNullRef4:                                    ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %5
+ThrowNullRef6:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %32
+ThrowNullRef8:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3467,8 +3822,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
@@ -3492,11 +3847,391 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(i16* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store i16* %param0, i16** %arg0
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load i32, i32* %arg3
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %42, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %37, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg2
+  %13 = load i32, i32* %arg3
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %37, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %24 = load i32, i32* %arg2
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load i16*, i16** %arg0
+  %35 = load i32, i32* %arg3
+  %36 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %36, i16* %34, i32 %35)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:37                                      ; preds = %5, %16
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %39)
+  %41 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41, %System.String addrspace(1)* %38, %System.String addrspace(1)* %40)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41) #0
+  unreachable
+
+; <label>:42                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
-Failed to read StringBuilder.ToString[loadElemA]
+Successfully read StringBuilder.ToString
+
+define %System.String addrspace(1)* @StringBuilder.ToString(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i16*
+  %loc3 = alloca %"System.Char[]" addrspace(1)*
+  %loc4 = alloca i32
+  %loc5 = alloca i32
+  %loc6 = alloca i16 addrspace(1)*
+  %loc7 = alloca %System.String addrspace(1)*
+  %loc8 = alloca %"System.Char[]" addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %0)
+  %2 = icmp ne i32 %1, 0
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %4
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %6)
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %7)
+  store %System.String addrspace(1)* %8, %System.String addrspace(1)** %loc0
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.Text.StringBuilder addrspace(1)* %9, %System.Text.StringBuilder addrspace(1)** %loc1
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  store %System.String addrspace(1)* %10, %System.String addrspace(1)** %loc7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc7
+  %12 = ptrtoint %System.String addrspace(1)* %11 to i64
+  %13 = icmp eq i64 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %5
+  %15 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %16 = sext i32 %15 to i64
+  %17 = add i64 %12, %16
+  br label %18
+
+; <label>:18                                      ; preds = %5, %14
+  %19 = phi i64 [ %12, %5 ], [ %17, %14 ]
+  %20 = inttoptr i64 %19 to i16*
+  store i16* %20, i16** %loc2
+  br label %21
+
+; <label>:21                                      ; preds = %98, %18
+  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %22, null
+  br i1 %NullCheck, label %ThrowNullRef, label %23
+
+; <label>:23                                      ; preds = %21
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 3
+  %25 = load i32, i32 addrspace(1)* %24, align 8
+  %26 = icmp sle i32 %25, 0
+  br i1 %26, label %96, label %27
+
+; <label>:27                                      ; preds = %23
+  %28 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %28, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %29
+
+; <label>:29                                      ; preds = %27
+  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %28, i32 0, i32 1
+  %31 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %30, align 8
+  store %"System.Char[]" addrspace(1)* %31, %"System.Char[]" addrspace(1)** %loc3
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %33
+
+; <label>:33                                      ; preds = %29
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  store i32 %35, i32* %loc4
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  %39 = load i32, i32 addrspace(1)* %38, align 8
+  store i32 %39, i32* %loc5
+  %40 = load i32, i32* %loc5
+  %41 = load i32, i32* %loc4
+  %42 = add i32 %40, %41
+  %43 = zext i32 %42 to i64
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %45
+
+; <label>:45                                      ; preds = %37
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = sext i32 %47 to i64
+  %49 = icmp sgt i64 %43, %48
+  br i1 %49, label %91, label %50
+
+; <label>:50                                      ; preds = %45
+  %51 = load i32, i32* %loc5
+  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %52, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %53
+
+; <label>:53                                      ; preds = %50
+  %54 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %52, i32 0, i32 1
+  %55 = load i32, i32 addrspace(1)* %54
+  %56 = zext i32 %55 to i64
+  %57 = trunc i64 %56 to i32
+  %58 = icmp ugt i32 %51, %57
+  br i1 %58, label %91, label %59
+
+; <label>:59                                      ; preds = %53
+  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  store %"System.Char[]" addrspace(1)* %60, %"System.Char[]" addrspace(1)** %loc8
+  %61 = icmp eq %"System.Char[]" addrspace(1)* %60, null
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %63, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %64
+
+; <label>:64                                      ; preds = %62
+  %65 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %63, i32 0, i32 1
+  %66 = load i32, i32 addrspace(1)* %65
+  %67 = zext i32 %66 to i64
+  %68 = trunc i64 %67 to i32
+  %69 = icmp ne i32 %68, 0
+  br i1 %69, label %71, label %70
+
+; <label>:70                                      ; preds = %59, %64
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:71                                      ; preds = %64
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %73
+
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %BoundsCheck = icmp uge i64 0, %76
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %77
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %78, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:79                                      ; preds = %70, %77
+  %80 = load i16*, i16** %loc2
+  %81 = load i32, i32* %loc4
+  %82 = sext i32 %81 to i64
+  %83 = mul i64 %82, 2
+  %84 = bitcast i16* %80 to i8*
+  %85 = getelementptr inbounds i8, i8* %84, i64 %83
+  %86 = load i16 addrspace(1)*, i16 addrspace(1)** %loc6
+  %87 = ptrtoint i16 addrspace(1)* %86 to i64
+  %88 = load i32, i32* %loc5
+  %89 = bitcast i8* %85 to i16*
+  %90 = inttoptr i64 %87 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %89, i16* %90, i32 %88)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %96
+
+; <label>:91                                      ; preds = %45, %53
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %94 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %93)
+  %95 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95, %System.String addrspace(1)* %92, %System.String addrspace(1)* %94)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95) #0
+  unreachable
+
+; <label>:96                                      ; preds = %23, %79
+  %97 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %97, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %98
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %97, i32 0, i32 2
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  store %System.Text.StringBuilder addrspace(1)* %100, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %102 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %102, label %21, label %103
+
+; <label>:103                                     ; preds = %98
+  store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc7
+  %104 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  ret %System.String addrspace(1)* %104
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method StringBuilder::get_Length using LLILCJit
+Successfully read StringBuilder.get_Length
+
+define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
+Successfully read RuntimeHelpers.get_OffsetToStringData
+
+define i32 @RuntimeHelpers.get_OffsetToStringData() {
+entry:
+  ret i32 12
+}
+
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
 Successfully read CultureData.CreateCultureData
 
@@ -3514,23 +4249,23 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
   store i8 %4, i8 addrspace(1)* %6
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
@@ -3549,11 +4284,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3566,50 +4301,50 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
   store i32 -1, i32 addrspace(1)* %2
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
   store i32 -1, i32 addrspace(1)* %8
   %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
   store i32 -1, i32 addrspace(1)* %14
   %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
   store i32 -1, i32 addrspace(1)* %17
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
@@ -3623,27 +4358,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3675,7 +4410,136 @@ Failed to read Dictionary`2.Insert[non-const derefAddress]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
 Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
-Failed to read HashHelpers.GetPrime[loadElem]
+Successfully read HashHelpers.GetPrime
+
+define i32 @HashHelpers.GetPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %6, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5, %System.String addrspace(1)* %4)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5) #0
+  unreachable
+
+; <label>:6                                       ; preds = %entry
+  store i32 0, i32* %loc0
+  br label %29
+
+; <label>:7                                       ; preds = %35
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 1296
+  %10 = addrspacecast i8 addrspace(1)* %9 to %"System.Int32[]" addrspace(1)**
+  %11 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %10
+  %12 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Int32[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = zext i32 %15 to i64
+  %17 = zext i32 %12 to i64
+  %BoundsCheck = icmp uge i64 %17, %16
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 3, i32 %12
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  store i32 %20, i32* %loc1
+  %21 = load i32, i32* %loc1
+  %22 = load i32, i32* %arg0
+  %23 = icmp slt i32 %21, %22
+  br i1 %23, label %26, label %24
+
+; <label>:24                                      ; preds = %18
+  %25 = load i32, i32* %loc1
+  ret i32 %25
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %loc0
+  %28 = add i32 %27, 1
+  store i32 %28, i32* %loc0
+  br label %29
+
+; <label>:29                                      ; preds = %6, %26
+  %30 = load i32, i32* %loc0
+  %31 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %32 = getelementptr inbounds i8, i8 addrspace(1)* %31, i64 1296
+  %33 = addrspacecast i8 addrspace(1)* %32 to %"System.Int32[]" addrspace(1)**
+  %34 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %33
+  %NullCheck = icmp eq %"System.Int32[]" addrspace(1)* %34, null
+  br i1 %NullCheck, label %ThrowNullRef, label %35
+
+; <label>:35                                      ; preds = %29
+  %36 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %34, i32 0, i32 1
+  %37 = load i32, i32 addrspace(1)* %36
+  %38 = zext i32 %37 to i64
+  %39 = trunc i64 %38 to i32
+  %40 = icmp slt i32 %30, %39
+  br i1 %40, label %7, label %41
+
+; <label>:41                                      ; preds = %35
+  %42 = load i32, i32* %arg0
+  %43 = or i32 %42, 1
+  store i32 %43, i32* %loc2
+  br label %59
+
+; <label>:44                                      ; preds = %59
+  %45 = load i32, i32* %loc2
+  %46 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %45)
+  %47 = zext i8 %46 to i32
+  %48 = icmp eq i32 %47, 0
+  br i1 %48, label %56, label %49
+
+; <label>:49                                      ; preds = %44
+  %50 = load i32, i32* %loc2
+  %51 = sub i32 %50, 1
+  %52 = srem i32 %51, 101
+  %53 = icmp eq i32 %52, 0
+  br i1 %53, label %56, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = load i32, i32* %loc2
+  ret i32 %55
+
+; <label>:56                                      ; preds = %44, %49
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %57, 2
+  store i32 %58, i32* %loc2
+  br label %59
+
+; <label>:59                                      ; preds = %41, %56
+  %60 = load i32, i32* %loc2
+  %61 = icmp slt i32 %60, 2147483647
+  br i1 %61, label %44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load i32, i32* %arg0
+  ret i32 %63
+
+ThrowNullRef:                                     ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
 Successfully read GenericEqualityComparer`1.GetHashCode
 
@@ -3694,14 +4558,14 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
   %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load i64, i64 addrspace(1)* %7
@@ -3720,7 +4584,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3750,8 +4614,8 @@ entry:
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
@@ -3796,8 +4660,8 @@ entry:
   %35 = bitcast i16* %34 to i8*
   %36 = getelementptr inbounds i8, i8* %35, i64 2
   %37 = bitcast i8* %36 to i16*
-  %NullCheck4 = icmp ne i16* %37, null
-  br i1 %NullCheck4, label %38, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %37, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %38
 
 ; <label>:38                                      ; preds = %27
   %39 = load i16, i16* %37, align 8
@@ -3824,8 +4688,8 @@ entry:
 
 ; <label>:54                                      ; preds = %22, %43
   %55 = load i16*, i16** %loc4
-  %NullCheck2 = icmp ne i16* %55, null
-  br i1 %NullCheck2, label %56, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i16* %55, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %56
 
 ; <label>:56                                      ; preds = %54
   %57 = load i16, i16* %55, align 8
@@ -3850,11 +4714,11 @@ ThrowNullRef:                                     ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %54
+ThrowNullRef2:                                    ; preds = %54
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %27
+ThrowNullRef4:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3871,8 +4735,8 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -3907,8 +4771,8 @@ entry:
 
 ; <label>:26                                      ; preds = %19
   %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
-  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %28
 
 ; <label>:28                                      ; preds = %26
   %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
@@ -3920,7 +4784,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3972,8 +4836,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
@@ -3984,26 +4848,26 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
-  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
@@ -4014,8 +4878,8 @@ entry:
 ; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
@@ -4024,8 +4888,8 @@ entry:
 
 ; <label>:25                                      ; preds = %1, %16, %23
   %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
-  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
@@ -4036,27 +4900,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %20
+ThrowNullRef10:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4069,8 +4933,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -4081,8 +4945,8 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
@@ -4091,8 +4955,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1, %8
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
@@ -4103,11 +4967,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4128,24 +4992,24 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   store i32 %3, i32* %loc0
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
   %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
   store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck4, label %9, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
@@ -4164,15 +5028,15 @@ entry:
 ; <label>:18                                      ; preds = %70
   %19 = load i16*, i16** %loc3
   %20 = bitcast i16* %19 to i64*
-  %NullCheck10 = icmp ne i64* %20, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %20, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = load i64, i64* %20, align 8
   %23 = load i16*, i16** %loc4
   %24 = bitcast i16* %23 to i64*
-  %NullCheck12 = icmp ne i64* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = load i64, i64* %24, align 8
@@ -4188,8 +5052,8 @@ entry:
   %31 = bitcast i16* %30 to i8*
   %32 = getelementptr inbounds i8, i8* %31, i64 8
   %33 = bitcast i8* %32 to i64*
-  %NullCheck14 = icmp ne i64* %33, null
-  br i1 %NullCheck14, label %34, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = load i64, i64* %33, align 8
@@ -4197,8 +5061,8 @@ entry:
   %37 = bitcast i16* %36 to i8*
   %38 = getelementptr inbounds i8, i8* %37, i64 8
   %39 = bitcast i8* %38 to i64*
-  %NullCheck16 = icmp ne i64* %39, null
-  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %40
 
 ; <label>:40                                      ; preds = %34
   %41 = load i64, i64* %39, align 8
@@ -4214,8 +5078,8 @@ entry:
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %NullCheck18 = icmp ne i64* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = load i64, i64* %48, align 8
@@ -4223,8 +5087,8 @@ entry:
   %52 = bitcast i16* %51 to i8*
   %53 = getelementptr inbounds i8, i8* %52, i64 16
   %54 = bitcast i8* %53 to i64*
-  %NullCheck20 = icmp ne i64* %54, null
-  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64* %54, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %55
 
 ; <label>:55                                      ; preds = %49
   %56 = load i64, i64* %54, align 8
@@ -4262,15 +5126,15 @@ entry:
 ; <label>:74                                      ; preds = %95
   %75 = load i16*, i16** %loc3
   %76 = bitcast i16* %75 to i32*
-  %NullCheck6 = icmp ne i32* %76, null
-  br i1 %NullCheck6, label %77, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32* %76, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %77
 
 ; <label>:77                                      ; preds = %74
   %78 = load i32, i32* %76, align 8
   %79 = load i16*, i16** %loc4
   %80 = bitcast i16* %79 to i32*
-  %NullCheck8 = icmp ne i32* %80, null
-  br i1 %NullCheck8, label %81, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i32* %80, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %81
 
 ; <label>:81                                      ; preds = %77
   %82 = load i32, i32* %80, align 8
@@ -4318,43 +5182,43 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %74
+ThrowNullRef6:                                    ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %77
+ThrowNullRef8:                                    ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %29
+ThrowNullRef14:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %34
+ThrowNullRef16:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4376,8 +5240,8 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load i64, i64 addrspace(1)* %4
@@ -4389,8 +5253,8 @@ entry:
   %12 = load i64, i64* %11
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %5
   %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
@@ -4399,8 +5263,8 @@ entry:
   %18 = load i8, i8* %arg2
   %19 = zext i8 %18 to i32
   %20 = trunc i32 %19 to i8
-  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %15
   %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
@@ -4411,11 +5275,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4442,8 +5306,8 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
@@ -4466,16 +5330,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
   %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = load i64, i64 addrspace(1)* %19
@@ -4500,8 +5364,8 @@ entry:
 ; <label>:35                                      ; preds = %30
   %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
@@ -4514,8 +5378,8 @@ entry:
 
 ; <label>:42                                      ; preds = %1, %38
   %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
-  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
@@ -4526,19 +5390,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %35
+ThrowNullRef2:                                    ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %42
+ThrowNullRef8:                                    ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4551,14 +5415,14 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
@@ -4570,7 +5434,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4583,8 +5447,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
@@ -4613,51 +5477,51 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
   %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
   %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
   %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
   %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
-  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
   store i64 %21, i64 addrspace(1)* %23
   %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %25 = load i64, i64* %loc0
-  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
@@ -4668,27 +5532,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %22
+ThrowNullRef12:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4701,8 +5565,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
@@ -4713,19 +5577,19 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
@@ -4734,8 +5598,8 @@ entry:
 
 ; <label>:15                                      ; preds = %1, %13
   %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
@@ -4746,19 +5610,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %15
+ThrowNullRef8:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4771,8 +5635,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -4831,8 +5695,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
@@ -4882,8 +5746,8 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
-  br i1 %NullCheck, label %17, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %ThrowNullRef, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
@@ -4894,15 +5758,15 @@ entry:
 
 ; <label>:22                                      ; preds = %17
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
-  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
   %26 = load i32, i32 addrspace(1)* %25
   %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
-  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %27, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
@@ -4925,8 +5789,8 @@ entry:
 ; <label>:40                                      ; preds = %17
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
-  br i1 %NullCheck6, label %43, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %41, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
@@ -4938,34 +5802,17 @@ ThrowNullRef:                                     ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %24
+ThrowNullRef4:                                    ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %40
+ThrowNullRef6:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
-}
-
-INFO:  jitting method Object::ReferenceEquals using LLILCJit
-Successfully read Object.ReferenceEquals
-
-define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
-entry:
-  %arg0 = alloca %System.Object addrspace(1)*
-  %arg1 = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
-  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
-  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = icmp eq %System.Object addrspace(1)* %0, %1
-  %3 = sext i1 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
 }
 
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
@@ -4978,21 +5825,21 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
   %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
-  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
@@ -5007,28 +5854,28 @@ entry:
 ; <label>:13                                      ; preds = %8, %12
   %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
   %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
   %21 = load i32, i32 addrspace(1)* %20, align 8
   %22 = add i32 %21, 1
-  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
   store i32 %22, i32 addrspace(1)* %24
   %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
@@ -5039,27 +5886,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5077,7 +5924,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::Setup using LLILCJit
-Failed to read AppDomain.Setup[loadElem]
+Failed to read AppDomain.Setup[unbox]
 INFO:  jitting method Thread::GetDomain using LLILCJit
 Successfully read Thread.GetDomain
 
@@ -5108,8 +5955,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
@@ -5122,14 +5969,14 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
   %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
@@ -5141,11 +5988,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5173,8 +6020,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -5189,7 +6036,328 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
 Failed to read KeyCollection.System.Collections.Generic.IEnumerable<TKey>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Successfully read Enumerator.MoveNext
+
+define i8 @Enumerator.MoveNext(%"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.RuntimeTypeHandle* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*
+  %"$TypeArg" = alloca %System.RuntimeTypeHandle*
+  store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
+  %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 8
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %76, label %12
+
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
+  br label %76
+
+; <label>:13                                      ; preds = %85
+  %14 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck19 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %15
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, i32 0, i32 0
+  %17 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %16, align 8
+  %NullCheck21 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, i32 0, i32 2
+  %20 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %19, align 8
+  %21 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck23 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %22
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, i32 0, i32 2
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %NullCheck25 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 3, i32 %24
+  %NullCheck27 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %32
+
+; <label>:32                                      ; preds = %30
+  %33 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, i32 0, i32 2
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = icmp slt i32 %34, 0
+  br i1 %35, label %68, label %36
+
+; <label>:36                                      ; preds = %32
+  %37 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %38 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck29 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %39
+
+; <label>:39                                      ; preds = %36
+  %40 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, i32 0, i32 0
+  %41 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %40, align 8
+  %NullCheck31 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, i32 0, i32 2
+  %44 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %43, align 8
+  %45 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck33 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, i32 0, i32 2
+  %48 = load i32, i32 addrspace(1)* %47, align 8
+  %NullCheck35 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %49
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = zext i32 %51 to i64
+  %53 = zext i32 %48 to i64
+  %BoundsCheck37 = icmp uge i64 %53, %52
+  br i1 %BoundsCheck37, label %ThrowIndexOutOfRange38, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 3, i32 %48
+  %NullCheck39 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %56
+
+; <label>:56                                      ; preds = %54
+  %57 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, i32 0, i32 0
+  %58 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck41 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %59
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %60, %System.__Canon addrspace(1)* %58)
+  %61 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck43 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  %64 = load i32, i32 addrspace(1)* %63, align 8
+  %65 = add i32 %64, 1
+  %NullCheck45 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  store i32 %65, i32 addrspace(1)* %67
+  ret i8 1
+
+; <label>:68                                      ; preds = %32
+  %69 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck47 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %73 = add i32 %72, 1
+  %NullCheck49 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %74
+
+; <label>:74                                      ; preds = %70
+  %75 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  store i32 %73, i32 addrspace(1)* %75
+  br label %76
+
+; <label>:76                                      ; preds = %8, %12, %74
+  %77 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %78
+
+; <label>:78                                      ; preds = %76
+  %79 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, i32 0, i32 2
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck7 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %82
+
+; <label>:82                                      ; preds = %78
+  %83 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, i32 0, i32 0
+  %84 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %83, align 8
+  %NullCheck9 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %85
+
+; <label>:85                                      ; preds = %82
+  %86 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, i32 0, i32 7
+  %87 = load i32, i32 addrspace(1)* %86, align 8
+  %88 = icmp ult i32 %80, %87
+  br i1 %88, label %13, label %89
+
+; <label>:89                                      ; preds = %85
+  %90 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %91 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck11 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %92
+
+; <label>:92                                      ; preds = %89
+  %93 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, i32 0, i32 0
+  %94 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck13 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %95
+
+; <label>:95                                      ; preds = %92
+  %96 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, i32 0, i32 7
+  %97 = load i32, i32 addrspace(1)* %96, align 8
+  %98 = add i32 %97, 1
+  %NullCheck15 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %99
+
+; <label>:99                                      ; preds = %95
+  %100 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, i32 0, i32 2
+  store i32 %98, i32 addrspace(1)* %100
+  %101 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck17 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %102
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %103, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %92
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef22:                                   ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef24:                                   ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef26:                                   ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef28:                                   ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef30:                                   ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef32:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef34:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef36:                                   ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange38:                           ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef40:                                   ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef42:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef44:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef46:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef48:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef50:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -5200,8 +6368,8 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -5232,9 +6400,9 @@ Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
 Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
-Failed to read String.MakeSeparatorList[loadElemA]
+Failed to read String.MakeSeparatorList[storeElem]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
-Failed to read String.InternalSplitKeepEmptyEntries[loadElem]
+Failed to read String.InternalSplitKeepEmptyEntries[storeElem]
 INFO:  jitting method Path::IsRelative using LLILCJit
 Successfully read Path.IsRelative
 
@@ -5243,8 +6411,8 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -5254,8 +6422,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
@@ -5271,8 +6439,8 @@ entry:
 
 ; <label>:17                                      ; preds = %7
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
@@ -5288,8 +6456,8 @@ entry:
 
 ; <label>:29                                      ; preds = %19
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %31
 
 ; <label>:31                                      ; preds = %29
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
@@ -5300,8 +6468,8 @@ entry:
 
 ; <label>:36                                      ; preds = %31
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
-  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %37, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
@@ -5312,8 +6480,8 @@ entry:
 
 ; <label>:43                                      ; preds = %31, %38
   %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
-  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %45
 
 ; <label>:45                                      ; preds = %43
   %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
@@ -5324,8 +6492,8 @@ entry:
 
 ; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %50
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
@@ -5336,8 +6504,8 @@ entry:
 
 ; <label>:57                                      ; preds = %1, %7, %19, %45, %52
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
-  br i1 %NullCheck14, label %59, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %59
 
 ; <label>:59                                      ; preds = %57
   %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
@@ -5347,8 +6515,8 @@ entry:
 
 ; <label>:63                                      ; preds = %59
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
@@ -5359,8 +6527,8 @@ entry:
 
 ; <label>:70                                      ; preds = %65
   %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
-  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.String addrspace(1)* %71, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %72
 
 ; <label>:72                                      ; preds = %70
   %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
@@ -5379,39 +6547,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %17
+ThrowNullRef4:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %29
+ThrowNullRef6:                                    ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %36
+ThrowNullRef8:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %43
+ThrowNullRef10:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %50
+ThrowNullRef12:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %57
+ThrowNullRef14:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %63
+ThrowNullRef16:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %70
+ThrowNullRef18:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5419,7 +6587,293 @@ ThrowNullRef17:                                   ; preds = %70
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
-Failed to read String.TrimHelper[loadElem]
+Successfully read String.TrimHelper
+
+define %System.String addrspace(1)* @String.TrimHelper(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i16
+  %loc4 = alloca i32
+  %loc5 = alloca i16
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = sub i32 %3, 1
+  store i32 %4, i32* %loc0
+  store i32 0, i32* %loc1
+  %5 = load i32, i32* %arg2
+  %6 = icmp eq i32 %5, 1
+  br i1 %6, label %62, label %7
+
+; <label>:7                                       ; preds = %1
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:8                                       ; preds = %58
+  store i32 0, i32* %loc2
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load i32, i32* %loc1
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2, i32 %10
+  %13 = load i16, i16 addrspace(1)* %12
+  %14 = zext i16 %13 to i32
+  %15 = trunc i32 %14 to i16
+  store i16 %15, i16* %loc3
+  store i32 0, i32* %loc2
+  br label %34
+
+; <label>:16                                      ; preds = %37
+  %17 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %18 = load i32, i32* %loc2
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %17, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %19
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = zext i32 %18 to i64
+  %BoundsCheck = icmp uge i64 %23, %22
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %24
+
+; <label>:24                                      ; preds = %19
+  %25 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 3, i32 %18
+  %26 = load i16, i16 addrspace(1)* %25, align 8
+  %27 = zext i16 %26 to i32
+  %28 = load i16, i16* %loc3
+  %29 = zext i16 %28 to i32
+  %30 = icmp eq i32 %27, %29
+  br i1 %30, label %43, label %31
+
+; <label>:31                                      ; preds = %24
+  %32 = load i32, i32* %loc2
+  %33 = add i32 %32, 1
+  store i32 %33, i32* %loc2
+  br label %34
+
+; <label>:34                                      ; preds = %11, %31
+  %35 = load i32, i32* %loc2
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = icmp slt i32 %35, %41
+  br i1 %42, label %16, label %43
+
+; <label>:43                                      ; preds = %24, %37
+  %44 = load i32, i32* %loc2
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %45, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp eq i32 %44, %50
+  br i1 %51, label %62, label %52
+
+; <label>:52                                      ; preds = %46
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %7, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %57, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %58
+
+; <label>:58                                      ; preds = %55
+  %59 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %60 = load i32, i32 addrspace(1)* %59
+  %61 = icmp slt i32 %56, %60
+  br i1 %61, label %8, label %62
+
+; <label>:62                                      ; preds = %1, %46, %58
+  %63 = load i32, i32* %arg2
+  %64 = icmp eq i32 %63, 0
+  br i1 %64, label %122, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %66, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %67
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %66, i32 0, i32 1
+  %69 = load i32, i32 addrspace(1)* %68
+  %70 = sub i32 %69, 1
+  store i32 %70, i32* %loc0
+  br label %118
+
+; <label>:71                                      ; preds = %118
+  store i32 0, i32* %loc4
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %73 = load i32, i32* %loc0
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %74
+
+; <label>:74                                      ; preds = %71
+  %75 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 2, i32 %73
+  %76 = load i16, i16 addrspace(1)* %75
+  %77 = zext i16 %76 to i32
+  %78 = trunc i32 %77 to i16
+  store i16 %78, i16* %loc5
+  store i32 0, i32* %loc4
+  br label %97
+
+; <label>:79                                      ; preds = %100
+  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %81 = load i32, i32* %loc4
+  %NullCheck19 = icmp eq %"System.Char[]" addrspace(1)* %80, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
+
+; <label>:82                                      ; preds = %79
+  %83 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 1
+  %84 = load i32, i32 addrspace(1)* %83
+  %85 = zext i32 %84 to i64
+  %86 = zext i32 %81 to i64
+  %BoundsCheck21 = icmp uge i64 %86, %85
+  br i1 %BoundsCheck21, label %ThrowIndexOutOfRange22, label %87
+
+; <label>:87                                      ; preds = %82
+  %88 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 3, i32 %81
+  %89 = load i16, i16 addrspace(1)* %88, align 8
+  %90 = zext i16 %89 to i32
+  %91 = load i16, i16* %loc5
+  %92 = zext i16 %91 to i32
+  %93 = icmp eq i32 %90, %92
+  br i1 %93, label %106, label %94
+
+; <label>:94                                      ; preds = %87
+  %95 = load i32, i32* %loc4
+  %96 = add i32 %95, 1
+  store i32 %96, i32* %loc4
+  br label %97
+
+; <label>:97                                      ; preds = %74, %94
+  %98 = load i32, i32* %loc4
+  %99 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck15 = icmp eq %"System.Char[]" addrspace(1)* %99, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %100
+
+; <label>:100                                     ; preds = %97
+  %101 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %99, i32 0, i32 1
+  %102 = load i32, i32 addrspace(1)* %101
+  %103 = zext i32 %102 to i64
+  %104 = trunc i64 %103 to i32
+  %105 = icmp slt i32 %98, %104
+  br i1 %105, label %79, label %106
+
+; <label>:106                                     ; preds = %87, %100
+  %107 = load i32, i32* %loc4
+  %108 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck17 = icmp eq %"System.Char[]" addrspace(1)* %108, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %109
+
+; <label>:109                                     ; preds = %106
+  %110 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %108, i32 0, i32 1
+  %111 = load i32, i32 addrspace(1)* %110
+  %112 = zext i32 %111 to i64
+  %113 = trunc i64 %112 to i32
+  %114 = icmp eq i32 %107, %113
+  br i1 %114, label %122, label %115
+
+; <label>:115                                     ; preds = %109
+  %116 = load i32, i32* %loc0
+  %117 = sub i32 %116, 1
+  store i32 %117, i32* %loc0
+  br label %118
+
+; <label>:118                                     ; preds = %67, %115
+  %119 = load i32, i32* %loc0
+  %120 = load i32, i32* %loc1
+  %121 = icmp sge i32 %119, %120
+  br i1 %121, label %71, label %122
+
+; <label>:122                                     ; preds = %62, %109, %118
+  %123 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %124 = load i32, i32* %loc1
+  %125 = load i32, i32* %loc0
+  %126 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %123, i32 %124, i32 %125)
+  ret %System.String addrspace(1)* %126
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %97
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange22:                           ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
 Successfully read String.CreateTrimmedString
 
@@ -5439,8 +6893,8 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
@@ -5535,8 +6989,8 @@ entry:
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i64 2872
   %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
   %8 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %7
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %3
   %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
@@ -5553,8 +7007,8 @@ entry:
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 2864
   %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
   %21 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %20
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
-  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %22
 
 ; <label>:22                                      ; preds = %16
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
@@ -5569,7 +7023,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %16
+ThrowNullRef2:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5586,8 +7040,8 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5613,8 +7067,8 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
@@ -5632,8 +7086,8 @@ entry:
 
 ; <label>:12                                      ; preds = %4
   %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
@@ -5644,8 +7098,8 @@ entry:
 
 ; <label>:19                                      ; preds = %14
   %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %19
   %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
@@ -5660,21 +7114,21 @@ entry:
   %31 = zext i16 %30 to i32
   %32 = bitcast i8* %29 to i16*
   %33 = trunc i32 %31 to i16
-  %NullCheck6 = icmp ne i16* %32, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i16* %32, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %21
   store i16 %33, i16* %32, align 8
   %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %36
 
 ; <label>:36                                      ; preds = %34
   %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
   %38 = load i32, i32 addrspace(1)* %37, align 8
   %39 = add i32 %38, 1
-  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %40
 
 ; <label>:40                                      ; preds = %36
   %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
@@ -5683,16 +7137,16 @@ entry:
 
 ; <label>:42                                      ; preds = %14
   %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
-  br i1 %NullCheck12, label %44, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
   %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
   %47 = load i16, i16* %arg1
   %48 = zext i16 %47 to i32
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = trunc i32 %48 to i16
@@ -5703,31 +7157,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %19
+ThrowNullRef4:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %21
+ThrowNullRef6:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %36
+ThrowNullRef10:                                   ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %42
+ThrowNullRef12:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %44
+ThrowNullRef14:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5740,8 +7194,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -5752,8 +7206,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
@@ -5762,14 +7216,14 @@ entry:
 
 ; <label>:11                                      ; preds = %1
   %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
@@ -5779,15 +7233,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5808,8 +7262,8 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5822,8 +7276,8 @@ entry:
 
 ; <label>:8                                       ; preds = %3
   %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
@@ -5842,15 +7296,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
-  br i1 %NullCheck4, label %22, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
   %24 = load i16*, i16* addrspace(1)* %23, align 8
   %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %25, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
@@ -5859,8 +7313,8 @@ entry:
   store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
@@ -5874,8 +7328,8 @@ entry:
 
 ; <label>:37                                      ; preds = %65
   %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %37
   %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
@@ -5886,16 +7340,16 @@ entry:
   %45 = bitcast i16* %41 to i8*
   %46 = getelementptr inbounds i8, i8* %45, i64 %44
   %47 = bitcast i8* %46 to i16*
-  %NullCheck14 = icmp ne i16* %47, null
-  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %47, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %48
 
 ; <label>:48                                      ; preds = %39
   %49 = load i16, i16* %47, align 8
   %50 = zext i16 %49 to i32
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %52 = load i32, i32* %loc1
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %53
 
 ; <label>:53                                      ; preds = %48
   %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
@@ -5916,8 +7370,8 @@ entry:
 ; <label>:62                                      ; preds = %36, %59
   %63 = load i32, i32* %loc1
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck10, label %65, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %65
 
 ; <label>:65                                      ; preds = %62
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
@@ -5936,15 +7390,15 @@ entry:
 
 ; <label>:74                                      ; preds = %70
   %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
-  br i1 %NullCheck18, label %76, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %76
 
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
   %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
-  br i1 %NullCheck20, label %80, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
   %81 = load i64, i64 addrspace(1)* %79
@@ -5958,8 +7412,8 @@ entry:
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
   %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
-  br i1 %NullCheck22, label %92, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.String addrspace(1)* %90, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %92
 
 ; <label>:92                                      ; preds = %80
   %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
@@ -5969,15 +7423,15 @@ entry:
 
 ; <label>:96                                      ; preds = %70
   %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
-  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %98
 
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
   %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
-  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
   %103 = load i64, i64 addrspace(1)* %101
@@ -5991,8 +7445,8 @@ entry:
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
   %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
-  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.String addrspace(1)* %112, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %114
 
 ; <label>:114                                     ; preds = %102
   %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
@@ -6004,59 +7458,59 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %20
+ThrowNullRef4:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %22
+ThrowNullRef6:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %26
+ThrowNullRef8:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %62
+ThrowNullRef10:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %48
+ThrowNullRef16:                                   ; preds = %48
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %74
+ThrowNullRef18:                                   ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %76
+ThrowNullRef20:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %80
+ThrowNullRef22:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %96
+ThrowNullRef24:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %98
+ThrowNullRef26:                                   ; preds = %98
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %102
+ThrowNullRef28:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6069,15 +7523,15 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
   %3 = load i16*, i16* addrspace(1)* %2, align 8
   %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
@@ -6087,8 +7541,8 @@ entry:
   %10 = bitcast i16* %3 to i8*
   %11 = getelementptr inbounds i8, i8* %10, i64 %9
   %12 = bitcast i8* %11 to i16*
-  %NullCheck4 = icmp ne i16* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %5
   store i16 0, i16* %12, align 8
@@ -6098,11 +7552,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6119,8 +7573,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -6131,8 +7585,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
@@ -6144,15 +7598,15 @@ entry:
 
 ; <label>:14                                      ; preds = %1
   %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
   %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
   %21 = load i64, i64 addrspace(1)* %19
@@ -6171,15 +7625,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %14
+ThrowNullRef4:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %16
+ThrowNullRef6:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6302,14 +7756,6 @@ entry:
   ret %System.String addrspace(1)* %57
 }
 
-INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
-Successfully read RuntimeHelpers.get_OffsetToStringData
-
-define i32 @RuntimeHelpers.get_OffsetToStringData() {
-entry:
-  ret i32 12
-}
-
 INFO:  jitting method String::Equals using LLILCJit
 Successfully read String.Equals
 
@@ -6381,8 +7827,8 @@ entry:
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
-  br i1 %NullCheck24, label %29, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
   %30 = load i64, i64 addrspace(1)* %28
@@ -6397,8 +7843,8 @@ entry:
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
-  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
   %43 = load i64, i64 addrspace(1)* %41
@@ -6418,8 +7864,8 @@ entry:
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
   %59 = load i64, i64 addrspace(1)* %57
@@ -6434,8 +7880,8 @@ entry:
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck22, label %71, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
   %72 = load i64, i64 addrspace(1)* %70
@@ -6455,8 +7901,8 @@ entry:
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
-  br i1 %NullCheck16, label %87, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = load i64, i64 addrspace(1)* %86
@@ -6471,8 +7917,8 @@ entry:
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck18, label %100, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
   %101 = load i64, i64 addrspace(1)* %99
@@ -6492,8 +7938,8 @@ entry:
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
-  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
   %117 = load i64, i64 addrspace(1)* %115
@@ -6508,8 +7954,8 @@ entry:
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
-  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
   %130 = load i64, i64 addrspace(1)* %128
@@ -6528,15 +7974,15 @@ entry:
 
 ; <label>:142                                     ; preds = %22
   %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
-  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %143, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %144
 
 ; <label>:144                                     ; preds = %142
   %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
   %146 = load i32, i32 addrspace(1)* %145
   %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
-  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %147, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %148
 
 ; <label>:148                                     ; preds = %144
   %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
@@ -6557,15 +8003,15 @@ entry:
 
 ; <label>:159                                     ; preds = %22
   %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
-  br i1 %NullCheck, label %161, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %ThrowNullRef, label %161
 
 ; <label>:161                                     ; preds = %159
   %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
   %163 = load i32, i32 addrspace(1)* %162
   %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
-  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %164, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %165
 
 ; <label>:165                                     ; preds = %161
   %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
@@ -6578,8 +8024,8 @@ entry:
 
 ; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
-  br i1 %NullCheck4, label %172, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %171, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %172
 
 ; <label>:172                                     ; preds = %170
   %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
@@ -6589,8 +8035,8 @@ entry:
 
 ; <label>:176                                     ; preds = %172
   %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
-  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %177, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %178
 
 ; <label>:178                                     ; preds = %176
   %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
@@ -6629,55 +8075,55 @@ ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %161
+ThrowNullRef2:                                    ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %170
+ThrowNullRef4:                                    ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %176
+ThrowNullRef6:                                    ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %142
+ThrowNullRef8:                                    ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %144
+ThrowNullRef10:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %113
+ThrowNullRef12:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %116
+ThrowNullRef14:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %84
+ThrowNullRef16:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %87
+ThrowNullRef18:                                   ; preds = %87
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %55
+ThrowNullRef20:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %58
+ThrowNullRef22:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %26
+ThrowNullRef24:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %29
+ThrowNullRef26:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,8 +8161,8 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck, label %14, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %ThrowNullRef, label %14
 
 ; <label>:14                                      ; preds = %8
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
@@ -6760,8 +8206,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
@@ -6770,14 +8216,14 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32, i32* %loc0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %10
   %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
   %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
@@ -6790,15 +8236,15 @@ entry:
 ; <label>:25                                      ; preds = %19
   %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
-  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
   %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
@@ -6807,8 +8253,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %37 = load i32, i32* %loc0
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %38, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %38
 
 ; <label>:38                                      ; preds = %32
   %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
@@ -6817,14 +8263,14 @@ entry:
 
 ; <label>:40                                      ; preds = %19
   %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %40
   %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
   %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
-  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
-  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
@@ -6832,8 +8278,8 @@ entry:
   %48 = zext i32 %47 to i64
   %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
-  br i1 %NullCheck16, label %51, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %51
 
 ; <label>:51                                      ; preds = %45
   %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
@@ -6847,15 +8293,15 @@ entry:
 ; <label>:57                                      ; preds = %51
   %58 = load i16*, i16** %arg1
   %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
-  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %60
 
 ; <label>:60                                      ; preds = %57
   %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
   %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
-  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %64
 
 ; <label>:64                                      ; preds = %60
   %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
@@ -6864,22 +8310,22 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
   %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
-  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %70
 
 ; <label>:70                                      ; preds = %64
   %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
   %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
-  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
-  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
   %75 = load i32, i32 addrspace(1)* %74
   %76 = zext i32 %75 to i64
   %77 = trunc i64 %76 to i32
-  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
-  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %78
 
 ; <label>:78                                      ; preds = %73
   %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
@@ -6901,8 +8347,8 @@ entry:
   %90 = bitcast i16* %86 to i8*
   %91 = getelementptr inbounds i8, i8* %90, i64 %89
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %93
 
 ; <label>:93                                      ; preds = %80
   %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
@@ -6912,8 +8358,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %99 = load i32, i32* %loc2
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %100
 
 ; <label>:100                                     ; preds = %93
   %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
@@ -6928,63 +8374,63 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %25
+ThrowNullRef6:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %32
+ThrowNullRef10:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %40
+ThrowNullRef12:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %45
+ThrowNullRef16:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %57
+ThrowNullRef18:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %60
+ThrowNullRef20:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %64
+ThrowNullRef22:                                   ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %70
+ThrowNullRef24:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %73
+ThrowNullRef26:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %80
+ThrowNullRef28:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %93
+ThrowNullRef30:                                   ; preds = %93
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7004,8 +8450,8 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
@@ -7033,43 +8479,43 @@ entry:
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %14
   %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
   %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   %28 = load i32, i32 addrspace(1)* %27, align 8
   %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
-  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %30
 
 ; <label>:30                                      ; preds = %26
   %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
   %32 = load i32, i32 addrspace(1)* %31, align 8
   %33 = add i32 %28, %32
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %34
 
 ; <label>:34                                      ; preds = %30
   %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   store i32 %33, i32 addrspace(1)* %35
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
   store i32 0, i32 addrspace(1)* %38
   %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %40
 
 ; <label>:40                                      ; preds = %37
   %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
@@ -7082,8 +8528,8 @@ entry:
 
 ; <label>:47                                      ; preds = %40
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
@@ -7098,8 +8544,8 @@ entry:
   %54 = load i32, i32* %loc0
   %55 = sext i32 %54 to i64
   %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
-  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %57
 
 ; <label>:57                                      ; preds = %52
   %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
@@ -7110,68 +8556,35 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %14
+ThrowNullRef2:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %23
+ThrowNullRef4:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %26
+ThrowNullRef6:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %30
+ThrowNullRef8:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %34
+ThrowNullRef10:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %47
+ThrowNullRef14:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %52
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-}
-
-INFO:  jitting method StringBuilder::get_Length using LLILCJit
-Successfully read StringBuilder.get_Length
-
-define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.StringBuilder addrspace(1)*
-  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
-  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
-
-; <label>:1                                       ; preds = %entry
-  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %3 = load i32, i32 addrspace(1)* %2, align 8
-  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
-
-; <label>:5                                       ; preds = %1
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = add i32 %3, %7
-  ret i32 %8
-
-ThrowNullRef:                                     ; preds = %entry
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef16:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7213,70 +8626,70 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
   %6 = load i32, i32 addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
   store i32 %6, i32 addrspace(1)* %8
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
   %13 = load i32, i32 addrspace(1)* %12, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
   store i32 %13, i32 addrspace(1)* %15
   %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
-  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %18
 
 ; <label>:18                                      ; preds = %14
   %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
   %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
   %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
   %34 = load i32, i32 addrspace(1)* %33, align 8
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
-  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
@@ -7287,39 +8700,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %28
+ThrowNullRef16:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %32
+ThrowNullRef18:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7455,13 +8868,13 @@ entry:
 ; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
@@ -7477,16 +8890,16 @@ entry:
 
 ; <label>:18                                      ; preds = %15
   %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
   store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
   %22 = load i32, i32* %loc0
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %24
 
 ; <label>:24                                      ; preds = %20
   %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
@@ -7498,13 +8911,13 @@ entry:
 ; <label>:28                                      ; preds = %15, %24
   %29 = load i32, i32* %arg1
   %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %31
   %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
@@ -7517,20 +8930,20 @@ entry:
   %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
-  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
   %46 = load i32, i32 addrspace(1)* %45, align 8
   %47 = sub i32 %40, %46
-  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
-  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i32 addrspace(1)* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %48
 
 ; <label>:48                                      ; preds = %44
   store i32 %47, i32 addrspace(1)* %39, align 8
@@ -7538,21 +8951,21 @@ entry:
 
 ; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
-  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %51
 
 ; <label>:51                                      ; preds = %49
   %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %53
 
 ; <label>:53                                      ; preds = %51
   %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
   %55 = load i32, i32 addrspace(1)* %54, align 8
   %56 = load i32, i32* %arg2
   %57 = sub i32 %55, %56
-  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %58
 
 ; <label>:58                                      ; preds = %53
   %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
@@ -7562,13 +8975,13 @@ entry:
 ; <label>:60                                      ; preds = %33, %58
   %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
   %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
-  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %63
 
 ; <label>:63                                      ; preds = %60
   %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
-  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
-  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
@@ -7578,15 +8991,15 @@ entry:
 
 ; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
-  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i32 addrspace(1)* %69, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %70
 
 ; <label>:70                                      ; preds = %68
   %71 = load i32, i32 addrspace(1)* %69, align 8
   store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
-  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
@@ -7596,8 +9009,8 @@ entry:
   store i32 %77, i32* %loc4
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
-  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %80
 
 ; <label>:80                                      ; preds = %73
   %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
@@ -7607,71 +9020,71 @@ entry:
 ; <label>:83                                      ; preds = %80
   store i32 0, i32* %loc3
   %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
-  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
-  br i1 %NullCheck26, label %88, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i32 addrspace(1)* %87, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %88
 
 ; <label>:88                                      ; preds = %85
   %89 = load i32, i32 addrspace(1)* %87, align 8
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
-  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %90
 
 ; <label>:90                                      ; preds = %88
   %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
   store i32 %89, i32 addrspace(1)* %91
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
-  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
-  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %96
 
 ; <label>:96                                      ; preds = %94
   %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
-  br i1 %NullCheck34, label %100, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %100
 
 ; <label>:100                                     ; preds = %96
   %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
-  br i1 %NullCheck36, label %102, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %102
 
 ; <label>:102                                     ; preds = %100
   %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
   %104 = load i32, i32 addrspace(1)* %103, align 8
   %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
-  br i1 %NullCheck38, label %106, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %106
 
 ; <label>:106                                     ; preds = %102
   %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
-  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
-  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %108
 
 ; <label>:108                                     ; preds = %106
   %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
   %110 = load i32, i32 addrspace(1)* %109, align 8
   %111 = add i32 %104, %110
-  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %112
 
 ; <label>:112                                     ; preds = %108
   %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
   store i32 %111, i32 addrspace(1)* %113
   %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
-  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i32 addrspace(1)* %114, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %115
 
 ; <label>:115                                     ; preds = %112
   %116 = load i32, i32 addrspace(1)* %114, align 8
@@ -7681,19 +9094,19 @@ entry:
 ; <label>:118                                     ; preds = %115
   %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
-  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %121
 
 ; <label>:121                                     ; preds = %118
   %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
-  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
-  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %123
 
 ; <label>:123                                     ; preds = %121
   %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
   %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
-  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
-  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %126
 
 ; <label>:126                                     ; preds = %123
   %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
@@ -7705,8 +9118,8 @@ entry:
 
 ; <label>:130                                     ; preds = %80, %115, %126
   %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %132
 
 ; <label>:132                                     ; preds = %130
   %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7715,8 +9128,8 @@ entry:
   %136 = load i32, i32* %loc3
   %137 = sub i32 %135, %136
   %138 = sub i32 %134, %137
-  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %139
 
 ; <label>:139                                     ; preds = %132
   %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7728,16 +9141,16 @@ entry:
 
 ; <label>:144                                     ; preds = %139
   %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
-  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %146
 
 ; <label>:146                                     ; preds = %144
   %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
   %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
   %149 = load i32, i32* %loc2
   %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
-  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %151
 
 ; <label>:151                                     ; preds = %146
   %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
@@ -7754,145 +9167,249 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %18
+ThrowNullRef4:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %31
+ThrowNullRef10:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %44
+ThrowNullRef16:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %68
+ThrowNullRef18:                                   ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %70
+ThrowNullRef20:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %73
+ThrowNullRef22:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %83
+ThrowNullRef24:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %85
+ThrowNullRef26:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %88
+ThrowNullRef28:                                   ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %90
+ThrowNullRef30:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %94
+ThrowNullRef32:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %96
+ThrowNullRef34:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %100
+ThrowNullRef36:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %102
+ThrowNullRef38:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %106
+ThrowNullRef40:                                   ; preds = %106
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %108
+ThrowNullRef42:                                   ; preds = %108
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %112
+ThrowNullRef44:                                   ; preds = %112
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %118
+ThrowNullRef46:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %121
+ThrowNullRef48:                                   ; preds = %121
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %123
+ThrowNullRef50:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %130
+ThrowNullRef52:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %132
+ThrowNullRef54:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %144
+ThrowNullRef56:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %146
+ThrowNullRef58:                                   ; preds = %146
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %60
+ThrowNullRef60:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %63
+ThrowNullRef62:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %49
+ThrowNullRef64:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %51
+ThrowNullRef66:                                   ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %53
+ThrowNullRef68:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(%"System.Char[]" addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %arg0 = alloca %"System.Char[]" addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store %"System.Char[]" addrspace(1)* %param0, %"System.Char[]" addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load i32, i32* %arg4
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %43, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %38, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg1
+  %13 = load i32, i32* %arg4
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %38, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %24 = load i32, i32* %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %35 = load i32, i32* %arg3
+  %36 = load i32, i32* %arg4
+  %37 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %37, %"System.Char[]" addrspace(1)* %34, i32 %35, i32 %36)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:38                                      ; preds = %5, %16
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Successfully read Buffer._Memmove
 
@@ -7914,7 +9431,7 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[loadElem]
+Failed to read AppDomain.SetDataHelper[storeElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -7923,8 +9440,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
@@ -7934,8 +9451,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
@@ -7947,15 +9464,15 @@ entry:
   %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
   %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
@@ -7966,15 +9483,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7992,7 +9509,79 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
-Failed to read Dictionary`2.TryGetValue[loadElemA]
+Successfully read Dictionary`2.TryGetValue
+
+define i8 @"Dictionary`2.TryGetValue"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)* addrspace(1)* %param2) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  %arg2 = alloca %System.__Canon addrspace(1)* addrspace(1)*
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  store %System.__Canon addrspace(1)* addrspace(1)* %param2, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  store i32 %2, i32* %loc0
+  %3 = load i32, i32* %loc0
+  %4 = icmp slt i32 %3, 0
+  br i1 %4, label %22, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 2
+  %10 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %9, align 8
+  %11 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = zext i32 %11 to i64
+  %BoundsCheck = icmp uge i64 %16, %15
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 3, i32 %11
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %20, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %6, %System.__Canon addrspace(1)* %21)
+  ret i8 1
+
+; <label>:22                                      ; preds = %entry
+  %23 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %23, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -8058,8 +9647,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
@@ -8091,8 +9680,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
@@ -8171,15 +9760,15 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck, label %19, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %ThrowNullRef, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
   %21 = load i32, i32 addrspace(1)* %20
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
@@ -8202,7 +9791,7 @@ ThrowNullRef:                                     ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %19
+ThrowNullRef2:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8248,8 +9837,8 @@ entry:
   %0 = alloca %System.AppDomainHandle
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %1 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %1, i32 0, i32 15
@@ -8269,8 +9858,8 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
@@ -8286,7 +9875,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -8299,8 +9888,8 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -8327,8 +9916,8 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
@@ -8352,8 +9941,8 @@ entry:
   %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
   store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
@@ -8363,8 +9952,8 @@ entry:
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
@@ -8374,8 +9963,8 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %9
   %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
@@ -8384,8 +9973,8 @@ entry:
 
 ; <label>:18                                      ; preds = %3, %16
   %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
@@ -8397,15 +9986,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %18
+ThrowNullRef6:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8418,8 +10007,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
@@ -8453,15 +10042,15 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
@@ -8473,7 +10062,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8481,7 +10070,7 @@ ThrowNullRef1:                                    ; preds = %1
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
 Failed to read Dictionary`2.System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
@@ -8506,8 +10095,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
@@ -8524,8 +10113,8 @@ entry:
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -8544,7 +10133,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8577,8 +10166,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = load i64, i64* %arg2
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = trunc i32 %3 to i8
@@ -8634,46 +10223,46 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
   %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
-  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
-  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
-  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
@@ -8684,27 +10273,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %20
+ThrowNullRef12:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8717,8 +10306,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -8756,22 +10345,22 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
   %9 = load i64, i64 addrspace(1)* %8, align 8
   %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
   %13 = load i64, i64 addrspace(1)* %12, align 8
   %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %11
   %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
@@ -8788,11 +10377,11 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8882,8 +10471,8 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
@@ -8900,8 +10489,8 @@ entry:
 ; <label>:8                                       ; preds = %1
   %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
   %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
@@ -8911,15 +10500,15 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
   %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
   %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
-  br i1 %NullCheck6, label %21, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
@@ -8946,15 +10535,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8992,15 +10581,15 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
   store i8 %3, i8 addrspace(1)* %5
   %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
@@ -9011,7 +10600,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9027,8 +10616,8 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -9041,8 +10630,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
@@ -9058,7 +10647,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9080,8 +10669,8 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
@@ -9096,8 +10685,8 @@ entry:
 ; <label>:12                                      ; preds = %6
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
@@ -9112,8 +10701,8 @@ entry:
 ; <label>:21                                      ; preds = %15
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
@@ -9128,8 +10717,8 @@ entry:
 ; <label>:30                                      ; preds = %24
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %31, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
@@ -9144,8 +10733,8 @@ entry:
 ; <label>:39                                      ; preds = %33
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
-  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %40, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %42
 
 ; <label>:42                                      ; preds = %39
   %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
@@ -9164,19 +10753,19 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %21
+ThrowNullRef4:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %30
+ThrowNullRef6:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %39
+ThrowNullRef8:                                    ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9243,8 +10832,8 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
@@ -9264,57 +10853,57 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
   store i8 0, i8 addrspace(1)* %2
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
   store i8 0, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
   store i8 0, i8 addrspace(1)* %17
   %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
   store i8 0, i8 addrspace(1)* %20
   %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
-  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
@@ -9325,31 +10914,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %19
+ThrowNullRef14:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9367,8 +10956,8 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
@@ -9380,8 +10969,8 @@ entry:
 
 ; <label>:9                                       ; preds = %4
   %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %9
   %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
@@ -9395,7 +10984,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef2:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9420,8 +11009,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
@@ -9512,8 +11101,8 @@ entry:
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
@@ -9524,8 +11113,8 @@ entry:
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = load i64, i64 addrspace(1)* %12
@@ -9537,8 +11126,8 @@ entry:
   %20 = load i64, i64* %19
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
-  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %13
   %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
@@ -9555,8 +11144,8 @@ entry:
 ; <label>:30                                      ; preds = %25
   %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %32 = load i32, i32* %arg2
-  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
-  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
@@ -9570,15 +11159,15 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %30
+ThrowNullRef2:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9622,87 +11211,87 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
   %10 = load i8, i8 addrspace(1)* %9, align 8
   %11 = zext i8 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %8
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
   store i8 %12, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
   %19 = load i8, i8 addrspace(1)* %18, align 8
   %20 = zext i8 %19 to i32
   %21 = trunc i32 %20 to i8
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
   store i8 %21, i8 addrspace(1)* %23
   %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
   %28 = load i8, i8 addrspace(1)* %27, align 8
   %29 = zext i8 %28 to i32
   %30 = trunc i32 %29 to i8
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
-  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %31
 
 ; <label>:31                                      ; preds = %26
   %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
   store i8 %30, i8 addrspace(1)* %32
   %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
-  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
-  br i1 %NullCheck14, label %40, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %40
 
 ; <label>:40                                      ; preds = %35
   %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
   store i8 %39, i8 addrspace(1)* %41
   %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
-  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %44
 
 ; <label>:44                                      ; preds = %40
   %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
   %46 = load i8, i8 addrspace(1)* %45, align 8
   %47 = zext i8 %46 to i32
   %48 = trunc i32 %47 to i8
-  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
   store i8 %48, i8 addrspace(1)* %50
   %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
-  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
@@ -9713,29 +11302,29 @@ entry:
 ; <label>:56                                      ; preds = %52
   %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
-  br i1 %NullCheck22, label %59, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
   %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
   %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
-  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
-  br i1 %NullCheck24, label %63, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
   %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
-  br i1 %NullCheck26, label %66, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
   %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
-  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
-  br i1 %NullCheck28, label %69, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %69
 
 ; <label>:69                                      ; preds = %66
   %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
@@ -9744,15 +11333,15 @@ entry:
 
 ; <label>:71                                      ; preds = %105
   %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
-  br i1 %NullCheck34, label %73, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %73
 
 ; <label>:73                                      ; preds = %71
   %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
   %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
   %76 = load i32, i32* %loc0
-  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
-  br i1 %NullCheck36, label %77, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
@@ -9766,8 +11355,8 @@ entry:
 
 ; <label>:83                                      ; preds = %77
   %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
-  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
@@ -9775,14 +11364,14 @@ entry:
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
   %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
-  br i1 %NullCheck40, label %91, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
 ; <label>:91                                      ; preds = %85
   %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
   %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
-  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck42, label %94, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %94
 
 ; <label>:94                                      ; preds = %91
   %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
@@ -9798,14 +11387,14 @@ entry:
 ; <label>:99                                      ; preds = %69, %96
   %100 = load i32, i32* %loc0
   %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
-  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %102
 
 ; <label>:102                                     ; preds = %99
   %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
   %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
-  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
-  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
@@ -9819,87 +11408,87 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %26
+ThrowNullRef10:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %31
+ThrowNullRef12:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %35
+ThrowNullRef14:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %40
+ThrowNullRef16:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %56
+ThrowNullRef22:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %59
+ThrowNullRef24:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %63
+ThrowNullRef26:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %66
+ThrowNullRef28:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %102
+ThrowNullRef32:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %71
+ThrowNullRef34:                                   ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %73
+ThrowNullRef36:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %83
+ThrowNullRef38:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %85
+ThrowNullRef40:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %91
+ThrowNullRef42:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9943,15 +11532,15 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
   %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
@@ -9961,28 +11550,28 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
   %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %12
   %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
   %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
   %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
-  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
@@ -9993,23 +11582,23 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %12
+ThrowNullRef6:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10031,15 +11620,15 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
   %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = load i64, i64 addrspace(1)* %7
@@ -10077,13 +11666,13 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[loadElem]
+Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -10111,8 +11700,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1

--- a/test/BaseLine/JIT/CodeGenBringUpTests/AsgSub1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/AsgSub1.error.txt
@@ -25,8 +25,8 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
@@ -40,8 +40,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
   %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
@@ -75,7 +75,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -90,8 +90,8 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %NullCheck = icmp ne i8 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = load i8, i8 addrspace(1)* %0, align 8
@@ -125,8 +125,8 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
@@ -159,8 +159,8 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -184,8 +184,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
   store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
@@ -195,8 +195,8 @@ entry:
 ; <label>:4                                       ; preds = %1
   %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
   %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
@@ -206,8 +206,8 @@ entry:
   %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
@@ -221,14 +221,14 @@ entry:
 
 ; <label>:17                                      ; preds = %14
   %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
   %21 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
@@ -238,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -249,8 +249,8 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
@@ -261,27 +261,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %30
+ThrowNullRef10:                                   ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -301,7 +301,89 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
-Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
+Successfully read AppDomainSetup.GetUnsecureApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.GetUnsecureApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %NullCheck = icmp eq %"System.String[]" addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %BoundsCheck = icmp uge i64 0, %5
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %6
+
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 3, i32 0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
+  ret %System.String addrspace(1)* %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_Value using LLILCJit
+Successfully read AppDomainSetup.get_Value
+
+define %"System.String[]" addrspace(1)* @AppDomainSetup.get_Value(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.String[]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 18)
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.String[]" addrspace(1)* addrspace(1)*, %"System.String[]" addrspace(1)*)*)(%"System.String[]" addrspace(1)* addrspace(1)* %9, %"System.String[]" addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %11, i32 0, i32 1
+  %14 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %13, align 8
+  ret %"System.String[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -319,8 +401,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -368,16 +450,16 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
   %5 = load i32, i32 addrspace(1)* %4
   %6 = sub i32 %5, 1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -389,7 +471,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -421,8 +503,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
@@ -456,8 +538,8 @@ entry:
 ; <label>:27                                      ; preds = %19
   %28 = load i32, i32* %arg1
   %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
-  br i1 %NullCheck2, label %30, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %29, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %30
 
 ; <label>:30                                      ; preds = %27
   %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
@@ -493,8 +575,8 @@ entry:
 ; <label>:49                                      ; preds = %46
   %50 = load i32, i32* %arg2
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck4, label %52, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
@@ -517,11 +599,11 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %27
+ThrowNullRef2:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %49
+ThrowNullRef4:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -544,16 +626,16 @@ entry:
   %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %0)
   store %System.String addrspace(1)* %1, %System.String addrspace(1)** %loc0
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 2
   %5 = bitcast [0 x i16] addrspace(1)* %4 to i16 addrspace(1)*
   store i16 addrspace(1)* %5, i16 addrspace(1)** %loc1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %3
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2
@@ -580,7 +662,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -691,15 +773,15 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %NullCheck132 = icmp ne i8* %21, null
-  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+  %NullCheck131 = icmp eq i8* %21, null
+  br i1 %NullCheck131, label %ThrowNullRef132, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = load i8, i8* %21, align 8
   %24 = zext i8 %23 to i32
   %25 = trunc i32 %24 to i8
-  %NullCheck134 = icmp ne i8* %20, null
-  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+  %NullCheck133 = icmp eq i8* %20, null
+  br i1 %NullCheck133, label %ThrowNullRef134, label %26
 
 ; <label>:26                                      ; preds = %22
   store i8 %25, i8* %20, align 8
@@ -709,16 +791,16 @@ entry:
   %28 = load i8*, i8** %arg0
   %29 = load i8*, i8** %arg1
   %30 = bitcast i8* %29 to i16*
-  %NullCheck128 = icmp ne i16* %30, null
-  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+  %NullCheck127 = icmp eq i16* %30, null
+  br i1 %NullCheck127, label %ThrowNullRef128, label %31
 
 ; <label>:31                                      ; preds = %27
   %32 = load i16, i16* %30, align 8
   %33 = sext i16 %32 to i32
   %34 = bitcast i8* %28 to i16*
   %35 = trunc i32 %33 to i16
-  %NullCheck130 = icmp ne i16* %34, null
-  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+  %NullCheck129 = icmp eq i16* %34, null
+  br i1 %NullCheck129, label %ThrowNullRef130, label %36
 
 ; <label>:36                                      ; preds = %31
   store i16 %35, i16* %34, align 8
@@ -728,16 +810,16 @@ entry:
   %38 = load i8*, i8** %arg0
   %39 = load i8*, i8** %arg1
   %40 = bitcast i8* %39 to i16*
-  %NullCheck120 = icmp ne i16* %40, null
-  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+  %NullCheck119 = icmp eq i16* %40, null
+  br i1 %NullCheck119, label %ThrowNullRef120, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i16, i16* %40, align 8
   %43 = sext i16 %42 to i32
   %44 = bitcast i8* %38 to i16*
   %45 = trunc i32 %43 to i16
-  %NullCheck122 = icmp ne i16* %44, null
-  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+  %NullCheck121 = icmp eq i16* %44, null
+  br i1 %NullCheck121, label %ThrowNullRef122, label %46
 
 ; <label>:46                                      ; preds = %41
   store i16 %45, i16* %44, align 8
@@ -745,15 +827,15 @@ entry:
   %48 = getelementptr inbounds i8, i8* %47, i64 2
   %49 = load i8*, i8** %arg1
   %50 = getelementptr inbounds i8, i8* %49, i64 2
-  %NullCheck124 = icmp ne i8* %50, null
-  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+  %NullCheck123 = icmp eq i8* %50, null
+  br i1 %NullCheck123, label %ThrowNullRef124, label %51
 
 ; <label>:51                                      ; preds = %46
   %52 = load i8, i8* %50, align 8
   %53 = zext i8 %52 to i32
   %54 = trunc i32 %53 to i8
-  %NullCheck126 = icmp ne i8* %48, null
-  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+  %NullCheck125 = icmp eq i8* %48, null
+  br i1 %NullCheck125, label %ThrowNullRef126, label %55
 
 ; <label>:55                                      ; preds = %51
   store i8 %54, i8* %48, align 8
@@ -763,14 +845,14 @@ entry:
   %57 = load i8*, i8** %arg0
   %58 = load i8*, i8** %arg1
   %59 = bitcast i8* %58 to i32*
-  %NullCheck116 = icmp ne i32* %59, null
-  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+  %NullCheck115 = icmp eq i32* %59, null
+  br i1 %NullCheck115, label %ThrowNullRef116, label %60
 
 ; <label>:60                                      ; preds = %56
   %61 = load i32, i32* %59, align 8
   %62 = bitcast i8* %57 to i32*
-  %NullCheck118 = icmp ne i32* %62, null
-  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+  %NullCheck117 = icmp eq i32* %62, null
+  br i1 %NullCheck117, label %ThrowNullRef118, label %63
 
 ; <label>:63                                      ; preds = %60
   store i32 %61, i32* %62, align 8
@@ -780,14 +862,14 @@ entry:
   %65 = load i8*, i8** %arg0
   %66 = load i8*, i8** %arg1
   %67 = bitcast i8* %66 to i32*
-  %NullCheck108 = icmp ne i32* %67, null
-  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+  %NullCheck107 = icmp eq i32* %67, null
+  br i1 %NullCheck107, label %ThrowNullRef108, label %68
 
 ; <label>:68                                      ; preds = %64
   %69 = load i32, i32* %67, align 8
   %70 = bitcast i8* %65 to i32*
-  %NullCheck110 = icmp ne i32* %70, null
-  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+  %NullCheck109 = icmp eq i32* %70, null
+  br i1 %NullCheck109, label %ThrowNullRef110, label %71
 
 ; <label>:71                                      ; preds = %68
   store i32 %69, i32* %70, align 8
@@ -795,15 +877,15 @@ entry:
   %73 = getelementptr inbounds i8, i8* %72, i64 4
   %74 = load i8*, i8** %arg1
   %75 = getelementptr inbounds i8, i8* %74, i64 4
-  %NullCheck112 = icmp ne i8* %75, null
-  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+  %NullCheck111 = icmp eq i8* %75, null
+  br i1 %NullCheck111, label %ThrowNullRef112, label %76
 
 ; <label>:76                                      ; preds = %71
   %77 = load i8, i8* %75, align 8
   %78 = zext i8 %77 to i32
   %79 = trunc i32 %78 to i8
-  %NullCheck114 = icmp ne i8* %73, null
-  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+  %NullCheck113 = icmp eq i8* %73, null
+  br i1 %NullCheck113, label %ThrowNullRef114, label %80
 
 ; <label>:80                                      ; preds = %76
   store i8 %79, i8* %73, align 8
@@ -813,14 +895,14 @@ entry:
   %82 = load i8*, i8** %arg0
   %83 = load i8*, i8** %arg1
   %84 = bitcast i8* %83 to i32*
-  %NullCheck100 = icmp ne i32* %84, null
-  br i1 %NullCheck100, label %85, label %ThrowNullRef99
+  %NullCheck99 = icmp eq i32* %84, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %85
 
 ; <label>:85                                      ; preds = %81
   %86 = load i32, i32* %84, align 8
   %87 = bitcast i8* %82 to i32*
-  %NullCheck102 = icmp ne i32* %87, null
-  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+  %NullCheck101 = icmp eq i32* %87, null
+  br i1 %NullCheck101, label %ThrowNullRef102, label %88
 
 ; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
@@ -829,16 +911,16 @@ entry:
   %91 = load i8*, i8** %arg1
   %92 = getelementptr inbounds i8, i8* %91, i64 4
   %93 = bitcast i8* %92 to i16*
-  %NullCheck104 = icmp ne i16* %93, null
-  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+  %NullCheck103 = icmp eq i16* %93, null
+  br i1 %NullCheck103, label %ThrowNullRef104, label %94
 
 ; <label>:94                                      ; preds = %88
   %95 = load i16, i16* %93, align 8
   %96 = sext i16 %95 to i32
   %97 = bitcast i8* %90 to i16*
   %98 = trunc i32 %96 to i16
-  %NullCheck106 = icmp ne i16* %97, null
-  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+  %NullCheck105 = icmp eq i16* %97, null
+  br i1 %NullCheck105, label %ThrowNullRef106, label %99
 
 ; <label>:99                                      ; preds = %94
   store i16 %98, i16* %97, align 8
@@ -848,14 +930,14 @@ entry:
   %101 = load i8*, i8** %arg0
   %102 = load i8*, i8** %arg1
   %103 = bitcast i8* %102 to i32*
-  %NullCheck88 = icmp ne i32* %103, null
-  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+  %NullCheck87 = icmp eq i32* %103, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %104
 
 ; <label>:104                                     ; preds = %100
   %105 = load i32, i32* %103, align 8
   %106 = bitcast i8* %101 to i32*
-  %NullCheck90 = icmp ne i32* %106, null
-  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+  %NullCheck89 = icmp eq i32* %106, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %107
 
 ; <label>:107                                     ; preds = %104
   store i32 %105, i32* %106, align 8
@@ -864,16 +946,16 @@ entry:
   %110 = load i8*, i8** %arg1
   %111 = getelementptr inbounds i8, i8* %110, i64 4
   %112 = bitcast i8* %111 to i16*
-  %NullCheck92 = icmp ne i16* %112, null
-  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+  %NullCheck91 = icmp eq i16* %112, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %113
 
 ; <label>:113                                     ; preds = %107
   %114 = load i16, i16* %112, align 8
   %115 = sext i16 %114 to i32
   %116 = bitcast i8* %109 to i16*
   %117 = trunc i32 %115 to i16
-  %NullCheck94 = icmp ne i16* %116, null
-  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+  %NullCheck93 = icmp eq i16* %116, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %118
 
 ; <label>:118                                     ; preds = %113
   store i16 %117, i16* %116, align 8
@@ -881,15 +963,15 @@ entry:
   %120 = getelementptr inbounds i8, i8* %119, i64 6
   %121 = load i8*, i8** %arg1
   %122 = getelementptr inbounds i8, i8* %121, i64 6
-  %NullCheck96 = icmp ne i8* %122, null
-  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+  %NullCheck95 = icmp eq i8* %122, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %123
 
 ; <label>:123                                     ; preds = %118
   %124 = load i8, i8* %122, align 8
   %125 = zext i8 %124 to i32
   %126 = trunc i32 %125 to i8
-  %NullCheck98 = icmp ne i8* %120, null
-  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+  %NullCheck97 = icmp eq i8* %120, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %127
 
 ; <label>:127                                     ; preds = %123
   store i8 %126, i8* %120, align 8
@@ -899,14 +981,14 @@ entry:
   %129 = load i8*, i8** %arg0
   %130 = load i8*, i8** %arg1
   %131 = bitcast i8* %130 to i64*
-  %NullCheck84 = icmp ne i64* %131, null
-  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+  %NullCheck83 = icmp eq i64* %131, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %132
 
 ; <label>:132                                     ; preds = %128
   %133 = load i64, i64* %131, align 8
   %134 = bitcast i8* %129 to i64*
-  %NullCheck86 = icmp ne i64* %134, null
-  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+  %NullCheck85 = icmp eq i64* %134, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %135
 
 ; <label>:135                                     ; preds = %132
   store i64 %133, i64* %134, align 8
@@ -916,14 +998,14 @@ entry:
   %137 = load i8*, i8** %arg0
   %138 = load i8*, i8** %arg1
   %139 = bitcast i8* %138 to i64*
-  %NullCheck76 = icmp ne i64* %139, null
-  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+  %NullCheck75 = icmp eq i64* %139, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %140
 
 ; <label>:140                                     ; preds = %136
   %141 = load i64, i64* %139, align 8
   %142 = bitcast i8* %137 to i64*
-  %NullCheck78 = icmp ne i64* %142, null
-  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+  %NullCheck77 = icmp eq i64* %142, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %143
 
 ; <label>:143                                     ; preds = %140
   store i64 %141, i64* %142, align 8
@@ -931,15 +1013,15 @@ entry:
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %NullCheck80 = icmp ne i8* %147, null
-  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+  %NullCheck79 = icmp eq i8* %147, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %148
 
 ; <label>:148                                     ; preds = %143
   %149 = load i8, i8* %147, align 8
   %150 = zext i8 %149 to i32
   %151 = trunc i32 %150 to i8
-  %NullCheck82 = icmp ne i8* %145, null
-  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+  %NullCheck81 = icmp eq i8* %145, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %152
 
 ; <label>:152                                     ; preds = %148
   store i8 %151, i8* %145, align 8
@@ -949,14 +1031,14 @@ entry:
   %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
   %156 = bitcast i8* %155 to i64*
-  %NullCheck68 = icmp ne i64* %156, null
-  br i1 %NullCheck68, label %157, label %ThrowNullRef67
+  %NullCheck67 = icmp eq i64* %156, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %157
 
 ; <label>:157                                     ; preds = %153
   %158 = load i64, i64* %156, align 8
   %159 = bitcast i8* %154 to i64*
-  %NullCheck70 = icmp ne i64* %159, null
-  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+  %NullCheck69 = icmp eq i64* %159, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %160
 
 ; <label>:160                                     ; preds = %157
   store i64 %158, i64* %159, align 8
@@ -965,16 +1047,16 @@ entry:
   %163 = load i8*, i8** %arg1
   %164 = getelementptr inbounds i8, i8* %163, i64 8
   %165 = bitcast i8* %164 to i16*
-  %NullCheck72 = icmp ne i16* %165, null
-  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+  %NullCheck71 = icmp eq i16* %165, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %166
 
 ; <label>:166                                     ; preds = %160
   %167 = load i16, i16* %165, align 8
   %168 = sext i16 %167 to i32
   %169 = bitcast i8* %162 to i16*
   %170 = trunc i32 %168 to i16
-  %NullCheck74 = icmp ne i16* %169, null
-  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+  %NullCheck73 = icmp eq i16* %169, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %171
 
 ; <label>:171                                     ; preds = %166
   store i16 %170, i16* %169, align 8
@@ -984,14 +1066,14 @@ entry:
   %173 = load i8*, i8** %arg0
   %174 = load i8*, i8** %arg1
   %175 = bitcast i8* %174 to i64*
-  %NullCheck56 = icmp ne i64* %175, null
-  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+  %NullCheck55 = icmp eq i64* %175, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %176
 
 ; <label>:176                                     ; preds = %172
   %177 = load i64, i64* %175, align 8
   %178 = bitcast i8* %173 to i64*
-  %NullCheck58 = icmp ne i64* %178, null
-  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+  %NullCheck57 = icmp eq i64* %178, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %179
 
 ; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
@@ -1000,16 +1082,16 @@ entry:
   %182 = load i8*, i8** %arg1
   %183 = getelementptr inbounds i8, i8* %182, i64 8
   %184 = bitcast i8* %183 to i16*
-  %NullCheck60 = icmp ne i16* %184, null
-  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+  %NullCheck59 = icmp eq i16* %184, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %185
 
 ; <label>:185                                     ; preds = %179
   %186 = load i16, i16* %184, align 8
   %187 = sext i16 %186 to i32
   %188 = bitcast i8* %181 to i16*
   %189 = trunc i32 %187 to i16
-  %NullCheck62 = icmp ne i16* %188, null
-  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+  %NullCheck61 = icmp eq i16* %188, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %190
 
 ; <label>:190                                     ; preds = %185
   store i16 %189, i16* %188, align 8
@@ -1017,15 +1099,15 @@ entry:
   %192 = getelementptr inbounds i8, i8* %191, i64 10
   %193 = load i8*, i8** %arg1
   %194 = getelementptr inbounds i8, i8* %193, i64 10
-  %NullCheck64 = icmp ne i8* %194, null
-  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+  %NullCheck63 = icmp eq i8* %194, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %195
 
 ; <label>:195                                     ; preds = %190
   %196 = load i8, i8* %194, align 8
   %197 = zext i8 %196 to i32
   %198 = trunc i32 %197 to i8
-  %NullCheck66 = icmp ne i8* %192, null
-  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+  %NullCheck65 = icmp eq i8* %192, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %199
 
 ; <label>:199                                     ; preds = %195
   store i8 %198, i8* %192, align 8
@@ -1035,14 +1117,14 @@ entry:
   %201 = load i8*, i8** %arg0
   %202 = load i8*, i8** %arg1
   %203 = bitcast i8* %202 to i64*
-  %NullCheck48 = icmp ne i64* %203, null
-  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+  %NullCheck47 = icmp eq i64* %203, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %204
 
 ; <label>:204                                     ; preds = %200
   %205 = load i64, i64* %203, align 8
   %206 = bitcast i8* %201 to i64*
-  %NullCheck50 = icmp ne i64* %206, null
-  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+  %NullCheck49 = icmp eq i64* %206, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %207
 
 ; <label>:207                                     ; preds = %204
   store i64 %205, i64* %206, align 8
@@ -1051,14 +1133,14 @@ entry:
   %210 = load i8*, i8** %arg1
   %211 = getelementptr inbounds i8, i8* %210, i64 8
   %212 = bitcast i8* %211 to i32*
-  %NullCheck52 = icmp ne i32* %212, null
-  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+  %NullCheck51 = icmp eq i32* %212, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %213
 
 ; <label>:213                                     ; preds = %207
   %214 = load i32, i32* %212, align 8
   %215 = bitcast i8* %209 to i32*
-  %NullCheck54 = icmp ne i32* %215, null
-  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+  %NullCheck53 = icmp eq i32* %215, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %216
 
 ; <label>:216                                     ; preds = %213
   store i32 %214, i32* %215, align 8
@@ -1068,14 +1150,14 @@ entry:
   %218 = load i8*, i8** %arg0
   %219 = load i8*, i8** %arg1
   %220 = bitcast i8* %219 to i64*
-  %NullCheck36 = icmp ne i64* %220, null
-  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64* %220, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %221
 
 ; <label>:221                                     ; preds = %217
   %222 = load i64, i64* %220, align 8
   %223 = bitcast i8* %218 to i64*
-  %NullCheck38 = icmp ne i64* %223, null
-  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+  %NullCheck37 = icmp eq i64* %223, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %224
 
 ; <label>:224                                     ; preds = %221
   store i64 %222, i64* %223, align 8
@@ -1084,14 +1166,14 @@ entry:
   %227 = load i8*, i8** %arg1
   %228 = getelementptr inbounds i8, i8* %227, i64 8
   %229 = bitcast i8* %228 to i32*
-  %NullCheck40 = icmp ne i32* %229, null
-  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i32* %229, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %230
 
 ; <label>:230                                     ; preds = %224
   %231 = load i32, i32* %229, align 8
   %232 = bitcast i8* %226 to i32*
-  %NullCheck42 = icmp ne i32* %232, null
-  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+  %NullCheck41 = icmp eq i32* %232, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %233
 
 ; <label>:233                                     ; preds = %230
   store i32 %231, i32* %232, align 8
@@ -1099,15 +1181,15 @@ entry:
   %235 = getelementptr inbounds i8, i8* %234, i64 12
   %236 = load i8*, i8** %arg1
   %237 = getelementptr inbounds i8, i8* %236, i64 12
-  %NullCheck44 = icmp ne i8* %237, null
-  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i8* %237, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %238
 
 ; <label>:238                                     ; preds = %233
   %239 = load i8, i8* %237, align 8
   %240 = zext i8 %239 to i32
   %241 = trunc i32 %240 to i8
-  %NullCheck46 = icmp ne i8* %235, null
-  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+  %NullCheck45 = icmp eq i8* %235, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %242
 
 ; <label>:242                                     ; preds = %238
   store i8 %241, i8* %235, align 8
@@ -1117,14 +1199,14 @@ entry:
   %244 = load i8*, i8** %arg0
   %245 = load i8*, i8** %arg1
   %246 = bitcast i8* %245 to i64*
-  %NullCheck24 = icmp ne i64* %246, null
-  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64* %246, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %247
 
 ; <label>:247                                     ; preds = %243
   %248 = load i64, i64* %246, align 8
   %249 = bitcast i8* %244 to i64*
-  %NullCheck26 = icmp ne i64* %249, null
-  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64* %249, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %250
 
 ; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
@@ -1133,14 +1215,14 @@ entry:
   %253 = load i8*, i8** %arg1
   %254 = getelementptr inbounds i8, i8* %253, i64 8
   %255 = bitcast i8* %254 to i32*
-  %NullCheck28 = icmp ne i32* %255, null
-  br i1 %NullCheck28, label %256, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i32* %255, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %256
 
 ; <label>:256                                     ; preds = %250
   %257 = load i32, i32* %255, align 8
   %258 = bitcast i8* %252 to i32*
-  %NullCheck30 = icmp ne i32* %258, null
-  br i1 %NullCheck30, label %259, label %ThrowNullRef29
+  %NullCheck29 = icmp eq i32* %258, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %259
 
 ; <label>:259                                     ; preds = %256
   store i32 %257, i32* %258, align 8
@@ -1149,16 +1231,16 @@ entry:
   %262 = load i8*, i8** %arg1
   %263 = getelementptr inbounds i8, i8* %262, i64 12
   %264 = bitcast i8* %263 to i16*
-  %NullCheck32 = icmp ne i16* %264, null
-  br i1 %NullCheck32, label %265, label %ThrowNullRef31
+  %NullCheck31 = icmp eq i16* %264, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %265
 
 ; <label>:265                                     ; preds = %259
   %266 = load i16, i16* %264, align 8
   %267 = sext i16 %266 to i32
   %268 = bitcast i8* %261 to i16*
   %269 = trunc i32 %267 to i16
-  %NullCheck34 = icmp ne i16* %268, null
-  br i1 %NullCheck34, label %270, label %ThrowNullRef33
+  %NullCheck33 = icmp eq i16* %268, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %270
 
 ; <label>:270                                     ; preds = %265
   store i16 %269, i16* %268, align 8
@@ -1168,14 +1250,14 @@ entry:
   %272 = load i8*, i8** %arg0
   %273 = load i8*, i8** %arg1
   %274 = bitcast i8* %273 to i64*
-  %NullCheck8 = icmp ne i64* %274, null
-  br i1 %NullCheck8, label %275, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64* %274, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %275
 
 ; <label>:275                                     ; preds = %271
   %276 = load i64, i64* %274, align 8
   %277 = bitcast i8* %272 to i64*
-  %NullCheck10 = icmp ne i64* %277, null
-  br i1 %NullCheck10, label %278, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %277, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %278
 
 ; <label>:278                                     ; preds = %275
   store i64 %276, i64* %277, align 8
@@ -1184,14 +1266,14 @@ entry:
   %281 = load i8*, i8** %arg1
   %282 = getelementptr inbounds i8, i8* %281, i64 8
   %283 = bitcast i8* %282 to i32*
-  %NullCheck12 = icmp ne i32* %283, null
-  br i1 %NullCheck12, label %284, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i32* %283, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %284
 
 ; <label>:284                                     ; preds = %278
   %285 = load i32, i32* %283, align 8
   %286 = bitcast i8* %280 to i32*
-  %NullCheck14 = icmp ne i32* %286, null
-  br i1 %NullCheck14, label %287, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i32* %286, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %287
 
 ; <label>:287                                     ; preds = %284
   store i32 %285, i32* %286, align 8
@@ -1200,16 +1282,16 @@ entry:
   %290 = load i8*, i8** %arg1
   %291 = getelementptr inbounds i8, i8* %290, i64 12
   %292 = bitcast i8* %291 to i16*
-  %NullCheck16 = icmp ne i16* %292, null
-  br i1 %NullCheck16, label %293, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i16* %292, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %293
 
 ; <label>:293                                     ; preds = %287
   %294 = load i16, i16* %292, align 8
   %295 = sext i16 %294 to i32
   %296 = bitcast i8* %289 to i16*
   %297 = trunc i32 %295 to i16
-  %NullCheck18 = icmp ne i16* %296, null
-  br i1 %NullCheck18, label %298, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i16* %296, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %298
 
 ; <label>:298                                     ; preds = %293
   store i16 %297, i16* %296, align 8
@@ -1217,15 +1299,15 @@ entry:
   %300 = getelementptr inbounds i8, i8* %299, i64 14
   %301 = load i8*, i8** %arg1
   %302 = getelementptr inbounds i8, i8* %301, i64 14
-  %NullCheck20 = icmp ne i8* %302, null
-  br i1 %NullCheck20, label %303, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i8* %302, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %303
 
 ; <label>:303                                     ; preds = %298
   %304 = load i8, i8* %302, align 8
   %305 = zext i8 %304 to i32
   %306 = trunc i32 %305 to i8
-  %NullCheck22 = icmp ne i8* %300, null
-  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i8* %300, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %307
 
 ; <label>:307                                     ; preds = %303
   store i8 %306, i8* %300, align 8
@@ -1235,14 +1317,14 @@ entry:
   %309 = load i8*, i8** %arg0
   %310 = load i8*, i8** %arg1
   %311 = bitcast i8* %310 to i64*
-  %NullCheck = icmp ne i64* %311, null
-  br i1 %NullCheck, label %312, label %ThrowNullRef
+  %NullCheck = icmp eq i64* %311, null
+  br i1 %NullCheck, label %ThrowNullRef, label %312
 
 ; <label>:312                                     ; preds = %308
   %313 = load i64, i64* %311, align 8
   %314 = bitcast i8* %309 to i64*
-  %NullCheck2 = icmp ne i64* %314, null
-  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64* %314, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %315
 
 ; <label>:315                                     ; preds = %312
   store i64 %313, i64* %314, align 8
@@ -1251,14 +1333,14 @@ entry:
   %318 = load i8*, i8** %arg1
   %319 = getelementptr inbounds i8, i8* %318, i64 8
   %320 = bitcast i8* %319 to i64*
-  %NullCheck4 = icmp ne i64* %320, null
-  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64* %320, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %321
 
 ; <label>:321                                     ; preds = %315
   %322 = load i64, i64* %320, align 8
   %323 = bitcast i8* %317 to i64*
-  %NullCheck6 = icmp ne i64* %323, null
-  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64* %323, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %324
 
 ; <label>:324                                     ; preds = %321
   store i64 %322, i64* %323, align 8
@@ -1286,15 +1368,15 @@ entry:
 ; <label>:338                                     ; preds = %333
   %339 = load i8*, i8** %arg0
   %340 = load i8*, i8** %arg1
-  %NullCheck136 = icmp ne i8* %340, null
-  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+  %NullCheck135 = icmp eq i8* %340, null
+  br i1 %NullCheck135, label %ThrowNullRef136, label %341
 
 ; <label>:341                                     ; preds = %338
   %342 = load i8, i8* %340, align 8
   %343 = zext i8 %342 to i32
   %344 = trunc i32 %343 to i8
-  %NullCheck138 = icmp ne i8* %339, null
-  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+  %NullCheck137 = icmp eq i8* %339, null
+  br i1 %NullCheck137, label %ThrowNullRef138, label %345
 
 ; <label>:345                                     ; preds = %341
   store i8 %344, i8* %339, align 8
@@ -1317,16 +1399,16 @@ entry:
   %357 = load i8*, i8** %arg0
   %358 = load i8*, i8** %arg1
   %359 = bitcast i8* %358 to i16*
-  %NullCheck140 = icmp ne i16* %359, null
-  br i1 %NullCheck140, label %360, label %ThrowNullRef139
+  %NullCheck139 = icmp eq i16* %359, null
+  br i1 %NullCheck139, label %ThrowNullRef140, label %360
 
 ; <label>:360                                     ; preds = %356
   %361 = load i16, i16* %359, align 8
   %362 = sext i16 %361 to i32
   %363 = bitcast i8* %357 to i16*
   %364 = trunc i32 %362 to i16
-  %NullCheck142 = icmp ne i16* %363, null
-  br i1 %NullCheck142, label %365, label %ThrowNullRef141
+  %NullCheck141 = icmp eq i16* %363, null
+  br i1 %NullCheck141, label %ThrowNullRef142, label %365
 
 ; <label>:365                                     ; preds = %360
   store i16 %364, i16* %363, align 8
@@ -1352,14 +1434,14 @@ entry:
   %378 = load i8*, i8** %arg0
   %379 = load i8*, i8** %arg1
   %380 = bitcast i8* %379 to i32*
-  %NullCheck144 = icmp ne i32* %380, null
-  br i1 %NullCheck144, label %381, label %ThrowNullRef143
+  %NullCheck143 = icmp eq i32* %380, null
+  br i1 %NullCheck143, label %ThrowNullRef144, label %381
 
 ; <label>:381                                     ; preds = %377
   %382 = load i32, i32* %380, align 8
   %383 = bitcast i8* %378 to i32*
-  %NullCheck146 = icmp ne i32* %383, null
-  br i1 %NullCheck146, label %384, label %ThrowNullRef145
+  %NullCheck145 = icmp eq i32* %383, null
+  br i1 %NullCheck145, label %ThrowNullRef146, label %384
 
 ; <label>:384                                     ; preds = %381
   store i32 %382, i32* %383, align 8
@@ -1384,14 +1466,14 @@ entry:
   %395 = load i8*, i8** %arg0
   %396 = load i8*, i8** %arg1
   %397 = bitcast i8* %396 to i64*
-  %NullCheck164 = icmp ne i64* %397, null
-  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+  %NullCheck163 = icmp eq i64* %397, null
+  br i1 %NullCheck163, label %ThrowNullRef164, label %398
 
 ; <label>:398                                     ; preds = %394
   %399 = load i64, i64* %397, align 8
   %400 = bitcast i8* %395 to i64*
-  %NullCheck166 = icmp ne i64* %400, null
-  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+  %NullCheck165 = icmp eq i64* %400, null
+  br i1 %NullCheck165, label %ThrowNullRef166, label %401
 
 ; <label>:401                                     ; preds = %398
   store i64 %399, i64* %400, align 8
@@ -1400,14 +1482,14 @@ entry:
   %404 = load i8*, i8** %arg1
   %405 = getelementptr inbounds i8, i8* %404, i64 8
   %406 = bitcast i8* %405 to i64*
-  %NullCheck168 = icmp ne i64* %406, null
-  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+  %NullCheck167 = icmp eq i64* %406, null
+  br i1 %NullCheck167, label %ThrowNullRef168, label %407
 
 ; <label>:407                                     ; preds = %401
   %408 = load i64, i64* %406, align 8
   %409 = bitcast i8* %403 to i64*
-  %NullCheck170 = icmp ne i64* %409, null
-  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+  %NullCheck169 = icmp eq i64* %409, null
+  br i1 %NullCheck169, label %ThrowNullRef170, label %410
 
 ; <label>:410                                     ; preds = %407
   store i64 %408, i64* %409, align 8
@@ -1437,14 +1519,14 @@ entry:
   %425 = load i8*, i8** %arg0
   %426 = load i8*, i8** %arg1
   %427 = bitcast i8* %426 to i64*
-  %NullCheck148 = icmp ne i64* %427, null
-  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+  %NullCheck147 = icmp eq i64* %427, null
+  br i1 %NullCheck147, label %ThrowNullRef148, label %428
 
 ; <label>:428                                     ; preds = %424
   %429 = load i64, i64* %427, align 8
   %430 = bitcast i8* %425 to i64*
-  %NullCheck150 = icmp ne i64* %430, null
-  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+  %NullCheck149 = icmp eq i64* %430, null
+  br i1 %NullCheck149, label %ThrowNullRef150, label %431
 
 ; <label>:431                                     ; preds = %428
   store i64 %429, i64* %430, align 8
@@ -1466,14 +1548,14 @@ entry:
   %441 = load i8*, i8** %arg0
   %442 = load i8*, i8** %arg1
   %443 = bitcast i8* %442 to i32*
-  %NullCheck152 = icmp ne i32* %443, null
-  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+  %NullCheck151 = icmp eq i32* %443, null
+  br i1 %NullCheck151, label %ThrowNullRef152, label %444
 
 ; <label>:444                                     ; preds = %440
   %445 = load i32, i32* %443, align 8
   %446 = bitcast i8* %441 to i32*
-  %NullCheck154 = icmp ne i32* %446, null
-  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+  %NullCheck153 = icmp eq i32* %446, null
+  br i1 %NullCheck153, label %ThrowNullRef154, label %447
 
 ; <label>:447                                     ; preds = %444
   store i32 %445, i32* %446, align 8
@@ -1495,16 +1577,16 @@ entry:
   %457 = load i8*, i8** %arg0
   %458 = load i8*, i8** %arg1
   %459 = bitcast i8* %458 to i16*
-  %NullCheck156 = icmp ne i16* %459, null
-  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+  %NullCheck155 = icmp eq i16* %459, null
+  br i1 %NullCheck155, label %ThrowNullRef156, label %460
 
 ; <label>:460                                     ; preds = %456
   %461 = load i16, i16* %459, align 8
   %462 = sext i16 %461 to i32
   %463 = bitcast i8* %457 to i16*
   %464 = trunc i32 %462 to i16
-  %NullCheck158 = icmp ne i16* %463, null
-  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+  %NullCheck157 = icmp eq i16* %463, null
+  br i1 %NullCheck157, label %ThrowNullRef158, label %465
 
 ; <label>:465                                     ; preds = %460
   store i16 %464, i16* %463, align 8
@@ -1525,15 +1607,15 @@ entry:
 ; <label>:474                                     ; preds = %470
   %475 = load i8*, i8** %arg0
   %476 = load i8*, i8** %arg1
-  %NullCheck160 = icmp ne i8* %476, null
-  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+  %NullCheck159 = icmp eq i8* %476, null
+  br i1 %NullCheck159, label %ThrowNullRef160, label %477
 
 ; <label>:477                                     ; preds = %474
   %478 = load i8, i8* %476, align 8
   %479 = zext i8 %478 to i32
   %480 = trunc i32 %479 to i8
-  %NullCheck162 = icmp ne i8* %475, null
-  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+  %NullCheck161 = icmp eq i8* %475, null
+  br i1 %NullCheck161, label %ThrowNullRef162, label %481
 
 ; <label>:481                                     ; preds = %477
   store i8 %480, i8* %475, align 8
@@ -1553,343 +1635,343 @@ ThrowNullRef:                                     ; preds = %308
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %312
+ThrowNullRef2:                                    ; preds = %312
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %315
+ThrowNullRef4:                                    ; preds = %315
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %321
+ThrowNullRef6:                                    ; preds = %321
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %271
+ThrowNullRef8:                                    ; preds = %271
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %275
+ThrowNullRef10:                                   ; preds = %275
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %278
+ThrowNullRef12:                                   ; preds = %278
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %284
+ThrowNullRef14:                                   ; preds = %284
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %287
+ThrowNullRef16:                                   ; preds = %287
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %293
+ThrowNullRef18:                                   ; preds = %293
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %298
+ThrowNullRef20:                                   ; preds = %298
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %303
+ThrowNullRef22:                                   ; preds = %303
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %243
+ThrowNullRef24:                                   ; preds = %243
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %247
+ThrowNullRef26:                                   ; preds = %247
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %250
+ThrowNullRef28:                                   ; preds = %250
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %256
+ThrowNullRef30:                                   ; preds = %256
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %259
+ThrowNullRef32:                                   ; preds = %259
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %265
+ThrowNullRef34:                                   ; preds = %265
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %217
+ThrowNullRef36:                                   ; preds = %217
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %221
+ThrowNullRef38:                                   ; preds = %221
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %224
+ThrowNullRef40:                                   ; preds = %224
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %230
+ThrowNullRef42:                                   ; preds = %230
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %233
+ThrowNullRef44:                                   ; preds = %233
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %238
+ThrowNullRef46:                                   ; preds = %238
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %200
+ThrowNullRef48:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %204
+ThrowNullRef50:                                   ; preds = %204
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %207
+ThrowNullRef52:                                   ; preds = %207
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %213
+ThrowNullRef54:                                   ; preds = %213
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %172
+ThrowNullRef56:                                   ; preds = %172
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %176
+ThrowNullRef58:                                   ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %179
+ThrowNullRef60:                                   ; preds = %179
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %185
+ThrowNullRef62:                                   ; preds = %185
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %190
+ThrowNullRef64:                                   ; preds = %190
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %195
+ThrowNullRef66:                                   ; preds = %195
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %153
+ThrowNullRef68:                                   ; preds = %153
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %157
+ThrowNullRef70:                                   ; preds = %157
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %160
+ThrowNullRef72:                                   ; preds = %160
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %166
+ThrowNullRef74:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %136
+ThrowNullRef76:                                   ; preds = %136
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %140
+ThrowNullRef78:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %143
+ThrowNullRef80:                                   ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %148
+ThrowNullRef82:                                   ; preds = %148
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %128
+ThrowNullRef84:                                   ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %132
+ThrowNullRef86:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %100
+ThrowNullRef88:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %104
+ThrowNullRef90:                                   ; preds = %104
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %107
+ThrowNullRef92:                                   ; preds = %107
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %113
+ThrowNullRef94:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %118
+ThrowNullRef96:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %123
+ThrowNullRef98:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %81
+ThrowNullRef100:                                  ; preds = %81
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef101:                                  ; preds = %85
+ThrowNullRef102:                                  ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef103:                                  ; preds = %88
+ThrowNullRef104:                                  ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef105:                                  ; preds = %94
+ThrowNullRef106:                                  ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef107:                                  ; preds = %64
+ThrowNullRef108:                                  ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef109:                                  ; preds = %68
+ThrowNullRef110:                                  ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef111:                                  ; preds = %71
+ThrowNullRef112:                                  ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef113:                                  ; preds = %76
+ThrowNullRef114:                                  ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef115:                                  ; preds = %56
+ThrowNullRef116:                                  ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef117:                                  ; preds = %60
+ThrowNullRef118:                                  ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef119:                                  ; preds = %37
+ThrowNullRef120:                                  ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef121:                                  ; preds = %41
+ThrowNullRef122:                                  ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef123:                                  ; preds = %46
+ThrowNullRef124:                                  ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef125:                                  ; preds = %51
+ThrowNullRef126:                                  ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef127:                                  ; preds = %27
+ThrowNullRef128:                                  ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef129:                                  ; preds = %31
+ThrowNullRef130:                                  ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef131:                                  ; preds = %19
+ThrowNullRef132:                                  ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef133:                                  ; preds = %22
+ThrowNullRef134:                                  ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef135:                                  ; preds = %338
+ThrowNullRef136:                                  ; preds = %338
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef137:                                  ; preds = %341
+ThrowNullRef138:                                  ; preds = %341
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef139:                                  ; preds = %356
+ThrowNullRef140:                                  ; preds = %356
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef141:                                  ; preds = %360
+ThrowNullRef142:                                  ; preds = %360
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef143:                                  ; preds = %377
+ThrowNullRef144:                                  ; preds = %377
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef145:                                  ; preds = %381
+ThrowNullRef146:                                  ; preds = %381
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef147:                                  ; preds = %424
+ThrowNullRef148:                                  ; preds = %424
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef149:                                  ; preds = %428
+ThrowNullRef150:                                  ; preds = %428
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef151:                                  ; preds = %440
+ThrowNullRef152:                                  ; preds = %440
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef153:                                  ; preds = %444
+ThrowNullRef154:                                  ; preds = %444
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef155:                                  ; preds = %456
+ThrowNullRef156:                                  ; preds = %456
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef157:                                  ; preds = %460
+ThrowNullRef158:                                  ; preds = %460
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef159:                                  ; preds = %474
+ThrowNullRef160:                                  ; preds = %474
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef161:                                  ; preds = %477
+ThrowNullRef162:                                  ; preds = %477
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef163:                                  ; preds = %394
+ThrowNullRef164:                                  ; preds = %394
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef165:                                  ; preds = %398
+ThrowNullRef166:                                  ; preds = %398
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef167:                                  ; preds = %401
+ThrowNullRef168:                                  ; preds = %401
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef169:                                  ; preds = %407
+ThrowNullRef170:                                  ; preds = %407
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1939,8 +2021,8 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
-  br i1 %NullCheck, label %22, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %ThrowNullRef, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
@@ -1948,8 +2030,8 @@ entry:
   store i32 %24, i32* %loc0
   %25 = load i32, i32* %loc0
   %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %26, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %27
 
 ; <label>:27                                      ; preds = %22
   %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
@@ -1971,7 +2053,7 @@ ThrowNullRef:                                     ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1989,8 +2071,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -2022,15 +2104,15 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2048,16 +2130,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
   %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
   store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %15
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
@@ -2072,8 +2154,8 @@ entry:
   %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
   %29 = ptrtoint i16 addrspace(1)* %28 to i64
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %19
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
@@ -2089,19 +2171,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2114,8 +2196,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
@@ -2128,7 +2210,7 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[loadElem]
+Failed to read AppDomain.PrepareDataForSetup[storeElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
@@ -2202,8 +2284,8 @@ entry:
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
-  br i1 %NullCheck24, label %27, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = load i64, i64 addrspace(1)* %26
@@ -2218,8 +2300,8 @@ entry:
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
-  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
   %41 = load i64, i64 addrspace(1)* %39
@@ -2236,8 +2318,8 @@ entry:
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
-  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
   %54 = load i64, i64 addrspace(1)* %52
@@ -2252,8 +2334,8 @@ entry:
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
   %67 = load i64, i64 addrspace(1)* %65
@@ -2270,8 +2352,8 @@ entry:
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
-  br i1 %NullCheck16, label %79, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
   %80 = load i64, i64 addrspace(1)* %78
@@ -2286,8 +2368,8 @@ entry:
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
-  br i1 %NullCheck18, label %92, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
   %93 = load i64, i64 addrspace(1)* %91
@@ -2304,8 +2386,8 @@ entry:
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
-  br i1 %NullCheck12, label %105, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = load i64, i64 addrspace(1)* %104
@@ -2320,8 +2402,8 @@ entry:
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
-  br i1 %NullCheck14, label %118, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
   %119 = load i64, i64 addrspace(1)* %117
@@ -2337,8 +2419,8 @@ entry:
 
 ; <label>:128                                     ; preds = %20
   %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
-  br i1 %NullCheck4, label %130, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %129, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %130
 
 ; <label>:130                                     ; preds = %128
   %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
@@ -2346,8 +2428,8 @@ entry:
   %133 = load i16, i16 addrspace(1)* %132, align 8
   %134 = zext i16 %133 to i32
   %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
-  br i1 %NullCheck6, label %136, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %135, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %136
 
 ; <label>:136                                     ; preds = %130
   %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
@@ -2360,8 +2442,8 @@ entry:
 
 ; <label>:143                                     ; preds = %136
   %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
-  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %144, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %145
 
 ; <label>:145                                     ; preds = %143
   %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
@@ -2369,8 +2451,8 @@ entry:
   %148 = load i16, i16 addrspace(1)* %147, align 8
   %149 = zext i16 %148 to i32
   %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %150, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %151
 
 ; <label>:151                                     ; preds = %145
   %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
@@ -2388,8 +2470,8 @@ entry:
 
 ; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
-  br i1 %NullCheck, label %163, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %ThrowNullRef, label %163
 
 ; <label>:163                                     ; preds = %161
   %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
@@ -2399,8 +2481,8 @@ entry:
 
 ; <label>:167                                     ; preds = %163
   %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
-  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %168, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %169
 
 ; <label>:169                                     ; preds = %167
   %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
@@ -2432,55 +2514,55 @@ ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %167
+ThrowNullRef2:                                    ; preds = %167
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %128
+ThrowNullRef4:                                    ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %130
+ThrowNullRef6:                                    ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %143
+ThrowNullRef8:                                    ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %145
+ThrowNullRef10:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %102
+ThrowNullRef12:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %105
+ThrowNullRef14:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %76
+ThrowNullRef16:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %79
+ThrowNullRef18:                                   ; preds = %79
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %50
+ThrowNullRef20:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %53
+ThrowNullRef22:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %24
+ThrowNullRef24:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %27
+ThrowNullRef26:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2503,15 +2585,15 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2519,16 +2601,16 @@ entry:
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
   store i32 %8, i32* %loc0
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
   %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
   store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
@@ -2546,16 +2628,16 @@ entry:
 
 ; <label>:23                                      ; preds = %64
   %24 = load i16*, i16** %loc3
-  %NullCheck12 = icmp ne i16* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i16* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
   store i32 %27, i32* %loc5
   %28 = load i16*, i16** %loc4
-  %NullCheck14 = icmp ne i16* %28, null
-  br i1 %NullCheck14, label %29, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %28, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = load i16, i16* %28, align 8
@@ -2620,15 +2702,15 @@ entry:
 
 ; <label>:67                                      ; preds = %64
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
-  br i1 %NullCheck8, label %69, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %68, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %69
 
 ; <label>:69                                      ; preds = %67
   %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
   %71 = load i32, i32 addrspace(1)* %70
   %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
-  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %73
 
 ; <label>:73                                      ; preds = %69
   %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
@@ -2645,31 +2727,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %67
+ThrowNullRef8:                                    ; preds = %67
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %69
+ThrowNullRef10:                                   ; preds = %69
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2710,14 +2792,14 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
   %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
@@ -2730,14 +2812,14 @@ entry:
 
 ; <label>:11                                      ; preds = %4
   %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
   %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
@@ -2749,14 +2831,14 @@ entry:
 
 ; <label>:22                                      ; preds = %16
   %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
   %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
-  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
-  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
@@ -2804,23 +2886,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2836,7 +2918,280 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[loadElem]
+Successfully read RuntimeType.IsAssignableFrom
+
+define i8 @RuntimeType.IsAssignableFrom(%System.RuntimeType addrspace(1)* %param0, %System.Type addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.RuntimeType addrspace(1)*
+  %arg1 = alloca %System.Type addrspace(1)*
+  %loc0 = alloca %System.RuntimeType addrspace(1)*
+  %loc1 = alloca %"System.Type[]" addrspace(1)*
+  %loc2 = alloca i32
+  store %System.RuntimeType addrspace(1)* %param0, %System.RuntimeType addrspace(1)** %this
+  store %System.Type addrspace(1)* %param1, %System.Type addrspace(1)** %arg1
+  %0 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %1 = icmp ne %System.Type addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i8 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %5 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %6 = bitcast %System.Type addrspace(1)* %4 to %System.Object addrspace(1)*
+  %7 = bitcast %System.RuntimeType addrspace(1)* %5 to %System.Object addrspace(1)*
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %6, %System.Object addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %3
+  ret i8 1
+
+; <label>:12                                      ; preds = %3
+  %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 152
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 32
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
+  %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
+  %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
+  store %System.RuntimeType addrspace(1)* %25, %System.RuntimeType addrspace(1)** %loc0
+  %26 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %27 = icmp eq %System.RuntimeType addrspace(1)* %26, null
+  br i1 %27, label %34, label %28
+
+; <label>:28                                      ; preds = %15
+  %29 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %30 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)*)*)(%System.RuntimeType addrspace(1)* %29, %System.RuntimeType addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+; <label>:34                                      ; preds = %15
+  %35 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %36 = call %System.Reflection.Emit.TypeBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Reflection.Emit.TypeBuilder addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %35)
+  %37 = icmp eq %System.Reflection.Emit.TypeBuilder addrspace(1)* %36, null
+  br i1 %37, label %139, label %38
+
+; <label>:38                                      ; preds = %34
+  %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %42
+
+; <label>:42                                      ; preds = %38
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 152
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 40
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
+  %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
+  %53 = zext i8 %52 to i32
+  %54 = icmp eq i32 %53, 0
+  br i1 %54, label %56, label %55
+
+; <label>:55                                      ; preds = %42
+  ret i8 1
+
+; <label>:56                                      ; preds = %42
+  %57 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %58 = bitcast %System.RuntimeType addrspace(1)* %57 to %System.Type addrspace(1)*
+  %59 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %58)
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %64 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.Type addrspace(1)* %63, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = bitcast %System.RuntimeType addrspace(1)* %64 to %System.Type addrspace(1)*
+  %67 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %63, %System.Type addrspace(1)* %66)
+  %68 = zext i8 %67 to i32
+  %69 = trunc i32 %68 to i8
+  ret i8 %69
+
+; <label>:70                                      ; preds = %56
+  %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
+  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %73
+
+; <label>:73                                      ; preds = %70
+  %74 = load i64, i64 addrspace(1)* %72
+  %75 = add i64 %74, 128
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = add i64 %77, 0
+  %79 = inttoptr i64 %78 to i64*
+  %80 = load i64, i64* %79
+  %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
+  %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
+  %83 = call i8 %82(%System.Type addrspace(1)* %81)
+  %84 = zext i8 %83 to i32
+  %85 = icmp eq i32 %84, 0
+  br i1 %85, label %139, label %86
+
+; <label>:86                                      ; preds = %73
+  %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
+  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %89
+
+; <label>:89                                      ; preds = %86
+  %90 = load i64, i64 addrspace(1)* %88
+  %91 = add i64 %90, 128
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = add i64 %93, 24
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
+  %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
+  %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
+  store %"System.Type[]" addrspace(1)* %99, %"System.Type[]" addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %129
+
+; <label>:100                                     ; preds = %132
+  %101 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %102 = load i32, i32* %loc2
+  %NullCheck11 = icmp eq %"System.Type[]" addrspace(1)* %101, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %103
+
+; <label>:103                                     ; preds = %100
+  %104 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 1
+  %105 = load i32, i32 addrspace(1)* %104
+  %106 = zext i32 %105 to i64
+  %107 = zext i32 %102 to i64
+  %BoundsCheck = icmp uge i64 %107, %106
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %108
+
+; <label>:108                                     ; preds = %103
+  %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
+  %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
+  %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
+  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %113
+
+; <label>:113                                     ; preds = %108
+  %114 = load i64, i64 addrspace(1)* %112
+  %115 = add i64 %114, 152
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = add i64 %117, 56
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
+  %123 = zext i8 %122 to i32
+  %124 = icmp ne i32 %123, 0
+  br i1 %124, label %126, label %125
+
+; <label>:125                                     ; preds = %113
+  ret i8 0
+
+; <label>:126                                     ; preds = %113
+  %127 = load i32, i32* %loc2
+  %128 = add i32 %127, 1
+  store i32 %128, i32* %loc2
+  br label %129
+
+; <label>:129                                     ; preds = %89, %126
+  %130 = load i32, i32* %loc2
+  %131 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %NullCheck9 = icmp eq %"System.Type[]" addrspace(1)* %131, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %132
+
+; <label>:132                                     ; preds = %129
+  %133 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %131, i32 0, i32 1
+  %134 = load i32, i32 addrspace(1)* %133
+  %135 = zext i32 %134 to i64
+  %136 = trunc i64 %135 to i32
+  %137 = icmp slt i32 %130, %136
+  br i1 %137, label %100, label %138
+
+; <label>:138                                     ; preds = %132
+  ret i8 1
+
+; <label>:139                                     ; preds = %34, %73
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %129
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %103
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -2893,7 +3248,7 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElem]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -2904,8 +3259,8 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -2997,8 +3352,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
@@ -3059,8 +3414,8 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -3087,8 +3442,8 @@ entry:
 
 ; <label>:17                                      ; preds = %5, %11
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
@@ -3097,8 +3452,8 @@ entry:
 
 ; <label>:22                                      ; preds = %1, %11
   %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
@@ -3109,11 +3464,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %17
+ThrowNullRef2:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %22
+ThrowNullRef4:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3167,15 +3522,15 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
   %15 = load i32, i32 addrspace(1)* %14
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
@@ -3198,7 +3553,7 @@ ThrowNullRef:                                     ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef2:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3232,8 +3587,8 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
@@ -3312,8 +3667,8 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -3327,8 +3682,8 @@ entry:
 ; <label>:5                                       ; preds = %43
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %7 = load i32, i32* %loc1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck6, label %8, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
@@ -3366,8 +3721,8 @@ entry:
 ; <label>:32                                      ; preds = %21, %25
   %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
   %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
-  br i1 %NullCheck8, label %35, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = trunc i32 %34 to i16
@@ -3380,8 +3735,8 @@ entry:
 ; <label>:40                                      ; preds = %1, %35
   %41 = load i32, i32* %loc1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
-  br i1 %NullCheck2, label %43, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %42, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
@@ -3392,8 +3747,8 @@ entry:
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
   %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
-  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
   %51 = load i64, i64 addrspace(1)* %49
@@ -3412,19 +3767,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %40
+ThrowNullRef2:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %47
+ThrowNullRef4:                                    ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %5
+ThrowNullRef6:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %32
+ThrowNullRef8:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3467,8 +3822,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
@@ -3492,11 +3847,391 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(i16* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store i16* %param0, i16** %arg0
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load i32, i32* %arg3
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %42, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %37, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg2
+  %13 = load i32, i32* %arg3
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %37, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %24 = load i32, i32* %arg2
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load i16*, i16** %arg0
+  %35 = load i32, i32* %arg3
+  %36 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %36, i16* %34, i32 %35)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:37                                      ; preds = %5, %16
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %39)
+  %41 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41, %System.String addrspace(1)* %38, %System.String addrspace(1)* %40)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41) #0
+  unreachable
+
+; <label>:42                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
-Failed to read StringBuilder.ToString[loadElemA]
+Successfully read StringBuilder.ToString
+
+define %System.String addrspace(1)* @StringBuilder.ToString(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i16*
+  %loc3 = alloca %"System.Char[]" addrspace(1)*
+  %loc4 = alloca i32
+  %loc5 = alloca i32
+  %loc6 = alloca i16 addrspace(1)*
+  %loc7 = alloca %System.String addrspace(1)*
+  %loc8 = alloca %"System.Char[]" addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %0)
+  %2 = icmp ne i32 %1, 0
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %4
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %6)
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %7)
+  store %System.String addrspace(1)* %8, %System.String addrspace(1)** %loc0
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.Text.StringBuilder addrspace(1)* %9, %System.Text.StringBuilder addrspace(1)** %loc1
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  store %System.String addrspace(1)* %10, %System.String addrspace(1)** %loc7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc7
+  %12 = ptrtoint %System.String addrspace(1)* %11 to i64
+  %13 = icmp eq i64 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %5
+  %15 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %16 = sext i32 %15 to i64
+  %17 = add i64 %12, %16
+  br label %18
+
+; <label>:18                                      ; preds = %5, %14
+  %19 = phi i64 [ %12, %5 ], [ %17, %14 ]
+  %20 = inttoptr i64 %19 to i16*
+  store i16* %20, i16** %loc2
+  br label %21
+
+; <label>:21                                      ; preds = %98, %18
+  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %22, null
+  br i1 %NullCheck, label %ThrowNullRef, label %23
+
+; <label>:23                                      ; preds = %21
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 3
+  %25 = load i32, i32 addrspace(1)* %24, align 8
+  %26 = icmp sle i32 %25, 0
+  br i1 %26, label %96, label %27
+
+; <label>:27                                      ; preds = %23
+  %28 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %28, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %29
+
+; <label>:29                                      ; preds = %27
+  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %28, i32 0, i32 1
+  %31 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %30, align 8
+  store %"System.Char[]" addrspace(1)* %31, %"System.Char[]" addrspace(1)** %loc3
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %33
+
+; <label>:33                                      ; preds = %29
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  store i32 %35, i32* %loc4
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  %39 = load i32, i32 addrspace(1)* %38, align 8
+  store i32 %39, i32* %loc5
+  %40 = load i32, i32* %loc5
+  %41 = load i32, i32* %loc4
+  %42 = add i32 %40, %41
+  %43 = zext i32 %42 to i64
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %45
+
+; <label>:45                                      ; preds = %37
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = sext i32 %47 to i64
+  %49 = icmp sgt i64 %43, %48
+  br i1 %49, label %91, label %50
+
+; <label>:50                                      ; preds = %45
+  %51 = load i32, i32* %loc5
+  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %52, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %53
+
+; <label>:53                                      ; preds = %50
+  %54 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %52, i32 0, i32 1
+  %55 = load i32, i32 addrspace(1)* %54
+  %56 = zext i32 %55 to i64
+  %57 = trunc i64 %56 to i32
+  %58 = icmp ugt i32 %51, %57
+  br i1 %58, label %91, label %59
+
+; <label>:59                                      ; preds = %53
+  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  store %"System.Char[]" addrspace(1)* %60, %"System.Char[]" addrspace(1)** %loc8
+  %61 = icmp eq %"System.Char[]" addrspace(1)* %60, null
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %63, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %64
+
+; <label>:64                                      ; preds = %62
+  %65 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %63, i32 0, i32 1
+  %66 = load i32, i32 addrspace(1)* %65
+  %67 = zext i32 %66 to i64
+  %68 = trunc i64 %67 to i32
+  %69 = icmp ne i32 %68, 0
+  br i1 %69, label %71, label %70
+
+; <label>:70                                      ; preds = %59, %64
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:71                                      ; preds = %64
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %73
+
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %BoundsCheck = icmp uge i64 0, %76
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %77
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %78, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:79                                      ; preds = %70, %77
+  %80 = load i16*, i16** %loc2
+  %81 = load i32, i32* %loc4
+  %82 = sext i32 %81 to i64
+  %83 = mul i64 %82, 2
+  %84 = bitcast i16* %80 to i8*
+  %85 = getelementptr inbounds i8, i8* %84, i64 %83
+  %86 = load i16 addrspace(1)*, i16 addrspace(1)** %loc6
+  %87 = ptrtoint i16 addrspace(1)* %86 to i64
+  %88 = load i32, i32* %loc5
+  %89 = bitcast i8* %85 to i16*
+  %90 = inttoptr i64 %87 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %89, i16* %90, i32 %88)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %96
+
+; <label>:91                                      ; preds = %45, %53
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %94 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %93)
+  %95 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95, %System.String addrspace(1)* %92, %System.String addrspace(1)* %94)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95) #0
+  unreachable
+
+; <label>:96                                      ; preds = %23, %79
+  %97 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %97, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %98
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %97, i32 0, i32 2
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  store %System.Text.StringBuilder addrspace(1)* %100, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %102 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %102, label %21, label %103
+
+; <label>:103                                     ; preds = %98
+  store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc7
+  %104 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  ret %System.String addrspace(1)* %104
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method StringBuilder::get_Length using LLILCJit
+Successfully read StringBuilder.get_Length
+
+define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
+Successfully read RuntimeHelpers.get_OffsetToStringData
+
+define i32 @RuntimeHelpers.get_OffsetToStringData() {
+entry:
+  ret i32 12
+}
+
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
 Successfully read CultureData.CreateCultureData
 
@@ -3514,23 +4249,23 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
   store i8 %4, i8 addrspace(1)* %6
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
@@ -3549,11 +4284,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3566,50 +4301,50 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
   store i32 -1, i32 addrspace(1)* %2
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
   store i32 -1, i32 addrspace(1)* %8
   %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
   store i32 -1, i32 addrspace(1)* %14
   %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
   store i32 -1, i32 addrspace(1)* %17
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
@@ -3623,27 +4358,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3675,7 +4410,136 @@ Failed to read Dictionary`2.Insert[non-const derefAddress]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
 Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
-Failed to read HashHelpers.GetPrime[loadElem]
+Successfully read HashHelpers.GetPrime
+
+define i32 @HashHelpers.GetPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %6, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5, %System.String addrspace(1)* %4)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5) #0
+  unreachable
+
+; <label>:6                                       ; preds = %entry
+  store i32 0, i32* %loc0
+  br label %29
+
+; <label>:7                                       ; preds = %35
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 1296
+  %10 = addrspacecast i8 addrspace(1)* %9 to %"System.Int32[]" addrspace(1)**
+  %11 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %10
+  %12 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Int32[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = zext i32 %15 to i64
+  %17 = zext i32 %12 to i64
+  %BoundsCheck = icmp uge i64 %17, %16
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 3, i32 %12
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  store i32 %20, i32* %loc1
+  %21 = load i32, i32* %loc1
+  %22 = load i32, i32* %arg0
+  %23 = icmp slt i32 %21, %22
+  br i1 %23, label %26, label %24
+
+; <label>:24                                      ; preds = %18
+  %25 = load i32, i32* %loc1
+  ret i32 %25
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %loc0
+  %28 = add i32 %27, 1
+  store i32 %28, i32* %loc0
+  br label %29
+
+; <label>:29                                      ; preds = %6, %26
+  %30 = load i32, i32* %loc0
+  %31 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %32 = getelementptr inbounds i8, i8 addrspace(1)* %31, i64 1296
+  %33 = addrspacecast i8 addrspace(1)* %32 to %"System.Int32[]" addrspace(1)**
+  %34 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %33
+  %NullCheck = icmp eq %"System.Int32[]" addrspace(1)* %34, null
+  br i1 %NullCheck, label %ThrowNullRef, label %35
+
+; <label>:35                                      ; preds = %29
+  %36 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %34, i32 0, i32 1
+  %37 = load i32, i32 addrspace(1)* %36
+  %38 = zext i32 %37 to i64
+  %39 = trunc i64 %38 to i32
+  %40 = icmp slt i32 %30, %39
+  br i1 %40, label %7, label %41
+
+; <label>:41                                      ; preds = %35
+  %42 = load i32, i32* %arg0
+  %43 = or i32 %42, 1
+  store i32 %43, i32* %loc2
+  br label %59
+
+; <label>:44                                      ; preds = %59
+  %45 = load i32, i32* %loc2
+  %46 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %45)
+  %47 = zext i8 %46 to i32
+  %48 = icmp eq i32 %47, 0
+  br i1 %48, label %56, label %49
+
+; <label>:49                                      ; preds = %44
+  %50 = load i32, i32* %loc2
+  %51 = sub i32 %50, 1
+  %52 = srem i32 %51, 101
+  %53 = icmp eq i32 %52, 0
+  br i1 %53, label %56, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = load i32, i32* %loc2
+  ret i32 %55
+
+; <label>:56                                      ; preds = %44, %49
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %57, 2
+  store i32 %58, i32* %loc2
+  br label %59
+
+; <label>:59                                      ; preds = %41, %56
+  %60 = load i32, i32* %loc2
+  %61 = icmp slt i32 %60, 2147483647
+  br i1 %61, label %44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load i32, i32* %arg0
+  ret i32 %63
+
+ThrowNullRef:                                     ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
 Successfully read GenericEqualityComparer`1.GetHashCode
 
@@ -3694,14 +4558,14 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
   %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load i64, i64 addrspace(1)* %7
@@ -3720,7 +4584,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3750,8 +4614,8 @@ entry:
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
@@ -3796,8 +4660,8 @@ entry:
   %35 = bitcast i16* %34 to i8*
   %36 = getelementptr inbounds i8, i8* %35, i64 2
   %37 = bitcast i8* %36 to i16*
-  %NullCheck4 = icmp ne i16* %37, null
-  br i1 %NullCheck4, label %38, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %37, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %38
 
 ; <label>:38                                      ; preds = %27
   %39 = load i16, i16* %37, align 8
@@ -3824,8 +4688,8 @@ entry:
 
 ; <label>:54                                      ; preds = %22, %43
   %55 = load i16*, i16** %loc4
-  %NullCheck2 = icmp ne i16* %55, null
-  br i1 %NullCheck2, label %56, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i16* %55, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %56
 
 ; <label>:56                                      ; preds = %54
   %57 = load i16, i16* %55, align 8
@@ -3850,11 +4714,11 @@ ThrowNullRef:                                     ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %54
+ThrowNullRef2:                                    ; preds = %54
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %27
+ThrowNullRef4:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3871,8 +4735,8 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -3907,8 +4771,8 @@ entry:
 
 ; <label>:26                                      ; preds = %19
   %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
-  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %28
 
 ; <label>:28                                      ; preds = %26
   %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
@@ -3920,7 +4784,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3972,8 +4836,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
@@ -3984,26 +4848,26 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
-  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
@@ -4014,8 +4878,8 @@ entry:
 ; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
@@ -4024,8 +4888,8 @@ entry:
 
 ; <label>:25                                      ; preds = %1, %16, %23
   %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
-  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
@@ -4036,27 +4900,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %20
+ThrowNullRef10:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4069,8 +4933,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -4081,8 +4945,8 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
@@ -4091,8 +4955,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1, %8
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
@@ -4103,11 +4967,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4128,24 +4992,24 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   store i32 %3, i32* %loc0
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
   %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
   store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck4, label %9, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
@@ -4164,15 +5028,15 @@ entry:
 ; <label>:18                                      ; preds = %70
   %19 = load i16*, i16** %loc3
   %20 = bitcast i16* %19 to i64*
-  %NullCheck10 = icmp ne i64* %20, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %20, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = load i64, i64* %20, align 8
   %23 = load i16*, i16** %loc4
   %24 = bitcast i16* %23 to i64*
-  %NullCheck12 = icmp ne i64* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = load i64, i64* %24, align 8
@@ -4188,8 +5052,8 @@ entry:
   %31 = bitcast i16* %30 to i8*
   %32 = getelementptr inbounds i8, i8* %31, i64 8
   %33 = bitcast i8* %32 to i64*
-  %NullCheck14 = icmp ne i64* %33, null
-  br i1 %NullCheck14, label %34, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = load i64, i64* %33, align 8
@@ -4197,8 +5061,8 @@ entry:
   %37 = bitcast i16* %36 to i8*
   %38 = getelementptr inbounds i8, i8* %37, i64 8
   %39 = bitcast i8* %38 to i64*
-  %NullCheck16 = icmp ne i64* %39, null
-  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %40
 
 ; <label>:40                                      ; preds = %34
   %41 = load i64, i64* %39, align 8
@@ -4214,8 +5078,8 @@ entry:
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %NullCheck18 = icmp ne i64* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = load i64, i64* %48, align 8
@@ -4223,8 +5087,8 @@ entry:
   %52 = bitcast i16* %51 to i8*
   %53 = getelementptr inbounds i8, i8* %52, i64 16
   %54 = bitcast i8* %53 to i64*
-  %NullCheck20 = icmp ne i64* %54, null
-  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64* %54, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %55
 
 ; <label>:55                                      ; preds = %49
   %56 = load i64, i64* %54, align 8
@@ -4262,15 +5126,15 @@ entry:
 ; <label>:74                                      ; preds = %95
   %75 = load i16*, i16** %loc3
   %76 = bitcast i16* %75 to i32*
-  %NullCheck6 = icmp ne i32* %76, null
-  br i1 %NullCheck6, label %77, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32* %76, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %77
 
 ; <label>:77                                      ; preds = %74
   %78 = load i32, i32* %76, align 8
   %79 = load i16*, i16** %loc4
   %80 = bitcast i16* %79 to i32*
-  %NullCheck8 = icmp ne i32* %80, null
-  br i1 %NullCheck8, label %81, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i32* %80, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %81
 
 ; <label>:81                                      ; preds = %77
   %82 = load i32, i32* %80, align 8
@@ -4318,43 +5182,43 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %74
+ThrowNullRef6:                                    ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %77
+ThrowNullRef8:                                    ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %29
+ThrowNullRef14:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %34
+ThrowNullRef16:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4376,8 +5240,8 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load i64, i64 addrspace(1)* %4
@@ -4389,8 +5253,8 @@ entry:
   %12 = load i64, i64* %11
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %5
   %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
@@ -4399,8 +5263,8 @@ entry:
   %18 = load i8, i8* %arg2
   %19 = zext i8 %18 to i32
   %20 = trunc i32 %19 to i8
-  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %15
   %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
@@ -4411,11 +5275,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4442,8 +5306,8 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
@@ -4466,16 +5330,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
   %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = load i64, i64 addrspace(1)* %19
@@ -4500,8 +5364,8 @@ entry:
 ; <label>:35                                      ; preds = %30
   %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
@@ -4514,8 +5378,8 @@ entry:
 
 ; <label>:42                                      ; preds = %1, %38
   %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
-  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
@@ -4526,19 +5390,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %35
+ThrowNullRef2:                                    ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %42
+ThrowNullRef8:                                    ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4551,14 +5415,14 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
@@ -4570,7 +5434,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4583,8 +5447,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
@@ -4613,51 +5477,51 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
   %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
   %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
   %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
   %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
-  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
   store i64 %21, i64 addrspace(1)* %23
   %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %25 = load i64, i64* %loc0
-  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
@@ -4668,27 +5532,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %22
+ThrowNullRef12:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4701,8 +5565,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
@@ -4713,19 +5577,19 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
@@ -4734,8 +5598,8 @@ entry:
 
 ; <label>:15                                      ; preds = %1, %13
   %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
@@ -4746,19 +5610,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %15
+ThrowNullRef8:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4771,8 +5635,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -4831,8 +5695,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
@@ -4882,8 +5746,8 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
-  br i1 %NullCheck, label %17, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %ThrowNullRef, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
@@ -4894,15 +5758,15 @@ entry:
 
 ; <label>:22                                      ; preds = %17
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
-  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
   %26 = load i32, i32 addrspace(1)* %25
   %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
-  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %27, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
@@ -4925,8 +5789,8 @@ entry:
 ; <label>:40                                      ; preds = %17
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
-  br i1 %NullCheck6, label %43, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %41, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
@@ -4938,34 +5802,17 @@ ThrowNullRef:                                     ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %24
+ThrowNullRef4:                                    ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %40
+ThrowNullRef6:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
-}
-
-INFO:  jitting method Object::ReferenceEquals using LLILCJit
-Successfully read Object.ReferenceEquals
-
-define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
-entry:
-  %arg0 = alloca %System.Object addrspace(1)*
-  %arg1 = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
-  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
-  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = icmp eq %System.Object addrspace(1)* %0, %1
-  %3 = sext i1 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
 }
 
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
@@ -4978,21 +5825,21 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
   %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
-  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
@@ -5007,28 +5854,28 @@ entry:
 ; <label>:13                                      ; preds = %8, %12
   %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
   %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
   %21 = load i32, i32 addrspace(1)* %20, align 8
   %22 = add i32 %21, 1
-  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
   store i32 %22, i32 addrspace(1)* %24
   %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
@@ -5039,27 +5886,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5077,7 +5924,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::Setup using LLILCJit
-Failed to read AppDomain.Setup[loadElem]
+Failed to read AppDomain.Setup[unbox]
 INFO:  jitting method Thread::GetDomain using LLILCJit
 Successfully read Thread.GetDomain
 
@@ -5108,8 +5955,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
@@ -5122,14 +5969,14 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
   %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
@@ -5141,11 +5988,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5173,8 +6020,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -5189,7 +6036,328 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
 Failed to read KeyCollection.System.Collections.Generic.IEnumerable<TKey>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Successfully read Enumerator.MoveNext
+
+define i8 @Enumerator.MoveNext(%"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.RuntimeTypeHandle* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*
+  %"$TypeArg" = alloca %System.RuntimeTypeHandle*
+  store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
+  %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 8
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %76, label %12
+
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
+  br label %76
+
+; <label>:13                                      ; preds = %85
+  %14 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck19 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %15
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, i32 0, i32 0
+  %17 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %16, align 8
+  %NullCheck21 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, i32 0, i32 2
+  %20 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %19, align 8
+  %21 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck23 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %22
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, i32 0, i32 2
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %NullCheck25 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 3, i32 %24
+  %NullCheck27 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %32
+
+; <label>:32                                      ; preds = %30
+  %33 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, i32 0, i32 2
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = icmp slt i32 %34, 0
+  br i1 %35, label %68, label %36
+
+; <label>:36                                      ; preds = %32
+  %37 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %38 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck29 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %39
+
+; <label>:39                                      ; preds = %36
+  %40 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, i32 0, i32 0
+  %41 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %40, align 8
+  %NullCheck31 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, i32 0, i32 2
+  %44 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %43, align 8
+  %45 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck33 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, i32 0, i32 2
+  %48 = load i32, i32 addrspace(1)* %47, align 8
+  %NullCheck35 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %49
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = zext i32 %51 to i64
+  %53 = zext i32 %48 to i64
+  %BoundsCheck37 = icmp uge i64 %53, %52
+  br i1 %BoundsCheck37, label %ThrowIndexOutOfRange38, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 3, i32 %48
+  %NullCheck39 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %56
+
+; <label>:56                                      ; preds = %54
+  %57 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, i32 0, i32 0
+  %58 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck41 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %59
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %60, %System.__Canon addrspace(1)* %58)
+  %61 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck43 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  %64 = load i32, i32 addrspace(1)* %63, align 8
+  %65 = add i32 %64, 1
+  %NullCheck45 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  store i32 %65, i32 addrspace(1)* %67
+  ret i8 1
+
+; <label>:68                                      ; preds = %32
+  %69 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck47 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %73 = add i32 %72, 1
+  %NullCheck49 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %74
+
+; <label>:74                                      ; preds = %70
+  %75 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  store i32 %73, i32 addrspace(1)* %75
+  br label %76
+
+; <label>:76                                      ; preds = %8, %12, %74
+  %77 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %78
+
+; <label>:78                                      ; preds = %76
+  %79 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, i32 0, i32 2
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck7 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %82
+
+; <label>:82                                      ; preds = %78
+  %83 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, i32 0, i32 0
+  %84 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %83, align 8
+  %NullCheck9 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %85
+
+; <label>:85                                      ; preds = %82
+  %86 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, i32 0, i32 7
+  %87 = load i32, i32 addrspace(1)* %86, align 8
+  %88 = icmp ult i32 %80, %87
+  br i1 %88, label %13, label %89
+
+; <label>:89                                      ; preds = %85
+  %90 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %91 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck11 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %92
+
+; <label>:92                                      ; preds = %89
+  %93 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, i32 0, i32 0
+  %94 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck13 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %95
+
+; <label>:95                                      ; preds = %92
+  %96 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, i32 0, i32 7
+  %97 = load i32, i32 addrspace(1)* %96, align 8
+  %98 = add i32 %97, 1
+  %NullCheck15 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %99
+
+; <label>:99                                      ; preds = %95
+  %100 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, i32 0, i32 2
+  store i32 %98, i32 addrspace(1)* %100
+  %101 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck17 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %102
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %103, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %92
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef22:                                   ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef24:                                   ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef26:                                   ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef28:                                   ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef30:                                   ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef32:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef34:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef36:                                   ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange38:                           ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef40:                                   ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef42:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef44:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef46:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef48:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef50:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -5200,8 +6368,8 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -5232,9 +6400,9 @@ Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
 Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
-Failed to read String.MakeSeparatorList[loadElemA]
+Failed to read String.MakeSeparatorList[storeElem]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
-Failed to read String.InternalSplitKeepEmptyEntries[loadElem]
+Failed to read String.InternalSplitKeepEmptyEntries[storeElem]
 INFO:  jitting method Path::IsRelative using LLILCJit
 Successfully read Path.IsRelative
 
@@ -5243,8 +6411,8 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -5254,8 +6422,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
@@ -5271,8 +6439,8 @@ entry:
 
 ; <label>:17                                      ; preds = %7
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
@@ -5288,8 +6456,8 @@ entry:
 
 ; <label>:29                                      ; preds = %19
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %31
 
 ; <label>:31                                      ; preds = %29
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
@@ -5300,8 +6468,8 @@ entry:
 
 ; <label>:36                                      ; preds = %31
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
-  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %37, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
@@ -5312,8 +6480,8 @@ entry:
 
 ; <label>:43                                      ; preds = %31, %38
   %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
-  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %45
 
 ; <label>:45                                      ; preds = %43
   %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
@@ -5324,8 +6492,8 @@ entry:
 
 ; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %50
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
@@ -5336,8 +6504,8 @@ entry:
 
 ; <label>:57                                      ; preds = %1, %7, %19, %45, %52
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
-  br i1 %NullCheck14, label %59, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %59
 
 ; <label>:59                                      ; preds = %57
   %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
@@ -5347,8 +6515,8 @@ entry:
 
 ; <label>:63                                      ; preds = %59
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
@@ -5359,8 +6527,8 @@ entry:
 
 ; <label>:70                                      ; preds = %65
   %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
-  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.String addrspace(1)* %71, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %72
 
 ; <label>:72                                      ; preds = %70
   %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
@@ -5379,39 +6547,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %17
+ThrowNullRef4:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %29
+ThrowNullRef6:                                    ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %36
+ThrowNullRef8:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %43
+ThrowNullRef10:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %50
+ThrowNullRef12:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %57
+ThrowNullRef14:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %63
+ThrowNullRef16:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %70
+ThrowNullRef18:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5419,7 +6587,293 @@ ThrowNullRef17:                                   ; preds = %70
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
-Failed to read String.TrimHelper[loadElem]
+Successfully read String.TrimHelper
+
+define %System.String addrspace(1)* @String.TrimHelper(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i16
+  %loc4 = alloca i32
+  %loc5 = alloca i16
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = sub i32 %3, 1
+  store i32 %4, i32* %loc0
+  store i32 0, i32* %loc1
+  %5 = load i32, i32* %arg2
+  %6 = icmp eq i32 %5, 1
+  br i1 %6, label %62, label %7
+
+; <label>:7                                       ; preds = %1
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:8                                       ; preds = %58
+  store i32 0, i32* %loc2
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load i32, i32* %loc1
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2, i32 %10
+  %13 = load i16, i16 addrspace(1)* %12
+  %14 = zext i16 %13 to i32
+  %15 = trunc i32 %14 to i16
+  store i16 %15, i16* %loc3
+  store i32 0, i32* %loc2
+  br label %34
+
+; <label>:16                                      ; preds = %37
+  %17 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %18 = load i32, i32* %loc2
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %17, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %19
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = zext i32 %18 to i64
+  %BoundsCheck = icmp uge i64 %23, %22
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %24
+
+; <label>:24                                      ; preds = %19
+  %25 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 3, i32 %18
+  %26 = load i16, i16 addrspace(1)* %25, align 8
+  %27 = zext i16 %26 to i32
+  %28 = load i16, i16* %loc3
+  %29 = zext i16 %28 to i32
+  %30 = icmp eq i32 %27, %29
+  br i1 %30, label %43, label %31
+
+; <label>:31                                      ; preds = %24
+  %32 = load i32, i32* %loc2
+  %33 = add i32 %32, 1
+  store i32 %33, i32* %loc2
+  br label %34
+
+; <label>:34                                      ; preds = %11, %31
+  %35 = load i32, i32* %loc2
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = icmp slt i32 %35, %41
+  br i1 %42, label %16, label %43
+
+; <label>:43                                      ; preds = %24, %37
+  %44 = load i32, i32* %loc2
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %45, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp eq i32 %44, %50
+  br i1 %51, label %62, label %52
+
+; <label>:52                                      ; preds = %46
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %7, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %57, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %58
+
+; <label>:58                                      ; preds = %55
+  %59 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %60 = load i32, i32 addrspace(1)* %59
+  %61 = icmp slt i32 %56, %60
+  br i1 %61, label %8, label %62
+
+; <label>:62                                      ; preds = %1, %46, %58
+  %63 = load i32, i32* %arg2
+  %64 = icmp eq i32 %63, 0
+  br i1 %64, label %122, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %66, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %67
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %66, i32 0, i32 1
+  %69 = load i32, i32 addrspace(1)* %68
+  %70 = sub i32 %69, 1
+  store i32 %70, i32* %loc0
+  br label %118
+
+; <label>:71                                      ; preds = %118
+  store i32 0, i32* %loc4
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %73 = load i32, i32* %loc0
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %74
+
+; <label>:74                                      ; preds = %71
+  %75 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 2, i32 %73
+  %76 = load i16, i16 addrspace(1)* %75
+  %77 = zext i16 %76 to i32
+  %78 = trunc i32 %77 to i16
+  store i16 %78, i16* %loc5
+  store i32 0, i32* %loc4
+  br label %97
+
+; <label>:79                                      ; preds = %100
+  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %81 = load i32, i32* %loc4
+  %NullCheck19 = icmp eq %"System.Char[]" addrspace(1)* %80, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
+
+; <label>:82                                      ; preds = %79
+  %83 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 1
+  %84 = load i32, i32 addrspace(1)* %83
+  %85 = zext i32 %84 to i64
+  %86 = zext i32 %81 to i64
+  %BoundsCheck21 = icmp uge i64 %86, %85
+  br i1 %BoundsCheck21, label %ThrowIndexOutOfRange22, label %87
+
+; <label>:87                                      ; preds = %82
+  %88 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 3, i32 %81
+  %89 = load i16, i16 addrspace(1)* %88, align 8
+  %90 = zext i16 %89 to i32
+  %91 = load i16, i16* %loc5
+  %92 = zext i16 %91 to i32
+  %93 = icmp eq i32 %90, %92
+  br i1 %93, label %106, label %94
+
+; <label>:94                                      ; preds = %87
+  %95 = load i32, i32* %loc4
+  %96 = add i32 %95, 1
+  store i32 %96, i32* %loc4
+  br label %97
+
+; <label>:97                                      ; preds = %74, %94
+  %98 = load i32, i32* %loc4
+  %99 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck15 = icmp eq %"System.Char[]" addrspace(1)* %99, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %100
+
+; <label>:100                                     ; preds = %97
+  %101 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %99, i32 0, i32 1
+  %102 = load i32, i32 addrspace(1)* %101
+  %103 = zext i32 %102 to i64
+  %104 = trunc i64 %103 to i32
+  %105 = icmp slt i32 %98, %104
+  br i1 %105, label %79, label %106
+
+; <label>:106                                     ; preds = %87, %100
+  %107 = load i32, i32* %loc4
+  %108 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck17 = icmp eq %"System.Char[]" addrspace(1)* %108, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %109
+
+; <label>:109                                     ; preds = %106
+  %110 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %108, i32 0, i32 1
+  %111 = load i32, i32 addrspace(1)* %110
+  %112 = zext i32 %111 to i64
+  %113 = trunc i64 %112 to i32
+  %114 = icmp eq i32 %107, %113
+  br i1 %114, label %122, label %115
+
+; <label>:115                                     ; preds = %109
+  %116 = load i32, i32* %loc0
+  %117 = sub i32 %116, 1
+  store i32 %117, i32* %loc0
+  br label %118
+
+; <label>:118                                     ; preds = %67, %115
+  %119 = load i32, i32* %loc0
+  %120 = load i32, i32* %loc1
+  %121 = icmp sge i32 %119, %120
+  br i1 %121, label %71, label %122
+
+; <label>:122                                     ; preds = %62, %109, %118
+  %123 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %124 = load i32, i32* %loc1
+  %125 = load i32, i32* %loc0
+  %126 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %123, i32 %124, i32 %125)
+  ret %System.String addrspace(1)* %126
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %97
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange22:                           ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
 Successfully read String.CreateTrimmedString
 
@@ -5439,8 +6893,8 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
@@ -5535,8 +6989,8 @@ entry:
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i64 2872
   %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
   %8 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %7
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %3
   %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
@@ -5553,8 +7007,8 @@ entry:
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 2864
   %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
   %21 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %20
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
-  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %22
 
 ; <label>:22                                      ; preds = %16
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
@@ -5569,7 +7023,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %16
+ThrowNullRef2:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5586,8 +7040,8 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5613,8 +7067,8 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
@@ -5632,8 +7086,8 @@ entry:
 
 ; <label>:12                                      ; preds = %4
   %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
@@ -5644,8 +7098,8 @@ entry:
 
 ; <label>:19                                      ; preds = %14
   %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %19
   %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
@@ -5660,21 +7114,21 @@ entry:
   %31 = zext i16 %30 to i32
   %32 = bitcast i8* %29 to i16*
   %33 = trunc i32 %31 to i16
-  %NullCheck6 = icmp ne i16* %32, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i16* %32, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %21
   store i16 %33, i16* %32, align 8
   %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %36
 
 ; <label>:36                                      ; preds = %34
   %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
   %38 = load i32, i32 addrspace(1)* %37, align 8
   %39 = add i32 %38, 1
-  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %40
 
 ; <label>:40                                      ; preds = %36
   %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
@@ -5683,16 +7137,16 @@ entry:
 
 ; <label>:42                                      ; preds = %14
   %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
-  br i1 %NullCheck12, label %44, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
   %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
   %47 = load i16, i16* %arg1
   %48 = zext i16 %47 to i32
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = trunc i32 %48 to i16
@@ -5703,31 +7157,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %19
+ThrowNullRef4:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %21
+ThrowNullRef6:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %36
+ThrowNullRef10:                                   ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %42
+ThrowNullRef12:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %44
+ThrowNullRef14:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5740,8 +7194,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -5752,8 +7206,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
@@ -5762,14 +7216,14 @@ entry:
 
 ; <label>:11                                      ; preds = %1
   %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
@@ -5779,15 +7233,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5808,8 +7262,8 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5822,8 +7276,8 @@ entry:
 
 ; <label>:8                                       ; preds = %3
   %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
@@ -5842,15 +7296,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
-  br i1 %NullCheck4, label %22, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
   %24 = load i16*, i16* addrspace(1)* %23, align 8
   %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %25, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
@@ -5859,8 +7313,8 @@ entry:
   store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
@@ -5874,8 +7328,8 @@ entry:
 
 ; <label>:37                                      ; preds = %65
   %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %37
   %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
@@ -5886,16 +7340,16 @@ entry:
   %45 = bitcast i16* %41 to i8*
   %46 = getelementptr inbounds i8, i8* %45, i64 %44
   %47 = bitcast i8* %46 to i16*
-  %NullCheck14 = icmp ne i16* %47, null
-  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %47, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %48
 
 ; <label>:48                                      ; preds = %39
   %49 = load i16, i16* %47, align 8
   %50 = zext i16 %49 to i32
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %52 = load i32, i32* %loc1
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %53
 
 ; <label>:53                                      ; preds = %48
   %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
@@ -5916,8 +7370,8 @@ entry:
 ; <label>:62                                      ; preds = %36, %59
   %63 = load i32, i32* %loc1
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck10, label %65, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %65
 
 ; <label>:65                                      ; preds = %62
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
@@ -5936,15 +7390,15 @@ entry:
 
 ; <label>:74                                      ; preds = %70
   %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
-  br i1 %NullCheck18, label %76, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %76
 
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
   %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
-  br i1 %NullCheck20, label %80, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
   %81 = load i64, i64 addrspace(1)* %79
@@ -5958,8 +7412,8 @@ entry:
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
   %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
-  br i1 %NullCheck22, label %92, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.String addrspace(1)* %90, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %92
 
 ; <label>:92                                      ; preds = %80
   %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
@@ -5969,15 +7423,15 @@ entry:
 
 ; <label>:96                                      ; preds = %70
   %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
-  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %98
 
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
   %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
-  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
   %103 = load i64, i64 addrspace(1)* %101
@@ -5991,8 +7445,8 @@ entry:
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
   %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
-  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.String addrspace(1)* %112, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %114
 
 ; <label>:114                                     ; preds = %102
   %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
@@ -6004,59 +7458,59 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %20
+ThrowNullRef4:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %22
+ThrowNullRef6:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %26
+ThrowNullRef8:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %62
+ThrowNullRef10:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %48
+ThrowNullRef16:                                   ; preds = %48
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %74
+ThrowNullRef18:                                   ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %76
+ThrowNullRef20:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %80
+ThrowNullRef22:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %96
+ThrowNullRef24:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %98
+ThrowNullRef26:                                   ; preds = %98
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %102
+ThrowNullRef28:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6069,15 +7523,15 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
   %3 = load i16*, i16* addrspace(1)* %2, align 8
   %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
@@ -6087,8 +7541,8 @@ entry:
   %10 = bitcast i16* %3 to i8*
   %11 = getelementptr inbounds i8, i8* %10, i64 %9
   %12 = bitcast i8* %11 to i16*
-  %NullCheck4 = icmp ne i16* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %5
   store i16 0, i16* %12, align 8
@@ -6098,11 +7552,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6119,8 +7573,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -6131,8 +7585,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
@@ -6144,15 +7598,15 @@ entry:
 
 ; <label>:14                                      ; preds = %1
   %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
   %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
   %21 = load i64, i64 addrspace(1)* %19
@@ -6171,15 +7625,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %14
+ThrowNullRef4:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %16
+ThrowNullRef6:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6302,14 +7756,6 @@ entry:
   ret %System.String addrspace(1)* %57
 }
 
-INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
-Successfully read RuntimeHelpers.get_OffsetToStringData
-
-define i32 @RuntimeHelpers.get_OffsetToStringData() {
-entry:
-  ret i32 12
-}
-
 INFO:  jitting method String::Equals using LLILCJit
 Successfully read String.Equals
 
@@ -6381,8 +7827,8 @@ entry:
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
-  br i1 %NullCheck24, label %29, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
   %30 = load i64, i64 addrspace(1)* %28
@@ -6397,8 +7843,8 @@ entry:
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
-  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
   %43 = load i64, i64 addrspace(1)* %41
@@ -6418,8 +7864,8 @@ entry:
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
   %59 = load i64, i64 addrspace(1)* %57
@@ -6434,8 +7880,8 @@ entry:
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck22, label %71, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
   %72 = load i64, i64 addrspace(1)* %70
@@ -6455,8 +7901,8 @@ entry:
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
-  br i1 %NullCheck16, label %87, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = load i64, i64 addrspace(1)* %86
@@ -6471,8 +7917,8 @@ entry:
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck18, label %100, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
   %101 = load i64, i64 addrspace(1)* %99
@@ -6492,8 +7938,8 @@ entry:
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
-  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
   %117 = load i64, i64 addrspace(1)* %115
@@ -6508,8 +7954,8 @@ entry:
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
-  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
   %130 = load i64, i64 addrspace(1)* %128
@@ -6528,15 +7974,15 @@ entry:
 
 ; <label>:142                                     ; preds = %22
   %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
-  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %143, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %144
 
 ; <label>:144                                     ; preds = %142
   %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
   %146 = load i32, i32 addrspace(1)* %145
   %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
-  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %147, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %148
 
 ; <label>:148                                     ; preds = %144
   %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
@@ -6557,15 +8003,15 @@ entry:
 
 ; <label>:159                                     ; preds = %22
   %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
-  br i1 %NullCheck, label %161, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %ThrowNullRef, label %161
 
 ; <label>:161                                     ; preds = %159
   %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
   %163 = load i32, i32 addrspace(1)* %162
   %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
-  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %164, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %165
 
 ; <label>:165                                     ; preds = %161
   %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
@@ -6578,8 +8024,8 @@ entry:
 
 ; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
-  br i1 %NullCheck4, label %172, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %171, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %172
 
 ; <label>:172                                     ; preds = %170
   %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
@@ -6589,8 +8035,8 @@ entry:
 
 ; <label>:176                                     ; preds = %172
   %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
-  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %177, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %178
 
 ; <label>:178                                     ; preds = %176
   %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
@@ -6629,55 +8075,55 @@ ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %161
+ThrowNullRef2:                                    ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %170
+ThrowNullRef4:                                    ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %176
+ThrowNullRef6:                                    ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %142
+ThrowNullRef8:                                    ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %144
+ThrowNullRef10:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %113
+ThrowNullRef12:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %116
+ThrowNullRef14:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %84
+ThrowNullRef16:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %87
+ThrowNullRef18:                                   ; preds = %87
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %55
+ThrowNullRef20:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %58
+ThrowNullRef22:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %26
+ThrowNullRef24:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %29
+ThrowNullRef26:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,8 +8161,8 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck, label %14, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %ThrowNullRef, label %14
 
 ; <label>:14                                      ; preds = %8
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
@@ -6760,8 +8206,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
@@ -6770,14 +8216,14 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32, i32* %loc0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %10
   %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
   %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
@@ -6790,15 +8236,15 @@ entry:
 ; <label>:25                                      ; preds = %19
   %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
-  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
   %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
@@ -6807,8 +8253,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %37 = load i32, i32* %loc0
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %38, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %38
 
 ; <label>:38                                      ; preds = %32
   %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
@@ -6817,14 +8263,14 @@ entry:
 
 ; <label>:40                                      ; preds = %19
   %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %40
   %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
   %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
-  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
-  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
@@ -6832,8 +8278,8 @@ entry:
   %48 = zext i32 %47 to i64
   %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
-  br i1 %NullCheck16, label %51, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %51
 
 ; <label>:51                                      ; preds = %45
   %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
@@ -6847,15 +8293,15 @@ entry:
 ; <label>:57                                      ; preds = %51
   %58 = load i16*, i16** %arg1
   %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
-  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %60
 
 ; <label>:60                                      ; preds = %57
   %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
   %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
-  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %64
 
 ; <label>:64                                      ; preds = %60
   %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
@@ -6864,22 +8310,22 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
   %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
-  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %70
 
 ; <label>:70                                      ; preds = %64
   %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
   %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
-  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
-  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
   %75 = load i32, i32 addrspace(1)* %74
   %76 = zext i32 %75 to i64
   %77 = trunc i64 %76 to i32
-  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
-  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %78
 
 ; <label>:78                                      ; preds = %73
   %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
@@ -6901,8 +8347,8 @@ entry:
   %90 = bitcast i16* %86 to i8*
   %91 = getelementptr inbounds i8, i8* %90, i64 %89
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %93
 
 ; <label>:93                                      ; preds = %80
   %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
@@ -6912,8 +8358,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %99 = load i32, i32* %loc2
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %100
 
 ; <label>:100                                     ; preds = %93
   %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
@@ -6928,63 +8374,63 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %25
+ThrowNullRef6:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %32
+ThrowNullRef10:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %40
+ThrowNullRef12:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %45
+ThrowNullRef16:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %57
+ThrowNullRef18:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %60
+ThrowNullRef20:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %64
+ThrowNullRef22:                                   ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %70
+ThrowNullRef24:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %73
+ThrowNullRef26:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %80
+ThrowNullRef28:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %93
+ThrowNullRef30:                                   ; preds = %93
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7004,8 +8450,8 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
@@ -7033,43 +8479,43 @@ entry:
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %14
   %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
   %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   %28 = load i32, i32 addrspace(1)* %27, align 8
   %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
-  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %30
 
 ; <label>:30                                      ; preds = %26
   %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
   %32 = load i32, i32 addrspace(1)* %31, align 8
   %33 = add i32 %28, %32
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %34
 
 ; <label>:34                                      ; preds = %30
   %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   store i32 %33, i32 addrspace(1)* %35
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
   store i32 0, i32 addrspace(1)* %38
   %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %40
 
 ; <label>:40                                      ; preds = %37
   %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
@@ -7082,8 +8528,8 @@ entry:
 
 ; <label>:47                                      ; preds = %40
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
@@ -7098,8 +8544,8 @@ entry:
   %54 = load i32, i32* %loc0
   %55 = sext i32 %54 to i64
   %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
-  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %57
 
 ; <label>:57                                      ; preds = %52
   %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
@@ -7110,68 +8556,35 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %14
+ThrowNullRef2:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %23
+ThrowNullRef4:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %26
+ThrowNullRef6:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %30
+ThrowNullRef8:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %34
+ThrowNullRef10:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %47
+ThrowNullRef14:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %52
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-}
-
-INFO:  jitting method StringBuilder::get_Length using LLILCJit
-Successfully read StringBuilder.get_Length
-
-define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.StringBuilder addrspace(1)*
-  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
-  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
-
-; <label>:1                                       ; preds = %entry
-  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %3 = load i32, i32 addrspace(1)* %2, align 8
-  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
-
-; <label>:5                                       ; preds = %1
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = add i32 %3, %7
-  ret i32 %8
-
-ThrowNullRef:                                     ; preds = %entry
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef16:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7213,70 +8626,70 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
   %6 = load i32, i32 addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
   store i32 %6, i32 addrspace(1)* %8
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
   %13 = load i32, i32 addrspace(1)* %12, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
   store i32 %13, i32 addrspace(1)* %15
   %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
-  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %18
 
 ; <label>:18                                      ; preds = %14
   %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
   %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
   %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
   %34 = load i32, i32 addrspace(1)* %33, align 8
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
-  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
@@ -7287,39 +8700,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %28
+ThrowNullRef16:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %32
+ThrowNullRef18:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7455,13 +8868,13 @@ entry:
 ; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
@@ -7477,16 +8890,16 @@ entry:
 
 ; <label>:18                                      ; preds = %15
   %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
   store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
   %22 = load i32, i32* %loc0
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %24
 
 ; <label>:24                                      ; preds = %20
   %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
@@ -7498,13 +8911,13 @@ entry:
 ; <label>:28                                      ; preds = %15, %24
   %29 = load i32, i32* %arg1
   %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %31
   %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
@@ -7517,20 +8930,20 @@ entry:
   %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
-  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
   %46 = load i32, i32 addrspace(1)* %45, align 8
   %47 = sub i32 %40, %46
-  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
-  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i32 addrspace(1)* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %48
 
 ; <label>:48                                      ; preds = %44
   store i32 %47, i32 addrspace(1)* %39, align 8
@@ -7538,21 +8951,21 @@ entry:
 
 ; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
-  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %51
 
 ; <label>:51                                      ; preds = %49
   %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %53
 
 ; <label>:53                                      ; preds = %51
   %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
   %55 = load i32, i32 addrspace(1)* %54, align 8
   %56 = load i32, i32* %arg2
   %57 = sub i32 %55, %56
-  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %58
 
 ; <label>:58                                      ; preds = %53
   %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
@@ -7562,13 +8975,13 @@ entry:
 ; <label>:60                                      ; preds = %33, %58
   %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
   %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
-  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %63
 
 ; <label>:63                                      ; preds = %60
   %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
-  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
-  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
@@ -7578,15 +8991,15 @@ entry:
 
 ; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
-  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i32 addrspace(1)* %69, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %70
 
 ; <label>:70                                      ; preds = %68
   %71 = load i32, i32 addrspace(1)* %69, align 8
   store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
-  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
@@ -7596,8 +9009,8 @@ entry:
   store i32 %77, i32* %loc4
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
-  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %80
 
 ; <label>:80                                      ; preds = %73
   %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
@@ -7607,71 +9020,71 @@ entry:
 ; <label>:83                                      ; preds = %80
   store i32 0, i32* %loc3
   %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
-  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
-  br i1 %NullCheck26, label %88, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i32 addrspace(1)* %87, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %88
 
 ; <label>:88                                      ; preds = %85
   %89 = load i32, i32 addrspace(1)* %87, align 8
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
-  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %90
 
 ; <label>:90                                      ; preds = %88
   %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
   store i32 %89, i32 addrspace(1)* %91
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
-  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
-  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %96
 
 ; <label>:96                                      ; preds = %94
   %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
-  br i1 %NullCheck34, label %100, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %100
 
 ; <label>:100                                     ; preds = %96
   %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
-  br i1 %NullCheck36, label %102, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %102
 
 ; <label>:102                                     ; preds = %100
   %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
   %104 = load i32, i32 addrspace(1)* %103, align 8
   %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
-  br i1 %NullCheck38, label %106, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %106
 
 ; <label>:106                                     ; preds = %102
   %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
-  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
-  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %108
 
 ; <label>:108                                     ; preds = %106
   %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
   %110 = load i32, i32 addrspace(1)* %109, align 8
   %111 = add i32 %104, %110
-  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %112
 
 ; <label>:112                                     ; preds = %108
   %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
   store i32 %111, i32 addrspace(1)* %113
   %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
-  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i32 addrspace(1)* %114, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %115
 
 ; <label>:115                                     ; preds = %112
   %116 = load i32, i32 addrspace(1)* %114, align 8
@@ -7681,19 +9094,19 @@ entry:
 ; <label>:118                                     ; preds = %115
   %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
-  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %121
 
 ; <label>:121                                     ; preds = %118
   %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
-  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
-  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %123
 
 ; <label>:123                                     ; preds = %121
   %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
   %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
-  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
-  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %126
 
 ; <label>:126                                     ; preds = %123
   %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
@@ -7705,8 +9118,8 @@ entry:
 
 ; <label>:130                                     ; preds = %80, %115, %126
   %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %132
 
 ; <label>:132                                     ; preds = %130
   %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7715,8 +9128,8 @@ entry:
   %136 = load i32, i32* %loc3
   %137 = sub i32 %135, %136
   %138 = sub i32 %134, %137
-  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %139
 
 ; <label>:139                                     ; preds = %132
   %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7728,16 +9141,16 @@ entry:
 
 ; <label>:144                                     ; preds = %139
   %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
-  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %146
 
 ; <label>:146                                     ; preds = %144
   %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
   %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
   %149 = load i32, i32* %loc2
   %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
-  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %151
 
 ; <label>:151                                     ; preds = %146
   %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
@@ -7754,145 +9167,249 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %18
+ThrowNullRef4:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %31
+ThrowNullRef10:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %44
+ThrowNullRef16:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %68
+ThrowNullRef18:                                   ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %70
+ThrowNullRef20:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %73
+ThrowNullRef22:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %83
+ThrowNullRef24:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %85
+ThrowNullRef26:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %88
+ThrowNullRef28:                                   ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %90
+ThrowNullRef30:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %94
+ThrowNullRef32:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %96
+ThrowNullRef34:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %100
+ThrowNullRef36:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %102
+ThrowNullRef38:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %106
+ThrowNullRef40:                                   ; preds = %106
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %108
+ThrowNullRef42:                                   ; preds = %108
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %112
+ThrowNullRef44:                                   ; preds = %112
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %118
+ThrowNullRef46:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %121
+ThrowNullRef48:                                   ; preds = %121
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %123
+ThrowNullRef50:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %130
+ThrowNullRef52:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %132
+ThrowNullRef54:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %144
+ThrowNullRef56:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %146
+ThrowNullRef58:                                   ; preds = %146
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %60
+ThrowNullRef60:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %63
+ThrowNullRef62:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %49
+ThrowNullRef64:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %51
+ThrowNullRef66:                                   ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %53
+ThrowNullRef68:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(%"System.Char[]" addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %arg0 = alloca %"System.Char[]" addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store %"System.Char[]" addrspace(1)* %param0, %"System.Char[]" addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load i32, i32* %arg4
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %43, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %38, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg1
+  %13 = load i32, i32* %arg4
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %38, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %24 = load i32, i32* %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %35 = load i32, i32* %arg3
+  %36 = load i32, i32* %arg4
+  %37 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %37, %"System.Char[]" addrspace(1)* %34, i32 %35, i32 %36)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:38                                      ; preds = %5, %16
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Successfully read Buffer._Memmove
 
@@ -7914,7 +9431,7 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[loadElem]
+Failed to read AppDomain.SetDataHelper[storeElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -7923,8 +9440,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
@@ -7934,8 +9451,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
@@ -7947,15 +9464,15 @@ entry:
   %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
   %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
@@ -7966,15 +9483,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7992,7 +9509,79 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
-Failed to read Dictionary`2.TryGetValue[loadElemA]
+Successfully read Dictionary`2.TryGetValue
+
+define i8 @"Dictionary`2.TryGetValue"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)* addrspace(1)* %param2) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  %arg2 = alloca %System.__Canon addrspace(1)* addrspace(1)*
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  store %System.__Canon addrspace(1)* addrspace(1)* %param2, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  store i32 %2, i32* %loc0
+  %3 = load i32, i32* %loc0
+  %4 = icmp slt i32 %3, 0
+  br i1 %4, label %22, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 2
+  %10 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %9, align 8
+  %11 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = zext i32 %11 to i64
+  %BoundsCheck = icmp uge i64 %16, %15
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 3, i32 %11
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %20, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %6, %System.__Canon addrspace(1)* %21)
+  ret i8 1
+
+; <label>:22                                      ; preds = %entry
+  %23 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %23, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -8058,8 +9647,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
@@ -8091,8 +9680,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
@@ -8171,15 +9760,15 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck, label %19, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %ThrowNullRef, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
   %21 = load i32, i32 addrspace(1)* %20
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
@@ -8202,7 +9791,7 @@ ThrowNullRef:                                     ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %19
+ThrowNullRef2:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8248,8 +9837,8 @@ entry:
   %0 = alloca %System.AppDomainHandle
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %1 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %1, i32 0, i32 15
@@ -8269,8 +9858,8 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
@@ -8286,7 +9875,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -8299,8 +9888,8 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -8327,8 +9916,8 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
@@ -8352,8 +9941,8 @@ entry:
   %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
   store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
@@ -8363,8 +9952,8 @@ entry:
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
@@ -8374,8 +9963,8 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %9
   %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
@@ -8384,8 +9973,8 @@ entry:
 
 ; <label>:18                                      ; preds = %3, %16
   %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
@@ -8397,15 +9986,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %18
+ThrowNullRef6:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8418,8 +10007,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
@@ -8453,15 +10042,15 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
@@ -8473,7 +10062,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8481,7 +10070,7 @@ ThrowNullRef1:                                    ; preds = %1
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
 Failed to read Dictionary`2.System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
@@ -8506,8 +10095,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
@@ -8524,8 +10113,8 @@ entry:
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -8544,7 +10133,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8577,8 +10166,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = load i64, i64* %arg2
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = trunc i32 %3 to i8
@@ -8634,46 +10223,46 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
   %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
-  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
-  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
-  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
@@ -8684,27 +10273,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %20
+ThrowNullRef12:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8717,8 +10306,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -8756,22 +10345,22 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
   %9 = load i64, i64 addrspace(1)* %8, align 8
   %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
   %13 = load i64, i64 addrspace(1)* %12, align 8
   %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %11
   %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
@@ -8788,11 +10377,11 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8882,8 +10471,8 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
@@ -8900,8 +10489,8 @@ entry:
 ; <label>:8                                       ; preds = %1
   %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
   %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
@@ -8911,15 +10500,15 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
   %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
   %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
-  br i1 %NullCheck6, label %21, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
@@ -8946,15 +10535,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8992,15 +10581,15 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
   store i8 %3, i8 addrspace(1)* %5
   %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
@@ -9011,7 +10600,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9027,8 +10616,8 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -9041,8 +10630,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
@@ -9058,7 +10647,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9080,8 +10669,8 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
@@ -9096,8 +10685,8 @@ entry:
 ; <label>:12                                      ; preds = %6
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
@@ -9112,8 +10701,8 @@ entry:
 ; <label>:21                                      ; preds = %15
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
@@ -9128,8 +10717,8 @@ entry:
 ; <label>:30                                      ; preds = %24
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %31, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
@@ -9144,8 +10733,8 @@ entry:
 ; <label>:39                                      ; preds = %33
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
-  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %40, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %42
 
 ; <label>:42                                      ; preds = %39
   %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
@@ -9164,19 +10753,19 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %21
+ThrowNullRef4:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %30
+ThrowNullRef6:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %39
+ThrowNullRef8:                                    ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9243,8 +10832,8 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
@@ -9264,57 +10853,57 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
   store i8 0, i8 addrspace(1)* %2
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
   store i8 0, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
   store i8 0, i8 addrspace(1)* %17
   %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
   store i8 0, i8 addrspace(1)* %20
   %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
-  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
@@ -9325,31 +10914,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %19
+ThrowNullRef14:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9367,8 +10956,8 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
@@ -9380,8 +10969,8 @@ entry:
 
 ; <label>:9                                       ; preds = %4
   %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %9
   %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
@@ -9395,7 +10984,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef2:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9420,8 +11009,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
@@ -9512,8 +11101,8 @@ entry:
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
@@ -9524,8 +11113,8 @@ entry:
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = load i64, i64 addrspace(1)* %12
@@ -9537,8 +11126,8 @@ entry:
   %20 = load i64, i64* %19
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
-  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %13
   %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
@@ -9555,8 +11144,8 @@ entry:
 ; <label>:30                                      ; preds = %25
   %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %32 = load i32, i32* %arg2
-  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
-  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
@@ -9570,15 +11159,15 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %30
+ThrowNullRef2:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9622,87 +11211,87 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
   %10 = load i8, i8 addrspace(1)* %9, align 8
   %11 = zext i8 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %8
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
   store i8 %12, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
   %19 = load i8, i8 addrspace(1)* %18, align 8
   %20 = zext i8 %19 to i32
   %21 = trunc i32 %20 to i8
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
   store i8 %21, i8 addrspace(1)* %23
   %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
   %28 = load i8, i8 addrspace(1)* %27, align 8
   %29 = zext i8 %28 to i32
   %30 = trunc i32 %29 to i8
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
-  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %31
 
 ; <label>:31                                      ; preds = %26
   %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
   store i8 %30, i8 addrspace(1)* %32
   %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
-  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
-  br i1 %NullCheck14, label %40, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %40
 
 ; <label>:40                                      ; preds = %35
   %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
   store i8 %39, i8 addrspace(1)* %41
   %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
-  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %44
 
 ; <label>:44                                      ; preds = %40
   %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
   %46 = load i8, i8 addrspace(1)* %45, align 8
   %47 = zext i8 %46 to i32
   %48 = trunc i32 %47 to i8
-  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
   store i8 %48, i8 addrspace(1)* %50
   %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
-  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
@@ -9713,29 +11302,29 @@ entry:
 ; <label>:56                                      ; preds = %52
   %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
-  br i1 %NullCheck22, label %59, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
   %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
   %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
-  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
-  br i1 %NullCheck24, label %63, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
   %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
-  br i1 %NullCheck26, label %66, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
   %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
-  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
-  br i1 %NullCheck28, label %69, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %69
 
 ; <label>:69                                      ; preds = %66
   %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
@@ -9744,15 +11333,15 @@ entry:
 
 ; <label>:71                                      ; preds = %105
   %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
-  br i1 %NullCheck34, label %73, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %73
 
 ; <label>:73                                      ; preds = %71
   %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
   %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
   %76 = load i32, i32* %loc0
-  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
-  br i1 %NullCheck36, label %77, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
@@ -9766,8 +11355,8 @@ entry:
 
 ; <label>:83                                      ; preds = %77
   %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
-  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
@@ -9775,14 +11364,14 @@ entry:
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
   %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
-  br i1 %NullCheck40, label %91, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
 ; <label>:91                                      ; preds = %85
   %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
   %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
-  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck42, label %94, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %94
 
 ; <label>:94                                      ; preds = %91
   %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
@@ -9798,14 +11387,14 @@ entry:
 ; <label>:99                                      ; preds = %69, %96
   %100 = load i32, i32* %loc0
   %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
-  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %102
 
 ; <label>:102                                     ; preds = %99
   %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
   %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
-  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
-  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
@@ -9819,87 +11408,87 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %26
+ThrowNullRef10:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %31
+ThrowNullRef12:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %35
+ThrowNullRef14:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %40
+ThrowNullRef16:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %56
+ThrowNullRef22:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %59
+ThrowNullRef24:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %63
+ThrowNullRef26:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %66
+ThrowNullRef28:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %102
+ThrowNullRef32:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %71
+ThrowNullRef34:                                   ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %73
+ThrowNullRef36:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %83
+ThrowNullRef38:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %85
+ThrowNullRef40:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %91
+ThrowNullRef42:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9943,15 +11532,15 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
   %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
@@ -9961,28 +11550,28 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
   %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %12
   %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
   %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
   %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
-  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
@@ -9993,23 +11582,23 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %12
+ThrowNullRef6:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10031,15 +11620,15 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
   %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = load i64, i64 addrspace(1)* %7
@@ -10077,13 +11666,13 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[loadElem]
+Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -10111,8 +11700,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1

--- a/test/BaseLine/JIT/CodeGenBringUpTests/AsgXor1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/AsgXor1.error.txt
@@ -25,8 +25,8 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
@@ -40,8 +40,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
   %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
@@ -75,7 +75,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -90,8 +90,8 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %NullCheck = icmp ne i8 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = load i8, i8 addrspace(1)* %0, align 8
@@ -125,8 +125,8 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
@@ -159,8 +159,8 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -184,8 +184,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
   store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
@@ -195,8 +195,8 @@ entry:
 ; <label>:4                                       ; preds = %1
   %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
   %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
@@ -206,8 +206,8 @@ entry:
   %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
@@ -221,14 +221,14 @@ entry:
 
 ; <label>:17                                      ; preds = %14
   %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
   %21 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
@@ -238,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -249,8 +249,8 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
@@ -261,27 +261,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %30
+ThrowNullRef10:                                   ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -301,7 +301,89 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
-Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
+Successfully read AppDomainSetup.GetUnsecureApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.GetUnsecureApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %NullCheck = icmp eq %"System.String[]" addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %BoundsCheck = icmp uge i64 0, %5
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %6
+
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 3, i32 0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
+  ret %System.String addrspace(1)* %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_Value using LLILCJit
+Successfully read AppDomainSetup.get_Value
+
+define %"System.String[]" addrspace(1)* @AppDomainSetup.get_Value(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.String[]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 18)
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.String[]" addrspace(1)* addrspace(1)*, %"System.String[]" addrspace(1)*)*)(%"System.String[]" addrspace(1)* addrspace(1)* %9, %"System.String[]" addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %11, i32 0, i32 1
+  %14 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %13, align 8
+  ret %"System.String[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -319,8 +401,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -368,16 +450,16 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
   %5 = load i32, i32 addrspace(1)* %4
   %6 = sub i32 %5, 1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -389,7 +471,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -421,8 +503,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
@@ -456,8 +538,8 @@ entry:
 ; <label>:27                                      ; preds = %19
   %28 = load i32, i32* %arg1
   %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
-  br i1 %NullCheck2, label %30, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %29, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %30
 
 ; <label>:30                                      ; preds = %27
   %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
@@ -493,8 +575,8 @@ entry:
 ; <label>:49                                      ; preds = %46
   %50 = load i32, i32* %arg2
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck4, label %52, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
@@ -517,11 +599,11 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %27
+ThrowNullRef2:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %49
+ThrowNullRef4:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -544,16 +626,16 @@ entry:
   %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %0)
   store %System.String addrspace(1)* %1, %System.String addrspace(1)** %loc0
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 2
   %5 = bitcast [0 x i16] addrspace(1)* %4 to i16 addrspace(1)*
   store i16 addrspace(1)* %5, i16 addrspace(1)** %loc1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %3
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2
@@ -580,7 +662,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -691,15 +773,15 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %NullCheck132 = icmp ne i8* %21, null
-  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+  %NullCheck131 = icmp eq i8* %21, null
+  br i1 %NullCheck131, label %ThrowNullRef132, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = load i8, i8* %21, align 8
   %24 = zext i8 %23 to i32
   %25 = trunc i32 %24 to i8
-  %NullCheck134 = icmp ne i8* %20, null
-  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+  %NullCheck133 = icmp eq i8* %20, null
+  br i1 %NullCheck133, label %ThrowNullRef134, label %26
 
 ; <label>:26                                      ; preds = %22
   store i8 %25, i8* %20, align 8
@@ -709,16 +791,16 @@ entry:
   %28 = load i8*, i8** %arg0
   %29 = load i8*, i8** %arg1
   %30 = bitcast i8* %29 to i16*
-  %NullCheck128 = icmp ne i16* %30, null
-  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+  %NullCheck127 = icmp eq i16* %30, null
+  br i1 %NullCheck127, label %ThrowNullRef128, label %31
 
 ; <label>:31                                      ; preds = %27
   %32 = load i16, i16* %30, align 8
   %33 = sext i16 %32 to i32
   %34 = bitcast i8* %28 to i16*
   %35 = trunc i32 %33 to i16
-  %NullCheck130 = icmp ne i16* %34, null
-  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+  %NullCheck129 = icmp eq i16* %34, null
+  br i1 %NullCheck129, label %ThrowNullRef130, label %36
 
 ; <label>:36                                      ; preds = %31
   store i16 %35, i16* %34, align 8
@@ -728,16 +810,16 @@ entry:
   %38 = load i8*, i8** %arg0
   %39 = load i8*, i8** %arg1
   %40 = bitcast i8* %39 to i16*
-  %NullCheck120 = icmp ne i16* %40, null
-  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+  %NullCheck119 = icmp eq i16* %40, null
+  br i1 %NullCheck119, label %ThrowNullRef120, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i16, i16* %40, align 8
   %43 = sext i16 %42 to i32
   %44 = bitcast i8* %38 to i16*
   %45 = trunc i32 %43 to i16
-  %NullCheck122 = icmp ne i16* %44, null
-  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+  %NullCheck121 = icmp eq i16* %44, null
+  br i1 %NullCheck121, label %ThrowNullRef122, label %46
 
 ; <label>:46                                      ; preds = %41
   store i16 %45, i16* %44, align 8
@@ -745,15 +827,15 @@ entry:
   %48 = getelementptr inbounds i8, i8* %47, i64 2
   %49 = load i8*, i8** %arg1
   %50 = getelementptr inbounds i8, i8* %49, i64 2
-  %NullCheck124 = icmp ne i8* %50, null
-  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+  %NullCheck123 = icmp eq i8* %50, null
+  br i1 %NullCheck123, label %ThrowNullRef124, label %51
 
 ; <label>:51                                      ; preds = %46
   %52 = load i8, i8* %50, align 8
   %53 = zext i8 %52 to i32
   %54 = trunc i32 %53 to i8
-  %NullCheck126 = icmp ne i8* %48, null
-  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+  %NullCheck125 = icmp eq i8* %48, null
+  br i1 %NullCheck125, label %ThrowNullRef126, label %55
 
 ; <label>:55                                      ; preds = %51
   store i8 %54, i8* %48, align 8
@@ -763,14 +845,14 @@ entry:
   %57 = load i8*, i8** %arg0
   %58 = load i8*, i8** %arg1
   %59 = bitcast i8* %58 to i32*
-  %NullCheck116 = icmp ne i32* %59, null
-  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+  %NullCheck115 = icmp eq i32* %59, null
+  br i1 %NullCheck115, label %ThrowNullRef116, label %60
 
 ; <label>:60                                      ; preds = %56
   %61 = load i32, i32* %59, align 8
   %62 = bitcast i8* %57 to i32*
-  %NullCheck118 = icmp ne i32* %62, null
-  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+  %NullCheck117 = icmp eq i32* %62, null
+  br i1 %NullCheck117, label %ThrowNullRef118, label %63
 
 ; <label>:63                                      ; preds = %60
   store i32 %61, i32* %62, align 8
@@ -780,14 +862,14 @@ entry:
   %65 = load i8*, i8** %arg0
   %66 = load i8*, i8** %arg1
   %67 = bitcast i8* %66 to i32*
-  %NullCheck108 = icmp ne i32* %67, null
-  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+  %NullCheck107 = icmp eq i32* %67, null
+  br i1 %NullCheck107, label %ThrowNullRef108, label %68
 
 ; <label>:68                                      ; preds = %64
   %69 = load i32, i32* %67, align 8
   %70 = bitcast i8* %65 to i32*
-  %NullCheck110 = icmp ne i32* %70, null
-  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+  %NullCheck109 = icmp eq i32* %70, null
+  br i1 %NullCheck109, label %ThrowNullRef110, label %71
 
 ; <label>:71                                      ; preds = %68
   store i32 %69, i32* %70, align 8
@@ -795,15 +877,15 @@ entry:
   %73 = getelementptr inbounds i8, i8* %72, i64 4
   %74 = load i8*, i8** %arg1
   %75 = getelementptr inbounds i8, i8* %74, i64 4
-  %NullCheck112 = icmp ne i8* %75, null
-  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+  %NullCheck111 = icmp eq i8* %75, null
+  br i1 %NullCheck111, label %ThrowNullRef112, label %76
 
 ; <label>:76                                      ; preds = %71
   %77 = load i8, i8* %75, align 8
   %78 = zext i8 %77 to i32
   %79 = trunc i32 %78 to i8
-  %NullCheck114 = icmp ne i8* %73, null
-  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+  %NullCheck113 = icmp eq i8* %73, null
+  br i1 %NullCheck113, label %ThrowNullRef114, label %80
 
 ; <label>:80                                      ; preds = %76
   store i8 %79, i8* %73, align 8
@@ -813,14 +895,14 @@ entry:
   %82 = load i8*, i8** %arg0
   %83 = load i8*, i8** %arg1
   %84 = bitcast i8* %83 to i32*
-  %NullCheck100 = icmp ne i32* %84, null
-  br i1 %NullCheck100, label %85, label %ThrowNullRef99
+  %NullCheck99 = icmp eq i32* %84, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %85
 
 ; <label>:85                                      ; preds = %81
   %86 = load i32, i32* %84, align 8
   %87 = bitcast i8* %82 to i32*
-  %NullCheck102 = icmp ne i32* %87, null
-  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+  %NullCheck101 = icmp eq i32* %87, null
+  br i1 %NullCheck101, label %ThrowNullRef102, label %88
 
 ; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
@@ -829,16 +911,16 @@ entry:
   %91 = load i8*, i8** %arg1
   %92 = getelementptr inbounds i8, i8* %91, i64 4
   %93 = bitcast i8* %92 to i16*
-  %NullCheck104 = icmp ne i16* %93, null
-  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+  %NullCheck103 = icmp eq i16* %93, null
+  br i1 %NullCheck103, label %ThrowNullRef104, label %94
 
 ; <label>:94                                      ; preds = %88
   %95 = load i16, i16* %93, align 8
   %96 = sext i16 %95 to i32
   %97 = bitcast i8* %90 to i16*
   %98 = trunc i32 %96 to i16
-  %NullCheck106 = icmp ne i16* %97, null
-  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+  %NullCheck105 = icmp eq i16* %97, null
+  br i1 %NullCheck105, label %ThrowNullRef106, label %99
 
 ; <label>:99                                      ; preds = %94
   store i16 %98, i16* %97, align 8
@@ -848,14 +930,14 @@ entry:
   %101 = load i8*, i8** %arg0
   %102 = load i8*, i8** %arg1
   %103 = bitcast i8* %102 to i32*
-  %NullCheck88 = icmp ne i32* %103, null
-  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+  %NullCheck87 = icmp eq i32* %103, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %104
 
 ; <label>:104                                     ; preds = %100
   %105 = load i32, i32* %103, align 8
   %106 = bitcast i8* %101 to i32*
-  %NullCheck90 = icmp ne i32* %106, null
-  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+  %NullCheck89 = icmp eq i32* %106, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %107
 
 ; <label>:107                                     ; preds = %104
   store i32 %105, i32* %106, align 8
@@ -864,16 +946,16 @@ entry:
   %110 = load i8*, i8** %arg1
   %111 = getelementptr inbounds i8, i8* %110, i64 4
   %112 = bitcast i8* %111 to i16*
-  %NullCheck92 = icmp ne i16* %112, null
-  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+  %NullCheck91 = icmp eq i16* %112, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %113
 
 ; <label>:113                                     ; preds = %107
   %114 = load i16, i16* %112, align 8
   %115 = sext i16 %114 to i32
   %116 = bitcast i8* %109 to i16*
   %117 = trunc i32 %115 to i16
-  %NullCheck94 = icmp ne i16* %116, null
-  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+  %NullCheck93 = icmp eq i16* %116, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %118
 
 ; <label>:118                                     ; preds = %113
   store i16 %117, i16* %116, align 8
@@ -881,15 +963,15 @@ entry:
   %120 = getelementptr inbounds i8, i8* %119, i64 6
   %121 = load i8*, i8** %arg1
   %122 = getelementptr inbounds i8, i8* %121, i64 6
-  %NullCheck96 = icmp ne i8* %122, null
-  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+  %NullCheck95 = icmp eq i8* %122, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %123
 
 ; <label>:123                                     ; preds = %118
   %124 = load i8, i8* %122, align 8
   %125 = zext i8 %124 to i32
   %126 = trunc i32 %125 to i8
-  %NullCheck98 = icmp ne i8* %120, null
-  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+  %NullCheck97 = icmp eq i8* %120, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %127
 
 ; <label>:127                                     ; preds = %123
   store i8 %126, i8* %120, align 8
@@ -899,14 +981,14 @@ entry:
   %129 = load i8*, i8** %arg0
   %130 = load i8*, i8** %arg1
   %131 = bitcast i8* %130 to i64*
-  %NullCheck84 = icmp ne i64* %131, null
-  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+  %NullCheck83 = icmp eq i64* %131, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %132
 
 ; <label>:132                                     ; preds = %128
   %133 = load i64, i64* %131, align 8
   %134 = bitcast i8* %129 to i64*
-  %NullCheck86 = icmp ne i64* %134, null
-  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+  %NullCheck85 = icmp eq i64* %134, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %135
 
 ; <label>:135                                     ; preds = %132
   store i64 %133, i64* %134, align 8
@@ -916,14 +998,14 @@ entry:
   %137 = load i8*, i8** %arg0
   %138 = load i8*, i8** %arg1
   %139 = bitcast i8* %138 to i64*
-  %NullCheck76 = icmp ne i64* %139, null
-  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+  %NullCheck75 = icmp eq i64* %139, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %140
 
 ; <label>:140                                     ; preds = %136
   %141 = load i64, i64* %139, align 8
   %142 = bitcast i8* %137 to i64*
-  %NullCheck78 = icmp ne i64* %142, null
-  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+  %NullCheck77 = icmp eq i64* %142, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %143
 
 ; <label>:143                                     ; preds = %140
   store i64 %141, i64* %142, align 8
@@ -931,15 +1013,15 @@ entry:
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %NullCheck80 = icmp ne i8* %147, null
-  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+  %NullCheck79 = icmp eq i8* %147, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %148
 
 ; <label>:148                                     ; preds = %143
   %149 = load i8, i8* %147, align 8
   %150 = zext i8 %149 to i32
   %151 = trunc i32 %150 to i8
-  %NullCheck82 = icmp ne i8* %145, null
-  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+  %NullCheck81 = icmp eq i8* %145, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %152
 
 ; <label>:152                                     ; preds = %148
   store i8 %151, i8* %145, align 8
@@ -949,14 +1031,14 @@ entry:
   %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
   %156 = bitcast i8* %155 to i64*
-  %NullCheck68 = icmp ne i64* %156, null
-  br i1 %NullCheck68, label %157, label %ThrowNullRef67
+  %NullCheck67 = icmp eq i64* %156, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %157
 
 ; <label>:157                                     ; preds = %153
   %158 = load i64, i64* %156, align 8
   %159 = bitcast i8* %154 to i64*
-  %NullCheck70 = icmp ne i64* %159, null
-  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+  %NullCheck69 = icmp eq i64* %159, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %160
 
 ; <label>:160                                     ; preds = %157
   store i64 %158, i64* %159, align 8
@@ -965,16 +1047,16 @@ entry:
   %163 = load i8*, i8** %arg1
   %164 = getelementptr inbounds i8, i8* %163, i64 8
   %165 = bitcast i8* %164 to i16*
-  %NullCheck72 = icmp ne i16* %165, null
-  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+  %NullCheck71 = icmp eq i16* %165, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %166
 
 ; <label>:166                                     ; preds = %160
   %167 = load i16, i16* %165, align 8
   %168 = sext i16 %167 to i32
   %169 = bitcast i8* %162 to i16*
   %170 = trunc i32 %168 to i16
-  %NullCheck74 = icmp ne i16* %169, null
-  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+  %NullCheck73 = icmp eq i16* %169, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %171
 
 ; <label>:171                                     ; preds = %166
   store i16 %170, i16* %169, align 8
@@ -984,14 +1066,14 @@ entry:
   %173 = load i8*, i8** %arg0
   %174 = load i8*, i8** %arg1
   %175 = bitcast i8* %174 to i64*
-  %NullCheck56 = icmp ne i64* %175, null
-  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+  %NullCheck55 = icmp eq i64* %175, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %176
 
 ; <label>:176                                     ; preds = %172
   %177 = load i64, i64* %175, align 8
   %178 = bitcast i8* %173 to i64*
-  %NullCheck58 = icmp ne i64* %178, null
-  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+  %NullCheck57 = icmp eq i64* %178, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %179
 
 ; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
@@ -1000,16 +1082,16 @@ entry:
   %182 = load i8*, i8** %arg1
   %183 = getelementptr inbounds i8, i8* %182, i64 8
   %184 = bitcast i8* %183 to i16*
-  %NullCheck60 = icmp ne i16* %184, null
-  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+  %NullCheck59 = icmp eq i16* %184, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %185
 
 ; <label>:185                                     ; preds = %179
   %186 = load i16, i16* %184, align 8
   %187 = sext i16 %186 to i32
   %188 = bitcast i8* %181 to i16*
   %189 = trunc i32 %187 to i16
-  %NullCheck62 = icmp ne i16* %188, null
-  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+  %NullCheck61 = icmp eq i16* %188, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %190
 
 ; <label>:190                                     ; preds = %185
   store i16 %189, i16* %188, align 8
@@ -1017,15 +1099,15 @@ entry:
   %192 = getelementptr inbounds i8, i8* %191, i64 10
   %193 = load i8*, i8** %arg1
   %194 = getelementptr inbounds i8, i8* %193, i64 10
-  %NullCheck64 = icmp ne i8* %194, null
-  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+  %NullCheck63 = icmp eq i8* %194, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %195
 
 ; <label>:195                                     ; preds = %190
   %196 = load i8, i8* %194, align 8
   %197 = zext i8 %196 to i32
   %198 = trunc i32 %197 to i8
-  %NullCheck66 = icmp ne i8* %192, null
-  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+  %NullCheck65 = icmp eq i8* %192, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %199
 
 ; <label>:199                                     ; preds = %195
   store i8 %198, i8* %192, align 8
@@ -1035,14 +1117,14 @@ entry:
   %201 = load i8*, i8** %arg0
   %202 = load i8*, i8** %arg1
   %203 = bitcast i8* %202 to i64*
-  %NullCheck48 = icmp ne i64* %203, null
-  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+  %NullCheck47 = icmp eq i64* %203, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %204
 
 ; <label>:204                                     ; preds = %200
   %205 = load i64, i64* %203, align 8
   %206 = bitcast i8* %201 to i64*
-  %NullCheck50 = icmp ne i64* %206, null
-  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+  %NullCheck49 = icmp eq i64* %206, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %207
 
 ; <label>:207                                     ; preds = %204
   store i64 %205, i64* %206, align 8
@@ -1051,14 +1133,14 @@ entry:
   %210 = load i8*, i8** %arg1
   %211 = getelementptr inbounds i8, i8* %210, i64 8
   %212 = bitcast i8* %211 to i32*
-  %NullCheck52 = icmp ne i32* %212, null
-  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+  %NullCheck51 = icmp eq i32* %212, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %213
 
 ; <label>:213                                     ; preds = %207
   %214 = load i32, i32* %212, align 8
   %215 = bitcast i8* %209 to i32*
-  %NullCheck54 = icmp ne i32* %215, null
-  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+  %NullCheck53 = icmp eq i32* %215, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %216
 
 ; <label>:216                                     ; preds = %213
   store i32 %214, i32* %215, align 8
@@ -1068,14 +1150,14 @@ entry:
   %218 = load i8*, i8** %arg0
   %219 = load i8*, i8** %arg1
   %220 = bitcast i8* %219 to i64*
-  %NullCheck36 = icmp ne i64* %220, null
-  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64* %220, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %221
 
 ; <label>:221                                     ; preds = %217
   %222 = load i64, i64* %220, align 8
   %223 = bitcast i8* %218 to i64*
-  %NullCheck38 = icmp ne i64* %223, null
-  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+  %NullCheck37 = icmp eq i64* %223, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %224
 
 ; <label>:224                                     ; preds = %221
   store i64 %222, i64* %223, align 8
@@ -1084,14 +1166,14 @@ entry:
   %227 = load i8*, i8** %arg1
   %228 = getelementptr inbounds i8, i8* %227, i64 8
   %229 = bitcast i8* %228 to i32*
-  %NullCheck40 = icmp ne i32* %229, null
-  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i32* %229, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %230
 
 ; <label>:230                                     ; preds = %224
   %231 = load i32, i32* %229, align 8
   %232 = bitcast i8* %226 to i32*
-  %NullCheck42 = icmp ne i32* %232, null
-  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+  %NullCheck41 = icmp eq i32* %232, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %233
 
 ; <label>:233                                     ; preds = %230
   store i32 %231, i32* %232, align 8
@@ -1099,15 +1181,15 @@ entry:
   %235 = getelementptr inbounds i8, i8* %234, i64 12
   %236 = load i8*, i8** %arg1
   %237 = getelementptr inbounds i8, i8* %236, i64 12
-  %NullCheck44 = icmp ne i8* %237, null
-  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i8* %237, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %238
 
 ; <label>:238                                     ; preds = %233
   %239 = load i8, i8* %237, align 8
   %240 = zext i8 %239 to i32
   %241 = trunc i32 %240 to i8
-  %NullCheck46 = icmp ne i8* %235, null
-  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+  %NullCheck45 = icmp eq i8* %235, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %242
 
 ; <label>:242                                     ; preds = %238
   store i8 %241, i8* %235, align 8
@@ -1117,14 +1199,14 @@ entry:
   %244 = load i8*, i8** %arg0
   %245 = load i8*, i8** %arg1
   %246 = bitcast i8* %245 to i64*
-  %NullCheck24 = icmp ne i64* %246, null
-  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64* %246, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %247
 
 ; <label>:247                                     ; preds = %243
   %248 = load i64, i64* %246, align 8
   %249 = bitcast i8* %244 to i64*
-  %NullCheck26 = icmp ne i64* %249, null
-  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64* %249, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %250
 
 ; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
@@ -1133,14 +1215,14 @@ entry:
   %253 = load i8*, i8** %arg1
   %254 = getelementptr inbounds i8, i8* %253, i64 8
   %255 = bitcast i8* %254 to i32*
-  %NullCheck28 = icmp ne i32* %255, null
-  br i1 %NullCheck28, label %256, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i32* %255, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %256
 
 ; <label>:256                                     ; preds = %250
   %257 = load i32, i32* %255, align 8
   %258 = bitcast i8* %252 to i32*
-  %NullCheck30 = icmp ne i32* %258, null
-  br i1 %NullCheck30, label %259, label %ThrowNullRef29
+  %NullCheck29 = icmp eq i32* %258, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %259
 
 ; <label>:259                                     ; preds = %256
   store i32 %257, i32* %258, align 8
@@ -1149,16 +1231,16 @@ entry:
   %262 = load i8*, i8** %arg1
   %263 = getelementptr inbounds i8, i8* %262, i64 12
   %264 = bitcast i8* %263 to i16*
-  %NullCheck32 = icmp ne i16* %264, null
-  br i1 %NullCheck32, label %265, label %ThrowNullRef31
+  %NullCheck31 = icmp eq i16* %264, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %265
 
 ; <label>:265                                     ; preds = %259
   %266 = load i16, i16* %264, align 8
   %267 = sext i16 %266 to i32
   %268 = bitcast i8* %261 to i16*
   %269 = trunc i32 %267 to i16
-  %NullCheck34 = icmp ne i16* %268, null
-  br i1 %NullCheck34, label %270, label %ThrowNullRef33
+  %NullCheck33 = icmp eq i16* %268, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %270
 
 ; <label>:270                                     ; preds = %265
   store i16 %269, i16* %268, align 8
@@ -1168,14 +1250,14 @@ entry:
   %272 = load i8*, i8** %arg0
   %273 = load i8*, i8** %arg1
   %274 = bitcast i8* %273 to i64*
-  %NullCheck8 = icmp ne i64* %274, null
-  br i1 %NullCheck8, label %275, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64* %274, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %275
 
 ; <label>:275                                     ; preds = %271
   %276 = load i64, i64* %274, align 8
   %277 = bitcast i8* %272 to i64*
-  %NullCheck10 = icmp ne i64* %277, null
-  br i1 %NullCheck10, label %278, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %277, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %278
 
 ; <label>:278                                     ; preds = %275
   store i64 %276, i64* %277, align 8
@@ -1184,14 +1266,14 @@ entry:
   %281 = load i8*, i8** %arg1
   %282 = getelementptr inbounds i8, i8* %281, i64 8
   %283 = bitcast i8* %282 to i32*
-  %NullCheck12 = icmp ne i32* %283, null
-  br i1 %NullCheck12, label %284, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i32* %283, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %284
 
 ; <label>:284                                     ; preds = %278
   %285 = load i32, i32* %283, align 8
   %286 = bitcast i8* %280 to i32*
-  %NullCheck14 = icmp ne i32* %286, null
-  br i1 %NullCheck14, label %287, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i32* %286, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %287
 
 ; <label>:287                                     ; preds = %284
   store i32 %285, i32* %286, align 8
@@ -1200,16 +1282,16 @@ entry:
   %290 = load i8*, i8** %arg1
   %291 = getelementptr inbounds i8, i8* %290, i64 12
   %292 = bitcast i8* %291 to i16*
-  %NullCheck16 = icmp ne i16* %292, null
-  br i1 %NullCheck16, label %293, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i16* %292, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %293
 
 ; <label>:293                                     ; preds = %287
   %294 = load i16, i16* %292, align 8
   %295 = sext i16 %294 to i32
   %296 = bitcast i8* %289 to i16*
   %297 = trunc i32 %295 to i16
-  %NullCheck18 = icmp ne i16* %296, null
-  br i1 %NullCheck18, label %298, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i16* %296, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %298
 
 ; <label>:298                                     ; preds = %293
   store i16 %297, i16* %296, align 8
@@ -1217,15 +1299,15 @@ entry:
   %300 = getelementptr inbounds i8, i8* %299, i64 14
   %301 = load i8*, i8** %arg1
   %302 = getelementptr inbounds i8, i8* %301, i64 14
-  %NullCheck20 = icmp ne i8* %302, null
-  br i1 %NullCheck20, label %303, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i8* %302, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %303
 
 ; <label>:303                                     ; preds = %298
   %304 = load i8, i8* %302, align 8
   %305 = zext i8 %304 to i32
   %306 = trunc i32 %305 to i8
-  %NullCheck22 = icmp ne i8* %300, null
-  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i8* %300, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %307
 
 ; <label>:307                                     ; preds = %303
   store i8 %306, i8* %300, align 8
@@ -1235,14 +1317,14 @@ entry:
   %309 = load i8*, i8** %arg0
   %310 = load i8*, i8** %arg1
   %311 = bitcast i8* %310 to i64*
-  %NullCheck = icmp ne i64* %311, null
-  br i1 %NullCheck, label %312, label %ThrowNullRef
+  %NullCheck = icmp eq i64* %311, null
+  br i1 %NullCheck, label %ThrowNullRef, label %312
 
 ; <label>:312                                     ; preds = %308
   %313 = load i64, i64* %311, align 8
   %314 = bitcast i8* %309 to i64*
-  %NullCheck2 = icmp ne i64* %314, null
-  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64* %314, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %315
 
 ; <label>:315                                     ; preds = %312
   store i64 %313, i64* %314, align 8
@@ -1251,14 +1333,14 @@ entry:
   %318 = load i8*, i8** %arg1
   %319 = getelementptr inbounds i8, i8* %318, i64 8
   %320 = bitcast i8* %319 to i64*
-  %NullCheck4 = icmp ne i64* %320, null
-  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64* %320, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %321
 
 ; <label>:321                                     ; preds = %315
   %322 = load i64, i64* %320, align 8
   %323 = bitcast i8* %317 to i64*
-  %NullCheck6 = icmp ne i64* %323, null
-  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64* %323, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %324
 
 ; <label>:324                                     ; preds = %321
   store i64 %322, i64* %323, align 8
@@ -1286,15 +1368,15 @@ entry:
 ; <label>:338                                     ; preds = %333
   %339 = load i8*, i8** %arg0
   %340 = load i8*, i8** %arg1
-  %NullCheck136 = icmp ne i8* %340, null
-  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+  %NullCheck135 = icmp eq i8* %340, null
+  br i1 %NullCheck135, label %ThrowNullRef136, label %341
 
 ; <label>:341                                     ; preds = %338
   %342 = load i8, i8* %340, align 8
   %343 = zext i8 %342 to i32
   %344 = trunc i32 %343 to i8
-  %NullCheck138 = icmp ne i8* %339, null
-  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+  %NullCheck137 = icmp eq i8* %339, null
+  br i1 %NullCheck137, label %ThrowNullRef138, label %345
 
 ; <label>:345                                     ; preds = %341
   store i8 %344, i8* %339, align 8
@@ -1317,16 +1399,16 @@ entry:
   %357 = load i8*, i8** %arg0
   %358 = load i8*, i8** %arg1
   %359 = bitcast i8* %358 to i16*
-  %NullCheck140 = icmp ne i16* %359, null
-  br i1 %NullCheck140, label %360, label %ThrowNullRef139
+  %NullCheck139 = icmp eq i16* %359, null
+  br i1 %NullCheck139, label %ThrowNullRef140, label %360
 
 ; <label>:360                                     ; preds = %356
   %361 = load i16, i16* %359, align 8
   %362 = sext i16 %361 to i32
   %363 = bitcast i8* %357 to i16*
   %364 = trunc i32 %362 to i16
-  %NullCheck142 = icmp ne i16* %363, null
-  br i1 %NullCheck142, label %365, label %ThrowNullRef141
+  %NullCheck141 = icmp eq i16* %363, null
+  br i1 %NullCheck141, label %ThrowNullRef142, label %365
 
 ; <label>:365                                     ; preds = %360
   store i16 %364, i16* %363, align 8
@@ -1352,14 +1434,14 @@ entry:
   %378 = load i8*, i8** %arg0
   %379 = load i8*, i8** %arg1
   %380 = bitcast i8* %379 to i32*
-  %NullCheck144 = icmp ne i32* %380, null
-  br i1 %NullCheck144, label %381, label %ThrowNullRef143
+  %NullCheck143 = icmp eq i32* %380, null
+  br i1 %NullCheck143, label %ThrowNullRef144, label %381
 
 ; <label>:381                                     ; preds = %377
   %382 = load i32, i32* %380, align 8
   %383 = bitcast i8* %378 to i32*
-  %NullCheck146 = icmp ne i32* %383, null
-  br i1 %NullCheck146, label %384, label %ThrowNullRef145
+  %NullCheck145 = icmp eq i32* %383, null
+  br i1 %NullCheck145, label %ThrowNullRef146, label %384
 
 ; <label>:384                                     ; preds = %381
   store i32 %382, i32* %383, align 8
@@ -1384,14 +1466,14 @@ entry:
   %395 = load i8*, i8** %arg0
   %396 = load i8*, i8** %arg1
   %397 = bitcast i8* %396 to i64*
-  %NullCheck164 = icmp ne i64* %397, null
-  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+  %NullCheck163 = icmp eq i64* %397, null
+  br i1 %NullCheck163, label %ThrowNullRef164, label %398
 
 ; <label>:398                                     ; preds = %394
   %399 = load i64, i64* %397, align 8
   %400 = bitcast i8* %395 to i64*
-  %NullCheck166 = icmp ne i64* %400, null
-  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+  %NullCheck165 = icmp eq i64* %400, null
+  br i1 %NullCheck165, label %ThrowNullRef166, label %401
 
 ; <label>:401                                     ; preds = %398
   store i64 %399, i64* %400, align 8
@@ -1400,14 +1482,14 @@ entry:
   %404 = load i8*, i8** %arg1
   %405 = getelementptr inbounds i8, i8* %404, i64 8
   %406 = bitcast i8* %405 to i64*
-  %NullCheck168 = icmp ne i64* %406, null
-  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+  %NullCheck167 = icmp eq i64* %406, null
+  br i1 %NullCheck167, label %ThrowNullRef168, label %407
 
 ; <label>:407                                     ; preds = %401
   %408 = load i64, i64* %406, align 8
   %409 = bitcast i8* %403 to i64*
-  %NullCheck170 = icmp ne i64* %409, null
-  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+  %NullCheck169 = icmp eq i64* %409, null
+  br i1 %NullCheck169, label %ThrowNullRef170, label %410
 
 ; <label>:410                                     ; preds = %407
   store i64 %408, i64* %409, align 8
@@ -1437,14 +1519,14 @@ entry:
   %425 = load i8*, i8** %arg0
   %426 = load i8*, i8** %arg1
   %427 = bitcast i8* %426 to i64*
-  %NullCheck148 = icmp ne i64* %427, null
-  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+  %NullCheck147 = icmp eq i64* %427, null
+  br i1 %NullCheck147, label %ThrowNullRef148, label %428
 
 ; <label>:428                                     ; preds = %424
   %429 = load i64, i64* %427, align 8
   %430 = bitcast i8* %425 to i64*
-  %NullCheck150 = icmp ne i64* %430, null
-  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+  %NullCheck149 = icmp eq i64* %430, null
+  br i1 %NullCheck149, label %ThrowNullRef150, label %431
 
 ; <label>:431                                     ; preds = %428
   store i64 %429, i64* %430, align 8
@@ -1466,14 +1548,14 @@ entry:
   %441 = load i8*, i8** %arg0
   %442 = load i8*, i8** %arg1
   %443 = bitcast i8* %442 to i32*
-  %NullCheck152 = icmp ne i32* %443, null
-  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+  %NullCheck151 = icmp eq i32* %443, null
+  br i1 %NullCheck151, label %ThrowNullRef152, label %444
 
 ; <label>:444                                     ; preds = %440
   %445 = load i32, i32* %443, align 8
   %446 = bitcast i8* %441 to i32*
-  %NullCheck154 = icmp ne i32* %446, null
-  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+  %NullCheck153 = icmp eq i32* %446, null
+  br i1 %NullCheck153, label %ThrowNullRef154, label %447
 
 ; <label>:447                                     ; preds = %444
   store i32 %445, i32* %446, align 8
@@ -1495,16 +1577,16 @@ entry:
   %457 = load i8*, i8** %arg0
   %458 = load i8*, i8** %arg1
   %459 = bitcast i8* %458 to i16*
-  %NullCheck156 = icmp ne i16* %459, null
-  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+  %NullCheck155 = icmp eq i16* %459, null
+  br i1 %NullCheck155, label %ThrowNullRef156, label %460
 
 ; <label>:460                                     ; preds = %456
   %461 = load i16, i16* %459, align 8
   %462 = sext i16 %461 to i32
   %463 = bitcast i8* %457 to i16*
   %464 = trunc i32 %462 to i16
-  %NullCheck158 = icmp ne i16* %463, null
-  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+  %NullCheck157 = icmp eq i16* %463, null
+  br i1 %NullCheck157, label %ThrowNullRef158, label %465
 
 ; <label>:465                                     ; preds = %460
   store i16 %464, i16* %463, align 8
@@ -1525,15 +1607,15 @@ entry:
 ; <label>:474                                     ; preds = %470
   %475 = load i8*, i8** %arg0
   %476 = load i8*, i8** %arg1
-  %NullCheck160 = icmp ne i8* %476, null
-  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+  %NullCheck159 = icmp eq i8* %476, null
+  br i1 %NullCheck159, label %ThrowNullRef160, label %477
 
 ; <label>:477                                     ; preds = %474
   %478 = load i8, i8* %476, align 8
   %479 = zext i8 %478 to i32
   %480 = trunc i32 %479 to i8
-  %NullCheck162 = icmp ne i8* %475, null
-  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+  %NullCheck161 = icmp eq i8* %475, null
+  br i1 %NullCheck161, label %ThrowNullRef162, label %481
 
 ; <label>:481                                     ; preds = %477
   store i8 %480, i8* %475, align 8
@@ -1553,343 +1635,343 @@ ThrowNullRef:                                     ; preds = %308
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %312
+ThrowNullRef2:                                    ; preds = %312
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %315
+ThrowNullRef4:                                    ; preds = %315
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %321
+ThrowNullRef6:                                    ; preds = %321
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %271
+ThrowNullRef8:                                    ; preds = %271
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %275
+ThrowNullRef10:                                   ; preds = %275
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %278
+ThrowNullRef12:                                   ; preds = %278
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %284
+ThrowNullRef14:                                   ; preds = %284
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %287
+ThrowNullRef16:                                   ; preds = %287
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %293
+ThrowNullRef18:                                   ; preds = %293
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %298
+ThrowNullRef20:                                   ; preds = %298
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %303
+ThrowNullRef22:                                   ; preds = %303
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %243
+ThrowNullRef24:                                   ; preds = %243
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %247
+ThrowNullRef26:                                   ; preds = %247
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %250
+ThrowNullRef28:                                   ; preds = %250
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %256
+ThrowNullRef30:                                   ; preds = %256
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %259
+ThrowNullRef32:                                   ; preds = %259
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %265
+ThrowNullRef34:                                   ; preds = %265
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %217
+ThrowNullRef36:                                   ; preds = %217
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %221
+ThrowNullRef38:                                   ; preds = %221
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %224
+ThrowNullRef40:                                   ; preds = %224
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %230
+ThrowNullRef42:                                   ; preds = %230
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %233
+ThrowNullRef44:                                   ; preds = %233
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %238
+ThrowNullRef46:                                   ; preds = %238
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %200
+ThrowNullRef48:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %204
+ThrowNullRef50:                                   ; preds = %204
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %207
+ThrowNullRef52:                                   ; preds = %207
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %213
+ThrowNullRef54:                                   ; preds = %213
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %172
+ThrowNullRef56:                                   ; preds = %172
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %176
+ThrowNullRef58:                                   ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %179
+ThrowNullRef60:                                   ; preds = %179
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %185
+ThrowNullRef62:                                   ; preds = %185
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %190
+ThrowNullRef64:                                   ; preds = %190
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %195
+ThrowNullRef66:                                   ; preds = %195
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %153
+ThrowNullRef68:                                   ; preds = %153
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %157
+ThrowNullRef70:                                   ; preds = %157
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %160
+ThrowNullRef72:                                   ; preds = %160
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %166
+ThrowNullRef74:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %136
+ThrowNullRef76:                                   ; preds = %136
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %140
+ThrowNullRef78:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %143
+ThrowNullRef80:                                   ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %148
+ThrowNullRef82:                                   ; preds = %148
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %128
+ThrowNullRef84:                                   ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %132
+ThrowNullRef86:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %100
+ThrowNullRef88:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %104
+ThrowNullRef90:                                   ; preds = %104
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %107
+ThrowNullRef92:                                   ; preds = %107
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %113
+ThrowNullRef94:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %118
+ThrowNullRef96:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %123
+ThrowNullRef98:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %81
+ThrowNullRef100:                                  ; preds = %81
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef101:                                  ; preds = %85
+ThrowNullRef102:                                  ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef103:                                  ; preds = %88
+ThrowNullRef104:                                  ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef105:                                  ; preds = %94
+ThrowNullRef106:                                  ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef107:                                  ; preds = %64
+ThrowNullRef108:                                  ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef109:                                  ; preds = %68
+ThrowNullRef110:                                  ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef111:                                  ; preds = %71
+ThrowNullRef112:                                  ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef113:                                  ; preds = %76
+ThrowNullRef114:                                  ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef115:                                  ; preds = %56
+ThrowNullRef116:                                  ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef117:                                  ; preds = %60
+ThrowNullRef118:                                  ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef119:                                  ; preds = %37
+ThrowNullRef120:                                  ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef121:                                  ; preds = %41
+ThrowNullRef122:                                  ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef123:                                  ; preds = %46
+ThrowNullRef124:                                  ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef125:                                  ; preds = %51
+ThrowNullRef126:                                  ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef127:                                  ; preds = %27
+ThrowNullRef128:                                  ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef129:                                  ; preds = %31
+ThrowNullRef130:                                  ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef131:                                  ; preds = %19
+ThrowNullRef132:                                  ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef133:                                  ; preds = %22
+ThrowNullRef134:                                  ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef135:                                  ; preds = %338
+ThrowNullRef136:                                  ; preds = %338
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef137:                                  ; preds = %341
+ThrowNullRef138:                                  ; preds = %341
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef139:                                  ; preds = %356
+ThrowNullRef140:                                  ; preds = %356
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef141:                                  ; preds = %360
+ThrowNullRef142:                                  ; preds = %360
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef143:                                  ; preds = %377
+ThrowNullRef144:                                  ; preds = %377
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef145:                                  ; preds = %381
+ThrowNullRef146:                                  ; preds = %381
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef147:                                  ; preds = %424
+ThrowNullRef148:                                  ; preds = %424
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef149:                                  ; preds = %428
+ThrowNullRef150:                                  ; preds = %428
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef151:                                  ; preds = %440
+ThrowNullRef152:                                  ; preds = %440
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef153:                                  ; preds = %444
+ThrowNullRef154:                                  ; preds = %444
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef155:                                  ; preds = %456
+ThrowNullRef156:                                  ; preds = %456
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef157:                                  ; preds = %460
+ThrowNullRef158:                                  ; preds = %460
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef159:                                  ; preds = %474
+ThrowNullRef160:                                  ; preds = %474
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef161:                                  ; preds = %477
+ThrowNullRef162:                                  ; preds = %477
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef163:                                  ; preds = %394
+ThrowNullRef164:                                  ; preds = %394
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef165:                                  ; preds = %398
+ThrowNullRef166:                                  ; preds = %398
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef167:                                  ; preds = %401
+ThrowNullRef168:                                  ; preds = %401
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef169:                                  ; preds = %407
+ThrowNullRef170:                                  ; preds = %407
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1939,8 +2021,8 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
-  br i1 %NullCheck, label %22, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %ThrowNullRef, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
@@ -1948,8 +2030,8 @@ entry:
   store i32 %24, i32* %loc0
   %25 = load i32, i32* %loc0
   %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %26, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %27
 
 ; <label>:27                                      ; preds = %22
   %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
@@ -1971,7 +2053,7 @@ ThrowNullRef:                                     ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1989,8 +2071,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -2022,15 +2104,15 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2048,16 +2130,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
   %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
   store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %15
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
@@ -2072,8 +2154,8 @@ entry:
   %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
   %29 = ptrtoint i16 addrspace(1)* %28 to i64
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %19
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
@@ -2089,19 +2171,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2114,8 +2196,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
@@ -2128,7 +2210,7 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[loadElem]
+Failed to read AppDomain.PrepareDataForSetup[storeElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
@@ -2202,8 +2284,8 @@ entry:
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
-  br i1 %NullCheck24, label %27, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = load i64, i64 addrspace(1)* %26
@@ -2218,8 +2300,8 @@ entry:
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
-  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
   %41 = load i64, i64 addrspace(1)* %39
@@ -2236,8 +2318,8 @@ entry:
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
-  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
   %54 = load i64, i64 addrspace(1)* %52
@@ -2252,8 +2334,8 @@ entry:
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
   %67 = load i64, i64 addrspace(1)* %65
@@ -2270,8 +2352,8 @@ entry:
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
-  br i1 %NullCheck16, label %79, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
   %80 = load i64, i64 addrspace(1)* %78
@@ -2286,8 +2368,8 @@ entry:
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
-  br i1 %NullCheck18, label %92, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
   %93 = load i64, i64 addrspace(1)* %91
@@ -2304,8 +2386,8 @@ entry:
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
-  br i1 %NullCheck12, label %105, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = load i64, i64 addrspace(1)* %104
@@ -2320,8 +2402,8 @@ entry:
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
-  br i1 %NullCheck14, label %118, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
   %119 = load i64, i64 addrspace(1)* %117
@@ -2337,8 +2419,8 @@ entry:
 
 ; <label>:128                                     ; preds = %20
   %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
-  br i1 %NullCheck4, label %130, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %129, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %130
 
 ; <label>:130                                     ; preds = %128
   %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
@@ -2346,8 +2428,8 @@ entry:
   %133 = load i16, i16 addrspace(1)* %132, align 8
   %134 = zext i16 %133 to i32
   %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
-  br i1 %NullCheck6, label %136, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %135, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %136
 
 ; <label>:136                                     ; preds = %130
   %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
@@ -2360,8 +2442,8 @@ entry:
 
 ; <label>:143                                     ; preds = %136
   %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
-  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %144, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %145
 
 ; <label>:145                                     ; preds = %143
   %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
@@ -2369,8 +2451,8 @@ entry:
   %148 = load i16, i16 addrspace(1)* %147, align 8
   %149 = zext i16 %148 to i32
   %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %150, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %151
 
 ; <label>:151                                     ; preds = %145
   %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
@@ -2388,8 +2470,8 @@ entry:
 
 ; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
-  br i1 %NullCheck, label %163, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %ThrowNullRef, label %163
 
 ; <label>:163                                     ; preds = %161
   %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
@@ -2399,8 +2481,8 @@ entry:
 
 ; <label>:167                                     ; preds = %163
   %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
-  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %168, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %169
 
 ; <label>:169                                     ; preds = %167
   %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
@@ -2432,55 +2514,55 @@ ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %167
+ThrowNullRef2:                                    ; preds = %167
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %128
+ThrowNullRef4:                                    ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %130
+ThrowNullRef6:                                    ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %143
+ThrowNullRef8:                                    ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %145
+ThrowNullRef10:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %102
+ThrowNullRef12:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %105
+ThrowNullRef14:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %76
+ThrowNullRef16:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %79
+ThrowNullRef18:                                   ; preds = %79
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %50
+ThrowNullRef20:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %53
+ThrowNullRef22:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %24
+ThrowNullRef24:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %27
+ThrowNullRef26:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2503,15 +2585,15 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2519,16 +2601,16 @@ entry:
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
   store i32 %8, i32* %loc0
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
   %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
   store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
@@ -2546,16 +2628,16 @@ entry:
 
 ; <label>:23                                      ; preds = %64
   %24 = load i16*, i16** %loc3
-  %NullCheck12 = icmp ne i16* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i16* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
   store i32 %27, i32* %loc5
   %28 = load i16*, i16** %loc4
-  %NullCheck14 = icmp ne i16* %28, null
-  br i1 %NullCheck14, label %29, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %28, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = load i16, i16* %28, align 8
@@ -2620,15 +2702,15 @@ entry:
 
 ; <label>:67                                      ; preds = %64
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
-  br i1 %NullCheck8, label %69, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %68, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %69
 
 ; <label>:69                                      ; preds = %67
   %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
   %71 = load i32, i32 addrspace(1)* %70
   %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
-  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %73
 
 ; <label>:73                                      ; preds = %69
   %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
@@ -2645,31 +2727,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %67
+ThrowNullRef8:                                    ; preds = %67
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %69
+ThrowNullRef10:                                   ; preds = %69
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2710,14 +2792,14 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
   %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
@@ -2730,14 +2812,14 @@ entry:
 
 ; <label>:11                                      ; preds = %4
   %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
   %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
@@ -2749,14 +2831,14 @@ entry:
 
 ; <label>:22                                      ; preds = %16
   %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
   %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
-  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
-  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
@@ -2804,23 +2886,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2836,7 +2918,280 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[loadElem]
+Successfully read RuntimeType.IsAssignableFrom
+
+define i8 @RuntimeType.IsAssignableFrom(%System.RuntimeType addrspace(1)* %param0, %System.Type addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.RuntimeType addrspace(1)*
+  %arg1 = alloca %System.Type addrspace(1)*
+  %loc0 = alloca %System.RuntimeType addrspace(1)*
+  %loc1 = alloca %"System.Type[]" addrspace(1)*
+  %loc2 = alloca i32
+  store %System.RuntimeType addrspace(1)* %param0, %System.RuntimeType addrspace(1)** %this
+  store %System.Type addrspace(1)* %param1, %System.Type addrspace(1)** %arg1
+  %0 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %1 = icmp ne %System.Type addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i8 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %5 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %6 = bitcast %System.Type addrspace(1)* %4 to %System.Object addrspace(1)*
+  %7 = bitcast %System.RuntimeType addrspace(1)* %5 to %System.Object addrspace(1)*
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %6, %System.Object addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %3
+  ret i8 1
+
+; <label>:12                                      ; preds = %3
+  %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 152
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 32
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
+  %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
+  %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
+  store %System.RuntimeType addrspace(1)* %25, %System.RuntimeType addrspace(1)** %loc0
+  %26 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %27 = icmp eq %System.RuntimeType addrspace(1)* %26, null
+  br i1 %27, label %34, label %28
+
+; <label>:28                                      ; preds = %15
+  %29 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %30 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)*)*)(%System.RuntimeType addrspace(1)* %29, %System.RuntimeType addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+; <label>:34                                      ; preds = %15
+  %35 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %36 = call %System.Reflection.Emit.TypeBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Reflection.Emit.TypeBuilder addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %35)
+  %37 = icmp eq %System.Reflection.Emit.TypeBuilder addrspace(1)* %36, null
+  br i1 %37, label %139, label %38
+
+; <label>:38                                      ; preds = %34
+  %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %42
+
+; <label>:42                                      ; preds = %38
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 152
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 40
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
+  %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
+  %53 = zext i8 %52 to i32
+  %54 = icmp eq i32 %53, 0
+  br i1 %54, label %56, label %55
+
+; <label>:55                                      ; preds = %42
+  ret i8 1
+
+; <label>:56                                      ; preds = %42
+  %57 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %58 = bitcast %System.RuntimeType addrspace(1)* %57 to %System.Type addrspace(1)*
+  %59 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %58)
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %64 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.Type addrspace(1)* %63, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = bitcast %System.RuntimeType addrspace(1)* %64 to %System.Type addrspace(1)*
+  %67 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %63, %System.Type addrspace(1)* %66)
+  %68 = zext i8 %67 to i32
+  %69 = trunc i32 %68 to i8
+  ret i8 %69
+
+; <label>:70                                      ; preds = %56
+  %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
+  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %73
+
+; <label>:73                                      ; preds = %70
+  %74 = load i64, i64 addrspace(1)* %72
+  %75 = add i64 %74, 128
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = add i64 %77, 0
+  %79 = inttoptr i64 %78 to i64*
+  %80 = load i64, i64* %79
+  %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
+  %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
+  %83 = call i8 %82(%System.Type addrspace(1)* %81)
+  %84 = zext i8 %83 to i32
+  %85 = icmp eq i32 %84, 0
+  br i1 %85, label %139, label %86
+
+; <label>:86                                      ; preds = %73
+  %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
+  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %89
+
+; <label>:89                                      ; preds = %86
+  %90 = load i64, i64 addrspace(1)* %88
+  %91 = add i64 %90, 128
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = add i64 %93, 24
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
+  %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
+  %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
+  store %"System.Type[]" addrspace(1)* %99, %"System.Type[]" addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %129
+
+; <label>:100                                     ; preds = %132
+  %101 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %102 = load i32, i32* %loc2
+  %NullCheck11 = icmp eq %"System.Type[]" addrspace(1)* %101, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %103
+
+; <label>:103                                     ; preds = %100
+  %104 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 1
+  %105 = load i32, i32 addrspace(1)* %104
+  %106 = zext i32 %105 to i64
+  %107 = zext i32 %102 to i64
+  %BoundsCheck = icmp uge i64 %107, %106
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %108
+
+; <label>:108                                     ; preds = %103
+  %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
+  %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
+  %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
+  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %113
+
+; <label>:113                                     ; preds = %108
+  %114 = load i64, i64 addrspace(1)* %112
+  %115 = add i64 %114, 152
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = add i64 %117, 56
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
+  %123 = zext i8 %122 to i32
+  %124 = icmp ne i32 %123, 0
+  br i1 %124, label %126, label %125
+
+; <label>:125                                     ; preds = %113
+  ret i8 0
+
+; <label>:126                                     ; preds = %113
+  %127 = load i32, i32* %loc2
+  %128 = add i32 %127, 1
+  store i32 %128, i32* %loc2
+  br label %129
+
+; <label>:129                                     ; preds = %89, %126
+  %130 = load i32, i32* %loc2
+  %131 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %NullCheck9 = icmp eq %"System.Type[]" addrspace(1)* %131, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %132
+
+; <label>:132                                     ; preds = %129
+  %133 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %131, i32 0, i32 1
+  %134 = load i32, i32 addrspace(1)* %133
+  %135 = zext i32 %134 to i64
+  %136 = trunc i64 %135 to i32
+  %137 = icmp slt i32 %130, %136
+  br i1 %137, label %100, label %138
+
+; <label>:138                                     ; preds = %132
+  ret i8 1
+
+; <label>:139                                     ; preds = %34, %73
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %129
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %103
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -2893,7 +3248,7 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElem]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -2904,8 +3259,8 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -2997,8 +3352,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
@@ -3059,8 +3414,8 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -3087,8 +3442,8 @@ entry:
 
 ; <label>:17                                      ; preds = %5, %11
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
@@ -3097,8 +3452,8 @@ entry:
 
 ; <label>:22                                      ; preds = %1, %11
   %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
@@ -3109,11 +3464,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %17
+ThrowNullRef2:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %22
+ThrowNullRef4:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3167,15 +3522,15 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
   %15 = load i32, i32 addrspace(1)* %14
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
@@ -3198,7 +3553,7 @@ ThrowNullRef:                                     ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef2:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3232,8 +3587,8 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
@@ -3312,8 +3667,8 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -3327,8 +3682,8 @@ entry:
 ; <label>:5                                       ; preds = %43
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %7 = load i32, i32* %loc1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck6, label %8, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
@@ -3366,8 +3721,8 @@ entry:
 ; <label>:32                                      ; preds = %21, %25
   %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
   %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
-  br i1 %NullCheck8, label %35, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = trunc i32 %34 to i16
@@ -3380,8 +3735,8 @@ entry:
 ; <label>:40                                      ; preds = %1, %35
   %41 = load i32, i32* %loc1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
-  br i1 %NullCheck2, label %43, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %42, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
@@ -3392,8 +3747,8 @@ entry:
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
   %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
-  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
   %51 = load i64, i64 addrspace(1)* %49
@@ -3412,19 +3767,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %40
+ThrowNullRef2:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %47
+ThrowNullRef4:                                    ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %5
+ThrowNullRef6:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %32
+ThrowNullRef8:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3467,8 +3822,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
@@ -3492,11 +3847,391 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(i16* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store i16* %param0, i16** %arg0
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load i32, i32* %arg3
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %42, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %37, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg2
+  %13 = load i32, i32* %arg3
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %37, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %24 = load i32, i32* %arg2
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load i16*, i16** %arg0
+  %35 = load i32, i32* %arg3
+  %36 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %36, i16* %34, i32 %35)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:37                                      ; preds = %5, %16
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %39)
+  %41 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41, %System.String addrspace(1)* %38, %System.String addrspace(1)* %40)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41) #0
+  unreachable
+
+; <label>:42                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
-Failed to read StringBuilder.ToString[loadElemA]
+Successfully read StringBuilder.ToString
+
+define %System.String addrspace(1)* @StringBuilder.ToString(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i16*
+  %loc3 = alloca %"System.Char[]" addrspace(1)*
+  %loc4 = alloca i32
+  %loc5 = alloca i32
+  %loc6 = alloca i16 addrspace(1)*
+  %loc7 = alloca %System.String addrspace(1)*
+  %loc8 = alloca %"System.Char[]" addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %0)
+  %2 = icmp ne i32 %1, 0
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %4
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %6)
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %7)
+  store %System.String addrspace(1)* %8, %System.String addrspace(1)** %loc0
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.Text.StringBuilder addrspace(1)* %9, %System.Text.StringBuilder addrspace(1)** %loc1
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  store %System.String addrspace(1)* %10, %System.String addrspace(1)** %loc7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc7
+  %12 = ptrtoint %System.String addrspace(1)* %11 to i64
+  %13 = icmp eq i64 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %5
+  %15 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %16 = sext i32 %15 to i64
+  %17 = add i64 %12, %16
+  br label %18
+
+; <label>:18                                      ; preds = %5, %14
+  %19 = phi i64 [ %12, %5 ], [ %17, %14 ]
+  %20 = inttoptr i64 %19 to i16*
+  store i16* %20, i16** %loc2
+  br label %21
+
+; <label>:21                                      ; preds = %98, %18
+  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %22, null
+  br i1 %NullCheck, label %ThrowNullRef, label %23
+
+; <label>:23                                      ; preds = %21
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 3
+  %25 = load i32, i32 addrspace(1)* %24, align 8
+  %26 = icmp sle i32 %25, 0
+  br i1 %26, label %96, label %27
+
+; <label>:27                                      ; preds = %23
+  %28 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %28, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %29
+
+; <label>:29                                      ; preds = %27
+  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %28, i32 0, i32 1
+  %31 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %30, align 8
+  store %"System.Char[]" addrspace(1)* %31, %"System.Char[]" addrspace(1)** %loc3
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %33
+
+; <label>:33                                      ; preds = %29
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  store i32 %35, i32* %loc4
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  %39 = load i32, i32 addrspace(1)* %38, align 8
+  store i32 %39, i32* %loc5
+  %40 = load i32, i32* %loc5
+  %41 = load i32, i32* %loc4
+  %42 = add i32 %40, %41
+  %43 = zext i32 %42 to i64
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %45
+
+; <label>:45                                      ; preds = %37
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = sext i32 %47 to i64
+  %49 = icmp sgt i64 %43, %48
+  br i1 %49, label %91, label %50
+
+; <label>:50                                      ; preds = %45
+  %51 = load i32, i32* %loc5
+  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %52, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %53
+
+; <label>:53                                      ; preds = %50
+  %54 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %52, i32 0, i32 1
+  %55 = load i32, i32 addrspace(1)* %54
+  %56 = zext i32 %55 to i64
+  %57 = trunc i64 %56 to i32
+  %58 = icmp ugt i32 %51, %57
+  br i1 %58, label %91, label %59
+
+; <label>:59                                      ; preds = %53
+  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  store %"System.Char[]" addrspace(1)* %60, %"System.Char[]" addrspace(1)** %loc8
+  %61 = icmp eq %"System.Char[]" addrspace(1)* %60, null
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %63, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %64
+
+; <label>:64                                      ; preds = %62
+  %65 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %63, i32 0, i32 1
+  %66 = load i32, i32 addrspace(1)* %65
+  %67 = zext i32 %66 to i64
+  %68 = trunc i64 %67 to i32
+  %69 = icmp ne i32 %68, 0
+  br i1 %69, label %71, label %70
+
+; <label>:70                                      ; preds = %59, %64
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:71                                      ; preds = %64
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %73
+
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %BoundsCheck = icmp uge i64 0, %76
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %77
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %78, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:79                                      ; preds = %70, %77
+  %80 = load i16*, i16** %loc2
+  %81 = load i32, i32* %loc4
+  %82 = sext i32 %81 to i64
+  %83 = mul i64 %82, 2
+  %84 = bitcast i16* %80 to i8*
+  %85 = getelementptr inbounds i8, i8* %84, i64 %83
+  %86 = load i16 addrspace(1)*, i16 addrspace(1)** %loc6
+  %87 = ptrtoint i16 addrspace(1)* %86 to i64
+  %88 = load i32, i32* %loc5
+  %89 = bitcast i8* %85 to i16*
+  %90 = inttoptr i64 %87 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %89, i16* %90, i32 %88)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %96
+
+; <label>:91                                      ; preds = %45, %53
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %94 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %93)
+  %95 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95, %System.String addrspace(1)* %92, %System.String addrspace(1)* %94)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95) #0
+  unreachable
+
+; <label>:96                                      ; preds = %23, %79
+  %97 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %97, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %98
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %97, i32 0, i32 2
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  store %System.Text.StringBuilder addrspace(1)* %100, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %102 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %102, label %21, label %103
+
+; <label>:103                                     ; preds = %98
+  store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc7
+  %104 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  ret %System.String addrspace(1)* %104
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method StringBuilder::get_Length using LLILCJit
+Successfully read StringBuilder.get_Length
+
+define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
+Successfully read RuntimeHelpers.get_OffsetToStringData
+
+define i32 @RuntimeHelpers.get_OffsetToStringData() {
+entry:
+  ret i32 12
+}
+
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
 Successfully read CultureData.CreateCultureData
 
@@ -3514,23 +4249,23 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
   store i8 %4, i8 addrspace(1)* %6
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
@@ -3549,11 +4284,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3566,50 +4301,50 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
   store i32 -1, i32 addrspace(1)* %2
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
   store i32 -1, i32 addrspace(1)* %8
   %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
   store i32 -1, i32 addrspace(1)* %14
   %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
   store i32 -1, i32 addrspace(1)* %17
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
@@ -3623,27 +4358,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3675,7 +4410,136 @@ Failed to read Dictionary`2.Insert[non-const derefAddress]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
 Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
-Failed to read HashHelpers.GetPrime[loadElem]
+Successfully read HashHelpers.GetPrime
+
+define i32 @HashHelpers.GetPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %6, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5, %System.String addrspace(1)* %4)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5) #0
+  unreachable
+
+; <label>:6                                       ; preds = %entry
+  store i32 0, i32* %loc0
+  br label %29
+
+; <label>:7                                       ; preds = %35
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 1296
+  %10 = addrspacecast i8 addrspace(1)* %9 to %"System.Int32[]" addrspace(1)**
+  %11 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %10
+  %12 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Int32[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = zext i32 %15 to i64
+  %17 = zext i32 %12 to i64
+  %BoundsCheck = icmp uge i64 %17, %16
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 3, i32 %12
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  store i32 %20, i32* %loc1
+  %21 = load i32, i32* %loc1
+  %22 = load i32, i32* %arg0
+  %23 = icmp slt i32 %21, %22
+  br i1 %23, label %26, label %24
+
+; <label>:24                                      ; preds = %18
+  %25 = load i32, i32* %loc1
+  ret i32 %25
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %loc0
+  %28 = add i32 %27, 1
+  store i32 %28, i32* %loc0
+  br label %29
+
+; <label>:29                                      ; preds = %6, %26
+  %30 = load i32, i32* %loc0
+  %31 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %32 = getelementptr inbounds i8, i8 addrspace(1)* %31, i64 1296
+  %33 = addrspacecast i8 addrspace(1)* %32 to %"System.Int32[]" addrspace(1)**
+  %34 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %33
+  %NullCheck = icmp eq %"System.Int32[]" addrspace(1)* %34, null
+  br i1 %NullCheck, label %ThrowNullRef, label %35
+
+; <label>:35                                      ; preds = %29
+  %36 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %34, i32 0, i32 1
+  %37 = load i32, i32 addrspace(1)* %36
+  %38 = zext i32 %37 to i64
+  %39 = trunc i64 %38 to i32
+  %40 = icmp slt i32 %30, %39
+  br i1 %40, label %7, label %41
+
+; <label>:41                                      ; preds = %35
+  %42 = load i32, i32* %arg0
+  %43 = or i32 %42, 1
+  store i32 %43, i32* %loc2
+  br label %59
+
+; <label>:44                                      ; preds = %59
+  %45 = load i32, i32* %loc2
+  %46 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %45)
+  %47 = zext i8 %46 to i32
+  %48 = icmp eq i32 %47, 0
+  br i1 %48, label %56, label %49
+
+; <label>:49                                      ; preds = %44
+  %50 = load i32, i32* %loc2
+  %51 = sub i32 %50, 1
+  %52 = srem i32 %51, 101
+  %53 = icmp eq i32 %52, 0
+  br i1 %53, label %56, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = load i32, i32* %loc2
+  ret i32 %55
+
+; <label>:56                                      ; preds = %44, %49
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %57, 2
+  store i32 %58, i32* %loc2
+  br label %59
+
+; <label>:59                                      ; preds = %41, %56
+  %60 = load i32, i32* %loc2
+  %61 = icmp slt i32 %60, 2147483647
+  br i1 %61, label %44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load i32, i32* %arg0
+  ret i32 %63
+
+ThrowNullRef:                                     ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
 Successfully read GenericEqualityComparer`1.GetHashCode
 
@@ -3694,14 +4558,14 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
   %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load i64, i64 addrspace(1)* %7
@@ -3720,7 +4584,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3750,8 +4614,8 @@ entry:
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
@@ -3796,8 +4660,8 @@ entry:
   %35 = bitcast i16* %34 to i8*
   %36 = getelementptr inbounds i8, i8* %35, i64 2
   %37 = bitcast i8* %36 to i16*
-  %NullCheck4 = icmp ne i16* %37, null
-  br i1 %NullCheck4, label %38, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %37, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %38
 
 ; <label>:38                                      ; preds = %27
   %39 = load i16, i16* %37, align 8
@@ -3824,8 +4688,8 @@ entry:
 
 ; <label>:54                                      ; preds = %22, %43
   %55 = load i16*, i16** %loc4
-  %NullCheck2 = icmp ne i16* %55, null
-  br i1 %NullCheck2, label %56, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i16* %55, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %56
 
 ; <label>:56                                      ; preds = %54
   %57 = load i16, i16* %55, align 8
@@ -3850,11 +4714,11 @@ ThrowNullRef:                                     ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %54
+ThrowNullRef2:                                    ; preds = %54
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %27
+ThrowNullRef4:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3871,8 +4735,8 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -3907,8 +4771,8 @@ entry:
 
 ; <label>:26                                      ; preds = %19
   %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
-  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %28
 
 ; <label>:28                                      ; preds = %26
   %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
@@ -3920,7 +4784,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3972,8 +4836,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
@@ -3984,26 +4848,26 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
-  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
@@ -4014,8 +4878,8 @@ entry:
 ; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
@@ -4024,8 +4888,8 @@ entry:
 
 ; <label>:25                                      ; preds = %1, %16, %23
   %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
-  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
@@ -4036,27 +4900,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %20
+ThrowNullRef10:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4069,8 +4933,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -4081,8 +4945,8 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
@@ -4091,8 +4955,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1, %8
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
@@ -4103,11 +4967,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4128,24 +4992,24 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   store i32 %3, i32* %loc0
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
   %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
   store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck4, label %9, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
@@ -4164,15 +5028,15 @@ entry:
 ; <label>:18                                      ; preds = %70
   %19 = load i16*, i16** %loc3
   %20 = bitcast i16* %19 to i64*
-  %NullCheck10 = icmp ne i64* %20, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %20, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = load i64, i64* %20, align 8
   %23 = load i16*, i16** %loc4
   %24 = bitcast i16* %23 to i64*
-  %NullCheck12 = icmp ne i64* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = load i64, i64* %24, align 8
@@ -4188,8 +5052,8 @@ entry:
   %31 = bitcast i16* %30 to i8*
   %32 = getelementptr inbounds i8, i8* %31, i64 8
   %33 = bitcast i8* %32 to i64*
-  %NullCheck14 = icmp ne i64* %33, null
-  br i1 %NullCheck14, label %34, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = load i64, i64* %33, align 8
@@ -4197,8 +5061,8 @@ entry:
   %37 = bitcast i16* %36 to i8*
   %38 = getelementptr inbounds i8, i8* %37, i64 8
   %39 = bitcast i8* %38 to i64*
-  %NullCheck16 = icmp ne i64* %39, null
-  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %40
 
 ; <label>:40                                      ; preds = %34
   %41 = load i64, i64* %39, align 8
@@ -4214,8 +5078,8 @@ entry:
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %NullCheck18 = icmp ne i64* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = load i64, i64* %48, align 8
@@ -4223,8 +5087,8 @@ entry:
   %52 = bitcast i16* %51 to i8*
   %53 = getelementptr inbounds i8, i8* %52, i64 16
   %54 = bitcast i8* %53 to i64*
-  %NullCheck20 = icmp ne i64* %54, null
-  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64* %54, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %55
 
 ; <label>:55                                      ; preds = %49
   %56 = load i64, i64* %54, align 8
@@ -4262,15 +5126,15 @@ entry:
 ; <label>:74                                      ; preds = %95
   %75 = load i16*, i16** %loc3
   %76 = bitcast i16* %75 to i32*
-  %NullCheck6 = icmp ne i32* %76, null
-  br i1 %NullCheck6, label %77, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32* %76, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %77
 
 ; <label>:77                                      ; preds = %74
   %78 = load i32, i32* %76, align 8
   %79 = load i16*, i16** %loc4
   %80 = bitcast i16* %79 to i32*
-  %NullCheck8 = icmp ne i32* %80, null
-  br i1 %NullCheck8, label %81, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i32* %80, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %81
 
 ; <label>:81                                      ; preds = %77
   %82 = load i32, i32* %80, align 8
@@ -4318,43 +5182,43 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %74
+ThrowNullRef6:                                    ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %77
+ThrowNullRef8:                                    ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %29
+ThrowNullRef14:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %34
+ThrowNullRef16:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4376,8 +5240,8 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load i64, i64 addrspace(1)* %4
@@ -4389,8 +5253,8 @@ entry:
   %12 = load i64, i64* %11
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %5
   %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
@@ -4399,8 +5263,8 @@ entry:
   %18 = load i8, i8* %arg2
   %19 = zext i8 %18 to i32
   %20 = trunc i32 %19 to i8
-  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %15
   %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
@@ -4411,11 +5275,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4442,8 +5306,8 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
@@ -4466,16 +5330,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
   %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = load i64, i64 addrspace(1)* %19
@@ -4500,8 +5364,8 @@ entry:
 ; <label>:35                                      ; preds = %30
   %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
@@ -4514,8 +5378,8 @@ entry:
 
 ; <label>:42                                      ; preds = %1, %38
   %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
-  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
@@ -4526,19 +5390,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %35
+ThrowNullRef2:                                    ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %42
+ThrowNullRef8:                                    ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4551,14 +5415,14 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
@@ -4570,7 +5434,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4583,8 +5447,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
@@ -4613,51 +5477,51 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
   %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
   %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
   %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
   %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
-  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
   store i64 %21, i64 addrspace(1)* %23
   %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %25 = load i64, i64* %loc0
-  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
@@ -4668,27 +5532,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %22
+ThrowNullRef12:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4701,8 +5565,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
@@ -4713,19 +5577,19 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
@@ -4734,8 +5598,8 @@ entry:
 
 ; <label>:15                                      ; preds = %1, %13
   %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
@@ -4746,19 +5610,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %15
+ThrowNullRef8:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4771,8 +5635,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -4831,8 +5695,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
@@ -4882,8 +5746,8 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
-  br i1 %NullCheck, label %17, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %ThrowNullRef, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
@@ -4894,15 +5758,15 @@ entry:
 
 ; <label>:22                                      ; preds = %17
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
-  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
   %26 = load i32, i32 addrspace(1)* %25
   %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
-  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %27, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
@@ -4925,8 +5789,8 @@ entry:
 ; <label>:40                                      ; preds = %17
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
-  br i1 %NullCheck6, label %43, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %41, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
@@ -4938,34 +5802,17 @@ ThrowNullRef:                                     ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %24
+ThrowNullRef4:                                    ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %40
+ThrowNullRef6:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
-}
-
-INFO:  jitting method Object::ReferenceEquals using LLILCJit
-Successfully read Object.ReferenceEquals
-
-define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
-entry:
-  %arg0 = alloca %System.Object addrspace(1)*
-  %arg1 = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
-  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
-  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = icmp eq %System.Object addrspace(1)* %0, %1
-  %3 = sext i1 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
 }
 
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
@@ -4978,21 +5825,21 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
   %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
-  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
@@ -5007,28 +5854,28 @@ entry:
 ; <label>:13                                      ; preds = %8, %12
   %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
   %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
   %21 = load i32, i32 addrspace(1)* %20, align 8
   %22 = add i32 %21, 1
-  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
   store i32 %22, i32 addrspace(1)* %24
   %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
@@ -5039,27 +5886,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5077,7 +5924,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::Setup using LLILCJit
-Failed to read AppDomain.Setup[loadElem]
+Failed to read AppDomain.Setup[unbox]
 INFO:  jitting method Thread::GetDomain using LLILCJit
 Successfully read Thread.GetDomain
 
@@ -5108,8 +5955,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
@@ -5122,14 +5969,14 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
   %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
@@ -5141,11 +5988,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5173,8 +6020,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -5189,7 +6036,328 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
 Failed to read KeyCollection.System.Collections.Generic.IEnumerable<TKey>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Successfully read Enumerator.MoveNext
+
+define i8 @Enumerator.MoveNext(%"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.RuntimeTypeHandle* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*
+  %"$TypeArg" = alloca %System.RuntimeTypeHandle*
+  store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
+  %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 8
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %76, label %12
+
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
+  br label %76
+
+; <label>:13                                      ; preds = %85
+  %14 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck19 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %15
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, i32 0, i32 0
+  %17 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %16, align 8
+  %NullCheck21 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, i32 0, i32 2
+  %20 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %19, align 8
+  %21 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck23 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %22
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, i32 0, i32 2
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %NullCheck25 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 3, i32 %24
+  %NullCheck27 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %32
+
+; <label>:32                                      ; preds = %30
+  %33 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, i32 0, i32 2
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = icmp slt i32 %34, 0
+  br i1 %35, label %68, label %36
+
+; <label>:36                                      ; preds = %32
+  %37 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %38 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck29 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %39
+
+; <label>:39                                      ; preds = %36
+  %40 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, i32 0, i32 0
+  %41 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %40, align 8
+  %NullCheck31 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, i32 0, i32 2
+  %44 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %43, align 8
+  %45 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck33 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, i32 0, i32 2
+  %48 = load i32, i32 addrspace(1)* %47, align 8
+  %NullCheck35 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %49
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = zext i32 %51 to i64
+  %53 = zext i32 %48 to i64
+  %BoundsCheck37 = icmp uge i64 %53, %52
+  br i1 %BoundsCheck37, label %ThrowIndexOutOfRange38, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 3, i32 %48
+  %NullCheck39 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %56
+
+; <label>:56                                      ; preds = %54
+  %57 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, i32 0, i32 0
+  %58 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck41 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %59
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %60, %System.__Canon addrspace(1)* %58)
+  %61 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck43 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  %64 = load i32, i32 addrspace(1)* %63, align 8
+  %65 = add i32 %64, 1
+  %NullCheck45 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  store i32 %65, i32 addrspace(1)* %67
+  ret i8 1
+
+; <label>:68                                      ; preds = %32
+  %69 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck47 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %73 = add i32 %72, 1
+  %NullCheck49 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %74
+
+; <label>:74                                      ; preds = %70
+  %75 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  store i32 %73, i32 addrspace(1)* %75
+  br label %76
+
+; <label>:76                                      ; preds = %8, %12, %74
+  %77 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %78
+
+; <label>:78                                      ; preds = %76
+  %79 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, i32 0, i32 2
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck7 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %82
+
+; <label>:82                                      ; preds = %78
+  %83 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, i32 0, i32 0
+  %84 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %83, align 8
+  %NullCheck9 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %85
+
+; <label>:85                                      ; preds = %82
+  %86 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, i32 0, i32 7
+  %87 = load i32, i32 addrspace(1)* %86, align 8
+  %88 = icmp ult i32 %80, %87
+  br i1 %88, label %13, label %89
+
+; <label>:89                                      ; preds = %85
+  %90 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %91 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck11 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %92
+
+; <label>:92                                      ; preds = %89
+  %93 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, i32 0, i32 0
+  %94 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck13 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %95
+
+; <label>:95                                      ; preds = %92
+  %96 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, i32 0, i32 7
+  %97 = load i32, i32 addrspace(1)* %96, align 8
+  %98 = add i32 %97, 1
+  %NullCheck15 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %99
+
+; <label>:99                                      ; preds = %95
+  %100 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, i32 0, i32 2
+  store i32 %98, i32 addrspace(1)* %100
+  %101 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck17 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %102
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %103, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %92
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef22:                                   ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef24:                                   ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef26:                                   ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef28:                                   ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef30:                                   ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef32:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef34:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef36:                                   ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange38:                           ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef40:                                   ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef42:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef44:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef46:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef48:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef50:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -5200,8 +6368,8 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -5232,9 +6400,9 @@ Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
 Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
-Failed to read String.MakeSeparatorList[loadElemA]
+Failed to read String.MakeSeparatorList[storeElem]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
-Failed to read String.InternalSplitKeepEmptyEntries[loadElem]
+Failed to read String.InternalSplitKeepEmptyEntries[storeElem]
 INFO:  jitting method Path::IsRelative using LLILCJit
 Successfully read Path.IsRelative
 
@@ -5243,8 +6411,8 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -5254,8 +6422,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
@@ -5271,8 +6439,8 @@ entry:
 
 ; <label>:17                                      ; preds = %7
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
@@ -5288,8 +6456,8 @@ entry:
 
 ; <label>:29                                      ; preds = %19
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %31
 
 ; <label>:31                                      ; preds = %29
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
@@ -5300,8 +6468,8 @@ entry:
 
 ; <label>:36                                      ; preds = %31
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
-  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %37, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
@@ -5312,8 +6480,8 @@ entry:
 
 ; <label>:43                                      ; preds = %31, %38
   %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
-  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %45
 
 ; <label>:45                                      ; preds = %43
   %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
@@ -5324,8 +6492,8 @@ entry:
 
 ; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %50
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
@@ -5336,8 +6504,8 @@ entry:
 
 ; <label>:57                                      ; preds = %1, %7, %19, %45, %52
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
-  br i1 %NullCheck14, label %59, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %59
 
 ; <label>:59                                      ; preds = %57
   %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
@@ -5347,8 +6515,8 @@ entry:
 
 ; <label>:63                                      ; preds = %59
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
@@ -5359,8 +6527,8 @@ entry:
 
 ; <label>:70                                      ; preds = %65
   %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
-  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.String addrspace(1)* %71, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %72
 
 ; <label>:72                                      ; preds = %70
   %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
@@ -5379,39 +6547,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %17
+ThrowNullRef4:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %29
+ThrowNullRef6:                                    ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %36
+ThrowNullRef8:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %43
+ThrowNullRef10:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %50
+ThrowNullRef12:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %57
+ThrowNullRef14:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %63
+ThrowNullRef16:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %70
+ThrowNullRef18:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5419,7 +6587,293 @@ ThrowNullRef17:                                   ; preds = %70
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
-Failed to read String.TrimHelper[loadElem]
+Successfully read String.TrimHelper
+
+define %System.String addrspace(1)* @String.TrimHelper(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i16
+  %loc4 = alloca i32
+  %loc5 = alloca i16
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = sub i32 %3, 1
+  store i32 %4, i32* %loc0
+  store i32 0, i32* %loc1
+  %5 = load i32, i32* %arg2
+  %6 = icmp eq i32 %5, 1
+  br i1 %6, label %62, label %7
+
+; <label>:7                                       ; preds = %1
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:8                                       ; preds = %58
+  store i32 0, i32* %loc2
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load i32, i32* %loc1
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2, i32 %10
+  %13 = load i16, i16 addrspace(1)* %12
+  %14 = zext i16 %13 to i32
+  %15 = trunc i32 %14 to i16
+  store i16 %15, i16* %loc3
+  store i32 0, i32* %loc2
+  br label %34
+
+; <label>:16                                      ; preds = %37
+  %17 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %18 = load i32, i32* %loc2
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %17, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %19
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = zext i32 %18 to i64
+  %BoundsCheck = icmp uge i64 %23, %22
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %24
+
+; <label>:24                                      ; preds = %19
+  %25 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 3, i32 %18
+  %26 = load i16, i16 addrspace(1)* %25, align 8
+  %27 = zext i16 %26 to i32
+  %28 = load i16, i16* %loc3
+  %29 = zext i16 %28 to i32
+  %30 = icmp eq i32 %27, %29
+  br i1 %30, label %43, label %31
+
+; <label>:31                                      ; preds = %24
+  %32 = load i32, i32* %loc2
+  %33 = add i32 %32, 1
+  store i32 %33, i32* %loc2
+  br label %34
+
+; <label>:34                                      ; preds = %11, %31
+  %35 = load i32, i32* %loc2
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = icmp slt i32 %35, %41
+  br i1 %42, label %16, label %43
+
+; <label>:43                                      ; preds = %24, %37
+  %44 = load i32, i32* %loc2
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %45, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp eq i32 %44, %50
+  br i1 %51, label %62, label %52
+
+; <label>:52                                      ; preds = %46
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %7, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %57, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %58
+
+; <label>:58                                      ; preds = %55
+  %59 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %60 = load i32, i32 addrspace(1)* %59
+  %61 = icmp slt i32 %56, %60
+  br i1 %61, label %8, label %62
+
+; <label>:62                                      ; preds = %1, %46, %58
+  %63 = load i32, i32* %arg2
+  %64 = icmp eq i32 %63, 0
+  br i1 %64, label %122, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %66, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %67
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %66, i32 0, i32 1
+  %69 = load i32, i32 addrspace(1)* %68
+  %70 = sub i32 %69, 1
+  store i32 %70, i32* %loc0
+  br label %118
+
+; <label>:71                                      ; preds = %118
+  store i32 0, i32* %loc4
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %73 = load i32, i32* %loc0
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %74
+
+; <label>:74                                      ; preds = %71
+  %75 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 2, i32 %73
+  %76 = load i16, i16 addrspace(1)* %75
+  %77 = zext i16 %76 to i32
+  %78 = trunc i32 %77 to i16
+  store i16 %78, i16* %loc5
+  store i32 0, i32* %loc4
+  br label %97
+
+; <label>:79                                      ; preds = %100
+  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %81 = load i32, i32* %loc4
+  %NullCheck19 = icmp eq %"System.Char[]" addrspace(1)* %80, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
+
+; <label>:82                                      ; preds = %79
+  %83 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 1
+  %84 = load i32, i32 addrspace(1)* %83
+  %85 = zext i32 %84 to i64
+  %86 = zext i32 %81 to i64
+  %BoundsCheck21 = icmp uge i64 %86, %85
+  br i1 %BoundsCheck21, label %ThrowIndexOutOfRange22, label %87
+
+; <label>:87                                      ; preds = %82
+  %88 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 3, i32 %81
+  %89 = load i16, i16 addrspace(1)* %88, align 8
+  %90 = zext i16 %89 to i32
+  %91 = load i16, i16* %loc5
+  %92 = zext i16 %91 to i32
+  %93 = icmp eq i32 %90, %92
+  br i1 %93, label %106, label %94
+
+; <label>:94                                      ; preds = %87
+  %95 = load i32, i32* %loc4
+  %96 = add i32 %95, 1
+  store i32 %96, i32* %loc4
+  br label %97
+
+; <label>:97                                      ; preds = %74, %94
+  %98 = load i32, i32* %loc4
+  %99 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck15 = icmp eq %"System.Char[]" addrspace(1)* %99, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %100
+
+; <label>:100                                     ; preds = %97
+  %101 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %99, i32 0, i32 1
+  %102 = load i32, i32 addrspace(1)* %101
+  %103 = zext i32 %102 to i64
+  %104 = trunc i64 %103 to i32
+  %105 = icmp slt i32 %98, %104
+  br i1 %105, label %79, label %106
+
+; <label>:106                                     ; preds = %87, %100
+  %107 = load i32, i32* %loc4
+  %108 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck17 = icmp eq %"System.Char[]" addrspace(1)* %108, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %109
+
+; <label>:109                                     ; preds = %106
+  %110 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %108, i32 0, i32 1
+  %111 = load i32, i32 addrspace(1)* %110
+  %112 = zext i32 %111 to i64
+  %113 = trunc i64 %112 to i32
+  %114 = icmp eq i32 %107, %113
+  br i1 %114, label %122, label %115
+
+; <label>:115                                     ; preds = %109
+  %116 = load i32, i32* %loc0
+  %117 = sub i32 %116, 1
+  store i32 %117, i32* %loc0
+  br label %118
+
+; <label>:118                                     ; preds = %67, %115
+  %119 = load i32, i32* %loc0
+  %120 = load i32, i32* %loc1
+  %121 = icmp sge i32 %119, %120
+  br i1 %121, label %71, label %122
+
+; <label>:122                                     ; preds = %62, %109, %118
+  %123 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %124 = load i32, i32* %loc1
+  %125 = load i32, i32* %loc0
+  %126 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %123, i32 %124, i32 %125)
+  ret %System.String addrspace(1)* %126
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %97
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange22:                           ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
 Successfully read String.CreateTrimmedString
 
@@ -5439,8 +6893,8 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
@@ -5535,8 +6989,8 @@ entry:
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i64 2872
   %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
   %8 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %7
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %3
   %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
@@ -5553,8 +7007,8 @@ entry:
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 2864
   %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
   %21 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %20
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
-  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %22
 
 ; <label>:22                                      ; preds = %16
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
@@ -5569,7 +7023,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %16
+ThrowNullRef2:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5586,8 +7040,8 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5613,8 +7067,8 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
@@ -5632,8 +7086,8 @@ entry:
 
 ; <label>:12                                      ; preds = %4
   %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
@@ -5644,8 +7098,8 @@ entry:
 
 ; <label>:19                                      ; preds = %14
   %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %19
   %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
@@ -5660,21 +7114,21 @@ entry:
   %31 = zext i16 %30 to i32
   %32 = bitcast i8* %29 to i16*
   %33 = trunc i32 %31 to i16
-  %NullCheck6 = icmp ne i16* %32, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i16* %32, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %21
   store i16 %33, i16* %32, align 8
   %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %36
 
 ; <label>:36                                      ; preds = %34
   %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
   %38 = load i32, i32 addrspace(1)* %37, align 8
   %39 = add i32 %38, 1
-  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %40
 
 ; <label>:40                                      ; preds = %36
   %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
@@ -5683,16 +7137,16 @@ entry:
 
 ; <label>:42                                      ; preds = %14
   %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
-  br i1 %NullCheck12, label %44, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
   %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
   %47 = load i16, i16* %arg1
   %48 = zext i16 %47 to i32
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = trunc i32 %48 to i16
@@ -5703,31 +7157,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %19
+ThrowNullRef4:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %21
+ThrowNullRef6:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %36
+ThrowNullRef10:                                   ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %42
+ThrowNullRef12:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %44
+ThrowNullRef14:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5740,8 +7194,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -5752,8 +7206,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
@@ -5762,14 +7216,14 @@ entry:
 
 ; <label>:11                                      ; preds = %1
   %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
@@ -5779,15 +7233,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5808,8 +7262,8 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5822,8 +7276,8 @@ entry:
 
 ; <label>:8                                       ; preds = %3
   %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
@@ -5842,15 +7296,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
-  br i1 %NullCheck4, label %22, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
   %24 = load i16*, i16* addrspace(1)* %23, align 8
   %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %25, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
@@ -5859,8 +7313,8 @@ entry:
   store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
@@ -5874,8 +7328,8 @@ entry:
 
 ; <label>:37                                      ; preds = %65
   %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %37
   %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
@@ -5886,16 +7340,16 @@ entry:
   %45 = bitcast i16* %41 to i8*
   %46 = getelementptr inbounds i8, i8* %45, i64 %44
   %47 = bitcast i8* %46 to i16*
-  %NullCheck14 = icmp ne i16* %47, null
-  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %47, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %48
 
 ; <label>:48                                      ; preds = %39
   %49 = load i16, i16* %47, align 8
   %50 = zext i16 %49 to i32
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %52 = load i32, i32* %loc1
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %53
 
 ; <label>:53                                      ; preds = %48
   %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
@@ -5916,8 +7370,8 @@ entry:
 ; <label>:62                                      ; preds = %36, %59
   %63 = load i32, i32* %loc1
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck10, label %65, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %65
 
 ; <label>:65                                      ; preds = %62
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
@@ -5936,15 +7390,15 @@ entry:
 
 ; <label>:74                                      ; preds = %70
   %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
-  br i1 %NullCheck18, label %76, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %76
 
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
   %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
-  br i1 %NullCheck20, label %80, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
   %81 = load i64, i64 addrspace(1)* %79
@@ -5958,8 +7412,8 @@ entry:
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
   %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
-  br i1 %NullCheck22, label %92, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.String addrspace(1)* %90, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %92
 
 ; <label>:92                                      ; preds = %80
   %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
@@ -5969,15 +7423,15 @@ entry:
 
 ; <label>:96                                      ; preds = %70
   %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
-  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %98
 
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
   %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
-  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
   %103 = load i64, i64 addrspace(1)* %101
@@ -5991,8 +7445,8 @@ entry:
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
   %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
-  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.String addrspace(1)* %112, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %114
 
 ; <label>:114                                     ; preds = %102
   %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
@@ -6004,59 +7458,59 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %20
+ThrowNullRef4:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %22
+ThrowNullRef6:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %26
+ThrowNullRef8:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %62
+ThrowNullRef10:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %48
+ThrowNullRef16:                                   ; preds = %48
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %74
+ThrowNullRef18:                                   ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %76
+ThrowNullRef20:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %80
+ThrowNullRef22:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %96
+ThrowNullRef24:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %98
+ThrowNullRef26:                                   ; preds = %98
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %102
+ThrowNullRef28:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6069,15 +7523,15 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
   %3 = load i16*, i16* addrspace(1)* %2, align 8
   %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
@@ -6087,8 +7541,8 @@ entry:
   %10 = bitcast i16* %3 to i8*
   %11 = getelementptr inbounds i8, i8* %10, i64 %9
   %12 = bitcast i8* %11 to i16*
-  %NullCheck4 = icmp ne i16* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %5
   store i16 0, i16* %12, align 8
@@ -6098,11 +7552,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6119,8 +7573,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -6131,8 +7585,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
@@ -6144,15 +7598,15 @@ entry:
 
 ; <label>:14                                      ; preds = %1
   %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
   %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
   %21 = load i64, i64 addrspace(1)* %19
@@ -6171,15 +7625,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %14
+ThrowNullRef4:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %16
+ThrowNullRef6:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6302,14 +7756,6 @@ entry:
   ret %System.String addrspace(1)* %57
 }
 
-INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
-Successfully read RuntimeHelpers.get_OffsetToStringData
-
-define i32 @RuntimeHelpers.get_OffsetToStringData() {
-entry:
-  ret i32 12
-}
-
 INFO:  jitting method String::Equals using LLILCJit
 Successfully read String.Equals
 
@@ -6381,8 +7827,8 @@ entry:
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
-  br i1 %NullCheck24, label %29, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
   %30 = load i64, i64 addrspace(1)* %28
@@ -6397,8 +7843,8 @@ entry:
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
-  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
   %43 = load i64, i64 addrspace(1)* %41
@@ -6418,8 +7864,8 @@ entry:
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
   %59 = load i64, i64 addrspace(1)* %57
@@ -6434,8 +7880,8 @@ entry:
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck22, label %71, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
   %72 = load i64, i64 addrspace(1)* %70
@@ -6455,8 +7901,8 @@ entry:
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
-  br i1 %NullCheck16, label %87, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = load i64, i64 addrspace(1)* %86
@@ -6471,8 +7917,8 @@ entry:
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck18, label %100, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
   %101 = load i64, i64 addrspace(1)* %99
@@ -6492,8 +7938,8 @@ entry:
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
-  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
   %117 = load i64, i64 addrspace(1)* %115
@@ -6508,8 +7954,8 @@ entry:
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
-  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
   %130 = load i64, i64 addrspace(1)* %128
@@ -6528,15 +7974,15 @@ entry:
 
 ; <label>:142                                     ; preds = %22
   %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
-  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %143, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %144
 
 ; <label>:144                                     ; preds = %142
   %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
   %146 = load i32, i32 addrspace(1)* %145
   %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
-  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %147, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %148
 
 ; <label>:148                                     ; preds = %144
   %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
@@ -6557,15 +8003,15 @@ entry:
 
 ; <label>:159                                     ; preds = %22
   %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
-  br i1 %NullCheck, label %161, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %ThrowNullRef, label %161
 
 ; <label>:161                                     ; preds = %159
   %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
   %163 = load i32, i32 addrspace(1)* %162
   %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
-  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %164, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %165
 
 ; <label>:165                                     ; preds = %161
   %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
@@ -6578,8 +8024,8 @@ entry:
 
 ; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
-  br i1 %NullCheck4, label %172, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %171, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %172
 
 ; <label>:172                                     ; preds = %170
   %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
@@ -6589,8 +8035,8 @@ entry:
 
 ; <label>:176                                     ; preds = %172
   %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
-  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %177, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %178
 
 ; <label>:178                                     ; preds = %176
   %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
@@ -6629,55 +8075,55 @@ ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %161
+ThrowNullRef2:                                    ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %170
+ThrowNullRef4:                                    ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %176
+ThrowNullRef6:                                    ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %142
+ThrowNullRef8:                                    ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %144
+ThrowNullRef10:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %113
+ThrowNullRef12:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %116
+ThrowNullRef14:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %84
+ThrowNullRef16:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %87
+ThrowNullRef18:                                   ; preds = %87
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %55
+ThrowNullRef20:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %58
+ThrowNullRef22:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %26
+ThrowNullRef24:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %29
+ThrowNullRef26:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,8 +8161,8 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck, label %14, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %ThrowNullRef, label %14
 
 ; <label>:14                                      ; preds = %8
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
@@ -6760,8 +8206,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
@@ -6770,14 +8216,14 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32, i32* %loc0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %10
   %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
   %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
@@ -6790,15 +8236,15 @@ entry:
 ; <label>:25                                      ; preds = %19
   %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
-  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
   %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
@@ -6807,8 +8253,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %37 = load i32, i32* %loc0
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %38, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %38
 
 ; <label>:38                                      ; preds = %32
   %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
@@ -6817,14 +8263,14 @@ entry:
 
 ; <label>:40                                      ; preds = %19
   %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %40
   %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
   %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
-  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
-  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
@@ -6832,8 +8278,8 @@ entry:
   %48 = zext i32 %47 to i64
   %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
-  br i1 %NullCheck16, label %51, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %51
 
 ; <label>:51                                      ; preds = %45
   %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
@@ -6847,15 +8293,15 @@ entry:
 ; <label>:57                                      ; preds = %51
   %58 = load i16*, i16** %arg1
   %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
-  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %60
 
 ; <label>:60                                      ; preds = %57
   %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
   %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
-  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %64
 
 ; <label>:64                                      ; preds = %60
   %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
@@ -6864,22 +8310,22 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
   %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
-  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %70
 
 ; <label>:70                                      ; preds = %64
   %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
   %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
-  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
-  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
   %75 = load i32, i32 addrspace(1)* %74
   %76 = zext i32 %75 to i64
   %77 = trunc i64 %76 to i32
-  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
-  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %78
 
 ; <label>:78                                      ; preds = %73
   %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
@@ -6901,8 +8347,8 @@ entry:
   %90 = bitcast i16* %86 to i8*
   %91 = getelementptr inbounds i8, i8* %90, i64 %89
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %93
 
 ; <label>:93                                      ; preds = %80
   %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
@@ -6912,8 +8358,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %99 = load i32, i32* %loc2
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %100
 
 ; <label>:100                                     ; preds = %93
   %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
@@ -6928,63 +8374,63 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %25
+ThrowNullRef6:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %32
+ThrowNullRef10:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %40
+ThrowNullRef12:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %45
+ThrowNullRef16:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %57
+ThrowNullRef18:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %60
+ThrowNullRef20:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %64
+ThrowNullRef22:                                   ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %70
+ThrowNullRef24:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %73
+ThrowNullRef26:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %80
+ThrowNullRef28:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %93
+ThrowNullRef30:                                   ; preds = %93
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7004,8 +8450,8 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
@@ -7033,43 +8479,43 @@ entry:
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %14
   %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
   %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   %28 = load i32, i32 addrspace(1)* %27, align 8
   %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
-  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %30
 
 ; <label>:30                                      ; preds = %26
   %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
   %32 = load i32, i32 addrspace(1)* %31, align 8
   %33 = add i32 %28, %32
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %34
 
 ; <label>:34                                      ; preds = %30
   %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   store i32 %33, i32 addrspace(1)* %35
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
   store i32 0, i32 addrspace(1)* %38
   %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %40
 
 ; <label>:40                                      ; preds = %37
   %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
@@ -7082,8 +8528,8 @@ entry:
 
 ; <label>:47                                      ; preds = %40
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
@@ -7098,8 +8544,8 @@ entry:
   %54 = load i32, i32* %loc0
   %55 = sext i32 %54 to i64
   %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
-  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %57
 
 ; <label>:57                                      ; preds = %52
   %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
@@ -7110,68 +8556,35 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %14
+ThrowNullRef2:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %23
+ThrowNullRef4:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %26
+ThrowNullRef6:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %30
+ThrowNullRef8:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %34
+ThrowNullRef10:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %47
+ThrowNullRef14:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %52
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-}
-
-INFO:  jitting method StringBuilder::get_Length using LLILCJit
-Successfully read StringBuilder.get_Length
-
-define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.StringBuilder addrspace(1)*
-  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
-  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
-
-; <label>:1                                       ; preds = %entry
-  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %3 = load i32, i32 addrspace(1)* %2, align 8
-  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
-
-; <label>:5                                       ; preds = %1
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = add i32 %3, %7
-  ret i32 %8
-
-ThrowNullRef:                                     ; preds = %entry
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef16:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7213,70 +8626,70 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
   %6 = load i32, i32 addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
   store i32 %6, i32 addrspace(1)* %8
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
   %13 = load i32, i32 addrspace(1)* %12, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
   store i32 %13, i32 addrspace(1)* %15
   %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
-  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %18
 
 ; <label>:18                                      ; preds = %14
   %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
   %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
   %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
   %34 = load i32, i32 addrspace(1)* %33, align 8
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
-  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
@@ -7287,39 +8700,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %28
+ThrowNullRef16:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %32
+ThrowNullRef18:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7455,13 +8868,13 @@ entry:
 ; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
@@ -7477,16 +8890,16 @@ entry:
 
 ; <label>:18                                      ; preds = %15
   %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
   store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
   %22 = load i32, i32* %loc0
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %24
 
 ; <label>:24                                      ; preds = %20
   %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
@@ -7498,13 +8911,13 @@ entry:
 ; <label>:28                                      ; preds = %15, %24
   %29 = load i32, i32* %arg1
   %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %31
   %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
@@ -7517,20 +8930,20 @@ entry:
   %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
-  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
   %46 = load i32, i32 addrspace(1)* %45, align 8
   %47 = sub i32 %40, %46
-  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
-  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i32 addrspace(1)* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %48
 
 ; <label>:48                                      ; preds = %44
   store i32 %47, i32 addrspace(1)* %39, align 8
@@ -7538,21 +8951,21 @@ entry:
 
 ; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
-  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %51
 
 ; <label>:51                                      ; preds = %49
   %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %53
 
 ; <label>:53                                      ; preds = %51
   %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
   %55 = load i32, i32 addrspace(1)* %54, align 8
   %56 = load i32, i32* %arg2
   %57 = sub i32 %55, %56
-  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %58
 
 ; <label>:58                                      ; preds = %53
   %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
@@ -7562,13 +8975,13 @@ entry:
 ; <label>:60                                      ; preds = %33, %58
   %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
   %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
-  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %63
 
 ; <label>:63                                      ; preds = %60
   %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
-  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
-  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
@@ -7578,15 +8991,15 @@ entry:
 
 ; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
-  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i32 addrspace(1)* %69, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %70
 
 ; <label>:70                                      ; preds = %68
   %71 = load i32, i32 addrspace(1)* %69, align 8
   store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
-  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
@@ -7596,8 +9009,8 @@ entry:
   store i32 %77, i32* %loc4
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
-  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %80
 
 ; <label>:80                                      ; preds = %73
   %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
@@ -7607,71 +9020,71 @@ entry:
 ; <label>:83                                      ; preds = %80
   store i32 0, i32* %loc3
   %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
-  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
-  br i1 %NullCheck26, label %88, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i32 addrspace(1)* %87, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %88
 
 ; <label>:88                                      ; preds = %85
   %89 = load i32, i32 addrspace(1)* %87, align 8
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
-  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %90
 
 ; <label>:90                                      ; preds = %88
   %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
   store i32 %89, i32 addrspace(1)* %91
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
-  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
-  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %96
 
 ; <label>:96                                      ; preds = %94
   %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
-  br i1 %NullCheck34, label %100, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %100
 
 ; <label>:100                                     ; preds = %96
   %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
-  br i1 %NullCheck36, label %102, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %102
 
 ; <label>:102                                     ; preds = %100
   %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
   %104 = load i32, i32 addrspace(1)* %103, align 8
   %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
-  br i1 %NullCheck38, label %106, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %106
 
 ; <label>:106                                     ; preds = %102
   %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
-  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
-  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %108
 
 ; <label>:108                                     ; preds = %106
   %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
   %110 = load i32, i32 addrspace(1)* %109, align 8
   %111 = add i32 %104, %110
-  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %112
 
 ; <label>:112                                     ; preds = %108
   %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
   store i32 %111, i32 addrspace(1)* %113
   %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
-  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i32 addrspace(1)* %114, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %115
 
 ; <label>:115                                     ; preds = %112
   %116 = load i32, i32 addrspace(1)* %114, align 8
@@ -7681,19 +9094,19 @@ entry:
 ; <label>:118                                     ; preds = %115
   %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
-  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %121
 
 ; <label>:121                                     ; preds = %118
   %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
-  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
-  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %123
 
 ; <label>:123                                     ; preds = %121
   %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
   %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
-  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
-  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %126
 
 ; <label>:126                                     ; preds = %123
   %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
@@ -7705,8 +9118,8 @@ entry:
 
 ; <label>:130                                     ; preds = %80, %115, %126
   %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %132
 
 ; <label>:132                                     ; preds = %130
   %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7715,8 +9128,8 @@ entry:
   %136 = load i32, i32* %loc3
   %137 = sub i32 %135, %136
   %138 = sub i32 %134, %137
-  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %139
 
 ; <label>:139                                     ; preds = %132
   %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7728,16 +9141,16 @@ entry:
 
 ; <label>:144                                     ; preds = %139
   %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
-  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %146
 
 ; <label>:146                                     ; preds = %144
   %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
   %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
   %149 = load i32, i32* %loc2
   %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
-  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %151
 
 ; <label>:151                                     ; preds = %146
   %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
@@ -7754,145 +9167,249 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %18
+ThrowNullRef4:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %31
+ThrowNullRef10:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %44
+ThrowNullRef16:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %68
+ThrowNullRef18:                                   ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %70
+ThrowNullRef20:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %73
+ThrowNullRef22:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %83
+ThrowNullRef24:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %85
+ThrowNullRef26:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %88
+ThrowNullRef28:                                   ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %90
+ThrowNullRef30:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %94
+ThrowNullRef32:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %96
+ThrowNullRef34:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %100
+ThrowNullRef36:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %102
+ThrowNullRef38:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %106
+ThrowNullRef40:                                   ; preds = %106
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %108
+ThrowNullRef42:                                   ; preds = %108
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %112
+ThrowNullRef44:                                   ; preds = %112
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %118
+ThrowNullRef46:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %121
+ThrowNullRef48:                                   ; preds = %121
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %123
+ThrowNullRef50:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %130
+ThrowNullRef52:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %132
+ThrowNullRef54:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %144
+ThrowNullRef56:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %146
+ThrowNullRef58:                                   ; preds = %146
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %60
+ThrowNullRef60:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %63
+ThrowNullRef62:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %49
+ThrowNullRef64:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %51
+ThrowNullRef66:                                   ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %53
+ThrowNullRef68:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(%"System.Char[]" addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %arg0 = alloca %"System.Char[]" addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store %"System.Char[]" addrspace(1)* %param0, %"System.Char[]" addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load i32, i32* %arg4
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %43, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %38, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg1
+  %13 = load i32, i32* %arg4
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %38, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %24 = load i32, i32* %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %35 = load i32, i32* %arg3
+  %36 = load i32, i32* %arg4
+  %37 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %37, %"System.Char[]" addrspace(1)* %34, i32 %35, i32 %36)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:38                                      ; preds = %5, %16
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Successfully read Buffer._Memmove
 
@@ -7914,7 +9431,7 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[loadElem]
+Failed to read AppDomain.SetDataHelper[storeElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -7923,8 +9440,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
@@ -7934,8 +9451,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
@@ -7947,15 +9464,15 @@ entry:
   %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
   %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
@@ -7966,15 +9483,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7992,7 +9509,79 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
-Failed to read Dictionary`2.TryGetValue[loadElemA]
+Successfully read Dictionary`2.TryGetValue
+
+define i8 @"Dictionary`2.TryGetValue"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)* addrspace(1)* %param2) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  %arg2 = alloca %System.__Canon addrspace(1)* addrspace(1)*
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  store %System.__Canon addrspace(1)* addrspace(1)* %param2, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  store i32 %2, i32* %loc0
+  %3 = load i32, i32* %loc0
+  %4 = icmp slt i32 %3, 0
+  br i1 %4, label %22, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 2
+  %10 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %9, align 8
+  %11 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = zext i32 %11 to i64
+  %BoundsCheck = icmp uge i64 %16, %15
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 3, i32 %11
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %20, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %6, %System.__Canon addrspace(1)* %21)
+  ret i8 1
+
+; <label>:22                                      ; preds = %entry
+  %23 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %23, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -8058,8 +9647,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
@@ -8091,8 +9680,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
@@ -8171,15 +9760,15 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck, label %19, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %ThrowNullRef, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
   %21 = load i32, i32 addrspace(1)* %20
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
@@ -8202,7 +9791,7 @@ ThrowNullRef:                                     ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %19
+ThrowNullRef2:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8248,8 +9837,8 @@ entry:
   %0 = alloca %System.AppDomainHandle
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %1 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %1, i32 0, i32 15
@@ -8269,8 +9858,8 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
@@ -8286,7 +9875,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -8299,8 +9888,8 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -8327,8 +9916,8 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
@@ -8352,8 +9941,8 @@ entry:
   %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
   store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
@@ -8363,8 +9952,8 @@ entry:
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
@@ -8374,8 +9963,8 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %9
   %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
@@ -8384,8 +9973,8 @@ entry:
 
 ; <label>:18                                      ; preds = %3, %16
   %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
@@ -8397,15 +9986,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %18
+ThrowNullRef6:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8418,8 +10007,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
@@ -8453,15 +10042,15 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
@@ -8473,7 +10062,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8481,7 +10070,7 @@ ThrowNullRef1:                                    ; preds = %1
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
 Failed to read Dictionary`2.System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
@@ -8506,8 +10095,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
@@ -8524,8 +10113,8 @@ entry:
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -8544,7 +10133,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8577,8 +10166,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = load i64, i64* %arg2
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = trunc i32 %3 to i8
@@ -8634,46 +10223,46 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
   %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
-  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
-  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
-  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
@@ -8684,27 +10273,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %20
+ThrowNullRef12:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8717,8 +10306,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -8756,22 +10345,22 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
   %9 = load i64, i64 addrspace(1)* %8, align 8
   %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
   %13 = load i64, i64 addrspace(1)* %12, align 8
   %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %11
   %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
@@ -8788,11 +10377,11 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8882,8 +10471,8 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
@@ -8900,8 +10489,8 @@ entry:
 ; <label>:8                                       ; preds = %1
   %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
   %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
@@ -8911,15 +10500,15 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
   %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
   %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
-  br i1 %NullCheck6, label %21, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
@@ -8946,15 +10535,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8992,15 +10581,15 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
   store i8 %3, i8 addrspace(1)* %5
   %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
@@ -9011,7 +10600,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9027,8 +10616,8 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -9041,8 +10630,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
@@ -9058,7 +10647,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9080,8 +10669,8 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
@@ -9096,8 +10685,8 @@ entry:
 ; <label>:12                                      ; preds = %6
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
@@ -9112,8 +10701,8 @@ entry:
 ; <label>:21                                      ; preds = %15
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
@@ -9128,8 +10717,8 @@ entry:
 ; <label>:30                                      ; preds = %24
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %31, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
@@ -9144,8 +10733,8 @@ entry:
 ; <label>:39                                      ; preds = %33
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
-  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %40, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %42
 
 ; <label>:42                                      ; preds = %39
   %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
@@ -9164,19 +10753,19 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %21
+ThrowNullRef4:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %30
+ThrowNullRef6:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %39
+ThrowNullRef8:                                    ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9243,8 +10832,8 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
@@ -9264,57 +10853,57 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
   store i8 0, i8 addrspace(1)* %2
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
   store i8 0, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
   store i8 0, i8 addrspace(1)* %17
   %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
   store i8 0, i8 addrspace(1)* %20
   %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
-  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
@@ -9325,31 +10914,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %19
+ThrowNullRef14:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9367,8 +10956,8 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
@@ -9380,8 +10969,8 @@ entry:
 
 ; <label>:9                                       ; preds = %4
   %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %9
   %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
@@ -9395,7 +10984,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef2:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9420,8 +11009,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
@@ -9512,8 +11101,8 @@ entry:
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
@@ -9524,8 +11113,8 @@ entry:
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = load i64, i64 addrspace(1)* %12
@@ -9537,8 +11126,8 @@ entry:
   %20 = load i64, i64* %19
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
-  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %13
   %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
@@ -9555,8 +11144,8 @@ entry:
 ; <label>:30                                      ; preds = %25
   %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %32 = load i32, i32* %arg2
-  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
-  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
@@ -9570,15 +11159,15 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %30
+ThrowNullRef2:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9622,87 +11211,87 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
   %10 = load i8, i8 addrspace(1)* %9, align 8
   %11 = zext i8 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %8
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
   store i8 %12, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
   %19 = load i8, i8 addrspace(1)* %18, align 8
   %20 = zext i8 %19 to i32
   %21 = trunc i32 %20 to i8
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
   store i8 %21, i8 addrspace(1)* %23
   %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
   %28 = load i8, i8 addrspace(1)* %27, align 8
   %29 = zext i8 %28 to i32
   %30 = trunc i32 %29 to i8
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
-  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %31
 
 ; <label>:31                                      ; preds = %26
   %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
   store i8 %30, i8 addrspace(1)* %32
   %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
-  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
-  br i1 %NullCheck14, label %40, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %40
 
 ; <label>:40                                      ; preds = %35
   %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
   store i8 %39, i8 addrspace(1)* %41
   %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
-  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %44
 
 ; <label>:44                                      ; preds = %40
   %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
   %46 = load i8, i8 addrspace(1)* %45, align 8
   %47 = zext i8 %46 to i32
   %48 = trunc i32 %47 to i8
-  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
   store i8 %48, i8 addrspace(1)* %50
   %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
-  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
@@ -9713,29 +11302,29 @@ entry:
 ; <label>:56                                      ; preds = %52
   %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
-  br i1 %NullCheck22, label %59, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
   %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
   %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
-  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
-  br i1 %NullCheck24, label %63, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
   %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
-  br i1 %NullCheck26, label %66, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
   %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
-  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
-  br i1 %NullCheck28, label %69, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %69
 
 ; <label>:69                                      ; preds = %66
   %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
@@ -9744,15 +11333,15 @@ entry:
 
 ; <label>:71                                      ; preds = %105
   %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
-  br i1 %NullCheck34, label %73, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %73
 
 ; <label>:73                                      ; preds = %71
   %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
   %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
   %76 = load i32, i32* %loc0
-  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
-  br i1 %NullCheck36, label %77, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
@@ -9766,8 +11355,8 @@ entry:
 
 ; <label>:83                                      ; preds = %77
   %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
-  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
@@ -9775,14 +11364,14 @@ entry:
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
   %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
-  br i1 %NullCheck40, label %91, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
 ; <label>:91                                      ; preds = %85
   %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
   %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
-  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck42, label %94, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %94
 
 ; <label>:94                                      ; preds = %91
   %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
@@ -9798,14 +11387,14 @@ entry:
 ; <label>:99                                      ; preds = %69, %96
   %100 = load i32, i32* %loc0
   %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
-  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %102
 
 ; <label>:102                                     ; preds = %99
   %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
   %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
-  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
-  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
@@ -9819,87 +11408,87 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %26
+ThrowNullRef10:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %31
+ThrowNullRef12:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %35
+ThrowNullRef14:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %40
+ThrowNullRef16:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %56
+ThrowNullRef22:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %59
+ThrowNullRef24:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %63
+ThrowNullRef26:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %66
+ThrowNullRef28:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %102
+ThrowNullRef32:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %71
+ThrowNullRef34:                                   ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %73
+ThrowNullRef36:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %83
+ThrowNullRef38:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %85
+ThrowNullRef40:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %91
+ThrowNullRef42:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9943,15 +11532,15 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
   %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
@@ -9961,28 +11550,28 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
   %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %12
   %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
   %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
   %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
-  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
@@ -9993,23 +11582,23 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %12
+ThrowNullRef6:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10031,15 +11620,15 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
   %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = load i64, i64 addrspace(1)* %7
@@ -10077,13 +11666,13 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[loadElem]
+Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -10111,8 +11700,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1

--- a/test/BaseLine/JIT/CodeGenBringUpTests/BinaryRMW.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/BinaryRMW.error.txt
@@ -25,8 +25,8 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
@@ -40,8 +40,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
   %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
@@ -75,7 +75,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -90,8 +90,8 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %NullCheck = icmp ne i8 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = load i8, i8 addrspace(1)* %0, align 8
@@ -125,8 +125,8 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
@@ -159,8 +159,8 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -184,8 +184,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
   store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
@@ -195,8 +195,8 @@ entry:
 ; <label>:4                                       ; preds = %1
   %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
   %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
@@ -206,8 +206,8 @@ entry:
   %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
@@ -221,14 +221,14 @@ entry:
 
 ; <label>:17                                      ; preds = %14
   %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
   %21 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
@@ -238,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -249,8 +249,8 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
@@ -261,27 +261,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %30
+ThrowNullRef10:                                   ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -301,7 +301,89 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
-Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
+Successfully read AppDomainSetup.GetUnsecureApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.GetUnsecureApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %NullCheck = icmp eq %"System.String[]" addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %BoundsCheck = icmp uge i64 0, %5
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %6
+
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 3, i32 0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
+  ret %System.String addrspace(1)* %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_Value using LLILCJit
+Successfully read AppDomainSetup.get_Value
+
+define %"System.String[]" addrspace(1)* @AppDomainSetup.get_Value(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.String[]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 18)
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.String[]" addrspace(1)* addrspace(1)*, %"System.String[]" addrspace(1)*)*)(%"System.String[]" addrspace(1)* addrspace(1)* %9, %"System.String[]" addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %11, i32 0, i32 1
+  %14 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %13, align 8
+  ret %"System.String[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -319,8 +401,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -368,16 +450,16 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
   %5 = load i32, i32 addrspace(1)* %4
   %6 = sub i32 %5, 1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -389,7 +471,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -421,8 +503,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
@@ -456,8 +538,8 @@ entry:
 ; <label>:27                                      ; preds = %19
   %28 = load i32, i32* %arg1
   %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
-  br i1 %NullCheck2, label %30, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %29, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %30
 
 ; <label>:30                                      ; preds = %27
   %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
@@ -493,8 +575,8 @@ entry:
 ; <label>:49                                      ; preds = %46
   %50 = load i32, i32* %arg2
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck4, label %52, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
@@ -517,11 +599,11 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %27
+ThrowNullRef2:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %49
+ThrowNullRef4:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -544,16 +626,16 @@ entry:
   %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %0)
   store %System.String addrspace(1)* %1, %System.String addrspace(1)** %loc0
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 2
   %5 = bitcast [0 x i16] addrspace(1)* %4 to i16 addrspace(1)*
   store i16 addrspace(1)* %5, i16 addrspace(1)** %loc1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %3
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2
@@ -580,7 +662,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -691,15 +773,15 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %NullCheck132 = icmp ne i8* %21, null
-  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+  %NullCheck131 = icmp eq i8* %21, null
+  br i1 %NullCheck131, label %ThrowNullRef132, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = load i8, i8* %21, align 8
   %24 = zext i8 %23 to i32
   %25 = trunc i32 %24 to i8
-  %NullCheck134 = icmp ne i8* %20, null
-  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+  %NullCheck133 = icmp eq i8* %20, null
+  br i1 %NullCheck133, label %ThrowNullRef134, label %26
 
 ; <label>:26                                      ; preds = %22
   store i8 %25, i8* %20, align 8
@@ -709,16 +791,16 @@ entry:
   %28 = load i8*, i8** %arg0
   %29 = load i8*, i8** %arg1
   %30 = bitcast i8* %29 to i16*
-  %NullCheck128 = icmp ne i16* %30, null
-  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+  %NullCheck127 = icmp eq i16* %30, null
+  br i1 %NullCheck127, label %ThrowNullRef128, label %31
 
 ; <label>:31                                      ; preds = %27
   %32 = load i16, i16* %30, align 8
   %33 = sext i16 %32 to i32
   %34 = bitcast i8* %28 to i16*
   %35 = trunc i32 %33 to i16
-  %NullCheck130 = icmp ne i16* %34, null
-  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+  %NullCheck129 = icmp eq i16* %34, null
+  br i1 %NullCheck129, label %ThrowNullRef130, label %36
 
 ; <label>:36                                      ; preds = %31
   store i16 %35, i16* %34, align 8
@@ -728,16 +810,16 @@ entry:
   %38 = load i8*, i8** %arg0
   %39 = load i8*, i8** %arg1
   %40 = bitcast i8* %39 to i16*
-  %NullCheck120 = icmp ne i16* %40, null
-  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+  %NullCheck119 = icmp eq i16* %40, null
+  br i1 %NullCheck119, label %ThrowNullRef120, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i16, i16* %40, align 8
   %43 = sext i16 %42 to i32
   %44 = bitcast i8* %38 to i16*
   %45 = trunc i32 %43 to i16
-  %NullCheck122 = icmp ne i16* %44, null
-  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+  %NullCheck121 = icmp eq i16* %44, null
+  br i1 %NullCheck121, label %ThrowNullRef122, label %46
 
 ; <label>:46                                      ; preds = %41
   store i16 %45, i16* %44, align 8
@@ -745,15 +827,15 @@ entry:
   %48 = getelementptr inbounds i8, i8* %47, i64 2
   %49 = load i8*, i8** %arg1
   %50 = getelementptr inbounds i8, i8* %49, i64 2
-  %NullCheck124 = icmp ne i8* %50, null
-  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+  %NullCheck123 = icmp eq i8* %50, null
+  br i1 %NullCheck123, label %ThrowNullRef124, label %51
 
 ; <label>:51                                      ; preds = %46
   %52 = load i8, i8* %50, align 8
   %53 = zext i8 %52 to i32
   %54 = trunc i32 %53 to i8
-  %NullCheck126 = icmp ne i8* %48, null
-  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+  %NullCheck125 = icmp eq i8* %48, null
+  br i1 %NullCheck125, label %ThrowNullRef126, label %55
 
 ; <label>:55                                      ; preds = %51
   store i8 %54, i8* %48, align 8
@@ -763,14 +845,14 @@ entry:
   %57 = load i8*, i8** %arg0
   %58 = load i8*, i8** %arg1
   %59 = bitcast i8* %58 to i32*
-  %NullCheck116 = icmp ne i32* %59, null
-  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+  %NullCheck115 = icmp eq i32* %59, null
+  br i1 %NullCheck115, label %ThrowNullRef116, label %60
 
 ; <label>:60                                      ; preds = %56
   %61 = load i32, i32* %59, align 8
   %62 = bitcast i8* %57 to i32*
-  %NullCheck118 = icmp ne i32* %62, null
-  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+  %NullCheck117 = icmp eq i32* %62, null
+  br i1 %NullCheck117, label %ThrowNullRef118, label %63
 
 ; <label>:63                                      ; preds = %60
   store i32 %61, i32* %62, align 8
@@ -780,14 +862,14 @@ entry:
   %65 = load i8*, i8** %arg0
   %66 = load i8*, i8** %arg1
   %67 = bitcast i8* %66 to i32*
-  %NullCheck108 = icmp ne i32* %67, null
-  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+  %NullCheck107 = icmp eq i32* %67, null
+  br i1 %NullCheck107, label %ThrowNullRef108, label %68
 
 ; <label>:68                                      ; preds = %64
   %69 = load i32, i32* %67, align 8
   %70 = bitcast i8* %65 to i32*
-  %NullCheck110 = icmp ne i32* %70, null
-  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+  %NullCheck109 = icmp eq i32* %70, null
+  br i1 %NullCheck109, label %ThrowNullRef110, label %71
 
 ; <label>:71                                      ; preds = %68
   store i32 %69, i32* %70, align 8
@@ -795,15 +877,15 @@ entry:
   %73 = getelementptr inbounds i8, i8* %72, i64 4
   %74 = load i8*, i8** %arg1
   %75 = getelementptr inbounds i8, i8* %74, i64 4
-  %NullCheck112 = icmp ne i8* %75, null
-  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+  %NullCheck111 = icmp eq i8* %75, null
+  br i1 %NullCheck111, label %ThrowNullRef112, label %76
 
 ; <label>:76                                      ; preds = %71
   %77 = load i8, i8* %75, align 8
   %78 = zext i8 %77 to i32
   %79 = trunc i32 %78 to i8
-  %NullCheck114 = icmp ne i8* %73, null
-  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+  %NullCheck113 = icmp eq i8* %73, null
+  br i1 %NullCheck113, label %ThrowNullRef114, label %80
 
 ; <label>:80                                      ; preds = %76
   store i8 %79, i8* %73, align 8
@@ -813,14 +895,14 @@ entry:
   %82 = load i8*, i8** %arg0
   %83 = load i8*, i8** %arg1
   %84 = bitcast i8* %83 to i32*
-  %NullCheck100 = icmp ne i32* %84, null
-  br i1 %NullCheck100, label %85, label %ThrowNullRef99
+  %NullCheck99 = icmp eq i32* %84, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %85
 
 ; <label>:85                                      ; preds = %81
   %86 = load i32, i32* %84, align 8
   %87 = bitcast i8* %82 to i32*
-  %NullCheck102 = icmp ne i32* %87, null
-  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+  %NullCheck101 = icmp eq i32* %87, null
+  br i1 %NullCheck101, label %ThrowNullRef102, label %88
 
 ; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
@@ -829,16 +911,16 @@ entry:
   %91 = load i8*, i8** %arg1
   %92 = getelementptr inbounds i8, i8* %91, i64 4
   %93 = bitcast i8* %92 to i16*
-  %NullCheck104 = icmp ne i16* %93, null
-  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+  %NullCheck103 = icmp eq i16* %93, null
+  br i1 %NullCheck103, label %ThrowNullRef104, label %94
 
 ; <label>:94                                      ; preds = %88
   %95 = load i16, i16* %93, align 8
   %96 = sext i16 %95 to i32
   %97 = bitcast i8* %90 to i16*
   %98 = trunc i32 %96 to i16
-  %NullCheck106 = icmp ne i16* %97, null
-  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+  %NullCheck105 = icmp eq i16* %97, null
+  br i1 %NullCheck105, label %ThrowNullRef106, label %99
 
 ; <label>:99                                      ; preds = %94
   store i16 %98, i16* %97, align 8
@@ -848,14 +930,14 @@ entry:
   %101 = load i8*, i8** %arg0
   %102 = load i8*, i8** %arg1
   %103 = bitcast i8* %102 to i32*
-  %NullCheck88 = icmp ne i32* %103, null
-  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+  %NullCheck87 = icmp eq i32* %103, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %104
 
 ; <label>:104                                     ; preds = %100
   %105 = load i32, i32* %103, align 8
   %106 = bitcast i8* %101 to i32*
-  %NullCheck90 = icmp ne i32* %106, null
-  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+  %NullCheck89 = icmp eq i32* %106, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %107
 
 ; <label>:107                                     ; preds = %104
   store i32 %105, i32* %106, align 8
@@ -864,16 +946,16 @@ entry:
   %110 = load i8*, i8** %arg1
   %111 = getelementptr inbounds i8, i8* %110, i64 4
   %112 = bitcast i8* %111 to i16*
-  %NullCheck92 = icmp ne i16* %112, null
-  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+  %NullCheck91 = icmp eq i16* %112, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %113
 
 ; <label>:113                                     ; preds = %107
   %114 = load i16, i16* %112, align 8
   %115 = sext i16 %114 to i32
   %116 = bitcast i8* %109 to i16*
   %117 = trunc i32 %115 to i16
-  %NullCheck94 = icmp ne i16* %116, null
-  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+  %NullCheck93 = icmp eq i16* %116, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %118
 
 ; <label>:118                                     ; preds = %113
   store i16 %117, i16* %116, align 8
@@ -881,15 +963,15 @@ entry:
   %120 = getelementptr inbounds i8, i8* %119, i64 6
   %121 = load i8*, i8** %arg1
   %122 = getelementptr inbounds i8, i8* %121, i64 6
-  %NullCheck96 = icmp ne i8* %122, null
-  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+  %NullCheck95 = icmp eq i8* %122, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %123
 
 ; <label>:123                                     ; preds = %118
   %124 = load i8, i8* %122, align 8
   %125 = zext i8 %124 to i32
   %126 = trunc i32 %125 to i8
-  %NullCheck98 = icmp ne i8* %120, null
-  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+  %NullCheck97 = icmp eq i8* %120, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %127
 
 ; <label>:127                                     ; preds = %123
   store i8 %126, i8* %120, align 8
@@ -899,14 +981,14 @@ entry:
   %129 = load i8*, i8** %arg0
   %130 = load i8*, i8** %arg1
   %131 = bitcast i8* %130 to i64*
-  %NullCheck84 = icmp ne i64* %131, null
-  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+  %NullCheck83 = icmp eq i64* %131, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %132
 
 ; <label>:132                                     ; preds = %128
   %133 = load i64, i64* %131, align 8
   %134 = bitcast i8* %129 to i64*
-  %NullCheck86 = icmp ne i64* %134, null
-  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+  %NullCheck85 = icmp eq i64* %134, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %135
 
 ; <label>:135                                     ; preds = %132
   store i64 %133, i64* %134, align 8
@@ -916,14 +998,14 @@ entry:
   %137 = load i8*, i8** %arg0
   %138 = load i8*, i8** %arg1
   %139 = bitcast i8* %138 to i64*
-  %NullCheck76 = icmp ne i64* %139, null
-  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+  %NullCheck75 = icmp eq i64* %139, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %140
 
 ; <label>:140                                     ; preds = %136
   %141 = load i64, i64* %139, align 8
   %142 = bitcast i8* %137 to i64*
-  %NullCheck78 = icmp ne i64* %142, null
-  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+  %NullCheck77 = icmp eq i64* %142, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %143
 
 ; <label>:143                                     ; preds = %140
   store i64 %141, i64* %142, align 8
@@ -931,15 +1013,15 @@ entry:
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %NullCheck80 = icmp ne i8* %147, null
-  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+  %NullCheck79 = icmp eq i8* %147, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %148
 
 ; <label>:148                                     ; preds = %143
   %149 = load i8, i8* %147, align 8
   %150 = zext i8 %149 to i32
   %151 = trunc i32 %150 to i8
-  %NullCheck82 = icmp ne i8* %145, null
-  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+  %NullCheck81 = icmp eq i8* %145, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %152
 
 ; <label>:152                                     ; preds = %148
   store i8 %151, i8* %145, align 8
@@ -949,14 +1031,14 @@ entry:
   %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
   %156 = bitcast i8* %155 to i64*
-  %NullCheck68 = icmp ne i64* %156, null
-  br i1 %NullCheck68, label %157, label %ThrowNullRef67
+  %NullCheck67 = icmp eq i64* %156, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %157
 
 ; <label>:157                                     ; preds = %153
   %158 = load i64, i64* %156, align 8
   %159 = bitcast i8* %154 to i64*
-  %NullCheck70 = icmp ne i64* %159, null
-  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+  %NullCheck69 = icmp eq i64* %159, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %160
 
 ; <label>:160                                     ; preds = %157
   store i64 %158, i64* %159, align 8
@@ -965,16 +1047,16 @@ entry:
   %163 = load i8*, i8** %arg1
   %164 = getelementptr inbounds i8, i8* %163, i64 8
   %165 = bitcast i8* %164 to i16*
-  %NullCheck72 = icmp ne i16* %165, null
-  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+  %NullCheck71 = icmp eq i16* %165, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %166
 
 ; <label>:166                                     ; preds = %160
   %167 = load i16, i16* %165, align 8
   %168 = sext i16 %167 to i32
   %169 = bitcast i8* %162 to i16*
   %170 = trunc i32 %168 to i16
-  %NullCheck74 = icmp ne i16* %169, null
-  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+  %NullCheck73 = icmp eq i16* %169, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %171
 
 ; <label>:171                                     ; preds = %166
   store i16 %170, i16* %169, align 8
@@ -984,14 +1066,14 @@ entry:
   %173 = load i8*, i8** %arg0
   %174 = load i8*, i8** %arg1
   %175 = bitcast i8* %174 to i64*
-  %NullCheck56 = icmp ne i64* %175, null
-  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+  %NullCheck55 = icmp eq i64* %175, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %176
 
 ; <label>:176                                     ; preds = %172
   %177 = load i64, i64* %175, align 8
   %178 = bitcast i8* %173 to i64*
-  %NullCheck58 = icmp ne i64* %178, null
-  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+  %NullCheck57 = icmp eq i64* %178, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %179
 
 ; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
@@ -1000,16 +1082,16 @@ entry:
   %182 = load i8*, i8** %arg1
   %183 = getelementptr inbounds i8, i8* %182, i64 8
   %184 = bitcast i8* %183 to i16*
-  %NullCheck60 = icmp ne i16* %184, null
-  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+  %NullCheck59 = icmp eq i16* %184, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %185
 
 ; <label>:185                                     ; preds = %179
   %186 = load i16, i16* %184, align 8
   %187 = sext i16 %186 to i32
   %188 = bitcast i8* %181 to i16*
   %189 = trunc i32 %187 to i16
-  %NullCheck62 = icmp ne i16* %188, null
-  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+  %NullCheck61 = icmp eq i16* %188, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %190
 
 ; <label>:190                                     ; preds = %185
   store i16 %189, i16* %188, align 8
@@ -1017,15 +1099,15 @@ entry:
   %192 = getelementptr inbounds i8, i8* %191, i64 10
   %193 = load i8*, i8** %arg1
   %194 = getelementptr inbounds i8, i8* %193, i64 10
-  %NullCheck64 = icmp ne i8* %194, null
-  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+  %NullCheck63 = icmp eq i8* %194, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %195
 
 ; <label>:195                                     ; preds = %190
   %196 = load i8, i8* %194, align 8
   %197 = zext i8 %196 to i32
   %198 = trunc i32 %197 to i8
-  %NullCheck66 = icmp ne i8* %192, null
-  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+  %NullCheck65 = icmp eq i8* %192, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %199
 
 ; <label>:199                                     ; preds = %195
   store i8 %198, i8* %192, align 8
@@ -1035,14 +1117,14 @@ entry:
   %201 = load i8*, i8** %arg0
   %202 = load i8*, i8** %arg1
   %203 = bitcast i8* %202 to i64*
-  %NullCheck48 = icmp ne i64* %203, null
-  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+  %NullCheck47 = icmp eq i64* %203, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %204
 
 ; <label>:204                                     ; preds = %200
   %205 = load i64, i64* %203, align 8
   %206 = bitcast i8* %201 to i64*
-  %NullCheck50 = icmp ne i64* %206, null
-  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+  %NullCheck49 = icmp eq i64* %206, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %207
 
 ; <label>:207                                     ; preds = %204
   store i64 %205, i64* %206, align 8
@@ -1051,14 +1133,14 @@ entry:
   %210 = load i8*, i8** %arg1
   %211 = getelementptr inbounds i8, i8* %210, i64 8
   %212 = bitcast i8* %211 to i32*
-  %NullCheck52 = icmp ne i32* %212, null
-  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+  %NullCheck51 = icmp eq i32* %212, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %213
 
 ; <label>:213                                     ; preds = %207
   %214 = load i32, i32* %212, align 8
   %215 = bitcast i8* %209 to i32*
-  %NullCheck54 = icmp ne i32* %215, null
-  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+  %NullCheck53 = icmp eq i32* %215, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %216
 
 ; <label>:216                                     ; preds = %213
   store i32 %214, i32* %215, align 8
@@ -1068,14 +1150,14 @@ entry:
   %218 = load i8*, i8** %arg0
   %219 = load i8*, i8** %arg1
   %220 = bitcast i8* %219 to i64*
-  %NullCheck36 = icmp ne i64* %220, null
-  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64* %220, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %221
 
 ; <label>:221                                     ; preds = %217
   %222 = load i64, i64* %220, align 8
   %223 = bitcast i8* %218 to i64*
-  %NullCheck38 = icmp ne i64* %223, null
-  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+  %NullCheck37 = icmp eq i64* %223, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %224
 
 ; <label>:224                                     ; preds = %221
   store i64 %222, i64* %223, align 8
@@ -1084,14 +1166,14 @@ entry:
   %227 = load i8*, i8** %arg1
   %228 = getelementptr inbounds i8, i8* %227, i64 8
   %229 = bitcast i8* %228 to i32*
-  %NullCheck40 = icmp ne i32* %229, null
-  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i32* %229, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %230
 
 ; <label>:230                                     ; preds = %224
   %231 = load i32, i32* %229, align 8
   %232 = bitcast i8* %226 to i32*
-  %NullCheck42 = icmp ne i32* %232, null
-  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+  %NullCheck41 = icmp eq i32* %232, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %233
 
 ; <label>:233                                     ; preds = %230
   store i32 %231, i32* %232, align 8
@@ -1099,15 +1181,15 @@ entry:
   %235 = getelementptr inbounds i8, i8* %234, i64 12
   %236 = load i8*, i8** %arg1
   %237 = getelementptr inbounds i8, i8* %236, i64 12
-  %NullCheck44 = icmp ne i8* %237, null
-  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i8* %237, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %238
 
 ; <label>:238                                     ; preds = %233
   %239 = load i8, i8* %237, align 8
   %240 = zext i8 %239 to i32
   %241 = trunc i32 %240 to i8
-  %NullCheck46 = icmp ne i8* %235, null
-  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+  %NullCheck45 = icmp eq i8* %235, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %242
 
 ; <label>:242                                     ; preds = %238
   store i8 %241, i8* %235, align 8
@@ -1117,14 +1199,14 @@ entry:
   %244 = load i8*, i8** %arg0
   %245 = load i8*, i8** %arg1
   %246 = bitcast i8* %245 to i64*
-  %NullCheck24 = icmp ne i64* %246, null
-  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64* %246, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %247
 
 ; <label>:247                                     ; preds = %243
   %248 = load i64, i64* %246, align 8
   %249 = bitcast i8* %244 to i64*
-  %NullCheck26 = icmp ne i64* %249, null
-  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64* %249, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %250
 
 ; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
@@ -1133,14 +1215,14 @@ entry:
   %253 = load i8*, i8** %arg1
   %254 = getelementptr inbounds i8, i8* %253, i64 8
   %255 = bitcast i8* %254 to i32*
-  %NullCheck28 = icmp ne i32* %255, null
-  br i1 %NullCheck28, label %256, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i32* %255, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %256
 
 ; <label>:256                                     ; preds = %250
   %257 = load i32, i32* %255, align 8
   %258 = bitcast i8* %252 to i32*
-  %NullCheck30 = icmp ne i32* %258, null
-  br i1 %NullCheck30, label %259, label %ThrowNullRef29
+  %NullCheck29 = icmp eq i32* %258, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %259
 
 ; <label>:259                                     ; preds = %256
   store i32 %257, i32* %258, align 8
@@ -1149,16 +1231,16 @@ entry:
   %262 = load i8*, i8** %arg1
   %263 = getelementptr inbounds i8, i8* %262, i64 12
   %264 = bitcast i8* %263 to i16*
-  %NullCheck32 = icmp ne i16* %264, null
-  br i1 %NullCheck32, label %265, label %ThrowNullRef31
+  %NullCheck31 = icmp eq i16* %264, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %265
 
 ; <label>:265                                     ; preds = %259
   %266 = load i16, i16* %264, align 8
   %267 = sext i16 %266 to i32
   %268 = bitcast i8* %261 to i16*
   %269 = trunc i32 %267 to i16
-  %NullCheck34 = icmp ne i16* %268, null
-  br i1 %NullCheck34, label %270, label %ThrowNullRef33
+  %NullCheck33 = icmp eq i16* %268, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %270
 
 ; <label>:270                                     ; preds = %265
   store i16 %269, i16* %268, align 8
@@ -1168,14 +1250,14 @@ entry:
   %272 = load i8*, i8** %arg0
   %273 = load i8*, i8** %arg1
   %274 = bitcast i8* %273 to i64*
-  %NullCheck8 = icmp ne i64* %274, null
-  br i1 %NullCheck8, label %275, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64* %274, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %275
 
 ; <label>:275                                     ; preds = %271
   %276 = load i64, i64* %274, align 8
   %277 = bitcast i8* %272 to i64*
-  %NullCheck10 = icmp ne i64* %277, null
-  br i1 %NullCheck10, label %278, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %277, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %278
 
 ; <label>:278                                     ; preds = %275
   store i64 %276, i64* %277, align 8
@@ -1184,14 +1266,14 @@ entry:
   %281 = load i8*, i8** %arg1
   %282 = getelementptr inbounds i8, i8* %281, i64 8
   %283 = bitcast i8* %282 to i32*
-  %NullCheck12 = icmp ne i32* %283, null
-  br i1 %NullCheck12, label %284, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i32* %283, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %284
 
 ; <label>:284                                     ; preds = %278
   %285 = load i32, i32* %283, align 8
   %286 = bitcast i8* %280 to i32*
-  %NullCheck14 = icmp ne i32* %286, null
-  br i1 %NullCheck14, label %287, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i32* %286, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %287
 
 ; <label>:287                                     ; preds = %284
   store i32 %285, i32* %286, align 8
@@ -1200,16 +1282,16 @@ entry:
   %290 = load i8*, i8** %arg1
   %291 = getelementptr inbounds i8, i8* %290, i64 12
   %292 = bitcast i8* %291 to i16*
-  %NullCheck16 = icmp ne i16* %292, null
-  br i1 %NullCheck16, label %293, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i16* %292, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %293
 
 ; <label>:293                                     ; preds = %287
   %294 = load i16, i16* %292, align 8
   %295 = sext i16 %294 to i32
   %296 = bitcast i8* %289 to i16*
   %297 = trunc i32 %295 to i16
-  %NullCheck18 = icmp ne i16* %296, null
-  br i1 %NullCheck18, label %298, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i16* %296, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %298
 
 ; <label>:298                                     ; preds = %293
   store i16 %297, i16* %296, align 8
@@ -1217,15 +1299,15 @@ entry:
   %300 = getelementptr inbounds i8, i8* %299, i64 14
   %301 = load i8*, i8** %arg1
   %302 = getelementptr inbounds i8, i8* %301, i64 14
-  %NullCheck20 = icmp ne i8* %302, null
-  br i1 %NullCheck20, label %303, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i8* %302, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %303
 
 ; <label>:303                                     ; preds = %298
   %304 = load i8, i8* %302, align 8
   %305 = zext i8 %304 to i32
   %306 = trunc i32 %305 to i8
-  %NullCheck22 = icmp ne i8* %300, null
-  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i8* %300, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %307
 
 ; <label>:307                                     ; preds = %303
   store i8 %306, i8* %300, align 8
@@ -1235,14 +1317,14 @@ entry:
   %309 = load i8*, i8** %arg0
   %310 = load i8*, i8** %arg1
   %311 = bitcast i8* %310 to i64*
-  %NullCheck = icmp ne i64* %311, null
-  br i1 %NullCheck, label %312, label %ThrowNullRef
+  %NullCheck = icmp eq i64* %311, null
+  br i1 %NullCheck, label %ThrowNullRef, label %312
 
 ; <label>:312                                     ; preds = %308
   %313 = load i64, i64* %311, align 8
   %314 = bitcast i8* %309 to i64*
-  %NullCheck2 = icmp ne i64* %314, null
-  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64* %314, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %315
 
 ; <label>:315                                     ; preds = %312
   store i64 %313, i64* %314, align 8
@@ -1251,14 +1333,14 @@ entry:
   %318 = load i8*, i8** %arg1
   %319 = getelementptr inbounds i8, i8* %318, i64 8
   %320 = bitcast i8* %319 to i64*
-  %NullCheck4 = icmp ne i64* %320, null
-  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64* %320, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %321
 
 ; <label>:321                                     ; preds = %315
   %322 = load i64, i64* %320, align 8
   %323 = bitcast i8* %317 to i64*
-  %NullCheck6 = icmp ne i64* %323, null
-  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64* %323, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %324
 
 ; <label>:324                                     ; preds = %321
   store i64 %322, i64* %323, align 8
@@ -1286,15 +1368,15 @@ entry:
 ; <label>:338                                     ; preds = %333
   %339 = load i8*, i8** %arg0
   %340 = load i8*, i8** %arg1
-  %NullCheck136 = icmp ne i8* %340, null
-  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+  %NullCheck135 = icmp eq i8* %340, null
+  br i1 %NullCheck135, label %ThrowNullRef136, label %341
 
 ; <label>:341                                     ; preds = %338
   %342 = load i8, i8* %340, align 8
   %343 = zext i8 %342 to i32
   %344 = trunc i32 %343 to i8
-  %NullCheck138 = icmp ne i8* %339, null
-  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+  %NullCheck137 = icmp eq i8* %339, null
+  br i1 %NullCheck137, label %ThrowNullRef138, label %345
 
 ; <label>:345                                     ; preds = %341
   store i8 %344, i8* %339, align 8
@@ -1317,16 +1399,16 @@ entry:
   %357 = load i8*, i8** %arg0
   %358 = load i8*, i8** %arg1
   %359 = bitcast i8* %358 to i16*
-  %NullCheck140 = icmp ne i16* %359, null
-  br i1 %NullCheck140, label %360, label %ThrowNullRef139
+  %NullCheck139 = icmp eq i16* %359, null
+  br i1 %NullCheck139, label %ThrowNullRef140, label %360
 
 ; <label>:360                                     ; preds = %356
   %361 = load i16, i16* %359, align 8
   %362 = sext i16 %361 to i32
   %363 = bitcast i8* %357 to i16*
   %364 = trunc i32 %362 to i16
-  %NullCheck142 = icmp ne i16* %363, null
-  br i1 %NullCheck142, label %365, label %ThrowNullRef141
+  %NullCheck141 = icmp eq i16* %363, null
+  br i1 %NullCheck141, label %ThrowNullRef142, label %365
 
 ; <label>:365                                     ; preds = %360
   store i16 %364, i16* %363, align 8
@@ -1352,14 +1434,14 @@ entry:
   %378 = load i8*, i8** %arg0
   %379 = load i8*, i8** %arg1
   %380 = bitcast i8* %379 to i32*
-  %NullCheck144 = icmp ne i32* %380, null
-  br i1 %NullCheck144, label %381, label %ThrowNullRef143
+  %NullCheck143 = icmp eq i32* %380, null
+  br i1 %NullCheck143, label %ThrowNullRef144, label %381
 
 ; <label>:381                                     ; preds = %377
   %382 = load i32, i32* %380, align 8
   %383 = bitcast i8* %378 to i32*
-  %NullCheck146 = icmp ne i32* %383, null
-  br i1 %NullCheck146, label %384, label %ThrowNullRef145
+  %NullCheck145 = icmp eq i32* %383, null
+  br i1 %NullCheck145, label %ThrowNullRef146, label %384
 
 ; <label>:384                                     ; preds = %381
   store i32 %382, i32* %383, align 8
@@ -1384,14 +1466,14 @@ entry:
   %395 = load i8*, i8** %arg0
   %396 = load i8*, i8** %arg1
   %397 = bitcast i8* %396 to i64*
-  %NullCheck164 = icmp ne i64* %397, null
-  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+  %NullCheck163 = icmp eq i64* %397, null
+  br i1 %NullCheck163, label %ThrowNullRef164, label %398
 
 ; <label>:398                                     ; preds = %394
   %399 = load i64, i64* %397, align 8
   %400 = bitcast i8* %395 to i64*
-  %NullCheck166 = icmp ne i64* %400, null
-  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+  %NullCheck165 = icmp eq i64* %400, null
+  br i1 %NullCheck165, label %ThrowNullRef166, label %401
 
 ; <label>:401                                     ; preds = %398
   store i64 %399, i64* %400, align 8
@@ -1400,14 +1482,14 @@ entry:
   %404 = load i8*, i8** %arg1
   %405 = getelementptr inbounds i8, i8* %404, i64 8
   %406 = bitcast i8* %405 to i64*
-  %NullCheck168 = icmp ne i64* %406, null
-  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+  %NullCheck167 = icmp eq i64* %406, null
+  br i1 %NullCheck167, label %ThrowNullRef168, label %407
 
 ; <label>:407                                     ; preds = %401
   %408 = load i64, i64* %406, align 8
   %409 = bitcast i8* %403 to i64*
-  %NullCheck170 = icmp ne i64* %409, null
-  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+  %NullCheck169 = icmp eq i64* %409, null
+  br i1 %NullCheck169, label %ThrowNullRef170, label %410
 
 ; <label>:410                                     ; preds = %407
   store i64 %408, i64* %409, align 8
@@ -1437,14 +1519,14 @@ entry:
   %425 = load i8*, i8** %arg0
   %426 = load i8*, i8** %arg1
   %427 = bitcast i8* %426 to i64*
-  %NullCheck148 = icmp ne i64* %427, null
-  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+  %NullCheck147 = icmp eq i64* %427, null
+  br i1 %NullCheck147, label %ThrowNullRef148, label %428
 
 ; <label>:428                                     ; preds = %424
   %429 = load i64, i64* %427, align 8
   %430 = bitcast i8* %425 to i64*
-  %NullCheck150 = icmp ne i64* %430, null
-  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+  %NullCheck149 = icmp eq i64* %430, null
+  br i1 %NullCheck149, label %ThrowNullRef150, label %431
 
 ; <label>:431                                     ; preds = %428
   store i64 %429, i64* %430, align 8
@@ -1466,14 +1548,14 @@ entry:
   %441 = load i8*, i8** %arg0
   %442 = load i8*, i8** %arg1
   %443 = bitcast i8* %442 to i32*
-  %NullCheck152 = icmp ne i32* %443, null
-  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+  %NullCheck151 = icmp eq i32* %443, null
+  br i1 %NullCheck151, label %ThrowNullRef152, label %444
 
 ; <label>:444                                     ; preds = %440
   %445 = load i32, i32* %443, align 8
   %446 = bitcast i8* %441 to i32*
-  %NullCheck154 = icmp ne i32* %446, null
-  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+  %NullCheck153 = icmp eq i32* %446, null
+  br i1 %NullCheck153, label %ThrowNullRef154, label %447
 
 ; <label>:447                                     ; preds = %444
   store i32 %445, i32* %446, align 8
@@ -1495,16 +1577,16 @@ entry:
   %457 = load i8*, i8** %arg0
   %458 = load i8*, i8** %arg1
   %459 = bitcast i8* %458 to i16*
-  %NullCheck156 = icmp ne i16* %459, null
-  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+  %NullCheck155 = icmp eq i16* %459, null
+  br i1 %NullCheck155, label %ThrowNullRef156, label %460
 
 ; <label>:460                                     ; preds = %456
   %461 = load i16, i16* %459, align 8
   %462 = sext i16 %461 to i32
   %463 = bitcast i8* %457 to i16*
   %464 = trunc i32 %462 to i16
-  %NullCheck158 = icmp ne i16* %463, null
-  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+  %NullCheck157 = icmp eq i16* %463, null
+  br i1 %NullCheck157, label %ThrowNullRef158, label %465
 
 ; <label>:465                                     ; preds = %460
   store i16 %464, i16* %463, align 8
@@ -1525,15 +1607,15 @@ entry:
 ; <label>:474                                     ; preds = %470
   %475 = load i8*, i8** %arg0
   %476 = load i8*, i8** %arg1
-  %NullCheck160 = icmp ne i8* %476, null
-  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+  %NullCheck159 = icmp eq i8* %476, null
+  br i1 %NullCheck159, label %ThrowNullRef160, label %477
 
 ; <label>:477                                     ; preds = %474
   %478 = load i8, i8* %476, align 8
   %479 = zext i8 %478 to i32
   %480 = trunc i32 %479 to i8
-  %NullCheck162 = icmp ne i8* %475, null
-  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+  %NullCheck161 = icmp eq i8* %475, null
+  br i1 %NullCheck161, label %ThrowNullRef162, label %481
 
 ; <label>:481                                     ; preds = %477
   store i8 %480, i8* %475, align 8
@@ -1553,343 +1635,343 @@ ThrowNullRef:                                     ; preds = %308
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %312
+ThrowNullRef2:                                    ; preds = %312
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %315
+ThrowNullRef4:                                    ; preds = %315
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %321
+ThrowNullRef6:                                    ; preds = %321
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %271
+ThrowNullRef8:                                    ; preds = %271
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %275
+ThrowNullRef10:                                   ; preds = %275
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %278
+ThrowNullRef12:                                   ; preds = %278
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %284
+ThrowNullRef14:                                   ; preds = %284
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %287
+ThrowNullRef16:                                   ; preds = %287
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %293
+ThrowNullRef18:                                   ; preds = %293
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %298
+ThrowNullRef20:                                   ; preds = %298
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %303
+ThrowNullRef22:                                   ; preds = %303
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %243
+ThrowNullRef24:                                   ; preds = %243
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %247
+ThrowNullRef26:                                   ; preds = %247
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %250
+ThrowNullRef28:                                   ; preds = %250
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %256
+ThrowNullRef30:                                   ; preds = %256
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %259
+ThrowNullRef32:                                   ; preds = %259
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %265
+ThrowNullRef34:                                   ; preds = %265
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %217
+ThrowNullRef36:                                   ; preds = %217
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %221
+ThrowNullRef38:                                   ; preds = %221
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %224
+ThrowNullRef40:                                   ; preds = %224
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %230
+ThrowNullRef42:                                   ; preds = %230
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %233
+ThrowNullRef44:                                   ; preds = %233
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %238
+ThrowNullRef46:                                   ; preds = %238
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %200
+ThrowNullRef48:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %204
+ThrowNullRef50:                                   ; preds = %204
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %207
+ThrowNullRef52:                                   ; preds = %207
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %213
+ThrowNullRef54:                                   ; preds = %213
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %172
+ThrowNullRef56:                                   ; preds = %172
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %176
+ThrowNullRef58:                                   ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %179
+ThrowNullRef60:                                   ; preds = %179
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %185
+ThrowNullRef62:                                   ; preds = %185
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %190
+ThrowNullRef64:                                   ; preds = %190
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %195
+ThrowNullRef66:                                   ; preds = %195
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %153
+ThrowNullRef68:                                   ; preds = %153
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %157
+ThrowNullRef70:                                   ; preds = %157
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %160
+ThrowNullRef72:                                   ; preds = %160
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %166
+ThrowNullRef74:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %136
+ThrowNullRef76:                                   ; preds = %136
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %140
+ThrowNullRef78:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %143
+ThrowNullRef80:                                   ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %148
+ThrowNullRef82:                                   ; preds = %148
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %128
+ThrowNullRef84:                                   ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %132
+ThrowNullRef86:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %100
+ThrowNullRef88:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %104
+ThrowNullRef90:                                   ; preds = %104
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %107
+ThrowNullRef92:                                   ; preds = %107
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %113
+ThrowNullRef94:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %118
+ThrowNullRef96:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %123
+ThrowNullRef98:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %81
+ThrowNullRef100:                                  ; preds = %81
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef101:                                  ; preds = %85
+ThrowNullRef102:                                  ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef103:                                  ; preds = %88
+ThrowNullRef104:                                  ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef105:                                  ; preds = %94
+ThrowNullRef106:                                  ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef107:                                  ; preds = %64
+ThrowNullRef108:                                  ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef109:                                  ; preds = %68
+ThrowNullRef110:                                  ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef111:                                  ; preds = %71
+ThrowNullRef112:                                  ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef113:                                  ; preds = %76
+ThrowNullRef114:                                  ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef115:                                  ; preds = %56
+ThrowNullRef116:                                  ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef117:                                  ; preds = %60
+ThrowNullRef118:                                  ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef119:                                  ; preds = %37
+ThrowNullRef120:                                  ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef121:                                  ; preds = %41
+ThrowNullRef122:                                  ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef123:                                  ; preds = %46
+ThrowNullRef124:                                  ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef125:                                  ; preds = %51
+ThrowNullRef126:                                  ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef127:                                  ; preds = %27
+ThrowNullRef128:                                  ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef129:                                  ; preds = %31
+ThrowNullRef130:                                  ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef131:                                  ; preds = %19
+ThrowNullRef132:                                  ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef133:                                  ; preds = %22
+ThrowNullRef134:                                  ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef135:                                  ; preds = %338
+ThrowNullRef136:                                  ; preds = %338
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef137:                                  ; preds = %341
+ThrowNullRef138:                                  ; preds = %341
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef139:                                  ; preds = %356
+ThrowNullRef140:                                  ; preds = %356
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef141:                                  ; preds = %360
+ThrowNullRef142:                                  ; preds = %360
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef143:                                  ; preds = %377
+ThrowNullRef144:                                  ; preds = %377
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef145:                                  ; preds = %381
+ThrowNullRef146:                                  ; preds = %381
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef147:                                  ; preds = %424
+ThrowNullRef148:                                  ; preds = %424
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef149:                                  ; preds = %428
+ThrowNullRef150:                                  ; preds = %428
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef151:                                  ; preds = %440
+ThrowNullRef152:                                  ; preds = %440
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef153:                                  ; preds = %444
+ThrowNullRef154:                                  ; preds = %444
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef155:                                  ; preds = %456
+ThrowNullRef156:                                  ; preds = %456
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef157:                                  ; preds = %460
+ThrowNullRef158:                                  ; preds = %460
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef159:                                  ; preds = %474
+ThrowNullRef160:                                  ; preds = %474
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef161:                                  ; preds = %477
+ThrowNullRef162:                                  ; preds = %477
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef163:                                  ; preds = %394
+ThrowNullRef164:                                  ; preds = %394
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef165:                                  ; preds = %398
+ThrowNullRef166:                                  ; preds = %398
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef167:                                  ; preds = %401
+ThrowNullRef168:                                  ; preds = %401
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef169:                                  ; preds = %407
+ThrowNullRef170:                                  ; preds = %407
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1939,8 +2021,8 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
-  br i1 %NullCheck, label %22, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %ThrowNullRef, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
@@ -1948,8 +2030,8 @@ entry:
   store i32 %24, i32* %loc0
   %25 = load i32, i32* %loc0
   %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %26, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %27
 
 ; <label>:27                                      ; preds = %22
   %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
@@ -1971,7 +2053,7 @@ ThrowNullRef:                                     ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1989,8 +2071,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -2022,15 +2104,15 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2048,16 +2130,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
   %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
   store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %15
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
@@ -2072,8 +2154,8 @@ entry:
   %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
   %29 = ptrtoint i16 addrspace(1)* %28 to i64
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %19
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
@@ -2089,19 +2171,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2114,8 +2196,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
@@ -2128,7 +2210,7 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[loadElem]
+Failed to read AppDomain.PrepareDataForSetup[storeElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
@@ -2202,8 +2284,8 @@ entry:
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
-  br i1 %NullCheck24, label %27, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = load i64, i64 addrspace(1)* %26
@@ -2218,8 +2300,8 @@ entry:
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
-  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
   %41 = load i64, i64 addrspace(1)* %39
@@ -2236,8 +2318,8 @@ entry:
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
-  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
   %54 = load i64, i64 addrspace(1)* %52
@@ -2252,8 +2334,8 @@ entry:
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
   %67 = load i64, i64 addrspace(1)* %65
@@ -2270,8 +2352,8 @@ entry:
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
-  br i1 %NullCheck16, label %79, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
   %80 = load i64, i64 addrspace(1)* %78
@@ -2286,8 +2368,8 @@ entry:
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
-  br i1 %NullCheck18, label %92, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
   %93 = load i64, i64 addrspace(1)* %91
@@ -2304,8 +2386,8 @@ entry:
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
-  br i1 %NullCheck12, label %105, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = load i64, i64 addrspace(1)* %104
@@ -2320,8 +2402,8 @@ entry:
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
-  br i1 %NullCheck14, label %118, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
   %119 = load i64, i64 addrspace(1)* %117
@@ -2337,8 +2419,8 @@ entry:
 
 ; <label>:128                                     ; preds = %20
   %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
-  br i1 %NullCheck4, label %130, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %129, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %130
 
 ; <label>:130                                     ; preds = %128
   %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
@@ -2346,8 +2428,8 @@ entry:
   %133 = load i16, i16 addrspace(1)* %132, align 8
   %134 = zext i16 %133 to i32
   %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
-  br i1 %NullCheck6, label %136, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %135, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %136
 
 ; <label>:136                                     ; preds = %130
   %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
@@ -2360,8 +2442,8 @@ entry:
 
 ; <label>:143                                     ; preds = %136
   %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
-  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %144, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %145
 
 ; <label>:145                                     ; preds = %143
   %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
@@ -2369,8 +2451,8 @@ entry:
   %148 = load i16, i16 addrspace(1)* %147, align 8
   %149 = zext i16 %148 to i32
   %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %150, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %151
 
 ; <label>:151                                     ; preds = %145
   %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
@@ -2388,8 +2470,8 @@ entry:
 
 ; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
-  br i1 %NullCheck, label %163, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %ThrowNullRef, label %163
 
 ; <label>:163                                     ; preds = %161
   %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
@@ -2399,8 +2481,8 @@ entry:
 
 ; <label>:167                                     ; preds = %163
   %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
-  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %168, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %169
 
 ; <label>:169                                     ; preds = %167
   %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
@@ -2432,55 +2514,55 @@ ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %167
+ThrowNullRef2:                                    ; preds = %167
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %128
+ThrowNullRef4:                                    ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %130
+ThrowNullRef6:                                    ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %143
+ThrowNullRef8:                                    ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %145
+ThrowNullRef10:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %102
+ThrowNullRef12:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %105
+ThrowNullRef14:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %76
+ThrowNullRef16:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %79
+ThrowNullRef18:                                   ; preds = %79
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %50
+ThrowNullRef20:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %53
+ThrowNullRef22:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %24
+ThrowNullRef24:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %27
+ThrowNullRef26:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2503,15 +2585,15 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2519,16 +2601,16 @@ entry:
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
   store i32 %8, i32* %loc0
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
   %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
   store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
@@ -2546,16 +2628,16 @@ entry:
 
 ; <label>:23                                      ; preds = %64
   %24 = load i16*, i16** %loc3
-  %NullCheck12 = icmp ne i16* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i16* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
   store i32 %27, i32* %loc5
   %28 = load i16*, i16** %loc4
-  %NullCheck14 = icmp ne i16* %28, null
-  br i1 %NullCheck14, label %29, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %28, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = load i16, i16* %28, align 8
@@ -2620,15 +2702,15 @@ entry:
 
 ; <label>:67                                      ; preds = %64
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
-  br i1 %NullCheck8, label %69, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %68, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %69
 
 ; <label>:69                                      ; preds = %67
   %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
   %71 = load i32, i32 addrspace(1)* %70
   %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
-  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %73
 
 ; <label>:73                                      ; preds = %69
   %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
@@ -2645,31 +2727,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %67
+ThrowNullRef8:                                    ; preds = %67
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %69
+ThrowNullRef10:                                   ; preds = %69
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2710,14 +2792,14 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
   %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
@@ -2730,14 +2812,14 @@ entry:
 
 ; <label>:11                                      ; preds = %4
   %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
   %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
@@ -2749,14 +2831,14 @@ entry:
 
 ; <label>:22                                      ; preds = %16
   %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
   %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
-  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
-  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
@@ -2804,23 +2886,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2836,7 +2918,280 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[loadElem]
+Successfully read RuntimeType.IsAssignableFrom
+
+define i8 @RuntimeType.IsAssignableFrom(%System.RuntimeType addrspace(1)* %param0, %System.Type addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.RuntimeType addrspace(1)*
+  %arg1 = alloca %System.Type addrspace(1)*
+  %loc0 = alloca %System.RuntimeType addrspace(1)*
+  %loc1 = alloca %"System.Type[]" addrspace(1)*
+  %loc2 = alloca i32
+  store %System.RuntimeType addrspace(1)* %param0, %System.RuntimeType addrspace(1)** %this
+  store %System.Type addrspace(1)* %param1, %System.Type addrspace(1)** %arg1
+  %0 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %1 = icmp ne %System.Type addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i8 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %5 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %6 = bitcast %System.Type addrspace(1)* %4 to %System.Object addrspace(1)*
+  %7 = bitcast %System.RuntimeType addrspace(1)* %5 to %System.Object addrspace(1)*
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %6, %System.Object addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %3
+  ret i8 1
+
+; <label>:12                                      ; preds = %3
+  %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 152
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 32
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
+  %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
+  %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
+  store %System.RuntimeType addrspace(1)* %25, %System.RuntimeType addrspace(1)** %loc0
+  %26 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %27 = icmp eq %System.RuntimeType addrspace(1)* %26, null
+  br i1 %27, label %34, label %28
+
+; <label>:28                                      ; preds = %15
+  %29 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %30 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)*)*)(%System.RuntimeType addrspace(1)* %29, %System.RuntimeType addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+; <label>:34                                      ; preds = %15
+  %35 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %36 = call %System.Reflection.Emit.TypeBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Reflection.Emit.TypeBuilder addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %35)
+  %37 = icmp eq %System.Reflection.Emit.TypeBuilder addrspace(1)* %36, null
+  br i1 %37, label %139, label %38
+
+; <label>:38                                      ; preds = %34
+  %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %42
+
+; <label>:42                                      ; preds = %38
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 152
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 40
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
+  %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
+  %53 = zext i8 %52 to i32
+  %54 = icmp eq i32 %53, 0
+  br i1 %54, label %56, label %55
+
+; <label>:55                                      ; preds = %42
+  ret i8 1
+
+; <label>:56                                      ; preds = %42
+  %57 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %58 = bitcast %System.RuntimeType addrspace(1)* %57 to %System.Type addrspace(1)*
+  %59 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %58)
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %64 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.Type addrspace(1)* %63, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = bitcast %System.RuntimeType addrspace(1)* %64 to %System.Type addrspace(1)*
+  %67 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %63, %System.Type addrspace(1)* %66)
+  %68 = zext i8 %67 to i32
+  %69 = trunc i32 %68 to i8
+  ret i8 %69
+
+; <label>:70                                      ; preds = %56
+  %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
+  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %73
+
+; <label>:73                                      ; preds = %70
+  %74 = load i64, i64 addrspace(1)* %72
+  %75 = add i64 %74, 128
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = add i64 %77, 0
+  %79 = inttoptr i64 %78 to i64*
+  %80 = load i64, i64* %79
+  %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
+  %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
+  %83 = call i8 %82(%System.Type addrspace(1)* %81)
+  %84 = zext i8 %83 to i32
+  %85 = icmp eq i32 %84, 0
+  br i1 %85, label %139, label %86
+
+; <label>:86                                      ; preds = %73
+  %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
+  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %89
+
+; <label>:89                                      ; preds = %86
+  %90 = load i64, i64 addrspace(1)* %88
+  %91 = add i64 %90, 128
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = add i64 %93, 24
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
+  %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
+  %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
+  store %"System.Type[]" addrspace(1)* %99, %"System.Type[]" addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %129
+
+; <label>:100                                     ; preds = %132
+  %101 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %102 = load i32, i32* %loc2
+  %NullCheck11 = icmp eq %"System.Type[]" addrspace(1)* %101, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %103
+
+; <label>:103                                     ; preds = %100
+  %104 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 1
+  %105 = load i32, i32 addrspace(1)* %104
+  %106 = zext i32 %105 to i64
+  %107 = zext i32 %102 to i64
+  %BoundsCheck = icmp uge i64 %107, %106
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %108
+
+; <label>:108                                     ; preds = %103
+  %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
+  %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
+  %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
+  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %113
+
+; <label>:113                                     ; preds = %108
+  %114 = load i64, i64 addrspace(1)* %112
+  %115 = add i64 %114, 152
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = add i64 %117, 56
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
+  %123 = zext i8 %122 to i32
+  %124 = icmp ne i32 %123, 0
+  br i1 %124, label %126, label %125
+
+; <label>:125                                     ; preds = %113
+  ret i8 0
+
+; <label>:126                                     ; preds = %113
+  %127 = load i32, i32* %loc2
+  %128 = add i32 %127, 1
+  store i32 %128, i32* %loc2
+  br label %129
+
+; <label>:129                                     ; preds = %89, %126
+  %130 = load i32, i32* %loc2
+  %131 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %NullCheck9 = icmp eq %"System.Type[]" addrspace(1)* %131, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %132
+
+; <label>:132                                     ; preds = %129
+  %133 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %131, i32 0, i32 1
+  %134 = load i32, i32 addrspace(1)* %133
+  %135 = zext i32 %134 to i64
+  %136 = trunc i64 %135 to i32
+  %137 = icmp slt i32 %130, %136
+  br i1 %137, label %100, label %138
+
+; <label>:138                                     ; preds = %132
+  ret i8 1
+
+; <label>:139                                     ; preds = %34, %73
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %129
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %103
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -2893,7 +3248,7 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElem]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -2904,8 +3259,8 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -2997,8 +3352,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
@@ -3059,8 +3414,8 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -3087,8 +3442,8 @@ entry:
 
 ; <label>:17                                      ; preds = %5, %11
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
@@ -3097,8 +3452,8 @@ entry:
 
 ; <label>:22                                      ; preds = %1, %11
   %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
@@ -3109,11 +3464,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %17
+ThrowNullRef2:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %22
+ThrowNullRef4:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3167,15 +3522,15 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
   %15 = load i32, i32 addrspace(1)* %14
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
@@ -3198,7 +3553,7 @@ ThrowNullRef:                                     ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef2:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3232,8 +3587,8 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
@@ -3312,8 +3667,8 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -3327,8 +3682,8 @@ entry:
 ; <label>:5                                       ; preds = %43
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %7 = load i32, i32* %loc1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck6, label %8, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
@@ -3366,8 +3721,8 @@ entry:
 ; <label>:32                                      ; preds = %21, %25
   %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
   %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
-  br i1 %NullCheck8, label %35, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = trunc i32 %34 to i16
@@ -3380,8 +3735,8 @@ entry:
 ; <label>:40                                      ; preds = %1, %35
   %41 = load i32, i32* %loc1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
-  br i1 %NullCheck2, label %43, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %42, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
@@ -3392,8 +3747,8 @@ entry:
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
   %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
-  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
   %51 = load i64, i64 addrspace(1)* %49
@@ -3412,19 +3767,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %40
+ThrowNullRef2:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %47
+ThrowNullRef4:                                    ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %5
+ThrowNullRef6:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %32
+ThrowNullRef8:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3467,8 +3822,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
@@ -3492,11 +3847,391 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(i16* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store i16* %param0, i16** %arg0
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load i32, i32* %arg3
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %42, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %37, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg2
+  %13 = load i32, i32* %arg3
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %37, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %24 = load i32, i32* %arg2
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load i16*, i16** %arg0
+  %35 = load i32, i32* %arg3
+  %36 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %36, i16* %34, i32 %35)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:37                                      ; preds = %5, %16
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %39)
+  %41 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41, %System.String addrspace(1)* %38, %System.String addrspace(1)* %40)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41) #0
+  unreachable
+
+; <label>:42                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
-Failed to read StringBuilder.ToString[loadElemA]
+Successfully read StringBuilder.ToString
+
+define %System.String addrspace(1)* @StringBuilder.ToString(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i16*
+  %loc3 = alloca %"System.Char[]" addrspace(1)*
+  %loc4 = alloca i32
+  %loc5 = alloca i32
+  %loc6 = alloca i16 addrspace(1)*
+  %loc7 = alloca %System.String addrspace(1)*
+  %loc8 = alloca %"System.Char[]" addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %0)
+  %2 = icmp ne i32 %1, 0
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %4
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %6)
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %7)
+  store %System.String addrspace(1)* %8, %System.String addrspace(1)** %loc0
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.Text.StringBuilder addrspace(1)* %9, %System.Text.StringBuilder addrspace(1)** %loc1
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  store %System.String addrspace(1)* %10, %System.String addrspace(1)** %loc7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc7
+  %12 = ptrtoint %System.String addrspace(1)* %11 to i64
+  %13 = icmp eq i64 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %5
+  %15 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %16 = sext i32 %15 to i64
+  %17 = add i64 %12, %16
+  br label %18
+
+; <label>:18                                      ; preds = %5, %14
+  %19 = phi i64 [ %12, %5 ], [ %17, %14 ]
+  %20 = inttoptr i64 %19 to i16*
+  store i16* %20, i16** %loc2
+  br label %21
+
+; <label>:21                                      ; preds = %98, %18
+  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %22, null
+  br i1 %NullCheck, label %ThrowNullRef, label %23
+
+; <label>:23                                      ; preds = %21
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 3
+  %25 = load i32, i32 addrspace(1)* %24, align 8
+  %26 = icmp sle i32 %25, 0
+  br i1 %26, label %96, label %27
+
+; <label>:27                                      ; preds = %23
+  %28 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %28, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %29
+
+; <label>:29                                      ; preds = %27
+  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %28, i32 0, i32 1
+  %31 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %30, align 8
+  store %"System.Char[]" addrspace(1)* %31, %"System.Char[]" addrspace(1)** %loc3
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %33
+
+; <label>:33                                      ; preds = %29
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  store i32 %35, i32* %loc4
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  %39 = load i32, i32 addrspace(1)* %38, align 8
+  store i32 %39, i32* %loc5
+  %40 = load i32, i32* %loc5
+  %41 = load i32, i32* %loc4
+  %42 = add i32 %40, %41
+  %43 = zext i32 %42 to i64
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %45
+
+; <label>:45                                      ; preds = %37
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = sext i32 %47 to i64
+  %49 = icmp sgt i64 %43, %48
+  br i1 %49, label %91, label %50
+
+; <label>:50                                      ; preds = %45
+  %51 = load i32, i32* %loc5
+  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %52, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %53
+
+; <label>:53                                      ; preds = %50
+  %54 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %52, i32 0, i32 1
+  %55 = load i32, i32 addrspace(1)* %54
+  %56 = zext i32 %55 to i64
+  %57 = trunc i64 %56 to i32
+  %58 = icmp ugt i32 %51, %57
+  br i1 %58, label %91, label %59
+
+; <label>:59                                      ; preds = %53
+  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  store %"System.Char[]" addrspace(1)* %60, %"System.Char[]" addrspace(1)** %loc8
+  %61 = icmp eq %"System.Char[]" addrspace(1)* %60, null
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %63, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %64
+
+; <label>:64                                      ; preds = %62
+  %65 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %63, i32 0, i32 1
+  %66 = load i32, i32 addrspace(1)* %65
+  %67 = zext i32 %66 to i64
+  %68 = trunc i64 %67 to i32
+  %69 = icmp ne i32 %68, 0
+  br i1 %69, label %71, label %70
+
+; <label>:70                                      ; preds = %59, %64
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:71                                      ; preds = %64
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %73
+
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %BoundsCheck = icmp uge i64 0, %76
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %77
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %78, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:79                                      ; preds = %70, %77
+  %80 = load i16*, i16** %loc2
+  %81 = load i32, i32* %loc4
+  %82 = sext i32 %81 to i64
+  %83 = mul i64 %82, 2
+  %84 = bitcast i16* %80 to i8*
+  %85 = getelementptr inbounds i8, i8* %84, i64 %83
+  %86 = load i16 addrspace(1)*, i16 addrspace(1)** %loc6
+  %87 = ptrtoint i16 addrspace(1)* %86 to i64
+  %88 = load i32, i32* %loc5
+  %89 = bitcast i8* %85 to i16*
+  %90 = inttoptr i64 %87 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %89, i16* %90, i32 %88)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %96
+
+; <label>:91                                      ; preds = %45, %53
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %94 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %93)
+  %95 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95, %System.String addrspace(1)* %92, %System.String addrspace(1)* %94)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95) #0
+  unreachable
+
+; <label>:96                                      ; preds = %23, %79
+  %97 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %97, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %98
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %97, i32 0, i32 2
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  store %System.Text.StringBuilder addrspace(1)* %100, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %102 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %102, label %21, label %103
+
+; <label>:103                                     ; preds = %98
+  store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc7
+  %104 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  ret %System.String addrspace(1)* %104
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method StringBuilder::get_Length using LLILCJit
+Successfully read StringBuilder.get_Length
+
+define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
+Successfully read RuntimeHelpers.get_OffsetToStringData
+
+define i32 @RuntimeHelpers.get_OffsetToStringData() {
+entry:
+  ret i32 12
+}
+
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
 Successfully read CultureData.CreateCultureData
 
@@ -3514,23 +4249,23 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
   store i8 %4, i8 addrspace(1)* %6
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
@@ -3549,11 +4284,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3566,50 +4301,50 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
   store i32 -1, i32 addrspace(1)* %2
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
   store i32 -1, i32 addrspace(1)* %8
   %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
   store i32 -1, i32 addrspace(1)* %14
   %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
   store i32 -1, i32 addrspace(1)* %17
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
@@ -3623,27 +4358,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3675,7 +4410,136 @@ Failed to read Dictionary`2.Insert[non-const derefAddress]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
 Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
-Failed to read HashHelpers.GetPrime[loadElem]
+Successfully read HashHelpers.GetPrime
+
+define i32 @HashHelpers.GetPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %6, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5, %System.String addrspace(1)* %4)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5) #0
+  unreachable
+
+; <label>:6                                       ; preds = %entry
+  store i32 0, i32* %loc0
+  br label %29
+
+; <label>:7                                       ; preds = %35
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 1296
+  %10 = addrspacecast i8 addrspace(1)* %9 to %"System.Int32[]" addrspace(1)**
+  %11 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %10
+  %12 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Int32[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = zext i32 %15 to i64
+  %17 = zext i32 %12 to i64
+  %BoundsCheck = icmp uge i64 %17, %16
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 3, i32 %12
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  store i32 %20, i32* %loc1
+  %21 = load i32, i32* %loc1
+  %22 = load i32, i32* %arg0
+  %23 = icmp slt i32 %21, %22
+  br i1 %23, label %26, label %24
+
+; <label>:24                                      ; preds = %18
+  %25 = load i32, i32* %loc1
+  ret i32 %25
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %loc0
+  %28 = add i32 %27, 1
+  store i32 %28, i32* %loc0
+  br label %29
+
+; <label>:29                                      ; preds = %6, %26
+  %30 = load i32, i32* %loc0
+  %31 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %32 = getelementptr inbounds i8, i8 addrspace(1)* %31, i64 1296
+  %33 = addrspacecast i8 addrspace(1)* %32 to %"System.Int32[]" addrspace(1)**
+  %34 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %33
+  %NullCheck = icmp eq %"System.Int32[]" addrspace(1)* %34, null
+  br i1 %NullCheck, label %ThrowNullRef, label %35
+
+; <label>:35                                      ; preds = %29
+  %36 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %34, i32 0, i32 1
+  %37 = load i32, i32 addrspace(1)* %36
+  %38 = zext i32 %37 to i64
+  %39 = trunc i64 %38 to i32
+  %40 = icmp slt i32 %30, %39
+  br i1 %40, label %7, label %41
+
+; <label>:41                                      ; preds = %35
+  %42 = load i32, i32* %arg0
+  %43 = or i32 %42, 1
+  store i32 %43, i32* %loc2
+  br label %59
+
+; <label>:44                                      ; preds = %59
+  %45 = load i32, i32* %loc2
+  %46 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %45)
+  %47 = zext i8 %46 to i32
+  %48 = icmp eq i32 %47, 0
+  br i1 %48, label %56, label %49
+
+; <label>:49                                      ; preds = %44
+  %50 = load i32, i32* %loc2
+  %51 = sub i32 %50, 1
+  %52 = srem i32 %51, 101
+  %53 = icmp eq i32 %52, 0
+  br i1 %53, label %56, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = load i32, i32* %loc2
+  ret i32 %55
+
+; <label>:56                                      ; preds = %44, %49
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %57, 2
+  store i32 %58, i32* %loc2
+  br label %59
+
+; <label>:59                                      ; preds = %41, %56
+  %60 = load i32, i32* %loc2
+  %61 = icmp slt i32 %60, 2147483647
+  br i1 %61, label %44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load i32, i32* %arg0
+  ret i32 %63
+
+ThrowNullRef:                                     ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
 Successfully read GenericEqualityComparer`1.GetHashCode
 
@@ -3694,14 +4558,14 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
   %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load i64, i64 addrspace(1)* %7
@@ -3720,7 +4584,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3750,8 +4614,8 @@ entry:
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
@@ -3796,8 +4660,8 @@ entry:
   %35 = bitcast i16* %34 to i8*
   %36 = getelementptr inbounds i8, i8* %35, i64 2
   %37 = bitcast i8* %36 to i16*
-  %NullCheck4 = icmp ne i16* %37, null
-  br i1 %NullCheck4, label %38, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %37, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %38
 
 ; <label>:38                                      ; preds = %27
   %39 = load i16, i16* %37, align 8
@@ -3824,8 +4688,8 @@ entry:
 
 ; <label>:54                                      ; preds = %22, %43
   %55 = load i16*, i16** %loc4
-  %NullCheck2 = icmp ne i16* %55, null
-  br i1 %NullCheck2, label %56, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i16* %55, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %56
 
 ; <label>:56                                      ; preds = %54
   %57 = load i16, i16* %55, align 8
@@ -3850,11 +4714,11 @@ ThrowNullRef:                                     ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %54
+ThrowNullRef2:                                    ; preds = %54
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %27
+ThrowNullRef4:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3871,8 +4735,8 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -3907,8 +4771,8 @@ entry:
 
 ; <label>:26                                      ; preds = %19
   %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
-  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %28
 
 ; <label>:28                                      ; preds = %26
   %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
@@ -3920,7 +4784,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3972,8 +4836,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
@@ -3984,26 +4848,26 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
-  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
@@ -4014,8 +4878,8 @@ entry:
 ; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
@@ -4024,8 +4888,8 @@ entry:
 
 ; <label>:25                                      ; preds = %1, %16, %23
   %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
-  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
@@ -4036,27 +4900,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %20
+ThrowNullRef10:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4069,8 +4933,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -4081,8 +4945,8 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
@@ -4091,8 +4955,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1, %8
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
@@ -4103,11 +4967,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4128,24 +4992,24 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   store i32 %3, i32* %loc0
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
   %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
   store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck4, label %9, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
@@ -4164,15 +5028,15 @@ entry:
 ; <label>:18                                      ; preds = %70
   %19 = load i16*, i16** %loc3
   %20 = bitcast i16* %19 to i64*
-  %NullCheck10 = icmp ne i64* %20, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %20, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = load i64, i64* %20, align 8
   %23 = load i16*, i16** %loc4
   %24 = bitcast i16* %23 to i64*
-  %NullCheck12 = icmp ne i64* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = load i64, i64* %24, align 8
@@ -4188,8 +5052,8 @@ entry:
   %31 = bitcast i16* %30 to i8*
   %32 = getelementptr inbounds i8, i8* %31, i64 8
   %33 = bitcast i8* %32 to i64*
-  %NullCheck14 = icmp ne i64* %33, null
-  br i1 %NullCheck14, label %34, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = load i64, i64* %33, align 8
@@ -4197,8 +5061,8 @@ entry:
   %37 = bitcast i16* %36 to i8*
   %38 = getelementptr inbounds i8, i8* %37, i64 8
   %39 = bitcast i8* %38 to i64*
-  %NullCheck16 = icmp ne i64* %39, null
-  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %40
 
 ; <label>:40                                      ; preds = %34
   %41 = load i64, i64* %39, align 8
@@ -4214,8 +5078,8 @@ entry:
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %NullCheck18 = icmp ne i64* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = load i64, i64* %48, align 8
@@ -4223,8 +5087,8 @@ entry:
   %52 = bitcast i16* %51 to i8*
   %53 = getelementptr inbounds i8, i8* %52, i64 16
   %54 = bitcast i8* %53 to i64*
-  %NullCheck20 = icmp ne i64* %54, null
-  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64* %54, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %55
 
 ; <label>:55                                      ; preds = %49
   %56 = load i64, i64* %54, align 8
@@ -4262,15 +5126,15 @@ entry:
 ; <label>:74                                      ; preds = %95
   %75 = load i16*, i16** %loc3
   %76 = bitcast i16* %75 to i32*
-  %NullCheck6 = icmp ne i32* %76, null
-  br i1 %NullCheck6, label %77, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32* %76, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %77
 
 ; <label>:77                                      ; preds = %74
   %78 = load i32, i32* %76, align 8
   %79 = load i16*, i16** %loc4
   %80 = bitcast i16* %79 to i32*
-  %NullCheck8 = icmp ne i32* %80, null
-  br i1 %NullCheck8, label %81, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i32* %80, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %81
 
 ; <label>:81                                      ; preds = %77
   %82 = load i32, i32* %80, align 8
@@ -4318,43 +5182,43 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %74
+ThrowNullRef6:                                    ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %77
+ThrowNullRef8:                                    ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %29
+ThrowNullRef14:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %34
+ThrowNullRef16:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4376,8 +5240,8 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load i64, i64 addrspace(1)* %4
@@ -4389,8 +5253,8 @@ entry:
   %12 = load i64, i64* %11
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %5
   %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
@@ -4399,8 +5263,8 @@ entry:
   %18 = load i8, i8* %arg2
   %19 = zext i8 %18 to i32
   %20 = trunc i32 %19 to i8
-  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %15
   %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
@@ -4411,11 +5275,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4442,8 +5306,8 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
@@ -4466,16 +5330,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
   %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = load i64, i64 addrspace(1)* %19
@@ -4500,8 +5364,8 @@ entry:
 ; <label>:35                                      ; preds = %30
   %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
@@ -4514,8 +5378,8 @@ entry:
 
 ; <label>:42                                      ; preds = %1, %38
   %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
-  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
@@ -4526,19 +5390,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %35
+ThrowNullRef2:                                    ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %42
+ThrowNullRef8:                                    ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4551,14 +5415,14 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
@@ -4570,7 +5434,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4583,8 +5447,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
@@ -4613,51 +5477,51 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
   %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
   %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
   %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
   %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
-  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
   store i64 %21, i64 addrspace(1)* %23
   %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %25 = load i64, i64* %loc0
-  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
@@ -4668,27 +5532,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %22
+ThrowNullRef12:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4701,8 +5565,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
@@ -4713,19 +5577,19 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
@@ -4734,8 +5598,8 @@ entry:
 
 ; <label>:15                                      ; preds = %1, %13
   %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
@@ -4746,19 +5610,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %15
+ThrowNullRef8:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4771,8 +5635,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -4831,8 +5695,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
@@ -4882,8 +5746,8 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
-  br i1 %NullCheck, label %17, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %ThrowNullRef, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
@@ -4894,15 +5758,15 @@ entry:
 
 ; <label>:22                                      ; preds = %17
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
-  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
   %26 = load i32, i32 addrspace(1)* %25
   %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
-  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %27, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
@@ -4925,8 +5789,8 @@ entry:
 ; <label>:40                                      ; preds = %17
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
-  br i1 %NullCheck6, label %43, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %41, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
@@ -4938,34 +5802,17 @@ ThrowNullRef:                                     ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %24
+ThrowNullRef4:                                    ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %40
+ThrowNullRef6:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
-}
-
-INFO:  jitting method Object::ReferenceEquals using LLILCJit
-Successfully read Object.ReferenceEquals
-
-define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
-entry:
-  %arg0 = alloca %System.Object addrspace(1)*
-  %arg1 = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
-  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
-  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = icmp eq %System.Object addrspace(1)* %0, %1
-  %3 = sext i1 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
 }
 
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
@@ -4978,21 +5825,21 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
   %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
-  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
@@ -5007,28 +5854,28 @@ entry:
 ; <label>:13                                      ; preds = %8, %12
   %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
   %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
   %21 = load i32, i32 addrspace(1)* %20, align 8
   %22 = add i32 %21, 1
-  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
   store i32 %22, i32 addrspace(1)* %24
   %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
@@ -5039,27 +5886,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5077,7 +5924,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::Setup using LLILCJit
-Failed to read AppDomain.Setup[loadElem]
+Failed to read AppDomain.Setup[unbox]
 INFO:  jitting method Thread::GetDomain using LLILCJit
 Successfully read Thread.GetDomain
 
@@ -5108,8 +5955,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
@@ -5122,14 +5969,14 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
   %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
@@ -5141,11 +5988,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5173,8 +6020,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -5189,7 +6036,328 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
 Failed to read KeyCollection.System.Collections.Generic.IEnumerable<TKey>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Successfully read Enumerator.MoveNext
+
+define i8 @Enumerator.MoveNext(%"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.RuntimeTypeHandle* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*
+  %"$TypeArg" = alloca %System.RuntimeTypeHandle*
+  store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
+  %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 8
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %76, label %12
+
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
+  br label %76
+
+; <label>:13                                      ; preds = %85
+  %14 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck19 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %15
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, i32 0, i32 0
+  %17 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %16, align 8
+  %NullCheck21 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, i32 0, i32 2
+  %20 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %19, align 8
+  %21 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck23 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %22
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, i32 0, i32 2
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %NullCheck25 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 3, i32 %24
+  %NullCheck27 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %32
+
+; <label>:32                                      ; preds = %30
+  %33 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, i32 0, i32 2
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = icmp slt i32 %34, 0
+  br i1 %35, label %68, label %36
+
+; <label>:36                                      ; preds = %32
+  %37 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %38 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck29 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %39
+
+; <label>:39                                      ; preds = %36
+  %40 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, i32 0, i32 0
+  %41 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %40, align 8
+  %NullCheck31 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, i32 0, i32 2
+  %44 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %43, align 8
+  %45 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck33 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, i32 0, i32 2
+  %48 = load i32, i32 addrspace(1)* %47, align 8
+  %NullCheck35 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %49
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = zext i32 %51 to i64
+  %53 = zext i32 %48 to i64
+  %BoundsCheck37 = icmp uge i64 %53, %52
+  br i1 %BoundsCheck37, label %ThrowIndexOutOfRange38, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 3, i32 %48
+  %NullCheck39 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %56
+
+; <label>:56                                      ; preds = %54
+  %57 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, i32 0, i32 0
+  %58 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck41 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %59
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %60, %System.__Canon addrspace(1)* %58)
+  %61 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck43 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  %64 = load i32, i32 addrspace(1)* %63, align 8
+  %65 = add i32 %64, 1
+  %NullCheck45 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  store i32 %65, i32 addrspace(1)* %67
+  ret i8 1
+
+; <label>:68                                      ; preds = %32
+  %69 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck47 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %73 = add i32 %72, 1
+  %NullCheck49 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %74
+
+; <label>:74                                      ; preds = %70
+  %75 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  store i32 %73, i32 addrspace(1)* %75
+  br label %76
+
+; <label>:76                                      ; preds = %8, %12, %74
+  %77 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %78
+
+; <label>:78                                      ; preds = %76
+  %79 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, i32 0, i32 2
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck7 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %82
+
+; <label>:82                                      ; preds = %78
+  %83 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, i32 0, i32 0
+  %84 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %83, align 8
+  %NullCheck9 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %85
+
+; <label>:85                                      ; preds = %82
+  %86 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, i32 0, i32 7
+  %87 = load i32, i32 addrspace(1)* %86, align 8
+  %88 = icmp ult i32 %80, %87
+  br i1 %88, label %13, label %89
+
+; <label>:89                                      ; preds = %85
+  %90 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %91 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck11 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %92
+
+; <label>:92                                      ; preds = %89
+  %93 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, i32 0, i32 0
+  %94 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck13 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %95
+
+; <label>:95                                      ; preds = %92
+  %96 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, i32 0, i32 7
+  %97 = load i32, i32 addrspace(1)* %96, align 8
+  %98 = add i32 %97, 1
+  %NullCheck15 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %99
+
+; <label>:99                                      ; preds = %95
+  %100 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, i32 0, i32 2
+  store i32 %98, i32 addrspace(1)* %100
+  %101 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck17 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %102
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %103, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %92
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef22:                                   ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef24:                                   ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef26:                                   ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef28:                                   ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef30:                                   ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef32:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef34:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef36:                                   ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange38:                           ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef40:                                   ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef42:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef44:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef46:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef48:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef50:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -5200,8 +6368,8 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -5232,9 +6400,9 @@ Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
 Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
-Failed to read String.MakeSeparatorList[loadElemA]
+Failed to read String.MakeSeparatorList[storeElem]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
-Failed to read String.InternalSplitKeepEmptyEntries[loadElem]
+Failed to read String.InternalSplitKeepEmptyEntries[storeElem]
 INFO:  jitting method Path::IsRelative using LLILCJit
 Successfully read Path.IsRelative
 
@@ -5243,8 +6411,8 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -5254,8 +6422,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
@@ -5271,8 +6439,8 @@ entry:
 
 ; <label>:17                                      ; preds = %7
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
@@ -5288,8 +6456,8 @@ entry:
 
 ; <label>:29                                      ; preds = %19
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %31
 
 ; <label>:31                                      ; preds = %29
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
@@ -5300,8 +6468,8 @@ entry:
 
 ; <label>:36                                      ; preds = %31
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
-  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %37, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
@@ -5312,8 +6480,8 @@ entry:
 
 ; <label>:43                                      ; preds = %31, %38
   %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
-  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %45
 
 ; <label>:45                                      ; preds = %43
   %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
@@ -5324,8 +6492,8 @@ entry:
 
 ; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %50
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
@@ -5336,8 +6504,8 @@ entry:
 
 ; <label>:57                                      ; preds = %1, %7, %19, %45, %52
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
-  br i1 %NullCheck14, label %59, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %59
 
 ; <label>:59                                      ; preds = %57
   %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
@@ -5347,8 +6515,8 @@ entry:
 
 ; <label>:63                                      ; preds = %59
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
@@ -5359,8 +6527,8 @@ entry:
 
 ; <label>:70                                      ; preds = %65
   %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
-  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.String addrspace(1)* %71, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %72
 
 ; <label>:72                                      ; preds = %70
   %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
@@ -5379,39 +6547,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %17
+ThrowNullRef4:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %29
+ThrowNullRef6:                                    ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %36
+ThrowNullRef8:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %43
+ThrowNullRef10:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %50
+ThrowNullRef12:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %57
+ThrowNullRef14:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %63
+ThrowNullRef16:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %70
+ThrowNullRef18:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5419,7 +6587,293 @@ ThrowNullRef17:                                   ; preds = %70
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
-Failed to read String.TrimHelper[loadElem]
+Successfully read String.TrimHelper
+
+define %System.String addrspace(1)* @String.TrimHelper(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i16
+  %loc4 = alloca i32
+  %loc5 = alloca i16
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = sub i32 %3, 1
+  store i32 %4, i32* %loc0
+  store i32 0, i32* %loc1
+  %5 = load i32, i32* %arg2
+  %6 = icmp eq i32 %5, 1
+  br i1 %6, label %62, label %7
+
+; <label>:7                                       ; preds = %1
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:8                                       ; preds = %58
+  store i32 0, i32* %loc2
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load i32, i32* %loc1
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2, i32 %10
+  %13 = load i16, i16 addrspace(1)* %12
+  %14 = zext i16 %13 to i32
+  %15 = trunc i32 %14 to i16
+  store i16 %15, i16* %loc3
+  store i32 0, i32* %loc2
+  br label %34
+
+; <label>:16                                      ; preds = %37
+  %17 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %18 = load i32, i32* %loc2
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %17, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %19
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = zext i32 %18 to i64
+  %BoundsCheck = icmp uge i64 %23, %22
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %24
+
+; <label>:24                                      ; preds = %19
+  %25 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 3, i32 %18
+  %26 = load i16, i16 addrspace(1)* %25, align 8
+  %27 = zext i16 %26 to i32
+  %28 = load i16, i16* %loc3
+  %29 = zext i16 %28 to i32
+  %30 = icmp eq i32 %27, %29
+  br i1 %30, label %43, label %31
+
+; <label>:31                                      ; preds = %24
+  %32 = load i32, i32* %loc2
+  %33 = add i32 %32, 1
+  store i32 %33, i32* %loc2
+  br label %34
+
+; <label>:34                                      ; preds = %11, %31
+  %35 = load i32, i32* %loc2
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = icmp slt i32 %35, %41
+  br i1 %42, label %16, label %43
+
+; <label>:43                                      ; preds = %24, %37
+  %44 = load i32, i32* %loc2
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %45, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp eq i32 %44, %50
+  br i1 %51, label %62, label %52
+
+; <label>:52                                      ; preds = %46
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %7, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %57, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %58
+
+; <label>:58                                      ; preds = %55
+  %59 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %60 = load i32, i32 addrspace(1)* %59
+  %61 = icmp slt i32 %56, %60
+  br i1 %61, label %8, label %62
+
+; <label>:62                                      ; preds = %1, %46, %58
+  %63 = load i32, i32* %arg2
+  %64 = icmp eq i32 %63, 0
+  br i1 %64, label %122, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %66, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %67
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %66, i32 0, i32 1
+  %69 = load i32, i32 addrspace(1)* %68
+  %70 = sub i32 %69, 1
+  store i32 %70, i32* %loc0
+  br label %118
+
+; <label>:71                                      ; preds = %118
+  store i32 0, i32* %loc4
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %73 = load i32, i32* %loc0
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %74
+
+; <label>:74                                      ; preds = %71
+  %75 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 2, i32 %73
+  %76 = load i16, i16 addrspace(1)* %75
+  %77 = zext i16 %76 to i32
+  %78 = trunc i32 %77 to i16
+  store i16 %78, i16* %loc5
+  store i32 0, i32* %loc4
+  br label %97
+
+; <label>:79                                      ; preds = %100
+  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %81 = load i32, i32* %loc4
+  %NullCheck19 = icmp eq %"System.Char[]" addrspace(1)* %80, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
+
+; <label>:82                                      ; preds = %79
+  %83 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 1
+  %84 = load i32, i32 addrspace(1)* %83
+  %85 = zext i32 %84 to i64
+  %86 = zext i32 %81 to i64
+  %BoundsCheck21 = icmp uge i64 %86, %85
+  br i1 %BoundsCheck21, label %ThrowIndexOutOfRange22, label %87
+
+; <label>:87                                      ; preds = %82
+  %88 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 3, i32 %81
+  %89 = load i16, i16 addrspace(1)* %88, align 8
+  %90 = zext i16 %89 to i32
+  %91 = load i16, i16* %loc5
+  %92 = zext i16 %91 to i32
+  %93 = icmp eq i32 %90, %92
+  br i1 %93, label %106, label %94
+
+; <label>:94                                      ; preds = %87
+  %95 = load i32, i32* %loc4
+  %96 = add i32 %95, 1
+  store i32 %96, i32* %loc4
+  br label %97
+
+; <label>:97                                      ; preds = %74, %94
+  %98 = load i32, i32* %loc4
+  %99 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck15 = icmp eq %"System.Char[]" addrspace(1)* %99, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %100
+
+; <label>:100                                     ; preds = %97
+  %101 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %99, i32 0, i32 1
+  %102 = load i32, i32 addrspace(1)* %101
+  %103 = zext i32 %102 to i64
+  %104 = trunc i64 %103 to i32
+  %105 = icmp slt i32 %98, %104
+  br i1 %105, label %79, label %106
+
+; <label>:106                                     ; preds = %87, %100
+  %107 = load i32, i32* %loc4
+  %108 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck17 = icmp eq %"System.Char[]" addrspace(1)* %108, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %109
+
+; <label>:109                                     ; preds = %106
+  %110 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %108, i32 0, i32 1
+  %111 = load i32, i32 addrspace(1)* %110
+  %112 = zext i32 %111 to i64
+  %113 = trunc i64 %112 to i32
+  %114 = icmp eq i32 %107, %113
+  br i1 %114, label %122, label %115
+
+; <label>:115                                     ; preds = %109
+  %116 = load i32, i32* %loc0
+  %117 = sub i32 %116, 1
+  store i32 %117, i32* %loc0
+  br label %118
+
+; <label>:118                                     ; preds = %67, %115
+  %119 = load i32, i32* %loc0
+  %120 = load i32, i32* %loc1
+  %121 = icmp sge i32 %119, %120
+  br i1 %121, label %71, label %122
+
+; <label>:122                                     ; preds = %62, %109, %118
+  %123 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %124 = load i32, i32* %loc1
+  %125 = load i32, i32* %loc0
+  %126 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %123, i32 %124, i32 %125)
+  ret %System.String addrspace(1)* %126
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %97
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange22:                           ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
 Successfully read String.CreateTrimmedString
 
@@ -5439,8 +6893,8 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
@@ -5535,8 +6989,8 @@ entry:
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i64 2872
   %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
   %8 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %7
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %3
   %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
@@ -5553,8 +7007,8 @@ entry:
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 2864
   %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
   %21 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %20
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
-  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %22
 
 ; <label>:22                                      ; preds = %16
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
@@ -5569,7 +7023,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %16
+ThrowNullRef2:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5586,8 +7040,8 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5613,8 +7067,8 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
@@ -5632,8 +7086,8 @@ entry:
 
 ; <label>:12                                      ; preds = %4
   %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
@@ -5644,8 +7098,8 @@ entry:
 
 ; <label>:19                                      ; preds = %14
   %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %19
   %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
@@ -5660,21 +7114,21 @@ entry:
   %31 = zext i16 %30 to i32
   %32 = bitcast i8* %29 to i16*
   %33 = trunc i32 %31 to i16
-  %NullCheck6 = icmp ne i16* %32, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i16* %32, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %21
   store i16 %33, i16* %32, align 8
   %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %36
 
 ; <label>:36                                      ; preds = %34
   %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
   %38 = load i32, i32 addrspace(1)* %37, align 8
   %39 = add i32 %38, 1
-  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %40
 
 ; <label>:40                                      ; preds = %36
   %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
@@ -5683,16 +7137,16 @@ entry:
 
 ; <label>:42                                      ; preds = %14
   %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
-  br i1 %NullCheck12, label %44, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
   %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
   %47 = load i16, i16* %arg1
   %48 = zext i16 %47 to i32
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = trunc i32 %48 to i16
@@ -5703,31 +7157,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %19
+ThrowNullRef4:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %21
+ThrowNullRef6:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %36
+ThrowNullRef10:                                   ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %42
+ThrowNullRef12:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %44
+ThrowNullRef14:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5740,8 +7194,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -5752,8 +7206,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
@@ -5762,14 +7216,14 @@ entry:
 
 ; <label>:11                                      ; preds = %1
   %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
@@ -5779,15 +7233,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5808,8 +7262,8 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5822,8 +7276,8 @@ entry:
 
 ; <label>:8                                       ; preds = %3
   %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
@@ -5842,15 +7296,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
-  br i1 %NullCheck4, label %22, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
   %24 = load i16*, i16* addrspace(1)* %23, align 8
   %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %25, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
@@ -5859,8 +7313,8 @@ entry:
   store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
@@ -5874,8 +7328,8 @@ entry:
 
 ; <label>:37                                      ; preds = %65
   %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %37
   %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
@@ -5886,16 +7340,16 @@ entry:
   %45 = bitcast i16* %41 to i8*
   %46 = getelementptr inbounds i8, i8* %45, i64 %44
   %47 = bitcast i8* %46 to i16*
-  %NullCheck14 = icmp ne i16* %47, null
-  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %47, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %48
 
 ; <label>:48                                      ; preds = %39
   %49 = load i16, i16* %47, align 8
   %50 = zext i16 %49 to i32
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %52 = load i32, i32* %loc1
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %53
 
 ; <label>:53                                      ; preds = %48
   %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
@@ -5916,8 +7370,8 @@ entry:
 ; <label>:62                                      ; preds = %36, %59
   %63 = load i32, i32* %loc1
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck10, label %65, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %65
 
 ; <label>:65                                      ; preds = %62
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
@@ -5936,15 +7390,15 @@ entry:
 
 ; <label>:74                                      ; preds = %70
   %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
-  br i1 %NullCheck18, label %76, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %76
 
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
   %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
-  br i1 %NullCheck20, label %80, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
   %81 = load i64, i64 addrspace(1)* %79
@@ -5958,8 +7412,8 @@ entry:
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
   %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
-  br i1 %NullCheck22, label %92, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.String addrspace(1)* %90, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %92
 
 ; <label>:92                                      ; preds = %80
   %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
@@ -5969,15 +7423,15 @@ entry:
 
 ; <label>:96                                      ; preds = %70
   %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
-  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %98
 
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
   %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
-  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
   %103 = load i64, i64 addrspace(1)* %101
@@ -5991,8 +7445,8 @@ entry:
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
   %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
-  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.String addrspace(1)* %112, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %114
 
 ; <label>:114                                     ; preds = %102
   %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
@@ -6004,59 +7458,59 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %20
+ThrowNullRef4:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %22
+ThrowNullRef6:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %26
+ThrowNullRef8:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %62
+ThrowNullRef10:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %48
+ThrowNullRef16:                                   ; preds = %48
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %74
+ThrowNullRef18:                                   ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %76
+ThrowNullRef20:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %80
+ThrowNullRef22:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %96
+ThrowNullRef24:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %98
+ThrowNullRef26:                                   ; preds = %98
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %102
+ThrowNullRef28:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6069,15 +7523,15 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
   %3 = load i16*, i16* addrspace(1)* %2, align 8
   %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
@@ -6087,8 +7541,8 @@ entry:
   %10 = bitcast i16* %3 to i8*
   %11 = getelementptr inbounds i8, i8* %10, i64 %9
   %12 = bitcast i8* %11 to i16*
-  %NullCheck4 = icmp ne i16* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %5
   store i16 0, i16* %12, align 8
@@ -6098,11 +7552,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6119,8 +7573,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -6131,8 +7585,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
@@ -6144,15 +7598,15 @@ entry:
 
 ; <label>:14                                      ; preds = %1
   %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
   %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
   %21 = load i64, i64 addrspace(1)* %19
@@ -6171,15 +7625,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %14
+ThrowNullRef4:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %16
+ThrowNullRef6:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6302,14 +7756,6 @@ entry:
   ret %System.String addrspace(1)* %57
 }
 
-INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
-Successfully read RuntimeHelpers.get_OffsetToStringData
-
-define i32 @RuntimeHelpers.get_OffsetToStringData() {
-entry:
-  ret i32 12
-}
-
 INFO:  jitting method String::Equals using LLILCJit
 Successfully read String.Equals
 
@@ -6381,8 +7827,8 @@ entry:
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
-  br i1 %NullCheck24, label %29, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
   %30 = load i64, i64 addrspace(1)* %28
@@ -6397,8 +7843,8 @@ entry:
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
-  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
   %43 = load i64, i64 addrspace(1)* %41
@@ -6418,8 +7864,8 @@ entry:
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
   %59 = load i64, i64 addrspace(1)* %57
@@ -6434,8 +7880,8 @@ entry:
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck22, label %71, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
   %72 = load i64, i64 addrspace(1)* %70
@@ -6455,8 +7901,8 @@ entry:
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
-  br i1 %NullCheck16, label %87, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = load i64, i64 addrspace(1)* %86
@@ -6471,8 +7917,8 @@ entry:
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck18, label %100, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
   %101 = load i64, i64 addrspace(1)* %99
@@ -6492,8 +7938,8 @@ entry:
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
-  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
   %117 = load i64, i64 addrspace(1)* %115
@@ -6508,8 +7954,8 @@ entry:
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
-  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
   %130 = load i64, i64 addrspace(1)* %128
@@ -6528,15 +7974,15 @@ entry:
 
 ; <label>:142                                     ; preds = %22
   %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
-  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %143, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %144
 
 ; <label>:144                                     ; preds = %142
   %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
   %146 = load i32, i32 addrspace(1)* %145
   %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
-  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %147, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %148
 
 ; <label>:148                                     ; preds = %144
   %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
@@ -6557,15 +8003,15 @@ entry:
 
 ; <label>:159                                     ; preds = %22
   %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
-  br i1 %NullCheck, label %161, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %ThrowNullRef, label %161
 
 ; <label>:161                                     ; preds = %159
   %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
   %163 = load i32, i32 addrspace(1)* %162
   %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
-  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %164, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %165
 
 ; <label>:165                                     ; preds = %161
   %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
@@ -6578,8 +8024,8 @@ entry:
 
 ; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
-  br i1 %NullCheck4, label %172, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %171, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %172
 
 ; <label>:172                                     ; preds = %170
   %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
@@ -6589,8 +8035,8 @@ entry:
 
 ; <label>:176                                     ; preds = %172
   %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
-  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %177, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %178
 
 ; <label>:178                                     ; preds = %176
   %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
@@ -6629,55 +8075,55 @@ ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %161
+ThrowNullRef2:                                    ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %170
+ThrowNullRef4:                                    ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %176
+ThrowNullRef6:                                    ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %142
+ThrowNullRef8:                                    ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %144
+ThrowNullRef10:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %113
+ThrowNullRef12:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %116
+ThrowNullRef14:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %84
+ThrowNullRef16:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %87
+ThrowNullRef18:                                   ; preds = %87
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %55
+ThrowNullRef20:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %58
+ThrowNullRef22:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %26
+ThrowNullRef24:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %29
+ThrowNullRef26:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,8 +8161,8 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck, label %14, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %ThrowNullRef, label %14
 
 ; <label>:14                                      ; preds = %8
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
@@ -6760,8 +8206,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
@@ -6770,14 +8216,14 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32, i32* %loc0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %10
   %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
   %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
@@ -6790,15 +8236,15 @@ entry:
 ; <label>:25                                      ; preds = %19
   %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
-  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
   %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
@@ -6807,8 +8253,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %37 = load i32, i32* %loc0
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %38, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %38
 
 ; <label>:38                                      ; preds = %32
   %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
@@ -6817,14 +8263,14 @@ entry:
 
 ; <label>:40                                      ; preds = %19
   %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %40
   %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
   %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
-  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
-  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
@@ -6832,8 +8278,8 @@ entry:
   %48 = zext i32 %47 to i64
   %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
-  br i1 %NullCheck16, label %51, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %51
 
 ; <label>:51                                      ; preds = %45
   %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
@@ -6847,15 +8293,15 @@ entry:
 ; <label>:57                                      ; preds = %51
   %58 = load i16*, i16** %arg1
   %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
-  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %60
 
 ; <label>:60                                      ; preds = %57
   %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
   %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
-  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %64
 
 ; <label>:64                                      ; preds = %60
   %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
@@ -6864,22 +8310,22 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
   %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
-  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %70
 
 ; <label>:70                                      ; preds = %64
   %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
   %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
-  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
-  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
   %75 = load i32, i32 addrspace(1)* %74
   %76 = zext i32 %75 to i64
   %77 = trunc i64 %76 to i32
-  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
-  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %78
 
 ; <label>:78                                      ; preds = %73
   %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
@@ -6901,8 +8347,8 @@ entry:
   %90 = bitcast i16* %86 to i8*
   %91 = getelementptr inbounds i8, i8* %90, i64 %89
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %93
 
 ; <label>:93                                      ; preds = %80
   %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
@@ -6912,8 +8358,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %99 = load i32, i32* %loc2
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %100
 
 ; <label>:100                                     ; preds = %93
   %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
@@ -6928,63 +8374,63 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %25
+ThrowNullRef6:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %32
+ThrowNullRef10:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %40
+ThrowNullRef12:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %45
+ThrowNullRef16:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %57
+ThrowNullRef18:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %60
+ThrowNullRef20:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %64
+ThrowNullRef22:                                   ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %70
+ThrowNullRef24:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %73
+ThrowNullRef26:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %80
+ThrowNullRef28:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %93
+ThrowNullRef30:                                   ; preds = %93
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7004,8 +8450,8 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
@@ -7033,43 +8479,43 @@ entry:
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %14
   %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
   %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   %28 = load i32, i32 addrspace(1)* %27, align 8
   %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
-  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %30
 
 ; <label>:30                                      ; preds = %26
   %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
   %32 = load i32, i32 addrspace(1)* %31, align 8
   %33 = add i32 %28, %32
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %34
 
 ; <label>:34                                      ; preds = %30
   %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   store i32 %33, i32 addrspace(1)* %35
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
   store i32 0, i32 addrspace(1)* %38
   %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %40
 
 ; <label>:40                                      ; preds = %37
   %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
@@ -7082,8 +8528,8 @@ entry:
 
 ; <label>:47                                      ; preds = %40
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
@@ -7098,8 +8544,8 @@ entry:
   %54 = load i32, i32* %loc0
   %55 = sext i32 %54 to i64
   %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
-  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %57
 
 ; <label>:57                                      ; preds = %52
   %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
@@ -7110,68 +8556,35 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %14
+ThrowNullRef2:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %23
+ThrowNullRef4:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %26
+ThrowNullRef6:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %30
+ThrowNullRef8:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %34
+ThrowNullRef10:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %47
+ThrowNullRef14:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %52
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-}
-
-INFO:  jitting method StringBuilder::get_Length using LLILCJit
-Successfully read StringBuilder.get_Length
-
-define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.StringBuilder addrspace(1)*
-  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
-  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
-
-; <label>:1                                       ; preds = %entry
-  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %3 = load i32, i32 addrspace(1)* %2, align 8
-  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
-
-; <label>:5                                       ; preds = %1
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = add i32 %3, %7
-  ret i32 %8
-
-ThrowNullRef:                                     ; preds = %entry
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef16:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7213,70 +8626,70 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
   %6 = load i32, i32 addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
   store i32 %6, i32 addrspace(1)* %8
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
   %13 = load i32, i32 addrspace(1)* %12, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
   store i32 %13, i32 addrspace(1)* %15
   %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
-  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %18
 
 ; <label>:18                                      ; preds = %14
   %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
   %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
   %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
   %34 = load i32, i32 addrspace(1)* %33, align 8
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
-  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
@@ -7287,39 +8700,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %28
+ThrowNullRef16:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %32
+ThrowNullRef18:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7455,13 +8868,13 @@ entry:
 ; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
@@ -7477,16 +8890,16 @@ entry:
 
 ; <label>:18                                      ; preds = %15
   %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
   store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
   %22 = load i32, i32* %loc0
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %24
 
 ; <label>:24                                      ; preds = %20
   %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
@@ -7498,13 +8911,13 @@ entry:
 ; <label>:28                                      ; preds = %15, %24
   %29 = load i32, i32* %arg1
   %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %31
   %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
@@ -7517,20 +8930,20 @@ entry:
   %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
-  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
   %46 = load i32, i32 addrspace(1)* %45, align 8
   %47 = sub i32 %40, %46
-  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
-  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i32 addrspace(1)* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %48
 
 ; <label>:48                                      ; preds = %44
   store i32 %47, i32 addrspace(1)* %39, align 8
@@ -7538,21 +8951,21 @@ entry:
 
 ; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
-  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %51
 
 ; <label>:51                                      ; preds = %49
   %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %53
 
 ; <label>:53                                      ; preds = %51
   %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
   %55 = load i32, i32 addrspace(1)* %54, align 8
   %56 = load i32, i32* %arg2
   %57 = sub i32 %55, %56
-  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %58
 
 ; <label>:58                                      ; preds = %53
   %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
@@ -7562,13 +8975,13 @@ entry:
 ; <label>:60                                      ; preds = %33, %58
   %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
   %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
-  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %63
 
 ; <label>:63                                      ; preds = %60
   %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
-  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
-  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
@@ -7578,15 +8991,15 @@ entry:
 
 ; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
-  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i32 addrspace(1)* %69, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %70
 
 ; <label>:70                                      ; preds = %68
   %71 = load i32, i32 addrspace(1)* %69, align 8
   store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
-  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
@@ -7596,8 +9009,8 @@ entry:
   store i32 %77, i32* %loc4
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
-  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %80
 
 ; <label>:80                                      ; preds = %73
   %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
@@ -7607,71 +9020,71 @@ entry:
 ; <label>:83                                      ; preds = %80
   store i32 0, i32* %loc3
   %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
-  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
-  br i1 %NullCheck26, label %88, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i32 addrspace(1)* %87, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %88
 
 ; <label>:88                                      ; preds = %85
   %89 = load i32, i32 addrspace(1)* %87, align 8
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
-  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %90
 
 ; <label>:90                                      ; preds = %88
   %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
   store i32 %89, i32 addrspace(1)* %91
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
-  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
-  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %96
 
 ; <label>:96                                      ; preds = %94
   %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
-  br i1 %NullCheck34, label %100, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %100
 
 ; <label>:100                                     ; preds = %96
   %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
-  br i1 %NullCheck36, label %102, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %102
 
 ; <label>:102                                     ; preds = %100
   %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
   %104 = load i32, i32 addrspace(1)* %103, align 8
   %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
-  br i1 %NullCheck38, label %106, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %106
 
 ; <label>:106                                     ; preds = %102
   %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
-  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
-  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %108
 
 ; <label>:108                                     ; preds = %106
   %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
   %110 = load i32, i32 addrspace(1)* %109, align 8
   %111 = add i32 %104, %110
-  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %112
 
 ; <label>:112                                     ; preds = %108
   %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
   store i32 %111, i32 addrspace(1)* %113
   %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
-  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i32 addrspace(1)* %114, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %115
 
 ; <label>:115                                     ; preds = %112
   %116 = load i32, i32 addrspace(1)* %114, align 8
@@ -7681,19 +9094,19 @@ entry:
 ; <label>:118                                     ; preds = %115
   %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
-  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %121
 
 ; <label>:121                                     ; preds = %118
   %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
-  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
-  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %123
 
 ; <label>:123                                     ; preds = %121
   %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
   %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
-  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
-  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %126
 
 ; <label>:126                                     ; preds = %123
   %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
@@ -7705,8 +9118,8 @@ entry:
 
 ; <label>:130                                     ; preds = %80, %115, %126
   %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %132
 
 ; <label>:132                                     ; preds = %130
   %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7715,8 +9128,8 @@ entry:
   %136 = load i32, i32* %loc3
   %137 = sub i32 %135, %136
   %138 = sub i32 %134, %137
-  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %139
 
 ; <label>:139                                     ; preds = %132
   %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7728,16 +9141,16 @@ entry:
 
 ; <label>:144                                     ; preds = %139
   %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
-  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %146
 
 ; <label>:146                                     ; preds = %144
   %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
   %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
   %149 = load i32, i32* %loc2
   %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
-  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %151
 
 ; <label>:151                                     ; preds = %146
   %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
@@ -7754,145 +9167,249 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %18
+ThrowNullRef4:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %31
+ThrowNullRef10:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %44
+ThrowNullRef16:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %68
+ThrowNullRef18:                                   ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %70
+ThrowNullRef20:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %73
+ThrowNullRef22:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %83
+ThrowNullRef24:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %85
+ThrowNullRef26:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %88
+ThrowNullRef28:                                   ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %90
+ThrowNullRef30:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %94
+ThrowNullRef32:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %96
+ThrowNullRef34:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %100
+ThrowNullRef36:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %102
+ThrowNullRef38:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %106
+ThrowNullRef40:                                   ; preds = %106
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %108
+ThrowNullRef42:                                   ; preds = %108
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %112
+ThrowNullRef44:                                   ; preds = %112
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %118
+ThrowNullRef46:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %121
+ThrowNullRef48:                                   ; preds = %121
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %123
+ThrowNullRef50:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %130
+ThrowNullRef52:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %132
+ThrowNullRef54:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %144
+ThrowNullRef56:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %146
+ThrowNullRef58:                                   ; preds = %146
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %60
+ThrowNullRef60:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %63
+ThrowNullRef62:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %49
+ThrowNullRef64:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %51
+ThrowNullRef66:                                   ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %53
+ThrowNullRef68:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(%"System.Char[]" addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %arg0 = alloca %"System.Char[]" addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store %"System.Char[]" addrspace(1)* %param0, %"System.Char[]" addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load i32, i32* %arg4
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %43, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %38, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg1
+  %13 = load i32, i32* %arg4
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %38, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %24 = load i32, i32* %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %35 = load i32, i32* %arg3
+  %36 = load i32, i32* %arg4
+  %37 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %37, %"System.Char[]" addrspace(1)* %34, i32 %35, i32 %36)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:38                                      ; preds = %5, %16
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Successfully read Buffer._Memmove
 
@@ -7914,7 +9431,7 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[loadElem]
+Failed to read AppDomain.SetDataHelper[storeElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -7923,8 +9440,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
@@ -7934,8 +9451,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
@@ -7947,15 +9464,15 @@ entry:
   %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
   %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
@@ -7966,15 +9483,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7992,7 +9509,79 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
-Failed to read Dictionary`2.TryGetValue[loadElemA]
+Successfully read Dictionary`2.TryGetValue
+
+define i8 @"Dictionary`2.TryGetValue"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)* addrspace(1)* %param2) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  %arg2 = alloca %System.__Canon addrspace(1)* addrspace(1)*
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  store %System.__Canon addrspace(1)* addrspace(1)* %param2, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  store i32 %2, i32* %loc0
+  %3 = load i32, i32* %loc0
+  %4 = icmp slt i32 %3, 0
+  br i1 %4, label %22, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 2
+  %10 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %9, align 8
+  %11 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = zext i32 %11 to i64
+  %BoundsCheck = icmp uge i64 %16, %15
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 3, i32 %11
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %20, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %6, %System.__Canon addrspace(1)* %21)
+  ret i8 1
+
+; <label>:22                                      ; preds = %entry
+  %23 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %23, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -8058,8 +9647,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
@@ -8091,8 +9680,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
@@ -8171,15 +9760,15 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck, label %19, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %ThrowNullRef, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
   %21 = load i32, i32 addrspace(1)* %20
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
@@ -8202,7 +9791,7 @@ ThrowNullRef:                                     ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %19
+ThrowNullRef2:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8248,8 +9837,8 @@ entry:
   %0 = alloca %System.AppDomainHandle
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %1 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %1, i32 0, i32 15
@@ -8269,8 +9858,8 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
@@ -8286,7 +9875,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -8299,8 +9888,8 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -8327,8 +9916,8 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
@@ -8352,8 +9941,8 @@ entry:
   %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
   store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
@@ -8363,8 +9952,8 @@ entry:
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
@@ -8374,8 +9963,8 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %9
   %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
@@ -8384,8 +9973,8 @@ entry:
 
 ; <label>:18                                      ; preds = %3, %16
   %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
@@ -8397,15 +9986,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %18
+ThrowNullRef6:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8418,8 +10007,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
@@ -8453,15 +10042,15 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
@@ -8473,7 +10062,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8481,7 +10070,7 @@ ThrowNullRef1:                                    ; preds = %1
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
 Failed to read Dictionary`2.System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
@@ -8506,8 +10095,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
@@ -8524,8 +10113,8 @@ entry:
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -8544,7 +10133,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8577,8 +10166,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = load i64, i64* %arg2
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = trunc i32 %3 to i8
@@ -8634,46 +10223,46 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
   %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
-  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
-  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
-  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
@@ -8684,27 +10273,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %20
+ThrowNullRef12:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8717,8 +10306,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -8756,22 +10345,22 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
   %9 = load i64, i64 addrspace(1)* %8, align 8
   %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
   %13 = load i64, i64 addrspace(1)* %12, align 8
   %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %11
   %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
@@ -8788,11 +10377,11 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8882,8 +10471,8 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
@@ -8900,8 +10489,8 @@ entry:
 ; <label>:8                                       ; preds = %1
   %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
   %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
@@ -8911,15 +10500,15 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
   %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
   %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
-  br i1 %NullCheck6, label %21, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
@@ -8946,15 +10535,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8992,15 +10581,15 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
   store i8 %3, i8 addrspace(1)* %5
   %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
@@ -9011,7 +10600,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9027,8 +10616,8 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -9041,8 +10630,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
@@ -9058,7 +10647,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9080,8 +10669,8 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
@@ -9096,8 +10685,8 @@ entry:
 ; <label>:12                                      ; preds = %6
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
@@ -9112,8 +10701,8 @@ entry:
 ; <label>:21                                      ; preds = %15
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
@@ -9128,8 +10717,8 @@ entry:
 ; <label>:30                                      ; preds = %24
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %31, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
@@ -9144,8 +10733,8 @@ entry:
 ; <label>:39                                      ; preds = %33
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
-  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %40, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %42
 
 ; <label>:42                                      ; preds = %39
   %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
@@ -9164,19 +10753,19 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %21
+ThrowNullRef4:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %30
+ThrowNullRef6:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %39
+ThrowNullRef8:                                    ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9243,8 +10832,8 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
@@ -9264,57 +10853,57 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
   store i8 0, i8 addrspace(1)* %2
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
   store i8 0, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
   store i8 0, i8 addrspace(1)* %17
   %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
   store i8 0, i8 addrspace(1)* %20
   %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
-  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
@@ -9325,31 +10914,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %19
+ThrowNullRef14:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9367,8 +10956,8 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
@@ -9380,8 +10969,8 @@ entry:
 
 ; <label>:9                                       ; preds = %4
   %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %9
   %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
@@ -9395,7 +10984,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef2:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9420,8 +11009,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
@@ -9512,8 +11101,8 @@ entry:
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
@@ -9524,8 +11113,8 @@ entry:
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = load i64, i64 addrspace(1)* %12
@@ -9537,8 +11126,8 @@ entry:
   %20 = load i64, i64* %19
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
-  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %13
   %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
@@ -9555,8 +11144,8 @@ entry:
 ; <label>:30                                      ; preds = %25
   %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %32 = load i32, i32* %arg2
-  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
-  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
@@ -9570,15 +11159,15 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %30
+ThrowNullRef2:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9622,87 +11211,87 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
   %10 = load i8, i8 addrspace(1)* %9, align 8
   %11 = zext i8 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %8
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
   store i8 %12, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
   %19 = load i8, i8 addrspace(1)* %18, align 8
   %20 = zext i8 %19 to i32
   %21 = trunc i32 %20 to i8
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
   store i8 %21, i8 addrspace(1)* %23
   %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
   %28 = load i8, i8 addrspace(1)* %27, align 8
   %29 = zext i8 %28 to i32
   %30 = trunc i32 %29 to i8
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
-  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %31
 
 ; <label>:31                                      ; preds = %26
   %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
   store i8 %30, i8 addrspace(1)* %32
   %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
-  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
-  br i1 %NullCheck14, label %40, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %40
 
 ; <label>:40                                      ; preds = %35
   %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
   store i8 %39, i8 addrspace(1)* %41
   %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
-  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %44
 
 ; <label>:44                                      ; preds = %40
   %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
   %46 = load i8, i8 addrspace(1)* %45, align 8
   %47 = zext i8 %46 to i32
   %48 = trunc i32 %47 to i8
-  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
   store i8 %48, i8 addrspace(1)* %50
   %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
-  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
@@ -9713,29 +11302,29 @@ entry:
 ; <label>:56                                      ; preds = %52
   %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
-  br i1 %NullCheck22, label %59, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
   %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
   %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
-  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
-  br i1 %NullCheck24, label %63, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
   %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
-  br i1 %NullCheck26, label %66, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
   %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
-  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
-  br i1 %NullCheck28, label %69, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %69
 
 ; <label>:69                                      ; preds = %66
   %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
@@ -9744,15 +11333,15 @@ entry:
 
 ; <label>:71                                      ; preds = %105
   %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
-  br i1 %NullCheck34, label %73, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %73
 
 ; <label>:73                                      ; preds = %71
   %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
   %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
   %76 = load i32, i32* %loc0
-  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
-  br i1 %NullCheck36, label %77, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
@@ -9766,8 +11355,8 @@ entry:
 
 ; <label>:83                                      ; preds = %77
   %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
-  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
@@ -9775,14 +11364,14 @@ entry:
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
   %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
-  br i1 %NullCheck40, label %91, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
 ; <label>:91                                      ; preds = %85
   %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
   %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
-  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck42, label %94, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %94
 
 ; <label>:94                                      ; preds = %91
   %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
@@ -9798,14 +11387,14 @@ entry:
 ; <label>:99                                      ; preds = %69, %96
   %100 = load i32, i32* %loc0
   %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
-  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %102
 
 ; <label>:102                                     ; preds = %99
   %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
   %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
-  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
-  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
@@ -9819,87 +11408,87 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %26
+ThrowNullRef10:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %31
+ThrowNullRef12:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %35
+ThrowNullRef14:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %40
+ThrowNullRef16:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %56
+ThrowNullRef22:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %59
+ThrowNullRef24:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %63
+ThrowNullRef26:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %66
+ThrowNullRef28:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %102
+ThrowNullRef32:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %71
+ThrowNullRef34:                                   ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %73
+ThrowNullRef36:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %83
+ThrowNullRef38:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %85
+ThrowNullRef40:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %91
+ThrowNullRef42:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9943,15 +11532,15 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
   %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
@@ -9961,28 +11550,28 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
   %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %12
   %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
   %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
   %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
-  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
@@ -9993,23 +11582,23 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %12
+ThrowNullRef6:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10031,15 +11620,15 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
   %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = load i64, i64 addrspace(1)* %7
@@ -10077,13 +11666,13 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[loadElem]
+Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -10111,8 +11700,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -10181,27 +11770,27 @@ entry:
   store i32 addrspace(1)* %param0, i32 addrspace(1)** %arg0
   store i32 %param1, i32* %arg1
   %0 = load i32 addrspace(1)*, i32 addrspace(1)** %arg0
-  %NullCheck = icmp ne i32 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i32 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = load i32, i32 addrspace(1)* %0, align 8
   %3 = load i32, i32* %arg1
   %4 = add i32 %2, %3
-  %NullCheck2 = icmp ne i32 addrspace(1)* %0, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i32 addrspace(1)* %0, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   store i32 %4, i32 addrspace(1)* %0, align 8
   %6 = load i32 addrspace(1)*, i32 addrspace(1)** %arg0
-  %NullCheck4 = icmp ne i32 addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i32 addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = load i32, i32 addrspace(1)* %6, align 8
   %9 = or i32 %8, 2
-  %NullCheck6 = icmp ne i32 addrspace(1)* %6, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32 addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   store i32 %9, i32 addrspace(1)* %6, align 8
@@ -10211,15 +11800,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Call1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Call1.error.txt
@@ -25,8 +25,8 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
@@ -40,8 +40,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
   %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
@@ -75,7 +75,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -90,8 +90,8 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %NullCheck = icmp ne i8 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = load i8, i8 addrspace(1)* %0, align 8
@@ -125,8 +125,8 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
@@ -159,8 +159,8 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -184,8 +184,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
   store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
@@ -195,8 +195,8 @@ entry:
 ; <label>:4                                       ; preds = %1
   %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
   %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
@@ -206,8 +206,8 @@ entry:
   %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
@@ -221,14 +221,14 @@ entry:
 
 ; <label>:17                                      ; preds = %14
   %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
   %21 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
@@ -238,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -249,8 +249,8 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
@@ -261,27 +261,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %30
+ThrowNullRef10:                                   ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -301,7 +301,89 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
-Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
+Successfully read AppDomainSetup.GetUnsecureApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.GetUnsecureApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %NullCheck = icmp eq %"System.String[]" addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %BoundsCheck = icmp uge i64 0, %5
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %6
+
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 3, i32 0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
+  ret %System.String addrspace(1)* %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_Value using LLILCJit
+Successfully read AppDomainSetup.get_Value
+
+define %"System.String[]" addrspace(1)* @AppDomainSetup.get_Value(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.String[]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 18)
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.String[]" addrspace(1)* addrspace(1)*, %"System.String[]" addrspace(1)*)*)(%"System.String[]" addrspace(1)* addrspace(1)* %9, %"System.String[]" addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %11, i32 0, i32 1
+  %14 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %13, align 8
+  ret %"System.String[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -319,8 +401,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -368,16 +450,16 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
   %5 = load i32, i32 addrspace(1)* %4
   %6 = sub i32 %5, 1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -389,7 +471,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -421,8 +503,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
@@ -456,8 +538,8 @@ entry:
 ; <label>:27                                      ; preds = %19
   %28 = load i32, i32* %arg1
   %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
-  br i1 %NullCheck2, label %30, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %29, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %30
 
 ; <label>:30                                      ; preds = %27
   %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
@@ -493,8 +575,8 @@ entry:
 ; <label>:49                                      ; preds = %46
   %50 = load i32, i32* %arg2
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck4, label %52, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
@@ -517,11 +599,11 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %27
+ThrowNullRef2:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %49
+ThrowNullRef4:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -544,16 +626,16 @@ entry:
   %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %0)
   store %System.String addrspace(1)* %1, %System.String addrspace(1)** %loc0
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 2
   %5 = bitcast [0 x i16] addrspace(1)* %4 to i16 addrspace(1)*
   store i16 addrspace(1)* %5, i16 addrspace(1)** %loc1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %3
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2
@@ -580,7 +662,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -691,15 +773,15 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %NullCheck132 = icmp ne i8* %21, null
-  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+  %NullCheck131 = icmp eq i8* %21, null
+  br i1 %NullCheck131, label %ThrowNullRef132, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = load i8, i8* %21, align 8
   %24 = zext i8 %23 to i32
   %25 = trunc i32 %24 to i8
-  %NullCheck134 = icmp ne i8* %20, null
-  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+  %NullCheck133 = icmp eq i8* %20, null
+  br i1 %NullCheck133, label %ThrowNullRef134, label %26
 
 ; <label>:26                                      ; preds = %22
   store i8 %25, i8* %20, align 8
@@ -709,16 +791,16 @@ entry:
   %28 = load i8*, i8** %arg0
   %29 = load i8*, i8** %arg1
   %30 = bitcast i8* %29 to i16*
-  %NullCheck128 = icmp ne i16* %30, null
-  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+  %NullCheck127 = icmp eq i16* %30, null
+  br i1 %NullCheck127, label %ThrowNullRef128, label %31
 
 ; <label>:31                                      ; preds = %27
   %32 = load i16, i16* %30, align 8
   %33 = sext i16 %32 to i32
   %34 = bitcast i8* %28 to i16*
   %35 = trunc i32 %33 to i16
-  %NullCheck130 = icmp ne i16* %34, null
-  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+  %NullCheck129 = icmp eq i16* %34, null
+  br i1 %NullCheck129, label %ThrowNullRef130, label %36
 
 ; <label>:36                                      ; preds = %31
   store i16 %35, i16* %34, align 8
@@ -728,16 +810,16 @@ entry:
   %38 = load i8*, i8** %arg0
   %39 = load i8*, i8** %arg1
   %40 = bitcast i8* %39 to i16*
-  %NullCheck120 = icmp ne i16* %40, null
-  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+  %NullCheck119 = icmp eq i16* %40, null
+  br i1 %NullCheck119, label %ThrowNullRef120, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i16, i16* %40, align 8
   %43 = sext i16 %42 to i32
   %44 = bitcast i8* %38 to i16*
   %45 = trunc i32 %43 to i16
-  %NullCheck122 = icmp ne i16* %44, null
-  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+  %NullCheck121 = icmp eq i16* %44, null
+  br i1 %NullCheck121, label %ThrowNullRef122, label %46
 
 ; <label>:46                                      ; preds = %41
   store i16 %45, i16* %44, align 8
@@ -745,15 +827,15 @@ entry:
   %48 = getelementptr inbounds i8, i8* %47, i64 2
   %49 = load i8*, i8** %arg1
   %50 = getelementptr inbounds i8, i8* %49, i64 2
-  %NullCheck124 = icmp ne i8* %50, null
-  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+  %NullCheck123 = icmp eq i8* %50, null
+  br i1 %NullCheck123, label %ThrowNullRef124, label %51
 
 ; <label>:51                                      ; preds = %46
   %52 = load i8, i8* %50, align 8
   %53 = zext i8 %52 to i32
   %54 = trunc i32 %53 to i8
-  %NullCheck126 = icmp ne i8* %48, null
-  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+  %NullCheck125 = icmp eq i8* %48, null
+  br i1 %NullCheck125, label %ThrowNullRef126, label %55
 
 ; <label>:55                                      ; preds = %51
   store i8 %54, i8* %48, align 8
@@ -763,14 +845,14 @@ entry:
   %57 = load i8*, i8** %arg0
   %58 = load i8*, i8** %arg1
   %59 = bitcast i8* %58 to i32*
-  %NullCheck116 = icmp ne i32* %59, null
-  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+  %NullCheck115 = icmp eq i32* %59, null
+  br i1 %NullCheck115, label %ThrowNullRef116, label %60
 
 ; <label>:60                                      ; preds = %56
   %61 = load i32, i32* %59, align 8
   %62 = bitcast i8* %57 to i32*
-  %NullCheck118 = icmp ne i32* %62, null
-  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+  %NullCheck117 = icmp eq i32* %62, null
+  br i1 %NullCheck117, label %ThrowNullRef118, label %63
 
 ; <label>:63                                      ; preds = %60
   store i32 %61, i32* %62, align 8
@@ -780,14 +862,14 @@ entry:
   %65 = load i8*, i8** %arg0
   %66 = load i8*, i8** %arg1
   %67 = bitcast i8* %66 to i32*
-  %NullCheck108 = icmp ne i32* %67, null
-  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+  %NullCheck107 = icmp eq i32* %67, null
+  br i1 %NullCheck107, label %ThrowNullRef108, label %68
 
 ; <label>:68                                      ; preds = %64
   %69 = load i32, i32* %67, align 8
   %70 = bitcast i8* %65 to i32*
-  %NullCheck110 = icmp ne i32* %70, null
-  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+  %NullCheck109 = icmp eq i32* %70, null
+  br i1 %NullCheck109, label %ThrowNullRef110, label %71
 
 ; <label>:71                                      ; preds = %68
   store i32 %69, i32* %70, align 8
@@ -795,15 +877,15 @@ entry:
   %73 = getelementptr inbounds i8, i8* %72, i64 4
   %74 = load i8*, i8** %arg1
   %75 = getelementptr inbounds i8, i8* %74, i64 4
-  %NullCheck112 = icmp ne i8* %75, null
-  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+  %NullCheck111 = icmp eq i8* %75, null
+  br i1 %NullCheck111, label %ThrowNullRef112, label %76
 
 ; <label>:76                                      ; preds = %71
   %77 = load i8, i8* %75, align 8
   %78 = zext i8 %77 to i32
   %79 = trunc i32 %78 to i8
-  %NullCheck114 = icmp ne i8* %73, null
-  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+  %NullCheck113 = icmp eq i8* %73, null
+  br i1 %NullCheck113, label %ThrowNullRef114, label %80
 
 ; <label>:80                                      ; preds = %76
   store i8 %79, i8* %73, align 8
@@ -813,14 +895,14 @@ entry:
   %82 = load i8*, i8** %arg0
   %83 = load i8*, i8** %arg1
   %84 = bitcast i8* %83 to i32*
-  %NullCheck100 = icmp ne i32* %84, null
-  br i1 %NullCheck100, label %85, label %ThrowNullRef99
+  %NullCheck99 = icmp eq i32* %84, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %85
 
 ; <label>:85                                      ; preds = %81
   %86 = load i32, i32* %84, align 8
   %87 = bitcast i8* %82 to i32*
-  %NullCheck102 = icmp ne i32* %87, null
-  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+  %NullCheck101 = icmp eq i32* %87, null
+  br i1 %NullCheck101, label %ThrowNullRef102, label %88
 
 ; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
@@ -829,16 +911,16 @@ entry:
   %91 = load i8*, i8** %arg1
   %92 = getelementptr inbounds i8, i8* %91, i64 4
   %93 = bitcast i8* %92 to i16*
-  %NullCheck104 = icmp ne i16* %93, null
-  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+  %NullCheck103 = icmp eq i16* %93, null
+  br i1 %NullCheck103, label %ThrowNullRef104, label %94
 
 ; <label>:94                                      ; preds = %88
   %95 = load i16, i16* %93, align 8
   %96 = sext i16 %95 to i32
   %97 = bitcast i8* %90 to i16*
   %98 = trunc i32 %96 to i16
-  %NullCheck106 = icmp ne i16* %97, null
-  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+  %NullCheck105 = icmp eq i16* %97, null
+  br i1 %NullCheck105, label %ThrowNullRef106, label %99
 
 ; <label>:99                                      ; preds = %94
   store i16 %98, i16* %97, align 8
@@ -848,14 +930,14 @@ entry:
   %101 = load i8*, i8** %arg0
   %102 = load i8*, i8** %arg1
   %103 = bitcast i8* %102 to i32*
-  %NullCheck88 = icmp ne i32* %103, null
-  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+  %NullCheck87 = icmp eq i32* %103, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %104
 
 ; <label>:104                                     ; preds = %100
   %105 = load i32, i32* %103, align 8
   %106 = bitcast i8* %101 to i32*
-  %NullCheck90 = icmp ne i32* %106, null
-  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+  %NullCheck89 = icmp eq i32* %106, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %107
 
 ; <label>:107                                     ; preds = %104
   store i32 %105, i32* %106, align 8
@@ -864,16 +946,16 @@ entry:
   %110 = load i8*, i8** %arg1
   %111 = getelementptr inbounds i8, i8* %110, i64 4
   %112 = bitcast i8* %111 to i16*
-  %NullCheck92 = icmp ne i16* %112, null
-  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+  %NullCheck91 = icmp eq i16* %112, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %113
 
 ; <label>:113                                     ; preds = %107
   %114 = load i16, i16* %112, align 8
   %115 = sext i16 %114 to i32
   %116 = bitcast i8* %109 to i16*
   %117 = trunc i32 %115 to i16
-  %NullCheck94 = icmp ne i16* %116, null
-  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+  %NullCheck93 = icmp eq i16* %116, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %118
 
 ; <label>:118                                     ; preds = %113
   store i16 %117, i16* %116, align 8
@@ -881,15 +963,15 @@ entry:
   %120 = getelementptr inbounds i8, i8* %119, i64 6
   %121 = load i8*, i8** %arg1
   %122 = getelementptr inbounds i8, i8* %121, i64 6
-  %NullCheck96 = icmp ne i8* %122, null
-  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+  %NullCheck95 = icmp eq i8* %122, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %123
 
 ; <label>:123                                     ; preds = %118
   %124 = load i8, i8* %122, align 8
   %125 = zext i8 %124 to i32
   %126 = trunc i32 %125 to i8
-  %NullCheck98 = icmp ne i8* %120, null
-  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+  %NullCheck97 = icmp eq i8* %120, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %127
 
 ; <label>:127                                     ; preds = %123
   store i8 %126, i8* %120, align 8
@@ -899,14 +981,14 @@ entry:
   %129 = load i8*, i8** %arg0
   %130 = load i8*, i8** %arg1
   %131 = bitcast i8* %130 to i64*
-  %NullCheck84 = icmp ne i64* %131, null
-  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+  %NullCheck83 = icmp eq i64* %131, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %132
 
 ; <label>:132                                     ; preds = %128
   %133 = load i64, i64* %131, align 8
   %134 = bitcast i8* %129 to i64*
-  %NullCheck86 = icmp ne i64* %134, null
-  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+  %NullCheck85 = icmp eq i64* %134, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %135
 
 ; <label>:135                                     ; preds = %132
   store i64 %133, i64* %134, align 8
@@ -916,14 +998,14 @@ entry:
   %137 = load i8*, i8** %arg0
   %138 = load i8*, i8** %arg1
   %139 = bitcast i8* %138 to i64*
-  %NullCheck76 = icmp ne i64* %139, null
-  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+  %NullCheck75 = icmp eq i64* %139, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %140
 
 ; <label>:140                                     ; preds = %136
   %141 = load i64, i64* %139, align 8
   %142 = bitcast i8* %137 to i64*
-  %NullCheck78 = icmp ne i64* %142, null
-  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+  %NullCheck77 = icmp eq i64* %142, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %143
 
 ; <label>:143                                     ; preds = %140
   store i64 %141, i64* %142, align 8
@@ -931,15 +1013,15 @@ entry:
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %NullCheck80 = icmp ne i8* %147, null
-  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+  %NullCheck79 = icmp eq i8* %147, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %148
 
 ; <label>:148                                     ; preds = %143
   %149 = load i8, i8* %147, align 8
   %150 = zext i8 %149 to i32
   %151 = trunc i32 %150 to i8
-  %NullCheck82 = icmp ne i8* %145, null
-  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+  %NullCheck81 = icmp eq i8* %145, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %152
 
 ; <label>:152                                     ; preds = %148
   store i8 %151, i8* %145, align 8
@@ -949,14 +1031,14 @@ entry:
   %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
   %156 = bitcast i8* %155 to i64*
-  %NullCheck68 = icmp ne i64* %156, null
-  br i1 %NullCheck68, label %157, label %ThrowNullRef67
+  %NullCheck67 = icmp eq i64* %156, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %157
 
 ; <label>:157                                     ; preds = %153
   %158 = load i64, i64* %156, align 8
   %159 = bitcast i8* %154 to i64*
-  %NullCheck70 = icmp ne i64* %159, null
-  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+  %NullCheck69 = icmp eq i64* %159, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %160
 
 ; <label>:160                                     ; preds = %157
   store i64 %158, i64* %159, align 8
@@ -965,16 +1047,16 @@ entry:
   %163 = load i8*, i8** %arg1
   %164 = getelementptr inbounds i8, i8* %163, i64 8
   %165 = bitcast i8* %164 to i16*
-  %NullCheck72 = icmp ne i16* %165, null
-  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+  %NullCheck71 = icmp eq i16* %165, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %166
 
 ; <label>:166                                     ; preds = %160
   %167 = load i16, i16* %165, align 8
   %168 = sext i16 %167 to i32
   %169 = bitcast i8* %162 to i16*
   %170 = trunc i32 %168 to i16
-  %NullCheck74 = icmp ne i16* %169, null
-  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+  %NullCheck73 = icmp eq i16* %169, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %171
 
 ; <label>:171                                     ; preds = %166
   store i16 %170, i16* %169, align 8
@@ -984,14 +1066,14 @@ entry:
   %173 = load i8*, i8** %arg0
   %174 = load i8*, i8** %arg1
   %175 = bitcast i8* %174 to i64*
-  %NullCheck56 = icmp ne i64* %175, null
-  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+  %NullCheck55 = icmp eq i64* %175, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %176
 
 ; <label>:176                                     ; preds = %172
   %177 = load i64, i64* %175, align 8
   %178 = bitcast i8* %173 to i64*
-  %NullCheck58 = icmp ne i64* %178, null
-  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+  %NullCheck57 = icmp eq i64* %178, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %179
 
 ; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
@@ -1000,16 +1082,16 @@ entry:
   %182 = load i8*, i8** %arg1
   %183 = getelementptr inbounds i8, i8* %182, i64 8
   %184 = bitcast i8* %183 to i16*
-  %NullCheck60 = icmp ne i16* %184, null
-  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+  %NullCheck59 = icmp eq i16* %184, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %185
 
 ; <label>:185                                     ; preds = %179
   %186 = load i16, i16* %184, align 8
   %187 = sext i16 %186 to i32
   %188 = bitcast i8* %181 to i16*
   %189 = trunc i32 %187 to i16
-  %NullCheck62 = icmp ne i16* %188, null
-  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+  %NullCheck61 = icmp eq i16* %188, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %190
 
 ; <label>:190                                     ; preds = %185
   store i16 %189, i16* %188, align 8
@@ -1017,15 +1099,15 @@ entry:
   %192 = getelementptr inbounds i8, i8* %191, i64 10
   %193 = load i8*, i8** %arg1
   %194 = getelementptr inbounds i8, i8* %193, i64 10
-  %NullCheck64 = icmp ne i8* %194, null
-  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+  %NullCheck63 = icmp eq i8* %194, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %195
 
 ; <label>:195                                     ; preds = %190
   %196 = load i8, i8* %194, align 8
   %197 = zext i8 %196 to i32
   %198 = trunc i32 %197 to i8
-  %NullCheck66 = icmp ne i8* %192, null
-  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+  %NullCheck65 = icmp eq i8* %192, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %199
 
 ; <label>:199                                     ; preds = %195
   store i8 %198, i8* %192, align 8
@@ -1035,14 +1117,14 @@ entry:
   %201 = load i8*, i8** %arg0
   %202 = load i8*, i8** %arg1
   %203 = bitcast i8* %202 to i64*
-  %NullCheck48 = icmp ne i64* %203, null
-  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+  %NullCheck47 = icmp eq i64* %203, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %204
 
 ; <label>:204                                     ; preds = %200
   %205 = load i64, i64* %203, align 8
   %206 = bitcast i8* %201 to i64*
-  %NullCheck50 = icmp ne i64* %206, null
-  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+  %NullCheck49 = icmp eq i64* %206, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %207
 
 ; <label>:207                                     ; preds = %204
   store i64 %205, i64* %206, align 8
@@ -1051,14 +1133,14 @@ entry:
   %210 = load i8*, i8** %arg1
   %211 = getelementptr inbounds i8, i8* %210, i64 8
   %212 = bitcast i8* %211 to i32*
-  %NullCheck52 = icmp ne i32* %212, null
-  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+  %NullCheck51 = icmp eq i32* %212, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %213
 
 ; <label>:213                                     ; preds = %207
   %214 = load i32, i32* %212, align 8
   %215 = bitcast i8* %209 to i32*
-  %NullCheck54 = icmp ne i32* %215, null
-  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+  %NullCheck53 = icmp eq i32* %215, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %216
 
 ; <label>:216                                     ; preds = %213
   store i32 %214, i32* %215, align 8
@@ -1068,14 +1150,14 @@ entry:
   %218 = load i8*, i8** %arg0
   %219 = load i8*, i8** %arg1
   %220 = bitcast i8* %219 to i64*
-  %NullCheck36 = icmp ne i64* %220, null
-  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64* %220, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %221
 
 ; <label>:221                                     ; preds = %217
   %222 = load i64, i64* %220, align 8
   %223 = bitcast i8* %218 to i64*
-  %NullCheck38 = icmp ne i64* %223, null
-  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+  %NullCheck37 = icmp eq i64* %223, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %224
 
 ; <label>:224                                     ; preds = %221
   store i64 %222, i64* %223, align 8
@@ -1084,14 +1166,14 @@ entry:
   %227 = load i8*, i8** %arg1
   %228 = getelementptr inbounds i8, i8* %227, i64 8
   %229 = bitcast i8* %228 to i32*
-  %NullCheck40 = icmp ne i32* %229, null
-  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i32* %229, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %230
 
 ; <label>:230                                     ; preds = %224
   %231 = load i32, i32* %229, align 8
   %232 = bitcast i8* %226 to i32*
-  %NullCheck42 = icmp ne i32* %232, null
-  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+  %NullCheck41 = icmp eq i32* %232, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %233
 
 ; <label>:233                                     ; preds = %230
   store i32 %231, i32* %232, align 8
@@ -1099,15 +1181,15 @@ entry:
   %235 = getelementptr inbounds i8, i8* %234, i64 12
   %236 = load i8*, i8** %arg1
   %237 = getelementptr inbounds i8, i8* %236, i64 12
-  %NullCheck44 = icmp ne i8* %237, null
-  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i8* %237, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %238
 
 ; <label>:238                                     ; preds = %233
   %239 = load i8, i8* %237, align 8
   %240 = zext i8 %239 to i32
   %241 = trunc i32 %240 to i8
-  %NullCheck46 = icmp ne i8* %235, null
-  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+  %NullCheck45 = icmp eq i8* %235, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %242
 
 ; <label>:242                                     ; preds = %238
   store i8 %241, i8* %235, align 8
@@ -1117,14 +1199,14 @@ entry:
   %244 = load i8*, i8** %arg0
   %245 = load i8*, i8** %arg1
   %246 = bitcast i8* %245 to i64*
-  %NullCheck24 = icmp ne i64* %246, null
-  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64* %246, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %247
 
 ; <label>:247                                     ; preds = %243
   %248 = load i64, i64* %246, align 8
   %249 = bitcast i8* %244 to i64*
-  %NullCheck26 = icmp ne i64* %249, null
-  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64* %249, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %250
 
 ; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
@@ -1133,14 +1215,14 @@ entry:
   %253 = load i8*, i8** %arg1
   %254 = getelementptr inbounds i8, i8* %253, i64 8
   %255 = bitcast i8* %254 to i32*
-  %NullCheck28 = icmp ne i32* %255, null
-  br i1 %NullCheck28, label %256, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i32* %255, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %256
 
 ; <label>:256                                     ; preds = %250
   %257 = load i32, i32* %255, align 8
   %258 = bitcast i8* %252 to i32*
-  %NullCheck30 = icmp ne i32* %258, null
-  br i1 %NullCheck30, label %259, label %ThrowNullRef29
+  %NullCheck29 = icmp eq i32* %258, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %259
 
 ; <label>:259                                     ; preds = %256
   store i32 %257, i32* %258, align 8
@@ -1149,16 +1231,16 @@ entry:
   %262 = load i8*, i8** %arg1
   %263 = getelementptr inbounds i8, i8* %262, i64 12
   %264 = bitcast i8* %263 to i16*
-  %NullCheck32 = icmp ne i16* %264, null
-  br i1 %NullCheck32, label %265, label %ThrowNullRef31
+  %NullCheck31 = icmp eq i16* %264, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %265
 
 ; <label>:265                                     ; preds = %259
   %266 = load i16, i16* %264, align 8
   %267 = sext i16 %266 to i32
   %268 = bitcast i8* %261 to i16*
   %269 = trunc i32 %267 to i16
-  %NullCheck34 = icmp ne i16* %268, null
-  br i1 %NullCheck34, label %270, label %ThrowNullRef33
+  %NullCheck33 = icmp eq i16* %268, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %270
 
 ; <label>:270                                     ; preds = %265
   store i16 %269, i16* %268, align 8
@@ -1168,14 +1250,14 @@ entry:
   %272 = load i8*, i8** %arg0
   %273 = load i8*, i8** %arg1
   %274 = bitcast i8* %273 to i64*
-  %NullCheck8 = icmp ne i64* %274, null
-  br i1 %NullCheck8, label %275, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64* %274, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %275
 
 ; <label>:275                                     ; preds = %271
   %276 = load i64, i64* %274, align 8
   %277 = bitcast i8* %272 to i64*
-  %NullCheck10 = icmp ne i64* %277, null
-  br i1 %NullCheck10, label %278, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %277, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %278
 
 ; <label>:278                                     ; preds = %275
   store i64 %276, i64* %277, align 8
@@ -1184,14 +1266,14 @@ entry:
   %281 = load i8*, i8** %arg1
   %282 = getelementptr inbounds i8, i8* %281, i64 8
   %283 = bitcast i8* %282 to i32*
-  %NullCheck12 = icmp ne i32* %283, null
-  br i1 %NullCheck12, label %284, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i32* %283, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %284
 
 ; <label>:284                                     ; preds = %278
   %285 = load i32, i32* %283, align 8
   %286 = bitcast i8* %280 to i32*
-  %NullCheck14 = icmp ne i32* %286, null
-  br i1 %NullCheck14, label %287, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i32* %286, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %287
 
 ; <label>:287                                     ; preds = %284
   store i32 %285, i32* %286, align 8
@@ -1200,16 +1282,16 @@ entry:
   %290 = load i8*, i8** %arg1
   %291 = getelementptr inbounds i8, i8* %290, i64 12
   %292 = bitcast i8* %291 to i16*
-  %NullCheck16 = icmp ne i16* %292, null
-  br i1 %NullCheck16, label %293, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i16* %292, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %293
 
 ; <label>:293                                     ; preds = %287
   %294 = load i16, i16* %292, align 8
   %295 = sext i16 %294 to i32
   %296 = bitcast i8* %289 to i16*
   %297 = trunc i32 %295 to i16
-  %NullCheck18 = icmp ne i16* %296, null
-  br i1 %NullCheck18, label %298, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i16* %296, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %298
 
 ; <label>:298                                     ; preds = %293
   store i16 %297, i16* %296, align 8
@@ -1217,15 +1299,15 @@ entry:
   %300 = getelementptr inbounds i8, i8* %299, i64 14
   %301 = load i8*, i8** %arg1
   %302 = getelementptr inbounds i8, i8* %301, i64 14
-  %NullCheck20 = icmp ne i8* %302, null
-  br i1 %NullCheck20, label %303, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i8* %302, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %303
 
 ; <label>:303                                     ; preds = %298
   %304 = load i8, i8* %302, align 8
   %305 = zext i8 %304 to i32
   %306 = trunc i32 %305 to i8
-  %NullCheck22 = icmp ne i8* %300, null
-  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i8* %300, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %307
 
 ; <label>:307                                     ; preds = %303
   store i8 %306, i8* %300, align 8
@@ -1235,14 +1317,14 @@ entry:
   %309 = load i8*, i8** %arg0
   %310 = load i8*, i8** %arg1
   %311 = bitcast i8* %310 to i64*
-  %NullCheck = icmp ne i64* %311, null
-  br i1 %NullCheck, label %312, label %ThrowNullRef
+  %NullCheck = icmp eq i64* %311, null
+  br i1 %NullCheck, label %ThrowNullRef, label %312
 
 ; <label>:312                                     ; preds = %308
   %313 = load i64, i64* %311, align 8
   %314 = bitcast i8* %309 to i64*
-  %NullCheck2 = icmp ne i64* %314, null
-  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64* %314, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %315
 
 ; <label>:315                                     ; preds = %312
   store i64 %313, i64* %314, align 8
@@ -1251,14 +1333,14 @@ entry:
   %318 = load i8*, i8** %arg1
   %319 = getelementptr inbounds i8, i8* %318, i64 8
   %320 = bitcast i8* %319 to i64*
-  %NullCheck4 = icmp ne i64* %320, null
-  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64* %320, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %321
 
 ; <label>:321                                     ; preds = %315
   %322 = load i64, i64* %320, align 8
   %323 = bitcast i8* %317 to i64*
-  %NullCheck6 = icmp ne i64* %323, null
-  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64* %323, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %324
 
 ; <label>:324                                     ; preds = %321
   store i64 %322, i64* %323, align 8
@@ -1286,15 +1368,15 @@ entry:
 ; <label>:338                                     ; preds = %333
   %339 = load i8*, i8** %arg0
   %340 = load i8*, i8** %arg1
-  %NullCheck136 = icmp ne i8* %340, null
-  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+  %NullCheck135 = icmp eq i8* %340, null
+  br i1 %NullCheck135, label %ThrowNullRef136, label %341
 
 ; <label>:341                                     ; preds = %338
   %342 = load i8, i8* %340, align 8
   %343 = zext i8 %342 to i32
   %344 = trunc i32 %343 to i8
-  %NullCheck138 = icmp ne i8* %339, null
-  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+  %NullCheck137 = icmp eq i8* %339, null
+  br i1 %NullCheck137, label %ThrowNullRef138, label %345
 
 ; <label>:345                                     ; preds = %341
   store i8 %344, i8* %339, align 8
@@ -1317,16 +1399,16 @@ entry:
   %357 = load i8*, i8** %arg0
   %358 = load i8*, i8** %arg1
   %359 = bitcast i8* %358 to i16*
-  %NullCheck140 = icmp ne i16* %359, null
-  br i1 %NullCheck140, label %360, label %ThrowNullRef139
+  %NullCheck139 = icmp eq i16* %359, null
+  br i1 %NullCheck139, label %ThrowNullRef140, label %360
 
 ; <label>:360                                     ; preds = %356
   %361 = load i16, i16* %359, align 8
   %362 = sext i16 %361 to i32
   %363 = bitcast i8* %357 to i16*
   %364 = trunc i32 %362 to i16
-  %NullCheck142 = icmp ne i16* %363, null
-  br i1 %NullCheck142, label %365, label %ThrowNullRef141
+  %NullCheck141 = icmp eq i16* %363, null
+  br i1 %NullCheck141, label %ThrowNullRef142, label %365
 
 ; <label>:365                                     ; preds = %360
   store i16 %364, i16* %363, align 8
@@ -1352,14 +1434,14 @@ entry:
   %378 = load i8*, i8** %arg0
   %379 = load i8*, i8** %arg1
   %380 = bitcast i8* %379 to i32*
-  %NullCheck144 = icmp ne i32* %380, null
-  br i1 %NullCheck144, label %381, label %ThrowNullRef143
+  %NullCheck143 = icmp eq i32* %380, null
+  br i1 %NullCheck143, label %ThrowNullRef144, label %381
 
 ; <label>:381                                     ; preds = %377
   %382 = load i32, i32* %380, align 8
   %383 = bitcast i8* %378 to i32*
-  %NullCheck146 = icmp ne i32* %383, null
-  br i1 %NullCheck146, label %384, label %ThrowNullRef145
+  %NullCheck145 = icmp eq i32* %383, null
+  br i1 %NullCheck145, label %ThrowNullRef146, label %384
 
 ; <label>:384                                     ; preds = %381
   store i32 %382, i32* %383, align 8
@@ -1384,14 +1466,14 @@ entry:
   %395 = load i8*, i8** %arg0
   %396 = load i8*, i8** %arg1
   %397 = bitcast i8* %396 to i64*
-  %NullCheck164 = icmp ne i64* %397, null
-  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+  %NullCheck163 = icmp eq i64* %397, null
+  br i1 %NullCheck163, label %ThrowNullRef164, label %398
 
 ; <label>:398                                     ; preds = %394
   %399 = load i64, i64* %397, align 8
   %400 = bitcast i8* %395 to i64*
-  %NullCheck166 = icmp ne i64* %400, null
-  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+  %NullCheck165 = icmp eq i64* %400, null
+  br i1 %NullCheck165, label %ThrowNullRef166, label %401
 
 ; <label>:401                                     ; preds = %398
   store i64 %399, i64* %400, align 8
@@ -1400,14 +1482,14 @@ entry:
   %404 = load i8*, i8** %arg1
   %405 = getelementptr inbounds i8, i8* %404, i64 8
   %406 = bitcast i8* %405 to i64*
-  %NullCheck168 = icmp ne i64* %406, null
-  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+  %NullCheck167 = icmp eq i64* %406, null
+  br i1 %NullCheck167, label %ThrowNullRef168, label %407
 
 ; <label>:407                                     ; preds = %401
   %408 = load i64, i64* %406, align 8
   %409 = bitcast i8* %403 to i64*
-  %NullCheck170 = icmp ne i64* %409, null
-  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+  %NullCheck169 = icmp eq i64* %409, null
+  br i1 %NullCheck169, label %ThrowNullRef170, label %410
 
 ; <label>:410                                     ; preds = %407
   store i64 %408, i64* %409, align 8
@@ -1437,14 +1519,14 @@ entry:
   %425 = load i8*, i8** %arg0
   %426 = load i8*, i8** %arg1
   %427 = bitcast i8* %426 to i64*
-  %NullCheck148 = icmp ne i64* %427, null
-  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+  %NullCheck147 = icmp eq i64* %427, null
+  br i1 %NullCheck147, label %ThrowNullRef148, label %428
 
 ; <label>:428                                     ; preds = %424
   %429 = load i64, i64* %427, align 8
   %430 = bitcast i8* %425 to i64*
-  %NullCheck150 = icmp ne i64* %430, null
-  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+  %NullCheck149 = icmp eq i64* %430, null
+  br i1 %NullCheck149, label %ThrowNullRef150, label %431
 
 ; <label>:431                                     ; preds = %428
   store i64 %429, i64* %430, align 8
@@ -1466,14 +1548,14 @@ entry:
   %441 = load i8*, i8** %arg0
   %442 = load i8*, i8** %arg1
   %443 = bitcast i8* %442 to i32*
-  %NullCheck152 = icmp ne i32* %443, null
-  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+  %NullCheck151 = icmp eq i32* %443, null
+  br i1 %NullCheck151, label %ThrowNullRef152, label %444
 
 ; <label>:444                                     ; preds = %440
   %445 = load i32, i32* %443, align 8
   %446 = bitcast i8* %441 to i32*
-  %NullCheck154 = icmp ne i32* %446, null
-  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+  %NullCheck153 = icmp eq i32* %446, null
+  br i1 %NullCheck153, label %ThrowNullRef154, label %447
 
 ; <label>:447                                     ; preds = %444
   store i32 %445, i32* %446, align 8
@@ -1495,16 +1577,16 @@ entry:
   %457 = load i8*, i8** %arg0
   %458 = load i8*, i8** %arg1
   %459 = bitcast i8* %458 to i16*
-  %NullCheck156 = icmp ne i16* %459, null
-  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+  %NullCheck155 = icmp eq i16* %459, null
+  br i1 %NullCheck155, label %ThrowNullRef156, label %460
 
 ; <label>:460                                     ; preds = %456
   %461 = load i16, i16* %459, align 8
   %462 = sext i16 %461 to i32
   %463 = bitcast i8* %457 to i16*
   %464 = trunc i32 %462 to i16
-  %NullCheck158 = icmp ne i16* %463, null
-  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+  %NullCheck157 = icmp eq i16* %463, null
+  br i1 %NullCheck157, label %ThrowNullRef158, label %465
 
 ; <label>:465                                     ; preds = %460
   store i16 %464, i16* %463, align 8
@@ -1525,15 +1607,15 @@ entry:
 ; <label>:474                                     ; preds = %470
   %475 = load i8*, i8** %arg0
   %476 = load i8*, i8** %arg1
-  %NullCheck160 = icmp ne i8* %476, null
-  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+  %NullCheck159 = icmp eq i8* %476, null
+  br i1 %NullCheck159, label %ThrowNullRef160, label %477
 
 ; <label>:477                                     ; preds = %474
   %478 = load i8, i8* %476, align 8
   %479 = zext i8 %478 to i32
   %480 = trunc i32 %479 to i8
-  %NullCheck162 = icmp ne i8* %475, null
-  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+  %NullCheck161 = icmp eq i8* %475, null
+  br i1 %NullCheck161, label %ThrowNullRef162, label %481
 
 ; <label>:481                                     ; preds = %477
   store i8 %480, i8* %475, align 8
@@ -1553,343 +1635,343 @@ ThrowNullRef:                                     ; preds = %308
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %312
+ThrowNullRef2:                                    ; preds = %312
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %315
+ThrowNullRef4:                                    ; preds = %315
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %321
+ThrowNullRef6:                                    ; preds = %321
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %271
+ThrowNullRef8:                                    ; preds = %271
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %275
+ThrowNullRef10:                                   ; preds = %275
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %278
+ThrowNullRef12:                                   ; preds = %278
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %284
+ThrowNullRef14:                                   ; preds = %284
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %287
+ThrowNullRef16:                                   ; preds = %287
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %293
+ThrowNullRef18:                                   ; preds = %293
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %298
+ThrowNullRef20:                                   ; preds = %298
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %303
+ThrowNullRef22:                                   ; preds = %303
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %243
+ThrowNullRef24:                                   ; preds = %243
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %247
+ThrowNullRef26:                                   ; preds = %247
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %250
+ThrowNullRef28:                                   ; preds = %250
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %256
+ThrowNullRef30:                                   ; preds = %256
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %259
+ThrowNullRef32:                                   ; preds = %259
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %265
+ThrowNullRef34:                                   ; preds = %265
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %217
+ThrowNullRef36:                                   ; preds = %217
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %221
+ThrowNullRef38:                                   ; preds = %221
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %224
+ThrowNullRef40:                                   ; preds = %224
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %230
+ThrowNullRef42:                                   ; preds = %230
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %233
+ThrowNullRef44:                                   ; preds = %233
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %238
+ThrowNullRef46:                                   ; preds = %238
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %200
+ThrowNullRef48:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %204
+ThrowNullRef50:                                   ; preds = %204
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %207
+ThrowNullRef52:                                   ; preds = %207
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %213
+ThrowNullRef54:                                   ; preds = %213
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %172
+ThrowNullRef56:                                   ; preds = %172
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %176
+ThrowNullRef58:                                   ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %179
+ThrowNullRef60:                                   ; preds = %179
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %185
+ThrowNullRef62:                                   ; preds = %185
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %190
+ThrowNullRef64:                                   ; preds = %190
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %195
+ThrowNullRef66:                                   ; preds = %195
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %153
+ThrowNullRef68:                                   ; preds = %153
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %157
+ThrowNullRef70:                                   ; preds = %157
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %160
+ThrowNullRef72:                                   ; preds = %160
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %166
+ThrowNullRef74:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %136
+ThrowNullRef76:                                   ; preds = %136
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %140
+ThrowNullRef78:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %143
+ThrowNullRef80:                                   ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %148
+ThrowNullRef82:                                   ; preds = %148
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %128
+ThrowNullRef84:                                   ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %132
+ThrowNullRef86:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %100
+ThrowNullRef88:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %104
+ThrowNullRef90:                                   ; preds = %104
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %107
+ThrowNullRef92:                                   ; preds = %107
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %113
+ThrowNullRef94:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %118
+ThrowNullRef96:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %123
+ThrowNullRef98:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %81
+ThrowNullRef100:                                  ; preds = %81
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef101:                                  ; preds = %85
+ThrowNullRef102:                                  ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef103:                                  ; preds = %88
+ThrowNullRef104:                                  ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef105:                                  ; preds = %94
+ThrowNullRef106:                                  ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef107:                                  ; preds = %64
+ThrowNullRef108:                                  ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef109:                                  ; preds = %68
+ThrowNullRef110:                                  ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef111:                                  ; preds = %71
+ThrowNullRef112:                                  ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef113:                                  ; preds = %76
+ThrowNullRef114:                                  ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef115:                                  ; preds = %56
+ThrowNullRef116:                                  ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef117:                                  ; preds = %60
+ThrowNullRef118:                                  ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef119:                                  ; preds = %37
+ThrowNullRef120:                                  ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef121:                                  ; preds = %41
+ThrowNullRef122:                                  ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef123:                                  ; preds = %46
+ThrowNullRef124:                                  ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef125:                                  ; preds = %51
+ThrowNullRef126:                                  ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef127:                                  ; preds = %27
+ThrowNullRef128:                                  ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef129:                                  ; preds = %31
+ThrowNullRef130:                                  ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef131:                                  ; preds = %19
+ThrowNullRef132:                                  ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef133:                                  ; preds = %22
+ThrowNullRef134:                                  ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef135:                                  ; preds = %338
+ThrowNullRef136:                                  ; preds = %338
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef137:                                  ; preds = %341
+ThrowNullRef138:                                  ; preds = %341
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef139:                                  ; preds = %356
+ThrowNullRef140:                                  ; preds = %356
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef141:                                  ; preds = %360
+ThrowNullRef142:                                  ; preds = %360
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef143:                                  ; preds = %377
+ThrowNullRef144:                                  ; preds = %377
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef145:                                  ; preds = %381
+ThrowNullRef146:                                  ; preds = %381
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef147:                                  ; preds = %424
+ThrowNullRef148:                                  ; preds = %424
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef149:                                  ; preds = %428
+ThrowNullRef150:                                  ; preds = %428
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef151:                                  ; preds = %440
+ThrowNullRef152:                                  ; preds = %440
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef153:                                  ; preds = %444
+ThrowNullRef154:                                  ; preds = %444
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef155:                                  ; preds = %456
+ThrowNullRef156:                                  ; preds = %456
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef157:                                  ; preds = %460
+ThrowNullRef158:                                  ; preds = %460
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef159:                                  ; preds = %474
+ThrowNullRef160:                                  ; preds = %474
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef161:                                  ; preds = %477
+ThrowNullRef162:                                  ; preds = %477
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef163:                                  ; preds = %394
+ThrowNullRef164:                                  ; preds = %394
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef165:                                  ; preds = %398
+ThrowNullRef166:                                  ; preds = %398
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef167:                                  ; preds = %401
+ThrowNullRef168:                                  ; preds = %401
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef169:                                  ; preds = %407
+ThrowNullRef170:                                  ; preds = %407
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1939,8 +2021,8 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
-  br i1 %NullCheck, label %22, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %ThrowNullRef, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
@@ -1948,8 +2030,8 @@ entry:
   store i32 %24, i32* %loc0
   %25 = load i32, i32* %loc0
   %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %26, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %27
 
 ; <label>:27                                      ; preds = %22
   %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
@@ -1971,7 +2053,7 @@ ThrowNullRef:                                     ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1989,8 +2071,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -2022,15 +2104,15 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2048,16 +2130,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
   %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
   store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %15
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
@@ -2072,8 +2154,8 @@ entry:
   %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
   %29 = ptrtoint i16 addrspace(1)* %28 to i64
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %19
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
@@ -2089,19 +2171,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2114,8 +2196,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
@@ -2128,7 +2210,7 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[loadElem]
+Failed to read AppDomain.PrepareDataForSetup[storeElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
@@ -2202,8 +2284,8 @@ entry:
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
-  br i1 %NullCheck24, label %27, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = load i64, i64 addrspace(1)* %26
@@ -2218,8 +2300,8 @@ entry:
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
-  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
   %41 = load i64, i64 addrspace(1)* %39
@@ -2236,8 +2318,8 @@ entry:
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
-  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
   %54 = load i64, i64 addrspace(1)* %52
@@ -2252,8 +2334,8 @@ entry:
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
   %67 = load i64, i64 addrspace(1)* %65
@@ -2270,8 +2352,8 @@ entry:
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
-  br i1 %NullCheck16, label %79, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
   %80 = load i64, i64 addrspace(1)* %78
@@ -2286,8 +2368,8 @@ entry:
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
-  br i1 %NullCheck18, label %92, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
   %93 = load i64, i64 addrspace(1)* %91
@@ -2304,8 +2386,8 @@ entry:
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
-  br i1 %NullCheck12, label %105, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = load i64, i64 addrspace(1)* %104
@@ -2320,8 +2402,8 @@ entry:
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
-  br i1 %NullCheck14, label %118, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
   %119 = load i64, i64 addrspace(1)* %117
@@ -2337,8 +2419,8 @@ entry:
 
 ; <label>:128                                     ; preds = %20
   %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
-  br i1 %NullCheck4, label %130, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %129, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %130
 
 ; <label>:130                                     ; preds = %128
   %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
@@ -2346,8 +2428,8 @@ entry:
   %133 = load i16, i16 addrspace(1)* %132, align 8
   %134 = zext i16 %133 to i32
   %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
-  br i1 %NullCheck6, label %136, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %135, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %136
 
 ; <label>:136                                     ; preds = %130
   %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
@@ -2360,8 +2442,8 @@ entry:
 
 ; <label>:143                                     ; preds = %136
   %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
-  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %144, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %145
 
 ; <label>:145                                     ; preds = %143
   %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
@@ -2369,8 +2451,8 @@ entry:
   %148 = load i16, i16 addrspace(1)* %147, align 8
   %149 = zext i16 %148 to i32
   %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %150, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %151
 
 ; <label>:151                                     ; preds = %145
   %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
@@ -2388,8 +2470,8 @@ entry:
 
 ; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
-  br i1 %NullCheck, label %163, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %ThrowNullRef, label %163
 
 ; <label>:163                                     ; preds = %161
   %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
@@ -2399,8 +2481,8 @@ entry:
 
 ; <label>:167                                     ; preds = %163
   %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
-  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %168, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %169
 
 ; <label>:169                                     ; preds = %167
   %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
@@ -2432,55 +2514,55 @@ ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %167
+ThrowNullRef2:                                    ; preds = %167
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %128
+ThrowNullRef4:                                    ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %130
+ThrowNullRef6:                                    ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %143
+ThrowNullRef8:                                    ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %145
+ThrowNullRef10:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %102
+ThrowNullRef12:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %105
+ThrowNullRef14:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %76
+ThrowNullRef16:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %79
+ThrowNullRef18:                                   ; preds = %79
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %50
+ThrowNullRef20:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %53
+ThrowNullRef22:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %24
+ThrowNullRef24:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %27
+ThrowNullRef26:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2503,15 +2585,15 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2519,16 +2601,16 @@ entry:
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
   store i32 %8, i32* %loc0
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
   %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
   store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
@@ -2546,16 +2628,16 @@ entry:
 
 ; <label>:23                                      ; preds = %64
   %24 = load i16*, i16** %loc3
-  %NullCheck12 = icmp ne i16* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i16* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
   store i32 %27, i32* %loc5
   %28 = load i16*, i16** %loc4
-  %NullCheck14 = icmp ne i16* %28, null
-  br i1 %NullCheck14, label %29, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %28, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = load i16, i16* %28, align 8
@@ -2620,15 +2702,15 @@ entry:
 
 ; <label>:67                                      ; preds = %64
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
-  br i1 %NullCheck8, label %69, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %68, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %69
 
 ; <label>:69                                      ; preds = %67
   %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
   %71 = load i32, i32 addrspace(1)* %70
   %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
-  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %73
 
 ; <label>:73                                      ; preds = %69
   %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
@@ -2645,31 +2727,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %67
+ThrowNullRef8:                                    ; preds = %67
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %69
+ThrowNullRef10:                                   ; preds = %69
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2710,14 +2792,14 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
   %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
@@ -2730,14 +2812,14 @@ entry:
 
 ; <label>:11                                      ; preds = %4
   %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
   %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
@@ -2749,14 +2831,14 @@ entry:
 
 ; <label>:22                                      ; preds = %16
   %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
   %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
-  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
-  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
@@ -2804,23 +2886,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2836,7 +2918,280 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[loadElem]
+Successfully read RuntimeType.IsAssignableFrom
+
+define i8 @RuntimeType.IsAssignableFrom(%System.RuntimeType addrspace(1)* %param0, %System.Type addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.RuntimeType addrspace(1)*
+  %arg1 = alloca %System.Type addrspace(1)*
+  %loc0 = alloca %System.RuntimeType addrspace(1)*
+  %loc1 = alloca %"System.Type[]" addrspace(1)*
+  %loc2 = alloca i32
+  store %System.RuntimeType addrspace(1)* %param0, %System.RuntimeType addrspace(1)** %this
+  store %System.Type addrspace(1)* %param1, %System.Type addrspace(1)** %arg1
+  %0 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %1 = icmp ne %System.Type addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i8 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %5 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %6 = bitcast %System.Type addrspace(1)* %4 to %System.Object addrspace(1)*
+  %7 = bitcast %System.RuntimeType addrspace(1)* %5 to %System.Object addrspace(1)*
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %6, %System.Object addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %3
+  ret i8 1
+
+; <label>:12                                      ; preds = %3
+  %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 152
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 32
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
+  %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
+  %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
+  store %System.RuntimeType addrspace(1)* %25, %System.RuntimeType addrspace(1)** %loc0
+  %26 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %27 = icmp eq %System.RuntimeType addrspace(1)* %26, null
+  br i1 %27, label %34, label %28
+
+; <label>:28                                      ; preds = %15
+  %29 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %30 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)*)*)(%System.RuntimeType addrspace(1)* %29, %System.RuntimeType addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+; <label>:34                                      ; preds = %15
+  %35 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %36 = call %System.Reflection.Emit.TypeBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Reflection.Emit.TypeBuilder addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %35)
+  %37 = icmp eq %System.Reflection.Emit.TypeBuilder addrspace(1)* %36, null
+  br i1 %37, label %139, label %38
+
+; <label>:38                                      ; preds = %34
+  %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %42
+
+; <label>:42                                      ; preds = %38
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 152
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 40
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
+  %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
+  %53 = zext i8 %52 to i32
+  %54 = icmp eq i32 %53, 0
+  br i1 %54, label %56, label %55
+
+; <label>:55                                      ; preds = %42
+  ret i8 1
+
+; <label>:56                                      ; preds = %42
+  %57 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %58 = bitcast %System.RuntimeType addrspace(1)* %57 to %System.Type addrspace(1)*
+  %59 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %58)
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %64 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.Type addrspace(1)* %63, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = bitcast %System.RuntimeType addrspace(1)* %64 to %System.Type addrspace(1)*
+  %67 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %63, %System.Type addrspace(1)* %66)
+  %68 = zext i8 %67 to i32
+  %69 = trunc i32 %68 to i8
+  ret i8 %69
+
+; <label>:70                                      ; preds = %56
+  %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
+  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %73
+
+; <label>:73                                      ; preds = %70
+  %74 = load i64, i64 addrspace(1)* %72
+  %75 = add i64 %74, 128
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = add i64 %77, 0
+  %79 = inttoptr i64 %78 to i64*
+  %80 = load i64, i64* %79
+  %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
+  %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
+  %83 = call i8 %82(%System.Type addrspace(1)* %81)
+  %84 = zext i8 %83 to i32
+  %85 = icmp eq i32 %84, 0
+  br i1 %85, label %139, label %86
+
+; <label>:86                                      ; preds = %73
+  %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
+  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %89
+
+; <label>:89                                      ; preds = %86
+  %90 = load i64, i64 addrspace(1)* %88
+  %91 = add i64 %90, 128
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = add i64 %93, 24
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
+  %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
+  %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
+  store %"System.Type[]" addrspace(1)* %99, %"System.Type[]" addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %129
+
+; <label>:100                                     ; preds = %132
+  %101 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %102 = load i32, i32* %loc2
+  %NullCheck11 = icmp eq %"System.Type[]" addrspace(1)* %101, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %103
+
+; <label>:103                                     ; preds = %100
+  %104 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 1
+  %105 = load i32, i32 addrspace(1)* %104
+  %106 = zext i32 %105 to i64
+  %107 = zext i32 %102 to i64
+  %BoundsCheck = icmp uge i64 %107, %106
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %108
+
+; <label>:108                                     ; preds = %103
+  %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
+  %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
+  %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
+  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %113
+
+; <label>:113                                     ; preds = %108
+  %114 = load i64, i64 addrspace(1)* %112
+  %115 = add i64 %114, 152
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = add i64 %117, 56
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
+  %123 = zext i8 %122 to i32
+  %124 = icmp ne i32 %123, 0
+  br i1 %124, label %126, label %125
+
+; <label>:125                                     ; preds = %113
+  ret i8 0
+
+; <label>:126                                     ; preds = %113
+  %127 = load i32, i32* %loc2
+  %128 = add i32 %127, 1
+  store i32 %128, i32* %loc2
+  br label %129
+
+; <label>:129                                     ; preds = %89, %126
+  %130 = load i32, i32* %loc2
+  %131 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %NullCheck9 = icmp eq %"System.Type[]" addrspace(1)* %131, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %132
+
+; <label>:132                                     ; preds = %129
+  %133 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %131, i32 0, i32 1
+  %134 = load i32, i32 addrspace(1)* %133
+  %135 = zext i32 %134 to i64
+  %136 = trunc i64 %135 to i32
+  %137 = icmp slt i32 %130, %136
+  br i1 %137, label %100, label %138
+
+; <label>:138                                     ; preds = %132
+  ret i8 1
+
+; <label>:139                                     ; preds = %34, %73
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %129
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %103
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -2893,7 +3248,7 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElem]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -2904,8 +3259,8 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -2997,8 +3352,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
@@ -3059,8 +3414,8 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -3087,8 +3442,8 @@ entry:
 
 ; <label>:17                                      ; preds = %5, %11
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
@@ -3097,8 +3452,8 @@ entry:
 
 ; <label>:22                                      ; preds = %1, %11
   %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
@@ -3109,11 +3464,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %17
+ThrowNullRef2:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %22
+ThrowNullRef4:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3167,15 +3522,15 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
   %15 = load i32, i32 addrspace(1)* %14
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
@@ -3198,7 +3553,7 @@ ThrowNullRef:                                     ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef2:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3232,8 +3587,8 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
@@ -3312,8 +3667,8 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -3327,8 +3682,8 @@ entry:
 ; <label>:5                                       ; preds = %43
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %7 = load i32, i32* %loc1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck6, label %8, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
@@ -3366,8 +3721,8 @@ entry:
 ; <label>:32                                      ; preds = %21, %25
   %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
   %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
-  br i1 %NullCheck8, label %35, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = trunc i32 %34 to i16
@@ -3380,8 +3735,8 @@ entry:
 ; <label>:40                                      ; preds = %1, %35
   %41 = load i32, i32* %loc1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
-  br i1 %NullCheck2, label %43, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %42, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
@@ -3392,8 +3747,8 @@ entry:
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
   %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
-  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
   %51 = load i64, i64 addrspace(1)* %49
@@ -3412,19 +3767,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %40
+ThrowNullRef2:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %47
+ThrowNullRef4:                                    ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %5
+ThrowNullRef6:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %32
+ThrowNullRef8:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3467,8 +3822,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
@@ -3492,11 +3847,391 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(i16* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store i16* %param0, i16** %arg0
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load i32, i32* %arg3
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %42, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %37, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg2
+  %13 = load i32, i32* %arg3
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %37, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %24 = load i32, i32* %arg2
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load i16*, i16** %arg0
+  %35 = load i32, i32* %arg3
+  %36 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %36, i16* %34, i32 %35)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:37                                      ; preds = %5, %16
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %39)
+  %41 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41, %System.String addrspace(1)* %38, %System.String addrspace(1)* %40)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41) #0
+  unreachable
+
+; <label>:42                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
-Failed to read StringBuilder.ToString[loadElemA]
+Successfully read StringBuilder.ToString
+
+define %System.String addrspace(1)* @StringBuilder.ToString(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i16*
+  %loc3 = alloca %"System.Char[]" addrspace(1)*
+  %loc4 = alloca i32
+  %loc5 = alloca i32
+  %loc6 = alloca i16 addrspace(1)*
+  %loc7 = alloca %System.String addrspace(1)*
+  %loc8 = alloca %"System.Char[]" addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %0)
+  %2 = icmp ne i32 %1, 0
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %4
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %6)
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %7)
+  store %System.String addrspace(1)* %8, %System.String addrspace(1)** %loc0
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.Text.StringBuilder addrspace(1)* %9, %System.Text.StringBuilder addrspace(1)** %loc1
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  store %System.String addrspace(1)* %10, %System.String addrspace(1)** %loc7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc7
+  %12 = ptrtoint %System.String addrspace(1)* %11 to i64
+  %13 = icmp eq i64 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %5
+  %15 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %16 = sext i32 %15 to i64
+  %17 = add i64 %12, %16
+  br label %18
+
+; <label>:18                                      ; preds = %5, %14
+  %19 = phi i64 [ %12, %5 ], [ %17, %14 ]
+  %20 = inttoptr i64 %19 to i16*
+  store i16* %20, i16** %loc2
+  br label %21
+
+; <label>:21                                      ; preds = %98, %18
+  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %22, null
+  br i1 %NullCheck, label %ThrowNullRef, label %23
+
+; <label>:23                                      ; preds = %21
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 3
+  %25 = load i32, i32 addrspace(1)* %24, align 8
+  %26 = icmp sle i32 %25, 0
+  br i1 %26, label %96, label %27
+
+; <label>:27                                      ; preds = %23
+  %28 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %28, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %29
+
+; <label>:29                                      ; preds = %27
+  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %28, i32 0, i32 1
+  %31 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %30, align 8
+  store %"System.Char[]" addrspace(1)* %31, %"System.Char[]" addrspace(1)** %loc3
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %33
+
+; <label>:33                                      ; preds = %29
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  store i32 %35, i32* %loc4
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  %39 = load i32, i32 addrspace(1)* %38, align 8
+  store i32 %39, i32* %loc5
+  %40 = load i32, i32* %loc5
+  %41 = load i32, i32* %loc4
+  %42 = add i32 %40, %41
+  %43 = zext i32 %42 to i64
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %45
+
+; <label>:45                                      ; preds = %37
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = sext i32 %47 to i64
+  %49 = icmp sgt i64 %43, %48
+  br i1 %49, label %91, label %50
+
+; <label>:50                                      ; preds = %45
+  %51 = load i32, i32* %loc5
+  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %52, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %53
+
+; <label>:53                                      ; preds = %50
+  %54 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %52, i32 0, i32 1
+  %55 = load i32, i32 addrspace(1)* %54
+  %56 = zext i32 %55 to i64
+  %57 = trunc i64 %56 to i32
+  %58 = icmp ugt i32 %51, %57
+  br i1 %58, label %91, label %59
+
+; <label>:59                                      ; preds = %53
+  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  store %"System.Char[]" addrspace(1)* %60, %"System.Char[]" addrspace(1)** %loc8
+  %61 = icmp eq %"System.Char[]" addrspace(1)* %60, null
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %63, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %64
+
+; <label>:64                                      ; preds = %62
+  %65 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %63, i32 0, i32 1
+  %66 = load i32, i32 addrspace(1)* %65
+  %67 = zext i32 %66 to i64
+  %68 = trunc i64 %67 to i32
+  %69 = icmp ne i32 %68, 0
+  br i1 %69, label %71, label %70
+
+; <label>:70                                      ; preds = %59, %64
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:71                                      ; preds = %64
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %73
+
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %BoundsCheck = icmp uge i64 0, %76
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %77
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %78, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:79                                      ; preds = %70, %77
+  %80 = load i16*, i16** %loc2
+  %81 = load i32, i32* %loc4
+  %82 = sext i32 %81 to i64
+  %83 = mul i64 %82, 2
+  %84 = bitcast i16* %80 to i8*
+  %85 = getelementptr inbounds i8, i8* %84, i64 %83
+  %86 = load i16 addrspace(1)*, i16 addrspace(1)** %loc6
+  %87 = ptrtoint i16 addrspace(1)* %86 to i64
+  %88 = load i32, i32* %loc5
+  %89 = bitcast i8* %85 to i16*
+  %90 = inttoptr i64 %87 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %89, i16* %90, i32 %88)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %96
+
+; <label>:91                                      ; preds = %45, %53
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %94 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %93)
+  %95 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95, %System.String addrspace(1)* %92, %System.String addrspace(1)* %94)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95) #0
+  unreachable
+
+; <label>:96                                      ; preds = %23, %79
+  %97 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %97, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %98
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %97, i32 0, i32 2
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  store %System.Text.StringBuilder addrspace(1)* %100, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %102 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %102, label %21, label %103
+
+; <label>:103                                     ; preds = %98
+  store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc7
+  %104 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  ret %System.String addrspace(1)* %104
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method StringBuilder::get_Length using LLILCJit
+Successfully read StringBuilder.get_Length
+
+define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
+Successfully read RuntimeHelpers.get_OffsetToStringData
+
+define i32 @RuntimeHelpers.get_OffsetToStringData() {
+entry:
+  ret i32 12
+}
+
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
 Successfully read CultureData.CreateCultureData
 
@@ -3514,23 +4249,23 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
   store i8 %4, i8 addrspace(1)* %6
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
@@ -3549,11 +4284,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3566,50 +4301,50 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
   store i32 -1, i32 addrspace(1)* %2
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
   store i32 -1, i32 addrspace(1)* %8
   %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
   store i32 -1, i32 addrspace(1)* %14
   %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
   store i32 -1, i32 addrspace(1)* %17
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
@@ -3623,27 +4358,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3675,7 +4410,136 @@ Failed to read Dictionary`2.Insert[non-const derefAddress]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
 Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
-Failed to read HashHelpers.GetPrime[loadElem]
+Successfully read HashHelpers.GetPrime
+
+define i32 @HashHelpers.GetPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %6, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5, %System.String addrspace(1)* %4)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5) #0
+  unreachable
+
+; <label>:6                                       ; preds = %entry
+  store i32 0, i32* %loc0
+  br label %29
+
+; <label>:7                                       ; preds = %35
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 1296
+  %10 = addrspacecast i8 addrspace(1)* %9 to %"System.Int32[]" addrspace(1)**
+  %11 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %10
+  %12 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Int32[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = zext i32 %15 to i64
+  %17 = zext i32 %12 to i64
+  %BoundsCheck = icmp uge i64 %17, %16
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 3, i32 %12
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  store i32 %20, i32* %loc1
+  %21 = load i32, i32* %loc1
+  %22 = load i32, i32* %arg0
+  %23 = icmp slt i32 %21, %22
+  br i1 %23, label %26, label %24
+
+; <label>:24                                      ; preds = %18
+  %25 = load i32, i32* %loc1
+  ret i32 %25
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %loc0
+  %28 = add i32 %27, 1
+  store i32 %28, i32* %loc0
+  br label %29
+
+; <label>:29                                      ; preds = %6, %26
+  %30 = load i32, i32* %loc0
+  %31 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %32 = getelementptr inbounds i8, i8 addrspace(1)* %31, i64 1296
+  %33 = addrspacecast i8 addrspace(1)* %32 to %"System.Int32[]" addrspace(1)**
+  %34 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %33
+  %NullCheck = icmp eq %"System.Int32[]" addrspace(1)* %34, null
+  br i1 %NullCheck, label %ThrowNullRef, label %35
+
+; <label>:35                                      ; preds = %29
+  %36 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %34, i32 0, i32 1
+  %37 = load i32, i32 addrspace(1)* %36
+  %38 = zext i32 %37 to i64
+  %39 = trunc i64 %38 to i32
+  %40 = icmp slt i32 %30, %39
+  br i1 %40, label %7, label %41
+
+; <label>:41                                      ; preds = %35
+  %42 = load i32, i32* %arg0
+  %43 = or i32 %42, 1
+  store i32 %43, i32* %loc2
+  br label %59
+
+; <label>:44                                      ; preds = %59
+  %45 = load i32, i32* %loc2
+  %46 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %45)
+  %47 = zext i8 %46 to i32
+  %48 = icmp eq i32 %47, 0
+  br i1 %48, label %56, label %49
+
+; <label>:49                                      ; preds = %44
+  %50 = load i32, i32* %loc2
+  %51 = sub i32 %50, 1
+  %52 = srem i32 %51, 101
+  %53 = icmp eq i32 %52, 0
+  br i1 %53, label %56, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = load i32, i32* %loc2
+  ret i32 %55
+
+; <label>:56                                      ; preds = %44, %49
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %57, 2
+  store i32 %58, i32* %loc2
+  br label %59
+
+; <label>:59                                      ; preds = %41, %56
+  %60 = load i32, i32* %loc2
+  %61 = icmp slt i32 %60, 2147483647
+  br i1 %61, label %44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load i32, i32* %arg0
+  ret i32 %63
+
+ThrowNullRef:                                     ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
 Successfully read GenericEqualityComparer`1.GetHashCode
 
@@ -3694,14 +4558,14 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
   %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load i64, i64 addrspace(1)* %7
@@ -3720,7 +4584,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3750,8 +4614,8 @@ entry:
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
@@ -3796,8 +4660,8 @@ entry:
   %35 = bitcast i16* %34 to i8*
   %36 = getelementptr inbounds i8, i8* %35, i64 2
   %37 = bitcast i8* %36 to i16*
-  %NullCheck4 = icmp ne i16* %37, null
-  br i1 %NullCheck4, label %38, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %37, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %38
 
 ; <label>:38                                      ; preds = %27
   %39 = load i16, i16* %37, align 8
@@ -3824,8 +4688,8 @@ entry:
 
 ; <label>:54                                      ; preds = %22, %43
   %55 = load i16*, i16** %loc4
-  %NullCheck2 = icmp ne i16* %55, null
-  br i1 %NullCheck2, label %56, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i16* %55, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %56
 
 ; <label>:56                                      ; preds = %54
   %57 = load i16, i16* %55, align 8
@@ -3850,11 +4714,11 @@ ThrowNullRef:                                     ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %54
+ThrowNullRef2:                                    ; preds = %54
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %27
+ThrowNullRef4:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3871,8 +4735,8 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -3907,8 +4771,8 @@ entry:
 
 ; <label>:26                                      ; preds = %19
   %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
-  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %28
 
 ; <label>:28                                      ; preds = %26
   %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
@@ -3920,7 +4784,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3972,8 +4836,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
@@ -3984,26 +4848,26 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
-  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
@@ -4014,8 +4878,8 @@ entry:
 ; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
@@ -4024,8 +4888,8 @@ entry:
 
 ; <label>:25                                      ; preds = %1, %16, %23
   %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
-  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
@@ -4036,27 +4900,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %20
+ThrowNullRef10:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4069,8 +4933,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -4081,8 +4945,8 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
@@ -4091,8 +4955,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1, %8
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
@@ -4103,11 +4967,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4128,24 +4992,24 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   store i32 %3, i32* %loc0
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
   %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
   store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck4, label %9, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
@@ -4164,15 +5028,15 @@ entry:
 ; <label>:18                                      ; preds = %70
   %19 = load i16*, i16** %loc3
   %20 = bitcast i16* %19 to i64*
-  %NullCheck10 = icmp ne i64* %20, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %20, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = load i64, i64* %20, align 8
   %23 = load i16*, i16** %loc4
   %24 = bitcast i16* %23 to i64*
-  %NullCheck12 = icmp ne i64* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = load i64, i64* %24, align 8
@@ -4188,8 +5052,8 @@ entry:
   %31 = bitcast i16* %30 to i8*
   %32 = getelementptr inbounds i8, i8* %31, i64 8
   %33 = bitcast i8* %32 to i64*
-  %NullCheck14 = icmp ne i64* %33, null
-  br i1 %NullCheck14, label %34, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = load i64, i64* %33, align 8
@@ -4197,8 +5061,8 @@ entry:
   %37 = bitcast i16* %36 to i8*
   %38 = getelementptr inbounds i8, i8* %37, i64 8
   %39 = bitcast i8* %38 to i64*
-  %NullCheck16 = icmp ne i64* %39, null
-  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %40
 
 ; <label>:40                                      ; preds = %34
   %41 = load i64, i64* %39, align 8
@@ -4214,8 +5078,8 @@ entry:
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %NullCheck18 = icmp ne i64* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = load i64, i64* %48, align 8
@@ -4223,8 +5087,8 @@ entry:
   %52 = bitcast i16* %51 to i8*
   %53 = getelementptr inbounds i8, i8* %52, i64 16
   %54 = bitcast i8* %53 to i64*
-  %NullCheck20 = icmp ne i64* %54, null
-  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64* %54, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %55
 
 ; <label>:55                                      ; preds = %49
   %56 = load i64, i64* %54, align 8
@@ -4262,15 +5126,15 @@ entry:
 ; <label>:74                                      ; preds = %95
   %75 = load i16*, i16** %loc3
   %76 = bitcast i16* %75 to i32*
-  %NullCheck6 = icmp ne i32* %76, null
-  br i1 %NullCheck6, label %77, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32* %76, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %77
 
 ; <label>:77                                      ; preds = %74
   %78 = load i32, i32* %76, align 8
   %79 = load i16*, i16** %loc4
   %80 = bitcast i16* %79 to i32*
-  %NullCheck8 = icmp ne i32* %80, null
-  br i1 %NullCheck8, label %81, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i32* %80, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %81
 
 ; <label>:81                                      ; preds = %77
   %82 = load i32, i32* %80, align 8
@@ -4318,43 +5182,43 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %74
+ThrowNullRef6:                                    ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %77
+ThrowNullRef8:                                    ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %29
+ThrowNullRef14:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %34
+ThrowNullRef16:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4376,8 +5240,8 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load i64, i64 addrspace(1)* %4
@@ -4389,8 +5253,8 @@ entry:
   %12 = load i64, i64* %11
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %5
   %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
@@ -4399,8 +5263,8 @@ entry:
   %18 = load i8, i8* %arg2
   %19 = zext i8 %18 to i32
   %20 = trunc i32 %19 to i8
-  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %15
   %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
@@ -4411,11 +5275,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4442,8 +5306,8 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
@@ -4466,16 +5330,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
   %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = load i64, i64 addrspace(1)* %19
@@ -4500,8 +5364,8 @@ entry:
 ; <label>:35                                      ; preds = %30
   %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
@@ -4514,8 +5378,8 @@ entry:
 
 ; <label>:42                                      ; preds = %1, %38
   %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
-  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
@@ -4526,19 +5390,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %35
+ThrowNullRef2:                                    ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %42
+ThrowNullRef8:                                    ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4551,14 +5415,14 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
@@ -4570,7 +5434,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4583,8 +5447,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
@@ -4613,51 +5477,51 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
   %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
   %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
   %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
   %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
-  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
   store i64 %21, i64 addrspace(1)* %23
   %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %25 = load i64, i64* %loc0
-  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
@@ -4668,27 +5532,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %22
+ThrowNullRef12:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4701,8 +5565,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
@@ -4713,19 +5577,19 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
@@ -4734,8 +5598,8 @@ entry:
 
 ; <label>:15                                      ; preds = %1, %13
   %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
@@ -4746,19 +5610,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %15
+ThrowNullRef8:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4771,8 +5635,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -4831,8 +5695,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
@@ -4882,8 +5746,8 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
-  br i1 %NullCheck, label %17, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %ThrowNullRef, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
@@ -4894,15 +5758,15 @@ entry:
 
 ; <label>:22                                      ; preds = %17
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
-  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
   %26 = load i32, i32 addrspace(1)* %25
   %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
-  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %27, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
@@ -4925,8 +5789,8 @@ entry:
 ; <label>:40                                      ; preds = %17
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
-  br i1 %NullCheck6, label %43, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %41, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
@@ -4938,34 +5802,17 @@ ThrowNullRef:                                     ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %24
+ThrowNullRef4:                                    ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %40
+ThrowNullRef6:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
-}
-
-INFO:  jitting method Object::ReferenceEquals using LLILCJit
-Successfully read Object.ReferenceEquals
-
-define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
-entry:
-  %arg0 = alloca %System.Object addrspace(1)*
-  %arg1 = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
-  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
-  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = icmp eq %System.Object addrspace(1)* %0, %1
-  %3 = sext i1 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
 }
 
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
@@ -4978,21 +5825,21 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
   %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
-  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
@@ -5007,28 +5854,28 @@ entry:
 ; <label>:13                                      ; preds = %8, %12
   %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
   %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
   %21 = load i32, i32 addrspace(1)* %20, align 8
   %22 = add i32 %21, 1
-  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
   store i32 %22, i32 addrspace(1)* %24
   %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
@@ -5039,27 +5886,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5077,7 +5924,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::Setup using LLILCJit
-Failed to read AppDomain.Setup[loadElem]
+Failed to read AppDomain.Setup[unbox]
 INFO:  jitting method Thread::GetDomain using LLILCJit
 Successfully read Thread.GetDomain
 
@@ -5108,8 +5955,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
@@ -5122,14 +5969,14 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
   %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
@@ -5141,11 +5988,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5173,8 +6020,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -5189,7 +6036,328 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
 Failed to read KeyCollection.System.Collections.Generic.IEnumerable<TKey>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Successfully read Enumerator.MoveNext
+
+define i8 @Enumerator.MoveNext(%"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.RuntimeTypeHandle* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*
+  %"$TypeArg" = alloca %System.RuntimeTypeHandle*
+  store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
+  %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 8
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %76, label %12
+
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
+  br label %76
+
+; <label>:13                                      ; preds = %85
+  %14 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck19 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %15
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, i32 0, i32 0
+  %17 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %16, align 8
+  %NullCheck21 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, i32 0, i32 2
+  %20 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %19, align 8
+  %21 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck23 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %22
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, i32 0, i32 2
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %NullCheck25 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 3, i32 %24
+  %NullCheck27 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %32
+
+; <label>:32                                      ; preds = %30
+  %33 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, i32 0, i32 2
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = icmp slt i32 %34, 0
+  br i1 %35, label %68, label %36
+
+; <label>:36                                      ; preds = %32
+  %37 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %38 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck29 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %39
+
+; <label>:39                                      ; preds = %36
+  %40 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, i32 0, i32 0
+  %41 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %40, align 8
+  %NullCheck31 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, i32 0, i32 2
+  %44 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %43, align 8
+  %45 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck33 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, i32 0, i32 2
+  %48 = load i32, i32 addrspace(1)* %47, align 8
+  %NullCheck35 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %49
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = zext i32 %51 to i64
+  %53 = zext i32 %48 to i64
+  %BoundsCheck37 = icmp uge i64 %53, %52
+  br i1 %BoundsCheck37, label %ThrowIndexOutOfRange38, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 3, i32 %48
+  %NullCheck39 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %56
+
+; <label>:56                                      ; preds = %54
+  %57 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, i32 0, i32 0
+  %58 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck41 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %59
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %60, %System.__Canon addrspace(1)* %58)
+  %61 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck43 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  %64 = load i32, i32 addrspace(1)* %63, align 8
+  %65 = add i32 %64, 1
+  %NullCheck45 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  store i32 %65, i32 addrspace(1)* %67
+  ret i8 1
+
+; <label>:68                                      ; preds = %32
+  %69 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck47 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %73 = add i32 %72, 1
+  %NullCheck49 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %74
+
+; <label>:74                                      ; preds = %70
+  %75 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  store i32 %73, i32 addrspace(1)* %75
+  br label %76
+
+; <label>:76                                      ; preds = %8, %12, %74
+  %77 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %78
+
+; <label>:78                                      ; preds = %76
+  %79 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, i32 0, i32 2
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck7 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %82
+
+; <label>:82                                      ; preds = %78
+  %83 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, i32 0, i32 0
+  %84 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %83, align 8
+  %NullCheck9 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %85
+
+; <label>:85                                      ; preds = %82
+  %86 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, i32 0, i32 7
+  %87 = load i32, i32 addrspace(1)* %86, align 8
+  %88 = icmp ult i32 %80, %87
+  br i1 %88, label %13, label %89
+
+; <label>:89                                      ; preds = %85
+  %90 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %91 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck11 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %92
+
+; <label>:92                                      ; preds = %89
+  %93 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, i32 0, i32 0
+  %94 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck13 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %95
+
+; <label>:95                                      ; preds = %92
+  %96 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, i32 0, i32 7
+  %97 = load i32, i32 addrspace(1)* %96, align 8
+  %98 = add i32 %97, 1
+  %NullCheck15 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %99
+
+; <label>:99                                      ; preds = %95
+  %100 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, i32 0, i32 2
+  store i32 %98, i32 addrspace(1)* %100
+  %101 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck17 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %102
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %103, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %92
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef22:                                   ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef24:                                   ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef26:                                   ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef28:                                   ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef30:                                   ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef32:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef34:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef36:                                   ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange38:                           ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef40:                                   ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef42:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef44:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef46:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef48:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef50:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -5200,8 +6368,8 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -5232,9 +6400,9 @@ Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
 Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
-Failed to read String.MakeSeparatorList[loadElemA]
+Failed to read String.MakeSeparatorList[storeElem]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
-Failed to read String.InternalSplitKeepEmptyEntries[loadElem]
+Failed to read String.InternalSplitKeepEmptyEntries[storeElem]
 INFO:  jitting method Path::IsRelative using LLILCJit
 Successfully read Path.IsRelative
 
@@ -5243,8 +6411,8 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -5254,8 +6422,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
@@ -5271,8 +6439,8 @@ entry:
 
 ; <label>:17                                      ; preds = %7
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
@@ -5288,8 +6456,8 @@ entry:
 
 ; <label>:29                                      ; preds = %19
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %31
 
 ; <label>:31                                      ; preds = %29
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
@@ -5300,8 +6468,8 @@ entry:
 
 ; <label>:36                                      ; preds = %31
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
-  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %37, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
@@ -5312,8 +6480,8 @@ entry:
 
 ; <label>:43                                      ; preds = %31, %38
   %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
-  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %45
 
 ; <label>:45                                      ; preds = %43
   %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
@@ -5324,8 +6492,8 @@ entry:
 
 ; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %50
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
@@ -5336,8 +6504,8 @@ entry:
 
 ; <label>:57                                      ; preds = %1, %7, %19, %45, %52
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
-  br i1 %NullCheck14, label %59, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %59
 
 ; <label>:59                                      ; preds = %57
   %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
@@ -5347,8 +6515,8 @@ entry:
 
 ; <label>:63                                      ; preds = %59
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
@@ -5359,8 +6527,8 @@ entry:
 
 ; <label>:70                                      ; preds = %65
   %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
-  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.String addrspace(1)* %71, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %72
 
 ; <label>:72                                      ; preds = %70
   %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
@@ -5379,39 +6547,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %17
+ThrowNullRef4:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %29
+ThrowNullRef6:                                    ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %36
+ThrowNullRef8:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %43
+ThrowNullRef10:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %50
+ThrowNullRef12:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %57
+ThrowNullRef14:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %63
+ThrowNullRef16:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %70
+ThrowNullRef18:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5419,7 +6587,293 @@ ThrowNullRef17:                                   ; preds = %70
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
-Failed to read String.TrimHelper[loadElem]
+Successfully read String.TrimHelper
+
+define %System.String addrspace(1)* @String.TrimHelper(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i16
+  %loc4 = alloca i32
+  %loc5 = alloca i16
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = sub i32 %3, 1
+  store i32 %4, i32* %loc0
+  store i32 0, i32* %loc1
+  %5 = load i32, i32* %arg2
+  %6 = icmp eq i32 %5, 1
+  br i1 %6, label %62, label %7
+
+; <label>:7                                       ; preds = %1
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:8                                       ; preds = %58
+  store i32 0, i32* %loc2
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load i32, i32* %loc1
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2, i32 %10
+  %13 = load i16, i16 addrspace(1)* %12
+  %14 = zext i16 %13 to i32
+  %15 = trunc i32 %14 to i16
+  store i16 %15, i16* %loc3
+  store i32 0, i32* %loc2
+  br label %34
+
+; <label>:16                                      ; preds = %37
+  %17 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %18 = load i32, i32* %loc2
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %17, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %19
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = zext i32 %18 to i64
+  %BoundsCheck = icmp uge i64 %23, %22
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %24
+
+; <label>:24                                      ; preds = %19
+  %25 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 3, i32 %18
+  %26 = load i16, i16 addrspace(1)* %25, align 8
+  %27 = zext i16 %26 to i32
+  %28 = load i16, i16* %loc3
+  %29 = zext i16 %28 to i32
+  %30 = icmp eq i32 %27, %29
+  br i1 %30, label %43, label %31
+
+; <label>:31                                      ; preds = %24
+  %32 = load i32, i32* %loc2
+  %33 = add i32 %32, 1
+  store i32 %33, i32* %loc2
+  br label %34
+
+; <label>:34                                      ; preds = %11, %31
+  %35 = load i32, i32* %loc2
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = icmp slt i32 %35, %41
+  br i1 %42, label %16, label %43
+
+; <label>:43                                      ; preds = %24, %37
+  %44 = load i32, i32* %loc2
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %45, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp eq i32 %44, %50
+  br i1 %51, label %62, label %52
+
+; <label>:52                                      ; preds = %46
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %7, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %57, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %58
+
+; <label>:58                                      ; preds = %55
+  %59 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %60 = load i32, i32 addrspace(1)* %59
+  %61 = icmp slt i32 %56, %60
+  br i1 %61, label %8, label %62
+
+; <label>:62                                      ; preds = %1, %46, %58
+  %63 = load i32, i32* %arg2
+  %64 = icmp eq i32 %63, 0
+  br i1 %64, label %122, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %66, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %67
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %66, i32 0, i32 1
+  %69 = load i32, i32 addrspace(1)* %68
+  %70 = sub i32 %69, 1
+  store i32 %70, i32* %loc0
+  br label %118
+
+; <label>:71                                      ; preds = %118
+  store i32 0, i32* %loc4
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %73 = load i32, i32* %loc0
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %74
+
+; <label>:74                                      ; preds = %71
+  %75 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 2, i32 %73
+  %76 = load i16, i16 addrspace(1)* %75
+  %77 = zext i16 %76 to i32
+  %78 = trunc i32 %77 to i16
+  store i16 %78, i16* %loc5
+  store i32 0, i32* %loc4
+  br label %97
+
+; <label>:79                                      ; preds = %100
+  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %81 = load i32, i32* %loc4
+  %NullCheck19 = icmp eq %"System.Char[]" addrspace(1)* %80, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
+
+; <label>:82                                      ; preds = %79
+  %83 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 1
+  %84 = load i32, i32 addrspace(1)* %83
+  %85 = zext i32 %84 to i64
+  %86 = zext i32 %81 to i64
+  %BoundsCheck21 = icmp uge i64 %86, %85
+  br i1 %BoundsCheck21, label %ThrowIndexOutOfRange22, label %87
+
+; <label>:87                                      ; preds = %82
+  %88 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 3, i32 %81
+  %89 = load i16, i16 addrspace(1)* %88, align 8
+  %90 = zext i16 %89 to i32
+  %91 = load i16, i16* %loc5
+  %92 = zext i16 %91 to i32
+  %93 = icmp eq i32 %90, %92
+  br i1 %93, label %106, label %94
+
+; <label>:94                                      ; preds = %87
+  %95 = load i32, i32* %loc4
+  %96 = add i32 %95, 1
+  store i32 %96, i32* %loc4
+  br label %97
+
+; <label>:97                                      ; preds = %74, %94
+  %98 = load i32, i32* %loc4
+  %99 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck15 = icmp eq %"System.Char[]" addrspace(1)* %99, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %100
+
+; <label>:100                                     ; preds = %97
+  %101 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %99, i32 0, i32 1
+  %102 = load i32, i32 addrspace(1)* %101
+  %103 = zext i32 %102 to i64
+  %104 = trunc i64 %103 to i32
+  %105 = icmp slt i32 %98, %104
+  br i1 %105, label %79, label %106
+
+; <label>:106                                     ; preds = %87, %100
+  %107 = load i32, i32* %loc4
+  %108 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck17 = icmp eq %"System.Char[]" addrspace(1)* %108, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %109
+
+; <label>:109                                     ; preds = %106
+  %110 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %108, i32 0, i32 1
+  %111 = load i32, i32 addrspace(1)* %110
+  %112 = zext i32 %111 to i64
+  %113 = trunc i64 %112 to i32
+  %114 = icmp eq i32 %107, %113
+  br i1 %114, label %122, label %115
+
+; <label>:115                                     ; preds = %109
+  %116 = load i32, i32* %loc0
+  %117 = sub i32 %116, 1
+  store i32 %117, i32* %loc0
+  br label %118
+
+; <label>:118                                     ; preds = %67, %115
+  %119 = load i32, i32* %loc0
+  %120 = load i32, i32* %loc1
+  %121 = icmp sge i32 %119, %120
+  br i1 %121, label %71, label %122
+
+; <label>:122                                     ; preds = %62, %109, %118
+  %123 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %124 = load i32, i32* %loc1
+  %125 = load i32, i32* %loc0
+  %126 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %123, i32 %124, i32 %125)
+  ret %System.String addrspace(1)* %126
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %97
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange22:                           ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
 Successfully read String.CreateTrimmedString
 
@@ -5439,8 +6893,8 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
@@ -5535,8 +6989,8 @@ entry:
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i64 2872
   %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
   %8 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %7
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %3
   %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
@@ -5553,8 +7007,8 @@ entry:
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 2864
   %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
   %21 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %20
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
-  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %22
 
 ; <label>:22                                      ; preds = %16
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
@@ -5569,7 +7023,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %16
+ThrowNullRef2:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5586,8 +7040,8 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5613,8 +7067,8 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
@@ -5632,8 +7086,8 @@ entry:
 
 ; <label>:12                                      ; preds = %4
   %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
@@ -5644,8 +7098,8 @@ entry:
 
 ; <label>:19                                      ; preds = %14
   %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %19
   %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
@@ -5660,21 +7114,21 @@ entry:
   %31 = zext i16 %30 to i32
   %32 = bitcast i8* %29 to i16*
   %33 = trunc i32 %31 to i16
-  %NullCheck6 = icmp ne i16* %32, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i16* %32, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %21
   store i16 %33, i16* %32, align 8
   %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %36
 
 ; <label>:36                                      ; preds = %34
   %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
   %38 = load i32, i32 addrspace(1)* %37, align 8
   %39 = add i32 %38, 1
-  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %40
 
 ; <label>:40                                      ; preds = %36
   %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
@@ -5683,16 +7137,16 @@ entry:
 
 ; <label>:42                                      ; preds = %14
   %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
-  br i1 %NullCheck12, label %44, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
   %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
   %47 = load i16, i16* %arg1
   %48 = zext i16 %47 to i32
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = trunc i32 %48 to i16
@@ -5703,31 +7157,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %19
+ThrowNullRef4:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %21
+ThrowNullRef6:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %36
+ThrowNullRef10:                                   ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %42
+ThrowNullRef12:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %44
+ThrowNullRef14:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5740,8 +7194,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -5752,8 +7206,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
@@ -5762,14 +7216,14 @@ entry:
 
 ; <label>:11                                      ; preds = %1
   %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
@@ -5779,15 +7233,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5808,8 +7262,8 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5822,8 +7276,8 @@ entry:
 
 ; <label>:8                                       ; preds = %3
   %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
@@ -5842,15 +7296,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
-  br i1 %NullCheck4, label %22, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
   %24 = load i16*, i16* addrspace(1)* %23, align 8
   %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %25, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
@@ -5859,8 +7313,8 @@ entry:
   store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
@@ -5874,8 +7328,8 @@ entry:
 
 ; <label>:37                                      ; preds = %65
   %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %37
   %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
@@ -5886,16 +7340,16 @@ entry:
   %45 = bitcast i16* %41 to i8*
   %46 = getelementptr inbounds i8, i8* %45, i64 %44
   %47 = bitcast i8* %46 to i16*
-  %NullCheck14 = icmp ne i16* %47, null
-  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %47, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %48
 
 ; <label>:48                                      ; preds = %39
   %49 = load i16, i16* %47, align 8
   %50 = zext i16 %49 to i32
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %52 = load i32, i32* %loc1
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %53
 
 ; <label>:53                                      ; preds = %48
   %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
@@ -5916,8 +7370,8 @@ entry:
 ; <label>:62                                      ; preds = %36, %59
   %63 = load i32, i32* %loc1
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck10, label %65, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %65
 
 ; <label>:65                                      ; preds = %62
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
@@ -5936,15 +7390,15 @@ entry:
 
 ; <label>:74                                      ; preds = %70
   %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
-  br i1 %NullCheck18, label %76, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %76
 
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
   %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
-  br i1 %NullCheck20, label %80, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
   %81 = load i64, i64 addrspace(1)* %79
@@ -5958,8 +7412,8 @@ entry:
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
   %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
-  br i1 %NullCheck22, label %92, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.String addrspace(1)* %90, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %92
 
 ; <label>:92                                      ; preds = %80
   %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
@@ -5969,15 +7423,15 @@ entry:
 
 ; <label>:96                                      ; preds = %70
   %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
-  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %98
 
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
   %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
-  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
   %103 = load i64, i64 addrspace(1)* %101
@@ -5991,8 +7445,8 @@ entry:
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
   %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
-  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.String addrspace(1)* %112, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %114
 
 ; <label>:114                                     ; preds = %102
   %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
@@ -6004,59 +7458,59 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %20
+ThrowNullRef4:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %22
+ThrowNullRef6:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %26
+ThrowNullRef8:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %62
+ThrowNullRef10:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %48
+ThrowNullRef16:                                   ; preds = %48
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %74
+ThrowNullRef18:                                   ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %76
+ThrowNullRef20:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %80
+ThrowNullRef22:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %96
+ThrowNullRef24:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %98
+ThrowNullRef26:                                   ; preds = %98
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %102
+ThrowNullRef28:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6069,15 +7523,15 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
   %3 = load i16*, i16* addrspace(1)* %2, align 8
   %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
@@ -6087,8 +7541,8 @@ entry:
   %10 = bitcast i16* %3 to i8*
   %11 = getelementptr inbounds i8, i8* %10, i64 %9
   %12 = bitcast i8* %11 to i16*
-  %NullCheck4 = icmp ne i16* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %5
   store i16 0, i16* %12, align 8
@@ -6098,11 +7552,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6119,8 +7573,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -6131,8 +7585,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
@@ -6144,15 +7598,15 @@ entry:
 
 ; <label>:14                                      ; preds = %1
   %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
   %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
   %21 = load i64, i64 addrspace(1)* %19
@@ -6171,15 +7625,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %14
+ThrowNullRef4:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %16
+ThrowNullRef6:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6302,14 +7756,6 @@ entry:
   ret %System.String addrspace(1)* %57
 }
 
-INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
-Successfully read RuntimeHelpers.get_OffsetToStringData
-
-define i32 @RuntimeHelpers.get_OffsetToStringData() {
-entry:
-  ret i32 12
-}
-
 INFO:  jitting method String::Equals using LLILCJit
 Successfully read String.Equals
 
@@ -6381,8 +7827,8 @@ entry:
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
-  br i1 %NullCheck24, label %29, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
   %30 = load i64, i64 addrspace(1)* %28
@@ -6397,8 +7843,8 @@ entry:
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
-  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
   %43 = load i64, i64 addrspace(1)* %41
@@ -6418,8 +7864,8 @@ entry:
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
   %59 = load i64, i64 addrspace(1)* %57
@@ -6434,8 +7880,8 @@ entry:
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck22, label %71, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
   %72 = load i64, i64 addrspace(1)* %70
@@ -6455,8 +7901,8 @@ entry:
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
-  br i1 %NullCheck16, label %87, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = load i64, i64 addrspace(1)* %86
@@ -6471,8 +7917,8 @@ entry:
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck18, label %100, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
   %101 = load i64, i64 addrspace(1)* %99
@@ -6492,8 +7938,8 @@ entry:
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
-  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
   %117 = load i64, i64 addrspace(1)* %115
@@ -6508,8 +7954,8 @@ entry:
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
-  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
   %130 = load i64, i64 addrspace(1)* %128
@@ -6528,15 +7974,15 @@ entry:
 
 ; <label>:142                                     ; preds = %22
   %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
-  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %143, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %144
 
 ; <label>:144                                     ; preds = %142
   %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
   %146 = load i32, i32 addrspace(1)* %145
   %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
-  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %147, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %148
 
 ; <label>:148                                     ; preds = %144
   %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
@@ -6557,15 +8003,15 @@ entry:
 
 ; <label>:159                                     ; preds = %22
   %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
-  br i1 %NullCheck, label %161, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %ThrowNullRef, label %161
 
 ; <label>:161                                     ; preds = %159
   %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
   %163 = load i32, i32 addrspace(1)* %162
   %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
-  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %164, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %165
 
 ; <label>:165                                     ; preds = %161
   %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
@@ -6578,8 +8024,8 @@ entry:
 
 ; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
-  br i1 %NullCheck4, label %172, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %171, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %172
 
 ; <label>:172                                     ; preds = %170
   %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
@@ -6589,8 +8035,8 @@ entry:
 
 ; <label>:176                                     ; preds = %172
   %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
-  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %177, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %178
 
 ; <label>:178                                     ; preds = %176
   %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
@@ -6629,55 +8075,55 @@ ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %161
+ThrowNullRef2:                                    ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %170
+ThrowNullRef4:                                    ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %176
+ThrowNullRef6:                                    ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %142
+ThrowNullRef8:                                    ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %144
+ThrowNullRef10:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %113
+ThrowNullRef12:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %116
+ThrowNullRef14:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %84
+ThrowNullRef16:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %87
+ThrowNullRef18:                                   ; preds = %87
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %55
+ThrowNullRef20:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %58
+ThrowNullRef22:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %26
+ThrowNullRef24:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %29
+ThrowNullRef26:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,8 +8161,8 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck, label %14, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %ThrowNullRef, label %14
 
 ; <label>:14                                      ; preds = %8
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
@@ -6760,8 +8206,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
@@ -6770,14 +8216,14 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32, i32* %loc0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %10
   %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
   %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
@@ -6790,15 +8236,15 @@ entry:
 ; <label>:25                                      ; preds = %19
   %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
-  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
   %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
@@ -6807,8 +8253,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %37 = load i32, i32* %loc0
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %38, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %38
 
 ; <label>:38                                      ; preds = %32
   %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
@@ -6817,14 +8263,14 @@ entry:
 
 ; <label>:40                                      ; preds = %19
   %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %40
   %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
   %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
-  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
-  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
@@ -6832,8 +8278,8 @@ entry:
   %48 = zext i32 %47 to i64
   %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
-  br i1 %NullCheck16, label %51, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %51
 
 ; <label>:51                                      ; preds = %45
   %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
@@ -6847,15 +8293,15 @@ entry:
 ; <label>:57                                      ; preds = %51
   %58 = load i16*, i16** %arg1
   %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
-  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %60
 
 ; <label>:60                                      ; preds = %57
   %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
   %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
-  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %64
 
 ; <label>:64                                      ; preds = %60
   %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
@@ -6864,22 +8310,22 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
   %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
-  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %70
 
 ; <label>:70                                      ; preds = %64
   %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
   %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
-  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
-  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
   %75 = load i32, i32 addrspace(1)* %74
   %76 = zext i32 %75 to i64
   %77 = trunc i64 %76 to i32
-  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
-  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %78
 
 ; <label>:78                                      ; preds = %73
   %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
@@ -6901,8 +8347,8 @@ entry:
   %90 = bitcast i16* %86 to i8*
   %91 = getelementptr inbounds i8, i8* %90, i64 %89
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %93
 
 ; <label>:93                                      ; preds = %80
   %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
@@ -6912,8 +8358,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %99 = load i32, i32* %loc2
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %100
 
 ; <label>:100                                     ; preds = %93
   %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
@@ -6928,63 +8374,63 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %25
+ThrowNullRef6:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %32
+ThrowNullRef10:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %40
+ThrowNullRef12:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %45
+ThrowNullRef16:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %57
+ThrowNullRef18:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %60
+ThrowNullRef20:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %64
+ThrowNullRef22:                                   ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %70
+ThrowNullRef24:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %73
+ThrowNullRef26:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %80
+ThrowNullRef28:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %93
+ThrowNullRef30:                                   ; preds = %93
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7004,8 +8450,8 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
@@ -7033,43 +8479,43 @@ entry:
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %14
   %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
   %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   %28 = load i32, i32 addrspace(1)* %27, align 8
   %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
-  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %30
 
 ; <label>:30                                      ; preds = %26
   %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
   %32 = load i32, i32 addrspace(1)* %31, align 8
   %33 = add i32 %28, %32
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %34
 
 ; <label>:34                                      ; preds = %30
   %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   store i32 %33, i32 addrspace(1)* %35
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
   store i32 0, i32 addrspace(1)* %38
   %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %40
 
 ; <label>:40                                      ; preds = %37
   %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
@@ -7082,8 +8528,8 @@ entry:
 
 ; <label>:47                                      ; preds = %40
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
@@ -7098,8 +8544,8 @@ entry:
   %54 = load i32, i32* %loc0
   %55 = sext i32 %54 to i64
   %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
-  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %57
 
 ; <label>:57                                      ; preds = %52
   %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
@@ -7110,68 +8556,35 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %14
+ThrowNullRef2:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %23
+ThrowNullRef4:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %26
+ThrowNullRef6:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %30
+ThrowNullRef8:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %34
+ThrowNullRef10:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %47
+ThrowNullRef14:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %52
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-}
-
-INFO:  jitting method StringBuilder::get_Length using LLILCJit
-Successfully read StringBuilder.get_Length
-
-define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.StringBuilder addrspace(1)*
-  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
-  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
-
-; <label>:1                                       ; preds = %entry
-  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %3 = load i32, i32 addrspace(1)* %2, align 8
-  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
-
-; <label>:5                                       ; preds = %1
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = add i32 %3, %7
-  ret i32 %8
-
-ThrowNullRef:                                     ; preds = %entry
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef16:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7213,70 +8626,70 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
   %6 = load i32, i32 addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
   store i32 %6, i32 addrspace(1)* %8
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
   %13 = load i32, i32 addrspace(1)* %12, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
   store i32 %13, i32 addrspace(1)* %15
   %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
-  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %18
 
 ; <label>:18                                      ; preds = %14
   %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
   %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
   %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
   %34 = load i32, i32 addrspace(1)* %33, align 8
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
-  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
@@ -7287,39 +8700,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %28
+ThrowNullRef16:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %32
+ThrowNullRef18:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7455,13 +8868,13 @@ entry:
 ; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
@@ -7477,16 +8890,16 @@ entry:
 
 ; <label>:18                                      ; preds = %15
   %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
   store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
   %22 = load i32, i32* %loc0
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %24
 
 ; <label>:24                                      ; preds = %20
   %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
@@ -7498,13 +8911,13 @@ entry:
 ; <label>:28                                      ; preds = %15, %24
   %29 = load i32, i32* %arg1
   %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %31
   %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
@@ -7517,20 +8930,20 @@ entry:
   %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
-  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
   %46 = load i32, i32 addrspace(1)* %45, align 8
   %47 = sub i32 %40, %46
-  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
-  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i32 addrspace(1)* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %48
 
 ; <label>:48                                      ; preds = %44
   store i32 %47, i32 addrspace(1)* %39, align 8
@@ -7538,21 +8951,21 @@ entry:
 
 ; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
-  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %51
 
 ; <label>:51                                      ; preds = %49
   %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %53
 
 ; <label>:53                                      ; preds = %51
   %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
   %55 = load i32, i32 addrspace(1)* %54, align 8
   %56 = load i32, i32* %arg2
   %57 = sub i32 %55, %56
-  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %58
 
 ; <label>:58                                      ; preds = %53
   %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
@@ -7562,13 +8975,13 @@ entry:
 ; <label>:60                                      ; preds = %33, %58
   %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
   %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
-  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %63
 
 ; <label>:63                                      ; preds = %60
   %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
-  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
-  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
@@ -7578,15 +8991,15 @@ entry:
 
 ; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
-  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i32 addrspace(1)* %69, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %70
 
 ; <label>:70                                      ; preds = %68
   %71 = load i32, i32 addrspace(1)* %69, align 8
   store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
-  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
@@ -7596,8 +9009,8 @@ entry:
   store i32 %77, i32* %loc4
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
-  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %80
 
 ; <label>:80                                      ; preds = %73
   %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
@@ -7607,71 +9020,71 @@ entry:
 ; <label>:83                                      ; preds = %80
   store i32 0, i32* %loc3
   %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
-  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
-  br i1 %NullCheck26, label %88, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i32 addrspace(1)* %87, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %88
 
 ; <label>:88                                      ; preds = %85
   %89 = load i32, i32 addrspace(1)* %87, align 8
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
-  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %90
 
 ; <label>:90                                      ; preds = %88
   %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
   store i32 %89, i32 addrspace(1)* %91
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
-  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
-  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %96
 
 ; <label>:96                                      ; preds = %94
   %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
-  br i1 %NullCheck34, label %100, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %100
 
 ; <label>:100                                     ; preds = %96
   %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
-  br i1 %NullCheck36, label %102, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %102
 
 ; <label>:102                                     ; preds = %100
   %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
   %104 = load i32, i32 addrspace(1)* %103, align 8
   %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
-  br i1 %NullCheck38, label %106, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %106
 
 ; <label>:106                                     ; preds = %102
   %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
-  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
-  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %108
 
 ; <label>:108                                     ; preds = %106
   %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
   %110 = load i32, i32 addrspace(1)* %109, align 8
   %111 = add i32 %104, %110
-  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %112
 
 ; <label>:112                                     ; preds = %108
   %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
   store i32 %111, i32 addrspace(1)* %113
   %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
-  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i32 addrspace(1)* %114, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %115
 
 ; <label>:115                                     ; preds = %112
   %116 = load i32, i32 addrspace(1)* %114, align 8
@@ -7681,19 +9094,19 @@ entry:
 ; <label>:118                                     ; preds = %115
   %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
-  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %121
 
 ; <label>:121                                     ; preds = %118
   %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
-  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
-  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %123
 
 ; <label>:123                                     ; preds = %121
   %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
   %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
-  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
-  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %126
 
 ; <label>:126                                     ; preds = %123
   %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
@@ -7705,8 +9118,8 @@ entry:
 
 ; <label>:130                                     ; preds = %80, %115, %126
   %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %132
 
 ; <label>:132                                     ; preds = %130
   %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7715,8 +9128,8 @@ entry:
   %136 = load i32, i32* %loc3
   %137 = sub i32 %135, %136
   %138 = sub i32 %134, %137
-  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %139
 
 ; <label>:139                                     ; preds = %132
   %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7728,16 +9141,16 @@ entry:
 
 ; <label>:144                                     ; preds = %139
   %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
-  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %146
 
 ; <label>:146                                     ; preds = %144
   %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
   %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
   %149 = load i32, i32* %loc2
   %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
-  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %151
 
 ; <label>:151                                     ; preds = %146
   %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
@@ -7754,145 +9167,249 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %18
+ThrowNullRef4:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %31
+ThrowNullRef10:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %44
+ThrowNullRef16:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %68
+ThrowNullRef18:                                   ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %70
+ThrowNullRef20:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %73
+ThrowNullRef22:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %83
+ThrowNullRef24:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %85
+ThrowNullRef26:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %88
+ThrowNullRef28:                                   ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %90
+ThrowNullRef30:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %94
+ThrowNullRef32:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %96
+ThrowNullRef34:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %100
+ThrowNullRef36:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %102
+ThrowNullRef38:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %106
+ThrowNullRef40:                                   ; preds = %106
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %108
+ThrowNullRef42:                                   ; preds = %108
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %112
+ThrowNullRef44:                                   ; preds = %112
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %118
+ThrowNullRef46:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %121
+ThrowNullRef48:                                   ; preds = %121
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %123
+ThrowNullRef50:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %130
+ThrowNullRef52:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %132
+ThrowNullRef54:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %144
+ThrowNullRef56:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %146
+ThrowNullRef58:                                   ; preds = %146
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %60
+ThrowNullRef60:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %63
+ThrowNullRef62:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %49
+ThrowNullRef64:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %51
+ThrowNullRef66:                                   ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %53
+ThrowNullRef68:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(%"System.Char[]" addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %arg0 = alloca %"System.Char[]" addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store %"System.Char[]" addrspace(1)* %param0, %"System.Char[]" addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load i32, i32* %arg4
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %43, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %38, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg1
+  %13 = load i32, i32* %arg4
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %38, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %24 = load i32, i32* %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %35 = load i32, i32* %arg3
+  %36 = load i32, i32* %arg4
+  %37 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %37, %"System.Char[]" addrspace(1)* %34, i32 %35, i32 %36)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:38                                      ; preds = %5, %16
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Successfully read Buffer._Memmove
 
@@ -7914,7 +9431,7 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[loadElem]
+Failed to read AppDomain.SetDataHelper[storeElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -7923,8 +9440,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
@@ -7934,8 +9451,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
@@ -7947,15 +9464,15 @@ entry:
   %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
   %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
@@ -7966,15 +9483,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7992,7 +9509,79 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
-Failed to read Dictionary`2.TryGetValue[loadElemA]
+Successfully read Dictionary`2.TryGetValue
+
+define i8 @"Dictionary`2.TryGetValue"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)* addrspace(1)* %param2) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  %arg2 = alloca %System.__Canon addrspace(1)* addrspace(1)*
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  store %System.__Canon addrspace(1)* addrspace(1)* %param2, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  store i32 %2, i32* %loc0
+  %3 = load i32, i32* %loc0
+  %4 = icmp slt i32 %3, 0
+  br i1 %4, label %22, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 2
+  %10 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %9, align 8
+  %11 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = zext i32 %11 to i64
+  %BoundsCheck = icmp uge i64 %16, %15
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 3, i32 %11
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %20, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %6, %System.__Canon addrspace(1)* %21)
+  ret i8 1
+
+; <label>:22                                      ; preds = %entry
+  %23 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %23, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -8058,8 +9647,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
@@ -8091,8 +9680,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
@@ -8171,15 +9760,15 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck, label %19, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %ThrowNullRef, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
   %21 = load i32, i32 addrspace(1)* %20
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
@@ -8202,7 +9791,7 @@ ThrowNullRef:                                     ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %19
+ThrowNullRef2:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8248,8 +9837,8 @@ entry:
   %0 = alloca %System.AppDomainHandle
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %1 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %1, i32 0, i32 15
@@ -8269,8 +9858,8 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
@@ -8286,7 +9875,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -8299,8 +9888,8 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -8327,8 +9916,8 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
@@ -8352,8 +9941,8 @@ entry:
   %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
   store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
@@ -8363,8 +9952,8 @@ entry:
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
@@ -8374,8 +9963,8 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %9
   %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
@@ -8384,8 +9973,8 @@ entry:
 
 ; <label>:18                                      ; preds = %3, %16
   %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
@@ -8397,15 +9986,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %18
+ThrowNullRef6:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8418,8 +10007,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
@@ -8453,15 +10042,15 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
@@ -8473,7 +10062,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8481,7 +10070,7 @@ ThrowNullRef1:                                    ; preds = %1
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
 Failed to read Dictionary`2.System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
@@ -8506,8 +10095,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
@@ -8524,8 +10113,8 @@ entry:
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -8544,7 +10133,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8577,8 +10166,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = load i64, i64* %arg2
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = trunc i32 %3 to i8
@@ -8634,46 +10223,46 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
   %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
-  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
-  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
-  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
@@ -8684,27 +10273,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %20
+ThrowNullRef12:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8717,8 +10306,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -8756,22 +10345,22 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
   %9 = load i64, i64 addrspace(1)* %8, align 8
   %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
   %13 = load i64, i64 addrspace(1)* %12, align 8
   %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %11
   %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
@@ -8788,11 +10377,11 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8882,8 +10471,8 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
@@ -8900,8 +10489,8 @@ entry:
 ; <label>:8                                       ; preds = %1
   %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
   %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
@@ -8911,15 +10500,15 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
   %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
   %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
-  br i1 %NullCheck6, label %21, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
@@ -8946,15 +10535,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8992,15 +10581,15 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
   store i8 %3, i8 addrspace(1)* %5
   %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
@@ -9011,7 +10600,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9027,8 +10616,8 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -9041,8 +10630,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
@@ -9058,7 +10647,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9080,8 +10669,8 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
@@ -9096,8 +10685,8 @@ entry:
 ; <label>:12                                      ; preds = %6
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
@@ -9112,8 +10701,8 @@ entry:
 ; <label>:21                                      ; preds = %15
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
@@ -9128,8 +10717,8 @@ entry:
 ; <label>:30                                      ; preds = %24
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %31, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
@@ -9144,8 +10733,8 @@ entry:
 ; <label>:39                                      ; preds = %33
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
-  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %40, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %42
 
 ; <label>:42                                      ; preds = %39
   %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
@@ -9164,19 +10753,19 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %21
+ThrowNullRef4:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %30
+ThrowNullRef6:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %39
+ThrowNullRef8:                                    ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9243,8 +10832,8 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
@@ -9264,57 +10853,57 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
   store i8 0, i8 addrspace(1)* %2
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
   store i8 0, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
   store i8 0, i8 addrspace(1)* %17
   %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
   store i8 0, i8 addrspace(1)* %20
   %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
-  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
@@ -9325,31 +10914,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %19
+ThrowNullRef14:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9367,8 +10956,8 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
@@ -9380,8 +10969,8 @@ entry:
 
 ; <label>:9                                       ; preds = %4
   %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %9
   %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
@@ -9395,7 +10984,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef2:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9420,8 +11009,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
@@ -9512,8 +11101,8 @@ entry:
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
@@ -9524,8 +11113,8 @@ entry:
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = load i64, i64 addrspace(1)* %12
@@ -9537,8 +11126,8 @@ entry:
   %20 = load i64, i64* %19
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
-  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %13
   %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
@@ -9555,8 +11144,8 @@ entry:
 ; <label>:30                                      ; preds = %25
   %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %32 = load i32, i32* %arg2
-  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
-  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
@@ -9570,15 +11159,15 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %30
+ThrowNullRef2:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9622,87 +11211,87 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
   %10 = load i8, i8 addrspace(1)* %9, align 8
   %11 = zext i8 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %8
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
   store i8 %12, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
   %19 = load i8, i8 addrspace(1)* %18, align 8
   %20 = zext i8 %19 to i32
   %21 = trunc i32 %20 to i8
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
   store i8 %21, i8 addrspace(1)* %23
   %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
   %28 = load i8, i8 addrspace(1)* %27, align 8
   %29 = zext i8 %28 to i32
   %30 = trunc i32 %29 to i8
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
-  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %31
 
 ; <label>:31                                      ; preds = %26
   %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
   store i8 %30, i8 addrspace(1)* %32
   %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
-  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
-  br i1 %NullCheck14, label %40, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %40
 
 ; <label>:40                                      ; preds = %35
   %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
   store i8 %39, i8 addrspace(1)* %41
   %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
-  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %44
 
 ; <label>:44                                      ; preds = %40
   %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
   %46 = load i8, i8 addrspace(1)* %45, align 8
   %47 = zext i8 %46 to i32
   %48 = trunc i32 %47 to i8
-  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
   store i8 %48, i8 addrspace(1)* %50
   %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
-  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
@@ -9713,29 +11302,29 @@ entry:
 ; <label>:56                                      ; preds = %52
   %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
-  br i1 %NullCheck22, label %59, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
   %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
   %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
-  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
-  br i1 %NullCheck24, label %63, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
   %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
-  br i1 %NullCheck26, label %66, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
   %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
-  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
-  br i1 %NullCheck28, label %69, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %69
 
 ; <label>:69                                      ; preds = %66
   %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
@@ -9744,15 +11333,15 @@ entry:
 
 ; <label>:71                                      ; preds = %105
   %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
-  br i1 %NullCheck34, label %73, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %73
 
 ; <label>:73                                      ; preds = %71
   %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
   %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
   %76 = load i32, i32* %loc0
-  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
-  br i1 %NullCheck36, label %77, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
@@ -9766,8 +11355,8 @@ entry:
 
 ; <label>:83                                      ; preds = %77
   %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
-  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
@@ -9775,14 +11364,14 @@ entry:
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
   %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
-  br i1 %NullCheck40, label %91, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
 ; <label>:91                                      ; preds = %85
   %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
   %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
-  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck42, label %94, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %94
 
 ; <label>:94                                      ; preds = %91
   %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
@@ -9798,14 +11387,14 @@ entry:
 ; <label>:99                                      ; preds = %69, %96
   %100 = load i32, i32* %loc0
   %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
-  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %102
 
 ; <label>:102                                     ; preds = %99
   %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
   %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
-  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
-  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
@@ -9819,87 +11408,87 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %26
+ThrowNullRef10:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %31
+ThrowNullRef12:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %35
+ThrowNullRef14:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %40
+ThrowNullRef16:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %56
+ThrowNullRef22:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %59
+ThrowNullRef24:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %63
+ThrowNullRef26:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %66
+ThrowNullRef28:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %102
+ThrowNullRef32:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %71
+ThrowNullRef34:                                   ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %73
+ThrowNullRef36:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %83
+ThrowNullRef38:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %85
+ThrowNullRef40:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %91
+ThrowNullRef42:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9943,15 +11532,15 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
   %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
@@ -9961,28 +11550,28 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
   %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %12
   %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
   %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
   %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
-  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
@@ -9993,23 +11582,23 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %12
+ThrowNullRef6:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10031,15 +11620,15 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
   %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = load i64, i64 addrspace(1)* %7
@@ -10077,13 +11666,13 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[loadElem]
+Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -10111,8 +11700,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -10189,8 +11778,8 @@ entry:
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -10324,8 +11913,8 @@ entry:
   store i64 %param0, i64* %arg0
   store i64 %param1, i64* %arg1
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
@@ -10333,8 +11922,8 @@ entry:
   %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
   %5 = load i16*, i16* addrspace(1)* %4, align 8
   %6 = addrspacecast i64* %arg1 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = bitcast i64 addrspace(1)* %6 to i8 addrspace(1)*
@@ -10350,7 +11939,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10384,8 +11973,8 @@ entry:
   %1 = load i32, i32* %arg1
   %2 = sext i32 %1 to i64
   %3 = inttoptr i64 %2 to i16*
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -10438,8 +12027,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, i32)*)(%System.IO.ConsoleStream addrspace(1)* %2, i32 %1)
   %3 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %4 = load i64, i64* %arg1
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
@@ -10450,8 +12039,8 @@ entry:
   %10 = icmp eq i32 %9, 3
   %11 = sext i1 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %5
   %14 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, i32 0, i32 5
@@ -10462,7 +12051,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10485,8 +12074,8 @@ entry:
   %5 = icmp eq i32 %4, 1
   %6 = sext i1 %5 to i32
   %7 = trunc i32 %6 to i8
-  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %2, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.ConsoleStream addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
@@ -10497,8 +12086,8 @@ entry:
   %13 = icmp eq i32 %12, 2
   %14 = sext i1 %13 to i32
   %15 = trunc i32 %14 to i8
-  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %10, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.ConsoleStream addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %8
   %17 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %10, i32 0, i32 4
@@ -10509,7 +12098,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10548,8 +12137,8 @@ entry:
   %arg0 = alloca i64
   store i64 %param0, i64* %arg0
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
@@ -10584,8 +12173,8 @@ entry:
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
   %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = load i64, i64 addrspace(1)* %7
@@ -10689,7 +12278,127 @@ entry:
 INFO:  jitting method Encoding::GetEncoding using LLILCJit
 Failed to read Encoding.GetEncoding[convertToHelperArgumentType]
 INFO:  jitting method EncodingProvider::GetEncodingFromProvider using LLILCJit
-Failed to read EncodingProvider.GetEncodingFromProvider[loadElem]
+Successfully read EncodingProvider.GetEncodingFromProvider
+
+define %System.Text.Encoding addrspace(1)* @EncodingProvider.GetEncodingFromProvider(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca %"System.Text.EncodingProvider[]" addrspace(1)*
+  %loc1 = alloca %System.Text.EncodingProvider addrspace(1)*
+  %loc2 = alloca %System.Text.Encoding addrspace(1)*
+  %loc3 = alloca %System.Text.Encoding addrspace(1)*
+  %loc4 = alloca %"System.Text.EncodingProvider[]" addrspace(1)*
+  %loc5 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1059)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2392
+  %2 = addrspacecast i8 addrspace(1)* %1 to %"System.Text.EncodingProvider[]" addrspace(1)**
+  %3 = load volatile %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %2
+  %4 = icmp ne %"System.Text.EncodingProvider[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %entry
+  ret %System.Text.Encoding addrspace(1)* null
+
+; <label>:6                                       ; preds = %entry
+  %7 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1059)
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i64 2392
+  %9 = addrspacecast i8 addrspace(1)* %8 to %"System.Text.EncodingProvider[]" addrspace(1)**
+  %10 = load volatile %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %9
+  store %"System.Text.EncodingProvider[]" addrspace(1)* %10, %"System.Text.EncodingProvider[]" addrspace(1)** %loc0
+  %11 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc0
+  store %"System.Text.EncodingProvider[]" addrspace(1)* %11, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  store i32 0, i32* %loc5
+  br label %43
+
+; <label>:12                                      ; preds = %46
+  %13 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  %14 = load i32, i32* %loc5
+  %NullCheck1 = icmp eq %"System.Text.EncodingProvider[]" addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %13, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = zext i32 %17 to i64
+  %19 = zext i32 %14 to i64
+  %BoundsCheck = icmp uge i64 %19, %18
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %20
+
+; <label>:20                                      ; preds = %15
+  %21 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %13, i32 0, i32 3, i32 %14
+  %22 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)* addrspace(1)* %21, align 8
+  store %System.Text.EncodingProvider addrspace(1)* %22, %System.Text.EncodingProvider addrspace(1)** %loc1
+  %23 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)** %loc1
+  %24 = load i32, i32* %arg0
+  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i64 addrspace(1)*
+  %NullCheck3 = icmp eq i64 addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
+
+; <label>:26                                      ; preds = %20
+  %27 = load i64, i64 addrspace(1)* %25
+  %28 = add i64 %27, 64
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 40
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Text.Encoding addrspace(1)* (%System.Text.EncodingProvider addrspace(1)*, i32)*
+  %35 = call %System.Text.Encoding addrspace(1)* %34(%System.Text.EncodingProvider addrspace(1)* %23, i32 %24)
+  store %System.Text.Encoding addrspace(1)* %35, %System.Text.Encoding addrspace(1)** %loc2
+  %36 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc2
+  %37 = icmp eq %System.Text.Encoding addrspace(1)* %36, null
+  br i1 %37, label %40, label %38
+
+; <label>:38                                      ; preds = %26
+  %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc2
+  store %System.Text.Encoding addrspace(1)* %39, %System.Text.Encoding addrspace(1)** %loc3
+  br label %53
+
+; <label>:40                                      ; preds = %26
+  %41 = load i32, i32* %loc5
+  %42 = add i32 %41, 1
+  store i32 %42, i32* %loc5
+  br label %43
+
+; <label>:43                                      ; preds = %6, %40
+  %44 = load i32, i32* %loc5
+  %45 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  %NullCheck = icmp eq %"System.Text.EncodingProvider[]" addrspace(1)* %45, null
+  br i1 %NullCheck, label %ThrowNullRef, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp slt i32 %44, %50
+  br i1 %51, label %12, label %52
+
+; <label>:52                                      ; preds = %46
+  ret %System.Text.Encoding addrspace(1)* null
+
+; <label>:53                                      ; preds = %38
+  %54 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc3
+  ret %System.Text.Encoding addrspace(1)* %54
+
+ThrowNullRef:                                     ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method EncodingProvider::.cctor using LLILCJit
 Successfully read EncodingProvider..cctor
 
@@ -10708,7 +12417,7 @@ Failed to read Encoding.get_InternalSyncObject[Call HasTypeArg]
 INFO:  jitting method Hashtable::.ctor using LLILCJit
 Failed to read Hashtable..ctor[Volatile store]
 INFO:  jitting method Hashtable::get_Item using LLILCJit
-Failed to read Hashtable.get_Item[loadElemA]
+Failed to read Hashtable.get_Item[loadNonPrimitiveObj]
 INFO:  jitting method Hashtable::InitHash using LLILCJit
 Successfully read Hashtable.InitHash
 
@@ -10728,8 +12437,8 @@ entry:
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -10745,15 +12454,15 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
   %15 = load i32, i32* %loc0
-  %NullCheck2 = icmp ne i32 addrspace(1)* %14, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i32 addrspace(1)* %14, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %3
   store i32 %15, i32 addrspace(1)* %14, align 8
   %17 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %18 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %NullCheck4 = icmp ne i32 addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i32 addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = load i32, i32 addrspace(1)* %18, align 8
@@ -10762,8 +12471,8 @@ entry:
   %23 = sub i32 %22, 1
   %24 = urem i32 %21, %23
   %25 = add i32 1, %24
-  %NullCheck6 = icmp ne i32 addrspace(1)* %17, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32 addrspace(1)* %17, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %19
   store i32 %25, i32 addrspace(1)* %17, align 8
@@ -10774,15 +12483,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %19
+ThrowNullRef6:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10797,8 +12506,8 @@ entry:
   store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
   store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %NullCheck = icmp ne %System.Collections.Hashtable addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Collections.Hashtable addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
@@ -10808,16 +12517,16 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Collections.Hashtable addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Collections.Hashtable addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
   %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck4 = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %9, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
   %13 = inttoptr i64 %11 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
@@ -10827,8 +12536,8 @@ entry:
 ; <label>:15                                      ; preds = %1
   %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -10846,15 +12555,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10868,8 +12577,8 @@ entry:
   store %System.Int32 addrspace(1)* %param0, %System.Int32 addrspace(1)** %this
   %0 = load %System.Int32 addrspace(1)*, %System.Int32 addrspace(1)** %this
   %1 = bitcast %System.Int32 addrspace(1)* %0 to i32 addrspace(1)*
-  %NullCheck = icmp ne i32 addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq i32 addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load i32, i32 addrspace(1)* %1, align 8
@@ -10945,8 +12654,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.UTF8Encoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
@@ -10955,15 +12664,15 @@ entry:
   %9 = load i8, i8* %arg2
   %10 = zext i8 %9 to i32
   %11 = trunc i32 %10 to i8
-  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %8, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %6
   %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %8, i32 0, i32 8
   store i8 %11, i8 addrspace(1)* %13
   %14 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %14, i32 0, i32 8
@@ -10975,8 +12684,8 @@ entry:
 ; <label>:20                                      ; preds = %15
   %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %22, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %22, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = load i64, i64 addrspace(1)* %22
@@ -10998,15 +12707,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %12
+ThrowNullRef4:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11021,8 +12730,8 @@ entry:
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
@@ -11044,16 +12753,16 @@ entry:
 ; <label>:10                                      ; preds = %1
   %11 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
   %12 = load i32, i32* %arg1
-  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %11, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.Encoding addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
   store i32 %12, i32 addrspace(1)* %14
   %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
   %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = load i64, i64 addrspace(1)* %16
@@ -11071,11 +12780,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11088,8 +12797,8 @@ entry:
   %this = alloca %System.Text.UTF8Encoding addrspace(1)*
   store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
   %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.UTF8Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
@@ -11101,16 +12810,16 @@ entry:
 ; <label>:6                                       ; preds = %1
   %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %8 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %10, %System.Text.EncoderFallback addrspace(1)* %8)
   %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %12 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
-  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %11, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %11, i32 0, i32 3
@@ -11123,8 +12832,8 @@ entry:
   %18 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %18, %System.String addrspace(1)* %17)
   %19 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %18 to %System.Text.EncoderFallback addrspace(1)*
-  %NullCheck6 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %16, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %16, i32 0, i32 2
@@ -11134,8 +12843,8 @@ entry:
   %24 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %24, %System.String addrspace(1)* %23)
   %25 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %24 to %System.Text.DecoderFallback addrspace(1)*
-  %NullCheck8 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %22, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %22, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %20
   %27 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %22, i32 0, i32 3
@@ -11146,19 +12855,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %20
+ThrowNullRef8:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11188,8 +12897,8 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load i32, i32* %arg1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -11207,8 +12916,8 @@ entry:
 ; <label>:15                                      ; preds = %8
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %17 = load i32, i32* %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 %17
@@ -11224,7 +12933,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11276,7 +12985,7 @@ entry:
 }
 
 INFO:  jitting method Hashtable::Insert using LLILCJit
-Failed to read Hashtable.Insert[loadElemA]
+Failed to read Hashtable.Insert[storeElem]
 INFO:  jitting method ConsoleEncoding::.ctor using LLILCJit
 Successfully read ConsoleEncoding..ctor
 
@@ -11291,8 +13000,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %1)
   %2 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
@@ -11328,8 +13037,8 @@ entry:
   %2 = call %System.Text.InternalEncoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalEncoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %1)
   %3 = bitcast %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2 to %System.Text.EncoderFallback addrspace(1)*
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
@@ -11339,8 +13048,8 @@ entry:
   %8 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %7)
   %9 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %8 to %System.Text.DecoderFallback addrspace(1)*
-  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %6, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.Encoding addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %4
   %11 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %6, i32 0, i32 3
@@ -11351,7 +13060,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11370,15 +13079,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* %1)
   %2 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   %6 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, i32 0, i32 1
@@ -11389,7 +13098,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11417,8 +13126,8 @@ entry:
   store %System.Text.InternalDecoderBestFitFallback addrspace(1)* %param0, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
   %0 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
@@ -11428,15 +13137,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %4)
   %5 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %6)
   %9 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, i32 0, i32 1
@@ -11447,11 +13156,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11519,8 +13228,8 @@ entry:
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
   %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = load i64, i64 addrspace(1)* %19
@@ -11584,8 +13293,8 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.ConsoleStream addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
@@ -11616,31 +13325,31 @@ entry:
   store i8 %param4, i8* %arg4
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %3, %System.IO.Stream addrspace(1)* %1)
   %4 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %4, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
   %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %4, i32 0, i32 4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %5)
   %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %6
   %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
   %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
   %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = load i64, i64 addrspace(1)* %13
@@ -11652,8 +13361,8 @@ entry:
   %21 = load i64, i64* %20
   %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %8, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %8, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %14
   %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 5
@@ -11671,24 +13380,24 @@ entry:
   %31 = load i32, i32* %arg3
   %32 = sext i32 %31 to i64
   %33 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %32)
-  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %30, null
-  br i1 %NullCheck10, label %34, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.StreamWriter addrspace(1)* %30, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %35, %"System.Char[]" addrspace(1)* %33)
   %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %37, null
-  br i1 %NullCheck12, label %38, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.StreamWriter addrspace(1)* %37, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %38
 
 ; <label>:38                                      ; preds = %34
   %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
   %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
   %41 = load i32, i32* %arg3
   %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %42, null
-  br i1 %NullCheck14, label %43, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %42, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
   %44 = load i64, i64 addrspace(1)* %42
@@ -11702,30 +13411,30 @@ entry:
   %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
   %53 = sext i32 %52 to i64
   %54 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %53)
-  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
-  br i1 %NullCheck16, label %55, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %55
 
 ; <label>:55                                      ; preds = %43
   %56 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %56, %"System.Byte[]" addrspace(1)* %54)
   %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %58 = load i32, i32* %arg3
-  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %57, null
-  br i1 %NullCheck18, label %59, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.StreamWriter addrspace(1)* %57, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %59
 
 ; <label>:59                                      ; preds = %55
   %60 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 10
   store i32 %58, i32 addrspace(1)* %60
   %61 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %61, null
-  br i1 %NullCheck20, label %62, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.IO.StreamWriter addrspace(1)* %61, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %62
 
 ; <label>:62                                      ; preds = %59
   %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
   %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
   %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
   %67 = load i64, i64 addrspace(1)* %65
@@ -11743,15 +13452,15 @@ entry:
 
 ; <label>:78                                      ; preds = %66
   %79 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %79, null
-  br i1 %NullCheck24, label %80, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.StreamWriter addrspace(1)* %79, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %80
 
 ; <label>:80                                      ; preds = %78
   %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
   %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
   %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %83, null
-  br i1 %NullCheck26, label %84, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %83, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
   %85 = load i64, i64 addrspace(1)* %83
@@ -11768,8 +13477,8 @@ entry:
 
 ; <label>:95                                      ; preds = %84
   %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.IO.StreamWriter addrspace(1)* %96, null
-  br i1 %NullCheck28, label %97, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.IO.StreamWriter addrspace(1)* %96, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %97
 
 ; <label>:97                                      ; preds = %95
   %98 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 12
@@ -11783,8 +13492,8 @@ entry:
   %103 = icmp eq i32 %102, 0
   %104 = sext i1 %103 to i32
   %105 = trunc i32 %104 to i8
-  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %100, null
-  br i1 %NullCheck30, label %106, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.IO.StreamWriter addrspace(1)* %100, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %106
 
 ; <label>:106                                     ; preds = %99
   %107 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %100, i32 0, i32 13
@@ -11795,63 +13504,63 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %6
+ThrowNullRef4:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %29
+ThrowNullRef10:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %34
+ThrowNullRef12:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %38
+ThrowNullRef14:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %43
+ThrowNullRef16:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %55
+ThrowNullRef18:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %59
+ThrowNullRef20:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %62
+ThrowNullRef22:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %78
+ThrowNullRef24:                                   ; preds = %78
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %80
+ThrowNullRef26:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %95
+ThrowNullRef28:                                   ; preds = %95
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11864,15 +13573,15 @@ entry:
   %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = load i64, i64 addrspace(1)* %4
@@ -11890,7 +13599,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11940,35 +13649,35 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
   %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderNLS addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %7 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.EncoderNLS addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Text.Encoding addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.Encoding addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Text.EncoderNLS addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.EncoderNLS addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
   %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck8 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = load i64, i64 addrspace(1)* %16
@@ -11987,19 +13696,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12025,8 +13734,8 @@ entry:
   %this = alloca %System.Text.Encoding addrspace(1)*
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
@@ -12046,15 +13755,15 @@ entry:
   %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
   store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
   %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
   store i32 0, i32 addrspace(1)* %2
   %3 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, i32 0, i32 2
@@ -12064,15 +13773,15 @@ entry:
 
 ; <label>:8                                       ; preds = %4
   %9 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
   %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
   %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = load i64, i64 addrspace(1)* %13
@@ -12093,15 +13802,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12116,16 +13825,16 @@ entry:
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = load i32, i32* %arg1
   %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
   %7 = load i64, i64 addrspace(1)* %5
@@ -12143,7 +13852,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12180,8 +13889,8 @@ entry:
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
   %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
   %16 = load i64, i64 addrspace(1)* %14
@@ -12202,8 +13911,8 @@ entry:
   %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
   %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
   %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %31, null
-  br i1 %NullCheck2, label %32, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = load i64, i64 addrspace(1)* %31
@@ -12246,7 +13955,7 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12259,14 +13968,14 @@ entry:
   %this = alloca %System.Text.EncoderReplacementFallback addrspace(1)*
   store %System.Text.EncoderReplacementFallback addrspace(1)* %param0, %System.Text.EncoderReplacementFallback addrspace(1)** %this
   %0 = load %System.Text.EncoderReplacementFallback addrspace(1)*, %System.Text.EncoderReplacementFallback addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -12277,7 +13986,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12307,8 +14016,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
@@ -12340,8 +14049,8 @@ entry:
   %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
   store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
@@ -12353,8 +14062,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Threading.Tasks.Task addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %7)
@@ -12377,7 +14086,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12396,8 +14105,8 @@ entry:
   store i8 %param1, i8* %arg1
   store i8 %param2, i8* %arg2
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
@@ -12411,8 +14120,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1, %5
   %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 9
@@ -12443,8 +14152,8 @@ entry:
 
 ; <label>:25                                      ; preds = %8, %20
   %26 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %26, null
-  br i1 %NullCheck4, label %27, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %26, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %26, i32 0, i32 12
@@ -12455,22 +14164,22 @@ entry:
 
 ; <label>:32                                      ; preds = %27
   %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %33, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.IO.StreamWriter addrspace(1)* %33, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %32
   %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 12
   store i8 1, i8 addrspace(1)* %35
   %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
-  br i1 %NullCheck8, label %37, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
   %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
   %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck10 = icmp ne i64 addrspace(1)* %40, null
-  br i1 %NullCheck10, label %41, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64 addrspace(1)* %40, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i64, i64 addrspace(1)* %40
@@ -12484,8 +14193,8 @@ entry:
   %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
   store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
   %51 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %NullCheck12 = icmp ne %"System.Byte[]" addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Byte[]" addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %41
   %53 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %51, i32 0, i32 1
@@ -12497,16 +14206,16 @@ entry:
 
 ; <label>:58                                      ; preds = %52
   %59 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %59, null
-  br i1 %NullCheck14, label %60, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.IO.StreamWriter addrspace(1)* %59, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %60
 
 ; <label>:60                                      ; preds = %58
   %61 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %59, i32 0, i32 3
   %62 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
   %64 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %NullCheck16 = icmp ne %"System.Byte[]" addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %"System.Byte[]" addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %60
   %66 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %64, i32 0, i32 1
@@ -12514,8 +14223,8 @@ entry:
   %68 = zext i32 %67 to i64
   %69 = trunc i64 %68 to i32
   %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck18, label %71, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
   %72 = load i64, i64 addrspace(1)* %70
@@ -12531,29 +14240,29 @@ entry:
 
 ; <label>:80                                      ; preds = %27, %52, %71
   %81 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %81, null
-  br i1 %NullCheck20, label %82, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.IO.StreamWriter addrspace(1)* %81, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
 
 ; <label>:82                                      ; preds = %80
   %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %81, i32 0, i32 5
   %84 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %83, align 8
   %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.IO.StreamWriter addrspace(1)* %85, null
-  br i1 %NullCheck22, label %86, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.IO.StreamWriter addrspace(1)* %85, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %86
 
 ; <label>:86                                      ; preds = %82
   %87 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 7
   %88 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %87, align 8
   %89 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %89, null
-  br i1 %NullCheck24, label %90, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.StreamWriter addrspace(1)* %89, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %90
 
 ; <label>:90                                      ; preds = %86
   %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %89, i32 0, i32 9
   %92 = load i32, i32 addrspace(1)* %91, align 8
   %93 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.IO.StreamWriter addrspace(1)* %93, null
-  br i1 %NullCheck26, label %94, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.IO.StreamWriter addrspace(1)* %93, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %93, i32 0, i32 6
@@ -12561,8 +14270,8 @@ entry:
   %97 = load i8, i8* %arg2
   %98 = zext i8 %97 to i32
   %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
-  %NullCheck28 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck28, label %100, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
   %101 = load i64, i64 addrspace(1)* %99
@@ -12577,8 +14286,8 @@ entry:
   %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
   store i32 %110, i32* %loc1
   %111 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %111, null
-  br i1 %NullCheck30, label %112, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.IO.StreamWriter addrspace(1)* %111, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %112
 
 ; <label>:112                                     ; preds = %100
   %113 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %111, i32 0, i32 9
@@ -12589,23 +14298,23 @@ entry:
 
 ; <label>:116                                     ; preds = %112
   %117 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck32 = icmp ne %System.IO.StreamWriter addrspace(1)* %117, null
-  br i1 %NullCheck32, label %118, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.IO.StreamWriter addrspace(1)* %117, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %118
 
 ; <label>:118                                     ; preds = %116
   %119 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %117, i32 0, i32 3
   %120 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %119, align 8
   %121 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.IO.StreamWriter addrspace(1)* %121, null
-  br i1 %NullCheck34, label %122, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.IO.StreamWriter addrspace(1)* %121, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %122
 
 ; <label>:122                                     ; preds = %118
   %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
   %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
   %125 = load i32, i32* %loc1
   %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
-  %NullCheck36 = icmp ne i64 addrspace(1)* %126, null
-  br i1 %NullCheck36, label %127, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64 addrspace(1)* %126, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
   %128 = load i64, i64 addrspace(1)* %126
@@ -12627,15 +14336,15 @@ entry:
 
 ; <label>:140                                     ; preds = %136
   %141 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.IO.StreamWriter addrspace(1)* %141, null
-  br i1 %NullCheck38, label %142, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.IO.StreamWriter addrspace(1)* %141, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %142
 
 ; <label>:142                                     ; preds = %140
   %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
   %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
   %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
-  %NullCheck40 = icmp ne i64 addrspace(1)* %145, null
-  br i1 %NullCheck40, label %146, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i64 addrspace(1)* %145, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
   %147 = load i64, i64 addrspace(1)* %145
@@ -12656,83 +14365,83 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %25
+ThrowNullRef4:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %32
+ThrowNullRef6:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %37
+ThrowNullRef10:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %41
+ThrowNullRef12:                                   ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %58
+ThrowNullRef14:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %60
+ThrowNullRef16:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %65
+ThrowNullRef18:                                   ; preds = %65
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %80
+ThrowNullRef20:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %82
+ThrowNullRef22:                                   ; preds = %82
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %86
+ThrowNullRef24:                                   ; preds = %86
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %90
+ThrowNullRef26:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %94
+ThrowNullRef28:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %100
+ThrowNullRef30:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %116
+ThrowNullRef32:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %118
+ThrowNullRef34:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %122
+ThrowNullRef36:                                   ; preds = %122
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %140
+ThrowNullRef38:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %142
+ThrowNullRef40:                                   ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12799,8 +14508,8 @@ entry:
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %1 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
-  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
@@ -12808,8 +14517,8 @@ entry:
   %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
   %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
   %8 = load i64, i64 addrspace(1)* %6
@@ -12825,8 +14534,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %17, %System.IFormatProvider addrspace(1)* %16)
   %18 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %19 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %18, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.SyncTextWriter addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %7
   %21 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %18, i32 0, i32 4
@@ -12837,11 +14546,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12854,8 +14563,8 @@ entry:
   %this = alloca %System.IO.TextWriter addrspace(1)*
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.TextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
@@ -12865,8 +14574,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.Threading.Thread addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Threading.Thread addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %6)
@@ -12875,8 +14584,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1
   %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.TextWriter addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.TextWriter addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %11, i32 0, i32 2
@@ -12887,11 +14596,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13088,8 +14797,8 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   store i8 0, i8* %loc1
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
@@ -13099,16 +14808,16 @@ entry:
   %5 = addrspacecast i8* %loc1 to i8 addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %4, i8 addrspace(1)* %5)
   %6 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.SyncTextWriter addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
   %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
   %13 = load i64, i64 addrspace(1)* %11
@@ -13143,19 +14852,229 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
-Failed to read TextWriter.WriteLine[loadElem]
+Failed to read TextWriter.WriteLine[storeElem]
 INFO:  jitting method String::CopyTo using LLILCJit
-Failed to read String.CopyTo[loadElemA]
+Successfully read String.CopyTo
+
+define void @String.CopyTo(%System.String addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  %loc1 = alloca i16 addrspace(1)*
+  %loc2 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %1 = icmp ne %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg4
+  %7 = icmp sge i32 %6, 0
+  br i1 %7, label %13, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  unreachable
+
+; <label>:13                                      ; preds = %5
+  %14 = load i32, i32* %arg1
+  %15 = icmp sge i32 %14, 0
+  br i1 %15, label %21, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %18)
+  %20 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %20, %System.String addrspace(1)* %17, %System.String addrspace(1)* %19)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %20) #0
+  unreachable
+
+; <label>:21                                      ; preds = %13
+  %22 = load i32, i32* %arg4
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck, label %ThrowNullRef, label %24
+
+; <label>:24                                      ; preds = %21
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load i32, i32* %arg1
+  %28 = sub i32 %26, %27
+  %29 = icmp sle i32 %22, %28
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34, %System.String addrspace(1)* %31, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %24
+  %36 = load i32, i32* %arg3
+  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %37, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
+
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
+  %40 = load i32, i32 addrspace(1)* %39
+  %41 = zext i32 %40 to i64
+  %42 = trunc i64 %41 to i32
+  %43 = load i32, i32* %arg4
+  %44 = sub i32 %42, %43
+  %45 = icmp sgt i32 %36, %44
+  br i1 %45, label %49, label %46
+
+; <label>:46                                      ; preds = %38
+  %47 = load i32, i32* %arg3
+  %48 = icmp sge i32 %47, 0
+  br i1 %48, label %54, label %49
+
+; <label>:49                                      ; preds = %38, %46
+  %50 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %52 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %51)
+  %53 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53, %System.String addrspace(1)* %50, %System.String addrspace(1)* %52)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53) #0
+  unreachable
+
+; <label>:54                                      ; preds = %46
+  %55 = load i32, i32* %arg4
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %97, label %57
+
+; <label>:57                                      ; preds = %54
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %59
+
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 2
+  %61 = bitcast [0 x i16] addrspace(1)* %60 to i16 addrspace(1)*
+  store i16 addrspace(1)* %61, i16 addrspace(1)** %loc0
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  store %"System.Char[]" addrspace(1)* %62, %"System.Char[]" addrspace(1)** %loc2
+  %63 = icmp eq %"System.Char[]" addrspace(1)* %62, null
+  br i1 %63, label %72, label %64
+
+; <label>:64                                      ; preds = %59
+  %65 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc2
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %65, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %66
+
+; <label>:66                                      ; preds = %64
+  %67 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %65, i32 0, i32 1
+  %68 = load i32, i32 addrspace(1)* %67
+  %69 = zext i32 %68 to i64
+  %70 = trunc i64 %69 to i32
+  %71 = icmp ne i32 %70, 0
+  br i1 %71, label %73, label %72
+
+; <label>:72                                      ; preds = %59, %66
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  br label %81
+
+; <label>:73                                      ; preds = %66
+  %74 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc2
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %74, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %75
+
+; <label>:75                                      ; preds = %73
+  %76 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %74, i32 0, i32 1
+  %77 = load i32, i32 addrspace(1)* %76
+  %78 = zext i32 %77 to i64
+  %BoundsCheck = icmp uge i64 0, %78
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %79
+
+; <label>:79                                      ; preds = %75
+  %80 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %74, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %80, i16 addrspace(1)** %loc1
+  br label %81
+
+; <label>:81                                      ; preds = %72, %79
+  %82 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %83 = ptrtoint i16 addrspace(1)* %82 to i64
+  %84 = load i32, i32* %arg3
+  %85 = sext i32 %84 to i64
+  %86 = mul i64 %85, 2
+  %87 = add i64 %83, %86
+  %88 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %89 = ptrtoint i16 addrspace(1)* %88 to i64
+  %90 = load i32, i32* %arg1
+  %91 = sext i32 %90 to i64
+  %92 = mul i64 %91, 2
+  %93 = add i64 %89, %92
+  %94 = load i32, i32* %arg4
+  %95 = inttoptr i64 %87 to i16*
+  %96 = inttoptr i64 %93 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %95, i16* %96, i32 %94)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  br label %97
+
+; <label>:97                                      ; preds = %54, %81
+  ret void
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StreamWriter::Write using LLILCJit
 Successfully read StreamWriter.Write
 
@@ -13213,8 +15132,8 @@ entry:
 
 ; <label>:23                                      ; preds = %15
   %24 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Char[]" addrspace(1)* %24, null
-  br i1 %NullCheck, label %25, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %24, null
+  br i1 %NullCheck, label %ThrowNullRef, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %24, i32 0, i32 1
@@ -13242,15 +15161,15 @@ entry:
 
 ; <label>:40                                      ; preds = %98
   %41 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %41, null
-  br i1 %NullCheck4, label %42, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %41, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %42
 
 ; <label>:42                                      ; preds = %40
   %43 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
   %44 = load i32, i32 addrspace(1)* %43, align 8
   %45 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %45, null
-  br i1 %NullCheck6, label %46, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.IO.StreamWriter addrspace(1)* %45, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %46
 
 ; <label>:46                                      ; preds = %42
   %47 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %45, i32 0, i32 10
@@ -13265,15 +15184,15 @@ entry:
 
 ; <label>:52                                      ; preds = %46, %50
   %53 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %53, null
-  br i1 %NullCheck8, label %54, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %53, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %54
 
 ; <label>:54                                      ; preds = %52
   %55 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %53, i32 0, i32 10
   %56 = load i32, i32 addrspace(1)* %55, align 8
   %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %57, null
-  br i1 %NullCheck10, label %58, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.StreamWriter addrspace(1)* %57, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %58
 
 ; <label>:58                                      ; preds = %54
   %59 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 9
@@ -13295,15 +15214,15 @@ entry:
   %69 = load i32, i32* %arg2
   %70 = mul i32 %69, 2
   %71 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %71, null
-  br i1 %NullCheck12, label %72, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.StreamWriter addrspace(1)* %71, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %72
 
 ; <label>:72                                      ; preds = %67
   %73 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %71, i32 0, i32 7
   %74 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %73, align 8
   %75 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %75, null
-  br i1 %NullCheck14, label %76, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.IO.StreamWriter addrspace(1)* %75, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %76
 
 ; <label>:76                                      ; preds = %72
   %77 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %75, i32 0, i32 9
@@ -13315,16 +15234,16 @@ entry:
   %83 = bitcast %"System.Char[]" addrspace(1)* %74 to %System.Array addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %82, i32 %70, %System.Array addrspace(1)* %83, i32 %79, i32 %81)
   %84 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %84, null
-  br i1 %NullCheck16, label %85, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.IO.StreamWriter addrspace(1)* %84, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %85
 
 ; <label>:85                                      ; preds = %76
   %86 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %84, i32 0, i32 9
   %87 = load i32, i32 addrspace(1)* %86, align 8
   %88 = load i32, i32* %loc0
   %89 = add i32 %87, %88
-  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %84, null
-  br i1 %NullCheck18, label %90, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.StreamWriter addrspace(1)* %84, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %90
 
 ; <label>:90                                      ; preds = %85
   %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %84, i32 0, i32 9
@@ -13346,8 +15265,8 @@ entry:
 
 ; <label>:101                                     ; preds = %98
   %102 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %102, null
-  br i1 %NullCheck2, label %103, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %102, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %103
 
 ; <label>:103                                     ; preds = %101
   %104 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %102, i32 0, i32 11
@@ -13368,39 +15287,39 @@ ThrowNullRef:                                     ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %101
+ThrowNullRef2:                                    ; preds = %101
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %40
+ThrowNullRef4:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %42
+ThrowNullRef6:                                    ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %52
+ThrowNullRef8:                                    ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %54
+ThrowNullRef10:                                   ; preds = %54
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %67
+ThrowNullRef12:                                   ; preds = %67
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %72
+ThrowNullRef14:                                   ; preds = %72
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %76
+ThrowNullRef16:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %85
+ThrowNullRef18:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13441,7 +15360,365 @@ entry:
 }
 
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[loadElemA]
+Successfully read EncoderNLS.GetBytes
+
+define i32 @EncoderNLS.GetBytes(%System.Text.EncoderNLS addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3, %"System.Byte[]" addrspace(1)* %param4, i32 %param5, i8 %param6) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %arg4 = alloca %"System.Byte[]" addrspace(1)*
+  %arg5 = alloca i32
+  %arg6 = alloca i8
+  %loc0 = alloca i32
+  %loc1 = alloca i16 addrspace(1)*
+  %loc2 = alloca i8 addrspace(1)*
+  %loc3 = alloca i32
+  %loc4 = alloca %"System.Char[]" addrspace(1)*
+  %loc5 = alloca %"System.Byte[]" addrspace(1)*
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  store %"System.Byte[]" addrspace(1)* %param4, %"System.Byte[]" addrspace(1)** %arg4
+  store i32 %param5, i32* %arg5
+  store i8 %param6, i8* %arg6
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %1 = icmp eq %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %17, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %7 = icmp eq %"System.Char[]" addrspace(1)* %6, null
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %12
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %12
+
+; <label>:12                                      ; preds = %8, %10
+  %13 = phi %System.String addrspace(1)* [ %9, %8 ], [ %11, %10 ]
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %14)
+  %16 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16, %System.String addrspace(1)* %13, %System.String addrspace(1)* %15)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16) #0
+  unreachable
+
+; <label>:17                                      ; preds = %2
+  %18 = load i32, i32* %arg2
+  %19 = icmp slt i32 %18, 0
+  br i1 %19, label %23, label %20
+
+; <label>:20                                      ; preds = %17
+  %21 = load i32, i32* %arg3
+  %22 = icmp sge i32 %21, 0
+  br i1 %22, label %35, label %23
+
+; <label>:23                                      ; preds = %17, %20
+  %24 = load i32, i32* %arg2
+  %25 = icmp slt i32 %24, 0
+  br i1 %25, label %28, label %26
+
+; <label>:26                                      ; preds = %23
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %30
+
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %30
+
+; <label>:30                                      ; preds = %26, %28
+  %31 = phi %System.String addrspace(1)* [ %27, %26 ], [ %29, %28 ]
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34, %System.String addrspace(1)* %31, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %20
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck, label %ThrowNullRef, label %37
+
+; <label>:37                                      ; preds = %35
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = load i32, i32* %arg2
+  %43 = sub i32 %41, %42
+  %44 = load i32, i32* %arg3
+  %45 = icmp sge i32 %43, %44
+  br i1 %45, label %51, label %46
+
+; <label>:46                                      ; preds = %37
+  %47 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %48 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %49 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %48)
+  %50 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %50, %System.String addrspace(1)* %47, %System.String addrspace(1)* %49)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %50) #0
+  unreachable
+
+; <label>:51                                      ; preds = %37
+  %52 = load i32, i32* %arg5
+  %53 = icmp slt i32 %52, 0
+  br i1 %53, label %63, label %54
+
+; <label>:54                                      ; preds = %51
+  %55 = load i32, i32* %arg5
+  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck1 = icmp eq %"System.Byte[]" addrspace(1)* %56, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %57
+
+; <label>:57                                      ; preds = %54
+  %58 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = zext i32 %59 to i64
+  %61 = trunc i64 %60 to i32
+  %62 = icmp sle i32 %55, %61
+  br i1 %62, label %68, label %63
+
+; <label>:63                                      ; preds = %51, %57
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %66 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %65)
+  %67 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %67, %System.String addrspace(1)* %64, %System.String addrspace(1)* %66)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %67) #0
+  unreachable
+
+; <label>:68                                      ; preds = %57
+  %69 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %69, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %69, i32 0, i32 1
+  %72 = load i32, i32 addrspace(1)* %71
+  %73 = zext i32 %72 to i64
+  %74 = trunc i64 %73 to i32
+  %75 = icmp ne i32 %74, 0
+  br i1 %75, label %78, label %76
+
+; <label>:76                                      ; preds = %70
+  %77 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1)
+  store %"System.Char[]" addrspace(1)* %77, %"System.Char[]" addrspace(1)** %arg1
+  br label %78
+
+; <label>:78                                      ; preds = %70, %76
+  %79 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck5 = icmp eq %"System.Byte[]" addrspace(1)* %79, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %80
+
+; <label>:80                                      ; preds = %78
+  %81 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %79, i32 0, i32 1
+  %82 = load i32, i32 addrspace(1)* %81
+  %83 = zext i32 %82 to i64
+  %84 = trunc i64 %83 to i32
+  %85 = load i32, i32* %arg5
+  %86 = sub i32 %84, %85
+  store i32 %86, i32* %loc0
+  %87 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck7 = icmp eq %"System.Byte[]" addrspace(1)* %87, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %88
+
+; <label>:88                                      ; preds = %80
+  %89 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %87, i32 0, i32 1
+  %90 = load i32, i32 addrspace(1)* %89
+  %91 = zext i32 %90 to i64
+  %92 = trunc i64 %91 to i32
+  %93 = icmp ne i32 %92, 0
+  br i1 %93, label %96, label %94
+
+; <label>:94                                      ; preds = %88
+  %95 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1)
+  store %"System.Byte[]" addrspace(1)* %95, %"System.Byte[]" addrspace(1)** %arg4
+  br label %96
+
+; <label>:96                                      ; preds = %88, %94
+  %97 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  store %"System.Char[]" addrspace(1)* %97, %"System.Char[]" addrspace(1)** %loc4
+  %98 = icmp eq %"System.Char[]" addrspace(1)* %97, null
+  br i1 %98, label %107, label %99
+
+; <label>:99                                      ; preds = %96
+  %100 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc4
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %100, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %101
+
+; <label>:101                                     ; preds = %99
+  %102 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %100, i32 0, i32 1
+  %103 = load i32, i32 addrspace(1)* %102
+  %104 = zext i32 %103 to i64
+  %105 = trunc i64 %104 to i32
+  %106 = icmp ne i32 %105, 0
+  br i1 %106, label %108, label %107
+
+; <label>:107                                     ; preds = %96, %101
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  br label %116
+
+; <label>:108                                     ; preds = %101
+  %109 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc4
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %109, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %110
+
+; <label>:110                                     ; preds = %108
+  %111 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %109, i32 0, i32 1
+  %112 = load i32, i32 addrspace(1)* %111
+  %113 = zext i32 %112 to i64
+  %BoundsCheck = icmp uge i64 0, %113
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %114
+
+; <label>:114                                     ; preds = %110
+  %115 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %109, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %115, i16 addrspace(1)** %loc1
+  br label %116
+
+; <label>:116                                     ; preds = %107, %114
+  %117 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  store %"System.Byte[]" addrspace(1)* %117, %"System.Byte[]" addrspace(1)** %loc5
+  %118 = icmp eq %"System.Byte[]" addrspace(1)* %117, null
+  br i1 %118, label %127, label %119
+
+; <label>:119                                     ; preds = %116
+  %120 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc5
+  %NullCheck13 = icmp eq %"System.Byte[]" addrspace(1)* %120, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %121
+
+; <label>:121                                     ; preds = %119
+  %122 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %120, i32 0, i32 1
+  %123 = load i32, i32 addrspace(1)* %122
+  %124 = zext i32 %123 to i64
+  %125 = trunc i64 %124 to i32
+  %126 = icmp ne i32 %125, 0
+  br i1 %126, label %128, label %127
+
+; <label>:127                                     ; preds = %116, %121
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc2
+  br label %136
+
+; <label>:128                                     ; preds = %121
+  %129 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc5
+  %NullCheck15 = icmp eq %"System.Byte[]" addrspace(1)* %129, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %130
+
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %129, i32 0, i32 1
+  %132 = load i32, i32 addrspace(1)* %131
+  %133 = zext i32 %132 to i64
+  %BoundsCheck17 = icmp uge i64 0, %133
+  br i1 %BoundsCheck17, label %ThrowIndexOutOfRange18, label %134
+
+; <label>:134                                     ; preds = %130
+  %135 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %129, i32 0, i32 3, i32 0
+  store i8 addrspace(1)* %135, i8 addrspace(1)** %loc2
+  br label %136
+
+; <label>:136                                     ; preds = %127, %134
+  %137 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %138 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %139 = ptrtoint i16 addrspace(1)* %138 to i64
+  %140 = load i32, i32* %arg2
+  %141 = sext i32 %140 to i64
+  %142 = mul i64 %141, 2
+  %143 = add i64 %139, %142
+  %144 = load i32, i32* %arg3
+  %145 = load i8 addrspace(1)*, i8 addrspace(1)** %loc2
+  %146 = ptrtoint i8 addrspace(1)* %145 to i64
+  %147 = load i32, i32* %arg5
+  %148 = sext i32 %147 to i64
+  %149 = add i64 %146, %148
+  %150 = load i32, i32* %loc0
+  %151 = load i8, i8* %arg6
+  %152 = zext i8 %151 to i32
+  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i64 addrspace(1)*
+  %NullCheck19 = icmp eq i64 addrspace(1)* %153, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %154
+
+; <label>:154                                     ; preds = %136
+  %155 = load i64, i64 addrspace(1)* %153
+  %156 = add i64 %155, 72
+  %157 = inttoptr i64 %156 to i64*
+  %158 = load i64, i64* %157
+  %159 = add i64 %158, 0
+  %160 = inttoptr i64 %159 to i64*
+  %161 = load i64, i64* %160
+  %162 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to %System.Text.Encoder addrspace(1)*
+  %163 = inttoptr i64 %143 to i16*
+  %164 = inttoptr i64 %149 to i8*
+  %165 = trunc i32 %152 to i8
+  %166 = inttoptr i64 %161 to i32 (%System.Text.Encoder addrspace(1)*, i16*, i32, i8*, i32, i8)*
+  %167 = call i32 %166(%System.Text.Encoder addrspace(1)* %162, i16* %163, i32 %144, i8* %164, i32 %150, i8 %165)
+  store i32 %167, i32* %loc3
+  br label %168
+
+; <label>:168                                     ; preds = %154
+  %169 = load i32, i32* %loc3
+  ret i32 %169
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %110
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %119
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange18:                           ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
 Successfully read EncoderNLS.GetBytes
 
@@ -13530,22 +15807,22 @@ entry:
   %40 = load i8, i8* %arg5
   %41 = zext i8 %40 to i32
   %42 = trunc i32 %41 to i8
-  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %39, null
-  br i1 %NullCheck, label %43, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderNLS addrspace(1)* %39, null
+  br i1 %NullCheck, label %ThrowNullRef, label %43
 
 ; <label>:43                                      ; preds = %38
   %44 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
   store i8 %42, i8 addrspace(1)* %44
   %45 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %45, null
-  br i1 %NullCheck2, label %46, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.EncoderNLS addrspace(1)* %45, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %46
 
 ; <label>:46                                      ; preds = %43
   %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %45, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %47
   %48 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.EncoderNLS addrspace(1)* %48, null
-  br i1 %NullCheck4, label %49, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.EncoderNLS addrspace(1)* %48, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %49
 
 ; <label>:49                                      ; preds = %46
   %50 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %48, i32 0, i32 3
@@ -13556,8 +15833,8 @@ entry:
   %55 = load i32, i32* %arg4
   %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck6, label %58, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
   %59 = load i64, i64 addrspace(1)* %57
@@ -13575,15 +15852,15 @@ ThrowNullRef:                                     ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %43
+ThrowNullRef2:                                    ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %46
+ThrowNullRef4:                                    ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %49
+ThrowNullRef6:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13611,8 +15888,8 @@ entry:
   %4 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0 to %System.IO.ConsoleStream addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*)(%System.IO.ConsoleStream addrspace(1)* %4, %"System.Byte[]" addrspace(1)* %1, i32 %2, i32 %3)
   %5 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
@@ -13697,8 +15974,8 @@ entry:
 
 ; <label>:22                                      ; preds = %8
   %23 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %23, null
-  br i1 %NullCheck, label %24, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Byte[]" addrspace(1)* %23, null
+  br i1 %NullCheck, label %ThrowNullRef, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
@@ -13720,8 +15997,8 @@ entry:
 
 ; <label>:36                                      ; preds = %24
   %37 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %37, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.ConsoleStream addrspace(1)* %37, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %37, i32 0, i32 4
@@ -13742,13 +16019,138 @@ ThrowNullRef:                                     ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %36
+ThrowNullRef2:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
-Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
+Successfully read WindowsConsoleStream.WriteFileNative
+
+define i32 @WindowsConsoleStream.WriteFileNative(i64 %param0, %"System.Byte[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i64
+  %arg1 = alloca %"System.Byte[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i8 addrspace(1)*
+  %loc2 = alloca %"System.Byte[]" addrspace(1)*
+  %loc3 = alloca i32
+  store i64 %param0, i64* %arg0
+  store %"System.Byte[]" addrspace(1)* %param1, %"System.Byte[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Byte[]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = zext i32 %3 to i64
+  %5 = icmp ne i64 %4, 0
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %1
+  ret i32 0
+
+; <label>:7                                       ; preds = %1
+  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  store %"System.Byte[]" addrspace(1)* %8, %"System.Byte[]" addrspace(1)** %loc2
+  %9 = icmp eq %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %9, label %18, label %10
+
+; <label>:10                                      ; preds = %7
+  %11 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc2
+  %NullCheck1 = icmp eq %"System.Byte[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %11, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp ne i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %7, %12
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc1
+  br label %27
+
+; <label>:19                                      ; preds = %12
+  %20 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc2
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %20, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %BoundsCheck = icmp uge i64 0, %24
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %25
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %20, i32 0, i32 3, i32 0
+  store i8 addrspace(1)* %26, i8 addrspace(1)** %loc1
+  br label %27
+
+; <label>:27                                      ; preds = %18, %25
+  %28 = load i64, i64* %arg0
+  %29 = load i8 addrspace(1)*, i8 addrspace(1)** %loc1
+  %30 = ptrtoint i8 addrspace(1)* %29 to i64
+  %31 = load i32, i32* %arg2
+  %32 = sext i32 %31 to i64
+  %33 = add i64 %30, %32
+  %34 = load i32, i32* %arg3
+  %35 = addrspacecast i32* %loc3 to i32 addrspace(1)*
+  %36 = inttoptr i64 %33 to i8*
+  %37 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i8*, i32, i32 addrspace(1)*, i64)*)(i64 %28, i8* %36, i32 %34, i32 addrspace(1)* %35, i64 0)
+  %38 = icmp ugt i32 %37, 0
+  %39 = sext i1 %38 to i32
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc1
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %42, label %41
+
+; <label>:41                                      ; preds = %27
+  ret i32 0
+
+; <label>:42                                      ; preds = %27
+  %43 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  store i32 %43, i32* %loc0
+  %44 = load i32, i32* %loc0
+  %45 = icmp eq i32 %44, 232
+  br i1 %45, label %49, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = load i32, i32* %loc0
+  %48 = icmp ne i32 %47, 109
+  br i1 %48, label %50, label %49
+
+; <label>:49                                      ; preds = %42, %46
+  ret i32 0
+
+; <label>:50                                      ; preds = %46
+  %51 = load i32, i32* %loc0
+  ret i32 %51
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
 Successfully read WindowsConsoleStream.Flush
 
@@ -13757,8 +16159,8 @@ entry:
   %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
   store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
@@ -13793,8 +16195,8 @@ entry:
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
   %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load i64, i64 addrspace(1)* %1

--- a/test/BaseLine/JIT/CodeGenBringUpTests/CnsBool.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/CnsBool.error.txt
@@ -25,8 +25,8 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
@@ -40,8 +40,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
   %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
@@ -75,7 +75,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -90,8 +90,8 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %NullCheck = icmp ne i8 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = load i8, i8 addrspace(1)* %0, align 8
@@ -125,8 +125,8 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
@@ -159,8 +159,8 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -184,8 +184,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
   store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
@@ -195,8 +195,8 @@ entry:
 ; <label>:4                                       ; preds = %1
   %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
   %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
@@ -206,8 +206,8 @@ entry:
   %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
@@ -221,14 +221,14 @@ entry:
 
 ; <label>:17                                      ; preds = %14
   %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
   %21 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
@@ -238,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -249,8 +249,8 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
@@ -261,27 +261,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %30
+ThrowNullRef10:                                   ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -301,7 +301,89 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
-Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
+Successfully read AppDomainSetup.GetUnsecureApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.GetUnsecureApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %NullCheck = icmp eq %"System.String[]" addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %BoundsCheck = icmp uge i64 0, %5
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %6
+
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 3, i32 0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
+  ret %System.String addrspace(1)* %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_Value using LLILCJit
+Successfully read AppDomainSetup.get_Value
+
+define %"System.String[]" addrspace(1)* @AppDomainSetup.get_Value(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.String[]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 18)
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.String[]" addrspace(1)* addrspace(1)*, %"System.String[]" addrspace(1)*)*)(%"System.String[]" addrspace(1)* addrspace(1)* %9, %"System.String[]" addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %11, i32 0, i32 1
+  %14 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %13, align 8
+  ret %"System.String[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -319,8 +401,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -368,16 +450,16 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
   %5 = load i32, i32 addrspace(1)* %4
   %6 = sub i32 %5, 1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -389,7 +471,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -421,8 +503,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
@@ -456,8 +538,8 @@ entry:
 ; <label>:27                                      ; preds = %19
   %28 = load i32, i32* %arg1
   %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
-  br i1 %NullCheck2, label %30, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %29, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %30
 
 ; <label>:30                                      ; preds = %27
   %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
@@ -493,8 +575,8 @@ entry:
 ; <label>:49                                      ; preds = %46
   %50 = load i32, i32* %arg2
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck4, label %52, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
@@ -517,11 +599,11 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %27
+ThrowNullRef2:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %49
+ThrowNullRef4:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -544,16 +626,16 @@ entry:
   %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %0)
   store %System.String addrspace(1)* %1, %System.String addrspace(1)** %loc0
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 2
   %5 = bitcast [0 x i16] addrspace(1)* %4 to i16 addrspace(1)*
   store i16 addrspace(1)* %5, i16 addrspace(1)** %loc1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %3
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2
@@ -580,7 +662,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -691,15 +773,15 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %NullCheck132 = icmp ne i8* %21, null
-  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+  %NullCheck131 = icmp eq i8* %21, null
+  br i1 %NullCheck131, label %ThrowNullRef132, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = load i8, i8* %21, align 8
   %24 = zext i8 %23 to i32
   %25 = trunc i32 %24 to i8
-  %NullCheck134 = icmp ne i8* %20, null
-  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+  %NullCheck133 = icmp eq i8* %20, null
+  br i1 %NullCheck133, label %ThrowNullRef134, label %26
 
 ; <label>:26                                      ; preds = %22
   store i8 %25, i8* %20, align 8
@@ -709,16 +791,16 @@ entry:
   %28 = load i8*, i8** %arg0
   %29 = load i8*, i8** %arg1
   %30 = bitcast i8* %29 to i16*
-  %NullCheck128 = icmp ne i16* %30, null
-  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+  %NullCheck127 = icmp eq i16* %30, null
+  br i1 %NullCheck127, label %ThrowNullRef128, label %31
 
 ; <label>:31                                      ; preds = %27
   %32 = load i16, i16* %30, align 8
   %33 = sext i16 %32 to i32
   %34 = bitcast i8* %28 to i16*
   %35 = trunc i32 %33 to i16
-  %NullCheck130 = icmp ne i16* %34, null
-  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+  %NullCheck129 = icmp eq i16* %34, null
+  br i1 %NullCheck129, label %ThrowNullRef130, label %36
 
 ; <label>:36                                      ; preds = %31
   store i16 %35, i16* %34, align 8
@@ -728,16 +810,16 @@ entry:
   %38 = load i8*, i8** %arg0
   %39 = load i8*, i8** %arg1
   %40 = bitcast i8* %39 to i16*
-  %NullCheck120 = icmp ne i16* %40, null
-  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+  %NullCheck119 = icmp eq i16* %40, null
+  br i1 %NullCheck119, label %ThrowNullRef120, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i16, i16* %40, align 8
   %43 = sext i16 %42 to i32
   %44 = bitcast i8* %38 to i16*
   %45 = trunc i32 %43 to i16
-  %NullCheck122 = icmp ne i16* %44, null
-  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+  %NullCheck121 = icmp eq i16* %44, null
+  br i1 %NullCheck121, label %ThrowNullRef122, label %46
 
 ; <label>:46                                      ; preds = %41
   store i16 %45, i16* %44, align 8
@@ -745,15 +827,15 @@ entry:
   %48 = getelementptr inbounds i8, i8* %47, i64 2
   %49 = load i8*, i8** %arg1
   %50 = getelementptr inbounds i8, i8* %49, i64 2
-  %NullCheck124 = icmp ne i8* %50, null
-  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+  %NullCheck123 = icmp eq i8* %50, null
+  br i1 %NullCheck123, label %ThrowNullRef124, label %51
 
 ; <label>:51                                      ; preds = %46
   %52 = load i8, i8* %50, align 8
   %53 = zext i8 %52 to i32
   %54 = trunc i32 %53 to i8
-  %NullCheck126 = icmp ne i8* %48, null
-  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+  %NullCheck125 = icmp eq i8* %48, null
+  br i1 %NullCheck125, label %ThrowNullRef126, label %55
 
 ; <label>:55                                      ; preds = %51
   store i8 %54, i8* %48, align 8
@@ -763,14 +845,14 @@ entry:
   %57 = load i8*, i8** %arg0
   %58 = load i8*, i8** %arg1
   %59 = bitcast i8* %58 to i32*
-  %NullCheck116 = icmp ne i32* %59, null
-  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+  %NullCheck115 = icmp eq i32* %59, null
+  br i1 %NullCheck115, label %ThrowNullRef116, label %60
 
 ; <label>:60                                      ; preds = %56
   %61 = load i32, i32* %59, align 8
   %62 = bitcast i8* %57 to i32*
-  %NullCheck118 = icmp ne i32* %62, null
-  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+  %NullCheck117 = icmp eq i32* %62, null
+  br i1 %NullCheck117, label %ThrowNullRef118, label %63
 
 ; <label>:63                                      ; preds = %60
   store i32 %61, i32* %62, align 8
@@ -780,14 +862,14 @@ entry:
   %65 = load i8*, i8** %arg0
   %66 = load i8*, i8** %arg1
   %67 = bitcast i8* %66 to i32*
-  %NullCheck108 = icmp ne i32* %67, null
-  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+  %NullCheck107 = icmp eq i32* %67, null
+  br i1 %NullCheck107, label %ThrowNullRef108, label %68
 
 ; <label>:68                                      ; preds = %64
   %69 = load i32, i32* %67, align 8
   %70 = bitcast i8* %65 to i32*
-  %NullCheck110 = icmp ne i32* %70, null
-  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+  %NullCheck109 = icmp eq i32* %70, null
+  br i1 %NullCheck109, label %ThrowNullRef110, label %71
 
 ; <label>:71                                      ; preds = %68
   store i32 %69, i32* %70, align 8
@@ -795,15 +877,15 @@ entry:
   %73 = getelementptr inbounds i8, i8* %72, i64 4
   %74 = load i8*, i8** %arg1
   %75 = getelementptr inbounds i8, i8* %74, i64 4
-  %NullCheck112 = icmp ne i8* %75, null
-  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+  %NullCheck111 = icmp eq i8* %75, null
+  br i1 %NullCheck111, label %ThrowNullRef112, label %76
 
 ; <label>:76                                      ; preds = %71
   %77 = load i8, i8* %75, align 8
   %78 = zext i8 %77 to i32
   %79 = trunc i32 %78 to i8
-  %NullCheck114 = icmp ne i8* %73, null
-  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+  %NullCheck113 = icmp eq i8* %73, null
+  br i1 %NullCheck113, label %ThrowNullRef114, label %80
 
 ; <label>:80                                      ; preds = %76
   store i8 %79, i8* %73, align 8
@@ -813,14 +895,14 @@ entry:
   %82 = load i8*, i8** %arg0
   %83 = load i8*, i8** %arg1
   %84 = bitcast i8* %83 to i32*
-  %NullCheck100 = icmp ne i32* %84, null
-  br i1 %NullCheck100, label %85, label %ThrowNullRef99
+  %NullCheck99 = icmp eq i32* %84, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %85
 
 ; <label>:85                                      ; preds = %81
   %86 = load i32, i32* %84, align 8
   %87 = bitcast i8* %82 to i32*
-  %NullCheck102 = icmp ne i32* %87, null
-  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+  %NullCheck101 = icmp eq i32* %87, null
+  br i1 %NullCheck101, label %ThrowNullRef102, label %88
 
 ; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
@@ -829,16 +911,16 @@ entry:
   %91 = load i8*, i8** %arg1
   %92 = getelementptr inbounds i8, i8* %91, i64 4
   %93 = bitcast i8* %92 to i16*
-  %NullCheck104 = icmp ne i16* %93, null
-  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+  %NullCheck103 = icmp eq i16* %93, null
+  br i1 %NullCheck103, label %ThrowNullRef104, label %94
 
 ; <label>:94                                      ; preds = %88
   %95 = load i16, i16* %93, align 8
   %96 = sext i16 %95 to i32
   %97 = bitcast i8* %90 to i16*
   %98 = trunc i32 %96 to i16
-  %NullCheck106 = icmp ne i16* %97, null
-  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+  %NullCheck105 = icmp eq i16* %97, null
+  br i1 %NullCheck105, label %ThrowNullRef106, label %99
 
 ; <label>:99                                      ; preds = %94
   store i16 %98, i16* %97, align 8
@@ -848,14 +930,14 @@ entry:
   %101 = load i8*, i8** %arg0
   %102 = load i8*, i8** %arg1
   %103 = bitcast i8* %102 to i32*
-  %NullCheck88 = icmp ne i32* %103, null
-  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+  %NullCheck87 = icmp eq i32* %103, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %104
 
 ; <label>:104                                     ; preds = %100
   %105 = load i32, i32* %103, align 8
   %106 = bitcast i8* %101 to i32*
-  %NullCheck90 = icmp ne i32* %106, null
-  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+  %NullCheck89 = icmp eq i32* %106, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %107
 
 ; <label>:107                                     ; preds = %104
   store i32 %105, i32* %106, align 8
@@ -864,16 +946,16 @@ entry:
   %110 = load i8*, i8** %arg1
   %111 = getelementptr inbounds i8, i8* %110, i64 4
   %112 = bitcast i8* %111 to i16*
-  %NullCheck92 = icmp ne i16* %112, null
-  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+  %NullCheck91 = icmp eq i16* %112, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %113
 
 ; <label>:113                                     ; preds = %107
   %114 = load i16, i16* %112, align 8
   %115 = sext i16 %114 to i32
   %116 = bitcast i8* %109 to i16*
   %117 = trunc i32 %115 to i16
-  %NullCheck94 = icmp ne i16* %116, null
-  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+  %NullCheck93 = icmp eq i16* %116, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %118
 
 ; <label>:118                                     ; preds = %113
   store i16 %117, i16* %116, align 8
@@ -881,15 +963,15 @@ entry:
   %120 = getelementptr inbounds i8, i8* %119, i64 6
   %121 = load i8*, i8** %arg1
   %122 = getelementptr inbounds i8, i8* %121, i64 6
-  %NullCheck96 = icmp ne i8* %122, null
-  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+  %NullCheck95 = icmp eq i8* %122, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %123
 
 ; <label>:123                                     ; preds = %118
   %124 = load i8, i8* %122, align 8
   %125 = zext i8 %124 to i32
   %126 = trunc i32 %125 to i8
-  %NullCheck98 = icmp ne i8* %120, null
-  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+  %NullCheck97 = icmp eq i8* %120, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %127
 
 ; <label>:127                                     ; preds = %123
   store i8 %126, i8* %120, align 8
@@ -899,14 +981,14 @@ entry:
   %129 = load i8*, i8** %arg0
   %130 = load i8*, i8** %arg1
   %131 = bitcast i8* %130 to i64*
-  %NullCheck84 = icmp ne i64* %131, null
-  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+  %NullCheck83 = icmp eq i64* %131, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %132
 
 ; <label>:132                                     ; preds = %128
   %133 = load i64, i64* %131, align 8
   %134 = bitcast i8* %129 to i64*
-  %NullCheck86 = icmp ne i64* %134, null
-  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+  %NullCheck85 = icmp eq i64* %134, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %135
 
 ; <label>:135                                     ; preds = %132
   store i64 %133, i64* %134, align 8
@@ -916,14 +998,14 @@ entry:
   %137 = load i8*, i8** %arg0
   %138 = load i8*, i8** %arg1
   %139 = bitcast i8* %138 to i64*
-  %NullCheck76 = icmp ne i64* %139, null
-  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+  %NullCheck75 = icmp eq i64* %139, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %140
 
 ; <label>:140                                     ; preds = %136
   %141 = load i64, i64* %139, align 8
   %142 = bitcast i8* %137 to i64*
-  %NullCheck78 = icmp ne i64* %142, null
-  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+  %NullCheck77 = icmp eq i64* %142, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %143
 
 ; <label>:143                                     ; preds = %140
   store i64 %141, i64* %142, align 8
@@ -931,15 +1013,15 @@ entry:
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %NullCheck80 = icmp ne i8* %147, null
-  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+  %NullCheck79 = icmp eq i8* %147, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %148
 
 ; <label>:148                                     ; preds = %143
   %149 = load i8, i8* %147, align 8
   %150 = zext i8 %149 to i32
   %151 = trunc i32 %150 to i8
-  %NullCheck82 = icmp ne i8* %145, null
-  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+  %NullCheck81 = icmp eq i8* %145, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %152
 
 ; <label>:152                                     ; preds = %148
   store i8 %151, i8* %145, align 8
@@ -949,14 +1031,14 @@ entry:
   %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
   %156 = bitcast i8* %155 to i64*
-  %NullCheck68 = icmp ne i64* %156, null
-  br i1 %NullCheck68, label %157, label %ThrowNullRef67
+  %NullCheck67 = icmp eq i64* %156, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %157
 
 ; <label>:157                                     ; preds = %153
   %158 = load i64, i64* %156, align 8
   %159 = bitcast i8* %154 to i64*
-  %NullCheck70 = icmp ne i64* %159, null
-  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+  %NullCheck69 = icmp eq i64* %159, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %160
 
 ; <label>:160                                     ; preds = %157
   store i64 %158, i64* %159, align 8
@@ -965,16 +1047,16 @@ entry:
   %163 = load i8*, i8** %arg1
   %164 = getelementptr inbounds i8, i8* %163, i64 8
   %165 = bitcast i8* %164 to i16*
-  %NullCheck72 = icmp ne i16* %165, null
-  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+  %NullCheck71 = icmp eq i16* %165, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %166
 
 ; <label>:166                                     ; preds = %160
   %167 = load i16, i16* %165, align 8
   %168 = sext i16 %167 to i32
   %169 = bitcast i8* %162 to i16*
   %170 = trunc i32 %168 to i16
-  %NullCheck74 = icmp ne i16* %169, null
-  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+  %NullCheck73 = icmp eq i16* %169, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %171
 
 ; <label>:171                                     ; preds = %166
   store i16 %170, i16* %169, align 8
@@ -984,14 +1066,14 @@ entry:
   %173 = load i8*, i8** %arg0
   %174 = load i8*, i8** %arg1
   %175 = bitcast i8* %174 to i64*
-  %NullCheck56 = icmp ne i64* %175, null
-  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+  %NullCheck55 = icmp eq i64* %175, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %176
 
 ; <label>:176                                     ; preds = %172
   %177 = load i64, i64* %175, align 8
   %178 = bitcast i8* %173 to i64*
-  %NullCheck58 = icmp ne i64* %178, null
-  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+  %NullCheck57 = icmp eq i64* %178, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %179
 
 ; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
@@ -1000,16 +1082,16 @@ entry:
   %182 = load i8*, i8** %arg1
   %183 = getelementptr inbounds i8, i8* %182, i64 8
   %184 = bitcast i8* %183 to i16*
-  %NullCheck60 = icmp ne i16* %184, null
-  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+  %NullCheck59 = icmp eq i16* %184, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %185
 
 ; <label>:185                                     ; preds = %179
   %186 = load i16, i16* %184, align 8
   %187 = sext i16 %186 to i32
   %188 = bitcast i8* %181 to i16*
   %189 = trunc i32 %187 to i16
-  %NullCheck62 = icmp ne i16* %188, null
-  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+  %NullCheck61 = icmp eq i16* %188, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %190
 
 ; <label>:190                                     ; preds = %185
   store i16 %189, i16* %188, align 8
@@ -1017,15 +1099,15 @@ entry:
   %192 = getelementptr inbounds i8, i8* %191, i64 10
   %193 = load i8*, i8** %arg1
   %194 = getelementptr inbounds i8, i8* %193, i64 10
-  %NullCheck64 = icmp ne i8* %194, null
-  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+  %NullCheck63 = icmp eq i8* %194, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %195
 
 ; <label>:195                                     ; preds = %190
   %196 = load i8, i8* %194, align 8
   %197 = zext i8 %196 to i32
   %198 = trunc i32 %197 to i8
-  %NullCheck66 = icmp ne i8* %192, null
-  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+  %NullCheck65 = icmp eq i8* %192, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %199
 
 ; <label>:199                                     ; preds = %195
   store i8 %198, i8* %192, align 8
@@ -1035,14 +1117,14 @@ entry:
   %201 = load i8*, i8** %arg0
   %202 = load i8*, i8** %arg1
   %203 = bitcast i8* %202 to i64*
-  %NullCheck48 = icmp ne i64* %203, null
-  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+  %NullCheck47 = icmp eq i64* %203, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %204
 
 ; <label>:204                                     ; preds = %200
   %205 = load i64, i64* %203, align 8
   %206 = bitcast i8* %201 to i64*
-  %NullCheck50 = icmp ne i64* %206, null
-  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+  %NullCheck49 = icmp eq i64* %206, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %207
 
 ; <label>:207                                     ; preds = %204
   store i64 %205, i64* %206, align 8
@@ -1051,14 +1133,14 @@ entry:
   %210 = load i8*, i8** %arg1
   %211 = getelementptr inbounds i8, i8* %210, i64 8
   %212 = bitcast i8* %211 to i32*
-  %NullCheck52 = icmp ne i32* %212, null
-  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+  %NullCheck51 = icmp eq i32* %212, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %213
 
 ; <label>:213                                     ; preds = %207
   %214 = load i32, i32* %212, align 8
   %215 = bitcast i8* %209 to i32*
-  %NullCheck54 = icmp ne i32* %215, null
-  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+  %NullCheck53 = icmp eq i32* %215, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %216
 
 ; <label>:216                                     ; preds = %213
   store i32 %214, i32* %215, align 8
@@ -1068,14 +1150,14 @@ entry:
   %218 = load i8*, i8** %arg0
   %219 = load i8*, i8** %arg1
   %220 = bitcast i8* %219 to i64*
-  %NullCheck36 = icmp ne i64* %220, null
-  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64* %220, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %221
 
 ; <label>:221                                     ; preds = %217
   %222 = load i64, i64* %220, align 8
   %223 = bitcast i8* %218 to i64*
-  %NullCheck38 = icmp ne i64* %223, null
-  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+  %NullCheck37 = icmp eq i64* %223, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %224
 
 ; <label>:224                                     ; preds = %221
   store i64 %222, i64* %223, align 8
@@ -1084,14 +1166,14 @@ entry:
   %227 = load i8*, i8** %arg1
   %228 = getelementptr inbounds i8, i8* %227, i64 8
   %229 = bitcast i8* %228 to i32*
-  %NullCheck40 = icmp ne i32* %229, null
-  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i32* %229, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %230
 
 ; <label>:230                                     ; preds = %224
   %231 = load i32, i32* %229, align 8
   %232 = bitcast i8* %226 to i32*
-  %NullCheck42 = icmp ne i32* %232, null
-  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+  %NullCheck41 = icmp eq i32* %232, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %233
 
 ; <label>:233                                     ; preds = %230
   store i32 %231, i32* %232, align 8
@@ -1099,15 +1181,15 @@ entry:
   %235 = getelementptr inbounds i8, i8* %234, i64 12
   %236 = load i8*, i8** %arg1
   %237 = getelementptr inbounds i8, i8* %236, i64 12
-  %NullCheck44 = icmp ne i8* %237, null
-  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i8* %237, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %238
 
 ; <label>:238                                     ; preds = %233
   %239 = load i8, i8* %237, align 8
   %240 = zext i8 %239 to i32
   %241 = trunc i32 %240 to i8
-  %NullCheck46 = icmp ne i8* %235, null
-  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+  %NullCheck45 = icmp eq i8* %235, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %242
 
 ; <label>:242                                     ; preds = %238
   store i8 %241, i8* %235, align 8
@@ -1117,14 +1199,14 @@ entry:
   %244 = load i8*, i8** %arg0
   %245 = load i8*, i8** %arg1
   %246 = bitcast i8* %245 to i64*
-  %NullCheck24 = icmp ne i64* %246, null
-  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64* %246, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %247
 
 ; <label>:247                                     ; preds = %243
   %248 = load i64, i64* %246, align 8
   %249 = bitcast i8* %244 to i64*
-  %NullCheck26 = icmp ne i64* %249, null
-  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64* %249, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %250
 
 ; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
@@ -1133,14 +1215,14 @@ entry:
   %253 = load i8*, i8** %arg1
   %254 = getelementptr inbounds i8, i8* %253, i64 8
   %255 = bitcast i8* %254 to i32*
-  %NullCheck28 = icmp ne i32* %255, null
-  br i1 %NullCheck28, label %256, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i32* %255, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %256
 
 ; <label>:256                                     ; preds = %250
   %257 = load i32, i32* %255, align 8
   %258 = bitcast i8* %252 to i32*
-  %NullCheck30 = icmp ne i32* %258, null
-  br i1 %NullCheck30, label %259, label %ThrowNullRef29
+  %NullCheck29 = icmp eq i32* %258, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %259
 
 ; <label>:259                                     ; preds = %256
   store i32 %257, i32* %258, align 8
@@ -1149,16 +1231,16 @@ entry:
   %262 = load i8*, i8** %arg1
   %263 = getelementptr inbounds i8, i8* %262, i64 12
   %264 = bitcast i8* %263 to i16*
-  %NullCheck32 = icmp ne i16* %264, null
-  br i1 %NullCheck32, label %265, label %ThrowNullRef31
+  %NullCheck31 = icmp eq i16* %264, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %265
 
 ; <label>:265                                     ; preds = %259
   %266 = load i16, i16* %264, align 8
   %267 = sext i16 %266 to i32
   %268 = bitcast i8* %261 to i16*
   %269 = trunc i32 %267 to i16
-  %NullCheck34 = icmp ne i16* %268, null
-  br i1 %NullCheck34, label %270, label %ThrowNullRef33
+  %NullCheck33 = icmp eq i16* %268, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %270
 
 ; <label>:270                                     ; preds = %265
   store i16 %269, i16* %268, align 8
@@ -1168,14 +1250,14 @@ entry:
   %272 = load i8*, i8** %arg0
   %273 = load i8*, i8** %arg1
   %274 = bitcast i8* %273 to i64*
-  %NullCheck8 = icmp ne i64* %274, null
-  br i1 %NullCheck8, label %275, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64* %274, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %275
 
 ; <label>:275                                     ; preds = %271
   %276 = load i64, i64* %274, align 8
   %277 = bitcast i8* %272 to i64*
-  %NullCheck10 = icmp ne i64* %277, null
-  br i1 %NullCheck10, label %278, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %277, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %278
 
 ; <label>:278                                     ; preds = %275
   store i64 %276, i64* %277, align 8
@@ -1184,14 +1266,14 @@ entry:
   %281 = load i8*, i8** %arg1
   %282 = getelementptr inbounds i8, i8* %281, i64 8
   %283 = bitcast i8* %282 to i32*
-  %NullCheck12 = icmp ne i32* %283, null
-  br i1 %NullCheck12, label %284, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i32* %283, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %284
 
 ; <label>:284                                     ; preds = %278
   %285 = load i32, i32* %283, align 8
   %286 = bitcast i8* %280 to i32*
-  %NullCheck14 = icmp ne i32* %286, null
-  br i1 %NullCheck14, label %287, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i32* %286, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %287
 
 ; <label>:287                                     ; preds = %284
   store i32 %285, i32* %286, align 8
@@ -1200,16 +1282,16 @@ entry:
   %290 = load i8*, i8** %arg1
   %291 = getelementptr inbounds i8, i8* %290, i64 12
   %292 = bitcast i8* %291 to i16*
-  %NullCheck16 = icmp ne i16* %292, null
-  br i1 %NullCheck16, label %293, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i16* %292, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %293
 
 ; <label>:293                                     ; preds = %287
   %294 = load i16, i16* %292, align 8
   %295 = sext i16 %294 to i32
   %296 = bitcast i8* %289 to i16*
   %297 = trunc i32 %295 to i16
-  %NullCheck18 = icmp ne i16* %296, null
-  br i1 %NullCheck18, label %298, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i16* %296, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %298
 
 ; <label>:298                                     ; preds = %293
   store i16 %297, i16* %296, align 8
@@ -1217,15 +1299,15 @@ entry:
   %300 = getelementptr inbounds i8, i8* %299, i64 14
   %301 = load i8*, i8** %arg1
   %302 = getelementptr inbounds i8, i8* %301, i64 14
-  %NullCheck20 = icmp ne i8* %302, null
-  br i1 %NullCheck20, label %303, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i8* %302, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %303
 
 ; <label>:303                                     ; preds = %298
   %304 = load i8, i8* %302, align 8
   %305 = zext i8 %304 to i32
   %306 = trunc i32 %305 to i8
-  %NullCheck22 = icmp ne i8* %300, null
-  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i8* %300, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %307
 
 ; <label>:307                                     ; preds = %303
   store i8 %306, i8* %300, align 8
@@ -1235,14 +1317,14 @@ entry:
   %309 = load i8*, i8** %arg0
   %310 = load i8*, i8** %arg1
   %311 = bitcast i8* %310 to i64*
-  %NullCheck = icmp ne i64* %311, null
-  br i1 %NullCheck, label %312, label %ThrowNullRef
+  %NullCheck = icmp eq i64* %311, null
+  br i1 %NullCheck, label %ThrowNullRef, label %312
 
 ; <label>:312                                     ; preds = %308
   %313 = load i64, i64* %311, align 8
   %314 = bitcast i8* %309 to i64*
-  %NullCheck2 = icmp ne i64* %314, null
-  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64* %314, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %315
 
 ; <label>:315                                     ; preds = %312
   store i64 %313, i64* %314, align 8
@@ -1251,14 +1333,14 @@ entry:
   %318 = load i8*, i8** %arg1
   %319 = getelementptr inbounds i8, i8* %318, i64 8
   %320 = bitcast i8* %319 to i64*
-  %NullCheck4 = icmp ne i64* %320, null
-  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64* %320, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %321
 
 ; <label>:321                                     ; preds = %315
   %322 = load i64, i64* %320, align 8
   %323 = bitcast i8* %317 to i64*
-  %NullCheck6 = icmp ne i64* %323, null
-  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64* %323, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %324
 
 ; <label>:324                                     ; preds = %321
   store i64 %322, i64* %323, align 8
@@ -1286,15 +1368,15 @@ entry:
 ; <label>:338                                     ; preds = %333
   %339 = load i8*, i8** %arg0
   %340 = load i8*, i8** %arg1
-  %NullCheck136 = icmp ne i8* %340, null
-  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+  %NullCheck135 = icmp eq i8* %340, null
+  br i1 %NullCheck135, label %ThrowNullRef136, label %341
 
 ; <label>:341                                     ; preds = %338
   %342 = load i8, i8* %340, align 8
   %343 = zext i8 %342 to i32
   %344 = trunc i32 %343 to i8
-  %NullCheck138 = icmp ne i8* %339, null
-  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+  %NullCheck137 = icmp eq i8* %339, null
+  br i1 %NullCheck137, label %ThrowNullRef138, label %345
 
 ; <label>:345                                     ; preds = %341
   store i8 %344, i8* %339, align 8
@@ -1317,16 +1399,16 @@ entry:
   %357 = load i8*, i8** %arg0
   %358 = load i8*, i8** %arg1
   %359 = bitcast i8* %358 to i16*
-  %NullCheck140 = icmp ne i16* %359, null
-  br i1 %NullCheck140, label %360, label %ThrowNullRef139
+  %NullCheck139 = icmp eq i16* %359, null
+  br i1 %NullCheck139, label %ThrowNullRef140, label %360
 
 ; <label>:360                                     ; preds = %356
   %361 = load i16, i16* %359, align 8
   %362 = sext i16 %361 to i32
   %363 = bitcast i8* %357 to i16*
   %364 = trunc i32 %362 to i16
-  %NullCheck142 = icmp ne i16* %363, null
-  br i1 %NullCheck142, label %365, label %ThrowNullRef141
+  %NullCheck141 = icmp eq i16* %363, null
+  br i1 %NullCheck141, label %ThrowNullRef142, label %365
 
 ; <label>:365                                     ; preds = %360
   store i16 %364, i16* %363, align 8
@@ -1352,14 +1434,14 @@ entry:
   %378 = load i8*, i8** %arg0
   %379 = load i8*, i8** %arg1
   %380 = bitcast i8* %379 to i32*
-  %NullCheck144 = icmp ne i32* %380, null
-  br i1 %NullCheck144, label %381, label %ThrowNullRef143
+  %NullCheck143 = icmp eq i32* %380, null
+  br i1 %NullCheck143, label %ThrowNullRef144, label %381
 
 ; <label>:381                                     ; preds = %377
   %382 = load i32, i32* %380, align 8
   %383 = bitcast i8* %378 to i32*
-  %NullCheck146 = icmp ne i32* %383, null
-  br i1 %NullCheck146, label %384, label %ThrowNullRef145
+  %NullCheck145 = icmp eq i32* %383, null
+  br i1 %NullCheck145, label %ThrowNullRef146, label %384
 
 ; <label>:384                                     ; preds = %381
   store i32 %382, i32* %383, align 8
@@ -1384,14 +1466,14 @@ entry:
   %395 = load i8*, i8** %arg0
   %396 = load i8*, i8** %arg1
   %397 = bitcast i8* %396 to i64*
-  %NullCheck164 = icmp ne i64* %397, null
-  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+  %NullCheck163 = icmp eq i64* %397, null
+  br i1 %NullCheck163, label %ThrowNullRef164, label %398
 
 ; <label>:398                                     ; preds = %394
   %399 = load i64, i64* %397, align 8
   %400 = bitcast i8* %395 to i64*
-  %NullCheck166 = icmp ne i64* %400, null
-  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+  %NullCheck165 = icmp eq i64* %400, null
+  br i1 %NullCheck165, label %ThrowNullRef166, label %401
 
 ; <label>:401                                     ; preds = %398
   store i64 %399, i64* %400, align 8
@@ -1400,14 +1482,14 @@ entry:
   %404 = load i8*, i8** %arg1
   %405 = getelementptr inbounds i8, i8* %404, i64 8
   %406 = bitcast i8* %405 to i64*
-  %NullCheck168 = icmp ne i64* %406, null
-  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+  %NullCheck167 = icmp eq i64* %406, null
+  br i1 %NullCheck167, label %ThrowNullRef168, label %407
 
 ; <label>:407                                     ; preds = %401
   %408 = load i64, i64* %406, align 8
   %409 = bitcast i8* %403 to i64*
-  %NullCheck170 = icmp ne i64* %409, null
-  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+  %NullCheck169 = icmp eq i64* %409, null
+  br i1 %NullCheck169, label %ThrowNullRef170, label %410
 
 ; <label>:410                                     ; preds = %407
   store i64 %408, i64* %409, align 8
@@ -1437,14 +1519,14 @@ entry:
   %425 = load i8*, i8** %arg0
   %426 = load i8*, i8** %arg1
   %427 = bitcast i8* %426 to i64*
-  %NullCheck148 = icmp ne i64* %427, null
-  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+  %NullCheck147 = icmp eq i64* %427, null
+  br i1 %NullCheck147, label %ThrowNullRef148, label %428
 
 ; <label>:428                                     ; preds = %424
   %429 = load i64, i64* %427, align 8
   %430 = bitcast i8* %425 to i64*
-  %NullCheck150 = icmp ne i64* %430, null
-  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+  %NullCheck149 = icmp eq i64* %430, null
+  br i1 %NullCheck149, label %ThrowNullRef150, label %431
 
 ; <label>:431                                     ; preds = %428
   store i64 %429, i64* %430, align 8
@@ -1466,14 +1548,14 @@ entry:
   %441 = load i8*, i8** %arg0
   %442 = load i8*, i8** %arg1
   %443 = bitcast i8* %442 to i32*
-  %NullCheck152 = icmp ne i32* %443, null
-  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+  %NullCheck151 = icmp eq i32* %443, null
+  br i1 %NullCheck151, label %ThrowNullRef152, label %444
 
 ; <label>:444                                     ; preds = %440
   %445 = load i32, i32* %443, align 8
   %446 = bitcast i8* %441 to i32*
-  %NullCheck154 = icmp ne i32* %446, null
-  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+  %NullCheck153 = icmp eq i32* %446, null
+  br i1 %NullCheck153, label %ThrowNullRef154, label %447
 
 ; <label>:447                                     ; preds = %444
   store i32 %445, i32* %446, align 8
@@ -1495,16 +1577,16 @@ entry:
   %457 = load i8*, i8** %arg0
   %458 = load i8*, i8** %arg1
   %459 = bitcast i8* %458 to i16*
-  %NullCheck156 = icmp ne i16* %459, null
-  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+  %NullCheck155 = icmp eq i16* %459, null
+  br i1 %NullCheck155, label %ThrowNullRef156, label %460
 
 ; <label>:460                                     ; preds = %456
   %461 = load i16, i16* %459, align 8
   %462 = sext i16 %461 to i32
   %463 = bitcast i8* %457 to i16*
   %464 = trunc i32 %462 to i16
-  %NullCheck158 = icmp ne i16* %463, null
-  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+  %NullCheck157 = icmp eq i16* %463, null
+  br i1 %NullCheck157, label %ThrowNullRef158, label %465
 
 ; <label>:465                                     ; preds = %460
   store i16 %464, i16* %463, align 8
@@ -1525,15 +1607,15 @@ entry:
 ; <label>:474                                     ; preds = %470
   %475 = load i8*, i8** %arg0
   %476 = load i8*, i8** %arg1
-  %NullCheck160 = icmp ne i8* %476, null
-  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+  %NullCheck159 = icmp eq i8* %476, null
+  br i1 %NullCheck159, label %ThrowNullRef160, label %477
 
 ; <label>:477                                     ; preds = %474
   %478 = load i8, i8* %476, align 8
   %479 = zext i8 %478 to i32
   %480 = trunc i32 %479 to i8
-  %NullCheck162 = icmp ne i8* %475, null
-  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+  %NullCheck161 = icmp eq i8* %475, null
+  br i1 %NullCheck161, label %ThrowNullRef162, label %481
 
 ; <label>:481                                     ; preds = %477
   store i8 %480, i8* %475, align 8
@@ -1553,343 +1635,343 @@ ThrowNullRef:                                     ; preds = %308
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %312
+ThrowNullRef2:                                    ; preds = %312
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %315
+ThrowNullRef4:                                    ; preds = %315
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %321
+ThrowNullRef6:                                    ; preds = %321
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %271
+ThrowNullRef8:                                    ; preds = %271
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %275
+ThrowNullRef10:                                   ; preds = %275
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %278
+ThrowNullRef12:                                   ; preds = %278
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %284
+ThrowNullRef14:                                   ; preds = %284
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %287
+ThrowNullRef16:                                   ; preds = %287
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %293
+ThrowNullRef18:                                   ; preds = %293
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %298
+ThrowNullRef20:                                   ; preds = %298
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %303
+ThrowNullRef22:                                   ; preds = %303
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %243
+ThrowNullRef24:                                   ; preds = %243
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %247
+ThrowNullRef26:                                   ; preds = %247
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %250
+ThrowNullRef28:                                   ; preds = %250
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %256
+ThrowNullRef30:                                   ; preds = %256
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %259
+ThrowNullRef32:                                   ; preds = %259
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %265
+ThrowNullRef34:                                   ; preds = %265
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %217
+ThrowNullRef36:                                   ; preds = %217
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %221
+ThrowNullRef38:                                   ; preds = %221
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %224
+ThrowNullRef40:                                   ; preds = %224
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %230
+ThrowNullRef42:                                   ; preds = %230
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %233
+ThrowNullRef44:                                   ; preds = %233
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %238
+ThrowNullRef46:                                   ; preds = %238
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %200
+ThrowNullRef48:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %204
+ThrowNullRef50:                                   ; preds = %204
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %207
+ThrowNullRef52:                                   ; preds = %207
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %213
+ThrowNullRef54:                                   ; preds = %213
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %172
+ThrowNullRef56:                                   ; preds = %172
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %176
+ThrowNullRef58:                                   ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %179
+ThrowNullRef60:                                   ; preds = %179
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %185
+ThrowNullRef62:                                   ; preds = %185
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %190
+ThrowNullRef64:                                   ; preds = %190
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %195
+ThrowNullRef66:                                   ; preds = %195
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %153
+ThrowNullRef68:                                   ; preds = %153
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %157
+ThrowNullRef70:                                   ; preds = %157
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %160
+ThrowNullRef72:                                   ; preds = %160
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %166
+ThrowNullRef74:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %136
+ThrowNullRef76:                                   ; preds = %136
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %140
+ThrowNullRef78:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %143
+ThrowNullRef80:                                   ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %148
+ThrowNullRef82:                                   ; preds = %148
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %128
+ThrowNullRef84:                                   ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %132
+ThrowNullRef86:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %100
+ThrowNullRef88:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %104
+ThrowNullRef90:                                   ; preds = %104
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %107
+ThrowNullRef92:                                   ; preds = %107
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %113
+ThrowNullRef94:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %118
+ThrowNullRef96:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %123
+ThrowNullRef98:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %81
+ThrowNullRef100:                                  ; preds = %81
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef101:                                  ; preds = %85
+ThrowNullRef102:                                  ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef103:                                  ; preds = %88
+ThrowNullRef104:                                  ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef105:                                  ; preds = %94
+ThrowNullRef106:                                  ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef107:                                  ; preds = %64
+ThrowNullRef108:                                  ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef109:                                  ; preds = %68
+ThrowNullRef110:                                  ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef111:                                  ; preds = %71
+ThrowNullRef112:                                  ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef113:                                  ; preds = %76
+ThrowNullRef114:                                  ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef115:                                  ; preds = %56
+ThrowNullRef116:                                  ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef117:                                  ; preds = %60
+ThrowNullRef118:                                  ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef119:                                  ; preds = %37
+ThrowNullRef120:                                  ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef121:                                  ; preds = %41
+ThrowNullRef122:                                  ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef123:                                  ; preds = %46
+ThrowNullRef124:                                  ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef125:                                  ; preds = %51
+ThrowNullRef126:                                  ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef127:                                  ; preds = %27
+ThrowNullRef128:                                  ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef129:                                  ; preds = %31
+ThrowNullRef130:                                  ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef131:                                  ; preds = %19
+ThrowNullRef132:                                  ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef133:                                  ; preds = %22
+ThrowNullRef134:                                  ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef135:                                  ; preds = %338
+ThrowNullRef136:                                  ; preds = %338
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef137:                                  ; preds = %341
+ThrowNullRef138:                                  ; preds = %341
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef139:                                  ; preds = %356
+ThrowNullRef140:                                  ; preds = %356
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef141:                                  ; preds = %360
+ThrowNullRef142:                                  ; preds = %360
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef143:                                  ; preds = %377
+ThrowNullRef144:                                  ; preds = %377
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef145:                                  ; preds = %381
+ThrowNullRef146:                                  ; preds = %381
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef147:                                  ; preds = %424
+ThrowNullRef148:                                  ; preds = %424
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef149:                                  ; preds = %428
+ThrowNullRef150:                                  ; preds = %428
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef151:                                  ; preds = %440
+ThrowNullRef152:                                  ; preds = %440
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef153:                                  ; preds = %444
+ThrowNullRef154:                                  ; preds = %444
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef155:                                  ; preds = %456
+ThrowNullRef156:                                  ; preds = %456
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef157:                                  ; preds = %460
+ThrowNullRef158:                                  ; preds = %460
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef159:                                  ; preds = %474
+ThrowNullRef160:                                  ; preds = %474
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef161:                                  ; preds = %477
+ThrowNullRef162:                                  ; preds = %477
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef163:                                  ; preds = %394
+ThrowNullRef164:                                  ; preds = %394
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef165:                                  ; preds = %398
+ThrowNullRef166:                                  ; preds = %398
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef167:                                  ; preds = %401
+ThrowNullRef168:                                  ; preds = %401
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef169:                                  ; preds = %407
+ThrowNullRef170:                                  ; preds = %407
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1939,8 +2021,8 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
-  br i1 %NullCheck, label %22, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %ThrowNullRef, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
@@ -1948,8 +2030,8 @@ entry:
   store i32 %24, i32* %loc0
   %25 = load i32, i32* %loc0
   %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %26, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %27
 
 ; <label>:27                                      ; preds = %22
   %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
@@ -1971,7 +2053,7 @@ ThrowNullRef:                                     ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1989,8 +2071,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -2022,15 +2104,15 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2048,16 +2130,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
   %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
   store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %15
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
@@ -2072,8 +2154,8 @@ entry:
   %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
   %29 = ptrtoint i16 addrspace(1)* %28 to i64
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %19
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
@@ -2089,19 +2171,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2114,8 +2196,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
@@ -2128,7 +2210,7 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[loadElem]
+Failed to read AppDomain.PrepareDataForSetup[storeElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
@@ -2202,8 +2284,8 @@ entry:
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
-  br i1 %NullCheck24, label %27, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = load i64, i64 addrspace(1)* %26
@@ -2218,8 +2300,8 @@ entry:
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
-  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
   %41 = load i64, i64 addrspace(1)* %39
@@ -2236,8 +2318,8 @@ entry:
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
-  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
   %54 = load i64, i64 addrspace(1)* %52
@@ -2252,8 +2334,8 @@ entry:
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
   %67 = load i64, i64 addrspace(1)* %65
@@ -2270,8 +2352,8 @@ entry:
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
-  br i1 %NullCheck16, label %79, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
   %80 = load i64, i64 addrspace(1)* %78
@@ -2286,8 +2368,8 @@ entry:
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
-  br i1 %NullCheck18, label %92, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
   %93 = load i64, i64 addrspace(1)* %91
@@ -2304,8 +2386,8 @@ entry:
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
-  br i1 %NullCheck12, label %105, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = load i64, i64 addrspace(1)* %104
@@ -2320,8 +2402,8 @@ entry:
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
-  br i1 %NullCheck14, label %118, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
   %119 = load i64, i64 addrspace(1)* %117
@@ -2337,8 +2419,8 @@ entry:
 
 ; <label>:128                                     ; preds = %20
   %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
-  br i1 %NullCheck4, label %130, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %129, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %130
 
 ; <label>:130                                     ; preds = %128
   %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
@@ -2346,8 +2428,8 @@ entry:
   %133 = load i16, i16 addrspace(1)* %132, align 8
   %134 = zext i16 %133 to i32
   %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
-  br i1 %NullCheck6, label %136, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %135, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %136
 
 ; <label>:136                                     ; preds = %130
   %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
@@ -2360,8 +2442,8 @@ entry:
 
 ; <label>:143                                     ; preds = %136
   %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
-  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %144, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %145
 
 ; <label>:145                                     ; preds = %143
   %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
@@ -2369,8 +2451,8 @@ entry:
   %148 = load i16, i16 addrspace(1)* %147, align 8
   %149 = zext i16 %148 to i32
   %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %150, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %151
 
 ; <label>:151                                     ; preds = %145
   %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
@@ -2388,8 +2470,8 @@ entry:
 
 ; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
-  br i1 %NullCheck, label %163, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %ThrowNullRef, label %163
 
 ; <label>:163                                     ; preds = %161
   %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
@@ -2399,8 +2481,8 @@ entry:
 
 ; <label>:167                                     ; preds = %163
   %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
-  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %168, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %169
 
 ; <label>:169                                     ; preds = %167
   %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
@@ -2432,55 +2514,55 @@ ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %167
+ThrowNullRef2:                                    ; preds = %167
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %128
+ThrowNullRef4:                                    ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %130
+ThrowNullRef6:                                    ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %143
+ThrowNullRef8:                                    ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %145
+ThrowNullRef10:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %102
+ThrowNullRef12:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %105
+ThrowNullRef14:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %76
+ThrowNullRef16:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %79
+ThrowNullRef18:                                   ; preds = %79
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %50
+ThrowNullRef20:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %53
+ThrowNullRef22:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %24
+ThrowNullRef24:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %27
+ThrowNullRef26:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2503,15 +2585,15 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2519,16 +2601,16 @@ entry:
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
   store i32 %8, i32* %loc0
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
   %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
   store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
@@ -2546,16 +2628,16 @@ entry:
 
 ; <label>:23                                      ; preds = %64
   %24 = load i16*, i16** %loc3
-  %NullCheck12 = icmp ne i16* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i16* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
   store i32 %27, i32* %loc5
   %28 = load i16*, i16** %loc4
-  %NullCheck14 = icmp ne i16* %28, null
-  br i1 %NullCheck14, label %29, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %28, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = load i16, i16* %28, align 8
@@ -2620,15 +2702,15 @@ entry:
 
 ; <label>:67                                      ; preds = %64
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
-  br i1 %NullCheck8, label %69, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %68, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %69
 
 ; <label>:69                                      ; preds = %67
   %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
   %71 = load i32, i32 addrspace(1)* %70
   %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
-  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %73
 
 ; <label>:73                                      ; preds = %69
   %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
@@ -2645,31 +2727,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %67
+ThrowNullRef8:                                    ; preds = %67
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %69
+ThrowNullRef10:                                   ; preds = %69
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2710,14 +2792,14 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
   %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
@@ -2730,14 +2812,14 @@ entry:
 
 ; <label>:11                                      ; preds = %4
   %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
   %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
@@ -2749,14 +2831,14 @@ entry:
 
 ; <label>:22                                      ; preds = %16
   %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
   %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
-  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
-  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
@@ -2804,23 +2886,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2836,7 +2918,280 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[loadElem]
+Successfully read RuntimeType.IsAssignableFrom
+
+define i8 @RuntimeType.IsAssignableFrom(%System.RuntimeType addrspace(1)* %param0, %System.Type addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.RuntimeType addrspace(1)*
+  %arg1 = alloca %System.Type addrspace(1)*
+  %loc0 = alloca %System.RuntimeType addrspace(1)*
+  %loc1 = alloca %"System.Type[]" addrspace(1)*
+  %loc2 = alloca i32
+  store %System.RuntimeType addrspace(1)* %param0, %System.RuntimeType addrspace(1)** %this
+  store %System.Type addrspace(1)* %param1, %System.Type addrspace(1)** %arg1
+  %0 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %1 = icmp ne %System.Type addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i8 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %5 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %6 = bitcast %System.Type addrspace(1)* %4 to %System.Object addrspace(1)*
+  %7 = bitcast %System.RuntimeType addrspace(1)* %5 to %System.Object addrspace(1)*
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %6, %System.Object addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %3
+  ret i8 1
+
+; <label>:12                                      ; preds = %3
+  %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 152
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 32
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
+  %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
+  %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
+  store %System.RuntimeType addrspace(1)* %25, %System.RuntimeType addrspace(1)** %loc0
+  %26 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %27 = icmp eq %System.RuntimeType addrspace(1)* %26, null
+  br i1 %27, label %34, label %28
+
+; <label>:28                                      ; preds = %15
+  %29 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %30 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)*)*)(%System.RuntimeType addrspace(1)* %29, %System.RuntimeType addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+; <label>:34                                      ; preds = %15
+  %35 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %36 = call %System.Reflection.Emit.TypeBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Reflection.Emit.TypeBuilder addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %35)
+  %37 = icmp eq %System.Reflection.Emit.TypeBuilder addrspace(1)* %36, null
+  br i1 %37, label %139, label %38
+
+; <label>:38                                      ; preds = %34
+  %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %42
+
+; <label>:42                                      ; preds = %38
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 152
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 40
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
+  %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
+  %53 = zext i8 %52 to i32
+  %54 = icmp eq i32 %53, 0
+  br i1 %54, label %56, label %55
+
+; <label>:55                                      ; preds = %42
+  ret i8 1
+
+; <label>:56                                      ; preds = %42
+  %57 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %58 = bitcast %System.RuntimeType addrspace(1)* %57 to %System.Type addrspace(1)*
+  %59 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %58)
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %64 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.Type addrspace(1)* %63, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = bitcast %System.RuntimeType addrspace(1)* %64 to %System.Type addrspace(1)*
+  %67 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %63, %System.Type addrspace(1)* %66)
+  %68 = zext i8 %67 to i32
+  %69 = trunc i32 %68 to i8
+  ret i8 %69
+
+; <label>:70                                      ; preds = %56
+  %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
+  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %73
+
+; <label>:73                                      ; preds = %70
+  %74 = load i64, i64 addrspace(1)* %72
+  %75 = add i64 %74, 128
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = add i64 %77, 0
+  %79 = inttoptr i64 %78 to i64*
+  %80 = load i64, i64* %79
+  %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
+  %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
+  %83 = call i8 %82(%System.Type addrspace(1)* %81)
+  %84 = zext i8 %83 to i32
+  %85 = icmp eq i32 %84, 0
+  br i1 %85, label %139, label %86
+
+; <label>:86                                      ; preds = %73
+  %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
+  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %89
+
+; <label>:89                                      ; preds = %86
+  %90 = load i64, i64 addrspace(1)* %88
+  %91 = add i64 %90, 128
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = add i64 %93, 24
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
+  %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
+  %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
+  store %"System.Type[]" addrspace(1)* %99, %"System.Type[]" addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %129
+
+; <label>:100                                     ; preds = %132
+  %101 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %102 = load i32, i32* %loc2
+  %NullCheck11 = icmp eq %"System.Type[]" addrspace(1)* %101, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %103
+
+; <label>:103                                     ; preds = %100
+  %104 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 1
+  %105 = load i32, i32 addrspace(1)* %104
+  %106 = zext i32 %105 to i64
+  %107 = zext i32 %102 to i64
+  %BoundsCheck = icmp uge i64 %107, %106
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %108
+
+; <label>:108                                     ; preds = %103
+  %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
+  %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
+  %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
+  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %113
+
+; <label>:113                                     ; preds = %108
+  %114 = load i64, i64 addrspace(1)* %112
+  %115 = add i64 %114, 152
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = add i64 %117, 56
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
+  %123 = zext i8 %122 to i32
+  %124 = icmp ne i32 %123, 0
+  br i1 %124, label %126, label %125
+
+; <label>:125                                     ; preds = %113
+  ret i8 0
+
+; <label>:126                                     ; preds = %113
+  %127 = load i32, i32* %loc2
+  %128 = add i32 %127, 1
+  store i32 %128, i32* %loc2
+  br label %129
+
+; <label>:129                                     ; preds = %89, %126
+  %130 = load i32, i32* %loc2
+  %131 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %NullCheck9 = icmp eq %"System.Type[]" addrspace(1)* %131, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %132
+
+; <label>:132                                     ; preds = %129
+  %133 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %131, i32 0, i32 1
+  %134 = load i32, i32 addrspace(1)* %133
+  %135 = zext i32 %134 to i64
+  %136 = trunc i64 %135 to i32
+  %137 = icmp slt i32 %130, %136
+  br i1 %137, label %100, label %138
+
+; <label>:138                                     ; preds = %132
+  ret i8 1
+
+; <label>:139                                     ; preds = %34, %73
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %129
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %103
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -2893,7 +3248,7 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElem]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -2904,8 +3259,8 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -2997,8 +3352,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
@@ -3059,8 +3414,8 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -3087,8 +3442,8 @@ entry:
 
 ; <label>:17                                      ; preds = %5, %11
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
@@ -3097,8 +3452,8 @@ entry:
 
 ; <label>:22                                      ; preds = %1, %11
   %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
@@ -3109,11 +3464,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %17
+ThrowNullRef2:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %22
+ThrowNullRef4:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3167,15 +3522,15 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
   %15 = load i32, i32 addrspace(1)* %14
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
@@ -3198,7 +3553,7 @@ ThrowNullRef:                                     ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef2:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3232,8 +3587,8 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
@@ -3312,8 +3667,8 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -3327,8 +3682,8 @@ entry:
 ; <label>:5                                       ; preds = %43
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %7 = load i32, i32* %loc1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck6, label %8, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
@@ -3366,8 +3721,8 @@ entry:
 ; <label>:32                                      ; preds = %21, %25
   %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
   %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
-  br i1 %NullCheck8, label %35, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = trunc i32 %34 to i16
@@ -3380,8 +3735,8 @@ entry:
 ; <label>:40                                      ; preds = %1, %35
   %41 = load i32, i32* %loc1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
-  br i1 %NullCheck2, label %43, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %42, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
@@ -3392,8 +3747,8 @@ entry:
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
   %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
-  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
   %51 = load i64, i64 addrspace(1)* %49
@@ -3412,19 +3767,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %40
+ThrowNullRef2:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %47
+ThrowNullRef4:                                    ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %5
+ThrowNullRef6:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %32
+ThrowNullRef8:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3467,8 +3822,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
@@ -3492,11 +3847,391 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(i16* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store i16* %param0, i16** %arg0
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load i32, i32* %arg3
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %42, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %37, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg2
+  %13 = load i32, i32* %arg3
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %37, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %24 = load i32, i32* %arg2
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load i16*, i16** %arg0
+  %35 = load i32, i32* %arg3
+  %36 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %36, i16* %34, i32 %35)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:37                                      ; preds = %5, %16
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %39)
+  %41 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41, %System.String addrspace(1)* %38, %System.String addrspace(1)* %40)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41) #0
+  unreachable
+
+; <label>:42                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
-Failed to read StringBuilder.ToString[loadElemA]
+Successfully read StringBuilder.ToString
+
+define %System.String addrspace(1)* @StringBuilder.ToString(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i16*
+  %loc3 = alloca %"System.Char[]" addrspace(1)*
+  %loc4 = alloca i32
+  %loc5 = alloca i32
+  %loc6 = alloca i16 addrspace(1)*
+  %loc7 = alloca %System.String addrspace(1)*
+  %loc8 = alloca %"System.Char[]" addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %0)
+  %2 = icmp ne i32 %1, 0
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %4
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %6)
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %7)
+  store %System.String addrspace(1)* %8, %System.String addrspace(1)** %loc0
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.Text.StringBuilder addrspace(1)* %9, %System.Text.StringBuilder addrspace(1)** %loc1
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  store %System.String addrspace(1)* %10, %System.String addrspace(1)** %loc7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc7
+  %12 = ptrtoint %System.String addrspace(1)* %11 to i64
+  %13 = icmp eq i64 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %5
+  %15 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %16 = sext i32 %15 to i64
+  %17 = add i64 %12, %16
+  br label %18
+
+; <label>:18                                      ; preds = %5, %14
+  %19 = phi i64 [ %12, %5 ], [ %17, %14 ]
+  %20 = inttoptr i64 %19 to i16*
+  store i16* %20, i16** %loc2
+  br label %21
+
+; <label>:21                                      ; preds = %98, %18
+  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %22, null
+  br i1 %NullCheck, label %ThrowNullRef, label %23
+
+; <label>:23                                      ; preds = %21
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 3
+  %25 = load i32, i32 addrspace(1)* %24, align 8
+  %26 = icmp sle i32 %25, 0
+  br i1 %26, label %96, label %27
+
+; <label>:27                                      ; preds = %23
+  %28 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %28, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %29
+
+; <label>:29                                      ; preds = %27
+  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %28, i32 0, i32 1
+  %31 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %30, align 8
+  store %"System.Char[]" addrspace(1)* %31, %"System.Char[]" addrspace(1)** %loc3
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %33
+
+; <label>:33                                      ; preds = %29
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  store i32 %35, i32* %loc4
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  %39 = load i32, i32 addrspace(1)* %38, align 8
+  store i32 %39, i32* %loc5
+  %40 = load i32, i32* %loc5
+  %41 = load i32, i32* %loc4
+  %42 = add i32 %40, %41
+  %43 = zext i32 %42 to i64
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %45
+
+; <label>:45                                      ; preds = %37
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = sext i32 %47 to i64
+  %49 = icmp sgt i64 %43, %48
+  br i1 %49, label %91, label %50
+
+; <label>:50                                      ; preds = %45
+  %51 = load i32, i32* %loc5
+  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %52, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %53
+
+; <label>:53                                      ; preds = %50
+  %54 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %52, i32 0, i32 1
+  %55 = load i32, i32 addrspace(1)* %54
+  %56 = zext i32 %55 to i64
+  %57 = trunc i64 %56 to i32
+  %58 = icmp ugt i32 %51, %57
+  br i1 %58, label %91, label %59
+
+; <label>:59                                      ; preds = %53
+  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  store %"System.Char[]" addrspace(1)* %60, %"System.Char[]" addrspace(1)** %loc8
+  %61 = icmp eq %"System.Char[]" addrspace(1)* %60, null
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %63, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %64
+
+; <label>:64                                      ; preds = %62
+  %65 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %63, i32 0, i32 1
+  %66 = load i32, i32 addrspace(1)* %65
+  %67 = zext i32 %66 to i64
+  %68 = trunc i64 %67 to i32
+  %69 = icmp ne i32 %68, 0
+  br i1 %69, label %71, label %70
+
+; <label>:70                                      ; preds = %59, %64
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:71                                      ; preds = %64
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %73
+
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %BoundsCheck = icmp uge i64 0, %76
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %77
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %78, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:79                                      ; preds = %70, %77
+  %80 = load i16*, i16** %loc2
+  %81 = load i32, i32* %loc4
+  %82 = sext i32 %81 to i64
+  %83 = mul i64 %82, 2
+  %84 = bitcast i16* %80 to i8*
+  %85 = getelementptr inbounds i8, i8* %84, i64 %83
+  %86 = load i16 addrspace(1)*, i16 addrspace(1)** %loc6
+  %87 = ptrtoint i16 addrspace(1)* %86 to i64
+  %88 = load i32, i32* %loc5
+  %89 = bitcast i8* %85 to i16*
+  %90 = inttoptr i64 %87 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %89, i16* %90, i32 %88)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %96
+
+; <label>:91                                      ; preds = %45, %53
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %94 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %93)
+  %95 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95, %System.String addrspace(1)* %92, %System.String addrspace(1)* %94)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95) #0
+  unreachable
+
+; <label>:96                                      ; preds = %23, %79
+  %97 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %97, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %98
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %97, i32 0, i32 2
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  store %System.Text.StringBuilder addrspace(1)* %100, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %102 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %102, label %21, label %103
+
+; <label>:103                                     ; preds = %98
+  store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc7
+  %104 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  ret %System.String addrspace(1)* %104
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method StringBuilder::get_Length using LLILCJit
+Successfully read StringBuilder.get_Length
+
+define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
+Successfully read RuntimeHelpers.get_OffsetToStringData
+
+define i32 @RuntimeHelpers.get_OffsetToStringData() {
+entry:
+  ret i32 12
+}
+
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
 Successfully read CultureData.CreateCultureData
 
@@ -3514,23 +4249,23 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
   store i8 %4, i8 addrspace(1)* %6
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
@@ -3549,11 +4284,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3566,50 +4301,50 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
   store i32 -1, i32 addrspace(1)* %2
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
   store i32 -1, i32 addrspace(1)* %8
   %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
   store i32 -1, i32 addrspace(1)* %14
   %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
   store i32 -1, i32 addrspace(1)* %17
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
@@ -3623,27 +4358,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3675,7 +4410,136 @@ Failed to read Dictionary`2.Insert[non-const derefAddress]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
 Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
-Failed to read HashHelpers.GetPrime[loadElem]
+Successfully read HashHelpers.GetPrime
+
+define i32 @HashHelpers.GetPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %6, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5, %System.String addrspace(1)* %4)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5) #0
+  unreachable
+
+; <label>:6                                       ; preds = %entry
+  store i32 0, i32* %loc0
+  br label %29
+
+; <label>:7                                       ; preds = %35
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 1296
+  %10 = addrspacecast i8 addrspace(1)* %9 to %"System.Int32[]" addrspace(1)**
+  %11 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %10
+  %12 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Int32[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = zext i32 %15 to i64
+  %17 = zext i32 %12 to i64
+  %BoundsCheck = icmp uge i64 %17, %16
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 3, i32 %12
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  store i32 %20, i32* %loc1
+  %21 = load i32, i32* %loc1
+  %22 = load i32, i32* %arg0
+  %23 = icmp slt i32 %21, %22
+  br i1 %23, label %26, label %24
+
+; <label>:24                                      ; preds = %18
+  %25 = load i32, i32* %loc1
+  ret i32 %25
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %loc0
+  %28 = add i32 %27, 1
+  store i32 %28, i32* %loc0
+  br label %29
+
+; <label>:29                                      ; preds = %6, %26
+  %30 = load i32, i32* %loc0
+  %31 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %32 = getelementptr inbounds i8, i8 addrspace(1)* %31, i64 1296
+  %33 = addrspacecast i8 addrspace(1)* %32 to %"System.Int32[]" addrspace(1)**
+  %34 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %33
+  %NullCheck = icmp eq %"System.Int32[]" addrspace(1)* %34, null
+  br i1 %NullCheck, label %ThrowNullRef, label %35
+
+; <label>:35                                      ; preds = %29
+  %36 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %34, i32 0, i32 1
+  %37 = load i32, i32 addrspace(1)* %36
+  %38 = zext i32 %37 to i64
+  %39 = trunc i64 %38 to i32
+  %40 = icmp slt i32 %30, %39
+  br i1 %40, label %7, label %41
+
+; <label>:41                                      ; preds = %35
+  %42 = load i32, i32* %arg0
+  %43 = or i32 %42, 1
+  store i32 %43, i32* %loc2
+  br label %59
+
+; <label>:44                                      ; preds = %59
+  %45 = load i32, i32* %loc2
+  %46 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %45)
+  %47 = zext i8 %46 to i32
+  %48 = icmp eq i32 %47, 0
+  br i1 %48, label %56, label %49
+
+; <label>:49                                      ; preds = %44
+  %50 = load i32, i32* %loc2
+  %51 = sub i32 %50, 1
+  %52 = srem i32 %51, 101
+  %53 = icmp eq i32 %52, 0
+  br i1 %53, label %56, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = load i32, i32* %loc2
+  ret i32 %55
+
+; <label>:56                                      ; preds = %44, %49
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %57, 2
+  store i32 %58, i32* %loc2
+  br label %59
+
+; <label>:59                                      ; preds = %41, %56
+  %60 = load i32, i32* %loc2
+  %61 = icmp slt i32 %60, 2147483647
+  br i1 %61, label %44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load i32, i32* %arg0
+  ret i32 %63
+
+ThrowNullRef:                                     ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
 Successfully read GenericEqualityComparer`1.GetHashCode
 
@@ -3694,14 +4558,14 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
   %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load i64, i64 addrspace(1)* %7
@@ -3720,7 +4584,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3750,8 +4614,8 @@ entry:
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
@@ -3796,8 +4660,8 @@ entry:
   %35 = bitcast i16* %34 to i8*
   %36 = getelementptr inbounds i8, i8* %35, i64 2
   %37 = bitcast i8* %36 to i16*
-  %NullCheck4 = icmp ne i16* %37, null
-  br i1 %NullCheck4, label %38, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %37, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %38
 
 ; <label>:38                                      ; preds = %27
   %39 = load i16, i16* %37, align 8
@@ -3824,8 +4688,8 @@ entry:
 
 ; <label>:54                                      ; preds = %22, %43
   %55 = load i16*, i16** %loc4
-  %NullCheck2 = icmp ne i16* %55, null
-  br i1 %NullCheck2, label %56, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i16* %55, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %56
 
 ; <label>:56                                      ; preds = %54
   %57 = load i16, i16* %55, align 8
@@ -3850,11 +4714,11 @@ ThrowNullRef:                                     ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %54
+ThrowNullRef2:                                    ; preds = %54
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %27
+ThrowNullRef4:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3871,8 +4735,8 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -3907,8 +4771,8 @@ entry:
 
 ; <label>:26                                      ; preds = %19
   %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
-  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %28
 
 ; <label>:28                                      ; preds = %26
   %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
@@ -3920,7 +4784,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3972,8 +4836,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
@@ -3984,26 +4848,26 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
-  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
@@ -4014,8 +4878,8 @@ entry:
 ; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
@@ -4024,8 +4888,8 @@ entry:
 
 ; <label>:25                                      ; preds = %1, %16, %23
   %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
-  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
@@ -4036,27 +4900,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %20
+ThrowNullRef10:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4069,8 +4933,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -4081,8 +4945,8 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
@@ -4091,8 +4955,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1, %8
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
@@ -4103,11 +4967,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4128,24 +4992,24 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   store i32 %3, i32* %loc0
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
   %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
   store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck4, label %9, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
@@ -4164,15 +5028,15 @@ entry:
 ; <label>:18                                      ; preds = %70
   %19 = load i16*, i16** %loc3
   %20 = bitcast i16* %19 to i64*
-  %NullCheck10 = icmp ne i64* %20, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %20, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = load i64, i64* %20, align 8
   %23 = load i16*, i16** %loc4
   %24 = bitcast i16* %23 to i64*
-  %NullCheck12 = icmp ne i64* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = load i64, i64* %24, align 8
@@ -4188,8 +5052,8 @@ entry:
   %31 = bitcast i16* %30 to i8*
   %32 = getelementptr inbounds i8, i8* %31, i64 8
   %33 = bitcast i8* %32 to i64*
-  %NullCheck14 = icmp ne i64* %33, null
-  br i1 %NullCheck14, label %34, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = load i64, i64* %33, align 8
@@ -4197,8 +5061,8 @@ entry:
   %37 = bitcast i16* %36 to i8*
   %38 = getelementptr inbounds i8, i8* %37, i64 8
   %39 = bitcast i8* %38 to i64*
-  %NullCheck16 = icmp ne i64* %39, null
-  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %40
 
 ; <label>:40                                      ; preds = %34
   %41 = load i64, i64* %39, align 8
@@ -4214,8 +5078,8 @@ entry:
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %NullCheck18 = icmp ne i64* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = load i64, i64* %48, align 8
@@ -4223,8 +5087,8 @@ entry:
   %52 = bitcast i16* %51 to i8*
   %53 = getelementptr inbounds i8, i8* %52, i64 16
   %54 = bitcast i8* %53 to i64*
-  %NullCheck20 = icmp ne i64* %54, null
-  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64* %54, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %55
 
 ; <label>:55                                      ; preds = %49
   %56 = load i64, i64* %54, align 8
@@ -4262,15 +5126,15 @@ entry:
 ; <label>:74                                      ; preds = %95
   %75 = load i16*, i16** %loc3
   %76 = bitcast i16* %75 to i32*
-  %NullCheck6 = icmp ne i32* %76, null
-  br i1 %NullCheck6, label %77, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32* %76, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %77
 
 ; <label>:77                                      ; preds = %74
   %78 = load i32, i32* %76, align 8
   %79 = load i16*, i16** %loc4
   %80 = bitcast i16* %79 to i32*
-  %NullCheck8 = icmp ne i32* %80, null
-  br i1 %NullCheck8, label %81, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i32* %80, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %81
 
 ; <label>:81                                      ; preds = %77
   %82 = load i32, i32* %80, align 8
@@ -4318,43 +5182,43 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %74
+ThrowNullRef6:                                    ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %77
+ThrowNullRef8:                                    ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %29
+ThrowNullRef14:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %34
+ThrowNullRef16:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4376,8 +5240,8 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load i64, i64 addrspace(1)* %4
@@ -4389,8 +5253,8 @@ entry:
   %12 = load i64, i64* %11
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %5
   %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
@@ -4399,8 +5263,8 @@ entry:
   %18 = load i8, i8* %arg2
   %19 = zext i8 %18 to i32
   %20 = trunc i32 %19 to i8
-  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %15
   %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
@@ -4411,11 +5275,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4442,8 +5306,8 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
@@ -4466,16 +5330,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
   %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = load i64, i64 addrspace(1)* %19
@@ -4500,8 +5364,8 @@ entry:
 ; <label>:35                                      ; preds = %30
   %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
@@ -4514,8 +5378,8 @@ entry:
 
 ; <label>:42                                      ; preds = %1, %38
   %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
-  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
@@ -4526,19 +5390,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %35
+ThrowNullRef2:                                    ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %42
+ThrowNullRef8:                                    ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4551,14 +5415,14 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
@@ -4570,7 +5434,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4583,8 +5447,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
@@ -4613,51 +5477,51 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
   %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
   %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
   %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
   %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
-  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
   store i64 %21, i64 addrspace(1)* %23
   %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %25 = load i64, i64* %loc0
-  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
@@ -4668,27 +5532,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %22
+ThrowNullRef12:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4701,8 +5565,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
@@ -4713,19 +5577,19 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
@@ -4734,8 +5598,8 @@ entry:
 
 ; <label>:15                                      ; preds = %1, %13
   %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
@@ -4746,19 +5610,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %15
+ThrowNullRef8:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4771,8 +5635,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -4831,8 +5695,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
@@ -4882,8 +5746,8 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
-  br i1 %NullCheck, label %17, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %ThrowNullRef, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
@@ -4894,15 +5758,15 @@ entry:
 
 ; <label>:22                                      ; preds = %17
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
-  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
   %26 = load i32, i32 addrspace(1)* %25
   %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
-  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %27, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
@@ -4925,8 +5789,8 @@ entry:
 ; <label>:40                                      ; preds = %17
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
-  br i1 %NullCheck6, label %43, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %41, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
@@ -4938,34 +5802,17 @@ ThrowNullRef:                                     ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %24
+ThrowNullRef4:                                    ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %40
+ThrowNullRef6:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
-}
-
-INFO:  jitting method Object::ReferenceEquals using LLILCJit
-Successfully read Object.ReferenceEquals
-
-define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
-entry:
-  %arg0 = alloca %System.Object addrspace(1)*
-  %arg1 = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
-  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
-  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = icmp eq %System.Object addrspace(1)* %0, %1
-  %3 = sext i1 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
 }
 
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
@@ -4978,21 +5825,21 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
   %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
-  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
@@ -5007,28 +5854,28 @@ entry:
 ; <label>:13                                      ; preds = %8, %12
   %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
   %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
   %21 = load i32, i32 addrspace(1)* %20, align 8
   %22 = add i32 %21, 1
-  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
   store i32 %22, i32 addrspace(1)* %24
   %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
@@ -5039,27 +5886,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5077,7 +5924,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::Setup using LLILCJit
-Failed to read AppDomain.Setup[loadElem]
+Failed to read AppDomain.Setup[unbox]
 INFO:  jitting method Thread::GetDomain using LLILCJit
 Successfully read Thread.GetDomain
 
@@ -5108,8 +5955,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
@@ -5122,14 +5969,14 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
   %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
@@ -5141,11 +5988,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5173,8 +6020,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -5189,7 +6036,328 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
 Failed to read KeyCollection.System.Collections.Generic.IEnumerable<TKey>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Successfully read Enumerator.MoveNext
+
+define i8 @Enumerator.MoveNext(%"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.RuntimeTypeHandle* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*
+  %"$TypeArg" = alloca %System.RuntimeTypeHandle*
+  store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
+  %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 8
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %76, label %12
+
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
+  br label %76
+
+; <label>:13                                      ; preds = %85
+  %14 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck19 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %15
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, i32 0, i32 0
+  %17 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %16, align 8
+  %NullCheck21 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, i32 0, i32 2
+  %20 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %19, align 8
+  %21 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck23 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %22
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, i32 0, i32 2
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %NullCheck25 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 3, i32 %24
+  %NullCheck27 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %32
+
+; <label>:32                                      ; preds = %30
+  %33 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, i32 0, i32 2
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = icmp slt i32 %34, 0
+  br i1 %35, label %68, label %36
+
+; <label>:36                                      ; preds = %32
+  %37 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %38 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck29 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %39
+
+; <label>:39                                      ; preds = %36
+  %40 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, i32 0, i32 0
+  %41 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %40, align 8
+  %NullCheck31 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, i32 0, i32 2
+  %44 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %43, align 8
+  %45 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck33 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, i32 0, i32 2
+  %48 = load i32, i32 addrspace(1)* %47, align 8
+  %NullCheck35 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %49
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = zext i32 %51 to i64
+  %53 = zext i32 %48 to i64
+  %BoundsCheck37 = icmp uge i64 %53, %52
+  br i1 %BoundsCheck37, label %ThrowIndexOutOfRange38, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 3, i32 %48
+  %NullCheck39 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %56
+
+; <label>:56                                      ; preds = %54
+  %57 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, i32 0, i32 0
+  %58 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck41 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %59
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %60, %System.__Canon addrspace(1)* %58)
+  %61 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck43 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  %64 = load i32, i32 addrspace(1)* %63, align 8
+  %65 = add i32 %64, 1
+  %NullCheck45 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  store i32 %65, i32 addrspace(1)* %67
+  ret i8 1
+
+; <label>:68                                      ; preds = %32
+  %69 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck47 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %73 = add i32 %72, 1
+  %NullCheck49 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %74
+
+; <label>:74                                      ; preds = %70
+  %75 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  store i32 %73, i32 addrspace(1)* %75
+  br label %76
+
+; <label>:76                                      ; preds = %8, %12, %74
+  %77 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %78
+
+; <label>:78                                      ; preds = %76
+  %79 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, i32 0, i32 2
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck7 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %82
+
+; <label>:82                                      ; preds = %78
+  %83 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, i32 0, i32 0
+  %84 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %83, align 8
+  %NullCheck9 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %85
+
+; <label>:85                                      ; preds = %82
+  %86 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, i32 0, i32 7
+  %87 = load i32, i32 addrspace(1)* %86, align 8
+  %88 = icmp ult i32 %80, %87
+  br i1 %88, label %13, label %89
+
+; <label>:89                                      ; preds = %85
+  %90 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %91 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck11 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %92
+
+; <label>:92                                      ; preds = %89
+  %93 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, i32 0, i32 0
+  %94 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck13 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %95
+
+; <label>:95                                      ; preds = %92
+  %96 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, i32 0, i32 7
+  %97 = load i32, i32 addrspace(1)* %96, align 8
+  %98 = add i32 %97, 1
+  %NullCheck15 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %99
+
+; <label>:99                                      ; preds = %95
+  %100 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, i32 0, i32 2
+  store i32 %98, i32 addrspace(1)* %100
+  %101 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck17 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %102
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %103, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %92
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef22:                                   ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef24:                                   ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef26:                                   ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef28:                                   ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef30:                                   ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef32:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef34:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef36:                                   ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange38:                           ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef40:                                   ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef42:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef44:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef46:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef48:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef50:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -5200,8 +6368,8 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -5232,9 +6400,9 @@ Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
 Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
-Failed to read String.MakeSeparatorList[loadElemA]
+Failed to read String.MakeSeparatorList[storeElem]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
-Failed to read String.InternalSplitKeepEmptyEntries[loadElem]
+Failed to read String.InternalSplitKeepEmptyEntries[storeElem]
 INFO:  jitting method Path::IsRelative using LLILCJit
 Successfully read Path.IsRelative
 
@@ -5243,8 +6411,8 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -5254,8 +6422,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
@@ -5271,8 +6439,8 @@ entry:
 
 ; <label>:17                                      ; preds = %7
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
@@ -5288,8 +6456,8 @@ entry:
 
 ; <label>:29                                      ; preds = %19
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %31
 
 ; <label>:31                                      ; preds = %29
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
@@ -5300,8 +6468,8 @@ entry:
 
 ; <label>:36                                      ; preds = %31
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
-  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %37, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
@@ -5312,8 +6480,8 @@ entry:
 
 ; <label>:43                                      ; preds = %31, %38
   %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
-  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %45
 
 ; <label>:45                                      ; preds = %43
   %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
@@ -5324,8 +6492,8 @@ entry:
 
 ; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %50
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
@@ -5336,8 +6504,8 @@ entry:
 
 ; <label>:57                                      ; preds = %1, %7, %19, %45, %52
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
-  br i1 %NullCheck14, label %59, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %59
 
 ; <label>:59                                      ; preds = %57
   %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
@@ -5347,8 +6515,8 @@ entry:
 
 ; <label>:63                                      ; preds = %59
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
@@ -5359,8 +6527,8 @@ entry:
 
 ; <label>:70                                      ; preds = %65
   %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
-  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.String addrspace(1)* %71, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %72
 
 ; <label>:72                                      ; preds = %70
   %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
@@ -5379,39 +6547,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %17
+ThrowNullRef4:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %29
+ThrowNullRef6:                                    ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %36
+ThrowNullRef8:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %43
+ThrowNullRef10:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %50
+ThrowNullRef12:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %57
+ThrowNullRef14:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %63
+ThrowNullRef16:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %70
+ThrowNullRef18:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5419,7 +6587,293 @@ ThrowNullRef17:                                   ; preds = %70
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
-Failed to read String.TrimHelper[loadElem]
+Successfully read String.TrimHelper
+
+define %System.String addrspace(1)* @String.TrimHelper(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i16
+  %loc4 = alloca i32
+  %loc5 = alloca i16
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = sub i32 %3, 1
+  store i32 %4, i32* %loc0
+  store i32 0, i32* %loc1
+  %5 = load i32, i32* %arg2
+  %6 = icmp eq i32 %5, 1
+  br i1 %6, label %62, label %7
+
+; <label>:7                                       ; preds = %1
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:8                                       ; preds = %58
+  store i32 0, i32* %loc2
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load i32, i32* %loc1
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2, i32 %10
+  %13 = load i16, i16 addrspace(1)* %12
+  %14 = zext i16 %13 to i32
+  %15 = trunc i32 %14 to i16
+  store i16 %15, i16* %loc3
+  store i32 0, i32* %loc2
+  br label %34
+
+; <label>:16                                      ; preds = %37
+  %17 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %18 = load i32, i32* %loc2
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %17, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %19
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = zext i32 %18 to i64
+  %BoundsCheck = icmp uge i64 %23, %22
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %24
+
+; <label>:24                                      ; preds = %19
+  %25 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 3, i32 %18
+  %26 = load i16, i16 addrspace(1)* %25, align 8
+  %27 = zext i16 %26 to i32
+  %28 = load i16, i16* %loc3
+  %29 = zext i16 %28 to i32
+  %30 = icmp eq i32 %27, %29
+  br i1 %30, label %43, label %31
+
+; <label>:31                                      ; preds = %24
+  %32 = load i32, i32* %loc2
+  %33 = add i32 %32, 1
+  store i32 %33, i32* %loc2
+  br label %34
+
+; <label>:34                                      ; preds = %11, %31
+  %35 = load i32, i32* %loc2
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = icmp slt i32 %35, %41
+  br i1 %42, label %16, label %43
+
+; <label>:43                                      ; preds = %24, %37
+  %44 = load i32, i32* %loc2
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %45, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp eq i32 %44, %50
+  br i1 %51, label %62, label %52
+
+; <label>:52                                      ; preds = %46
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %7, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %57, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %58
+
+; <label>:58                                      ; preds = %55
+  %59 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %60 = load i32, i32 addrspace(1)* %59
+  %61 = icmp slt i32 %56, %60
+  br i1 %61, label %8, label %62
+
+; <label>:62                                      ; preds = %1, %46, %58
+  %63 = load i32, i32* %arg2
+  %64 = icmp eq i32 %63, 0
+  br i1 %64, label %122, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %66, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %67
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %66, i32 0, i32 1
+  %69 = load i32, i32 addrspace(1)* %68
+  %70 = sub i32 %69, 1
+  store i32 %70, i32* %loc0
+  br label %118
+
+; <label>:71                                      ; preds = %118
+  store i32 0, i32* %loc4
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %73 = load i32, i32* %loc0
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %74
+
+; <label>:74                                      ; preds = %71
+  %75 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 2, i32 %73
+  %76 = load i16, i16 addrspace(1)* %75
+  %77 = zext i16 %76 to i32
+  %78 = trunc i32 %77 to i16
+  store i16 %78, i16* %loc5
+  store i32 0, i32* %loc4
+  br label %97
+
+; <label>:79                                      ; preds = %100
+  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %81 = load i32, i32* %loc4
+  %NullCheck19 = icmp eq %"System.Char[]" addrspace(1)* %80, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
+
+; <label>:82                                      ; preds = %79
+  %83 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 1
+  %84 = load i32, i32 addrspace(1)* %83
+  %85 = zext i32 %84 to i64
+  %86 = zext i32 %81 to i64
+  %BoundsCheck21 = icmp uge i64 %86, %85
+  br i1 %BoundsCheck21, label %ThrowIndexOutOfRange22, label %87
+
+; <label>:87                                      ; preds = %82
+  %88 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 3, i32 %81
+  %89 = load i16, i16 addrspace(1)* %88, align 8
+  %90 = zext i16 %89 to i32
+  %91 = load i16, i16* %loc5
+  %92 = zext i16 %91 to i32
+  %93 = icmp eq i32 %90, %92
+  br i1 %93, label %106, label %94
+
+; <label>:94                                      ; preds = %87
+  %95 = load i32, i32* %loc4
+  %96 = add i32 %95, 1
+  store i32 %96, i32* %loc4
+  br label %97
+
+; <label>:97                                      ; preds = %74, %94
+  %98 = load i32, i32* %loc4
+  %99 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck15 = icmp eq %"System.Char[]" addrspace(1)* %99, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %100
+
+; <label>:100                                     ; preds = %97
+  %101 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %99, i32 0, i32 1
+  %102 = load i32, i32 addrspace(1)* %101
+  %103 = zext i32 %102 to i64
+  %104 = trunc i64 %103 to i32
+  %105 = icmp slt i32 %98, %104
+  br i1 %105, label %79, label %106
+
+; <label>:106                                     ; preds = %87, %100
+  %107 = load i32, i32* %loc4
+  %108 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck17 = icmp eq %"System.Char[]" addrspace(1)* %108, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %109
+
+; <label>:109                                     ; preds = %106
+  %110 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %108, i32 0, i32 1
+  %111 = load i32, i32 addrspace(1)* %110
+  %112 = zext i32 %111 to i64
+  %113 = trunc i64 %112 to i32
+  %114 = icmp eq i32 %107, %113
+  br i1 %114, label %122, label %115
+
+; <label>:115                                     ; preds = %109
+  %116 = load i32, i32* %loc0
+  %117 = sub i32 %116, 1
+  store i32 %117, i32* %loc0
+  br label %118
+
+; <label>:118                                     ; preds = %67, %115
+  %119 = load i32, i32* %loc0
+  %120 = load i32, i32* %loc1
+  %121 = icmp sge i32 %119, %120
+  br i1 %121, label %71, label %122
+
+; <label>:122                                     ; preds = %62, %109, %118
+  %123 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %124 = load i32, i32* %loc1
+  %125 = load i32, i32* %loc0
+  %126 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %123, i32 %124, i32 %125)
+  ret %System.String addrspace(1)* %126
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %97
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange22:                           ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
 Successfully read String.CreateTrimmedString
 
@@ -5439,8 +6893,8 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
@@ -5535,8 +6989,8 @@ entry:
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i64 2872
   %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
   %8 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %7
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %3
   %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
@@ -5553,8 +7007,8 @@ entry:
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 2864
   %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
   %21 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %20
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
-  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %22
 
 ; <label>:22                                      ; preds = %16
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
@@ -5569,7 +7023,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %16
+ThrowNullRef2:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5586,8 +7040,8 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5613,8 +7067,8 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
@@ -5632,8 +7086,8 @@ entry:
 
 ; <label>:12                                      ; preds = %4
   %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
@@ -5644,8 +7098,8 @@ entry:
 
 ; <label>:19                                      ; preds = %14
   %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %19
   %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
@@ -5660,21 +7114,21 @@ entry:
   %31 = zext i16 %30 to i32
   %32 = bitcast i8* %29 to i16*
   %33 = trunc i32 %31 to i16
-  %NullCheck6 = icmp ne i16* %32, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i16* %32, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %21
   store i16 %33, i16* %32, align 8
   %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %36
 
 ; <label>:36                                      ; preds = %34
   %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
   %38 = load i32, i32 addrspace(1)* %37, align 8
   %39 = add i32 %38, 1
-  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %40
 
 ; <label>:40                                      ; preds = %36
   %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
@@ -5683,16 +7137,16 @@ entry:
 
 ; <label>:42                                      ; preds = %14
   %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
-  br i1 %NullCheck12, label %44, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
   %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
   %47 = load i16, i16* %arg1
   %48 = zext i16 %47 to i32
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = trunc i32 %48 to i16
@@ -5703,31 +7157,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %19
+ThrowNullRef4:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %21
+ThrowNullRef6:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %36
+ThrowNullRef10:                                   ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %42
+ThrowNullRef12:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %44
+ThrowNullRef14:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5740,8 +7194,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -5752,8 +7206,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
@@ -5762,14 +7216,14 @@ entry:
 
 ; <label>:11                                      ; preds = %1
   %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
@@ -5779,15 +7233,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5808,8 +7262,8 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5822,8 +7276,8 @@ entry:
 
 ; <label>:8                                       ; preds = %3
   %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
@@ -5842,15 +7296,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
-  br i1 %NullCheck4, label %22, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
   %24 = load i16*, i16* addrspace(1)* %23, align 8
   %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %25, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
@@ -5859,8 +7313,8 @@ entry:
   store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
@@ -5874,8 +7328,8 @@ entry:
 
 ; <label>:37                                      ; preds = %65
   %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %37
   %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
@@ -5886,16 +7340,16 @@ entry:
   %45 = bitcast i16* %41 to i8*
   %46 = getelementptr inbounds i8, i8* %45, i64 %44
   %47 = bitcast i8* %46 to i16*
-  %NullCheck14 = icmp ne i16* %47, null
-  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %47, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %48
 
 ; <label>:48                                      ; preds = %39
   %49 = load i16, i16* %47, align 8
   %50 = zext i16 %49 to i32
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %52 = load i32, i32* %loc1
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %53
 
 ; <label>:53                                      ; preds = %48
   %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
@@ -5916,8 +7370,8 @@ entry:
 ; <label>:62                                      ; preds = %36, %59
   %63 = load i32, i32* %loc1
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck10, label %65, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %65
 
 ; <label>:65                                      ; preds = %62
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
@@ -5936,15 +7390,15 @@ entry:
 
 ; <label>:74                                      ; preds = %70
   %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
-  br i1 %NullCheck18, label %76, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %76
 
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
   %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
-  br i1 %NullCheck20, label %80, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
   %81 = load i64, i64 addrspace(1)* %79
@@ -5958,8 +7412,8 @@ entry:
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
   %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
-  br i1 %NullCheck22, label %92, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.String addrspace(1)* %90, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %92
 
 ; <label>:92                                      ; preds = %80
   %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
@@ -5969,15 +7423,15 @@ entry:
 
 ; <label>:96                                      ; preds = %70
   %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
-  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %98
 
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
   %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
-  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
   %103 = load i64, i64 addrspace(1)* %101
@@ -5991,8 +7445,8 @@ entry:
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
   %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
-  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.String addrspace(1)* %112, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %114
 
 ; <label>:114                                     ; preds = %102
   %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
@@ -6004,59 +7458,59 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %20
+ThrowNullRef4:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %22
+ThrowNullRef6:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %26
+ThrowNullRef8:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %62
+ThrowNullRef10:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %48
+ThrowNullRef16:                                   ; preds = %48
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %74
+ThrowNullRef18:                                   ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %76
+ThrowNullRef20:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %80
+ThrowNullRef22:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %96
+ThrowNullRef24:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %98
+ThrowNullRef26:                                   ; preds = %98
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %102
+ThrowNullRef28:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6069,15 +7523,15 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
   %3 = load i16*, i16* addrspace(1)* %2, align 8
   %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
@@ -6087,8 +7541,8 @@ entry:
   %10 = bitcast i16* %3 to i8*
   %11 = getelementptr inbounds i8, i8* %10, i64 %9
   %12 = bitcast i8* %11 to i16*
-  %NullCheck4 = icmp ne i16* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %5
   store i16 0, i16* %12, align 8
@@ -6098,11 +7552,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6119,8 +7573,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -6131,8 +7585,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
@@ -6144,15 +7598,15 @@ entry:
 
 ; <label>:14                                      ; preds = %1
   %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
   %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
   %21 = load i64, i64 addrspace(1)* %19
@@ -6171,15 +7625,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %14
+ThrowNullRef4:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %16
+ThrowNullRef6:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6302,14 +7756,6 @@ entry:
   ret %System.String addrspace(1)* %57
 }
 
-INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
-Successfully read RuntimeHelpers.get_OffsetToStringData
-
-define i32 @RuntimeHelpers.get_OffsetToStringData() {
-entry:
-  ret i32 12
-}
-
 INFO:  jitting method String::Equals using LLILCJit
 Successfully read String.Equals
 
@@ -6381,8 +7827,8 @@ entry:
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
-  br i1 %NullCheck24, label %29, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
   %30 = load i64, i64 addrspace(1)* %28
@@ -6397,8 +7843,8 @@ entry:
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
-  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
   %43 = load i64, i64 addrspace(1)* %41
@@ -6418,8 +7864,8 @@ entry:
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
   %59 = load i64, i64 addrspace(1)* %57
@@ -6434,8 +7880,8 @@ entry:
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck22, label %71, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
   %72 = load i64, i64 addrspace(1)* %70
@@ -6455,8 +7901,8 @@ entry:
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
-  br i1 %NullCheck16, label %87, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = load i64, i64 addrspace(1)* %86
@@ -6471,8 +7917,8 @@ entry:
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck18, label %100, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
   %101 = load i64, i64 addrspace(1)* %99
@@ -6492,8 +7938,8 @@ entry:
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
-  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
   %117 = load i64, i64 addrspace(1)* %115
@@ -6508,8 +7954,8 @@ entry:
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
-  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
   %130 = load i64, i64 addrspace(1)* %128
@@ -6528,15 +7974,15 @@ entry:
 
 ; <label>:142                                     ; preds = %22
   %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
-  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %143, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %144
 
 ; <label>:144                                     ; preds = %142
   %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
   %146 = load i32, i32 addrspace(1)* %145
   %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
-  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %147, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %148
 
 ; <label>:148                                     ; preds = %144
   %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
@@ -6557,15 +8003,15 @@ entry:
 
 ; <label>:159                                     ; preds = %22
   %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
-  br i1 %NullCheck, label %161, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %ThrowNullRef, label %161
 
 ; <label>:161                                     ; preds = %159
   %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
   %163 = load i32, i32 addrspace(1)* %162
   %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
-  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %164, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %165
 
 ; <label>:165                                     ; preds = %161
   %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
@@ -6578,8 +8024,8 @@ entry:
 
 ; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
-  br i1 %NullCheck4, label %172, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %171, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %172
 
 ; <label>:172                                     ; preds = %170
   %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
@@ -6589,8 +8035,8 @@ entry:
 
 ; <label>:176                                     ; preds = %172
   %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
-  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %177, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %178
 
 ; <label>:178                                     ; preds = %176
   %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
@@ -6629,55 +8075,55 @@ ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %161
+ThrowNullRef2:                                    ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %170
+ThrowNullRef4:                                    ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %176
+ThrowNullRef6:                                    ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %142
+ThrowNullRef8:                                    ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %144
+ThrowNullRef10:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %113
+ThrowNullRef12:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %116
+ThrowNullRef14:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %84
+ThrowNullRef16:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %87
+ThrowNullRef18:                                   ; preds = %87
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %55
+ThrowNullRef20:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %58
+ThrowNullRef22:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %26
+ThrowNullRef24:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %29
+ThrowNullRef26:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,8 +8161,8 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck, label %14, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %ThrowNullRef, label %14
 
 ; <label>:14                                      ; preds = %8
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
@@ -6760,8 +8206,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
@@ -6770,14 +8216,14 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32, i32* %loc0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %10
   %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
   %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
@@ -6790,15 +8236,15 @@ entry:
 ; <label>:25                                      ; preds = %19
   %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
-  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
   %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
@@ -6807,8 +8253,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %37 = load i32, i32* %loc0
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %38, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %38
 
 ; <label>:38                                      ; preds = %32
   %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
@@ -6817,14 +8263,14 @@ entry:
 
 ; <label>:40                                      ; preds = %19
   %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %40
   %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
   %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
-  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
-  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
@@ -6832,8 +8278,8 @@ entry:
   %48 = zext i32 %47 to i64
   %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
-  br i1 %NullCheck16, label %51, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %51
 
 ; <label>:51                                      ; preds = %45
   %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
@@ -6847,15 +8293,15 @@ entry:
 ; <label>:57                                      ; preds = %51
   %58 = load i16*, i16** %arg1
   %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
-  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %60
 
 ; <label>:60                                      ; preds = %57
   %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
   %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
-  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %64
 
 ; <label>:64                                      ; preds = %60
   %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
@@ -6864,22 +8310,22 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
   %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
-  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %70
 
 ; <label>:70                                      ; preds = %64
   %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
   %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
-  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
-  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
   %75 = load i32, i32 addrspace(1)* %74
   %76 = zext i32 %75 to i64
   %77 = trunc i64 %76 to i32
-  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
-  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %78
 
 ; <label>:78                                      ; preds = %73
   %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
@@ -6901,8 +8347,8 @@ entry:
   %90 = bitcast i16* %86 to i8*
   %91 = getelementptr inbounds i8, i8* %90, i64 %89
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %93
 
 ; <label>:93                                      ; preds = %80
   %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
@@ -6912,8 +8358,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %99 = load i32, i32* %loc2
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %100
 
 ; <label>:100                                     ; preds = %93
   %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
@@ -6928,63 +8374,63 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %25
+ThrowNullRef6:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %32
+ThrowNullRef10:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %40
+ThrowNullRef12:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %45
+ThrowNullRef16:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %57
+ThrowNullRef18:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %60
+ThrowNullRef20:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %64
+ThrowNullRef22:                                   ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %70
+ThrowNullRef24:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %73
+ThrowNullRef26:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %80
+ThrowNullRef28:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %93
+ThrowNullRef30:                                   ; preds = %93
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7004,8 +8450,8 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
@@ -7033,43 +8479,43 @@ entry:
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %14
   %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
   %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   %28 = load i32, i32 addrspace(1)* %27, align 8
   %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
-  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %30
 
 ; <label>:30                                      ; preds = %26
   %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
   %32 = load i32, i32 addrspace(1)* %31, align 8
   %33 = add i32 %28, %32
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %34
 
 ; <label>:34                                      ; preds = %30
   %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   store i32 %33, i32 addrspace(1)* %35
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
   store i32 0, i32 addrspace(1)* %38
   %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %40
 
 ; <label>:40                                      ; preds = %37
   %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
@@ -7082,8 +8528,8 @@ entry:
 
 ; <label>:47                                      ; preds = %40
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
@@ -7098,8 +8544,8 @@ entry:
   %54 = load i32, i32* %loc0
   %55 = sext i32 %54 to i64
   %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
-  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %57
 
 ; <label>:57                                      ; preds = %52
   %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
@@ -7110,68 +8556,35 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %14
+ThrowNullRef2:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %23
+ThrowNullRef4:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %26
+ThrowNullRef6:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %30
+ThrowNullRef8:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %34
+ThrowNullRef10:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %47
+ThrowNullRef14:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %52
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-}
-
-INFO:  jitting method StringBuilder::get_Length using LLILCJit
-Successfully read StringBuilder.get_Length
-
-define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.StringBuilder addrspace(1)*
-  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
-  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
-
-; <label>:1                                       ; preds = %entry
-  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %3 = load i32, i32 addrspace(1)* %2, align 8
-  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
-
-; <label>:5                                       ; preds = %1
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = add i32 %3, %7
-  ret i32 %8
-
-ThrowNullRef:                                     ; preds = %entry
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef16:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7213,70 +8626,70 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
   %6 = load i32, i32 addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
   store i32 %6, i32 addrspace(1)* %8
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
   %13 = load i32, i32 addrspace(1)* %12, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
   store i32 %13, i32 addrspace(1)* %15
   %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
-  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %18
 
 ; <label>:18                                      ; preds = %14
   %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
   %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
   %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
   %34 = load i32, i32 addrspace(1)* %33, align 8
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
-  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
@@ -7287,39 +8700,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %28
+ThrowNullRef16:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %32
+ThrowNullRef18:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7455,13 +8868,13 @@ entry:
 ; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
@@ -7477,16 +8890,16 @@ entry:
 
 ; <label>:18                                      ; preds = %15
   %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
   store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
   %22 = load i32, i32* %loc0
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %24
 
 ; <label>:24                                      ; preds = %20
   %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
@@ -7498,13 +8911,13 @@ entry:
 ; <label>:28                                      ; preds = %15, %24
   %29 = load i32, i32* %arg1
   %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %31
   %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
@@ -7517,20 +8930,20 @@ entry:
   %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
-  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
   %46 = load i32, i32 addrspace(1)* %45, align 8
   %47 = sub i32 %40, %46
-  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
-  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i32 addrspace(1)* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %48
 
 ; <label>:48                                      ; preds = %44
   store i32 %47, i32 addrspace(1)* %39, align 8
@@ -7538,21 +8951,21 @@ entry:
 
 ; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
-  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %51
 
 ; <label>:51                                      ; preds = %49
   %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %53
 
 ; <label>:53                                      ; preds = %51
   %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
   %55 = load i32, i32 addrspace(1)* %54, align 8
   %56 = load i32, i32* %arg2
   %57 = sub i32 %55, %56
-  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %58
 
 ; <label>:58                                      ; preds = %53
   %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
@@ -7562,13 +8975,13 @@ entry:
 ; <label>:60                                      ; preds = %33, %58
   %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
   %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
-  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %63
 
 ; <label>:63                                      ; preds = %60
   %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
-  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
-  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
@@ -7578,15 +8991,15 @@ entry:
 
 ; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
-  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i32 addrspace(1)* %69, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %70
 
 ; <label>:70                                      ; preds = %68
   %71 = load i32, i32 addrspace(1)* %69, align 8
   store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
-  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
@@ -7596,8 +9009,8 @@ entry:
   store i32 %77, i32* %loc4
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
-  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %80
 
 ; <label>:80                                      ; preds = %73
   %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
@@ -7607,71 +9020,71 @@ entry:
 ; <label>:83                                      ; preds = %80
   store i32 0, i32* %loc3
   %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
-  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
-  br i1 %NullCheck26, label %88, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i32 addrspace(1)* %87, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %88
 
 ; <label>:88                                      ; preds = %85
   %89 = load i32, i32 addrspace(1)* %87, align 8
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
-  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %90
 
 ; <label>:90                                      ; preds = %88
   %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
   store i32 %89, i32 addrspace(1)* %91
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
-  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
-  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %96
 
 ; <label>:96                                      ; preds = %94
   %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
-  br i1 %NullCheck34, label %100, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %100
 
 ; <label>:100                                     ; preds = %96
   %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
-  br i1 %NullCheck36, label %102, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %102
 
 ; <label>:102                                     ; preds = %100
   %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
   %104 = load i32, i32 addrspace(1)* %103, align 8
   %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
-  br i1 %NullCheck38, label %106, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %106
 
 ; <label>:106                                     ; preds = %102
   %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
-  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
-  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %108
 
 ; <label>:108                                     ; preds = %106
   %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
   %110 = load i32, i32 addrspace(1)* %109, align 8
   %111 = add i32 %104, %110
-  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %112
 
 ; <label>:112                                     ; preds = %108
   %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
   store i32 %111, i32 addrspace(1)* %113
   %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
-  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i32 addrspace(1)* %114, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %115
 
 ; <label>:115                                     ; preds = %112
   %116 = load i32, i32 addrspace(1)* %114, align 8
@@ -7681,19 +9094,19 @@ entry:
 ; <label>:118                                     ; preds = %115
   %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
-  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %121
 
 ; <label>:121                                     ; preds = %118
   %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
-  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
-  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %123
 
 ; <label>:123                                     ; preds = %121
   %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
   %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
-  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
-  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %126
 
 ; <label>:126                                     ; preds = %123
   %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
@@ -7705,8 +9118,8 @@ entry:
 
 ; <label>:130                                     ; preds = %80, %115, %126
   %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %132
 
 ; <label>:132                                     ; preds = %130
   %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7715,8 +9128,8 @@ entry:
   %136 = load i32, i32* %loc3
   %137 = sub i32 %135, %136
   %138 = sub i32 %134, %137
-  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %139
 
 ; <label>:139                                     ; preds = %132
   %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7728,16 +9141,16 @@ entry:
 
 ; <label>:144                                     ; preds = %139
   %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
-  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %146
 
 ; <label>:146                                     ; preds = %144
   %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
   %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
   %149 = load i32, i32* %loc2
   %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
-  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %151
 
 ; <label>:151                                     ; preds = %146
   %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
@@ -7754,145 +9167,249 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %18
+ThrowNullRef4:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %31
+ThrowNullRef10:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %44
+ThrowNullRef16:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %68
+ThrowNullRef18:                                   ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %70
+ThrowNullRef20:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %73
+ThrowNullRef22:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %83
+ThrowNullRef24:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %85
+ThrowNullRef26:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %88
+ThrowNullRef28:                                   ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %90
+ThrowNullRef30:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %94
+ThrowNullRef32:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %96
+ThrowNullRef34:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %100
+ThrowNullRef36:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %102
+ThrowNullRef38:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %106
+ThrowNullRef40:                                   ; preds = %106
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %108
+ThrowNullRef42:                                   ; preds = %108
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %112
+ThrowNullRef44:                                   ; preds = %112
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %118
+ThrowNullRef46:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %121
+ThrowNullRef48:                                   ; preds = %121
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %123
+ThrowNullRef50:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %130
+ThrowNullRef52:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %132
+ThrowNullRef54:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %144
+ThrowNullRef56:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %146
+ThrowNullRef58:                                   ; preds = %146
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %60
+ThrowNullRef60:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %63
+ThrowNullRef62:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %49
+ThrowNullRef64:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %51
+ThrowNullRef66:                                   ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %53
+ThrowNullRef68:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(%"System.Char[]" addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %arg0 = alloca %"System.Char[]" addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store %"System.Char[]" addrspace(1)* %param0, %"System.Char[]" addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load i32, i32* %arg4
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %43, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %38, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg1
+  %13 = load i32, i32* %arg4
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %38, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %24 = load i32, i32* %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %35 = load i32, i32* %arg3
+  %36 = load i32, i32* %arg4
+  %37 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %37, %"System.Char[]" addrspace(1)* %34, i32 %35, i32 %36)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:38                                      ; preds = %5, %16
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Successfully read Buffer._Memmove
 
@@ -7914,7 +9431,7 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[loadElem]
+Failed to read AppDomain.SetDataHelper[storeElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -7923,8 +9440,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
@@ -7934,8 +9451,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
@@ -7947,15 +9464,15 @@ entry:
   %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
   %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
@@ -7966,15 +9483,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7992,7 +9509,79 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
-Failed to read Dictionary`2.TryGetValue[loadElemA]
+Successfully read Dictionary`2.TryGetValue
+
+define i8 @"Dictionary`2.TryGetValue"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)* addrspace(1)* %param2) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  %arg2 = alloca %System.__Canon addrspace(1)* addrspace(1)*
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  store %System.__Canon addrspace(1)* addrspace(1)* %param2, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  store i32 %2, i32* %loc0
+  %3 = load i32, i32* %loc0
+  %4 = icmp slt i32 %3, 0
+  br i1 %4, label %22, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 2
+  %10 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %9, align 8
+  %11 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = zext i32 %11 to i64
+  %BoundsCheck = icmp uge i64 %16, %15
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 3, i32 %11
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %20, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %6, %System.__Canon addrspace(1)* %21)
+  ret i8 1
+
+; <label>:22                                      ; preds = %entry
+  %23 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %23, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -8058,8 +9647,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
@@ -8091,8 +9680,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
@@ -8171,15 +9760,15 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck, label %19, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %ThrowNullRef, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
   %21 = load i32, i32 addrspace(1)* %20
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
@@ -8202,7 +9791,7 @@ ThrowNullRef:                                     ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %19
+ThrowNullRef2:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8248,8 +9837,8 @@ entry:
   %0 = alloca %System.AppDomainHandle
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %1 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %1, i32 0, i32 15
@@ -8269,8 +9858,8 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
@@ -8286,7 +9875,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -8299,8 +9888,8 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -8327,8 +9916,8 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
@@ -8352,8 +9941,8 @@ entry:
   %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
   store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
@@ -8363,8 +9952,8 @@ entry:
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
@@ -8374,8 +9963,8 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %9
   %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
@@ -8384,8 +9973,8 @@ entry:
 
 ; <label>:18                                      ; preds = %3, %16
   %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
@@ -8397,15 +9986,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %18
+ThrowNullRef6:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8418,8 +10007,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
@@ -8453,15 +10042,15 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
@@ -8473,7 +10062,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8481,7 +10070,7 @@ ThrowNullRef1:                                    ; preds = %1
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
 Failed to read Dictionary`2.System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
@@ -8506,8 +10095,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
@@ -8524,8 +10113,8 @@ entry:
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -8544,7 +10133,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8577,8 +10166,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = load i64, i64* %arg2
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = trunc i32 %3 to i8
@@ -8634,46 +10223,46 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
   %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
-  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
-  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
-  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
@@ -8684,27 +10273,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %20
+ThrowNullRef12:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8717,8 +10306,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -8756,22 +10345,22 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
   %9 = load i64, i64 addrspace(1)* %8, align 8
   %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
   %13 = load i64, i64 addrspace(1)* %12, align 8
   %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %11
   %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
@@ -8788,11 +10377,11 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8882,8 +10471,8 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
@@ -8900,8 +10489,8 @@ entry:
 ; <label>:8                                       ; preds = %1
   %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
   %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
@@ -8911,15 +10500,15 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
   %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
   %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
-  br i1 %NullCheck6, label %21, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
@@ -8946,15 +10535,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8992,15 +10581,15 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
   store i8 %3, i8 addrspace(1)* %5
   %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
@@ -9011,7 +10600,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9027,8 +10616,8 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -9041,8 +10630,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
@@ -9058,7 +10647,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9080,8 +10669,8 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
@@ -9096,8 +10685,8 @@ entry:
 ; <label>:12                                      ; preds = %6
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
@@ -9112,8 +10701,8 @@ entry:
 ; <label>:21                                      ; preds = %15
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
@@ -9128,8 +10717,8 @@ entry:
 ; <label>:30                                      ; preds = %24
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %31, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
@@ -9144,8 +10733,8 @@ entry:
 ; <label>:39                                      ; preds = %33
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
-  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %40, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %42
 
 ; <label>:42                                      ; preds = %39
   %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
@@ -9164,19 +10753,19 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %21
+ThrowNullRef4:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %30
+ThrowNullRef6:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %39
+ThrowNullRef8:                                    ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9243,8 +10832,8 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
@@ -9264,57 +10853,57 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
   store i8 0, i8 addrspace(1)* %2
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
   store i8 0, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
   store i8 0, i8 addrspace(1)* %17
   %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
   store i8 0, i8 addrspace(1)* %20
   %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
-  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
@@ -9325,31 +10914,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %19
+ThrowNullRef14:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9367,8 +10956,8 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
@@ -9380,8 +10969,8 @@ entry:
 
 ; <label>:9                                       ; preds = %4
   %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %9
   %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
@@ -9395,7 +10984,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef2:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9420,8 +11009,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
@@ -9512,8 +11101,8 @@ entry:
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
@@ -9524,8 +11113,8 @@ entry:
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = load i64, i64 addrspace(1)* %12
@@ -9537,8 +11126,8 @@ entry:
   %20 = load i64, i64* %19
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
-  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %13
   %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
@@ -9555,8 +11144,8 @@ entry:
 ; <label>:30                                      ; preds = %25
   %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %32 = load i32, i32* %arg2
-  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
-  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
@@ -9570,15 +11159,15 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %30
+ThrowNullRef2:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9622,87 +11211,87 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
   %10 = load i8, i8 addrspace(1)* %9, align 8
   %11 = zext i8 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %8
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
   store i8 %12, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
   %19 = load i8, i8 addrspace(1)* %18, align 8
   %20 = zext i8 %19 to i32
   %21 = trunc i32 %20 to i8
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
   store i8 %21, i8 addrspace(1)* %23
   %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
   %28 = load i8, i8 addrspace(1)* %27, align 8
   %29 = zext i8 %28 to i32
   %30 = trunc i32 %29 to i8
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
-  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %31
 
 ; <label>:31                                      ; preds = %26
   %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
   store i8 %30, i8 addrspace(1)* %32
   %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
-  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
-  br i1 %NullCheck14, label %40, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %40
 
 ; <label>:40                                      ; preds = %35
   %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
   store i8 %39, i8 addrspace(1)* %41
   %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
-  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %44
 
 ; <label>:44                                      ; preds = %40
   %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
   %46 = load i8, i8 addrspace(1)* %45, align 8
   %47 = zext i8 %46 to i32
   %48 = trunc i32 %47 to i8
-  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
   store i8 %48, i8 addrspace(1)* %50
   %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
-  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
@@ -9713,29 +11302,29 @@ entry:
 ; <label>:56                                      ; preds = %52
   %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
-  br i1 %NullCheck22, label %59, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
   %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
   %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
-  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
-  br i1 %NullCheck24, label %63, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
   %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
-  br i1 %NullCheck26, label %66, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
   %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
-  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
-  br i1 %NullCheck28, label %69, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %69
 
 ; <label>:69                                      ; preds = %66
   %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
@@ -9744,15 +11333,15 @@ entry:
 
 ; <label>:71                                      ; preds = %105
   %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
-  br i1 %NullCheck34, label %73, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %73
 
 ; <label>:73                                      ; preds = %71
   %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
   %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
   %76 = load i32, i32* %loc0
-  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
-  br i1 %NullCheck36, label %77, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
@@ -9766,8 +11355,8 @@ entry:
 
 ; <label>:83                                      ; preds = %77
   %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
-  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
@@ -9775,14 +11364,14 @@ entry:
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
   %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
-  br i1 %NullCheck40, label %91, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
 ; <label>:91                                      ; preds = %85
   %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
   %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
-  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck42, label %94, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %94
 
 ; <label>:94                                      ; preds = %91
   %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
@@ -9798,14 +11387,14 @@ entry:
 ; <label>:99                                      ; preds = %69, %96
   %100 = load i32, i32* %loc0
   %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
-  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %102
 
 ; <label>:102                                     ; preds = %99
   %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
   %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
-  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
-  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
@@ -9819,87 +11408,87 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %26
+ThrowNullRef10:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %31
+ThrowNullRef12:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %35
+ThrowNullRef14:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %40
+ThrowNullRef16:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %56
+ThrowNullRef22:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %59
+ThrowNullRef24:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %63
+ThrowNullRef26:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %66
+ThrowNullRef28:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %102
+ThrowNullRef32:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %71
+ThrowNullRef34:                                   ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %73
+ThrowNullRef36:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %83
+ThrowNullRef38:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %85
+ThrowNullRef40:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %91
+ThrowNullRef42:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9943,15 +11532,15 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
   %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
@@ -9961,28 +11550,28 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
   %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %12
   %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
   %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
   %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
-  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
@@ -9993,23 +11582,23 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %12
+ThrowNullRef6:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10031,15 +11620,15 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
   %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = load i64, i64 addrspace(1)* %7
@@ -10077,13 +11666,13 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[loadElem]
+Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -10111,8 +11700,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1

--- a/test/BaseLine/JIT/CodeGenBringUpTests/CnsLng1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/CnsLng1.error.txt
@@ -25,8 +25,8 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
@@ -40,8 +40,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
   %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
@@ -75,7 +75,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -90,8 +90,8 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %NullCheck = icmp ne i8 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = load i8, i8 addrspace(1)* %0, align 8
@@ -125,8 +125,8 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
@@ -159,8 +159,8 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -184,8 +184,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
   store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
@@ -195,8 +195,8 @@ entry:
 ; <label>:4                                       ; preds = %1
   %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
   %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
@@ -206,8 +206,8 @@ entry:
   %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
@@ -221,14 +221,14 @@ entry:
 
 ; <label>:17                                      ; preds = %14
   %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
   %21 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
@@ -238,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -249,8 +249,8 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
@@ -261,27 +261,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %30
+ThrowNullRef10:                                   ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -301,7 +301,89 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
-Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
+Successfully read AppDomainSetup.GetUnsecureApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.GetUnsecureApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %NullCheck = icmp eq %"System.String[]" addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %BoundsCheck = icmp uge i64 0, %5
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %6
+
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 3, i32 0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
+  ret %System.String addrspace(1)* %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_Value using LLILCJit
+Successfully read AppDomainSetup.get_Value
+
+define %"System.String[]" addrspace(1)* @AppDomainSetup.get_Value(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.String[]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 18)
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.String[]" addrspace(1)* addrspace(1)*, %"System.String[]" addrspace(1)*)*)(%"System.String[]" addrspace(1)* addrspace(1)* %9, %"System.String[]" addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %11, i32 0, i32 1
+  %14 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %13, align 8
+  ret %"System.String[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -319,8 +401,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -368,16 +450,16 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
   %5 = load i32, i32 addrspace(1)* %4
   %6 = sub i32 %5, 1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -389,7 +471,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -421,8 +503,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
@@ -456,8 +538,8 @@ entry:
 ; <label>:27                                      ; preds = %19
   %28 = load i32, i32* %arg1
   %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
-  br i1 %NullCheck2, label %30, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %29, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %30
 
 ; <label>:30                                      ; preds = %27
   %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
@@ -493,8 +575,8 @@ entry:
 ; <label>:49                                      ; preds = %46
   %50 = load i32, i32* %arg2
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck4, label %52, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
@@ -517,11 +599,11 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %27
+ThrowNullRef2:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %49
+ThrowNullRef4:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -544,16 +626,16 @@ entry:
   %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %0)
   store %System.String addrspace(1)* %1, %System.String addrspace(1)** %loc0
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 2
   %5 = bitcast [0 x i16] addrspace(1)* %4 to i16 addrspace(1)*
   store i16 addrspace(1)* %5, i16 addrspace(1)** %loc1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %3
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2
@@ -580,7 +662,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -691,15 +773,15 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %NullCheck132 = icmp ne i8* %21, null
-  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+  %NullCheck131 = icmp eq i8* %21, null
+  br i1 %NullCheck131, label %ThrowNullRef132, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = load i8, i8* %21, align 8
   %24 = zext i8 %23 to i32
   %25 = trunc i32 %24 to i8
-  %NullCheck134 = icmp ne i8* %20, null
-  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+  %NullCheck133 = icmp eq i8* %20, null
+  br i1 %NullCheck133, label %ThrowNullRef134, label %26
 
 ; <label>:26                                      ; preds = %22
   store i8 %25, i8* %20, align 8
@@ -709,16 +791,16 @@ entry:
   %28 = load i8*, i8** %arg0
   %29 = load i8*, i8** %arg1
   %30 = bitcast i8* %29 to i16*
-  %NullCheck128 = icmp ne i16* %30, null
-  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+  %NullCheck127 = icmp eq i16* %30, null
+  br i1 %NullCheck127, label %ThrowNullRef128, label %31
 
 ; <label>:31                                      ; preds = %27
   %32 = load i16, i16* %30, align 8
   %33 = sext i16 %32 to i32
   %34 = bitcast i8* %28 to i16*
   %35 = trunc i32 %33 to i16
-  %NullCheck130 = icmp ne i16* %34, null
-  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+  %NullCheck129 = icmp eq i16* %34, null
+  br i1 %NullCheck129, label %ThrowNullRef130, label %36
 
 ; <label>:36                                      ; preds = %31
   store i16 %35, i16* %34, align 8
@@ -728,16 +810,16 @@ entry:
   %38 = load i8*, i8** %arg0
   %39 = load i8*, i8** %arg1
   %40 = bitcast i8* %39 to i16*
-  %NullCheck120 = icmp ne i16* %40, null
-  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+  %NullCheck119 = icmp eq i16* %40, null
+  br i1 %NullCheck119, label %ThrowNullRef120, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i16, i16* %40, align 8
   %43 = sext i16 %42 to i32
   %44 = bitcast i8* %38 to i16*
   %45 = trunc i32 %43 to i16
-  %NullCheck122 = icmp ne i16* %44, null
-  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+  %NullCheck121 = icmp eq i16* %44, null
+  br i1 %NullCheck121, label %ThrowNullRef122, label %46
 
 ; <label>:46                                      ; preds = %41
   store i16 %45, i16* %44, align 8
@@ -745,15 +827,15 @@ entry:
   %48 = getelementptr inbounds i8, i8* %47, i64 2
   %49 = load i8*, i8** %arg1
   %50 = getelementptr inbounds i8, i8* %49, i64 2
-  %NullCheck124 = icmp ne i8* %50, null
-  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+  %NullCheck123 = icmp eq i8* %50, null
+  br i1 %NullCheck123, label %ThrowNullRef124, label %51
 
 ; <label>:51                                      ; preds = %46
   %52 = load i8, i8* %50, align 8
   %53 = zext i8 %52 to i32
   %54 = trunc i32 %53 to i8
-  %NullCheck126 = icmp ne i8* %48, null
-  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+  %NullCheck125 = icmp eq i8* %48, null
+  br i1 %NullCheck125, label %ThrowNullRef126, label %55
 
 ; <label>:55                                      ; preds = %51
   store i8 %54, i8* %48, align 8
@@ -763,14 +845,14 @@ entry:
   %57 = load i8*, i8** %arg0
   %58 = load i8*, i8** %arg1
   %59 = bitcast i8* %58 to i32*
-  %NullCheck116 = icmp ne i32* %59, null
-  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+  %NullCheck115 = icmp eq i32* %59, null
+  br i1 %NullCheck115, label %ThrowNullRef116, label %60
 
 ; <label>:60                                      ; preds = %56
   %61 = load i32, i32* %59, align 8
   %62 = bitcast i8* %57 to i32*
-  %NullCheck118 = icmp ne i32* %62, null
-  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+  %NullCheck117 = icmp eq i32* %62, null
+  br i1 %NullCheck117, label %ThrowNullRef118, label %63
 
 ; <label>:63                                      ; preds = %60
   store i32 %61, i32* %62, align 8
@@ -780,14 +862,14 @@ entry:
   %65 = load i8*, i8** %arg0
   %66 = load i8*, i8** %arg1
   %67 = bitcast i8* %66 to i32*
-  %NullCheck108 = icmp ne i32* %67, null
-  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+  %NullCheck107 = icmp eq i32* %67, null
+  br i1 %NullCheck107, label %ThrowNullRef108, label %68
 
 ; <label>:68                                      ; preds = %64
   %69 = load i32, i32* %67, align 8
   %70 = bitcast i8* %65 to i32*
-  %NullCheck110 = icmp ne i32* %70, null
-  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+  %NullCheck109 = icmp eq i32* %70, null
+  br i1 %NullCheck109, label %ThrowNullRef110, label %71
 
 ; <label>:71                                      ; preds = %68
   store i32 %69, i32* %70, align 8
@@ -795,15 +877,15 @@ entry:
   %73 = getelementptr inbounds i8, i8* %72, i64 4
   %74 = load i8*, i8** %arg1
   %75 = getelementptr inbounds i8, i8* %74, i64 4
-  %NullCheck112 = icmp ne i8* %75, null
-  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+  %NullCheck111 = icmp eq i8* %75, null
+  br i1 %NullCheck111, label %ThrowNullRef112, label %76
 
 ; <label>:76                                      ; preds = %71
   %77 = load i8, i8* %75, align 8
   %78 = zext i8 %77 to i32
   %79 = trunc i32 %78 to i8
-  %NullCheck114 = icmp ne i8* %73, null
-  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+  %NullCheck113 = icmp eq i8* %73, null
+  br i1 %NullCheck113, label %ThrowNullRef114, label %80
 
 ; <label>:80                                      ; preds = %76
   store i8 %79, i8* %73, align 8
@@ -813,14 +895,14 @@ entry:
   %82 = load i8*, i8** %arg0
   %83 = load i8*, i8** %arg1
   %84 = bitcast i8* %83 to i32*
-  %NullCheck100 = icmp ne i32* %84, null
-  br i1 %NullCheck100, label %85, label %ThrowNullRef99
+  %NullCheck99 = icmp eq i32* %84, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %85
 
 ; <label>:85                                      ; preds = %81
   %86 = load i32, i32* %84, align 8
   %87 = bitcast i8* %82 to i32*
-  %NullCheck102 = icmp ne i32* %87, null
-  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+  %NullCheck101 = icmp eq i32* %87, null
+  br i1 %NullCheck101, label %ThrowNullRef102, label %88
 
 ; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
@@ -829,16 +911,16 @@ entry:
   %91 = load i8*, i8** %arg1
   %92 = getelementptr inbounds i8, i8* %91, i64 4
   %93 = bitcast i8* %92 to i16*
-  %NullCheck104 = icmp ne i16* %93, null
-  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+  %NullCheck103 = icmp eq i16* %93, null
+  br i1 %NullCheck103, label %ThrowNullRef104, label %94
 
 ; <label>:94                                      ; preds = %88
   %95 = load i16, i16* %93, align 8
   %96 = sext i16 %95 to i32
   %97 = bitcast i8* %90 to i16*
   %98 = trunc i32 %96 to i16
-  %NullCheck106 = icmp ne i16* %97, null
-  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+  %NullCheck105 = icmp eq i16* %97, null
+  br i1 %NullCheck105, label %ThrowNullRef106, label %99
 
 ; <label>:99                                      ; preds = %94
   store i16 %98, i16* %97, align 8
@@ -848,14 +930,14 @@ entry:
   %101 = load i8*, i8** %arg0
   %102 = load i8*, i8** %arg1
   %103 = bitcast i8* %102 to i32*
-  %NullCheck88 = icmp ne i32* %103, null
-  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+  %NullCheck87 = icmp eq i32* %103, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %104
 
 ; <label>:104                                     ; preds = %100
   %105 = load i32, i32* %103, align 8
   %106 = bitcast i8* %101 to i32*
-  %NullCheck90 = icmp ne i32* %106, null
-  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+  %NullCheck89 = icmp eq i32* %106, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %107
 
 ; <label>:107                                     ; preds = %104
   store i32 %105, i32* %106, align 8
@@ -864,16 +946,16 @@ entry:
   %110 = load i8*, i8** %arg1
   %111 = getelementptr inbounds i8, i8* %110, i64 4
   %112 = bitcast i8* %111 to i16*
-  %NullCheck92 = icmp ne i16* %112, null
-  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+  %NullCheck91 = icmp eq i16* %112, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %113
 
 ; <label>:113                                     ; preds = %107
   %114 = load i16, i16* %112, align 8
   %115 = sext i16 %114 to i32
   %116 = bitcast i8* %109 to i16*
   %117 = trunc i32 %115 to i16
-  %NullCheck94 = icmp ne i16* %116, null
-  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+  %NullCheck93 = icmp eq i16* %116, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %118
 
 ; <label>:118                                     ; preds = %113
   store i16 %117, i16* %116, align 8
@@ -881,15 +963,15 @@ entry:
   %120 = getelementptr inbounds i8, i8* %119, i64 6
   %121 = load i8*, i8** %arg1
   %122 = getelementptr inbounds i8, i8* %121, i64 6
-  %NullCheck96 = icmp ne i8* %122, null
-  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+  %NullCheck95 = icmp eq i8* %122, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %123
 
 ; <label>:123                                     ; preds = %118
   %124 = load i8, i8* %122, align 8
   %125 = zext i8 %124 to i32
   %126 = trunc i32 %125 to i8
-  %NullCheck98 = icmp ne i8* %120, null
-  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+  %NullCheck97 = icmp eq i8* %120, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %127
 
 ; <label>:127                                     ; preds = %123
   store i8 %126, i8* %120, align 8
@@ -899,14 +981,14 @@ entry:
   %129 = load i8*, i8** %arg0
   %130 = load i8*, i8** %arg1
   %131 = bitcast i8* %130 to i64*
-  %NullCheck84 = icmp ne i64* %131, null
-  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+  %NullCheck83 = icmp eq i64* %131, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %132
 
 ; <label>:132                                     ; preds = %128
   %133 = load i64, i64* %131, align 8
   %134 = bitcast i8* %129 to i64*
-  %NullCheck86 = icmp ne i64* %134, null
-  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+  %NullCheck85 = icmp eq i64* %134, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %135
 
 ; <label>:135                                     ; preds = %132
   store i64 %133, i64* %134, align 8
@@ -916,14 +998,14 @@ entry:
   %137 = load i8*, i8** %arg0
   %138 = load i8*, i8** %arg1
   %139 = bitcast i8* %138 to i64*
-  %NullCheck76 = icmp ne i64* %139, null
-  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+  %NullCheck75 = icmp eq i64* %139, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %140
 
 ; <label>:140                                     ; preds = %136
   %141 = load i64, i64* %139, align 8
   %142 = bitcast i8* %137 to i64*
-  %NullCheck78 = icmp ne i64* %142, null
-  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+  %NullCheck77 = icmp eq i64* %142, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %143
 
 ; <label>:143                                     ; preds = %140
   store i64 %141, i64* %142, align 8
@@ -931,15 +1013,15 @@ entry:
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %NullCheck80 = icmp ne i8* %147, null
-  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+  %NullCheck79 = icmp eq i8* %147, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %148
 
 ; <label>:148                                     ; preds = %143
   %149 = load i8, i8* %147, align 8
   %150 = zext i8 %149 to i32
   %151 = trunc i32 %150 to i8
-  %NullCheck82 = icmp ne i8* %145, null
-  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+  %NullCheck81 = icmp eq i8* %145, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %152
 
 ; <label>:152                                     ; preds = %148
   store i8 %151, i8* %145, align 8
@@ -949,14 +1031,14 @@ entry:
   %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
   %156 = bitcast i8* %155 to i64*
-  %NullCheck68 = icmp ne i64* %156, null
-  br i1 %NullCheck68, label %157, label %ThrowNullRef67
+  %NullCheck67 = icmp eq i64* %156, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %157
 
 ; <label>:157                                     ; preds = %153
   %158 = load i64, i64* %156, align 8
   %159 = bitcast i8* %154 to i64*
-  %NullCheck70 = icmp ne i64* %159, null
-  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+  %NullCheck69 = icmp eq i64* %159, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %160
 
 ; <label>:160                                     ; preds = %157
   store i64 %158, i64* %159, align 8
@@ -965,16 +1047,16 @@ entry:
   %163 = load i8*, i8** %arg1
   %164 = getelementptr inbounds i8, i8* %163, i64 8
   %165 = bitcast i8* %164 to i16*
-  %NullCheck72 = icmp ne i16* %165, null
-  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+  %NullCheck71 = icmp eq i16* %165, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %166
 
 ; <label>:166                                     ; preds = %160
   %167 = load i16, i16* %165, align 8
   %168 = sext i16 %167 to i32
   %169 = bitcast i8* %162 to i16*
   %170 = trunc i32 %168 to i16
-  %NullCheck74 = icmp ne i16* %169, null
-  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+  %NullCheck73 = icmp eq i16* %169, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %171
 
 ; <label>:171                                     ; preds = %166
   store i16 %170, i16* %169, align 8
@@ -984,14 +1066,14 @@ entry:
   %173 = load i8*, i8** %arg0
   %174 = load i8*, i8** %arg1
   %175 = bitcast i8* %174 to i64*
-  %NullCheck56 = icmp ne i64* %175, null
-  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+  %NullCheck55 = icmp eq i64* %175, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %176
 
 ; <label>:176                                     ; preds = %172
   %177 = load i64, i64* %175, align 8
   %178 = bitcast i8* %173 to i64*
-  %NullCheck58 = icmp ne i64* %178, null
-  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+  %NullCheck57 = icmp eq i64* %178, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %179
 
 ; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
@@ -1000,16 +1082,16 @@ entry:
   %182 = load i8*, i8** %arg1
   %183 = getelementptr inbounds i8, i8* %182, i64 8
   %184 = bitcast i8* %183 to i16*
-  %NullCheck60 = icmp ne i16* %184, null
-  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+  %NullCheck59 = icmp eq i16* %184, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %185
 
 ; <label>:185                                     ; preds = %179
   %186 = load i16, i16* %184, align 8
   %187 = sext i16 %186 to i32
   %188 = bitcast i8* %181 to i16*
   %189 = trunc i32 %187 to i16
-  %NullCheck62 = icmp ne i16* %188, null
-  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+  %NullCheck61 = icmp eq i16* %188, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %190
 
 ; <label>:190                                     ; preds = %185
   store i16 %189, i16* %188, align 8
@@ -1017,15 +1099,15 @@ entry:
   %192 = getelementptr inbounds i8, i8* %191, i64 10
   %193 = load i8*, i8** %arg1
   %194 = getelementptr inbounds i8, i8* %193, i64 10
-  %NullCheck64 = icmp ne i8* %194, null
-  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+  %NullCheck63 = icmp eq i8* %194, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %195
 
 ; <label>:195                                     ; preds = %190
   %196 = load i8, i8* %194, align 8
   %197 = zext i8 %196 to i32
   %198 = trunc i32 %197 to i8
-  %NullCheck66 = icmp ne i8* %192, null
-  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+  %NullCheck65 = icmp eq i8* %192, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %199
 
 ; <label>:199                                     ; preds = %195
   store i8 %198, i8* %192, align 8
@@ -1035,14 +1117,14 @@ entry:
   %201 = load i8*, i8** %arg0
   %202 = load i8*, i8** %arg1
   %203 = bitcast i8* %202 to i64*
-  %NullCheck48 = icmp ne i64* %203, null
-  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+  %NullCheck47 = icmp eq i64* %203, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %204
 
 ; <label>:204                                     ; preds = %200
   %205 = load i64, i64* %203, align 8
   %206 = bitcast i8* %201 to i64*
-  %NullCheck50 = icmp ne i64* %206, null
-  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+  %NullCheck49 = icmp eq i64* %206, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %207
 
 ; <label>:207                                     ; preds = %204
   store i64 %205, i64* %206, align 8
@@ -1051,14 +1133,14 @@ entry:
   %210 = load i8*, i8** %arg1
   %211 = getelementptr inbounds i8, i8* %210, i64 8
   %212 = bitcast i8* %211 to i32*
-  %NullCheck52 = icmp ne i32* %212, null
-  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+  %NullCheck51 = icmp eq i32* %212, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %213
 
 ; <label>:213                                     ; preds = %207
   %214 = load i32, i32* %212, align 8
   %215 = bitcast i8* %209 to i32*
-  %NullCheck54 = icmp ne i32* %215, null
-  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+  %NullCheck53 = icmp eq i32* %215, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %216
 
 ; <label>:216                                     ; preds = %213
   store i32 %214, i32* %215, align 8
@@ -1068,14 +1150,14 @@ entry:
   %218 = load i8*, i8** %arg0
   %219 = load i8*, i8** %arg1
   %220 = bitcast i8* %219 to i64*
-  %NullCheck36 = icmp ne i64* %220, null
-  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64* %220, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %221
 
 ; <label>:221                                     ; preds = %217
   %222 = load i64, i64* %220, align 8
   %223 = bitcast i8* %218 to i64*
-  %NullCheck38 = icmp ne i64* %223, null
-  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+  %NullCheck37 = icmp eq i64* %223, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %224
 
 ; <label>:224                                     ; preds = %221
   store i64 %222, i64* %223, align 8
@@ -1084,14 +1166,14 @@ entry:
   %227 = load i8*, i8** %arg1
   %228 = getelementptr inbounds i8, i8* %227, i64 8
   %229 = bitcast i8* %228 to i32*
-  %NullCheck40 = icmp ne i32* %229, null
-  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i32* %229, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %230
 
 ; <label>:230                                     ; preds = %224
   %231 = load i32, i32* %229, align 8
   %232 = bitcast i8* %226 to i32*
-  %NullCheck42 = icmp ne i32* %232, null
-  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+  %NullCheck41 = icmp eq i32* %232, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %233
 
 ; <label>:233                                     ; preds = %230
   store i32 %231, i32* %232, align 8
@@ -1099,15 +1181,15 @@ entry:
   %235 = getelementptr inbounds i8, i8* %234, i64 12
   %236 = load i8*, i8** %arg1
   %237 = getelementptr inbounds i8, i8* %236, i64 12
-  %NullCheck44 = icmp ne i8* %237, null
-  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i8* %237, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %238
 
 ; <label>:238                                     ; preds = %233
   %239 = load i8, i8* %237, align 8
   %240 = zext i8 %239 to i32
   %241 = trunc i32 %240 to i8
-  %NullCheck46 = icmp ne i8* %235, null
-  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+  %NullCheck45 = icmp eq i8* %235, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %242
 
 ; <label>:242                                     ; preds = %238
   store i8 %241, i8* %235, align 8
@@ -1117,14 +1199,14 @@ entry:
   %244 = load i8*, i8** %arg0
   %245 = load i8*, i8** %arg1
   %246 = bitcast i8* %245 to i64*
-  %NullCheck24 = icmp ne i64* %246, null
-  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64* %246, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %247
 
 ; <label>:247                                     ; preds = %243
   %248 = load i64, i64* %246, align 8
   %249 = bitcast i8* %244 to i64*
-  %NullCheck26 = icmp ne i64* %249, null
-  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64* %249, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %250
 
 ; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
@@ -1133,14 +1215,14 @@ entry:
   %253 = load i8*, i8** %arg1
   %254 = getelementptr inbounds i8, i8* %253, i64 8
   %255 = bitcast i8* %254 to i32*
-  %NullCheck28 = icmp ne i32* %255, null
-  br i1 %NullCheck28, label %256, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i32* %255, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %256
 
 ; <label>:256                                     ; preds = %250
   %257 = load i32, i32* %255, align 8
   %258 = bitcast i8* %252 to i32*
-  %NullCheck30 = icmp ne i32* %258, null
-  br i1 %NullCheck30, label %259, label %ThrowNullRef29
+  %NullCheck29 = icmp eq i32* %258, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %259
 
 ; <label>:259                                     ; preds = %256
   store i32 %257, i32* %258, align 8
@@ -1149,16 +1231,16 @@ entry:
   %262 = load i8*, i8** %arg1
   %263 = getelementptr inbounds i8, i8* %262, i64 12
   %264 = bitcast i8* %263 to i16*
-  %NullCheck32 = icmp ne i16* %264, null
-  br i1 %NullCheck32, label %265, label %ThrowNullRef31
+  %NullCheck31 = icmp eq i16* %264, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %265
 
 ; <label>:265                                     ; preds = %259
   %266 = load i16, i16* %264, align 8
   %267 = sext i16 %266 to i32
   %268 = bitcast i8* %261 to i16*
   %269 = trunc i32 %267 to i16
-  %NullCheck34 = icmp ne i16* %268, null
-  br i1 %NullCheck34, label %270, label %ThrowNullRef33
+  %NullCheck33 = icmp eq i16* %268, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %270
 
 ; <label>:270                                     ; preds = %265
   store i16 %269, i16* %268, align 8
@@ -1168,14 +1250,14 @@ entry:
   %272 = load i8*, i8** %arg0
   %273 = load i8*, i8** %arg1
   %274 = bitcast i8* %273 to i64*
-  %NullCheck8 = icmp ne i64* %274, null
-  br i1 %NullCheck8, label %275, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64* %274, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %275
 
 ; <label>:275                                     ; preds = %271
   %276 = load i64, i64* %274, align 8
   %277 = bitcast i8* %272 to i64*
-  %NullCheck10 = icmp ne i64* %277, null
-  br i1 %NullCheck10, label %278, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %277, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %278
 
 ; <label>:278                                     ; preds = %275
   store i64 %276, i64* %277, align 8
@@ -1184,14 +1266,14 @@ entry:
   %281 = load i8*, i8** %arg1
   %282 = getelementptr inbounds i8, i8* %281, i64 8
   %283 = bitcast i8* %282 to i32*
-  %NullCheck12 = icmp ne i32* %283, null
-  br i1 %NullCheck12, label %284, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i32* %283, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %284
 
 ; <label>:284                                     ; preds = %278
   %285 = load i32, i32* %283, align 8
   %286 = bitcast i8* %280 to i32*
-  %NullCheck14 = icmp ne i32* %286, null
-  br i1 %NullCheck14, label %287, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i32* %286, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %287
 
 ; <label>:287                                     ; preds = %284
   store i32 %285, i32* %286, align 8
@@ -1200,16 +1282,16 @@ entry:
   %290 = load i8*, i8** %arg1
   %291 = getelementptr inbounds i8, i8* %290, i64 12
   %292 = bitcast i8* %291 to i16*
-  %NullCheck16 = icmp ne i16* %292, null
-  br i1 %NullCheck16, label %293, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i16* %292, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %293
 
 ; <label>:293                                     ; preds = %287
   %294 = load i16, i16* %292, align 8
   %295 = sext i16 %294 to i32
   %296 = bitcast i8* %289 to i16*
   %297 = trunc i32 %295 to i16
-  %NullCheck18 = icmp ne i16* %296, null
-  br i1 %NullCheck18, label %298, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i16* %296, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %298
 
 ; <label>:298                                     ; preds = %293
   store i16 %297, i16* %296, align 8
@@ -1217,15 +1299,15 @@ entry:
   %300 = getelementptr inbounds i8, i8* %299, i64 14
   %301 = load i8*, i8** %arg1
   %302 = getelementptr inbounds i8, i8* %301, i64 14
-  %NullCheck20 = icmp ne i8* %302, null
-  br i1 %NullCheck20, label %303, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i8* %302, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %303
 
 ; <label>:303                                     ; preds = %298
   %304 = load i8, i8* %302, align 8
   %305 = zext i8 %304 to i32
   %306 = trunc i32 %305 to i8
-  %NullCheck22 = icmp ne i8* %300, null
-  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i8* %300, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %307
 
 ; <label>:307                                     ; preds = %303
   store i8 %306, i8* %300, align 8
@@ -1235,14 +1317,14 @@ entry:
   %309 = load i8*, i8** %arg0
   %310 = load i8*, i8** %arg1
   %311 = bitcast i8* %310 to i64*
-  %NullCheck = icmp ne i64* %311, null
-  br i1 %NullCheck, label %312, label %ThrowNullRef
+  %NullCheck = icmp eq i64* %311, null
+  br i1 %NullCheck, label %ThrowNullRef, label %312
 
 ; <label>:312                                     ; preds = %308
   %313 = load i64, i64* %311, align 8
   %314 = bitcast i8* %309 to i64*
-  %NullCheck2 = icmp ne i64* %314, null
-  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64* %314, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %315
 
 ; <label>:315                                     ; preds = %312
   store i64 %313, i64* %314, align 8
@@ -1251,14 +1333,14 @@ entry:
   %318 = load i8*, i8** %arg1
   %319 = getelementptr inbounds i8, i8* %318, i64 8
   %320 = bitcast i8* %319 to i64*
-  %NullCheck4 = icmp ne i64* %320, null
-  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64* %320, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %321
 
 ; <label>:321                                     ; preds = %315
   %322 = load i64, i64* %320, align 8
   %323 = bitcast i8* %317 to i64*
-  %NullCheck6 = icmp ne i64* %323, null
-  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64* %323, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %324
 
 ; <label>:324                                     ; preds = %321
   store i64 %322, i64* %323, align 8
@@ -1286,15 +1368,15 @@ entry:
 ; <label>:338                                     ; preds = %333
   %339 = load i8*, i8** %arg0
   %340 = load i8*, i8** %arg1
-  %NullCheck136 = icmp ne i8* %340, null
-  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+  %NullCheck135 = icmp eq i8* %340, null
+  br i1 %NullCheck135, label %ThrowNullRef136, label %341
 
 ; <label>:341                                     ; preds = %338
   %342 = load i8, i8* %340, align 8
   %343 = zext i8 %342 to i32
   %344 = trunc i32 %343 to i8
-  %NullCheck138 = icmp ne i8* %339, null
-  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+  %NullCheck137 = icmp eq i8* %339, null
+  br i1 %NullCheck137, label %ThrowNullRef138, label %345
 
 ; <label>:345                                     ; preds = %341
   store i8 %344, i8* %339, align 8
@@ -1317,16 +1399,16 @@ entry:
   %357 = load i8*, i8** %arg0
   %358 = load i8*, i8** %arg1
   %359 = bitcast i8* %358 to i16*
-  %NullCheck140 = icmp ne i16* %359, null
-  br i1 %NullCheck140, label %360, label %ThrowNullRef139
+  %NullCheck139 = icmp eq i16* %359, null
+  br i1 %NullCheck139, label %ThrowNullRef140, label %360
 
 ; <label>:360                                     ; preds = %356
   %361 = load i16, i16* %359, align 8
   %362 = sext i16 %361 to i32
   %363 = bitcast i8* %357 to i16*
   %364 = trunc i32 %362 to i16
-  %NullCheck142 = icmp ne i16* %363, null
-  br i1 %NullCheck142, label %365, label %ThrowNullRef141
+  %NullCheck141 = icmp eq i16* %363, null
+  br i1 %NullCheck141, label %ThrowNullRef142, label %365
 
 ; <label>:365                                     ; preds = %360
   store i16 %364, i16* %363, align 8
@@ -1352,14 +1434,14 @@ entry:
   %378 = load i8*, i8** %arg0
   %379 = load i8*, i8** %arg1
   %380 = bitcast i8* %379 to i32*
-  %NullCheck144 = icmp ne i32* %380, null
-  br i1 %NullCheck144, label %381, label %ThrowNullRef143
+  %NullCheck143 = icmp eq i32* %380, null
+  br i1 %NullCheck143, label %ThrowNullRef144, label %381
 
 ; <label>:381                                     ; preds = %377
   %382 = load i32, i32* %380, align 8
   %383 = bitcast i8* %378 to i32*
-  %NullCheck146 = icmp ne i32* %383, null
-  br i1 %NullCheck146, label %384, label %ThrowNullRef145
+  %NullCheck145 = icmp eq i32* %383, null
+  br i1 %NullCheck145, label %ThrowNullRef146, label %384
 
 ; <label>:384                                     ; preds = %381
   store i32 %382, i32* %383, align 8
@@ -1384,14 +1466,14 @@ entry:
   %395 = load i8*, i8** %arg0
   %396 = load i8*, i8** %arg1
   %397 = bitcast i8* %396 to i64*
-  %NullCheck164 = icmp ne i64* %397, null
-  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+  %NullCheck163 = icmp eq i64* %397, null
+  br i1 %NullCheck163, label %ThrowNullRef164, label %398
 
 ; <label>:398                                     ; preds = %394
   %399 = load i64, i64* %397, align 8
   %400 = bitcast i8* %395 to i64*
-  %NullCheck166 = icmp ne i64* %400, null
-  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+  %NullCheck165 = icmp eq i64* %400, null
+  br i1 %NullCheck165, label %ThrowNullRef166, label %401
 
 ; <label>:401                                     ; preds = %398
   store i64 %399, i64* %400, align 8
@@ -1400,14 +1482,14 @@ entry:
   %404 = load i8*, i8** %arg1
   %405 = getelementptr inbounds i8, i8* %404, i64 8
   %406 = bitcast i8* %405 to i64*
-  %NullCheck168 = icmp ne i64* %406, null
-  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+  %NullCheck167 = icmp eq i64* %406, null
+  br i1 %NullCheck167, label %ThrowNullRef168, label %407
 
 ; <label>:407                                     ; preds = %401
   %408 = load i64, i64* %406, align 8
   %409 = bitcast i8* %403 to i64*
-  %NullCheck170 = icmp ne i64* %409, null
-  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+  %NullCheck169 = icmp eq i64* %409, null
+  br i1 %NullCheck169, label %ThrowNullRef170, label %410
 
 ; <label>:410                                     ; preds = %407
   store i64 %408, i64* %409, align 8
@@ -1437,14 +1519,14 @@ entry:
   %425 = load i8*, i8** %arg0
   %426 = load i8*, i8** %arg1
   %427 = bitcast i8* %426 to i64*
-  %NullCheck148 = icmp ne i64* %427, null
-  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+  %NullCheck147 = icmp eq i64* %427, null
+  br i1 %NullCheck147, label %ThrowNullRef148, label %428
 
 ; <label>:428                                     ; preds = %424
   %429 = load i64, i64* %427, align 8
   %430 = bitcast i8* %425 to i64*
-  %NullCheck150 = icmp ne i64* %430, null
-  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+  %NullCheck149 = icmp eq i64* %430, null
+  br i1 %NullCheck149, label %ThrowNullRef150, label %431
 
 ; <label>:431                                     ; preds = %428
   store i64 %429, i64* %430, align 8
@@ -1466,14 +1548,14 @@ entry:
   %441 = load i8*, i8** %arg0
   %442 = load i8*, i8** %arg1
   %443 = bitcast i8* %442 to i32*
-  %NullCheck152 = icmp ne i32* %443, null
-  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+  %NullCheck151 = icmp eq i32* %443, null
+  br i1 %NullCheck151, label %ThrowNullRef152, label %444
 
 ; <label>:444                                     ; preds = %440
   %445 = load i32, i32* %443, align 8
   %446 = bitcast i8* %441 to i32*
-  %NullCheck154 = icmp ne i32* %446, null
-  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+  %NullCheck153 = icmp eq i32* %446, null
+  br i1 %NullCheck153, label %ThrowNullRef154, label %447
 
 ; <label>:447                                     ; preds = %444
   store i32 %445, i32* %446, align 8
@@ -1495,16 +1577,16 @@ entry:
   %457 = load i8*, i8** %arg0
   %458 = load i8*, i8** %arg1
   %459 = bitcast i8* %458 to i16*
-  %NullCheck156 = icmp ne i16* %459, null
-  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+  %NullCheck155 = icmp eq i16* %459, null
+  br i1 %NullCheck155, label %ThrowNullRef156, label %460
 
 ; <label>:460                                     ; preds = %456
   %461 = load i16, i16* %459, align 8
   %462 = sext i16 %461 to i32
   %463 = bitcast i8* %457 to i16*
   %464 = trunc i32 %462 to i16
-  %NullCheck158 = icmp ne i16* %463, null
-  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+  %NullCheck157 = icmp eq i16* %463, null
+  br i1 %NullCheck157, label %ThrowNullRef158, label %465
 
 ; <label>:465                                     ; preds = %460
   store i16 %464, i16* %463, align 8
@@ -1525,15 +1607,15 @@ entry:
 ; <label>:474                                     ; preds = %470
   %475 = load i8*, i8** %arg0
   %476 = load i8*, i8** %arg1
-  %NullCheck160 = icmp ne i8* %476, null
-  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+  %NullCheck159 = icmp eq i8* %476, null
+  br i1 %NullCheck159, label %ThrowNullRef160, label %477
 
 ; <label>:477                                     ; preds = %474
   %478 = load i8, i8* %476, align 8
   %479 = zext i8 %478 to i32
   %480 = trunc i32 %479 to i8
-  %NullCheck162 = icmp ne i8* %475, null
-  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+  %NullCheck161 = icmp eq i8* %475, null
+  br i1 %NullCheck161, label %ThrowNullRef162, label %481
 
 ; <label>:481                                     ; preds = %477
   store i8 %480, i8* %475, align 8
@@ -1553,343 +1635,343 @@ ThrowNullRef:                                     ; preds = %308
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %312
+ThrowNullRef2:                                    ; preds = %312
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %315
+ThrowNullRef4:                                    ; preds = %315
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %321
+ThrowNullRef6:                                    ; preds = %321
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %271
+ThrowNullRef8:                                    ; preds = %271
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %275
+ThrowNullRef10:                                   ; preds = %275
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %278
+ThrowNullRef12:                                   ; preds = %278
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %284
+ThrowNullRef14:                                   ; preds = %284
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %287
+ThrowNullRef16:                                   ; preds = %287
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %293
+ThrowNullRef18:                                   ; preds = %293
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %298
+ThrowNullRef20:                                   ; preds = %298
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %303
+ThrowNullRef22:                                   ; preds = %303
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %243
+ThrowNullRef24:                                   ; preds = %243
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %247
+ThrowNullRef26:                                   ; preds = %247
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %250
+ThrowNullRef28:                                   ; preds = %250
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %256
+ThrowNullRef30:                                   ; preds = %256
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %259
+ThrowNullRef32:                                   ; preds = %259
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %265
+ThrowNullRef34:                                   ; preds = %265
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %217
+ThrowNullRef36:                                   ; preds = %217
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %221
+ThrowNullRef38:                                   ; preds = %221
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %224
+ThrowNullRef40:                                   ; preds = %224
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %230
+ThrowNullRef42:                                   ; preds = %230
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %233
+ThrowNullRef44:                                   ; preds = %233
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %238
+ThrowNullRef46:                                   ; preds = %238
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %200
+ThrowNullRef48:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %204
+ThrowNullRef50:                                   ; preds = %204
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %207
+ThrowNullRef52:                                   ; preds = %207
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %213
+ThrowNullRef54:                                   ; preds = %213
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %172
+ThrowNullRef56:                                   ; preds = %172
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %176
+ThrowNullRef58:                                   ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %179
+ThrowNullRef60:                                   ; preds = %179
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %185
+ThrowNullRef62:                                   ; preds = %185
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %190
+ThrowNullRef64:                                   ; preds = %190
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %195
+ThrowNullRef66:                                   ; preds = %195
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %153
+ThrowNullRef68:                                   ; preds = %153
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %157
+ThrowNullRef70:                                   ; preds = %157
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %160
+ThrowNullRef72:                                   ; preds = %160
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %166
+ThrowNullRef74:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %136
+ThrowNullRef76:                                   ; preds = %136
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %140
+ThrowNullRef78:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %143
+ThrowNullRef80:                                   ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %148
+ThrowNullRef82:                                   ; preds = %148
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %128
+ThrowNullRef84:                                   ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %132
+ThrowNullRef86:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %100
+ThrowNullRef88:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %104
+ThrowNullRef90:                                   ; preds = %104
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %107
+ThrowNullRef92:                                   ; preds = %107
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %113
+ThrowNullRef94:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %118
+ThrowNullRef96:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %123
+ThrowNullRef98:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %81
+ThrowNullRef100:                                  ; preds = %81
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef101:                                  ; preds = %85
+ThrowNullRef102:                                  ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef103:                                  ; preds = %88
+ThrowNullRef104:                                  ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef105:                                  ; preds = %94
+ThrowNullRef106:                                  ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef107:                                  ; preds = %64
+ThrowNullRef108:                                  ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef109:                                  ; preds = %68
+ThrowNullRef110:                                  ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef111:                                  ; preds = %71
+ThrowNullRef112:                                  ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef113:                                  ; preds = %76
+ThrowNullRef114:                                  ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef115:                                  ; preds = %56
+ThrowNullRef116:                                  ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef117:                                  ; preds = %60
+ThrowNullRef118:                                  ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef119:                                  ; preds = %37
+ThrowNullRef120:                                  ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef121:                                  ; preds = %41
+ThrowNullRef122:                                  ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef123:                                  ; preds = %46
+ThrowNullRef124:                                  ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef125:                                  ; preds = %51
+ThrowNullRef126:                                  ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef127:                                  ; preds = %27
+ThrowNullRef128:                                  ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef129:                                  ; preds = %31
+ThrowNullRef130:                                  ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef131:                                  ; preds = %19
+ThrowNullRef132:                                  ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef133:                                  ; preds = %22
+ThrowNullRef134:                                  ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef135:                                  ; preds = %338
+ThrowNullRef136:                                  ; preds = %338
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef137:                                  ; preds = %341
+ThrowNullRef138:                                  ; preds = %341
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef139:                                  ; preds = %356
+ThrowNullRef140:                                  ; preds = %356
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef141:                                  ; preds = %360
+ThrowNullRef142:                                  ; preds = %360
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef143:                                  ; preds = %377
+ThrowNullRef144:                                  ; preds = %377
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef145:                                  ; preds = %381
+ThrowNullRef146:                                  ; preds = %381
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef147:                                  ; preds = %424
+ThrowNullRef148:                                  ; preds = %424
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef149:                                  ; preds = %428
+ThrowNullRef150:                                  ; preds = %428
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef151:                                  ; preds = %440
+ThrowNullRef152:                                  ; preds = %440
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef153:                                  ; preds = %444
+ThrowNullRef154:                                  ; preds = %444
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef155:                                  ; preds = %456
+ThrowNullRef156:                                  ; preds = %456
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef157:                                  ; preds = %460
+ThrowNullRef158:                                  ; preds = %460
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef159:                                  ; preds = %474
+ThrowNullRef160:                                  ; preds = %474
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef161:                                  ; preds = %477
+ThrowNullRef162:                                  ; preds = %477
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef163:                                  ; preds = %394
+ThrowNullRef164:                                  ; preds = %394
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef165:                                  ; preds = %398
+ThrowNullRef166:                                  ; preds = %398
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef167:                                  ; preds = %401
+ThrowNullRef168:                                  ; preds = %401
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef169:                                  ; preds = %407
+ThrowNullRef170:                                  ; preds = %407
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1939,8 +2021,8 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
-  br i1 %NullCheck, label %22, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %ThrowNullRef, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
@@ -1948,8 +2030,8 @@ entry:
   store i32 %24, i32* %loc0
   %25 = load i32, i32* %loc0
   %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %26, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %27
 
 ; <label>:27                                      ; preds = %22
   %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
@@ -1971,7 +2053,7 @@ ThrowNullRef:                                     ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1989,8 +2071,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -2022,15 +2104,15 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2048,16 +2130,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
   %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
   store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %15
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
@@ -2072,8 +2154,8 @@ entry:
   %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
   %29 = ptrtoint i16 addrspace(1)* %28 to i64
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %19
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
@@ -2089,19 +2171,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2114,8 +2196,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
@@ -2128,7 +2210,7 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[loadElem]
+Failed to read AppDomain.PrepareDataForSetup[storeElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
@@ -2202,8 +2284,8 @@ entry:
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
-  br i1 %NullCheck24, label %27, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = load i64, i64 addrspace(1)* %26
@@ -2218,8 +2300,8 @@ entry:
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
-  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
   %41 = load i64, i64 addrspace(1)* %39
@@ -2236,8 +2318,8 @@ entry:
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
-  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
   %54 = load i64, i64 addrspace(1)* %52
@@ -2252,8 +2334,8 @@ entry:
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
   %67 = load i64, i64 addrspace(1)* %65
@@ -2270,8 +2352,8 @@ entry:
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
-  br i1 %NullCheck16, label %79, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
   %80 = load i64, i64 addrspace(1)* %78
@@ -2286,8 +2368,8 @@ entry:
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
-  br i1 %NullCheck18, label %92, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
   %93 = load i64, i64 addrspace(1)* %91
@@ -2304,8 +2386,8 @@ entry:
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
-  br i1 %NullCheck12, label %105, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = load i64, i64 addrspace(1)* %104
@@ -2320,8 +2402,8 @@ entry:
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
-  br i1 %NullCheck14, label %118, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
   %119 = load i64, i64 addrspace(1)* %117
@@ -2337,8 +2419,8 @@ entry:
 
 ; <label>:128                                     ; preds = %20
   %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
-  br i1 %NullCheck4, label %130, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %129, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %130
 
 ; <label>:130                                     ; preds = %128
   %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
@@ -2346,8 +2428,8 @@ entry:
   %133 = load i16, i16 addrspace(1)* %132, align 8
   %134 = zext i16 %133 to i32
   %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
-  br i1 %NullCheck6, label %136, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %135, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %136
 
 ; <label>:136                                     ; preds = %130
   %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
@@ -2360,8 +2442,8 @@ entry:
 
 ; <label>:143                                     ; preds = %136
   %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
-  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %144, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %145
 
 ; <label>:145                                     ; preds = %143
   %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
@@ -2369,8 +2451,8 @@ entry:
   %148 = load i16, i16 addrspace(1)* %147, align 8
   %149 = zext i16 %148 to i32
   %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %150, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %151
 
 ; <label>:151                                     ; preds = %145
   %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
@@ -2388,8 +2470,8 @@ entry:
 
 ; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
-  br i1 %NullCheck, label %163, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %ThrowNullRef, label %163
 
 ; <label>:163                                     ; preds = %161
   %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
@@ -2399,8 +2481,8 @@ entry:
 
 ; <label>:167                                     ; preds = %163
   %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
-  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %168, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %169
 
 ; <label>:169                                     ; preds = %167
   %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
@@ -2432,55 +2514,55 @@ ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %167
+ThrowNullRef2:                                    ; preds = %167
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %128
+ThrowNullRef4:                                    ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %130
+ThrowNullRef6:                                    ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %143
+ThrowNullRef8:                                    ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %145
+ThrowNullRef10:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %102
+ThrowNullRef12:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %105
+ThrowNullRef14:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %76
+ThrowNullRef16:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %79
+ThrowNullRef18:                                   ; preds = %79
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %50
+ThrowNullRef20:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %53
+ThrowNullRef22:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %24
+ThrowNullRef24:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %27
+ThrowNullRef26:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2503,15 +2585,15 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2519,16 +2601,16 @@ entry:
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
   store i32 %8, i32* %loc0
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
   %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
   store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
@@ -2546,16 +2628,16 @@ entry:
 
 ; <label>:23                                      ; preds = %64
   %24 = load i16*, i16** %loc3
-  %NullCheck12 = icmp ne i16* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i16* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
   store i32 %27, i32* %loc5
   %28 = load i16*, i16** %loc4
-  %NullCheck14 = icmp ne i16* %28, null
-  br i1 %NullCheck14, label %29, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %28, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = load i16, i16* %28, align 8
@@ -2620,15 +2702,15 @@ entry:
 
 ; <label>:67                                      ; preds = %64
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
-  br i1 %NullCheck8, label %69, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %68, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %69
 
 ; <label>:69                                      ; preds = %67
   %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
   %71 = load i32, i32 addrspace(1)* %70
   %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
-  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %73
 
 ; <label>:73                                      ; preds = %69
   %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
@@ -2645,31 +2727,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %67
+ThrowNullRef8:                                    ; preds = %67
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %69
+ThrowNullRef10:                                   ; preds = %69
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2710,14 +2792,14 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
   %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
@@ -2730,14 +2812,14 @@ entry:
 
 ; <label>:11                                      ; preds = %4
   %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
   %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
@@ -2749,14 +2831,14 @@ entry:
 
 ; <label>:22                                      ; preds = %16
   %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
   %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
-  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
-  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
@@ -2804,23 +2886,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2836,7 +2918,280 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[loadElem]
+Successfully read RuntimeType.IsAssignableFrom
+
+define i8 @RuntimeType.IsAssignableFrom(%System.RuntimeType addrspace(1)* %param0, %System.Type addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.RuntimeType addrspace(1)*
+  %arg1 = alloca %System.Type addrspace(1)*
+  %loc0 = alloca %System.RuntimeType addrspace(1)*
+  %loc1 = alloca %"System.Type[]" addrspace(1)*
+  %loc2 = alloca i32
+  store %System.RuntimeType addrspace(1)* %param0, %System.RuntimeType addrspace(1)** %this
+  store %System.Type addrspace(1)* %param1, %System.Type addrspace(1)** %arg1
+  %0 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %1 = icmp ne %System.Type addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i8 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %5 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %6 = bitcast %System.Type addrspace(1)* %4 to %System.Object addrspace(1)*
+  %7 = bitcast %System.RuntimeType addrspace(1)* %5 to %System.Object addrspace(1)*
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %6, %System.Object addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %3
+  ret i8 1
+
+; <label>:12                                      ; preds = %3
+  %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 152
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 32
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
+  %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
+  %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
+  store %System.RuntimeType addrspace(1)* %25, %System.RuntimeType addrspace(1)** %loc0
+  %26 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %27 = icmp eq %System.RuntimeType addrspace(1)* %26, null
+  br i1 %27, label %34, label %28
+
+; <label>:28                                      ; preds = %15
+  %29 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %30 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)*)*)(%System.RuntimeType addrspace(1)* %29, %System.RuntimeType addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+; <label>:34                                      ; preds = %15
+  %35 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %36 = call %System.Reflection.Emit.TypeBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Reflection.Emit.TypeBuilder addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %35)
+  %37 = icmp eq %System.Reflection.Emit.TypeBuilder addrspace(1)* %36, null
+  br i1 %37, label %139, label %38
+
+; <label>:38                                      ; preds = %34
+  %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %42
+
+; <label>:42                                      ; preds = %38
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 152
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 40
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
+  %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
+  %53 = zext i8 %52 to i32
+  %54 = icmp eq i32 %53, 0
+  br i1 %54, label %56, label %55
+
+; <label>:55                                      ; preds = %42
+  ret i8 1
+
+; <label>:56                                      ; preds = %42
+  %57 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %58 = bitcast %System.RuntimeType addrspace(1)* %57 to %System.Type addrspace(1)*
+  %59 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %58)
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %64 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.Type addrspace(1)* %63, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = bitcast %System.RuntimeType addrspace(1)* %64 to %System.Type addrspace(1)*
+  %67 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %63, %System.Type addrspace(1)* %66)
+  %68 = zext i8 %67 to i32
+  %69 = trunc i32 %68 to i8
+  ret i8 %69
+
+; <label>:70                                      ; preds = %56
+  %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
+  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %73
+
+; <label>:73                                      ; preds = %70
+  %74 = load i64, i64 addrspace(1)* %72
+  %75 = add i64 %74, 128
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = add i64 %77, 0
+  %79 = inttoptr i64 %78 to i64*
+  %80 = load i64, i64* %79
+  %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
+  %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
+  %83 = call i8 %82(%System.Type addrspace(1)* %81)
+  %84 = zext i8 %83 to i32
+  %85 = icmp eq i32 %84, 0
+  br i1 %85, label %139, label %86
+
+; <label>:86                                      ; preds = %73
+  %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
+  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %89
+
+; <label>:89                                      ; preds = %86
+  %90 = load i64, i64 addrspace(1)* %88
+  %91 = add i64 %90, 128
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = add i64 %93, 24
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
+  %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
+  %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
+  store %"System.Type[]" addrspace(1)* %99, %"System.Type[]" addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %129
+
+; <label>:100                                     ; preds = %132
+  %101 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %102 = load i32, i32* %loc2
+  %NullCheck11 = icmp eq %"System.Type[]" addrspace(1)* %101, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %103
+
+; <label>:103                                     ; preds = %100
+  %104 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 1
+  %105 = load i32, i32 addrspace(1)* %104
+  %106 = zext i32 %105 to i64
+  %107 = zext i32 %102 to i64
+  %BoundsCheck = icmp uge i64 %107, %106
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %108
+
+; <label>:108                                     ; preds = %103
+  %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
+  %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
+  %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
+  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %113
+
+; <label>:113                                     ; preds = %108
+  %114 = load i64, i64 addrspace(1)* %112
+  %115 = add i64 %114, 152
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = add i64 %117, 56
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
+  %123 = zext i8 %122 to i32
+  %124 = icmp ne i32 %123, 0
+  br i1 %124, label %126, label %125
+
+; <label>:125                                     ; preds = %113
+  ret i8 0
+
+; <label>:126                                     ; preds = %113
+  %127 = load i32, i32* %loc2
+  %128 = add i32 %127, 1
+  store i32 %128, i32* %loc2
+  br label %129
+
+; <label>:129                                     ; preds = %89, %126
+  %130 = load i32, i32* %loc2
+  %131 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %NullCheck9 = icmp eq %"System.Type[]" addrspace(1)* %131, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %132
+
+; <label>:132                                     ; preds = %129
+  %133 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %131, i32 0, i32 1
+  %134 = load i32, i32 addrspace(1)* %133
+  %135 = zext i32 %134 to i64
+  %136 = trunc i64 %135 to i32
+  %137 = icmp slt i32 %130, %136
+  br i1 %137, label %100, label %138
+
+; <label>:138                                     ; preds = %132
+  ret i8 1
+
+; <label>:139                                     ; preds = %34, %73
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %129
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %103
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -2893,7 +3248,7 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElem]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -2904,8 +3259,8 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -2997,8 +3352,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
@@ -3059,8 +3414,8 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -3087,8 +3442,8 @@ entry:
 
 ; <label>:17                                      ; preds = %5, %11
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
@@ -3097,8 +3452,8 @@ entry:
 
 ; <label>:22                                      ; preds = %1, %11
   %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
@@ -3109,11 +3464,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %17
+ThrowNullRef2:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %22
+ThrowNullRef4:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3167,15 +3522,15 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
   %15 = load i32, i32 addrspace(1)* %14
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
@@ -3198,7 +3553,7 @@ ThrowNullRef:                                     ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef2:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3232,8 +3587,8 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
@@ -3312,8 +3667,8 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -3327,8 +3682,8 @@ entry:
 ; <label>:5                                       ; preds = %43
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %7 = load i32, i32* %loc1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck6, label %8, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
@@ -3366,8 +3721,8 @@ entry:
 ; <label>:32                                      ; preds = %21, %25
   %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
   %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
-  br i1 %NullCheck8, label %35, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = trunc i32 %34 to i16
@@ -3380,8 +3735,8 @@ entry:
 ; <label>:40                                      ; preds = %1, %35
   %41 = load i32, i32* %loc1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
-  br i1 %NullCheck2, label %43, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %42, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
@@ -3392,8 +3747,8 @@ entry:
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
   %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
-  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
   %51 = load i64, i64 addrspace(1)* %49
@@ -3412,19 +3767,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %40
+ThrowNullRef2:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %47
+ThrowNullRef4:                                    ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %5
+ThrowNullRef6:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %32
+ThrowNullRef8:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3467,8 +3822,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
@@ -3492,11 +3847,391 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(i16* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store i16* %param0, i16** %arg0
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load i32, i32* %arg3
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %42, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %37, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg2
+  %13 = load i32, i32* %arg3
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %37, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %24 = load i32, i32* %arg2
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load i16*, i16** %arg0
+  %35 = load i32, i32* %arg3
+  %36 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %36, i16* %34, i32 %35)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:37                                      ; preds = %5, %16
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %39)
+  %41 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41, %System.String addrspace(1)* %38, %System.String addrspace(1)* %40)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41) #0
+  unreachable
+
+; <label>:42                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
-Failed to read StringBuilder.ToString[loadElemA]
+Successfully read StringBuilder.ToString
+
+define %System.String addrspace(1)* @StringBuilder.ToString(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i16*
+  %loc3 = alloca %"System.Char[]" addrspace(1)*
+  %loc4 = alloca i32
+  %loc5 = alloca i32
+  %loc6 = alloca i16 addrspace(1)*
+  %loc7 = alloca %System.String addrspace(1)*
+  %loc8 = alloca %"System.Char[]" addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %0)
+  %2 = icmp ne i32 %1, 0
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %4
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %6)
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %7)
+  store %System.String addrspace(1)* %8, %System.String addrspace(1)** %loc0
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.Text.StringBuilder addrspace(1)* %9, %System.Text.StringBuilder addrspace(1)** %loc1
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  store %System.String addrspace(1)* %10, %System.String addrspace(1)** %loc7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc7
+  %12 = ptrtoint %System.String addrspace(1)* %11 to i64
+  %13 = icmp eq i64 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %5
+  %15 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %16 = sext i32 %15 to i64
+  %17 = add i64 %12, %16
+  br label %18
+
+; <label>:18                                      ; preds = %5, %14
+  %19 = phi i64 [ %12, %5 ], [ %17, %14 ]
+  %20 = inttoptr i64 %19 to i16*
+  store i16* %20, i16** %loc2
+  br label %21
+
+; <label>:21                                      ; preds = %98, %18
+  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %22, null
+  br i1 %NullCheck, label %ThrowNullRef, label %23
+
+; <label>:23                                      ; preds = %21
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 3
+  %25 = load i32, i32 addrspace(1)* %24, align 8
+  %26 = icmp sle i32 %25, 0
+  br i1 %26, label %96, label %27
+
+; <label>:27                                      ; preds = %23
+  %28 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %28, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %29
+
+; <label>:29                                      ; preds = %27
+  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %28, i32 0, i32 1
+  %31 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %30, align 8
+  store %"System.Char[]" addrspace(1)* %31, %"System.Char[]" addrspace(1)** %loc3
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %33
+
+; <label>:33                                      ; preds = %29
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  store i32 %35, i32* %loc4
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  %39 = load i32, i32 addrspace(1)* %38, align 8
+  store i32 %39, i32* %loc5
+  %40 = load i32, i32* %loc5
+  %41 = load i32, i32* %loc4
+  %42 = add i32 %40, %41
+  %43 = zext i32 %42 to i64
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %45
+
+; <label>:45                                      ; preds = %37
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = sext i32 %47 to i64
+  %49 = icmp sgt i64 %43, %48
+  br i1 %49, label %91, label %50
+
+; <label>:50                                      ; preds = %45
+  %51 = load i32, i32* %loc5
+  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %52, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %53
+
+; <label>:53                                      ; preds = %50
+  %54 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %52, i32 0, i32 1
+  %55 = load i32, i32 addrspace(1)* %54
+  %56 = zext i32 %55 to i64
+  %57 = trunc i64 %56 to i32
+  %58 = icmp ugt i32 %51, %57
+  br i1 %58, label %91, label %59
+
+; <label>:59                                      ; preds = %53
+  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  store %"System.Char[]" addrspace(1)* %60, %"System.Char[]" addrspace(1)** %loc8
+  %61 = icmp eq %"System.Char[]" addrspace(1)* %60, null
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %63, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %64
+
+; <label>:64                                      ; preds = %62
+  %65 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %63, i32 0, i32 1
+  %66 = load i32, i32 addrspace(1)* %65
+  %67 = zext i32 %66 to i64
+  %68 = trunc i64 %67 to i32
+  %69 = icmp ne i32 %68, 0
+  br i1 %69, label %71, label %70
+
+; <label>:70                                      ; preds = %59, %64
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:71                                      ; preds = %64
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %73
+
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %BoundsCheck = icmp uge i64 0, %76
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %77
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %78, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:79                                      ; preds = %70, %77
+  %80 = load i16*, i16** %loc2
+  %81 = load i32, i32* %loc4
+  %82 = sext i32 %81 to i64
+  %83 = mul i64 %82, 2
+  %84 = bitcast i16* %80 to i8*
+  %85 = getelementptr inbounds i8, i8* %84, i64 %83
+  %86 = load i16 addrspace(1)*, i16 addrspace(1)** %loc6
+  %87 = ptrtoint i16 addrspace(1)* %86 to i64
+  %88 = load i32, i32* %loc5
+  %89 = bitcast i8* %85 to i16*
+  %90 = inttoptr i64 %87 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %89, i16* %90, i32 %88)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %96
+
+; <label>:91                                      ; preds = %45, %53
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %94 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %93)
+  %95 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95, %System.String addrspace(1)* %92, %System.String addrspace(1)* %94)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95) #0
+  unreachable
+
+; <label>:96                                      ; preds = %23, %79
+  %97 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %97, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %98
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %97, i32 0, i32 2
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  store %System.Text.StringBuilder addrspace(1)* %100, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %102 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %102, label %21, label %103
+
+; <label>:103                                     ; preds = %98
+  store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc7
+  %104 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  ret %System.String addrspace(1)* %104
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method StringBuilder::get_Length using LLILCJit
+Successfully read StringBuilder.get_Length
+
+define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
+Successfully read RuntimeHelpers.get_OffsetToStringData
+
+define i32 @RuntimeHelpers.get_OffsetToStringData() {
+entry:
+  ret i32 12
+}
+
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
 Successfully read CultureData.CreateCultureData
 
@@ -3514,23 +4249,23 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
   store i8 %4, i8 addrspace(1)* %6
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
@@ -3549,11 +4284,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3566,50 +4301,50 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
   store i32 -1, i32 addrspace(1)* %2
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
   store i32 -1, i32 addrspace(1)* %8
   %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
   store i32 -1, i32 addrspace(1)* %14
   %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
   store i32 -1, i32 addrspace(1)* %17
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
@@ -3623,27 +4358,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3675,7 +4410,136 @@ Failed to read Dictionary`2.Insert[non-const derefAddress]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
 Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
-Failed to read HashHelpers.GetPrime[loadElem]
+Successfully read HashHelpers.GetPrime
+
+define i32 @HashHelpers.GetPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %6, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5, %System.String addrspace(1)* %4)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5) #0
+  unreachable
+
+; <label>:6                                       ; preds = %entry
+  store i32 0, i32* %loc0
+  br label %29
+
+; <label>:7                                       ; preds = %35
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 1296
+  %10 = addrspacecast i8 addrspace(1)* %9 to %"System.Int32[]" addrspace(1)**
+  %11 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %10
+  %12 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Int32[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = zext i32 %15 to i64
+  %17 = zext i32 %12 to i64
+  %BoundsCheck = icmp uge i64 %17, %16
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 3, i32 %12
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  store i32 %20, i32* %loc1
+  %21 = load i32, i32* %loc1
+  %22 = load i32, i32* %arg0
+  %23 = icmp slt i32 %21, %22
+  br i1 %23, label %26, label %24
+
+; <label>:24                                      ; preds = %18
+  %25 = load i32, i32* %loc1
+  ret i32 %25
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %loc0
+  %28 = add i32 %27, 1
+  store i32 %28, i32* %loc0
+  br label %29
+
+; <label>:29                                      ; preds = %6, %26
+  %30 = load i32, i32* %loc0
+  %31 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %32 = getelementptr inbounds i8, i8 addrspace(1)* %31, i64 1296
+  %33 = addrspacecast i8 addrspace(1)* %32 to %"System.Int32[]" addrspace(1)**
+  %34 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %33
+  %NullCheck = icmp eq %"System.Int32[]" addrspace(1)* %34, null
+  br i1 %NullCheck, label %ThrowNullRef, label %35
+
+; <label>:35                                      ; preds = %29
+  %36 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %34, i32 0, i32 1
+  %37 = load i32, i32 addrspace(1)* %36
+  %38 = zext i32 %37 to i64
+  %39 = trunc i64 %38 to i32
+  %40 = icmp slt i32 %30, %39
+  br i1 %40, label %7, label %41
+
+; <label>:41                                      ; preds = %35
+  %42 = load i32, i32* %arg0
+  %43 = or i32 %42, 1
+  store i32 %43, i32* %loc2
+  br label %59
+
+; <label>:44                                      ; preds = %59
+  %45 = load i32, i32* %loc2
+  %46 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %45)
+  %47 = zext i8 %46 to i32
+  %48 = icmp eq i32 %47, 0
+  br i1 %48, label %56, label %49
+
+; <label>:49                                      ; preds = %44
+  %50 = load i32, i32* %loc2
+  %51 = sub i32 %50, 1
+  %52 = srem i32 %51, 101
+  %53 = icmp eq i32 %52, 0
+  br i1 %53, label %56, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = load i32, i32* %loc2
+  ret i32 %55
+
+; <label>:56                                      ; preds = %44, %49
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %57, 2
+  store i32 %58, i32* %loc2
+  br label %59
+
+; <label>:59                                      ; preds = %41, %56
+  %60 = load i32, i32* %loc2
+  %61 = icmp slt i32 %60, 2147483647
+  br i1 %61, label %44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load i32, i32* %arg0
+  ret i32 %63
+
+ThrowNullRef:                                     ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
 Successfully read GenericEqualityComparer`1.GetHashCode
 
@@ -3694,14 +4558,14 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
   %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load i64, i64 addrspace(1)* %7
@@ -3720,7 +4584,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3750,8 +4614,8 @@ entry:
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
@@ -3796,8 +4660,8 @@ entry:
   %35 = bitcast i16* %34 to i8*
   %36 = getelementptr inbounds i8, i8* %35, i64 2
   %37 = bitcast i8* %36 to i16*
-  %NullCheck4 = icmp ne i16* %37, null
-  br i1 %NullCheck4, label %38, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %37, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %38
 
 ; <label>:38                                      ; preds = %27
   %39 = load i16, i16* %37, align 8
@@ -3824,8 +4688,8 @@ entry:
 
 ; <label>:54                                      ; preds = %22, %43
   %55 = load i16*, i16** %loc4
-  %NullCheck2 = icmp ne i16* %55, null
-  br i1 %NullCheck2, label %56, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i16* %55, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %56
 
 ; <label>:56                                      ; preds = %54
   %57 = load i16, i16* %55, align 8
@@ -3850,11 +4714,11 @@ ThrowNullRef:                                     ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %54
+ThrowNullRef2:                                    ; preds = %54
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %27
+ThrowNullRef4:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3871,8 +4735,8 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -3907,8 +4771,8 @@ entry:
 
 ; <label>:26                                      ; preds = %19
   %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
-  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %28
 
 ; <label>:28                                      ; preds = %26
   %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
@@ -3920,7 +4784,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3972,8 +4836,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
@@ -3984,26 +4848,26 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
-  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
@@ -4014,8 +4878,8 @@ entry:
 ; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
@@ -4024,8 +4888,8 @@ entry:
 
 ; <label>:25                                      ; preds = %1, %16, %23
   %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
-  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
@@ -4036,27 +4900,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %20
+ThrowNullRef10:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4069,8 +4933,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -4081,8 +4945,8 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
@@ -4091,8 +4955,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1, %8
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
@@ -4103,11 +4967,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4128,24 +4992,24 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   store i32 %3, i32* %loc0
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
   %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
   store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck4, label %9, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
@@ -4164,15 +5028,15 @@ entry:
 ; <label>:18                                      ; preds = %70
   %19 = load i16*, i16** %loc3
   %20 = bitcast i16* %19 to i64*
-  %NullCheck10 = icmp ne i64* %20, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %20, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = load i64, i64* %20, align 8
   %23 = load i16*, i16** %loc4
   %24 = bitcast i16* %23 to i64*
-  %NullCheck12 = icmp ne i64* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = load i64, i64* %24, align 8
@@ -4188,8 +5052,8 @@ entry:
   %31 = bitcast i16* %30 to i8*
   %32 = getelementptr inbounds i8, i8* %31, i64 8
   %33 = bitcast i8* %32 to i64*
-  %NullCheck14 = icmp ne i64* %33, null
-  br i1 %NullCheck14, label %34, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = load i64, i64* %33, align 8
@@ -4197,8 +5061,8 @@ entry:
   %37 = bitcast i16* %36 to i8*
   %38 = getelementptr inbounds i8, i8* %37, i64 8
   %39 = bitcast i8* %38 to i64*
-  %NullCheck16 = icmp ne i64* %39, null
-  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %40
 
 ; <label>:40                                      ; preds = %34
   %41 = load i64, i64* %39, align 8
@@ -4214,8 +5078,8 @@ entry:
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %NullCheck18 = icmp ne i64* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = load i64, i64* %48, align 8
@@ -4223,8 +5087,8 @@ entry:
   %52 = bitcast i16* %51 to i8*
   %53 = getelementptr inbounds i8, i8* %52, i64 16
   %54 = bitcast i8* %53 to i64*
-  %NullCheck20 = icmp ne i64* %54, null
-  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64* %54, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %55
 
 ; <label>:55                                      ; preds = %49
   %56 = load i64, i64* %54, align 8
@@ -4262,15 +5126,15 @@ entry:
 ; <label>:74                                      ; preds = %95
   %75 = load i16*, i16** %loc3
   %76 = bitcast i16* %75 to i32*
-  %NullCheck6 = icmp ne i32* %76, null
-  br i1 %NullCheck6, label %77, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32* %76, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %77
 
 ; <label>:77                                      ; preds = %74
   %78 = load i32, i32* %76, align 8
   %79 = load i16*, i16** %loc4
   %80 = bitcast i16* %79 to i32*
-  %NullCheck8 = icmp ne i32* %80, null
-  br i1 %NullCheck8, label %81, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i32* %80, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %81
 
 ; <label>:81                                      ; preds = %77
   %82 = load i32, i32* %80, align 8
@@ -4318,43 +5182,43 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %74
+ThrowNullRef6:                                    ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %77
+ThrowNullRef8:                                    ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %29
+ThrowNullRef14:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %34
+ThrowNullRef16:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4376,8 +5240,8 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load i64, i64 addrspace(1)* %4
@@ -4389,8 +5253,8 @@ entry:
   %12 = load i64, i64* %11
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %5
   %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
@@ -4399,8 +5263,8 @@ entry:
   %18 = load i8, i8* %arg2
   %19 = zext i8 %18 to i32
   %20 = trunc i32 %19 to i8
-  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %15
   %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
@@ -4411,11 +5275,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4442,8 +5306,8 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
@@ -4466,16 +5330,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
   %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = load i64, i64 addrspace(1)* %19
@@ -4500,8 +5364,8 @@ entry:
 ; <label>:35                                      ; preds = %30
   %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
@@ -4514,8 +5378,8 @@ entry:
 
 ; <label>:42                                      ; preds = %1, %38
   %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
-  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
@@ -4526,19 +5390,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %35
+ThrowNullRef2:                                    ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %42
+ThrowNullRef8:                                    ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4551,14 +5415,14 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
@@ -4570,7 +5434,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4583,8 +5447,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
@@ -4613,51 +5477,51 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
   %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
   %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
   %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
   %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
-  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
   store i64 %21, i64 addrspace(1)* %23
   %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %25 = load i64, i64* %loc0
-  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
@@ -4668,27 +5532,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %22
+ThrowNullRef12:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4701,8 +5565,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
@@ -4713,19 +5577,19 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
@@ -4734,8 +5598,8 @@ entry:
 
 ; <label>:15                                      ; preds = %1, %13
   %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
@@ -4746,19 +5610,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %15
+ThrowNullRef8:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4771,8 +5635,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -4831,8 +5695,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
@@ -4882,8 +5746,8 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
-  br i1 %NullCheck, label %17, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %ThrowNullRef, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
@@ -4894,15 +5758,15 @@ entry:
 
 ; <label>:22                                      ; preds = %17
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
-  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
   %26 = load i32, i32 addrspace(1)* %25
   %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
-  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %27, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
@@ -4925,8 +5789,8 @@ entry:
 ; <label>:40                                      ; preds = %17
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
-  br i1 %NullCheck6, label %43, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %41, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
@@ -4938,34 +5802,17 @@ ThrowNullRef:                                     ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %24
+ThrowNullRef4:                                    ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %40
+ThrowNullRef6:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
-}
-
-INFO:  jitting method Object::ReferenceEquals using LLILCJit
-Successfully read Object.ReferenceEquals
-
-define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
-entry:
-  %arg0 = alloca %System.Object addrspace(1)*
-  %arg1 = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
-  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
-  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = icmp eq %System.Object addrspace(1)* %0, %1
-  %3 = sext i1 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
 }
 
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
@@ -4978,21 +5825,21 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
   %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
-  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
@@ -5007,28 +5854,28 @@ entry:
 ; <label>:13                                      ; preds = %8, %12
   %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
   %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
   %21 = load i32, i32 addrspace(1)* %20, align 8
   %22 = add i32 %21, 1
-  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
   store i32 %22, i32 addrspace(1)* %24
   %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
@@ -5039,27 +5886,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5077,7 +5924,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::Setup using LLILCJit
-Failed to read AppDomain.Setup[loadElem]
+Failed to read AppDomain.Setup[unbox]
 INFO:  jitting method Thread::GetDomain using LLILCJit
 Successfully read Thread.GetDomain
 
@@ -5108,8 +5955,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
@@ -5122,14 +5969,14 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
   %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
@@ -5141,11 +5988,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5173,8 +6020,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -5189,7 +6036,328 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
 Failed to read KeyCollection.System.Collections.Generic.IEnumerable<TKey>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Successfully read Enumerator.MoveNext
+
+define i8 @Enumerator.MoveNext(%"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.RuntimeTypeHandle* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*
+  %"$TypeArg" = alloca %System.RuntimeTypeHandle*
+  store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
+  %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 8
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %76, label %12
+
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
+  br label %76
+
+; <label>:13                                      ; preds = %85
+  %14 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck19 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %15
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, i32 0, i32 0
+  %17 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %16, align 8
+  %NullCheck21 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, i32 0, i32 2
+  %20 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %19, align 8
+  %21 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck23 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %22
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, i32 0, i32 2
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %NullCheck25 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 3, i32 %24
+  %NullCheck27 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %32
+
+; <label>:32                                      ; preds = %30
+  %33 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, i32 0, i32 2
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = icmp slt i32 %34, 0
+  br i1 %35, label %68, label %36
+
+; <label>:36                                      ; preds = %32
+  %37 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %38 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck29 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %39
+
+; <label>:39                                      ; preds = %36
+  %40 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, i32 0, i32 0
+  %41 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %40, align 8
+  %NullCheck31 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, i32 0, i32 2
+  %44 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %43, align 8
+  %45 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck33 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, i32 0, i32 2
+  %48 = load i32, i32 addrspace(1)* %47, align 8
+  %NullCheck35 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %49
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = zext i32 %51 to i64
+  %53 = zext i32 %48 to i64
+  %BoundsCheck37 = icmp uge i64 %53, %52
+  br i1 %BoundsCheck37, label %ThrowIndexOutOfRange38, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 3, i32 %48
+  %NullCheck39 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %56
+
+; <label>:56                                      ; preds = %54
+  %57 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, i32 0, i32 0
+  %58 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck41 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %59
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %60, %System.__Canon addrspace(1)* %58)
+  %61 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck43 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  %64 = load i32, i32 addrspace(1)* %63, align 8
+  %65 = add i32 %64, 1
+  %NullCheck45 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  store i32 %65, i32 addrspace(1)* %67
+  ret i8 1
+
+; <label>:68                                      ; preds = %32
+  %69 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck47 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %73 = add i32 %72, 1
+  %NullCheck49 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %74
+
+; <label>:74                                      ; preds = %70
+  %75 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  store i32 %73, i32 addrspace(1)* %75
+  br label %76
+
+; <label>:76                                      ; preds = %8, %12, %74
+  %77 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %78
+
+; <label>:78                                      ; preds = %76
+  %79 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, i32 0, i32 2
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck7 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %82
+
+; <label>:82                                      ; preds = %78
+  %83 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, i32 0, i32 0
+  %84 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %83, align 8
+  %NullCheck9 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %85
+
+; <label>:85                                      ; preds = %82
+  %86 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, i32 0, i32 7
+  %87 = load i32, i32 addrspace(1)* %86, align 8
+  %88 = icmp ult i32 %80, %87
+  br i1 %88, label %13, label %89
+
+; <label>:89                                      ; preds = %85
+  %90 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %91 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck11 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %92
+
+; <label>:92                                      ; preds = %89
+  %93 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, i32 0, i32 0
+  %94 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck13 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %95
+
+; <label>:95                                      ; preds = %92
+  %96 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, i32 0, i32 7
+  %97 = load i32, i32 addrspace(1)* %96, align 8
+  %98 = add i32 %97, 1
+  %NullCheck15 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %99
+
+; <label>:99                                      ; preds = %95
+  %100 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, i32 0, i32 2
+  store i32 %98, i32 addrspace(1)* %100
+  %101 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck17 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %102
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %103, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %92
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef22:                                   ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef24:                                   ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef26:                                   ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef28:                                   ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef30:                                   ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef32:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef34:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef36:                                   ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange38:                           ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef40:                                   ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef42:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef44:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef46:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef48:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef50:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -5200,8 +6368,8 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -5232,9 +6400,9 @@ Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
 Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
-Failed to read String.MakeSeparatorList[loadElemA]
+Failed to read String.MakeSeparatorList[storeElem]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
-Failed to read String.InternalSplitKeepEmptyEntries[loadElem]
+Failed to read String.InternalSplitKeepEmptyEntries[storeElem]
 INFO:  jitting method Path::IsRelative using LLILCJit
 Successfully read Path.IsRelative
 
@@ -5243,8 +6411,8 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -5254,8 +6422,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
@@ -5271,8 +6439,8 @@ entry:
 
 ; <label>:17                                      ; preds = %7
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
@@ -5288,8 +6456,8 @@ entry:
 
 ; <label>:29                                      ; preds = %19
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %31
 
 ; <label>:31                                      ; preds = %29
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
@@ -5300,8 +6468,8 @@ entry:
 
 ; <label>:36                                      ; preds = %31
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
-  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %37, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
@@ -5312,8 +6480,8 @@ entry:
 
 ; <label>:43                                      ; preds = %31, %38
   %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
-  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %45
 
 ; <label>:45                                      ; preds = %43
   %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
@@ -5324,8 +6492,8 @@ entry:
 
 ; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %50
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
@@ -5336,8 +6504,8 @@ entry:
 
 ; <label>:57                                      ; preds = %1, %7, %19, %45, %52
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
-  br i1 %NullCheck14, label %59, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %59
 
 ; <label>:59                                      ; preds = %57
   %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
@@ -5347,8 +6515,8 @@ entry:
 
 ; <label>:63                                      ; preds = %59
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
@@ -5359,8 +6527,8 @@ entry:
 
 ; <label>:70                                      ; preds = %65
   %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
-  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.String addrspace(1)* %71, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %72
 
 ; <label>:72                                      ; preds = %70
   %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
@@ -5379,39 +6547,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %17
+ThrowNullRef4:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %29
+ThrowNullRef6:                                    ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %36
+ThrowNullRef8:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %43
+ThrowNullRef10:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %50
+ThrowNullRef12:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %57
+ThrowNullRef14:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %63
+ThrowNullRef16:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %70
+ThrowNullRef18:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5419,7 +6587,293 @@ ThrowNullRef17:                                   ; preds = %70
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
-Failed to read String.TrimHelper[loadElem]
+Successfully read String.TrimHelper
+
+define %System.String addrspace(1)* @String.TrimHelper(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i16
+  %loc4 = alloca i32
+  %loc5 = alloca i16
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = sub i32 %3, 1
+  store i32 %4, i32* %loc0
+  store i32 0, i32* %loc1
+  %5 = load i32, i32* %arg2
+  %6 = icmp eq i32 %5, 1
+  br i1 %6, label %62, label %7
+
+; <label>:7                                       ; preds = %1
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:8                                       ; preds = %58
+  store i32 0, i32* %loc2
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load i32, i32* %loc1
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2, i32 %10
+  %13 = load i16, i16 addrspace(1)* %12
+  %14 = zext i16 %13 to i32
+  %15 = trunc i32 %14 to i16
+  store i16 %15, i16* %loc3
+  store i32 0, i32* %loc2
+  br label %34
+
+; <label>:16                                      ; preds = %37
+  %17 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %18 = load i32, i32* %loc2
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %17, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %19
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = zext i32 %18 to i64
+  %BoundsCheck = icmp uge i64 %23, %22
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %24
+
+; <label>:24                                      ; preds = %19
+  %25 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 3, i32 %18
+  %26 = load i16, i16 addrspace(1)* %25, align 8
+  %27 = zext i16 %26 to i32
+  %28 = load i16, i16* %loc3
+  %29 = zext i16 %28 to i32
+  %30 = icmp eq i32 %27, %29
+  br i1 %30, label %43, label %31
+
+; <label>:31                                      ; preds = %24
+  %32 = load i32, i32* %loc2
+  %33 = add i32 %32, 1
+  store i32 %33, i32* %loc2
+  br label %34
+
+; <label>:34                                      ; preds = %11, %31
+  %35 = load i32, i32* %loc2
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = icmp slt i32 %35, %41
+  br i1 %42, label %16, label %43
+
+; <label>:43                                      ; preds = %24, %37
+  %44 = load i32, i32* %loc2
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %45, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp eq i32 %44, %50
+  br i1 %51, label %62, label %52
+
+; <label>:52                                      ; preds = %46
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %7, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %57, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %58
+
+; <label>:58                                      ; preds = %55
+  %59 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %60 = load i32, i32 addrspace(1)* %59
+  %61 = icmp slt i32 %56, %60
+  br i1 %61, label %8, label %62
+
+; <label>:62                                      ; preds = %1, %46, %58
+  %63 = load i32, i32* %arg2
+  %64 = icmp eq i32 %63, 0
+  br i1 %64, label %122, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %66, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %67
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %66, i32 0, i32 1
+  %69 = load i32, i32 addrspace(1)* %68
+  %70 = sub i32 %69, 1
+  store i32 %70, i32* %loc0
+  br label %118
+
+; <label>:71                                      ; preds = %118
+  store i32 0, i32* %loc4
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %73 = load i32, i32* %loc0
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %74
+
+; <label>:74                                      ; preds = %71
+  %75 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 2, i32 %73
+  %76 = load i16, i16 addrspace(1)* %75
+  %77 = zext i16 %76 to i32
+  %78 = trunc i32 %77 to i16
+  store i16 %78, i16* %loc5
+  store i32 0, i32* %loc4
+  br label %97
+
+; <label>:79                                      ; preds = %100
+  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %81 = load i32, i32* %loc4
+  %NullCheck19 = icmp eq %"System.Char[]" addrspace(1)* %80, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
+
+; <label>:82                                      ; preds = %79
+  %83 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 1
+  %84 = load i32, i32 addrspace(1)* %83
+  %85 = zext i32 %84 to i64
+  %86 = zext i32 %81 to i64
+  %BoundsCheck21 = icmp uge i64 %86, %85
+  br i1 %BoundsCheck21, label %ThrowIndexOutOfRange22, label %87
+
+; <label>:87                                      ; preds = %82
+  %88 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 3, i32 %81
+  %89 = load i16, i16 addrspace(1)* %88, align 8
+  %90 = zext i16 %89 to i32
+  %91 = load i16, i16* %loc5
+  %92 = zext i16 %91 to i32
+  %93 = icmp eq i32 %90, %92
+  br i1 %93, label %106, label %94
+
+; <label>:94                                      ; preds = %87
+  %95 = load i32, i32* %loc4
+  %96 = add i32 %95, 1
+  store i32 %96, i32* %loc4
+  br label %97
+
+; <label>:97                                      ; preds = %74, %94
+  %98 = load i32, i32* %loc4
+  %99 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck15 = icmp eq %"System.Char[]" addrspace(1)* %99, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %100
+
+; <label>:100                                     ; preds = %97
+  %101 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %99, i32 0, i32 1
+  %102 = load i32, i32 addrspace(1)* %101
+  %103 = zext i32 %102 to i64
+  %104 = trunc i64 %103 to i32
+  %105 = icmp slt i32 %98, %104
+  br i1 %105, label %79, label %106
+
+; <label>:106                                     ; preds = %87, %100
+  %107 = load i32, i32* %loc4
+  %108 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck17 = icmp eq %"System.Char[]" addrspace(1)* %108, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %109
+
+; <label>:109                                     ; preds = %106
+  %110 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %108, i32 0, i32 1
+  %111 = load i32, i32 addrspace(1)* %110
+  %112 = zext i32 %111 to i64
+  %113 = trunc i64 %112 to i32
+  %114 = icmp eq i32 %107, %113
+  br i1 %114, label %122, label %115
+
+; <label>:115                                     ; preds = %109
+  %116 = load i32, i32* %loc0
+  %117 = sub i32 %116, 1
+  store i32 %117, i32* %loc0
+  br label %118
+
+; <label>:118                                     ; preds = %67, %115
+  %119 = load i32, i32* %loc0
+  %120 = load i32, i32* %loc1
+  %121 = icmp sge i32 %119, %120
+  br i1 %121, label %71, label %122
+
+; <label>:122                                     ; preds = %62, %109, %118
+  %123 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %124 = load i32, i32* %loc1
+  %125 = load i32, i32* %loc0
+  %126 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %123, i32 %124, i32 %125)
+  ret %System.String addrspace(1)* %126
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %97
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange22:                           ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
 Successfully read String.CreateTrimmedString
 
@@ -5439,8 +6893,8 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
@@ -5535,8 +6989,8 @@ entry:
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i64 2872
   %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
   %8 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %7
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %3
   %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
@@ -5553,8 +7007,8 @@ entry:
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 2864
   %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
   %21 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %20
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
-  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %22
 
 ; <label>:22                                      ; preds = %16
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
@@ -5569,7 +7023,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %16
+ThrowNullRef2:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5586,8 +7040,8 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5613,8 +7067,8 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
@@ -5632,8 +7086,8 @@ entry:
 
 ; <label>:12                                      ; preds = %4
   %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
@@ -5644,8 +7098,8 @@ entry:
 
 ; <label>:19                                      ; preds = %14
   %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %19
   %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
@@ -5660,21 +7114,21 @@ entry:
   %31 = zext i16 %30 to i32
   %32 = bitcast i8* %29 to i16*
   %33 = trunc i32 %31 to i16
-  %NullCheck6 = icmp ne i16* %32, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i16* %32, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %21
   store i16 %33, i16* %32, align 8
   %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %36
 
 ; <label>:36                                      ; preds = %34
   %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
   %38 = load i32, i32 addrspace(1)* %37, align 8
   %39 = add i32 %38, 1
-  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %40
 
 ; <label>:40                                      ; preds = %36
   %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
@@ -5683,16 +7137,16 @@ entry:
 
 ; <label>:42                                      ; preds = %14
   %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
-  br i1 %NullCheck12, label %44, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
   %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
   %47 = load i16, i16* %arg1
   %48 = zext i16 %47 to i32
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = trunc i32 %48 to i16
@@ -5703,31 +7157,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %19
+ThrowNullRef4:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %21
+ThrowNullRef6:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %36
+ThrowNullRef10:                                   ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %42
+ThrowNullRef12:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %44
+ThrowNullRef14:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5740,8 +7194,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -5752,8 +7206,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
@@ -5762,14 +7216,14 @@ entry:
 
 ; <label>:11                                      ; preds = %1
   %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
@@ -5779,15 +7233,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5808,8 +7262,8 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5822,8 +7276,8 @@ entry:
 
 ; <label>:8                                       ; preds = %3
   %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
@@ -5842,15 +7296,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
-  br i1 %NullCheck4, label %22, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
   %24 = load i16*, i16* addrspace(1)* %23, align 8
   %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %25, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
@@ -5859,8 +7313,8 @@ entry:
   store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
@@ -5874,8 +7328,8 @@ entry:
 
 ; <label>:37                                      ; preds = %65
   %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %37
   %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
@@ -5886,16 +7340,16 @@ entry:
   %45 = bitcast i16* %41 to i8*
   %46 = getelementptr inbounds i8, i8* %45, i64 %44
   %47 = bitcast i8* %46 to i16*
-  %NullCheck14 = icmp ne i16* %47, null
-  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %47, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %48
 
 ; <label>:48                                      ; preds = %39
   %49 = load i16, i16* %47, align 8
   %50 = zext i16 %49 to i32
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %52 = load i32, i32* %loc1
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %53
 
 ; <label>:53                                      ; preds = %48
   %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
@@ -5916,8 +7370,8 @@ entry:
 ; <label>:62                                      ; preds = %36, %59
   %63 = load i32, i32* %loc1
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck10, label %65, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %65
 
 ; <label>:65                                      ; preds = %62
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
@@ -5936,15 +7390,15 @@ entry:
 
 ; <label>:74                                      ; preds = %70
   %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
-  br i1 %NullCheck18, label %76, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %76
 
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
   %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
-  br i1 %NullCheck20, label %80, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
   %81 = load i64, i64 addrspace(1)* %79
@@ -5958,8 +7412,8 @@ entry:
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
   %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
-  br i1 %NullCheck22, label %92, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.String addrspace(1)* %90, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %92
 
 ; <label>:92                                      ; preds = %80
   %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
@@ -5969,15 +7423,15 @@ entry:
 
 ; <label>:96                                      ; preds = %70
   %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
-  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %98
 
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
   %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
-  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
   %103 = load i64, i64 addrspace(1)* %101
@@ -5991,8 +7445,8 @@ entry:
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
   %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
-  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.String addrspace(1)* %112, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %114
 
 ; <label>:114                                     ; preds = %102
   %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
@@ -6004,59 +7458,59 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %20
+ThrowNullRef4:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %22
+ThrowNullRef6:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %26
+ThrowNullRef8:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %62
+ThrowNullRef10:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %48
+ThrowNullRef16:                                   ; preds = %48
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %74
+ThrowNullRef18:                                   ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %76
+ThrowNullRef20:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %80
+ThrowNullRef22:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %96
+ThrowNullRef24:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %98
+ThrowNullRef26:                                   ; preds = %98
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %102
+ThrowNullRef28:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6069,15 +7523,15 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
   %3 = load i16*, i16* addrspace(1)* %2, align 8
   %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
@@ -6087,8 +7541,8 @@ entry:
   %10 = bitcast i16* %3 to i8*
   %11 = getelementptr inbounds i8, i8* %10, i64 %9
   %12 = bitcast i8* %11 to i16*
-  %NullCheck4 = icmp ne i16* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %5
   store i16 0, i16* %12, align 8
@@ -6098,11 +7552,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6119,8 +7573,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -6131,8 +7585,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
@@ -6144,15 +7598,15 @@ entry:
 
 ; <label>:14                                      ; preds = %1
   %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
   %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
   %21 = load i64, i64 addrspace(1)* %19
@@ -6171,15 +7625,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %14
+ThrowNullRef4:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %16
+ThrowNullRef6:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6302,14 +7756,6 @@ entry:
   ret %System.String addrspace(1)* %57
 }
 
-INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
-Successfully read RuntimeHelpers.get_OffsetToStringData
-
-define i32 @RuntimeHelpers.get_OffsetToStringData() {
-entry:
-  ret i32 12
-}
-
 INFO:  jitting method String::Equals using LLILCJit
 Successfully read String.Equals
 
@@ -6381,8 +7827,8 @@ entry:
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
-  br i1 %NullCheck24, label %29, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
   %30 = load i64, i64 addrspace(1)* %28
@@ -6397,8 +7843,8 @@ entry:
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
-  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
   %43 = load i64, i64 addrspace(1)* %41
@@ -6418,8 +7864,8 @@ entry:
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
   %59 = load i64, i64 addrspace(1)* %57
@@ -6434,8 +7880,8 @@ entry:
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck22, label %71, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
   %72 = load i64, i64 addrspace(1)* %70
@@ -6455,8 +7901,8 @@ entry:
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
-  br i1 %NullCheck16, label %87, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = load i64, i64 addrspace(1)* %86
@@ -6471,8 +7917,8 @@ entry:
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck18, label %100, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
   %101 = load i64, i64 addrspace(1)* %99
@@ -6492,8 +7938,8 @@ entry:
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
-  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
   %117 = load i64, i64 addrspace(1)* %115
@@ -6508,8 +7954,8 @@ entry:
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
-  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
   %130 = load i64, i64 addrspace(1)* %128
@@ -6528,15 +7974,15 @@ entry:
 
 ; <label>:142                                     ; preds = %22
   %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
-  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %143, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %144
 
 ; <label>:144                                     ; preds = %142
   %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
   %146 = load i32, i32 addrspace(1)* %145
   %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
-  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %147, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %148
 
 ; <label>:148                                     ; preds = %144
   %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
@@ -6557,15 +8003,15 @@ entry:
 
 ; <label>:159                                     ; preds = %22
   %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
-  br i1 %NullCheck, label %161, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %ThrowNullRef, label %161
 
 ; <label>:161                                     ; preds = %159
   %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
   %163 = load i32, i32 addrspace(1)* %162
   %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
-  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %164, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %165
 
 ; <label>:165                                     ; preds = %161
   %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
@@ -6578,8 +8024,8 @@ entry:
 
 ; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
-  br i1 %NullCheck4, label %172, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %171, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %172
 
 ; <label>:172                                     ; preds = %170
   %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
@@ -6589,8 +8035,8 @@ entry:
 
 ; <label>:176                                     ; preds = %172
   %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
-  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %177, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %178
 
 ; <label>:178                                     ; preds = %176
   %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
@@ -6629,55 +8075,55 @@ ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %161
+ThrowNullRef2:                                    ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %170
+ThrowNullRef4:                                    ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %176
+ThrowNullRef6:                                    ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %142
+ThrowNullRef8:                                    ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %144
+ThrowNullRef10:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %113
+ThrowNullRef12:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %116
+ThrowNullRef14:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %84
+ThrowNullRef16:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %87
+ThrowNullRef18:                                   ; preds = %87
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %55
+ThrowNullRef20:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %58
+ThrowNullRef22:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %26
+ThrowNullRef24:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %29
+ThrowNullRef26:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,8 +8161,8 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck, label %14, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %ThrowNullRef, label %14
 
 ; <label>:14                                      ; preds = %8
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
@@ -6760,8 +8206,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
@@ -6770,14 +8216,14 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32, i32* %loc0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %10
   %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
   %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
@@ -6790,15 +8236,15 @@ entry:
 ; <label>:25                                      ; preds = %19
   %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
-  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
   %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
@@ -6807,8 +8253,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %37 = load i32, i32* %loc0
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %38, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %38
 
 ; <label>:38                                      ; preds = %32
   %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
@@ -6817,14 +8263,14 @@ entry:
 
 ; <label>:40                                      ; preds = %19
   %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %40
   %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
   %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
-  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
-  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
@@ -6832,8 +8278,8 @@ entry:
   %48 = zext i32 %47 to i64
   %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
-  br i1 %NullCheck16, label %51, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %51
 
 ; <label>:51                                      ; preds = %45
   %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
@@ -6847,15 +8293,15 @@ entry:
 ; <label>:57                                      ; preds = %51
   %58 = load i16*, i16** %arg1
   %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
-  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %60
 
 ; <label>:60                                      ; preds = %57
   %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
   %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
-  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %64
 
 ; <label>:64                                      ; preds = %60
   %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
@@ -6864,22 +8310,22 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
   %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
-  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %70
 
 ; <label>:70                                      ; preds = %64
   %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
   %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
-  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
-  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
   %75 = load i32, i32 addrspace(1)* %74
   %76 = zext i32 %75 to i64
   %77 = trunc i64 %76 to i32
-  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
-  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %78
 
 ; <label>:78                                      ; preds = %73
   %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
@@ -6901,8 +8347,8 @@ entry:
   %90 = bitcast i16* %86 to i8*
   %91 = getelementptr inbounds i8, i8* %90, i64 %89
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %93
 
 ; <label>:93                                      ; preds = %80
   %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
@@ -6912,8 +8358,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %99 = load i32, i32* %loc2
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %100
 
 ; <label>:100                                     ; preds = %93
   %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
@@ -6928,63 +8374,63 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %25
+ThrowNullRef6:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %32
+ThrowNullRef10:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %40
+ThrowNullRef12:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %45
+ThrowNullRef16:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %57
+ThrowNullRef18:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %60
+ThrowNullRef20:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %64
+ThrowNullRef22:                                   ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %70
+ThrowNullRef24:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %73
+ThrowNullRef26:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %80
+ThrowNullRef28:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %93
+ThrowNullRef30:                                   ; preds = %93
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7004,8 +8450,8 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
@@ -7033,43 +8479,43 @@ entry:
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %14
   %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
   %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   %28 = load i32, i32 addrspace(1)* %27, align 8
   %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
-  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %30
 
 ; <label>:30                                      ; preds = %26
   %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
   %32 = load i32, i32 addrspace(1)* %31, align 8
   %33 = add i32 %28, %32
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %34
 
 ; <label>:34                                      ; preds = %30
   %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   store i32 %33, i32 addrspace(1)* %35
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
   store i32 0, i32 addrspace(1)* %38
   %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %40
 
 ; <label>:40                                      ; preds = %37
   %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
@@ -7082,8 +8528,8 @@ entry:
 
 ; <label>:47                                      ; preds = %40
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
@@ -7098,8 +8544,8 @@ entry:
   %54 = load i32, i32* %loc0
   %55 = sext i32 %54 to i64
   %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
-  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %57
 
 ; <label>:57                                      ; preds = %52
   %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
@@ -7110,68 +8556,35 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %14
+ThrowNullRef2:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %23
+ThrowNullRef4:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %26
+ThrowNullRef6:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %30
+ThrowNullRef8:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %34
+ThrowNullRef10:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %47
+ThrowNullRef14:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %52
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-}
-
-INFO:  jitting method StringBuilder::get_Length using LLILCJit
-Successfully read StringBuilder.get_Length
-
-define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.StringBuilder addrspace(1)*
-  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
-  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
-
-; <label>:1                                       ; preds = %entry
-  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %3 = load i32, i32 addrspace(1)* %2, align 8
-  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
-
-; <label>:5                                       ; preds = %1
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = add i32 %3, %7
-  ret i32 %8
-
-ThrowNullRef:                                     ; preds = %entry
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef16:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7213,70 +8626,70 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
   %6 = load i32, i32 addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
   store i32 %6, i32 addrspace(1)* %8
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
   %13 = load i32, i32 addrspace(1)* %12, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
   store i32 %13, i32 addrspace(1)* %15
   %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
-  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %18
 
 ; <label>:18                                      ; preds = %14
   %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
   %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
   %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
   %34 = load i32, i32 addrspace(1)* %33, align 8
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
-  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
@@ -7287,39 +8700,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %28
+ThrowNullRef16:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %32
+ThrowNullRef18:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7455,13 +8868,13 @@ entry:
 ; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
@@ -7477,16 +8890,16 @@ entry:
 
 ; <label>:18                                      ; preds = %15
   %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
   store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
   %22 = load i32, i32* %loc0
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %24
 
 ; <label>:24                                      ; preds = %20
   %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
@@ -7498,13 +8911,13 @@ entry:
 ; <label>:28                                      ; preds = %15, %24
   %29 = load i32, i32* %arg1
   %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %31
   %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
@@ -7517,20 +8930,20 @@ entry:
   %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
-  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
   %46 = load i32, i32 addrspace(1)* %45, align 8
   %47 = sub i32 %40, %46
-  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
-  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i32 addrspace(1)* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %48
 
 ; <label>:48                                      ; preds = %44
   store i32 %47, i32 addrspace(1)* %39, align 8
@@ -7538,21 +8951,21 @@ entry:
 
 ; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
-  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %51
 
 ; <label>:51                                      ; preds = %49
   %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %53
 
 ; <label>:53                                      ; preds = %51
   %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
   %55 = load i32, i32 addrspace(1)* %54, align 8
   %56 = load i32, i32* %arg2
   %57 = sub i32 %55, %56
-  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %58
 
 ; <label>:58                                      ; preds = %53
   %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
@@ -7562,13 +8975,13 @@ entry:
 ; <label>:60                                      ; preds = %33, %58
   %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
   %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
-  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %63
 
 ; <label>:63                                      ; preds = %60
   %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
-  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
-  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
@@ -7578,15 +8991,15 @@ entry:
 
 ; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
-  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i32 addrspace(1)* %69, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %70
 
 ; <label>:70                                      ; preds = %68
   %71 = load i32, i32 addrspace(1)* %69, align 8
   store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
-  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
@@ -7596,8 +9009,8 @@ entry:
   store i32 %77, i32* %loc4
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
-  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %80
 
 ; <label>:80                                      ; preds = %73
   %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
@@ -7607,71 +9020,71 @@ entry:
 ; <label>:83                                      ; preds = %80
   store i32 0, i32* %loc3
   %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
-  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
-  br i1 %NullCheck26, label %88, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i32 addrspace(1)* %87, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %88
 
 ; <label>:88                                      ; preds = %85
   %89 = load i32, i32 addrspace(1)* %87, align 8
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
-  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %90
 
 ; <label>:90                                      ; preds = %88
   %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
   store i32 %89, i32 addrspace(1)* %91
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
-  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
-  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %96
 
 ; <label>:96                                      ; preds = %94
   %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
-  br i1 %NullCheck34, label %100, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %100
 
 ; <label>:100                                     ; preds = %96
   %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
-  br i1 %NullCheck36, label %102, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %102
 
 ; <label>:102                                     ; preds = %100
   %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
   %104 = load i32, i32 addrspace(1)* %103, align 8
   %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
-  br i1 %NullCheck38, label %106, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %106
 
 ; <label>:106                                     ; preds = %102
   %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
-  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
-  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %108
 
 ; <label>:108                                     ; preds = %106
   %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
   %110 = load i32, i32 addrspace(1)* %109, align 8
   %111 = add i32 %104, %110
-  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %112
 
 ; <label>:112                                     ; preds = %108
   %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
   store i32 %111, i32 addrspace(1)* %113
   %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
-  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i32 addrspace(1)* %114, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %115
 
 ; <label>:115                                     ; preds = %112
   %116 = load i32, i32 addrspace(1)* %114, align 8
@@ -7681,19 +9094,19 @@ entry:
 ; <label>:118                                     ; preds = %115
   %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
-  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %121
 
 ; <label>:121                                     ; preds = %118
   %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
-  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
-  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %123
 
 ; <label>:123                                     ; preds = %121
   %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
   %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
-  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
-  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %126
 
 ; <label>:126                                     ; preds = %123
   %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
@@ -7705,8 +9118,8 @@ entry:
 
 ; <label>:130                                     ; preds = %80, %115, %126
   %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %132
 
 ; <label>:132                                     ; preds = %130
   %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7715,8 +9128,8 @@ entry:
   %136 = load i32, i32* %loc3
   %137 = sub i32 %135, %136
   %138 = sub i32 %134, %137
-  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %139
 
 ; <label>:139                                     ; preds = %132
   %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7728,16 +9141,16 @@ entry:
 
 ; <label>:144                                     ; preds = %139
   %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
-  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %146
 
 ; <label>:146                                     ; preds = %144
   %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
   %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
   %149 = load i32, i32* %loc2
   %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
-  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %151
 
 ; <label>:151                                     ; preds = %146
   %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
@@ -7754,145 +9167,249 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %18
+ThrowNullRef4:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %31
+ThrowNullRef10:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %44
+ThrowNullRef16:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %68
+ThrowNullRef18:                                   ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %70
+ThrowNullRef20:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %73
+ThrowNullRef22:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %83
+ThrowNullRef24:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %85
+ThrowNullRef26:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %88
+ThrowNullRef28:                                   ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %90
+ThrowNullRef30:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %94
+ThrowNullRef32:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %96
+ThrowNullRef34:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %100
+ThrowNullRef36:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %102
+ThrowNullRef38:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %106
+ThrowNullRef40:                                   ; preds = %106
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %108
+ThrowNullRef42:                                   ; preds = %108
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %112
+ThrowNullRef44:                                   ; preds = %112
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %118
+ThrowNullRef46:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %121
+ThrowNullRef48:                                   ; preds = %121
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %123
+ThrowNullRef50:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %130
+ThrowNullRef52:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %132
+ThrowNullRef54:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %144
+ThrowNullRef56:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %146
+ThrowNullRef58:                                   ; preds = %146
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %60
+ThrowNullRef60:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %63
+ThrowNullRef62:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %49
+ThrowNullRef64:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %51
+ThrowNullRef66:                                   ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %53
+ThrowNullRef68:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(%"System.Char[]" addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %arg0 = alloca %"System.Char[]" addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store %"System.Char[]" addrspace(1)* %param0, %"System.Char[]" addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load i32, i32* %arg4
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %43, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %38, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg1
+  %13 = load i32, i32* %arg4
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %38, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %24 = load i32, i32* %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %35 = load i32, i32* %arg3
+  %36 = load i32, i32* %arg4
+  %37 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %37, %"System.Char[]" addrspace(1)* %34, i32 %35, i32 %36)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:38                                      ; preds = %5, %16
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Successfully read Buffer._Memmove
 
@@ -7914,7 +9431,7 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[loadElem]
+Failed to read AppDomain.SetDataHelper[storeElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -7923,8 +9440,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
@@ -7934,8 +9451,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
@@ -7947,15 +9464,15 @@ entry:
   %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
   %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
@@ -7966,15 +9483,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7992,7 +9509,79 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
-Failed to read Dictionary`2.TryGetValue[loadElemA]
+Successfully read Dictionary`2.TryGetValue
+
+define i8 @"Dictionary`2.TryGetValue"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)* addrspace(1)* %param2) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  %arg2 = alloca %System.__Canon addrspace(1)* addrspace(1)*
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  store %System.__Canon addrspace(1)* addrspace(1)* %param2, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  store i32 %2, i32* %loc0
+  %3 = load i32, i32* %loc0
+  %4 = icmp slt i32 %3, 0
+  br i1 %4, label %22, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 2
+  %10 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %9, align 8
+  %11 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = zext i32 %11 to i64
+  %BoundsCheck = icmp uge i64 %16, %15
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 3, i32 %11
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %20, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %6, %System.__Canon addrspace(1)* %21)
+  ret i8 1
+
+; <label>:22                                      ; preds = %entry
+  %23 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %23, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -8058,8 +9647,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
@@ -8091,8 +9680,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
@@ -8171,15 +9760,15 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck, label %19, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %ThrowNullRef, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
   %21 = load i32, i32 addrspace(1)* %20
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
@@ -8202,7 +9791,7 @@ ThrowNullRef:                                     ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %19
+ThrowNullRef2:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8248,8 +9837,8 @@ entry:
   %0 = alloca %System.AppDomainHandle
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %1 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %1, i32 0, i32 15
@@ -8269,8 +9858,8 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
@@ -8286,7 +9875,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -8299,8 +9888,8 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -8327,8 +9916,8 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
@@ -8352,8 +9941,8 @@ entry:
   %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
   store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
@@ -8363,8 +9952,8 @@ entry:
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
@@ -8374,8 +9963,8 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %9
   %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
@@ -8384,8 +9973,8 @@ entry:
 
 ; <label>:18                                      ; preds = %3, %16
   %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
@@ -8397,15 +9986,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %18
+ThrowNullRef6:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8418,8 +10007,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
@@ -8453,15 +10042,15 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
@@ -8473,7 +10062,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8481,7 +10070,7 @@ ThrowNullRef1:                                    ; preds = %1
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
 Failed to read Dictionary`2.System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
@@ -8506,8 +10095,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
@@ -8524,8 +10113,8 @@ entry:
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -8544,7 +10133,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8577,8 +10166,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = load i64, i64* %arg2
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = trunc i32 %3 to i8
@@ -8634,46 +10223,46 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
   %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
-  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
-  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
-  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
@@ -8684,27 +10273,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %20
+ThrowNullRef12:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8717,8 +10306,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -8756,22 +10345,22 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
   %9 = load i64, i64 addrspace(1)* %8, align 8
   %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
   %13 = load i64, i64 addrspace(1)* %12, align 8
   %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %11
   %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
@@ -8788,11 +10377,11 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8882,8 +10471,8 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
@@ -8900,8 +10489,8 @@ entry:
 ; <label>:8                                       ; preds = %1
   %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
   %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
@@ -8911,15 +10500,15 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
   %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
   %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
-  br i1 %NullCheck6, label %21, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
@@ -8946,15 +10535,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8992,15 +10581,15 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
   store i8 %3, i8 addrspace(1)* %5
   %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
@@ -9011,7 +10600,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9027,8 +10616,8 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -9041,8 +10630,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
@@ -9058,7 +10647,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9080,8 +10669,8 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
@@ -9096,8 +10685,8 @@ entry:
 ; <label>:12                                      ; preds = %6
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
@@ -9112,8 +10701,8 @@ entry:
 ; <label>:21                                      ; preds = %15
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
@@ -9128,8 +10717,8 @@ entry:
 ; <label>:30                                      ; preds = %24
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %31, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
@@ -9144,8 +10733,8 @@ entry:
 ; <label>:39                                      ; preds = %33
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
-  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %40, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %42
 
 ; <label>:42                                      ; preds = %39
   %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
@@ -9164,19 +10753,19 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %21
+ThrowNullRef4:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %30
+ThrowNullRef6:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %39
+ThrowNullRef8:                                    ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9243,8 +10832,8 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
@@ -9264,57 +10853,57 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
   store i8 0, i8 addrspace(1)* %2
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
   store i8 0, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
   store i8 0, i8 addrspace(1)* %17
   %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
   store i8 0, i8 addrspace(1)* %20
   %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
-  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
@@ -9325,31 +10914,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %19
+ThrowNullRef14:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9367,8 +10956,8 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
@@ -9380,8 +10969,8 @@ entry:
 
 ; <label>:9                                       ; preds = %4
   %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %9
   %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
@@ -9395,7 +10984,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef2:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9420,8 +11009,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
@@ -9512,8 +11101,8 @@ entry:
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
@@ -9524,8 +11113,8 @@ entry:
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = load i64, i64 addrspace(1)* %12
@@ -9537,8 +11126,8 @@ entry:
   %20 = load i64, i64* %19
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
-  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %13
   %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
@@ -9555,8 +11144,8 @@ entry:
 ; <label>:30                                      ; preds = %25
   %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %32 = load i32, i32* %arg2
-  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
-  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
@@ -9570,15 +11159,15 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %30
+ThrowNullRef2:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9622,87 +11211,87 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
   %10 = load i8, i8 addrspace(1)* %9, align 8
   %11 = zext i8 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %8
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
   store i8 %12, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
   %19 = load i8, i8 addrspace(1)* %18, align 8
   %20 = zext i8 %19 to i32
   %21 = trunc i32 %20 to i8
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
   store i8 %21, i8 addrspace(1)* %23
   %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
   %28 = load i8, i8 addrspace(1)* %27, align 8
   %29 = zext i8 %28 to i32
   %30 = trunc i32 %29 to i8
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
-  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %31
 
 ; <label>:31                                      ; preds = %26
   %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
   store i8 %30, i8 addrspace(1)* %32
   %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
-  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
-  br i1 %NullCheck14, label %40, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %40
 
 ; <label>:40                                      ; preds = %35
   %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
   store i8 %39, i8 addrspace(1)* %41
   %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
-  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %44
 
 ; <label>:44                                      ; preds = %40
   %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
   %46 = load i8, i8 addrspace(1)* %45, align 8
   %47 = zext i8 %46 to i32
   %48 = trunc i32 %47 to i8
-  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
   store i8 %48, i8 addrspace(1)* %50
   %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
-  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
@@ -9713,29 +11302,29 @@ entry:
 ; <label>:56                                      ; preds = %52
   %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
-  br i1 %NullCheck22, label %59, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
   %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
   %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
-  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
-  br i1 %NullCheck24, label %63, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
   %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
-  br i1 %NullCheck26, label %66, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
   %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
-  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
-  br i1 %NullCheck28, label %69, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %69
 
 ; <label>:69                                      ; preds = %66
   %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
@@ -9744,15 +11333,15 @@ entry:
 
 ; <label>:71                                      ; preds = %105
   %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
-  br i1 %NullCheck34, label %73, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %73
 
 ; <label>:73                                      ; preds = %71
   %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
   %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
   %76 = load i32, i32* %loc0
-  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
-  br i1 %NullCheck36, label %77, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
@@ -9766,8 +11355,8 @@ entry:
 
 ; <label>:83                                      ; preds = %77
   %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
-  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
@@ -9775,14 +11364,14 @@ entry:
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
   %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
-  br i1 %NullCheck40, label %91, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
 ; <label>:91                                      ; preds = %85
   %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
   %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
-  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck42, label %94, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %94
 
 ; <label>:94                                      ; preds = %91
   %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
@@ -9798,14 +11387,14 @@ entry:
 ; <label>:99                                      ; preds = %69, %96
   %100 = load i32, i32* %loc0
   %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
-  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %102
 
 ; <label>:102                                     ; preds = %99
   %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
   %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
-  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
-  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
@@ -9819,87 +11408,87 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %26
+ThrowNullRef10:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %31
+ThrowNullRef12:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %35
+ThrowNullRef14:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %40
+ThrowNullRef16:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %56
+ThrowNullRef22:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %59
+ThrowNullRef24:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %63
+ThrowNullRef26:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %66
+ThrowNullRef28:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %102
+ThrowNullRef32:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %71
+ThrowNullRef34:                                   ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %73
+ThrowNullRef36:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %83
+ThrowNullRef38:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %85
+ThrowNullRef40:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %91
+ThrowNullRef42:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9943,15 +11532,15 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
   %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
@@ -9961,28 +11550,28 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
   %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %12
   %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
   %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
   %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
-  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
@@ -9993,23 +11582,23 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %12
+ThrowNullRef6:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10031,15 +11620,15 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
   %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = load i64, i64 addrspace(1)* %7
@@ -10077,13 +11666,13 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[loadElem]
+Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -10111,8 +11700,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblAdd.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblAdd.error.txt
@@ -25,8 +25,8 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
@@ -40,8 +40,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
   %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
@@ -75,7 +75,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -90,8 +90,8 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %NullCheck = icmp ne i8 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = load i8, i8 addrspace(1)* %0, align 8
@@ -125,8 +125,8 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
@@ -159,8 +159,8 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -184,8 +184,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
   store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
@@ -195,8 +195,8 @@ entry:
 ; <label>:4                                       ; preds = %1
   %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
   %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
@@ -206,8 +206,8 @@ entry:
   %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
@@ -221,14 +221,14 @@ entry:
 
 ; <label>:17                                      ; preds = %14
   %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
   %21 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
@@ -238,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -249,8 +249,8 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
@@ -261,27 +261,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %30
+ThrowNullRef10:                                   ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -301,7 +301,89 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
-Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
+Successfully read AppDomainSetup.GetUnsecureApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.GetUnsecureApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %NullCheck = icmp eq %"System.String[]" addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %BoundsCheck = icmp uge i64 0, %5
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %6
+
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 3, i32 0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
+  ret %System.String addrspace(1)* %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_Value using LLILCJit
+Successfully read AppDomainSetup.get_Value
+
+define %"System.String[]" addrspace(1)* @AppDomainSetup.get_Value(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.String[]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 18)
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.String[]" addrspace(1)* addrspace(1)*, %"System.String[]" addrspace(1)*)*)(%"System.String[]" addrspace(1)* addrspace(1)* %9, %"System.String[]" addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %11, i32 0, i32 1
+  %14 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %13, align 8
+  ret %"System.String[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -319,8 +401,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -368,16 +450,16 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
   %5 = load i32, i32 addrspace(1)* %4
   %6 = sub i32 %5, 1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -389,7 +471,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -421,8 +503,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
@@ -456,8 +538,8 @@ entry:
 ; <label>:27                                      ; preds = %19
   %28 = load i32, i32* %arg1
   %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
-  br i1 %NullCheck2, label %30, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %29, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %30
 
 ; <label>:30                                      ; preds = %27
   %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
@@ -493,8 +575,8 @@ entry:
 ; <label>:49                                      ; preds = %46
   %50 = load i32, i32* %arg2
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck4, label %52, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
@@ -517,11 +599,11 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %27
+ThrowNullRef2:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %49
+ThrowNullRef4:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -544,16 +626,16 @@ entry:
   %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %0)
   store %System.String addrspace(1)* %1, %System.String addrspace(1)** %loc0
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 2
   %5 = bitcast [0 x i16] addrspace(1)* %4 to i16 addrspace(1)*
   store i16 addrspace(1)* %5, i16 addrspace(1)** %loc1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %3
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2
@@ -580,7 +662,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -691,15 +773,15 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %NullCheck132 = icmp ne i8* %21, null
-  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+  %NullCheck131 = icmp eq i8* %21, null
+  br i1 %NullCheck131, label %ThrowNullRef132, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = load i8, i8* %21, align 8
   %24 = zext i8 %23 to i32
   %25 = trunc i32 %24 to i8
-  %NullCheck134 = icmp ne i8* %20, null
-  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+  %NullCheck133 = icmp eq i8* %20, null
+  br i1 %NullCheck133, label %ThrowNullRef134, label %26
 
 ; <label>:26                                      ; preds = %22
   store i8 %25, i8* %20, align 8
@@ -709,16 +791,16 @@ entry:
   %28 = load i8*, i8** %arg0
   %29 = load i8*, i8** %arg1
   %30 = bitcast i8* %29 to i16*
-  %NullCheck128 = icmp ne i16* %30, null
-  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+  %NullCheck127 = icmp eq i16* %30, null
+  br i1 %NullCheck127, label %ThrowNullRef128, label %31
 
 ; <label>:31                                      ; preds = %27
   %32 = load i16, i16* %30, align 8
   %33 = sext i16 %32 to i32
   %34 = bitcast i8* %28 to i16*
   %35 = trunc i32 %33 to i16
-  %NullCheck130 = icmp ne i16* %34, null
-  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+  %NullCheck129 = icmp eq i16* %34, null
+  br i1 %NullCheck129, label %ThrowNullRef130, label %36
 
 ; <label>:36                                      ; preds = %31
   store i16 %35, i16* %34, align 8
@@ -728,16 +810,16 @@ entry:
   %38 = load i8*, i8** %arg0
   %39 = load i8*, i8** %arg1
   %40 = bitcast i8* %39 to i16*
-  %NullCheck120 = icmp ne i16* %40, null
-  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+  %NullCheck119 = icmp eq i16* %40, null
+  br i1 %NullCheck119, label %ThrowNullRef120, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i16, i16* %40, align 8
   %43 = sext i16 %42 to i32
   %44 = bitcast i8* %38 to i16*
   %45 = trunc i32 %43 to i16
-  %NullCheck122 = icmp ne i16* %44, null
-  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+  %NullCheck121 = icmp eq i16* %44, null
+  br i1 %NullCheck121, label %ThrowNullRef122, label %46
 
 ; <label>:46                                      ; preds = %41
   store i16 %45, i16* %44, align 8
@@ -745,15 +827,15 @@ entry:
   %48 = getelementptr inbounds i8, i8* %47, i64 2
   %49 = load i8*, i8** %arg1
   %50 = getelementptr inbounds i8, i8* %49, i64 2
-  %NullCheck124 = icmp ne i8* %50, null
-  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+  %NullCheck123 = icmp eq i8* %50, null
+  br i1 %NullCheck123, label %ThrowNullRef124, label %51
 
 ; <label>:51                                      ; preds = %46
   %52 = load i8, i8* %50, align 8
   %53 = zext i8 %52 to i32
   %54 = trunc i32 %53 to i8
-  %NullCheck126 = icmp ne i8* %48, null
-  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+  %NullCheck125 = icmp eq i8* %48, null
+  br i1 %NullCheck125, label %ThrowNullRef126, label %55
 
 ; <label>:55                                      ; preds = %51
   store i8 %54, i8* %48, align 8
@@ -763,14 +845,14 @@ entry:
   %57 = load i8*, i8** %arg0
   %58 = load i8*, i8** %arg1
   %59 = bitcast i8* %58 to i32*
-  %NullCheck116 = icmp ne i32* %59, null
-  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+  %NullCheck115 = icmp eq i32* %59, null
+  br i1 %NullCheck115, label %ThrowNullRef116, label %60
 
 ; <label>:60                                      ; preds = %56
   %61 = load i32, i32* %59, align 8
   %62 = bitcast i8* %57 to i32*
-  %NullCheck118 = icmp ne i32* %62, null
-  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+  %NullCheck117 = icmp eq i32* %62, null
+  br i1 %NullCheck117, label %ThrowNullRef118, label %63
 
 ; <label>:63                                      ; preds = %60
   store i32 %61, i32* %62, align 8
@@ -780,14 +862,14 @@ entry:
   %65 = load i8*, i8** %arg0
   %66 = load i8*, i8** %arg1
   %67 = bitcast i8* %66 to i32*
-  %NullCheck108 = icmp ne i32* %67, null
-  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+  %NullCheck107 = icmp eq i32* %67, null
+  br i1 %NullCheck107, label %ThrowNullRef108, label %68
 
 ; <label>:68                                      ; preds = %64
   %69 = load i32, i32* %67, align 8
   %70 = bitcast i8* %65 to i32*
-  %NullCheck110 = icmp ne i32* %70, null
-  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+  %NullCheck109 = icmp eq i32* %70, null
+  br i1 %NullCheck109, label %ThrowNullRef110, label %71
 
 ; <label>:71                                      ; preds = %68
   store i32 %69, i32* %70, align 8
@@ -795,15 +877,15 @@ entry:
   %73 = getelementptr inbounds i8, i8* %72, i64 4
   %74 = load i8*, i8** %arg1
   %75 = getelementptr inbounds i8, i8* %74, i64 4
-  %NullCheck112 = icmp ne i8* %75, null
-  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+  %NullCheck111 = icmp eq i8* %75, null
+  br i1 %NullCheck111, label %ThrowNullRef112, label %76
 
 ; <label>:76                                      ; preds = %71
   %77 = load i8, i8* %75, align 8
   %78 = zext i8 %77 to i32
   %79 = trunc i32 %78 to i8
-  %NullCheck114 = icmp ne i8* %73, null
-  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+  %NullCheck113 = icmp eq i8* %73, null
+  br i1 %NullCheck113, label %ThrowNullRef114, label %80
 
 ; <label>:80                                      ; preds = %76
   store i8 %79, i8* %73, align 8
@@ -813,14 +895,14 @@ entry:
   %82 = load i8*, i8** %arg0
   %83 = load i8*, i8** %arg1
   %84 = bitcast i8* %83 to i32*
-  %NullCheck100 = icmp ne i32* %84, null
-  br i1 %NullCheck100, label %85, label %ThrowNullRef99
+  %NullCheck99 = icmp eq i32* %84, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %85
 
 ; <label>:85                                      ; preds = %81
   %86 = load i32, i32* %84, align 8
   %87 = bitcast i8* %82 to i32*
-  %NullCheck102 = icmp ne i32* %87, null
-  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+  %NullCheck101 = icmp eq i32* %87, null
+  br i1 %NullCheck101, label %ThrowNullRef102, label %88
 
 ; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
@@ -829,16 +911,16 @@ entry:
   %91 = load i8*, i8** %arg1
   %92 = getelementptr inbounds i8, i8* %91, i64 4
   %93 = bitcast i8* %92 to i16*
-  %NullCheck104 = icmp ne i16* %93, null
-  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+  %NullCheck103 = icmp eq i16* %93, null
+  br i1 %NullCheck103, label %ThrowNullRef104, label %94
 
 ; <label>:94                                      ; preds = %88
   %95 = load i16, i16* %93, align 8
   %96 = sext i16 %95 to i32
   %97 = bitcast i8* %90 to i16*
   %98 = trunc i32 %96 to i16
-  %NullCheck106 = icmp ne i16* %97, null
-  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+  %NullCheck105 = icmp eq i16* %97, null
+  br i1 %NullCheck105, label %ThrowNullRef106, label %99
 
 ; <label>:99                                      ; preds = %94
   store i16 %98, i16* %97, align 8
@@ -848,14 +930,14 @@ entry:
   %101 = load i8*, i8** %arg0
   %102 = load i8*, i8** %arg1
   %103 = bitcast i8* %102 to i32*
-  %NullCheck88 = icmp ne i32* %103, null
-  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+  %NullCheck87 = icmp eq i32* %103, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %104
 
 ; <label>:104                                     ; preds = %100
   %105 = load i32, i32* %103, align 8
   %106 = bitcast i8* %101 to i32*
-  %NullCheck90 = icmp ne i32* %106, null
-  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+  %NullCheck89 = icmp eq i32* %106, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %107
 
 ; <label>:107                                     ; preds = %104
   store i32 %105, i32* %106, align 8
@@ -864,16 +946,16 @@ entry:
   %110 = load i8*, i8** %arg1
   %111 = getelementptr inbounds i8, i8* %110, i64 4
   %112 = bitcast i8* %111 to i16*
-  %NullCheck92 = icmp ne i16* %112, null
-  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+  %NullCheck91 = icmp eq i16* %112, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %113
 
 ; <label>:113                                     ; preds = %107
   %114 = load i16, i16* %112, align 8
   %115 = sext i16 %114 to i32
   %116 = bitcast i8* %109 to i16*
   %117 = trunc i32 %115 to i16
-  %NullCheck94 = icmp ne i16* %116, null
-  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+  %NullCheck93 = icmp eq i16* %116, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %118
 
 ; <label>:118                                     ; preds = %113
   store i16 %117, i16* %116, align 8
@@ -881,15 +963,15 @@ entry:
   %120 = getelementptr inbounds i8, i8* %119, i64 6
   %121 = load i8*, i8** %arg1
   %122 = getelementptr inbounds i8, i8* %121, i64 6
-  %NullCheck96 = icmp ne i8* %122, null
-  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+  %NullCheck95 = icmp eq i8* %122, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %123
 
 ; <label>:123                                     ; preds = %118
   %124 = load i8, i8* %122, align 8
   %125 = zext i8 %124 to i32
   %126 = trunc i32 %125 to i8
-  %NullCheck98 = icmp ne i8* %120, null
-  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+  %NullCheck97 = icmp eq i8* %120, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %127
 
 ; <label>:127                                     ; preds = %123
   store i8 %126, i8* %120, align 8
@@ -899,14 +981,14 @@ entry:
   %129 = load i8*, i8** %arg0
   %130 = load i8*, i8** %arg1
   %131 = bitcast i8* %130 to i64*
-  %NullCheck84 = icmp ne i64* %131, null
-  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+  %NullCheck83 = icmp eq i64* %131, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %132
 
 ; <label>:132                                     ; preds = %128
   %133 = load i64, i64* %131, align 8
   %134 = bitcast i8* %129 to i64*
-  %NullCheck86 = icmp ne i64* %134, null
-  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+  %NullCheck85 = icmp eq i64* %134, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %135
 
 ; <label>:135                                     ; preds = %132
   store i64 %133, i64* %134, align 8
@@ -916,14 +998,14 @@ entry:
   %137 = load i8*, i8** %arg0
   %138 = load i8*, i8** %arg1
   %139 = bitcast i8* %138 to i64*
-  %NullCheck76 = icmp ne i64* %139, null
-  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+  %NullCheck75 = icmp eq i64* %139, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %140
 
 ; <label>:140                                     ; preds = %136
   %141 = load i64, i64* %139, align 8
   %142 = bitcast i8* %137 to i64*
-  %NullCheck78 = icmp ne i64* %142, null
-  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+  %NullCheck77 = icmp eq i64* %142, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %143
 
 ; <label>:143                                     ; preds = %140
   store i64 %141, i64* %142, align 8
@@ -931,15 +1013,15 @@ entry:
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %NullCheck80 = icmp ne i8* %147, null
-  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+  %NullCheck79 = icmp eq i8* %147, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %148
 
 ; <label>:148                                     ; preds = %143
   %149 = load i8, i8* %147, align 8
   %150 = zext i8 %149 to i32
   %151 = trunc i32 %150 to i8
-  %NullCheck82 = icmp ne i8* %145, null
-  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+  %NullCheck81 = icmp eq i8* %145, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %152
 
 ; <label>:152                                     ; preds = %148
   store i8 %151, i8* %145, align 8
@@ -949,14 +1031,14 @@ entry:
   %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
   %156 = bitcast i8* %155 to i64*
-  %NullCheck68 = icmp ne i64* %156, null
-  br i1 %NullCheck68, label %157, label %ThrowNullRef67
+  %NullCheck67 = icmp eq i64* %156, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %157
 
 ; <label>:157                                     ; preds = %153
   %158 = load i64, i64* %156, align 8
   %159 = bitcast i8* %154 to i64*
-  %NullCheck70 = icmp ne i64* %159, null
-  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+  %NullCheck69 = icmp eq i64* %159, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %160
 
 ; <label>:160                                     ; preds = %157
   store i64 %158, i64* %159, align 8
@@ -965,16 +1047,16 @@ entry:
   %163 = load i8*, i8** %arg1
   %164 = getelementptr inbounds i8, i8* %163, i64 8
   %165 = bitcast i8* %164 to i16*
-  %NullCheck72 = icmp ne i16* %165, null
-  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+  %NullCheck71 = icmp eq i16* %165, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %166
 
 ; <label>:166                                     ; preds = %160
   %167 = load i16, i16* %165, align 8
   %168 = sext i16 %167 to i32
   %169 = bitcast i8* %162 to i16*
   %170 = trunc i32 %168 to i16
-  %NullCheck74 = icmp ne i16* %169, null
-  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+  %NullCheck73 = icmp eq i16* %169, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %171
 
 ; <label>:171                                     ; preds = %166
   store i16 %170, i16* %169, align 8
@@ -984,14 +1066,14 @@ entry:
   %173 = load i8*, i8** %arg0
   %174 = load i8*, i8** %arg1
   %175 = bitcast i8* %174 to i64*
-  %NullCheck56 = icmp ne i64* %175, null
-  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+  %NullCheck55 = icmp eq i64* %175, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %176
 
 ; <label>:176                                     ; preds = %172
   %177 = load i64, i64* %175, align 8
   %178 = bitcast i8* %173 to i64*
-  %NullCheck58 = icmp ne i64* %178, null
-  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+  %NullCheck57 = icmp eq i64* %178, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %179
 
 ; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
@@ -1000,16 +1082,16 @@ entry:
   %182 = load i8*, i8** %arg1
   %183 = getelementptr inbounds i8, i8* %182, i64 8
   %184 = bitcast i8* %183 to i16*
-  %NullCheck60 = icmp ne i16* %184, null
-  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+  %NullCheck59 = icmp eq i16* %184, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %185
 
 ; <label>:185                                     ; preds = %179
   %186 = load i16, i16* %184, align 8
   %187 = sext i16 %186 to i32
   %188 = bitcast i8* %181 to i16*
   %189 = trunc i32 %187 to i16
-  %NullCheck62 = icmp ne i16* %188, null
-  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+  %NullCheck61 = icmp eq i16* %188, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %190
 
 ; <label>:190                                     ; preds = %185
   store i16 %189, i16* %188, align 8
@@ -1017,15 +1099,15 @@ entry:
   %192 = getelementptr inbounds i8, i8* %191, i64 10
   %193 = load i8*, i8** %arg1
   %194 = getelementptr inbounds i8, i8* %193, i64 10
-  %NullCheck64 = icmp ne i8* %194, null
-  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+  %NullCheck63 = icmp eq i8* %194, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %195
 
 ; <label>:195                                     ; preds = %190
   %196 = load i8, i8* %194, align 8
   %197 = zext i8 %196 to i32
   %198 = trunc i32 %197 to i8
-  %NullCheck66 = icmp ne i8* %192, null
-  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+  %NullCheck65 = icmp eq i8* %192, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %199
 
 ; <label>:199                                     ; preds = %195
   store i8 %198, i8* %192, align 8
@@ -1035,14 +1117,14 @@ entry:
   %201 = load i8*, i8** %arg0
   %202 = load i8*, i8** %arg1
   %203 = bitcast i8* %202 to i64*
-  %NullCheck48 = icmp ne i64* %203, null
-  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+  %NullCheck47 = icmp eq i64* %203, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %204
 
 ; <label>:204                                     ; preds = %200
   %205 = load i64, i64* %203, align 8
   %206 = bitcast i8* %201 to i64*
-  %NullCheck50 = icmp ne i64* %206, null
-  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+  %NullCheck49 = icmp eq i64* %206, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %207
 
 ; <label>:207                                     ; preds = %204
   store i64 %205, i64* %206, align 8
@@ -1051,14 +1133,14 @@ entry:
   %210 = load i8*, i8** %arg1
   %211 = getelementptr inbounds i8, i8* %210, i64 8
   %212 = bitcast i8* %211 to i32*
-  %NullCheck52 = icmp ne i32* %212, null
-  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+  %NullCheck51 = icmp eq i32* %212, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %213
 
 ; <label>:213                                     ; preds = %207
   %214 = load i32, i32* %212, align 8
   %215 = bitcast i8* %209 to i32*
-  %NullCheck54 = icmp ne i32* %215, null
-  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+  %NullCheck53 = icmp eq i32* %215, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %216
 
 ; <label>:216                                     ; preds = %213
   store i32 %214, i32* %215, align 8
@@ -1068,14 +1150,14 @@ entry:
   %218 = load i8*, i8** %arg0
   %219 = load i8*, i8** %arg1
   %220 = bitcast i8* %219 to i64*
-  %NullCheck36 = icmp ne i64* %220, null
-  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64* %220, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %221
 
 ; <label>:221                                     ; preds = %217
   %222 = load i64, i64* %220, align 8
   %223 = bitcast i8* %218 to i64*
-  %NullCheck38 = icmp ne i64* %223, null
-  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+  %NullCheck37 = icmp eq i64* %223, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %224
 
 ; <label>:224                                     ; preds = %221
   store i64 %222, i64* %223, align 8
@@ -1084,14 +1166,14 @@ entry:
   %227 = load i8*, i8** %arg1
   %228 = getelementptr inbounds i8, i8* %227, i64 8
   %229 = bitcast i8* %228 to i32*
-  %NullCheck40 = icmp ne i32* %229, null
-  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i32* %229, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %230
 
 ; <label>:230                                     ; preds = %224
   %231 = load i32, i32* %229, align 8
   %232 = bitcast i8* %226 to i32*
-  %NullCheck42 = icmp ne i32* %232, null
-  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+  %NullCheck41 = icmp eq i32* %232, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %233
 
 ; <label>:233                                     ; preds = %230
   store i32 %231, i32* %232, align 8
@@ -1099,15 +1181,15 @@ entry:
   %235 = getelementptr inbounds i8, i8* %234, i64 12
   %236 = load i8*, i8** %arg1
   %237 = getelementptr inbounds i8, i8* %236, i64 12
-  %NullCheck44 = icmp ne i8* %237, null
-  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i8* %237, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %238
 
 ; <label>:238                                     ; preds = %233
   %239 = load i8, i8* %237, align 8
   %240 = zext i8 %239 to i32
   %241 = trunc i32 %240 to i8
-  %NullCheck46 = icmp ne i8* %235, null
-  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+  %NullCheck45 = icmp eq i8* %235, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %242
 
 ; <label>:242                                     ; preds = %238
   store i8 %241, i8* %235, align 8
@@ -1117,14 +1199,14 @@ entry:
   %244 = load i8*, i8** %arg0
   %245 = load i8*, i8** %arg1
   %246 = bitcast i8* %245 to i64*
-  %NullCheck24 = icmp ne i64* %246, null
-  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64* %246, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %247
 
 ; <label>:247                                     ; preds = %243
   %248 = load i64, i64* %246, align 8
   %249 = bitcast i8* %244 to i64*
-  %NullCheck26 = icmp ne i64* %249, null
-  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64* %249, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %250
 
 ; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
@@ -1133,14 +1215,14 @@ entry:
   %253 = load i8*, i8** %arg1
   %254 = getelementptr inbounds i8, i8* %253, i64 8
   %255 = bitcast i8* %254 to i32*
-  %NullCheck28 = icmp ne i32* %255, null
-  br i1 %NullCheck28, label %256, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i32* %255, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %256
 
 ; <label>:256                                     ; preds = %250
   %257 = load i32, i32* %255, align 8
   %258 = bitcast i8* %252 to i32*
-  %NullCheck30 = icmp ne i32* %258, null
-  br i1 %NullCheck30, label %259, label %ThrowNullRef29
+  %NullCheck29 = icmp eq i32* %258, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %259
 
 ; <label>:259                                     ; preds = %256
   store i32 %257, i32* %258, align 8
@@ -1149,16 +1231,16 @@ entry:
   %262 = load i8*, i8** %arg1
   %263 = getelementptr inbounds i8, i8* %262, i64 12
   %264 = bitcast i8* %263 to i16*
-  %NullCheck32 = icmp ne i16* %264, null
-  br i1 %NullCheck32, label %265, label %ThrowNullRef31
+  %NullCheck31 = icmp eq i16* %264, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %265
 
 ; <label>:265                                     ; preds = %259
   %266 = load i16, i16* %264, align 8
   %267 = sext i16 %266 to i32
   %268 = bitcast i8* %261 to i16*
   %269 = trunc i32 %267 to i16
-  %NullCheck34 = icmp ne i16* %268, null
-  br i1 %NullCheck34, label %270, label %ThrowNullRef33
+  %NullCheck33 = icmp eq i16* %268, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %270
 
 ; <label>:270                                     ; preds = %265
   store i16 %269, i16* %268, align 8
@@ -1168,14 +1250,14 @@ entry:
   %272 = load i8*, i8** %arg0
   %273 = load i8*, i8** %arg1
   %274 = bitcast i8* %273 to i64*
-  %NullCheck8 = icmp ne i64* %274, null
-  br i1 %NullCheck8, label %275, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64* %274, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %275
 
 ; <label>:275                                     ; preds = %271
   %276 = load i64, i64* %274, align 8
   %277 = bitcast i8* %272 to i64*
-  %NullCheck10 = icmp ne i64* %277, null
-  br i1 %NullCheck10, label %278, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %277, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %278
 
 ; <label>:278                                     ; preds = %275
   store i64 %276, i64* %277, align 8
@@ -1184,14 +1266,14 @@ entry:
   %281 = load i8*, i8** %arg1
   %282 = getelementptr inbounds i8, i8* %281, i64 8
   %283 = bitcast i8* %282 to i32*
-  %NullCheck12 = icmp ne i32* %283, null
-  br i1 %NullCheck12, label %284, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i32* %283, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %284
 
 ; <label>:284                                     ; preds = %278
   %285 = load i32, i32* %283, align 8
   %286 = bitcast i8* %280 to i32*
-  %NullCheck14 = icmp ne i32* %286, null
-  br i1 %NullCheck14, label %287, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i32* %286, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %287
 
 ; <label>:287                                     ; preds = %284
   store i32 %285, i32* %286, align 8
@@ -1200,16 +1282,16 @@ entry:
   %290 = load i8*, i8** %arg1
   %291 = getelementptr inbounds i8, i8* %290, i64 12
   %292 = bitcast i8* %291 to i16*
-  %NullCheck16 = icmp ne i16* %292, null
-  br i1 %NullCheck16, label %293, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i16* %292, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %293
 
 ; <label>:293                                     ; preds = %287
   %294 = load i16, i16* %292, align 8
   %295 = sext i16 %294 to i32
   %296 = bitcast i8* %289 to i16*
   %297 = trunc i32 %295 to i16
-  %NullCheck18 = icmp ne i16* %296, null
-  br i1 %NullCheck18, label %298, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i16* %296, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %298
 
 ; <label>:298                                     ; preds = %293
   store i16 %297, i16* %296, align 8
@@ -1217,15 +1299,15 @@ entry:
   %300 = getelementptr inbounds i8, i8* %299, i64 14
   %301 = load i8*, i8** %arg1
   %302 = getelementptr inbounds i8, i8* %301, i64 14
-  %NullCheck20 = icmp ne i8* %302, null
-  br i1 %NullCheck20, label %303, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i8* %302, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %303
 
 ; <label>:303                                     ; preds = %298
   %304 = load i8, i8* %302, align 8
   %305 = zext i8 %304 to i32
   %306 = trunc i32 %305 to i8
-  %NullCheck22 = icmp ne i8* %300, null
-  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i8* %300, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %307
 
 ; <label>:307                                     ; preds = %303
   store i8 %306, i8* %300, align 8
@@ -1235,14 +1317,14 @@ entry:
   %309 = load i8*, i8** %arg0
   %310 = load i8*, i8** %arg1
   %311 = bitcast i8* %310 to i64*
-  %NullCheck = icmp ne i64* %311, null
-  br i1 %NullCheck, label %312, label %ThrowNullRef
+  %NullCheck = icmp eq i64* %311, null
+  br i1 %NullCheck, label %ThrowNullRef, label %312
 
 ; <label>:312                                     ; preds = %308
   %313 = load i64, i64* %311, align 8
   %314 = bitcast i8* %309 to i64*
-  %NullCheck2 = icmp ne i64* %314, null
-  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64* %314, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %315
 
 ; <label>:315                                     ; preds = %312
   store i64 %313, i64* %314, align 8
@@ -1251,14 +1333,14 @@ entry:
   %318 = load i8*, i8** %arg1
   %319 = getelementptr inbounds i8, i8* %318, i64 8
   %320 = bitcast i8* %319 to i64*
-  %NullCheck4 = icmp ne i64* %320, null
-  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64* %320, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %321
 
 ; <label>:321                                     ; preds = %315
   %322 = load i64, i64* %320, align 8
   %323 = bitcast i8* %317 to i64*
-  %NullCheck6 = icmp ne i64* %323, null
-  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64* %323, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %324
 
 ; <label>:324                                     ; preds = %321
   store i64 %322, i64* %323, align 8
@@ -1286,15 +1368,15 @@ entry:
 ; <label>:338                                     ; preds = %333
   %339 = load i8*, i8** %arg0
   %340 = load i8*, i8** %arg1
-  %NullCheck136 = icmp ne i8* %340, null
-  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+  %NullCheck135 = icmp eq i8* %340, null
+  br i1 %NullCheck135, label %ThrowNullRef136, label %341
 
 ; <label>:341                                     ; preds = %338
   %342 = load i8, i8* %340, align 8
   %343 = zext i8 %342 to i32
   %344 = trunc i32 %343 to i8
-  %NullCheck138 = icmp ne i8* %339, null
-  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+  %NullCheck137 = icmp eq i8* %339, null
+  br i1 %NullCheck137, label %ThrowNullRef138, label %345
 
 ; <label>:345                                     ; preds = %341
   store i8 %344, i8* %339, align 8
@@ -1317,16 +1399,16 @@ entry:
   %357 = load i8*, i8** %arg0
   %358 = load i8*, i8** %arg1
   %359 = bitcast i8* %358 to i16*
-  %NullCheck140 = icmp ne i16* %359, null
-  br i1 %NullCheck140, label %360, label %ThrowNullRef139
+  %NullCheck139 = icmp eq i16* %359, null
+  br i1 %NullCheck139, label %ThrowNullRef140, label %360
 
 ; <label>:360                                     ; preds = %356
   %361 = load i16, i16* %359, align 8
   %362 = sext i16 %361 to i32
   %363 = bitcast i8* %357 to i16*
   %364 = trunc i32 %362 to i16
-  %NullCheck142 = icmp ne i16* %363, null
-  br i1 %NullCheck142, label %365, label %ThrowNullRef141
+  %NullCheck141 = icmp eq i16* %363, null
+  br i1 %NullCheck141, label %ThrowNullRef142, label %365
 
 ; <label>:365                                     ; preds = %360
   store i16 %364, i16* %363, align 8
@@ -1352,14 +1434,14 @@ entry:
   %378 = load i8*, i8** %arg0
   %379 = load i8*, i8** %arg1
   %380 = bitcast i8* %379 to i32*
-  %NullCheck144 = icmp ne i32* %380, null
-  br i1 %NullCheck144, label %381, label %ThrowNullRef143
+  %NullCheck143 = icmp eq i32* %380, null
+  br i1 %NullCheck143, label %ThrowNullRef144, label %381
 
 ; <label>:381                                     ; preds = %377
   %382 = load i32, i32* %380, align 8
   %383 = bitcast i8* %378 to i32*
-  %NullCheck146 = icmp ne i32* %383, null
-  br i1 %NullCheck146, label %384, label %ThrowNullRef145
+  %NullCheck145 = icmp eq i32* %383, null
+  br i1 %NullCheck145, label %ThrowNullRef146, label %384
 
 ; <label>:384                                     ; preds = %381
   store i32 %382, i32* %383, align 8
@@ -1384,14 +1466,14 @@ entry:
   %395 = load i8*, i8** %arg0
   %396 = load i8*, i8** %arg1
   %397 = bitcast i8* %396 to i64*
-  %NullCheck164 = icmp ne i64* %397, null
-  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+  %NullCheck163 = icmp eq i64* %397, null
+  br i1 %NullCheck163, label %ThrowNullRef164, label %398
 
 ; <label>:398                                     ; preds = %394
   %399 = load i64, i64* %397, align 8
   %400 = bitcast i8* %395 to i64*
-  %NullCheck166 = icmp ne i64* %400, null
-  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+  %NullCheck165 = icmp eq i64* %400, null
+  br i1 %NullCheck165, label %ThrowNullRef166, label %401
 
 ; <label>:401                                     ; preds = %398
   store i64 %399, i64* %400, align 8
@@ -1400,14 +1482,14 @@ entry:
   %404 = load i8*, i8** %arg1
   %405 = getelementptr inbounds i8, i8* %404, i64 8
   %406 = bitcast i8* %405 to i64*
-  %NullCheck168 = icmp ne i64* %406, null
-  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+  %NullCheck167 = icmp eq i64* %406, null
+  br i1 %NullCheck167, label %ThrowNullRef168, label %407
 
 ; <label>:407                                     ; preds = %401
   %408 = load i64, i64* %406, align 8
   %409 = bitcast i8* %403 to i64*
-  %NullCheck170 = icmp ne i64* %409, null
-  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+  %NullCheck169 = icmp eq i64* %409, null
+  br i1 %NullCheck169, label %ThrowNullRef170, label %410
 
 ; <label>:410                                     ; preds = %407
   store i64 %408, i64* %409, align 8
@@ -1437,14 +1519,14 @@ entry:
   %425 = load i8*, i8** %arg0
   %426 = load i8*, i8** %arg1
   %427 = bitcast i8* %426 to i64*
-  %NullCheck148 = icmp ne i64* %427, null
-  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+  %NullCheck147 = icmp eq i64* %427, null
+  br i1 %NullCheck147, label %ThrowNullRef148, label %428
 
 ; <label>:428                                     ; preds = %424
   %429 = load i64, i64* %427, align 8
   %430 = bitcast i8* %425 to i64*
-  %NullCheck150 = icmp ne i64* %430, null
-  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+  %NullCheck149 = icmp eq i64* %430, null
+  br i1 %NullCheck149, label %ThrowNullRef150, label %431
 
 ; <label>:431                                     ; preds = %428
   store i64 %429, i64* %430, align 8
@@ -1466,14 +1548,14 @@ entry:
   %441 = load i8*, i8** %arg0
   %442 = load i8*, i8** %arg1
   %443 = bitcast i8* %442 to i32*
-  %NullCheck152 = icmp ne i32* %443, null
-  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+  %NullCheck151 = icmp eq i32* %443, null
+  br i1 %NullCheck151, label %ThrowNullRef152, label %444
 
 ; <label>:444                                     ; preds = %440
   %445 = load i32, i32* %443, align 8
   %446 = bitcast i8* %441 to i32*
-  %NullCheck154 = icmp ne i32* %446, null
-  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+  %NullCheck153 = icmp eq i32* %446, null
+  br i1 %NullCheck153, label %ThrowNullRef154, label %447
 
 ; <label>:447                                     ; preds = %444
   store i32 %445, i32* %446, align 8
@@ -1495,16 +1577,16 @@ entry:
   %457 = load i8*, i8** %arg0
   %458 = load i8*, i8** %arg1
   %459 = bitcast i8* %458 to i16*
-  %NullCheck156 = icmp ne i16* %459, null
-  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+  %NullCheck155 = icmp eq i16* %459, null
+  br i1 %NullCheck155, label %ThrowNullRef156, label %460
 
 ; <label>:460                                     ; preds = %456
   %461 = load i16, i16* %459, align 8
   %462 = sext i16 %461 to i32
   %463 = bitcast i8* %457 to i16*
   %464 = trunc i32 %462 to i16
-  %NullCheck158 = icmp ne i16* %463, null
-  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+  %NullCheck157 = icmp eq i16* %463, null
+  br i1 %NullCheck157, label %ThrowNullRef158, label %465
 
 ; <label>:465                                     ; preds = %460
   store i16 %464, i16* %463, align 8
@@ -1525,15 +1607,15 @@ entry:
 ; <label>:474                                     ; preds = %470
   %475 = load i8*, i8** %arg0
   %476 = load i8*, i8** %arg1
-  %NullCheck160 = icmp ne i8* %476, null
-  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+  %NullCheck159 = icmp eq i8* %476, null
+  br i1 %NullCheck159, label %ThrowNullRef160, label %477
 
 ; <label>:477                                     ; preds = %474
   %478 = load i8, i8* %476, align 8
   %479 = zext i8 %478 to i32
   %480 = trunc i32 %479 to i8
-  %NullCheck162 = icmp ne i8* %475, null
-  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+  %NullCheck161 = icmp eq i8* %475, null
+  br i1 %NullCheck161, label %ThrowNullRef162, label %481
 
 ; <label>:481                                     ; preds = %477
   store i8 %480, i8* %475, align 8
@@ -1553,343 +1635,343 @@ ThrowNullRef:                                     ; preds = %308
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %312
+ThrowNullRef2:                                    ; preds = %312
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %315
+ThrowNullRef4:                                    ; preds = %315
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %321
+ThrowNullRef6:                                    ; preds = %321
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %271
+ThrowNullRef8:                                    ; preds = %271
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %275
+ThrowNullRef10:                                   ; preds = %275
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %278
+ThrowNullRef12:                                   ; preds = %278
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %284
+ThrowNullRef14:                                   ; preds = %284
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %287
+ThrowNullRef16:                                   ; preds = %287
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %293
+ThrowNullRef18:                                   ; preds = %293
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %298
+ThrowNullRef20:                                   ; preds = %298
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %303
+ThrowNullRef22:                                   ; preds = %303
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %243
+ThrowNullRef24:                                   ; preds = %243
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %247
+ThrowNullRef26:                                   ; preds = %247
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %250
+ThrowNullRef28:                                   ; preds = %250
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %256
+ThrowNullRef30:                                   ; preds = %256
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %259
+ThrowNullRef32:                                   ; preds = %259
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %265
+ThrowNullRef34:                                   ; preds = %265
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %217
+ThrowNullRef36:                                   ; preds = %217
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %221
+ThrowNullRef38:                                   ; preds = %221
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %224
+ThrowNullRef40:                                   ; preds = %224
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %230
+ThrowNullRef42:                                   ; preds = %230
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %233
+ThrowNullRef44:                                   ; preds = %233
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %238
+ThrowNullRef46:                                   ; preds = %238
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %200
+ThrowNullRef48:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %204
+ThrowNullRef50:                                   ; preds = %204
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %207
+ThrowNullRef52:                                   ; preds = %207
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %213
+ThrowNullRef54:                                   ; preds = %213
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %172
+ThrowNullRef56:                                   ; preds = %172
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %176
+ThrowNullRef58:                                   ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %179
+ThrowNullRef60:                                   ; preds = %179
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %185
+ThrowNullRef62:                                   ; preds = %185
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %190
+ThrowNullRef64:                                   ; preds = %190
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %195
+ThrowNullRef66:                                   ; preds = %195
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %153
+ThrowNullRef68:                                   ; preds = %153
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %157
+ThrowNullRef70:                                   ; preds = %157
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %160
+ThrowNullRef72:                                   ; preds = %160
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %166
+ThrowNullRef74:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %136
+ThrowNullRef76:                                   ; preds = %136
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %140
+ThrowNullRef78:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %143
+ThrowNullRef80:                                   ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %148
+ThrowNullRef82:                                   ; preds = %148
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %128
+ThrowNullRef84:                                   ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %132
+ThrowNullRef86:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %100
+ThrowNullRef88:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %104
+ThrowNullRef90:                                   ; preds = %104
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %107
+ThrowNullRef92:                                   ; preds = %107
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %113
+ThrowNullRef94:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %118
+ThrowNullRef96:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %123
+ThrowNullRef98:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %81
+ThrowNullRef100:                                  ; preds = %81
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef101:                                  ; preds = %85
+ThrowNullRef102:                                  ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef103:                                  ; preds = %88
+ThrowNullRef104:                                  ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef105:                                  ; preds = %94
+ThrowNullRef106:                                  ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef107:                                  ; preds = %64
+ThrowNullRef108:                                  ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef109:                                  ; preds = %68
+ThrowNullRef110:                                  ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef111:                                  ; preds = %71
+ThrowNullRef112:                                  ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef113:                                  ; preds = %76
+ThrowNullRef114:                                  ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef115:                                  ; preds = %56
+ThrowNullRef116:                                  ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef117:                                  ; preds = %60
+ThrowNullRef118:                                  ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef119:                                  ; preds = %37
+ThrowNullRef120:                                  ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef121:                                  ; preds = %41
+ThrowNullRef122:                                  ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef123:                                  ; preds = %46
+ThrowNullRef124:                                  ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef125:                                  ; preds = %51
+ThrowNullRef126:                                  ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef127:                                  ; preds = %27
+ThrowNullRef128:                                  ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef129:                                  ; preds = %31
+ThrowNullRef130:                                  ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef131:                                  ; preds = %19
+ThrowNullRef132:                                  ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef133:                                  ; preds = %22
+ThrowNullRef134:                                  ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef135:                                  ; preds = %338
+ThrowNullRef136:                                  ; preds = %338
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef137:                                  ; preds = %341
+ThrowNullRef138:                                  ; preds = %341
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef139:                                  ; preds = %356
+ThrowNullRef140:                                  ; preds = %356
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef141:                                  ; preds = %360
+ThrowNullRef142:                                  ; preds = %360
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef143:                                  ; preds = %377
+ThrowNullRef144:                                  ; preds = %377
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef145:                                  ; preds = %381
+ThrowNullRef146:                                  ; preds = %381
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef147:                                  ; preds = %424
+ThrowNullRef148:                                  ; preds = %424
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef149:                                  ; preds = %428
+ThrowNullRef150:                                  ; preds = %428
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef151:                                  ; preds = %440
+ThrowNullRef152:                                  ; preds = %440
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef153:                                  ; preds = %444
+ThrowNullRef154:                                  ; preds = %444
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef155:                                  ; preds = %456
+ThrowNullRef156:                                  ; preds = %456
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef157:                                  ; preds = %460
+ThrowNullRef158:                                  ; preds = %460
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef159:                                  ; preds = %474
+ThrowNullRef160:                                  ; preds = %474
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef161:                                  ; preds = %477
+ThrowNullRef162:                                  ; preds = %477
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef163:                                  ; preds = %394
+ThrowNullRef164:                                  ; preds = %394
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef165:                                  ; preds = %398
+ThrowNullRef166:                                  ; preds = %398
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef167:                                  ; preds = %401
+ThrowNullRef168:                                  ; preds = %401
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef169:                                  ; preds = %407
+ThrowNullRef170:                                  ; preds = %407
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1939,8 +2021,8 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
-  br i1 %NullCheck, label %22, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %ThrowNullRef, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
@@ -1948,8 +2030,8 @@ entry:
   store i32 %24, i32* %loc0
   %25 = load i32, i32* %loc0
   %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %26, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %27
 
 ; <label>:27                                      ; preds = %22
   %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
@@ -1971,7 +2053,7 @@ ThrowNullRef:                                     ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1989,8 +2071,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -2022,15 +2104,15 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2048,16 +2130,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
   %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
   store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %15
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
@@ -2072,8 +2154,8 @@ entry:
   %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
   %29 = ptrtoint i16 addrspace(1)* %28 to i64
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %19
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
@@ -2089,19 +2171,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2114,8 +2196,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
@@ -2128,7 +2210,7 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[loadElem]
+Failed to read AppDomain.PrepareDataForSetup[storeElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
@@ -2202,8 +2284,8 @@ entry:
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
-  br i1 %NullCheck24, label %27, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = load i64, i64 addrspace(1)* %26
@@ -2218,8 +2300,8 @@ entry:
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
-  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
   %41 = load i64, i64 addrspace(1)* %39
@@ -2236,8 +2318,8 @@ entry:
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
-  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
   %54 = load i64, i64 addrspace(1)* %52
@@ -2252,8 +2334,8 @@ entry:
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
   %67 = load i64, i64 addrspace(1)* %65
@@ -2270,8 +2352,8 @@ entry:
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
-  br i1 %NullCheck16, label %79, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
   %80 = load i64, i64 addrspace(1)* %78
@@ -2286,8 +2368,8 @@ entry:
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
-  br i1 %NullCheck18, label %92, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
   %93 = load i64, i64 addrspace(1)* %91
@@ -2304,8 +2386,8 @@ entry:
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
-  br i1 %NullCheck12, label %105, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = load i64, i64 addrspace(1)* %104
@@ -2320,8 +2402,8 @@ entry:
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
-  br i1 %NullCheck14, label %118, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
   %119 = load i64, i64 addrspace(1)* %117
@@ -2337,8 +2419,8 @@ entry:
 
 ; <label>:128                                     ; preds = %20
   %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
-  br i1 %NullCheck4, label %130, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %129, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %130
 
 ; <label>:130                                     ; preds = %128
   %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
@@ -2346,8 +2428,8 @@ entry:
   %133 = load i16, i16 addrspace(1)* %132, align 8
   %134 = zext i16 %133 to i32
   %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
-  br i1 %NullCheck6, label %136, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %135, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %136
 
 ; <label>:136                                     ; preds = %130
   %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
@@ -2360,8 +2442,8 @@ entry:
 
 ; <label>:143                                     ; preds = %136
   %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
-  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %144, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %145
 
 ; <label>:145                                     ; preds = %143
   %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
@@ -2369,8 +2451,8 @@ entry:
   %148 = load i16, i16 addrspace(1)* %147, align 8
   %149 = zext i16 %148 to i32
   %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %150, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %151
 
 ; <label>:151                                     ; preds = %145
   %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
@@ -2388,8 +2470,8 @@ entry:
 
 ; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
-  br i1 %NullCheck, label %163, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %ThrowNullRef, label %163
 
 ; <label>:163                                     ; preds = %161
   %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
@@ -2399,8 +2481,8 @@ entry:
 
 ; <label>:167                                     ; preds = %163
   %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
-  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %168, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %169
 
 ; <label>:169                                     ; preds = %167
   %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
@@ -2432,55 +2514,55 @@ ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %167
+ThrowNullRef2:                                    ; preds = %167
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %128
+ThrowNullRef4:                                    ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %130
+ThrowNullRef6:                                    ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %143
+ThrowNullRef8:                                    ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %145
+ThrowNullRef10:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %102
+ThrowNullRef12:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %105
+ThrowNullRef14:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %76
+ThrowNullRef16:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %79
+ThrowNullRef18:                                   ; preds = %79
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %50
+ThrowNullRef20:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %53
+ThrowNullRef22:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %24
+ThrowNullRef24:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %27
+ThrowNullRef26:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2503,15 +2585,15 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2519,16 +2601,16 @@ entry:
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
   store i32 %8, i32* %loc0
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
   %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
   store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
@@ -2546,16 +2628,16 @@ entry:
 
 ; <label>:23                                      ; preds = %64
   %24 = load i16*, i16** %loc3
-  %NullCheck12 = icmp ne i16* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i16* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
   store i32 %27, i32* %loc5
   %28 = load i16*, i16** %loc4
-  %NullCheck14 = icmp ne i16* %28, null
-  br i1 %NullCheck14, label %29, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %28, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = load i16, i16* %28, align 8
@@ -2620,15 +2702,15 @@ entry:
 
 ; <label>:67                                      ; preds = %64
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
-  br i1 %NullCheck8, label %69, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %68, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %69
 
 ; <label>:69                                      ; preds = %67
   %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
   %71 = load i32, i32 addrspace(1)* %70
   %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
-  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %73
 
 ; <label>:73                                      ; preds = %69
   %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
@@ -2645,31 +2727,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %67
+ThrowNullRef8:                                    ; preds = %67
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %69
+ThrowNullRef10:                                   ; preds = %69
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2710,14 +2792,14 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
   %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
@@ -2730,14 +2812,14 @@ entry:
 
 ; <label>:11                                      ; preds = %4
   %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
   %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
@@ -2749,14 +2831,14 @@ entry:
 
 ; <label>:22                                      ; preds = %16
   %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
   %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
-  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
-  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
@@ -2804,23 +2886,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2836,7 +2918,280 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[loadElem]
+Successfully read RuntimeType.IsAssignableFrom
+
+define i8 @RuntimeType.IsAssignableFrom(%System.RuntimeType addrspace(1)* %param0, %System.Type addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.RuntimeType addrspace(1)*
+  %arg1 = alloca %System.Type addrspace(1)*
+  %loc0 = alloca %System.RuntimeType addrspace(1)*
+  %loc1 = alloca %"System.Type[]" addrspace(1)*
+  %loc2 = alloca i32
+  store %System.RuntimeType addrspace(1)* %param0, %System.RuntimeType addrspace(1)** %this
+  store %System.Type addrspace(1)* %param1, %System.Type addrspace(1)** %arg1
+  %0 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %1 = icmp ne %System.Type addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i8 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %5 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %6 = bitcast %System.Type addrspace(1)* %4 to %System.Object addrspace(1)*
+  %7 = bitcast %System.RuntimeType addrspace(1)* %5 to %System.Object addrspace(1)*
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %6, %System.Object addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %3
+  ret i8 1
+
+; <label>:12                                      ; preds = %3
+  %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 152
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 32
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
+  %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
+  %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
+  store %System.RuntimeType addrspace(1)* %25, %System.RuntimeType addrspace(1)** %loc0
+  %26 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %27 = icmp eq %System.RuntimeType addrspace(1)* %26, null
+  br i1 %27, label %34, label %28
+
+; <label>:28                                      ; preds = %15
+  %29 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %30 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)*)*)(%System.RuntimeType addrspace(1)* %29, %System.RuntimeType addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+; <label>:34                                      ; preds = %15
+  %35 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %36 = call %System.Reflection.Emit.TypeBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Reflection.Emit.TypeBuilder addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %35)
+  %37 = icmp eq %System.Reflection.Emit.TypeBuilder addrspace(1)* %36, null
+  br i1 %37, label %139, label %38
+
+; <label>:38                                      ; preds = %34
+  %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %42
+
+; <label>:42                                      ; preds = %38
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 152
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 40
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
+  %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
+  %53 = zext i8 %52 to i32
+  %54 = icmp eq i32 %53, 0
+  br i1 %54, label %56, label %55
+
+; <label>:55                                      ; preds = %42
+  ret i8 1
+
+; <label>:56                                      ; preds = %42
+  %57 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %58 = bitcast %System.RuntimeType addrspace(1)* %57 to %System.Type addrspace(1)*
+  %59 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %58)
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %64 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.Type addrspace(1)* %63, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = bitcast %System.RuntimeType addrspace(1)* %64 to %System.Type addrspace(1)*
+  %67 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %63, %System.Type addrspace(1)* %66)
+  %68 = zext i8 %67 to i32
+  %69 = trunc i32 %68 to i8
+  ret i8 %69
+
+; <label>:70                                      ; preds = %56
+  %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
+  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %73
+
+; <label>:73                                      ; preds = %70
+  %74 = load i64, i64 addrspace(1)* %72
+  %75 = add i64 %74, 128
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = add i64 %77, 0
+  %79 = inttoptr i64 %78 to i64*
+  %80 = load i64, i64* %79
+  %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
+  %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
+  %83 = call i8 %82(%System.Type addrspace(1)* %81)
+  %84 = zext i8 %83 to i32
+  %85 = icmp eq i32 %84, 0
+  br i1 %85, label %139, label %86
+
+; <label>:86                                      ; preds = %73
+  %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
+  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %89
+
+; <label>:89                                      ; preds = %86
+  %90 = load i64, i64 addrspace(1)* %88
+  %91 = add i64 %90, 128
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = add i64 %93, 24
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
+  %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
+  %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
+  store %"System.Type[]" addrspace(1)* %99, %"System.Type[]" addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %129
+
+; <label>:100                                     ; preds = %132
+  %101 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %102 = load i32, i32* %loc2
+  %NullCheck11 = icmp eq %"System.Type[]" addrspace(1)* %101, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %103
+
+; <label>:103                                     ; preds = %100
+  %104 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 1
+  %105 = load i32, i32 addrspace(1)* %104
+  %106 = zext i32 %105 to i64
+  %107 = zext i32 %102 to i64
+  %BoundsCheck = icmp uge i64 %107, %106
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %108
+
+; <label>:108                                     ; preds = %103
+  %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
+  %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
+  %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
+  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %113
+
+; <label>:113                                     ; preds = %108
+  %114 = load i64, i64 addrspace(1)* %112
+  %115 = add i64 %114, 152
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = add i64 %117, 56
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
+  %123 = zext i8 %122 to i32
+  %124 = icmp ne i32 %123, 0
+  br i1 %124, label %126, label %125
+
+; <label>:125                                     ; preds = %113
+  ret i8 0
+
+; <label>:126                                     ; preds = %113
+  %127 = load i32, i32* %loc2
+  %128 = add i32 %127, 1
+  store i32 %128, i32* %loc2
+  br label %129
+
+; <label>:129                                     ; preds = %89, %126
+  %130 = load i32, i32* %loc2
+  %131 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %NullCheck9 = icmp eq %"System.Type[]" addrspace(1)* %131, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %132
+
+; <label>:132                                     ; preds = %129
+  %133 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %131, i32 0, i32 1
+  %134 = load i32, i32 addrspace(1)* %133
+  %135 = zext i32 %134 to i64
+  %136 = trunc i64 %135 to i32
+  %137 = icmp slt i32 %130, %136
+  br i1 %137, label %100, label %138
+
+; <label>:138                                     ; preds = %132
+  ret i8 1
+
+; <label>:139                                     ; preds = %34, %73
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %129
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %103
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -2893,7 +3248,7 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElem]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -2904,8 +3259,8 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -2997,8 +3352,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
@@ -3059,8 +3414,8 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -3087,8 +3442,8 @@ entry:
 
 ; <label>:17                                      ; preds = %5, %11
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
@@ -3097,8 +3452,8 @@ entry:
 
 ; <label>:22                                      ; preds = %1, %11
   %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
@@ -3109,11 +3464,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %17
+ThrowNullRef2:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %22
+ThrowNullRef4:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3167,15 +3522,15 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
   %15 = load i32, i32 addrspace(1)* %14
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
@@ -3198,7 +3553,7 @@ ThrowNullRef:                                     ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef2:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3232,8 +3587,8 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
@@ -3312,8 +3667,8 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -3327,8 +3682,8 @@ entry:
 ; <label>:5                                       ; preds = %43
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %7 = load i32, i32* %loc1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck6, label %8, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
@@ -3366,8 +3721,8 @@ entry:
 ; <label>:32                                      ; preds = %21, %25
   %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
   %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
-  br i1 %NullCheck8, label %35, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = trunc i32 %34 to i16
@@ -3380,8 +3735,8 @@ entry:
 ; <label>:40                                      ; preds = %1, %35
   %41 = load i32, i32* %loc1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
-  br i1 %NullCheck2, label %43, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %42, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
@@ -3392,8 +3747,8 @@ entry:
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
   %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
-  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
   %51 = load i64, i64 addrspace(1)* %49
@@ -3412,19 +3767,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %40
+ThrowNullRef2:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %47
+ThrowNullRef4:                                    ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %5
+ThrowNullRef6:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %32
+ThrowNullRef8:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3467,8 +3822,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
@@ -3492,11 +3847,391 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(i16* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store i16* %param0, i16** %arg0
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load i32, i32* %arg3
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %42, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %37, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg2
+  %13 = load i32, i32* %arg3
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %37, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %24 = load i32, i32* %arg2
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load i16*, i16** %arg0
+  %35 = load i32, i32* %arg3
+  %36 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %36, i16* %34, i32 %35)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:37                                      ; preds = %5, %16
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %39)
+  %41 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41, %System.String addrspace(1)* %38, %System.String addrspace(1)* %40)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41) #0
+  unreachable
+
+; <label>:42                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
-Failed to read StringBuilder.ToString[loadElemA]
+Successfully read StringBuilder.ToString
+
+define %System.String addrspace(1)* @StringBuilder.ToString(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i16*
+  %loc3 = alloca %"System.Char[]" addrspace(1)*
+  %loc4 = alloca i32
+  %loc5 = alloca i32
+  %loc6 = alloca i16 addrspace(1)*
+  %loc7 = alloca %System.String addrspace(1)*
+  %loc8 = alloca %"System.Char[]" addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %0)
+  %2 = icmp ne i32 %1, 0
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %4
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %6)
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %7)
+  store %System.String addrspace(1)* %8, %System.String addrspace(1)** %loc0
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.Text.StringBuilder addrspace(1)* %9, %System.Text.StringBuilder addrspace(1)** %loc1
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  store %System.String addrspace(1)* %10, %System.String addrspace(1)** %loc7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc7
+  %12 = ptrtoint %System.String addrspace(1)* %11 to i64
+  %13 = icmp eq i64 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %5
+  %15 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %16 = sext i32 %15 to i64
+  %17 = add i64 %12, %16
+  br label %18
+
+; <label>:18                                      ; preds = %5, %14
+  %19 = phi i64 [ %12, %5 ], [ %17, %14 ]
+  %20 = inttoptr i64 %19 to i16*
+  store i16* %20, i16** %loc2
+  br label %21
+
+; <label>:21                                      ; preds = %98, %18
+  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %22, null
+  br i1 %NullCheck, label %ThrowNullRef, label %23
+
+; <label>:23                                      ; preds = %21
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 3
+  %25 = load i32, i32 addrspace(1)* %24, align 8
+  %26 = icmp sle i32 %25, 0
+  br i1 %26, label %96, label %27
+
+; <label>:27                                      ; preds = %23
+  %28 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %28, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %29
+
+; <label>:29                                      ; preds = %27
+  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %28, i32 0, i32 1
+  %31 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %30, align 8
+  store %"System.Char[]" addrspace(1)* %31, %"System.Char[]" addrspace(1)** %loc3
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %33
+
+; <label>:33                                      ; preds = %29
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  store i32 %35, i32* %loc4
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  %39 = load i32, i32 addrspace(1)* %38, align 8
+  store i32 %39, i32* %loc5
+  %40 = load i32, i32* %loc5
+  %41 = load i32, i32* %loc4
+  %42 = add i32 %40, %41
+  %43 = zext i32 %42 to i64
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %45
+
+; <label>:45                                      ; preds = %37
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = sext i32 %47 to i64
+  %49 = icmp sgt i64 %43, %48
+  br i1 %49, label %91, label %50
+
+; <label>:50                                      ; preds = %45
+  %51 = load i32, i32* %loc5
+  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %52, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %53
+
+; <label>:53                                      ; preds = %50
+  %54 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %52, i32 0, i32 1
+  %55 = load i32, i32 addrspace(1)* %54
+  %56 = zext i32 %55 to i64
+  %57 = trunc i64 %56 to i32
+  %58 = icmp ugt i32 %51, %57
+  br i1 %58, label %91, label %59
+
+; <label>:59                                      ; preds = %53
+  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  store %"System.Char[]" addrspace(1)* %60, %"System.Char[]" addrspace(1)** %loc8
+  %61 = icmp eq %"System.Char[]" addrspace(1)* %60, null
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %63, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %64
+
+; <label>:64                                      ; preds = %62
+  %65 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %63, i32 0, i32 1
+  %66 = load i32, i32 addrspace(1)* %65
+  %67 = zext i32 %66 to i64
+  %68 = trunc i64 %67 to i32
+  %69 = icmp ne i32 %68, 0
+  br i1 %69, label %71, label %70
+
+; <label>:70                                      ; preds = %59, %64
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:71                                      ; preds = %64
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %73
+
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %BoundsCheck = icmp uge i64 0, %76
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %77
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %78, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:79                                      ; preds = %70, %77
+  %80 = load i16*, i16** %loc2
+  %81 = load i32, i32* %loc4
+  %82 = sext i32 %81 to i64
+  %83 = mul i64 %82, 2
+  %84 = bitcast i16* %80 to i8*
+  %85 = getelementptr inbounds i8, i8* %84, i64 %83
+  %86 = load i16 addrspace(1)*, i16 addrspace(1)** %loc6
+  %87 = ptrtoint i16 addrspace(1)* %86 to i64
+  %88 = load i32, i32* %loc5
+  %89 = bitcast i8* %85 to i16*
+  %90 = inttoptr i64 %87 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %89, i16* %90, i32 %88)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %96
+
+; <label>:91                                      ; preds = %45, %53
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %94 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %93)
+  %95 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95, %System.String addrspace(1)* %92, %System.String addrspace(1)* %94)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95) #0
+  unreachable
+
+; <label>:96                                      ; preds = %23, %79
+  %97 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %97, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %98
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %97, i32 0, i32 2
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  store %System.Text.StringBuilder addrspace(1)* %100, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %102 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %102, label %21, label %103
+
+; <label>:103                                     ; preds = %98
+  store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc7
+  %104 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  ret %System.String addrspace(1)* %104
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method StringBuilder::get_Length using LLILCJit
+Successfully read StringBuilder.get_Length
+
+define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
+Successfully read RuntimeHelpers.get_OffsetToStringData
+
+define i32 @RuntimeHelpers.get_OffsetToStringData() {
+entry:
+  ret i32 12
+}
+
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
 Successfully read CultureData.CreateCultureData
 
@@ -3514,23 +4249,23 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
   store i8 %4, i8 addrspace(1)* %6
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
@@ -3549,11 +4284,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3566,50 +4301,50 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
   store i32 -1, i32 addrspace(1)* %2
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
   store i32 -1, i32 addrspace(1)* %8
   %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
   store i32 -1, i32 addrspace(1)* %14
   %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
   store i32 -1, i32 addrspace(1)* %17
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
@@ -3623,27 +4358,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3675,7 +4410,136 @@ Failed to read Dictionary`2.Insert[non-const derefAddress]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
 Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
-Failed to read HashHelpers.GetPrime[loadElem]
+Successfully read HashHelpers.GetPrime
+
+define i32 @HashHelpers.GetPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %6, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5, %System.String addrspace(1)* %4)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5) #0
+  unreachable
+
+; <label>:6                                       ; preds = %entry
+  store i32 0, i32* %loc0
+  br label %29
+
+; <label>:7                                       ; preds = %35
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 1296
+  %10 = addrspacecast i8 addrspace(1)* %9 to %"System.Int32[]" addrspace(1)**
+  %11 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %10
+  %12 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Int32[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = zext i32 %15 to i64
+  %17 = zext i32 %12 to i64
+  %BoundsCheck = icmp uge i64 %17, %16
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 3, i32 %12
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  store i32 %20, i32* %loc1
+  %21 = load i32, i32* %loc1
+  %22 = load i32, i32* %arg0
+  %23 = icmp slt i32 %21, %22
+  br i1 %23, label %26, label %24
+
+; <label>:24                                      ; preds = %18
+  %25 = load i32, i32* %loc1
+  ret i32 %25
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %loc0
+  %28 = add i32 %27, 1
+  store i32 %28, i32* %loc0
+  br label %29
+
+; <label>:29                                      ; preds = %6, %26
+  %30 = load i32, i32* %loc0
+  %31 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %32 = getelementptr inbounds i8, i8 addrspace(1)* %31, i64 1296
+  %33 = addrspacecast i8 addrspace(1)* %32 to %"System.Int32[]" addrspace(1)**
+  %34 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %33
+  %NullCheck = icmp eq %"System.Int32[]" addrspace(1)* %34, null
+  br i1 %NullCheck, label %ThrowNullRef, label %35
+
+; <label>:35                                      ; preds = %29
+  %36 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %34, i32 0, i32 1
+  %37 = load i32, i32 addrspace(1)* %36
+  %38 = zext i32 %37 to i64
+  %39 = trunc i64 %38 to i32
+  %40 = icmp slt i32 %30, %39
+  br i1 %40, label %7, label %41
+
+; <label>:41                                      ; preds = %35
+  %42 = load i32, i32* %arg0
+  %43 = or i32 %42, 1
+  store i32 %43, i32* %loc2
+  br label %59
+
+; <label>:44                                      ; preds = %59
+  %45 = load i32, i32* %loc2
+  %46 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %45)
+  %47 = zext i8 %46 to i32
+  %48 = icmp eq i32 %47, 0
+  br i1 %48, label %56, label %49
+
+; <label>:49                                      ; preds = %44
+  %50 = load i32, i32* %loc2
+  %51 = sub i32 %50, 1
+  %52 = srem i32 %51, 101
+  %53 = icmp eq i32 %52, 0
+  br i1 %53, label %56, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = load i32, i32* %loc2
+  ret i32 %55
+
+; <label>:56                                      ; preds = %44, %49
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %57, 2
+  store i32 %58, i32* %loc2
+  br label %59
+
+; <label>:59                                      ; preds = %41, %56
+  %60 = load i32, i32* %loc2
+  %61 = icmp slt i32 %60, 2147483647
+  br i1 %61, label %44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load i32, i32* %arg0
+  ret i32 %63
+
+ThrowNullRef:                                     ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
 Successfully read GenericEqualityComparer`1.GetHashCode
 
@@ -3694,14 +4558,14 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
   %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load i64, i64 addrspace(1)* %7
@@ -3720,7 +4584,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3750,8 +4614,8 @@ entry:
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
@@ -3796,8 +4660,8 @@ entry:
   %35 = bitcast i16* %34 to i8*
   %36 = getelementptr inbounds i8, i8* %35, i64 2
   %37 = bitcast i8* %36 to i16*
-  %NullCheck4 = icmp ne i16* %37, null
-  br i1 %NullCheck4, label %38, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %37, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %38
 
 ; <label>:38                                      ; preds = %27
   %39 = load i16, i16* %37, align 8
@@ -3824,8 +4688,8 @@ entry:
 
 ; <label>:54                                      ; preds = %22, %43
   %55 = load i16*, i16** %loc4
-  %NullCheck2 = icmp ne i16* %55, null
-  br i1 %NullCheck2, label %56, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i16* %55, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %56
 
 ; <label>:56                                      ; preds = %54
   %57 = load i16, i16* %55, align 8
@@ -3850,11 +4714,11 @@ ThrowNullRef:                                     ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %54
+ThrowNullRef2:                                    ; preds = %54
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %27
+ThrowNullRef4:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3871,8 +4735,8 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -3907,8 +4771,8 @@ entry:
 
 ; <label>:26                                      ; preds = %19
   %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
-  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %28
 
 ; <label>:28                                      ; preds = %26
   %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
@@ -3920,7 +4784,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3972,8 +4836,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
@@ -3984,26 +4848,26 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
-  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
@@ -4014,8 +4878,8 @@ entry:
 ; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
@@ -4024,8 +4888,8 @@ entry:
 
 ; <label>:25                                      ; preds = %1, %16, %23
   %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
-  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
@@ -4036,27 +4900,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %20
+ThrowNullRef10:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4069,8 +4933,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -4081,8 +4945,8 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
@@ -4091,8 +4955,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1, %8
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
@@ -4103,11 +4967,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4128,24 +4992,24 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   store i32 %3, i32* %loc0
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
   %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
   store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck4, label %9, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
@@ -4164,15 +5028,15 @@ entry:
 ; <label>:18                                      ; preds = %70
   %19 = load i16*, i16** %loc3
   %20 = bitcast i16* %19 to i64*
-  %NullCheck10 = icmp ne i64* %20, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %20, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = load i64, i64* %20, align 8
   %23 = load i16*, i16** %loc4
   %24 = bitcast i16* %23 to i64*
-  %NullCheck12 = icmp ne i64* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = load i64, i64* %24, align 8
@@ -4188,8 +5052,8 @@ entry:
   %31 = bitcast i16* %30 to i8*
   %32 = getelementptr inbounds i8, i8* %31, i64 8
   %33 = bitcast i8* %32 to i64*
-  %NullCheck14 = icmp ne i64* %33, null
-  br i1 %NullCheck14, label %34, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = load i64, i64* %33, align 8
@@ -4197,8 +5061,8 @@ entry:
   %37 = bitcast i16* %36 to i8*
   %38 = getelementptr inbounds i8, i8* %37, i64 8
   %39 = bitcast i8* %38 to i64*
-  %NullCheck16 = icmp ne i64* %39, null
-  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %40
 
 ; <label>:40                                      ; preds = %34
   %41 = load i64, i64* %39, align 8
@@ -4214,8 +5078,8 @@ entry:
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %NullCheck18 = icmp ne i64* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = load i64, i64* %48, align 8
@@ -4223,8 +5087,8 @@ entry:
   %52 = bitcast i16* %51 to i8*
   %53 = getelementptr inbounds i8, i8* %52, i64 16
   %54 = bitcast i8* %53 to i64*
-  %NullCheck20 = icmp ne i64* %54, null
-  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64* %54, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %55
 
 ; <label>:55                                      ; preds = %49
   %56 = load i64, i64* %54, align 8
@@ -4262,15 +5126,15 @@ entry:
 ; <label>:74                                      ; preds = %95
   %75 = load i16*, i16** %loc3
   %76 = bitcast i16* %75 to i32*
-  %NullCheck6 = icmp ne i32* %76, null
-  br i1 %NullCheck6, label %77, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32* %76, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %77
 
 ; <label>:77                                      ; preds = %74
   %78 = load i32, i32* %76, align 8
   %79 = load i16*, i16** %loc4
   %80 = bitcast i16* %79 to i32*
-  %NullCheck8 = icmp ne i32* %80, null
-  br i1 %NullCheck8, label %81, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i32* %80, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %81
 
 ; <label>:81                                      ; preds = %77
   %82 = load i32, i32* %80, align 8
@@ -4318,43 +5182,43 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %74
+ThrowNullRef6:                                    ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %77
+ThrowNullRef8:                                    ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %29
+ThrowNullRef14:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %34
+ThrowNullRef16:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4376,8 +5240,8 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load i64, i64 addrspace(1)* %4
@@ -4389,8 +5253,8 @@ entry:
   %12 = load i64, i64* %11
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %5
   %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
@@ -4399,8 +5263,8 @@ entry:
   %18 = load i8, i8* %arg2
   %19 = zext i8 %18 to i32
   %20 = trunc i32 %19 to i8
-  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %15
   %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
@@ -4411,11 +5275,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4442,8 +5306,8 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
@@ -4466,16 +5330,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
   %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = load i64, i64 addrspace(1)* %19
@@ -4500,8 +5364,8 @@ entry:
 ; <label>:35                                      ; preds = %30
   %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
@@ -4514,8 +5378,8 @@ entry:
 
 ; <label>:42                                      ; preds = %1, %38
   %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
-  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
@@ -4526,19 +5390,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %35
+ThrowNullRef2:                                    ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %42
+ThrowNullRef8:                                    ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4551,14 +5415,14 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
@@ -4570,7 +5434,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4583,8 +5447,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
@@ -4613,51 +5477,51 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
   %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
   %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
   %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
   %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
-  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
   store i64 %21, i64 addrspace(1)* %23
   %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %25 = load i64, i64* %loc0
-  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
@@ -4668,27 +5532,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %22
+ThrowNullRef12:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4701,8 +5565,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
@@ -4713,19 +5577,19 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
@@ -4734,8 +5598,8 @@ entry:
 
 ; <label>:15                                      ; preds = %1, %13
   %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
@@ -4746,19 +5610,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %15
+ThrowNullRef8:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4771,8 +5635,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -4831,8 +5695,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
@@ -4882,8 +5746,8 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
-  br i1 %NullCheck, label %17, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %ThrowNullRef, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
@@ -4894,15 +5758,15 @@ entry:
 
 ; <label>:22                                      ; preds = %17
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
-  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
   %26 = load i32, i32 addrspace(1)* %25
   %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
-  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %27, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
@@ -4925,8 +5789,8 @@ entry:
 ; <label>:40                                      ; preds = %17
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
-  br i1 %NullCheck6, label %43, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %41, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
@@ -4938,34 +5802,17 @@ ThrowNullRef:                                     ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %24
+ThrowNullRef4:                                    ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %40
+ThrowNullRef6:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
-}
-
-INFO:  jitting method Object::ReferenceEquals using LLILCJit
-Successfully read Object.ReferenceEquals
-
-define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
-entry:
-  %arg0 = alloca %System.Object addrspace(1)*
-  %arg1 = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
-  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
-  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = icmp eq %System.Object addrspace(1)* %0, %1
-  %3 = sext i1 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
 }
 
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
@@ -4978,21 +5825,21 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
   %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
-  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
@@ -5007,28 +5854,28 @@ entry:
 ; <label>:13                                      ; preds = %8, %12
   %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
   %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
   %21 = load i32, i32 addrspace(1)* %20, align 8
   %22 = add i32 %21, 1
-  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
   store i32 %22, i32 addrspace(1)* %24
   %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
@@ -5039,27 +5886,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5077,7 +5924,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::Setup using LLILCJit
-Failed to read AppDomain.Setup[loadElem]
+Failed to read AppDomain.Setup[unbox]
 INFO:  jitting method Thread::GetDomain using LLILCJit
 Successfully read Thread.GetDomain
 
@@ -5108,8 +5955,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
@@ -5122,14 +5969,14 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
   %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
@@ -5141,11 +5988,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5173,8 +6020,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -5189,7 +6036,328 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
 Failed to read KeyCollection.System.Collections.Generic.IEnumerable<TKey>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Successfully read Enumerator.MoveNext
+
+define i8 @Enumerator.MoveNext(%"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.RuntimeTypeHandle* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*
+  %"$TypeArg" = alloca %System.RuntimeTypeHandle*
+  store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
+  %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 8
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %76, label %12
+
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
+  br label %76
+
+; <label>:13                                      ; preds = %85
+  %14 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck19 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %15
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, i32 0, i32 0
+  %17 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %16, align 8
+  %NullCheck21 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, i32 0, i32 2
+  %20 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %19, align 8
+  %21 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck23 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %22
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, i32 0, i32 2
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %NullCheck25 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 3, i32 %24
+  %NullCheck27 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %32
+
+; <label>:32                                      ; preds = %30
+  %33 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, i32 0, i32 2
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = icmp slt i32 %34, 0
+  br i1 %35, label %68, label %36
+
+; <label>:36                                      ; preds = %32
+  %37 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %38 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck29 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %39
+
+; <label>:39                                      ; preds = %36
+  %40 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, i32 0, i32 0
+  %41 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %40, align 8
+  %NullCheck31 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, i32 0, i32 2
+  %44 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %43, align 8
+  %45 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck33 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, i32 0, i32 2
+  %48 = load i32, i32 addrspace(1)* %47, align 8
+  %NullCheck35 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %49
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = zext i32 %51 to i64
+  %53 = zext i32 %48 to i64
+  %BoundsCheck37 = icmp uge i64 %53, %52
+  br i1 %BoundsCheck37, label %ThrowIndexOutOfRange38, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 3, i32 %48
+  %NullCheck39 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %56
+
+; <label>:56                                      ; preds = %54
+  %57 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, i32 0, i32 0
+  %58 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck41 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %59
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %60, %System.__Canon addrspace(1)* %58)
+  %61 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck43 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  %64 = load i32, i32 addrspace(1)* %63, align 8
+  %65 = add i32 %64, 1
+  %NullCheck45 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  store i32 %65, i32 addrspace(1)* %67
+  ret i8 1
+
+; <label>:68                                      ; preds = %32
+  %69 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck47 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %73 = add i32 %72, 1
+  %NullCheck49 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %74
+
+; <label>:74                                      ; preds = %70
+  %75 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  store i32 %73, i32 addrspace(1)* %75
+  br label %76
+
+; <label>:76                                      ; preds = %8, %12, %74
+  %77 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %78
+
+; <label>:78                                      ; preds = %76
+  %79 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, i32 0, i32 2
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck7 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %82
+
+; <label>:82                                      ; preds = %78
+  %83 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, i32 0, i32 0
+  %84 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %83, align 8
+  %NullCheck9 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %85
+
+; <label>:85                                      ; preds = %82
+  %86 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, i32 0, i32 7
+  %87 = load i32, i32 addrspace(1)* %86, align 8
+  %88 = icmp ult i32 %80, %87
+  br i1 %88, label %13, label %89
+
+; <label>:89                                      ; preds = %85
+  %90 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %91 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck11 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %92
+
+; <label>:92                                      ; preds = %89
+  %93 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, i32 0, i32 0
+  %94 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck13 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %95
+
+; <label>:95                                      ; preds = %92
+  %96 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, i32 0, i32 7
+  %97 = load i32, i32 addrspace(1)* %96, align 8
+  %98 = add i32 %97, 1
+  %NullCheck15 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %99
+
+; <label>:99                                      ; preds = %95
+  %100 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, i32 0, i32 2
+  store i32 %98, i32 addrspace(1)* %100
+  %101 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck17 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %102
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %103, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %92
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef22:                                   ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef24:                                   ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef26:                                   ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef28:                                   ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef30:                                   ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef32:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef34:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef36:                                   ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange38:                           ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef40:                                   ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef42:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef44:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef46:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef48:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef50:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -5200,8 +6368,8 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -5232,9 +6400,9 @@ Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
 Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
-Failed to read String.MakeSeparatorList[loadElemA]
+Failed to read String.MakeSeparatorList[storeElem]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
-Failed to read String.InternalSplitKeepEmptyEntries[loadElem]
+Failed to read String.InternalSplitKeepEmptyEntries[storeElem]
 INFO:  jitting method Path::IsRelative using LLILCJit
 Successfully read Path.IsRelative
 
@@ -5243,8 +6411,8 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -5254,8 +6422,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
@@ -5271,8 +6439,8 @@ entry:
 
 ; <label>:17                                      ; preds = %7
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
@@ -5288,8 +6456,8 @@ entry:
 
 ; <label>:29                                      ; preds = %19
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %31
 
 ; <label>:31                                      ; preds = %29
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
@@ -5300,8 +6468,8 @@ entry:
 
 ; <label>:36                                      ; preds = %31
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
-  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %37, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
@@ -5312,8 +6480,8 @@ entry:
 
 ; <label>:43                                      ; preds = %31, %38
   %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
-  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %45
 
 ; <label>:45                                      ; preds = %43
   %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
@@ -5324,8 +6492,8 @@ entry:
 
 ; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %50
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
@@ -5336,8 +6504,8 @@ entry:
 
 ; <label>:57                                      ; preds = %1, %7, %19, %45, %52
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
-  br i1 %NullCheck14, label %59, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %59
 
 ; <label>:59                                      ; preds = %57
   %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
@@ -5347,8 +6515,8 @@ entry:
 
 ; <label>:63                                      ; preds = %59
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
@@ -5359,8 +6527,8 @@ entry:
 
 ; <label>:70                                      ; preds = %65
   %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
-  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.String addrspace(1)* %71, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %72
 
 ; <label>:72                                      ; preds = %70
   %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
@@ -5379,39 +6547,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %17
+ThrowNullRef4:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %29
+ThrowNullRef6:                                    ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %36
+ThrowNullRef8:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %43
+ThrowNullRef10:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %50
+ThrowNullRef12:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %57
+ThrowNullRef14:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %63
+ThrowNullRef16:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %70
+ThrowNullRef18:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5419,7 +6587,293 @@ ThrowNullRef17:                                   ; preds = %70
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
-Failed to read String.TrimHelper[loadElem]
+Successfully read String.TrimHelper
+
+define %System.String addrspace(1)* @String.TrimHelper(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i16
+  %loc4 = alloca i32
+  %loc5 = alloca i16
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = sub i32 %3, 1
+  store i32 %4, i32* %loc0
+  store i32 0, i32* %loc1
+  %5 = load i32, i32* %arg2
+  %6 = icmp eq i32 %5, 1
+  br i1 %6, label %62, label %7
+
+; <label>:7                                       ; preds = %1
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:8                                       ; preds = %58
+  store i32 0, i32* %loc2
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load i32, i32* %loc1
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2, i32 %10
+  %13 = load i16, i16 addrspace(1)* %12
+  %14 = zext i16 %13 to i32
+  %15 = trunc i32 %14 to i16
+  store i16 %15, i16* %loc3
+  store i32 0, i32* %loc2
+  br label %34
+
+; <label>:16                                      ; preds = %37
+  %17 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %18 = load i32, i32* %loc2
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %17, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %19
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = zext i32 %18 to i64
+  %BoundsCheck = icmp uge i64 %23, %22
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %24
+
+; <label>:24                                      ; preds = %19
+  %25 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 3, i32 %18
+  %26 = load i16, i16 addrspace(1)* %25, align 8
+  %27 = zext i16 %26 to i32
+  %28 = load i16, i16* %loc3
+  %29 = zext i16 %28 to i32
+  %30 = icmp eq i32 %27, %29
+  br i1 %30, label %43, label %31
+
+; <label>:31                                      ; preds = %24
+  %32 = load i32, i32* %loc2
+  %33 = add i32 %32, 1
+  store i32 %33, i32* %loc2
+  br label %34
+
+; <label>:34                                      ; preds = %11, %31
+  %35 = load i32, i32* %loc2
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = icmp slt i32 %35, %41
+  br i1 %42, label %16, label %43
+
+; <label>:43                                      ; preds = %24, %37
+  %44 = load i32, i32* %loc2
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %45, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp eq i32 %44, %50
+  br i1 %51, label %62, label %52
+
+; <label>:52                                      ; preds = %46
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %7, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %57, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %58
+
+; <label>:58                                      ; preds = %55
+  %59 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %60 = load i32, i32 addrspace(1)* %59
+  %61 = icmp slt i32 %56, %60
+  br i1 %61, label %8, label %62
+
+; <label>:62                                      ; preds = %1, %46, %58
+  %63 = load i32, i32* %arg2
+  %64 = icmp eq i32 %63, 0
+  br i1 %64, label %122, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %66, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %67
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %66, i32 0, i32 1
+  %69 = load i32, i32 addrspace(1)* %68
+  %70 = sub i32 %69, 1
+  store i32 %70, i32* %loc0
+  br label %118
+
+; <label>:71                                      ; preds = %118
+  store i32 0, i32* %loc4
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %73 = load i32, i32* %loc0
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %74
+
+; <label>:74                                      ; preds = %71
+  %75 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 2, i32 %73
+  %76 = load i16, i16 addrspace(1)* %75
+  %77 = zext i16 %76 to i32
+  %78 = trunc i32 %77 to i16
+  store i16 %78, i16* %loc5
+  store i32 0, i32* %loc4
+  br label %97
+
+; <label>:79                                      ; preds = %100
+  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %81 = load i32, i32* %loc4
+  %NullCheck19 = icmp eq %"System.Char[]" addrspace(1)* %80, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
+
+; <label>:82                                      ; preds = %79
+  %83 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 1
+  %84 = load i32, i32 addrspace(1)* %83
+  %85 = zext i32 %84 to i64
+  %86 = zext i32 %81 to i64
+  %BoundsCheck21 = icmp uge i64 %86, %85
+  br i1 %BoundsCheck21, label %ThrowIndexOutOfRange22, label %87
+
+; <label>:87                                      ; preds = %82
+  %88 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 3, i32 %81
+  %89 = load i16, i16 addrspace(1)* %88, align 8
+  %90 = zext i16 %89 to i32
+  %91 = load i16, i16* %loc5
+  %92 = zext i16 %91 to i32
+  %93 = icmp eq i32 %90, %92
+  br i1 %93, label %106, label %94
+
+; <label>:94                                      ; preds = %87
+  %95 = load i32, i32* %loc4
+  %96 = add i32 %95, 1
+  store i32 %96, i32* %loc4
+  br label %97
+
+; <label>:97                                      ; preds = %74, %94
+  %98 = load i32, i32* %loc4
+  %99 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck15 = icmp eq %"System.Char[]" addrspace(1)* %99, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %100
+
+; <label>:100                                     ; preds = %97
+  %101 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %99, i32 0, i32 1
+  %102 = load i32, i32 addrspace(1)* %101
+  %103 = zext i32 %102 to i64
+  %104 = trunc i64 %103 to i32
+  %105 = icmp slt i32 %98, %104
+  br i1 %105, label %79, label %106
+
+; <label>:106                                     ; preds = %87, %100
+  %107 = load i32, i32* %loc4
+  %108 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck17 = icmp eq %"System.Char[]" addrspace(1)* %108, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %109
+
+; <label>:109                                     ; preds = %106
+  %110 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %108, i32 0, i32 1
+  %111 = load i32, i32 addrspace(1)* %110
+  %112 = zext i32 %111 to i64
+  %113 = trunc i64 %112 to i32
+  %114 = icmp eq i32 %107, %113
+  br i1 %114, label %122, label %115
+
+; <label>:115                                     ; preds = %109
+  %116 = load i32, i32* %loc0
+  %117 = sub i32 %116, 1
+  store i32 %117, i32* %loc0
+  br label %118
+
+; <label>:118                                     ; preds = %67, %115
+  %119 = load i32, i32* %loc0
+  %120 = load i32, i32* %loc1
+  %121 = icmp sge i32 %119, %120
+  br i1 %121, label %71, label %122
+
+; <label>:122                                     ; preds = %62, %109, %118
+  %123 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %124 = load i32, i32* %loc1
+  %125 = load i32, i32* %loc0
+  %126 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %123, i32 %124, i32 %125)
+  ret %System.String addrspace(1)* %126
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %97
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange22:                           ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
 Successfully read String.CreateTrimmedString
 
@@ -5439,8 +6893,8 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
@@ -5535,8 +6989,8 @@ entry:
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i64 2872
   %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
   %8 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %7
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %3
   %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
@@ -5553,8 +7007,8 @@ entry:
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 2864
   %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
   %21 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %20
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
-  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %22
 
 ; <label>:22                                      ; preds = %16
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
@@ -5569,7 +7023,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %16
+ThrowNullRef2:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5586,8 +7040,8 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5613,8 +7067,8 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
@@ -5632,8 +7086,8 @@ entry:
 
 ; <label>:12                                      ; preds = %4
   %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
@@ -5644,8 +7098,8 @@ entry:
 
 ; <label>:19                                      ; preds = %14
   %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %19
   %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
@@ -5660,21 +7114,21 @@ entry:
   %31 = zext i16 %30 to i32
   %32 = bitcast i8* %29 to i16*
   %33 = trunc i32 %31 to i16
-  %NullCheck6 = icmp ne i16* %32, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i16* %32, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %21
   store i16 %33, i16* %32, align 8
   %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %36
 
 ; <label>:36                                      ; preds = %34
   %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
   %38 = load i32, i32 addrspace(1)* %37, align 8
   %39 = add i32 %38, 1
-  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %40
 
 ; <label>:40                                      ; preds = %36
   %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
@@ -5683,16 +7137,16 @@ entry:
 
 ; <label>:42                                      ; preds = %14
   %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
-  br i1 %NullCheck12, label %44, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
   %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
   %47 = load i16, i16* %arg1
   %48 = zext i16 %47 to i32
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = trunc i32 %48 to i16
@@ -5703,31 +7157,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %19
+ThrowNullRef4:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %21
+ThrowNullRef6:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %36
+ThrowNullRef10:                                   ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %42
+ThrowNullRef12:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %44
+ThrowNullRef14:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5740,8 +7194,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -5752,8 +7206,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
@@ -5762,14 +7216,14 @@ entry:
 
 ; <label>:11                                      ; preds = %1
   %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
@@ -5779,15 +7233,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5808,8 +7262,8 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5822,8 +7276,8 @@ entry:
 
 ; <label>:8                                       ; preds = %3
   %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
@@ -5842,15 +7296,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
-  br i1 %NullCheck4, label %22, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
   %24 = load i16*, i16* addrspace(1)* %23, align 8
   %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %25, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
@@ -5859,8 +7313,8 @@ entry:
   store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
@@ -5874,8 +7328,8 @@ entry:
 
 ; <label>:37                                      ; preds = %65
   %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %37
   %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
@@ -5886,16 +7340,16 @@ entry:
   %45 = bitcast i16* %41 to i8*
   %46 = getelementptr inbounds i8, i8* %45, i64 %44
   %47 = bitcast i8* %46 to i16*
-  %NullCheck14 = icmp ne i16* %47, null
-  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %47, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %48
 
 ; <label>:48                                      ; preds = %39
   %49 = load i16, i16* %47, align 8
   %50 = zext i16 %49 to i32
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %52 = load i32, i32* %loc1
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %53
 
 ; <label>:53                                      ; preds = %48
   %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
@@ -5916,8 +7370,8 @@ entry:
 ; <label>:62                                      ; preds = %36, %59
   %63 = load i32, i32* %loc1
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck10, label %65, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %65
 
 ; <label>:65                                      ; preds = %62
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
@@ -5936,15 +7390,15 @@ entry:
 
 ; <label>:74                                      ; preds = %70
   %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
-  br i1 %NullCheck18, label %76, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %76
 
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
   %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
-  br i1 %NullCheck20, label %80, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
   %81 = load i64, i64 addrspace(1)* %79
@@ -5958,8 +7412,8 @@ entry:
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
   %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
-  br i1 %NullCheck22, label %92, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.String addrspace(1)* %90, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %92
 
 ; <label>:92                                      ; preds = %80
   %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
@@ -5969,15 +7423,15 @@ entry:
 
 ; <label>:96                                      ; preds = %70
   %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
-  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %98
 
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
   %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
-  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
   %103 = load i64, i64 addrspace(1)* %101
@@ -5991,8 +7445,8 @@ entry:
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
   %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
-  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.String addrspace(1)* %112, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %114
 
 ; <label>:114                                     ; preds = %102
   %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
@@ -6004,59 +7458,59 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %20
+ThrowNullRef4:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %22
+ThrowNullRef6:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %26
+ThrowNullRef8:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %62
+ThrowNullRef10:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %48
+ThrowNullRef16:                                   ; preds = %48
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %74
+ThrowNullRef18:                                   ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %76
+ThrowNullRef20:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %80
+ThrowNullRef22:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %96
+ThrowNullRef24:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %98
+ThrowNullRef26:                                   ; preds = %98
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %102
+ThrowNullRef28:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6069,15 +7523,15 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
   %3 = load i16*, i16* addrspace(1)* %2, align 8
   %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
@@ -6087,8 +7541,8 @@ entry:
   %10 = bitcast i16* %3 to i8*
   %11 = getelementptr inbounds i8, i8* %10, i64 %9
   %12 = bitcast i8* %11 to i16*
-  %NullCheck4 = icmp ne i16* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %5
   store i16 0, i16* %12, align 8
@@ -6098,11 +7552,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6119,8 +7573,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -6131,8 +7585,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
@@ -6144,15 +7598,15 @@ entry:
 
 ; <label>:14                                      ; preds = %1
   %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
   %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
   %21 = load i64, i64 addrspace(1)* %19
@@ -6171,15 +7625,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %14
+ThrowNullRef4:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %16
+ThrowNullRef6:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6302,14 +7756,6 @@ entry:
   ret %System.String addrspace(1)* %57
 }
 
-INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
-Successfully read RuntimeHelpers.get_OffsetToStringData
-
-define i32 @RuntimeHelpers.get_OffsetToStringData() {
-entry:
-  ret i32 12
-}
-
 INFO:  jitting method String::Equals using LLILCJit
 Successfully read String.Equals
 
@@ -6381,8 +7827,8 @@ entry:
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
-  br i1 %NullCheck24, label %29, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
   %30 = load i64, i64 addrspace(1)* %28
@@ -6397,8 +7843,8 @@ entry:
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
-  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
   %43 = load i64, i64 addrspace(1)* %41
@@ -6418,8 +7864,8 @@ entry:
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
   %59 = load i64, i64 addrspace(1)* %57
@@ -6434,8 +7880,8 @@ entry:
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck22, label %71, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
   %72 = load i64, i64 addrspace(1)* %70
@@ -6455,8 +7901,8 @@ entry:
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
-  br i1 %NullCheck16, label %87, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = load i64, i64 addrspace(1)* %86
@@ -6471,8 +7917,8 @@ entry:
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck18, label %100, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
   %101 = load i64, i64 addrspace(1)* %99
@@ -6492,8 +7938,8 @@ entry:
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
-  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
   %117 = load i64, i64 addrspace(1)* %115
@@ -6508,8 +7954,8 @@ entry:
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
-  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
   %130 = load i64, i64 addrspace(1)* %128
@@ -6528,15 +7974,15 @@ entry:
 
 ; <label>:142                                     ; preds = %22
   %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
-  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %143, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %144
 
 ; <label>:144                                     ; preds = %142
   %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
   %146 = load i32, i32 addrspace(1)* %145
   %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
-  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %147, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %148
 
 ; <label>:148                                     ; preds = %144
   %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
@@ -6557,15 +8003,15 @@ entry:
 
 ; <label>:159                                     ; preds = %22
   %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
-  br i1 %NullCheck, label %161, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %ThrowNullRef, label %161
 
 ; <label>:161                                     ; preds = %159
   %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
   %163 = load i32, i32 addrspace(1)* %162
   %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
-  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %164, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %165
 
 ; <label>:165                                     ; preds = %161
   %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
@@ -6578,8 +8024,8 @@ entry:
 
 ; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
-  br i1 %NullCheck4, label %172, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %171, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %172
 
 ; <label>:172                                     ; preds = %170
   %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
@@ -6589,8 +8035,8 @@ entry:
 
 ; <label>:176                                     ; preds = %172
   %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
-  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %177, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %178
 
 ; <label>:178                                     ; preds = %176
   %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
@@ -6629,55 +8075,55 @@ ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %161
+ThrowNullRef2:                                    ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %170
+ThrowNullRef4:                                    ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %176
+ThrowNullRef6:                                    ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %142
+ThrowNullRef8:                                    ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %144
+ThrowNullRef10:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %113
+ThrowNullRef12:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %116
+ThrowNullRef14:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %84
+ThrowNullRef16:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %87
+ThrowNullRef18:                                   ; preds = %87
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %55
+ThrowNullRef20:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %58
+ThrowNullRef22:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %26
+ThrowNullRef24:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %29
+ThrowNullRef26:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,8 +8161,8 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck, label %14, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %ThrowNullRef, label %14
 
 ; <label>:14                                      ; preds = %8
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
@@ -6760,8 +8206,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
@@ -6770,14 +8216,14 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32, i32* %loc0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %10
   %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
   %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
@@ -6790,15 +8236,15 @@ entry:
 ; <label>:25                                      ; preds = %19
   %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
-  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
   %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
@@ -6807,8 +8253,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %37 = load i32, i32* %loc0
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %38, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %38
 
 ; <label>:38                                      ; preds = %32
   %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
@@ -6817,14 +8263,14 @@ entry:
 
 ; <label>:40                                      ; preds = %19
   %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %40
   %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
   %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
-  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
-  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
@@ -6832,8 +8278,8 @@ entry:
   %48 = zext i32 %47 to i64
   %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
-  br i1 %NullCheck16, label %51, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %51
 
 ; <label>:51                                      ; preds = %45
   %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
@@ -6847,15 +8293,15 @@ entry:
 ; <label>:57                                      ; preds = %51
   %58 = load i16*, i16** %arg1
   %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
-  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %60
 
 ; <label>:60                                      ; preds = %57
   %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
   %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
-  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %64
 
 ; <label>:64                                      ; preds = %60
   %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
@@ -6864,22 +8310,22 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
   %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
-  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %70
 
 ; <label>:70                                      ; preds = %64
   %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
   %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
-  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
-  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
   %75 = load i32, i32 addrspace(1)* %74
   %76 = zext i32 %75 to i64
   %77 = trunc i64 %76 to i32
-  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
-  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %78
 
 ; <label>:78                                      ; preds = %73
   %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
@@ -6901,8 +8347,8 @@ entry:
   %90 = bitcast i16* %86 to i8*
   %91 = getelementptr inbounds i8, i8* %90, i64 %89
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %93
 
 ; <label>:93                                      ; preds = %80
   %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
@@ -6912,8 +8358,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %99 = load i32, i32* %loc2
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %100
 
 ; <label>:100                                     ; preds = %93
   %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
@@ -6928,63 +8374,63 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %25
+ThrowNullRef6:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %32
+ThrowNullRef10:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %40
+ThrowNullRef12:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %45
+ThrowNullRef16:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %57
+ThrowNullRef18:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %60
+ThrowNullRef20:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %64
+ThrowNullRef22:                                   ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %70
+ThrowNullRef24:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %73
+ThrowNullRef26:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %80
+ThrowNullRef28:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %93
+ThrowNullRef30:                                   ; preds = %93
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7004,8 +8450,8 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
@@ -7033,43 +8479,43 @@ entry:
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %14
   %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
   %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   %28 = load i32, i32 addrspace(1)* %27, align 8
   %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
-  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %30
 
 ; <label>:30                                      ; preds = %26
   %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
   %32 = load i32, i32 addrspace(1)* %31, align 8
   %33 = add i32 %28, %32
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %34
 
 ; <label>:34                                      ; preds = %30
   %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   store i32 %33, i32 addrspace(1)* %35
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
   store i32 0, i32 addrspace(1)* %38
   %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %40
 
 ; <label>:40                                      ; preds = %37
   %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
@@ -7082,8 +8528,8 @@ entry:
 
 ; <label>:47                                      ; preds = %40
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
@@ -7098,8 +8544,8 @@ entry:
   %54 = load i32, i32* %loc0
   %55 = sext i32 %54 to i64
   %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
-  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %57
 
 ; <label>:57                                      ; preds = %52
   %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
@@ -7110,68 +8556,35 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %14
+ThrowNullRef2:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %23
+ThrowNullRef4:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %26
+ThrowNullRef6:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %30
+ThrowNullRef8:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %34
+ThrowNullRef10:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %47
+ThrowNullRef14:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %52
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-}
-
-INFO:  jitting method StringBuilder::get_Length using LLILCJit
-Successfully read StringBuilder.get_Length
-
-define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.StringBuilder addrspace(1)*
-  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
-  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
-
-; <label>:1                                       ; preds = %entry
-  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %3 = load i32, i32 addrspace(1)* %2, align 8
-  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
-
-; <label>:5                                       ; preds = %1
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = add i32 %3, %7
-  ret i32 %8
-
-ThrowNullRef:                                     ; preds = %entry
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef16:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7213,70 +8626,70 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
   %6 = load i32, i32 addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
   store i32 %6, i32 addrspace(1)* %8
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
   %13 = load i32, i32 addrspace(1)* %12, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
   store i32 %13, i32 addrspace(1)* %15
   %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
-  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %18
 
 ; <label>:18                                      ; preds = %14
   %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
   %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
   %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
   %34 = load i32, i32 addrspace(1)* %33, align 8
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
-  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
@@ -7287,39 +8700,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %28
+ThrowNullRef16:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %32
+ThrowNullRef18:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7455,13 +8868,13 @@ entry:
 ; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
@@ -7477,16 +8890,16 @@ entry:
 
 ; <label>:18                                      ; preds = %15
   %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
   store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
   %22 = load i32, i32* %loc0
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %24
 
 ; <label>:24                                      ; preds = %20
   %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
@@ -7498,13 +8911,13 @@ entry:
 ; <label>:28                                      ; preds = %15, %24
   %29 = load i32, i32* %arg1
   %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %31
   %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
@@ -7517,20 +8930,20 @@ entry:
   %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
-  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
   %46 = load i32, i32 addrspace(1)* %45, align 8
   %47 = sub i32 %40, %46
-  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
-  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i32 addrspace(1)* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %48
 
 ; <label>:48                                      ; preds = %44
   store i32 %47, i32 addrspace(1)* %39, align 8
@@ -7538,21 +8951,21 @@ entry:
 
 ; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
-  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %51
 
 ; <label>:51                                      ; preds = %49
   %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %53
 
 ; <label>:53                                      ; preds = %51
   %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
   %55 = load i32, i32 addrspace(1)* %54, align 8
   %56 = load i32, i32* %arg2
   %57 = sub i32 %55, %56
-  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %58
 
 ; <label>:58                                      ; preds = %53
   %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
@@ -7562,13 +8975,13 @@ entry:
 ; <label>:60                                      ; preds = %33, %58
   %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
   %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
-  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %63
 
 ; <label>:63                                      ; preds = %60
   %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
-  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
-  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
@@ -7578,15 +8991,15 @@ entry:
 
 ; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
-  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i32 addrspace(1)* %69, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %70
 
 ; <label>:70                                      ; preds = %68
   %71 = load i32, i32 addrspace(1)* %69, align 8
   store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
-  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
@@ -7596,8 +9009,8 @@ entry:
   store i32 %77, i32* %loc4
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
-  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %80
 
 ; <label>:80                                      ; preds = %73
   %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
@@ -7607,71 +9020,71 @@ entry:
 ; <label>:83                                      ; preds = %80
   store i32 0, i32* %loc3
   %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
-  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
-  br i1 %NullCheck26, label %88, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i32 addrspace(1)* %87, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %88
 
 ; <label>:88                                      ; preds = %85
   %89 = load i32, i32 addrspace(1)* %87, align 8
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
-  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %90
 
 ; <label>:90                                      ; preds = %88
   %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
   store i32 %89, i32 addrspace(1)* %91
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
-  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
-  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %96
 
 ; <label>:96                                      ; preds = %94
   %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
-  br i1 %NullCheck34, label %100, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %100
 
 ; <label>:100                                     ; preds = %96
   %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
-  br i1 %NullCheck36, label %102, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %102
 
 ; <label>:102                                     ; preds = %100
   %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
   %104 = load i32, i32 addrspace(1)* %103, align 8
   %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
-  br i1 %NullCheck38, label %106, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %106
 
 ; <label>:106                                     ; preds = %102
   %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
-  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
-  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %108
 
 ; <label>:108                                     ; preds = %106
   %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
   %110 = load i32, i32 addrspace(1)* %109, align 8
   %111 = add i32 %104, %110
-  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %112
 
 ; <label>:112                                     ; preds = %108
   %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
   store i32 %111, i32 addrspace(1)* %113
   %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
-  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i32 addrspace(1)* %114, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %115
 
 ; <label>:115                                     ; preds = %112
   %116 = load i32, i32 addrspace(1)* %114, align 8
@@ -7681,19 +9094,19 @@ entry:
 ; <label>:118                                     ; preds = %115
   %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
-  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %121
 
 ; <label>:121                                     ; preds = %118
   %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
-  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
-  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %123
 
 ; <label>:123                                     ; preds = %121
   %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
   %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
-  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
-  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %126
 
 ; <label>:126                                     ; preds = %123
   %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
@@ -7705,8 +9118,8 @@ entry:
 
 ; <label>:130                                     ; preds = %80, %115, %126
   %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %132
 
 ; <label>:132                                     ; preds = %130
   %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7715,8 +9128,8 @@ entry:
   %136 = load i32, i32* %loc3
   %137 = sub i32 %135, %136
   %138 = sub i32 %134, %137
-  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %139
 
 ; <label>:139                                     ; preds = %132
   %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7728,16 +9141,16 @@ entry:
 
 ; <label>:144                                     ; preds = %139
   %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
-  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %146
 
 ; <label>:146                                     ; preds = %144
   %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
   %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
   %149 = load i32, i32* %loc2
   %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
-  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %151
 
 ; <label>:151                                     ; preds = %146
   %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
@@ -7754,145 +9167,249 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %18
+ThrowNullRef4:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %31
+ThrowNullRef10:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %44
+ThrowNullRef16:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %68
+ThrowNullRef18:                                   ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %70
+ThrowNullRef20:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %73
+ThrowNullRef22:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %83
+ThrowNullRef24:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %85
+ThrowNullRef26:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %88
+ThrowNullRef28:                                   ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %90
+ThrowNullRef30:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %94
+ThrowNullRef32:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %96
+ThrowNullRef34:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %100
+ThrowNullRef36:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %102
+ThrowNullRef38:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %106
+ThrowNullRef40:                                   ; preds = %106
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %108
+ThrowNullRef42:                                   ; preds = %108
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %112
+ThrowNullRef44:                                   ; preds = %112
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %118
+ThrowNullRef46:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %121
+ThrowNullRef48:                                   ; preds = %121
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %123
+ThrowNullRef50:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %130
+ThrowNullRef52:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %132
+ThrowNullRef54:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %144
+ThrowNullRef56:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %146
+ThrowNullRef58:                                   ; preds = %146
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %60
+ThrowNullRef60:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %63
+ThrowNullRef62:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %49
+ThrowNullRef64:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %51
+ThrowNullRef66:                                   ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %53
+ThrowNullRef68:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(%"System.Char[]" addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %arg0 = alloca %"System.Char[]" addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store %"System.Char[]" addrspace(1)* %param0, %"System.Char[]" addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load i32, i32* %arg4
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %43, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %38, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg1
+  %13 = load i32, i32* %arg4
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %38, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %24 = load i32, i32* %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %35 = load i32, i32* %arg3
+  %36 = load i32, i32* %arg4
+  %37 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %37, %"System.Char[]" addrspace(1)* %34, i32 %35, i32 %36)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:38                                      ; preds = %5, %16
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Successfully read Buffer._Memmove
 
@@ -7914,7 +9431,7 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[loadElem]
+Failed to read AppDomain.SetDataHelper[storeElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -7923,8 +9440,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
@@ -7934,8 +9451,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
@@ -7947,15 +9464,15 @@ entry:
   %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
   %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
@@ -7966,15 +9483,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7992,7 +9509,79 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
-Failed to read Dictionary`2.TryGetValue[loadElemA]
+Successfully read Dictionary`2.TryGetValue
+
+define i8 @"Dictionary`2.TryGetValue"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)* addrspace(1)* %param2) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  %arg2 = alloca %System.__Canon addrspace(1)* addrspace(1)*
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  store %System.__Canon addrspace(1)* addrspace(1)* %param2, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  store i32 %2, i32* %loc0
+  %3 = load i32, i32* %loc0
+  %4 = icmp slt i32 %3, 0
+  br i1 %4, label %22, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 2
+  %10 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %9, align 8
+  %11 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = zext i32 %11 to i64
+  %BoundsCheck = icmp uge i64 %16, %15
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 3, i32 %11
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %20, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %6, %System.__Canon addrspace(1)* %21)
+  ret i8 1
+
+; <label>:22                                      ; preds = %entry
+  %23 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %23, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -8058,8 +9647,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
@@ -8091,8 +9680,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
@@ -8171,15 +9760,15 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck, label %19, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %ThrowNullRef, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
   %21 = load i32, i32 addrspace(1)* %20
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
@@ -8202,7 +9791,7 @@ ThrowNullRef:                                     ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %19
+ThrowNullRef2:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8248,8 +9837,8 @@ entry:
   %0 = alloca %System.AppDomainHandle
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %1 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %1, i32 0, i32 15
@@ -8269,8 +9858,8 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
@@ -8286,7 +9875,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -8299,8 +9888,8 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -8327,8 +9916,8 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
@@ -8352,8 +9941,8 @@ entry:
   %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
   store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
@@ -8363,8 +9952,8 @@ entry:
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
@@ -8374,8 +9963,8 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %9
   %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
@@ -8384,8 +9973,8 @@ entry:
 
 ; <label>:18                                      ; preds = %3, %16
   %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
@@ -8397,15 +9986,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %18
+ThrowNullRef6:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8418,8 +10007,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
@@ -8453,15 +10042,15 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
@@ -8473,7 +10062,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8481,7 +10070,7 @@ ThrowNullRef1:                                    ; preds = %1
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
 Failed to read Dictionary`2.System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
@@ -8506,8 +10095,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
@@ -8524,8 +10113,8 @@ entry:
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -8544,7 +10133,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8577,8 +10166,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = load i64, i64* %arg2
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = trunc i32 %3 to i8
@@ -8634,46 +10223,46 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
   %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
-  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
-  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
-  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
@@ -8684,27 +10273,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %20
+ThrowNullRef12:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8717,8 +10306,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -8756,22 +10345,22 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
   %9 = load i64, i64 addrspace(1)* %8, align 8
   %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
   %13 = load i64, i64 addrspace(1)* %12, align 8
   %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %11
   %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
@@ -8788,11 +10377,11 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8882,8 +10471,8 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
@@ -8900,8 +10489,8 @@ entry:
 ; <label>:8                                       ; preds = %1
   %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
   %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
@@ -8911,15 +10500,15 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
   %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
   %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
-  br i1 %NullCheck6, label %21, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
@@ -8946,15 +10535,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8992,15 +10581,15 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
   store i8 %3, i8 addrspace(1)* %5
   %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
@@ -9011,7 +10600,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9027,8 +10616,8 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -9041,8 +10630,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
@@ -9058,7 +10647,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9080,8 +10669,8 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
@@ -9096,8 +10685,8 @@ entry:
 ; <label>:12                                      ; preds = %6
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
@@ -9112,8 +10701,8 @@ entry:
 ; <label>:21                                      ; preds = %15
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
@@ -9128,8 +10717,8 @@ entry:
 ; <label>:30                                      ; preds = %24
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %31, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
@@ -9144,8 +10733,8 @@ entry:
 ; <label>:39                                      ; preds = %33
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
-  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %40, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %42
 
 ; <label>:42                                      ; preds = %39
   %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
@@ -9164,19 +10753,19 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %21
+ThrowNullRef4:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %30
+ThrowNullRef6:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %39
+ThrowNullRef8:                                    ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9243,8 +10832,8 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
@@ -9264,57 +10853,57 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
   store i8 0, i8 addrspace(1)* %2
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
   store i8 0, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
   store i8 0, i8 addrspace(1)* %17
   %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
   store i8 0, i8 addrspace(1)* %20
   %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
-  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
@@ -9325,31 +10914,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %19
+ThrowNullRef14:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9367,8 +10956,8 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
@@ -9380,8 +10969,8 @@ entry:
 
 ; <label>:9                                       ; preds = %4
   %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %9
   %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
@@ -9395,7 +10984,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef2:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9420,8 +11009,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
@@ -9512,8 +11101,8 @@ entry:
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
@@ -9524,8 +11113,8 @@ entry:
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = load i64, i64 addrspace(1)* %12
@@ -9537,8 +11126,8 @@ entry:
   %20 = load i64, i64* %19
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
-  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %13
   %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
@@ -9555,8 +11144,8 @@ entry:
 ; <label>:30                                      ; preds = %25
   %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %32 = load i32, i32* %arg2
-  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
-  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
@@ -9570,15 +11159,15 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %30
+ThrowNullRef2:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9622,87 +11211,87 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
   %10 = load i8, i8 addrspace(1)* %9, align 8
   %11 = zext i8 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %8
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
   store i8 %12, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
   %19 = load i8, i8 addrspace(1)* %18, align 8
   %20 = zext i8 %19 to i32
   %21 = trunc i32 %20 to i8
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
   store i8 %21, i8 addrspace(1)* %23
   %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
   %28 = load i8, i8 addrspace(1)* %27, align 8
   %29 = zext i8 %28 to i32
   %30 = trunc i32 %29 to i8
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
-  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %31
 
 ; <label>:31                                      ; preds = %26
   %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
   store i8 %30, i8 addrspace(1)* %32
   %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
-  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
-  br i1 %NullCheck14, label %40, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %40
 
 ; <label>:40                                      ; preds = %35
   %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
   store i8 %39, i8 addrspace(1)* %41
   %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
-  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %44
 
 ; <label>:44                                      ; preds = %40
   %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
   %46 = load i8, i8 addrspace(1)* %45, align 8
   %47 = zext i8 %46 to i32
   %48 = trunc i32 %47 to i8
-  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
   store i8 %48, i8 addrspace(1)* %50
   %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
-  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
@@ -9713,29 +11302,29 @@ entry:
 ; <label>:56                                      ; preds = %52
   %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
-  br i1 %NullCheck22, label %59, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
   %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
   %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
-  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
-  br i1 %NullCheck24, label %63, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
   %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
-  br i1 %NullCheck26, label %66, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
   %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
-  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
-  br i1 %NullCheck28, label %69, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %69
 
 ; <label>:69                                      ; preds = %66
   %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
@@ -9744,15 +11333,15 @@ entry:
 
 ; <label>:71                                      ; preds = %105
   %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
-  br i1 %NullCheck34, label %73, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %73
 
 ; <label>:73                                      ; preds = %71
   %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
   %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
   %76 = load i32, i32* %loc0
-  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
-  br i1 %NullCheck36, label %77, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
@@ -9766,8 +11355,8 @@ entry:
 
 ; <label>:83                                      ; preds = %77
   %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
-  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
@@ -9775,14 +11364,14 @@ entry:
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
   %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
-  br i1 %NullCheck40, label %91, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
 ; <label>:91                                      ; preds = %85
   %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
   %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
-  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck42, label %94, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %94
 
 ; <label>:94                                      ; preds = %91
   %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
@@ -9798,14 +11387,14 @@ entry:
 ; <label>:99                                      ; preds = %69, %96
   %100 = load i32, i32* %loc0
   %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
-  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %102
 
 ; <label>:102                                     ; preds = %99
   %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
   %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
-  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
-  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
@@ -9819,87 +11408,87 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %26
+ThrowNullRef10:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %31
+ThrowNullRef12:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %35
+ThrowNullRef14:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %40
+ThrowNullRef16:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %56
+ThrowNullRef22:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %59
+ThrowNullRef24:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %63
+ThrowNullRef26:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %66
+ThrowNullRef28:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %102
+ThrowNullRef32:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %71
+ThrowNullRef34:                                   ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %73
+ThrowNullRef36:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %83
+ThrowNullRef38:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %85
+ThrowNullRef40:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %91
+ThrowNullRef42:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9943,15 +11532,15 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
   %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
@@ -9961,28 +11550,28 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
   %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %12
   %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
   %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
   %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
-  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
@@ -9993,23 +11582,23 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %12
+ThrowNullRef6:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10031,15 +11620,15 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
   %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = load i64, i64 addrspace(1)* %7
@@ -10077,13 +11666,13 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[loadElem]
+Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -10111,8 +11700,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -10178,8 +11767,8 @@ entry:
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load double, double* %arg0
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -10313,8 +11902,8 @@ entry:
   store i64 %param0, i64* %arg0
   store i64 %param1, i64* %arg1
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
@@ -10322,8 +11911,8 @@ entry:
   %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
   %5 = load i16*, i16* addrspace(1)* %4, align 8
   %6 = addrspacecast i64* %arg1 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = bitcast i64 addrspace(1)* %6 to i8 addrspace(1)*
@@ -10339,7 +11928,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10373,8 +11962,8 @@ entry:
   %1 = load i32, i32* %arg1
   %2 = sext i32 %1 to i64
   %3 = inttoptr i64 %2 to i16*
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -10427,8 +12016,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, i32)*)(%System.IO.ConsoleStream addrspace(1)* %2, i32 %1)
   %3 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %4 = load i64, i64* %arg1
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
@@ -10439,8 +12028,8 @@ entry:
   %10 = icmp eq i32 %9, 3
   %11 = sext i1 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %5
   %14 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, i32 0, i32 5
@@ -10451,7 +12040,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10474,8 +12063,8 @@ entry:
   %5 = icmp eq i32 %4, 1
   %6 = sext i1 %5 to i32
   %7 = trunc i32 %6 to i8
-  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %2, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.ConsoleStream addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
@@ -10486,8 +12075,8 @@ entry:
   %13 = icmp eq i32 %12, 2
   %14 = sext i1 %13 to i32
   %15 = trunc i32 %14 to i8
-  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %10, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.ConsoleStream addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %8
   %17 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %10, i32 0, i32 4
@@ -10498,7 +12087,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10537,8 +12126,8 @@ entry:
   %arg0 = alloca i64
   store i64 %param0, i64* %arg0
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
@@ -10573,8 +12162,8 @@ entry:
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
   %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = load i64, i64 addrspace(1)* %7
@@ -10678,7 +12267,127 @@ entry:
 INFO:  jitting method Encoding::GetEncoding using LLILCJit
 Failed to read Encoding.GetEncoding[convertToHelperArgumentType]
 INFO:  jitting method EncodingProvider::GetEncodingFromProvider using LLILCJit
-Failed to read EncodingProvider.GetEncodingFromProvider[loadElem]
+Successfully read EncodingProvider.GetEncodingFromProvider
+
+define %System.Text.Encoding addrspace(1)* @EncodingProvider.GetEncodingFromProvider(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca %"System.Text.EncodingProvider[]" addrspace(1)*
+  %loc1 = alloca %System.Text.EncodingProvider addrspace(1)*
+  %loc2 = alloca %System.Text.Encoding addrspace(1)*
+  %loc3 = alloca %System.Text.Encoding addrspace(1)*
+  %loc4 = alloca %"System.Text.EncodingProvider[]" addrspace(1)*
+  %loc5 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1059)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2392
+  %2 = addrspacecast i8 addrspace(1)* %1 to %"System.Text.EncodingProvider[]" addrspace(1)**
+  %3 = load volatile %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %2
+  %4 = icmp ne %"System.Text.EncodingProvider[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %entry
+  ret %System.Text.Encoding addrspace(1)* null
+
+; <label>:6                                       ; preds = %entry
+  %7 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1059)
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i64 2392
+  %9 = addrspacecast i8 addrspace(1)* %8 to %"System.Text.EncodingProvider[]" addrspace(1)**
+  %10 = load volatile %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %9
+  store %"System.Text.EncodingProvider[]" addrspace(1)* %10, %"System.Text.EncodingProvider[]" addrspace(1)** %loc0
+  %11 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc0
+  store %"System.Text.EncodingProvider[]" addrspace(1)* %11, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  store i32 0, i32* %loc5
+  br label %43
+
+; <label>:12                                      ; preds = %46
+  %13 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  %14 = load i32, i32* %loc5
+  %NullCheck1 = icmp eq %"System.Text.EncodingProvider[]" addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %13, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = zext i32 %17 to i64
+  %19 = zext i32 %14 to i64
+  %BoundsCheck = icmp uge i64 %19, %18
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %20
+
+; <label>:20                                      ; preds = %15
+  %21 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %13, i32 0, i32 3, i32 %14
+  %22 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)* addrspace(1)* %21, align 8
+  store %System.Text.EncodingProvider addrspace(1)* %22, %System.Text.EncodingProvider addrspace(1)** %loc1
+  %23 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)** %loc1
+  %24 = load i32, i32* %arg0
+  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i64 addrspace(1)*
+  %NullCheck3 = icmp eq i64 addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
+
+; <label>:26                                      ; preds = %20
+  %27 = load i64, i64 addrspace(1)* %25
+  %28 = add i64 %27, 64
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 40
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Text.Encoding addrspace(1)* (%System.Text.EncodingProvider addrspace(1)*, i32)*
+  %35 = call %System.Text.Encoding addrspace(1)* %34(%System.Text.EncodingProvider addrspace(1)* %23, i32 %24)
+  store %System.Text.Encoding addrspace(1)* %35, %System.Text.Encoding addrspace(1)** %loc2
+  %36 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc2
+  %37 = icmp eq %System.Text.Encoding addrspace(1)* %36, null
+  br i1 %37, label %40, label %38
+
+; <label>:38                                      ; preds = %26
+  %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc2
+  store %System.Text.Encoding addrspace(1)* %39, %System.Text.Encoding addrspace(1)** %loc3
+  br label %53
+
+; <label>:40                                      ; preds = %26
+  %41 = load i32, i32* %loc5
+  %42 = add i32 %41, 1
+  store i32 %42, i32* %loc5
+  br label %43
+
+; <label>:43                                      ; preds = %6, %40
+  %44 = load i32, i32* %loc5
+  %45 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  %NullCheck = icmp eq %"System.Text.EncodingProvider[]" addrspace(1)* %45, null
+  br i1 %NullCheck, label %ThrowNullRef, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp slt i32 %44, %50
+  br i1 %51, label %12, label %52
+
+; <label>:52                                      ; preds = %46
+  ret %System.Text.Encoding addrspace(1)* null
+
+; <label>:53                                      ; preds = %38
+  %54 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc3
+  ret %System.Text.Encoding addrspace(1)* %54
+
+ThrowNullRef:                                     ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method EncodingProvider::.cctor using LLILCJit
 Successfully read EncodingProvider..cctor
 
@@ -10697,7 +12406,7 @@ Failed to read Encoding.get_InternalSyncObject[Call HasTypeArg]
 INFO:  jitting method Hashtable::.ctor using LLILCJit
 Failed to read Hashtable..ctor[Volatile store]
 INFO:  jitting method Hashtable::get_Item using LLILCJit
-Failed to read Hashtable.get_Item[loadElemA]
+Failed to read Hashtable.get_Item[loadNonPrimitiveObj]
 INFO:  jitting method Hashtable::InitHash using LLILCJit
 Successfully read Hashtable.InitHash
 
@@ -10717,8 +12426,8 @@ entry:
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -10734,15 +12443,15 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
   %15 = load i32, i32* %loc0
-  %NullCheck2 = icmp ne i32 addrspace(1)* %14, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i32 addrspace(1)* %14, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %3
   store i32 %15, i32 addrspace(1)* %14, align 8
   %17 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %18 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %NullCheck4 = icmp ne i32 addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i32 addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = load i32, i32 addrspace(1)* %18, align 8
@@ -10751,8 +12460,8 @@ entry:
   %23 = sub i32 %22, 1
   %24 = urem i32 %21, %23
   %25 = add i32 1, %24
-  %NullCheck6 = icmp ne i32 addrspace(1)* %17, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32 addrspace(1)* %17, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %19
   store i32 %25, i32 addrspace(1)* %17, align 8
@@ -10763,15 +12472,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %19
+ThrowNullRef6:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10786,8 +12495,8 @@ entry:
   store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
   store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %NullCheck = icmp ne %System.Collections.Hashtable addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Collections.Hashtable addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
@@ -10797,16 +12506,16 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Collections.Hashtable addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Collections.Hashtable addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
   %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck4 = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %9, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
   %13 = inttoptr i64 %11 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
@@ -10816,8 +12525,8 @@ entry:
 ; <label>:15                                      ; preds = %1
   %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -10835,15 +12544,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10857,8 +12566,8 @@ entry:
   store %System.Int32 addrspace(1)* %param0, %System.Int32 addrspace(1)** %this
   %0 = load %System.Int32 addrspace(1)*, %System.Int32 addrspace(1)** %this
   %1 = bitcast %System.Int32 addrspace(1)* %0 to i32 addrspace(1)*
-  %NullCheck = icmp ne i32 addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq i32 addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load i32, i32 addrspace(1)* %1, align 8
@@ -10934,8 +12643,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.UTF8Encoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
@@ -10944,15 +12653,15 @@ entry:
   %9 = load i8, i8* %arg2
   %10 = zext i8 %9 to i32
   %11 = trunc i32 %10 to i8
-  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %8, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %6
   %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %8, i32 0, i32 8
   store i8 %11, i8 addrspace(1)* %13
   %14 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %14, i32 0, i32 8
@@ -10964,8 +12673,8 @@ entry:
 ; <label>:20                                      ; preds = %15
   %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %22, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %22, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = load i64, i64 addrspace(1)* %22
@@ -10987,15 +12696,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %12
+ThrowNullRef4:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11010,8 +12719,8 @@ entry:
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
@@ -11033,16 +12742,16 @@ entry:
 ; <label>:10                                      ; preds = %1
   %11 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
   %12 = load i32, i32* %arg1
-  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %11, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.Encoding addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
   store i32 %12, i32 addrspace(1)* %14
   %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
   %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = load i64, i64 addrspace(1)* %16
@@ -11060,11 +12769,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11077,8 +12786,8 @@ entry:
   %this = alloca %System.Text.UTF8Encoding addrspace(1)*
   store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
   %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.UTF8Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
@@ -11090,16 +12799,16 @@ entry:
 ; <label>:6                                       ; preds = %1
   %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %8 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %10, %System.Text.EncoderFallback addrspace(1)* %8)
   %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %12 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
-  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %11, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %11, i32 0, i32 3
@@ -11112,8 +12821,8 @@ entry:
   %18 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %18, %System.String addrspace(1)* %17)
   %19 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %18 to %System.Text.EncoderFallback addrspace(1)*
-  %NullCheck6 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %16, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %16, i32 0, i32 2
@@ -11123,8 +12832,8 @@ entry:
   %24 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %24, %System.String addrspace(1)* %23)
   %25 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %24 to %System.Text.DecoderFallback addrspace(1)*
-  %NullCheck8 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %22, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %22, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %20
   %27 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %22, i32 0, i32 3
@@ -11135,19 +12844,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %20
+ThrowNullRef8:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11177,8 +12886,8 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load i32, i32* %arg1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -11196,8 +12905,8 @@ entry:
 ; <label>:15                                      ; preds = %8
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %17 = load i32, i32* %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 %17
@@ -11213,7 +12922,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11265,7 +12974,7 @@ entry:
 }
 
 INFO:  jitting method Hashtable::Insert using LLILCJit
-Failed to read Hashtable.Insert[loadElemA]
+Failed to read Hashtable.Insert[storeElem]
 INFO:  jitting method ConsoleEncoding::.ctor using LLILCJit
 Successfully read ConsoleEncoding..ctor
 
@@ -11280,8 +12989,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %1)
   %2 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
@@ -11317,8 +13026,8 @@ entry:
   %2 = call %System.Text.InternalEncoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalEncoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %1)
   %3 = bitcast %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2 to %System.Text.EncoderFallback addrspace(1)*
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
@@ -11328,8 +13037,8 @@ entry:
   %8 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %7)
   %9 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %8 to %System.Text.DecoderFallback addrspace(1)*
-  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %6, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.Encoding addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %4
   %11 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %6, i32 0, i32 3
@@ -11340,7 +13049,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11359,15 +13068,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* %1)
   %2 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   %6 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, i32 0, i32 1
@@ -11378,7 +13087,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11406,8 +13115,8 @@ entry:
   store %System.Text.InternalDecoderBestFitFallback addrspace(1)* %param0, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
   %0 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
@@ -11417,15 +13126,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %4)
   %5 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %6)
   %9 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, i32 0, i32 1
@@ -11436,11 +13145,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11508,8 +13217,8 @@ entry:
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
   %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = load i64, i64 addrspace(1)* %19
@@ -11573,8 +13282,8 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.ConsoleStream addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
@@ -11605,31 +13314,31 @@ entry:
   store i8 %param4, i8* %arg4
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %3, %System.IO.Stream addrspace(1)* %1)
   %4 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %4, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
   %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %4, i32 0, i32 4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %5)
   %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %6
   %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
   %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
   %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = load i64, i64 addrspace(1)* %13
@@ -11641,8 +13350,8 @@ entry:
   %21 = load i64, i64* %20
   %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %8, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %8, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %14
   %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 5
@@ -11660,24 +13369,24 @@ entry:
   %31 = load i32, i32* %arg3
   %32 = sext i32 %31 to i64
   %33 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %32)
-  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %30, null
-  br i1 %NullCheck10, label %34, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.StreamWriter addrspace(1)* %30, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %35, %"System.Char[]" addrspace(1)* %33)
   %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %37, null
-  br i1 %NullCheck12, label %38, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.StreamWriter addrspace(1)* %37, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %38
 
 ; <label>:38                                      ; preds = %34
   %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
   %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
   %41 = load i32, i32* %arg3
   %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %42, null
-  br i1 %NullCheck14, label %43, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %42, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
   %44 = load i64, i64 addrspace(1)* %42
@@ -11691,30 +13400,30 @@ entry:
   %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
   %53 = sext i32 %52 to i64
   %54 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %53)
-  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
-  br i1 %NullCheck16, label %55, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %55
 
 ; <label>:55                                      ; preds = %43
   %56 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %56, %"System.Byte[]" addrspace(1)* %54)
   %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %58 = load i32, i32* %arg3
-  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %57, null
-  br i1 %NullCheck18, label %59, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.StreamWriter addrspace(1)* %57, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %59
 
 ; <label>:59                                      ; preds = %55
   %60 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 10
   store i32 %58, i32 addrspace(1)* %60
   %61 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %61, null
-  br i1 %NullCheck20, label %62, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.IO.StreamWriter addrspace(1)* %61, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %62
 
 ; <label>:62                                      ; preds = %59
   %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
   %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
   %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
   %67 = load i64, i64 addrspace(1)* %65
@@ -11732,15 +13441,15 @@ entry:
 
 ; <label>:78                                      ; preds = %66
   %79 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %79, null
-  br i1 %NullCheck24, label %80, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.StreamWriter addrspace(1)* %79, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %80
 
 ; <label>:80                                      ; preds = %78
   %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
   %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
   %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %83, null
-  br i1 %NullCheck26, label %84, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %83, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
   %85 = load i64, i64 addrspace(1)* %83
@@ -11757,8 +13466,8 @@ entry:
 
 ; <label>:95                                      ; preds = %84
   %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.IO.StreamWriter addrspace(1)* %96, null
-  br i1 %NullCheck28, label %97, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.IO.StreamWriter addrspace(1)* %96, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %97
 
 ; <label>:97                                      ; preds = %95
   %98 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 12
@@ -11772,8 +13481,8 @@ entry:
   %103 = icmp eq i32 %102, 0
   %104 = sext i1 %103 to i32
   %105 = trunc i32 %104 to i8
-  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %100, null
-  br i1 %NullCheck30, label %106, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.IO.StreamWriter addrspace(1)* %100, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %106
 
 ; <label>:106                                     ; preds = %99
   %107 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %100, i32 0, i32 13
@@ -11784,63 +13493,63 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %6
+ThrowNullRef4:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %29
+ThrowNullRef10:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %34
+ThrowNullRef12:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %38
+ThrowNullRef14:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %43
+ThrowNullRef16:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %55
+ThrowNullRef18:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %59
+ThrowNullRef20:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %62
+ThrowNullRef22:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %78
+ThrowNullRef24:                                   ; preds = %78
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %80
+ThrowNullRef26:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %95
+ThrowNullRef28:                                   ; preds = %95
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11853,15 +13562,15 @@ entry:
   %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = load i64, i64 addrspace(1)* %4
@@ -11879,7 +13588,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11929,35 +13638,35 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
   %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderNLS addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %7 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.EncoderNLS addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Text.Encoding addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.Encoding addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Text.EncoderNLS addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.EncoderNLS addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
   %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck8 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = load i64, i64 addrspace(1)* %16
@@ -11976,19 +13685,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12014,8 +13723,8 @@ entry:
   %this = alloca %System.Text.Encoding addrspace(1)*
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
@@ -12035,15 +13744,15 @@ entry:
   %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
   store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
   %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
   store i32 0, i32 addrspace(1)* %2
   %3 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, i32 0, i32 2
@@ -12053,15 +13762,15 @@ entry:
 
 ; <label>:8                                       ; preds = %4
   %9 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
   %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
   %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = load i64, i64 addrspace(1)* %13
@@ -12082,15 +13791,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12105,16 +13814,16 @@ entry:
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = load i32, i32* %arg1
   %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
   %7 = load i64, i64 addrspace(1)* %5
@@ -12132,7 +13841,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12169,8 +13878,8 @@ entry:
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
   %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
   %16 = load i64, i64 addrspace(1)* %14
@@ -12191,8 +13900,8 @@ entry:
   %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
   %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
   %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %31, null
-  br i1 %NullCheck2, label %32, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = load i64, i64 addrspace(1)* %31
@@ -12235,7 +13944,7 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12248,14 +13957,14 @@ entry:
   %this = alloca %System.Text.EncoderReplacementFallback addrspace(1)*
   store %System.Text.EncoderReplacementFallback addrspace(1)* %param0, %System.Text.EncoderReplacementFallback addrspace(1)** %this
   %0 = load %System.Text.EncoderReplacementFallback addrspace(1)*, %System.Text.EncoderReplacementFallback addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -12266,7 +13975,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12296,8 +14005,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
@@ -12329,8 +14038,8 @@ entry:
   %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
   store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
@@ -12342,8 +14051,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Threading.Tasks.Task addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %7)
@@ -12366,7 +14075,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12385,8 +14094,8 @@ entry:
   store i8 %param1, i8* %arg1
   store i8 %param2, i8* %arg2
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
@@ -12400,8 +14109,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1, %5
   %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 9
@@ -12432,8 +14141,8 @@ entry:
 
 ; <label>:25                                      ; preds = %8, %20
   %26 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %26, null
-  br i1 %NullCheck4, label %27, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %26, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %26, i32 0, i32 12
@@ -12444,22 +14153,22 @@ entry:
 
 ; <label>:32                                      ; preds = %27
   %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %33, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.IO.StreamWriter addrspace(1)* %33, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %32
   %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 12
   store i8 1, i8 addrspace(1)* %35
   %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
-  br i1 %NullCheck8, label %37, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
   %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
   %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck10 = icmp ne i64 addrspace(1)* %40, null
-  br i1 %NullCheck10, label %41, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64 addrspace(1)* %40, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i64, i64 addrspace(1)* %40
@@ -12473,8 +14182,8 @@ entry:
   %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
   store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
   %51 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %NullCheck12 = icmp ne %"System.Byte[]" addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Byte[]" addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %41
   %53 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %51, i32 0, i32 1
@@ -12486,16 +14195,16 @@ entry:
 
 ; <label>:58                                      ; preds = %52
   %59 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %59, null
-  br i1 %NullCheck14, label %60, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.IO.StreamWriter addrspace(1)* %59, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %60
 
 ; <label>:60                                      ; preds = %58
   %61 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %59, i32 0, i32 3
   %62 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
   %64 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %NullCheck16 = icmp ne %"System.Byte[]" addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %"System.Byte[]" addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %60
   %66 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %64, i32 0, i32 1
@@ -12503,8 +14212,8 @@ entry:
   %68 = zext i32 %67 to i64
   %69 = trunc i64 %68 to i32
   %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck18, label %71, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
   %72 = load i64, i64 addrspace(1)* %70
@@ -12520,29 +14229,29 @@ entry:
 
 ; <label>:80                                      ; preds = %27, %52, %71
   %81 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %81, null
-  br i1 %NullCheck20, label %82, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.IO.StreamWriter addrspace(1)* %81, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
 
 ; <label>:82                                      ; preds = %80
   %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %81, i32 0, i32 5
   %84 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %83, align 8
   %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.IO.StreamWriter addrspace(1)* %85, null
-  br i1 %NullCheck22, label %86, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.IO.StreamWriter addrspace(1)* %85, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %86
 
 ; <label>:86                                      ; preds = %82
   %87 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 7
   %88 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %87, align 8
   %89 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %89, null
-  br i1 %NullCheck24, label %90, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.StreamWriter addrspace(1)* %89, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %90
 
 ; <label>:90                                      ; preds = %86
   %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %89, i32 0, i32 9
   %92 = load i32, i32 addrspace(1)* %91, align 8
   %93 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.IO.StreamWriter addrspace(1)* %93, null
-  br i1 %NullCheck26, label %94, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.IO.StreamWriter addrspace(1)* %93, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %93, i32 0, i32 6
@@ -12550,8 +14259,8 @@ entry:
   %97 = load i8, i8* %arg2
   %98 = zext i8 %97 to i32
   %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
-  %NullCheck28 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck28, label %100, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
   %101 = load i64, i64 addrspace(1)* %99
@@ -12566,8 +14275,8 @@ entry:
   %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
   store i32 %110, i32* %loc1
   %111 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %111, null
-  br i1 %NullCheck30, label %112, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.IO.StreamWriter addrspace(1)* %111, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %112
 
 ; <label>:112                                     ; preds = %100
   %113 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %111, i32 0, i32 9
@@ -12578,23 +14287,23 @@ entry:
 
 ; <label>:116                                     ; preds = %112
   %117 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck32 = icmp ne %System.IO.StreamWriter addrspace(1)* %117, null
-  br i1 %NullCheck32, label %118, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.IO.StreamWriter addrspace(1)* %117, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %118
 
 ; <label>:118                                     ; preds = %116
   %119 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %117, i32 0, i32 3
   %120 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %119, align 8
   %121 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.IO.StreamWriter addrspace(1)* %121, null
-  br i1 %NullCheck34, label %122, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.IO.StreamWriter addrspace(1)* %121, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %122
 
 ; <label>:122                                     ; preds = %118
   %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
   %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
   %125 = load i32, i32* %loc1
   %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
-  %NullCheck36 = icmp ne i64 addrspace(1)* %126, null
-  br i1 %NullCheck36, label %127, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64 addrspace(1)* %126, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
   %128 = load i64, i64 addrspace(1)* %126
@@ -12616,15 +14325,15 @@ entry:
 
 ; <label>:140                                     ; preds = %136
   %141 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.IO.StreamWriter addrspace(1)* %141, null
-  br i1 %NullCheck38, label %142, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.IO.StreamWriter addrspace(1)* %141, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %142
 
 ; <label>:142                                     ; preds = %140
   %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
   %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
   %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
-  %NullCheck40 = icmp ne i64 addrspace(1)* %145, null
-  br i1 %NullCheck40, label %146, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i64 addrspace(1)* %145, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
   %147 = load i64, i64 addrspace(1)* %145
@@ -12645,83 +14354,83 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %25
+ThrowNullRef4:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %32
+ThrowNullRef6:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %37
+ThrowNullRef10:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %41
+ThrowNullRef12:                                   ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %58
+ThrowNullRef14:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %60
+ThrowNullRef16:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %65
+ThrowNullRef18:                                   ; preds = %65
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %80
+ThrowNullRef20:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %82
+ThrowNullRef22:                                   ; preds = %82
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %86
+ThrowNullRef24:                                   ; preds = %86
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %90
+ThrowNullRef26:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %94
+ThrowNullRef28:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %100
+ThrowNullRef30:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %116
+ThrowNullRef32:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %118
+ThrowNullRef34:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %122
+ThrowNullRef36:                                   ; preds = %122
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %140
+ThrowNullRef38:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %142
+ThrowNullRef40:                                   ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12788,8 +14497,8 @@ entry:
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %1 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
-  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
@@ -12797,8 +14506,8 @@ entry:
   %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
   %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
   %8 = load i64, i64 addrspace(1)* %6
@@ -12814,8 +14523,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %17, %System.IFormatProvider addrspace(1)* %16)
   %18 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %19 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %18, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.SyncTextWriter addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %7
   %21 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %18, i32 0, i32 4
@@ -12826,11 +14535,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12843,8 +14552,8 @@ entry:
   %this = alloca %System.IO.TextWriter addrspace(1)*
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.TextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
@@ -12854,8 +14563,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.Threading.Thread addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Threading.Thread addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %6)
@@ -12864,8 +14573,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1
   %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.TextWriter addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.TextWriter addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %11, i32 0, i32 2
@@ -12876,11 +14585,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13077,8 +14786,8 @@ entry:
   store double %param1, double* %arg1
   store i8 0, i8* %loc1
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
@@ -13088,16 +14797,16 @@ entry:
   %5 = addrspacecast i8* %loc1 to i8 addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %4, i8 addrspace(1)* %5)
   %6 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.SyncTextWriter addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
   %10 = load double, double* %arg1
   %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
   %13 = load i64, i64 addrspace(1)* %11
@@ -13132,11 +14841,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13153,8 +14862,8 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load double, double* %arg1
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -13168,8 +14877,8 @@ entry:
   call void %11(%System.IO.TextWriter addrspace(1)* %0, double %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
   %15 = load i64, i64 addrspace(1)* %13
@@ -13187,7 +14896,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13205,8 +14914,8 @@ entry:
   %1 = addrspacecast double* %arg1 to double addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -13221,8 +14930,8 @@ entry:
   %14 = bitcast double addrspace(1)* %1 to %System.Double addrspace(1)*
   %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Double addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Double addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
   %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
   %18 = load i64, i64 addrspace(1)* %16
@@ -13240,7 +14949,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13256,8 +14965,8 @@ entry:
   store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
   %0 = load %System.Double addrspace(1)*, %System.Double addrspace(1)** %this
   %1 = bitcast %System.Double addrspace(1)* %0 to double addrspace(1)*
-  %NullCheck = icmp ne double addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq double addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load double, double addrspace(1)* %1, align 8
@@ -13282,8 +14991,8 @@ entry:
   %loc0 = alloca %System.Globalization.NumberFormatInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 3
@@ -13293,8 +15002,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
@@ -13304,24 +15013,24 @@ entry:
   store %System.Globalization.NumberFormatInfo addrspace(1)* %10, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
   %11 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %7
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
   %15 = load i8, i8 addrspace(1)* %14, align 8
   %16 = zext i8 %15 to i32
   %17 = trunc i32 %16 to i8
-  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %11, null
-  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %11, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %13
   %19 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %11, i32 0, i32 29
   store i8 %17, i8 addrspace(1)* %19
   %20 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %21 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %20, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %20, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %18
   %23 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %20, i32 0, i32 3
@@ -13330,8 +15039,8 @@ entry:
 
 ; <label>:24                                      ; preds = %1, %22
   %25 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %25, null
-  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %25, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %26
 
 ; <label>:26                                      ; preds = %24
   %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %25, i32 0, i32 3
@@ -13342,23 +15051,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %18
+ThrowNullRef8:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13383,168 +15092,168 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 18
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %8, align 8
-  %NullCheck2 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %5, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %5, i32 0, i32 4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %9)
   %12 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 19
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %15, align 8
-  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %12, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %12, i32 0, i32 5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %16)
   %19 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %20 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %20, null
-  br i1 %NullCheck8, label %21, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %20, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %20, i32 0, i32 23
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  %NullCheck10 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %19, null
-  br i1 %NullCheck10, label %24, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %19, i32 0, i32 7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %25, %System.String addrspace(1)* %23)
   %26 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %27 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %27, i32 0, i32 22
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %29, align 8
-  %NullCheck14 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %26, null
-  br i1 %NullCheck14, label %31, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %26, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %26, i32 0, i32 6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %32, %System.String addrspace(1)* %30)
   %33 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %34 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Globalization.CultureData addrspace(1)* %34, null
-  br i1 %NullCheck16, label %35, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Globalization.CultureData addrspace(1)* %34, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %34, i32 0, i32 51
   %37 = load i32, i32 addrspace(1)* %36, align 8
-  %NullCheck18 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %33, null
-  br i1 %NullCheck18, label %38, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %33, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %33, i32 0, i32 21
   store i32 %37, i32 addrspace(1)* %39
   %40 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %41 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Globalization.CultureData addrspace(1)* %41, null
-  br i1 %NullCheck20, label %42, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Globalization.CultureData addrspace(1)* %41, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %41, i32 0, i32 52
   %44 = load i32, i32 addrspace(1)* %43, align 8
-  %NullCheck22 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %40, null
-  br i1 %NullCheck22, label %45, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %40, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %40, i32 0, i32 25
   store i32 %44, i32 addrspace(1)* %46
   %47 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %48 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.Globalization.CultureData addrspace(1)* %48, null
-  br i1 %NullCheck24, label %49, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Globalization.CultureData addrspace(1)* %48, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %49
 
 ; <label>:49                                      ; preds = %45
   %50 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %48, i32 0, i32 29
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck26 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %47, null
-  br i1 %NullCheck26, label %52, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %47, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %47, i32 0, i32 10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %53, %System.String addrspace(1)* %51)
   %54 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %55 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Globalization.CultureData addrspace(1)* %55, null
-  br i1 %NullCheck28, label %56, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Globalization.CultureData addrspace(1)* %55, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %56
 
 ; <label>:56                                      ; preds = %52
   %57 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %55, i32 0, i32 35
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %57, align 8
-  %NullCheck30 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %54, null
-  br i1 %NullCheck30, label %59, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %54, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %54, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %60, %System.String addrspace(1)* %58)
   %61 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %62 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck32 = icmp ne %System.Globalization.CultureData addrspace(1)* %62, null
-  br i1 %NullCheck32, label %63, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Globalization.CultureData addrspace(1)* %62, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %62, i32 0, i32 34
   %65 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %64, align 8
-  %NullCheck34 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %61, null
-  br i1 %NullCheck34, label %66, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %61, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %61, i32 0, i32 9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %67, %System.String addrspace(1)* %65)
   %68 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %69 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck36 = icmp ne %System.Globalization.CultureData addrspace(1)* %69, null
-  br i1 %NullCheck36, label %70, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Globalization.CultureData addrspace(1)* %69, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %70
 
 ; <label>:70                                      ; preds = %66
   %71 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %69, i32 0, i32 55
   %72 = load i32, i32 addrspace(1)* %71, align 8
-  %NullCheck38 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %68, null
-  br i1 %NullCheck38, label %73, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %68, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %68, i32 0, i32 22
   store i32 %72, i32 addrspace(1)* %74
   %75 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %76 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck40 = icmp ne %System.Globalization.CultureData addrspace(1)* %76, null
-  br i1 %NullCheck40, label %77, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Globalization.CultureData addrspace(1)* %76, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %76, i32 0, i32 57
   %79 = load i32, i32 addrspace(1)* %78, align 8
-  %NullCheck42 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %75, null
-  br i1 %NullCheck42, label %80, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %75, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %80
 
 ; <label>:80                                      ; preds = %77
   %81 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %75, i32 0, i32 24
   store i32 %79, i32 addrspace(1)* %81
   %82 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %83 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck44 = icmp ne %System.Globalization.CultureData addrspace(1)* %83, null
-  br i1 %NullCheck44, label %84, label %ThrowNullRef43
+  %NullCheck43 = icmp eq %System.Globalization.CultureData addrspace(1)* %83, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %84
 
 ; <label>:84                                      ; preds = %80
   %85 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %83, i32 0, i32 56
   %86 = load i32, i32 addrspace(1)* %85, align 8
-  %NullCheck46 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %82, null
-  br i1 %NullCheck46, label %87, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %82, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %82, i32 0, i32 23
@@ -13553,8 +15262,8 @@ entry:
 
 ; <label>:89                                      ; preds = %entry
   %90 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck100 = icmp ne %System.Globalization.CultureData addrspace(1)* %90, null
-  br i1 %NullCheck100, label %91, label %ThrowNullRef99
+  %NullCheck99 = icmp eq %System.Globalization.CultureData addrspace(1)* %90, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %91
 
 ; <label>:91                                      ; preds = %89
   %92 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %90, i32 0, i32 2
@@ -13572,8 +15281,8 @@ entry:
   %102 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %103 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %104 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %103)
-  %NullCheck48 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %102, null
-  br i1 %NullCheck48, label %105, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %102, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %105
 
 ; <label>:105                                     ; preds = %101
   %106 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %102, i32 0, i32 1
@@ -13581,8 +15290,8 @@ entry:
   %107 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %108 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %109 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %108)
-  %NullCheck50 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %107, null
-  br i1 %NullCheck50, label %110, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %107, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %110
 
 ; <label>:110                                     ; preds = %105
   %111 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %107, i32 0, i32 2
@@ -13590,8 +15299,8 @@ entry:
   %112 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %113 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %114 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %113)
-  %NullCheck52 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %112, null
-  br i1 %NullCheck52, label %115, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %112, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %115
 
 ; <label>:115                                     ; preds = %110
   %116 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %112, i32 0, i32 27
@@ -13599,8 +15308,8 @@ entry:
   %117 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %118 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %119 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %118)
-  %NullCheck54 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %117, null
-  br i1 %NullCheck54, label %120, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %117, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %120
 
 ; <label>:120                                     ; preds = %115
   %121 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %117, i32 0, i32 26
@@ -13608,8 +15317,8 @@ entry:
   %122 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %123 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %124 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %123)
-  %NullCheck56 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %122, null
-  br i1 %NullCheck56, label %125, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %122, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %125
 
 ; <label>:125                                     ; preds = %120
   %126 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %122, i32 0, i32 17
@@ -13617,8 +15326,8 @@ entry:
   %127 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %128 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %129 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %128)
-  %NullCheck58 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %127, null
-  br i1 %NullCheck58, label %130, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %127, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %130
 
 ; <label>:130                                     ; preds = %125
   %131 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %127, i32 0, i32 18
@@ -13626,8 +15335,8 @@ entry:
   %132 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %133 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %134 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %133)
-  %NullCheck60 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %132, null
-  br i1 %NullCheck60, label %135, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %132, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %135
 
 ; <label>:135                                     ; preds = %130
   %136 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %132, i32 0, i32 14
@@ -13635,8 +15344,8 @@ entry:
   %137 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %138 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %139 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %138)
-  %NullCheck62 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %137, null
-  br i1 %NullCheck62, label %140, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %137, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %140
 
 ; <label>:140                                     ; preds = %135
   %141 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %137, i32 0, i32 13
@@ -13644,71 +15353,71 @@ entry:
   %142 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %143 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %144 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %143)
-  %NullCheck64 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %142, null
-  br i1 %NullCheck64, label %145, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %142, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %145
 
 ; <label>:145                                     ; preds = %140
   %146 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %142, i32 0, i32 12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %146, %System.String addrspace(1)* %144)
   %147 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %148 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck66 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %148, null
-  br i1 %NullCheck66, label %149, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %148, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %149
 
 ; <label>:149                                     ; preds = %145
   %150 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %148, i32 0, i32 21
   %151 = load i32, i32 addrspace(1)* %150, align 8
-  %NullCheck68 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %147, null
-  br i1 %NullCheck68, label %152, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %147, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %152
 
 ; <label>:152                                     ; preds = %149
   %153 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %147, i32 0, i32 28
   store i32 %151, i32 addrspace(1)* %153
   %154 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %155 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck70 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %155, null
-  br i1 %NullCheck70, label %156, label %ThrowNullRef69
+  %NullCheck69 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %155, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %156
 
 ; <label>:156                                     ; preds = %152
   %157 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %155, i32 0, i32 6
   %158 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %157, align 8
-  %NullCheck72 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %154, null
-  br i1 %NullCheck72, label %159, label %ThrowNullRef71
+  %NullCheck71 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %154, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %159
 
 ; <label>:159                                     ; preds = %156
   %160 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %154, i32 0, i32 15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %160, %System.String addrspace(1)* %158)
   %161 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %162 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck74 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %162, null
-  br i1 %NullCheck74, label %163, label %ThrowNullRef73
+  %NullCheck73 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %162, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %163
 
 ; <label>:163                                     ; preds = %159
   %164 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %162, i32 0, i32 1
   %165 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %164, align 8
-  %NullCheck76 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %161, null
-  br i1 %NullCheck76, label %166, label %ThrowNullRef75
+  %NullCheck75 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %161, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %166
 
 ; <label>:166                                     ; preds = %163
   %167 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %161, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %167, %"System.Int32[]" addrspace(1)* %165)
   %168 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %169 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck78 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %169, null
-  br i1 %NullCheck78, label %170, label %ThrowNullRef77
+  %NullCheck77 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %169, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %170
 
 ; <label>:170                                     ; preds = %166
   %171 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %169, i32 0, i32 7
   %172 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %171, align 8
-  %NullCheck80 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %168, null
-  br i1 %NullCheck80, label %173, label %ThrowNullRef79
+  %NullCheck79 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %168, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %173
 
 ; <label>:173                                     ; preds = %170
   %174 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %168, i32 0, i32 16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %174, %System.String addrspace(1)* %172)
   %175 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck82 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %175, null
-  br i1 %NullCheck82, label %176, label %ThrowNullRef81
+  %NullCheck81 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %175, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %176
 
 ; <label>:176                                     ; preds = %173
   %177 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %175, i32 0, i32 4
@@ -13718,14 +15427,14 @@ entry:
 
 ; <label>:180                                     ; preds = %176
   %181 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck84 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %181, null
-  br i1 %NullCheck84, label %182, label %ThrowNullRef83
+  %NullCheck83 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %181, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %182
 
 ; <label>:182                                     ; preds = %180
   %183 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %181, i32 0, i32 4
   %184 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %183, align 8
-  %NullCheck86 = icmp ne %System.String addrspace(1)* %184, null
-  br i1 %NullCheck86, label %185, label %ThrowNullRef85
+  %NullCheck85 = icmp eq %System.String addrspace(1)* %184, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %185
 
 ; <label>:185                                     ; preds = %182
   %186 = getelementptr inbounds %System.String, %System.String addrspace(1)* %184, i32 0, i32 1
@@ -13736,8 +15445,8 @@ entry:
 ; <label>:189                                     ; preds = %176, %185
   %190 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck98 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %190, null
-  br i1 %NullCheck98, label %192, label %ThrowNullRef97
+  %NullCheck97 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %190, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %192
 
 ; <label>:192                                     ; preds = %189
   %193 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %190, i32 0, i32 4
@@ -13746,8 +15455,8 @@ entry:
 
 ; <label>:194                                     ; preds = %185, %192
   %195 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck88 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %195, null
-  br i1 %NullCheck88, label %196, label %ThrowNullRef87
+  %NullCheck87 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %195, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %196
 
 ; <label>:196                                     ; preds = %194
   %197 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %195, i32 0, i32 9
@@ -13757,14 +15466,14 @@ entry:
 
 ; <label>:200                                     ; preds = %196
   %201 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck90 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %201, null
-  br i1 %NullCheck90, label %202, label %ThrowNullRef89
+  %NullCheck89 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %201, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %202
 
 ; <label>:202                                     ; preds = %200
   %203 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %201, i32 0, i32 9
   %204 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %203, align 8
-  %NullCheck92 = icmp ne %System.String addrspace(1)* %204, null
-  br i1 %NullCheck92, label %205, label %ThrowNullRef91
+  %NullCheck91 = icmp eq %System.String addrspace(1)* %204, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %205
 
 ; <label>:205                                     ; preds = %202
   %206 = getelementptr inbounds %System.String, %System.String addrspace(1)* %204, i32 0, i32 1
@@ -13775,14 +15484,14 @@ entry:
 ; <label>:209                                     ; preds = %196, %205
   %210 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %211 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck94 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %211, null
-  br i1 %NullCheck94, label %212, label %ThrowNullRef93
+  %NullCheck93 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %211, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %212
 
 ; <label>:212                                     ; preds = %209
   %213 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %211, i32 0, i32 6
   %214 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %213, align 8
-  %NullCheck96 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %210, null
-  br i1 %NullCheck96, label %215, label %ThrowNullRef95
+  %NullCheck95 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %210, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %215
 
 ; <label>:215                                     ; preds = %212
   %216 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %210, i32 0, i32 9
@@ -13796,203 +15505,203 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %17
+ThrowNullRef8:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %21
+ThrowNullRef10:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %24
+ThrowNullRef12:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %28
+ThrowNullRef14:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %31
+ThrowNullRef16:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %35
+ThrowNullRef18:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %38
+ThrowNullRef20:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %42
+ThrowNullRef22:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %45
+ThrowNullRef24:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %49
+ThrowNullRef26:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %52
+ThrowNullRef28:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %56
+ThrowNullRef30:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %59
+ThrowNullRef32:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %63
+ThrowNullRef34:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %66
+ThrowNullRef36:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %70
+ThrowNullRef38:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %73
+ThrowNullRef40:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %77
+ThrowNullRef42:                                   ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %80
+ThrowNullRef44:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %84
+ThrowNullRef46:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %101
+ThrowNullRef48:                                   ; preds = %101
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %105
+ThrowNullRef50:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %110
+ThrowNullRef52:                                   ; preds = %110
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %115
+ThrowNullRef54:                                   ; preds = %115
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %120
+ThrowNullRef56:                                   ; preds = %120
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %125
+ThrowNullRef58:                                   ; preds = %125
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %130
+ThrowNullRef60:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %135
+ThrowNullRef62:                                   ; preds = %135
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %140
+ThrowNullRef64:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %145
+ThrowNullRef66:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %149
+ThrowNullRef68:                                   ; preds = %149
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %152
+ThrowNullRef70:                                   ; preds = %152
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %156
+ThrowNullRef72:                                   ; preds = %156
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %159
+ThrowNullRef74:                                   ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %163
+ThrowNullRef76:                                   ; preds = %163
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %166
+ThrowNullRef78:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %170
+ThrowNullRef80:                                   ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %173
+ThrowNullRef82:                                   ; preds = %173
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %180
+ThrowNullRef84:                                   ; preds = %180
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %182
+ThrowNullRef86:                                   ; preds = %182
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %194
+ThrowNullRef88:                                   ; preds = %194
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %200
+ThrowNullRef90:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %202
+ThrowNullRef92:                                   ; preds = %202
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %209
+ThrowNullRef94:                                   ; preds = %209
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %212
+ThrowNullRef96:                                   ; preds = %212
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %189
+ThrowNullRef98:                                   ; preds = %189
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %89
+ThrowNullRef100:                                  ; preds = %89
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14020,8 +15729,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 21
@@ -14034,8 +15743,8 @@ entry:
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 16)
   %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 21
@@ -14044,8 +15753,8 @@ entry:
 
 ; <label>:12                                      ; preds = %1, %10
   %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 21
@@ -14056,11 +15765,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %12
+ThrowNullRef4:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14076,8 +15785,8 @@ entry:
   store i32 %param1, i32* %arg1
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %1 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
@@ -14144,8 +15853,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 33
@@ -14158,8 +15867,8 @@ entry:
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 24)
   %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 33
@@ -14168,8 +15877,8 @@ entry:
 
 ; <label>:12                                      ; preds = %1, %10
   %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 33
@@ -14180,11 +15889,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %12
+ThrowNullRef4:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14197,8 +15906,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 53
@@ -14210,8 +15919,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 116)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 53
@@ -14220,8 +15929,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 53
@@ -14232,11 +15941,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14265,8 +15974,8 @@ entry:
 
 ; <label>:7                                       ; preds = %entry, %4
   %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %7
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 2
@@ -14290,8 +15999,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 54
@@ -14303,8 +16012,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 117)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
@@ -14313,8 +16022,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 54
@@ -14325,11 +16034,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14342,8 +16051,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 27
@@ -14355,8 +16064,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 118)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 27
@@ -14365,8 +16074,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 27
@@ -14377,11 +16086,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14394,8 +16103,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 28
@@ -14407,8 +16116,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 119)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 28
@@ -14417,8 +16126,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 28
@@ -14429,11 +16138,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14446,8 +16155,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 26
@@ -14459,8 +16168,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 107)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 26
@@ -14469,8 +16178,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 26
@@ -14481,11 +16190,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14498,8 +16207,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 25
@@ -14511,8 +16220,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 106)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 25
@@ -14521,8 +16230,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 25
@@ -14533,11 +16242,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14550,8 +16259,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 24
@@ -14563,8 +16272,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 105)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 24
@@ -14573,8 +16282,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 24
@@ -14585,11 +16294,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14614,8 +16323,8 @@ entry:
   %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %3)
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %2
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -14626,15 +16335,15 @@ entry:
 
 ; <label>:8                                       ; preds = %62
   %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 9
   %12 = load i32, i32 addrspace(1)* %11, align 8
   %13 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.IO.StreamWriter addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %13, i32 0, i32 10
@@ -14649,15 +16358,15 @@ entry:
 
 ; <label>:20                                      ; preds = %14, %18
   %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
   %24 = load i32, i32 addrspace(1)* %23, align 8
   %25 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %25, null
-  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.StreamWriter addrspace(1)* %25, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %25, i32 0, i32 9
@@ -14678,36 +16387,36 @@ entry:
   %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %37 = load i32, i32* %loc1
   %38 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.StreamWriter addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %35
   %40 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %38, i32 0, i32 7
   %41 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %40, align 8
   %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
-  br i1 %NullCheck14, label %43, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %39
   %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 9
   %45 = load i32, i32 addrspace(1)* %44, align 8
   %46 = load i32, i32* %loc2
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %36, null
-  br i1 %NullCheck16, label %47, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %36, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %47
 
 ; <label>:47                                      ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %36, i32 %37, %"System.Char[]" addrspace(1)* %41, i32 %45, i32 %46)
   %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
   %51 = load i32, i32 addrspace(1)* %50, align 8
   %52 = load i32, i32* %loc2
   %53 = add i32 %51, %52
-  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
-  br i1 %NullCheck20, label %54, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %54
 
 ; <label>:54                                      ; preds = %49
   %55 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
@@ -14729,8 +16438,8 @@ entry:
 
 ; <label>:65                                      ; preds = %62
   %66 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %66, null
-  br i1 %NullCheck2, label %67, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %66, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %67
 
 ; <label>:67                                      ; preds = %65
   %68 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %66, i32 0, i32 11
@@ -14751,49 +16460,259 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %65
+ThrowNullRef2:                                    ; preds = %65
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %20
+ThrowNullRef8:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %22
+ThrowNullRef10:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %35
+ThrowNullRef12:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %43
+ThrowNullRef16:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %47
+ThrowNullRef18:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method String::CopyTo using LLILCJit
-Failed to read String.CopyTo[loadElemA]
+Successfully read String.CopyTo
+
+define void @String.CopyTo(%System.String addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  %loc1 = alloca i16 addrspace(1)*
+  %loc2 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %1 = icmp ne %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg4
+  %7 = icmp sge i32 %6, 0
+  br i1 %7, label %13, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  unreachable
+
+; <label>:13                                      ; preds = %5
+  %14 = load i32, i32* %arg1
+  %15 = icmp sge i32 %14, 0
+  br i1 %15, label %21, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %18)
+  %20 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %20, %System.String addrspace(1)* %17, %System.String addrspace(1)* %19)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %20) #0
+  unreachable
+
+; <label>:21                                      ; preds = %13
+  %22 = load i32, i32* %arg4
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck, label %ThrowNullRef, label %24
+
+; <label>:24                                      ; preds = %21
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load i32, i32* %arg1
+  %28 = sub i32 %26, %27
+  %29 = icmp sle i32 %22, %28
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34, %System.String addrspace(1)* %31, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %24
+  %36 = load i32, i32* %arg3
+  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %37, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
+
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
+  %40 = load i32, i32 addrspace(1)* %39
+  %41 = zext i32 %40 to i64
+  %42 = trunc i64 %41 to i32
+  %43 = load i32, i32* %arg4
+  %44 = sub i32 %42, %43
+  %45 = icmp sgt i32 %36, %44
+  br i1 %45, label %49, label %46
+
+; <label>:46                                      ; preds = %38
+  %47 = load i32, i32* %arg3
+  %48 = icmp sge i32 %47, 0
+  br i1 %48, label %54, label %49
+
+; <label>:49                                      ; preds = %38, %46
+  %50 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %52 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %51)
+  %53 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53, %System.String addrspace(1)* %50, %System.String addrspace(1)* %52)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53) #0
+  unreachable
+
+; <label>:54                                      ; preds = %46
+  %55 = load i32, i32* %arg4
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %97, label %57
+
+; <label>:57                                      ; preds = %54
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %59
+
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 2
+  %61 = bitcast [0 x i16] addrspace(1)* %60 to i16 addrspace(1)*
+  store i16 addrspace(1)* %61, i16 addrspace(1)** %loc0
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  store %"System.Char[]" addrspace(1)* %62, %"System.Char[]" addrspace(1)** %loc2
+  %63 = icmp eq %"System.Char[]" addrspace(1)* %62, null
+  br i1 %63, label %72, label %64
+
+; <label>:64                                      ; preds = %59
+  %65 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc2
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %65, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %66
+
+; <label>:66                                      ; preds = %64
+  %67 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %65, i32 0, i32 1
+  %68 = load i32, i32 addrspace(1)* %67
+  %69 = zext i32 %68 to i64
+  %70 = trunc i64 %69 to i32
+  %71 = icmp ne i32 %70, 0
+  br i1 %71, label %73, label %72
+
+; <label>:72                                      ; preds = %59, %66
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  br label %81
+
+; <label>:73                                      ; preds = %66
+  %74 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc2
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %74, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %75
+
+; <label>:75                                      ; preds = %73
+  %76 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %74, i32 0, i32 1
+  %77 = load i32, i32 addrspace(1)* %76
+  %78 = zext i32 %77 to i64
+  %BoundsCheck = icmp uge i64 0, %78
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %79
+
+; <label>:79                                      ; preds = %75
+  %80 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %74, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %80, i16 addrspace(1)** %loc1
+  br label %81
+
+; <label>:81                                      ; preds = %72, %79
+  %82 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %83 = ptrtoint i16 addrspace(1)* %82 to i64
+  %84 = load i32, i32* %arg3
+  %85 = sext i32 %84 to i64
+  %86 = mul i64 %85, 2
+  %87 = add i64 %83, %86
+  %88 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %89 = ptrtoint i16 addrspace(1)* %88 to i64
+  %90 = load i32, i32* %arg1
+  %91 = sext i32 %90 to i64
+  %92 = mul i64 %91, 2
+  %93 = add i64 %89, %92
+  %94 = load i32, i32* %arg4
+  %95 = inttoptr i64 %87 to i16*
+  %96 = inttoptr i64 %93 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %95, i16* %96, i32 %94)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  br label %97
+
+; <label>:97                                      ; preds = %54, %81
+  ret void
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
 Successfully read ConsoleEncoding.GetPreamble
 
@@ -14830,7 +16749,365 @@ entry:
 }
 
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[loadElemA]
+Successfully read EncoderNLS.GetBytes
+
+define i32 @EncoderNLS.GetBytes(%System.Text.EncoderNLS addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3, %"System.Byte[]" addrspace(1)* %param4, i32 %param5, i8 %param6) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %arg4 = alloca %"System.Byte[]" addrspace(1)*
+  %arg5 = alloca i32
+  %arg6 = alloca i8
+  %loc0 = alloca i32
+  %loc1 = alloca i16 addrspace(1)*
+  %loc2 = alloca i8 addrspace(1)*
+  %loc3 = alloca i32
+  %loc4 = alloca %"System.Char[]" addrspace(1)*
+  %loc5 = alloca %"System.Byte[]" addrspace(1)*
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  store %"System.Byte[]" addrspace(1)* %param4, %"System.Byte[]" addrspace(1)** %arg4
+  store i32 %param5, i32* %arg5
+  store i8 %param6, i8* %arg6
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %1 = icmp eq %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %17, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %7 = icmp eq %"System.Char[]" addrspace(1)* %6, null
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %12
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %12
+
+; <label>:12                                      ; preds = %8, %10
+  %13 = phi %System.String addrspace(1)* [ %9, %8 ], [ %11, %10 ]
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %14)
+  %16 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16, %System.String addrspace(1)* %13, %System.String addrspace(1)* %15)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16) #0
+  unreachable
+
+; <label>:17                                      ; preds = %2
+  %18 = load i32, i32* %arg2
+  %19 = icmp slt i32 %18, 0
+  br i1 %19, label %23, label %20
+
+; <label>:20                                      ; preds = %17
+  %21 = load i32, i32* %arg3
+  %22 = icmp sge i32 %21, 0
+  br i1 %22, label %35, label %23
+
+; <label>:23                                      ; preds = %17, %20
+  %24 = load i32, i32* %arg2
+  %25 = icmp slt i32 %24, 0
+  br i1 %25, label %28, label %26
+
+; <label>:26                                      ; preds = %23
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %30
+
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %30
+
+; <label>:30                                      ; preds = %26, %28
+  %31 = phi %System.String addrspace(1)* [ %27, %26 ], [ %29, %28 ]
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34, %System.String addrspace(1)* %31, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %20
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck, label %ThrowNullRef, label %37
+
+; <label>:37                                      ; preds = %35
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = load i32, i32* %arg2
+  %43 = sub i32 %41, %42
+  %44 = load i32, i32* %arg3
+  %45 = icmp sge i32 %43, %44
+  br i1 %45, label %51, label %46
+
+; <label>:46                                      ; preds = %37
+  %47 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %48 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %49 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %48)
+  %50 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %50, %System.String addrspace(1)* %47, %System.String addrspace(1)* %49)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %50) #0
+  unreachable
+
+; <label>:51                                      ; preds = %37
+  %52 = load i32, i32* %arg5
+  %53 = icmp slt i32 %52, 0
+  br i1 %53, label %63, label %54
+
+; <label>:54                                      ; preds = %51
+  %55 = load i32, i32* %arg5
+  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck1 = icmp eq %"System.Byte[]" addrspace(1)* %56, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %57
+
+; <label>:57                                      ; preds = %54
+  %58 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = zext i32 %59 to i64
+  %61 = trunc i64 %60 to i32
+  %62 = icmp sle i32 %55, %61
+  br i1 %62, label %68, label %63
+
+; <label>:63                                      ; preds = %51, %57
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %66 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %65)
+  %67 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %67, %System.String addrspace(1)* %64, %System.String addrspace(1)* %66)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %67) #0
+  unreachable
+
+; <label>:68                                      ; preds = %57
+  %69 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %69, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %69, i32 0, i32 1
+  %72 = load i32, i32 addrspace(1)* %71
+  %73 = zext i32 %72 to i64
+  %74 = trunc i64 %73 to i32
+  %75 = icmp ne i32 %74, 0
+  br i1 %75, label %78, label %76
+
+; <label>:76                                      ; preds = %70
+  %77 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1)
+  store %"System.Char[]" addrspace(1)* %77, %"System.Char[]" addrspace(1)** %arg1
+  br label %78
+
+; <label>:78                                      ; preds = %70, %76
+  %79 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck5 = icmp eq %"System.Byte[]" addrspace(1)* %79, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %80
+
+; <label>:80                                      ; preds = %78
+  %81 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %79, i32 0, i32 1
+  %82 = load i32, i32 addrspace(1)* %81
+  %83 = zext i32 %82 to i64
+  %84 = trunc i64 %83 to i32
+  %85 = load i32, i32* %arg5
+  %86 = sub i32 %84, %85
+  store i32 %86, i32* %loc0
+  %87 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck7 = icmp eq %"System.Byte[]" addrspace(1)* %87, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %88
+
+; <label>:88                                      ; preds = %80
+  %89 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %87, i32 0, i32 1
+  %90 = load i32, i32 addrspace(1)* %89
+  %91 = zext i32 %90 to i64
+  %92 = trunc i64 %91 to i32
+  %93 = icmp ne i32 %92, 0
+  br i1 %93, label %96, label %94
+
+; <label>:94                                      ; preds = %88
+  %95 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1)
+  store %"System.Byte[]" addrspace(1)* %95, %"System.Byte[]" addrspace(1)** %arg4
+  br label %96
+
+; <label>:96                                      ; preds = %88, %94
+  %97 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  store %"System.Char[]" addrspace(1)* %97, %"System.Char[]" addrspace(1)** %loc4
+  %98 = icmp eq %"System.Char[]" addrspace(1)* %97, null
+  br i1 %98, label %107, label %99
+
+; <label>:99                                      ; preds = %96
+  %100 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc4
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %100, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %101
+
+; <label>:101                                     ; preds = %99
+  %102 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %100, i32 0, i32 1
+  %103 = load i32, i32 addrspace(1)* %102
+  %104 = zext i32 %103 to i64
+  %105 = trunc i64 %104 to i32
+  %106 = icmp ne i32 %105, 0
+  br i1 %106, label %108, label %107
+
+; <label>:107                                     ; preds = %96, %101
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  br label %116
+
+; <label>:108                                     ; preds = %101
+  %109 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc4
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %109, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %110
+
+; <label>:110                                     ; preds = %108
+  %111 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %109, i32 0, i32 1
+  %112 = load i32, i32 addrspace(1)* %111
+  %113 = zext i32 %112 to i64
+  %BoundsCheck = icmp uge i64 0, %113
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %114
+
+; <label>:114                                     ; preds = %110
+  %115 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %109, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %115, i16 addrspace(1)** %loc1
+  br label %116
+
+; <label>:116                                     ; preds = %107, %114
+  %117 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  store %"System.Byte[]" addrspace(1)* %117, %"System.Byte[]" addrspace(1)** %loc5
+  %118 = icmp eq %"System.Byte[]" addrspace(1)* %117, null
+  br i1 %118, label %127, label %119
+
+; <label>:119                                     ; preds = %116
+  %120 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc5
+  %NullCheck13 = icmp eq %"System.Byte[]" addrspace(1)* %120, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %121
+
+; <label>:121                                     ; preds = %119
+  %122 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %120, i32 0, i32 1
+  %123 = load i32, i32 addrspace(1)* %122
+  %124 = zext i32 %123 to i64
+  %125 = trunc i64 %124 to i32
+  %126 = icmp ne i32 %125, 0
+  br i1 %126, label %128, label %127
+
+; <label>:127                                     ; preds = %116, %121
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc2
+  br label %136
+
+; <label>:128                                     ; preds = %121
+  %129 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc5
+  %NullCheck15 = icmp eq %"System.Byte[]" addrspace(1)* %129, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %130
+
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %129, i32 0, i32 1
+  %132 = load i32, i32 addrspace(1)* %131
+  %133 = zext i32 %132 to i64
+  %BoundsCheck17 = icmp uge i64 0, %133
+  br i1 %BoundsCheck17, label %ThrowIndexOutOfRange18, label %134
+
+; <label>:134                                     ; preds = %130
+  %135 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %129, i32 0, i32 3, i32 0
+  store i8 addrspace(1)* %135, i8 addrspace(1)** %loc2
+  br label %136
+
+; <label>:136                                     ; preds = %127, %134
+  %137 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %138 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %139 = ptrtoint i16 addrspace(1)* %138 to i64
+  %140 = load i32, i32* %arg2
+  %141 = sext i32 %140 to i64
+  %142 = mul i64 %141, 2
+  %143 = add i64 %139, %142
+  %144 = load i32, i32* %arg3
+  %145 = load i8 addrspace(1)*, i8 addrspace(1)** %loc2
+  %146 = ptrtoint i8 addrspace(1)* %145 to i64
+  %147 = load i32, i32* %arg5
+  %148 = sext i32 %147 to i64
+  %149 = add i64 %146, %148
+  %150 = load i32, i32* %loc0
+  %151 = load i8, i8* %arg6
+  %152 = zext i8 %151 to i32
+  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i64 addrspace(1)*
+  %NullCheck19 = icmp eq i64 addrspace(1)* %153, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %154
+
+; <label>:154                                     ; preds = %136
+  %155 = load i64, i64 addrspace(1)* %153
+  %156 = add i64 %155, 72
+  %157 = inttoptr i64 %156 to i64*
+  %158 = load i64, i64* %157
+  %159 = add i64 %158, 0
+  %160 = inttoptr i64 %159 to i64*
+  %161 = load i64, i64* %160
+  %162 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to %System.Text.Encoder addrspace(1)*
+  %163 = inttoptr i64 %143 to i16*
+  %164 = inttoptr i64 %149 to i8*
+  %165 = trunc i32 %152 to i8
+  %166 = inttoptr i64 %161 to i32 (%System.Text.Encoder addrspace(1)*, i16*, i32, i8*, i32, i8)*
+  %167 = call i32 %166(%System.Text.Encoder addrspace(1)* %162, i16* %163, i32 %144, i8* %164, i32 %150, i8 %165)
+  store i32 %167, i32* %loc3
+  br label %168
+
+; <label>:168                                     ; preds = %154
+  %169 = load i32, i32* %loc3
+  ret i32 %169
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %110
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %119
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange18:                           ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
 Successfully read EncoderNLS.GetBytes
 
@@ -14919,22 +17196,22 @@ entry:
   %40 = load i8, i8* %arg5
   %41 = zext i8 %40 to i32
   %42 = trunc i32 %41 to i8
-  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %39, null
-  br i1 %NullCheck, label %43, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderNLS addrspace(1)* %39, null
+  br i1 %NullCheck, label %ThrowNullRef, label %43
 
 ; <label>:43                                      ; preds = %38
   %44 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
   store i8 %42, i8 addrspace(1)* %44
   %45 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %45, null
-  br i1 %NullCheck2, label %46, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.EncoderNLS addrspace(1)* %45, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %46
 
 ; <label>:46                                      ; preds = %43
   %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %45, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %47
   %48 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.EncoderNLS addrspace(1)* %48, null
-  br i1 %NullCheck4, label %49, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.EncoderNLS addrspace(1)* %48, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %49
 
 ; <label>:49                                      ; preds = %46
   %50 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %48, i32 0, i32 3
@@ -14945,8 +17222,8 @@ entry:
   %55 = load i32, i32* %arg4
   %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck6, label %58, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
   %59 = load i64, i64 addrspace(1)* %57
@@ -14964,15 +17241,15 @@ ThrowNullRef:                                     ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %43
+ThrowNullRef2:                                    ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %46
+ThrowNullRef4:                                    ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %49
+ThrowNullRef6:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -15000,8 +17277,8 @@ entry:
   %4 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0 to %System.IO.ConsoleStream addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*)(%System.IO.ConsoleStream addrspace(1)* %4, %"System.Byte[]" addrspace(1)* %1, i32 %2, i32 %3)
   %5 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
@@ -15086,8 +17363,8 @@ entry:
 
 ; <label>:22                                      ; preds = %8
   %23 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %23, null
-  br i1 %NullCheck, label %24, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Byte[]" addrspace(1)* %23, null
+  br i1 %NullCheck, label %ThrowNullRef, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
@@ -15109,8 +17386,8 @@ entry:
 
 ; <label>:36                                      ; preds = %24
   %37 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %37, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.ConsoleStream addrspace(1)* %37, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %37, i32 0, i32 4
@@ -15131,13 +17408,138 @@ ThrowNullRef:                                     ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %36
+ThrowNullRef2:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
-Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
+Successfully read WindowsConsoleStream.WriteFileNative
+
+define i32 @WindowsConsoleStream.WriteFileNative(i64 %param0, %"System.Byte[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i64
+  %arg1 = alloca %"System.Byte[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i8 addrspace(1)*
+  %loc2 = alloca %"System.Byte[]" addrspace(1)*
+  %loc3 = alloca i32
+  store i64 %param0, i64* %arg0
+  store %"System.Byte[]" addrspace(1)* %param1, %"System.Byte[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Byte[]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = zext i32 %3 to i64
+  %5 = icmp ne i64 %4, 0
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %1
+  ret i32 0
+
+; <label>:7                                       ; preds = %1
+  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  store %"System.Byte[]" addrspace(1)* %8, %"System.Byte[]" addrspace(1)** %loc2
+  %9 = icmp eq %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %9, label %18, label %10
+
+; <label>:10                                      ; preds = %7
+  %11 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc2
+  %NullCheck1 = icmp eq %"System.Byte[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %11, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp ne i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %7, %12
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc1
+  br label %27
+
+; <label>:19                                      ; preds = %12
+  %20 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc2
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %20, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %BoundsCheck = icmp uge i64 0, %24
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %25
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %20, i32 0, i32 3, i32 0
+  store i8 addrspace(1)* %26, i8 addrspace(1)** %loc1
+  br label %27
+
+; <label>:27                                      ; preds = %18, %25
+  %28 = load i64, i64* %arg0
+  %29 = load i8 addrspace(1)*, i8 addrspace(1)** %loc1
+  %30 = ptrtoint i8 addrspace(1)* %29 to i64
+  %31 = load i32, i32* %arg2
+  %32 = sext i32 %31 to i64
+  %33 = add i64 %30, %32
+  %34 = load i32, i32* %arg3
+  %35 = addrspacecast i32* %loc3 to i32 addrspace(1)*
+  %36 = inttoptr i64 %33 to i8*
+  %37 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i8*, i32, i32 addrspace(1)*, i64)*)(i64 %28, i8* %36, i32 %34, i32 addrspace(1)* %35, i64 0)
+  %38 = icmp ugt i32 %37, 0
+  %39 = sext i1 %38 to i32
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc1
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %42, label %41
+
+; <label>:41                                      ; preds = %27
+  ret i32 0
+
+; <label>:42                                      ; preds = %27
+  %43 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  store i32 %43, i32* %loc0
+  %44 = load i32, i32* %loc0
+  %45 = icmp eq i32 %44, 232
+  br i1 %45, label %49, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = load i32, i32* %loc0
+  %48 = icmp ne i32 %47, 109
+  br i1 %48, label %50, label %49
+
+; <label>:49                                      ; preds = %42, %46
+  ret i32 0
+
+; <label>:50                                      ; preds = %46
+  %51 = load i32, i32* %loc0
+  ret i32 %51
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
 Successfully read WindowsConsoleStream.Flush
 
@@ -15146,8 +17548,8 @@ entry:
   %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
   store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
@@ -15182,8 +17584,8 @@ entry:
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
   %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load i64, i64 addrspace(1)* %1
@@ -15222,15 +17624,15 @@ entry:
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.TextWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
   %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %3, align 8
   %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
   %7 = load i64, i64 addrspace(1)* %5
@@ -15248,7 +17650,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -15277,8 +17679,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %4)
   store i32 0, i32* %loc0
   %5 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Char[]" addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
@@ -15290,15 +17692,15 @@ entry:
 
 ; <label>:11                                      ; preds = %69
   %12 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %12, i32 0, i32 9
   %15 = load i32, i32 addrspace(1)* %14, align 8
   %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.IO.StreamWriter addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %16, i32 0, i32 10
@@ -15313,15 +17715,15 @@ entry:
 
 ; <label>:23                                      ; preds = %17, %21
   %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %24, null
-  br i1 %NullCheck8, label %25, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %24, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 10
   %27 = load i32, i32 addrspace(1)* %26, align 8
   %28 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %28, null
-  br i1 %NullCheck10, label %29, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.StreamWriter addrspace(1)* %28, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %28, i32 0, i32 9
@@ -15343,15 +17745,15 @@ entry:
   %40 = load i32, i32* %loc0
   %41 = mul i32 %40, 2
   %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
-  br i1 %NullCheck12, label %43, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %43
 
 ; <label>:43                                      ; preds = %38
   %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 7
   %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %44, align 8
   %46 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %46, null
-  br i1 %NullCheck14, label %47, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.IO.StreamWriter addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %47
 
 ; <label>:47                                      ; preds = %43
   %48 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %46, i32 0, i32 9
@@ -15363,16 +17765,16 @@ entry:
   %54 = bitcast %"System.Char[]" addrspace(1)* %45 to %System.Array addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %53, i32 %41, %System.Array addrspace(1)* %54, i32 %50, i32 %52)
   %55 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
-  br i1 %NullCheck16, label %56, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %56
 
 ; <label>:56                                      ; preds = %47
   %57 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
   %58 = load i32, i32 addrspace(1)* %57, align 8
   %59 = load i32, i32* %loc2
   %60 = add i32 %58, %59
-  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
-  br i1 %NullCheck18, label %61, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %61
 
 ; <label>:61                                      ; preds = %56
   %62 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
@@ -15394,8 +17796,8 @@ entry:
 
 ; <label>:72                                      ; preds = %69
   %73 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %73, null
-  br i1 %NullCheck2, label %74, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %73, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %74
 
 ; <label>:74                                      ; preds = %72
   %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %73, i32 0, i32 11
@@ -15416,39 +17818,39 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %72
+ThrowNullRef2:                                    ; preds = %72
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %23
+ThrowNullRef8:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef10:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %43
+ThrowNullRef14:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %47
+ThrowNullRef16:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %56
+ThrowNullRef18:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblAddConst.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblAddConst.error.txt
@@ -25,8 +25,8 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
@@ -40,8 +40,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
   %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
@@ -75,7 +75,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -90,8 +90,8 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %NullCheck = icmp ne i8 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = load i8, i8 addrspace(1)* %0, align 8
@@ -125,8 +125,8 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
@@ -159,8 +159,8 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -184,8 +184,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
   store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
@@ -195,8 +195,8 @@ entry:
 ; <label>:4                                       ; preds = %1
   %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
   %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
@@ -206,8 +206,8 @@ entry:
   %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
@@ -221,14 +221,14 @@ entry:
 
 ; <label>:17                                      ; preds = %14
   %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
   %21 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
@@ -238,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -249,8 +249,8 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
@@ -261,27 +261,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %30
+ThrowNullRef10:                                   ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -301,7 +301,89 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
-Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
+Successfully read AppDomainSetup.GetUnsecureApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.GetUnsecureApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %NullCheck = icmp eq %"System.String[]" addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %BoundsCheck = icmp uge i64 0, %5
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %6
+
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 3, i32 0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
+  ret %System.String addrspace(1)* %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_Value using LLILCJit
+Successfully read AppDomainSetup.get_Value
+
+define %"System.String[]" addrspace(1)* @AppDomainSetup.get_Value(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.String[]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 18)
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.String[]" addrspace(1)* addrspace(1)*, %"System.String[]" addrspace(1)*)*)(%"System.String[]" addrspace(1)* addrspace(1)* %9, %"System.String[]" addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %11, i32 0, i32 1
+  %14 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %13, align 8
+  ret %"System.String[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -319,8 +401,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -368,16 +450,16 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
   %5 = load i32, i32 addrspace(1)* %4
   %6 = sub i32 %5, 1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -389,7 +471,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -421,8 +503,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
@@ -456,8 +538,8 @@ entry:
 ; <label>:27                                      ; preds = %19
   %28 = load i32, i32* %arg1
   %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
-  br i1 %NullCheck2, label %30, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %29, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %30
 
 ; <label>:30                                      ; preds = %27
   %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
@@ -493,8 +575,8 @@ entry:
 ; <label>:49                                      ; preds = %46
   %50 = load i32, i32* %arg2
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck4, label %52, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
@@ -517,11 +599,11 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %27
+ThrowNullRef2:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %49
+ThrowNullRef4:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -544,16 +626,16 @@ entry:
   %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %0)
   store %System.String addrspace(1)* %1, %System.String addrspace(1)** %loc0
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 2
   %5 = bitcast [0 x i16] addrspace(1)* %4 to i16 addrspace(1)*
   store i16 addrspace(1)* %5, i16 addrspace(1)** %loc1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %3
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2
@@ -580,7 +662,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -691,15 +773,15 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %NullCheck132 = icmp ne i8* %21, null
-  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+  %NullCheck131 = icmp eq i8* %21, null
+  br i1 %NullCheck131, label %ThrowNullRef132, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = load i8, i8* %21, align 8
   %24 = zext i8 %23 to i32
   %25 = trunc i32 %24 to i8
-  %NullCheck134 = icmp ne i8* %20, null
-  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+  %NullCheck133 = icmp eq i8* %20, null
+  br i1 %NullCheck133, label %ThrowNullRef134, label %26
 
 ; <label>:26                                      ; preds = %22
   store i8 %25, i8* %20, align 8
@@ -709,16 +791,16 @@ entry:
   %28 = load i8*, i8** %arg0
   %29 = load i8*, i8** %arg1
   %30 = bitcast i8* %29 to i16*
-  %NullCheck128 = icmp ne i16* %30, null
-  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+  %NullCheck127 = icmp eq i16* %30, null
+  br i1 %NullCheck127, label %ThrowNullRef128, label %31
 
 ; <label>:31                                      ; preds = %27
   %32 = load i16, i16* %30, align 8
   %33 = sext i16 %32 to i32
   %34 = bitcast i8* %28 to i16*
   %35 = trunc i32 %33 to i16
-  %NullCheck130 = icmp ne i16* %34, null
-  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+  %NullCheck129 = icmp eq i16* %34, null
+  br i1 %NullCheck129, label %ThrowNullRef130, label %36
 
 ; <label>:36                                      ; preds = %31
   store i16 %35, i16* %34, align 8
@@ -728,16 +810,16 @@ entry:
   %38 = load i8*, i8** %arg0
   %39 = load i8*, i8** %arg1
   %40 = bitcast i8* %39 to i16*
-  %NullCheck120 = icmp ne i16* %40, null
-  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+  %NullCheck119 = icmp eq i16* %40, null
+  br i1 %NullCheck119, label %ThrowNullRef120, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i16, i16* %40, align 8
   %43 = sext i16 %42 to i32
   %44 = bitcast i8* %38 to i16*
   %45 = trunc i32 %43 to i16
-  %NullCheck122 = icmp ne i16* %44, null
-  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+  %NullCheck121 = icmp eq i16* %44, null
+  br i1 %NullCheck121, label %ThrowNullRef122, label %46
 
 ; <label>:46                                      ; preds = %41
   store i16 %45, i16* %44, align 8
@@ -745,15 +827,15 @@ entry:
   %48 = getelementptr inbounds i8, i8* %47, i64 2
   %49 = load i8*, i8** %arg1
   %50 = getelementptr inbounds i8, i8* %49, i64 2
-  %NullCheck124 = icmp ne i8* %50, null
-  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+  %NullCheck123 = icmp eq i8* %50, null
+  br i1 %NullCheck123, label %ThrowNullRef124, label %51
 
 ; <label>:51                                      ; preds = %46
   %52 = load i8, i8* %50, align 8
   %53 = zext i8 %52 to i32
   %54 = trunc i32 %53 to i8
-  %NullCheck126 = icmp ne i8* %48, null
-  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+  %NullCheck125 = icmp eq i8* %48, null
+  br i1 %NullCheck125, label %ThrowNullRef126, label %55
 
 ; <label>:55                                      ; preds = %51
   store i8 %54, i8* %48, align 8
@@ -763,14 +845,14 @@ entry:
   %57 = load i8*, i8** %arg0
   %58 = load i8*, i8** %arg1
   %59 = bitcast i8* %58 to i32*
-  %NullCheck116 = icmp ne i32* %59, null
-  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+  %NullCheck115 = icmp eq i32* %59, null
+  br i1 %NullCheck115, label %ThrowNullRef116, label %60
 
 ; <label>:60                                      ; preds = %56
   %61 = load i32, i32* %59, align 8
   %62 = bitcast i8* %57 to i32*
-  %NullCheck118 = icmp ne i32* %62, null
-  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+  %NullCheck117 = icmp eq i32* %62, null
+  br i1 %NullCheck117, label %ThrowNullRef118, label %63
 
 ; <label>:63                                      ; preds = %60
   store i32 %61, i32* %62, align 8
@@ -780,14 +862,14 @@ entry:
   %65 = load i8*, i8** %arg0
   %66 = load i8*, i8** %arg1
   %67 = bitcast i8* %66 to i32*
-  %NullCheck108 = icmp ne i32* %67, null
-  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+  %NullCheck107 = icmp eq i32* %67, null
+  br i1 %NullCheck107, label %ThrowNullRef108, label %68
 
 ; <label>:68                                      ; preds = %64
   %69 = load i32, i32* %67, align 8
   %70 = bitcast i8* %65 to i32*
-  %NullCheck110 = icmp ne i32* %70, null
-  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+  %NullCheck109 = icmp eq i32* %70, null
+  br i1 %NullCheck109, label %ThrowNullRef110, label %71
 
 ; <label>:71                                      ; preds = %68
   store i32 %69, i32* %70, align 8
@@ -795,15 +877,15 @@ entry:
   %73 = getelementptr inbounds i8, i8* %72, i64 4
   %74 = load i8*, i8** %arg1
   %75 = getelementptr inbounds i8, i8* %74, i64 4
-  %NullCheck112 = icmp ne i8* %75, null
-  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+  %NullCheck111 = icmp eq i8* %75, null
+  br i1 %NullCheck111, label %ThrowNullRef112, label %76
 
 ; <label>:76                                      ; preds = %71
   %77 = load i8, i8* %75, align 8
   %78 = zext i8 %77 to i32
   %79 = trunc i32 %78 to i8
-  %NullCheck114 = icmp ne i8* %73, null
-  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+  %NullCheck113 = icmp eq i8* %73, null
+  br i1 %NullCheck113, label %ThrowNullRef114, label %80
 
 ; <label>:80                                      ; preds = %76
   store i8 %79, i8* %73, align 8
@@ -813,14 +895,14 @@ entry:
   %82 = load i8*, i8** %arg0
   %83 = load i8*, i8** %arg1
   %84 = bitcast i8* %83 to i32*
-  %NullCheck100 = icmp ne i32* %84, null
-  br i1 %NullCheck100, label %85, label %ThrowNullRef99
+  %NullCheck99 = icmp eq i32* %84, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %85
 
 ; <label>:85                                      ; preds = %81
   %86 = load i32, i32* %84, align 8
   %87 = bitcast i8* %82 to i32*
-  %NullCheck102 = icmp ne i32* %87, null
-  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+  %NullCheck101 = icmp eq i32* %87, null
+  br i1 %NullCheck101, label %ThrowNullRef102, label %88
 
 ; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
@@ -829,16 +911,16 @@ entry:
   %91 = load i8*, i8** %arg1
   %92 = getelementptr inbounds i8, i8* %91, i64 4
   %93 = bitcast i8* %92 to i16*
-  %NullCheck104 = icmp ne i16* %93, null
-  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+  %NullCheck103 = icmp eq i16* %93, null
+  br i1 %NullCheck103, label %ThrowNullRef104, label %94
 
 ; <label>:94                                      ; preds = %88
   %95 = load i16, i16* %93, align 8
   %96 = sext i16 %95 to i32
   %97 = bitcast i8* %90 to i16*
   %98 = trunc i32 %96 to i16
-  %NullCheck106 = icmp ne i16* %97, null
-  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+  %NullCheck105 = icmp eq i16* %97, null
+  br i1 %NullCheck105, label %ThrowNullRef106, label %99
 
 ; <label>:99                                      ; preds = %94
   store i16 %98, i16* %97, align 8
@@ -848,14 +930,14 @@ entry:
   %101 = load i8*, i8** %arg0
   %102 = load i8*, i8** %arg1
   %103 = bitcast i8* %102 to i32*
-  %NullCheck88 = icmp ne i32* %103, null
-  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+  %NullCheck87 = icmp eq i32* %103, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %104
 
 ; <label>:104                                     ; preds = %100
   %105 = load i32, i32* %103, align 8
   %106 = bitcast i8* %101 to i32*
-  %NullCheck90 = icmp ne i32* %106, null
-  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+  %NullCheck89 = icmp eq i32* %106, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %107
 
 ; <label>:107                                     ; preds = %104
   store i32 %105, i32* %106, align 8
@@ -864,16 +946,16 @@ entry:
   %110 = load i8*, i8** %arg1
   %111 = getelementptr inbounds i8, i8* %110, i64 4
   %112 = bitcast i8* %111 to i16*
-  %NullCheck92 = icmp ne i16* %112, null
-  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+  %NullCheck91 = icmp eq i16* %112, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %113
 
 ; <label>:113                                     ; preds = %107
   %114 = load i16, i16* %112, align 8
   %115 = sext i16 %114 to i32
   %116 = bitcast i8* %109 to i16*
   %117 = trunc i32 %115 to i16
-  %NullCheck94 = icmp ne i16* %116, null
-  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+  %NullCheck93 = icmp eq i16* %116, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %118
 
 ; <label>:118                                     ; preds = %113
   store i16 %117, i16* %116, align 8
@@ -881,15 +963,15 @@ entry:
   %120 = getelementptr inbounds i8, i8* %119, i64 6
   %121 = load i8*, i8** %arg1
   %122 = getelementptr inbounds i8, i8* %121, i64 6
-  %NullCheck96 = icmp ne i8* %122, null
-  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+  %NullCheck95 = icmp eq i8* %122, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %123
 
 ; <label>:123                                     ; preds = %118
   %124 = load i8, i8* %122, align 8
   %125 = zext i8 %124 to i32
   %126 = trunc i32 %125 to i8
-  %NullCheck98 = icmp ne i8* %120, null
-  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+  %NullCheck97 = icmp eq i8* %120, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %127
 
 ; <label>:127                                     ; preds = %123
   store i8 %126, i8* %120, align 8
@@ -899,14 +981,14 @@ entry:
   %129 = load i8*, i8** %arg0
   %130 = load i8*, i8** %arg1
   %131 = bitcast i8* %130 to i64*
-  %NullCheck84 = icmp ne i64* %131, null
-  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+  %NullCheck83 = icmp eq i64* %131, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %132
 
 ; <label>:132                                     ; preds = %128
   %133 = load i64, i64* %131, align 8
   %134 = bitcast i8* %129 to i64*
-  %NullCheck86 = icmp ne i64* %134, null
-  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+  %NullCheck85 = icmp eq i64* %134, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %135
 
 ; <label>:135                                     ; preds = %132
   store i64 %133, i64* %134, align 8
@@ -916,14 +998,14 @@ entry:
   %137 = load i8*, i8** %arg0
   %138 = load i8*, i8** %arg1
   %139 = bitcast i8* %138 to i64*
-  %NullCheck76 = icmp ne i64* %139, null
-  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+  %NullCheck75 = icmp eq i64* %139, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %140
 
 ; <label>:140                                     ; preds = %136
   %141 = load i64, i64* %139, align 8
   %142 = bitcast i8* %137 to i64*
-  %NullCheck78 = icmp ne i64* %142, null
-  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+  %NullCheck77 = icmp eq i64* %142, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %143
 
 ; <label>:143                                     ; preds = %140
   store i64 %141, i64* %142, align 8
@@ -931,15 +1013,15 @@ entry:
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %NullCheck80 = icmp ne i8* %147, null
-  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+  %NullCheck79 = icmp eq i8* %147, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %148
 
 ; <label>:148                                     ; preds = %143
   %149 = load i8, i8* %147, align 8
   %150 = zext i8 %149 to i32
   %151 = trunc i32 %150 to i8
-  %NullCheck82 = icmp ne i8* %145, null
-  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+  %NullCheck81 = icmp eq i8* %145, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %152
 
 ; <label>:152                                     ; preds = %148
   store i8 %151, i8* %145, align 8
@@ -949,14 +1031,14 @@ entry:
   %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
   %156 = bitcast i8* %155 to i64*
-  %NullCheck68 = icmp ne i64* %156, null
-  br i1 %NullCheck68, label %157, label %ThrowNullRef67
+  %NullCheck67 = icmp eq i64* %156, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %157
 
 ; <label>:157                                     ; preds = %153
   %158 = load i64, i64* %156, align 8
   %159 = bitcast i8* %154 to i64*
-  %NullCheck70 = icmp ne i64* %159, null
-  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+  %NullCheck69 = icmp eq i64* %159, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %160
 
 ; <label>:160                                     ; preds = %157
   store i64 %158, i64* %159, align 8
@@ -965,16 +1047,16 @@ entry:
   %163 = load i8*, i8** %arg1
   %164 = getelementptr inbounds i8, i8* %163, i64 8
   %165 = bitcast i8* %164 to i16*
-  %NullCheck72 = icmp ne i16* %165, null
-  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+  %NullCheck71 = icmp eq i16* %165, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %166
 
 ; <label>:166                                     ; preds = %160
   %167 = load i16, i16* %165, align 8
   %168 = sext i16 %167 to i32
   %169 = bitcast i8* %162 to i16*
   %170 = trunc i32 %168 to i16
-  %NullCheck74 = icmp ne i16* %169, null
-  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+  %NullCheck73 = icmp eq i16* %169, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %171
 
 ; <label>:171                                     ; preds = %166
   store i16 %170, i16* %169, align 8
@@ -984,14 +1066,14 @@ entry:
   %173 = load i8*, i8** %arg0
   %174 = load i8*, i8** %arg1
   %175 = bitcast i8* %174 to i64*
-  %NullCheck56 = icmp ne i64* %175, null
-  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+  %NullCheck55 = icmp eq i64* %175, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %176
 
 ; <label>:176                                     ; preds = %172
   %177 = load i64, i64* %175, align 8
   %178 = bitcast i8* %173 to i64*
-  %NullCheck58 = icmp ne i64* %178, null
-  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+  %NullCheck57 = icmp eq i64* %178, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %179
 
 ; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
@@ -1000,16 +1082,16 @@ entry:
   %182 = load i8*, i8** %arg1
   %183 = getelementptr inbounds i8, i8* %182, i64 8
   %184 = bitcast i8* %183 to i16*
-  %NullCheck60 = icmp ne i16* %184, null
-  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+  %NullCheck59 = icmp eq i16* %184, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %185
 
 ; <label>:185                                     ; preds = %179
   %186 = load i16, i16* %184, align 8
   %187 = sext i16 %186 to i32
   %188 = bitcast i8* %181 to i16*
   %189 = trunc i32 %187 to i16
-  %NullCheck62 = icmp ne i16* %188, null
-  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+  %NullCheck61 = icmp eq i16* %188, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %190
 
 ; <label>:190                                     ; preds = %185
   store i16 %189, i16* %188, align 8
@@ -1017,15 +1099,15 @@ entry:
   %192 = getelementptr inbounds i8, i8* %191, i64 10
   %193 = load i8*, i8** %arg1
   %194 = getelementptr inbounds i8, i8* %193, i64 10
-  %NullCheck64 = icmp ne i8* %194, null
-  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+  %NullCheck63 = icmp eq i8* %194, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %195
 
 ; <label>:195                                     ; preds = %190
   %196 = load i8, i8* %194, align 8
   %197 = zext i8 %196 to i32
   %198 = trunc i32 %197 to i8
-  %NullCheck66 = icmp ne i8* %192, null
-  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+  %NullCheck65 = icmp eq i8* %192, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %199
 
 ; <label>:199                                     ; preds = %195
   store i8 %198, i8* %192, align 8
@@ -1035,14 +1117,14 @@ entry:
   %201 = load i8*, i8** %arg0
   %202 = load i8*, i8** %arg1
   %203 = bitcast i8* %202 to i64*
-  %NullCheck48 = icmp ne i64* %203, null
-  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+  %NullCheck47 = icmp eq i64* %203, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %204
 
 ; <label>:204                                     ; preds = %200
   %205 = load i64, i64* %203, align 8
   %206 = bitcast i8* %201 to i64*
-  %NullCheck50 = icmp ne i64* %206, null
-  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+  %NullCheck49 = icmp eq i64* %206, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %207
 
 ; <label>:207                                     ; preds = %204
   store i64 %205, i64* %206, align 8
@@ -1051,14 +1133,14 @@ entry:
   %210 = load i8*, i8** %arg1
   %211 = getelementptr inbounds i8, i8* %210, i64 8
   %212 = bitcast i8* %211 to i32*
-  %NullCheck52 = icmp ne i32* %212, null
-  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+  %NullCheck51 = icmp eq i32* %212, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %213
 
 ; <label>:213                                     ; preds = %207
   %214 = load i32, i32* %212, align 8
   %215 = bitcast i8* %209 to i32*
-  %NullCheck54 = icmp ne i32* %215, null
-  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+  %NullCheck53 = icmp eq i32* %215, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %216
 
 ; <label>:216                                     ; preds = %213
   store i32 %214, i32* %215, align 8
@@ -1068,14 +1150,14 @@ entry:
   %218 = load i8*, i8** %arg0
   %219 = load i8*, i8** %arg1
   %220 = bitcast i8* %219 to i64*
-  %NullCheck36 = icmp ne i64* %220, null
-  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64* %220, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %221
 
 ; <label>:221                                     ; preds = %217
   %222 = load i64, i64* %220, align 8
   %223 = bitcast i8* %218 to i64*
-  %NullCheck38 = icmp ne i64* %223, null
-  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+  %NullCheck37 = icmp eq i64* %223, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %224
 
 ; <label>:224                                     ; preds = %221
   store i64 %222, i64* %223, align 8
@@ -1084,14 +1166,14 @@ entry:
   %227 = load i8*, i8** %arg1
   %228 = getelementptr inbounds i8, i8* %227, i64 8
   %229 = bitcast i8* %228 to i32*
-  %NullCheck40 = icmp ne i32* %229, null
-  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i32* %229, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %230
 
 ; <label>:230                                     ; preds = %224
   %231 = load i32, i32* %229, align 8
   %232 = bitcast i8* %226 to i32*
-  %NullCheck42 = icmp ne i32* %232, null
-  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+  %NullCheck41 = icmp eq i32* %232, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %233
 
 ; <label>:233                                     ; preds = %230
   store i32 %231, i32* %232, align 8
@@ -1099,15 +1181,15 @@ entry:
   %235 = getelementptr inbounds i8, i8* %234, i64 12
   %236 = load i8*, i8** %arg1
   %237 = getelementptr inbounds i8, i8* %236, i64 12
-  %NullCheck44 = icmp ne i8* %237, null
-  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i8* %237, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %238
 
 ; <label>:238                                     ; preds = %233
   %239 = load i8, i8* %237, align 8
   %240 = zext i8 %239 to i32
   %241 = trunc i32 %240 to i8
-  %NullCheck46 = icmp ne i8* %235, null
-  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+  %NullCheck45 = icmp eq i8* %235, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %242
 
 ; <label>:242                                     ; preds = %238
   store i8 %241, i8* %235, align 8
@@ -1117,14 +1199,14 @@ entry:
   %244 = load i8*, i8** %arg0
   %245 = load i8*, i8** %arg1
   %246 = bitcast i8* %245 to i64*
-  %NullCheck24 = icmp ne i64* %246, null
-  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64* %246, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %247
 
 ; <label>:247                                     ; preds = %243
   %248 = load i64, i64* %246, align 8
   %249 = bitcast i8* %244 to i64*
-  %NullCheck26 = icmp ne i64* %249, null
-  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64* %249, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %250
 
 ; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
@@ -1133,14 +1215,14 @@ entry:
   %253 = load i8*, i8** %arg1
   %254 = getelementptr inbounds i8, i8* %253, i64 8
   %255 = bitcast i8* %254 to i32*
-  %NullCheck28 = icmp ne i32* %255, null
-  br i1 %NullCheck28, label %256, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i32* %255, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %256
 
 ; <label>:256                                     ; preds = %250
   %257 = load i32, i32* %255, align 8
   %258 = bitcast i8* %252 to i32*
-  %NullCheck30 = icmp ne i32* %258, null
-  br i1 %NullCheck30, label %259, label %ThrowNullRef29
+  %NullCheck29 = icmp eq i32* %258, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %259
 
 ; <label>:259                                     ; preds = %256
   store i32 %257, i32* %258, align 8
@@ -1149,16 +1231,16 @@ entry:
   %262 = load i8*, i8** %arg1
   %263 = getelementptr inbounds i8, i8* %262, i64 12
   %264 = bitcast i8* %263 to i16*
-  %NullCheck32 = icmp ne i16* %264, null
-  br i1 %NullCheck32, label %265, label %ThrowNullRef31
+  %NullCheck31 = icmp eq i16* %264, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %265
 
 ; <label>:265                                     ; preds = %259
   %266 = load i16, i16* %264, align 8
   %267 = sext i16 %266 to i32
   %268 = bitcast i8* %261 to i16*
   %269 = trunc i32 %267 to i16
-  %NullCheck34 = icmp ne i16* %268, null
-  br i1 %NullCheck34, label %270, label %ThrowNullRef33
+  %NullCheck33 = icmp eq i16* %268, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %270
 
 ; <label>:270                                     ; preds = %265
   store i16 %269, i16* %268, align 8
@@ -1168,14 +1250,14 @@ entry:
   %272 = load i8*, i8** %arg0
   %273 = load i8*, i8** %arg1
   %274 = bitcast i8* %273 to i64*
-  %NullCheck8 = icmp ne i64* %274, null
-  br i1 %NullCheck8, label %275, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64* %274, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %275
 
 ; <label>:275                                     ; preds = %271
   %276 = load i64, i64* %274, align 8
   %277 = bitcast i8* %272 to i64*
-  %NullCheck10 = icmp ne i64* %277, null
-  br i1 %NullCheck10, label %278, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %277, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %278
 
 ; <label>:278                                     ; preds = %275
   store i64 %276, i64* %277, align 8
@@ -1184,14 +1266,14 @@ entry:
   %281 = load i8*, i8** %arg1
   %282 = getelementptr inbounds i8, i8* %281, i64 8
   %283 = bitcast i8* %282 to i32*
-  %NullCheck12 = icmp ne i32* %283, null
-  br i1 %NullCheck12, label %284, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i32* %283, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %284
 
 ; <label>:284                                     ; preds = %278
   %285 = load i32, i32* %283, align 8
   %286 = bitcast i8* %280 to i32*
-  %NullCheck14 = icmp ne i32* %286, null
-  br i1 %NullCheck14, label %287, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i32* %286, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %287
 
 ; <label>:287                                     ; preds = %284
   store i32 %285, i32* %286, align 8
@@ -1200,16 +1282,16 @@ entry:
   %290 = load i8*, i8** %arg1
   %291 = getelementptr inbounds i8, i8* %290, i64 12
   %292 = bitcast i8* %291 to i16*
-  %NullCheck16 = icmp ne i16* %292, null
-  br i1 %NullCheck16, label %293, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i16* %292, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %293
 
 ; <label>:293                                     ; preds = %287
   %294 = load i16, i16* %292, align 8
   %295 = sext i16 %294 to i32
   %296 = bitcast i8* %289 to i16*
   %297 = trunc i32 %295 to i16
-  %NullCheck18 = icmp ne i16* %296, null
-  br i1 %NullCheck18, label %298, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i16* %296, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %298
 
 ; <label>:298                                     ; preds = %293
   store i16 %297, i16* %296, align 8
@@ -1217,15 +1299,15 @@ entry:
   %300 = getelementptr inbounds i8, i8* %299, i64 14
   %301 = load i8*, i8** %arg1
   %302 = getelementptr inbounds i8, i8* %301, i64 14
-  %NullCheck20 = icmp ne i8* %302, null
-  br i1 %NullCheck20, label %303, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i8* %302, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %303
 
 ; <label>:303                                     ; preds = %298
   %304 = load i8, i8* %302, align 8
   %305 = zext i8 %304 to i32
   %306 = trunc i32 %305 to i8
-  %NullCheck22 = icmp ne i8* %300, null
-  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i8* %300, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %307
 
 ; <label>:307                                     ; preds = %303
   store i8 %306, i8* %300, align 8
@@ -1235,14 +1317,14 @@ entry:
   %309 = load i8*, i8** %arg0
   %310 = load i8*, i8** %arg1
   %311 = bitcast i8* %310 to i64*
-  %NullCheck = icmp ne i64* %311, null
-  br i1 %NullCheck, label %312, label %ThrowNullRef
+  %NullCheck = icmp eq i64* %311, null
+  br i1 %NullCheck, label %ThrowNullRef, label %312
 
 ; <label>:312                                     ; preds = %308
   %313 = load i64, i64* %311, align 8
   %314 = bitcast i8* %309 to i64*
-  %NullCheck2 = icmp ne i64* %314, null
-  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64* %314, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %315
 
 ; <label>:315                                     ; preds = %312
   store i64 %313, i64* %314, align 8
@@ -1251,14 +1333,14 @@ entry:
   %318 = load i8*, i8** %arg1
   %319 = getelementptr inbounds i8, i8* %318, i64 8
   %320 = bitcast i8* %319 to i64*
-  %NullCheck4 = icmp ne i64* %320, null
-  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64* %320, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %321
 
 ; <label>:321                                     ; preds = %315
   %322 = load i64, i64* %320, align 8
   %323 = bitcast i8* %317 to i64*
-  %NullCheck6 = icmp ne i64* %323, null
-  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64* %323, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %324
 
 ; <label>:324                                     ; preds = %321
   store i64 %322, i64* %323, align 8
@@ -1286,15 +1368,15 @@ entry:
 ; <label>:338                                     ; preds = %333
   %339 = load i8*, i8** %arg0
   %340 = load i8*, i8** %arg1
-  %NullCheck136 = icmp ne i8* %340, null
-  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+  %NullCheck135 = icmp eq i8* %340, null
+  br i1 %NullCheck135, label %ThrowNullRef136, label %341
 
 ; <label>:341                                     ; preds = %338
   %342 = load i8, i8* %340, align 8
   %343 = zext i8 %342 to i32
   %344 = trunc i32 %343 to i8
-  %NullCheck138 = icmp ne i8* %339, null
-  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+  %NullCheck137 = icmp eq i8* %339, null
+  br i1 %NullCheck137, label %ThrowNullRef138, label %345
 
 ; <label>:345                                     ; preds = %341
   store i8 %344, i8* %339, align 8
@@ -1317,16 +1399,16 @@ entry:
   %357 = load i8*, i8** %arg0
   %358 = load i8*, i8** %arg1
   %359 = bitcast i8* %358 to i16*
-  %NullCheck140 = icmp ne i16* %359, null
-  br i1 %NullCheck140, label %360, label %ThrowNullRef139
+  %NullCheck139 = icmp eq i16* %359, null
+  br i1 %NullCheck139, label %ThrowNullRef140, label %360
 
 ; <label>:360                                     ; preds = %356
   %361 = load i16, i16* %359, align 8
   %362 = sext i16 %361 to i32
   %363 = bitcast i8* %357 to i16*
   %364 = trunc i32 %362 to i16
-  %NullCheck142 = icmp ne i16* %363, null
-  br i1 %NullCheck142, label %365, label %ThrowNullRef141
+  %NullCheck141 = icmp eq i16* %363, null
+  br i1 %NullCheck141, label %ThrowNullRef142, label %365
 
 ; <label>:365                                     ; preds = %360
   store i16 %364, i16* %363, align 8
@@ -1352,14 +1434,14 @@ entry:
   %378 = load i8*, i8** %arg0
   %379 = load i8*, i8** %arg1
   %380 = bitcast i8* %379 to i32*
-  %NullCheck144 = icmp ne i32* %380, null
-  br i1 %NullCheck144, label %381, label %ThrowNullRef143
+  %NullCheck143 = icmp eq i32* %380, null
+  br i1 %NullCheck143, label %ThrowNullRef144, label %381
 
 ; <label>:381                                     ; preds = %377
   %382 = load i32, i32* %380, align 8
   %383 = bitcast i8* %378 to i32*
-  %NullCheck146 = icmp ne i32* %383, null
-  br i1 %NullCheck146, label %384, label %ThrowNullRef145
+  %NullCheck145 = icmp eq i32* %383, null
+  br i1 %NullCheck145, label %ThrowNullRef146, label %384
 
 ; <label>:384                                     ; preds = %381
   store i32 %382, i32* %383, align 8
@@ -1384,14 +1466,14 @@ entry:
   %395 = load i8*, i8** %arg0
   %396 = load i8*, i8** %arg1
   %397 = bitcast i8* %396 to i64*
-  %NullCheck164 = icmp ne i64* %397, null
-  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+  %NullCheck163 = icmp eq i64* %397, null
+  br i1 %NullCheck163, label %ThrowNullRef164, label %398
 
 ; <label>:398                                     ; preds = %394
   %399 = load i64, i64* %397, align 8
   %400 = bitcast i8* %395 to i64*
-  %NullCheck166 = icmp ne i64* %400, null
-  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+  %NullCheck165 = icmp eq i64* %400, null
+  br i1 %NullCheck165, label %ThrowNullRef166, label %401
 
 ; <label>:401                                     ; preds = %398
   store i64 %399, i64* %400, align 8
@@ -1400,14 +1482,14 @@ entry:
   %404 = load i8*, i8** %arg1
   %405 = getelementptr inbounds i8, i8* %404, i64 8
   %406 = bitcast i8* %405 to i64*
-  %NullCheck168 = icmp ne i64* %406, null
-  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+  %NullCheck167 = icmp eq i64* %406, null
+  br i1 %NullCheck167, label %ThrowNullRef168, label %407
 
 ; <label>:407                                     ; preds = %401
   %408 = load i64, i64* %406, align 8
   %409 = bitcast i8* %403 to i64*
-  %NullCheck170 = icmp ne i64* %409, null
-  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+  %NullCheck169 = icmp eq i64* %409, null
+  br i1 %NullCheck169, label %ThrowNullRef170, label %410
 
 ; <label>:410                                     ; preds = %407
   store i64 %408, i64* %409, align 8
@@ -1437,14 +1519,14 @@ entry:
   %425 = load i8*, i8** %arg0
   %426 = load i8*, i8** %arg1
   %427 = bitcast i8* %426 to i64*
-  %NullCheck148 = icmp ne i64* %427, null
-  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+  %NullCheck147 = icmp eq i64* %427, null
+  br i1 %NullCheck147, label %ThrowNullRef148, label %428
 
 ; <label>:428                                     ; preds = %424
   %429 = load i64, i64* %427, align 8
   %430 = bitcast i8* %425 to i64*
-  %NullCheck150 = icmp ne i64* %430, null
-  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+  %NullCheck149 = icmp eq i64* %430, null
+  br i1 %NullCheck149, label %ThrowNullRef150, label %431
 
 ; <label>:431                                     ; preds = %428
   store i64 %429, i64* %430, align 8
@@ -1466,14 +1548,14 @@ entry:
   %441 = load i8*, i8** %arg0
   %442 = load i8*, i8** %arg1
   %443 = bitcast i8* %442 to i32*
-  %NullCheck152 = icmp ne i32* %443, null
-  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+  %NullCheck151 = icmp eq i32* %443, null
+  br i1 %NullCheck151, label %ThrowNullRef152, label %444
 
 ; <label>:444                                     ; preds = %440
   %445 = load i32, i32* %443, align 8
   %446 = bitcast i8* %441 to i32*
-  %NullCheck154 = icmp ne i32* %446, null
-  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+  %NullCheck153 = icmp eq i32* %446, null
+  br i1 %NullCheck153, label %ThrowNullRef154, label %447
 
 ; <label>:447                                     ; preds = %444
   store i32 %445, i32* %446, align 8
@@ -1495,16 +1577,16 @@ entry:
   %457 = load i8*, i8** %arg0
   %458 = load i8*, i8** %arg1
   %459 = bitcast i8* %458 to i16*
-  %NullCheck156 = icmp ne i16* %459, null
-  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+  %NullCheck155 = icmp eq i16* %459, null
+  br i1 %NullCheck155, label %ThrowNullRef156, label %460
 
 ; <label>:460                                     ; preds = %456
   %461 = load i16, i16* %459, align 8
   %462 = sext i16 %461 to i32
   %463 = bitcast i8* %457 to i16*
   %464 = trunc i32 %462 to i16
-  %NullCheck158 = icmp ne i16* %463, null
-  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+  %NullCheck157 = icmp eq i16* %463, null
+  br i1 %NullCheck157, label %ThrowNullRef158, label %465
 
 ; <label>:465                                     ; preds = %460
   store i16 %464, i16* %463, align 8
@@ -1525,15 +1607,15 @@ entry:
 ; <label>:474                                     ; preds = %470
   %475 = load i8*, i8** %arg0
   %476 = load i8*, i8** %arg1
-  %NullCheck160 = icmp ne i8* %476, null
-  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+  %NullCheck159 = icmp eq i8* %476, null
+  br i1 %NullCheck159, label %ThrowNullRef160, label %477
 
 ; <label>:477                                     ; preds = %474
   %478 = load i8, i8* %476, align 8
   %479 = zext i8 %478 to i32
   %480 = trunc i32 %479 to i8
-  %NullCheck162 = icmp ne i8* %475, null
-  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+  %NullCheck161 = icmp eq i8* %475, null
+  br i1 %NullCheck161, label %ThrowNullRef162, label %481
 
 ; <label>:481                                     ; preds = %477
   store i8 %480, i8* %475, align 8
@@ -1553,343 +1635,343 @@ ThrowNullRef:                                     ; preds = %308
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %312
+ThrowNullRef2:                                    ; preds = %312
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %315
+ThrowNullRef4:                                    ; preds = %315
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %321
+ThrowNullRef6:                                    ; preds = %321
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %271
+ThrowNullRef8:                                    ; preds = %271
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %275
+ThrowNullRef10:                                   ; preds = %275
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %278
+ThrowNullRef12:                                   ; preds = %278
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %284
+ThrowNullRef14:                                   ; preds = %284
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %287
+ThrowNullRef16:                                   ; preds = %287
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %293
+ThrowNullRef18:                                   ; preds = %293
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %298
+ThrowNullRef20:                                   ; preds = %298
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %303
+ThrowNullRef22:                                   ; preds = %303
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %243
+ThrowNullRef24:                                   ; preds = %243
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %247
+ThrowNullRef26:                                   ; preds = %247
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %250
+ThrowNullRef28:                                   ; preds = %250
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %256
+ThrowNullRef30:                                   ; preds = %256
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %259
+ThrowNullRef32:                                   ; preds = %259
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %265
+ThrowNullRef34:                                   ; preds = %265
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %217
+ThrowNullRef36:                                   ; preds = %217
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %221
+ThrowNullRef38:                                   ; preds = %221
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %224
+ThrowNullRef40:                                   ; preds = %224
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %230
+ThrowNullRef42:                                   ; preds = %230
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %233
+ThrowNullRef44:                                   ; preds = %233
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %238
+ThrowNullRef46:                                   ; preds = %238
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %200
+ThrowNullRef48:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %204
+ThrowNullRef50:                                   ; preds = %204
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %207
+ThrowNullRef52:                                   ; preds = %207
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %213
+ThrowNullRef54:                                   ; preds = %213
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %172
+ThrowNullRef56:                                   ; preds = %172
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %176
+ThrowNullRef58:                                   ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %179
+ThrowNullRef60:                                   ; preds = %179
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %185
+ThrowNullRef62:                                   ; preds = %185
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %190
+ThrowNullRef64:                                   ; preds = %190
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %195
+ThrowNullRef66:                                   ; preds = %195
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %153
+ThrowNullRef68:                                   ; preds = %153
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %157
+ThrowNullRef70:                                   ; preds = %157
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %160
+ThrowNullRef72:                                   ; preds = %160
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %166
+ThrowNullRef74:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %136
+ThrowNullRef76:                                   ; preds = %136
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %140
+ThrowNullRef78:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %143
+ThrowNullRef80:                                   ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %148
+ThrowNullRef82:                                   ; preds = %148
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %128
+ThrowNullRef84:                                   ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %132
+ThrowNullRef86:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %100
+ThrowNullRef88:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %104
+ThrowNullRef90:                                   ; preds = %104
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %107
+ThrowNullRef92:                                   ; preds = %107
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %113
+ThrowNullRef94:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %118
+ThrowNullRef96:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %123
+ThrowNullRef98:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %81
+ThrowNullRef100:                                  ; preds = %81
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef101:                                  ; preds = %85
+ThrowNullRef102:                                  ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef103:                                  ; preds = %88
+ThrowNullRef104:                                  ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef105:                                  ; preds = %94
+ThrowNullRef106:                                  ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef107:                                  ; preds = %64
+ThrowNullRef108:                                  ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef109:                                  ; preds = %68
+ThrowNullRef110:                                  ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef111:                                  ; preds = %71
+ThrowNullRef112:                                  ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef113:                                  ; preds = %76
+ThrowNullRef114:                                  ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef115:                                  ; preds = %56
+ThrowNullRef116:                                  ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef117:                                  ; preds = %60
+ThrowNullRef118:                                  ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef119:                                  ; preds = %37
+ThrowNullRef120:                                  ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef121:                                  ; preds = %41
+ThrowNullRef122:                                  ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef123:                                  ; preds = %46
+ThrowNullRef124:                                  ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef125:                                  ; preds = %51
+ThrowNullRef126:                                  ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef127:                                  ; preds = %27
+ThrowNullRef128:                                  ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef129:                                  ; preds = %31
+ThrowNullRef130:                                  ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef131:                                  ; preds = %19
+ThrowNullRef132:                                  ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef133:                                  ; preds = %22
+ThrowNullRef134:                                  ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef135:                                  ; preds = %338
+ThrowNullRef136:                                  ; preds = %338
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef137:                                  ; preds = %341
+ThrowNullRef138:                                  ; preds = %341
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef139:                                  ; preds = %356
+ThrowNullRef140:                                  ; preds = %356
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef141:                                  ; preds = %360
+ThrowNullRef142:                                  ; preds = %360
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef143:                                  ; preds = %377
+ThrowNullRef144:                                  ; preds = %377
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef145:                                  ; preds = %381
+ThrowNullRef146:                                  ; preds = %381
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef147:                                  ; preds = %424
+ThrowNullRef148:                                  ; preds = %424
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef149:                                  ; preds = %428
+ThrowNullRef150:                                  ; preds = %428
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef151:                                  ; preds = %440
+ThrowNullRef152:                                  ; preds = %440
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef153:                                  ; preds = %444
+ThrowNullRef154:                                  ; preds = %444
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef155:                                  ; preds = %456
+ThrowNullRef156:                                  ; preds = %456
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef157:                                  ; preds = %460
+ThrowNullRef158:                                  ; preds = %460
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef159:                                  ; preds = %474
+ThrowNullRef160:                                  ; preds = %474
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef161:                                  ; preds = %477
+ThrowNullRef162:                                  ; preds = %477
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef163:                                  ; preds = %394
+ThrowNullRef164:                                  ; preds = %394
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef165:                                  ; preds = %398
+ThrowNullRef166:                                  ; preds = %398
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef167:                                  ; preds = %401
+ThrowNullRef168:                                  ; preds = %401
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef169:                                  ; preds = %407
+ThrowNullRef170:                                  ; preds = %407
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1939,8 +2021,8 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
-  br i1 %NullCheck, label %22, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %ThrowNullRef, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
@@ -1948,8 +2030,8 @@ entry:
   store i32 %24, i32* %loc0
   %25 = load i32, i32* %loc0
   %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %26, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %27
 
 ; <label>:27                                      ; preds = %22
   %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
@@ -1971,7 +2053,7 @@ ThrowNullRef:                                     ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1989,8 +2071,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -2022,15 +2104,15 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2048,16 +2130,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
   %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
   store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %15
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
@@ -2072,8 +2154,8 @@ entry:
   %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
   %29 = ptrtoint i16 addrspace(1)* %28 to i64
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %19
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
@@ -2089,19 +2171,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2114,8 +2196,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
@@ -2128,7 +2210,7 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[loadElem]
+Failed to read AppDomain.PrepareDataForSetup[storeElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
@@ -2202,8 +2284,8 @@ entry:
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
-  br i1 %NullCheck24, label %27, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = load i64, i64 addrspace(1)* %26
@@ -2218,8 +2300,8 @@ entry:
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
-  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
   %41 = load i64, i64 addrspace(1)* %39
@@ -2236,8 +2318,8 @@ entry:
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
-  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
   %54 = load i64, i64 addrspace(1)* %52
@@ -2252,8 +2334,8 @@ entry:
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
   %67 = load i64, i64 addrspace(1)* %65
@@ -2270,8 +2352,8 @@ entry:
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
-  br i1 %NullCheck16, label %79, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
   %80 = load i64, i64 addrspace(1)* %78
@@ -2286,8 +2368,8 @@ entry:
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
-  br i1 %NullCheck18, label %92, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
   %93 = load i64, i64 addrspace(1)* %91
@@ -2304,8 +2386,8 @@ entry:
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
-  br i1 %NullCheck12, label %105, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = load i64, i64 addrspace(1)* %104
@@ -2320,8 +2402,8 @@ entry:
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
-  br i1 %NullCheck14, label %118, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
   %119 = load i64, i64 addrspace(1)* %117
@@ -2337,8 +2419,8 @@ entry:
 
 ; <label>:128                                     ; preds = %20
   %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
-  br i1 %NullCheck4, label %130, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %129, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %130
 
 ; <label>:130                                     ; preds = %128
   %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
@@ -2346,8 +2428,8 @@ entry:
   %133 = load i16, i16 addrspace(1)* %132, align 8
   %134 = zext i16 %133 to i32
   %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
-  br i1 %NullCheck6, label %136, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %135, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %136
 
 ; <label>:136                                     ; preds = %130
   %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
@@ -2360,8 +2442,8 @@ entry:
 
 ; <label>:143                                     ; preds = %136
   %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
-  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %144, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %145
 
 ; <label>:145                                     ; preds = %143
   %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
@@ -2369,8 +2451,8 @@ entry:
   %148 = load i16, i16 addrspace(1)* %147, align 8
   %149 = zext i16 %148 to i32
   %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %150, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %151
 
 ; <label>:151                                     ; preds = %145
   %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
@@ -2388,8 +2470,8 @@ entry:
 
 ; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
-  br i1 %NullCheck, label %163, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %ThrowNullRef, label %163
 
 ; <label>:163                                     ; preds = %161
   %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
@@ -2399,8 +2481,8 @@ entry:
 
 ; <label>:167                                     ; preds = %163
   %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
-  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %168, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %169
 
 ; <label>:169                                     ; preds = %167
   %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
@@ -2432,55 +2514,55 @@ ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %167
+ThrowNullRef2:                                    ; preds = %167
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %128
+ThrowNullRef4:                                    ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %130
+ThrowNullRef6:                                    ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %143
+ThrowNullRef8:                                    ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %145
+ThrowNullRef10:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %102
+ThrowNullRef12:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %105
+ThrowNullRef14:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %76
+ThrowNullRef16:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %79
+ThrowNullRef18:                                   ; preds = %79
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %50
+ThrowNullRef20:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %53
+ThrowNullRef22:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %24
+ThrowNullRef24:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %27
+ThrowNullRef26:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2503,15 +2585,15 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2519,16 +2601,16 @@ entry:
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
   store i32 %8, i32* %loc0
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
   %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
   store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
@@ -2546,16 +2628,16 @@ entry:
 
 ; <label>:23                                      ; preds = %64
   %24 = load i16*, i16** %loc3
-  %NullCheck12 = icmp ne i16* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i16* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
   store i32 %27, i32* %loc5
   %28 = load i16*, i16** %loc4
-  %NullCheck14 = icmp ne i16* %28, null
-  br i1 %NullCheck14, label %29, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %28, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = load i16, i16* %28, align 8
@@ -2620,15 +2702,15 @@ entry:
 
 ; <label>:67                                      ; preds = %64
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
-  br i1 %NullCheck8, label %69, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %68, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %69
 
 ; <label>:69                                      ; preds = %67
   %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
   %71 = load i32, i32 addrspace(1)* %70
   %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
-  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %73
 
 ; <label>:73                                      ; preds = %69
   %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
@@ -2645,31 +2727,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %67
+ThrowNullRef8:                                    ; preds = %67
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %69
+ThrowNullRef10:                                   ; preds = %69
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2710,14 +2792,14 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
   %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
@@ -2730,14 +2812,14 @@ entry:
 
 ; <label>:11                                      ; preds = %4
   %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
   %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
@@ -2749,14 +2831,14 @@ entry:
 
 ; <label>:22                                      ; preds = %16
   %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
   %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
-  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
-  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
@@ -2804,23 +2886,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2836,7 +2918,280 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[loadElem]
+Successfully read RuntimeType.IsAssignableFrom
+
+define i8 @RuntimeType.IsAssignableFrom(%System.RuntimeType addrspace(1)* %param0, %System.Type addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.RuntimeType addrspace(1)*
+  %arg1 = alloca %System.Type addrspace(1)*
+  %loc0 = alloca %System.RuntimeType addrspace(1)*
+  %loc1 = alloca %"System.Type[]" addrspace(1)*
+  %loc2 = alloca i32
+  store %System.RuntimeType addrspace(1)* %param0, %System.RuntimeType addrspace(1)** %this
+  store %System.Type addrspace(1)* %param1, %System.Type addrspace(1)** %arg1
+  %0 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %1 = icmp ne %System.Type addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i8 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %5 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %6 = bitcast %System.Type addrspace(1)* %4 to %System.Object addrspace(1)*
+  %7 = bitcast %System.RuntimeType addrspace(1)* %5 to %System.Object addrspace(1)*
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %6, %System.Object addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %3
+  ret i8 1
+
+; <label>:12                                      ; preds = %3
+  %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 152
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 32
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
+  %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
+  %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
+  store %System.RuntimeType addrspace(1)* %25, %System.RuntimeType addrspace(1)** %loc0
+  %26 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %27 = icmp eq %System.RuntimeType addrspace(1)* %26, null
+  br i1 %27, label %34, label %28
+
+; <label>:28                                      ; preds = %15
+  %29 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %30 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)*)*)(%System.RuntimeType addrspace(1)* %29, %System.RuntimeType addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+; <label>:34                                      ; preds = %15
+  %35 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %36 = call %System.Reflection.Emit.TypeBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Reflection.Emit.TypeBuilder addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %35)
+  %37 = icmp eq %System.Reflection.Emit.TypeBuilder addrspace(1)* %36, null
+  br i1 %37, label %139, label %38
+
+; <label>:38                                      ; preds = %34
+  %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %42
+
+; <label>:42                                      ; preds = %38
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 152
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 40
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
+  %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
+  %53 = zext i8 %52 to i32
+  %54 = icmp eq i32 %53, 0
+  br i1 %54, label %56, label %55
+
+; <label>:55                                      ; preds = %42
+  ret i8 1
+
+; <label>:56                                      ; preds = %42
+  %57 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %58 = bitcast %System.RuntimeType addrspace(1)* %57 to %System.Type addrspace(1)*
+  %59 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %58)
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %64 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.Type addrspace(1)* %63, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = bitcast %System.RuntimeType addrspace(1)* %64 to %System.Type addrspace(1)*
+  %67 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %63, %System.Type addrspace(1)* %66)
+  %68 = zext i8 %67 to i32
+  %69 = trunc i32 %68 to i8
+  ret i8 %69
+
+; <label>:70                                      ; preds = %56
+  %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
+  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %73
+
+; <label>:73                                      ; preds = %70
+  %74 = load i64, i64 addrspace(1)* %72
+  %75 = add i64 %74, 128
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = add i64 %77, 0
+  %79 = inttoptr i64 %78 to i64*
+  %80 = load i64, i64* %79
+  %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
+  %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
+  %83 = call i8 %82(%System.Type addrspace(1)* %81)
+  %84 = zext i8 %83 to i32
+  %85 = icmp eq i32 %84, 0
+  br i1 %85, label %139, label %86
+
+; <label>:86                                      ; preds = %73
+  %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
+  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %89
+
+; <label>:89                                      ; preds = %86
+  %90 = load i64, i64 addrspace(1)* %88
+  %91 = add i64 %90, 128
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = add i64 %93, 24
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
+  %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
+  %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
+  store %"System.Type[]" addrspace(1)* %99, %"System.Type[]" addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %129
+
+; <label>:100                                     ; preds = %132
+  %101 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %102 = load i32, i32* %loc2
+  %NullCheck11 = icmp eq %"System.Type[]" addrspace(1)* %101, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %103
+
+; <label>:103                                     ; preds = %100
+  %104 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 1
+  %105 = load i32, i32 addrspace(1)* %104
+  %106 = zext i32 %105 to i64
+  %107 = zext i32 %102 to i64
+  %BoundsCheck = icmp uge i64 %107, %106
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %108
+
+; <label>:108                                     ; preds = %103
+  %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
+  %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
+  %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
+  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %113
+
+; <label>:113                                     ; preds = %108
+  %114 = load i64, i64 addrspace(1)* %112
+  %115 = add i64 %114, 152
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = add i64 %117, 56
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
+  %123 = zext i8 %122 to i32
+  %124 = icmp ne i32 %123, 0
+  br i1 %124, label %126, label %125
+
+; <label>:125                                     ; preds = %113
+  ret i8 0
+
+; <label>:126                                     ; preds = %113
+  %127 = load i32, i32* %loc2
+  %128 = add i32 %127, 1
+  store i32 %128, i32* %loc2
+  br label %129
+
+; <label>:129                                     ; preds = %89, %126
+  %130 = load i32, i32* %loc2
+  %131 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %NullCheck9 = icmp eq %"System.Type[]" addrspace(1)* %131, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %132
+
+; <label>:132                                     ; preds = %129
+  %133 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %131, i32 0, i32 1
+  %134 = load i32, i32 addrspace(1)* %133
+  %135 = zext i32 %134 to i64
+  %136 = trunc i64 %135 to i32
+  %137 = icmp slt i32 %130, %136
+  br i1 %137, label %100, label %138
+
+; <label>:138                                     ; preds = %132
+  ret i8 1
+
+; <label>:139                                     ; preds = %34, %73
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %129
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %103
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -2893,7 +3248,7 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElem]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -2904,8 +3259,8 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -2997,8 +3352,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
@@ -3059,8 +3414,8 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -3087,8 +3442,8 @@ entry:
 
 ; <label>:17                                      ; preds = %5, %11
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
@@ -3097,8 +3452,8 @@ entry:
 
 ; <label>:22                                      ; preds = %1, %11
   %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
@@ -3109,11 +3464,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %17
+ThrowNullRef2:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %22
+ThrowNullRef4:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3167,15 +3522,15 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
   %15 = load i32, i32 addrspace(1)* %14
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
@@ -3198,7 +3553,7 @@ ThrowNullRef:                                     ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef2:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3232,8 +3587,8 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
@@ -3312,8 +3667,8 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -3327,8 +3682,8 @@ entry:
 ; <label>:5                                       ; preds = %43
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %7 = load i32, i32* %loc1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck6, label %8, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
@@ -3366,8 +3721,8 @@ entry:
 ; <label>:32                                      ; preds = %21, %25
   %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
   %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
-  br i1 %NullCheck8, label %35, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = trunc i32 %34 to i16
@@ -3380,8 +3735,8 @@ entry:
 ; <label>:40                                      ; preds = %1, %35
   %41 = load i32, i32* %loc1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
-  br i1 %NullCheck2, label %43, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %42, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
@@ -3392,8 +3747,8 @@ entry:
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
   %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
-  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
   %51 = load i64, i64 addrspace(1)* %49
@@ -3412,19 +3767,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %40
+ThrowNullRef2:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %47
+ThrowNullRef4:                                    ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %5
+ThrowNullRef6:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %32
+ThrowNullRef8:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3467,8 +3822,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
@@ -3492,11 +3847,391 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(i16* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store i16* %param0, i16** %arg0
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load i32, i32* %arg3
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %42, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %37, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg2
+  %13 = load i32, i32* %arg3
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %37, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %24 = load i32, i32* %arg2
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load i16*, i16** %arg0
+  %35 = load i32, i32* %arg3
+  %36 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %36, i16* %34, i32 %35)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:37                                      ; preds = %5, %16
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %39)
+  %41 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41, %System.String addrspace(1)* %38, %System.String addrspace(1)* %40)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41) #0
+  unreachable
+
+; <label>:42                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
-Failed to read StringBuilder.ToString[loadElemA]
+Successfully read StringBuilder.ToString
+
+define %System.String addrspace(1)* @StringBuilder.ToString(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i16*
+  %loc3 = alloca %"System.Char[]" addrspace(1)*
+  %loc4 = alloca i32
+  %loc5 = alloca i32
+  %loc6 = alloca i16 addrspace(1)*
+  %loc7 = alloca %System.String addrspace(1)*
+  %loc8 = alloca %"System.Char[]" addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %0)
+  %2 = icmp ne i32 %1, 0
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %4
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %6)
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %7)
+  store %System.String addrspace(1)* %8, %System.String addrspace(1)** %loc0
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.Text.StringBuilder addrspace(1)* %9, %System.Text.StringBuilder addrspace(1)** %loc1
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  store %System.String addrspace(1)* %10, %System.String addrspace(1)** %loc7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc7
+  %12 = ptrtoint %System.String addrspace(1)* %11 to i64
+  %13 = icmp eq i64 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %5
+  %15 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %16 = sext i32 %15 to i64
+  %17 = add i64 %12, %16
+  br label %18
+
+; <label>:18                                      ; preds = %5, %14
+  %19 = phi i64 [ %12, %5 ], [ %17, %14 ]
+  %20 = inttoptr i64 %19 to i16*
+  store i16* %20, i16** %loc2
+  br label %21
+
+; <label>:21                                      ; preds = %98, %18
+  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %22, null
+  br i1 %NullCheck, label %ThrowNullRef, label %23
+
+; <label>:23                                      ; preds = %21
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 3
+  %25 = load i32, i32 addrspace(1)* %24, align 8
+  %26 = icmp sle i32 %25, 0
+  br i1 %26, label %96, label %27
+
+; <label>:27                                      ; preds = %23
+  %28 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %28, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %29
+
+; <label>:29                                      ; preds = %27
+  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %28, i32 0, i32 1
+  %31 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %30, align 8
+  store %"System.Char[]" addrspace(1)* %31, %"System.Char[]" addrspace(1)** %loc3
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %33
+
+; <label>:33                                      ; preds = %29
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  store i32 %35, i32* %loc4
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  %39 = load i32, i32 addrspace(1)* %38, align 8
+  store i32 %39, i32* %loc5
+  %40 = load i32, i32* %loc5
+  %41 = load i32, i32* %loc4
+  %42 = add i32 %40, %41
+  %43 = zext i32 %42 to i64
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %45
+
+; <label>:45                                      ; preds = %37
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = sext i32 %47 to i64
+  %49 = icmp sgt i64 %43, %48
+  br i1 %49, label %91, label %50
+
+; <label>:50                                      ; preds = %45
+  %51 = load i32, i32* %loc5
+  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %52, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %53
+
+; <label>:53                                      ; preds = %50
+  %54 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %52, i32 0, i32 1
+  %55 = load i32, i32 addrspace(1)* %54
+  %56 = zext i32 %55 to i64
+  %57 = trunc i64 %56 to i32
+  %58 = icmp ugt i32 %51, %57
+  br i1 %58, label %91, label %59
+
+; <label>:59                                      ; preds = %53
+  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  store %"System.Char[]" addrspace(1)* %60, %"System.Char[]" addrspace(1)** %loc8
+  %61 = icmp eq %"System.Char[]" addrspace(1)* %60, null
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %63, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %64
+
+; <label>:64                                      ; preds = %62
+  %65 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %63, i32 0, i32 1
+  %66 = load i32, i32 addrspace(1)* %65
+  %67 = zext i32 %66 to i64
+  %68 = trunc i64 %67 to i32
+  %69 = icmp ne i32 %68, 0
+  br i1 %69, label %71, label %70
+
+; <label>:70                                      ; preds = %59, %64
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:71                                      ; preds = %64
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %73
+
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %BoundsCheck = icmp uge i64 0, %76
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %77
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %78, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:79                                      ; preds = %70, %77
+  %80 = load i16*, i16** %loc2
+  %81 = load i32, i32* %loc4
+  %82 = sext i32 %81 to i64
+  %83 = mul i64 %82, 2
+  %84 = bitcast i16* %80 to i8*
+  %85 = getelementptr inbounds i8, i8* %84, i64 %83
+  %86 = load i16 addrspace(1)*, i16 addrspace(1)** %loc6
+  %87 = ptrtoint i16 addrspace(1)* %86 to i64
+  %88 = load i32, i32* %loc5
+  %89 = bitcast i8* %85 to i16*
+  %90 = inttoptr i64 %87 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %89, i16* %90, i32 %88)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %96
+
+; <label>:91                                      ; preds = %45, %53
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %94 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %93)
+  %95 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95, %System.String addrspace(1)* %92, %System.String addrspace(1)* %94)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95) #0
+  unreachable
+
+; <label>:96                                      ; preds = %23, %79
+  %97 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %97, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %98
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %97, i32 0, i32 2
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  store %System.Text.StringBuilder addrspace(1)* %100, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %102 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %102, label %21, label %103
+
+; <label>:103                                     ; preds = %98
+  store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc7
+  %104 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  ret %System.String addrspace(1)* %104
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method StringBuilder::get_Length using LLILCJit
+Successfully read StringBuilder.get_Length
+
+define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
+Successfully read RuntimeHelpers.get_OffsetToStringData
+
+define i32 @RuntimeHelpers.get_OffsetToStringData() {
+entry:
+  ret i32 12
+}
+
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
 Successfully read CultureData.CreateCultureData
 
@@ -3514,23 +4249,23 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
   store i8 %4, i8 addrspace(1)* %6
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
@@ -3549,11 +4284,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3566,50 +4301,50 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
   store i32 -1, i32 addrspace(1)* %2
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
   store i32 -1, i32 addrspace(1)* %8
   %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
   store i32 -1, i32 addrspace(1)* %14
   %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
   store i32 -1, i32 addrspace(1)* %17
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
@@ -3623,27 +4358,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3675,7 +4410,136 @@ Failed to read Dictionary`2.Insert[non-const derefAddress]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
 Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
-Failed to read HashHelpers.GetPrime[loadElem]
+Successfully read HashHelpers.GetPrime
+
+define i32 @HashHelpers.GetPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %6, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5, %System.String addrspace(1)* %4)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5) #0
+  unreachable
+
+; <label>:6                                       ; preds = %entry
+  store i32 0, i32* %loc0
+  br label %29
+
+; <label>:7                                       ; preds = %35
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 1296
+  %10 = addrspacecast i8 addrspace(1)* %9 to %"System.Int32[]" addrspace(1)**
+  %11 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %10
+  %12 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Int32[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = zext i32 %15 to i64
+  %17 = zext i32 %12 to i64
+  %BoundsCheck = icmp uge i64 %17, %16
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 3, i32 %12
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  store i32 %20, i32* %loc1
+  %21 = load i32, i32* %loc1
+  %22 = load i32, i32* %arg0
+  %23 = icmp slt i32 %21, %22
+  br i1 %23, label %26, label %24
+
+; <label>:24                                      ; preds = %18
+  %25 = load i32, i32* %loc1
+  ret i32 %25
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %loc0
+  %28 = add i32 %27, 1
+  store i32 %28, i32* %loc0
+  br label %29
+
+; <label>:29                                      ; preds = %6, %26
+  %30 = load i32, i32* %loc0
+  %31 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %32 = getelementptr inbounds i8, i8 addrspace(1)* %31, i64 1296
+  %33 = addrspacecast i8 addrspace(1)* %32 to %"System.Int32[]" addrspace(1)**
+  %34 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %33
+  %NullCheck = icmp eq %"System.Int32[]" addrspace(1)* %34, null
+  br i1 %NullCheck, label %ThrowNullRef, label %35
+
+; <label>:35                                      ; preds = %29
+  %36 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %34, i32 0, i32 1
+  %37 = load i32, i32 addrspace(1)* %36
+  %38 = zext i32 %37 to i64
+  %39 = trunc i64 %38 to i32
+  %40 = icmp slt i32 %30, %39
+  br i1 %40, label %7, label %41
+
+; <label>:41                                      ; preds = %35
+  %42 = load i32, i32* %arg0
+  %43 = or i32 %42, 1
+  store i32 %43, i32* %loc2
+  br label %59
+
+; <label>:44                                      ; preds = %59
+  %45 = load i32, i32* %loc2
+  %46 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %45)
+  %47 = zext i8 %46 to i32
+  %48 = icmp eq i32 %47, 0
+  br i1 %48, label %56, label %49
+
+; <label>:49                                      ; preds = %44
+  %50 = load i32, i32* %loc2
+  %51 = sub i32 %50, 1
+  %52 = srem i32 %51, 101
+  %53 = icmp eq i32 %52, 0
+  br i1 %53, label %56, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = load i32, i32* %loc2
+  ret i32 %55
+
+; <label>:56                                      ; preds = %44, %49
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %57, 2
+  store i32 %58, i32* %loc2
+  br label %59
+
+; <label>:59                                      ; preds = %41, %56
+  %60 = load i32, i32* %loc2
+  %61 = icmp slt i32 %60, 2147483647
+  br i1 %61, label %44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load i32, i32* %arg0
+  ret i32 %63
+
+ThrowNullRef:                                     ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
 Successfully read GenericEqualityComparer`1.GetHashCode
 
@@ -3694,14 +4558,14 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
   %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load i64, i64 addrspace(1)* %7
@@ -3720,7 +4584,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3750,8 +4614,8 @@ entry:
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
@@ -3796,8 +4660,8 @@ entry:
   %35 = bitcast i16* %34 to i8*
   %36 = getelementptr inbounds i8, i8* %35, i64 2
   %37 = bitcast i8* %36 to i16*
-  %NullCheck4 = icmp ne i16* %37, null
-  br i1 %NullCheck4, label %38, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %37, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %38
 
 ; <label>:38                                      ; preds = %27
   %39 = load i16, i16* %37, align 8
@@ -3824,8 +4688,8 @@ entry:
 
 ; <label>:54                                      ; preds = %22, %43
   %55 = load i16*, i16** %loc4
-  %NullCheck2 = icmp ne i16* %55, null
-  br i1 %NullCheck2, label %56, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i16* %55, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %56
 
 ; <label>:56                                      ; preds = %54
   %57 = load i16, i16* %55, align 8
@@ -3850,11 +4714,11 @@ ThrowNullRef:                                     ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %54
+ThrowNullRef2:                                    ; preds = %54
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %27
+ThrowNullRef4:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3871,8 +4735,8 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -3907,8 +4771,8 @@ entry:
 
 ; <label>:26                                      ; preds = %19
   %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
-  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %28
 
 ; <label>:28                                      ; preds = %26
   %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
@@ -3920,7 +4784,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3972,8 +4836,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
@@ -3984,26 +4848,26 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
-  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
@@ -4014,8 +4878,8 @@ entry:
 ; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
@@ -4024,8 +4888,8 @@ entry:
 
 ; <label>:25                                      ; preds = %1, %16, %23
   %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
-  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
@@ -4036,27 +4900,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %20
+ThrowNullRef10:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4069,8 +4933,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -4081,8 +4945,8 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
@@ -4091,8 +4955,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1, %8
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
@@ -4103,11 +4967,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4128,24 +4992,24 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   store i32 %3, i32* %loc0
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
   %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
   store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck4, label %9, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
@@ -4164,15 +5028,15 @@ entry:
 ; <label>:18                                      ; preds = %70
   %19 = load i16*, i16** %loc3
   %20 = bitcast i16* %19 to i64*
-  %NullCheck10 = icmp ne i64* %20, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %20, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = load i64, i64* %20, align 8
   %23 = load i16*, i16** %loc4
   %24 = bitcast i16* %23 to i64*
-  %NullCheck12 = icmp ne i64* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = load i64, i64* %24, align 8
@@ -4188,8 +5052,8 @@ entry:
   %31 = bitcast i16* %30 to i8*
   %32 = getelementptr inbounds i8, i8* %31, i64 8
   %33 = bitcast i8* %32 to i64*
-  %NullCheck14 = icmp ne i64* %33, null
-  br i1 %NullCheck14, label %34, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = load i64, i64* %33, align 8
@@ -4197,8 +5061,8 @@ entry:
   %37 = bitcast i16* %36 to i8*
   %38 = getelementptr inbounds i8, i8* %37, i64 8
   %39 = bitcast i8* %38 to i64*
-  %NullCheck16 = icmp ne i64* %39, null
-  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %40
 
 ; <label>:40                                      ; preds = %34
   %41 = load i64, i64* %39, align 8
@@ -4214,8 +5078,8 @@ entry:
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %NullCheck18 = icmp ne i64* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = load i64, i64* %48, align 8
@@ -4223,8 +5087,8 @@ entry:
   %52 = bitcast i16* %51 to i8*
   %53 = getelementptr inbounds i8, i8* %52, i64 16
   %54 = bitcast i8* %53 to i64*
-  %NullCheck20 = icmp ne i64* %54, null
-  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64* %54, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %55
 
 ; <label>:55                                      ; preds = %49
   %56 = load i64, i64* %54, align 8
@@ -4262,15 +5126,15 @@ entry:
 ; <label>:74                                      ; preds = %95
   %75 = load i16*, i16** %loc3
   %76 = bitcast i16* %75 to i32*
-  %NullCheck6 = icmp ne i32* %76, null
-  br i1 %NullCheck6, label %77, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32* %76, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %77
 
 ; <label>:77                                      ; preds = %74
   %78 = load i32, i32* %76, align 8
   %79 = load i16*, i16** %loc4
   %80 = bitcast i16* %79 to i32*
-  %NullCheck8 = icmp ne i32* %80, null
-  br i1 %NullCheck8, label %81, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i32* %80, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %81
 
 ; <label>:81                                      ; preds = %77
   %82 = load i32, i32* %80, align 8
@@ -4318,43 +5182,43 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %74
+ThrowNullRef6:                                    ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %77
+ThrowNullRef8:                                    ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %29
+ThrowNullRef14:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %34
+ThrowNullRef16:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4376,8 +5240,8 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load i64, i64 addrspace(1)* %4
@@ -4389,8 +5253,8 @@ entry:
   %12 = load i64, i64* %11
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %5
   %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
@@ -4399,8 +5263,8 @@ entry:
   %18 = load i8, i8* %arg2
   %19 = zext i8 %18 to i32
   %20 = trunc i32 %19 to i8
-  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %15
   %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
@@ -4411,11 +5275,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4442,8 +5306,8 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
@@ -4466,16 +5330,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
   %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = load i64, i64 addrspace(1)* %19
@@ -4500,8 +5364,8 @@ entry:
 ; <label>:35                                      ; preds = %30
   %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
@@ -4514,8 +5378,8 @@ entry:
 
 ; <label>:42                                      ; preds = %1, %38
   %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
-  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
@@ -4526,19 +5390,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %35
+ThrowNullRef2:                                    ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %42
+ThrowNullRef8:                                    ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4551,14 +5415,14 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
@@ -4570,7 +5434,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4583,8 +5447,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
@@ -4613,51 +5477,51 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
   %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
   %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
   %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
   %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
-  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
   store i64 %21, i64 addrspace(1)* %23
   %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %25 = load i64, i64* %loc0
-  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
@@ -4668,27 +5532,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %22
+ThrowNullRef12:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4701,8 +5565,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
@@ -4713,19 +5577,19 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
@@ -4734,8 +5598,8 @@ entry:
 
 ; <label>:15                                      ; preds = %1, %13
   %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
@@ -4746,19 +5610,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %15
+ThrowNullRef8:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4771,8 +5635,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -4831,8 +5695,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
@@ -4882,8 +5746,8 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
-  br i1 %NullCheck, label %17, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %ThrowNullRef, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
@@ -4894,15 +5758,15 @@ entry:
 
 ; <label>:22                                      ; preds = %17
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
-  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
   %26 = load i32, i32 addrspace(1)* %25
   %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
-  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %27, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
@@ -4925,8 +5789,8 @@ entry:
 ; <label>:40                                      ; preds = %17
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
-  br i1 %NullCheck6, label %43, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %41, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
@@ -4938,34 +5802,17 @@ ThrowNullRef:                                     ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %24
+ThrowNullRef4:                                    ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %40
+ThrowNullRef6:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
-}
-
-INFO:  jitting method Object::ReferenceEquals using LLILCJit
-Successfully read Object.ReferenceEquals
-
-define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
-entry:
-  %arg0 = alloca %System.Object addrspace(1)*
-  %arg1 = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
-  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
-  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = icmp eq %System.Object addrspace(1)* %0, %1
-  %3 = sext i1 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
 }
 
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
@@ -4978,21 +5825,21 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
   %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
-  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
@@ -5007,28 +5854,28 @@ entry:
 ; <label>:13                                      ; preds = %8, %12
   %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
   %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
   %21 = load i32, i32 addrspace(1)* %20, align 8
   %22 = add i32 %21, 1
-  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
   store i32 %22, i32 addrspace(1)* %24
   %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
@@ -5039,27 +5886,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5077,7 +5924,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::Setup using LLILCJit
-Failed to read AppDomain.Setup[loadElem]
+Failed to read AppDomain.Setup[unbox]
 INFO:  jitting method Thread::GetDomain using LLILCJit
 Successfully read Thread.GetDomain
 
@@ -5108,8 +5955,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
@@ -5122,14 +5969,14 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
   %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
@@ -5141,11 +5988,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5173,8 +6020,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -5189,7 +6036,328 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
 Failed to read KeyCollection.System.Collections.Generic.IEnumerable<TKey>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Successfully read Enumerator.MoveNext
+
+define i8 @Enumerator.MoveNext(%"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.RuntimeTypeHandle* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*
+  %"$TypeArg" = alloca %System.RuntimeTypeHandle*
+  store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
+  %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 8
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %76, label %12
+
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
+  br label %76
+
+; <label>:13                                      ; preds = %85
+  %14 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck19 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %15
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, i32 0, i32 0
+  %17 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %16, align 8
+  %NullCheck21 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, i32 0, i32 2
+  %20 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %19, align 8
+  %21 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck23 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %22
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, i32 0, i32 2
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %NullCheck25 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 3, i32 %24
+  %NullCheck27 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %32
+
+; <label>:32                                      ; preds = %30
+  %33 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, i32 0, i32 2
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = icmp slt i32 %34, 0
+  br i1 %35, label %68, label %36
+
+; <label>:36                                      ; preds = %32
+  %37 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %38 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck29 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %39
+
+; <label>:39                                      ; preds = %36
+  %40 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, i32 0, i32 0
+  %41 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %40, align 8
+  %NullCheck31 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, i32 0, i32 2
+  %44 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %43, align 8
+  %45 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck33 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, i32 0, i32 2
+  %48 = load i32, i32 addrspace(1)* %47, align 8
+  %NullCheck35 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %49
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = zext i32 %51 to i64
+  %53 = zext i32 %48 to i64
+  %BoundsCheck37 = icmp uge i64 %53, %52
+  br i1 %BoundsCheck37, label %ThrowIndexOutOfRange38, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 3, i32 %48
+  %NullCheck39 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %56
+
+; <label>:56                                      ; preds = %54
+  %57 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, i32 0, i32 0
+  %58 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck41 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %59
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %60, %System.__Canon addrspace(1)* %58)
+  %61 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck43 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  %64 = load i32, i32 addrspace(1)* %63, align 8
+  %65 = add i32 %64, 1
+  %NullCheck45 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  store i32 %65, i32 addrspace(1)* %67
+  ret i8 1
+
+; <label>:68                                      ; preds = %32
+  %69 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck47 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %73 = add i32 %72, 1
+  %NullCheck49 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %74
+
+; <label>:74                                      ; preds = %70
+  %75 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  store i32 %73, i32 addrspace(1)* %75
+  br label %76
+
+; <label>:76                                      ; preds = %8, %12, %74
+  %77 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %78
+
+; <label>:78                                      ; preds = %76
+  %79 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, i32 0, i32 2
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck7 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %82
+
+; <label>:82                                      ; preds = %78
+  %83 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, i32 0, i32 0
+  %84 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %83, align 8
+  %NullCheck9 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %85
+
+; <label>:85                                      ; preds = %82
+  %86 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, i32 0, i32 7
+  %87 = load i32, i32 addrspace(1)* %86, align 8
+  %88 = icmp ult i32 %80, %87
+  br i1 %88, label %13, label %89
+
+; <label>:89                                      ; preds = %85
+  %90 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %91 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck11 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %92
+
+; <label>:92                                      ; preds = %89
+  %93 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, i32 0, i32 0
+  %94 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck13 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %95
+
+; <label>:95                                      ; preds = %92
+  %96 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, i32 0, i32 7
+  %97 = load i32, i32 addrspace(1)* %96, align 8
+  %98 = add i32 %97, 1
+  %NullCheck15 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %99
+
+; <label>:99                                      ; preds = %95
+  %100 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, i32 0, i32 2
+  store i32 %98, i32 addrspace(1)* %100
+  %101 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck17 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %102
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %103, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %92
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef22:                                   ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef24:                                   ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef26:                                   ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef28:                                   ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef30:                                   ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef32:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef34:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef36:                                   ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange38:                           ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef40:                                   ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef42:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef44:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef46:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef48:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef50:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -5200,8 +6368,8 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -5232,9 +6400,9 @@ Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
 Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
-Failed to read String.MakeSeparatorList[loadElemA]
+Failed to read String.MakeSeparatorList[storeElem]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
-Failed to read String.InternalSplitKeepEmptyEntries[loadElem]
+Failed to read String.InternalSplitKeepEmptyEntries[storeElem]
 INFO:  jitting method Path::IsRelative using LLILCJit
 Successfully read Path.IsRelative
 
@@ -5243,8 +6411,8 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -5254,8 +6422,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
@@ -5271,8 +6439,8 @@ entry:
 
 ; <label>:17                                      ; preds = %7
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
@@ -5288,8 +6456,8 @@ entry:
 
 ; <label>:29                                      ; preds = %19
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %31
 
 ; <label>:31                                      ; preds = %29
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
@@ -5300,8 +6468,8 @@ entry:
 
 ; <label>:36                                      ; preds = %31
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
-  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %37, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
@@ -5312,8 +6480,8 @@ entry:
 
 ; <label>:43                                      ; preds = %31, %38
   %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
-  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %45
 
 ; <label>:45                                      ; preds = %43
   %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
@@ -5324,8 +6492,8 @@ entry:
 
 ; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %50
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
@@ -5336,8 +6504,8 @@ entry:
 
 ; <label>:57                                      ; preds = %1, %7, %19, %45, %52
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
-  br i1 %NullCheck14, label %59, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %59
 
 ; <label>:59                                      ; preds = %57
   %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
@@ -5347,8 +6515,8 @@ entry:
 
 ; <label>:63                                      ; preds = %59
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
@@ -5359,8 +6527,8 @@ entry:
 
 ; <label>:70                                      ; preds = %65
   %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
-  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.String addrspace(1)* %71, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %72
 
 ; <label>:72                                      ; preds = %70
   %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
@@ -5379,39 +6547,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %17
+ThrowNullRef4:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %29
+ThrowNullRef6:                                    ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %36
+ThrowNullRef8:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %43
+ThrowNullRef10:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %50
+ThrowNullRef12:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %57
+ThrowNullRef14:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %63
+ThrowNullRef16:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %70
+ThrowNullRef18:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5419,7 +6587,293 @@ ThrowNullRef17:                                   ; preds = %70
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
-Failed to read String.TrimHelper[loadElem]
+Successfully read String.TrimHelper
+
+define %System.String addrspace(1)* @String.TrimHelper(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i16
+  %loc4 = alloca i32
+  %loc5 = alloca i16
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = sub i32 %3, 1
+  store i32 %4, i32* %loc0
+  store i32 0, i32* %loc1
+  %5 = load i32, i32* %arg2
+  %6 = icmp eq i32 %5, 1
+  br i1 %6, label %62, label %7
+
+; <label>:7                                       ; preds = %1
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:8                                       ; preds = %58
+  store i32 0, i32* %loc2
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load i32, i32* %loc1
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2, i32 %10
+  %13 = load i16, i16 addrspace(1)* %12
+  %14 = zext i16 %13 to i32
+  %15 = trunc i32 %14 to i16
+  store i16 %15, i16* %loc3
+  store i32 0, i32* %loc2
+  br label %34
+
+; <label>:16                                      ; preds = %37
+  %17 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %18 = load i32, i32* %loc2
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %17, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %19
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = zext i32 %18 to i64
+  %BoundsCheck = icmp uge i64 %23, %22
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %24
+
+; <label>:24                                      ; preds = %19
+  %25 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 3, i32 %18
+  %26 = load i16, i16 addrspace(1)* %25, align 8
+  %27 = zext i16 %26 to i32
+  %28 = load i16, i16* %loc3
+  %29 = zext i16 %28 to i32
+  %30 = icmp eq i32 %27, %29
+  br i1 %30, label %43, label %31
+
+; <label>:31                                      ; preds = %24
+  %32 = load i32, i32* %loc2
+  %33 = add i32 %32, 1
+  store i32 %33, i32* %loc2
+  br label %34
+
+; <label>:34                                      ; preds = %11, %31
+  %35 = load i32, i32* %loc2
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = icmp slt i32 %35, %41
+  br i1 %42, label %16, label %43
+
+; <label>:43                                      ; preds = %24, %37
+  %44 = load i32, i32* %loc2
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %45, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp eq i32 %44, %50
+  br i1 %51, label %62, label %52
+
+; <label>:52                                      ; preds = %46
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %7, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %57, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %58
+
+; <label>:58                                      ; preds = %55
+  %59 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %60 = load i32, i32 addrspace(1)* %59
+  %61 = icmp slt i32 %56, %60
+  br i1 %61, label %8, label %62
+
+; <label>:62                                      ; preds = %1, %46, %58
+  %63 = load i32, i32* %arg2
+  %64 = icmp eq i32 %63, 0
+  br i1 %64, label %122, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %66, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %67
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %66, i32 0, i32 1
+  %69 = load i32, i32 addrspace(1)* %68
+  %70 = sub i32 %69, 1
+  store i32 %70, i32* %loc0
+  br label %118
+
+; <label>:71                                      ; preds = %118
+  store i32 0, i32* %loc4
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %73 = load i32, i32* %loc0
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %74
+
+; <label>:74                                      ; preds = %71
+  %75 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 2, i32 %73
+  %76 = load i16, i16 addrspace(1)* %75
+  %77 = zext i16 %76 to i32
+  %78 = trunc i32 %77 to i16
+  store i16 %78, i16* %loc5
+  store i32 0, i32* %loc4
+  br label %97
+
+; <label>:79                                      ; preds = %100
+  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %81 = load i32, i32* %loc4
+  %NullCheck19 = icmp eq %"System.Char[]" addrspace(1)* %80, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
+
+; <label>:82                                      ; preds = %79
+  %83 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 1
+  %84 = load i32, i32 addrspace(1)* %83
+  %85 = zext i32 %84 to i64
+  %86 = zext i32 %81 to i64
+  %BoundsCheck21 = icmp uge i64 %86, %85
+  br i1 %BoundsCheck21, label %ThrowIndexOutOfRange22, label %87
+
+; <label>:87                                      ; preds = %82
+  %88 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 3, i32 %81
+  %89 = load i16, i16 addrspace(1)* %88, align 8
+  %90 = zext i16 %89 to i32
+  %91 = load i16, i16* %loc5
+  %92 = zext i16 %91 to i32
+  %93 = icmp eq i32 %90, %92
+  br i1 %93, label %106, label %94
+
+; <label>:94                                      ; preds = %87
+  %95 = load i32, i32* %loc4
+  %96 = add i32 %95, 1
+  store i32 %96, i32* %loc4
+  br label %97
+
+; <label>:97                                      ; preds = %74, %94
+  %98 = load i32, i32* %loc4
+  %99 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck15 = icmp eq %"System.Char[]" addrspace(1)* %99, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %100
+
+; <label>:100                                     ; preds = %97
+  %101 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %99, i32 0, i32 1
+  %102 = load i32, i32 addrspace(1)* %101
+  %103 = zext i32 %102 to i64
+  %104 = trunc i64 %103 to i32
+  %105 = icmp slt i32 %98, %104
+  br i1 %105, label %79, label %106
+
+; <label>:106                                     ; preds = %87, %100
+  %107 = load i32, i32* %loc4
+  %108 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck17 = icmp eq %"System.Char[]" addrspace(1)* %108, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %109
+
+; <label>:109                                     ; preds = %106
+  %110 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %108, i32 0, i32 1
+  %111 = load i32, i32 addrspace(1)* %110
+  %112 = zext i32 %111 to i64
+  %113 = trunc i64 %112 to i32
+  %114 = icmp eq i32 %107, %113
+  br i1 %114, label %122, label %115
+
+; <label>:115                                     ; preds = %109
+  %116 = load i32, i32* %loc0
+  %117 = sub i32 %116, 1
+  store i32 %117, i32* %loc0
+  br label %118
+
+; <label>:118                                     ; preds = %67, %115
+  %119 = load i32, i32* %loc0
+  %120 = load i32, i32* %loc1
+  %121 = icmp sge i32 %119, %120
+  br i1 %121, label %71, label %122
+
+; <label>:122                                     ; preds = %62, %109, %118
+  %123 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %124 = load i32, i32* %loc1
+  %125 = load i32, i32* %loc0
+  %126 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %123, i32 %124, i32 %125)
+  ret %System.String addrspace(1)* %126
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %97
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange22:                           ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
 Successfully read String.CreateTrimmedString
 
@@ -5439,8 +6893,8 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
@@ -5535,8 +6989,8 @@ entry:
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i64 2872
   %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
   %8 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %7
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %3
   %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
@@ -5553,8 +7007,8 @@ entry:
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 2864
   %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
   %21 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %20
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
-  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %22
 
 ; <label>:22                                      ; preds = %16
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
@@ -5569,7 +7023,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %16
+ThrowNullRef2:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5586,8 +7040,8 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5613,8 +7067,8 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
@@ -5632,8 +7086,8 @@ entry:
 
 ; <label>:12                                      ; preds = %4
   %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
@@ -5644,8 +7098,8 @@ entry:
 
 ; <label>:19                                      ; preds = %14
   %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %19
   %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
@@ -5660,21 +7114,21 @@ entry:
   %31 = zext i16 %30 to i32
   %32 = bitcast i8* %29 to i16*
   %33 = trunc i32 %31 to i16
-  %NullCheck6 = icmp ne i16* %32, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i16* %32, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %21
   store i16 %33, i16* %32, align 8
   %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %36
 
 ; <label>:36                                      ; preds = %34
   %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
   %38 = load i32, i32 addrspace(1)* %37, align 8
   %39 = add i32 %38, 1
-  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %40
 
 ; <label>:40                                      ; preds = %36
   %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
@@ -5683,16 +7137,16 @@ entry:
 
 ; <label>:42                                      ; preds = %14
   %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
-  br i1 %NullCheck12, label %44, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
   %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
   %47 = load i16, i16* %arg1
   %48 = zext i16 %47 to i32
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = trunc i32 %48 to i16
@@ -5703,31 +7157,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %19
+ThrowNullRef4:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %21
+ThrowNullRef6:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %36
+ThrowNullRef10:                                   ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %42
+ThrowNullRef12:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %44
+ThrowNullRef14:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5740,8 +7194,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -5752,8 +7206,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
@@ -5762,14 +7216,14 @@ entry:
 
 ; <label>:11                                      ; preds = %1
   %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
@@ -5779,15 +7233,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5808,8 +7262,8 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5822,8 +7276,8 @@ entry:
 
 ; <label>:8                                       ; preds = %3
   %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
@@ -5842,15 +7296,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
-  br i1 %NullCheck4, label %22, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
   %24 = load i16*, i16* addrspace(1)* %23, align 8
   %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %25, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
@@ -5859,8 +7313,8 @@ entry:
   store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
@@ -5874,8 +7328,8 @@ entry:
 
 ; <label>:37                                      ; preds = %65
   %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %37
   %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
@@ -5886,16 +7340,16 @@ entry:
   %45 = bitcast i16* %41 to i8*
   %46 = getelementptr inbounds i8, i8* %45, i64 %44
   %47 = bitcast i8* %46 to i16*
-  %NullCheck14 = icmp ne i16* %47, null
-  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %47, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %48
 
 ; <label>:48                                      ; preds = %39
   %49 = load i16, i16* %47, align 8
   %50 = zext i16 %49 to i32
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %52 = load i32, i32* %loc1
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %53
 
 ; <label>:53                                      ; preds = %48
   %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
@@ -5916,8 +7370,8 @@ entry:
 ; <label>:62                                      ; preds = %36, %59
   %63 = load i32, i32* %loc1
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck10, label %65, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %65
 
 ; <label>:65                                      ; preds = %62
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
@@ -5936,15 +7390,15 @@ entry:
 
 ; <label>:74                                      ; preds = %70
   %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
-  br i1 %NullCheck18, label %76, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %76
 
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
   %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
-  br i1 %NullCheck20, label %80, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
   %81 = load i64, i64 addrspace(1)* %79
@@ -5958,8 +7412,8 @@ entry:
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
   %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
-  br i1 %NullCheck22, label %92, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.String addrspace(1)* %90, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %92
 
 ; <label>:92                                      ; preds = %80
   %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
@@ -5969,15 +7423,15 @@ entry:
 
 ; <label>:96                                      ; preds = %70
   %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
-  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %98
 
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
   %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
-  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
   %103 = load i64, i64 addrspace(1)* %101
@@ -5991,8 +7445,8 @@ entry:
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
   %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
-  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.String addrspace(1)* %112, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %114
 
 ; <label>:114                                     ; preds = %102
   %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
@@ -6004,59 +7458,59 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %20
+ThrowNullRef4:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %22
+ThrowNullRef6:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %26
+ThrowNullRef8:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %62
+ThrowNullRef10:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %48
+ThrowNullRef16:                                   ; preds = %48
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %74
+ThrowNullRef18:                                   ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %76
+ThrowNullRef20:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %80
+ThrowNullRef22:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %96
+ThrowNullRef24:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %98
+ThrowNullRef26:                                   ; preds = %98
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %102
+ThrowNullRef28:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6069,15 +7523,15 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
   %3 = load i16*, i16* addrspace(1)* %2, align 8
   %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
@@ -6087,8 +7541,8 @@ entry:
   %10 = bitcast i16* %3 to i8*
   %11 = getelementptr inbounds i8, i8* %10, i64 %9
   %12 = bitcast i8* %11 to i16*
-  %NullCheck4 = icmp ne i16* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %5
   store i16 0, i16* %12, align 8
@@ -6098,11 +7552,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6119,8 +7573,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -6131,8 +7585,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
@@ -6144,15 +7598,15 @@ entry:
 
 ; <label>:14                                      ; preds = %1
   %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
   %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
   %21 = load i64, i64 addrspace(1)* %19
@@ -6171,15 +7625,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %14
+ThrowNullRef4:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %16
+ThrowNullRef6:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6302,14 +7756,6 @@ entry:
   ret %System.String addrspace(1)* %57
 }
 
-INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
-Successfully read RuntimeHelpers.get_OffsetToStringData
-
-define i32 @RuntimeHelpers.get_OffsetToStringData() {
-entry:
-  ret i32 12
-}
-
 INFO:  jitting method String::Equals using LLILCJit
 Successfully read String.Equals
 
@@ -6381,8 +7827,8 @@ entry:
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
-  br i1 %NullCheck24, label %29, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
   %30 = load i64, i64 addrspace(1)* %28
@@ -6397,8 +7843,8 @@ entry:
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
-  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
   %43 = load i64, i64 addrspace(1)* %41
@@ -6418,8 +7864,8 @@ entry:
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
   %59 = load i64, i64 addrspace(1)* %57
@@ -6434,8 +7880,8 @@ entry:
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck22, label %71, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
   %72 = load i64, i64 addrspace(1)* %70
@@ -6455,8 +7901,8 @@ entry:
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
-  br i1 %NullCheck16, label %87, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = load i64, i64 addrspace(1)* %86
@@ -6471,8 +7917,8 @@ entry:
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck18, label %100, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
   %101 = load i64, i64 addrspace(1)* %99
@@ -6492,8 +7938,8 @@ entry:
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
-  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
   %117 = load i64, i64 addrspace(1)* %115
@@ -6508,8 +7954,8 @@ entry:
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
-  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
   %130 = load i64, i64 addrspace(1)* %128
@@ -6528,15 +7974,15 @@ entry:
 
 ; <label>:142                                     ; preds = %22
   %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
-  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %143, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %144
 
 ; <label>:144                                     ; preds = %142
   %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
   %146 = load i32, i32 addrspace(1)* %145
   %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
-  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %147, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %148
 
 ; <label>:148                                     ; preds = %144
   %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
@@ -6557,15 +8003,15 @@ entry:
 
 ; <label>:159                                     ; preds = %22
   %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
-  br i1 %NullCheck, label %161, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %ThrowNullRef, label %161
 
 ; <label>:161                                     ; preds = %159
   %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
   %163 = load i32, i32 addrspace(1)* %162
   %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
-  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %164, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %165
 
 ; <label>:165                                     ; preds = %161
   %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
@@ -6578,8 +8024,8 @@ entry:
 
 ; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
-  br i1 %NullCheck4, label %172, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %171, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %172
 
 ; <label>:172                                     ; preds = %170
   %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
@@ -6589,8 +8035,8 @@ entry:
 
 ; <label>:176                                     ; preds = %172
   %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
-  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %177, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %178
 
 ; <label>:178                                     ; preds = %176
   %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
@@ -6629,55 +8075,55 @@ ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %161
+ThrowNullRef2:                                    ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %170
+ThrowNullRef4:                                    ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %176
+ThrowNullRef6:                                    ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %142
+ThrowNullRef8:                                    ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %144
+ThrowNullRef10:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %113
+ThrowNullRef12:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %116
+ThrowNullRef14:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %84
+ThrowNullRef16:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %87
+ThrowNullRef18:                                   ; preds = %87
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %55
+ThrowNullRef20:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %58
+ThrowNullRef22:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %26
+ThrowNullRef24:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %29
+ThrowNullRef26:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,8 +8161,8 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck, label %14, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %ThrowNullRef, label %14
 
 ; <label>:14                                      ; preds = %8
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
@@ -6760,8 +8206,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
@@ -6770,14 +8216,14 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32, i32* %loc0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %10
   %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
   %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
@@ -6790,15 +8236,15 @@ entry:
 ; <label>:25                                      ; preds = %19
   %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
-  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
   %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
@@ -6807,8 +8253,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %37 = load i32, i32* %loc0
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %38, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %38
 
 ; <label>:38                                      ; preds = %32
   %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
@@ -6817,14 +8263,14 @@ entry:
 
 ; <label>:40                                      ; preds = %19
   %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %40
   %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
   %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
-  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
-  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
@@ -6832,8 +8278,8 @@ entry:
   %48 = zext i32 %47 to i64
   %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
-  br i1 %NullCheck16, label %51, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %51
 
 ; <label>:51                                      ; preds = %45
   %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
@@ -6847,15 +8293,15 @@ entry:
 ; <label>:57                                      ; preds = %51
   %58 = load i16*, i16** %arg1
   %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
-  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %60
 
 ; <label>:60                                      ; preds = %57
   %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
   %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
-  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %64
 
 ; <label>:64                                      ; preds = %60
   %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
@@ -6864,22 +8310,22 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
   %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
-  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %70
 
 ; <label>:70                                      ; preds = %64
   %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
   %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
-  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
-  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
   %75 = load i32, i32 addrspace(1)* %74
   %76 = zext i32 %75 to i64
   %77 = trunc i64 %76 to i32
-  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
-  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %78
 
 ; <label>:78                                      ; preds = %73
   %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
@@ -6901,8 +8347,8 @@ entry:
   %90 = bitcast i16* %86 to i8*
   %91 = getelementptr inbounds i8, i8* %90, i64 %89
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %93
 
 ; <label>:93                                      ; preds = %80
   %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
@@ -6912,8 +8358,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %99 = load i32, i32* %loc2
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %100
 
 ; <label>:100                                     ; preds = %93
   %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
@@ -6928,63 +8374,63 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %25
+ThrowNullRef6:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %32
+ThrowNullRef10:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %40
+ThrowNullRef12:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %45
+ThrowNullRef16:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %57
+ThrowNullRef18:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %60
+ThrowNullRef20:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %64
+ThrowNullRef22:                                   ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %70
+ThrowNullRef24:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %73
+ThrowNullRef26:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %80
+ThrowNullRef28:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %93
+ThrowNullRef30:                                   ; preds = %93
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7004,8 +8450,8 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
@@ -7033,43 +8479,43 @@ entry:
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %14
   %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
   %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   %28 = load i32, i32 addrspace(1)* %27, align 8
   %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
-  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %30
 
 ; <label>:30                                      ; preds = %26
   %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
   %32 = load i32, i32 addrspace(1)* %31, align 8
   %33 = add i32 %28, %32
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %34
 
 ; <label>:34                                      ; preds = %30
   %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   store i32 %33, i32 addrspace(1)* %35
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
   store i32 0, i32 addrspace(1)* %38
   %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %40
 
 ; <label>:40                                      ; preds = %37
   %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
@@ -7082,8 +8528,8 @@ entry:
 
 ; <label>:47                                      ; preds = %40
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
@@ -7098,8 +8544,8 @@ entry:
   %54 = load i32, i32* %loc0
   %55 = sext i32 %54 to i64
   %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
-  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %57
 
 ; <label>:57                                      ; preds = %52
   %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
@@ -7110,68 +8556,35 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %14
+ThrowNullRef2:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %23
+ThrowNullRef4:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %26
+ThrowNullRef6:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %30
+ThrowNullRef8:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %34
+ThrowNullRef10:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %47
+ThrowNullRef14:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %52
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-}
-
-INFO:  jitting method StringBuilder::get_Length using LLILCJit
-Successfully read StringBuilder.get_Length
-
-define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.StringBuilder addrspace(1)*
-  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
-  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
-
-; <label>:1                                       ; preds = %entry
-  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %3 = load i32, i32 addrspace(1)* %2, align 8
-  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
-
-; <label>:5                                       ; preds = %1
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = add i32 %3, %7
-  ret i32 %8
-
-ThrowNullRef:                                     ; preds = %entry
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef16:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7213,70 +8626,70 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
   %6 = load i32, i32 addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
   store i32 %6, i32 addrspace(1)* %8
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
   %13 = load i32, i32 addrspace(1)* %12, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
   store i32 %13, i32 addrspace(1)* %15
   %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
-  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %18
 
 ; <label>:18                                      ; preds = %14
   %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
   %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
   %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
   %34 = load i32, i32 addrspace(1)* %33, align 8
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
-  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
@@ -7287,39 +8700,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %28
+ThrowNullRef16:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %32
+ThrowNullRef18:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7455,13 +8868,13 @@ entry:
 ; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
@@ -7477,16 +8890,16 @@ entry:
 
 ; <label>:18                                      ; preds = %15
   %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
   store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
   %22 = load i32, i32* %loc0
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %24
 
 ; <label>:24                                      ; preds = %20
   %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
@@ -7498,13 +8911,13 @@ entry:
 ; <label>:28                                      ; preds = %15, %24
   %29 = load i32, i32* %arg1
   %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %31
   %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
@@ -7517,20 +8930,20 @@ entry:
   %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
-  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
   %46 = load i32, i32 addrspace(1)* %45, align 8
   %47 = sub i32 %40, %46
-  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
-  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i32 addrspace(1)* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %48
 
 ; <label>:48                                      ; preds = %44
   store i32 %47, i32 addrspace(1)* %39, align 8
@@ -7538,21 +8951,21 @@ entry:
 
 ; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
-  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %51
 
 ; <label>:51                                      ; preds = %49
   %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %53
 
 ; <label>:53                                      ; preds = %51
   %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
   %55 = load i32, i32 addrspace(1)* %54, align 8
   %56 = load i32, i32* %arg2
   %57 = sub i32 %55, %56
-  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %58
 
 ; <label>:58                                      ; preds = %53
   %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
@@ -7562,13 +8975,13 @@ entry:
 ; <label>:60                                      ; preds = %33, %58
   %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
   %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
-  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %63
 
 ; <label>:63                                      ; preds = %60
   %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
-  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
-  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
@@ -7578,15 +8991,15 @@ entry:
 
 ; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
-  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i32 addrspace(1)* %69, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %70
 
 ; <label>:70                                      ; preds = %68
   %71 = load i32, i32 addrspace(1)* %69, align 8
   store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
-  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
@@ -7596,8 +9009,8 @@ entry:
   store i32 %77, i32* %loc4
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
-  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %80
 
 ; <label>:80                                      ; preds = %73
   %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
@@ -7607,71 +9020,71 @@ entry:
 ; <label>:83                                      ; preds = %80
   store i32 0, i32* %loc3
   %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
-  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
-  br i1 %NullCheck26, label %88, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i32 addrspace(1)* %87, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %88
 
 ; <label>:88                                      ; preds = %85
   %89 = load i32, i32 addrspace(1)* %87, align 8
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
-  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %90
 
 ; <label>:90                                      ; preds = %88
   %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
   store i32 %89, i32 addrspace(1)* %91
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
-  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
-  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %96
 
 ; <label>:96                                      ; preds = %94
   %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
-  br i1 %NullCheck34, label %100, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %100
 
 ; <label>:100                                     ; preds = %96
   %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
-  br i1 %NullCheck36, label %102, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %102
 
 ; <label>:102                                     ; preds = %100
   %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
   %104 = load i32, i32 addrspace(1)* %103, align 8
   %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
-  br i1 %NullCheck38, label %106, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %106
 
 ; <label>:106                                     ; preds = %102
   %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
-  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
-  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %108
 
 ; <label>:108                                     ; preds = %106
   %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
   %110 = load i32, i32 addrspace(1)* %109, align 8
   %111 = add i32 %104, %110
-  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %112
 
 ; <label>:112                                     ; preds = %108
   %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
   store i32 %111, i32 addrspace(1)* %113
   %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
-  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i32 addrspace(1)* %114, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %115
 
 ; <label>:115                                     ; preds = %112
   %116 = load i32, i32 addrspace(1)* %114, align 8
@@ -7681,19 +9094,19 @@ entry:
 ; <label>:118                                     ; preds = %115
   %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
-  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %121
 
 ; <label>:121                                     ; preds = %118
   %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
-  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
-  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %123
 
 ; <label>:123                                     ; preds = %121
   %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
   %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
-  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
-  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %126
 
 ; <label>:126                                     ; preds = %123
   %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
@@ -7705,8 +9118,8 @@ entry:
 
 ; <label>:130                                     ; preds = %80, %115, %126
   %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %132
 
 ; <label>:132                                     ; preds = %130
   %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7715,8 +9128,8 @@ entry:
   %136 = load i32, i32* %loc3
   %137 = sub i32 %135, %136
   %138 = sub i32 %134, %137
-  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %139
 
 ; <label>:139                                     ; preds = %132
   %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7728,16 +9141,16 @@ entry:
 
 ; <label>:144                                     ; preds = %139
   %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
-  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %146
 
 ; <label>:146                                     ; preds = %144
   %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
   %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
   %149 = load i32, i32* %loc2
   %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
-  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %151
 
 ; <label>:151                                     ; preds = %146
   %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
@@ -7754,145 +9167,249 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %18
+ThrowNullRef4:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %31
+ThrowNullRef10:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %44
+ThrowNullRef16:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %68
+ThrowNullRef18:                                   ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %70
+ThrowNullRef20:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %73
+ThrowNullRef22:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %83
+ThrowNullRef24:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %85
+ThrowNullRef26:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %88
+ThrowNullRef28:                                   ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %90
+ThrowNullRef30:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %94
+ThrowNullRef32:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %96
+ThrowNullRef34:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %100
+ThrowNullRef36:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %102
+ThrowNullRef38:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %106
+ThrowNullRef40:                                   ; preds = %106
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %108
+ThrowNullRef42:                                   ; preds = %108
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %112
+ThrowNullRef44:                                   ; preds = %112
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %118
+ThrowNullRef46:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %121
+ThrowNullRef48:                                   ; preds = %121
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %123
+ThrowNullRef50:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %130
+ThrowNullRef52:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %132
+ThrowNullRef54:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %144
+ThrowNullRef56:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %146
+ThrowNullRef58:                                   ; preds = %146
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %60
+ThrowNullRef60:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %63
+ThrowNullRef62:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %49
+ThrowNullRef64:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %51
+ThrowNullRef66:                                   ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %53
+ThrowNullRef68:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(%"System.Char[]" addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %arg0 = alloca %"System.Char[]" addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store %"System.Char[]" addrspace(1)* %param0, %"System.Char[]" addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load i32, i32* %arg4
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %43, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %38, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg1
+  %13 = load i32, i32* %arg4
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %38, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %24 = load i32, i32* %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %35 = load i32, i32* %arg3
+  %36 = load i32, i32* %arg4
+  %37 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %37, %"System.Char[]" addrspace(1)* %34, i32 %35, i32 %36)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:38                                      ; preds = %5, %16
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Successfully read Buffer._Memmove
 
@@ -7914,7 +9431,7 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[loadElem]
+Failed to read AppDomain.SetDataHelper[storeElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -7923,8 +9440,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
@@ -7934,8 +9451,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
@@ -7947,15 +9464,15 @@ entry:
   %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
   %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
@@ -7966,15 +9483,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7992,7 +9509,79 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
-Failed to read Dictionary`2.TryGetValue[loadElemA]
+Successfully read Dictionary`2.TryGetValue
+
+define i8 @"Dictionary`2.TryGetValue"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)* addrspace(1)* %param2) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  %arg2 = alloca %System.__Canon addrspace(1)* addrspace(1)*
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  store %System.__Canon addrspace(1)* addrspace(1)* %param2, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  store i32 %2, i32* %loc0
+  %3 = load i32, i32* %loc0
+  %4 = icmp slt i32 %3, 0
+  br i1 %4, label %22, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 2
+  %10 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %9, align 8
+  %11 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = zext i32 %11 to i64
+  %BoundsCheck = icmp uge i64 %16, %15
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 3, i32 %11
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %20, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %6, %System.__Canon addrspace(1)* %21)
+  ret i8 1
+
+; <label>:22                                      ; preds = %entry
+  %23 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %23, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -8058,8 +9647,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
@@ -8091,8 +9680,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
@@ -8171,15 +9760,15 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck, label %19, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %ThrowNullRef, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
   %21 = load i32, i32 addrspace(1)* %20
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
@@ -8202,7 +9791,7 @@ ThrowNullRef:                                     ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %19
+ThrowNullRef2:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8248,8 +9837,8 @@ entry:
   %0 = alloca %System.AppDomainHandle
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %1 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %1, i32 0, i32 15
@@ -8269,8 +9858,8 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
@@ -8286,7 +9875,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -8299,8 +9888,8 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -8327,8 +9916,8 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
@@ -8352,8 +9941,8 @@ entry:
   %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
   store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
@@ -8363,8 +9952,8 @@ entry:
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
@@ -8374,8 +9963,8 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %9
   %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
@@ -8384,8 +9973,8 @@ entry:
 
 ; <label>:18                                      ; preds = %3, %16
   %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
@@ -8397,15 +9986,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %18
+ThrowNullRef6:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8418,8 +10007,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
@@ -8453,15 +10042,15 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
@@ -8473,7 +10062,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8481,7 +10070,7 @@ ThrowNullRef1:                                    ; preds = %1
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
 Failed to read Dictionary`2.System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
@@ -8506,8 +10095,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
@@ -8524,8 +10113,8 @@ entry:
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -8544,7 +10133,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8577,8 +10166,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = load i64, i64* %arg2
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = trunc i32 %3 to i8
@@ -8634,46 +10223,46 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
   %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
-  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
-  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
-  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
@@ -8684,27 +10273,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %20
+ThrowNullRef12:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8717,8 +10306,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -8756,22 +10345,22 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
   %9 = load i64, i64 addrspace(1)* %8, align 8
   %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
   %13 = load i64, i64 addrspace(1)* %12, align 8
   %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %11
   %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
@@ -8788,11 +10377,11 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8882,8 +10471,8 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
@@ -8900,8 +10489,8 @@ entry:
 ; <label>:8                                       ; preds = %1
   %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
   %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
@@ -8911,15 +10500,15 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
   %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
   %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
-  br i1 %NullCheck6, label %21, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
@@ -8946,15 +10535,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8992,15 +10581,15 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
   store i8 %3, i8 addrspace(1)* %5
   %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
@@ -9011,7 +10600,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9027,8 +10616,8 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -9041,8 +10630,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
@@ -9058,7 +10647,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9080,8 +10669,8 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
@@ -9096,8 +10685,8 @@ entry:
 ; <label>:12                                      ; preds = %6
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
@@ -9112,8 +10701,8 @@ entry:
 ; <label>:21                                      ; preds = %15
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
@@ -9128,8 +10717,8 @@ entry:
 ; <label>:30                                      ; preds = %24
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %31, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
@@ -9144,8 +10733,8 @@ entry:
 ; <label>:39                                      ; preds = %33
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
-  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %40, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %42
 
 ; <label>:42                                      ; preds = %39
   %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
@@ -9164,19 +10753,19 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %21
+ThrowNullRef4:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %30
+ThrowNullRef6:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %39
+ThrowNullRef8:                                    ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9243,8 +10832,8 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
@@ -9264,57 +10853,57 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
   store i8 0, i8 addrspace(1)* %2
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
   store i8 0, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
   store i8 0, i8 addrspace(1)* %17
   %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
   store i8 0, i8 addrspace(1)* %20
   %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
-  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
@@ -9325,31 +10914,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %19
+ThrowNullRef14:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9367,8 +10956,8 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
@@ -9380,8 +10969,8 @@ entry:
 
 ; <label>:9                                       ; preds = %4
   %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %9
   %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
@@ -9395,7 +10984,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef2:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9420,8 +11009,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
@@ -9512,8 +11101,8 @@ entry:
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
@@ -9524,8 +11113,8 @@ entry:
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = load i64, i64 addrspace(1)* %12
@@ -9537,8 +11126,8 @@ entry:
   %20 = load i64, i64* %19
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
-  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %13
   %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
@@ -9555,8 +11144,8 @@ entry:
 ; <label>:30                                      ; preds = %25
   %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %32 = load i32, i32* %arg2
-  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
-  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
@@ -9570,15 +11159,15 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %30
+ThrowNullRef2:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9622,87 +11211,87 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
   %10 = load i8, i8 addrspace(1)* %9, align 8
   %11 = zext i8 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %8
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
   store i8 %12, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
   %19 = load i8, i8 addrspace(1)* %18, align 8
   %20 = zext i8 %19 to i32
   %21 = trunc i32 %20 to i8
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
   store i8 %21, i8 addrspace(1)* %23
   %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
   %28 = load i8, i8 addrspace(1)* %27, align 8
   %29 = zext i8 %28 to i32
   %30 = trunc i32 %29 to i8
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
-  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %31
 
 ; <label>:31                                      ; preds = %26
   %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
   store i8 %30, i8 addrspace(1)* %32
   %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
-  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
-  br i1 %NullCheck14, label %40, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %40
 
 ; <label>:40                                      ; preds = %35
   %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
   store i8 %39, i8 addrspace(1)* %41
   %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
-  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %44
 
 ; <label>:44                                      ; preds = %40
   %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
   %46 = load i8, i8 addrspace(1)* %45, align 8
   %47 = zext i8 %46 to i32
   %48 = trunc i32 %47 to i8
-  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
   store i8 %48, i8 addrspace(1)* %50
   %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
-  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
@@ -9713,29 +11302,29 @@ entry:
 ; <label>:56                                      ; preds = %52
   %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
-  br i1 %NullCheck22, label %59, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
   %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
   %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
-  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
-  br i1 %NullCheck24, label %63, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
   %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
-  br i1 %NullCheck26, label %66, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
   %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
-  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
-  br i1 %NullCheck28, label %69, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %69
 
 ; <label>:69                                      ; preds = %66
   %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
@@ -9744,15 +11333,15 @@ entry:
 
 ; <label>:71                                      ; preds = %105
   %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
-  br i1 %NullCheck34, label %73, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %73
 
 ; <label>:73                                      ; preds = %71
   %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
   %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
   %76 = load i32, i32* %loc0
-  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
-  br i1 %NullCheck36, label %77, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
@@ -9766,8 +11355,8 @@ entry:
 
 ; <label>:83                                      ; preds = %77
   %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
-  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
@@ -9775,14 +11364,14 @@ entry:
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
   %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
-  br i1 %NullCheck40, label %91, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
 ; <label>:91                                      ; preds = %85
   %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
   %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
-  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck42, label %94, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %94
 
 ; <label>:94                                      ; preds = %91
   %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
@@ -9798,14 +11387,14 @@ entry:
 ; <label>:99                                      ; preds = %69, %96
   %100 = load i32, i32* %loc0
   %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
-  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %102
 
 ; <label>:102                                     ; preds = %99
   %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
   %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
-  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
-  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
@@ -9819,87 +11408,87 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %26
+ThrowNullRef10:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %31
+ThrowNullRef12:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %35
+ThrowNullRef14:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %40
+ThrowNullRef16:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %56
+ThrowNullRef22:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %59
+ThrowNullRef24:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %63
+ThrowNullRef26:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %66
+ThrowNullRef28:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %102
+ThrowNullRef32:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %71
+ThrowNullRef34:                                   ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %73
+ThrowNullRef36:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %83
+ThrowNullRef38:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %85
+ThrowNullRef40:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %91
+ThrowNullRef42:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9943,15 +11532,15 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
   %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
@@ -9961,28 +11550,28 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
   %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %12
   %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
   %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
   %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
-  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
@@ -9993,23 +11582,23 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %12
+ThrowNullRef6:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10031,15 +11620,15 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
   %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = load i64, i64 addrspace(1)* %7
@@ -10077,13 +11666,13 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[loadElem]
+Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -10111,8 +11700,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -10175,8 +11764,8 @@ entry:
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load double, double* %arg0
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -10310,8 +11899,8 @@ entry:
   store i64 %param0, i64* %arg0
   store i64 %param1, i64* %arg1
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
@@ -10319,8 +11908,8 @@ entry:
   %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
   %5 = load i16*, i16* addrspace(1)* %4, align 8
   %6 = addrspacecast i64* %arg1 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = bitcast i64 addrspace(1)* %6 to i8 addrspace(1)*
@@ -10336,7 +11925,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10370,8 +11959,8 @@ entry:
   %1 = load i32, i32* %arg1
   %2 = sext i32 %1 to i64
   %3 = inttoptr i64 %2 to i16*
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -10424,8 +12013,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, i32)*)(%System.IO.ConsoleStream addrspace(1)* %2, i32 %1)
   %3 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %4 = load i64, i64* %arg1
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
@@ -10436,8 +12025,8 @@ entry:
   %10 = icmp eq i32 %9, 3
   %11 = sext i1 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %5
   %14 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, i32 0, i32 5
@@ -10448,7 +12037,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10471,8 +12060,8 @@ entry:
   %5 = icmp eq i32 %4, 1
   %6 = sext i1 %5 to i32
   %7 = trunc i32 %6 to i8
-  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %2, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.ConsoleStream addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
@@ -10483,8 +12072,8 @@ entry:
   %13 = icmp eq i32 %12, 2
   %14 = sext i1 %13 to i32
   %15 = trunc i32 %14 to i8
-  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %10, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.ConsoleStream addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %8
   %17 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %10, i32 0, i32 4
@@ -10495,7 +12084,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10534,8 +12123,8 @@ entry:
   %arg0 = alloca i64
   store i64 %param0, i64* %arg0
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
@@ -10570,8 +12159,8 @@ entry:
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
   %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = load i64, i64 addrspace(1)* %7
@@ -10675,7 +12264,127 @@ entry:
 INFO:  jitting method Encoding::GetEncoding using LLILCJit
 Failed to read Encoding.GetEncoding[convertToHelperArgumentType]
 INFO:  jitting method EncodingProvider::GetEncodingFromProvider using LLILCJit
-Failed to read EncodingProvider.GetEncodingFromProvider[loadElem]
+Successfully read EncodingProvider.GetEncodingFromProvider
+
+define %System.Text.Encoding addrspace(1)* @EncodingProvider.GetEncodingFromProvider(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca %"System.Text.EncodingProvider[]" addrspace(1)*
+  %loc1 = alloca %System.Text.EncodingProvider addrspace(1)*
+  %loc2 = alloca %System.Text.Encoding addrspace(1)*
+  %loc3 = alloca %System.Text.Encoding addrspace(1)*
+  %loc4 = alloca %"System.Text.EncodingProvider[]" addrspace(1)*
+  %loc5 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1059)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2392
+  %2 = addrspacecast i8 addrspace(1)* %1 to %"System.Text.EncodingProvider[]" addrspace(1)**
+  %3 = load volatile %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %2
+  %4 = icmp ne %"System.Text.EncodingProvider[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %entry
+  ret %System.Text.Encoding addrspace(1)* null
+
+; <label>:6                                       ; preds = %entry
+  %7 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1059)
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i64 2392
+  %9 = addrspacecast i8 addrspace(1)* %8 to %"System.Text.EncodingProvider[]" addrspace(1)**
+  %10 = load volatile %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %9
+  store %"System.Text.EncodingProvider[]" addrspace(1)* %10, %"System.Text.EncodingProvider[]" addrspace(1)** %loc0
+  %11 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc0
+  store %"System.Text.EncodingProvider[]" addrspace(1)* %11, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  store i32 0, i32* %loc5
+  br label %43
+
+; <label>:12                                      ; preds = %46
+  %13 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  %14 = load i32, i32* %loc5
+  %NullCheck1 = icmp eq %"System.Text.EncodingProvider[]" addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %13, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = zext i32 %17 to i64
+  %19 = zext i32 %14 to i64
+  %BoundsCheck = icmp uge i64 %19, %18
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %20
+
+; <label>:20                                      ; preds = %15
+  %21 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %13, i32 0, i32 3, i32 %14
+  %22 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)* addrspace(1)* %21, align 8
+  store %System.Text.EncodingProvider addrspace(1)* %22, %System.Text.EncodingProvider addrspace(1)** %loc1
+  %23 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)** %loc1
+  %24 = load i32, i32* %arg0
+  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i64 addrspace(1)*
+  %NullCheck3 = icmp eq i64 addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
+
+; <label>:26                                      ; preds = %20
+  %27 = load i64, i64 addrspace(1)* %25
+  %28 = add i64 %27, 64
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 40
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Text.Encoding addrspace(1)* (%System.Text.EncodingProvider addrspace(1)*, i32)*
+  %35 = call %System.Text.Encoding addrspace(1)* %34(%System.Text.EncodingProvider addrspace(1)* %23, i32 %24)
+  store %System.Text.Encoding addrspace(1)* %35, %System.Text.Encoding addrspace(1)** %loc2
+  %36 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc2
+  %37 = icmp eq %System.Text.Encoding addrspace(1)* %36, null
+  br i1 %37, label %40, label %38
+
+; <label>:38                                      ; preds = %26
+  %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc2
+  store %System.Text.Encoding addrspace(1)* %39, %System.Text.Encoding addrspace(1)** %loc3
+  br label %53
+
+; <label>:40                                      ; preds = %26
+  %41 = load i32, i32* %loc5
+  %42 = add i32 %41, 1
+  store i32 %42, i32* %loc5
+  br label %43
+
+; <label>:43                                      ; preds = %6, %40
+  %44 = load i32, i32* %loc5
+  %45 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  %NullCheck = icmp eq %"System.Text.EncodingProvider[]" addrspace(1)* %45, null
+  br i1 %NullCheck, label %ThrowNullRef, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp slt i32 %44, %50
+  br i1 %51, label %12, label %52
+
+; <label>:52                                      ; preds = %46
+  ret %System.Text.Encoding addrspace(1)* null
+
+; <label>:53                                      ; preds = %38
+  %54 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc3
+  ret %System.Text.Encoding addrspace(1)* %54
+
+ThrowNullRef:                                     ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method EncodingProvider::.cctor using LLILCJit
 Successfully read EncodingProvider..cctor
 
@@ -10694,7 +12403,7 @@ Failed to read Encoding.get_InternalSyncObject[Call HasTypeArg]
 INFO:  jitting method Hashtable::.ctor using LLILCJit
 Failed to read Hashtable..ctor[Volatile store]
 INFO:  jitting method Hashtable::get_Item using LLILCJit
-Failed to read Hashtable.get_Item[loadElemA]
+Failed to read Hashtable.get_Item[loadNonPrimitiveObj]
 INFO:  jitting method Hashtable::InitHash using LLILCJit
 Successfully read Hashtable.InitHash
 
@@ -10714,8 +12423,8 @@ entry:
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -10731,15 +12440,15 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
   %15 = load i32, i32* %loc0
-  %NullCheck2 = icmp ne i32 addrspace(1)* %14, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i32 addrspace(1)* %14, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %3
   store i32 %15, i32 addrspace(1)* %14, align 8
   %17 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %18 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %NullCheck4 = icmp ne i32 addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i32 addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = load i32, i32 addrspace(1)* %18, align 8
@@ -10748,8 +12457,8 @@ entry:
   %23 = sub i32 %22, 1
   %24 = urem i32 %21, %23
   %25 = add i32 1, %24
-  %NullCheck6 = icmp ne i32 addrspace(1)* %17, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32 addrspace(1)* %17, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %19
   store i32 %25, i32 addrspace(1)* %17, align 8
@@ -10760,15 +12469,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %19
+ThrowNullRef6:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10783,8 +12492,8 @@ entry:
   store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
   store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %NullCheck = icmp ne %System.Collections.Hashtable addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Collections.Hashtable addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
@@ -10794,16 +12503,16 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Collections.Hashtable addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Collections.Hashtable addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
   %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck4 = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %9, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
   %13 = inttoptr i64 %11 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
@@ -10813,8 +12522,8 @@ entry:
 ; <label>:15                                      ; preds = %1
   %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -10832,15 +12541,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10854,8 +12563,8 @@ entry:
   store %System.Int32 addrspace(1)* %param0, %System.Int32 addrspace(1)** %this
   %0 = load %System.Int32 addrspace(1)*, %System.Int32 addrspace(1)** %this
   %1 = bitcast %System.Int32 addrspace(1)* %0 to i32 addrspace(1)*
-  %NullCheck = icmp ne i32 addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq i32 addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load i32, i32 addrspace(1)* %1, align 8
@@ -10931,8 +12640,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.UTF8Encoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
@@ -10941,15 +12650,15 @@ entry:
   %9 = load i8, i8* %arg2
   %10 = zext i8 %9 to i32
   %11 = trunc i32 %10 to i8
-  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %8, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %6
   %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %8, i32 0, i32 8
   store i8 %11, i8 addrspace(1)* %13
   %14 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %14, i32 0, i32 8
@@ -10961,8 +12670,8 @@ entry:
 ; <label>:20                                      ; preds = %15
   %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %22, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %22, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = load i64, i64 addrspace(1)* %22
@@ -10984,15 +12693,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %12
+ThrowNullRef4:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11007,8 +12716,8 @@ entry:
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
@@ -11030,16 +12739,16 @@ entry:
 ; <label>:10                                      ; preds = %1
   %11 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
   %12 = load i32, i32* %arg1
-  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %11, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.Encoding addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
   store i32 %12, i32 addrspace(1)* %14
   %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
   %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = load i64, i64 addrspace(1)* %16
@@ -11057,11 +12766,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11074,8 +12783,8 @@ entry:
   %this = alloca %System.Text.UTF8Encoding addrspace(1)*
   store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
   %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.UTF8Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
@@ -11087,16 +12796,16 @@ entry:
 ; <label>:6                                       ; preds = %1
   %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %8 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %10, %System.Text.EncoderFallback addrspace(1)* %8)
   %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %12 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
-  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %11, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %11, i32 0, i32 3
@@ -11109,8 +12818,8 @@ entry:
   %18 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %18, %System.String addrspace(1)* %17)
   %19 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %18 to %System.Text.EncoderFallback addrspace(1)*
-  %NullCheck6 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %16, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %16, i32 0, i32 2
@@ -11120,8 +12829,8 @@ entry:
   %24 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %24, %System.String addrspace(1)* %23)
   %25 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %24 to %System.Text.DecoderFallback addrspace(1)*
-  %NullCheck8 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %22, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %22, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %20
   %27 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %22, i32 0, i32 3
@@ -11132,19 +12841,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %20
+ThrowNullRef8:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11174,8 +12883,8 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load i32, i32* %arg1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -11193,8 +12902,8 @@ entry:
 ; <label>:15                                      ; preds = %8
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %17 = load i32, i32* %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 %17
@@ -11210,7 +12919,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11262,7 +12971,7 @@ entry:
 }
 
 INFO:  jitting method Hashtable::Insert using LLILCJit
-Failed to read Hashtable.Insert[loadElemA]
+Failed to read Hashtable.Insert[storeElem]
 INFO:  jitting method ConsoleEncoding::.ctor using LLILCJit
 Successfully read ConsoleEncoding..ctor
 
@@ -11277,8 +12986,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %1)
   %2 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
@@ -11314,8 +13023,8 @@ entry:
   %2 = call %System.Text.InternalEncoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalEncoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %1)
   %3 = bitcast %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2 to %System.Text.EncoderFallback addrspace(1)*
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
@@ -11325,8 +13034,8 @@ entry:
   %8 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %7)
   %9 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %8 to %System.Text.DecoderFallback addrspace(1)*
-  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %6, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.Encoding addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %4
   %11 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %6, i32 0, i32 3
@@ -11337,7 +13046,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11356,15 +13065,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* %1)
   %2 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   %6 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, i32 0, i32 1
@@ -11375,7 +13084,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11403,8 +13112,8 @@ entry:
   store %System.Text.InternalDecoderBestFitFallback addrspace(1)* %param0, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
   %0 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
@@ -11414,15 +13123,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %4)
   %5 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %6)
   %9 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, i32 0, i32 1
@@ -11433,11 +13142,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11505,8 +13214,8 @@ entry:
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
   %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = load i64, i64 addrspace(1)* %19
@@ -11570,8 +13279,8 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.ConsoleStream addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
@@ -11602,31 +13311,31 @@ entry:
   store i8 %param4, i8* %arg4
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %3, %System.IO.Stream addrspace(1)* %1)
   %4 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %4, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
   %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %4, i32 0, i32 4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %5)
   %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %6
   %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
   %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
   %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = load i64, i64 addrspace(1)* %13
@@ -11638,8 +13347,8 @@ entry:
   %21 = load i64, i64* %20
   %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %8, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %8, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %14
   %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 5
@@ -11657,24 +13366,24 @@ entry:
   %31 = load i32, i32* %arg3
   %32 = sext i32 %31 to i64
   %33 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %32)
-  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %30, null
-  br i1 %NullCheck10, label %34, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.StreamWriter addrspace(1)* %30, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %35, %"System.Char[]" addrspace(1)* %33)
   %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %37, null
-  br i1 %NullCheck12, label %38, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.StreamWriter addrspace(1)* %37, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %38
 
 ; <label>:38                                      ; preds = %34
   %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
   %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
   %41 = load i32, i32* %arg3
   %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %42, null
-  br i1 %NullCheck14, label %43, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %42, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
   %44 = load i64, i64 addrspace(1)* %42
@@ -11688,30 +13397,30 @@ entry:
   %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
   %53 = sext i32 %52 to i64
   %54 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %53)
-  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
-  br i1 %NullCheck16, label %55, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %55
 
 ; <label>:55                                      ; preds = %43
   %56 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %56, %"System.Byte[]" addrspace(1)* %54)
   %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %58 = load i32, i32* %arg3
-  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %57, null
-  br i1 %NullCheck18, label %59, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.StreamWriter addrspace(1)* %57, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %59
 
 ; <label>:59                                      ; preds = %55
   %60 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 10
   store i32 %58, i32 addrspace(1)* %60
   %61 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %61, null
-  br i1 %NullCheck20, label %62, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.IO.StreamWriter addrspace(1)* %61, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %62
 
 ; <label>:62                                      ; preds = %59
   %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
   %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
   %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
   %67 = load i64, i64 addrspace(1)* %65
@@ -11729,15 +13438,15 @@ entry:
 
 ; <label>:78                                      ; preds = %66
   %79 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %79, null
-  br i1 %NullCheck24, label %80, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.StreamWriter addrspace(1)* %79, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %80
 
 ; <label>:80                                      ; preds = %78
   %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
   %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
   %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %83, null
-  br i1 %NullCheck26, label %84, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %83, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
   %85 = load i64, i64 addrspace(1)* %83
@@ -11754,8 +13463,8 @@ entry:
 
 ; <label>:95                                      ; preds = %84
   %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.IO.StreamWriter addrspace(1)* %96, null
-  br i1 %NullCheck28, label %97, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.IO.StreamWriter addrspace(1)* %96, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %97
 
 ; <label>:97                                      ; preds = %95
   %98 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 12
@@ -11769,8 +13478,8 @@ entry:
   %103 = icmp eq i32 %102, 0
   %104 = sext i1 %103 to i32
   %105 = trunc i32 %104 to i8
-  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %100, null
-  br i1 %NullCheck30, label %106, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.IO.StreamWriter addrspace(1)* %100, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %106
 
 ; <label>:106                                     ; preds = %99
   %107 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %100, i32 0, i32 13
@@ -11781,63 +13490,63 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %6
+ThrowNullRef4:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %29
+ThrowNullRef10:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %34
+ThrowNullRef12:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %38
+ThrowNullRef14:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %43
+ThrowNullRef16:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %55
+ThrowNullRef18:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %59
+ThrowNullRef20:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %62
+ThrowNullRef22:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %78
+ThrowNullRef24:                                   ; preds = %78
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %80
+ThrowNullRef26:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %95
+ThrowNullRef28:                                   ; preds = %95
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11850,15 +13559,15 @@ entry:
   %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = load i64, i64 addrspace(1)* %4
@@ -11876,7 +13585,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11926,35 +13635,35 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
   %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderNLS addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %7 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.EncoderNLS addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Text.Encoding addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.Encoding addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Text.EncoderNLS addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.EncoderNLS addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
   %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck8 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = load i64, i64 addrspace(1)* %16
@@ -11973,19 +13682,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12011,8 +13720,8 @@ entry:
   %this = alloca %System.Text.Encoding addrspace(1)*
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
@@ -12032,15 +13741,15 @@ entry:
   %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
   store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
   %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
   store i32 0, i32 addrspace(1)* %2
   %3 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, i32 0, i32 2
@@ -12050,15 +13759,15 @@ entry:
 
 ; <label>:8                                       ; preds = %4
   %9 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
   %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
   %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = load i64, i64 addrspace(1)* %13
@@ -12079,15 +13788,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12102,16 +13811,16 @@ entry:
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = load i32, i32* %arg1
   %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
   %7 = load i64, i64 addrspace(1)* %5
@@ -12129,7 +13838,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12166,8 +13875,8 @@ entry:
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
   %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
   %16 = load i64, i64 addrspace(1)* %14
@@ -12188,8 +13897,8 @@ entry:
   %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
   %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
   %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %31, null
-  br i1 %NullCheck2, label %32, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = load i64, i64 addrspace(1)* %31
@@ -12232,7 +13941,7 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12245,14 +13954,14 @@ entry:
   %this = alloca %System.Text.EncoderReplacementFallback addrspace(1)*
   store %System.Text.EncoderReplacementFallback addrspace(1)* %param0, %System.Text.EncoderReplacementFallback addrspace(1)** %this
   %0 = load %System.Text.EncoderReplacementFallback addrspace(1)*, %System.Text.EncoderReplacementFallback addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -12263,7 +13972,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12293,8 +14002,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
@@ -12326,8 +14035,8 @@ entry:
   %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
   store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
@@ -12339,8 +14048,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Threading.Tasks.Task addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %7)
@@ -12363,7 +14072,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12382,8 +14091,8 @@ entry:
   store i8 %param1, i8* %arg1
   store i8 %param2, i8* %arg2
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
@@ -12397,8 +14106,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1, %5
   %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 9
@@ -12429,8 +14138,8 @@ entry:
 
 ; <label>:25                                      ; preds = %8, %20
   %26 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %26, null
-  br i1 %NullCheck4, label %27, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %26, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %26, i32 0, i32 12
@@ -12441,22 +14150,22 @@ entry:
 
 ; <label>:32                                      ; preds = %27
   %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %33, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.IO.StreamWriter addrspace(1)* %33, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %32
   %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 12
   store i8 1, i8 addrspace(1)* %35
   %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
-  br i1 %NullCheck8, label %37, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
   %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
   %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck10 = icmp ne i64 addrspace(1)* %40, null
-  br i1 %NullCheck10, label %41, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64 addrspace(1)* %40, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i64, i64 addrspace(1)* %40
@@ -12470,8 +14179,8 @@ entry:
   %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
   store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
   %51 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %NullCheck12 = icmp ne %"System.Byte[]" addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Byte[]" addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %41
   %53 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %51, i32 0, i32 1
@@ -12483,16 +14192,16 @@ entry:
 
 ; <label>:58                                      ; preds = %52
   %59 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %59, null
-  br i1 %NullCheck14, label %60, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.IO.StreamWriter addrspace(1)* %59, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %60
 
 ; <label>:60                                      ; preds = %58
   %61 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %59, i32 0, i32 3
   %62 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
   %64 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %NullCheck16 = icmp ne %"System.Byte[]" addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %"System.Byte[]" addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %60
   %66 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %64, i32 0, i32 1
@@ -12500,8 +14209,8 @@ entry:
   %68 = zext i32 %67 to i64
   %69 = trunc i64 %68 to i32
   %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck18, label %71, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
   %72 = load i64, i64 addrspace(1)* %70
@@ -12517,29 +14226,29 @@ entry:
 
 ; <label>:80                                      ; preds = %27, %52, %71
   %81 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %81, null
-  br i1 %NullCheck20, label %82, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.IO.StreamWriter addrspace(1)* %81, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
 
 ; <label>:82                                      ; preds = %80
   %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %81, i32 0, i32 5
   %84 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %83, align 8
   %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.IO.StreamWriter addrspace(1)* %85, null
-  br i1 %NullCheck22, label %86, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.IO.StreamWriter addrspace(1)* %85, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %86
 
 ; <label>:86                                      ; preds = %82
   %87 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 7
   %88 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %87, align 8
   %89 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %89, null
-  br i1 %NullCheck24, label %90, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.StreamWriter addrspace(1)* %89, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %90
 
 ; <label>:90                                      ; preds = %86
   %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %89, i32 0, i32 9
   %92 = load i32, i32 addrspace(1)* %91, align 8
   %93 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.IO.StreamWriter addrspace(1)* %93, null
-  br i1 %NullCheck26, label %94, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.IO.StreamWriter addrspace(1)* %93, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %93, i32 0, i32 6
@@ -12547,8 +14256,8 @@ entry:
   %97 = load i8, i8* %arg2
   %98 = zext i8 %97 to i32
   %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
-  %NullCheck28 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck28, label %100, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
   %101 = load i64, i64 addrspace(1)* %99
@@ -12563,8 +14272,8 @@ entry:
   %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
   store i32 %110, i32* %loc1
   %111 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %111, null
-  br i1 %NullCheck30, label %112, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.IO.StreamWriter addrspace(1)* %111, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %112
 
 ; <label>:112                                     ; preds = %100
   %113 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %111, i32 0, i32 9
@@ -12575,23 +14284,23 @@ entry:
 
 ; <label>:116                                     ; preds = %112
   %117 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck32 = icmp ne %System.IO.StreamWriter addrspace(1)* %117, null
-  br i1 %NullCheck32, label %118, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.IO.StreamWriter addrspace(1)* %117, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %118
 
 ; <label>:118                                     ; preds = %116
   %119 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %117, i32 0, i32 3
   %120 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %119, align 8
   %121 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.IO.StreamWriter addrspace(1)* %121, null
-  br i1 %NullCheck34, label %122, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.IO.StreamWriter addrspace(1)* %121, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %122
 
 ; <label>:122                                     ; preds = %118
   %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
   %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
   %125 = load i32, i32* %loc1
   %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
-  %NullCheck36 = icmp ne i64 addrspace(1)* %126, null
-  br i1 %NullCheck36, label %127, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64 addrspace(1)* %126, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
   %128 = load i64, i64 addrspace(1)* %126
@@ -12613,15 +14322,15 @@ entry:
 
 ; <label>:140                                     ; preds = %136
   %141 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.IO.StreamWriter addrspace(1)* %141, null
-  br i1 %NullCheck38, label %142, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.IO.StreamWriter addrspace(1)* %141, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %142
 
 ; <label>:142                                     ; preds = %140
   %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
   %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
   %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
-  %NullCheck40 = icmp ne i64 addrspace(1)* %145, null
-  br i1 %NullCheck40, label %146, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i64 addrspace(1)* %145, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
   %147 = load i64, i64 addrspace(1)* %145
@@ -12642,83 +14351,83 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %25
+ThrowNullRef4:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %32
+ThrowNullRef6:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %37
+ThrowNullRef10:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %41
+ThrowNullRef12:                                   ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %58
+ThrowNullRef14:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %60
+ThrowNullRef16:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %65
+ThrowNullRef18:                                   ; preds = %65
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %80
+ThrowNullRef20:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %82
+ThrowNullRef22:                                   ; preds = %82
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %86
+ThrowNullRef24:                                   ; preds = %86
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %90
+ThrowNullRef26:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %94
+ThrowNullRef28:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %100
+ThrowNullRef30:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %116
+ThrowNullRef32:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %118
+ThrowNullRef34:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %122
+ThrowNullRef36:                                   ; preds = %122
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %140
+ThrowNullRef38:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %142
+ThrowNullRef40:                                   ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12785,8 +14494,8 @@ entry:
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %1 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
-  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
@@ -12794,8 +14503,8 @@ entry:
   %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
   %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
   %8 = load i64, i64 addrspace(1)* %6
@@ -12811,8 +14520,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %17, %System.IFormatProvider addrspace(1)* %16)
   %18 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %19 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %18, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.SyncTextWriter addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %7
   %21 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %18, i32 0, i32 4
@@ -12823,11 +14532,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12840,8 +14549,8 @@ entry:
   %this = alloca %System.IO.TextWriter addrspace(1)*
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.TextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
@@ -12851,8 +14560,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.Threading.Thread addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Threading.Thread addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %6)
@@ -12861,8 +14570,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1
   %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.TextWriter addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.TextWriter addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %11, i32 0, i32 2
@@ -12873,11 +14582,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13074,8 +14783,8 @@ entry:
   store double %param1, double* %arg1
   store i8 0, i8* %loc1
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
@@ -13085,16 +14794,16 @@ entry:
   %5 = addrspacecast i8* %loc1 to i8 addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %4, i8 addrspace(1)* %5)
   %6 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.SyncTextWriter addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
   %10 = load double, double* %arg1
   %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
   %13 = load i64, i64 addrspace(1)* %11
@@ -13129,11 +14838,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13150,8 +14859,8 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load double, double* %arg1
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -13165,8 +14874,8 @@ entry:
   call void %11(%System.IO.TextWriter addrspace(1)* %0, double %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
   %15 = load i64, i64 addrspace(1)* %13
@@ -13184,7 +14893,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13202,8 +14911,8 @@ entry:
   %1 = addrspacecast double* %arg1 to double addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -13218,8 +14927,8 @@ entry:
   %14 = bitcast double addrspace(1)* %1 to %System.Double addrspace(1)*
   %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Double addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Double addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
   %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
   %18 = load i64, i64 addrspace(1)* %16
@@ -13237,7 +14946,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13253,8 +14962,8 @@ entry:
   store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
   %0 = load %System.Double addrspace(1)*, %System.Double addrspace(1)** %this
   %1 = bitcast %System.Double addrspace(1)* %0 to double addrspace(1)*
-  %NullCheck = icmp ne double addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq double addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load double, double addrspace(1)* %1, align 8
@@ -13279,8 +14988,8 @@ entry:
   %loc0 = alloca %System.Globalization.NumberFormatInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 3
@@ -13290,8 +14999,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
@@ -13301,24 +15010,24 @@ entry:
   store %System.Globalization.NumberFormatInfo addrspace(1)* %10, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
   %11 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %7
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
   %15 = load i8, i8 addrspace(1)* %14, align 8
   %16 = zext i8 %15 to i32
   %17 = trunc i32 %16 to i8
-  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %11, null
-  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %11, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %13
   %19 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %11, i32 0, i32 29
   store i8 %17, i8 addrspace(1)* %19
   %20 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %21 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %20, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %20, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %18
   %23 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %20, i32 0, i32 3
@@ -13327,8 +15036,8 @@ entry:
 
 ; <label>:24                                      ; preds = %1, %22
   %25 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %25, null
-  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %25, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %26
 
 ; <label>:26                                      ; preds = %24
   %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %25, i32 0, i32 3
@@ -13339,23 +15048,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %18
+ThrowNullRef8:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13380,168 +15089,168 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 18
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %8, align 8
-  %NullCheck2 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %5, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %5, i32 0, i32 4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %9)
   %12 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 19
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %15, align 8
-  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %12, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %12, i32 0, i32 5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %16)
   %19 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %20 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %20, null
-  br i1 %NullCheck8, label %21, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %20, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %20, i32 0, i32 23
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  %NullCheck10 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %19, null
-  br i1 %NullCheck10, label %24, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %19, i32 0, i32 7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %25, %System.String addrspace(1)* %23)
   %26 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %27 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %27, i32 0, i32 22
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %29, align 8
-  %NullCheck14 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %26, null
-  br i1 %NullCheck14, label %31, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %26, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %26, i32 0, i32 6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %32, %System.String addrspace(1)* %30)
   %33 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %34 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Globalization.CultureData addrspace(1)* %34, null
-  br i1 %NullCheck16, label %35, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Globalization.CultureData addrspace(1)* %34, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %34, i32 0, i32 51
   %37 = load i32, i32 addrspace(1)* %36, align 8
-  %NullCheck18 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %33, null
-  br i1 %NullCheck18, label %38, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %33, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %33, i32 0, i32 21
   store i32 %37, i32 addrspace(1)* %39
   %40 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %41 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Globalization.CultureData addrspace(1)* %41, null
-  br i1 %NullCheck20, label %42, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Globalization.CultureData addrspace(1)* %41, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %41, i32 0, i32 52
   %44 = load i32, i32 addrspace(1)* %43, align 8
-  %NullCheck22 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %40, null
-  br i1 %NullCheck22, label %45, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %40, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %40, i32 0, i32 25
   store i32 %44, i32 addrspace(1)* %46
   %47 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %48 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.Globalization.CultureData addrspace(1)* %48, null
-  br i1 %NullCheck24, label %49, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Globalization.CultureData addrspace(1)* %48, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %49
 
 ; <label>:49                                      ; preds = %45
   %50 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %48, i32 0, i32 29
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck26 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %47, null
-  br i1 %NullCheck26, label %52, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %47, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %47, i32 0, i32 10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %53, %System.String addrspace(1)* %51)
   %54 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %55 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Globalization.CultureData addrspace(1)* %55, null
-  br i1 %NullCheck28, label %56, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Globalization.CultureData addrspace(1)* %55, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %56
 
 ; <label>:56                                      ; preds = %52
   %57 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %55, i32 0, i32 35
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %57, align 8
-  %NullCheck30 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %54, null
-  br i1 %NullCheck30, label %59, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %54, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %54, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %60, %System.String addrspace(1)* %58)
   %61 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %62 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck32 = icmp ne %System.Globalization.CultureData addrspace(1)* %62, null
-  br i1 %NullCheck32, label %63, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Globalization.CultureData addrspace(1)* %62, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %62, i32 0, i32 34
   %65 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %64, align 8
-  %NullCheck34 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %61, null
-  br i1 %NullCheck34, label %66, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %61, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %61, i32 0, i32 9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %67, %System.String addrspace(1)* %65)
   %68 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %69 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck36 = icmp ne %System.Globalization.CultureData addrspace(1)* %69, null
-  br i1 %NullCheck36, label %70, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Globalization.CultureData addrspace(1)* %69, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %70
 
 ; <label>:70                                      ; preds = %66
   %71 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %69, i32 0, i32 55
   %72 = load i32, i32 addrspace(1)* %71, align 8
-  %NullCheck38 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %68, null
-  br i1 %NullCheck38, label %73, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %68, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %68, i32 0, i32 22
   store i32 %72, i32 addrspace(1)* %74
   %75 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %76 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck40 = icmp ne %System.Globalization.CultureData addrspace(1)* %76, null
-  br i1 %NullCheck40, label %77, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Globalization.CultureData addrspace(1)* %76, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %76, i32 0, i32 57
   %79 = load i32, i32 addrspace(1)* %78, align 8
-  %NullCheck42 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %75, null
-  br i1 %NullCheck42, label %80, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %75, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %80
 
 ; <label>:80                                      ; preds = %77
   %81 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %75, i32 0, i32 24
   store i32 %79, i32 addrspace(1)* %81
   %82 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %83 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck44 = icmp ne %System.Globalization.CultureData addrspace(1)* %83, null
-  br i1 %NullCheck44, label %84, label %ThrowNullRef43
+  %NullCheck43 = icmp eq %System.Globalization.CultureData addrspace(1)* %83, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %84
 
 ; <label>:84                                      ; preds = %80
   %85 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %83, i32 0, i32 56
   %86 = load i32, i32 addrspace(1)* %85, align 8
-  %NullCheck46 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %82, null
-  br i1 %NullCheck46, label %87, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %82, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %82, i32 0, i32 23
@@ -13550,8 +15259,8 @@ entry:
 
 ; <label>:89                                      ; preds = %entry
   %90 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck100 = icmp ne %System.Globalization.CultureData addrspace(1)* %90, null
-  br i1 %NullCheck100, label %91, label %ThrowNullRef99
+  %NullCheck99 = icmp eq %System.Globalization.CultureData addrspace(1)* %90, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %91
 
 ; <label>:91                                      ; preds = %89
   %92 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %90, i32 0, i32 2
@@ -13569,8 +15278,8 @@ entry:
   %102 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %103 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %104 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %103)
-  %NullCheck48 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %102, null
-  br i1 %NullCheck48, label %105, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %102, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %105
 
 ; <label>:105                                     ; preds = %101
   %106 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %102, i32 0, i32 1
@@ -13578,8 +15287,8 @@ entry:
   %107 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %108 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %109 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %108)
-  %NullCheck50 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %107, null
-  br i1 %NullCheck50, label %110, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %107, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %110
 
 ; <label>:110                                     ; preds = %105
   %111 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %107, i32 0, i32 2
@@ -13587,8 +15296,8 @@ entry:
   %112 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %113 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %114 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %113)
-  %NullCheck52 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %112, null
-  br i1 %NullCheck52, label %115, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %112, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %115
 
 ; <label>:115                                     ; preds = %110
   %116 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %112, i32 0, i32 27
@@ -13596,8 +15305,8 @@ entry:
   %117 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %118 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %119 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %118)
-  %NullCheck54 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %117, null
-  br i1 %NullCheck54, label %120, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %117, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %120
 
 ; <label>:120                                     ; preds = %115
   %121 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %117, i32 0, i32 26
@@ -13605,8 +15314,8 @@ entry:
   %122 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %123 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %124 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %123)
-  %NullCheck56 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %122, null
-  br i1 %NullCheck56, label %125, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %122, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %125
 
 ; <label>:125                                     ; preds = %120
   %126 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %122, i32 0, i32 17
@@ -13614,8 +15323,8 @@ entry:
   %127 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %128 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %129 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %128)
-  %NullCheck58 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %127, null
-  br i1 %NullCheck58, label %130, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %127, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %130
 
 ; <label>:130                                     ; preds = %125
   %131 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %127, i32 0, i32 18
@@ -13623,8 +15332,8 @@ entry:
   %132 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %133 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %134 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %133)
-  %NullCheck60 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %132, null
-  br i1 %NullCheck60, label %135, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %132, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %135
 
 ; <label>:135                                     ; preds = %130
   %136 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %132, i32 0, i32 14
@@ -13632,8 +15341,8 @@ entry:
   %137 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %138 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %139 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %138)
-  %NullCheck62 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %137, null
-  br i1 %NullCheck62, label %140, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %137, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %140
 
 ; <label>:140                                     ; preds = %135
   %141 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %137, i32 0, i32 13
@@ -13641,71 +15350,71 @@ entry:
   %142 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %143 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %144 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %143)
-  %NullCheck64 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %142, null
-  br i1 %NullCheck64, label %145, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %142, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %145
 
 ; <label>:145                                     ; preds = %140
   %146 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %142, i32 0, i32 12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %146, %System.String addrspace(1)* %144)
   %147 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %148 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck66 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %148, null
-  br i1 %NullCheck66, label %149, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %148, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %149
 
 ; <label>:149                                     ; preds = %145
   %150 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %148, i32 0, i32 21
   %151 = load i32, i32 addrspace(1)* %150, align 8
-  %NullCheck68 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %147, null
-  br i1 %NullCheck68, label %152, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %147, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %152
 
 ; <label>:152                                     ; preds = %149
   %153 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %147, i32 0, i32 28
   store i32 %151, i32 addrspace(1)* %153
   %154 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %155 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck70 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %155, null
-  br i1 %NullCheck70, label %156, label %ThrowNullRef69
+  %NullCheck69 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %155, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %156
 
 ; <label>:156                                     ; preds = %152
   %157 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %155, i32 0, i32 6
   %158 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %157, align 8
-  %NullCheck72 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %154, null
-  br i1 %NullCheck72, label %159, label %ThrowNullRef71
+  %NullCheck71 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %154, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %159
 
 ; <label>:159                                     ; preds = %156
   %160 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %154, i32 0, i32 15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %160, %System.String addrspace(1)* %158)
   %161 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %162 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck74 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %162, null
-  br i1 %NullCheck74, label %163, label %ThrowNullRef73
+  %NullCheck73 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %162, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %163
 
 ; <label>:163                                     ; preds = %159
   %164 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %162, i32 0, i32 1
   %165 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %164, align 8
-  %NullCheck76 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %161, null
-  br i1 %NullCheck76, label %166, label %ThrowNullRef75
+  %NullCheck75 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %161, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %166
 
 ; <label>:166                                     ; preds = %163
   %167 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %161, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %167, %"System.Int32[]" addrspace(1)* %165)
   %168 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %169 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck78 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %169, null
-  br i1 %NullCheck78, label %170, label %ThrowNullRef77
+  %NullCheck77 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %169, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %170
 
 ; <label>:170                                     ; preds = %166
   %171 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %169, i32 0, i32 7
   %172 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %171, align 8
-  %NullCheck80 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %168, null
-  br i1 %NullCheck80, label %173, label %ThrowNullRef79
+  %NullCheck79 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %168, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %173
 
 ; <label>:173                                     ; preds = %170
   %174 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %168, i32 0, i32 16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %174, %System.String addrspace(1)* %172)
   %175 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck82 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %175, null
-  br i1 %NullCheck82, label %176, label %ThrowNullRef81
+  %NullCheck81 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %175, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %176
 
 ; <label>:176                                     ; preds = %173
   %177 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %175, i32 0, i32 4
@@ -13715,14 +15424,14 @@ entry:
 
 ; <label>:180                                     ; preds = %176
   %181 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck84 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %181, null
-  br i1 %NullCheck84, label %182, label %ThrowNullRef83
+  %NullCheck83 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %181, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %182
 
 ; <label>:182                                     ; preds = %180
   %183 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %181, i32 0, i32 4
   %184 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %183, align 8
-  %NullCheck86 = icmp ne %System.String addrspace(1)* %184, null
-  br i1 %NullCheck86, label %185, label %ThrowNullRef85
+  %NullCheck85 = icmp eq %System.String addrspace(1)* %184, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %185
 
 ; <label>:185                                     ; preds = %182
   %186 = getelementptr inbounds %System.String, %System.String addrspace(1)* %184, i32 0, i32 1
@@ -13733,8 +15442,8 @@ entry:
 ; <label>:189                                     ; preds = %176, %185
   %190 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck98 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %190, null
-  br i1 %NullCheck98, label %192, label %ThrowNullRef97
+  %NullCheck97 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %190, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %192
 
 ; <label>:192                                     ; preds = %189
   %193 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %190, i32 0, i32 4
@@ -13743,8 +15452,8 @@ entry:
 
 ; <label>:194                                     ; preds = %185, %192
   %195 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck88 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %195, null
-  br i1 %NullCheck88, label %196, label %ThrowNullRef87
+  %NullCheck87 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %195, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %196
 
 ; <label>:196                                     ; preds = %194
   %197 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %195, i32 0, i32 9
@@ -13754,14 +15463,14 @@ entry:
 
 ; <label>:200                                     ; preds = %196
   %201 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck90 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %201, null
-  br i1 %NullCheck90, label %202, label %ThrowNullRef89
+  %NullCheck89 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %201, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %202
 
 ; <label>:202                                     ; preds = %200
   %203 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %201, i32 0, i32 9
   %204 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %203, align 8
-  %NullCheck92 = icmp ne %System.String addrspace(1)* %204, null
-  br i1 %NullCheck92, label %205, label %ThrowNullRef91
+  %NullCheck91 = icmp eq %System.String addrspace(1)* %204, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %205
 
 ; <label>:205                                     ; preds = %202
   %206 = getelementptr inbounds %System.String, %System.String addrspace(1)* %204, i32 0, i32 1
@@ -13772,14 +15481,14 @@ entry:
 ; <label>:209                                     ; preds = %196, %205
   %210 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %211 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck94 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %211, null
-  br i1 %NullCheck94, label %212, label %ThrowNullRef93
+  %NullCheck93 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %211, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %212
 
 ; <label>:212                                     ; preds = %209
   %213 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %211, i32 0, i32 6
   %214 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %213, align 8
-  %NullCheck96 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %210, null
-  br i1 %NullCheck96, label %215, label %ThrowNullRef95
+  %NullCheck95 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %210, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %215
 
 ; <label>:215                                     ; preds = %212
   %216 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %210, i32 0, i32 9
@@ -13793,203 +15502,203 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %17
+ThrowNullRef8:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %21
+ThrowNullRef10:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %24
+ThrowNullRef12:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %28
+ThrowNullRef14:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %31
+ThrowNullRef16:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %35
+ThrowNullRef18:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %38
+ThrowNullRef20:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %42
+ThrowNullRef22:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %45
+ThrowNullRef24:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %49
+ThrowNullRef26:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %52
+ThrowNullRef28:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %56
+ThrowNullRef30:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %59
+ThrowNullRef32:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %63
+ThrowNullRef34:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %66
+ThrowNullRef36:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %70
+ThrowNullRef38:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %73
+ThrowNullRef40:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %77
+ThrowNullRef42:                                   ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %80
+ThrowNullRef44:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %84
+ThrowNullRef46:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %101
+ThrowNullRef48:                                   ; preds = %101
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %105
+ThrowNullRef50:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %110
+ThrowNullRef52:                                   ; preds = %110
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %115
+ThrowNullRef54:                                   ; preds = %115
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %120
+ThrowNullRef56:                                   ; preds = %120
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %125
+ThrowNullRef58:                                   ; preds = %125
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %130
+ThrowNullRef60:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %135
+ThrowNullRef62:                                   ; preds = %135
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %140
+ThrowNullRef64:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %145
+ThrowNullRef66:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %149
+ThrowNullRef68:                                   ; preds = %149
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %152
+ThrowNullRef70:                                   ; preds = %152
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %156
+ThrowNullRef72:                                   ; preds = %156
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %159
+ThrowNullRef74:                                   ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %163
+ThrowNullRef76:                                   ; preds = %163
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %166
+ThrowNullRef78:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %170
+ThrowNullRef80:                                   ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %173
+ThrowNullRef82:                                   ; preds = %173
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %180
+ThrowNullRef84:                                   ; preds = %180
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %182
+ThrowNullRef86:                                   ; preds = %182
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %194
+ThrowNullRef88:                                   ; preds = %194
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %200
+ThrowNullRef90:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %202
+ThrowNullRef92:                                   ; preds = %202
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %209
+ThrowNullRef94:                                   ; preds = %209
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %212
+ThrowNullRef96:                                   ; preds = %212
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %189
+ThrowNullRef98:                                   ; preds = %189
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %89
+ThrowNullRef100:                                  ; preds = %89
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14017,8 +15726,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 21
@@ -14031,8 +15740,8 @@ entry:
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 16)
   %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 21
@@ -14041,8 +15750,8 @@ entry:
 
 ; <label>:12                                      ; preds = %1, %10
   %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 21
@@ -14053,11 +15762,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %12
+ThrowNullRef4:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14073,8 +15782,8 @@ entry:
   store i32 %param1, i32* %arg1
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %1 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
@@ -14141,8 +15850,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 33
@@ -14155,8 +15864,8 @@ entry:
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 24)
   %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 33
@@ -14165,8 +15874,8 @@ entry:
 
 ; <label>:12                                      ; preds = %1, %10
   %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 33
@@ -14177,11 +15886,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %12
+ThrowNullRef4:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14194,8 +15903,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 53
@@ -14207,8 +15916,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 116)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 53
@@ -14217,8 +15926,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 53
@@ -14229,11 +15938,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14262,8 +15971,8 @@ entry:
 
 ; <label>:7                                       ; preds = %entry, %4
   %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %7
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 2
@@ -14287,8 +15996,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 54
@@ -14300,8 +16009,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 117)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
@@ -14310,8 +16019,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 54
@@ -14322,11 +16031,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14339,8 +16048,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 27
@@ -14352,8 +16061,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 118)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 27
@@ -14362,8 +16071,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 27
@@ -14374,11 +16083,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14391,8 +16100,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 28
@@ -14404,8 +16113,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 119)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 28
@@ -14414,8 +16123,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 28
@@ -14426,11 +16135,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14443,8 +16152,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 26
@@ -14456,8 +16165,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 107)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 26
@@ -14466,8 +16175,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 26
@@ -14478,11 +16187,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14495,8 +16204,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 25
@@ -14508,8 +16217,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 106)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 25
@@ -14518,8 +16227,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 25
@@ -14530,11 +16239,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14547,8 +16256,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 24
@@ -14560,8 +16269,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 105)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 24
@@ -14570,8 +16279,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 24
@@ -14582,11 +16291,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14611,8 +16320,8 @@ entry:
   %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %3)
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %2
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -14623,15 +16332,15 @@ entry:
 
 ; <label>:8                                       ; preds = %62
   %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 9
   %12 = load i32, i32 addrspace(1)* %11, align 8
   %13 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.IO.StreamWriter addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %13, i32 0, i32 10
@@ -14646,15 +16355,15 @@ entry:
 
 ; <label>:20                                      ; preds = %14, %18
   %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
   %24 = load i32, i32 addrspace(1)* %23, align 8
   %25 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %25, null
-  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.StreamWriter addrspace(1)* %25, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %25, i32 0, i32 9
@@ -14675,36 +16384,36 @@ entry:
   %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %37 = load i32, i32* %loc1
   %38 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.StreamWriter addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %35
   %40 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %38, i32 0, i32 7
   %41 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %40, align 8
   %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
-  br i1 %NullCheck14, label %43, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %39
   %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 9
   %45 = load i32, i32 addrspace(1)* %44, align 8
   %46 = load i32, i32* %loc2
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %36, null
-  br i1 %NullCheck16, label %47, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %36, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %47
 
 ; <label>:47                                      ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %36, i32 %37, %"System.Char[]" addrspace(1)* %41, i32 %45, i32 %46)
   %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
   %51 = load i32, i32 addrspace(1)* %50, align 8
   %52 = load i32, i32* %loc2
   %53 = add i32 %51, %52
-  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
-  br i1 %NullCheck20, label %54, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %54
 
 ; <label>:54                                      ; preds = %49
   %55 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
@@ -14726,8 +16435,8 @@ entry:
 
 ; <label>:65                                      ; preds = %62
   %66 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %66, null
-  br i1 %NullCheck2, label %67, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %66, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %67
 
 ; <label>:67                                      ; preds = %65
   %68 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %66, i32 0, i32 11
@@ -14748,49 +16457,259 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %65
+ThrowNullRef2:                                    ; preds = %65
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %20
+ThrowNullRef8:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %22
+ThrowNullRef10:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %35
+ThrowNullRef12:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %43
+ThrowNullRef16:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %47
+ThrowNullRef18:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method String::CopyTo using LLILCJit
-Failed to read String.CopyTo[loadElemA]
+Successfully read String.CopyTo
+
+define void @String.CopyTo(%System.String addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  %loc1 = alloca i16 addrspace(1)*
+  %loc2 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %1 = icmp ne %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg4
+  %7 = icmp sge i32 %6, 0
+  br i1 %7, label %13, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  unreachable
+
+; <label>:13                                      ; preds = %5
+  %14 = load i32, i32* %arg1
+  %15 = icmp sge i32 %14, 0
+  br i1 %15, label %21, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %18)
+  %20 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %20, %System.String addrspace(1)* %17, %System.String addrspace(1)* %19)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %20) #0
+  unreachable
+
+; <label>:21                                      ; preds = %13
+  %22 = load i32, i32* %arg4
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck, label %ThrowNullRef, label %24
+
+; <label>:24                                      ; preds = %21
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load i32, i32* %arg1
+  %28 = sub i32 %26, %27
+  %29 = icmp sle i32 %22, %28
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34, %System.String addrspace(1)* %31, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %24
+  %36 = load i32, i32* %arg3
+  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %37, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
+
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
+  %40 = load i32, i32 addrspace(1)* %39
+  %41 = zext i32 %40 to i64
+  %42 = trunc i64 %41 to i32
+  %43 = load i32, i32* %arg4
+  %44 = sub i32 %42, %43
+  %45 = icmp sgt i32 %36, %44
+  br i1 %45, label %49, label %46
+
+; <label>:46                                      ; preds = %38
+  %47 = load i32, i32* %arg3
+  %48 = icmp sge i32 %47, 0
+  br i1 %48, label %54, label %49
+
+; <label>:49                                      ; preds = %38, %46
+  %50 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %52 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %51)
+  %53 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53, %System.String addrspace(1)* %50, %System.String addrspace(1)* %52)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53) #0
+  unreachable
+
+; <label>:54                                      ; preds = %46
+  %55 = load i32, i32* %arg4
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %97, label %57
+
+; <label>:57                                      ; preds = %54
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %59
+
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 2
+  %61 = bitcast [0 x i16] addrspace(1)* %60 to i16 addrspace(1)*
+  store i16 addrspace(1)* %61, i16 addrspace(1)** %loc0
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  store %"System.Char[]" addrspace(1)* %62, %"System.Char[]" addrspace(1)** %loc2
+  %63 = icmp eq %"System.Char[]" addrspace(1)* %62, null
+  br i1 %63, label %72, label %64
+
+; <label>:64                                      ; preds = %59
+  %65 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc2
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %65, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %66
+
+; <label>:66                                      ; preds = %64
+  %67 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %65, i32 0, i32 1
+  %68 = load i32, i32 addrspace(1)* %67
+  %69 = zext i32 %68 to i64
+  %70 = trunc i64 %69 to i32
+  %71 = icmp ne i32 %70, 0
+  br i1 %71, label %73, label %72
+
+; <label>:72                                      ; preds = %59, %66
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  br label %81
+
+; <label>:73                                      ; preds = %66
+  %74 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc2
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %74, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %75
+
+; <label>:75                                      ; preds = %73
+  %76 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %74, i32 0, i32 1
+  %77 = load i32, i32 addrspace(1)* %76
+  %78 = zext i32 %77 to i64
+  %BoundsCheck = icmp uge i64 0, %78
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %79
+
+; <label>:79                                      ; preds = %75
+  %80 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %74, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %80, i16 addrspace(1)** %loc1
+  br label %81
+
+; <label>:81                                      ; preds = %72, %79
+  %82 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %83 = ptrtoint i16 addrspace(1)* %82 to i64
+  %84 = load i32, i32* %arg3
+  %85 = sext i32 %84 to i64
+  %86 = mul i64 %85, 2
+  %87 = add i64 %83, %86
+  %88 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %89 = ptrtoint i16 addrspace(1)* %88 to i64
+  %90 = load i32, i32* %arg1
+  %91 = sext i32 %90 to i64
+  %92 = mul i64 %91, 2
+  %93 = add i64 %89, %92
+  %94 = load i32, i32* %arg4
+  %95 = inttoptr i64 %87 to i16*
+  %96 = inttoptr i64 %93 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %95, i16* %96, i32 %94)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  br label %97
+
+; <label>:97                                      ; preds = %54, %81
+  ret void
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
 Successfully read ConsoleEncoding.GetPreamble
 
@@ -14827,7 +16746,365 @@ entry:
 }
 
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[loadElemA]
+Successfully read EncoderNLS.GetBytes
+
+define i32 @EncoderNLS.GetBytes(%System.Text.EncoderNLS addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3, %"System.Byte[]" addrspace(1)* %param4, i32 %param5, i8 %param6) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %arg4 = alloca %"System.Byte[]" addrspace(1)*
+  %arg5 = alloca i32
+  %arg6 = alloca i8
+  %loc0 = alloca i32
+  %loc1 = alloca i16 addrspace(1)*
+  %loc2 = alloca i8 addrspace(1)*
+  %loc3 = alloca i32
+  %loc4 = alloca %"System.Char[]" addrspace(1)*
+  %loc5 = alloca %"System.Byte[]" addrspace(1)*
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  store %"System.Byte[]" addrspace(1)* %param4, %"System.Byte[]" addrspace(1)** %arg4
+  store i32 %param5, i32* %arg5
+  store i8 %param6, i8* %arg6
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %1 = icmp eq %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %17, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %7 = icmp eq %"System.Char[]" addrspace(1)* %6, null
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %12
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %12
+
+; <label>:12                                      ; preds = %8, %10
+  %13 = phi %System.String addrspace(1)* [ %9, %8 ], [ %11, %10 ]
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %14)
+  %16 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16, %System.String addrspace(1)* %13, %System.String addrspace(1)* %15)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16) #0
+  unreachable
+
+; <label>:17                                      ; preds = %2
+  %18 = load i32, i32* %arg2
+  %19 = icmp slt i32 %18, 0
+  br i1 %19, label %23, label %20
+
+; <label>:20                                      ; preds = %17
+  %21 = load i32, i32* %arg3
+  %22 = icmp sge i32 %21, 0
+  br i1 %22, label %35, label %23
+
+; <label>:23                                      ; preds = %17, %20
+  %24 = load i32, i32* %arg2
+  %25 = icmp slt i32 %24, 0
+  br i1 %25, label %28, label %26
+
+; <label>:26                                      ; preds = %23
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %30
+
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %30
+
+; <label>:30                                      ; preds = %26, %28
+  %31 = phi %System.String addrspace(1)* [ %27, %26 ], [ %29, %28 ]
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34, %System.String addrspace(1)* %31, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %20
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck, label %ThrowNullRef, label %37
+
+; <label>:37                                      ; preds = %35
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = load i32, i32* %arg2
+  %43 = sub i32 %41, %42
+  %44 = load i32, i32* %arg3
+  %45 = icmp sge i32 %43, %44
+  br i1 %45, label %51, label %46
+
+; <label>:46                                      ; preds = %37
+  %47 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %48 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %49 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %48)
+  %50 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %50, %System.String addrspace(1)* %47, %System.String addrspace(1)* %49)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %50) #0
+  unreachable
+
+; <label>:51                                      ; preds = %37
+  %52 = load i32, i32* %arg5
+  %53 = icmp slt i32 %52, 0
+  br i1 %53, label %63, label %54
+
+; <label>:54                                      ; preds = %51
+  %55 = load i32, i32* %arg5
+  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck1 = icmp eq %"System.Byte[]" addrspace(1)* %56, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %57
+
+; <label>:57                                      ; preds = %54
+  %58 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = zext i32 %59 to i64
+  %61 = trunc i64 %60 to i32
+  %62 = icmp sle i32 %55, %61
+  br i1 %62, label %68, label %63
+
+; <label>:63                                      ; preds = %51, %57
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %66 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %65)
+  %67 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %67, %System.String addrspace(1)* %64, %System.String addrspace(1)* %66)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %67) #0
+  unreachable
+
+; <label>:68                                      ; preds = %57
+  %69 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %69, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %69, i32 0, i32 1
+  %72 = load i32, i32 addrspace(1)* %71
+  %73 = zext i32 %72 to i64
+  %74 = trunc i64 %73 to i32
+  %75 = icmp ne i32 %74, 0
+  br i1 %75, label %78, label %76
+
+; <label>:76                                      ; preds = %70
+  %77 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1)
+  store %"System.Char[]" addrspace(1)* %77, %"System.Char[]" addrspace(1)** %arg1
+  br label %78
+
+; <label>:78                                      ; preds = %70, %76
+  %79 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck5 = icmp eq %"System.Byte[]" addrspace(1)* %79, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %80
+
+; <label>:80                                      ; preds = %78
+  %81 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %79, i32 0, i32 1
+  %82 = load i32, i32 addrspace(1)* %81
+  %83 = zext i32 %82 to i64
+  %84 = trunc i64 %83 to i32
+  %85 = load i32, i32* %arg5
+  %86 = sub i32 %84, %85
+  store i32 %86, i32* %loc0
+  %87 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck7 = icmp eq %"System.Byte[]" addrspace(1)* %87, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %88
+
+; <label>:88                                      ; preds = %80
+  %89 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %87, i32 0, i32 1
+  %90 = load i32, i32 addrspace(1)* %89
+  %91 = zext i32 %90 to i64
+  %92 = trunc i64 %91 to i32
+  %93 = icmp ne i32 %92, 0
+  br i1 %93, label %96, label %94
+
+; <label>:94                                      ; preds = %88
+  %95 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1)
+  store %"System.Byte[]" addrspace(1)* %95, %"System.Byte[]" addrspace(1)** %arg4
+  br label %96
+
+; <label>:96                                      ; preds = %88, %94
+  %97 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  store %"System.Char[]" addrspace(1)* %97, %"System.Char[]" addrspace(1)** %loc4
+  %98 = icmp eq %"System.Char[]" addrspace(1)* %97, null
+  br i1 %98, label %107, label %99
+
+; <label>:99                                      ; preds = %96
+  %100 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc4
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %100, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %101
+
+; <label>:101                                     ; preds = %99
+  %102 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %100, i32 0, i32 1
+  %103 = load i32, i32 addrspace(1)* %102
+  %104 = zext i32 %103 to i64
+  %105 = trunc i64 %104 to i32
+  %106 = icmp ne i32 %105, 0
+  br i1 %106, label %108, label %107
+
+; <label>:107                                     ; preds = %96, %101
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  br label %116
+
+; <label>:108                                     ; preds = %101
+  %109 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc4
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %109, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %110
+
+; <label>:110                                     ; preds = %108
+  %111 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %109, i32 0, i32 1
+  %112 = load i32, i32 addrspace(1)* %111
+  %113 = zext i32 %112 to i64
+  %BoundsCheck = icmp uge i64 0, %113
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %114
+
+; <label>:114                                     ; preds = %110
+  %115 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %109, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %115, i16 addrspace(1)** %loc1
+  br label %116
+
+; <label>:116                                     ; preds = %107, %114
+  %117 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  store %"System.Byte[]" addrspace(1)* %117, %"System.Byte[]" addrspace(1)** %loc5
+  %118 = icmp eq %"System.Byte[]" addrspace(1)* %117, null
+  br i1 %118, label %127, label %119
+
+; <label>:119                                     ; preds = %116
+  %120 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc5
+  %NullCheck13 = icmp eq %"System.Byte[]" addrspace(1)* %120, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %121
+
+; <label>:121                                     ; preds = %119
+  %122 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %120, i32 0, i32 1
+  %123 = load i32, i32 addrspace(1)* %122
+  %124 = zext i32 %123 to i64
+  %125 = trunc i64 %124 to i32
+  %126 = icmp ne i32 %125, 0
+  br i1 %126, label %128, label %127
+
+; <label>:127                                     ; preds = %116, %121
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc2
+  br label %136
+
+; <label>:128                                     ; preds = %121
+  %129 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc5
+  %NullCheck15 = icmp eq %"System.Byte[]" addrspace(1)* %129, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %130
+
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %129, i32 0, i32 1
+  %132 = load i32, i32 addrspace(1)* %131
+  %133 = zext i32 %132 to i64
+  %BoundsCheck17 = icmp uge i64 0, %133
+  br i1 %BoundsCheck17, label %ThrowIndexOutOfRange18, label %134
+
+; <label>:134                                     ; preds = %130
+  %135 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %129, i32 0, i32 3, i32 0
+  store i8 addrspace(1)* %135, i8 addrspace(1)** %loc2
+  br label %136
+
+; <label>:136                                     ; preds = %127, %134
+  %137 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %138 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %139 = ptrtoint i16 addrspace(1)* %138 to i64
+  %140 = load i32, i32* %arg2
+  %141 = sext i32 %140 to i64
+  %142 = mul i64 %141, 2
+  %143 = add i64 %139, %142
+  %144 = load i32, i32* %arg3
+  %145 = load i8 addrspace(1)*, i8 addrspace(1)** %loc2
+  %146 = ptrtoint i8 addrspace(1)* %145 to i64
+  %147 = load i32, i32* %arg5
+  %148 = sext i32 %147 to i64
+  %149 = add i64 %146, %148
+  %150 = load i32, i32* %loc0
+  %151 = load i8, i8* %arg6
+  %152 = zext i8 %151 to i32
+  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i64 addrspace(1)*
+  %NullCheck19 = icmp eq i64 addrspace(1)* %153, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %154
+
+; <label>:154                                     ; preds = %136
+  %155 = load i64, i64 addrspace(1)* %153
+  %156 = add i64 %155, 72
+  %157 = inttoptr i64 %156 to i64*
+  %158 = load i64, i64* %157
+  %159 = add i64 %158, 0
+  %160 = inttoptr i64 %159 to i64*
+  %161 = load i64, i64* %160
+  %162 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to %System.Text.Encoder addrspace(1)*
+  %163 = inttoptr i64 %143 to i16*
+  %164 = inttoptr i64 %149 to i8*
+  %165 = trunc i32 %152 to i8
+  %166 = inttoptr i64 %161 to i32 (%System.Text.Encoder addrspace(1)*, i16*, i32, i8*, i32, i8)*
+  %167 = call i32 %166(%System.Text.Encoder addrspace(1)* %162, i16* %163, i32 %144, i8* %164, i32 %150, i8 %165)
+  store i32 %167, i32* %loc3
+  br label %168
+
+; <label>:168                                     ; preds = %154
+  %169 = load i32, i32* %loc3
+  ret i32 %169
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %110
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %119
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange18:                           ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
 Successfully read EncoderNLS.GetBytes
 
@@ -14916,22 +17193,22 @@ entry:
   %40 = load i8, i8* %arg5
   %41 = zext i8 %40 to i32
   %42 = trunc i32 %41 to i8
-  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %39, null
-  br i1 %NullCheck, label %43, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderNLS addrspace(1)* %39, null
+  br i1 %NullCheck, label %ThrowNullRef, label %43
 
 ; <label>:43                                      ; preds = %38
   %44 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
   store i8 %42, i8 addrspace(1)* %44
   %45 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %45, null
-  br i1 %NullCheck2, label %46, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.EncoderNLS addrspace(1)* %45, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %46
 
 ; <label>:46                                      ; preds = %43
   %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %45, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %47
   %48 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.EncoderNLS addrspace(1)* %48, null
-  br i1 %NullCheck4, label %49, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.EncoderNLS addrspace(1)* %48, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %49
 
 ; <label>:49                                      ; preds = %46
   %50 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %48, i32 0, i32 3
@@ -14942,8 +17219,8 @@ entry:
   %55 = load i32, i32* %arg4
   %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck6, label %58, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
   %59 = load i64, i64 addrspace(1)* %57
@@ -14961,15 +17238,15 @@ ThrowNullRef:                                     ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %43
+ThrowNullRef2:                                    ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %46
+ThrowNullRef4:                                    ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %49
+ThrowNullRef6:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14997,8 +17274,8 @@ entry:
   %4 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0 to %System.IO.ConsoleStream addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*)(%System.IO.ConsoleStream addrspace(1)* %4, %"System.Byte[]" addrspace(1)* %1, i32 %2, i32 %3)
   %5 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
@@ -15083,8 +17360,8 @@ entry:
 
 ; <label>:22                                      ; preds = %8
   %23 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %23, null
-  br i1 %NullCheck, label %24, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Byte[]" addrspace(1)* %23, null
+  br i1 %NullCheck, label %ThrowNullRef, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
@@ -15106,8 +17383,8 @@ entry:
 
 ; <label>:36                                      ; preds = %24
   %37 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %37, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.ConsoleStream addrspace(1)* %37, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %37, i32 0, i32 4
@@ -15128,13 +17405,138 @@ ThrowNullRef:                                     ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %36
+ThrowNullRef2:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
-Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
+Successfully read WindowsConsoleStream.WriteFileNative
+
+define i32 @WindowsConsoleStream.WriteFileNative(i64 %param0, %"System.Byte[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i64
+  %arg1 = alloca %"System.Byte[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i8 addrspace(1)*
+  %loc2 = alloca %"System.Byte[]" addrspace(1)*
+  %loc3 = alloca i32
+  store i64 %param0, i64* %arg0
+  store %"System.Byte[]" addrspace(1)* %param1, %"System.Byte[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Byte[]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = zext i32 %3 to i64
+  %5 = icmp ne i64 %4, 0
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %1
+  ret i32 0
+
+; <label>:7                                       ; preds = %1
+  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  store %"System.Byte[]" addrspace(1)* %8, %"System.Byte[]" addrspace(1)** %loc2
+  %9 = icmp eq %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %9, label %18, label %10
+
+; <label>:10                                      ; preds = %7
+  %11 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc2
+  %NullCheck1 = icmp eq %"System.Byte[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %11, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp ne i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %7, %12
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc1
+  br label %27
+
+; <label>:19                                      ; preds = %12
+  %20 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc2
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %20, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %BoundsCheck = icmp uge i64 0, %24
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %25
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %20, i32 0, i32 3, i32 0
+  store i8 addrspace(1)* %26, i8 addrspace(1)** %loc1
+  br label %27
+
+; <label>:27                                      ; preds = %18, %25
+  %28 = load i64, i64* %arg0
+  %29 = load i8 addrspace(1)*, i8 addrspace(1)** %loc1
+  %30 = ptrtoint i8 addrspace(1)* %29 to i64
+  %31 = load i32, i32* %arg2
+  %32 = sext i32 %31 to i64
+  %33 = add i64 %30, %32
+  %34 = load i32, i32* %arg3
+  %35 = addrspacecast i32* %loc3 to i32 addrspace(1)*
+  %36 = inttoptr i64 %33 to i8*
+  %37 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i8*, i32, i32 addrspace(1)*, i64)*)(i64 %28, i8* %36, i32 %34, i32 addrspace(1)* %35, i64 0)
+  %38 = icmp ugt i32 %37, 0
+  %39 = sext i1 %38 to i32
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc1
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %42, label %41
+
+; <label>:41                                      ; preds = %27
+  ret i32 0
+
+; <label>:42                                      ; preds = %27
+  %43 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  store i32 %43, i32* %loc0
+  %44 = load i32, i32* %loc0
+  %45 = icmp eq i32 %44, 232
+  br i1 %45, label %49, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = load i32, i32* %loc0
+  %48 = icmp ne i32 %47, 109
+  br i1 %48, label %50, label %49
+
+; <label>:49                                      ; preds = %42, %46
+  ret i32 0
+
+; <label>:50                                      ; preds = %46
+  %51 = load i32, i32* %loc0
+  ret i32 %51
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
 Successfully read WindowsConsoleStream.Flush
 
@@ -15143,8 +17545,8 @@ entry:
   %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
   store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
@@ -15179,8 +17581,8 @@ entry:
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
   %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load i64, i64 addrspace(1)* %1
@@ -15219,15 +17621,15 @@ entry:
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.TextWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
   %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %3, align 8
   %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
   %7 = load i64, i64 addrspace(1)* %5
@@ -15245,7 +17647,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -15274,8 +17676,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %4)
   store i32 0, i32* %loc0
   %5 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Char[]" addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
@@ -15287,15 +17689,15 @@ entry:
 
 ; <label>:11                                      ; preds = %69
   %12 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %12, i32 0, i32 9
   %15 = load i32, i32 addrspace(1)* %14, align 8
   %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.IO.StreamWriter addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %16, i32 0, i32 10
@@ -15310,15 +17712,15 @@ entry:
 
 ; <label>:23                                      ; preds = %17, %21
   %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %24, null
-  br i1 %NullCheck8, label %25, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %24, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 10
   %27 = load i32, i32 addrspace(1)* %26, align 8
   %28 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %28, null
-  br i1 %NullCheck10, label %29, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.StreamWriter addrspace(1)* %28, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %28, i32 0, i32 9
@@ -15340,15 +17742,15 @@ entry:
   %40 = load i32, i32* %loc0
   %41 = mul i32 %40, 2
   %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
-  br i1 %NullCheck12, label %43, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %43
 
 ; <label>:43                                      ; preds = %38
   %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 7
   %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %44, align 8
   %46 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %46, null
-  br i1 %NullCheck14, label %47, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.IO.StreamWriter addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %47
 
 ; <label>:47                                      ; preds = %43
   %48 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %46, i32 0, i32 9
@@ -15360,16 +17762,16 @@ entry:
   %54 = bitcast %"System.Char[]" addrspace(1)* %45 to %System.Array addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %53, i32 %41, %System.Array addrspace(1)* %54, i32 %50, i32 %52)
   %55 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
-  br i1 %NullCheck16, label %56, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %56
 
 ; <label>:56                                      ; preds = %47
   %57 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
   %58 = load i32, i32 addrspace(1)* %57, align 8
   %59 = load i32, i32* %loc2
   %60 = add i32 %58, %59
-  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
-  br i1 %NullCheck18, label %61, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %61
 
 ; <label>:61                                      ; preds = %56
   %62 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
@@ -15391,8 +17793,8 @@ entry:
 
 ; <label>:72                                      ; preds = %69
   %73 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %73, null
-  br i1 %NullCheck2, label %74, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %73, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %74
 
 ; <label>:74                                      ; preds = %72
   %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %73, i32 0, i32 11
@@ -15413,39 +17815,39 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %72
+ThrowNullRef2:                                    ; preds = %72
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %23
+ThrowNullRef8:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef10:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %43
+ThrowNullRef14:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %47
+ThrowNullRef16:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %56
+ThrowNullRef18:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblArea.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblArea.error.txt
@@ -25,8 +25,8 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
@@ -40,8 +40,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
   %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
@@ -75,7 +75,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -90,8 +90,8 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %NullCheck = icmp ne i8 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = load i8, i8 addrspace(1)* %0, align 8
@@ -125,8 +125,8 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
@@ -159,8 +159,8 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -184,8 +184,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
   store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
@@ -195,8 +195,8 @@ entry:
 ; <label>:4                                       ; preds = %1
   %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
   %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
@@ -206,8 +206,8 @@ entry:
   %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
@@ -221,14 +221,14 @@ entry:
 
 ; <label>:17                                      ; preds = %14
   %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
   %21 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
@@ -238,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -249,8 +249,8 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
@@ -261,27 +261,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %30
+ThrowNullRef10:                                   ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -301,7 +301,89 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
-Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
+Successfully read AppDomainSetup.GetUnsecureApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.GetUnsecureApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %NullCheck = icmp eq %"System.String[]" addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %BoundsCheck = icmp uge i64 0, %5
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %6
+
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 3, i32 0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
+  ret %System.String addrspace(1)* %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_Value using LLILCJit
+Successfully read AppDomainSetup.get_Value
+
+define %"System.String[]" addrspace(1)* @AppDomainSetup.get_Value(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.String[]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 18)
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.String[]" addrspace(1)* addrspace(1)*, %"System.String[]" addrspace(1)*)*)(%"System.String[]" addrspace(1)* addrspace(1)* %9, %"System.String[]" addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %11, i32 0, i32 1
+  %14 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %13, align 8
+  ret %"System.String[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -319,8 +401,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -368,16 +450,16 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
   %5 = load i32, i32 addrspace(1)* %4
   %6 = sub i32 %5, 1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -389,7 +471,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -421,8 +503,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
@@ -456,8 +538,8 @@ entry:
 ; <label>:27                                      ; preds = %19
   %28 = load i32, i32* %arg1
   %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
-  br i1 %NullCheck2, label %30, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %29, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %30
 
 ; <label>:30                                      ; preds = %27
   %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
@@ -493,8 +575,8 @@ entry:
 ; <label>:49                                      ; preds = %46
   %50 = load i32, i32* %arg2
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck4, label %52, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
@@ -517,11 +599,11 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %27
+ThrowNullRef2:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %49
+ThrowNullRef4:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -544,16 +626,16 @@ entry:
   %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %0)
   store %System.String addrspace(1)* %1, %System.String addrspace(1)** %loc0
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 2
   %5 = bitcast [0 x i16] addrspace(1)* %4 to i16 addrspace(1)*
   store i16 addrspace(1)* %5, i16 addrspace(1)** %loc1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %3
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2
@@ -580,7 +662,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -691,15 +773,15 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %NullCheck132 = icmp ne i8* %21, null
-  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+  %NullCheck131 = icmp eq i8* %21, null
+  br i1 %NullCheck131, label %ThrowNullRef132, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = load i8, i8* %21, align 8
   %24 = zext i8 %23 to i32
   %25 = trunc i32 %24 to i8
-  %NullCheck134 = icmp ne i8* %20, null
-  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+  %NullCheck133 = icmp eq i8* %20, null
+  br i1 %NullCheck133, label %ThrowNullRef134, label %26
 
 ; <label>:26                                      ; preds = %22
   store i8 %25, i8* %20, align 8
@@ -709,16 +791,16 @@ entry:
   %28 = load i8*, i8** %arg0
   %29 = load i8*, i8** %arg1
   %30 = bitcast i8* %29 to i16*
-  %NullCheck128 = icmp ne i16* %30, null
-  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+  %NullCheck127 = icmp eq i16* %30, null
+  br i1 %NullCheck127, label %ThrowNullRef128, label %31
 
 ; <label>:31                                      ; preds = %27
   %32 = load i16, i16* %30, align 8
   %33 = sext i16 %32 to i32
   %34 = bitcast i8* %28 to i16*
   %35 = trunc i32 %33 to i16
-  %NullCheck130 = icmp ne i16* %34, null
-  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+  %NullCheck129 = icmp eq i16* %34, null
+  br i1 %NullCheck129, label %ThrowNullRef130, label %36
 
 ; <label>:36                                      ; preds = %31
   store i16 %35, i16* %34, align 8
@@ -728,16 +810,16 @@ entry:
   %38 = load i8*, i8** %arg0
   %39 = load i8*, i8** %arg1
   %40 = bitcast i8* %39 to i16*
-  %NullCheck120 = icmp ne i16* %40, null
-  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+  %NullCheck119 = icmp eq i16* %40, null
+  br i1 %NullCheck119, label %ThrowNullRef120, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i16, i16* %40, align 8
   %43 = sext i16 %42 to i32
   %44 = bitcast i8* %38 to i16*
   %45 = trunc i32 %43 to i16
-  %NullCheck122 = icmp ne i16* %44, null
-  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+  %NullCheck121 = icmp eq i16* %44, null
+  br i1 %NullCheck121, label %ThrowNullRef122, label %46
 
 ; <label>:46                                      ; preds = %41
   store i16 %45, i16* %44, align 8
@@ -745,15 +827,15 @@ entry:
   %48 = getelementptr inbounds i8, i8* %47, i64 2
   %49 = load i8*, i8** %arg1
   %50 = getelementptr inbounds i8, i8* %49, i64 2
-  %NullCheck124 = icmp ne i8* %50, null
-  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+  %NullCheck123 = icmp eq i8* %50, null
+  br i1 %NullCheck123, label %ThrowNullRef124, label %51
 
 ; <label>:51                                      ; preds = %46
   %52 = load i8, i8* %50, align 8
   %53 = zext i8 %52 to i32
   %54 = trunc i32 %53 to i8
-  %NullCheck126 = icmp ne i8* %48, null
-  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+  %NullCheck125 = icmp eq i8* %48, null
+  br i1 %NullCheck125, label %ThrowNullRef126, label %55
 
 ; <label>:55                                      ; preds = %51
   store i8 %54, i8* %48, align 8
@@ -763,14 +845,14 @@ entry:
   %57 = load i8*, i8** %arg0
   %58 = load i8*, i8** %arg1
   %59 = bitcast i8* %58 to i32*
-  %NullCheck116 = icmp ne i32* %59, null
-  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+  %NullCheck115 = icmp eq i32* %59, null
+  br i1 %NullCheck115, label %ThrowNullRef116, label %60
 
 ; <label>:60                                      ; preds = %56
   %61 = load i32, i32* %59, align 8
   %62 = bitcast i8* %57 to i32*
-  %NullCheck118 = icmp ne i32* %62, null
-  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+  %NullCheck117 = icmp eq i32* %62, null
+  br i1 %NullCheck117, label %ThrowNullRef118, label %63
 
 ; <label>:63                                      ; preds = %60
   store i32 %61, i32* %62, align 8
@@ -780,14 +862,14 @@ entry:
   %65 = load i8*, i8** %arg0
   %66 = load i8*, i8** %arg1
   %67 = bitcast i8* %66 to i32*
-  %NullCheck108 = icmp ne i32* %67, null
-  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+  %NullCheck107 = icmp eq i32* %67, null
+  br i1 %NullCheck107, label %ThrowNullRef108, label %68
 
 ; <label>:68                                      ; preds = %64
   %69 = load i32, i32* %67, align 8
   %70 = bitcast i8* %65 to i32*
-  %NullCheck110 = icmp ne i32* %70, null
-  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+  %NullCheck109 = icmp eq i32* %70, null
+  br i1 %NullCheck109, label %ThrowNullRef110, label %71
 
 ; <label>:71                                      ; preds = %68
   store i32 %69, i32* %70, align 8
@@ -795,15 +877,15 @@ entry:
   %73 = getelementptr inbounds i8, i8* %72, i64 4
   %74 = load i8*, i8** %arg1
   %75 = getelementptr inbounds i8, i8* %74, i64 4
-  %NullCheck112 = icmp ne i8* %75, null
-  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+  %NullCheck111 = icmp eq i8* %75, null
+  br i1 %NullCheck111, label %ThrowNullRef112, label %76
 
 ; <label>:76                                      ; preds = %71
   %77 = load i8, i8* %75, align 8
   %78 = zext i8 %77 to i32
   %79 = trunc i32 %78 to i8
-  %NullCheck114 = icmp ne i8* %73, null
-  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+  %NullCheck113 = icmp eq i8* %73, null
+  br i1 %NullCheck113, label %ThrowNullRef114, label %80
 
 ; <label>:80                                      ; preds = %76
   store i8 %79, i8* %73, align 8
@@ -813,14 +895,14 @@ entry:
   %82 = load i8*, i8** %arg0
   %83 = load i8*, i8** %arg1
   %84 = bitcast i8* %83 to i32*
-  %NullCheck100 = icmp ne i32* %84, null
-  br i1 %NullCheck100, label %85, label %ThrowNullRef99
+  %NullCheck99 = icmp eq i32* %84, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %85
 
 ; <label>:85                                      ; preds = %81
   %86 = load i32, i32* %84, align 8
   %87 = bitcast i8* %82 to i32*
-  %NullCheck102 = icmp ne i32* %87, null
-  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+  %NullCheck101 = icmp eq i32* %87, null
+  br i1 %NullCheck101, label %ThrowNullRef102, label %88
 
 ; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
@@ -829,16 +911,16 @@ entry:
   %91 = load i8*, i8** %arg1
   %92 = getelementptr inbounds i8, i8* %91, i64 4
   %93 = bitcast i8* %92 to i16*
-  %NullCheck104 = icmp ne i16* %93, null
-  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+  %NullCheck103 = icmp eq i16* %93, null
+  br i1 %NullCheck103, label %ThrowNullRef104, label %94
 
 ; <label>:94                                      ; preds = %88
   %95 = load i16, i16* %93, align 8
   %96 = sext i16 %95 to i32
   %97 = bitcast i8* %90 to i16*
   %98 = trunc i32 %96 to i16
-  %NullCheck106 = icmp ne i16* %97, null
-  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+  %NullCheck105 = icmp eq i16* %97, null
+  br i1 %NullCheck105, label %ThrowNullRef106, label %99
 
 ; <label>:99                                      ; preds = %94
   store i16 %98, i16* %97, align 8
@@ -848,14 +930,14 @@ entry:
   %101 = load i8*, i8** %arg0
   %102 = load i8*, i8** %arg1
   %103 = bitcast i8* %102 to i32*
-  %NullCheck88 = icmp ne i32* %103, null
-  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+  %NullCheck87 = icmp eq i32* %103, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %104
 
 ; <label>:104                                     ; preds = %100
   %105 = load i32, i32* %103, align 8
   %106 = bitcast i8* %101 to i32*
-  %NullCheck90 = icmp ne i32* %106, null
-  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+  %NullCheck89 = icmp eq i32* %106, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %107
 
 ; <label>:107                                     ; preds = %104
   store i32 %105, i32* %106, align 8
@@ -864,16 +946,16 @@ entry:
   %110 = load i8*, i8** %arg1
   %111 = getelementptr inbounds i8, i8* %110, i64 4
   %112 = bitcast i8* %111 to i16*
-  %NullCheck92 = icmp ne i16* %112, null
-  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+  %NullCheck91 = icmp eq i16* %112, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %113
 
 ; <label>:113                                     ; preds = %107
   %114 = load i16, i16* %112, align 8
   %115 = sext i16 %114 to i32
   %116 = bitcast i8* %109 to i16*
   %117 = trunc i32 %115 to i16
-  %NullCheck94 = icmp ne i16* %116, null
-  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+  %NullCheck93 = icmp eq i16* %116, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %118
 
 ; <label>:118                                     ; preds = %113
   store i16 %117, i16* %116, align 8
@@ -881,15 +963,15 @@ entry:
   %120 = getelementptr inbounds i8, i8* %119, i64 6
   %121 = load i8*, i8** %arg1
   %122 = getelementptr inbounds i8, i8* %121, i64 6
-  %NullCheck96 = icmp ne i8* %122, null
-  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+  %NullCheck95 = icmp eq i8* %122, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %123
 
 ; <label>:123                                     ; preds = %118
   %124 = load i8, i8* %122, align 8
   %125 = zext i8 %124 to i32
   %126 = trunc i32 %125 to i8
-  %NullCheck98 = icmp ne i8* %120, null
-  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+  %NullCheck97 = icmp eq i8* %120, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %127
 
 ; <label>:127                                     ; preds = %123
   store i8 %126, i8* %120, align 8
@@ -899,14 +981,14 @@ entry:
   %129 = load i8*, i8** %arg0
   %130 = load i8*, i8** %arg1
   %131 = bitcast i8* %130 to i64*
-  %NullCheck84 = icmp ne i64* %131, null
-  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+  %NullCheck83 = icmp eq i64* %131, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %132
 
 ; <label>:132                                     ; preds = %128
   %133 = load i64, i64* %131, align 8
   %134 = bitcast i8* %129 to i64*
-  %NullCheck86 = icmp ne i64* %134, null
-  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+  %NullCheck85 = icmp eq i64* %134, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %135
 
 ; <label>:135                                     ; preds = %132
   store i64 %133, i64* %134, align 8
@@ -916,14 +998,14 @@ entry:
   %137 = load i8*, i8** %arg0
   %138 = load i8*, i8** %arg1
   %139 = bitcast i8* %138 to i64*
-  %NullCheck76 = icmp ne i64* %139, null
-  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+  %NullCheck75 = icmp eq i64* %139, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %140
 
 ; <label>:140                                     ; preds = %136
   %141 = load i64, i64* %139, align 8
   %142 = bitcast i8* %137 to i64*
-  %NullCheck78 = icmp ne i64* %142, null
-  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+  %NullCheck77 = icmp eq i64* %142, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %143
 
 ; <label>:143                                     ; preds = %140
   store i64 %141, i64* %142, align 8
@@ -931,15 +1013,15 @@ entry:
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %NullCheck80 = icmp ne i8* %147, null
-  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+  %NullCheck79 = icmp eq i8* %147, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %148
 
 ; <label>:148                                     ; preds = %143
   %149 = load i8, i8* %147, align 8
   %150 = zext i8 %149 to i32
   %151 = trunc i32 %150 to i8
-  %NullCheck82 = icmp ne i8* %145, null
-  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+  %NullCheck81 = icmp eq i8* %145, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %152
 
 ; <label>:152                                     ; preds = %148
   store i8 %151, i8* %145, align 8
@@ -949,14 +1031,14 @@ entry:
   %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
   %156 = bitcast i8* %155 to i64*
-  %NullCheck68 = icmp ne i64* %156, null
-  br i1 %NullCheck68, label %157, label %ThrowNullRef67
+  %NullCheck67 = icmp eq i64* %156, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %157
 
 ; <label>:157                                     ; preds = %153
   %158 = load i64, i64* %156, align 8
   %159 = bitcast i8* %154 to i64*
-  %NullCheck70 = icmp ne i64* %159, null
-  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+  %NullCheck69 = icmp eq i64* %159, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %160
 
 ; <label>:160                                     ; preds = %157
   store i64 %158, i64* %159, align 8
@@ -965,16 +1047,16 @@ entry:
   %163 = load i8*, i8** %arg1
   %164 = getelementptr inbounds i8, i8* %163, i64 8
   %165 = bitcast i8* %164 to i16*
-  %NullCheck72 = icmp ne i16* %165, null
-  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+  %NullCheck71 = icmp eq i16* %165, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %166
 
 ; <label>:166                                     ; preds = %160
   %167 = load i16, i16* %165, align 8
   %168 = sext i16 %167 to i32
   %169 = bitcast i8* %162 to i16*
   %170 = trunc i32 %168 to i16
-  %NullCheck74 = icmp ne i16* %169, null
-  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+  %NullCheck73 = icmp eq i16* %169, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %171
 
 ; <label>:171                                     ; preds = %166
   store i16 %170, i16* %169, align 8
@@ -984,14 +1066,14 @@ entry:
   %173 = load i8*, i8** %arg0
   %174 = load i8*, i8** %arg1
   %175 = bitcast i8* %174 to i64*
-  %NullCheck56 = icmp ne i64* %175, null
-  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+  %NullCheck55 = icmp eq i64* %175, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %176
 
 ; <label>:176                                     ; preds = %172
   %177 = load i64, i64* %175, align 8
   %178 = bitcast i8* %173 to i64*
-  %NullCheck58 = icmp ne i64* %178, null
-  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+  %NullCheck57 = icmp eq i64* %178, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %179
 
 ; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
@@ -1000,16 +1082,16 @@ entry:
   %182 = load i8*, i8** %arg1
   %183 = getelementptr inbounds i8, i8* %182, i64 8
   %184 = bitcast i8* %183 to i16*
-  %NullCheck60 = icmp ne i16* %184, null
-  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+  %NullCheck59 = icmp eq i16* %184, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %185
 
 ; <label>:185                                     ; preds = %179
   %186 = load i16, i16* %184, align 8
   %187 = sext i16 %186 to i32
   %188 = bitcast i8* %181 to i16*
   %189 = trunc i32 %187 to i16
-  %NullCheck62 = icmp ne i16* %188, null
-  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+  %NullCheck61 = icmp eq i16* %188, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %190
 
 ; <label>:190                                     ; preds = %185
   store i16 %189, i16* %188, align 8
@@ -1017,15 +1099,15 @@ entry:
   %192 = getelementptr inbounds i8, i8* %191, i64 10
   %193 = load i8*, i8** %arg1
   %194 = getelementptr inbounds i8, i8* %193, i64 10
-  %NullCheck64 = icmp ne i8* %194, null
-  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+  %NullCheck63 = icmp eq i8* %194, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %195
 
 ; <label>:195                                     ; preds = %190
   %196 = load i8, i8* %194, align 8
   %197 = zext i8 %196 to i32
   %198 = trunc i32 %197 to i8
-  %NullCheck66 = icmp ne i8* %192, null
-  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+  %NullCheck65 = icmp eq i8* %192, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %199
 
 ; <label>:199                                     ; preds = %195
   store i8 %198, i8* %192, align 8
@@ -1035,14 +1117,14 @@ entry:
   %201 = load i8*, i8** %arg0
   %202 = load i8*, i8** %arg1
   %203 = bitcast i8* %202 to i64*
-  %NullCheck48 = icmp ne i64* %203, null
-  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+  %NullCheck47 = icmp eq i64* %203, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %204
 
 ; <label>:204                                     ; preds = %200
   %205 = load i64, i64* %203, align 8
   %206 = bitcast i8* %201 to i64*
-  %NullCheck50 = icmp ne i64* %206, null
-  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+  %NullCheck49 = icmp eq i64* %206, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %207
 
 ; <label>:207                                     ; preds = %204
   store i64 %205, i64* %206, align 8
@@ -1051,14 +1133,14 @@ entry:
   %210 = load i8*, i8** %arg1
   %211 = getelementptr inbounds i8, i8* %210, i64 8
   %212 = bitcast i8* %211 to i32*
-  %NullCheck52 = icmp ne i32* %212, null
-  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+  %NullCheck51 = icmp eq i32* %212, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %213
 
 ; <label>:213                                     ; preds = %207
   %214 = load i32, i32* %212, align 8
   %215 = bitcast i8* %209 to i32*
-  %NullCheck54 = icmp ne i32* %215, null
-  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+  %NullCheck53 = icmp eq i32* %215, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %216
 
 ; <label>:216                                     ; preds = %213
   store i32 %214, i32* %215, align 8
@@ -1068,14 +1150,14 @@ entry:
   %218 = load i8*, i8** %arg0
   %219 = load i8*, i8** %arg1
   %220 = bitcast i8* %219 to i64*
-  %NullCheck36 = icmp ne i64* %220, null
-  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64* %220, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %221
 
 ; <label>:221                                     ; preds = %217
   %222 = load i64, i64* %220, align 8
   %223 = bitcast i8* %218 to i64*
-  %NullCheck38 = icmp ne i64* %223, null
-  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+  %NullCheck37 = icmp eq i64* %223, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %224
 
 ; <label>:224                                     ; preds = %221
   store i64 %222, i64* %223, align 8
@@ -1084,14 +1166,14 @@ entry:
   %227 = load i8*, i8** %arg1
   %228 = getelementptr inbounds i8, i8* %227, i64 8
   %229 = bitcast i8* %228 to i32*
-  %NullCheck40 = icmp ne i32* %229, null
-  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i32* %229, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %230
 
 ; <label>:230                                     ; preds = %224
   %231 = load i32, i32* %229, align 8
   %232 = bitcast i8* %226 to i32*
-  %NullCheck42 = icmp ne i32* %232, null
-  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+  %NullCheck41 = icmp eq i32* %232, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %233
 
 ; <label>:233                                     ; preds = %230
   store i32 %231, i32* %232, align 8
@@ -1099,15 +1181,15 @@ entry:
   %235 = getelementptr inbounds i8, i8* %234, i64 12
   %236 = load i8*, i8** %arg1
   %237 = getelementptr inbounds i8, i8* %236, i64 12
-  %NullCheck44 = icmp ne i8* %237, null
-  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i8* %237, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %238
 
 ; <label>:238                                     ; preds = %233
   %239 = load i8, i8* %237, align 8
   %240 = zext i8 %239 to i32
   %241 = trunc i32 %240 to i8
-  %NullCheck46 = icmp ne i8* %235, null
-  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+  %NullCheck45 = icmp eq i8* %235, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %242
 
 ; <label>:242                                     ; preds = %238
   store i8 %241, i8* %235, align 8
@@ -1117,14 +1199,14 @@ entry:
   %244 = load i8*, i8** %arg0
   %245 = load i8*, i8** %arg1
   %246 = bitcast i8* %245 to i64*
-  %NullCheck24 = icmp ne i64* %246, null
-  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64* %246, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %247
 
 ; <label>:247                                     ; preds = %243
   %248 = load i64, i64* %246, align 8
   %249 = bitcast i8* %244 to i64*
-  %NullCheck26 = icmp ne i64* %249, null
-  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64* %249, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %250
 
 ; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
@@ -1133,14 +1215,14 @@ entry:
   %253 = load i8*, i8** %arg1
   %254 = getelementptr inbounds i8, i8* %253, i64 8
   %255 = bitcast i8* %254 to i32*
-  %NullCheck28 = icmp ne i32* %255, null
-  br i1 %NullCheck28, label %256, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i32* %255, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %256
 
 ; <label>:256                                     ; preds = %250
   %257 = load i32, i32* %255, align 8
   %258 = bitcast i8* %252 to i32*
-  %NullCheck30 = icmp ne i32* %258, null
-  br i1 %NullCheck30, label %259, label %ThrowNullRef29
+  %NullCheck29 = icmp eq i32* %258, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %259
 
 ; <label>:259                                     ; preds = %256
   store i32 %257, i32* %258, align 8
@@ -1149,16 +1231,16 @@ entry:
   %262 = load i8*, i8** %arg1
   %263 = getelementptr inbounds i8, i8* %262, i64 12
   %264 = bitcast i8* %263 to i16*
-  %NullCheck32 = icmp ne i16* %264, null
-  br i1 %NullCheck32, label %265, label %ThrowNullRef31
+  %NullCheck31 = icmp eq i16* %264, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %265
 
 ; <label>:265                                     ; preds = %259
   %266 = load i16, i16* %264, align 8
   %267 = sext i16 %266 to i32
   %268 = bitcast i8* %261 to i16*
   %269 = trunc i32 %267 to i16
-  %NullCheck34 = icmp ne i16* %268, null
-  br i1 %NullCheck34, label %270, label %ThrowNullRef33
+  %NullCheck33 = icmp eq i16* %268, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %270
 
 ; <label>:270                                     ; preds = %265
   store i16 %269, i16* %268, align 8
@@ -1168,14 +1250,14 @@ entry:
   %272 = load i8*, i8** %arg0
   %273 = load i8*, i8** %arg1
   %274 = bitcast i8* %273 to i64*
-  %NullCheck8 = icmp ne i64* %274, null
-  br i1 %NullCheck8, label %275, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64* %274, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %275
 
 ; <label>:275                                     ; preds = %271
   %276 = load i64, i64* %274, align 8
   %277 = bitcast i8* %272 to i64*
-  %NullCheck10 = icmp ne i64* %277, null
-  br i1 %NullCheck10, label %278, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %277, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %278
 
 ; <label>:278                                     ; preds = %275
   store i64 %276, i64* %277, align 8
@@ -1184,14 +1266,14 @@ entry:
   %281 = load i8*, i8** %arg1
   %282 = getelementptr inbounds i8, i8* %281, i64 8
   %283 = bitcast i8* %282 to i32*
-  %NullCheck12 = icmp ne i32* %283, null
-  br i1 %NullCheck12, label %284, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i32* %283, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %284
 
 ; <label>:284                                     ; preds = %278
   %285 = load i32, i32* %283, align 8
   %286 = bitcast i8* %280 to i32*
-  %NullCheck14 = icmp ne i32* %286, null
-  br i1 %NullCheck14, label %287, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i32* %286, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %287
 
 ; <label>:287                                     ; preds = %284
   store i32 %285, i32* %286, align 8
@@ -1200,16 +1282,16 @@ entry:
   %290 = load i8*, i8** %arg1
   %291 = getelementptr inbounds i8, i8* %290, i64 12
   %292 = bitcast i8* %291 to i16*
-  %NullCheck16 = icmp ne i16* %292, null
-  br i1 %NullCheck16, label %293, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i16* %292, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %293
 
 ; <label>:293                                     ; preds = %287
   %294 = load i16, i16* %292, align 8
   %295 = sext i16 %294 to i32
   %296 = bitcast i8* %289 to i16*
   %297 = trunc i32 %295 to i16
-  %NullCheck18 = icmp ne i16* %296, null
-  br i1 %NullCheck18, label %298, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i16* %296, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %298
 
 ; <label>:298                                     ; preds = %293
   store i16 %297, i16* %296, align 8
@@ -1217,15 +1299,15 @@ entry:
   %300 = getelementptr inbounds i8, i8* %299, i64 14
   %301 = load i8*, i8** %arg1
   %302 = getelementptr inbounds i8, i8* %301, i64 14
-  %NullCheck20 = icmp ne i8* %302, null
-  br i1 %NullCheck20, label %303, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i8* %302, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %303
 
 ; <label>:303                                     ; preds = %298
   %304 = load i8, i8* %302, align 8
   %305 = zext i8 %304 to i32
   %306 = trunc i32 %305 to i8
-  %NullCheck22 = icmp ne i8* %300, null
-  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i8* %300, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %307
 
 ; <label>:307                                     ; preds = %303
   store i8 %306, i8* %300, align 8
@@ -1235,14 +1317,14 @@ entry:
   %309 = load i8*, i8** %arg0
   %310 = load i8*, i8** %arg1
   %311 = bitcast i8* %310 to i64*
-  %NullCheck = icmp ne i64* %311, null
-  br i1 %NullCheck, label %312, label %ThrowNullRef
+  %NullCheck = icmp eq i64* %311, null
+  br i1 %NullCheck, label %ThrowNullRef, label %312
 
 ; <label>:312                                     ; preds = %308
   %313 = load i64, i64* %311, align 8
   %314 = bitcast i8* %309 to i64*
-  %NullCheck2 = icmp ne i64* %314, null
-  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64* %314, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %315
 
 ; <label>:315                                     ; preds = %312
   store i64 %313, i64* %314, align 8
@@ -1251,14 +1333,14 @@ entry:
   %318 = load i8*, i8** %arg1
   %319 = getelementptr inbounds i8, i8* %318, i64 8
   %320 = bitcast i8* %319 to i64*
-  %NullCheck4 = icmp ne i64* %320, null
-  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64* %320, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %321
 
 ; <label>:321                                     ; preds = %315
   %322 = load i64, i64* %320, align 8
   %323 = bitcast i8* %317 to i64*
-  %NullCheck6 = icmp ne i64* %323, null
-  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64* %323, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %324
 
 ; <label>:324                                     ; preds = %321
   store i64 %322, i64* %323, align 8
@@ -1286,15 +1368,15 @@ entry:
 ; <label>:338                                     ; preds = %333
   %339 = load i8*, i8** %arg0
   %340 = load i8*, i8** %arg1
-  %NullCheck136 = icmp ne i8* %340, null
-  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+  %NullCheck135 = icmp eq i8* %340, null
+  br i1 %NullCheck135, label %ThrowNullRef136, label %341
 
 ; <label>:341                                     ; preds = %338
   %342 = load i8, i8* %340, align 8
   %343 = zext i8 %342 to i32
   %344 = trunc i32 %343 to i8
-  %NullCheck138 = icmp ne i8* %339, null
-  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+  %NullCheck137 = icmp eq i8* %339, null
+  br i1 %NullCheck137, label %ThrowNullRef138, label %345
 
 ; <label>:345                                     ; preds = %341
   store i8 %344, i8* %339, align 8
@@ -1317,16 +1399,16 @@ entry:
   %357 = load i8*, i8** %arg0
   %358 = load i8*, i8** %arg1
   %359 = bitcast i8* %358 to i16*
-  %NullCheck140 = icmp ne i16* %359, null
-  br i1 %NullCheck140, label %360, label %ThrowNullRef139
+  %NullCheck139 = icmp eq i16* %359, null
+  br i1 %NullCheck139, label %ThrowNullRef140, label %360
 
 ; <label>:360                                     ; preds = %356
   %361 = load i16, i16* %359, align 8
   %362 = sext i16 %361 to i32
   %363 = bitcast i8* %357 to i16*
   %364 = trunc i32 %362 to i16
-  %NullCheck142 = icmp ne i16* %363, null
-  br i1 %NullCheck142, label %365, label %ThrowNullRef141
+  %NullCheck141 = icmp eq i16* %363, null
+  br i1 %NullCheck141, label %ThrowNullRef142, label %365
 
 ; <label>:365                                     ; preds = %360
   store i16 %364, i16* %363, align 8
@@ -1352,14 +1434,14 @@ entry:
   %378 = load i8*, i8** %arg0
   %379 = load i8*, i8** %arg1
   %380 = bitcast i8* %379 to i32*
-  %NullCheck144 = icmp ne i32* %380, null
-  br i1 %NullCheck144, label %381, label %ThrowNullRef143
+  %NullCheck143 = icmp eq i32* %380, null
+  br i1 %NullCheck143, label %ThrowNullRef144, label %381
 
 ; <label>:381                                     ; preds = %377
   %382 = load i32, i32* %380, align 8
   %383 = bitcast i8* %378 to i32*
-  %NullCheck146 = icmp ne i32* %383, null
-  br i1 %NullCheck146, label %384, label %ThrowNullRef145
+  %NullCheck145 = icmp eq i32* %383, null
+  br i1 %NullCheck145, label %ThrowNullRef146, label %384
 
 ; <label>:384                                     ; preds = %381
   store i32 %382, i32* %383, align 8
@@ -1384,14 +1466,14 @@ entry:
   %395 = load i8*, i8** %arg0
   %396 = load i8*, i8** %arg1
   %397 = bitcast i8* %396 to i64*
-  %NullCheck164 = icmp ne i64* %397, null
-  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+  %NullCheck163 = icmp eq i64* %397, null
+  br i1 %NullCheck163, label %ThrowNullRef164, label %398
 
 ; <label>:398                                     ; preds = %394
   %399 = load i64, i64* %397, align 8
   %400 = bitcast i8* %395 to i64*
-  %NullCheck166 = icmp ne i64* %400, null
-  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+  %NullCheck165 = icmp eq i64* %400, null
+  br i1 %NullCheck165, label %ThrowNullRef166, label %401
 
 ; <label>:401                                     ; preds = %398
   store i64 %399, i64* %400, align 8
@@ -1400,14 +1482,14 @@ entry:
   %404 = load i8*, i8** %arg1
   %405 = getelementptr inbounds i8, i8* %404, i64 8
   %406 = bitcast i8* %405 to i64*
-  %NullCheck168 = icmp ne i64* %406, null
-  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+  %NullCheck167 = icmp eq i64* %406, null
+  br i1 %NullCheck167, label %ThrowNullRef168, label %407
 
 ; <label>:407                                     ; preds = %401
   %408 = load i64, i64* %406, align 8
   %409 = bitcast i8* %403 to i64*
-  %NullCheck170 = icmp ne i64* %409, null
-  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+  %NullCheck169 = icmp eq i64* %409, null
+  br i1 %NullCheck169, label %ThrowNullRef170, label %410
 
 ; <label>:410                                     ; preds = %407
   store i64 %408, i64* %409, align 8
@@ -1437,14 +1519,14 @@ entry:
   %425 = load i8*, i8** %arg0
   %426 = load i8*, i8** %arg1
   %427 = bitcast i8* %426 to i64*
-  %NullCheck148 = icmp ne i64* %427, null
-  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+  %NullCheck147 = icmp eq i64* %427, null
+  br i1 %NullCheck147, label %ThrowNullRef148, label %428
 
 ; <label>:428                                     ; preds = %424
   %429 = load i64, i64* %427, align 8
   %430 = bitcast i8* %425 to i64*
-  %NullCheck150 = icmp ne i64* %430, null
-  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+  %NullCheck149 = icmp eq i64* %430, null
+  br i1 %NullCheck149, label %ThrowNullRef150, label %431
 
 ; <label>:431                                     ; preds = %428
   store i64 %429, i64* %430, align 8
@@ -1466,14 +1548,14 @@ entry:
   %441 = load i8*, i8** %arg0
   %442 = load i8*, i8** %arg1
   %443 = bitcast i8* %442 to i32*
-  %NullCheck152 = icmp ne i32* %443, null
-  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+  %NullCheck151 = icmp eq i32* %443, null
+  br i1 %NullCheck151, label %ThrowNullRef152, label %444
 
 ; <label>:444                                     ; preds = %440
   %445 = load i32, i32* %443, align 8
   %446 = bitcast i8* %441 to i32*
-  %NullCheck154 = icmp ne i32* %446, null
-  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+  %NullCheck153 = icmp eq i32* %446, null
+  br i1 %NullCheck153, label %ThrowNullRef154, label %447
 
 ; <label>:447                                     ; preds = %444
   store i32 %445, i32* %446, align 8
@@ -1495,16 +1577,16 @@ entry:
   %457 = load i8*, i8** %arg0
   %458 = load i8*, i8** %arg1
   %459 = bitcast i8* %458 to i16*
-  %NullCheck156 = icmp ne i16* %459, null
-  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+  %NullCheck155 = icmp eq i16* %459, null
+  br i1 %NullCheck155, label %ThrowNullRef156, label %460
 
 ; <label>:460                                     ; preds = %456
   %461 = load i16, i16* %459, align 8
   %462 = sext i16 %461 to i32
   %463 = bitcast i8* %457 to i16*
   %464 = trunc i32 %462 to i16
-  %NullCheck158 = icmp ne i16* %463, null
-  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+  %NullCheck157 = icmp eq i16* %463, null
+  br i1 %NullCheck157, label %ThrowNullRef158, label %465
 
 ; <label>:465                                     ; preds = %460
   store i16 %464, i16* %463, align 8
@@ -1525,15 +1607,15 @@ entry:
 ; <label>:474                                     ; preds = %470
   %475 = load i8*, i8** %arg0
   %476 = load i8*, i8** %arg1
-  %NullCheck160 = icmp ne i8* %476, null
-  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+  %NullCheck159 = icmp eq i8* %476, null
+  br i1 %NullCheck159, label %ThrowNullRef160, label %477
 
 ; <label>:477                                     ; preds = %474
   %478 = load i8, i8* %476, align 8
   %479 = zext i8 %478 to i32
   %480 = trunc i32 %479 to i8
-  %NullCheck162 = icmp ne i8* %475, null
-  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+  %NullCheck161 = icmp eq i8* %475, null
+  br i1 %NullCheck161, label %ThrowNullRef162, label %481
 
 ; <label>:481                                     ; preds = %477
   store i8 %480, i8* %475, align 8
@@ -1553,343 +1635,343 @@ ThrowNullRef:                                     ; preds = %308
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %312
+ThrowNullRef2:                                    ; preds = %312
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %315
+ThrowNullRef4:                                    ; preds = %315
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %321
+ThrowNullRef6:                                    ; preds = %321
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %271
+ThrowNullRef8:                                    ; preds = %271
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %275
+ThrowNullRef10:                                   ; preds = %275
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %278
+ThrowNullRef12:                                   ; preds = %278
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %284
+ThrowNullRef14:                                   ; preds = %284
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %287
+ThrowNullRef16:                                   ; preds = %287
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %293
+ThrowNullRef18:                                   ; preds = %293
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %298
+ThrowNullRef20:                                   ; preds = %298
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %303
+ThrowNullRef22:                                   ; preds = %303
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %243
+ThrowNullRef24:                                   ; preds = %243
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %247
+ThrowNullRef26:                                   ; preds = %247
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %250
+ThrowNullRef28:                                   ; preds = %250
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %256
+ThrowNullRef30:                                   ; preds = %256
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %259
+ThrowNullRef32:                                   ; preds = %259
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %265
+ThrowNullRef34:                                   ; preds = %265
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %217
+ThrowNullRef36:                                   ; preds = %217
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %221
+ThrowNullRef38:                                   ; preds = %221
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %224
+ThrowNullRef40:                                   ; preds = %224
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %230
+ThrowNullRef42:                                   ; preds = %230
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %233
+ThrowNullRef44:                                   ; preds = %233
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %238
+ThrowNullRef46:                                   ; preds = %238
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %200
+ThrowNullRef48:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %204
+ThrowNullRef50:                                   ; preds = %204
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %207
+ThrowNullRef52:                                   ; preds = %207
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %213
+ThrowNullRef54:                                   ; preds = %213
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %172
+ThrowNullRef56:                                   ; preds = %172
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %176
+ThrowNullRef58:                                   ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %179
+ThrowNullRef60:                                   ; preds = %179
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %185
+ThrowNullRef62:                                   ; preds = %185
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %190
+ThrowNullRef64:                                   ; preds = %190
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %195
+ThrowNullRef66:                                   ; preds = %195
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %153
+ThrowNullRef68:                                   ; preds = %153
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %157
+ThrowNullRef70:                                   ; preds = %157
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %160
+ThrowNullRef72:                                   ; preds = %160
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %166
+ThrowNullRef74:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %136
+ThrowNullRef76:                                   ; preds = %136
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %140
+ThrowNullRef78:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %143
+ThrowNullRef80:                                   ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %148
+ThrowNullRef82:                                   ; preds = %148
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %128
+ThrowNullRef84:                                   ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %132
+ThrowNullRef86:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %100
+ThrowNullRef88:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %104
+ThrowNullRef90:                                   ; preds = %104
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %107
+ThrowNullRef92:                                   ; preds = %107
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %113
+ThrowNullRef94:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %118
+ThrowNullRef96:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %123
+ThrowNullRef98:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %81
+ThrowNullRef100:                                  ; preds = %81
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef101:                                  ; preds = %85
+ThrowNullRef102:                                  ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef103:                                  ; preds = %88
+ThrowNullRef104:                                  ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef105:                                  ; preds = %94
+ThrowNullRef106:                                  ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef107:                                  ; preds = %64
+ThrowNullRef108:                                  ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef109:                                  ; preds = %68
+ThrowNullRef110:                                  ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef111:                                  ; preds = %71
+ThrowNullRef112:                                  ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef113:                                  ; preds = %76
+ThrowNullRef114:                                  ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef115:                                  ; preds = %56
+ThrowNullRef116:                                  ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef117:                                  ; preds = %60
+ThrowNullRef118:                                  ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef119:                                  ; preds = %37
+ThrowNullRef120:                                  ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef121:                                  ; preds = %41
+ThrowNullRef122:                                  ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef123:                                  ; preds = %46
+ThrowNullRef124:                                  ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef125:                                  ; preds = %51
+ThrowNullRef126:                                  ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef127:                                  ; preds = %27
+ThrowNullRef128:                                  ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef129:                                  ; preds = %31
+ThrowNullRef130:                                  ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef131:                                  ; preds = %19
+ThrowNullRef132:                                  ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef133:                                  ; preds = %22
+ThrowNullRef134:                                  ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef135:                                  ; preds = %338
+ThrowNullRef136:                                  ; preds = %338
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef137:                                  ; preds = %341
+ThrowNullRef138:                                  ; preds = %341
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef139:                                  ; preds = %356
+ThrowNullRef140:                                  ; preds = %356
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef141:                                  ; preds = %360
+ThrowNullRef142:                                  ; preds = %360
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef143:                                  ; preds = %377
+ThrowNullRef144:                                  ; preds = %377
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef145:                                  ; preds = %381
+ThrowNullRef146:                                  ; preds = %381
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef147:                                  ; preds = %424
+ThrowNullRef148:                                  ; preds = %424
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef149:                                  ; preds = %428
+ThrowNullRef150:                                  ; preds = %428
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef151:                                  ; preds = %440
+ThrowNullRef152:                                  ; preds = %440
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef153:                                  ; preds = %444
+ThrowNullRef154:                                  ; preds = %444
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef155:                                  ; preds = %456
+ThrowNullRef156:                                  ; preds = %456
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef157:                                  ; preds = %460
+ThrowNullRef158:                                  ; preds = %460
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef159:                                  ; preds = %474
+ThrowNullRef160:                                  ; preds = %474
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef161:                                  ; preds = %477
+ThrowNullRef162:                                  ; preds = %477
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef163:                                  ; preds = %394
+ThrowNullRef164:                                  ; preds = %394
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef165:                                  ; preds = %398
+ThrowNullRef166:                                  ; preds = %398
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef167:                                  ; preds = %401
+ThrowNullRef168:                                  ; preds = %401
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef169:                                  ; preds = %407
+ThrowNullRef170:                                  ; preds = %407
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1939,8 +2021,8 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
-  br i1 %NullCheck, label %22, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %ThrowNullRef, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
@@ -1948,8 +2030,8 @@ entry:
   store i32 %24, i32* %loc0
   %25 = load i32, i32* %loc0
   %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %26, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %27
 
 ; <label>:27                                      ; preds = %22
   %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
@@ -1971,7 +2053,7 @@ ThrowNullRef:                                     ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1989,8 +2071,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -2022,15 +2104,15 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2048,16 +2130,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
   %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
   store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %15
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
@@ -2072,8 +2154,8 @@ entry:
   %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
   %29 = ptrtoint i16 addrspace(1)* %28 to i64
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %19
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
@@ -2089,19 +2171,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2114,8 +2196,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
@@ -2128,7 +2210,7 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[loadElem]
+Failed to read AppDomain.PrepareDataForSetup[storeElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
@@ -2202,8 +2284,8 @@ entry:
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
-  br i1 %NullCheck24, label %27, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = load i64, i64 addrspace(1)* %26
@@ -2218,8 +2300,8 @@ entry:
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
-  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
   %41 = load i64, i64 addrspace(1)* %39
@@ -2236,8 +2318,8 @@ entry:
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
-  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
   %54 = load i64, i64 addrspace(1)* %52
@@ -2252,8 +2334,8 @@ entry:
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
   %67 = load i64, i64 addrspace(1)* %65
@@ -2270,8 +2352,8 @@ entry:
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
-  br i1 %NullCheck16, label %79, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
   %80 = load i64, i64 addrspace(1)* %78
@@ -2286,8 +2368,8 @@ entry:
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
-  br i1 %NullCheck18, label %92, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
   %93 = load i64, i64 addrspace(1)* %91
@@ -2304,8 +2386,8 @@ entry:
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
-  br i1 %NullCheck12, label %105, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = load i64, i64 addrspace(1)* %104
@@ -2320,8 +2402,8 @@ entry:
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
-  br i1 %NullCheck14, label %118, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
   %119 = load i64, i64 addrspace(1)* %117
@@ -2337,8 +2419,8 @@ entry:
 
 ; <label>:128                                     ; preds = %20
   %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
-  br i1 %NullCheck4, label %130, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %129, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %130
 
 ; <label>:130                                     ; preds = %128
   %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
@@ -2346,8 +2428,8 @@ entry:
   %133 = load i16, i16 addrspace(1)* %132, align 8
   %134 = zext i16 %133 to i32
   %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
-  br i1 %NullCheck6, label %136, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %135, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %136
 
 ; <label>:136                                     ; preds = %130
   %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
@@ -2360,8 +2442,8 @@ entry:
 
 ; <label>:143                                     ; preds = %136
   %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
-  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %144, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %145
 
 ; <label>:145                                     ; preds = %143
   %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
@@ -2369,8 +2451,8 @@ entry:
   %148 = load i16, i16 addrspace(1)* %147, align 8
   %149 = zext i16 %148 to i32
   %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %150, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %151
 
 ; <label>:151                                     ; preds = %145
   %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
@@ -2388,8 +2470,8 @@ entry:
 
 ; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
-  br i1 %NullCheck, label %163, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %ThrowNullRef, label %163
 
 ; <label>:163                                     ; preds = %161
   %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
@@ -2399,8 +2481,8 @@ entry:
 
 ; <label>:167                                     ; preds = %163
   %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
-  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %168, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %169
 
 ; <label>:169                                     ; preds = %167
   %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
@@ -2432,55 +2514,55 @@ ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %167
+ThrowNullRef2:                                    ; preds = %167
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %128
+ThrowNullRef4:                                    ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %130
+ThrowNullRef6:                                    ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %143
+ThrowNullRef8:                                    ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %145
+ThrowNullRef10:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %102
+ThrowNullRef12:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %105
+ThrowNullRef14:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %76
+ThrowNullRef16:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %79
+ThrowNullRef18:                                   ; preds = %79
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %50
+ThrowNullRef20:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %53
+ThrowNullRef22:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %24
+ThrowNullRef24:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %27
+ThrowNullRef26:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2503,15 +2585,15 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2519,16 +2601,16 @@ entry:
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
   store i32 %8, i32* %loc0
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
   %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
   store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
@@ -2546,16 +2628,16 @@ entry:
 
 ; <label>:23                                      ; preds = %64
   %24 = load i16*, i16** %loc3
-  %NullCheck12 = icmp ne i16* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i16* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
   store i32 %27, i32* %loc5
   %28 = load i16*, i16** %loc4
-  %NullCheck14 = icmp ne i16* %28, null
-  br i1 %NullCheck14, label %29, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %28, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = load i16, i16* %28, align 8
@@ -2620,15 +2702,15 @@ entry:
 
 ; <label>:67                                      ; preds = %64
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
-  br i1 %NullCheck8, label %69, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %68, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %69
 
 ; <label>:69                                      ; preds = %67
   %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
   %71 = load i32, i32 addrspace(1)* %70
   %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
-  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %73
 
 ; <label>:73                                      ; preds = %69
   %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
@@ -2645,31 +2727,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %67
+ThrowNullRef8:                                    ; preds = %67
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %69
+ThrowNullRef10:                                   ; preds = %69
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2710,14 +2792,14 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
   %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
@@ -2730,14 +2812,14 @@ entry:
 
 ; <label>:11                                      ; preds = %4
   %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
   %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
@@ -2749,14 +2831,14 @@ entry:
 
 ; <label>:22                                      ; preds = %16
   %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
   %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
-  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
-  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
@@ -2804,23 +2886,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2836,7 +2918,280 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[loadElem]
+Successfully read RuntimeType.IsAssignableFrom
+
+define i8 @RuntimeType.IsAssignableFrom(%System.RuntimeType addrspace(1)* %param0, %System.Type addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.RuntimeType addrspace(1)*
+  %arg1 = alloca %System.Type addrspace(1)*
+  %loc0 = alloca %System.RuntimeType addrspace(1)*
+  %loc1 = alloca %"System.Type[]" addrspace(1)*
+  %loc2 = alloca i32
+  store %System.RuntimeType addrspace(1)* %param0, %System.RuntimeType addrspace(1)** %this
+  store %System.Type addrspace(1)* %param1, %System.Type addrspace(1)** %arg1
+  %0 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %1 = icmp ne %System.Type addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i8 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %5 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %6 = bitcast %System.Type addrspace(1)* %4 to %System.Object addrspace(1)*
+  %7 = bitcast %System.RuntimeType addrspace(1)* %5 to %System.Object addrspace(1)*
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %6, %System.Object addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %3
+  ret i8 1
+
+; <label>:12                                      ; preds = %3
+  %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 152
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 32
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
+  %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
+  %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
+  store %System.RuntimeType addrspace(1)* %25, %System.RuntimeType addrspace(1)** %loc0
+  %26 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %27 = icmp eq %System.RuntimeType addrspace(1)* %26, null
+  br i1 %27, label %34, label %28
+
+; <label>:28                                      ; preds = %15
+  %29 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %30 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)*)*)(%System.RuntimeType addrspace(1)* %29, %System.RuntimeType addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+; <label>:34                                      ; preds = %15
+  %35 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %36 = call %System.Reflection.Emit.TypeBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Reflection.Emit.TypeBuilder addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %35)
+  %37 = icmp eq %System.Reflection.Emit.TypeBuilder addrspace(1)* %36, null
+  br i1 %37, label %139, label %38
+
+; <label>:38                                      ; preds = %34
+  %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %42
+
+; <label>:42                                      ; preds = %38
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 152
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 40
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
+  %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
+  %53 = zext i8 %52 to i32
+  %54 = icmp eq i32 %53, 0
+  br i1 %54, label %56, label %55
+
+; <label>:55                                      ; preds = %42
+  ret i8 1
+
+; <label>:56                                      ; preds = %42
+  %57 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %58 = bitcast %System.RuntimeType addrspace(1)* %57 to %System.Type addrspace(1)*
+  %59 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %58)
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %64 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.Type addrspace(1)* %63, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = bitcast %System.RuntimeType addrspace(1)* %64 to %System.Type addrspace(1)*
+  %67 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %63, %System.Type addrspace(1)* %66)
+  %68 = zext i8 %67 to i32
+  %69 = trunc i32 %68 to i8
+  ret i8 %69
+
+; <label>:70                                      ; preds = %56
+  %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
+  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %73
+
+; <label>:73                                      ; preds = %70
+  %74 = load i64, i64 addrspace(1)* %72
+  %75 = add i64 %74, 128
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = add i64 %77, 0
+  %79 = inttoptr i64 %78 to i64*
+  %80 = load i64, i64* %79
+  %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
+  %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
+  %83 = call i8 %82(%System.Type addrspace(1)* %81)
+  %84 = zext i8 %83 to i32
+  %85 = icmp eq i32 %84, 0
+  br i1 %85, label %139, label %86
+
+; <label>:86                                      ; preds = %73
+  %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
+  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %89
+
+; <label>:89                                      ; preds = %86
+  %90 = load i64, i64 addrspace(1)* %88
+  %91 = add i64 %90, 128
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = add i64 %93, 24
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
+  %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
+  %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
+  store %"System.Type[]" addrspace(1)* %99, %"System.Type[]" addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %129
+
+; <label>:100                                     ; preds = %132
+  %101 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %102 = load i32, i32* %loc2
+  %NullCheck11 = icmp eq %"System.Type[]" addrspace(1)* %101, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %103
+
+; <label>:103                                     ; preds = %100
+  %104 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 1
+  %105 = load i32, i32 addrspace(1)* %104
+  %106 = zext i32 %105 to i64
+  %107 = zext i32 %102 to i64
+  %BoundsCheck = icmp uge i64 %107, %106
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %108
+
+; <label>:108                                     ; preds = %103
+  %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
+  %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
+  %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
+  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %113
+
+; <label>:113                                     ; preds = %108
+  %114 = load i64, i64 addrspace(1)* %112
+  %115 = add i64 %114, 152
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = add i64 %117, 56
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
+  %123 = zext i8 %122 to i32
+  %124 = icmp ne i32 %123, 0
+  br i1 %124, label %126, label %125
+
+; <label>:125                                     ; preds = %113
+  ret i8 0
+
+; <label>:126                                     ; preds = %113
+  %127 = load i32, i32* %loc2
+  %128 = add i32 %127, 1
+  store i32 %128, i32* %loc2
+  br label %129
+
+; <label>:129                                     ; preds = %89, %126
+  %130 = load i32, i32* %loc2
+  %131 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %NullCheck9 = icmp eq %"System.Type[]" addrspace(1)* %131, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %132
+
+; <label>:132                                     ; preds = %129
+  %133 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %131, i32 0, i32 1
+  %134 = load i32, i32 addrspace(1)* %133
+  %135 = zext i32 %134 to i64
+  %136 = trunc i64 %135 to i32
+  %137 = icmp slt i32 %130, %136
+  br i1 %137, label %100, label %138
+
+; <label>:138                                     ; preds = %132
+  ret i8 1
+
+; <label>:139                                     ; preds = %34, %73
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %129
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %103
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -2893,7 +3248,7 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElem]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -2904,8 +3259,8 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -2997,8 +3352,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
@@ -3059,8 +3414,8 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -3087,8 +3442,8 @@ entry:
 
 ; <label>:17                                      ; preds = %5, %11
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
@@ -3097,8 +3452,8 @@ entry:
 
 ; <label>:22                                      ; preds = %1, %11
   %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
@@ -3109,11 +3464,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %17
+ThrowNullRef2:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %22
+ThrowNullRef4:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3167,15 +3522,15 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
   %15 = load i32, i32 addrspace(1)* %14
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
@@ -3198,7 +3553,7 @@ ThrowNullRef:                                     ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef2:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3232,8 +3587,8 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
@@ -3312,8 +3667,8 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -3327,8 +3682,8 @@ entry:
 ; <label>:5                                       ; preds = %43
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %7 = load i32, i32* %loc1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck6, label %8, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
@@ -3366,8 +3721,8 @@ entry:
 ; <label>:32                                      ; preds = %21, %25
   %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
   %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
-  br i1 %NullCheck8, label %35, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = trunc i32 %34 to i16
@@ -3380,8 +3735,8 @@ entry:
 ; <label>:40                                      ; preds = %1, %35
   %41 = load i32, i32* %loc1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
-  br i1 %NullCheck2, label %43, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %42, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
@@ -3392,8 +3747,8 @@ entry:
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
   %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
-  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
   %51 = load i64, i64 addrspace(1)* %49
@@ -3412,19 +3767,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %40
+ThrowNullRef2:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %47
+ThrowNullRef4:                                    ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %5
+ThrowNullRef6:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %32
+ThrowNullRef8:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3467,8 +3822,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
@@ -3492,11 +3847,391 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(i16* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store i16* %param0, i16** %arg0
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load i32, i32* %arg3
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %42, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %37, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg2
+  %13 = load i32, i32* %arg3
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %37, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %24 = load i32, i32* %arg2
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load i16*, i16** %arg0
+  %35 = load i32, i32* %arg3
+  %36 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %36, i16* %34, i32 %35)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:37                                      ; preds = %5, %16
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %39)
+  %41 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41, %System.String addrspace(1)* %38, %System.String addrspace(1)* %40)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41) #0
+  unreachable
+
+; <label>:42                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
-Failed to read StringBuilder.ToString[loadElemA]
+Successfully read StringBuilder.ToString
+
+define %System.String addrspace(1)* @StringBuilder.ToString(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i16*
+  %loc3 = alloca %"System.Char[]" addrspace(1)*
+  %loc4 = alloca i32
+  %loc5 = alloca i32
+  %loc6 = alloca i16 addrspace(1)*
+  %loc7 = alloca %System.String addrspace(1)*
+  %loc8 = alloca %"System.Char[]" addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %0)
+  %2 = icmp ne i32 %1, 0
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %4
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %6)
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %7)
+  store %System.String addrspace(1)* %8, %System.String addrspace(1)** %loc0
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.Text.StringBuilder addrspace(1)* %9, %System.Text.StringBuilder addrspace(1)** %loc1
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  store %System.String addrspace(1)* %10, %System.String addrspace(1)** %loc7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc7
+  %12 = ptrtoint %System.String addrspace(1)* %11 to i64
+  %13 = icmp eq i64 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %5
+  %15 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %16 = sext i32 %15 to i64
+  %17 = add i64 %12, %16
+  br label %18
+
+; <label>:18                                      ; preds = %5, %14
+  %19 = phi i64 [ %12, %5 ], [ %17, %14 ]
+  %20 = inttoptr i64 %19 to i16*
+  store i16* %20, i16** %loc2
+  br label %21
+
+; <label>:21                                      ; preds = %98, %18
+  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %22, null
+  br i1 %NullCheck, label %ThrowNullRef, label %23
+
+; <label>:23                                      ; preds = %21
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 3
+  %25 = load i32, i32 addrspace(1)* %24, align 8
+  %26 = icmp sle i32 %25, 0
+  br i1 %26, label %96, label %27
+
+; <label>:27                                      ; preds = %23
+  %28 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %28, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %29
+
+; <label>:29                                      ; preds = %27
+  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %28, i32 0, i32 1
+  %31 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %30, align 8
+  store %"System.Char[]" addrspace(1)* %31, %"System.Char[]" addrspace(1)** %loc3
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %33
+
+; <label>:33                                      ; preds = %29
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  store i32 %35, i32* %loc4
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  %39 = load i32, i32 addrspace(1)* %38, align 8
+  store i32 %39, i32* %loc5
+  %40 = load i32, i32* %loc5
+  %41 = load i32, i32* %loc4
+  %42 = add i32 %40, %41
+  %43 = zext i32 %42 to i64
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %45
+
+; <label>:45                                      ; preds = %37
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = sext i32 %47 to i64
+  %49 = icmp sgt i64 %43, %48
+  br i1 %49, label %91, label %50
+
+; <label>:50                                      ; preds = %45
+  %51 = load i32, i32* %loc5
+  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %52, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %53
+
+; <label>:53                                      ; preds = %50
+  %54 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %52, i32 0, i32 1
+  %55 = load i32, i32 addrspace(1)* %54
+  %56 = zext i32 %55 to i64
+  %57 = trunc i64 %56 to i32
+  %58 = icmp ugt i32 %51, %57
+  br i1 %58, label %91, label %59
+
+; <label>:59                                      ; preds = %53
+  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  store %"System.Char[]" addrspace(1)* %60, %"System.Char[]" addrspace(1)** %loc8
+  %61 = icmp eq %"System.Char[]" addrspace(1)* %60, null
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %63, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %64
+
+; <label>:64                                      ; preds = %62
+  %65 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %63, i32 0, i32 1
+  %66 = load i32, i32 addrspace(1)* %65
+  %67 = zext i32 %66 to i64
+  %68 = trunc i64 %67 to i32
+  %69 = icmp ne i32 %68, 0
+  br i1 %69, label %71, label %70
+
+; <label>:70                                      ; preds = %59, %64
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:71                                      ; preds = %64
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %73
+
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %BoundsCheck = icmp uge i64 0, %76
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %77
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %78, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:79                                      ; preds = %70, %77
+  %80 = load i16*, i16** %loc2
+  %81 = load i32, i32* %loc4
+  %82 = sext i32 %81 to i64
+  %83 = mul i64 %82, 2
+  %84 = bitcast i16* %80 to i8*
+  %85 = getelementptr inbounds i8, i8* %84, i64 %83
+  %86 = load i16 addrspace(1)*, i16 addrspace(1)** %loc6
+  %87 = ptrtoint i16 addrspace(1)* %86 to i64
+  %88 = load i32, i32* %loc5
+  %89 = bitcast i8* %85 to i16*
+  %90 = inttoptr i64 %87 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %89, i16* %90, i32 %88)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %96
+
+; <label>:91                                      ; preds = %45, %53
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %94 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %93)
+  %95 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95, %System.String addrspace(1)* %92, %System.String addrspace(1)* %94)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95) #0
+  unreachable
+
+; <label>:96                                      ; preds = %23, %79
+  %97 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %97, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %98
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %97, i32 0, i32 2
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  store %System.Text.StringBuilder addrspace(1)* %100, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %102 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %102, label %21, label %103
+
+; <label>:103                                     ; preds = %98
+  store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc7
+  %104 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  ret %System.String addrspace(1)* %104
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method StringBuilder::get_Length using LLILCJit
+Successfully read StringBuilder.get_Length
+
+define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
+Successfully read RuntimeHelpers.get_OffsetToStringData
+
+define i32 @RuntimeHelpers.get_OffsetToStringData() {
+entry:
+  ret i32 12
+}
+
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
 Successfully read CultureData.CreateCultureData
 
@@ -3514,23 +4249,23 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
   store i8 %4, i8 addrspace(1)* %6
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
@@ -3549,11 +4284,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3566,50 +4301,50 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
   store i32 -1, i32 addrspace(1)* %2
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
   store i32 -1, i32 addrspace(1)* %8
   %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
   store i32 -1, i32 addrspace(1)* %14
   %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
   store i32 -1, i32 addrspace(1)* %17
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
@@ -3623,27 +4358,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3675,7 +4410,136 @@ Failed to read Dictionary`2.Insert[non-const derefAddress]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
 Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
-Failed to read HashHelpers.GetPrime[loadElem]
+Successfully read HashHelpers.GetPrime
+
+define i32 @HashHelpers.GetPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %6, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5, %System.String addrspace(1)* %4)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5) #0
+  unreachable
+
+; <label>:6                                       ; preds = %entry
+  store i32 0, i32* %loc0
+  br label %29
+
+; <label>:7                                       ; preds = %35
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 1296
+  %10 = addrspacecast i8 addrspace(1)* %9 to %"System.Int32[]" addrspace(1)**
+  %11 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %10
+  %12 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Int32[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = zext i32 %15 to i64
+  %17 = zext i32 %12 to i64
+  %BoundsCheck = icmp uge i64 %17, %16
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 3, i32 %12
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  store i32 %20, i32* %loc1
+  %21 = load i32, i32* %loc1
+  %22 = load i32, i32* %arg0
+  %23 = icmp slt i32 %21, %22
+  br i1 %23, label %26, label %24
+
+; <label>:24                                      ; preds = %18
+  %25 = load i32, i32* %loc1
+  ret i32 %25
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %loc0
+  %28 = add i32 %27, 1
+  store i32 %28, i32* %loc0
+  br label %29
+
+; <label>:29                                      ; preds = %6, %26
+  %30 = load i32, i32* %loc0
+  %31 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %32 = getelementptr inbounds i8, i8 addrspace(1)* %31, i64 1296
+  %33 = addrspacecast i8 addrspace(1)* %32 to %"System.Int32[]" addrspace(1)**
+  %34 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %33
+  %NullCheck = icmp eq %"System.Int32[]" addrspace(1)* %34, null
+  br i1 %NullCheck, label %ThrowNullRef, label %35
+
+; <label>:35                                      ; preds = %29
+  %36 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %34, i32 0, i32 1
+  %37 = load i32, i32 addrspace(1)* %36
+  %38 = zext i32 %37 to i64
+  %39 = trunc i64 %38 to i32
+  %40 = icmp slt i32 %30, %39
+  br i1 %40, label %7, label %41
+
+; <label>:41                                      ; preds = %35
+  %42 = load i32, i32* %arg0
+  %43 = or i32 %42, 1
+  store i32 %43, i32* %loc2
+  br label %59
+
+; <label>:44                                      ; preds = %59
+  %45 = load i32, i32* %loc2
+  %46 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %45)
+  %47 = zext i8 %46 to i32
+  %48 = icmp eq i32 %47, 0
+  br i1 %48, label %56, label %49
+
+; <label>:49                                      ; preds = %44
+  %50 = load i32, i32* %loc2
+  %51 = sub i32 %50, 1
+  %52 = srem i32 %51, 101
+  %53 = icmp eq i32 %52, 0
+  br i1 %53, label %56, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = load i32, i32* %loc2
+  ret i32 %55
+
+; <label>:56                                      ; preds = %44, %49
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %57, 2
+  store i32 %58, i32* %loc2
+  br label %59
+
+; <label>:59                                      ; preds = %41, %56
+  %60 = load i32, i32* %loc2
+  %61 = icmp slt i32 %60, 2147483647
+  br i1 %61, label %44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load i32, i32* %arg0
+  ret i32 %63
+
+ThrowNullRef:                                     ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
 Successfully read GenericEqualityComparer`1.GetHashCode
 
@@ -3694,14 +4558,14 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
   %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load i64, i64 addrspace(1)* %7
@@ -3720,7 +4584,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3750,8 +4614,8 @@ entry:
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
@@ -3796,8 +4660,8 @@ entry:
   %35 = bitcast i16* %34 to i8*
   %36 = getelementptr inbounds i8, i8* %35, i64 2
   %37 = bitcast i8* %36 to i16*
-  %NullCheck4 = icmp ne i16* %37, null
-  br i1 %NullCheck4, label %38, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %37, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %38
 
 ; <label>:38                                      ; preds = %27
   %39 = load i16, i16* %37, align 8
@@ -3824,8 +4688,8 @@ entry:
 
 ; <label>:54                                      ; preds = %22, %43
   %55 = load i16*, i16** %loc4
-  %NullCheck2 = icmp ne i16* %55, null
-  br i1 %NullCheck2, label %56, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i16* %55, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %56
 
 ; <label>:56                                      ; preds = %54
   %57 = load i16, i16* %55, align 8
@@ -3850,11 +4714,11 @@ ThrowNullRef:                                     ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %54
+ThrowNullRef2:                                    ; preds = %54
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %27
+ThrowNullRef4:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3871,8 +4735,8 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -3907,8 +4771,8 @@ entry:
 
 ; <label>:26                                      ; preds = %19
   %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
-  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %28
 
 ; <label>:28                                      ; preds = %26
   %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
@@ -3920,7 +4784,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3972,8 +4836,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
@@ -3984,26 +4848,26 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
-  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
@@ -4014,8 +4878,8 @@ entry:
 ; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
@@ -4024,8 +4888,8 @@ entry:
 
 ; <label>:25                                      ; preds = %1, %16, %23
   %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
-  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
@@ -4036,27 +4900,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %20
+ThrowNullRef10:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4069,8 +4933,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -4081,8 +4945,8 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
@@ -4091,8 +4955,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1, %8
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
@@ -4103,11 +4967,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4128,24 +4992,24 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   store i32 %3, i32* %loc0
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
   %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
   store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck4, label %9, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
@@ -4164,15 +5028,15 @@ entry:
 ; <label>:18                                      ; preds = %70
   %19 = load i16*, i16** %loc3
   %20 = bitcast i16* %19 to i64*
-  %NullCheck10 = icmp ne i64* %20, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %20, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = load i64, i64* %20, align 8
   %23 = load i16*, i16** %loc4
   %24 = bitcast i16* %23 to i64*
-  %NullCheck12 = icmp ne i64* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = load i64, i64* %24, align 8
@@ -4188,8 +5052,8 @@ entry:
   %31 = bitcast i16* %30 to i8*
   %32 = getelementptr inbounds i8, i8* %31, i64 8
   %33 = bitcast i8* %32 to i64*
-  %NullCheck14 = icmp ne i64* %33, null
-  br i1 %NullCheck14, label %34, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = load i64, i64* %33, align 8
@@ -4197,8 +5061,8 @@ entry:
   %37 = bitcast i16* %36 to i8*
   %38 = getelementptr inbounds i8, i8* %37, i64 8
   %39 = bitcast i8* %38 to i64*
-  %NullCheck16 = icmp ne i64* %39, null
-  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %40
 
 ; <label>:40                                      ; preds = %34
   %41 = load i64, i64* %39, align 8
@@ -4214,8 +5078,8 @@ entry:
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %NullCheck18 = icmp ne i64* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = load i64, i64* %48, align 8
@@ -4223,8 +5087,8 @@ entry:
   %52 = bitcast i16* %51 to i8*
   %53 = getelementptr inbounds i8, i8* %52, i64 16
   %54 = bitcast i8* %53 to i64*
-  %NullCheck20 = icmp ne i64* %54, null
-  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64* %54, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %55
 
 ; <label>:55                                      ; preds = %49
   %56 = load i64, i64* %54, align 8
@@ -4262,15 +5126,15 @@ entry:
 ; <label>:74                                      ; preds = %95
   %75 = load i16*, i16** %loc3
   %76 = bitcast i16* %75 to i32*
-  %NullCheck6 = icmp ne i32* %76, null
-  br i1 %NullCheck6, label %77, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32* %76, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %77
 
 ; <label>:77                                      ; preds = %74
   %78 = load i32, i32* %76, align 8
   %79 = load i16*, i16** %loc4
   %80 = bitcast i16* %79 to i32*
-  %NullCheck8 = icmp ne i32* %80, null
-  br i1 %NullCheck8, label %81, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i32* %80, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %81
 
 ; <label>:81                                      ; preds = %77
   %82 = load i32, i32* %80, align 8
@@ -4318,43 +5182,43 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %74
+ThrowNullRef6:                                    ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %77
+ThrowNullRef8:                                    ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %29
+ThrowNullRef14:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %34
+ThrowNullRef16:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4376,8 +5240,8 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load i64, i64 addrspace(1)* %4
@@ -4389,8 +5253,8 @@ entry:
   %12 = load i64, i64* %11
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %5
   %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
@@ -4399,8 +5263,8 @@ entry:
   %18 = load i8, i8* %arg2
   %19 = zext i8 %18 to i32
   %20 = trunc i32 %19 to i8
-  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %15
   %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
@@ -4411,11 +5275,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4442,8 +5306,8 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
@@ -4466,16 +5330,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
   %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = load i64, i64 addrspace(1)* %19
@@ -4500,8 +5364,8 @@ entry:
 ; <label>:35                                      ; preds = %30
   %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
@@ -4514,8 +5378,8 @@ entry:
 
 ; <label>:42                                      ; preds = %1, %38
   %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
-  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
@@ -4526,19 +5390,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %35
+ThrowNullRef2:                                    ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %42
+ThrowNullRef8:                                    ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4551,14 +5415,14 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
@@ -4570,7 +5434,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4583,8 +5447,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
@@ -4613,51 +5477,51 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
   %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
   %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
   %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
   %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
-  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
   store i64 %21, i64 addrspace(1)* %23
   %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %25 = load i64, i64* %loc0
-  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
@@ -4668,27 +5532,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %22
+ThrowNullRef12:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4701,8 +5565,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
@@ -4713,19 +5577,19 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
@@ -4734,8 +5598,8 @@ entry:
 
 ; <label>:15                                      ; preds = %1, %13
   %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
@@ -4746,19 +5610,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %15
+ThrowNullRef8:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4771,8 +5635,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -4831,8 +5695,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
@@ -4882,8 +5746,8 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
-  br i1 %NullCheck, label %17, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %ThrowNullRef, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
@@ -4894,15 +5758,15 @@ entry:
 
 ; <label>:22                                      ; preds = %17
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
-  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
   %26 = load i32, i32 addrspace(1)* %25
   %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
-  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %27, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
@@ -4925,8 +5789,8 @@ entry:
 ; <label>:40                                      ; preds = %17
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
-  br i1 %NullCheck6, label %43, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %41, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
@@ -4938,34 +5802,17 @@ ThrowNullRef:                                     ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %24
+ThrowNullRef4:                                    ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %40
+ThrowNullRef6:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
-}
-
-INFO:  jitting method Object::ReferenceEquals using LLILCJit
-Successfully read Object.ReferenceEquals
-
-define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
-entry:
-  %arg0 = alloca %System.Object addrspace(1)*
-  %arg1 = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
-  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
-  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = icmp eq %System.Object addrspace(1)* %0, %1
-  %3 = sext i1 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
 }
 
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
@@ -4978,21 +5825,21 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
   %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
-  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
@@ -5007,28 +5854,28 @@ entry:
 ; <label>:13                                      ; preds = %8, %12
   %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
   %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
   %21 = load i32, i32 addrspace(1)* %20, align 8
   %22 = add i32 %21, 1
-  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
   store i32 %22, i32 addrspace(1)* %24
   %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
@@ -5039,27 +5886,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5077,7 +5924,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::Setup using LLILCJit
-Failed to read AppDomain.Setup[loadElem]
+Failed to read AppDomain.Setup[unbox]
 INFO:  jitting method Thread::GetDomain using LLILCJit
 Successfully read Thread.GetDomain
 
@@ -5108,8 +5955,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
@@ -5122,14 +5969,14 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
   %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
@@ -5141,11 +5988,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5173,8 +6020,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -5189,7 +6036,328 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
 Failed to read KeyCollection.System.Collections.Generic.IEnumerable<TKey>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Successfully read Enumerator.MoveNext
+
+define i8 @Enumerator.MoveNext(%"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.RuntimeTypeHandle* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*
+  %"$TypeArg" = alloca %System.RuntimeTypeHandle*
+  store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
+  %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 8
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %76, label %12
+
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
+  br label %76
+
+; <label>:13                                      ; preds = %85
+  %14 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck19 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %15
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, i32 0, i32 0
+  %17 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %16, align 8
+  %NullCheck21 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, i32 0, i32 2
+  %20 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %19, align 8
+  %21 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck23 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %22
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, i32 0, i32 2
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %NullCheck25 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 3, i32 %24
+  %NullCheck27 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %32
+
+; <label>:32                                      ; preds = %30
+  %33 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, i32 0, i32 2
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = icmp slt i32 %34, 0
+  br i1 %35, label %68, label %36
+
+; <label>:36                                      ; preds = %32
+  %37 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %38 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck29 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %39
+
+; <label>:39                                      ; preds = %36
+  %40 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, i32 0, i32 0
+  %41 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %40, align 8
+  %NullCheck31 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, i32 0, i32 2
+  %44 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %43, align 8
+  %45 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck33 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, i32 0, i32 2
+  %48 = load i32, i32 addrspace(1)* %47, align 8
+  %NullCheck35 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %49
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = zext i32 %51 to i64
+  %53 = zext i32 %48 to i64
+  %BoundsCheck37 = icmp uge i64 %53, %52
+  br i1 %BoundsCheck37, label %ThrowIndexOutOfRange38, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 3, i32 %48
+  %NullCheck39 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %56
+
+; <label>:56                                      ; preds = %54
+  %57 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, i32 0, i32 0
+  %58 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck41 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %59
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %60, %System.__Canon addrspace(1)* %58)
+  %61 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck43 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  %64 = load i32, i32 addrspace(1)* %63, align 8
+  %65 = add i32 %64, 1
+  %NullCheck45 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  store i32 %65, i32 addrspace(1)* %67
+  ret i8 1
+
+; <label>:68                                      ; preds = %32
+  %69 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck47 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %73 = add i32 %72, 1
+  %NullCheck49 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %74
+
+; <label>:74                                      ; preds = %70
+  %75 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  store i32 %73, i32 addrspace(1)* %75
+  br label %76
+
+; <label>:76                                      ; preds = %8, %12, %74
+  %77 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %78
+
+; <label>:78                                      ; preds = %76
+  %79 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, i32 0, i32 2
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck7 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %82
+
+; <label>:82                                      ; preds = %78
+  %83 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, i32 0, i32 0
+  %84 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %83, align 8
+  %NullCheck9 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %85
+
+; <label>:85                                      ; preds = %82
+  %86 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, i32 0, i32 7
+  %87 = load i32, i32 addrspace(1)* %86, align 8
+  %88 = icmp ult i32 %80, %87
+  br i1 %88, label %13, label %89
+
+; <label>:89                                      ; preds = %85
+  %90 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %91 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck11 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %92
+
+; <label>:92                                      ; preds = %89
+  %93 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, i32 0, i32 0
+  %94 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck13 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %95
+
+; <label>:95                                      ; preds = %92
+  %96 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, i32 0, i32 7
+  %97 = load i32, i32 addrspace(1)* %96, align 8
+  %98 = add i32 %97, 1
+  %NullCheck15 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %99
+
+; <label>:99                                      ; preds = %95
+  %100 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, i32 0, i32 2
+  store i32 %98, i32 addrspace(1)* %100
+  %101 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck17 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %102
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %103, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %92
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef22:                                   ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef24:                                   ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef26:                                   ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef28:                                   ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef30:                                   ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef32:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef34:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef36:                                   ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange38:                           ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef40:                                   ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef42:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef44:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef46:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef48:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef50:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -5200,8 +6368,8 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -5232,9 +6400,9 @@ Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
 Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
-Failed to read String.MakeSeparatorList[loadElemA]
+Failed to read String.MakeSeparatorList[storeElem]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
-Failed to read String.InternalSplitKeepEmptyEntries[loadElem]
+Failed to read String.InternalSplitKeepEmptyEntries[storeElem]
 INFO:  jitting method Path::IsRelative using LLILCJit
 Successfully read Path.IsRelative
 
@@ -5243,8 +6411,8 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -5254,8 +6422,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
@@ -5271,8 +6439,8 @@ entry:
 
 ; <label>:17                                      ; preds = %7
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
@@ -5288,8 +6456,8 @@ entry:
 
 ; <label>:29                                      ; preds = %19
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %31
 
 ; <label>:31                                      ; preds = %29
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
@@ -5300,8 +6468,8 @@ entry:
 
 ; <label>:36                                      ; preds = %31
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
-  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %37, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
@@ -5312,8 +6480,8 @@ entry:
 
 ; <label>:43                                      ; preds = %31, %38
   %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
-  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %45
 
 ; <label>:45                                      ; preds = %43
   %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
@@ -5324,8 +6492,8 @@ entry:
 
 ; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %50
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
@@ -5336,8 +6504,8 @@ entry:
 
 ; <label>:57                                      ; preds = %1, %7, %19, %45, %52
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
-  br i1 %NullCheck14, label %59, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %59
 
 ; <label>:59                                      ; preds = %57
   %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
@@ -5347,8 +6515,8 @@ entry:
 
 ; <label>:63                                      ; preds = %59
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
@@ -5359,8 +6527,8 @@ entry:
 
 ; <label>:70                                      ; preds = %65
   %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
-  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.String addrspace(1)* %71, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %72
 
 ; <label>:72                                      ; preds = %70
   %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
@@ -5379,39 +6547,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %17
+ThrowNullRef4:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %29
+ThrowNullRef6:                                    ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %36
+ThrowNullRef8:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %43
+ThrowNullRef10:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %50
+ThrowNullRef12:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %57
+ThrowNullRef14:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %63
+ThrowNullRef16:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %70
+ThrowNullRef18:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5419,7 +6587,293 @@ ThrowNullRef17:                                   ; preds = %70
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
-Failed to read String.TrimHelper[loadElem]
+Successfully read String.TrimHelper
+
+define %System.String addrspace(1)* @String.TrimHelper(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i16
+  %loc4 = alloca i32
+  %loc5 = alloca i16
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = sub i32 %3, 1
+  store i32 %4, i32* %loc0
+  store i32 0, i32* %loc1
+  %5 = load i32, i32* %arg2
+  %6 = icmp eq i32 %5, 1
+  br i1 %6, label %62, label %7
+
+; <label>:7                                       ; preds = %1
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:8                                       ; preds = %58
+  store i32 0, i32* %loc2
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load i32, i32* %loc1
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2, i32 %10
+  %13 = load i16, i16 addrspace(1)* %12
+  %14 = zext i16 %13 to i32
+  %15 = trunc i32 %14 to i16
+  store i16 %15, i16* %loc3
+  store i32 0, i32* %loc2
+  br label %34
+
+; <label>:16                                      ; preds = %37
+  %17 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %18 = load i32, i32* %loc2
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %17, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %19
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = zext i32 %18 to i64
+  %BoundsCheck = icmp uge i64 %23, %22
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %24
+
+; <label>:24                                      ; preds = %19
+  %25 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 3, i32 %18
+  %26 = load i16, i16 addrspace(1)* %25, align 8
+  %27 = zext i16 %26 to i32
+  %28 = load i16, i16* %loc3
+  %29 = zext i16 %28 to i32
+  %30 = icmp eq i32 %27, %29
+  br i1 %30, label %43, label %31
+
+; <label>:31                                      ; preds = %24
+  %32 = load i32, i32* %loc2
+  %33 = add i32 %32, 1
+  store i32 %33, i32* %loc2
+  br label %34
+
+; <label>:34                                      ; preds = %11, %31
+  %35 = load i32, i32* %loc2
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = icmp slt i32 %35, %41
+  br i1 %42, label %16, label %43
+
+; <label>:43                                      ; preds = %24, %37
+  %44 = load i32, i32* %loc2
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %45, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp eq i32 %44, %50
+  br i1 %51, label %62, label %52
+
+; <label>:52                                      ; preds = %46
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %7, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %57, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %58
+
+; <label>:58                                      ; preds = %55
+  %59 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %60 = load i32, i32 addrspace(1)* %59
+  %61 = icmp slt i32 %56, %60
+  br i1 %61, label %8, label %62
+
+; <label>:62                                      ; preds = %1, %46, %58
+  %63 = load i32, i32* %arg2
+  %64 = icmp eq i32 %63, 0
+  br i1 %64, label %122, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %66, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %67
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %66, i32 0, i32 1
+  %69 = load i32, i32 addrspace(1)* %68
+  %70 = sub i32 %69, 1
+  store i32 %70, i32* %loc0
+  br label %118
+
+; <label>:71                                      ; preds = %118
+  store i32 0, i32* %loc4
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %73 = load i32, i32* %loc0
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %74
+
+; <label>:74                                      ; preds = %71
+  %75 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 2, i32 %73
+  %76 = load i16, i16 addrspace(1)* %75
+  %77 = zext i16 %76 to i32
+  %78 = trunc i32 %77 to i16
+  store i16 %78, i16* %loc5
+  store i32 0, i32* %loc4
+  br label %97
+
+; <label>:79                                      ; preds = %100
+  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %81 = load i32, i32* %loc4
+  %NullCheck19 = icmp eq %"System.Char[]" addrspace(1)* %80, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
+
+; <label>:82                                      ; preds = %79
+  %83 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 1
+  %84 = load i32, i32 addrspace(1)* %83
+  %85 = zext i32 %84 to i64
+  %86 = zext i32 %81 to i64
+  %BoundsCheck21 = icmp uge i64 %86, %85
+  br i1 %BoundsCheck21, label %ThrowIndexOutOfRange22, label %87
+
+; <label>:87                                      ; preds = %82
+  %88 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 3, i32 %81
+  %89 = load i16, i16 addrspace(1)* %88, align 8
+  %90 = zext i16 %89 to i32
+  %91 = load i16, i16* %loc5
+  %92 = zext i16 %91 to i32
+  %93 = icmp eq i32 %90, %92
+  br i1 %93, label %106, label %94
+
+; <label>:94                                      ; preds = %87
+  %95 = load i32, i32* %loc4
+  %96 = add i32 %95, 1
+  store i32 %96, i32* %loc4
+  br label %97
+
+; <label>:97                                      ; preds = %74, %94
+  %98 = load i32, i32* %loc4
+  %99 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck15 = icmp eq %"System.Char[]" addrspace(1)* %99, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %100
+
+; <label>:100                                     ; preds = %97
+  %101 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %99, i32 0, i32 1
+  %102 = load i32, i32 addrspace(1)* %101
+  %103 = zext i32 %102 to i64
+  %104 = trunc i64 %103 to i32
+  %105 = icmp slt i32 %98, %104
+  br i1 %105, label %79, label %106
+
+; <label>:106                                     ; preds = %87, %100
+  %107 = load i32, i32* %loc4
+  %108 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck17 = icmp eq %"System.Char[]" addrspace(1)* %108, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %109
+
+; <label>:109                                     ; preds = %106
+  %110 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %108, i32 0, i32 1
+  %111 = load i32, i32 addrspace(1)* %110
+  %112 = zext i32 %111 to i64
+  %113 = trunc i64 %112 to i32
+  %114 = icmp eq i32 %107, %113
+  br i1 %114, label %122, label %115
+
+; <label>:115                                     ; preds = %109
+  %116 = load i32, i32* %loc0
+  %117 = sub i32 %116, 1
+  store i32 %117, i32* %loc0
+  br label %118
+
+; <label>:118                                     ; preds = %67, %115
+  %119 = load i32, i32* %loc0
+  %120 = load i32, i32* %loc1
+  %121 = icmp sge i32 %119, %120
+  br i1 %121, label %71, label %122
+
+; <label>:122                                     ; preds = %62, %109, %118
+  %123 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %124 = load i32, i32* %loc1
+  %125 = load i32, i32* %loc0
+  %126 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %123, i32 %124, i32 %125)
+  ret %System.String addrspace(1)* %126
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %97
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange22:                           ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
 Successfully read String.CreateTrimmedString
 
@@ -5439,8 +6893,8 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
@@ -5535,8 +6989,8 @@ entry:
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i64 2872
   %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
   %8 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %7
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %3
   %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
@@ -5553,8 +7007,8 @@ entry:
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 2864
   %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
   %21 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %20
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
-  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %22
 
 ; <label>:22                                      ; preds = %16
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
@@ -5569,7 +7023,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %16
+ThrowNullRef2:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5586,8 +7040,8 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5613,8 +7067,8 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
@@ -5632,8 +7086,8 @@ entry:
 
 ; <label>:12                                      ; preds = %4
   %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
@@ -5644,8 +7098,8 @@ entry:
 
 ; <label>:19                                      ; preds = %14
   %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %19
   %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
@@ -5660,21 +7114,21 @@ entry:
   %31 = zext i16 %30 to i32
   %32 = bitcast i8* %29 to i16*
   %33 = trunc i32 %31 to i16
-  %NullCheck6 = icmp ne i16* %32, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i16* %32, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %21
   store i16 %33, i16* %32, align 8
   %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %36
 
 ; <label>:36                                      ; preds = %34
   %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
   %38 = load i32, i32 addrspace(1)* %37, align 8
   %39 = add i32 %38, 1
-  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %40
 
 ; <label>:40                                      ; preds = %36
   %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
@@ -5683,16 +7137,16 @@ entry:
 
 ; <label>:42                                      ; preds = %14
   %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
-  br i1 %NullCheck12, label %44, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
   %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
   %47 = load i16, i16* %arg1
   %48 = zext i16 %47 to i32
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = trunc i32 %48 to i16
@@ -5703,31 +7157,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %19
+ThrowNullRef4:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %21
+ThrowNullRef6:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %36
+ThrowNullRef10:                                   ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %42
+ThrowNullRef12:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %44
+ThrowNullRef14:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5740,8 +7194,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -5752,8 +7206,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
@@ -5762,14 +7216,14 @@ entry:
 
 ; <label>:11                                      ; preds = %1
   %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
@@ -5779,15 +7233,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5808,8 +7262,8 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5822,8 +7276,8 @@ entry:
 
 ; <label>:8                                       ; preds = %3
   %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
@@ -5842,15 +7296,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
-  br i1 %NullCheck4, label %22, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
   %24 = load i16*, i16* addrspace(1)* %23, align 8
   %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %25, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
@@ -5859,8 +7313,8 @@ entry:
   store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
@@ -5874,8 +7328,8 @@ entry:
 
 ; <label>:37                                      ; preds = %65
   %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %37
   %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
@@ -5886,16 +7340,16 @@ entry:
   %45 = bitcast i16* %41 to i8*
   %46 = getelementptr inbounds i8, i8* %45, i64 %44
   %47 = bitcast i8* %46 to i16*
-  %NullCheck14 = icmp ne i16* %47, null
-  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %47, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %48
 
 ; <label>:48                                      ; preds = %39
   %49 = load i16, i16* %47, align 8
   %50 = zext i16 %49 to i32
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %52 = load i32, i32* %loc1
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %53
 
 ; <label>:53                                      ; preds = %48
   %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
@@ -5916,8 +7370,8 @@ entry:
 ; <label>:62                                      ; preds = %36, %59
   %63 = load i32, i32* %loc1
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck10, label %65, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %65
 
 ; <label>:65                                      ; preds = %62
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
@@ -5936,15 +7390,15 @@ entry:
 
 ; <label>:74                                      ; preds = %70
   %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
-  br i1 %NullCheck18, label %76, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %76
 
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
   %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
-  br i1 %NullCheck20, label %80, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
   %81 = load i64, i64 addrspace(1)* %79
@@ -5958,8 +7412,8 @@ entry:
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
   %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
-  br i1 %NullCheck22, label %92, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.String addrspace(1)* %90, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %92
 
 ; <label>:92                                      ; preds = %80
   %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
@@ -5969,15 +7423,15 @@ entry:
 
 ; <label>:96                                      ; preds = %70
   %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
-  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %98
 
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
   %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
-  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
   %103 = load i64, i64 addrspace(1)* %101
@@ -5991,8 +7445,8 @@ entry:
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
   %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
-  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.String addrspace(1)* %112, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %114
 
 ; <label>:114                                     ; preds = %102
   %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
@@ -6004,59 +7458,59 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %20
+ThrowNullRef4:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %22
+ThrowNullRef6:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %26
+ThrowNullRef8:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %62
+ThrowNullRef10:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %48
+ThrowNullRef16:                                   ; preds = %48
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %74
+ThrowNullRef18:                                   ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %76
+ThrowNullRef20:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %80
+ThrowNullRef22:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %96
+ThrowNullRef24:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %98
+ThrowNullRef26:                                   ; preds = %98
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %102
+ThrowNullRef28:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6069,15 +7523,15 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
   %3 = load i16*, i16* addrspace(1)* %2, align 8
   %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
@@ -6087,8 +7541,8 @@ entry:
   %10 = bitcast i16* %3 to i8*
   %11 = getelementptr inbounds i8, i8* %10, i64 %9
   %12 = bitcast i8* %11 to i16*
-  %NullCheck4 = icmp ne i16* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %5
   store i16 0, i16* %12, align 8
@@ -6098,11 +7552,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6119,8 +7573,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -6131,8 +7585,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
@@ -6144,15 +7598,15 @@ entry:
 
 ; <label>:14                                      ; preds = %1
   %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
   %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
   %21 = load i64, i64 addrspace(1)* %19
@@ -6171,15 +7625,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %14
+ThrowNullRef4:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %16
+ThrowNullRef6:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6302,14 +7756,6 @@ entry:
   ret %System.String addrspace(1)* %57
 }
 
-INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
-Successfully read RuntimeHelpers.get_OffsetToStringData
-
-define i32 @RuntimeHelpers.get_OffsetToStringData() {
-entry:
-  ret i32 12
-}
-
 INFO:  jitting method String::Equals using LLILCJit
 Successfully read String.Equals
 
@@ -6381,8 +7827,8 @@ entry:
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
-  br i1 %NullCheck24, label %29, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
   %30 = load i64, i64 addrspace(1)* %28
@@ -6397,8 +7843,8 @@ entry:
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
-  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
   %43 = load i64, i64 addrspace(1)* %41
@@ -6418,8 +7864,8 @@ entry:
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
   %59 = load i64, i64 addrspace(1)* %57
@@ -6434,8 +7880,8 @@ entry:
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck22, label %71, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
   %72 = load i64, i64 addrspace(1)* %70
@@ -6455,8 +7901,8 @@ entry:
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
-  br i1 %NullCheck16, label %87, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = load i64, i64 addrspace(1)* %86
@@ -6471,8 +7917,8 @@ entry:
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck18, label %100, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
   %101 = load i64, i64 addrspace(1)* %99
@@ -6492,8 +7938,8 @@ entry:
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
-  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
   %117 = load i64, i64 addrspace(1)* %115
@@ -6508,8 +7954,8 @@ entry:
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
-  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
   %130 = load i64, i64 addrspace(1)* %128
@@ -6528,15 +7974,15 @@ entry:
 
 ; <label>:142                                     ; preds = %22
   %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
-  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %143, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %144
 
 ; <label>:144                                     ; preds = %142
   %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
   %146 = load i32, i32 addrspace(1)* %145
   %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
-  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %147, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %148
 
 ; <label>:148                                     ; preds = %144
   %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
@@ -6557,15 +8003,15 @@ entry:
 
 ; <label>:159                                     ; preds = %22
   %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
-  br i1 %NullCheck, label %161, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %ThrowNullRef, label %161
 
 ; <label>:161                                     ; preds = %159
   %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
   %163 = load i32, i32 addrspace(1)* %162
   %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
-  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %164, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %165
 
 ; <label>:165                                     ; preds = %161
   %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
@@ -6578,8 +8024,8 @@ entry:
 
 ; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
-  br i1 %NullCheck4, label %172, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %171, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %172
 
 ; <label>:172                                     ; preds = %170
   %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
@@ -6589,8 +8035,8 @@ entry:
 
 ; <label>:176                                     ; preds = %172
   %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
-  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %177, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %178
 
 ; <label>:178                                     ; preds = %176
   %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
@@ -6629,55 +8075,55 @@ ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %161
+ThrowNullRef2:                                    ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %170
+ThrowNullRef4:                                    ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %176
+ThrowNullRef6:                                    ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %142
+ThrowNullRef8:                                    ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %144
+ThrowNullRef10:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %113
+ThrowNullRef12:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %116
+ThrowNullRef14:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %84
+ThrowNullRef16:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %87
+ThrowNullRef18:                                   ; preds = %87
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %55
+ThrowNullRef20:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %58
+ThrowNullRef22:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %26
+ThrowNullRef24:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %29
+ThrowNullRef26:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,8 +8161,8 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck, label %14, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %ThrowNullRef, label %14
 
 ; <label>:14                                      ; preds = %8
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
@@ -6760,8 +8206,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
@@ -6770,14 +8216,14 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32, i32* %loc0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %10
   %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
   %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
@@ -6790,15 +8236,15 @@ entry:
 ; <label>:25                                      ; preds = %19
   %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
-  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
   %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
@@ -6807,8 +8253,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %37 = load i32, i32* %loc0
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %38, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %38
 
 ; <label>:38                                      ; preds = %32
   %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
@@ -6817,14 +8263,14 @@ entry:
 
 ; <label>:40                                      ; preds = %19
   %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %40
   %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
   %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
-  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
-  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
@@ -6832,8 +8278,8 @@ entry:
   %48 = zext i32 %47 to i64
   %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
-  br i1 %NullCheck16, label %51, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %51
 
 ; <label>:51                                      ; preds = %45
   %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
@@ -6847,15 +8293,15 @@ entry:
 ; <label>:57                                      ; preds = %51
   %58 = load i16*, i16** %arg1
   %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
-  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %60
 
 ; <label>:60                                      ; preds = %57
   %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
   %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
-  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %64
 
 ; <label>:64                                      ; preds = %60
   %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
@@ -6864,22 +8310,22 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
   %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
-  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %70
 
 ; <label>:70                                      ; preds = %64
   %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
   %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
-  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
-  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
   %75 = load i32, i32 addrspace(1)* %74
   %76 = zext i32 %75 to i64
   %77 = trunc i64 %76 to i32
-  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
-  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %78
 
 ; <label>:78                                      ; preds = %73
   %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
@@ -6901,8 +8347,8 @@ entry:
   %90 = bitcast i16* %86 to i8*
   %91 = getelementptr inbounds i8, i8* %90, i64 %89
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %93
 
 ; <label>:93                                      ; preds = %80
   %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
@@ -6912,8 +8358,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %99 = load i32, i32* %loc2
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %100
 
 ; <label>:100                                     ; preds = %93
   %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
@@ -6928,63 +8374,63 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %25
+ThrowNullRef6:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %32
+ThrowNullRef10:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %40
+ThrowNullRef12:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %45
+ThrowNullRef16:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %57
+ThrowNullRef18:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %60
+ThrowNullRef20:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %64
+ThrowNullRef22:                                   ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %70
+ThrowNullRef24:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %73
+ThrowNullRef26:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %80
+ThrowNullRef28:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %93
+ThrowNullRef30:                                   ; preds = %93
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7004,8 +8450,8 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
@@ -7033,43 +8479,43 @@ entry:
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %14
   %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
   %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   %28 = load i32, i32 addrspace(1)* %27, align 8
   %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
-  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %30
 
 ; <label>:30                                      ; preds = %26
   %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
   %32 = load i32, i32 addrspace(1)* %31, align 8
   %33 = add i32 %28, %32
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %34
 
 ; <label>:34                                      ; preds = %30
   %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   store i32 %33, i32 addrspace(1)* %35
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
   store i32 0, i32 addrspace(1)* %38
   %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %40
 
 ; <label>:40                                      ; preds = %37
   %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
@@ -7082,8 +8528,8 @@ entry:
 
 ; <label>:47                                      ; preds = %40
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
@@ -7098,8 +8544,8 @@ entry:
   %54 = load i32, i32* %loc0
   %55 = sext i32 %54 to i64
   %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
-  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %57
 
 ; <label>:57                                      ; preds = %52
   %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
@@ -7110,68 +8556,35 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %14
+ThrowNullRef2:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %23
+ThrowNullRef4:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %26
+ThrowNullRef6:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %30
+ThrowNullRef8:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %34
+ThrowNullRef10:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %47
+ThrowNullRef14:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %52
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-}
-
-INFO:  jitting method StringBuilder::get_Length using LLILCJit
-Successfully read StringBuilder.get_Length
-
-define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.StringBuilder addrspace(1)*
-  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
-  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
-
-; <label>:1                                       ; preds = %entry
-  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %3 = load i32, i32 addrspace(1)* %2, align 8
-  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
-
-; <label>:5                                       ; preds = %1
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = add i32 %3, %7
-  ret i32 %8
-
-ThrowNullRef:                                     ; preds = %entry
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef16:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7213,70 +8626,70 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
   %6 = load i32, i32 addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
   store i32 %6, i32 addrspace(1)* %8
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
   %13 = load i32, i32 addrspace(1)* %12, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
   store i32 %13, i32 addrspace(1)* %15
   %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
-  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %18
 
 ; <label>:18                                      ; preds = %14
   %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
   %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
   %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
   %34 = load i32, i32 addrspace(1)* %33, align 8
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
-  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
@@ -7287,39 +8700,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %28
+ThrowNullRef16:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %32
+ThrowNullRef18:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7455,13 +8868,13 @@ entry:
 ; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
@@ -7477,16 +8890,16 @@ entry:
 
 ; <label>:18                                      ; preds = %15
   %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
   store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
   %22 = load i32, i32* %loc0
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %24
 
 ; <label>:24                                      ; preds = %20
   %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
@@ -7498,13 +8911,13 @@ entry:
 ; <label>:28                                      ; preds = %15, %24
   %29 = load i32, i32* %arg1
   %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %31
   %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
@@ -7517,20 +8930,20 @@ entry:
   %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
-  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
   %46 = load i32, i32 addrspace(1)* %45, align 8
   %47 = sub i32 %40, %46
-  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
-  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i32 addrspace(1)* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %48
 
 ; <label>:48                                      ; preds = %44
   store i32 %47, i32 addrspace(1)* %39, align 8
@@ -7538,21 +8951,21 @@ entry:
 
 ; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
-  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %51
 
 ; <label>:51                                      ; preds = %49
   %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %53
 
 ; <label>:53                                      ; preds = %51
   %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
   %55 = load i32, i32 addrspace(1)* %54, align 8
   %56 = load i32, i32* %arg2
   %57 = sub i32 %55, %56
-  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %58
 
 ; <label>:58                                      ; preds = %53
   %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
@@ -7562,13 +8975,13 @@ entry:
 ; <label>:60                                      ; preds = %33, %58
   %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
   %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
-  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %63
 
 ; <label>:63                                      ; preds = %60
   %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
-  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
-  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
@@ -7578,15 +8991,15 @@ entry:
 
 ; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
-  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i32 addrspace(1)* %69, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %70
 
 ; <label>:70                                      ; preds = %68
   %71 = load i32, i32 addrspace(1)* %69, align 8
   store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
-  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
@@ -7596,8 +9009,8 @@ entry:
   store i32 %77, i32* %loc4
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
-  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %80
 
 ; <label>:80                                      ; preds = %73
   %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
@@ -7607,71 +9020,71 @@ entry:
 ; <label>:83                                      ; preds = %80
   store i32 0, i32* %loc3
   %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
-  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
-  br i1 %NullCheck26, label %88, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i32 addrspace(1)* %87, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %88
 
 ; <label>:88                                      ; preds = %85
   %89 = load i32, i32 addrspace(1)* %87, align 8
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
-  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %90
 
 ; <label>:90                                      ; preds = %88
   %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
   store i32 %89, i32 addrspace(1)* %91
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
-  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
-  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %96
 
 ; <label>:96                                      ; preds = %94
   %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
-  br i1 %NullCheck34, label %100, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %100
 
 ; <label>:100                                     ; preds = %96
   %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
-  br i1 %NullCheck36, label %102, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %102
 
 ; <label>:102                                     ; preds = %100
   %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
   %104 = load i32, i32 addrspace(1)* %103, align 8
   %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
-  br i1 %NullCheck38, label %106, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %106
 
 ; <label>:106                                     ; preds = %102
   %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
-  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
-  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %108
 
 ; <label>:108                                     ; preds = %106
   %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
   %110 = load i32, i32 addrspace(1)* %109, align 8
   %111 = add i32 %104, %110
-  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %112
 
 ; <label>:112                                     ; preds = %108
   %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
   store i32 %111, i32 addrspace(1)* %113
   %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
-  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i32 addrspace(1)* %114, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %115
 
 ; <label>:115                                     ; preds = %112
   %116 = load i32, i32 addrspace(1)* %114, align 8
@@ -7681,19 +9094,19 @@ entry:
 ; <label>:118                                     ; preds = %115
   %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
-  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %121
 
 ; <label>:121                                     ; preds = %118
   %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
-  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
-  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %123
 
 ; <label>:123                                     ; preds = %121
   %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
   %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
-  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
-  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %126
 
 ; <label>:126                                     ; preds = %123
   %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
@@ -7705,8 +9118,8 @@ entry:
 
 ; <label>:130                                     ; preds = %80, %115, %126
   %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %132
 
 ; <label>:132                                     ; preds = %130
   %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7715,8 +9128,8 @@ entry:
   %136 = load i32, i32* %loc3
   %137 = sub i32 %135, %136
   %138 = sub i32 %134, %137
-  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %139
 
 ; <label>:139                                     ; preds = %132
   %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7728,16 +9141,16 @@ entry:
 
 ; <label>:144                                     ; preds = %139
   %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
-  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %146
 
 ; <label>:146                                     ; preds = %144
   %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
   %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
   %149 = load i32, i32* %loc2
   %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
-  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %151
 
 ; <label>:151                                     ; preds = %146
   %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
@@ -7754,145 +9167,249 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %18
+ThrowNullRef4:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %31
+ThrowNullRef10:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %44
+ThrowNullRef16:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %68
+ThrowNullRef18:                                   ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %70
+ThrowNullRef20:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %73
+ThrowNullRef22:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %83
+ThrowNullRef24:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %85
+ThrowNullRef26:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %88
+ThrowNullRef28:                                   ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %90
+ThrowNullRef30:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %94
+ThrowNullRef32:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %96
+ThrowNullRef34:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %100
+ThrowNullRef36:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %102
+ThrowNullRef38:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %106
+ThrowNullRef40:                                   ; preds = %106
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %108
+ThrowNullRef42:                                   ; preds = %108
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %112
+ThrowNullRef44:                                   ; preds = %112
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %118
+ThrowNullRef46:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %121
+ThrowNullRef48:                                   ; preds = %121
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %123
+ThrowNullRef50:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %130
+ThrowNullRef52:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %132
+ThrowNullRef54:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %144
+ThrowNullRef56:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %146
+ThrowNullRef58:                                   ; preds = %146
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %60
+ThrowNullRef60:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %63
+ThrowNullRef62:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %49
+ThrowNullRef64:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %51
+ThrowNullRef66:                                   ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %53
+ThrowNullRef68:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(%"System.Char[]" addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %arg0 = alloca %"System.Char[]" addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store %"System.Char[]" addrspace(1)* %param0, %"System.Char[]" addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load i32, i32* %arg4
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %43, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %38, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg1
+  %13 = load i32, i32* %arg4
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %38, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %24 = load i32, i32* %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %35 = load i32, i32* %arg3
+  %36 = load i32, i32* %arg4
+  %37 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %37, %"System.Char[]" addrspace(1)* %34, i32 %35, i32 %36)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:38                                      ; preds = %5, %16
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Successfully read Buffer._Memmove
 
@@ -7914,7 +9431,7 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[loadElem]
+Failed to read AppDomain.SetDataHelper[storeElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -7923,8 +9440,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
@@ -7934,8 +9451,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
@@ -7947,15 +9464,15 @@ entry:
   %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
   %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
@@ -7966,15 +9483,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7992,7 +9509,79 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
-Failed to read Dictionary`2.TryGetValue[loadElemA]
+Successfully read Dictionary`2.TryGetValue
+
+define i8 @"Dictionary`2.TryGetValue"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)* addrspace(1)* %param2) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  %arg2 = alloca %System.__Canon addrspace(1)* addrspace(1)*
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  store %System.__Canon addrspace(1)* addrspace(1)* %param2, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  store i32 %2, i32* %loc0
+  %3 = load i32, i32* %loc0
+  %4 = icmp slt i32 %3, 0
+  br i1 %4, label %22, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 2
+  %10 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %9, align 8
+  %11 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = zext i32 %11 to i64
+  %BoundsCheck = icmp uge i64 %16, %15
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 3, i32 %11
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %20, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %6, %System.__Canon addrspace(1)* %21)
+  ret i8 1
+
+; <label>:22                                      ; preds = %entry
+  %23 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %23, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -8058,8 +9647,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
@@ -8091,8 +9680,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
@@ -8171,15 +9760,15 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck, label %19, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %ThrowNullRef, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
   %21 = load i32, i32 addrspace(1)* %20
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
@@ -8202,7 +9791,7 @@ ThrowNullRef:                                     ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %19
+ThrowNullRef2:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8248,8 +9837,8 @@ entry:
   %0 = alloca %System.AppDomainHandle
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %1 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %1, i32 0, i32 15
@@ -8269,8 +9858,8 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
@@ -8286,7 +9875,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -8299,8 +9888,8 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -8327,8 +9916,8 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
@@ -8352,8 +9941,8 @@ entry:
   %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
   store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
@@ -8363,8 +9952,8 @@ entry:
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
@@ -8374,8 +9963,8 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %9
   %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
@@ -8384,8 +9973,8 @@ entry:
 
 ; <label>:18                                      ; preds = %3, %16
   %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
@@ -8397,15 +9986,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %18
+ThrowNullRef6:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8418,8 +10007,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
@@ -8453,15 +10042,15 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
@@ -8473,7 +10062,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8481,7 +10070,7 @@ ThrowNullRef1:                                    ; preds = %1
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
 Failed to read Dictionary`2.System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
@@ -8506,8 +10095,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
@@ -8524,8 +10113,8 @@ entry:
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -8544,7 +10133,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8577,8 +10166,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = load i64, i64* %arg2
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = trunc i32 %3 to i8
@@ -8634,46 +10223,46 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
   %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
-  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
-  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
-  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
@@ -8684,27 +10273,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %20
+ThrowNullRef12:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8717,8 +10306,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -8756,22 +10345,22 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
   %9 = load i64, i64 addrspace(1)* %8, align 8
   %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
   %13 = load i64, i64 addrspace(1)* %12, align 8
   %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %11
   %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
@@ -8788,11 +10377,11 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8882,8 +10471,8 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
@@ -8900,8 +10489,8 @@ entry:
 ; <label>:8                                       ; preds = %1
   %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
   %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
@@ -8911,15 +10500,15 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
   %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
   %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
-  br i1 %NullCheck6, label %21, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
@@ -8946,15 +10535,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8992,15 +10581,15 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
   store i8 %3, i8 addrspace(1)* %5
   %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
@@ -9011,7 +10600,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9027,8 +10616,8 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -9041,8 +10630,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
@@ -9058,7 +10647,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9080,8 +10669,8 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
@@ -9096,8 +10685,8 @@ entry:
 ; <label>:12                                      ; preds = %6
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
@@ -9112,8 +10701,8 @@ entry:
 ; <label>:21                                      ; preds = %15
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
@@ -9128,8 +10717,8 @@ entry:
 ; <label>:30                                      ; preds = %24
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %31, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
@@ -9144,8 +10733,8 @@ entry:
 ; <label>:39                                      ; preds = %33
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
-  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %40, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %42
 
 ; <label>:42                                      ; preds = %39
   %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
@@ -9164,19 +10753,19 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %21
+ThrowNullRef4:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %30
+ThrowNullRef6:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %39
+ThrowNullRef8:                                    ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9243,8 +10832,8 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
@@ -9264,57 +10853,57 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
   store i8 0, i8 addrspace(1)* %2
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
   store i8 0, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
   store i8 0, i8 addrspace(1)* %17
   %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
   store i8 0, i8 addrspace(1)* %20
   %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
-  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
@@ -9325,31 +10914,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %19
+ThrowNullRef14:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9367,8 +10956,8 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
@@ -9380,8 +10969,8 @@ entry:
 
 ; <label>:9                                       ; preds = %4
   %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %9
   %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
@@ -9395,7 +10984,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef2:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9420,8 +11009,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
@@ -9512,8 +11101,8 @@ entry:
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
@@ -9524,8 +11113,8 @@ entry:
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = load i64, i64 addrspace(1)* %12
@@ -9537,8 +11126,8 @@ entry:
   %20 = load i64, i64* %19
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
-  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %13
   %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
@@ -9555,8 +11144,8 @@ entry:
 ; <label>:30                                      ; preds = %25
   %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %32 = load i32, i32* %arg2
-  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
-  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
@@ -9570,15 +11159,15 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %30
+ThrowNullRef2:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9622,87 +11211,87 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
   %10 = load i8, i8 addrspace(1)* %9, align 8
   %11 = zext i8 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %8
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
   store i8 %12, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
   %19 = load i8, i8 addrspace(1)* %18, align 8
   %20 = zext i8 %19 to i32
   %21 = trunc i32 %20 to i8
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
   store i8 %21, i8 addrspace(1)* %23
   %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
   %28 = load i8, i8 addrspace(1)* %27, align 8
   %29 = zext i8 %28 to i32
   %30 = trunc i32 %29 to i8
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
-  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %31
 
 ; <label>:31                                      ; preds = %26
   %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
   store i8 %30, i8 addrspace(1)* %32
   %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
-  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
-  br i1 %NullCheck14, label %40, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %40
 
 ; <label>:40                                      ; preds = %35
   %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
   store i8 %39, i8 addrspace(1)* %41
   %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
-  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %44
 
 ; <label>:44                                      ; preds = %40
   %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
   %46 = load i8, i8 addrspace(1)* %45, align 8
   %47 = zext i8 %46 to i32
   %48 = trunc i32 %47 to i8
-  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
   store i8 %48, i8 addrspace(1)* %50
   %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
-  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
@@ -9713,29 +11302,29 @@ entry:
 ; <label>:56                                      ; preds = %52
   %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
-  br i1 %NullCheck22, label %59, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
   %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
   %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
-  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
-  br i1 %NullCheck24, label %63, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
   %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
-  br i1 %NullCheck26, label %66, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
   %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
-  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
-  br i1 %NullCheck28, label %69, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %69
 
 ; <label>:69                                      ; preds = %66
   %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
@@ -9744,15 +11333,15 @@ entry:
 
 ; <label>:71                                      ; preds = %105
   %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
-  br i1 %NullCheck34, label %73, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %73
 
 ; <label>:73                                      ; preds = %71
   %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
   %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
   %76 = load i32, i32* %loc0
-  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
-  br i1 %NullCheck36, label %77, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
@@ -9766,8 +11355,8 @@ entry:
 
 ; <label>:83                                      ; preds = %77
   %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
-  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
@@ -9775,14 +11364,14 @@ entry:
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
   %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
-  br i1 %NullCheck40, label %91, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
 ; <label>:91                                      ; preds = %85
   %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
   %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
-  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck42, label %94, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %94
 
 ; <label>:94                                      ; preds = %91
   %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
@@ -9798,14 +11387,14 @@ entry:
 ; <label>:99                                      ; preds = %69, %96
   %100 = load i32, i32* %loc0
   %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
-  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %102
 
 ; <label>:102                                     ; preds = %99
   %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
   %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
-  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
-  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
@@ -9819,87 +11408,87 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %26
+ThrowNullRef10:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %31
+ThrowNullRef12:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %35
+ThrowNullRef14:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %40
+ThrowNullRef16:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %56
+ThrowNullRef22:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %59
+ThrowNullRef24:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %63
+ThrowNullRef26:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %66
+ThrowNullRef28:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %102
+ThrowNullRef32:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %71
+ThrowNullRef34:                                   ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %73
+ThrowNullRef36:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %83
+ThrowNullRef38:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %85
+ThrowNullRef40:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %91
+ThrowNullRef42:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9943,15 +11532,15 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
   %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
@@ -9961,28 +11550,28 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
   %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %12
   %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
   %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
   %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
-  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
@@ -9993,23 +11582,23 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %12
+ThrowNullRef6:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10031,15 +11620,15 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
   %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = load i64, i64 addrspace(1)* %7
@@ -10077,13 +11666,13 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[loadElem]
+Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -10111,8 +11700,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -10201,8 +11790,8 @@ entry:
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load double, double* %arg0
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -10336,8 +11925,8 @@ entry:
   store i64 %param0, i64* %arg0
   store i64 %param1, i64* %arg1
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
@@ -10345,8 +11934,8 @@ entry:
   %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
   %5 = load i16*, i16* addrspace(1)* %4, align 8
   %6 = addrspacecast i64* %arg1 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = bitcast i64 addrspace(1)* %6 to i8 addrspace(1)*
@@ -10362,7 +11951,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10396,8 +11985,8 @@ entry:
   %1 = load i32, i32* %arg1
   %2 = sext i32 %1 to i64
   %3 = inttoptr i64 %2 to i16*
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -10450,8 +12039,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, i32)*)(%System.IO.ConsoleStream addrspace(1)* %2, i32 %1)
   %3 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %4 = load i64, i64* %arg1
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
@@ -10462,8 +12051,8 @@ entry:
   %10 = icmp eq i32 %9, 3
   %11 = sext i1 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %5
   %14 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, i32 0, i32 5
@@ -10474,7 +12063,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10497,8 +12086,8 @@ entry:
   %5 = icmp eq i32 %4, 1
   %6 = sext i1 %5 to i32
   %7 = trunc i32 %6 to i8
-  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %2, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.ConsoleStream addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
@@ -10509,8 +12098,8 @@ entry:
   %13 = icmp eq i32 %12, 2
   %14 = sext i1 %13 to i32
   %15 = trunc i32 %14 to i8
-  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %10, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.ConsoleStream addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %8
   %17 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %10, i32 0, i32 4
@@ -10521,7 +12110,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10560,8 +12149,8 @@ entry:
   %arg0 = alloca i64
   store i64 %param0, i64* %arg0
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
@@ -10596,8 +12185,8 @@ entry:
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
   %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = load i64, i64 addrspace(1)* %7
@@ -10701,7 +12290,127 @@ entry:
 INFO:  jitting method Encoding::GetEncoding using LLILCJit
 Failed to read Encoding.GetEncoding[convertToHelperArgumentType]
 INFO:  jitting method EncodingProvider::GetEncodingFromProvider using LLILCJit
-Failed to read EncodingProvider.GetEncodingFromProvider[loadElem]
+Successfully read EncodingProvider.GetEncodingFromProvider
+
+define %System.Text.Encoding addrspace(1)* @EncodingProvider.GetEncodingFromProvider(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca %"System.Text.EncodingProvider[]" addrspace(1)*
+  %loc1 = alloca %System.Text.EncodingProvider addrspace(1)*
+  %loc2 = alloca %System.Text.Encoding addrspace(1)*
+  %loc3 = alloca %System.Text.Encoding addrspace(1)*
+  %loc4 = alloca %"System.Text.EncodingProvider[]" addrspace(1)*
+  %loc5 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1059)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2392
+  %2 = addrspacecast i8 addrspace(1)* %1 to %"System.Text.EncodingProvider[]" addrspace(1)**
+  %3 = load volatile %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %2
+  %4 = icmp ne %"System.Text.EncodingProvider[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %entry
+  ret %System.Text.Encoding addrspace(1)* null
+
+; <label>:6                                       ; preds = %entry
+  %7 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1059)
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i64 2392
+  %9 = addrspacecast i8 addrspace(1)* %8 to %"System.Text.EncodingProvider[]" addrspace(1)**
+  %10 = load volatile %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %9
+  store %"System.Text.EncodingProvider[]" addrspace(1)* %10, %"System.Text.EncodingProvider[]" addrspace(1)** %loc0
+  %11 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc0
+  store %"System.Text.EncodingProvider[]" addrspace(1)* %11, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  store i32 0, i32* %loc5
+  br label %43
+
+; <label>:12                                      ; preds = %46
+  %13 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  %14 = load i32, i32* %loc5
+  %NullCheck1 = icmp eq %"System.Text.EncodingProvider[]" addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %13, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = zext i32 %17 to i64
+  %19 = zext i32 %14 to i64
+  %BoundsCheck = icmp uge i64 %19, %18
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %20
+
+; <label>:20                                      ; preds = %15
+  %21 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %13, i32 0, i32 3, i32 %14
+  %22 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)* addrspace(1)* %21, align 8
+  store %System.Text.EncodingProvider addrspace(1)* %22, %System.Text.EncodingProvider addrspace(1)** %loc1
+  %23 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)** %loc1
+  %24 = load i32, i32* %arg0
+  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i64 addrspace(1)*
+  %NullCheck3 = icmp eq i64 addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
+
+; <label>:26                                      ; preds = %20
+  %27 = load i64, i64 addrspace(1)* %25
+  %28 = add i64 %27, 64
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 40
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Text.Encoding addrspace(1)* (%System.Text.EncodingProvider addrspace(1)*, i32)*
+  %35 = call %System.Text.Encoding addrspace(1)* %34(%System.Text.EncodingProvider addrspace(1)* %23, i32 %24)
+  store %System.Text.Encoding addrspace(1)* %35, %System.Text.Encoding addrspace(1)** %loc2
+  %36 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc2
+  %37 = icmp eq %System.Text.Encoding addrspace(1)* %36, null
+  br i1 %37, label %40, label %38
+
+; <label>:38                                      ; preds = %26
+  %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc2
+  store %System.Text.Encoding addrspace(1)* %39, %System.Text.Encoding addrspace(1)** %loc3
+  br label %53
+
+; <label>:40                                      ; preds = %26
+  %41 = load i32, i32* %loc5
+  %42 = add i32 %41, 1
+  store i32 %42, i32* %loc5
+  br label %43
+
+; <label>:43                                      ; preds = %6, %40
+  %44 = load i32, i32* %loc5
+  %45 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  %NullCheck = icmp eq %"System.Text.EncodingProvider[]" addrspace(1)* %45, null
+  br i1 %NullCheck, label %ThrowNullRef, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp slt i32 %44, %50
+  br i1 %51, label %12, label %52
+
+; <label>:52                                      ; preds = %46
+  ret %System.Text.Encoding addrspace(1)* null
+
+; <label>:53                                      ; preds = %38
+  %54 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc3
+  ret %System.Text.Encoding addrspace(1)* %54
+
+ThrowNullRef:                                     ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method EncodingProvider::.cctor using LLILCJit
 Successfully read EncodingProvider..cctor
 
@@ -10720,7 +12429,7 @@ Failed to read Encoding.get_InternalSyncObject[Call HasTypeArg]
 INFO:  jitting method Hashtable::.ctor using LLILCJit
 Failed to read Hashtable..ctor[Volatile store]
 INFO:  jitting method Hashtable::get_Item using LLILCJit
-Failed to read Hashtable.get_Item[loadElemA]
+Failed to read Hashtable.get_Item[loadNonPrimitiveObj]
 INFO:  jitting method Hashtable::InitHash using LLILCJit
 Successfully read Hashtable.InitHash
 
@@ -10740,8 +12449,8 @@ entry:
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -10757,15 +12466,15 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
   %15 = load i32, i32* %loc0
-  %NullCheck2 = icmp ne i32 addrspace(1)* %14, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i32 addrspace(1)* %14, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %3
   store i32 %15, i32 addrspace(1)* %14, align 8
   %17 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %18 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %NullCheck4 = icmp ne i32 addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i32 addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = load i32, i32 addrspace(1)* %18, align 8
@@ -10774,8 +12483,8 @@ entry:
   %23 = sub i32 %22, 1
   %24 = urem i32 %21, %23
   %25 = add i32 1, %24
-  %NullCheck6 = icmp ne i32 addrspace(1)* %17, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32 addrspace(1)* %17, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %19
   store i32 %25, i32 addrspace(1)* %17, align 8
@@ -10786,15 +12495,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %19
+ThrowNullRef6:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10809,8 +12518,8 @@ entry:
   store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
   store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %NullCheck = icmp ne %System.Collections.Hashtable addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Collections.Hashtable addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
@@ -10820,16 +12529,16 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Collections.Hashtable addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Collections.Hashtable addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
   %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck4 = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %9, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
   %13 = inttoptr i64 %11 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
@@ -10839,8 +12548,8 @@ entry:
 ; <label>:15                                      ; preds = %1
   %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -10858,15 +12567,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10880,8 +12589,8 @@ entry:
   store %System.Int32 addrspace(1)* %param0, %System.Int32 addrspace(1)** %this
   %0 = load %System.Int32 addrspace(1)*, %System.Int32 addrspace(1)** %this
   %1 = bitcast %System.Int32 addrspace(1)* %0 to i32 addrspace(1)*
-  %NullCheck = icmp ne i32 addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq i32 addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load i32, i32 addrspace(1)* %1, align 8
@@ -10957,8 +12666,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.UTF8Encoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
@@ -10967,15 +12676,15 @@ entry:
   %9 = load i8, i8* %arg2
   %10 = zext i8 %9 to i32
   %11 = trunc i32 %10 to i8
-  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %8, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %6
   %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %8, i32 0, i32 8
   store i8 %11, i8 addrspace(1)* %13
   %14 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %14, i32 0, i32 8
@@ -10987,8 +12696,8 @@ entry:
 ; <label>:20                                      ; preds = %15
   %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %22, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %22, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = load i64, i64 addrspace(1)* %22
@@ -11010,15 +12719,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %12
+ThrowNullRef4:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11033,8 +12742,8 @@ entry:
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
@@ -11056,16 +12765,16 @@ entry:
 ; <label>:10                                      ; preds = %1
   %11 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
   %12 = load i32, i32* %arg1
-  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %11, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.Encoding addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
   store i32 %12, i32 addrspace(1)* %14
   %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
   %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = load i64, i64 addrspace(1)* %16
@@ -11083,11 +12792,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11100,8 +12809,8 @@ entry:
   %this = alloca %System.Text.UTF8Encoding addrspace(1)*
   store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
   %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.UTF8Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
@@ -11113,16 +12822,16 @@ entry:
 ; <label>:6                                       ; preds = %1
   %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %8 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %10, %System.Text.EncoderFallback addrspace(1)* %8)
   %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %12 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
-  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %11, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %11, i32 0, i32 3
@@ -11135,8 +12844,8 @@ entry:
   %18 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %18, %System.String addrspace(1)* %17)
   %19 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %18 to %System.Text.EncoderFallback addrspace(1)*
-  %NullCheck6 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %16, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %16, i32 0, i32 2
@@ -11146,8 +12855,8 @@ entry:
   %24 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %24, %System.String addrspace(1)* %23)
   %25 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %24 to %System.Text.DecoderFallback addrspace(1)*
-  %NullCheck8 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %22, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %22, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %20
   %27 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %22, i32 0, i32 3
@@ -11158,19 +12867,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %20
+ThrowNullRef8:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11200,8 +12909,8 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load i32, i32* %arg1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -11219,8 +12928,8 @@ entry:
 ; <label>:15                                      ; preds = %8
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %17 = load i32, i32* %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 %17
@@ -11236,7 +12945,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11288,7 +12997,7 @@ entry:
 }
 
 INFO:  jitting method Hashtable::Insert using LLILCJit
-Failed to read Hashtable.Insert[loadElemA]
+Failed to read Hashtable.Insert[storeElem]
 INFO:  jitting method ConsoleEncoding::.ctor using LLILCJit
 Successfully read ConsoleEncoding..ctor
 
@@ -11303,8 +13012,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %1)
   %2 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
@@ -11340,8 +13049,8 @@ entry:
   %2 = call %System.Text.InternalEncoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalEncoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %1)
   %3 = bitcast %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2 to %System.Text.EncoderFallback addrspace(1)*
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
@@ -11351,8 +13060,8 @@ entry:
   %8 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %7)
   %9 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %8 to %System.Text.DecoderFallback addrspace(1)*
-  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %6, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.Encoding addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %4
   %11 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %6, i32 0, i32 3
@@ -11363,7 +13072,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11382,15 +13091,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* %1)
   %2 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   %6 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, i32 0, i32 1
@@ -11401,7 +13110,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11429,8 +13138,8 @@ entry:
   store %System.Text.InternalDecoderBestFitFallback addrspace(1)* %param0, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
   %0 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
@@ -11440,15 +13149,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %4)
   %5 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %6)
   %9 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, i32 0, i32 1
@@ -11459,11 +13168,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11531,8 +13240,8 @@ entry:
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
   %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = load i64, i64 addrspace(1)* %19
@@ -11596,8 +13305,8 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.ConsoleStream addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
@@ -11628,31 +13337,31 @@ entry:
   store i8 %param4, i8* %arg4
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %3, %System.IO.Stream addrspace(1)* %1)
   %4 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %4, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
   %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %4, i32 0, i32 4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %5)
   %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %6
   %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
   %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
   %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = load i64, i64 addrspace(1)* %13
@@ -11664,8 +13373,8 @@ entry:
   %21 = load i64, i64* %20
   %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %8, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %8, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %14
   %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 5
@@ -11683,24 +13392,24 @@ entry:
   %31 = load i32, i32* %arg3
   %32 = sext i32 %31 to i64
   %33 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %32)
-  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %30, null
-  br i1 %NullCheck10, label %34, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.StreamWriter addrspace(1)* %30, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %35, %"System.Char[]" addrspace(1)* %33)
   %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %37, null
-  br i1 %NullCheck12, label %38, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.StreamWriter addrspace(1)* %37, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %38
 
 ; <label>:38                                      ; preds = %34
   %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
   %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
   %41 = load i32, i32* %arg3
   %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %42, null
-  br i1 %NullCheck14, label %43, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %42, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
   %44 = load i64, i64 addrspace(1)* %42
@@ -11714,30 +13423,30 @@ entry:
   %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
   %53 = sext i32 %52 to i64
   %54 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %53)
-  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
-  br i1 %NullCheck16, label %55, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %55
 
 ; <label>:55                                      ; preds = %43
   %56 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %56, %"System.Byte[]" addrspace(1)* %54)
   %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %58 = load i32, i32* %arg3
-  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %57, null
-  br i1 %NullCheck18, label %59, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.StreamWriter addrspace(1)* %57, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %59
 
 ; <label>:59                                      ; preds = %55
   %60 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 10
   store i32 %58, i32 addrspace(1)* %60
   %61 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %61, null
-  br i1 %NullCheck20, label %62, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.IO.StreamWriter addrspace(1)* %61, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %62
 
 ; <label>:62                                      ; preds = %59
   %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
   %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
   %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
   %67 = load i64, i64 addrspace(1)* %65
@@ -11755,15 +13464,15 @@ entry:
 
 ; <label>:78                                      ; preds = %66
   %79 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %79, null
-  br i1 %NullCheck24, label %80, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.StreamWriter addrspace(1)* %79, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %80
 
 ; <label>:80                                      ; preds = %78
   %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
   %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
   %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %83, null
-  br i1 %NullCheck26, label %84, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %83, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
   %85 = load i64, i64 addrspace(1)* %83
@@ -11780,8 +13489,8 @@ entry:
 
 ; <label>:95                                      ; preds = %84
   %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.IO.StreamWriter addrspace(1)* %96, null
-  br i1 %NullCheck28, label %97, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.IO.StreamWriter addrspace(1)* %96, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %97
 
 ; <label>:97                                      ; preds = %95
   %98 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 12
@@ -11795,8 +13504,8 @@ entry:
   %103 = icmp eq i32 %102, 0
   %104 = sext i1 %103 to i32
   %105 = trunc i32 %104 to i8
-  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %100, null
-  br i1 %NullCheck30, label %106, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.IO.StreamWriter addrspace(1)* %100, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %106
 
 ; <label>:106                                     ; preds = %99
   %107 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %100, i32 0, i32 13
@@ -11807,63 +13516,63 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %6
+ThrowNullRef4:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %29
+ThrowNullRef10:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %34
+ThrowNullRef12:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %38
+ThrowNullRef14:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %43
+ThrowNullRef16:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %55
+ThrowNullRef18:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %59
+ThrowNullRef20:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %62
+ThrowNullRef22:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %78
+ThrowNullRef24:                                   ; preds = %78
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %80
+ThrowNullRef26:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %95
+ThrowNullRef28:                                   ; preds = %95
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11876,15 +13585,15 @@ entry:
   %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = load i64, i64 addrspace(1)* %4
@@ -11902,7 +13611,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11952,35 +13661,35 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
   %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderNLS addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %7 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.EncoderNLS addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Text.Encoding addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.Encoding addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Text.EncoderNLS addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.EncoderNLS addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
   %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck8 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = load i64, i64 addrspace(1)* %16
@@ -11999,19 +13708,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12037,8 +13746,8 @@ entry:
   %this = alloca %System.Text.Encoding addrspace(1)*
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
@@ -12058,15 +13767,15 @@ entry:
   %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
   store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
   %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
   store i32 0, i32 addrspace(1)* %2
   %3 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, i32 0, i32 2
@@ -12076,15 +13785,15 @@ entry:
 
 ; <label>:8                                       ; preds = %4
   %9 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
   %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
   %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = load i64, i64 addrspace(1)* %13
@@ -12105,15 +13814,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12128,16 +13837,16 @@ entry:
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = load i32, i32* %arg1
   %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
   %7 = load i64, i64 addrspace(1)* %5
@@ -12155,7 +13864,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12192,8 +13901,8 @@ entry:
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
   %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
   %16 = load i64, i64 addrspace(1)* %14
@@ -12214,8 +13923,8 @@ entry:
   %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
   %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
   %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %31, null
-  br i1 %NullCheck2, label %32, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = load i64, i64 addrspace(1)* %31
@@ -12258,7 +13967,7 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12271,14 +13980,14 @@ entry:
   %this = alloca %System.Text.EncoderReplacementFallback addrspace(1)*
   store %System.Text.EncoderReplacementFallback addrspace(1)* %param0, %System.Text.EncoderReplacementFallback addrspace(1)** %this
   %0 = load %System.Text.EncoderReplacementFallback addrspace(1)*, %System.Text.EncoderReplacementFallback addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -12289,7 +13998,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12319,8 +14028,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
@@ -12352,8 +14061,8 @@ entry:
   %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
   store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
@@ -12365,8 +14074,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Threading.Tasks.Task addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %7)
@@ -12389,7 +14098,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12408,8 +14117,8 @@ entry:
   store i8 %param1, i8* %arg1
   store i8 %param2, i8* %arg2
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
@@ -12423,8 +14132,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1, %5
   %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 9
@@ -12455,8 +14164,8 @@ entry:
 
 ; <label>:25                                      ; preds = %8, %20
   %26 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %26, null
-  br i1 %NullCheck4, label %27, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %26, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %26, i32 0, i32 12
@@ -12467,22 +14176,22 @@ entry:
 
 ; <label>:32                                      ; preds = %27
   %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %33, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.IO.StreamWriter addrspace(1)* %33, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %32
   %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 12
   store i8 1, i8 addrspace(1)* %35
   %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
-  br i1 %NullCheck8, label %37, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
   %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
   %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck10 = icmp ne i64 addrspace(1)* %40, null
-  br i1 %NullCheck10, label %41, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64 addrspace(1)* %40, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i64, i64 addrspace(1)* %40
@@ -12496,8 +14205,8 @@ entry:
   %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
   store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
   %51 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %NullCheck12 = icmp ne %"System.Byte[]" addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Byte[]" addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %41
   %53 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %51, i32 0, i32 1
@@ -12509,16 +14218,16 @@ entry:
 
 ; <label>:58                                      ; preds = %52
   %59 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %59, null
-  br i1 %NullCheck14, label %60, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.IO.StreamWriter addrspace(1)* %59, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %60
 
 ; <label>:60                                      ; preds = %58
   %61 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %59, i32 0, i32 3
   %62 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
   %64 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %NullCheck16 = icmp ne %"System.Byte[]" addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %"System.Byte[]" addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %60
   %66 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %64, i32 0, i32 1
@@ -12526,8 +14235,8 @@ entry:
   %68 = zext i32 %67 to i64
   %69 = trunc i64 %68 to i32
   %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck18, label %71, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
   %72 = load i64, i64 addrspace(1)* %70
@@ -12543,29 +14252,29 @@ entry:
 
 ; <label>:80                                      ; preds = %27, %52, %71
   %81 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %81, null
-  br i1 %NullCheck20, label %82, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.IO.StreamWriter addrspace(1)* %81, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
 
 ; <label>:82                                      ; preds = %80
   %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %81, i32 0, i32 5
   %84 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %83, align 8
   %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.IO.StreamWriter addrspace(1)* %85, null
-  br i1 %NullCheck22, label %86, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.IO.StreamWriter addrspace(1)* %85, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %86
 
 ; <label>:86                                      ; preds = %82
   %87 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 7
   %88 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %87, align 8
   %89 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %89, null
-  br i1 %NullCheck24, label %90, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.StreamWriter addrspace(1)* %89, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %90
 
 ; <label>:90                                      ; preds = %86
   %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %89, i32 0, i32 9
   %92 = load i32, i32 addrspace(1)* %91, align 8
   %93 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.IO.StreamWriter addrspace(1)* %93, null
-  br i1 %NullCheck26, label %94, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.IO.StreamWriter addrspace(1)* %93, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %93, i32 0, i32 6
@@ -12573,8 +14282,8 @@ entry:
   %97 = load i8, i8* %arg2
   %98 = zext i8 %97 to i32
   %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
-  %NullCheck28 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck28, label %100, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
   %101 = load i64, i64 addrspace(1)* %99
@@ -12589,8 +14298,8 @@ entry:
   %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
   store i32 %110, i32* %loc1
   %111 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %111, null
-  br i1 %NullCheck30, label %112, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.IO.StreamWriter addrspace(1)* %111, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %112
 
 ; <label>:112                                     ; preds = %100
   %113 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %111, i32 0, i32 9
@@ -12601,23 +14310,23 @@ entry:
 
 ; <label>:116                                     ; preds = %112
   %117 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck32 = icmp ne %System.IO.StreamWriter addrspace(1)* %117, null
-  br i1 %NullCheck32, label %118, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.IO.StreamWriter addrspace(1)* %117, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %118
 
 ; <label>:118                                     ; preds = %116
   %119 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %117, i32 0, i32 3
   %120 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %119, align 8
   %121 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.IO.StreamWriter addrspace(1)* %121, null
-  br i1 %NullCheck34, label %122, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.IO.StreamWriter addrspace(1)* %121, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %122
 
 ; <label>:122                                     ; preds = %118
   %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
   %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
   %125 = load i32, i32* %loc1
   %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
-  %NullCheck36 = icmp ne i64 addrspace(1)* %126, null
-  br i1 %NullCheck36, label %127, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64 addrspace(1)* %126, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
   %128 = load i64, i64 addrspace(1)* %126
@@ -12639,15 +14348,15 @@ entry:
 
 ; <label>:140                                     ; preds = %136
   %141 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.IO.StreamWriter addrspace(1)* %141, null
-  br i1 %NullCheck38, label %142, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.IO.StreamWriter addrspace(1)* %141, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %142
 
 ; <label>:142                                     ; preds = %140
   %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
   %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
   %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
-  %NullCheck40 = icmp ne i64 addrspace(1)* %145, null
-  br i1 %NullCheck40, label %146, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i64 addrspace(1)* %145, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
   %147 = load i64, i64 addrspace(1)* %145
@@ -12668,83 +14377,83 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %25
+ThrowNullRef4:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %32
+ThrowNullRef6:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %37
+ThrowNullRef10:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %41
+ThrowNullRef12:                                   ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %58
+ThrowNullRef14:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %60
+ThrowNullRef16:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %65
+ThrowNullRef18:                                   ; preds = %65
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %80
+ThrowNullRef20:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %82
+ThrowNullRef22:                                   ; preds = %82
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %86
+ThrowNullRef24:                                   ; preds = %86
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %90
+ThrowNullRef26:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %94
+ThrowNullRef28:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %100
+ThrowNullRef30:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %116
+ThrowNullRef32:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %118
+ThrowNullRef34:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %122
+ThrowNullRef36:                                   ; preds = %122
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %140
+ThrowNullRef38:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %142
+ThrowNullRef40:                                   ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12811,8 +14520,8 @@ entry:
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %1 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
-  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
@@ -12820,8 +14529,8 @@ entry:
   %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
   %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
   %8 = load i64, i64 addrspace(1)* %6
@@ -12837,8 +14546,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %17, %System.IFormatProvider addrspace(1)* %16)
   %18 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %19 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %18, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.SyncTextWriter addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %7
   %21 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %18, i32 0, i32 4
@@ -12849,11 +14558,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12866,8 +14575,8 @@ entry:
   %this = alloca %System.IO.TextWriter addrspace(1)*
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.TextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
@@ -12877,8 +14586,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.Threading.Thread addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Threading.Thread addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %6)
@@ -12887,8 +14596,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1
   %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.TextWriter addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.TextWriter addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %11, i32 0, i32 2
@@ -12899,11 +14608,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13100,8 +14809,8 @@ entry:
   store double %param1, double* %arg1
   store i8 0, i8* %loc1
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
@@ -13111,16 +14820,16 @@ entry:
   %5 = addrspacecast i8* %loc1 to i8 addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %4, i8 addrspace(1)* %5)
   %6 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.SyncTextWriter addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
   %10 = load double, double* %arg1
   %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
   %13 = load i64, i64 addrspace(1)* %11
@@ -13155,11 +14864,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13176,8 +14885,8 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load double, double* %arg1
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -13191,8 +14900,8 @@ entry:
   call void %11(%System.IO.TextWriter addrspace(1)* %0, double %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
   %15 = load i64, i64 addrspace(1)* %13
@@ -13210,7 +14919,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13228,8 +14937,8 @@ entry:
   %1 = addrspacecast double* %arg1 to double addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -13244,8 +14953,8 @@ entry:
   %14 = bitcast double addrspace(1)* %1 to %System.Double addrspace(1)*
   %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Double addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Double addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
   %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
   %18 = load i64, i64 addrspace(1)* %16
@@ -13263,7 +14972,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13279,8 +14988,8 @@ entry:
   store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
   %0 = load %System.Double addrspace(1)*, %System.Double addrspace(1)** %this
   %1 = bitcast %System.Double addrspace(1)* %0 to double addrspace(1)*
-  %NullCheck = icmp ne double addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq double addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load double, double addrspace(1)* %1, align 8
@@ -13305,8 +15014,8 @@ entry:
   %loc0 = alloca %System.Globalization.NumberFormatInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 3
@@ -13316,8 +15025,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
@@ -13327,24 +15036,24 @@ entry:
   store %System.Globalization.NumberFormatInfo addrspace(1)* %10, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
   %11 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %7
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
   %15 = load i8, i8 addrspace(1)* %14, align 8
   %16 = zext i8 %15 to i32
   %17 = trunc i32 %16 to i8
-  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %11, null
-  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %11, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %13
   %19 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %11, i32 0, i32 29
   store i8 %17, i8 addrspace(1)* %19
   %20 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %21 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %20, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %20, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %18
   %23 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %20, i32 0, i32 3
@@ -13353,8 +15062,8 @@ entry:
 
 ; <label>:24                                      ; preds = %1, %22
   %25 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %25, null
-  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %25, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %26
 
 ; <label>:26                                      ; preds = %24
   %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %25, i32 0, i32 3
@@ -13365,23 +15074,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %18
+ThrowNullRef8:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13406,168 +15115,168 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 18
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %8, align 8
-  %NullCheck2 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %5, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %5, i32 0, i32 4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %9)
   %12 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 19
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %15, align 8
-  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %12, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %12, i32 0, i32 5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %16)
   %19 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %20 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %20, null
-  br i1 %NullCheck8, label %21, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %20, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %20, i32 0, i32 23
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  %NullCheck10 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %19, null
-  br i1 %NullCheck10, label %24, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %19, i32 0, i32 7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %25, %System.String addrspace(1)* %23)
   %26 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %27 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %27, i32 0, i32 22
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %29, align 8
-  %NullCheck14 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %26, null
-  br i1 %NullCheck14, label %31, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %26, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %26, i32 0, i32 6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %32, %System.String addrspace(1)* %30)
   %33 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %34 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Globalization.CultureData addrspace(1)* %34, null
-  br i1 %NullCheck16, label %35, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Globalization.CultureData addrspace(1)* %34, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %34, i32 0, i32 51
   %37 = load i32, i32 addrspace(1)* %36, align 8
-  %NullCheck18 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %33, null
-  br i1 %NullCheck18, label %38, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %33, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %33, i32 0, i32 21
   store i32 %37, i32 addrspace(1)* %39
   %40 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %41 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Globalization.CultureData addrspace(1)* %41, null
-  br i1 %NullCheck20, label %42, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Globalization.CultureData addrspace(1)* %41, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %41, i32 0, i32 52
   %44 = load i32, i32 addrspace(1)* %43, align 8
-  %NullCheck22 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %40, null
-  br i1 %NullCheck22, label %45, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %40, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %40, i32 0, i32 25
   store i32 %44, i32 addrspace(1)* %46
   %47 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %48 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.Globalization.CultureData addrspace(1)* %48, null
-  br i1 %NullCheck24, label %49, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Globalization.CultureData addrspace(1)* %48, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %49
 
 ; <label>:49                                      ; preds = %45
   %50 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %48, i32 0, i32 29
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck26 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %47, null
-  br i1 %NullCheck26, label %52, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %47, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %47, i32 0, i32 10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %53, %System.String addrspace(1)* %51)
   %54 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %55 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Globalization.CultureData addrspace(1)* %55, null
-  br i1 %NullCheck28, label %56, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Globalization.CultureData addrspace(1)* %55, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %56
 
 ; <label>:56                                      ; preds = %52
   %57 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %55, i32 0, i32 35
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %57, align 8
-  %NullCheck30 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %54, null
-  br i1 %NullCheck30, label %59, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %54, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %54, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %60, %System.String addrspace(1)* %58)
   %61 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %62 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck32 = icmp ne %System.Globalization.CultureData addrspace(1)* %62, null
-  br i1 %NullCheck32, label %63, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Globalization.CultureData addrspace(1)* %62, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %62, i32 0, i32 34
   %65 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %64, align 8
-  %NullCheck34 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %61, null
-  br i1 %NullCheck34, label %66, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %61, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %61, i32 0, i32 9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %67, %System.String addrspace(1)* %65)
   %68 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %69 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck36 = icmp ne %System.Globalization.CultureData addrspace(1)* %69, null
-  br i1 %NullCheck36, label %70, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Globalization.CultureData addrspace(1)* %69, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %70
 
 ; <label>:70                                      ; preds = %66
   %71 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %69, i32 0, i32 55
   %72 = load i32, i32 addrspace(1)* %71, align 8
-  %NullCheck38 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %68, null
-  br i1 %NullCheck38, label %73, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %68, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %68, i32 0, i32 22
   store i32 %72, i32 addrspace(1)* %74
   %75 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %76 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck40 = icmp ne %System.Globalization.CultureData addrspace(1)* %76, null
-  br i1 %NullCheck40, label %77, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Globalization.CultureData addrspace(1)* %76, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %76, i32 0, i32 57
   %79 = load i32, i32 addrspace(1)* %78, align 8
-  %NullCheck42 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %75, null
-  br i1 %NullCheck42, label %80, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %75, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %80
 
 ; <label>:80                                      ; preds = %77
   %81 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %75, i32 0, i32 24
   store i32 %79, i32 addrspace(1)* %81
   %82 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %83 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck44 = icmp ne %System.Globalization.CultureData addrspace(1)* %83, null
-  br i1 %NullCheck44, label %84, label %ThrowNullRef43
+  %NullCheck43 = icmp eq %System.Globalization.CultureData addrspace(1)* %83, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %84
 
 ; <label>:84                                      ; preds = %80
   %85 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %83, i32 0, i32 56
   %86 = load i32, i32 addrspace(1)* %85, align 8
-  %NullCheck46 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %82, null
-  br i1 %NullCheck46, label %87, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %82, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %82, i32 0, i32 23
@@ -13576,8 +15285,8 @@ entry:
 
 ; <label>:89                                      ; preds = %entry
   %90 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck100 = icmp ne %System.Globalization.CultureData addrspace(1)* %90, null
-  br i1 %NullCheck100, label %91, label %ThrowNullRef99
+  %NullCheck99 = icmp eq %System.Globalization.CultureData addrspace(1)* %90, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %91
 
 ; <label>:91                                      ; preds = %89
   %92 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %90, i32 0, i32 2
@@ -13595,8 +15304,8 @@ entry:
   %102 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %103 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %104 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %103)
-  %NullCheck48 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %102, null
-  br i1 %NullCheck48, label %105, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %102, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %105
 
 ; <label>:105                                     ; preds = %101
   %106 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %102, i32 0, i32 1
@@ -13604,8 +15313,8 @@ entry:
   %107 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %108 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %109 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %108)
-  %NullCheck50 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %107, null
-  br i1 %NullCheck50, label %110, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %107, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %110
 
 ; <label>:110                                     ; preds = %105
   %111 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %107, i32 0, i32 2
@@ -13613,8 +15322,8 @@ entry:
   %112 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %113 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %114 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %113)
-  %NullCheck52 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %112, null
-  br i1 %NullCheck52, label %115, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %112, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %115
 
 ; <label>:115                                     ; preds = %110
   %116 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %112, i32 0, i32 27
@@ -13622,8 +15331,8 @@ entry:
   %117 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %118 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %119 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %118)
-  %NullCheck54 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %117, null
-  br i1 %NullCheck54, label %120, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %117, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %120
 
 ; <label>:120                                     ; preds = %115
   %121 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %117, i32 0, i32 26
@@ -13631,8 +15340,8 @@ entry:
   %122 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %123 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %124 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %123)
-  %NullCheck56 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %122, null
-  br i1 %NullCheck56, label %125, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %122, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %125
 
 ; <label>:125                                     ; preds = %120
   %126 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %122, i32 0, i32 17
@@ -13640,8 +15349,8 @@ entry:
   %127 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %128 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %129 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %128)
-  %NullCheck58 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %127, null
-  br i1 %NullCheck58, label %130, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %127, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %130
 
 ; <label>:130                                     ; preds = %125
   %131 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %127, i32 0, i32 18
@@ -13649,8 +15358,8 @@ entry:
   %132 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %133 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %134 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %133)
-  %NullCheck60 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %132, null
-  br i1 %NullCheck60, label %135, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %132, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %135
 
 ; <label>:135                                     ; preds = %130
   %136 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %132, i32 0, i32 14
@@ -13658,8 +15367,8 @@ entry:
   %137 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %138 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %139 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %138)
-  %NullCheck62 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %137, null
-  br i1 %NullCheck62, label %140, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %137, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %140
 
 ; <label>:140                                     ; preds = %135
   %141 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %137, i32 0, i32 13
@@ -13667,71 +15376,71 @@ entry:
   %142 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %143 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %144 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %143)
-  %NullCheck64 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %142, null
-  br i1 %NullCheck64, label %145, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %142, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %145
 
 ; <label>:145                                     ; preds = %140
   %146 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %142, i32 0, i32 12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %146, %System.String addrspace(1)* %144)
   %147 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %148 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck66 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %148, null
-  br i1 %NullCheck66, label %149, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %148, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %149
 
 ; <label>:149                                     ; preds = %145
   %150 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %148, i32 0, i32 21
   %151 = load i32, i32 addrspace(1)* %150, align 8
-  %NullCheck68 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %147, null
-  br i1 %NullCheck68, label %152, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %147, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %152
 
 ; <label>:152                                     ; preds = %149
   %153 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %147, i32 0, i32 28
   store i32 %151, i32 addrspace(1)* %153
   %154 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %155 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck70 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %155, null
-  br i1 %NullCheck70, label %156, label %ThrowNullRef69
+  %NullCheck69 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %155, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %156
 
 ; <label>:156                                     ; preds = %152
   %157 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %155, i32 0, i32 6
   %158 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %157, align 8
-  %NullCheck72 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %154, null
-  br i1 %NullCheck72, label %159, label %ThrowNullRef71
+  %NullCheck71 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %154, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %159
 
 ; <label>:159                                     ; preds = %156
   %160 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %154, i32 0, i32 15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %160, %System.String addrspace(1)* %158)
   %161 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %162 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck74 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %162, null
-  br i1 %NullCheck74, label %163, label %ThrowNullRef73
+  %NullCheck73 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %162, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %163
 
 ; <label>:163                                     ; preds = %159
   %164 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %162, i32 0, i32 1
   %165 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %164, align 8
-  %NullCheck76 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %161, null
-  br i1 %NullCheck76, label %166, label %ThrowNullRef75
+  %NullCheck75 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %161, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %166
 
 ; <label>:166                                     ; preds = %163
   %167 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %161, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %167, %"System.Int32[]" addrspace(1)* %165)
   %168 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %169 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck78 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %169, null
-  br i1 %NullCheck78, label %170, label %ThrowNullRef77
+  %NullCheck77 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %169, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %170
 
 ; <label>:170                                     ; preds = %166
   %171 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %169, i32 0, i32 7
   %172 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %171, align 8
-  %NullCheck80 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %168, null
-  br i1 %NullCheck80, label %173, label %ThrowNullRef79
+  %NullCheck79 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %168, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %173
 
 ; <label>:173                                     ; preds = %170
   %174 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %168, i32 0, i32 16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %174, %System.String addrspace(1)* %172)
   %175 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck82 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %175, null
-  br i1 %NullCheck82, label %176, label %ThrowNullRef81
+  %NullCheck81 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %175, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %176
 
 ; <label>:176                                     ; preds = %173
   %177 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %175, i32 0, i32 4
@@ -13741,14 +15450,14 @@ entry:
 
 ; <label>:180                                     ; preds = %176
   %181 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck84 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %181, null
-  br i1 %NullCheck84, label %182, label %ThrowNullRef83
+  %NullCheck83 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %181, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %182
 
 ; <label>:182                                     ; preds = %180
   %183 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %181, i32 0, i32 4
   %184 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %183, align 8
-  %NullCheck86 = icmp ne %System.String addrspace(1)* %184, null
-  br i1 %NullCheck86, label %185, label %ThrowNullRef85
+  %NullCheck85 = icmp eq %System.String addrspace(1)* %184, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %185
 
 ; <label>:185                                     ; preds = %182
   %186 = getelementptr inbounds %System.String, %System.String addrspace(1)* %184, i32 0, i32 1
@@ -13759,8 +15468,8 @@ entry:
 ; <label>:189                                     ; preds = %176, %185
   %190 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck98 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %190, null
-  br i1 %NullCheck98, label %192, label %ThrowNullRef97
+  %NullCheck97 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %190, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %192
 
 ; <label>:192                                     ; preds = %189
   %193 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %190, i32 0, i32 4
@@ -13769,8 +15478,8 @@ entry:
 
 ; <label>:194                                     ; preds = %185, %192
   %195 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck88 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %195, null
-  br i1 %NullCheck88, label %196, label %ThrowNullRef87
+  %NullCheck87 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %195, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %196
 
 ; <label>:196                                     ; preds = %194
   %197 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %195, i32 0, i32 9
@@ -13780,14 +15489,14 @@ entry:
 
 ; <label>:200                                     ; preds = %196
   %201 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck90 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %201, null
-  br i1 %NullCheck90, label %202, label %ThrowNullRef89
+  %NullCheck89 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %201, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %202
 
 ; <label>:202                                     ; preds = %200
   %203 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %201, i32 0, i32 9
   %204 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %203, align 8
-  %NullCheck92 = icmp ne %System.String addrspace(1)* %204, null
-  br i1 %NullCheck92, label %205, label %ThrowNullRef91
+  %NullCheck91 = icmp eq %System.String addrspace(1)* %204, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %205
 
 ; <label>:205                                     ; preds = %202
   %206 = getelementptr inbounds %System.String, %System.String addrspace(1)* %204, i32 0, i32 1
@@ -13798,14 +15507,14 @@ entry:
 ; <label>:209                                     ; preds = %196, %205
   %210 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %211 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck94 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %211, null
-  br i1 %NullCheck94, label %212, label %ThrowNullRef93
+  %NullCheck93 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %211, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %212
 
 ; <label>:212                                     ; preds = %209
   %213 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %211, i32 0, i32 6
   %214 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %213, align 8
-  %NullCheck96 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %210, null
-  br i1 %NullCheck96, label %215, label %ThrowNullRef95
+  %NullCheck95 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %210, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %215
 
 ; <label>:215                                     ; preds = %212
   %216 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %210, i32 0, i32 9
@@ -13819,203 +15528,203 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %17
+ThrowNullRef8:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %21
+ThrowNullRef10:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %24
+ThrowNullRef12:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %28
+ThrowNullRef14:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %31
+ThrowNullRef16:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %35
+ThrowNullRef18:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %38
+ThrowNullRef20:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %42
+ThrowNullRef22:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %45
+ThrowNullRef24:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %49
+ThrowNullRef26:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %52
+ThrowNullRef28:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %56
+ThrowNullRef30:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %59
+ThrowNullRef32:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %63
+ThrowNullRef34:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %66
+ThrowNullRef36:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %70
+ThrowNullRef38:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %73
+ThrowNullRef40:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %77
+ThrowNullRef42:                                   ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %80
+ThrowNullRef44:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %84
+ThrowNullRef46:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %101
+ThrowNullRef48:                                   ; preds = %101
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %105
+ThrowNullRef50:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %110
+ThrowNullRef52:                                   ; preds = %110
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %115
+ThrowNullRef54:                                   ; preds = %115
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %120
+ThrowNullRef56:                                   ; preds = %120
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %125
+ThrowNullRef58:                                   ; preds = %125
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %130
+ThrowNullRef60:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %135
+ThrowNullRef62:                                   ; preds = %135
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %140
+ThrowNullRef64:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %145
+ThrowNullRef66:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %149
+ThrowNullRef68:                                   ; preds = %149
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %152
+ThrowNullRef70:                                   ; preds = %152
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %156
+ThrowNullRef72:                                   ; preds = %156
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %159
+ThrowNullRef74:                                   ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %163
+ThrowNullRef76:                                   ; preds = %163
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %166
+ThrowNullRef78:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %170
+ThrowNullRef80:                                   ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %173
+ThrowNullRef82:                                   ; preds = %173
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %180
+ThrowNullRef84:                                   ; preds = %180
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %182
+ThrowNullRef86:                                   ; preds = %182
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %194
+ThrowNullRef88:                                   ; preds = %194
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %200
+ThrowNullRef90:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %202
+ThrowNullRef92:                                   ; preds = %202
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %209
+ThrowNullRef94:                                   ; preds = %209
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %212
+ThrowNullRef96:                                   ; preds = %212
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %189
+ThrowNullRef98:                                   ; preds = %189
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %89
+ThrowNullRef100:                                  ; preds = %89
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14043,8 +15752,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 21
@@ -14057,8 +15766,8 @@ entry:
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 16)
   %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 21
@@ -14067,8 +15776,8 @@ entry:
 
 ; <label>:12                                      ; preds = %1, %10
   %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 21
@@ -14079,11 +15788,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %12
+ThrowNullRef4:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14099,8 +15808,8 @@ entry:
   store i32 %param1, i32* %arg1
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %1 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
@@ -14167,8 +15876,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 33
@@ -14181,8 +15890,8 @@ entry:
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 24)
   %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 33
@@ -14191,8 +15900,8 @@ entry:
 
 ; <label>:12                                      ; preds = %1, %10
   %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 33
@@ -14203,11 +15912,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %12
+ThrowNullRef4:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14220,8 +15929,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 53
@@ -14233,8 +15942,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 116)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 53
@@ -14243,8 +15952,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 53
@@ -14255,11 +15964,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14288,8 +15997,8 @@ entry:
 
 ; <label>:7                                       ; preds = %entry, %4
   %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %7
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 2
@@ -14313,8 +16022,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 54
@@ -14326,8 +16035,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 117)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
@@ -14336,8 +16045,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 54
@@ -14348,11 +16057,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14365,8 +16074,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 27
@@ -14378,8 +16087,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 118)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 27
@@ -14388,8 +16097,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 27
@@ -14400,11 +16109,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14417,8 +16126,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 28
@@ -14430,8 +16139,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 119)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 28
@@ -14440,8 +16149,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 28
@@ -14452,11 +16161,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14469,8 +16178,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 26
@@ -14482,8 +16191,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 107)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 26
@@ -14492,8 +16201,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 26
@@ -14504,11 +16213,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14521,8 +16230,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 25
@@ -14534,8 +16243,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 106)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 25
@@ -14544,8 +16253,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 25
@@ -14556,11 +16265,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14573,8 +16282,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 24
@@ -14586,8 +16295,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 105)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 24
@@ -14596,8 +16305,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 24
@@ -14608,11 +16317,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14637,8 +16346,8 @@ entry:
   %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %3)
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %2
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -14649,15 +16358,15 @@ entry:
 
 ; <label>:8                                       ; preds = %62
   %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 9
   %12 = load i32, i32 addrspace(1)* %11, align 8
   %13 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.IO.StreamWriter addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %13, i32 0, i32 10
@@ -14672,15 +16381,15 @@ entry:
 
 ; <label>:20                                      ; preds = %14, %18
   %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
   %24 = load i32, i32 addrspace(1)* %23, align 8
   %25 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %25, null
-  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.StreamWriter addrspace(1)* %25, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %25, i32 0, i32 9
@@ -14701,36 +16410,36 @@ entry:
   %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %37 = load i32, i32* %loc1
   %38 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.StreamWriter addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %35
   %40 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %38, i32 0, i32 7
   %41 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %40, align 8
   %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
-  br i1 %NullCheck14, label %43, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %39
   %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 9
   %45 = load i32, i32 addrspace(1)* %44, align 8
   %46 = load i32, i32* %loc2
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %36, null
-  br i1 %NullCheck16, label %47, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %36, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %47
 
 ; <label>:47                                      ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %36, i32 %37, %"System.Char[]" addrspace(1)* %41, i32 %45, i32 %46)
   %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
   %51 = load i32, i32 addrspace(1)* %50, align 8
   %52 = load i32, i32* %loc2
   %53 = add i32 %51, %52
-  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
-  br i1 %NullCheck20, label %54, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %54
 
 ; <label>:54                                      ; preds = %49
   %55 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
@@ -14752,8 +16461,8 @@ entry:
 
 ; <label>:65                                      ; preds = %62
   %66 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %66, null
-  br i1 %NullCheck2, label %67, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %66, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %67
 
 ; <label>:67                                      ; preds = %65
   %68 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %66, i32 0, i32 11
@@ -14774,49 +16483,259 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %65
+ThrowNullRef2:                                    ; preds = %65
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %20
+ThrowNullRef8:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %22
+ThrowNullRef10:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %35
+ThrowNullRef12:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %43
+ThrowNullRef16:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %47
+ThrowNullRef18:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method String::CopyTo using LLILCJit
-Failed to read String.CopyTo[loadElemA]
+Successfully read String.CopyTo
+
+define void @String.CopyTo(%System.String addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  %loc1 = alloca i16 addrspace(1)*
+  %loc2 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %1 = icmp ne %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg4
+  %7 = icmp sge i32 %6, 0
+  br i1 %7, label %13, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  unreachable
+
+; <label>:13                                      ; preds = %5
+  %14 = load i32, i32* %arg1
+  %15 = icmp sge i32 %14, 0
+  br i1 %15, label %21, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %18)
+  %20 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %20, %System.String addrspace(1)* %17, %System.String addrspace(1)* %19)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %20) #0
+  unreachable
+
+; <label>:21                                      ; preds = %13
+  %22 = load i32, i32* %arg4
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck, label %ThrowNullRef, label %24
+
+; <label>:24                                      ; preds = %21
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load i32, i32* %arg1
+  %28 = sub i32 %26, %27
+  %29 = icmp sle i32 %22, %28
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34, %System.String addrspace(1)* %31, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %24
+  %36 = load i32, i32* %arg3
+  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %37, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
+
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
+  %40 = load i32, i32 addrspace(1)* %39
+  %41 = zext i32 %40 to i64
+  %42 = trunc i64 %41 to i32
+  %43 = load i32, i32* %arg4
+  %44 = sub i32 %42, %43
+  %45 = icmp sgt i32 %36, %44
+  br i1 %45, label %49, label %46
+
+; <label>:46                                      ; preds = %38
+  %47 = load i32, i32* %arg3
+  %48 = icmp sge i32 %47, 0
+  br i1 %48, label %54, label %49
+
+; <label>:49                                      ; preds = %38, %46
+  %50 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %52 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %51)
+  %53 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53, %System.String addrspace(1)* %50, %System.String addrspace(1)* %52)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53) #0
+  unreachable
+
+; <label>:54                                      ; preds = %46
+  %55 = load i32, i32* %arg4
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %97, label %57
+
+; <label>:57                                      ; preds = %54
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %59
+
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 2
+  %61 = bitcast [0 x i16] addrspace(1)* %60 to i16 addrspace(1)*
+  store i16 addrspace(1)* %61, i16 addrspace(1)** %loc0
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  store %"System.Char[]" addrspace(1)* %62, %"System.Char[]" addrspace(1)** %loc2
+  %63 = icmp eq %"System.Char[]" addrspace(1)* %62, null
+  br i1 %63, label %72, label %64
+
+; <label>:64                                      ; preds = %59
+  %65 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc2
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %65, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %66
+
+; <label>:66                                      ; preds = %64
+  %67 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %65, i32 0, i32 1
+  %68 = load i32, i32 addrspace(1)* %67
+  %69 = zext i32 %68 to i64
+  %70 = trunc i64 %69 to i32
+  %71 = icmp ne i32 %70, 0
+  br i1 %71, label %73, label %72
+
+; <label>:72                                      ; preds = %59, %66
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  br label %81
+
+; <label>:73                                      ; preds = %66
+  %74 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc2
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %74, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %75
+
+; <label>:75                                      ; preds = %73
+  %76 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %74, i32 0, i32 1
+  %77 = load i32, i32 addrspace(1)* %76
+  %78 = zext i32 %77 to i64
+  %BoundsCheck = icmp uge i64 0, %78
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %79
+
+; <label>:79                                      ; preds = %75
+  %80 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %74, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %80, i16 addrspace(1)** %loc1
+  br label %81
+
+; <label>:81                                      ; preds = %72, %79
+  %82 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %83 = ptrtoint i16 addrspace(1)* %82 to i64
+  %84 = load i32, i32* %arg3
+  %85 = sext i32 %84 to i64
+  %86 = mul i64 %85, 2
+  %87 = add i64 %83, %86
+  %88 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %89 = ptrtoint i16 addrspace(1)* %88 to i64
+  %90 = load i32, i32* %arg1
+  %91 = sext i32 %90 to i64
+  %92 = mul i64 %91, 2
+  %93 = add i64 %89, %92
+  %94 = load i32, i32* %arg4
+  %95 = inttoptr i64 %87 to i16*
+  %96 = inttoptr i64 %93 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %95, i16* %96, i32 %94)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  br label %97
+
+; <label>:97                                      ; preds = %54, %81
+  ret void
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
 Successfully read ConsoleEncoding.GetPreamble
 
@@ -14853,7 +16772,365 @@ entry:
 }
 
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[loadElemA]
+Successfully read EncoderNLS.GetBytes
+
+define i32 @EncoderNLS.GetBytes(%System.Text.EncoderNLS addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3, %"System.Byte[]" addrspace(1)* %param4, i32 %param5, i8 %param6) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %arg4 = alloca %"System.Byte[]" addrspace(1)*
+  %arg5 = alloca i32
+  %arg6 = alloca i8
+  %loc0 = alloca i32
+  %loc1 = alloca i16 addrspace(1)*
+  %loc2 = alloca i8 addrspace(1)*
+  %loc3 = alloca i32
+  %loc4 = alloca %"System.Char[]" addrspace(1)*
+  %loc5 = alloca %"System.Byte[]" addrspace(1)*
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  store %"System.Byte[]" addrspace(1)* %param4, %"System.Byte[]" addrspace(1)** %arg4
+  store i32 %param5, i32* %arg5
+  store i8 %param6, i8* %arg6
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %1 = icmp eq %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %17, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %7 = icmp eq %"System.Char[]" addrspace(1)* %6, null
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %12
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %12
+
+; <label>:12                                      ; preds = %8, %10
+  %13 = phi %System.String addrspace(1)* [ %9, %8 ], [ %11, %10 ]
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %14)
+  %16 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16, %System.String addrspace(1)* %13, %System.String addrspace(1)* %15)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16) #0
+  unreachable
+
+; <label>:17                                      ; preds = %2
+  %18 = load i32, i32* %arg2
+  %19 = icmp slt i32 %18, 0
+  br i1 %19, label %23, label %20
+
+; <label>:20                                      ; preds = %17
+  %21 = load i32, i32* %arg3
+  %22 = icmp sge i32 %21, 0
+  br i1 %22, label %35, label %23
+
+; <label>:23                                      ; preds = %17, %20
+  %24 = load i32, i32* %arg2
+  %25 = icmp slt i32 %24, 0
+  br i1 %25, label %28, label %26
+
+; <label>:26                                      ; preds = %23
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %30
+
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %30
+
+; <label>:30                                      ; preds = %26, %28
+  %31 = phi %System.String addrspace(1)* [ %27, %26 ], [ %29, %28 ]
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34, %System.String addrspace(1)* %31, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %20
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck, label %ThrowNullRef, label %37
+
+; <label>:37                                      ; preds = %35
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = load i32, i32* %arg2
+  %43 = sub i32 %41, %42
+  %44 = load i32, i32* %arg3
+  %45 = icmp sge i32 %43, %44
+  br i1 %45, label %51, label %46
+
+; <label>:46                                      ; preds = %37
+  %47 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %48 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %49 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %48)
+  %50 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %50, %System.String addrspace(1)* %47, %System.String addrspace(1)* %49)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %50) #0
+  unreachable
+
+; <label>:51                                      ; preds = %37
+  %52 = load i32, i32* %arg5
+  %53 = icmp slt i32 %52, 0
+  br i1 %53, label %63, label %54
+
+; <label>:54                                      ; preds = %51
+  %55 = load i32, i32* %arg5
+  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck1 = icmp eq %"System.Byte[]" addrspace(1)* %56, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %57
+
+; <label>:57                                      ; preds = %54
+  %58 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = zext i32 %59 to i64
+  %61 = trunc i64 %60 to i32
+  %62 = icmp sle i32 %55, %61
+  br i1 %62, label %68, label %63
+
+; <label>:63                                      ; preds = %51, %57
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %66 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %65)
+  %67 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %67, %System.String addrspace(1)* %64, %System.String addrspace(1)* %66)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %67) #0
+  unreachable
+
+; <label>:68                                      ; preds = %57
+  %69 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %69, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %69, i32 0, i32 1
+  %72 = load i32, i32 addrspace(1)* %71
+  %73 = zext i32 %72 to i64
+  %74 = trunc i64 %73 to i32
+  %75 = icmp ne i32 %74, 0
+  br i1 %75, label %78, label %76
+
+; <label>:76                                      ; preds = %70
+  %77 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1)
+  store %"System.Char[]" addrspace(1)* %77, %"System.Char[]" addrspace(1)** %arg1
+  br label %78
+
+; <label>:78                                      ; preds = %70, %76
+  %79 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck5 = icmp eq %"System.Byte[]" addrspace(1)* %79, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %80
+
+; <label>:80                                      ; preds = %78
+  %81 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %79, i32 0, i32 1
+  %82 = load i32, i32 addrspace(1)* %81
+  %83 = zext i32 %82 to i64
+  %84 = trunc i64 %83 to i32
+  %85 = load i32, i32* %arg5
+  %86 = sub i32 %84, %85
+  store i32 %86, i32* %loc0
+  %87 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck7 = icmp eq %"System.Byte[]" addrspace(1)* %87, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %88
+
+; <label>:88                                      ; preds = %80
+  %89 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %87, i32 0, i32 1
+  %90 = load i32, i32 addrspace(1)* %89
+  %91 = zext i32 %90 to i64
+  %92 = trunc i64 %91 to i32
+  %93 = icmp ne i32 %92, 0
+  br i1 %93, label %96, label %94
+
+; <label>:94                                      ; preds = %88
+  %95 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1)
+  store %"System.Byte[]" addrspace(1)* %95, %"System.Byte[]" addrspace(1)** %arg4
+  br label %96
+
+; <label>:96                                      ; preds = %88, %94
+  %97 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  store %"System.Char[]" addrspace(1)* %97, %"System.Char[]" addrspace(1)** %loc4
+  %98 = icmp eq %"System.Char[]" addrspace(1)* %97, null
+  br i1 %98, label %107, label %99
+
+; <label>:99                                      ; preds = %96
+  %100 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc4
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %100, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %101
+
+; <label>:101                                     ; preds = %99
+  %102 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %100, i32 0, i32 1
+  %103 = load i32, i32 addrspace(1)* %102
+  %104 = zext i32 %103 to i64
+  %105 = trunc i64 %104 to i32
+  %106 = icmp ne i32 %105, 0
+  br i1 %106, label %108, label %107
+
+; <label>:107                                     ; preds = %96, %101
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  br label %116
+
+; <label>:108                                     ; preds = %101
+  %109 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc4
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %109, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %110
+
+; <label>:110                                     ; preds = %108
+  %111 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %109, i32 0, i32 1
+  %112 = load i32, i32 addrspace(1)* %111
+  %113 = zext i32 %112 to i64
+  %BoundsCheck = icmp uge i64 0, %113
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %114
+
+; <label>:114                                     ; preds = %110
+  %115 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %109, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %115, i16 addrspace(1)** %loc1
+  br label %116
+
+; <label>:116                                     ; preds = %107, %114
+  %117 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  store %"System.Byte[]" addrspace(1)* %117, %"System.Byte[]" addrspace(1)** %loc5
+  %118 = icmp eq %"System.Byte[]" addrspace(1)* %117, null
+  br i1 %118, label %127, label %119
+
+; <label>:119                                     ; preds = %116
+  %120 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc5
+  %NullCheck13 = icmp eq %"System.Byte[]" addrspace(1)* %120, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %121
+
+; <label>:121                                     ; preds = %119
+  %122 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %120, i32 0, i32 1
+  %123 = load i32, i32 addrspace(1)* %122
+  %124 = zext i32 %123 to i64
+  %125 = trunc i64 %124 to i32
+  %126 = icmp ne i32 %125, 0
+  br i1 %126, label %128, label %127
+
+; <label>:127                                     ; preds = %116, %121
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc2
+  br label %136
+
+; <label>:128                                     ; preds = %121
+  %129 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc5
+  %NullCheck15 = icmp eq %"System.Byte[]" addrspace(1)* %129, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %130
+
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %129, i32 0, i32 1
+  %132 = load i32, i32 addrspace(1)* %131
+  %133 = zext i32 %132 to i64
+  %BoundsCheck17 = icmp uge i64 0, %133
+  br i1 %BoundsCheck17, label %ThrowIndexOutOfRange18, label %134
+
+; <label>:134                                     ; preds = %130
+  %135 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %129, i32 0, i32 3, i32 0
+  store i8 addrspace(1)* %135, i8 addrspace(1)** %loc2
+  br label %136
+
+; <label>:136                                     ; preds = %127, %134
+  %137 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %138 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %139 = ptrtoint i16 addrspace(1)* %138 to i64
+  %140 = load i32, i32* %arg2
+  %141 = sext i32 %140 to i64
+  %142 = mul i64 %141, 2
+  %143 = add i64 %139, %142
+  %144 = load i32, i32* %arg3
+  %145 = load i8 addrspace(1)*, i8 addrspace(1)** %loc2
+  %146 = ptrtoint i8 addrspace(1)* %145 to i64
+  %147 = load i32, i32* %arg5
+  %148 = sext i32 %147 to i64
+  %149 = add i64 %146, %148
+  %150 = load i32, i32* %loc0
+  %151 = load i8, i8* %arg6
+  %152 = zext i8 %151 to i32
+  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i64 addrspace(1)*
+  %NullCheck19 = icmp eq i64 addrspace(1)* %153, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %154
+
+; <label>:154                                     ; preds = %136
+  %155 = load i64, i64 addrspace(1)* %153
+  %156 = add i64 %155, 72
+  %157 = inttoptr i64 %156 to i64*
+  %158 = load i64, i64* %157
+  %159 = add i64 %158, 0
+  %160 = inttoptr i64 %159 to i64*
+  %161 = load i64, i64* %160
+  %162 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to %System.Text.Encoder addrspace(1)*
+  %163 = inttoptr i64 %143 to i16*
+  %164 = inttoptr i64 %149 to i8*
+  %165 = trunc i32 %152 to i8
+  %166 = inttoptr i64 %161 to i32 (%System.Text.Encoder addrspace(1)*, i16*, i32, i8*, i32, i8)*
+  %167 = call i32 %166(%System.Text.Encoder addrspace(1)* %162, i16* %163, i32 %144, i8* %164, i32 %150, i8 %165)
+  store i32 %167, i32* %loc3
+  br label %168
+
+; <label>:168                                     ; preds = %154
+  %169 = load i32, i32* %loc3
+  ret i32 %169
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %110
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %119
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange18:                           ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
 Successfully read EncoderNLS.GetBytes
 
@@ -14942,22 +17219,22 @@ entry:
   %40 = load i8, i8* %arg5
   %41 = zext i8 %40 to i32
   %42 = trunc i32 %41 to i8
-  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %39, null
-  br i1 %NullCheck, label %43, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderNLS addrspace(1)* %39, null
+  br i1 %NullCheck, label %ThrowNullRef, label %43
 
 ; <label>:43                                      ; preds = %38
   %44 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
   store i8 %42, i8 addrspace(1)* %44
   %45 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %45, null
-  br i1 %NullCheck2, label %46, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.EncoderNLS addrspace(1)* %45, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %46
 
 ; <label>:46                                      ; preds = %43
   %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %45, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %47
   %48 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.EncoderNLS addrspace(1)* %48, null
-  br i1 %NullCheck4, label %49, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.EncoderNLS addrspace(1)* %48, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %49
 
 ; <label>:49                                      ; preds = %46
   %50 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %48, i32 0, i32 3
@@ -14968,8 +17245,8 @@ entry:
   %55 = load i32, i32* %arg4
   %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck6, label %58, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
   %59 = load i64, i64 addrspace(1)* %57
@@ -14987,15 +17264,15 @@ ThrowNullRef:                                     ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %43
+ThrowNullRef2:                                    ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %46
+ThrowNullRef4:                                    ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %49
+ThrowNullRef6:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -15023,8 +17300,8 @@ entry:
   %4 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0 to %System.IO.ConsoleStream addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*)(%System.IO.ConsoleStream addrspace(1)* %4, %"System.Byte[]" addrspace(1)* %1, i32 %2, i32 %3)
   %5 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
@@ -15109,8 +17386,8 @@ entry:
 
 ; <label>:22                                      ; preds = %8
   %23 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %23, null
-  br i1 %NullCheck, label %24, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Byte[]" addrspace(1)* %23, null
+  br i1 %NullCheck, label %ThrowNullRef, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
@@ -15132,8 +17409,8 @@ entry:
 
 ; <label>:36                                      ; preds = %24
   %37 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %37, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.ConsoleStream addrspace(1)* %37, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %37, i32 0, i32 4
@@ -15154,13 +17431,138 @@ ThrowNullRef:                                     ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %36
+ThrowNullRef2:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
-Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
+Successfully read WindowsConsoleStream.WriteFileNative
+
+define i32 @WindowsConsoleStream.WriteFileNative(i64 %param0, %"System.Byte[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i64
+  %arg1 = alloca %"System.Byte[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i8 addrspace(1)*
+  %loc2 = alloca %"System.Byte[]" addrspace(1)*
+  %loc3 = alloca i32
+  store i64 %param0, i64* %arg0
+  store %"System.Byte[]" addrspace(1)* %param1, %"System.Byte[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Byte[]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = zext i32 %3 to i64
+  %5 = icmp ne i64 %4, 0
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %1
+  ret i32 0
+
+; <label>:7                                       ; preds = %1
+  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  store %"System.Byte[]" addrspace(1)* %8, %"System.Byte[]" addrspace(1)** %loc2
+  %9 = icmp eq %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %9, label %18, label %10
+
+; <label>:10                                      ; preds = %7
+  %11 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc2
+  %NullCheck1 = icmp eq %"System.Byte[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %11, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp ne i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %7, %12
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc1
+  br label %27
+
+; <label>:19                                      ; preds = %12
+  %20 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc2
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %20, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %BoundsCheck = icmp uge i64 0, %24
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %25
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %20, i32 0, i32 3, i32 0
+  store i8 addrspace(1)* %26, i8 addrspace(1)** %loc1
+  br label %27
+
+; <label>:27                                      ; preds = %18, %25
+  %28 = load i64, i64* %arg0
+  %29 = load i8 addrspace(1)*, i8 addrspace(1)** %loc1
+  %30 = ptrtoint i8 addrspace(1)* %29 to i64
+  %31 = load i32, i32* %arg2
+  %32 = sext i32 %31 to i64
+  %33 = add i64 %30, %32
+  %34 = load i32, i32* %arg3
+  %35 = addrspacecast i32* %loc3 to i32 addrspace(1)*
+  %36 = inttoptr i64 %33 to i8*
+  %37 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i8*, i32, i32 addrspace(1)*, i64)*)(i64 %28, i8* %36, i32 %34, i32 addrspace(1)* %35, i64 0)
+  %38 = icmp ugt i32 %37, 0
+  %39 = sext i1 %38 to i32
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc1
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %42, label %41
+
+; <label>:41                                      ; preds = %27
+  ret i32 0
+
+; <label>:42                                      ; preds = %27
+  %43 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  store i32 %43, i32* %loc0
+  %44 = load i32, i32* %loc0
+  %45 = icmp eq i32 %44, 232
+  br i1 %45, label %49, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = load i32, i32* %loc0
+  %48 = icmp ne i32 %47, 109
+  br i1 %48, label %50, label %49
+
+; <label>:49                                      ; preds = %42, %46
+  ret i32 0
+
+; <label>:50                                      ; preds = %46
+  %51 = load i32, i32* %loc0
+  ret i32 %51
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
 Successfully read WindowsConsoleStream.Flush
 
@@ -15169,8 +17571,8 @@ entry:
   %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
   store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
@@ -15205,8 +17607,8 @@ entry:
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
   %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load i64, i64 addrspace(1)* %1
@@ -15245,15 +17647,15 @@ entry:
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.TextWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
   %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %3, align 8
   %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
   %7 = load i64, i64 addrspace(1)* %5
@@ -15271,7 +17673,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -15300,8 +17702,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %4)
   store i32 0, i32* %loc0
   %5 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Char[]" addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
@@ -15313,15 +17715,15 @@ entry:
 
 ; <label>:11                                      ; preds = %69
   %12 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %12, i32 0, i32 9
   %15 = load i32, i32 addrspace(1)* %14, align 8
   %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.IO.StreamWriter addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %16, i32 0, i32 10
@@ -15336,15 +17738,15 @@ entry:
 
 ; <label>:23                                      ; preds = %17, %21
   %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %24, null
-  br i1 %NullCheck8, label %25, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %24, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 10
   %27 = load i32, i32 addrspace(1)* %26, align 8
   %28 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %28, null
-  br i1 %NullCheck10, label %29, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.StreamWriter addrspace(1)* %28, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %28, i32 0, i32 9
@@ -15366,15 +17768,15 @@ entry:
   %40 = load i32, i32* %loc0
   %41 = mul i32 %40, 2
   %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
-  br i1 %NullCheck12, label %43, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %43
 
 ; <label>:43                                      ; preds = %38
   %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 7
   %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %44, align 8
   %46 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %46, null
-  br i1 %NullCheck14, label %47, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.IO.StreamWriter addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %47
 
 ; <label>:47                                      ; preds = %43
   %48 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %46, i32 0, i32 9
@@ -15386,16 +17788,16 @@ entry:
   %54 = bitcast %"System.Char[]" addrspace(1)* %45 to %System.Array addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %53, i32 %41, %System.Array addrspace(1)* %54, i32 %50, i32 %52)
   %55 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
-  br i1 %NullCheck16, label %56, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %56
 
 ; <label>:56                                      ; preds = %47
   %57 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
   %58 = load i32, i32 addrspace(1)* %57, align 8
   %59 = load i32, i32* %loc2
   %60 = add i32 %58, %59
-  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
-  br i1 %NullCheck18, label %61, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %61
 
 ; <label>:61                                      ; preds = %56
   %62 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
@@ -15417,8 +17819,8 @@ entry:
 
 ; <label>:72                                      ; preds = %69
   %73 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %73, null
-  br i1 %NullCheck2, label %74, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %73, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %74
 
 ; <label>:74                                      ; preds = %72
   %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %73, i32 0, i32 11
@@ -15439,39 +17841,39 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %72
+ThrowNullRef2:                                    ; preds = %72
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %23
+ThrowNullRef8:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef10:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %43
+ThrowNullRef14:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %47
+ThrowNullRef16:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %56
+ThrowNullRef18:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblArray.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblArray.error.txt
@@ -25,8 +25,8 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
@@ -40,8 +40,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
   %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
@@ -75,7 +75,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -90,8 +90,8 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %NullCheck = icmp ne i8 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = load i8, i8 addrspace(1)* %0, align 8
@@ -125,8 +125,8 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
@@ -159,8 +159,8 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -184,8 +184,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
   store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
@@ -195,8 +195,8 @@ entry:
 ; <label>:4                                       ; preds = %1
   %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
   %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
@@ -206,8 +206,8 @@ entry:
   %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
@@ -221,14 +221,14 @@ entry:
 
 ; <label>:17                                      ; preds = %14
   %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
   %21 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
@@ -238,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -249,8 +249,8 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
@@ -261,27 +261,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %30
+ThrowNullRef10:                                   ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -301,7 +301,89 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
-Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
+Successfully read AppDomainSetup.GetUnsecureApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.GetUnsecureApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %NullCheck = icmp eq %"System.String[]" addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %BoundsCheck = icmp uge i64 0, %5
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %6
+
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 3, i32 0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
+  ret %System.String addrspace(1)* %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_Value using LLILCJit
+Successfully read AppDomainSetup.get_Value
+
+define %"System.String[]" addrspace(1)* @AppDomainSetup.get_Value(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.String[]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 18)
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.String[]" addrspace(1)* addrspace(1)*, %"System.String[]" addrspace(1)*)*)(%"System.String[]" addrspace(1)* addrspace(1)* %9, %"System.String[]" addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %11, i32 0, i32 1
+  %14 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %13, align 8
+  ret %"System.String[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -319,8 +401,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -368,16 +450,16 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
   %5 = load i32, i32 addrspace(1)* %4
   %6 = sub i32 %5, 1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -389,7 +471,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -421,8 +503,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
@@ -456,8 +538,8 @@ entry:
 ; <label>:27                                      ; preds = %19
   %28 = load i32, i32* %arg1
   %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
-  br i1 %NullCheck2, label %30, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %29, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %30
 
 ; <label>:30                                      ; preds = %27
   %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
@@ -493,8 +575,8 @@ entry:
 ; <label>:49                                      ; preds = %46
   %50 = load i32, i32* %arg2
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck4, label %52, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
@@ -517,11 +599,11 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %27
+ThrowNullRef2:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %49
+ThrowNullRef4:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -544,16 +626,16 @@ entry:
   %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %0)
   store %System.String addrspace(1)* %1, %System.String addrspace(1)** %loc0
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 2
   %5 = bitcast [0 x i16] addrspace(1)* %4 to i16 addrspace(1)*
   store i16 addrspace(1)* %5, i16 addrspace(1)** %loc1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %3
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2
@@ -580,7 +662,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -691,15 +773,15 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %NullCheck132 = icmp ne i8* %21, null
-  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+  %NullCheck131 = icmp eq i8* %21, null
+  br i1 %NullCheck131, label %ThrowNullRef132, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = load i8, i8* %21, align 8
   %24 = zext i8 %23 to i32
   %25 = trunc i32 %24 to i8
-  %NullCheck134 = icmp ne i8* %20, null
-  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+  %NullCheck133 = icmp eq i8* %20, null
+  br i1 %NullCheck133, label %ThrowNullRef134, label %26
 
 ; <label>:26                                      ; preds = %22
   store i8 %25, i8* %20, align 8
@@ -709,16 +791,16 @@ entry:
   %28 = load i8*, i8** %arg0
   %29 = load i8*, i8** %arg1
   %30 = bitcast i8* %29 to i16*
-  %NullCheck128 = icmp ne i16* %30, null
-  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+  %NullCheck127 = icmp eq i16* %30, null
+  br i1 %NullCheck127, label %ThrowNullRef128, label %31
 
 ; <label>:31                                      ; preds = %27
   %32 = load i16, i16* %30, align 8
   %33 = sext i16 %32 to i32
   %34 = bitcast i8* %28 to i16*
   %35 = trunc i32 %33 to i16
-  %NullCheck130 = icmp ne i16* %34, null
-  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+  %NullCheck129 = icmp eq i16* %34, null
+  br i1 %NullCheck129, label %ThrowNullRef130, label %36
 
 ; <label>:36                                      ; preds = %31
   store i16 %35, i16* %34, align 8
@@ -728,16 +810,16 @@ entry:
   %38 = load i8*, i8** %arg0
   %39 = load i8*, i8** %arg1
   %40 = bitcast i8* %39 to i16*
-  %NullCheck120 = icmp ne i16* %40, null
-  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+  %NullCheck119 = icmp eq i16* %40, null
+  br i1 %NullCheck119, label %ThrowNullRef120, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i16, i16* %40, align 8
   %43 = sext i16 %42 to i32
   %44 = bitcast i8* %38 to i16*
   %45 = trunc i32 %43 to i16
-  %NullCheck122 = icmp ne i16* %44, null
-  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+  %NullCheck121 = icmp eq i16* %44, null
+  br i1 %NullCheck121, label %ThrowNullRef122, label %46
 
 ; <label>:46                                      ; preds = %41
   store i16 %45, i16* %44, align 8
@@ -745,15 +827,15 @@ entry:
   %48 = getelementptr inbounds i8, i8* %47, i64 2
   %49 = load i8*, i8** %arg1
   %50 = getelementptr inbounds i8, i8* %49, i64 2
-  %NullCheck124 = icmp ne i8* %50, null
-  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+  %NullCheck123 = icmp eq i8* %50, null
+  br i1 %NullCheck123, label %ThrowNullRef124, label %51
 
 ; <label>:51                                      ; preds = %46
   %52 = load i8, i8* %50, align 8
   %53 = zext i8 %52 to i32
   %54 = trunc i32 %53 to i8
-  %NullCheck126 = icmp ne i8* %48, null
-  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+  %NullCheck125 = icmp eq i8* %48, null
+  br i1 %NullCheck125, label %ThrowNullRef126, label %55
 
 ; <label>:55                                      ; preds = %51
   store i8 %54, i8* %48, align 8
@@ -763,14 +845,14 @@ entry:
   %57 = load i8*, i8** %arg0
   %58 = load i8*, i8** %arg1
   %59 = bitcast i8* %58 to i32*
-  %NullCheck116 = icmp ne i32* %59, null
-  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+  %NullCheck115 = icmp eq i32* %59, null
+  br i1 %NullCheck115, label %ThrowNullRef116, label %60
 
 ; <label>:60                                      ; preds = %56
   %61 = load i32, i32* %59, align 8
   %62 = bitcast i8* %57 to i32*
-  %NullCheck118 = icmp ne i32* %62, null
-  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+  %NullCheck117 = icmp eq i32* %62, null
+  br i1 %NullCheck117, label %ThrowNullRef118, label %63
 
 ; <label>:63                                      ; preds = %60
   store i32 %61, i32* %62, align 8
@@ -780,14 +862,14 @@ entry:
   %65 = load i8*, i8** %arg0
   %66 = load i8*, i8** %arg1
   %67 = bitcast i8* %66 to i32*
-  %NullCheck108 = icmp ne i32* %67, null
-  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+  %NullCheck107 = icmp eq i32* %67, null
+  br i1 %NullCheck107, label %ThrowNullRef108, label %68
 
 ; <label>:68                                      ; preds = %64
   %69 = load i32, i32* %67, align 8
   %70 = bitcast i8* %65 to i32*
-  %NullCheck110 = icmp ne i32* %70, null
-  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+  %NullCheck109 = icmp eq i32* %70, null
+  br i1 %NullCheck109, label %ThrowNullRef110, label %71
 
 ; <label>:71                                      ; preds = %68
   store i32 %69, i32* %70, align 8
@@ -795,15 +877,15 @@ entry:
   %73 = getelementptr inbounds i8, i8* %72, i64 4
   %74 = load i8*, i8** %arg1
   %75 = getelementptr inbounds i8, i8* %74, i64 4
-  %NullCheck112 = icmp ne i8* %75, null
-  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+  %NullCheck111 = icmp eq i8* %75, null
+  br i1 %NullCheck111, label %ThrowNullRef112, label %76
 
 ; <label>:76                                      ; preds = %71
   %77 = load i8, i8* %75, align 8
   %78 = zext i8 %77 to i32
   %79 = trunc i32 %78 to i8
-  %NullCheck114 = icmp ne i8* %73, null
-  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+  %NullCheck113 = icmp eq i8* %73, null
+  br i1 %NullCheck113, label %ThrowNullRef114, label %80
 
 ; <label>:80                                      ; preds = %76
   store i8 %79, i8* %73, align 8
@@ -813,14 +895,14 @@ entry:
   %82 = load i8*, i8** %arg0
   %83 = load i8*, i8** %arg1
   %84 = bitcast i8* %83 to i32*
-  %NullCheck100 = icmp ne i32* %84, null
-  br i1 %NullCheck100, label %85, label %ThrowNullRef99
+  %NullCheck99 = icmp eq i32* %84, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %85
 
 ; <label>:85                                      ; preds = %81
   %86 = load i32, i32* %84, align 8
   %87 = bitcast i8* %82 to i32*
-  %NullCheck102 = icmp ne i32* %87, null
-  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+  %NullCheck101 = icmp eq i32* %87, null
+  br i1 %NullCheck101, label %ThrowNullRef102, label %88
 
 ; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
@@ -829,16 +911,16 @@ entry:
   %91 = load i8*, i8** %arg1
   %92 = getelementptr inbounds i8, i8* %91, i64 4
   %93 = bitcast i8* %92 to i16*
-  %NullCheck104 = icmp ne i16* %93, null
-  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+  %NullCheck103 = icmp eq i16* %93, null
+  br i1 %NullCheck103, label %ThrowNullRef104, label %94
 
 ; <label>:94                                      ; preds = %88
   %95 = load i16, i16* %93, align 8
   %96 = sext i16 %95 to i32
   %97 = bitcast i8* %90 to i16*
   %98 = trunc i32 %96 to i16
-  %NullCheck106 = icmp ne i16* %97, null
-  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+  %NullCheck105 = icmp eq i16* %97, null
+  br i1 %NullCheck105, label %ThrowNullRef106, label %99
 
 ; <label>:99                                      ; preds = %94
   store i16 %98, i16* %97, align 8
@@ -848,14 +930,14 @@ entry:
   %101 = load i8*, i8** %arg0
   %102 = load i8*, i8** %arg1
   %103 = bitcast i8* %102 to i32*
-  %NullCheck88 = icmp ne i32* %103, null
-  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+  %NullCheck87 = icmp eq i32* %103, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %104
 
 ; <label>:104                                     ; preds = %100
   %105 = load i32, i32* %103, align 8
   %106 = bitcast i8* %101 to i32*
-  %NullCheck90 = icmp ne i32* %106, null
-  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+  %NullCheck89 = icmp eq i32* %106, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %107
 
 ; <label>:107                                     ; preds = %104
   store i32 %105, i32* %106, align 8
@@ -864,16 +946,16 @@ entry:
   %110 = load i8*, i8** %arg1
   %111 = getelementptr inbounds i8, i8* %110, i64 4
   %112 = bitcast i8* %111 to i16*
-  %NullCheck92 = icmp ne i16* %112, null
-  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+  %NullCheck91 = icmp eq i16* %112, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %113
 
 ; <label>:113                                     ; preds = %107
   %114 = load i16, i16* %112, align 8
   %115 = sext i16 %114 to i32
   %116 = bitcast i8* %109 to i16*
   %117 = trunc i32 %115 to i16
-  %NullCheck94 = icmp ne i16* %116, null
-  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+  %NullCheck93 = icmp eq i16* %116, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %118
 
 ; <label>:118                                     ; preds = %113
   store i16 %117, i16* %116, align 8
@@ -881,15 +963,15 @@ entry:
   %120 = getelementptr inbounds i8, i8* %119, i64 6
   %121 = load i8*, i8** %arg1
   %122 = getelementptr inbounds i8, i8* %121, i64 6
-  %NullCheck96 = icmp ne i8* %122, null
-  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+  %NullCheck95 = icmp eq i8* %122, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %123
 
 ; <label>:123                                     ; preds = %118
   %124 = load i8, i8* %122, align 8
   %125 = zext i8 %124 to i32
   %126 = trunc i32 %125 to i8
-  %NullCheck98 = icmp ne i8* %120, null
-  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+  %NullCheck97 = icmp eq i8* %120, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %127
 
 ; <label>:127                                     ; preds = %123
   store i8 %126, i8* %120, align 8
@@ -899,14 +981,14 @@ entry:
   %129 = load i8*, i8** %arg0
   %130 = load i8*, i8** %arg1
   %131 = bitcast i8* %130 to i64*
-  %NullCheck84 = icmp ne i64* %131, null
-  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+  %NullCheck83 = icmp eq i64* %131, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %132
 
 ; <label>:132                                     ; preds = %128
   %133 = load i64, i64* %131, align 8
   %134 = bitcast i8* %129 to i64*
-  %NullCheck86 = icmp ne i64* %134, null
-  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+  %NullCheck85 = icmp eq i64* %134, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %135
 
 ; <label>:135                                     ; preds = %132
   store i64 %133, i64* %134, align 8
@@ -916,14 +998,14 @@ entry:
   %137 = load i8*, i8** %arg0
   %138 = load i8*, i8** %arg1
   %139 = bitcast i8* %138 to i64*
-  %NullCheck76 = icmp ne i64* %139, null
-  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+  %NullCheck75 = icmp eq i64* %139, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %140
 
 ; <label>:140                                     ; preds = %136
   %141 = load i64, i64* %139, align 8
   %142 = bitcast i8* %137 to i64*
-  %NullCheck78 = icmp ne i64* %142, null
-  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+  %NullCheck77 = icmp eq i64* %142, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %143
 
 ; <label>:143                                     ; preds = %140
   store i64 %141, i64* %142, align 8
@@ -931,15 +1013,15 @@ entry:
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %NullCheck80 = icmp ne i8* %147, null
-  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+  %NullCheck79 = icmp eq i8* %147, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %148
 
 ; <label>:148                                     ; preds = %143
   %149 = load i8, i8* %147, align 8
   %150 = zext i8 %149 to i32
   %151 = trunc i32 %150 to i8
-  %NullCheck82 = icmp ne i8* %145, null
-  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+  %NullCheck81 = icmp eq i8* %145, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %152
 
 ; <label>:152                                     ; preds = %148
   store i8 %151, i8* %145, align 8
@@ -949,14 +1031,14 @@ entry:
   %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
   %156 = bitcast i8* %155 to i64*
-  %NullCheck68 = icmp ne i64* %156, null
-  br i1 %NullCheck68, label %157, label %ThrowNullRef67
+  %NullCheck67 = icmp eq i64* %156, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %157
 
 ; <label>:157                                     ; preds = %153
   %158 = load i64, i64* %156, align 8
   %159 = bitcast i8* %154 to i64*
-  %NullCheck70 = icmp ne i64* %159, null
-  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+  %NullCheck69 = icmp eq i64* %159, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %160
 
 ; <label>:160                                     ; preds = %157
   store i64 %158, i64* %159, align 8
@@ -965,16 +1047,16 @@ entry:
   %163 = load i8*, i8** %arg1
   %164 = getelementptr inbounds i8, i8* %163, i64 8
   %165 = bitcast i8* %164 to i16*
-  %NullCheck72 = icmp ne i16* %165, null
-  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+  %NullCheck71 = icmp eq i16* %165, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %166
 
 ; <label>:166                                     ; preds = %160
   %167 = load i16, i16* %165, align 8
   %168 = sext i16 %167 to i32
   %169 = bitcast i8* %162 to i16*
   %170 = trunc i32 %168 to i16
-  %NullCheck74 = icmp ne i16* %169, null
-  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+  %NullCheck73 = icmp eq i16* %169, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %171
 
 ; <label>:171                                     ; preds = %166
   store i16 %170, i16* %169, align 8
@@ -984,14 +1066,14 @@ entry:
   %173 = load i8*, i8** %arg0
   %174 = load i8*, i8** %arg1
   %175 = bitcast i8* %174 to i64*
-  %NullCheck56 = icmp ne i64* %175, null
-  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+  %NullCheck55 = icmp eq i64* %175, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %176
 
 ; <label>:176                                     ; preds = %172
   %177 = load i64, i64* %175, align 8
   %178 = bitcast i8* %173 to i64*
-  %NullCheck58 = icmp ne i64* %178, null
-  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+  %NullCheck57 = icmp eq i64* %178, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %179
 
 ; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
@@ -1000,16 +1082,16 @@ entry:
   %182 = load i8*, i8** %arg1
   %183 = getelementptr inbounds i8, i8* %182, i64 8
   %184 = bitcast i8* %183 to i16*
-  %NullCheck60 = icmp ne i16* %184, null
-  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+  %NullCheck59 = icmp eq i16* %184, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %185
 
 ; <label>:185                                     ; preds = %179
   %186 = load i16, i16* %184, align 8
   %187 = sext i16 %186 to i32
   %188 = bitcast i8* %181 to i16*
   %189 = trunc i32 %187 to i16
-  %NullCheck62 = icmp ne i16* %188, null
-  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+  %NullCheck61 = icmp eq i16* %188, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %190
 
 ; <label>:190                                     ; preds = %185
   store i16 %189, i16* %188, align 8
@@ -1017,15 +1099,15 @@ entry:
   %192 = getelementptr inbounds i8, i8* %191, i64 10
   %193 = load i8*, i8** %arg1
   %194 = getelementptr inbounds i8, i8* %193, i64 10
-  %NullCheck64 = icmp ne i8* %194, null
-  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+  %NullCheck63 = icmp eq i8* %194, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %195
 
 ; <label>:195                                     ; preds = %190
   %196 = load i8, i8* %194, align 8
   %197 = zext i8 %196 to i32
   %198 = trunc i32 %197 to i8
-  %NullCheck66 = icmp ne i8* %192, null
-  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+  %NullCheck65 = icmp eq i8* %192, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %199
 
 ; <label>:199                                     ; preds = %195
   store i8 %198, i8* %192, align 8
@@ -1035,14 +1117,14 @@ entry:
   %201 = load i8*, i8** %arg0
   %202 = load i8*, i8** %arg1
   %203 = bitcast i8* %202 to i64*
-  %NullCheck48 = icmp ne i64* %203, null
-  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+  %NullCheck47 = icmp eq i64* %203, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %204
 
 ; <label>:204                                     ; preds = %200
   %205 = load i64, i64* %203, align 8
   %206 = bitcast i8* %201 to i64*
-  %NullCheck50 = icmp ne i64* %206, null
-  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+  %NullCheck49 = icmp eq i64* %206, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %207
 
 ; <label>:207                                     ; preds = %204
   store i64 %205, i64* %206, align 8
@@ -1051,14 +1133,14 @@ entry:
   %210 = load i8*, i8** %arg1
   %211 = getelementptr inbounds i8, i8* %210, i64 8
   %212 = bitcast i8* %211 to i32*
-  %NullCheck52 = icmp ne i32* %212, null
-  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+  %NullCheck51 = icmp eq i32* %212, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %213
 
 ; <label>:213                                     ; preds = %207
   %214 = load i32, i32* %212, align 8
   %215 = bitcast i8* %209 to i32*
-  %NullCheck54 = icmp ne i32* %215, null
-  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+  %NullCheck53 = icmp eq i32* %215, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %216
 
 ; <label>:216                                     ; preds = %213
   store i32 %214, i32* %215, align 8
@@ -1068,14 +1150,14 @@ entry:
   %218 = load i8*, i8** %arg0
   %219 = load i8*, i8** %arg1
   %220 = bitcast i8* %219 to i64*
-  %NullCheck36 = icmp ne i64* %220, null
-  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64* %220, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %221
 
 ; <label>:221                                     ; preds = %217
   %222 = load i64, i64* %220, align 8
   %223 = bitcast i8* %218 to i64*
-  %NullCheck38 = icmp ne i64* %223, null
-  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+  %NullCheck37 = icmp eq i64* %223, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %224
 
 ; <label>:224                                     ; preds = %221
   store i64 %222, i64* %223, align 8
@@ -1084,14 +1166,14 @@ entry:
   %227 = load i8*, i8** %arg1
   %228 = getelementptr inbounds i8, i8* %227, i64 8
   %229 = bitcast i8* %228 to i32*
-  %NullCheck40 = icmp ne i32* %229, null
-  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i32* %229, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %230
 
 ; <label>:230                                     ; preds = %224
   %231 = load i32, i32* %229, align 8
   %232 = bitcast i8* %226 to i32*
-  %NullCheck42 = icmp ne i32* %232, null
-  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+  %NullCheck41 = icmp eq i32* %232, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %233
 
 ; <label>:233                                     ; preds = %230
   store i32 %231, i32* %232, align 8
@@ -1099,15 +1181,15 @@ entry:
   %235 = getelementptr inbounds i8, i8* %234, i64 12
   %236 = load i8*, i8** %arg1
   %237 = getelementptr inbounds i8, i8* %236, i64 12
-  %NullCheck44 = icmp ne i8* %237, null
-  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i8* %237, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %238
 
 ; <label>:238                                     ; preds = %233
   %239 = load i8, i8* %237, align 8
   %240 = zext i8 %239 to i32
   %241 = trunc i32 %240 to i8
-  %NullCheck46 = icmp ne i8* %235, null
-  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+  %NullCheck45 = icmp eq i8* %235, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %242
 
 ; <label>:242                                     ; preds = %238
   store i8 %241, i8* %235, align 8
@@ -1117,14 +1199,14 @@ entry:
   %244 = load i8*, i8** %arg0
   %245 = load i8*, i8** %arg1
   %246 = bitcast i8* %245 to i64*
-  %NullCheck24 = icmp ne i64* %246, null
-  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64* %246, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %247
 
 ; <label>:247                                     ; preds = %243
   %248 = load i64, i64* %246, align 8
   %249 = bitcast i8* %244 to i64*
-  %NullCheck26 = icmp ne i64* %249, null
-  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64* %249, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %250
 
 ; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
@@ -1133,14 +1215,14 @@ entry:
   %253 = load i8*, i8** %arg1
   %254 = getelementptr inbounds i8, i8* %253, i64 8
   %255 = bitcast i8* %254 to i32*
-  %NullCheck28 = icmp ne i32* %255, null
-  br i1 %NullCheck28, label %256, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i32* %255, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %256
 
 ; <label>:256                                     ; preds = %250
   %257 = load i32, i32* %255, align 8
   %258 = bitcast i8* %252 to i32*
-  %NullCheck30 = icmp ne i32* %258, null
-  br i1 %NullCheck30, label %259, label %ThrowNullRef29
+  %NullCheck29 = icmp eq i32* %258, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %259
 
 ; <label>:259                                     ; preds = %256
   store i32 %257, i32* %258, align 8
@@ -1149,16 +1231,16 @@ entry:
   %262 = load i8*, i8** %arg1
   %263 = getelementptr inbounds i8, i8* %262, i64 12
   %264 = bitcast i8* %263 to i16*
-  %NullCheck32 = icmp ne i16* %264, null
-  br i1 %NullCheck32, label %265, label %ThrowNullRef31
+  %NullCheck31 = icmp eq i16* %264, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %265
 
 ; <label>:265                                     ; preds = %259
   %266 = load i16, i16* %264, align 8
   %267 = sext i16 %266 to i32
   %268 = bitcast i8* %261 to i16*
   %269 = trunc i32 %267 to i16
-  %NullCheck34 = icmp ne i16* %268, null
-  br i1 %NullCheck34, label %270, label %ThrowNullRef33
+  %NullCheck33 = icmp eq i16* %268, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %270
 
 ; <label>:270                                     ; preds = %265
   store i16 %269, i16* %268, align 8
@@ -1168,14 +1250,14 @@ entry:
   %272 = load i8*, i8** %arg0
   %273 = load i8*, i8** %arg1
   %274 = bitcast i8* %273 to i64*
-  %NullCheck8 = icmp ne i64* %274, null
-  br i1 %NullCheck8, label %275, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64* %274, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %275
 
 ; <label>:275                                     ; preds = %271
   %276 = load i64, i64* %274, align 8
   %277 = bitcast i8* %272 to i64*
-  %NullCheck10 = icmp ne i64* %277, null
-  br i1 %NullCheck10, label %278, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %277, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %278
 
 ; <label>:278                                     ; preds = %275
   store i64 %276, i64* %277, align 8
@@ -1184,14 +1266,14 @@ entry:
   %281 = load i8*, i8** %arg1
   %282 = getelementptr inbounds i8, i8* %281, i64 8
   %283 = bitcast i8* %282 to i32*
-  %NullCheck12 = icmp ne i32* %283, null
-  br i1 %NullCheck12, label %284, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i32* %283, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %284
 
 ; <label>:284                                     ; preds = %278
   %285 = load i32, i32* %283, align 8
   %286 = bitcast i8* %280 to i32*
-  %NullCheck14 = icmp ne i32* %286, null
-  br i1 %NullCheck14, label %287, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i32* %286, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %287
 
 ; <label>:287                                     ; preds = %284
   store i32 %285, i32* %286, align 8
@@ -1200,16 +1282,16 @@ entry:
   %290 = load i8*, i8** %arg1
   %291 = getelementptr inbounds i8, i8* %290, i64 12
   %292 = bitcast i8* %291 to i16*
-  %NullCheck16 = icmp ne i16* %292, null
-  br i1 %NullCheck16, label %293, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i16* %292, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %293
 
 ; <label>:293                                     ; preds = %287
   %294 = load i16, i16* %292, align 8
   %295 = sext i16 %294 to i32
   %296 = bitcast i8* %289 to i16*
   %297 = trunc i32 %295 to i16
-  %NullCheck18 = icmp ne i16* %296, null
-  br i1 %NullCheck18, label %298, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i16* %296, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %298
 
 ; <label>:298                                     ; preds = %293
   store i16 %297, i16* %296, align 8
@@ -1217,15 +1299,15 @@ entry:
   %300 = getelementptr inbounds i8, i8* %299, i64 14
   %301 = load i8*, i8** %arg1
   %302 = getelementptr inbounds i8, i8* %301, i64 14
-  %NullCheck20 = icmp ne i8* %302, null
-  br i1 %NullCheck20, label %303, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i8* %302, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %303
 
 ; <label>:303                                     ; preds = %298
   %304 = load i8, i8* %302, align 8
   %305 = zext i8 %304 to i32
   %306 = trunc i32 %305 to i8
-  %NullCheck22 = icmp ne i8* %300, null
-  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i8* %300, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %307
 
 ; <label>:307                                     ; preds = %303
   store i8 %306, i8* %300, align 8
@@ -1235,14 +1317,14 @@ entry:
   %309 = load i8*, i8** %arg0
   %310 = load i8*, i8** %arg1
   %311 = bitcast i8* %310 to i64*
-  %NullCheck = icmp ne i64* %311, null
-  br i1 %NullCheck, label %312, label %ThrowNullRef
+  %NullCheck = icmp eq i64* %311, null
+  br i1 %NullCheck, label %ThrowNullRef, label %312
 
 ; <label>:312                                     ; preds = %308
   %313 = load i64, i64* %311, align 8
   %314 = bitcast i8* %309 to i64*
-  %NullCheck2 = icmp ne i64* %314, null
-  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64* %314, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %315
 
 ; <label>:315                                     ; preds = %312
   store i64 %313, i64* %314, align 8
@@ -1251,14 +1333,14 @@ entry:
   %318 = load i8*, i8** %arg1
   %319 = getelementptr inbounds i8, i8* %318, i64 8
   %320 = bitcast i8* %319 to i64*
-  %NullCheck4 = icmp ne i64* %320, null
-  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64* %320, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %321
 
 ; <label>:321                                     ; preds = %315
   %322 = load i64, i64* %320, align 8
   %323 = bitcast i8* %317 to i64*
-  %NullCheck6 = icmp ne i64* %323, null
-  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64* %323, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %324
 
 ; <label>:324                                     ; preds = %321
   store i64 %322, i64* %323, align 8
@@ -1286,15 +1368,15 @@ entry:
 ; <label>:338                                     ; preds = %333
   %339 = load i8*, i8** %arg0
   %340 = load i8*, i8** %arg1
-  %NullCheck136 = icmp ne i8* %340, null
-  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+  %NullCheck135 = icmp eq i8* %340, null
+  br i1 %NullCheck135, label %ThrowNullRef136, label %341
 
 ; <label>:341                                     ; preds = %338
   %342 = load i8, i8* %340, align 8
   %343 = zext i8 %342 to i32
   %344 = trunc i32 %343 to i8
-  %NullCheck138 = icmp ne i8* %339, null
-  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+  %NullCheck137 = icmp eq i8* %339, null
+  br i1 %NullCheck137, label %ThrowNullRef138, label %345
 
 ; <label>:345                                     ; preds = %341
   store i8 %344, i8* %339, align 8
@@ -1317,16 +1399,16 @@ entry:
   %357 = load i8*, i8** %arg0
   %358 = load i8*, i8** %arg1
   %359 = bitcast i8* %358 to i16*
-  %NullCheck140 = icmp ne i16* %359, null
-  br i1 %NullCheck140, label %360, label %ThrowNullRef139
+  %NullCheck139 = icmp eq i16* %359, null
+  br i1 %NullCheck139, label %ThrowNullRef140, label %360
 
 ; <label>:360                                     ; preds = %356
   %361 = load i16, i16* %359, align 8
   %362 = sext i16 %361 to i32
   %363 = bitcast i8* %357 to i16*
   %364 = trunc i32 %362 to i16
-  %NullCheck142 = icmp ne i16* %363, null
-  br i1 %NullCheck142, label %365, label %ThrowNullRef141
+  %NullCheck141 = icmp eq i16* %363, null
+  br i1 %NullCheck141, label %ThrowNullRef142, label %365
 
 ; <label>:365                                     ; preds = %360
   store i16 %364, i16* %363, align 8
@@ -1352,14 +1434,14 @@ entry:
   %378 = load i8*, i8** %arg0
   %379 = load i8*, i8** %arg1
   %380 = bitcast i8* %379 to i32*
-  %NullCheck144 = icmp ne i32* %380, null
-  br i1 %NullCheck144, label %381, label %ThrowNullRef143
+  %NullCheck143 = icmp eq i32* %380, null
+  br i1 %NullCheck143, label %ThrowNullRef144, label %381
 
 ; <label>:381                                     ; preds = %377
   %382 = load i32, i32* %380, align 8
   %383 = bitcast i8* %378 to i32*
-  %NullCheck146 = icmp ne i32* %383, null
-  br i1 %NullCheck146, label %384, label %ThrowNullRef145
+  %NullCheck145 = icmp eq i32* %383, null
+  br i1 %NullCheck145, label %ThrowNullRef146, label %384
 
 ; <label>:384                                     ; preds = %381
   store i32 %382, i32* %383, align 8
@@ -1384,14 +1466,14 @@ entry:
   %395 = load i8*, i8** %arg0
   %396 = load i8*, i8** %arg1
   %397 = bitcast i8* %396 to i64*
-  %NullCheck164 = icmp ne i64* %397, null
-  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+  %NullCheck163 = icmp eq i64* %397, null
+  br i1 %NullCheck163, label %ThrowNullRef164, label %398
 
 ; <label>:398                                     ; preds = %394
   %399 = load i64, i64* %397, align 8
   %400 = bitcast i8* %395 to i64*
-  %NullCheck166 = icmp ne i64* %400, null
-  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+  %NullCheck165 = icmp eq i64* %400, null
+  br i1 %NullCheck165, label %ThrowNullRef166, label %401
 
 ; <label>:401                                     ; preds = %398
   store i64 %399, i64* %400, align 8
@@ -1400,14 +1482,14 @@ entry:
   %404 = load i8*, i8** %arg1
   %405 = getelementptr inbounds i8, i8* %404, i64 8
   %406 = bitcast i8* %405 to i64*
-  %NullCheck168 = icmp ne i64* %406, null
-  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+  %NullCheck167 = icmp eq i64* %406, null
+  br i1 %NullCheck167, label %ThrowNullRef168, label %407
 
 ; <label>:407                                     ; preds = %401
   %408 = load i64, i64* %406, align 8
   %409 = bitcast i8* %403 to i64*
-  %NullCheck170 = icmp ne i64* %409, null
-  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+  %NullCheck169 = icmp eq i64* %409, null
+  br i1 %NullCheck169, label %ThrowNullRef170, label %410
 
 ; <label>:410                                     ; preds = %407
   store i64 %408, i64* %409, align 8
@@ -1437,14 +1519,14 @@ entry:
   %425 = load i8*, i8** %arg0
   %426 = load i8*, i8** %arg1
   %427 = bitcast i8* %426 to i64*
-  %NullCheck148 = icmp ne i64* %427, null
-  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+  %NullCheck147 = icmp eq i64* %427, null
+  br i1 %NullCheck147, label %ThrowNullRef148, label %428
 
 ; <label>:428                                     ; preds = %424
   %429 = load i64, i64* %427, align 8
   %430 = bitcast i8* %425 to i64*
-  %NullCheck150 = icmp ne i64* %430, null
-  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+  %NullCheck149 = icmp eq i64* %430, null
+  br i1 %NullCheck149, label %ThrowNullRef150, label %431
 
 ; <label>:431                                     ; preds = %428
   store i64 %429, i64* %430, align 8
@@ -1466,14 +1548,14 @@ entry:
   %441 = load i8*, i8** %arg0
   %442 = load i8*, i8** %arg1
   %443 = bitcast i8* %442 to i32*
-  %NullCheck152 = icmp ne i32* %443, null
-  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+  %NullCheck151 = icmp eq i32* %443, null
+  br i1 %NullCheck151, label %ThrowNullRef152, label %444
 
 ; <label>:444                                     ; preds = %440
   %445 = load i32, i32* %443, align 8
   %446 = bitcast i8* %441 to i32*
-  %NullCheck154 = icmp ne i32* %446, null
-  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+  %NullCheck153 = icmp eq i32* %446, null
+  br i1 %NullCheck153, label %ThrowNullRef154, label %447
 
 ; <label>:447                                     ; preds = %444
   store i32 %445, i32* %446, align 8
@@ -1495,16 +1577,16 @@ entry:
   %457 = load i8*, i8** %arg0
   %458 = load i8*, i8** %arg1
   %459 = bitcast i8* %458 to i16*
-  %NullCheck156 = icmp ne i16* %459, null
-  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+  %NullCheck155 = icmp eq i16* %459, null
+  br i1 %NullCheck155, label %ThrowNullRef156, label %460
 
 ; <label>:460                                     ; preds = %456
   %461 = load i16, i16* %459, align 8
   %462 = sext i16 %461 to i32
   %463 = bitcast i8* %457 to i16*
   %464 = trunc i32 %462 to i16
-  %NullCheck158 = icmp ne i16* %463, null
-  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+  %NullCheck157 = icmp eq i16* %463, null
+  br i1 %NullCheck157, label %ThrowNullRef158, label %465
 
 ; <label>:465                                     ; preds = %460
   store i16 %464, i16* %463, align 8
@@ -1525,15 +1607,15 @@ entry:
 ; <label>:474                                     ; preds = %470
   %475 = load i8*, i8** %arg0
   %476 = load i8*, i8** %arg1
-  %NullCheck160 = icmp ne i8* %476, null
-  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+  %NullCheck159 = icmp eq i8* %476, null
+  br i1 %NullCheck159, label %ThrowNullRef160, label %477
 
 ; <label>:477                                     ; preds = %474
   %478 = load i8, i8* %476, align 8
   %479 = zext i8 %478 to i32
   %480 = trunc i32 %479 to i8
-  %NullCheck162 = icmp ne i8* %475, null
-  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+  %NullCheck161 = icmp eq i8* %475, null
+  br i1 %NullCheck161, label %ThrowNullRef162, label %481
 
 ; <label>:481                                     ; preds = %477
   store i8 %480, i8* %475, align 8
@@ -1553,343 +1635,343 @@ ThrowNullRef:                                     ; preds = %308
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %312
+ThrowNullRef2:                                    ; preds = %312
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %315
+ThrowNullRef4:                                    ; preds = %315
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %321
+ThrowNullRef6:                                    ; preds = %321
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %271
+ThrowNullRef8:                                    ; preds = %271
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %275
+ThrowNullRef10:                                   ; preds = %275
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %278
+ThrowNullRef12:                                   ; preds = %278
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %284
+ThrowNullRef14:                                   ; preds = %284
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %287
+ThrowNullRef16:                                   ; preds = %287
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %293
+ThrowNullRef18:                                   ; preds = %293
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %298
+ThrowNullRef20:                                   ; preds = %298
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %303
+ThrowNullRef22:                                   ; preds = %303
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %243
+ThrowNullRef24:                                   ; preds = %243
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %247
+ThrowNullRef26:                                   ; preds = %247
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %250
+ThrowNullRef28:                                   ; preds = %250
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %256
+ThrowNullRef30:                                   ; preds = %256
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %259
+ThrowNullRef32:                                   ; preds = %259
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %265
+ThrowNullRef34:                                   ; preds = %265
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %217
+ThrowNullRef36:                                   ; preds = %217
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %221
+ThrowNullRef38:                                   ; preds = %221
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %224
+ThrowNullRef40:                                   ; preds = %224
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %230
+ThrowNullRef42:                                   ; preds = %230
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %233
+ThrowNullRef44:                                   ; preds = %233
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %238
+ThrowNullRef46:                                   ; preds = %238
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %200
+ThrowNullRef48:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %204
+ThrowNullRef50:                                   ; preds = %204
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %207
+ThrowNullRef52:                                   ; preds = %207
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %213
+ThrowNullRef54:                                   ; preds = %213
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %172
+ThrowNullRef56:                                   ; preds = %172
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %176
+ThrowNullRef58:                                   ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %179
+ThrowNullRef60:                                   ; preds = %179
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %185
+ThrowNullRef62:                                   ; preds = %185
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %190
+ThrowNullRef64:                                   ; preds = %190
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %195
+ThrowNullRef66:                                   ; preds = %195
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %153
+ThrowNullRef68:                                   ; preds = %153
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %157
+ThrowNullRef70:                                   ; preds = %157
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %160
+ThrowNullRef72:                                   ; preds = %160
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %166
+ThrowNullRef74:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %136
+ThrowNullRef76:                                   ; preds = %136
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %140
+ThrowNullRef78:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %143
+ThrowNullRef80:                                   ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %148
+ThrowNullRef82:                                   ; preds = %148
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %128
+ThrowNullRef84:                                   ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %132
+ThrowNullRef86:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %100
+ThrowNullRef88:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %104
+ThrowNullRef90:                                   ; preds = %104
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %107
+ThrowNullRef92:                                   ; preds = %107
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %113
+ThrowNullRef94:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %118
+ThrowNullRef96:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %123
+ThrowNullRef98:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %81
+ThrowNullRef100:                                  ; preds = %81
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef101:                                  ; preds = %85
+ThrowNullRef102:                                  ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef103:                                  ; preds = %88
+ThrowNullRef104:                                  ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef105:                                  ; preds = %94
+ThrowNullRef106:                                  ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef107:                                  ; preds = %64
+ThrowNullRef108:                                  ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef109:                                  ; preds = %68
+ThrowNullRef110:                                  ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef111:                                  ; preds = %71
+ThrowNullRef112:                                  ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef113:                                  ; preds = %76
+ThrowNullRef114:                                  ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef115:                                  ; preds = %56
+ThrowNullRef116:                                  ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef117:                                  ; preds = %60
+ThrowNullRef118:                                  ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef119:                                  ; preds = %37
+ThrowNullRef120:                                  ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef121:                                  ; preds = %41
+ThrowNullRef122:                                  ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef123:                                  ; preds = %46
+ThrowNullRef124:                                  ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef125:                                  ; preds = %51
+ThrowNullRef126:                                  ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef127:                                  ; preds = %27
+ThrowNullRef128:                                  ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef129:                                  ; preds = %31
+ThrowNullRef130:                                  ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef131:                                  ; preds = %19
+ThrowNullRef132:                                  ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef133:                                  ; preds = %22
+ThrowNullRef134:                                  ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef135:                                  ; preds = %338
+ThrowNullRef136:                                  ; preds = %338
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef137:                                  ; preds = %341
+ThrowNullRef138:                                  ; preds = %341
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef139:                                  ; preds = %356
+ThrowNullRef140:                                  ; preds = %356
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef141:                                  ; preds = %360
+ThrowNullRef142:                                  ; preds = %360
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef143:                                  ; preds = %377
+ThrowNullRef144:                                  ; preds = %377
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef145:                                  ; preds = %381
+ThrowNullRef146:                                  ; preds = %381
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef147:                                  ; preds = %424
+ThrowNullRef148:                                  ; preds = %424
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef149:                                  ; preds = %428
+ThrowNullRef150:                                  ; preds = %428
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef151:                                  ; preds = %440
+ThrowNullRef152:                                  ; preds = %440
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef153:                                  ; preds = %444
+ThrowNullRef154:                                  ; preds = %444
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef155:                                  ; preds = %456
+ThrowNullRef156:                                  ; preds = %456
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef157:                                  ; preds = %460
+ThrowNullRef158:                                  ; preds = %460
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef159:                                  ; preds = %474
+ThrowNullRef160:                                  ; preds = %474
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef161:                                  ; preds = %477
+ThrowNullRef162:                                  ; preds = %477
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef163:                                  ; preds = %394
+ThrowNullRef164:                                  ; preds = %394
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef165:                                  ; preds = %398
+ThrowNullRef166:                                  ; preds = %398
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef167:                                  ; preds = %401
+ThrowNullRef168:                                  ; preds = %401
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef169:                                  ; preds = %407
+ThrowNullRef170:                                  ; preds = %407
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1939,8 +2021,8 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
-  br i1 %NullCheck, label %22, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %ThrowNullRef, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
@@ -1948,8 +2030,8 @@ entry:
   store i32 %24, i32* %loc0
   %25 = load i32, i32* %loc0
   %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %26, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %27
 
 ; <label>:27                                      ; preds = %22
   %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
@@ -1971,7 +2053,7 @@ ThrowNullRef:                                     ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1989,8 +2071,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -2022,15 +2104,15 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2048,16 +2130,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
   %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
   store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %15
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
@@ -2072,8 +2154,8 @@ entry:
   %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
   %29 = ptrtoint i16 addrspace(1)* %28 to i64
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %19
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
@@ -2089,19 +2171,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2114,8 +2196,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
@@ -2128,7 +2210,7 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[loadElem]
+Failed to read AppDomain.PrepareDataForSetup[storeElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
@@ -2202,8 +2284,8 @@ entry:
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
-  br i1 %NullCheck24, label %27, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = load i64, i64 addrspace(1)* %26
@@ -2218,8 +2300,8 @@ entry:
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
-  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
   %41 = load i64, i64 addrspace(1)* %39
@@ -2236,8 +2318,8 @@ entry:
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
-  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
   %54 = load i64, i64 addrspace(1)* %52
@@ -2252,8 +2334,8 @@ entry:
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
   %67 = load i64, i64 addrspace(1)* %65
@@ -2270,8 +2352,8 @@ entry:
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
-  br i1 %NullCheck16, label %79, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
   %80 = load i64, i64 addrspace(1)* %78
@@ -2286,8 +2368,8 @@ entry:
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
-  br i1 %NullCheck18, label %92, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
   %93 = load i64, i64 addrspace(1)* %91
@@ -2304,8 +2386,8 @@ entry:
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
-  br i1 %NullCheck12, label %105, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = load i64, i64 addrspace(1)* %104
@@ -2320,8 +2402,8 @@ entry:
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
-  br i1 %NullCheck14, label %118, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
   %119 = load i64, i64 addrspace(1)* %117
@@ -2337,8 +2419,8 @@ entry:
 
 ; <label>:128                                     ; preds = %20
   %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
-  br i1 %NullCheck4, label %130, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %129, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %130
 
 ; <label>:130                                     ; preds = %128
   %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
@@ -2346,8 +2428,8 @@ entry:
   %133 = load i16, i16 addrspace(1)* %132, align 8
   %134 = zext i16 %133 to i32
   %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
-  br i1 %NullCheck6, label %136, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %135, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %136
 
 ; <label>:136                                     ; preds = %130
   %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
@@ -2360,8 +2442,8 @@ entry:
 
 ; <label>:143                                     ; preds = %136
   %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
-  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %144, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %145
 
 ; <label>:145                                     ; preds = %143
   %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
@@ -2369,8 +2451,8 @@ entry:
   %148 = load i16, i16 addrspace(1)* %147, align 8
   %149 = zext i16 %148 to i32
   %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %150, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %151
 
 ; <label>:151                                     ; preds = %145
   %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
@@ -2388,8 +2470,8 @@ entry:
 
 ; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
-  br i1 %NullCheck, label %163, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %ThrowNullRef, label %163
 
 ; <label>:163                                     ; preds = %161
   %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
@@ -2399,8 +2481,8 @@ entry:
 
 ; <label>:167                                     ; preds = %163
   %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
-  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %168, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %169
 
 ; <label>:169                                     ; preds = %167
   %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
@@ -2432,55 +2514,55 @@ ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %167
+ThrowNullRef2:                                    ; preds = %167
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %128
+ThrowNullRef4:                                    ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %130
+ThrowNullRef6:                                    ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %143
+ThrowNullRef8:                                    ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %145
+ThrowNullRef10:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %102
+ThrowNullRef12:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %105
+ThrowNullRef14:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %76
+ThrowNullRef16:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %79
+ThrowNullRef18:                                   ; preds = %79
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %50
+ThrowNullRef20:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %53
+ThrowNullRef22:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %24
+ThrowNullRef24:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %27
+ThrowNullRef26:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2503,15 +2585,15 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2519,16 +2601,16 @@ entry:
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
   store i32 %8, i32* %loc0
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
   %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
   store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
@@ -2546,16 +2628,16 @@ entry:
 
 ; <label>:23                                      ; preds = %64
   %24 = load i16*, i16** %loc3
-  %NullCheck12 = icmp ne i16* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i16* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
   store i32 %27, i32* %loc5
   %28 = load i16*, i16** %loc4
-  %NullCheck14 = icmp ne i16* %28, null
-  br i1 %NullCheck14, label %29, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %28, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = load i16, i16* %28, align 8
@@ -2620,15 +2702,15 @@ entry:
 
 ; <label>:67                                      ; preds = %64
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
-  br i1 %NullCheck8, label %69, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %68, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %69
 
 ; <label>:69                                      ; preds = %67
   %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
   %71 = load i32, i32 addrspace(1)* %70
   %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
-  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %73
 
 ; <label>:73                                      ; preds = %69
   %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
@@ -2645,31 +2727,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %67
+ThrowNullRef8:                                    ; preds = %67
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %69
+ThrowNullRef10:                                   ; preds = %69
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2710,14 +2792,14 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
   %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
@@ -2730,14 +2812,14 @@ entry:
 
 ; <label>:11                                      ; preds = %4
   %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
   %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
@@ -2749,14 +2831,14 @@ entry:
 
 ; <label>:22                                      ; preds = %16
   %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
   %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
-  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
-  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
@@ -2804,23 +2886,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2836,7 +2918,280 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[loadElem]
+Successfully read RuntimeType.IsAssignableFrom
+
+define i8 @RuntimeType.IsAssignableFrom(%System.RuntimeType addrspace(1)* %param0, %System.Type addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.RuntimeType addrspace(1)*
+  %arg1 = alloca %System.Type addrspace(1)*
+  %loc0 = alloca %System.RuntimeType addrspace(1)*
+  %loc1 = alloca %"System.Type[]" addrspace(1)*
+  %loc2 = alloca i32
+  store %System.RuntimeType addrspace(1)* %param0, %System.RuntimeType addrspace(1)** %this
+  store %System.Type addrspace(1)* %param1, %System.Type addrspace(1)** %arg1
+  %0 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %1 = icmp ne %System.Type addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i8 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %5 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %6 = bitcast %System.Type addrspace(1)* %4 to %System.Object addrspace(1)*
+  %7 = bitcast %System.RuntimeType addrspace(1)* %5 to %System.Object addrspace(1)*
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %6, %System.Object addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %3
+  ret i8 1
+
+; <label>:12                                      ; preds = %3
+  %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 152
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 32
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
+  %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
+  %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
+  store %System.RuntimeType addrspace(1)* %25, %System.RuntimeType addrspace(1)** %loc0
+  %26 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %27 = icmp eq %System.RuntimeType addrspace(1)* %26, null
+  br i1 %27, label %34, label %28
+
+; <label>:28                                      ; preds = %15
+  %29 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %30 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)*)*)(%System.RuntimeType addrspace(1)* %29, %System.RuntimeType addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+; <label>:34                                      ; preds = %15
+  %35 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %36 = call %System.Reflection.Emit.TypeBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Reflection.Emit.TypeBuilder addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %35)
+  %37 = icmp eq %System.Reflection.Emit.TypeBuilder addrspace(1)* %36, null
+  br i1 %37, label %139, label %38
+
+; <label>:38                                      ; preds = %34
+  %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %42
+
+; <label>:42                                      ; preds = %38
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 152
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 40
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
+  %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
+  %53 = zext i8 %52 to i32
+  %54 = icmp eq i32 %53, 0
+  br i1 %54, label %56, label %55
+
+; <label>:55                                      ; preds = %42
+  ret i8 1
+
+; <label>:56                                      ; preds = %42
+  %57 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %58 = bitcast %System.RuntimeType addrspace(1)* %57 to %System.Type addrspace(1)*
+  %59 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %58)
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %64 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.Type addrspace(1)* %63, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = bitcast %System.RuntimeType addrspace(1)* %64 to %System.Type addrspace(1)*
+  %67 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %63, %System.Type addrspace(1)* %66)
+  %68 = zext i8 %67 to i32
+  %69 = trunc i32 %68 to i8
+  ret i8 %69
+
+; <label>:70                                      ; preds = %56
+  %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
+  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %73
+
+; <label>:73                                      ; preds = %70
+  %74 = load i64, i64 addrspace(1)* %72
+  %75 = add i64 %74, 128
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = add i64 %77, 0
+  %79 = inttoptr i64 %78 to i64*
+  %80 = load i64, i64* %79
+  %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
+  %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
+  %83 = call i8 %82(%System.Type addrspace(1)* %81)
+  %84 = zext i8 %83 to i32
+  %85 = icmp eq i32 %84, 0
+  br i1 %85, label %139, label %86
+
+; <label>:86                                      ; preds = %73
+  %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
+  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %89
+
+; <label>:89                                      ; preds = %86
+  %90 = load i64, i64 addrspace(1)* %88
+  %91 = add i64 %90, 128
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = add i64 %93, 24
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
+  %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
+  %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
+  store %"System.Type[]" addrspace(1)* %99, %"System.Type[]" addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %129
+
+; <label>:100                                     ; preds = %132
+  %101 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %102 = load i32, i32* %loc2
+  %NullCheck11 = icmp eq %"System.Type[]" addrspace(1)* %101, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %103
+
+; <label>:103                                     ; preds = %100
+  %104 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 1
+  %105 = load i32, i32 addrspace(1)* %104
+  %106 = zext i32 %105 to i64
+  %107 = zext i32 %102 to i64
+  %BoundsCheck = icmp uge i64 %107, %106
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %108
+
+; <label>:108                                     ; preds = %103
+  %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
+  %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
+  %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
+  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %113
+
+; <label>:113                                     ; preds = %108
+  %114 = load i64, i64 addrspace(1)* %112
+  %115 = add i64 %114, 152
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = add i64 %117, 56
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
+  %123 = zext i8 %122 to i32
+  %124 = icmp ne i32 %123, 0
+  br i1 %124, label %126, label %125
+
+; <label>:125                                     ; preds = %113
+  ret i8 0
+
+; <label>:126                                     ; preds = %113
+  %127 = load i32, i32* %loc2
+  %128 = add i32 %127, 1
+  store i32 %128, i32* %loc2
+  br label %129
+
+; <label>:129                                     ; preds = %89, %126
+  %130 = load i32, i32* %loc2
+  %131 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %NullCheck9 = icmp eq %"System.Type[]" addrspace(1)* %131, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %132
+
+; <label>:132                                     ; preds = %129
+  %133 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %131, i32 0, i32 1
+  %134 = load i32, i32 addrspace(1)* %133
+  %135 = zext i32 %134 to i64
+  %136 = trunc i64 %135 to i32
+  %137 = icmp slt i32 %130, %136
+  br i1 %137, label %100, label %138
+
+; <label>:138                                     ; preds = %132
+  ret i8 1
+
+; <label>:139                                     ; preds = %34, %73
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %129
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %103
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -2893,7 +3248,7 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElem]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -2904,8 +3259,8 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -2997,8 +3352,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
@@ -3059,8 +3414,8 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -3087,8 +3442,8 @@ entry:
 
 ; <label>:17                                      ; preds = %5, %11
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
@@ -3097,8 +3452,8 @@ entry:
 
 ; <label>:22                                      ; preds = %1, %11
   %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
@@ -3109,11 +3464,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %17
+ThrowNullRef2:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %22
+ThrowNullRef4:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3167,15 +3522,15 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
   %15 = load i32, i32 addrspace(1)* %14
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
@@ -3198,7 +3553,7 @@ ThrowNullRef:                                     ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef2:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3232,8 +3587,8 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
@@ -3312,8 +3667,8 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -3327,8 +3682,8 @@ entry:
 ; <label>:5                                       ; preds = %43
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %7 = load i32, i32* %loc1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck6, label %8, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
@@ -3366,8 +3721,8 @@ entry:
 ; <label>:32                                      ; preds = %21, %25
   %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
   %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
-  br i1 %NullCheck8, label %35, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = trunc i32 %34 to i16
@@ -3380,8 +3735,8 @@ entry:
 ; <label>:40                                      ; preds = %1, %35
   %41 = load i32, i32* %loc1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
-  br i1 %NullCheck2, label %43, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %42, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
@@ -3392,8 +3747,8 @@ entry:
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
   %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
-  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
   %51 = load i64, i64 addrspace(1)* %49
@@ -3412,19 +3767,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %40
+ThrowNullRef2:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %47
+ThrowNullRef4:                                    ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %5
+ThrowNullRef6:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %32
+ThrowNullRef8:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3467,8 +3822,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
@@ -3492,11 +3847,391 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(i16* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store i16* %param0, i16** %arg0
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load i32, i32* %arg3
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %42, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %37, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg2
+  %13 = load i32, i32* %arg3
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %37, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %24 = load i32, i32* %arg2
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load i16*, i16** %arg0
+  %35 = load i32, i32* %arg3
+  %36 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %36, i16* %34, i32 %35)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:37                                      ; preds = %5, %16
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %39)
+  %41 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41, %System.String addrspace(1)* %38, %System.String addrspace(1)* %40)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41) #0
+  unreachable
+
+; <label>:42                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
-Failed to read StringBuilder.ToString[loadElemA]
+Successfully read StringBuilder.ToString
+
+define %System.String addrspace(1)* @StringBuilder.ToString(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i16*
+  %loc3 = alloca %"System.Char[]" addrspace(1)*
+  %loc4 = alloca i32
+  %loc5 = alloca i32
+  %loc6 = alloca i16 addrspace(1)*
+  %loc7 = alloca %System.String addrspace(1)*
+  %loc8 = alloca %"System.Char[]" addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %0)
+  %2 = icmp ne i32 %1, 0
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %4
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %6)
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %7)
+  store %System.String addrspace(1)* %8, %System.String addrspace(1)** %loc0
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.Text.StringBuilder addrspace(1)* %9, %System.Text.StringBuilder addrspace(1)** %loc1
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  store %System.String addrspace(1)* %10, %System.String addrspace(1)** %loc7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc7
+  %12 = ptrtoint %System.String addrspace(1)* %11 to i64
+  %13 = icmp eq i64 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %5
+  %15 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %16 = sext i32 %15 to i64
+  %17 = add i64 %12, %16
+  br label %18
+
+; <label>:18                                      ; preds = %5, %14
+  %19 = phi i64 [ %12, %5 ], [ %17, %14 ]
+  %20 = inttoptr i64 %19 to i16*
+  store i16* %20, i16** %loc2
+  br label %21
+
+; <label>:21                                      ; preds = %98, %18
+  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %22, null
+  br i1 %NullCheck, label %ThrowNullRef, label %23
+
+; <label>:23                                      ; preds = %21
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 3
+  %25 = load i32, i32 addrspace(1)* %24, align 8
+  %26 = icmp sle i32 %25, 0
+  br i1 %26, label %96, label %27
+
+; <label>:27                                      ; preds = %23
+  %28 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %28, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %29
+
+; <label>:29                                      ; preds = %27
+  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %28, i32 0, i32 1
+  %31 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %30, align 8
+  store %"System.Char[]" addrspace(1)* %31, %"System.Char[]" addrspace(1)** %loc3
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %33
+
+; <label>:33                                      ; preds = %29
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  store i32 %35, i32* %loc4
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  %39 = load i32, i32 addrspace(1)* %38, align 8
+  store i32 %39, i32* %loc5
+  %40 = load i32, i32* %loc5
+  %41 = load i32, i32* %loc4
+  %42 = add i32 %40, %41
+  %43 = zext i32 %42 to i64
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %45
+
+; <label>:45                                      ; preds = %37
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = sext i32 %47 to i64
+  %49 = icmp sgt i64 %43, %48
+  br i1 %49, label %91, label %50
+
+; <label>:50                                      ; preds = %45
+  %51 = load i32, i32* %loc5
+  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %52, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %53
+
+; <label>:53                                      ; preds = %50
+  %54 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %52, i32 0, i32 1
+  %55 = load i32, i32 addrspace(1)* %54
+  %56 = zext i32 %55 to i64
+  %57 = trunc i64 %56 to i32
+  %58 = icmp ugt i32 %51, %57
+  br i1 %58, label %91, label %59
+
+; <label>:59                                      ; preds = %53
+  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  store %"System.Char[]" addrspace(1)* %60, %"System.Char[]" addrspace(1)** %loc8
+  %61 = icmp eq %"System.Char[]" addrspace(1)* %60, null
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %63, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %64
+
+; <label>:64                                      ; preds = %62
+  %65 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %63, i32 0, i32 1
+  %66 = load i32, i32 addrspace(1)* %65
+  %67 = zext i32 %66 to i64
+  %68 = trunc i64 %67 to i32
+  %69 = icmp ne i32 %68, 0
+  br i1 %69, label %71, label %70
+
+; <label>:70                                      ; preds = %59, %64
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:71                                      ; preds = %64
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %73
+
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %BoundsCheck = icmp uge i64 0, %76
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %77
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %78, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:79                                      ; preds = %70, %77
+  %80 = load i16*, i16** %loc2
+  %81 = load i32, i32* %loc4
+  %82 = sext i32 %81 to i64
+  %83 = mul i64 %82, 2
+  %84 = bitcast i16* %80 to i8*
+  %85 = getelementptr inbounds i8, i8* %84, i64 %83
+  %86 = load i16 addrspace(1)*, i16 addrspace(1)** %loc6
+  %87 = ptrtoint i16 addrspace(1)* %86 to i64
+  %88 = load i32, i32* %loc5
+  %89 = bitcast i8* %85 to i16*
+  %90 = inttoptr i64 %87 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %89, i16* %90, i32 %88)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %96
+
+; <label>:91                                      ; preds = %45, %53
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %94 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %93)
+  %95 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95, %System.String addrspace(1)* %92, %System.String addrspace(1)* %94)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95) #0
+  unreachable
+
+; <label>:96                                      ; preds = %23, %79
+  %97 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %97, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %98
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %97, i32 0, i32 2
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  store %System.Text.StringBuilder addrspace(1)* %100, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %102 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %102, label %21, label %103
+
+; <label>:103                                     ; preds = %98
+  store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc7
+  %104 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  ret %System.String addrspace(1)* %104
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method StringBuilder::get_Length using LLILCJit
+Successfully read StringBuilder.get_Length
+
+define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
+Successfully read RuntimeHelpers.get_OffsetToStringData
+
+define i32 @RuntimeHelpers.get_OffsetToStringData() {
+entry:
+  ret i32 12
+}
+
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
 Successfully read CultureData.CreateCultureData
 
@@ -3514,23 +4249,23 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
   store i8 %4, i8 addrspace(1)* %6
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
@@ -3549,11 +4284,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3566,50 +4301,50 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
   store i32 -1, i32 addrspace(1)* %2
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
   store i32 -1, i32 addrspace(1)* %8
   %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
   store i32 -1, i32 addrspace(1)* %14
   %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
   store i32 -1, i32 addrspace(1)* %17
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
@@ -3623,27 +4358,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3675,7 +4410,136 @@ Failed to read Dictionary`2.Insert[non-const derefAddress]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
 Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
-Failed to read HashHelpers.GetPrime[loadElem]
+Successfully read HashHelpers.GetPrime
+
+define i32 @HashHelpers.GetPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %6, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5, %System.String addrspace(1)* %4)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5) #0
+  unreachable
+
+; <label>:6                                       ; preds = %entry
+  store i32 0, i32* %loc0
+  br label %29
+
+; <label>:7                                       ; preds = %35
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 1296
+  %10 = addrspacecast i8 addrspace(1)* %9 to %"System.Int32[]" addrspace(1)**
+  %11 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %10
+  %12 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Int32[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = zext i32 %15 to i64
+  %17 = zext i32 %12 to i64
+  %BoundsCheck = icmp uge i64 %17, %16
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 3, i32 %12
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  store i32 %20, i32* %loc1
+  %21 = load i32, i32* %loc1
+  %22 = load i32, i32* %arg0
+  %23 = icmp slt i32 %21, %22
+  br i1 %23, label %26, label %24
+
+; <label>:24                                      ; preds = %18
+  %25 = load i32, i32* %loc1
+  ret i32 %25
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %loc0
+  %28 = add i32 %27, 1
+  store i32 %28, i32* %loc0
+  br label %29
+
+; <label>:29                                      ; preds = %6, %26
+  %30 = load i32, i32* %loc0
+  %31 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %32 = getelementptr inbounds i8, i8 addrspace(1)* %31, i64 1296
+  %33 = addrspacecast i8 addrspace(1)* %32 to %"System.Int32[]" addrspace(1)**
+  %34 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %33
+  %NullCheck = icmp eq %"System.Int32[]" addrspace(1)* %34, null
+  br i1 %NullCheck, label %ThrowNullRef, label %35
+
+; <label>:35                                      ; preds = %29
+  %36 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %34, i32 0, i32 1
+  %37 = load i32, i32 addrspace(1)* %36
+  %38 = zext i32 %37 to i64
+  %39 = trunc i64 %38 to i32
+  %40 = icmp slt i32 %30, %39
+  br i1 %40, label %7, label %41
+
+; <label>:41                                      ; preds = %35
+  %42 = load i32, i32* %arg0
+  %43 = or i32 %42, 1
+  store i32 %43, i32* %loc2
+  br label %59
+
+; <label>:44                                      ; preds = %59
+  %45 = load i32, i32* %loc2
+  %46 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %45)
+  %47 = zext i8 %46 to i32
+  %48 = icmp eq i32 %47, 0
+  br i1 %48, label %56, label %49
+
+; <label>:49                                      ; preds = %44
+  %50 = load i32, i32* %loc2
+  %51 = sub i32 %50, 1
+  %52 = srem i32 %51, 101
+  %53 = icmp eq i32 %52, 0
+  br i1 %53, label %56, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = load i32, i32* %loc2
+  ret i32 %55
+
+; <label>:56                                      ; preds = %44, %49
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %57, 2
+  store i32 %58, i32* %loc2
+  br label %59
+
+; <label>:59                                      ; preds = %41, %56
+  %60 = load i32, i32* %loc2
+  %61 = icmp slt i32 %60, 2147483647
+  br i1 %61, label %44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load i32, i32* %arg0
+  ret i32 %63
+
+ThrowNullRef:                                     ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
 Successfully read GenericEqualityComparer`1.GetHashCode
 
@@ -3694,14 +4558,14 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
   %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load i64, i64 addrspace(1)* %7
@@ -3720,7 +4584,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3750,8 +4614,8 @@ entry:
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
@@ -3796,8 +4660,8 @@ entry:
   %35 = bitcast i16* %34 to i8*
   %36 = getelementptr inbounds i8, i8* %35, i64 2
   %37 = bitcast i8* %36 to i16*
-  %NullCheck4 = icmp ne i16* %37, null
-  br i1 %NullCheck4, label %38, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %37, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %38
 
 ; <label>:38                                      ; preds = %27
   %39 = load i16, i16* %37, align 8
@@ -3824,8 +4688,8 @@ entry:
 
 ; <label>:54                                      ; preds = %22, %43
   %55 = load i16*, i16** %loc4
-  %NullCheck2 = icmp ne i16* %55, null
-  br i1 %NullCheck2, label %56, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i16* %55, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %56
 
 ; <label>:56                                      ; preds = %54
   %57 = load i16, i16* %55, align 8
@@ -3850,11 +4714,11 @@ ThrowNullRef:                                     ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %54
+ThrowNullRef2:                                    ; preds = %54
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %27
+ThrowNullRef4:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3871,8 +4735,8 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -3907,8 +4771,8 @@ entry:
 
 ; <label>:26                                      ; preds = %19
   %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
-  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %28
 
 ; <label>:28                                      ; preds = %26
   %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
@@ -3920,7 +4784,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3972,8 +4836,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
@@ -3984,26 +4848,26 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
-  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
@@ -4014,8 +4878,8 @@ entry:
 ; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
@@ -4024,8 +4888,8 @@ entry:
 
 ; <label>:25                                      ; preds = %1, %16, %23
   %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
-  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
@@ -4036,27 +4900,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %20
+ThrowNullRef10:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4069,8 +4933,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -4081,8 +4945,8 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
@@ -4091,8 +4955,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1, %8
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
@@ -4103,11 +4967,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4128,24 +4992,24 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   store i32 %3, i32* %loc0
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
   %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
   store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck4, label %9, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
@@ -4164,15 +5028,15 @@ entry:
 ; <label>:18                                      ; preds = %70
   %19 = load i16*, i16** %loc3
   %20 = bitcast i16* %19 to i64*
-  %NullCheck10 = icmp ne i64* %20, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %20, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = load i64, i64* %20, align 8
   %23 = load i16*, i16** %loc4
   %24 = bitcast i16* %23 to i64*
-  %NullCheck12 = icmp ne i64* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = load i64, i64* %24, align 8
@@ -4188,8 +5052,8 @@ entry:
   %31 = bitcast i16* %30 to i8*
   %32 = getelementptr inbounds i8, i8* %31, i64 8
   %33 = bitcast i8* %32 to i64*
-  %NullCheck14 = icmp ne i64* %33, null
-  br i1 %NullCheck14, label %34, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = load i64, i64* %33, align 8
@@ -4197,8 +5061,8 @@ entry:
   %37 = bitcast i16* %36 to i8*
   %38 = getelementptr inbounds i8, i8* %37, i64 8
   %39 = bitcast i8* %38 to i64*
-  %NullCheck16 = icmp ne i64* %39, null
-  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %40
 
 ; <label>:40                                      ; preds = %34
   %41 = load i64, i64* %39, align 8
@@ -4214,8 +5078,8 @@ entry:
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %NullCheck18 = icmp ne i64* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = load i64, i64* %48, align 8
@@ -4223,8 +5087,8 @@ entry:
   %52 = bitcast i16* %51 to i8*
   %53 = getelementptr inbounds i8, i8* %52, i64 16
   %54 = bitcast i8* %53 to i64*
-  %NullCheck20 = icmp ne i64* %54, null
-  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64* %54, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %55
 
 ; <label>:55                                      ; preds = %49
   %56 = load i64, i64* %54, align 8
@@ -4262,15 +5126,15 @@ entry:
 ; <label>:74                                      ; preds = %95
   %75 = load i16*, i16** %loc3
   %76 = bitcast i16* %75 to i32*
-  %NullCheck6 = icmp ne i32* %76, null
-  br i1 %NullCheck6, label %77, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32* %76, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %77
 
 ; <label>:77                                      ; preds = %74
   %78 = load i32, i32* %76, align 8
   %79 = load i16*, i16** %loc4
   %80 = bitcast i16* %79 to i32*
-  %NullCheck8 = icmp ne i32* %80, null
-  br i1 %NullCheck8, label %81, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i32* %80, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %81
 
 ; <label>:81                                      ; preds = %77
   %82 = load i32, i32* %80, align 8
@@ -4318,43 +5182,43 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %74
+ThrowNullRef6:                                    ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %77
+ThrowNullRef8:                                    ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %29
+ThrowNullRef14:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %34
+ThrowNullRef16:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4376,8 +5240,8 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load i64, i64 addrspace(1)* %4
@@ -4389,8 +5253,8 @@ entry:
   %12 = load i64, i64* %11
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %5
   %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
@@ -4399,8 +5263,8 @@ entry:
   %18 = load i8, i8* %arg2
   %19 = zext i8 %18 to i32
   %20 = trunc i32 %19 to i8
-  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %15
   %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
@@ -4411,11 +5275,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4442,8 +5306,8 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
@@ -4466,16 +5330,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
   %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = load i64, i64 addrspace(1)* %19
@@ -4500,8 +5364,8 @@ entry:
 ; <label>:35                                      ; preds = %30
   %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
@@ -4514,8 +5378,8 @@ entry:
 
 ; <label>:42                                      ; preds = %1, %38
   %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
-  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
@@ -4526,19 +5390,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %35
+ThrowNullRef2:                                    ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %42
+ThrowNullRef8:                                    ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4551,14 +5415,14 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
@@ -4570,7 +5434,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4583,8 +5447,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
@@ -4613,51 +5477,51 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
   %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
   %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
   %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
   %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
-  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
   store i64 %21, i64 addrspace(1)* %23
   %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %25 = load i64, i64* %loc0
-  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
@@ -4668,27 +5532,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %22
+ThrowNullRef12:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4701,8 +5565,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
@@ -4713,19 +5577,19 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
@@ -4734,8 +5598,8 @@ entry:
 
 ; <label>:15                                      ; preds = %1, %13
   %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
@@ -4746,19 +5610,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %15
+ThrowNullRef8:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4771,8 +5635,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -4831,8 +5695,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
@@ -4882,8 +5746,8 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
-  br i1 %NullCheck, label %17, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %ThrowNullRef, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
@@ -4894,15 +5758,15 @@ entry:
 
 ; <label>:22                                      ; preds = %17
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
-  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
   %26 = load i32, i32 addrspace(1)* %25
   %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
-  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %27, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
@@ -4925,8 +5789,8 @@ entry:
 ; <label>:40                                      ; preds = %17
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
-  br i1 %NullCheck6, label %43, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %41, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
@@ -4938,34 +5802,17 @@ ThrowNullRef:                                     ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %24
+ThrowNullRef4:                                    ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %40
+ThrowNullRef6:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
-}
-
-INFO:  jitting method Object::ReferenceEquals using LLILCJit
-Successfully read Object.ReferenceEquals
-
-define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
-entry:
-  %arg0 = alloca %System.Object addrspace(1)*
-  %arg1 = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
-  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
-  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = icmp eq %System.Object addrspace(1)* %0, %1
-  %3 = sext i1 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
 }
 
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
@@ -4978,21 +5825,21 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
   %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
-  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
@@ -5007,28 +5854,28 @@ entry:
 ; <label>:13                                      ; preds = %8, %12
   %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
   %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
   %21 = load i32, i32 addrspace(1)* %20, align 8
   %22 = add i32 %21, 1
-  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
   store i32 %22, i32 addrspace(1)* %24
   %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
@@ -5039,27 +5886,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5077,7 +5924,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::Setup using LLILCJit
-Failed to read AppDomain.Setup[loadElem]
+Failed to read AppDomain.Setup[unbox]
 INFO:  jitting method Thread::GetDomain using LLILCJit
 Successfully read Thread.GetDomain
 
@@ -5108,8 +5955,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
@@ -5122,14 +5969,14 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
   %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
@@ -5141,11 +5988,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5173,8 +6020,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -5189,7 +6036,328 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
 Failed to read KeyCollection.System.Collections.Generic.IEnumerable<TKey>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Successfully read Enumerator.MoveNext
+
+define i8 @Enumerator.MoveNext(%"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.RuntimeTypeHandle* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*
+  %"$TypeArg" = alloca %System.RuntimeTypeHandle*
+  store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
+  %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 8
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %76, label %12
+
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
+  br label %76
+
+; <label>:13                                      ; preds = %85
+  %14 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck19 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %15
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, i32 0, i32 0
+  %17 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %16, align 8
+  %NullCheck21 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, i32 0, i32 2
+  %20 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %19, align 8
+  %21 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck23 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %22
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, i32 0, i32 2
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %NullCheck25 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 3, i32 %24
+  %NullCheck27 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %32
+
+; <label>:32                                      ; preds = %30
+  %33 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, i32 0, i32 2
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = icmp slt i32 %34, 0
+  br i1 %35, label %68, label %36
+
+; <label>:36                                      ; preds = %32
+  %37 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %38 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck29 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %39
+
+; <label>:39                                      ; preds = %36
+  %40 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, i32 0, i32 0
+  %41 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %40, align 8
+  %NullCheck31 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, i32 0, i32 2
+  %44 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %43, align 8
+  %45 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck33 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, i32 0, i32 2
+  %48 = load i32, i32 addrspace(1)* %47, align 8
+  %NullCheck35 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %49
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = zext i32 %51 to i64
+  %53 = zext i32 %48 to i64
+  %BoundsCheck37 = icmp uge i64 %53, %52
+  br i1 %BoundsCheck37, label %ThrowIndexOutOfRange38, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 3, i32 %48
+  %NullCheck39 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %56
+
+; <label>:56                                      ; preds = %54
+  %57 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, i32 0, i32 0
+  %58 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck41 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %59
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %60, %System.__Canon addrspace(1)* %58)
+  %61 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck43 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  %64 = load i32, i32 addrspace(1)* %63, align 8
+  %65 = add i32 %64, 1
+  %NullCheck45 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  store i32 %65, i32 addrspace(1)* %67
+  ret i8 1
+
+; <label>:68                                      ; preds = %32
+  %69 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck47 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %73 = add i32 %72, 1
+  %NullCheck49 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %74
+
+; <label>:74                                      ; preds = %70
+  %75 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  store i32 %73, i32 addrspace(1)* %75
+  br label %76
+
+; <label>:76                                      ; preds = %8, %12, %74
+  %77 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %78
+
+; <label>:78                                      ; preds = %76
+  %79 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, i32 0, i32 2
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck7 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %82
+
+; <label>:82                                      ; preds = %78
+  %83 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, i32 0, i32 0
+  %84 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %83, align 8
+  %NullCheck9 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %85
+
+; <label>:85                                      ; preds = %82
+  %86 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, i32 0, i32 7
+  %87 = load i32, i32 addrspace(1)* %86, align 8
+  %88 = icmp ult i32 %80, %87
+  br i1 %88, label %13, label %89
+
+; <label>:89                                      ; preds = %85
+  %90 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %91 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck11 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %92
+
+; <label>:92                                      ; preds = %89
+  %93 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, i32 0, i32 0
+  %94 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck13 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %95
+
+; <label>:95                                      ; preds = %92
+  %96 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, i32 0, i32 7
+  %97 = load i32, i32 addrspace(1)* %96, align 8
+  %98 = add i32 %97, 1
+  %NullCheck15 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %99
+
+; <label>:99                                      ; preds = %95
+  %100 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, i32 0, i32 2
+  store i32 %98, i32 addrspace(1)* %100
+  %101 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck17 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %102
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %103, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %92
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef22:                                   ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef24:                                   ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef26:                                   ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef28:                                   ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef30:                                   ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef32:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef34:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef36:                                   ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange38:                           ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef40:                                   ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef42:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef44:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef46:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef48:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef50:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -5200,8 +6368,8 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -5232,9 +6400,9 @@ Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
 Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
-Failed to read String.MakeSeparatorList[loadElemA]
+Failed to read String.MakeSeparatorList[storeElem]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
-Failed to read String.InternalSplitKeepEmptyEntries[loadElem]
+Failed to read String.InternalSplitKeepEmptyEntries[storeElem]
 INFO:  jitting method Path::IsRelative using LLILCJit
 Successfully read Path.IsRelative
 
@@ -5243,8 +6411,8 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -5254,8 +6422,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
@@ -5271,8 +6439,8 @@ entry:
 
 ; <label>:17                                      ; preds = %7
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
@@ -5288,8 +6456,8 @@ entry:
 
 ; <label>:29                                      ; preds = %19
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %31
 
 ; <label>:31                                      ; preds = %29
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
@@ -5300,8 +6468,8 @@ entry:
 
 ; <label>:36                                      ; preds = %31
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
-  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %37, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
@@ -5312,8 +6480,8 @@ entry:
 
 ; <label>:43                                      ; preds = %31, %38
   %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
-  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %45
 
 ; <label>:45                                      ; preds = %43
   %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
@@ -5324,8 +6492,8 @@ entry:
 
 ; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %50
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
@@ -5336,8 +6504,8 @@ entry:
 
 ; <label>:57                                      ; preds = %1, %7, %19, %45, %52
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
-  br i1 %NullCheck14, label %59, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %59
 
 ; <label>:59                                      ; preds = %57
   %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
@@ -5347,8 +6515,8 @@ entry:
 
 ; <label>:63                                      ; preds = %59
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
@@ -5359,8 +6527,8 @@ entry:
 
 ; <label>:70                                      ; preds = %65
   %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
-  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.String addrspace(1)* %71, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %72
 
 ; <label>:72                                      ; preds = %70
   %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
@@ -5379,39 +6547,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %17
+ThrowNullRef4:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %29
+ThrowNullRef6:                                    ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %36
+ThrowNullRef8:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %43
+ThrowNullRef10:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %50
+ThrowNullRef12:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %57
+ThrowNullRef14:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %63
+ThrowNullRef16:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %70
+ThrowNullRef18:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5419,7 +6587,293 @@ ThrowNullRef17:                                   ; preds = %70
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
-Failed to read String.TrimHelper[loadElem]
+Successfully read String.TrimHelper
+
+define %System.String addrspace(1)* @String.TrimHelper(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i16
+  %loc4 = alloca i32
+  %loc5 = alloca i16
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = sub i32 %3, 1
+  store i32 %4, i32* %loc0
+  store i32 0, i32* %loc1
+  %5 = load i32, i32* %arg2
+  %6 = icmp eq i32 %5, 1
+  br i1 %6, label %62, label %7
+
+; <label>:7                                       ; preds = %1
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:8                                       ; preds = %58
+  store i32 0, i32* %loc2
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load i32, i32* %loc1
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2, i32 %10
+  %13 = load i16, i16 addrspace(1)* %12
+  %14 = zext i16 %13 to i32
+  %15 = trunc i32 %14 to i16
+  store i16 %15, i16* %loc3
+  store i32 0, i32* %loc2
+  br label %34
+
+; <label>:16                                      ; preds = %37
+  %17 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %18 = load i32, i32* %loc2
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %17, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %19
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = zext i32 %18 to i64
+  %BoundsCheck = icmp uge i64 %23, %22
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %24
+
+; <label>:24                                      ; preds = %19
+  %25 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 3, i32 %18
+  %26 = load i16, i16 addrspace(1)* %25, align 8
+  %27 = zext i16 %26 to i32
+  %28 = load i16, i16* %loc3
+  %29 = zext i16 %28 to i32
+  %30 = icmp eq i32 %27, %29
+  br i1 %30, label %43, label %31
+
+; <label>:31                                      ; preds = %24
+  %32 = load i32, i32* %loc2
+  %33 = add i32 %32, 1
+  store i32 %33, i32* %loc2
+  br label %34
+
+; <label>:34                                      ; preds = %11, %31
+  %35 = load i32, i32* %loc2
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = icmp slt i32 %35, %41
+  br i1 %42, label %16, label %43
+
+; <label>:43                                      ; preds = %24, %37
+  %44 = load i32, i32* %loc2
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %45, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp eq i32 %44, %50
+  br i1 %51, label %62, label %52
+
+; <label>:52                                      ; preds = %46
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %7, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %57, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %58
+
+; <label>:58                                      ; preds = %55
+  %59 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %60 = load i32, i32 addrspace(1)* %59
+  %61 = icmp slt i32 %56, %60
+  br i1 %61, label %8, label %62
+
+; <label>:62                                      ; preds = %1, %46, %58
+  %63 = load i32, i32* %arg2
+  %64 = icmp eq i32 %63, 0
+  br i1 %64, label %122, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %66, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %67
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %66, i32 0, i32 1
+  %69 = load i32, i32 addrspace(1)* %68
+  %70 = sub i32 %69, 1
+  store i32 %70, i32* %loc0
+  br label %118
+
+; <label>:71                                      ; preds = %118
+  store i32 0, i32* %loc4
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %73 = load i32, i32* %loc0
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %74
+
+; <label>:74                                      ; preds = %71
+  %75 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 2, i32 %73
+  %76 = load i16, i16 addrspace(1)* %75
+  %77 = zext i16 %76 to i32
+  %78 = trunc i32 %77 to i16
+  store i16 %78, i16* %loc5
+  store i32 0, i32* %loc4
+  br label %97
+
+; <label>:79                                      ; preds = %100
+  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %81 = load i32, i32* %loc4
+  %NullCheck19 = icmp eq %"System.Char[]" addrspace(1)* %80, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
+
+; <label>:82                                      ; preds = %79
+  %83 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 1
+  %84 = load i32, i32 addrspace(1)* %83
+  %85 = zext i32 %84 to i64
+  %86 = zext i32 %81 to i64
+  %BoundsCheck21 = icmp uge i64 %86, %85
+  br i1 %BoundsCheck21, label %ThrowIndexOutOfRange22, label %87
+
+; <label>:87                                      ; preds = %82
+  %88 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 3, i32 %81
+  %89 = load i16, i16 addrspace(1)* %88, align 8
+  %90 = zext i16 %89 to i32
+  %91 = load i16, i16* %loc5
+  %92 = zext i16 %91 to i32
+  %93 = icmp eq i32 %90, %92
+  br i1 %93, label %106, label %94
+
+; <label>:94                                      ; preds = %87
+  %95 = load i32, i32* %loc4
+  %96 = add i32 %95, 1
+  store i32 %96, i32* %loc4
+  br label %97
+
+; <label>:97                                      ; preds = %74, %94
+  %98 = load i32, i32* %loc4
+  %99 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck15 = icmp eq %"System.Char[]" addrspace(1)* %99, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %100
+
+; <label>:100                                     ; preds = %97
+  %101 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %99, i32 0, i32 1
+  %102 = load i32, i32 addrspace(1)* %101
+  %103 = zext i32 %102 to i64
+  %104 = trunc i64 %103 to i32
+  %105 = icmp slt i32 %98, %104
+  br i1 %105, label %79, label %106
+
+; <label>:106                                     ; preds = %87, %100
+  %107 = load i32, i32* %loc4
+  %108 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck17 = icmp eq %"System.Char[]" addrspace(1)* %108, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %109
+
+; <label>:109                                     ; preds = %106
+  %110 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %108, i32 0, i32 1
+  %111 = load i32, i32 addrspace(1)* %110
+  %112 = zext i32 %111 to i64
+  %113 = trunc i64 %112 to i32
+  %114 = icmp eq i32 %107, %113
+  br i1 %114, label %122, label %115
+
+; <label>:115                                     ; preds = %109
+  %116 = load i32, i32* %loc0
+  %117 = sub i32 %116, 1
+  store i32 %117, i32* %loc0
+  br label %118
+
+; <label>:118                                     ; preds = %67, %115
+  %119 = load i32, i32* %loc0
+  %120 = load i32, i32* %loc1
+  %121 = icmp sge i32 %119, %120
+  br i1 %121, label %71, label %122
+
+; <label>:122                                     ; preds = %62, %109, %118
+  %123 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %124 = load i32, i32* %loc1
+  %125 = load i32, i32* %loc0
+  %126 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %123, i32 %124, i32 %125)
+  ret %System.String addrspace(1)* %126
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %97
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange22:                           ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
 Successfully read String.CreateTrimmedString
 
@@ -5439,8 +6893,8 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
@@ -5535,8 +6989,8 @@ entry:
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i64 2872
   %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
   %8 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %7
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %3
   %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
@@ -5553,8 +7007,8 @@ entry:
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 2864
   %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
   %21 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %20
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
-  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %22
 
 ; <label>:22                                      ; preds = %16
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
@@ -5569,7 +7023,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %16
+ThrowNullRef2:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5586,8 +7040,8 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5613,8 +7067,8 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
@@ -5632,8 +7086,8 @@ entry:
 
 ; <label>:12                                      ; preds = %4
   %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
@@ -5644,8 +7098,8 @@ entry:
 
 ; <label>:19                                      ; preds = %14
   %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %19
   %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
@@ -5660,21 +7114,21 @@ entry:
   %31 = zext i16 %30 to i32
   %32 = bitcast i8* %29 to i16*
   %33 = trunc i32 %31 to i16
-  %NullCheck6 = icmp ne i16* %32, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i16* %32, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %21
   store i16 %33, i16* %32, align 8
   %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %36
 
 ; <label>:36                                      ; preds = %34
   %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
   %38 = load i32, i32 addrspace(1)* %37, align 8
   %39 = add i32 %38, 1
-  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %40
 
 ; <label>:40                                      ; preds = %36
   %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
@@ -5683,16 +7137,16 @@ entry:
 
 ; <label>:42                                      ; preds = %14
   %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
-  br i1 %NullCheck12, label %44, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
   %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
   %47 = load i16, i16* %arg1
   %48 = zext i16 %47 to i32
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = trunc i32 %48 to i16
@@ -5703,31 +7157,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %19
+ThrowNullRef4:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %21
+ThrowNullRef6:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %36
+ThrowNullRef10:                                   ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %42
+ThrowNullRef12:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %44
+ThrowNullRef14:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5740,8 +7194,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -5752,8 +7206,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
@@ -5762,14 +7216,14 @@ entry:
 
 ; <label>:11                                      ; preds = %1
   %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
@@ -5779,15 +7233,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5808,8 +7262,8 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5822,8 +7276,8 @@ entry:
 
 ; <label>:8                                       ; preds = %3
   %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
@@ -5842,15 +7296,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
-  br i1 %NullCheck4, label %22, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
   %24 = load i16*, i16* addrspace(1)* %23, align 8
   %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %25, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
@@ -5859,8 +7313,8 @@ entry:
   store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
@@ -5874,8 +7328,8 @@ entry:
 
 ; <label>:37                                      ; preds = %65
   %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %37
   %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
@@ -5886,16 +7340,16 @@ entry:
   %45 = bitcast i16* %41 to i8*
   %46 = getelementptr inbounds i8, i8* %45, i64 %44
   %47 = bitcast i8* %46 to i16*
-  %NullCheck14 = icmp ne i16* %47, null
-  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %47, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %48
 
 ; <label>:48                                      ; preds = %39
   %49 = load i16, i16* %47, align 8
   %50 = zext i16 %49 to i32
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %52 = load i32, i32* %loc1
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %53
 
 ; <label>:53                                      ; preds = %48
   %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
@@ -5916,8 +7370,8 @@ entry:
 ; <label>:62                                      ; preds = %36, %59
   %63 = load i32, i32* %loc1
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck10, label %65, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %65
 
 ; <label>:65                                      ; preds = %62
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
@@ -5936,15 +7390,15 @@ entry:
 
 ; <label>:74                                      ; preds = %70
   %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
-  br i1 %NullCheck18, label %76, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %76
 
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
   %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
-  br i1 %NullCheck20, label %80, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
   %81 = load i64, i64 addrspace(1)* %79
@@ -5958,8 +7412,8 @@ entry:
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
   %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
-  br i1 %NullCheck22, label %92, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.String addrspace(1)* %90, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %92
 
 ; <label>:92                                      ; preds = %80
   %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
@@ -5969,15 +7423,15 @@ entry:
 
 ; <label>:96                                      ; preds = %70
   %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
-  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %98
 
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
   %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
-  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
   %103 = load i64, i64 addrspace(1)* %101
@@ -5991,8 +7445,8 @@ entry:
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
   %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
-  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.String addrspace(1)* %112, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %114
 
 ; <label>:114                                     ; preds = %102
   %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
@@ -6004,59 +7458,59 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %20
+ThrowNullRef4:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %22
+ThrowNullRef6:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %26
+ThrowNullRef8:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %62
+ThrowNullRef10:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %48
+ThrowNullRef16:                                   ; preds = %48
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %74
+ThrowNullRef18:                                   ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %76
+ThrowNullRef20:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %80
+ThrowNullRef22:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %96
+ThrowNullRef24:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %98
+ThrowNullRef26:                                   ; preds = %98
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %102
+ThrowNullRef28:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6069,15 +7523,15 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
   %3 = load i16*, i16* addrspace(1)* %2, align 8
   %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
@@ -6087,8 +7541,8 @@ entry:
   %10 = bitcast i16* %3 to i8*
   %11 = getelementptr inbounds i8, i8* %10, i64 %9
   %12 = bitcast i8* %11 to i16*
-  %NullCheck4 = icmp ne i16* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %5
   store i16 0, i16* %12, align 8
@@ -6098,11 +7552,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6119,8 +7573,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -6131,8 +7585,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
@@ -6144,15 +7598,15 @@ entry:
 
 ; <label>:14                                      ; preds = %1
   %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
   %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
   %21 = load i64, i64 addrspace(1)* %19
@@ -6171,15 +7625,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %14
+ThrowNullRef4:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %16
+ThrowNullRef6:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6302,14 +7756,6 @@ entry:
   ret %System.String addrspace(1)* %57
 }
 
-INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
-Successfully read RuntimeHelpers.get_OffsetToStringData
-
-define i32 @RuntimeHelpers.get_OffsetToStringData() {
-entry:
-  ret i32 12
-}
-
 INFO:  jitting method String::Equals using LLILCJit
 Successfully read String.Equals
 
@@ -6381,8 +7827,8 @@ entry:
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
-  br i1 %NullCheck24, label %29, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
   %30 = load i64, i64 addrspace(1)* %28
@@ -6397,8 +7843,8 @@ entry:
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
-  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
   %43 = load i64, i64 addrspace(1)* %41
@@ -6418,8 +7864,8 @@ entry:
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
   %59 = load i64, i64 addrspace(1)* %57
@@ -6434,8 +7880,8 @@ entry:
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck22, label %71, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
   %72 = load i64, i64 addrspace(1)* %70
@@ -6455,8 +7901,8 @@ entry:
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
-  br i1 %NullCheck16, label %87, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = load i64, i64 addrspace(1)* %86
@@ -6471,8 +7917,8 @@ entry:
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck18, label %100, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
   %101 = load i64, i64 addrspace(1)* %99
@@ -6492,8 +7938,8 @@ entry:
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
-  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
   %117 = load i64, i64 addrspace(1)* %115
@@ -6508,8 +7954,8 @@ entry:
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
-  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
   %130 = load i64, i64 addrspace(1)* %128
@@ -6528,15 +7974,15 @@ entry:
 
 ; <label>:142                                     ; preds = %22
   %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
-  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %143, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %144
 
 ; <label>:144                                     ; preds = %142
   %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
   %146 = load i32, i32 addrspace(1)* %145
   %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
-  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %147, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %148
 
 ; <label>:148                                     ; preds = %144
   %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
@@ -6557,15 +8003,15 @@ entry:
 
 ; <label>:159                                     ; preds = %22
   %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
-  br i1 %NullCheck, label %161, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %ThrowNullRef, label %161
 
 ; <label>:161                                     ; preds = %159
   %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
   %163 = load i32, i32 addrspace(1)* %162
   %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
-  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %164, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %165
 
 ; <label>:165                                     ; preds = %161
   %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
@@ -6578,8 +8024,8 @@ entry:
 
 ; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
-  br i1 %NullCheck4, label %172, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %171, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %172
 
 ; <label>:172                                     ; preds = %170
   %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
@@ -6589,8 +8035,8 @@ entry:
 
 ; <label>:176                                     ; preds = %172
   %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
-  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %177, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %178
 
 ; <label>:178                                     ; preds = %176
   %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
@@ -6629,55 +8075,55 @@ ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %161
+ThrowNullRef2:                                    ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %170
+ThrowNullRef4:                                    ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %176
+ThrowNullRef6:                                    ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %142
+ThrowNullRef8:                                    ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %144
+ThrowNullRef10:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %113
+ThrowNullRef12:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %116
+ThrowNullRef14:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %84
+ThrowNullRef16:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %87
+ThrowNullRef18:                                   ; preds = %87
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %55
+ThrowNullRef20:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %58
+ThrowNullRef22:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %26
+ThrowNullRef24:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %29
+ThrowNullRef26:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,8 +8161,8 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck, label %14, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %ThrowNullRef, label %14
 
 ; <label>:14                                      ; preds = %8
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
@@ -6760,8 +8206,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
@@ -6770,14 +8216,14 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32, i32* %loc0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %10
   %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
   %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
@@ -6790,15 +8236,15 @@ entry:
 ; <label>:25                                      ; preds = %19
   %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
-  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
   %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
@@ -6807,8 +8253,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %37 = load i32, i32* %loc0
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %38, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %38
 
 ; <label>:38                                      ; preds = %32
   %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
@@ -6817,14 +8263,14 @@ entry:
 
 ; <label>:40                                      ; preds = %19
   %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %40
   %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
   %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
-  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
-  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
@@ -6832,8 +8278,8 @@ entry:
   %48 = zext i32 %47 to i64
   %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
-  br i1 %NullCheck16, label %51, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %51
 
 ; <label>:51                                      ; preds = %45
   %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
@@ -6847,15 +8293,15 @@ entry:
 ; <label>:57                                      ; preds = %51
   %58 = load i16*, i16** %arg1
   %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
-  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %60
 
 ; <label>:60                                      ; preds = %57
   %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
   %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
-  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %64
 
 ; <label>:64                                      ; preds = %60
   %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
@@ -6864,22 +8310,22 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
   %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
-  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %70
 
 ; <label>:70                                      ; preds = %64
   %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
   %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
-  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
-  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
   %75 = load i32, i32 addrspace(1)* %74
   %76 = zext i32 %75 to i64
   %77 = trunc i64 %76 to i32
-  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
-  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %78
 
 ; <label>:78                                      ; preds = %73
   %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
@@ -6901,8 +8347,8 @@ entry:
   %90 = bitcast i16* %86 to i8*
   %91 = getelementptr inbounds i8, i8* %90, i64 %89
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %93
 
 ; <label>:93                                      ; preds = %80
   %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
@@ -6912,8 +8358,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %99 = load i32, i32* %loc2
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %100
 
 ; <label>:100                                     ; preds = %93
   %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
@@ -6928,63 +8374,63 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %25
+ThrowNullRef6:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %32
+ThrowNullRef10:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %40
+ThrowNullRef12:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %45
+ThrowNullRef16:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %57
+ThrowNullRef18:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %60
+ThrowNullRef20:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %64
+ThrowNullRef22:                                   ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %70
+ThrowNullRef24:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %73
+ThrowNullRef26:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %80
+ThrowNullRef28:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %93
+ThrowNullRef30:                                   ; preds = %93
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7004,8 +8450,8 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
@@ -7033,43 +8479,43 @@ entry:
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %14
   %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
   %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   %28 = load i32, i32 addrspace(1)* %27, align 8
   %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
-  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %30
 
 ; <label>:30                                      ; preds = %26
   %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
   %32 = load i32, i32 addrspace(1)* %31, align 8
   %33 = add i32 %28, %32
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %34
 
 ; <label>:34                                      ; preds = %30
   %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   store i32 %33, i32 addrspace(1)* %35
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
   store i32 0, i32 addrspace(1)* %38
   %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %40
 
 ; <label>:40                                      ; preds = %37
   %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
@@ -7082,8 +8528,8 @@ entry:
 
 ; <label>:47                                      ; preds = %40
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
@@ -7098,8 +8544,8 @@ entry:
   %54 = load i32, i32* %loc0
   %55 = sext i32 %54 to i64
   %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
-  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %57
 
 ; <label>:57                                      ; preds = %52
   %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
@@ -7110,68 +8556,35 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %14
+ThrowNullRef2:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %23
+ThrowNullRef4:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %26
+ThrowNullRef6:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %30
+ThrowNullRef8:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %34
+ThrowNullRef10:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %47
+ThrowNullRef14:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %52
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-}
-
-INFO:  jitting method StringBuilder::get_Length using LLILCJit
-Successfully read StringBuilder.get_Length
-
-define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.StringBuilder addrspace(1)*
-  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
-  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
-
-; <label>:1                                       ; preds = %entry
-  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %3 = load i32, i32 addrspace(1)* %2, align 8
-  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
-
-; <label>:5                                       ; preds = %1
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = add i32 %3, %7
-  ret i32 %8
-
-ThrowNullRef:                                     ; preds = %entry
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef16:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7213,70 +8626,70 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
   %6 = load i32, i32 addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
   store i32 %6, i32 addrspace(1)* %8
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
   %13 = load i32, i32 addrspace(1)* %12, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
   store i32 %13, i32 addrspace(1)* %15
   %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
-  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %18
 
 ; <label>:18                                      ; preds = %14
   %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
   %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
   %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
   %34 = load i32, i32 addrspace(1)* %33, align 8
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
-  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
@@ -7287,39 +8700,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %28
+ThrowNullRef16:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %32
+ThrowNullRef18:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7455,13 +8868,13 @@ entry:
 ; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
@@ -7477,16 +8890,16 @@ entry:
 
 ; <label>:18                                      ; preds = %15
   %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
   store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
   %22 = load i32, i32* %loc0
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %24
 
 ; <label>:24                                      ; preds = %20
   %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
@@ -7498,13 +8911,13 @@ entry:
 ; <label>:28                                      ; preds = %15, %24
   %29 = load i32, i32* %arg1
   %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %31
   %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
@@ -7517,20 +8930,20 @@ entry:
   %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
-  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
   %46 = load i32, i32 addrspace(1)* %45, align 8
   %47 = sub i32 %40, %46
-  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
-  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i32 addrspace(1)* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %48
 
 ; <label>:48                                      ; preds = %44
   store i32 %47, i32 addrspace(1)* %39, align 8
@@ -7538,21 +8951,21 @@ entry:
 
 ; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
-  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %51
 
 ; <label>:51                                      ; preds = %49
   %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %53
 
 ; <label>:53                                      ; preds = %51
   %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
   %55 = load i32, i32 addrspace(1)* %54, align 8
   %56 = load i32, i32* %arg2
   %57 = sub i32 %55, %56
-  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %58
 
 ; <label>:58                                      ; preds = %53
   %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
@@ -7562,13 +8975,13 @@ entry:
 ; <label>:60                                      ; preds = %33, %58
   %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
   %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
-  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %63
 
 ; <label>:63                                      ; preds = %60
   %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
-  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
-  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
@@ -7578,15 +8991,15 @@ entry:
 
 ; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
-  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i32 addrspace(1)* %69, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %70
 
 ; <label>:70                                      ; preds = %68
   %71 = load i32, i32 addrspace(1)* %69, align 8
   store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
-  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
@@ -7596,8 +9009,8 @@ entry:
   store i32 %77, i32* %loc4
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
-  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %80
 
 ; <label>:80                                      ; preds = %73
   %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
@@ -7607,71 +9020,71 @@ entry:
 ; <label>:83                                      ; preds = %80
   store i32 0, i32* %loc3
   %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
-  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
-  br i1 %NullCheck26, label %88, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i32 addrspace(1)* %87, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %88
 
 ; <label>:88                                      ; preds = %85
   %89 = load i32, i32 addrspace(1)* %87, align 8
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
-  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %90
 
 ; <label>:90                                      ; preds = %88
   %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
   store i32 %89, i32 addrspace(1)* %91
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
-  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
-  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %96
 
 ; <label>:96                                      ; preds = %94
   %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
-  br i1 %NullCheck34, label %100, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %100
 
 ; <label>:100                                     ; preds = %96
   %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
-  br i1 %NullCheck36, label %102, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %102
 
 ; <label>:102                                     ; preds = %100
   %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
   %104 = load i32, i32 addrspace(1)* %103, align 8
   %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
-  br i1 %NullCheck38, label %106, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %106
 
 ; <label>:106                                     ; preds = %102
   %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
-  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
-  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %108
 
 ; <label>:108                                     ; preds = %106
   %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
   %110 = load i32, i32 addrspace(1)* %109, align 8
   %111 = add i32 %104, %110
-  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %112
 
 ; <label>:112                                     ; preds = %108
   %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
   store i32 %111, i32 addrspace(1)* %113
   %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
-  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i32 addrspace(1)* %114, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %115
 
 ; <label>:115                                     ; preds = %112
   %116 = load i32, i32 addrspace(1)* %114, align 8
@@ -7681,19 +9094,19 @@ entry:
 ; <label>:118                                     ; preds = %115
   %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
-  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %121
 
 ; <label>:121                                     ; preds = %118
   %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
-  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
-  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %123
 
 ; <label>:123                                     ; preds = %121
   %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
   %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
-  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
-  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %126
 
 ; <label>:126                                     ; preds = %123
   %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
@@ -7705,8 +9118,8 @@ entry:
 
 ; <label>:130                                     ; preds = %80, %115, %126
   %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %132
 
 ; <label>:132                                     ; preds = %130
   %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7715,8 +9128,8 @@ entry:
   %136 = load i32, i32* %loc3
   %137 = sub i32 %135, %136
   %138 = sub i32 %134, %137
-  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %139
 
 ; <label>:139                                     ; preds = %132
   %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7728,16 +9141,16 @@ entry:
 
 ; <label>:144                                     ; preds = %139
   %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
-  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %146
 
 ; <label>:146                                     ; preds = %144
   %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
   %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
   %149 = load i32, i32* %loc2
   %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
-  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %151
 
 ; <label>:151                                     ; preds = %146
   %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
@@ -7754,145 +9167,249 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %18
+ThrowNullRef4:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %31
+ThrowNullRef10:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %44
+ThrowNullRef16:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %68
+ThrowNullRef18:                                   ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %70
+ThrowNullRef20:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %73
+ThrowNullRef22:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %83
+ThrowNullRef24:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %85
+ThrowNullRef26:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %88
+ThrowNullRef28:                                   ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %90
+ThrowNullRef30:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %94
+ThrowNullRef32:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %96
+ThrowNullRef34:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %100
+ThrowNullRef36:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %102
+ThrowNullRef38:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %106
+ThrowNullRef40:                                   ; preds = %106
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %108
+ThrowNullRef42:                                   ; preds = %108
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %112
+ThrowNullRef44:                                   ; preds = %112
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %118
+ThrowNullRef46:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %121
+ThrowNullRef48:                                   ; preds = %121
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %123
+ThrowNullRef50:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %130
+ThrowNullRef52:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %132
+ThrowNullRef54:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %144
+ThrowNullRef56:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %146
+ThrowNullRef58:                                   ; preds = %146
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %60
+ThrowNullRef60:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %63
+ThrowNullRef62:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %49
+ThrowNullRef64:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %51
+ThrowNullRef66:                                   ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %53
+ThrowNullRef68:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(%"System.Char[]" addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %arg0 = alloca %"System.Char[]" addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store %"System.Char[]" addrspace(1)* %param0, %"System.Char[]" addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load i32, i32* %arg4
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %43, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %38, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg1
+  %13 = load i32, i32* %arg4
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %38, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %24 = load i32, i32* %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %35 = load i32, i32* %arg3
+  %36 = load i32, i32* %arg4
+  %37 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %37, %"System.Char[]" addrspace(1)* %34, i32 %35, i32 %36)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:38                                      ; preds = %5, %16
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Successfully read Buffer._Memmove
 
@@ -7914,7 +9431,7 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[loadElem]
+Failed to read AppDomain.SetDataHelper[storeElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -7923,8 +9440,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
@@ -7934,8 +9451,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
@@ -7947,15 +9464,15 @@ entry:
   %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
   %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
@@ -7966,15 +9483,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7992,7 +9509,79 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
-Failed to read Dictionary`2.TryGetValue[loadElemA]
+Successfully read Dictionary`2.TryGetValue
+
+define i8 @"Dictionary`2.TryGetValue"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)* addrspace(1)* %param2) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  %arg2 = alloca %System.__Canon addrspace(1)* addrspace(1)*
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  store %System.__Canon addrspace(1)* addrspace(1)* %param2, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  store i32 %2, i32* %loc0
+  %3 = load i32, i32* %loc0
+  %4 = icmp slt i32 %3, 0
+  br i1 %4, label %22, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 2
+  %10 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %9, align 8
+  %11 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = zext i32 %11 to i64
+  %BoundsCheck = icmp uge i64 %16, %15
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 3, i32 %11
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %20, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %6, %System.__Canon addrspace(1)* %21)
+  ret i8 1
+
+; <label>:22                                      ; preds = %entry
+  %23 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %23, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -8058,8 +9647,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
@@ -8091,8 +9680,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
@@ -8171,15 +9760,15 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck, label %19, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %ThrowNullRef, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
   %21 = load i32, i32 addrspace(1)* %20
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
@@ -8202,7 +9791,7 @@ ThrowNullRef:                                     ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %19
+ThrowNullRef2:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8248,8 +9837,8 @@ entry:
   %0 = alloca %System.AppDomainHandle
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %1 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %1, i32 0, i32 15
@@ -8269,8 +9858,8 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
@@ -8286,7 +9875,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -8299,8 +9888,8 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -8327,8 +9916,8 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
@@ -8352,8 +9941,8 @@ entry:
   %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
   store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
@@ -8363,8 +9952,8 @@ entry:
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
@@ -8374,8 +9963,8 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %9
   %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
@@ -8384,8 +9973,8 @@ entry:
 
 ; <label>:18                                      ; preds = %3, %16
   %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
@@ -8397,15 +9986,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %18
+ThrowNullRef6:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8418,8 +10007,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
@@ -8453,15 +10042,15 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
@@ -8473,7 +10062,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8481,7 +10070,7 @@ ThrowNullRef1:                                    ; preds = %1
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
 Failed to read Dictionary`2.System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
@@ -8506,8 +10095,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
@@ -8524,8 +10113,8 @@ entry:
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -8544,7 +10133,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8577,8 +10166,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = load i64, i64* %arg2
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = trunc i32 %3 to i8
@@ -8634,46 +10223,46 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
   %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
-  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
-  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
-  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
@@ -8684,27 +10273,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %20
+ThrowNullRef12:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8717,8 +10306,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -8756,22 +10345,22 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
   %9 = load i64, i64 addrspace(1)* %8, align 8
   %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
   %13 = load i64, i64 addrspace(1)* %12, align 8
   %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %11
   %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
@@ -8788,11 +10377,11 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8882,8 +10471,8 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
@@ -8900,8 +10489,8 @@ entry:
 ; <label>:8                                       ; preds = %1
   %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
   %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
@@ -8911,15 +10500,15 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
   %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
   %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
-  br i1 %NullCheck6, label %21, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
@@ -8946,15 +10535,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8992,15 +10581,15 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
   store i8 %3, i8 addrspace(1)* %5
   %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
@@ -9011,7 +10600,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9027,8 +10616,8 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -9041,8 +10630,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
@@ -9058,7 +10647,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9080,8 +10669,8 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
@@ -9096,8 +10685,8 @@ entry:
 ; <label>:12                                      ; preds = %6
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
@@ -9112,8 +10701,8 @@ entry:
 ; <label>:21                                      ; preds = %15
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
@@ -9128,8 +10717,8 @@ entry:
 ; <label>:30                                      ; preds = %24
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %31, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
@@ -9144,8 +10733,8 @@ entry:
 ; <label>:39                                      ; preds = %33
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
-  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %40, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %42
 
 ; <label>:42                                      ; preds = %39
   %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
@@ -9164,19 +10753,19 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %21
+ThrowNullRef4:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %30
+ThrowNullRef6:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %39
+ThrowNullRef8:                                    ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9243,8 +10832,8 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
@@ -9264,57 +10853,57 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
   store i8 0, i8 addrspace(1)* %2
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
   store i8 0, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
   store i8 0, i8 addrspace(1)* %17
   %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
   store i8 0, i8 addrspace(1)* %20
   %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
-  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
@@ -9325,31 +10914,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %19
+ThrowNullRef14:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9367,8 +10956,8 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
@@ -9380,8 +10969,8 @@ entry:
 
 ; <label>:9                                       ; preds = %4
   %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %9
   %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
@@ -9395,7 +10984,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef2:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9420,8 +11009,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
@@ -9512,8 +11101,8 @@ entry:
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
@@ -9524,8 +11113,8 @@ entry:
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = load i64, i64 addrspace(1)* %12
@@ -9537,8 +11126,8 @@ entry:
   %20 = load i64, i64* %19
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
-  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %13
   %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
@@ -9555,8 +11144,8 @@ entry:
 ; <label>:30                                      ; preds = %25
   %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %32 = load i32, i32* %arg2
-  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
-  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
@@ -9570,15 +11159,15 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %30
+ThrowNullRef2:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9622,87 +11211,87 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
   %10 = load i8, i8 addrspace(1)* %9, align 8
   %11 = zext i8 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %8
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
   store i8 %12, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
   %19 = load i8, i8 addrspace(1)* %18, align 8
   %20 = zext i8 %19 to i32
   %21 = trunc i32 %20 to i8
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
   store i8 %21, i8 addrspace(1)* %23
   %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
   %28 = load i8, i8 addrspace(1)* %27, align 8
   %29 = zext i8 %28 to i32
   %30 = trunc i32 %29 to i8
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
-  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %31
 
 ; <label>:31                                      ; preds = %26
   %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
   store i8 %30, i8 addrspace(1)* %32
   %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
-  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
-  br i1 %NullCheck14, label %40, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %40
 
 ; <label>:40                                      ; preds = %35
   %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
   store i8 %39, i8 addrspace(1)* %41
   %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
-  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %44
 
 ; <label>:44                                      ; preds = %40
   %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
   %46 = load i8, i8 addrspace(1)* %45, align 8
   %47 = zext i8 %46 to i32
   %48 = trunc i32 %47 to i8
-  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
   store i8 %48, i8 addrspace(1)* %50
   %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
-  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
@@ -9713,29 +11302,29 @@ entry:
 ; <label>:56                                      ; preds = %52
   %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
-  br i1 %NullCheck22, label %59, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
   %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
   %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
-  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
-  br i1 %NullCheck24, label %63, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
   %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
-  br i1 %NullCheck26, label %66, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
   %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
-  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
-  br i1 %NullCheck28, label %69, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %69
 
 ; <label>:69                                      ; preds = %66
   %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
@@ -9744,15 +11333,15 @@ entry:
 
 ; <label>:71                                      ; preds = %105
   %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
-  br i1 %NullCheck34, label %73, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %73
 
 ; <label>:73                                      ; preds = %71
   %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
   %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
   %76 = load i32, i32* %loc0
-  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
-  br i1 %NullCheck36, label %77, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
@@ -9766,8 +11355,8 @@ entry:
 
 ; <label>:83                                      ; preds = %77
   %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
-  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
@@ -9775,14 +11364,14 @@ entry:
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
   %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
-  br i1 %NullCheck40, label %91, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
 ; <label>:91                                      ; preds = %85
   %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
   %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
-  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck42, label %94, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %94
 
 ; <label>:94                                      ; preds = %91
   %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
@@ -9798,14 +11387,14 @@ entry:
 ; <label>:99                                      ; preds = %69, %96
   %100 = load i32, i32* %loc0
   %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
-  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %102
 
 ; <label>:102                                     ; preds = %99
   %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
   %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
-  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
-  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
@@ -9819,87 +11408,87 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %26
+ThrowNullRef10:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %31
+ThrowNullRef12:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %35
+ThrowNullRef14:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %40
+ThrowNullRef16:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %56
+ThrowNullRef22:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %59
+ThrowNullRef24:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %63
+ThrowNullRef26:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %66
+ThrowNullRef28:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %102
+ThrowNullRef32:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %71
+ThrowNullRef34:                                   ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %73
+ThrowNullRef36:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %83
+ThrowNullRef38:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %85
+ThrowNullRef40:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %91
+ThrowNullRef42:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9943,15 +11532,15 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
   %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
@@ -9961,28 +11550,28 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
   %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %12
   %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
   %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
   %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
-  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
@@ -9993,23 +11582,23 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %12
+ThrowNullRef6:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10031,15 +11620,15 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
   %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = load i64, i64 addrspace(1)* %7
@@ -10077,13 +11666,13 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[loadElem]
+Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -10111,8 +11700,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -10154,7 +11743,78 @@ entry:
 INFO:  jitting method BringUpTest::Main using LLILCJit
 Failed to read BringUpTest.Main[convertHandle]
 INFO:  jitting method BringUpTest::DblArray using LLILCJit
-Failed to read BringUpTest.DblArray[loadElem]
+Successfully read BringUpTest.DblArray
+
+define double @BringUpTest.DblArray(%"System.Double[]" addrspace(1)* %param0, double %param1) {
+entry:
+  %arg0 = alloca %"System.Double[]" addrspace(1)*
+  %arg1 = alloca double
+  %loc0 = alloca double
+  %loc1 = alloca i32
+  store %"System.Double[]" addrspace(1)* %param0, %"System.Double[]" addrspace(1)** %arg0
+  store double %param1, double* %arg1
+  store double 0.000000e+00, double* %loc0
+  store i32 0, i32* %loc1
+  br label %15
+
+; <label>:0                                       ; preds = %18
+  %1 = load double, double* %loc0
+  %2 = load %"System.Double[]" addrspace(1)*, %"System.Double[]" addrspace(1)** %arg0
+  %3 = load i32, i32* %loc1
+  %NullCheck1 = icmp eq %"System.Double[]" addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
+
+; <label>:4                                       ; preds = %0
+  %5 = getelementptr inbounds %"System.Double[]", %"System.Double[]" addrspace(1)* %2, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = zext i32 %6 to i64
+  %8 = zext i32 %3 to i64
+  %BoundsCheck = icmp uge i64 %8, %7
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %9
+
+; <label>:9                                       ; preds = %4
+  %10 = getelementptr inbounds %"System.Double[]", %"System.Double[]" addrspace(1)* %2, i32 0, i32 3, i32 %3
+  %11 = load double, double addrspace(1)* %10, align 8
+  %12 = fadd double %1, %11
+  store double %12, double* %loc0
+  %13 = load i32, i32* %loc1
+  %14 = add i32 %13, 1
+  store i32 %14, i32* %loc1
+  br label %15
+
+; <label>:15                                      ; preds = %entry, %9
+  %16 = load i32, i32* %loc1
+  %17 = load %"System.Double[]" addrspace(1)*, %"System.Double[]" addrspace(1)** %arg0
+  %NullCheck = icmp eq %"System.Double[]" addrspace(1)* %17, null
+  br i1 %NullCheck, label %ThrowNullRef, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %"System.Double[]", %"System.Double[]" addrspace(1)* %17, i32 0, i32 1
+  %20 = load i32, i32 addrspace(1)* %19
+  %21 = zext i32 %20 to i64
+  %22 = trunc i64 %21 to i32
+  %23 = icmp slt i32 %16, %22
+  br i1 %23, label %0, label %24
+
+; <label>:24                                      ; preds = %18
+  %25 = load double, double* %loc0
+  %26 = load double, double* %arg1
+  %27 = fdiv double %25, %26
+  ret double %27
+
+ThrowNullRef:                                     ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Console::WriteLine using LLILCJit
 Successfully read Console.WriteLine
 
@@ -10165,8 +11825,8 @@ entry:
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load double, double* %arg0
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -10300,8 +11960,8 @@ entry:
   store i64 %param0, i64* %arg0
   store i64 %param1, i64* %arg1
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
@@ -10309,8 +11969,8 @@ entry:
   %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
   %5 = load i16*, i16* addrspace(1)* %4, align 8
   %6 = addrspacecast i64* %arg1 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = bitcast i64 addrspace(1)* %6 to i8 addrspace(1)*
@@ -10326,7 +11986,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10360,8 +12020,8 @@ entry:
   %1 = load i32, i32* %arg1
   %2 = sext i32 %1 to i64
   %3 = inttoptr i64 %2 to i16*
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -10414,8 +12074,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, i32)*)(%System.IO.ConsoleStream addrspace(1)* %2, i32 %1)
   %3 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %4 = load i64, i64* %arg1
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
@@ -10426,8 +12086,8 @@ entry:
   %10 = icmp eq i32 %9, 3
   %11 = sext i1 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %5
   %14 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, i32 0, i32 5
@@ -10438,7 +12098,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10461,8 +12121,8 @@ entry:
   %5 = icmp eq i32 %4, 1
   %6 = sext i1 %5 to i32
   %7 = trunc i32 %6 to i8
-  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %2, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.ConsoleStream addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
@@ -10473,8 +12133,8 @@ entry:
   %13 = icmp eq i32 %12, 2
   %14 = sext i1 %13 to i32
   %15 = trunc i32 %14 to i8
-  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %10, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.ConsoleStream addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %8
   %17 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %10, i32 0, i32 4
@@ -10485,7 +12145,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10524,8 +12184,8 @@ entry:
   %arg0 = alloca i64
   store i64 %param0, i64* %arg0
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
@@ -10560,8 +12220,8 @@ entry:
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
   %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = load i64, i64 addrspace(1)* %7
@@ -10665,7 +12325,127 @@ entry:
 INFO:  jitting method Encoding::GetEncoding using LLILCJit
 Failed to read Encoding.GetEncoding[convertToHelperArgumentType]
 INFO:  jitting method EncodingProvider::GetEncodingFromProvider using LLILCJit
-Failed to read EncodingProvider.GetEncodingFromProvider[loadElem]
+Successfully read EncodingProvider.GetEncodingFromProvider
+
+define %System.Text.Encoding addrspace(1)* @EncodingProvider.GetEncodingFromProvider(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca %"System.Text.EncodingProvider[]" addrspace(1)*
+  %loc1 = alloca %System.Text.EncodingProvider addrspace(1)*
+  %loc2 = alloca %System.Text.Encoding addrspace(1)*
+  %loc3 = alloca %System.Text.Encoding addrspace(1)*
+  %loc4 = alloca %"System.Text.EncodingProvider[]" addrspace(1)*
+  %loc5 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1059)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2392
+  %2 = addrspacecast i8 addrspace(1)* %1 to %"System.Text.EncodingProvider[]" addrspace(1)**
+  %3 = load volatile %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %2
+  %4 = icmp ne %"System.Text.EncodingProvider[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %entry
+  ret %System.Text.Encoding addrspace(1)* null
+
+; <label>:6                                       ; preds = %entry
+  %7 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1059)
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i64 2392
+  %9 = addrspacecast i8 addrspace(1)* %8 to %"System.Text.EncodingProvider[]" addrspace(1)**
+  %10 = load volatile %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %9
+  store %"System.Text.EncodingProvider[]" addrspace(1)* %10, %"System.Text.EncodingProvider[]" addrspace(1)** %loc0
+  %11 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc0
+  store %"System.Text.EncodingProvider[]" addrspace(1)* %11, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  store i32 0, i32* %loc5
+  br label %43
+
+; <label>:12                                      ; preds = %46
+  %13 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  %14 = load i32, i32* %loc5
+  %NullCheck1 = icmp eq %"System.Text.EncodingProvider[]" addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %13, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = zext i32 %17 to i64
+  %19 = zext i32 %14 to i64
+  %BoundsCheck = icmp uge i64 %19, %18
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %20
+
+; <label>:20                                      ; preds = %15
+  %21 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %13, i32 0, i32 3, i32 %14
+  %22 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)* addrspace(1)* %21, align 8
+  store %System.Text.EncodingProvider addrspace(1)* %22, %System.Text.EncodingProvider addrspace(1)** %loc1
+  %23 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)** %loc1
+  %24 = load i32, i32* %arg0
+  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i64 addrspace(1)*
+  %NullCheck3 = icmp eq i64 addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
+
+; <label>:26                                      ; preds = %20
+  %27 = load i64, i64 addrspace(1)* %25
+  %28 = add i64 %27, 64
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 40
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Text.Encoding addrspace(1)* (%System.Text.EncodingProvider addrspace(1)*, i32)*
+  %35 = call %System.Text.Encoding addrspace(1)* %34(%System.Text.EncodingProvider addrspace(1)* %23, i32 %24)
+  store %System.Text.Encoding addrspace(1)* %35, %System.Text.Encoding addrspace(1)** %loc2
+  %36 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc2
+  %37 = icmp eq %System.Text.Encoding addrspace(1)* %36, null
+  br i1 %37, label %40, label %38
+
+; <label>:38                                      ; preds = %26
+  %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc2
+  store %System.Text.Encoding addrspace(1)* %39, %System.Text.Encoding addrspace(1)** %loc3
+  br label %53
+
+; <label>:40                                      ; preds = %26
+  %41 = load i32, i32* %loc5
+  %42 = add i32 %41, 1
+  store i32 %42, i32* %loc5
+  br label %43
+
+; <label>:43                                      ; preds = %6, %40
+  %44 = load i32, i32* %loc5
+  %45 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  %NullCheck = icmp eq %"System.Text.EncodingProvider[]" addrspace(1)* %45, null
+  br i1 %NullCheck, label %ThrowNullRef, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp slt i32 %44, %50
+  br i1 %51, label %12, label %52
+
+; <label>:52                                      ; preds = %46
+  ret %System.Text.Encoding addrspace(1)* null
+
+; <label>:53                                      ; preds = %38
+  %54 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc3
+  ret %System.Text.Encoding addrspace(1)* %54
+
+ThrowNullRef:                                     ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method EncodingProvider::.cctor using LLILCJit
 Successfully read EncodingProvider..cctor
 
@@ -10684,7 +12464,7 @@ Failed to read Encoding.get_InternalSyncObject[Call HasTypeArg]
 INFO:  jitting method Hashtable::.ctor using LLILCJit
 Failed to read Hashtable..ctor[Volatile store]
 INFO:  jitting method Hashtable::get_Item using LLILCJit
-Failed to read Hashtable.get_Item[loadElemA]
+Failed to read Hashtable.get_Item[loadNonPrimitiveObj]
 INFO:  jitting method Hashtable::InitHash using LLILCJit
 Successfully read Hashtable.InitHash
 
@@ -10704,8 +12484,8 @@ entry:
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -10721,15 +12501,15 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
   %15 = load i32, i32* %loc0
-  %NullCheck2 = icmp ne i32 addrspace(1)* %14, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i32 addrspace(1)* %14, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %3
   store i32 %15, i32 addrspace(1)* %14, align 8
   %17 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %18 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %NullCheck4 = icmp ne i32 addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i32 addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = load i32, i32 addrspace(1)* %18, align 8
@@ -10738,8 +12518,8 @@ entry:
   %23 = sub i32 %22, 1
   %24 = urem i32 %21, %23
   %25 = add i32 1, %24
-  %NullCheck6 = icmp ne i32 addrspace(1)* %17, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32 addrspace(1)* %17, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %19
   store i32 %25, i32 addrspace(1)* %17, align 8
@@ -10750,15 +12530,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %19
+ThrowNullRef6:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10773,8 +12553,8 @@ entry:
   store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
   store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %NullCheck = icmp ne %System.Collections.Hashtable addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Collections.Hashtable addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
@@ -10784,16 +12564,16 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Collections.Hashtable addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Collections.Hashtable addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
   %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck4 = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %9, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
   %13 = inttoptr i64 %11 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
@@ -10803,8 +12583,8 @@ entry:
 ; <label>:15                                      ; preds = %1
   %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -10822,15 +12602,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10844,8 +12624,8 @@ entry:
   store %System.Int32 addrspace(1)* %param0, %System.Int32 addrspace(1)** %this
   %0 = load %System.Int32 addrspace(1)*, %System.Int32 addrspace(1)** %this
   %1 = bitcast %System.Int32 addrspace(1)* %0 to i32 addrspace(1)*
-  %NullCheck = icmp ne i32 addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq i32 addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load i32, i32 addrspace(1)* %1, align 8
@@ -10921,8 +12701,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.UTF8Encoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
@@ -10931,15 +12711,15 @@ entry:
   %9 = load i8, i8* %arg2
   %10 = zext i8 %9 to i32
   %11 = trunc i32 %10 to i8
-  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %8, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %6
   %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %8, i32 0, i32 8
   store i8 %11, i8 addrspace(1)* %13
   %14 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %14, i32 0, i32 8
@@ -10951,8 +12731,8 @@ entry:
 ; <label>:20                                      ; preds = %15
   %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %22, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %22, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = load i64, i64 addrspace(1)* %22
@@ -10974,15 +12754,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %12
+ThrowNullRef4:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10997,8 +12777,8 @@ entry:
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
@@ -11020,16 +12800,16 @@ entry:
 ; <label>:10                                      ; preds = %1
   %11 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
   %12 = load i32, i32* %arg1
-  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %11, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.Encoding addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
   store i32 %12, i32 addrspace(1)* %14
   %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
   %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = load i64, i64 addrspace(1)* %16
@@ -11047,11 +12827,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11064,8 +12844,8 @@ entry:
   %this = alloca %System.Text.UTF8Encoding addrspace(1)*
   store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
   %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.UTF8Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
@@ -11077,16 +12857,16 @@ entry:
 ; <label>:6                                       ; preds = %1
   %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %8 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %10, %System.Text.EncoderFallback addrspace(1)* %8)
   %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %12 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
-  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %11, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %11, i32 0, i32 3
@@ -11099,8 +12879,8 @@ entry:
   %18 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %18, %System.String addrspace(1)* %17)
   %19 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %18 to %System.Text.EncoderFallback addrspace(1)*
-  %NullCheck6 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %16, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %16, i32 0, i32 2
@@ -11110,8 +12890,8 @@ entry:
   %24 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %24, %System.String addrspace(1)* %23)
   %25 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %24 to %System.Text.DecoderFallback addrspace(1)*
-  %NullCheck8 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %22, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %22, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %20
   %27 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %22, i32 0, i32 3
@@ -11122,19 +12902,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %20
+ThrowNullRef8:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11164,8 +12944,8 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load i32, i32* %arg1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -11183,8 +12963,8 @@ entry:
 ; <label>:15                                      ; preds = %8
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %17 = load i32, i32* %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 %17
@@ -11200,7 +12980,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11252,7 +13032,7 @@ entry:
 }
 
 INFO:  jitting method Hashtable::Insert using LLILCJit
-Failed to read Hashtable.Insert[loadElemA]
+Failed to read Hashtable.Insert[storeElem]
 INFO:  jitting method ConsoleEncoding::.ctor using LLILCJit
 Successfully read ConsoleEncoding..ctor
 
@@ -11267,8 +13047,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %1)
   %2 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
@@ -11304,8 +13084,8 @@ entry:
   %2 = call %System.Text.InternalEncoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalEncoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %1)
   %3 = bitcast %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2 to %System.Text.EncoderFallback addrspace(1)*
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
@@ -11315,8 +13095,8 @@ entry:
   %8 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %7)
   %9 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %8 to %System.Text.DecoderFallback addrspace(1)*
-  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %6, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.Encoding addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %4
   %11 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %6, i32 0, i32 3
@@ -11327,7 +13107,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11346,15 +13126,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* %1)
   %2 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   %6 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, i32 0, i32 1
@@ -11365,7 +13145,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11393,8 +13173,8 @@ entry:
   store %System.Text.InternalDecoderBestFitFallback addrspace(1)* %param0, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
   %0 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
@@ -11404,15 +13184,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %4)
   %5 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %6)
   %9 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, i32 0, i32 1
@@ -11423,11 +13203,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11495,8 +13275,8 @@ entry:
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
   %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = load i64, i64 addrspace(1)* %19
@@ -11560,8 +13340,8 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.ConsoleStream addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
@@ -11592,31 +13372,31 @@ entry:
   store i8 %param4, i8* %arg4
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %3, %System.IO.Stream addrspace(1)* %1)
   %4 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %4, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
   %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %4, i32 0, i32 4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %5)
   %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %6
   %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
   %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
   %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = load i64, i64 addrspace(1)* %13
@@ -11628,8 +13408,8 @@ entry:
   %21 = load i64, i64* %20
   %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %8, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %8, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %14
   %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 5
@@ -11647,24 +13427,24 @@ entry:
   %31 = load i32, i32* %arg3
   %32 = sext i32 %31 to i64
   %33 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %32)
-  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %30, null
-  br i1 %NullCheck10, label %34, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.StreamWriter addrspace(1)* %30, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %35, %"System.Char[]" addrspace(1)* %33)
   %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %37, null
-  br i1 %NullCheck12, label %38, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.StreamWriter addrspace(1)* %37, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %38
 
 ; <label>:38                                      ; preds = %34
   %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
   %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
   %41 = load i32, i32* %arg3
   %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %42, null
-  br i1 %NullCheck14, label %43, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %42, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
   %44 = load i64, i64 addrspace(1)* %42
@@ -11678,30 +13458,30 @@ entry:
   %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
   %53 = sext i32 %52 to i64
   %54 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %53)
-  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
-  br i1 %NullCheck16, label %55, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %55
 
 ; <label>:55                                      ; preds = %43
   %56 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %56, %"System.Byte[]" addrspace(1)* %54)
   %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %58 = load i32, i32* %arg3
-  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %57, null
-  br i1 %NullCheck18, label %59, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.StreamWriter addrspace(1)* %57, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %59
 
 ; <label>:59                                      ; preds = %55
   %60 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 10
   store i32 %58, i32 addrspace(1)* %60
   %61 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %61, null
-  br i1 %NullCheck20, label %62, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.IO.StreamWriter addrspace(1)* %61, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %62
 
 ; <label>:62                                      ; preds = %59
   %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
   %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
   %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
   %67 = load i64, i64 addrspace(1)* %65
@@ -11719,15 +13499,15 @@ entry:
 
 ; <label>:78                                      ; preds = %66
   %79 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %79, null
-  br i1 %NullCheck24, label %80, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.StreamWriter addrspace(1)* %79, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %80
 
 ; <label>:80                                      ; preds = %78
   %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
   %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
   %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %83, null
-  br i1 %NullCheck26, label %84, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %83, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
   %85 = load i64, i64 addrspace(1)* %83
@@ -11744,8 +13524,8 @@ entry:
 
 ; <label>:95                                      ; preds = %84
   %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.IO.StreamWriter addrspace(1)* %96, null
-  br i1 %NullCheck28, label %97, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.IO.StreamWriter addrspace(1)* %96, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %97
 
 ; <label>:97                                      ; preds = %95
   %98 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 12
@@ -11759,8 +13539,8 @@ entry:
   %103 = icmp eq i32 %102, 0
   %104 = sext i1 %103 to i32
   %105 = trunc i32 %104 to i8
-  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %100, null
-  br i1 %NullCheck30, label %106, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.IO.StreamWriter addrspace(1)* %100, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %106
 
 ; <label>:106                                     ; preds = %99
   %107 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %100, i32 0, i32 13
@@ -11771,63 +13551,63 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %6
+ThrowNullRef4:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %29
+ThrowNullRef10:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %34
+ThrowNullRef12:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %38
+ThrowNullRef14:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %43
+ThrowNullRef16:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %55
+ThrowNullRef18:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %59
+ThrowNullRef20:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %62
+ThrowNullRef22:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %78
+ThrowNullRef24:                                   ; preds = %78
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %80
+ThrowNullRef26:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %95
+ThrowNullRef28:                                   ; preds = %95
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11840,15 +13620,15 @@ entry:
   %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = load i64, i64 addrspace(1)* %4
@@ -11866,7 +13646,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11916,35 +13696,35 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
   %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderNLS addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %7 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.EncoderNLS addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Text.Encoding addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.Encoding addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Text.EncoderNLS addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.EncoderNLS addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
   %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck8 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = load i64, i64 addrspace(1)* %16
@@ -11963,19 +13743,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12001,8 +13781,8 @@ entry:
   %this = alloca %System.Text.Encoding addrspace(1)*
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
@@ -12022,15 +13802,15 @@ entry:
   %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
   store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
   %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
   store i32 0, i32 addrspace(1)* %2
   %3 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, i32 0, i32 2
@@ -12040,15 +13820,15 @@ entry:
 
 ; <label>:8                                       ; preds = %4
   %9 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
   %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
   %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = load i64, i64 addrspace(1)* %13
@@ -12069,15 +13849,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12092,16 +13872,16 @@ entry:
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = load i32, i32* %arg1
   %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
   %7 = load i64, i64 addrspace(1)* %5
@@ -12119,7 +13899,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12156,8 +13936,8 @@ entry:
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
   %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
   %16 = load i64, i64 addrspace(1)* %14
@@ -12178,8 +13958,8 @@ entry:
   %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
   %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
   %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %31, null
-  br i1 %NullCheck2, label %32, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = load i64, i64 addrspace(1)* %31
@@ -12222,7 +14002,7 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12235,14 +14015,14 @@ entry:
   %this = alloca %System.Text.EncoderReplacementFallback addrspace(1)*
   store %System.Text.EncoderReplacementFallback addrspace(1)* %param0, %System.Text.EncoderReplacementFallback addrspace(1)** %this
   %0 = load %System.Text.EncoderReplacementFallback addrspace(1)*, %System.Text.EncoderReplacementFallback addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -12253,7 +14033,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12283,8 +14063,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
@@ -12316,8 +14096,8 @@ entry:
   %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
   store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
@@ -12329,8 +14109,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Threading.Tasks.Task addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %7)
@@ -12353,7 +14133,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12372,8 +14152,8 @@ entry:
   store i8 %param1, i8* %arg1
   store i8 %param2, i8* %arg2
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
@@ -12387,8 +14167,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1, %5
   %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 9
@@ -12419,8 +14199,8 @@ entry:
 
 ; <label>:25                                      ; preds = %8, %20
   %26 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %26, null
-  br i1 %NullCheck4, label %27, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %26, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %26, i32 0, i32 12
@@ -12431,22 +14211,22 @@ entry:
 
 ; <label>:32                                      ; preds = %27
   %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %33, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.IO.StreamWriter addrspace(1)* %33, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %32
   %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 12
   store i8 1, i8 addrspace(1)* %35
   %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
-  br i1 %NullCheck8, label %37, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
   %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
   %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck10 = icmp ne i64 addrspace(1)* %40, null
-  br i1 %NullCheck10, label %41, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64 addrspace(1)* %40, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i64, i64 addrspace(1)* %40
@@ -12460,8 +14240,8 @@ entry:
   %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
   store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
   %51 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %NullCheck12 = icmp ne %"System.Byte[]" addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Byte[]" addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %41
   %53 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %51, i32 0, i32 1
@@ -12473,16 +14253,16 @@ entry:
 
 ; <label>:58                                      ; preds = %52
   %59 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %59, null
-  br i1 %NullCheck14, label %60, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.IO.StreamWriter addrspace(1)* %59, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %60
 
 ; <label>:60                                      ; preds = %58
   %61 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %59, i32 0, i32 3
   %62 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
   %64 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %NullCheck16 = icmp ne %"System.Byte[]" addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %"System.Byte[]" addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %60
   %66 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %64, i32 0, i32 1
@@ -12490,8 +14270,8 @@ entry:
   %68 = zext i32 %67 to i64
   %69 = trunc i64 %68 to i32
   %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck18, label %71, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
   %72 = load i64, i64 addrspace(1)* %70
@@ -12507,29 +14287,29 @@ entry:
 
 ; <label>:80                                      ; preds = %27, %52, %71
   %81 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %81, null
-  br i1 %NullCheck20, label %82, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.IO.StreamWriter addrspace(1)* %81, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
 
 ; <label>:82                                      ; preds = %80
   %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %81, i32 0, i32 5
   %84 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %83, align 8
   %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.IO.StreamWriter addrspace(1)* %85, null
-  br i1 %NullCheck22, label %86, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.IO.StreamWriter addrspace(1)* %85, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %86
 
 ; <label>:86                                      ; preds = %82
   %87 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 7
   %88 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %87, align 8
   %89 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %89, null
-  br i1 %NullCheck24, label %90, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.StreamWriter addrspace(1)* %89, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %90
 
 ; <label>:90                                      ; preds = %86
   %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %89, i32 0, i32 9
   %92 = load i32, i32 addrspace(1)* %91, align 8
   %93 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.IO.StreamWriter addrspace(1)* %93, null
-  br i1 %NullCheck26, label %94, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.IO.StreamWriter addrspace(1)* %93, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %93, i32 0, i32 6
@@ -12537,8 +14317,8 @@ entry:
   %97 = load i8, i8* %arg2
   %98 = zext i8 %97 to i32
   %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
-  %NullCheck28 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck28, label %100, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
   %101 = load i64, i64 addrspace(1)* %99
@@ -12553,8 +14333,8 @@ entry:
   %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
   store i32 %110, i32* %loc1
   %111 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %111, null
-  br i1 %NullCheck30, label %112, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.IO.StreamWriter addrspace(1)* %111, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %112
 
 ; <label>:112                                     ; preds = %100
   %113 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %111, i32 0, i32 9
@@ -12565,23 +14345,23 @@ entry:
 
 ; <label>:116                                     ; preds = %112
   %117 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck32 = icmp ne %System.IO.StreamWriter addrspace(1)* %117, null
-  br i1 %NullCheck32, label %118, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.IO.StreamWriter addrspace(1)* %117, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %118
 
 ; <label>:118                                     ; preds = %116
   %119 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %117, i32 0, i32 3
   %120 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %119, align 8
   %121 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.IO.StreamWriter addrspace(1)* %121, null
-  br i1 %NullCheck34, label %122, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.IO.StreamWriter addrspace(1)* %121, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %122
 
 ; <label>:122                                     ; preds = %118
   %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
   %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
   %125 = load i32, i32* %loc1
   %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
-  %NullCheck36 = icmp ne i64 addrspace(1)* %126, null
-  br i1 %NullCheck36, label %127, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64 addrspace(1)* %126, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
   %128 = load i64, i64 addrspace(1)* %126
@@ -12603,15 +14383,15 @@ entry:
 
 ; <label>:140                                     ; preds = %136
   %141 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.IO.StreamWriter addrspace(1)* %141, null
-  br i1 %NullCheck38, label %142, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.IO.StreamWriter addrspace(1)* %141, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %142
 
 ; <label>:142                                     ; preds = %140
   %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
   %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
   %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
-  %NullCheck40 = icmp ne i64 addrspace(1)* %145, null
-  br i1 %NullCheck40, label %146, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i64 addrspace(1)* %145, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
   %147 = load i64, i64 addrspace(1)* %145
@@ -12632,83 +14412,83 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %25
+ThrowNullRef4:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %32
+ThrowNullRef6:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %37
+ThrowNullRef10:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %41
+ThrowNullRef12:                                   ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %58
+ThrowNullRef14:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %60
+ThrowNullRef16:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %65
+ThrowNullRef18:                                   ; preds = %65
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %80
+ThrowNullRef20:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %82
+ThrowNullRef22:                                   ; preds = %82
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %86
+ThrowNullRef24:                                   ; preds = %86
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %90
+ThrowNullRef26:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %94
+ThrowNullRef28:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %100
+ThrowNullRef30:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %116
+ThrowNullRef32:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %118
+ThrowNullRef34:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %122
+ThrowNullRef36:                                   ; preds = %122
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %140
+ThrowNullRef38:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %142
+ThrowNullRef40:                                   ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12775,8 +14555,8 @@ entry:
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %1 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
-  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
@@ -12784,8 +14564,8 @@ entry:
   %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
   %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
   %8 = load i64, i64 addrspace(1)* %6
@@ -12801,8 +14581,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %17, %System.IFormatProvider addrspace(1)* %16)
   %18 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %19 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %18, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.SyncTextWriter addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %7
   %21 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %18, i32 0, i32 4
@@ -12813,11 +14593,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12830,8 +14610,8 @@ entry:
   %this = alloca %System.IO.TextWriter addrspace(1)*
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.TextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
@@ -12841,8 +14621,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.Threading.Thread addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Threading.Thread addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %6)
@@ -12851,8 +14631,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1
   %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.TextWriter addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.TextWriter addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %11, i32 0, i32 2
@@ -12863,11 +14643,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13064,8 +14844,8 @@ entry:
   store double %param1, double* %arg1
   store i8 0, i8* %loc1
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
@@ -13075,16 +14855,16 @@ entry:
   %5 = addrspacecast i8* %loc1 to i8 addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %4, i8 addrspace(1)* %5)
   %6 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.SyncTextWriter addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
   %10 = load double, double* %arg1
   %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
   %13 = load i64, i64 addrspace(1)* %11
@@ -13119,11 +14899,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13140,8 +14920,8 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load double, double* %arg1
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -13155,8 +14935,8 @@ entry:
   call void %11(%System.IO.TextWriter addrspace(1)* %0, double %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
   %15 = load i64, i64 addrspace(1)* %13
@@ -13174,7 +14954,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13192,8 +14972,8 @@ entry:
   %1 = addrspacecast double* %arg1 to double addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -13208,8 +14988,8 @@ entry:
   %14 = bitcast double addrspace(1)* %1 to %System.Double addrspace(1)*
   %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Double addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Double addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
   %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
   %18 = load i64, i64 addrspace(1)* %16
@@ -13227,7 +15007,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13243,8 +15023,8 @@ entry:
   store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
   %0 = load %System.Double addrspace(1)*, %System.Double addrspace(1)** %this
   %1 = bitcast %System.Double addrspace(1)* %0 to double addrspace(1)*
-  %NullCheck = icmp ne double addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq double addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load double, double addrspace(1)* %1, align 8
@@ -13269,8 +15049,8 @@ entry:
   %loc0 = alloca %System.Globalization.NumberFormatInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 3
@@ -13280,8 +15060,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
@@ -13291,24 +15071,24 @@ entry:
   store %System.Globalization.NumberFormatInfo addrspace(1)* %10, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
   %11 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %7
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
   %15 = load i8, i8 addrspace(1)* %14, align 8
   %16 = zext i8 %15 to i32
   %17 = trunc i32 %16 to i8
-  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %11, null
-  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %11, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %13
   %19 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %11, i32 0, i32 29
   store i8 %17, i8 addrspace(1)* %19
   %20 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %21 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %20, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %20, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %18
   %23 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %20, i32 0, i32 3
@@ -13317,8 +15097,8 @@ entry:
 
 ; <label>:24                                      ; preds = %1, %22
   %25 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %25, null
-  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %25, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %26
 
 ; <label>:26                                      ; preds = %24
   %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %25, i32 0, i32 3
@@ -13329,23 +15109,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %18
+ThrowNullRef8:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13370,168 +15150,168 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 18
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %8, align 8
-  %NullCheck2 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %5, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %5, i32 0, i32 4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %9)
   %12 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 19
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %15, align 8
-  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %12, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %12, i32 0, i32 5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %16)
   %19 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %20 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %20, null
-  br i1 %NullCheck8, label %21, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %20, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %20, i32 0, i32 23
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  %NullCheck10 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %19, null
-  br i1 %NullCheck10, label %24, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %19, i32 0, i32 7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %25, %System.String addrspace(1)* %23)
   %26 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %27 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %27, i32 0, i32 22
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %29, align 8
-  %NullCheck14 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %26, null
-  br i1 %NullCheck14, label %31, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %26, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %26, i32 0, i32 6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %32, %System.String addrspace(1)* %30)
   %33 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %34 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Globalization.CultureData addrspace(1)* %34, null
-  br i1 %NullCheck16, label %35, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Globalization.CultureData addrspace(1)* %34, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %34, i32 0, i32 51
   %37 = load i32, i32 addrspace(1)* %36, align 8
-  %NullCheck18 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %33, null
-  br i1 %NullCheck18, label %38, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %33, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %33, i32 0, i32 21
   store i32 %37, i32 addrspace(1)* %39
   %40 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %41 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Globalization.CultureData addrspace(1)* %41, null
-  br i1 %NullCheck20, label %42, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Globalization.CultureData addrspace(1)* %41, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %41, i32 0, i32 52
   %44 = load i32, i32 addrspace(1)* %43, align 8
-  %NullCheck22 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %40, null
-  br i1 %NullCheck22, label %45, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %40, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %40, i32 0, i32 25
   store i32 %44, i32 addrspace(1)* %46
   %47 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %48 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.Globalization.CultureData addrspace(1)* %48, null
-  br i1 %NullCheck24, label %49, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Globalization.CultureData addrspace(1)* %48, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %49
 
 ; <label>:49                                      ; preds = %45
   %50 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %48, i32 0, i32 29
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck26 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %47, null
-  br i1 %NullCheck26, label %52, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %47, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %47, i32 0, i32 10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %53, %System.String addrspace(1)* %51)
   %54 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %55 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Globalization.CultureData addrspace(1)* %55, null
-  br i1 %NullCheck28, label %56, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Globalization.CultureData addrspace(1)* %55, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %56
 
 ; <label>:56                                      ; preds = %52
   %57 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %55, i32 0, i32 35
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %57, align 8
-  %NullCheck30 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %54, null
-  br i1 %NullCheck30, label %59, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %54, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %54, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %60, %System.String addrspace(1)* %58)
   %61 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %62 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck32 = icmp ne %System.Globalization.CultureData addrspace(1)* %62, null
-  br i1 %NullCheck32, label %63, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Globalization.CultureData addrspace(1)* %62, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %62, i32 0, i32 34
   %65 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %64, align 8
-  %NullCheck34 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %61, null
-  br i1 %NullCheck34, label %66, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %61, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %61, i32 0, i32 9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %67, %System.String addrspace(1)* %65)
   %68 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %69 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck36 = icmp ne %System.Globalization.CultureData addrspace(1)* %69, null
-  br i1 %NullCheck36, label %70, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Globalization.CultureData addrspace(1)* %69, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %70
 
 ; <label>:70                                      ; preds = %66
   %71 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %69, i32 0, i32 55
   %72 = load i32, i32 addrspace(1)* %71, align 8
-  %NullCheck38 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %68, null
-  br i1 %NullCheck38, label %73, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %68, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %68, i32 0, i32 22
   store i32 %72, i32 addrspace(1)* %74
   %75 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %76 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck40 = icmp ne %System.Globalization.CultureData addrspace(1)* %76, null
-  br i1 %NullCheck40, label %77, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Globalization.CultureData addrspace(1)* %76, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %76, i32 0, i32 57
   %79 = load i32, i32 addrspace(1)* %78, align 8
-  %NullCheck42 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %75, null
-  br i1 %NullCheck42, label %80, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %75, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %80
 
 ; <label>:80                                      ; preds = %77
   %81 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %75, i32 0, i32 24
   store i32 %79, i32 addrspace(1)* %81
   %82 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %83 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck44 = icmp ne %System.Globalization.CultureData addrspace(1)* %83, null
-  br i1 %NullCheck44, label %84, label %ThrowNullRef43
+  %NullCheck43 = icmp eq %System.Globalization.CultureData addrspace(1)* %83, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %84
 
 ; <label>:84                                      ; preds = %80
   %85 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %83, i32 0, i32 56
   %86 = load i32, i32 addrspace(1)* %85, align 8
-  %NullCheck46 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %82, null
-  br i1 %NullCheck46, label %87, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %82, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %82, i32 0, i32 23
@@ -13540,8 +15320,8 @@ entry:
 
 ; <label>:89                                      ; preds = %entry
   %90 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck100 = icmp ne %System.Globalization.CultureData addrspace(1)* %90, null
-  br i1 %NullCheck100, label %91, label %ThrowNullRef99
+  %NullCheck99 = icmp eq %System.Globalization.CultureData addrspace(1)* %90, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %91
 
 ; <label>:91                                      ; preds = %89
   %92 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %90, i32 0, i32 2
@@ -13559,8 +15339,8 @@ entry:
   %102 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %103 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %104 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %103)
-  %NullCheck48 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %102, null
-  br i1 %NullCheck48, label %105, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %102, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %105
 
 ; <label>:105                                     ; preds = %101
   %106 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %102, i32 0, i32 1
@@ -13568,8 +15348,8 @@ entry:
   %107 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %108 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %109 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %108)
-  %NullCheck50 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %107, null
-  br i1 %NullCheck50, label %110, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %107, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %110
 
 ; <label>:110                                     ; preds = %105
   %111 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %107, i32 0, i32 2
@@ -13577,8 +15357,8 @@ entry:
   %112 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %113 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %114 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %113)
-  %NullCheck52 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %112, null
-  br i1 %NullCheck52, label %115, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %112, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %115
 
 ; <label>:115                                     ; preds = %110
   %116 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %112, i32 0, i32 27
@@ -13586,8 +15366,8 @@ entry:
   %117 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %118 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %119 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %118)
-  %NullCheck54 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %117, null
-  br i1 %NullCheck54, label %120, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %117, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %120
 
 ; <label>:120                                     ; preds = %115
   %121 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %117, i32 0, i32 26
@@ -13595,8 +15375,8 @@ entry:
   %122 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %123 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %124 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %123)
-  %NullCheck56 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %122, null
-  br i1 %NullCheck56, label %125, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %122, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %125
 
 ; <label>:125                                     ; preds = %120
   %126 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %122, i32 0, i32 17
@@ -13604,8 +15384,8 @@ entry:
   %127 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %128 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %129 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %128)
-  %NullCheck58 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %127, null
-  br i1 %NullCheck58, label %130, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %127, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %130
 
 ; <label>:130                                     ; preds = %125
   %131 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %127, i32 0, i32 18
@@ -13613,8 +15393,8 @@ entry:
   %132 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %133 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %134 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %133)
-  %NullCheck60 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %132, null
-  br i1 %NullCheck60, label %135, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %132, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %135
 
 ; <label>:135                                     ; preds = %130
   %136 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %132, i32 0, i32 14
@@ -13622,8 +15402,8 @@ entry:
   %137 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %138 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %139 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %138)
-  %NullCheck62 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %137, null
-  br i1 %NullCheck62, label %140, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %137, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %140
 
 ; <label>:140                                     ; preds = %135
   %141 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %137, i32 0, i32 13
@@ -13631,71 +15411,71 @@ entry:
   %142 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %143 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %144 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %143)
-  %NullCheck64 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %142, null
-  br i1 %NullCheck64, label %145, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %142, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %145
 
 ; <label>:145                                     ; preds = %140
   %146 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %142, i32 0, i32 12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %146, %System.String addrspace(1)* %144)
   %147 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %148 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck66 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %148, null
-  br i1 %NullCheck66, label %149, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %148, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %149
 
 ; <label>:149                                     ; preds = %145
   %150 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %148, i32 0, i32 21
   %151 = load i32, i32 addrspace(1)* %150, align 8
-  %NullCheck68 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %147, null
-  br i1 %NullCheck68, label %152, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %147, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %152
 
 ; <label>:152                                     ; preds = %149
   %153 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %147, i32 0, i32 28
   store i32 %151, i32 addrspace(1)* %153
   %154 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %155 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck70 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %155, null
-  br i1 %NullCheck70, label %156, label %ThrowNullRef69
+  %NullCheck69 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %155, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %156
 
 ; <label>:156                                     ; preds = %152
   %157 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %155, i32 0, i32 6
   %158 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %157, align 8
-  %NullCheck72 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %154, null
-  br i1 %NullCheck72, label %159, label %ThrowNullRef71
+  %NullCheck71 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %154, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %159
 
 ; <label>:159                                     ; preds = %156
   %160 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %154, i32 0, i32 15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %160, %System.String addrspace(1)* %158)
   %161 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %162 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck74 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %162, null
-  br i1 %NullCheck74, label %163, label %ThrowNullRef73
+  %NullCheck73 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %162, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %163
 
 ; <label>:163                                     ; preds = %159
   %164 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %162, i32 0, i32 1
   %165 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %164, align 8
-  %NullCheck76 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %161, null
-  br i1 %NullCheck76, label %166, label %ThrowNullRef75
+  %NullCheck75 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %161, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %166
 
 ; <label>:166                                     ; preds = %163
   %167 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %161, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %167, %"System.Int32[]" addrspace(1)* %165)
   %168 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %169 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck78 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %169, null
-  br i1 %NullCheck78, label %170, label %ThrowNullRef77
+  %NullCheck77 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %169, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %170
 
 ; <label>:170                                     ; preds = %166
   %171 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %169, i32 0, i32 7
   %172 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %171, align 8
-  %NullCheck80 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %168, null
-  br i1 %NullCheck80, label %173, label %ThrowNullRef79
+  %NullCheck79 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %168, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %173
 
 ; <label>:173                                     ; preds = %170
   %174 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %168, i32 0, i32 16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %174, %System.String addrspace(1)* %172)
   %175 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck82 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %175, null
-  br i1 %NullCheck82, label %176, label %ThrowNullRef81
+  %NullCheck81 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %175, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %176
 
 ; <label>:176                                     ; preds = %173
   %177 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %175, i32 0, i32 4
@@ -13705,14 +15485,14 @@ entry:
 
 ; <label>:180                                     ; preds = %176
   %181 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck84 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %181, null
-  br i1 %NullCheck84, label %182, label %ThrowNullRef83
+  %NullCheck83 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %181, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %182
 
 ; <label>:182                                     ; preds = %180
   %183 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %181, i32 0, i32 4
   %184 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %183, align 8
-  %NullCheck86 = icmp ne %System.String addrspace(1)* %184, null
-  br i1 %NullCheck86, label %185, label %ThrowNullRef85
+  %NullCheck85 = icmp eq %System.String addrspace(1)* %184, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %185
 
 ; <label>:185                                     ; preds = %182
   %186 = getelementptr inbounds %System.String, %System.String addrspace(1)* %184, i32 0, i32 1
@@ -13723,8 +15503,8 @@ entry:
 ; <label>:189                                     ; preds = %176, %185
   %190 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck98 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %190, null
-  br i1 %NullCheck98, label %192, label %ThrowNullRef97
+  %NullCheck97 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %190, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %192
 
 ; <label>:192                                     ; preds = %189
   %193 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %190, i32 0, i32 4
@@ -13733,8 +15513,8 @@ entry:
 
 ; <label>:194                                     ; preds = %185, %192
   %195 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck88 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %195, null
-  br i1 %NullCheck88, label %196, label %ThrowNullRef87
+  %NullCheck87 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %195, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %196
 
 ; <label>:196                                     ; preds = %194
   %197 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %195, i32 0, i32 9
@@ -13744,14 +15524,14 @@ entry:
 
 ; <label>:200                                     ; preds = %196
   %201 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck90 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %201, null
-  br i1 %NullCheck90, label %202, label %ThrowNullRef89
+  %NullCheck89 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %201, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %202
 
 ; <label>:202                                     ; preds = %200
   %203 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %201, i32 0, i32 9
   %204 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %203, align 8
-  %NullCheck92 = icmp ne %System.String addrspace(1)* %204, null
-  br i1 %NullCheck92, label %205, label %ThrowNullRef91
+  %NullCheck91 = icmp eq %System.String addrspace(1)* %204, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %205
 
 ; <label>:205                                     ; preds = %202
   %206 = getelementptr inbounds %System.String, %System.String addrspace(1)* %204, i32 0, i32 1
@@ -13762,14 +15542,14 @@ entry:
 ; <label>:209                                     ; preds = %196, %205
   %210 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %211 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck94 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %211, null
-  br i1 %NullCheck94, label %212, label %ThrowNullRef93
+  %NullCheck93 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %211, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %212
 
 ; <label>:212                                     ; preds = %209
   %213 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %211, i32 0, i32 6
   %214 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %213, align 8
-  %NullCheck96 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %210, null
-  br i1 %NullCheck96, label %215, label %ThrowNullRef95
+  %NullCheck95 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %210, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %215
 
 ; <label>:215                                     ; preds = %212
   %216 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %210, i32 0, i32 9
@@ -13783,203 +15563,203 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %17
+ThrowNullRef8:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %21
+ThrowNullRef10:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %24
+ThrowNullRef12:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %28
+ThrowNullRef14:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %31
+ThrowNullRef16:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %35
+ThrowNullRef18:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %38
+ThrowNullRef20:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %42
+ThrowNullRef22:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %45
+ThrowNullRef24:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %49
+ThrowNullRef26:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %52
+ThrowNullRef28:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %56
+ThrowNullRef30:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %59
+ThrowNullRef32:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %63
+ThrowNullRef34:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %66
+ThrowNullRef36:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %70
+ThrowNullRef38:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %73
+ThrowNullRef40:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %77
+ThrowNullRef42:                                   ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %80
+ThrowNullRef44:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %84
+ThrowNullRef46:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %101
+ThrowNullRef48:                                   ; preds = %101
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %105
+ThrowNullRef50:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %110
+ThrowNullRef52:                                   ; preds = %110
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %115
+ThrowNullRef54:                                   ; preds = %115
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %120
+ThrowNullRef56:                                   ; preds = %120
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %125
+ThrowNullRef58:                                   ; preds = %125
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %130
+ThrowNullRef60:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %135
+ThrowNullRef62:                                   ; preds = %135
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %140
+ThrowNullRef64:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %145
+ThrowNullRef66:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %149
+ThrowNullRef68:                                   ; preds = %149
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %152
+ThrowNullRef70:                                   ; preds = %152
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %156
+ThrowNullRef72:                                   ; preds = %156
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %159
+ThrowNullRef74:                                   ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %163
+ThrowNullRef76:                                   ; preds = %163
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %166
+ThrowNullRef78:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %170
+ThrowNullRef80:                                   ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %173
+ThrowNullRef82:                                   ; preds = %173
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %180
+ThrowNullRef84:                                   ; preds = %180
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %182
+ThrowNullRef86:                                   ; preds = %182
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %194
+ThrowNullRef88:                                   ; preds = %194
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %200
+ThrowNullRef90:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %202
+ThrowNullRef92:                                   ; preds = %202
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %209
+ThrowNullRef94:                                   ; preds = %209
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %212
+ThrowNullRef96:                                   ; preds = %212
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %189
+ThrowNullRef98:                                   ; preds = %189
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %89
+ThrowNullRef100:                                  ; preds = %89
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14007,8 +15787,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 21
@@ -14021,8 +15801,8 @@ entry:
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 16)
   %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 21
@@ -14031,8 +15811,8 @@ entry:
 
 ; <label>:12                                      ; preds = %1, %10
   %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 21
@@ -14043,11 +15823,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %12
+ThrowNullRef4:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14063,8 +15843,8 @@ entry:
   store i32 %param1, i32* %arg1
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %1 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
@@ -14131,8 +15911,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 33
@@ -14145,8 +15925,8 @@ entry:
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 24)
   %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 33
@@ -14155,8 +15935,8 @@ entry:
 
 ; <label>:12                                      ; preds = %1, %10
   %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 33
@@ -14167,11 +15947,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %12
+ThrowNullRef4:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14184,8 +15964,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 53
@@ -14197,8 +15977,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 116)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 53
@@ -14207,8 +15987,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 53
@@ -14219,11 +15999,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14252,8 +16032,8 @@ entry:
 
 ; <label>:7                                       ; preds = %entry, %4
   %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %7
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 2
@@ -14277,8 +16057,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 54
@@ -14290,8 +16070,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 117)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
@@ -14300,8 +16080,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 54
@@ -14312,11 +16092,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14329,8 +16109,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 27
@@ -14342,8 +16122,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 118)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 27
@@ -14352,8 +16132,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 27
@@ -14364,11 +16144,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14381,8 +16161,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 28
@@ -14394,8 +16174,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 119)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 28
@@ -14404,8 +16184,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 28
@@ -14416,11 +16196,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14433,8 +16213,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 26
@@ -14446,8 +16226,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 107)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 26
@@ -14456,8 +16236,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 26
@@ -14468,11 +16248,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14485,8 +16265,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 25
@@ -14498,8 +16278,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 106)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 25
@@ -14508,8 +16288,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 25
@@ -14520,11 +16300,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14537,8 +16317,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 24
@@ -14550,8 +16330,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 105)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 24
@@ -14560,8 +16340,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 24
@@ -14572,11 +16352,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14601,8 +16381,8 @@ entry:
   %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %3)
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %2
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -14613,15 +16393,15 @@ entry:
 
 ; <label>:8                                       ; preds = %62
   %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 9
   %12 = load i32, i32 addrspace(1)* %11, align 8
   %13 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.IO.StreamWriter addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %13, i32 0, i32 10
@@ -14636,15 +16416,15 @@ entry:
 
 ; <label>:20                                      ; preds = %14, %18
   %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
   %24 = load i32, i32 addrspace(1)* %23, align 8
   %25 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %25, null
-  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.StreamWriter addrspace(1)* %25, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %25, i32 0, i32 9
@@ -14665,36 +16445,36 @@ entry:
   %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %37 = load i32, i32* %loc1
   %38 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.StreamWriter addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %35
   %40 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %38, i32 0, i32 7
   %41 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %40, align 8
   %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
-  br i1 %NullCheck14, label %43, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %39
   %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 9
   %45 = load i32, i32 addrspace(1)* %44, align 8
   %46 = load i32, i32* %loc2
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %36, null
-  br i1 %NullCheck16, label %47, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %36, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %47
 
 ; <label>:47                                      ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %36, i32 %37, %"System.Char[]" addrspace(1)* %41, i32 %45, i32 %46)
   %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
   %51 = load i32, i32 addrspace(1)* %50, align 8
   %52 = load i32, i32* %loc2
   %53 = add i32 %51, %52
-  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
-  br i1 %NullCheck20, label %54, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %54
 
 ; <label>:54                                      ; preds = %49
   %55 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
@@ -14716,8 +16496,8 @@ entry:
 
 ; <label>:65                                      ; preds = %62
   %66 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %66, null
-  br i1 %NullCheck2, label %67, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %66, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %67
 
 ; <label>:67                                      ; preds = %65
   %68 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %66, i32 0, i32 11
@@ -14738,49 +16518,259 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %65
+ThrowNullRef2:                                    ; preds = %65
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %20
+ThrowNullRef8:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %22
+ThrowNullRef10:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %35
+ThrowNullRef12:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %43
+ThrowNullRef16:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %47
+ThrowNullRef18:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method String::CopyTo using LLILCJit
-Failed to read String.CopyTo[loadElemA]
+Successfully read String.CopyTo
+
+define void @String.CopyTo(%System.String addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  %loc1 = alloca i16 addrspace(1)*
+  %loc2 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %1 = icmp ne %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg4
+  %7 = icmp sge i32 %6, 0
+  br i1 %7, label %13, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  unreachable
+
+; <label>:13                                      ; preds = %5
+  %14 = load i32, i32* %arg1
+  %15 = icmp sge i32 %14, 0
+  br i1 %15, label %21, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %18)
+  %20 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %20, %System.String addrspace(1)* %17, %System.String addrspace(1)* %19)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %20) #0
+  unreachable
+
+; <label>:21                                      ; preds = %13
+  %22 = load i32, i32* %arg4
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck, label %ThrowNullRef, label %24
+
+; <label>:24                                      ; preds = %21
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load i32, i32* %arg1
+  %28 = sub i32 %26, %27
+  %29 = icmp sle i32 %22, %28
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34, %System.String addrspace(1)* %31, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %24
+  %36 = load i32, i32* %arg3
+  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %37, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
+
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
+  %40 = load i32, i32 addrspace(1)* %39
+  %41 = zext i32 %40 to i64
+  %42 = trunc i64 %41 to i32
+  %43 = load i32, i32* %arg4
+  %44 = sub i32 %42, %43
+  %45 = icmp sgt i32 %36, %44
+  br i1 %45, label %49, label %46
+
+; <label>:46                                      ; preds = %38
+  %47 = load i32, i32* %arg3
+  %48 = icmp sge i32 %47, 0
+  br i1 %48, label %54, label %49
+
+; <label>:49                                      ; preds = %38, %46
+  %50 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %52 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %51)
+  %53 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53, %System.String addrspace(1)* %50, %System.String addrspace(1)* %52)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53) #0
+  unreachable
+
+; <label>:54                                      ; preds = %46
+  %55 = load i32, i32* %arg4
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %97, label %57
+
+; <label>:57                                      ; preds = %54
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %59
+
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 2
+  %61 = bitcast [0 x i16] addrspace(1)* %60 to i16 addrspace(1)*
+  store i16 addrspace(1)* %61, i16 addrspace(1)** %loc0
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  store %"System.Char[]" addrspace(1)* %62, %"System.Char[]" addrspace(1)** %loc2
+  %63 = icmp eq %"System.Char[]" addrspace(1)* %62, null
+  br i1 %63, label %72, label %64
+
+; <label>:64                                      ; preds = %59
+  %65 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc2
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %65, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %66
+
+; <label>:66                                      ; preds = %64
+  %67 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %65, i32 0, i32 1
+  %68 = load i32, i32 addrspace(1)* %67
+  %69 = zext i32 %68 to i64
+  %70 = trunc i64 %69 to i32
+  %71 = icmp ne i32 %70, 0
+  br i1 %71, label %73, label %72
+
+; <label>:72                                      ; preds = %59, %66
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  br label %81
+
+; <label>:73                                      ; preds = %66
+  %74 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc2
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %74, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %75
+
+; <label>:75                                      ; preds = %73
+  %76 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %74, i32 0, i32 1
+  %77 = load i32, i32 addrspace(1)* %76
+  %78 = zext i32 %77 to i64
+  %BoundsCheck = icmp uge i64 0, %78
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %79
+
+; <label>:79                                      ; preds = %75
+  %80 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %74, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %80, i16 addrspace(1)** %loc1
+  br label %81
+
+; <label>:81                                      ; preds = %72, %79
+  %82 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %83 = ptrtoint i16 addrspace(1)* %82 to i64
+  %84 = load i32, i32* %arg3
+  %85 = sext i32 %84 to i64
+  %86 = mul i64 %85, 2
+  %87 = add i64 %83, %86
+  %88 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %89 = ptrtoint i16 addrspace(1)* %88 to i64
+  %90 = load i32, i32* %arg1
+  %91 = sext i32 %90 to i64
+  %92 = mul i64 %91, 2
+  %93 = add i64 %89, %92
+  %94 = load i32, i32* %arg4
+  %95 = inttoptr i64 %87 to i16*
+  %96 = inttoptr i64 %93 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %95, i16* %96, i32 %94)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  br label %97
+
+; <label>:97                                      ; preds = %54, %81
+  ret void
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
 Successfully read ConsoleEncoding.GetPreamble
 
@@ -14817,7 +16807,365 @@ entry:
 }
 
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[loadElemA]
+Successfully read EncoderNLS.GetBytes
+
+define i32 @EncoderNLS.GetBytes(%System.Text.EncoderNLS addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3, %"System.Byte[]" addrspace(1)* %param4, i32 %param5, i8 %param6) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %arg4 = alloca %"System.Byte[]" addrspace(1)*
+  %arg5 = alloca i32
+  %arg6 = alloca i8
+  %loc0 = alloca i32
+  %loc1 = alloca i16 addrspace(1)*
+  %loc2 = alloca i8 addrspace(1)*
+  %loc3 = alloca i32
+  %loc4 = alloca %"System.Char[]" addrspace(1)*
+  %loc5 = alloca %"System.Byte[]" addrspace(1)*
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  store %"System.Byte[]" addrspace(1)* %param4, %"System.Byte[]" addrspace(1)** %arg4
+  store i32 %param5, i32* %arg5
+  store i8 %param6, i8* %arg6
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %1 = icmp eq %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %17, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %7 = icmp eq %"System.Char[]" addrspace(1)* %6, null
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %12
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %12
+
+; <label>:12                                      ; preds = %8, %10
+  %13 = phi %System.String addrspace(1)* [ %9, %8 ], [ %11, %10 ]
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %14)
+  %16 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16, %System.String addrspace(1)* %13, %System.String addrspace(1)* %15)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16) #0
+  unreachable
+
+; <label>:17                                      ; preds = %2
+  %18 = load i32, i32* %arg2
+  %19 = icmp slt i32 %18, 0
+  br i1 %19, label %23, label %20
+
+; <label>:20                                      ; preds = %17
+  %21 = load i32, i32* %arg3
+  %22 = icmp sge i32 %21, 0
+  br i1 %22, label %35, label %23
+
+; <label>:23                                      ; preds = %17, %20
+  %24 = load i32, i32* %arg2
+  %25 = icmp slt i32 %24, 0
+  br i1 %25, label %28, label %26
+
+; <label>:26                                      ; preds = %23
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %30
+
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %30
+
+; <label>:30                                      ; preds = %26, %28
+  %31 = phi %System.String addrspace(1)* [ %27, %26 ], [ %29, %28 ]
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34, %System.String addrspace(1)* %31, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %20
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck, label %ThrowNullRef, label %37
+
+; <label>:37                                      ; preds = %35
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = load i32, i32* %arg2
+  %43 = sub i32 %41, %42
+  %44 = load i32, i32* %arg3
+  %45 = icmp sge i32 %43, %44
+  br i1 %45, label %51, label %46
+
+; <label>:46                                      ; preds = %37
+  %47 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %48 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %49 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %48)
+  %50 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %50, %System.String addrspace(1)* %47, %System.String addrspace(1)* %49)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %50) #0
+  unreachable
+
+; <label>:51                                      ; preds = %37
+  %52 = load i32, i32* %arg5
+  %53 = icmp slt i32 %52, 0
+  br i1 %53, label %63, label %54
+
+; <label>:54                                      ; preds = %51
+  %55 = load i32, i32* %arg5
+  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck1 = icmp eq %"System.Byte[]" addrspace(1)* %56, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %57
+
+; <label>:57                                      ; preds = %54
+  %58 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = zext i32 %59 to i64
+  %61 = trunc i64 %60 to i32
+  %62 = icmp sle i32 %55, %61
+  br i1 %62, label %68, label %63
+
+; <label>:63                                      ; preds = %51, %57
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %66 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %65)
+  %67 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %67, %System.String addrspace(1)* %64, %System.String addrspace(1)* %66)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %67) #0
+  unreachable
+
+; <label>:68                                      ; preds = %57
+  %69 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %69, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %69, i32 0, i32 1
+  %72 = load i32, i32 addrspace(1)* %71
+  %73 = zext i32 %72 to i64
+  %74 = trunc i64 %73 to i32
+  %75 = icmp ne i32 %74, 0
+  br i1 %75, label %78, label %76
+
+; <label>:76                                      ; preds = %70
+  %77 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1)
+  store %"System.Char[]" addrspace(1)* %77, %"System.Char[]" addrspace(1)** %arg1
+  br label %78
+
+; <label>:78                                      ; preds = %70, %76
+  %79 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck5 = icmp eq %"System.Byte[]" addrspace(1)* %79, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %80
+
+; <label>:80                                      ; preds = %78
+  %81 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %79, i32 0, i32 1
+  %82 = load i32, i32 addrspace(1)* %81
+  %83 = zext i32 %82 to i64
+  %84 = trunc i64 %83 to i32
+  %85 = load i32, i32* %arg5
+  %86 = sub i32 %84, %85
+  store i32 %86, i32* %loc0
+  %87 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck7 = icmp eq %"System.Byte[]" addrspace(1)* %87, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %88
+
+; <label>:88                                      ; preds = %80
+  %89 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %87, i32 0, i32 1
+  %90 = load i32, i32 addrspace(1)* %89
+  %91 = zext i32 %90 to i64
+  %92 = trunc i64 %91 to i32
+  %93 = icmp ne i32 %92, 0
+  br i1 %93, label %96, label %94
+
+; <label>:94                                      ; preds = %88
+  %95 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1)
+  store %"System.Byte[]" addrspace(1)* %95, %"System.Byte[]" addrspace(1)** %arg4
+  br label %96
+
+; <label>:96                                      ; preds = %88, %94
+  %97 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  store %"System.Char[]" addrspace(1)* %97, %"System.Char[]" addrspace(1)** %loc4
+  %98 = icmp eq %"System.Char[]" addrspace(1)* %97, null
+  br i1 %98, label %107, label %99
+
+; <label>:99                                      ; preds = %96
+  %100 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc4
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %100, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %101
+
+; <label>:101                                     ; preds = %99
+  %102 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %100, i32 0, i32 1
+  %103 = load i32, i32 addrspace(1)* %102
+  %104 = zext i32 %103 to i64
+  %105 = trunc i64 %104 to i32
+  %106 = icmp ne i32 %105, 0
+  br i1 %106, label %108, label %107
+
+; <label>:107                                     ; preds = %96, %101
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  br label %116
+
+; <label>:108                                     ; preds = %101
+  %109 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc4
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %109, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %110
+
+; <label>:110                                     ; preds = %108
+  %111 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %109, i32 0, i32 1
+  %112 = load i32, i32 addrspace(1)* %111
+  %113 = zext i32 %112 to i64
+  %BoundsCheck = icmp uge i64 0, %113
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %114
+
+; <label>:114                                     ; preds = %110
+  %115 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %109, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %115, i16 addrspace(1)** %loc1
+  br label %116
+
+; <label>:116                                     ; preds = %107, %114
+  %117 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  store %"System.Byte[]" addrspace(1)* %117, %"System.Byte[]" addrspace(1)** %loc5
+  %118 = icmp eq %"System.Byte[]" addrspace(1)* %117, null
+  br i1 %118, label %127, label %119
+
+; <label>:119                                     ; preds = %116
+  %120 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc5
+  %NullCheck13 = icmp eq %"System.Byte[]" addrspace(1)* %120, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %121
+
+; <label>:121                                     ; preds = %119
+  %122 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %120, i32 0, i32 1
+  %123 = load i32, i32 addrspace(1)* %122
+  %124 = zext i32 %123 to i64
+  %125 = trunc i64 %124 to i32
+  %126 = icmp ne i32 %125, 0
+  br i1 %126, label %128, label %127
+
+; <label>:127                                     ; preds = %116, %121
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc2
+  br label %136
+
+; <label>:128                                     ; preds = %121
+  %129 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc5
+  %NullCheck15 = icmp eq %"System.Byte[]" addrspace(1)* %129, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %130
+
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %129, i32 0, i32 1
+  %132 = load i32, i32 addrspace(1)* %131
+  %133 = zext i32 %132 to i64
+  %BoundsCheck17 = icmp uge i64 0, %133
+  br i1 %BoundsCheck17, label %ThrowIndexOutOfRange18, label %134
+
+; <label>:134                                     ; preds = %130
+  %135 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %129, i32 0, i32 3, i32 0
+  store i8 addrspace(1)* %135, i8 addrspace(1)** %loc2
+  br label %136
+
+; <label>:136                                     ; preds = %127, %134
+  %137 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %138 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %139 = ptrtoint i16 addrspace(1)* %138 to i64
+  %140 = load i32, i32* %arg2
+  %141 = sext i32 %140 to i64
+  %142 = mul i64 %141, 2
+  %143 = add i64 %139, %142
+  %144 = load i32, i32* %arg3
+  %145 = load i8 addrspace(1)*, i8 addrspace(1)** %loc2
+  %146 = ptrtoint i8 addrspace(1)* %145 to i64
+  %147 = load i32, i32* %arg5
+  %148 = sext i32 %147 to i64
+  %149 = add i64 %146, %148
+  %150 = load i32, i32* %loc0
+  %151 = load i8, i8* %arg6
+  %152 = zext i8 %151 to i32
+  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i64 addrspace(1)*
+  %NullCheck19 = icmp eq i64 addrspace(1)* %153, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %154
+
+; <label>:154                                     ; preds = %136
+  %155 = load i64, i64 addrspace(1)* %153
+  %156 = add i64 %155, 72
+  %157 = inttoptr i64 %156 to i64*
+  %158 = load i64, i64* %157
+  %159 = add i64 %158, 0
+  %160 = inttoptr i64 %159 to i64*
+  %161 = load i64, i64* %160
+  %162 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to %System.Text.Encoder addrspace(1)*
+  %163 = inttoptr i64 %143 to i16*
+  %164 = inttoptr i64 %149 to i8*
+  %165 = trunc i32 %152 to i8
+  %166 = inttoptr i64 %161 to i32 (%System.Text.Encoder addrspace(1)*, i16*, i32, i8*, i32, i8)*
+  %167 = call i32 %166(%System.Text.Encoder addrspace(1)* %162, i16* %163, i32 %144, i8* %164, i32 %150, i8 %165)
+  store i32 %167, i32* %loc3
+  br label %168
+
+; <label>:168                                     ; preds = %154
+  %169 = load i32, i32* %loc3
+  ret i32 %169
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %110
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %119
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange18:                           ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
 Successfully read EncoderNLS.GetBytes
 
@@ -14906,22 +17254,22 @@ entry:
   %40 = load i8, i8* %arg5
   %41 = zext i8 %40 to i32
   %42 = trunc i32 %41 to i8
-  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %39, null
-  br i1 %NullCheck, label %43, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderNLS addrspace(1)* %39, null
+  br i1 %NullCheck, label %ThrowNullRef, label %43
 
 ; <label>:43                                      ; preds = %38
   %44 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
   store i8 %42, i8 addrspace(1)* %44
   %45 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %45, null
-  br i1 %NullCheck2, label %46, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.EncoderNLS addrspace(1)* %45, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %46
 
 ; <label>:46                                      ; preds = %43
   %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %45, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %47
   %48 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.EncoderNLS addrspace(1)* %48, null
-  br i1 %NullCheck4, label %49, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.EncoderNLS addrspace(1)* %48, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %49
 
 ; <label>:49                                      ; preds = %46
   %50 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %48, i32 0, i32 3
@@ -14932,8 +17280,8 @@ entry:
   %55 = load i32, i32* %arg4
   %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck6, label %58, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
   %59 = load i64, i64 addrspace(1)* %57
@@ -14951,15 +17299,15 @@ ThrowNullRef:                                     ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %43
+ThrowNullRef2:                                    ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %46
+ThrowNullRef4:                                    ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %49
+ThrowNullRef6:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14987,8 +17335,8 @@ entry:
   %4 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0 to %System.IO.ConsoleStream addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*)(%System.IO.ConsoleStream addrspace(1)* %4, %"System.Byte[]" addrspace(1)* %1, i32 %2, i32 %3)
   %5 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
@@ -15073,8 +17421,8 @@ entry:
 
 ; <label>:22                                      ; preds = %8
   %23 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %23, null
-  br i1 %NullCheck, label %24, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Byte[]" addrspace(1)* %23, null
+  br i1 %NullCheck, label %ThrowNullRef, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
@@ -15096,8 +17444,8 @@ entry:
 
 ; <label>:36                                      ; preds = %24
   %37 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %37, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.ConsoleStream addrspace(1)* %37, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %37, i32 0, i32 4
@@ -15118,13 +17466,138 @@ ThrowNullRef:                                     ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %36
+ThrowNullRef2:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
-Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
+Successfully read WindowsConsoleStream.WriteFileNative
+
+define i32 @WindowsConsoleStream.WriteFileNative(i64 %param0, %"System.Byte[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i64
+  %arg1 = alloca %"System.Byte[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i8 addrspace(1)*
+  %loc2 = alloca %"System.Byte[]" addrspace(1)*
+  %loc3 = alloca i32
+  store i64 %param0, i64* %arg0
+  store %"System.Byte[]" addrspace(1)* %param1, %"System.Byte[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Byte[]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = zext i32 %3 to i64
+  %5 = icmp ne i64 %4, 0
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %1
+  ret i32 0
+
+; <label>:7                                       ; preds = %1
+  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  store %"System.Byte[]" addrspace(1)* %8, %"System.Byte[]" addrspace(1)** %loc2
+  %9 = icmp eq %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %9, label %18, label %10
+
+; <label>:10                                      ; preds = %7
+  %11 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc2
+  %NullCheck1 = icmp eq %"System.Byte[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %11, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp ne i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %7, %12
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc1
+  br label %27
+
+; <label>:19                                      ; preds = %12
+  %20 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc2
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %20, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %BoundsCheck = icmp uge i64 0, %24
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %25
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %20, i32 0, i32 3, i32 0
+  store i8 addrspace(1)* %26, i8 addrspace(1)** %loc1
+  br label %27
+
+; <label>:27                                      ; preds = %18, %25
+  %28 = load i64, i64* %arg0
+  %29 = load i8 addrspace(1)*, i8 addrspace(1)** %loc1
+  %30 = ptrtoint i8 addrspace(1)* %29 to i64
+  %31 = load i32, i32* %arg2
+  %32 = sext i32 %31 to i64
+  %33 = add i64 %30, %32
+  %34 = load i32, i32* %arg3
+  %35 = addrspacecast i32* %loc3 to i32 addrspace(1)*
+  %36 = inttoptr i64 %33 to i8*
+  %37 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i8*, i32, i32 addrspace(1)*, i64)*)(i64 %28, i8* %36, i32 %34, i32 addrspace(1)* %35, i64 0)
+  %38 = icmp ugt i32 %37, 0
+  %39 = sext i1 %38 to i32
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc1
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %42, label %41
+
+; <label>:41                                      ; preds = %27
+  ret i32 0
+
+; <label>:42                                      ; preds = %27
+  %43 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  store i32 %43, i32* %loc0
+  %44 = load i32, i32* %loc0
+  %45 = icmp eq i32 %44, 232
+  br i1 %45, label %49, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = load i32, i32* %loc0
+  %48 = icmp ne i32 %47, 109
+  br i1 %48, label %50, label %49
+
+; <label>:49                                      ; preds = %42, %46
+  ret i32 0
+
+; <label>:50                                      ; preds = %46
+  %51 = load i32, i32* %loc0
+  ret i32 %51
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
 Successfully read WindowsConsoleStream.Flush
 
@@ -15133,8 +17606,8 @@ entry:
   %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
   store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
@@ -15169,8 +17642,8 @@ entry:
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
   %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load i64, i64 addrspace(1)* %1
@@ -15209,15 +17682,15 @@ entry:
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.TextWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
   %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %3, align 8
   %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
   %7 = load i64, i64 addrspace(1)* %5
@@ -15235,7 +17708,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -15264,8 +17737,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %4)
   store i32 0, i32* %loc0
   %5 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Char[]" addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
@@ -15277,15 +17750,15 @@ entry:
 
 ; <label>:11                                      ; preds = %69
   %12 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %12, i32 0, i32 9
   %15 = load i32, i32 addrspace(1)* %14, align 8
   %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.IO.StreamWriter addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %16, i32 0, i32 10
@@ -15300,15 +17773,15 @@ entry:
 
 ; <label>:23                                      ; preds = %17, %21
   %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %24, null
-  br i1 %NullCheck8, label %25, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %24, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 10
   %27 = load i32, i32 addrspace(1)* %26, align 8
   %28 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %28, null
-  br i1 %NullCheck10, label %29, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.StreamWriter addrspace(1)* %28, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %28, i32 0, i32 9
@@ -15330,15 +17803,15 @@ entry:
   %40 = load i32, i32* %loc0
   %41 = mul i32 %40, 2
   %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
-  br i1 %NullCheck12, label %43, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %43
 
 ; <label>:43                                      ; preds = %38
   %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 7
   %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %44, align 8
   %46 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %46, null
-  br i1 %NullCheck14, label %47, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.IO.StreamWriter addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %47
 
 ; <label>:47                                      ; preds = %43
   %48 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %46, i32 0, i32 9
@@ -15350,16 +17823,16 @@ entry:
   %54 = bitcast %"System.Char[]" addrspace(1)* %45 to %System.Array addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %53, i32 %41, %System.Array addrspace(1)* %54, i32 %50, i32 %52)
   %55 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
-  br i1 %NullCheck16, label %56, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %56
 
 ; <label>:56                                      ; preds = %47
   %57 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
   %58 = load i32, i32 addrspace(1)* %57, align 8
   %59 = load i32, i32* %loc2
   %60 = add i32 %58, %59
-  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
-  br i1 %NullCheck18, label %61, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %61
 
 ; <label>:61                                      ; preds = %56
   %62 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
@@ -15381,8 +17854,8 @@ entry:
 
 ; <label>:72                                      ; preds = %69
   %73 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %73, null
-  br i1 %NullCheck2, label %74, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %73, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %74
 
 ; <label>:74                                      ; preds = %72
   %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %73, i32 0, i32 11
@@ -15403,39 +17876,39 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %72
+ThrowNullRef2:                                    ; preds = %72
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %23
+ThrowNullRef8:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef10:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %43
+ThrowNullRef14:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %47
+ThrowNullRef16:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %56
+ThrowNullRef18:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblAvg2.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblAvg2.error.txt
@@ -25,8 +25,8 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
@@ -40,8 +40,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
   %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
@@ -75,7 +75,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -90,8 +90,8 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %NullCheck = icmp ne i8 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = load i8, i8 addrspace(1)* %0, align 8
@@ -125,8 +125,8 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
@@ -159,8 +159,8 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -184,8 +184,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
   store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
@@ -195,8 +195,8 @@ entry:
 ; <label>:4                                       ; preds = %1
   %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
   %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
@@ -206,8 +206,8 @@ entry:
   %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
@@ -221,14 +221,14 @@ entry:
 
 ; <label>:17                                      ; preds = %14
   %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
   %21 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
@@ -238,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -249,8 +249,8 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
@@ -261,27 +261,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %30
+ThrowNullRef10:                                   ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -301,7 +301,89 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
-Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
+Successfully read AppDomainSetup.GetUnsecureApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.GetUnsecureApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %NullCheck = icmp eq %"System.String[]" addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %BoundsCheck = icmp uge i64 0, %5
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %6
+
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 3, i32 0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
+  ret %System.String addrspace(1)* %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_Value using LLILCJit
+Successfully read AppDomainSetup.get_Value
+
+define %"System.String[]" addrspace(1)* @AppDomainSetup.get_Value(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.String[]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 18)
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.String[]" addrspace(1)* addrspace(1)*, %"System.String[]" addrspace(1)*)*)(%"System.String[]" addrspace(1)* addrspace(1)* %9, %"System.String[]" addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %11, i32 0, i32 1
+  %14 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %13, align 8
+  ret %"System.String[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -319,8 +401,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -368,16 +450,16 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
   %5 = load i32, i32 addrspace(1)* %4
   %6 = sub i32 %5, 1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -389,7 +471,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -421,8 +503,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
@@ -456,8 +538,8 @@ entry:
 ; <label>:27                                      ; preds = %19
   %28 = load i32, i32* %arg1
   %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
-  br i1 %NullCheck2, label %30, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %29, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %30
 
 ; <label>:30                                      ; preds = %27
   %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
@@ -493,8 +575,8 @@ entry:
 ; <label>:49                                      ; preds = %46
   %50 = load i32, i32* %arg2
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck4, label %52, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
@@ -517,11 +599,11 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %27
+ThrowNullRef2:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %49
+ThrowNullRef4:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -544,16 +626,16 @@ entry:
   %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %0)
   store %System.String addrspace(1)* %1, %System.String addrspace(1)** %loc0
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 2
   %5 = bitcast [0 x i16] addrspace(1)* %4 to i16 addrspace(1)*
   store i16 addrspace(1)* %5, i16 addrspace(1)** %loc1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %3
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2
@@ -580,7 +662,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -691,15 +773,15 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %NullCheck132 = icmp ne i8* %21, null
-  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+  %NullCheck131 = icmp eq i8* %21, null
+  br i1 %NullCheck131, label %ThrowNullRef132, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = load i8, i8* %21, align 8
   %24 = zext i8 %23 to i32
   %25 = trunc i32 %24 to i8
-  %NullCheck134 = icmp ne i8* %20, null
-  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+  %NullCheck133 = icmp eq i8* %20, null
+  br i1 %NullCheck133, label %ThrowNullRef134, label %26
 
 ; <label>:26                                      ; preds = %22
   store i8 %25, i8* %20, align 8
@@ -709,16 +791,16 @@ entry:
   %28 = load i8*, i8** %arg0
   %29 = load i8*, i8** %arg1
   %30 = bitcast i8* %29 to i16*
-  %NullCheck128 = icmp ne i16* %30, null
-  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+  %NullCheck127 = icmp eq i16* %30, null
+  br i1 %NullCheck127, label %ThrowNullRef128, label %31
 
 ; <label>:31                                      ; preds = %27
   %32 = load i16, i16* %30, align 8
   %33 = sext i16 %32 to i32
   %34 = bitcast i8* %28 to i16*
   %35 = trunc i32 %33 to i16
-  %NullCheck130 = icmp ne i16* %34, null
-  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+  %NullCheck129 = icmp eq i16* %34, null
+  br i1 %NullCheck129, label %ThrowNullRef130, label %36
 
 ; <label>:36                                      ; preds = %31
   store i16 %35, i16* %34, align 8
@@ -728,16 +810,16 @@ entry:
   %38 = load i8*, i8** %arg0
   %39 = load i8*, i8** %arg1
   %40 = bitcast i8* %39 to i16*
-  %NullCheck120 = icmp ne i16* %40, null
-  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+  %NullCheck119 = icmp eq i16* %40, null
+  br i1 %NullCheck119, label %ThrowNullRef120, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i16, i16* %40, align 8
   %43 = sext i16 %42 to i32
   %44 = bitcast i8* %38 to i16*
   %45 = trunc i32 %43 to i16
-  %NullCheck122 = icmp ne i16* %44, null
-  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+  %NullCheck121 = icmp eq i16* %44, null
+  br i1 %NullCheck121, label %ThrowNullRef122, label %46
 
 ; <label>:46                                      ; preds = %41
   store i16 %45, i16* %44, align 8
@@ -745,15 +827,15 @@ entry:
   %48 = getelementptr inbounds i8, i8* %47, i64 2
   %49 = load i8*, i8** %arg1
   %50 = getelementptr inbounds i8, i8* %49, i64 2
-  %NullCheck124 = icmp ne i8* %50, null
-  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+  %NullCheck123 = icmp eq i8* %50, null
+  br i1 %NullCheck123, label %ThrowNullRef124, label %51
 
 ; <label>:51                                      ; preds = %46
   %52 = load i8, i8* %50, align 8
   %53 = zext i8 %52 to i32
   %54 = trunc i32 %53 to i8
-  %NullCheck126 = icmp ne i8* %48, null
-  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+  %NullCheck125 = icmp eq i8* %48, null
+  br i1 %NullCheck125, label %ThrowNullRef126, label %55
 
 ; <label>:55                                      ; preds = %51
   store i8 %54, i8* %48, align 8
@@ -763,14 +845,14 @@ entry:
   %57 = load i8*, i8** %arg0
   %58 = load i8*, i8** %arg1
   %59 = bitcast i8* %58 to i32*
-  %NullCheck116 = icmp ne i32* %59, null
-  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+  %NullCheck115 = icmp eq i32* %59, null
+  br i1 %NullCheck115, label %ThrowNullRef116, label %60
 
 ; <label>:60                                      ; preds = %56
   %61 = load i32, i32* %59, align 8
   %62 = bitcast i8* %57 to i32*
-  %NullCheck118 = icmp ne i32* %62, null
-  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+  %NullCheck117 = icmp eq i32* %62, null
+  br i1 %NullCheck117, label %ThrowNullRef118, label %63
 
 ; <label>:63                                      ; preds = %60
   store i32 %61, i32* %62, align 8
@@ -780,14 +862,14 @@ entry:
   %65 = load i8*, i8** %arg0
   %66 = load i8*, i8** %arg1
   %67 = bitcast i8* %66 to i32*
-  %NullCheck108 = icmp ne i32* %67, null
-  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+  %NullCheck107 = icmp eq i32* %67, null
+  br i1 %NullCheck107, label %ThrowNullRef108, label %68
 
 ; <label>:68                                      ; preds = %64
   %69 = load i32, i32* %67, align 8
   %70 = bitcast i8* %65 to i32*
-  %NullCheck110 = icmp ne i32* %70, null
-  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+  %NullCheck109 = icmp eq i32* %70, null
+  br i1 %NullCheck109, label %ThrowNullRef110, label %71
 
 ; <label>:71                                      ; preds = %68
   store i32 %69, i32* %70, align 8
@@ -795,15 +877,15 @@ entry:
   %73 = getelementptr inbounds i8, i8* %72, i64 4
   %74 = load i8*, i8** %arg1
   %75 = getelementptr inbounds i8, i8* %74, i64 4
-  %NullCheck112 = icmp ne i8* %75, null
-  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+  %NullCheck111 = icmp eq i8* %75, null
+  br i1 %NullCheck111, label %ThrowNullRef112, label %76
 
 ; <label>:76                                      ; preds = %71
   %77 = load i8, i8* %75, align 8
   %78 = zext i8 %77 to i32
   %79 = trunc i32 %78 to i8
-  %NullCheck114 = icmp ne i8* %73, null
-  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+  %NullCheck113 = icmp eq i8* %73, null
+  br i1 %NullCheck113, label %ThrowNullRef114, label %80
 
 ; <label>:80                                      ; preds = %76
   store i8 %79, i8* %73, align 8
@@ -813,14 +895,14 @@ entry:
   %82 = load i8*, i8** %arg0
   %83 = load i8*, i8** %arg1
   %84 = bitcast i8* %83 to i32*
-  %NullCheck100 = icmp ne i32* %84, null
-  br i1 %NullCheck100, label %85, label %ThrowNullRef99
+  %NullCheck99 = icmp eq i32* %84, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %85
 
 ; <label>:85                                      ; preds = %81
   %86 = load i32, i32* %84, align 8
   %87 = bitcast i8* %82 to i32*
-  %NullCheck102 = icmp ne i32* %87, null
-  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+  %NullCheck101 = icmp eq i32* %87, null
+  br i1 %NullCheck101, label %ThrowNullRef102, label %88
 
 ; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
@@ -829,16 +911,16 @@ entry:
   %91 = load i8*, i8** %arg1
   %92 = getelementptr inbounds i8, i8* %91, i64 4
   %93 = bitcast i8* %92 to i16*
-  %NullCheck104 = icmp ne i16* %93, null
-  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+  %NullCheck103 = icmp eq i16* %93, null
+  br i1 %NullCheck103, label %ThrowNullRef104, label %94
 
 ; <label>:94                                      ; preds = %88
   %95 = load i16, i16* %93, align 8
   %96 = sext i16 %95 to i32
   %97 = bitcast i8* %90 to i16*
   %98 = trunc i32 %96 to i16
-  %NullCheck106 = icmp ne i16* %97, null
-  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+  %NullCheck105 = icmp eq i16* %97, null
+  br i1 %NullCheck105, label %ThrowNullRef106, label %99
 
 ; <label>:99                                      ; preds = %94
   store i16 %98, i16* %97, align 8
@@ -848,14 +930,14 @@ entry:
   %101 = load i8*, i8** %arg0
   %102 = load i8*, i8** %arg1
   %103 = bitcast i8* %102 to i32*
-  %NullCheck88 = icmp ne i32* %103, null
-  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+  %NullCheck87 = icmp eq i32* %103, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %104
 
 ; <label>:104                                     ; preds = %100
   %105 = load i32, i32* %103, align 8
   %106 = bitcast i8* %101 to i32*
-  %NullCheck90 = icmp ne i32* %106, null
-  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+  %NullCheck89 = icmp eq i32* %106, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %107
 
 ; <label>:107                                     ; preds = %104
   store i32 %105, i32* %106, align 8
@@ -864,16 +946,16 @@ entry:
   %110 = load i8*, i8** %arg1
   %111 = getelementptr inbounds i8, i8* %110, i64 4
   %112 = bitcast i8* %111 to i16*
-  %NullCheck92 = icmp ne i16* %112, null
-  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+  %NullCheck91 = icmp eq i16* %112, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %113
 
 ; <label>:113                                     ; preds = %107
   %114 = load i16, i16* %112, align 8
   %115 = sext i16 %114 to i32
   %116 = bitcast i8* %109 to i16*
   %117 = trunc i32 %115 to i16
-  %NullCheck94 = icmp ne i16* %116, null
-  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+  %NullCheck93 = icmp eq i16* %116, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %118
 
 ; <label>:118                                     ; preds = %113
   store i16 %117, i16* %116, align 8
@@ -881,15 +963,15 @@ entry:
   %120 = getelementptr inbounds i8, i8* %119, i64 6
   %121 = load i8*, i8** %arg1
   %122 = getelementptr inbounds i8, i8* %121, i64 6
-  %NullCheck96 = icmp ne i8* %122, null
-  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+  %NullCheck95 = icmp eq i8* %122, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %123
 
 ; <label>:123                                     ; preds = %118
   %124 = load i8, i8* %122, align 8
   %125 = zext i8 %124 to i32
   %126 = trunc i32 %125 to i8
-  %NullCheck98 = icmp ne i8* %120, null
-  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+  %NullCheck97 = icmp eq i8* %120, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %127
 
 ; <label>:127                                     ; preds = %123
   store i8 %126, i8* %120, align 8
@@ -899,14 +981,14 @@ entry:
   %129 = load i8*, i8** %arg0
   %130 = load i8*, i8** %arg1
   %131 = bitcast i8* %130 to i64*
-  %NullCheck84 = icmp ne i64* %131, null
-  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+  %NullCheck83 = icmp eq i64* %131, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %132
 
 ; <label>:132                                     ; preds = %128
   %133 = load i64, i64* %131, align 8
   %134 = bitcast i8* %129 to i64*
-  %NullCheck86 = icmp ne i64* %134, null
-  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+  %NullCheck85 = icmp eq i64* %134, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %135
 
 ; <label>:135                                     ; preds = %132
   store i64 %133, i64* %134, align 8
@@ -916,14 +998,14 @@ entry:
   %137 = load i8*, i8** %arg0
   %138 = load i8*, i8** %arg1
   %139 = bitcast i8* %138 to i64*
-  %NullCheck76 = icmp ne i64* %139, null
-  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+  %NullCheck75 = icmp eq i64* %139, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %140
 
 ; <label>:140                                     ; preds = %136
   %141 = load i64, i64* %139, align 8
   %142 = bitcast i8* %137 to i64*
-  %NullCheck78 = icmp ne i64* %142, null
-  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+  %NullCheck77 = icmp eq i64* %142, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %143
 
 ; <label>:143                                     ; preds = %140
   store i64 %141, i64* %142, align 8
@@ -931,15 +1013,15 @@ entry:
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %NullCheck80 = icmp ne i8* %147, null
-  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+  %NullCheck79 = icmp eq i8* %147, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %148
 
 ; <label>:148                                     ; preds = %143
   %149 = load i8, i8* %147, align 8
   %150 = zext i8 %149 to i32
   %151 = trunc i32 %150 to i8
-  %NullCheck82 = icmp ne i8* %145, null
-  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+  %NullCheck81 = icmp eq i8* %145, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %152
 
 ; <label>:152                                     ; preds = %148
   store i8 %151, i8* %145, align 8
@@ -949,14 +1031,14 @@ entry:
   %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
   %156 = bitcast i8* %155 to i64*
-  %NullCheck68 = icmp ne i64* %156, null
-  br i1 %NullCheck68, label %157, label %ThrowNullRef67
+  %NullCheck67 = icmp eq i64* %156, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %157
 
 ; <label>:157                                     ; preds = %153
   %158 = load i64, i64* %156, align 8
   %159 = bitcast i8* %154 to i64*
-  %NullCheck70 = icmp ne i64* %159, null
-  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+  %NullCheck69 = icmp eq i64* %159, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %160
 
 ; <label>:160                                     ; preds = %157
   store i64 %158, i64* %159, align 8
@@ -965,16 +1047,16 @@ entry:
   %163 = load i8*, i8** %arg1
   %164 = getelementptr inbounds i8, i8* %163, i64 8
   %165 = bitcast i8* %164 to i16*
-  %NullCheck72 = icmp ne i16* %165, null
-  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+  %NullCheck71 = icmp eq i16* %165, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %166
 
 ; <label>:166                                     ; preds = %160
   %167 = load i16, i16* %165, align 8
   %168 = sext i16 %167 to i32
   %169 = bitcast i8* %162 to i16*
   %170 = trunc i32 %168 to i16
-  %NullCheck74 = icmp ne i16* %169, null
-  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+  %NullCheck73 = icmp eq i16* %169, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %171
 
 ; <label>:171                                     ; preds = %166
   store i16 %170, i16* %169, align 8
@@ -984,14 +1066,14 @@ entry:
   %173 = load i8*, i8** %arg0
   %174 = load i8*, i8** %arg1
   %175 = bitcast i8* %174 to i64*
-  %NullCheck56 = icmp ne i64* %175, null
-  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+  %NullCheck55 = icmp eq i64* %175, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %176
 
 ; <label>:176                                     ; preds = %172
   %177 = load i64, i64* %175, align 8
   %178 = bitcast i8* %173 to i64*
-  %NullCheck58 = icmp ne i64* %178, null
-  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+  %NullCheck57 = icmp eq i64* %178, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %179
 
 ; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
@@ -1000,16 +1082,16 @@ entry:
   %182 = load i8*, i8** %arg1
   %183 = getelementptr inbounds i8, i8* %182, i64 8
   %184 = bitcast i8* %183 to i16*
-  %NullCheck60 = icmp ne i16* %184, null
-  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+  %NullCheck59 = icmp eq i16* %184, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %185
 
 ; <label>:185                                     ; preds = %179
   %186 = load i16, i16* %184, align 8
   %187 = sext i16 %186 to i32
   %188 = bitcast i8* %181 to i16*
   %189 = trunc i32 %187 to i16
-  %NullCheck62 = icmp ne i16* %188, null
-  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+  %NullCheck61 = icmp eq i16* %188, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %190
 
 ; <label>:190                                     ; preds = %185
   store i16 %189, i16* %188, align 8
@@ -1017,15 +1099,15 @@ entry:
   %192 = getelementptr inbounds i8, i8* %191, i64 10
   %193 = load i8*, i8** %arg1
   %194 = getelementptr inbounds i8, i8* %193, i64 10
-  %NullCheck64 = icmp ne i8* %194, null
-  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+  %NullCheck63 = icmp eq i8* %194, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %195
 
 ; <label>:195                                     ; preds = %190
   %196 = load i8, i8* %194, align 8
   %197 = zext i8 %196 to i32
   %198 = trunc i32 %197 to i8
-  %NullCheck66 = icmp ne i8* %192, null
-  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+  %NullCheck65 = icmp eq i8* %192, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %199
 
 ; <label>:199                                     ; preds = %195
   store i8 %198, i8* %192, align 8
@@ -1035,14 +1117,14 @@ entry:
   %201 = load i8*, i8** %arg0
   %202 = load i8*, i8** %arg1
   %203 = bitcast i8* %202 to i64*
-  %NullCheck48 = icmp ne i64* %203, null
-  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+  %NullCheck47 = icmp eq i64* %203, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %204
 
 ; <label>:204                                     ; preds = %200
   %205 = load i64, i64* %203, align 8
   %206 = bitcast i8* %201 to i64*
-  %NullCheck50 = icmp ne i64* %206, null
-  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+  %NullCheck49 = icmp eq i64* %206, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %207
 
 ; <label>:207                                     ; preds = %204
   store i64 %205, i64* %206, align 8
@@ -1051,14 +1133,14 @@ entry:
   %210 = load i8*, i8** %arg1
   %211 = getelementptr inbounds i8, i8* %210, i64 8
   %212 = bitcast i8* %211 to i32*
-  %NullCheck52 = icmp ne i32* %212, null
-  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+  %NullCheck51 = icmp eq i32* %212, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %213
 
 ; <label>:213                                     ; preds = %207
   %214 = load i32, i32* %212, align 8
   %215 = bitcast i8* %209 to i32*
-  %NullCheck54 = icmp ne i32* %215, null
-  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+  %NullCheck53 = icmp eq i32* %215, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %216
 
 ; <label>:216                                     ; preds = %213
   store i32 %214, i32* %215, align 8
@@ -1068,14 +1150,14 @@ entry:
   %218 = load i8*, i8** %arg0
   %219 = load i8*, i8** %arg1
   %220 = bitcast i8* %219 to i64*
-  %NullCheck36 = icmp ne i64* %220, null
-  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64* %220, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %221
 
 ; <label>:221                                     ; preds = %217
   %222 = load i64, i64* %220, align 8
   %223 = bitcast i8* %218 to i64*
-  %NullCheck38 = icmp ne i64* %223, null
-  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+  %NullCheck37 = icmp eq i64* %223, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %224
 
 ; <label>:224                                     ; preds = %221
   store i64 %222, i64* %223, align 8
@@ -1084,14 +1166,14 @@ entry:
   %227 = load i8*, i8** %arg1
   %228 = getelementptr inbounds i8, i8* %227, i64 8
   %229 = bitcast i8* %228 to i32*
-  %NullCheck40 = icmp ne i32* %229, null
-  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i32* %229, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %230
 
 ; <label>:230                                     ; preds = %224
   %231 = load i32, i32* %229, align 8
   %232 = bitcast i8* %226 to i32*
-  %NullCheck42 = icmp ne i32* %232, null
-  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+  %NullCheck41 = icmp eq i32* %232, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %233
 
 ; <label>:233                                     ; preds = %230
   store i32 %231, i32* %232, align 8
@@ -1099,15 +1181,15 @@ entry:
   %235 = getelementptr inbounds i8, i8* %234, i64 12
   %236 = load i8*, i8** %arg1
   %237 = getelementptr inbounds i8, i8* %236, i64 12
-  %NullCheck44 = icmp ne i8* %237, null
-  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i8* %237, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %238
 
 ; <label>:238                                     ; preds = %233
   %239 = load i8, i8* %237, align 8
   %240 = zext i8 %239 to i32
   %241 = trunc i32 %240 to i8
-  %NullCheck46 = icmp ne i8* %235, null
-  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+  %NullCheck45 = icmp eq i8* %235, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %242
 
 ; <label>:242                                     ; preds = %238
   store i8 %241, i8* %235, align 8
@@ -1117,14 +1199,14 @@ entry:
   %244 = load i8*, i8** %arg0
   %245 = load i8*, i8** %arg1
   %246 = bitcast i8* %245 to i64*
-  %NullCheck24 = icmp ne i64* %246, null
-  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64* %246, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %247
 
 ; <label>:247                                     ; preds = %243
   %248 = load i64, i64* %246, align 8
   %249 = bitcast i8* %244 to i64*
-  %NullCheck26 = icmp ne i64* %249, null
-  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64* %249, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %250
 
 ; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
@@ -1133,14 +1215,14 @@ entry:
   %253 = load i8*, i8** %arg1
   %254 = getelementptr inbounds i8, i8* %253, i64 8
   %255 = bitcast i8* %254 to i32*
-  %NullCheck28 = icmp ne i32* %255, null
-  br i1 %NullCheck28, label %256, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i32* %255, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %256
 
 ; <label>:256                                     ; preds = %250
   %257 = load i32, i32* %255, align 8
   %258 = bitcast i8* %252 to i32*
-  %NullCheck30 = icmp ne i32* %258, null
-  br i1 %NullCheck30, label %259, label %ThrowNullRef29
+  %NullCheck29 = icmp eq i32* %258, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %259
 
 ; <label>:259                                     ; preds = %256
   store i32 %257, i32* %258, align 8
@@ -1149,16 +1231,16 @@ entry:
   %262 = load i8*, i8** %arg1
   %263 = getelementptr inbounds i8, i8* %262, i64 12
   %264 = bitcast i8* %263 to i16*
-  %NullCheck32 = icmp ne i16* %264, null
-  br i1 %NullCheck32, label %265, label %ThrowNullRef31
+  %NullCheck31 = icmp eq i16* %264, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %265
 
 ; <label>:265                                     ; preds = %259
   %266 = load i16, i16* %264, align 8
   %267 = sext i16 %266 to i32
   %268 = bitcast i8* %261 to i16*
   %269 = trunc i32 %267 to i16
-  %NullCheck34 = icmp ne i16* %268, null
-  br i1 %NullCheck34, label %270, label %ThrowNullRef33
+  %NullCheck33 = icmp eq i16* %268, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %270
 
 ; <label>:270                                     ; preds = %265
   store i16 %269, i16* %268, align 8
@@ -1168,14 +1250,14 @@ entry:
   %272 = load i8*, i8** %arg0
   %273 = load i8*, i8** %arg1
   %274 = bitcast i8* %273 to i64*
-  %NullCheck8 = icmp ne i64* %274, null
-  br i1 %NullCheck8, label %275, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64* %274, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %275
 
 ; <label>:275                                     ; preds = %271
   %276 = load i64, i64* %274, align 8
   %277 = bitcast i8* %272 to i64*
-  %NullCheck10 = icmp ne i64* %277, null
-  br i1 %NullCheck10, label %278, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %277, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %278
 
 ; <label>:278                                     ; preds = %275
   store i64 %276, i64* %277, align 8
@@ -1184,14 +1266,14 @@ entry:
   %281 = load i8*, i8** %arg1
   %282 = getelementptr inbounds i8, i8* %281, i64 8
   %283 = bitcast i8* %282 to i32*
-  %NullCheck12 = icmp ne i32* %283, null
-  br i1 %NullCheck12, label %284, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i32* %283, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %284
 
 ; <label>:284                                     ; preds = %278
   %285 = load i32, i32* %283, align 8
   %286 = bitcast i8* %280 to i32*
-  %NullCheck14 = icmp ne i32* %286, null
-  br i1 %NullCheck14, label %287, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i32* %286, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %287
 
 ; <label>:287                                     ; preds = %284
   store i32 %285, i32* %286, align 8
@@ -1200,16 +1282,16 @@ entry:
   %290 = load i8*, i8** %arg1
   %291 = getelementptr inbounds i8, i8* %290, i64 12
   %292 = bitcast i8* %291 to i16*
-  %NullCheck16 = icmp ne i16* %292, null
-  br i1 %NullCheck16, label %293, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i16* %292, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %293
 
 ; <label>:293                                     ; preds = %287
   %294 = load i16, i16* %292, align 8
   %295 = sext i16 %294 to i32
   %296 = bitcast i8* %289 to i16*
   %297 = trunc i32 %295 to i16
-  %NullCheck18 = icmp ne i16* %296, null
-  br i1 %NullCheck18, label %298, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i16* %296, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %298
 
 ; <label>:298                                     ; preds = %293
   store i16 %297, i16* %296, align 8
@@ -1217,15 +1299,15 @@ entry:
   %300 = getelementptr inbounds i8, i8* %299, i64 14
   %301 = load i8*, i8** %arg1
   %302 = getelementptr inbounds i8, i8* %301, i64 14
-  %NullCheck20 = icmp ne i8* %302, null
-  br i1 %NullCheck20, label %303, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i8* %302, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %303
 
 ; <label>:303                                     ; preds = %298
   %304 = load i8, i8* %302, align 8
   %305 = zext i8 %304 to i32
   %306 = trunc i32 %305 to i8
-  %NullCheck22 = icmp ne i8* %300, null
-  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i8* %300, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %307
 
 ; <label>:307                                     ; preds = %303
   store i8 %306, i8* %300, align 8
@@ -1235,14 +1317,14 @@ entry:
   %309 = load i8*, i8** %arg0
   %310 = load i8*, i8** %arg1
   %311 = bitcast i8* %310 to i64*
-  %NullCheck = icmp ne i64* %311, null
-  br i1 %NullCheck, label %312, label %ThrowNullRef
+  %NullCheck = icmp eq i64* %311, null
+  br i1 %NullCheck, label %ThrowNullRef, label %312
 
 ; <label>:312                                     ; preds = %308
   %313 = load i64, i64* %311, align 8
   %314 = bitcast i8* %309 to i64*
-  %NullCheck2 = icmp ne i64* %314, null
-  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64* %314, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %315
 
 ; <label>:315                                     ; preds = %312
   store i64 %313, i64* %314, align 8
@@ -1251,14 +1333,14 @@ entry:
   %318 = load i8*, i8** %arg1
   %319 = getelementptr inbounds i8, i8* %318, i64 8
   %320 = bitcast i8* %319 to i64*
-  %NullCheck4 = icmp ne i64* %320, null
-  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64* %320, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %321
 
 ; <label>:321                                     ; preds = %315
   %322 = load i64, i64* %320, align 8
   %323 = bitcast i8* %317 to i64*
-  %NullCheck6 = icmp ne i64* %323, null
-  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64* %323, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %324
 
 ; <label>:324                                     ; preds = %321
   store i64 %322, i64* %323, align 8
@@ -1286,15 +1368,15 @@ entry:
 ; <label>:338                                     ; preds = %333
   %339 = load i8*, i8** %arg0
   %340 = load i8*, i8** %arg1
-  %NullCheck136 = icmp ne i8* %340, null
-  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+  %NullCheck135 = icmp eq i8* %340, null
+  br i1 %NullCheck135, label %ThrowNullRef136, label %341
 
 ; <label>:341                                     ; preds = %338
   %342 = load i8, i8* %340, align 8
   %343 = zext i8 %342 to i32
   %344 = trunc i32 %343 to i8
-  %NullCheck138 = icmp ne i8* %339, null
-  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+  %NullCheck137 = icmp eq i8* %339, null
+  br i1 %NullCheck137, label %ThrowNullRef138, label %345
 
 ; <label>:345                                     ; preds = %341
   store i8 %344, i8* %339, align 8
@@ -1317,16 +1399,16 @@ entry:
   %357 = load i8*, i8** %arg0
   %358 = load i8*, i8** %arg1
   %359 = bitcast i8* %358 to i16*
-  %NullCheck140 = icmp ne i16* %359, null
-  br i1 %NullCheck140, label %360, label %ThrowNullRef139
+  %NullCheck139 = icmp eq i16* %359, null
+  br i1 %NullCheck139, label %ThrowNullRef140, label %360
 
 ; <label>:360                                     ; preds = %356
   %361 = load i16, i16* %359, align 8
   %362 = sext i16 %361 to i32
   %363 = bitcast i8* %357 to i16*
   %364 = trunc i32 %362 to i16
-  %NullCheck142 = icmp ne i16* %363, null
-  br i1 %NullCheck142, label %365, label %ThrowNullRef141
+  %NullCheck141 = icmp eq i16* %363, null
+  br i1 %NullCheck141, label %ThrowNullRef142, label %365
 
 ; <label>:365                                     ; preds = %360
   store i16 %364, i16* %363, align 8
@@ -1352,14 +1434,14 @@ entry:
   %378 = load i8*, i8** %arg0
   %379 = load i8*, i8** %arg1
   %380 = bitcast i8* %379 to i32*
-  %NullCheck144 = icmp ne i32* %380, null
-  br i1 %NullCheck144, label %381, label %ThrowNullRef143
+  %NullCheck143 = icmp eq i32* %380, null
+  br i1 %NullCheck143, label %ThrowNullRef144, label %381
 
 ; <label>:381                                     ; preds = %377
   %382 = load i32, i32* %380, align 8
   %383 = bitcast i8* %378 to i32*
-  %NullCheck146 = icmp ne i32* %383, null
-  br i1 %NullCheck146, label %384, label %ThrowNullRef145
+  %NullCheck145 = icmp eq i32* %383, null
+  br i1 %NullCheck145, label %ThrowNullRef146, label %384
 
 ; <label>:384                                     ; preds = %381
   store i32 %382, i32* %383, align 8
@@ -1384,14 +1466,14 @@ entry:
   %395 = load i8*, i8** %arg0
   %396 = load i8*, i8** %arg1
   %397 = bitcast i8* %396 to i64*
-  %NullCheck164 = icmp ne i64* %397, null
-  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+  %NullCheck163 = icmp eq i64* %397, null
+  br i1 %NullCheck163, label %ThrowNullRef164, label %398
 
 ; <label>:398                                     ; preds = %394
   %399 = load i64, i64* %397, align 8
   %400 = bitcast i8* %395 to i64*
-  %NullCheck166 = icmp ne i64* %400, null
-  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+  %NullCheck165 = icmp eq i64* %400, null
+  br i1 %NullCheck165, label %ThrowNullRef166, label %401
 
 ; <label>:401                                     ; preds = %398
   store i64 %399, i64* %400, align 8
@@ -1400,14 +1482,14 @@ entry:
   %404 = load i8*, i8** %arg1
   %405 = getelementptr inbounds i8, i8* %404, i64 8
   %406 = bitcast i8* %405 to i64*
-  %NullCheck168 = icmp ne i64* %406, null
-  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+  %NullCheck167 = icmp eq i64* %406, null
+  br i1 %NullCheck167, label %ThrowNullRef168, label %407
 
 ; <label>:407                                     ; preds = %401
   %408 = load i64, i64* %406, align 8
   %409 = bitcast i8* %403 to i64*
-  %NullCheck170 = icmp ne i64* %409, null
-  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+  %NullCheck169 = icmp eq i64* %409, null
+  br i1 %NullCheck169, label %ThrowNullRef170, label %410
 
 ; <label>:410                                     ; preds = %407
   store i64 %408, i64* %409, align 8
@@ -1437,14 +1519,14 @@ entry:
   %425 = load i8*, i8** %arg0
   %426 = load i8*, i8** %arg1
   %427 = bitcast i8* %426 to i64*
-  %NullCheck148 = icmp ne i64* %427, null
-  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+  %NullCheck147 = icmp eq i64* %427, null
+  br i1 %NullCheck147, label %ThrowNullRef148, label %428
 
 ; <label>:428                                     ; preds = %424
   %429 = load i64, i64* %427, align 8
   %430 = bitcast i8* %425 to i64*
-  %NullCheck150 = icmp ne i64* %430, null
-  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+  %NullCheck149 = icmp eq i64* %430, null
+  br i1 %NullCheck149, label %ThrowNullRef150, label %431
 
 ; <label>:431                                     ; preds = %428
   store i64 %429, i64* %430, align 8
@@ -1466,14 +1548,14 @@ entry:
   %441 = load i8*, i8** %arg0
   %442 = load i8*, i8** %arg1
   %443 = bitcast i8* %442 to i32*
-  %NullCheck152 = icmp ne i32* %443, null
-  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+  %NullCheck151 = icmp eq i32* %443, null
+  br i1 %NullCheck151, label %ThrowNullRef152, label %444
 
 ; <label>:444                                     ; preds = %440
   %445 = load i32, i32* %443, align 8
   %446 = bitcast i8* %441 to i32*
-  %NullCheck154 = icmp ne i32* %446, null
-  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+  %NullCheck153 = icmp eq i32* %446, null
+  br i1 %NullCheck153, label %ThrowNullRef154, label %447
 
 ; <label>:447                                     ; preds = %444
   store i32 %445, i32* %446, align 8
@@ -1495,16 +1577,16 @@ entry:
   %457 = load i8*, i8** %arg0
   %458 = load i8*, i8** %arg1
   %459 = bitcast i8* %458 to i16*
-  %NullCheck156 = icmp ne i16* %459, null
-  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+  %NullCheck155 = icmp eq i16* %459, null
+  br i1 %NullCheck155, label %ThrowNullRef156, label %460
 
 ; <label>:460                                     ; preds = %456
   %461 = load i16, i16* %459, align 8
   %462 = sext i16 %461 to i32
   %463 = bitcast i8* %457 to i16*
   %464 = trunc i32 %462 to i16
-  %NullCheck158 = icmp ne i16* %463, null
-  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+  %NullCheck157 = icmp eq i16* %463, null
+  br i1 %NullCheck157, label %ThrowNullRef158, label %465
 
 ; <label>:465                                     ; preds = %460
   store i16 %464, i16* %463, align 8
@@ -1525,15 +1607,15 @@ entry:
 ; <label>:474                                     ; preds = %470
   %475 = load i8*, i8** %arg0
   %476 = load i8*, i8** %arg1
-  %NullCheck160 = icmp ne i8* %476, null
-  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+  %NullCheck159 = icmp eq i8* %476, null
+  br i1 %NullCheck159, label %ThrowNullRef160, label %477
 
 ; <label>:477                                     ; preds = %474
   %478 = load i8, i8* %476, align 8
   %479 = zext i8 %478 to i32
   %480 = trunc i32 %479 to i8
-  %NullCheck162 = icmp ne i8* %475, null
-  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+  %NullCheck161 = icmp eq i8* %475, null
+  br i1 %NullCheck161, label %ThrowNullRef162, label %481
 
 ; <label>:481                                     ; preds = %477
   store i8 %480, i8* %475, align 8
@@ -1553,343 +1635,343 @@ ThrowNullRef:                                     ; preds = %308
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %312
+ThrowNullRef2:                                    ; preds = %312
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %315
+ThrowNullRef4:                                    ; preds = %315
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %321
+ThrowNullRef6:                                    ; preds = %321
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %271
+ThrowNullRef8:                                    ; preds = %271
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %275
+ThrowNullRef10:                                   ; preds = %275
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %278
+ThrowNullRef12:                                   ; preds = %278
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %284
+ThrowNullRef14:                                   ; preds = %284
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %287
+ThrowNullRef16:                                   ; preds = %287
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %293
+ThrowNullRef18:                                   ; preds = %293
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %298
+ThrowNullRef20:                                   ; preds = %298
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %303
+ThrowNullRef22:                                   ; preds = %303
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %243
+ThrowNullRef24:                                   ; preds = %243
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %247
+ThrowNullRef26:                                   ; preds = %247
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %250
+ThrowNullRef28:                                   ; preds = %250
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %256
+ThrowNullRef30:                                   ; preds = %256
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %259
+ThrowNullRef32:                                   ; preds = %259
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %265
+ThrowNullRef34:                                   ; preds = %265
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %217
+ThrowNullRef36:                                   ; preds = %217
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %221
+ThrowNullRef38:                                   ; preds = %221
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %224
+ThrowNullRef40:                                   ; preds = %224
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %230
+ThrowNullRef42:                                   ; preds = %230
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %233
+ThrowNullRef44:                                   ; preds = %233
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %238
+ThrowNullRef46:                                   ; preds = %238
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %200
+ThrowNullRef48:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %204
+ThrowNullRef50:                                   ; preds = %204
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %207
+ThrowNullRef52:                                   ; preds = %207
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %213
+ThrowNullRef54:                                   ; preds = %213
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %172
+ThrowNullRef56:                                   ; preds = %172
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %176
+ThrowNullRef58:                                   ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %179
+ThrowNullRef60:                                   ; preds = %179
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %185
+ThrowNullRef62:                                   ; preds = %185
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %190
+ThrowNullRef64:                                   ; preds = %190
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %195
+ThrowNullRef66:                                   ; preds = %195
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %153
+ThrowNullRef68:                                   ; preds = %153
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %157
+ThrowNullRef70:                                   ; preds = %157
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %160
+ThrowNullRef72:                                   ; preds = %160
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %166
+ThrowNullRef74:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %136
+ThrowNullRef76:                                   ; preds = %136
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %140
+ThrowNullRef78:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %143
+ThrowNullRef80:                                   ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %148
+ThrowNullRef82:                                   ; preds = %148
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %128
+ThrowNullRef84:                                   ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %132
+ThrowNullRef86:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %100
+ThrowNullRef88:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %104
+ThrowNullRef90:                                   ; preds = %104
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %107
+ThrowNullRef92:                                   ; preds = %107
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %113
+ThrowNullRef94:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %118
+ThrowNullRef96:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %123
+ThrowNullRef98:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %81
+ThrowNullRef100:                                  ; preds = %81
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef101:                                  ; preds = %85
+ThrowNullRef102:                                  ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef103:                                  ; preds = %88
+ThrowNullRef104:                                  ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef105:                                  ; preds = %94
+ThrowNullRef106:                                  ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef107:                                  ; preds = %64
+ThrowNullRef108:                                  ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef109:                                  ; preds = %68
+ThrowNullRef110:                                  ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef111:                                  ; preds = %71
+ThrowNullRef112:                                  ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef113:                                  ; preds = %76
+ThrowNullRef114:                                  ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef115:                                  ; preds = %56
+ThrowNullRef116:                                  ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef117:                                  ; preds = %60
+ThrowNullRef118:                                  ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef119:                                  ; preds = %37
+ThrowNullRef120:                                  ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef121:                                  ; preds = %41
+ThrowNullRef122:                                  ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef123:                                  ; preds = %46
+ThrowNullRef124:                                  ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef125:                                  ; preds = %51
+ThrowNullRef126:                                  ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef127:                                  ; preds = %27
+ThrowNullRef128:                                  ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef129:                                  ; preds = %31
+ThrowNullRef130:                                  ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef131:                                  ; preds = %19
+ThrowNullRef132:                                  ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef133:                                  ; preds = %22
+ThrowNullRef134:                                  ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef135:                                  ; preds = %338
+ThrowNullRef136:                                  ; preds = %338
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef137:                                  ; preds = %341
+ThrowNullRef138:                                  ; preds = %341
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef139:                                  ; preds = %356
+ThrowNullRef140:                                  ; preds = %356
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef141:                                  ; preds = %360
+ThrowNullRef142:                                  ; preds = %360
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef143:                                  ; preds = %377
+ThrowNullRef144:                                  ; preds = %377
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef145:                                  ; preds = %381
+ThrowNullRef146:                                  ; preds = %381
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef147:                                  ; preds = %424
+ThrowNullRef148:                                  ; preds = %424
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef149:                                  ; preds = %428
+ThrowNullRef150:                                  ; preds = %428
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef151:                                  ; preds = %440
+ThrowNullRef152:                                  ; preds = %440
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef153:                                  ; preds = %444
+ThrowNullRef154:                                  ; preds = %444
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef155:                                  ; preds = %456
+ThrowNullRef156:                                  ; preds = %456
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef157:                                  ; preds = %460
+ThrowNullRef158:                                  ; preds = %460
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef159:                                  ; preds = %474
+ThrowNullRef160:                                  ; preds = %474
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef161:                                  ; preds = %477
+ThrowNullRef162:                                  ; preds = %477
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef163:                                  ; preds = %394
+ThrowNullRef164:                                  ; preds = %394
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef165:                                  ; preds = %398
+ThrowNullRef166:                                  ; preds = %398
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef167:                                  ; preds = %401
+ThrowNullRef168:                                  ; preds = %401
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef169:                                  ; preds = %407
+ThrowNullRef170:                                  ; preds = %407
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1939,8 +2021,8 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
-  br i1 %NullCheck, label %22, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %ThrowNullRef, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
@@ -1948,8 +2030,8 @@ entry:
   store i32 %24, i32* %loc0
   %25 = load i32, i32* %loc0
   %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %26, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %27
 
 ; <label>:27                                      ; preds = %22
   %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
@@ -1971,7 +2053,7 @@ ThrowNullRef:                                     ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1989,8 +2071,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -2022,15 +2104,15 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2048,16 +2130,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
   %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
   store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %15
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
@@ -2072,8 +2154,8 @@ entry:
   %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
   %29 = ptrtoint i16 addrspace(1)* %28 to i64
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %19
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
@@ -2089,19 +2171,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2114,8 +2196,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
@@ -2128,7 +2210,7 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[loadElem]
+Failed to read AppDomain.PrepareDataForSetup[storeElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
@@ -2202,8 +2284,8 @@ entry:
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
-  br i1 %NullCheck24, label %27, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = load i64, i64 addrspace(1)* %26
@@ -2218,8 +2300,8 @@ entry:
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
-  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
   %41 = load i64, i64 addrspace(1)* %39
@@ -2236,8 +2318,8 @@ entry:
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
-  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
   %54 = load i64, i64 addrspace(1)* %52
@@ -2252,8 +2334,8 @@ entry:
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
   %67 = load i64, i64 addrspace(1)* %65
@@ -2270,8 +2352,8 @@ entry:
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
-  br i1 %NullCheck16, label %79, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
   %80 = load i64, i64 addrspace(1)* %78
@@ -2286,8 +2368,8 @@ entry:
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
-  br i1 %NullCheck18, label %92, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
   %93 = load i64, i64 addrspace(1)* %91
@@ -2304,8 +2386,8 @@ entry:
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
-  br i1 %NullCheck12, label %105, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = load i64, i64 addrspace(1)* %104
@@ -2320,8 +2402,8 @@ entry:
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
-  br i1 %NullCheck14, label %118, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
   %119 = load i64, i64 addrspace(1)* %117
@@ -2337,8 +2419,8 @@ entry:
 
 ; <label>:128                                     ; preds = %20
   %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
-  br i1 %NullCheck4, label %130, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %129, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %130
 
 ; <label>:130                                     ; preds = %128
   %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
@@ -2346,8 +2428,8 @@ entry:
   %133 = load i16, i16 addrspace(1)* %132, align 8
   %134 = zext i16 %133 to i32
   %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
-  br i1 %NullCheck6, label %136, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %135, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %136
 
 ; <label>:136                                     ; preds = %130
   %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
@@ -2360,8 +2442,8 @@ entry:
 
 ; <label>:143                                     ; preds = %136
   %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
-  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %144, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %145
 
 ; <label>:145                                     ; preds = %143
   %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
@@ -2369,8 +2451,8 @@ entry:
   %148 = load i16, i16 addrspace(1)* %147, align 8
   %149 = zext i16 %148 to i32
   %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %150, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %151
 
 ; <label>:151                                     ; preds = %145
   %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
@@ -2388,8 +2470,8 @@ entry:
 
 ; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
-  br i1 %NullCheck, label %163, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %ThrowNullRef, label %163
 
 ; <label>:163                                     ; preds = %161
   %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
@@ -2399,8 +2481,8 @@ entry:
 
 ; <label>:167                                     ; preds = %163
   %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
-  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %168, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %169
 
 ; <label>:169                                     ; preds = %167
   %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
@@ -2432,55 +2514,55 @@ ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %167
+ThrowNullRef2:                                    ; preds = %167
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %128
+ThrowNullRef4:                                    ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %130
+ThrowNullRef6:                                    ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %143
+ThrowNullRef8:                                    ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %145
+ThrowNullRef10:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %102
+ThrowNullRef12:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %105
+ThrowNullRef14:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %76
+ThrowNullRef16:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %79
+ThrowNullRef18:                                   ; preds = %79
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %50
+ThrowNullRef20:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %53
+ThrowNullRef22:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %24
+ThrowNullRef24:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %27
+ThrowNullRef26:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2503,15 +2585,15 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2519,16 +2601,16 @@ entry:
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
   store i32 %8, i32* %loc0
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
   %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
   store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
@@ -2546,16 +2628,16 @@ entry:
 
 ; <label>:23                                      ; preds = %64
   %24 = load i16*, i16** %loc3
-  %NullCheck12 = icmp ne i16* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i16* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
   store i32 %27, i32* %loc5
   %28 = load i16*, i16** %loc4
-  %NullCheck14 = icmp ne i16* %28, null
-  br i1 %NullCheck14, label %29, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %28, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = load i16, i16* %28, align 8
@@ -2620,15 +2702,15 @@ entry:
 
 ; <label>:67                                      ; preds = %64
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
-  br i1 %NullCheck8, label %69, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %68, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %69
 
 ; <label>:69                                      ; preds = %67
   %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
   %71 = load i32, i32 addrspace(1)* %70
   %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
-  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %73
 
 ; <label>:73                                      ; preds = %69
   %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
@@ -2645,31 +2727,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %67
+ThrowNullRef8:                                    ; preds = %67
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %69
+ThrowNullRef10:                                   ; preds = %69
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2710,14 +2792,14 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
   %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
@@ -2730,14 +2812,14 @@ entry:
 
 ; <label>:11                                      ; preds = %4
   %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
   %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
@@ -2749,14 +2831,14 @@ entry:
 
 ; <label>:22                                      ; preds = %16
   %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
   %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
-  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
-  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
@@ -2804,23 +2886,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2836,7 +2918,280 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[loadElem]
+Successfully read RuntimeType.IsAssignableFrom
+
+define i8 @RuntimeType.IsAssignableFrom(%System.RuntimeType addrspace(1)* %param0, %System.Type addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.RuntimeType addrspace(1)*
+  %arg1 = alloca %System.Type addrspace(1)*
+  %loc0 = alloca %System.RuntimeType addrspace(1)*
+  %loc1 = alloca %"System.Type[]" addrspace(1)*
+  %loc2 = alloca i32
+  store %System.RuntimeType addrspace(1)* %param0, %System.RuntimeType addrspace(1)** %this
+  store %System.Type addrspace(1)* %param1, %System.Type addrspace(1)** %arg1
+  %0 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %1 = icmp ne %System.Type addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i8 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %5 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %6 = bitcast %System.Type addrspace(1)* %4 to %System.Object addrspace(1)*
+  %7 = bitcast %System.RuntimeType addrspace(1)* %5 to %System.Object addrspace(1)*
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %6, %System.Object addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %3
+  ret i8 1
+
+; <label>:12                                      ; preds = %3
+  %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 152
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 32
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
+  %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
+  %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
+  store %System.RuntimeType addrspace(1)* %25, %System.RuntimeType addrspace(1)** %loc0
+  %26 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %27 = icmp eq %System.RuntimeType addrspace(1)* %26, null
+  br i1 %27, label %34, label %28
+
+; <label>:28                                      ; preds = %15
+  %29 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %30 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)*)*)(%System.RuntimeType addrspace(1)* %29, %System.RuntimeType addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+; <label>:34                                      ; preds = %15
+  %35 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %36 = call %System.Reflection.Emit.TypeBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Reflection.Emit.TypeBuilder addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %35)
+  %37 = icmp eq %System.Reflection.Emit.TypeBuilder addrspace(1)* %36, null
+  br i1 %37, label %139, label %38
+
+; <label>:38                                      ; preds = %34
+  %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %42
+
+; <label>:42                                      ; preds = %38
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 152
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 40
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
+  %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
+  %53 = zext i8 %52 to i32
+  %54 = icmp eq i32 %53, 0
+  br i1 %54, label %56, label %55
+
+; <label>:55                                      ; preds = %42
+  ret i8 1
+
+; <label>:56                                      ; preds = %42
+  %57 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %58 = bitcast %System.RuntimeType addrspace(1)* %57 to %System.Type addrspace(1)*
+  %59 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %58)
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %64 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.Type addrspace(1)* %63, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = bitcast %System.RuntimeType addrspace(1)* %64 to %System.Type addrspace(1)*
+  %67 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %63, %System.Type addrspace(1)* %66)
+  %68 = zext i8 %67 to i32
+  %69 = trunc i32 %68 to i8
+  ret i8 %69
+
+; <label>:70                                      ; preds = %56
+  %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
+  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %73
+
+; <label>:73                                      ; preds = %70
+  %74 = load i64, i64 addrspace(1)* %72
+  %75 = add i64 %74, 128
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = add i64 %77, 0
+  %79 = inttoptr i64 %78 to i64*
+  %80 = load i64, i64* %79
+  %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
+  %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
+  %83 = call i8 %82(%System.Type addrspace(1)* %81)
+  %84 = zext i8 %83 to i32
+  %85 = icmp eq i32 %84, 0
+  br i1 %85, label %139, label %86
+
+; <label>:86                                      ; preds = %73
+  %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
+  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %89
+
+; <label>:89                                      ; preds = %86
+  %90 = load i64, i64 addrspace(1)* %88
+  %91 = add i64 %90, 128
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = add i64 %93, 24
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
+  %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
+  %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
+  store %"System.Type[]" addrspace(1)* %99, %"System.Type[]" addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %129
+
+; <label>:100                                     ; preds = %132
+  %101 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %102 = load i32, i32* %loc2
+  %NullCheck11 = icmp eq %"System.Type[]" addrspace(1)* %101, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %103
+
+; <label>:103                                     ; preds = %100
+  %104 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 1
+  %105 = load i32, i32 addrspace(1)* %104
+  %106 = zext i32 %105 to i64
+  %107 = zext i32 %102 to i64
+  %BoundsCheck = icmp uge i64 %107, %106
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %108
+
+; <label>:108                                     ; preds = %103
+  %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
+  %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
+  %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
+  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %113
+
+; <label>:113                                     ; preds = %108
+  %114 = load i64, i64 addrspace(1)* %112
+  %115 = add i64 %114, 152
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = add i64 %117, 56
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
+  %123 = zext i8 %122 to i32
+  %124 = icmp ne i32 %123, 0
+  br i1 %124, label %126, label %125
+
+; <label>:125                                     ; preds = %113
+  ret i8 0
+
+; <label>:126                                     ; preds = %113
+  %127 = load i32, i32* %loc2
+  %128 = add i32 %127, 1
+  store i32 %128, i32* %loc2
+  br label %129
+
+; <label>:129                                     ; preds = %89, %126
+  %130 = load i32, i32* %loc2
+  %131 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %NullCheck9 = icmp eq %"System.Type[]" addrspace(1)* %131, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %132
+
+; <label>:132                                     ; preds = %129
+  %133 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %131, i32 0, i32 1
+  %134 = load i32, i32 addrspace(1)* %133
+  %135 = zext i32 %134 to i64
+  %136 = trunc i64 %135 to i32
+  %137 = icmp slt i32 %130, %136
+  br i1 %137, label %100, label %138
+
+; <label>:138                                     ; preds = %132
+  ret i8 1
+
+; <label>:139                                     ; preds = %34, %73
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %129
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %103
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -2893,7 +3248,7 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElem]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -2904,8 +3259,8 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -2997,8 +3352,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
@@ -3059,8 +3414,8 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -3087,8 +3442,8 @@ entry:
 
 ; <label>:17                                      ; preds = %5, %11
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
@@ -3097,8 +3452,8 @@ entry:
 
 ; <label>:22                                      ; preds = %1, %11
   %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
@@ -3109,11 +3464,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %17
+ThrowNullRef2:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %22
+ThrowNullRef4:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3167,15 +3522,15 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
   %15 = load i32, i32 addrspace(1)* %14
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
@@ -3198,7 +3553,7 @@ ThrowNullRef:                                     ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef2:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3232,8 +3587,8 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
@@ -3312,8 +3667,8 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -3327,8 +3682,8 @@ entry:
 ; <label>:5                                       ; preds = %43
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %7 = load i32, i32* %loc1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck6, label %8, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
@@ -3366,8 +3721,8 @@ entry:
 ; <label>:32                                      ; preds = %21, %25
   %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
   %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
-  br i1 %NullCheck8, label %35, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = trunc i32 %34 to i16
@@ -3380,8 +3735,8 @@ entry:
 ; <label>:40                                      ; preds = %1, %35
   %41 = load i32, i32* %loc1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
-  br i1 %NullCheck2, label %43, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %42, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
@@ -3392,8 +3747,8 @@ entry:
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
   %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
-  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
   %51 = load i64, i64 addrspace(1)* %49
@@ -3412,19 +3767,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %40
+ThrowNullRef2:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %47
+ThrowNullRef4:                                    ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %5
+ThrowNullRef6:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %32
+ThrowNullRef8:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3467,8 +3822,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
@@ -3492,11 +3847,391 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(i16* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store i16* %param0, i16** %arg0
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load i32, i32* %arg3
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %42, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %37, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg2
+  %13 = load i32, i32* %arg3
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %37, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %24 = load i32, i32* %arg2
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load i16*, i16** %arg0
+  %35 = load i32, i32* %arg3
+  %36 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %36, i16* %34, i32 %35)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:37                                      ; preds = %5, %16
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %39)
+  %41 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41, %System.String addrspace(1)* %38, %System.String addrspace(1)* %40)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41) #0
+  unreachable
+
+; <label>:42                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
-Failed to read StringBuilder.ToString[loadElemA]
+Successfully read StringBuilder.ToString
+
+define %System.String addrspace(1)* @StringBuilder.ToString(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i16*
+  %loc3 = alloca %"System.Char[]" addrspace(1)*
+  %loc4 = alloca i32
+  %loc5 = alloca i32
+  %loc6 = alloca i16 addrspace(1)*
+  %loc7 = alloca %System.String addrspace(1)*
+  %loc8 = alloca %"System.Char[]" addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %0)
+  %2 = icmp ne i32 %1, 0
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %4
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %6)
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %7)
+  store %System.String addrspace(1)* %8, %System.String addrspace(1)** %loc0
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.Text.StringBuilder addrspace(1)* %9, %System.Text.StringBuilder addrspace(1)** %loc1
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  store %System.String addrspace(1)* %10, %System.String addrspace(1)** %loc7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc7
+  %12 = ptrtoint %System.String addrspace(1)* %11 to i64
+  %13 = icmp eq i64 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %5
+  %15 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %16 = sext i32 %15 to i64
+  %17 = add i64 %12, %16
+  br label %18
+
+; <label>:18                                      ; preds = %5, %14
+  %19 = phi i64 [ %12, %5 ], [ %17, %14 ]
+  %20 = inttoptr i64 %19 to i16*
+  store i16* %20, i16** %loc2
+  br label %21
+
+; <label>:21                                      ; preds = %98, %18
+  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %22, null
+  br i1 %NullCheck, label %ThrowNullRef, label %23
+
+; <label>:23                                      ; preds = %21
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 3
+  %25 = load i32, i32 addrspace(1)* %24, align 8
+  %26 = icmp sle i32 %25, 0
+  br i1 %26, label %96, label %27
+
+; <label>:27                                      ; preds = %23
+  %28 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %28, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %29
+
+; <label>:29                                      ; preds = %27
+  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %28, i32 0, i32 1
+  %31 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %30, align 8
+  store %"System.Char[]" addrspace(1)* %31, %"System.Char[]" addrspace(1)** %loc3
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %33
+
+; <label>:33                                      ; preds = %29
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  store i32 %35, i32* %loc4
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  %39 = load i32, i32 addrspace(1)* %38, align 8
+  store i32 %39, i32* %loc5
+  %40 = load i32, i32* %loc5
+  %41 = load i32, i32* %loc4
+  %42 = add i32 %40, %41
+  %43 = zext i32 %42 to i64
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %45
+
+; <label>:45                                      ; preds = %37
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = sext i32 %47 to i64
+  %49 = icmp sgt i64 %43, %48
+  br i1 %49, label %91, label %50
+
+; <label>:50                                      ; preds = %45
+  %51 = load i32, i32* %loc5
+  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %52, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %53
+
+; <label>:53                                      ; preds = %50
+  %54 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %52, i32 0, i32 1
+  %55 = load i32, i32 addrspace(1)* %54
+  %56 = zext i32 %55 to i64
+  %57 = trunc i64 %56 to i32
+  %58 = icmp ugt i32 %51, %57
+  br i1 %58, label %91, label %59
+
+; <label>:59                                      ; preds = %53
+  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  store %"System.Char[]" addrspace(1)* %60, %"System.Char[]" addrspace(1)** %loc8
+  %61 = icmp eq %"System.Char[]" addrspace(1)* %60, null
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %63, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %64
+
+; <label>:64                                      ; preds = %62
+  %65 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %63, i32 0, i32 1
+  %66 = load i32, i32 addrspace(1)* %65
+  %67 = zext i32 %66 to i64
+  %68 = trunc i64 %67 to i32
+  %69 = icmp ne i32 %68, 0
+  br i1 %69, label %71, label %70
+
+; <label>:70                                      ; preds = %59, %64
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:71                                      ; preds = %64
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %73
+
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %BoundsCheck = icmp uge i64 0, %76
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %77
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %78, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:79                                      ; preds = %70, %77
+  %80 = load i16*, i16** %loc2
+  %81 = load i32, i32* %loc4
+  %82 = sext i32 %81 to i64
+  %83 = mul i64 %82, 2
+  %84 = bitcast i16* %80 to i8*
+  %85 = getelementptr inbounds i8, i8* %84, i64 %83
+  %86 = load i16 addrspace(1)*, i16 addrspace(1)** %loc6
+  %87 = ptrtoint i16 addrspace(1)* %86 to i64
+  %88 = load i32, i32* %loc5
+  %89 = bitcast i8* %85 to i16*
+  %90 = inttoptr i64 %87 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %89, i16* %90, i32 %88)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %96
+
+; <label>:91                                      ; preds = %45, %53
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %94 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %93)
+  %95 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95, %System.String addrspace(1)* %92, %System.String addrspace(1)* %94)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95) #0
+  unreachable
+
+; <label>:96                                      ; preds = %23, %79
+  %97 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %97, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %98
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %97, i32 0, i32 2
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  store %System.Text.StringBuilder addrspace(1)* %100, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %102 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %102, label %21, label %103
+
+; <label>:103                                     ; preds = %98
+  store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc7
+  %104 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  ret %System.String addrspace(1)* %104
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method StringBuilder::get_Length using LLILCJit
+Successfully read StringBuilder.get_Length
+
+define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
+Successfully read RuntimeHelpers.get_OffsetToStringData
+
+define i32 @RuntimeHelpers.get_OffsetToStringData() {
+entry:
+  ret i32 12
+}
+
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
 Successfully read CultureData.CreateCultureData
 
@@ -3514,23 +4249,23 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
   store i8 %4, i8 addrspace(1)* %6
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
@@ -3549,11 +4284,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3566,50 +4301,50 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
   store i32 -1, i32 addrspace(1)* %2
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
   store i32 -1, i32 addrspace(1)* %8
   %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
   store i32 -1, i32 addrspace(1)* %14
   %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
   store i32 -1, i32 addrspace(1)* %17
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
@@ -3623,27 +4358,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3675,7 +4410,136 @@ Failed to read Dictionary`2.Insert[non-const derefAddress]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
 Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
-Failed to read HashHelpers.GetPrime[loadElem]
+Successfully read HashHelpers.GetPrime
+
+define i32 @HashHelpers.GetPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %6, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5, %System.String addrspace(1)* %4)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5) #0
+  unreachable
+
+; <label>:6                                       ; preds = %entry
+  store i32 0, i32* %loc0
+  br label %29
+
+; <label>:7                                       ; preds = %35
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 1296
+  %10 = addrspacecast i8 addrspace(1)* %9 to %"System.Int32[]" addrspace(1)**
+  %11 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %10
+  %12 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Int32[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = zext i32 %15 to i64
+  %17 = zext i32 %12 to i64
+  %BoundsCheck = icmp uge i64 %17, %16
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 3, i32 %12
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  store i32 %20, i32* %loc1
+  %21 = load i32, i32* %loc1
+  %22 = load i32, i32* %arg0
+  %23 = icmp slt i32 %21, %22
+  br i1 %23, label %26, label %24
+
+; <label>:24                                      ; preds = %18
+  %25 = load i32, i32* %loc1
+  ret i32 %25
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %loc0
+  %28 = add i32 %27, 1
+  store i32 %28, i32* %loc0
+  br label %29
+
+; <label>:29                                      ; preds = %6, %26
+  %30 = load i32, i32* %loc0
+  %31 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %32 = getelementptr inbounds i8, i8 addrspace(1)* %31, i64 1296
+  %33 = addrspacecast i8 addrspace(1)* %32 to %"System.Int32[]" addrspace(1)**
+  %34 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %33
+  %NullCheck = icmp eq %"System.Int32[]" addrspace(1)* %34, null
+  br i1 %NullCheck, label %ThrowNullRef, label %35
+
+; <label>:35                                      ; preds = %29
+  %36 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %34, i32 0, i32 1
+  %37 = load i32, i32 addrspace(1)* %36
+  %38 = zext i32 %37 to i64
+  %39 = trunc i64 %38 to i32
+  %40 = icmp slt i32 %30, %39
+  br i1 %40, label %7, label %41
+
+; <label>:41                                      ; preds = %35
+  %42 = load i32, i32* %arg0
+  %43 = or i32 %42, 1
+  store i32 %43, i32* %loc2
+  br label %59
+
+; <label>:44                                      ; preds = %59
+  %45 = load i32, i32* %loc2
+  %46 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %45)
+  %47 = zext i8 %46 to i32
+  %48 = icmp eq i32 %47, 0
+  br i1 %48, label %56, label %49
+
+; <label>:49                                      ; preds = %44
+  %50 = load i32, i32* %loc2
+  %51 = sub i32 %50, 1
+  %52 = srem i32 %51, 101
+  %53 = icmp eq i32 %52, 0
+  br i1 %53, label %56, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = load i32, i32* %loc2
+  ret i32 %55
+
+; <label>:56                                      ; preds = %44, %49
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %57, 2
+  store i32 %58, i32* %loc2
+  br label %59
+
+; <label>:59                                      ; preds = %41, %56
+  %60 = load i32, i32* %loc2
+  %61 = icmp slt i32 %60, 2147483647
+  br i1 %61, label %44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load i32, i32* %arg0
+  ret i32 %63
+
+ThrowNullRef:                                     ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
 Successfully read GenericEqualityComparer`1.GetHashCode
 
@@ -3694,14 +4558,14 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
   %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load i64, i64 addrspace(1)* %7
@@ -3720,7 +4584,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3750,8 +4614,8 @@ entry:
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
@@ -3796,8 +4660,8 @@ entry:
   %35 = bitcast i16* %34 to i8*
   %36 = getelementptr inbounds i8, i8* %35, i64 2
   %37 = bitcast i8* %36 to i16*
-  %NullCheck4 = icmp ne i16* %37, null
-  br i1 %NullCheck4, label %38, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %37, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %38
 
 ; <label>:38                                      ; preds = %27
   %39 = load i16, i16* %37, align 8
@@ -3824,8 +4688,8 @@ entry:
 
 ; <label>:54                                      ; preds = %22, %43
   %55 = load i16*, i16** %loc4
-  %NullCheck2 = icmp ne i16* %55, null
-  br i1 %NullCheck2, label %56, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i16* %55, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %56
 
 ; <label>:56                                      ; preds = %54
   %57 = load i16, i16* %55, align 8
@@ -3850,11 +4714,11 @@ ThrowNullRef:                                     ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %54
+ThrowNullRef2:                                    ; preds = %54
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %27
+ThrowNullRef4:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3871,8 +4735,8 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -3907,8 +4771,8 @@ entry:
 
 ; <label>:26                                      ; preds = %19
   %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
-  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %28
 
 ; <label>:28                                      ; preds = %26
   %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
@@ -3920,7 +4784,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3972,8 +4836,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
@@ -3984,26 +4848,26 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
-  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
@@ -4014,8 +4878,8 @@ entry:
 ; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
@@ -4024,8 +4888,8 @@ entry:
 
 ; <label>:25                                      ; preds = %1, %16, %23
   %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
-  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
@@ -4036,27 +4900,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %20
+ThrowNullRef10:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4069,8 +4933,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -4081,8 +4945,8 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
@@ -4091,8 +4955,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1, %8
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
@@ -4103,11 +4967,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4128,24 +4992,24 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   store i32 %3, i32* %loc0
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
   %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
   store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck4, label %9, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
@@ -4164,15 +5028,15 @@ entry:
 ; <label>:18                                      ; preds = %70
   %19 = load i16*, i16** %loc3
   %20 = bitcast i16* %19 to i64*
-  %NullCheck10 = icmp ne i64* %20, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %20, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = load i64, i64* %20, align 8
   %23 = load i16*, i16** %loc4
   %24 = bitcast i16* %23 to i64*
-  %NullCheck12 = icmp ne i64* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = load i64, i64* %24, align 8
@@ -4188,8 +5052,8 @@ entry:
   %31 = bitcast i16* %30 to i8*
   %32 = getelementptr inbounds i8, i8* %31, i64 8
   %33 = bitcast i8* %32 to i64*
-  %NullCheck14 = icmp ne i64* %33, null
-  br i1 %NullCheck14, label %34, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = load i64, i64* %33, align 8
@@ -4197,8 +5061,8 @@ entry:
   %37 = bitcast i16* %36 to i8*
   %38 = getelementptr inbounds i8, i8* %37, i64 8
   %39 = bitcast i8* %38 to i64*
-  %NullCheck16 = icmp ne i64* %39, null
-  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %40
 
 ; <label>:40                                      ; preds = %34
   %41 = load i64, i64* %39, align 8
@@ -4214,8 +5078,8 @@ entry:
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %NullCheck18 = icmp ne i64* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = load i64, i64* %48, align 8
@@ -4223,8 +5087,8 @@ entry:
   %52 = bitcast i16* %51 to i8*
   %53 = getelementptr inbounds i8, i8* %52, i64 16
   %54 = bitcast i8* %53 to i64*
-  %NullCheck20 = icmp ne i64* %54, null
-  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64* %54, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %55
 
 ; <label>:55                                      ; preds = %49
   %56 = load i64, i64* %54, align 8
@@ -4262,15 +5126,15 @@ entry:
 ; <label>:74                                      ; preds = %95
   %75 = load i16*, i16** %loc3
   %76 = bitcast i16* %75 to i32*
-  %NullCheck6 = icmp ne i32* %76, null
-  br i1 %NullCheck6, label %77, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32* %76, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %77
 
 ; <label>:77                                      ; preds = %74
   %78 = load i32, i32* %76, align 8
   %79 = load i16*, i16** %loc4
   %80 = bitcast i16* %79 to i32*
-  %NullCheck8 = icmp ne i32* %80, null
-  br i1 %NullCheck8, label %81, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i32* %80, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %81
 
 ; <label>:81                                      ; preds = %77
   %82 = load i32, i32* %80, align 8
@@ -4318,43 +5182,43 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %74
+ThrowNullRef6:                                    ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %77
+ThrowNullRef8:                                    ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %29
+ThrowNullRef14:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %34
+ThrowNullRef16:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4376,8 +5240,8 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load i64, i64 addrspace(1)* %4
@@ -4389,8 +5253,8 @@ entry:
   %12 = load i64, i64* %11
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %5
   %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
@@ -4399,8 +5263,8 @@ entry:
   %18 = load i8, i8* %arg2
   %19 = zext i8 %18 to i32
   %20 = trunc i32 %19 to i8
-  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %15
   %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
@@ -4411,11 +5275,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4442,8 +5306,8 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
@@ -4466,16 +5330,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
   %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = load i64, i64 addrspace(1)* %19
@@ -4500,8 +5364,8 @@ entry:
 ; <label>:35                                      ; preds = %30
   %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
@@ -4514,8 +5378,8 @@ entry:
 
 ; <label>:42                                      ; preds = %1, %38
   %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
-  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
@@ -4526,19 +5390,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %35
+ThrowNullRef2:                                    ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %42
+ThrowNullRef8:                                    ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4551,14 +5415,14 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
@@ -4570,7 +5434,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4583,8 +5447,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
@@ -4613,51 +5477,51 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
   %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
   %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
   %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
   %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
-  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
   store i64 %21, i64 addrspace(1)* %23
   %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %25 = load i64, i64* %loc0
-  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
@@ -4668,27 +5532,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %22
+ThrowNullRef12:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4701,8 +5565,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
@@ -4713,19 +5577,19 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
@@ -4734,8 +5598,8 @@ entry:
 
 ; <label>:15                                      ; preds = %1, %13
   %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
@@ -4746,19 +5610,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %15
+ThrowNullRef8:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4771,8 +5635,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -4831,8 +5695,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
@@ -4882,8 +5746,8 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
-  br i1 %NullCheck, label %17, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %ThrowNullRef, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
@@ -4894,15 +5758,15 @@ entry:
 
 ; <label>:22                                      ; preds = %17
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
-  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
   %26 = load i32, i32 addrspace(1)* %25
   %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
-  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %27, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
@@ -4925,8 +5789,8 @@ entry:
 ; <label>:40                                      ; preds = %17
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
-  br i1 %NullCheck6, label %43, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %41, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
@@ -4938,34 +5802,17 @@ ThrowNullRef:                                     ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %24
+ThrowNullRef4:                                    ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %40
+ThrowNullRef6:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
-}
-
-INFO:  jitting method Object::ReferenceEquals using LLILCJit
-Successfully read Object.ReferenceEquals
-
-define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
-entry:
-  %arg0 = alloca %System.Object addrspace(1)*
-  %arg1 = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
-  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
-  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = icmp eq %System.Object addrspace(1)* %0, %1
-  %3 = sext i1 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
 }
 
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
@@ -4978,21 +5825,21 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
   %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
-  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
@@ -5007,28 +5854,28 @@ entry:
 ; <label>:13                                      ; preds = %8, %12
   %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
   %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
   %21 = load i32, i32 addrspace(1)* %20, align 8
   %22 = add i32 %21, 1
-  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
   store i32 %22, i32 addrspace(1)* %24
   %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
@@ -5039,27 +5886,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5077,7 +5924,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::Setup using LLILCJit
-Failed to read AppDomain.Setup[loadElem]
+Failed to read AppDomain.Setup[unbox]
 INFO:  jitting method Thread::GetDomain using LLILCJit
 Successfully read Thread.GetDomain
 
@@ -5108,8 +5955,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
@@ -5122,14 +5969,14 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
   %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
@@ -5141,11 +5988,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5173,8 +6020,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -5189,7 +6036,328 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
 Failed to read KeyCollection.System.Collections.Generic.IEnumerable<TKey>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Successfully read Enumerator.MoveNext
+
+define i8 @Enumerator.MoveNext(%"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.RuntimeTypeHandle* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*
+  %"$TypeArg" = alloca %System.RuntimeTypeHandle*
+  store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
+  %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 8
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %76, label %12
+
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
+  br label %76
+
+; <label>:13                                      ; preds = %85
+  %14 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck19 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %15
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, i32 0, i32 0
+  %17 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %16, align 8
+  %NullCheck21 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, i32 0, i32 2
+  %20 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %19, align 8
+  %21 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck23 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %22
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, i32 0, i32 2
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %NullCheck25 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 3, i32 %24
+  %NullCheck27 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %32
+
+; <label>:32                                      ; preds = %30
+  %33 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, i32 0, i32 2
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = icmp slt i32 %34, 0
+  br i1 %35, label %68, label %36
+
+; <label>:36                                      ; preds = %32
+  %37 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %38 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck29 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %39
+
+; <label>:39                                      ; preds = %36
+  %40 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, i32 0, i32 0
+  %41 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %40, align 8
+  %NullCheck31 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, i32 0, i32 2
+  %44 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %43, align 8
+  %45 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck33 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, i32 0, i32 2
+  %48 = load i32, i32 addrspace(1)* %47, align 8
+  %NullCheck35 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %49
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = zext i32 %51 to i64
+  %53 = zext i32 %48 to i64
+  %BoundsCheck37 = icmp uge i64 %53, %52
+  br i1 %BoundsCheck37, label %ThrowIndexOutOfRange38, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 3, i32 %48
+  %NullCheck39 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %56
+
+; <label>:56                                      ; preds = %54
+  %57 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, i32 0, i32 0
+  %58 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck41 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %59
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %60, %System.__Canon addrspace(1)* %58)
+  %61 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck43 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  %64 = load i32, i32 addrspace(1)* %63, align 8
+  %65 = add i32 %64, 1
+  %NullCheck45 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  store i32 %65, i32 addrspace(1)* %67
+  ret i8 1
+
+; <label>:68                                      ; preds = %32
+  %69 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck47 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %73 = add i32 %72, 1
+  %NullCheck49 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %74
+
+; <label>:74                                      ; preds = %70
+  %75 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  store i32 %73, i32 addrspace(1)* %75
+  br label %76
+
+; <label>:76                                      ; preds = %8, %12, %74
+  %77 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %78
+
+; <label>:78                                      ; preds = %76
+  %79 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, i32 0, i32 2
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck7 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %82
+
+; <label>:82                                      ; preds = %78
+  %83 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, i32 0, i32 0
+  %84 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %83, align 8
+  %NullCheck9 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %85
+
+; <label>:85                                      ; preds = %82
+  %86 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, i32 0, i32 7
+  %87 = load i32, i32 addrspace(1)* %86, align 8
+  %88 = icmp ult i32 %80, %87
+  br i1 %88, label %13, label %89
+
+; <label>:89                                      ; preds = %85
+  %90 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %91 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck11 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %92
+
+; <label>:92                                      ; preds = %89
+  %93 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, i32 0, i32 0
+  %94 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck13 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %95
+
+; <label>:95                                      ; preds = %92
+  %96 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, i32 0, i32 7
+  %97 = load i32, i32 addrspace(1)* %96, align 8
+  %98 = add i32 %97, 1
+  %NullCheck15 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %99
+
+; <label>:99                                      ; preds = %95
+  %100 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, i32 0, i32 2
+  store i32 %98, i32 addrspace(1)* %100
+  %101 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck17 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %102
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %103, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %92
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef22:                                   ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef24:                                   ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef26:                                   ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef28:                                   ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef30:                                   ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef32:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef34:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef36:                                   ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange38:                           ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef40:                                   ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef42:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef44:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef46:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef48:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef50:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -5200,8 +6368,8 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -5232,9 +6400,9 @@ Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
 Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
-Failed to read String.MakeSeparatorList[loadElemA]
+Failed to read String.MakeSeparatorList[storeElem]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
-Failed to read String.InternalSplitKeepEmptyEntries[loadElem]
+Failed to read String.InternalSplitKeepEmptyEntries[storeElem]
 INFO:  jitting method Path::IsRelative using LLILCJit
 Successfully read Path.IsRelative
 
@@ -5243,8 +6411,8 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -5254,8 +6422,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
@@ -5271,8 +6439,8 @@ entry:
 
 ; <label>:17                                      ; preds = %7
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
@@ -5288,8 +6456,8 @@ entry:
 
 ; <label>:29                                      ; preds = %19
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %31
 
 ; <label>:31                                      ; preds = %29
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
@@ -5300,8 +6468,8 @@ entry:
 
 ; <label>:36                                      ; preds = %31
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
-  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %37, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
@@ -5312,8 +6480,8 @@ entry:
 
 ; <label>:43                                      ; preds = %31, %38
   %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
-  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %45
 
 ; <label>:45                                      ; preds = %43
   %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
@@ -5324,8 +6492,8 @@ entry:
 
 ; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %50
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
@@ -5336,8 +6504,8 @@ entry:
 
 ; <label>:57                                      ; preds = %1, %7, %19, %45, %52
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
-  br i1 %NullCheck14, label %59, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %59
 
 ; <label>:59                                      ; preds = %57
   %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
@@ -5347,8 +6515,8 @@ entry:
 
 ; <label>:63                                      ; preds = %59
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
@@ -5359,8 +6527,8 @@ entry:
 
 ; <label>:70                                      ; preds = %65
   %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
-  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.String addrspace(1)* %71, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %72
 
 ; <label>:72                                      ; preds = %70
   %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
@@ -5379,39 +6547,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %17
+ThrowNullRef4:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %29
+ThrowNullRef6:                                    ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %36
+ThrowNullRef8:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %43
+ThrowNullRef10:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %50
+ThrowNullRef12:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %57
+ThrowNullRef14:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %63
+ThrowNullRef16:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %70
+ThrowNullRef18:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5419,7 +6587,293 @@ ThrowNullRef17:                                   ; preds = %70
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
-Failed to read String.TrimHelper[loadElem]
+Successfully read String.TrimHelper
+
+define %System.String addrspace(1)* @String.TrimHelper(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i16
+  %loc4 = alloca i32
+  %loc5 = alloca i16
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = sub i32 %3, 1
+  store i32 %4, i32* %loc0
+  store i32 0, i32* %loc1
+  %5 = load i32, i32* %arg2
+  %6 = icmp eq i32 %5, 1
+  br i1 %6, label %62, label %7
+
+; <label>:7                                       ; preds = %1
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:8                                       ; preds = %58
+  store i32 0, i32* %loc2
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load i32, i32* %loc1
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2, i32 %10
+  %13 = load i16, i16 addrspace(1)* %12
+  %14 = zext i16 %13 to i32
+  %15 = trunc i32 %14 to i16
+  store i16 %15, i16* %loc3
+  store i32 0, i32* %loc2
+  br label %34
+
+; <label>:16                                      ; preds = %37
+  %17 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %18 = load i32, i32* %loc2
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %17, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %19
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = zext i32 %18 to i64
+  %BoundsCheck = icmp uge i64 %23, %22
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %24
+
+; <label>:24                                      ; preds = %19
+  %25 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 3, i32 %18
+  %26 = load i16, i16 addrspace(1)* %25, align 8
+  %27 = zext i16 %26 to i32
+  %28 = load i16, i16* %loc3
+  %29 = zext i16 %28 to i32
+  %30 = icmp eq i32 %27, %29
+  br i1 %30, label %43, label %31
+
+; <label>:31                                      ; preds = %24
+  %32 = load i32, i32* %loc2
+  %33 = add i32 %32, 1
+  store i32 %33, i32* %loc2
+  br label %34
+
+; <label>:34                                      ; preds = %11, %31
+  %35 = load i32, i32* %loc2
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = icmp slt i32 %35, %41
+  br i1 %42, label %16, label %43
+
+; <label>:43                                      ; preds = %24, %37
+  %44 = load i32, i32* %loc2
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %45, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp eq i32 %44, %50
+  br i1 %51, label %62, label %52
+
+; <label>:52                                      ; preds = %46
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %7, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %57, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %58
+
+; <label>:58                                      ; preds = %55
+  %59 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %60 = load i32, i32 addrspace(1)* %59
+  %61 = icmp slt i32 %56, %60
+  br i1 %61, label %8, label %62
+
+; <label>:62                                      ; preds = %1, %46, %58
+  %63 = load i32, i32* %arg2
+  %64 = icmp eq i32 %63, 0
+  br i1 %64, label %122, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %66, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %67
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %66, i32 0, i32 1
+  %69 = load i32, i32 addrspace(1)* %68
+  %70 = sub i32 %69, 1
+  store i32 %70, i32* %loc0
+  br label %118
+
+; <label>:71                                      ; preds = %118
+  store i32 0, i32* %loc4
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %73 = load i32, i32* %loc0
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %74
+
+; <label>:74                                      ; preds = %71
+  %75 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 2, i32 %73
+  %76 = load i16, i16 addrspace(1)* %75
+  %77 = zext i16 %76 to i32
+  %78 = trunc i32 %77 to i16
+  store i16 %78, i16* %loc5
+  store i32 0, i32* %loc4
+  br label %97
+
+; <label>:79                                      ; preds = %100
+  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %81 = load i32, i32* %loc4
+  %NullCheck19 = icmp eq %"System.Char[]" addrspace(1)* %80, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
+
+; <label>:82                                      ; preds = %79
+  %83 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 1
+  %84 = load i32, i32 addrspace(1)* %83
+  %85 = zext i32 %84 to i64
+  %86 = zext i32 %81 to i64
+  %BoundsCheck21 = icmp uge i64 %86, %85
+  br i1 %BoundsCheck21, label %ThrowIndexOutOfRange22, label %87
+
+; <label>:87                                      ; preds = %82
+  %88 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 3, i32 %81
+  %89 = load i16, i16 addrspace(1)* %88, align 8
+  %90 = zext i16 %89 to i32
+  %91 = load i16, i16* %loc5
+  %92 = zext i16 %91 to i32
+  %93 = icmp eq i32 %90, %92
+  br i1 %93, label %106, label %94
+
+; <label>:94                                      ; preds = %87
+  %95 = load i32, i32* %loc4
+  %96 = add i32 %95, 1
+  store i32 %96, i32* %loc4
+  br label %97
+
+; <label>:97                                      ; preds = %74, %94
+  %98 = load i32, i32* %loc4
+  %99 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck15 = icmp eq %"System.Char[]" addrspace(1)* %99, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %100
+
+; <label>:100                                     ; preds = %97
+  %101 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %99, i32 0, i32 1
+  %102 = load i32, i32 addrspace(1)* %101
+  %103 = zext i32 %102 to i64
+  %104 = trunc i64 %103 to i32
+  %105 = icmp slt i32 %98, %104
+  br i1 %105, label %79, label %106
+
+; <label>:106                                     ; preds = %87, %100
+  %107 = load i32, i32* %loc4
+  %108 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck17 = icmp eq %"System.Char[]" addrspace(1)* %108, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %109
+
+; <label>:109                                     ; preds = %106
+  %110 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %108, i32 0, i32 1
+  %111 = load i32, i32 addrspace(1)* %110
+  %112 = zext i32 %111 to i64
+  %113 = trunc i64 %112 to i32
+  %114 = icmp eq i32 %107, %113
+  br i1 %114, label %122, label %115
+
+; <label>:115                                     ; preds = %109
+  %116 = load i32, i32* %loc0
+  %117 = sub i32 %116, 1
+  store i32 %117, i32* %loc0
+  br label %118
+
+; <label>:118                                     ; preds = %67, %115
+  %119 = load i32, i32* %loc0
+  %120 = load i32, i32* %loc1
+  %121 = icmp sge i32 %119, %120
+  br i1 %121, label %71, label %122
+
+; <label>:122                                     ; preds = %62, %109, %118
+  %123 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %124 = load i32, i32* %loc1
+  %125 = load i32, i32* %loc0
+  %126 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %123, i32 %124, i32 %125)
+  ret %System.String addrspace(1)* %126
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %97
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange22:                           ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
 Successfully read String.CreateTrimmedString
 
@@ -5439,8 +6893,8 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
@@ -5535,8 +6989,8 @@ entry:
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i64 2872
   %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
   %8 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %7
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %3
   %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
@@ -5553,8 +7007,8 @@ entry:
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 2864
   %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
   %21 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %20
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
-  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %22
 
 ; <label>:22                                      ; preds = %16
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
@@ -5569,7 +7023,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %16
+ThrowNullRef2:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5586,8 +7040,8 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5613,8 +7067,8 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
@@ -5632,8 +7086,8 @@ entry:
 
 ; <label>:12                                      ; preds = %4
   %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
@@ -5644,8 +7098,8 @@ entry:
 
 ; <label>:19                                      ; preds = %14
   %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %19
   %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
@@ -5660,21 +7114,21 @@ entry:
   %31 = zext i16 %30 to i32
   %32 = bitcast i8* %29 to i16*
   %33 = trunc i32 %31 to i16
-  %NullCheck6 = icmp ne i16* %32, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i16* %32, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %21
   store i16 %33, i16* %32, align 8
   %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %36
 
 ; <label>:36                                      ; preds = %34
   %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
   %38 = load i32, i32 addrspace(1)* %37, align 8
   %39 = add i32 %38, 1
-  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %40
 
 ; <label>:40                                      ; preds = %36
   %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
@@ -5683,16 +7137,16 @@ entry:
 
 ; <label>:42                                      ; preds = %14
   %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
-  br i1 %NullCheck12, label %44, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
   %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
   %47 = load i16, i16* %arg1
   %48 = zext i16 %47 to i32
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = trunc i32 %48 to i16
@@ -5703,31 +7157,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %19
+ThrowNullRef4:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %21
+ThrowNullRef6:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %36
+ThrowNullRef10:                                   ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %42
+ThrowNullRef12:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %44
+ThrowNullRef14:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5740,8 +7194,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -5752,8 +7206,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
@@ -5762,14 +7216,14 @@ entry:
 
 ; <label>:11                                      ; preds = %1
   %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
@@ -5779,15 +7233,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5808,8 +7262,8 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5822,8 +7276,8 @@ entry:
 
 ; <label>:8                                       ; preds = %3
   %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
@@ -5842,15 +7296,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
-  br i1 %NullCheck4, label %22, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
   %24 = load i16*, i16* addrspace(1)* %23, align 8
   %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %25, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
@@ -5859,8 +7313,8 @@ entry:
   store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
@@ -5874,8 +7328,8 @@ entry:
 
 ; <label>:37                                      ; preds = %65
   %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %37
   %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
@@ -5886,16 +7340,16 @@ entry:
   %45 = bitcast i16* %41 to i8*
   %46 = getelementptr inbounds i8, i8* %45, i64 %44
   %47 = bitcast i8* %46 to i16*
-  %NullCheck14 = icmp ne i16* %47, null
-  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %47, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %48
 
 ; <label>:48                                      ; preds = %39
   %49 = load i16, i16* %47, align 8
   %50 = zext i16 %49 to i32
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %52 = load i32, i32* %loc1
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %53
 
 ; <label>:53                                      ; preds = %48
   %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
@@ -5916,8 +7370,8 @@ entry:
 ; <label>:62                                      ; preds = %36, %59
   %63 = load i32, i32* %loc1
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck10, label %65, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %65
 
 ; <label>:65                                      ; preds = %62
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
@@ -5936,15 +7390,15 @@ entry:
 
 ; <label>:74                                      ; preds = %70
   %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
-  br i1 %NullCheck18, label %76, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %76
 
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
   %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
-  br i1 %NullCheck20, label %80, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
   %81 = load i64, i64 addrspace(1)* %79
@@ -5958,8 +7412,8 @@ entry:
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
   %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
-  br i1 %NullCheck22, label %92, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.String addrspace(1)* %90, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %92
 
 ; <label>:92                                      ; preds = %80
   %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
@@ -5969,15 +7423,15 @@ entry:
 
 ; <label>:96                                      ; preds = %70
   %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
-  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %98
 
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
   %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
-  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
   %103 = load i64, i64 addrspace(1)* %101
@@ -5991,8 +7445,8 @@ entry:
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
   %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
-  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.String addrspace(1)* %112, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %114
 
 ; <label>:114                                     ; preds = %102
   %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
@@ -6004,59 +7458,59 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %20
+ThrowNullRef4:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %22
+ThrowNullRef6:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %26
+ThrowNullRef8:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %62
+ThrowNullRef10:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %48
+ThrowNullRef16:                                   ; preds = %48
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %74
+ThrowNullRef18:                                   ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %76
+ThrowNullRef20:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %80
+ThrowNullRef22:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %96
+ThrowNullRef24:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %98
+ThrowNullRef26:                                   ; preds = %98
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %102
+ThrowNullRef28:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6069,15 +7523,15 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
   %3 = load i16*, i16* addrspace(1)* %2, align 8
   %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
@@ -6087,8 +7541,8 @@ entry:
   %10 = bitcast i16* %3 to i8*
   %11 = getelementptr inbounds i8, i8* %10, i64 %9
   %12 = bitcast i8* %11 to i16*
-  %NullCheck4 = icmp ne i16* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %5
   store i16 0, i16* %12, align 8
@@ -6098,11 +7552,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6119,8 +7573,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -6131,8 +7585,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
@@ -6144,15 +7598,15 @@ entry:
 
 ; <label>:14                                      ; preds = %1
   %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
   %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
   %21 = load i64, i64 addrspace(1)* %19
@@ -6171,15 +7625,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %14
+ThrowNullRef4:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %16
+ThrowNullRef6:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6302,14 +7756,6 @@ entry:
   ret %System.String addrspace(1)* %57
 }
 
-INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
-Successfully read RuntimeHelpers.get_OffsetToStringData
-
-define i32 @RuntimeHelpers.get_OffsetToStringData() {
-entry:
-  ret i32 12
-}
-
 INFO:  jitting method String::Equals using LLILCJit
 Successfully read String.Equals
 
@@ -6381,8 +7827,8 @@ entry:
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
-  br i1 %NullCheck24, label %29, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
   %30 = load i64, i64 addrspace(1)* %28
@@ -6397,8 +7843,8 @@ entry:
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
-  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
   %43 = load i64, i64 addrspace(1)* %41
@@ -6418,8 +7864,8 @@ entry:
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
   %59 = load i64, i64 addrspace(1)* %57
@@ -6434,8 +7880,8 @@ entry:
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck22, label %71, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
   %72 = load i64, i64 addrspace(1)* %70
@@ -6455,8 +7901,8 @@ entry:
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
-  br i1 %NullCheck16, label %87, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = load i64, i64 addrspace(1)* %86
@@ -6471,8 +7917,8 @@ entry:
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck18, label %100, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
   %101 = load i64, i64 addrspace(1)* %99
@@ -6492,8 +7938,8 @@ entry:
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
-  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
   %117 = load i64, i64 addrspace(1)* %115
@@ -6508,8 +7954,8 @@ entry:
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
-  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
   %130 = load i64, i64 addrspace(1)* %128
@@ -6528,15 +7974,15 @@ entry:
 
 ; <label>:142                                     ; preds = %22
   %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
-  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %143, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %144
 
 ; <label>:144                                     ; preds = %142
   %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
   %146 = load i32, i32 addrspace(1)* %145
   %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
-  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %147, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %148
 
 ; <label>:148                                     ; preds = %144
   %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
@@ -6557,15 +8003,15 @@ entry:
 
 ; <label>:159                                     ; preds = %22
   %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
-  br i1 %NullCheck, label %161, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %ThrowNullRef, label %161
 
 ; <label>:161                                     ; preds = %159
   %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
   %163 = load i32, i32 addrspace(1)* %162
   %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
-  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %164, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %165
 
 ; <label>:165                                     ; preds = %161
   %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
@@ -6578,8 +8024,8 @@ entry:
 
 ; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
-  br i1 %NullCheck4, label %172, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %171, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %172
 
 ; <label>:172                                     ; preds = %170
   %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
@@ -6589,8 +8035,8 @@ entry:
 
 ; <label>:176                                     ; preds = %172
   %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
-  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %177, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %178
 
 ; <label>:178                                     ; preds = %176
   %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
@@ -6629,55 +8075,55 @@ ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %161
+ThrowNullRef2:                                    ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %170
+ThrowNullRef4:                                    ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %176
+ThrowNullRef6:                                    ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %142
+ThrowNullRef8:                                    ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %144
+ThrowNullRef10:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %113
+ThrowNullRef12:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %116
+ThrowNullRef14:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %84
+ThrowNullRef16:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %87
+ThrowNullRef18:                                   ; preds = %87
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %55
+ThrowNullRef20:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %58
+ThrowNullRef22:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %26
+ThrowNullRef24:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %29
+ThrowNullRef26:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,8 +8161,8 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck, label %14, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %ThrowNullRef, label %14
 
 ; <label>:14                                      ; preds = %8
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
@@ -6760,8 +8206,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
@@ -6770,14 +8216,14 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32, i32* %loc0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %10
   %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
   %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
@@ -6790,15 +8236,15 @@ entry:
 ; <label>:25                                      ; preds = %19
   %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
-  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
   %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
@@ -6807,8 +8253,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %37 = load i32, i32* %loc0
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %38, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %38
 
 ; <label>:38                                      ; preds = %32
   %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
@@ -6817,14 +8263,14 @@ entry:
 
 ; <label>:40                                      ; preds = %19
   %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %40
   %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
   %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
-  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
-  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
@@ -6832,8 +8278,8 @@ entry:
   %48 = zext i32 %47 to i64
   %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
-  br i1 %NullCheck16, label %51, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %51
 
 ; <label>:51                                      ; preds = %45
   %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
@@ -6847,15 +8293,15 @@ entry:
 ; <label>:57                                      ; preds = %51
   %58 = load i16*, i16** %arg1
   %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
-  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %60
 
 ; <label>:60                                      ; preds = %57
   %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
   %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
-  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %64
 
 ; <label>:64                                      ; preds = %60
   %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
@@ -6864,22 +8310,22 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
   %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
-  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %70
 
 ; <label>:70                                      ; preds = %64
   %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
   %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
-  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
-  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
   %75 = load i32, i32 addrspace(1)* %74
   %76 = zext i32 %75 to i64
   %77 = trunc i64 %76 to i32
-  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
-  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %78
 
 ; <label>:78                                      ; preds = %73
   %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
@@ -6901,8 +8347,8 @@ entry:
   %90 = bitcast i16* %86 to i8*
   %91 = getelementptr inbounds i8, i8* %90, i64 %89
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %93
 
 ; <label>:93                                      ; preds = %80
   %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
@@ -6912,8 +8358,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %99 = load i32, i32* %loc2
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %100
 
 ; <label>:100                                     ; preds = %93
   %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
@@ -6928,63 +8374,63 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %25
+ThrowNullRef6:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %32
+ThrowNullRef10:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %40
+ThrowNullRef12:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %45
+ThrowNullRef16:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %57
+ThrowNullRef18:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %60
+ThrowNullRef20:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %64
+ThrowNullRef22:                                   ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %70
+ThrowNullRef24:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %73
+ThrowNullRef26:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %80
+ThrowNullRef28:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %93
+ThrowNullRef30:                                   ; preds = %93
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7004,8 +8450,8 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
@@ -7033,43 +8479,43 @@ entry:
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %14
   %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
   %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   %28 = load i32, i32 addrspace(1)* %27, align 8
   %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
-  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %30
 
 ; <label>:30                                      ; preds = %26
   %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
   %32 = load i32, i32 addrspace(1)* %31, align 8
   %33 = add i32 %28, %32
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %34
 
 ; <label>:34                                      ; preds = %30
   %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   store i32 %33, i32 addrspace(1)* %35
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
   store i32 0, i32 addrspace(1)* %38
   %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %40
 
 ; <label>:40                                      ; preds = %37
   %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
@@ -7082,8 +8528,8 @@ entry:
 
 ; <label>:47                                      ; preds = %40
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
@@ -7098,8 +8544,8 @@ entry:
   %54 = load i32, i32* %loc0
   %55 = sext i32 %54 to i64
   %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
-  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %57
 
 ; <label>:57                                      ; preds = %52
   %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
@@ -7110,68 +8556,35 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %14
+ThrowNullRef2:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %23
+ThrowNullRef4:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %26
+ThrowNullRef6:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %30
+ThrowNullRef8:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %34
+ThrowNullRef10:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %47
+ThrowNullRef14:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %52
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-}
-
-INFO:  jitting method StringBuilder::get_Length using LLILCJit
-Successfully read StringBuilder.get_Length
-
-define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.StringBuilder addrspace(1)*
-  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
-  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
-
-; <label>:1                                       ; preds = %entry
-  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %3 = load i32, i32 addrspace(1)* %2, align 8
-  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
-
-; <label>:5                                       ; preds = %1
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = add i32 %3, %7
-  ret i32 %8
-
-ThrowNullRef:                                     ; preds = %entry
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef16:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7213,70 +8626,70 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
   %6 = load i32, i32 addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
   store i32 %6, i32 addrspace(1)* %8
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
   %13 = load i32, i32 addrspace(1)* %12, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
   store i32 %13, i32 addrspace(1)* %15
   %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
-  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %18
 
 ; <label>:18                                      ; preds = %14
   %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
   %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
   %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
   %34 = load i32, i32 addrspace(1)* %33, align 8
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
-  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
@@ -7287,39 +8700,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %28
+ThrowNullRef16:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %32
+ThrowNullRef18:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7455,13 +8868,13 @@ entry:
 ; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
@@ -7477,16 +8890,16 @@ entry:
 
 ; <label>:18                                      ; preds = %15
   %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
   store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
   %22 = load i32, i32* %loc0
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %24
 
 ; <label>:24                                      ; preds = %20
   %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
@@ -7498,13 +8911,13 @@ entry:
 ; <label>:28                                      ; preds = %15, %24
   %29 = load i32, i32* %arg1
   %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %31
   %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
@@ -7517,20 +8930,20 @@ entry:
   %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
-  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
   %46 = load i32, i32 addrspace(1)* %45, align 8
   %47 = sub i32 %40, %46
-  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
-  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i32 addrspace(1)* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %48
 
 ; <label>:48                                      ; preds = %44
   store i32 %47, i32 addrspace(1)* %39, align 8
@@ -7538,21 +8951,21 @@ entry:
 
 ; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
-  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %51
 
 ; <label>:51                                      ; preds = %49
   %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %53
 
 ; <label>:53                                      ; preds = %51
   %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
   %55 = load i32, i32 addrspace(1)* %54, align 8
   %56 = load i32, i32* %arg2
   %57 = sub i32 %55, %56
-  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %58
 
 ; <label>:58                                      ; preds = %53
   %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
@@ -7562,13 +8975,13 @@ entry:
 ; <label>:60                                      ; preds = %33, %58
   %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
   %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
-  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %63
 
 ; <label>:63                                      ; preds = %60
   %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
-  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
-  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
@@ -7578,15 +8991,15 @@ entry:
 
 ; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
-  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i32 addrspace(1)* %69, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %70
 
 ; <label>:70                                      ; preds = %68
   %71 = load i32, i32 addrspace(1)* %69, align 8
   store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
-  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
@@ -7596,8 +9009,8 @@ entry:
   store i32 %77, i32* %loc4
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
-  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %80
 
 ; <label>:80                                      ; preds = %73
   %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
@@ -7607,71 +9020,71 @@ entry:
 ; <label>:83                                      ; preds = %80
   store i32 0, i32* %loc3
   %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
-  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
-  br i1 %NullCheck26, label %88, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i32 addrspace(1)* %87, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %88
 
 ; <label>:88                                      ; preds = %85
   %89 = load i32, i32 addrspace(1)* %87, align 8
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
-  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %90
 
 ; <label>:90                                      ; preds = %88
   %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
   store i32 %89, i32 addrspace(1)* %91
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
-  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
-  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %96
 
 ; <label>:96                                      ; preds = %94
   %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
-  br i1 %NullCheck34, label %100, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %100
 
 ; <label>:100                                     ; preds = %96
   %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
-  br i1 %NullCheck36, label %102, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %102
 
 ; <label>:102                                     ; preds = %100
   %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
   %104 = load i32, i32 addrspace(1)* %103, align 8
   %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
-  br i1 %NullCheck38, label %106, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %106
 
 ; <label>:106                                     ; preds = %102
   %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
-  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
-  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %108
 
 ; <label>:108                                     ; preds = %106
   %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
   %110 = load i32, i32 addrspace(1)* %109, align 8
   %111 = add i32 %104, %110
-  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %112
 
 ; <label>:112                                     ; preds = %108
   %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
   store i32 %111, i32 addrspace(1)* %113
   %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
-  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i32 addrspace(1)* %114, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %115
 
 ; <label>:115                                     ; preds = %112
   %116 = load i32, i32 addrspace(1)* %114, align 8
@@ -7681,19 +9094,19 @@ entry:
 ; <label>:118                                     ; preds = %115
   %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
-  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %121
 
 ; <label>:121                                     ; preds = %118
   %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
-  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
-  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %123
 
 ; <label>:123                                     ; preds = %121
   %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
   %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
-  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
-  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %126
 
 ; <label>:126                                     ; preds = %123
   %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
@@ -7705,8 +9118,8 @@ entry:
 
 ; <label>:130                                     ; preds = %80, %115, %126
   %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %132
 
 ; <label>:132                                     ; preds = %130
   %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7715,8 +9128,8 @@ entry:
   %136 = load i32, i32* %loc3
   %137 = sub i32 %135, %136
   %138 = sub i32 %134, %137
-  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %139
 
 ; <label>:139                                     ; preds = %132
   %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7728,16 +9141,16 @@ entry:
 
 ; <label>:144                                     ; preds = %139
   %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
-  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %146
 
 ; <label>:146                                     ; preds = %144
   %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
   %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
   %149 = load i32, i32* %loc2
   %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
-  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %151
 
 ; <label>:151                                     ; preds = %146
   %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
@@ -7754,145 +9167,249 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %18
+ThrowNullRef4:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %31
+ThrowNullRef10:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %44
+ThrowNullRef16:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %68
+ThrowNullRef18:                                   ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %70
+ThrowNullRef20:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %73
+ThrowNullRef22:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %83
+ThrowNullRef24:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %85
+ThrowNullRef26:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %88
+ThrowNullRef28:                                   ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %90
+ThrowNullRef30:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %94
+ThrowNullRef32:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %96
+ThrowNullRef34:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %100
+ThrowNullRef36:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %102
+ThrowNullRef38:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %106
+ThrowNullRef40:                                   ; preds = %106
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %108
+ThrowNullRef42:                                   ; preds = %108
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %112
+ThrowNullRef44:                                   ; preds = %112
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %118
+ThrowNullRef46:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %121
+ThrowNullRef48:                                   ; preds = %121
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %123
+ThrowNullRef50:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %130
+ThrowNullRef52:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %132
+ThrowNullRef54:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %144
+ThrowNullRef56:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %146
+ThrowNullRef58:                                   ; preds = %146
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %60
+ThrowNullRef60:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %63
+ThrowNullRef62:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %49
+ThrowNullRef64:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %51
+ThrowNullRef66:                                   ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %53
+ThrowNullRef68:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(%"System.Char[]" addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %arg0 = alloca %"System.Char[]" addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store %"System.Char[]" addrspace(1)* %param0, %"System.Char[]" addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load i32, i32* %arg4
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %43, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %38, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg1
+  %13 = load i32, i32* %arg4
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %38, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %24 = load i32, i32* %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %35 = load i32, i32* %arg3
+  %36 = load i32, i32* %arg4
+  %37 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %37, %"System.Char[]" addrspace(1)* %34, i32 %35, i32 %36)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:38                                      ; preds = %5, %16
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Successfully read Buffer._Memmove
 
@@ -7914,7 +9431,7 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[loadElem]
+Failed to read AppDomain.SetDataHelper[storeElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -7923,8 +9440,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
@@ -7934,8 +9451,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
@@ -7947,15 +9464,15 @@ entry:
   %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
   %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
@@ -7966,15 +9483,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7992,7 +9509,79 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
-Failed to read Dictionary`2.TryGetValue[loadElemA]
+Successfully read Dictionary`2.TryGetValue
+
+define i8 @"Dictionary`2.TryGetValue"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)* addrspace(1)* %param2) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  %arg2 = alloca %System.__Canon addrspace(1)* addrspace(1)*
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  store %System.__Canon addrspace(1)* addrspace(1)* %param2, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  store i32 %2, i32* %loc0
+  %3 = load i32, i32* %loc0
+  %4 = icmp slt i32 %3, 0
+  br i1 %4, label %22, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 2
+  %10 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %9, align 8
+  %11 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = zext i32 %11 to i64
+  %BoundsCheck = icmp uge i64 %16, %15
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 3, i32 %11
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %20, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %6, %System.__Canon addrspace(1)* %21)
+  ret i8 1
+
+; <label>:22                                      ; preds = %entry
+  %23 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %23, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -8058,8 +9647,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
@@ -8091,8 +9680,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
@@ -8171,15 +9760,15 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck, label %19, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %ThrowNullRef, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
   %21 = load i32, i32 addrspace(1)* %20
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
@@ -8202,7 +9791,7 @@ ThrowNullRef:                                     ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %19
+ThrowNullRef2:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8248,8 +9837,8 @@ entry:
   %0 = alloca %System.AppDomainHandle
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %1 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %1, i32 0, i32 15
@@ -8269,8 +9858,8 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
@@ -8286,7 +9875,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -8299,8 +9888,8 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -8327,8 +9916,8 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
@@ -8352,8 +9941,8 @@ entry:
   %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
   store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
@@ -8363,8 +9952,8 @@ entry:
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
@@ -8374,8 +9963,8 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %9
   %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
@@ -8384,8 +9973,8 @@ entry:
 
 ; <label>:18                                      ; preds = %3, %16
   %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
@@ -8397,15 +9986,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %18
+ThrowNullRef6:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8418,8 +10007,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
@@ -8453,15 +10042,15 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
@@ -8473,7 +10062,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8481,7 +10070,7 @@ ThrowNullRef1:                                    ; preds = %1
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
 Failed to read Dictionary`2.System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
@@ -8506,8 +10095,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
@@ -8524,8 +10113,8 @@ entry:
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -8544,7 +10133,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8577,8 +10166,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = load i64, i64* %arg2
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = trunc i32 %3 to i8
@@ -8634,46 +10223,46 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
   %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
-  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
-  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
-  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
@@ -8684,27 +10273,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %20
+ThrowNullRef12:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8717,8 +10306,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -8756,22 +10345,22 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
   %9 = load i64, i64 addrspace(1)* %8, align 8
   %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
   %13 = load i64, i64 addrspace(1)* %12, align 8
   %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %11
   %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
@@ -8788,11 +10377,11 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8882,8 +10471,8 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
@@ -8900,8 +10489,8 @@ entry:
 ; <label>:8                                       ; preds = %1
   %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
   %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
@@ -8911,15 +10500,15 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
   %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
   %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
-  br i1 %NullCheck6, label %21, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
@@ -8946,15 +10535,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8992,15 +10581,15 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
   store i8 %3, i8 addrspace(1)* %5
   %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
@@ -9011,7 +10600,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9027,8 +10616,8 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -9041,8 +10630,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
@@ -9058,7 +10647,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9080,8 +10669,8 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
@@ -9096,8 +10685,8 @@ entry:
 ; <label>:12                                      ; preds = %6
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
@@ -9112,8 +10701,8 @@ entry:
 ; <label>:21                                      ; preds = %15
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
@@ -9128,8 +10717,8 @@ entry:
 ; <label>:30                                      ; preds = %24
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %31, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
@@ -9144,8 +10733,8 @@ entry:
 ; <label>:39                                      ; preds = %33
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
-  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %40, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %42
 
 ; <label>:42                                      ; preds = %39
   %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
@@ -9164,19 +10753,19 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %21
+ThrowNullRef4:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %30
+ThrowNullRef6:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %39
+ThrowNullRef8:                                    ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9243,8 +10832,8 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
@@ -9264,57 +10853,57 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
   store i8 0, i8 addrspace(1)* %2
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
   store i8 0, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
   store i8 0, i8 addrspace(1)* %17
   %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
   store i8 0, i8 addrspace(1)* %20
   %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
-  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
@@ -9325,31 +10914,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %19
+ThrowNullRef14:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9367,8 +10956,8 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
@@ -9380,8 +10969,8 @@ entry:
 
 ; <label>:9                                       ; preds = %4
   %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %9
   %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
@@ -9395,7 +10984,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef2:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9420,8 +11009,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
@@ -9512,8 +11101,8 @@ entry:
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
@@ -9524,8 +11113,8 @@ entry:
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = load i64, i64 addrspace(1)* %12
@@ -9537,8 +11126,8 @@ entry:
   %20 = load i64, i64* %19
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
-  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %13
   %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
@@ -9555,8 +11144,8 @@ entry:
 ; <label>:30                                      ; preds = %25
   %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %32 = load i32, i32* %arg2
-  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
-  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
@@ -9570,15 +11159,15 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %30
+ThrowNullRef2:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9622,87 +11211,87 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
   %10 = load i8, i8 addrspace(1)* %9, align 8
   %11 = zext i8 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %8
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
   store i8 %12, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
   %19 = load i8, i8 addrspace(1)* %18, align 8
   %20 = zext i8 %19 to i32
   %21 = trunc i32 %20 to i8
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
   store i8 %21, i8 addrspace(1)* %23
   %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
   %28 = load i8, i8 addrspace(1)* %27, align 8
   %29 = zext i8 %28 to i32
   %30 = trunc i32 %29 to i8
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
-  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %31
 
 ; <label>:31                                      ; preds = %26
   %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
   store i8 %30, i8 addrspace(1)* %32
   %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
-  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
-  br i1 %NullCheck14, label %40, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %40
 
 ; <label>:40                                      ; preds = %35
   %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
   store i8 %39, i8 addrspace(1)* %41
   %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
-  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %44
 
 ; <label>:44                                      ; preds = %40
   %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
   %46 = load i8, i8 addrspace(1)* %45, align 8
   %47 = zext i8 %46 to i32
   %48 = trunc i32 %47 to i8
-  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
   store i8 %48, i8 addrspace(1)* %50
   %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
-  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
@@ -9713,29 +11302,29 @@ entry:
 ; <label>:56                                      ; preds = %52
   %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
-  br i1 %NullCheck22, label %59, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
   %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
   %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
-  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
-  br i1 %NullCheck24, label %63, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
   %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
-  br i1 %NullCheck26, label %66, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
   %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
-  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
-  br i1 %NullCheck28, label %69, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %69
 
 ; <label>:69                                      ; preds = %66
   %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
@@ -9744,15 +11333,15 @@ entry:
 
 ; <label>:71                                      ; preds = %105
   %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
-  br i1 %NullCheck34, label %73, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %73
 
 ; <label>:73                                      ; preds = %71
   %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
   %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
   %76 = load i32, i32* %loc0
-  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
-  br i1 %NullCheck36, label %77, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
@@ -9766,8 +11355,8 @@ entry:
 
 ; <label>:83                                      ; preds = %77
   %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
-  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
@@ -9775,14 +11364,14 @@ entry:
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
   %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
-  br i1 %NullCheck40, label %91, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
 ; <label>:91                                      ; preds = %85
   %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
   %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
-  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck42, label %94, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %94
 
 ; <label>:94                                      ; preds = %91
   %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
@@ -9798,14 +11387,14 @@ entry:
 ; <label>:99                                      ; preds = %69, %96
   %100 = load i32, i32* %loc0
   %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
-  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %102
 
 ; <label>:102                                     ; preds = %99
   %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
   %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
-  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
-  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
@@ -9819,87 +11408,87 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %26
+ThrowNullRef10:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %31
+ThrowNullRef12:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %35
+ThrowNullRef14:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %40
+ThrowNullRef16:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %56
+ThrowNullRef22:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %59
+ThrowNullRef24:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %63
+ThrowNullRef26:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %66
+ThrowNullRef28:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %102
+ThrowNullRef32:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %71
+ThrowNullRef34:                                   ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %73
+ThrowNullRef36:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %83
+ThrowNullRef38:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %85
+ThrowNullRef40:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %91
+ThrowNullRef42:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9943,15 +11532,15 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
   %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
@@ -9961,28 +11550,28 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
   %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %12
   %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
   %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
   %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
-  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
@@ -9993,23 +11582,23 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %12
+ThrowNullRef6:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10031,15 +11620,15 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
   %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = load i64, i64 addrspace(1)* %7
@@ -10077,13 +11666,13 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[loadElem]
+Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -10111,8 +11700,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -10182,8 +11771,8 @@ entry:
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load double, double* %arg0
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -10317,8 +11906,8 @@ entry:
   store i64 %param0, i64* %arg0
   store i64 %param1, i64* %arg1
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
@@ -10326,8 +11915,8 @@ entry:
   %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
   %5 = load i16*, i16* addrspace(1)* %4, align 8
   %6 = addrspacecast i64* %arg1 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = bitcast i64 addrspace(1)* %6 to i8 addrspace(1)*
@@ -10343,7 +11932,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10377,8 +11966,8 @@ entry:
   %1 = load i32, i32* %arg1
   %2 = sext i32 %1 to i64
   %3 = inttoptr i64 %2 to i16*
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -10431,8 +12020,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, i32)*)(%System.IO.ConsoleStream addrspace(1)* %2, i32 %1)
   %3 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %4 = load i64, i64* %arg1
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
@@ -10443,8 +12032,8 @@ entry:
   %10 = icmp eq i32 %9, 3
   %11 = sext i1 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %5
   %14 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, i32 0, i32 5
@@ -10455,7 +12044,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10478,8 +12067,8 @@ entry:
   %5 = icmp eq i32 %4, 1
   %6 = sext i1 %5 to i32
   %7 = trunc i32 %6 to i8
-  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %2, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.ConsoleStream addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
@@ -10490,8 +12079,8 @@ entry:
   %13 = icmp eq i32 %12, 2
   %14 = sext i1 %13 to i32
   %15 = trunc i32 %14 to i8
-  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %10, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.ConsoleStream addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %8
   %17 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %10, i32 0, i32 4
@@ -10502,7 +12091,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10541,8 +12130,8 @@ entry:
   %arg0 = alloca i64
   store i64 %param0, i64* %arg0
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
@@ -10577,8 +12166,8 @@ entry:
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
   %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = load i64, i64 addrspace(1)* %7
@@ -10682,7 +12271,127 @@ entry:
 INFO:  jitting method Encoding::GetEncoding using LLILCJit
 Failed to read Encoding.GetEncoding[convertToHelperArgumentType]
 INFO:  jitting method EncodingProvider::GetEncodingFromProvider using LLILCJit
-Failed to read EncodingProvider.GetEncodingFromProvider[loadElem]
+Successfully read EncodingProvider.GetEncodingFromProvider
+
+define %System.Text.Encoding addrspace(1)* @EncodingProvider.GetEncodingFromProvider(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca %"System.Text.EncodingProvider[]" addrspace(1)*
+  %loc1 = alloca %System.Text.EncodingProvider addrspace(1)*
+  %loc2 = alloca %System.Text.Encoding addrspace(1)*
+  %loc3 = alloca %System.Text.Encoding addrspace(1)*
+  %loc4 = alloca %"System.Text.EncodingProvider[]" addrspace(1)*
+  %loc5 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1059)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2392
+  %2 = addrspacecast i8 addrspace(1)* %1 to %"System.Text.EncodingProvider[]" addrspace(1)**
+  %3 = load volatile %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %2
+  %4 = icmp ne %"System.Text.EncodingProvider[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %entry
+  ret %System.Text.Encoding addrspace(1)* null
+
+; <label>:6                                       ; preds = %entry
+  %7 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1059)
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i64 2392
+  %9 = addrspacecast i8 addrspace(1)* %8 to %"System.Text.EncodingProvider[]" addrspace(1)**
+  %10 = load volatile %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %9
+  store %"System.Text.EncodingProvider[]" addrspace(1)* %10, %"System.Text.EncodingProvider[]" addrspace(1)** %loc0
+  %11 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc0
+  store %"System.Text.EncodingProvider[]" addrspace(1)* %11, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  store i32 0, i32* %loc5
+  br label %43
+
+; <label>:12                                      ; preds = %46
+  %13 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  %14 = load i32, i32* %loc5
+  %NullCheck1 = icmp eq %"System.Text.EncodingProvider[]" addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %13, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = zext i32 %17 to i64
+  %19 = zext i32 %14 to i64
+  %BoundsCheck = icmp uge i64 %19, %18
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %20
+
+; <label>:20                                      ; preds = %15
+  %21 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %13, i32 0, i32 3, i32 %14
+  %22 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)* addrspace(1)* %21, align 8
+  store %System.Text.EncodingProvider addrspace(1)* %22, %System.Text.EncodingProvider addrspace(1)** %loc1
+  %23 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)** %loc1
+  %24 = load i32, i32* %arg0
+  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i64 addrspace(1)*
+  %NullCheck3 = icmp eq i64 addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
+
+; <label>:26                                      ; preds = %20
+  %27 = load i64, i64 addrspace(1)* %25
+  %28 = add i64 %27, 64
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 40
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Text.Encoding addrspace(1)* (%System.Text.EncodingProvider addrspace(1)*, i32)*
+  %35 = call %System.Text.Encoding addrspace(1)* %34(%System.Text.EncodingProvider addrspace(1)* %23, i32 %24)
+  store %System.Text.Encoding addrspace(1)* %35, %System.Text.Encoding addrspace(1)** %loc2
+  %36 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc2
+  %37 = icmp eq %System.Text.Encoding addrspace(1)* %36, null
+  br i1 %37, label %40, label %38
+
+; <label>:38                                      ; preds = %26
+  %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc2
+  store %System.Text.Encoding addrspace(1)* %39, %System.Text.Encoding addrspace(1)** %loc3
+  br label %53
+
+; <label>:40                                      ; preds = %26
+  %41 = load i32, i32* %loc5
+  %42 = add i32 %41, 1
+  store i32 %42, i32* %loc5
+  br label %43
+
+; <label>:43                                      ; preds = %6, %40
+  %44 = load i32, i32* %loc5
+  %45 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  %NullCheck = icmp eq %"System.Text.EncodingProvider[]" addrspace(1)* %45, null
+  br i1 %NullCheck, label %ThrowNullRef, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp slt i32 %44, %50
+  br i1 %51, label %12, label %52
+
+; <label>:52                                      ; preds = %46
+  ret %System.Text.Encoding addrspace(1)* null
+
+; <label>:53                                      ; preds = %38
+  %54 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc3
+  ret %System.Text.Encoding addrspace(1)* %54
+
+ThrowNullRef:                                     ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method EncodingProvider::.cctor using LLILCJit
 Successfully read EncodingProvider..cctor
 
@@ -10701,7 +12410,7 @@ Failed to read Encoding.get_InternalSyncObject[Call HasTypeArg]
 INFO:  jitting method Hashtable::.ctor using LLILCJit
 Failed to read Hashtable..ctor[Volatile store]
 INFO:  jitting method Hashtable::get_Item using LLILCJit
-Failed to read Hashtable.get_Item[loadElemA]
+Failed to read Hashtable.get_Item[loadNonPrimitiveObj]
 INFO:  jitting method Hashtable::InitHash using LLILCJit
 Successfully read Hashtable.InitHash
 
@@ -10721,8 +12430,8 @@ entry:
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -10738,15 +12447,15 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
   %15 = load i32, i32* %loc0
-  %NullCheck2 = icmp ne i32 addrspace(1)* %14, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i32 addrspace(1)* %14, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %3
   store i32 %15, i32 addrspace(1)* %14, align 8
   %17 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %18 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %NullCheck4 = icmp ne i32 addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i32 addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = load i32, i32 addrspace(1)* %18, align 8
@@ -10755,8 +12464,8 @@ entry:
   %23 = sub i32 %22, 1
   %24 = urem i32 %21, %23
   %25 = add i32 1, %24
-  %NullCheck6 = icmp ne i32 addrspace(1)* %17, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32 addrspace(1)* %17, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %19
   store i32 %25, i32 addrspace(1)* %17, align 8
@@ -10767,15 +12476,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %19
+ThrowNullRef6:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10790,8 +12499,8 @@ entry:
   store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
   store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %NullCheck = icmp ne %System.Collections.Hashtable addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Collections.Hashtable addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
@@ -10801,16 +12510,16 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Collections.Hashtable addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Collections.Hashtable addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
   %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck4 = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %9, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
   %13 = inttoptr i64 %11 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
@@ -10820,8 +12529,8 @@ entry:
 ; <label>:15                                      ; preds = %1
   %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -10839,15 +12548,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10861,8 +12570,8 @@ entry:
   store %System.Int32 addrspace(1)* %param0, %System.Int32 addrspace(1)** %this
   %0 = load %System.Int32 addrspace(1)*, %System.Int32 addrspace(1)** %this
   %1 = bitcast %System.Int32 addrspace(1)* %0 to i32 addrspace(1)*
-  %NullCheck = icmp ne i32 addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq i32 addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load i32, i32 addrspace(1)* %1, align 8
@@ -10938,8 +12647,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.UTF8Encoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
@@ -10948,15 +12657,15 @@ entry:
   %9 = load i8, i8* %arg2
   %10 = zext i8 %9 to i32
   %11 = trunc i32 %10 to i8
-  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %8, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %6
   %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %8, i32 0, i32 8
   store i8 %11, i8 addrspace(1)* %13
   %14 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %14, i32 0, i32 8
@@ -10968,8 +12677,8 @@ entry:
 ; <label>:20                                      ; preds = %15
   %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %22, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %22, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = load i64, i64 addrspace(1)* %22
@@ -10991,15 +12700,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %12
+ThrowNullRef4:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11014,8 +12723,8 @@ entry:
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
@@ -11037,16 +12746,16 @@ entry:
 ; <label>:10                                      ; preds = %1
   %11 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
   %12 = load i32, i32* %arg1
-  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %11, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.Encoding addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
   store i32 %12, i32 addrspace(1)* %14
   %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
   %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = load i64, i64 addrspace(1)* %16
@@ -11064,11 +12773,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11081,8 +12790,8 @@ entry:
   %this = alloca %System.Text.UTF8Encoding addrspace(1)*
   store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
   %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.UTF8Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
@@ -11094,16 +12803,16 @@ entry:
 ; <label>:6                                       ; preds = %1
   %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %8 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %10, %System.Text.EncoderFallback addrspace(1)* %8)
   %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %12 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
-  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %11, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %11, i32 0, i32 3
@@ -11116,8 +12825,8 @@ entry:
   %18 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %18, %System.String addrspace(1)* %17)
   %19 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %18 to %System.Text.EncoderFallback addrspace(1)*
-  %NullCheck6 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %16, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %16, i32 0, i32 2
@@ -11127,8 +12836,8 @@ entry:
   %24 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %24, %System.String addrspace(1)* %23)
   %25 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %24 to %System.Text.DecoderFallback addrspace(1)*
-  %NullCheck8 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %22, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %22, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %20
   %27 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %22, i32 0, i32 3
@@ -11139,19 +12848,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %20
+ThrowNullRef8:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11181,8 +12890,8 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load i32, i32* %arg1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -11200,8 +12909,8 @@ entry:
 ; <label>:15                                      ; preds = %8
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %17 = load i32, i32* %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 %17
@@ -11217,7 +12926,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11269,7 +12978,7 @@ entry:
 }
 
 INFO:  jitting method Hashtable::Insert using LLILCJit
-Failed to read Hashtable.Insert[loadElemA]
+Failed to read Hashtable.Insert[storeElem]
 INFO:  jitting method ConsoleEncoding::.ctor using LLILCJit
 Successfully read ConsoleEncoding..ctor
 
@@ -11284,8 +12993,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %1)
   %2 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
@@ -11321,8 +13030,8 @@ entry:
   %2 = call %System.Text.InternalEncoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalEncoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %1)
   %3 = bitcast %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2 to %System.Text.EncoderFallback addrspace(1)*
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
@@ -11332,8 +13041,8 @@ entry:
   %8 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %7)
   %9 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %8 to %System.Text.DecoderFallback addrspace(1)*
-  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %6, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.Encoding addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %4
   %11 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %6, i32 0, i32 3
@@ -11344,7 +13053,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11363,15 +13072,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* %1)
   %2 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   %6 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, i32 0, i32 1
@@ -11382,7 +13091,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11410,8 +13119,8 @@ entry:
   store %System.Text.InternalDecoderBestFitFallback addrspace(1)* %param0, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
   %0 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
@@ -11421,15 +13130,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %4)
   %5 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %6)
   %9 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, i32 0, i32 1
@@ -11440,11 +13149,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11512,8 +13221,8 @@ entry:
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
   %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = load i64, i64 addrspace(1)* %19
@@ -11577,8 +13286,8 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.ConsoleStream addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
@@ -11609,31 +13318,31 @@ entry:
   store i8 %param4, i8* %arg4
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %3, %System.IO.Stream addrspace(1)* %1)
   %4 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %4, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
   %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %4, i32 0, i32 4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %5)
   %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %6
   %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
   %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
   %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = load i64, i64 addrspace(1)* %13
@@ -11645,8 +13354,8 @@ entry:
   %21 = load i64, i64* %20
   %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %8, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %8, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %14
   %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 5
@@ -11664,24 +13373,24 @@ entry:
   %31 = load i32, i32* %arg3
   %32 = sext i32 %31 to i64
   %33 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %32)
-  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %30, null
-  br i1 %NullCheck10, label %34, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.StreamWriter addrspace(1)* %30, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %35, %"System.Char[]" addrspace(1)* %33)
   %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %37, null
-  br i1 %NullCheck12, label %38, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.StreamWriter addrspace(1)* %37, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %38
 
 ; <label>:38                                      ; preds = %34
   %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
   %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
   %41 = load i32, i32* %arg3
   %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %42, null
-  br i1 %NullCheck14, label %43, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %42, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
   %44 = load i64, i64 addrspace(1)* %42
@@ -11695,30 +13404,30 @@ entry:
   %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
   %53 = sext i32 %52 to i64
   %54 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %53)
-  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
-  br i1 %NullCheck16, label %55, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %55
 
 ; <label>:55                                      ; preds = %43
   %56 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %56, %"System.Byte[]" addrspace(1)* %54)
   %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %58 = load i32, i32* %arg3
-  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %57, null
-  br i1 %NullCheck18, label %59, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.StreamWriter addrspace(1)* %57, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %59
 
 ; <label>:59                                      ; preds = %55
   %60 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 10
   store i32 %58, i32 addrspace(1)* %60
   %61 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %61, null
-  br i1 %NullCheck20, label %62, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.IO.StreamWriter addrspace(1)* %61, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %62
 
 ; <label>:62                                      ; preds = %59
   %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
   %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
   %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
   %67 = load i64, i64 addrspace(1)* %65
@@ -11736,15 +13445,15 @@ entry:
 
 ; <label>:78                                      ; preds = %66
   %79 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %79, null
-  br i1 %NullCheck24, label %80, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.StreamWriter addrspace(1)* %79, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %80
 
 ; <label>:80                                      ; preds = %78
   %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
   %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
   %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %83, null
-  br i1 %NullCheck26, label %84, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %83, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
   %85 = load i64, i64 addrspace(1)* %83
@@ -11761,8 +13470,8 @@ entry:
 
 ; <label>:95                                      ; preds = %84
   %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.IO.StreamWriter addrspace(1)* %96, null
-  br i1 %NullCheck28, label %97, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.IO.StreamWriter addrspace(1)* %96, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %97
 
 ; <label>:97                                      ; preds = %95
   %98 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 12
@@ -11776,8 +13485,8 @@ entry:
   %103 = icmp eq i32 %102, 0
   %104 = sext i1 %103 to i32
   %105 = trunc i32 %104 to i8
-  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %100, null
-  br i1 %NullCheck30, label %106, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.IO.StreamWriter addrspace(1)* %100, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %106
 
 ; <label>:106                                     ; preds = %99
   %107 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %100, i32 0, i32 13
@@ -11788,63 +13497,63 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %6
+ThrowNullRef4:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %29
+ThrowNullRef10:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %34
+ThrowNullRef12:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %38
+ThrowNullRef14:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %43
+ThrowNullRef16:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %55
+ThrowNullRef18:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %59
+ThrowNullRef20:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %62
+ThrowNullRef22:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %78
+ThrowNullRef24:                                   ; preds = %78
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %80
+ThrowNullRef26:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %95
+ThrowNullRef28:                                   ; preds = %95
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11857,15 +13566,15 @@ entry:
   %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = load i64, i64 addrspace(1)* %4
@@ -11883,7 +13592,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11933,35 +13642,35 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
   %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderNLS addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %7 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.EncoderNLS addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Text.Encoding addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.Encoding addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Text.EncoderNLS addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.EncoderNLS addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
   %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck8 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = load i64, i64 addrspace(1)* %16
@@ -11980,19 +13689,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12018,8 +13727,8 @@ entry:
   %this = alloca %System.Text.Encoding addrspace(1)*
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
@@ -12039,15 +13748,15 @@ entry:
   %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
   store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
   %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
   store i32 0, i32 addrspace(1)* %2
   %3 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, i32 0, i32 2
@@ -12057,15 +13766,15 @@ entry:
 
 ; <label>:8                                       ; preds = %4
   %9 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
   %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
   %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = load i64, i64 addrspace(1)* %13
@@ -12086,15 +13795,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12109,16 +13818,16 @@ entry:
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = load i32, i32* %arg1
   %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
   %7 = load i64, i64 addrspace(1)* %5
@@ -12136,7 +13845,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12173,8 +13882,8 @@ entry:
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
   %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
   %16 = load i64, i64 addrspace(1)* %14
@@ -12195,8 +13904,8 @@ entry:
   %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
   %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
   %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %31, null
-  br i1 %NullCheck2, label %32, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = load i64, i64 addrspace(1)* %31
@@ -12239,7 +13948,7 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12252,14 +13961,14 @@ entry:
   %this = alloca %System.Text.EncoderReplacementFallback addrspace(1)*
   store %System.Text.EncoderReplacementFallback addrspace(1)* %param0, %System.Text.EncoderReplacementFallback addrspace(1)** %this
   %0 = load %System.Text.EncoderReplacementFallback addrspace(1)*, %System.Text.EncoderReplacementFallback addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -12270,7 +13979,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12300,8 +14009,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
@@ -12333,8 +14042,8 @@ entry:
   %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
   store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
@@ -12346,8 +14055,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Threading.Tasks.Task addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %7)
@@ -12370,7 +14079,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12389,8 +14098,8 @@ entry:
   store i8 %param1, i8* %arg1
   store i8 %param2, i8* %arg2
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
@@ -12404,8 +14113,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1, %5
   %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 9
@@ -12436,8 +14145,8 @@ entry:
 
 ; <label>:25                                      ; preds = %8, %20
   %26 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %26, null
-  br i1 %NullCheck4, label %27, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %26, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %26, i32 0, i32 12
@@ -12448,22 +14157,22 @@ entry:
 
 ; <label>:32                                      ; preds = %27
   %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %33, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.IO.StreamWriter addrspace(1)* %33, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %32
   %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 12
   store i8 1, i8 addrspace(1)* %35
   %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
-  br i1 %NullCheck8, label %37, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
   %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
   %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck10 = icmp ne i64 addrspace(1)* %40, null
-  br i1 %NullCheck10, label %41, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64 addrspace(1)* %40, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i64, i64 addrspace(1)* %40
@@ -12477,8 +14186,8 @@ entry:
   %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
   store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
   %51 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %NullCheck12 = icmp ne %"System.Byte[]" addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Byte[]" addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %41
   %53 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %51, i32 0, i32 1
@@ -12490,16 +14199,16 @@ entry:
 
 ; <label>:58                                      ; preds = %52
   %59 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %59, null
-  br i1 %NullCheck14, label %60, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.IO.StreamWriter addrspace(1)* %59, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %60
 
 ; <label>:60                                      ; preds = %58
   %61 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %59, i32 0, i32 3
   %62 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
   %64 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %NullCheck16 = icmp ne %"System.Byte[]" addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %"System.Byte[]" addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %60
   %66 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %64, i32 0, i32 1
@@ -12507,8 +14216,8 @@ entry:
   %68 = zext i32 %67 to i64
   %69 = trunc i64 %68 to i32
   %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck18, label %71, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
   %72 = load i64, i64 addrspace(1)* %70
@@ -12524,29 +14233,29 @@ entry:
 
 ; <label>:80                                      ; preds = %27, %52, %71
   %81 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %81, null
-  br i1 %NullCheck20, label %82, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.IO.StreamWriter addrspace(1)* %81, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
 
 ; <label>:82                                      ; preds = %80
   %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %81, i32 0, i32 5
   %84 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %83, align 8
   %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.IO.StreamWriter addrspace(1)* %85, null
-  br i1 %NullCheck22, label %86, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.IO.StreamWriter addrspace(1)* %85, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %86
 
 ; <label>:86                                      ; preds = %82
   %87 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 7
   %88 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %87, align 8
   %89 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %89, null
-  br i1 %NullCheck24, label %90, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.StreamWriter addrspace(1)* %89, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %90
 
 ; <label>:90                                      ; preds = %86
   %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %89, i32 0, i32 9
   %92 = load i32, i32 addrspace(1)* %91, align 8
   %93 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.IO.StreamWriter addrspace(1)* %93, null
-  br i1 %NullCheck26, label %94, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.IO.StreamWriter addrspace(1)* %93, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %93, i32 0, i32 6
@@ -12554,8 +14263,8 @@ entry:
   %97 = load i8, i8* %arg2
   %98 = zext i8 %97 to i32
   %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
-  %NullCheck28 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck28, label %100, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
   %101 = load i64, i64 addrspace(1)* %99
@@ -12570,8 +14279,8 @@ entry:
   %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
   store i32 %110, i32* %loc1
   %111 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %111, null
-  br i1 %NullCheck30, label %112, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.IO.StreamWriter addrspace(1)* %111, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %112
 
 ; <label>:112                                     ; preds = %100
   %113 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %111, i32 0, i32 9
@@ -12582,23 +14291,23 @@ entry:
 
 ; <label>:116                                     ; preds = %112
   %117 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck32 = icmp ne %System.IO.StreamWriter addrspace(1)* %117, null
-  br i1 %NullCheck32, label %118, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.IO.StreamWriter addrspace(1)* %117, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %118
 
 ; <label>:118                                     ; preds = %116
   %119 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %117, i32 0, i32 3
   %120 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %119, align 8
   %121 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.IO.StreamWriter addrspace(1)* %121, null
-  br i1 %NullCheck34, label %122, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.IO.StreamWriter addrspace(1)* %121, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %122
 
 ; <label>:122                                     ; preds = %118
   %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
   %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
   %125 = load i32, i32* %loc1
   %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
-  %NullCheck36 = icmp ne i64 addrspace(1)* %126, null
-  br i1 %NullCheck36, label %127, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64 addrspace(1)* %126, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
   %128 = load i64, i64 addrspace(1)* %126
@@ -12620,15 +14329,15 @@ entry:
 
 ; <label>:140                                     ; preds = %136
   %141 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.IO.StreamWriter addrspace(1)* %141, null
-  br i1 %NullCheck38, label %142, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.IO.StreamWriter addrspace(1)* %141, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %142
 
 ; <label>:142                                     ; preds = %140
   %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
   %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
   %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
-  %NullCheck40 = icmp ne i64 addrspace(1)* %145, null
-  br i1 %NullCheck40, label %146, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i64 addrspace(1)* %145, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
   %147 = load i64, i64 addrspace(1)* %145
@@ -12649,83 +14358,83 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %25
+ThrowNullRef4:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %32
+ThrowNullRef6:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %37
+ThrowNullRef10:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %41
+ThrowNullRef12:                                   ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %58
+ThrowNullRef14:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %60
+ThrowNullRef16:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %65
+ThrowNullRef18:                                   ; preds = %65
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %80
+ThrowNullRef20:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %82
+ThrowNullRef22:                                   ; preds = %82
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %86
+ThrowNullRef24:                                   ; preds = %86
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %90
+ThrowNullRef26:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %94
+ThrowNullRef28:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %100
+ThrowNullRef30:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %116
+ThrowNullRef32:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %118
+ThrowNullRef34:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %122
+ThrowNullRef36:                                   ; preds = %122
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %140
+ThrowNullRef38:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %142
+ThrowNullRef40:                                   ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12792,8 +14501,8 @@ entry:
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %1 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
-  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
@@ -12801,8 +14510,8 @@ entry:
   %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
   %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
   %8 = load i64, i64 addrspace(1)* %6
@@ -12818,8 +14527,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %17, %System.IFormatProvider addrspace(1)* %16)
   %18 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %19 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %18, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.SyncTextWriter addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %7
   %21 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %18, i32 0, i32 4
@@ -12830,11 +14539,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12847,8 +14556,8 @@ entry:
   %this = alloca %System.IO.TextWriter addrspace(1)*
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.TextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
@@ -12858,8 +14567,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.Threading.Thread addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Threading.Thread addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %6)
@@ -12868,8 +14577,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1
   %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.TextWriter addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.TextWriter addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %11, i32 0, i32 2
@@ -12880,11 +14589,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13081,8 +14790,8 @@ entry:
   store double %param1, double* %arg1
   store i8 0, i8* %loc1
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
@@ -13092,16 +14801,16 @@ entry:
   %5 = addrspacecast i8* %loc1 to i8 addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %4, i8 addrspace(1)* %5)
   %6 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.SyncTextWriter addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
   %10 = load double, double* %arg1
   %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
   %13 = load i64, i64 addrspace(1)* %11
@@ -13136,11 +14845,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13157,8 +14866,8 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load double, double* %arg1
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -13172,8 +14881,8 @@ entry:
   call void %11(%System.IO.TextWriter addrspace(1)* %0, double %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
   %15 = load i64, i64 addrspace(1)* %13
@@ -13191,7 +14900,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13209,8 +14918,8 @@ entry:
   %1 = addrspacecast double* %arg1 to double addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -13225,8 +14934,8 @@ entry:
   %14 = bitcast double addrspace(1)* %1 to %System.Double addrspace(1)*
   %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Double addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Double addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
   %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
   %18 = load i64, i64 addrspace(1)* %16
@@ -13244,7 +14953,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13260,8 +14969,8 @@ entry:
   store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
   %0 = load %System.Double addrspace(1)*, %System.Double addrspace(1)** %this
   %1 = bitcast %System.Double addrspace(1)* %0 to double addrspace(1)*
-  %NullCheck = icmp ne double addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq double addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load double, double addrspace(1)* %1, align 8
@@ -13286,8 +14995,8 @@ entry:
   %loc0 = alloca %System.Globalization.NumberFormatInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 3
@@ -13297,8 +15006,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
@@ -13308,24 +15017,24 @@ entry:
   store %System.Globalization.NumberFormatInfo addrspace(1)* %10, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
   %11 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %7
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
   %15 = load i8, i8 addrspace(1)* %14, align 8
   %16 = zext i8 %15 to i32
   %17 = trunc i32 %16 to i8
-  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %11, null
-  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %11, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %13
   %19 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %11, i32 0, i32 29
   store i8 %17, i8 addrspace(1)* %19
   %20 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %21 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %20, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %20, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %18
   %23 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %20, i32 0, i32 3
@@ -13334,8 +15043,8 @@ entry:
 
 ; <label>:24                                      ; preds = %1, %22
   %25 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %25, null
-  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %25, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %26
 
 ; <label>:26                                      ; preds = %24
   %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %25, i32 0, i32 3
@@ -13346,23 +15055,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %18
+ThrowNullRef8:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13387,168 +15096,168 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 18
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %8, align 8
-  %NullCheck2 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %5, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %5, i32 0, i32 4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %9)
   %12 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 19
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %15, align 8
-  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %12, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %12, i32 0, i32 5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %16)
   %19 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %20 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %20, null
-  br i1 %NullCheck8, label %21, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %20, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %20, i32 0, i32 23
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  %NullCheck10 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %19, null
-  br i1 %NullCheck10, label %24, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %19, i32 0, i32 7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %25, %System.String addrspace(1)* %23)
   %26 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %27 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %27, i32 0, i32 22
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %29, align 8
-  %NullCheck14 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %26, null
-  br i1 %NullCheck14, label %31, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %26, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %26, i32 0, i32 6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %32, %System.String addrspace(1)* %30)
   %33 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %34 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Globalization.CultureData addrspace(1)* %34, null
-  br i1 %NullCheck16, label %35, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Globalization.CultureData addrspace(1)* %34, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %34, i32 0, i32 51
   %37 = load i32, i32 addrspace(1)* %36, align 8
-  %NullCheck18 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %33, null
-  br i1 %NullCheck18, label %38, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %33, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %33, i32 0, i32 21
   store i32 %37, i32 addrspace(1)* %39
   %40 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %41 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Globalization.CultureData addrspace(1)* %41, null
-  br i1 %NullCheck20, label %42, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Globalization.CultureData addrspace(1)* %41, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %41, i32 0, i32 52
   %44 = load i32, i32 addrspace(1)* %43, align 8
-  %NullCheck22 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %40, null
-  br i1 %NullCheck22, label %45, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %40, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %40, i32 0, i32 25
   store i32 %44, i32 addrspace(1)* %46
   %47 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %48 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.Globalization.CultureData addrspace(1)* %48, null
-  br i1 %NullCheck24, label %49, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Globalization.CultureData addrspace(1)* %48, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %49
 
 ; <label>:49                                      ; preds = %45
   %50 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %48, i32 0, i32 29
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck26 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %47, null
-  br i1 %NullCheck26, label %52, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %47, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %47, i32 0, i32 10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %53, %System.String addrspace(1)* %51)
   %54 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %55 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Globalization.CultureData addrspace(1)* %55, null
-  br i1 %NullCheck28, label %56, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Globalization.CultureData addrspace(1)* %55, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %56
 
 ; <label>:56                                      ; preds = %52
   %57 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %55, i32 0, i32 35
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %57, align 8
-  %NullCheck30 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %54, null
-  br i1 %NullCheck30, label %59, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %54, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %54, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %60, %System.String addrspace(1)* %58)
   %61 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %62 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck32 = icmp ne %System.Globalization.CultureData addrspace(1)* %62, null
-  br i1 %NullCheck32, label %63, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Globalization.CultureData addrspace(1)* %62, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %62, i32 0, i32 34
   %65 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %64, align 8
-  %NullCheck34 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %61, null
-  br i1 %NullCheck34, label %66, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %61, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %61, i32 0, i32 9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %67, %System.String addrspace(1)* %65)
   %68 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %69 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck36 = icmp ne %System.Globalization.CultureData addrspace(1)* %69, null
-  br i1 %NullCheck36, label %70, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Globalization.CultureData addrspace(1)* %69, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %70
 
 ; <label>:70                                      ; preds = %66
   %71 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %69, i32 0, i32 55
   %72 = load i32, i32 addrspace(1)* %71, align 8
-  %NullCheck38 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %68, null
-  br i1 %NullCheck38, label %73, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %68, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %68, i32 0, i32 22
   store i32 %72, i32 addrspace(1)* %74
   %75 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %76 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck40 = icmp ne %System.Globalization.CultureData addrspace(1)* %76, null
-  br i1 %NullCheck40, label %77, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Globalization.CultureData addrspace(1)* %76, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %76, i32 0, i32 57
   %79 = load i32, i32 addrspace(1)* %78, align 8
-  %NullCheck42 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %75, null
-  br i1 %NullCheck42, label %80, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %75, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %80
 
 ; <label>:80                                      ; preds = %77
   %81 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %75, i32 0, i32 24
   store i32 %79, i32 addrspace(1)* %81
   %82 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %83 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck44 = icmp ne %System.Globalization.CultureData addrspace(1)* %83, null
-  br i1 %NullCheck44, label %84, label %ThrowNullRef43
+  %NullCheck43 = icmp eq %System.Globalization.CultureData addrspace(1)* %83, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %84
 
 ; <label>:84                                      ; preds = %80
   %85 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %83, i32 0, i32 56
   %86 = load i32, i32 addrspace(1)* %85, align 8
-  %NullCheck46 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %82, null
-  br i1 %NullCheck46, label %87, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %82, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %82, i32 0, i32 23
@@ -13557,8 +15266,8 @@ entry:
 
 ; <label>:89                                      ; preds = %entry
   %90 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck100 = icmp ne %System.Globalization.CultureData addrspace(1)* %90, null
-  br i1 %NullCheck100, label %91, label %ThrowNullRef99
+  %NullCheck99 = icmp eq %System.Globalization.CultureData addrspace(1)* %90, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %91
 
 ; <label>:91                                      ; preds = %89
   %92 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %90, i32 0, i32 2
@@ -13576,8 +15285,8 @@ entry:
   %102 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %103 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %104 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %103)
-  %NullCheck48 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %102, null
-  br i1 %NullCheck48, label %105, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %102, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %105
 
 ; <label>:105                                     ; preds = %101
   %106 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %102, i32 0, i32 1
@@ -13585,8 +15294,8 @@ entry:
   %107 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %108 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %109 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %108)
-  %NullCheck50 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %107, null
-  br i1 %NullCheck50, label %110, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %107, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %110
 
 ; <label>:110                                     ; preds = %105
   %111 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %107, i32 0, i32 2
@@ -13594,8 +15303,8 @@ entry:
   %112 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %113 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %114 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %113)
-  %NullCheck52 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %112, null
-  br i1 %NullCheck52, label %115, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %112, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %115
 
 ; <label>:115                                     ; preds = %110
   %116 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %112, i32 0, i32 27
@@ -13603,8 +15312,8 @@ entry:
   %117 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %118 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %119 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %118)
-  %NullCheck54 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %117, null
-  br i1 %NullCheck54, label %120, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %117, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %120
 
 ; <label>:120                                     ; preds = %115
   %121 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %117, i32 0, i32 26
@@ -13612,8 +15321,8 @@ entry:
   %122 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %123 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %124 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %123)
-  %NullCheck56 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %122, null
-  br i1 %NullCheck56, label %125, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %122, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %125
 
 ; <label>:125                                     ; preds = %120
   %126 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %122, i32 0, i32 17
@@ -13621,8 +15330,8 @@ entry:
   %127 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %128 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %129 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %128)
-  %NullCheck58 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %127, null
-  br i1 %NullCheck58, label %130, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %127, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %130
 
 ; <label>:130                                     ; preds = %125
   %131 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %127, i32 0, i32 18
@@ -13630,8 +15339,8 @@ entry:
   %132 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %133 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %134 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %133)
-  %NullCheck60 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %132, null
-  br i1 %NullCheck60, label %135, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %132, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %135
 
 ; <label>:135                                     ; preds = %130
   %136 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %132, i32 0, i32 14
@@ -13639,8 +15348,8 @@ entry:
   %137 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %138 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %139 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %138)
-  %NullCheck62 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %137, null
-  br i1 %NullCheck62, label %140, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %137, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %140
 
 ; <label>:140                                     ; preds = %135
   %141 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %137, i32 0, i32 13
@@ -13648,71 +15357,71 @@ entry:
   %142 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %143 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %144 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %143)
-  %NullCheck64 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %142, null
-  br i1 %NullCheck64, label %145, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %142, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %145
 
 ; <label>:145                                     ; preds = %140
   %146 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %142, i32 0, i32 12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %146, %System.String addrspace(1)* %144)
   %147 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %148 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck66 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %148, null
-  br i1 %NullCheck66, label %149, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %148, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %149
 
 ; <label>:149                                     ; preds = %145
   %150 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %148, i32 0, i32 21
   %151 = load i32, i32 addrspace(1)* %150, align 8
-  %NullCheck68 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %147, null
-  br i1 %NullCheck68, label %152, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %147, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %152
 
 ; <label>:152                                     ; preds = %149
   %153 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %147, i32 0, i32 28
   store i32 %151, i32 addrspace(1)* %153
   %154 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %155 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck70 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %155, null
-  br i1 %NullCheck70, label %156, label %ThrowNullRef69
+  %NullCheck69 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %155, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %156
 
 ; <label>:156                                     ; preds = %152
   %157 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %155, i32 0, i32 6
   %158 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %157, align 8
-  %NullCheck72 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %154, null
-  br i1 %NullCheck72, label %159, label %ThrowNullRef71
+  %NullCheck71 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %154, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %159
 
 ; <label>:159                                     ; preds = %156
   %160 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %154, i32 0, i32 15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %160, %System.String addrspace(1)* %158)
   %161 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %162 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck74 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %162, null
-  br i1 %NullCheck74, label %163, label %ThrowNullRef73
+  %NullCheck73 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %162, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %163
 
 ; <label>:163                                     ; preds = %159
   %164 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %162, i32 0, i32 1
   %165 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %164, align 8
-  %NullCheck76 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %161, null
-  br i1 %NullCheck76, label %166, label %ThrowNullRef75
+  %NullCheck75 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %161, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %166
 
 ; <label>:166                                     ; preds = %163
   %167 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %161, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %167, %"System.Int32[]" addrspace(1)* %165)
   %168 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %169 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck78 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %169, null
-  br i1 %NullCheck78, label %170, label %ThrowNullRef77
+  %NullCheck77 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %169, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %170
 
 ; <label>:170                                     ; preds = %166
   %171 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %169, i32 0, i32 7
   %172 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %171, align 8
-  %NullCheck80 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %168, null
-  br i1 %NullCheck80, label %173, label %ThrowNullRef79
+  %NullCheck79 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %168, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %173
 
 ; <label>:173                                     ; preds = %170
   %174 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %168, i32 0, i32 16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %174, %System.String addrspace(1)* %172)
   %175 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck82 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %175, null
-  br i1 %NullCheck82, label %176, label %ThrowNullRef81
+  %NullCheck81 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %175, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %176
 
 ; <label>:176                                     ; preds = %173
   %177 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %175, i32 0, i32 4
@@ -13722,14 +15431,14 @@ entry:
 
 ; <label>:180                                     ; preds = %176
   %181 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck84 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %181, null
-  br i1 %NullCheck84, label %182, label %ThrowNullRef83
+  %NullCheck83 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %181, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %182
 
 ; <label>:182                                     ; preds = %180
   %183 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %181, i32 0, i32 4
   %184 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %183, align 8
-  %NullCheck86 = icmp ne %System.String addrspace(1)* %184, null
-  br i1 %NullCheck86, label %185, label %ThrowNullRef85
+  %NullCheck85 = icmp eq %System.String addrspace(1)* %184, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %185
 
 ; <label>:185                                     ; preds = %182
   %186 = getelementptr inbounds %System.String, %System.String addrspace(1)* %184, i32 0, i32 1
@@ -13740,8 +15449,8 @@ entry:
 ; <label>:189                                     ; preds = %176, %185
   %190 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck98 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %190, null
-  br i1 %NullCheck98, label %192, label %ThrowNullRef97
+  %NullCheck97 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %190, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %192
 
 ; <label>:192                                     ; preds = %189
   %193 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %190, i32 0, i32 4
@@ -13750,8 +15459,8 @@ entry:
 
 ; <label>:194                                     ; preds = %185, %192
   %195 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck88 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %195, null
-  br i1 %NullCheck88, label %196, label %ThrowNullRef87
+  %NullCheck87 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %195, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %196
 
 ; <label>:196                                     ; preds = %194
   %197 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %195, i32 0, i32 9
@@ -13761,14 +15470,14 @@ entry:
 
 ; <label>:200                                     ; preds = %196
   %201 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck90 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %201, null
-  br i1 %NullCheck90, label %202, label %ThrowNullRef89
+  %NullCheck89 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %201, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %202
 
 ; <label>:202                                     ; preds = %200
   %203 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %201, i32 0, i32 9
   %204 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %203, align 8
-  %NullCheck92 = icmp ne %System.String addrspace(1)* %204, null
-  br i1 %NullCheck92, label %205, label %ThrowNullRef91
+  %NullCheck91 = icmp eq %System.String addrspace(1)* %204, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %205
 
 ; <label>:205                                     ; preds = %202
   %206 = getelementptr inbounds %System.String, %System.String addrspace(1)* %204, i32 0, i32 1
@@ -13779,14 +15488,14 @@ entry:
 ; <label>:209                                     ; preds = %196, %205
   %210 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %211 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck94 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %211, null
-  br i1 %NullCheck94, label %212, label %ThrowNullRef93
+  %NullCheck93 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %211, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %212
 
 ; <label>:212                                     ; preds = %209
   %213 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %211, i32 0, i32 6
   %214 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %213, align 8
-  %NullCheck96 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %210, null
-  br i1 %NullCheck96, label %215, label %ThrowNullRef95
+  %NullCheck95 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %210, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %215
 
 ; <label>:215                                     ; preds = %212
   %216 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %210, i32 0, i32 9
@@ -13800,203 +15509,203 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %17
+ThrowNullRef8:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %21
+ThrowNullRef10:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %24
+ThrowNullRef12:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %28
+ThrowNullRef14:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %31
+ThrowNullRef16:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %35
+ThrowNullRef18:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %38
+ThrowNullRef20:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %42
+ThrowNullRef22:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %45
+ThrowNullRef24:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %49
+ThrowNullRef26:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %52
+ThrowNullRef28:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %56
+ThrowNullRef30:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %59
+ThrowNullRef32:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %63
+ThrowNullRef34:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %66
+ThrowNullRef36:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %70
+ThrowNullRef38:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %73
+ThrowNullRef40:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %77
+ThrowNullRef42:                                   ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %80
+ThrowNullRef44:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %84
+ThrowNullRef46:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %101
+ThrowNullRef48:                                   ; preds = %101
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %105
+ThrowNullRef50:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %110
+ThrowNullRef52:                                   ; preds = %110
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %115
+ThrowNullRef54:                                   ; preds = %115
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %120
+ThrowNullRef56:                                   ; preds = %120
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %125
+ThrowNullRef58:                                   ; preds = %125
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %130
+ThrowNullRef60:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %135
+ThrowNullRef62:                                   ; preds = %135
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %140
+ThrowNullRef64:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %145
+ThrowNullRef66:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %149
+ThrowNullRef68:                                   ; preds = %149
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %152
+ThrowNullRef70:                                   ; preds = %152
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %156
+ThrowNullRef72:                                   ; preds = %156
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %159
+ThrowNullRef74:                                   ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %163
+ThrowNullRef76:                                   ; preds = %163
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %166
+ThrowNullRef78:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %170
+ThrowNullRef80:                                   ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %173
+ThrowNullRef82:                                   ; preds = %173
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %180
+ThrowNullRef84:                                   ; preds = %180
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %182
+ThrowNullRef86:                                   ; preds = %182
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %194
+ThrowNullRef88:                                   ; preds = %194
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %200
+ThrowNullRef90:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %202
+ThrowNullRef92:                                   ; preds = %202
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %209
+ThrowNullRef94:                                   ; preds = %209
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %212
+ThrowNullRef96:                                   ; preds = %212
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %189
+ThrowNullRef98:                                   ; preds = %189
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %89
+ThrowNullRef100:                                  ; preds = %89
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14024,8 +15733,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 21
@@ -14038,8 +15747,8 @@ entry:
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 16)
   %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 21
@@ -14048,8 +15757,8 @@ entry:
 
 ; <label>:12                                      ; preds = %1, %10
   %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 21
@@ -14060,11 +15769,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %12
+ThrowNullRef4:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14080,8 +15789,8 @@ entry:
   store i32 %param1, i32* %arg1
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %1 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
@@ -14148,8 +15857,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 33
@@ -14162,8 +15871,8 @@ entry:
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 24)
   %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 33
@@ -14172,8 +15881,8 @@ entry:
 
 ; <label>:12                                      ; preds = %1, %10
   %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 33
@@ -14184,11 +15893,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %12
+ThrowNullRef4:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14201,8 +15910,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 53
@@ -14214,8 +15923,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 116)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 53
@@ -14224,8 +15933,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 53
@@ -14236,11 +15945,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14269,8 +15978,8 @@ entry:
 
 ; <label>:7                                       ; preds = %entry, %4
   %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %7
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 2
@@ -14294,8 +16003,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 54
@@ -14307,8 +16016,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 117)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
@@ -14317,8 +16026,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 54
@@ -14329,11 +16038,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14346,8 +16055,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 27
@@ -14359,8 +16068,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 118)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 27
@@ -14369,8 +16078,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 27
@@ -14381,11 +16090,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14398,8 +16107,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 28
@@ -14411,8 +16120,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 119)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 28
@@ -14421,8 +16130,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 28
@@ -14433,11 +16142,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14450,8 +16159,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 26
@@ -14463,8 +16172,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 107)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 26
@@ -14473,8 +16182,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 26
@@ -14485,11 +16194,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14502,8 +16211,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 25
@@ -14515,8 +16224,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 106)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 25
@@ -14525,8 +16234,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 25
@@ -14537,11 +16246,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14554,8 +16263,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 24
@@ -14567,8 +16276,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 105)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 24
@@ -14577,8 +16286,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 24
@@ -14589,11 +16298,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14618,8 +16327,8 @@ entry:
   %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %3)
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %2
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -14630,15 +16339,15 @@ entry:
 
 ; <label>:8                                       ; preds = %62
   %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 9
   %12 = load i32, i32 addrspace(1)* %11, align 8
   %13 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.IO.StreamWriter addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %13, i32 0, i32 10
@@ -14653,15 +16362,15 @@ entry:
 
 ; <label>:20                                      ; preds = %14, %18
   %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
   %24 = load i32, i32 addrspace(1)* %23, align 8
   %25 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %25, null
-  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.StreamWriter addrspace(1)* %25, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %25, i32 0, i32 9
@@ -14682,36 +16391,36 @@ entry:
   %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %37 = load i32, i32* %loc1
   %38 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.StreamWriter addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %35
   %40 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %38, i32 0, i32 7
   %41 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %40, align 8
   %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
-  br i1 %NullCheck14, label %43, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %39
   %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 9
   %45 = load i32, i32 addrspace(1)* %44, align 8
   %46 = load i32, i32* %loc2
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %36, null
-  br i1 %NullCheck16, label %47, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %36, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %47
 
 ; <label>:47                                      ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %36, i32 %37, %"System.Char[]" addrspace(1)* %41, i32 %45, i32 %46)
   %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
   %51 = load i32, i32 addrspace(1)* %50, align 8
   %52 = load i32, i32* %loc2
   %53 = add i32 %51, %52
-  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
-  br i1 %NullCheck20, label %54, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %54
 
 ; <label>:54                                      ; preds = %49
   %55 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
@@ -14733,8 +16442,8 @@ entry:
 
 ; <label>:65                                      ; preds = %62
   %66 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %66, null
-  br i1 %NullCheck2, label %67, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %66, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %67
 
 ; <label>:67                                      ; preds = %65
   %68 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %66, i32 0, i32 11
@@ -14755,49 +16464,259 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %65
+ThrowNullRef2:                                    ; preds = %65
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %20
+ThrowNullRef8:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %22
+ThrowNullRef10:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %35
+ThrowNullRef12:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %43
+ThrowNullRef16:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %47
+ThrowNullRef18:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method String::CopyTo using LLILCJit
-Failed to read String.CopyTo[loadElemA]
+Successfully read String.CopyTo
+
+define void @String.CopyTo(%System.String addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  %loc1 = alloca i16 addrspace(1)*
+  %loc2 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %1 = icmp ne %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg4
+  %7 = icmp sge i32 %6, 0
+  br i1 %7, label %13, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  unreachable
+
+; <label>:13                                      ; preds = %5
+  %14 = load i32, i32* %arg1
+  %15 = icmp sge i32 %14, 0
+  br i1 %15, label %21, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %18)
+  %20 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %20, %System.String addrspace(1)* %17, %System.String addrspace(1)* %19)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %20) #0
+  unreachable
+
+; <label>:21                                      ; preds = %13
+  %22 = load i32, i32* %arg4
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck, label %ThrowNullRef, label %24
+
+; <label>:24                                      ; preds = %21
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load i32, i32* %arg1
+  %28 = sub i32 %26, %27
+  %29 = icmp sle i32 %22, %28
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34, %System.String addrspace(1)* %31, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %24
+  %36 = load i32, i32* %arg3
+  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %37, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
+
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
+  %40 = load i32, i32 addrspace(1)* %39
+  %41 = zext i32 %40 to i64
+  %42 = trunc i64 %41 to i32
+  %43 = load i32, i32* %arg4
+  %44 = sub i32 %42, %43
+  %45 = icmp sgt i32 %36, %44
+  br i1 %45, label %49, label %46
+
+; <label>:46                                      ; preds = %38
+  %47 = load i32, i32* %arg3
+  %48 = icmp sge i32 %47, 0
+  br i1 %48, label %54, label %49
+
+; <label>:49                                      ; preds = %38, %46
+  %50 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %52 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %51)
+  %53 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53, %System.String addrspace(1)* %50, %System.String addrspace(1)* %52)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53) #0
+  unreachable
+
+; <label>:54                                      ; preds = %46
+  %55 = load i32, i32* %arg4
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %97, label %57
+
+; <label>:57                                      ; preds = %54
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %59
+
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 2
+  %61 = bitcast [0 x i16] addrspace(1)* %60 to i16 addrspace(1)*
+  store i16 addrspace(1)* %61, i16 addrspace(1)** %loc0
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  store %"System.Char[]" addrspace(1)* %62, %"System.Char[]" addrspace(1)** %loc2
+  %63 = icmp eq %"System.Char[]" addrspace(1)* %62, null
+  br i1 %63, label %72, label %64
+
+; <label>:64                                      ; preds = %59
+  %65 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc2
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %65, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %66
+
+; <label>:66                                      ; preds = %64
+  %67 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %65, i32 0, i32 1
+  %68 = load i32, i32 addrspace(1)* %67
+  %69 = zext i32 %68 to i64
+  %70 = trunc i64 %69 to i32
+  %71 = icmp ne i32 %70, 0
+  br i1 %71, label %73, label %72
+
+; <label>:72                                      ; preds = %59, %66
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  br label %81
+
+; <label>:73                                      ; preds = %66
+  %74 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc2
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %74, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %75
+
+; <label>:75                                      ; preds = %73
+  %76 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %74, i32 0, i32 1
+  %77 = load i32, i32 addrspace(1)* %76
+  %78 = zext i32 %77 to i64
+  %BoundsCheck = icmp uge i64 0, %78
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %79
+
+; <label>:79                                      ; preds = %75
+  %80 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %74, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %80, i16 addrspace(1)** %loc1
+  br label %81
+
+; <label>:81                                      ; preds = %72, %79
+  %82 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %83 = ptrtoint i16 addrspace(1)* %82 to i64
+  %84 = load i32, i32* %arg3
+  %85 = sext i32 %84 to i64
+  %86 = mul i64 %85, 2
+  %87 = add i64 %83, %86
+  %88 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %89 = ptrtoint i16 addrspace(1)* %88 to i64
+  %90 = load i32, i32* %arg1
+  %91 = sext i32 %90 to i64
+  %92 = mul i64 %91, 2
+  %93 = add i64 %89, %92
+  %94 = load i32, i32* %arg4
+  %95 = inttoptr i64 %87 to i16*
+  %96 = inttoptr i64 %93 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %95, i16* %96, i32 %94)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  br label %97
+
+; <label>:97                                      ; preds = %54, %81
+  ret void
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
 Successfully read ConsoleEncoding.GetPreamble
 
@@ -14834,7 +16753,365 @@ entry:
 }
 
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[loadElemA]
+Successfully read EncoderNLS.GetBytes
+
+define i32 @EncoderNLS.GetBytes(%System.Text.EncoderNLS addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3, %"System.Byte[]" addrspace(1)* %param4, i32 %param5, i8 %param6) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %arg4 = alloca %"System.Byte[]" addrspace(1)*
+  %arg5 = alloca i32
+  %arg6 = alloca i8
+  %loc0 = alloca i32
+  %loc1 = alloca i16 addrspace(1)*
+  %loc2 = alloca i8 addrspace(1)*
+  %loc3 = alloca i32
+  %loc4 = alloca %"System.Char[]" addrspace(1)*
+  %loc5 = alloca %"System.Byte[]" addrspace(1)*
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  store %"System.Byte[]" addrspace(1)* %param4, %"System.Byte[]" addrspace(1)** %arg4
+  store i32 %param5, i32* %arg5
+  store i8 %param6, i8* %arg6
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %1 = icmp eq %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %17, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %7 = icmp eq %"System.Char[]" addrspace(1)* %6, null
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %12
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %12
+
+; <label>:12                                      ; preds = %8, %10
+  %13 = phi %System.String addrspace(1)* [ %9, %8 ], [ %11, %10 ]
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %14)
+  %16 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16, %System.String addrspace(1)* %13, %System.String addrspace(1)* %15)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16) #0
+  unreachable
+
+; <label>:17                                      ; preds = %2
+  %18 = load i32, i32* %arg2
+  %19 = icmp slt i32 %18, 0
+  br i1 %19, label %23, label %20
+
+; <label>:20                                      ; preds = %17
+  %21 = load i32, i32* %arg3
+  %22 = icmp sge i32 %21, 0
+  br i1 %22, label %35, label %23
+
+; <label>:23                                      ; preds = %17, %20
+  %24 = load i32, i32* %arg2
+  %25 = icmp slt i32 %24, 0
+  br i1 %25, label %28, label %26
+
+; <label>:26                                      ; preds = %23
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %30
+
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %30
+
+; <label>:30                                      ; preds = %26, %28
+  %31 = phi %System.String addrspace(1)* [ %27, %26 ], [ %29, %28 ]
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34, %System.String addrspace(1)* %31, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %20
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck, label %ThrowNullRef, label %37
+
+; <label>:37                                      ; preds = %35
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = load i32, i32* %arg2
+  %43 = sub i32 %41, %42
+  %44 = load i32, i32* %arg3
+  %45 = icmp sge i32 %43, %44
+  br i1 %45, label %51, label %46
+
+; <label>:46                                      ; preds = %37
+  %47 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %48 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %49 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %48)
+  %50 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %50, %System.String addrspace(1)* %47, %System.String addrspace(1)* %49)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %50) #0
+  unreachable
+
+; <label>:51                                      ; preds = %37
+  %52 = load i32, i32* %arg5
+  %53 = icmp slt i32 %52, 0
+  br i1 %53, label %63, label %54
+
+; <label>:54                                      ; preds = %51
+  %55 = load i32, i32* %arg5
+  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck1 = icmp eq %"System.Byte[]" addrspace(1)* %56, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %57
+
+; <label>:57                                      ; preds = %54
+  %58 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = zext i32 %59 to i64
+  %61 = trunc i64 %60 to i32
+  %62 = icmp sle i32 %55, %61
+  br i1 %62, label %68, label %63
+
+; <label>:63                                      ; preds = %51, %57
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %66 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %65)
+  %67 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %67, %System.String addrspace(1)* %64, %System.String addrspace(1)* %66)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %67) #0
+  unreachable
+
+; <label>:68                                      ; preds = %57
+  %69 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %69, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %69, i32 0, i32 1
+  %72 = load i32, i32 addrspace(1)* %71
+  %73 = zext i32 %72 to i64
+  %74 = trunc i64 %73 to i32
+  %75 = icmp ne i32 %74, 0
+  br i1 %75, label %78, label %76
+
+; <label>:76                                      ; preds = %70
+  %77 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1)
+  store %"System.Char[]" addrspace(1)* %77, %"System.Char[]" addrspace(1)** %arg1
+  br label %78
+
+; <label>:78                                      ; preds = %70, %76
+  %79 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck5 = icmp eq %"System.Byte[]" addrspace(1)* %79, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %80
+
+; <label>:80                                      ; preds = %78
+  %81 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %79, i32 0, i32 1
+  %82 = load i32, i32 addrspace(1)* %81
+  %83 = zext i32 %82 to i64
+  %84 = trunc i64 %83 to i32
+  %85 = load i32, i32* %arg5
+  %86 = sub i32 %84, %85
+  store i32 %86, i32* %loc0
+  %87 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck7 = icmp eq %"System.Byte[]" addrspace(1)* %87, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %88
+
+; <label>:88                                      ; preds = %80
+  %89 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %87, i32 0, i32 1
+  %90 = load i32, i32 addrspace(1)* %89
+  %91 = zext i32 %90 to i64
+  %92 = trunc i64 %91 to i32
+  %93 = icmp ne i32 %92, 0
+  br i1 %93, label %96, label %94
+
+; <label>:94                                      ; preds = %88
+  %95 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1)
+  store %"System.Byte[]" addrspace(1)* %95, %"System.Byte[]" addrspace(1)** %arg4
+  br label %96
+
+; <label>:96                                      ; preds = %88, %94
+  %97 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  store %"System.Char[]" addrspace(1)* %97, %"System.Char[]" addrspace(1)** %loc4
+  %98 = icmp eq %"System.Char[]" addrspace(1)* %97, null
+  br i1 %98, label %107, label %99
+
+; <label>:99                                      ; preds = %96
+  %100 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc4
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %100, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %101
+
+; <label>:101                                     ; preds = %99
+  %102 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %100, i32 0, i32 1
+  %103 = load i32, i32 addrspace(1)* %102
+  %104 = zext i32 %103 to i64
+  %105 = trunc i64 %104 to i32
+  %106 = icmp ne i32 %105, 0
+  br i1 %106, label %108, label %107
+
+; <label>:107                                     ; preds = %96, %101
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  br label %116
+
+; <label>:108                                     ; preds = %101
+  %109 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc4
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %109, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %110
+
+; <label>:110                                     ; preds = %108
+  %111 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %109, i32 0, i32 1
+  %112 = load i32, i32 addrspace(1)* %111
+  %113 = zext i32 %112 to i64
+  %BoundsCheck = icmp uge i64 0, %113
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %114
+
+; <label>:114                                     ; preds = %110
+  %115 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %109, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %115, i16 addrspace(1)** %loc1
+  br label %116
+
+; <label>:116                                     ; preds = %107, %114
+  %117 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  store %"System.Byte[]" addrspace(1)* %117, %"System.Byte[]" addrspace(1)** %loc5
+  %118 = icmp eq %"System.Byte[]" addrspace(1)* %117, null
+  br i1 %118, label %127, label %119
+
+; <label>:119                                     ; preds = %116
+  %120 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc5
+  %NullCheck13 = icmp eq %"System.Byte[]" addrspace(1)* %120, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %121
+
+; <label>:121                                     ; preds = %119
+  %122 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %120, i32 0, i32 1
+  %123 = load i32, i32 addrspace(1)* %122
+  %124 = zext i32 %123 to i64
+  %125 = trunc i64 %124 to i32
+  %126 = icmp ne i32 %125, 0
+  br i1 %126, label %128, label %127
+
+; <label>:127                                     ; preds = %116, %121
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc2
+  br label %136
+
+; <label>:128                                     ; preds = %121
+  %129 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc5
+  %NullCheck15 = icmp eq %"System.Byte[]" addrspace(1)* %129, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %130
+
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %129, i32 0, i32 1
+  %132 = load i32, i32 addrspace(1)* %131
+  %133 = zext i32 %132 to i64
+  %BoundsCheck17 = icmp uge i64 0, %133
+  br i1 %BoundsCheck17, label %ThrowIndexOutOfRange18, label %134
+
+; <label>:134                                     ; preds = %130
+  %135 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %129, i32 0, i32 3, i32 0
+  store i8 addrspace(1)* %135, i8 addrspace(1)** %loc2
+  br label %136
+
+; <label>:136                                     ; preds = %127, %134
+  %137 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %138 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %139 = ptrtoint i16 addrspace(1)* %138 to i64
+  %140 = load i32, i32* %arg2
+  %141 = sext i32 %140 to i64
+  %142 = mul i64 %141, 2
+  %143 = add i64 %139, %142
+  %144 = load i32, i32* %arg3
+  %145 = load i8 addrspace(1)*, i8 addrspace(1)** %loc2
+  %146 = ptrtoint i8 addrspace(1)* %145 to i64
+  %147 = load i32, i32* %arg5
+  %148 = sext i32 %147 to i64
+  %149 = add i64 %146, %148
+  %150 = load i32, i32* %loc0
+  %151 = load i8, i8* %arg6
+  %152 = zext i8 %151 to i32
+  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i64 addrspace(1)*
+  %NullCheck19 = icmp eq i64 addrspace(1)* %153, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %154
+
+; <label>:154                                     ; preds = %136
+  %155 = load i64, i64 addrspace(1)* %153
+  %156 = add i64 %155, 72
+  %157 = inttoptr i64 %156 to i64*
+  %158 = load i64, i64* %157
+  %159 = add i64 %158, 0
+  %160 = inttoptr i64 %159 to i64*
+  %161 = load i64, i64* %160
+  %162 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to %System.Text.Encoder addrspace(1)*
+  %163 = inttoptr i64 %143 to i16*
+  %164 = inttoptr i64 %149 to i8*
+  %165 = trunc i32 %152 to i8
+  %166 = inttoptr i64 %161 to i32 (%System.Text.Encoder addrspace(1)*, i16*, i32, i8*, i32, i8)*
+  %167 = call i32 %166(%System.Text.Encoder addrspace(1)* %162, i16* %163, i32 %144, i8* %164, i32 %150, i8 %165)
+  store i32 %167, i32* %loc3
+  br label %168
+
+; <label>:168                                     ; preds = %154
+  %169 = load i32, i32* %loc3
+  ret i32 %169
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %110
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %119
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange18:                           ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
 Successfully read EncoderNLS.GetBytes
 
@@ -14923,22 +17200,22 @@ entry:
   %40 = load i8, i8* %arg5
   %41 = zext i8 %40 to i32
   %42 = trunc i32 %41 to i8
-  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %39, null
-  br i1 %NullCheck, label %43, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderNLS addrspace(1)* %39, null
+  br i1 %NullCheck, label %ThrowNullRef, label %43
 
 ; <label>:43                                      ; preds = %38
   %44 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
   store i8 %42, i8 addrspace(1)* %44
   %45 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %45, null
-  br i1 %NullCheck2, label %46, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.EncoderNLS addrspace(1)* %45, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %46
 
 ; <label>:46                                      ; preds = %43
   %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %45, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %47
   %48 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.EncoderNLS addrspace(1)* %48, null
-  br i1 %NullCheck4, label %49, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.EncoderNLS addrspace(1)* %48, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %49
 
 ; <label>:49                                      ; preds = %46
   %50 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %48, i32 0, i32 3
@@ -14949,8 +17226,8 @@ entry:
   %55 = load i32, i32* %arg4
   %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck6, label %58, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
   %59 = load i64, i64 addrspace(1)* %57
@@ -14968,15 +17245,15 @@ ThrowNullRef:                                     ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %43
+ThrowNullRef2:                                    ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %46
+ThrowNullRef4:                                    ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %49
+ThrowNullRef6:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -15004,8 +17281,8 @@ entry:
   %4 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0 to %System.IO.ConsoleStream addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*)(%System.IO.ConsoleStream addrspace(1)* %4, %"System.Byte[]" addrspace(1)* %1, i32 %2, i32 %3)
   %5 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
@@ -15090,8 +17367,8 @@ entry:
 
 ; <label>:22                                      ; preds = %8
   %23 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %23, null
-  br i1 %NullCheck, label %24, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Byte[]" addrspace(1)* %23, null
+  br i1 %NullCheck, label %ThrowNullRef, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
@@ -15113,8 +17390,8 @@ entry:
 
 ; <label>:36                                      ; preds = %24
   %37 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %37, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.ConsoleStream addrspace(1)* %37, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %37, i32 0, i32 4
@@ -15135,13 +17412,138 @@ ThrowNullRef:                                     ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %36
+ThrowNullRef2:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
-Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
+Successfully read WindowsConsoleStream.WriteFileNative
+
+define i32 @WindowsConsoleStream.WriteFileNative(i64 %param0, %"System.Byte[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i64
+  %arg1 = alloca %"System.Byte[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i8 addrspace(1)*
+  %loc2 = alloca %"System.Byte[]" addrspace(1)*
+  %loc3 = alloca i32
+  store i64 %param0, i64* %arg0
+  store %"System.Byte[]" addrspace(1)* %param1, %"System.Byte[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Byte[]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = zext i32 %3 to i64
+  %5 = icmp ne i64 %4, 0
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %1
+  ret i32 0
+
+; <label>:7                                       ; preds = %1
+  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  store %"System.Byte[]" addrspace(1)* %8, %"System.Byte[]" addrspace(1)** %loc2
+  %9 = icmp eq %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %9, label %18, label %10
+
+; <label>:10                                      ; preds = %7
+  %11 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc2
+  %NullCheck1 = icmp eq %"System.Byte[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %11, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp ne i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %7, %12
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc1
+  br label %27
+
+; <label>:19                                      ; preds = %12
+  %20 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc2
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %20, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %BoundsCheck = icmp uge i64 0, %24
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %25
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %20, i32 0, i32 3, i32 0
+  store i8 addrspace(1)* %26, i8 addrspace(1)** %loc1
+  br label %27
+
+; <label>:27                                      ; preds = %18, %25
+  %28 = load i64, i64* %arg0
+  %29 = load i8 addrspace(1)*, i8 addrspace(1)** %loc1
+  %30 = ptrtoint i8 addrspace(1)* %29 to i64
+  %31 = load i32, i32* %arg2
+  %32 = sext i32 %31 to i64
+  %33 = add i64 %30, %32
+  %34 = load i32, i32* %arg3
+  %35 = addrspacecast i32* %loc3 to i32 addrspace(1)*
+  %36 = inttoptr i64 %33 to i8*
+  %37 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i8*, i32, i32 addrspace(1)*, i64)*)(i64 %28, i8* %36, i32 %34, i32 addrspace(1)* %35, i64 0)
+  %38 = icmp ugt i32 %37, 0
+  %39 = sext i1 %38 to i32
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc1
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %42, label %41
+
+; <label>:41                                      ; preds = %27
+  ret i32 0
+
+; <label>:42                                      ; preds = %27
+  %43 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  store i32 %43, i32* %loc0
+  %44 = load i32, i32* %loc0
+  %45 = icmp eq i32 %44, 232
+  br i1 %45, label %49, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = load i32, i32* %loc0
+  %48 = icmp ne i32 %47, 109
+  br i1 %48, label %50, label %49
+
+; <label>:49                                      ; preds = %42, %46
+  ret i32 0
+
+; <label>:50                                      ; preds = %46
+  %51 = load i32, i32* %loc0
+  ret i32 %51
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
 Successfully read WindowsConsoleStream.Flush
 
@@ -15150,8 +17552,8 @@ entry:
   %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
   store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
@@ -15186,8 +17588,8 @@ entry:
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
   %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load i64, i64 addrspace(1)* %1
@@ -15226,15 +17628,15 @@ entry:
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.TextWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
   %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %3, align 8
   %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
   %7 = load i64, i64 addrspace(1)* %5
@@ -15252,7 +17654,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -15281,8 +17683,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %4)
   store i32 0, i32* %loc0
   %5 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Char[]" addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
@@ -15294,15 +17696,15 @@ entry:
 
 ; <label>:11                                      ; preds = %69
   %12 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %12, i32 0, i32 9
   %15 = load i32, i32 addrspace(1)* %14, align 8
   %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.IO.StreamWriter addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %16, i32 0, i32 10
@@ -15317,15 +17719,15 @@ entry:
 
 ; <label>:23                                      ; preds = %17, %21
   %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %24, null
-  br i1 %NullCheck8, label %25, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %24, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 10
   %27 = load i32, i32 addrspace(1)* %26, align 8
   %28 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %28, null
-  br i1 %NullCheck10, label %29, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.StreamWriter addrspace(1)* %28, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %28, i32 0, i32 9
@@ -15347,15 +17749,15 @@ entry:
   %40 = load i32, i32* %loc0
   %41 = mul i32 %40, 2
   %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
-  br i1 %NullCheck12, label %43, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %43
 
 ; <label>:43                                      ; preds = %38
   %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 7
   %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %44, align 8
   %46 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %46, null
-  br i1 %NullCheck14, label %47, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.IO.StreamWriter addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %47
 
 ; <label>:47                                      ; preds = %43
   %48 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %46, i32 0, i32 9
@@ -15367,16 +17769,16 @@ entry:
   %54 = bitcast %"System.Char[]" addrspace(1)* %45 to %System.Array addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %53, i32 %41, %System.Array addrspace(1)* %54, i32 %50, i32 %52)
   %55 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
-  br i1 %NullCheck16, label %56, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %56
 
 ; <label>:56                                      ; preds = %47
   %57 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
   %58 = load i32, i32 addrspace(1)* %57, align 8
   %59 = load i32, i32* %loc2
   %60 = add i32 %58, %59
-  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
-  br i1 %NullCheck18, label %61, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %61
 
 ; <label>:61                                      ; preds = %56
   %62 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
@@ -15398,8 +17800,8 @@ entry:
 
 ; <label>:72                                      ; preds = %69
   %73 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %73, null
-  br i1 %NullCheck2, label %74, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %73, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %74
 
 ; <label>:74                                      ; preds = %72
   %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %73, i32 0, i32 11
@@ -15420,39 +17822,39 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %72
+ThrowNullRef2:                                    ; preds = %72
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %23
+ThrowNullRef8:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef10:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %43
+ThrowNullRef14:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %47
+ThrowNullRef16:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %56
+ThrowNullRef18:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblAvg6.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblAvg6.error.txt
@@ -25,8 +25,8 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
@@ -40,8 +40,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
   %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
@@ -75,7 +75,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -90,8 +90,8 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %NullCheck = icmp ne i8 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = load i8, i8 addrspace(1)* %0, align 8
@@ -125,8 +125,8 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
@@ -159,8 +159,8 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -184,8 +184,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
   store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
@@ -195,8 +195,8 @@ entry:
 ; <label>:4                                       ; preds = %1
   %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
   %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
@@ -206,8 +206,8 @@ entry:
   %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
@@ -221,14 +221,14 @@ entry:
 
 ; <label>:17                                      ; preds = %14
   %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
   %21 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
@@ -238,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -249,8 +249,8 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
@@ -261,27 +261,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %30
+ThrowNullRef10:                                   ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -301,7 +301,89 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
-Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
+Successfully read AppDomainSetup.GetUnsecureApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.GetUnsecureApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %NullCheck = icmp eq %"System.String[]" addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %BoundsCheck = icmp uge i64 0, %5
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %6
+
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 3, i32 0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
+  ret %System.String addrspace(1)* %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_Value using LLILCJit
+Successfully read AppDomainSetup.get_Value
+
+define %"System.String[]" addrspace(1)* @AppDomainSetup.get_Value(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.String[]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 18)
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.String[]" addrspace(1)* addrspace(1)*, %"System.String[]" addrspace(1)*)*)(%"System.String[]" addrspace(1)* addrspace(1)* %9, %"System.String[]" addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %11, i32 0, i32 1
+  %14 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %13, align 8
+  ret %"System.String[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -319,8 +401,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -368,16 +450,16 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
   %5 = load i32, i32 addrspace(1)* %4
   %6 = sub i32 %5, 1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -389,7 +471,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -421,8 +503,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
@@ -456,8 +538,8 @@ entry:
 ; <label>:27                                      ; preds = %19
   %28 = load i32, i32* %arg1
   %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
-  br i1 %NullCheck2, label %30, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %29, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %30
 
 ; <label>:30                                      ; preds = %27
   %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
@@ -493,8 +575,8 @@ entry:
 ; <label>:49                                      ; preds = %46
   %50 = load i32, i32* %arg2
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck4, label %52, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
@@ -517,11 +599,11 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %27
+ThrowNullRef2:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %49
+ThrowNullRef4:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -544,16 +626,16 @@ entry:
   %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %0)
   store %System.String addrspace(1)* %1, %System.String addrspace(1)** %loc0
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 2
   %5 = bitcast [0 x i16] addrspace(1)* %4 to i16 addrspace(1)*
   store i16 addrspace(1)* %5, i16 addrspace(1)** %loc1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %3
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2
@@ -580,7 +662,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -691,15 +773,15 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %NullCheck132 = icmp ne i8* %21, null
-  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+  %NullCheck131 = icmp eq i8* %21, null
+  br i1 %NullCheck131, label %ThrowNullRef132, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = load i8, i8* %21, align 8
   %24 = zext i8 %23 to i32
   %25 = trunc i32 %24 to i8
-  %NullCheck134 = icmp ne i8* %20, null
-  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+  %NullCheck133 = icmp eq i8* %20, null
+  br i1 %NullCheck133, label %ThrowNullRef134, label %26
 
 ; <label>:26                                      ; preds = %22
   store i8 %25, i8* %20, align 8
@@ -709,16 +791,16 @@ entry:
   %28 = load i8*, i8** %arg0
   %29 = load i8*, i8** %arg1
   %30 = bitcast i8* %29 to i16*
-  %NullCheck128 = icmp ne i16* %30, null
-  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+  %NullCheck127 = icmp eq i16* %30, null
+  br i1 %NullCheck127, label %ThrowNullRef128, label %31
 
 ; <label>:31                                      ; preds = %27
   %32 = load i16, i16* %30, align 8
   %33 = sext i16 %32 to i32
   %34 = bitcast i8* %28 to i16*
   %35 = trunc i32 %33 to i16
-  %NullCheck130 = icmp ne i16* %34, null
-  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+  %NullCheck129 = icmp eq i16* %34, null
+  br i1 %NullCheck129, label %ThrowNullRef130, label %36
 
 ; <label>:36                                      ; preds = %31
   store i16 %35, i16* %34, align 8
@@ -728,16 +810,16 @@ entry:
   %38 = load i8*, i8** %arg0
   %39 = load i8*, i8** %arg1
   %40 = bitcast i8* %39 to i16*
-  %NullCheck120 = icmp ne i16* %40, null
-  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+  %NullCheck119 = icmp eq i16* %40, null
+  br i1 %NullCheck119, label %ThrowNullRef120, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i16, i16* %40, align 8
   %43 = sext i16 %42 to i32
   %44 = bitcast i8* %38 to i16*
   %45 = trunc i32 %43 to i16
-  %NullCheck122 = icmp ne i16* %44, null
-  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+  %NullCheck121 = icmp eq i16* %44, null
+  br i1 %NullCheck121, label %ThrowNullRef122, label %46
 
 ; <label>:46                                      ; preds = %41
   store i16 %45, i16* %44, align 8
@@ -745,15 +827,15 @@ entry:
   %48 = getelementptr inbounds i8, i8* %47, i64 2
   %49 = load i8*, i8** %arg1
   %50 = getelementptr inbounds i8, i8* %49, i64 2
-  %NullCheck124 = icmp ne i8* %50, null
-  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+  %NullCheck123 = icmp eq i8* %50, null
+  br i1 %NullCheck123, label %ThrowNullRef124, label %51
 
 ; <label>:51                                      ; preds = %46
   %52 = load i8, i8* %50, align 8
   %53 = zext i8 %52 to i32
   %54 = trunc i32 %53 to i8
-  %NullCheck126 = icmp ne i8* %48, null
-  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+  %NullCheck125 = icmp eq i8* %48, null
+  br i1 %NullCheck125, label %ThrowNullRef126, label %55
 
 ; <label>:55                                      ; preds = %51
   store i8 %54, i8* %48, align 8
@@ -763,14 +845,14 @@ entry:
   %57 = load i8*, i8** %arg0
   %58 = load i8*, i8** %arg1
   %59 = bitcast i8* %58 to i32*
-  %NullCheck116 = icmp ne i32* %59, null
-  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+  %NullCheck115 = icmp eq i32* %59, null
+  br i1 %NullCheck115, label %ThrowNullRef116, label %60
 
 ; <label>:60                                      ; preds = %56
   %61 = load i32, i32* %59, align 8
   %62 = bitcast i8* %57 to i32*
-  %NullCheck118 = icmp ne i32* %62, null
-  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+  %NullCheck117 = icmp eq i32* %62, null
+  br i1 %NullCheck117, label %ThrowNullRef118, label %63
 
 ; <label>:63                                      ; preds = %60
   store i32 %61, i32* %62, align 8
@@ -780,14 +862,14 @@ entry:
   %65 = load i8*, i8** %arg0
   %66 = load i8*, i8** %arg1
   %67 = bitcast i8* %66 to i32*
-  %NullCheck108 = icmp ne i32* %67, null
-  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+  %NullCheck107 = icmp eq i32* %67, null
+  br i1 %NullCheck107, label %ThrowNullRef108, label %68
 
 ; <label>:68                                      ; preds = %64
   %69 = load i32, i32* %67, align 8
   %70 = bitcast i8* %65 to i32*
-  %NullCheck110 = icmp ne i32* %70, null
-  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+  %NullCheck109 = icmp eq i32* %70, null
+  br i1 %NullCheck109, label %ThrowNullRef110, label %71
 
 ; <label>:71                                      ; preds = %68
   store i32 %69, i32* %70, align 8
@@ -795,15 +877,15 @@ entry:
   %73 = getelementptr inbounds i8, i8* %72, i64 4
   %74 = load i8*, i8** %arg1
   %75 = getelementptr inbounds i8, i8* %74, i64 4
-  %NullCheck112 = icmp ne i8* %75, null
-  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+  %NullCheck111 = icmp eq i8* %75, null
+  br i1 %NullCheck111, label %ThrowNullRef112, label %76
 
 ; <label>:76                                      ; preds = %71
   %77 = load i8, i8* %75, align 8
   %78 = zext i8 %77 to i32
   %79 = trunc i32 %78 to i8
-  %NullCheck114 = icmp ne i8* %73, null
-  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+  %NullCheck113 = icmp eq i8* %73, null
+  br i1 %NullCheck113, label %ThrowNullRef114, label %80
 
 ; <label>:80                                      ; preds = %76
   store i8 %79, i8* %73, align 8
@@ -813,14 +895,14 @@ entry:
   %82 = load i8*, i8** %arg0
   %83 = load i8*, i8** %arg1
   %84 = bitcast i8* %83 to i32*
-  %NullCheck100 = icmp ne i32* %84, null
-  br i1 %NullCheck100, label %85, label %ThrowNullRef99
+  %NullCheck99 = icmp eq i32* %84, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %85
 
 ; <label>:85                                      ; preds = %81
   %86 = load i32, i32* %84, align 8
   %87 = bitcast i8* %82 to i32*
-  %NullCheck102 = icmp ne i32* %87, null
-  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+  %NullCheck101 = icmp eq i32* %87, null
+  br i1 %NullCheck101, label %ThrowNullRef102, label %88
 
 ; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
@@ -829,16 +911,16 @@ entry:
   %91 = load i8*, i8** %arg1
   %92 = getelementptr inbounds i8, i8* %91, i64 4
   %93 = bitcast i8* %92 to i16*
-  %NullCheck104 = icmp ne i16* %93, null
-  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+  %NullCheck103 = icmp eq i16* %93, null
+  br i1 %NullCheck103, label %ThrowNullRef104, label %94
 
 ; <label>:94                                      ; preds = %88
   %95 = load i16, i16* %93, align 8
   %96 = sext i16 %95 to i32
   %97 = bitcast i8* %90 to i16*
   %98 = trunc i32 %96 to i16
-  %NullCheck106 = icmp ne i16* %97, null
-  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+  %NullCheck105 = icmp eq i16* %97, null
+  br i1 %NullCheck105, label %ThrowNullRef106, label %99
 
 ; <label>:99                                      ; preds = %94
   store i16 %98, i16* %97, align 8
@@ -848,14 +930,14 @@ entry:
   %101 = load i8*, i8** %arg0
   %102 = load i8*, i8** %arg1
   %103 = bitcast i8* %102 to i32*
-  %NullCheck88 = icmp ne i32* %103, null
-  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+  %NullCheck87 = icmp eq i32* %103, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %104
 
 ; <label>:104                                     ; preds = %100
   %105 = load i32, i32* %103, align 8
   %106 = bitcast i8* %101 to i32*
-  %NullCheck90 = icmp ne i32* %106, null
-  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+  %NullCheck89 = icmp eq i32* %106, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %107
 
 ; <label>:107                                     ; preds = %104
   store i32 %105, i32* %106, align 8
@@ -864,16 +946,16 @@ entry:
   %110 = load i8*, i8** %arg1
   %111 = getelementptr inbounds i8, i8* %110, i64 4
   %112 = bitcast i8* %111 to i16*
-  %NullCheck92 = icmp ne i16* %112, null
-  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+  %NullCheck91 = icmp eq i16* %112, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %113
 
 ; <label>:113                                     ; preds = %107
   %114 = load i16, i16* %112, align 8
   %115 = sext i16 %114 to i32
   %116 = bitcast i8* %109 to i16*
   %117 = trunc i32 %115 to i16
-  %NullCheck94 = icmp ne i16* %116, null
-  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+  %NullCheck93 = icmp eq i16* %116, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %118
 
 ; <label>:118                                     ; preds = %113
   store i16 %117, i16* %116, align 8
@@ -881,15 +963,15 @@ entry:
   %120 = getelementptr inbounds i8, i8* %119, i64 6
   %121 = load i8*, i8** %arg1
   %122 = getelementptr inbounds i8, i8* %121, i64 6
-  %NullCheck96 = icmp ne i8* %122, null
-  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+  %NullCheck95 = icmp eq i8* %122, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %123
 
 ; <label>:123                                     ; preds = %118
   %124 = load i8, i8* %122, align 8
   %125 = zext i8 %124 to i32
   %126 = trunc i32 %125 to i8
-  %NullCheck98 = icmp ne i8* %120, null
-  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+  %NullCheck97 = icmp eq i8* %120, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %127
 
 ; <label>:127                                     ; preds = %123
   store i8 %126, i8* %120, align 8
@@ -899,14 +981,14 @@ entry:
   %129 = load i8*, i8** %arg0
   %130 = load i8*, i8** %arg1
   %131 = bitcast i8* %130 to i64*
-  %NullCheck84 = icmp ne i64* %131, null
-  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+  %NullCheck83 = icmp eq i64* %131, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %132
 
 ; <label>:132                                     ; preds = %128
   %133 = load i64, i64* %131, align 8
   %134 = bitcast i8* %129 to i64*
-  %NullCheck86 = icmp ne i64* %134, null
-  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+  %NullCheck85 = icmp eq i64* %134, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %135
 
 ; <label>:135                                     ; preds = %132
   store i64 %133, i64* %134, align 8
@@ -916,14 +998,14 @@ entry:
   %137 = load i8*, i8** %arg0
   %138 = load i8*, i8** %arg1
   %139 = bitcast i8* %138 to i64*
-  %NullCheck76 = icmp ne i64* %139, null
-  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+  %NullCheck75 = icmp eq i64* %139, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %140
 
 ; <label>:140                                     ; preds = %136
   %141 = load i64, i64* %139, align 8
   %142 = bitcast i8* %137 to i64*
-  %NullCheck78 = icmp ne i64* %142, null
-  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+  %NullCheck77 = icmp eq i64* %142, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %143
 
 ; <label>:143                                     ; preds = %140
   store i64 %141, i64* %142, align 8
@@ -931,15 +1013,15 @@ entry:
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %NullCheck80 = icmp ne i8* %147, null
-  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+  %NullCheck79 = icmp eq i8* %147, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %148
 
 ; <label>:148                                     ; preds = %143
   %149 = load i8, i8* %147, align 8
   %150 = zext i8 %149 to i32
   %151 = trunc i32 %150 to i8
-  %NullCheck82 = icmp ne i8* %145, null
-  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+  %NullCheck81 = icmp eq i8* %145, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %152
 
 ; <label>:152                                     ; preds = %148
   store i8 %151, i8* %145, align 8
@@ -949,14 +1031,14 @@ entry:
   %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
   %156 = bitcast i8* %155 to i64*
-  %NullCheck68 = icmp ne i64* %156, null
-  br i1 %NullCheck68, label %157, label %ThrowNullRef67
+  %NullCheck67 = icmp eq i64* %156, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %157
 
 ; <label>:157                                     ; preds = %153
   %158 = load i64, i64* %156, align 8
   %159 = bitcast i8* %154 to i64*
-  %NullCheck70 = icmp ne i64* %159, null
-  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+  %NullCheck69 = icmp eq i64* %159, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %160
 
 ; <label>:160                                     ; preds = %157
   store i64 %158, i64* %159, align 8
@@ -965,16 +1047,16 @@ entry:
   %163 = load i8*, i8** %arg1
   %164 = getelementptr inbounds i8, i8* %163, i64 8
   %165 = bitcast i8* %164 to i16*
-  %NullCheck72 = icmp ne i16* %165, null
-  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+  %NullCheck71 = icmp eq i16* %165, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %166
 
 ; <label>:166                                     ; preds = %160
   %167 = load i16, i16* %165, align 8
   %168 = sext i16 %167 to i32
   %169 = bitcast i8* %162 to i16*
   %170 = trunc i32 %168 to i16
-  %NullCheck74 = icmp ne i16* %169, null
-  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+  %NullCheck73 = icmp eq i16* %169, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %171
 
 ; <label>:171                                     ; preds = %166
   store i16 %170, i16* %169, align 8
@@ -984,14 +1066,14 @@ entry:
   %173 = load i8*, i8** %arg0
   %174 = load i8*, i8** %arg1
   %175 = bitcast i8* %174 to i64*
-  %NullCheck56 = icmp ne i64* %175, null
-  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+  %NullCheck55 = icmp eq i64* %175, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %176
 
 ; <label>:176                                     ; preds = %172
   %177 = load i64, i64* %175, align 8
   %178 = bitcast i8* %173 to i64*
-  %NullCheck58 = icmp ne i64* %178, null
-  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+  %NullCheck57 = icmp eq i64* %178, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %179
 
 ; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
@@ -1000,16 +1082,16 @@ entry:
   %182 = load i8*, i8** %arg1
   %183 = getelementptr inbounds i8, i8* %182, i64 8
   %184 = bitcast i8* %183 to i16*
-  %NullCheck60 = icmp ne i16* %184, null
-  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+  %NullCheck59 = icmp eq i16* %184, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %185
 
 ; <label>:185                                     ; preds = %179
   %186 = load i16, i16* %184, align 8
   %187 = sext i16 %186 to i32
   %188 = bitcast i8* %181 to i16*
   %189 = trunc i32 %187 to i16
-  %NullCheck62 = icmp ne i16* %188, null
-  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+  %NullCheck61 = icmp eq i16* %188, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %190
 
 ; <label>:190                                     ; preds = %185
   store i16 %189, i16* %188, align 8
@@ -1017,15 +1099,15 @@ entry:
   %192 = getelementptr inbounds i8, i8* %191, i64 10
   %193 = load i8*, i8** %arg1
   %194 = getelementptr inbounds i8, i8* %193, i64 10
-  %NullCheck64 = icmp ne i8* %194, null
-  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+  %NullCheck63 = icmp eq i8* %194, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %195
 
 ; <label>:195                                     ; preds = %190
   %196 = load i8, i8* %194, align 8
   %197 = zext i8 %196 to i32
   %198 = trunc i32 %197 to i8
-  %NullCheck66 = icmp ne i8* %192, null
-  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+  %NullCheck65 = icmp eq i8* %192, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %199
 
 ; <label>:199                                     ; preds = %195
   store i8 %198, i8* %192, align 8
@@ -1035,14 +1117,14 @@ entry:
   %201 = load i8*, i8** %arg0
   %202 = load i8*, i8** %arg1
   %203 = bitcast i8* %202 to i64*
-  %NullCheck48 = icmp ne i64* %203, null
-  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+  %NullCheck47 = icmp eq i64* %203, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %204
 
 ; <label>:204                                     ; preds = %200
   %205 = load i64, i64* %203, align 8
   %206 = bitcast i8* %201 to i64*
-  %NullCheck50 = icmp ne i64* %206, null
-  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+  %NullCheck49 = icmp eq i64* %206, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %207
 
 ; <label>:207                                     ; preds = %204
   store i64 %205, i64* %206, align 8
@@ -1051,14 +1133,14 @@ entry:
   %210 = load i8*, i8** %arg1
   %211 = getelementptr inbounds i8, i8* %210, i64 8
   %212 = bitcast i8* %211 to i32*
-  %NullCheck52 = icmp ne i32* %212, null
-  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+  %NullCheck51 = icmp eq i32* %212, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %213
 
 ; <label>:213                                     ; preds = %207
   %214 = load i32, i32* %212, align 8
   %215 = bitcast i8* %209 to i32*
-  %NullCheck54 = icmp ne i32* %215, null
-  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+  %NullCheck53 = icmp eq i32* %215, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %216
 
 ; <label>:216                                     ; preds = %213
   store i32 %214, i32* %215, align 8
@@ -1068,14 +1150,14 @@ entry:
   %218 = load i8*, i8** %arg0
   %219 = load i8*, i8** %arg1
   %220 = bitcast i8* %219 to i64*
-  %NullCheck36 = icmp ne i64* %220, null
-  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64* %220, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %221
 
 ; <label>:221                                     ; preds = %217
   %222 = load i64, i64* %220, align 8
   %223 = bitcast i8* %218 to i64*
-  %NullCheck38 = icmp ne i64* %223, null
-  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+  %NullCheck37 = icmp eq i64* %223, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %224
 
 ; <label>:224                                     ; preds = %221
   store i64 %222, i64* %223, align 8
@@ -1084,14 +1166,14 @@ entry:
   %227 = load i8*, i8** %arg1
   %228 = getelementptr inbounds i8, i8* %227, i64 8
   %229 = bitcast i8* %228 to i32*
-  %NullCheck40 = icmp ne i32* %229, null
-  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i32* %229, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %230
 
 ; <label>:230                                     ; preds = %224
   %231 = load i32, i32* %229, align 8
   %232 = bitcast i8* %226 to i32*
-  %NullCheck42 = icmp ne i32* %232, null
-  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+  %NullCheck41 = icmp eq i32* %232, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %233
 
 ; <label>:233                                     ; preds = %230
   store i32 %231, i32* %232, align 8
@@ -1099,15 +1181,15 @@ entry:
   %235 = getelementptr inbounds i8, i8* %234, i64 12
   %236 = load i8*, i8** %arg1
   %237 = getelementptr inbounds i8, i8* %236, i64 12
-  %NullCheck44 = icmp ne i8* %237, null
-  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i8* %237, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %238
 
 ; <label>:238                                     ; preds = %233
   %239 = load i8, i8* %237, align 8
   %240 = zext i8 %239 to i32
   %241 = trunc i32 %240 to i8
-  %NullCheck46 = icmp ne i8* %235, null
-  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+  %NullCheck45 = icmp eq i8* %235, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %242
 
 ; <label>:242                                     ; preds = %238
   store i8 %241, i8* %235, align 8
@@ -1117,14 +1199,14 @@ entry:
   %244 = load i8*, i8** %arg0
   %245 = load i8*, i8** %arg1
   %246 = bitcast i8* %245 to i64*
-  %NullCheck24 = icmp ne i64* %246, null
-  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64* %246, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %247
 
 ; <label>:247                                     ; preds = %243
   %248 = load i64, i64* %246, align 8
   %249 = bitcast i8* %244 to i64*
-  %NullCheck26 = icmp ne i64* %249, null
-  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64* %249, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %250
 
 ; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
@@ -1133,14 +1215,14 @@ entry:
   %253 = load i8*, i8** %arg1
   %254 = getelementptr inbounds i8, i8* %253, i64 8
   %255 = bitcast i8* %254 to i32*
-  %NullCheck28 = icmp ne i32* %255, null
-  br i1 %NullCheck28, label %256, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i32* %255, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %256
 
 ; <label>:256                                     ; preds = %250
   %257 = load i32, i32* %255, align 8
   %258 = bitcast i8* %252 to i32*
-  %NullCheck30 = icmp ne i32* %258, null
-  br i1 %NullCheck30, label %259, label %ThrowNullRef29
+  %NullCheck29 = icmp eq i32* %258, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %259
 
 ; <label>:259                                     ; preds = %256
   store i32 %257, i32* %258, align 8
@@ -1149,16 +1231,16 @@ entry:
   %262 = load i8*, i8** %arg1
   %263 = getelementptr inbounds i8, i8* %262, i64 12
   %264 = bitcast i8* %263 to i16*
-  %NullCheck32 = icmp ne i16* %264, null
-  br i1 %NullCheck32, label %265, label %ThrowNullRef31
+  %NullCheck31 = icmp eq i16* %264, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %265
 
 ; <label>:265                                     ; preds = %259
   %266 = load i16, i16* %264, align 8
   %267 = sext i16 %266 to i32
   %268 = bitcast i8* %261 to i16*
   %269 = trunc i32 %267 to i16
-  %NullCheck34 = icmp ne i16* %268, null
-  br i1 %NullCheck34, label %270, label %ThrowNullRef33
+  %NullCheck33 = icmp eq i16* %268, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %270
 
 ; <label>:270                                     ; preds = %265
   store i16 %269, i16* %268, align 8
@@ -1168,14 +1250,14 @@ entry:
   %272 = load i8*, i8** %arg0
   %273 = load i8*, i8** %arg1
   %274 = bitcast i8* %273 to i64*
-  %NullCheck8 = icmp ne i64* %274, null
-  br i1 %NullCheck8, label %275, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64* %274, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %275
 
 ; <label>:275                                     ; preds = %271
   %276 = load i64, i64* %274, align 8
   %277 = bitcast i8* %272 to i64*
-  %NullCheck10 = icmp ne i64* %277, null
-  br i1 %NullCheck10, label %278, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %277, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %278
 
 ; <label>:278                                     ; preds = %275
   store i64 %276, i64* %277, align 8
@@ -1184,14 +1266,14 @@ entry:
   %281 = load i8*, i8** %arg1
   %282 = getelementptr inbounds i8, i8* %281, i64 8
   %283 = bitcast i8* %282 to i32*
-  %NullCheck12 = icmp ne i32* %283, null
-  br i1 %NullCheck12, label %284, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i32* %283, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %284
 
 ; <label>:284                                     ; preds = %278
   %285 = load i32, i32* %283, align 8
   %286 = bitcast i8* %280 to i32*
-  %NullCheck14 = icmp ne i32* %286, null
-  br i1 %NullCheck14, label %287, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i32* %286, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %287
 
 ; <label>:287                                     ; preds = %284
   store i32 %285, i32* %286, align 8
@@ -1200,16 +1282,16 @@ entry:
   %290 = load i8*, i8** %arg1
   %291 = getelementptr inbounds i8, i8* %290, i64 12
   %292 = bitcast i8* %291 to i16*
-  %NullCheck16 = icmp ne i16* %292, null
-  br i1 %NullCheck16, label %293, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i16* %292, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %293
 
 ; <label>:293                                     ; preds = %287
   %294 = load i16, i16* %292, align 8
   %295 = sext i16 %294 to i32
   %296 = bitcast i8* %289 to i16*
   %297 = trunc i32 %295 to i16
-  %NullCheck18 = icmp ne i16* %296, null
-  br i1 %NullCheck18, label %298, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i16* %296, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %298
 
 ; <label>:298                                     ; preds = %293
   store i16 %297, i16* %296, align 8
@@ -1217,15 +1299,15 @@ entry:
   %300 = getelementptr inbounds i8, i8* %299, i64 14
   %301 = load i8*, i8** %arg1
   %302 = getelementptr inbounds i8, i8* %301, i64 14
-  %NullCheck20 = icmp ne i8* %302, null
-  br i1 %NullCheck20, label %303, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i8* %302, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %303
 
 ; <label>:303                                     ; preds = %298
   %304 = load i8, i8* %302, align 8
   %305 = zext i8 %304 to i32
   %306 = trunc i32 %305 to i8
-  %NullCheck22 = icmp ne i8* %300, null
-  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i8* %300, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %307
 
 ; <label>:307                                     ; preds = %303
   store i8 %306, i8* %300, align 8
@@ -1235,14 +1317,14 @@ entry:
   %309 = load i8*, i8** %arg0
   %310 = load i8*, i8** %arg1
   %311 = bitcast i8* %310 to i64*
-  %NullCheck = icmp ne i64* %311, null
-  br i1 %NullCheck, label %312, label %ThrowNullRef
+  %NullCheck = icmp eq i64* %311, null
+  br i1 %NullCheck, label %ThrowNullRef, label %312
 
 ; <label>:312                                     ; preds = %308
   %313 = load i64, i64* %311, align 8
   %314 = bitcast i8* %309 to i64*
-  %NullCheck2 = icmp ne i64* %314, null
-  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64* %314, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %315
 
 ; <label>:315                                     ; preds = %312
   store i64 %313, i64* %314, align 8
@@ -1251,14 +1333,14 @@ entry:
   %318 = load i8*, i8** %arg1
   %319 = getelementptr inbounds i8, i8* %318, i64 8
   %320 = bitcast i8* %319 to i64*
-  %NullCheck4 = icmp ne i64* %320, null
-  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64* %320, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %321
 
 ; <label>:321                                     ; preds = %315
   %322 = load i64, i64* %320, align 8
   %323 = bitcast i8* %317 to i64*
-  %NullCheck6 = icmp ne i64* %323, null
-  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64* %323, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %324
 
 ; <label>:324                                     ; preds = %321
   store i64 %322, i64* %323, align 8
@@ -1286,15 +1368,15 @@ entry:
 ; <label>:338                                     ; preds = %333
   %339 = load i8*, i8** %arg0
   %340 = load i8*, i8** %arg1
-  %NullCheck136 = icmp ne i8* %340, null
-  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+  %NullCheck135 = icmp eq i8* %340, null
+  br i1 %NullCheck135, label %ThrowNullRef136, label %341
 
 ; <label>:341                                     ; preds = %338
   %342 = load i8, i8* %340, align 8
   %343 = zext i8 %342 to i32
   %344 = trunc i32 %343 to i8
-  %NullCheck138 = icmp ne i8* %339, null
-  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+  %NullCheck137 = icmp eq i8* %339, null
+  br i1 %NullCheck137, label %ThrowNullRef138, label %345
 
 ; <label>:345                                     ; preds = %341
   store i8 %344, i8* %339, align 8
@@ -1317,16 +1399,16 @@ entry:
   %357 = load i8*, i8** %arg0
   %358 = load i8*, i8** %arg1
   %359 = bitcast i8* %358 to i16*
-  %NullCheck140 = icmp ne i16* %359, null
-  br i1 %NullCheck140, label %360, label %ThrowNullRef139
+  %NullCheck139 = icmp eq i16* %359, null
+  br i1 %NullCheck139, label %ThrowNullRef140, label %360
 
 ; <label>:360                                     ; preds = %356
   %361 = load i16, i16* %359, align 8
   %362 = sext i16 %361 to i32
   %363 = bitcast i8* %357 to i16*
   %364 = trunc i32 %362 to i16
-  %NullCheck142 = icmp ne i16* %363, null
-  br i1 %NullCheck142, label %365, label %ThrowNullRef141
+  %NullCheck141 = icmp eq i16* %363, null
+  br i1 %NullCheck141, label %ThrowNullRef142, label %365
 
 ; <label>:365                                     ; preds = %360
   store i16 %364, i16* %363, align 8
@@ -1352,14 +1434,14 @@ entry:
   %378 = load i8*, i8** %arg0
   %379 = load i8*, i8** %arg1
   %380 = bitcast i8* %379 to i32*
-  %NullCheck144 = icmp ne i32* %380, null
-  br i1 %NullCheck144, label %381, label %ThrowNullRef143
+  %NullCheck143 = icmp eq i32* %380, null
+  br i1 %NullCheck143, label %ThrowNullRef144, label %381
 
 ; <label>:381                                     ; preds = %377
   %382 = load i32, i32* %380, align 8
   %383 = bitcast i8* %378 to i32*
-  %NullCheck146 = icmp ne i32* %383, null
-  br i1 %NullCheck146, label %384, label %ThrowNullRef145
+  %NullCheck145 = icmp eq i32* %383, null
+  br i1 %NullCheck145, label %ThrowNullRef146, label %384
 
 ; <label>:384                                     ; preds = %381
   store i32 %382, i32* %383, align 8
@@ -1384,14 +1466,14 @@ entry:
   %395 = load i8*, i8** %arg0
   %396 = load i8*, i8** %arg1
   %397 = bitcast i8* %396 to i64*
-  %NullCheck164 = icmp ne i64* %397, null
-  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+  %NullCheck163 = icmp eq i64* %397, null
+  br i1 %NullCheck163, label %ThrowNullRef164, label %398
 
 ; <label>:398                                     ; preds = %394
   %399 = load i64, i64* %397, align 8
   %400 = bitcast i8* %395 to i64*
-  %NullCheck166 = icmp ne i64* %400, null
-  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+  %NullCheck165 = icmp eq i64* %400, null
+  br i1 %NullCheck165, label %ThrowNullRef166, label %401
 
 ; <label>:401                                     ; preds = %398
   store i64 %399, i64* %400, align 8
@@ -1400,14 +1482,14 @@ entry:
   %404 = load i8*, i8** %arg1
   %405 = getelementptr inbounds i8, i8* %404, i64 8
   %406 = bitcast i8* %405 to i64*
-  %NullCheck168 = icmp ne i64* %406, null
-  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+  %NullCheck167 = icmp eq i64* %406, null
+  br i1 %NullCheck167, label %ThrowNullRef168, label %407
 
 ; <label>:407                                     ; preds = %401
   %408 = load i64, i64* %406, align 8
   %409 = bitcast i8* %403 to i64*
-  %NullCheck170 = icmp ne i64* %409, null
-  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+  %NullCheck169 = icmp eq i64* %409, null
+  br i1 %NullCheck169, label %ThrowNullRef170, label %410
 
 ; <label>:410                                     ; preds = %407
   store i64 %408, i64* %409, align 8
@@ -1437,14 +1519,14 @@ entry:
   %425 = load i8*, i8** %arg0
   %426 = load i8*, i8** %arg1
   %427 = bitcast i8* %426 to i64*
-  %NullCheck148 = icmp ne i64* %427, null
-  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+  %NullCheck147 = icmp eq i64* %427, null
+  br i1 %NullCheck147, label %ThrowNullRef148, label %428
 
 ; <label>:428                                     ; preds = %424
   %429 = load i64, i64* %427, align 8
   %430 = bitcast i8* %425 to i64*
-  %NullCheck150 = icmp ne i64* %430, null
-  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+  %NullCheck149 = icmp eq i64* %430, null
+  br i1 %NullCheck149, label %ThrowNullRef150, label %431
 
 ; <label>:431                                     ; preds = %428
   store i64 %429, i64* %430, align 8
@@ -1466,14 +1548,14 @@ entry:
   %441 = load i8*, i8** %arg0
   %442 = load i8*, i8** %arg1
   %443 = bitcast i8* %442 to i32*
-  %NullCheck152 = icmp ne i32* %443, null
-  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+  %NullCheck151 = icmp eq i32* %443, null
+  br i1 %NullCheck151, label %ThrowNullRef152, label %444
 
 ; <label>:444                                     ; preds = %440
   %445 = load i32, i32* %443, align 8
   %446 = bitcast i8* %441 to i32*
-  %NullCheck154 = icmp ne i32* %446, null
-  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+  %NullCheck153 = icmp eq i32* %446, null
+  br i1 %NullCheck153, label %ThrowNullRef154, label %447
 
 ; <label>:447                                     ; preds = %444
   store i32 %445, i32* %446, align 8
@@ -1495,16 +1577,16 @@ entry:
   %457 = load i8*, i8** %arg0
   %458 = load i8*, i8** %arg1
   %459 = bitcast i8* %458 to i16*
-  %NullCheck156 = icmp ne i16* %459, null
-  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+  %NullCheck155 = icmp eq i16* %459, null
+  br i1 %NullCheck155, label %ThrowNullRef156, label %460
 
 ; <label>:460                                     ; preds = %456
   %461 = load i16, i16* %459, align 8
   %462 = sext i16 %461 to i32
   %463 = bitcast i8* %457 to i16*
   %464 = trunc i32 %462 to i16
-  %NullCheck158 = icmp ne i16* %463, null
-  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+  %NullCheck157 = icmp eq i16* %463, null
+  br i1 %NullCheck157, label %ThrowNullRef158, label %465
 
 ; <label>:465                                     ; preds = %460
   store i16 %464, i16* %463, align 8
@@ -1525,15 +1607,15 @@ entry:
 ; <label>:474                                     ; preds = %470
   %475 = load i8*, i8** %arg0
   %476 = load i8*, i8** %arg1
-  %NullCheck160 = icmp ne i8* %476, null
-  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+  %NullCheck159 = icmp eq i8* %476, null
+  br i1 %NullCheck159, label %ThrowNullRef160, label %477
 
 ; <label>:477                                     ; preds = %474
   %478 = load i8, i8* %476, align 8
   %479 = zext i8 %478 to i32
   %480 = trunc i32 %479 to i8
-  %NullCheck162 = icmp ne i8* %475, null
-  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+  %NullCheck161 = icmp eq i8* %475, null
+  br i1 %NullCheck161, label %ThrowNullRef162, label %481
 
 ; <label>:481                                     ; preds = %477
   store i8 %480, i8* %475, align 8
@@ -1553,343 +1635,343 @@ ThrowNullRef:                                     ; preds = %308
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %312
+ThrowNullRef2:                                    ; preds = %312
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %315
+ThrowNullRef4:                                    ; preds = %315
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %321
+ThrowNullRef6:                                    ; preds = %321
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %271
+ThrowNullRef8:                                    ; preds = %271
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %275
+ThrowNullRef10:                                   ; preds = %275
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %278
+ThrowNullRef12:                                   ; preds = %278
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %284
+ThrowNullRef14:                                   ; preds = %284
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %287
+ThrowNullRef16:                                   ; preds = %287
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %293
+ThrowNullRef18:                                   ; preds = %293
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %298
+ThrowNullRef20:                                   ; preds = %298
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %303
+ThrowNullRef22:                                   ; preds = %303
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %243
+ThrowNullRef24:                                   ; preds = %243
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %247
+ThrowNullRef26:                                   ; preds = %247
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %250
+ThrowNullRef28:                                   ; preds = %250
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %256
+ThrowNullRef30:                                   ; preds = %256
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %259
+ThrowNullRef32:                                   ; preds = %259
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %265
+ThrowNullRef34:                                   ; preds = %265
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %217
+ThrowNullRef36:                                   ; preds = %217
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %221
+ThrowNullRef38:                                   ; preds = %221
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %224
+ThrowNullRef40:                                   ; preds = %224
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %230
+ThrowNullRef42:                                   ; preds = %230
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %233
+ThrowNullRef44:                                   ; preds = %233
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %238
+ThrowNullRef46:                                   ; preds = %238
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %200
+ThrowNullRef48:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %204
+ThrowNullRef50:                                   ; preds = %204
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %207
+ThrowNullRef52:                                   ; preds = %207
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %213
+ThrowNullRef54:                                   ; preds = %213
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %172
+ThrowNullRef56:                                   ; preds = %172
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %176
+ThrowNullRef58:                                   ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %179
+ThrowNullRef60:                                   ; preds = %179
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %185
+ThrowNullRef62:                                   ; preds = %185
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %190
+ThrowNullRef64:                                   ; preds = %190
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %195
+ThrowNullRef66:                                   ; preds = %195
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %153
+ThrowNullRef68:                                   ; preds = %153
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %157
+ThrowNullRef70:                                   ; preds = %157
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %160
+ThrowNullRef72:                                   ; preds = %160
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %166
+ThrowNullRef74:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %136
+ThrowNullRef76:                                   ; preds = %136
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %140
+ThrowNullRef78:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %143
+ThrowNullRef80:                                   ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %148
+ThrowNullRef82:                                   ; preds = %148
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %128
+ThrowNullRef84:                                   ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %132
+ThrowNullRef86:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %100
+ThrowNullRef88:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %104
+ThrowNullRef90:                                   ; preds = %104
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %107
+ThrowNullRef92:                                   ; preds = %107
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %113
+ThrowNullRef94:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %118
+ThrowNullRef96:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %123
+ThrowNullRef98:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %81
+ThrowNullRef100:                                  ; preds = %81
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef101:                                  ; preds = %85
+ThrowNullRef102:                                  ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef103:                                  ; preds = %88
+ThrowNullRef104:                                  ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef105:                                  ; preds = %94
+ThrowNullRef106:                                  ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef107:                                  ; preds = %64
+ThrowNullRef108:                                  ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef109:                                  ; preds = %68
+ThrowNullRef110:                                  ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef111:                                  ; preds = %71
+ThrowNullRef112:                                  ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef113:                                  ; preds = %76
+ThrowNullRef114:                                  ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef115:                                  ; preds = %56
+ThrowNullRef116:                                  ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef117:                                  ; preds = %60
+ThrowNullRef118:                                  ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef119:                                  ; preds = %37
+ThrowNullRef120:                                  ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef121:                                  ; preds = %41
+ThrowNullRef122:                                  ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef123:                                  ; preds = %46
+ThrowNullRef124:                                  ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef125:                                  ; preds = %51
+ThrowNullRef126:                                  ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef127:                                  ; preds = %27
+ThrowNullRef128:                                  ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef129:                                  ; preds = %31
+ThrowNullRef130:                                  ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef131:                                  ; preds = %19
+ThrowNullRef132:                                  ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef133:                                  ; preds = %22
+ThrowNullRef134:                                  ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef135:                                  ; preds = %338
+ThrowNullRef136:                                  ; preds = %338
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef137:                                  ; preds = %341
+ThrowNullRef138:                                  ; preds = %341
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef139:                                  ; preds = %356
+ThrowNullRef140:                                  ; preds = %356
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef141:                                  ; preds = %360
+ThrowNullRef142:                                  ; preds = %360
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef143:                                  ; preds = %377
+ThrowNullRef144:                                  ; preds = %377
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef145:                                  ; preds = %381
+ThrowNullRef146:                                  ; preds = %381
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef147:                                  ; preds = %424
+ThrowNullRef148:                                  ; preds = %424
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef149:                                  ; preds = %428
+ThrowNullRef150:                                  ; preds = %428
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef151:                                  ; preds = %440
+ThrowNullRef152:                                  ; preds = %440
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef153:                                  ; preds = %444
+ThrowNullRef154:                                  ; preds = %444
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef155:                                  ; preds = %456
+ThrowNullRef156:                                  ; preds = %456
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef157:                                  ; preds = %460
+ThrowNullRef158:                                  ; preds = %460
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef159:                                  ; preds = %474
+ThrowNullRef160:                                  ; preds = %474
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef161:                                  ; preds = %477
+ThrowNullRef162:                                  ; preds = %477
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef163:                                  ; preds = %394
+ThrowNullRef164:                                  ; preds = %394
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef165:                                  ; preds = %398
+ThrowNullRef166:                                  ; preds = %398
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef167:                                  ; preds = %401
+ThrowNullRef168:                                  ; preds = %401
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef169:                                  ; preds = %407
+ThrowNullRef170:                                  ; preds = %407
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1939,8 +2021,8 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
-  br i1 %NullCheck, label %22, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %ThrowNullRef, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
@@ -1948,8 +2030,8 @@ entry:
   store i32 %24, i32* %loc0
   %25 = load i32, i32* %loc0
   %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %26, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %27
 
 ; <label>:27                                      ; preds = %22
   %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
@@ -1971,7 +2053,7 @@ ThrowNullRef:                                     ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1989,8 +2071,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -2022,15 +2104,15 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2048,16 +2130,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
   %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
   store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %15
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
@@ -2072,8 +2154,8 @@ entry:
   %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
   %29 = ptrtoint i16 addrspace(1)* %28 to i64
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %19
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
@@ -2089,19 +2171,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2114,8 +2196,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
@@ -2128,7 +2210,7 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[loadElem]
+Failed to read AppDomain.PrepareDataForSetup[storeElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
@@ -2202,8 +2284,8 @@ entry:
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
-  br i1 %NullCheck24, label %27, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = load i64, i64 addrspace(1)* %26
@@ -2218,8 +2300,8 @@ entry:
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
-  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
   %41 = load i64, i64 addrspace(1)* %39
@@ -2236,8 +2318,8 @@ entry:
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
-  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
   %54 = load i64, i64 addrspace(1)* %52
@@ -2252,8 +2334,8 @@ entry:
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
   %67 = load i64, i64 addrspace(1)* %65
@@ -2270,8 +2352,8 @@ entry:
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
-  br i1 %NullCheck16, label %79, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
   %80 = load i64, i64 addrspace(1)* %78
@@ -2286,8 +2368,8 @@ entry:
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
-  br i1 %NullCheck18, label %92, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
   %93 = load i64, i64 addrspace(1)* %91
@@ -2304,8 +2386,8 @@ entry:
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
-  br i1 %NullCheck12, label %105, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = load i64, i64 addrspace(1)* %104
@@ -2320,8 +2402,8 @@ entry:
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
-  br i1 %NullCheck14, label %118, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
   %119 = load i64, i64 addrspace(1)* %117
@@ -2337,8 +2419,8 @@ entry:
 
 ; <label>:128                                     ; preds = %20
   %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
-  br i1 %NullCheck4, label %130, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %129, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %130
 
 ; <label>:130                                     ; preds = %128
   %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
@@ -2346,8 +2428,8 @@ entry:
   %133 = load i16, i16 addrspace(1)* %132, align 8
   %134 = zext i16 %133 to i32
   %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
-  br i1 %NullCheck6, label %136, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %135, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %136
 
 ; <label>:136                                     ; preds = %130
   %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
@@ -2360,8 +2442,8 @@ entry:
 
 ; <label>:143                                     ; preds = %136
   %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
-  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %144, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %145
 
 ; <label>:145                                     ; preds = %143
   %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
@@ -2369,8 +2451,8 @@ entry:
   %148 = load i16, i16 addrspace(1)* %147, align 8
   %149 = zext i16 %148 to i32
   %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %150, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %151
 
 ; <label>:151                                     ; preds = %145
   %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
@@ -2388,8 +2470,8 @@ entry:
 
 ; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
-  br i1 %NullCheck, label %163, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %ThrowNullRef, label %163
 
 ; <label>:163                                     ; preds = %161
   %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
@@ -2399,8 +2481,8 @@ entry:
 
 ; <label>:167                                     ; preds = %163
   %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
-  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %168, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %169
 
 ; <label>:169                                     ; preds = %167
   %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
@@ -2432,55 +2514,55 @@ ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %167
+ThrowNullRef2:                                    ; preds = %167
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %128
+ThrowNullRef4:                                    ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %130
+ThrowNullRef6:                                    ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %143
+ThrowNullRef8:                                    ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %145
+ThrowNullRef10:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %102
+ThrowNullRef12:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %105
+ThrowNullRef14:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %76
+ThrowNullRef16:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %79
+ThrowNullRef18:                                   ; preds = %79
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %50
+ThrowNullRef20:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %53
+ThrowNullRef22:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %24
+ThrowNullRef24:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %27
+ThrowNullRef26:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2503,15 +2585,15 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2519,16 +2601,16 @@ entry:
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
   store i32 %8, i32* %loc0
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
   %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
   store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
@@ -2546,16 +2628,16 @@ entry:
 
 ; <label>:23                                      ; preds = %64
   %24 = load i16*, i16** %loc3
-  %NullCheck12 = icmp ne i16* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i16* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
   store i32 %27, i32* %loc5
   %28 = load i16*, i16** %loc4
-  %NullCheck14 = icmp ne i16* %28, null
-  br i1 %NullCheck14, label %29, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %28, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = load i16, i16* %28, align 8
@@ -2620,15 +2702,15 @@ entry:
 
 ; <label>:67                                      ; preds = %64
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
-  br i1 %NullCheck8, label %69, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %68, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %69
 
 ; <label>:69                                      ; preds = %67
   %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
   %71 = load i32, i32 addrspace(1)* %70
   %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
-  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %73
 
 ; <label>:73                                      ; preds = %69
   %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
@@ -2645,31 +2727,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %67
+ThrowNullRef8:                                    ; preds = %67
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %69
+ThrowNullRef10:                                   ; preds = %69
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2710,14 +2792,14 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
   %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
@@ -2730,14 +2812,14 @@ entry:
 
 ; <label>:11                                      ; preds = %4
   %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
   %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
@@ -2749,14 +2831,14 @@ entry:
 
 ; <label>:22                                      ; preds = %16
   %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
   %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
-  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
-  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
@@ -2804,23 +2886,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2836,7 +2918,280 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[loadElem]
+Successfully read RuntimeType.IsAssignableFrom
+
+define i8 @RuntimeType.IsAssignableFrom(%System.RuntimeType addrspace(1)* %param0, %System.Type addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.RuntimeType addrspace(1)*
+  %arg1 = alloca %System.Type addrspace(1)*
+  %loc0 = alloca %System.RuntimeType addrspace(1)*
+  %loc1 = alloca %"System.Type[]" addrspace(1)*
+  %loc2 = alloca i32
+  store %System.RuntimeType addrspace(1)* %param0, %System.RuntimeType addrspace(1)** %this
+  store %System.Type addrspace(1)* %param1, %System.Type addrspace(1)** %arg1
+  %0 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %1 = icmp ne %System.Type addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i8 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %5 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %6 = bitcast %System.Type addrspace(1)* %4 to %System.Object addrspace(1)*
+  %7 = bitcast %System.RuntimeType addrspace(1)* %5 to %System.Object addrspace(1)*
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %6, %System.Object addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %3
+  ret i8 1
+
+; <label>:12                                      ; preds = %3
+  %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 152
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 32
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
+  %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
+  %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
+  store %System.RuntimeType addrspace(1)* %25, %System.RuntimeType addrspace(1)** %loc0
+  %26 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %27 = icmp eq %System.RuntimeType addrspace(1)* %26, null
+  br i1 %27, label %34, label %28
+
+; <label>:28                                      ; preds = %15
+  %29 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %30 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)*)*)(%System.RuntimeType addrspace(1)* %29, %System.RuntimeType addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+; <label>:34                                      ; preds = %15
+  %35 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %36 = call %System.Reflection.Emit.TypeBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Reflection.Emit.TypeBuilder addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %35)
+  %37 = icmp eq %System.Reflection.Emit.TypeBuilder addrspace(1)* %36, null
+  br i1 %37, label %139, label %38
+
+; <label>:38                                      ; preds = %34
+  %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %42
+
+; <label>:42                                      ; preds = %38
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 152
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 40
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
+  %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
+  %53 = zext i8 %52 to i32
+  %54 = icmp eq i32 %53, 0
+  br i1 %54, label %56, label %55
+
+; <label>:55                                      ; preds = %42
+  ret i8 1
+
+; <label>:56                                      ; preds = %42
+  %57 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %58 = bitcast %System.RuntimeType addrspace(1)* %57 to %System.Type addrspace(1)*
+  %59 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %58)
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %64 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.Type addrspace(1)* %63, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = bitcast %System.RuntimeType addrspace(1)* %64 to %System.Type addrspace(1)*
+  %67 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %63, %System.Type addrspace(1)* %66)
+  %68 = zext i8 %67 to i32
+  %69 = trunc i32 %68 to i8
+  ret i8 %69
+
+; <label>:70                                      ; preds = %56
+  %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
+  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %73
+
+; <label>:73                                      ; preds = %70
+  %74 = load i64, i64 addrspace(1)* %72
+  %75 = add i64 %74, 128
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = add i64 %77, 0
+  %79 = inttoptr i64 %78 to i64*
+  %80 = load i64, i64* %79
+  %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
+  %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
+  %83 = call i8 %82(%System.Type addrspace(1)* %81)
+  %84 = zext i8 %83 to i32
+  %85 = icmp eq i32 %84, 0
+  br i1 %85, label %139, label %86
+
+; <label>:86                                      ; preds = %73
+  %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
+  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %89
+
+; <label>:89                                      ; preds = %86
+  %90 = load i64, i64 addrspace(1)* %88
+  %91 = add i64 %90, 128
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = add i64 %93, 24
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
+  %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
+  %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
+  store %"System.Type[]" addrspace(1)* %99, %"System.Type[]" addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %129
+
+; <label>:100                                     ; preds = %132
+  %101 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %102 = load i32, i32* %loc2
+  %NullCheck11 = icmp eq %"System.Type[]" addrspace(1)* %101, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %103
+
+; <label>:103                                     ; preds = %100
+  %104 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 1
+  %105 = load i32, i32 addrspace(1)* %104
+  %106 = zext i32 %105 to i64
+  %107 = zext i32 %102 to i64
+  %BoundsCheck = icmp uge i64 %107, %106
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %108
+
+; <label>:108                                     ; preds = %103
+  %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
+  %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
+  %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
+  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %113
+
+; <label>:113                                     ; preds = %108
+  %114 = load i64, i64 addrspace(1)* %112
+  %115 = add i64 %114, 152
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = add i64 %117, 56
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
+  %123 = zext i8 %122 to i32
+  %124 = icmp ne i32 %123, 0
+  br i1 %124, label %126, label %125
+
+; <label>:125                                     ; preds = %113
+  ret i8 0
+
+; <label>:126                                     ; preds = %113
+  %127 = load i32, i32* %loc2
+  %128 = add i32 %127, 1
+  store i32 %128, i32* %loc2
+  br label %129
+
+; <label>:129                                     ; preds = %89, %126
+  %130 = load i32, i32* %loc2
+  %131 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %NullCheck9 = icmp eq %"System.Type[]" addrspace(1)* %131, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %132
+
+; <label>:132                                     ; preds = %129
+  %133 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %131, i32 0, i32 1
+  %134 = load i32, i32 addrspace(1)* %133
+  %135 = zext i32 %134 to i64
+  %136 = trunc i64 %135 to i32
+  %137 = icmp slt i32 %130, %136
+  br i1 %137, label %100, label %138
+
+; <label>:138                                     ; preds = %132
+  ret i8 1
+
+; <label>:139                                     ; preds = %34, %73
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %129
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %103
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -2893,7 +3248,7 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElem]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -2904,8 +3259,8 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -2997,8 +3352,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
@@ -3059,8 +3414,8 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -3087,8 +3442,8 @@ entry:
 
 ; <label>:17                                      ; preds = %5, %11
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
@@ -3097,8 +3452,8 @@ entry:
 
 ; <label>:22                                      ; preds = %1, %11
   %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
@@ -3109,11 +3464,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %17
+ThrowNullRef2:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %22
+ThrowNullRef4:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3167,15 +3522,15 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
   %15 = load i32, i32 addrspace(1)* %14
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
@@ -3198,7 +3553,7 @@ ThrowNullRef:                                     ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef2:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3232,8 +3587,8 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
@@ -3312,8 +3667,8 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -3327,8 +3682,8 @@ entry:
 ; <label>:5                                       ; preds = %43
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %7 = load i32, i32* %loc1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck6, label %8, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
@@ -3366,8 +3721,8 @@ entry:
 ; <label>:32                                      ; preds = %21, %25
   %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
   %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
-  br i1 %NullCheck8, label %35, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = trunc i32 %34 to i16
@@ -3380,8 +3735,8 @@ entry:
 ; <label>:40                                      ; preds = %1, %35
   %41 = load i32, i32* %loc1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
-  br i1 %NullCheck2, label %43, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %42, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
@@ -3392,8 +3747,8 @@ entry:
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
   %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
-  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
   %51 = load i64, i64 addrspace(1)* %49
@@ -3412,19 +3767,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %40
+ThrowNullRef2:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %47
+ThrowNullRef4:                                    ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %5
+ThrowNullRef6:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %32
+ThrowNullRef8:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3467,8 +3822,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
@@ -3492,11 +3847,391 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(i16* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store i16* %param0, i16** %arg0
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load i32, i32* %arg3
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %42, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %37, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg2
+  %13 = load i32, i32* %arg3
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %37, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %24 = load i32, i32* %arg2
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load i16*, i16** %arg0
+  %35 = load i32, i32* %arg3
+  %36 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %36, i16* %34, i32 %35)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:37                                      ; preds = %5, %16
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %39)
+  %41 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41, %System.String addrspace(1)* %38, %System.String addrspace(1)* %40)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41) #0
+  unreachable
+
+; <label>:42                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
-Failed to read StringBuilder.ToString[loadElemA]
+Successfully read StringBuilder.ToString
+
+define %System.String addrspace(1)* @StringBuilder.ToString(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i16*
+  %loc3 = alloca %"System.Char[]" addrspace(1)*
+  %loc4 = alloca i32
+  %loc5 = alloca i32
+  %loc6 = alloca i16 addrspace(1)*
+  %loc7 = alloca %System.String addrspace(1)*
+  %loc8 = alloca %"System.Char[]" addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %0)
+  %2 = icmp ne i32 %1, 0
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %4
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %6)
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %7)
+  store %System.String addrspace(1)* %8, %System.String addrspace(1)** %loc0
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.Text.StringBuilder addrspace(1)* %9, %System.Text.StringBuilder addrspace(1)** %loc1
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  store %System.String addrspace(1)* %10, %System.String addrspace(1)** %loc7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc7
+  %12 = ptrtoint %System.String addrspace(1)* %11 to i64
+  %13 = icmp eq i64 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %5
+  %15 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %16 = sext i32 %15 to i64
+  %17 = add i64 %12, %16
+  br label %18
+
+; <label>:18                                      ; preds = %5, %14
+  %19 = phi i64 [ %12, %5 ], [ %17, %14 ]
+  %20 = inttoptr i64 %19 to i16*
+  store i16* %20, i16** %loc2
+  br label %21
+
+; <label>:21                                      ; preds = %98, %18
+  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %22, null
+  br i1 %NullCheck, label %ThrowNullRef, label %23
+
+; <label>:23                                      ; preds = %21
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 3
+  %25 = load i32, i32 addrspace(1)* %24, align 8
+  %26 = icmp sle i32 %25, 0
+  br i1 %26, label %96, label %27
+
+; <label>:27                                      ; preds = %23
+  %28 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %28, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %29
+
+; <label>:29                                      ; preds = %27
+  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %28, i32 0, i32 1
+  %31 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %30, align 8
+  store %"System.Char[]" addrspace(1)* %31, %"System.Char[]" addrspace(1)** %loc3
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %33
+
+; <label>:33                                      ; preds = %29
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  store i32 %35, i32* %loc4
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  %39 = load i32, i32 addrspace(1)* %38, align 8
+  store i32 %39, i32* %loc5
+  %40 = load i32, i32* %loc5
+  %41 = load i32, i32* %loc4
+  %42 = add i32 %40, %41
+  %43 = zext i32 %42 to i64
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %45
+
+; <label>:45                                      ; preds = %37
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = sext i32 %47 to i64
+  %49 = icmp sgt i64 %43, %48
+  br i1 %49, label %91, label %50
+
+; <label>:50                                      ; preds = %45
+  %51 = load i32, i32* %loc5
+  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %52, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %53
+
+; <label>:53                                      ; preds = %50
+  %54 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %52, i32 0, i32 1
+  %55 = load i32, i32 addrspace(1)* %54
+  %56 = zext i32 %55 to i64
+  %57 = trunc i64 %56 to i32
+  %58 = icmp ugt i32 %51, %57
+  br i1 %58, label %91, label %59
+
+; <label>:59                                      ; preds = %53
+  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  store %"System.Char[]" addrspace(1)* %60, %"System.Char[]" addrspace(1)** %loc8
+  %61 = icmp eq %"System.Char[]" addrspace(1)* %60, null
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %63, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %64
+
+; <label>:64                                      ; preds = %62
+  %65 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %63, i32 0, i32 1
+  %66 = load i32, i32 addrspace(1)* %65
+  %67 = zext i32 %66 to i64
+  %68 = trunc i64 %67 to i32
+  %69 = icmp ne i32 %68, 0
+  br i1 %69, label %71, label %70
+
+; <label>:70                                      ; preds = %59, %64
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:71                                      ; preds = %64
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %73
+
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %BoundsCheck = icmp uge i64 0, %76
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %77
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %78, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:79                                      ; preds = %70, %77
+  %80 = load i16*, i16** %loc2
+  %81 = load i32, i32* %loc4
+  %82 = sext i32 %81 to i64
+  %83 = mul i64 %82, 2
+  %84 = bitcast i16* %80 to i8*
+  %85 = getelementptr inbounds i8, i8* %84, i64 %83
+  %86 = load i16 addrspace(1)*, i16 addrspace(1)** %loc6
+  %87 = ptrtoint i16 addrspace(1)* %86 to i64
+  %88 = load i32, i32* %loc5
+  %89 = bitcast i8* %85 to i16*
+  %90 = inttoptr i64 %87 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %89, i16* %90, i32 %88)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %96
+
+; <label>:91                                      ; preds = %45, %53
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %94 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %93)
+  %95 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95, %System.String addrspace(1)* %92, %System.String addrspace(1)* %94)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95) #0
+  unreachable
+
+; <label>:96                                      ; preds = %23, %79
+  %97 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %97, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %98
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %97, i32 0, i32 2
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  store %System.Text.StringBuilder addrspace(1)* %100, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %102 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %102, label %21, label %103
+
+; <label>:103                                     ; preds = %98
+  store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc7
+  %104 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  ret %System.String addrspace(1)* %104
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method StringBuilder::get_Length using LLILCJit
+Successfully read StringBuilder.get_Length
+
+define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
+Successfully read RuntimeHelpers.get_OffsetToStringData
+
+define i32 @RuntimeHelpers.get_OffsetToStringData() {
+entry:
+  ret i32 12
+}
+
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
 Successfully read CultureData.CreateCultureData
 
@@ -3514,23 +4249,23 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
   store i8 %4, i8 addrspace(1)* %6
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
@@ -3549,11 +4284,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3566,50 +4301,50 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
   store i32 -1, i32 addrspace(1)* %2
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
   store i32 -1, i32 addrspace(1)* %8
   %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
   store i32 -1, i32 addrspace(1)* %14
   %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
   store i32 -1, i32 addrspace(1)* %17
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
@@ -3623,27 +4358,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3675,7 +4410,136 @@ Failed to read Dictionary`2.Insert[non-const derefAddress]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
 Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
-Failed to read HashHelpers.GetPrime[loadElem]
+Successfully read HashHelpers.GetPrime
+
+define i32 @HashHelpers.GetPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %6, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5, %System.String addrspace(1)* %4)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5) #0
+  unreachable
+
+; <label>:6                                       ; preds = %entry
+  store i32 0, i32* %loc0
+  br label %29
+
+; <label>:7                                       ; preds = %35
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 1296
+  %10 = addrspacecast i8 addrspace(1)* %9 to %"System.Int32[]" addrspace(1)**
+  %11 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %10
+  %12 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Int32[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = zext i32 %15 to i64
+  %17 = zext i32 %12 to i64
+  %BoundsCheck = icmp uge i64 %17, %16
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 3, i32 %12
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  store i32 %20, i32* %loc1
+  %21 = load i32, i32* %loc1
+  %22 = load i32, i32* %arg0
+  %23 = icmp slt i32 %21, %22
+  br i1 %23, label %26, label %24
+
+; <label>:24                                      ; preds = %18
+  %25 = load i32, i32* %loc1
+  ret i32 %25
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %loc0
+  %28 = add i32 %27, 1
+  store i32 %28, i32* %loc0
+  br label %29
+
+; <label>:29                                      ; preds = %6, %26
+  %30 = load i32, i32* %loc0
+  %31 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %32 = getelementptr inbounds i8, i8 addrspace(1)* %31, i64 1296
+  %33 = addrspacecast i8 addrspace(1)* %32 to %"System.Int32[]" addrspace(1)**
+  %34 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %33
+  %NullCheck = icmp eq %"System.Int32[]" addrspace(1)* %34, null
+  br i1 %NullCheck, label %ThrowNullRef, label %35
+
+; <label>:35                                      ; preds = %29
+  %36 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %34, i32 0, i32 1
+  %37 = load i32, i32 addrspace(1)* %36
+  %38 = zext i32 %37 to i64
+  %39 = trunc i64 %38 to i32
+  %40 = icmp slt i32 %30, %39
+  br i1 %40, label %7, label %41
+
+; <label>:41                                      ; preds = %35
+  %42 = load i32, i32* %arg0
+  %43 = or i32 %42, 1
+  store i32 %43, i32* %loc2
+  br label %59
+
+; <label>:44                                      ; preds = %59
+  %45 = load i32, i32* %loc2
+  %46 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %45)
+  %47 = zext i8 %46 to i32
+  %48 = icmp eq i32 %47, 0
+  br i1 %48, label %56, label %49
+
+; <label>:49                                      ; preds = %44
+  %50 = load i32, i32* %loc2
+  %51 = sub i32 %50, 1
+  %52 = srem i32 %51, 101
+  %53 = icmp eq i32 %52, 0
+  br i1 %53, label %56, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = load i32, i32* %loc2
+  ret i32 %55
+
+; <label>:56                                      ; preds = %44, %49
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %57, 2
+  store i32 %58, i32* %loc2
+  br label %59
+
+; <label>:59                                      ; preds = %41, %56
+  %60 = load i32, i32* %loc2
+  %61 = icmp slt i32 %60, 2147483647
+  br i1 %61, label %44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load i32, i32* %arg0
+  ret i32 %63
+
+ThrowNullRef:                                     ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
 Successfully read GenericEqualityComparer`1.GetHashCode
 
@@ -3694,14 +4558,14 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
   %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load i64, i64 addrspace(1)* %7
@@ -3720,7 +4584,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3750,8 +4614,8 @@ entry:
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
@@ -3796,8 +4660,8 @@ entry:
   %35 = bitcast i16* %34 to i8*
   %36 = getelementptr inbounds i8, i8* %35, i64 2
   %37 = bitcast i8* %36 to i16*
-  %NullCheck4 = icmp ne i16* %37, null
-  br i1 %NullCheck4, label %38, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %37, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %38
 
 ; <label>:38                                      ; preds = %27
   %39 = load i16, i16* %37, align 8
@@ -3824,8 +4688,8 @@ entry:
 
 ; <label>:54                                      ; preds = %22, %43
   %55 = load i16*, i16** %loc4
-  %NullCheck2 = icmp ne i16* %55, null
-  br i1 %NullCheck2, label %56, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i16* %55, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %56
 
 ; <label>:56                                      ; preds = %54
   %57 = load i16, i16* %55, align 8
@@ -3850,11 +4714,11 @@ ThrowNullRef:                                     ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %54
+ThrowNullRef2:                                    ; preds = %54
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %27
+ThrowNullRef4:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3871,8 +4735,8 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -3907,8 +4771,8 @@ entry:
 
 ; <label>:26                                      ; preds = %19
   %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
-  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %28
 
 ; <label>:28                                      ; preds = %26
   %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
@@ -3920,7 +4784,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3972,8 +4836,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
@@ -3984,26 +4848,26 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
-  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
@@ -4014,8 +4878,8 @@ entry:
 ; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
@@ -4024,8 +4888,8 @@ entry:
 
 ; <label>:25                                      ; preds = %1, %16, %23
   %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
-  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
@@ -4036,27 +4900,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %20
+ThrowNullRef10:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4069,8 +4933,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -4081,8 +4945,8 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
@@ -4091,8 +4955,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1, %8
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
@@ -4103,11 +4967,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4128,24 +4992,24 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   store i32 %3, i32* %loc0
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
   %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
   store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck4, label %9, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
@@ -4164,15 +5028,15 @@ entry:
 ; <label>:18                                      ; preds = %70
   %19 = load i16*, i16** %loc3
   %20 = bitcast i16* %19 to i64*
-  %NullCheck10 = icmp ne i64* %20, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %20, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = load i64, i64* %20, align 8
   %23 = load i16*, i16** %loc4
   %24 = bitcast i16* %23 to i64*
-  %NullCheck12 = icmp ne i64* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = load i64, i64* %24, align 8
@@ -4188,8 +5052,8 @@ entry:
   %31 = bitcast i16* %30 to i8*
   %32 = getelementptr inbounds i8, i8* %31, i64 8
   %33 = bitcast i8* %32 to i64*
-  %NullCheck14 = icmp ne i64* %33, null
-  br i1 %NullCheck14, label %34, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = load i64, i64* %33, align 8
@@ -4197,8 +5061,8 @@ entry:
   %37 = bitcast i16* %36 to i8*
   %38 = getelementptr inbounds i8, i8* %37, i64 8
   %39 = bitcast i8* %38 to i64*
-  %NullCheck16 = icmp ne i64* %39, null
-  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %40
 
 ; <label>:40                                      ; preds = %34
   %41 = load i64, i64* %39, align 8
@@ -4214,8 +5078,8 @@ entry:
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %NullCheck18 = icmp ne i64* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = load i64, i64* %48, align 8
@@ -4223,8 +5087,8 @@ entry:
   %52 = bitcast i16* %51 to i8*
   %53 = getelementptr inbounds i8, i8* %52, i64 16
   %54 = bitcast i8* %53 to i64*
-  %NullCheck20 = icmp ne i64* %54, null
-  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64* %54, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %55
 
 ; <label>:55                                      ; preds = %49
   %56 = load i64, i64* %54, align 8
@@ -4262,15 +5126,15 @@ entry:
 ; <label>:74                                      ; preds = %95
   %75 = load i16*, i16** %loc3
   %76 = bitcast i16* %75 to i32*
-  %NullCheck6 = icmp ne i32* %76, null
-  br i1 %NullCheck6, label %77, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32* %76, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %77
 
 ; <label>:77                                      ; preds = %74
   %78 = load i32, i32* %76, align 8
   %79 = load i16*, i16** %loc4
   %80 = bitcast i16* %79 to i32*
-  %NullCheck8 = icmp ne i32* %80, null
-  br i1 %NullCheck8, label %81, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i32* %80, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %81
 
 ; <label>:81                                      ; preds = %77
   %82 = load i32, i32* %80, align 8
@@ -4318,43 +5182,43 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %74
+ThrowNullRef6:                                    ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %77
+ThrowNullRef8:                                    ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %29
+ThrowNullRef14:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %34
+ThrowNullRef16:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4376,8 +5240,8 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load i64, i64 addrspace(1)* %4
@@ -4389,8 +5253,8 @@ entry:
   %12 = load i64, i64* %11
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %5
   %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
@@ -4399,8 +5263,8 @@ entry:
   %18 = load i8, i8* %arg2
   %19 = zext i8 %18 to i32
   %20 = trunc i32 %19 to i8
-  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %15
   %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
@@ -4411,11 +5275,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4442,8 +5306,8 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
@@ -4466,16 +5330,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
   %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = load i64, i64 addrspace(1)* %19
@@ -4500,8 +5364,8 @@ entry:
 ; <label>:35                                      ; preds = %30
   %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
@@ -4514,8 +5378,8 @@ entry:
 
 ; <label>:42                                      ; preds = %1, %38
   %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
-  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
@@ -4526,19 +5390,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %35
+ThrowNullRef2:                                    ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %42
+ThrowNullRef8:                                    ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4551,14 +5415,14 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
@@ -4570,7 +5434,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4583,8 +5447,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
@@ -4613,51 +5477,51 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
   %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
   %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
   %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
   %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
-  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
   store i64 %21, i64 addrspace(1)* %23
   %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %25 = load i64, i64* %loc0
-  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
@@ -4668,27 +5532,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %22
+ThrowNullRef12:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4701,8 +5565,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
@@ -4713,19 +5577,19 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
@@ -4734,8 +5598,8 @@ entry:
 
 ; <label>:15                                      ; preds = %1, %13
   %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
@@ -4746,19 +5610,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %15
+ThrowNullRef8:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4771,8 +5635,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -4831,8 +5695,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
@@ -4882,8 +5746,8 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
-  br i1 %NullCheck, label %17, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %ThrowNullRef, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
@@ -4894,15 +5758,15 @@ entry:
 
 ; <label>:22                                      ; preds = %17
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
-  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
   %26 = load i32, i32 addrspace(1)* %25
   %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
-  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %27, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
@@ -4925,8 +5789,8 @@ entry:
 ; <label>:40                                      ; preds = %17
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
-  br i1 %NullCheck6, label %43, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %41, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
@@ -4938,34 +5802,17 @@ ThrowNullRef:                                     ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %24
+ThrowNullRef4:                                    ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %40
+ThrowNullRef6:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
-}
-
-INFO:  jitting method Object::ReferenceEquals using LLILCJit
-Successfully read Object.ReferenceEquals
-
-define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
-entry:
-  %arg0 = alloca %System.Object addrspace(1)*
-  %arg1 = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
-  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
-  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = icmp eq %System.Object addrspace(1)* %0, %1
-  %3 = sext i1 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
 }
 
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
@@ -4978,21 +5825,21 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
   %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
-  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
@@ -5007,28 +5854,28 @@ entry:
 ; <label>:13                                      ; preds = %8, %12
   %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
   %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
   %21 = load i32, i32 addrspace(1)* %20, align 8
   %22 = add i32 %21, 1
-  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
   store i32 %22, i32 addrspace(1)* %24
   %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
@@ -5039,27 +5886,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5077,7 +5924,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::Setup using LLILCJit
-Failed to read AppDomain.Setup[loadElem]
+Failed to read AppDomain.Setup[unbox]
 INFO:  jitting method Thread::GetDomain using LLILCJit
 Successfully read Thread.GetDomain
 
@@ -5108,8 +5955,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
@@ -5122,14 +5969,14 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
   %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
@@ -5141,11 +5988,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5173,8 +6020,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -5189,7 +6036,328 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
 Failed to read KeyCollection.System.Collections.Generic.IEnumerable<TKey>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Successfully read Enumerator.MoveNext
+
+define i8 @Enumerator.MoveNext(%"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.RuntimeTypeHandle* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*
+  %"$TypeArg" = alloca %System.RuntimeTypeHandle*
+  store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
+  %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 8
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %76, label %12
+
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
+  br label %76
+
+; <label>:13                                      ; preds = %85
+  %14 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck19 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %15
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, i32 0, i32 0
+  %17 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %16, align 8
+  %NullCheck21 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, i32 0, i32 2
+  %20 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %19, align 8
+  %21 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck23 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %22
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, i32 0, i32 2
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %NullCheck25 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 3, i32 %24
+  %NullCheck27 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %32
+
+; <label>:32                                      ; preds = %30
+  %33 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, i32 0, i32 2
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = icmp slt i32 %34, 0
+  br i1 %35, label %68, label %36
+
+; <label>:36                                      ; preds = %32
+  %37 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %38 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck29 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %39
+
+; <label>:39                                      ; preds = %36
+  %40 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, i32 0, i32 0
+  %41 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %40, align 8
+  %NullCheck31 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, i32 0, i32 2
+  %44 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %43, align 8
+  %45 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck33 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, i32 0, i32 2
+  %48 = load i32, i32 addrspace(1)* %47, align 8
+  %NullCheck35 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %49
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = zext i32 %51 to i64
+  %53 = zext i32 %48 to i64
+  %BoundsCheck37 = icmp uge i64 %53, %52
+  br i1 %BoundsCheck37, label %ThrowIndexOutOfRange38, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 3, i32 %48
+  %NullCheck39 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %56
+
+; <label>:56                                      ; preds = %54
+  %57 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, i32 0, i32 0
+  %58 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck41 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %59
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %60, %System.__Canon addrspace(1)* %58)
+  %61 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck43 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  %64 = load i32, i32 addrspace(1)* %63, align 8
+  %65 = add i32 %64, 1
+  %NullCheck45 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  store i32 %65, i32 addrspace(1)* %67
+  ret i8 1
+
+; <label>:68                                      ; preds = %32
+  %69 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck47 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %73 = add i32 %72, 1
+  %NullCheck49 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %74
+
+; <label>:74                                      ; preds = %70
+  %75 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  store i32 %73, i32 addrspace(1)* %75
+  br label %76
+
+; <label>:76                                      ; preds = %8, %12, %74
+  %77 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %78
+
+; <label>:78                                      ; preds = %76
+  %79 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, i32 0, i32 2
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck7 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %82
+
+; <label>:82                                      ; preds = %78
+  %83 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, i32 0, i32 0
+  %84 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %83, align 8
+  %NullCheck9 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %85
+
+; <label>:85                                      ; preds = %82
+  %86 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, i32 0, i32 7
+  %87 = load i32, i32 addrspace(1)* %86, align 8
+  %88 = icmp ult i32 %80, %87
+  br i1 %88, label %13, label %89
+
+; <label>:89                                      ; preds = %85
+  %90 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %91 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck11 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %92
+
+; <label>:92                                      ; preds = %89
+  %93 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, i32 0, i32 0
+  %94 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck13 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %95
+
+; <label>:95                                      ; preds = %92
+  %96 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, i32 0, i32 7
+  %97 = load i32, i32 addrspace(1)* %96, align 8
+  %98 = add i32 %97, 1
+  %NullCheck15 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %99
+
+; <label>:99                                      ; preds = %95
+  %100 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, i32 0, i32 2
+  store i32 %98, i32 addrspace(1)* %100
+  %101 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck17 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %102
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %103, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %92
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef22:                                   ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef24:                                   ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef26:                                   ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef28:                                   ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef30:                                   ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef32:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef34:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef36:                                   ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange38:                           ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef40:                                   ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef42:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef44:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef46:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef48:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef50:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -5200,8 +6368,8 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -5232,9 +6400,9 @@ Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
 Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
-Failed to read String.MakeSeparatorList[loadElemA]
+Failed to read String.MakeSeparatorList[storeElem]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
-Failed to read String.InternalSplitKeepEmptyEntries[loadElem]
+Failed to read String.InternalSplitKeepEmptyEntries[storeElem]
 INFO:  jitting method Path::IsRelative using LLILCJit
 Successfully read Path.IsRelative
 
@@ -5243,8 +6411,8 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -5254,8 +6422,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
@@ -5271,8 +6439,8 @@ entry:
 
 ; <label>:17                                      ; preds = %7
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
@@ -5288,8 +6456,8 @@ entry:
 
 ; <label>:29                                      ; preds = %19
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %31
 
 ; <label>:31                                      ; preds = %29
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
@@ -5300,8 +6468,8 @@ entry:
 
 ; <label>:36                                      ; preds = %31
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
-  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %37, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
@@ -5312,8 +6480,8 @@ entry:
 
 ; <label>:43                                      ; preds = %31, %38
   %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
-  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %45
 
 ; <label>:45                                      ; preds = %43
   %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
@@ -5324,8 +6492,8 @@ entry:
 
 ; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %50
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
@@ -5336,8 +6504,8 @@ entry:
 
 ; <label>:57                                      ; preds = %1, %7, %19, %45, %52
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
-  br i1 %NullCheck14, label %59, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %59
 
 ; <label>:59                                      ; preds = %57
   %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
@@ -5347,8 +6515,8 @@ entry:
 
 ; <label>:63                                      ; preds = %59
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
@@ -5359,8 +6527,8 @@ entry:
 
 ; <label>:70                                      ; preds = %65
   %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
-  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.String addrspace(1)* %71, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %72
 
 ; <label>:72                                      ; preds = %70
   %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
@@ -5379,39 +6547,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %17
+ThrowNullRef4:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %29
+ThrowNullRef6:                                    ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %36
+ThrowNullRef8:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %43
+ThrowNullRef10:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %50
+ThrowNullRef12:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %57
+ThrowNullRef14:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %63
+ThrowNullRef16:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %70
+ThrowNullRef18:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5419,7 +6587,293 @@ ThrowNullRef17:                                   ; preds = %70
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
-Failed to read String.TrimHelper[loadElem]
+Successfully read String.TrimHelper
+
+define %System.String addrspace(1)* @String.TrimHelper(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i16
+  %loc4 = alloca i32
+  %loc5 = alloca i16
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = sub i32 %3, 1
+  store i32 %4, i32* %loc0
+  store i32 0, i32* %loc1
+  %5 = load i32, i32* %arg2
+  %6 = icmp eq i32 %5, 1
+  br i1 %6, label %62, label %7
+
+; <label>:7                                       ; preds = %1
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:8                                       ; preds = %58
+  store i32 0, i32* %loc2
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load i32, i32* %loc1
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2, i32 %10
+  %13 = load i16, i16 addrspace(1)* %12
+  %14 = zext i16 %13 to i32
+  %15 = trunc i32 %14 to i16
+  store i16 %15, i16* %loc3
+  store i32 0, i32* %loc2
+  br label %34
+
+; <label>:16                                      ; preds = %37
+  %17 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %18 = load i32, i32* %loc2
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %17, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %19
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = zext i32 %18 to i64
+  %BoundsCheck = icmp uge i64 %23, %22
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %24
+
+; <label>:24                                      ; preds = %19
+  %25 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 3, i32 %18
+  %26 = load i16, i16 addrspace(1)* %25, align 8
+  %27 = zext i16 %26 to i32
+  %28 = load i16, i16* %loc3
+  %29 = zext i16 %28 to i32
+  %30 = icmp eq i32 %27, %29
+  br i1 %30, label %43, label %31
+
+; <label>:31                                      ; preds = %24
+  %32 = load i32, i32* %loc2
+  %33 = add i32 %32, 1
+  store i32 %33, i32* %loc2
+  br label %34
+
+; <label>:34                                      ; preds = %11, %31
+  %35 = load i32, i32* %loc2
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = icmp slt i32 %35, %41
+  br i1 %42, label %16, label %43
+
+; <label>:43                                      ; preds = %24, %37
+  %44 = load i32, i32* %loc2
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %45, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp eq i32 %44, %50
+  br i1 %51, label %62, label %52
+
+; <label>:52                                      ; preds = %46
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %7, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %57, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %58
+
+; <label>:58                                      ; preds = %55
+  %59 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %60 = load i32, i32 addrspace(1)* %59
+  %61 = icmp slt i32 %56, %60
+  br i1 %61, label %8, label %62
+
+; <label>:62                                      ; preds = %1, %46, %58
+  %63 = load i32, i32* %arg2
+  %64 = icmp eq i32 %63, 0
+  br i1 %64, label %122, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %66, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %67
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %66, i32 0, i32 1
+  %69 = load i32, i32 addrspace(1)* %68
+  %70 = sub i32 %69, 1
+  store i32 %70, i32* %loc0
+  br label %118
+
+; <label>:71                                      ; preds = %118
+  store i32 0, i32* %loc4
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %73 = load i32, i32* %loc0
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %74
+
+; <label>:74                                      ; preds = %71
+  %75 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 2, i32 %73
+  %76 = load i16, i16 addrspace(1)* %75
+  %77 = zext i16 %76 to i32
+  %78 = trunc i32 %77 to i16
+  store i16 %78, i16* %loc5
+  store i32 0, i32* %loc4
+  br label %97
+
+; <label>:79                                      ; preds = %100
+  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %81 = load i32, i32* %loc4
+  %NullCheck19 = icmp eq %"System.Char[]" addrspace(1)* %80, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
+
+; <label>:82                                      ; preds = %79
+  %83 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 1
+  %84 = load i32, i32 addrspace(1)* %83
+  %85 = zext i32 %84 to i64
+  %86 = zext i32 %81 to i64
+  %BoundsCheck21 = icmp uge i64 %86, %85
+  br i1 %BoundsCheck21, label %ThrowIndexOutOfRange22, label %87
+
+; <label>:87                                      ; preds = %82
+  %88 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 3, i32 %81
+  %89 = load i16, i16 addrspace(1)* %88, align 8
+  %90 = zext i16 %89 to i32
+  %91 = load i16, i16* %loc5
+  %92 = zext i16 %91 to i32
+  %93 = icmp eq i32 %90, %92
+  br i1 %93, label %106, label %94
+
+; <label>:94                                      ; preds = %87
+  %95 = load i32, i32* %loc4
+  %96 = add i32 %95, 1
+  store i32 %96, i32* %loc4
+  br label %97
+
+; <label>:97                                      ; preds = %74, %94
+  %98 = load i32, i32* %loc4
+  %99 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck15 = icmp eq %"System.Char[]" addrspace(1)* %99, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %100
+
+; <label>:100                                     ; preds = %97
+  %101 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %99, i32 0, i32 1
+  %102 = load i32, i32 addrspace(1)* %101
+  %103 = zext i32 %102 to i64
+  %104 = trunc i64 %103 to i32
+  %105 = icmp slt i32 %98, %104
+  br i1 %105, label %79, label %106
+
+; <label>:106                                     ; preds = %87, %100
+  %107 = load i32, i32* %loc4
+  %108 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck17 = icmp eq %"System.Char[]" addrspace(1)* %108, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %109
+
+; <label>:109                                     ; preds = %106
+  %110 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %108, i32 0, i32 1
+  %111 = load i32, i32 addrspace(1)* %110
+  %112 = zext i32 %111 to i64
+  %113 = trunc i64 %112 to i32
+  %114 = icmp eq i32 %107, %113
+  br i1 %114, label %122, label %115
+
+; <label>:115                                     ; preds = %109
+  %116 = load i32, i32* %loc0
+  %117 = sub i32 %116, 1
+  store i32 %117, i32* %loc0
+  br label %118
+
+; <label>:118                                     ; preds = %67, %115
+  %119 = load i32, i32* %loc0
+  %120 = load i32, i32* %loc1
+  %121 = icmp sge i32 %119, %120
+  br i1 %121, label %71, label %122
+
+; <label>:122                                     ; preds = %62, %109, %118
+  %123 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %124 = load i32, i32* %loc1
+  %125 = load i32, i32* %loc0
+  %126 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %123, i32 %124, i32 %125)
+  ret %System.String addrspace(1)* %126
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %97
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange22:                           ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
 Successfully read String.CreateTrimmedString
 
@@ -5439,8 +6893,8 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
@@ -5535,8 +6989,8 @@ entry:
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i64 2872
   %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
   %8 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %7
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %3
   %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
@@ -5553,8 +7007,8 @@ entry:
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 2864
   %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
   %21 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %20
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
-  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %22
 
 ; <label>:22                                      ; preds = %16
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
@@ -5569,7 +7023,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %16
+ThrowNullRef2:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5586,8 +7040,8 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5613,8 +7067,8 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
@@ -5632,8 +7086,8 @@ entry:
 
 ; <label>:12                                      ; preds = %4
   %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
@@ -5644,8 +7098,8 @@ entry:
 
 ; <label>:19                                      ; preds = %14
   %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %19
   %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
@@ -5660,21 +7114,21 @@ entry:
   %31 = zext i16 %30 to i32
   %32 = bitcast i8* %29 to i16*
   %33 = trunc i32 %31 to i16
-  %NullCheck6 = icmp ne i16* %32, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i16* %32, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %21
   store i16 %33, i16* %32, align 8
   %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %36
 
 ; <label>:36                                      ; preds = %34
   %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
   %38 = load i32, i32 addrspace(1)* %37, align 8
   %39 = add i32 %38, 1
-  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %40
 
 ; <label>:40                                      ; preds = %36
   %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
@@ -5683,16 +7137,16 @@ entry:
 
 ; <label>:42                                      ; preds = %14
   %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
-  br i1 %NullCheck12, label %44, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
   %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
   %47 = load i16, i16* %arg1
   %48 = zext i16 %47 to i32
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = trunc i32 %48 to i16
@@ -5703,31 +7157,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %19
+ThrowNullRef4:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %21
+ThrowNullRef6:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %36
+ThrowNullRef10:                                   ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %42
+ThrowNullRef12:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %44
+ThrowNullRef14:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5740,8 +7194,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -5752,8 +7206,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
@@ -5762,14 +7216,14 @@ entry:
 
 ; <label>:11                                      ; preds = %1
   %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
@@ -5779,15 +7233,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5808,8 +7262,8 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5822,8 +7276,8 @@ entry:
 
 ; <label>:8                                       ; preds = %3
   %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
@@ -5842,15 +7296,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
-  br i1 %NullCheck4, label %22, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
   %24 = load i16*, i16* addrspace(1)* %23, align 8
   %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %25, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
@@ -5859,8 +7313,8 @@ entry:
   store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
@@ -5874,8 +7328,8 @@ entry:
 
 ; <label>:37                                      ; preds = %65
   %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %37
   %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
@@ -5886,16 +7340,16 @@ entry:
   %45 = bitcast i16* %41 to i8*
   %46 = getelementptr inbounds i8, i8* %45, i64 %44
   %47 = bitcast i8* %46 to i16*
-  %NullCheck14 = icmp ne i16* %47, null
-  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %47, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %48
 
 ; <label>:48                                      ; preds = %39
   %49 = load i16, i16* %47, align 8
   %50 = zext i16 %49 to i32
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %52 = load i32, i32* %loc1
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %53
 
 ; <label>:53                                      ; preds = %48
   %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
@@ -5916,8 +7370,8 @@ entry:
 ; <label>:62                                      ; preds = %36, %59
   %63 = load i32, i32* %loc1
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck10, label %65, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %65
 
 ; <label>:65                                      ; preds = %62
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
@@ -5936,15 +7390,15 @@ entry:
 
 ; <label>:74                                      ; preds = %70
   %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
-  br i1 %NullCheck18, label %76, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %76
 
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
   %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
-  br i1 %NullCheck20, label %80, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
   %81 = load i64, i64 addrspace(1)* %79
@@ -5958,8 +7412,8 @@ entry:
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
   %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
-  br i1 %NullCheck22, label %92, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.String addrspace(1)* %90, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %92
 
 ; <label>:92                                      ; preds = %80
   %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
@@ -5969,15 +7423,15 @@ entry:
 
 ; <label>:96                                      ; preds = %70
   %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
-  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %98
 
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
   %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
-  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
   %103 = load i64, i64 addrspace(1)* %101
@@ -5991,8 +7445,8 @@ entry:
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
   %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
-  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.String addrspace(1)* %112, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %114
 
 ; <label>:114                                     ; preds = %102
   %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
@@ -6004,59 +7458,59 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %20
+ThrowNullRef4:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %22
+ThrowNullRef6:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %26
+ThrowNullRef8:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %62
+ThrowNullRef10:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %48
+ThrowNullRef16:                                   ; preds = %48
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %74
+ThrowNullRef18:                                   ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %76
+ThrowNullRef20:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %80
+ThrowNullRef22:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %96
+ThrowNullRef24:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %98
+ThrowNullRef26:                                   ; preds = %98
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %102
+ThrowNullRef28:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6069,15 +7523,15 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
   %3 = load i16*, i16* addrspace(1)* %2, align 8
   %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
@@ -6087,8 +7541,8 @@ entry:
   %10 = bitcast i16* %3 to i8*
   %11 = getelementptr inbounds i8, i8* %10, i64 %9
   %12 = bitcast i8* %11 to i16*
-  %NullCheck4 = icmp ne i16* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %5
   store i16 0, i16* %12, align 8
@@ -6098,11 +7552,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6119,8 +7573,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -6131,8 +7585,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
@@ -6144,15 +7598,15 @@ entry:
 
 ; <label>:14                                      ; preds = %1
   %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
   %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
   %21 = load i64, i64 addrspace(1)* %19
@@ -6171,15 +7625,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %14
+ThrowNullRef4:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %16
+ThrowNullRef6:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6302,14 +7756,6 @@ entry:
   ret %System.String addrspace(1)* %57
 }
 
-INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
-Successfully read RuntimeHelpers.get_OffsetToStringData
-
-define i32 @RuntimeHelpers.get_OffsetToStringData() {
-entry:
-  ret i32 12
-}
-
 INFO:  jitting method String::Equals using LLILCJit
 Successfully read String.Equals
 
@@ -6381,8 +7827,8 @@ entry:
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
-  br i1 %NullCheck24, label %29, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
   %30 = load i64, i64 addrspace(1)* %28
@@ -6397,8 +7843,8 @@ entry:
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
-  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
   %43 = load i64, i64 addrspace(1)* %41
@@ -6418,8 +7864,8 @@ entry:
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
   %59 = load i64, i64 addrspace(1)* %57
@@ -6434,8 +7880,8 @@ entry:
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck22, label %71, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
   %72 = load i64, i64 addrspace(1)* %70
@@ -6455,8 +7901,8 @@ entry:
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
-  br i1 %NullCheck16, label %87, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = load i64, i64 addrspace(1)* %86
@@ -6471,8 +7917,8 @@ entry:
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck18, label %100, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
   %101 = load i64, i64 addrspace(1)* %99
@@ -6492,8 +7938,8 @@ entry:
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
-  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
   %117 = load i64, i64 addrspace(1)* %115
@@ -6508,8 +7954,8 @@ entry:
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
-  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
   %130 = load i64, i64 addrspace(1)* %128
@@ -6528,15 +7974,15 @@ entry:
 
 ; <label>:142                                     ; preds = %22
   %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
-  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %143, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %144
 
 ; <label>:144                                     ; preds = %142
   %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
   %146 = load i32, i32 addrspace(1)* %145
   %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
-  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %147, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %148
 
 ; <label>:148                                     ; preds = %144
   %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
@@ -6557,15 +8003,15 @@ entry:
 
 ; <label>:159                                     ; preds = %22
   %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
-  br i1 %NullCheck, label %161, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %ThrowNullRef, label %161
 
 ; <label>:161                                     ; preds = %159
   %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
   %163 = load i32, i32 addrspace(1)* %162
   %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
-  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %164, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %165
 
 ; <label>:165                                     ; preds = %161
   %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
@@ -6578,8 +8024,8 @@ entry:
 
 ; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
-  br i1 %NullCheck4, label %172, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %171, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %172
 
 ; <label>:172                                     ; preds = %170
   %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
@@ -6589,8 +8035,8 @@ entry:
 
 ; <label>:176                                     ; preds = %172
   %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
-  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %177, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %178
 
 ; <label>:178                                     ; preds = %176
   %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
@@ -6629,55 +8075,55 @@ ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %161
+ThrowNullRef2:                                    ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %170
+ThrowNullRef4:                                    ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %176
+ThrowNullRef6:                                    ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %142
+ThrowNullRef8:                                    ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %144
+ThrowNullRef10:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %113
+ThrowNullRef12:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %116
+ThrowNullRef14:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %84
+ThrowNullRef16:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %87
+ThrowNullRef18:                                   ; preds = %87
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %55
+ThrowNullRef20:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %58
+ThrowNullRef22:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %26
+ThrowNullRef24:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %29
+ThrowNullRef26:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,8 +8161,8 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck, label %14, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %ThrowNullRef, label %14
 
 ; <label>:14                                      ; preds = %8
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
@@ -6760,8 +8206,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
@@ -6770,14 +8216,14 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32, i32* %loc0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %10
   %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
   %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
@@ -6790,15 +8236,15 @@ entry:
 ; <label>:25                                      ; preds = %19
   %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
-  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
   %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
@@ -6807,8 +8253,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %37 = load i32, i32* %loc0
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %38, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %38
 
 ; <label>:38                                      ; preds = %32
   %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
@@ -6817,14 +8263,14 @@ entry:
 
 ; <label>:40                                      ; preds = %19
   %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %40
   %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
   %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
-  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
-  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
@@ -6832,8 +8278,8 @@ entry:
   %48 = zext i32 %47 to i64
   %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
-  br i1 %NullCheck16, label %51, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %51
 
 ; <label>:51                                      ; preds = %45
   %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
@@ -6847,15 +8293,15 @@ entry:
 ; <label>:57                                      ; preds = %51
   %58 = load i16*, i16** %arg1
   %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
-  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %60
 
 ; <label>:60                                      ; preds = %57
   %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
   %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
-  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %64
 
 ; <label>:64                                      ; preds = %60
   %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
@@ -6864,22 +8310,22 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
   %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
-  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %70
 
 ; <label>:70                                      ; preds = %64
   %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
   %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
-  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
-  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
   %75 = load i32, i32 addrspace(1)* %74
   %76 = zext i32 %75 to i64
   %77 = trunc i64 %76 to i32
-  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
-  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %78
 
 ; <label>:78                                      ; preds = %73
   %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
@@ -6901,8 +8347,8 @@ entry:
   %90 = bitcast i16* %86 to i8*
   %91 = getelementptr inbounds i8, i8* %90, i64 %89
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %93
 
 ; <label>:93                                      ; preds = %80
   %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
@@ -6912,8 +8358,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %99 = load i32, i32* %loc2
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %100
 
 ; <label>:100                                     ; preds = %93
   %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
@@ -6928,63 +8374,63 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %25
+ThrowNullRef6:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %32
+ThrowNullRef10:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %40
+ThrowNullRef12:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %45
+ThrowNullRef16:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %57
+ThrowNullRef18:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %60
+ThrowNullRef20:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %64
+ThrowNullRef22:                                   ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %70
+ThrowNullRef24:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %73
+ThrowNullRef26:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %80
+ThrowNullRef28:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %93
+ThrowNullRef30:                                   ; preds = %93
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7004,8 +8450,8 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
@@ -7033,43 +8479,43 @@ entry:
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %14
   %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
   %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   %28 = load i32, i32 addrspace(1)* %27, align 8
   %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
-  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %30
 
 ; <label>:30                                      ; preds = %26
   %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
   %32 = load i32, i32 addrspace(1)* %31, align 8
   %33 = add i32 %28, %32
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %34
 
 ; <label>:34                                      ; preds = %30
   %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   store i32 %33, i32 addrspace(1)* %35
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
   store i32 0, i32 addrspace(1)* %38
   %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %40
 
 ; <label>:40                                      ; preds = %37
   %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
@@ -7082,8 +8528,8 @@ entry:
 
 ; <label>:47                                      ; preds = %40
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
@@ -7098,8 +8544,8 @@ entry:
   %54 = load i32, i32* %loc0
   %55 = sext i32 %54 to i64
   %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
-  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %57
 
 ; <label>:57                                      ; preds = %52
   %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
@@ -7110,68 +8556,35 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %14
+ThrowNullRef2:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %23
+ThrowNullRef4:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %26
+ThrowNullRef6:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %30
+ThrowNullRef8:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %34
+ThrowNullRef10:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %47
+ThrowNullRef14:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %52
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-}
-
-INFO:  jitting method StringBuilder::get_Length using LLILCJit
-Successfully read StringBuilder.get_Length
-
-define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.StringBuilder addrspace(1)*
-  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
-  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
-
-; <label>:1                                       ; preds = %entry
-  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %3 = load i32, i32 addrspace(1)* %2, align 8
-  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
-
-; <label>:5                                       ; preds = %1
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = add i32 %3, %7
-  ret i32 %8
-
-ThrowNullRef:                                     ; preds = %entry
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef16:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7213,70 +8626,70 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
   %6 = load i32, i32 addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
   store i32 %6, i32 addrspace(1)* %8
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
   %13 = load i32, i32 addrspace(1)* %12, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
   store i32 %13, i32 addrspace(1)* %15
   %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
-  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %18
 
 ; <label>:18                                      ; preds = %14
   %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
   %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
   %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
   %34 = load i32, i32 addrspace(1)* %33, align 8
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
-  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
@@ -7287,39 +8700,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %28
+ThrowNullRef16:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %32
+ThrowNullRef18:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7455,13 +8868,13 @@ entry:
 ; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
@@ -7477,16 +8890,16 @@ entry:
 
 ; <label>:18                                      ; preds = %15
   %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
   store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
   %22 = load i32, i32* %loc0
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %24
 
 ; <label>:24                                      ; preds = %20
   %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
@@ -7498,13 +8911,13 @@ entry:
 ; <label>:28                                      ; preds = %15, %24
   %29 = load i32, i32* %arg1
   %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %31
   %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
@@ -7517,20 +8930,20 @@ entry:
   %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
-  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
   %46 = load i32, i32 addrspace(1)* %45, align 8
   %47 = sub i32 %40, %46
-  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
-  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i32 addrspace(1)* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %48
 
 ; <label>:48                                      ; preds = %44
   store i32 %47, i32 addrspace(1)* %39, align 8
@@ -7538,21 +8951,21 @@ entry:
 
 ; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
-  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %51
 
 ; <label>:51                                      ; preds = %49
   %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %53
 
 ; <label>:53                                      ; preds = %51
   %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
   %55 = load i32, i32 addrspace(1)* %54, align 8
   %56 = load i32, i32* %arg2
   %57 = sub i32 %55, %56
-  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %58
 
 ; <label>:58                                      ; preds = %53
   %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
@@ -7562,13 +8975,13 @@ entry:
 ; <label>:60                                      ; preds = %33, %58
   %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
   %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
-  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %63
 
 ; <label>:63                                      ; preds = %60
   %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
-  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
-  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
@@ -7578,15 +8991,15 @@ entry:
 
 ; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
-  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i32 addrspace(1)* %69, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %70
 
 ; <label>:70                                      ; preds = %68
   %71 = load i32, i32 addrspace(1)* %69, align 8
   store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
-  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
@@ -7596,8 +9009,8 @@ entry:
   store i32 %77, i32* %loc4
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
-  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %80
 
 ; <label>:80                                      ; preds = %73
   %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
@@ -7607,71 +9020,71 @@ entry:
 ; <label>:83                                      ; preds = %80
   store i32 0, i32* %loc3
   %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
-  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
-  br i1 %NullCheck26, label %88, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i32 addrspace(1)* %87, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %88
 
 ; <label>:88                                      ; preds = %85
   %89 = load i32, i32 addrspace(1)* %87, align 8
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
-  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %90
 
 ; <label>:90                                      ; preds = %88
   %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
   store i32 %89, i32 addrspace(1)* %91
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
-  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
-  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %96
 
 ; <label>:96                                      ; preds = %94
   %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
-  br i1 %NullCheck34, label %100, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %100
 
 ; <label>:100                                     ; preds = %96
   %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
-  br i1 %NullCheck36, label %102, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %102
 
 ; <label>:102                                     ; preds = %100
   %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
   %104 = load i32, i32 addrspace(1)* %103, align 8
   %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
-  br i1 %NullCheck38, label %106, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %106
 
 ; <label>:106                                     ; preds = %102
   %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
-  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
-  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %108
 
 ; <label>:108                                     ; preds = %106
   %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
   %110 = load i32, i32 addrspace(1)* %109, align 8
   %111 = add i32 %104, %110
-  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %112
 
 ; <label>:112                                     ; preds = %108
   %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
   store i32 %111, i32 addrspace(1)* %113
   %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
-  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i32 addrspace(1)* %114, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %115
 
 ; <label>:115                                     ; preds = %112
   %116 = load i32, i32 addrspace(1)* %114, align 8
@@ -7681,19 +9094,19 @@ entry:
 ; <label>:118                                     ; preds = %115
   %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
-  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %121
 
 ; <label>:121                                     ; preds = %118
   %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
-  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
-  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %123
 
 ; <label>:123                                     ; preds = %121
   %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
   %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
-  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
-  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %126
 
 ; <label>:126                                     ; preds = %123
   %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
@@ -7705,8 +9118,8 @@ entry:
 
 ; <label>:130                                     ; preds = %80, %115, %126
   %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %132
 
 ; <label>:132                                     ; preds = %130
   %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7715,8 +9128,8 @@ entry:
   %136 = load i32, i32* %loc3
   %137 = sub i32 %135, %136
   %138 = sub i32 %134, %137
-  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %139
 
 ; <label>:139                                     ; preds = %132
   %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7728,16 +9141,16 @@ entry:
 
 ; <label>:144                                     ; preds = %139
   %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
-  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %146
 
 ; <label>:146                                     ; preds = %144
   %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
   %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
   %149 = load i32, i32* %loc2
   %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
-  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %151
 
 ; <label>:151                                     ; preds = %146
   %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
@@ -7754,145 +9167,249 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %18
+ThrowNullRef4:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %31
+ThrowNullRef10:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %44
+ThrowNullRef16:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %68
+ThrowNullRef18:                                   ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %70
+ThrowNullRef20:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %73
+ThrowNullRef22:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %83
+ThrowNullRef24:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %85
+ThrowNullRef26:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %88
+ThrowNullRef28:                                   ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %90
+ThrowNullRef30:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %94
+ThrowNullRef32:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %96
+ThrowNullRef34:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %100
+ThrowNullRef36:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %102
+ThrowNullRef38:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %106
+ThrowNullRef40:                                   ; preds = %106
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %108
+ThrowNullRef42:                                   ; preds = %108
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %112
+ThrowNullRef44:                                   ; preds = %112
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %118
+ThrowNullRef46:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %121
+ThrowNullRef48:                                   ; preds = %121
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %123
+ThrowNullRef50:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %130
+ThrowNullRef52:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %132
+ThrowNullRef54:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %144
+ThrowNullRef56:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %146
+ThrowNullRef58:                                   ; preds = %146
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %60
+ThrowNullRef60:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %63
+ThrowNullRef62:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %49
+ThrowNullRef64:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %51
+ThrowNullRef66:                                   ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %53
+ThrowNullRef68:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(%"System.Char[]" addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %arg0 = alloca %"System.Char[]" addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store %"System.Char[]" addrspace(1)* %param0, %"System.Char[]" addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load i32, i32* %arg4
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %43, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %38, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg1
+  %13 = load i32, i32* %arg4
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %38, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %24 = load i32, i32* %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %35 = load i32, i32* %arg3
+  %36 = load i32, i32* %arg4
+  %37 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %37, %"System.Char[]" addrspace(1)* %34, i32 %35, i32 %36)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:38                                      ; preds = %5, %16
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Successfully read Buffer._Memmove
 
@@ -7914,7 +9431,7 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[loadElem]
+Failed to read AppDomain.SetDataHelper[storeElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -7923,8 +9440,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
@@ -7934,8 +9451,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
@@ -7947,15 +9464,15 @@ entry:
   %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
   %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
@@ -7966,15 +9483,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7992,7 +9509,79 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
-Failed to read Dictionary`2.TryGetValue[loadElemA]
+Successfully read Dictionary`2.TryGetValue
+
+define i8 @"Dictionary`2.TryGetValue"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)* addrspace(1)* %param2) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  %arg2 = alloca %System.__Canon addrspace(1)* addrspace(1)*
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  store %System.__Canon addrspace(1)* addrspace(1)* %param2, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  store i32 %2, i32* %loc0
+  %3 = load i32, i32* %loc0
+  %4 = icmp slt i32 %3, 0
+  br i1 %4, label %22, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 2
+  %10 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %9, align 8
+  %11 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = zext i32 %11 to i64
+  %BoundsCheck = icmp uge i64 %16, %15
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 3, i32 %11
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %20, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %6, %System.__Canon addrspace(1)* %21)
+  ret i8 1
+
+; <label>:22                                      ; preds = %entry
+  %23 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %23, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -8058,8 +9647,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
@@ -8091,8 +9680,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
@@ -8171,15 +9760,15 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck, label %19, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %ThrowNullRef, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
   %21 = load i32, i32 addrspace(1)* %20
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
@@ -8202,7 +9791,7 @@ ThrowNullRef:                                     ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %19
+ThrowNullRef2:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8248,8 +9837,8 @@ entry:
   %0 = alloca %System.AppDomainHandle
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %1 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %1, i32 0, i32 15
@@ -8269,8 +9858,8 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
@@ -8286,7 +9875,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -8299,8 +9888,8 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -8327,8 +9916,8 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
@@ -8352,8 +9941,8 @@ entry:
   %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
   store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
@@ -8363,8 +9952,8 @@ entry:
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
@@ -8374,8 +9963,8 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %9
   %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
@@ -8384,8 +9973,8 @@ entry:
 
 ; <label>:18                                      ; preds = %3, %16
   %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
@@ -8397,15 +9986,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %18
+ThrowNullRef6:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8418,8 +10007,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
@@ -8453,15 +10042,15 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
@@ -8473,7 +10062,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8481,7 +10070,7 @@ ThrowNullRef1:                                    ; preds = %1
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
 Failed to read Dictionary`2.System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
@@ -8506,8 +10095,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
@@ -8524,8 +10113,8 @@ entry:
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -8544,7 +10133,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8577,8 +10166,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = load i64, i64* %arg2
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = trunc i32 %3 to i8
@@ -8634,46 +10223,46 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
   %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
-  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
-  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
-  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
@@ -8684,27 +10273,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %20
+ThrowNullRef12:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8717,8 +10306,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -8756,22 +10345,22 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
   %9 = load i64, i64 addrspace(1)* %8, align 8
   %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
   %13 = load i64, i64 addrspace(1)* %12, align 8
   %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %11
   %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
@@ -8788,11 +10377,11 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8882,8 +10471,8 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
@@ -8900,8 +10489,8 @@ entry:
 ; <label>:8                                       ; preds = %1
   %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
   %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
@@ -8911,15 +10500,15 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
   %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
   %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
-  br i1 %NullCheck6, label %21, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
@@ -8946,15 +10535,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8992,15 +10581,15 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
   store i8 %3, i8 addrspace(1)* %5
   %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
@@ -9011,7 +10600,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9027,8 +10616,8 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -9041,8 +10630,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
@@ -9058,7 +10647,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9080,8 +10669,8 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
@@ -9096,8 +10685,8 @@ entry:
 ; <label>:12                                      ; preds = %6
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
@@ -9112,8 +10701,8 @@ entry:
 ; <label>:21                                      ; preds = %15
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
@@ -9128,8 +10717,8 @@ entry:
 ; <label>:30                                      ; preds = %24
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %31, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
@@ -9144,8 +10733,8 @@ entry:
 ; <label>:39                                      ; preds = %33
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
-  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %40, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %42
 
 ; <label>:42                                      ; preds = %39
   %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
@@ -9164,19 +10753,19 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %21
+ThrowNullRef4:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %30
+ThrowNullRef6:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %39
+ThrowNullRef8:                                    ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9243,8 +10832,8 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
@@ -9264,57 +10853,57 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
   store i8 0, i8 addrspace(1)* %2
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
   store i8 0, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
   store i8 0, i8 addrspace(1)* %17
   %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
   store i8 0, i8 addrspace(1)* %20
   %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
-  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
@@ -9325,31 +10914,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %19
+ThrowNullRef14:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9367,8 +10956,8 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
@@ -9380,8 +10969,8 @@ entry:
 
 ; <label>:9                                       ; preds = %4
   %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %9
   %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
@@ -9395,7 +10984,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef2:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9420,8 +11009,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
@@ -9512,8 +11101,8 @@ entry:
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
@@ -9524,8 +11113,8 @@ entry:
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = load i64, i64 addrspace(1)* %12
@@ -9537,8 +11126,8 @@ entry:
   %20 = load i64, i64* %19
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
-  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %13
   %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
@@ -9555,8 +11144,8 @@ entry:
 ; <label>:30                                      ; preds = %25
   %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %32 = load i32, i32* %arg2
-  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
-  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
@@ -9570,15 +11159,15 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %30
+ThrowNullRef2:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9622,87 +11211,87 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
   %10 = load i8, i8 addrspace(1)* %9, align 8
   %11 = zext i8 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %8
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
   store i8 %12, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
   %19 = load i8, i8 addrspace(1)* %18, align 8
   %20 = zext i8 %19 to i32
   %21 = trunc i32 %20 to i8
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
   store i8 %21, i8 addrspace(1)* %23
   %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
   %28 = load i8, i8 addrspace(1)* %27, align 8
   %29 = zext i8 %28 to i32
   %30 = trunc i32 %29 to i8
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
-  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %31
 
 ; <label>:31                                      ; preds = %26
   %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
   store i8 %30, i8 addrspace(1)* %32
   %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
-  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
-  br i1 %NullCheck14, label %40, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %40
 
 ; <label>:40                                      ; preds = %35
   %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
   store i8 %39, i8 addrspace(1)* %41
   %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
-  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %44
 
 ; <label>:44                                      ; preds = %40
   %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
   %46 = load i8, i8 addrspace(1)* %45, align 8
   %47 = zext i8 %46 to i32
   %48 = trunc i32 %47 to i8
-  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
   store i8 %48, i8 addrspace(1)* %50
   %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
-  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
@@ -9713,29 +11302,29 @@ entry:
 ; <label>:56                                      ; preds = %52
   %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
-  br i1 %NullCheck22, label %59, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
   %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
   %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
-  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
-  br i1 %NullCheck24, label %63, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
   %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
-  br i1 %NullCheck26, label %66, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
   %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
-  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
-  br i1 %NullCheck28, label %69, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %69
 
 ; <label>:69                                      ; preds = %66
   %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
@@ -9744,15 +11333,15 @@ entry:
 
 ; <label>:71                                      ; preds = %105
   %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
-  br i1 %NullCheck34, label %73, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %73
 
 ; <label>:73                                      ; preds = %71
   %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
   %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
   %76 = load i32, i32* %loc0
-  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
-  br i1 %NullCheck36, label %77, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
@@ -9766,8 +11355,8 @@ entry:
 
 ; <label>:83                                      ; preds = %77
   %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
-  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
@@ -9775,14 +11364,14 @@ entry:
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
   %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
-  br i1 %NullCheck40, label %91, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
 ; <label>:91                                      ; preds = %85
   %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
   %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
-  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck42, label %94, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %94
 
 ; <label>:94                                      ; preds = %91
   %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
@@ -9798,14 +11387,14 @@ entry:
 ; <label>:99                                      ; preds = %69, %96
   %100 = load i32, i32* %loc0
   %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
-  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %102
 
 ; <label>:102                                     ; preds = %99
   %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
   %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
-  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
-  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
@@ -9819,87 +11408,87 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %26
+ThrowNullRef10:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %31
+ThrowNullRef12:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %35
+ThrowNullRef14:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %40
+ThrowNullRef16:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %56
+ThrowNullRef22:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %59
+ThrowNullRef24:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %63
+ThrowNullRef26:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %66
+ThrowNullRef28:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %102
+ThrowNullRef32:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %71
+ThrowNullRef34:                                   ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %73
+ThrowNullRef36:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %83
+ThrowNullRef38:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %85
+ThrowNullRef40:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %91
+ThrowNullRef42:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9943,15 +11532,15 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
   %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
@@ -9961,28 +11550,28 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
   %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %12
   %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
   %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
   %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
-  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
@@ -9993,23 +11582,23 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %12
+ThrowNullRef6:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10031,15 +11620,15 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
   %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = load i64, i64 addrspace(1)* %7
@@ -10077,13 +11666,13 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[loadElem]
+Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -10111,8 +11700,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -10198,8 +11787,8 @@ entry:
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load double, double* %arg0
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -10333,8 +11922,8 @@ entry:
   store i64 %param0, i64* %arg0
   store i64 %param1, i64* %arg1
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
@@ -10342,8 +11931,8 @@ entry:
   %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
   %5 = load i16*, i16* addrspace(1)* %4, align 8
   %6 = addrspacecast i64* %arg1 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = bitcast i64 addrspace(1)* %6 to i8 addrspace(1)*
@@ -10359,7 +11948,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10393,8 +11982,8 @@ entry:
   %1 = load i32, i32* %arg1
   %2 = sext i32 %1 to i64
   %3 = inttoptr i64 %2 to i16*
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -10447,8 +12036,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, i32)*)(%System.IO.ConsoleStream addrspace(1)* %2, i32 %1)
   %3 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %4 = load i64, i64* %arg1
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
@@ -10459,8 +12048,8 @@ entry:
   %10 = icmp eq i32 %9, 3
   %11 = sext i1 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %5
   %14 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, i32 0, i32 5
@@ -10471,7 +12060,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10494,8 +12083,8 @@ entry:
   %5 = icmp eq i32 %4, 1
   %6 = sext i1 %5 to i32
   %7 = trunc i32 %6 to i8
-  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %2, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.ConsoleStream addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
@@ -10506,8 +12095,8 @@ entry:
   %13 = icmp eq i32 %12, 2
   %14 = sext i1 %13 to i32
   %15 = trunc i32 %14 to i8
-  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %10, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.ConsoleStream addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %8
   %17 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %10, i32 0, i32 4
@@ -10518,7 +12107,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10557,8 +12146,8 @@ entry:
   %arg0 = alloca i64
   store i64 %param0, i64* %arg0
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
@@ -10593,8 +12182,8 @@ entry:
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
   %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = load i64, i64 addrspace(1)* %7
@@ -10698,7 +12287,127 @@ entry:
 INFO:  jitting method Encoding::GetEncoding using LLILCJit
 Failed to read Encoding.GetEncoding[convertToHelperArgumentType]
 INFO:  jitting method EncodingProvider::GetEncodingFromProvider using LLILCJit
-Failed to read EncodingProvider.GetEncodingFromProvider[loadElem]
+Successfully read EncodingProvider.GetEncodingFromProvider
+
+define %System.Text.Encoding addrspace(1)* @EncodingProvider.GetEncodingFromProvider(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca %"System.Text.EncodingProvider[]" addrspace(1)*
+  %loc1 = alloca %System.Text.EncodingProvider addrspace(1)*
+  %loc2 = alloca %System.Text.Encoding addrspace(1)*
+  %loc3 = alloca %System.Text.Encoding addrspace(1)*
+  %loc4 = alloca %"System.Text.EncodingProvider[]" addrspace(1)*
+  %loc5 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1059)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2392
+  %2 = addrspacecast i8 addrspace(1)* %1 to %"System.Text.EncodingProvider[]" addrspace(1)**
+  %3 = load volatile %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %2
+  %4 = icmp ne %"System.Text.EncodingProvider[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %entry
+  ret %System.Text.Encoding addrspace(1)* null
+
+; <label>:6                                       ; preds = %entry
+  %7 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1059)
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i64 2392
+  %9 = addrspacecast i8 addrspace(1)* %8 to %"System.Text.EncodingProvider[]" addrspace(1)**
+  %10 = load volatile %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %9
+  store %"System.Text.EncodingProvider[]" addrspace(1)* %10, %"System.Text.EncodingProvider[]" addrspace(1)** %loc0
+  %11 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc0
+  store %"System.Text.EncodingProvider[]" addrspace(1)* %11, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  store i32 0, i32* %loc5
+  br label %43
+
+; <label>:12                                      ; preds = %46
+  %13 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  %14 = load i32, i32* %loc5
+  %NullCheck1 = icmp eq %"System.Text.EncodingProvider[]" addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %13, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = zext i32 %17 to i64
+  %19 = zext i32 %14 to i64
+  %BoundsCheck = icmp uge i64 %19, %18
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %20
+
+; <label>:20                                      ; preds = %15
+  %21 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %13, i32 0, i32 3, i32 %14
+  %22 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)* addrspace(1)* %21, align 8
+  store %System.Text.EncodingProvider addrspace(1)* %22, %System.Text.EncodingProvider addrspace(1)** %loc1
+  %23 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)** %loc1
+  %24 = load i32, i32* %arg0
+  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i64 addrspace(1)*
+  %NullCheck3 = icmp eq i64 addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
+
+; <label>:26                                      ; preds = %20
+  %27 = load i64, i64 addrspace(1)* %25
+  %28 = add i64 %27, 64
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 40
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Text.Encoding addrspace(1)* (%System.Text.EncodingProvider addrspace(1)*, i32)*
+  %35 = call %System.Text.Encoding addrspace(1)* %34(%System.Text.EncodingProvider addrspace(1)* %23, i32 %24)
+  store %System.Text.Encoding addrspace(1)* %35, %System.Text.Encoding addrspace(1)** %loc2
+  %36 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc2
+  %37 = icmp eq %System.Text.Encoding addrspace(1)* %36, null
+  br i1 %37, label %40, label %38
+
+; <label>:38                                      ; preds = %26
+  %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc2
+  store %System.Text.Encoding addrspace(1)* %39, %System.Text.Encoding addrspace(1)** %loc3
+  br label %53
+
+; <label>:40                                      ; preds = %26
+  %41 = load i32, i32* %loc5
+  %42 = add i32 %41, 1
+  store i32 %42, i32* %loc5
+  br label %43
+
+; <label>:43                                      ; preds = %6, %40
+  %44 = load i32, i32* %loc5
+  %45 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  %NullCheck = icmp eq %"System.Text.EncodingProvider[]" addrspace(1)* %45, null
+  br i1 %NullCheck, label %ThrowNullRef, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp slt i32 %44, %50
+  br i1 %51, label %12, label %52
+
+; <label>:52                                      ; preds = %46
+  ret %System.Text.Encoding addrspace(1)* null
+
+; <label>:53                                      ; preds = %38
+  %54 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc3
+  ret %System.Text.Encoding addrspace(1)* %54
+
+ThrowNullRef:                                     ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method EncodingProvider::.cctor using LLILCJit
 Successfully read EncodingProvider..cctor
 
@@ -10717,7 +12426,7 @@ Failed to read Encoding.get_InternalSyncObject[Call HasTypeArg]
 INFO:  jitting method Hashtable::.ctor using LLILCJit
 Failed to read Hashtable..ctor[Volatile store]
 INFO:  jitting method Hashtable::get_Item using LLILCJit
-Failed to read Hashtable.get_Item[loadElemA]
+Failed to read Hashtable.get_Item[loadNonPrimitiveObj]
 INFO:  jitting method Hashtable::InitHash using LLILCJit
 Successfully read Hashtable.InitHash
 
@@ -10737,8 +12446,8 @@ entry:
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -10754,15 +12463,15 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
   %15 = load i32, i32* %loc0
-  %NullCheck2 = icmp ne i32 addrspace(1)* %14, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i32 addrspace(1)* %14, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %3
   store i32 %15, i32 addrspace(1)* %14, align 8
   %17 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %18 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %NullCheck4 = icmp ne i32 addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i32 addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = load i32, i32 addrspace(1)* %18, align 8
@@ -10771,8 +12480,8 @@ entry:
   %23 = sub i32 %22, 1
   %24 = urem i32 %21, %23
   %25 = add i32 1, %24
-  %NullCheck6 = icmp ne i32 addrspace(1)* %17, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32 addrspace(1)* %17, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %19
   store i32 %25, i32 addrspace(1)* %17, align 8
@@ -10783,15 +12492,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %19
+ThrowNullRef6:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10806,8 +12515,8 @@ entry:
   store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
   store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %NullCheck = icmp ne %System.Collections.Hashtable addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Collections.Hashtable addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
@@ -10817,16 +12526,16 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Collections.Hashtable addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Collections.Hashtable addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
   %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck4 = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %9, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
   %13 = inttoptr i64 %11 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
@@ -10836,8 +12545,8 @@ entry:
 ; <label>:15                                      ; preds = %1
   %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -10855,15 +12564,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10877,8 +12586,8 @@ entry:
   store %System.Int32 addrspace(1)* %param0, %System.Int32 addrspace(1)** %this
   %0 = load %System.Int32 addrspace(1)*, %System.Int32 addrspace(1)** %this
   %1 = bitcast %System.Int32 addrspace(1)* %0 to i32 addrspace(1)*
-  %NullCheck = icmp ne i32 addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq i32 addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load i32, i32 addrspace(1)* %1, align 8
@@ -10954,8 +12663,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.UTF8Encoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
@@ -10964,15 +12673,15 @@ entry:
   %9 = load i8, i8* %arg2
   %10 = zext i8 %9 to i32
   %11 = trunc i32 %10 to i8
-  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %8, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %6
   %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %8, i32 0, i32 8
   store i8 %11, i8 addrspace(1)* %13
   %14 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %14, i32 0, i32 8
@@ -10984,8 +12693,8 @@ entry:
 ; <label>:20                                      ; preds = %15
   %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %22, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %22, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = load i64, i64 addrspace(1)* %22
@@ -11007,15 +12716,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %12
+ThrowNullRef4:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11030,8 +12739,8 @@ entry:
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
@@ -11053,16 +12762,16 @@ entry:
 ; <label>:10                                      ; preds = %1
   %11 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
   %12 = load i32, i32* %arg1
-  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %11, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.Encoding addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
   store i32 %12, i32 addrspace(1)* %14
   %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
   %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = load i64, i64 addrspace(1)* %16
@@ -11080,11 +12789,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11097,8 +12806,8 @@ entry:
   %this = alloca %System.Text.UTF8Encoding addrspace(1)*
   store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
   %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.UTF8Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
@@ -11110,16 +12819,16 @@ entry:
 ; <label>:6                                       ; preds = %1
   %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %8 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %10, %System.Text.EncoderFallback addrspace(1)* %8)
   %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %12 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
-  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %11, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %11, i32 0, i32 3
@@ -11132,8 +12841,8 @@ entry:
   %18 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %18, %System.String addrspace(1)* %17)
   %19 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %18 to %System.Text.EncoderFallback addrspace(1)*
-  %NullCheck6 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %16, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %16, i32 0, i32 2
@@ -11143,8 +12852,8 @@ entry:
   %24 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %24, %System.String addrspace(1)* %23)
   %25 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %24 to %System.Text.DecoderFallback addrspace(1)*
-  %NullCheck8 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %22, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %22, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %20
   %27 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %22, i32 0, i32 3
@@ -11155,19 +12864,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %20
+ThrowNullRef8:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11197,8 +12906,8 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load i32, i32* %arg1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -11216,8 +12925,8 @@ entry:
 ; <label>:15                                      ; preds = %8
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %17 = load i32, i32* %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 %17
@@ -11233,7 +12942,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11285,7 +12994,7 @@ entry:
 }
 
 INFO:  jitting method Hashtable::Insert using LLILCJit
-Failed to read Hashtable.Insert[loadElemA]
+Failed to read Hashtable.Insert[storeElem]
 INFO:  jitting method ConsoleEncoding::.ctor using LLILCJit
 Successfully read ConsoleEncoding..ctor
 
@@ -11300,8 +13009,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %1)
   %2 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
@@ -11337,8 +13046,8 @@ entry:
   %2 = call %System.Text.InternalEncoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalEncoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %1)
   %3 = bitcast %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2 to %System.Text.EncoderFallback addrspace(1)*
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
@@ -11348,8 +13057,8 @@ entry:
   %8 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %7)
   %9 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %8 to %System.Text.DecoderFallback addrspace(1)*
-  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %6, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.Encoding addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %4
   %11 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %6, i32 0, i32 3
@@ -11360,7 +13069,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11379,15 +13088,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* %1)
   %2 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   %6 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, i32 0, i32 1
@@ -11398,7 +13107,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11426,8 +13135,8 @@ entry:
   store %System.Text.InternalDecoderBestFitFallback addrspace(1)* %param0, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
   %0 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
@@ -11437,15 +13146,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %4)
   %5 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %6)
   %9 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, i32 0, i32 1
@@ -11456,11 +13165,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11528,8 +13237,8 @@ entry:
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
   %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = load i64, i64 addrspace(1)* %19
@@ -11593,8 +13302,8 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.ConsoleStream addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
@@ -11625,31 +13334,31 @@ entry:
   store i8 %param4, i8* %arg4
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %3, %System.IO.Stream addrspace(1)* %1)
   %4 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %4, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
   %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %4, i32 0, i32 4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %5)
   %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %6
   %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
   %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
   %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = load i64, i64 addrspace(1)* %13
@@ -11661,8 +13370,8 @@ entry:
   %21 = load i64, i64* %20
   %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %8, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %8, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %14
   %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 5
@@ -11680,24 +13389,24 @@ entry:
   %31 = load i32, i32* %arg3
   %32 = sext i32 %31 to i64
   %33 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %32)
-  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %30, null
-  br i1 %NullCheck10, label %34, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.StreamWriter addrspace(1)* %30, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %35, %"System.Char[]" addrspace(1)* %33)
   %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %37, null
-  br i1 %NullCheck12, label %38, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.StreamWriter addrspace(1)* %37, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %38
 
 ; <label>:38                                      ; preds = %34
   %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
   %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
   %41 = load i32, i32* %arg3
   %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %42, null
-  br i1 %NullCheck14, label %43, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %42, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
   %44 = load i64, i64 addrspace(1)* %42
@@ -11711,30 +13420,30 @@ entry:
   %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
   %53 = sext i32 %52 to i64
   %54 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %53)
-  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
-  br i1 %NullCheck16, label %55, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %55
 
 ; <label>:55                                      ; preds = %43
   %56 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %56, %"System.Byte[]" addrspace(1)* %54)
   %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %58 = load i32, i32* %arg3
-  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %57, null
-  br i1 %NullCheck18, label %59, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.StreamWriter addrspace(1)* %57, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %59
 
 ; <label>:59                                      ; preds = %55
   %60 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 10
   store i32 %58, i32 addrspace(1)* %60
   %61 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %61, null
-  br i1 %NullCheck20, label %62, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.IO.StreamWriter addrspace(1)* %61, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %62
 
 ; <label>:62                                      ; preds = %59
   %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
   %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
   %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
   %67 = load i64, i64 addrspace(1)* %65
@@ -11752,15 +13461,15 @@ entry:
 
 ; <label>:78                                      ; preds = %66
   %79 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %79, null
-  br i1 %NullCheck24, label %80, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.StreamWriter addrspace(1)* %79, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %80
 
 ; <label>:80                                      ; preds = %78
   %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
   %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
   %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %83, null
-  br i1 %NullCheck26, label %84, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %83, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
   %85 = load i64, i64 addrspace(1)* %83
@@ -11777,8 +13486,8 @@ entry:
 
 ; <label>:95                                      ; preds = %84
   %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.IO.StreamWriter addrspace(1)* %96, null
-  br i1 %NullCheck28, label %97, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.IO.StreamWriter addrspace(1)* %96, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %97
 
 ; <label>:97                                      ; preds = %95
   %98 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 12
@@ -11792,8 +13501,8 @@ entry:
   %103 = icmp eq i32 %102, 0
   %104 = sext i1 %103 to i32
   %105 = trunc i32 %104 to i8
-  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %100, null
-  br i1 %NullCheck30, label %106, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.IO.StreamWriter addrspace(1)* %100, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %106
 
 ; <label>:106                                     ; preds = %99
   %107 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %100, i32 0, i32 13
@@ -11804,63 +13513,63 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %6
+ThrowNullRef4:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %29
+ThrowNullRef10:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %34
+ThrowNullRef12:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %38
+ThrowNullRef14:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %43
+ThrowNullRef16:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %55
+ThrowNullRef18:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %59
+ThrowNullRef20:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %62
+ThrowNullRef22:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %78
+ThrowNullRef24:                                   ; preds = %78
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %80
+ThrowNullRef26:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %95
+ThrowNullRef28:                                   ; preds = %95
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11873,15 +13582,15 @@ entry:
   %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = load i64, i64 addrspace(1)* %4
@@ -11899,7 +13608,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11949,35 +13658,35 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
   %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderNLS addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %7 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.EncoderNLS addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Text.Encoding addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.Encoding addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Text.EncoderNLS addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.EncoderNLS addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
   %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck8 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = load i64, i64 addrspace(1)* %16
@@ -11996,19 +13705,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12034,8 +13743,8 @@ entry:
   %this = alloca %System.Text.Encoding addrspace(1)*
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
@@ -12055,15 +13764,15 @@ entry:
   %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
   store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
   %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
   store i32 0, i32 addrspace(1)* %2
   %3 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, i32 0, i32 2
@@ -12073,15 +13782,15 @@ entry:
 
 ; <label>:8                                       ; preds = %4
   %9 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
   %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
   %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = load i64, i64 addrspace(1)* %13
@@ -12102,15 +13811,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12125,16 +13834,16 @@ entry:
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = load i32, i32* %arg1
   %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
   %7 = load i64, i64 addrspace(1)* %5
@@ -12152,7 +13861,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12189,8 +13898,8 @@ entry:
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
   %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
   %16 = load i64, i64 addrspace(1)* %14
@@ -12211,8 +13920,8 @@ entry:
   %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
   %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
   %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %31, null
-  br i1 %NullCheck2, label %32, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = load i64, i64 addrspace(1)* %31
@@ -12255,7 +13964,7 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12268,14 +13977,14 @@ entry:
   %this = alloca %System.Text.EncoderReplacementFallback addrspace(1)*
   store %System.Text.EncoderReplacementFallback addrspace(1)* %param0, %System.Text.EncoderReplacementFallback addrspace(1)** %this
   %0 = load %System.Text.EncoderReplacementFallback addrspace(1)*, %System.Text.EncoderReplacementFallback addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -12286,7 +13995,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12316,8 +14025,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
@@ -12349,8 +14058,8 @@ entry:
   %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
   store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
@@ -12362,8 +14071,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Threading.Tasks.Task addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %7)
@@ -12386,7 +14095,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12405,8 +14114,8 @@ entry:
   store i8 %param1, i8* %arg1
   store i8 %param2, i8* %arg2
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
@@ -12420,8 +14129,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1, %5
   %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 9
@@ -12452,8 +14161,8 @@ entry:
 
 ; <label>:25                                      ; preds = %8, %20
   %26 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %26, null
-  br i1 %NullCheck4, label %27, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %26, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %26, i32 0, i32 12
@@ -12464,22 +14173,22 @@ entry:
 
 ; <label>:32                                      ; preds = %27
   %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %33, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.IO.StreamWriter addrspace(1)* %33, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %32
   %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 12
   store i8 1, i8 addrspace(1)* %35
   %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
-  br i1 %NullCheck8, label %37, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
   %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
   %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck10 = icmp ne i64 addrspace(1)* %40, null
-  br i1 %NullCheck10, label %41, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64 addrspace(1)* %40, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i64, i64 addrspace(1)* %40
@@ -12493,8 +14202,8 @@ entry:
   %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
   store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
   %51 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %NullCheck12 = icmp ne %"System.Byte[]" addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Byte[]" addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %41
   %53 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %51, i32 0, i32 1
@@ -12506,16 +14215,16 @@ entry:
 
 ; <label>:58                                      ; preds = %52
   %59 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %59, null
-  br i1 %NullCheck14, label %60, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.IO.StreamWriter addrspace(1)* %59, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %60
 
 ; <label>:60                                      ; preds = %58
   %61 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %59, i32 0, i32 3
   %62 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
   %64 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %NullCheck16 = icmp ne %"System.Byte[]" addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %"System.Byte[]" addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %60
   %66 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %64, i32 0, i32 1
@@ -12523,8 +14232,8 @@ entry:
   %68 = zext i32 %67 to i64
   %69 = trunc i64 %68 to i32
   %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck18, label %71, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
   %72 = load i64, i64 addrspace(1)* %70
@@ -12540,29 +14249,29 @@ entry:
 
 ; <label>:80                                      ; preds = %27, %52, %71
   %81 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %81, null
-  br i1 %NullCheck20, label %82, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.IO.StreamWriter addrspace(1)* %81, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
 
 ; <label>:82                                      ; preds = %80
   %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %81, i32 0, i32 5
   %84 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %83, align 8
   %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.IO.StreamWriter addrspace(1)* %85, null
-  br i1 %NullCheck22, label %86, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.IO.StreamWriter addrspace(1)* %85, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %86
 
 ; <label>:86                                      ; preds = %82
   %87 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 7
   %88 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %87, align 8
   %89 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %89, null
-  br i1 %NullCheck24, label %90, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.StreamWriter addrspace(1)* %89, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %90
 
 ; <label>:90                                      ; preds = %86
   %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %89, i32 0, i32 9
   %92 = load i32, i32 addrspace(1)* %91, align 8
   %93 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.IO.StreamWriter addrspace(1)* %93, null
-  br i1 %NullCheck26, label %94, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.IO.StreamWriter addrspace(1)* %93, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %93, i32 0, i32 6
@@ -12570,8 +14279,8 @@ entry:
   %97 = load i8, i8* %arg2
   %98 = zext i8 %97 to i32
   %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
-  %NullCheck28 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck28, label %100, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
   %101 = load i64, i64 addrspace(1)* %99
@@ -12586,8 +14295,8 @@ entry:
   %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
   store i32 %110, i32* %loc1
   %111 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %111, null
-  br i1 %NullCheck30, label %112, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.IO.StreamWriter addrspace(1)* %111, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %112
 
 ; <label>:112                                     ; preds = %100
   %113 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %111, i32 0, i32 9
@@ -12598,23 +14307,23 @@ entry:
 
 ; <label>:116                                     ; preds = %112
   %117 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck32 = icmp ne %System.IO.StreamWriter addrspace(1)* %117, null
-  br i1 %NullCheck32, label %118, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.IO.StreamWriter addrspace(1)* %117, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %118
 
 ; <label>:118                                     ; preds = %116
   %119 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %117, i32 0, i32 3
   %120 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %119, align 8
   %121 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.IO.StreamWriter addrspace(1)* %121, null
-  br i1 %NullCheck34, label %122, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.IO.StreamWriter addrspace(1)* %121, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %122
 
 ; <label>:122                                     ; preds = %118
   %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
   %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
   %125 = load i32, i32* %loc1
   %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
-  %NullCheck36 = icmp ne i64 addrspace(1)* %126, null
-  br i1 %NullCheck36, label %127, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64 addrspace(1)* %126, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
   %128 = load i64, i64 addrspace(1)* %126
@@ -12636,15 +14345,15 @@ entry:
 
 ; <label>:140                                     ; preds = %136
   %141 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.IO.StreamWriter addrspace(1)* %141, null
-  br i1 %NullCheck38, label %142, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.IO.StreamWriter addrspace(1)* %141, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %142
 
 ; <label>:142                                     ; preds = %140
   %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
   %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
   %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
-  %NullCheck40 = icmp ne i64 addrspace(1)* %145, null
-  br i1 %NullCheck40, label %146, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i64 addrspace(1)* %145, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
   %147 = load i64, i64 addrspace(1)* %145
@@ -12665,83 +14374,83 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %25
+ThrowNullRef4:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %32
+ThrowNullRef6:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %37
+ThrowNullRef10:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %41
+ThrowNullRef12:                                   ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %58
+ThrowNullRef14:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %60
+ThrowNullRef16:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %65
+ThrowNullRef18:                                   ; preds = %65
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %80
+ThrowNullRef20:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %82
+ThrowNullRef22:                                   ; preds = %82
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %86
+ThrowNullRef24:                                   ; preds = %86
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %90
+ThrowNullRef26:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %94
+ThrowNullRef28:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %100
+ThrowNullRef30:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %116
+ThrowNullRef32:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %118
+ThrowNullRef34:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %122
+ThrowNullRef36:                                   ; preds = %122
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %140
+ThrowNullRef38:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %142
+ThrowNullRef40:                                   ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12808,8 +14517,8 @@ entry:
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %1 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
-  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
@@ -12817,8 +14526,8 @@ entry:
   %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
   %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
   %8 = load i64, i64 addrspace(1)* %6
@@ -12834,8 +14543,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %17, %System.IFormatProvider addrspace(1)* %16)
   %18 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %19 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %18, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.SyncTextWriter addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %7
   %21 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %18, i32 0, i32 4
@@ -12846,11 +14555,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12863,8 +14572,8 @@ entry:
   %this = alloca %System.IO.TextWriter addrspace(1)*
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.TextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
@@ -12874,8 +14583,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.Threading.Thread addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Threading.Thread addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %6)
@@ -12884,8 +14593,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1
   %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.TextWriter addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.TextWriter addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %11, i32 0, i32 2
@@ -12896,11 +14605,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13097,8 +14806,8 @@ entry:
   store double %param1, double* %arg1
   store i8 0, i8* %loc1
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
@@ -13108,16 +14817,16 @@ entry:
   %5 = addrspacecast i8* %loc1 to i8 addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %4, i8 addrspace(1)* %5)
   %6 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.SyncTextWriter addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
   %10 = load double, double* %arg1
   %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
   %13 = load i64, i64 addrspace(1)* %11
@@ -13152,11 +14861,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13173,8 +14882,8 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load double, double* %arg1
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -13188,8 +14897,8 @@ entry:
   call void %11(%System.IO.TextWriter addrspace(1)* %0, double %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
   %15 = load i64, i64 addrspace(1)* %13
@@ -13207,7 +14916,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13225,8 +14934,8 @@ entry:
   %1 = addrspacecast double* %arg1 to double addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -13241,8 +14950,8 @@ entry:
   %14 = bitcast double addrspace(1)* %1 to %System.Double addrspace(1)*
   %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Double addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Double addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
   %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
   %18 = load i64, i64 addrspace(1)* %16
@@ -13260,7 +14969,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13276,8 +14985,8 @@ entry:
   store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
   %0 = load %System.Double addrspace(1)*, %System.Double addrspace(1)** %this
   %1 = bitcast %System.Double addrspace(1)* %0 to double addrspace(1)*
-  %NullCheck = icmp ne double addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq double addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load double, double addrspace(1)* %1, align 8
@@ -13302,8 +15011,8 @@ entry:
   %loc0 = alloca %System.Globalization.NumberFormatInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 3
@@ -13313,8 +15022,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
@@ -13324,24 +15033,24 @@ entry:
   store %System.Globalization.NumberFormatInfo addrspace(1)* %10, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
   %11 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %7
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
   %15 = load i8, i8 addrspace(1)* %14, align 8
   %16 = zext i8 %15 to i32
   %17 = trunc i32 %16 to i8
-  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %11, null
-  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %11, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %13
   %19 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %11, i32 0, i32 29
   store i8 %17, i8 addrspace(1)* %19
   %20 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %21 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %20, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %20, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %18
   %23 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %20, i32 0, i32 3
@@ -13350,8 +15059,8 @@ entry:
 
 ; <label>:24                                      ; preds = %1, %22
   %25 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %25, null
-  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %25, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %26
 
 ; <label>:26                                      ; preds = %24
   %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %25, i32 0, i32 3
@@ -13362,23 +15071,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %18
+ThrowNullRef8:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13403,168 +15112,168 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 18
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %8, align 8
-  %NullCheck2 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %5, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %5, i32 0, i32 4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %9)
   %12 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 19
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %15, align 8
-  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %12, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %12, i32 0, i32 5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %16)
   %19 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %20 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %20, null
-  br i1 %NullCheck8, label %21, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %20, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %20, i32 0, i32 23
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  %NullCheck10 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %19, null
-  br i1 %NullCheck10, label %24, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %19, i32 0, i32 7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %25, %System.String addrspace(1)* %23)
   %26 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %27 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %27, i32 0, i32 22
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %29, align 8
-  %NullCheck14 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %26, null
-  br i1 %NullCheck14, label %31, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %26, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %26, i32 0, i32 6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %32, %System.String addrspace(1)* %30)
   %33 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %34 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Globalization.CultureData addrspace(1)* %34, null
-  br i1 %NullCheck16, label %35, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Globalization.CultureData addrspace(1)* %34, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %34, i32 0, i32 51
   %37 = load i32, i32 addrspace(1)* %36, align 8
-  %NullCheck18 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %33, null
-  br i1 %NullCheck18, label %38, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %33, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %33, i32 0, i32 21
   store i32 %37, i32 addrspace(1)* %39
   %40 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %41 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Globalization.CultureData addrspace(1)* %41, null
-  br i1 %NullCheck20, label %42, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Globalization.CultureData addrspace(1)* %41, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %41, i32 0, i32 52
   %44 = load i32, i32 addrspace(1)* %43, align 8
-  %NullCheck22 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %40, null
-  br i1 %NullCheck22, label %45, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %40, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %40, i32 0, i32 25
   store i32 %44, i32 addrspace(1)* %46
   %47 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %48 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.Globalization.CultureData addrspace(1)* %48, null
-  br i1 %NullCheck24, label %49, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Globalization.CultureData addrspace(1)* %48, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %49
 
 ; <label>:49                                      ; preds = %45
   %50 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %48, i32 0, i32 29
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck26 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %47, null
-  br i1 %NullCheck26, label %52, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %47, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %47, i32 0, i32 10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %53, %System.String addrspace(1)* %51)
   %54 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %55 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Globalization.CultureData addrspace(1)* %55, null
-  br i1 %NullCheck28, label %56, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Globalization.CultureData addrspace(1)* %55, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %56
 
 ; <label>:56                                      ; preds = %52
   %57 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %55, i32 0, i32 35
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %57, align 8
-  %NullCheck30 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %54, null
-  br i1 %NullCheck30, label %59, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %54, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %54, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %60, %System.String addrspace(1)* %58)
   %61 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %62 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck32 = icmp ne %System.Globalization.CultureData addrspace(1)* %62, null
-  br i1 %NullCheck32, label %63, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Globalization.CultureData addrspace(1)* %62, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %62, i32 0, i32 34
   %65 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %64, align 8
-  %NullCheck34 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %61, null
-  br i1 %NullCheck34, label %66, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %61, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %61, i32 0, i32 9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %67, %System.String addrspace(1)* %65)
   %68 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %69 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck36 = icmp ne %System.Globalization.CultureData addrspace(1)* %69, null
-  br i1 %NullCheck36, label %70, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Globalization.CultureData addrspace(1)* %69, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %70
 
 ; <label>:70                                      ; preds = %66
   %71 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %69, i32 0, i32 55
   %72 = load i32, i32 addrspace(1)* %71, align 8
-  %NullCheck38 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %68, null
-  br i1 %NullCheck38, label %73, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %68, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %68, i32 0, i32 22
   store i32 %72, i32 addrspace(1)* %74
   %75 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %76 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck40 = icmp ne %System.Globalization.CultureData addrspace(1)* %76, null
-  br i1 %NullCheck40, label %77, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Globalization.CultureData addrspace(1)* %76, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %76, i32 0, i32 57
   %79 = load i32, i32 addrspace(1)* %78, align 8
-  %NullCheck42 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %75, null
-  br i1 %NullCheck42, label %80, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %75, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %80
 
 ; <label>:80                                      ; preds = %77
   %81 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %75, i32 0, i32 24
   store i32 %79, i32 addrspace(1)* %81
   %82 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %83 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck44 = icmp ne %System.Globalization.CultureData addrspace(1)* %83, null
-  br i1 %NullCheck44, label %84, label %ThrowNullRef43
+  %NullCheck43 = icmp eq %System.Globalization.CultureData addrspace(1)* %83, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %84
 
 ; <label>:84                                      ; preds = %80
   %85 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %83, i32 0, i32 56
   %86 = load i32, i32 addrspace(1)* %85, align 8
-  %NullCheck46 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %82, null
-  br i1 %NullCheck46, label %87, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %82, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %82, i32 0, i32 23
@@ -13573,8 +15282,8 @@ entry:
 
 ; <label>:89                                      ; preds = %entry
   %90 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck100 = icmp ne %System.Globalization.CultureData addrspace(1)* %90, null
-  br i1 %NullCheck100, label %91, label %ThrowNullRef99
+  %NullCheck99 = icmp eq %System.Globalization.CultureData addrspace(1)* %90, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %91
 
 ; <label>:91                                      ; preds = %89
   %92 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %90, i32 0, i32 2
@@ -13592,8 +15301,8 @@ entry:
   %102 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %103 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %104 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %103)
-  %NullCheck48 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %102, null
-  br i1 %NullCheck48, label %105, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %102, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %105
 
 ; <label>:105                                     ; preds = %101
   %106 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %102, i32 0, i32 1
@@ -13601,8 +15310,8 @@ entry:
   %107 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %108 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %109 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %108)
-  %NullCheck50 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %107, null
-  br i1 %NullCheck50, label %110, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %107, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %110
 
 ; <label>:110                                     ; preds = %105
   %111 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %107, i32 0, i32 2
@@ -13610,8 +15319,8 @@ entry:
   %112 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %113 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %114 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %113)
-  %NullCheck52 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %112, null
-  br i1 %NullCheck52, label %115, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %112, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %115
 
 ; <label>:115                                     ; preds = %110
   %116 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %112, i32 0, i32 27
@@ -13619,8 +15328,8 @@ entry:
   %117 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %118 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %119 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %118)
-  %NullCheck54 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %117, null
-  br i1 %NullCheck54, label %120, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %117, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %120
 
 ; <label>:120                                     ; preds = %115
   %121 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %117, i32 0, i32 26
@@ -13628,8 +15337,8 @@ entry:
   %122 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %123 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %124 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %123)
-  %NullCheck56 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %122, null
-  br i1 %NullCheck56, label %125, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %122, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %125
 
 ; <label>:125                                     ; preds = %120
   %126 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %122, i32 0, i32 17
@@ -13637,8 +15346,8 @@ entry:
   %127 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %128 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %129 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %128)
-  %NullCheck58 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %127, null
-  br i1 %NullCheck58, label %130, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %127, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %130
 
 ; <label>:130                                     ; preds = %125
   %131 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %127, i32 0, i32 18
@@ -13646,8 +15355,8 @@ entry:
   %132 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %133 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %134 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %133)
-  %NullCheck60 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %132, null
-  br i1 %NullCheck60, label %135, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %132, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %135
 
 ; <label>:135                                     ; preds = %130
   %136 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %132, i32 0, i32 14
@@ -13655,8 +15364,8 @@ entry:
   %137 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %138 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %139 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %138)
-  %NullCheck62 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %137, null
-  br i1 %NullCheck62, label %140, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %137, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %140
 
 ; <label>:140                                     ; preds = %135
   %141 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %137, i32 0, i32 13
@@ -13664,71 +15373,71 @@ entry:
   %142 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %143 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %144 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %143)
-  %NullCheck64 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %142, null
-  br i1 %NullCheck64, label %145, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %142, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %145
 
 ; <label>:145                                     ; preds = %140
   %146 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %142, i32 0, i32 12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %146, %System.String addrspace(1)* %144)
   %147 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %148 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck66 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %148, null
-  br i1 %NullCheck66, label %149, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %148, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %149
 
 ; <label>:149                                     ; preds = %145
   %150 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %148, i32 0, i32 21
   %151 = load i32, i32 addrspace(1)* %150, align 8
-  %NullCheck68 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %147, null
-  br i1 %NullCheck68, label %152, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %147, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %152
 
 ; <label>:152                                     ; preds = %149
   %153 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %147, i32 0, i32 28
   store i32 %151, i32 addrspace(1)* %153
   %154 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %155 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck70 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %155, null
-  br i1 %NullCheck70, label %156, label %ThrowNullRef69
+  %NullCheck69 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %155, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %156
 
 ; <label>:156                                     ; preds = %152
   %157 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %155, i32 0, i32 6
   %158 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %157, align 8
-  %NullCheck72 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %154, null
-  br i1 %NullCheck72, label %159, label %ThrowNullRef71
+  %NullCheck71 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %154, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %159
 
 ; <label>:159                                     ; preds = %156
   %160 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %154, i32 0, i32 15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %160, %System.String addrspace(1)* %158)
   %161 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %162 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck74 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %162, null
-  br i1 %NullCheck74, label %163, label %ThrowNullRef73
+  %NullCheck73 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %162, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %163
 
 ; <label>:163                                     ; preds = %159
   %164 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %162, i32 0, i32 1
   %165 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %164, align 8
-  %NullCheck76 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %161, null
-  br i1 %NullCheck76, label %166, label %ThrowNullRef75
+  %NullCheck75 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %161, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %166
 
 ; <label>:166                                     ; preds = %163
   %167 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %161, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %167, %"System.Int32[]" addrspace(1)* %165)
   %168 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %169 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck78 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %169, null
-  br i1 %NullCheck78, label %170, label %ThrowNullRef77
+  %NullCheck77 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %169, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %170
 
 ; <label>:170                                     ; preds = %166
   %171 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %169, i32 0, i32 7
   %172 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %171, align 8
-  %NullCheck80 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %168, null
-  br i1 %NullCheck80, label %173, label %ThrowNullRef79
+  %NullCheck79 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %168, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %173
 
 ; <label>:173                                     ; preds = %170
   %174 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %168, i32 0, i32 16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %174, %System.String addrspace(1)* %172)
   %175 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck82 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %175, null
-  br i1 %NullCheck82, label %176, label %ThrowNullRef81
+  %NullCheck81 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %175, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %176
 
 ; <label>:176                                     ; preds = %173
   %177 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %175, i32 0, i32 4
@@ -13738,14 +15447,14 @@ entry:
 
 ; <label>:180                                     ; preds = %176
   %181 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck84 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %181, null
-  br i1 %NullCheck84, label %182, label %ThrowNullRef83
+  %NullCheck83 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %181, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %182
 
 ; <label>:182                                     ; preds = %180
   %183 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %181, i32 0, i32 4
   %184 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %183, align 8
-  %NullCheck86 = icmp ne %System.String addrspace(1)* %184, null
-  br i1 %NullCheck86, label %185, label %ThrowNullRef85
+  %NullCheck85 = icmp eq %System.String addrspace(1)* %184, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %185
 
 ; <label>:185                                     ; preds = %182
   %186 = getelementptr inbounds %System.String, %System.String addrspace(1)* %184, i32 0, i32 1
@@ -13756,8 +15465,8 @@ entry:
 ; <label>:189                                     ; preds = %176, %185
   %190 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck98 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %190, null
-  br i1 %NullCheck98, label %192, label %ThrowNullRef97
+  %NullCheck97 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %190, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %192
 
 ; <label>:192                                     ; preds = %189
   %193 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %190, i32 0, i32 4
@@ -13766,8 +15475,8 @@ entry:
 
 ; <label>:194                                     ; preds = %185, %192
   %195 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck88 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %195, null
-  br i1 %NullCheck88, label %196, label %ThrowNullRef87
+  %NullCheck87 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %195, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %196
 
 ; <label>:196                                     ; preds = %194
   %197 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %195, i32 0, i32 9
@@ -13777,14 +15486,14 @@ entry:
 
 ; <label>:200                                     ; preds = %196
   %201 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck90 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %201, null
-  br i1 %NullCheck90, label %202, label %ThrowNullRef89
+  %NullCheck89 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %201, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %202
 
 ; <label>:202                                     ; preds = %200
   %203 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %201, i32 0, i32 9
   %204 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %203, align 8
-  %NullCheck92 = icmp ne %System.String addrspace(1)* %204, null
-  br i1 %NullCheck92, label %205, label %ThrowNullRef91
+  %NullCheck91 = icmp eq %System.String addrspace(1)* %204, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %205
 
 ; <label>:205                                     ; preds = %202
   %206 = getelementptr inbounds %System.String, %System.String addrspace(1)* %204, i32 0, i32 1
@@ -13795,14 +15504,14 @@ entry:
 ; <label>:209                                     ; preds = %196, %205
   %210 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %211 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck94 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %211, null
-  br i1 %NullCheck94, label %212, label %ThrowNullRef93
+  %NullCheck93 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %211, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %212
 
 ; <label>:212                                     ; preds = %209
   %213 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %211, i32 0, i32 6
   %214 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %213, align 8
-  %NullCheck96 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %210, null
-  br i1 %NullCheck96, label %215, label %ThrowNullRef95
+  %NullCheck95 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %210, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %215
 
 ; <label>:215                                     ; preds = %212
   %216 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %210, i32 0, i32 9
@@ -13816,203 +15525,203 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %17
+ThrowNullRef8:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %21
+ThrowNullRef10:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %24
+ThrowNullRef12:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %28
+ThrowNullRef14:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %31
+ThrowNullRef16:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %35
+ThrowNullRef18:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %38
+ThrowNullRef20:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %42
+ThrowNullRef22:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %45
+ThrowNullRef24:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %49
+ThrowNullRef26:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %52
+ThrowNullRef28:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %56
+ThrowNullRef30:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %59
+ThrowNullRef32:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %63
+ThrowNullRef34:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %66
+ThrowNullRef36:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %70
+ThrowNullRef38:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %73
+ThrowNullRef40:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %77
+ThrowNullRef42:                                   ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %80
+ThrowNullRef44:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %84
+ThrowNullRef46:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %101
+ThrowNullRef48:                                   ; preds = %101
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %105
+ThrowNullRef50:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %110
+ThrowNullRef52:                                   ; preds = %110
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %115
+ThrowNullRef54:                                   ; preds = %115
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %120
+ThrowNullRef56:                                   ; preds = %120
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %125
+ThrowNullRef58:                                   ; preds = %125
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %130
+ThrowNullRef60:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %135
+ThrowNullRef62:                                   ; preds = %135
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %140
+ThrowNullRef64:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %145
+ThrowNullRef66:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %149
+ThrowNullRef68:                                   ; preds = %149
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %152
+ThrowNullRef70:                                   ; preds = %152
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %156
+ThrowNullRef72:                                   ; preds = %156
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %159
+ThrowNullRef74:                                   ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %163
+ThrowNullRef76:                                   ; preds = %163
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %166
+ThrowNullRef78:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %170
+ThrowNullRef80:                                   ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %173
+ThrowNullRef82:                                   ; preds = %173
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %180
+ThrowNullRef84:                                   ; preds = %180
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %182
+ThrowNullRef86:                                   ; preds = %182
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %194
+ThrowNullRef88:                                   ; preds = %194
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %200
+ThrowNullRef90:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %202
+ThrowNullRef92:                                   ; preds = %202
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %209
+ThrowNullRef94:                                   ; preds = %209
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %212
+ThrowNullRef96:                                   ; preds = %212
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %189
+ThrowNullRef98:                                   ; preds = %189
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %89
+ThrowNullRef100:                                  ; preds = %89
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14040,8 +15749,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 21
@@ -14054,8 +15763,8 @@ entry:
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 16)
   %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 21
@@ -14064,8 +15773,8 @@ entry:
 
 ; <label>:12                                      ; preds = %1, %10
   %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 21
@@ -14076,11 +15785,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %12
+ThrowNullRef4:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14096,8 +15805,8 @@ entry:
   store i32 %param1, i32* %arg1
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %1 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
@@ -14164,8 +15873,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 33
@@ -14178,8 +15887,8 @@ entry:
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 24)
   %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 33
@@ -14188,8 +15897,8 @@ entry:
 
 ; <label>:12                                      ; preds = %1, %10
   %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 33
@@ -14200,11 +15909,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %12
+ThrowNullRef4:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14217,8 +15926,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 53
@@ -14230,8 +15939,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 116)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 53
@@ -14240,8 +15949,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 53
@@ -14252,11 +15961,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14285,8 +15994,8 @@ entry:
 
 ; <label>:7                                       ; preds = %entry, %4
   %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %7
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 2
@@ -14310,8 +16019,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 54
@@ -14323,8 +16032,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 117)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
@@ -14333,8 +16042,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 54
@@ -14345,11 +16054,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14362,8 +16071,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 27
@@ -14375,8 +16084,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 118)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 27
@@ -14385,8 +16094,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 27
@@ -14397,11 +16106,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14414,8 +16123,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 28
@@ -14427,8 +16136,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 119)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 28
@@ -14437,8 +16146,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 28
@@ -14449,11 +16158,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14466,8 +16175,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 26
@@ -14479,8 +16188,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 107)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 26
@@ -14489,8 +16198,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 26
@@ -14501,11 +16210,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14518,8 +16227,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 25
@@ -14531,8 +16240,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 106)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 25
@@ -14541,8 +16250,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 25
@@ -14553,11 +16262,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14570,8 +16279,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 24
@@ -14583,8 +16292,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 105)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 24
@@ -14593,8 +16302,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 24
@@ -14605,11 +16314,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14634,8 +16343,8 @@ entry:
   %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %3)
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %2
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -14646,15 +16355,15 @@ entry:
 
 ; <label>:8                                       ; preds = %62
   %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 9
   %12 = load i32, i32 addrspace(1)* %11, align 8
   %13 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.IO.StreamWriter addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %13, i32 0, i32 10
@@ -14669,15 +16378,15 @@ entry:
 
 ; <label>:20                                      ; preds = %14, %18
   %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
   %24 = load i32, i32 addrspace(1)* %23, align 8
   %25 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %25, null
-  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.StreamWriter addrspace(1)* %25, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %25, i32 0, i32 9
@@ -14698,36 +16407,36 @@ entry:
   %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %37 = load i32, i32* %loc1
   %38 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.StreamWriter addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %35
   %40 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %38, i32 0, i32 7
   %41 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %40, align 8
   %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
-  br i1 %NullCheck14, label %43, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %39
   %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 9
   %45 = load i32, i32 addrspace(1)* %44, align 8
   %46 = load i32, i32* %loc2
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %36, null
-  br i1 %NullCheck16, label %47, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %36, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %47
 
 ; <label>:47                                      ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %36, i32 %37, %"System.Char[]" addrspace(1)* %41, i32 %45, i32 %46)
   %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
   %51 = load i32, i32 addrspace(1)* %50, align 8
   %52 = load i32, i32* %loc2
   %53 = add i32 %51, %52
-  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
-  br i1 %NullCheck20, label %54, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %54
 
 ; <label>:54                                      ; preds = %49
   %55 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
@@ -14749,8 +16458,8 @@ entry:
 
 ; <label>:65                                      ; preds = %62
   %66 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %66, null
-  br i1 %NullCheck2, label %67, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %66, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %67
 
 ; <label>:67                                      ; preds = %65
   %68 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %66, i32 0, i32 11
@@ -14771,49 +16480,259 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %65
+ThrowNullRef2:                                    ; preds = %65
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %20
+ThrowNullRef8:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %22
+ThrowNullRef10:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %35
+ThrowNullRef12:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %43
+ThrowNullRef16:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %47
+ThrowNullRef18:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method String::CopyTo using LLILCJit
-Failed to read String.CopyTo[loadElemA]
+Successfully read String.CopyTo
+
+define void @String.CopyTo(%System.String addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  %loc1 = alloca i16 addrspace(1)*
+  %loc2 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %1 = icmp ne %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg4
+  %7 = icmp sge i32 %6, 0
+  br i1 %7, label %13, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  unreachable
+
+; <label>:13                                      ; preds = %5
+  %14 = load i32, i32* %arg1
+  %15 = icmp sge i32 %14, 0
+  br i1 %15, label %21, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %18)
+  %20 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %20, %System.String addrspace(1)* %17, %System.String addrspace(1)* %19)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %20) #0
+  unreachable
+
+; <label>:21                                      ; preds = %13
+  %22 = load i32, i32* %arg4
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck, label %ThrowNullRef, label %24
+
+; <label>:24                                      ; preds = %21
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load i32, i32* %arg1
+  %28 = sub i32 %26, %27
+  %29 = icmp sle i32 %22, %28
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34, %System.String addrspace(1)* %31, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %24
+  %36 = load i32, i32* %arg3
+  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %37, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
+
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
+  %40 = load i32, i32 addrspace(1)* %39
+  %41 = zext i32 %40 to i64
+  %42 = trunc i64 %41 to i32
+  %43 = load i32, i32* %arg4
+  %44 = sub i32 %42, %43
+  %45 = icmp sgt i32 %36, %44
+  br i1 %45, label %49, label %46
+
+; <label>:46                                      ; preds = %38
+  %47 = load i32, i32* %arg3
+  %48 = icmp sge i32 %47, 0
+  br i1 %48, label %54, label %49
+
+; <label>:49                                      ; preds = %38, %46
+  %50 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %52 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %51)
+  %53 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53, %System.String addrspace(1)* %50, %System.String addrspace(1)* %52)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53) #0
+  unreachable
+
+; <label>:54                                      ; preds = %46
+  %55 = load i32, i32* %arg4
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %97, label %57
+
+; <label>:57                                      ; preds = %54
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %59
+
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 2
+  %61 = bitcast [0 x i16] addrspace(1)* %60 to i16 addrspace(1)*
+  store i16 addrspace(1)* %61, i16 addrspace(1)** %loc0
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  store %"System.Char[]" addrspace(1)* %62, %"System.Char[]" addrspace(1)** %loc2
+  %63 = icmp eq %"System.Char[]" addrspace(1)* %62, null
+  br i1 %63, label %72, label %64
+
+; <label>:64                                      ; preds = %59
+  %65 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc2
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %65, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %66
+
+; <label>:66                                      ; preds = %64
+  %67 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %65, i32 0, i32 1
+  %68 = load i32, i32 addrspace(1)* %67
+  %69 = zext i32 %68 to i64
+  %70 = trunc i64 %69 to i32
+  %71 = icmp ne i32 %70, 0
+  br i1 %71, label %73, label %72
+
+; <label>:72                                      ; preds = %59, %66
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  br label %81
+
+; <label>:73                                      ; preds = %66
+  %74 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc2
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %74, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %75
+
+; <label>:75                                      ; preds = %73
+  %76 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %74, i32 0, i32 1
+  %77 = load i32, i32 addrspace(1)* %76
+  %78 = zext i32 %77 to i64
+  %BoundsCheck = icmp uge i64 0, %78
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %79
+
+; <label>:79                                      ; preds = %75
+  %80 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %74, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %80, i16 addrspace(1)** %loc1
+  br label %81
+
+; <label>:81                                      ; preds = %72, %79
+  %82 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %83 = ptrtoint i16 addrspace(1)* %82 to i64
+  %84 = load i32, i32* %arg3
+  %85 = sext i32 %84 to i64
+  %86 = mul i64 %85, 2
+  %87 = add i64 %83, %86
+  %88 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %89 = ptrtoint i16 addrspace(1)* %88 to i64
+  %90 = load i32, i32* %arg1
+  %91 = sext i32 %90 to i64
+  %92 = mul i64 %91, 2
+  %93 = add i64 %89, %92
+  %94 = load i32, i32* %arg4
+  %95 = inttoptr i64 %87 to i16*
+  %96 = inttoptr i64 %93 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %95, i16* %96, i32 %94)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  br label %97
+
+; <label>:97                                      ; preds = %54, %81
+  ret void
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
 Successfully read ConsoleEncoding.GetPreamble
 
@@ -14850,7 +16769,365 @@ entry:
 }
 
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[loadElemA]
+Successfully read EncoderNLS.GetBytes
+
+define i32 @EncoderNLS.GetBytes(%System.Text.EncoderNLS addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3, %"System.Byte[]" addrspace(1)* %param4, i32 %param5, i8 %param6) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %arg4 = alloca %"System.Byte[]" addrspace(1)*
+  %arg5 = alloca i32
+  %arg6 = alloca i8
+  %loc0 = alloca i32
+  %loc1 = alloca i16 addrspace(1)*
+  %loc2 = alloca i8 addrspace(1)*
+  %loc3 = alloca i32
+  %loc4 = alloca %"System.Char[]" addrspace(1)*
+  %loc5 = alloca %"System.Byte[]" addrspace(1)*
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  store %"System.Byte[]" addrspace(1)* %param4, %"System.Byte[]" addrspace(1)** %arg4
+  store i32 %param5, i32* %arg5
+  store i8 %param6, i8* %arg6
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %1 = icmp eq %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %17, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %7 = icmp eq %"System.Char[]" addrspace(1)* %6, null
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %12
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %12
+
+; <label>:12                                      ; preds = %8, %10
+  %13 = phi %System.String addrspace(1)* [ %9, %8 ], [ %11, %10 ]
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %14)
+  %16 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16, %System.String addrspace(1)* %13, %System.String addrspace(1)* %15)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16) #0
+  unreachable
+
+; <label>:17                                      ; preds = %2
+  %18 = load i32, i32* %arg2
+  %19 = icmp slt i32 %18, 0
+  br i1 %19, label %23, label %20
+
+; <label>:20                                      ; preds = %17
+  %21 = load i32, i32* %arg3
+  %22 = icmp sge i32 %21, 0
+  br i1 %22, label %35, label %23
+
+; <label>:23                                      ; preds = %17, %20
+  %24 = load i32, i32* %arg2
+  %25 = icmp slt i32 %24, 0
+  br i1 %25, label %28, label %26
+
+; <label>:26                                      ; preds = %23
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %30
+
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %30
+
+; <label>:30                                      ; preds = %26, %28
+  %31 = phi %System.String addrspace(1)* [ %27, %26 ], [ %29, %28 ]
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34, %System.String addrspace(1)* %31, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %20
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck, label %ThrowNullRef, label %37
+
+; <label>:37                                      ; preds = %35
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = load i32, i32* %arg2
+  %43 = sub i32 %41, %42
+  %44 = load i32, i32* %arg3
+  %45 = icmp sge i32 %43, %44
+  br i1 %45, label %51, label %46
+
+; <label>:46                                      ; preds = %37
+  %47 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %48 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %49 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %48)
+  %50 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %50, %System.String addrspace(1)* %47, %System.String addrspace(1)* %49)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %50) #0
+  unreachable
+
+; <label>:51                                      ; preds = %37
+  %52 = load i32, i32* %arg5
+  %53 = icmp slt i32 %52, 0
+  br i1 %53, label %63, label %54
+
+; <label>:54                                      ; preds = %51
+  %55 = load i32, i32* %arg5
+  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck1 = icmp eq %"System.Byte[]" addrspace(1)* %56, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %57
+
+; <label>:57                                      ; preds = %54
+  %58 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = zext i32 %59 to i64
+  %61 = trunc i64 %60 to i32
+  %62 = icmp sle i32 %55, %61
+  br i1 %62, label %68, label %63
+
+; <label>:63                                      ; preds = %51, %57
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %66 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %65)
+  %67 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %67, %System.String addrspace(1)* %64, %System.String addrspace(1)* %66)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %67) #0
+  unreachable
+
+; <label>:68                                      ; preds = %57
+  %69 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %69, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %69, i32 0, i32 1
+  %72 = load i32, i32 addrspace(1)* %71
+  %73 = zext i32 %72 to i64
+  %74 = trunc i64 %73 to i32
+  %75 = icmp ne i32 %74, 0
+  br i1 %75, label %78, label %76
+
+; <label>:76                                      ; preds = %70
+  %77 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1)
+  store %"System.Char[]" addrspace(1)* %77, %"System.Char[]" addrspace(1)** %arg1
+  br label %78
+
+; <label>:78                                      ; preds = %70, %76
+  %79 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck5 = icmp eq %"System.Byte[]" addrspace(1)* %79, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %80
+
+; <label>:80                                      ; preds = %78
+  %81 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %79, i32 0, i32 1
+  %82 = load i32, i32 addrspace(1)* %81
+  %83 = zext i32 %82 to i64
+  %84 = trunc i64 %83 to i32
+  %85 = load i32, i32* %arg5
+  %86 = sub i32 %84, %85
+  store i32 %86, i32* %loc0
+  %87 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck7 = icmp eq %"System.Byte[]" addrspace(1)* %87, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %88
+
+; <label>:88                                      ; preds = %80
+  %89 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %87, i32 0, i32 1
+  %90 = load i32, i32 addrspace(1)* %89
+  %91 = zext i32 %90 to i64
+  %92 = trunc i64 %91 to i32
+  %93 = icmp ne i32 %92, 0
+  br i1 %93, label %96, label %94
+
+; <label>:94                                      ; preds = %88
+  %95 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1)
+  store %"System.Byte[]" addrspace(1)* %95, %"System.Byte[]" addrspace(1)** %arg4
+  br label %96
+
+; <label>:96                                      ; preds = %88, %94
+  %97 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  store %"System.Char[]" addrspace(1)* %97, %"System.Char[]" addrspace(1)** %loc4
+  %98 = icmp eq %"System.Char[]" addrspace(1)* %97, null
+  br i1 %98, label %107, label %99
+
+; <label>:99                                      ; preds = %96
+  %100 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc4
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %100, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %101
+
+; <label>:101                                     ; preds = %99
+  %102 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %100, i32 0, i32 1
+  %103 = load i32, i32 addrspace(1)* %102
+  %104 = zext i32 %103 to i64
+  %105 = trunc i64 %104 to i32
+  %106 = icmp ne i32 %105, 0
+  br i1 %106, label %108, label %107
+
+; <label>:107                                     ; preds = %96, %101
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  br label %116
+
+; <label>:108                                     ; preds = %101
+  %109 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc4
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %109, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %110
+
+; <label>:110                                     ; preds = %108
+  %111 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %109, i32 0, i32 1
+  %112 = load i32, i32 addrspace(1)* %111
+  %113 = zext i32 %112 to i64
+  %BoundsCheck = icmp uge i64 0, %113
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %114
+
+; <label>:114                                     ; preds = %110
+  %115 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %109, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %115, i16 addrspace(1)** %loc1
+  br label %116
+
+; <label>:116                                     ; preds = %107, %114
+  %117 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  store %"System.Byte[]" addrspace(1)* %117, %"System.Byte[]" addrspace(1)** %loc5
+  %118 = icmp eq %"System.Byte[]" addrspace(1)* %117, null
+  br i1 %118, label %127, label %119
+
+; <label>:119                                     ; preds = %116
+  %120 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc5
+  %NullCheck13 = icmp eq %"System.Byte[]" addrspace(1)* %120, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %121
+
+; <label>:121                                     ; preds = %119
+  %122 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %120, i32 0, i32 1
+  %123 = load i32, i32 addrspace(1)* %122
+  %124 = zext i32 %123 to i64
+  %125 = trunc i64 %124 to i32
+  %126 = icmp ne i32 %125, 0
+  br i1 %126, label %128, label %127
+
+; <label>:127                                     ; preds = %116, %121
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc2
+  br label %136
+
+; <label>:128                                     ; preds = %121
+  %129 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc5
+  %NullCheck15 = icmp eq %"System.Byte[]" addrspace(1)* %129, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %130
+
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %129, i32 0, i32 1
+  %132 = load i32, i32 addrspace(1)* %131
+  %133 = zext i32 %132 to i64
+  %BoundsCheck17 = icmp uge i64 0, %133
+  br i1 %BoundsCheck17, label %ThrowIndexOutOfRange18, label %134
+
+; <label>:134                                     ; preds = %130
+  %135 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %129, i32 0, i32 3, i32 0
+  store i8 addrspace(1)* %135, i8 addrspace(1)** %loc2
+  br label %136
+
+; <label>:136                                     ; preds = %127, %134
+  %137 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %138 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %139 = ptrtoint i16 addrspace(1)* %138 to i64
+  %140 = load i32, i32* %arg2
+  %141 = sext i32 %140 to i64
+  %142 = mul i64 %141, 2
+  %143 = add i64 %139, %142
+  %144 = load i32, i32* %arg3
+  %145 = load i8 addrspace(1)*, i8 addrspace(1)** %loc2
+  %146 = ptrtoint i8 addrspace(1)* %145 to i64
+  %147 = load i32, i32* %arg5
+  %148 = sext i32 %147 to i64
+  %149 = add i64 %146, %148
+  %150 = load i32, i32* %loc0
+  %151 = load i8, i8* %arg6
+  %152 = zext i8 %151 to i32
+  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i64 addrspace(1)*
+  %NullCheck19 = icmp eq i64 addrspace(1)* %153, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %154
+
+; <label>:154                                     ; preds = %136
+  %155 = load i64, i64 addrspace(1)* %153
+  %156 = add i64 %155, 72
+  %157 = inttoptr i64 %156 to i64*
+  %158 = load i64, i64* %157
+  %159 = add i64 %158, 0
+  %160 = inttoptr i64 %159 to i64*
+  %161 = load i64, i64* %160
+  %162 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to %System.Text.Encoder addrspace(1)*
+  %163 = inttoptr i64 %143 to i16*
+  %164 = inttoptr i64 %149 to i8*
+  %165 = trunc i32 %152 to i8
+  %166 = inttoptr i64 %161 to i32 (%System.Text.Encoder addrspace(1)*, i16*, i32, i8*, i32, i8)*
+  %167 = call i32 %166(%System.Text.Encoder addrspace(1)* %162, i16* %163, i32 %144, i8* %164, i32 %150, i8 %165)
+  store i32 %167, i32* %loc3
+  br label %168
+
+; <label>:168                                     ; preds = %154
+  %169 = load i32, i32* %loc3
+  ret i32 %169
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %110
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %119
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange18:                           ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
 Successfully read EncoderNLS.GetBytes
 
@@ -14939,22 +17216,22 @@ entry:
   %40 = load i8, i8* %arg5
   %41 = zext i8 %40 to i32
   %42 = trunc i32 %41 to i8
-  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %39, null
-  br i1 %NullCheck, label %43, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderNLS addrspace(1)* %39, null
+  br i1 %NullCheck, label %ThrowNullRef, label %43
 
 ; <label>:43                                      ; preds = %38
   %44 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
   store i8 %42, i8 addrspace(1)* %44
   %45 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %45, null
-  br i1 %NullCheck2, label %46, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.EncoderNLS addrspace(1)* %45, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %46
 
 ; <label>:46                                      ; preds = %43
   %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %45, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %47
   %48 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.EncoderNLS addrspace(1)* %48, null
-  br i1 %NullCheck4, label %49, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.EncoderNLS addrspace(1)* %48, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %49
 
 ; <label>:49                                      ; preds = %46
   %50 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %48, i32 0, i32 3
@@ -14965,8 +17242,8 @@ entry:
   %55 = load i32, i32* %arg4
   %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck6, label %58, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
   %59 = load i64, i64 addrspace(1)* %57
@@ -14984,15 +17261,15 @@ ThrowNullRef:                                     ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %43
+ThrowNullRef2:                                    ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %46
+ThrowNullRef4:                                    ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %49
+ThrowNullRef6:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -15020,8 +17297,8 @@ entry:
   %4 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0 to %System.IO.ConsoleStream addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*)(%System.IO.ConsoleStream addrspace(1)* %4, %"System.Byte[]" addrspace(1)* %1, i32 %2, i32 %3)
   %5 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
@@ -15106,8 +17383,8 @@ entry:
 
 ; <label>:22                                      ; preds = %8
   %23 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %23, null
-  br i1 %NullCheck, label %24, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Byte[]" addrspace(1)* %23, null
+  br i1 %NullCheck, label %ThrowNullRef, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
@@ -15129,8 +17406,8 @@ entry:
 
 ; <label>:36                                      ; preds = %24
   %37 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %37, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.ConsoleStream addrspace(1)* %37, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %37, i32 0, i32 4
@@ -15151,13 +17428,138 @@ ThrowNullRef:                                     ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %36
+ThrowNullRef2:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
-Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
+Successfully read WindowsConsoleStream.WriteFileNative
+
+define i32 @WindowsConsoleStream.WriteFileNative(i64 %param0, %"System.Byte[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i64
+  %arg1 = alloca %"System.Byte[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i8 addrspace(1)*
+  %loc2 = alloca %"System.Byte[]" addrspace(1)*
+  %loc3 = alloca i32
+  store i64 %param0, i64* %arg0
+  store %"System.Byte[]" addrspace(1)* %param1, %"System.Byte[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Byte[]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = zext i32 %3 to i64
+  %5 = icmp ne i64 %4, 0
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %1
+  ret i32 0
+
+; <label>:7                                       ; preds = %1
+  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  store %"System.Byte[]" addrspace(1)* %8, %"System.Byte[]" addrspace(1)** %loc2
+  %9 = icmp eq %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %9, label %18, label %10
+
+; <label>:10                                      ; preds = %7
+  %11 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc2
+  %NullCheck1 = icmp eq %"System.Byte[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %11, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp ne i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %7, %12
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc1
+  br label %27
+
+; <label>:19                                      ; preds = %12
+  %20 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc2
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %20, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %BoundsCheck = icmp uge i64 0, %24
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %25
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %20, i32 0, i32 3, i32 0
+  store i8 addrspace(1)* %26, i8 addrspace(1)** %loc1
+  br label %27
+
+; <label>:27                                      ; preds = %18, %25
+  %28 = load i64, i64* %arg0
+  %29 = load i8 addrspace(1)*, i8 addrspace(1)** %loc1
+  %30 = ptrtoint i8 addrspace(1)* %29 to i64
+  %31 = load i32, i32* %arg2
+  %32 = sext i32 %31 to i64
+  %33 = add i64 %30, %32
+  %34 = load i32, i32* %arg3
+  %35 = addrspacecast i32* %loc3 to i32 addrspace(1)*
+  %36 = inttoptr i64 %33 to i8*
+  %37 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i8*, i32, i32 addrspace(1)*, i64)*)(i64 %28, i8* %36, i32 %34, i32 addrspace(1)* %35, i64 0)
+  %38 = icmp ugt i32 %37, 0
+  %39 = sext i1 %38 to i32
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc1
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %42, label %41
+
+; <label>:41                                      ; preds = %27
+  ret i32 0
+
+; <label>:42                                      ; preds = %27
+  %43 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  store i32 %43, i32* %loc0
+  %44 = load i32, i32* %loc0
+  %45 = icmp eq i32 %44, 232
+  br i1 %45, label %49, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = load i32, i32* %loc0
+  %48 = icmp ne i32 %47, 109
+  br i1 %48, label %50, label %49
+
+; <label>:49                                      ; preds = %42, %46
+  ret i32 0
+
+; <label>:50                                      ; preds = %46
+  %51 = load i32, i32* %loc0
+  ret i32 %51
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
 Successfully read WindowsConsoleStream.Flush
 
@@ -15166,8 +17568,8 @@ entry:
   %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
   store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
@@ -15202,8 +17604,8 @@ entry:
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
   %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load i64, i64 addrspace(1)* %1
@@ -15242,15 +17644,15 @@ entry:
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.TextWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
   %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %3, align 8
   %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
   %7 = load i64, i64 addrspace(1)* %5
@@ -15268,7 +17670,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -15297,8 +17699,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %4)
   store i32 0, i32* %loc0
   %5 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Char[]" addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
@@ -15310,15 +17712,15 @@ entry:
 
 ; <label>:11                                      ; preds = %69
   %12 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %12, i32 0, i32 9
   %15 = load i32, i32 addrspace(1)* %14, align 8
   %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.IO.StreamWriter addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %16, i32 0, i32 10
@@ -15333,15 +17735,15 @@ entry:
 
 ; <label>:23                                      ; preds = %17, %21
   %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %24, null
-  br i1 %NullCheck8, label %25, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %24, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 10
   %27 = load i32, i32 addrspace(1)* %26, align 8
   %28 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %28, null
-  br i1 %NullCheck10, label %29, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.StreamWriter addrspace(1)* %28, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %28, i32 0, i32 9
@@ -15363,15 +17765,15 @@ entry:
   %40 = load i32, i32* %loc0
   %41 = mul i32 %40, 2
   %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
-  br i1 %NullCheck12, label %43, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %43
 
 ; <label>:43                                      ; preds = %38
   %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 7
   %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %44, align 8
   %46 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %46, null
-  br i1 %NullCheck14, label %47, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.IO.StreamWriter addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %47
 
 ; <label>:47                                      ; preds = %43
   %48 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %46, i32 0, i32 9
@@ -15383,16 +17785,16 @@ entry:
   %54 = bitcast %"System.Char[]" addrspace(1)* %45 to %System.Array addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %53, i32 %41, %System.Array addrspace(1)* %54, i32 %50, i32 %52)
   %55 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
-  br i1 %NullCheck16, label %56, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %56
 
 ; <label>:56                                      ; preds = %47
   %57 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
   %58 = load i32, i32 addrspace(1)* %57, align 8
   %59 = load i32, i32* %loc2
   %60 = add i32 %58, %59
-  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
-  br i1 %NullCheck18, label %61, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %61
 
 ; <label>:61                                      ; preds = %56
   %62 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
@@ -15414,8 +17816,8 @@ entry:
 
 ; <label>:72                                      ; preds = %69
   %73 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %73, null
-  br i1 %NullCheck2, label %74, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %73, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %74
 
 ; <label>:74                                      ; preds = %72
   %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %73, i32 0, i32 11
@@ -15436,39 +17838,39 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %72
+ThrowNullRef2:                                    ; preds = %72
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %23
+ThrowNullRef8:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef10:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %43
+ThrowNullRef14:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %47
+ThrowNullRef16:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %56
+ThrowNullRef18:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblCall1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblCall1.error.txt
@@ -25,8 +25,8 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
@@ -40,8 +40,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
   %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
@@ -75,7 +75,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -90,8 +90,8 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %NullCheck = icmp ne i8 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = load i8, i8 addrspace(1)* %0, align 8
@@ -125,8 +125,8 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
@@ -159,8 +159,8 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -184,8 +184,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
   store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
@@ -195,8 +195,8 @@ entry:
 ; <label>:4                                       ; preds = %1
   %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
   %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
@@ -206,8 +206,8 @@ entry:
   %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
@@ -221,14 +221,14 @@ entry:
 
 ; <label>:17                                      ; preds = %14
   %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
   %21 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
@@ -238,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -249,8 +249,8 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
@@ -261,27 +261,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %30
+ThrowNullRef10:                                   ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -301,7 +301,89 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
-Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
+Successfully read AppDomainSetup.GetUnsecureApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.GetUnsecureApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %NullCheck = icmp eq %"System.String[]" addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %BoundsCheck = icmp uge i64 0, %5
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %6
+
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 3, i32 0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
+  ret %System.String addrspace(1)* %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_Value using LLILCJit
+Successfully read AppDomainSetup.get_Value
+
+define %"System.String[]" addrspace(1)* @AppDomainSetup.get_Value(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.String[]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 18)
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.String[]" addrspace(1)* addrspace(1)*, %"System.String[]" addrspace(1)*)*)(%"System.String[]" addrspace(1)* addrspace(1)* %9, %"System.String[]" addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %11, i32 0, i32 1
+  %14 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %13, align 8
+  ret %"System.String[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -319,8 +401,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -368,16 +450,16 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
   %5 = load i32, i32 addrspace(1)* %4
   %6 = sub i32 %5, 1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -389,7 +471,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -421,8 +503,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
@@ -456,8 +538,8 @@ entry:
 ; <label>:27                                      ; preds = %19
   %28 = load i32, i32* %arg1
   %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
-  br i1 %NullCheck2, label %30, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %29, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %30
 
 ; <label>:30                                      ; preds = %27
   %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
@@ -493,8 +575,8 @@ entry:
 ; <label>:49                                      ; preds = %46
   %50 = load i32, i32* %arg2
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck4, label %52, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
@@ -517,11 +599,11 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %27
+ThrowNullRef2:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %49
+ThrowNullRef4:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -544,16 +626,16 @@ entry:
   %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %0)
   store %System.String addrspace(1)* %1, %System.String addrspace(1)** %loc0
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 2
   %5 = bitcast [0 x i16] addrspace(1)* %4 to i16 addrspace(1)*
   store i16 addrspace(1)* %5, i16 addrspace(1)** %loc1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %3
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2
@@ -580,7 +662,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -691,15 +773,15 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %NullCheck132 = icmp ne i8* %21, null
-  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+  %NullCheck131 = icmp eq i8* %21, null
+  br i1 %NullCheck131, label %ThrowNullRef132, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = load i8, i8* %21, align 8
   %24 = zext i8 %23 to i32
   %25 = trunc i32 %24 to i8
-  %NullCheck134 = icmp ne i8* %20, null
-  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+  %NullCheck133 = icmp eq i8* %20, null
+  br i1 %NullCheck133, label %ThrowNullRef134, label %26
 
 ; <label>:26                                      ; preds = %22
   store i8 %25, i8* %20, align 8
@@ -709,16 +791,16 @@ entry:
   %28 = load i8*, i8** %arg0
   %29 = load i8*, i8** %arg1
   %30 = bitcast i8* %29 to i16*
-  %NullCheck128 = icmp ne i16* %30, null
-  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+  %NullCheck127 = icmp eq i16* %30, null
+  br i1 %NullCheck127, label %ThrowNullRef128, label %31
 
 ; <label>:31                                      ; preds = %27
   %32 = load i16, i16* %30, align 8
   %33 = sext i16 %32 to i32
   %34 = bitcast i8* %28 to i16*
   %35 = trunc i32 %33 to i16
-  %NullCheck130 = icmp ne i16* %34, null
-  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+  %NullCheck129 = icmp eq i16* %34, null
+  br i1 %NullCheck129, label %ThrowNullRef130, label %36
 
 ; <label>:36                                      ; preds = %31
   store i16 %35, i16* %34, align 8
@@ -728,16 +810,16 @@ entry:
   %38 = load i8*, i8** %arg0
   %39 = load i8*, i8** %arg1
   %40 = bitcast i8* %39 to i16*
-  %NullCheck120 = icmp ne i16* %40, null
-  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+  %NullCheck119 = icmp eq i16* %40, null
+  br i1 %NullCheck119, label %ThrowNullRef120, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i16, i16* %40, align 8
   %43 = sext i16 %42 to i32
   %44 = bitcast i8* %38 to i16*
   %45 = trunc i32 %43 to i16
-  %NullCheck122 = icmp ne i16* %44, null
-  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+  %NullCheck121 = icmp eq i16* %44, null
+  br i1 %NullCheck121, label %ThrowNullRef122, label %46
 
 ; <label>:46                                      ; preds = %41
   store i16 %45, i16* %44, align 8
@@ -745,15 +827,15 @@ entry:
   %48 = getelementptr inbounds i8, i8* %47, i64 2
   %49 = load i8*, i8** %arg1
   %50 = getelementptr inbounds i8, i8* %49, i64 2
-  %NullCheck124 = icmp ne i8* %50, null
-  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+  %NullCheck123 = icmp eq i8* %50, null
+  br i1 %NullCheck123, label %ThrowNullRef124, label %51
 
 ; <label>:51                                      ; preds = %46
   %52 = load i8, i8* %50, align 8
   %53 = zext i8 %52 to i32
   %54 = trunc i32 %53 to i8
-  %NullCheck126 = icmp ne i8* %48, null
-  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+  %NullCheck125 = icmp eq i8* %48, null
+  br i1 %NullCheck125, label %ThrowNullRef126, label %55
 
 ; <label>:55                                      ; preds = %51
   store i8 %54, i8* %48, align 8
@@ -763,14 +845,14 @@ entry:
   %57 = load i8*, i8** %arg0
   %58 = load i8*, i8** %arg1
   %59 = bitcast i8* %58 to i32*
-  %NullCheck116 = icmp ne i32* %59, null
-  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+  %NullCheck115 = icmp eq i32* %59, null
+  br i1 %NullCheck115, label %ThrowNullRef116, label %60
 
 ; <label>:60                                      ; preds = %56
   %61 = load i32, i32* %59, align 8
   %62 = bitcast i8* %57 to i32*
-  %NullCheck118 = icmp ne i32* %62, null
-  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+  %NullCheck117 = icmp eq i32* %62, null
+  br i1 %NullCheck117, label %ThrowNullRef118, label %63
 
 ; <label>:63                                      ; preds = %60
   store i32 %61, i32* %62, align 8
@@ -780,14 +862,14 @@ entry:
   %65 = load i8*, i8** %arg0
   %66 = load i8*, i8** %arg1
   %67 = bitcast i8* %66 to i32*
-  %NullCheck108 = icmp ne i32* %67, null
-  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+  %NullCheck107 = icmp eq i32* %67, null
+  br i1 %NullCheck107, label %ThrowNullRef108, label %68
 
 ; <label>:68                                      ; preds = %64
   %69 = load i32, i32* %67, align 8
   %70 = bitcast i8* %65 to i32*
-  %NullCheck110 = icmp ne i32* %70, null
-  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+  %NullCheck109 = icmp eq i32* %70, null
+  br i1 %NullCheck109, label %ThrowNullRef110, label %71
 
 ; <label>:71                                      ; preds = %68
   store i32 %69, i32* %70, align 8
@@ -795,15 +877,15 @@ entry:
   %73 = getelementptr inbounds i8, i8* %72, i64 4
   %74 = load i8*, i8** %arg1
   %75 = getelementptr inbounds i8, i8* %74, i64 4
-  %NullCheck112 = icmp ne i8* %75, null
-  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+  %NullCheck111 = icmp eq i8* %75, null
+  br i1 %NullCheck111, label %ThrowNullRef112, label %76
 
 ; <label>:76                                      ; preds = %71
   %77 = load i8, i8* %75, align 8
   %78 = zext i8 %77 to i32
   %79 = trunc i32 %78 to i8
-  %NullCheck114 = icmp ne i8* %73, null
-  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+  %NullCheck113 = icmp eq i8* %73, null
+  br i1 %NullCheck113, label %ThrowNullRef114, label %80
 
 ; <label>:80                                      ; preds = %76
   store i8 %79, i8* %73, align 8
@@ -813,14 +895,14 @@ entry:
   %82 = load i8*, i8** %arg0
   %83 = load i8*, i8** %arg1
   %84 = bitcast i8* %83 to i32*
-  %NullCheck100 = icmp ne i32* %84, null
-  br i1 %NullCheck100, label %85, label %ThrowNullRef99
+  %NullCheck99 = icmp eq i32* %84, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %85
 
 ; <label>:85                                      ; preds = %81
   %86 = load i32, i32* %84, align 8
   %87 = bitcast i8* %82 to i32*
-  %NullCheck102 = icmp ne i32* %87, null
-  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+  %NullCheck101 = icmp eq i32* %87, null
+  br i1 %NullCheck101, label %ThrowNullRef102, label %88
 
 ; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
@@ -829,16 +911,16 @@ entry:
   %91 = load i8*, i8** %arg1
   %92 = getelementptr inbounds i8, i8* %91, i64 4
   %93 = bitcast i8* %92 to i16*
-  %NullCheck104 = icmp ne i16* %93, null
-  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+  %NullCheck103 = icmp eq i16* %93, null
+  br i1 %NullCheck103, label %ThrowNullRef104, label %94
 
 ; <label>:94                                      ; preds = %88
   %95 = load i16, i16* %93, align 8
   %96 = sext i16 %95 to i32
   %97 = bitcast i8* %90 to i16*
   %98 = trunc i32 %96 to i16
-  %NullCheck106 = icmp ne i16* %97, null
-  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+  %NullCheck105 = icmp eq i16* %97, null
+  br i1 %NullCheck105, label %ThrowNullRef106, label %99
 
 ; <label>:99                                      ; preds = %94
   store i16 %98, i16* %97, align 8
@@ -848,14 +930,14 @@ entry:
   %101 = load i8*, i8** %arg0
   %102 = load i8*, i8** %arg1
   %103 = bitcast i8* %102 to i32*
-  %NullCheck88 = icmp ne i32* %103, null
-  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+  %NullCheck87 = icmp eq i32* %103, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %104
 
 ; <label>:104                                     ; preds = %100
   %105 = load i32, i32* %103, align 8
   %106 = bitcast i8* %101 to i32*
-  %NullCheck90 = icmp ne i32* %106, null
-  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+  %NullCheck89 = icmp eq i32* %106, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %107
 
 ; <label>:107                                     ; preds = %104
   store i32 %105, i32* %106, align 8
@@ -864,16 +946,16 @@ entry:
   %110 = load i8*, i8** %arg1
   %111 = getelementptr inbounds i8, i8* %110, i64 4
   %112 = bitcast i8* %111 to i16*
-  %NullCheck92 = icmp ne i16* %112, null
-  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+  %NullCheck91 = icmp eq i16* %112, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %113
 
 ; <label>:113                                     ; preds = %107
   %114 = load i16, i16* %112, align 8
   %115 = sext i16 %114 to i32
   %116 = bitcast i8* %109 to i16*
   %117 = trunc i32 %115 to i16
-  %NullCheck94 = icmp ne i16* %116, null
-  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+  %NullCheck93 = icmp eq i16* %116, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %118
 
 ; <label>:118                                     ; preds = %113
   store i16 %117, i16* %116, align 8
@@ -881,15 +963,15 @@ entry:
   %120 = getelementptr inbounds i8, i8* %119, i64 6
   %121 = load i8*, i8** %arg1
   %122 = getelementptr inbounds i8, i8* %121, i64 6
-  %NullCheck96 = icmp ne i8* %122, null
-  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+  %NullCheck95 = icmp eq i8* %122, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %123
 
 ; <label>:123                                     ; preds = %118
   %124 = load i8, i8* %122, align 8
   %125 = zext i8 %124 to i32
   %126 = trunc i32 %125 to i8
-  %NullCheck98 = icmp ne i8* %120, null
-  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+  %NullCheck97 = icmp eq i8* %120, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %127
 
 ; <label>:127                                     ; preds = %123
   store i8 %126, i8* %120, align 8
@@ -899,14 +981,14 @@ entry:
   %129 = load i8*, i8** %arg0
   %130 = load i8*, i8** %arg1
   %131 = bitcast i8* %130 to i64*
-  %NullCheck84 = icmp ne i64* %131, null
-  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+  %NullCheck83 = icmp eq i64* %131, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %132
 
 ; <label>:132                                     ; preds = %128
   %133 = load i64, i64* %131, align 8
   %134 = bitcast i8* %129 to i64*
-  %NullCheck86 = icmp ne i64* %134, null
-  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+  %NullCheck85 = icmp eq i64* %134, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %135
 
 ; <label>:135                                     ; preds = %132
   store i64 %133, i64* %134, align 8
@@ -916,14 +998,14 @@ entry:
   %137 = load i8*, i8** %arg0
   %138 = load i8*, i8** %arg1
   %139 = bitcast i8* %138 to i64*
-  %NullCheck76 = icmp ne i64* %139, null
-  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+  %NullCheck75 = icmp eq i64* %139, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %140
 
 ; <label>:140                                     ; preds = %136
   %141 = load i64, i64* %139, align 8
   %142 = bitcast i8* %137 to i64*
-  %NullCheck78 = icmp ne i64* %142, null
-  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+  %NullCheck77 = icmp eq i64* %142, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %143
 
 ; <label>:143                                     ; preds = %140
   store i64 %141, i64* %142, align 8
@@ -931,15 +1013,15 @@ entry:
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %NullCheck80 = icmp ne i8* %147, null
-  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+  %NullCheck79 = icmp eq i8* %147, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %148
 
 ; <label>:148                                     ; preds = %143
   %149 = load i8, i8* %147, align 8
   %150 = zext i8 %149 to i32
   %151 = trunc i32 %150 to i8
-  %NullCheck82 = icmp ne i8* %145, null
-  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+  %NullCheck81 = icmp eq i8* %145, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %152
 
 ; <label>:152                                     ; preds = %148
   store i8 %151, i8* %145, align 8
@@ -949,14 +1031,14 @@ entry:
   %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
   %156 = bitcast i8* %155 to i64*
-  %NullCheck68 = icmp ne i64* %156, null
-  br i1 %NullCheck68, label %157, label %ThrowNullRef67
+  %NullCheck67 = icmp eq i64* %156, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %157
 
 ; <label>:157                                     ; preds = %153
   %158 = load i64, i64* %156, align 8
   %159 = bitcast i8* %154 to i64*
-  %NullCheck70 = icmp ne i64* %159, null
-  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+  %NullCheck69 = icmp eq i64* %159, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %160
 
 ; <label>:160                                     ; preds = %157
   store i64 %158, i64* %159, align 8
@@ -965,16 +1047,16 @@ entry:
   %163 = load i8*, i8** %arg1
   %164 = getelementptr inbounds i8, i8* %163, i64 8
   %165 = bitcast i8* %164 to i16*
-  %NullCheck72 = icmp ne i16* %165, null
-  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+  %NullCheck71 = icmp eq i16* %165, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %166
 
 ; <label>:166                                     ; preds = %160
   %167 = load i16, i16* %165, align 8
   %168 = sext i16 %167 to i32
   %169 = bitcast i8* %162 to i16*
   %170 = trunc i32 %168 to i16
-  %NullCheck74 = icmp ne i16* %169, null
-  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+  %NullCheck73 = icmp eq i16* %169, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %171
 
 ; <label>:171                                     ; preds = %166
   store i16 %170, i16* %169, align 8
@@ -984,14 +1066,14 @@ entry:
   %173 = load i8*, i8** %arg0
   %174 = load i8*, i8** %arg1
   %175 = bitcast i8* %174 to i64*
-  %NullCheck56 = icmp ne i64* %175, null
-  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+  %NullCheck55 = icmp eq i64* %175, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %176
 
 ; <label>:176                                     ; preds = %172
   %177 = load i64, i64* %175, align 8
   %178 = bitcast i8* %173 to i64*
-  %NullCheck58 = icmp ne i64* %178, null
-  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+  %NullCheck57 = icmp eq i64* %178, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %179
 
 ; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
@@ -1000,16 +1082,16 @@ entry:
   %182 = load i8*, i8** %arg1
   %183 = getelementptr inbounds i8, i8* %182, i64 8
   %184 = bitcast i8* %183 to i16*
-  %NullCheck60 = icmp ne i16* %184, null
-  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+  %NullCheck59 = icmp eq i16* %184, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %185
 
 ; <label>:185                                     ; preds = %179
   %186 = load i16, i16* %184, align 8
   %187 = sext i16 %186 to i32
   %188 = bitcast i8* %181 to i16*
   %189 = trunc i32 %187 to i16
-  %NullCheck62 = icmp ne i16* %188, null
-  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+  %NullCheck61 = icmp eq i16* %188, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %190
 
 ; <label>:190                                     ; preds = %185
   store i16 %189, i16* %188, align 8
@@ -1017,15 +1099,15 @@ entry:
   %192 = getelementptr inbounds i8, i8* %191, i64 10
   %193 = load i8*, i8** %arg1
   %194 = getelementptr inbounds i8, i8* %193, i64 10
-  %NullCheck64 = icmp ne i8* %194, null
-  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+  %NullCheck63 = icmp eq i8* %194, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %195
 
 ; <label>:195                                     ; preds = %190
   %196 = load i8, i8* %194, align 8
   %197 = zext i8 %196 to i32
   %198 = trunc i32 %197 to i8
-  %NullCheck66 = icmp ne i8* %192, null
-  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+  %NullCheck65 = icmp eq i8* %192, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %199
 
 ; <label>:199                                     ; preds = %195
   store i8 %198, i8* %192, align 8
@@ -1035,14 +1117,14 @@ entry:
   %201 = load i8*, i8** %arg0
   %202 = load i8*, i8** %arg1
   %203 = bitcast i8* %202 to i64*
-  %NullCheck48 = icmp ne i64* %203, null
-  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+  %NullCheck47 = icmp eq i64* %203, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %204
 
 ; <label>:204                                     ; preds = %200
   %205 = load i64, i64* %203, align 8
   %206 = bitcast i8* %201 to i64*
-  %NullCheck50 = icmp ne i64* %206, null
-  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+  %NullCheck49 = icmp eq i64* %206, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %207
 
 ; <label>:207                                     ; preds = %204
   store i64 %205, i64* %206, align 8
@@ -1051,14 +1133,14 @@ entry:
   %210 = load i8*, i8** %arg1
   %211 = getelementptr inbounds i8, i8* %210, i64 8
   %212 = bitcast i8* %211 to i32*
-  %NullCheck52 = icmp ne i32* %212, null
-  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+  %NullCheck51 = icmp eq i32* %212, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %213
 
 ; <label>:213                                     ; preds = %207
   %214 = load i32, i32* %212, align 8
   %215 = bitcast i8* %209 to i32*
-  %NullCheck54 = icmp ne i32* %215, null
-  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+  %NullCheck53 = icmp eq i32* %215, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %216
 
 ; <label>:216                                     ; preds = %213
   store i32 %214, i32* %215, align 8
@@ -1068,14 +1150,14 @@ entry:
   %218 = load i8*, i8** %arg0
   %219 = load i8*, i8** %arg1
   %220 = bitcast i8* %219 to i64*
-  %NullCheck36 = icmp ne i64* %220, null
-  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64* %220, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %221
 
 ; <label>:221                                     ; preds = %217
   %222 = load i64, i64* %220, align 8
   %223 = bitcast i8* %218 to i64*
-  %NullCheck38 = icmp ne i64* %223, null
-  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+  %NullCheck37 = icmp eq i64* %223, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %224
 
 ; <label>:224                                     ; preds = %221
   store i64 %222, i64* %223, align 8
@@ -1084,14 +1166,14 @@ entry:
   %227 = load i8*, i8** %arg1
   %228 = getelementptr inbounds i8, i8* %227, i64 8
   %229 = bitcast i8* %228 to i32*
-  %NullCheck40 = icmp ne i32* %229, null
-  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i32* %229, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %230
 
 ; <label>:230                                     ; preds = %224
   %231 = load i32, i32* %229, align 8
   %232 = bitcast i8* %226 to i32*
-  %NullCheck42 = icmp ne i32* %232, null
-  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+  %NullCheck41 = icmp eq i32* %232, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %233
 
 ; <label>:233                                     ; preds = %230
   store i32 %231, i32* %232, align 8
@@ -1099,15 +1181,15 @@ entry:
   %235 = getelementptr inbounds i8, i8* %234, i64 12
   %236 = load i8*, i8** %arg1
   %237 = getelementptr inbounds i8, i8* %236, i64 12
-  %NullCheck44 = icmp ne i8* %237, null
-  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i8* %237, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %238
 
 ; <label>:238                                     ; preds = %233
   %239 = load i8, i8* %237, align 8
   %240 = zext i8 %239 to i32
   %241 = trunc i32 %240 to i8
-  %NullCheck46 = icmp ne i8* %235, null
-  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+  %NullCheck45 = icmp eq i8* %235, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %242
 
 ; <label>:242                                     ; preds = %238
   store i8 %241, i8* %235, align 8
@@ -1117,14 +1199,14 @@ entry:
   %244 = load i8*, i8** %arg0
   %245 = load i8*, i8** %arg1
   %246 = bitcast i8* %245 to i64*
-  %NullCheck24 = icmp ne i64* %246, null
-  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64* %246, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %247
 
 ; <label>:247                                     ; preds = %243
   %248 = load i64, i64* %246, align 8
   %249 = bitcast i8* %244 to i64*
-  %NullCheck26 = icmp ne i64* %249, null
-  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64* %249, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %250
 
 ; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
@@ -1133,14 +1215,14 @@ entry:
   %253 = load i8*, i8** %arg1
   %254 = getelementptr inbounds i8, i8* %253, i64 8
   %255 = bitcast i8* %254 to i32*
-  %NullCheck28 = icmp ne i32* %255, null
-  br i1 %NullCheck28, label %256, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i32* %255, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %256
 
 ; <label>:256                                     ; preds = %250
   %257 = load i32, i32* %255, align 8
   %258 = bitcast i8* %252 to i32*
-  %NullCheck30 = icmp ne i32* %258, null
-  br i1 %NullCheck30, label %259, label %ThrowNullRef29
+  %NullCheck29 = icmp eq i32* %258, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %259
 
 ; <label>:259                                     ; preds = %256
   store i32 %257, i32* %258, align 8
@@ -1149,16 +1231,16 @@ entry:
   %262 = load i8*, i8** %arg1
   %263 = getelementptr inbounds i8, i8* %262, i64 12
   %264 = bitcast i8* %263 to i16*
-  %NullCheck32 = icmp ne i16* %264, null
-  br i1 %NullCheck32, label %265, label %ThrowNullRef31
+  %NullCheck31 = icmp eq i16* %264, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %265
 
 ; <label>:265                                     ; preds = %259
   %266 = load i16, i16* %264, align 8
   %267 = sext i16 %266 to i32
   %268 = bitcast i8* %261 to i16*
   %269 = trunc i32 %267 to i16
-  %NullCheck34 = icmp ne i16* %268, null
-  br i1 %NullCheck34, label %270, label %ThrowNullRef33
+  %NullCheck33 = icmp eq i16* %268, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %270
 
 ; <label>:270                                     ; preds = %265
   store i16 %269, i16* %268, align 8
@@ -1168,14 +1250,14 @@ entry:
   %272 = load i8*, i8** %arg0
   %273 = load i8*, i8** %arg1
   %274 = bitcast i8* %273 to i64*
-  %NullCheck8 = icmp ne i64* %274, null
-  br i1 %NullCheck8, label %275, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64* %274, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %275
 
 ; <label>:275                                     ; preds = %271
   %276 = load i64, i64* %274, align 8
   %277 = bitcast i8* %272 to i64*
-  %NullCheck10 = icmp ne i64* %277, null
-  br i1 %NullCheck10, label %278, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %277, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %278
 
 ; <label>:278                                     ; preds = %275
   store i64 %276, i64* %277, align 8
@@ -1184,14 +1266,14 @@ entry:
   %281 = load i8*, i8** %arg1
   %282 = getelementptr inbounds i8, i8* %281, i64 8
   %283 = bitcast i8* %282 to i32*
-  %NullCheck12 = icmp ne i32* %283, null
-  br i1 %NullCheck12, label %284, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i32* %283, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %284
 
 ; <label>:284                                     ; preds = %278
   %285 = load i32, i32* %283, align 8
   %286 = bitcast i8* %280 to i32*
-  %NullCheck14 = icmp ne i32* %286, null
-  br i1 %NullCheck14, label %287, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i32* %286, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %287
 
 ; <label>:287                                     ; preds = %284
   store i32 %285, i32* %286, align 8
@@ -1200,16 +1282,16 @@ entry:
   %290 = load i8*, i8** %arg1
   %291 = getelementptr inbounds i8, i8* %290, i64 12
   %292 = bitcast i8* %291 to i16*
-  %NullCheck16 = icmp ne i16* %292, null
-  br i1 %NullCheck16, label %293, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i16* %292, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %293
 
 ; <label>:293                                     ; preds = %287
   %294 = load i16, i16* %292, align 8
   %295 = sext i16 %294 to i32
   %296 = bitcast i8* %289 to i16*
   %297 = trunc i32 %295 to i16
-  %NullCheck18 = icmp ne i16* %296, null
-  br i1 %NullCheck18, label %298, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i16* %296, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %298
 
 ; <label>:298                                     ; preds = %293
   store i16 %297, i16* %296, align 8
@@ -1217,15 +1299,15 @@ entry:
   %300 = getelementptr inbounds i8, i8* %299, i64 14
   %301 = load i8*, i8** %arg1
   %302 = getelementptr inbounds i8, i8* %301, i64 14
-  %NullCheck20 = icmp ne i8* %302, null
-  br i1 %NullCheck20, label %303, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i8* %302, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %303
 
 ; <label>:303                                     ; preds = %298
   %304 = load i8, i8* %302, align 8
   %305 = zext i8 %304 to i32
   %306 = trunc i32 %305 to i8
-  %NullCheck22 = icmp ne i8* %300, null
-  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i8* %300, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %307
 
 ; <label>:307                                     ; preds = %303
   store i8 %306, i8* %300, align 8
@@ -1235,14 +1317,14 @@ entry:
   %309 = load i8*, i8** %arg0
   %310 = load i8*, i8** %arg1
   %311 = bitcast i8* %310 to i64*
-  %NullCheck = icmp ne i64* %311, null
-  br i1 %NullCheck, label %312, label %ThrowNullRef
+  %NullCheck = icmp eq i64* %311, null
+  br i1 %NullCheck, label %ThrowNullRef, label %312
 
 ; <label>:312                                     ; preds = %308
   %313 = load i64, i64* %311, align 8
   %314 = bitcast i8* %309 to i64*
-  %NullCheck2 = icmp ne i64* %314, null
-  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64* %314, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %315
 
 ; <label>:315                                     ; preds = %312
   store i64 %313, i64* %314, align 8
@@ -1251,14 +1333,14 @@ entry:
   %318 = load i8*, i8** %arg1
   %319 = getelementptr inbounds i8, i8* %318, i64 8
   %320 = bitcast i8* %319 to i64*
-  %NullCheck4 = icmp ne i64* %320, null
-  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64* %320, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %321
 
 ; <label>:321                                     ; preds = %315
   %322 = load i64, i64* %320, align 8
   %323 = bitcast i8* %317 to i64*
-  %NullCheck6 = icmp ne i64* %323, null
-  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64* %323, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %324
 
 ; <label>:324                                     ; preds = %321
   store i64 %322, i64* %323, align 8
@@ -1286,15 +1368,15 @@ entry:
 ; <label>:338                                     ; preds = %333
   %339 = load i8*, i8** %arg0
   %340 = load i8*, i8** %arg1
-  %NullCheck136 = icmp ne i8* %340, null
-  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+  %NullCheck135 = icmp eq i8* %340, null
+  br i1 %NullCheck135, label %ThrowNullRef136, label %341
 
 ; <label>:341                                     ; preds = %338
   %342 = load i8, i8* %340, align 8
   %343 = zext i8 %342 to i32
   %344 = trunc i32 %343 to i8
-  %NullCheck138 = icmp ne i8* %339, null
-  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+  %NullCheck137 = icmp eq i8* %339, null
+  br i1 %NullCheck137, label %ThrowNullRef138, label %345
 
 ; <label>:345                                     ; preds = %341
   store i8 %344, i8* %339, align 8
@@ -1317,16 +1399,16 @@ entry:
   %357 = load i8*, i8** %arg0
   %358 = load i8*, i8** %arg1
   %359 = bitcast i8* %358 to i16*
-  %NullCheck140 = icmp ne i16* %359, null
-  br i1 %NullCheck140, label %360, label %ThrowNullRef139
+  %NullCheck139 = icmp eq i16* %359, null
+  br i1 %NullCheck139, label %ThrowNullRef140, label %360
 
 ; <label>:360                                     ; preds = %356
   %361 = load i16, i16* %359, align 8
   %362 = sext i16 %361 to i32
   %363 = bitcast i8* %357 to i16*
   %364 = trunc i32 %362 to i16
-  %NullCheck142 = icmp ne i16* %363, null
-  br i1 %NullCheck142, label %365, label %ThrowNullRef141
+  %NullCheck141 = icmp eq i16* %363, null
+  br i1 %NullCheck141, label %ThrowNullRef142, label %365
 
 ; <label>:365                                     ; preds = %360
   store i16 %364, i16* %363, align 8
@@ -1352,14 +1434,14 @@ entry:
   %378 = load i8*, i8** %arg0
   %379 = load i8*, i8** %arg1
   %380 = bitcast i8* %379 to i32*
-  %NullCheck144 = icmp ne i32* %380, null
-  br i1 %NullCheck144, label %381, label %ThrowNullRef143
+  %NullCheck143 = icmp eq i32* %380, null
+  br i1 %NullCheck143, label %ThrowNullRef144, label %381
 
 ; <label>:381                                     ; preds = %377
   %382 = load i32, i32* %380, align 8
   %383 = bitcast i8* %378 to i32*
-  %NullCheck146 = icmp ne i32* %383, null
-  br i1 %NullCheck146, label %384, label %ThrowNullRef145
+  %NullCheck145 = icmp eq i32* %383, null
+  br i1 %NullCheck145, label %ThrowNullRef146, label %384
 
 ; <label>:384                                     ; preds = %381
   store i32 %382, i32* %383, align 8
@@ -1384,14 +1466,14 @@ entry:
   %395 = load i8*, i8** %arg0
   %396 = load i8*, i8** %arg1
   %397 = bitcast i8* %396 to i64*
-  %NullCheck164 = icmp ne i64* %397, null
-  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+  %NullCheck163 = icmp eq i64* %397, null
+  br i1 %NullCheck163, label %ThrowNullRef164, label %398
 
 ; <label>:398                                     ; preds = %394
   %399 = load i64, i64* %397, align 8
   %400 = bitcast i8* %395 to i64*
-  %NullCheck166 = icmp ne i64* %400, null
-  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+  %NullCheck165 = icmp eq i64* %400, null
+  br i1 %NullCheck165, label %ThrowNullRef166, label %401
 
 ; <label>:401                                     ; preds = %398
   store i64 %399, i64* %400, align 8
@@ -1400,14 +1482,14 @@ entry:
   %404 = load i8*, i8** %arg1
   %405 = getelementptr inbounds i8, i8* %404, i64 8
   %406 = bitcast i8* %405 to i64*
-  %NullCheck168 = icmp ne i64* %406, null
-  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+  %NullCheck167 = icmp eq i64* %406, null
+  br i1 %NullCheck167, label %ThrowNullRef168, label %407
 
 ; <label>:407                                     ; preds = %401
   %408 = load i64, i64* %406, align 8
   %409 = bitcast i8* %403 to i64*
-  %NullCheck170 = icmp ne i64* %409, null
-  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+  %NullCheck169 = icmp eq i64* %409, null
+  br i1 %NullCheck169, label %ThrowNullRef170, label %410
 
 ; <label>:410                                     ; preds = %407
   store i64 %408, i64* %409, align 8
@@ -1437,14 +1519,14 @@ entry:
   %425 = load i8*, i8** %arg0
   %426 = load i8*, i8** %arg1
   %427 = bitcast i8* %426 to i64*
-  %NullCheck148 = icmp ne i64* %427, null
-  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+  %NullCheck147 = icmp eq i64* %427, null
+  br i1 %NullCheck147, label %ThrowNullRef148, label %428
 
 ; <label>:428                                     ; preds = %424
   %429 = load i64, i64* %427, align 8
   %430 = bitcast i8* %425 to i64*
-  %NullCheck150 = icmp ne i64* %430, null
-  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+  %NullCheck149 = icmp eq i64* %430, null
+  br i1 %NullCheck149, label %ThrowNullRef150, label %431
 
 ; <label>:431                                     ; preds = %428
   store i64 %429, i64* %430, align 8
@@ -1466,14 +1548,14 @@ entry:
   %441 = load i8*, i8** %arg0
   %442 = load i8*, i8** %arg1
   %443 = bitcast i8* %442 to i32*
-  %NullCheck152 = icmp ne i32* %443, null
-  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+  %NullCheck151 = icmp eq i32* %443, null
+  br i1 %NullCheck151, label %ThrowNullRef152, label %444
 
 ; <label>:444                                     ; preds = %440
   %445 = load i32, i32* %443, align 8
   %446 = bitcast i8* %441 to i32*
-  %NullCheck154 = icmp ne i32* %446, null
-  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+  %NullCheck153 = icmp eq i32* %446, null
+  br i1 %NullCheck153, label %ThrowNullRef154, label %447
 
 ; <label>:447                                     ; preds = %444
   store i32 %445, i32* %446, align 8
@@ -1495,16 +1577,16 @@ entry:
   %457 = load i8*, i8** %arg0
   %458 = load i8*, i8** %arg1
   %459 = bitcast i8* %458 to i16*
-  %NullCheck156 = icmp ne i16* %459, null
-  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+  %NullCheck155 = icmp eq i16* %459, null
+  br i1 %NullCheck155, label %ThrowNullRef156, label %460
 
 ; <label>:460                                     ; preds = %456
   %461 = load i16, i16* %459, align 8
   %462 = sext i16 %461 to i32
   %463 = bitcast i8* %457 to i16*
   %464 = trunc i32 %462 to i16
-  %NullCheck158 = icmp ne i16* %463, null
-  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+  %NullCheck157 = icmp eq i16* %463, null
+  br i1 %NullCheck157, label %ThrowNullRef158, label %465
 
 ; <label>:465                                     ; preds = %460
   store i16 %464, i16* %463, align 8
@@ -1525,15 +1607,15 @@ entry:
 ; <label>:474                                     ; preds = %470
   %475 = load i8*, i8** %arg0
   %476 = load i8*, i8** %arg1
-  %NullCheck160 = icmp ne i8* %476, null
-  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+  %NullCheck159 = icmp eq i8* %476, null
+  br i1 %NullCheck159, label %ThrowNullRef160, label %477
 
 ; <label>:477                                     ; preds = %474
   %478 = load i8, i8* %476, align 8
   %479 = zext i8 %478 to i32
   %480 = trunc i32 %479 to i8
-  %NullCheck162 = icmp ne i8* %475, null
-  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+  %NullCheck161 = icmp eq i8* %475, null
+  br i1 %NullCheck161, label %ThrowNullRef162, label %481
 
 ; <label>:481                                     ; preds = %477
   store i8 %480, i8* %475, align 8
@@ -1553,343 +1635,343 @@ ThrowNullRef:                                     ; preds = %308
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %312
+ThrowNullRef2:                                    ; preds = %312
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %315
+ThrowNullRef4:                                    ; preds = %315
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %321
+ThrowNullRef6:                                    ; preds = %321
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %271
+ThrowNullRef8:                                    ; preds = %271
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %275
+ThrowNullRef10:                                   ; preds = %275
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %278
+ThrowNullRef12:                                   ; preds = %278
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %284
+ThrowNullRef14:                                   ; preds = %284
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %287
+ThrowNullRef16:                                   ; preds = %287
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %293
+ThrowNullRef18:                                   ; preds = %293
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %298
+ThrowNullRef20:                                   ; preds = %298
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %303
+ThrowNullRef22:                                   ; preds = %303
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %243
+ThrowNullRef24:                                   ; preds = %243
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %247
+ThrowNullRef26:                                   ; preds = %247
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %250
+ThrowNullRef28:                                   ; preds = %250
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %256
+ThrowNullRef30:                                   ; preds = %256
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %259
+ThrowNullRef32:                                   ; preds = %259
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %265
+ThrowNullRef34:                                   ; preds = %265
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %217
+ThrowNullRef36:                                   ; preds = %217
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %221
+ThrowNullRef38:                                   ; preds = %221
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %224
+ThrowNullRef40:                                   ; preds = %224
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %230
+ThrowNullRef42:                                   ; preds = %230
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %233
+ThrowNullRef44:                                   ; preds = %233
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %238
+ThrowNullRef46:                                   ; preds = %238
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %200
+ThrowNullRef48:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %204
+ThrowNullRef50:                                   ; preds = %204
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %207
+ThrowNullRef52:                                   ; preds = %207
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %213
+ThrowNullRef54:                                   ; preds = %213
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %172
+ThrowNullRef56:                                   ; preds = %172
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %176
+ThrowNullRef58:                                   ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %179
+ThrowNullRef60:                                   ; preds = %179
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %185
+ThrowNullRef62:                                   ; preds = %185
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %190
+ThrowNullRef64:                                   ; preds = %190
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %195
+ThrowNullRef66:                                   ; preds = %195
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %153
+ThrowNullRef68:                                   ; preds = %153
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %157
+ThrowNullRef70:                                   ; preds = %157
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %160
+ThrowNullRef72:                                   ; preds = %160
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %166
+ThrowNullRef74:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %136
+ThrowNullRef76:                                   ; preds = %136
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %140
+ThrowNullRef78:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %143
+ThrowNullRef80:                                   ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %148
+ThrowNullRef82:                                   ; preds = %148
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %128
+ThrowNullRef84:                                   ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %132
+ThrowNullRef86:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %100
+ThrowNullRef88:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %104
+ThrowNullRef90:                                   ; preds = %104
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %107
+ThrowNullRef92:                                   ; preds = %107
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %113
+ThrowNullRef94:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %118
+ThrowNullRef96:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %123
+ThrowNullRef98:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %81
+ThrowNullRef100:                                  ; preds = %81
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef101:                                  ; preds = %85
+ThrowNullRef102:                                  ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef103:                                  ; preds = %88
+ThrowNullRef104:                                  ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef105:                                  ; preds = %94
+ThrowNullRef106:                                  ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef107:                                  ; preds = %64
+ThrowNullRef108:                                  ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef109:                                  ; preds = %68
+ThrowNullRef110:                                  ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef111:                                  ; preds = %71
+ThrowNullRef112:                                  ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef113:                                  ; preds = %76
+ThrowNullRef114:                                  ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef115:                                  ; preds = %56
+ThrowNullRef116:                                  ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef117:                                  ; preds = %60
+ThrowNullRef118:                                  ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef119:                                  ; preds = %37
+ThrowNullRef120:                                  ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef121:                                  ; preds = %41
+ThrowNullRef122:                                  ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef123:                                  ; preds = %46
+ThrowNullRef124:                                  ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef125:                                  ; preds = %51
+ThrowNullRef126:                                  ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef127:                                  ; preds = %27
+ThrowNullRef128:                                  ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef129:                                  ; preds = %31
+ThrowNullRef130:                                  ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef131:                                  ; preds = %19
+ThrowNullRef132:                                  ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef133:                                  ; preds = %22
+ThrowNullRef134:                                  ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef135:                                  ; preds = %338
+ThrowNullRef136:                                  ; preds = %338
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef137:                                  ; preds = %341
+ThrowNullRef138:                                  ; preds = %341
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef139:                                  ; preds = %356
+ThrowNullRef140:                                  ; preds = %356
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef141:                                  ; preds = %360
+ThrowNullRef142:                                  ; preds = %360
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef143:                                  ; preds = %377
+ThrowNullRef144:                                  ; preds = %377
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef145:                                  ; preds = %381
+ThrowNullRef146:                                  ; preds = %381
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef147:                                  ; preds = %424
+ThrowNullRef148:                                  ; preds = %424
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef149:                                  ; preds = %428
+ThrowNullRef150:                                  ; preds = %428
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef151:                                  ; preds = %440
+ThrowNullRef152:                                  ; preds = %440
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef153:                                  ; preds = %444
+ThrowNullRef154:                                  ; preds = %444
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef155:                                  ; preds = %456
+ThrowNullRef156:                                  ; preds = %456
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef157:                                  ; preds = %460
+ThrowNullRef158:                                  ; preds = %460
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef159:                                  ; preds = %474
+ThrowNullRef160:                                  ; preds = %474
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef161:                                  ; preds = %477
+ThrowNullRef162:                                  ; preds = %477
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef163:                                  ; preds = %394
+ThrowNullRef164:                                  ; preds = %394
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef165:                                  ; preds = %398
+ThrowNullRef166:                                  ; preds = %398
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef167:                                  ; preds = %401
+ThrowNullRef168:                                  ; preds = %401
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef169:                                  ; preds = %407
+ThrowNullRef170:                                  ; preds = %407
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1939,8 +2021,8 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
-  br i1 %NullCheck, label %22, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %ThrowNullRef, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
@@ -1948,8 +2030,8 @@ entry:
   store i32 %24, i32* %loc0
   %25 = load i32, i32* %loc0
   %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %26, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %27
 
 ; <label>:27                                      ; preds = %22
   %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
@@ -1971,7 +2053,7 @@ ThrowNullRef:                                     ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1989,8 +2071,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -2022,15 +2104,15 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2048,16 +2130,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
   %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
   store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %15
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
@@ -2072,8 +2154,8 @@ entry:
   %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
   %29 = ptrtoint i16 addrspace(1)* %28 to i64
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %19
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
@@ -2089,19 +2171,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2114,8 +2196,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
@@ -2128,7 +2210,7 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[loadElem]
+Failed to read AppDomain.PrepareDataForSetup[storeElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
@@ -2202,8 +2284,8 @@ entry:
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
-  br i1 %NullCheck24, label %27, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = load i64, i64 addrspace(1)* %26
@@ -2218,8 +2300,8 @@ entry:
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
-  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
   %41 = load i64, i64 addrspace(1)* %39
@@ -2236,8 +2318,8 @@ entry:
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
-  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
   %54 = load i64, i64 addrspace(1)* %52
@@ -2252,8 +2334,8 @@ entry:
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
   %67 = load i64, i64 addrspace(1)* %65
@@ -2270,8 +2352,8 @@ entry:
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
-  br i1 %NullCheck16, label %79, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
   %80 = load i64, i64 addrspace(1)* %78
@@ -2286,8 +2368,8 @@ entry:
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
-  br i1 %NullCheck18, label %92, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
   %93 = load i64, i64 addrspace(1)* %91
@@ -2304,8 +2386,8 @@ entry:
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
-  br i1 %NullCheck12, label %105, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = load i64, i64 addrspace(1)* %104
@@ -2320,8 +2402,8 @@ entry:
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
-  br i1 %NullCheck14, label %118, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
   %119 = load i64, i64 addrspace(1)* %117
@@ -2337,8 +2419,8 @@ entry:
 
 ; <label>:128                                     ; preds = %20
   %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
-  br i1 %NullCheck4, label %130, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %129, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %130
 
 ; <label>:130                                     ; preds = %128
   %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
@@ -2346,8 +2428,8 @@ entry:
   %133 = load i16, i16 addrspace(1)* %132, align 8
   %134 = zext i16 %133 to i32
   %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
-  br i1 %NullCheck6, label %136, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %135, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %136
 
 ; <label>:136                                     ; preds = %130
   %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
@@ -2360,8 +2442,8 @@ entry:
 
 ; <label>:143                                     ; preds = %136
   %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
-  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %144, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %145
 
 ; <label>:145                                     ; preds = %143
   %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
@@ -2369,8 +2451,8 @@ entry:
   %148 = load i16, i16 addrspace(1)* %147, align 8
   %149 = zext i16 %148 to i32
   %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %150, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %151
 
 ; <label>:151                                     ; preds = %145
   %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
@@ -2388,8 +2470,8 @@ entry:
 
 ; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
-  br i1 %NullCheck, label %163, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %ThrowNullRef, label %163
 
 ; <label>:163                                     ; preds = %161
   %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
@@ -2399,8 +2481,8 @@ entry:
 
 ; <label>:167                                     ; preds = %163
   %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
-  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %168, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %169
 
 ; <label>:169                                     ; preds = %167
   %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
@@ -2432,55 +2514,55 @@ ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %167
+ThrowNullRef2:                                    ; preds = %167
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %128
+ThrowNullRef4:                                    ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %130
+ThrowNullRef6:                                    ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %143
+ThrowNullRef8:                                    ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %145
+ThrowNullRef10:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %102
+ThrowNullRef12:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %105
+ThrowNullRef14:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %76
+ThrowNullRef16:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %79
+ThrowNullRef18:                                   ; preds = %79
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %50
+ThrowNullRef20:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %53
+ThrowNullRef22:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %24
+ThrowNullRef24:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %27
+ThrowNullRef26:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2503,15 +2585,15 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2519,16 +2601,16 @@ entry:
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
   store i32 %8, i32* %loc0
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
   %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
   store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
@@ -2546,16 +2628,16 @@ entry:
 
 ; <label>:23                                      ; preds = %64
   %24 = load i16*, i16** %loc3
-  %NullCheck12 = icmp ne i16* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i16* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
   store i32 %27, i32* %loc5
   %28 = load i16*, i16** %loc4
-  %NullCheck14 = icmp ne i16* %28, null
-  br i1 %NullCheck14, label %29, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %28, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = load i16, i16* %28, align 8
@@ -2620,15 +2702,15 @@ entry:
 
 ; <label>:67                                      ; preds = %64
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
-  br i1 %NullCheck8, label %69, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %68, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %69
 
 ; <label>:69                                      ; preds = %67
   %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
   %71 = load i32, i32 addrspace(1)* %70
   %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
-  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %73
 
 ; <label>:73                                      ; preds = %69
   %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
@@ -2645,31 +2727,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %67
+ThrowNullRef8:                                    ; preds = %67
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %69
+ThrowNullRef10:                                   ; preds = %69
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2710,14 +2792,14 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
   %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
@@ -2730,14 +2812,14 @@ entry:
 
 ; <label>:11                                      ; preds = %4
   %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
   %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
@@ -2749,14 +2831,14 @@ entry:
 
 ; <label>:22                                      ; preds = %16
   %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
   %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
-  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
-  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
@@ -2804,23 +2886,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2836,7 +2918,280 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[loadElem]
+Successfully read RuntimeType.IsAssignableFrom
+
+define i8 @RuntimeType.IsAssignableFrom(%System.RuntimeType addrspace(1)* %param0, %System.Type addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.RuntimeType addrspace(1)*
+  %arg1 = alloca %System.Type addrspace(1)*
+  %loc0 = alloca %System.RuntimeType addrspace(1)*
+  %loc1 = alloca %"System.Type[]" addrspace(1)*
+  %loc2 = alloca i32
+  store %System.RuntimeType addrspace(1)* %param0, %System.RuntimeType addrspace(1)** %this
+  store %System.Type addrspace(1)* %param1, %System.Type addrspace(1)** %arg1
+  %0 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %1 = icmp ne %System.Type addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i8 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %5 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %6 = bitcast %System.Type addrspace(1)* %4 to %System.Object addrspace(1)*
+  %7 = bitcast %System.RuntimeType addrspace(1)* %5 to %System.Object addrspace(1)*
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %6, %System.Object addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %3
+  ret i8 1
+
+; <label>:12                                      ; preds = %3
+  %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 152
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 32
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
+  %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
+  %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
+  store %System.RuntimeType addrspace(1)* %25, %System.RuntimeType addrspace(1)** %loc0
+  %26 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %27 = icmp eq %System.RuntimeType addrspace(1)* %26, null
+  br i1 %27, label %34, label %28
+
+; <label>:28                                      ; preds = %15
+  %29 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %30 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)*)*)(%System.RuntimeType addrspace(1)* %29, %System.RuntimeType addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+; <label>:34                                      ; preds = %15
+  %35 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %36 = call %System.Reflection.Emit.TypeBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Reflection.Emit.TypeBuilder addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %35)
+  %37 = icmp eq %System.Reflection.Emit.TypeBuilder addrspace(1)* %36, null
+  br i1 %37, label %139, label %38
+
+; <label>:38                                      ; preds = %34
+  %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %42
+
+; <label>:42                                      ; preds = %38
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 152
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 40
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
+  %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
+  %53 = zext i8 %52 to i32
+  %54 = icmp eq i32 %53, 0
+  br i1 %54, label %56, label %55
+
+; <label>:55                                      ; preds = %42
+  ret i8 1
+
+; <label>:56                                      ; preds = %42
+  %57 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %58 = bitcast %System.RuntimeType addrspace(1)* %57 to %System.Type addrspace(1)*
+  %59 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %58)
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %64 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.Type addrspace(1)* %63, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = bitcast %System.RuntimeType addrspace(1)* %64 to %System.Type addrspace(1)*
+  %67 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %63, %System.Type addrspace(1)* %66)
+  %68 = zext i8 %67 to i32
+  %69 = trunc i32 %68 to i8
+  ret i8 %69
+
+; <label>:70                                      ; preds = %56
+  %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
+  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %73
+
+; <label>:73                                      ; preds = %70
+  %74 = load i64, i64 addrspace(1)* %72
+  %75 = add i64 %74, 128
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = add i64 %77, 0
+  %79 = inttoptr i64 %78 to i64*
+  %80 = load i64, i64* %79
+  %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
+  %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
+  %83 = call i8 %82(%System.Type addrspace(1)* %81)
+  %84 = zext i8 %83 to i32
+  %85 = icmp eq i32 %84, 0
+  br i1 %85, label %139, label %86
+
+; <label>:86                                      ; preds = %73
+  %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
+  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %89
+
+; <label>:89                                      ; preds = %86
+  %90 = load i64, i64 addrspace(1)* %88
+  %91 = add i64 %90, 128
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = add i64 %93, 24
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
+  %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
+  %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
+  store %"System.Type[]" addrspace(1)* %99, %"System.Type[]" addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %129
+
+; <label>:100                                     ; preds = %132
+  %101 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %102 = load i32, i32* %loc2
+  %NullCheck11 = icmp eq %"System.Type[]" addrspace(1)* %101, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %103
+
+; <label>:103                                     ; preds = %100
+  %104 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 1
+  %105 = load i32, i32 addrspace(1)* %104
+  %106 = zext i32 %105 to i64
+  %107 = zext i32 %102 to i64
+  %BoundsCheck = icmp uge i64 %107, %106
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %108
+
+; <label>:108                                     ; preds = %103
+  %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
+  %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
+  %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
+  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %113
+
+; <label>:113                                     ; preds = %108
+  %114 = load i64, i64 addrspace(1)* %112
+  %115 = add i64 %114, 152
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = add i64 %117, 56
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
+  %123 = zext i8 %122 to i32
+  %124 = icmp ne i32 %123, 0
+  br i1 %124, label %126, label %125
+
+; <label>:125                                     ; preds = %113
+  ret i8 0
+
+; <label>:126                                     ; preds = %113
+  %127 = load i32, i32* %loc2
+  %128 = add i32 %127, 1
+  store i32 %128, i32* %loc2
+  br label %129
+
+; <label>:129                                     ; preds = %89, %126
+  %130 = load i32, i32* %loc2
+  %131 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %NullCheck9 = icmp eq %"System.Type[]" addrspace(1)* %131, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %132
+
+; <label>:132                                     ; preds = %129
+  %133 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %131, i32 0, i32 1
+  %134 = load i32, i32 addrspace(1)* %133
+  %135 = zext i32 %134 to i64
+  %136 = trunc i64 %135 to i32
+  %137 = icmp slt i32 %130, %136
+  br i1 %137, label %100, label %138
+
+; <label>:138                                     ; preds = %132
+  ret i8 1
+
+; <label>:139                                     ; preds = %34, %73
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %129
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %103
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -2893,7 +3248,7 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElem]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -2904,8 +3259,8 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -2997,8 +3352,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
@@ -3059,8 +3414,8 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -3087,8 +3442,8 @@ entry:
 
 ; <label>:17                                      ; preds = %5, %11
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
@@ -3097,8 +3452,8 @@ entry:
 
 ; <label>:22                                      ; preds = %1, %11
   %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
@@ -3109,11 +3464,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %17
+ThrowNullRef2:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %22
+ThrowNullRef4:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3167,15 +3522,15 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
   %15 = load i32, i32 addrspace(1)* %14
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
@@ -3198,7 +3553,7 @@ ThrowNullRef:                                     ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef2:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3232,8 +3587,8 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
@@ -3312,8 +3667,8 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -3327,8 +3682,8 @@ entry:
 ; <label>:5                                       ; preds = %43
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %7 = load i32, i32* %loc1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck6, label %8, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
@@ -3366,8 +3721,8 @@ entry:
 ; <label>:32                                      ; preds = %21, %25
   %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
   %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
-  br i1 %NullCheck8, label %35, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = trunc i32 %34 to i16
@@ -3380,8 +3735,8 @@ entry:
 ; <label>:40                                      ; preds = %1, %35
   %41 = load i32, i32* %loc1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
-  br i1 %NullCheck2, label %43, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %42, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
@@ -3392,8 +3747,8 @@ entry:
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
   %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
-  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
   %51 = load i64, i64 addrspace(1)* %49
@@ -3412,19 +3767,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %40
+ThrowNullRef2:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %47
+ThrowNullRef4:                                    ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %5
+ThrowNullRef6:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %32
+ThrowNullRef8:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3467,8 +3822,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
@@ -3492,11 +3847,391 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(i16* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store i16* %param0, i16** %arg0
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load i32, i32* %arg3
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %42, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %37, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg2
+  %13 = load i32, i32* %arg3
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %37, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %24 = load i32, i32* %arg2
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load i16*, i16** %arg0
+  %35 = load i32, i32* %arg3
+  %36 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %36, i16* %34, i32 %35)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:37                                      ; preds = %5, %16
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %39)
+  %41 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41, %System.String addrspace(1)* %38, %System.String addrspace(1)* %40)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41) #0
+  unreachable
+
+; <label>:42                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
-Failed to read StringBuilder.ToString[loadElemA]
+Successfully read StringBuilder.ToString
+
+define %System.String addrspace(1)* @StringBuilder.ToString(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i16*
+  %loc3 = alloca %"System.Char[]" addrspace(1)*
+  %loc4 = alloca i32
+  %loc5 = alloca i32
+  %loc6 = alloca i16 addrspace(1)*
+  %loc7 = alloca %System.String addrspace(1)*
+  %loc8 = alloca %"System.Char[]" addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %0)
+  %2 = icmp ne i32 %1, 0
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %4
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %6)
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %7)
+  store %System.String addrspace(1)* %8, %System.String addrspace(1)** %loc0
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.Text.StringBuilder addrspace(1)* %9, %System.Text.StringBuilder addrspace(1)** %loc1
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  store %System.String addrspace(1)* %10, %System.String addrspace(1)** %loc7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc7
+  %12 = ptrtoint %System.String addrspace(1)* %11 to i64
+  %13 = icmp eq i64 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %5
+  %15 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %16 = sext i32 %15 to i64
+  %17 = add i64 %12, %16
+  br label %18
+
+; <label>:18                                      ; preds = %5, %14
+  %19 = phi i64 [ %12, %5 ], [ %17, %14 ]
+  %20 = inttoptr i64 %19 to i16*
+  store i16* %20, i16** %loc2
+  br label %21
+
+; <label>:21                                      ; preds = %98, %18
+  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %22, null
+  br i1 %NullCheck, label %ThrowNullRef, label %23
+
+; <label>:23                                      ; preds = %21
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 3
+  %25 = load i32, i32 addrspace(1)* %24, align 8
+  %26 = icmp sle i32 %25, 0
+  br i1 %26, label %96, label %27
+
+; <label>:27                                      ; preds = %23
+  %28 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %28, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %29
+
+; <label>:29                                      ; preds = %27
+  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %28, i32 0, i32 1
+  %31 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %30, align 8
+  store %"System.Char[]" addrspace(1)* %31, %"System.Char[]" addrspace(1)** %loc3
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %33
+
+; <label>:33                                      ; preds = %29
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  store i32 %35, i32* %loc4
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  %39 = load i32, i32 addrspace(1)* %38, align 8
+  store i32 %39, i32* %loc5
+  %40 = load i32, i32* %loc5
+  %41 = load i32, i32* %loc4
+  %42 = add i32 %40, %41
+  %43 = zext i32 %42 to i64
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %45
+
+; <label>:45                                      ; preds = %37
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = sext i32 %47 to i64
+  %49 = icmp sgt i64 %43, %48
+  br i1 %49, label %91, label %50
+
+; <label>:50                                      ; preds = %45
+  %51 = load i32, i32* %loc5
+  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %52, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %53
+
+; <label>:53                                      ; preds = %50
+  %54 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %52, i32 0, i32 1
+  %55 = load i32, i32 addrspace(1)* %54
+  %56 = zext i32 %55 to i64
+  %57 = trunc i64 %56 to i32
+  %58 = icmp ugt i32 %51, %57
+  br i1 %58, label %91, label %59
+
+; <label>:59                                      ; preds = %53
+  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  store %"System.Char[]" addrspace(1)* %60, %"System.Char[]" addrspace(1)** %loc8
+  %61 = icmp eq %"System.Char[]" addrspace(1)* %60, null
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %63, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %64
+
+; <label>:64                                      ; preds = %62
+  %65 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %63, i32 0, i32 1
+  %66 = load i32, i32 addrspace(1)* %65
+  %67 = zext i32 %66 to i64
+  %68 = trunc i64 %67 to i32
+  %69 = icmp ne i32 %68, 0
+  br i1 %69, label %71, label %70
+
+; <label>:70                                      ; preds = %59, %64
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:71                                      ; preds = %64
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %73
+
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %BoundsCheck = icmp uge i64 0, %76
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %77
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %78, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:79                                      ; preds = %70, %77
+  %80 = load i16*, i16** %loc2
+  %81 = load i32, i32* %loc4
+  %82 = sext i32 %81 to i64
+  %83 = mul i64 %82, 2
+  %84 = bitcast i16* %80 to i8*
+  %85 = getelementptr inbounds i8, i8* %84, i64 %83
+  %86 = load i16 addrspace(1)*, i16 addrspace(1)** %loc6
+  %87 = ptrtoint i16 addrspace(1)* %86 to i64
+  %88 = load i32, i32* %loc5
+  %89 = bitcast i8* %85 to i16*
+  %90 = inttoptr i64 %87 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %89, i16* %90, i32 %88)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %96
+
+; <label>:91                                      ; preds = %45, %53
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %94 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %93)
+  %95 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95, %System.String addrspace(1)* %92, %System.String addrspace(1)* %94)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95) #0
+  unreachable
+
+; <label>:96                                      ; preds = %23, %79
+  %97 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %97, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %98
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %97, i32 0, i32 2
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  store %System.Text.StringBuilder addrspace(1)* %100, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %102 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %102, label %21, label %103
+
+; <label>:103                                     ; preds = %98
+  store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc7
+  %104 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  ret %System.String addrspace(1)* %104
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method StringBuilder::get_Length using LLILCJit
+Successfully read StringBuilder.get_Length
+
+define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
+Successfully read RuntimeHelpers.get_OffsetToStringData
+
+define i32 @RuntimeHelpers.get_OffsetToStringData() {
+entry:
+  ret i32 12
+}
+
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
 Successfully read CultureData.CreateCultureData
 
@@ -3514,23 +4249,23 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
   store i8 %4, i8 addrspace(1)* %6
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
@@ -3549,11 +4284,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3566,50 +4301,50 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
   store i32 -1, i32 addrspace(1)* %2
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
   store i32 -1, i32 addrspace(1)* %8
   %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
   store i32 -1, i32 addrspace(1)* %14
   %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
   store i32 -1, i32 addrspace(1)* %17
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
@@ -3623,27 +4358,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3675,7 +4410,136 @@ Failed to read Dictionary`2.Insert[non-const derefAddress]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
 Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
-Failed to read HashHelpers.GetPrime[loadElem]
+Successfully read HashHelpers.GetPrime
+
+define i32 @HashHelpers.GetPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %6, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5, %System.String addrspace(1)* %4)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5) #0
+  unreachable
+
+; <label>:6                                       ; preds = %entry
+  store i32 0, i32* %loc0
+  br label %29
+
+; <label>:7                                       ; preds = %35
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 1296
+  %10 = addrspacecast i8 addrspace(1)* %9 to %"System.Int32[]" addrspace(1)**
+  %11 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %10
+  %12 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Int32[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = zext i32 %15 to i64
+  %17 = zext i32 %12 to i64
+  %BoundsCheck = icmp uge i64 %17, %16
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 3, i32 %12
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  store i32 %20, i32* %loc1
+  %21 = load i32, i32* %loc1
+  %22 = load i32, i32* %arg0
+  %23 = icmp slt i32 %21, %22
+  br i1 %23, label %26, label %24
+
+; <label>:24                                      ; preds = %18
+  %25 = load i32, i32* %loc1
+  ret i32 %25
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %loc0
+  %28 = add i32 %27, 1
+  store i32 %28, i32* %loc0
+  br label %29
+
+; <label>:29                                      ; preds = %6, %26
+  %30 = load i32, i32* %loc0
+  %31 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %32 = getelementptr inbounds i8, i8 addrspace(1)* %31, i64 1296
+  %33 = addrspacecast i8 addrspace(1)* %32 to %"System.Int32[]" addrspace(1)**
+  %34 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %33
+  %NullCheck = icmp eq %"System.Int32[]" addrspace(1)* %34, null
+  br i1 %NullCheck, label %ThrowNullRef, label %35
+
+; <label>:35                                      ; preds = %29
+  %36 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %34, i32 0, i32 1
+  %37 = load i32, i32 addrspace(1)* %36
+  %38 = zext i32 %37 to i64
+  %39 = trunc i64 %38 to i32
+  %40 = icmp slt i32 %30, %39
+  br i1 %40, label %7, label %41
+
+; <label>:41                                      ; preds = %35
+  %42 = load i32, i32* %arg0
+  %43 = or i32 %42, 1
+  store i32 %43, i32* %loc2
+  br label %59
+
+; <label>:44                                      ; preds = %59
+  %45 = load i32, i32* %loc2
+  %46 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %45)
+  %47 = zext i8 %46 to i32
+  %48 = icmp eq i32 %47, 0
+  br i1 %48, label %56, label %49
+
+; <label>:49                                      ; preds = %44
+  %50 = load i32, i32* %loc2
+  %51 = sub i32 %50, 1
+  %52 = srem i32 %51, 101
+  %53 = icmp eq i32 %52, 0
+  br i1 %53, label %56, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = load i32, i32* %loc2
+  ret i32 %55
+
+; <label>:56                                      ; preds = %44, %49
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %57, 2
+  store i32 %58, i32* %loc2
+  br label %59
+
+; <label>:59                                      ; preds = %41, %56
+  %60 = load i32, i32* %loc2
+  %61 = icmp slt i32 %60, 2147483647
+  br i1 %61, label %44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load i32, i32* %arg0
+  ret i32 %63
+
+ThrowNullRef:                                     ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
 Successfully read GenericEqualityComparer`1.GetHashCode
 
@@ -3694,14 +4558,14 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
   %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load i64, i64 addrspace(1)* %7
@@ -3720,7 +4584,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3750,8 +4614,8 @@ entry:
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
@@ -3796,8 +4660,8 @@ entry:
   %35 = bitcast i16* %34 to i8*
   %36 = getelementptr inbounds i8, i8* %35, i64 2
   %37 = bitcast i8* %36 to i16*
-  %NullCheck4 = icmp ne i16* %37, null
-  br i1 %NullCheck4, label %38, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %37, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %38
 
 ; <label>:38                                      ; preds = %27
   %39 = load i16, i16* %37, align 8
@@ -3824,8 +4688,8 @@ entry:
 
 ; <label>:54                                      ; preds = %22, %43
   %55 = load i16*, i16** %loc4
-  %NullCheck2 = icmp ne i16* %55, null
-  br i1 %NullCheck2, label %56, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i16* %55, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %56
 
 ; <label>:56                                      ; preds = %54
   %57 = load i16, i16* %55, align 8
@@ -3850,11 +4714,11 @@ ThrowNullRef:                                     ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %54
+ThrowNullRef2:                                    ; preds = %54
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %27
+ThrowNullRef4:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3871,8 +4735,8 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -3907,8 +4771,8 @@ entry:
 
 ; <label>:26                                      ; preds = %19
   %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
-  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %28
 
 ; <label>:28                                      ; preds = %26
   %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
@@ -3920,7 +4784,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3972,8 +4836,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
@@ -3984,26 +4848,26 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
-  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
@@ -4014,8 +4878,8 @@ entry:
 ; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
@@ -4024,8 +4888,8 @@ entry:
 
 ; <label>:25                                      ; preds = %1, %16, %23
   %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
-  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
@@ -4036,27 +4900,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %20
+ThrowNullRef10:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4069,8 +4933,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -4081,8 +4945,8 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
@@ -4091,8 +4955,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1, %8
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
@@ -4103,11 +4967,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4128,24 +4992,24 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   store i32 %3, i32* %loc0
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
   %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
   store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck4, label %9, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
@@ -4164,15 +5028,15 @@ entry:
 ; <label>:18                                      ; preds = %70
   %19 = load i16*, i16** %loc3
   %20 = bitcast i16* %19 to i64*
-  %NullCheck10 = icmp ne i64* %20, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %20, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = load i64, i64* %20, align 8
   %23 = load i16*, i16** %loc4
   %24 = bitcast i16* %23 to i64*
-  %NullCheck12 = icmp ne i64* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = load i64, i64* %24, align 8
@@ -4188,8 +5052,8 @@ entry:
   %31 = bitcast i16* %30 to i8*
   %32 = getelementptr inbounds i8, i8* %31, i64 8
   %33 = bitcast i8* %32 to i64*
-  %NullCheck14 = icmp ne i64* %33, null
-  br i1 %NullCheck14, label %34, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = load i64, i64* %33, align 8
@@ -4197,8 +5061,8 @@ entry:
   %37 = bitcast i16* %36 to i8*
   %38 = getelementptr inbounds i8, i8* %37, i64 8
   %39 = bitcast i8* %38 to i64*
-  %NullCheck16 = icmp ne i64* %39, null
-  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %40
 
 ; <label>:40                                      ; preds = %34
   %41 = load i64, i64* %39, align 8
@@ -4214,8 +5078,8 @@ entry:
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %NullCheck18 = icmp ne i64* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = load i64, i64* %48, align 8
@@ -4223,8 +5087,8 @@ entry:
   %52 = bitcast i16* %51 to i8*
   %53 = getelementptr inbounds i8, i8* %52, i64 16
   %54 = bitcast i8* %53 to i64*
-  %NullCheck20 = icmp ne i64* %54, null
-  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64* %54, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %55
 
 ; <label>:55                                      ; preds = %49
   %56 = load i64, i64* %54, align 8
@@ -4262,15 +5126,15 @@ entry:
 ; <label>:74                                      ; preds = %95
   %75 = load i16*, i16** %loc3
   %76 = bitcast i16* %75 to i32*
-  %NullCheck6 = icmp ne i32* %76, null
-  br i1 %NullCheck6, label %77, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32* %76, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %77
 
 ; <label>:77                                      ; preds = %74
   %78 = load i32, i32* %76, align 8
   %79 = load i16*, i16** %loc4
   %80 = bitcast i16* %79 to i32*
-  %NullCheck8 = icmp ne i32* %80, null
-  br i1 %NullCheck8, label %81, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i32* %80, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %81
 
 ; <label>:81                                      ; preds = %77
   %82 = load i32, i32* %80, align 8
@@ -4318,43 +5182,43 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %74
+ThrowNullRef6:                                    ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %77
+ThrowNullRef8:                                    ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %29
+ThrowNullRef14:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %34
+ThrowNullRef16:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4376,8 +5240,8 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load i64, i64 addrspace(1)* %4
@@ -4389,8 +5253,8 @@ entry:
   %12 = load i64, i64* %11
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %5
   %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
@@ -4399,8 +5263,8 @@ entry:
   %18 = load i8, i8* %arg2
   %19 = zext i8 %18 to i32
   %20 = trunc i32 %19 to i8
-  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %15
   %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
@@ -4411,11 +5275,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4442,8 +5306,8 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
@@ -4466,16 +5330,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
   %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = load i64, i64 addrspace(1)* %19
@@ -4500,8 +5364,8 @@ entry:
 ; <label>:35                                      ; preds = %30
   %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
@@ -4514,8 +5378,8 @@ entry:
 
 ; <label>:42                                      ; preds = %1, %38
   %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
-  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
@@ -4526,19 +5390,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %35
+ThrowNullRef2:                                    ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %42
+ThrowNullRef8:                                    ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4551,14 +5415,14 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
@@ -4570,7 +5434,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4583,8 +5447,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
@@ -4613,51 +5477,51 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
   %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
   %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
   %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
   %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
-  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
   store i64 %21, i64 addrspace(1)* %23
   %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %25 = load i64, i64* %loc0
-  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
@@ -4668,27 +5532,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %22
+ThrowNullRef12:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4701,8 +5565,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
@@ -4713,19 +5577,19 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
@@ -4734,8 +5598,8 @@ entry:
 
 ; <label>:15                                      ; preds = %1, %13
   %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
@@ -4746,19 +5610,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %15
+ThrowNullRef8:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4771,8 +5635,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -4831,8 +5695,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
@@ -4882,8 +5746,8 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
-  br i1 %NullCheck, label %17, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %ThrowNullRef, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
@@ -4894,15 +5758,15 @@ entry:
 
 ; <label>:22                                      ; preds = %17
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
-  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
   %26 = load i32, i32 addrspace(1)* %25
   %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
-  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %27, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
@@ -4925,8 +5789,8 @@ entry:
 ; <label>:40                                      ; preds = %17
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
-  br i1 %NullCheck6, label %43, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %41, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
@@ -4938,34 +5802,17 @@ ThrowNullRef:                                     ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %24
+ThrowNullRef4:                                    ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %40
+ThrowNullRef6:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
-}
-
-INFO:  jitting method Object::ReferenceEquals using LLILCJit
-Successfully read Object.ReferenceEquals
-
-define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
-entry:
-  %arg0 = alloca %System.Object addrspace(1)*
-  %arg1 = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
-  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
-  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = icmp eq %System.Object addrspace(1)* %0, %1
-  %3 = sext i1 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
 }
 
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
@@ -4978,21 +5825,21 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
   %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
-  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
@@ -5007,28 +5854,28 @@ entry:
 ; <label>:13                                      ; preds = %8, %12
   %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
   %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
   %21 = load i32, i32 addrspace(1)* %20, align 8
   %22 = add i32 %21, 1
-  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
   store i32 %22, i32 addrspace(1)* %24
   %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
@@ -5039,27 +5886,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5077,7 +5924,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::Setup using LLILCJit
-Failed to read AppDomain.Setup[loadElem]
+Failed to read AppDomain.Setup[unbox]
 INFO:  jitting method Thread::GetDomain using LLILCJit
 Successfully read Thread.GetDomain
 
@@ -5108,8 +5955,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
@@ -5122,14 +5969,14 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
   %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
@@ -5141,11 +5988,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5173,8 +6020,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -5189,7 +6036,328 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
 Failed to read KeyCollection.System.Collections.Generic.IEnumerable<TKey>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Successfully read Enumerator.MoveNext
+
+define i8 @Enumerator.MoveNext(%"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.RuntimeTypeHandle* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*
+  %"$TypeArg" = alloca %System.RuntimeTypeHandle*
+  store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
+  %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 8
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %76, label %12
+
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
+  br label %76
+
+; <label>:13                                      ; preds = %85
+  %14 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck19 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %15
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, i32 0, i32 0
+  %17 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %16, align 8
+  %NullCheck21 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, i32 0, i32 2
+  %20 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %19, align 8
+  %21 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck23 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %22
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, i32 0, i32 2
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %NullCheck25 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 3, i32 %24
+  %NullCheck27 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %32
+
+; <label>:32                                      ; preds = %30
+  %33 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, i32 0, i32 2
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = icmp slt i32 %34, 0
+  br i1 %35, label %68, label %36
+
+; <label>:36                                      ; preds = %32
+  %37 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %38 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck29 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %39
+
+; <label>:39                                      ; preds = %36
+  %40 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, i32 0, i32 0
+  %41 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %40, align 8
+  %NullCheck31 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, i32 0, i32 2
+  %44 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %43, align 8
+  %45 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck33 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, i32 0, i32 2
+  %48 = load i32, i32 addrspace(1)* %47, align 8
+  %NullCheck35 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %49
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = zext i32 %51 to i64
+  %53 = zext i32 %48 to i64
+  %BoundsCheck37 = icmp uge i64 %53, %52
+  br i1 %BoundsCheck37, label %ThrowIndexOutOfRange38, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 3, i32 %48
+  %NullCheck39 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %56
+
+; <label>:56                                      ; preds = %54
+  %57 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, i32 0, i32 0
+  %58 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck41 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %59
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %60, %System.__Canon addrspace(1)* %58)
+  %61 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck43 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  %64 = load i32, i32 addrspace(1)* %63, align 8
+  %65 = add i32 %64, 1
+  %NullCheck45 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  store i32 %65, i32 addrspace(1)* %67
+  ret i8 1
+
+; <label>:68                                      ; preds = %32
+  %69 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck47 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %73 = add i32 %72, 1
+  %NullCheck49 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %74
+
+; <label>:74                                      ; preds = %70
+  %75 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  store i32 %73, i32 addrspace(1)* %75
+  br label %76
+
+; <label>:76                                      ; preds = %8, %12, %74
+  %77 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %78
+
+; <label>:78                                      ; preds = %76
+  %79 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, i32 0, i32 2
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck7 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %82
+
+; <label>:82                                      ; preds = %78
+  %83 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, i32 0, i32 0
+  %84 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %83, align 8
+  %NullCheck9 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %85
+
+; <label>:85                                      ; preds = %82
+  %86 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, i32 0, i32 7
+  %87 = load i32, i32 addrspace(1)* %86, align 8
+  %88 = icmp ult i32 %80, %87
+  br i1 %88, label %13, label %89
+
+; <label>:89                                      ; preds = %85
+  %90 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %91 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck11 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %92
+
+; <label>:92                                      ; preds = %89
+  %93 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, i32 0, i32 0
+  %94 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck13 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %95
+
+; <label>:95                                      ; preds = %92
+  %96 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, i32 0, i32 7
+  %97 = load i32, i32 addrspace(1)* %96, align 8
+  %98 = add i32 %97, 1
+  %NullCheck15 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %99
+
+; <label>:99                                      ; preds = %95
+  %100 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, i32 0, i32 2
+  store i32 %98, i32 addrspace(1)* %100
+  %101 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck17 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %102
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %103, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %92
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef22:                                   ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef24:                                   ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef26:                                   ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef28:                                   ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef30:                                   ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef32:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef34:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef36:                                   ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange38:                           ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef40:                                   ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef42:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef44:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef46:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef48:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef50:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -5200,8 +6368,8 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -5232,9 +6400,9 @@ Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
 Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
-Failed to read String.MakeSeparatorList[loadElemA]
+Failed to read String.MakeSeparatorList[storeElem]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
-Failed to read String.InternalSplitKeepEmptyEntries[loadElem]
+Failed to read String.InternalSplitKeepEmptyEntries[storeElem]
 INFO:  jitting method Path::IsRelative using LLILCJit
 Successfully read Path.IsRelative
 
@@ -5243,8 +6411,8 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -5254,8 +6422,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
@@ -5271,8 +6439,8 @@ entry:
 
 ; <label>:17                                      ; preds = %7
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
@@ -5288,8 +6456,8 @@ entry:
 
 ; <label>:29                                      ; preds = %19
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %31
 
 ; <label>:31                                      ; preds = %29
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
@@ -5300,8 +6468,8 @@ entry:
 
 ; <label>:36                                      ; preds = %31
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
-  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %37, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
@@ -5312,8 +6480,8 @@ entry:
 
 ; <label>:43                                      ; preds = %31, %38
   %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
-  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %45
 
 ; <label>:45                                      ; preds = %43
   %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
@@ -5324,8 +6492,8 @@ entry:
 
 ; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %50
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
@@ -5336,8 +6504,8 @@ entry:
 
 ; <label>:57                                      ; preds = %1, %7, %19, %45, %52
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
-  br i1 %NullCheck14, label %59, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %59
 
 ; <label>:59                                      ; preds = %57
   %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
@@ -5347,8 +6515,8 @@ entry:
 
 ; <label>:63                                      ; preds = %59
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
@@ -5359,8 +6527,8 @@ entry:
 
 ; <label>:70                                      ; preds = %65
   %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
-  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.String addrspace(1)* %71, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %72
 
 ; <label>:72                                      ; preds = %70
   %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
@@ -5379,39 +6547,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %17
+ThrowNullRef4:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %29
+ThrowNullRef6:                                    ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %36
+ThrowNullRef8:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %43
+ThrowNullRef10:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %50
+ThrowNullRef12:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %57
+ThrowNullRef14:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %63
+ThrowNullRef16:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %70
+ThrowNullRef18:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5419,7 +6587,293 @@ ThrowNullRef17:                                   ; preds = %70
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
-Failed to read String.TrimHelper[loadElem]
+Successfully read String.TrimHelper
+
+define %System.String addrspace(1)* @String.TrimHelper(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i16
+  %loc4 = alloca i32
+  %loc5 = alloca i16
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = sub i32 %3, 1
+  store i32 %4, i32* %loc0
+  store i32 0, i32* %loc1
+  %5 = load i32, i32* %arg2
+  %6 = icmp eq i32 %5, 1
+  br i1 %6, label %62, label %7
+
+; <label>:7                                       ; preds = %1
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:8                                       ; preds = %58
+  store i32 0, i32* %loc2
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load i32, i32* %loc1
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2, i32 %10
+  %13 = load i16, i16 addrspace(1)* %12
+  %14 = zext i16 %13 to i32
+  %15 = trunc i32 %14 to i16
+  store i16 %15, i16* %loc3
+  store i32 0, i32* %loc2
+  br label %34
+
+; <label>:16                                      ; preds = %37
+  %17 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %18 = load i32, i32* %loc2
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %17, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %19
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = zext i32 %18 to i64
+  %BoundsCheck = icmp uge i64 %23, %22
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %24
+
+; <label>:24                                      ; preds = %19
+  %25 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 3, i32 %18
+  %26 = load i16, i16 addrspace(1)* %25, align 8
+  %27 = zext i16 %26 to i32
+  %28 = load i16, i16* %loc3
+  %29 = zext i16 %28 to i32
+  %30 = icmp eq i32 %27, %29
+  br i1 %30, label %43, label %31
+
+; <label>:31                                      ; preds = %24
+  %32 = load i32, i32* %loc2
+  %33 = add i32 %32, 1
+  store i32 %33, i32* %loc2
+  br label %34
+
+; <label>:34                                      ; preds = %11, %31
+  %35 = load i32, i32* %loc2
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = icmp slt i32 %35, %41
+  br i1 %42, label %16, label %43
+
+; <label>:43                                      ; preds = %24, %37
+  %44 = load i32, i32* %loc2
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %45, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp eq i32 %44, %50
+  br i1 %51, label %62, label %52
+
+; <label>:52                                      ; preds = %46
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %7, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %57, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %58
+
+; <label>:58                                      ; preds = %55
+  %59 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %60 = load i32, i32 addrspace(1)* %59
+  %61 = icmp slt i32 %56, %60
+  br i1 %61, label %8, label %62
+
+; <label>:62                                      ; preds = %1, %46, %58
+  %63 = load i32, i32* %arg2
+  %64 = icmp eq i32 %63, 0
+  br i1 %64, label %122, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %66, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %67
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %66, i32 0, i32 1
+  %69 = load i32, i32 addrspace(1)* %68
+  %70 = sub i32 %69, 1
+  store i32 %70, i32* %loc0
+  br label %118
+
+; <label>:71                                      ; preds = %118
+  store i32 0, i32* %loc4
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %73 = load i32, i32* %loc0
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %74
+
+; <label>:74                                      ; preds = %71
+  %75 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 2, i32 %73
+  %76 = load i16, i16 addrspace(1)* %75
+  %77 = zext i16 %76 to i32
+  %78 = trunc i32 %77 to i16
+  store i16 %78, i16* %loc5
+  store i32 0, i32* %loc4
+  br label %97
+
+; <label>:79                                      ; preds = %100
+  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %81 = load i32, i32* %loc4
+  %NullCheck19 = icmp eq %"System.Char[]" addrspace(1)* %80, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
+
+; <label>:82                                      ; preds = %79
+  %83 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 1
+  %84 = load i32, i32 addrspace(1)* %83
+  %85 = zext i32 %84 to i64
+  %86 = zext i32 %81 to i64
+  %BoundsCheck21 = icmp uge i64 %86, %85
+  br i1 %BoundsCheck21, label %ThrowIndexOutOfRange22, label %87
+
+; <label>:87                                      ; preds = %82
+  %88 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 3, i32 %81
+  %89 = load i16, i16 addrspace(1)* %88, align 8
+  %90 = zext i16 %89 to i32
+  %91 = load i16, i16* %loc5
+  %92 = zext i16 %91 to i32
+  %93 = icmp eq i32 %90, %92
+  br i1 %93, label %106, label %94
+
+; <label>:94                                      ; preds = %87
+  %95 = load i32, i32* %loc4
+  %96 = add i32 %95, 1
+  store i32 %96, i32* %loc4
+  br label %97
+
+; <label>:97                                      ; preds = %74, %94
+  %98 = load i32, i32* %loc4
+  %99 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck15 = icmp eq %"System.Char[]" addrspace(1)* %99, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %100
+
+; <label>:100                                     ; preds = %97
+  %101 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %99, i32 0, i32 1
+  %102 = load i32, i32 addrspace(1)* %101
+  %103 = zext i32 %102 to i64
+  %104 = trunc i64 %103 to i32
+  %105 = icmp slt i32 %98, %104
+  br i1 %105, label %79, label %106
+
+; <label>:106                                     ; preds = %87, %100
+  %107 = load i32, i32* %loc4
+  %108 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck17 = icmp eq %"System.Char[]" addrspace(1)* %108, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %109
+
+; <label>:109                                     ; preds = %106
+  %110 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %108, i32 0, i32 1
+  %111 = load i32, i32 addrspace(1)* %110
+  %112 = zext i32 %111 to i64
+  %113 = trunc i64 %112 to i32
+  %114 = icmp eq i32 %107, %113
+  br i1 %114, label %122, label %115
+
+; <label>:115                                     ; preds = %109
+  %116 = load i32, i32* %loc0
+  %117 = sub i32 %116, 1
+  store i32 %117, i32* %loc0
+  br label %118
+
+; <label>:118                                     ; preds = %67, %115
+  %119 = load i32, i32* %loc0
+  %120 = load i32, i32* %loc1
+  %121 = icmp sge i32 %119, %120
+  br i1 %121, label %71, label %122
+
+; <label>:122                                     ; preds = %62, %109, %118
+  %123 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %124 = load i32, i32* %loc1
+  %125 = load i32, i32* %loc0
+  %126 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %123, i32 %124, i32 %125)
+  ret %System.String addrspace(1)* %126
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %97
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange22:                           ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
 Successfully read String.CreateTrimmedString
 
@@ -5439,8 +6893,8 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
@@ -5535,8 +6989,8 @@ entry:
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i64 2872
   %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
   %8 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %7
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %3
   %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
@@ -5553,8 +7007,8 @@ entry:
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 2864
   %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
   %21 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %20
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
-  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %22
 
 ; <label>:22                                      ; preds = %16
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
@@ -5569,7 +7023,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %16
+ThrowNullRef2:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5586,8 +7040,8 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5613,8 +7067,8 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
@@ -5632,8 +7086,8 @@ entry:
 
 ; <label>:12                                      ; preds = %4
   %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
@@ -5644,8 +7098,8 @@ entry:
 
 ; <label>:19                                      ; preds = %14
   %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %19
   %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
@@ -5660,21 +7114,21 @@ entry:
   %31 = zext i16 %30 to i32
   %32 = bitcast i8* %29 to i16*
   %33 = trunc i32 %31 to i16
-  %NullCheck6 = icmp ne i16* %32, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i16* %32, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %21
   store i16 %33, i16* %32, align 8
   %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %36
 
 ; <label>:36                                      ; preds = %34
   %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
   %38 = load i32, i32 addrspace(1)* %37, align 8
   %39 = add i32 %38, 1
-  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %40
 
 ; <label>:40                                      ; preds = %36
   %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
@@ -5683,16 +7137,16 @@ entry:
 
 ; <label>:42                                      ; preds = %14
   %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
-  br i1 %NullCheck12, label %44, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
   %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
   %47 = load i16, i16* %arg1
   %48 = zext i16 %47 to i32
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = trunc i32 %48 to i16
@@ -5703,31 +7157,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %19
+ThrowNullRef4:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %21
+ThrowNullRef6:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %36
+ThrowNullRef10:                                   ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %42
+ThrowNullRef12:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %44
+ThrowNullRef14:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5740,8 +7194,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -5752,8 +7206,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
@@ -5762,14 +7216,14 @@ entry:
 
 ; <label>:11                                      ; preds = %1
   %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
@@ -5779,15 +7233,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5808,8 +7262,8 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5822,8 +7276,8 @@ entry:
 
 ; <label>:8                                       ; preds = %3
   %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
@@ -5842,15 +7296,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
-  br i1 %NullCheck4, label %22, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
   %24 = load i16*, i16* addrspace(1)* %23, align 8
   %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %25, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
@@ -5859,8 +7313,8 @@ entry:
   store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
@@ -5874,8 +7328,8 @@ entry:
 
 ; <label>:37                                      ; preds = %65
   %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %37
   %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
@@ -5886,16 +7340,16 @@ entry:
   %45 = bitcast i16* %41 to i8*
   %46 = getelementptr inbounds i8, i8* %45, i64 %44
   %47 = bitcast i8* %46 to i16*
-  %NullCheck14 = icmp ne i16* %47, null
-  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %47, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %48
 
 ; <label>:48                                      ; preds = %39
   %49 = load i16, i16* %47, align 8
   %50 = zext i16 %49 to i32
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %52 = load i32, i32* %loc1
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %53
 
 ; <label>:53                                      ; preds = %48
   %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
@@ -5916,8 +7370,8 @@ entry:
 ; <label>:62                                      ; preds = %36, %59
   %63 = load i32, i32* %loc1
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck10, label %65, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %65
 
 ; <label>:65                                      ; preds = %62
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
@@ -5936,15 +7390,15 @@ entry:
 
 ; <label>:74                                      ; preds = %70
   %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
-  br i1 %NullCheck18, label %76, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %76
 
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
   %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
-  br i1 %NullCheck20, label %80, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
   %81 = load i64, i64 addrspace(1)* %79
@@ -5958,8 +7412,8 @@ entry:
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
   %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
-  br i1 %NullCheck22, label %92, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.String addrspace(1)* %90, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %92
 
 ; <label>:92                                      ; preds = %80
   %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
@@ -5969,15 +7423,15 @@ entry:
 
 ; <label>:96                                      ; preds = %70
   %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
-  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %98
 
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
   %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
-  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
   %103 = load i64, i64 addrspace(1)* %101
@@ -5991,8 +7445,8 @@ entry:
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
   %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
-  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.String addrspace(1)* %112, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %114
 
 ; <label>:114                                     ; preds = %102
   %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
@@ -6004,59 +7458,59 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %20
+ThrowNullRef4:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %22
+ThrowNullRef6:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %26
+ThrowNullRef8:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %62
+ThrowNullRef10:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %48
+ThrowNullRef16:                                   ; preds = %48
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %74
+ThrowNullRef18:                                   ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %76
+ThrowNullRef20:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %80
+ThrowNullRef22:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %96
+ThrowNullRef24:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %98
+ThrowNullRef26:                                   ; preds = %98
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %102
+ThrowNullRef28:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6069,15 +7523,15 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
   %3 = load i16*, i16* addrspace(1)* %2, align 8
   %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
@@ -6087,8 +7541,8 @@ entry:
   %10 = bitcast i16* %3 to i8*
   %11 = getelementptr inbounds i8, i8* %10, i64 %9
   %12 = bitcast i8* %11 to i16*
-  %NullCheck4 = icmp ne i16* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %5
   store i16 0, i16* %12, align 8
@@ -6098,11 +7552,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6119,8 +7573,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -6131,8 +7585,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
@@ -6144,15 +7598,15 @@ entry:
 
 ; <label>:14                                      ; preds = %1
   %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
   %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
   %21 = load i64, i64 addrspace(1)* %19
@@ -6171,15 +7625,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %14
+ThrowNullRef4:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %16
+ThrowNullRef6:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6302,14 +7756,6 @@ entry:
   ret %System.String addrspace(1)* %57
 }
 
-INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
-Successfully read RuntimeHelpers.get_OffsetToStringData
-
-define i32 @RuntimeHelpers.get_OffsetToStringData() {
-entry:
-  ret i32 12
-}
-
 INFO:  jitting method String::Equals using LLILCJit
 Successfully read String.Equals
 
@@ -6381,8 +7827,8 @@ entry:
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
-  br i1 %NullCheck24, label %29, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
   %30 = load i64, i64 addrspace(1)* %28
@@ -6397,8 +7843,8 @@ entry:
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
-  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
   %43 = load i64, i64 addrspace(1)* %41
@@ -6418,8 +7864,8 @@ entry:
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
   %59 = load i64, i64 addrspace(1)* %57
@@ -6434,8 +7880,8 @@ entry:
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck22, label %71, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
   %72 = load i64, i64 addrspace(1)* %70
@@ -6455,8 +7901,8 @@ entry:
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
-  br i1 %NullCheck16, label %87, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = load i64, i64 addrspace(1)* %86
@@ -6471,8 +7917,8 @@ entry:
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck18, label %100, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
   %101 = load i64, i64 addrspace(1)* %99
@@ -6492,8 +7938,8 @@ entry:
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
-  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
   %117 = load i64, i64 addrspace(1)* %115
@@ -6508,8 +7954,8 @@ entry:
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
-  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
   %130 = load i64, i64 addrspace(1)* %128
@@ -6528,15 +7974,15 @@ entry:
 
 ; <label>:142                                     ; preds = %22
   %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
-  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %143, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %144
 
 ; <label>:144                                     ; preds = %142
   %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
   %146 = load i32, i32 addrspace(1)* %145
   %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
-  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %147, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %148
 
 ; <label>:148                                     ; preds = %144
   %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
@@ -6557,15 +8003,15 @@ entry:
 
 ; <label>:159                                     ; preds = %22
   %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
-  br i1 %NullCheck, label %161, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %ThrowNullRef, label %161
 
 ; <label>:161                                     ; preds = %159
   %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
   %163 = load i32, i32 addrspace(1)* %162
   %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
-  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %164, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %165
 
 ; <label>:165                                     ; preds = %161
   %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
@@ -6578,8 +8024,8 @@ entry:
 
 ; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
-  br i1 %NullCheck4, label %172, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %171, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %172
 
 ; <label>:172                                     ; preds = %170
   %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
@@ -6589,8 +8035,8 @@ entry:
 
 ; <label>:176                                     ; preds = %172
   %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
-  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %177, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %178
 
 ; <label>:178                                     ; preds = %176
   %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
@@ -6629,55 +8075,55 @@ ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %161
+ThrowNullRef2:                                    ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %170
+ThrowNullRef4:                                    ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %176
+ThrowNullRef6:                                    ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %142
+ThrowNullRef8:                                    ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %144
+ThrowNullRef10:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %113
+ThrowNullRef12:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %116
+ThrowNullRef14:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %84
+ThrowNullRef16:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %87
+ThrowNullRef18:                                   ; preds = %87
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %55
+ThrowNullRef20:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %58
+ThrowNullRef22:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %26
+ThrowNullRef24:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %29
+ThrowNullRef26:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,8 +8161,8 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck, label %14, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %ThrowNullRef, label %14
 
 ; <label>:14                                      ; preds = %8
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
@@ -6760,8 +8206,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
@@ -6770,14 +8216,14 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32, i32* %loc0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %10
   %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
   %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
@@ -6790,15 +8236,15 @@ entry:
 ; <label>:25                                      ; preds = %19
   %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
-  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
   %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
@@ -6807,8 +8253,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %37 = load i32, i32* %loc0
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %38, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %38
 
 ; <label>:38                                      ; preds = %32
   %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
@@ -6817,14 +8263,14 @@ entry:
 
 ; <label>:40                                      ; preds = %19
   %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %40
   %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
   %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
-  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
-  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
@@ -6832,8 +8278,8 @@ entry:
   %48 = zext i32 %47 to i64
   %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
-  br i1 %NullCheck16, label %51, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %51
 
 ; <label>:51                                      ; preds = %45
   %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
@@ -6847,15 +8293,15 @@ entry:
 ; <label>:57                                      ; preds = %51
   %58 = load i16*, i16** %arg1
   %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
-  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %60
 
 ; <label>:60                                      ; preds = %57
   %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
   %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
-  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %64
 
 ; <label>:64                                      ; preds = %60
   %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
@@ -6864,22 +8310,22 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
   %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
-  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %70
 
 ; <label>:70                                      ; preds = %64
   %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
   %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
-  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
-  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
   %75 = load i32, i32 addrspace(1)* %74
   %76 = zext i32 %75 to i64
   %77 = trunc i64 %76 to i32
-  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
-  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %78
 
 ; <label>:78                                      ; preds = %73
   %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
@@ -6901,8 +8347,8 @@ entry:
   %90 = bitcast i16* %86 to i8*
   %91 = getelementptr inbounds i8, i8* %90, i64 %89
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %93
 
 ; <label>:93                                      ; preds = %80
   %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
@@ -6912,8 +8358,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %99 = load i32, i32* %loc2
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %100
 
 ; <label>:100                                     ; preds = %93
   %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
@@ -6928,63 +8374,63 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %25
+ThrowNullRef6:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %32
+ThrowNullRef10:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %40
+ThrowNullRef12:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %45
+ThrowNullRef16:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %57
+ThrowNullRef18:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %60
+ThrowNullRef20:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %64
+ThrowNullRef22:                                   ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %70
+ThrowNullRef24:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %73
+ThrowNullRef26:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %80
+ThrowNullRef28:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %93
+ThrowNullRef30:                                   ; preds = %93
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7004,8 +8450,8 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
@@ -7033,43 +8479,43 @@ entry:
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %14
   %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
   %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   %28 = load i32, i32 addrspace(1)* %27, align 8
   %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
-  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %30
 
 ; <label>:30                                      ; preds = %26
   %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
   %32 = load i32, i32 addrspace(1)* %31, align 8
   %33 = add i32 %28, %32
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %34
 
 ; <label>:34                                      ; preds = %30
   %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   store i32 %33, i32 addrspace(1)* %35
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
   store i32 0, i32 addrspace(1)* %38
   %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %40
 
 ; <label>:40                                      ; preds = %37
   %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
@@ -7082,8 +8528,8 @@ entry:
 
 ; <label>:47                                      ; preds = %40
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
@@ -7098,8 +8544,8 @@ entry:
   %54 = load i32, i32* %loc0
   %55 = sext i32 %54 to i64
   %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
-  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %57
 
 ; <label>:57                                      ; preds = %52
   %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
@@ -7110,68 +8556,35 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %14
+ThrowNullRef2:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %23
+ThrowNullRef4:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %26
+ThrowNullRef6:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %30
+ThrowNullRef8:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %34
+ThrowNullRef10:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %47
+ThrowNullRef14:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %52
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-}
-
-INFO:  jitting method StringBuilder::get_Length using LLILCJit
-Successfully read StringBuilder.get_Length
-
-define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.StringBuilder addrspace(1)*
-  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
-  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
-
-; <label>:1                                       ; preds = %entry
-  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %3 = load i32, i32 addrspace(1)* %2, align 8
-  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
-
-; <label>:5                                       ; preds = %1
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = add i32 %3, %7
-  ret i32 %8
-
-ThrowNullRef:                                     ; preds = %entry
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef16:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7213,70 +8626,70 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
   %6 = load i32, i32 addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
   store i32 %6, i32 addrspace(1)* %8
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
   %13 = load i32, i32 addrspace(1)* %12, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
   store i32 %13, i32 addrspace(1)* %15
   %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
-  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %18
 
 ; <label>:18                                      ; preds = %14
   %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
   %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
   %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
   %34 = load i32, i32 addrspace(1)* %33, align 8
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
-  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
@@ -7287,39 +8700,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %28
+ThrowNullRef16:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %32
+ThrowNullRef18:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7455,13 +8868,13 @@ entry:
 ; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
@@ -7477,16 +8890,16 @@ entry:
 
 ; <label>:18                                      ; preds = %15
   %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
   store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
   %22 = load i32, i32* %loc0
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %24
 
 ; <label>:24                                      ; preds = %20
   %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
@@ -7498,13 +8911,13 @@ entry:
 ; <label>:28                                      ; preds = %15, %24
   %29 = load i32, i32* %arg1
   %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %31
   %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
@@ -7517,20 +8930,20 @@ entry:
   %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
-  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
   %46 = load i32, i32 addrspace(1)* %45, align 8
   %47 = sub i32 %40, %46
-  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
-  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i32 addrspace(1)* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %48
 
 ; <label>:48                                      ; preds = %44
   store i32 %47, i32 addrspace(1)* %39, align 8
@@ -7538,21 +8951,21 @@ entry:
 
 ; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
-  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %51
 
 ; <label>:51                                      ; preds = %49
   %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %53
 
 ; <label>:53                                      ; preds = %51
   %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
   %55 = load i32, i32 addrspace(1)* %54, align 8
   %56 = load i32, i32* %arg2
   %57 = sub i32 %55, %56
-  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %58
 
 ; <label>:58                                      ; preds = %53
   %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
@@ -7562,13 +8975,13 @@ entry:
 ; <label>:60                                      ; preds = %33, %58
   %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
   %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
-  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %63
 
 ; <label>:63                                      ; preds = %60
   %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
-  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
-  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
@@ -7578,15 +8991,15 @@ entry:
 
 ; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
-  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i32 addrspace(1)* %69, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %70
 
 ; <label>:70                                      ; preds = %68
   %71 = load i32, i32 addrspace(1)* %69, align 8
   store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
-  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
@@ -7596,8 +9009,8 @@ entry:
   store i32 %77, i32* %loc4
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
-  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %80
 
 ; <label>:80                                      ; preds = %73
   %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
@@ -7607,71 +9020,71 @@ entry:
 ; <label>:83                                      ; preds = %80
   store i32 0, i32* %loc3
   %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
-  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
-  br i1 %NullCheck26, label %88, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i32 addrspace(1)* %87, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %88
 
 ; <label>:88                                      ; preds = %85
   %89 = load i32, i32 addrspace(1)* %87, align 8
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
-  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %90
 
 ; <label>:90                                      ; preds = %88
   %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
   store i32 %89, i32 addrspace(1)* %91
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
-  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
-  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %96
 
 ; <label>:96                                      ; preds = %94
   %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
-  br i1 %NullCheck34, label %100, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %100
 
 ; <label>:100                                     ; preds = %96
   %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
-  br i1 %NullCheck36, label %102, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %102
 
 ; <label>:102                                     ; preds = %100
   %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
   %104 = load i32, i32 addrspace(1)* %103, align 8
   %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
-  br i1 %NullCheck38, label %106, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %106
 
 ; <label>:106                                     ; preds = %102
   %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
-  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
-  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %108
 
 ; <label>:108                                     ; preds = %106
   %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
   %110 = load i32, i32 addrspace(1)* %109, align 8
   %111 = add i32 %104, %110
-  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %112
 
 ; <label>:112                                     ; preds = %108
   %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
   store i32 %111, i32 addrspace(1)* %113
   %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
-  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i32 addrspace(1)* %114, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %115
 
 ; <label>:115                                     ; preds = %112
   %116 = load i32, i32 addrspace(1)* %114, align 8
@@ -7681,19 +9094,19 @@ entry:
 ; <label>:118                                     ; preds = %115
   %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
-  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %121
 
 ; <label>:121                                     ; preds = %118
   %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
-  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
-  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %123
 
 ; <label>:123                                     ; preds = %121
   %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
   %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
-  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
-  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %126
 
 ; <label>:126                                     ; preds = %123
   %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
@@ -7705,8 +9118,8 @@ entry:
 
 ; <label>:130                                     ; preds = %80, %115, %126
   %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %132
 
 ; <label>:132                                     ; preds = %130
   %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7715,8 +9128,8 @@ entry:
   %136 = load i32, i32* %loc3
   %137 = sub i32 %135, %136
   %138 = sub i32 %134, %137
-  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %139
 
 ; <label>:139                                     ; preds = %132
   %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7728,16 +9141,16 @@ entry:
 
 ; <label>:144                                     ; preds = %139
   %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
-  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %146
 
 ; <label>:146                                     ; preds = %144
   %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
   %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
   %149 = load i32, i32* %loc2
   %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
-  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %151
 
 ; <label>:151                                     ; preds = %146
   %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
@@ -7754,145 +9167,249 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %18
+ThrowNullRef4:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %31
+ThrowNullRef10:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %44
+ThrowNullRef16:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %68
+ThrowNullRef18:                                   ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %70
+ThrowNullRef20:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %73
+ThrowNullRef22:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %83
+ThrowNullRef24:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %85
+ThrowNullRef26:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %88
+ThrowNullRef28:                                   ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %90
+ThrowNullRef30:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %94
+ThrowNullRef32:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %96
+ThrowNullRef34:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %100
+ThrowNullRef36:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %102
+ThrowNullRef38:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %106
+ThrowNullRef40:                                   ; preds = %106
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %108
+ThrowNullRef42:                                   ; preds = %108
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %112
+ThrowNullRef44:                                   ; preds = %112
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %118
+ThrowNullRef46:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %121
+ThrowNullRef48:                                   ; preds = %121
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %123
+ThrowNullRef50:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %130
+ThrowNullRef52:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %132
+ThrowNullRef54:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %144
+ThrowNullRef56:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %146
+ThrowNullRef58:                                   ; preds = %146
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %60
+ThrowNullRef60:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %63
+ThrowNullRef62:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %49
+ThrowNullRef64:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %51
+ThrowNullRef66:                                   ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %53
+ThrowNullRef68:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(%"System.Char[]" addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %arg0 = alloca %"System.Char[]" addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store %"System.Char[]" addrspace(1)* %param0, %"System.Char[]" addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load i32, i32* %arg4
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %43, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %38, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg1
+  %13 = load i32, i32* %arg4
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %38, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %24 = load i32, i32* %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %35 = load i32, i32* %arg3
+  %36 = load i32, i32* %arg4
+  %37 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %37, %"System.Char[]" addrspace(1)* %34, i32 %35, i32 %36)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:38                                      ; preds = %5, %16
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Successfully read Buffer._Memmove
 
@@ -7914,7 +9431,7 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[loadElem]
+Failed to read AppDomain.SetDataHelper[storeElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -7923,8 +9440,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
@@ -7934,8 +9451,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
@@ -7947,15 +9464,15 @@ entry:
   %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
   %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
@@ -7966,15 +9483,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7992,7 +9509,79 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
-Failed to read Dictionary`2.TryGetValue[loadElemA]
+Successfully read Dictionary`2.TryGetValue
+
+define i8 @"Dictionary`2.TryGetValue"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)* addrspace(1)* %param2) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  %arg2 = alloca %System.__Canon addrspace(1)* addrspace(1)*
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  store %System.__Canon addrspace(1)* addrspace(1)* %param2, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  store i32 %2, i32* %loc0
+  %3 = load i32, i32* %loc0
+  %4 = icmp slt i32 %3, 0
+  br i1 %4, label %22, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 2
+  %10 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %9, align 8
+  %11 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = zext i32 %11 to i64
+  %BoundsCheck = icmp uge i64 %16, %15
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 3, i32 %11
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %20, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %6, %System.__Canon addrspace(1)* %21)
+  ret i8 1
+
+; <label>:22                                      ; preds = %entry
+  %23 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %23, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -8058,8 +9647,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
@@ -8091,8 +9680,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
@@ -8171,15 +9760,15 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck, label %19, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %ThrowNullRef, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
   %21 = load i32, i32 addrspace(1)* %20
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
@@ -8202,7 +9791,7 @@ ThrowNullRef:                                     ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %19
+ThrowNullRef2:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8248,8 +9837,8 @@ entry:
   %0 = alloca %System.AppDomainHandle
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %1 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %1, i32 0, i32 15
@@ -8269,8 +9858,8 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
@@ -8286,7 +9875,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -8299,8 +9888,8 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -8327,8 +9916,8 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
@@ -8352,8 +9941,8 @@ entry:
   %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
   store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
@@ -8363,8 +9952,8 @@ entry:
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
@@ -8374,8 +9963,8 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %9
   %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
@@ -8384,8 +9973,8 @@ entry:
 
 ; <label>:18                                      ; preds = %3, %16
   %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
@@ -8397,15 +9986,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %18
+ThrowNullRef6:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8418,8 +10007,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
@@ -8453,15 +10042,15 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
@@ -8473,7 +10062,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8481,7 +10070,7 @@ ThrowNullRef1:                                    ; preds = %1
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
 Failed to read Dictionary`2.System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
@@ -8506,8 +10095,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
@@ -8524,8 +10113,8 @@ entry:
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -8544,7 +10133,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8577,8 +10166,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = load i64, i64* %arg2
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = trunc i32 %3 to i8
@@ -8634,46 +10223,46 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
   %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
-  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
-  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
-  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
@@ -8684,27 +10273,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %20
+ThrowNullRef12:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8717,8 +10306,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -8756,22 +10345,22 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
   %9 = load i64, i64 addrspace(1)* %8, align 8
   %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
   %13 = load i64, i64 addrspace(1)* %12, align 8
   %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %11
   %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
@@ -8788,11 +10377,11 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8882,8 +10471,8 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
@@ -8900,8 +10489,8 @@ entry:
 ; <label>:8                                       ; preds = %1
   %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
   %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
@@ -8911,15 +10500,15 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
   %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
   %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
-  br i1 %NullCheck6, label %21, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
@@ -8946,15 +10535,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8992,15 +10581,15 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
   store i8 %3, i8 addrspace(1)* %5
   %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
@@ -9011,7 +10600,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9027,8 +10616,8 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -9041,8 +10630,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
@@ -9058,7 +10647,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9080,8 +10669,8 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
@@ -9096,8 +10685,8 @@ entry:
 ; <label>:12                                      ; preds = %6
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
@@ -9112,8 +10701,8 @@ entry:
 ; <label>:21                                      ; preds = %15
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
@@ -9128,8 +10717,8 @@ entry:
 ; <label>:30                                      ; preds = %24
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %31, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
@@ -9144,8 +10733,8 @@ entry:
 ; <label>:39                                      ; preds = %33
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
-  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %40, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %42
 
 ; <label>:42                                      ; preds = %39
   %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
@@ -9164,19 +10753,19 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %21
+ThrowNullRef4:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %30
+ThrowNullRef6:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %39
+ThrowNullRef8:                                    ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9243,8 +10832,8 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
@@ -9264,57 +10853,57 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
   store i8 0, i8 addrspace(1)* %2
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
   store i8 0, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
   store i8 0, i8 addrspace(1)* %17
   %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
   store i8 0, i8 addrspace(1)* %20
   %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
-  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
@@ -9325,31 +10914,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %19
+ThrowNullRef14:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9367,8 +10956,8 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
@@ -9380,8 +10969,8 @@ entry:
 
 ; <label>:9                                       ; preds = %4
   %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %9
   %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
@@ -9395,7 +10984,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef2:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9420,8 +11009,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
@@ -9512,8 +11101,8 @@ entry:
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
@@ -9524,8 +11113,8 @@ entry:
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = load i64, i64 addrspace(1)* %12
@@ -9537,8 +11126,8 @@ entry:
   %20 = load i64, i64* %19
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
-  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %13
   %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
@@ -9555,8 +11144,8 @@ entry:
 ; <label>:30                                      ; preds = %25
   %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %32 = load i32, i32* %arg2
-  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
-  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
@@ -9570,15 +11159,15 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %30
+ThrowNullRef2:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9622,87 +11211,87 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
   %10 = load i8, i8 addrspace(1)* %9, align 8
   %11 = zext i8 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %8
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
   store i8 %12, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
   %19 = load i8, i8 addrspace(1)* %18, align 8
   %20 = zext i8 %19 to i32
   %21 = trunc i32 %20 to i8
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
   store i8 %21, i8 addrspace(1)* %23
   %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
   %28 = load i8, i8 addrspace(1)* %27, align 8
   %29 = zext i8 %28 to i32
   %30 = trunc i32 %29 to i8
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
-  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %31
 
 ; <label>:31                                      ; preds = %26
   %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
   store i8 %30, i8 addrspace(1)* %32
   %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
-  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
-  br i1 %NullCheck14, label %40, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %40
 
 ; <label>:40                                      ; preds = %35
   %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
   store i8 %39, i8 addrspace(1)* %41
   %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
-  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %44
 
 ; <label>:44                                      ; preds = %40
   %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
   %46 = load i8, i8 addrspace(1)* %45, align 8
   %47 = zext i8 %46 to i32
   %48 = trunc i32 %47 to i8
-  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
   store i8 %48, i8 addrspace(1)* %50
   %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
-  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
@@ -9713,29 +11302,29 @@ entry:
 ; <label>:56                                      ; preds = %52
   %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
-  br i1 %NullCheck22, label %59, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
   %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
   %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
-  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
-  br i1 %NullCheck24, label %63, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
   %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
-  br i1 %NullCheck26, label %66, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
   %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
-  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
-  br i1 %NullCheck28, label %69, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %69
 
 ; <label>:69                                      ; preds = %66
   %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
@@ -9744,15 +11333,15 @@ entry:
 
 ; <label>:71                                      ; preds = %105
   %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
-  br i1 %NullCheck34, label %73, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %73
 
 ; <label>:73                                      ; preds = %71
   %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
   %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
   %76 = load i32, i32* %loc0
-  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
-  br i1 %NullCheck36, label %77, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
@@ -9766,8 +11355,8 @@ entry:
 
 ; <label>:83                                      ; preds = %77
   %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
-  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
@@ -9775,14 +11364,14 @@ entry:
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
   %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
-  br i1 %NullCheck40, label %91, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
 ; <label>:91                                      ; preds = %85
   %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
   %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
-  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck42, label %94, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %94
 
 ; <label>:94                                      ; preds = %91
   %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
@@ -9798,14 +11387,14 @@ entry:
 ; <label>:99                                      ; preds = %69, %96
   %100 = load i32, i32* %loc0
   %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
-  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %102
 
 ; <label>:102                                     ; preds = %99
   %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
   %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
-  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
-  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
@@ -9819,87 +11408,87 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %26
+ThrowNullRef10:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %31
+ThrowNullRef12:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %35
+ThrowNullRef14:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %40
+ThrowNullRef16:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %56
+ThrowNullRef22:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %59
+ThrowNullRef24:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %63
+ThrowNullRef26:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %66
+ThrowNullRef28:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %102
+ThrowNullRef32:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %71
+ThrowNullRef34:                                   ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %73
+ThrowNullRef36:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %83
+ThrowNullRef38:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %85
+ThrowNullRef40:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %91
+ThrowNullRef42:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9943,15 +11532,15 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
   %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
@@ -9961,28 +11550,28 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
   %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %12
   %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
   %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
   %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
-  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
@@ -9993,23 +11582,23 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %12
+ThrowNullRef6:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10031,15 +11620,15 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
   %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = load i64, i64 addrspace(1)* %7
@@ -10077,13 +11666,13 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[loadElem]
+Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -10111,8 +11700,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -10195,8 +11784,8 @@ entry:
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load double, double* %arg0
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -10330,8 +11919,8 @@ entry:
   store i64 %param0, i64* %arg0
   store i64 %param1, i64* %arg1
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
@@ -10339,8 +11928,8 @@ entry:
   %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
   %5 = load i16*, i16* addrspace(1)* %4, align 8
   %6 = addrspacecast i64* %arg1 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = bitcast i64 addrspace(1)* %6 to i8 addrspace(1)*
@@ -10356,7 +11945,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10390,8 +11979,8 @@ entry:
   %1 = load i32, i32* %arg1
   %2 = sext i32 %1 to i64
   %3 = inttoptr i64 %2 to i16*
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -10444,8 +12033,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, i32)*)(%System.IO.ConsoleStream addrspace(1)* %2, i32 %1)
   %3 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %4 = load i64, i64* %arg1
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
@@ -10456,8 +12045,8 @@ entry:
   %10 = icmp eq i32 %9, 3
   %11 = sext i1 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %5
   %14 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, i32 0, i32 5
@@ -10468,7 +12057,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10491,8 +12080,8 @@ entry:
   %5 = icmp eq i32 %4, 1
   %6 = sext i1 %5 to i32
   %7 = trunc i32 %6 to i8
-  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %2, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.ConsoleStream addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
@@ -10503,8 +12092,8 @@ entry:
   %13 = icmp eq i32 %12, 2
   %14 = sext i1 %13 to i32
   %15 = trunc i32 %14 to i8
-  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %10, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.ConsoleStream addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %8
   %17 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %10, i32 0, i32 4
@@ -10515,7 +12104,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10554,8 +12143,8 @@ entry:
   %arg0 = alloca i64
   store i64 %param0, i64* %arg0
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
@@ -10590,8 +12179,8 @@ entry:
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
   %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = load i64, i64 addrspace(1)* %7
@@ -10695,7 +12284,127 @@ entry:
 INFO:  jitting method Encoding::GetEncoding using LLILCJit
 Failed to read Encoding.GetEncoding[convertToHelperArgumentType]
 INFO:  jitting method EncodingProvider::GetEncodingFromProvider using LLILCJit
-Failed to read EncodingProvider.GetEncodingFromProvider[loadElem]
+Successfully read EncodingProvider.GetEncodingFromProvider
+
+define %System.Text.Encoding addrspace(1)* @EncodingProvider.GetEncodingFromProvider(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca %"System.Text.EncodingProvider[]" addrspace(1)*
+  %loc1 = alloca %System.Text.EncodingProvider addrspace(1)*
+  %loc2 = alloca %System.Text.Encoding addrspace(1)*
+  %loc3 = alloca %System.Text.Encoding addrspace(1)*
+  %loc4 = alloca %"System.Text.EncodingProvider[]" addrspace(1)*
+  %loc5 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1059)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2392
+  %2 = addrspacecast i8 addrspace(1)* %1 to %"System.Text.EncodingProvider[]" addrspace(1)**
+  %3 = load volatile %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %2
+  %4 = icmp ne %"System.Text.EncodingProvider[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %entry
+  ret %System.Text.Encoding addrspace(1)* null
+
+; <label>:6                                       ; preds = %entry
+  %7 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1059)
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i64 2392
+  %9 = addrspacecast i8 addrspace(1)* %8 to %"System.Text.EncodingProvider[]" addrspace(1)**
+  %10 = load volatile %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %9
+  store %"System.Text.EncodingProvider[]" addrspace(1)* %10, %"System.Text.EncodingProvider[]" addrspace(1)** %loc0
+  %11 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc0
+  store %"System.Text.EncodingProvider[]" addrspace(1)* %11, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  store i32 0, i32* %loc5
+  br label %43
+
+; <label>:12                                      ; preds = %46
+  %13 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  %14 = load i32, i32* %loc5
+  %NullCheck1 = icmp eq %"System.Text.EncodingProvider[]" addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %13, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = zext i32 %17 to i64
+  %19 = zext i32 %14 to i64
+  %BoundsCheck = icmp uge i64 %19, %18
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %20
+
+; <label>:20                                      ; preds = %15
+  %21 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %13, i32 0, i32 3, i32 %14
+  %22 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)* addrspace(1)* %21, align 8
+  store %System.Text.EncodingProvider addrspace(1)* %22, %System.Text.EncodingProvider addrspace(1)** %loc1
+  %23 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)** %loc1
+  %24 = load i32, i32* %arg0
+  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i64 addrspace(1)*
+  %NullCheck3 = icmp eq i64 addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
+
+; <label>:26                                      ; preds = %20
+  %27 = load i64, i64 addrspace(1)* %25
+  %28 = add i64 %27, 64
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 40
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Text.Encoding addrspace(1)* (%System.Text.EncodingProvider addrspace(1)*, i32)*
+  %35 = call %System.Text.Encoding addrspace(1)* %34(%System.Text.EncodingProvider addrspace(1)* %23, i32 %24)
+  store %System.Text.Encoding addrspace(1)* %35, %System.Text.Encoding addrspace(1)** %loc2
+  %36 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc2
+  %37 = icmp eq %System.Text.Encoding addrspace(1)* %36, null
+  br i1 %37, label %40, label %38
+
+; <label>:38                                      ; preds = %26
+  %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc2
+  store %System.Text.Encoding addrspace(1)* %39, %System.Text.Encoding addrspace(1)** %loc3
+  br label %53
+
+; <label>:40                                      ; preds = %26
+  %41 = load i32, i32* %loc5
+  %42 = add i32 %41, 1
+  store i32 %42, i32* %loc5
+  br label %43
+
+; <label>:43                                      ; preds = %6, %40
+  %44 = load i32, i32* %loc5
+  %45 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  %NullCheck = icmp eq %"System.Text.EncodingProvider[]" addrspace(1)* %45, null
+  br i1 %NullCheck, label %ThrowNullRef, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp slt i32 %44, %50
+  br i1 %51, label %12, label %52
+
+; <label>:52                                      ; preds = %46
+  ret %System.Text.Encoding addrspace(1)* null
+
+; <label>:53                                      ; preds = %38
+  %54 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc3
+  ret %System.Text.Encoding addrspace(1)* %54
+
+ThrowNullRef:                                     ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method EncodingProvider::.cctor using LLILCJit
 Successfully read EncodingProvider..cctor
 
@@ -10714,7 +12423,7 @@ Failed to read Encoding.get_InternalSyncObject[Call HasTypeArg]
 INFO:  jitting method Hashtable::.ctor using LLILCJit
 Failed to read Hashtable..ctor[Volatile store]
 INFO:  jitting method Hashtable::get_Item using LLILCJit
-Failed to read Hashtable.get_Item[loadElemA]
+Failed to read Hashtable.get_Item[loadNonPrimitiveObj]
 INFO:  jitting method Hashtable::InitHash using LLILCJit
 Successfully read Hashtable.InitHash
 
@@ -10734,8 +12443,8 @@ entry:
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -10751,15 +12460,15 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
   %15 = load i32, i32* %loc0
-  %NullCheck2 = icmp ne i32 addrspace(1)* %14, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i32 addrspace(1)* %14, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %3
   store i32 %15, i32 addrspace(1)* %14, align 8
   %17 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %18 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %NullCheck4 = icmp ne i32 addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i32 addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = load i32, i32 addrspace(1)* %18, align 8
@@ -10768,8 +12477,8 @@ entry:
   %23 = sub i32 %22, 1
   %24 = urem i32 %21, %23
   %25 = add i32 1, %24
-  %NullCheck6 = icmp ne i32 addrspace(1)* %17, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32 addrspace(1)* %17, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %19
   store i32 %25, i32 addrspace(1)* %17, align 8
@@ -10780,15 +12489,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %19
+ThrowNullRef6:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10803,8 +12512,8 @@ entry:
   store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
   store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %NullCheck = icmp ne %System.Collections.Hashtable addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Collections.Hashtable addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
@@ -10814,16 +12523,16 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Collections.Hashtable addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Collections.Hashtable addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
   %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck4 = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %9, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
   %13 = inttoptr i64 %11 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
@@ -10833,8 +12542,8 @@ entry:
 ; <label>:15                                      ; preds = %1
   %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -10852,15 +12561,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10874,8 +12583,8 @@ entry:
   store %System.Int32 addrspace(1)* %param0, %System.Int32 addrspace(1)** %this
   %0 = load %System.Int32 addrspace(1)*, %System.Int32 addrspace(1)** %this
   %1 = bitcast %System.Int32 addrspace(1)* %0 to i32 addrspace(1)*
-  %NullCheck = icmp ne i32 addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq i32 addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load i32, i32 addrspace(1)* %1, align 8
@@ -10951,8 +12660,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.UTF8Encoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
@@ -10961,15 +12670,15 @@ entry:
   %9 = load i8, i8* %arg2
   %10 = zext i8 %9 to i32
   %11 = trunc i32 %10 to i8
-  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %8, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %6
   %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %8, i32 0, i32 8
   store i8 %11, i8 addrspace(1)* %13
   %14 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %14, i32 0, i32 8
@@ -10981,8 +12690,8 @@ entry:
 ; <label>:20                                      ; preds = %15
   %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %22, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %22, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = load i64, i64 addrspace(1)* %22
@@ -11004,15 +12713,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %12
+ThrowNullRef4:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11027,8 +12736,8 @@ entry:
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
@@ -11050,16 +12759,16 @@ entry:
 ; <label>:10                                      ; preds = %1
   %11 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
   %12 = load i32, i32* %arg1
-  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %11, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.Encoding addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
   store i32 %12, i32 addrspace(1)* %14
   %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
   %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = load i64, i64 addrspace(1)* %16
@@ -11077,11 +12786,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11094,8 +12803,8 @@ entry:
   %this = alloca %System.Text.UTF8Encoding addrspace(1)*
   store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
   %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.UTF8Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
@@ -11107,16 +12816,16 @@ entry:
 ; <label>:6                                       ; preds = %1
   %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %8 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %10, %System.Text.EncoderFallback addrspace(1)* %8)
   %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %12 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
-  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %11, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %11, i32 0, i32 3
@@ -11129,8 +12838,8 @@ entry:
   %18 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %18, %System.String addrspace(1)* %17)
   %19 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %18 to %System.Text.EncoderFallback addrspace(1)*
-  %NullCheck6 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %16, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %16, i32 0, i32 2
@@ -11140,8 +12849,8 @@ entry:
   %24 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %24, %System.String addrspace(1)* %23)
   %25 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %24 to %System.Text.DecoderFallback addrspace(1)*
-  %NullCheck8 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %22, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %22, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %20
   %27 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %22, i32 0, i32 3
@@ -11152,19 +12861,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %20
+ThrowNullRef8:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11194,8 +12903,8 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load i32, i32* %arg1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -11213,8 +12922,8 @@ entry:
 ; <label>:15                                      ; preds = %8
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %17 = load i32, i32* %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 %17
@@ -11230,7 +12939,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11282,7 +12991,7 @@ entry:
 }
 
 INFO:  jitting method Hashtable::Insert using LLILCJit
-Failed to read Hashtable.Insert[loadElemA]
+Failed to read Hashtable.Insert[storeElem]
 INFO:  jitting method ConsoleEncoding::.ctor using LLILCJit
 Successfully read ConsoleEncoding..ctor
 
@@ -11297,8 +13006,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %1)
   %2 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
@@ -11334,8 +13043,8 @@ entry:
   %2 = call %System.Text.InternalEncoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalEncoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %1)
   %3 = bitcast %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2 to %System.Text.EncoderFallback addrspace(1)*
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
@@ -11345,8 +13054,8 @@ entry:
   %8 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %7)
   %9 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %8 to %System.Text.DecoderFallback addrspace(1)*
-  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %6, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.Encoding addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %4
   %11 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %6, i32 0, i32 3
@@ -11357,7 +13066,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11376,15 +13085,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* %1)
   %2 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   %6 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, i32 0, i32 1
@@ -11395,7 +13104,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11423,8 +13132,8 @@ entry:
   store %System.Text.InternalDecoderBestFitFallback addrspace(1)* %param0, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
   %0 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
@@ -11434,15 +13143,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %4)
   %5 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %6)
   %9 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, i32 0, i32 1
@@ -11453,11 +13162,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11525,8 +13234,8 @@ entry:
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
   %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = load i64, i64 addrspace(1)* %19
@@ -11590,8 +13299,8 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.ConsoleStream addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
@@ -11622,31 +13331,31 @@ entry:
   store i8 %param4, i8* %arg4
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %3, %System.IO.Stream addrspace(1)* %1)
   %4 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %4, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
   %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %4, i32 0, i32 4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %5)
   %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %6
   %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
   %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
   %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = load i64, i64 addrspace(1)* %13
@@ -11658,8 +13367,8 @@ entry:
   %21 = load i64, i64* %20
   %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %8, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %8, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %14
   %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 5
@@ -11677,24 +13386,24 @@ entry:
   %31 = load i32, i32* %arg3
   %32 = sext i32 %31 to i64
   %33 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %32)
-  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %30, null
-  br i1 %NullCheck10, label %34, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.StreamWriter addrspace(1)* %30, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %35, %"System.Char[]" addrspace(1)* %33)
   %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %37, null
-  br i1 %NullCheck12, label %38, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.StreamWriter addrspace(1)* %37, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %38
 
 ; <label>:38                                      ; preds = %34
   %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
   %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
   %41 = load i32, i32* %arg3
   %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %42, null
-  br i1 %NullCheck14, label %43, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %42, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
   %44 = load i64, i64 addrspace(1)* %42
@@ -11708,30 +13417,30 @@ entry:
   %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
   %53 = sext i32 %52 to i64
   %54 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %53)
-  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
-  br i1 %NullCheck16, label %55, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %55
 
 ; <label>:55                                      ; preds = %43
   %56 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %56, %"System.Byte[]" addrspace(1)* %54)
   %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %58 = load i32, i32* %arg3
-  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %57, null
-  br i1 %NullCheck18, label %59, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.StreamWriter addrspace(1)* %57, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %59
 
 ; <label>:59                                      ; preds = %55
   %60 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 10
   store i32 %58, i32 addrspace(1)* %60
   %61 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %61, null
-  br i1 %NullCheck20, label %62, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.IO.StreamWriter addrspace(1)* %61, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %62
 
 ; <label>:62                                      ; preds = %59
   %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
   %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
   %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
   %67 = load i64, i64 addrspace(1)* %65
@@ -11749,15 +13458,15 @@ entry:
 
 ; <label>:78                                      ; preds = %66
   %79 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %79, null
-  br i1 %NullCheck24, label %80, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.StreamWriter addrspace(1)* %79, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %80
 
 ; <label>:80                                      ; preds = %78
   %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
   %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
   %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %83, null
-  br i1 %NullCheck26, label %84, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %83, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
   %85 = load i64, i64 addrspace(1)* %83
@@ -11774,8 +13483,8 @@ entry:
 
 ; <label>:95                                      ; preds = %84
   %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.IO.StreamWriter addrspace(1)* %96, null
-  br i1 %NullCheck28, label %97, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.IO.StreamWriter addrspace(1)* %96, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %97
 
 ; <label>:97                                      ; preds = %95
   %98 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 12
@@ -11789,8 +13498,8 @@ entry:
   %103 = icmp eq i32 %102, 0
   %104 = sext i1 %103 to i32
   %105 = trunc i32 %104 to i8
-  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %100, null
-  br i1 %NullCheck30, label %106, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.IO.StreamWriter addrspace(1)* %100, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %106
 
 ; <label>:106                                     ; preds = %99
   %107 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %100, i32 0, i32 13
@@ -11801,63 +13510,63 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %6
+ThrowNullRef4:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %29
+ThrowNullRef10:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %34
+ThrowNullRef12:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %38
+ThrowNullRef14:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %43
+ThrowNullRef16:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %55
+ThrowNullRef18:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %59
+ThrowNullRef20:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %62
+ThrowNullRef22:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %78
+ThrowNullRef24:                                   ; preds = %78
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %80
+ThrowNullRef26:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %95
+ThrowNullRef28:                                   ; preds = %95
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11870,15 +13579,15 @@ entry:
   %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = load i64, i64 addrspace(1)* %4
@@ -11896,7 +13605,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11946,35 +13655,35 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
   %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderNLS addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %7 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.EncoderNLS addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Text.Encoding addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.Encoding addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Text.EncoderNLS addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.EncoderNLS addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
   %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck8 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = load i64, i64 addrspace(1)* %16
@@ -11993,19 +13702,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12031,8 +13740,8 @@ entry:
   %this = alloca %System.Text.Encoding addrspace(1)*
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
@@ -12052,15 +13761,15 @@ entry:
   %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
   store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
   %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
   store i32 0, i32 addrspace(1)* %2
   %3 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, i32 0, i32 2
@@ -12070,15 +13779,15 @@ entry:
 
 ; <label>:8                                       ; preds = %4
   %9 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
   %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
   %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = load i64, i64 addrspace(1)* %13
@@ -12099,15 +13808,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12122,16 +13831,16 @@ entry:
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = load i32, i32* %arg1
   %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
   %7 = load i64, i64 addrspace(1)* %5
@@ -12149,7 +13858,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12186,8 +13895,8 @@ entry:
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
   %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
   %16 = load i64, i64 addrspace(1)* %14
@@ -12208,8 +13917,8 @@ entry:
   %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
   %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
   %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %31, null
-  br i1 %NullCheck2, label %32, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = load i64, i64 addrspace(1)* %31
@@ -12252,7 +13961,7 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12265,14 +13974,14 @@ entry:
   %this = alloca %System.Text.EncoderReplacementFallback addrspace(1)*
   store %System.Text.EncoderReplacementFallback addrspace(1)* %param0, %System.Text.EncoderReplacementFallback addrspace(1)** %this
   %0 = load %System.Text.EncoderReplacementFallback addrspace(1)*, %System.Text.EncoderReplacementFallback addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -12283,7 +13992,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12313,8 +14022,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
@@ -12346,8 +14055,8 @@ entry:
   %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
   store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
@@ -12359,8 +14068,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Threading.Tasks.Task addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %7)
@@ -12383,7 +14092,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12402,8 +14111,8 @@ entry:
   store i8 %param1, i8* %arg1
   store i8 %param2, i8* %arg2
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
@@ -12417,8 +14126,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1, %5
   %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 9
@@ -12449,8 +14158,8 @@ entry:
 
 ; <label>:25                                      ; preds = %8, %20
   %26 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %26, null
-  br i1 %NullCheck4, label %27, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %26, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %26, i32 0, i32 12
@@ -12461,22 +14170,22 @@ entry:
 
 ; <label>:32                                      ; preds = %27
   %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %33, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.IO.StreamWriter addrspace(1)* %33, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %32
   %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 12
   store i8 1, i8 addrspace(1)* %35
   %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
-  br i1 %NullCheck8, label %37, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
   %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
   %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck10 = icmp ne i64 addrspace(1)* %40, null
-  br i1 %NullCheck10, label %41, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64 addrspace(1)* %40, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i64, i64 addrspace(1)* %40
@@ -12490,8 +14199,8 @@ entry:
   %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
   store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
   %51 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %NullCheck12 = icmp ne %"System.Byte[]" addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Byte[]" addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %41
   %53 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %51, i32 0, i32 1
@@ -12503,16 +14212,16 @@ entry:
 
 ; <label>:58                                      ; preds = %52
   %59 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %59, null
-  br i1 %NullCheck14, label %60, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.IO.StreamWriter addrspace(1)* %59, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %60
 
 ; <label>:60                                      ; preds = %58
   %61 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %59, i32 0, i32 3
   %62 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
   %64 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %NullCheck16 = icmp ne %"System.Byte[]" addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %"System.Byte[]" addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %60
   %66 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %64, i32 0, i32 1
@@ -12520,8 +14229,8 @@ entry:
   %68 = zext i32 %67 to i64
   %69 = trunc i64 %68 to i32
   %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck18, label %71, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
   %72 = load i64, i64 addrspace(1)* %70
@@ -12537,29 +14246,29 @@ entry:
 
 ; <label>:80                                      ; preds = %27, %52, %71
   %81 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %81, null
-  br i1 %NullCheck20, label %82, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.IO.StreamWriter addrspace(1)* %81, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
 
 ; <label>:82                                      ; preds = %80
   %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %81, i32 0, i32 5
   %84 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %83, align 8
   %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.IO.StreamWriter addrspace(1)* %85, null
-  br i1 %NullCheck22, label %86, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.IO.StreamWriter addrspace(1)* %85, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %86
 
 ; <label>:86                                      ; preds = %82
   %87 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 7
   %88 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %87, align 8
   %89 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %89, null
-  br i1 %NullCheck24, label %90, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.StreamWriter addrspace(1)* %89, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %90
 
 ; <label>:90                                      ; preds = %86
   %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %89, i32 0, i32 9
   %92 = load i32, i32 addrspace(1)* %91, align 8
   %93 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.IO.StreamWriter addrspace(1)* %93, null
-  br i1 %NullCheck26, label %94, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.IO.StreamWriter addrspace(1)* %93, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %93, i32 0, i32 6
@@ -12567,8 +14276,8 @@ entry:
   %97 = load i8, i8* %arg2
   %98 = zext i8 %97 to i32
   %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
-  %NullCheck28 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck28, label %100, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
   %101 = load i64, i64 addrspace(1)* %99
@@ -12583,8 +14292,8 @@ entry:
   %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
   store i32 %110, i32* %loc1
   %111 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %111, null
-  br i1 %NullCheck30, label %112, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.IO.StreamWriter addrspace(1)* %111, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %112
 
 ; <label>:112                                     ; preds = %100
   %113 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %111, i32 0, i32 9
@@ -12595,23 +14304,23 @@ entry:
 
 ; <label>:116                                     ; preds = %112
   %117 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck32 = icmp ne %System.IO.StreamWriter addrspace(1)* %117, null
-  br i1 %NullCheck32, label %118, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.IO.StreamWriter addrspace(1)* %117, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %118
 
 ; <label>:118                                     ; preds = %116
   %119 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %117, i32 0, i32 3
   %120 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %119, align 8
   %121 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.IO.StreamWriter addrspace(1)* %121, null
-  br i1 %NullCheck34, label %122, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.IO.StreamWriter addrspace(1)* %121, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %122
 
 ; <label>:122                                     ; preds = %118
   %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
   %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
   %125 = load i32, i32* %loc1
   %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
-  %NullCheck36 = icmp ne i64 addrspace(1)* %126, null
-  br i1 %NullCheck36, label %127, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64 addrspace(1)* %126, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
   %128 = load i64, i64 addrspace(1)* %126
@@ -12633,15 +14342,15 @@ entry:
 
 ; <label>:140                                     ; preds = %136
   %141 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.IO.StreamWriter addrspace(1)* %141, null
-  br i1 %NullCheck38, label %142, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.IO.StreamWriter addrspace(1)* %141, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %142
 
 ; <label>:142                                     ; preds = %140
   %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
   %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
   %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
-  %NullCheck40 = icmp ne i64 addrspace(1)* %145, null
-  br i1 %NullCheck40, label %146, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i64 addrspace(1)* %145, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
   %147 = load i64, i64 addrspace(1)* %145
@@ -12662,83 +14371,83 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %25
+ThrowNullRef4:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %32
+ThrowNullRef6:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %37
+ThrowNullRef10:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %41
+ThrowNullRef12:                                   ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %58
+ThrowNullRef14:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %60
+ThrowNullRef16:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %65
+ThrowNullRef18:                                   ; preds = %65
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %80
+ThrowNullRef20:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %82
+ThrowNullRef22:                                   ; preds = %82
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %86
+ThrowNullRef24:                                   ; preds = %86
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %90
+ThrowNullRef26:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %94
+ThrowNullRef28:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %100
+ThrowNullRef30:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %116
+ThrowNullRef32:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %118
+ThrowNullRef34:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %122
+ThrowNullRef36:                                   ; preds = %122
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %140
+ThrowNullRef38:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %142
+ThrowNullRef40:                                   ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12805,8 +14514,8 @@ entry:
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %1 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
-  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
@@ -12814,8 +14523,8 @@ entry:
   %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
   %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
   %8 = load i64, i64 addrspace(1)* %6
@@ -12831,8 +14540,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %17, %System.IFormatProvider addrspace(1)* %16)
   %18 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %19 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %18, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.SyncTextWriter addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %7
   %21 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %18, i32 0, i32 4
@@ -12843,11 +14552,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12860,8 +14569,8 @@ entry:
   %this = alloca %System.IO.TextWriter addrspace(1)*
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.TextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
@@ -12871,8 +14580,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.Threading.Thread addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Threading.Thread addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %6)
@@ -12881,8 +14590,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1
   %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.TextWriter addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.TextWriter addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %11, i32 0, i32 2
@@ -12893,11 +14602,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13094,8 +14803,8 @@ entry:
   store double %param1, double* %arg1
   store i8 0, i8* %loc1
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
@@ -13105,16 +14814,16 @@ entry:
   %5 = addrspacecast i8* %loc1 to i8 addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %4, i8 addrspace(1)* %5)
   %6 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.SyncTextWriter addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
   %10 = load double, double* %arg1
   %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
   %13 = load i64, i64 addrspace(1)* %11
@@ -13149,11 +14858,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13170,8 +14879,8 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load double, double* %arg1
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -13185,8 +14894,8 @@ entry:
   call void %11(%System.IO.TextWriter addrspace(1)* %0, double %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
   %15 = load i64, i64 addrspace(1)* %13
@@ -13204,7 +14913,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13222,8 +14931,8 @@ entry:
   %1 = addrspacecast double* %arg1 to double addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -13238,8 +14947,8 @@ entry:
   %14 = bitcast double addrspace(1)* %1 to %System.Double addrspace(1)*
   %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Double addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Double addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
   %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
   %18 = load i64, i64 addrspace(1)* %16
@@ -13257,7 +14966,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13273,8 +14982,8 @@ entry:
   store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
   %0 = load %System.Double addrspace(1)*, %System.Double addrspace(1)** %this
   %1 = bitcast %System.Double addrspace(1)* %0 to double addrspace(1)*
-  %NullCheck = icmp ne double addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq double addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load double, double addrspace(1)* %1, align 8
@@ -13299,8 +15008,8 @@ entry:
   %loc0 = alloca %System.Globalization.NumberFormatInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 3
@@ -13310,8 +15019,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
@@ -13321,24 +15030,24 @@ entry:
   store %System.Globalization.NumberFormatInfo addrspace(1)* %10, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
   %11 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %7
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
   %15 = load i8, i8 addrspace(1)* %14, align 8
   %16 = zext i8 %15 to i32
   %17 = trunc i32 %16 to i8
-  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %11, null
-  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %11, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %13
   %19 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %11, i32 0, i32 29
   store i8 %17, i8 addrspace(1)* %19
   %20 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %21 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %20, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %20, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %18
   %23 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %20, i32 0, i32 3
@@ -13347,8 +15056,8 @@ entry:
 
 ; <label>:24                                      ; preds = %1, %22
   %25 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %25, null
-  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %25, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %26
 
 ; <label>:26                                      ; preds = %24
   %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %25, i32 0, i32 3
@@ -13359,23 +15068,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %18
+ThrowNullRef8:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13400,168 +15109,168 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 18
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %8, align 8
-  %NullCheck2 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %5, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %5, i32 0, i32 4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %9)
   %12 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 19
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %15, align 8
-  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %12, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %12, i32 0, i32 5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %16)
   %19 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %20 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %20, null
-  br i1 %NullCheck8, label %21, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %20, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %20, i32 0, i32 23
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  %NullCheck10 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %19, null
-  br i1 %NullCheck10, label %24, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %19, i32 0, i32 7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %25, %System.String addrspace(1)* %23)
   %26 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %27 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %27, i32 0, i32 22
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %29, align 8
-  %NullCheck14 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %26, null
-  br i1 %NullCheck14, label %31, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %26, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %26, i32 0, i32 6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %32, %System.String addrspace(1)* %30)
   %33 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %34 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Globalization.CultureData addrspace(1)* %34, null
-  br i1 %NullCheck16, label %35, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Globalization.CultureData addrspace(1)* %34, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %34, i32 0, i32 51
   %37 = load i32, i32 addrspace(1)* %36, align 8
-  %NullCheck18 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %33, null
-  br i1 %NullCheck18, label %38, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %33, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %33, i32 0, i32 21
   store i32 %37, i32 addrspace(1)* %39
   %40 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %41 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Globalization.CultureData addrspace(1)* %41, null
-  br i1 %NullCheck20, label %42, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Globalization.CultureData addrspace(1)* %41, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %41, i32 0, i32 52
   %44 = load i32, i32 addrspace(1)* %43, align 8
-  %NullCheck22 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %40, null
-  br i1 %NullCheck22, label %45, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %40, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %40, i32 0, i32 25
   store i32 %44, i32 addrspace(1)* %46
   %47 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %48 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.Globalization.CultureData addrspace(1)* %48, null
-  br i1 %NullCheck24, label %49, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Globalization.CultureData addrspace(1)* %48, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %49
 
 ; <label>:49                                      ; preds = %45
   %50 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %48, i32 0, i32 29
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck26 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %47, null
-  br i1 %NullCheck26, label %52, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %47, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %47, i32 0, i32 10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %53, %System.String addrspace(1)* %51)
   %54 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %55 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Globalization.CultureData addrspace(1)* %55, null
-  br i1 %NullCheck28, label %56, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Globalization.CultureData addrspace(1)* %55, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %56
 
 ; <label>:56                                      ; preds = %52
   %57 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %55, i32 0, i32 35
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %57, align 8
-  %NullCheck30 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %54, null
-  br i1 %NullCheck30, label %59, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %54, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %54, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %60, %System.String addrspace(1)* %58)
   %61 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %62 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck32 = icmp ne %System.Globalization.CultureData addrspace(1)* %62, null
-  br i1 %NullCheck32, label %63, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Globalization.CultureData addrspace(1)* %62, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %62, i32 0, i32 34
   %65 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %64, align 8
-  %NullCheck34 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %61, null
-  br i1 %NullCheck34, label %66, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %61, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %61, i32 0, i32 9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %67, %System.String addrspace(1)* %65)
   %68 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %69 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck36 = icmp ne %System.Globalization.CultureData addrspace(1)* %69, null
-  br i1 %NullCheck36, label %70, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Globalization.CultureData addrspace(1)* %69, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %70
 
 ; <label>:70                                      ; preds = %66
   %71 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %69, i32 0, i32 55
   %72 = load i32, i32 addrspace(1)* %71, align 8
-  %NullCheck38 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %68, null
-  br i1 %NullCheck38, label %73, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %68, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %68, i32 0, i32 22
   store i32 %72, i32 addrspace(1)* %74
   %75 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %76 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck40 = icmp ne %System.Globalization.CultureData addrspace(1)* %76, null
-  br i1 %NullCheck40, label %77, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Globalization.CultureData addrspace(1)* %76, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %76, i32 0, i32 57
   %79 = load i32, i32 addrspace(1)* %78, align 8
-  %NullCheck42 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %75, null
-  br i1 %NullCheck42, label %80, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %75, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %80
 
 ; <label>:80                                      ; preds = %77
   %81 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %75, i32 0, i32 24
   store i32 %79, i32 addrspace(1)* %81
   %82 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %83 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck44 = icmp ne %System.Globalization.CultureData addrspace(1)* %83, null
-  br i1 %NullCheck44, label %84, label %ThrowNullRef43
+  %NullCheck43 = icmp eq %System.Globalization.CultureData addrspace(1)* %83, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %84
 
 ; <label>:84                                      ; preds = %80
   %85 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %83, i32 0, i32 56
   %86 = load i32, i32 addrspace(1)* %85, align 8
-  %NullCheck46 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %82, null
-  br i1 %NullCheck46, label %87, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %82, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %82, i32 0, i32 23
@@ -13570,8 +15279,8 @@ entry:
 
 ; <label>:89                                      ; preds = %entry
   %90 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck100 = icmp ne %System.Globalization.CultureData addrspace(1)* %90, null
-  br i1 %NullCheck100, label %91, label %ThrowNullRef99
+  %NullCheck99 = icmp eq %System.Globalization.CultureData addrspace(1)* %90, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %91
 
 ; <label>:91                                      ; preds = %89
   %92 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %90, i32 0, i32 2
@@ -13589,8 +15298,8 @@ entry:
   %102 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %103 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %104 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %103)
-  %NullCheck48 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %102, null
-  br i1 %NullCheck48, label %105, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %102, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %105
 
 ; <label>:105                                     ; preds = %101
   %106 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %102, i32 0, i32 1
@@ -13598,8 +15307,8 @@ entry:
   %107 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %108 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %109 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %108)
-  %NullCheck50 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %107, null
-  br i1 %NullCheck50, label %110, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %107, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %110
 
 ; <label>:110                                     ; preds = %105
   %111 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %107, i32 0, i32 2
@@ -13607,8 +15316,8 @@ entry:
   %112 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %113 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %114 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %113)
-  %NullCheck52 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %112, null
-  br i1 %NullCheck52, label %115, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %112, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %115
 
 ; <label>:115                                     ; preds = %110
   %116 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %112, i32 0, i32 27
@@ -13616,8 +15325,8 @@ entry:
   %117 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %118 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %119 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %118)
-  %NullCheck54 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %117, null
-  br i1 %NullCheck54, label %120, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %117, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %120
 
 ; <label>:120                                     ; preds = %115
   %121 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %117, i32 0, i32 26
@@ -13625,8 +15334,8 @@ entry:
   %122 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %123 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %124 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %123)
-  %NullCheck56 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %122, null
-  br i1 %NullCheck56, label %125, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %122, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %125
 
 ; <label>:125                                     ; preds = %120
   %126 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %122, i32 0, i32 17
@@ -13634,8 +15343,8 @@ entry:
   %127 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %128 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %129 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %128)
-  %NullCheck58 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %127, null
-  br i1 %NullCheck58, label %130, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %127, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %130
 
 ; <label>:130                                     ; preds = %125
   %131 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %127, i32 0, i32 18
@@ -13643,8 +15352,8 @@ entry:
   %132 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %133 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %134 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %133)
-  %NullCheck60 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %132, null
-  br i1 %NullCheck60, label %135, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %132, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %135
 
 ; <label>:135                                     ; preds = %130
   %136 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %132, i32 0, i32 14
@@ -13652,8 +15361,8 @@ entry:
   %137 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %138 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %139 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %138)
-  %NullCheck62 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %137, null
-  br i1 %NullCheck62, label %140, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %137, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %140
 
 ; <label>:140                                     ; preds = %135
   %141 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %137, i32 0, i32 13
@@ -13661,71 +15370,71 @@ entry:
   %142 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %143 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %144 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %143)
-  %NullCheck64 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %142, null
-  br i1 %NullCheck64, label %145, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %142, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %145
 
 ; <label>:145                                     ; preds = %140
   %146 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %142, i32 0, i32 12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %146, %System.String addrspace(1)* %144)
   %147 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %148 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck66 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %148, null
-  br i1 %NullCheck66, label %149, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %148, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %149
 
 ; <label>:149                                     ; preds = %145
   %150 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %148, i32 0, i32 21
   %151 = load i32, i32 addrspace(1)* %150, align 8
-  %NullCheck68 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %147, null
-  br i1 %NullCheck68, label %152, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %147, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %152
 
 ; <label>:152                                     ; preds = %149
   %153 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %147, i32 0, i32 28
   store i32 %151, i32 addrspace(1)* %153
   %154 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %155 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck70 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %155, null
-  br i1 %NullCheck70, label %156, label %ThrowNullRef69
+  %NullCheck69 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %155, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %156
 
 ; <label>:156                                     ; preds = %152
   %157 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %155, i32 0, i32 6
   %158 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %157, align 8
-  %NullCheck72 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %154, null
-  br i1 %NullCheck72, label %159, label %ThrowNullRef71
+  %NullCheck71 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %154, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %159
 
 ; <label>:159                                     ; preds = %156
   %160 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %154, i32 0, i32 15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %160, %System.String addrspace(1)* %158)
   %161 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %162 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck74 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %162, null
-  br i1 %NullCheck74, label %163, label %ThrowNullRef73
+  %NullCheck73 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %162, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %163
 
 ; <label>:163                                     ; preds = %159
   %164 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %162, i32 0, i32 1
   %165 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %164, align 8
-  %NullCheck76 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %161, null
-  br i1 %NullCheck76, label %166, label %ThrowNullRef75
+  %NullCheck75 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %161, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %166
 
 ; <label>:166                                     ; preds = %163
   %167 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %161, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %167, %"System.Int32[]" addrspace(1)* %165)
   %168 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %169 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck78 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %169, null
-  br i1 %NullCheck78, label %170, label %ThrowNullRef77
+  %NullCheck77 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %169, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %170
 
 ; <label>:170                                     ; preds = %166
   %171 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %169, i32 0, i32 7
   %172 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %171, align 8
-  %NullCheck80 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %168, null
-  br i1 %NullCheck80, label %173, label %ThrowNullRef79
+  %NullCheck79 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %168, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %173
 
 ; <label>:173                                     ; preds = %170
   %174 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %168, i32 0, i32 16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %174, %System.String addrspace(1)* %172)
   %175 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck82 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %175, null
-  br i1 %NullCheck82, label %176, label %ThrowNullRef81
+  %NullCheck81 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %175, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %176
 
 ; <label>:176                                     ; preds = %173
   %177 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %175, i32 0, i32 4
@@ -13735,14 +15444,14 @@ entry:
 
 ; <label>:180                                     ; preds = %176
   %181 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck84 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %181, null
-  br i1 %NullCheck84, label %182, label %ThrowNullRef83
+  %NullCheck83 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %181, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %182
 
 ; <label>:182                                     ; preds = %180
   %183 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %181, i32 0, i32 4
   %184 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %183, align 8
-  %NullCheck86 = icmp ne %System.String addrspace(1)* %184, null
-  br i1 %NullCheck86, label %185, label %ThrowNullRef85
+  %NullCheck85 = icmp eq %System.String addrspace(1)* %184, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %185
 
 ; <label>:185                                     ; preds = %182
   %186 = getelementptr inbounds %System.String, %System.String addrspace(1)* %184, i32 0, i32 1
@@ -13753,8 +15462,8 @@ entry:
 ; <label>:189                                     ; preds = %176, %185
   %190 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck98 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %190, null
-  br i1 %NullCheck98, label %192, label %ThrowNullRef97
+  %NullCheck97 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %190, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %192
 
 ; <label>:192                                     ; preds = %189
   %193 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %190, i32 0, i32 4
@@ -13763,8 +15472,8 @@ entry:
 
 ; <label>:194                                     ; preds = %185, %192
   %195 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck88 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %195, null
-  br i1 %NullCheck88, label %196, label %ThrowNullRef87
+  %NullCheck87 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %195, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %196
 
 ; <label>:196                                     ; preds = %194
   %197 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %195, i32 0, i32 9
@@ -13774,14 +15483,14 @@ entry:
 
 ; <label>:200                                     ; preds = %196
   %201 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck90 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %201, null
-  br i1 %NullCheck90, label %202, label %ThrowNullRef89
+  %NullCheck89 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %201, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %202
 
 ; <label>:202                                     ; preds = %200
   %203 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %201, i32 0, i32 9
   %204 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %203, align 8
-  %NullCheck92 = icmp ne %System.String addrspace(1)* %204, null
-  br i1 %NullCheck92, label %205, label %ThrowNullRef91
+  %NullCheck91 = icmp eq %System.String addrspace(1)* %204, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %205
 
 ; <label>:205                                     ; preds = %202
   %206 = getelementptr inbounds %System.String, %System.String addrspace(1)* %204, i32 0, i32 1
@@ -13792,14 +15501,14 @@ entry:
 ; <label>:209                                     ; preds = %196, %205
   %210 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %211 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck94 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %211, null
-  br i1 %NullCheck94, label %212, label %ThrowNullRef93
+  %NullCheck93 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %211, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %212
 
 ; <label>:212                                     ; preds = %209
   %213 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %211, i32 0, i32 6
   %214 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %213, align 8
-  %NullCheck96 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %210, null
-  br i1 %NullCheck96, label %215, label %ThrowNullRef95
+  %NullCheck95 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %210, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %215
 
 ; <label>:215                                     ; preds = %212
   %216 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %210, i32 0, i32 9
@@ -13813,203 +15522,203 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %17
+ThrowNullRef8:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %21
+ThrowNullRef10:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %24
+ThrowNullRef12:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %28
+ThrowNullRef14:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %31
+ThrowNullRef16:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %35
+ThrowNullRef18:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %38
+ThrowNullRef20:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %42
+ThrowNullRef22:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %45
+ThrowNullRef24:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %49
+ThrowNullRef26:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %52
+ThrowNullRef28:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %56
+ThrowNullRef30:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %59
+ThrowNullRef32:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %63
+ThrowNullRef34:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %66
+ThrowNullRef36:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %70
+ThrowNullRef38:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %73
+ThrowNullRef40:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %77
+ThrowNullRef42:                                   ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %80
+ThrowNullRef44:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %84
+ThrowNullRef46:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %101
+ThrowNullRef48:                                   ; preds = %101
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %105
+ThrowNullRef50:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %110
+ThrowNullRef52:                                   ; preds = %110
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %115
+ThrowNullRef54:                                   ; preds = %115
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %120
+ThrowNullRef56:                                   ; preds = %120
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %125
+ThrowNullRef58:                                   ; preds = %125
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %130
+ThrowNullRef60:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %135
+ThrowNullRef62:                                   ; preds = %135
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %140
+ThrowNullRef64:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %145
+ThrowNullRef66:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %149
+ThrowNullRef68:                                   ; preds = %149
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %152
+ThrowNullRef70:                                   ; preds = %152
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %156
+ThrowNullRef72:                                   ; preds = %156
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %159
+ThrowNullRef74:                                   ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %163
+ThrowNullRef76:                                   ; preds = %163
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %166
+ThrowNullRef78:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %170
+ThrowNullRef80:                                   ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %173
+ThrowNullRef82:                                   ; preds = %173
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %180
+ThrowNullRef84:                                   ; preds = %180
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %182
+ThrowNullRef86:                                   ; preds = %182
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %194
+ThrowNullRef88:                                   ; preds = %194
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %200
+ThrowNullRef90:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %202
+ThrowNullRef92:                                   ; preds = %202
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %209
+ThrowNullRef94:                                   ; preds = %209
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %212
+ThrowNullRef96:                                   ; preds = %212
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %189
+ThrowNullRef98:                                   ; preds = %189
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %89
+ThrowNullRef100:                                  ; preds = %89
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14037,8 +15746,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 21
@@ -14051,8 +15760,8 @@ entry:
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 16)
   %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 21
@@ -14061,8 +15770,8 @@ entry:
 
 ; <label>:12                                      ; preds = %1, %10
   %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 21
@@ -14073,11 +15782,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %12
+ThrowNullRef4:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14093,8 +15802,8 @@ entry:
   store i32 %param1, i32* %arg1
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %1 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
@@ -14161,8 +15870,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 33
@@ -14175,8 +15884,8 @@ entry:
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 24)
   %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 33
@@ -14185,8 +15894,8 @@ entry:
 
 ; <label>:12                                      ; preds = %1, %10
   %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 33
@@ -14197,11 +15906,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %12
+ThrowNullRef4:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14214,8 +15923,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 53
@@ -14227,8 +15936,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 116)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 53
@@ -14237,8 +15946,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 53
@@ -14249,11 +15958,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14282,8 +15991,8 @@ entry:
 
 ; <label>:7                                       ; preds = %entry, %4
   %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %7
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 2
@@ -14307,8 +16016,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 54
@@ -14320,8 +16029,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 117)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
@@ -14330,8 +16039,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 54
@@ -14342,11 +16051,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14359,8 +16068,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 27
@@ -14372,8 +16081,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 118)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 27
@@ -14382,8 +16091,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 27
@@ -14394,11 +16103,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14411,8 +16120,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 28
@@ -14424,8 +16133,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 119)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 28
@@ -14434,8 +16143,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 28
@@ -14446,11 +16155,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14463,8 +16172,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 26
@@ -14476,8 +16185,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 107)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 26
@@ -14486,8 +16195,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 26
@@ -14498,11 +16207,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14515,8 +16224,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 25
@@ -14528,8 +16237,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 106)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 25
@@ -14538,8 +16247,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 25
@@ -14550,11 +16259,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14567,8 +16276,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 24
@@ -14580,8 +16289,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 105)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 24
@@ -14590,8 +16299,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 24
@@ -14602,11 +16311,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14631,8 +16340,8 @@ entry:
   %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %3)
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %2
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -14643,15 +16352,15 @@ entry:
 
 ; <label>:8                                       ; preds = %62
   %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 9
   %12 = load i32, i32 addrspace(1)* %11, align 8
   %13 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.IO.StreamWriter addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %13, i32 0, i32 10
@@ -14666,15 +16375,15 @@ entry:
 
 ; <label>:20                                      ; preds = %14, %18
   %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
   %24 = load i32, i32 addrspace(1)* %23, align 8
   %25 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %25, null
-  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.StreamWriter addrspace(1)* %25, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %25, i32 0, i32 9
@@ -14695,36 +16404,36 @@ entry:
   %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %37 = load i32, i32* %loc1
   %38 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.StreamWriter addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %35
   %40 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %38, i32 0, i32 7
   %41 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %40, align 8
   %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
-  br i1 %NullCheck14, label %43, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %39
   %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 9
   %45 = load i32, i32 addrspace(1)* %44, align 8
   %46 = load i32, i32* %loc2
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %36, null
-  br i1 %NullCheck16, label %47, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %36, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %47
 
 ; <label>:47                                      ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %36, i32 %37, %"System.Char[]" addrspace(1)* %41, i32 %45, i32 %46)
   %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
   %51 = load i32, i32 addrspace(1)* %50, align 8
   %52 = load i32, i32* %loc2
   %53 = add i32 %51, %52
-  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
-  br i1 %NullCheck20, label %54, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %54
 
 ; <label>:54                                      ; preds = %49
   %55 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
@@ -14746,8 +16455,8 @@ entry:
 
 ; <label>:65                                      ; preds = %62
   %66 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %66, null
-  br i1 %NullCheck2, label %67, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %66, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %67
 
 ; <label>:67                                      ; preds = %65
   %68 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %66, i32 0, i32 11
@@ -14768,49 +16477,259 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %65
+ThrowNullRef2:                                    ; preds = %65
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %20
+ThrowNullRef8:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %22
+ThrowNullRef10:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %35
+ThrowNullRef12:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %43
+ThrowNullRef16:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %47
+ThrowNullRef18:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method String::CopyTo using LLILCJit
-Failed to read String.CopyTo[loadElemA]
+Successfully read String.CopyTo
+
+define void @String.CopyTo(%System.String addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  %loc1 = alloca i16 addrspace(1)*
+  %loc2 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %1 = icmp ne %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg4
+  %7 = icmp sge i32 %6, 0
+  br i1 %7, label %13, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  unreachable
+
+; <label>:13                                      ; preds = %5
+  %14 = load i32, i32* %arg1
+  %15 = icmp sge i32 %14, 0
+  br i1 %15, label %21, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %18)
+  %20 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %20, %System.String addrspace(1)* %17, %System.String addrspace(1)* %19)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %20) #0
+  unreachable
+
+; <label>:21                                      ; preds = %13
+  %22 = load i32, i32* %arg4
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck, label %ThrowNullRef, label %24
+
+; <label>:24                                      ; preds = %21
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load i32, i32* %arg1
+  %28 = sub i32 %26, %27
+  %29 = icmp sle i32 %22, %28
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34, %System.String addrspace(1)* %31, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %24
+  %36 = load i32, i32* %arg3
+  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %37, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
+
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
+  %40 = load i32, i32 addrspace(1)* %39
+  %41 = zext i32 %40 to i64
+  %42 = trunc i64 %41 to i32
+  %43 = load i32, i32* %arg4
+  %44 = sub i32 %42, %43
+  %45 = icmp sgt i32 %36, %44
+  br i1 %45, label %49, label %46
+
+; <label>:46                                      ; preds = %38
+  %47 = load i32, i32* %arg3
+  %48 = icmp sge i32 %47, 0
+  br i1 %48, label %54, label %49
+
+; <label>:49                                      ; preds = %38, %46
+  %50 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %52 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %51)
+  %53 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53, %System.String addrspace(1)* %50, %System.String addrspace(1)* %52)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53) #0
+  unreachable
+
+; <label>:54                                      ; preds = %46
+  %55 = load i32, i32* %arg4
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %97, label %57
+
+; <label>:57                                      ; preds = %54
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %59
+
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 2
+  %61 = bitcast [0 x i16] addrspace(1)* %60 to i16 addrspace(1)*
+  store i16 addrspace(1)* %61, i16 addrspace(1)** %loc0
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  store %"System.Char[]" addrspace(1)* %62, %"System.Char[]" addrspace(1)** %loc2
+  %63 = icmp eq %"System.Char[]" addrspace(1)* %62, null
+  br i1 %63, label %72, label %64
+
+; <label>:64                                      ; preds = %59
+  %65 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc2
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %65, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %66
+
+; <label>:66                                      ; preds = %64
+  %67 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %65, i32 0, i32 1
+  %68 = load i32, i32 addrspace(1)* %67
+  %69 = zext i32 %68 to i64
+  %70 = trunc i64 %69 to i32
+  %71 = icmp ne i32 %70, 0
+  br i1 %71, label %73, label %72
+
+; <label>:72                                      ; preds = %59, %66
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  br label %81
+
+; <label>:73                                      ; preds = %66
+  %74 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc2
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %74, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %75
+
+; <label>:75                                      ; preds = %73
+  %76 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %74, i32 0, i32 1
+  %77 = load i32, i32 addrspace(1)* %76
+  %78 = zext i32 %77 to i64
+  %BoundsCheck = icmp uge i64 0, %78
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %79
+
+; <label>:79                                      ; preds = %75
+  %80 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %74, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %80, i16 addrspace(1)** %loc1
+  br label %81
+
+; <label>:81                                      ; preds = %72, %79
+  %82 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %83 = ptrtoint i16 addrspace(1)* %82 to i64
+  %84 = load i32, i32* %arg3
+  %85 = sext i32 %84 to i64
+  %86 = mul i64 %85, 2
+  %87 = add i64 %83, %86
+  %88 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %89 = ptrtoint i16 addrspace(1)* %88 to i64
+  %90 = load i32, i32* %arg1
+  %91 = sext i32 %90 to i64
+  %92 = mul i64 %91, 2
+  %93 = add i64 %89, %92
+  %94 = load i32, i32* %arg4
+  %95 = inttoptr i64 %87 to i16*
+  %96 = inttoptr i64 %93 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %95, i16* %96, i32 %94)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  br label %97
+
+; <label>:97                                      ; preds = %54, %81
+  ret void
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
 Successfully read ConsoleEncoding.GetPreamble
 
@@ -14847,7 +16766,365 @@ entry:
 }
 
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[loadElemA]
+Successfully read EncoderNLS.GetBytes
+
+define i32 @EncoderNLS.GetBytes(%System.Text.EncoderNLS addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3, %"System.Byte[]" addrspace(1)* %param4, i32 %param5, i8 %param6) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %arg4 = alloca %"System.Byte[]" addrspace(1)*
+  %arg5 = alloca i32
+  %arg6 = alloca i8
+  %loc0 = alloca i32
+  %loc1 = alloca i16 addrspace(1)*
+  %loc2 = alloca i8 addrspace(1)*
+  %loc3 = alloca i32
+  %loc4 = alloca %"System.Char[]" addrspace(1)*
+  %loc5 = alloca %"System.Byte[]" addrspace(1)*
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  store %"System.Byte[]" addrspace(1)* %param4, %"System.Byte[]" addrspace(1)** %arg4
+  store i32 %param5, i32* %arg5
+  store i8 %param6, i8* %arg6
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %1 = icmp eq %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %17, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %7 = icmp eq %"System.Char[]" addrspace(1)* %6, null
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %12
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %12
+
+; <label>:12                                      ; preds = %8, %10
+  %13 = phi %System.String addrspace(1)* [ %9, %8 ], [ %11, %10 ]
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %14)
+  %16 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16, %System.String addrspace(1)* %13, %System.String addrspace(1)* %15)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16) #0
+  unreachable
+
+; <label>:17                                      ; preds = %2
+  %18 = load i32, i32* %arg2
+  %19 = icmp slt i32 %18, 0
+  br i1 %19, label %23, label %20
+
+; <label>:20                                      ; preds = %17
+  %21 = load i32, i32* %arg3
+  %22 = icmp sge i32 %21, 0
+  br i1 %22, label %35, label %23
+
+; <label>:23                                      ; preds = %17, %20
+  %24 = load i32, i32* %arg2
+  %25 = icmp slt i32 %24, 0
+  br i1 %25, label %28, label %26
+
+; <label>:26                                      ; preds = %23
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %30
+
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %30
+
+; <label>:30                                      ; preds = %26, %28
+  %31 = phi %System.String addrspace(1)* [ %27, %26 ], [ %29, %28 ]
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34, %System.String addrspace(1)* %31, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %20
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck, label %ThrowNullRef, label %37
+
+; <label>:37                                      ; preds = %35
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = load i32, i32* %arg2
+  %43 = sub i32 %41, %42
+  %44 = load i32, i32* %arg3
+  %45 = icmp sge i32 %43, %44
+  br i1 %45, label %51, label %46
+
+; <label>:46                                      ; preds = %37
+  %47 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %48 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %49 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %48)
+  %50 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %50, %System.String addrspace(1)* %47, %System.String addrspace(1)* %49)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %50) #0
+  unreachable
+
+; <label>:51                                      ; preds = %37
+  %52 = load i32, i32* %arg5
+  %53 = icmp slt i32 %52, 0
+  br i1 %53, label %63, label %54
+
+; <label>:54                                      ; preds = %51
+  %55 = load i32, i32* %arg5
+  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck1 = icmp eq %"System.Byte[]" addrspace(1)* %56, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %57
+
+; <label>:57                                      ; preds = %54
+  %58 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = zext i32 %59 to i64
+  %61 = trunc i64 %60 to i32
+  %62 = icmp sle i32 %55, %61
+  br i1 %62, label %68, label %63
+
+; <label>:63                                      ; preds = %51, %57
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %66 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %65)
+  %67 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %67, %System.String addrspace(1)* %64, %System.String addrspace(1)* %66)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %67) #0
+  unreachable
+
+; <label>:68                                      ; preds = %57
+  %69 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %69, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %69, i32 0, i32 1
+  %72 = load i32, i32 addrspace(1)* %71
+  %73 = zext i32 %72 to i64
+  %74 = trunc i64 %73 to i32
+  %75 = icmp ne i32 %74, 0
+  br i1 %75, label %78, label %76
+
+; <label>:76                                      ; preds = %70
+  %77 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1)
+  store %"System.Char[]" addrspace(1)* %77, %"System.Char[]" addrspace(1)** %arg1
+  br label %78
+
+; <label>:78                                      ; preds = %70, %76
+  %79 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck5 = icmp eq %"System.Byte[]" addrspace(1)* %79, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %80
+
+; <label>:80                                      ; preds = %78
+  %81 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %79, i32 0, i32 1
+  %82 = load i32, i32 addrspace(1)* %81
+  %83 = zext i32 %82 to i64
+  %84 = trunc i64 %83 to i32
+  %85 = load i32, i32* %arg5
+  %86 = sub i32 %84, %85
+  store i32 %86, i32* %loc0
+  %87 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck7 = icmp eq %"System.Byte[]" addrspace(1)* %87, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %88
+
+; <label>:88                                      ; preds = %80
+  %89 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %87, i32 0, i32 1
+  %90 = load i32, i32 addrspace(1)* %89
+  %91 = zext i32 %90 to i64
+  %92 = trunc i64 %91 to i32
+  %93 = icmp ne i32 %92, 0
+  br i1 %93, label %96, label %94
+
+; <label>:94                                      ; preds = %88
+  %95 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1)
+  store %"System.Byte[]" addrspace(1)* %95, %"System.Byte[]" addrspace(1)** %arg4
+  br label %96
+
+; <label>:96                                      ; preds = %88, %94
+  %97 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  store %"System.Char[]" addrspace(1)* %97, %"System.Char[]" addrspace(1)** %loc4
+  %98 = icmp eq %"System.Char[]" addrspace(1)* %97, null
+  br i1 %98, label %107, label %99
+
+; <label>:99                                      ; preds = %96
+  %100 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc4
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %100, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %101
+
+; <label>:101                                     ; preds = %99
+  %102 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %100, i32 0, i32 1
+  %103 = load i32, i32 addrspace(1)* %102
+  %104 = zext i32 %103 to i64
+  %105 = trunc i64 %104 to i32
+  %106 = icmp ne i32 %105, 0
+  br i1 %106, label %108, label %107
+
+; <label>:107                                     ; preds = %96, %101
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  br label %116
+
+; <label>:108                                     ; preds = %101
+  %109 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc4
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %109, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %110
+
+; <label>:110                                     ; preds = %108
+  %111 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %109, i32 0, i32 1
+  %112 = load i32, i32 addrspace(1)* %111
+  %113 = zext i32 %112 to i64
+  %BoundsCheck = icmp uge i64 0, %113
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %114
+
+; <label>:114                                     ; preds = %110
+  %115 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %109, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %115, i16 addrspace(1)** %loc1
+  br label %116
+
+; <label>:116                                     ; preds = %107, %114
+  %117 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  store %"System.Byte[]" addrspace(1)* %117, %"System.Byte[]" addrspace(1)** %loc5
+  %118 = icmp eq %"System.Byte[]" addrspace(1)* %117, null
+  br i1 %118, label %127, label %119
+
+; <label>:119                                     ; preds = %116
+  %120 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc5
+  %NullCheck13 = icmp eq %"System.Byte[]" addrspace(1)* %120, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %121
+
+; <label>:121                                     ; preds = %119
+  %122 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %120, i32 0, i32 1
+  %123 = load i32, i32 addrspace(1)* %122
+  %124 = zext i32 %123 to i64
+  %125 = trunc i64 %124 to i32
+  %126 = icmp ne i32 %125, 0
+  br i1 %126, label %128, label %127
+
+; <label>:127                                     ; preds = %116, %121
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc2
+  br label %136
+
+; <label>:128                                     ; preds = %121
+  %129 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc5
+  %NullCheck15 = icmp eq %"System.Byte[]" addrspace(1)* %129, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %130
+
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %129, i32 0, i32 1
+  %132 = load i32, i32 addrspace(1)* %131
+  %133 = zext i32 %132 to i64
+  %BoundsCheck17 = icmp uge i64 0, %133
+  br i1 %BoundsCheck17, label %ThrowIndexOutOfRange18, label %134
+
+; <label>:134                                     ; preds = %130
+  %135 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %129, i32 0, i32 3, i32 0
+  store i8 addrspace(1)* %135, i8 addrspace(1)** %loc2
+  br label %136
+
+; <label>:136                                     ; preds = %127, %134
+  %137 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %138 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %139 = ptrtoint i16 addrspace(1)* %138 to i64
+  %140 = load i32, i32* %arg2
+  %141 = sext i32 %140 to i64
+  %142 = mul i64 %141, 2
+  %143 = add i64 %139, %142
+  %144 = load i32, i32* %arg3
+  %145 = load i8 addrspace(1)*, i8 addrspace(1)** %loc2
+  %146 = ptrtoint i8 addrspace(1)* %145 to i64
+  %147 = load i32, i32* %arg5
+  %148 = sext i32 %147 to i64
+  %149 = add i64 %146, %148
+  %150 = load i32, i32* %loc0
+  %151 = load i8, i8* %arg6
+  %152 = zext i8 %151 to i32
+  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i64 addrspace(1)*
+  %NullCheck19 = icmp eq i64 addrspace(1)* %153, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %154
+
+; <label>:154                                     ; preds = %136
+  %155 = load i64, i64 addrspace(1)* %153
+  %156 = add i64 %155, 72
+  %157 = inttoptr i64 %156 to i64*
+  %158 = load i64, i64* %157
+  %159 = add i64 %158, 0
+  %160 = inttoptr i64 %159 to i64*
+  %161 = load i64, i64* %160
+  %162 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to %System.Text.Encoder addrspace(1)*
+  %163 = inttoptr i64 %143 to i16*
+  %164 = inttoptr i64 %149 to i8*
+  %165 = trunc i32 %152 to i8
+  %166 = inttoptr i64 %161 to i32 (%System.Text.Encoder addrspace(1)*, i16*, i32, i8*, i32, i8)*
+  %167 = call i32 %166(%System.Text.Encoder addrspace(1)* %162, i16* %163, i32 %144, i8* %164, i32 %150, i8 %165)
+  store i32 %167, i32* %loc3
+  br label %168
+
+; <label>:168                                     ; preds = %154
+  %169 = load i32, i32* %loc3
+  ret i32 %169
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %110
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %119
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange18:                           ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
 Successfully read EncoderNLS.GetBytes
 
@@ -14936,22 +17213,22 @@ entry:
   %40 = load i8, i8* %arg5
   %41 = zext i8 %40 to i32
   %42 = trunc i32 %41 to i8
-  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %39, null
-  br i1 %NullCheck, label %43, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderNLS addrspace(1)* %39, null
+  br i1 %NullCheck, label %ThrowNullRef, label %43
 
 ; <label>:43                                      ; preds = %38
   %44 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
   store i8 %42, i8 addrspace(1)* %44
   %45 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %45, null
-  br i1 %NullCheck2, label %46, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.EncoderNLS addrspace(1)* %45, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %46
 
 ; <label>:46                                      ; preds = %43
   %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %45, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %47
   %48 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.EncoderNLS addrspace(1)* %48, null
-  br i1 %NullCheck4, label %49, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.EncoderNLS addrspace(1)* %48, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %49
 
 ; <label>:49                                      ; preds = %46
   %50 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %48, i32 0, i32 3
@@ -14962,8 +17239,8 @@ entry:
   %55 = load i32, i32* %arg4
   %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck6, label %58, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
   %59 = load i64, i64 addrspace(1)* %57
@@ -14981,15 +17258,15 @@ ThrowNullRef:                                     ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %43
+ThrowNullRef2:                                    ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %46
+ThrowNullRef4:                                    ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %49
+ThrowNullRef6:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -15017,8 +17294,8 @@ entry:
   %4 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0 to %System.IO.ConsoleStream addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*)(%System.IO.ConsoleStream addrspace(1)* %4, %"System.Byte[]" addrspace(1)* %1, i32 %2, i32 %3)
   %5 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
@@ -15103,8 +17380,8 @@ entry:
 
 ; <label>:22                                      ; preds = %8
   %23 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %23, null
-  br i1 %NullCheck, label %24, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Byte[]" addrspace(1)* %23, null
+  br i1 %NullCheck, label %ThrowNullRef, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
@@ -15126,8 +17403,8 @@ entry:
 
 ; <label>:36                                      ; preds = %24
   %37 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %37, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.ConsoleStream addrspace(1)* %37, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %37, i32 0, i32 4
@@ -15148,13 +17425,138 @@ ThrowNullRef:                                     ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %36
+ThrowNullRef2:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
-Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
+Successfully read WindowsConsoleStream.WriteFileNative
+
+define i32 @WindowsConsoleStream.WriteFileNative(i64 %param0, %"System.Byte[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i64
+  %arg1 = alloca %"System.Byte[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i8 addrspace(1)*
+  %loc2 = alloca %"System.Byte[]" addrspace(1)*
+  %loc3 = alloca i32
+  store i64 %param0, i64* %arg0
+  store %"System.Byte[]" addrspace(1)* %param1, %"System.Byte[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Byte[]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = zext i32 %3 to i64
+  %5 = icmp ne i64 %4, 0
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %1
+  ret i32 0
+
+; <label>:7                                       ; preds = %1
+  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  store %"System.Byte[]" addrspace(1)* %8, %"System.Byte[]" addrspace(1)** %loc2
+  %9 = icmp eq %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %9, label %18, label %10
+
+; <label>:10                                      ; preds = %7
+  %11 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc2
+  %NullCheck1 = icmp eq %"System.Byte[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %11, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp ne i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %7, %12
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc1
+  br label %27
+
+; <label>:19                                      ; preds = %12
+  %20 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc2
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %20, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %BoundsCheck = icmp uge i64 0, %24
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %25
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %20, i32 0, i32 3, i32 0
+  store i8 addrspace(1)* %26, i8 addrspace(1)** %loc1
+  br label %27
+
+; <label>:27                                      ; preds = %18, %25
+  %28 = load i64, i64* %arg0
+  %29 = load i8 addrspace(1)*, i8 addrspace(1)** %loc1
+  %30 = ptrtoint i8 addrspace(1)* %29 to i64
+  %31 = load i32, i32* %arg2
+  %32 = sext i32 %31 to i64
+  %33 = add i64 %30, %32
+  %34 = load i32, i32* %arg3
+  %35 = addrspacecast i32* %loc3 to i32 addrspace(1)*
+  %36 = inttoptr i64 %33 to i8*
+  %37 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i8*, i32, i32 addrspace(1)*, i64)*)(i64 %28, i8* %36, i32 %34, i32 addrspace(1)* %35, i64 0)
+  %38 = icmp ugt i32 %37, 0
+  %39 = sext i1 %38 to i32
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc1
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %42, label %41
+
+; <label>:41                                      ; preds = %27
+  ret i32 0
+
+; <label>:42                                      ; preds = %27
+  %43 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  store i32 %43, i32* %loc0
+  %44 = load i32, i32* %loc0
+  %45 = icmp eq i32 %44, 232
+  br i1 %45, label %49, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = load i32, i32* %loc0
+  %48 = icmp ne i32 %47, 109
+  br i1 %48, label %50, label %49
+
+; <label>:49                                      ; preds = %42, %46
+  ret i32 0
+
+; <label>:50                                      ; preds = %46
+  %51 = load i32, i32* %loc0
+  ret i32 %51
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
 Successfully read WindowsConsoleStream.Flush
 
@@ -15163,8 +17565,8 @@ entry:
   %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
   store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
@@ -15199,8 +17601,8 @@ entry:
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
   %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load i64, i64 addrspace(1)* %1
@@ -15239,15 +17641,15 @@ entry:
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.TextWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
   %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %3, align 8
   %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
   %7 = load i64, i64 addrspace(1)* %5
@@ -15265,7 +17667,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -15294,8 +17696,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %4)
   store i32 0, i32* %loc0
   %5 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Char[]" addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
@@ -15307,15 +17709,15 @@ entry:
 
 ; <label>:11                                      ; preds = %69
   %12 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %12, i32 0, i32 9
   %15 = load i32, i32 addrspace(1)* %14, align 8
   %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.IO.StreamWriter addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %16, i32 0, i32 10
@@ -15330,15 +17732,15 @@ entry:
 
 ; <label>:23                                      ; preds = %17, %21
   %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %24, null
-  br i1 %NullCheck8, label %25, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %24, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 10
   %27 = load i32, i32 addrspace(1)* %26, align 8
   %28 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %28, null
-  br i1 %NullCheck10, label %29, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.StreamWriter addrspace(1)* %28, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %28, i32 0, i32 9
@@ -15360,15 +17762,15 @@ entry:
   %40 = load i32, i32* %loc0
   %41 = mul i32 %40, 2
   %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
-  br i1 %NullCheck12, label %43, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %43
 
 ; <label>:43                                      ; preds = %38
   %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 7
   %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %44, align 8
   %46 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %46, null
-  br i1 %NullCheck14, label %47, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.IO.StreamWriter addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %47
 
 ; <label>:47                                      ; preds = %43
   %48 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %46, i32 0, i32 9
@@ -15380,16 +17782,16 @@ entry:
   %54 = bitcast %"System.Char[]" addrspace(1)* %45 to %System.Array addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %53, i32 %41, %System.Array addrspace(1)* %54, i32 %50, i32 %52)
   %55 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
-  br i1 %NullCheck16, label %56, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %56
 
 ; <label>:56                                      ; preds = %47
   %57 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
   %58 = load i32, i32 addrspace(1)* %57, align 8
   %59 = load i32, i32* %loc2
   %60 = add i32 %58, %59
-  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
-  br i1 %NullCheck18, label %61, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %61
 
 ; <label>:61                                      ; preds = %56
   %62 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
@@ -15411,8 +17813,8 @@ entry:
 
 ; <label>:72                                      ; preds = %69
   %73 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %73, null
-  br i1 %NullCheck2, label %74, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %73, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %74
 
 ; <label>:74                                      ; preds = %72
   %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %73, i32 0, i32 11
@@ -15433,39 +17835,39 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %72
+ThrowNullRef2:                                    ; preds = %72
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %23
+ThrowNullRef8:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef10:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %43
+ThrowNullRef14:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %47
+ThrowNullRef16:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %56
+ThrowNullRef18:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblCall2.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblCall2.error.txt
@@ -25,8 +25,8 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
@@ -40,8 +40,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
   %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
@@ -75,7 +75,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -90,8 +90,8 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %NullCheck = icmp ne i8 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = load i8, i8 addrspace(1)* %0, align 8
@@ -125,8 +125,8 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
@@ -159,8 +159,8 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -184,8 +184,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
   store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
@@ -195,8 +195,8 @@ entry:
 ; <label>:4                                       ; preds = %1
   %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
   %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
@@ -206,8 +206,8 @@ entry:
   %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
@@ -221,14 +221,14 @@ entry:
 
 ; <label>:17                                      ; preds = %14
   %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
   %21 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
@@ -238,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -249,8 +249,8 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
@@ -261,27 +261,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %30
+ThrowNullRef10:                                   ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -301,7 +301,89 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
-Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
+Successfully read AppDomainSetup.GetUnsecureApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.GetUnsecureApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %NullCheck = icmp eq %"System.String[]" addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %BoundsCheck = icmp uge i64 0, %5
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %6
+
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 3, i32 0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
+  ret %System.String addrspace(1)* %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_Value using LLILCJit
+Successfully read AppDomainSetup.get_Value
+
+define %"System.String[]" addrspace(1)* @AppDomainSetup.get_Value(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.String[]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 18)
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.String[]" addrspace(1)* addrspace(1)*, %"System.String[]" addrspace(1)*)*)(%"System.String[]" addrspace(1)* addrspace(1)* %9, %"System.String[]" addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %11, i32 0, i32 1
+  %14 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %13, align 8
+  ret %"System.String[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -319,8 +401,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -368,16 +450,16 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
   %5 = load i32, i32 addrspace(1)* %4
   %6 = sub i32 %5, 1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -389,7 +471,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -421,8 +503,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
@@ -456,8 +538,8 @@ entry:
 ; <label>:27                                      ; preds = %19
   %28 = load i32, i32* %arg1
   %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
-  br i1 %NullCheck2, label %30, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %29, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %30
 
 ; <label>:30                                      ; preds = %27
   %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
@@ -493,8 +575,8 @@ entry:
 ; <label>:49                                      ; preds = %46
   %50 = load i32, i32* %arg2
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck4, label %52, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
@@ -517,11 +599,11 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %27
+ThrowNullRef2:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %49
+ThrowNullRef4:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -544,16 +626,16 @@ entry:
   %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %0)
   store %System.String addrspace(1)* %1, %System.String addrspace(1)** %loc0
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 2
   %5 = bitcast [0 x i16] addrspace(1)* %4 to i16 addrspace(1)*
   store i16 addrspace(1)* %5, i16 addrspace(1)** %loc1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %3
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2
@@ -580,7 +662,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -691,15 +773,15 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %NullCheck132 = icmp ne i8* %21, null
-  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+  %NullCheck131 = icmp eq i8* %21, null
+  br i1 %NullCheck131, label %ThrowNullRef132, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = load i8, i8* %21, align 8
   %24 = zext i8 %23 to i32
   %25 = trunc i32 %24 to i8
-  %NullCheck134 = icmp ne i8* %20, null
-  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+  %NullCheck133 = icmp eq i8* %20, null
+  br i1 %NullCheck133, label %ThrowNullRef134, label %26
 
 ; <label>:26                                      ; preds = %22
   store i8 %25, i8* %20, align 8
@@ -709,16 +791,16 @@ entry:
   %28 = load i8*, i8** %arg0
   %29 = load i8*, i8** %arg1
   %30 = bitcast i8* %29 to i16*
-  %NullCheck128 = icmp ne i16* %30, null
-  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+  %NullCheck127 = icmp eq i16* %30, null
+  br i1 %NullCheck127, label %ThrowNullRef128, label %31
 
 ; <label>:31                                      ; preds = %27
   %32 = load i16, i16* %30, align 8
   %33 = sext i16 %32 to i32
   %34 = bitcast i8* %28 to i16*
   %35 = trunc i32 %33 to i16
-  %NullCheck130 = icmp ne i16* %34, null
-  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+  %NullCheck129 = icmp eq i16* %34, null
+  br i1 %NullCheck129, label %ThrowNullRef130, label %36
 
 ; <label>:36                                      ; preds = %31
   store i16 %35, i16* %34, align 8
@@ -728,16 +810,16 @@ entry:
   %38 = load i8*, i8** %arg0
   %39 = load i8*, i8** %arg1
   %40 = bitcast i8* %39 to i16*
-  %NullCheck120 = icmp ne i16* %40, null
-  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+  %NullCheck119 = icmp eq i16* %40, null
+  br i1 %NullCheck119, label %ThrowNullRef120, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i16, i16* %40, align 8
   %43 = sext i16 %42 to i32
   %44 = bitcast i8* %38 to i16*
   %45 = trunc i32 %43 to i16
-  %NullCheck122 = icmp ne i16* %44, null
-  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+  %NullCheck121 = icmp eq i16* %44, null
+  br i1 %NullCheck121, label %ThrowNullRef122, label %46
 
 ; <label>:46                                      ; preds = %41
   store i16 %45, i16* %44, align 8
@@ -745,15 +827,15 @@ entry:
   %48 = getelementptr inbounds i8, i8* %47, i64 2
   %49 = load i8*, i8** %arg1
   %50 = getelementptr inbounds i8, i8* %49, i64 2
-  %NullCheck124 = icmp ne i8* %50, null
-  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+  %NullCheck123 = icmp eq i8* %50, null
+  br i1 %NullCheck123, label %ThrowNullRef124, label %51
 
 ; <label>:51                                      ; preds = %46
   %52 = load i8, i8* %50, align 8
   %53 = zext i8 %52 to i32
   %54 = trunc i32 %53 to i8
-  %NullCheck126 = icmp ne i8* %48, null
-  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+  %NullCheck125 = icmp eq i8* %48, null
+  br i1 %NullCheck125, label %ThrowNullRef126, label %55
 
 ; <label>:55                                      ; preds = %51
   store i8 %54, i8* %48, align 8
@@ -763,14 +845,14 @@ entry:
   %57 = load i8*, i8** %arg0
   %58 = load i8*, i8** %arg1
   %59 = bitcast i8* %58 to i32*
-  %NullCheck116 = icmp ne i32* %59, null
-  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+  %NullCheck115 = icmp eq i32* %59, null
+  br i1 %NullCheck115, label %ThrowNullRef116, label %60
 
 ; <label>:60                                      ; preds = %56
   %61 = load i32, i32* %59, align 8
   %62 = bitcast i8* %57 to i32*
-  %NullCheck118 = icmp ne i32* %62, null
-  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+  %NullCheck117 = icmp eq i32* %62, null
+  br i1 %NullCheck117, label %ThrowNullRef118, label %63
 
 ; <label>:63                                      ; preds = %60
   store i32 %61, i32* %62, align 8
@@ -780,14 +862,14 @@ entry:
   %65 = load i8*, i8** %arg0
   %66 = load i8*, i8** %arg1
   %67 = bitcast i8* %66 to i32*
-  %NullCheck108 = icmp ne i32* %67, null
-  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+  %NullCheck107 = icmp eq i32* %67, null
+  br i1 %NullCheck107, label %ThrowNullRef108, label %68
 
 ; <label>:68                                      ; preds = %64
   %69 = load i32, i32* %67, align 8
   %70 = bitcast i8* %65 to i32*
-  %NullCheck110 = icmp ne i32* %70, null
-  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+  %NullCheck109 = icmp eq i32* %70, null
+  br i1 %NullCheck109, label %ThrowNullRef110, label %71
 
 ; <label>:71                                      ; preds = %68
   store i32 %69, i32* %70, align 8
@@ -795,15 +877,15 @@ entry:
   %73 = getelementptr inbounds i8, i8* %72, i64 4
   %74 = load i8*, i8** %arg1
   %75 = getelementptr inbounds i8, i8* %74, i64 4
-  %NullCheck112 = icmp ne i8* %75, null
-  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+  %NullCheck111 = icmp eq i8* %75, null
+  br i1 %NullCheck111, label %ThrowNullRef112, label %76
 
 ; <label>:76                                      ; preds = %71
   %77 = load i8, i8* %75, align 8
   %78 = zext i8 %77 to i32
   %79 = trunc i32 %78 to i8
-  %NullCheck114 = icmp ne i8* %73, null
-  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+  %NullCheck113 = icmp eq i8* %73, null
+  br i1 %NullCheck113, label %ThrowNullRef114, label %80
 
 ; <label>:80                                      ; preds = %76
   store i8 %79, i8* %73, align 8
@@ -813,14 +895,14 @@ entry:
   %82 = load i8*, i8** %arg0
   %83 = load i8*, i8** %arg1
   %84 = bitcast i8* %83 to i32*
-  %NullCheck100 = icmp ne i32* %84, null
-  br i1 %NullCheck100, label %85, label %ThrowNullRef99
+  %NullCheck99 = icmp eq i32* %84, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %85
 
 ; <label>:85                                      ; preds = %81
   %86 = load i32, i32* %84, align 8
   %87 = bitcast i8* %82 to i32*
-  %NullCheck102 = icmp ne i32* %87, null
-  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+  %NullCheck101 = icmp eq i32* %87, null
+  br i1 %NullCheck101, label %ThrowNullRef102, label %88
 
 ; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
@@ -829,16 +911,16 @@ entry:
   %91 = load i8*, i8** %arg1
   %92 = getelementptr inbounds i8, i8* %91, i64 4
   %93 = bitcast i8* %92 to i16*
-  %NullCheck104 = icmp ne i16* %93, null
-  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+  %NullCheck103 = icmp eq i16* %93, null
+  br i1 %NullCheck103, label %ThrowNullRef104, label %94
 
 ; <label>:94                                      ; preds = %88
   %95 = load i16, i16* %93, align 8
   %96 = sext i16 %95 to i32
   %97 = bitcast i8* %90 to i16*
   %98 = trunc i32 %96 to i16
-  %NullCheck106 = icmp ne i16* %97, null
-  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+  %NullCheck105 = icmp eq i16* %97, null
+  br i1 %NullCheck105, label %ThrowNullRef106, label %99
 
 ; <label>:99                                      ; preds = %94
   store i16 %98, i16* %97, align 8
@@ -848,14 +930,14 @@ entry:
   %101 = load i8*, i8** %arg0
   %102 = load i8*, i8** %arg1
   %103 = bitcast i8* %102 to i32*
-  %NullCheck88 = icmp ne i32* %103, null
-  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+  %NullCheck87 = icmp eq i32* %103, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %104
 
 ; <label>:104                                     ; preds = %100
   %105 = load i32, i32* %103, align 8
   %106 = bitcast i8* %101 to i32*
-  %NullCheck90 = icmp ne i32* %106, null
-  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+  %NullCheck89 = icmp eq i32* %106, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %107
 
 ; <label>:107                                     ; preds = %104
   store i32 %105, i32* %106, align 8
@@ -864,16 +946,16 @@ entry:
   %110 = load i8*, i8** %arg1
   %111 = getelementptr inbounds i8, i8* %110, i64 4
   %112 = bitcast i8* %111 to i16*
-  %NullCheck92 = icmp ne i16* %112, null
-  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+  %NullCheck91 = icmp eq i16* %112, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %113
 
 ; <label>:113                                     ; preds = %107
   %114 = load i16, i16* %112, align 8
   %115 = sext i16 %114 to i32
   %116 = bitcast i8* %109 to i16*
   %117 = trunc i32 %115 to i16
-  %NullCheck94 = icmp ne i16* %116, null
-  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+  %NullCheck93 = icmp eq i16* %116, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %118
 
 ; <label>:118                                     ; preds = %113
   store i16 %117, i16* %116, align 8
@@ -881,15 +963,15 @@ entry:
   %120 = getelementptr inbounds i8, i8* %119, i64 6
   %121 = load i8*, i8** %arg1
   %122 = getelementptr inbounds i8, i8* %121, i64 6
-  %NullCheck96 = icmp ne i8* %122, null
-  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+  %NullCheck95 = icmp eq i8* %122, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %123
 
 ; <label>:123                                     ; preds = %118
   %124 = load i8, i8* %122, align 8
   %125 = zext i8 %124 to i32
   %126 = trunc i32 %125 to i8
-  %NullCheck98 = icmp ne i8* %120, null
-  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+  %NullCheck97 = icmp eq i8* %120, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %127
 
 ; <label>:127                                     ; preds = %123
   store i8 %126, i8* %120, align 8
@@ -899,14 +981,14 @@ entry:
   %129 = load i8*, i8** %arg0
   %130 = load i8*, i8** %arg1
   %131 = bitcast i8* %130 to i64*
-  %NullCheck84 = icmp ne i64* %131, null
-  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+  %NullCheck83 = icmp eq i64* %131, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %132
 
 ; <label>:132                                     ; preds = %128
   %133 = load i64, i64* %131, align 8
   %134 = bitcast i8* %129 to i64*
-  %NullCheck86 = icmp ne i64* %134, null
-  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+  %NullCheck85 = icmp eq i64* %134, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %135
 
 ; <label>:135                                     ; preds = %132
   store i64 %133, i64* %134, align 8
@@ -916,14 +998,14 @@ entry:
   %137 = load i8*, i8** %arg0
   %138 = load i8*, i8** %arg1
   %139 = bitcast i8* %138 to i64*
-  %NullCheck76 = icmp ne i64* %139, null
-  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+  %NullCheck75 = icmp eq i64* %139, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %140
 
 ; <label>:140                                     ; preds = %136
   %141 = load i64, i64* %139, align 8
   %142 = bitcast i8* %137 to i64*
-  %NullCheck78 = icmp ne i64* %142, null
-  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+  %NullCheck77 = icmp eq i64* %142, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %143
 
 ; <label>:143                                     ; preds = %140
   store i64 %141, i64* %142, align 8
@@ -931,15 +1013,15 @@ entry:
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %NullCheck80 = icmp ne i8* %147, null
-  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+  %NullCheck79 = icmp eq i8* %147, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %148
 
 ; <label>:148                                     ; preds = %143
   %149 = load i8, i8* %147, align 8
   %150 = zext i8 %149 to i32
   %151 = trunc i32 %150 to i8
-  %NullCheck82 = icmp ne i8* %145, null
-  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+  %NullCheck81 = icmp eq i8* %145, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %152
 
 ; <label>:152                                     ; preds = %148
   store i8 %151, i8* %145, align 8
@@ -949,14 +1031,14 @@ entry:
   %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
   %156 = bitcast i8* %155 to i64*
-  %NullCheck68 = icmp ne i64* %156, null
-  br i1 %NullCheck68, label %157, label %ThrowNullRef67
+  %NullCheck67 = icmp eq i64* %156, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %157
 
 ; <label>:157                                     ; preds = %153
   %158 = load i64, i64* %156, align 8
   %159 = bitcast i8* %154 to i64*
-  %NullCheck70 = icmp ne i64* %159, null
-  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+  %NullCheck69 = icmp eq i64* %159, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %160
 
 ; <label>:160                                     ; preds = %157
   store i64 %158, i64* %159, align 8
@@ -965,16 +1047,16 @@ entry:
   %163 = load i8*, i8** %arg1
   %164 = getelementptr inbounds i8, i8* %163, i64 8
   %165 = bitcast i8* %164 to i16*
-  %NullCheck72 = icmp ne i16* %165, null
-  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+  %NullCheck71 = icmp eq i16* %165, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %166
 
 ; <label>:166                                     ; preds = %160
   %167 = load i16, i16* %165, align 8
   %168 = sext i16 %167 to i32
   %169 = bitcast i8* %162 to i16*
   %170 = trunc i32 %168 to i16
-  %NullCheck74 = icmp ne i16* %169, null
-  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+  %NullCheck73 = icmp eq i16* %169, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %171
 
 ; <label>:171                                     ; preds = %166
   store i16 %170, i16* %169, align 8
@@ -984,14 +1066,14 @@ entry:
   %173 = load i8*, i8** %arg0
   %174 = load i8*, i8** %arg1
   %175 = bitcast i8* %174 to i64*
-  %NullCheck56 = icmp ne i64* %175, null
-  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+  %NullCheck55 = icmp eq i64* %175, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %176
 
 ; <label>:176                                     ; preds = %172
   %177 = load i64, i64* %175, align 8
   %178 = bitcast i8* %173 to i64*
-  %NullCheck58 = icmp ne i64* %178, null
-  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+  %NullCheck57 = icmp eq i64* %178, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %179
 
 ; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
@@ -1000,16 +1082,16 @@ entry:
   %182 = load i8*, i8** %arg1
   %183 = getelementptr inbounds i8, i8* %182, i64 8
   %184 = bitcast i8* %183 to i16*
-  %NullCheck60 = icmp ne i16* %184, null
-  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+  %NullCheck59 = icmp eq i16* %184, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %185
 
 ; <label>:185                                     ; preds = %179
   %186 = load i16, i16* %184, align 8
   %187 = sext i16 %186 to i32
   %188 = bitcast i8* %181 to i16*
   %189 = trunc i32 %187 to i16
-  %NullCheck62 = icmp ne i16* %188, null
-  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+  %NullCheck61 = icmp eq i16* %188, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %190
 
 ; <label>:190                                     ; preds = %185
   store i16 %189, i16* %188, align 8
@@ -1017,15 +1099,15 @@ entry:
   %192 = getelementptr inbounds i8, i8* %191, i64 10
   %193 = load i8*, i8** %arg1
   %194 = getelementptr inbounds i8, i8* %193, i64 10
-  %NullCheck64 = icmp ne i8* %194, null
-  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+  %NullCheck63 = icmp eq i8* %194, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %195
 
 ; <label>:195                                     ; preds = %190
   %196 = load i8, i8* %194, align 8
   %197 = zext i8 %196 to i32
   %198 = trunc i32 %197 to i8
-  %NullCheck66 = icmp ne i8* %192, null
-  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+  %NullCheck65 = icmp eq i8* %192, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %199
 
 ; <label>:199                                     ; preds = %195
   store i8 %198, i8* %192, align 8
@@ -1035,14 +1117,14 @@ entry:
   %201 = load i8*, i8** %arg0
   %202 = load i8*, i8** %arg1
   %203 = bitcast i8* %202 to i64*
-  %NullCheck48 = icmp ne i64* %203, null
-  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+  %NullCheck47 = icmp eq i64* %203, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %204
 
 ; <label>:204                                     ; preds = %200
   %205 = load i64, i64* %203, align 8
   %206 = bitcast i8* %201 to i64*
-  %NullCheck50 = icmp ne i64* %206, null
-  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+  %NullCheck49 = icmp eq i64* %206, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %207
 
 ; <label>:207                                     ; preds = %204
   store i64 %205, i64* %206, align 8
@@ -1051,14 +1133,14 @@ entry:
   %210 = load i8*, i8** %arg1
   %211 = getelementptr inbounds i8, i8* %210, i64 8
   %212 = bitcast i8* %211 to i32*
-  %NullCheck52 = icmp ne i32* %212, null
-  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+  %NullCheck51 = icmp eq i32* %212, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %213
 
 ; <label>:213                                     ; preds = %207
   %214 = load i32, i32* %212, align 8
   %215 = bitcast i8* %209 to i32*
-  %NullCheck54 = icmp ne i32* %215, null
-  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+  %NullCheck53 = icmp eq i32* %215, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %216
 
 ; <label>:216                                     ; preds = %213
   store i32 %214, i32* %215, align 8
@@ -1068,14 +1150,14 @@ entry:
   %218 = load i8*, i8** %arg0
   %219 = load i8*, i8** %arg1
   %220 = bitcast i8* %219 to i64*
-  %NullCheck36 = icmp ne i64* %220, null
-  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64* %220, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %221
 
 ; <label>:221                                     ; preds = %217
   %222 = load i64, i64* %220, align 8
   %223 = bitcast i8* %218 to i64*
-  %NullCheck38 = icmp ne i64* %223, null
-  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+  %NullCheck37 = icmp eq i64* %223, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %224
 
 ; <label>:224                                     ; preds = %221
   store i64 %222, i64* %223, align 8
@@ -1084,14 +1166,14 @@ entry:
   %227 = load i8*, i8** %arg1
   %228 = getelementptr inbounds i8, i8* %227, i64 8
   %229 = bitcast i8* %228 to i32*
-  %NullCheck40 = icmp ne i32* %229, null
-  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i32* %229, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %230
 
 ; <label>:230                                     ; preds = %224
   %231 = load i32, i32* %229, align 8
   %232 = bitcast i8* %226 to i32*
-  %NullCheck42 = icmp ne i32* %232, null
-  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+  %NullCheck41 = icmp eq i32* %232, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %233
 
 ; <label>:233                                     ; preds = %230
   store i32 %231, i32* %232, align 8
@@ -1099,15 +1181,15 @@ entry:
   %235 = getelementptr inbounds i8, i8* %234, i64 12
   %236 = load i8*, i8** %arg1
   %237 = getelementptr inbounds i8, i8* %236, i64 12
-  %NullCheck44 = icmp ne i8* %237, null
-  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i8* %237, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %238
 
 ; <label>:238                                     ; preds = %233
   %239 = load i8, i8* %237, align 8
   %240 = zext i8 %239 to i32
   %241 = trunc i32 %240 to i8
-  %NullCheck46 = icmp ne i8* %235, null
-  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+  %NullCheck45 = icmp eq i8* %235, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %242
 
 ; <label>:242                                     ; preds = %238
   store i8 %241, i8* %235, align 8
@@ -1117,14 +1199,14 @@ entry:
   %244 = load i8*, i8** %arg0
   %245 = load i8*, i8** %arg1
   %246 = bitcast i8* %245 to i64*
-  %NullCheck24 = icmp ne i64* %246, null
-  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64* %246, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %247
 
 ; <label>:247                                     ; preds = %243
   %248 = load i64, i64* %246, align 8
   %249 = bitcast i8* %244 to i64*
-  %NullCheck26 = icmp ne i64* %249, null
-  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64* %249, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %250
 
 ; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
@@ -1133,14 +1215,14 @@ entry:
   %253 = load i8*, i8** %arg1
   %254 = getelementptr inbounds i8, i8* %253, i64 8
   %255 = bitcast i8* %254 to i32*
-  %NullCheck28 = icmp ne i32* %255, null
-  br i1 %NullCheck28, label %256, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i32* %255, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %256
 
 ; <label>:256                                     ; preds = %250
   %257 = load i32, i32* %255, align 8
   %258 = bitcast i8* %252 to i32*
-  %NullCheck30 = icmp ne i32* %258, null
-  br i1 %NullCheck30, label %259, label %ThrowNullRef29
+  %NullCheck29 = icmp eq i32* %258, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %259
 
 ; <label>:259                                     ; preds = %256
   store i32 %257, i32* %258, align 8
@@ -1149,16 +1231,16 @@ entry:
   %262 = load i8*, i8** %arg1
   %263 = getelementptr inbounds i8, i8* %262, i64 12
   %264 = bitcast i8* %263 to i16*
-  %NullCheck32 = icmp ne i16* %264, null
-  br i1 %NullCheck32, label %265, label %ThrowNullRef31
+  %NullCheck31 = icmp eq i16* %264, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %265
 
 ; <label>:265                                     ; preds = %259
   %266 = load i16, i16* %264, align 8
   %267 = sext i16 %266 to i32
   %268 = bitcast i8* %261 to i16*
   %269 = trunc i32 %267 to i16
-  %NullCheck34 = icmp ne i16* %268, null
-  br i1 %NullCheck34, label %270, label %ThrowNullRef33
+  %NullCheck33 = icmp eq i16* %268, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %270
 
 ; <label>:270                                     ; preds = %265
   store i16 %269, i16* %268, align 8
@@ -1168,14 +1250,14 @@ entry:
   %272 = load i8*, i8** %arg0
   %273 = load i8*, i8** %arg1
   %274 = bitcast i8* %273 to i64*
-  %NullCheck8 = icmp ne i64* %274, null
-  br i1 %NullCheck8, label %275, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64* %274, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %275
 
 ; <label>:275                                     ; preds = %271
   %276 = load i64, i64* %274, align 8
   %277 = bitcast i8* %272 to i64*
-  %NullCheck10 = icmp ne i64* %277, null
-  br i1 %NullCheck10, label %278, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %277, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %278
 
 ; <label>:278                                     ; preds = %275
   store i64 %276, i64* %277, align 8
@@ -1184,14 +1266,14 @@ entry:
   %281 = load i8*, i8** %arg1
   %282 = getelementptr inbounds i8, i8* %281, i64 8
   %283 = bitcast i8* %282 to i32*
-  %NullCheck12 = icmp ne i32* %283, null
-  br i1 %NullCheck12, label %284, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i32* %283, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %284
 
 ; <label>:284                                     ; preds = %278
   %285 = load i32, i32* %283, align 8
   %286 = bitcast i8* %280 to i32*
-  %NullCheck14 = icmp ne i32* %286, null
-  br i1 %NullCheck14, label %287, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i32* %286, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %287
 
 ; <label>:287                                     ; preds = %284
   store i32 %285, i32* %286, align 8
@@ -1200,16 +1282,16 @@ entry:
   %290 = load i8*, i8** %arg1
   %291 = getelementptr inbounds i8, i8* %290, i64 12
   %292 = bitcast i8* %291 to i16*
-  %NullCheck16 = icmp ne i16* %292, null
-  br i1 %NullCheck16, label %293, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i16* %292, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %293
 
 ; <label>:293                                     ; preds = %287
   %294 = load i16, i16* %292, align 8
   %295 = sext i16 %294 to i32
   %296 = bitcast i8* %289 to i16*
   %297 = trunc i32 %295 to i16
-  %NullCheck18 = icmp ne i16* %296, null
-  br i1 %NullCheck18, label %298, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i16* %296, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %298
 
 ; <label>:298                                     ; preds = %293
   store i16 %297, i16* %296, align 8
@@ -1217,15 +1299,15 @@ entry:
   %300 = getelementptr inbounds i8, i8* %299, i64 14
   %301 = load i8*, i8** %arg1
   %302 = getelementptr inbounds i8, i8* %301, i64 14
-  %NullCheck20 = icmp ne i8* %302, null
-  br i1 %NullCheck20, label %303, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i8* %302, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %303
 
 ; <label>:303                                     ; preds = %298
   %304 = load i8, i8* %302, align 8
   %305 = zext i8 %304 to i32
   %306 = trunc i32 %305 to i8
-  %NullCheck22 = icmp ne i8* %300, null
-  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i8* %300, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %307
 
 ; <label>:307                                     ; preds = %303
   store i8 %306, i8* %300, align 8
@@ -1235,14 +1317,14 @@ entry:
   %309 = load i8*, i8** %arg0
   %310 = load i8*, i8** %arg1
   %311 = bitcast i8* %310 to i64*
-  %NullCheck = icmp ne i64* %311, null
-  br i1 %NullCheck, label %312, label %ThrowNullRef
+  %NullCheck = icmp eq i64* %311, null
+  br i1 %NullCheck, label %ThrowNullRef, label %312
 
 ; <label>:312                                     ; preds = %308
   %313 = load i64, i64* %311, align 8
   %314 = bitcast i8* %309 to i64*
-  %NullCheck2 = icmp ne i64* %314, null
-  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64* %314, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %315
 
 ; <label>:315                                     ; preds = %312
   store i64 %313, i64* %314, align 8
@@ -1251,14 +1333,14 @@ entry:
   %318 = load i8*, i8** %arg1
   %319 = getelementptr inbounds i8, i8* %318, i64 8
   %320 = bitcast i8* %319 to i64*
-  %NullCheck4 = icmp ne i64* %320, null
-  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64* %320, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %321
 
 ; <label>:321                                     ; preds = %315
   %322 = load i64, i64* %320, align 8
   %323 = bitcast i8* %317 to i64*
-  %NullCheck6 = icmp ne i64* %323, null
-  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64* %323, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %324
 
 ; <label>:324                                     ; preds = %321
   store i64 %322, i64* %323, align 8
@@ -1286,15 +1368,15 @@ entry:
 ; <label>:338                                     ; preds = %333
   %339 = load i8*, i8** %arg0
   %340 = load i8*, i8** %arg1
-  %NullCheck136 = icmp ne i8* %340, null
-  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+  %NullCheck135 = icmp eq i8* %340, null
+  br i1 %NullCheck135, label %ThrowNullRef136, label %341
 
 ; <label>:341                                     ; preds = %338
   %342 = load i8, i8* %340, align 8
   %343 = zext i8 %342 to i32
   %344 = trunc i32 %343 to i8
-  %NullCheck138 = icmp ne i8* %339, null
-  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+  %NullCheck137 = icmp eq i8* %339, null
+  br i1 %NullCheck137, label %ThrowNullRef138, label %345
 
 ; <label>:345                                     ; preds = %341
   store i8 %344, i8* %339, align 8
@@ -1317,16 +1399,16 @@ entry:
   %357 = load i8*, i8** %arg0
   %358 = load i8*, i8** %arg1
   %359 = bitcast i8* %358 to i16*
-  %NullCheck140 = icmp ne i16* %359, null
-  br i1 %NullCheck140, label %360, label %ThrowNullRef139
+  %NullCheck139 = icmp eq i16* %359, null
+  br i1 %NullCheck139, label %ThrowNullRef140, label %360
 
 ; <label>:360                                     ; preds = %356
   %361 = load i16, i16* %359, align 8
   %362 = sext i16 %361 to i32
   %363 = bitcast i8* %357 to i16*
   %364 = trunc i32 %362 to i16
-  %NullCheck142 = icmp ne i16* %363, null
-  br i1 %NullCheck142, label %365, label %ThrowNullRef141
+  %NullCheck141 = icmp eq i16* %363, null
+  br i1 %NullCheck141, label %ThrowNullRef142, label %365
 
 ; <label>:365                                     ; preds = %360
   store i16 %364, i16* %363, align 8
@@ -1352,14 +1434,14 @@ entry:
   %378 = load i8*, i8** %arg0
   %379 = load i8*, i8** %arg1
   %380 = bitcast i8* %379 to i32*
-  %NullCheck144 = icmp ne i32* %380, null
-  br i1 %NullCheck144, label %381, label %ThrowNullRef143
+  %NullCheck143 = icmp eq i32* %380, null
+  br i1 %NullCheck143, label %ThrowNullRef144, label %381
 
 ; <label>:381                                     ; preds = %377
   %382 = load i32, i32* %380, align 8
   %383 = bitcast i8* %378 to i32*
-  %NullCheck146 = icmp ne i32* %383, null
-  br i1 %NullCheck146, label %384, label %ThrowNullRef145
+  %NullCheck145 = icmp eq i32* %383, null
+  br i1 %NullCheck145, label %ThrowNullRef146, label %384
 
 ; <label>:384                                     ; preds = %381
   store i32 %382, i32* %383, align 8
@@ -1384,14 +1466,14 @@ entry:
   %395 = load i8*, i8** %arg0
   %396 = load i8*, i8** %arg1
   %397 = bitcast i8* %396 to i64*
-  %NullCheck164 = icmp ne i64* %397, null
-  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+  %NullCheck163 = icmp eq i64* %397, null
+  br i1 %NullCheck163, label %ThrowNullRef164, label %398
 
 ; <label>:398                                     ; preds = %394
   %399 = load i64, i64* %397, align 8
   %400 = bitcast i8* %395 to i64*
-  %NullCheck166 = icmp ne i64* %400, null
-  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+  %NullCheck165 = icmp eq i64* %400, null
+  br i1 %NullCheck165, label %ThrowNullRef166, label %401
 
 ; <label>:401                                     ; preds = %398
   store i64 %399, i64* %400, align 8
@@ -1400,14 +1482,14 @@ entry:
   %404 = load i8*, i8** %arg1
   %405 = getelementptr inbounds i8, i8* %404, i64 8
   %406 = bitcast i8* %405 to i64*
-  %NullCheck168 = icmp ne i64* %406, null
-  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+  %NullCheck167 = icmp eq i64* %406, null
+  br i1 %NullCheck167, label %ThrowNullRef168, label %407
 
 ; <label>:407                                     ; preds = %401
   %408 = load i64, i64* %406, align 8
   %409 = bitcast i8* %403 to i64*
-  %NullCheck170 = icmp ne i64* %409, null
-  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+  %NullCheck169 = icmp eq i64* %409, null
+  br i1 %NullCheck169, label %ThrowNullRef170, label %410
 
 ; <label>:410                                     ; preds = %407
   store i64 %408, i64* %409, align 8
@@ -1437,14 +1519,14 @@ entry:
   %425 = load i8*, i8** %arg0
   %426 = load i8*, i8** %arg1
   %427 = bitcast i8* %426 to i64*
-  %NullCheck148 = icmp ne i64* %427, null
-  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+  %NullCheck147 = icmp eq i64* %427, null
+  br i1 %NullCheck147, label %ThrowNullRef148, label %428
 
 ; <label>:428                                     ; preds = %424
   %429 = load i64, i64* %427, align 8
   %430 = bitcast i8* %425 to i64*
-  %NullCheck150 = icmp ne i64* %430, null
-  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+  %NullCheck149 = icmp eq i64* %430, null
+  br i1 %NullCheck149, label %ThrowNullRef150, label %431
 
 ; <label>:431                                     ; preds = %428
   store i64 %429, i64* %430, align 8
@@ -1466,14 +1548,14 @@ entry:
   %441 = load i8*, i8** %arg0
   %442 = load i8*, i8** %arg1
   %443 = bitcast i8* %442 to i32*
-  %NullCheck152 = icmp ne i32* %443, null
-  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+  %NullCheck151 = icmp eq i32* %443, null
+  br i1 %NullCheck151, label %ThrowNullRef152, label %444
 
 ; <label>:444                                     ; preds = %440
   %445 = load i32, i32* %443, align 8
   %446 = bitcast i8* %441 to i32*
-  %NullCheck154 = icmp ne i32* %446, null
-  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+  %NullCheck153 = icmp eq i32* %446, null
+  br i1 %NullCheck153, label %ThrowNullRef154, label %447
 
 ; <label>:447                                     ; preds = %444
   store i32 %445, i32* %446, align 8
@@ -1495,16 +1577,16 @@ entry:
   %457 = load i8*, i8** %arg0
   %458 = load i8*, i8** %arg1
   %459 = bitcast i8* %458 to i16*
-  %NullCheck156 = icmp ne i16* %459, null
-  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+  %NullCheck155 = icmp eq i16* %459, null
+  br i1 %NullCheck155, label %ThrowNullRef156, label %460
 
 ; <label>:460                                     ; preds = %456
   %461 = load i16, i16* %459, align 8
   %462 = sext i16 %461 to i32
   %463 = bitcast i8* %457 to i16*
   %464 = trunc i32 %462 to i16
-  %NullCheck158 = icmp ne i16* %463, null
-  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+  %NullCheck157 = icmp eq i16* %463, null
+  br i1 %NullCheck157, label %ThrowNullRef158, label %465
 
 ; <label>:465                                     ; preds = %460
   store i16 %464, i16* %463, align 8
@@ -1525,15 +1607,15 @@ entry:
 ; <label>:474                                     ; preds = %470
   %475 = load i8*, i8** %arg0
   %476 = load i8*, i8** %arg1
-  %NullCheck160 = icmp ne i8* %476, null
-  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+  %NullCheck159 = icmp eq i8* %476, null
+  br i1 %NullCheck159, label %ThrowNullRef160, label %477
 
 ; <label>:477                                     ; preds = %474
   %478 = load i8, i8* %476, align 8
   %479 = zext i8 %478 to i32
   %480 = trunc i32 %479 to i8
-  %NullCheck162 = icmp ne i8* %475, null
-  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+  %NullCheck161 = icmp eq i8* %475, null
+  br i1 %NullCheck161, label %ThrowNullRef162, label %481
 
 ; <label>:481                                     ; preds = %477
   store i8 %480, i8* %475, align 8
@@ -1553,343 +1635,343 @@ ThrowNullRef:                                     ; preds = %308
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %312
+ThrowNullRef2:                                    ; preds = %312
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %315
+ThrowNullRef4:                                    ; preds = %315
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %321
+ThrowNullRef6:                                    ; preds = %321
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %271
+ThrowNullRef8:                                    ; preds = %271
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %275
+ThrowNullRef10:                                   ; preds = %275
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %278
+ThrowNullRef12:                                   ; preds = %278
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %284
+ThrowNullRef14:                                   ; preds = %284
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %287
+ThrowNullRef16:                                   ; preds = %287
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %293
+ThrowNullRef18:                                   ; preds = %293
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %298
+ThrowNullRef20:                                   ; preds = %298
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %303
+ThrowNullRef22:                                   ; preds = %303
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %243
+ThrowNullRef24:                                   ; preds = %243
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %247
+ThrowNullRef26:                                   ; preds = %247
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %250
+ThrowNullRef28:                                   ; preds = %250
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %256
+ThrowNullRef30:                                   ; preds = %256
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %259
+ThrowNullRef32:                                   ; preds = %259
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %265
+ThrowNullRef34:                                   ; preds = %265
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %217
+ThrowNullRef36:                                   ; preds = %217
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %221
+ThrowNullRef38:                                   ; preds = %221
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %224
+ThrowNullRef40:                                   ; preds = %224
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %230
+ThrowNullRef42:                                   ; preds = %230
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %233
+ThrowNullRef44:                                   ; preds = %233
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %238
+ThrowNullRef46:                                   ; preds = %238
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %200
+ThrowNullRef48:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %204
+ThrowNullRef50:                                   ; preds = %204
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %207
+ThrowNullRef52:                                   ; preds = %207
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %213
+ThrowNullRef54:                                   ; preds = %213
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %172
+ThrowNullRef56:                                   ; preds = %172
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %176
+ThrowNullRef58:                                   ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %179
+ThrowNullRef60:                                   ; preds = %179
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %185
+ThrowNullRef62:                                   ; preds = %185
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %190
+ThrowNullRef64:                                   ; preds = %190
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %195
+ThrowNullRef66:                                   ; preds = %195
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %153
+ThrowNullRef68:                                   ; preds = %153
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %157
+ThrowNullRef70:                                   ; preds = %157
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %160
+ThrowNullRef72:                                   ; preds = %160
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %166
+ThrowNullRef74:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %136
+ThrowNullRef76:                                   ; preds = %136
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %140
+ThrowNullRef78:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %143
+ThrowNullRef80:                                   ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %148
+ThrowNullRef82:                                   ; preds = %148
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %128
+ThrowNullRef84:                                   ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %132
+ThrowNullRef86:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %100
+ThrowNullRef88:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %104
+ThrowNullRef90:                                   ; preds = %104
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %107
+ThrowNullRef92:                                   ; preds = %107
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %113
+ThrowNullRef94:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %118
+ThrowNullRef96:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %123
+ThrowNullRef98:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %81
+ThrowNullRef100:                                  ; preds = %81
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef101:                                  ; preds = %85
+ThrowNullRef102:                                  ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef103:                                  ; preds = %88
+ThrowNullRef104:                                  ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef105:                                  ; preds = %94
+ThrowNullRef106:                                  ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef107:                                  ; preds = %64
+ThrowNullRef108:                                  ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef109:                                  ; preds = %68
+ThrowNullRef110:                                  ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef111:                                  ; preds = %71
+ThrowNullRef112:                                  ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef113:                                  ; preds = %76
+ThrowNullRef114:                                  ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef115:                                  ; preds = %56
+ThrowNullRef116:                                  ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef117:                                  ; preds = %60
+ThrowNullRef118:                                  ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef119:                                  ; preds = %37
+ThrowNullRef120:                                  ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef121:                                  ; preds = %41
+ThrowNullRef122:                                  ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef123:                                  ; preds = %46
+ThrowNullRef124:                                  ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef125:                                  ; preds = %51
+ThrowNullRef126:                                  ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef127:                                  ; preds = %27
+ThrowNullRef128:                                  ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef129:                                  ; preds = %31
+ThrowNullRef130:                                  ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef131:                                  ; preds = %19
+ThrowNullRef132:                                  ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef133:                                  ; preds = %22
+ThrowNullRef134:                                  ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef135:                                  ; preds = %338
+ThrowNullRef136:                                  ; preds = %338
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef137:                                  ; preds = %341
+ThrowNullRef138:                                  ; preds = %341
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef139:                                  ; preds = %356
+ThrowNullRef140:                                  ; preds = %356
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef141:                                  ; preds = %360
+ThrowNullRef142:                                  ; preds = %360
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef143:                                  ; preds = %377
+ThrowNullRef144:                                  ; preds = %377
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef145:                                  ; preds = %381
+ThrowNullRef146:                                  ; preds = %381
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef147:                                  ; preds = %424
+ThrowNullRef148:                                  ; preds = %424
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef149:                                  ; preds = %428
+ThrowNullRef150:                                  ; preds = %428
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef151:                                  ; preds = %440
+ThrowNullRef152:                                  ; preds = %440
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef153:                                  ; preds = %444
+ThrowNullRef154:                                  ; preds = %444
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef155:                                  ; preds = %456
+ThrowNullRef156:                                  ; preds = %456
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef157:                                  ; preds = %460
+ThrowNullRef158:                                  ; preds = %460
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef159:                                  ; preds = %474
+ThrowNullRef160:                                  ; preds = %474
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef161:                                  ; preds = %477
+ThrowNullRef162:                                  ; preds = %477
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef163:                                  ; preds = %394
+ThrowNullRef164:                                  ; preds = %394
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef165:                                  ; preds = %398
+ThrowNullRef166:                                  ; preds = %398
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef167:                                  ; preds = %401
+ThrowNullRef168:                                  ; preds = %401
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef169:                                  ; preds = %407
+ThrowNullRef170:                                  ; preds = %407
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1939,8 +2021,8 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
-  br i1 %NullCheck, label %22, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %ThrowNullRef, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
@@ -1948,8 +2030,8 @@ entry:
   store i32 %24, i32* %loc0
   %25 = load i32, i32* %loc0
   %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %26, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %27
 
 ; <label>:27                                      ; preds = %22
   %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
@@ -1971,7 +2053,7 @@ ThrowNullRef:                                     ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1989,8 +2071,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -2022,15 +2104,15 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2048,16 +2130,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
   %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
   store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %15
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
@@ -2072,8 +2154,8 @@ entry:
   %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
   %29 = ptrtoint i16 addrspace(1)* %28 to i64
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %19
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
@@ -2089,19 +2171,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2114,8 +2196,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
@@ -2128,7 +2210,7 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[loadElem]
+Failed to read AppDomain.PrepareDataForSetup[storeElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
@@ -2202,8 +2284,8 @@ entry:
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
-  br i1 %NullCheck24, label %27, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = load i64, i64 addrspace(1)* %26
@@ -2218,8 +2300,8 @@ entry:
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
-  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
   %41 = load i64, i64 addrspace(1)* %39
@@ -2236,8 +2318,8 @@ entry:
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
-  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
   %54 = load i64, i64 addrspace(1)* %52
@@ -2252,8 +2334,8 @@ entry:
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
   %67 = load i64, i64 addrspace(1)* %65
@@ -2270,8 +2352,8 @@ entry:
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
-  br i1 %NullCheck16, label %79, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
   %80 = load i64, i64 addrspace(1)* %78
@@ -2286,8 +2368,8 @@ entry:
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
-  br i1 %NullCheck18, label %92, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
   %93 = load i64, i64 addrspace(1)* %91
@@ -2304,8 +2386,8 @@ entry:
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
-  br i1 %NullCheck12, label %105, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = load i64, i64 addrspace(1)* %104
@@ -2320,8 +2402,8 @@ entry:
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
-  br i1 %NullCheck14, label %118, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
   %119 = load i64, i64 addrspace(1)* %117
@@ -2337,8 +2419,8 @@ entry:
 
 ; <label>:128                                     ; preds = %20
   %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
-  br i1 %NullCheck4, label %130, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %129, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %130
 
 ; <label>:130                                     ; preds = %128
   %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
@@ -2346,8 +2428,8 @@ entry:
   %133 = load i16, i16 addrspace(1)* %132, align 8
   %134 = zext i16 %133 to i32
   %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
-  br i1 %NullCheck6, label %136, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %135, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %136
 
 ; <label>:136                                     ; preds = %130
   %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
@@ -2360,8 +2442,8 @@ entry:
 
 ; <label>:143                                     ; preds = %136
   %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
-  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %144, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %145
 
 ; <label>:145                                     ; preds = %143
   %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
@@ -2369,8 +2451,8 @@ entry:
   %148 = load i16, i16 addrspace(1)* %147, align 8
   %149 = zext i16 %148 to i32
   %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %150, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %151
 
 ; <label>:151                                     ; preds = %145
   %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
@@ -2388,8 +2470,8 @@ entry:
 
 ; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
-  br i1 %NullCheck, label %163, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %ThrowNullRef, label %163
 
 ; <label>:163                                     ; preds = %161
   %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
@@ -2399,8 +2481,8 @@ entry:
 
 ; <label>:167                                     ; preds = %163
   %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
-  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %168, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %169
 
 ; <label>:169                                     ; preds = %167
   %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
@@ -2432,55 +2514,55 @@ ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %167
+ThrowNullRef2:                                    ; preds = %167
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %128
+ThrowNullRef4:                                    ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %130
+ThrowNullRef6:                                    ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %143
+ThrowNullRef8:                                    ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %145
+ThrowNullRef10:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %102
+ThrowNullRef12:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %105
+ThrowNullRef14:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %76
+ThrowNullRef16:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %79
+ThrowNullRef18:                                   ; preds = %79
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %50
+ThrowNullRef20:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %53
+ThrowNullRef22:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %24
+ThrowNullRef24:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %27
+ThrowNullRef26:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2503,15 +2585,15 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2519,16 +2601,16 @@ entry:
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
   store i32 %8, i32* %loc0
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
   %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
   store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
@@ -2546,16 +2628,16 @@ entry:
 
 ; <label>:23                                      ; preds = %64
   %24 = load i16*, i16** %loc3
-  %NullCheck12 = icmp ne i16* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i16* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
   store i32 %27, i32* %loc5
   %28 = load i16*, i16** %loc4
-  %NullCheck14 = icmp ne i16* %28, null
-  br i1 %NullCheck14, label %29, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %28, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = load i16, i16* %28, align 8
@@ -2620,15 +2702,15 @@ entry:
 
 ; <label>:67                                      ; preds = %64
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
-  br i1 %NullCheck8, label %69, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %68, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %69
 
 ; <label>:69                                      ; preds = %67
   %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
   %71 = load i32, i32 addrspace(1)* %70
   %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
-  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %73
 
 ; <label>:73                                      ; preds = %69
   %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
@@ -2645,31 +2727,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %67
+ThrowNullRef8:                                    ; preds = %67
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %69
+ThrowNullRef10:                                   ; preds = %69
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2710,14 +2792,14 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
   %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
@@ -2730,14 +2812,14 @@ entry:
 
 ; <label>:11                                      ; preds = %4
   %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
   %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
@@ -2749,14 +2831,14 @@ entry:
 
 ; <label>:22                                      ; preds = %16
   %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
   %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
-  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
-  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
@@ -2804,23 +2886,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2836,7 +2918,280 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[loadElem]
+Successfully read RuntimeType.IsAssignableFrom
+
+define i8 @RuntimeType.IsAssignableFrom(%System.RuntimeType addrspace(1)* %param0, %System.Type addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.RuntimeType addrspace(1)*
+  %arg1 = alloca %System.Type addrspace(1)*
+  %loc0 = alloca %System.RuntimeType addrspace(1)*
+  %loc1 = alloca %"System.Type[]" addrspace(1)*
+  %loc2 = alloca i32
+  store %System.RuntimeType addrspace(1)* %param0, %System.RuntimeType addrspace(1)** %this
+  store %System.Type addrspace(1)* %param1, %System.Type addrspace(1)** %arg1
+  %0 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %1 = icmp ne %System.Type addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i8 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %5 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %6 = bitcast %System.Type addrspace(1)* %4 to %System.Object addrspace(1)*
+  %7 = bitcast %System.RuntimeType addrspace(1)* %5 to %System.Object addrspace(1)*
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %6, %System.Object addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %3
+  ret i8 1
+
+; <label>:12                                      ; preds = %3
+  %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 152
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 32
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
+  %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
+  %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
+  store %System.RuntimeType addrspace(1)* %25, %System.RuntimeType addrspace(1)** %loc0
+  %26 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %27 = icmp eq %System.RuntimeType addrspace(1)* %26, null
+  br i1 %27, label %34, label %28
+
+; <label>:28                                      ; preds = %15
+  %29 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %30 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)*)*)(%System.RuntimeType addrspace(1)* %29, %System.RuntimeType addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+; <label>:34                                      ; preds = %15
+  %35 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %36 = call %System.Reflection.Emit.TypeBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Reflection.Emit.TypeBuilder addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %35)
+  %37 = icmp eq %System.Reflection.Emit.TypeBuilder addrspace(1)* %36, null
+  br i1 %37, label %139, label %38
+
+; <label>:38                                      ; preds = %34
+  %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %42
+
+; <label>:42                                      ; preds = %38
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 152
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 40
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
+  %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
+  %53 = zext i8 %52 to i32
+  %54 = icmp eq i32 %53, 0
+  br i1 %54, label %56, label %55
+
+; <label>:55                                      ; preds = %42
+  ret i8 1
+
+; <label>:56                                      ; preds = %42
+  %57 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %58 = bitcast %System.RuntimeType addrspace(1)* %57 to %System.Type addrspace(1)*
+  %59 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %58)
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %64 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.Type addrspace(1)* %63, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = bitcast %System.RuntimeType addrspace(1)* %64 to %System.Type addrspace(1)*
+  %67 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %63, %System.Type addrspace(1)* %66)
+  %68 = zext i8 %67 to i32
+  %69 = trunc i32 %68 to i8
+  ret i8 %69
+
+; <label>:70                                      ; preds = %56
+  %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
+  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %73
+
+; <label>:73                                      ; preds = %70
+  %74 = load i64, i64 addrspace(1)* %72
+  %75 = add i64 %74, 128
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = add i64 %77, 0
+  %79 = inttoptr i64 %78 to i64*
+  %80 = load i64, i64* %79
+  %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
+  %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
+  %83 = call i8 %82(%System.Type addrspace(1)* %81)
+  %84 = zext i8 %83 to i32
+  %85 = icmp eq i32 %84, 0
+  br i1 %85, label %139, label %86
+
+; <label>:86                                      ; preds = %73
+  %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
+  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %89
+
+; <label>:89                                      ; preds = %86
+  %90 = load i64, i64 addrspace(1)* %88
+  %91 = add i64 %90, 128
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = add i64 %93, 24
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
+  %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
+  %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
+  store %"System.Type[]" addrspace(1)* %99, %"System.Type[]" addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %129
+
+; <label>:100                                     ; preds = %132
+  %101 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %102 = load i32, i32* %loc2
+  %NullCheck11 = icmp eq %"System.Type[]" addrspace(1)* %101, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %103
+
+; <label>:103                                     ; preds = %100
+  %104 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 1
+  %105 = load i32, i32 addrspace(1)* %104
+  %106 = zext i32 %105 to i64
+  %107 = zext i32 %102 to i64
+  %BoundsCheck = icmp uge i64 %107, %106
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %108
+
+; <label>:108                                     ; preds = %103
+  %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
+  %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
+  %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
+  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %113
+
+; <label>:113                                     ; preds = %108
+  %114 = load i64, i64 addrspace(1)* %112
+  %115 = add i64 %114, 152
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = add i64 %117, 56
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
+  %123 = zext i8 %122 to i32
+  %124 = icmp ne i32 %123, 0
+  br i1 %124, label %126, label %125
+
+; <label>:125                                     ; preds = %113
+  ret i8 0
+
+; <label>:126                                     ; preds = %113
+  %127 = load i32, i32* %loc2
+  %128 = add i32 %127, 1
+  store i32 %128, i32* %loc2
+  br label %129
+
+; <label>:129                                     ; preds = %89, %126
+  %130 = load i32, i32* %loc2
+  %131 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %NullCheck9 = icmp eq %"System.Type[]" addrspace(1)* %131, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %132
+
+; <label>:132                                     ; preds = %129
+  %133 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %131, i32 0, i32 1
+  %134 = load i32, i32 addrspace(1)* %133
+  %135 = zext i32 %134 to i64
+  %136 = trunc i64 %135 to i32
+  %137 = icmp slt i32 %130, %136
+  br i1 %137, label %100, label %138
+
+; <label>:138                                     ; preds = %132
+  ret i8 1
+
+; <label>:139                                     ; preds = %34, %73
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %129
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %103
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -2893,7 +3248,7 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElem]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -2904,8 +3259,8 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -2997,8 +3352,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
@@ -3059,8 +3414,8 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -3087,8 +3442,8 @@ entry:
 
 ; <label>:17                                      ; preds = %5, %11
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
@@ -3097,8 +3452,8 @@ entry:
 
 ; <label>:22                                      ; preds = %1, %11
   %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
@@ -3109,11 +3464,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %17
+ThrowNullRef2:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %22
+ThrowNullRef4:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3167,15 +3522,15 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
   %15 = load i32, i32 addrspace(1)* %14
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
@@ -3198,7 +3553,7 @@ ThrowNullRef:                                     ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef2:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3232,8 +3587,8 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
@@ -3312,8 +3667,8 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -3327,8 +3682,8 @@ entry:
 ; <label>:5                                       ; preds = %43
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %7 = load i32, i32* %loc1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck6, label %8, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
@@ -3366,8 +3721,8 @@ entry:
 ; <label>:32                                      ; preds = %21, %25
   %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
   %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
-  br i1 %NullCheck8, label %35, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = trunc i32 %34 to i16
@@ -3380,8 +3735,8 @@ entry:
 ; <label>:40                                      ; preds = %1, %35
   %41 = load i32, i32* %loc1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
-  br i1 %NullCheck2, label %43, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %42, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
@@ -3392,8 +3747,8 @@ entry:
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
   %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
-  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
   %51 = load i64, i64 addrspace(1)* %49
@@ -3412,19 +3767,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %40
+ThrowNullRef2:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %47
+ThrowNullRef4:                                    ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %5
+ThrowNullRef6:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %32
+ThrowNullRef8:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3467,8 +3822,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
@@ -3492,11 +3847,391 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(i16* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store i16* %param0, i16** %arg0
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load i32, i32* %arg3
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %42, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %37, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg2
+  %13 = load i32, i32* %arg3
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %37, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %24 = load i32, i32* %arg2
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load i16*, i16** %arg0
+  %35 = load i32, i32* %arg3
+  %36 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %36, i16* %34, i32 %35)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:37                                      ; preds = %5, %16
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %39)
+  %41 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41, %System.String addrspace(1)* %38, %System.String addrspace(1)* %40)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41) #0
+  unreachable
+
+; <label>:42                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
-Failed to read StringBuilder.ToString[loadElemA]
+Successfully read StringBuilder.ToString
+
+define %System.String addrspace(1)* @StringBuilder.ToString(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i16*
+  %loc3 = alloca %"System.Char[]" addrspace(1)*
+  %loc4 = alloca i32
+  %loc5 = alloca i32
+  %loc6 = alloca i16 addrspace(1)*
+  %loc7 = alloca %System.String addrspace(1)*
+  %loc8 = alloca %"System.Char[]" addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %0)
+  %2 = icmp ne i32 %1, 0
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %4
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %6)
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %7)
+  store %System.String addrspace(1)* %8, %System.String addrspace(1)** %loc0
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.Text.StringBuilder addrspace(1)* %9, %System.Text.StringBuilder addrspace(1)** %loc1
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  store %System.String addrspace(1)* %10, %System.String addrspace(1)** %loc7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc7
+  %12 = ptrtoint %System.String addrspace(1)* %11 to i64
+  %13 = icmp eq i64 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %5
+  %15 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %16 = sext i32 %15 to i64
+  %17 = add i64 %12, %16
+  br label %18
+
+; <label>:18                                      ; preds = %5, %14
+  %19 = phi i64 [ %12, %5 ], [ %17, %14 ]
+  %20 = inttoptr i64 %19 to i16*
+  store i16* %20, i16** %loc2
+  br label %21
+
+; <label>:21                                      ; preds = %98, %18
+  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %22, null
+  br i1 %NullCheck, label %ThrowNullRef, label %23
+
+; <label>:23                                      ; preds = %21
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 3
+  %25 = load i32, i32 addrspace(1)* %24, align 8
+  %26 = icmp sle i32 %25, 0
+  br i1 %26, label %96, label %27
+
+; <label>:27                                      ; preds = %23
+  %28 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %28, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %29
+
+; <label>:29                                      ; preds = %27
+  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %28, i32 0, i32 1
+  %31 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %30, align 8
+  store %"System.Char[]" addrspace(1)* %31, %"System.Char[]" addrspace(1)** %loc3
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %33
+
+; <label>:33                                      ; preds = %29
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  store i32 %35, i32* %loc4
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  %39 = load i32, i32 addrspace(1)* %38, align 8
+  store i32 %39, i32* %loc5
+  %40 = load i32, i32* %loc5
+  %41 = load i32, i32* %loc4
+  %42 = add i32 %40, %41
+  %43 = zext i32 %42 to i64
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %45
+
+; <label>:45                                      ; preds = %37
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = sext i32 %47 to i64
+  %49 = icmp sgt i64 %43, %48
+  br i1 %49, label %91, label %50
+
+; <label>:50                                      ; preds = %45
+  %51 = load i32, i32* %loc5
+  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %52, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %53
+
+; <label>:53                                      ; preds = %50
+  %54 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %52, i32 0, i32 1
+  %55 = load i32, i32 addrspace(1)* %54
+  %56 = zext i32 %55 to i64
+  %57 = trunc i64 %56 to i32
+  %58 = icmp ugt i32 %51, %57
+  br i1 %58, label %91, label %59
+
+; <label>:59                                      ; preds = %53
+  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  store %"System.Char[]" addrspace(1)* %60, %"System.Char[]" addrspace(1)** %loc8
+  %61 = icmp eq %"System.Char[]" addrspace(1)* %60, null
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %63, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %64
+
+; <label>:64                                      ; preds = %62
+  %65 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %63, i32 0, i32 1
+  %66 = load i32, i32 addrspace(1)* %65
+  %67 = zext i32 %66 to i64
+  %68 = trunc i64 %67 to i32
+  %69 = icmp ne i32 %68, 0
+  br i1 %69, label %71, label %70
+
+; <label>:70                                      ; preds = %59, %64
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:71                                      ; preds = %64
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %73
+
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %BoundsCheck = icmp uge i64 0, %76
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %77
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %78, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:79                                      ; preds = %70, %77
+  %80 = load i16*, i16** %loc2
+  %81 = load i32, i32* %loc4
+  %82 = sext i32 %81 to i64
+  %83 = mul i64 %82, 2
+  %84 = bitcast i16* %80 to i8*
+  %85 = getelementptr inbounds i8, i8* %84, i64 %83
+  %86 = load i16 addrspace(1)*, i16 addrspace(1)** %loc6
+  %87 = ptrtoint i16 addrspace(1)* %86 to i64
+  %88 = load i32, i32* %loc5
+  %89 = bitcast i8* %85 to i16*
+  %90 = inttoptr i64 %87 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %89, i16* %90, i32 %88)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %96
+
+; <label>:91                                      ; preds = %45, %53
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %94 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %93)
+  %95 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95, %System.String addrspace(1)* %92, %System.String addrspace(1)* %94)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95) #0
+  unreachable
+
+; <label>:96                                      ; preds = %23, %79
+  %97 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %97, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %98
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %97, i32 0, i32 2
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  store %System.Text.StringBuilder addrspace(1)* %100, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %102 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %102, label %21, label %103
+
+; <label>:103                                     ; preds = %98
+  store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc7
+  %104 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  ret %System.String addrspace(1)* %104
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method StringBuilder::get_Length using LLILCJit
+Successfully read StringBuilder.get_Length
+
+define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
+Successfully read RuntimeHelpers.get_OffsetToStringData
+
+define i32 @RuntimeHelpers.get_OffsetToStringData() {
+entry:
+  ret i32 12
+}
+
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
 Successfully read CultureData.CreateCultureData
 
@@ -3514,23 +4249,23 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
   store i8 %4, i8 addrspace(1)* %6
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
@@ -3549,11 +4284,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3566,50 +4301,50 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
   store i32 -1, i32 addrspace(1)* %2
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
   store i32 -1, i32 addrspace(1)* %8
   %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
   store i32 -1, i32 addrspace(1)* %14
   %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
   store i32 -1, i32 addrspace(1)* %17
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
@@ -3623,27 +4358,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3675,7 +4410,136 @@ Failed to read Dictionary`2.Insert[non-const derefAddress]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
 Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
-Failed to read HashHelpers.GetPrime[loadElem]
+Successfully read HashHelpers.GetPrime
+
+define i32 @HashHelpers.GetPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %6, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5, %System.String addrspace(1)* %4)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5) #0
+  unreachable
+
+; <label>:6                                       ; preds = %entry
+  store i32 0, i32* %loc0
+  br label %29
+
+; <label>:7                                       ; preds = %35
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 1296
+  %10 = addrspacecast i8 addrspace(1)* %9 to %"System.Int32[]" addrspace(1)**
+  %11 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %10
+  %12 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Int32[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = zext i32 %15 to i64
+  %17 = zext i32 %12 to i64
+  %BoundsCheck = icmp uge i64 %17, %16
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 3, i32 %12
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  store i32 %20, i32* %loc1
+  %21 = load i32, i32* %loc1
+  %22 = load i32, i32* %arg0
+  %23 = icmp slt i32 %21, %22
+  br i1 %23, label %26, label %24
+
+; <label>:24                                      ; preds = %18
+  %25 = load i32, i32* %loc1
+  ret i32 %25
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %loc0
+  %28 = add i32 %27, 1
+  store i32 %28, i32* %loc0
+  br label %29
+
+; <label>:29                                      ; preds = %6, %26
+  %30 = load i32, i32* %loc0
+  %31 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %32 = getelementptr inbounds i8, i8 addrspace(1)* %31, i64 1296
+  %33 = addrspacecast i8 addrspace(1)* %32 to %"System.Int32[]" addrspace(1)**
+  %34 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %33
+  %NullCheck = icmp eq %"System.Int32[]" addrspace(1)* %34, null
+  br i1 %NullCheck, label %ThrowNullRef, label %35
+
+; <label>:35                                      ; preds = %29
+  %36 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %34, i32 0, i32 1
+  %37 = load i32, i32 addrspace(1)* %36
+  %38 = zext i32 %37 to i64
+  %39 = trunc i64 %38 to i32
+  %40 = icmp slt i32 %30, %39
+  br i1 %40, label %7, label %41
+
+; <label>:41                                      ; preds = %35
+  %42 = load i32, i32* %arg0
+  %43 = or i32 %42, 1
+  store i32 %43, i32* %loc2
+  br label %59
+
+; <label>:44                                      ; preds = %59
+  %45 = load i32, i32* %loc2
+  %46 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %45)
+  %47 = zext i8 %46 to i32
+  %48 = icmp eq i32 %47, 0
+  br i1 %48, label %56, label %49
+
+; <label>:49                                      ; preds = %44
+  %50 = load i32, i32* %loc2
+  %51 = sub i32 %50, 1
+  %52 = srem i32 %51, 101
+  %53 = icmp eq i32 %52, 0
+  br i1 %53, label %56, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = load i32, i32* %loc2
+  ret i32 %55
+
+; <label>:56                                      ; preds = %44, %49
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %57, 2
+  store i32 %58, i32* %loc2
+  br label %59
+
+; <label>:59                                      ; preds = %41, %56
+  %60 = load i32, i32* %loc2
+  %61 = icmp slt i32 %60, 2147483647
+  br i1 %61, label %44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load i32, i32* %arg0
+  ret i32 %63
+
+ThrowNullRef:                                     ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
 Successfully read GenericEqualityComparer`1.GetHashCode
 
@@ -3694,14 +4558,14 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
   %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load i64, i64 addrspace(1)* %7
@@ -3720,7 +4584,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3750,8 +4614,8 @@ entry:
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
@@ -3796,8 +4660,8 @@ entry:
   %35 = bitcast i16* %34 to i8*
   %36 = getelementptr inbounds i8, i8* %35, i64 2
   %37 = bitcast i8* %36 to i16*
-  %NullCheck4 = icmp ne i16* %37, null
-  br i1 %NullCheck4, label %38, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %37, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %38
 
 ; <label>:38                                      ; preds = %27
   %39 = load i16, i16* %37, align 8
@@ -3824,8 +4688,8 @@ entry:
 
 ; <label>:54                                      ; preds = %22, %43
   %55 = load i16*, i16** %loc4
-  %NullCheck2 = icmp ne i16* %55, null
-  br i1 %NullCheck2, label %56, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i16* %55, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %56
 
 ; <label>:56                                      ; preds = %54
   %57 = load i16, i16* %55, align 8
@@ -3850,11 +4714,11 @@ ThrowNullRef:                                     ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %54
+ThrowNullRef2:                                    ; preds = %54
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %27
+ThrowNullRef4:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3871,8 +4735,8 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -3907,8 +4771,8 @@ entry:
 
 ; <label>:26                                      ; preds = %19
   %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
-  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %28
 
 ; <label>:28                                      ; preds = %26
   %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
@@ -3920,7 +4784,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3972,8 +4836,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
@@ -3984,26 +4848,26 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
-  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
@@ -4014,8 +4878,8 @@ entry:
 ; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
@@ -4024,8 +4888,8 @@ entry:
 
 ; <label>:25                                      ; preds = %1, %16, %23
   %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
-  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
@@ -4036,27 +4900,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %20
+ThrowNullRef10:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4069,8 +4933,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -4081,8 +4945,8 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
@@ -4091,8 +4955,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1, %8
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
@@ -4103,11 +4967,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4128,24 +4992,24 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   store i32 %3, i32* %loc0
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
   %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
   store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck4, label %9, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
@@ -4164,15 +5028,15 @@ entry:
 ; <label>:18                                      ; preds = %70
   %19 = load i16*, i16** %loc3
   %20 = bitcast i16* %19 to i64*
-  %NullCheck10 = icmp ne i64* %20, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %20, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = load i64, i64* %20, align 8
   %23 = load i16*, i16** %loc4
   %24 = bitcast i16* %23 to i64*
-  %NullCheck12 = icmp ne i64* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = load i64, i64* %24, align 8
@@ -4188,8 +5052,8 @@ entry:
   %31 = bitcast i16* %30 to i8*
   %32 = getelementptr inbounds i8, i8* %31, i64 8
   %33 = bitcast i8* %32 to i64*
-  %NullCheck14 = icmp ne i64* %33, null
-  br i1 %NullCheck14, label %34, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = load i64, i64* %33, align 8
@@ -4197,8 +5061,8 @@ entry:
   %37 = bitcast i16* %36 to i8*
   %38 = getelementptr inbounds i8, i8* %37, i64 8
   %39 = bitcast i8* %38 to i64*
-  %NullCheck16 = icmp ne i64* %39, null
-  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %40
 
 ; <label>:40                                      ; preds = %34
   %41 = load i64, i64* %39, align 8
@@ -4214,8 +5078,8 @@ entry:
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %NullCheck18 = icmp ne i64* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = load i64, i64* %48, align 8
@@ -4223,8 +5087,8 @@ entry:
   %52 = bitcast i16* %51 to i8*
   %53 = getelementptr inbounds i8, i8* %52, i64 16
   %54 = bitcast i8* %53 to i64*
-  %NullCheck20 = icmp ne i64* %54, null
-  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64* %54, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %55
 
 ; <label>:55                                      ; preds = %49
   %56 = load i64, i64* %54, align 8
@@ -4262,15 +5126,15 @@ entry:
 ; <label>:74                                      ; preds = %95
   %75 = load i16*, i16** %loc3
   %76 = bitcast i16* %75 to i32*
-  %NullCheck6 = icmp ne i32* %76, null
-  br i1 %NullCheck6, label %77, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32* %76, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %77
 
 ; <label>:77                                      ; preds = %74
   %78 = load i32, i32* %76, align 8
   %79 = load i16*, i16** %loc4
   %80 = bitcast i16* %79 to i32*
-  %NullCheck8 = icmp ne i32* %80, null
-  br i1 %NullCheck8, label %81, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i32* %80, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %81
 
 ; <label>:81                                      ; preds = %77
   %82 = load i32, i32* %80, align 8
@@ -4318,43 +5182,43 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %74
+ThrowNullRef6:                                    ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %77
+ThrowNullRef8:                                    ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %29
+ThrowNullRef14:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %34
+ThrowNullRef16:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4376,8 +5240,8 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load i64, i64 addrspace(1)* %4
@@ -4389,8 +5253,8 @@ entry:
   %12 = load i64, i64* %11
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %5
   %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
@@ -4399,8 +5263,8 @@ entry:
   %18 = load i8, i8* %arg2
   %19 = zext i8 %18 to i32
   %20 = trunc i32 %19 to i8
-  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %15
   %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
@@ -4411,11 +5275,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4442,8 +5306,8 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
@@ -4466,16 +5330,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
   %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = load i64, i64 addrspace(1)* %19
@@ -4500,8 +5364,8 @@ entry:
 ; <label>:35                                      ; preds = %30
   %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
@@ -4514,8 +5378,8 @@ entry:
 
 ; <label>:42                                      ; preds = %1, %38
   %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
-  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
@@ -4526,19 +5390,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %35
+ThrowNullRef2:                                    ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %42
+ThrowNullRef8:                                    ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4551,14 +5415,14 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
@@ -4570,7 +5434,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4583,8 +5447,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
@@ -4613,51 +5477,51 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
   %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
   %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
   %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
   %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
-  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
   store i64 %21, i64 addrspace(1)* %23
   %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %25 = load i64, i64* %loc0
-  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
@@ -4668,27 +5532,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %22
+ThrowNullRef12:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4701,8 +5565,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
@@ -4713,19 +5577,19 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
@@ -4734,8 +5598,8 @@ entry:
 
 ; <label>:15                                      ; preds = %1, %13
   %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
@@ -4746,19 +5610,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %15
+ThrowNullRef8:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4771,8 +5635,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -4831,8 +5695,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
@@ -4882,8 +5746,8 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
-  br i1 %NullCheck, label %17, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %ThrowNullRef, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
@@ -4894,15 +5758,15 @@ entry:
 
 ; <label>:22                                      ; preds = %17
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
-  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
   %26 = load i32, i32 addrspace(1)* %25
   %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
-  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %27, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
@@ -4925,8 +5789,8 @@ entry:
 ; <label>:40                                      ; preds = %17
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
-  br i1 %NullCheck6, label %43, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %41, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
@@ -4938,34 +5802,17 @@ ThrowNullRef:                                     ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %24
+ThrowNullRef4:                                    ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %40
+ThrowNullRef6:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
-}
-
-INFO:  jitting method Object::ReferenceEquals using LLILCJit
-Successfully read Object.ReferenceEquals
-
-define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
-entry:
-  %arg0 = alloca %System.Object addrspace(1)*
-  %arg1 = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
-  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
-  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = icmp eq %System.Object addrspace(1)* %0, %1
-  %3 = sext i1 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
 }
 
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
@@ -4978,21 +5825,21 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
   %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
-  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
@@ -5007,28 +5854,28 @@ entry:
 ; <label>:13                                      ; preds = %8, %12
   %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
   %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
   %21 = load i32, i32 addrspace(1)* %20, align 8
   %22 = add i32 %21, 1
-  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
   store i32 %22, i32 addrspace(1)* %24
   %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
@@ -5039,27 +5886,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5077,7 +5924,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::Setup using LLILCJit
-Failed to read AppDomain.Setup[loadElem]
+Failed to read AppDomain.Setup[unbox]
 INFO:  jitting method Thread::GetDomain using LLILCJit
 Successfully read Thread.GetDomain
 
@@ -5108,8 +5955,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
@@ -5122,14 +5969,14 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
   %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
@@ -5141,11 +5988,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5173,8 +6020,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -5189,7 +6036,328 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
 Failed to read KeyCollection.System.Collections.Generic.IEnumerable<TKey>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Successfully read Enumerator.MoveNext
+
+define i8 @Enumerator.MoveNext(%"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.RuntimeTypeHandle* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*
+  %"$TypeArg" = alloca %System.RuntimeTypeHandle*
+  store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
+  %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 8
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %76, label %12
+
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
+  br label %76
+
+; <label>:13                                      ; preds = %85
+  %14 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck19 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %15
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, i32 0, i32 0
+  %17 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %16, align 8
+  %NullCheck21 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, i32 0, i32 2
+  %20 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %19, align 8
+  %21 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck23 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %22
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, i32 0, i32 2
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %NullCheck25 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 3, i32 %24
+  %NullCheck27 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %32
+
+; <label>:32                                      ; preds = %30
+  %33 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, i32 0, i32 2
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = icmp slt i32 %34, 0
+  br i1 %35, label %68, label %36
+
+; <label>:36                                      ; preds = %32
+  %37 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %38 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck29 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %39
+
+; <label>:39                                      ; preds = %36
+  %40 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, i32 0, i32 0
+  %41 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %40, align 8
+  %NullCheck31 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, i32 0, i32 2
+  %44 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %43, align 8
+  %45 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck33 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, i32 0, i32 2
+  %48 = load i32, i32 addrspace(1)* %47, align 8
+  %NullCheck35 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %49
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = zext i32 %51 to i64
+  %53 = zext i32 %48 to i64
+  %BoundsCheck37 = icmp uge i64 %53, %52
+  br i1 %BoundsCheck37, label %ThrowIndexOutOfRange38, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 3, i32 %48
+  %NullCheck39 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %56
+
+; <label>:56                                      ; preds = %54
+  %57 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, i32 0, i32 0
+  %58 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck41 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %59
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %60, %System.__Canon addrspace(1)* %58)
+  %61 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck43 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  %64 = load i32, i32 addrspace(1)* %63, align 8
+  %65 = add i32 %64, 1
+  %NullCheck45 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  store i32 %65, i32 addrspace(1)* %67
+  ret i8 1
+
+; <label>:68                                      ; preds = %32
+  %69 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck47 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %73 = add i32 %72, 1
+  %NullCheck49 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %74
+
+; <label>:74                                      ; preds = %70
+  %75 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  store i32 %73, i32 addrspace(1)* %75
+  br label %76
+
+; <label>:76                                      ; preds = %8, %12, %74
+  %77 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %78
+
+; <label>:78                                      ; preds = %76
+  %79 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, i32 0, i32 2
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck7 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %82
+
+; <label>:82                                      ; preds = %78
+  %83 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, i32 0, i32 0
+  %84 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %83, align 8
+  %NullCheck9 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %85
+
+; <label>:85                                      ; preds = %82
+  %86 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, i32 0, i32 7
+  %87 = load i32, i32 addrspace(1)* %86, align 8
+  %88 = icmp ult i32 %80, %87
+  br i1 %88, label %13, label %89
+
+; <label>:89                                      ; preds = %85
+  %90 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %91 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck11 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %92
+
+; <label>:92                                      ; preds = %89
+  %93 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, i32 0, i32 0
+  %94 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck13 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %95
+
+; <label>:95                                      ; preds = %92
+  %96 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, i32 0, i32 7
+  %97 = load i32, i32 addrspace(1)* %96, align 8
+  %98 = add i32 %97, 1
+  %NullCheck15 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %99
+
+; <label>:99                                      ; preds = %95
+  %100 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, i32 0, i32 2
+  store i32 %98, i32 addrspace(1)* %100
+  %101 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck17 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %102
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %103, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %92
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef22:                                   ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef24:                                   ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef26:                                   ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef28:                                   ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef30:                                   ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef32:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef34:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef36:                                   ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange38:                           ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef40:                                   ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef42:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef44:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef46:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef48:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef50:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -5200,8 +6368,8 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -5232,9 +6400,9 @@ Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
 Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
-Failed to read String.MakeSeparatorList[loadElemA]
+Failed to read String.MakeSeparatorList[storeElem]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
-Failed to read String.InternalSplitKeepEmptyEntries[loadElem]
+Failed to read String.InternalSplitKeepEmptyEntries[storeElem]
 INFO:  jitting method Path::IsRelative using LLILCJit
 Successfully read Path.IsRelative
 
@@ -5243,8 +6411,8 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -5254,8 +6422,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
@@ -5271,8 +6439,8 @@ entry:
 
 ; <label>:17                                      ; preds = %7
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
@@ -5288,8 +6456,8 @@ entry:
 
 ; <label>:29                                      ; preds = %19
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %31
 
 ; <label>:31                                      ; preds = %29
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
@@ -5300,8 +6468,8 @@ entry:
 
 ; <label>:36                                      ; preds = %31
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
-  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %37, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
@@ -5312,8 +6480,8 @@ entry:
 
 ; <label>:43                                      ; preds = %31, %38
   %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
-  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %45
 
 ; <label>:45                                      ; preds = %43
   %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
@@ -5324,8 +6492,8 @@ entry:
 
 ; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %50
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
@@ -5336,8 +6504,8 @@ entry:
 
 ; <label>:57                                      ; preds = %1, %7, %19, %45, %52
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
-  br i1 %NullCheck14, label %59, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %59
 
 ; <label>:59                                      ; preds = %57
   %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
@@ -5347,8 +6515,8 @@ entry:
 
 ; <label>:63                                      ; preds = %59
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
@@ -5359,8 +6527,8 @@ entry:
 
 ; <label>:70                                      ; preds = %65
   %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
-  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.String addrspace(1)* %71, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %72
 
 ; <label>:72                                      ; preds = %70
   %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
@@ -5379,39 +6547,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %17
+ThrowNullRef4:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %29
+ThrowNullRef6:                                    ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %36
+ThrowNullRef8:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %43
+ThrowNullRef10:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %50
+ThrowNullRef12:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %57
+ThrowNullRef14:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %63
+ThrowNullRef16:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %70
+ThrowNullRef18:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5419,7 +6587,293 @@ ThrowNullRef17:                                   ; preds = %70
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
-Failed to read String.TrimHelper[loadElem]
+Successfully read String.TrimHelper
+
+define %System.String addrspace(1)* @String.TrimHelper(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i16
+  %loc4 = alloca i32
+  %loc5 = alloca i16
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = sub i32 %3, 1
+  store i32 %4, i32* %loc0
+  store i32 0, i32* %loc1
+  %5 = load i32, i32* %arg2
+  %6 = icmp eq i32 %5, 1
+  br i1 %6, label %62, label %7
+
+; <label>:7                                       ; preds = %1
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:8                                       ; preds = %58
+  store i32 0, i32* %loc2
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load i32, i32* %loc1
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2, i32 %10
+  %13 = load i16, i16 addrspace(1)* %12
+  %14 = zext i16 %13 to i32
+  %15 = trunc i32 %14 to i16
+  store i16 %15, i16* %loc3
+  store i32 0, i32* %loc2
+  br label %34
+
+; <label>:16                                      ; preds = %37
+  %17 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %18 = load i32, i32* %loc2
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %17, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %19
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = zext i32 %18 to i64
+  %BoundsCheck = icmp uge i64 %23, %22
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %24
+
+; <label>:24                                      ; preds = %19
+  %25 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 3, i32 %18
+  %26 = load i16, i16 addrspace(1)* %25, align 8
+  %27 = zext i16 %26 to i32
+  %28 = load i16, i16* %loc3
+  %29 = zext i16 %28 to i32
+  %30 = icmp eq i32 %27, %29
+  br i1 %30, label %43, label %31
+
+; <label>:31                                      ; preds = %24
+  %32 = load i32, i32* %loc2
+  %33 = add i32 %32, 1
+  store i32 %33, i32* %loc2
+  br label %34
+
+; <label>:34                                      ; preds = %11, %31
+  %35 = load i32, i32* %loc2
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = icmp slt i32 %35, %41
+  br i1 %42, label %16, label %43
+
+; <label>:43                                      ; preds = %24, %37
+  %44 = load i32, i32* %loc2
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %45, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp eq i32 %44, %50
+  br i1 %51, label %62, label %52
+
+; <label>:52                                      ; preds = %46
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %7, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %57, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %58
+
+; <label>:58                                      ; preds = %55
+  %59 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %60 = load i32, i32 addrspace(1)* %59
+  %61 = icmp slt i32 %56, %60
+  br i1 %61, label %8, label %62
+
+; <label>:62                                      ; preds = %1, %46, %58
+  %63 = load i32, i32* %arg2
+  %64 = icmp eq i32 %63, 0
+  br i1 %64, label %122, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %66, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %67
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %66, i32 0, i32 1
+  %69 = load i32, i32 addrspace(1)* %68
+  %70 = sub i32 %69, 1
+  store i32 %70, i32* %loc0
+  br label %118
+
+; <label>:71                                      ; preds = %118
+  store i32 0, i32* %loc4
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %73 = load i32, i32* %loc0
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %74
+
+; <label>:74                                      ; preds = %71
+  %75 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 2, i32 %73
+  %76 = load i16, i16 addrspace(1)* %75
+  %77 = zext i16 %76 to i32
+  %78 = trunc i32 %77 to i16
+  store i16 %78, i16* %loc5
+  store i32 0, i32* %loc4
+  br label %97
+
+; <label>:79                                      ; preds = %100
+  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %81 = load i32, i32* %loc4
+  %NullCheck19 = icmp eq %"System.Char[]" addrspace(1)* %80, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
+
+; <label>:82                                      ; preds = %79
+  %83 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 1
+  %84 = load i32, i32 addrspace(1)* %83
+  %85 = zext i32 %84 to i64
+  %86 = zext i32 %81 to i64
+  %BoundsCheck21 = icmp uge i64 %86, %85
+  br i1 %BoundsCheck21, label %ThrowIndexOutOfRange22, label %87
+
+; <label>:87                                      ; preds = %82
+  %88 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 3, i32 %81
+  %89 = load i16, i16 addrspace(1)* %88, align 8
+  %90 = zext i16 %89 to i32
+  %91 = load i16, i16* %loc5
+  %92 = zext i16 %91 to i32
+  %93 = icmp eq i32 %90, %92
+  br i1 %93, label %106, label %94
+
+; <label>:94                                      ; preds = %87
+  %95 = load i32, i32* %loc4
+  %96 = add i32 %95, 1
+  store i32 %96, i32* %loc4
+  br label %97
+
+; <label>:97                                      ; preds = %74, %94
+  %98 = load i32, i32* %loc4
+  %99 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck15 = icmp eq %"System.Char[]" addrspace(1)* %99, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %100
+
+; <label>:100                                     ; preds = %97
+  %101 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %99, i32 0, i32 1
+  %102 = load i32, i32 addrspace(1)* %101
+  %103 = zext i32 %102 to i64
+  %104 = trunc i64 %103 to i32
+  %105 = icmp slt i32 %98, %104
+  br i1 %105, label %79, label %106
+
+; <label>:106                                     ; preds = %87, %100
+  %107 = load i32, i32* %loc4
+  %108 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck17 = icmp eq %"System.Char[]" addrspace(1)* %108, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %109
+
+; <label>:109                                     ; preds = %106
+  %110 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %108, i32 0, i32 1
+  %111 = load i32, i32 addrspace(1)* %110
+  %112 = zext i32 %111 to i64
+  %113 = trunc i64 %112 to i32
+  %114 = icmp eq i32 %107, %113
+  br i1 %114, label %122, label %115
+
+; <label>:115                                     ; preds = %109
+  %116 = load i32, i32* %loc0
+  %117 = sub i32 %116, 1
+  store i32 %117, i32* %loc0
+  br label %118
+
+; <label>:118                                     ; preds = %67, %115
+  %119 = load i32, i32* %loc0
+  %120 = load i32, i32* %loc1
+  %121 = icmp sge i32 %119, %120
+  br i1 %121, label %71, label %122
+
+; <label>:122                                     ; preds = %62, %109, %118
+  %123 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %124 = load i32, i32* %loc1
+  %125 = load i32, i32* %loc0
+  %126 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %123, i32 %124, i32 %125)
+  ret %System.String addrspace(1)* %126
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %97
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange22:                           ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
 Successfully read String.CreateTrimmedString
 
@@ -5439,8 +6893,8 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
@@ -5535,8 +6989,8 @@ entry:
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i64 2872
   %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
   %8 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %7
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %3
   %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
@@ -5553,8 +7007,8 @@ entry:
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 2864
   %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
   %21 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %20
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
-  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %22
 
 ; <label>:22                                      ; preds = %16
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
@@ -5569,7 +7023,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %16
+ThrowNullRef2:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5586,8 +7040,8 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5613,8 +7067,8 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
@@ -5632,8 +7086,8 @@ entry:
 
 ; <label>:12                                      ; preds = %4
   %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
@@ -5644,8 +7098,8 @@ entry:
 
 ; <label>:19                                      ; preds = %14
   %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %19
   %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
@@ -5660,21 +7114,21 @@ entry:
   %31 = zext i16 %30 to i32
   %32 = bitcast i8* %29 to i16*
   %33 = trunc i32 %31 to i16
-  %NullCheck6 = icmp ne i16* %32, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i16* %32, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %21
   store i16 %33, i16* %32, align 8
   %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %36
 
 ; <label>:36                                      ; preds = %34
   %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
   %38 = load i32, i32 addrspace(1)* %37, align 8
   %39 = add i32 %38, 1
-  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %40
 
 ; <label>:40                                      ; preds = %36
   %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
@@ -5683,16 +7137,16 @@ entry:
 
 ; <label>:42                                      ; preds = %14
   %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
-  br i1 %NullCheck12, label %44, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
   %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
   %47 = load i16, i16* %arg1
   %48 = zext i16 %47 to i32
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = trunc i32 %48 to i16
@@ -5703,31 +7157,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %19
+ThrowNullRef4:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %21
+ThrowNullRef6:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %36
+ThrowNullRef10:                                   ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %42
+ThrowNullRef12:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %44
+ThrowNullRef14:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5740,8 +7194,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -5752,8 +7206,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
@@ -5762,14 +7216,14 @@ entry:
 
 ; <label>:11                                      ; preds = %1
   %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
@@ -5779,15 +7233,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5808,8 +7262,8 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5822,8 +7276,8 @@ entry:
 
 ; <label>:8                                       ; preds = %3
   %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
@@ -5842,15 +7296,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
-  br i1 %NullCheck4, label %22, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
   %24 = load i16*, i16* addrspace(1)* %23, align 8
   %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %25, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
@@ -5859,8 +7313,8 @@ entry:
   store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
@@ -5874,8 +7328,8 @@ entry:
 
 ; <label>:37                                      ; preds = %65
   %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %37
   %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
@@ -5886,16 +7340,16 @@ entry:
   %45 = bitcast i16* %41 to i8*
   %46 = getelementptr inbounds i8, i8* %45, i64 %44
   %47 = bitcast i8* %46 to i16*
-  %NullCheck14 = icmp ne i16* %47, null
-  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %47, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %48
 
 ; <label>:48                                      ; preds = %39
   %49 = load i16, i16* %47, align 8
   %50 = zext i16 %49 to i32
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %52 = load i32, i32* %loc1
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %53
 
 ; <label>:53                                      ; preds = %48
   %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
@@ -5916,8 +7370,8 @@ entry:
 ; <label>:62                                      ; preds = %36, %59
   %63 = load i32, i32* %loc1
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck10, label %65, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %65
 
 ; <label>:65                                      ; preds = %62
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
@@ -5936,15 +7390,15 @@ entry:
 
 ; <label>:74                                      ; preds = %70
   %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
-  br i1 %NullCheck18, label %76, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %76
 
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
   %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
-  br i1 %NullCheck20, label %80, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
   %81 = load i64, i64 addrspace(1)* %79
@@ -5958,8 +7412,8 @@ entry:
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
   %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
-  br i1 %NullCheck22, label %92, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.String addrspace(1)* %90, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %92
 
 ; <label>:92                                      ; preds = %80
   %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
@@ -5969,15 +7423,15 @@ entry:
 
 ; <label>:96                                      ; preds = %70
   %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
-  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %98
 
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
   %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
-  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
   %103 = load i64, i64 addrspace(1)* %101
@@ -5991,8 +7445,8 @@ entry:
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
   %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
-  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.String addrspace(1)* %112, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %114
 
 ; <label>:114                                     ; preds = %102
   %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
@@ -6004,59 +7458,59 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %20
+ThrowNullRef4:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %22
+ThrowNullRef6:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %26
+ThrowNullRef8:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %62
+ThrowNullRef10:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %48
+ThrowNullRef16:                                   ; preds = %48
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %74
+ThrowNullRef18:                                   ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %76
+ThrowNullRef20:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %80
+ThrowNullRef22:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %96
+ThrowNullRef24:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %98
+ThrowNullRef26:                                   ; preds = %98
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %102
+ThrowNullRef28:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6069,15 +7523,15 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
   %3 = load i16*, i16* addrspace(1)* %2, align 8
   %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
@@ -6087,8 +7541,8 @@ entry:
   %10 = bitcast i16* %3 to i8*
   %11 = getelementptr inbounds i8, i8* %10, i64 %9
   %12 = bitcast i8* %11 to i16*
-  %NullCheck4 = icmp ne i16* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %5
   store i16 0, i16* %12, align 8
@@ -6098,11 +7552,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6119,8 +7573,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -6131,8 +7585,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
@@ -6144,15 +7598,15 @@ entry:
 
 ; <label>:14                                      ; preds = %1
   %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
   %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
   %21 = load i64, i64 addrspace(1)* %19
@@ -6171,15 +7625,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %14
+ThrowNullRef4:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %16
+ThrowNullRef6:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6302,14 +7756,6 @@ entry:
   ret %System.String addrspace(1)* %57
 }
 
-INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
-Successfully read RuntimeHelpers.get_OffsetToStringData
-
-define i32 @RuntimeHelpers.get_OffsetToStringData() {
-entry:
-  ret i32 12
-}
-
 INFO:  jitting method String::Equals using LLILCJit
 Successfully read String.Equals
 
@@ -6381,8 +7827,8 @@ entry:
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
-  br i1 %NullCheck24, label %29, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
   %30 = load i64, i64 addrspace(1)* %28
@@ -6397,8 +7843,8 @@ entry:
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
-  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
   %43 = load i64, i64 addrspace(1)* %41
@@ -6418,8 +7864,8 @@ entry:
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
   %59 = load i64, i64 addrspace(1)* %57
@@ -6434,8 +7880,8 @@ entry:
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck22, label %71, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
   %72 = load i64, i64 addrspace(1)* %70
@@ -6455,8 +7901,8 @@ entry:
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
-  br i1 %NullCheck16, label %87, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = load i64, i64 addrspace(1)* %86
@@ -6471,8 +7917,8 @@ entry:
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck18, label %100, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
   %101 = load i64, i64 addrspace(1)* %99
@@ -6492,8 +7938,8 @@ entry:
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
-  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
   %117 = load i64, i64 addrspace(1)* %115
@@ -6508,8 +7954,8 @@ entry:
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
-  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
   %130 = load i64, i64 addrspace(1)* %128
@@ -6528,15 +7974,15 @@ entry:
 
 ; <label>:142                                     ; preds = %22
   %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
-  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %143, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %144
 
 ; <label>:144                                     ; preds = %142
   %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
   %146 = load i32, i32 addrspace(1)* %145
   %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
-  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %147, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %148
 
 ; <label>:148                                     ; preds = %144
   %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
@@ -6557,15 +8003,15 @@ entry:
 
 ; <label>:159                                     ; preds = %22
   %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
-  br i1 %NullCheck, label %161, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %ThrowNullRef, label %161
 
 ; <label>:161                                     ; preds = %159
   %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
   %163 = load i32, i32 addrspace(1)* %162
   %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
-  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %164, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %165
 
 ; <label>:165                                     ; preds = %161
   %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
@@ -6578,8 +8024,8 @@ entry:
 
 ; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
-  br i1 %NullCheck4, label %172, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %171, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %172
 
 ; <label>:172                                     ; preds = %170
   %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
@@ -6589,8 +8035,8 @@ entry:
 
 ; <label>:176                                     ; preds = %172
   %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
-  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %177, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %178
 
 ; <label>:178                                     ; preds = %176
   %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
@@ -6629,55 +8075,55 @@ ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %161
+ThrowNullRef2:                                    ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %170
+ThrowNullRef4:                                    ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %176
+ThrowNullRef6:                                    ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %142
+ThrowNullRef8:                                    ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %144
+ThrowNullRef10:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %113
+ThrowNullRef12:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %116
+ThrowNullRef14:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %84
+ThrowNullRef16:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %87
+ThrowNullRef18:                                   ; preds = %87
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %55
+ThrowNullRef20:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %58
+ThrowNullRef22:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %26
+ThrowNullRef24:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %29
+ThrowNullRef26:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,8 +8161,8 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck, label %14, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %ThrowNullRef, label %14
 
 ; <label>:14                                      ; preds = %8
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
@@ -6760,8 +8206,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
@@ -6770,14 +8216,14 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32, i32* %loc0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %10
   %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
   %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
@@ -6790,15 +8236,15 @@ entry:
 ; <label>:25                                      ; preds = %19
   %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
-  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
   %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
@@ -6807,8 +8253,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %37 = load i32, i32* %loc0
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %38, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %38
 
 ; <label>:38                                      ; preds = %32
   %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
@@ -6817,14 +8263,14 @@ entry:
 
 ; <label>:40                                      ; preds = %19
   %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %40
   %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
   %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
-  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
-  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
@@ -6832,8 +8278,8 @@ entry:
   %48 = zext i32 %47 to i64
   %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
-  br i1 %NullCheck16, label %51, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %51
 
 ; <label>:51                                      ; preds = %45
   %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
@@ -6847,15 +8293,15 @@ entry:
 ; <label>:57                                      ; preds = %51
   %58 = load i16*, i16** %arg1
   %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
-  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %60
 
 ; <label>:60                                      ; preds = %57
   %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
   %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
-  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %64
 
 ; <label>:64                                      ; preds = %60
   %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
@@ -6864,22 +8310,22 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
   %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
-  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %70
 
 ; <label>:70                                      ; preds = %64
   %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
   %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
-  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
-  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
   %75 = load i32, i32 addrspace(1)* %74
   %76 = zext i32 %75 to i64
   %77 = trunc i64 %76 to i32
-  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
-  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %78
 
 ; <label>:78                                      ; preds = %73
   %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
@@ -6901,8 +8347,8 @@ entry:
   %90 = bitcast i16* %86 to i8*
   %91 = getelementptr inbounds i8, i8* %90, i64 %89
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %93
 
 ; <label>:93                                      ; preds = %80
   %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
@@ -6912,8 +8358,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %99 = load i32, i32* %loc2
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %100
 
 ; <label>:100                                     ; preds = %93
   %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
@@ -6928,63 +8374,63 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %25
+ThrowNullRef6:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %32
+ThrowNullRef10:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %40
+ThrowNullRef12:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %45
+ThrowNullRef16:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %57
+ThrowNullRef18:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %60
+ThrowNullRef20:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %64
+ThrowNullRef22:                                   ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %70
+ThrowNullRef24:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %73
+ThrowNullRef26:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %80
+ThrowNullRef28:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %93
+ThrowNullRef30:                                   ; preds = %93
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7004,8 +8450,8 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
@@ -7033,43 +8479,43 @@ entry:
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %14
   %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
   %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   %28 = load i32, i32 addrspace(1)* %27, align 8
   %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
-  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %30
 
 ; <label>:30                                      ; preds = %26
   %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
   %32 = load i32, i32 addrspace(1)* %31, align 8
   %33 = add i32 %28, %32
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %34
 
 ; <label>:34                                      ; preds = %30
   %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   store i32 %33, i32 addrspace(1)* %35
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
   store i32 0, i32 addrspace(1)* %38
   %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %40
 
 ; <label>:40                                      ; preds = %37
   %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
@@ -7082,8 +8528,8 @@ entry:
 
 ; <label>:47                                      ; preds = %40
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
@@ -7098,8 +8544,8 @@ entry:
   %54 = load i32, i32* %loc0
   %55 = sext i32 %54 to i64
   %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
-  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %57
 
 ; <label>:57                                      ; preds = %52
   %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
@@ -7110,68 +8556,35 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %14
+ThrowNullRef2:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %23
+ThrowNullRef4:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %26
+ThrowNullRef6:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %30
+ThrowNullRef8:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %34
+ThrowNullRef10:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %47
+ThrowNullRef14:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %52
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-}
-
-INFO:  jitting method StringBuilder::get_Length using LLILCJit
-Successfully read StringBuilder.get_Length
-
-define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.StringBuilder addrspace(1)*
-  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
-  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
-
-; <label>:1                                       ; preds = %entry
-  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %3 = load i32, i32 addrspace(1)* %2, align 8
-  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
-
-; <label>:5                                       ; preds = %1
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = add i32 %3, %7
-  ret i32 %8
-
-ThrowNullRef:                                     ; preds = %entry
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef16:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7213,70 +8626,70 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
   %6 = load i32, i32 addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
   store i32 %6, i32 addrspace(1)* %8
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
   %13 = load i32, i32 addrspace(1)* %12, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
   store i32 %13, i32 addrspace(1)* %15
   %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
-  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %18
 
 ; <label>:18                                      ; preds = %14
   %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
   %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
   %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
   %34 = load i32, i32 addrspace(1)* %33, align 8
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
-  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
@@ -7287,39 +8700,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %28
+ThrowNullRef16:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %32
+ThrowNullRef18:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7455,13 +8868,13 @@ entry:
 ; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
@@ -7477,16 +8890,16 @@ entry:
 
 ; <label>:18                                      ; preds = %15
   %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
   store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
   %22 = load i32, i32* %loc0
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %24
 
 ; <label>:24                                      ; preds = %20
   %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
@@ -7498,13 +8911,13 @@ entry:
 ; <label>:28                                      ; preds = %15, %24
   %29 = load i32, i32* %arg1
   %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %31
   %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
@@ -7517,20 +8930,20 @@ entry:
   %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
-  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
   %46 = load i32, i32 addrspace(1)* %45, align 8
   %47 = sub i32 %40, %46
-  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
-  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i32 addrspace(1)* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %48
 
 ; <label>:48                                      ; preds = %44
   store i32 %47, i32 addrspace(1)* %39, align 8
@@ -7538,21 +8951,21 @@ entry:
 
 ; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
-  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %51
 
 ; <label>:51                                      ; preds = %49
   %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %53
 
 ; <label>:53                                      ; preds = %51
   %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
   %55 = load i32, i32 addrspace(1)* %54, align 8
   %56 = load i32, i32* %arg2
   %57 = sub i32 %55, %56
-  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %58
 
 ; <label>:58                                      ; preds = %53
   %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
@@ -7562,13 +8975,13 @@ entry:
 ; <label>:60                                      ; preds = %33, %58
   %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
   %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
-  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %63
 
 ; <label>:63                                      ; preds = %60
   %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
-  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
-  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
@@ -7578,15 +8991,15 @@ entry:
 
 ; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
-  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i32 addrspace(1)* %69, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %70
 
 ; <label>:70                                      ; preds = %68
   %71 = load i32, i32 addrspace(1)* %69, align 8
   store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
-  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
@@ -7596,8 +9009,8 @@ entry:
   store i32 %77, i32* %loc4
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
-  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %80
 
 ; <label>:80                                      ; preds = %73
   %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
@@ -7607,71 +9020,71 @@ entry:
 ; <label>:83                                      ; preds = %80
   store i32 0, i32* %loc3
   %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
-  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
-  br i1 %NullCheck26, label %88, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i32 addrspace(1)* %87, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %88
 
 ; <label>:88                                      ; preds = %85
   %89 = load i32, i32 addrspace(1)* %87, align 8
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
-  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %90
 
 ; <label>:90                                      ; preds = %88
   %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
   store i32 %89, i32 addrspace(1)* %91
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
-  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
-  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %96
 
 ; <label>:96                                      ; preds = %94
   %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
-  br i1 %NullCheck34, label %100, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %100
 
 ; <label>:100                                     ; preds = %96
   %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
-  br i1 %NullCheck36, label %102, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %102
 
 ; <label>:102                                     ; preds = %100
   %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
   %104 = load i32, i32 addrspace(1)* %103, align 8
   %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
-  br i1 %NullCheck38, label %106, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %106
 
 ; <label>:106                                     ; preds = %102
   %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
-  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
-  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %108
 
 ; <label>:108                                     ; preds = %106
   %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
   %110 = load i32, i32 addrspace(1)* %109, align 8
   %111 = add i32 %104, %110
-  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %112
 
 ; <label>:112                                     ; preds = %108
   %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
   store i32 %111, i32 addrspace(1)* %113
   %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
-  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i32 addrspace(1)* %114, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %115
 
 ; <label>:115                                     ; preds = %112
   %116 = load i32, i32 addrspace(1)* %114, align 8
@@ -7681,19 +9094,19 @@ entry:
 ; <label>:118                                     ; preds = %115
   %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
-  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %121
 
 ; <label>:121                                     ; preds = %118
   %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
-  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
-  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %123
 
 ; <label>:123                                     ; preds = %121
   %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
   %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
-  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
-  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %126
 
 ; <label>:126                                     ; preds = %123
   %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
@@ -7705,8 +9118,8 @@ entry:
 
 ; <label>:130                                     ; preds = %80, %115, %126
   %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %132
 
 ; <label>:132                                     ; preds = %130
   %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7715,8 +9128,8 @@ entry:
   %136 = load i32, i32* %loc3
   %137 = sub i32 %135, %136
   %138 = sub i32 %134, %137
-  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %139
 
 ; <label>:139                                     ; preds = %132
   %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7728,16 +9141,16 @@ entry:
 
 ; <label>:144                                     ; preds = %139
   %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
-  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %146
 
 ; <label>:146                                     ; preds = %144
   %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
   %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
   %149 = load i32, i32* %loc2
   %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
-  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %151
 
 ; <label>:151                                     ; preds = %146
   %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
@@ -7754,145 +9167,249 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %18
+ThrowNullRef4:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %31
+ThrowNullRef10:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %44
+ThrowNullRef16:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %68
+ThrowNullRef18:                                   ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %70
+ThrowNullRef20:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %73
+ThrowNullRef22:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %83
+ThrowNullRef24:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %85
+ThrowNullRef26:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %88
+ThrowNullRef28:                                   ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %90
+ThrowNullRef30:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %94
+ThrowNullRef32:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %96
+ThrowNullRef34:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %100
+ThrowNullRef36:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %102
+ThrowNullRef38:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %106
+ThrowNullRef40:                                   ; preds = %106
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %108
+ThrowNullRef42:                                   ; preds = %108
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %112
+ThrowNullRef44:                                   ; preds = %112
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %118
+ThrowNullRef46:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %121
+ThrowNullRef48:                                   ; preds = %121
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %123
+ThrowNullRef50:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %130
+ThrowNullRef52:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %132
+ThrowNullRef54:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %144
+ThrowNullRef56:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %146
+ThrowNullRef58:                                   ; preds = %146
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %60
+ThrowNullRef60:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %63
+ThrowNullRef62:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %49
+ThrowNullRef64:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %51
+ThrowNullRef66:                                   ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %53
+ThrowNullRef68:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(%"System.Char[]" addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %arg0 = alloca %"System.Char[]" addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store %"System.Char[]" addrspace(1)* %param0, %"System.Char[]" addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load i32, i32* %arg4
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %43, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %38, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg1
+  %13 = load i32, i32* %arg4
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %38, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %24 = load i32, i32* %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %35 = load i32, i32* %arg3
+  %36 = load i32, i32* %arg4
+  %37 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %37, %"System.Char[]" addrspace(1)* %34, i32 %35, i32 %36)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:38                                      ; preds = %5, %16
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Successfully read Buffer._Memmove
 
@@ -7914,7 +9431,7 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[loadElem]
+Failed to read AppDomain.SetDataHelper[storeElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -7923,8 +9440,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
@@ -7934,8 +9451,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
@@ -7947,15 +9464,15 @@ entry:
   %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
   %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
@@ -7966,15 +9483,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7992,7 +9509,79 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
-Failed to read Dictionary`2.TryGetValue[loadElemA]
+Successfully read Dictionary`2.TryGetValue
+
+define i8 @"Dictionary`2.TryGetValue"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)* addrspace(1)* %param2) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  %arg2 = alloca %System.__Canon addrspace(1)* addrspace(1)*
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  store %System.__Canon addrspace(1)* addrspace(1)* %param2, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  store i32 %2, i32* %loc0
+  %3 = load i32, i32* %loc0
+  %4 = icmp slt i32 %3, 0
+  br i1 %4, label %22, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 2
+  %10 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %9, align 8
+  %11 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = zext i32 %11 to i64
+  %BoundsCheck = icmp uge i64 %16, %15
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 3, i32 %11
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %20, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %6, %System.__Canon addrspace(1)* %21)
+  ret i8 1
+
+; <label>:22                                      ; preds = %entry
+  %23 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %23, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -8058,8 +9647,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
@@ -8091,8 +9680,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
@@ -8171,15 +9760,15 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck, label %19, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %ThrowNullRef, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
   %21 = load i32, i32 addrspace(1)* %20
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
@@ -8202,7 +9791,7 @@ ThrowNullRef:                                     ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %19
+ThrowNullRef2:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8248,8 +9837,8 @@ entry:
   %0 = alloca %System.AppDomainHandle
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %1 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %1, i32 0, i32 15
@@ -8269,8 +9858,8 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
@@ -8286,7 +9875,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -8299,8 +9888,8 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -8327,8 +9916,8 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
@@ -8352,8 +9941,8 @@ entry:
   %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
   store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
@@ -8363,8 +9952,8 @@ entry:
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
@@ -8374,8 +9963,8 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %9
   %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
@@ -8384,8 +9973,8 @@ entry:
 
 ; <label>:18                                      ; preds = %3, %16
   %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
@@ -8397,15 +9986,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %18
+ThrowNullRef6:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8418,8 +10007,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
@@ -8453,15 +10042,15 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
@@ -8473,7 +10062,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8481,7 +10070,7 @@ ThrowNullRef1:                                    ; preds = %1
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
 Failed to read Dictionary`2.System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
@@ -8506,8 +10095,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
@@ -8524,8 +10113,8 @@ entry:
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -8544,7 +10133,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8577,8 +10166,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = load i64, i64* %arg2
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = trunc i32 %3 to i8
@@ -8634,46 +10223,46 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
   %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
-  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
-  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
-  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
@@ -8684,27 +10273,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %20
+ThrowNullRef12:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8717,8 +10306,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -8756,22 +10345,22 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
   %9 = load i64, i64 addrspace(1)* %8, align 8
   %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
   %13 = load i64, i64 addrspace(1)* %12, align 8
   %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %11
   %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
@@ -8788,11 +10377,11 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8882,8 +10471,8 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
@@ -8900,8 +10489,8 @@ entry:
 ; <label>:8                                       ; preds = %1
   %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
   %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
@@ -8911,15 +10500,15 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
   %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
   %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
-  br i1 %NullCheck6, label %21, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
@@ -8946,15 +10535,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8992,15 +10581,15 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
   store i8 %3, i8 addrspace(1)* %5
   %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
@@ -9011,7 +10600,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9027,8 +10616,8 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -9041,8 +10630,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
@@ -9058,7 +10647,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9080,8 +10669,8 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
@@ -9096,8 +10685,8 @@ entry:
 ; <label>:12                                      ; preds = %6
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
@@ -9112,8 +10701,8 @@ entry:
 ; <label>:21                                      ; preds = %15
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
@@ -9128,8 +10717,8 @@ entry:
 ; <label>:30                                      ; preds = %24
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %31, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
@@ -9144,8 +10733,8 @@ entry:
 ; <label>:39                                      ; preds = %33
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
-  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %40, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %42
 
 ; <label>:42                                      ; preds = %39
   %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
@@ -9164,19 +10753,19 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %21
+ThrowNullRef4:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %30
+ThrowNullRef6:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %39
+ThrowNullRef8:                                    ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9243,8 +10832,8 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
@@ -9264,57 +10853,57 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
   store i8 0, i8 addrspace(1)* %2
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
   store i8 0, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
   store i8 0, i8 addrspace(1)* %17
   %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
   store i8 0, i8 addrspace(1)* %20
   %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
-  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
@@ -9325,31 +10914,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %19
+ThrowNullRef14:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9367,8 +10956,8 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
@@ -9380,8 +10969,8 @@ entry:
 
 ; <label>:9                                       ; preds = %4
   %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %9
   %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
@@ -9395,7 +10984,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef2:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9420,8 +11009,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
@@ -9512,8 +11101,8 @@ entry:
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
@@ -9524,8 +11113,8 @@ entry:
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = load i64, i64 addrspace(1)* %12
@@ -9537,8 +11126,8 @@ entry:
   %20 = load i64, i64* %19
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
-  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %13
   %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
@@ -9555,8 +11144,8 @@ entry:
 ; <label>:30                                      ; preds = %25
   %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %32 = load i32, i32* %arg2
-  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
-  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
@@ -9570,15 +11159,15 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %30
+ThrowNullRef2:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9622,87 +11211,87 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
   %10 = load i8, i8 addrspace(1)* %9, align 8
   %11 = zext i8 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %8
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
   store i8 %12, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
   %19 = load i8, i8 addrspace(1)* %18, align 8
   %20 = zext i8 %19 to i32
   %21 = trunc i32 %20 to i8
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
   store i8 %21, i8 addrspace(1)* %23
   %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
   %28 = load i8, i8 addrspace(1)* %27, align 8
   %29 = zext i8 %28 to i32
   %30 = trunc i32 %29 to i8
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
-  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %31
 
 ; <label>:31                                      ; preds = %26
   %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
   store i8 %30, i8 addrspace(1)* %32
   %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
-  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
-  br i1 %NullCheck14, label %40, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %40
 
 ; <label>:40                                      ; preds = %35
   %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
   store i8 %39, i8 addrspace(1)* %41
   %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
-  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %44
 
 ; <label>:44                                      ; preds = %40
   %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
   %46 = load i8, i8 addrspace(1)* %45, align 8
   %47 = zext i8 %46 to i32
   %48 = trunc i32 %47 to i8
-  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
   store i8 %48, i8 addrspace(1)* %50
   %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
-  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
@@ -9713,29 +11302,29 @@ entry:
 ; <label>:56                                      ; preds = %52
   %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
-  br i1 %NullCheck22, label %59, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
   %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
   %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
-  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
-  br i1 %NullCheck24, label %63, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
   %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
-  br i1 %NullCheck26, label %66, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
   %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
-  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
-  br i1 %NullCheck28, label %69, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %69
 
 ; <label>:69                                      ; preds = %66
   %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
@@ -9744,15 +11333,15 @@ entry:
 
 ; <label>:71                                      ; preds = %105
   %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
-  br i1 %NullCheck34, label %73, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %73
 
 ; <label>:73                                      ; preds = %71
   %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
   %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
   %76 = load i32, i32* %loc0
-  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
-  br i1 %NullCheck36, label %77, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
@@ -9766,8 +11355,8 @@ entry:
 
 ; <label>:83                                      ; preds = %77
   %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
-  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
@@ -9775,14 +11364,14 @@ entry:
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
   %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
-  br i1 %NullCheck40, label %91, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
 ; <label>:91                                      ; preds = %85
   %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
   %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
-  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck42, label %94, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %94
 
 ; <label>:94                                      ; preds = %91
   %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
@@ -9798,14 +11387,14 @@ entry:
 ; <label>:99                                      ; preds = %69, %96
   %100 = load i32, i32* %loc0
   %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
-  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %102
 
 ; <label>:102                                     ; preds = %99
   %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
   %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
-  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
-  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
@@ -9819,87 +11408,87 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %26
+ThrowNullRef10:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %31
+ThrowNullRef12:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %35
+ThrowNullRef14:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %40
+ThrowNullRef16:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %56
+ThrowNullRef22:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %59
+ThrowNullRef24:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %63
+ThrowNullRef26:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %66
+ThrowNullRef28:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %102
+ThrowNullRef32:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %71
+ThrowNullRef34:                                   ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %73
+ThrowNullRef36:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %83
+ThrowNullRef38:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %85
+ThrowNullRef40:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %91
+ThrowNullRef42:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9943,15 +11532,15 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
   %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
@@ -9961,28 +11550,28 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
   %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %12
   %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
   %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
   %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
-  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
@@ -9993,23 +11582,23 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %12
+ThrowNullRef6:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10031,15 +11620,15 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
   %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = load i64, i64 addrspace(1)* %7
@@ -10077,13 +11666,13 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[loadElem]
+Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -10111,8 +11700,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -10205,8 +11794,8 @@ entry:
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load double, double* %arg0
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -10340,8 +11929,8 @@ entry:
   store i64 %param0, i64* %arg0
   store i64 %param1, i64* %arg1
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
@@ -10349,8 +11938,8 @@ entry:
   %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
   %5 = load i16*, i16* addrspace(1)* %4, align 8
   %6 = addrspacecast i64* %arg1 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = bitcast i64 addrspace(1)* %6 to i8 addrspace(1)*
@@ -10366,7 +11955,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10400,8 +11989,8 @@ entry:
   %1 = load i32, i32* %arg1
   %2 = sext i32 %1 to i64
   %3 = inttoptr i64 %2 to i16*
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -10454,8 +12043,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, i32)*)(%System.IO.ConsoleStream addrspace(1)* %2, i32 %1)
   %3 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %4 = load i64, i64* %arg1
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
@@ -10466,8 +12055,8 @@ entry:
   %10 = icmp eq i32 %9, 3
   %11 = sext i1 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %5
   %14 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, i32 0, i32 5
@@ -10478,7 +12067,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10501,8 +12090,8 @@ entry:
   %5 = icmp eq i32 %4, 1
   %6 = sext i1 %5 to i32
   %7 = trunc i32 %6 to i8
-  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %2, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.ConsoleStream addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
@@ -10513,8 +12102,8 @@ entry:
   %13 = icmp eq i32 %12, 2
   %14 = sext i1 %13 to i32
   %15 = trunc i32 %14 to i8
-  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %10, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.ConsoleStream addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %8
   %17 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %10, i32 0, i32 4
@@ -10525,7 +12114,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10564,8 +12153,8 @@ entry:
   %arg0 = alloca i64
   store i64 %param0, i64* %arg0
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
@@ -10600,8 +12189,8 @@ entry:
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
   %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = load i64, i64 addrspace(1)* %7
@@ -10705,7 +12294,127 @@ entry:
 INFO:  jitting method Encoding::GetEncoding using LLILCJit
 Failed to read Encoding.GetEncoding[convertToHelperArgumentType]
 INFO:  jitting method EncodingProvider::GetEncodingFromProvider using LLILCJit
-Failed to read EncodingProvider.GetEncodingFromProvider[loadElem]
+Successfully read EncodingProvider.GetEncodingFromProvider
+
+define %System.Text.Encoding addrspace(1)* @EncodingProvider.GetEncodingFromProvider(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca %"System.Text.EncodingProvider[]" addrspace(1)*
+  %loc1 = alloca %System.Text.EncodingProvider addrspace(1)*
+  %loc2 = alloca %System.Text.Encoding addrspace(1)*
+  %loc3 = alloca %System.Text.Encoding addrspace(1)*
+  %loc4 = alloca %"System.Text.EncodingProvider[]" addrspace(1)*
+  %loc5 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1059)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2392
+  %2 = addrspacecast i8 addrspace(1)* %1 to %"System.Text.EncodingProvider[]" addrspace(1)**
+  %3 = load volatile %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %2
+  %4 = icmp ne %"System.Text.EncodingProvider[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %entry
+  ret %System.Text.Encoding addrspace(1)* null
+
+; <label>:6                                       ; preds = %entry
+  %7 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1059)
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i64 2392
+  %9 = addrspacecast i8 addrspace(1)* %8 to %"System.Text.EncodingProvider[]" addrspace(1)**
+  %10 = load volatile %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %9
+  store %"System.Text.EncodingProvider[]" addrspace(1)* %10, %"System.Text.EncodingProvider[]" addrspace(1)** %loc0
+  %11 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc0
+  store %"System.Text.EncodingProvider[]" addrspace(1)* %11, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  store i32 0, i32* %loc5
+  br label %43
+
+; <label>:12                                      ; preds = %46
+  %13 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  %14 = load i32, i32* %loc5
+  %NullCheck1 = icmp eq %"System.Text.EncodingProvider[]" addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %13, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = zext i32 %17 to i64
+  %19 = zext i32 %14 to i64
+  %BoundsCheck = icmp uge i64 %19, %18
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %20
+
+; <label>:20                                      ; preds = %15
+  %21 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %13, i32 0, i32 3, i32 %14
+  %22 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)* addrspace(1)* %21, align 8
+  store %System.Text.EncodingProvider addrspace(1)* %22, %System.Text.EncodingProvider addrspace(1)** %loc1
+  %23 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)** %loc1
+  %24 = load i32, i32* %arg0
+  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i64 addrspace(1)*
+  %NullCheck3 = icmp eq i64 addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
+
+; <label>:26                                      ; preds = %20
+  %27 = load i64, i64 addrspace(1)* %25
+  %28 = add i64 %27, 64
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 40
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Text.Encoding addrspace(1)* (%System.Text.EncodingProvider addrspace(1)*, i32)*
+  %35 = call %System.Text.Encoding addrspace(1)* %34(%System.Text.EncodingProvider addrspace(1)* %23, i32 %24)
+  store %System.Text.Encoding addrspace(1)* %35, %System.Text.Encoding addrspace(1)** %loc2
+  %36 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc2
+  %37 = icmp eq %System.Text.Encoding addrspace(1)* %36, null
+  br i1 %37, label %40, label %38
+
+; <label>:38                                      ; preds = %26
+  %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc2
+  store %System.Text.Encoding addrspace(1)* %39, %System.Text.Encoding addrspace(1)** %loc3
+  br label %53
+
+; <label>:40                                      ; preds = %26
+  %41 = load i32, i32* %loc5
+  %42 = add i32 %41, 1
+  store i32 %42, i32* %loc5
+  br label %43
+
+; <label>:43                                      ; preds = %6, %40
+  %44 = load i32, i32* %loc5
+  %45 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  %NullCheck = icmp eq %"System.Text.EncodingProvider[]" addrspace(1)* %45, null
+  br i1 %NullCheck, label %ThrowNullRef, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp slt i32 %44, %50
+  br i1 %51, label %12, label %52
+
+; <label>:52                                      ; preds = %46
+  ret %System.Text.Encoding addrspace(1)* null
+
+; <label>:53                                      ; preds = %38
+  %54 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc3
+  ret %System.Text.Encoding addrspace(1)* %54
+
+ThrowNullRef:                                     ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method EncodingProvider::.cctor using LLILCJit
 Successfully read EncodingProvider..cctor
 
@@ -10724,7 +12433,7 @@ Failed to read Encoding.get_InternalSyncObject[Call HasTypeArg]
 INFO:  jitting method Hashtable::.ctor using LLILCJit
 Failed to read Hashtable..ctor[Volatile store]
 INFO:  jitting method Hashtable::get_Item using LLILCJit
-Failed to read Hashtable.get_Item[loadElemA]
+Failed to read Hashtable.get_Item[loadNonPrimitiveObj]
 INFO:  jitting method Hashtable::InitHash using LLILCJit
 Successfully read Hashtable.InitHash
 
@@ -10744,8 +12453,8 @@ entry:
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -10761,15 +12470,15 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
   %15 = load i32, i32* %loc0
-  %NullCheck2 = icmp ne i32 addrspace(1)* %14, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i32 addrspace(1)* %14, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %3
   store i32 %15, i32 addrspace(1)* %14, align 8
   %17 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %18 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %NullCheck4 = icmp ne i32 addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i32 addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = load i32, i32 addrspace(1)* %18, align 8
@@ -10778,8 +12487,8 @@ entry:
   %23 = sub i32 %22, 1
   %24 = urem i32 %21, %23
   %25 = add i32 1, %24
-  %NullCheck6 = icmp ne i32 addrspace(1)* %17, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32 addrspace(1)* %17, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %19
   store i32 %25, i32 addrspace(1)* %17, align 8
@@ -10790,15 +12499,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %19
+ThrowNullRef6:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10813,8 +12522,8 @@ entry:
   store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
   store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %NullCheck = icmp ne %System.Collections.Hashtable addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Collections.Hashtable addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
@@ -10824,16 +12533,16 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Collections.Hashtable addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Collections.Hashtable addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
   %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck4 = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %9, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
   %13 = inttoptr i64 %11 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
@@ -10843,8 +12552,8 @@ entry:
 ; <label>:15                                      ; preds = %1
   %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -10862,15 +12571,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10884,8 +12593,8 @@ entry:
   store %System.Int32 addrspace(1)* %param0, %System.Int32 addrspace(1)** %this
   %0 = load %System.Int32 addrspace(1)*, %System.Int32 addrspace(1)** %this
   %1 = bitcast %System.Int32 addrspace(1)* %0 to i32 addrspace(1)*
-  %NullCheck = icmp ne i32 addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq i32 addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load i32, i32 addrspace(1)* %1, align 8
@@ -10961,8 +12670,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.UTF8Encoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
@@ -10971,15 +12680,15 @@ entry:
   %9 = load i8, i8* %arg2
   %10 = zext i8 %9 to i32
   %11 = trunc i32 %10 to i8
-  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %8, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %6
   %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %8, i32 0, i32 8
   store i8 %11, i8 addrspace(1)* %13
   %14 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %14, i32 0, i32 8
@@ -10991,8 +12700,8 @@ entry:
 ; <label>:20                                      ; preds = %15
   %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %22, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %22, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = load i64, i64 addrspace(1)* %22
@@ -11014,15 +12723,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %12
+ThrowNullRef4:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11037,8 +12746,8 @@ entry:
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
@@ -11060,16 +12769,16 @@ entry:
 ; <label>:10                                      ; preds = %1
   %11 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
   %12 = load i32, i32* %arg1
-  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %11, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.Encoding addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
   store i32 %12, i32 addrspace(1)* %14
   %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
   %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = load i64, i64 addrspace(1)* %16
@@ -11087,11 +12796,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11104,8 +12813,8 @@ entry:
   %this = alloca %System.Text.UTF8Encoding addrspace(1)*
   store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
   %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.UTF8Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
@@ -11117,16 +12826,16 @@ entry:
 ; <label>:6                                       ; preds = %1
   %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %8 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %10, %System.Text.EncoderFallback addrspace(1)* %8)
   %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %12 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
-  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %11, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %11, i32 0, i32 3
@@ -11139,8 +12848,8 @@ entry:
   %18 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %18, %System.String addrspace(1)* %17)
   %19 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %18 to %System.Text.EncoderFallback addrspace(1)*
-  %NullCheck6 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %16, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %16, i32 0, i32 2
@@ -11150,8 +12859,8 @@ entry:
   %24 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %24, %System.String addrspace(1)* %23)
   %25 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %24 to %System.Text.DecoderFallback addrspace(1)*
-  %NullCheck8 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %22, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %22, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %20
   %27 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %22, i32 0, i32 3
@@ -11162,19 +12871,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %20
+ThrowNullRef8:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11204,8 +12913,8 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load i32, i32* %arg1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -11223,8 +12932,8 @@ entry:
 ; <label>:15                                      ; preds = %8
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %17 = load i32, i32* %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 %17
@@ -11240,7 +12949,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11292,7 +13001,7 @@ entry:
 }
 
 INFO:  jitting method Hashtable::Insert using LLILCJit
-Failed to read Hashtable.Insert[loadElemA]
+Failed to read Hashtable.Insert[storeElem]
 INFO:  jitting method ConsoleEncoding::.ctor using LLILCJit
 Successfully read ConsoleEncoding..ctor
 
@@ -11307,8 +13016,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %1)
   %2 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
@@ -11344,8 +13053,8 @@ entry:
   %2 = call %System.Text.InternalEncoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalEncoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %1)
   %3 = bitcast %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2 to %System.Text.EncoderFallback addrspace(1)*
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
@@ -11355,8 +13064,8 @@ entry:
   %8 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %7)
   %9 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %8 to %System.Text.DecoderFallback addrspace(1)*
-  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %6, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.Encoding addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %4
   %11 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %6, i32 0, i32 3
@@ -11367,7 +13076,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11386,15 +13095,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* %1)
   %2 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   %6 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, i32 0, i32 1
@@ -11405,7 +13114,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11433,8 +13142,8 @@ entry:
   store %System.Text.InternalDecoderBestFitFallback addrspace(1)* %param0, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
   %0 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
@@ -11444,15 +13153,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %4)
   %5 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %6)
   %9 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, i32 0, i32 1
@@ -11463,11 +13172,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11535,8 +13244,8 @@ entry:
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
   %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = load i64, i64 addrspace(1)* %19
@@ -11600,8 +13309,8 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.ConsoleStream addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
@@ -11632,31 +13341,31 @@ entry:
   store i8 %param4, i8* %arg4
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %3, %System.IO.Stream addrspace(1)* %1)
   %4 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %4, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
   %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %4, i32 0, i32 4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %5)
   %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %6
   %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
   %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
   %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = load i64, i64 addrspace(1)* %13
@@ -11668,8 +13377,8 @@ entry:
   %21 = load i64, i64* %20
   %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %8, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %8, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %14
   %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 5
@@ -11687,24 +13396,24 @@ entry:
   %31 = load i32, i32* %arg3
   %32 = sext i32 %31 to i64
   %33 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %32)
-  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %30, null
-  br i1 %NullCheck10, label %34, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.StreamWriter addrspace(1)* %30, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %35, %"System.Char[]" addrspace(1)* %33)
   %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %37, null
-  br i1 %NullCheck12, label %38, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.StreamWriter addrspace(1)* %37, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %38
 
 ; <label>:38                                      ; preds = %34
   %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
   %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
   %41 = load i32, i32* %arg3
   %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %42, null
-  br i1 %NullCheck14, label %43, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %42, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
   %44 = load i64, i64 addrspace(1)* %42
@@ -11718,30 +13427,30 @@ entry:
   %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
   %53 = sext i32 %52 to i64
   %54 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %53)
-  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
-  br i1 %NullCheck16, label %55, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %55
 
 ; <label>:55                                      ; preds = %43
   %56 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %56, %"System.Byte[]" addrspace(1)* %54)
   %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %58 = load i32, i32* %arg3
-  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %57, null
-  br i1 %NullCheck18, label %59, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.StreamWriter addrspace(1)* %57, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %59
 
 ; <label>:59                                      ; preds = %55
   %60 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 10
   store i32 %58, i32 addrspace(1)* %60
   %61 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %61, null
-  br i1 %NullCheck20, label %62, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.IO.StreamWriter addrspace(1)* %61, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %62
 
 ; <label>:62                                      ; preds = %59
   %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
   %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
   %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
   %67 = load i64, i64 addrspace(1)* %65
@@ -11759,15 +13468,15 @@ entry:
 
 ; <label>:78                                      ; preds = %66
   %79 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %79, null
-  br i1 %NullCheck24, label %80, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.StreamWriter addrspace(1)* %79, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %80
 
 ; <label>:80                                      ; preds = %78
   %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
   %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
   %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %83, null
-  br i1 %NullCheck26, label %84, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %83, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
   %85 = load i64, i64 addrspace(1)* %83
@@ -11784,8 +13493,8 @@ entry:
 
 ; <label>:95                                      ; preds = %84
   %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.IO.StreamWriter addrspace(1)* %96, null
-  br i1 %NullCheck28, label %97, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.IO.StreamWriter addrspace(1)* %96, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %97
 
 ; <label>:97                                      ; preds = %95
   %98 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 12
@@ -11799,8 +13508,8 @@ entry:
   %103 = icmp eq i32 %102, 0
   %104 = sext i1 %103 to i32
   %105 = trunc i32 %104 to i8
-  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %100, null
-  br i1 %NullCheck30, label %106, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.IO.StreamWriter addrspace(1)* %100, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %106
 
 ; <label>:106                                     ; preds = %99
   %107 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %100, i32 0, i32 13
@@ -11811,63 +13520,63 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %6
+ThrowNullRef4:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %29
+ThrowNullRef10:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %34
+ThrowNullRef12:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %38
+ThrowNullRef14:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %43
+ThrowNullRef16:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %55
+ThrowNullRef18:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %59
+ThrowNullRef20:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %62
+ThrowNullRef22:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %78
+ThrowNullRef24:                                   ; preds = %78
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %80
+ThrowNullRef26:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %95
+ThrowNullRef28:                                   ; preds = %95
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11880,15 +13589,15 @@ entry:
   %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = load i64, i64 addrspace(1)* %4
@@ -11906,7 +13615,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11956,35 +13665,35 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
   %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderNLS addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %7 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.EncoderNLS addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Text.Encoding addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.Encoding addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Text.EncoderNLS addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.EncoderNLS addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
   %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck8 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = load i64, i64 addrspace(1)* %16
@@ -12003,19 +13712,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12041,8 +13750,8 @@ entry:
   %this = alloca %System.Text.Encoding addrspace(1)*
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
@@ -12062,15 +13771,15 @@ entry:
   %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
   store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
   %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
   store i32 0, i32 addrspace(1)* %2
   %3 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, i32 0, i32 2
@@ -12080,15 +13789,15 @@ entry:
 
 ; <label>:8                                       ; preds = %4
   %9 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
   %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
   %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = load i64, i64 addrspace(1)* %13
@@ -12109,15 +13818,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12132,16 +13841,16 @@ entry:
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = load i32, i32* %arg1
   %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
   %7 = load i64, i64 addrspace(1)* %5
@@ -12159,7 +13868,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12196,8 +13905,8 @@ entry:
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
   %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
   %16 = load i64, i64 addrspace(1)* %14
@@ -12218,8 +13927,8 @@ entry:
   %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
   %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
   %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %31, null
-  br i1 %NullCheck2, label %32, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = load i64, i64 addrspace(1)* %31
@@ -12262,7 +13971,7 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12275,14 +13984,14 @@ entry:
   %this = alloca %System.Text.EncoderReplacementFallback addrspace(1)*
   store %System.Text.EncoderReplacementFallback addrspace(1)* %param0, %System.Text.EncoderReplacementFallback addrspace(1)** %this
   %0 = load %System.Text.EncoderReplacementFallback addrspace(1)*, %System.Text.EncoderReplacementFallback addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -12293,7 +14002,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12323,8 +14032,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
@@ -12356,8 +14065,8 @@ entry:
   %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
   store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
@@ -12369,8 +14078,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Threading.Tasks.Task addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %7)
@@ -12393,7 +14102,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12412,8 +14121,8 @@ entry:
   store i8 %param1, i8* %arg1
   store i8 %param2, i8* %arg2
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
@@ -12427,8 +14136,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1, %5
   %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 9
@@ -12459,8 +14168,8 @@ entry:
 
 ; <label>:25                                      ; preds = %8, %20
   %26 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %26, null
-  br i1 %NullCheck4, label %27, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %26, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %26, i32 0, i32 12
@@ -12471,22 +14180,22 @@ entry:
 
 ; <label>:32                                      ; preds = %27
   %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %33, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.IO.StreamWriter addrspace(1)* %33, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %32
   %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 12
   store i8 1, i8 addrspace(1)* %35
   %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
-  br i1 %NullCheck8, label %37, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
   %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
   %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck10 = icmp ne i64 addrspace(1)* %40, null
-  br i1 %NullCheck10, label %41, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64 addrspace(1)* %40, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i64, i64 addrspace(1)* %40
@@ -12500,8 +14209,8 @@ entry:
   %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
   store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
   %51 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %NullCheck12 = icmp ne %"System.Byte[]" addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Byte[]" addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %41
   %53 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %51, i32 0, i32 1
@@ -12513,16 +14222,16 @@ entry:
 
 ; <label>:58                                      ; preds = %52
   %59 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %59, null
-  br i1 %NullCheck14, label %60, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.IO.StreamWriter addrspace(1)* %59, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %60
 
 ; <label>:60                                      ; preds = %58
   %61 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %59, i32 0, i32 3
   %62 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
   %64 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %NullCheck16 = icmp ne %"System.Byte[]" addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %"System.Byte[]" addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %60
   %66 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %64, i32 0, i32 1
@@ -12530,8 +14239,8 @@ entry:
   %68 = zext i32 %67 to i64
   %69 = trunc i64 %68 to i32
   %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck18, label %71, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
   %72 = load i64, i64 addrspace(1)* %70
@@ -12547,29 +14256,29 @@ entry:
 
 ; <label>:80                                      ; preds = %27, %52, %71
   %81 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %81, null
-  br i1 %NullCheck20, label %82, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.IO.StreamWriter addrspace(1)* %81, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
 
 ; <label>:82                                      ; preds = %80
   %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %81, i32 0, i32 5
   %84 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %83, align 8
   %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.IO.StreamWriter addrspace(1)* %85, null
-  br i1 %NullCheck22, label %86, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.IO.StreamWriter addrspace(1)* %85, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %86
 
 ; <label>:86                                      ; preds = %82
   %87 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 7
   %88 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %87, align 8
   %89 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %89, null
-  br i1 %NullCheck24, label %90, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.StreamWriter addrspace(1)* %89, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %90
 
 ; <label>:90                                      ; preds = %86
   %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %89, i32 0, i32 9
   %92 = load i32, i32 addrspace(1)* %91, align 8
   %93 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.IO.StreamWriter addrspace(1)* %93, null
-  br i1 %NullCheck26, label %94, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.IO.StreamWriter addrspace(1)* %93, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %93, i32 0, i32 6
@@ -12577,8 +14286,8 @@ entry:
   %97 = load i8, i8* %arg2
   %98 = zext i8 %97 to i32
   %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
-  %NullCheck28 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck28, label %100, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
   %101 = load i64, i64 addrspace(1)* %99
@@ -12593,8 +14302,8 @@ entry:
   %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
   store i32 %110, i32* %loc1
   %111 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %111, null
-  br i1 %NullCheck30, label %112, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.IO.StreamWriter addrspace(1)* %111, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %112
 
 ; <label>:112                                     ; preds = %100
   %113 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %111, i32 0, i32 9
@@ -12605,23 +14314,23 @@ entry:
 
 ; <label>:116                                     ; preds = %112
   %117 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck32 = icmp ne %System.IO.StreamWriter addrspace(1)* %117, null
-  br i1 %NullCheck32, label %118, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.IO.StreamWriter addrspace(1)* %117, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %118
 
 ; <label>:118                                     ; preds = %116
   %119 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %117, i32 0, i32 3
   %120 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %119, align 8
   %121 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.IO.StreamWriter addrspace(1)* %121, null
-  br i1 %NullCheck34, label %122, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.IO.StreamWriter addrspace(1)* %121, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %122
 
 ; <label>:122                                     ; preds = %118
   %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
   %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
   %125 = load i32, i32* %loc1
   %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
-  %NullCheck36 = icmp ne i64 addrspace(1)* %126, null
-  br i1 %NullCheck36, label %127, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64 addrspace(1)* %126, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
   %128 = load i64, i64 addrspace(1)* %126
@@ -12643,15 +14352,15 @@ entry:
 
 ; <label>:140                                     ; preds = %136
   %141 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.IO.StreamWriter addrspace(1)* %141, null
-  br i1 %NullCheck38, label %142, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.IO.StreamWriter addrspace(1)* %141, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %142
 
 ; <label>:142                                     ; preds = %140
   %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
   %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
   %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
-  %NullCheck40 = icmp ne i64 addrspace(1)* %145, null
-  br i1 %NullCheck40, label %146, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i64 addrspace(1)* %145, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
   %147 = load i64, i64 addrspace(1)* %145
@@ -12672,83 +14381,83 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %25
+ThrowNullRef4:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %32
+ThrowNullRef6:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %37
+ThrowNullRef10:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %41
+ThrowNullRef12:                                   ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %58
+ThrowNullRef14:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %60
+ThrowNullRef16:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %65
+ThrowNullRef18:                                   ; preds = %65
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %80
+ThrowNullRef20:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %82
+ThrowNullRef22:                                   ; preds = %82
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %86
+ThrowNullRef24:                                   ; preds = %86
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %90
+ThrowNullRef26:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %94
+ThrowNullRef28:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %100
+ThrowNullRef30:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %116
+ThrowNullRef32:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %118
+ThrowNullRef34:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %122
+ThrowNullRef36:                                   ; preds = %122
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %140
+ThrowNullRef38:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %142
+ThrowNullRef40:                                   ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12815,8 +14524,8 @@ entry:
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %1 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
-  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
@@ -12824,8 +14533,8 @@ entry:
   %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
   %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
   %8 = load i64, i64 addrspace(1)* %6
@@ -12841,8 +14550,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %17, %System.IFormatProvider addrspace(1)* %16)
   %18 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %19 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %18, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.SyncTextWriter addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %7
   %21 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %18, i32 0, i32 4
@@ -12853,11 +14562,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12870,8 +14579,8 @@ entry:
   %this = alloca %System.IO.TextWriter addrspace(1)*
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.TextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
@@ -12881,8 +14590,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.Threading.Thread addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Threading.Thread addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %6)
@@ -12891,8 +14600,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1
   %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.TextWriter addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.TextWriter addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %11, i32 0, i32 2
@@ -12903,11 +14612,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13104,8 +14813,8 @@ entry:
   store double %param1, double* %arg1
   store i8 0, i8* %loc1
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
@@ -13115,16 +14824,16 @@ entry:
   %5 = addrspacecast i8* %loc1 to i8 addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %4, i8 addrspace(1)* %5)
   %6 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.SyncTextWriter addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
   %10 = load double, double* %arg1
   %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
   %13 = load i64, i64 addrspace(1)* %11
@@ -13159,11 +14868,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13180,8 +14889,8 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load double, double* %arg1
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -13195,8 +14904,8 @@ entry:
   call void %11(%System.IO.TextWriter addrspace(1)* %0, double %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
   %15 = load i64, i64 addrspace(1)* %13
@@ -13214,7 +14923,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13232,8 +14941,8 @@ entry:
   %1 = addrspacecast double* %arg1 to double addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -13248,8 +14957,8 @@ entry:
   %14 = bitcast double addrspace(1)* %1 to %System.Double addrspace(1)*
   %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Double addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Double addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
   %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
   %18 = load i64, i64 addrspace(1)* %16
@@ -13267,7 +14976,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13283,8 +14992,8 @@ entry:
   store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
   %0 = load %System.Double addrspace(1)*, %System.Double addrspace(1)** %this
   %1 = bitcast %System.Double addrspace(1)* %0 to double addrspace(1)*
-  %NullCheck = icmp ne double addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq double addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load double, double addrspace(1)* %1, align 8
@@ -13309,8 +15018,8 @@ entry:
   %loc0 = alloca %System.Globalization.NumberFormatInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 3
@@ -13320,8 +15029,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
@@ -13331,24 +15040,24 @@ entry:
   store %System.Globalization.NumberFormatInfo addrspace(1)* %10, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
   %11 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %7
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
   %15 = load i8, i8 addrspace(1)* %14, align 8
   %16 = zext i8 %15 to i32
   %17 = trunc i32 %16 to i8
-  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %11, null
-  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %11, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %13
   %19 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %11, i32 0, i32 29
   store i8 %17, i8 addrspace(1)* %19
   %20 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %21 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %20, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %20, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %18
   %23 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %20, i32 0, i32 3
@@ -13357,8 +15066,8 @@ entry:
 
 ; <label>:24                                      ; preds = %1, %22
   %25 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %25, null
-  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %25, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %26
 
 ; <label>:26                                      ; preds = %24
   %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %25, i32 0, i32 3
@@ -13369,23 +15078,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %18
+ThrowNullRef8:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13410,168 +15119,168 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 18
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %8, align 8
-  %NullCheck2 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %5, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %5, i32 0, i32 4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %9)
   %12 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 19
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %15, align 8
-  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %12, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %12, i32 0, i32 5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %16)
   %19 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %20 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %20, null
-  br i1 %NullCheck8, label %21, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %20, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %20, i32 0, i32 23
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  %NullCheck10 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %19, null
-  br i1 %NullCheck10, label %24, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %19, i32 0, i32 7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %25, %System.String addrspace(1)* %23)
   %26 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %27 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %27, i32 0, i32 22
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %29, align 8
-  %NullCheck14 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %26, null
-  br i1 %NullCheck14, label %31, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %26, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %26, i32 0, i32 6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %32, %System.String addrspace(1)* %30)
   %33 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %34 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Globalization.CultureData addrspace(1)* %34, null
-  br i1 %NullCheck16, label %35, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Globalization.CultureData addrspace(1)* %34, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %34, i32 0, i32 51
   %37 = load i32, i32 addrspace(1)* %36, align 8
-  %NullCheck18 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %33, null
-  br i1 %NullCheck18, label %38, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %33, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %33, i32 0, i32 21
   store i32 %37, i32 addrspace(1)* %39
   %40 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %41 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Globalization.CultureData addrspace(1)* %41, null
-  br i1 %NullCheck20, label %42, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Globalization.CultureData addrspace(1)* %41, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %41, i32 0, i32 52
   %44 = load i32, i32 addrspace(1)* %43, align 8
-  %NullCheck22 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %40, null
-  br i1 %NullCheck22, label %45, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %40, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %40, i32 0, i32 25
   store i32 %44, i32 addrspace(1)* %46
   %47 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %48 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.Globalization.CultureData addrspace(1)* %48, null
-  br i1 %NullCheck24, label %49, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Globalization.CultureData addrspace(1)* %48, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %49
 
 ; <label>:49                                      ; preds = %45
   %50 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %48, i32 0, i32 29
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck26 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %47, null
-  br i1 %NullCheck26, label %52, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %47, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %47, i32 0, i32 10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %53, %System.String addrspace(1)* %51)
   %54 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %55 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Globalization.CultureData addrspace(1)* %55, null
-  br i1 %NullCheck28, label %56, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Globalization.CultureData addrspace(1)* %55, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %56
 
 ; <label>:56                                      ; preds = %52
   %57 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %55, i32 0, i32 35
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %57, align 8
-  %NullCheck30 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %54, null
-  br i1 %NullCheck30, label %59, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %54, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %54, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %60, %System.String addrspace(1)* %58)
   %61 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %62 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck32 = icmp ne %System.Globalization.CultureData addrspace(1)* %62, null
-  br i1 %NullCheck32, label %63, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Globalization.CultureData addrspace(1)* %62, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %62, i32 0, i32 34
   %65 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %64, align 8
-  %NullCheck34 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %61, null
-  br i1 %NullCheck34, label %66, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %61, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %61, i32 0, i32 9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %67, %System.String addrspace(1)* %65)
   %68 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %69 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck36 = icmp ne %System.Globalization.CultureData addrspace(1)* %69, null
-  br i1 %NullCheck36, label %70, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Globalization.CultureData addrspace(1)* %69, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %70
 
 ; <label>:70                                      ; preds = %66
   %71 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %69, i32 0, i32 55
   %72 = load i32, i32 addrspace(1)* %71, align 8
-  %NullCheck38 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %68, null
-  br i1 %NullCheck38, label %73, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %68, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %68, i32 0, i32 22
   store i32 %72, i32 addrspace(1)* %74
   %75 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %76 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck40 = icmp ne %System.Globalization.CultureData addrspace(1)* %76, null
-  br i1 %NullCheck40, label %77, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Globalization.CultureData addrspace(1)* %76, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %76, i32 0, i32 57
   %79 = load i32, i32 addrspace(1)* %78, align 8
-  %NullCheck42 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %75, null
-  br i1 %NullCheck42, label %80, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %75, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %80
 
 ; <label>:80                                      ; preds = %77
   %81 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %75, i32 0, i32 24
   store i32 %79, i32 addrspace(1)* %81
   %82 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %83 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck44 = icmp ne %System.Globalization.CultureData addrspace(1)* %83, null
-  br i1 %NullCheck44, label %84, label %ThrowNullRef43
+  %NullCheck43 = icmp eq %System.Globalization.CultureData addrspace(1)* %83, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %84
 
 ; <label>:84                                      ; preds = %80
   %85 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %83, i32 0, i32 56
   %86 = load i32, i32 addrspace(1)* %85, align 8
-  %NullCheck46 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %82, null
-  br i1 %NullCheck46, label %87, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %82, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %82, i32 0, i32 23
@@ -13580,8 +15289,8 @@ entry:
 
 ; <label>:89                                      ; preds = %entry
   %90 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck100 = icmp ne %System.Globalization.CultureData addrspace(1)* %90, null
-  br i1 %NullCheck100, label %91, label %ThrowNullRef99
+  %NullCheck99 = icmp eq %System.Globalization.CultureData addrspace(1)* %90, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %91
 
 ; <label>:91                                      ; preds = %89
   %92 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %90, i32 0, i32 2
@@ -13599,8 +15308,8 @@ entry:
   %102 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %103 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %104 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %103)
-  %NullCheck48 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %102, null
-  br i1 %NullCheck48, label %105, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %102, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %105
 
 ; <label>:105                                     ; preds = %101
   %106 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %102, i32 0, i32 1
@@ -13608,8 +15317,8 @@ entry:
   %107 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %108 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %109 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %108)
-  %NullCheck50 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %107, null
-  br i1 %NullCheck50, label %110, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %107, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %110
 
 ; <label>:110                                     ; preds = %105
   %111 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %107, i32 0, i32 2
@@ -13617,8 +15326,8 @@ entry:
   %112 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %113 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %114 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %113)
-  %NullCheck52 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %112, null
-  br i1 %NullCheck52, label %115, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %112, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %115
 
 ; <label>:115                                     ; preds = %110
   %116 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %112, i32 0, i32 27
@@ -13626,8 +15335,8 @@ entry:
   %117 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %118 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %119 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %118)
-  %NullCheck54 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %117, null
-  br i1 %NullCheck54, label %120, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %117, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %120
 
 ; <label>:120                                     ; preds = %115
   %121 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %117, i32 0, i32 26
@@ -13635,8 +15344,8 @@ entry:
   %122 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %123 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %124 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %123)
-  %NullCheck56 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %122, null
-  br i1 %NullCheck56, label %125, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %122, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %125
 
 ; <label>:125                                     ; preds = %120
   %126 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %122, i32 0, i32 17
@@ -13644,8 +15353,8 @@ entry:
   %127 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %128 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %129 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %128)
-  %NullCheck58 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %127, null
-  br i1 %NullCheck58, label %130, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %127, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %130
 
 ; <label>:130                                     ; preds = %125
   %131 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %127, i32 0, i32 18
@@ -13653,8 +15362,8 @@ entry:
   %132 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %133 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %134 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %133)
-  %NullCheck60 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %132, null
-  br i1 %NullCheck60, label %135, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %132, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %135
 
 ; <label>:135                                     ; preds = %130
   %136 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %132, i32 0, i32 14
@@ -13662,8 +15371,8 @@ entry:
   %137 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %138 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %139 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %138)
-  %NullCheck62 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %137, null
-  br i1 %NullCheck62, label %140, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %137, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %140
 
 ; <label>:140                                     ; preds = %135
   %141 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %137, i32 0, i32 13
@@ -13671,71 +15380,71 @@ entry:
   %142 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %143 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %144 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %143)
-  %NullCheck64 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %142, null
-  br i1 %NullCheck64, label %145, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %142, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %145
 
 ; <label>:145                                     ; preds = %140
   %146 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %142, i32 0, i32 12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %146, %System.String addrspace(1)* %144)
   %147 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %148 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck66 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %148, null
-  br i1 %NullCheck66, label %149, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %148, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %149
 
 ; <label>:149                                     ; preds = %145
   %150 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %148, i32 0, i32 21
   %151 = load i32, i32 addrspace(1)* %150, align 8
-  %NullCheck68 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %147, null
-  br i1 %NullCheck68, label %152, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %147, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %152
 
 ; <label>:152                                     ; preds = %149
   %153 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %147, i32 0, i32 28
   store i32 %151, i32 addrspace(1)* %153
   %154 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %155 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck70 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %155, null
-  br i1 %NullCheck70, label %156, label %ThrowNullRef69
+  %NullCheck69 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %155, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %156
 
 ; <label>:156                                     ; preds = %152
   %157 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %155, i32 0, i32 6
   %158 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %157, align 8
-  %NullCheck72 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %154, null
-  br i1 %NullCheck72, label %159, label %ThrowNullRef71
+  %NullCheck71 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %154, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %159
 
 ; <label>:159                                     ; preds = %156
   %160 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %154, i32 0, i32 15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %160, %System.String addrspace(1)* %158)
   %161 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %162 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck74 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %162, null
-  br i1 %NullCheck74, label %163, label %ThrowNullRef73
+  %NullCheck73 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %162, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %163
 
 ; <label>:163                                     ; preds = %159
   %164 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %162, i32 0, i32 1
   %165 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %164, align 8
-  %NullCheck76 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %161, null
-  br i1 %NullCheck76, label %166, label %ThrowNullRef75
+  %NullCheck75 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %161, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %166
 
 ; <label>:166                                     ; preds = %163
   %167 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %161, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %167, %"System.Int32[]" addrspace(1)* %165)
   %168 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %169 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck78 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %169, null
-  br i1 %NullCheck78, label %170, label %ThrowNullRef77
+  %NullCheck77 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %169, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %170
 
 ; <label>:170                                     ; preds = %166
   %171 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %169, i32 0, i32 7
   %172 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %171, align 8
-  %NullCheck80 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %168, null
-  br i1 %NullCheck80, label %173, label %ThrowNullRef79
+  %NullCheck79 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %168, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %173
 
 ; <label>:173                                     ; preds = %170
   %174 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %168, i32 0, i32 16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %174, %System.String addrspace(1)* %172)
   %175 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck82 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %175, null
-  br i1 %NullCheck82, label %176, label %ThrowNullRef81
+  %NullCheck81 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %175, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %176
 
 ; <label>:176                                     ; preds = %173
   %177 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %175, i32 0, i32 4
@@ -13745,14 +15454,14 @@ entry:
 
 ; <label>:180                                     ; preds = %176
   %181 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck84 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %181, null
-  br i1 %NullCheck84, label %182, label %ThrowNullRef83
+  %NullCheck83 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %181, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %182
 
 ; <label>:182                                     ; preds = %180
   %183 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %181, i32 0, i32 4
   %184 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %183, align 8
-  %NullCheck86 = icmp ne %System.String addrspace(1)* %184, null
-  br i1 %NullCheck86, label %185, label %ThrowNullRef85
+  %NullCheck85 = icmp eq %System.String addrspace(1)* %184, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %185
 
 ; <label>:185                                     ; preds = %182
   %186 = getelementptr inbounds %System.String, %System.String addrspace(1)* %184, i32 0, i32 1
@@ -13763,8 +15472,8 @@ entry:
 ; <label>:189                                     ; preds = %176, %185
   %190 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck98 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %190, null
-  br i1 %NullCheck98, label %192, label %ThrowNullRef97
+  %NullCheck97 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %190, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %192
 
 ; <label>:192                                     ; preds = %189
   %193 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %190, i32 0, i32 4
@@ -13773,8 +15482,8 @@ entry:
 
 ; <label>:194                                     ; preds = %185, %192
   %195 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck88 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %195, null
-  br i1 %NullCheck88, label %196, label %ThrowNullRef87
+  %NullCheck87 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %195, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %196
 
 ; <label>:196                                     ; preds = %194
   %197 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %195, i32 0, i32 9
@@ -13784,14 +15493,14 @@ entry:
 
 ; <label>:200                                     ; preds = %196
   %201 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck90 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %201, null
-  br i1 %NullCheck90, label %202, label %ThrowNullRef89
+  %NullCheck89 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %201, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %202
 
 ; <label>:202                                     ; preds = %200
   %203 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %201, i32 0, i32 9
   %204 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %203, align 8
-  %NullCheck92 = icmp ne %System.String addrspace(1)* %204, null
-  br i1 %NullCheck92, label %205, label %ThrowNullRef91
+  %NullCheck91 = icmp eq %System.String addrspace(1)* %204, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %205
 
 ; <label>:205                                     ; preds = %202
   %206 = getelementptr inbounds %System.String, %System.String addrspace(1)* %204, i32 0, i32 1
@@ -13802,14 +15511,14 @@ entry:
 ; <label>:209                                     ; preds = %196, %205
   %210 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %211 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck94 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %211, null
-  br i1 %NullCheck94, label %212, label %ThrowNullRef93
+  %NullCheck93 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %211, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %212
 
 ; <label>:212                                     ; preds = %209
   %213 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %211, i32 0, i32 6
   %214 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %213, align 8
-  %NullCheck96 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %210, null
-  br i1 %NullCheck96, label %215, label %ThrowNullRef95
+  %NullCheck95 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %210, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %215
 
 ; <label>:215                                     ; preds = %212
   %216 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %210, i32 0, i32 9
@@ -13823,203 +15532,203 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %17
+ThrowNullRef8:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %21
+ThrowNullRef10:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %24
+ThrowNullRef12:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %28
+ThrowNullRef14:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %31
+ThrowNullRef16:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %35
+ThrowNullRef18:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %38
+ThrowNullRef20:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %42
+ThrowNullRef22:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %45
+ThrowNullRef24:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %49
+ThrowNullRef26:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %52
+ThrowNullRef28:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %56
+ThrowNullRef30:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %59
+ThrowNullRef32:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %63
+ThrowNullRef34:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %66
+ThrowNullRef36:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %70
+ThrowNullRef38:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %73
+ThrowNullRef40:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %77
+ThrowNullRef42:                                   ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %80
+ThrowNullRef44:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %84
+ThrowNullRef46:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %101
+ThrowNullRef48:                                   ; preds = %101
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %105
+ThrowNullRef50:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %110
+ThrowNullRef52:                                   ; preds = %110
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %115
+ThrowNullRef54:                                   ; preds = %115
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %120
+ThrowNullRef56:                                   ; preds = %120
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %125
+ThrowNullRef58:                                   ; preds = %125
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %130
+ThrowNullRef60:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %135
+ThrowNullRef62:                                   ; preds = %135
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %140
+ThrowNullRef64:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %145
+ThrowNullRef66:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %149
+ThrowNullRef68:                                   ; preds = %149
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %152
+ThrowNullRef70:                                   ; preds = %152
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %156
+ThrowNullRef72:                                   ; preds = %156
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %159
+ThrowNullRef74:                                   ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %163
+ThrowNullRef76:                                   ; preds = %163
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %166
+ThrowNullRef78:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %170
+ThrowNullRef80:                                   ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %173
+ThrowNullRef82:                                   ; preds = %173
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %180
+ThrowNullRef84:                                   ; preds = %180
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %182
+ThrowNullRef86:                                   ; preds = %182
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %194
+ThrowNullRef88:                                   ; preds = %194
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %200
+ThrowNullRef90:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %202
+ThrowNullRef92:                                   ; preds = %202
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %209
+ThrowNullRef94:                                   ; preds = %209
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %212
+ThrowNullRef96:                                   ; preds = %212
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %189
+ThrowNullRef98:                                   ; preds = %189
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %89
+ThrowNullRef100:                                  ; preds = %89
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14047,8 +15756,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 21
@@ -14061,8 +15770,8 @@ entry:
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 16)
   %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 21
@@ -14071,8 +15780,8 @@ entry:
 
 ; <label>:12                                      ; preds = %1, %10
   %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 21
@@ -14083,11 +15792,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %12
+ThrowNullRef4:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14103,8 +15812,8 @@ entry:
   store i32 %param1, i32* %arg1
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %1 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
@@ -14171,8 +15880,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 33
@@ -14185,8 +15894,8 @@ entry:
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 24)
   %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 33
@@ -14195,8 +15904,8 @@ entry:
 
 ; <label>:12                                      ; preds = %1, %10
   %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 33
@@ -14207,11 +15916,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %12
+ThrowNullRef4:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14224,8 +15933,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 53
@@ -14237,8 +15946,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 116)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 53
@@ -14247,8 +15956,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 53
@@ -14259,11 +15968,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14292,8 +16001,8 @@ entry:
 
 ; <label>:7                                       ; preds = %entry, %4
   %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %7
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 2
@@ -14317,8 +16026,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 54
@@ -14330,8 +16039,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 117)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
@@ -14340,8 +16049,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 54
@@ -14352,11 +16061,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14369,8 +16078,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 27
@@ -14382,8 +16091,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 118)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 27
@@ -14392,8 +16101,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 27
@@ -14404,11 +16113,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14421,8 +16130,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 28
@@ -14434,8 +16143,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 119)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 28
@@ -14444,8 +16153,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 28
@@ -14456,11 +16165,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14473,8 +16182,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 26
@@ -14486,8 +16195,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 107)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 26
@@ -14496,8 +16205,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 26
@@ -14508,11 +16217,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14525,8 +16234,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 25
@@ -14538,8 +16247,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 106)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 25
@@ -14548,8 +16257,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 25
@@ -14560,11 +16269,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14577,8 +16286,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 24
@@ -14590,8 +16299,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 105)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 24
@@ -14600,8 +16309,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 24
@@ -14612,11 +16321,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14641,8 +16350,8 @@ entry:
   %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %3)
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %2
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -14653,15 +16362,15 @@ entry:
 
 ; <label>:8                                       ; preds = %62
   %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 9
   %12 = load i32, i32 addrspace(1)* %11, align 8
   %13 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.IO.StreamWriter addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %13, i32 0, i32 10
@@ -14676,15 +16385,15 @@ entry:
 
 ; <label>:20                                      ; preds = %14, %18
   %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
   %24 = load i32, i32 addrspace(1)* %23, align 8
   %25 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %25, null
-  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.StreamWriter addrspace(1)* %25, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %25, i32 0, i32 9
@@ -14705,36 +16414,36 @@ entry:
   %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %37 = load i32, i32* %loc1
   %38 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.StreamWriter addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %35
   %40 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %38, i32 0, i32 7
   %41 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %40, align 8
   %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
-  br i1 %NullCheck14, label %43, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %39
   %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 9
   %45 = load i32, i32 addrspace(1)* %44, align 8
   %46 = load i32, i32* %loc2
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %36, null
-  br i1 %NullCheck16, label %47, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %36, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %47
 
 ; <label>:47                                      ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %36, i32 %37, %"System.Char[]" addrspace(1)* %41, i32 %45, i32 %46)
   %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
   %51 = load i32, i32 addrspace(1)* %50, align 8
   %52 = load i32, i32* %loc2
   %53 = add i32 %51, %52
-  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
-  br i1 %NullCheck20, label %54, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %54
 
 ; <label>:54                                      ; preds = %49
   %55 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
@@ -14756,8 +16465,8 @@ entry:
 
 ; <label>:65                                      ; preds = %62
   %66 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %66, null
-  br i1 %NullCheck2, label %67, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %66, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %67
 
 ; <label>:67                                      ; preds = %65
   %68 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %66, i32 0, i32 11
@@ -14778,49 +16487,259 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %65
+ThrowNullRef2:                                    ; preds = %65
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %20
+ThrowNullRef8:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %22
+ThrowNullRef10:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %35
+ThrowNullRef12:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %43
+ThrowNullRef16:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %47
+ThrowNullRef18:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method String::CopyTo using LLILCJit
-Failed to read String.CopyTo[loadElemA]
+Successfully read String.CopyTo
+
+define void @String.CopyTo(%System.String addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  %loc1 = alloca i16 addrspace(1)*
+  %loc2 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %1 = icmp ne %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg4
+  %7 = icmp sge i32 %6, 0
+  br i1 %7, label %13, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  unreachable
+
+; <label>:13                                      ; preds = %5
+  %14 = load i32, i32* %arg1
+  %15 = icmp sge i32 %14, 0
+  br i1 %15, label %21, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %18)
+  %20 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %20, %System.String addrspace(1)* %17, %System.String addrspace(1)* %19)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %20) #0
+  unreachable
+
+; <label>:21                                      ; preds = %13
+  %22 = load i32, i32* %arg4
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck, label %ThrowNullRef, label %24
+
+; <label>:24                                      ; preds = %21
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load i32, i32* %arg1
+  %28 = sub i32 %26, %27
+  %29 = icmp sle i32 %22, %28
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34, %System.String addrspace(1)* %31, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %24
+  %36 = load i32, i32* %arg3
+  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %37, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
+
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
+  %40 = load i32, i32 addrspace(1)* %39
+  %41 = zext i32 %40 to i64
+  %42 = trunc i64 %41 to i32
+  %43 = load i32, i32* %arg4
+  %44 = sub i32 %42, %43
+  %45 = icmp sgt i32 %36, %44
+  br i1 %45, label %49, label %46
+
+; <label>:46                                      ; preds = %38
+  %47 = load i32, i32* %arg3
+  %48 = icmp sge i32 %47, 0
+  br i1 %48, label %54, label %49
+
+; <label>:49                                      ; preds = %38, %46
+  %50 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %52 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %51)
+  %53 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53, %System.String addrspace(1)* %50, %System.String addrspace(1)* %52)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53) #0
+  unreachable
+
+; <label>:54                                      ; preds = %46
+  %55 = load i32, i32* %arg4
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %97, label %57
+
+; <label>:57                                      ; preds = %54
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %59
+
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 2
+  %61 = bitcast [0 x i16] addrspace(1)* %60 to i16 addrspace(1)*
+  store i16 addrspace(1)* %61, i16 addrspace(1)** %loc0
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  store %"System.Char[]" addrspace(1)* %62, %"System.Char[]" addrspace(1)** %loc2
+  %63 = icmp eq %"System.Char[]" addrspace(1)* %62, null
+  br i1 %63, label %72, label %64
+
+; <label>:64                                      ; preds = %59
+  %65 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc2
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %65, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %66
+
+; <label>:66                                      ; preds = %64
+  %67 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %65, i32 0, i32 1
+  %68 = load i32, i32 addrspace(1)* %67
+  %69 = zext i32 %68 to i64
+  %70 = trunc i64 %69 to i32
+  %71 = icmp ne i32 %70, 0
+  br i1 %71, label %73, label %72
+
+; <label>:72                                      ; preds = %59, %66
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  br label %81
+
+; <label>:73                                      ; preds = %66
+  %74 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc2
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %74, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %75
+
+; <label>:75                                      ; preds = %73
+  %76 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %74, i32 0, i32 1
+  %77 = load i32, i32 addrspace(1)* %76
+  %78 = zext i32 %77 to i64
+  %BoundsCheck = icmp uge i64 0, %78
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %79
+
+; <label>:79                                      ; preds = %75
+  %80 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %74, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %80, i16 addrspace(1)** %loc1
+  br label %81
+
+; <label>:81                                      ; preds = %72, %79
+  %82 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %83 = ptrtoint i16 addrspace(1)* %82 to i64
+  %84 = load i32, i32* %arg3
+  %85 = sext i32 %84 to i64
+  %86 = mul i64 %85, 2
+  %87 = add i64 %83, %86
+  %88 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %89 = ptrtoint i16 addrspace(1)* %88 to i64
+  %90 = load i32, i32* %arg1
+  %91 = sext i32 %90 to i64
+  %92 = mul i64 %91, 2
+  %93 = add i64 %89, %92
+  %94 = load i32, i32* %arg4
+  %95 = inttoptr i64 %87 to i16*
+  %96 = inttoptr i64 %93 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %95, i16* %96, i32 %94)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  br label %97
+
+; <label>:97                                      ; preds = %54, %81
+  ret void
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
 Successfully read ConsoleEncoding.GetPreamble
 
@@ -14857,7 +16776,365 @@ entry:
 }
 
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[loadElemA]
+Successfully read EncoderNLS.GetBytes
+
+define i32 @EncoderNLS.GetBytes(%System.Text.EncoderNLS addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3, %"System.Byte[]" addrspace(1)* %param4, i32 %param5, i8 %param6) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %arg4 = alloca %"System.Byte[]" addrspace(1)*
+  %arg5 = alloca i32
+  %arg6 = alloca i8
+  %loc0 = alloca i32
+  %loc1 = alloca i16 addrspace(1)*
+  %loc2 = alloca i8 addrspace(1)*
+  %loc3 = alloca i32
+  %loc4 = alloca %"System.Char[]" addrspace(1)*
+  %loc5 = alloca %"System.Byte[]" addrspace(1)*
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  store %"System.Byte[]" addrspace(1)* %param4, %"System.Byte[]" addrspace(1)** %arg4
+  store i32 %param5, i32* %arg5
+  store i8 %param6, i8* %arg6
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %1 = icmp eq %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %17, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %7 = icmp eq %"System.Char[]" addrspace(1)* %6, null
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %12
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %12
+
+; <label>:12                                      ; preds = %8, %10
+  %13 = phi %System.String addrspace(1)* [ %9, %8 ], [ %11, %10 ]
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %14)
+  %16 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16, %System.String addrspace(1)* %13, %System.String addrspace(1)* %15)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16) #0
+  unreachable
+
+; <label>:17                                      ; preds = %2
+  %18 = load i32, i32* %arg2
+  %19 = icmp slt i32 %18, 0
+  br i1 %19, label %23, label %20
+
+; <label>:20                                      ; preds = %17
+  %21 = load i32, i32* %arg3
+  %22 = icmp sge i32 %21, 0
+  br i1 %22, label %35, label %23
+
+; <label>:23                                      ; preds = %17, %20
+  %24 = load i32, i32* %arg2
+  %25 = icmp slt i32 %24, 0
+  br i1 %25, label %28, label %26
+
+; <label>:26                                      ; preds = %23
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %30
+
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %30
+
+; <label>:30                                      ; preds = %26, %28
+  %31 = phi %System.String addrspace(1)* [ %27, %26 ], [ %29, %28 ]
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34, %System.String addrspace(1)* %31, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %20
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck, label %ThrowNullRef, label %37
+
+; <label>:37                                      ; preds = %35
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = load i32, i32* %arg2
+  %43 = sub i32 %41, %42
+  %44 = load i32, i32* %arg3
+  %45 = icmp sge i32 %43, %44
+  br i1 %45, label %51, label %46
+
+; <label>:46                                      ; preds = %37
+  %47 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %48 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %49 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %48)
+  %50 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %50, %System.String addrspace(1)* %47, %System.String addrspace(1)* %49)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %50) #0
+  unreachable
+
+; <label>:51                                      ; preds = %37
+  %52 = load i32, i32* %arg5
+  %53 = icmp slt i32 %52, 0
+  br i1 %53, label %63, label %54
+
+; <label>:54                                      ; preds = %51
+  %55 = load i32, i32* %arg5
+  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck1 = icmp eq %"System.Byte[]" addrspace(1)* %56, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %57
+
+; <label>:57                                      ; preds = %54
+  %58 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = zext i32 %59 to i64
+  %61 = trunc i64 %60 to i32
+  %62 = icmp sle i32 %55, %61
+  br i1 %62, label %68, label %63
+
+; <label>:63                                      ; preds = %51, %57
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %66 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %65)
+  %67 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %67, %System.String addrspace(1)* %64, %System.String addrspace(1)* %66)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %67) #0
+  unreachable
+
+; <label>:68                                      ; preds = %57
+  %69 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %69, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %69, i32 0, i32 1
+  %72 = load i32, i32 addrspace(1)* %71
+  %73 = zext i32 %72 to i64
+  %74 = trunc i64 %73 to i32
+  %75 = icmp ne i32 %74, 0
+  br i1 %75, label %78, label %76
+
+; <label>:76                                      ; preds = %70
+  %77 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1)
+  store %"System.Char[]" addrspace(1)* %77, %"System.Char[]" addrspace(1)** %arg1
+  br label %78
+
+; <label>:78                                      ; preds = %70, %76
+  %79 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck5 = icmp eq %"System.Byte[]" addrspace(1)* %79, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %80
+
+; <label>:80                                      ; preds = %78
+  %81 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %79, i32 0, i32 1
+  %82 = load i32, i32 addrspace(1)* %81
+  %83 = zext i32 %82 to i64
+  %84 = trunc i64 %83 to i32
+  %85 = load i32, i32* %arg5
+  %86 = sub i32 %84, %85
+  store i32 %86, i32* %loc0
+  %87 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck7 = icmp eq %"System.Byte[]" addrspace(1)* %87, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %88
+
+; <label>:88                                      ; preds = %80
+  %89 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %87, i32 0, i32 1
+  %90 = load i32, i32 addrspace(1)* %89
+  %91 = zext i32 %90 to i64
+  %92 = trunc i64 %91 to i32
+  %93 = icmp ne i32 %92, 0
+  br i1 %93, label %96, label %94
+
+; <label>:94                                      ; preds = %88
+  %95 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1)
+  store %"System.Byte[]" addrspace(1)* %95, %"System.Byte[]" addrspace(1)** %arg4
+  br label %96
+
+; <label>:96                                      ; preds = %88, %94
+  %97 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  store %"System.Char[]" addrspace(1)* %97, %"System.Char[]" addrspace(1)** %loc4
+  %98 = icmp eq %"System.Char[]" addrspace(1)* %97, null
+  br i1 %98, label %107, label %99
+
+; <label>:99                                      ; preds = %96
+  %100 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc4
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %100, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %101
+
+; <label>:101                                     ; preds = %99
+  %102 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %100, i32 0, i32 1
+  %103 = load i32, i32 addrspace(1)* %102
+  %104 = zext i32 %103 to i64
+  %105 = trunc i64 %104 to i32
+  %106 = icmp ne i32 %105, 0
+  br i1 %106, label %108, label %107
+
+; <label>:107                                     ; preds = %96, %101
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  br label %116
+
+; <label>:108                                     ; preds = %101
+  %109 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc4
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %109, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %110
+
+; <label>:110                                     ; preds = %108
+  %111 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %109, i32 0, i32 1
+  %112 = load i32, i32 addrspace(1)* %111
+  %113 = zext i32 %112 to i64
+  %BoundsCheck = icmp uge i64 0, %113
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %114
+
+; <label>:114                                     ; preds = %110
+  %115 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %109, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %115, i16 addrspace(1)** %loc1
+  br label %116
+
+; <label>:116                                     ; preds = %107, %114
+  %117 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  store %"System.Byte[]" addrspace(1)* %117, %"System.Byte[]" addrspace(1)** %loc5
+  %118 = icmp eq %"System.Byte[]" addrspace(1)* %117, null
+  br i1 %118, label %127, label %119
+
+; <label>:119                                     ; preds = %116
+  %120 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc5
+  %NullCheck13 = icmp eq %"System.Byte[]" addrspace(1)* %120, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %121
+
+; <label>:121                                     ; preds = %119
+  %122 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %120, i32 0, i32 1
+  %123 = load i32, i32 addrspace(1)* %122
+  %124 = zext i32 %123 to i64
+  %125 = trunc i64 %124 to i32
+  %126 = icmp ne i32 %125, 0
+  br i1 %126, label %128, label %127
+
+; <label>:127                                     ; preds = %116, %121
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc2
+  br label %136
+
+; <label>:128                                     ; preds = %121
+  %129 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc5
+  %NullCheck15 = icmp eq %"System.Byte[]" addrspace(1)* %129, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %130
+
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %129, i32 0, i32 1
+  %132 = load i32, i32 addrspace(1)* %131
+  %133 = zext i32 %132 to i64
+  %BoundsCheck17 = icmp uge i64 0, %133
+  br i1 %BoundsCheck17, label %ThrowIndexOutOfRange18, label %134
+
+; <label>:134                                     ; preds = %130
+  %135 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %129, i32 0, i32 3, i32 0
+  store i8 addrspace(1)* %135, i8 addrspace(1)** %loc2
+  br label %136
+
+; <label>:136                                     ; preds = %127, %134
+  %137 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %138 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %139 = ptrtoint i16 addrspace(1)* %138 to i64
+  %140 = load i32, i32* %arg2
+  %141 = sext i32 %140 to i64
+  %142 = mul i64 %141, 2
+  %143 = add i64 %139, %142
+  %144 = load i32, i32* %arg3
+  %145 = load i8 addrspace(1)*, i8 addrspace(1)** %loc2
+  %146 = ptrtoint i8 addrspace(1)* %145 to i64
+  %147 = load i32, i32* %arg5
+  %148 = sext i32 %147 to i64
+  %149 = add i64 %146, %148
+  %150 = load i32, i32* %loc0
+  %151 = load i8, i8* %arg6
+  %152 = zext i8 %151 to i32
+  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i64 addrspace(1)*
+  %NullCheck19 = icmp eq i64 addrspace(1)* %153, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %154
+
+; <label>:154                                     ; preds = %136
+  %155 = load i64, i64 addrspace(1)* %153
+  %156 = add i64 %155, 72
+  %157 = inttoptr i64 %156 to i64*
+  %158 = load i64, i64* %157
+  %159 = add i64 %158, 0
+  %160 = inttoptr i64 %159 to i64*
+  %161 = load i64, i64* %160
+  %162 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to %System.Text.Encoder addrspace(1)*
+  %163 = inttoptr i64 %143 to i16*
+  %164 = inttoptr i64 %149 to i8*
+  %165 = trunc i32 %152 to i8
+  %166 = inttoptr i64 %161 to i32 (%System.Text.Encoder addrspace(1)*, i16*, i32, i8*, i32, i8)*
+  %167 = call i32 %166(%System.Text.Encoder addrspace(1)* %162, i16* %163, i32 %144, i8* %164, i32 %150, i8 %165)
+  store i32 %167, i32* %loc3
+  br label %168
+
+; <label>:168                                     ; preds = %154
+  %169 = load i32, i32* %loc3
+  ret i32 %169
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %110
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %119
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange18:                           ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
 Successfully read EncoderNLS.GetBytes
 
@@ -14946,22 +17223,22 @@ entry:
   %40 = load i8, i8* %arg5
   %41 = zext i8 %40 to i32
   %42 = trunc i32 %41 to i8
-  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %39, null
-  br i1 %NullCheck, label %43, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderNLS addrspace(1)* %39, null
+  br i1 %NullCheck, label %ThrowNullRef, label %43
 
 ; <label>:43                                      ; preds = %38
   %44 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
   store i8 %42, i8 addrspace(1)* %44
   %45 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %45, null
-  br i1 %NullCheck2, label %46, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.EncoderNLS addrspace(1)* %45, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %46
 
 ; <label>:46                                      ; preds = %43
   %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %45, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %47
   %48 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.EncoderNLS addrspace(1)* %48, null
-  br i1 %NullCheck4, label %49, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.EncoderNLS addrspace(1)* %48, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %49
 
 ; <label>:49                                      ; preds = %46
   %50 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %48, i32 0, i32 3
@@ -14972,8 +17249,8 @@ entry:
   %55 = load i32, i32* %arg4
   %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck6, label %58, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
   %59 = load i64, i64 addrspace(1)* %57
@@ -14991,15 +17268,15 @@ ThrowNullRef:                                     ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %43
+ThrowNullRef2:                                    ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %46
+ThrowNullRef4:                                    ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %49
+ThrowNullRef6:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -15027,8 +17304,8 @@ entry:
   %4 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0 to %System.IO.ConsoleStream addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*)(%System.IO.ConsoleStream addrspace(1)* %4, %"System.Byte[]" addrspace(1)* %1, i32 %2, i32 %3)
   %5 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
@@ -15113,8 +17390,8 @@ entry:
 
 ; <label>:22                                      ; preds = %8
   %23 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %23, null
-  br i1 %NullCheck, label %24, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Byte[]" addrspace(1)* %23, null
+  br i1 %NullCheck, label %ThrowNullRef, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
@@ -15136,8 +17413,8 @@ entry:
 
 ; <label>:36                                      ; preds = %24
   %37 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %37, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.ConsoleStream addrspace(1)* %37, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %37, i32 0, i32 4
@@ -15158,13 +17435,138 @@ ThrowNullRef:                                     ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %36
+ThrowNullRef2:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
-Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
+Successfully read WindowsConsoleStream.WriteFileNative
+
+define i32 @WindowsConsoleStream.WriteFileNative(i64 %param0, %"System.Byte[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i64
+  %arg1 = alloca %"System.Byte[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i8 addrspace(1)*
+  %loc2 = alloca %"System.Byte[]" addrspace(1)*
+  %loc3 = alloca i32
+  store i64 %param0, i64* %arg0
+  store %"System.Byte[]" addrspace(1)* %param1, %"System.Byte[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Byte[]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = zext i32 %3 to i64
+  %5 = icmp ne i64 %4, 0
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %1
+  ret i32 0
+
+; <label>:7                                       ; preds = %1
+  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  store %"System.Byte[]" addrspace(1)* %8, %"System.Byte[]" addrspace(1)** %loc2
+  %9 = icmp eq %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %9, label %18, label %10
+
+; <label>:10                                      ; preds = %7
+  %11 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc2
+  %NullCheck1 = icmp eq %"System.Byte[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %11, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp ne i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %7, %12
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc1
+  br label %27
+
+; <label>:19                                      ; preds = %12
+  %20 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc2
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %20, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %BoundsCheck = icmp uge i64 0, %24
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %25
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %20, i32 0, i32 3, i32 0
+  store i8 addrspace(1)* %26, i8 addrspace(1)** %loc1
+  br label %27
+
+; <label>:27                                      ; preds = %18, %25
+  %28 = load i64, i64* %arg0
+  %29 = load i8 addrspace(1)*, i8 addrspace(1)** %loc1
+  %30 = ptrtoint i8 addrspace(1)* %29 to i64
+  %31 = load i32, i32* %arg2
+  %32 = sext i32 %31 to i64
+  %33 = add i64 %30, %32
+  %34 = load i32, i32* %arg3
+  %35 = addrspacecast i32* %loc3 to i32 addrspace(1)*
+  %36 = inttoptr i64 %33 to i8*
+  %37 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i8*, i32, i32 addrspace(1)*, i64)*)(i64 %28, i8* %36, i32 %34, i32 addrspace(1)* %35, i64 0)
+  %38 = icmp ugt i32 %37, 0
+  %39 = sext i1 %38 to i32
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc1
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %42, label %41
+
+; <label>:41                                      ; preds = %27
+  ret i32 0
+
+; <label>:42                                      ; preds = %27
+  %43 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  store i32 %43, i32* %loc0
+  %44 = load i32, i32* %loc0
+  %45 = icmp eq i32 %44, 232
+  br i1 %45, label %49, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = load i32, i32* %loc0
+  %48 = icmp ne i32 %47, 109
+  br i1 %48, label %50, label %49
+
+; <label>:49                                      ; preds = %42, %46
+  ret i32 0
+
+; <label>:50                                      ; preds = %46
+  %51 = load i32, i32* %loc0
+  ret i32 %51
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
 Successfully read WindowsConsoleStream.Flush
 
@@ -15173,8 +17575,8 @@ entry:
   %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
   store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
@@ -15209,8 +17611,8 @@ entry:
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
   %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load i64, i64 addrspace(1)* %1
@@ -15249,15 +17651,15 @@ entry:
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.TextWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
   %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %3, align 8
   %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
   %7 = load i64, i64 addrspace(1)* %5
@@ -15275,7 +17677,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -15304,8 +17706,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %4)
   store i32 0, i32* %loc0
   %5 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Char[]" addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
@@ -15317,15 +17719,15 @@ entry:
 
 ; <label>:11                                      ; preds = %69
   %12 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %12, i32 0, i32 9
   %15 = load i32, i32 addrspace(1)* %14, align 8
   %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.IO.StreamWriter addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %16, i32 0, i32 10
@@ -15340,15 +17742,15 @@ entry:
 
 ; <label>:23                                      ; preds = %17, %21
   %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %24, null
-  br i1 %NullCheck8, label %25, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %24, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 10
   %27 = load i32, i32 addrspace(1)* %26, align 8
   %28 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %28, null
-  br i1 %NullCheck10, label %29, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.StreamWriter addrspace(1)* %28, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %28, i32 0, i32 9
@@ -15370,15 +17772,15 @@ entry:
   %40 = load i32, i32* %loc0
   %41 = mul i32 %40, 2
   %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
-  br i1 %NullCheck12, label %43, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %43
 
 ; <label>:43                                      ; preds = %38
   %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 7
   %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %44, align 8
   %46 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %46, null
-  br i1 %NullCheck14, label %47, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.IO.StreamWriter addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %47
 
 ; <label>:47                                      ; preds = %43
   %48 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %46, i32 0, i32 9
@@ -15390,16 +17792,16 @@ entry:
   %54 = bitcast %"System.Char[]" addrspace(1)* %45 to %System.Array addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %53, i32 %41, %System.Array addrspace(1)* %54, i32 %50, i32 %52)
   %55 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
-  br i1 %NullCheck16, label %56, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %56
 
 ; <label>:56                                      ; preds = %47
   %57 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
   %58 = load i32, i32 addrspace(1)* %57, align 8
   %59 = load i32, i32* %loc2
   %60 = add i32 %58, %59
-  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
-  br i1 %NullCheck18, label %61, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %61
 
 ; <label>:61                                      ; preds = %56
   %62 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
@@ -15421,8 +17823,8 @@ entry:
 
 ; <label>:72                                      ; preds = %69
   %73 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %73, null
-  br i1 %NullCheck2, label %74, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %73, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %74
 
 ; <label>:74                                      ; preds = %72
   %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %73, i32 0, i32 11
@@ -15443,39 +17845,39 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %72
+ThrowNullRef2:                                    ; preds = %72
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %23
+ThrowNullRef8:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef10:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %43
+ThrowNullRef14:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %47
+ThrowNullRef16:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %56
+ThrowNullRef18:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblDist.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblDist.error.txt
@@ -25,8 +25,8 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
@@ -40,8 +40,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
   %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
@@ -75,7 +75,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -90,8 +90,8 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %NullCheck = icmp ne i8 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = load i8, i8 addrspace(1)* %0, align 8
@@ -125,8 +125,8 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
@@ -159,8 +159,8 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -184,8 +184,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
   store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
@@ -195,8 +195,8 @@ entry:
 ; <label>:4                                       ; preds = %1
   %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
   %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
@@ -206,8 +206,8 @@ entry:
   %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
@@ -221,14 +221,14 @@ entry:
 
 ; <label>:17                                      ; preds = %14
   %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
   %21 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
@@ -238,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -249,8 +249,8 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
@@ -261,27 +261,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %30
+ThrowNullRef10:                                   ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -301,7 +301,89 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
-Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
+Successfully read AppDomainSetup.GetUnsecureApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.GetUnsecureApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %NullCheck = icmp eq %"System.String[]" addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %BoundsCheck = icmp uge i64 0, %5
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %6
+
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 3, i32 0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
+  ret %System.String addrspace(1)* %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_Value using LLILCJit
+Successfully read AppDomainSetup.get_Value
+
+define %"System.String[]" addrspace(1)* @AppDomainSetup.get_Value(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.String[]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 18)
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.String[]" addrspace(1)* addrspace(1)*, %"System.String[]" addrspace(1)*)*)(%"System.String[]" addrspace(1)* addrspace(1)* %9, %"System.String[]" addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %11, i32 0, i32 1
+  %14 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %13, align 8
+  ret %"System.String[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -319,8 +401,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -368,16 +450,16 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
   %5 = load i32, i32 addrspace(1)* %4
   %6 = sub i32 %5, 1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -389,7 +471,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -421,8 +503,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
@@ -456,8 +538,8 @@ entry:
 ; <label>:27                                      ; preds = %19
   %28 = load i32, i32* %arg1
   %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
-  br i1 %NullCheck2, label %30, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %29, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %30
 
 ; <label>:30                                      ; preds = %27
   %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
@@ -493,8 +575,8 @@ entry:
 ; <label>:49                                      ; preds = %46
   %50 = load i32, i32* %arg2
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck4, label %52, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
@@ -517,11 +599,11 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %27
+ThrowNullRef2:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %49
+ThrowNullRef4:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -544,16 +626,16 @@ entry:
   %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %0)
   store %System.String addrspace(1)* %1, %System.String addrspace(1)** %loc0
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 2
   %5 = bitcast [0 x i16] addrspace(1)* %4 to i16 addrspace(1)*
   store i16 addrspace(1)* %5, i16 addrspace(1)** %loc1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %3
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2
@@ -580,7 +662,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -691,15 +773,15 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %NullCheck132 = icmp ne i8* %21, null
-  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+  %NullCheck131 = icmp eq i8* %21, null
+  br i1 %NullCheck131, label %ThrowNullRef132, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = load i8, i8* %21, align 8
   %24 = zext i8 %23 to i32
   %25 = trunc i32 %24 to i8
-  %NullCheck134 = icmp ne i8* %20, null
-  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+  %NullCheck133 = icmp eq i8* %20, null
+  br i1 %NullCheck133, label %ThrowNullRef134, label %26
 
 ; <label>:26                                      ; preds = %22
   store i8 %25, i8* %20, align 8
@@ -709,16 +791,16 @@ entry:
   %28 = load i8*, i8** %arg0
   %29 = load i8*, i8** %arg1
   %30 = bitcast i8* %29 to i16*
-  %NullCheck128 = icmp ne i16* %30, null
-  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+  %NullCheck127 = icmp eq i16* %30, null
+  br i1 %NullCheck127, label %ThrowNullRef128, label %31
 
 ; <label>:31                                      ; preds = %27
   %32 = load i16, i16* %30, align 8
   %33 = sext i16 %32 to i32
   %34 = bitcast i8* %28 to i16*
   %35 = trunc i32 %33 to i16
-  %NullCheck130 = icmp ne i16* %34, null
-  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+  %NullCheck129 = icmp eq i16* %34, null
+  br i1 %NullCheck129, label %ThrowNullRef130, label %36
 
 ; <label>:36                                      ; preds = %31
   store i16 %35, i16* %34, align 8
@@ -728,16 +810,16 @@ entry:
   %38 = load i8*, i8** %arg0
   %39 = load i8*, i8** %arg1
   %40 = bitcast i8* %39 to i16*
-  %NullCheck120 = icmp ne i16* %40, null
-  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+  %NullCheck119 = icmp eq i16* %40, null
+  br i1 %NullCheck119, label %ThrowNullRef120, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i16, i16* %40, align 8
   %43 = sext i16 %42 to i32
   %44 = bitcast i8* %38 to i16*
   %45 = trunc i32 %43 to i16
-  %NullCheck122 = icmp ne i16* %44, null
-  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+  %NullCheck121 = icmp eq i16* %44, null
+  br i1 %NullCheck121, label %ThrowNullRef122, label %46
 
 ; <label>:46                                      ; preds = %41
   store i16 %45, i16* %44, align 8
@@ -745,15 +827,15 @@ entry:
   %48 = getelementptr inbounds i8, i8* %47, i64 2
   %49 = load i8*, i8** %arg1
   %50 = getelementptr inbounds i8, i8* %49, i64 2
-  %NullCheck124 = icmp ne i8* %50, null
-  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+  %NullCheck123 = icmp eq i8* %50, null
+  br i1 %NullCheck123, label %ThrowNullRef124, label %51
 
 ; <label>:51                                      ; preds = %46
   %52 = load i8, i8* %50, align 8
   %53 = zext i8 %52 to i32
   %54 = trunc i32 %53 to i8
-  %NullCheck126 = icmp ne i8* %48, null
-  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+  %NullCheck125 = icmp eq i8* %48, null
+  br i1 %NullCheck125, label %ThrowNullRef126, label %55
 
 ; <label>:55                                      ; preds = %51
   store i8 %54, i8* %48, align 8
@@ -763,14 +845,14 @@ entry:
   %57 = load i8*, i8** %arg0
   %58 = load i8*, i8** %arg1
   %59 = bitcast i8* %58 to i32*
-  %NullCheck116 = icmp ne i32* %59, null
-  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+  %NullCheck115 = icmp eq i32* %59, null
+  br i1 %NullCheck115, label %ThrowNullRef116, label %60
 
 ; <label>:60                                      ; preds = %56
   %61 = load i32, i32* %59, align 8
   %62 = bitcast i8* %57 to i32*
-  %NullCheck118 = icmp ne i32* %62, null
-  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+  %NullCheck117 = icmp eq i32* %62, null
+  br i1 %NullCheck117, label %ThrowNullRef118, label %63
 
 ; <label>:63                                      ; preds = %60
   store i32 %61, i32* %62, align 8
@@ -780,14 +862,14 @@ entry:
   %65 = load i8*, i8** %arg0
   %66 = load i8*, i8** %arg1
   %67 = bitcast i8* %66 to i32*
-  %NullCheck108 = icmp ne i32* %67, null
-  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+  %NullCheck107 = icmp eq i32* %67, null
+  br i1 %NullCheck107, label %ThrowNullRef108, label %68
 
 ; <label>:68                                      ; preds = %64
   %69 = load i32, i32* %67, align 8
   %70 = bitcast i8* %65 to i32*
-  %NullCheck110 = icmp ne i32* %70, null
-  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+  %NullCheck109 = icmp eq i32* %70, null
+  br i1 %NullCheck109, label %ThrowNullRef110, label %71
 
 ; <label>:71                                      ; preds = %68
   store i32 %69, i32* %70, align 8
@@ -795,15 +877,15 @@ entry:
   %73 = getelementptr inbounds i8, i8* %72, i64 4
   %74 = load i8*, i8** %arg1
   %75 = getelementptr inbounds i8, i8* %74, i64 4
-  %NullCheck112 = icmp ne i8* %75, null
-  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+  %NullCheck111 = icmp eq i8* %75, null
+  br i1 %NullCheck111, label %ThrowNullRef112, label %76
 
 ; <label>:76                                      ; preds = %71
   %77 = load i8, i8* %75, align 8
   %78 = zext i8 %77 to i32
   %79 = trunc i32 %78 to i8
-  %NullCheck114 = icmp ne i8* %73, null
-  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+  %NullCheck113 = icmp eq i8* %73, null
+  br i1 %NullCheck113, label %ThrowNullRef114, label %80
 
 ; <label>:80                                      ; preds = %76
   store i8 %79, i8* %73, align 8
@@ -813,14 +895,14 @@ entry:
   %82 = load i8*, i8** %arg0
   %83 = load i8*, i8** %arg1
   %84 = bitcast i8* %83 to i32*
-  %NullCheck100 = icmp ne i32* %84, null
-  br i1 %NullCheck100, label %85, label %ThrowNullRef99
+  %NullCheck99 = icmp eq i32* %84, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %85
 
 ; <label>:85                                      ; preds = %81
   %86 = load i32, i32* %84, align 8
   %87 = bitcast i8* %82 to i32*
-  %NullCheck102 = icmp ne i32* %87, null
-  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+  %NullCheck101 = icmp eq i32* %87, null
+  br i1 %NullCheck101, label %ThrowNullRef102, label %88
 
 ; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
@@ -829,16 +911,16 @@ entry:
   %91 = load i8*, i8** %arg1
   %92 = getelementptr inbounds i8, i8* %91, i64 4
   %93 = bitcast i8* %92 to i16*
-  %NullCheck104 = icmp ne i16* %93, null
-  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+  %NullCheck103 = icmp eq i16* %93, null
+  br i1 %NullCheck103, label %ThrowNullRef104, label %94
 
 ; <label>:94                                      ; preds = %88
   %95 = load i16, i16* %93, align 8
   %96 = sext i16 %95 to i32
   %97 = bitcast i8* %90 to i16*
   %98 = trunc i32 %96 to i16
-  %NullCheck106 = icmp ne i16* %97, null
-  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+  %NullCheck105 = icmp eq i16* %97, null
+  br i1 %NullCheck105, label %ThrowNullRef106, label %99
 
 ; <label>:99                                      ; preds = %94
   store i16 %98, i16* %97, align 8
@@ -848,14 +930,14 @@ entry:
   %101 = load i8*, i8** %arg0
   %102 = load i8*, i8** %arg1
   %103 = bitcast i8* %102 to i32*
-  %NullCheck88 = icmp ne i32* %103, null
-  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+  %NullCheck87 = icmp eq i32* %103, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %104
 
 ; <label>:104                                     ; preds = %100
   %105 = load i32, i32* %103, align 8
   %106 = bitcast i8* %101 to i32*
-  %NullCheck90 = icmp ne i32* %106, null
-  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+  %NullCheck89 = icmp eq i32* %106, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %107
 
 ; <label>:107                                     ; preds = %104
   store i32 %105, i32* %106, align 8
@@ -864,16 +946,16 @@ entry:
   %110 = load i8*, i8** %arg1
   %111 = getelementptr inbounds i8, i8* %110, i64 4
   %112 = bitcast i8* %111 to i16*
-  %NullCheck92 = icmp ne i16* %112, null
-  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+  %NullCheck91 = icmp eq i16* %112, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %113
 
 ; <label>:113                                     ; preds = %107
   %114 = load i16, i16* %112, align 8
   %115 = sext i16 %114 to i32
   %116 = bitcast i8* %109 to i16*
   %117 = trunc i32 %115 to i16
-  %NullCheck94 = icmp ne i16* %116, null
-  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+  %NullCheck93 = icmp eq i16* %116, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %118
 
 ; <label>:118                                     ; preds = %113
   store i16 %117, i16* %116, align 8
@@ -881,15 +963,15 @@ entry:
   %120 = getelementptr inbounds i8, i8* %119, i64 6
   %121 = load i8*, i8** %arg1
   %122 = getelementptr inbounds i8, i8* %121, i64 6
-  %NullCheck96 = icmp ne i8* %122, null
-  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+  %NullCheck95 = icmp eq i8* %122, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %123
 
 ; <label>:123                                     ; preds = %118
   %124 = load i8, i8* %122, align 8
   %125 = zext i8 %124 to i32
   %126 = trunc i32 %125 to i8
-  %NullCheck98 = icmp ne i8* %120, null
-  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+  %NullCheck97 = icmp eq i8* %120, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %127
 
 ; <label>:127                                     ; preds = %123
   store i8 %126, i8* %120, align 8
@@ -899,14 +981,14 @@ entry:
   %129 = load i8*, i8** %arg0
   %130 = load i8*, i8** %arg1
   %131 = bitcast i8* %130 to i64*
-  %NullCheck84 = icmp ne i64* %131, null
-  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+  %NullCheck83 = icmp eq i64* %131, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %132
 
 ; <label>:132                                     ; preds = %128
   %133 = load i64, i64* %131, align 8
   %134 = bitcast i8* %129 to i64*
-  %NullCheck86 = icmp ne i64* %134, null
-  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+  %NullCheck85 = icmp eq i64* %134, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %135
 
 ; <label>:135                                     ; preds = %132
   store i64 %133, i64* %134, align 8
@@ -916,14 +998,14 @@ entry:
   %137 = load i8*, i8** %arg0
   %138 = load i8*, i8** %arg1
   %139 = bitcast i8* %138 to i64*
-  %NullCheck76 = icmp ne i64* %139, null
-  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+  %NullCheck75 = icmp eq i64* %139, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %140
 
 ; <label>:140                                     ; preds = %136
   %141 = load i64, i64* %139, align 8
   %142 = bitcast i8* %137 to i64*
-  %NullCheck78 = icmp ne i64* %142, null
-  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+  %NullCheck77 = icmp eq i64* %142, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %143
 
 ; <label>:143                                     ; preds = %140
   store i64 %141, i64* %142, align 8
@@ -931,15 +1013,15 @@ entry:
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %NullCheck80 = icmp ne i8* %147, null
-  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+  %NullCheck79 = icmp eq i8* %147, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %148
 
 ; <label>:148                                     ; preds = %143
   %149 = load i8, i8* %147, align 8
   %150 = zext i8 %149 to i32
   %151 = trunc i32 %150 to i8
-  %NullCheck82 = icmp ne i8* %145, null
-  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+  %NullCheck81 = icmp eq i8* %145, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %152
 
 ; <label>:152                                     ; preds = %148
   store i8 %151, i8* %145, align 8
@@ -949,14 +1031,14 @@ entry:
   %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
   %156 = bitcast i8* %155 to i64*
-  %NullCheck68 = icmp ne i64* %156, null
-  br i1 %NullCheck68, label %157, label %ThrowNullRef67
+  %NullCheck67 = icmp eq i64* %156, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %157
 
 ; <label>:157                                     ; preds = %153
   %158 = load i64, i64* %156, align 8
   %159 = bitcast i8* %154 to i64*
-  %NullCheck70 = icmp ne i64* %159, null
-  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+  %NullCheck69 = icmp eq i64* %159, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %160
 
 ; <label>:160                                     ; preds = %157
   store i64 %158, i64* %159, align 8
@@ -965,16 +1047,16 @@ entry:
   %163 = load i8*, i8** %arg1
   %164 = getelementptr inbounds i8, i8* %163, i64 8
   %165 = bitcast i8* %164 to i16*
-  %NullCheck72 = icmp ne i16* %165, null
-  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+  %NullCheck71 = icmp eq i16* %165, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %166
 
 ; <label>:166                                     ; preds = %160
   %167 = load i16, i16* %165, align 8
   %168 = sext i16 %167 to i32
   %169 = bitcast i8* %162 to i16*
   %170 = trunc i32 %168 to i16
-  %NullCheck74 = icmp ne i16* %169, null
-  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+  %NullCheck73 = icmp eq i16* %169, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %171
 
 ; <label>:171                                     ; preds = %166
   store i16 %170, i16* %169, align 8
@@ -984,14 +1066,14 @@ entry:
   %173 = load i8*, i8** %arg0
   %174 = load i8*, i8** %arg1
   %175 = bitcast i8* %174 to i64*
-  %NullCheck56 = icmp ne i64* %175, null
-  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+  %NullCheck55 = icmp eq i64* %175, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %176
 
 ; <label>:176                                     ; preds = %172
   %177 = load i64, i64* %175, align 8
   %178 = bitcast i8* %173 to i64*
-  %NullCheck58 = icmp ne i64* %178, null
-  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+  %NullCheck57 = icmp eq i64* %178, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %179
 
 ; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
@@ -1000,16 +1082,16 @@ entry:
   %182 = load i8*, i8** %arg1
   %183 = getelementptr inbounds i8, i8* %182, i64 8
   %184 = bitcast i8* %183 to i16*
-  %NullCheck60 = icmp ne i16* %184, null
-  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+  %NullCheck59 = icmp eq i16* %184, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %185
 
 ; <label>:185                                     ; preds = %179
   %186 = load i16, i16* %184, align 8
   %187 = sext i16 %186 to i32
   %188 = bitcast i8* %181 to i16*
   %189 = trunc i32 %187 to i16
-  %NullCheck62 = icmp ne i16* %188, null
-  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+  %NullCheck61 = icmp eq i16* %188, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %190
 
 ; <label>:190                                     ; preds = %185
   store i16 %189, i16* %188, align 8
@@ -1017,15 +1099,15 @@ entry:
   %192 = getelementptr inbounds i8, i8* %191, i64 10
   %193 = load i8*, i8** %arg1
   %194 = getelementptr inbounds i8, i8* %193, i64 10
-  %NullCheck64 = icmp ne i8* %194, null
-  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+  %NullCheck63 = icmp eq i8* %194, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %195
 
 ; <label>:195                                     ; preds = %190
   %196 = load i8, i8* %194, align 8
   %197 = zext i8 %196 to i32
   %198 = trunc i32 %197 to i8
-  %NullCheck66 = icmp ne i8* %192, null
-  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+  %NullCheck65 = icmp eq i8* %192, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %199
 
 ; <label>:199                                     ; preds = %195
   store i8 %198, i8* %192, align 8
@@ -1035,14 +1117,14 @@ entry:
   %201 = load i8*, i8** %arg0
   %202 = load i8*, i8** %arg1
   %203 = bitcast i8* %202 to i64*
-  %NullCheck48 = icmp ne i64* %203, null
-  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+  %NullCheck47 = icmp eq i64* %203, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %204
 
 ; <label>:204                                     ; preds = %200
   %205 = load i64, i64* %203, align 8
   %206 = bitcast i8* %201 to i64*
-  %NullCheck50 = icmp ne i64* %206, null
-  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+  %NullCheck49 = icmp eq i64* %206, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %207
 
 ; <label>:207                                     ; preds = %204
   store i64 %205, i64* %206, align 8
@@ -1051,14 +1133,14 @@ entry:
   %210 = load i8*, i8** %arg1
   %211 = getelementptr inbounds i8, i8* %210, i64 8
   %212 = bitcast i8* %211 to i32*
-  %NullCheck52 = icmp ne i32* %212, null
-  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+  %NullCheck51 = icmp eq i32* %212, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %213
 
 ; <label>:213                                     ; preds = %207
   %214 = load i32, i32* %212, align 8
   %215 = bitcast i8* %209 to i32*
-  %NullCheck54 = icmp ne i32* %215, null
-  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+  %NullCheck53 = icmp eq i32* %215, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %216
 
 ; <label>:216                                     ; preds = %213
   store i32 %214, i32* %215, align 8
@@ -1068,14 +1150,14 @@ entry:
   %218 = load i8*, i8** %arg0
   %219 = load i8*, i8** %arg1
   %220 = bitcast i8* %219 to i64*
-  %NullCheck36 = icmp ne i64* %220, null
-  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64* %220, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %221
 
 ; <label>:221                                     ; preds = %217
   %222 = load i64, i64* %220, align 8
   %223 = bitcast i8* %218 to i64*
-  %NullCheck38 = icmp ne i64* %223, null
-  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+  %NullCheck37 = icmp eq i64* %223, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %224
 
 ; <label>:224                                     ; preds = %221
   store i64 %222, i64* %223, align 8
@@ -1084,14 +1166,14 @@ entry:
   %227 = load i8*, i8** %arg1
   %228 = getelementptr inbounds i8, i8* %227, i64 8
   %229 = bitcast i8* %228 to i32*
-  %NullCheck40 = icmp ne i32* %229, null
-  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i32* %229, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %230
 
 ; <label>:230                                     ; preds = %224
   %231 = load i32, i32* %229, align 8
   %232 = bitcast i8* %226 to i32*
-  %NullCheck42 = icmp ne i32* %232, null
-  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+  %NullCheck41 = icmp eq i32* %232, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %233
 
 ; <label>:233                                     ; preds = %230
   store i32 %231, i32* %232, align 8
@@ -1099,15 +1181,15 @@ entry:
   %235 = getelementptr inbounds i8, i8* %234, i64 12
   %236 = load i8*, i8** %arg1
   %237 = getelementptr inbounds i8, i8* %236, i64 12
-  %NullCheck44 = icmp ne i8* %237, null
-  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i8* %237, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %238
 
 ; <label>:238                                     ; preds = %233
   %239 = load i8, i8* %237, align 8
   %240 = zext i8 %239 to i32
   %241 = trunc i32 %240 to i8
-  %NullCheck46 = icmp ne i8* %235, null
-  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+  %NullCheck45 = icmp eq i8* %235, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %242
 
 ; <label>:242                                     ; preds = %238
   store i8 %241, i8* %235, align 8
@@ -1117,14 +1199,14 @@ entry:
   %244 = load i8*, i8** %arg0
   %245 = load i8*, i8** %arg1
   %246 = bitcast i8* %245 to i64*
-  %NullCheck24 = icmp ne i64* %246, null
-  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64* %246, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %247
 
 ; <label>:247                                     ; preds = %243
   %248 = load i64, i64* %246, align 8
   %249 = bitcast i8* %244 to i64*
-  %NullCheck26 = icmp ne i64* %249, null
-  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64* %249, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %250
 
 ; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
@@ -1133,14 +1215,14 @@ entry:
   %253 = load i8*, i8** %arg1
   %254 = getelementptr inbounds i8, i8* %253, i64 8
   %255 = bitcast i8* %254 to i32*
-  %NullCheck28 = icmp ne i32* %255, null
-  br i1 %NullCheck28, label %256, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i32* %255, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %256
 
 ; <label>:256                                     ; preds = %250
   %257 = load i32, i32* %255, align 8
   %258 = bitcast i8* %252 to i32*
-  %NullCheck30 = icmp ne i32* %258, null
-  br i1 %NullCheck30, label %259, label %ThrowNullRef29
+  %NullCheck29 = icmp eq i32* %258, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %259
 
 ; <label>:259                                     ; preds = %256
   store i32 %257, i32* %258, align 8
@@ -1149,16 +1231,16 @@ entry:
   %262 = load i8*, i8** %arg1
   %263 = getelementptr inbounds i8, i8* %262, i64 12
   %264 = bitcast i8* %263 to i16*
-  %NullCheck32 = icmp ne i16* %264, null
-  br i1 %NullCheck32, label %265, label %ThrowNullRef31
+  %NullCheck31 = icmp eq i16* %264, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %265
 
 ; <label>:265                                     ; preds = %259
   %266 = load i16, i16* %264, align 8
   %267 = sext i16 %266 to i32
   %268 = bitcast i8* %261 to i16*
   %269 = trunc i32 %267 to i16
-  %NullCheck34 = icmp ne i16* %268, null
-  br i1 %NullCheck34, label %270, label %ThrowNullRef33
+  %NullCheck33 = icmp eq i16* %268, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %270
 
 ; <label>:270                                     ; preds = %265
   store i16 %269, i16* %268, align 8
@@ -1168,14 +1250,14 @@ entry:
   %272 = load i8*, i8** %arg0
   %273 = load i8*, i8** %arg1
   %274 = bitcast i8* %273 to i64*
-  %NullCheck8 = icmp ne i64* %274, null
-  br i1 %NullCheck8, label %275, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64* %274, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %275
 
 ; <label>:275                                     ; preds = %271
   %276 = load i64, i64* %274, align 8
   %277 = bitcast i8* %272 to i64*
-  %NullCheck10 = icmp ne i64* %277, null
-  br i1 %NullCheck10, label %278, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %277, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %278
 
 ; <label>:278                                     ; preds = %275
   store i64 %276, i64* %277, align 8
@@ -1184,14 +1266,14 @@ entry:
   %281 = load i8*, i8** %arg1
   %282 = getelementptr inbounds i8, i8* %281, i64 8
   %283 = bitcast i8* %282 to i32*
-  %NullCheck12 = icmp ne i32* %283, null
-  br i1 %NullCheck12, label %284, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i32* %283, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %284
 
 ; <label>:284                                     ; preds = %278
   %285 = load i32, i32* %283, align 8
   %286 = bitcast i8* %280 to i32*
-  %NullCheck14 = icmp ne i32* %286, null
-  br i1 %NullCheck14, label %287, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i32* %286, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %287
 
 ; <label>:287                                     ; preds = %284
   store i32 %285, i32* %286, align 8
@@ -1200,16 +1282,16 @@ entry:
   %290 = load i8*, i8** %arg1
   %291 = getelementptr inbounds i8, i8* %290, i64 12
   %292 = bitcast i8* %291 to i16*
-  %NullCheck16 = icmp ne i16* %292, null
-  br i1 %NullCheck16, label %293, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i16* %292, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %293
 
 ; <label>:293                                     ; preds = %287
   %294 = load i16, i16* %292, align 8
   %295 = sext i16 %294 to i32
   %296 = bitcast i8* %289 to i16*
   %297 = trunc i32 %295 to i16
-  %NullCheck18 = icmp ne i16* %296, null
-  br i1 %NullCheck18, label %298, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i16* %296, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %298
 
 ; <label>:298                                     ; preds = %293
   store i16 %297, i16* %296, align 8
@@ -1217,15 +1299,15 @@ entry:
   %300 = getelementptr inbounds i8, i8* %299, i64 14
   %301 = load i8*, i8** %arg1
   %302 = getelementptr inbounds i8, i8* %301, i64 14
-  %NullCheck20 = icmp ne i8* %302, null
-  br i1 %NullCheck20, label %303, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i8* %302, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %303
 
 ; <label>:303                                     ; preds = %298
   %304 = load i8, i8* %302, align 8
   %305 = zext i8 %304 to i32
   %306 = trunc i32 %305 to i8
-  %NullCheck22 = icmp ne i8* %300, null
-  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i8* %300, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %307
 
 ; <label>:307                                     ; preds = %303
   store i8 %306, i8* %300, align 8
@@ -1235,14 +1317,14 @@ entry:
   %309 = load i8*, i8** %arg0
   %310 = load i8*, i8** %arg1
   %311 = bitcast i8* %310 to i64*
-  %NullCheck = icmp ne i64* %311, null
-  br i1 %NullCheck, label %312, label %ThrowNullRef
+  %NullCheck = icmp eq i64* %311, null
+  br i1 %NullCheck, label %ThrowNullRef, label %312
 
 ; <label>:312                                     ; preds = %308
   %313 = load i64, i64* %311, align 8
   %314 = bitcast i8* %309 to i64*
-  %NullCheck2 = icmp ne i64* %314, null
-  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64* %314, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %315
 
 ; <label>:315                                     ; preds = %312
   store i64 %313, i64* %314, align 8
@@ -1251,14 +1333,14 @@ entry:
   %318 = load i8*, i8** %arg1
   %319 = getelementptr inbounds i8, i8* %318, i64 8
   %320 = bitcast i8* %319 to i64*
-  %NullCheck4 = icmp ne i64* %320, null
-  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64* %320, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %321
 
 ; <label>:321                                     ; preds = %315
   %322 = load i64, i64* %320, align 8
   %323 = bitcast i8* %317 to i64*
-  %NullCheck6 = icmp ne i64* %323, null
-  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64* %323, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %324
 
 ; <label>:324                                     ; preds = %321
   store i64 %322, i64* %323, align 8
@@ -1286,15 +1368,15 @@ entry:
 ; <label>:338                                     ; preds = %333
   %339 = load i8*, i8** %arg0
   %340 = load i8*, i8** %arg1
-  %NullCheck136 = icmp ne i8* %340, null
-  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+  %NullCheck135 = icmp eq i8* %340, null
+  br i1 %NullCheck135, label %ThrowNullRef136, label %341
 
 ; <label>:341                                     ; preds = %338
   %342 = load i8, i8* %340, align 8
   %343 = zext i8 %342 to i32
   %344 = trunc i32 %343 to i8
-  %NullCheck138 = icmp ne i8* %339, null
-  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+  %NullCheck137 = icmp eq i8* %339, null
+  br i1 %NullCheck137, label %ThrowNullRef138, label %345
 
 ; <label>:345                                     ; preds = %341
   store i8 %344, i8* %339, align 8
@@ -1317,16 +1399,16 @@ entry:
   %357 = load i8*, i8** %arg0
   %358 = load i8*, i8** %arg1
   %359 = bitcast i8* %358 to i16*
-  %NullCheck140 = icmp ne i16* %359, null
-  br i1 %NullCheck140, label %360, label %ThrowNullRef139
+  %NullCheck139 = icmp eq i16* %359, null
+  br i1 %NullCheck139, label %ThrowNullRef140, label %360
 
 ; <label>:360                                     ; preds = %356
   %361 = load i16, i16* %359, align 8
   %362 = sext i16 %361 to i32
   %363 = bitcast i8* %357 to i16*
   %364 = trunc i32 %362 to i16
-  %NullCheck142 = icmp ne i16* %363, null
-  br i1 %NullCheck142, label %365, label %ThrowNullRef141
+  %NullCheck141 = icmp eq i16* %363, null
+  br i1 %NullCheck141, label %ThrowNullRef142, label %365
 
 ; <label>:365                                     ; preds = %360
   store i16 %364, i16* %363, align 8
@@ -1352,14 +1434,14 @@ entry:
   %378 = load i8*, i8** %arg0
   %379 = load i8*, i8** %arg1
   %380 = bitcast i8* %379 to i32*
-  %NullCheck144 = icmp ne i32* %380, null
-  br i1 %NullCheck144, label %381, label %ThrowNullRef143
+  %NullCheck143 = icmp eq i32* %380, null
+  br i1 %NullCheck143, label %ThrowNullRef144, label %381
 
 ; <label>:381                                     ; preds = %377
   %382 = load i32, i32* %380, align 8
   %383 = bitcast i8* %378 to i32*
-  %NullCheck146 = icmp ne i32* %383, null
-  br i1 %NullCheck146, label %384, label %ThrowNullRef145
+  %NullCheck145 = icmp eq i32* %383, null
+  br i1 %NullCheck145, label %ThrowNullRef146, label %384
 
 ; <label>:384                                     ; preds = %381
   store i32 %382, i32* %383, align 8
@@ -1384,14 +1466,14 @@ entry:
   %395 = load i8*, i8** %arg0
   %396 = load i8*, i8** %arg1
   %397 = bitcast i8* %396 to i64*
-  %NullCheck164 = icmp ne i64* %397, null
-  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+  %NullCheck163 = icmp eq i64* %397, null
+  br i1 %NullCheck163, label %ThrowNullRef164, label %398
 
 ; <label>:398                                     ; preds = %394
   %399 = load i64, i64* %397, align 8
   %400 = bitcast i8* %395 to i64*
-  %NullCheck166 = icmp ne i64* %400, null
-  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+  %NullCheck165 = icmp eq i64* %400, null
+  br i1 %NullCheck165, label %ThrowNullRef166, label %401
 
 ; <label>:401                                     ; preds = %398
   store i64 %399, i64* %400, align 8
@@ -1400,14 +1482,14 @@ entry:
   %404 = load i8*, i8** %arg1
   %405 = getelementptr inbounds i8, i8* %404, i64 8
   %406 = bitcast i8* %405 to i64*
-  %NullCheck168 = icmp ne i64* %406, null
-  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+  %NullCheck167 = icmp eq i64* %406, null
+  br i1 %NullCheck167, label %ThrowNullRef168, label %407
 
 ; <label>:407                                     ; preds = %401
   %408 = load i64, i64* %406, align 8
   %409 = bitcast i8* %403 to i64*
-  %NullCheck170 = icmp ne i64* %409, null
-  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+  %NullCheck169 = icmp eq i64* %409, null
+  br i1 %NullCheck169, label %ThrowNullRef170, label %410
 
 ; <label>:410                                     ; preds = %407
   store i64 %408, i64* %409, align 8
@@ -1437,14 +1519,14 @@ entry:
   %425 = load i8*, i8** %arg0
   %426 = load i8*, i8** %arg1
   %427 = bitcast i8* %426 to i64*
-  %NullCheck148 = icmp ne i64* %427, null
-  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+  %NullCheck147 = icmp eq i64* %427, null
+  br i1 %NullCheck147, label %ThrowNullRef148, label %428
 
 ; <label>:428                                     ; preds = %424
   %429 = load i64, i64* %427, align 8
   %430 = bitcast i8* %425 to i64*
-  %NullCheck150 = icmp ne i64* %430, null
-  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+  %NullCheck149 = icmp eq i64* %430, null
+  br i1 %NullCheck149, label %ThrowNullRef150, label %431
 
 ; <label>:431                                     ; preds = %428
   store i64 %429, i64* %430, align 8
@@ -1466,14 +1548,14 @@ entry:
   %441 = load i8*, i8** %arg0
   %442 = load i8*, i8** %arg1
   %443 = bitcast i8* %442 to i32*
-  %NullCheck152 = icmp ne i32* %443, null
-  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+  %NullCheck151 = icmp eq i32* %443, null
+  br i1 %NullCheck151, label %ThrowNullRef152, label %444
 
 ; <label>:444                                     ; preds = %440
   %445 = load i32, i32* %443, align 8
   %446 = bitcast i8* %441 to i32*
-  %NullCheck154 = icmp ne i32* %446, null
-  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+  %NullCheck153 = icmp eq i32* %446, null
+  br i1 %NullCheck153, label %ThrowNullRef154, label %447
 
 ; <label>:447                                     ; preds = %444
   store i32 %445, i32* %446, align 8
@@ -1495,16 +1577,16 @@ entry:
   %457 = load i8*, i8** %arg0
   %458 = load i8*, i8** %arg1
   %459 = bitcast i8* %458 to i16*
-  %NullCheck156 = icmp ne i16* %459, null
-  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+  %NullCheck155 = icmp eq i16* %459, null
+  br i1 %NullCheck155, label %ThrowNullRef156, label %460
 
 ; <label>:460                                     ; preds = %456
   %461 = load i16, i16* %459, align 8
   %462 = sext i16 %461 to i32
   %463 = bitcast i8* %457 to i16*
   %464 = trunc i32 %462 to i16
-  %NullCheck158 = icmp ne i16* %463, null
-  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+  %NullCheck157 = icmp eq i16* %463, null
+  br i1 %NullCheck157, label %ThrowNullRef158, label %465
 
 ; <label>:465                                     ; preds = %460
   store i16 %464, i16* %463, align 8
@@ -1525,15 +1607,15 @@ entry:
 ; <label>:474                                     ; preds = %470
   %475 = load i8*, i8** %arg0
   %476 = load i8*, i8** %arg1
-  %NullCheck160 = icmp ne i8* %476, null
-  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+  %NullCheck159 = icmp eq i8* %476, null
+  br i1 %NullCheck159, label %ThrowNullRef160, label %477
 
 ; <label>:477                                     ; preds = %474
   %478 = load i8, i8* %476, align 8
   %479 = zext i8 %478 to i32
   %480 = trunc i32 %479 to i8
-  %NullCheck162 = icmp ne i8* %475, null
-  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+  %NullCheck161 = icmp eq i8* %475, null
+  br i1 %NullCheck161, label %ThrowNullRef162, label %481
 
 ; <label>:481                                     ; preds = %477
   store i8 %480, i8* %475, align 8
@@ -1553,343 +1635,343 @@ ThrowNullRef:                                     ; preds = %308
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %312
+ThrowNullRef2:                                    ; preds = %312
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %315
+ThrowNullRef4:                                    ; preds = %315
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %321
+ThrowNullRef6:                                    ; preds = %321
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %271
+ThrowNullRef8:                                    ; preds = %271
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %275
+ThrowNullRef10:                                   ; preds = %275
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %278
+ThrowNullRef12:                                   ; preds = %278
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %284
+ThrowNullRef14:                                   ; preds = %284
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %287
+ThrowNullRef16:                                   ; preds = %287
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %293
+ThrowNullRef18:                                   ; preds = %293
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %298
+ThrowNullRef20:                                   ; preds = %298
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %303
+ThrowNullRef22:                                   ; preds = %303
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %243
+ThrowNullRef24:                                   ; preds = %243
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %247
+ThrowNullRef26:                                   ; preds = %247
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %250
+ThrowNullRef28:                                   ; preds = %250
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %256
+ThrowNullRef30:                                   ; preds = %256
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %259
+ThrowNullRef32:                                   ; preds = %259
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %265
+ThrowNullRef34:                                   ; preds = %265
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %217
+ThrowNullRef36:                                   ; preds = %217
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %221
+ThrowNullRef38:                                   ; preds = %221
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %224
+ThrowNullRef40:                                   ; preds = %224
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %230
+ThrowNullRef42:                                   ; preds = %230
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %233
+ThrowNullRef44:                                   ; preds = %233
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %238
+ThrowNullRef46:                                   ; preds = %238
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %200
+ThrowNullRef48:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %204
+ThrowNullRef50:                                   ; preds = %204
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %207
+ThrowNullRef52:                                   ; preds = %207
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %213
+ThrowNullRef54:                                   ; preds = %213
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %172
+ThrowNullRef56:                                   ; preds = %172
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %176
+ThrowNullRef58:                                   ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %179
+ThrowNullRef60:                                   ; preds = %179
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %185
+ThrowNullRef62:                                   ; preds = %185
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %190
+ThrowNullRef64:                                   ; preds = %190
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %195
+ThrowNullRef66:                                   ; preds = %195
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %153
+ThrowNullRef68:                                   ; preds = %153
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %157
+ThrowNullRef70:                                   ; preds = %157
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %160
+ThrowNullRef72:                                   ; preds = %160
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %166
+ThrowNullRef74:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %136
+ThrowNullRef76:                                   ; preds = %136
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %140
+ThrowNullRef78:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %143
+ThrowNullRef80:                                   ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %148
+ThrowNullRef82:                                   ; preds = %148
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %128
+ThrowNullRef84:                                   ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %132
+ThrowNullRef86:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %100
+ThrowNullRef88:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %104
+ThrowNullRef90:                                   ; preds = %104
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %107
+ThrowNullRef92:                                   ; preds = %107
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %113
+ThrowNullRef94:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %118
+ThrowNullRef96:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %123
+ThrowNullRef98:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %81
+ThrowNullRef100:                                  ; preds = %81
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef101:                                  ; preds = %85
+ThrowNullRef102:                                  ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef103:                                  ; preds = %88
+ThrowNullRef104:                                  ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef105:                                  ; preds = %94
+ThrowNullRef106:                                  ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef107:                                  ; preds = %64
+ThrowNullRef108:                                  ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef109:                                  ; preds = %68
+ThrowNullRef110:                                  ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef111:                                  ; preds = %71
+ThrowNullRef112:                                  ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef113:                                  ; preds = %76
+ThrowNullRef114:                                  ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef115:                                  ; preds = %56
+ThrowNullRef116:                                  ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef117:                                  ; preds = %60
+ThrowNullRef118:                                  ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef119:                                  ; preds = %37
+ThrowNullRef120:                                  ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef121:                                  ; preds = %41
+ThrowNullRef122:                                  ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef123:                                  ; preds = %46
+ThrowNullRef124:                                  ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef125:                                  ; preds = %51
+ThrowNullRef126:                                  ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef127:                                  ; preds = %27
+ThrowNullRef128:                                  ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef129:                                  ; preds = %31
+ThrowNullRef130:                                  ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef131:                                  ; preds = %19
+ThrowNullRef132:                                  ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef133:                                  ; preds = %22
+ThrowNullRef134:                                  ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef135:                                  ; preds = %338
+ThrowNullRef136:                                  ; preds = %338
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef137:                                  ; preds = %341
+ThrowNullRef138:                                  ; preds = %341
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef139:                                  ; preds = %356
+ThrowNullRef140:                                  ; preds = %356
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef141:                                  ; preds = %360
+ThrowNullRef142:                                  ; preds = %360
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef143:                                  ; preds = %377
+ThrowNullRef144:                                  ; preds = %377
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef145:                                  ; preds = %381
+ThrowNullRef146:                                  ; preds = %381
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef147:                                  ; preds = %424
+ThrowNullRef148:                                  ; preds = %424
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef149:                                  ; preds = %428
+ThrowNullRef150:                                  ; preds = %428
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef151:                                  ; preds = %440
+ThrowNullRef152:                                  ; preds = %440
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef153:                                  ; preds = %444
+ThrowNullRef154:                                  ; preds = %444
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef155:                                  ; preds = %456
+ThrowNullRef156:                                  ; preds = %456
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef157:                                  ; preds = %460
+ThrowNullRef158:                                  ; preds = %460
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef159:                                  ; preds = %474
+ThrowNullRef160:                                  ; preds = %474
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef161:                                  ; preds = %477
+ThrowNullRef162:                                  ; preds = %477
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef163:                                  ; preds = %394
+ThrowNullRef164:                                  ; preds = %394
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef165:                                  ; preds = %398
+ThrowNullRef166:                                  ; preds = %398
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef167:                                  ; preds = %401
+ThrowNullRef168:                                  ; preds = %401
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef169:                                  ; preds = %407
+ThrowNullRef170:                                  ; preds = %407
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1939,8 +2021,8 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
-  br i1 %NullCheck, label %22, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %ThrowNullRef, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
@@ -1948,8 +2030,8 @@ entry:
   store i32 %24, i32* %loc0
   %25 = load i32, i32* %loc0
   %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %26, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %27
 
 ; <label>:27                                      ; preds = %22
   %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
@@ -1971,7 +2053,7 @@ ThrowNullRef:                                     ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1989,8 +2071,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -2022,15 +2104,15 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2048,16 +2130,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
   %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
   store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %15
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
@@ -2072,8 +2154,8 @@ entry:
   %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
   %29 = ptrtoint i16 addrspace(1)* %28 to i64
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %19
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
@@ -2089,19 +2171,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2114,8 +2196,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
@@ -2128,7 +2210,7 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[loadElem]
+Failed to read AppDomain.PrepareDataForSetup[storeElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
@@ -2202,8 +2284,8 @@ entry:
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
-  br i1 %NullCheck24, label %27, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = load i64, i64 addrspace(1)* %26
@@ -2218,8 +2300,8 @@ entry:
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
-  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
   %41 = load i64, i64 addrspace(1)* %39
@@ -2236,8 +2318,8 @@ entry:
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
-  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
   %54 = load i64, i64 addrspace(1)* %52
@@ -2252,8 +2334,8 @@ entry:
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
   %67 = load i64, i64 addrspace(1)* %65
@@ -2270,8 +2352,8 @@ entry:
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
-  br i1 %NullCheck16, label %79, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
   %80 = load i64, i64 addrspace(1)* %78
@@ -2286,8 +2368,8 @@ entry:
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
-  br i1 %NullCheck18, label %92, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
   %93 = load i64, i64 addrspace(1)* %91
@@ -2304,8 +2386,8 @@ entry:
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
-  br i1 %NullCheck12, label %105, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = load i64, i64 addrspace(1)* %104
@@ -2320,8 +2402,8 @@ entry:
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
-  br i1 %NullCheck14, label %118, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
   %119 = load i64, i64 addrspace(1)* %117
@@ -2337,8 +2419,8 @@ entry:
 
 ; <label>:128                                     ; preds = %20
   %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
-  br i1 %NullCheck4, label %130, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %129, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %130
 
 ; <label>:130                                     ; preds = %128
   %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
@@ -2346,8 +2428,8 @@ entry:
   %133 = load i16, i16 addrspace(1)* %132, align 8
   %134 = zext i16 %133 to i32
   %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
-  br i1 %NullCheck6, label %136, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %135, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %136
 
 ; <label>:136                                     ; preds = %130
   %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
@@ -2360,8 +2442,8 @@ entry:
 
 ; <label>:143                                     ; preds = %136
   %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
-  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %144, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %145
 
 ; <label>:145                                     ; preds = %143
   %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
@@ -2369,8 +2451,8 @@ entry:
   %148 = load i16, i16 addrspace(1)* %147, align 8
   %149 = zext i16 %148 to i32
   %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %150, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %151
 
 ; <label>:151                                     ; preds = %145
   %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
@@ -2388,8 +2470,8 @@ entry:
 
 ; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
-  br i1 %NullCheck, label %163, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %ThrowNullRef, label %163
 
 ; <label>:163                                     ; preds = %161
   %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
@@ -2399,8 +2481,8 @@ entry:
 
 ; <label>:167                                     ; preds = %163
   %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
-  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %168, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %169
 
 ; <label>:169                                     ; preds = %167
   %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
@@ -2432,55 +2514,55 @@ ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %167
+ThrowNullRef2:                                    ; preds = %167
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %128
+ThrowNullRef4:                                    ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %130
+ThrowNullRef6:                                    ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %143
+ThrowNullRef8:                                    ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %145
+ThrowNullRef10:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %102
+ThrowNullRef12:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %105
+ThrowNullRef14:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %76
+ThrowNullRef16:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %79
+ThrowNullRef18:                                   ; preds = %79
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %50
+ThrowNullRef20:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %53
+ThrowNullRef22:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %24
+ThrowNullRef24:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %27
+ThrowNullRef26:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2503,15 +2585,15 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2519,16 +2601,16 @@ entry:
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
   store i32 %8, i32* %loc0
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
   %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
   store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
@@ -2546,16 +2628,16 @@ entry:
 
 ; <label>:23                                      ; preds = %64
   %24 = load i16*, i16** %loc3
-  %NullCheck12 = icmp ne i16* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i16* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
   store i32 %27, i32* %loc5
   %28 = load i16*, i16** %loc4
-  %NullCheck14 = icmp ne i16* %28, null
-  br i1 %NullCheck14, label %29, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %28, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = load i16, i16* %28, align 8
@@ -2620,15 +2702,15 @@ entry:
 
 ; <label>:67                                      ; preds = %64
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
-  br i1 %NullCheck8, label %69, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %68, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %69
 
 ; <label>:69                                      ; preds = %67
   %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
   %71 = load i32, i32 addrspace(1)* %70
   %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
-  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %73
 
 ; <label>:73                                      ; preds = %69
   %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
@@ -2645,31 +2727,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %67
+ThrowNullRef8:                                    ; preds = %67
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %69
+ThrowNullRef10:                                   ; preds = %69
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2710,14 +2792,14 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
   %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
@@ -2730,14 +2812,14 @@ entry:
 
 ; <label>:11                                      ; preds = %4
   %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
   %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
@@ -2749,14 +2831,14 @@ entry:
 
 ; <label>:22                                      ; preds = %16
   %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
   %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
-  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
-  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
@@ -2804,23 +2886,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2836,7 +2918,280 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[loadElem]
+Successfully read RuntimeType.IsAssignableFrom
+
+define i8 @RuntimeType.IsAssignableFrom(%System.RuntimeType addrspace(1)* %param0, %System.Type addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.RuntimeType addrspace(1)*
+  %arg1 = alloca %System.Type addrspace(1)*
+  %loc0 = alloca %System.RuntimeType addrspace(1)*
+  %loc1 = alloca %"System.Type[]" addrspace(1)*
+  %loc2 = alloca i32
+  store %System.RuntimeType addrspace(1)* %param0, %System.RuntimeType addrspace(1)** %this
+  store %System.Type addrspace(1)* %param1, %System.Type addrspace(1)** %arg1
+  %0 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %1 = icmp ne %System.Type addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i8 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %5 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %6 = bitcast %System.Type addrspace(1)* %4 to %System.Object addrspace(1)*
+  %7 = bitcast %System.RuntimeType addrspace(1)* %5 to %System.Object addrspace(1)*
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %6, %System.Object addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %3
+  ret i8 1
+
+; <label>:12                                      ; preds = %3
+  %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 152
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 32
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
+  %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
+  %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
+  store %System.RuntimeType addrspace(1)* %25, %System.RuntimeType addrspace(1)** %loc0
+  %26 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %27 = icmp eq %System.RuntimeType addrspace(1)* %26, null
+  br i1 %27, label %34, label %28
+
+; <label>:28                                      ; preds = %15
+  %29 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %30 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)*)*)(%System.RuntimeType addrspace(1)* %29, %System.RuntimeType addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+; <label>:34                                      ; preds = %15
+  %35 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %36 = call %System.Reflection.Emit.TypeBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Reflection.Emit.TypeBuilder addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %35)
+  %37 = icmp eq %System.Reflection.Emit.TypeBuilder addrspace(1)* %36, null
+  br i1 %37, label %139, label %38
+
+; <label>:38                                      ; preds = %34
+  %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %42
+
+; <label>:42                                      ; preds = %38
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 152
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 40
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
+  %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
+  %53 = zext i8 %52 to i32
+  %54 = icmp eq i32 %53, 0
+  br i1 %54, label %56, label %55
+
+; <label>:55                                      ; preds = %42
+  ret i8 1
+
+; <label>:56                                      ; preds = %42
+  %57 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %58 = bitcast %System.RuntimeType addrspace(1)* %57 to %System.Type addrspace(1)*
+  %59 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %58)
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %64 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.Type addrspace(1)* %63, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = bitcast %System.RuntimeType addrspace(1)* %64 to %System.Type addrspace(1)*
+  %67 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %63, %System.Type addrspace(1)* %66)
+  %68 = zext i8 %67 to i32
+  %69 = trunc i32 %68 to i8
+  ret i8 %69
+
+; <label>:70                                      ; preds = %56
+  %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
+  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %73
+
+; <label>:73                                      ; preds = %70
+  %74 = load i64, i64 addrspace(1)* %72
+  %75 = add i64 %74, 128
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = add i64 %77, 0
+  %79 = inttoptr i64 %78 to i64*
+  %80 = load i64, i64* %79
+  %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
+  %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
+  %83 = call i8 %82(%System.Type addrspace(1)* %81)
+  %84 = zext i8 %83 to i32
+  %85 = icmp eq i32 %84, 0
+  br i1 %85, label %139, label %86
+
+; <label>:86                                      ; preds = %73
+  %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
+  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %89
+
+; <label>:89                                      ; preds = %86
+  %90 = load i64, i64 addrspace(1)* %88
+  %91 = add i64 %90, 128
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = add i64 %93, 24
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
+  %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
+  %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
+  store %"System.Type[]" addrspace(1)* %99, %"System.Type[]" addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %129
+
+; <label>:100                                     ; preds = %132
+  %101 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %102 = load i32, i32* %loc2
+  %NullCheck11 = icmp eq %"System.Type[]" addrspace(1)* %101, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %103
+
+; <label>:103                                     ; preds = %100
+  %104 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 1
+  %105 = load i32, i32 addrspace(1)* %104
+  %106 = zext i32 %105 to i64
+  %107 = zext i32 %102 to i64
+  %BoundsCheck = icmp uge i64 %107, %106
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %108
+
+; <label>:108                                     ; preds = %103
+  %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
+  %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
+  %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
+  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %113
+
+; <label>:113                                     ; preds = %108
+  %114 = load i64, i64 addrspace(1)* %112
+  %115 = add i64 %114, 152
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = add i64 %117, 56
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
+  %123 = zext i8 %122 to i32
+  %124 = icmp ne i32 %123, 0
+  br i1 %124, label %126, label %125
+
+; <label>:125                                     ; preds = %113
+  ret i8 0
+
+; <label>:126                                     ; preds = %113
+  %127 = load i32, i32* %loc2
+  %128 = add i32 %127, 1
+  store i32 %128, i32* %loc2
+  br label %129
+
+; <label>:129                                     ; preds = %89, %126
+  %130 = load i32, i32* %loc2
+  %131 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %NullCheck9 = icmp eq %"System.Type[]" addrspace(1)* %131, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %132
+
+; <label>:132                                     ; preds = %129
+  %133 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %131, i32 0, i32 1
+  %134 = load i32, i32 addrspace(1)* %133
+  %135 = zext i32 %134 to i64
+  %136 = trunc i64 %135 to i32
+  %137 = icmp slt i32 %130, %136
+  br i1 %137, label %100, label %138
+
+; <label>:138                                     ; preds = %132
+  ret i8 1
+
+; <label>:139                                     ; preds = %34, %73
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %129
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %103
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -2893,7 +3248,7 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElem]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -2904,8 +3259,8 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -2997,8 +3352,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
@@ -3059,8 +3414,8 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -3087,8 +3442,8 @@ entry:
 
 ; <label>:17                                      ; preds = %5, %11
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
@@ -3097,8 +3452,8 @@ entry:
 
 ; <label>:22                                      ; preds = %1, %11
   %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
@@ -3109,11 +3464,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %17
+ThrowNullRef2:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %22
+ThrowNullRef4:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3167,15 +3522,15 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
   %15 = load i32, i32 addrspace(1)* %14
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
@@ -3198,7 +3553,7 @@ ThrowNullRef:                                     ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef2:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3232,8 +3587,8 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
@@ -3312,8 +3667,8 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -3327,8 +3682,8 @@ entry:
 ; <label>:5                                       ; preds = %43
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %7 = load i32, i32* %loc1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck6, label %8, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
@@ -3366,8 +3721,8 @@ entry:
 ; <label>:32                                      ; preds = %21, %25
   %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
   %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
-  br i1 %NullCheck8, label %35, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = trunc i32 %34 to i16
@@ -3380,8 +3735,8 @@ entry:
 ; <label>:40                                      ; preds = %1, %35
   %41 = load i32, i32* %loc1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
-  br i1 %NullCheck2, label %43, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %42, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
@@ -3392,8 +3747,8 @@ entry:
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
   %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
-  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
   %51 = load i64, i64 addrspace(1)* %49
@@ -3412,19 +3767,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %40
+ThrowNullRef2:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %47
+ThrowNullRef4:                                    ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %5
+ThrowNullRef6:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %32
+ThrowNullRef8:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3467,8 +3822,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
@@ -3492,11 +3847,391 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(i16* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store i16* %param0, i16** %arg0
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load i32, i32* %arg3
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %42, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %37, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg2
+  %13 = load i32, i32* %arg3
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %37, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %24 = load i32, i32* %arg2
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load i16*, i16** %arg0
+  %35 = load i32, i32* %arg3
+  %36 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %36, i16* %34, i32 %35)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:37                                      ; preds = %5, %16
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %39)
+  %41 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41, %System.String addrspace(1)* %38, %System.String addrspace(1)* %40)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41) #0
+  unreachable
+
+; <label>:42                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
-Failed to read StringBuilder.ToString[loadElemA]
+Successfully read StringBuilder.ToString
+
+define %System.String addrspace(1)* @StringBuilder.ToString(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i16*
+  %loc3 = alloca %"System.Char[]" addrspace(1)*
+  %loc4 = alloca i32
+  %loc5 = alloca i32
+  %loc6 = alloca i16 addrspace(1)*
+  %loc7 = alloca %System.String addrspace(1)*
+  %loc8 = alloca %"System.Char[]" addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %0)
+  %2 = icmp ne i32 %1, 0
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %4
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %6)
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %7)
+  store %System.String addrspace(1)* %8, %System.String addrspace(1)** %loc0
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.Text.StringBuilder addrspace(1)* %9, %System.Text.StringBuilder addrspace(1)** %loc1
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  store %System.String addrspace(1)* %10, %System.String addrspace(1)** %loc7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc7
+  %12 = ptrtoint %System.String addrspace(1)* %11 to i64
+  %13 = icmp eq i64 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %5
+  %15 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %16 = sext i32 %15 to i64
+  %17 = add i64 %12, %16
+  br label %18
+
+; <label>:18                                      ; preds = %5, %14
+  %19 = phi i64 [ %12, %5 ], [ %17, %14 ]
+  %20 = inttoptr i64 %19 to i16*
+  store i16* %20, i16** %loc2
+  br label %21
+
+; <label>:21                                      ; preds = %98, %18
+  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %22, null
+  br i1 %NullCheck, label %ThrowNullRef, label %23
+
+; <label>:23                                      ; preds = %21
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 3
+  %25 = load i32, i32 addrspace(1)* %24, align 8
+  %26 = icmp sle i32 %25, 0
+  br i1 %26, label %96, label %27
+
+; <label>:27                                      ; preds = %23
+  %28 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %28, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %29
+
+; <label>:29                                      ; preds = %27
+  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %28, i32 0, i32 1
+  %31 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %30, align 8
+  store %"System.Char[]" addrspace(1)* %31, %"System.Char[]" addrspace(1)** %loc3
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %33
+
+; <label>:33                                      ; preds = %29
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  store i32 %35, i32* %loc4
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  %39 = load i32, i32 addrspace(1)* %38, align 8
+  store i32 %39, i32* %loc5
+  %40 = load i32, i32* %loc5
+  %41 = load i32, i32* %loc4
+  %42 = add i32 %40, %41
+  %43 = zext i32 %42 to i64
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %45
+
+; <label>:45                                      ; preds = %37
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = sext i32 %47 to i64
+  %49 = icmp sgt i64 %43, %48
+  br i1 %49, label %91, label %50
+
+; <label>:50                                      ; preds = %45
+  %51 = load i32, i32* %loc5
+  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %52, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %53
+
+; <label>:53                                      ; preds = %50
+  %54 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %52, i32 0, i32 1
+  %55 = load i32, i32 addrspace(1)* %54
+  %56 = zext i32 %55 to i64
+  %57 = trunc i64 %56 to i32
+  %58 = icmp ugt i32 %51, %57
+  br i1 %58, label %91, label %59
+
+; <label>:59                                      ; preds = %53
+  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  store %"System.Char[]" addrspace(1)* %60, %"System.Char[]" addrspace(1)** %loc8
+  %61 = icmp eq %"System.Char[]" addrspace(1)* %60, null
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %63, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %64
+
+; <label>:64                                      ; preds = %62
+  %65 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %63, i32 0, i32 1
+  %66 = load i32, i32 addrspace(1)* %65
+  %67 = zext i32 %66 to i64
+  %68 = trunc i64 %67 to i32
+  %69 = icmp ne i32 %68, 0
+  br i1 %69, label %71, label %70
+
+; <label>:70                                      ; preds = %59, %64
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:71                                      ; preds = %64
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %73
+
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %BoundsCheck = icmp uge i64 0, %76
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %77
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %78, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:79                                      ; preds = %70, %77
+  %80 = load i16*, i16** %loc2
+  %81 = load i32, i32* %loc4
+  %82 = sext i32 %81 to i64
+  %83 = mul i64 %82, 2
+  %84 = bitcast i16* %80 to i8*
+  %85 = getelementptr inbounds i8, i8* %84, i64 %83
+  %86 = load i16 addrspace(1)*, i16 addrspace(1)** %loc6
+  %87 = ptrtoint i16 addrspace(1)* %86 to i64
+  %88 = load i32, i32* %loc5
+  %89 = bitcast i8* %85 to i16*
+  %90 = inttoptr i64 %87 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %89, i16* %90, i32 %88)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %96
+
+; <label>:91                                      ; preds = %45, %53
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %94 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %93)
+  %95 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95, %System.String addrspace(1)* %92, %System.String addrspace(1)* %94)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95) #0
+  unreachable
+
+; <label>:96                                      ; preds = %23, %79
+  %97 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %97, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %98
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %97, i32 0, i32 2
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  store %System.Text.StringBuilder addrspace(1)* %100, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %102 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %102, label %21, label %103
+
+; <label>:103                                     ; preds = %98
+  store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc7
+  %104 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  ret %System.String addrspace(1)* %104
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method StringBuilder::get_Length using LLILCJit
+Successfully read StringBuilder.get_Length
+
+define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
+Successfully read RuntimeHelpers.get_OffsetToStringData
+
+define i32 @RuntimeHelpers.get_OffsetToStringData() {
+entry:
+  ret i32 12
+}
+
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
 Successfully read CultureData.CreateCultureData
 
@@ -3514,23 +4249,23 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
   store i8 %4, i8 addrspace(1)* %6
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
@@ -3549,11 +4284,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3566,50 +4301,50 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
   store i32 -1, i32 addrspace(1)* %2
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
   store i32 -1, i32 addrspace(1)* %8
   %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
   store i32 -1, i32 addrspace(1)* %14
   %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
   store i32 -1, i32 addrspace(1)* %17
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
@@ -3623,27 +4358,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3675,7 +4410,136 @@ Failed to read Dictionary`2.Insert[non-const derefAddress]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
 Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
-Failed to read HashHelpers.GetPrime[loadElem]
+Successfully read HashHelpers.GetPrime
+
+define i32 @HashHelpers.GetPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %6, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5, %System.String addrspace(1)* %4)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5) #0
+  unreachable
+
+; <label>:6                                       ; preds = %entry
+  store i32 0, i32* %loc0
+  br label %29
+
+; <label>:7                                       ; preds = %35
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 1296
+  %10 = addrspacecast i8 addrspace(1)* %9 to %"System.Int32[]" addrspace(1)**
+  %11 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %10
+  %12 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Int32[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = zext i32 %15 to i64
+  %17 = zext i32 %12 to i64
+  %BoundsCheck = icmp uge i64 %17, %16
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 3, i32 %12
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  store i32 %20, i32* %loc1
+  %21 = load i32, i32* %loc1
+  %22 = load i32, i32* %arg0
+  %23 = icmp slt i32 %21, %22
+  br i1 %23, label %26, label %24
+
+; <label>:24                                      ; preds = %18
+  %25 = load i32, i32* %loc1
+  ret i32 %25
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %loc0
+  %28 = add i32 %27, 1
+  store i32 %28, i32* %loc0
+  br label %29
+
+; <label>:29                                      ; preds = %6, %26
+  %30 = load i32, i32* %loc0
+  %31 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %32 = getelementptr inbounds i8, i8 addrspace(1)* %31, i64 1296
+  %33 = addrspacecast i8 addrspace(1)* %32 to %"System.Int32[]" addrspace(1)**
+  %34 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %33
+  %NullCheck = icmp eq %"System.Int32[]" addrspace(1)* %34, null
+  br i1 %NullCheck, label %ThrowNullRef, label %35
+
+; <label>:35                                      ; preds = %29
+  %36 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %34, i32 0, i32 1
+  %37 = load i32, i32 addrspace(1)* %36
+  %38 = zext i32 %37 to i64
+  %39 = trunc i64 %38 to i32
+  %40 = icmp slt i32 %30, %39
+  br i1 %40, label %7, label %41
+
+; <label>:41                                      ; preds = %35
+  %42 = load i32, i32* %arg0
+  %43 = or i32 %42, 1
+  store i32 %43, i32* %loc2
+  br label %59
+
+; <label>:44                                      ; preds = %59
+  %45 = load i32, i32* %loc2
+  %46 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %45)
+  %47 = zext i8 %46 to i32
+  %48 = icmp eq i32 %47, 0
+  br i1 %48, label %56, label %49
+
+; <label>:49                                      ; preds = %44
+  %50 = load i32, i32* %loc2
+  %51 = sub i32 %50, 1
+  %52 = srem i32 %51, 101
+  %53 = icmp eq i32 %52, 0
+  br i1 %53, label %56, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = load i32, i32* %loc2
+  ret i32 %55
+
+; <label>:56                                      ; preds = %44, %49
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %57, 2
+  store i32 %58, i32* %loc2
+  br label %59
+
+; <label>:59                                      ; preds = %41, %56
+  %60 = load i32, i32* %loc2
+  %61 = icmp slt i32 %60, 2147483647
+  br i1 %61, label %44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load i32, i32* %arg0
+  ret i32 %63
+
+ThrowNullRef:                                     ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
 Successfully read GenericEqualityComparer`1.GetHashCode
 
@@ -3694,14 +4558,14 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
   %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load i64, i64 addrspace(1)* %7
@@ -3720,7 +4584,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3750,8 +4614,8 @@ entry:
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
@@ -3796,8 +4660,8 @@ entry:
   %35 = bitcast i16* %34 to i8*
   %36 = getelementptr inbounds i8, i8* %35, i64 2
   %37 = bitcast i8* %36 to i16*
-  %NullCheck4 = icmp ne i16* %37, null
-  br i1 %NullCheck4, label %38, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %37, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %38
 
 ; <label>:38                                      ; preds = %27
   %39 = load i16, i16* %37, align 8
@@ -3824,8 +4688,8 @@ entry:
 
 ; <label>:54                                      ; preds = %22, %43
   %55 = load i16*, i16** %loc4
-  %NullCheck2 = icmp ne i16* %55, null
-  br i1 %NullCheck2, label %56, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i16* %55, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %56
 
 ; <label>:56                                      ; preds = %54
   %57 = load i16, i16* %55, align 8
@@ -3850,11 +4714,11 @@ ThrowNullRef:                                     ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %54
+ThrowNullRef2:                                    ; preds = %54
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %27
+ThrowNullRef4:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3871,8 +4735,8 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -3907,8 +4771,8 @@ entry:
 
 ; <label>:26                                      ; preds = %19
   %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
-  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %28
 
 ; <label>:28                                      ; preds = %26
   %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
@@ -3920,7 +4784,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3972,8 +4836,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
@@ -3984,26 +4848,26 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
-  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
@@ -4014,8 +4878,8 @@ entry:
 ; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
@@ -4024,8 +4888,8 @@ entry:
 
 ; <label>:25                                      ; preds = %1, %16, %23
   %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
-  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
@@ -4036,27 +4900,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %20
+ThrowNullRef10:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4069,8 +4933,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -4081,8 +4945,8 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
@@ -4091,8 +4955,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1, %8
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
@@ -4103,11 +4967,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4128,24 +4992,24 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   store i32 %3, i32* %loc0
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
   %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
   store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck4, label %9, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
@@ -4164,15 +5028,15 @@ entry:
 ; <label>:18                                      ; preds = %70
   %19 = load i16*, i16** %loc3
   %20 = bitcast i16* %19 to i64*
-  %NullCheck10 = icmp ne i64* %20, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %20, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = load i64, i64* %20, align 8
   %23 = load i16*, i16** %loc4
   %24 = bitcast i16* %23 to i64*
-  %NullCheck12 = icmp ne i64* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = load i64, i64* %24, align 8
@@ -4188,8 +5052,8 @@ entry:
   %31 = bitcast i16* %30 to i8*
   %32 = getelementptr inbounds i8, i8* %31, i64 8
   %33 = bitcast i8* %32 to i64*
-  %NullCheck14 = icmp ne i64* %33, null
-  br i1 %NullCheck14, label %34, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = load i64, i64* %33, align 8
@@ -4197,8 +5061,8 @@ entry:
   %37 = bitcast i16* %36 to i8*
   %38 = getelementptr inbounds i8, i8* %37, i64 8
   %39 = bitcast i8* %38 to i64*
-  %NullCheck16 = icmp ne i64* %39, null
-  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %40
 
 ; <label>:40                                      ; preds = %34
   %41 = load i64, i64* %39, align 8
@@ -4214,8 +5078,8 @@ entry:
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %NullCheck18 = icmp ne i64* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = load i64, i64* %48, align 8
@@ -4223,8 +5087,8 @@ entry:
   %52 = bitcast i16* %51 to i8*
   %53 = getelementptr inbounds i8, i8* %52, i64 16
   %54 = bitcast i8* %53 to i64*
-  %NullCheck20 = icmp ne i64* %54, null
-  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64* %54, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %55
 
 ; <label>:55                                      ; preds = %49
   %56 = load i64, i64* %54, align 8
@@ -4262,15 +5126,15 @@ entry:
 ; <label>:74                                      ; preds = %95
   %75 = load i16*, i16** %loc3
   %76 = bitcast i16* %75 to i32*
-  %NullCheck6 = icmp ne i32* %76, null
-  br i1 %NullCheck6, label %77, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32* %76, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %77
 
 ; <label>:77                                      ; preds = %74
   %78 = load i32, i32* %76, align 8
   %79 = load i16*, i16** %loc4
   %80 = bitcast i16* %79 to i32*
-  %NullCheck8 = icmp ne i32* %80, null
-  br i1 %NullCheck8, label %81, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i32* %80, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %81
 
 ; <label>:81                                      ; preds = %77
   %82 = load i32, i32* %80, align 8
@@ -4318,43 +5182,43 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %74
+ThrowNullRef6:                                    ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %77
+ThrowNullRef8:                                    ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %29
+ThrowNullRef14:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %34
+ThrowNullRef16:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4376,8 +5240,8 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load i64, i64 addrspace(1)* %4
@@ -4389,8 +5253,8 @@ entry:
   %12 = load i64, i64* %11
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %5
   %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
@@ -4399,8 +5263,8 @@ entry:
   %18 = load i8, i8* %arg2
   %19 = zext i8 %18 to i32
   %20 = trunc i32 %19 to i8
-  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %15
   %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
@@ -4411,11 +5275,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4442,8 +5306,8 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
@@ -4466,16 +5330,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
   %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = load i64, i64 addrspace(1)* %19
@@ -4500,8 +5364,8 @@ entry:
 ; <label>:35                                      ; preds = %30
   %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
@@ -4514,8 +5378,8 @@ entry:
 
 ; <label>:42                                      ; preds = %1, %38
   %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
-  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
@@ -4526,19 +5390,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %35
+ThrowNullRef2:                                    ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %42
+ThrowNullRef8:                                    ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4551,14 +5415,14 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
@@ -4570,7 +5434,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4583,8 +5447,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
@@ -4613,51 +5477,51 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
   %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
   %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
   %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
   %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
-  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
   store i64 %21, i64 addrspace(1)* %23
   %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %25 = load i64, i64* %loc0
-  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
@@ -4668,27 +5532,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %22
+ThrowNullRef12:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4701,8 +5565,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
@@ -4713,19 +5577,19 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
@@ -4734,8 +5598,8 @@ entry:
 
 ; <label>:15                                      ; preds = %1, %13
   %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
@@ -4746,19 +5610,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %15
+ThrowNullRef8:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4771,8 +5635,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -4831,8 +5695,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
@@ -4882,8 +5746,8 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
-  br i1 %NullCheck, label %17, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %ThrowNullRef, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
@@ -4894,15 +5758,15 @@ entry:
 
 ; <label>:22                                      ; preds = %17
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
-  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
   %26 = load i32, i32 addrspace(1)* %25
   %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
-  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %27, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
@@ -4925,8 +5789,8 @@ entry:
 ; <label>:40                                      ; preds = %17
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
-  br i1 %NullCheck6, label %43, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %41, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
@@ -4938,34 +5802,17 @@ ThrowNullRef:                                     ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %24
+ThrowNullRef4:                                    ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %40
+ThrowNullRef6:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
-}
-
-INFO:  jitting method Object::ReferenceEquals using LLILCJit
-Successfully read Object.ReferenceEquals
-
-define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
-entry:
-  %arg0 = alloca %System.Object addrspace(1)*
-  %arg1 = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
-  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
-  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = icmp eq %System.Object addrspace(1)* %0, %1
-  %3 = sext i1 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
 }
 
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
@@ -4978,21 +5825,21 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
   %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
-  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
@@ -5007,28 +5854,28 @@ entry:
 ; <label>:13                                      ; preds = %8, %12
   %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
   %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
   %21 = load i32, i32 addrspace(1)* %20, align 8
   %22 = add i32 %21, 1
-  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
   store i32 %22, i32 addrspace(1)* %24
   %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
@@ -5039,27 +5886,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5077,7 +5924,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::Setup using LLILCJit
-Failed to read AppDomain.Setup[loadElem]
+Failed to read AppDomain.Setup[unbox]
 INFO:  jitting method Thread::GetDomain using LLILCJit
 Successfully read Thread.GetDomain
 
@@ -5108,8 +5955,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
@@ -5122,14 +5969,14 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
   %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
@@ -5141,11 +5988,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5173,8 +6020,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -5189,7 +6036,328 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
 Failed to read KeyCollection.System.Collections.Generic.IEnumerable<TKey>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Successfully read Enumerator.MoveNext
+
+define i8 @Enumerator.MoveNext(%"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.RuntimeTypeHandle* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*
+  %"$TypeArg" = alloca %System.RuntimeTypeHandle*
+  store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
+  %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 8
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %76, label %12
+
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
+  br label %76
+
+; <label>:13                                      ; preds = %85
+  %14 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck19 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %15
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, i32 0, i32 0
+  %17 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %16, align 8
+  %NullCheck21 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, i32 0, i32 2
+  %20 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %19, align 8
+  %21 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck23 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %22
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, i32 0, i32 2
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %NullCheck25 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 3, i32 %24
+  %NullCheck27 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %32
+
+; <label>:32                                      ; preds = %30
+  %33 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, i32 0, i32 2
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = icmp slt i32 %34, 0
+  br i1 %35, label %68, label %36
+
+; <label>:36                                      ; preds = %32
+  %37 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %38 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck29 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %39
+
+; <label>:39                                      ; preds = %36
+  %40 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, i32 0, i32 0
+  %41 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %40, align 8
+  %NullCheck31 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, i32 0, i32 2
+  %44 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %43, align 8
+  %45 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck33 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, i32 0, i32 2
+  %48 = load i32, i32 addrspace(1)* %47, align 8
+  %NullCheck35 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %49
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = zext i32 %51 to i64
+  %53 = zext i32 %48 to i64
+  %BoundsCheck37 = icmp uge i64 %53, %52
+  br i1 %BoundsCheck37, label %ThrowIndexOutOfRange38, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 3, i32 %48
+  %NullCheck39 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %56
+
+; <label>:56                                      ; preds = %54
+  %57 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, i32 0, i32 0
+  %58 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck41 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %59
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %60, %System.__Canon addrspace(1)* %58)
+  %61 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck43 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  %64 = load i32, i32 addrspace(1)* %63, align 8
+  %65 = add i32 %64, 1
+  %NullCheck45 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  store i32 %65, i32 addrspace(1)* %67
+  ret i8 1
+
+; <label>:68                                      ; preds = %32
+  %69 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck47 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %73 = add i32 %72, 1
+  %NullCheck49 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %74
+
+; <label>:74                                      ; preds = %70
+  %75 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  store i32 %73, i32 addrspace(1)* %75
+  br label %76
+
+; <label>:76                                      ; preds = %8, %12, %74
+  %77 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %78
+
+; <label>:78                                      ; preds = %76
+  %79 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, i32 0, i32 2
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck7 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %82
+
+; <label>:82                                      ; preds = %78
+  %83 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, i32 0, i32 0
+  %84 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %83, align 8
+  %NullCheck9 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %85
+
+; <label>:85                                      ; preds = %82
+  %86 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, i32 0, i32 7
+  %87 = load i32, i32 addrspace(1)* %86, align 8
+  %88 = icmp ult i32 %80, %87
+  br i1 %88, label %13, label %89
+
+; <label>:89                                      ; preds = %85
+  %90 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %91 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck11 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %92
+
+; <label>:92                                      ; preds = %89
+  %93 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, i32 0, i32 0
+  %94 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck13 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %95
+
+; <label>:95                                      ; preds = %92
+  %96 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, i32 0, i32 7
+  %97 = load i32, i32 addrspace(1)* %96, align 8
+  %98 = add i32 %97, 1
+  %NullCheck15 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %99
+
+; <label>:99                                      ; preds = %95
+  %100 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, i32 0, i32 2
+  store i32 %98, i32 addrspace(1)* %100
+  %101 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck17 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %102
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %103, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %92
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef22:                                   ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef24:                                   ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef26:                                   ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef28:                                   ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef30:                                   ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef32:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef34:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef36:                                   ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange38:                           ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef40:                                   ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef42:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef44:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef46:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef48:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef50:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -5200,8 +6368,8 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -5232,9 +6400,9 @@ Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
 Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
-Failed to read String.MakeSeparatorList[loadElemA]
+Failed to read String.MakeSeparatorList[storeElem]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
-Failed to read String.InternalSplitKeepEmptyEntries[loadElem]
+Failed to read String.InternalSplitKeepEmptyEntries[storeElem]
 INFO:  jitting method Path::IsRelative using LLILCJit
 Successfully read Path.IsRelative
 
@@ -5243,8 +6411,8 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -5254,8 +6422,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
@@ -5271,8 +6439,8 @@ entry:
 
 ; <label>:17                                      ; preds = %7
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
@@ -5288,8 +6456,8 @@ entry:
 
 ; <label>:29                                      ; preds = %19
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %31
 
 ; <label>:31                                      ; preds = %29
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
@@ -5300,8 +6468,8 @@ entry:
 
 ; <label>:36                                      ; preds = %31
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
-  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %37, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
@@ -5312,8 +6480,8 @@ entry:
 
 ; <label>:43                                      ; preds = %31, %38
   %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
-  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %45
 
 ; <label>:45                                      ; preds = %43
   %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
@@ -5324,8 +6492,8 @@ entry:
 
 ; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %50
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
@@ -5336,8 +6504,8 @@ entry:
 
 ; <label>:57                                      ; preds = %1, %7, %19, %45, %52
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
-  br i1 %NullCheck14, label %59, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %59
 
 ; <label>:59                                      ; preds = %57
   %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
@@ -5347,8 +6515,8 @@ entry:
 
 ; <label>:63                                      ; preds = %59
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
@@ -5359,8 +6527,8 @@ entry:
 
 ; <label>:70                                      ; preds = %65
   %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
-  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.String addrspace(1)* %71, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %72
 
 ; <label>:72                                      ; preds = %70
   %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
@@ -5379,39 +6547,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %17
+ThrowNullRef4:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %29
+ThrowNullRef6:                                    ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %36
+ThrowNullRef8:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %43
+ThrowNullRef10:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %50
+ThrowNullRef12:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %57
+ThrowNullRef14:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %63
+ThrowNullRef16:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %70
+ThrowNullRef18:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5419,7 +6587,293 @@ ThrowNullRef17:                                   ; preds = %70
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
-Failed to read String.TrimHelper[loadElem]
+Successfully read String.TrimHelper
+
+define %System.String addrspace(1)* @String.TrimHelper(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i16
+  %loc4 = alloca i32
+  %loc5 = alloca i16
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = sub i32 %3, 1
+  store i32 %4, i32* %loc0
+  store i32 0, i32* %loc1
+  %5 = load i32, i32* %arg2
+  %6 = icmp eq i32 %5, 1
+  br i1 %6, label %62, label %7
+
+; <label>:7                                       ; preds = %1
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:8                                       ; preds = %58
+  store i32 0, i32* %loc2
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load i32, i32* %loc1
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2, i32 %10
+  %13 = load i16, i16 addrspace(1)* %12
+  %14 = zext i16 %13 to i32
+  %15 = trunc i32 %14 to i16
+  store i16 %15, i16* %loc3
+  store i32 0, i32* %loc2
+  br label %34
+
+; <label>:16                                      ; preds = %37
+  %17 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %18 = load i32, i32* %loc2
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %17, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %19
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = zext i32 %18 to i64
+  %BoundsCheck = icmp uge i64 %23, %22
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %24
+
+; <label>:24                                      ; preds = %19
+  %25 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 3, i32 %18
+  %26 = load i16, i16 addrspace(1)* %25, align 8
+  %27 = zext i16 %26 to i32
+  %28 = load i16, i16* %loc3
+  %29 = zext i16 %28 to i32
+  %30 = icmp eq i32 %27, %29
+  br i1 %30, label %43, label %31
+
+; <label>:31                                      ; preds = %24
+  %32 = load i32, i32* %loc2
+  %33 = add i32 %32, 1
+  store i32 %33, i32* %loc2
+  br label %34
+
+; <label>:34                                      ; preds = %11, %31
+  %35 = load i32, i32* %loc2
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = icmp slt i32 %35, %41
+  br i1 %42, label %16, label %43
+
+; <label>:43                                      ; preds = %24, %37
+  %44 = load i32, i32* %loc2
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %45, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp eq i32 %44, %50
+  br i1 %51, label %62, label %52
+
+; <label>:52                                      ; preds = %46
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %7, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %57, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %58
+
+; <label>:58                                      ; preds = %55
+  %59 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %60 = load i32, i32 addrspace(1)* %59
+  %61 = icmp slt i32 %56, %60
+  br i1 %61, label %8, label %62
+
+; <label>:62                                      ; preds = %1, %46, %58
+  %63 = load i32, i32* %arg2
+  %64 = icmp eq i32 %63, 0
+  br i1 %64, label %122, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %66, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %67
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %66, i32 0, i32 1
+  %69 = load i32, i32 addrspace(1)* %68
+  %70 = sub i32 %69, 1
+  store i32 %70, i32* %loc0
+  br label %118
+
+; <label>:71                                      ; preds = %118
+  store i32 0, i32* %loc4
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %73 = load i32, i32* %loc0
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %74
+
+; <label>:74                                      ; preds = %71
+  %75 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 2, i32 %73
+  %76 = load i16, i16 addrspace(1)* %75
+  %77 = zext i16 %76 to i32
+  %78 = trunc i32 %77 to i16
+  store i16 %78, i16* %loc5
+  store i32 0, i32* %loc4
+  br label %97
+
+; <label>:79                                      ; preds = %100
+  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %81 = load i32, i32* %loc4
+  %NullCheck19 = icmp eq %"System.Char[]" addrspace(1)* %80, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
+
+; <label>:82                                      ; preds = %79
+  %83 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 1
+  %84 = load i32, i32 addrspace(1)* %83
+  %85 = zext i32 %84 to i64
+  %86 = zext i32 %81 to i64
+  %BoundsCheck21 = icmp uge i64 %86, %85
+  br i1 %BoundsCheck21, label %ThrowIndexOutOfRange22, label %87
+
+; <label>:87                                      ; preds = %82
+  %88 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 3, i32 %81
+  %89 = load i16, i16 addrspace(1)* %88, align 8
+  %90 = zext i16 %89 to i32
+  %91 = load i16, i16* %loc5
+  %92 = zext i16 %91 to i32
+  %93 = icmp eq i32 %90, %92
+  br i1 %93, label %106, label %94
+
+; <label>:94                                      ; preds = %87
+  %95 = load i32, i32* %loc4
+  %96 = add i32 %95, 1
+  store i32 %96, i32* %loc4
+  br label %97
+
+; <label>:97                                      ; preds = %74, %94
+  %98 = load i32, i32* %loc4
+  %99 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck15 = icmp eq %"System.Char[]" addrspace(1)* %99, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %100
+
+; <label>:100                                     ; preds = %97
+  %101 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %99, i32 0, i32 1
+  %102 = load i32, i32 addrspace(1)* %101
+  %103 = zext i32 %102 to i64
+  %104 = trunc i64 %103 to i32
+  %105 = icmp slt i32 %98, %104
+  br i1 %105, label %79, label %106
+
+; <label>:106                                     ; preds = %87, %100
+  %107 = load i32, i32* %loc4
+  %108 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck17 = icmp eq %"System.Char[]" addrspace(1)* %108, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %109
+
+; <label>:109                                     ; preds = %106
+  %110 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %108, i32 0, i32 1
+  %111 = load i32, i32 addrspace(1)* %110
+  %112 = zext i32 %111 to i64
+  %113 = trunc i64 %112 to i32
+  %114 = icmp eq i32 %107, %113
+  br i1 %114, label %122, label %115
+
+; <label>:115                                     ; preds = %109
+  %116 = load i32, i32* %loc0
+  %117 = sub i32 %116, 1
+  store i32 %117, i32* %loc0
+  br label %118
+
+; <label>:118                                     ; preds = %67, %115
+  %119 = load i32, i32* %loc0
+  %120 = load i32, i32* %loc1
+  %121 = icmp sge i32 %119, %120
+  br i1 %121, label %71, label %122
+
+; <label>:122                                     ; preds = %62, %109, %118
+  %123 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %124 = load i32, i32* %loc1
+  %125 = load i32, i32* %loc0
+  %126 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %123, i32 %124, i32 %125)
+  ret %System.String addrspace(1)* %126
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %97
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange22:                           ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
 Successfully read String.CreateTrimmedString
 
@@ -5439,8 +6893,8 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
@@ -5535,8 +6989,8 @@ entry:
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i64 2872
   %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
   %8 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %7
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %3
   %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
@@ -5553,8 +7007,8 @@ entry:
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 2864
   %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
   %21 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %20
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
-  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %22
 
 ; <label>:22                                      ; preds = %16
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
@@ -5569,7 +7023,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %16
+ThrowNullRef2:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5586,8 +7040,8 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5613,8 +7067,8 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
@@ -5632,8 +7086,8 @@ entry:
 
 ; <label>:12                                      ; preds = %4
   %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
@@ -5644,8 +7098,8 @@ entry:
 
 ; <label>:19                                      ; preds = %14
   %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %19
   %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
@@ -5660,21 +7114,21 @@ entry:
   %31 = zext i16 %30 to i32
   %32 = bitcast i8* %29 to i16*
   %33 = trunc i32 %31 to i16
-  %NullCheck6 = icmp ne i16* %32, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i16* %32, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %21
   store i16 %33, i16* %32, align 8
   %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %36
 
 ; <label>:36                                      ; preds = %34
   %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
   %38 = load i32, i32 addrspace(1)* %37, align 8
   %39 = add i32 %38, 1
-  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %40
 
 ; <label>:40                                      ; preds = %36
   %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
@@ -5683,16 +7137,16 @@ entry:
 
 ; <label>:42                                      ; preds = %14
   %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
-  br i1 %NullCheck12, label %44, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
   %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
   %47 = load i16, i16* %arg1
   %48 = zext i16 %47 to i32
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = trunc i32 %48 to i16
@@ -5703,31 +7157,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %19
+ThrowNullRef4:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %21
+ThrowNullRef6:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %36
+ThrowNullRef10:                                   ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %42
+ThrowNullRef12:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %44
+ThrowNullRef14:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5740,8 +7194,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -5752,8 +7206,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
@@ -5762,14 +7216,14 @@ entry:
 
 ; <label>:11                                      ; preds = %1
   %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
@@ -5779,15 +7233,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5808,8 +7262,8 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5822,8 +7276,8 @@ entry:
 
 ; <label>:8                                       ; preds = %3
   %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
@@ -5842,15 +7296,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
-  br i1 %NullCheck4, label %22, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
   %24 = load i16*, i16* addrspace(1)* %23, align 8
   %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %25, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
@@ -5859,8 +7313,8 @@ entry:
   store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
@@ -5874,8 +7328,8 @@ entry:
 
 ; <label>:37                                      ; preds = %65
   %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %37
   %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
@@ -5886,16 +7340,16 @@ entry:
   %45 = bitcast i16* %41 to i8*
   %46 = getelementptr inbounds i8, i8* %45, i64 %44
   %47 = bitcast i8* %46 to i16*
-  %NullCheck14 = icmp ne i16* %47, null
-  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %47, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %48
 
 ; <label>:48                                      ; preds = %39
   %49 = load i16, i16* %47, align 8
   %50 = zext i16 %49 to i32
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %52 = load i32, i32* %loc1
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %53
 
 ; <label>:53                                      ; preds = %48
   %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
@@ -5916,8 +7370,8 @@ entry:
 ; <label>:62                                      ; preds = %36, %59
   %63 = load i32, i32* %loc1
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck10, label %65, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %65
 
 ; <label>:65                                      ; preds = %62
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
@@ -5936,15 +7390,15 @@ entry:
 
 ; <label>:74                                      ; preds = %70
   %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
-  br i1 %NullCheck18, label %76, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %76
 
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
   %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
-  br i1 %NullCheck20, label %80, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
   %81 = load i64, i64 addrspace(1)* %79
@@ -5958,8 +7412,8 @@ entry:
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
   %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
-  br i1 %NullCheck22, label %92, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.String addrspace(1)* %90, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %92
 
 ; <label>:92                                      ; preds = %80
   %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
@@ -5969,15 +7423,15 @@ entry:
 
 ; <label>:96                                      ; preds = %70
   %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
-  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %98
 
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
   %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
-  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
   %103 = load i64, i64 addrspace(1)* %101
@@ -5991,8 +7445,8 @@ entry:
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
   %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
-  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.String addrspace(1)* %112, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %114
 
 ; <label>:114                                     ; preds = %102
   %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
@@ -6004,59 +7458,59 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %20
+ThrowNullRef4:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %22
+ThrowNullRef6:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %26
+ThrowNullRef8:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %62
+ThrowNullRef10:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %48
+ThrowNullRef16:                                   ; preds = %48
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %74
+ThrowNullRef18:                                   ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %76
+ThrowNullRef20:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %80
+ThrowNullRef22:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %96
+ThrowNullRef24:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %98
+ThrowNullRef26:                                   ; preds = %98
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %102
+ThrowNullRef28:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6069,15 +7523,15 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
   %3 = load i16*, i16* addrspace(1)* %2, align 8
   %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
@@ -6087,8 +7541,8 @@ entry:
   %10 = bitcast i16* %3 to i8*
   %11 = getelementptr inbounds i8, i8* %10, i64 %9
   %12 = bitcast i8* %11 to i16*
-  %NullCheck4 = icmp ne i16* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %5
   store i16 0, i16* %12, align 8
@@ -6098,11 +7552,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6119,8 +7573,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -6131,8 +7585,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
@@ -6144,15 +7598,15 @@ entry:
 
 ; <label>:14                                      ; preds = %1
   %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
   %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
   %21 = load i64, i64 addrspace(1)* %19
@@ -6171,15 +7625,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %14
+ThrowNullRef4:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %16
+ThrowNullRef6:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6302,14 +7756,6 @@ entry:
   ret %System.String addrspace(1)* %57
 }
 
-INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
-Successfully read RuntimeHelpers.get_OffsetToStringData
-
-define i32 @RuntimeHelpers.get_OffsetToStringData() {
-entry:
-  ret i32 12
-}
-
 INFO:  jitting method String::Equals using LLILCJit
 Successfully read String.Equals
 
@@ -6381,8 +7827,8 @@ entry:
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
-  br i1 %NullCheck24, label %29, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
   %30 = load i64, i64 addrspace(1)* %28
@@ -6397,8 +7843,8 @@ entry:
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
-  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
   %43 = load i64, i64 addrspace(1)* %41
@@ -6418,8 +7864,8 @@ entry:
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
   %59 = load i64, i64 addrspace(1)* %57
@@ -6434,8 +7880,8 @@ entry:
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck22, label %71, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
   %72 = load i64, i64 addrspace(1)* %70
@@ -6455,8 +7901,8 @@ entry:
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
-  br i1 %NullCheck16, label %87, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = load i64, i64 addrspace(1)* %86
@@ -6471,8 +7917,8 @@ entry:
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck18, label %100, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
   %101 = load i64, i64 addrspace(1)* %99
@@ -6492,8 +7938,8 @@ entry:
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
-  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
   %117 = load i64, i64 addrspace(1)* %115
@@ -6508,8 +7954,8 @@ entry:
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
-  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
   %130 = load i64, i64 addrspace(1)* %128
@@ -6528,15 +7974,15 @@ entry:
 
 ; <label>:142                                     ; preds = %22
   %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
-  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %143, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %144
 
 ; <label>:144                                     ; preds = %142
   %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
   %146 = load i32, i32 addrspace(1)* %145
   %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
-  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %147, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %148
 
 ; <label>:148                                     ; preds = %144
   %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
@@ -6557,15 +8003,15 @@ entry:
 
 ; <label>:159                                     ; preds = %22
   %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
-  br i1 %NullCheck, label %161, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %ThrowNullRef, label %161
 
 ; <label>:161                                     ; preds = %159
   %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
   %163 = load i32, i32 addrspace(1)* %162
   %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
-  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %164, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %165
 
 ; <label>:165                                     ; preds = %161
   %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
@@ -6578,8 +8024,8 @@ entry:
 
 ; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
-  br i1 %NullCheck4, label %172, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %171, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %172
 
 ; <label>:172                                     ; preds = %170
   %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
@@ -6589,8 +8035,8 @@ entry:
 
 ; <label>:176                                     ; preds = %172
   %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
-  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %177, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %178
 
 ; <label>:178                                     ; preds = %176
   %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
@@ -6629,55 +8075,55 @@ ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %161
+ThrowNullRef2:                                    ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %170
+ThrowNullRef4:                                    ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %176
+ThrowNullRef6:                                    ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %142
+ThrowNullRef8:                                    ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %144
+ThrowNullRef10:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %113
+ThrowNullRef12:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %116
+ThrowNullRef14:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %84
+ThrowNullRef16:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %87
+ThrowNullRef18:                                   ; preds = %87
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %55
+ThrowNullRef20:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %58
+ThrowNullRef22:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %26
+ThrowNullRef24:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %29
+ThrowNullRef26:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,8 +8161,8 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck, label %14, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %ThrowNullRef, label %14
 
 ; <label>:14                                      ; preds = %8
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
@@ -6760,8 +8206,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
@@ -6770,14 +8216,14 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32, i32* %loc0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %10
   %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
   %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
@@ -6790,15 +8236,15 @@ entry:
 ; <label>:25                                      ; preds = %19
   %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
-  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
   %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
@@ -6807,8 +8253,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %37 = load i32, i32* %loc0
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %38, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %38
 
 ; <label>:38                                      ; preds = %32
   %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
@@ -6817,14 +8263,14 @@ entry:
 
 ; <label>:40                                      ; preds = %19
   %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %40
   %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
   %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
-  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
-  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
@@ -6832,8 +8278,8 @@ entry:
   %48 = zext i32 %47 to i64
   %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
-  br i1 %NullCheck16, label %51, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %51
 
 ; <label>:51                                      ; preds = %45
   %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
@@ -6847,15 +8293,15 @@ entry:
 ; <label>:57                                      ; preds = %51
   %58 = load i16*, i16** %arg1
   %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
-  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %60
 
 ; <label>:60                                      ; preds = %57
   %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
   %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
-  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %64
 
 ; <label>:64                                      ; preds = %60
   %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
@@ -6864,22 +8310,22 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
   %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
-  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %70
 
 ; <label>:70                                      ; preds = %64
   %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
   %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
-  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
-  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
   %75 = load i32, i32 addrspace(1)* %74
   %76 = zext i32 %75 to i64
   %77 = trunc i64 %76 to i32
-  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
-  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %78
 
 ; <label>:78                                      ; preds = %73
   %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
@@ -6901,8 +8347,8 @@ entry:
   %90 = bitcast i16* %86 to i8*
   %91 = getelementptr inbounds i8, i8* %90, i64 %89
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %93
 
 ; <label>:93                                      ; preds = %80
   %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
@@ -6912,8 +8358,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %99 = load i32, i32* %loc2
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %100
 
 ; <label>:100                                     ; preds = %93
   %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
@@ -6928,63 +8374,63 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %25
+ThrowNullRef6:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %32
+ThrowNullRef10:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %40
+ThrowNullRef12:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %45
+ThrowNullRef16:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %57
+ThrowNullRef18:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %60
+ThrowNullRef20:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %64
+ThrowNullRef22:                                   ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %70
+ThrowNullRef24:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %73
+ThrowNullRef26:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %80
+ThrowNullRef28:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %93
+ThrowNullRef30:                                   ; preds = %93
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7004,8 +8450,8 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
@@ -7033,43 +8479,43 @@ entry:
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %14
   %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
   %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   %28 = load i32, i32 addrspace(1)* %27, align 8
   %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
-  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %30
 
 ; <label>:30                                      ; preds = %26
   %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
   %32 = load i32, i32 addrspace(1)* %31, align 8
   %33 = add i32 %28, %32
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %34
 
 ; <label>:34                                      ; preds = %30
   %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   store i32 %33, i32 addrspace(1)* %35
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
   store i32 0, i32 addrspace(1)* %38
   %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %40
 
 ; <label>:40                                      ; preds = %37
   %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
@@ -7082,8 +8528,8 @@ entry:
 
 ; <label>:47                                      ; preds = %40
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
@@ -7098,8 +8544,8 @@ entry:
   %54 = load i32, i32* %loc0
   %55 = sext i32 %54 to i64
   %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
-  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %57
 
 ; <label>:57                                      ; preds = %52
   %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
@@ -7110,68 +8556,35 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %14
+ThrowNullRef2:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %23
+ThrowNullRef4:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %26
+ThrowNullRef6:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %30
+ThrowNullRef8:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %34
+ThrowNullRef10:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %47
+ThrowNullRef14:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %52
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-}
-
-INFO:  jitting method StringBuilder::get_Length using LLILCJit
-Successfully read StringBuilder.get_Length
-
-define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.StringBuilder addrspace(1)*
-  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
-  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
-
-; <label>:1                                       ; preds = %entry
-  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %3 = load i32, i32 addrspace(1)* %2, align 8
-  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
-
-; <label>:5                                       ; preds = %1
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = add i32 %3, %7
-  ret i32 %8
-
-ThrowNullRef:                                     ; preds = %entry
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef16:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7213,70 +8626,70 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
   %6 = load i32, i32 addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
   store i32 %6, i32 addrspace(1)* %8
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
   %13 = load i32, i32 addrspace(1)* %12, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
   store i32 %13, i32 addrspace(1)* %15
   %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
-  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %18
 
 ; <label>:18                                      ; preds = %14
   %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
   %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
   %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
   %34 = load i32, i32 addrspace(1)* %33, align 8
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
-  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
@@ -7287,39 +8700,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %28
+ThrowNullRef16:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %32
+ThrowNullRef18:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7455,13 +8868,13 @@ entry:
 ; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
@@ -7477,16 +8890,16 @@ entry:
 
 ; <label>:18                                      ; preds = %15
   %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
   store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
   %22 = load i32, i32* %loc0
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %24
 
 ; <label>:24                                      ; preds = %20
   %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
@@ -7498,13 +8911,13 @@ entry:
 ; <label>:28                                      ; preds = %15, %24
   %29 = load i32, i32* %arg1
   %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %31
   %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
@@ -7517,20 +8930,20 @@ entry:
   %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
-  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
   %46 = load i32, i32 addrspace(1)* %45, align 8
   %47 = sub i32 %40, %46
-  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
-  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i32 addrspace(1)* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %48
 
 ; <label>:48                                      ; preds = %44
   store i32 %47, i32 addrspace(1)* %39, align 8
@@ -7538,21 +8951,21 @@ entry:
 
 ; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
-  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %51
 
 ; <label>:51                                      ; preds = %49
   %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %53
 
 ; <label>:53                                      ; preds = %51
   %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
   %55 = load i32, i32 addrspace(1)* %54, align 8
   %56 = load i32, i32* %arg2
   %57 = sub i32 %55, %56
-  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %58
 
 ; <label>:58                                      ; preds = %53
   %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
@@ -7562,13 +8975,13 @@ entry:
 ; <label>:60                                      ; preds = %33, %58
   %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
   %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
-  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %63
 
 ; <label>:63                                      ; preds = %60
   %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
-  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
-  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
@@ -7578,15 +8991,15 @@ entry:
 
 ; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
-  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i32 addrspace(1)* %69, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %70
 
 ; <label>:70                                      ; preds = %68
   %71 = load i32, i32 addrspace(1)* %69, align 8
   store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
-  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
@@ -7596,8 +9009,8 @@ entry:
   store i32 %77, i32* %loc4
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
-  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %80
 
 ; <label>:80                                      ; preds = %73
   %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
@@ -7607,71 +9020,71 @@ entry:
 ; <label>:83                                      ; preds = %80
   store i32 0, i32* %loc3
   %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
-  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
-  br i1 %NullCheck26, label %88, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i32 addrspace(1)* %87, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %88
 
 ; <label>:88                                      ; preds = %85
   %89 = load i32, i32 addrspace(1)* %87, align 8
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
-  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %90
 
 ; <label>:90                                      ; preds = %88
   %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
   store i32 %89, i32 addrspace(1)* %91
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
-  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
-  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %96
 
 ; <label>:96                                      ; preds = %94
   %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
-  br i1 %NullCheck34, label %100, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %100
 
 ; <label>:100                                     ; preds = %96
   %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
-  br i1 %NullCheck36, label %102, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %102
 
 ; <label>:102                                     ; preds = %100
   %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
   %104 = load i32, i32 addrspace(1)* %103, align 8
   %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
-  br i1 %NullCheck38, label %106, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %106
 
 ; <label>:106                                     ; preds = %102
   %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
-  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
-  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %108
 
 ; <label>:108                                     ; preds = %106
   %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
   %110 = load i32, i32 addrspace(1)* %109, align 8
   %111 = add i32 %104, %110
-  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %112
 
 ; <label>:112                                     ; preds = %108
   %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
   store i32 %111, i32 addrspace(1)* %113
   %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
-  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i32 addrspace(1)* %114, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %115
 
 ; <label>:115                                     ; preds = %112
   %116 = load i32, i32 addrspace(1)* %114, align 8
@@ -7681,19 +9094,19 @@ entry:
 ; <label>:118                                     ; preds = %115
   %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
-  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %121
 
 ; <label>:121                                     ; preds = %118
   %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
-  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
-  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %123
 
 ; <label>:123                                     ; preds = %121
   %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
   %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
-  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
-  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %126
 
 ; <label>:126                                     ; preds = %123
   %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
@@ -7705,8 +9118,8 @@ entry:
 
 ; <label>:130                                     ; preds = %80, %115, %126
   %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %132
 
 ; <label>:132                                     ; preds = %130
   %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7715,8 +9128,8 @@ entry:
   %136 = load i32, i32* %loc3
   %137 = sub i32 %135, %136
   %138 = sub i32 %134, %137
-  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %139
 
 ; <label>:139                                     ; preds = %132
   %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7728,16 +9141,16 @@ entry:
 
 ; <label>:144                                     ; preds = %139
   %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
-  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %146
 
 ; <label>:146                                     ; preds = %144
   %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
   %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
   %149 = load i32, i32* %loc2
   %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
-  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %151
 
 ; <label>:151                                     ; preds = %146
   %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
@@ -7754,145 +9167,249 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %18
+ThrowNullRef4:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %31
+ThrowNullRef10:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %44
+ThrowNullRef16:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %68
+ThrowNullRef18:                                   ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %70
+ThrowNullRef20:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %73
+ThrowNullRef22:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %83
+ThrowNullRef24:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %85
+ThrowNullRef26:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %88
+ThrowNullRef28:                                   ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %90
+ThrowNullRef30:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %94
+ThrowNullRef32:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %96
+ThrowNullRef34:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %100
+ThrowNullRef36:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %102
+ThrowNullRef38:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %106
+ThrowNullRef40:                                   ; preds = %106
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %108
+ThrowNullRef42:                                   ; preds = %108
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %112
+ThrowNullRef44:                                   ; preds = %112
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %118
+ThrowNullRef46:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %121
+ThrowNullRef48:                                   ; preds = %121
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %123
+ThrowNullRef50:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %130
+ThrowNullRef52:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %132
+ThrowNullRef54:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %144
+ThrowNullRef56:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %146
+ThrowNullRef58:                                   ; preds = %146
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %60
+ThrowNullRef60:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %63
+ThrowNullRef62:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %49
+ThrowNullRef64:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %51
+ThrowNullRef66:                                   ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %53
+ThrowNullRef68:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(%"System.Char[]" addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %arg0 = alloca %"System.Char[]" addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store %"System.Char[]" addrspace(1)* %param0, %"System.Char[]" addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load i32, i32* %arg4
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %43, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %38, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg1
+  %13 = load i32, i32* %arg4
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %38, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %24 = load i32, i32* %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %35 = load i32, i32* %arg3
+  %36 = load i32, i32* %arg4
+  %37 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %37, %"System.Char[]" addrspace(1)* %34, i32 %35, i32 %36)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:38                                      ; preds = %5, %16
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Successfully read Buffer._Memmove
 
@@ -7914,7 +9431,7 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[loadElem]
+Failed to read AppDomain.SetDataHelper[storeElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -7923,8 +9440,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
@@ -7934,8 +9451,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
@@ -7947,15 +9464,15 @@ entry:
   %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
   %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
@@ -7966,15 +9483,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7992,7 +9509,79 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
-Failed to read Dictionary`2.TryGetValue[loadElemA]
+Successfully read Dictionary`2.TryGetValue
+
+define i8 @"Dictionary`2.TryGetValue"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)* addrspace(1)* %param2) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  %arg2 = alloca %System.__Canon addrspace(1)* addrspace(1)*
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  store %System.__Canon addrspace(1)* addrspace(1)* %param2, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  store i32 %2, i32* %loc0
+  %3 = load i32, i32* %loc0
+  %4 = icmp slt i32 %3, 0
+  br i1 %4, label %22, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 2
+  %10 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %9, align 8
+  %11 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = zext i32 %11 to i64
+  %BoundsCheck = icmp uge i64 %16, %15
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 3, i32 %11
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %20, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %6, %System.__Canon addrspace(1)* %21)
+  ret i8 1
+
+; <label>:22                                      ; preds = %entry
+  %23 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %23, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -8058,8 +9647,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
@@ -8091,8 +9680,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
@@ -8171,15 +9760,15 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck, label %19, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %ThrowNullRef, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
   %21 = load i32, i32 addrspace(1)* %20
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
@@ -8202,7 +9791,7 @@ ThrowNullRef:                                     ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %19
+ThrowNullRef2:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8248,8 +9837,8 @@ entry:
   %0 = alloca %System.AppDomainHandle
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %1 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %1, i32 0, i32 15
@@ -8269,8 +9858,8 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
@@ -8286,7 +9875,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -8299,8 +9888,8 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -8327,8 +9916,8 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
@@ -8352,8 +9941,8 @@ entry:
   %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
   store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
@@ -8363,8 +9952,8 @@ entry:
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
@@ -8374,8 +9963,8 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %9
   %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
@@ -8384,8 +9973,8 @@ entry:
 
 ; <label>:18                                      ; preds = %3, %16
   %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
@@ -8397,15 +9986,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %18
+ThrowNullRef6:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8418,8 +10007,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
@@ -8453,15 +10042,15 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
@@ -8473,7 +10062,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8481,7 +10070,7 @@ ThrowNullRef1:                                    ; preds = %1
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
 Failed to read Dictionary`2.System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
@@ -8506,8 +10095,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
@@ -8524,8 +10113,8 @@ entry:
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -8544,7 +10133,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8577,8 +10166,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = load i64, i64* %arg2
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = trunc i32 %3 to i8
@@ -8634,46 +10223,46 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
   %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
-  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
-  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
-  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
@@ -8684,27 +10273,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %20
+ThrowNullRef12:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8717,8 +10306,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -8756,22 +10345,22 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
   %9 = load i64, i64 addrspace(1)* %8, align 8
   %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
   %13 = load i64, i64 addrspace(1)* %12, align 8
   %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %11
   %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
@@ -8788,11 +10377,11 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8882,8 +10471,8 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
@@ -8900,8 +10489,8 @@ entry:
 ; <label>:8                                       ; preds = %1
   %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
   %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
@@ -8911,15 +10500,15 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
   %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
   %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
-  br i1 %NullCheck6, label %21, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
@@ -8946,15 +10535,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8992,15 +10581,15 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
   store i8 %3, i8 addrspace(1)* %5
   %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
@@ -9011,7 +10600,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9027,8 +10616,8 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -9041,8 +10630,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
@@ -9058,7 +10647,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9080,8 +10669,8 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
@@ -9096,8 +10685,8 @@ entry:
 ; <label>:12                                      ; preds = %6
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
@@ -9112,8 +10701,8 @@ entry:
 ; <label>:21                                      ; preds = %15
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
@@ -9128,8 +10717,8 @@ entry:
 ; <label>:30                                      ; preds = %24
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %31, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
@@ -9144,8 +10733,8 @@ entry:
 ; <label>:39                                      ; preds = %33
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
-  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %40, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %42
 
 ; <label>:42                                      ; preds = %39
   %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
@@ -9164,19 +10753,19 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %21
+ThrowNullRef4:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %30
+ThrowNullRef6:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %39
+ThrowNullRef8:                                    ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9243,8 +10832,8 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
@@ -9264,57 +10853,57 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
   store i8 0, i8 addrspace(1)* %2
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
   store i8 0, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
   store i8 0, i8 addrspace(1)* %17
   %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
   store i8 0, i8 addrspace(1)* %20
   %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
-  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
@@ -9325,31 +10914,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %19
+ThrowNullRef14:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9367,8 +10956,8 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
@@ -9380,8 +10969,8 @@ entry:
 
 ; <label>:9                                       ; preds = %4
   %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %9
   %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
@@ -9395,7 +10984,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef2:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9420,8 +11009,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
@@ -9512,8 +11101,8 @@ entry:
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
@@ -9524,8 +11113,8 @@ entry:
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = load i64, i64 addrspace(1)* %12
@@ -9537,8 +11126,8 @@ entry:
   %20 = load i64, i64* %19
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
-  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %13
   %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
@@ -9555,8 +11144,8 @@ entry:
 ; <label>:30                                      ; preds = %25
   %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %32 = load i32, i32* %arg2
-  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
-  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
@@ -9570,15 +11159,15 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %30
+ThrowNullRef2:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9622,87 +11211,87 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
   %10 = load i8, i8 addrspace(1)* %9, align 8
   %11 = zext i8 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %8
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
   store i8 %12, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
   %19 = load i8, i8 addrspace(1)* %18, align 8
   %20 = zext i8 %19 to i32
   %21 = trunc i32 %20 to i8
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
   store i8 %21, i8 addrspace(1)* %23
   %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
   %28 = load i8, i8 addrspace(1)* %27, align 8
   %29 = zext i8 %28 to i32
   %30 = trunc i32 %29 to i8
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
-  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %31
 
 ; <label>:31                                      ; preds = %26
   %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
   store i8 %30, i8 addrspace(1)* %32
   %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
-  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
-  br i1 %NullCheck14, label %40, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %40
 
 ; <label>:40                                      ; preds = %35
   %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
   store i8 %39, i8 addrspace(1)* %41
   %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
-  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %44
 
 ; <label>:44                                      ; preds = %40
   %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
   %46 = load i8, i8 addrspace(1)* %45, align 8
   %47 = zext i8 %46 to i32
   %48 = trunc i32 %47 to i8
-  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
   store i8 %48, i8 addrspace(1)* %50
   %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
-  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
@@ -9713,29 +11302,29 @@ entry:
 ; <label>:56                                      ; preds = %52
   %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
-  br i1 %NullCheck22, label %59, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
   %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
   %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
-  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
-  br i1 %NullCheck24, label %63, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
   %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
-  br i1 %NullCheck26, label %66, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
   %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
-  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
-  br i1 %NullCheck28, label %69, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %69
 
 ; <label>:69                                      ; preds = %66
   %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
@@ -9744,15 +11333,15 @@ entry:
 
 ; <label>:71                                      ; preds = %105
   %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
-  br i1 %NullCheck34, label %73, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %73
 
 ; <label>:73                                      ; preds = %71
   %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
   %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
   %76 = load i32, i32* %loc0
-  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
-  br i1 %NullCheck36, label %77, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
@@ -9766,8 +11355,8 @@ entry:
 
 ; <label>:83                                      ; preds = %77
   %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
-  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
@@ -9775,14 +11364,14 @@ entry:
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
   %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
-  br i1 %NullCheck40, label %91, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
 ; <label>:91                                      ; preds = %85
   %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
   %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
-  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck42, label %94, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %94
 
 ; <label>:94                                      ; preds = %91
   %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
@@ -9798,14 +11387,14 @@ entry:
 ; <label>:99                                      ; preds = %69, %96
   %100 = load i32, i32* %loc0
   %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
-  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %102
 
 ; <label>:102                                     ; preds = %99
   %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
   %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
-  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
-  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
@@ -9819,87 +11408,87 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %26
+ThrowNullRef10:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %31
+ThrowNullRef12:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %35
+ThrowNullRef14:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %40
+ThrowNullRef16:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %56
+ThrowNullRef22:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %59
+ThrowNullRef24:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %63
+ThrowNullRef26:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %66
+ThrowNullRef28:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %102
+ThrowNullRef32:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %71
+ThrowNullRef34:                                   ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %73
+ThrowNullRef36:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %83
+ThrowNullRef38:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %85
+ThrowNullRef40:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %91
+ThrowNullRef42:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9943,15 +11532,15 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
   %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
@@ -9961,28 +11550,28 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
   %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %12
   %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
   %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
   %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
-  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
@@ -9993,23 +11582,23 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %12
+ThrowNullRef6:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10031,15 +11620,15 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
   %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = load i64, i64 addrspace(1)* %7
@@ -10077,13 +11666,13 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[loadElem]
+Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -10111,8 +11700,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -10200,8 +11789,8 @@ entry:
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load double, double* %arg0
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -10335,8 +11924,8 @@ entry:
   store i64 %param0, i64* %arg0
   store i64 %param1, i64* %arg1
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
@@ -10344,8 +11933,8 @@ entry:
   %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
   %5 = load i16*, i16* addrspace(1)* %4, align 8
   %6 = addrspacecast i64* %arg1 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = bitcast i64 addrspace(1)* %6 to i8 addrspace(1)*
@@ -10361,7 +11950,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10395,8 +11984,8 @@ entry:
   %1 = load i32, i32* %arg1
   %2 = sext i32 %1 to i64
   %3 = inttoptr i64 %2 to i16*
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -10449,8 +12038,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, i32)*)(%System.IO.ConsoleStream addrspace(1)* %2, i32 %1)
   %3 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %4 = load i64, i64* %arg1
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
@@ -10461,8 +12050,8 @@ entry:
   %10 = icmp eq i32 %9, 3
   %11 = sext i1 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %5
   %14 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, i32 0, i32 5
@@ -10473,7 +12062,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10496,8 +12085,8 @@ entry:
   %5 = icmp eq i32 %4, 1
   %6 = sext i1 %5 to i32
   %7 = trunc i32 %6 to i8
-  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %2, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.ConsoleStream addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
@@ -10508,8 +12097,8 @@ entry:
   %13 = icmp eq i32 %12, 2
   %14 = sext i1 %13 to i32
   %15 = trunc i32 %14 to i8
-  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %10, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.ConsoleStream addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %8
   %17 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %10, i32 0, i32 4
@@ -10520,7 +12109,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10559,8 +12148,8 @@ entry:
   %arg0 = alloca i64
   store i64 %param0, i64* %arg0
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
@@ -10595,8 +12184,8 @@ entry:
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
   %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = load i64, i64 addrspace(1)* %7
@@ -10700,7 +12289,127 @@ entry:
 INFO:  jitting method Encoding::GetEncoding using LLILCJit
 Failed to read Encoding.GetEncoding[convertToHelperArgumentType]
 INFO:  jitting method EncodingProvider::GetEncodingFromProvider using LLILCJit
-Failed to read EncodingProvider.GetEncodingFromProvider[loadElem]
+Successfully read EncodingProvider.GetEncodingFromProvider
+
+define %System.Text.Encoding addrspace(1)* @EncodingProvider.GetEncodingFromProvider(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca %"System.Text.EncodingProvider[]" addrspace(1)*
+  %loc1 = alloca %System.Text.EncodingProvider addrspace(1)*
+  %loc2 = alloca %System.Text.Encoding addrspace(1)*
+  %loc3 = alloca %System.Text.Encoding addrspace(1)*
+  %loc4 = alloca %"System.Text.EncodingProvider[]" addrspace(1)*
+  %loc5 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1059)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2392
+  %2 = addrspacecast i8 addrspace(1)* %1 to %"System.Text.EncodingProvider[]" addrspace(1)**
+  %3 = load volatile %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %2
+  %4 = icmp ne %"System.Text.EncodingProvider[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %entry
+  ret %System.Text.Encoding addrspace(1)* null
+
+; <label>:6                                       ; preds = %entry
+  %7 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1059)
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i64 2392
+  %9 = addrspacecast i8 addrspace(1)* %8 to %"System.Text.EncodingProvider[]" addrspace(1)**
+  %10 = load volatile %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %9
+  store %"System.Text.EncodingProvider[]" addrspace(1)* %10, %"System.Text.EncodingProvider[]" addrspace(1)** %loc0
+  %11 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc0
+  store %"System.Text.EncodingProvider[]" addrspace(1)* %11, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  store i32 0, i32* %loc5
+  br label %43
+
+; <label>:12                                      ; preds = %46
+  %13 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  %14 = load i32, i32* %loc5
+  %NullCheck1 = icmp eq %"System.Text.EncodingProvider[]" addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %13, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = zext i32 %17 to i64
+  %19 = zext i32 %14 to i64
+  %BoundsCheck = icmp uge i64 %19, %18
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %20
+
+; <label>:20                                      ; preds = %15
+  %21 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %13, i32 0, i32 3, i32 %14
+  %22 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)* addrspace(1)* %21, align 8
+  store %System.Text.EncodingProvider addrspace(1)* %22, %System.Text.EncodingProvider addrspace(1)** %loc1
+  %23 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)** %loc1
+  %24 = load i32, i32* %arg0
+  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i64 addrspace(1)*
+  %NullCheck3 = icmp eq i64 addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
+
+; <label>:26                                      ; preds = %20
+  %27 = load i64, i64 addrspace(1)* %25
+  %28 = add i64 %27, 64
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 40
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Text.Encoding addrspace(1)* (%System.Text.EncodingProvider addrspace(1)*, i32)*
+  %35 = call %System.Text.Encoding addrspace(1)* %34(%System.Text.EncodingProvider addrspace(1)* %23, i32 %24)
+  store %System.Text.Encoding addrspace(1)* %35, %System.Text.Encoding addrspace(1)** %loc2
+  %36 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc2
+  %37 = icmp eq %System.Text.Encoding addrspace(1)* %36, null
+  br i1 %37, label %40, label %38
+
+; <label>:38                                      ; preds = %26
+  %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc2
+  store %System.Text.Encoding addrspace(1)* %39, %System.Text.Encoding addrspace(1)** %loc3
+  br label %53
+
+; <label>:40                                      ; preds = %26
+  %41 = load i32, i32* %loc5
+  %42 = add i32 %41, 1
+  store i32 %42, i32* %loc5
+  br label %43
+
+; <label>:43                                      ; preds = %6, %40
+  %44 = load i32, i32* %loc5
+  %45 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  %NullCheck = icmp eq %"System.Text.EncodingProvider[]" addrspace(1)* %45, null
+  br i1 %NullCheck, label %ThrowNullRef, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp slt i32 %44, %50
+  br i1 %51, label %12, label %52
+
+; <label>:52                                      ; preds = %46
+  ret %System.Text.Encoding addrspace(1)* null
+
+; <label>:53                                      ; preds = %38
+  %54 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc3
+  ret %System.Text.Encoding addrspace(1)* %54
+
+ThrowNullRef:                                     ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method EncodingProvider::.cctor using LLILCJit
 Successfully read EncodingProvider..cctor
 
@@ -10719,7 +12428,7 @@ Failed to read Encoding.get_InternalSyncObject[Call HasTypeArg]
 INFO:  jitting method Hashtable::.ctor using LLILCJit
 Failed to read Hashtable..ctor[Volatile store]
 INFO:  jitting method Hashtable::get_Item using LLILCJit
-Failed to read Hashtable.get_Item[loadElemA]
+Failed to read Hashtable.get_Item[loadNonPrimitiveObj]
 INFO:  jitting method Hashtable::InitHash using LLILCJit
 Successfully read Hashtable.InitHash
 
@@ -10739,8 +12448,8 @@ entry:
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -10756,15 +12465,15 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
   %15 = load i32, i32* %loc0
-  %NullCheck2 = icmp ne i32 addrspace(1)* %14, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i32 addrspace(1)* %14, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %3
   store i32 %15, i32 addrspace(1)* %14, align 8
   %17 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %18 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %NullCheck4 = icmp ne i32 addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i32 addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = load i32, i32 addrspace(1)* %18, align 8
@@ -10773,8 +12482,8 @@ entry:
   %23 = sub i32 %22, 1
   %24 = urem i32 %21, %23
   %25 = add i32 1, %24
-  %NullCheck6 = icmp ne i32 addrspace(1)* %17, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32 addrspace(1)* %17, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %19
   store i32 %25, i32 addrspace(1)* %17, align 8
@@ -10785,15 +12494,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %19
+ThrowNullRef6:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10808,8 +12517,8 @@ entry:
   store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
   store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %NullCheck = icmp ne %System.Collections.Hashtable addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Collections.Hashtable addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
@@ -10819,16 +12528,16 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Collections.Hashtable addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Collections.Hashtable addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
   %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck4 = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %9, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
   %13 = inttoptr i64 %11 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
@@ -10838,8 +12547,8 @@ entry:
 ; <label>:15                                      ; preds = %1
   %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -10857,15 +12566,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10879,8 +12588,8 @@ entry:
   store %System.Int32 addrspace(1)* %param0, %System.Int32 addrspace(1)** %this
   %0 = load %System.Int32 addrspace(1)*, %System.Int32 addrspace(1)** %this
   %1 = bitcast %System.Int32 addrspace(1)* %0 to i32 addrspace(1)*
-  %NullCheck = icmp ne i32 addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq i32 addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load i32, i32 addrspace(1)* %1, align 8
@@ -10956,8 +12665,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.UTF8Encoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
@@ -10966,15 +12675,15 @@ entry:
   %9 = load i8, i8* %arg2
   %10 = zext i8 %9 to i32
   %11 = trunc i32 %10 to i8
-  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %8, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %6
   %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %8, i32 0, i32 8
   store i8 %11, i8 addrspace(1)* %13
   %14 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %14, i32 0, i32 8
@@ -10986,8 +12695,8 @@ entry:
 ; <label>:20                                      ; preds = %15
   %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %22, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %22, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = load i64, i64 addrspace(1)* %22
@@ -11009,15 +12718,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %12
+ThrowNullRef4:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11032,8 +12741,8 @@ entry:
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
@@ -11055,16 +12764,16 @@ entry:
 ; <label>:10                                      ; preds = %1
   %11 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
   %12 = load i32, i32* %arg1
-  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %11, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.Encoding addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
   store i32 %12, i32 addrspace(1)* %14
   %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
   %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = load i64, i64 addrspace(1)* %16
@@ -11082,11 +12791,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11099,8 +12808,8 @@ entry:
   %this = alloca %System.Text.UTF8Encoding addrspace(1)*
   store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
   %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.UTF8Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
@@ -11112,16 +12821,16 @@ entry:
 ; <label>:6                                       ; preds = %1
   %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %8 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %10, %System.Text.EncoderFallback addrspace(1)* %8)
   %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %12 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
-  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %11, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %11, i32 0, i32 3
@@ -11134,8 +12843,8 @@ entry:
   %18 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %18, %System.String addrspace(1)* %17)
   %19 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %18 to %System.Text.EncoderFallback addrspace(1)*
-  %NullCheck6 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %16, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %16, i32 0, i32 2
@@ -11145,8 +12854,8 @@ entry:
   %24 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %24, %System.String addrspace(1)* %23)
   %25 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %24 to %System.Text.DecoderFallback addrspace(1)*
-  %NullCheck8 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %22, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %22, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %20
   %27 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %22, i32 0, i32 3
@@ -11157,19 +12866,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %20
+ThrowNullRef8:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11199,8 +12908,8 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load i32, i32* %arg1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -11218,8 +12927,8 @@ entry:
 ; <label>:15                                      ; preds = %8
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %17 = load i32, i32* %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 %17
@@ -11235,7 +12944,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11287,7 +12996,7 @@ entry:
 }
 
 INFO:  jitting method Hashtable::Insert using LLILCJit
-Failed to read Hashtable.Insert[loadElemA]
+Failed to read Hashtable.Insert[storeElem]
 INFO:  jitting method ConsoleEncoding::.ctor using LLILCJit
 Successfully read ConsoleEncoding..ctor
 
@@ -11302,8 +13011,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %1)
   %2 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
@@ -11339,8 +13048,8 @@ entry:
   %2 = call %System.Text.InternalEncoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalEncoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %1)
   %3 = bitcast %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2 to %System.Text.EncoderFallback addrspace(1)*
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
@@ -11350,8 +13059,8 @@ entry:
   %8 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %7)
   %9 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %8 to %System.Text.DecoderFallback addrspace(1)*
-  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %6, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.Encoding addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %4
   %11 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %6, i32 0, i32 3
@@ -11362,7 +13071,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11381,15 +13090,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* %1)
   %2 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   %6 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, i32 0, i32 1
@@ -11400,7 +13109,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11428,8 +13137,8 @@ entry:
   store %System.Text.InternalDecoderBestFitFallback addrspace(1)* %param0, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
   %0 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
@@ -11439,15 +13148,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %4)
   %5 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %6)
   %9 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, i32 0, i32 1
@@ -11458,11 +13167,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11530,8 +13239,8 @@ entry:
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
   %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = load i64, i64 addrspace(1)* %19
@@ -11595,8 +13304,8 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.ConsoleStream addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
@@ -11627,31 +13336,31 @@ entry:
   store i8 %param4, i8* %arg4
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %3, %System.IO.Stream addrspace(1)* %1)
   %4 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %4, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
   %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %4, i32 0, i32 4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %5)
   %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %6
   %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
   %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
   %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = load i64, i64 addrspace(1)* %13
@@ -11663,8 +13372,8 @@ entry:
   %21 = load i64, i64* %20
   %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %8, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %8, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %14
   %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 5
@@ -11682,24 +13391,24 @@ entry:
   %31 = load i32, i32* %arg3
   %32 = sext i32 %31 to i64
   %33 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %32)
-  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %30, null
-  br i1 %NullCheck10, label %34, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.StreamWriter addrspace(1)* %30, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %35, %"System.Char[]" addrspace(1)* %33)
   %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %37, null
-  br i1 %NullCheck12, label %38, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.StreamWriter addrspace(1)* %37, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %38
 
 ; <label>:38                                      ; preds = %34
   %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
   %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
   %41 = load i32, i32* %arg3
   %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %42, null
-  br i1 %NullCheck14, label %43, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %42, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
   %44 = load i64, i64 addrspace(1)* %42
@@ -11713,30 +13422,30 @@ entry:
   %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
   %53 = sext i32 %52 to i64
   %54 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %53)
-  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
-  br i1 %NullCheck16, label %55, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %55
 
 ; <label>:55                                      ; preds = %43
   %56 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %56, %"System.Byte[]" addrspace(1)* %54)
   %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %58 = load i32, i32* %arg3
-  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %57, null
-  br i1 %NullCheck18, label %59, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.StreamWriter addrspace(1)* %57, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %59
 
 ; <label>:59                                      ; preds = %55
   %60 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 10
   store i32 %58, i32 addrspace(1)* %60
   %61 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %61, null
-  br i1 %NullCheck20, label %62, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.IO.StreamWriter addrspace(1)* %61, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %62
 
 ; <label>:62                                      ; preds = %59
   %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
   %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
   %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
   %67 = load i64, i64 addrspace(1)* %65
@@ -11754,15 +13463,15 @@ entry:
 
 ; <label>:78                                      ; preds = %66
   %79 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %79, null
-  br i1 %NullCheck24, label %80, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.StreamWriter addrspace(1)* %79, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %80
 
 ; <label>:80                                      ; preds = %78
   %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
   %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
   %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %83, null
-  br i1 %NullCheck26, label %84, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %83, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
   %85 = load i64, i64 addrspace(1)* %83
@@ -11779,8 +13488,8 @@ entry:
 
 ; <label>:95                                      ; preds = %84
   %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.IO.StreamWriter addrspace(1)* %96, null
-  br i1 %NullCheck28, label %97, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.IO.StreamWriter addrspace(1)* %96, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %97
 
 ; <label>:97                                      ; preds = %95
   %98 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 12
@@ -11794,8 +13503,8 @@ entry:
   %103 = icmp eq i32 %102, 0
   %104 = sext i1 %103 to i32
   %105 = trunc i32 %104 to i8
-  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %100, null
-  br i1 %NullCheck30, label %106, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.IO.StreamWriter addrspace(1)* %100, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %106
 
 ; <label>:106                                     ; preds = %99
   %107 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %100, i32 0, i32 13
@@ -11806,63 +13515,63 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %6
+ThrowNullRef4:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %29
+ThrowNullRef10:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %34
+ThrowNullRef12:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %38
+ThrowNullRef14:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %43
+ThrowNullRef16:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %55
+ThrowNullRef18:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %59
+ThrowNullRef20:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %62
+ThrowNullRef22:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %78
+ThrowNullRef24:                                   ; preds = %78
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %80
+ThrowNullRef26:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %95
+ThrowNullRef28:                                   ; preds = %95
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11875,15 +13584,15 @@ entry:
   %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = load i64, i64 addrspace(1)* %4
@@ -11901,7 +13610,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11951,35 +13660,35 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
   %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderNLS addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %7 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.EncoderNLS addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Text.Encoding addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.Encoding addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Text.EncoderNLS addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.EncoderNLS addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
   %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck8 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = load i64, i64 addrspace(1)* %16
@@ -11998,19 +13707,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12036,8 +13745,8 @@ entry:
   %this = alloca %System.Text.Encoding addrspace(1)*
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
@@ -12057,15 +13766,15 @@ entry:
   %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
   store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
   %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
   store i32 0, i32 addrspace(1)* %2
   %3 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, i32 0, i32 2
@@ -12075,15 +13784,15 @@ entry:
 
 ; <label>:8                                       ; preds = %4
   %9 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
   %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
   %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = load i64, i64 addrspace(1)* %13
@@ -12104,15 +13813,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12127,16 +13836,16 @@ entry:
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = load i32, i32* %arg1
   %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
   %7 = load i64, i64 addrspace(1)* %5
@@ -12154,7 +13863,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12191,8 +13900,8 @@ entry:
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
   %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
   %16 = load i64, i64 addrspace(1)* %14
@@ -12213,8 +13922,8 @@ entry:
   %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
   %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
   %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %31, null
-  br i1 %NullCheck2, label %32, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = load i64, i64 addrspace(1)* %31
@@ -12257,7 +13966,7 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12270,14 +13979,14 @@ entry:
   %this = alloca %System.Text.EncoderReplacementFallback addrspace(1)*
   store %System.Text.EncoderReplacementFallback addrspace(1)* %param0, %System.Text.EncoderReplacementFallback addrspace(1)** %this
   %0 = load %System.Text.EncoderReplacementFallback addrspace(1)*, %System.Text.EncoderReplacementFallback addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -12288,7 +13997,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12318,8 +14027,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
@@ -12351,8 +14060,8 @@ entry:
   %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
   store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
@@ -12364,8 +14073,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Threading.Tasks.Task addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %7)
@@ -12388,7 +14097,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12407,8 +14116,8 @@ entry:
   store i8 %param1, i8* %arg1
   store i8 %param2, i8* %arg2
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
@@ -12422,8 +14131,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1, %5
   %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 9
@@ -12454,8 +14163,8 @@ entry:
 
 ; <label>:25                                      ; preds = %8, %20
   %26 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %26, null
-  br i1 %NullCheck4, label %27, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %26, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %26, i32 0, i32 12
@@ -12466,22 +14175,22 @@ entry:
 
 ; <label>:32                                      ; preds = %27
   %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %33, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.IO.StreamWriter addrspace(1)* %33, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %32
   %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 12
   store i8 1, i8 addrspace(1)* %35
   %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
-  br i1 %NullCheck8, label %37, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
   %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
   %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck10 = icmp ne i64 addrspace(1)* %40, null
-  br i1 %NullCheck10, label %41, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64 addrspace(1)* %40, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i64, i64 addrspace(1)* %40
@@ -12495,8 +14204,8 @@ entry:
   %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
   store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
   %51 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %NullCheck12 = icmp ne %"System.Byte[]" addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Byte[]" addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %41
   %53 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %51, i32 0, i32 1
@@ -12508,16 +14217,16 @@ entry:
 
 ; <label>:58                                      ; preds = %52
   %59 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %59, null
-  br i1 %NullCheck14, label %60, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.IO.StreamWriter addrspace(1)* %59, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %60
 
 ; <label>:60                                      ; preds = %58
   %61 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %59, i32 0, i32 3
   %62 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
   %64 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %NullCheck16 = icmp ne %"System.Byte[]" addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %"System.Byte[]" addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %60
   %66 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %64, i32 0, i32 1
@@ -12525,8 +14234,8 @@ entry:
   %68 = zext i32 %67 to i64
   %69 = trunc i64 %68 to i32
   %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck18, label %71, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
   %72 = load i64, i64 addrspace(1)* %70
@@ -12542,29 +14251,29 @@ entry:
 
 ; <label>:80                                      ; preds = %27, %52, %71
   %81 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %81, null
-  br i1 %NullCheck20, label %82, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.IO.StreamWriter addrspace(1)* %81, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
 
 ; <label>:82                                      ; preds = %80
   %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %81, i32 0, i32 5
   %84 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %83, align 8
   %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.IO.StreamWriter addrspace(1)* %85, null
-  br i1 %NullCheck22, label %86, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.IO.StreamWriter addrspace(1)* %85, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %86
 
 ; <label>:86                                      ; preds = %82
   %87 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 7
   %88 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %87, align 8
   %89 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %89, null
-  br i1 %NullCheck24, label %90, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.StreamWriter addrspace(1)* %89, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %90
 
 ; <label>:90                                      ; preds = %86
   %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %89, i32 0, i32 9
   %92 = load i32, i32 addrspace(1)* %91, align 8
   %93 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.IO.StreamWriter addrspace(1)* %93, null
-  br i1 %NullCheck26, label %94, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.IO.StreamWriter addrspace(1)* %93, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %93, i32 0, i32 6
@@ -12572,8 +14281,8 @@ entry:
   %97 = load i8, i8* %arg2
   %98 = zext i8 %97 to i32
   %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
-  %NullCheck28 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck28, label %100, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
   %101 = load i64, i64 addrspace(1)* %99
@@ -12588,8 +14297,8 @@ entry:
   %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
   store i32 %110, i32* %loc1
   %111 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %111, null
-  br i1 %NullCheck30, label %112, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.IO.StreamWriter addrspace(1)* %111, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %112
 
 ; <label>:112                                     ; preds = %100
   %113 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %111, i32 0, i32 9
@@ -12600,23 +14309,23 @@ entry:
 
 ; <label>:116                                     ; preds = %112
   %117 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck32 = icmp ne %System.IO.StreamWriter addrspace(1)* %117, null
-  br i1 %NullCheck32, label %118, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.IO.StreamWriter addrspace(1)* %117, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %118
 
 ; <label>:118                                     ; preds = %116
   %119 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %117, i32 0, i32 3
   %120 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %119, align 8
   %121 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.IO.StreamWriter addrspace(1)* %121, null
-  br i1 %NullCheck34, label %122, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.IO.StreamWriter addrspace(1)* %121, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %122
 
 ; <label>:122                                     ; preds = %118
   %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
   %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
   %125 = load i32, i32* %loc1
   %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
-  %NullCheck36 = icmp ne i64 addrspace(1)* %126, null
-  br i1 %NullCheck36, label %127, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64 addrspace(1)* %126, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
   %128 = load i64, i64 addrspace(1)* %126
@@ -12638,15 +14347,15 @@ entry:
 
 ; <label>:140                                     ; preds = %136
   %141 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.IO.StreamWriter addrspace(1)* %141, null
-  br i1 %NullCheck38, label %142, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.IO.StreamWriter addrspace(1)* %141, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %142
 
 ; <label>:142                                     ; preds = %140
   %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
   %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
   %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
-  %NullCheck40 = icmp ne i64 addrspace(1)* %145, null
-  br i1 %NullCheck40, label %146, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i64 addrspace(1)* %145, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
   %147 = load i64, i64 addrspace(1)* %145
@@ -12667,83 +14376,83 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %25
+ThrowNullRef4:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %32
+ThrowNullRef6:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %37
+ThrowNullRef10:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %41
+ThrowNullRef12:                                   ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %58
+ThrowNullRef14:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %60
+ThrowNullRef16:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %65
+ThrowNullRef18:                                   ; preds = %65
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %80
+ThrowNullRef20:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %82
+ThrowNullRef22:                                   ; preds = %82
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %86
+ThrowNullRef24:                                   ; preds = %86
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %90
+ThrowNullRef26:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %94
+ThrowNullRef28:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %100
+ThrowNullRef30:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %116
+ThrowNullRef32:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %118
+ThrowNullRef34:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %122
+ThrowNullRef36:                                   ; preds = %122
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %140
+ThrowNullRef38:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %142
+ThrowNullRef40:                                   ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12810,8 +14519,8 @@ entry:
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %1 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
-  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
@@ -12819,8 +14528,8 @@ entry:
   %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
   %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
   %8 = load i64, i64 addrspace(1)* %6
@@ -12836,8 +14545,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %17, %System.IFormatProvider addrspace(1)* %16)
   %18 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %19 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %18, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.SyncTextWriter addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %7
   %21 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %18, i32 0, i32 4
@@ -12848,11 +14557,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12865,8 +14574,8 @@ entry:
   %this = alloca %System.IO.TextWriter addrspace(1)*
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.TextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
@@ -12876,8 +14585,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.Threading.Thread addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Threading.Thread addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %6)
@@ -12886,8 +14595,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1
   %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.TextWriter addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.TextWriter addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %11, i32 0, i32 2
@@ -12898,11 +14607,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13099,8 +14808,8 @@ entry:
   store double %param1, double* %arg1
   store i8 0, i8* %loc1
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
@@ -13110,16 +14819,16 @@ entry:
   %5 = addrspacecast i8* %loc1 to i8 addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %4, i8 addrspace(1)* %5)
   %6 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.SyncTextWriter addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
   %10 = load double, double* %arg1
   %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
   %13 = load i64, i64 addrspace(1)* %11
@@ -13154,11 +14863,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13175,8 +14884,8 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load double, double* %arg1
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -13190,8 +14899,8 @@ entry:
   call void %11(%System.IO.TextWriter addrspace(1)* %0, double %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
   %15 = load i64, i64 addrspace(1)* %13
@@ -13209,7 +14918,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13227,8 +14936,8 @@ entry:
   %1 = addrspacecast double* %arg1 to double addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -13243,8 +14952,8 @@ entry:
   %14 = bitcast double addrspace(1)* %1 to %System.Double addrspace(1)*
   %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Double addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Double addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
   %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
   %18 = load i64, i64 addrspace(1)* %16
@@ -13262,7 +14971,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13278,8 +14987,8 @@ entry:
   store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
   %0 = load %System.Double addrspace(1)*, %System.Double addrspace(1)** %this
   %1 = bitcast %System.Double addrspace(1)* %0 to double addrspace(1)*
-  %NullCheck = icmp ne double addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq double addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load double, double addrspace(1)* %1, align 8
@@ -13304,8 +15013,8 @@ entry:
   %loc0 = alloca %System.Globalization.NumberFormatInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 3
@@ -13315,8 +15024,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
@@ -13326,24 +15035,24 @@ entry:
   store %System.Globalization.NumberFormatInfo addrspace(1)* %10, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
   %11 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %7
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
   %15 = load i8, i8 addrspace(1)* %14, align 8
   %16 = zext i8 %15 to i32
   %17 = trunc i32 %16 to i8
-  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %11, null
-  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %11, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %13
   %19 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %11, i32 0, i32 29
   store i8 %17, i8 addrspace(1)* %19
   %20 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %21 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %20, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %20, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %18
   %23 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %20, i32 0, i32 3
@@ -13352,8 +15061,8 @@ entry:
 
 ; <label>:24                                      ; preds = %1, %22
   %25 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %25, null
-  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %25, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %26
 
 ; <label>:26                                      ; preds = %24
   %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %25, i32 0, i32 3
@@ -13364,23 +15073,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %18
+ThrowNullRef8:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13405,168 +15114,168 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 18
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %8, align 8
-  %NullCheck2 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %5, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %5, i32 0, i32 4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %9)
   %12 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 19
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %15, align 8
-  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %12, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %12, i32 0, i32 5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %16)
   %19 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %20 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %20, null
-  br i1 %NullCheck8, label %21, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %20, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %20, i32 0, i32 23
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  %NullCheck10 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %19, null
-  br i1 %NullCheck10, label %24, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %19, i32 0, i32 7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %25, %System.String addrspace(1)* %23)
   %26 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %27 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %27, i32 0, i32 22
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %29, align 8
-  %NullCheck14 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %26, null
-  br i1 %NullCheck14, label %31, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %26, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %26, i32 0, i32 6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %32, %System.String addrspace(1)* %30)
   %33 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %34 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Globalization.CultureData addrspace(1)* %34, null
-  br i1 %NullCheck16, label %35, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Globalization.CultureData addrspace(1)* %34, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %34, i32 0, i32 51
   %37 = load i32, i32 addrspace(1)* %36, align 8
-  %NullCheck18 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %33, null
-  br i1 %NullCheck18, label %38, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %33, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %33, i32 0, i32 21
   store i32 %37, i32 addrspace(1)* %39
   %40 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %41 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Globalization.CultureData addrspace(1)* %41, null
-  br i1 %NullCheck20, label %42, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Globalization.CultureData addrspace(1)* %41, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %41, i32 0, i32 52
   %44 = load i32, i32 addrspace(1)* %43, align 8
-  %NullCheck22 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %40, null
-  br i1 %NullCheck22, label %45, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %40, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %40, i32 0, i32 25
   store i32 %44, i32 addrspace(1)* %46
   %47 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %48 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.Globalization.CultureData addrspace(1)* %48, null
-  br i1 %NullCheck24, label %49, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Globalization.CultureData addrspace(1)* %48, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %49
 
 ; <label>:49                                      ; preds = %45
   %50 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %48, i32 0, i32 29
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck26 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %47, null
-  br i1 %NullCheck26, label %52, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %47, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %47, i32 0, i32 10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %53, %System.String addrspace(1)* %51)
   %54 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %55 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Globalization.CultureData addrspace(1)* %55, null
-  br i1 %NullCheck28, label %56, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Globalization.CultureData addrspace(1)* %55, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %56
 
 ; <label>:56                                      ; preds = %52
   %57 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %55, i32 0, i32 35
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %57, align 8
-  %NullCheck30 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %54, null
-  br i1 %NullCheck30, label %59, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %54, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %54, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %60, %System.String addrspace(1)* %58)
   %61 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %62 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck32 = icmp ne %System.Globalization.CultureData addrspace(1)* %62, null
-  br i1 %NullCheck32, label %63, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Globalization.CultureData addrspace(1)* %62, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %62, i32 0, i32 34
   %65 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %64, align 8
-  %NullCheck34 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %61, null
-  br i1 %NullCheck34, label %66, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %61, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %61, i32 0, i32 9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %67, %System.String addrspace(1)* %65)
   %68 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %69 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck36 = icmp ne %System.Globalization.CultureData addrspace(1)* %69, null
-  br i1 %NullCheck36, label %70, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Globalization.CultureData addrspace(1)* %69, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %70
 
 ; <label>:70                                      ; preds = %66
   %71 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %69, i32 0, i32 55
   %72 = load i32, i32 addrspace(1)* %71, align 8
-  %NullCheck38 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %68, null
-  br i1 %NullCheck38, label %73, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %68, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %68, i32 0, i32 22
   store i32 %72, i32 addrspace(1)* %74
   %75 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %76 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck40 = icmp ne %System.Globalization.CultureData addrspace(1)* %76, null
-  br i1 %NullCheck40, label %77, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Globalization.CultureData addrspace(1)* %76, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %76, i32 0, i32 57
   %79 = load i32, i32 addrspace(1)* %78, align 8
-  %NullCheck42 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %75, null
-  br i1 %NullCheck42, label %80, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %75, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %80
 
 ; <label>:80                                      ; preds = %77
   %81 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %75, i32 0, i32 24
   store i32 %79, i32 addrspace(1)* %81
   %82 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %83 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck44 = icmp ne %System.Globalization.CultureData addrspace(1)* %83, null
-  br i1 %NullCheck44, label %84, label %ThrowNullRef43
+  %NullCheck43 = icmp eq %System.Globalization.CultureData addrspace(1)* %83, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %84
 
 ; <label>:84                                      ; preds = %80
   %85 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %83, i32 0, i32 56
   %86 = load i32, i32 addrspace(1)* %85, align 8
-  %NullCheck46 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %82, null
-  br i1 %NullCheck46, label %87, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %82, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %82, i32 0, i32 23
@@ -13575,8 +15284,8 @@ entry:
 
 ; <label>:89                                      ; preds = %entry
   %90 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck100 = icmp ne %System.Globalization.CultureData addrspace(1)* %90, null
-  br i1 %NullCheck100, label %91, label %ThrowNullRef99
+  %NullCheck99 = icmp eq %System.Globalization.CultureData addrspace(1)* %90, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %91
 
 ; <label>:91                                      ; preds = %89
   %92 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %90, i32 0, i32 2
@@ -13594,8 +15303,8 @@ entry:
   %102 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %103 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %104 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %103)
-  %NullCheck48 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %102, null
-  br i1 %NullCheck48, label %105, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %102, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %105
 
 ; <label>:105                                     ; preds = %101
   %106 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %102, i32 0, i32 1
@@ -13603,8 +15312,8 @@ entry:
   %107 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %108 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %109 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %108)
-  %NullCheck50 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %107, null
-  br i1 %NullCheck50, label %110, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %107, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %110
 
 ; <label>:110                                     ; preds = %105
   %111 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %107, i32 0, i32 2
@@ -13612,8 +15321,8 @@ entry:
   %112 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %113 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %114 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %113)
-  %NullCheck52 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %112, null
-  br i1 %NullCheck52, label %115, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %112, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %115
 
 ; <label>:115                                     ; preds = %110
   %116 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %112, i32 0, i32 27
@@ -13621,8 +15330,8 @@ entry:
   %117 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %118 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %119 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %118)
-  %NullCheck54 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %117, null
-  br i1 %NullCheck54, label %120, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %117, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %120
 
 ; <label>:120                                     ; preds = %115
   %121 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %117, i32 0, i32 26
@@ -13630,8 +15339,8 @@ entry:
   %122 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %123 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %124 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %123)
-  %NullCheck56 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %122, null
-  br i1 %NullCheck56, label %125, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %122, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %125
 
 ; <label>:125                                     ; preds = %120
   %126 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %122, i32 0, i32 17
@@ -13639,8 +15348,8 @@ entry:
   %127 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %128 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %129 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %128)
-  %NullCheck58 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %127, null
-  br i1 %NullCheck58, label %130, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %127, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %130
 
 ; <label>:130                                     ; preds = %125
   %131 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %127, i32 0, i32 18
@@ -13648,8 +15357,8 @@ entry:
   %132 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %133 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %134 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %133)
-  %NullCheck60 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %132, null
-  br i1 %NullCheck60, label %135, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %132, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %135
 
 ; <label>:135                                     ; preds = %130
   %136 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %132, i32 0, i32 14
@@ -13657,8 +15366,8 @@ entry:
   %137 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %138 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %139 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %138)
-  %NullCheck62 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %137, null
-  br i1 %NullCheck62, label %140, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %137, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %140
 
 ; <label>:140                                     ; preds = %135
   %141 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %137, i32 0, i32 13
@@ -13666,71 +15375,71 @@ entry:
   %142 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %143 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %144 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %143)
-  %NullCheck64 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %142, null
-  br i1 %NullCheck64, label %145, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %142, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %145
 
 ; <label>:145                                     ; preds = %140
   %146 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %142, i32 0, i32 12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %146, %System.String addrspace(1)* %144)
   %147 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %148 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck66 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %148, null
-  br i1 %NullCheck66, label %149, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %148, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %149
 
 ; <label>:149                                     ; preds = %145
   %150 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %148, i32 0, i32 21
   %151 = load i32, i32 addrspace(1)* %150, align 8
-  %NullCheck68 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %147, null
-  br i1 %NullCheck68, label %152, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %147, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %152
 
 ; <label>:152                                     ; preds = %149
   %153 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %147, i32 0, i32 28
   store i32 %151, i32 addrspace(1)* %153
   %154 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %155 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck70 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %155, null
-  br i1 %NullCheck70, label %156, label %ThrowNullRef69
+  %NullCheck69 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %155, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %156
 
 ; <label>:156                                     ; preds = %152
   %157 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %155, i32 0, i32 6
   %158 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %157, align 8
-  %NullCheck72 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %154, null
-  br i1 %NullCheck72, label %159, label %ThrowNullRef71
+  %NullCheck71 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %154, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %159
 
 ; <label>:159                                     ; preds = %156
   %160 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %154, i32 0, i32 15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %160, %System.String addrspace(1)* %158)
   %161 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %162 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck74 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %162, null
-  br i1 %NullCheck74, label %163, label %ThrowNullRef73
+  %NullCheck73 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %162, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %163
 
 ; <label>:163                                     ; preds = %159
   %164 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %162, i32 0, i32 1
   %165 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %164, align 8
-  %NullCheck76 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %161, null
-  br i1 %NullCheck76, label %166, label %ThrowNullRef75
+  %NullCheck75 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %161, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %166
 
 ; <label>:166                                     ; preds = %163
   %167 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %161, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %167, %"System.Int32[]" addrspace(1)* %165)
   %168 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %169 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck78 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %169, null
-  br i1 %NullCheck78, label %170, label %ThrowNullRef77
+  %NullCheck77 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %169, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %170
 
 ; <label>:170                                     ; preds = %166
   %171 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %169, i32 0, i32 7
   %172 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %171, align 8
-  %NullCheck80 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %168, null
-  br i1 %NullCheck80, label %173, label %ThrowNullRef79
+  %NullCheck79 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %168, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %173
 
 ; <label>:173                                     ; preds = %170
   %174 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %168, i32 0, i32 16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %174, %System.String addrspace(1)* %172)
   %175 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck82 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %175, null
-  br i1 %NullCheck82, label %176, label %ThrowNullRef81
+  %NullCheck81 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %175, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %176
 
 ; <label>:176                                     ; preds = %173
   %177 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %175, i32 0, i32 4
@@ -13740,14 +15449,14 @@ entry:
 
 ; <label>:180                                     ; preds = %176
   %181 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck84 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %181, null
-  br i1 %NullCheck84, label %182, label %ThrowNullRef83
+  %NullCheck83 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %181, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %182
 
 ; <label>:182                                     ; preds = %180
   %183 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %181, i32 0, i32 4
   %184 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %183, align 8
-  %NullCheck86 = icmp ne %System.String addrspace(1)* %184, null
-  br i1 %NullCheck86, label %185, label %ThrowNullRef85
+  %NullCheck85 = icmp eq %System.String addrspace(1)* %184, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %185
 
 ; <label>:185                                     ; preds = %182
   %186 = getelementptr inbounds %System.String, %System.String addrspace(1)* %184, i32 0, i32 1
@@ -13758,8 +15467,8 @@ entry:
 ; <label>:189                                     ; preds = %176, %185
   %190 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck98 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %190, null
-  br i1 %NullCheck98, label %192, label %ThrowNullRef97
+  %NullCheck97 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %190, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %192
 
 ; <label>:192                                     ; preds = %189
   %193 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %190, i32 0, i32 4
@@ -13768,8 +15477,8 @@ entry:
 
 ; <label>:194                                     ; preds = %185, %192
   %195 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck88 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %195, null
-  br i1 %NullCheck88, label %196, label %ThrowNullRef87
+  %NullCheck87 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %195, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %196
 
 ; <label>:196                                     ; preds = %194
   %197 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %195, i32 0, i32 9
@@ -13779,14 +15488,14 @@ entry:
 
 ; <label>:200                                     ; preds = %196
   %201 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck90 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %201, null
-  br i1 %NullCheck90, label %202, label %ThrowNullRef89
+  %NullCheck89 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %201, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %202
 
 ; <label>:202                                     ; preds = %200
   %203 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %201, i32 0, i32 9
   %204 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %203, align 8
-  %NullCheck92 = icmp ne %System.String addrspace(1)* %204, null
-  br i1 %NullCheck92, label %205, label %ThrowNullRef91
+  %NullCheck91 = icmp eq %System.String addrspace(1)* %204, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %205
 
 ; <label>:205                                     ; preds = %202
   %206 = getelementptr inbounds %System.String, %System.String addrspace(1)* %204, i32 0, i32 1
@@ -13797,14 +15506,14 @@ entry:
 ; <label>:209                                     ; preds = %196, %205
   %210 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %211 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck94 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %211, null
-  br i1 %NullCheck94, label %212, label %ThrowNullRef93
+  %NullCheck93 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %211, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %212
 
 ; <label>:212                                     ; preds = %209
   %213 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %211, i32 0, i32 6
   %214 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %213, align 8
-  %NullCheck96 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %210, null
-  br i1 %NullCheck96, label %215, label %ThrowNullRef95
+  %NullCheck95 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %210, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %215
 
 ; <label>:215                                     ; preds = %212
   %216 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %210, i32 0, i32 9
@@ -13818,203 +15527,203 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %17
+ThrowNullRef8:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %21
+ThrowNullRef10:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %24
+ThrowNullRef12:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %28
+ThrowNullRef14:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %31
+ThrowNullRef16:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %35
+ThrowNullRef18:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %38
+ThrowNullRef20:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %42
+ThrowNullRef22:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %45
+ThrowNullRef24:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %49
+ThrowNullRef26:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %52
+ThrowNullRef28:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %56
+ThrowNullRef30:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %59
+ThrowNullRef32:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %63
+ThrowNullRef34:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %66
+ThrowNullRef36:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %70
+ThrowNullRef38:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %73
+ThrowNullRef40:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %77
+ThrowNullRef42:                                   ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %80
+ThrowNullRef44:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %84
+ThrowNullRef46:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %101
+ThrowNullRef48:                                   ; preds = %101
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %105
+ThrowNullRef50:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %110
+ThrowNullRef52:                                   ; preds = %110
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %115
+ThrowNullRef54:                                   ; preds = %115
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %120
+ThrowNullRef56:                                   ; preds = %120
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %125
+ThrowNullRef58:                                   ; preds = %125
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %130
+ThrowNullRef60:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %135
+ThrowNullRef62:                                   ; preds = %135
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %140
+ThrowNullRef64:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %145
+ThrowNullRef66:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %149
+ThrowNullRef68:                                   ; preds = %149
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %152
+ThrowNullRef70:                                   ; preds = %152
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %156
+ThrowNullRef72:                                   ; preds = %156
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %159
+ThrowNullRef74:                                   ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %163
+ThrowNullRef76:                                   ; preds = %163
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %166
+ThrowNullRef78:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %170
+ThrowNullRef80:                                   ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %173
+ThrowNullRef82:                                   ; preds = %173
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %180
+ThrowNullRef84:                                   ; preds = %180
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %182
+ThrowNullRef86:                                   ; preds = %182
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %194
+ThrowNullRef88:                                   ; preds = %194
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %200
+ThrowNullRef90:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %202
+ThrowNullRef92:                                   ; preds = %202
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %209
+ThrowNullRef94:                                   ; preds = %209
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %212
+ThrowNullRef96:                                   ; preds = %212
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %189
+ThrowNullRef98:                                   ; preds = %189
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %89
+ThrowNullRef100:                                  ; preds = %89
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14042,8 +15751,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 21
@@ -14056,8 +15765,8 @@ entry:
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 16)
   %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 21
@@ -14066,8 +15775,8 @@ entry:
 
 ; <label>:12                                      ; preds = %1, %10
   %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 21
@@ -14078,11 +15787,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %12
+ThrowNullRef4:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14098,8 +15807,8 @@ entry:
   store i32 %param1, i32* %arg1
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %1 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
@@ -14166,8 +15875,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 33
@@ -14180,8 +15889,8 @@ entry:
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 24)
   %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 33
@@ -14190,8 +15899,8 @@ entry:
 
 ; <label>:12                                      ; preds = %1, %10
   %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 33
@@ -14202,11 +15911,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %12
+ThrowNullRef4:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14219,8 +15928,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 53
@@ -14232,8 +15941,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 116)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 53
@@ -14242,8 +15951,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 53
@@ -14254,11 +15963,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14287,8 +15996,8 @@ entry:
 
 ; <label>:7                                       ; preds = %entry, %4
   %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %7
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 2
@@ -14312,8 +16021,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 54
@@ -14325,8 +16034,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 117)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
@@ -14335,8 +16044,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 54
@@ -14347,11 +16056,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14364,8 +16073,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 27
@@ -14377,8 +16086,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 118)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 27
@@ -14387,8 +16096,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 27
@@ -14399,11 +16108,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14416,8 +16125,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 28
@@ -14429,8 +16138,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 119)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 28
@@ -14439,8 +16148,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 28
@@ -14451,11 +16160,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14468,8 +16177,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 26
@@ -14481,8 +16190,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 107)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 26
@@ -14491,8 +16200,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 26
@@ -14503,11 +16212,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14520,8 +16229,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 25
@@ -14533,8 +16242,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 106)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 25
@@ -14543,8 +16252,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 25
@@ -14555,11 +16264,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14572,8 +16281,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 24
@@ -14585,8 +16294,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 105)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 24
@@ -14595,8 +16304,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 24
@@ -14607,11 +16316,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14636,8 +16345,8 @@ entry:
   %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %3)
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %2
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -14648,15 +16357,15 @@ entry:
 
 ; <label>:8                                       ; preds = %62
   %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 9
   %12 = load i32, i32 addrspace(1)* %11, align 8
   %13 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.IO.StreamWriter addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %13, i32 0, i32 10
@@ -14671,15 +16380,15 @@ entry:
 
 ; <label>:20                                      ; preds = %14, %18
   %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
   %24 = load i32, i32 addrspace(1)* %23, align 8
   %25 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %25, null
-  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.StreamWriter addrspace(1)* %25, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %25, i32 0, i32 9
@@ -14700,36 +16409,36 @@ entry:
   %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %37 = load i32, i32* %loc1
   %38 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.StreamWriter addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %35
   %40 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %38, i32 0, i32 7
   %41 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %40, align 8
   %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
-  br i1 %NullCheck14, label %43, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %39
   %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 9
   %45 = load i32, i32 addrspace(1)* %44, align 8
   %46 = load i32, i32* %loc2
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %36, null
-  br i1 %NullCheck16, label %47, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %36, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %47
 
 ; <label>:47                                      ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %36, i32 %37, %"System.Char[]" addrspace(1)* %41, i32 %45, i32 %46)
   %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
   %51 = load i32, i32 addrspace(1)* %50, align 8
   %52 = load i32, i32* %loc2
   %53 = add i32 %51, %52
-  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
-  br i1 %NullCheck20, label %54, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %54
 
 ; <label>:54                                      ; preds = %49
   %55 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
@@ -14751,8 +16460,8 @@ entry:
 
 ; <label>:65                                      ; preds = %62
   %66 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %66, null
-  br i1 %NullCheck2, label %67, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %66, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %67
 
 ; <label>:67                                      ; preds = %65
   %68 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %66, i32 0, i32 11
@@ -14773,49 +16482,259 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %65
+ThrowNullRef2:                                    ; preds = %65
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %20
+ThrowNullRef8:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %22
+ThrowNullRef10:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %35
+ThrowNullRef12:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %43
+ThrowNullRef16:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %47
+ThrowNullRef18:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method String::CopyTo using LLILCJit
-Failed to read String.CopyTo[loadElemA]
+Successfully read String.CopyTo
+
+define void @String.CopyTo(%System.String addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  %loc1 = alloca i16 addrspace(1)*
+  %loc2 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %1 = icmp ne %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg4
+  %7 = icmp sge i32 %6, 0
+  br i1 %7, label %13, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  unreachable
+
+; <label>:13                                      ; preds = %5
+  %14 = load i32, i32* %arg1
+  %15 = icmp sge i32 %14, 0
+  br i1 %15, label %21, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %18)
+  %20 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %20, %System.String addrspace(1)* %17, %System.String addrspace(1)* %19)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %20) #0
+  unreachable
+
+; <label>:21                                      ; preds = %13
+  %22 = load i32, i32* %arg4
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck, label %ThrowNullRef, label %24
+
+; <label>:24                                      ; preds = %21
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load i32, i32* %arg1
+  %28 = sub i32 %26, %27
+  %29 = icmp sle i32 %22, %28
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34, %System.String addrspace(1)* %31, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %24
+  %36 = load i32, i32* %arg3
+  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %37, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
+
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
+  %40 = load i32, i32 addrspace(1)* %39
+  %41 = zext i32 %40 to i64
+  %42 = trunc i64 %41 to i32
+  %43 = load i32, i32* %arg4
+  %44 = sub i32 %42, %43
+  %45 = icmp sgt i32 %36, %44
+  br i1 %45, label %49, label %46
+
+; <label>:46                                      ; preds = %38
+  %47 = load i32, i32* %arg3
+  %48 = icmp sge i32 %47, 0
+  br i1 %48, label %54, label %49
+
+; <label>:49                                      ; preds = %38, %46
+  %50 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %52 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %51)
+  %53 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53, %System.String addrspace(1)* %50, %System.String addrspace(1)* %52)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53) #0
+  unreachable
+
+; <label>:54                                      ; preds = %46
+  %55 = load i32, i32* %arg4
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %97, label %57
+
+; <label>:57                                      ; preds = %54
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %59
+
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 2
+  %61 = bitcast [0 x i16] addrspace(1)* %60 to i16 addrspace(1)*
+  store i16 addrspace(1)* %61, i16 addrspace(1)** %loc0
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  store %"System.Char[]" addrspace(1)* %62, %"System.Char[]" addrspace(1)** %loc2
+  %63 = icmp eq %"System.Char[]" addrspace(1)* %62, null
+  br i1 %63, label %72, label %64
+
+; <label>:64                                      ; preds = %59
+  %65 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc2
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %65, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %66
+
+; <label>:66                                      ; preds = %64
+  %67 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %65, i32 0, i32 1
+  %68 = load i32, i32 addrspace(1)* %67
+  %69 = zext i32 %68 to i64
+  %70 = trunc i64 %69 to i32
+  %71 = icmp ne i32 %70, 0
+  br i1 %71, label %73, label %72
+
+; <label>:72                                      ; preds = %59, %66
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  br label %81
+
+; <label>:73                                      ; preds = %66
+  %74 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc2
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %74, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %75
+
+; <label>:75                                      ; preds = %73
+  %76 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %74, i32 0, i32 1
+  %77 = load i32, i32 addrspace(1)* %76
+  %78 = zext i32 %77 to i64
+  %BoundsCheck = icmp uge i64 0, %78
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %79
+
+; <label>:79                                      ; preds = %75
+  %80 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %74, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %80, i16 addrspace(1)** %loc1
+  br label %81
+
+; <label>:81                                      ; preds = %72, %79
+  %82 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %83 = ptrtoint i16 addrspace(1)* %82 to i64
+  %84 = load i32, i32* %arg3
+  %85 = sext i32 %84 to i64
+  %86 = mul i64 %85, 2
+  %87 = add i64 %83, %86
+  %88 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %89 = ptrtoint i16 addrspace(1)* %88 to i64
+  %90 = load i32, i32* %arg1
+  %91 = sext i32 %90 to i64
+  %92 = mul i64 %91, 2
+  %93 = add i64 %89, %92
+  %94 = load i32, i32* %arg4
+  %95 = inttoptr i64 %87 to i16*
+  %96 = inttoptr i64 %93 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %95, i16* %96, i32 %94)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  br label %97
+
+; <label>:97                                      ; preds = %54, %81
+  ret void
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
 Successfully read ConsoleEncoding.GetPreamble
 
@@ -14852,7 +16771,365 @@ entry:
 }
 
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[loadElemA]
+Successfully read EncoderNLS.GetBytes
+
+define i32 @EncoderNLS.GetBytes(%System.Text.EncoderNLS addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3, %"System.Byte[]" addrspace(1)* %param4, i32 %param5, i8 %param6) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %arg4 = alloca %"System.Byte[]" addrspace(1)*
+  %arg5 = alloca i32
+  %arg6 = alloca i8
+  %loc0 = alloca i32
+  %loc1 = alloca i16 addrspace(1)*
+  %loc2 = alloca i8 addrspace(1)*
+  %loc3 = alloca i32
+  %loc4 = alloca %"System.Char[]" addrspace(1)*
+  %loc5 = alloca %"System.Byte[]" addrspace(1)*
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  store %"System.Byte[]" addrspace(1)* %param4, %"System.Byte[]" addrspace(1)** %arg4
+  store i32 %param5, i32* %arg5
+  store i8 %param6, i8* %arg6
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %1 = icmp eq %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %17, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %7 = icmp eq %"System.Char[]" addrspace(1)* %6, null
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %12
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %12
+
+; <label>:12                                      ; preds = %8, %10
+  %13 = phi %System.String addrspace(1)* [ %9, %8 ], [ %11, %10 ]
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %14)
+  %16 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16, %System.String addrspace(1)* %13, %System.String addrspace(1)* %15)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16) #0
+  unreachable
+
+; <label>:17                                      ; preds = %2
+  %18 = load i32, i32* %arg2
+  %19 = icmp slt i32 %18, 0
+  br i1 %19, label %23, label %20
+
+; <label>:20                                      ; preds = %17
+  %21 = load i32, i32* %arg3
+  %22 = icmp sge i32 %21, 0
+  br i1 %22, label %35, label %23
+
+; <label>:23                                      ; preds = %17, %20
+  %24 = load i32, i32* %arg2
+  %25 = icmp slt i32 %24, 0
+  br i1 %25, label %28, label %26
+
+; <label>:26                                      ; preds = %23
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %30
+
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %30
+
+; <label>:30                                      ; preds = %26, %28
+  %31 = phi %System.String addrspace(1)* [ %27, %26 ], [ %29, %28 ]
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34, %System.String addrspace(1)* %31, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %20
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck, label %ThrowNullRef, label %37
+
+; <label>:37                                      ; preds = %35
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = load i32, i32* %arg2
+  %43 = sub i32 %41, %42
+  %44 = load i32, i32* %arg3
+  %45 = icmp sge i32 %43, %44
+  br i1 %45, label %51, label %46
+
+; <label>:46                                      ; preds = %37
+  %47 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %48 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %49 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %48)
+  %50 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %50, %System.String addrspace(1)* %47, %System.String addrspace(1)* %49)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %50) #0
+  unreachable
+
+; <label>:51                                      ; preds = %37
+  %52 = load i32, i32* %arg5
+  %53 = icmp slt i32 %52, 0
+  br i1 %53, label %63, label %54
+
+; <label>:54                                      ; preds = %51
+  %55 = load i32, i32* %arg5
+  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck1 = icmp eq %"System.Byte[]" addrspace(1)* %56, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %57
+
+; <label>:57                                      ; preds = %54
+  %58 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = zext i32 %59 to i64
+  %61 = trunc i64 %60 to i32
+  %62 = icmp sle i32 %55, %61
+  br i1 %62, label %68, label %63
+
+; <label>:63                                      ; preds = %51, %57
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %66 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %65)
+  %67 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %67, %System.String addrspace(1)* %64, %System.String addrspace(1)* %66)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %67) #0
+  unreachable
+
+; <label>:68                                      ; preds = %57
+  %69 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %69, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %69, i32 0, i32 1
+  %72 = load i32, i32 addrspace(1)* %71
+  %73 = zext i32 %72 to i64
+  %74 = trunc i64 %73 to i32
+  %75 = icmp ne i32 %74, 0
+  br i1 %75, label %78, label %76
+
+; <label>:76                                      ; preds = %70
+  %77 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1)
+  store %"System.Char[]" addrspace(1)* %77, %"System.Char[]" addrspace(1)** %arg1
+  br label %78
+
+; <label>:78                                      ; preds = %70, %76
+  %79 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck5 = icmp eq %"System.Byte[]" addrspace(1)* %79, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %80
+
+; <label>:80                                      ; preds = %78
+  %81 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %79, i32 0, i32 1
+  %82 = load i32, i32 addrspace(1)* %81
+  %83 = zext i32 %82 to i64
+  %84 = trunc i64 %83 to i32
+  %85 = load i32, i32* %arg5
+  %86 = sub i32 %84, %85
+  store i32 %86, i32* %loc0
+  %87 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck7 = icmp eq %"System.Byte[]" addrspace(1)* %87, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %88
+
+; <label>:88                                      ; preds = %80
+  %89 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %87, i32 0, i32 1
+  %90 = load i32, i32 addrspace(1)* %89
+  %91 = zext i32 %90 to i64
+  %92 = trunc i64 %91 to i32
+  %93 = icmp ne i32 %92, 0
+  br i1 %93, label %96, label %94
+
+; <label>:94                                      ; preds = %88
+  %95 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1)
+  store %"System.Byte[]" addrspace(1)* %95, %"System.Byte[]" addrspace(1)** %arg4
+  br label %96
+
+; <label>:96                                      ; preds = %88, %94
+  %97 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  store %"System.Char[]" addrspace(1)* %97, %"System.Char[]" addrspace(1)** %loc4
+  %98 = icmp eq %"System.Char[]" addrspace(1)* %97, null
+  br i1 %98, label %107, label %99
+
+; <label>:99                                      ; preds = %96
+  %100 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc4
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %100, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %101
+
+; <label>:101                                     ; preds = %99
+  %102 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %100, i32 0, i32 1
+  %103 = load i32, i32 addrspace(1)* %102
+  %104 = zext i32 %103 to i64
+  %105 = trunc i64 %104 to i32
+  %106 = icmp ne i32 %105, 0
+  br i1 %106, label %108, label %107
+
+; <label>:107                                     ; preds = %96, %101
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  br label %116
+
+; <label>:108                                     ; preds = %101
+  %109 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc4
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %109, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %110
+
+; <label>:110                                     ; preds = %108
+  %111 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %109, i32 0, i32 1
+  %112 = load i32, i32 addrspace(1)* %111
+  %113 = zext i32 %112 to i64
+  %BoundsCheck = icmp uge i64 0, %113
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %114
+
+; <label>:114                                     ; preds = %110
+  %115 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %109, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %115, i16 addrspace(1)** %loc1
+  br label %116
+
+; <label>:116                                     ; preds = %107, %114
+  %117 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  store %"System.Byte[]" addrspace(1)* %117, %"System.Byte[]" addrspace(1)** %loc5
+  %118 = icmp eq %"System.Byte[]" addrspace(1)* %117, null
+  br i1 %118, label %127, label %119
+
+; <label>:119                                     ; preds = %116
+  %120 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc5
+  %NullCheck13 = icmp eq %"System.Byte[]" addrspace(1)* %120, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %121
+
+; <label>:121                                     ; preds = %119
+  %122 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %120, i32 0, i32 1
+  %123 = load i32, i32 addrspace(1)* %122
+  %124 = zext i32 %123 to i64
+  %125 = trunc i64 %124 to i32
+  %126 = icmp ne i32 %125, 0
+  br i1 %126, label %128, label %127
+
+; <label>:127                                     ; preds = %116, %121
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc2
+  br label %136
+
+; <label>:128                                     ; preds = %121
+  %129 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc5
+  %NullCheck15 = icmp eq %"System.Byte[]" addrspace(1)* %129, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %130
+
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %129, i32 0, i32 1
+  %132 = load i32, i32 addrspace(1)* %131
+  %133 = zext i32 %132 to i64
+  %BoundsCheck17 = icmp uge i64 0, %133
+  br i1 %BoundsCheck17, label %ThrowIndexOutOfRange18, label %134
+
+; <label>:134                                     ; preds = %130
+  %135 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %129, i32 0, i32 3, i32 0
+  store i8 addrspace(1)* %135, i8 addrspace(1)** %loc2
+  br label %136
+
+; <label>:136                                     ; preds = %127, %134
+  %137 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %138 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %139 = ptrtoint i16 addrspace(1)* %138 to i64
+  %140 = load i32, i32* %arg2
+  %141 = sext i32 %140 to i64
+  %142 = mul i64 %141, 2
+  %143 = add i64 %139, %142
+  %144 = load i32, i32* %arg3
+  %145 = load i8 addrspace(1)*, i8 addrspace(1)** %loc2
+  %146 = ptrtoint i8 addrspace(1)* %145 to i64
+  %147 = load i32, i32* %arg5
+  %148 = sext i32 %147 to i64
+  %149 = add i64 %146, %148
+  %150 = load i32, i32* %loc0
+  %151 = load i8, i8* %arg6
+  %152 = zext i8 %151 to i32
+  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i64 addrspace(1)*
+  %NullCheck19 = icmp eq i64 addrspace(1)* %153, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %154
+
+; <label>:154                                     ; preds = %136
+  %155 = load i64, i64 addrspace(1)* %153
+  %156 = add i64 %155, 72
+  %157 = inttoptr i64 %156 to i64*
+  %158 = load i64, i64* %157
+  %159 = add i64 %158, 0
+  %160 = inttoptr i64 %159 to i64*
+  %161 = load i64, i64* %160
+  %162 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to %System.Text.Encoder addrspace(1)*
+  %163 = inttoptr i64 %143 to i16*
+  %164 = inttoptr i64 %149 to i8*
+  %165 = trunc i32 %152 to i8
+  %166 = inttoptr i64 %161 to i32 (%System.Text.Encoder addrspace(1)*, i16*, i32, i8*, i32, i8)*
+  %167 = call i32 %166(%System.Text.Encoder addrspace(1)* %162, i16* %163, i32 %144, i8* %164, i32 %150, i8 %165)
+  store i32 %167, i32* %loc3
+  br label %168
+
+; <label>:168                                     ; preds = %154
+  %169 = load i32, i32* %loc3
+  ret i32 %169
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %110
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %119
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange18:                           ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
 Successfully read EncoderNLS.GetBytes
 
@@ -14941,22 +17218,22 @@ entry:
   %40 = load i8, i8* %arg5
   %41 = zext i8 %40 to i32
   %42 = trunc i32 %41 to i8
-  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %39, null
-  br i1 %NullCheck, label %43, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderNLS addrspace(1)* %39, null
+  br i1 %NullCheck, label %ThrowNullRef, label %43
 
 ; <label>:43                                      ; preds = %38
   %44 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
   store i8 %42, i8 addrspace(1)* %44
   %45 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %45, null
-  br i1 %NullCheck2, label %46, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.EncoderNLS addrspace(1)* %45, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %46
 
 ; <label>:46                                      ; preds = %43
   %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %45, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %47
   %48 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.EncoderNLS addrspace(1)* %48, null
-  br i1 %NullCheck4, label %49, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.EncoderNLS addrspace(1)* %48, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %49
 
 ; <label>:49                                      ; preds = %46
   %50 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %48, i32 0, i32 3
@@ -14967,8 +17244,8 @@ entry:
   %55 = load i32, i32* %arg4
   %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck6, label %58, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
   %59 = load i64, i64 addrspace(1)* %57
@@ -14986,15 +17263,15 @@ ThrowNullRef:                                     ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %43
+ThrowNullRef2:                                    ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %46
+ThrowNullRef4:                                    ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %49
+ThrowNullRef6:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -15022,8 +17299,8 @@ entry:
   %4 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0 to %System.IO.ConsoleStream addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*)(%System.IO.ConsoleStream addrspace(1)* %4, %"System.Byte[]" addrspace(1)* %1, i32 %2, i32 %3)
   %5 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
@@ -15108,8 +17385,8 @@ entry:
 
 ; <label>:22                                      ; preds = %8
   %23 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %23, null
-  br i1 %NullCheck, label %24, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Byte[]" addrspace(1)* %23, null
+  br i1 %NullCheck, label %ThrowNullRef, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
@@ -15131,8 +17408,8 @@ entry:
 
 ; <label>:36                                      ; preds = %24
   %37 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %37, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.ConsoleStream addrspace(1)* %37, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %37, i32 0, i32 4
@@ -15153,13 +17430,138 @@ ThrowNullRef:                                     ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %36
+ThrowNullRef2:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
-Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
+Successfully read WindowsConsoleStream.WriteFileNative
+
+define i32 @WindowsConsoleStream.WriteFileNative(i64 %param0, %"System.Byte[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i64
+  %arg1 = alloca %"System.Byte[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i8 addrspace(1)*
+  %loc2 = alloca %"System.Byte[]" addrspace(1)*
+  %loc3 = alloca i32
+  store i64 %param0, i64* %arg0
+  store %"System.Byte[]" addrspace(1)* %param1, %"System.Byte[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Byte[]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = zext i32 %3 to i64
+  %5 = icmp ne i64 %4, 0
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %1
+  ret i32 0
+
+; <label>:7                                       ; preds = %1
+  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  store %"System.Byte[]" addrspace(1)* %8, %"System.Byte[]" addrspace(1)** %loc2
+  %9 = icmp eq %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %9, label %18, label %10
+
+; <label>:10                                      ; preds = %7
+  %11 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc2
+  %NullCheck1 = icmp eq %"System.Byte[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %11, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp ne i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %7, %12
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc1
+  br label %27
+
+; <label>:19                                      ; preds = %12
+  %20 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc2
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %20, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %BoundsCheck = icmp uge i64 0, %24
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %25
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %20, i32 0, i32 3, i32 0
+  store i8 addrspace(1)* %26, i8 addrspace(1)** %loc1
+  br label %27
+
+; <label>:27                                      ; preds = %18, %25
+  %28 = load i64, i64* %arg0
+  %29 = load i8 addrspace(1)*, i8 addrspace(1)** %loc1
+  %30 = ptrtoint i8 addrspace(1)* %29 to i64
+  %31 = load i32, i32* %arg2
+  %32 = sext i32 %31 to i64
+  %33 = add i64 %30, %32
+  %34 = load i32, i32* %arg3
+  %35 = addrspacecast i32* %loc3 to i32 addrspace(1)*
+  %36 = inttoptr i64 %33 to i8*
+  %37 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i8*, i32, i32 addrspace(1)*, i64)*)(i64 %28, i8* %36, i32 %34, i32 addrspace(1)* %35, i64 0)
+  %38 = icmp ugt i32 %37, 0
+  %39 = sext i1 %38 to i32
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc1
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %42, label %41
+
+; <label>:41                                      ; preds = %27
+  ret i32 0
+
+; <label>:42                                      ; preds = %27
+  %43 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  store i32 %43, i32* %loc0
+  %44 = load i32, i32* %loc0
+  %45 = icmp eq i32 %44, 232
+  br i1 %45, label %49, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = load i32, i32* %loc0
+  %48 = icmp ne i32 %47, 109
+  br i1 %48, label %50, label %49
+
+; <label>:49                                      ; preds = %42, %46
+  ret i32 0
+
+; <label>:50                                      ; preds = %46
+  %51 = load i32, i32* %loc0
+  ret i32 %51
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
 Successfully read WindowsConsoleStream.Flush
 
@@ -15168,8 +17570,8 @@ entry:
   %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
   store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
@@ -15204,8 +17606,8 @@ entry:
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
   %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load i64, i64 addrspace(1)* %1
@@ -15244,15 +17646,15 @@ entry:
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.TextWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
   %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %3, align 8
   %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
   %7 = load i64, i64 addrspace(1)* %5
@@ -15270,7 +17672,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -15299,8 +17701,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %4)
   store i32 0, i32* %loc0
   %5 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Char[]" addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
@@ -15312,15 +17714,15 @@ entry:
 
 ; <label>:11                                      ; preds = %69
   %12 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %12, i32 0, i32 9
   %15 = load i32, i32 addrspace(1)* %14, align 8
   %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.IO.StreamWriter addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %16, i32 0, i32 10
@@ -15335,15 +17737,15 @@ entry:
 
 ; <label>:23                                      ; preds = %17, %21
   %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %24, null
-  br i1 %NullCheck8, label %25, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %24, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 10
   %27 = load i32, i32 addrspace(1)* %26, align 8
   %28 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %28, null
-  br i1 %NullCheck10, label %29, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.StreamWriter addrspace(1)* %28, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %28, i32 0, i32 9
@@ -15365,15 +17767,15 @@ entry:
   %40 = load i32, i32* %loc0
   %41 = mul i32 %40, 2
   %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
-  br i1 %NullCheck12, label %43, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %43
 
 ; <label>:43                                      ; preds = %38
   %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 7
   %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %44, align 8
   %46 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %46, null
-  br i1 %NullCheck14, label %47, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.IO.StreamWriter addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %47
 
 ; <label>:47                                      ; preds = %43
   %48 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %46, i32 0, i32 9
@@ -15385,16 +17787,16 @@ entry:
   %54 = bitcast %"System.Char[]" addrspace(1)* %45 to %System.Array addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %53, i32 %41, %System.Array addrspace(1)* %54, i32 %50, i32 %52)
   %55 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
-  br i1 %NullCheck16, label %56, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %56
 
 ; <label>:56                                      ; preds = %47
   %57 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
   %58 = load i32, i32 addrspace(1)* %57, align 8
   %59 = load i32, i32* %loc2
   %60 = add i32 %58, %59
-  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
-  br i1 %NullCheck18, label %61, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %61
 
 ; <label>:61                                      ; preds = %56
   %62 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
@@ -15416,8 +17818,8 @@ entry:
 
 ; <label>:72                                      ; preds = %69
   %73 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %73, null
-  br i1 %NullCheck2, label %74, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %73, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %74
 
 ; <label>:74                                      ; preds = %72
   %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %73, i32 0, i32 11
@@ -15438,39 +17840,39 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %72
+ThrowNullRef2:                                    ; preds = %72
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %23
+ThrowNullRef8:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef10:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %43
+ThrowNullRef14:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %47
+ThrowNullRef16:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %56
+ThrowNullRef18:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblDiv.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblDiv.error.txt
@@ -25,8 +25,8 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
@@ -40,8 +40,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
   %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
@@ -75,7 +75,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -90,8 +90,8 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %NullCheck = icmp ne i8 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = load i8, i8 addrspace(1)* %0, align 8
@@ -125,8 +125,8 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
@@ -159,8 +159,8 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -184,8 +184,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
   store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
@@ -195,8 +195,8 @@ entry:
 ; <label>:4                                       ; preds = %1
   %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
   %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
@@ -206,8 +206,8 @@ entry:
   %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
@@ -221,14 +221,14 @@ entry:
 
 ; <label>:17                                      ; preds = %14
   %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
   %21 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
@@ -238,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -249,8 +249,8 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
@@ -261,27 +261,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %30
+ThrowNullRef10:                                   ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -301,7 +301,89 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
-Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
+Successfully read AppDomainSetup.GetUnsecureApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.GetUnsecureApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %NullCheck = icmp eq %"System.String[]" addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %BoundsCheck = icmp uge i64 0, %5
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %6
+
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 3, i32 0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
+  ret %System.String addrspace(1)* %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_Value using LLILCJit
+Successfully read AppDomainSetup.get_Value
+
+define %"System.String[]" addrspace(1)* @AppDomainSetup.get_Value(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.String[]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 18)
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.String[]" addrspace(1)* addrspace(1)*, %"System.String[]" addrspace(1)*)*)(%"System.String[]" addrspace(1)* addrspace(1)* %9, %"System.String[]" addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %11, i32 0, i32 1
+  %14 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %13, align 8
+  ret %"System.String[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -319,8 +401,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -368,16 +450,16 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
   %5 = load i32, i32 addrspace(1)* %4
   %6 = sub i32 %5, 1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -389,7 +471,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -421,8 +503,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
@@ -456,8 +538,8 @@ entry:
 ; <label>:27                                      ; preds = %19
   %28 = load i32, i32* %arg1
   %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
-  br i1 %NullCheck2, label %30, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %29, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %30
 
 ; <label>:30                                      ; preds = %27
   %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
@@ -493,8 +575,8 @@ entry:
 ; <label>:49                                      ; preds = %46
   %50 = load i32, i32* %arg2
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck4, label %52, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
@@ -517,11 +599,11 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %27
+ThrowNullRef2:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %49
+ThrowNullRef4:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -544,16 +626,16 @@ entry:
   %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %0)
   store %System.String addrspace(1)* %1, %System.String addrspace(1)** %loc0
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 2
   %5 = bitcast [0 x i16] addrspace(1)* %4 to i16 addrspace(1)*
   store i16 addrspace(1)* %5, i16 addrspace(1)** %loc1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %3
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2
@@ -580,7 +662,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -691,15 +773,15 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %NullCheck132 = icmp ne i8* %21, null
-  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+  %NullCheck131 = icmp eq i8* %21, null
+  br i1 %NullCheck131, label %ThrowNullRef132, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = load i8, i8* %21, align 8
   %24 = zext i8 %23 to i32
   %25 = trunc i32 %24 to i8
-  %NullCheck134 = icmp ne i8* %20, null
-  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+  %NullCheck133 = icmp eq i8* %20, null
+  br i1 %NullCheck133, label %ThrowNullRef134, label %26
 
 ; <label>:26                                      ; preds = %22
   store i8 %25, i8* %20, align 8
@@ -709,16 +791,16 @@ entry:
   %28 = load i8*, i8** %arg0
   %29 = load i8*, i8** %arg1
   %30 = bitcast i8* %29 to i16*
-  %NullCheck128 = icmp ne i16* %30, null
-  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+  %NullCheck127 = icmp eq i16* %30, null
+  br i1 %NullCheck127, label %ThrowNullRef128, label %31
 
 ; <label>:31                                      ; preds = %27
   %32 = load i16, i16* %30, align 8
   %33 = sext i16 %32 to i32
   %34 = bitcast i8* %28 to i16*
   %35 = trunc i32 %33 to i16
-  %NullCheck130 = icmp ne i16* %34, null
-  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+  %NullCheck129 = icmp eq i16* %34, null
+  br i1 %NullCheck129, label %ThrowNullRef130, label %36
 
 ; <label>:36                                      ; preds = %31
   store i16 %35, i16* %34, align 8
@@ -728,16 +810,16 @@ entry:
   %38 = load i8*, i8** %arg0
   %39 = load i8*, i8** %arg1
   %40 = bitcast i8* %39 to i16*
-  %NullCheck120 = icmp ne i16* %40, null
-  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+  %NullCheck119 = icmp eq i16* %40, null
+  br i1 %NullCheck119, label %ThrowNullRef120, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i16, i16* %40, align 8
   %43 = sext i16 %42 to i32
   %44 = bitcast i8* %38 to i16*
   %45 = trunc i32 %43 to i16
-  %NullCheck122 = icmp ne i16* %44, null
-  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+  %NullCheck121 = icmp eq i16* %44, null
+  br i1 %NullCheck121, label %ThrowNullRef122, label %46
 
 ; <label>:46                                      ; preds = %41
   store i16 %45, i16* %44, align 8
@@ -745,15 +827,15 @@ entry:
   %48 = getelementptr inbounds i8, i8* %47, i64 2
   %49 = load i8*, i8** %arg1
   %50 = getelementptr inbounds i8, i8* %49, i64 2
-  %NullCheck124 = icmp ne i8* %50, null
-  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+  %NullCheck123 = icmp eq i8* %50, null
+  br i1 %NullCheck123, label %ThrowNullRef124, label %51
 
 ; <label>:51                                      ; preds = %46
   %52 = load i8, i8* %50, align 8
   %53 = zext i8 %52 to i32
   %54 = trunc i32 %53 to i8
-  %NullCheck126 = icmp ne i8* %48, null
-  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+  %NullCheck125 = icmp eq i8* %48, null
+  br i1 %NullCheck125, label %ThrowNullRef126, label %55
 
 ; <label>:55                                      ; preds = %51
   store i8 %54, i8* %48, align 8
@@ -763,14 +845,14 @@ entry:
   %57 = load i8*, i8** %arg0
   %58 = load i8*, i8** %arg1
   %59 = bitcast i8* %58 to i32*
-  %NullCheck116 = icmp ne i32* %59, null
-  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+  %NullCheck115 = icmp eq i32* %59, null
+  br i1 %NullCheck115, label %ThrowNullRef116, label %60
 
 ; <label>:60                                      ; preds = %56
   %61 = load i32, i32* %59, align 8
   %62 = bitcast i8* %57 to i32*
-  %NullCheck118 = icmp ne i32* %62, null
-  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+  %NullCheck117 = icmp eq i32* %62, null
+  br i1 %NullCheck117, label %ThrowNullRef118, label %63
 
 ; <label>:63                                      ; preds = %60
   store i32 %61, i32* %62, align 8
@@ -780,14 +862,14 @@ entry:
   %65 = load i8*, i8** %arg0
   %66 = load i8*, i8** %arg1
   %67 = bitcast i8* %66 to i32*
-  %NullCheck108 = icmp ne i32* %67, null
-  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+  %NullCheck107 = icmp eq i32* %67, null
+  br i1 %NullCheck107, label %ThrowNullRef108, label %68
 
 ; <label>:68                                      ; preds = %64
   %69 = load i32, i32* %67, align 8
   %70 = bitcast i8* %65 to i32*
-  %NullCheck110 = icmp ne i32* %70, null
-  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+  %NullCheck109 = icmp eq i32* %70, null
+  br i1 %NullCheck109, label %ThrowNullRef110, label %71
 
 ; <label>:71                                      ; preds = %68
   store i32 %69, i32* %70, align 8
@@ -795,15 +877,15 @@ entry:
   %73 = getelementptr inbounds i8, i8* %72, i64 4
   %74 = load i8*, i8** %arg1
   %75 = getelementptr inbounds i8, i8* %74, i64 4
-  %NullCheck112 = icmp ne i8* %75, null
-  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+  %NullCheck111 = icmp eq i8* %75, null
+  br i1 %NullCheck111, label %ThrowNullRef112, label %76
 
 ; <label>:76                                      ; preds = %71
   %77 = load i8, i8* %75, align 8
   %78 = zext i8 %77 to i32
   %79 = trunc i32 %78 to i8
-  %NullCheck114 = icmp ne i8* %73, null
-  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+  %NullCheck113 = icmp eq i8* %73, null
+  br i1 %NullCheck113, label %ThrowNullRef114, label %80
 
 ; <label>:80                                      ; preds = %76
   store i8 %79, i8* %73, align 8
@@ -813,14 +895,14 @@ entry:
   %82 = load i8*, i8** %arg0
   %83 = load i8*, i8** %arg1
   %84 = bitcast i8* %83 to i32*
-  %NullCheck100 = icmp ne i32* %84, null
-  br i1 %NullCheck100, label %85, label %ThrowNullRef99
+  %NullCheck99 = icmp eq i32* %84, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %85
 
 ; <label>:85                                      ; preds = %81
   %86 = load i32, i32* %84, align 8
   %87 = bitcast i8* %82 to i32*
-  %NullCheck102 = icmp ne i32* %87, null
-  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+  %NullCheck101 = icmp eq i32* %87, null
+  br i1 %NullCheck101, label %ThrowNullRef102, label %88
 
 ; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
@@ -829,16 +911,16 @@ entry:
   %91 = load i8*, i8** %arg1
   %92 = getelementptr inbounds i8, i8* %91, i64 4
   %93 = bitcast i8* %92 to i16*
-  %NullCheck104 = icmp ne i16* %93, null
-  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+  %NullCheck103 = icmp eq i16* %93, null
+  br i1 %NullCheck103, label %ThrowNullRef104, label %94
 
 ; <label>:94                                      ; preds = %88
   %95 = load i16, i16* %93, align 8
   %96 = sext i16 %95 to i32
   %97 = bitcast i8* %90 to i16*
   %98 = trunc i32 %96 to i16
-  %NullCheck106 = icmp ne i16* %97, null
-  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+  %NullCheck105 = icmp eq i16* %97, null
+  br i1 %NullCheck105, label %ThrowNullRef106, label %99
 
 ; <label>:99                                      ; preds = %94
   store i16 %98, i16* %97, align 8
@@ -848,14 +930,14 @@ entry:
   %101 = load i8*, i8** %arg0
   %102 = load i8*, i8** %arg1
   %103 = bitcast i8* %102 to i32*
-  %NullCheck88 = icmp ne i32* %103, null
-  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+  %NullCheck87 = icmp eq i32* %103, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %104
 
 ; <label>:104                                     ; preds = %100
   %105 = load i32, i32* %103, align 8
   %106 = bitcast i8* %101 to i32*
-  %NullCheck90 = icmp ne i32* %106, null
-  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+  %NullCheck89 = icmp eq i32* %106, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %107
 
 ; <label>:107                                     ; preds = %104
   store i32 %105, i32* %106, align 8
@@ -864,16 +946,16 @@ entry:
   %110 = load i8*, i8** %arg1
   %111 = getelementptr inbounds i8, i8* %110, i64 4
   %112 = bitcast i8* %111 to i16*
-  %NullCheck92 = icmp ne i16* %112, null
-  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+  %NullCheck91 = icmp eq i16* %112, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %113
 
 ; <label>:113                                     ; preds = %107
   %114 = load i16, i16* %112, align 8
   %115 = sext i16 %114 to i32
   %116 = bitcast i8* %109 to i16*
   %117 = trunc i32 %115 to i16
-  %NullCheck94 = icmp ne i16* %116, null
-  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+  %NullCheck93 = icmp eq i16* %116, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %118
 
 ; <label>:118                                     ; preds = %113
   store i16 %117, i16* %116, align 8
@@ -881,15 +963,15 @@ entry:
   %120 = getelementptr inbounds i8, i8* %119, i64 6
   %121 = load i8*, i8** %arg1
   %122 = getelementptr inbounds i8, i8* %121, i64 6
-  %NullCheck96 = icmp ne i8* %122, null
-  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+  %NullCheck95 = icmp eq i8* %122, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %123
 
 ; <label>:123                                     ; preds = %118
   %124 = load i8, i8* %122, align 8
   %125 = zext i8 %124 to i32
   %126 = trunc i32 %125 to i8
-  %NullCheck98 = icmp ne i8* %120, null
-  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+  %NullCheck97 = icmp eq i8* %120, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %127
 
 ; <label>:127                                     ; preds = %123
   store i8 %126, i8* %120, align 8
@@ -899,14 +981,14 @@ entry:
   %129 = load i8*, i8** %arg0
   %130 = load i8*, i8** %arg1
   %131 = bitcast i8* %130 to i64*
-  %NullCheck84 = icmp ne i64* %131, null
-  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+  %NullCheck83 = icmp eq i64* %131, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %132
 
 ; <label>:132                                     ; preds = %128
   %133 = load i64, i64* %131, align 8
   %134 = bitcast i8* %129 to i64*
-  %NullCheck86 = icmp ne i64* %134, null
-  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+  %NullCheck85 = icmp eq i64* %134, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %135
 
 ; <label>:135                                     ; preds = %132
   store i64 %133, i64* %134, align 8
@@ -916,14 +998,14 @@ entry:
   %137 = load i8*, i8** %arg0
   %138 = load i8*, i8** %arg1
   %139 = bitcast i8* %138 to i64*
-  %NullCheck76 = icmp ne i64* %139, null
-  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+  %NullCheck75 = icmp eq i64* %139, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %140
 
 ; <label>:140                                     ; preds = %136
   %141 = load i64, i64* %139, align 8
   %142 = bitcast i8* %137 to i64*
-  %NullCheck78 = icmp ne i64* %142, null
-  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+  %NullCheck77 = icmp eq i64* %142, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %143
 
 ; <label>:143                                     ; preds = %140
   store i64 %141, i64* %142, align 8
@@ -931,15 +1013,15 @@ entry:
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %NullCheck80 = icmp ne i8* %147, null
-  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+  %NullCheck79 = icmp eq i8* %147, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %148
 
 ; <label>:148                                     ; preds = %143
   %149 = load i8, i8* %147, align 8
   %150 = zext i8 %149 to i32
   %151 = trunc i32 %150 to i8
-  %NullCheck82 = icmp ne i8* %145, null
-  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+  %NullCheck81 = icmp eq i8* %145, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %152
 
 ; <label>:152                                     ; preds = %148
   store i8 %151, i8* %145, align 8
@@ -949,14 +1031,14 @@ entry:
   %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
   %156 = bitcast i8* %155 to i64*
-  %NullCheck68 = icmp ne i64* %156, null
-  br i1 %NullCheck68, label %157, label %ThrowNullRef67
+  %NullCheck67 = icmp eq i64* %156, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %157
 
 ; <label>:157                                     ; preds = %153
   %158 = load i64, i64* %156, align 8
   %159 = bitcast i8* %154 to i64*
-  %NullCheck70 = icmp ne i64* %159, null
-  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+  %NullCheck69 = icmp eq i64* %159, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %160
 
 ; <label>:160                                     ; preds = %157
   store i64 %158, i64* %159, align 8
@@ -965,16 +1047,16 @@ entry:
   %163 = load i8*, i8** %arg1
   %164 = getelementptr inbounds i8, i8* %163, i64 8
   %165 = bitcast i8* %164 to i16*
-  %NullCheck72 = icmp ne i16* %165, null
-  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+  %NullCheck71 = icmp eq i16* %165, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %166
 
 ; <label>:166                                     ; preds = %160
   %167 = load i16, i16* %165, align 8
   %168 = sext i16 %167 to i32
   %169 = bitcast i8* %162 to i16*
   %170 = trunc i32 %168 to i16
-  %NullCheck74 = icmp ne i16* %169, null
-  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+  %NullCheck73 = icmp eq i16* %169, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %171
 
 ; <label>:171                                     ; preds = %166
   store i16 %170, i16* %169, align 8
@@ -984,14 +1066,14 @@ entry:
   %173 = load i8*, i8** %arg0
   %174 = load i8*, i8** %arg1
   %175 = bitcast i8* %174 to i64*
-  %NullCheck56 = icmp ne i64* %175, null
-  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+  %NullCheck55 = icmp eq i64* %175, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %176
 
 ; <label>:176                                     ; preds = %172
   %177 = load i64, i64* %175, align 8
   %178 = bitcast i8* %173 to i64*
-  %NullCheck58 = icmp ne i64* %178, null
-  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+  %NullCheck57 = icmp eq i64* %178, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %179
 
 ; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
@@ -1000,16 +1082,16 @@ entry:
   %182 = load i8*, i8** %arg1
   %183 = getelementptr inbounds i8, i8* %182, i64 8
   %184 = bitcast i8* %183 to i16*
-  %NullCheck60 = icmp ne i16* %184, null
-  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+  %NullCheck59 = icmp eq i16* %184, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %185
 
 ; <label>:185                                     ; preds = %179
   %186 = load i16, i16* %184, align 8
   %187 = sext i16 %186 to i32
   %188 = bitcast i8* %181 to i16*
   %189 = trunc i32 %187 to i16
-  %NullCheck62 = icmp ne i16* %188, null
-  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+  %NullCheck61 = icmp eq i16* %188, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %190
 
 ; <label>:190                                     ; preds = %185
   store i16 %189, i16* %188, align 8
@@ -1017,15 +1099,15 @@ entry:
   %192 = getelementptr inbounds i8, i8* %191, i64 10
   %193 = load i8*, i8** %arg1
   %194 = getelementptr inbounds i8, i8* %193, i64 10
-  %NullCheck64 = icmp ne i8* %194, null
-  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+  %NullCheck63 = icmp eq i8* %194, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %195
 
 ; <label>:195                                     ; preds = %190
   %196 = load i8, i8* %194, align 8
   %197 = zext i8 %196 to i32
   %198 = trunc i32 %197 to i8
-  %NullCheck66 = icmp ne i8* %192, null
-  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+  %NullCheck65 = icmp eq i8* %192, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %199
 
 ; <label>:199                                     ; preds = %195
   store i8 %198, i8* %192, align 8
@@ -1035,14 +1117,14 @@ entry:
   %201 = load i8*, i8** %arg0
   %202 = load i8*, i8** %arg1
   %203 = bitcast i8* %202 to i64*
-  %NullCheck48 = icmp ne i64* %203, null
-  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+  %NullCheck47 = icmp eq i64* %203, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %204
 
 ; <label>:204                                     ; preds = %200
   %205 = load i64, i64* %203, align 8
   %206 = bitcast i8* %201 to i64*
-  %NullCheck50 = icmp ne i64* %206, null
-  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+  %NullCheck49 = icmp eq i64* %206, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %207
 
 ; <label>:207                                     ; preds = %204
   store i64 %205, i64* %206, align 8
@@ -1051,14 +1133,14 @@ entry:
   %210 = load i8*, i8** %arg1
   %211 = getelementptr inbounds i8, i8* %210, i64 8
   %212 = bitcast i8* %211 to i32*
-  %NullCheck52 = icmp ne i32* %212, null
-  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+  %NullCheck51 = icmp eq i32* %212, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %213
 
 ; <label>:213                                     ; preds = %207
   %214 = load i32, i32* %212, align 8
   %215 = bitcast i8* %209 to i32*
-  %NullCheck54 = icmp ne i32* %215, null
-  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+  %NullCheck53 = icmp eq i32* %215, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %216
 
 ; <label>:216                                     ; preds = %213
   store i32 %214, i32* %215, align 8
@@ -1068,14 +1150,14 @@ entry:
   %218 = load i8*, i8** %arg0
   %219 = load i8*, i8** %arg1
   %220 = bitcast i8* %219 to i64*
-  %NullCheck36 = icmp ne i64* %220, null
-  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64* %220, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %221
 
 ; <label>:221                                     ; preds = %217
   %222 = load i64, i64* %220, align 8
   %223 = bitcast i8* %218 to i64*
-  %NullCheck38 = icmp ne i64* %223, null
-  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+  %NullCheck37 = icmp eq i64* %223, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %224
 
 ; <label>:224                                     ; preds = %221
   store i64 %222, i64* %223, align 8
@@ -1084,14 +1166,14 @@ entry:
   %227 = load i8*, i8** %arg1
   %228 = getelementptr inbounds i8, i8* %227, i64 8
   %229 = bitcast i8* %228 to i32*
-  %NullCheck40 = icmp ne i32* %229, null
-  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i32* %229, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %230
 
 ; <label>:230                                     ; preds = %224
   %231 = load i32, i32* %229, align 8
   %232 = bitcast i8* %226 to i32*
-  %NullCheck42 = icmp ne i32* %232, null
-  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+  %NullCheck41 = icmp eq i32* %232, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %233
 
 ; <label>:233                                     ; preds = %230
   store i32 %231, i32* %232, align 8
@@ -1099,15 +1181,15 @@ entry:
   %235 = getelementptr inbounds i8, i8* %234, i64 12
   %236 = load i8*, i8** %arg1
   %237 = getelementptr inbounds i8, i8* %236, i64 12
-  %NullCheck44 = icmp ne i8* %237, null
-  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i8* %237, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %238
 
 ; <label>:238                                     ; preds = %233
   %239 = load i8, i8* %237, align 8
   %240 = zext i8 %239 to i32
   %241 = trunc i32 %240 to i8
-  %NullCheck46 = icmp ne i8* %235, null
-  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+  %NullCheck45 = icmp eq i8* %235, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %242
 
 ; <label>:242                                     ; preds = %238
   store i8 %241, i8* %235, align 8
@@ -1117,14 +1199,14 @@ entry:
   %244 = load i8*, i8** %arg0
   %245 = load i8*, i8** %arg1
   %246 = bitcast i8* %245 to i64*
-  %NullCheck24 = icmp ne i64* %246, null
-  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64* %246, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %247
 
 ; <label>:247                                     ; preds = %243
   %248 = load i64, i64* %246, align 8
   %249 = bitcast i8* %244 to i64*
-  %NullCheck26 = icmp ne i64* %249, null
-  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64* %249, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %250
 
 ; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
@@ -1133,14 +1215,14 @@ entry:
   %253 = load i8*, i8** %arg1
   %254 = getelementptr inbounds i8, i8* %253, i64 8
   %255 = bitcast i8* %254 to i32*
-  %NullCheck28 = icmp ne i32* %255, null
-  br i1 %NullCheck28, label %256, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i32* %255, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %256
 
 ; <label>:256                                     ; preds = %250
   %257 = load i32, i32* %255, align 8
   %258 = bitcast i8* %252 to i32*
-  %NullCheck30 = icmp ne i32* %258, null
-  br i1 %NullCheck30, label %259, label %ThrowNullRef29
+  %NullCheck29 = icmp eq i32* %258, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %259
 
 ; <label>:259                                     ; preds = %256
   store i32 %257, i32* %258, align 8
@@ -1149,16 +1231,16 @@ entry:
   %262 = load i8*, i8** %arg1
   %263 = getelementptr inbounds i8, i8* %262, i64 12
   %264 = bitcast i8* %263 to i16*
-  %NullCheck32 = icmp ne i16* %264, null
-  br i1 %NullCheck32, label %265, label %ThrowNullRef31
+  %NullCheck31 = icmp eq i16* %264, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %265
 
 ; <label>:265                                     ; preds = %259
   %266 = load i16, i16* %264, align 8
   %267 = sext i16 %266 to i32
   %268 = bitcast i8* %261 to i16*
   %269 = trunc i32 %267 to i16
-  %NullCheck34 = icmp ne i16* %268, null
-  br i1 %NullCheck34, label %270, label %ThrowNullRef33
+  %NullCheck33 = icmp eq i16* %268, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %270
 
 ; <label>:270                                     ; preds = %265
   store i16 %269, i16* %268, align 8
@@ -1168,14 +1250,14 @@ entry:
   %272 = load i8*, i8** %arg0
   %273 = load i8*, i8** %arg1
   %274 = bitcast i8* %273 to i64*
-  %NullCheck8 = icmp ne i64* %274, null
-  br i1 %NullCheck8, label %275, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64* %274, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %275
 
 ; <label>:275                                     ; preds = %271
   %276 = load i64, i64* %274, align 8
   %277 = bitcast i8* %272 to i64*
-  %NullCheck10 = icmp ne i64* %277, null
-  br i1 %NullCheck10, label %278, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %277, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %278
 
 ; <label>:278                                     ; preds = %275
   store i64 %276, i64* %277, align 8
@@ -1184,14 +1266,14 @@ entry:
   %281 = load i8*, i8** %arg1
   %282 = getelementptr inbounds i8, i8* %281, i64 8
   %283 = bitcast i8* %282 to i32*
-  %NullCheck12 = icmp ne i32* %283, null
-  br i1 %NullCheck12, label %284, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i32* %283, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %284
 
 ; <label>:284                                     ; preds = %278
   %285 = load i32, i32* %283, align 8
   %286 = bitcast i8* %280 to i32*
-  %NullCheck14 = icmp ne i32* %286, null
-  br i1 %NullCheck14, label %287, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i32* %286, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %287
 
 ; <label>:287                                     ; preds = %284
   store i32 %285, i32* %286, align 8
@@ -1200,16 +1282,16 @@ entry:
   %290 = load i8*, i8** %arg1
   %291 = getelementptr inbounds i8, i8* %290, i64 12
   %292 = bitcast i8* %291 to i16*
-  %NullCheck16 = icmp ne i16* %292, null
-  br i1 %NullCheck16, label %293, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i16* %292, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %293
 
 ; <label>:293                                     ; preds = %287
   %294 = load i16, i16* %292, align 8
   %295 = sext i16 %294 to i32
   %296 = bitcast i8* %289 to i16*
   %297 = trunc i32 %295 to i16
-  %NullCheck18 = icmp ne i16* %296, null
-  br i1 %NullCheck18, label %298, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i16* %296, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %298
 
 ; <label>:298                                     ; preds = %293
   store i16 %297, i16* %296, align 8
@@ -1217,15 +1299,15 @@ entry:
   %300 = getelementptr inbounds i8, i8* %299, i64 14
   %301 = load i8*, i8** %arg1
   %302 = getelementptr inbounds i8, i8* %301, i64 14
-  %NullCheck20 = icmp ne i8* %302, null
-  br i1 %NullCheck20, label %303, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i8* %302, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %303
 
 ; <label>:303                                     ; preds = %298
   %304 = load i8, i8* %302, align 8
   %305 = zext i8 %304 to i32
   %306 = trunc i32 %305 to i8
-  %NullCheck22 = icmp ne i8* %300, null
-  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i8* %300, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %307
 
 ; <label>:307                                     ; preds = %303
   store i8 %306, i8* %300, align 8
@@ -1235,14 +1317,14 @@ entry:
   %309 = load i8*, i8** %arg0
   %310 = load i8*, i8** %arg1
   %311 = bitcast i8* %310 to i64*
-  %NullCheck = icmp ne i64* %311, null
-  br i1 %NullCheck, label %312, label %ThrowNullRef
+  %NullCheck = icmp eq i64* %311, null
+  br i1 %NullCheck, label %ThrowNullRef, label %312
 
 ; <label>:312                                     ; preds = %308
   %313 = load i64, i64* %311, align 8
   %314 = bitcast i8* %309 to i64*
-  %NullCheck2 = icmp ne i64* %314, null
-  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64* %314, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %315
 
 ; <label>:315                                     ; preds = %312
   store i64 %313, i64* %314, align 8
@@ -1251,14 +1333,14 @@ entry:
   %318 = load i8*, i8** %arg1
   %319 = getelementptr inbounds i8, i8* %318, i64 8
   %320 = bitcast i8* %319 to i64*
-  %NullCheck4 = icmp ne i64* %320, null
-  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64* %320, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %321
 
 ; <label>:321                                     ; preds = %315
   %322 = load i64, i64* %320, align 8
   %323 = bitcast i8* %317 to i64*
-  %NullCheck6 = icmp ne i64* %323, null
-  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64* %323, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %324
 
 ; <label>:324                                     ; preds = %321
   store i64 %322, i64* %323, align 8
@@ -1286,15 +1368,15 @@ entry:
 ; <label>:338                                     ; preds = %333
   %339 = load i8*, i8** %arg0
   %340 = load i8*, i8** %arg1
-  %NullCheck136 = icmp ne i8* %340, null
-  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+  %NullCheck135 = icmp eq i8* %340, null
+  br i1 %NullCheck135, label %ThrowNullRef136, label %341
 
 ; <label>:341                                     ; preds = %338
   %342 = load i8, i8* %340, align 8
   %343 = zext i8 %342 to i32
   %344 = trunc i32 %343 to i8
-  %NullCheck138 = icmp ne i8* %339, null
-  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+  %NullCheck137 = icmp eq i8* %339, null
+  br i1 %NullCheck137, label %ThrowNullRef138, label %345
 
 ; <label>:345                                     ; preds = %341
   store i8 %344, i8* %339, align 8
@@ -1317,16 +1399,16 @@ entry:
   %357 = load i8*, i8** %arg0
   %358 = load i8*, i8** %arg1
   %359 = bitcast i8* %358 to i16*
-  %NullCheck140 = icmp ne i16* %359, null
-  br i1 %NullCheck140, label %360, label %ThrowNullRef139
+  %NullCheck139 = icmp eq i16* %359, null
+  br i1 %NullCheck139, label %ThrowNullRef140, label %360
 
 ; <label>:360                                     ; preds = %356
   %361 = load i16, i16* %359, align 8
   %362 = sext i16 %361 to i32
   %363 = bitcast i8* %357 to i16*
   %364 = trunc i32 %362 to i16
-  %NullCheck142 = icmp ne i16* %363, null
-  br i1 %NullCheck142, label %365, label %ThrowNullRef141
+  %NullCheck141 = icmp eq i16* %363, null
+  br i1 %NullCheck141, label %ThrowNullRef142, label %365
 
 ; <label>:365                                     ; preds = %360
   store i16 %364, i16* %363, align 8
@@ -1352,14 +1434,14 @@ entry:
   %378 = load i8*, i8** %arg0
   %379 = load i8*, i8** %arg1
   %380 = bitcast i8* %379 to i32*
-  %NullCheck144 = icmp ne i32* %380, null
-  br i1 %NullCheck144, label %381, label %ThrowNullRef143
+  %NullCheck143 = icmp eq i32* %380, null
+  br i1 %NullCheck143, label %ThrowNullRef144, label %381
 
 ; <label>:381                                     ; preds = %377
   %382 = load i32, i32* %380, align 8
   %383 = bitcast i8* %378 to i32*
-  %NullCheck146 = icmp ne i32* %383, null
-  br i1 %NullCheck146, label %384, label %ThrowNullRef145
+  %NullCheck145 = icmp eq i32* %383, null
+  br i1 %NullCheck145, label %ThrowNullRef146, label %384
 
 ; <label>:384                                     ; preds = %381
   store i32 %382, i32* %383, align 8
@@ -1384,14 +1466,14 @@ entry:
   %395 = load i8*, i8** %arg0
   %396 = load i8*, i8** %arg1
   %397 = bitcast i8* %396 to i64*
-  %NullCheck164 = icmp ne i64* %397, null
-  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+  %NullCheck163 = icmp eq i64* %397, null
+  br i1 %NullCheck163, label %ThrowNullRef164, label %398
 
 ; <label>:398                                     ; preds = %394
   %399 = load i64, i64* %397, align 8
   %400 = bitcast i8* %395 to i64*
-  %NullCheck166 = icmp ne i64* %400, null
-  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+  %NullCheck165 = icmp eq i64* %400, null
+  br i1 %NullCheck165, label %ThrowNullRef166, label %401
 
 ; <label>:401                                     ; preds = %398
   store i64 %399, i64* %400, align 8
@@ -1400,14 +1482,14 @@ entry:
   %404 = load i8*, i8** %arg1
   %405 = getelementptr inbounds i8, i8* %404, i64 8
   %406 = bitcast i8* %405 to i64*
-  %NullCheck168 = icmp ne i64* %406, null
-  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+  %NullCheck167 = icmp eq i64* %406, null
+  br i1 %NullCheck167, label %ThrowNullRef168, label %407
 
 ; <label>:407                                     ; preds = %401
   %408 = load i64, i64* %406, align 8
   %409 = bitcast i8* %403 to i64*
-  %NullCheck170 = icmp ne i64* %409, null
-  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+  %NullCheck169 = icmp eq i64* %409, null
+  br i1 %NullCheck169, label %ThrowNullRef170, label %410
 
 ; <label>:410                                     ; preds = %407
   store i64 %408, i64* %409, align 8
@@ -1437,14 +1519,14 @@ entry:
   %425 = load i8*, i8** %arg0
   %426 = load i8*, i8** %arg1
   %427 = bitcast i8* %426 to i64*
-  %NullCheck148 = icmp ne i64* %427, null
-  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+  %NullCheck147 = icmp eq i64* %427, null
+  br i1 %NullCheck147, label %ThrowNullRef148, label %428
 
 ; <label>:428                                     ; preds = %424
   %429 = load i64, i64* %427, align 8
   %430 = bitcast i8* %425 to i64*
-  %NullCheck150 = icmp ne i64* %430, null
-  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+  %NullCheck149 = icmp eq i64* %430, null
+  br i1 %NullCheck149, label %ThrowNullRef150, label %431
 
 ; <label>:431                                     ; preds = %428
   store i64 %429, i64* %430, align 8
@@ -1466,14 +1548,14 @@ entry:
   %441 = load i8*, i8** %arg0
   %442 = load i8*, i8** %arg1
   %443 = bitcast i8* %442 to i32*
-  %NullCheck152 = icmp ne i32* %443, null
-  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+  %NullCheck151 = icmp eq i32* %443, null
+  br i1 %NullCheck151, label %ThrowNullRef152, label %444
 
 ; <label>:444                                     ; preds = %440
   %445 = load i32, i32* %443, align 8
   %446 = bitcast i8* %441 to i32*
-  %NullCheck154 = icmp ne i32* %446, null
-  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+  %NullCheck153 = icmp eq i32* %446, null
+  br i1 %NullCheck153, label %ThrowNullRef154, label %447
 
 ; <label>:447                                     ; preds = %444
   store i32 %445, i32* %446, align 8
@@ -1495,16 +1577,16 @@ entry:
   %457 = load i8*, i8** %arg0
   %458 = load i8*, i8** %arg1
   %459 = bitcast i8* %458 to i16*
-  %NullCheck156 = icmp ne i16* %459, null
-  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+  %NullCheck155 = icmp eq i16* %459, null
+  br i1 %NullCheck155, label %ThrowNullRef156, label %460
 
 ; <label>:460                                     ; preds = %456
   %461 = load i16, i16* %459, align 8
   %462 = sext i16 %461 to i32
   %463 = bitcast i8* %457 to i16*
   %464 = trunc i32 %462 to i16
-  %NullCheck158 = icmp ne i16* %463, null
-  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+  %NullCheck157 = icmp eq i16* %463, null
+  br i1 %NullCheck157, label %ThrowNullRef158, label %465
 
 ; <label>:465                                     ; preds = %460
   store i16 %464, i16* %463, align 8
@@ -1525,15 +1607,15 @@ entry:
 ; <label>:474                                     ; preds = %470
   %475 = load i8*, i8** %arg0
   %476 = load i8*, i8** %arg1
-  %NullCheck160 = icmp ne i8* %476, null
-  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+  %NullCheck159 = icmp eq i8* %476, null
+  br i1 %NullCheck159, label %ThrowNullRef160, label %477
 
 ; <label>:477                                     ; preds = %474
   %478 = load i8, i8* %476, align 8
   %479 = zext i8 %478 to i32
   %480 = trunc i32 %479 to i8
-  %NullCheck162 = icmp ne i8* %475, null
-  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+  %NullCheck161 = icmp eq i8* %475, null
+  br i1 %NullCheck161, label %ThrowNullRef162, label %481
 
 ; <label>:481                                     ; preds = %477
   store i8 %480, i8* %475, align 8
@@ -1553,343 +1635,343 @@ ThrowNullRef:                                     ; preds = %308
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %312
+ThrowNullRef2:                                    ; preds = %312
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %315
+ThrowNullRef4:                                    ; preds = %315
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %321
+ThrowNullRef6:                                    ; preds = %321
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %271
+ThrowNullRef8:                                    ; preds = %271
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %275
+ThrowNullRef10:                                   ; preds = %275
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %278
+ThrowNullRef12:                                   ; preds = %278
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %284
+ThrowNullRef14:                                   ; preds = %284
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %287
+ThrowNullRef16:                                   ; preds = %287
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %293
+ThrowNullRef18:                                   ; preds = %293
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %298
+ThrowNullRef20:                                   ; preds = %298
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %303
+ThrowNullRef22:                                   ; preds = %303
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %243
+ThrowNullRef24:                                   ; preds = %243
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %247
+ThrowNullRef26:                                   ; preds = %247
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %250
+ThrowNullRef28:                                   ; preds = %250
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %256
+ThrowNullRef30:                                   ; preds = %256
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %259
+ThrowNullRef32:                                   ; preds = %259
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %265
+ThrowNullRef34:                                   ; preds = %265
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %217
+ThrowNullRef36:                                   ; preds = %217
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %221
+ThrowNullRef38:                                   ; preds = %221
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %224
+ThrowNullRef40:                                   ; preds = %224
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %230
+ThrowNullRef42:                                   ; preds = %230
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %233
+ThrowNullRef44:                                   ; preds = %233
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %238
+ThrowNullRef46:                                   ; preds = %238
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %200
+ThrowNullRef48:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %204
+ThrowNullRef50:                                   ; preds = %204
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %207
+ThrowNullRef52:                                   ; preds = %207
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %213
+ThrowNullRef54:                                   ; preds = %213
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %172
+ThrowNullRef56:                                   ; preds = %172
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %176
+ThrowNullRef58:                                   ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %179
+ThrowNullRef60:                                   ; preds = %179
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %185
+ThrowNullRef62:                                   ; preds = %185
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %190
+ThrowNullRef64:                                   ; preds = %190
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %195
+ThrowNullRef66:                                   ; preds = %195
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %153
+ThrowNullRef68:                                   ; preds = %153
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %157
+ThrowNullRef70:                                   ; preds = %157
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %160
+ThrowNullRef72:                                   ; preds = %160
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %166
+ThrowNullRef74:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %136
+ThrowNullRef76:                                   ; preds = %136
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %140
+ThrowNullRef78:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %143
+ThrowNullRef80:                                   ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %148
+ThrowNullRef82:                                   ; preds = %148
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %128
+ThrowNullRef84:                                   ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %132
+ThrowNullRef86:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %100
+ThrowNullRef88:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %104
+ThrowNullRef90:                                   ; preds = %104
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %107
+ThrowNullRef92:                                   ; preds = %107
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %113
+ThrowNullRef94:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %118
+ThrowNullRef96:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %123
+ThrowNullRef98:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %81
+ThrowNullRef100:                                  ; preds = %81
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef101:                                  ; preds = %85
+ThrowNullRef102:                                  ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef103:                                  ; preds = %88
+ThrowNullRef104:                                  ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef105:                                  ; preds = %94
+ThrowNullRef106:                                  ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef107:                                  ; preds = %64
+ThrowNullRef108:                                  ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef109:                                  ; preds = %68
+ThrowNullRef110:                                  ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef111:                                  ; preds = %71
+ThrowNullRef112:                                  ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef113:                                  ; preds = %76
+ThrowNullRef114:                                  ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef115:                                  ; preds = %56
+ThrowNullRef116:                                  ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef117:                                  ; preds = %60
+ThrowNullRef118:                                  ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef119:                                  ; preds = %37
+ThrowNullRef120:                                  ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef121:                                  ; preds = %41
+ThrowNullRef122:                                  ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef123:                                  ; preds = %46
+ThrowNullRef124:                                  ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef125:                                  ; preds = %51
+ThrowNullRef126:                                  ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef127:                                  ; preds = %27
+ThrowNullRef128:                                  ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef129:                                  ; preds = %31
+ThrowNullRef130:                                  ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef131:                                  ; preds = %19
+ThrowNullRef132:                                  ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef133:                                  ; preds = %22
+ThrowNullRef134:                                  ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef135:                                  ; preds = %338
+ThrowNullRef136:                                  ; preds = %338
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef137:                                  ; preds = %341
+ThrowNullRef138:                                  ; preds = %341
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef139:                                  ; preds = %356
+ThrowNullRef140:                                  ; preds = %356
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef141:                                  ; preds = %360
+ThrowNullRef142:                                  ; preds = %360
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef143:                                  ; preds = %377
+ThrowNullRef144:                                  ; preds = %377
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef145:                                  ; preds = %381
+ThrowNullRef146:                                  ; preds = %381
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef147:                                  ; preds = %424
+ThrowNullRef148:                                  ; preds = %424
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef149:                                  ; preds = %428
+ThrowNullRef150:                                  ; preds = %428
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef151:                                  ; preds = %440
+ThrowNullRef152:                                  ; preds = %440
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef153:                                  ; preds = %444
+ThrowNullRef154:                                  ; preds = %444
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef155:                                  ; preds = %456
+ThrowNullRef156:                                  ; preds = %456
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef157:                                  ; preds = %460
+ThrowNullRef158:                                  ; preds = %460
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef159:                                  ; preds = %474
+ThrowNullRef160:                                  ; preds = %474
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef161:                                  ; preds = %477
+ThrowNullRef162:                                  ; preds = %477
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef163:                                  ; preds = %394
+ThrowNullRef164:                                  ; preds = %394
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef165:                                  ; preds = %398
+ThrowNullRef166:                                  ; preds = %398
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef167:                                  ; preds = %401
+ThrowNullRef168:                                  ; preds = %401
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef169:                                  ; preds = %407
+ThrowNullRef170:                                  ; preds = %407
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1939,8 +2021,8 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
-  br i1 %NullCheck, label %22, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %ThrowNullRef, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
@@ -1948,8 +2030,8 @@ entry:
   store i32 %24, i32* %loc0
   %25 = load i32, i32* %loc0
   %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %26, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %27
 
 ; <label>:27                                      ; preds = %22
   %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
@@ -1971,7 +2053,7 @@ ThrowNullRef:                                     ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1989,8 +2071,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -2022,15 +2104,15 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2048,16 +2130,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
   %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
   store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %15
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
@@ -2072,8 +2154,8 @@ entry:
   %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
   %29 = ptrtoint i16 addrspace(1)* %28 to i64
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %19
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
@@ -2089,19 +2171,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2114,8 +2196,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
@@ -2128,7 +2210,7 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[loadElem]
+Failed to read AppDomain.PrepareDataForSetup[storeElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
@@ -2202,8 +2284,8 @@ entry:
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
-  br i1 %NullCheck24, label %27, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = load i64, i64 addrspace(1)* %26
@@ -2218,8 +2300,8 @@ entry:
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
-  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
   %41 = load i64, i64 addrspace(1)* %39
@@ -2236,8 +2318,8 @@ entry:
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
-  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
   %54 = load i64, i64 addrspace(1)* %52
@@ -2252,8 +2334,8 @@ entry:
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
   %67 = load i64, i64 addrspace(1)* %65
@@ -2270,8 +2352,8 @@ entry:
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
-  br i1 %NullCheck16, label %79, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
   %80 = load i64, i64 addrspace(1)* %78
@@ -2286,8 +2368,8 @@ entry:
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
-  br i1 %NullCheck18, label %92, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
   %93 = load i64, i64 addrspace(1)* %91
@@ -2304,8 +2386,8 @@ entry:
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
-  br i1 %NullCheck12, label %105, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = load i64, i64 addrspace(1)* %104
@@ -2320,8 +2402,8 @@ entry:
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
-  br i1 %NullCheck14, label %118, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
   %119 = load i64, i64 addrspace(1)* %117
@@ -2337,8 +2419,8 @@ entry:
 
 ; <label>:128                                     ; preds = %20
   %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
-  br i1 %NullCheck4, label %130, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %129, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %130
 
 ; <label>:130                                     ; preds = %128
   %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
@@ -2346,8 +2428,8 @@ entry:
   %133 = load i16, i16 addrspace(1)* %132, align 8
   %134 = zext i16 %133 to i32
   %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
-  br i1 %NullCheck6, label %136, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %135, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %136
 
 ; <label>:136                                     ; preds = %130
   %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
@@ -2360,8 +2442,8 @@ entry:
 
 ; <label>:143                                     ; preds = %136
   %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
-  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %144, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %145
 
 ; <label>:145                                     ; preds = %143
   %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
@@ -2369,8 +2451,8 @@ entry:
   %148 = load i16, i16 addrspace(1)* %147, align 8
   %149 = zext i16 %148 to i32
   %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %150, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %151
 
 ; <label>:151                                     ; preds = %145
   %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
@@ -2388,8 +2470,8 @@ entry:
 
 ; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
-  br i1 %NullCheck, label %163, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %ThrowNullRef, label %163
 
 ; <label>:163                                     ; preds = %161
   %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
@@ -2399,8 +2481,8 @@ entry:
 
 ; <label>:167                                     ; preds = %163
   %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
-  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %168, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %169
 
 ; <label>:169                                     ; preds = %167
   %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
@@ -2432,55 +2514,55 @@ ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %167
+ThrowNullRef2:                                    ; preds = %167
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %128
+ThrowNullRef4:                                    ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %130
+ThrowNullRef6:                                    ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %143
+ThrowNullRef8:                                    ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %145
+ThrowNullRef10:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %102
+ThrowNullRef12:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %105
+ThrowNullRef14:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %76
+ThrowNullRef16:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %79
+ThrowNullRef18:                                   ; preds = %79
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %50
+ThrowNullRef20:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %53
+ThrowNullRef22:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %24
+ThrowNullRef24:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %27
+ThrowNullRef26:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2503,15 +2585,15 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2519,16 +2601,16 @@ entry:
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
   store i32 %8, i32* %loc0
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
   %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
   store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
@@ -2546,16 +2628,16 @@ entry:
 
 ; <label>:23                                      ; preds = %64
   %24 = load i16*, i16** %loc3
-  %NullCheck12 = icmp ne i16* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i16* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
   store i32 %27, i32* %loc5
   %28 = load i16*, i16** %loc4
-  %NullCheck14 = icmp ne i16* %28, null
-  br i1 %NullCheck14, label %29, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %28, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = load i16, i16* %28, align 8
@@ -2620,15 +2702,15 @@ entry:
 
 ; <label>:67                                      ; preds = %64
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
-  br i1 %NullCheck8, label %69, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %68, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %69
 
 ; <label>:69                                      ; preds = %67
   %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
   %71 = load i32, i32 addrspace(1)* %70
   %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
-  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %73
 
 ; <label>:73                                      ; preds = %69
   %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
@@ -2645,31 +2727,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %67
+ThrowNullRef8:                                    ; preds = %67
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %69
+ThrowNullRef10:                                   ; preds = %69
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2710,14 +2792,14 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
   %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
@@ -2730,14 +2812,14 @@ entry:
 
 ; <label>:11                                      ; preds = %4
   %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
   %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
@@ -2749,14 +2831,14 @@ entry:
 
 ; <label>:22                                      ; preds = %16
   %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
   %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
-  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
-  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
@@ -2804,23 +2886,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2836,7 +2918,280 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[loadElem]
+Successfully read RuntimeType.IsAssignableFrom
+
+define i8 @RuntimeType.IsAssignableFrom(%System.RuntimeType addrspace(1)* %param0, %System.Type addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.RuntimeType addrspace(1)*
+  %arg1 = alloca %System.Type addrspace(1)*
+  %loc0 = alloca %System.RuntimeType addrspace(1)*
+  %loc1 = alloca %"System.Type[]" addrspace(1)*
+  %loc2 = alloca i32
+  store %System.RuntimeType addrspace(1)* %param0, %System.RuntimeType addrspace(1)** %this
+  store %System.Type addrspace(1)* %param1, %System.Type addrspace(1)** %arg1
+  %0 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %1 = icmp ne %System.Type addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i8 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %5 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %6 = bitcast %System.Type addrspace(1)* %4 to %System.Object addrspace(1)*
+  %7 = bitcast %System.RuntimeType addrspace(1)* %5 to %System.Object addrspace(1)*
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %6, %System.Object addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %3
+  ret i8 1
+
+; <label>:12                                      ; preds = %3
+  %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 152
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 32
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
+  %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
+  %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
+  store %System.RuntimeType addrspace(1)* %25, %System.RuntimeType addrspace(1)** %loc0
+  %26 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %27 = icmp eq %System.RuntimeType addrspace(1)* %26, null
+  br i1 %27, label %34, label %28
+
+; <label>:28                                      ; preds = %15
+  %29 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %30 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)*)*)(%System.RuntimeType addrspace(1)* %29, %System.RuntimeType addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+; <label>:34                                      ; preds = %15
+  %35 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %36 = call %System.Reflection.Emit.TypeBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Reflection.Emit.TypeBuilder addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %35)
+  %37 = icmp eq %System.Reflection.Emit.TypeBuilder addrspace(1)* %36, null
+  br i1 %37, label %139, label %38
+
+; <label>:38                                      ; preds = %34
+  %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %42
+
+; <label>:42                                      ; preds = %38
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 152
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 40
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
+  %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
+  %53 = zext i8 %52 to i32
+  %54 = icmp eq i32 %53, 0
+  br i1 %54, label %56, label %55
+
+; <label>:55                                      ; preds = %42
+  ret i8 1
+
+; <label>:56                                      ; preds = %42
+  %57 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %58 = bitcast %System.RuntimeType addrspace(1)* %57 to %System.Type addrspace(1)*
+  %59 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %58)
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %64 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.Type addrspace(1)* %63, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = bitcast %System.RuntimeType addrspace(1)* %64 to %System.Type addrspace(1)*
+  %67 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %63, %System.Type addrspace(1)* %66)
+  %68 = zext i8 %67 to i32
+  %69 = trunc i32 %68 to i8
+  ret i8 %69
+
+; <label>:70                                      ; preds = %56
+  %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
+  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %73
+
+; <label>:73                                      ; preds = %70
+  %74 = load i64, i64 addrspace(1)* %72
+  %75 = add i64 %74, 128
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = add i64 %77, 0
+  %79 = inttoptr i64 %78 to i64*
+  %80 = load i64, i64* %79
+  %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
+  %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
+  %83 = call i8 %82(%System.Type addrspace(1)* %81)
+  %84 = zext i8 %83 to i32
+  %85 = icmp eq i32 %84, 0
+  br i1 %85, label %139, label %86
+
+; <label>:86                                      ; preds = %73
+  %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
+  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %89
+
+; <label>:89                                      ; preds = %86
+  %90 = load i64, i64 addrspace(1)* %88
+  %91 = add i64 %90, 128
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = add i64 %93, 24
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
+  %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
+  %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
+  store %"System.Type[]" addrspace(1)* %99, %"System.Type[]" addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %129
+
+; <label>:100                                     ; preds = %132
+  %101 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %102 = load i32, i32* %loc2
+  %NullCheck11 = icmp eq %"System.Type[]" addrspace(1)* %101, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %103
+
+; <label>:103                                     ; preds = %100
+  %104 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 1
+  %105 = load i32, i32 addrspace(1)* %104
+  %106 = zext i32 %105 to i64
+  %107 = zext i32 %102 to i64
+  %BoundsCheck = icmp uge i64 %107, %106
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %108
+
+; <label>:108                                     ; preds = %103
+  %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
+  %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
+  %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
+  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %113
+
+; <label>:113                                     ; preds = %108
+  %114 = load i64, i64 addrspace(1)* %112
+  %115 = add i64 %114, 152
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = add i64 %117, 56
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
+  %123 = zext i8 %122 to i32
+  %124 = icmp ne i32 %123, 0
+  br i1 %124, label %126, label %125
+
+; <label>:125                                     ; preds = %113
+  ret i8 0
+
+; <label>:126                                     ; preds = %113
+  %127 = load i32, i32* %loc2
+  %128 = add i32 %127, 1
+  store i32 %128, i32* %loc2
+  br label %129
+
+; <label>:129                                     ; preds = %89, %126
+  %130 = load i32, i32* %loc2
+  %131 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %NullCheck9 = icmp eq %"System.Type[]" addrspace(1)* %131, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %132
+
+; <label>:132                                     ; preds = %129
+  %133 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %131, i32 0, i32 1
+  %134 = load i32, i32 addrspace(1)* %133
+  %135 = zext i32 %134 to i64
+  %136 = trunc i64 %135 to i32
+  %137 = icmp slt i32 %130, %136
+  br i1 %137, label %100, label %138
+
+; <label>:138                                     ; preds = %132
+  ret i8 1
+
+; <label>:139                                     ; preds = %34, %73
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %129
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %103
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -2893,7 +3248,7 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElem]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -2904,8 +3259,8 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -2997,8 +3352,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
@@ -3059,8 +3414,8 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -3087,8 +3442,8 @@ entry:
 
 ; <label>:17                                      ; preds = %5, %11
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
@@ -3097,8 +3452,8 @@ entry:
 
 ; <label>:22                                      ; preds = %1, %11
   %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
@@ -3109,11 +3464,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %17
+ThrowNullRef2:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %22
+ThrowNullRef4:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3167,15 +3522,15 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
   %15 = load i32, i32 addrspace(1)* %14
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
@@ -3198,7 +3553,7 @@ ThrowNullRef:                                     ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef2:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3232,8 +3587,8 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
@@ -3312,8 +3667,8 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -3327,8 +3682,8 @@ entry:
 ; <label>:5                                       ; preds = %43
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %7 = load i32, i32* %loc1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck6, label %8, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
@@ -3366,8 +3721,8 @@ entry:
 ; <label>:32                                      ; preds = %21, %25
   %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
   %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
-  br i1 %NullCheck8, label %35, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = trunc i32 %34 to i16
@@ -3380,8 +3735,8 @@ entry:
 ; <label>:40                                      ; preds = %1, %35
   %41 = load i32, i32* %loc1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
-  br i1 %NullCheck2, label %43, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %42, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
@@ -3392,8 +3747,8 @@ entry:
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
   %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
-  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
   %51 = load i64, i64 addrspace(1)* %49
@@ -3412,19 +3767,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %40
+ThrowNullRef2:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %47
+ThrowNullRef4:                                    ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %5
+ThrowNullRef6:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %32
+ThrowNullRef8:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3467,8 +3822,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
@@ -3492,11 +3847,391 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(i16* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store i16* %param0, i16** %arg0
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load i32, i32* %arg3
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %42, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %37, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg2
+  %13 = load i32, i32* %arg3
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %37, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %24 = load i32, i32* %arg2
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load i16*, i16** %arg0
+  %35 = load i32, i32* %arg3
+  %36 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %36, i16* %34, i32 %35)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:37                                      ; preds = %5, %16
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %39)
+  %41 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41, %System.String addrspace(1)* %38, %System.String addrspace(1)* %40)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41) #0
+  unreachable
+
+; <label>:42                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
-Failed to read StringBuilder.ToString[loadElemA]
+Successfully read StringBuilder.ToString
+
+define %System.String addrspace(1)* @StringBuilder.ToString(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i16*
+  %loc3 = alloca %"System.Char[]" addrspace(1)*
+  %loc4 = alloca i32
+  %loc5 = alloca i32
+  %loc6 = alloca i16 addrspace(1)*
+  %loc7 = alloca %System.String addrspace(1)*
+  %loc8 = alloca %"System.Char[]" addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %0)
+  %2 = icmp ne i32 %1, 0
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %4
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %6)
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %7)
+  store %System.String addrspace(1)* %8, %System.String addrspace(1)** %loc0
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.Text.StringBuilder addrspace(1)* %9, %System.Text.StringBuilder addrspace(1)** %loc1
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  store %System.String addrspace(1)* %10, %System.String addrspace(1)** %loc7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc7
+  %12 = ptrtoint %System.String addrspace(1)* %11 to i64
+  %13 = icmp eq i64 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %5
+  %15 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %16 = sext i32 %15 to i64
+  %17 = add i64 %12, %16
+  br label %18
+
+; <label>:18                                      ; preds = %5, %14
+  %19 = phi i64 [ %12, %5 ], [ %17, %14 ]
+  %20 = inttoptr i64 %19 to i16*
+  store i16* %20, i16** %loc2
+  br label %21
+
+; <label>:21                                      ; preds = %98, %18
+  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %22, null
+  br i1 %NullCheck, label %ThrowNullRef, label %23
+
+; <label>:23                                      ; preds = %21
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 3
+  %25 = load i32, i32 addrspace(1)* %24, align 8
+  %26 = icmp sle i32 %25, 0
+  br i1 %26, label %96, label %27
+
+; <label>:27                                      ; preds = %23
+  %28 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %28, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %29
+
+; <label>:29                                      ; preds = %27
+  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %28, i32 0, i32 1
+  %31 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %30, align 8
+  store %"System.Char[]" addrspace(1)* %31, %"System.Char[]" addrspace(1)** %loc3
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %33
+
+; <label>:33                                      ; preds = %29
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  store i32 %35, i32* %loc4
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  %39 = load i32, i32 addrspace(1)* %38, align 8
+  store i32 %39, i32* %loc5
+  %40 = load i32, i32* %loc5
+  %41 = load i32, i32* %loc4
+  %42 = add i32 %40, %41
+  %43 = zext i32 %42 to i64
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %45
+
+; <label>:45                                      ; preds = %37
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = sext i32 %47 to i64
+  %49 = icmp sgt i64 %43, %48
+  br i1 %49, label %91, label %50
+
+; <label>:50                                      ; preds = %45
+  %51 = load i32, i32* %loc5
+  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %52, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %53
+
+; <label>:53                                      ; preds = %50
+  %54 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %52, i32 0, i32 1
+  %55 = load i32, i32 addrspace(1)* %54
+  %56 = zext i32 %55 to i64
+  %57 = trunc i64 %56 to i32
+  %58 = icmp ugt i32 %51, %57
+  br i1 %58, label %91, label %59
+
+; <label>:59                                      ; preds = %53
+  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  store %"System.Char[]" addrspace(1)* %60, %"System.Char[]" addrspace(1)** %loc8
+  %61 = icmp eq %"System.Char[]" addrspace(1)* %60, null
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %63, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %64
+
+; <label>:64                                      ; preds = %62
+  %65 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %63, i32 0, i32 1
+  %66 = load i32, i32 addrspace(1)* %65
+  %67 = zext i32 %66 to i64
+  %68 = trunc i64 %67 to i32
+  %69 = icmp ne i32 %68, 0
+  br i1 %69, label %71, label %70
+
+; <label>:70                                      ; preds = %59, %64
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:71                                      ; preds = %64
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %73
+
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %BoundsCheck = icmp uge i64 0, %76
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %77
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %78, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:79                                      ; preds = %70, %77
+  %80 = load i16*, i16** %loc2
+  %81 = load i32, i32* %loc4
+  %82 = sext i32 %81 to i64
+  %83 = mul i64 %82, 2
+  %84 = bitcast i16* %80 to i8*
+  %85 = getelementptr inbounds i8, i8* %84, i64 %83
+  %86 = load i16 addrspace(1)*, i16 addrspace(1)** %loc6
+  %87 = ptrtoint i16 addrspace(1)* %86 to i64
+  %88 = load i32, i32* %loc5
+  %89 = bitcast i8* %85 to i16*
+  %90 = inttoptr i64 %87 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %89, i16* %90, i32 %88)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %96
+
+; <label>:91                                      ; preds = %45, %53
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %94 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %93)
+  %95 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95, %System.String addrspace(1)* %92, %System.String addrspace(1)* %94)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95) #0
+  unreachable
+
+; <label>:96                                      ; preds = %23, %79
+  %97 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %97, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %98
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %97, i32 0, i32 2
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  store %System.Text.StringBuilder addrspace(1)* %100, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %102 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %102, label %21, label %103
+
+; <label>:103                                     ; preds = %98
+  store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc7
+  %104 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  ret %System.String addrspace(1)* %104
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method StringBuilder::get_Length using LLILCJit
+Successfully read StringBuilder.get_Length
+
+define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
+Successfully read RuntimeHelpers.get_OffsetToStringData
+
+define i32 @RuntimeHelpers.get_OffsetToStringData() {
+entry:
+  ret i32 12
+}
+
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
 Successfully read CultureData.CreateCultureData
 
@@ -3514,23 +4249,23 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
   store i8 %4, i8 addrspace(1)* %6
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
@@ -3549,11 +4284,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3566,50 +4301,50 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
   store i32 -1, i32 addrspace(1)* %2
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
   store i32 -1, i32 addrspace(1)* %8
   %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
   store i32 -1, i32 addrspace(1)* %14
   %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
   store i32 -1, i32 addrspace(1)* %17
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
@@ -3623,27 +4358,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3675,7 +4410,136 @@ Failed to read Dictionary`2.Insert[non-const derefAddress]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
 Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
-Failed to read HashHelpers.GetPrime[loadElem]
+Successfully read HashHelpers.GetPrime
+
+define i32 @HashHelpers.GetPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %6, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5, %System.String addrspace(1)* %4)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5) #0
+  unreachable
+
+; <label>:6                                       ; preds = %entry
+  store i32 0, i32* %loc0
+  br label %29
+
+; <label>:7                                       ; preds = %35
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 1296
+  %10 = addrspacecast i8 addrspace(1)* %9 to %"System.Int32[]" addrspace(1)**
+  %11 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %10
+  %12 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Int32[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = zext i32 %15 to i64
+  %17 = zext i32 %12 to i64
+  %BoundsCheck = icmp uge i64 %17, %16
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 3, i32 %12
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  store i32 %20, i32* %loc1
+  %21 = load i32, i32* %loc1
+  %22 = load i32, i32* %arg0
+  %23 = icmp slt i32 %21, %22
+  br i1 %23, label %26, label %24
+
+; <label>:24                                      ; preds = %18
+  %25 = load i32, i32* %loc1
+  ret i32 %25
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %loc0
+  %28 = add i32 %27, 1
+  store i32 %28, i32* %loc0
+  br label %29
+
+; <label>:29                                      ; preds = %6, %26
+  %30 = load i32, i32* %loc0
+  %31 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %32 = getelementptr inbounds i8, i8 addrspace(1)* %31, i64 1296
+  %33 = addrspacecast i8 addrspace(1)* %32 to %"System.Int32[]" addrspace(1)**
+  %34 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %33
+  %NullCheck = icmp eq %"System.Int32[]" addrspace(1)* %34, null
+  br i1 %NullCheck, label %ThrowNullRef, label %35
+
+; <label>:35                                      ; preds = %29
+  %36 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %34, i32 0, i32 1
+  %37 = load i32, i32 addrspace(1)* %36
+  %38 = zext i32 %37 to i64
+  %39 = trunc i64 %38 to i32
+  %40 = icmp slt i32 %30, %39
+  br i1 %40, label %7, label %41
+
+; <label>:41                                      ; preds = %35
+  %42 = load i32, i32* %arg0
+  %43 = or i32 %42, 1
+  store i32 %43, i32* %loc2
+  br label %59
+
+; <label>:44                                      ; preds = %59
+  %45 = load i32, i32* %loc2
+  %46 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %45)
+  %47 = zext i8 %46 to i32
+  %48 = icmp eq i32 %47, 0
+  br i1 %48, label %56, label %49
+
+; <label>:49                                      ; preds = %44
+  %50 = load i32, i32* %loc2
+  %51 = sub i32 %50, 1
+  %52 = srem i32 %51, 101
+  %53 = icmp eq i32 %52, 0
+  br i1 %53, label %56, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = load i32, i32* %loc2
+  ret i32 %55
+
+; <label>:56                                      ; preds = %44, %49
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %57, 2
+  store i32 %58, i32* %loc2
+  br label %59
+
+; <label>:59                                      ; preds = %41, %56
+  %60 = load i32, i32* %loc2
+  %61 = icmp slt i32 %60, 2147483647
+  br i1 %61, label %44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load i32, i32* %arg0
+  ret i32 %63
+
+ThrowNullRef:                                     ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
 Successfully read GenericEqualityComparer`1.GetHashCode
 
@@ -3694,14 +4558,14 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
   %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load i64, i64 addrspace(1)* %7
@@ -3720,7 +4584,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3750,8 +4614,8 @@ entry:
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
@@ -3796,8 +4660,8 @@ entry:
   %35 = bitcast i16* %34 to i8*
   %36 = getelementptr inbounds i8, i8* %35, i64 2
   %37 = bitcast i8* %36 to i16*
-  %NullCheck4 = icmp ne i16* %37, null
-  br i1 %NullCheck4, label %38, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %37, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %38
 
 ; <label>:38                                      ; preds = %27
   %39 = load i16, i16* %37, align 8
@@ -3824,8 +4688,8 @@ entry:
 
 ; <label>:54                                      ; preds = %22, %43
   %55 = load i16*, i16** %loc4
-  %NullCheck2 = icmp ne i16* %55, null
-  br i1 %NullCheck2, label %56, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i16* %55, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %56
 
 ; <label>:56                                      ; preds = %54
   %57 = load i16, i16* %55, align 8
@@ -3850,11 +4714,11 @@ ThrowNullRef:                                     ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %54
+ThrowNullRef2:                                    ; preds = %54
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %27
+ThrowNullRef4:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3871,8 +4735,8 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -3907,8 +4771,8 @@ entry:
 
 ; <label>:26                                      ; preds = %19
   %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
-  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %28
 
 ; <label>:28                                      ; preds = %26
   %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
@@ -3920,7 +4784,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3972,8 +4836,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
@@ -3984,26 +4848,26 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
-  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
@@ -4014,8 +4878,8 @@ entry:
 ; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
@@ -4024,8 +4888,8 @@ entry:
 
 ; <label>:25                                      ; preds = %1, %16, %23
   %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
-  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
@@ -4036,27 +4900,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %20
+ThrowNullRef10:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4069,8 +4933,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -4081,8 +4945,8 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
@@ -4091,8 +4955,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1, %8
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
@@ -4103,11 +4967,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4128,24 +4992,24 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   store i32 %3, i32* %loc0
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
   %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
   store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck4, label %9, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
@@ -4164,15 +5028,15 @@ entry:
 ; <label>:18                                      ; preds = %70
   %19 = load i16*, i16** %loc3
   %20 = bitcast i16* %19 to i64*
-  %NullCheck10 = icmp ne i64* %20, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %20, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = load i64, i64* %20, align 8
   %23 = load i16*, i16** %loc4
   %24 = bitcast i16* %23 to i64*
-  %NullCheck12 = icmp ne i64* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = load i64, i64* %24, align 8
@@ -4188,8 +5052,8 @@ entry:
   %31 = bitcast i16* %30 to i8*
   %32 = getelementptr inbounds i8, i8* %31, i64 8
   %33 = bitcast i8* %32 to i64*
-  %NullCheck14 = icmp ne i64* %33, null
-  br i1 %NullCheck14, label %34, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = load i64, i64* %33, align 8
@@ -4197,8 +5061,8 @@ entry:
   %37 = bitcast i16* %36 to i8*
   %38 = getelementptr inbounds i8, i8* %37, i64 8
   %39 = bitcast i8* %38 to i64*
-  %NullCheck16 = icmp ne i64* %39, null
-  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %40
 
 ; <label>:40                                      ; preds = %34
   %41 = load i64, i64* %39, align 8
@@ -4214,8 +5078,8 @@ entry:
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %NullCheck18 = icmp ne i64* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = load i64, i64* %48, align 8
@@ -4223,8 +5087,8 @@ entry:
   %52 = bitcast i16* %51 to i8*
   %53 = getelementptr inbounds i8, i8* %52, i64 16
   %54 = bitcast i8* %53 to i64*
-  %NullCheck20 = icmp ne i64* %54, null
-  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64* %54, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %55
 
 ; <label>:55                                      ; preds = %49
   %56 = load i64, i64* %54, align 8
@@ -4262,15 +5126,15 @@ entry:
 ; <label>:74                                      ; preds = %95
   %75 = load i16*, i16** %loc3
   %76 = bitcast i16* %75 to i32*
-  %NullCheck6 = icmp ne i32* %76, null
-  br i1 %NullCheck6, label %77, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32* %76, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %77
 
 ; <label>:77                                      ; preds = %74
   %78 = load i32, i32* %76, align 8
   %79 = load i16*, i16** %loc4
   %80 = bitcast i16* %79 to i32*
-  %NullCheck8 = icmp ne i32* %80, null
-  br i1 %NullCheck8, label %81, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i32* %80, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %81
 
 ; <label>:81                                      ; preds = %77
   %82 = load i32, i32* %80, align 8
@@ -4318,43 +5182,43 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %74
+ThrowNullRef6:                                    ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %77
+ThrowNullRef8:                                    ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %29
+ThrowNullRef14:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %34
+ThrowNullRef16:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4376,8 +5240,8 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load i64, i64 addrspace(1)* %4
@@ -4389,8 +5253,8 @@ entry:
   %12 = load i64, i64* %11
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %5
   %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
@@ -4399,8 +5263,8 @@ entry:
   %18 = load i8, i8* %arg2
   %19 = zext i8 %18 to i32
   %20 = trunc i32 %19 to i8
-  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %15
   %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
@@ -4411,11 +5275,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4442,8 +5306,8 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
@@ -4466,16 +5330,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
   %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = load i64, i64 addrspace(1)* %19
@@ -4500,8 +5364,8 @@ entry:
 ; <label>:35                                      ; preds = %30
   %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
@@ -4514,8 +5378,8 @@ entry:
 
 ; <label>:42                                      ; preds = %1, %38
   %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
-  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
@@ -4526,19 +5390,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %35
+ThrowNullRef2:                                    ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %42
+ThrowNullRef8:                                    ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4551,14 +5415,14 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
@@ -4570,7 +5434,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4583,8 +5447,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
@@ -4613,51 +5477,51 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
   %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
   %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
   %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
   %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
-  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
   store i64 %21, i64 addrspace(1)* %23
   %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %25 = load i64, i64* %loc0
-  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
@@ -4668,27 +5532,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %22
+ThrowNullRef12:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4701,8 +5565,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
@@ -4713,19 +5577,19 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
@@ -4734,8 +5598,8 @@ entry:
 
 ; <label>:15                                      ; preds = %1, %13
   %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
@@ -4746,19 +5610,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %15
+ThrowNullRef8:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4771,8 +5635,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -4831,8 +5695,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
@@ -4882,8 +5746,8 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
-  br i1 %NullCheck, label %17, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %ThrowNullRef, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
@@ -4894,15 +5758,15 @@ entry:
 
 ; <label>:22                                      ; preds = %17
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
-  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
   %26 = load i32, i32 addrspace(1)* %25
   %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
-  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %27, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
@@ -4925,8 +5789,8 @@ entry:
 ; <label>:40                                      ; preds = %17
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
-  br i1 %NullCheck6, label %43, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %41, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
@@ -4938,34 +5802,17 @@ ThrowNullRef:                                     ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %24
+ThrowNullRef4:                                    ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %40
+ThrowNullRef6:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
-}
-
-INFO:  jitting method Object::ReferenceEquals using LLILCJit
-Successfully read Object.ReferenceEquals
-
-define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
-entry:
-  %arg0 = alloca %System.Object addrspace(1)*
-  %arg1 = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
-  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
-  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = icmp eq %System.Object addrspace(1)* %0, %1
-  %3 = sext i1 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
 }
 
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
@@ -4978,21 +5825,21 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
   %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
-  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
@@ -5007,28 +5854,28 @@ entry:
 ; <label>:13                                      ; preds = %8, %12
   %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
   %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
   %21 = load i32, i32 addrspace(1)* %20, align 8
   %22 = add i32 %21, 1
-  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
   store i32 %22, i32 addrspace(1)* %24
   %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
@@ -5039,27 +5886,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5077,7 +5924,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::Setup using LLILCJit
-Failed to read AppDomain.Setup[loadElem]
+Failed to read AppDomain.Setup[unbox]
 INFO:  jitting method Thread::GetDomain using LLILCJit
 Successfully read Thread.GetDomain
 
@@ -5108,8 +5955,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
@@ -5122,14 +5969,14 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
   %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
@@ -5141,11 +5988,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5173,8 +6020,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -5189,7 +6036,328 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
 Failed to read KeyCollection.System.Collections.Generic.IEnumerable<TKey>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Successfully read Enumerator.MoveNext
+
+define i8 @Enumerator.MoveNext(%"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.RuntimeTypeHandle* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*
+  %"$TypeArg" = alloca %System.RuntimeTypeHandle*
+  store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
+  %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 8
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %76, label %12
+
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
+  br label %76
+
+; <label>:13                                      ; preds = %85
+  %14 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck19 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %15
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, i32 0, i32 0
+  %17 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %16, align 8
+  %NullCheck21 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, i32 0, i32 2
+  %20 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %19, align 8
+  %21 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck23 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %22
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, i32 0, i32 2
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %NullCheck25 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 3, i32 %24
+  %NullCheck27 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %32
+
+; <label>:32                                      ; preds = %30
+  %33 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, i32 0, i32 2
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = icmp slt i32 %34, 0
+  br i1 %35, label %68, label %36
+
+; <label>:36                                      ; preds = %32
+  %37 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %38 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck29 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %39
+
+; <label>:39                                      ; preds = %36
+  %40 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, i32 0, i32 0
+  %41 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %40, align 8
+  %NullCheck31 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, i32 0, i32 2
+  %44 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %43, align 8
+  %45 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck33 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, i32 0, i32 2
+  %48 = load i32, i32 addrspace(1)* %47, align 8
+  %NullCheck35 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %49
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = zext i32 %51 to i64
+  %53 = zext i32 %48 to i64
+  %BoundsCheck37 = icmp uge i64 %53, %52
+  br i1 %BoundsCheck37, label %ThrowIndexOutOfRange38, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 3, i32 %48
+  %NullCheck39 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %56
+
+; <label>:56                                      ; preds = %54
+  %57 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, i32 0, i32 0
+  %58 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck41 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %59
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %60, %System.__Canon addrspace(1)* %58)
+  %61 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck43 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  %64 = load i32, i32 addrspace(1)* %63, align 8
+  %65 = add i32 %64, 1
+  %NullCheck45 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  store i32 %65, i32 addrspace(1)* %67
+  ret i8 1
+
+; <label>:68                                      ; preds = %32
+  %69 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck47 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %73 = add i32 %72, 1
+  %NullCheck49 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %74
+
+; <label>:74                                      ; preds = %70
+  %75 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  store i32 %73, i32 addrspace(1)* %75
+  br label %76
+
+; <label>:76                                      ; preds = %8, %12, %74
+  %77 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %78
+
+; <label>:78                                      ; preds = %76
+  %79 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, i32 0, i32 2
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck7 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %82
+
+; <label>:82                                      ; preds = %78
+  %83 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, i32 0, i32 0
+  %84 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %83, align 8
+  %NullCheck9 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %85
+
+; <label>:85                                      ; preds = %82
+  %86 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, i32 0, i32 7
+  %87 = load i32, i32 addrspace(1)* %86, align 8
+  %88 = icmp ult i32 %80, %87
+  br i1 %88, label %13, label %89
+
+; <label>:89                                      ; preds = %85
+  %90 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %91 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck11 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %92
+
+; <label>:92                                      ; preds = %89
+  %93 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, i32 0, i32 0
+  %94 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck13 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %95
+
+; <label>:95                                      ; preds = %92
+  %96 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, i32 0, i32 7
+  %97 = load i32, i32 addrspace(1)* %96, align 8
+  %98 = add i32 %97, 1
+  %NullCheck15 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %99
+
+; <label>:99                                      ; preds = %95
+  %100 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, i32 0, i32 2
+  store i32 %98, i32 addrspace(1)* %100
+  %101 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck17 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %102
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %103, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %92
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef22:                                   ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef24:                                   ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef26:                                   ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef28:                                   ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef30:                                   ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef32:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef34:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef36:                                   ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange38:                           ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef40:                                   ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef42:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef44:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef46:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef48:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef50:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -5200,8 +6368,8 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -5232,9 +6400,9 @@ Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
 Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
-Failed to read String.MakeSeparatorList[loadElemA]
+Failed to read String.MakeSeparatorList[storeElem]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
-Failed to read String.InternalSplitKeepEmptyEntries[loadElem]
+Failed to read String.InternalSplitKeepEmptyEntries[storeElem]
 INFO:  jitting method Path::IsRelative using LLILCJit
 Successfully read Path.IsRelative
 
@@ -5243,8 +6411,8 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -5254,8 +6422,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
@@ -5271,8 +6439,8 @@ entry:
 
 ; <label>:17                                      ; preds = %7
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
@@ -5288,8 +6456,8 @@ entry:
 
 ; <label>:29                                      ; preds = %19
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %31
 
 ; <label>:31                                      ; preds = %29
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
@@ -5300,8 +6468,8 @@ entry:
 
 ; <label>:36                                      ; preds = %31
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
-  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %37, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
@@ -5312,8 +6480,8 @@ entry:
 
 ; <label>:43                                      ; preds = %31, %38
   %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
-  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %45
 
 ; <label>:45                                      ; preds = %43
   %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
@@ -5324,8 +6492,8 @@ entry:
 
 ; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %50
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
@@ -5336,8 +6504,8 @@ entry:
 
 ; <label>:57                                      ; preds = %1, %7, %19, %45, %52
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
-  br i1 %NullCheck14, label %59, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %59
 
 ; <label>:59                                      ; preds = %57
   %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
@@ -5347,8 +6515,8 @@ entry:
 
 ; <label>:63                                      ; preds = %59
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
@@ -5359,8 +6527,8 @@ entry:
 
 ; <label>:70                                      ; preds = %65
   %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
-  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.String addrspace(1)* %71, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %72
 
 ; <label>:72                                      ; preds = %70
   %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
@@ -5379,39 +6547,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %17
+ThrowNullRef4:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %29
+ThrowNullRef6:                                    ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %36
+ThrowNullRef8:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %43
+ThrowNullRef10:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %50
+ThrowNullRef12:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %57
+ThrowNullRef14:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %63
+ThrowNullRef16:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %70
+ThrowNullRef18:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5419,7 +6587,293 @@ ThrowNullRef17:                                   ; preds = %70
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
-Failed to read String.TrimHelper[loadElem]
+Successfully read String.TrimHelper
+
+define %System.String addrspace(1)* @String.TrimHelper(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i16
+  %loc4 = alloca i32
+  %loc5 = alloca i16
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = sub i32 %3, 1
+  store i32 %4, i32* %loc0
+  store i32 0, i32* %loc1
+  %5 = load i32, i32* %arg2
+  %6 = icmp eq i32 %5, 1
+  br i1 %6, label %62, label %7
+
+; <label>:7                                       ; preds = %1
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:8                                       ; preds = %58
+  store i32 0, i32* %loc2
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load i32, i32* %loc1
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2, i32 %10
+  %13 = load i16, i16 addrspace(1)* %12
+  %14 = zext i16 %13 to i32
+  %15 = trunc i32 %14 to i16
+  store i16 %15, i16* %loc3
+  store i32 0, i32* %loc2
+  br label %34
+
+; <label>:16                                      ; preds = %37
+  %17 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %18 = load i32, i32* %loc2
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %17, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %19
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = zext i32 %18 to i64
+  %BoundsCheck = icmp uge i64 %23, %22
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %24
+
+; <label>:24                                      ; preds = %19
+  %25 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 3, i32 %18
+  %26 = load i16, i16 addrspace(1)* %25, align 8
+  %27 = zext i16 %26 to i32
+  %28 = load i16, i16* %loc3
+  %29 = zext i16 %28 to i32
+  %30 = icmp eq i32 %27, %29
+  br i1 %30, label %43, label %31
+
+; <label>:31                                      ; preds = %24
+  %32 = load i32, i32* %loc2
+  %33 = add i32 %32, 1
+  store i32 %33, i32* %loc2
+  br label %34
+
+; <label>:34                                      ; preds = %11, %31
+  %35 = load i32, i32* %loc2
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = icmp slt i32 %35, %41
+  br i1 %42, label %16, label %43
+
+; <label>:43                                      ; preds = %24, %37
+  %44 = load i32, i32* %loc2
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %45, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp eq i32 %44, %50
+  br i1 %51, label %62, label %52
+
+; <label>:52                                      ; preds = %46
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %7, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %57, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %58
+
+; <label>:58                                      ; preds = %55
+  %59 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %60 = load i32, i32 addrspace(1)* %59
+  %61 = icmp slt i32 %56, %60
+  br i1 %61, label %8, label %62
+
+; <label>:62                                      ; preds = %1, %46, %58
+  %63 = load i32, i32* %arg2
+  %64 = icmp eq i32 %63, 0
+  br i1 %64, label %122, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %66, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %67
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %66, i32 0, i32 1
+  %69 = load i32, i32 addrspace(1)* %68
+  %70 = sub i32 %69, 1
+  store i32 %70, i32* %loc0
+  br label %118
+
+; <label>:71                                      ; preds = %118
+  store i32 0, i32* %loc4
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %73 = load i32, i32* %loc0
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %74
+
+; <label>:74                                      ; preds = %71
+  %75 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 2, i32 %73
+  %76 = load i16, i16 addrspace(1)* %75
+  %77 = zext i16 %76 to i32
+  %78 = trunc i32 %77 to i16
+  store i16 %78, i16* %loc5
+  store i32 0, i32* %loc4
+  br label %97
+
+; <label>:79                                      ; preds = %100
+  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %81 = load i32, i32* %loc4
+  %NullCheck19 = icmp eq %"System.Char[]" addrspace(1)* %80, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
+
+; <label>:82                                      ; preds = %79
+  %83 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 1
+  %84 = load i32, i32 addrspace(1)* %83
+  %85 = zext i32 %84 to i64
+  %86 = zext i32 %81 to i64
+  %BoundsCheck21 = icmp uge i64 %86, %85
+  br i1 %BoundsCheck21, label %ThrowIndexOutOfRange22, label %87
+
+; <label>:87                                      ; preds = %82
+  %88 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 3, i32 %81
+  %89 = load i16, i16 addrspace(1)* %88, align 8
+  %90 = zext i16 %89 to i32
+  %91 = load i16, i16* %loc5
+  %92 = zext i16 %91 to i32
+  %93 = icmp eq i32 %90, %92
+  br i1 %93, label %106, label %94
+
+; <label>:94                                      ; preds = %87
+  %95 = load i32, i32* %loc4
+  %96 = add i32 %95, 1
+  store i32 %96, i32* %loc4
+  br label %97
+
+; <label>:97                                      ; preds = %74, %94
+  %98 = load i32, i32* %loc4
+  %99 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck15 = icmp eq %"System.Char[]" addrspace(1)* %99, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %100
+
+; <label>:100                                     ; preds = %97
+  %101 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %99, i32 0, i32 1
+  %102 = load i32, i32 addrspace(1)* %101
+  %103 = zext i32 %102 to i64
+  %104 = trunc i64 %103 to i32
+  %105 = icmp slt i32 %98, %104
+  br i1 %105, label %79, label %106
+
+; <label>:106                                     ; preds = %87, %100
+  %107 = load i32, i32* %loc4
+  %108 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck17 = icmp eq %"System.Char[]" addrspace(1)* %108, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %109
+
+; <label>:109                                     ; preds = %106
+  %110 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %108, i32 0, i32 1
+  %111 = load i32, i32 addrspace(1)* %110
+  %112 = zext i32 %111 to i64
+  %113 = trunc i64 %112 to i32
+  %114 = icmp eq i32 %107, %113
+  br i1 %114, label %122, label %115
+
+; <label>:115                                     ; preds = %109
+  %116 = load i32, i32* %loc0
+  %117 = sub i32 %116, 1
+  store i32 %117, i32* %loc0
+  br label %118
+
+; <label>:118                                     ; preds = %67, %115
+  %119 = load i32, i32* %loc0
+  %120 = load i32, i32* %loc1
+  %121 = icmp sge i32 %119, %120
+  br i1 %121, label %71, label %122
+
+; <label>:122                                     ; preds = %62, %109, %118
+  %123 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %124 = load i32, i32* %loc1
+  %125 = load i32, i32* %loc0
+  %126 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %123, i32 %124, i32 %125)
+  ret %System.String addrspace(1)* %126
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %97
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange22:                           ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
 Successfully read String.CreateTrimmedString
 
@@ -5439,8 +6893,8 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
@@ -5535,8 +6989,8 @@ entry:
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i64 2872
   %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
   %8 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %7
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %3
   %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
@@ -5553,8 +7007,8 @@ entry:
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 2864
   %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
   %21 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %20
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
-  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %22
 
 ; <label>:22                                      ; preds = %16
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
@@ -5569,7 +7023,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %16
+ThrowNullRef2:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5586,8 +7040,8 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5613,8 +7067,8 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
@@ -5632,8 +7086,8 @@ entry:
 
 ; <label>:12                                      ; preds = %4
   %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
@@ -5644,8 +7098,8 @@ entry:
 
 ; <label>:19                                      ; preds = %14
   %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %19
   %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
@@ -5660,21 +7114,21 @@ entry:
   %31 = zext i16 %30 to i32
   %32 = bitcast i8* %29 to i16*
   %33 = trunc i32 %31 to i16
-  %NullCheck6 = icmp ne i16* %32, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i16* %32, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %21
   store i16 %33, i16* %32, align 8
   %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %36
 
 ; <label>:36                                      ; preds = %34
   %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
   %38 = load i32, i32 addrspace(1)* %37, align 8
   %39 = add i32 %38, 1
-  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %40
 
 ; <label>:40                                      ; preds = %36
   %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
@@ -5683,16 +7137,16 @@ entry:
 
 ; <label>:42                                      ; preds = %14
   %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
-  br i1 %NullCheck12, label %44, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
   %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
   %47 = load i16, i16* %arg1
   %48 = zext i16 %47 to i32
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = trunc i32 %48 to i16
@@ -5703,31 +7157,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %19
+ThrowNullRef4:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %21
+ThrowNullRef6:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %36
+ThrowNullRef10:                                   ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %42
+ThrowNullRef12:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %44
+ThrowNullRef14:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5740,8 +7194,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -5752,8 +7206,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
@@ -5762,14 +7216,14 @@ entry:
 
 ; <label>:11                                      ; preds = %1
   %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
@@ -5779,15 +7233,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5808,8 +7262,8 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5822,8 +7276,8 @@ entry:
 
 ; <label>:8                                       ; preds = %3
   %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
@@ -5842,15 +7296,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
-  br i1 %NullCheck4, label %22, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
   %24 = load i16*, i16* addrspace(1)* %23, align 8
   %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %25, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
@@ -5859,8 +7313,8 @@ entry:
   store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
@@ -5874,8 +7328,8 @@ entry:
 
 ; <label>:37                                      ; preds = %65
   %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %37
   %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
@@ -5886,16 +7340,16 @@ entry:
   %45 = bitcast i16* %41 to i8*
   %46 = getelementptr inbounds i8, i8* %45, i64 %44
   %47 = bitcast i8* %46 to i16*
-  %NullCheck14 = icmp ne i16* %47, null
-  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %47, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %48
 
 ; <label>:48                                      ; preds = %39
   %49 = load i16, i16* %47, align 8
   %50 = zext i16 %49 to i32
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %52 = load i32, i32* %loc1
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %53
 
 ; <label>:53                                      ; preds = %48
   %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
@@ -5916,8 +7370,8 @@ entry:
 ; <label>:62                                      ; preds = %36, %59
   %63 = load i32, i32* %loc1
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck10, label %65, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %65
 
 ; <label>:65                                      ; preds = %62
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
@@ -5936,15 +7390,15 @@ entry:
 
 ; <label>:74                                      ; preds = %70
   %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
-  br i1 %NullCheck18, label %76, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %76
 
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
   %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
-  br i1 %NullCheck20, label %80, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
   %81 = load i64, i64 addrspace(1)* %79
@@ -5958,8 +7412,8 @@ entry:
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
   %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
-  br i1 %NullCheck22, label %92, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.String addrspace(1)* %90, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %92
 
 ; <label>:92                                      ; preds = %80
   %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
@@ -5969,15 +7423,15 @@ entry:
 
 ; <label>:96                                      ; preds = %70
   %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
-  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %98
 
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
   %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
-  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
   %103 = load i64, i64 addrspace(1)* %101
@@ -5991,8 +7445,8 @@ entry:
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
   %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
-  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.String addrspace(1)* %112, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %114
 
 ; <label>:114                                     ; preds = %102
   %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
@@ -6004,59 +7458,59 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %20
+ThrowNullRef4:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %22
+ThrowNullRef6:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %26
+ThrowNullRef8:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %62
+ThrowNullRef10:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %48
+ThrowNullRef16:                                   ; preds = %48
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %74
+ThrowNullRef18:                                   ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %76
+ThrowNullRef20:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %80
+ThrowNullRef22:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %96
+ThrowNullRef24:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %98
+ThrowNullRef26:                                   ; preds = %98
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %102
+ThrowNullRef28:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6069,15 +7523,15 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
   %3 = load i16*, i16* addrspace(1)* %2, align 8
   %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
@@ -6087,8 +7541,8 @@ entry:
   %10 = bitcast i16* %3 to i8*
   %11 = getelementptr inbounds i8, i8* %10, i64 %9
   %12 = bitcast i8* %11 to i16*
-  %NullCheck4 = icmp ne i16* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %5
   store i16 0, i16* %12, align 8
@@ -6098,11 +7552,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6119,8 +7573,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -6131,8 +7585,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
@@ -6144,15 +7598,15 @@ entry:
 
 ; <label>:14                                      ; preds = %1
   %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
   %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
   %21 = load i64, i64 addrspace(1)* %19
@@ -6171,15 +7625,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %14
+ThrowNullRef4:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %16
+ThrowNullRef6:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6302,14 +7756,6 @@ entry:
   ret %System.String addrspace(1)* %57
 }
 
-INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
-Successfully read RuntimeHelpers.get_OffsetToStringData
-
-define i32 @RuntimeHelpers.get_OffsetToStringData() {
-entry:
-  ret i32 12
-}
-
 INFO:  jitting method String::Equals using LLILCJit
 Successfully read String.Equals
 
@@ -6381,8 +7827,8 @@ entry:
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
-  br i1 %NullCheck24, label %29, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
   %30 = load i64, i64 addrspace(1)* %28
@@ -6397,8 +7843,8 @@ entry:
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
-  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
   %43 = load i64, i64 addrspace(1)* %41
@@ -6418,8 +7864,8 @@ entry:
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
   %59 = load i64, i64 addrspace(1)* %57
@@ -6434,8 +7880,8 @@ entry:
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck22, label %71, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
   %72 = load i64, i64 addrspace(1)* %70
@@ -6455,8 +7901,8 @@ entry:
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
-  br i1 %NullCheck16, label %87, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = load i64, i64 addrspace(1)* %86
@@ -6471,8 +7917,8 @@ entry:
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck18, label %100, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
   %101 = load i64, i64 addrspace(1)* %99
@@ -6492,8 +7938,8 @@ entry:
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
-  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
   %117 = load i64, i64 addrspace(1)* %115
@@ -6508,8 +7954,8 @@ entry:
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
-  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
   %130 = load i64, i64 addrspace(1)* %128
@@ -6528,15 +7974,15 @@ entry:
 
 ; <label>:142                                     ; preds = %22
   %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
-  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %143, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %144
 
 ; <label>:144                                     ; preds = %142
   %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
   %146 = load i32, i32 addrspace(1)* %145
   %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
-  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %147, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %148
 
 ; <label>:148                                     ; preds = %144
   %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
@@ -6557,15 +8003,15 @@ entry:
 
 ; <label>:159                                     ; preds = %22
   %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
-  br i1 %NullCheck, label %161, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %ThrowNullRef, label %161
 
 ; <label>:161                                     ; preds = %159
   %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
   %163 = load i32, i32 addrspace(1)* %162
   %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
-  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %164, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %165
 
 ; <label>:165                                     ; preds = %161
   %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
@@ -6578,8 +8024,8 @@ entry:
 
 ; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
-  br i1 %NullCheck4, label %172, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %171, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %172
 
 ; <label>:172                                     ; preds = %170
   %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
@@ -6589,8 +8035,8 @@ entry:
 
 ; <label>:176                                     ; preds = %172
   %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
-  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %177, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %178
 
 ; <label>:178                                     ; preds = %176
   %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
@@ -6629,55 +8075,55 @@ ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %161
+ThrowNullRef2:                                    ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %170
+ThrowNullRef4:                                    ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %176
+ThrowNullRef6:                                    ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %142
+ThrowNullRef8:                                    ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %144
+ThrowNullRef10:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %113
+ThrowNullRef12:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %116
+ThrowNullRef14:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %84
+ThrowNullRef16:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %87
+ThrowNullRef18:                                   ; preds = %87
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %55
+ThrowNullRef20:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %58
+ThrowNullRef22:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %26
+ThrowNullRef24:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %29
+ThrowNullRef26:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,8 +8161,8 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck, label %14, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %ThrowNullRef, label %14
 
 ; <label>:14                                      ; preds = %8
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
@@ -6760,8 +8206,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
@@ -6770,14 +8216,14 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32, i32* %loc0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %10
   %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
   %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
@@ -6790,15 +8236,15 @@ entry:
 ; <label>:25                                      ; preds = %19
   %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
-  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
   %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
@@ -6807,8 +8253,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %37 = load i32, i32* %loc0
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %38, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %38
 
 ; <label>:38                                      ; preds = %32
   %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
@@ -6817,14 +8263,14 @@ entry:
 
 ; <label>:40                                      ; preds = %19
   %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %40
   %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
   %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
-  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
-  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
@@ -6832,8 +8278,8 @@ entry:
   %48 = zext i32 %47 to i64
   %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
-  br i1 %NullCheck16, label %51, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %51
 
 ; <label>:51                                      ; preds = %45
   %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
@@ -6847,15 +8293,15 @@ entry:
 ; <label>:57                                      ; preds = %51
   %58 = load i16*, i16** %arg1
   %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
-  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %60
 
 ; <label>:60                                      ; preds = %57
   %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
   %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
-  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %64
 
 ; <label>:64                                      ; preds = %60
   %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
@@ -6864,22 +8310,22 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
   %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
-  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %70
 
 ; <label>:70                                      ; preds = %64
   %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
   %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
-  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
-  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
   %75 = load i32, i32 addrspace(1)* %74
   %76 = zext i32 %75 to i64
   %77 = trunc i64 %76 to i32
-  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
-  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %78
 
 ; <label>:78                                      ; preds = %73
   %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
@@ -6901,8 +8347,8 @@ entry:
   %90 = bitcast i16* %86 to i8*
   %91 = getelementptr inbounds i8, i8* %90, i64 %89
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %93
 
 ; <label>:93                                      ; preds = %80
   %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
@@ -6912,8 +8358,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %99 = load i32, i32* %loc2
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %100
 
 ; <label>:100                                     ; preds = %93
   %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
@@ -6928,63 +8374,63 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %25
+ThrowNullRef6:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %32
+ThrowNullRef10:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %40
+ThrowNullRef12:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %45
+ThrowNullRef16:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %57
+ThrowNullRef18:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %60
+ThrowNullRef20:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %64
+ThrowNullRef22:                                   ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %70
+ThrowNullRef24:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %73
+ThrowNullRef26:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %80
+ThrowNullRef28:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %93
+ThrowNullRef30:                                   ; preds = %93
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7004,8 +8450,8 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
@@ -7033,43 +8479,43 @@ entry:
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %14
   %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
   %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   %28 = load i32, i32 addrspace(1)* %27, align 8
   %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
-  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %30
 
 ; <label>:30                                      ; preds = %26
   %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
   %32 = load i32, i32 addrspace(1)* %31, align 8
   %33 = add i32 %28, %32
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %34
 
 ; <label>:34                                      ; preds = %30
   %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   store i32 %33, i32 addrspace(1)* %35
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
   store i32 0, i32 addrspace(1)* %38
   %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %40
 
 ; <label>:40                                      ; preds = %37
   %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
@@ -7082,8 +8528,8 @@ entry:
 
 ; <label>:47                                      ; preds = %40
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
@@ -7098,8 +8544,8 @@ entry:
   %54 = load i32, i32* %loc0
   %55 = sext i32 %54 to i64
   %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
-  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %57
 
 ; <label>:57                                      ; preds = %52
   %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
@@ -7110,68 +8556,35 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %14
+ThrowNullRef2:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %23
+ThrowNullRef4:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %26
+ThrowNullRef6:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %30
+ThrowNullRef8:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %34
+ThrowNullRef10:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %47
+ThrowNullRef14:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %52
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-}
-
-INFO:  jitting method StringBuilder::get_Length using LLILCJit
-Successfully read StringBuilder.get_Length
-
-define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.StringBuilder addrspace(1)*
-  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
-  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
-
-; <label>:1                                       ; preds = %entry
-  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %3 = load i32, i32 addrspace(1)* %2, align 8
-  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
-
-; <label>:5                                       ; preds = %1
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = add i32 %3, %7
-  ret i32 %8
-
-ThrowNullRef:                                     ; preds = %entry
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef16:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7213,70 +8626,70 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
   %6 = load i32, i32 addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
   store i32 %6, i32 addrspace(1)* %8
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
   %13 = load i32, i32 addrspace(1)* %12, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
   store i32 %13, i32 addrspace(1)* %15
   %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
-  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %18
 
 ; <label>:18                                      ; preds = %14
   %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
   %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
   %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
   %34 = load i32, i32 addrspace(1)* %33, align 8
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
-  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
@@ -7287,39 +8700,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %28
+ThrowNullRef16:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %32
+ThrowNullRef18:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7455,13 +8868,13 @@ entry:
 ; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
@@ -7477,16 +8890,16 @@ entry:
 
 ; <label>:18                                      ; preds = %15
   %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
   store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
   %22 = load i32, i32* %loc0
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %24
 
 ; <label>:24                                      ; preds = %20
   %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
@@ -7498,13 +8911,13 @@ entry:
 ; <label>:28                                      ; preds = %15, %24
   %29 = load i32, i32* %arg1
   %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %31
   %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
@@ -7517,20 +8930,20 @@ entry:
   %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
-  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
   %46 = load i32, i32 addrspace(1)* %45, align 8
   %47 = sub i32 %40, %46
-  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
-  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i32 addrspace(1)* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %48
 
 ; <label>:48                                      ; preds = %44
   store i32 %47, i32 addrspace(1)* %39, align 8
@@ -7538,21 +8951,21 @@ entry:
 
 ; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
-  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %51
 
 ; <label>:51                                      ; preds = %49
   %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %53
 
 ; <label>:53                                      ; preds = %51
   %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
   %55 = load i32, i32 addrspace(1)* %54, align 8
   %56 = load i32, i32* %arg2
   %57 = sub i32 %55, %56
-  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %58
 
 ; <label>:58                                      ; preds = %53
   %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
@@ -7562,13 +8975,13 @@ entry:
 ; <label>:60                                      ; preds = %33, %58
   %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
   %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
-  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %63
 
 ; <label>:63                                      ; preds = %60
   %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
-  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
-  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
@@ -7578,15 +8991,15 @@ entry:
 
 ; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
-  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i32 addrspace(1)* %69, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %70
 
 ; <label>:70                                      ; preds = %68
   %71 = load i32, i32 addrspace(1)* %69, align 8
   store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
-  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
@@ -7596,8 +9009,8 @@ entry:
   store i32 %77, i32* %loc4
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
-  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %80
 
 ; <label>:80                                      ; preds = %73
   %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
@@ -7607,71 +9020,71 @@ entry:
 ; <label>:83                                      ; preds = %80
   store i32 0, i32* %loc3
   %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
-  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
-  br i1 %NullCheck26, label %88, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i32 addrspace(1)* %87, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %88
 
 ; <label>:88                                      ; preds = %85
   %89 = load i32, i32 addrspace(1)* %87, align 8
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
-  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %90
 
 ; <label>:90                                      ; preds = %88
   %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
   store i32 %89, i32 addrspace(1)* %91
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
-  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
-  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %96
 
 ; <label>:96                                      ; preds = %94
   %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
-  br i1 %NullCheck34, label %100, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %100
 
 ; <label>:100                                     ; preds = %96
   %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
-  br i1 %NullCheck36, label %102, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %102
 
 ; <label>:102                                     ; preds = %100
   %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
   %104 = load i32, i32 addrspace(1)* %103, align 8
   %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
-  br i1 %NullCheck38, label %106, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %106
 
 ; <label>:106                                     ; preds = %102
   %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
-  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
-  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %108
 
 ; <label>:108                                     ; preds = %106
   %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
   %110 = load i32, i32 addrspace(1)* %109, align 8
   %111 = add i32 %104, %110
-  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %112
 
 ; <label>:112                                     ; preds = %108
   %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
   store i32 %111, i32 addrspace(1)* %113
   %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
-  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i32 addrspace(1)* %114, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %115
 
 ; <label>:115                                     ; preds = %112
   %116 = load i32, i32 addrspace(1)* %114, align 8
@@ -7681,19 +9094,19 @@ entry:
 ; <label>:118                                     ; preds = %115
   %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
-  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %121
 
 ; <label>:121                                     ; preds = %118
   %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
-  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
-  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %123
 
 ; <label>:123                                     ; preds = %121
   %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
   %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
-  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
-  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %126
 
 ; <label>:126                                     ; preds = %123
   %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
@@ -7705,8 +9118,8 @@ entry:
 
 ; <label>:130                                     ; preds = %80, %115, %126
   %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %132
 
 ; <label>:132                                     ; preds = %130
   %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7715,8 +9128,8 @@ entry:
   %136 = load i32, i32* %loc3
   %137 = sub i32 %135, %136
   %138 = sub i32 %134, %137
-  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %139
 
 ; <label>:139                                     ; preds = %132
   %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7728,16 +9141,16 @@ entry:
 
 ; <label>:144                                     ; preds = %139
   %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
-  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %146
 
 ; <label>:146                                     ; preds = %144
   %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
   %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
   %149 = load i32, i32* %loc2
   %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
-  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %151
 
 ; <label>:151                                     ; preds = %146
   %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
@@ -7754,145 +9167,249 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %18
+ThrowNullRef4:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %31
+ThrowNullRef10:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %44
+ThrowNullRef16:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %68
+ThrowNullRef18:                                   ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %70
+ThrowNullRef20:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %73
+ThrowNullRef22:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %83
+ThrowNullRef24:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %85
+ThrowNullRef26:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %88
+ThrowNullRef28:                                   ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %90
+ThrowNullRef30:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %94
+ThrowNullRef32:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %96
+ThrowNullRef34:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %100
+ThrowNullRef36:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %102
+ThrowNullRef38:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %106
+ThrowNullRef40:                                   ; preds = %106
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %108
+ThrowNullRef42:                                   ; preds = %108
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %112
+ThrowNullRef44:                                   ; preds = %112
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %118
+ThrowNullRef46:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %121
+ThrowNullRef48:                                   ; preds = %121
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %123
+ThrowNullRef50:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %130
+ThrowNullRef52:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %132
+ThrowNullRef54:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %144
+ThrowNullRef56:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %146
+ThrowNullRef58:                                   ; preds = %146
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %60
+ThrowNullRef60:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %63
+ThrowNullRef62:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %49
+ThrowNullRef64:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %51
+ThrowNullRef66:                                   ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %53
+ThrowNullRef68:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(%"System.Char[]" addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %arg0 = alloca %"System.Char[]" addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store %"System.Char[]" addrspace(1)* %param0, %"System.Char[]" addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load i32, i32* %arg4
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %43, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %38, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg1
+  %13 = load i32, i32* %arg4
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %38, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %24 = load i32, i32* %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %35 = load i32, i32* %arg3
+  %36 = load i32, i32* %arg4
+  %37 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %37, %"System.Char[]" addrspace(1)* %34, i32 %35, i32 %36)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:38                                      ; preds = %5, %16
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Successfully read Buffer._Memmove
 
@@ -7914,7 +9431,7 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[loadElem]
+Failed to read AppDomain.SetDataHelper[storeElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -7923,8 +9440,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
@@ -7934,8 +9451,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
@@ -7947,15 +9464,15 @@ entry:
   %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
   %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
@@ -7966,15 +9483,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7992,7 +9509,79 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
-Failed to read Dictionary`2.TryGetValue[loadElemA]
+Successfully read Dictionary`2.TryGetValue
+
+define i8 @"Dictionary`2.TryGetValue"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)* addrspace(1)* %param2) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  %arg2 = alloca %System.__Canon addrspace(1)* addrspace(1)*
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  store %System.__Canon addrspace(1)* addrspace(1)* %param2, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  store i32 %2, i32* %loc0
+  %3 = load i32, i32* %loc0
+  %4 = icmp slt i32 %3, 0
+  br i1 %4, label %22, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 2
+  %10 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %9, align 8
+  %11 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = zext i32 %11 to i64
+  %BoundsCheck = icmp uge i64 %16, %15
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 3, i32 %11
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %20, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %6, %System.__Canon addrspace(1)* %21)
+  ret i8 1
+
+; <label>:22                                      ; preds = %entry
+  %23 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %23, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -8058,8 +9647,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
@@ -8091,8 +9680,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
@@ -8171,15 +9760,15 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck, label %19, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %ThrowNullRef, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
   %21 = load i32, i32 addrspace(1)* %20
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
@@ -8202,7 +9791,7 @@ ThrowNullRef:                                     ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %19
+ThrowNullRef2:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8248,8 +9837,8 @@ entry:
   %0 = alloca %System.AppDomainHandle
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %1 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %1, i32 0, i32 15
@@ -8269,8 +9858,8 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
@@ -8286,7 +9875,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -8299,8 +9888,8 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -8327,8 +9916,8 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
@@ -8352,8 +9941,8 @@ entry:
   %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
   store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
@@ -8363,8 +9952,8 @@ entry:
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
@@ -8374,8 +9963,8 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %9
   %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
@@ -8384,8 +9973,8 @@ entry:
 
 ; <label>:18                                      ; preds = %3, %16
   %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
@@ -8397,15 +9986,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %18
+ThrowNullRef6:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8418,8 +10007,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
@@ -8453,15 +10042,15 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
@@ -8473,7 +10062,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8481,7 +10070,7 @@ ThrowNullRef1:                                    ; preds = %1
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
 Failed to read Dictionary`2.System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
@@ -8506,8 +10095,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
@@ -8524,8 +10113,8 @@ entry:
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -8544,7 +10133,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8577,8 +10166,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = load i64, i64* %arg2
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = trunc i32 %3 to i8
@@ -8634,46 +10223,46 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
   %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
-  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
-  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
-  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
@@ -8684,27 +10273,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %20
+ThrowNullRef12:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8717,8 +10306,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -8756,22 +10345,22 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
   %9 = load i64, i64 addrspace(1)* %8, align 8
   %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
   %13 = load i64, i64 addrspace(1)* %12, align 8
   %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %11
   %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
@@ -8788,11 +10377,11 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8882,8 +10471,8 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
@@ -8900,8 +10489,8 @@ entry:
 ; <label>:8                                       ; preds = %1
   %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
   %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
@@ -8911,15 +10500,15 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
   %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
   %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
-  br i1 %NullCheck6, label %21, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
@@ -8946,15 +10535,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8992,15 +10581,15 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
   store i8 %3, i8 addrspace(1)* %5
   %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
@@ -9011,7 +10600,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9027,8 +10616,8 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -9041,8 +10630,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
@@ -9058,7 +10647,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9080,8 +10669,8 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
@@ -9096,8 +10685,8 @@ entry:
 ; <label>:12                                      ; preds = %6
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
@@ -9112,8 +10701,8 @@ entry:
 ; <label>:21                                      ; preds = %15
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
@@ -9128,8 +10717,8 @@ entry:
 ; <label>:30                                      ; preds = %24
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %31, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
@@ -9144,8 +10733,8 @@ entry:
 ; <label>:39                                      ; preds = %33
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
-  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %40, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %42
 
 ; <label>:42                                      ; preds = %39
   %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
@@ -9164,19 +10753,19 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %21
+ThrowNullRef4:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %30
+ThrowNullRef6:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %39
+ThrowNullRef8:                                    ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9243,8 +10832,8 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
@@ -9264,57 +10853,57 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
   store i8 0, i8 addrspace(1)* %2
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
   store i8 0, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
   store i8 0, i8 addrspace(1)* %17
   %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
   store i8 0, i8 addrspace(1)* %20
   %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
-  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
@@ -9325,31 +10914,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %19
+ThrowNullRef14:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9367,8 +10956,8 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
@@ -9380,8 +10969,8 @@ entry:
 
 ; <label>:9                                       ; preds = %4
   %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %9
   %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
@@ -9395,7 +10984,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef2:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9420,8 +11009,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
@@ -9512,8 +11101,8 @@ entry:
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
@@ -9524,8 +11113,8 @@ entry:
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = load i64, i64 addrspace(1)* %12
@@ -9537,8 +11126,8 @@ entry:
   %20 = load i64, i64* %19
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
-  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %13
   %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
@@ -9555,8 +11144,8 @@ entry:
 ; <label>:30                                      ; preds = %25
   %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %32 = load i32, i32* %arg2
-  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
-  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
@@ -9570,15 +11159,15 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %30
+ThrowNullRef2:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9622,87 +11211,87 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
   %10 = load i8, i8 addrspace(1)* %9, align 8
   %11 = zext i8 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %8
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
   store i8 %12, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
   %19 = load i8, i8 addrspace(1)* %18, align 8
   %20 = zext i8 %19 to i32
   %21 = trunc i32 %20 to i8
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
   store i8 %21, i8 addrspace(1)* %23
   %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
   %28 = load i8, i8 addrspace(1)* %27, align 8
   %29 = zext i8 %28 to i32
   %30 = trunc i32 %29 to i8
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
-  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %31
 
 ; <label>:31                                      ; preds = %26
   %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
   store i8 %30, i8 addrspace(1)* %32
   %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
-  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
-  br i1 %NullCheck14, label %40, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %40
 
 ; <label>:40                                      ; preds = %35
   %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
   store i8 %39, i8 addrspace(1)* %41
   %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
-  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %44
 
 ; <label>:44                                      ; preds = %40
   %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
   %46 = load i8, i8 addrspace(1)* %45, align 8
   %47 = zext i8 %46 to i32
   %48 = trunc i32 %47 to i8
-  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
   store i8 %48, i8 addrspace(1)* %50
   %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
-  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
@@ -9713,29 +11302,29 @@ entry:
 ; <label>:56                                      ; preds = %52
   %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
-  br i1 %NullCheck22, label %59, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
   %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
   %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
-  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
-  br i1 %NullCheck24, label %63, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
   %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
-  br i1 %NullCheck26, label %66, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
   %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
-  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
-  br i1 %NullCheck28, label %69, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %69
 
 ; <label>:69                                      ; preds = %66
   %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
@@ -9744,15 +11333,15 @@ entry:
 
 ; <label>:71                                      ; preds = %105
   %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
-  br i1 %NullCheck34, label %73, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %73
 
 ; <label>:73                                      ; preds = %71
   %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
   %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
   %76 = load i32, i32* %loc0
-  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
-  br i1 %NullCheck36, label %77, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
@@ -9766,8 +11355,8 @@ entry:
 
 ; <label>:83                                      ; preds = %77
   %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
-  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
@@ -9775,14 +11364,14 @@ entry:
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
   %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
-  br i1 %NullCheck40, label %91, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
 ; <label>:91                                      ; preds = %85
   %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
   %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
-  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck42, label %94, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %94
 
 ; <label>:94                                      ; preds = %91
   %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
@@ -9798,14 +11387,14 @@ entry:
 ; <label>:99                                      ; preds = %69, %96
   %100 = load i32, i32* %loc0
   %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
-  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %102
 
 ; <label>:102                                     ; preds = %99
   %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
   %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
-  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
-  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
@@ -9819,87 +11408,87 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %26
+ThrowNullRef10:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %31
+ThrowNullRef12:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %35
+ThrowNullRef14:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %40
+ThrowNullRef16:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %56
+ThrowNullRef22:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %59
+ThrowNullRef24:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %63
+ThrowNullRef26:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %66
+ThrowNullRef28:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %102
+ThrowNullRef32:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %71
+ThrowNullRef34:                                   ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %73
+ThrowNullRef36:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %83
+ThrowNullRef38:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %85
+ThrowNullRef40:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %91
+ThrowNullRef42:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9943,15 +11532,15 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
   %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
@@ -9961,28 +11550,28 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
   %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %12
   %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
   %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
   %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
-  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
@@ -9993,23 +11582,23 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %12
+ThrowNullRef6:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10031,15 +11620,15 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
   %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = load i64, i64 addrspace(1)* %7
@@ -10077,13 +11666,13 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[loadElem]
+Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -10111,8 +11700,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -10178,8 +11767,8 @@ entry:
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load double, double* %arg0
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -10313,8 +11902,8 @@ entry:
   store i64 %param0, i64* %arg0
   store i64 %param1, i64* %arg1
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
@@ -10322,8 +11911,8 @@ entry:
   %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
   %5 = load i16*, i16* addrspace(1)* %4, align 8
   %6 = addrspacecast i64* %arg1 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = bitcast i64 addrspace(1)* %6 to i8 addrspace(1)*
@@ -10339,7 +11928,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10373,8 +11962,8 @@ entry:
   %1 = load i32, i32* %arg1
   %2 = sext i32 %1 to i64
   %3 = inttoptr i64 %2 to i16*
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -10427,8 +12016,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, i32)*)(%System.IO.ConsoleStream addrspace(1)* %2, i32 %1)
   %3 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %4 = load i64, i64* %arg1
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
@@ -10439,8 +12028,8 @@ entry:
   %10 = icmp eq i32 %9, 3
   %11 = sext i1 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %5
   %14 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, i32 0, i32 5
@@ -10451,7 +12040,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10474,8 +12063,8 @@ entry:
   %5 = icmp eq i32 %4, 1
   %6 = sext i1 %5 to i32
   %7 = trunc i32 %6 to i8
-  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %2, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.ConsoleStream addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
@@ -10486,8 +12075,8 @@ entry:
   %13 = icmp eq i32 %12, 2
   %14 = sext i1 %13 to i32
   %15 = trunc i32 %14 to i8
-  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %10, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.ConsoleStream addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %8
   %17 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %10, i32 0, i32 4
@@ -10498,7 +12087,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10537,8 +12126,8 @@ entry:
   %arg0 = alloca i64
   store i64 %param0, i64* %arg0
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
@@ -10573,8 +12162,8 @@ entry:
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
   %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = load i64, i64 addrspace(1)* %7
@@ -10678,7 +12267,127 @@ entry:
 INFO:  jitting method Encoding::GetEncoding using LLILCJit
 Failed to read Encoding.GetEncoding[convertToHelperArgumentType]
 INFO:  jitting method EncodingProvider::GetEncodingFromProvider using LLILCJit
-Failed to read EncodingProvider.GetEncodingFromProvider[loadElem]
+Successfully read EncodingProvider.GetEncodingFromProvider
+
+define %System.Text.Encoding addrspace(1)* @EncodingProvider.GetEncodingFromProvider(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca %"System.Text.EncodingProvider[]" addrspace(1)*
+  %loc1 = alloca %System.Text.EncodingProvider addrspace(1)*
+  %loc2 = alloca %System.Text.Encoding addrspace(1)*
+  %loc3 = alloca %System.Text.Encoding addrspace(1)*
+  %loc4 = alloca %"System.Text.EncodingProvider[]" addrspace(1)*
+  %loc5 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1059)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2392
+  %2 = addrspacecast i8 addrspace(1)* %1 to %"System.Text.EncodingProvider[]" addrspace(1)**
+  %3 = load volatile %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %2
+  %4 = icmp ne %"System.Text.EncodingProvider[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %entry
+  ret %System.Text.Encoding addrspace(1)* null
+
+; <label>:6                                       ; preds = %entry
+  %7 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1059)
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i64 2392
+  %9 = addrspacecast i8 addrspace(1)* %8 to %"System.Text.EncodingProvider[]" addrspace(1)**
+  %10 = load volatile %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %9
+  store %"System.Text.EncodingProvider[]" addrspace(1)* %10, %"System.Text.EncodingProvider[]" addrspace(1)** %loc0
+  %11 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc0
+  store %"System.Text.EncodingProvider[]" addrspace(1)* %11, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  store i32 0, i32* %loc5
+  br label %43
+
+; <label>:12                                      ; preds = %46
+  %13 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  %14 = load i32, i32* %loc5
+  %NullCheck1 = icmp eq %"System.Text.EncodingProvider[]" addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %13, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = zext i32 %17 to i64
+  %19 = zext i32 %14 to i64
+  %BoundsCheck = icmp uge i64 %19, %18
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %20
+
+; <label>:20                                      ; preds = %15
+  %21 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %13, i32 0, i32 3, i32 %14
+  %22 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)* addrspace(1)* %21, align 8
+  store %System.Text.EncodingProvider addrspace(1)* %22, %System.Text.EncodingProvider addrspace(1)** %loc1
+  %23 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)** %loc1
+  %24 = load i32, i32* %arg0
+  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i64 addrspace(1)*
+  %NullCheck3 = icmp eq i64 addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
+
+; <label>:26                                      ; preds = %20
+  %27 = load i64, i64 addrspace(1)* %25
+  %28 = add i64 %27, 64
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 40
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Text.Encoding addrspace(1)* (%System.Text.EncodingProvider addrspace(1)*, i32)*
+  %35 = call %System.Text.Encoding addrspace(1)* %34(%System.Text.EncodingProvider addrspace(1)* %23, i32 %24)
+  store %System.Text.Encoding addrspace(1)* %35, %System.Text.Encoding addrspace(1)** %loc2
+  %36 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc2
+  %37 = icmp eq %System.Text.Encoding addrspace(1)* %36, null
+  br i1 %37, label %40, label %38
+
+; <label>:38                                      ; preds = %26
+  %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc2
+  store %System.Text.Encoding addrspace(1)* %39, %System.Text.Encoding addrspace(1)** %loc3
+  br label %53
+
+; <label>:40                                      ; preds = %26
+  %41 = load i32, i32* %loc5
+  %42 = add i32 %41, 1
+  store i32 %42, i32* %loc5
+  br label %43
+
+; <label>:43                                      ; preds = %6, %40
+  %44 = load i32, i32* %loc5
+  %45 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  %NullCheck = icmp eq %"System.Text.EncodingProvider[]" addrspace(1)* %45, null
+  br i1 %NullCheck, label %ThrowNullRef, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp slt i32 %44, %50
+  br i1 %51, label %12, label %52
+
+; <label>:52                                      ; preds = %46
+  ret %System.Text.Encoding addrspace(1)* null
+
+; <label>:53                                      ; preds = %38
+  %54 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc3
+  ret %System.Text.Encoding addrspace(1)* %54
+
+ThrowNullRef:                                     ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method EncodingProvider::.cctor using LLILCJit
 Successfully read EncodingProvider..cctor
 
@@ -10697,7 +12406,7 @@ Failed to read Encoding.get_InternalSyncObject[Call HasTypeArg]
 INFO:  jitting method Hashtable::.ctor using LLILCJit
 Failed to read Hashtable..ctor[Volatile store]
 INFO:  jitting method Hashtable::get_Item using LLILCJit
-Failed to read Hashtable.get_Item[loadElemA]
+Failed to read Hashtable.get_Item[loadNonPrimitiveObj]
 INFO:  jitting method Hashtable::InitHash using LLILCJit
 Successfully read Hashtable.InitHash
 
@@ -10717,8 +12426,8 @@ entry:
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -10734,15 +12443,15 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
   %15 = load i32, i32* %loc0
-  %NullCheck2 = icmp ne i32 addrspace(1)* %14, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i32 addrspace(1)* %14, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %3
   store i32 %15, i32 addrspace(1)* %14, align 8
   %17 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %18 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %NullCheck4 = icmp ne i32 addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i32 addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = load i32, i32 addrspace(1)* %18, align 8
@@ -10751,8 +12460,8 @@ entry:
   %23 = sub i32 %22, 1
   %24 = urem i32 %21, %23
   %25 = add i32 1, %24
-  %NullCheck6 = icmp ne i32 addrspace(1)* %17, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32 addrspace(1)* %17, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %19
   store i32 %25, i32 addrspace(1)* %17, align 8
@@ -10763,15 +12472,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %19
+ThrowNullRef6:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10786,8 +12495,8 @@ entry:
   store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
   store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %NullCheck = icmp ne %System.Collections.Hashtable addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Collections.Hashtable addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
@@ -10797,16 +12506,16 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Collections.Hashtable addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Collections.Hashtable addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
   %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck4 = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %9, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
   %13 = inttoptr i64 %11 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
@@ -10816,8 +12525,8 @@ entry:
 ; <label>:15                                      ; preds = %1
   %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -10835,15 +12544,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10857,8 +12566,8 @@ entry:
   store %System.Int32 addrspace(1)* %param0, %System.Int32 addrspace(1)** %this
   %0 = load %System.Int32 addrspace(1)*, %System.Int32 addrspace(1)** %this
   %1 = bitcast %System.Int32 addrspace(1)* %0 to i32 addrspace(1)*
-  %NullCheck = icmp ne i32 addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq i32 addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load i32, i32 addrspace(1)* %1, align 8
@@ -10934,8 +12643,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.UTF8Encoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
@@ -10944,15 +12653,15 @@ entry:
   %9 = load i8, i8* %arg2
   %10 = zext i8 %9 to i32
   %11 = trunc i32 %10 to i8
-  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %8, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %6
   %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %8, i32 0, i32 8
   store i8 %11, i8 addrspace(1)* %13
   %14 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %14, i32 0, i32 8
@@ -10964,8 +12673,8 @@ entry:
 ; <label>:20                                      ; preds = %15
   %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %22, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %22, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = load i64, i64 addrspace(1)* %22
@@ -10987,15 +12696,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %12
+ThrowNullRef4:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11010,8 +12719,8 @@ entry:
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
@@ -11033,16 +12742,16 @@ entry:
 ; <label>:10                                      ; preds = %1
   %11 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
   %12 = load i32, i32* %arg1
-  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %11, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.Encoding addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
   store i32 %12, i32 addrspace(1)* %14
   %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
   %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = load i64, i64 addrspace(1)* %16
@@ -11060,11 +12769,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11077,8 +12786,8 @@ entry:
   %this = alloca %System.Text.UTF8Encoding addrspace(1)*
   store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
   %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.UTF8Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
@@ -11090,16 +12799,16 @@ entry:
 ; <label>:6                                       ; preds = %1
   %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %8 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %10, %System.Text.EncoderFallback addrspace(1)* %8)
   %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %12 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
-  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %11, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %11, i32 0, i32 3
@@ -11112,8 +12821,8 @@ entry:
   %18 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %18, %System.String addrspace(1)* %17)
   %19 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %18 to %System.Text.EncoderFallback addrspace(1)*
-  %NullCheck6 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %16, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %16, i32 0, i32 2
@@ -11123,8 +12832,8 @@ entry:
   %24 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %24, %System.String addrspace(1)* %23)
   %25 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %24 to %System.Text.DecoderFallback addrspace(1)*
-  %NullCheck8 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %22, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %22, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %20
   %27 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %22, i32 0, i32 3
@@ -11135,19 +12844,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %20
+ThrowNullRef8:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11177,8 +12886,8 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load i32, i32* %arg1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -11196,8 +12905,8 @@ entry:
 ; <label>:15                                      ; preds = %8
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %17 = load i32, i32* %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 %17
@@ -11213,7 +12922,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11265,7 +12974,7 @@ entry:
 }
 
 INFO:  jitting method Hashtable::Insert using LLILCJit
-Failed to read Hashtable.Insert[loadElemA]
+Failed to read Hashtable.Insert[storeElem]
 INFO:  jitting method ConsoleEncoding::.ctor using LLILCJit
 Successfully read ConsoleEncoding..ctor
 
@@ -11280,8 +12989,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %1)
   %2 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
@@ -11317,8 +13026,8 @@ entry:
   %2 = call %System.Text.InternalEncoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalEncoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %1)
   %3 = bitcast %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2 to %System.Text.EncoderFallback addrspace(1)*
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
@@ -11328,8 +13037,8 @@ entry:
   %8 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %7)
   %9 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %8 to %System.Text.DecoderFallback addrspace(1)*
-  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %6, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.Encoding addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %4
   %11 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %6, i32 0, i32 3
@@ -11340,7 +13049,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11359,15 +13068,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* %1)
   %2 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   %6 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, i32 0, i32 1
@@ -11378,7 +13087,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11406,8 +13115,8 @@ entry:
   store %System.Text.InternalDecoderBestFitFallback addrspace(1)* %param0, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
   %0 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
@@ -11417,15 +13126,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %4)
   %5 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %6)
   %9 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, i32 0, i32 1
@@ -11436,11 +13145,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11508,8 +13217,8 @@ entry:
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
   %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = load i64, i64 addrspace(1)* %19
@@ -11573,8 +13282,8 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.ConsoleStream addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
@@ -11605,31 +13314,31 @@ entry:
   store i8 %param4, i8* %arg4
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %3, %System.IO.Stream addrspace(1)* %1)
   %4 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %4, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
   %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %4, i32 0, i32 4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %5)
   %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %6
   %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
   %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
   %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = load i64, i64 addrspace(1)* %13
@@ -11641,8 +13350,8 @@ entry:
   %21 = load i64, i64* %20
   %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %8, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %8, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %14
   %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 5
@@ -11660,24 +13369,24 @@ entry:
   %31 = load i32, i32* %arg3
   %32 = sext i32 %31 to i64
   %33 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %32)
-  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %30, null
-  br i1 %NullCheck10, label %34, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.StreamWriter addrspace(1)* %30, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %35, %"System.Char[]" addrspace(1)* %33)
   %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %37, null
-  br i1 %NullCheck12, label %38, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.StreamWriter addrspace(1)* %37, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %38
 
 ; <label>:38                                      ; preds = %34
   %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
   %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
   %41 = load i32, i32* %arg3
   %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %42, null
-  br i1 %NullCheck14, label %43, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %42, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
   %44 = load i64, i64 addrspace(1)* %42
@@ -11691,30 +13400,30 @@ entry:
   %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
   %53 = sext i32 %52 to i64
   %54 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %53)
-  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
-  br i1 %NullCheck16, label %55, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %55
 
 ; <label>:55                                      ; preds = %43
   %56 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %56, %"System.Byte[]" addrspace(1)* %54)
   %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %58 = load i32, i32* %arg3
-  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %57, null
-  br i1 %NullCheck18, label %59, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.StreamWriter addrspace(1)* %57, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %59
 
 ; <label>:59                                      ; preds = %55
   %60 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 10
   store i32 %58, i32 addrspace(1)* %60
   %61 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %61, null
-  br i1 %NullCheck20, label %62, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.IO.StreamWriter addrspace(1)* %61, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %62
 
 ; <label>:62                                      ; preds = %59
   %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
   %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
   %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
   %67 = load i64, i64 addrspace(1)* %65
@@ -11732,15 +13441,15 @@ entry:
 
 ; <label>:78                                      ; preds = %66
   %79 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %79, null
-  br i1 %NullCheck24, label %80, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.StreamWriter addrspace(1)* %79, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %80
 
 ; <label>:80                                      ; preds = %78
   %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
   %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
   %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %83, null
-  br i1 %NullCheck26, label %84, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %83, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
   %85 = load i64, i64 addrspace(1)* %83
@@ -11757,8 +13466,8 @@ entry:
 
 ; <label>:95                                      ; preds = %84
   %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.IO.StreamWriter addrspace(1)* %96, null
-  br i1 %NullCheck28, label %97, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.IO.StreamWriter addrspace(1)* %96, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %97
 
 ; <label>:97                                      ; preds = %95
   %98 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 12
@@ -11772,8 +13481,8 @@ entry:
   %103 = icmp eq i32 %102, 0
   %104 = sext i1 %103 to i32
   %105 = trunc i32 %104 to i8
-  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %100, null
-  br i1 %NullCheck30, label %106, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.IO.StreamWriter addrspace(1)* %100, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %106
 
 ; <label>:106                                     ; preds = %99
   %107 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %100, i32 0, i32 13
@@ -11784,63 +13493,63 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %6
+ThrowNullRef4:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %29
+ThrowNullRef10:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %34
+ThrowNullRef12:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %38
+ThrowNullRef14:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %43
+ThrowNullRef16:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %55
+ThrowNullRef18:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %59
+ThrowNullRef20:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %62
+ThrowNullRef22:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %78
+ThrowNullRef24:                                   ; preds = %78
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %80
+ThrowNullRef26:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %95
+ThrowNullRef28:                                   ; preds = %95
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11853,15 +13562,15 @@ entry:
   %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = load i64, i64 addrspace(1)* %4
@@ -11879,7 +13588,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11929,35 +13638,35 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
   %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderNLS addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %7 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.EncoderNLS addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Text.Encoding addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.Encoding addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Text.EncoderNLS addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.EncoderNLS addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
   %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck8 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = load i64, i64 addrspace(1)* %16
@@ -11976,19 +13685,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12014,8 +13723,8 @@ entry:
   %this = alloca %System.Text.Encoding addrspace(1)*
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
@@ -12035,15 +13744,15 @@ entry:
   %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
   store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
   %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
   store i32 0, i32 addrspace(1)* %2
   %3 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, i32 0, i32 2
@@ -12053,15 +13762,15 @@ entry:
 
 ; <label>:8                                       ; preds = %4
   %9 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
   %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
   %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = load i64, i64 addrspace(1)* %13
@@ -12082,15 +13791,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12105,16 +13814,16 @@ entry:
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = load i32, i32* %arg1
   %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
   %7 = load i64, i64 addrspace(1)* %5
@@ -12132,7 +13841,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12169,8 +13878,8 @@ entry:
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
   %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
   %16 = load i64, i64 addrspace(1)* %14
@@ -12191,8 +13900,8 @@ entry:
   %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
   %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
   %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %31, null
-  br i1 %NullCheck2, label %32, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = load i64, i64 addrspace(1)* %31
@@ -12235,7 +13944,7 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12248,14 +13957,14 @@ entry:
   %this = alloca %System.Text.EncoderReplacementFallback addrspace(1)*
   store %System.Text.EncoderReplacementFallback addrspace(1)* %param0, %System.Text.EncoderReplacementFallback addrspace(1)** %this
   %0 = load %System.Text.EncoderReplacementFallback addrspace(1)*, %System.Text.EncoderReplacementFallback addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -12266,7 +13975,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12296,8 +14005,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
@@ -12329,8 +14038,8 @@ entry:
   %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
   store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
@@ -12342,8 +14051,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Threading.Tasks.Task addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %7)
@@ -12366,7 +14075,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12385,8 +14094,8 @@ entry:
   store i8 %param1, i8* %arg1
   store i8 %param2, i8* %arg2
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
@@ -12400,8 +14109,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1, %5
   %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 9
@@ -12432,8 +14141,8 @@ entry:
 
 ; <label>:25                                      ; preds = %8, %20
   %26 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %26, null
-  br i1 %NullCheck4, label %27, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %26, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %26, i32 0, i32 12
@@ -12444,22 +14153,22 @@ entry:
 
 ; <label>:32                                      ; preds = %27
   %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %33, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.IO.StreamWriter addrspace(1)* %33, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %32
   %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 12
   store i8 1, i8 addrspace(1)* %35
   %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
-  br i1 %NullCheck8, label %37, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
   %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
   %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck10 = icmp ne i64 addrspace(1)* %40, null
-  br i1 %NullCheck10, label %41, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64 addrspace(1)* %40, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i64, i64 addrspace(1)* %40
@@ -12473,8 +14182,8 @@ entry:
   %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
   store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
   %51 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %NullCheck12 = icmp ne %"System.Byte[]" addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Byte[]" addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %41
   %53 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %51, i32 0, i32 1
@@ -12486,16 +14195,16 @@ entry:
 
 ; <label>:58                                      ; preds = %52
   %59 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %59, null
-  br i1 %NullCheck14, label %60, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.IO.StreamWriter addrspace(1)* %59, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %60
 
 ; <label>:60                                      ; preds = %58
   %61 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %59, i32 0, i32 3
   %62 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
   %64 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %NullCheck16 = icmp ne %"System.Byte[]" addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %"System.Byte[]" addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %60
   %66 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %64, i32 0, i32 1
@@ -12503,8 +14212,8 @@ entry:
   %68 = zext i32 %67 to i64
   %69 = trunc i64 %68 to i32
   %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck18, label %71, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
   %72 = load i64, i64 addrspace(1)* %70
@@ -12520,29 +14229,29 @@ entry:
 
 ; <label>:80                                      ; preds = %27, %52, %71
   %81 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %81, null
-  br i1 %NullCheck20, label %82, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.IO.StreamWriter addrspace(1)* %81, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
 
 ; <label>:82                                      ; preds = %80
   %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %81, i32 0, i32 5
   %84 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %83, align 8
   %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.IO.StreamWriter addrspace(1)* %85, null
-  br i1 %NullCheck22, label %86, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.IO.StreamWriter addrspace(1)* %85, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %86
 
 ; <label>:86                                      ; preds = %82
   %87 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 7
   %88 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %87, align 8
   %89 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %89, null
-  br i1 %NullCheck24, label %90, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.StreamWriter addrspace(1)* %89, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %90
 
 ; <label>:90                                      ; preds = %86
   %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %89, i32 0, i32 9
   %92 = load i32, i32 addrspace(1)* %91, align 8
   %93 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.IO.StreamWriter addrspace(1)* %93, null
-  br i1 %NullCheck26, label %94, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.IO.StreamWriter addrspace(1)* %93, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %93, i32 0, i32 6
@@ -12550,8 +14259,8 @@ entry:
   %97 = load i8, i8* %arg2
   %98 = zext i8 %97 to i32
   %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
-  %NullCheck28 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck28, label %100, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
   %101 = load i64, i64 addrspace(1)* %99
@@ -12566,8 +14275,8 @@ entry:
   %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
   store i32 %110, i32* %loc1
   %111 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %111, null
-  br i1 %NullCheck30, label %112, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.IO.StreamWriter addrspace(1)* %111, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %112
 
 ; <label>:112                                     ; preds = %100
   %113 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %111, i32 0, i32 9
@@ -12578,23 +14287,23 @@ entry:
 
 ; <label>:116                                     ; preds = %112
   %117 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck32 = icmp ne %System.IO.StreamWriter addrspace(1)* %117, null
-  br i1 %NullCheck32, label %118, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.IO.StreamWriter addrspace(1)* %117, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %118
 
 ; <label>:118                                     ; preds = %116
   %119 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %117, i32 0, i32 3
   %120 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %119, align 8
   %121 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.IO.StreamWriter addrspace(1)* %121, null
-  br i1 %NullCheck34, label %122, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.IO.StreamWriter addrspace(1)* %121, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %122
 
 ; <label>:122                                     ; preds = %118
   %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
   %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
   %125 = load i32, i32* %loc1
   %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
-  %NullCheck36 = icmp ne i64 addrspace(1)* %126, null
-  br i1 %NullCheck36, label %127, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64 addrspace(1)* %126, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
   %128 = load i64, i64 addrspace(1)* %126
@@ -12616,15 +14325,15 @@ entry:
 
 ; <label>:140                                     ; preds = %136
   %141 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.IO.StreamWriter addrspace(1)* %141, null
-  br i1 %NullCheck38, label %142, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.IO.StreamWriter addrspace(1)* %141, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %142
 
 ; <label>:142                                     ; preds = %140
   %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
   %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
   %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
-  %NullCheck40 = icmp ne i64 addrspace(1)* %145, null
-  br i1 %NullCheck40, label %146, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i64 addrspace(1)* %145, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
   %147 = load i64, i64 addrspace(1)* %145
@@ -12645,83 +14354,83 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %25
+ThrowNullRef4:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %32
+ThrowNullRef6:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %37
+ThrowNullRef10:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %41
+ThrowNullRef12:                                   ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %58
+ThrowNullRef14:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %60
+ThrowNullRef16:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %65
+ThrowNullRef18:                                   ; preds = %65
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %80
+ThrowNullRef20:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %82
+ThrowNullRef22:                                   ; preds = %82
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %86
+ThrowNullRef24:                                   ; preds = %86
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %90
+ThrowNullRef26:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %94
+ThrowNullRef28:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %100
+ThrowNullRef30:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %116
+ThrowNullRef32:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %118
+ThrowNullRef34:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %122
+ThrowNullRef36:                                   ; preds = %122
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %140
+ThrowNullRef38:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %142
+ThrowNullRef40:                                   ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12788,8 +14497,8 @@ entry:
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %1 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
-  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
@@ -12797,8 +14506,8 @@ entry:
   %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
   %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
   %8 = load i64, i64 addrspace(1)* %6
@@ -12814,8 +14523,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %17, %System.IFormatProvider addrspace(1)* %16)
   %18 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %19 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %18, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.SyncTextWriter addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %7
   %21 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %18, i32 0, i32 4
@@ -12826,11 +14535,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12843,8 +14552,8 @@ entry:
   %this = alloca %System.IO.TextWriter addrspace(1)*
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.TextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
@@ -12854,8 +14563,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.Threading.Thread addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Threading.Thread addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %6)
@@ -12864,8 +14573,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1
   %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.TextWriter addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.TextWriter addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %11, i32 0, i32 2
@@ -12876,11 +14585,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13077,8 +14786,8 @@ entry:
   store double %param1, double* %arg1
   store i8 0, i8* %loc1
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
@@ -13088,16 +14797,16 @@ entry:
   %5 = addrspacecast i8* %loc1 to i8 addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %4, i8 addrspace(1)* %5)
   %6 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.SyncTextWriter addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
   %10 = load double, double* %arg1
   %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
   %13 = load i64, i64 addrspace(1)* %11
@@ -13132,11 +14841,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13153,8 +14862,8 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load double, double* %arg1
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -13168,8 +14877,8 @@ entry:
   call void %11(%System.IO.TextWriter addrspace(1)* %0, double %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
   %15 = load i64, i64 addrspace(1)* %13
@@ -13187,7 +14896,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13205,8 +14914,8 @@ entry:
   %1 = addrspacecast double* %arg1 to double addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -13221,8 +14930,8 @@ entry:
   %14 = bitcast double addrspace(1)* %1 to %System.Double addrspace(1)*
   %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Double addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Double addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
   %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
   %18 = load i64, i64 addrspace(1)* %16
@@ -13240,7 +14949,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13256,8 +14965,8 @@ entry:
   store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
   %0 = load %System.Double addrspace(1)*, %System.Double addrspace(1)** %this
   %1 = bitcast %System.Double addrspace(1)* %0 to double addrspace(1)*
-  %NullCheck = icmp ne double addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq double addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load double, double addrspace(1)* %1, align 8
@@ -13282,8 +14991,8 @@ entry:
   %loc0 = alloca %System.Globalization.NumberFormatInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 3
@@ -13293,8 +15002,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
@@ -13304,24 +15013,24 @@ entry:
   store %System.Globalization.NumberFormatInfo addrspace(1)* %10, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
   %11 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %7
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
   %15 = load i8, i8 addrspace(1)* %14, align 8
   %16 = zext i8 %15 to i32
   %17 = trunc i32 %16 to i8
-  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %11, null
-  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %11, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %13
   %19 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %11, i32 0, i32 29
   store i8 %17, i8 addrspace(1)* %19
   %20 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %21 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %20, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %20, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %18
   %23 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %20, i32 0, i32 3
@@ -13330,8 +15039,8 @@ entry:
 
 ; <label>:24                                      ; preds = %1, %22
   %25 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %25, null
-  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %25, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %26
 
 ; <label>:26                                      ; preds = %24
   %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %25, i32 0, i32 3
@@ -13342,23 +15051,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %18
+ThrowNullRef8:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13383,168 +15092,168 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 18
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %8, align 8
-  %NullCheck2 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %5, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %5, i32 0, i32 4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %9)
   %12 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 19
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %15, align 8
-  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %12, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %12, i32 0, i32 5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %16)
   %19 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %20 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %20, null
-  br i1 %NullCheck8, label %21, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %20, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %20, i32 0, i32 23
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  %NullCheck10 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %19, null
-  br i1 %NullCheck10, label %24, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %19, i32 0, i32 7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %25, %System.String addrspace(1)* %23)
   %26 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %27 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %27, i32 0, i32 22
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %29, align 8
-  %NullCheck14 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %26, null
-  br i1 %NullCheck14, label %31, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %26, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %26, i32 0, i32 6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %32, %System.String addrspace(1)* %30)
   %33 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %34 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Globalization.CultureData addrspace(1)* %34, null
-  br i1 %NullCheck16, label %35, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Globalization.CultureData addrspace(1)* %34, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %34, i32 0, i32 51
   %37 = load i32, i32 addrspace(1)* %36, align 8
-  %NullCheck18 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %33, null
-  br i1 %NullCheck18, label %38, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %33, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %33, i32 0, i32 21
   store i32 %37, i32 addrspace(1)* %39
   %40 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %41 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Globalization.CultureData addrspace(1)* %41, null
-  br i1 %NullCheck20, label %42, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Globalization.CultureData addrspace(1)* %41, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %41, i32 0, i32 52
   %44 = load i32, i32 addrspace(1)* %43, align 8
-  %NullCheck22 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %40, null
-  br i1 %NullCheck22, label %45, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %40, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %40, i32 0, i32 25
   store i32 %44, i32 addrspace(1)* %46
   %47 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %48 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.Globalization.CultureData addrspace(1)* %48, null
-  br i1 %NullCheck24, label %49, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Globalization.CultureData addrspace(1)* %48, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %49
 
 ; <label>:49                                      ; preds = %45
   %50 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %48, i32 0, i32 29
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck26 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %47, null
-  br i1 %NullCheck26, label %52, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %47, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %47, i32 0, i32 10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %53, %System.String addrspace(1)* %51)
   %54 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %55 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Globalization.CultureData addrspace(1)* %55, null
-  br i1 %NullCheck28, label %56, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Globalization.CultureData addrspace(1)* %55, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %56
 
 ; <label>:56                                      ; preds = %52
   %57 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %55, i32 0, i32 35
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %57, align 8
-  %NullCheck30 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %54, null
-  br i1 %NullCheck30, label %59, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %54, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %54, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %60, %System.String addrspace(1)* %58)
   %61 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %62 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck32 = icmp ne %System.Globalization.CultureData addrspace(1)* %62, null
-  br i1 %NullCheck32, label %63, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Globalization.CultureData addrspace(1)* %62, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %62, i32 0, i32 34
   %65 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %64, align 8
-  %NullCheck34 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %61, null
-  br i1 %NullCheck34, label %66, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %61, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %61, i32 0, i32 9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %67, %System.String addrspace(1)* %65)
   %68 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %69 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck36 = icmp ne %System.Globalization.CultureData addrspace(1)* %69, null
-  br i1 %NullCheck36, label %70, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Globalization.CultureData addrspace(1)* %69, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %70
 
 ; <label>:70                                      ; preds = %66
   %71 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %69, i32 0, i32 55
   %72 = load i32, i32 addrspace(1)* %71, align 8
-  %NullCheck38 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %68, null
-  br i1 %NullCheck38, label %73, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %68, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %68, i32 0, i32 22
   store i32 %72, i32 addrspace(1)* %74
   %75 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %76 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck40 = icmp ne %System.Globalization.CultureData addrspace(1)* %76, null
-  br i1 %NullCheck40, label %77, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Globalization.CultureData addrspace(1)* %76, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %76, i32 0, i32 57
   %79 = load i32, i32 addrspace(1)* %78, align 8
-  %NullCheck42 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %75, null
-  br i1 %NullCheck42, label %80, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %75, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %80
 
 ; <label>:80                                      ; preds = %77
   %81 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %75, i32 0, i32 24
   store i32 %79, i32 addrspace(1)* %81
   %82 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %83 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck44 = icmp ne %System.Globalization.CultureData addrspace(1)* %83, null
-  br i1 %NullCheck44, label %84, label %ThrowNullRef43
+  %NullCheck43 = icmp eq %System.Globalization.CultureData addrspace(1)* %83, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %84
 
 ; <label>:84                                      ; preds = %80
   %85 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %83, i32 0, i32 56
   %86 = load i32, i32 addrspace(1)* %85, align 8
-  %NullCheck46 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %82, null
-  br i1 %NullCheck46, label %87, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %82, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %82, i32 0, i32 23
@@ -13553,8 +15262,8 @@ entry:
 
 ; <label>:89                                      ; preds = %entry
   %90 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck100 = icmp ne %System.Globalization.CultureData addrspace(1)* %90, null
-  br i1 %NullCheck100, label %91, label %ThrowNullRef99
+  %NullCheck99 = icmp eq %System.Globalization.CultureData addrspace(1)* %90, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %91
 
 ; <label>:91                                      ; preds = %89
   %92 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %90, i32 0, i32 2
@@ -13572,8 +15281,8 @@ entry:
   %102 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %103 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %104 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %103)
-  %NullCheck48 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %102, null
-  br i1 %NullCheck48, label %105, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %102, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %105
 
 ; <label>:105                                     ; preds = %101
   %106 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %102, i32 0, i32 1
@@ -13581,8 +15290,8 @@ entry:
   %107 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %108 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %109 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %108)
-  %NullCheck50 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %107, null
-  br i1 %NullCheck50, label %110, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %107, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %110
 
 ; <label>:110                                     ; preds = %105
   %111 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %107, i32 0, i32 2
@@ -13590,8 +15299,8 @@ entry:
   %112 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %113 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %114 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %113)
-  %NullCheck52 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %112, null
-  br i1 %NullCheck52, label %115, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %112, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %115
 
 ; <label>:115                                     ; preds = %110
   %116 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %112, i32 0, i32 27
@@ -13599,8 +15308,8 @@ entry:
   %117 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %118 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %119 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %118)
-  %NullCheck54 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %117, null
-  br i1 %NullCheck54, label %120, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %117, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %120
 
 ; <label>:120                                     ; preds = %115
   %121 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %117, i32 0, i32 26
@@ -13608,8 +15317,8 @@ entry:
   %122 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %123 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %124 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %123)
-  %NullCheck56 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %122, null
-  br i1 %NullCheck56, label %125, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %122, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %125
 
 ; <label>:125                                     ; preds = %120
   %126 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %122, i32 0, i32 17
@@ -13617,8 +15326,8 @@ entry:
   %127 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %128 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %129 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %128)
-  %NullCheck58 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %127, null
-  br i1 %NullCheck58, label %130, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %127, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %130
 
 ; <label>:130                                     ; preds = %125
   %131 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %127, i32 0, i32 18
@@ -13626,8 +15335,8 @@ entry:
   %132 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %133 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %134 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %133)
-  %NullCheck60 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %132, null
-  br i1 %NullCheck60, label %135, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %132, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %135
 
 ; <label>:135                                     ; preds = %130
   %136 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %132, i32 0, i32 14
@@ -13635,8 +15344,8 @@ entry:
   %137 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %138 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %139 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %138)
-  %NullCheck62 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %137, null
-  br i1 %NullCheck62, label %140, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %137, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %140
 
 ; <label>:140                                     ; preds = %135
   %141 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %137, i32 0, i32 13
@@ -13644,71 +15353,71 @@ entry:
   %142 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %143 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %144 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %143)
-  %NullCheck64 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %142, null
-  br i1 %NullCheck64, label %145, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %142, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %145
 
 ; <label>:145                                     ; preds = %140
   %146 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %142, i32 0, i32 12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %146, %System.String addrspace(1)* %144)
   %147 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %148 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck66 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %148, null
-  br i1 %NullCheck66, label %149, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %148, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %149
 
 ; <label>:149                                     ; preds = %145
   %150 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %148, i32 0, i32 21
   %151 = load i32, i32 addrspace(1)* %150, align 8
-  %NullCheck68 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %147, null
-  br i1 %NullCheck68, label %152, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %147, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %152
 
 ; <label>:152                                     ; preds = %149
   %153 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %147, i32 0, i32 28
   store i32 %151, i32 addrspace(1)* %153
   %154 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %155 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck70 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %155, null
-  br i1 %NullCheck70, label %156, label %ThrowNullRef69
+  %NullCheck69 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %155, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %156
 
 ; <label>:156                                     ; preds = %152
   %157 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %155, i32 0, i32 6
   %158 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %157, align 8
-  %NullCheck72 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %154, null
-  br i1 %NullCheck72, label %159, label %ThrowNullRef71
+  %NullCheck71 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %154, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %159
 
 ; <label>:159                                     ; preds = %156
   %160 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %154, i32 0, i32 15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %160, %System.String addrspace(1)* %158)
   %161 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %162 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck74 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %162, null
-  br i1 %NullCheck74, label %163, label %ThrowNullRef73
+  %NullCheck73 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %162, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %163
 
 ; <label>:163                                     ; preds = %159
   %164 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %162, i32 0, i32 1
   %165 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %164, align 8
-  %NullCheck76 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %161, null
-  br i1 %NullCheck76, label %166, label %ThrowNullRef75
+  %NullCheck75 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %161, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %166
 
 ; <label>:166                                     ; preds = %163
   %167 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %161, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %167, %"System.Int32[]" addrspace(1)* %165)
   %168 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %169 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck78 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %169, null
-  br i1 %NullCheck78, label %170, label %ThrowNullRef77
+  %NullCheck77 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %169, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %170
 
 ; <label>:170                                     ; preds = %166
   %171 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %169, i32 0, i32 7
   %172 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %171, align 8
-  %NullCheck80 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %168, null
-  br i1 %NullCheck80, label %173, label %ThrowNullRef79
+  %NullCheck79 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %168, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %173
 
 ; <label>:173                                     ; preds = %170
   %174 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %168, i32 0, i32 16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %174, %System.String addrspace(1)* %172)
   %175 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck82 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %175, null
-  br i1 %NullCheck82, label %176, label %ThrowNullRef81
+  %NullCheck81 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %175, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %176
 
 ; <label>:176                                     ; preds = %173
   %177 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %175, i32 0, i32 4
@@ -13718,14 +15427,14 @@ entry:
 
 ; <label>:180                                     ; preds = %176
   %181 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck84 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %181, null
-  br i1 %NullCheck84, label %182, label %ThrowNullRef83
+  %NullCheck83 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %181, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %182
 
 ; <label>:182                                     ; preds = %180
   %183 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %181, i32 0, i32 4
   %184 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %183, align 8
-  %NullCheck86 = icmp ne %System.String addrspace(1)* %184, null
-  br i1 %NullCheck86, label %185, label %ThrowNullRef85
+  %NullCheck85 = icmp eq %System.String addrspace(1)* %184, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %185
 
 ; <label>:185                                     ; preds = %182
   %186 = getelementptr inbounds %System.String, %System.String addrspace(1)* %184, i32 0, i32 1
@@ -13736,8 +15445,8 @@ entry:
 ; <label>:189                                     ; preds = %176, %185
   %190 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck98 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %190, null
-  br i1 %NullCheck98, label %192, label %ThrowNullRef97
+  %NullCheck97 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %190, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %192
 
 ; <label>:192                                     ; preds = %189
   %193 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %190, i32 0, i32 4
@@ -13746,8 +15455,8 @@ entry:
 
 ; <label>:194                                     ; preds = %185, %192
   %195 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck88 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %195, null
-  br i1 %NullCheck88, label %196, label %ThrowNullRef87
+  %NullCheck87 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %195, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %196
 
 ; <label>:196                                     ; preds = %194
   %197 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %195, i32 0, i32 9
@@ -13757,14 +15466,14 @@ entry:
 
 ; <label>:200                                     ; preds = %196
   %201 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck90 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %201, null
-  br i1 %NullCheck90, label %202, label %ThrowNullRef89
+  %NullCheck89 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %201, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %202
 
 ; <label>:202                                     ; preds = %200
   %203 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %201, i32 0, i32 9
   %204 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %203, align 8
-  %NullCheck92 = icmp ne %System.String addrspace(1)* %204, null
-  br i1 %NullCheck92, label %205, label %ThrowNullRef91
+  %NullCheck91 = icmp eq %System.String addrspace(1)* %204, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %205
 
 ; <label>:205                                     ; preds = %202
   %206 = getelementptr inbounds %System.String, %System.String addrspace(1)* %204, i32 0, i32 1
@@ -13775,14 +15484,14 @@ entry:
 ; <label>:209                                     ; preds = %196, %205
   %210 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %211 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck94 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %211, null
-  br i1 %NullCheck94, label %212, label %ThrowNullRef93
+  %NullCheck93 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %211, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %212
 
 ; <label>:212                                     ; preds = %209
   %213 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %211, i32 0, i32 6
   %214 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %213, align 8
-  %NullCheck96 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %210, null
-  br i1 %NullCheck96, label %215, label %ThrowNullRef95
+  %NullCheck95 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %210, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %215
 
 ; <label>:215                                     ; preds = %212
   %216 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %210, i32 0, i32 9
@@ -13796,203 +15505,203 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %17
+ThrowNullRef8:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %21
+ThrowNullRef10:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %24
+ThrowNullRef12:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %28
+ThrowNullRef14:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %31
+ThrowNullRef16:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %35
+ThrowNullRef18:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %38
+ThrowNullRef20:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %42
+ThrowNullRef22:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %45
+ThrowNullRef24:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %49
+ThrowNullRef26:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %52
+ThrowNullRef28:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %56
+ThrowNullRef30:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %59
+ThrowNullRef32:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %63
+ThrowNullRef34:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %66
+ThrowNullRef36:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %70
+ThrowNullRef38:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %73
+ThrowNullRef40:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %77
+ThrowNullRef42:                                   ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %80
+ThrowNullRef44:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %84
+ThrowNullRef46:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %101
+ThrowNullRef48:                                   ; preds = %101
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %105
+ThrowNullRef50:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %110
+ThrowNullRef52:                                   ; preds = %110
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %115
+ThrowNullRef54:                                   ; preds = %115
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %120
+ThrowNullRef56:                                   ; preds = %120
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %125
+ThrowNullRef58:                                   ; preds = %125
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %130
+ThrowNullRef60:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %135
+ThrowNullRef62:                                   ; preds = %135
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %140
+ThrowNullRef64:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %145
+ThrowNullRef66:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %149
+ThrowNullRef68:                                   ; preds = %149
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %152
+ThrowNullRef70:                                   ; preds = %152
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %156
+ThrowNullRef72:                                   ; preds = %156
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %159
+ThrowNullRef74:                                   ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %163
+ThrowNullRef76:                                   ; preds = %163
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %166
+ThrowNullRef78:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %170
+ThrowNullRef80:                                   ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %173
+ThrowNullRef82:                                   ; preds = %173
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %180
+ThrowNullRef84:                                   ; preds = %180
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %182
+ThrowNullRef86:                                   ; preds = %182
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %194
+ThrowNullRef88:                                   ; preds = %194
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %200
+ThrowNullRef90:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %202
+ThrowNullRef92:                                   ; preds = %202
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %209
+ThrowNullRef94:                                   ; preds = %209
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %212
+ThrowNullRef96:                                   ; preds = %212
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %189
+ThrowNullRef98:                                   ; preds = %189
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %89
+ThrowNullRef100:                                  ; preds = %89
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14020,8 +15729,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 21
@@ -14034,8 +15743,8 @@ entry:
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 16)
   %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 21
@@ -14044,8 +15753,8 @@ entry:
 
 ; <label>:12                                      ; preds = %1, %10
   %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 21
@@ -14056,11 +15765,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %12
+ThrowNullRef4:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14076,8 +15785,8 @@ entry:
   store i32 %param1, i32* %arg1
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %1 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
@@ -14144,8 +15853,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 33
@@ -14158,8 +15867,8 @@ entry:
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 24)
   %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 33
@@ -14168,8 +15877,8 @@ entry:
 
 ; <label>:12                                      ; preds = %1, %10
   %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 33
@@ -14180,11 +15889,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %12
+ThrowNullRef4:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14197,8 +15906,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 53
@@ -14210,8 +15919,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 116)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 53
@@ -14220,8 +15929,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 53
@@ -14232,11 +15941,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14265,8 +15974,8 @@ entry:
 
 ; <label>:7                                       ; preds = %entry, %4
   %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %7
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 2
@@ -14290,8 +15999,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 54
@@ -14303,8 +16012,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 117)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
@@ -14313,8 +16022,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 54
@@ -14325,11 +16034,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14342,8 +16051,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 27
@@ -14355,8 +16064,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 118)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 27
@@ -14365,8 +16074,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 27
@@ -14377,11 +16086,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14394,8 +16103,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 28
@@ -14407,8 +16116,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 119)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 28
@@ -14417,8 +16126,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 28
@@ -14429,11 +16138,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14446,8 +16155,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 26
@@ -14459,8 +16168,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 107)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 26
@@ -14469,8 +16178,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 26
@@ -14481,11 +16190,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14498,8 +16207,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 25
@@ -14511,8 +16220,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 106)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 25
@@ -14521,8 +16230,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 25
@@ -14533,11 +16242,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14550,8 +16259,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 24
@@ -14563,8 +16272,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 105)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 24
@@ -14573,8 +16282,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 24
@@ -14585,11 +16294,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14614,8 +16323,8 @@ entry:
   %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %3)
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %2
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -14626,15 +16335,15 @@ entry:
 
 ; <label>:8                                       ; preds = %62
   %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 9
   %12 = load i32, i32 addrspace(1)* %11, align 8
   %13 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.IO.StreamWriter addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %13, i32 0, i32 10
@@ -14649,15 +16358,15 @@ entry:
 
 ; <label>:20                                      ; preds = %14, %18
   %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
   %24 = load i32, i32 addrspace(1)* %23, align 8
   %25 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %25, null
-  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.StreamWriter addrspace(1)* %25, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %25, i32 0, i32 9
@@ -14678,36 +16387,36 @@ entry:
   %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %37 = load i32, i32* %loc1
   %38 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.StreamWriter addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %35
   %40 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %38, i32 0, i32 7
   %41 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %40, align 8
   %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
-  br i1 %NullCheck14, label %43, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %39
   %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 9
   %45 = load i32, i32 addrspace(1)* %44, align 8
   %46 = load i32, i32* %loc2
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %36, null
-  br i1 %NullCheck16, label %47, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %36, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %47
 
 ; <label>:47                                      ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %36, i32 %37, %"System.Char[]" addrspace(1)* %41, i32 %45, i32 %46)
   %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
   %51 = load i32, i32 addrspace(1)* %50, align 8
   %52 = load i32, i32* %loc2
   %53 = add i32 %51, %52
-  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
-  br i1 %NullCheck20, label %54, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %54
 
 ; <label>:54                                      ; preds = %49
   %55 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
@@ -14729,8 +16438,8 @@ entry:
 
 ; <label>:65                                      ; preds = %62
   %66 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %66, null
-  br i1 %NullCheck2, label %67, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %66, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %67
 
 ; <label>:67                                      ; preds = %65
   %68 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %66, i32 0, i32 11
@@ -14751,49 +16460,259 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %65
+ThrowNullRef2:                                    ; preds = %65
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %20
+ThrowNullRef8:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %22
+ThrowNullRef10:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %35
+ThrowNullRef12:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %43
+ThrowNullRef16:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %47
+ThrowNullRef18:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method String::CopyTo using LLILCJit
-Failed to read String.CopyTo[loadElemA]
+Successfully read String.CopyTo
+
+define void @String.CopyTo(%System.String addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  %loc1 = alloca i16 addrspace(1)*
+  %loc2 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %1 = icmp ne %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg4
+  %7 = icmp sge i32 %6, 0
+  br i1 %7, label %13, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  unreachable
+
+; <label>:13                                      ; preds = %5
+  %14 = load i32, i32* %arg1
+  %15 = icmp sge i32 %14, 0
+  br i1 %15, label %21, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %18)
+  %20 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %20, %System.String addrspace(1)* %17, %System.String addrspace(1)* %19)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %20) #0
+  unreachable
+
+; <label>:21                                      ; preds = %13
+  %22 = load i32, i32* %arg4
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck, label %ThrowNullRef, label %24
+
+; <label>:24                                      ; preds = %21
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load i32, i32* %arg1
+  %28 = sub i32 %26, %27
+  %29 = icmp sle i32 %22, %28
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34, %System.String addrspace(1)* %31, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %24
+  %36 = load i32, i32* %arg3
+  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %37, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
+
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
+  %40 = load i32, i32 addrspace(1)* %39
+  %41 = zext i32 %40 to i64
+  %42 = trunc i64 %41 to i32
+  %43 = load i32, i32* %arg4
+  %44 = sub i32 %42, %43
+  %45 = icmp sgt i32 %36, %44
+  br i1 %45, label %49, label %46
+
+; <label>:46                                      ; preds = %38
+  %47 = load i32, i32* %arg3
+  %48 = icmp sge i32 %47, 0
+  br i1 %48, label %54, label %49
+
+; <label>:49                                      ; preds = %38, %46
+  %50 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %52 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %51)
+  %53 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53, %System.String addrspace(1)* %50, %System.String addrspace(1)* %52)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53) #0
+  unreachable
+
+; <label>:54                                      ; preds = %46
+  %55 = load i32, i32* %arg4
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %97, label %57
+
+; <label>:57                                      ; preds = %54
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %59
+
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 2
+  %61 = bitcast [0 x i16] addrspace(1)* %60 to i16 addrspace(1)*
+  store i16 addrspace(1)* %61, i16 addrspace(1)** %loc0
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  store %"System.Char[]" addrspace(1)* %62, %"System.Char[]" addrspace(1)** %loc2
+  %63 = icmp eq %"System.Char[]" addrspace(1)* %62, null
+  br i1 %63, label %72, label %64
+
+; <label>:64                                      ; preds = %59
+  %65 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc2
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %65, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %66
+
+; <label>:66                                      ; preds = %64
+  %67 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %65, i32 0, i32 1
+  %68 = load i32, i32 addrspace(1)* %67
+  %69 = zext i32 %68 to i64
+  %70 = trunc i64 %69 to i32
+  %71 = icmp ne i32 %70, 0
+  br i1 %71, label %73, label %72
+
+; <label>:72                                      ; preds = %59, %66
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  br label %81
+
+; <label>:73                                      ; preds = %66
+  %74 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc2
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %74, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %75
+
+; <label>:75                                      ; preds = %73
+  %76 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %74, i32 0, i32 1
+  %77 = load i32, i32 addrspace(1)* %76
+  %78 = zext i32 %77 to i64
+  %BoundsCheck = icmp uge i64 0, %78
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %79
+
+; <label>:79                                      ; preds = %75
+  %80 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %74, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %80, i16 addrspace(1)** %loc1
+  br label %81
+
+; <label>:81                                      ; preds = %72, %79
+  %82 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %83 = ptrtoint i16 addrspace(1)* %82 to i64
+  %84 = load i32, i32* %arg3
+  %85 = sext i32 %84 to i64
+  %86 = mul i64 %85, 2
+  %87 = add i64 %83, %86
+  %88 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %89 = ptrtoint i16 addrspace(1)* %88 to i64
+  %90 = load i32, i32* %arg1
+  %91 = sext i32 %90 to i64
+  %92 = mul i64 %91, 2
+  %93 = add i64 %89, %92
+  %94 = load i32, i32* %arg4
+  %95 = inttoptr i64 %87 to i16*
+  %96 = inttoptr i64 %93 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %95, i16* %96, i32 %94)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  br label %97
+
+; <label>:97                                      ; preds = %54, %81
+  ret void
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
 Successfully read ConsoleEncoding.GetPreamble
 
@@ -14830,7 +16749,365 @@ entry:
 }
 
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[loadElemA]
+Successfully read EncoderNLS.GetBytes
+
+define i32 @EncoderNLS.GetBytes(%System.Text.EncoderNLS addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3, %"System.Byte[]" addrspace(1)* %param4, i32 %param5, i8 %param6) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %arg4 = alloca %"System.Byte[]" addrspace(1)*
+  %arg5 = alloca i32
+  %arg6 = alloca i8
+  %loc0 = alloca i32
+  %loc1 = alloca i16 addrspace(1)*
+  %loc2 = alloca i8 addrspace(1)*
+  %loc3 = alloca i32
+  %loc4 = alloca %"System.Char[]" addrspace(1)*
+  %loc5 = alloca %"System.Byte[]" addrspace(1)*
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  store %"System.Byte[]" addrspace(1)* %param4, %"System.Byte[]" addrspace(1)** %arg4
+  store i32 %param5, i32* %arg5
+  store i8 %param6, i8* %arg6
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %1 = icmp eq %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %17, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %7 = icmp eq %"System.Char[]" addrspace(1)* %6, null
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %12
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %12
+
+; <label>:12                                      ; preds = %8, %10
+  %13 = phi %System.String addrspace(1)* [ %9, %8 ], [ %11, %10 ]
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %14)
+  %16 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16, %System.String addrspace(1)* %13, %System.String addrspace(1)* %15)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16) #0
+  unreachable
+
+; <label>:17                                      ; preds = %2
+  %18 = load i32, i32* %arg2
+  %19 = icmp slt i32 %18, 0
+  br i1 %19, label %23, label %20
+
+; <label>:20                                      ; preds = %17
+  %21 = load i32, i32* %arg3
+  %22 = icmp sge i32 %21, 0
+  br i1 %22, label %35, label %23
+
+; <label>:23                                      ; preds = %17, %20
+  %24 = load i32, i32* %arg2
+  %25 = icmp slt i32 %24, 0
+  br i1 %25, label %28, label %26
+
+; <label>:26                                      ; preds = %23
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %30
+
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %30
+
+; <label>:30                                      ; preds = %26, %28
+  %31 = phi %System.String addrspace(1)* [ %27, %26 ], [ %29, %28 ]
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34, %System.String addrspace(1)* %31, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %20
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck, label %ThrowNullRef, label %37
+
+; <label>:37                                      ; preds = %35
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = load i32, i32* %arg2
+  %43 = sub i32 %41, %42
+  %44 = load i32, i32* %arg3
+  %45 = icmp sge i32 %43, %44
+  br i1 %45, label %51, label %46
+
+; <label>:46                                      ; preds = %37
+  %47 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %48 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %49 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %48)
+  %50 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %50, %System.String addrspace(1)* %47, %System.String addrspace(1)* %49)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %50) #0
+  unreachable
+
+; <label>:51                                      ; preds = %37
+  %52 = load i32, i32* %arg5
+  %53 = icmp slt i32 %52, 0
+  br i1 %53, label %63, label %54
+
+; <label>:54                                      ; preds = %51
+  %55 = load i32, i32* %arg5
+  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck1 = icmp eq %"System.Byte[]" addrspace(1)* %56, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %57
+
+; <label>:57                                      ; preds = %54
+  %58 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = zext i32 %59 to i64
+  %61 = trunc i64 %60 to i32
+  %62 = icmp sle i32 %55, %61
+  br i1 %62, label %68, label %63
+
+; <label>:63                                      ; preds = %51, %57
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %66 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %65)
+  %67 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %67, %System.String addrspace(1)* %64, %System.String addrspace(1)* %66)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %67) #0
+  unreachable
+
+; <label>:68                                      ; preds = %57
+  %69 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %69, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %69, i32 0, i32 1
+  %72 = load i32, i32 addrspace(1)* %71
+  %73 = zext i32 %72 to i64
+  %74 = trunc i64 %73 to i32
+  %75 = icmp ne i32 %74, 0
+  br i1 %75, label %78, label %76
+
+; <label>:76                                      ; preds = %70
+  %77 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1)
+  store %"System.Char[]" addrspace(1)* %77, %"System.Char[]" addrspace(1)** %arg1
+  br label %78
+
+; <label>:78                                      ; preds = %70, %76
+  %79 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck5 = icmp eq %"System.Byte[]" addrspace(1)* %79, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %80
+
+; <label>:80                                      ; preds = %78
+  %81 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %79, i32 0, i32 1
+  %82 = load i32, i32 addrspace(1)* %81
+  %83 = zext i32 %82 to i64
+  %84 = trunc i64 %83 to i32
+  %85 = load i32, i32* %arg5
+  %86 = sub i32 %84, %85
+  store i32 %86, i32* %loc0
+  %87 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck7 = icmp eq %"System.Byte[]" addrspace(1)* %87, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %88
+
+; <label>:88                                      ; preds = %80
+  %89 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %87, i32 0, i32 1
+  %90 = load i32, i32 addrspace(1)* %89
+  %91 = zext i32 %90 to i64
+  %92 = trunc i64 %91 to i32
+  %93 = icmp ne i32 %92, 0
+  br i1 %93, label %96, label %94
+
+; <label>:94                                      ; preds = %88
+  %95 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1)
+  store %"System.Byte[]" addrspace(1)* %95, %"System.Byte[]" addrspace(1)** %arg4
+  br label %96
+
+; <label>:96                                      ; preds = %88, %94
+  %97 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  store %"System.Char[]" addrspace(1)* %97, %"System.Char[]" addrspace(1)** %loc4
+  %98 = icmp eq %"System.Char[]" addrspace(1)* %97, null
+  br i1 %98, label %107, label %99
+
+; <label>:99                                      ; preds = %96
+  %100 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc4
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %100, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %101
+
+; <label>:101                                     ; preds = %99
+  %102 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %100, i32 0, i32 1
+  %103 = load i32, i32 addrspace(1)* %102
+  %104 = zext i32 %103 to i64
+  %105 = trunc i64 %104 to i32
+  %106 = icmp ne i32 %105, 0
+  br i1 %106, label %108, label %107
+
+; <label>:107                                     ; preds = %96, %101
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  br label %116
+
+; <label>:108                                     ; preds = %101
+  %109 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc4
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %109, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %110
+
+; <label>:110                                     ; preds = %108
+  %111 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %109, i32 0, i32 1
+  %112 = load i32, i32 addrspace(1)* %111
+  %113 = zext i32 %112 to i64
+  %BoundsCheck = icmp uge i64 0, %113
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %114
+
+; <label>:114                                     ; preds = %110
+  %115 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %109, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %115, i16 addrspace(1)** %loc1
+  br label %116
+
+; <label>:116                                     ; preds = %107, %114
+  %117 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  store %"System.Byte[]" addrspace(1)* %117, %"System.Byte[]" addrspace(1)** %loc5
+  %118 = icmp eq %"System.Byte[]" addrspace(1)* %117, null
+  br i1 %118, label %127, label %119
+
+; <label>:119                                     ; preds = %116
+  %120 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc5
+  %NullCheck13 = icmp eq %"System.Byte[]" addrspace(1)* %120, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %121
+
+; <label>:121                                     ; preds = %119
+  %122 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %120, i32 0, i32 1
+  %123 = load i32, i32 addrspace(1)* %122
+  %124 = zext i32 %123 to i64
+  %125 = trunc i64 %124 to i32
+  %126 = icmp ne i32 %125, 0
+  br i1 %126, label %128, label %127
+
+; <label>:127                                     ; preds = %116, %121
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc2
+  br label %136
+
+; <label>:128                                     ; preds = %121
+  %129 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc5
+  %NullCheck15 = icmp eq %"System.Byte[]" addrspace(1)* %129, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %130
+
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %129, i32 0, i32 1
+  %132 = load i32, i32 addrspace(1)* %131
+  %133 = zext i32 %132 to i64
+  %BoundsCheck17 = icmp uge i64 0, %133
+  br i1 %BoundsCheck17, label %ThrowIndexOutOfRange18, label %134
+
+; <label>:134                                     ; preds = %130
+  %135 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %129, i32 0, i32 3, i32 0
+  store i8 addrspace(1)* %135, i8 addrspace(1)** %loc2
+  br label %136
+
+; <label>:136                                     ; preds = %127, %134
+  %137 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %138 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %139 = ptrtoint i16 addrspace(1)* %138 to i64
+  %140 = load i32, i32* %arg2
+  %141 = sext i32 %140 to i64
+  %142 = mul i64 %141, 2
+  %143 = add i64 %139, %142
+  %144 = load i32, i32* %arg3
+  %145 = load i8 addrspace(1)*, i8 addrspace(1)** %loc2
+  %146 = ptrtoint i8 addrspace(1)* %145 to i64
+  %147 = load i32, i32* %arg5
+  %148 = sext i32 %147 to i64
+  %149 = add i64 %146, %148
+  %150 = load i32, i32* %loc0
+  %151 = load i8, i8* %arg6
+  %152 = zext i8 %151 to i32
+  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i64 addrspace(1)*
+  %NullCheck19 = icmp eq i64 addrspace(1)* %153, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %154
+
+; <label>:154                                     ; preds = %136
+  %155 = load i64, i64 addrspace(1)* %153
+  %156 = add i64 %155, 72
+  %157 = inttoptr i64 %156 to i64*
+  %158 = load i64, i64* %157
+  %159 = add i64 %158, 0
+  %160 = inttoptr i64 %159 to i64*
+  %161 = load i64, i64* %160
+  %162 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to %System.Text.Encoder addrspace(1)*
+  %163 = inttoptr i64 %143 to i16*
+  %164 = inttoptr i64 %149 to i8*
+  %165 = trunc i32 %152 to i8
+  %166 = inttoptr i64 %161 to i32 (%System.Text.Encoder addrspace(1)*, i16*, i32, i8*, i32, i8)*
+  %167 = call i32 %166(%System.Text.Encoder addrspace(1)* %162, i16* %163, i32 %144, i8* %164, i32 %150, i8 %165)
+  store i32 %167, i32* %loc3
+  br label %168
+
+; <label>:168                                     ; preds = %154
+  %169 = load i32, i32* %loc3
+  ret i32 %169
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %110
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %119
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange18:                           ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
 Successfully read EncoderNLS.GetBytes
 
@@ -14919,22 +17196,22 @@ entry:
   %40 = load i8, i8* %arg5
   %41 = zext i8 %40 to i32
   %42 = trunc i32 %41 to i8
-  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %39, null
-  br i1 %NullCheck, label %43, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderNLS addrspace(1)* %39, null
+  br i1 %NullCheck, label %ThrowNullRef, label %43
 
 ; <label>:43                                      ; preds = %38
   %44 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
   store i8 %42, i8 addrspace(1)* %44
   %45 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %45, null
-  br i1 %NullCheck2, label %46, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.EncoderNLS addrspace(1)* %45, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %46
 
 ; <label>:46                                      ; preds = %43
   %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %45, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %47
   %48 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.EncoderNLS addrspace(1)* %48, null
-  br i1 %NullCheck4, label %49, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.EncoderNLS addrspace(1)* %48, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %49
 
 ; <label>:49                                      ; preds = %46
   %50 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %48, i32 0, i32 3
@@ -14945,8 +17222,8 @@ entry:
   %55 = load i32, i32* %arg4
   %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck6, label %58, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
   %59 = load i64, i64 addrspace(1)* %57
@@ -14964,15 +17241,15 @@ ThrowNullRef:                                     ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %43
+ThrowNullRef2:                                    ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %46
+ThrowNullRef4:                                    ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %49
+ThrowNullRef6:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -15000,8 +17277,8 @@ entry:
   %4 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0 to %System.IO.ConsoleStream addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*)(%System.IO.ConsoleStream addrspace(1)* %4, %"System.Byte[]" addrspace(1)* %1, i32 %2, i32 %3)
   %5 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
@@ -15086,8 +17363,8 @@ entry:
 
 ; <label>:22                                      ; preds = %8
   %23 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %23, null
-  br i1 %NullCheck, label %24, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Byte[]" addrspace(1)* %23, null
+  br i1 %NullCheck, label %ThrowNullRef, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
@@ -15109,8 +17386,8 @@ entry:
 
 ; <label>:36                                      ; preds = %24
   %37 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %37, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.ConsoleStream addrspace(1)* %37, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %37, i32 0, i32 4
@@ -15131,13 +17408,138 @@ ThrowNullRef:                                     ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %36
+ThrowNullRef2:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
-Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
+Successfully read WindowsConsoleStream.WriteFileNative
+
+define i32 @WindowsConsoleStream.WriteFileNative(i64 %param0, %"System.Byte[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i64
+  %arg1 = alloca %"System.Byte[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i8 addrspace(1)*
+  %loc2 = alloca %"System.Byte[]" addrspace(1)*
+  %loc3 = alloca i32
+  store i64 %param0, i64* %arg0
+  store %"System.Byte[]" addrspace(1)* %param1, %"System.Byte[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Byte[]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = zext i32 %3 to i64
+  %5 = icmp ne i64 %4, 0
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %1
+  ret i32 0
+
+; <label>:7                                       ; preds = %1
+  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  store %"System.Byte[]" addrspace(1)* %8, %"System.Byte[]" addrspace(1)** %loc2
+  %9 = icmp eq %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %9, label %18, label %10
+
+; <label>:10                                      ; preds = %7
+  %11 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc2
+  %NullCheck1 = icmp eq %"System.Byte[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %11, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp ne i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %7, %12
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc1
+  br label %27
+
+; <label>:19                                      ; preds = %12
+  %20 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc2
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %20, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %BoundsCheck = icmp uge i64 0, %24
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %25
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %20, i32 0, i32 3, i32 0
+  store i8 addrspace(1)* %26, i8 addrspace(1)** %loc1
+  br label %27
+
+; <label>:27                                      ; preds = %18, %25
+  %28 = load i64, i64* %arg0
+  %29 = load i8 addrspace(1)*, i8 addrspace(1)** %loc1
+  %30 = ptrtoint i8 addrspace(1)* %29 to i64
+  %31 = load i32, i32* %arg2
+  %32 = sext i32 %31 to i64
+  %33 = add i64 %30, %32
+  %34 = load i32, i32* %arg3
+  %35 = addrspacecast i32* %loc3 to i32 addrspace(1)*
+  %36 = inttoptr i64 %33 to i8*
+  %37 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i8*, i32, i32 addrspace(1)*, i64)*)(i64 %28, i8* %36, i32 %34, i32 addrspace(1)* %35, i64 0)
+  %38 = icmp ugt i32 %37, 0
+  %39 = sext i1 %38 to i32
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc1
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %42, label %41
+
+; <label>:41                                      ; preds = %27
+  ret i32 0
+
+; <label>:42                                      ; preds = %27
+  %43 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  store i32 %43, i32* %loc0
+  %44 = load i32, i32* %loc0
+  %45 = icmp eq i32 %44, 232
+  br i1 %45, label %49, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = load i32, i32* %loc0
+  %48 = icmp ne i32 %47, 109
+  br i1 %48, label %50, label %49
+
+; <label>:49                                      ; preds = %42, %46
+  ret i32 0
+
+; <label>:50                                      ; preds = %46
+  %51 = load i32, i32* %loc0
+  ret i32 %51
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
 Successfully read WindowsConsoleStream.Flush
 
@@ -15146,8 +17548,8 @@ entry:
   %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
   store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
@@ -15182,8 +17584,8 @@ entry:
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
   %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load i64, i64 addrspace(1)* %1
@@ -15222,15 +17624,15 @@ entry:
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.TextWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
   %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %3, align 8
   %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
   %7 = load i64, i64 addrspace(1)* %5
@@ -15248,7 +17650,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -15277,8 +17679,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %4)
   store i32 0, i32* %loc0
   %5 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Char[]" addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
@@ -15290,15 +17692,15 @@ entry:
 
 ; <label>:11                                      ; preds = %69
   %12 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %12, i32 0, i32 9
   %15 = load i32, i32 addrspace(1)* %14, align 8
   %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.IO.StreamWriter addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %16, i32 0, i32 10
@@ -15313,15 +17715,15 @@ entry:
 
 ; <label>:23                                      ; preds = %17, %21
   %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %24, null
-  br i1 %NullCheck8, label %25, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %24, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 10
   %27 = load i32, i32 addrspace(1)* %26, align 8
   %28 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %28, null
-  br i1 %NullCheck10, label %29, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.StreamWriter addrspace(1)* %28, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %28, i32 0, i32 9
@@ -15343,15 +17745,15 @@ entry:
   %40 = load i32, i32* %loc0
   %41 = mul i32 %40, 2
   %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
-  br i1 %NullCheck12, label %43, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %43
 
 ; <label>:43                                      ; preds = %38
   %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 7
   %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %44, align 8
   %46 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %46, null
-  br i1 %NullCheck14, label %47, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.IO.StreamWriter addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %47
 
 ; <label>:47                                      ; preds = %43
   %48 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %46, i32 0, i32 9
@@ -15363,16 +17765,16 @@ entry:
   %54 = bitcast %"System.Char[]" addrspace(1)* %45 to %System.Array addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %53, i32 %41, %System.Array addrspace(1)* %54, i32 %50, i32 %52)
   %55 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
-  br i1 %NullCheck16, label %56, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %56
 
 ; <label>:56                                      ; preds = %47
   %57 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
   %58 = load i32, i32 addrspace(1)* %57, align 8
   %59 = load i32, i32* %loc2
   %60 = add i32 %58, %59
-  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
-  br i1 %NullCheck18, label %61, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %61
 
 ; <label>:61                                      ; preds = %56
   %62 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
@@ -15394,8 +17796,8 @@ entry:
 
 ; <label>:72                                      ; preds = %69
   %73 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %73, null
-  br i1 %NullCheck2, label %74, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %73, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %74
 
 ; <label>:74                                      ; preds = %72
   %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %73, i32 0, i32 11
@@ -15416,39 +17818,39 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %72
+ThrowNullRef2:                                    ; preds = %72
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %23
+ThrowNullRef8:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef10:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %43
+ThrowNullRef14:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %47
+ThrowNullRef16:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %56
+ThrowNullRef18:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblDivConst.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblDivConst.error.txt
@@ -25,8 +25,8 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
@@ -40,8 +40,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
   %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
@@ -75,7 +75,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -90,8 +90,8 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %NullCheck = icmp ne i8 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = load i8, i8 addrspace(1)* %0, align 8
@@ -125,8 +125,8 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
@@ -159,8 +159,8 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -184,8 +184,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
   store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
@@ -195,8 +195,8 @@ entry:
 ; <label>:4                                       ; preds = %1
   %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
   %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
@@ -206,8 +206,8 @@ entry:
   %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
@@ -221,14 +221,14 @@ entry:
 
 ; <label>:17                                      ; preds = %14
   %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
   %21 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
@@ -238,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -249,8 +249,8 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
@@ -261,27 +261,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %30
+ThrowNullRef10:                                   ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -301,7 +301,89 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
-Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
+Successfully read AppDomainSetup.GetUnsecureApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.GetUnsecureApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %NullCheck = icmp eq %"System.String[]" addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %BoundsCheck = icmp uge i64 0, %5
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %6
+
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 3, i32 0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
+  ret %System.String addrspace(1)* %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_Value using LLILCJit
+Successfully read AppDomainSetup.get_Value
+
+define %"System.String[]" addrspace(1)* @AppDomainSetup.get_Value(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.String[]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 18)
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.String[]" addrspace(1)* addrspace(1)*, %"System.String[]" addrspace(1)*)*)(%"System.String[]" addrspace(1)* addrspace(1)* %9, %"System.String[]" addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %11, i32 0, i32 1
+  %14 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %13, align 8
+  ret %"System.String[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -319,8 +401,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -368,16 +450,16 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
   %5 = load i32, i32 addrspace(1)* %4
   %6 = sub i32 %5, 1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -389,7 +471,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -421,8 +503,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
@@ -456,8 +538,8 @@ entry:
 ; <label>:27                                      ; preds = %19
   %28 = load i32, i32* %arg1
   %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
-  br i1 %NullCheck2, label %30, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %29, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %30
 
 ; <label>:30                                      ; preds = %27
   %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
@@ -493,8 +575,8 @@ entry:
 ; <label>:49                                      ; preds = %46
   %50 = load i32, i32* %arg2
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck4, label %52, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
@@ -517,11 +599,11 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %27
+ThrowNullRef2:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %49
+ThrowNullRef4:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -544,16 +626,16 @@ entry:
   %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %0)
   store %System.String addrspace(1)* %1, %System.String addrspace(1)** %loc0
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 2
   %5 = bitcast [0 x i16] addrspace(1)* %4 to i16 addrspace(1)*
   store i16 addrspace(1)* %5, i16 addrspace(1)** %loc1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %3
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2
@@ -580,7 +662,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -691,15 +773,15 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %NullCheck132 = icmp ne i8* %21, null
-  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+  %NullCheck131 = icmp eq i8* %21, null
+  br i1 %NullCheck131, label %ThrowNullRef132, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = load i8, i8* %21, align 8
   %24 = zext i8 %23 to i32
   %25 = trunc i32 %24 to i8
-  %NullCheck134 = icmp ne i8* %20, null
-  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+  %NullCheck133 = icmp eq i8* %20, null
+  br i1 %NullCheck133, label %ThrowNullRef134, label %26
 
 ; <label>:26                                      ; preds = %22
   store i8 %25, i8* %20, align 8
@@ -709,16 +791,16 @@ entry:
   %28 = load i8*, i8** %arg0
   %29 = load i8*, i8** %arg1
   %30 = bitcast i8* %29 to i16*
-  %NullCheck128 = icmp ne i16* %30, null
-  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+  %NullCheck127 = icmp eq i16* %30, null
+  br i1 %NullCheck127, label %ThrowNullRef128, label %31
 
 ; <label>:31                                      ; preds = %27
   %32 = load i16, i16* %30, align 8
   %33 = sext i16 %32 to i32
   %34 = bitcast i8* %28 to i16*
   %35 = trunc i32 %33 to i16
-  %NullCheck130 = icmp ne i16* %34, null
-  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+  %NullCheck129 = icmp eq i16* %34, null
+  br i1 %NullCheck129, label %ThrowNullRef130, label %36
 
 ; <label>:36                                      ; preds = %31
   store i16 %35, i16* %34, align 8
@@ -728,16 +810,16 @@ entry:
   %38 = load i8*, i8** %arg0
   %39 = load i8*, i8** %arg1
   %40 = bitcast i8* %39 to i16*
-  %NullCheck120 = icmp ne i16* %40, null
-  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+  %NullCheck119 = icmp eq i16* %40, null
+  br i1 %NullCheck119, label %ThrowNullRef120, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i16, i16* %40, align 8
   %43 = sext i16 %42 to i32
   %44 = bitcast i8* %38 to i16*
   %45 = trunc i32 %43 to i16
-  %NullCheck122 = icmp ne i16* %44, null
-  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+  %NullCheck121 = icmp eq i16* %44, null
+  br i1 %NullCheck121, label %ThrowNullRef122, label %46
 
 ; <label>:46                                      ; preds = %41
   store i16 %45, i16* %44, align 8
@@ -745,15 +827,15 @@ entry:
   %48 = getelementptr inbounds i8, i8* %47, i64 2
   %49 = load i8*, i8** %arg1
   %50 = getelementptr inbounds i8, i8* %49, i64 2
-  %NullCheck124 = icmp ne i8* %50, null
-  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+  %NullCheck123 = icmp eq i8* %50, null
+  br i1 %NullCheck123, label %ThrowNullRef124, label %51
 
 ; <label>:51                                      ; preds = %46
   %52 = load i8, i8* %50, align 8
   %53 = zext i8 %52 to i32
   %54 = trunc i32 %53 to i8
-  %NullCheck126 = icmp ne i8* %48, null
-  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+  %NullCheck125 = icmp eq i8* %48, null
+  br i1 %NullCheck125, label %ThrowNullRef126, label %55
 
 ; <label>:55                                      ; preds = %51
   store i8 %54, i8* %48, align 8
@@ -763,14 +845,14 @@ entry:
   %57 = load i8*, i8** %arg0
   %58 = load i8*, i8** %arg1
   %59 = bitcast i8* %58 to i32*
-  %NullCheck116 = icmp ne i32* %59, null
-  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+  %NullCheck115 = icmp eq i32* %59, null
+  br i1 %NullCheck115, label %ThrowNullRef116, label %60
 
 ; <label>:60                                      ; preds = %56
   %61 = load i32, i32* %59, align 8
   %62 = bitcast i8* %57 to i32*
-  %NullCheck118 = icmp ne i32* %62, null
-  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+  %NullCheck117 = icmp eq i32* %62, null
+  br i1 %NullCheck117, label %ThrowNullRef118, label %63
 
 ; <label>:63                                      ; preds = %60
   store i32 %61, i32* %62, align 8
@@ -780,14 +862,14 @@ entry:
   %65 = load i8*, i8** %arg0
   %66 = load i8*, i8** %arg1
   %67 = bitcast i8* %66 to i32*
-  %NullCheck108 = icmp ne i32* %67, null
-  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+  %NullCheck107 = icmp eq i32* %67, null
+  br i1 %NullCheck107, label %ThrowNullRef108, label %68
 
 ; <label>:68                                      ; preds = %64
   %69 = load i32, i32* %67, align 8
   %70 = bitcast i8* %65 to i32*
-  %NullCheck110 = icmp ne i32* %70, null
-  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+  %NullCheck109 = icmp eq i32* %70, null
+  br i1 %NullCheck109, label %ThrowNullRef110, label %71
 
 ; <label>:71                                      ; preds = %68
   store i32 %69, i32* %70, align 8
@@ -795,15 +877,15 @@ entry:
   %73 = getelementptr inbounds i8, i8* %72, i64 4
   %74 = load i8*, i8** %arg1
   %75 = getelementptr inbounds i8, i8* %74, i64 4
-  %NullCheck112 = icmp ne i8* %75, null
-  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+  %NullCheck111 = icmp eq i8* %75, null
+  br i1 %NullCheck111, label %ThrowNullRef112, label %76
 
 ; <label>:76                                      ; preds = %71
   %77 = load i8, i8* %75, align 8
   %78 = zext i8 %77 to i32
   %79 = trunc i32 %78 to i8
-  %NullCheck114 = icmp ne i8* %73, null
-  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+  %NullCheck113 = icmp eq i8* %73, null
+  br i1 %NullCheck113, label %ThrowNullRef114, label %80
 
 ; <label>:80                                      ; preds = %76
   store i8 %79, i8* %73, align 8
@@ -813,14 +895,14 @@ entry:
   %82 = load i8*, i8** %arg0
   %83 = load i8*, i8** %arg1
   %84 = bitcast i8* %83 to i32*
-  %NullCheck100 = icmp ne i32* %84, null
-  br i1 %NullCheck100, label %85, label %ThrowNullRef99
+  %NullCheck99 = icmp eq i32* %84, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %85
 
 ; <label>:85                                      ; preds = %81
   %86 = load i32, i32* %84, align 8
   %87 = bitcast i8* %82 to i32*
-  %NullCheck102 = icmp ne i32* %87, null
-  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+  %NullCheck101 = icmp eq i32* %87, null
+  br i1 %NullCheck101, label %ThrowNullRef102, label %88
 
 ; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
@@ -829,16 +911,16 @@ entry:
   %91 = load i8*, i8** %arg1
   %92 = getelementptr inbounds i8, i8* %91, i64 4
   %93 = bitcast i8* %92 to i16*
-  %NullCheck104 = icmp ne i16* %93, null
-  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+  %NullCheck103 = icmp eq i16* %93, null
+  br i1 %NullCheck103, label %ThrowNullRef104, label %94
 
 ; <label>:94                                      ; preds = %88
   %95 = load i16, i16* %93, align 8
   %96 = sext i16 %95 to i32
   %97 = bitcast i8* %90 to i16*
   %98 = trunc i32 %96 to i16
-  %NullCheck106 = icmp ne i16* %97, null
-  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+  %NullCheck105 = icmp eq i16* %97, null
+  br i1 %NullCheck105, label %ThrowNullRef106, label %99
 
 ; <label>:99                                      ; preds = %94
   store i16 %98, i16* %97, align 8
@@ -848,14 +930,14 @@ entry:
   %101 = load i8*, i8** %arg0
   %102 = load i8*, i8** %arg1
   %103 = bitcast i8* %102 to i32*
-  %NullCheck88 = icmp ne i32* %103, null
-  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+  %NullCheck87 = icmp eq i32* %103, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %104
 
 ; <label>:104                                     ; preds = %100
   %105 = load i32, i32* %103, align 8
   %106 = bitcast i8* %101 to i32*
-  %NullCheck90 = icmp ne i32* %106, null
-  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+  %NullCheck89 = icmp eq i32* %106, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %107
 
 ; <label>:107                                     ; preds = %104
   store i32 %105, i32* %106, align 8
@@ -864,16 +946,16 @@ entry:
   %110 = load i8*, i8** %arg1
   %111 = getelementptr inbounds i8, i8* %110, i64 4
   %112 = bitcast i8* %111 to i16*
-  %NullCheck92 = icmp ne i16* %112, null
-  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+  %NullCheck91 = icmp eq i16* %112, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %113
 
 ; <label>:113                                     ; preds = %107
   %114 = load i16, i16* %112, align 8
   %115 = sext i16 %114 to i32
   %116 = bitcast i8* %109 to i16*
   %117 = trunc i32 %115 to i16
-  %NullCheck94 = icmp ne i16* %116, null
-  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+  %NullCheck93 = icmp eq i16* %116, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %118
 
 ; <label>:118                                     ; preds = %113
   store i16 %117, i16* %116, align 8
@@ -881,15 +963,15 @@ entry:
   %120 = getelementptr inbounds i8, i8* %119, i64 6
   %121 = load i8*, i8** %arg1
   %122 = getelementptr inbounds i8, i8* %121, i64 6
-  %NullCheck96 = icmp ne i8* %122, null
-  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+  %NullCheck95 = icmp eq i8* %122, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %123
 
 ; <label>:123                                     ; preds = %118
   %124 = load i8, i8* %122, align 8
   %125 = zext i8 %124 to i32
   %126 = trunc i32 %125 to i8
-  %NullCheck98 = icmp ne i8* %120, null
-  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+  %NullCheck97 = icmp eq i8* %120, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %127
 
 ; <label>:127                                     ; preds = %123
   store i8 %126, i8* %120, align 8
@@ -899,14 +981,14 @@ entry:
   %129 = load i8*, i8** %arg0
   %130 = load i8*, i8** %arg1
   %131 = bitcast i8* %130 to i64*
-  %NullCheck84 = icmp ne i64* %131, null
-  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+  %NullCheck83 = icmp eq i64* %131, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %132
 
 ; <label>:132                                     ; preds = %128
   %133 = load i64, i64* %131, align 8
   %134 = bitcast i8* %129 to i64*
-  %NullCheck86 = icmp ne i64* %134, null
-  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+  %NullCheck85 = icmp eq i64* %134, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %135
 
 ; <label>:135                                     ; preds = %132
   store i64 %133, i64* %134, align 8
@@ -916,14 +998,14 @@ entry:
   %137 = load i8*, i8** %arg0
   %138 = load i8*, i8** %arg1
   %139 = bitcast i8* %138 to i64*
-  %NullCheck76 = icmp ne i64* %139, null
-  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+  %NullCheck75 = icmp eq i64* %139, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %140
 
 ; <label>:140                                     ; preds = %136
   %141 = load i64, i64* %139, align 8
   %142 = bitcast i8* %137 to i64*
-  %NullCheck78 = icmp ne i64* %142, null
-  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+  %NullCheck77 = icmp eq i64* %142, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %143
 
 ; <label>:143                                     ; preds = %140
   store i64 %141, i64* %142, align 8
@@ -931,15 +1013,15 @@ entry:
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %NullCheck80 = icmp ne i8* %147, null
-  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+  %NullCheck79 = icmp eq i8* %147, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %148
 
 ; <label>:148                                     ; preds = %143
   %149 = load i8, i8* %147, align 8
   %150 = zext i8 %149 to i32
   %151 = trunc i32 %150 to i8
-  %NullCheck82 = icmp ne i8* %145, null
-  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+  %NullCheck81 = icmp eq i8* %145, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %152
 
 ; <label>:152                                     ; preds = %148
   store i8 %151, i8* %145, align 8
@@ -949,14 +1031,14 @@ entry:
   %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
   %156 = bitcast i8* %155 to i64*
-  %NullCheck68 = icmp ne i64* %156, null
-  br i1 %NullCheck68, label %157, label %ThrowNullRef67
+  %NullCheck67 = icmp eq i64* %156, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %157
 
 ; <label>:157                                     ; preds = %153
   %158 = load i64, i64* %156, align 8
   %159 = bitcast i8* %154 to i64*
-  %NullCheck70 = icmp ne i64* %159, null
-  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+  %NullCheck69 = icmp eq i64* %159, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %160
 
 ; <label>:160                                     ; preds = %157
   store i64 %158, i64* %159, align 8
@@ -965,16 +1047,16 @@ entry:
   %163 = load i8*, i8** %arg1
   %164 = getelementptr inbounds i8, i8* %163, i64 8
   %165 = bitcast i8* %164 to i16*
-  %NullCheck72 = icmp ne i16* %165, null
-  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+  %NullCheck71 = icmp eq i16* %165, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %166
 
 ; <label>:166                                     ; preds = %160
   %167 = load i16, i16* %165, align 8
   %168 = sext i16 %167 to i32
   %169 = bitcast i8* %162 to i16*
   %170 = trunc i32 %168 to i16
-  %NullCheck74 = icmp ne i16* %169, null
-  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+  %NullCheck73 = icmp eq i16* %169, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %171
 
 ; <label>:171                                     ; preds = %166
   store i16 %170, i16* %169, align 8
@@ -984,14 +1066,14 @@ entry:
   %173 = load i8*, i8** %arg0
   %174 = load i8*, i8** %arg1
   %175 = bitcast i8* %174 to i64*
-  %NullCheck56 = icmp ne i64* %175, null
-  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+  %NullCheck55 = icmp eq i64* %175, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %176
 
 ; <label>:176                                     ; preds = %172
   %177 = load i64, i64* %175, align 8
   %178 = bitcast i8* %173 to i64*
-  %NullCheck58 = icmp ne i64* %178, null
-  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+  %NullCheck57 = icmp eq i64* %178, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %179
 
 ; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
@@ -1000,16 +1082,16 @@ entry:
   %182 = load i8*, i8** %arg1
   %183 = getelementptr inbounds i8, i8* %182, i64 8
   %184 = bitcast i8* %183 to i16*
-  %NullCheck60 = icmp ne i16* %184, null
-  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+  %NullCheck59 = icmp eq i16* %184, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %185
 
 ; <label>:185                                     ; preds = %179
   %186 = load i16, i16* %184, align 8
   %187 = sext i16 %186 to i32
   %188 = bitcast i8* %181 to i16*
   %189 = trunc i32 %187 to i16
-  %NullCheck62 = icmp ne i16* %188, null
-  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+  %NullCheck61 = icmp eq i16* %188, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %190
 
 ; <label>:190                                     ; preds = %185
   store i16 %189, i16* %188, align 8
@@ -1017,15 +1099,15 @@ entry:
   %192 = getelementptr inbounds i8, i8* %191, i64 10
   %193 = load i8*, i8** %arg1
   %194 = getelementptr inbounds i8, i8* %193, i64 10
-  %NullCheck64 = icmp ne i8* %194, null
-  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+  %NullCheck63 = icmp eq i8* %194, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %195
 
 ; <label>:195                                     ; preds = %190
   %196 = load i8, i8* %194, align 8
   %197 = zext i8 %196 to i32
   %198 = trunc i32 %197 to i8
-  %NullCheck66 = icmp ne i8* %192, null
-  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+  %NullCheck65 = icmp eq i8* %192, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %199
 
 ; <label>:199                                     ; preds = %195
   store i8 %198, i8* %192, align 8
@@ -1035,14 +1117,14 @@ entry:
   %201 = load i8*, i8** %arg0
   %202 = load i8*, i8** %arg1
   %203 = bitcast i8* %202 to i64*
-  %NullCheck48 = icmp ne i64* %203, null
-  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+  %NullCheck47 = icmp eq i64* %203, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %204
 
 ; <label>:204                                     ; preds = %200
   %205 = load i64, i64* %203, align 8
   %206 = bitcast i8* %201 to i64*
-  %NullCheck50 = icmp ne i64* %206, null
-  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+  %NullCheck49 = icmp eq i64* %206, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %207
 
 ; <label>:207                                     ; preds = %204
   store i64 %205, i64* %206, align 8
@@ -1051,14 +1133,14 @@ entry:
   %210 = load i8*, i8** %arg1
   %211 = getelementptr inbounds i8, i8* %210, i64 8
   %212 = bitcast i8* %211 to i32*
-  %NullCheck52 = icmp ne i32* %212, null
-  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+  %NullCheck51 = icmp eq i32* %212, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %213
 
 ; <label>:213                                     ; preds = %207
   %214 = load i32, i32* %212, align 8
   %215 = bitcast i8* %209 to i32*
-  %NullCheck54 = icmp ne i32* %215, null
-  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+  %NullCheck53 = icmp eq i32* %215, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %216
 
 ; <label>:216                                     ; preds = %213
   store i32 %214, i32* %215, align 8
@@ -1068,14 +1150,14 @@ entry:
   %218 = load i8*, i8** %arg0
   %219 = load i8*, i8** %arg1
   %220 = bitcast i8* %219 to i64*
-  %NullCheck36 = icmp ne i64* %220, null
-  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64* %220, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %221
 
 ; <label>:221                                     ; preds = %217
   %222 = load i64, i64* %220, align 8
   %223 = bitcast i8* %218 to i64*
-  %NullCheck38 = icmp ne i64* %223, null
-  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+  %NullCheck37 = icmp eq i64* %223, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %224
 
 ; <label>:224                                     ; preds = %221
   store i64 %222, i64* %223, align 8
@@ -1084,14 +1166,14 @@ entry:
   %227 = load i8*, i8** %arg1
   %228 = getelementptr inbounds i8, i8* %227, i64 8
   %229 = bitcast i8* %228 to i32*
-  %NullCheck40 = icmp ne i32* %229, null
-  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i32* %229, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %230
 
 ; <label>:230                                     ; preds = %224
   %231 = load i32, i32* %229, align 8
   %232 = bitcast i8* %226 to i32*
-  %NullCheck42 = icmp ne i32* %232, null
-  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+  %NullCheck41 = icmp eq i32* %232, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %233
 
 ; <label>:233                                     ; preds = %230
   store i32 %231, i32* %232, align 8
@@ -1099,15 +1181,15 @@ entry:
   %235 = getelementptr inbounds i8, i8* %234, i64 12
   %236 = load i8*, i8** %arg1
   %237 = getelementptr inbounds i8, i8* %236, i64 12
-  %NullCheck44 = icmp ne i8* %237, null
-  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i8* %237, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %238
 
 ; <label>:238                                     ; preds = %233
   %239 = load i8, i8* %237, align 8
   %240 = zext i8 %239 to i32
   %241 = trunc i32 %240 to i8
-  %NullCheck46 = icmp ne i8* %235, null
-  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+  %NullCheck45 = icmp eq i8* %235, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %242
 
 ; <label>:242                                     ; preds = %238
   store i8 %241, i8* %235, align 8
@@ -1117,14 +1199,14 @@ entry:
   %244 = load i8*, i8** %arg0
   %245 = load i8*, i8** %arg1
   %246 = bitcast i8* %245 to i64*
-  %NullCheck24 = icmp ne i64* %246, null
-  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64* %246, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %247
 
 ; <label>:247                                     ; preds = %243
   %248 = load i64, i64* %246, align 8
   %249 = bitcast i8* %244 to i64*
-  %NullCheck26 = icmp ne i64* %249, null
-  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64* %249, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %250
 
 ; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
@@ -1133,14 +1215,14 @@ entry:
   %253 = load i8*, i8** %arg1
   %254 = getelementptr inbounds i8, i8* %253, i64 8
   %255 = bitcast i8* %254 to i32*
-  %NullCheck28 = icmp ne i32* %255, null
-  br i1 %NullCheck28, label %256, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i32* %255, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %256
 
 ; <label>:256                                     ; preds = %250
   %257 = load i32, i32* %255, align 8
   %258 = bitcast i8* %252 to i32*
-  %NullCheck30 = icmp ne i32* %258, null
-  br i1 %NullCheck30, label %259, label %ThrowNullRef29
+  %NullCheck29 = icmp eq i32* %258, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %259
 
 ; <label>:259                                     ; preds = %256
   store i32 %257, i32* %258, align 8
@@ -1149,16 +1231,16 @@ entry:
   %262 = load i8*, i8** %arg1
   %263 = getelementptr inbounds i8, i8* %262, i64 12
   %264 = bitcast i8* %263 to i16*
-  %NullCheck32 = icmp ne i16* %264, null
-  br i1 %NullCheck32, label %265, label %ThrowNullRef31
+  %NullCheck31 = icmp eq i16* %264, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %265
 
 ; <label>:265                                     ; preds = %259
   %266 = load i16, i16* %264, align 8
   %267 = sext i16 %266 to i32
   %268 = bitcast i8* %261 to i16*
   %269 = trunc i32 %267 to i16
-  %NullCheck34 = icmp ne i16* %268, null
-  br i1 %NullCheck34, label %270, label %ThrowNullRef33
+  %NullCheck33 = icmp eq i16* %268, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %270
 
 ; <label>:270                                     ; preds = %265
   store i16 %269, i16* %268, align 8
@@ -1168,14 +1250,14 @@ entry:
   %272 = load i8*, i8** %arg0
   %273 = load i8*, i8** %arg1
   %274 = bitcast i8* %273 to i64*
-  %NullCheck8 = icmp ne i64* %274, null
-  br i1 %NullCheck8, label %275, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64* %274, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %275
 
 ; <label>:275                                     ; preds = %271
   %276 = load i64, i64* %274, align 8
   %277 = bitcast i8* %272 to i64*
-  %NullCheck10 = icmp ne i64* %277, null
-  br i1 %NullCheck10, label %278, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %277, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %278
 
 ; <label>:278                                     ; preds = %275
   store i64 %276, i64* %277, align 8
@@ -1184,14 +1266,14 @@ entry:
   %281 = load i8*, i8** %arg1
   %282 = getelementptr inbounds i8, i8* %281, i64 8
   %283 = bitcast i8* %282 to i32*
-  %NullCheck12 = icmp ne i32* %283, null
-  br i1 %NullCheck12, label %284, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i32* %283, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %284
 
 ; <label>:284                                     ; preds = %278
   %285 = load i32, i32* %283, align 8
   %286 = bitcast i8* %280 to i32*
-  %NullCheck14 = icmp ne i32* %286, null
-  br i1 %NullCheck14, label %287, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i32* %286, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %287
 
 ; <label>:287                                     ; preds = %284
   store i32 %285, i32* %286, align 8
@@ -1200,16 +1282,16 @@ entry:
   %290 = load i8*, i8** %arg1
   %291 = getelementptr inbounds i8, i8* %290, i64 12
   %292 = bitcast i8* %291 to i16*
-  %NullCheck16 = icmp ne i16* %292, null
-  br i1 %NullCheck16, label %293, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i16* %292, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %293
 
 ; <label>:293                                     ; preds = %287
   %294 = load i16, i16* %292, align 8
   %295 = sext i16 %294 to i32
   %296 = bitcast i8* %289 to i16*
   %297 = trunc i32 %295 to i16
-  %NullCheck18 = icmp ne i16* %296, null
-  br i1 %NullCheck18, label %298, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i16* %296, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %298
 
 ; <label>:298                                     ; preds = %293
   store i16 %297, i16* %296, align 8
@@ -1217,15 +1299,15 @@ entry:
   %300 = getelementptr inbounds i8, i8* %299, i64 14
   %301 = load i8*, i8** %arg1
   %302 = getelementptr inbounds i8, i8* %301, i64 14
-  %NullCheck20 = icmp ne i8* %302, null
-  br i1 %NullCheck20, label %303, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i8* %302, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %303
 
 ; <label>:303                                     ; preds = %298
   %304 = load i8, i8* %302, align 8
   %305 = zext i8 %304 to i32
   %306 = trunc i32 %305 to i8
-  %NullCheck22 = icmp ne i8* %300, null
-  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i8* %300, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %307
 
 ; <label>:307                                     ; preds = %303
   store i8 %306, i8* %300, align 8
@@ -1235,14 +1317,14 @@ entry:
   %309 = load i8*, i8** %arg0
   %310 = load i8*, i8** %arg1
   %311 = bitcast i8* %310 to i64*
-  %NullCheck = icmp ne i64* %311, null
-  br i1 %NullCheck, label %312, label %ThrowNullRef
+  %NullCheck = icmp eq i64* %311, null
+  br i1 %NullCheck, label %ThrowNullRef, label %312
 
 ; <label>:312                                     ; preds = %308
   %313 = load i64, i64* %311, align 8
   %314 = bitcast i8* %309 to i64*
-  %NullCheck2 = icmp ne i64* %314, null
-  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64* %314, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %315
 
 ; <label>:315                                     ; preds = %312
   store i64 %313, i64* %314, align 8
@@ -1251,14 +1333,14 @@ entry:
   %318 = load i8*, i8** %arg1
   %319 = getelementptr inbounds i8, i8* %318, i64 8
   %320 = bitcast i8* %319 to i64*
-  %NullCheck4 = icmp ne i64* %320, null
-  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64* %320, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %321
 
 ; <label>:321                                     ; preds = %315
   %322 = load i64, i64* %320, align 8
   %323 = bitcast i8* %317 to i64*
-  %NullCheck6 = icmp ne i64* %323, null
-  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64* %323, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %324
 
 ; <label>:324                                     ; preds = %321
   store i64 %322, i64* %323, align 8
@@ -1286,15 +1368,15 @@ entry:
 ; <label>:338                                     ; preds = %333
   %339 = load i8*, i8** %arg0
   %340 = load i8*, i8** %arg1
-  %NullCheck136 = icmp ne i8* %340, null
-  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+  %NullCheck135 = icmp eq i8* %340, null
+  br i1 %NullCheck135, label %ThrowNullRef136, label %341
 
 ; <label>:341                                     ; preds = %338
   %342 = load i8, i8* %340, align 8
   %343 = zext i8 %342 to i32
   %344 = trunc i32 %343 to i8
-  %NullCheck138 = icmp ne i8* %339, null
-  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+  %NullCheck137 = icmp eq i8* %339, null
+  br i1 %NullCheck137, label %ThrowNullRef138, label %345
 
 ; <label>:345                                     ; preds = %341
   store i8 %344, i8* %339, align 8
@@ -1317,16 +1399,16 @@ entry:
   %357 = load i8*, i8** %arg0
   %358 = load i8*, i8** %arg1
   %359 = bitcast i8* %358 to i16*
-  %NullCheck140 = icmp ne i16* %359, null
-  br i1 %NullCheck140, label %360, label %ThrowNullRef139
+  %NullCheck139 = icmp eq i16* %359, null
+  br i1 %NullCheck139, label %ThrowNullRef140, label %360
 
 ; <label>:360                                     ; preds = %356
   %361 = load i16, i16* %359, align 8
   %362 = sext i16 %361 to i32
   %363 = bitcast i8* %357 to i16*
   %364 = trunc i32 %362 to i16
-  %NullCheck142 = icmp ne i16* %363, null
-  br i1 %NullCheck142, label %365, label %ThrowNullRef141
+  %NullCheck141 = icmp eq i16* %363, null
+  br i1 %NullCheck141, label %ThrowNullRef142, label %365
 
 ; <label>:365                                     ; preds = %360
   store i16 %364, i16* %363, align 8
@@ -1352,14 +1434,14 @@ entry:
   %378 = load i8*, i8** %arg0
   %379 = load i8*, i8** %arg1
   %380 = bitcast i8* %379 to i32*
-  %NullCheck144 = icmp ne i32* %380, null
-  br i1 %NullCheck144, label %381, label %ThrowNullRef143
+  %NullCheck143 = icmp eq i32* %380, null
+  br i1 %NullCheck143, label %ThrowNullRef144, label %381
 
 ; <label>:381                                     ; preds = %377
   %382 = load i32, i32* %380, align 8
   %383 = bitcast i8* %378 to i32*
-  %NullCheck146 = icmp ne i32* %383, null
-  br i1 %NullCheck146, label %384, label %ThrowNullRef145
+  %NullCheck145 = icmp eq i32* %383, null
+  br i1 %NullCheck145, label %ThrowNullRef146, label %384
 
 ; <label>:384                                     ; preds = %381
   store i32 %382, i32* %383, align 8
@@ -1384,14 +1466,14 @@ entry:
   %395 = load i8*, i8** %arg0
   %396 = load i8*, i8** %arg1
   %397 = bitcast i8* %396 to i64*
-  %NullCheck164 = icmp ne i64* %397, null
-  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+  %NullCheck163 = icmp eq i64* %397, null
+  br i1 %NullCheck163, label %ThrowNullRef164, label %398
 
 ; <label>:398                                     ; preds = %394
   %399 = load i64, i64* %397, align 8
   %400 = bitcast i8* %395 to i64*
-  %NullCheck166 = icmp ne i64* %400, null
-  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+  %NullCheck165 = icmp eq i64* %400, null
+  br i1 %NullCheck165, label %ThrowNullRef166, label %401
 
 ; <label>:401                                     ; preds = %398
   store i64 %399, i64* %400, align 8
@@ -1400,14 +1482,14 @@ entry:
   %404 = load i8*, i8** %arg1
   %405 = getelementptr inbounds i8, i8* %404, i64 8
   %406 = bitcast i8* %405 to i64*
-  %NullCheck168 = icmp ne i64* %406, null
-  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+  %NullCheck167 = icmp eq i64* %406, null
+  br i1 %NullCheck167, label %ThrowNullRef168, label %407
 
 ; <label>:407                                     ; preds = %401
   %408 = load i64, i64* %406, align 8
   %409 = bitcast i8* %403 to i64*
-  %NullCheck170 = icmp ne i64* %409, null
-  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+  %NullCheck169 = icmp eq i64* %409, null
+  br i1 %NullCheck169, label %ThrowNullRef170, label %410
 
 ; <label>:410                                     ; preds = %407
   store i64 %408, i64* %409, align 8
@@ -1437,14 +1519,14 @@ entry:
   %425 = load i8*, i8** %arg0
   %426 = load i8*, i8** %arg1
   %427 = bitcast i8* %426 to i64*
-  %NullCheck148 = icmp ne i64* %427, null
-  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+  %NullCheck147 = icmp eq i64* %427, null
+  br i1 %NullCheck147, label %ThrowNullRef148, label %428
 
 ; <label>:428                                     ; preds = %424
   %429 = load i64, i64* %427, align 8
   %430 = bitcast i8* %425 to i64*
-  %NullCheck150 = icmp ne i64* %430, null
-  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+  %NullCheck149 = icmp eq i64* %430, null
+  br i1 %NullCheck149, label %ThrowNullRef150, label %431
 
 ; <label>:431                                     ; preds = %428
   store i64 %429, i64* %430, align 8
@@ -1466,14 +1548,14 @@ entry:
   %441 = load i8*, i8** %arg0
   %442 = load i8*, i8** %arg1
   %443 = bitcast i8* %442 to i32*
-  %NullCheck152 = icmp ne i32* %443, null
-  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+  %NullCheck151 = icmp eq i32* %443, null
+  br i1 %NullCheck151, label %ThrowNullRef152, label %444
 
 ; <label>:444                                     ; preds = %440
   %445 = load i32, i32* %443, align 8
   %446 = bitcast i8* %441 to i32*
-  %NullCheck154 = icmp ne i32* %446, null
-  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+  %NullCheck153 = icmp eq i32* %446, null
+  br i1 %NullCheck153, label %ThrowNullRef154, label %447
 
 ; <label>:447                                     ; preds = %444
   store i32 %445, i32* %446, align 8
@@ -1495,16 +1577,16 @@ entry:
   %457 = load i8*, i8** %arg0
   %458 = load i8*, i8** %arg1
   %459 = bitcast i8* %458 to i16*
-  %NullCheck156 = icmp ne i16* %459, null
-  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+  %NullCheck155 = icmp eq i16* %459, null
+  br i1 %NullCheck155, label %ThrowNullRef156, label %460
 
 ; <label>:460                                     ; preds = %456
   %461 = load i16, i16* %459, align 8
   %462 = sext i16 %461 to i32
   %463 = bitcast i8* %457 to i16*
   %464 = trunc i32 %462 to i16
-  %NullCheck158 = icmp ne i16* %463, null
-  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+  %NullCheck157 = icmp eq i16* %463, null
+  br i1 %NullCheck157, label %ThrowNullRef158, label %465
 
 ; <label>:465                                     ; preds = %460
   store i16 %464, i16* %463, align 8
@@ -1525,15 +1607,15 @@ entry:
 ; <label>:474                                     ; preds = %470
   %475 = load i8*, i8** %arg0
   %476 = load i8*, i8** %arg1
-  %NullCheck160 = icmp ne i8* %476, null
-  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+  %NullCheck159 = icmp eq i8* %476, null
+  br i1 %NullCheck159, label %ThrowNullRef160, label %477
 
 ; <label>:477                                     ; preds = %474
   %478 = load i8, i8* %476, align 8
   %479 = zext i8 %478 to i32
   %480 = trunc i32 %479 to i8
-  %NullCheck162 = icmp ne i8* %475, null
-  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+  %NullCheck161 = icmp eq i8* %475, null
+  br i1 %NullCheck161, label %ThrowNullRef162, label %481
 
 ; <label>:481                                     ; preds = %477
   store i8 %480, i8* %475, align 8
@@ -1553,343 +1635,343 @@ ThrowNullRef:                                     ; preds = %308
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %312
+ThrowNullRef2:                                    ; preds = %312
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %315
+ThrowNullRef4:                                    ; preds = %315
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %321
+ThrowNullRef6:                                    ; preds = %321
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %271
+ThrowNullRef8:                                    ; preds = %271
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %275
+ThrowNullRef10:                                   ; preds = %275
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %278
+ThrowNullRef12:                                   ; preds = %278
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %284
+ThrowNullRef14:                                   ; preds = %284
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %287
+ThrowNullRef16:                                   ; preds = %287
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %293
+ThrowNullRef18:                                   ; preds = %293
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %298
+ThrowNullRef20:                                   ; preds = %298
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %303
+ThrowNullRef22:                                   ; preds = %303
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %243
+ThrowNullRef24:                                   ; preds = %243
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %247
+ThrowNullRef26:                                   ; preds = %247
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %250
+ThrowNullRef28:                                   ; preds = %250
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %256
+ThrowNullRef30:                                   ; preds = %256
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %259
+ThrowNullRef32:                                   ; preds = %259
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %265
+ThrowNullRef34:                                   ; preds = %265
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %217
+ThrowNullRef36:                                   ; preds = %217
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %221
+ThrowNullRef38:                                   ; preds = %221
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %224
+ThrowNullRef40:                                   ; preds = %224
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %230
+ThrowNullRef42:                                   ; preds = %230
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %233
+ThrowNullRef44:                                   ; preds = %233
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %238
+ThrowNullRef46:                                   ; preds = %238
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %200
+ThrowNullRef48:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %204
+ThrowNullRef50:                                   ; preds = %204
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %207
+ThrowNullRef52:                                   ; preds = %207
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %213
+ThrowNullRef54:                                   ; preds = %213
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %172
+ThrowNullRef56:                                   ; preds = %172
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %176
+ThrowNullRef58:                                   ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %179
+ThrowNullRef60:                                   ; preds = %179
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %185
+ThrowNullRef62:                                   ; preds = %185
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %190
+ThrowNullRef64:                                   ; preds = %190
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %195
+ThrowNullRef66:                                   ; preds = %195
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %153
+ThrowNullRef68:                                   ; preds = %153
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %157
+ThrowNullRef70:                                   ; preds = %157
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %160
+ThrowNullRef72:                                   ; preds = %160
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %166
+ThrowNullRef74:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %136
+ThrowNullRef76:                                   ; preds = %136
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %140
+ThrowNullRef78:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %143
+ThrowNullRef80:                                   ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %148
+ThrowNullRef82:                                   ; preds = %148
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %128
+ThrowNullRef84:                                   ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %132
+ThrowNullRef86:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %100
+ThrowNullRef88:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %104
+ThrowNullRef90:                                   ; preds = %104
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %107
+ThrowNullRef92:                                   ; preds = %107
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %113
+ThrowNullRef94:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %118
+ThrowNullRef96:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %123
+ThrowNullRef98:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %81
+ThrowNullRef100:                                  ; preds = %81
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef101:                                  ; preds = %85
+ThrowNullRef102:                                  ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef103:                                  ; preds = %88
+ThrowNullRef104:                                  ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef105:                                  ; preds = %94
+ThrowNullRef106:                                  ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef107:                                  ; preds = %64
+ThrowNullRef108:                                  ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef109:                                  ; preds = %68
+ThrowNullRef110:                                  ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef111:                                  ; preds = %71
+ThrowNullRef112:                                  ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef113:                                  ; preds = %76
+ThrowNullRef114:                                  ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef115:                                  ; preds = %56
+ThrowNullRef116:                                  ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef117:                                  ; preds = %60
+ThrowNullRef118:                                  ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef119:                                  ; preds = %37
+ThrowNullRef120:                                  ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef121:                                  ; preds = %41
+ThrowNullRef122:                                  ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef123:                                  ; preds = %46
+ThrowNullRef124:                                  ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef125:                                  ; preds = %51
+ThrowNullRef126:                                  ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef127:                                  ; preds = %27
+ThrowNullRef128:                                  ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef129:                                  ; preds = %31
+ThrowNullRef130:                                  ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef131:                                  ; preds = %19
+ThrowNullRef132:                                  ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef133:                                  ; preds = %22
+ThrowNullRef134:                                  ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef135:                                  ; preds = %338
+ThrowNullRef136:                                  ; preds = %338
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef137:                                  ; preds = %341
+ThrowNullRef138:                                  ; preds = %341
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef139:                                  ; preds = %356
+ThrowNullRef140:                                  ; preds = %356
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef141:                                  ; preds = %360
+ThrowNullRef142:                                  ; preds = %360
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef143:                                  ; preds = %377
+ThrowNullRef144:                                  ; preds = %377
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef145:                                  ; preds = %381
+ThrowNullRef146:                                  ; preds = %381
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef147:                                  ; preds = %424
+ThrowNullRef148:                                  ; preds = %424
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef149:                                  ; preds = %428
+ThrowNullRef150:                                  ; preds = %428
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef151:                                  ; preds = %440
+ThrowNullRef152:                                  ; preds = %440
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef153:                                  ; preds = %444
+ThrowNullRef154:                                  ; preds = %444
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef155:                                  ; preds = %456
+ThrowNullRef156:                                  ; preds = %456
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef157:                                  ; preds = %460
+ThrowNullRef158:                                  ; preds = %460
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef159:                                  ; preds = %474
+ThrowNullRef160:                                  ; preds = %474
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef161:                                  ; preds = %477
+ThrowNullRef162:                                  ; preds = %477
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef163:                                  ; preds = %394
+ThrowNullRef164:                                  ; preds = %394
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef165:                                  ; preds = %398
+ThrowNullRef166:                                  ; preds = %398
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef167:                                  ; preds = %401
+ThrowNullRef168:                                  ; preds = %401
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef169:                                  ; preds = %407
+ThrowNullRef170:                                  ; preds = %407
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1939,8 +2021,8 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
-  br i1 %NullCheck, label %22, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %ThrowNullRef, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
@@ -1948,8 +2030,8 @@ entry:
   store i32 %24, i32* %loc0
   %25 = load i32, i32* %loc0
   %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %26, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %27
 
 ; <label>:27                                      ; preds = %22
   %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
@@ -1971,7 +2053,7 @@ ThrowNullRef:                                     ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1989,8 +2071,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -2022,15 +2104,15 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2048,16 +2130,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
   %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
   store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %15
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
@@ -2072,8 +2154,8 @@ entry:
   %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
   %29 = ptrtoint i16 addrspace(1)* %28 to i64
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %19
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
@@ -2089,19 +2171,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2114,8 +2196,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
@@ -2128,7 +2210,7 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[loadElem]
+Failed to read AppDomain.PrepareDataForSetup[storeElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
@@ -2202,8 +2284,8 @@ entry:
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
-  br i1 %NullCheck24, label %27, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = load i64, i64 addrspace(1)* %26
@@ -2218,8 +2300,8 @@ entry:
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
-  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
   %41 = load i64, i64 addrspace(1)* %39
@@ -2236,8 +2318,8 @@ entry:
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
-  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
   %54 = load i64, i64 addrspace(1)* %52
@@ -2252,8 +2334,8 @@ entry:
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
   %67 = load i64, i64 addrspace(1)* %65
@@ -2270,8 +2352,8 @@ entry:
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
-  br i1 %NullCheck16, label %79, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
   %80 = load i64, i64 addrspace(1)* %78
@@ -2286,8 +2368,8 @@ entry:
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
-  br i1 %NullCheck18, label %92, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
   %93 = load i64, i64 addrspace(1)* %91
@@ -2304,8 +2386,8 @@ entry:
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
-  br i1 %NullCheck12, label %105, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = load i64, i64 addrspace(1)* %104
@@ -2320,8 +2402,8 @@ entry:
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
-  br i1 %NullCheck14, label %118, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
   %119 = load i64, i64 addrspace(1)* %117
@@ -2337,8 +2419,8 @@ entry:
 
 ; <label>:128                                     ; preds = %20
   %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
-  br i1 %NullCheck4, label %130, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %129, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %130
 
 ; <label>:130                                     ; preds = %128
   %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
@@ -2346,8 +2428,8 @@ entry:
   %133 = load i16, i16 addrspace(1)* %132, align 8
   %134 = zext i16 %133 to i32
   %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
-  br i1 %NullCheck6, label %136, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %135, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %136
 
 ; <label>:136                                     ; preds = %130
   %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
@@ -2360,8 +2442,8 @@ entry:
 
 ; <label>:143                                     ; preds = %136
   %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
-  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %144, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %145
 
 ; <label>:145                                     ; preds = %143
   %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
@@ -2369,8 +2451,8 @@ entry:
   %148 = load i16, i16 addrspace(1)* %147, align 8
   %149 = zext i16 %148 to i32
   %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %150, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %151
 
 ; <label>:151                                     ; preds = %145
   %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
@@ -2388,8 +2470,8 @@ entry:
 
 ; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
-  br i1 %NullCheck, label %163, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %ThrowNullRef, label %163
 
 ; <label>:163                                     ; preds = %161
   %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
@@ -2399,8 +2481,8 @@ entry:
 
 ; <label>:167                                     ; preds = %163
   %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
-  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %168, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %169
 
 ; <label>:169                                     ; preds = %167
   %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
@@ -2432,55 +2514,55 @@ ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %167
+ThrowNullRef2:                                    ; preds = %167
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %128
+ThrowNullRef4:                                    ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %130
+ThrowNullRef6:                                    ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %143
+ThrowNullRef8:                                    ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %145
+ThrowNullRef10:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %102
+ThrowNullRef12:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %105
+ThrowNullRef14:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %76
+ThrowNullRef16:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %79
+ThrowNullRef18:                                   ; preds = %79
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %50
+ThrowNullRef20:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %53
+ThrowNullRef22:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %24
+ThrowNullRef24:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %27
+ThrowNullRef26:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2503,15 +2585,15 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2519,16 +2601,16 @@ entry:
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
   store i32 %8, i32* %loc0
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
   %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
   store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
@@ -2546,16 +2628,16 @@ entry:
 
 ; <label>:23                                      ; preds = %64
   %24 = load i16*, i16** %loc3
-  %NullCheck12 = icmp ne i16* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i16* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
   store i32 %27, i32* %loc5
   %28 = load i16*, i16** %loc4
-  %NullCheck14 = icmp ne i16* %28, null
-  br i1 %NullCheck14, label %29, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %28, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = load i16, i16* %28, align 8
@@ -2620,15 +2702,15 @@ entry:
 
 ; <label>:67                                      ; preds = %64
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
-  br i1 %NullCheck8, label %69, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %68, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %69
 
 ; <label>:69                                      ; preds = %67
   %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
   %71 = load i32, i32 addrspace(1)* %70
   %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
-  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %73
 
 ; <label>:73                                      ; preds = %69
   %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
@@ -2645,31 +2727,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %67
+ThrowNullRef8:                                    ; preds = %67
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %69
+ThrowNullRef10:                                   ; preds = %69
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2710,14 +2792,14 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
   %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
@@ -2730,14 +2812,14 @@ entry:
 
 ; <label>:11                                      ; preds = %4
   %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
   %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
@@ -2749,14 +2831,14 @@ entry:
 
 ; <label>:22                                      ; preds = %16
   %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
   %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
-  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
-  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
@@ -2804,23 +2886,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2836,7 +2918,280 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[loadElem]
+Successfully read RuntimeType.IsAssignableFrom
+
+define i8 @RuntimeType.IsAssignableFrom(%System.RuntimeType addrspace(1)* %param0, %System.Type addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.RuntimeType addrspace(1)*
+  %arg1 = alloca %System.Type addrspace(1)*
+  %loc0 = alloca %System.RuntimeType addrspace(1)*
+  %loc1 = alloca %"System.Type[]" addrspace(1)*
+  %loc2 = alloca i32
+  store %System.RuntimeType addrspace(1)* %param0, %System.RuntimeType addrspace(1)** %this
+  store %System.Type addrspace(1)* %param1, %System.Type addrspace(1)** %arg1
+  %0 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %1 = icmp ne %System.Type addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i8 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %5 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %6 = bitcast %System.Type addrspace(1)* %4 to %System.Object addrspace(1)*
+  %7 = bitcast %System.RuntimeType addrspace(1)* %5 to %System.Object addrspace(1)*
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %6, %System.Object addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %3
+  ret i8 1
+
+; <label>:12                                      ; preds = %3
+  %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 152
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 32
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
+  %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
+  %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
+  store %System.RuntimeType addrspace(1)* %25, %System.RuntimeType addrspace(1)** %loc0
+  %26 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %27 = icmp eq %System.RuntimeType addrspace(1)* %26, null
+  br i1 %27, label %34, label %28
+
+; <label>:28                                      ; preds = %15
+  %29 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %30 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)*)*)(%System.RuntimeType addrspace(1)* %29, %System.RuntimeType addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+; <label>:34                                      ; preds = %15
+  %35 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %36 = call %System.Reflection.Emit.TypeBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Reflection.Emit.TypeBuilder addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %35)
+  %37 = icmp eq %System.Reflection.Emit.TypeBuilder addrspace(1)* %36, null
+  br i1 %37, label %139, label %38
+
+; <label>:38                                      ; preds = %34
+  %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %42
+
+; <label>:42                                      ; preds = %38
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 152
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 40
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
+  %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
+  %53 = zext i8 %52 to i32
+  %54 = icmp eq i32 %53, 0
+  br i1 %54, label %56, label %55
+
+; <label>:55                                      ; preds = %42
+  ret i8 1
+
+; <label>:56                                      ; preds = %42
+  %57 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %58 = bitcast %System.RuntimeType addrspace(1)* %57 to %System.Type addrspace(1)*
+  %59 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %58)
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %64 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.Type addrspace(1)* %63, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = bitcast %System.RuntimeType addrspace(1)* %64 to %System.Type addrspace(1)*
+  %67 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %63, %System.Type addrspace(1)* %66)
+  %68 = zext i8 %67 to i32
+  %69 = trunc i32 %68 to i8
+  ret i8 %69
+
+; <label>:70                                      ; preds = %56
+  %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
+  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %73
+
+; <label>:73                                      ; preds = %70
+  %74 = load i64, i64 addrspace(1)* %72
+  %75 = add i64 %74, 128
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = add i64 %77, 0
+  %79 = inttoptr i64 %78 to i64*
+  %80 = load i64, i64* %79
+  %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
+  %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
+  %83 = call i8 %82(%System.Type addrspace(1)* %81)
+  %84 = zext i8 %83 to i32
+  %85 = icmp eq i32 %84, 0
+  br i1 %85, label %139, label %86
+
+; <label>:86                                      ; preds = %73
+  %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
+  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %89
+
+; <label>:89                                      ; preds = %86
+  %90 = load i64, i64 addrspace(1)* %88
+  %91 = add i64 %90, 128
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = add i64 %93, 24
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
+  %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
+  %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
+  store %"System.Type[]" addrspace(1)* %99, %"System.Type[]" addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %129
+
+; <label>:100                                     ; preds = %132
+  %101 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %102 = load i32, i32* %loc2
+  %NullCheck11 = icmp eq %"System.Type[]" addrspace(1)* %101, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %103
+
+; <label>:103                                     ; preds = %100
+  %104 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 1
+  %105 = load i32, i32 addrspace(1)* %104
+  %106 = zext i32 %105 to i64
+  %107 = zext i32 %102 to i64
+  %BoundsCheck = icmp uge i64 %107, %106
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %108
+
+; <label>:108                                     ; preds = %103
+  %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
+  %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
+  %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
+  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %113
+
+; <label>:113                                     ; preds = %108
+  %114 = load i64, i64 addrspace(1)* %112
+  %115 = add i64 %114, 152
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = add i64 %117, 56
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
+  %123 = zext i8 %122 to i32
+  %124 = icmp ne i32 %123, 0
+  br i1 %124, label %126, label %125
+
+; <label>:125                                     ; preds = %113
+  ret i8 0
+
+; <label>:126                                     ; preds = %113
+  %127 = load i32, i32* %loc2
+  %128 = add i32 %127, 1
+  store i32 %128, i32* %loc2
+  br label %129
+
+; <label>:129                                     ; preds = %89, %126
+  %130 = load i32, i32* %loc2
+  %131 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %NullCheck9 = icmp eq %"System.Type[]" addrspace(1)* %131, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %132
+
+; <label>:132                                     ; preds = %129
+  %133 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %131, i32 0, i32 1
+  %134 = load i32, i32 addrspace(1)* %133
+  %135 = zext i32 %134 to i64
+  %136 = trunc i64 %135 to i32
+  %137 = icmp slt i32 %130, %136
+  br i1 %137, label %100, label %138
+
+; <label>:138                                     ; preds = %132
+  ret i8 1
+
+; <label>:139                                     ; preds = %34, %73
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %129
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %103
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -2893,7 +3248,7 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElem]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -2904,8 +3259,8 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -2997,8 +3352,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
@@ -3059,8 +3414,8 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -3087,8 +3442,8 @@ entry:
 
 ; <label>:17                                      ; preds = %5, %11
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
@@ -3097,8 +3452,8 @@ entry:
 
 ; <label>:22                                      ; preds = %1, %11
   %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
@@ -3109,11 +3464,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %17
+ThrowNullRef2:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %22
+ThrowNullRef4:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3167,15 +3522,15 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
   %15 = load i32, i32 addrspace(1)* %14
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
@@ -3198,7 +3553,7 @@ ThrowNullRef:                                     ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef2:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3232,8 +3587,8 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
@@ -3312,8 +3667,8 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -3327,8 +3682,8 @@ entry:
 ; <label>:5                                       ; preds = %43
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %7 = load i32, i32* %loc1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck6, label %8, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
@@ -3366,8 +3721,8 @@ entry:
 ; <label>:32                                      ; preds = %21, %25
   %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
   %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
-  br i1 %NullCheck8, label %35, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = trunc i32 %34 to i16
@@ -3380,8 +3735,8 @@ entry:
 ; <label>:40                                      ; preds = %1, %35
   %41 = load i32, i32* %loc1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
-  br i1 %NullCheck2, label %43, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %42, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
@@ -3392,8 +3747,8 @@ entry:
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
   %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
-  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
   %51 = load i64, i64 addrspace(1)* %49
@@ -3412,19 +3767,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %40
+ThrowNullRef2:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %47
+ThrowNullRef4:                                    ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %5
+ThrowNullRef6:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %32
+ThrowNullRef8:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3467,8 +3822,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
@@ -3492,11 +3847,391 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(i16* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store i16* %param0, i16** %arg0
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load i32, i32* %arg3
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %42, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %37, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg2
+  %13 = load i32, i32* %arg3
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %37, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %24 = load i32, i32* %arg2
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load i16*, i16** %arg0
+  %35 = load i32, i32* %arg3
+  %36 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %36, i16* %34, i32 %35)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:37                                      ; preds = %5, %16
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %39)
+  %41 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41, %System.String addrspace(1)* %38, %System.String addrspace(1)* %40)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41) #0
+  unreachable
+
+; <label>:42                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
-Failed to read StringBuilder.ToString[loadElemA]
+Successfully read StringBuilder.ToString
+
+define %System.String addrspace(1)* @StringBuilder.ToString(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i16*
+  %loc3 = alloca %"System.Char[]" addrspace(1)*
+  %loc4 = alloca i32
+  %loc5 = alloca i32
+  %loc6 = alloca i16 addrspace(1)*
+  %loc7 = alloca %System.String addrspace(1)*
+  %loc8 = alloca %"System.Char[]" addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %0)
+  %2 = icmp ne i32 %1, 0
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %4
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %6)
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %7)
+  store %System.String addrspace(1)* %8, %System.String addrspace(1)** %loc0
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.Text.StringBuilder addrspace(1)* %9, %System.Text.StringBuilder addrspace(1)** %loc1
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  store %System.String addrspace(1)* %10, %System.String addrspace(1)** %loc7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc7
+  %12 = ptrtoint %System.String addrspace(1)* %11 to i64
+  %13 = icmp eq i64 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %5
+  %15 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %16 = sext i32 %15 to i64
+  %17 = add i64 %12, %16
+  br label %18
+
+; <label>:18                                      ; preds = %5, %14
+  %19 = phi i64 [ %12, %5 ], [ %17, %14 ]
+  %20 = inttoptr i64 %19 to i16*
+  store i16* %20, i16** %loc2
+  br label %21
+
+; <label>:21                                      ; preds = %98, %18
+  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %22, null
+  br i1 %NullCheck, label %ThrowNullRef, label %23
+
+; <label>:23                                      ; preds = %21
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 3
+  %25 = load i32, i32 addrspace(1)* %24, align 8
+  %26 = icmp sle i32 %25, 0
+  br i1 %26, label %96, label %27
+
+; <label>:27                                      ; preds = %23
+  %28 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %28, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %29
+
+; <label>:29                                      ; preds = %27
+  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %28, i32 0, i32 1
+  %31 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %30, align 8
+  store %"System.Char[]" addrspace(1)* %31, %"System.Char[]" addrspace(1)** %loc3
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %33
+
+; <label>:33                                      ; preds = %29
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  store i32 %35, i32* %loc4
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  %39 = load i32, i32 addrspace(1)* %38, align 8
+  store i32 %39, i32* %loc5
+  %40 = load i32, i32* %loc5
+  %41 = load i32, i32* %loc4
+  %42 = add i32 %40, %41
+  %43 = zext i32 %42 to i64
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %45
+
+; <label>:45                                      ; preds = %37
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = sext i32 %47 to i64
+  %49 = icmp sgt i64 %43, %48
+  br i1 %49, label %91, label %50
+
+; <label>:50                                      ; preds = %45
+  %51 = load i32, i32* %loc5
+  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %52, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %53
+
+; <label>:53                                      ; preds = %50
+  %54 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %52, i32 0, i32 1
+  %55 = load i32, i32 addrspace(1)* %54
+  %56 = zext i32 %55 to i64
+  %57 = trunc i64 %56 to i32
+  %58 = icmp ugt i32 %51, %57
+  br i1 %58, label %91, label %59
+
+; <label>:59                                      ; preds = %53
+  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  store %"System.Char[]" addrspace(1)* %60, %"System.Char[]" addrspace(1)** %loc8
+  %61 = icmp eq %"System.Char[]" addrspace(1)* %60, null
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %63, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %64
+
+; <label>:64                                      ; preds = %62
+  %65 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %63, i32 0, i32 1
+  %66 = load i32, i32 addrspace(1)* %65
+  %67 = zext i32 %66 to i64
+  %68 = trunc i64 %67 to i32
+  %69 = icmp ne i32 %68, 0
+  br i1 %69, label %71, label %70
+
+; <label>:70                                      ; preds = %59, %64
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:71                                      ; preds = %64
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %73
+
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %BoundsCheck = icmp uge i64 0, %76
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %77
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %78, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:79                                      ; preds = %70, %77
+  %80 = load i16*, i16** %loc2
+  %81 = load i32, i32* %loc4
+  %82 = sext i32 %81 to i64
+  %83 = mul i64 %82, 2
+  %84 = bitcast i16* %80 to i8*
+  %85 = getelementptr inbounds i8, i8* %84, i64 %83
+  %86 = load i16 addrspace(1)*, i16 addrspace(1)** %loc6
+  %87 = ptrtoint i16 addrspace(1)* %86 to i64
+  %88 = load i32, i32* %loc5
+  %89 = bitcast i8* %85 to i16*
+  %90 = inttoptr i64 %87 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %89, i16* %90, i32 %88)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %96
+
+; <label>:91                                      ; preds = %45, %53
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %94 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %93)
+  %95 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95, %System.String addrspace(1)* %92, %System.String addrspace(1)* %94)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95) #0
+  unreachable
+
+; <label>:96                                      ; preds = %23, %79
+  %97 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %97, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %98
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %97, i32 0, i32 2
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  store %System.Text.StringBuilder addrspace(1)* %100, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %102 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %102, label %21, label %103
+
+; <label>:103                                     ; preds = %98
+  store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc7
+  %104 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  ret %System.String addrspace(1)* %104
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method StringBuilder::get_Length using LLILCJit
+Successfully read StringBuilder.get_Length
+
+define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
+Successfully read RuntimeHelpers.get_OffsetToStringData
+
+define i32 @RuntimeHelpers.get_OffsetToStringData() {
+entry:
+  ret i32 12
+}
+
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
 Successfully read CultureData.CreateCultureData
 
@@ -3514,23 +4249,23 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
   store i8 %4, i8 addrspace(1)* %6
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
@@ -3549,11 +4284,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3566,50 +4301,50 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
   store i32 -1, i32 addrspace(1)* %2
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
   store i32 -1, i32 addrspace(1)* %8
   %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
   store i32 -1, i32 addrspace(1)* %14
   %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
   store i32 -1, i32 addrspace(1)* %17
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
@@ -3623,27 +4358,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3675,7 +4410,136 @@ Failed to read Dictionary`2.Insert[non-const derefAddress]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
 Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
-Failed to read HashHelpers.GetPrime[loadElem]
+Successfully read HashHelpers.GetPrime
+
+define i32 @HashHelpers.GetPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %6, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5, %System.String addrspace(1)* %4)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5) #0
+  unreachable
+
+; <label>:6                                       ; preds = %entry
+  store i32 0, i32* %loc0
+  br label %29
+
+; <label>:7                                       ; preds = %35
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 1296
+  %10 = addrspacecast i8 addrspace(1)* %9 to %"System.Int32[]" addrspace(1)**
+  %11 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %10
+  %12 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Int32[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = zext i32 %15 to i64
+  %17 = zext i32 %12 to i64
+  %BoundsCheck = icmp uge i64 %17, %16
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 3, i32 %12
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  store i32 %20, i32* %loc1
+  %21 = load i32, i32* %loc1
+  %22 = load i32, i32* %arg0
+  %23 = icmp slt i32 %21, %22
+  br i1 %23, label %26, label %24
+
+; <label>:24                                      ; preds = %18
+  %25 = load i32, i32* %loc1
+  ret i32 %25
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %loc0
+  %28 = add i32 %27, 1
+  store i32 %28, i32* %loc0
+  br label %29
+
+; <label>:29                                      ; preds = %6, %26
+  %30 = load i32, i32* %loc0
+  %31 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %32 = getelementptr inbounds i8, i8 addrspace(1)* %31, i64 1296
+  %33 = addrspacecast i8 addrspace(1)* %32 to %"System.Int32[]" addrspace(1)**
+  %34 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %33
+  %NullCheck = icmp eq %"System.Int32[]" addrspace(1)* %34, null
+  br i1 %NullCheck, label %ThrowNullRef, label %35
+
+; <label>:35                                      ; preds = %29
+  %36 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %34, i32 0, i32 1
+  %37 = load i32, i32 addrspace(1)* %36
+  %38 = zext i32 %37 to i64
+  %39 = trunc i64 %38 to i32
+  %40 = icmp slt i32 %30, %39
+  br i1 %40, label %7, label %41
+
+; <label>:41                                      ; preds = %35
+  %42 = load i32, i32* %arg0
+  %43 = or i32 %42, 1
+  store i32 %43, i32* %loc2
+  br label %59
+
+; <label>:44                                      ; preds = %59
+  %45 = load i32, i32* %loc2
+  %46 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %45)
+  %47 = zext i8 %46 to i32
+  %48 = icmp eq i32 %47, 0
+  br i1 %48, label %56, label %49
+
+; <label>:49                                      ; preds = %44
+  %50 = load i32, i32* %loc2
+  %51 = sub i32 %50, 1
+  %52 = srem i32 %51, 101
+  %53 = icmp eq i32 %52, 0
+  br i1 %53, label %56, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = load i32, i32* %loc2
+  ret i32 %55
+
+; <label>:56                                      ; preds = %44, %49
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %57, 2
+  store i32 %58, i32* %loc2
+  br label %59
+
+; <label>:59                                      ; preds = %41, %56
+  %60 = load i32, i32* %loc2
+  %61 = icmp slt i32 %60, 2147483647
+  br i1 %61, label %44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load i32, i32* %arg0
+  ret i32 %63
+
+ThrowNullRef:                                     ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
 Successfully read GenericEqualityComparer`1.GetHashCode
 
@@ -3694,14 +4558,14 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
   %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load i64, i64 addrspace(1)* %7
@@ -3720,7 +4584,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3750,8 +4614,8 @@ entry:
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
@@ -3796,8 +4660,8 @@ entry:
   %35 = bitcast i16* %34 to i8*
   %36 = getelementptr inbounds i8, i8* %35, i64 2
   %37 = bitcast i8* %36 to i16*
-  %NullCheck4 = icmp ne i16* %37, null
-  br i1 %NullCheck4, label %38, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %37, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %38
 
 ; <label>:38                                      ; preds = %27
   %39 = load i16, i16* %37, align 8
@@ -3824,8 +4688,8 @@ entry:
 
 ; <label>:54                                      ; preds = %22, %43
   %55 = load i16*, i16** %loc4
-  %NullCheck2 = icmp ne i16* %55, null
-  br i1 %NullCheck2, label %56, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i16* %55, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %56
 
 ; <label>:56                                      ; preds = %54
   %57 = load i16, i16* %55, align 8
@@ -3850,11 +4714,11 @@ ThrowNullRef:                                     ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %54
+ThrowNullRef2:                                    ; preds = %54
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %27
+ThrowNullRef4:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3871,8 +4735,8 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -3907,8 +4771,8 @@ entry:
 
 ; <label>:26                                      ; preds = %19
   %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
-  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %28
 
 ; <label>:28                                      ; preds = %26
   %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
@@ -3920,7 +4784,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3972,8 +4836,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
@@ -3984,26 +4848,26 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
-  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
@@ -4014,8 +4878,8 @@ entry:
 ; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
@@ -4024,8 +4888,8 @@ entry:
 
 ; <label>:25                                      ; preds = %1, %16, %23
   %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
-  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
@@ -4036,27 +4900,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %20
+ThrowNullRef10:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4069,8 +4933,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -4081,8 +4945,8 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
@@ -4091,8 +4955,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1, %8
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
@@ -4103,11 +4967,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4128,24 +4992,24 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   store i32 %3, i32* %loc0
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
   %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
   store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck4, label %9, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
@@ -4164,15 +5028,15 @@ entry:
 ; <label>:18                                      ; preds = %70
   %19 = load i16*, i16** %loc3
   %20 = bitcast i16* %19 to i64*
-  %NullCheck10 = icmp ne i64* %20, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %20, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = load i64, i64* %20, align 8
   %23 = load i16*, i16** %loc4
   %24 = bitcast i16* %23 to i64*
-  %NullCheck12 = icmp ne i64* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = load i64, i64* %24, align 8
@@ -4188,8 +5052,8 @@ entry:
   %31 = bitcast i16* %30 to i8*
   %32 = getelementptr inbounds i8, i8* %31, i64 8
   %33 = bitcast i8* %32 to i64*
-  %NullCheck14 = icmp ne i64* %33, null
-  br i1 %NullCheck14, label %34, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = load i64, i64* %33, align 8
@@ -4197,8 +5061,8 @@ entry:
   %37 = bitcast i16* %36 to i8*
   %38 = getelementptr inbounds i8, i8* %37, i64 8
   %39 = bitcast i8* %38 to i64*
-  %NullCheck16 = icmp ne i64* %39, null
-  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %40
 
 ; <label>:40                                      ; preds = %34
   %41 = load i64, i64* %39, align 8
@@ -4214,8 +5078,8 @@ entry:
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %NullCheck18 = icmp ne i64* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = load i64, i64* %48, align 8
@@ -4223,8 +5087,8 @@ entry:
   %52 = bitcast i16* %51 to i8*
   %53 = getelementptr inbounds i8, i8* %52, i64 16
   %54 = bitcast i8* %53 to i64*
-  %NullCheck20 = icmp ne i64* %54, null
-  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64* %54, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %55
 
 ; <label>:55                                      ; preds = %49
   %56 = load i64, i64* %54, align 8
@@ -4262,15 +5126,15 @@ entry:
 ; <label>:74                                      ; preds = %95
   %75 = load i16*, i16** %loc3
   %76 = bitcast i16* %75 to i32*
-  %NullCheck6 = icmp ne i32* %76, null
-  br i1 %NullCheck6, label %77, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32* %76, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %77
 
 ; <label>:77                                      ; preds = %74
   %78 = load i32, i32* %76, align 8
   %79 = load i16*, i16** %loc4
   %80 = bitcast i16* %79 to i32*
-  %NullCheck8 = icmp ne i32* %80, null
-  br i1 %NullCheck8, label %81, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i32* %80, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %81
 
 ; <label>:81                                      ; preds = %77
   %82 = load i32, i32* %80, align 8
@@ -4318,43 +5182,43 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %74
+ThrowNullRef6:                                    ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %77
+ThrowNullRef8:                                    ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %29
+ThrowNullRef14:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %34
+ThrowNullRef16:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4376,8 +5240,8 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load i64, i64 addrspace(1)* %4
@@ -4389,8 +5253,8 @@ entry:
   %12 = load i64, i64* %11
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %5
   %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
@@ -4399,8 +5263,8 @@ entry:
   %18 = load i8, i8* %arg2
   %19 = zext i8 %18 to i32
   %20 = trunc i32 %19 to i8
-  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %15
   %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
@@ -4411,11 +5275,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4442,8 +5306,8 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
@@ -4466,16 +5330,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
   %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = load i64, i64 addrspace(1)* %19
@@ -4500,8 +5364,8 @@ entry:
 ; <label>:35                                      ; preds = %30
   %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
@@ -4514,8 +5378,8 @@ entry:
 
 ; <label>:42                                      ; preds = %1, %38
   %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
-  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
@@ -4526,19 +5390,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %35
+ThrowNullRef2:                                    ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %42
+ThrowNullRef8:                                    ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4551,14 +5415,14 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
@@ -4570,7 +5434,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4583,8 +5447,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
@@ -4613,51 +5477,51 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
   %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
   %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
   %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
   %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
-  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
   store i64 %21, i64 addrspace(1)* %23
   %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %25 = load i64, i64* %loc0
-  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
@@ -4668,27 +5532,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %22
+ThrowNullRef12:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4701,8 +5565,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
@@ -4713,19 +5577,19 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
@@ -4734,8 +5598,8 @@ entry:
 
 ; <label>:15                                      ; preds = %1, %13
   %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
@@ -4746,19 +5610,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %15
+ThrowNullRef8:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4771,8 +5635,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -4831,8 +5695,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
@@ -4882,8 +5746,8 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
-  br i1 %NullCheck, label %17, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %ThrowNullRef, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
@@ -4894,15 +5758,15 @@ entry:
 
 ; <label>:22                                      ; preds = %17
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
-  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
   %26 = load i32, i32 addrspace(1)* %25
   %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
-  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %27, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
@@ -4925,8 +5789,8 @@ entry:
 ; <label>:40                                      ; preds = %17
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
-  br i1 %NullCheck6, label %43, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %41, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
@@ -4938,34 +5802,17 @@ ThrowNullRef:                                     ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %24
+ThrowNullRef4:                                    ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %40
+ThrowNullRef6:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
-}
-
-INFO:  jitting method Object::ReferenceEquals using LLILCJit
-Successfully read Object.ReferenceEquals
-
-define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
-entry:
-  %arg0 = alloca %System.Object addrspace(1)*
-  %arg1 = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
-  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
-  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = icmp eq %System.Object addrspace(1)* %0, %1
-  %3 = sext i1 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
 }
 
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
@@ -4978,21 +5825,21 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
   %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
-  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
@@ -5007,28 +5854,28 @@ entry:
 ; <label>:13                                      ; preds = %8, %12
   %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
   %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
   %21 = load i32, i32 addrspace(1)* %20, align 8
   %22 = add i32 %21, 1
-  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
   store i32 %22, i32 addrspace(1)* %24
   %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
@@ -5039,27 +5886,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5077,7 +5924,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::Setup using LLILCJit
-Failed to read AppDomain.Setup[loadElem]
+Failed to read AppDomain.Setup[unbox]
 INFO:  jitting method Thread::GetDomain using LLILCJit
 Successfully read Thread.GetDomain
 
@@ -5108,8 +5955,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
@@ -5122,14 +5969,14 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
   %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
@@ -5141,11 +5988,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5173,8 +6020,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -5189,7 +6036,328 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
 Failed to read KeyCollection.System.Collections.Generic.IEnumerable<TKey>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Successfully read Enumerator.MoveNext
+
+define i8 @Enumerator.MoveNext(%"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.RuntimeTypeHandle* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*
+  %"$TypeArg" = alloca %System.RuntimeTypeHandle*
+  store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
+  %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 8
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %76, label %12
+
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
+  br label %76
+
+; <label>:13                                      ; preds = %85
+  %14 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck19 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %15
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, i32 0, i32 0
+  %17 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %16, align 8
+  %NullCheck21 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, i32 0, i32 2
+  %20 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %19, align 8
+  %21 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck23 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %22
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, i32 0, i32 2
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %NullCheck25 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 3, i32 %24
+  %NullCheck27 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %32
+
+; <label>:32                                      ; preds = %30
+  %33 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, i32 0, i32 2
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = icmp slt i32 %34, 0
+  br i1 %35, label %68, label %36
+
+; <label>:36                                      ; preds = %32
+  %37 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %38 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck29 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %39
+
+; <label>:39                                      ; preds = %36
+  %40 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, i32 0, i32 0
+  %41 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %40, align 8
+  %NullCheck31 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, i32 0, i32 2
+  %44 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %43, align 8
+  %45 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck33 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, i32 0, i32 2
+  %48 = load i32, i32 addrspace(1)* %47, align 8
+  %NullCheck35 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %49
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = zext i32 %51 to i64
+  %53 = zext i32 %48 to i64
+  %BoundsCheck37 = icmp uge i64 %53, %52
+  br i1 %BoundsCheck37, label %ThrowIndexOutOfRange38, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 3, i32 %48
+  %NullCheck39 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %56
+
+; <label>:56                                      ; preds = %54
+  %57 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, i32 0, i32 0
+  %58 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck41 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %59
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %60, %System.__Canon addrspace(1)* %58)
+  %61 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck43 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  %64 = load i32, i32 addrspace(1)* %63, align 8
+  %65 = add i32 %64, 1
+  %NullCheck45 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  store i32 %65, i32 addrspace(1)* %67
+  ret i8 1
+
+; <label>:68                                      ; preds = %32
+  %69 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck47 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %73 = add i32 %72, 1
+  %NullCheck49 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %74
+
+; <label>:74                                      ; preds = %70
+  %75 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  store i32 %73, i32 addrspace(1)* %75
+  br label %76
+
+; <label>:76                                      ; preds = %8, %12, %74
+  %77 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %78
+
+; <label>:78                                      ; preds = %76
+  %79 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, i32 0, i32 2
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck7 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %82
+
+; <label>:82                                      ; preds = %78
+  %83 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, i32 0, i32 0
+  %84 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %83, align 8
+  %NullCheck9 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %85
+
+; <label>:85                                      ; preds = %82
+  %86 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, i32 0, i32 7
+  %87 = load i32, i32 addrspace(1)* %86, align 8
+  %88 = icmp ult i32 %80, %87
+  br i1 %88, label %13, label %89
+
+; <label>:89                                      ; preds = %85
+  %90 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %91 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck11 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %92
+
+; <label>:92                                      ; preds = %89
+  %93 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, i32 0, i32 0
+  %94 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck13 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %95
+
+; <label>:95                                      ; preds = %92
+  %96 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, i32 0, i32 7
+  %97 = load i32, i32 addrspace(1)* %96, align 8
+  %98 = add i32 %97, 1
+  %NullCheck15 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %99
+
+; <label>:99                                      ; preds = %95
+  %100 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, i32 0, i32 2
+  store i32 %98, i32 addrspace(1)* %100
+  %101 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck17 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %102
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %103, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %92
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef22:                                   ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef24:                                   ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef26:                                   ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef28:                                   ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef30:                                   ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef32:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef34:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef36:                                   ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange38:                           ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef40:                                   ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef42:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef44:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef46:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef48:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef50:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -5200,8 +6368,8 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -5232,9 +6400,9 @@ Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
 Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
-Failed to read String.MakeSeparatorList[loadElemA]
+Failed to read String.MakeSeparatorList[storeElem]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
-Failed to read String.InternalSplitKeepEmptyEntries[loadElem]
+Failed to read String.InternalSplitKeepEmptyEntries[storeElem]
 INFO:  jitting method Path::IsRelative using LLILCJit
 Successfully read Path.IsRelative
 
@@ -5243,8 +6411,8 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -5254,8 +6422,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
@@ -5271,8 +6439,8 @@ entry:
 
 ; <label>:17                                      ; preds = %7
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
@@ -5288,8 +6456,8 @@ entry:
 
 ; <label>:29                                      ; preds = %19
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %31
 
 ; <label>:31                                      ; preds = %29
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
@@ -5300,8 +6468,8 @@ entry:
 
 ; <label>:36                                      ; preds = %31
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
-  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %37, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
@@ -5312,8 +6480,8 @@ entry:
 
 ; <label>:43                                      ; preds = %31, %38
   %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
-  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %45
 
 ; <label>:45                                      ; preds = %43
   %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
@@ -5324,8 +6492,8 @@ entry:
 
 ; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %50
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
@@ -5336,8 +6504,8 @@ entry:
 
 ; <label>:57                                      ; preds = %1, %7, %19, %45, %52
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
-  br i1 %NullCheck14, label %59, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %59
 
 ; <label>:59                                      ; preds = %57
   %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
@@ -5347,8 +6515,8 @@ entry:
 
 ; <label>:63                                      ; preds = %59
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
@@ -5359,8 +6527,8 @@ entry:
 
 ; <label>:70                                      ; preds = %65
   %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
-  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.String addrspace(1)* %71, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %72
 
 ; <label>:72                                      ; preds = %70
   %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
@@ -5379,39 +6547,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %17
+ThrowNullRef4:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %29
+ThrowNullRef6:                                    ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %36
+ThrowNullRef8:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %43
+ThrowNullRef10:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %50
+ThrowNullRef12:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %57
+ThrowNullRef14:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %63
+ThrowNullRef16:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %70
+ThrowNullRef18:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5419,7 +6587,293 @@ ThrowNullRef17:                                   ; preds = %70
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
-Failed to read String.TrimHelper[loadElem]
+Successfully read String.TrimHelper
+
+define %System.String addrspace(1)* @String.TrimHelper(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i16
+  %loc4 = alloca i32
+  %loc5 = alloca i16
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = sub i32 %3, 1
+  store i32 %4, i32* %loc0
+  store i32 0, i32* %loc1
+  %5 = load i32, i32* %arg2
+  %6 = icmp eq i32 %5, 1
+  br i1 %6, label %62, label %7
+
+; <label>:7                                       ; preds = %1
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:8                                       ; preds = %58
+  store i32 0, i32* %loc2
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load i32, i32* %loc1
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2, i32 %10
+  %13 = load i16, i16 addrspace(1)* %12
+  %14 = zext i16 %13 to i32
+  %15 = trunc i32 %14 to i16
+  store i16 %15, i16* %loc3
+  store i32 0, i32* %loc2
+  br label %34
+
+; <label>:16                                      ; preds = %37
+  %17 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %18 = load i32, i32* %loc2
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %17, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %19
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = zext i32 %18 to i64
+  %BoundsCheck = icmp uge i64 %23, %22
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %24
+
+; <label>:24                                      ; preds = %19
+  %25 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 3, i32 %18
+  %26 = load i16, i16 addrspace(1)* %25, align 8
+  %27 = zext i16 %26 to i32
+  %28 = load i16, i16* %loc3
+  %29 = zext i16 %28 to i32
+  %30 = icmp eq i32 %27, %29
+  br i1 %30, label %43, label %31
+
+; <label>:31                                      ; preds = %24
+  %32 = load i32, i32* %loc2
+  %33 = add i32 %32, 1
+  store i32 %33, i32* %loc2
+  br label %34
+
+; <label>:34                                      ; preds = %11, %31
+  %35 = load i32, i32* %loc2
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = icmp slt i32 %35, %41
+  br i1 %42, label %16, label %43
+
+; <label>:43                                      ; preds = %24, %37
+  %44 = load i32, i32* %loc2
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %45, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp eq i32 %44, %50
+  br i1 %51, label %62, label %52
+
+; <label>:52                                      ; preds = %46
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %7, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %57, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %58
+
+; <label>:58                                      ; preds = %55
+  %59 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %60 = load i32, i32 addrspace(1)* %59
+  %61 = icmp slt i32 %56, %60
+  br i1 %61, label %8, label %62
+
+; <label>:62                                      ; preds = %1, %46, %58
+  %63 = load i32, i32* %arg2
+  %64 = icmp eq i32 %63, 0
+  br i1 %64, label %122, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %66, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %67
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %66, i32 0, i32 1
+  %69 = load i32, i32 addrspace(1)* %68
+  %70 = sub i32 %69, 1
+  store i32 %70, i32* %loc0
+  br label %118
+
+; <label>:71                                      ; preds = %118
+  store i32 0, i32* %loc4
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %73 = load i32, i32* %loc0
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %74
+
+; <label>:74                                      ; preds = %71
+  %75 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 2, i32 %73
+  %76 = load i16, i16 addrspace(1)* %75
+  %77 = zext i16 %76 to i32
+  %78 = trunc i32 %77 to i16
+  store i16 %78, i16* %loc5
+  store i32 0, i32* %loc4
+  br label %97
+
+; <label>:79                                      ; preds = %100
+  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %81 = load i32, i32* %loc4
+  %NullCheck19 = icmp eq %"System.Char[]" addrspace(1)* %80, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
+
+; <label>:82                                      ; preds = %79
+  %83 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 1
+  %84 = load i32, i32 addrspace(1)* %83
+  %85 = zext i32 %84 to i64
+  %86 = zext i32 %81 to i64
+  %BoundsCheck21 = icmp uge i64 %86, %85
+  br i1 %BoundsCheck21, label %ThrowIndexOutOfRange22, label %87
+
+; <label>:87                                      ; preds = %82
+  %88 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 3, i32 %81
+  %89 = load i16, i16 addrspace(1)* %88, align 8
+  %90 = zext i16 %89 to i32
+  %91 = load i16, i16* %loc5
+  %92 = zext i16 %91 to i32
+  %93 = icmp eq i32 %90, %92
+  br i1 %93, label %106, label %94
+
+; <label>:94                                      ; preds = %87
+  %95 = load i32, i32* %loc4
+  %96 = add i32 %95, 1
+  store i32 %96, i32* %loc4
+  br label %97
+
+; <label>:97                                      ; preds = %74, %94
+  %98 = load i32, i32* %loc4
+  %99 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck15 = icmp eq %"System.Char[]" addrspace(1)* %99, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %100
+
+; <label>:100                                     ; preds = %97
+  %101 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %99, i32 0, i32 1
+  %102 = load i32, i32 addrspace(1)* %101
+  %103 = zext i32 %102 to i64
+  %104 = trunc i64 %103 to i32
+  %105 = icmp slt i32 %98, %104
+  br i1 %105, label %79, label %106
+
+; <label>:106                                     ; preds = %87, %100
+  %107 = load i32, i32* %loc4
+  %108 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck17 = icmp eq %"System.Char[]" addrspace(1)* %108, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %109
+
+; <label>:109                                     ; preds = %106
+  %110 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %108, i32 0, i32 1
+  %111 = load i32, i32 addrspace(1)* %110
+  %112 = zext i32 %111 to i64
+  %113 = trunc i64 %112 to i32
+  %114 = icmp eq i32 %107, %113
+  br i1 %114, label %122, label %115
+
+; <label>:115                                     ; preds = %109
+  %116 = load i32, i32* %loc0
+  %117 = sub i32 %116, 1
+  store i32 %117, i32* %loc0
+  br label %118
+
+; <label>:118                                     ; preds = %67, %115
+  %119 = load i32, i32* %loc0
+  %120 = load i32, i32* %loc1
+  %121 = icmp sge i32 %119, %120
+  br i1 %121, label %71, label %122
+
+; <label>:122                                     ; preds = %62, %109, %118
+  %123 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %124 = load i32, i32* %loc1
+  %125 = load i32, i32* %loc0
+  %126 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %123, i32 %124, i32 %125)
+  ret %System.String addrspace(1)* %126
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %97
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange22:                           ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
 Successfully read String.CreateTrimmedString
 
@@ -5439,8 +6893,8 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
@@ -5535,8 +6989,8 @@ entry:
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i64 2872
   %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
   %8 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %7
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %3
   %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
@@ -5553,8 +7007,8 @@ entry:
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 2864
   %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
   %21 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %20
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
-  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %22
 
 ; <label>:22                                      ; preds = %16
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
@@ -5569,7 +7023,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %16
+ThrowNullRef2:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5586,8 +7040,8 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5613,8 +7067,8 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
@@ -5632,8 +7086,8 @@ entry:
 
 ; <label>:12                                      ; preds = %4
   %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
@@ -5644,8 +7098,8 @@ entry:
 
 ; <label>:19                                      ; preds = %14
   %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %19
   %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
@@ -5660,21 +7114,21 @@ entry:
   %31 = zext i16 %30 to i32
   %32 = bitcast i8* %29 to i16*
   %33 = trunc i32 %31 to i16
-  %NullCheck6 = icmp ne i16* %32, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i16* %32, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %21
   store i16 %33, i16* %32, align 8
   %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %36
 
 ; <label>:36                                      ; preds = %34
   %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
   %38 = load i32, i32 addrspace(1)* %37, align 8
   %39 = add i32 %38, 1
-  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %40
 
 ; <label>:40                                      ; preds = %36
   %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
@@ -5683,16 +7137,16 @@ entry:
 
 ; <label>:42                                      ; preds = %14
   %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
-  br i1 %NullCheck12, label %44, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
   %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
   %47 = load i16, i16* %arg1
   %48 = zext i16 %47 to i32
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = trunc i32 %48 to i16
@@ -5703,31 +7157,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %19
+ThrowNullRef4:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %21
+ThrowNullRef6:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %36
+ThrowNullRef10:                                   ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %42
+ThrowNullRef12:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %44
+ThrowNullRef14:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5740,8 +7194,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -5752,8 +7206,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
@@ -5762,14 +7216,14 @@ entry:
 
 ; <label>:11                                      ; preds = %1
   %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
@@ -5779,15 +7233,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5808,8 +7262,8 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5822,8 +7276,8 @@ entry:
 
 ; <label>:8                                       ; preds = %3
   %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
@@ -5842,15 +7296,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
-  br i1 %NullCheck4, label %22, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
   %24 = load i16*, i16* addrspace(1)* %23, align 8
   %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %25, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
@@ -5859,8 +7313,8 @@ entry:
   store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
@@ -5874,8 +7328,8 @@ entry:
 
 ; <label>:37                                      ; preds = %65
   %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %37
   %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
@@ -5886,16 +7340,16 @@ entry:
   %45 = bitcast i16* %41 to i8*
   %46 = getelementptr inbounds i8, i8* %45, i64 %44
   %47 = bitcast i8* %46 to i16*
-  %NullCheck14 = icmp ne i16* %47, null
-  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %47, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %48
 
 ; <label>:48                                      ; preds = %39
   %49 = load i16, i16* %47, align 8
   %50 = zext i16 %49 to i32
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %52 = load i32, i32* %loc1
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %53
 
 ; <label>:53                                      ; preds = %48
   %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
@@ -5916,8 +7370,8 @@ entry:
 ; <label>:62                                      ; preds = %36, %59
   %63 = load i32, i32* %loc1
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck10, label %65, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %65
 
 ; <label>:65                                      ; preds = %62
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
@@ -5936,15 +7390,15 @@ entry:
 
 ; <label>:74                                      ; preds = %70
   %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
-  br i1 %NullCheck18, label %76, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %76
 
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
   %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
-  br i1 %NullCheck20, label %80, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
   %81 = load i64, i64 addrspace(1)* %79
@@ -5958,8 +7412,8 @@ entry:
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
   %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
-  br i1 %NullCheck22, label %92, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.String addrspace(1)* %90, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %92
 
 ; <label>:92                                      ; preds = %80
   %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
@@ -5969,15 +7423,15 @@ entry:
 
 ; <label>:96                                      ; preds = %70
   %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
-  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %98
 
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
   %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
-  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
   %103 = load i64, i64 addrspace(1)* %101
@@ -5991,8 +7445,8 @@ entry:
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
   %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
-  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.String addrspace(1)* %112, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %114
 
 ; <label>:114                                     ; preds = %102
   %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
@@ -6004,59 +7458,59 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %20
+ThrowNullRef4:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %22
+ThrowNullRef6:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %26
+ThrowNullRef8:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %62
+ThrowNullRef10:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %48
+ThrowNullRef16:                                   ; preds = %48
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %74
+ThrowNullRef18:                                   ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %76
+ThrowNullRef20:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %80
+ThrowNullRef22:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %96
+ThrowNullRef24:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %98
+ThrowNullRef26:                                   ; preds = %98
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %102
+ThrowNullRef28:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6069,15 +7523,15 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
   %3 = load i16*, i16* addrspace(1)* %2, align 8
   %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
@@ -6087,8 +7541,8 @@ entry:
   %10 = bitcast i16* %3 to i8*
   %11 = getelementptr inbounds i8, i8* %10, i64 %9
   %12 = bitcast i8* %11 to i16*
-  %NullCheck4 = icmp ne i16* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %5
   store i16 0, i16* %12, align 8
@@ -6098,11 +7552,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6119,8 +7573,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -6131,8 +7585,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
@@ -6144,15 +7598,15 @@ entry:
 
 ; <label>:14                                      ; preds = %1
   %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
   %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
   %21 = load i64, i64 addrspace(1)* %19
@@ -6171,15 +7625,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %14
+ThrowNullRef4:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %16
+ThrowNullRef6:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6302,14 +7756,6 @@ entry:
   ret %System.String addrspace(1)* %57
 }
 
-INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
-Successfully read RuntimeHelpers.get_OffsetToStringData
-
-define i32 @RuntimeHelpers.get_OffsetToStringData() {
-entry:
-  ret i32 12
-}
-
 INFO:  jitting method String::Equals using LLILCJit
 Successfully read String.Equals
 
@@ -6381,8 +7827,8 @@ entry:
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
-  br i1 %NullCheck24, label %29, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
   %30 = load i64, i64 addrspace(1)* %28
@@ -6397,8 +7843,8 @@ entry:
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
-  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
   %43 = load i64, i64 addrspace(1)* %41
@@ -6418,8 +7864,8 @@ entry:
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
   %59 = load i64, i64 addrspace(1)* %57
@@ -6434,8 +7880,8 @@ entry:
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck22, label %71, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
   %72 = load i64, i64 addrspace(1)* %70
@@ -6455,8 +7901,8 @@ entry:
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
-  br i1 %NullCheck16, label %87, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = load i64, i64 addrspace(1)* %86
@@ -6471,8 +7917,8 @@ entry:
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck18, label %100, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
   %101 = load i64, i64 addrspace(1)* %99
@@ -6492,8 +7938,8 @@ entry:
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
-  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
   %117 = load i64, i64 addrspace(1)* %115
@@ -6508,8 +7954,8 @@ entry:
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
-  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
   %130 = load i64, i64 addrspace(1)* %128
@@ -6528,15 +7974,15 @@ entry:
 
 ; <label>:142                                     ; preds = %22
   %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
-  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %143, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %144
 
 ; <label>:144                                     ; preds = %142
   %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
   %146 = load i32, i32 addrspace(1)* %145
   %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
-  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %147, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %148
 
 ; <label>:148                                     ; preds = %144
   %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
@@ -6557,15 +8003,15 @@ entry:
 
 ; <label>:159                                     ; preds = %22
   %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
-  br i1 %NullCheck, label %161, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %ThrowNullRef, label %161
 
 ; <label>:161                                     ; preds = %159
   %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
   %163 = load i32, i32 addrspace(1)* %162
   %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
-  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %164, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %165
 
 ; <label>:165                                     ; preds = %161
   %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
@@ -6578,8 +8024,8 @@ entry:
 
 ; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
-  br i1 %NullCheck4, label %172, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %171, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %172
 
 ; <label>:172                                     ; preds = %170
   %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
@@ -6589,8 +8035,8 @@ entry:
 
 ; <label>:176                                     ; preds = %172
   %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
-  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %177, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %178
 
 ; <label>:178                                     ; preds = %176
   %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
@@ -6629,55 +8075,55 @@ ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %161
+ThrowNullRef2:                                    ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %170
+ThrowNullRef4:                                    ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %176
+ThrowNullRef6:                                    ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %142
+ThrowNullRef8:                                    ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %144
+ThrowNullRef10:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %113
+ThrowNullRef12:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %116
+ThrowNullRef14:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %84
+ThrowNullRef16:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %87
+ThrowNullRef18:                                   ; preds = %87
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %55
+ThrowNullRef20:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %58
+ThrowNullRef22:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %26
+ThrowNullRef24:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %29
+ThrowNullRef26:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,8 +8161,8 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck, label %14, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %ThrowNullRef, label %14
 
 ; <label>:14                                      ; preds = %8
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
@@ -6760,8 +8206,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
@@ -6770,14 +8216,14 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32, i32* %loc0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %10
   %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
   %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
@@ -6790,15 +8236,15 @@ entry:
 ; <label>:25                                      ; preds = %19
   %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
-  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
   %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
@@ -6807,8 +8253,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %37 = load i32, i32* %loc0
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %38, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %38
 
 ; <label>:38                                      ; preds = %32
   %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
@@ -6817,14 +8263,14 @@ entry:
 
 ; <label>:40                                      ; preds = %19
   %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %40
   %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
   %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
-  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
-  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
@@ -6832,8 +8278,8 @@ entry:
   %48 = zext i32 %47 to i64
   %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
-  br i1 %NullCheck16, label %51, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %51
 
 ; <label>:51                                      ; preds = %45
   %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
@@ -6847,15 +8293,15 @@ entry:
 ; <label>:57                                      ; preds = %51
   %58 = load i16*, i16** %arg1
   %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
-  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %60
 
 ; <label>:60                                      ; preds = %57
   %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
   %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
-  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %64
 
 ; <label>:64                                      ; preds = %60
   %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
@@ -6864,22 +8310,22 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
   %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
-  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %70
 
 ; <label>:70                                      ; preds = %64
   %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
   %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
-  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
-  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
   %75 = load i32, i32 addrspace(1)* %74
   %76 = zext i32 %75 to i64
   %77 = trunc i64 %76 to i32
-  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
-  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %78
 
 ; <label>:78                                      ; preds = %73
   %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
@@ -6901,8 +8347,8 @@ entry:
   %90 = bitcast i16* %86 to i8*
   %91 = getelementptr inbounds i8, i8* %90, i64 %89
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %93
 
 ; <label>:93                                      ; preds = %80
   %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
@@ -6912,8 +8358,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %99 = load i32, i32* %loc2
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %100
 
 ; <label>:100                                     ; preds = %93
   %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
@@ -6928,63 +8374,63 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %25
+ThrowNullRef6:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %32
+ThrowNullRef10:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %40
+ThrowNullRef12:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %45
+ThrowNullRef16:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %57
+ThrowNullRef18:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %60
+ThrowNullRef20:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %64
+ThrowNullRef22:                                   ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %70
+ThrowNullRef24:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %73
+ThrowNullRef26:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %80
+ThrowNullRef28:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %93
+ThrowNullRef30:                                   ; preds = %93
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7004,8 +8450,8 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
@@ -7033,43 +8479,43 @@ entry:
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %14
   %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
   %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   %28 = load i32, i32 addrspace(1)* %27, align 8
   %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
-  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %30
 
 ; <label>:30                                      ; preds = %26
   %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
   %32 = load i32, i32 addrspace(1)* %31, align 8
   %33 = add i32 %28, %32
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %34
 
 ; <label>:34                                      ; preds = %30
   %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   store i32 %33, i32 addrspace(1)* %35
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
   store i32 0, i32 addrspace(1)* %38
   %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %40
 
 ; <label>:40                                      ; preds = %37
   %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
@@ -7082,8 +8528,8 @@ entry:
 
 ; <label>:47                                      ; preds = %40
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
@@ -7098,8 +8544,8 @@ entry:
   %54 = load i32, i32* %loc0
   %55 = sext i32 %54 to i64
   %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
-  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %57
 
 ; <label>:57                                      ; preds = %52
   %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
@@ -7110,68 +8556,35 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %14
+ThrowNullRef2:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %23
+ThrowNullRef4:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %26
+ThrowNullRef6:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %30
+ThrowNullRef8:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %34
+ThrowNullRef10:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %47
+ThrowNullRef14:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %52
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-}
-
-INFO:  jitting method StringBuilder::get_Length using LLILCJit
-Successfully read StringBuilder.get_Length
-
-define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.StringBuilder addrspace(1)*
-  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
-  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
-
-; <label>:1                                       ; preds = %entry
-  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %3 = load i32, i32 addrspace(1)* %2, align 8
-  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
-
-; <label>:5                                       ; preds = %1
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = add i32 %3, %7
-  ret i32 %8
-
-ThrowNullRef:                                     ; preds = %entry
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef16:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7213,70 +8626,70 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
   %6 = load i32, i32 addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
   store i32 %6, i32 addrspace(1)* %8
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
   %13 = load i32, i32 addrspace(1)* %12, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
   store i32 %13, i32 addrspace(1)* %15
   %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
-  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %18
 
 ; <label>:18                                      ; preds = %14
   %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
   %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
   %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
   %34 = load i32, i32 addrspace(1)* %33, align 8
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
-  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
@@ -7287,39 +8700,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %28
+ThrowNullRef16:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %32
+ThrowNullRef18:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7455,13 +8868,13 @@ entry:
 ; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
@@ -7477,16 +8890,16 @@ entry:
 
 ; <label>:18                                      ; preds = %15
   %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
   store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
   %22 = load i32, i32* %loc0
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %24
 
 ; <label>:24                                      ; preds = %20
   %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
@@ -7498,13 +8911,13 @@ entry:
 ; <label>:28                                      ; preds = %15, %24
   %29 = load i32, i32* %arg1
   %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %31
   %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
@@ -7517,20 +8930,20 @@ entry:
   %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
-  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
   %46 = load i32, i32 addrspace(1)* %45, align 8
   %47 = sub i32 %40, %46
-  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
-  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i32 addrspace(1)* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %48
 
 ; <label>:48                                      ; preds = %44
   store i32 %47, i32 addrspace(1)* %39, align 8
@@ -7538,21 +8951,21 @@ entry:
 
 ; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
-  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %51
 
 ; <label>:51                                      ; preds = %49
   %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %53
 
 ; <label>:53                                      ; preds = %51
   %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
   %55 = load i32, i32 addrspace(1)* %54, align 8
   %56 = load i32, i32* %arg2
   %57 = sub i32 %55, %56
-  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %58
 
 ; <label>:58                                      ; preds = %53
   %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
@@ -7562,13 +8975,13 @@ entry:
 ; <label>:60                                      ; preds = %33, %58
   %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
   %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
-  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %63
 
 ; <label>:63                                      ; preds = %60
   %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
-  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
-  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
@@ -7578,15 +8991,15 @@ entry:
 
 ; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
-  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i32 addrspace(1)* %69, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %70
 
 ; <label>:70                                      ; preds = %68
   %71 = load i32, i32 addrspace(1)* %69, align 8
   store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
-  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
@@ -7596,8 +9009,8 @@ entry:
   store i32 %77, i32* %loc4
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
-  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %80
 
 ; <label>:80                                      ; preds = %73
   %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
@@ -7607,71 +9020,71 @@ entry:
 ; <label>:83                                      ; preds = %80
   store i32 0, i32* %loc3
   %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
-  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
-  br i1 %NullCheck26, label %88, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i32 addrspace(1)* %87, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %88
 
 ; <label>:88                                      ; preds = %85
   %89 = load i32, i32 addrspace(1)* %87, align 8
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
-  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %90
 
 ; <label>:90                                      ; preds = %88
   %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
   store i32 %89, i32 addrspace(1)* %91
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
-  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
-  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %96
 
 ; <label>:96                                      ; preds = %94
   %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
-  br i1 %NullCheck34, label %100, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %100
 
 ; <label>:100                                     ; preds = %96
   %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
-  br i1 %NullCheck36, label %102, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %102
 
 ; <label>:102                                     ; preds = %100
   %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
   %104 = load i32, i32 addrspace(1)* %103, align 8
   %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
-  br i1 %NullCheck38, label %106, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %106
 
 ; <label>:106                                     ; preds = %102
   %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
-  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
-  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %108
 
 ; <label>:108                                     ; preds = %106
   %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
   %110 = load i32, i32 addrspace(1)* %109, align 8
   %111 = add i32 %104, %110
-  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %112
 
 ; <label>:112                                     ; preds = %108
   %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
   store i32 %111, i32 addrspace(1)* %113
   %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
-  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i32 addrspace(1)* %114, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %115
 
 ; <label>:115                                     ; preds = %112
   %116 = load i32, i32 addrspace(1)* %114, align 8
@@ -7681,19 +9094,19 @@ entry:
 ; <label>:118                                     ; preds = %115
   %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
-  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %121
 
 ; <label>:121                                     ; preds = %118
   %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
-  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
-  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %123
 
 ; <label>:123                                     ; preds = %121
   %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
   %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
-  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
-  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %126
 
 ; <label>:126                                     ; preds = %123
   %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
@@ -7705,8 +9118,8 @@ entry:
 
 ; <label>:130                                     ; preds = %80, %115, %126
   %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %132
 
 ; <label>:132                                     ; preds = %130
   %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7715,8 +9128,8 @@ entry:
   %136 = load i32, i32* %loc3
   %137 = sub i32 %135, %136
   %138 = sub i32 %134, %137
-  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %139
 
 ; <label>:139                                     ; preds = %132
   %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7728,16 +9141,16 @@ entry:
 
 ; <label>:144                                     ; preds = %139
   %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
-  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %146
 
 ; <label>:146                                     ; preds = %144
   %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
   %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
   %149 = load i32, i32* %loc2
   %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
-  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %151
 
 ; <label>:151                                     ; preds = %146
   %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
@@ -7754,145 +9167,249 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %18
+ThrowNullRef4:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %31
+ThrowNullRef10:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %44
+ThrowNullRef16:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %68
+ThrowNullRef18:                                   ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %70
+ThrowNullRef20:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %73
+ThrowNullRef22:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %83
+ThrowNullRef24:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %85
+ThrowNullRef26:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %88
+ThrowNullRef28:                                   ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %90
+ThrowNullRef30:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %94
+ThrowNullRef32:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %96
+ThrowNullRef34:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %100
+ThrowNullRef36:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %102
+ThrowNullRef38:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %106
+ThrowNullRef40:                                   ; preds = %106
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %108
+ThrowNullRef42:                                   ; preds = %108
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %112
+ThrowNullRef44:                                   ; preds = %112
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %118
+ThrowNullRef46:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %121
+ThrowNullRef48:                                   ; preds = %121
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %123
+ThrowNullRef50:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %130
+ThrowNullRef52:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %132
+ThrowNullRef54:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %144
+ThrowNullRef56:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %146
+ThrowNullRef58:                                   ; preds = %146
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %60
+ThrowNullRef60:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %63
+ThrowNullRef62:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %49
+ThrowNullRef64:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %51
+ThrowNullRef66:                                   ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %53
+ThrowNullRef68:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(%"System.Char[]" addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %arg0 = alloca %"System.Char[]" addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store %"System.Char[]" addrspace(1)* %param0, %"System.Char[]" addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load i32, i32* %arg4
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %43, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %38, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg1
+  %13 = load i32, i32* %arg4
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %38, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %24 = load i32, i32* %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %35 = load i32, i32* %arg3
+  %36 = load i32, i32* %arg4
+  %37 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %37, %"System.Char[]" addrspace(1)* %34, i32 %35, i32 %36)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:38                                      ; preds = %5, %16
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Successfully read Buffer._Memmove
 
@@ -7914,7 +9431,7 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[loadElem]
+Failed to read AppDomain.SetDataHelper[storeElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -7923,8 +9440,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
@@ -7934,8 +9451,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
@@ -7947,15 +9464,15 @@ entry:
   %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
   %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
@@ -7966,15 +9483,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7992,7 +9509,79 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
-Failed to read Dictionary`2.TryGetValue[loadElemA]
+Successfully read Dictionary`2.TryGetValue
+
+define i8 @"Dictionary`2.TryGetValue"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)* addrspace(1)* %param2) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  %arg2 = alloca %System.__Canon addrspace(1)* addrspace(1)*
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  store %System.__Canon addrspace(1)* addrspace(1)* %param2, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  store i32 %2, i32* %loc0
+  %3 = load i32, i32* %loc0
+  %4 = icmp slt i32 %3, 0
+  br i1 %4, label %22, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 2
+  %10 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %9, align 8
+  %11 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = zext i32 %11 to i64
+  %BoundsCheck = icmp uge i64 %16, %15
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 3, i32 %11
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %20, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %6, %System.__Canon addrspace(1)* %21)
+  ret i8 1
+
+; <label>:22                                      ; preds = %entry
+  %23 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %23, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -8058,8 +9647,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
@@ -8091,8 +9680,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
@@ -8171,15 +9760,15 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck, label %19, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %ThrowNullRef, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
   %21 = load i32, i32 addrspace(1)* %20
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
@@ -8202,7 +9791,7 @@ ThrowNullRef:                                     ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %19
+ThrowNullRef2:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8248,8 +9837,8 @@ entry:
   %0 = alloca %System.AppDomainHandle
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %1 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %1, i32 0, i32 15
@@ -8269,8 +9858,8 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
@@ -8286,7 +9875,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -8299,8 +9888,8 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -8327,8 +9916,8 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
@@ -8352,8 +9941,8 @@ entry:
   %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
   store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
@@ -8363,8 +9952,8 @@ entry:
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
@@ -8374,8 +9963,8 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %9
   %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
@@ -8384,8 +9973,8 @@ entry:
 
 ; <label>:18                                      ; preds = %3, %16
   %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
@@ -8397,15 +9986,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %18
+ThrowNullRef6:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8418,8 +10007,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
@@ -8453,15 +10042,15 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
@@ -8473,7 +10062,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8481,7 +10070,7 @@ ThrowNullRef1:                                    ; preds = %1
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
 Failed to read Dictionary`2.System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
@@ -8506,8 +10095,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
@@ -8524,8 +10113,8 @@ entry:
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -8544,7 +10133,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8577,8 +10166,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = load i64, i64* %arg2
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = trunc i32 %3 to i8
@@ -8634,46 +10223,46 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
   %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
-  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
-  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
-  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
@@ -8684,27 +10273,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %20
+ThrowNullRef12:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8717,8 +10306,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -8756,22 +10345,22 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
   %9 = load i64, i64 addrspace(1)* %8, align 8
   %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
   %13 = load i64, i64 addrspace(1)* %12, align 8
   %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %11
   %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
@@ -8788,11 +10377,11 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8882,8 +10471,8 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
@@ -8900,8 +10489,8 @@ entry:
 ; <label>:8                                       ; preds = %1
   %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
   %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
@@ -8911,15 +10500,15 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
   %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
   %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
-  br i1 %NullCheck6, label %21, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
@@ -8946,15 +10535,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8992,15 +10581,15 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
   store i8 %3, i8 addrspace(1)* %5
   %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
@@ -9011,7 +10600,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9027,8 +10616,8 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -9041,8 +10630,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
@@ -9058,7 +10647,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9080,8 +10669,8 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
@@ -9096,8 +10685,8 @@ entry:
 ; <label>:12                                      ; preds = %6
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
@@ -9112,8 +10701,8 @@ entry:
 ; <label>:21                                      ; preds = %15
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
@@ -9128,8 +10717,8 @@ entry:
 ; <label>:30                                      ; preds = %24
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %31, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
@@ -9144,8 +10733,8 @@ entry:
 ; <label>:39                                      ; preds = %33
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
-  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %40, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %42
 
 ; <label>:42                                      ; preds = %39
   %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
@@ -9164,19 +10753,19 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %21
+ThrowNullRef4:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %30
+ThrowNullRef6:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %39
+ThrowNullRef8:                                    ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9243,8 +10832,8 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
@@ -9264,57 +10853,57 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
   store i8 0, i8 addrspace(1)* %2
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
   store i8 0, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
   store i8 0, i8 addrspace(1)* %17
   %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
   store i8 0, i8 addrspace(1)* %20
   %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
-  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
@@ -9325,31 +10914,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %19
+ThrowNullRef14:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9367,8 +10956,8 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
@@ -9380,8 +10969,8 @@ entry:
 
 ; <label>:9                                       ; preds = %4
   %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %9
   %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
@@ -9395,7 +10984,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef2:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9420,8 +11009,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
@@ -9512,8 +11101,8 @@ entry:
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
@@ -9524,8 +11113,8 @@ entry:
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = load i64, i64 addrspace(1)* %12
@@ -9537,8 +11126,8 @@ entry:
   %20 = load i64, i64* %19
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
-  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %13
   %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
@@ -9555,8 +11144,8 @@ entry:
 ; <label>:30                                      ; preds = %25
   %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %32 = load i32, i32* %arg2
-  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
-  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
@@ -9570,15 +11159,15 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %30
+ThrowNullRef2:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9622,87 +11211,87 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
   %10 = load i8, i8 addrspace(1)* %9, align 8
   %11 = zext i8 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %8
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
   store i8 %12, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
   %19 = load i8, i8 addrspace(1)* %18, align 8
   %20 = zext i8 %19 to i32
   %21 = trunc i32 %20 to i8
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
   store i8 %21, i8 addrspace(1)* %23
   %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
   %28 = load i8, i8 addrspace(1)* %27, align 8
   %29 = zext i8 %28 to i32
   %30 = trunc i32 %29 to i8
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
-  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %31
 
 ; <label>:31                                      ; preds = %26
   %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
   store i8 %30, i8 addrspace(1)* %32
   %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
-  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
-  br i1 %NullCheck14, label %40, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %40
 
 ; <label>:40                                      ; preds = %35
   %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
   store i8 %39, i8 addrspace(1)* %41
   %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
-  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %44
 
 ; <label>:44                                      ; preds = %40
   %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
   %46 = load i8, i8 addrspace(1)* %45, align 8
   %47 = zext i8 %46 to i32
   %48 = trunc i32 %47 to i8
-  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
   store i8 %48, i8 addrspace(1)* %50
   %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
-  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
@@ -9713,29 +11302,29 @@ entry:
 ; <label>:56                                      ; preds = %52
   %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
-  br i1 %NullCheck22, label %59, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
   %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
   %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
-  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
-  br i1 %NullCheck24, label %63, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
   %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
-  br i1 %NullCheck26, label %66, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
   %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
-  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
-  br i1 %NullCheck28, label %69, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %69
 
 ; <label>:69                                      ; preds = %66
   %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
@@ -9744,15 +11333,15 @@ entry:
 
 ; <label>:71                                      ; preds = %105
   %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
-  br i1 %NullCheck34, label %73, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %73
 
 ; <label>:73                                      ; preds = %71
   %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
   %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
   %76 = load i32, i32* %loc0
-  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
-  br i1 %NullCheck36, label %77, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
@@ -9766,8 +11355,8 @@ entry:
 
 ; <label>:83                                      ; preds = %77
   %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
-  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
@@ -9775,14 +11364,14 @@ entry:
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
   %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
-  br i1 %NullCheck40, label %91, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
 ; <label>:91                                      ; preds = %85
   %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
   %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
-  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck42, label %94, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %94
 
 ; <label>:94                                      ; preds = %91
   %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
@@ -9798,14 +11387,14 @@ entry:
 ; <label>:99                                      ; preds = %69, %96
   %100 = load i32, i32* %loc0
   %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
-  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %102
 
 ; <label>:102                                     ; preds = %99
   %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
   %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
-  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
-  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
@@ -9819,87 +11408,87 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %26
+ThrowNullRef10:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %31
+ThrowNullRef12:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %35
+ThrowNullRef14:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %40
+ThrowNullRef16:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %56
+ThrowNullRef22:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %59
+ThrowNullRef24:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %63
+ThrowNullRef26:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %66
+ThrowNullRef28:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %102
+ThrowNullRef32:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %71
+ThrowNullRef34:                                   ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %73
+ThrowNullRef36:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %83
+ThrowNullRef38:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %85
+ThrowNullRef40:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %91
+ThrowNullRef42:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9943,15 +11532,15 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
   %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
@@ -9961,28 +11550,28 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
   %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %12
   %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
   %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
   %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
-  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
@@ -9993,23 +11582,23 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %12
+ThrowNullRef6:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10031,15 +11620,15 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
   %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = load i64, i64 addrspace(1)* %7
@@ -10077,13 +11666,13 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[loadElem]
+Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -10111,8 +11700,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -10175,8 +11764,8 @@ entry:
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load double, double* %arg0
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -10310,8 +11899,8 @@ entry:
   store i64 %param0, i64* %arg0
   store i64 %param1, i64* %arg1
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
@@ -10319,8 +11908,8 @@ entry:
   %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
   %5 = load i16*, i16* addrspace(1)* %4, align 8
   %6 = addrspacecast i64* %arg1 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = bitcast i64 addrspace(1)* %6 to i8 addrspace(1)*
@@ -10336,7 +11925,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10370,8 +11959,8 @@ entry:
   %1 = load i32, i32* %arg1
   %2 = sext i32 %1 to i64
   %3 = inttoptr i64 %2 to i16*
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -10424,8 +12013,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, i32)*)(%System.IO.ConsoleStream addrspace(1)* %2, i32 %1)
   %3 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %4 = load i64, i64* %arg1
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
@@ -10436,8 +12025,8 @@ entry:
   %10 = icmp eq i32 %9, 3
   %11 = sext i1 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %5
   %14 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, i32 0, i32 5
@@ -10448,7 +12037,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10471,8 +12060,8 @@ entry:
   %5 = icmp eq i32 %4, 1
   %6 = sext i1 %5 to i32
   %7 = trunc i32 %6 to i8
-  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %2, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.ConsoleStream addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
@@ -10483,8 +12072,8 @@ entry:
   %13 = icmp eq i32 %12, 2
   %14 = sext i1 %13 to i32
   %15 = trunc i32 %14 to i8
-  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %10, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.ConsoleStream addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %8
   %17 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %10, i32 0, i32 4
@@ -10495,7 +12084,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10534,8 +12123,8 @@ entry:
   %arg0 = alloca i64
   store i64 %param0, i64* %arg0
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
@@ -10570,8 +12159,8 @@ entry:
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
   %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = load i64, i64 addrspace(1)* %7
@@ -10675,7 +12264,127 @@ entry:
 INFO:  jitting method Encoding::GetEncoding using LLILCJit
 Failed to read Encoding.GetEncoding[convertToHelperArgumentType]
 INFO:  jitting method EncodingProvider::GetEncodingFromProvider using LLILCJit
-Failed to read EncodingProvider.GetEncodingFromProvider[loadElem]
+Successfully read EncodingProvider.GetEncodingFromProvider
+
+define %System.Text.Encoding addrspace(1)* @EncodingProvider.GetEncodingFromProvider(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca %"System.Text.EncodingProvider[]" addrspace(1)*
+  %loc1 = alloca %System.Text.EncodingProvider addrspace(1)*
+  %loc2 = alloca %System.Text.Encoding addrspace(1)*
+  %loc3 = alloca %System.Text.Encoding addrspace(1)*
+  %loc4 = alloca %"System.Text.EncodingProvider[]" addrspace(1)*
+  %loc5 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1059)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2392
+  %2 = addrspacecast i8 addrspace(1)* %1 to %"System.Text.EncodingProvider[]" addrspace(1)**
+  %3 = load volatile %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %2
+  %4 = icmp ne %"System.Text.EncodingProvider[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %entry
+  ret %System.Text.Encoding addrspace(1)* null
+
+; <label>:6                                       ; preds = %entry
+  %7 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1059)
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i64 2392
+  %9 = addrspacecast i8 addrspace(1)* %8 to %"System.Text.EncodingProvider[]" addrspace(1)**
+  %10 = load volatile %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %9
+  store %"System.Text.EncodingProvider[]" addrspace(1)* %10, %"System.Text.EncodingProvider[]" addrspace(1)** %loc0
+  %11 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc0
+  store %"System.Text.EncodingProvider[]" addrspace(1)* %11, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  store i32 0, i32* %loc5
+  br label %43
+
+; <label>:12                                      ; preds = %46
+  %13 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  %14 = load i32, i32* %loc5
+  %NullCheck1 = icmp eq %"System.Text.EncodingProvider[]" addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %13, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = zext i32 %17 to i64
+  %19 = zext i32 %14 to i64
+  %BoundsCheck = icmp uge i64 %19, %18
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %20
+
+; <label>:20                                      ; preds = %15
+  %21 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %13, i32 0, i32 3, i32 %14
+  %22 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)* addrspace(1)* %21, align 8
+  store %System.Text.EncodingProvider addrspace(1)* %22, %System.Text.EncodingProvider addrspace(1)** %loc1
+  %23 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)** %loc1
+  %24 = load i32, i32* %arg0
+  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i64 addrspace(1)*
+  %NullCheck3 = icmp eq i64 addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
+
+; <label>:26                                      ; preds = %20
+  %27 = load i64, i64 addrspace(1)* %25
+  %28 = add i64 %27, 64
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 40
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Text.Encoding addrspace(1)* (%System.Text.EncodingProvider addrspace(1)*, i32)*
+  %35 = call %System.Text.Encoding addrspace(1)* %34(%System.Text.EncodingProvider addrspace(1)* %23, i32 %24)
+  store %System.Text.Encoding addrspace(1)* %35, %System.Text.Encoding addrspace(1)** %loc2
+  %36 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc2
+  %37 = icmp eq %System.Text.Encoding addrspace(1)* %36, null
+  br i1 %37, label %40, label %38
+
+; <label>:38                                      ; preds = %26
+  %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc2
+  store %System.Text.Encoding addrspace(1)* %39, %System.Text.Encoding addrspace(1)** %loc3
+  br label %53
+
+; <label>:40                                      ; preds = %26
+  %41 = load i32, i32* %loc5
+  %42 = add i32 %41, 1
+  store i32 %42, i32* %loc5
+  br label %43
+
+; <label>:43                                      ; preds = %6, %40
+  %44 = load i32, i32* %loc5
+  %45 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  %NullCheck = icmp eq %"System.Text.EncodingProvider[]" addrspace(1)* %45, null
+  br i1 %NullCheck, label %ThrowNullRef, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp slt i32 %44, %50
+  br i1 %51, label %12, label %52
+
+; <label>:52                                      ; preds = %46
+  ret %System.Text.Encoding addrspace(1)* null
+
+; <label>:53                                      ; preds = %38
+  %54 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc3
+  ret %System.Text.Encoding addrspace(1)* %54
+
+ThrowNullRef:                                     ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method EncodingProvider::.cctor using LLILCJit
 Successfully read EncodingProvider..cctor
 
@@ -10694,7 +12403,7 @@ Failed to read Encoding.get_InternalSyncObject[Call HasTypeArg]
 INFO:  jitting method Hashtable::.ctor using LLILCJit
 Failed to read Hashtable..ctor[Volatile store]
 INFO:  jitting method Hashtable::get_Item using LLILCJit
-Failed to read Hashtable.get_Item[loadElemA]
+Failed to read Hashtable.get_Item[loadNonPrimitiveObj]
 INFO:  jitting method Hashtable::InitHash using LLILCJit
 Successfully read Hashtable.InitHash
 
@@ -10714,8 +12423,8 @@ entry:
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -10731,15 +12440,15 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
   %15 = load i32, i32* %loc0
-  %NullCheck2 = icmp ne i32 addrspace(1)* %14, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i32 addrspace(1)* %14, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %3
   store i32 %15, i32 addrspace(1)* %14, align 8
   %17 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %18 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %NullCheck4 = icmp ne i32 addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i32 addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = load i32, i32 addrspace(1)* %18, align 8
@@ -10748,8 +12457,8 @@ entry:
   %23 = sub i32 %22, 1
   %24 = urem i32 %21, %23
   %25 = add i32 1, %24
-  %NullCheck6 = icmp ne i32 addrspace(1)* %17, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32 addrspace(1)* %17, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %19
   store i32 %25, i32 addrspace(1)* %17, align 8
@@ -10760,15 +12469,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %19
+ThrowNullRef6:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10783,8 +12492,8 @@ entry:
   store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
   store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %NullCheck = icmp ne %System.Collections.Hashtable addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Collections.Hashtable addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
@@ -10794,16 +12503,16 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Collections.Hashtable addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Collections.Hashtable addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
   %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck4 = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %9, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
   %13 = inttoptr i64 %11 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
@@ -10813,8 +12522,8 @@ entry:
 ; <label>:15                                      ; preds = %1
   %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -10832,15 +12541,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10854,8 +12563,8 @@ entry:
   store %System.Int32 addrspace(1)* %param0, %System.Int32 addrspace(1)** %this
   %0 = load %System.Int32 addrspace(1)*, %System.Int32 addrspace(1)** %this
   %1 = bitcast %System.Int32 addrspace(1)* %0 to i32 addrspace(1)*
-  %NullCheck = icmp ne i32 addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq i32 addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load i32, i32 addrspace(1)* %1, align 8
@@ -10931,8 +12640,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.UTF8Encoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
@@ -10941,15 +12650,15 @@ entry:
   %9 = load i8, i8* %arg2
   %10 = zext i8 %9 to i32
   %11 = trunc i32 %10 to i8
-  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %8, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %6
   %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %8, i32 0, i32 8
   store i8 %11, i8 addrspace(1)* %13
   %14 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %14, i32 0, i32 8
@@ -10961,8 +12670,8 @@ entry:
 ; <label>:20                                      ; preds = %15
   %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %22, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %22, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = load i64, i64 addrspace(1)* %22
@@ -10984,15 +12693,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %12
+ThrowNullRef4:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11007,8 +12716,8 @@ entry:
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
@@ -11030,16 +12739,16 @@ entry:
 ; <label>:10                                      ; preds = %1
   %11 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
   %12 = load i32, i32* %arg1
-  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %11, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.Encoding addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
   store i32 %12, i32 addrspace(1)* %14
   %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
   %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = load i64, i64 addrspace(1)* %16
@@ -11057,11 +12766,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11074,8 +12783,8 @@ entry:
   %this = alloca %System.Text.UTF8Encoding addrspace(1)*
   store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
   %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.UTF8Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
@@ -11087,16 +12796,16 @@ entry:
 ; <label>:6                                       ; preds = %1
   %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %8 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %10, %System.Text.EncoderFallback addrspace(1)* %8)
   %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %12 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
-  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %11, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %11, i32 0, i32 3
@@ -11109,8 +12818,8 @@ entry:
   %18 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %18, %System.String addrspace(1)* %17)
   %19 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %18 to %System.Text.EncoderFallback addrspace(1)*
-  %NullCheck6 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %16, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %16, i32 0, i32 2
@@ -11120,8 +12829,8 @@ entry:
   %24 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %24, %System.String addrspace(1)* %23)
   %25 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %24 to %System.Text.DecoderFallback addrspace(1)*
-  %NullCheck8 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %22, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %22, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %20
   %27 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %22, i32 0, i32 3
@@ -11132,19 +12841,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %20
+ThrowNullRef8:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11174,8 +12883,8 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load i32, i32* %arg1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -11193,8 +12902,8 @@ entry:
 ; <label>:15                                      ; preds = %8
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %17 = load i32, i32* %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 %17
@@ -11210,7 +12919,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11262,7 +12971,7 @@ entry:
 }
 
 INFO:  jitting method Hashtable::Insert using LLILCJit
-Failed to read Hashtable.Insert[loadElemA]
+Failed to read Hashtable.Insert[storeElem]
 INFO:  jitting method ConsoleEncoding::.ctor using LLILCJit
 Successfully read ConsoleEncoding..ctor
 
@@ -11277,8 +12986,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %1)
   %2 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
@@ -11314,8 +13023,8 @@ entry:
   %2 = call %System.Text.InternalEncoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalEncoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %1)
   %3 = bitcast %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2 to %System.Text.EncoderFallback addrspace(1)*
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
@@ -11325,8 +13034,8 @@ entry:
   %8 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %7)
   %9 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %8 to %System.Text.DecoderFallback addrspace(1)*
-  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %6, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.Encoding addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %4
   %11 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %6, i32 0, i32 3
@@ -11337,7 +13046,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11356,15 +13065,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* %1)
   %2 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   %6 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, i32 0, i32 1
@@ -11375,7 +13084,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11403,8 +13112,8 @@ entry:
   store %System.Text.InternalDecoderBestFitFallback addrspace(1)* %param0, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
   %0 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
@@ -11414,15 +13123,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %4)
   %5 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %6)
   %9 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, i32 0, i32 1
@@ -11433,11 +13142,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11505,8 +13214,8 @@ entry:
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
   %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = load i64, i64 addrspace(1)* %19
@@ -11570,8 +13279,8 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.ConsoleStream addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
@@ -11602,31 +13311,31 @@ entry:
   store i8 %param4, i8* %arg4
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %3, %System.IO.Stream addrspace(1)* %1)
   %4 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %4, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
   %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %4, i32 0, i32 4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %5)
   %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %6
   %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
   %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
   %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = load i64, i64 addrspace(1)* %13
@@ -11638,8 +13347,8 @@ entry:
   %21 = load i64, i64* %20
   %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %8, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %8, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %14
   %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 5
@@ -11657,24 +13366,24 @@ entry:
   %31 = load i32, i32* %arg3
   %32 = sext i32 %31 to i64
   %33 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %32)
-  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %30, null
-  br i1 %NullCheck10, label %34, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.StreamWriter addrspace(1)* %30, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %35, %"System.Char[]" addrspace(1)* %33)
   %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %37, null
-  br i1 %NullCheck12, label %38, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.StreamWriter addrspace(1)* %37, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %38
 
 ; <label>:38                                      ; preds = %34
   %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
   %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
   %41 = load i32, i32* %arg3
   %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %42, null
-  br i1 %NullCheck14, label %43, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %42, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
   %44 = load i64, i64 addrspace(1)* %42
@@ -11688,30 +13397,30 @@ entry:
   %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
   %53 = sext i32 %52 to i64
   %54 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %53)
-  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
-  br i1 %NullCheck16, label %55, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %55
 
 ; <label>:55                                      ; preds = %43
   %56 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %56, %"System.Byte[]" addrspace(1)* %54)
   %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %58 = load i32, i32* %arg3
-  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %57, null
-  br i1 %NullCheck18, label %59, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.StreamWriter addrspace(1)* %57, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %59
 
 ; <label>:59                                      ; preds = %55
   %60 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 10
   store i32 %58, i32 addrspace(1)* %60
   %61 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %61, null
-  br i1 %NullCheck20, label %62, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.IO.StreamWriter addrspace(1)* %61, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %62
 
 ; <label>:62                                      ; preds = %59
   %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
   %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
   %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
   %67 = load i64, i64 addrspace(1)* %65
@@ -11729,15 +13438,15 @@ entry:
 
 ; <label>:78                                      ; preds = %66
   %79 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %79, null
-  br i1 %NullCheck24, label %80, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.StreamWriter addrspace(1)* %79, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %80
 
 ; <label>:80                                      ; preds = %78
   %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
   %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
   %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %83, null
-  br i1 %NullCheck26, label %84, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %83, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
   %85 = load i64, i64 addrspace(1)* %83
@@ -11754,8 +13463,8 @@ entry:
 
 ; <label>:95                                      ; preds = %84
   %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.IO.StreamWriter addrspace(1)* %96, null
-  br i1 %NullCheck28, label %97, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.IO.StreamWriter addrspace(1)* %96, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %97
 
 ; <label>:97                                      ; preds = %95
   %98 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 12
@@ -11769,8 +13478,8 @@ entry:
   %103 = icmp eq i32 %102, 0
   %104 = sext i1 %103 to i32
   %105 = trunc i32 %104 to i8
-  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %100, null
-  br i1 %NullCheck30, label %106, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.IO.StreamWriter addrspace(1)* %100, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %106
 
 ; <label>:106                                     ; preds = %99
   %107 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %100, i32 0, i32 13
@@ -11781,63 +13490,63 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %6
+ThrowNullRef4:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %29
+ThrowNullRef10:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %34
+ThrowNullRef12:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %38
+ThrowNullRef14:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %43
+ThrowNullRef16:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %55
+ThrowNullRef18:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %59
+ThrowNullRef20:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %62
+ThrowNullRef22:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %78
+ThrowNullRef24:                                   ; preds = %78
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %80
+ThrowNullRef26:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %95
+ThrowNullRef28:                                   ; preds = %95
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11850,15 +13559,15 @@ entry:
   %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = load i64, i64 addrspace(1)* %4
@@ -11876,7 +13585,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11926,35 +13635,35 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
   %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderNLS addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %7 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.EncoderNLS addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Text.Encoding addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.Encoding addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Text.EncoderNLS addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.EncoderNLS addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
   %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck8 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = load i64, i64 addrspace(1)* %16
@@ -11973,19 +13682,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12011,8 +13720,8 @@ entry:
   %this = alloca %System.Text.Encoding addrspace(1)*
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
@@ -12032,15 +13741,15 @@ entry:
   %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
   store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
   %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
   store i32 0, i32 addrspace(1)* %2
   %3 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, i32 0, i32 2
@@ -12050,15 +13759,15 @@ entry:
 
 ; <label>:8                                       ; preds = %4
   %9 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
   %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
   %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = load i64, i64 addrspace(1)* %13
@@ -12079,15 +13788,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12102,16 +13811,16 @@ entry:
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = load i32, i32* %arg1
   %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
   %7 = load i64, i64 addrspace(1)* %5
@@ -12129,7 +13838,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12166,8 +13875,8 @@ entry:
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
   %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
   %16 = load i64, i64 addrspace(1)* %14
@@ -12188,8 +13897,8 @@ entry:
   %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
   %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
   %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %31, null
-  br i1 %NullCheck2, label %32, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = load i64, i64 addrspace(1)* %31
@@ -12232,7 +13941,7 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12245,14 +13954,14 @@ entry:
   %this = alloca %System.Text.EncoderReplacementFallback addrspace(1)*
   store %System.Text.EncoderReplacementFallback addrspace(1)* %param0, %System.Text.EncoderReplacementFallback addrspace(1)** %this
   %0 = load %System.Text.EncoderReplacementFallback addrspace(1)*, %System.Text.EncoderReplacementFallback addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -12263,7 +13972,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12293,8 +14002,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
@@ -12326,8 +14035,8 @@ entry:
   %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
   store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
@@ -12339,8 +14048,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Threading.Tasks.Task addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %7)
@@ -12363,7 +14072,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12382,8 +14091,8 @@ entry:
   store i8 %param1, i8* %arg1
   store i8 %param2, i8* %arg2
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
@@ -12397,8 +14106,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1, %5
   %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 9
@@ -12429,8 +14138,8 @@ entry:
 
 ; <label>:25                                      ; preds = %8, %20
   %26 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %26, null
-  br i1 %NullCheck4, label %27, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %26, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %26, i32 0, i32 12
@@ -12441,22 +14150,22 @@ entry:
 
 ; <label>:32                                      ; preds = %27
   %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %33, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.IO.StreamWriter addrspace(1)* %33, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %32
   %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 12
   store i8 1, i8 addrspace(1)* %35
   %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
-  br i1 %NullCheck8, label %37, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
   %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
   %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck10 = icmp ne i64 addrspace(1)* %40, null
-  br i1 %NullCheck10, label %41, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64 addrspace(1)* %40, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i64, i64 addrspace(1)* %40
@@ -12470,8 +14179,8 @@ entry:
   %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
   store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
   %51 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %NullCheck12 = icmp ne %"System.Byte[]" addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Byte[]" addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %41
   %53 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %51, i32 0, i32 1
@@ -12483,16 +14192,16 @@ entry:
 
 ; <label>:58                                      ; preds = %52
   %59 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %59, null
-  br i1 %NullCheck14, label %60, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.IO.StreamWriter addrspace(1)* %59, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %60
 
 ; <label>:60                                      ; preds = %58
   %61 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %59, i32 0, i32 3
   %62 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
   %64 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %NullCheck16 = icmp ne %"System.Byte[]" addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %"System.Byte[]" addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %60
   %66 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %64, i32 0, i32 1
@@ -12500,8 +14209,8 @@ entry:
   %68 = zext i32 %67 to i64
   %69 = trunc i64 %68 to i32
   %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck18, label %71, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
   %72 = load i64, i64 addrspace(1)* %70
@@ -12517,29 +14226,29 @@ entry:
 
 ; <label>:80                                      ; preds = %27, %52, %71
   %81 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %81, null
-  br i1 %NullCheck20, label %82, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.IO.StreamWriter addrspace(1)* %81, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
 
 ; <label>:82                                      ; preds = %80
   %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %81, i32 0, i32 5
   %84 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %83, align 8
   %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.IO.StreamWriter addrspace(1)* %85, null
-  br i1 %NullCheck22, label %86, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.IO.StreamWriter addrspace(1)* %85, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %86
 
 ; <label>:86                                      ; preds = %82
   %87 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 7
   %88 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %87, align 8
   %89 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %89, null
-  br i1 %NullCheck24, label %90, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.StreamWriter addrspace(1)* %89, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %90
 
 ; <label>:90                                      ; preds = %86
   %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %89, i32 0, i32 9
   %92 = load i32, i32 addrspace(1)* %91, align 8
   %93 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.IO.StreamWriter addrspace(1)* %93, null
-  br i1 %NullCheck26, label %94, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.IO.StreamWriter addrspace(1)* %93, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %93, i32 0, i32 6
@@ -12547,8 +14256,8 @@ entry:
   %97 = load i8, i8* %arg2
   %98 = zext i8 %97 to i32
   %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
-  %NullCheck28 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck28, label %100, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
   %101 = load i64, i64 addrspace(1)* %99
@@ -12563,8 +14272,8 @@ entry:
   %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
   store i32 %110, i32* %loc1
   %111 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %111, null
-  br i1 %NullCheck30, label %112, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.IO.StreamWriter addrspace(1)* %111, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %112
 
 ; <label>:112                                     ; preds = %100
   %113 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %111, i32 0, i32 9
@@ -12575,23 +14284,23 @@ entry:
 
 ; <label>:116                                     ; preds = %112
   %117 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck32 = icmp ne %System.IO.StreamWriter addrspace(1)* %117, null
-  br i1 %NullCheck32, label %118, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.IO.StreamWriter addrspace(1)* %117, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %118
 
 ; <label>:118                                     ; preds = %116
   %119 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %117, i32 0, i32 3
   %120 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %119, align 8
   %121 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.IO.StreamWriter addrspace(1)* %121, null
-  br i1 %NullCheck34, label %122, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.IO.StreamWriter addrspace(1)* %121, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %122
 
 ; <label>:122                                     ; preds = %118
   %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
   %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
   %125 = load i32, i32* %loc1
   %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
-  %NullCheck36 = icmp ne i64 addrspace(1)* %126, null
-  br i1 %NullCheck36, label %127, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64 addrspace(1)* %126, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
   %128 = load i64, i64 addrspace(1)* %126
@@ -12613,15 +14322,15 @@ entry:
 
 ; <label>:140                                     ; preds = %136
   %141 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.IO.StreamWriter addrspace(1)* %141, null
-  br i1 %NullCheck38, label %142, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.IO.StreamWriter addrspace(1)* %141, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %142
 
 ; <label>:142                                     ; preds = %140
   %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
   %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
   %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
-  %NullCheck40 = icmp ne i64 addrspace(1)* %145, null
-  br i1 %NullCheck40, label %146, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i64 addrspace(1)* %145, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
   %147 = load i64, i64 addrspace(1)* %145
@@ -12642,83 +14351,83 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %25
+ThrowNullRef4:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %32
+ThrowNullRef6:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %37
+ThrowNullRef10:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %41
+ThrowNullRef12:                                   ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %58
+ThrowNullRef14:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %60
+ThrowNullRef16:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %65
+ThrowNullRef18:                                   ; preds = %65
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %80
+ThrowNullRef20:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %82
+ThrowNullRef22:                                   ; preds = %82
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %86
+ThrowNullRef24:                                   ; preds = %86
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %90
+ThrowNullRef26:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %94
+ThrowNullRef28:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %100
+ThrowNullRef30:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %116
+ThrowNullRef32:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %118
+ThrowNullRef34:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %122
+ThrowNullRef36:                                   ; preds = %122
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %140
+ThrowNullRef38:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %142
+ThrowNullRef40:                                   ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12785,8 +14494,8 @@ entry:
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %1 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
-  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
@@ -12794,8 +14503,8 @@ entry:
   %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
   %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
   %8 = load i64, i64 addrspace(1)* %6
@@ -12811,8 +14520,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %17, %System.IFormatProvider addrspace(1)* %16)
   %18 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %19 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %18, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.SyncTextWriter addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %7
   %21 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %18, i32 0, i32 4
@@ -12823,11 +14532,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12840,8 +14549,8 @@ entry:
   %this = alloca %System.IO.TextWriter addrspace(1)*
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.TextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
@@ -12851,8 +14560,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.Threading.Thread addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Threading.Thread addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %6)
@@ -12861,8 +14570,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1
   %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.TextWriter addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.TextWriter addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %11, i32 0, i32 2
@@ -12873,11 +14582,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13074,8 +14783,8 @@ entry:
   store double %param1, double* %arg1
   store i8 0, i8* %loc1
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
@@ -13085,16 +14794,16 @@ entry:
   %5 = addrspacecast i8* %loc1 to i8 addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %4, i8 addrspace(1)* %5)
   %6 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.SyncTextWriter addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
   %10 = load double, double* %arg1
   %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
   %13 = load i64, i64 addrspace(1)* %11
@@ -13129,11 +14838,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13150,8 +14859,8 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load double, double* %arg1
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -13165,8 +14874,8 @@ entry:
   call void %11(%System.IO.TextWriter addrspace(1)* %0, double %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
   %15 = load i64, i64 addrspace(1)* %13
@@ -13184,7 +14893,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13202,8 +14911,8 @@ entry:
   %1 = addrspacecast double* %arg1 to double addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -13218,8 +14927,8 @@ entry:
   %14 = bitcast double addrspace(1)* %1 to %System.Double addrspace(1)*
   %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Double addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Double addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
   %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
   %18 = load i64, i64 addrspace(1)* %16
@@ -13237,7 +14946,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13253,8 +14962,8 @@ entry:
   store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
   %0 = load %System.Double addrspace(1)*, %System.Double addrspace(1)** %this
   %1 = bitcast %System.Double addrspace(1)* %0 to double addrspace(1)*
-  %NullCheck = icmp ne double addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq double addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load double, double addrspace(1)* %1, align 8
@@ -13279,8 +14988,8 @@ entry:
   %loc0 = alloca %System.Globalization.NumberFormatInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 3
@@ -13290,8 +14999,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
@@ -13301,24 +15010,24 @@ entry:
   store %System.Globalization.NumberFormatInfo addrspace(1)* %10, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
   %11 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %7
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
   %15 = load i8, i8 addrspace(1)* %14, align 8
   %16 = zext i8 %15 to i32
   %17 = trunc i32 %16 to i8
-  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %11, null
-  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %11, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %13
   %19 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %11, i32 0, i32 29
   store i8 %17, i8 addrspace(1)* %19
   %20 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %21 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %20, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %20, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %18
   %23 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %20, i32 0, i32 3
@@ -13327,8 +15036,8 @@ entry:
 
 ; <label>:24                                      ; preds = %1, %22
   %25 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %25, null
-  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %25, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %26
 
 ; <label>:26                                      ; preds = %24
   %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %25, i32 0, i32 3
@@ -13339,23 +15048,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %18
+ThrowNullRef8:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13380,168 +15089,168 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 18
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %8, align 8
-  %NullCheck2 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %5, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %5, i32 0, i32 4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %9)
   %12 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 19
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %15, align 8
-  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %12, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %12, i32 0, i32 5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %16)
   %19 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %20 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %20, null
-  br i1 %NullCheck8, label %21, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %20, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %20, i32 0, i32 23
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  %NullCheck10 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %19, null
-  br i1 %NullCheck10, label %24, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %19, i32 0, i32 7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %25, %System.String addrspace(1)* %23)
   %26 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %27 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %27, i32 0, i32 22
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %29, align 8
-  %NullCheck14 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %26, null
-  br i1 %NullCheck14, label %31, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %26, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %26, i32 0, i32 6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %32, %System.String addrspace(1)* %30)
   %33 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %34 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Globalization.CultureData addrspace(1)* %34, null
-  br i1 %NullCheck16, label %35, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Globalization.CultureData addrspace(1)* %34, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %34, i32 0, i32 51
   %37 = load i32, i32 addrspace(1)* %36, align 8
-  %NullCheck18 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %33, null
-  br i1 %NullCheck18, label %38, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %33, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %33, i32 0, i32 21
   store i32 %37, i32 addrspace(1)* %39
   %40 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %41 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Globalization.CultureData addrspace(1)* %41, null
-  br i1 %NullCheck20, label %42, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Globalization.CultureData addrspace(1)* %41, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %41, i32 0, i32 52
   %44 = load i32, i32 addrspace(1)* %43, align 8
-  %NullCheck22 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %40, null
-  br i1 %NullCheck22, label %45, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %40, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %40, i32 0, i32 25
   store i32 %44, i32 addrspace(1)* %46
   %47 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %48 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.Globalization.CultureData addrspace(1)* %48, null
-  br i1 %NullCheck24, label %49, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Globalization.CultureData addrspace(1)* %48, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %49
 
 ; <label>:49                                      ; preds = %45
   %50 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %48, i32 0, i32 29
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck26 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %47, null
-  br i1 %NullCheck26, label %52, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %47, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %47, i32 0, i32 10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %53, %System.String addrspace(1)* %51)
   %54 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %55 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Globalization.CultureData addrspace(1)* %55, null
-  br i1 %NullCheck28, label %56, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Globalization.CultureData addrspace(1)* %55, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %56
 
 ; <label>:56                                      ; preds = %52
   %57 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %55, i32 0, i32 35
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %57, align 8
-  %NullCheck30 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %54, null
-  br i1 %NullCheck30, label %59, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %54, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %54, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %60, %System.String addrspace(1)* %58)
   %61 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %62 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck32 = icmp ne %System.Globalization.CultureData addrspace(1)* %62, null
-  br i1 %NullCheck32, label %63, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Globalization.CultureData addrspace(1)* %62, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %62, i32 0, i32 34
   %65 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %64, align 8
-  %NullCheck34 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %61, null
-  br i1 %NullCheck34, label %66, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %61, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %61, i32 0, i32 9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %67, %System.String addrspace(1)* %65)
   %68 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %69 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck36 = icmp ne %System.Globalization.CultureData addrspace(1)* %69, null
-  br i1 %NullCheck36, label %70, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Globalization.CultureData addrspace(1)* %69, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %70
 
 ; <label>:70                                      ; preds = %66
   %71 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %69, i32 0, i32 55
   %72 = load i32, i32 addrspace(1)* %71, align 8
-  %NullCheck38 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %68, null
-  br i1 %NullCheck38, label %73, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %68, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %68, i32 0, i32 22
   store i32 %72, i32 addrspace(1)* %74
   %75 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %76 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck40 = icmp ne %System.Globalization.CultureData addrspace(1)* %76, null
-  br i1 %NullCheck40, label %77, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Globalization.CultureData addrspace(1)* %76, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %76, i32 0, i32 57
   %79 = load i32, i32 addrspace(1)* %78, align 8
-  %NullCheck42 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %75, null
-  br i1 %NullCheck42, label %80, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %75, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %80
 
 ; <label>:80                                      ; preds = %77
   %81 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %75, i32 0, i32 24
   store i32 %79, i32 addrspace(1)* %81
   %82 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %83 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck44 = icmp ne %System.Globalization.CultureData addrspace(1)* %83, null
-  br i1 %NullCheck44, label %84, label %ThrowNullRef43
+  %NullCheck43 = icmp eq %System.Globalization.CultureData addrspace(1)* %83, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %84
 
 ; <label>:84                                      ; preds = %80
   %85 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %83, i32 0, i32 56
   %86 = load i32, i32 addrspace(1)* %85, align 8
-  %NullCheck46 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %82, null
-  br i1 %NullCheck46, label %87, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %82, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %82, i32 0, i32 23
@@ -13550,8 +15259,8 @@ entry:
 
 ; <label>:89                                      ; preds = %entry
   %90 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck100 = icmp ne %System.Globalization.CultureData addrspace(1)* %90, null
-  br i1 %NullCheck100, label %91, label %ThrowNullRef99
+  %NullCheck99 = icmp eq %System.Globalization.CultureData addrspace(1)* %90, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %91
 
 ; <label>:91                                      ; preds = %89
   %92 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %90, i32 0, i32 2
@@ -13569,8 +15278,8 @@ entry:
   %102 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %103 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %104 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %103)
-  %NullCheck48 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %102, null
-  br i1 %NullCheck48, label %105, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %102, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %105
 
 ; <label>:105                                     ; preds = %101
   %106 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %102, i32 0, i32 1
@@ -13578,8 +15287,8 @@ entry:
   %107 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %108 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %109 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %108)
-  %NullCheck50 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %107, null
-  br i1 %NullCheck50, label %110, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %107, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %110
 
 ; <label>:110                                     ; preds = %105
   %111 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %107, i32 0, i32 2
@@ -13587,8 +15296,8 @@ entry:
   %112 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %113 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %114 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %113)
-  %NullCheck52 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %112, null
-  br i1 %NullCheck52, label %115, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %112, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %115
 
 ; <label>:115                                     ; preds = %110
   %116 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %112, i32 0, i32 27
@@ -13596,8 +15305,8 @@ entry:
   %117 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %118 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %119 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %118)
-  %NullCheck54 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %117, null
-  br i1 %NullCheck54, label %120, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %117, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %120
 
 ; <label>:120                                     ; preds = %115
   %121 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %117, i32 0, i32 26
@@ -13605,8 +15314,8 @@ entry:
   %122 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %123 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %124 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %123)
-  %NullCheck56 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %122, null
-  br i1 %NullCheck56, label %125, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %122, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %125
 
 ; <label>:125                                     ; preds = %120
   %126 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %122, i32 0, i32 17
@@ -13614,8 +15323,8 @@ entry:
   %127 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %128 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %129 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %128)
-  %NullCheck58 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %127, null
-  br i1 %NullCheck58, label %130, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %127, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %130
 
 ; <label>:130                                     ; preds = %125
   %131 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %127, i32 0, i32 18
@@ -13623,8 +15332,8 @@ entry:
   %132 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %133 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %134 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %133)
-  %NullCheck60 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %132, null
-  br i1 %NullCheck60, label %135, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %132, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %135
 
 ; <label>:135                                     ; preds = %130
   %136 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %132, i32 0, i32 14
@@ -13632,8 +15341,8 @@ entry:
   %137 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %138 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %139 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %138)
-  %NullCheck62 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %137, null
-  br i1 %NullCheck62, label %140, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %137, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %140
 
 ; <label>:140                                     ; preds = %135
   %141 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %137, i32 0, i32 13
@@ -13641,71 +15350,71 @@ entry:
   %142 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %143 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %144 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %143)
-  %NullCheck64 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %142, null
-  br i1 %NullCheck64, label %145, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %142, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %145
 
 ; <label>:145                                     ; preds = %140
   %146 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %142, i32 0, i32 12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %146, %System.String addrspace(1)* %144)
   %147 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %148 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck66 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %148, null
-  br i1 %NullCheck66, label %149, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %148, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %149
 
 ; <label>:149                                     ; preds = %145
   %150 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %148, i32 0, i32 21
   %151 = load i32, i32 addrspace(1)* %150, align 8
-  %NullCheck68 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %147, null
-  br i1 %NullCheck68, label %152, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %147, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %152
 
 ; <label>:152                                     ; preds = %149
   %153 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %147, i32 0, i32 28
   store i32 %151, i32 addrspace(1)* %153
   %154 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %155 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck70 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %155, null
-  br i1 %NullCheck70, label %156, label %ThrowNullRef69
+  %NullCheck69 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %155, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %156
 
 ; <label>:156                                     ; preds = %152
   %157 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %155, i32 0, i32 6
   %158 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %157, align 8
-  %NullCheck72 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %154, null
-  br i1 %NullCheck72, label %159, label %ThrowNullRef71
+  %NullCheck71 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %154, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %159
 
 ; <label>:159                                     ; preds = %156
   %160 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %154, i32 0, i32 15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %160, %System.String addrspace(1)* %158)
   %161 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %162 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck74 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %162, null
-  br i1 %NullCheck74, label %163, label %ThrowNullRef73
+  %NullCheck73 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %162, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %163
 
 ; <label>:163                                     ; preds = %159
   %164 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %162, i32 0, i32 1
   %165 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %164, align 8
-  %NullCheck76 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %161, null
-  br i1 %NullCheck76, label %166, label %ThrowNullRef75
+  %NullCheck75 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %161, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %166
 
 ; <label>:166                                     ; preds = %163
   %167 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %161, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %167, %"System.Int32[]" addrspace(1)* %165)
   %168 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %169 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck78 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %169, null
-  br i1 %NullCheck78, label %170, label %ThrowNullRef77
+  %NullCheck77 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %169, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %170
 
 ; <label>:170                                     ; preds = %166
   %171 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %169, i32 0, i32 7
   %172 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %171, align 8
-  %NullCheck80 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %168, null
-  br i1 %NullCheck80, label %173, label %ThrowNullRef79
+  %NullCheck79 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %168, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %173
 
 ; <label>:173                                     ; preds = %170
   %174 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %168, i32 0, i32 16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %174, %System.String addrspace(1)* %172)
   %175 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck82 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %175, null
-  br i1 %NullCheck82, label %176, label %ThrowNullRef81
+  %NullCheck81 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %175, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %176
 
 ; <label>:176                                     ; preds = %173
   %177 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %175, i32 0, i32 4
@@ -13715,14 +15424,14 @@ entry:
 
 ; <label>:180                                     ; preds = %176
   %181 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck84 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %181, null
-  br i1 %NullCheck84, label %182, label %ThrowNullRef83
+  %NullCheck83 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %181, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %182
 
 ; <label>:182                                     ; preds = %180
   %183 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %181, i32 0, i32 4
   %184 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %183, align 8
-  %NullCheck86 = icmp ne %System.String addrspace(1)* %184, null
-  br i1 %NullCheck86, label %185, label %ThrowNullRef85
+  %NullCheck85 = icmp eq %System.String addrspace(1)* %184, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %185
 
 ; <label>:185                                     ; preds = %182
   %186 = getelementptr inbounds %System.String, %System.String addrspace(1)* %184, i32 0, i32 1
@@ -13733,8 +15442,8 @@ entry:
 ; <label>:189                                     ; preds = %176, %185
   %190 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck98 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %190, null
-  br i1 %NullCheck98, label %192, label %ThrowNullRef97
+  %NullCheck97 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %190, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %192
 
 ; <label>:192                                     ; preds = %189
   %193 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %190, i32 0, i32 4
@@ -13743,8 +15452,8 @@ entry:
 
 ; <label>:194                                     ; preds = %185, %192
   %195 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck88 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %195, null
-  br i1 %NullCheck88, label %196, label %ThrowNullRef87
+  %NullCheck87 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %195, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %196
 
 ; <label>:196                                     ; preds = %194
   %197 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %195, i32 0, i32 9
@@ -13754,14 +15463,14 @@ entry:
 
 ; <label>:200                                     ; preds = %196
   %201 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck90 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %201, null
-  br i1 %NullCheck90, label %202, label %ThrowNullRef89
+  %NullCheck89 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %201, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %202
 
 ; <label>:202                                     ; preds = %200
   %203 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %201, i32 0, i32 9
   %204 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %203, align 8
-  %NullCheck92 = icmp ne %System.String addrspace(1)* %204, null
-  br i1 %NullCheck92, label %205, label %ThrowNullRef91
+  %NullCheck91 = icmp eq %System.String addrspace(1)* %204, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %205
 
 ; <label>:205                                     ; preds = %202
   %206 = getelementptr inbounds %System.String, %System.String addrspace(1)* %204, i32 0, i32 1
@@ -13772,14 +15481,14 @@ entry:
 ; <label>:209                                     ; preds = %196, %205
   %210 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %211 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck94 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %211, null
-  br i1 %NullCheck94, label %212, label %ThrowNullRef93
+  %NullCheck93 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %211, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %212
 
 ; <label>:212                                     ; preds = %209
   %213 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %211, i32 0, i32 6
   %214 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %213, align 8
-  %NullCheck96 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %210, null
-  br i1 %NullCheck96, label %215, label %ThrowNullRef95
+  %NullCheck95 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %210, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %215
 
 ; <label>:215                                     ; preds = %212
   %216 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %210, i32 0, i32 9
@@ -13793,203 +15502,203 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %17
+ThrowNullRef8:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %21
+ThrowNullRef10:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %24
+ThrowNullRef12:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %28
+ThrowNullRef14:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %31
+ThrowNullRef16:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %35
+ThrowNullRef18:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %38
+ThrowNullRef20:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %42
+ThrowNullRef22:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %45
+ThrowNullRef24:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %49
+ThrowNullRef26:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %52
+ThrowNullRef28:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %56
+ThrowNullRef30:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %59
+ThrowNullRef32:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %63
+ThrowNullRef34:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %66
+ThrowNullRef36:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %70
+ThrowNullRef38:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %73
+ThrowNullRef40:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %77
+ThrowNullRef42:                                   ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %80
+ThrowNullRef44:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %84
+ThrowNullRef46:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %101
+ThrowNullRef48:                                   ; preds = %101
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %105
+ThrowNullRef50:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %110
+ThrowNullRef52:                                   ; preds = %110
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %115
+ThrowNullRef54:                                   ; preds = %115
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %120
+ThrowNullRef56:                                   ; preds = %120
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %125
+ThrowNullRef58:                                   ; preds = %125
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %130
+ThrowNullRef60:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %135
+ThrowNullRef62:                                   ; preds = %135
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %140
+ThrowNullRef64:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %145
+ThrowNullRef66:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %149
+ThrowNullRef68:                                   ; preds = %149
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %152
+ThrowNullRef70:                                   ; preds = %152
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %156
+ThrowNullRef72:                                   ; preds = %156
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %159
+ThrowNullRef74:                                   ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %163
+ThrowNullRef76:                                   ; preds = %163
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %166
+ThrowNullRef78:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %170
+ThrowNullRef80:                                   ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %173
+ThrowNullRef82:                                   ; preds = %173
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %180
+ThrowNullRef84:                                   ; preds = %180
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %182
+ThrowNullRef86:                                   ; preds = %182
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %194
+ThrowNullRef88:                                   ; preds = %194
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %200
+ThrowNullRef90:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %202
+ThrowNullRef92:                                   ; preds = %202
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %209
+ThrowNullRef94:                                   ; preds = %209
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %212
+ThrowNullRef96:                                   ; preds = %212
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %189
+ThrowNullRef98:                                   ; preds = %189
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %89
+ThrowNullRef100:                                  ; preds = %89
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14017,8 +15726,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 21
@@ -14031,8 +15740,8 @@ entry:
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 16)
   %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 21
@@ -14041,8 +15750,8 @@ entry:
 
 ; <label>:12                                      ; preds = %1, %10
   %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 21
@@ -14053,11 +15762,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %12
+ThrowNullRef4:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14073,8 +15782,8 @@ entry:
   store i32 %param1, i32* %arg1
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %1 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
@@ -14141,8 +15850,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 33
@@ -14155,8 +15864,8 @@ entry:
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 24)
   %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 33
@@ -14165,8 +15874,8 @@ entry:
 
 ; <label>:12                                      ; preds = %1, %10
   %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 33
@@ -14177,11 +15886,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %12
+ThrowNullRef4:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14194,8 +15903,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 53
@@ -14207,8 +15916,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 116)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 53
@@ -14217,8 +15926,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 53
@@ -14229,11 +15938,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14262,8 +15971,8 @@ entry:
 
 ; <label>:7                                       ; preds = %entry, %4
   %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %7
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 2
@@ -14287,8 +15996,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 54
@@ -14300,8 +16009,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 117)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
@@ -14310,8 +16019,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 54
@@ -14322,11 +16031,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14339,8 +16048,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 27
@@ -14352,8 +16061,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 118)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 27
@@ -14362,8 +16071,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 27
@@ -14374,11 +16083,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14391,8 +16100,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 28
@@ -14404,8 +16113,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 119)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 28
@@ -14414,8 +16123,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 28
@@ -14426,11 +16135,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14443,8 +16152,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 26
@@ -14456,8 +16165,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 107)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 26
@@ -14466,8 +16175,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 26
@@ -14478,11 +16187,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14495,8 +16204,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 25
@@ -14508,8 +16217,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 106)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 25
@@ -14518,8 +16227,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 25
@@ -14530,11 +16239,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14547,8 +16256,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 24
@@ -14560,8 +16269,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 105)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 24
@@ -14570,8 +16279,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 24
@@ -14582,11 +16291,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14611,8 +16320,8 @@ entry:
   %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %3)
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %2
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -14623,15 +16332,15 @@ entry:
 
 ; <label>:8                                       ; preds = %62
   %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 9
   %12 = load i32, i32 addrspace(1)* %11, align 8
   %13 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.IO.StreamWriter addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %13, i32 0, i32 10
@@ -14646,15 +16355,15 @@ entry:
 
 ; <label>:20                                      ; preds = %14, %18
   %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
   %24 = load i32, i32 addrspace(1)* %23, align 8
   %25 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %25, null
-  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.StreamWriter addrspace(1)* %25, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %25, i32 0, i32 9
@@ -14675,36 +16384,36 @@ entry:
   %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %37 = load i32, i32* %loc1
   %38 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.StreamWriter addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %35
   %40 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %38, i32 0, i32 7
   %41 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %40, align 8
   %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
-  br i1 %NullCheck14, label %43, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %39
   %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 9
   %45 = load i32, i32 addrspace(1)* %44, align 8
   %46 = load i32, i32* %loc2
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %36, null
-  br i1 %NullCheck16, label %47, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %36, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %47
 
 ; <label>:47                                      ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %36, i32 %37, %"System.Char[]" addrspace(1)* %41, i32 %45, i32 %46)
   %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
   %51 = load i32, i32 addrspace(1)* %50, align 8
   %52 = load i32, i32* %loc2
   %53 = add i32 %51, %52
-  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
-  br i1 %NullCheck20, label %54, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %54
 
 ; <label>:54                                      ; preds = %49
   %55 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
@@ -14726,8 +16435,8 @@ entry:
 
 ; <label>:65                                      ; preds = %62
   %66 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %66, null
-  br i1 %NullCheck2, label %67, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %66, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %67
 
 ; <label>:67                                      ; preds = %65
   %68 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %66, i32 0, i32 11
@@ -14748,49 +16457,259 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %65
+ThrowNullRef2:                                    ; preds = %65
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %20
+ThrowNullRef8:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %22
+ThrowNullRef10:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %35
+ThrowNullRef12:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %43
+ThrowNullRef16:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %47
+ThrowNullRef18:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method String::CopyTo using LLILCJit
-Failed to read String.CopyTo[loadElemA]
+Successfully read String.CopyTo
+
+define void @String.CopyTo(%System.String addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  %loc1 = alloca i16 addrspace(1)*
+  %loc2 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %1 = icmp ne %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg4
+  %7 = icmp sge i32 %6, 0
+  br i1 %7, label %13, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  unreachable
+
+; <label>:13                                      ; preds = %5
+  %14 = load i32, i32* %arg1
+  %15 = icmp sge i32 %14, 0
+  br i1 %15, label %21, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %18)
+  %20 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %20, %System.String addrspace(1)* %17, %System.String addrspace(1)* %19)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %20) #0
+  unreachable
+
+; <label>:21                                      ; preds = %13
+  %22 = load i32, i32* %arg4
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck, label %ThrowNullRef, label %24
+
+; <label>:24                                      ; preds = %21
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load i32, i32* %arg1
+  %28 = sub i32 %26, %27
+  %29 = icmp sle i32 %22, %28
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34, %System.String addrspace(1)* %31, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %24
+  %36 = load i32, i32* %arg3
+  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %37, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
+
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
+  %40 = load i32, i32 addrspace(1)* %39
+  %41 = zext i32 %40 to i64
+  %42 = trunc i64 %41 to i32
+  %43 = load i32, i32* %arg4
+  %44 = sub i32 %42, %43
+  %45 = icmp sgt i32 %36, %44
+  br i1 %45, label %49, label %46
+
+; <label>:46                                      ; preds = %38
+  %47 = load i32, i32* %arg3
+  %48 = icmp sge i32 %47, 0
+  br i1 %48, label %54, label %49
+
+; <label>:49                                      ; preds = %38, %46
+  %50 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %52 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %51)
+  %53 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53, %System.String addrspace(1)* %50, %System.String addrspace(1)* %52)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53) #0
+  unreachable
+
+; <label>:54                                      ; preds = %46
+  %55 = load i32, i32* %arg4
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %97, label %57
+
+; <label>:57                                      ; preds = %54
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %59
+
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 2
+  %61 = bitcast [0 x i16] addrspace(1)* %60 to i16 addrspace(1)*
+  store i16 addrspace(1)* %61, i16 addrspace(1)** %loc0
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  store %"System.Char[]" addrspace(1)* %62, %"System.Char[]" addrspace(1)** %loc2
+  %63 = icmp eq %"System.Char[]" addrspace(1)* %62, null
+  br i1 %63, label %72, label %64
+
+; <label>:64                                      ; preds = %59
+  %65 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc2
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %65, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %66
+
+; <label>:66                                      ; preds = %64
+  %67 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %65, i32 0, i32 1
+  %68 = load i32, i32 addrspace(1)* %67
+  %69 = zext i32 %68 to i64
+  %70 = trunc i64 %69 to i32
+  %71 = icmp ne i32 %70, 0
+  br i1 %71, label %73, label %72
+
+; <label>:72                                      ; preds = %59, %66
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  br label %81
+
+; <label>:73                                      ; preds = %66
+  %74 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc2
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %74, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %75
+
+; <label>:75                                      ; preds = %73
+  %76 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %74, i32 0, i32 1
+  %77 = load i32, i32 addrspace(1)* %76
+  %78 = zext i32 %77 to i64
+  %BoundsCheck = icmp uge i64 0, %78
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %79
+
+; <label>:79                                      ; preds = %75
+  %80 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %74, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %80, i16 addrspace(1)** %loc1
+  br label %81
+
+; <label>:81                                      ; preds = %72, %79
+  %82 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %83 = ptrtoint i16 addrspace(1)* %82 to i64
+  %84 = load i32, i32* %arg3
+  %85 = sext i32 %84 to i64
+  %86 = mul i64 %85, 2
+  %87 = add i64 %83, %86
+  %88 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %89 = ptrtoint i16 addrspace(1)* %88 to i64
+  %90 = load i32, i32* %arg1
+  %91 = sext i32 %90 to i64
+  %92 = mul i64 %91, 2
+  %93 = add i64 %89, %92
+  %94 = load i32, i32* %arg4
+  %95 = inttoptr i64 %87 to i16*
+  %96 = inttoptr i64 %93 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %95, i16* %96, i32 %94)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  br label %97
+
+; <label>:97                                      ; preds = %54, %81
+  ret void
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
 Successfully read ConsoleEncoding.GetPreamble
 
@@ -14827,7 +16746,365 @@ entry:
 }
 
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[loadElemA]
+Successfully read EncoderNLS.GetBytes
+
+define i32 @EncoderNLS.GetBytes(%System.Text.EncoderNLS addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3, %"System.Byte[]" addrspace(1)* %param4, i32 %param5, i8 %param6) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %arg4 = alloca %"System.Byte[]" addrspace(1)*
+  %arg5 = alloca i32
+  %arg6 = alloca i8
+  %loc0 = alloca i32
+  %loc1 = alloca i16 addrspace(1)*
+  %loc2 = alloca i8 addrspace(1)*
+  %loc3 = alloca i32
+  %loc4 = alloca %"System.Char[]" addrspace(1)*
+  %loc5 = alloca %"System.Byte[]" addrspace(1)*
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  store %"System.Byte[]" addrspace(1)* %param4, %"System.Byte[]" addrspace(1)** %arg4
+  store i32 %param5, i32* %arg5
+  store i8 %param6, i8* %arg6
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %1 = icmp eq %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %17, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %7 = icmp eq %"System.Char[]" addrspace(1)* %6, null
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %12
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %12
+
+; <label>:12                                      ; preds = %8, %10
+  %13 = phi %System.String addrspace(1)* [ %9, %8 ], [ %11, %10 ]
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %14)
+  %16 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16, %System.String addrspace(1)* %13, %System.String addrspace(1)* %15)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16) #0
+  unreachable
+
+; <label>:17                                      ; preds = %2
+  %18 = load i32, i32* %arg2
+  %19 = icmp slt i32 %18, 0
+  br i1 %19, label %23, label %20
+
+; <label>:20                                      ; preds = %17
+  %21 = load i32, i32* %arg3
+  %22 = icmp sge i32 %21, 0
+  br i1 %22, label %35, label %23
+
+; <label>:23                                      ; preds = %17, %20
+  %24 = load i32, i32* %arg2
+  %25 = icmp slt i32 %24, 0
+  br i1 %25, label %28, label %26
+
+; <label>:26                                      ; preds = %23
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %30
+
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %30
+
+; <label>:30                                      ; preds = %26, %28
+  %31 = phi %System.String addrspace(1)* [ %27, %26 ], [ %29, %28 ]
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34, %System.String addrspace(1)* %31, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %20
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck, label %ThrowNullRef, label %37
+
+; <label>:37                                      ; preds = %35
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = load i32, i32* %arg2
+  %43 = sub i32 %41, %42
+  %44 = load i32, i32* %arg3
+  %45 = icmp sge i32 %43, %44
+  br i1 %45, label %51, label %46
+
+; <label>:46                                      ; preds = %37
+  %47 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %48 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %49 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %48)
+  %50 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %50, %System.String addrspace(1)* %47, %System.String addrspace(1)* %49)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %50) #0
+  unreachable
+
+; <label>:51                                      ; preds = %37
+  %52 = load i32, i32* %arg5
+  %53 = icmp slt i32 %52, 0
+  br i1 %53, label %63, label %54
+
+; <label>:54                                      ; preds = %51
+  %55 = load i32, i32* %arg5
+  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck1 = icmp eq %"System.Byte[]" addrspace(1)* %56, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %57
+
+; <label>:57                                      ; preds = %54
+  %58 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = zext i32 %59 to i64
+  %61 = trunc i64 %60 to i32
+  %62 = icmp sle i32 %55, %61
+  br i1 %62, label %68, label %63
+
+; <label>:63                                      ; preds = %51, %57
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %66 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %65)
+  %67 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %67, %System.String addrspace(1)* %64, %System.String addrspace(1)* %66)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %67) #0
+  unreachable
+
+; <label>:68                                      ; preds = %57
+  %69 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %69, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %69, i32 0, i32 1
+  %72 = load i32, i32 addrspace(1)* %71
+  %73 = zext i32 %72 to i64
+  %74 = trunc i64 %73 to i32
+  %75 = icmp ne i32 %74, 0
+  br i1 %75, label %78, label %76
+
+; <label>:76                                      ; preds = %70
+  %77 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1)
+  store %"System.Char[]" addrspace(1)* %77, %"System.Char[]" addrspace(1)** %arg1
+  br label %78
+
+; <label>:78                                      ; preds = %70, %76
+  %79 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck5 = icmp eq %"System.Byte[]" addrspace(1)* %79, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %80
+
+; <label>:80                                      ; preds = %78
+  %81 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %79, i32 0, i32 1
+  %82 = load i32, i32 addrspace(1)* %81
+  %83 = zext i32 %82 to i64
+  %84 = trunc i64 %83 to i32
+  %85 = load i32, i32* %arg5
+  %86 = sub i32 %84, %85
+  store i32 %86, i32* %loc0
+  %87 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck7 = icmp eq %"System.Byte[]" addrspace(1)* %87, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %88
+
+; <label>:88                                      ; preds = %80
+  %89 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %87, i32 0, i32 1
+  %90 = load i32, i32 addrspace(1)* %89
+  %91 = zext i32 %90 to i64
+  %92 = trunc i64 %91 to i32
+  %93 = icmp ne i32 %92, 0
+  br i1 %93, label %96, label %94
+
+; <label>:94                                      ; preds = %88
+  %95 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1)
+  store %"System.Byte[]" addrspace(1)* %95, %"System.Byte[]" addrspace(1)** %arg4
+  br label %96
+
+; <label>:96                                      ; preds = %88, %94
+  %97 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  store %"System.Char[]" addrspace(1)* %97, %"System.Char[]" addrspace(1)** %loc4
+  %98 = icmp eq %"System.Char[]" addrspace(1)* %97, null
+  br i1 %98, label %107, label %99
+
+; <label>:99                                      ; preds = %96
+  %100 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc4
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %100, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %101
+
+; <label>:101                                     ; preds = %99
+  %102 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %100, i32 0, i32 1
+  %103 = load i32, i32 addrspace(1)* %102
+  %104 = zext i32 %103 to i64
+  %105 = trunc i64 %104 to i32
+  %106 = icmp ne i32 %105, 0
+  br i1 %106, label %108, label %107
+
+; <label>:107                                     ; preds = %96, %101
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  br label %116
+
+; <label>:108                                     ; preds = %101
+  %109 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc4
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %109, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %110
+
+; <label>:110                                     ; preds = %108
+  %111 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %109, i32 0, i32 1
+  %112 = load i32, i32 addrspace(1)* %111
+  %113 = zext i32 %112 to i64
+  %BoundsCheck = icmp uge i64 0, %113
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %114
+
+; <label>:114                                     ; preds = %110
+  %115 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %109, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %115, i16 addrspace(1)** %loc1
+  br label %116
+
+; <label>:116                                     ; preds = %107, %114
+  %117 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  store %"System.Byte[]" addrspace(1)* %117, %"System.Byte[]" addrspace(1)** %loc5
+  %118 = icmp eq %"System.Byte[]" addrspace(1)* %117, null
+  br i1 %118, label %127, label %119
+
+; <label>:119                                     ; preds = %116
+  %120 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc5
+  %NullCheck13 = icmp eq %"System.Byte[]" addrspace(1)* %120, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %121
+
+; <label>:121                                     ; preds = %119
+  %122 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %120, i32 0, i32 1
+  %123 = load i32, i32 addrspace(1)* %122
+  %124 = zext i32 %123 to i64
+  %125 = trunc i64 %124 to i32
+  %126 = icmp ne i32 %125, 0
+  br i1 %126, label %128, label %127
+
+; <label>:127                                     ; preds = %116, %121
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc2
+  br label %136
+
+; <label>:128                                     ; preds = %121
+  %129 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc5
+  %NullCheck15 = icmp eq %"System.Byte[]" addrspace(1)* %129, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %130
+
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %129, i32 0, i32 1
+  %132 = load i32, i32 addrspace(1)* %131
+  %133 = zext i32 %132 to i64
+  %BoundsCheck17 = icmp uge i64 0, %133
+  br i1 %BoundsCheck17, label %ThrowIndexOutOfRange18, label %134
+
+; <label>:134                                     ; preds = %130
+  %135 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %129, i32 0, i32 3, i32 0
+  store i8 addrspace(1)* %135, i8 addrspace(1)** %loc2
+  br label %136
+
+; <label>:136                                     ; preds = %127, %134
+  %137 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %138 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %139 = ptrtoint i16 addrspace(1)* %138 to i64
+  %140 = load i32, i32* %arg2
+  %141 = sext i32 %140 to i64
+  %142 = mul i64 %141, 2
+  %143 = add i64 %139, %142
+  %144 = load i32, i32* %arg3
+  %145 = load i8 addrspace(1)*, i8 addrspace(1)** %loc2
+  %146 = ptrtoint i8 addrspace(1)* %145 to i64
+  %147 = load i32, i32* %arg5
+  %148 = sext i32 %147 to i64
+  %149 = add i64 %146, %148
+  %150 = load i32, i32* %loc0
+  %151 = load i8, i8* %arg6
+  %152 = zext i8 %151 to i32
+  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i64 addrspace(1)*
+  %NullCheck19 = icmp eq i64 addrspace(1)* %153, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %154
+
+; <label>:154                                     ; preds = %136
+  %155 = load i64, i64 addrspace(1)* %153
+  %156 = add i64 %155, 72
+  %157 = inttoptr i64 %156 to i64*
+  %158 = load i64, i64* %157
+  %159 = add i64 %158, 0
+  %160 = inttoptr i64 %159 to i64*
+  %161 = load i64, i64* %160
+  %162 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to %System.Text.Encoder addrspace(1)*
+  %163 = inttoptr i64 %143 to i16*
+  %164 = inttoptr i64 %149 to i8*
+  %165 = trunc i32 %152 to i8
+  %166 = inttoptr i64 %161 to i32 (%System.Text.Encoder addrspace(1)*, i16*, i32, i8*, i32, i8)*
+  %167 = call i32 %166(%System.Text.Encoder addrspace(1)* %162, i16* %163, i32 %144, i8* %164, i32 %150, i8 %165)
+  store i32 %167, i32* %loc3
+  br label %168
+
+; <label>:168                                     ; preds = %154
+  %169 = load i32, i32* %loc3
+  ret i32 %169
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %110
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %119
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange18:                           ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
 Successfully read EncoderNLS.GetBytes
 
@@ -14916,22 +17193,22 @@ entry:
   %40 = load i8, i8* %arg5
   %41 = zext i8 %40 to i32
   %42 = trunc i32 %41 to i8
-  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %39, null
-  br i1 %NullCheck, label %43, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderNLS addrspace(1)* %39, null
+  br i1 %NullCheck, label %ThrowNullRef, label %43
 
 ; <label>:43                                      ; preds = %38
   %44 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
   store i8 %42, i8 addrspace(1)* %44
   %45 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %45, null
-  br i1 %NullCheck2, label %46, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.EncoderNLS addrspace(1)* %45, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %46
 
 ; <label>:46                                      ; preds = %43
   %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %45, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %47
   %48 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.EncoderNLS addrspace(1)* %48, null
-  br i1 %NullCheck4, label %49, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.EncoderNLS addrspace(1)* %48, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %49
 
 ; <label>:49                                      ; preds = %46
   %50 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %48, i32 0, i32 3
@@ -14942,8 +17219,8 @@ entry:
   %55 = load i32, i32* %arg4
   %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck6, label %58, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
   %59 = load i64, i64 addrspace(1)* %57
@@ -14961,15 +17238,15 @@ ThrowNullRef:                                     ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %43
+ThrowNullRef2:                                    ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %46
+ThrowNullRef4:                                    ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %49
+ThrowNullRef6:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14997,8 +17274,8 @@ entry:
   %4 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0 to %System.IO.ConsoleStream addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*)(%System.IO.ConsoleStream addrspace(1)* %4, %"System.Byte[]" addrspace(1)* %1, i32 %2, i32 %3)
   %5 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
@@ -15083,8 +17360,8 @@ entry:
 
 ; <label>:22                                      ; preds = %8
   %23 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %23, null
-  br i1 %NullCheck, label %24, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Byte[]" addrspace(1)* %23, null
+  br i1 %NullCheck, label %ThrowNullRef, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
@@ -15106,8 +17383,8 @@ entry:
 
 ; <label>:36                                      ; preds = %24
   %37 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %37, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.ConsoleStream addrspace(1)* %37, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %37, i32 0, i32 4
@@ -15128,13 +17405,138 @@ ThrowNullRef:                                     ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %36
+ThrowNullRef2:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
-Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
+Successfully read WindowsConsoleStream.WriteFileNative
+
+define i32 @WindowsConsoleStream.WriteFileNative(i64 %param0, %"System.Byte[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i64
+  %arg1 = alloca %"System.Byte[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i8 addrspace(1)*
+  %loc2 = alloca %"System.Byte[]" addrspace(1)*
+  %loc3 = alloca i32
+  store i64 %param0, i64* %arg0
+  store %"System.Byte[]" addrspace(1)* %param1, %"System.Byte[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Byte[]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = zext i32 %3 to i64
+  %5 = icmp ne i64 %4, 0
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %1
+  ret i32 0
+
+; <label>:7                                       ; preds = %1
+  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  store %"System.Byte[]" addrspace(1)* %8, %"System.Byte[]" addrspace(1)** %loc2
+  %9 = icmp eq %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %9, label %18, label %10
+
+; <label>:10                                      ; preds = %7
+  %11 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc2
+  %NullCheck1 = icmp eq %"System.Byte[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %11, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp ne i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %7, %12
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc1
+  br label %27
+
+; <label>:19                                      ; preds = %12
+  %20 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc2
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %20, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %BoundsCheck = icmp uge i64 0, %24
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %25
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %20, i32 0, i32 3, i32 0
+  store i8 addrspace(1)* %26, i8 addrspace(1)** %loc1
+  br label %27
+
+; <label>:27                                      ; preds = %18, %25
+  %28 = load i64, i64* %arg0
+  %29 = load i8 addrspace(1)*, i8 addrspace(1)** %loc1
+  %30 = ptrtoint i8 addrspace(1)* %29 to i64
+  %31 = load i32, i32* %arg2
+  %32 = sext i32 %31 to i64
+  %33 = add i64 %30, %32
+  %34 = load i32, i32* %arg3
+  %35 = addrspacecast i32* %loc3 to i32 addrspace(1)*
+  %36 = inttoptr i64 %33 to i8*
+  %37 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i8*, i32, i32 addrspace(1)*, i64)*)(i64 %28, i8* %36, i32 %34, i32 addrspace(1)* %35, i64 0)
+  %38 = icmp ugt i32 %37, 0
+  %39 = sext i1 %38 to i32
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc1
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %42, label %41
+
+; <label>:41                                      ; preds = %27
+  ret i32 0
+
+; <label>:42                                      ; preds = %27
+  %43 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  store i32 %43, i32* %loc0
+  %44 = load i32, i32* %loc0
+  %45 = icmp eq i32 %44, 232
+  br i1 %45, label %49, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = load i32, i32* %loc0
+  %48 = icmp ne i32 %47, 109
+  br i1 %48, label %50, label %49
+
+; <label>:49                                      ; preds = %42, %46
+  ret i32 0
+
+; <label>:50                                      ; preds = %46
+  %51 = load i32, i32* %loc0
+  ret i32 %51
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
 Successfully read WindowsConsoleStream.Flush
 
@@ -15143,8 +17545,8 @@ entry:
   %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
   store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
@@ -15179,8 +17581,8 @@ entry:
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
   %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load i64, i64 addrspace(1)* %1
@@ -15219,15 +17621,15 @@ entry:
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.TextWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
   %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %3, align 8
   %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
   %7 = load i64, i64 addrspace(1)* %5
@@ -15245,7 +17647,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -15274,8 +17676,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %4)
   store i32 0, i32* %loc0
   %5 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Char[]" addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
@@ -15287,15 +17689,15 @@ entry:
 
 ; <label>:11                                      ; preds = %69
   %12 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %12, i32 0, i32 9
   %15 = load i32, i32 addrspace(1)* %14, align 8
   %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.IO.StreamWriter addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %16, i32 0, i32 10
@@ -15310,15 +17712,15 @@ entry:
 
 ; <label>:23                                      ; preds = %17, %21
   %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %24, null
-  br i1 %NullCheck8, label %25, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %24, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 10
   %27 = load i32, i32 addrspace(1)* %26, align 8
   %28 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %28, null
-  br i1 %NullCheck10, label %29, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.StreamWriter addrspace(1)* %28, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %28, i32 0, i32 9
@@ -15340,15 +17742,15 @@ entry:
   %40 = load i32, i32* %loc0
   %41 = mul i32 %40, 2
   %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
-  br i1 %NullCheck12, label %43, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %43
 
 ; <label>:43                                      ; preds = %38
   %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 7
   %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %44, align 8
   %46 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %46, null
-  br i1 %NullCheck14, label %47, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.IO.StreamWriter addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %47
 
 ; <label>:47                                      ; preds = %43
   %48 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %46, i32 0, i32 9
@@ -15360,16 +17762,16 @@ entry:
   %54 = bitcast %"System.Char[]" addrspace(1)* %45 to %System.Array addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %53, i32 %41, %System.Array addrspace(1)* %54, i32 %50, i32 %52)
   %55 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
-  br i1 %NullCheck16, label %56, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %56
 
 ; <label>:56                                      ; preds = %47
   %57 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
   %58 = load i32, i32 addrspace(1)* %57, align 8
   %59 = load i32, i32* %loc2
   %60 = add i32 %58, %59
-  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
-  br i1 %NullCheck18, label %61, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %61
 
 ; <label>:61                                      ; preds = %56
   %62 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
@@ -15391,8 +17793,8 @@ entry:
 
 ; <label>:72                                      ; preds = %69
   %73 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %73, null
-  br i1 %NullCheck2, label %74, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %73, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %74
 
 ; <label>:74                                      ; preds = %72
   %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %73, i32 0, i32 11
@@ -15413,39 +17815,39 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %72
+ThrowNullRef2:                                    ; preds = %72
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %23
+ThrowNullRef8:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef10:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %43
+ThrowNullRef14:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %47
+ThrowNullRef16:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %56
+ThrowNullRef18:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblFillArray.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblFillArray.error.txt
@@ -25,8 +25,8 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
@@ -40,8 +40,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
   %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
@@ -75,7 +75,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -90,8 +90,8 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %NullCheck = icmp ne i8 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = load i8, i8 addrspace(1)* %0, align 8
@@ -125,8 +125,8 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
@@ -159,8 +159,8 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -184,8 +184,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
   store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
@@ -195,8 +195,8 @@ entry:
 ; <label>:4                                       ; preds = %1
   %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
   %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
@@ -206,8 +206,8 @@ entry:
   %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
@@ -221,14 +221,14 @@ entry:
 
 ; <label>:17                                      ; preds = %14
   %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
   %21 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
@@ -238,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -249,8 +249,8 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
@@ -261,27 +261,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %30
+ThrowNullRef10:                                   ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -301,7 +301,89 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
-Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
+Successfully read AppDomainSetup.GetUnsecureApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.GetUnsecureApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %NullCheck = icmp eq %"System.String[]" addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %BoundsCheck = icmp uge i64 0, %5
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %6
+
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 3, i32 0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
+  ret %System.String addrspace(1)* %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_Value using LLILCJit
+Successfully read AppDomainSetup.get_Value
+
+define %"System.String[]" addrspace(1)* @AppDomainSetup.get_Value(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.String[]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 18)
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.String[]" addrspace(1)* addrspace(1)*, %"System.String[]" addrspace(1)*)*)(%"System.String[]" addrspace(1)* addrspace(1)* %9, %"System.String[]" addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %11, i32 0, i32 1
+  %14 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %13, align 8
+  ret %"System.String[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -319,8 +401,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -368,16 +450,16 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
   %5 = load i32, i32 addrspace(1)* %4
   %6 = sub i32 %5, 1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -389,7 +471,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -421,8 +503,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
@@ -456,8 +538,8 @@ entry:
 ; <label>:27                                      ; preds = %19
   %28 = load i32, i32* %arg1
   %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
-  br i1 %NullCheck2, label %30, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %29, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %30
 
 ; <label>:30                                      ; preds = %27
   %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
@@ -493,8 +575,8 @@ entry:
 ; <label>:49                                      ; preds = %46
   %50 = load i32, i32* %arg2
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck4, label %52, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
@@ -517,11 +599,11 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %27
+ThrowNullRef2:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %49
+ThrowNullRef4:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -544,16 +626,16 @@ entry:
   %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %0)
   store %System.String addrspace(1)* %1, %System.String addrspace(1)** %loc0
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 2
   %5 = bitcast [0 x i16] addrspace(1)* %4 to i16 addrspace(1)*
   store i16 addrspace(1)* %5, i16 addrspace(1)** %loc1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %3
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2
@@ -580,7 +662,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -691,15 +773,15 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %NullCheck132 = icmp ne i8* %21, null
-  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+  %NullCheck131 = icmp eq i8* %21, null
+  br i1 %NullCheck131, label %ThrowNullRef132, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = load i8, i8* %21, align 8
   %24 = zext i8 %23 to i32
   %25 = trunc i32 %24 to i8
-  %NullCheck134 = icmp ne i8* %20, null
-  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+  %NullCheck133 = icmp eq i8* %20, null
+  br i1 %NullCheck133, label %ThrowNullRef134, label %26
 
 ; <label>:26                                      ; preds = %22
   store i8 %25, i8* %20, align 8
@@ -709,16 +791,16 @@ entry:
   %28 = load i8*, i8** %arg0
   %29 = load i8*, i8** %arg1
   %30 = bitcast i8* %29 to i16*
-  %NullCheck128 = icmp ne i16* %30, null
-  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+  %NullCheck127 = icmp eq i16* %30, null
+  br i1 %NullCheck127, label %ThrowNullRef128, label %31
 
 ; <label>:31                                      ; preds = %27
   %32 = load i16, i16* %30, align 8
   %33 = sext i16 %32 to i32
   %34 = bitcast i8* %28 to i16*
   %35 = trunc i32 %33 to i16
-  %NullCheck130 = icmp ne i16* %34, null
-  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+  %NullCheck129 = icmp eq i16* %34, null
+  br i1 %NullCheck129, label %ThrowNullRef130, label %36
 
 ; <label>:36                                      ; preds = %31
   store i16 %35, i16* %34, align 8
@@ -728,16 +810,16 @@ entry:
   %38 = load i8*, i8** %arg0
   %39 = load i8*, i8** %arg1
   %40 = bitcast i8* %39 to i16*
-  %NullCheck120 = icmp ne i16* %40, null
-  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+  %NullCheck119 = icmp eq i16* %40, null
+  br i1 %NullCheck119, label %ThrowNullRef120, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i16, i16* %40, align 8
   %43 = sext i16 %42 to i32
   %44 = bitcast i8* %38 to i16*
   %45 = trunc i32 %43 to i16
-  %NullCheck122 = icmp ne i16* %44, null
-  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+  %NullCheck121 = icmp eq i16* %44, null
+  br i1 %NullCheck121, label %ThrowNullRef122, label %46
 
 ; <label>:46                                      ; preds = %41
   store i16 %45, i16* %44, align 8
@@ -745,15 +827,15 @@ entry:
   %48 = getelementptr inbounds i8, i8* %47, i64 2
   %49 = load i8*, i8** %arg1
   %50 = getelementptr inbounds i8, i8* %49, i64 2
-  %NullCheck124 = icmp ne i8* %50, null
-  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+  %NullCheck123 = icmp eq i8* %50, null
+  br i1 %NullCheck123, label %ThrowNullRef124, label %51
 
 ; <label>:51                                      ; preds = %46
   %52 = load i8, i8* %50, align 8
   %53 = zext i8 %52 to i32
   %54 = trunc i32 %53 to i8
-  %NullCheck126 = icmp ne i8* %48, null
-  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+  %NullCheck125 = icmp eq i8* %48, null
+  br i1 %NullCheck125, label %ThrowNullRef126, label %55
 
 ; <label>:55                                      ; preds = %51
   store i8 %54, i8* %48, align 8
@@ -763,14 +845,14 @@ entry:
   %57 = load i8*, i8** %arg0
   %58 = load i8*, i8** %arg1
   %59 = bitcast i8* %58 to i32*
-  %NullCheck116 = icmp ne i32* %59, null
-  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+  %NullCheck115 = icmp eq i32* %59, null
+  br i1 %NullCheck115, label %ThrowNullRef116, label %60
 
 ; <label>:60                                      ; preds = %56
   %61 = load i32, i32* %59, align 8
   %62 = bitcast i8* %57 to i32*
-  %NullCheck118 = icmp ne i32* %62, null
-  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+  %NullCheck117 = icmp eq i32* %62, null
+  br i1 %NullCheck117, label %ThrowNullRef118, label %63
 
 ; <label>:63                                      ; preds = %60
   store i32 %61, i32* %62, align 8
@@ -780,14 +862,14 @@ entry:
   %65 = load i8*, i8** %arg0
   %66 = load i8*, i8** %arg1
   %67 = bitcast i8* %66 to i32*
-  %NullCheck108 = icmp ne i32* %67, null
-  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+  %NullCheck107 = icmp eq i32* %67, null
+  br i1 %NullCheck107, label %ThrowNullRef108, label %68
 
 ; <label>:68                                      ; preds = %64
   %69 = load i32, i32* %67, align 8
   %70 = bitcast i8* %65 to i32*
-  %NullCheck110 = icmp ne i32* %70, null
-  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+  %NullCheck109 = icmp eq i32* %70, null
+  br i1 %NullCheck109, label %ThrowNullRef110, label %71
 
 ; <label>:71                                      ; preds = %68
   store i32 %69, i32* %70, align 8
@@ -795,15 +877,15 @@ entry:
   %73 = getelementptr inbounds i8, i8* %72, i64 4
   %74 = load i8*, i8** %arg1
   %75 = getelementptr inbounds i8, i8* %74, i64 4
-  %NullCheck112 = icmp ne i8* %75, null
-  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+  %NullCheck111 = icmp eq i8* %75, null
+  br i1 %NullCheck111, label %ThrowNullRef112, label %76
 
 ; <label>:76                                      ; preds = %71
   %77 = load i8, i8* %75, align 8
   %78 = zext i8 %77 to i32
   %79 = trunc i32 %78 to i8
-  %NullCheck114 = icmp ne i8* %73, null
-  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+  %NullCheck113 = icmp eq i8* %73, null
+  br i1 %NullCheck113, label %ThrowNullRef114, label %80
 
 ; <label>:80                                      ; preds = %76
   store i8 %79, i8* %73, align 8
@@ -813,14 +895,14 @@ entry:
   %82 = load i8*, i8** %arg0
   %83 = load i8*, i8** %arg1
   %84 = bitcast i8* %83 to i32*
-  %NullCheck100 = icmp ne i32* %84, null
-  br i1 %NullCheck100, label %85, label %ThrowNullRef99
+  %NullCheck99 = icmp eq i32* %84, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %85
 
 ; <label>:85                                      ; preds = %81
   %86 = load i32, i32* %84, align 8
   %87 = bitcast i8* %82 to i32*
-  %NullCheck102 = icmp ne i32* %87, null
-  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+  %NullCheck101 = icmp eq i32* %87, null
+  br i1 %NullCheck101, label %ThrowNullRef102, label %88
 
 ; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
@@ -829,16 +911,16 @@ entry:
   %91 = load i8*, i8** %arg1
   %92 = getelementptr inbounds i8, i8* %91, i64 4
   %93 = bitcast i8* %92 to i16*
-  %NullCheck104 = icmp ne i16* %93, null
-  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+  %NullCheck103 = icmp eq i16* %93, null
+  br i1 %NullCheck103, label %ThrowNullRef104, label %94
 
 ; <label>:94                                      ; preds = %88
   %95 = load i16, i16* %93, align 8
   %96 = sext i16 %95 to i32
   %97 = bitcast i8* %90 to i16*
   %98 = trunc i32 %96 to i16
-  %NullCheck106 = icmp ne i16* %97, null
-  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+  %NullCheck105 = icmp eq i16* %97, null
+  br i1 %NullCheck105, label %ThrowNullRef106, label %99
 
 ; <label>:99                                      ; preds = %94
   store i16 %98, i16* %97, align 8
@@ -848,14 +930,14 @@ entry:
   %101 = load i8*, i8** %arg0
   %102 = load i8*, i8** %arg1
   %103 = bitcast i8* %102 to i32*
-  %NullCheck88 = icmp ne i32* %103, null
-  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+  %NullCheck87 = icmp eq i32* %103, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %104
 
 ; <label>:104                                     ; preds = %100
   %105 = load i32, i32* %103, align 8
   %106 = bitcast i8* %101 to i32*
-  %NullCheck90 = icmp ne i32* %106, null
-  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+  %NullCheck89 = icmp eq i32* %106, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %107
 
 ; <label>:107                                     ; preds = %104
   store i32 %105, i32* %106, align 8
@@ -864,16 +946,16 @@ entry:
   %110 = load i8*, i8** %arg1
   %111 = getelementptr inbounds i8, i8* %110, i64 4
   %112 = bitcast i8* %111 to i16*
-  %NullCheck92 = icmp ne i16* %112, null
-  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+  %NullCheck91 = icmp eq i16* %112, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %113
 
 ; <label>:113                                     ; preds = %107
   %114 = load i16, i16* %112, align 8
   %115 = sext i16 %114 to i32
   %116 = bitcast i8* %109 to i16*
   %117 = trunc i32 %115 to i16
-  %NullCheck94 = icmp ne i16* %116, null
-  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+  %NullCheck93 = icmp eq i16* %116, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %118
 
 ; <label>:118                                     ; preds = %113
   store i16 %117, i16* %116, align 8
@@ -881,15 +963,15 @@ entry:
   %120 = getelementptr inbounds i8, i8* %119, i64 6
   %121 = load i8*, i8** %arg1
   %122 = getelementptr inbounds i8, i8* %121, i64 6
-  %NullCheck96 = icmp ne i8* %122, null
-  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+  %NullCheck95 = icmp eq i8* %122, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %123
 
 ; <label>:123                                     ; preds = %118
   %124 = load i8, i8* %122, align 8
   %125 = zext i8 %124 to i32
   %126 = trunc i32 %125 to i8
-  %NullCheck98 = icmp ne i8* %120, null
-  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+  %NullCheck97 = icmp eq i8* %120, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %127
 
 ; <label>:127                                     ; preds = %123
   store i8 %126, i8* %120, align 8
@@ -899,14 +981,14 @@ entry:
   %129 = load i8*, i8** %arg0
   %130 = load i8*, i8** %arg1
   %131 = bitcast i8* %130 to i64*
-  %NullCheck84 = icmp ne i64* %131, null
-  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+  %NullCheck83 = icmp eq i64* %131, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %132
 
 ; <label>:132                                     ; preds = %128
   %133 = load i64, i64* %131, align 8
   %134 = bitcast i8* %129 to i64*
-  %NullCheck86 = icmp ne i64* %134, null
-  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+  %NullCheck85 = icmp eq i64* %134, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %135
 
 ; <label>:135                                     ; preds = %132
   store i64 %133, i64* %134, align 8
@@ -916,14 +998,14 @@ entry:
   %137 = load i8*, i8** %arg0
   %138 = load i8*, i8** %arg1
   %139 = bitcast i8* %138 to i64*
-  %NullCheck76 = icmp ne i64* %139, null
-  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+  %NullCheck75 = icmp eq i64* %139, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %140
 
 ; <label>:140                                     ; preds = %136
   %141 = load i64, i64* %139, align 8
   %142 = bitcast i8* %137 to i64*
-  %NullCheck78 = icmp ne i64* %142, null
-  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+  %NullCheck77 = icmp eq i64* %142, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %143
 
 ; <label>:143                                     ; preds = %140
   store i64 %141, i64* %142, align 8
@@ -931,15 +1013,15 @@ entry:
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %NullCheck80 = icmp ne i8* %147, null
-  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+  %NullCheck79 = icmp eq i8* %147, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %148
 
 ; <label>:148                                     ; preds = %143
   %149 = load i8, i8* %147, align 8
   %150 = zext i8 %149 to i32
   %151 = trunc i32 %150 to i8
-  %NullCheck82 = icmp ne i8* %145, null
-  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+  %NullCheck81 = icmp eq i8* %145, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %152
 
 ; <label>:152                                     ; preds = %148
   store i8 %151, i8* %145, align 8
@@ -949,14 +1031,14 @@ entry:
   %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
   %156 = bitcast i8* %155 to i64*
-  %NullCheck68 = icmp ne i64* %156, null
-  br i1 %NullCheck68, label %157, label %ThrowNullRef67
+  %NullCheck67 = icmp eq i64* %156, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %157
 
 ; <label>:157                                     ; preds = %153
   %158 = load i64, i64* %156, align 8
   %159 = bitcast i8* %154 to i64*
-  %NullCheck70 = icmp ne i64* %159, null
-  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+  %NullCheck69 = icmp eq i64* %159, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %160
 
 ; <label>:160                                     ; preds = %157
   store i64 %158, i64* %159, align 8
@@ -965,16 +1047,16 @@ entry:
   %163 = load i8*, i8** %arg1
   %164 = getelementptr inbounds i8, i8* %163, i64 8
   %165 = bitcast i8* %164 to i16*
-  %NullCheck72 = icmp ne i16* %165, null
-  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+  %NullCheck71 = icmp eq i16* %165, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %166
 
 ; <label>:166                                     ; preds = %160
   %167 = load i16, i16* %165, align 8
   %168 = sext i16 %167 to i32
   %169 = bitcast i8* %162 to i16*
   %170 = trunc i32 %168 to i16
-  %NullCheck74 = icmp ne i16* %169, null
-  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+  %NullCheck73 = icmp eq i16* %169, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %171
 
 ; <label>:171                                     ; preds = %166
   store i16 %170, i16* %169, align 8
@@ -984,14 +1066,14 @@ entry:
   %173 = load i8*, i8** %arg0
   %174 = load i8*, i8** %arg1
   %175 = bitcast i8* %174 to i64*
-  %NullCheck56 = icmp ne i64* %175, null
-  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+  %NullCheck55 = icmp eq i64* %175, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %176
 
 ; <label>:176                                     ; preds = %172
   %177 = load i64, i64* %175, align 8
   %178 = bitcast i8* %173 to i64*
-  %NullCheck58 = icmp ne i64* %178, null
-  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+  %NullCheck57 = icmp eq i64* %178, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %179
 
 ; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
@@ -1000,16 +1082,16 @@ entry:
   %182 = load i8*, i8** %arg1
   %183 = getelementptr inbounds i8, i8* %182, i64 8
   %184 = bitcast i8* %183 to i16*
-  %NullCheck60 = icmp ne i16* %184, null
-  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+  %NullCheck59 = icmp eq i16* %184, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %185
 
 ; <label>:185                                     ; preds = %179
   %186 = load i16, i16* %184, align 8
   %187 = sext i16 %186 to i32
   %188 = bitcast i8* %181 to i16*
   %189 = trunc i32 %187 to i16
-  %NullCheck62 = icmp ne i16* %188, null
-  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+  %NullCheck61 = icmp eq i16* %188, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %190
 
 ; <label>:190                                     ; preds = %185
   store i16 %189, i16* %188, align 8
@@ -1017,15 +1099,15 @@ entry:
   %192 = getelementptr inbounds i8, i8* %191, i64 10
   %193 = load i8*, i8** %arg1
   %194 = getelementptr inbounds i8, i8* %193, i64 10
-  %NullCheck64 = icmp ne i8* %194, null
-  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+  %NullCheck63 = icmp eq i8* %194, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %195
 
 ; <label>:195                                     ; preds = %190
   %196 = load i8, i8* %194, align 8
   %197 = zext i8 %196 to i32
   %198 = trunc i32 %197 to i8
-  %NullCheck66 = icmp ne i8* %192, null
-  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+  %NullCheck65 = icmp eq i8* %192, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %199
 
 ; <label>:199                                     ; preds = %195
   store i8 %198, i8* %192, align 8
@@ -1035,14 +1117,14 @@ entry:
   %201 = load i8*, i8** %arg0
   %202 = load i8*, i8** %arg1
   %203 = bitcast i8* %202 to i64*
-  %NullCheck48 = icmp ne i64* %203, null
-  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+  %NullCheck47 = icmp eq i64* %203, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %204
 
 ; <label>:204                                     ; preds = %200
   %205 = load i64, i64* %203, align 8
   %206 = bitcast i8* %201 to i64*
-  %NullCheck50 = icmp ne i64* %206, null
-  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+  %NullCheck49 = icmp eq i64* %206, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %207
 
 ; <label>:207                                     ; preds = %204
   store i64 %205, i64* %206, align 8
@@ -1051,14 +1133,14 @@ entry:
   %210 = load i8*, i8** %arg1
   %211 = getelementptr inbounds i8, i8* %210, i64 8
   %212 = bitcast i8* %211 to i32*
-  %NullCheck52 = icmp ne i32* %212, null
-  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+  %NullCheck51 = icmp eq i32* %212, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %213
 
 ; <label>:213                                     ; preds = %207
   %214 = load i32, i32* %212, align 8
   %215 = bitcast i8* %209 to i32*
-  %NullCheck54 = icmp ne i32* %215, null
-  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+  %NullCheck53 = icmp eq i32* %215, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %216
 
 ; <label>:216                                     ; preds = %213
   store i32 %214, i32* %215, align 8
@@ -1068,14 +1150,14 @@ entry:
   %218 = load i8*, i8** %arg0
   %219 = load i8*, i8** %arg1
   %220 = bitcast i8* %219 to i64*
-  %NullCheck36 = icmp ne i64* %220, null
-  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64* %220, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %221
 
 ; <label>:221                                     ; preds = %217
   %222 = load i64, i64* %220, align 8
   %223 = bitcast i8* %218 to i64*
-  %NullCheck38 = icmp ne i64* %223, null
-  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+  %NullCheck37 = icmp eq i64* %223, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %224
 
 ; <label>:224                                     ; preds = %221
   store i64 %222, i64* %223, align 8
@@ -1084,14 +1166,14 @@ entry:
   %227 = load i8*, i8** %arg1
   %228 = getelementptr inbounds i8, i8* %227, i64 8
   %229 = bitcast i8* %228 to i32*
-  %NullCheck40 = icmp ne i32* %229, null
-  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i32* %229, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %230
 
 ; <label>:230                                     ; preds = %224
   %231 = load i32, i32* %229, align 8
   %232 = bitcast i8* %226 to i32*
-  %NullCheck42 = icmp ne i32* %232, null
-  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+  %NullCheck41 = icmp eq i32* %232, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %233
 
 ; <label>:233                                     ; preds = %230
   store i32 %231, i32* %232, align 8
@@ -1099,15 +1181,15 @@ entry:
   %235 = getelementptr inbounds i8, i8* %234, i64 12
   %236 = load i8*, i8** %arg1
   %237 = getelementptr inbounds i8, i8* %236, i64 12
-  %NullCheck44 = icmp ne i8* %237, null
-  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i8* %237, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %238
 
 ; <label>:238                                     ; preds = %233
   %239 = load i8, i8* %237, align 8
   %240 = zext i8 %239 to i32
   %241 = trunc i32 %240 to i8
-  %NullCheck46 = icmp ne i8* %235, null
-  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+  %NullCheck45 = icmp eq i8* %235, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %242
 
 ; <label>:242                                     ; preds = %238
   store i8 %241, i8* %235, align 8
@@ -1117,14 +1199,14 @@ entry:
   %244 = load i8*, i8** %arg0
   %245 = load i8*, i8** %arg1
   %246 = bitcast i8* %245 to i64*
-  %NullCheck24 = icmp ne i64* %246, null
-  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64* %246, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %247
 
 ; <label>:247                                     ; preds = %243
   %248 = load i64, i64* %246, align 8
   %249 = bitcast i8* %244 to i64*
-  %NullCheck26 = icmp ne i64* %249, null
-  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64* %249, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %250
 
 ; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
@@ -1133,14 +1215,14 @@ entry:
   %253 = load i8*, i8** %arg1
   %254 = getelementptr inbounds i8, i8* %253, i64 8
   %255 = bitcast i8* %254 to i32*
-  %NullCheck28 = icmp ne i32* %255, null
-  br i1 %NullCheck28, label %256, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i32* %255, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %256
 
 ; <label>:256                                     ; preds = %250
   %257 = load i32, i32* %255, align 8
   %258 = bitcast i8* %252 to i32*
-  %NullCheck30 = icmp ne i32* %258, null
-  br i1 %NullCheck30, label %259, label %ThrowNullRef29
+  %NullCheck29 = icmp eq i32* %258, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %259
 
 ; <label>:259                                     ; preds = %256
   store i32 %257, i32* %258, align 8
@@ -1149,16 +1231,16 @@ entry:
   %262 = load i8*, i8** %arg1
   %263 = getelementptr inbounds i8, i8* %262, i64 12
   %264 = bitcast i8* %263 to i16*
-  %NullCheck32 = icmp ne i16* %264, null
-  br i1 %NullCheck32, label %265, label %ThrowNullRef31
+  %NullCheck31 = icmp eq i16* %264, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %265
 
 ; <label>:265                                     ; preds = %259
   %266 = load i16, i16* %264, align 8
   %267 = sext i16 %266 to i32
   %268 = bitcast i8* %261 to i16*
   %269 = trunc i32 %267 to i16
-  %NullCheck34 = icmp ne i16* %268, null
-  br i1 %NullCheck34, label %270, label %ThrowNullRef33
+  %NullCheck33 = icmp eq i16* %268, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %270
 
 ; <label>:270                                     ; preds = %265
   store i16 %269, i16* %268, align 8
@@ -1168,14 +1250,14 @@ entry:
   %272 = load i8*, i8** %arg0
   %273 = load i8*, i8** %arg1
   %274 = bitcast i8* %273 to i64*
-  %NullCheck8 = icmp ne i64* %274, null
-  br i1 %NullCheck8, label %275, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64* %274, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %275
 
 ; <label>:275                                     ; preds = %271
   %276 = load i64, i64* %274, align 8
   %277 = bitcast i8* %272 to i64*
-  %NullCheck10 = icmp ne i64* %277, null
-  br i1 %NullCheck10, label %278, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %277, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %278
 
 ; <label>:278                                     ; preds = %275
   store i64 %276, i64* %277, align 8
@@ -1184,14 +1266,14 @@ entry:
   %281 = load i8*, i8** %arg1
   %282 = getelementptr inbounds i8, i8* %281, i64 8
   %283 = bitcast i8* %282 to i32*
-  %NullCheck12 = icmp ne i32* %283, null
-  br i1 %NullCheck12, label %284, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i32* %283, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %284
 
 ; <label>:284                                     ; preds = %278
   %285 = load i32, i32* %283, align 8
   %286 = bitcast i8* %280 to i32*
-  %NullCheck14 = icmp ne i32* %286, null
-  br i1 %NullCheck14, label %287, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i32* %286, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %287
 
 ; <label>:287                                     ; preds = %284
   store i32 %285, i32* %286, align 8
@@ -1200,16 +1282,16 @@ entry:
   %290 = load i8*, i8** %arg1
   %291 = getelementptr inbounds i8, i8* %290, i64 12
   %292 = bitcast i8* %291 to i16*
-  %NullCheck16 = icmp ne i16* %292, null
-  br i1 %NullCheck16, label %293, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i16* %292, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %293
 
 ; <label>:293                                     ; preds = %287
   %294 = load i16, i16* %292, align 8
   %295 = sext i16 %294 to i32
   %296 = bitcast i8* %289 to i16*
   %297 = trunc i32 %295 to i16
-  %NullCheck18 = icmp ne i16* %296, null
-  br i1 %NullCheck18, label %298, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i16* %296, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %298
 
 ; <label>:298                                     ; preds = %293
   store i16 %297, i16* %296, align 8
@@ -1217,15 +1299,15 @@ entry:
   %300 = getelementptr inbounds i8, i8* %299, i64 14
   %301 = load i8*, i8** %arg1
   %302 = getelementptr inbounds i8, i8* %301, i64 14
-  %NullCheck20 = icmp ne i8* %302, null
-  br i1 %NullCheck20, label %303, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i8* %302, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %303
 
 ; <label>:303                                     ; preds = %298
   %304 = load i8, i8* %302, align 8
   %305 = zext i8 %304 to i32
   %306 = trunc i32 %305 to i8
-  %NullCheck22 = icmp ne i8* %300, null
-  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i8* %300, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %307
 
 ; <label>:307                                     ; preds = %303
   store i8 %306, i8* %300, align 8
@@ -1235,14 +1317,14 @@ entry:
   %309 = load i8*, i8** %arg0
   %310 = load i8*, i8** %arg1
   %311 = bitcast i8* %310 to i64*
-  %NullCheck = icmp ne i64* %311, null
-  br i1 %NullCheck, label %312, label %ThrowNullRef
+  %NullCheck = icmp eq i64* %311, null
+  br i1 %NullCheck, label %ThrowNullRef, label %312
 
 ; <label>:312                                     ; preds = %308
   %313 = load i64, i64* %311, align 8
   %314 = bitcast i8* %309 to i64*
-  %NullCheck2 = icmp ne i64* %314, null
-  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64* %314, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %315
 
 ; <label>:315                                     ; preds = %312
   store i64 %313, i64* %314, align 8
@@ -1251,14 +1333,14 @@ entry:
   %318 = load i8*, i8** %arg1
   %319 = getelementptr inbounds i8, i8* %318, i64 8
   %320 = bitcast i8* %319 to i64*
-  %NullCheck4 = icmp ne i64* %320, null
-  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64* %320, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %321
 
 ; <label>:321                                     ; preds = %315
   %322 = load i64, i64* %320, align 8
   %323 = bitcast i8* %317 to i64*
-  %NullCheck6 = icmp ne i64* %323, null
-  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64* %323, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %324
 
 ; <label>:324                                     ; preds = %321
   store i64 %322, i64* %323, align 8
@@ -1286,15 +1368,15 @@ entry:
 ; <label>:338                                     ; preds = %333
   %339 = load i8*, i8** %arg0
   %340 = load i8*, i8** %arg1
-  %NullCheck136 = icmp ne i8* %340, null
-  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+  %NullCheck135 = icmp eq i8* %340, null
+  br i1 %NullCheck135, label %ThrowNullRef136, label %341
 
 ; <label>:341                                     ; preds = %338
   %342 = load i8, i8* %340, align 8
   %343 = zext i8 %342 to i32
   %344 = trunc i32 %343 to i8
-  %NullCheck138 = icmp ne i8* %339, null
-  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+  %NullCheck137 = icmp eq i8* %339, null
+  br i1 %NullCheck137, label %ThrowNullRef138, label %345
 
 ; <label>:345                                     ; preds = %341
   store i8 %344, i8* %339, align 8
@@ -1317,16 +1399,16 @@ entry:
   %357 = load i8*, i8** %arg0
   %358 = load i8*, i8** %arg1
   %359 = bitcast i8* %358 to i16*
-  %NullCheck140 = icmp ne i16* %359, null
-  br i1 %NullCheck140, label %360, label %ThrowNullRef139
+  %NullCheck139 = icmp eq i16* %359, null
+  br i1 %NullCheck139, label %ThrowNullRef140, label %360
 
 ; <label>:360                                     ; preds = %356
   %361 = load i16, i16* %359, align 8
   %362 = sext i16 %361 to i32
   %363 = bitcast i8* %357 to i16*
   %364 = trunc i32 %362 to i16
-  %NullCheck142 = icmp ne i16* %363, null
-  br i1 %NullCheck142, label %365, label %ThrowNullRef141
+  %NullCheck141 = icmp eq i16* %363, null
+  br i1 %NullCheck141, label %ThrowNullRef142, label %365
 
 ; <label>:365                                     ; preds = %360
   store i16 %364, i16* %363, align 8
@@ -1352,14 +1434,14 @@ entry:
   %378 = load i8*, i8** %arg0
   %379 = load i8*, i8** %arg1
   %380 = bitcast i8* %379 to i32*
-  %NullCheck144 = icmp ne i32* %380, null
-  br i1 %NullCheck144, label %381, label %ThrowNullRef143
+  %NullCheck143 = icmp eq i32* %380, null
+  br i1 %NullCheck143, label %ThrowNullRef144, label %381
 
 ; <label>:381                                     ; preds = %377
   %382 = load i32, i32* %380, align 8
   %383 = bitcast i8* %378 to i32*
-  %NullCheck146 = icmp ne i32* %383, null
-  br i1 %NullCheck146, label %384, label %ThrowNullRef145
+  %NullCheck145 = icmp eq i32* %383, null
+  br i1 %NullCheck145, label %ThrowNullRef146, label %384
 
 ; <label>:384                                     ; preds = %381
   store i32 %382, i32* %383, align 8
@@ -1384,14 +1466,14 @@ entry:
   %395 = load i8*, i8** %arg0
   %396 = load i8*, i8** %arg1
   %397 = bitcast i8* %396 to i64*
-  %NullCheck164 = icmp ne i64* %397, null
-  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+  %NullCheck163 = icmp eq i64* %397, null
+  br i1 %NullCheck163, label %ThrowNullRef164, label %398
 
 ; <label>:398                                     ; preds = %394
   %399 = load i64, i64* %397, align 8
   %400 = bitcast i8* %395 to i64*
-  %NullCheck166 = icmp ne i64* %400, null
-  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+  %NullCheck165 = icmp eq i64* %400, null
+  br i1 %NullCheck165, label %ThrowNullRef166, label %401
 
 ; <label>:401                                     ; preds = %398
   store i64 %399, i64* %400, align 8
@@ -1400,14 +1482,14 @@ entry:
   %404 = load i8*, i8** %arg1
   %405 = getelementptr inbounds i8, i8* %404, i64 8
   %406 = bitcast i8* %405 to i64*
-  %NullCheck168 = icmp ne i64* %406, null
-  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+  %NullCheck167 = icmp eq i64* %406, null
+  br i1 %NullCheck167, label %ThrowNullRef168, label %407
 
 ; <label>:407                                     ; preds = %401
   %408 = load i64, i64* %406, align 8
   %409 = bitcast i8* %403 to i64*
-  %NullCheck170 = icmp ne i64* %409, null
-  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+  %NullCheck169 = icmp eq i64* %409, null
+  br i1 %NullCheck169, label %ThrowNullRef170, label %410
 
 ; <label>:410                                     ; preds = %407
   store i64 %408, i64* %409, align 8
@@ -1437,14 +1519,14 @@ entry:
   %425 = load i8*, i8** %arg0
   %426 = load i8*, i8** %arg1
   %427 = bitcast i8* %426 to i64*
-  %NullCheck148 = icmp ne i64* %427, null
-  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+  %NullCheck147 = icmp eq i64* %427, null
+  br i1 %NullCheck147, label %ThrowNullRef148, label %428
 
 ; <label>:428                                     ; preds = %424
   %429 = load i64, i64* %427, align 8
   %430 = bitcast i8* %425 to i64*
-  %NullCheck150 = icmp ne i64* %430, null
-  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+  %NullCheck149 = icmp eq i64* %430, null
+  br i1 %NullCheck149, label %ThrowNullRef150, label %431
 
 ; <label>:431                                     ; preds = %428
   store i64 %429, i64* %430, align 8
@@ -1466,14 +1548,14 @@ entry:
   %441 = load i8*, i8** %arg0
   %442 = load i8*, i8** %arg1
   %443 = bitcast i8* %442 to i32*
-  %NullCheck152 = icmp ne i32* %443, null
-  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+  %NullCheck151 = icmp eq i32* %443, null
+  br i1 %NullCheck151, label %ThrowNullRef152, label %444
 
 ; <label>:444                                     ; preds = %440
   %445 = load i32, i32* %443, align 8
   %446 = bitcast i8* %441 to i32*
-  %NullCheck154 = icmp ne i32* %446, null
-  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+  %NullCheck153 = icmp eq i32* %446, null
+  br i1 %NullCheck153, label %ThrowNullRef154, label %447
 
 ; <label>:447                                     ; preds = %444
   store i32 %445, i32* %446, align 8
@@ -1495,16 +1577,16 @@ entry:
   %457 = load i8*, i8** %arg0
   %458 = load i8*, i8** %arg1
   %459 = bitcast i8* %458 to i16*
-  %NullCheck156 = icmp ne i16* %459, null
-  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+  %NullCheck155 = icmp eq i16* %459, null
+  br i1 %NullCheck155, label %ThrowNullRef156, label %460
 
 ; <label>:460                                     ; preds = %456
   %461 = load i16, i16* %459, align 8
   %462 = sext i16 %461 to i32
   %463 = bitcast i8* %457 to i16*
   %464 = trunc i32 %462 to i16
-  %NullCheck158 = icmp ne i16* %463, null
-  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+  %NullCheck157 = icmp eq i16* %463, null
+  br i1 %NullCheck157, label %ThrowNullRef158, label %465
 
 ; <label>:465                                     ; preds = %460
   store i16 %464, i16* %463, align 8
@@ -1525,15 +1607,15 @@ entry:
 ; <label>:474                                     ; preds = %470
   %475 = load i8*, i8** %arg0
   %476 = load i8*, i8** %arg1
-  %NullCheck160 = icmp ne i8* %476, null
-  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+  %NullCheck159 = icmp eq i8* %476, null
+  br i1 %NullCheck159, label %ThrowNullRef160, label %477
 
 ; <label>:477                                     ; preds = %474
   %478 = load i8, i8* %476, align 8
   %479 = zext i8 %478 to i32
   %480 = trunc i32 %479 to i8
-  %NullCheck162 = icmp ne i8* %475, null
-  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+  %NullCheck161 = icmp eq i8* %475, null
+  br i1 %NullCheck161, label %ThrowNullRef162, label %481
 
 ; <label>:481                                     ; preds = %477
   store i8 %480, i8* %475, align 8
@@ -1553,343 +1635,343 @@ ThrowNullRef:                                     ; preds = %308
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %312
+ThrowNullRef2:                                    ; preds = %312
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %315
+ThrowNullRef4:                                    ; preds = %315
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %321
+ThrowNullRef6:                                    ; preds = %321
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %271
+ThrowNullRef8:                                    ; preds = %271
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %275
+ThrowNullRef10:                                   ; preds = %275
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %278
+ThrowNullRef12:                                   ; preds = %278
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %284
+ThrowNullRef14:                                   ; preds = %284
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %287
+ThrowNullRef16:                                   ; preds = %287
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %293
+ThrowNullRef18:                                   ; preds = %293
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %298
+ThrowNullRef20:                                   ; preds = %298
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %303
+ThrowNullRef22:                                   ; preds = %303
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %243
+ThrowNullRef24:                                   ; preds = %243
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %247
+ThrowNullRef26:                                   ; preds = %247
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %250
+ThrowNullRef28:                                   ; preds = %250
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %256
+ThrowNullRef30:                                   ; preds = %256
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %259
+ThrowNullRef32:                                   ; preds = %259
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %265
+ThrowNullRef34:                                   ; preds = %265
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %217
+ThrowNullRef36:                                   ; preds = %217
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %221
+ThrowNullRef38:                                   ; preds = %221
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %224
+ThrowNullRef40:                                   ; preds = %224
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %230
+ThrowNullRef42:                                   ; preds = %230
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %233
+ThrowNullRef44:                                   ; preds = %233
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %238
+ThrowNullRef46:                                   ; preds = %238
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %200
+ThrowNullRef48:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %204
+ThrowNullRef50:                                   ; preds = %204
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %207
+ThrowNullRef52:                                   ; preds = %207
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %213
+ThrowNullRef54:                                   ; preds = %213
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %172
+ThrowNullRef56:                                   ; preds = %172
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %176
+ThrowNullRef58:                                   ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %179
+ThrowNullRef60:                                   ; preds = %179
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %185
+ThrowNullRef62:                                   ; preds = %185
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %190
+ThrowNullRef64:                                   ; preds = %190
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %195
+ThrowNullRef66:                                   ; preds = %195
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %153
+ThrowNullRef68:                                   ; preds = %153
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %157
+ThrowNullRef70:                                   ; preds = %157
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %160
+ThrowNullRef72:                                   ; preds = %160
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %166
+ThrowNullRef74:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %136
+ThrowNullRef76:                                   ; preds = %136
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %140
+ThrowNullRef78:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %143
+ThrowNullRef80:                                   ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %148
+ThrowNullRef82:                                   ; preds = %148
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %128
+ThrowNullRef84:                                   ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %132
+ThrowNullRef86:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %100
+ThrowNullRef88:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %104
+ThrowNullRef90:                                   ; preds = %104
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %107
+ThrowNullRef92:                                   ; preds = %107
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %113
+ThrowNullRef94:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %118
+ThrowNullRef96:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %123
+ThrowNullRef98:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %81
+ThrowNullRef100:                                  ; preds = %81
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef101:                                  ; preds = %85
+ThrowNullRef102:                                  ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef103:                                  ; preds = %88
+ThrowNullRef104:                                  ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef105:                                  ; preds = %94
+ThrowNullRef106:                                  ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef107:                                  ; preds = %64
+ThrowNullRef108:                                  ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef109:                                  ; preds = %68
+ThrowNullRef110:                                  ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef111:                                  ; preds = %71
+ThrowNullRef112:                                  ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef113:                                  ; preds = %76
+ThrowNullRef114:                                  ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef115:                                  ; preds = %56
+ThrowNullRef116:                                  ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef117:                                  ; preds = %60
+ThrowNullRef118:                                  ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef119:                                  ; preds = %37
+ThrowNullRef120:                                  ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef121:                                  ; preds = %41
+ThrowNullRef122:                                  ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef123:                                  ; preds = %46
+ThrowNullRef124:                                  ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef125:                                  ; preds = %51
+ThrowNullRef126:                                  ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef127:                                  ; preds = %27
+ThrowNullRef128:                                  ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef129:                                  ; preds = %31
+ThrowNullRef130:                                  ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef131:                                  ; preds = %19
+ThrowNullRef132:                                  ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef133:                                  ; preds = %22
+ThrowNullRef134:                                  ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef135:                                  ; preds = %338
+ThrowNullRef136:                                  ; preds = %338
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef137:                                  ; preds = %341
+ThrowNullRef138:                                  ; preds = %341
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef139:                                  ; preds = %356
+ThrowNullRef140:                                  ; preds = %356
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef141:                                  ; preds = %360
+ThrowNullRef142:                                  ; preds = %360
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef143:                                  ; preds = %377
+ThrowNullRef144:                                  ; preds = %377
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef145:                                  ; preds = %381
+ThrowNullRef146:                                  ; preds = %381
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef147:                                  ; preds = %424
+ThrowNullRef148:                                  ; preds = %424
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef149:                                  ; preds = %428
+ThrowNullRef150:                                  ; preds = %428
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef151:                                  ; preds = %440
+ThrowNullRef152:                                  ; preds = %440
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef153:                                  ; preds = %444
+ThrowNullRef154:                                  ; preds = %444
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef155:                                  ; preds = %456
+ThrowNullRef156:                                  ; preds = %456
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef157:                                  ; preds = %460
+ThrowNullRef158:                                  ; preds = %460
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef159:                                  ; preds = %474
+ThrowNullRef160:                                  ; preds = %474
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef161:                                  ; preds = %477
+ThrowNullRef162:                                  ; preds = %477
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef163:                                  ; preds = %394
+ThrowNullRef164:                                  ; preds = %394
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef165:                                  ; preds = %398
+ThrowNullRef166:                                  ; preds = %398
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef167:                                  ; preds = %401
+ThrowNullRef168:                                  ; preds = %401
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef169:                                  ; preds = %407
+ThrowNullRef170:                                  ; preds = %407
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1939,8 +2021,8 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
-  br i1 %NullCheck, label %22, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %ThrowNullRef, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
@@ -1948,8 +2030,8 @@ entry:
   store i32 %24, i32* %loc0
   %25 = load i32, i32* %loc0
   %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %26, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %27
 
 ; <label>:27                                      ; preds = %22
   %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
@@ -1971,7 +2053,7 @@ ThrowNullRef:                                     ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1989,8 +2071,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -2022,15 +2104,15 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2048,16 +2130,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
   %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
   store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %15
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
@@ -2072,8 +2154,8 @@ entry:
   %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
   %29 = ptrtoint i16 addrspace(1)* %28 to i64
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %19
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
@@ -2089,19 +2171,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2114,8 +2196,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
@@ -2128,7 +2210,7 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[loadElem]
+Failed to read AppDomain.PrepareDataForSetup[storeElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
@@ -2202,8 +2284,8 @@ entry:
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
-  br i1 %NullCheck24, label %27, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = load i64, i64 addrspace(1)* %26
@@ -2218,8 +2300,8 @@ entry:
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
-  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
   %41 = load i64, i64 addrspace(1)* %39
@@ -2236,8 +2318,8 @@ entry:
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
-  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
   %54 = load i64, i64 addrspace(1)* %52
@@ -2252,8 +2334,8 @@ entry:
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
   %67 = load i64, i64 addrspace(1)* %65
@@ -2270,8 +2352,8 @@ entry:
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
-  br i1 %NullCheck16, label %79, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
   %80 = load i64, i64 addrspace(1)* %78
@@ -2286,8 +2368,8 @@ entry:
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
-  br i1 %NullCheck18, label %92, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
   %93 = load i64, i64 addrspace(1)* %91
@@ -2304,8 +2386,8 @@ entry:
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
-  br i1 %NullCheck12, label %105, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = load i64, i64 addrspace(1)* %104
@@ -2320,8 +2402,8 @@ entry:
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
-  br i1 %NullCheck14, label %118, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
   %119 = load i64, i64 addrspace(1)* %117
@@ -2337,8 +2419,8 @@ entry:
 
 ; <label>:128                                     ; preds = %20
   %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
-  br i1 %NullCheck4, label %130, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %129, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %130
 
 ; <label>:130                                     ; preds = %128
   %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
@@ -2346,8 +2428,8 @@ entry:
   %133 = load i16, i16 addrspace(1)* %132, align 8
   %134 = zext i16 %133 to i32
   %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
-  br i1 %NullCheck6, label %136, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %135, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %136
 
 ; <label>:136                                     ; preds = %130
   %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
@@ -2360,8 +2442,8 @@ entry:
 
 ; <label>:143                                     ; preds = %136
   %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
-  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %144, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %145
 
 ; <label>:145                                     ; preds = %143
   %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
@@ -2369,8 +2451,8 @@ entry:
   %148 = load i16, i16 addrspace(1)* %147, align 8
   %149 = zext i16 %148 to i32
   %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %150, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %151
 
 ; <label>:151                                     ; preds = %145
   %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
@@ -2388,8 +2470,8 @@ entry:
 
 ; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
-  br i1 %NullCheck, label %163, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %ThrowNullRef, label %163
 
 ; <label>:163                                     ; preds = %161
   %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
@@ -2399,8 +2481,8 @@ entry:
 
 ; <label>:167                                     ; preds = %163
   %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
-  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %168, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %169
 
 ; <label>:169                                     ; preds = %167
   %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
@@ -2432,55 +2514,55 @@ ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %167
+ThrowNullRef2:                                    ; preds = %167
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %128
+ThrowNullRef4:                                    ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %130
+ThrowNullRef6:                                    ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %143
+ThrowNullRef8:                                    ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %145
+ThrowNullRef10:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %102
+ThrowNullRef12:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %105
+ThrowNullRef14:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %76
+ThrowNullRef16:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %79
+ThrowNullRef18:                                   ; preds = %79
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %50
+ThrowNullRef20:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %53
+ThrowNullRef22:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %24
+ThrowNullRef24:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %27
+ThrowNullRef26:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2503,15 +2585,15 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2519,16 +2601,16 @@ entry:
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
   store i32 %8, i32* %loc0
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
   %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
   store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
@@ -2546,16 +2628,16 @@ entry:
 
 ; <label>:23                                      ; preds = %64
   %24 = load i16*, i16** %loc3
-  %NullCheck12 = icmp ne i16* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i16* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
   store i32 %27, i32* %loc5
   %28 = load i16*, i16** %loc4
-  %NullCheck14 = icmp ne i16* %28, null
-  br i1 %NullCheck14, label %29, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %28, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = load i16, i16* %28, align 8
@@ -2620,15 +2702,15 @@ entry:
 
 ; <label>:67                                      ; preds = %64
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
-  br i1 %NullCheck8, label %69, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %68, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %69
 
 ; <label>:69                                      ; preds = %67
   %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
   %71 = load i32, i32 addrspace(1)* %70
   %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
-  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %73
 
 ; <label>:73                                      ; preds = %69
   %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
@@ -2645,31 +2727,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %67
+ThrowNullRef8:                                    ; preds = %67
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %69
+ThrowNullRef10:                                   ; preds = %69
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2710,14 +2792,14 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
   %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
@@ -2730,14 +2812,14 @@ entry:
 
 ; <label>:11                                      ; preds = %4
   %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
   %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
@@ -2749,14 +2831,14 @@ entry:
 
 ; <label>:22                                      ; preds = %16
   %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
   %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
-  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
-  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
@@ -2804,23 +2886,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2836,7 +2918,280 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[loadElem]
+Successfully read RuntimeType.IsAssignableFrom
+
+define i8 @RuntimeType.IsAssignableFrom(%System.RuntimeType addrspace(1)* %param0, %System.Type addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.RuntimeType addrspace(1)*
+  %arg1 = alloca %System.Type addrspace(1)*
+  %loc0 = alloca %System.RuntimeType addrspace(1)*
+  %loc1 = alloca %"System.Type[]" addrspace(1)*
+  %loc2 = alloca i32
+  store %System.RuntimeType addrspace(1)* %param0, %System.RuntimeType addrspace(1)** %this
+  store %System.Type addrspace(1)* %param1, %System.Type addrspace(1)** %arg1
+  %0 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %1 = icmp ne %System.Type addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i8 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %5 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %6 = bitcast %System.Type addrspace(1)* %4 to %System.Object addrspace(1)*
+  %7 = bitcast %System.RuntimeType addrspace(1)* %5 to %System.Object addrspace(1)*
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %6, %System.Object addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %3
+  ret i8 1
+
+; <label>:12                                      ; preds = %3
+  %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 152
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 32
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
+  %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
+  %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
+  store %System.RuntimeType addrspace(1)* %25, %System.RuntimeType addrspace(1)** %loc0
+  %26 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %27 = icmp eq %System.RuntimeType addrspace(1)* %26, null
+  br i1 %27, label %34, label %28
+
+; <label>:28                                      ; preds = %15
+  %29 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %30 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)*)*)(%System.RuntimeType addrspace(1)* %29, %System.RuntimeType addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+; <label>:34                                      ; preds = %15
+  %35 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %36 = call %System.Reflection.Emit.TypeBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Reflection.Emit.TypeBuilder addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %35)
+  %37 = icmp eq %System.Reflection.Emit.TypeBuilder addrspace(1)* %36, null
+  br i1 %37, label %139, label %38
+
+; <label>:38                                      ; preds = %34
+  %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %42
+
+; <label>:42                                      ; preds = %38
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 152
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 40
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
+  %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
+  %53 = zext i8 %52 to i32
+  %54 = icmp eq i32 %53, 0
+  br i1 %54, label %56, label %55
+
+; <label>:55                                      ; preds = %42
+  ret i8 1
+
+; <label>:56                                      ; preds = %42
+  %57 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %58 = bitcast %System.RuntimeType addrspace(1)* %57 to %System.Type addrspace(1)*
+  %59 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %58)
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %64 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.Type addrspace(1)* %63, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = bitcast %System.RuntimeType addrspace(1)* %64 to %System.Type addrspace(1)*
+  %67 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %63, %System.Type addrspace(1)* %66)
+  %68 = zext i8 %67 to i32
+  %69 = trunc i32 %68 to i8
+  ret i8 %69
+
+; <label>:70                                      ; preds = %56
+  %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
+  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %73
+
+; <label>:73                                      ; preds = %70
+  %74 = load i64, i64 addrspace(1)* %72
+  %75 = add i64 %74, 128
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = add i64 %77, 0
+  %79 = inttoptr i64 %78 to i64*
+  %80 = load i64, i64* %79
+  %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
+  %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
+  %83 = call i8 %82(%System.Type addrspace(1)* %81)
+  %84 = zext i8 %83 to i32
+  %85 = icmp eq i32 %84, 0
+  br i1 %85, label %139, label %86
+
+; <label>:86                                      ; preds = %73
+  %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
+  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %89
+
+; <label>:89                                      ; preds = %86
+  %90 = load i64, i64 addrspace(1)* %88
+  %91 = add i64 %90, 128
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = add i64 %93, 24
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
+  %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
+  %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
+  store %"System.Type[]" addrspace(1)* %99, %"System.Type[]" addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %129
+
+; <label>:100                                     ; preds = %132
+  %101 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %102 = load i32, i32* %loc2
+  %NullCheck11 = icmp eq %"System.Type[]" addrspace(1)* %101, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %103
+
+; <label>:103                                     ; preds = %100
+  %104 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 1
+  %105 = load i32, i32 addrspace(1)* %104
+  %106 = zext i32 %105 to i64
+  %107 = zext i32 %102 to i64
+  %BoundsCheck = icmp uge i64 %107, %106
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %108
+
+; <label>:108                                     ; preds = %103
+  %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
+  %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
+  %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
+  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %113
+
+; <label>:113                                     ; preds = %108
+  %114 = load i64, i64 addrspace(1)* %112
+  %115 = add i64 %114, 152
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = add i64 %117, 56
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
+  %123 = zext i8 %122 to i32
+  %124 = icmp ne i32 %123, 0
+  br i1 %124, label %126, label %125
+
+; <label>:125                                     ; preds = %113
+  ret i8 0
+
+; <label>:126                                     ; preds = %113
+  %127 = load i32, i32* %loc2
+  %128 = add i32 %127, 1
+  store i32 %128, i32* %loc2
+  br label %129
+
+; <label>:129                                     ; preds = %89, %126
+  %130 = load i32, i32* %loc2
+  %131 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %NullCheck9 = icmp eq %"System.Type[]" addrspace(1)* %131, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %132
+
+; <label>:132                                     ; preds = %129
+  %133 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %131, i32 0, i32 1
+  %134 = load i32, i32 addrspace(1)* %133
+  %135 = zext i32 %134 to i64
+  %136 = trunc i64 %135 to i32
+  %137 = icmp slt i32 %130, %136
+  br i1 %137, label %100, label %138
+
+; <label>:138                                     ; preds = %132
+  ret i8 1
+
+; <label>:139                                     ; preds = %34, %73
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %129
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %103
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -2893,7 +3248,7 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElem]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -2904,8 +3259,8 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -2997,8 +3352,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
@@ -3059,8 +3414,8 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -3087,8 +3442,8 @@ entry:
 
 ; <label>:17                                      ; preds = %5, %11
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
@@ -3097,8 +3452,8 @@ entry:
 
 ; <label>:22                                      ; preds = %1, %11
   %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
@@ -3109,11 +3464,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %17
+ThrowNullRef2:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %22
+ThrowNullRef4:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3167,15 +3522,15 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
   %15 = load i32, i32 addrspace(1)* %14
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
@@ -3198,7 +3553,7 @@ ThrowNullRef:                                     ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef2:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3232,8 +3587,8 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
@@ -3312,8 +3667,8 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -3327,8 +3682,8 @@ entry:
 ; <label>:5                                       ; preds = %43
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %7 = load i32, i32* %loc1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck6, label %8, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
@@ -3366,8 +3721,8 @@ entry:
 ; <label>:32                                      ; preds = %21, %25
   %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
   %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
-  br i1 %NullCheck8, label %35, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = trunc i32 %34 to i16
@@ -3380,8 +3735,8 @@ entry:
 ; <label>:40                                      ; preds = %1, %35
   %41 = load i32, i32* %loc1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
-  br i1 %NullCheck2, label %43, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %42, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
@@ -3392,8 +3747,8 @@ entry:
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
   %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
-  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
   %51 = load i64, i64 addrspace(1)* %49
@@ -3412,19 +3767,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %40
+ThrowNullRef2:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %47
+ThrowNullRef4:                                    ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %5
+ThrowNullRef6:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %32
+ThrowNullRef8:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3467,8 +3822,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
@@ -3492,11 +3847,391 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(i16* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store i16* %param0, i16** %arg0
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load i32, i32* %arg3
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %42, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %37, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg2
+  %13 = load i32, i32* %arg3
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %37, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %24 = load i32, i32* %arg2
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load i16*, i16** %arg0
+  %35 = load i32, i32* %arg3
+  %36 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %36, i16* %34, i32 %35)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:37                                      ; preds = %5, %16
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %39)
+  %41 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41, %System.String addrspace(1)* %38, %System.String addrspace(1)* %40)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41) #0
+  unreachable
+
+; <label>:42                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
-Failed to read StringBuilder.ToString[loadElemA]
+Successfully read StringBuilder.ToString
+
+define %System.String addrspace(1)* @StringBuilder.ToString(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i16*
+  %loc3 = alloca %"System.Char[]" addrspace(1)*
+  %loc4 = alloca i32
+  %loc5 = alloca i32
+  %loc6 = alloca i16 addrspace(1)*
+  %loc7 = alloca %System.String addrspace(1)*
+  %loc8 = alloca %"System.Char[]" addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %0)
+  %2 = icmp ne i32 %1, 0
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %4
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %6)
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %7)
+  store %System.String addrspace(1)* %8, %System.String addrspace(1)** %loc0
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.Text.StringBuilder addrspace(1)* %9, %System.Text.StringBuilder addrspace(1)** %loc1
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  store %System.String addrspace(1)* %10, %System.String addrspace(1)** %loc7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc7
+  %12 = ptrtoint %System.String addrspace(1)* %11 to i64
+  %13 = icmp eq i64 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %5
+  %15 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %16 = sext i32 %15 to i64
+  %17 = add i64 %12, %16
+  br label %18
+
+; <label>:18                                      ; preds = %5, %14
+  %19 = phi i64 [ %12, %5 ], [ %17, %14 ]
+  %20 = inttoptr i64 %19 to i16*
+  store i16* %20, i16** %loc2
+  br label %21
+
+; <label>:21                                      ; preds = %98, %18
+  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %22, null
+  br i1 %NullCheck, label %ThrowNullRef, label %23
+
+; <label>:23                                      ; preds = %21
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 3
+  %25 = load i32, i32 addrspace(1)* %24, align 8
+  %26 = icmp sle i32 %25, 0
+  br i1 %26, label %96, label %27
+
+; <label>:27                                      ; preds = %23
+  %28 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %28, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %29
+
+; <label>:29                                      ; preds = %27
+  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %28, i32 0, i32 1
+  %31 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %30, align 8
+  store %"System.Char[]" addrspace(1)* %31, %"System.Char[]" addrspace(1)** %loc3
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %33
+
+; <label>:33                                      ; preds = %29
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  store i32 %35, i32* %loc4
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  %39 = load i32, i32 addrspace(1)* %38, align 8
+  store i32 %39, i32* %loc5
+  %40 = load i32, i32* %loc5
+  %41 = load i32, i32* %loc4
+  %42 = add i32 %40, %41
+  %43 = zext i32 %42 to i64
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %45
+
+; <label>:45                                      ; preds = %37
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = sext i32 %47 to i64
+  %49 = icmp sgt i64 %43, %48
+  br i1 %49, label %91, label %50
+
+; <label>:50                                      ; preds = %45
+  %51 = load i32, i32* %loc5
+  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %52, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %53
+
+; <label>:53                                      ; preds = %50
+  %54 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %52, i32 0, i32 1
+  %55 = load i32, i32 addrspace(1)* %54
+  %56 = zext i32 %55 to i64
+  %57 = trunc i64 %56 to i32
+  %58 = icmp ugt i32 %51, %57
+  br i1 %58, label %91, label %59
+
+; <label>:59                                      ; preds = %53
+  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  store %"System.Char[]" addrspace(1)* %60, %"System.Char[]" addrspace(1)** %loc8
+  %61 = icmp eq %"System.Char[]" addrspace(1)* %60, null
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %63, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %64
+
+; <label>:64                                      ; preds = %62
+  %65 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %63, i32 0, i32 1
+  %66 = load i32, i32 addrspace(1)* %65
+  %67 = zext i32 %66 to i64
+  %68 = trunc i64 %67 to i32
+  %69 = icmp ne i32 %68, 0
+  br i1 %69, label %71, label %70
+
+; <label>:70                                      ; preds = %59, %64
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:71                                      ; preds = %64
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %73
+
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %BoundsCheck = icmp uge i64 0, %76
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %77
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %78, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:79                                      ; preds = %70, %77
+  %80 = load i16*, i16** %loc2
+  %81 = load i32, i32* %loc4
+  %82 = sext i32 %81 to i64
+  %83 = mul i64 %82, 2
+  %84 = bitcast i16* %80 to i8*
+  %85 = getelementptr inbounds i8, i8* %84, i64 %83
+  %86 = load i16 addrspace(1)*, i16 addrspace(1)** %loc6
+  %87 = ptrtoint i16 addrspace(1)* %86 to i64
+  %88 = load i32, i32* %loc5
+  %89 = bitcast i8* %85 to i16*
+  %90 = inttoptr i64 %87 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %89, i16* %90, i32 %88)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %96
+
+; <label>:91                                      ; preds = %45, %53
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %94 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %93)
+  %95 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95, %System.String addrspace(1)* %92, %System.String addrspace(1)* %94)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95) #0
+  unreachable
+
+; <label>:96                                      ; preds = %23, %79
+  %97 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %97, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %98
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %97, i32 0, i32 2
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  store %System.Text.StringBuilder addrspace(1)* %100, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %102 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %102, label %21, label %103
+
+; <label>:103                                     ; preds = %98
+  store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc7
+  %104 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  ret %System.String addrspace(1)* %104
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method StringBuilder::get_Length using LLILCJit
+Successfully read StringBuilder.get_Length
+
+define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
+Successfully read RuntimeHelpers.get_OffsetToStringData
+
+define i32 @RuntimeHelpers.get_OffsetToStringData() {
+entry:
+  ret i32 12
+}
+
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
 Successfully read CultureData.CreateCultureData
 
@@ -3514,23 +4249,23 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
   store i8 %4, i8 addrspace(1)* %6
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
@@ -3549,11 +4284,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3566,50 +4301,50 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
   store i32 -1, i32 addrspace(1)* %2
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
   store i32 -1, i32 addrspace(1)* %8
   %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
   store i32 -1, i32 addrspace(1)* %14
   %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
   store i32 -1, i32 addrspace(1)* %17
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
@@ -3623,27 +4358,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3675,7 +4410,136 @@ Failed to read Dictionary`2.Insert[non-const derefAddress]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
 Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
-Failed to read HashHelpers.GetPrime[loadElem]
+Successfully read HashHelpers.GetPrime
+
+define i32 @HashHelpers.GetPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %6, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5, %System.String addrspace(1)* %4)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5) #0
+  unreachable
+
+; <label>:6                                       ; preds = %entry
+  store i32 0, i32* %loc0
+  br label %29
+
+; <label>:7                                       ; preds = %35
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 1296
+  %10 = addrspacecast i8 addrspace(1)* %9 to %"System.Int32[]" addrspace(1)**
+  %11 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %10
+  %12 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Int32[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = zext i32 %15 to i64
+  %17 = zext i32 %12 to i64
+  %BoundsCheck = icmp uge i64 %17, %16
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 3, i32 %12
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  store i32 %20, i32* %loc1
+  %21 = load i32, i32* %loc1
+  %22 = load i32, i32* %arg0
+  %23 = icmp slt i32 %21, %22
+  br i1 %23, label %26, label %24
+
+; <label>:24                                      ; preds = %18
+  %25 = load i32, i32* %loc1
+  ret i32 %25
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %loc0
+  %28 = add i32 %27, 1
+  store i32 %28, i32* %loc0
+  br label %29
+
+; <label>:29                                      ; preds = %6, %26
+  %30 = load i32, i32* %loc0
+  %31 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %32 = getelementptr inbounds i8, i8 addrspace(1)* %31, i64 1296
+  %33 = addrspacecast i8 addrspace(1)* %32 to %"System.Int32[]" addrspace(1)**
+  %34 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %33
+  %NullCheck = icmp eq %"System.Int32[]" addrspace(1)* %34, null
+  br i1 %NullCheck, label %ThrowNullRef, label %35
+
+; <label>:35                                      ; preds = %29
+  %36 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %34, i32 0, i32 1
+  %37 = load i32, i32 addrspace(1)* %36
+  %38 = zext i32 %37 to i64
+  %39 = trunc i64 %38 to i32
+  %40 = icmp slt i32 %30, %39
+  br i1 %40, label %7, label %41
+
+; <label>:41                                      ; preds = %35
+  %42 = load i32, i32* %arg0
+  %43 = or i32 %42, 1
+  store i32 %43, i32* %loc2
+  br label %59
+
+; <label>:44                                      ; preds = %59
+  %45 = load i32, i32* %loc2
+  %46 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %45)
+  %47 = zext i8 %46 to i32
+  %48 = icmp eq i32 %47, 0
+  br i1 %48, label %56, label %49
+
+; <label>:49                                      ; preds = %44
+  %50 = load i32, i32* %loc2
+  %51 = sub i32 %50, 1
+  %52 = srem i32 %51, 101
+  %53 = icmp eq i32 %52, 0
+  br i1 %53, label %56, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = load i32, i32* %loc2
+  ret i32 %55
+
+; <label>:56                                      ; preds = %44, %49
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %57, 2
+  store i32 %58, i32* %loc2
+  br label %59
+
+; <label>:59                                      ; preds = %41, %56
+  %60 = load i32, i32* %loc2
+  %61 = icmp slt i32 %60, 2147483647
+  br i1 %61, label %44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load i32, i32* %arg0
+  ret i32 %63
+
+ThrowNullRef:                                     ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
 Successfully read GenericEqualityComparer`1.GetHashCode
 
@@ -3694,14 +4558,14 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
   %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load i64, i64 addrspace(1)* %7
@@ -3720,7 +4584,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3750,8 +4614,8 @@ entry:
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
@@ -3796,8 +4660,8 @@ entry:
   %35 = bitcast i16* %34 to i8*
   %36 = getelementptr inbounds i8, i8* %35, i64 2
   %37 = bitcast i8* %36 to i16*
-  %NullCheck4 = icmp ne i16* %37, null
-  br i1 %NullCheck4, label %38, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %37, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %38
 
 ; <label>:38                                      ; preds = %27
   %39 = load i16, i16* %37, align 8
@@ -3824,8 +4688,8 @@ entry:
 
 ; <label>:54                                      ; preds = %22, %43
   %55 = load i16*, i16** %loc4
-  %NullCheck2 = icmp ne i16* %55, null
-  br i1 %NullCheck2, label %56, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i16* %55, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %56
 
 ; <label>:56                                      ; preds = %54
   %57 = load i16, i16* %55, align 8
@@ -3850,11 +4714,11 @@ ThrowNullRef:                                     ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %54
+ThrowNullRef2:                                    ; preds = %54
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %27
+ThrowNullRef4:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3871,8 +4735,8 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -3907,8 +4771,8 @@ entry:
 
 ; <label>:26                                      ; preds = %19
   %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
-  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %28
 
 ; <label>:28                                      ; preds = %26
   %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
@@ -3920,7 +4784,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3972,8 +4836,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
@@ -3984,26 +4848,26 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
-  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
@@ -4014,8 +4878,8 @@ entry:
 ; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
@@ -4024,8 +4888,8 @@ entry:
 
 ; <label>:25                                      ; preds = %1, %16, %23
   %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
-  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
@@ -4036,27 +4900,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %20
+ThrowNullRef10:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4069,8 +4933,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -4081,8 +4945,8 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
@@ -4091,8 +4955,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1, %8
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
@@ -4103,11 +4967,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4128,24 +4992,24 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   store i32 %3, i32* %loc0
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
   %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
   store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck4, label %9, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
@@ -4164,15 +5028,15 @@ entry:
 ; <label>:18                                      ; preds = %70
   %19 = load i16*, i16** %loc3
   %20 = bitcast i16* %19 to i64*
-  %NullCheck10 = icmp ne i64* %20, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %20, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = load i64, i64* %20, align 8
   %23 = load i16*, i16** %loc4
   %24 = bitcast i16* %23 to i64*
-  %NullCheck12 = icmp ne i64* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = load i64, i64* %24, align 8
@@ -4188,8 +5052,8 @@ entry:
   %31 = bitcast i16* %30 to i8*
   %32 = getelementptr inbounds i8, i8* %31, i64 8
   %33 = bitcast i8* %32 to i64*
-  %NullCheck14 = icmp ne i64* %33, null
-  br i1 %NullCheck14, label %34, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = load i64, i64* %33, align 8
@@ -4197,8 +5061,8 @@ entry:
   %37 = bitcast i16* %36 to i8*
   %38 = getelementptr inbounds i8, i8* %37, i64 8
   %39 = bitcast i8* %38 to i64*
-  %NullCheck16 = icmp ne i64* %39, null
-  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %40
 
 ; <label>:40                                      ; preds = %34
   %41 = load i64, i64* %39, align 8
@@ -4214,8 +5078,8 @@ entry:
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %NullCheck18 = icmp ne i64* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = load i64, i64* %48, align 8
@@ -4223,8 +5087,8 @@ entry:
   %52 = bitcast i16* %51 to i8*
   %53 = getelementptr inbounds i8, i8* %52, i64 16
   %54 = bitcast i8* %53 to i64*
-  %NullCheck20 = icmp ne i64* %54, null
-  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64* %54, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %55
 
 ; <label>:55                                      ; preds = %49
   %56 = load i64, i64* %54, align 8
@@ -4262,15 +5126,15 @@ entry:
 ; <label>:74                                      ; preds = %95
   %75 = load i16*, i16** %loc3
   %76 = bitcast i16* %75 to i32*
-  %NullCheck6 = icmp ne i32* %76, null
-  br i1 %NullCheck6, label %77, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32* %76, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %77
 
 ; <label>:77                                      ; preds = %74
   %78 = load i32, i32* %76, align 8
   %79 = load i16*, i16** %loc4
   %80 = bitcast i16* %79 to i32*
-  %NullCheck8 = icmp ne i32* %80, null
-  br i1 %NullCheck8, label %81, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i32* %80, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %81
 
 ; <label>:81                                      ; preds = %77
   %82 = load i32, i32* %80, align 8
@@ -4318,43 +5182,43 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %74
+ThrowNullRef6:                                    ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %77
+ThrowNullRef8:                                    ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %29
+ThrowNullRef14:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %34
+ThrowNullRef16:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4376,8 +5240,8 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load i64, i64 addrspace(1)* %4
@@ -4389,8 +5253,8 @@ entry:
   %12 = load i64, i64* %11
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %5
   %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
@@ -4399,8 +5263,8 @@ entry:
   %18 = load i8, i8* %arg2
   %19 = zext i8 %18 to i32
   %20 = trunc i32 %19 to i8
-  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %15
   %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
@@ -4411,11 +5275,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4442,8 +5306,8 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
@@ -4466,16 +5330,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
   %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = load i64, i64 addrspace(1)* %19
@@ -4500,8 +5364,8 @@ entry:
 ; <label>:35                                      ; preds = %30
   %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
@@ -4514,8 +5378,8 @@ entry:
 
 ; <label>:42                                      ; preds = %1, %38
   %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
-  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
@@ -4526,19 +5390,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %35
+ThrowNullRef2:                                    ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %42
+ThrowNullRef8:                                    ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4551,14 +5415,14 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
@@ -4570,7 +5434,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4583,8 +5447,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
@@ -4613,51 +5477,51 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
   %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
   %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
   %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
   %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
-  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
   store i64 %21, i64 addrspace(1)* %23
   %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %25 = load i64, i64* %loc0
-  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
@@ -4668,27 +5532,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %22
+ThrowNullRef12:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4701,8 +5565,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
@@ -4713,19 +5577,19 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
@@ -4734,8 +5598,8 @@ entry:
 
 ; <label>:15                                      ; preds = %1, %13
   %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
@@ -4746,19 +5610,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %15
+ThrowNullRef8:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4771,8 +5635,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -4831,8 +5695,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
@@ -4882,8 +5746,8 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
-  br i1 %NullCheck, label %17, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %ThrowNullRef, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
@@ -4894,15 +5758,15 @@ entry:
 
 ; <label>:22                                      ; preds = %17
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
-  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
   %26 = load i32, i32 addrspace(1)* %25
   %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
-  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %27, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
@@ -4925,8 +5789,8 @@ entry:
 ; <label>:40                                      ; preds = %17
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
-  br i1 %NullCheck6, label %43, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %41, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
@@ -4938,34 +5802,17 @@ ThrowNullRef:                                     ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %24
+ThrowNullRef4:                                    ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %40
+ThrowNullRef6:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
-}
-
-INFO:  jitting method Object::ReferenceEquals using LLILCJit
-Successfully read Object.ReferenceEquals
-
-define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
-entry:
-  %arg0 = alloca %System.Object addrspace(1)*
-  %arg1 = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
-  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
-  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = icmp eq %System.Object addrspace(1)* %0, %1
-  %3 = sext i1 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
 }
 
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
@@ -4978,21 +5825,21 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
   %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
-  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
@@ -5007,28 +5854,28 @@ entry:
 ; <label>:13                                      ; preds = %8, %12
   %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
   %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
   %21 = load i32, i32 addrspace(1)* %20, align 8
   %22 = add i32 %21, 1
-  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
   store i32 %22, i32 addrspace(1)* %24
   %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
@@ -5039,27 +5886,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5077,7 +5924,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::Setup using LLILCJit
-Failed to read AppDomain.Setup[loadElem]
+Failed to read AppDomain.Setup[unbox]
 INFO:  jitting method Thread::GetDomain using LLILCJit
 Successfully read Thread.GetDomain
 
@@ -5108,8 +5955,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
@@ -5122,14 +5969,14 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
   %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
@@ -5141,11 +5988,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5173,8 +6020,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -5189,7 +6036,328 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
 Failed to read KeyCollection.System.Collections.Generic.IEnumerable<TKey>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Successfully read Enumerator.MoveNext
+
+define i8 @Enumerator.MoveNext(%"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.RuntimeTypeHandle* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*
+  %"$TypeArg" = alloca %System.RuntimeTypeHandle*
+  store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
+  %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 8
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %76, label %12
+
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
+  br label %76
+
+; <label>:13                                      ; preds = %85
+  %14 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck19 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %15
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, i32 0, i32 0
+  %17 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %16, align 8
+  %NullCheck21 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, i32 0, i32 2
+  %20 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %19, align 8
+  %21 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck23 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %22
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, i32 0, i32 2
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %NullCheck25 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 3, i32 %24
+  %NullCheck27 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %32
+
+; <label>:32                                      ; preds = %30
+  %33 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, i32 0, i32 2
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = icmp slt i32 %34, 0
+  br i1 %35, label %68, label %36
+
+; <label>:36                                      ; preds = %32
+  %37 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %38 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck29 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %39
+
+; <label>:39                                      ; preds = %36
+  %40 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, i32 0, i32 0
+  %41 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %40, align 8
+  %NullCheck31 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, i32 0, i32 2
+  %44 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %43, align 8
+  %45 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck33 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, i32 0, i32 2
+  %48 = load i32, i32 addrspace(1)* %47, align 8
+  %NullCheck35 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %49
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = zext i32 %51 to i64
+  %53 = zext i32 %48 to i64
+  %BoundsCheck37 = icmp uge i64 %53, %52
+  br i1 %BoundsCheck37, label %ThrowIndexOutOfRange38, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 3, i32 %48
+  %NullCheck39 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %56
+
+; <label>:56                                      ; preds = %54
+  %57 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, i32 0, i32 0
+  %58 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck41 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %59
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %60, %System.__Canon addrspace(1)* %58)
+  %61 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck43 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  %64 = load i32, i32 addrspace(1)* %63, align 8
+  %65 = add i32 %64, 1
+  %NullCheck45 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  store i32 %65, i32 addrspace(1)* %67
+  ret i8 1
+
+; <label>:68                                      ; preds = %32
+  %69 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck47 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %73 = add i32 %72, 1
+  %NullCheck49 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %74
+
+; <label>:74                                      ; preds = %70
+  %75 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  store i32 %73, i32 addrspace(1)* %75
+  br label %76
+
+; <label>:76                                      ; preds = %8, %12, %74
+  %77 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %78
+
+; <label>:78                                      ; preds = %76
+  %79 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, i32 0, i32 2
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck7 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %82
+
+; <label>:82                                      ; preds = %78
+  %83 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, i32 0, i32 0
+  %84 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %83, align 8
+  %NullCheck9 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %85
+
+; <label>:85                                      ; preds = %82
+  %86 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, i32 0, i32 7
+  %87 = load i32, i32 addrspace(1)* %86, align 8
+  %88 = icmp ult i32 %80, %87
+  br i1 %88, label %13, label %89
+
+; <label>:89                                      ; preds = %85
+  %90 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %91 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck11 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %92
+
+; <label>:92                                      ; preds = %89
+  %93 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, i32 0, i32 0
+  %94 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck13 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %95
+
+; <label>:95                                      ; preds = %92
+  %96 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, i32 0, i32 7
+  %97 = load i32, i32 addrspace(1)* %96, align 8
+  %98 = add i32 %97, 1
+  %NullCheck15 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %99
+
+; <label>:99                                      ; preds = %95
+  %100 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, i32 0, i32 2
+  store i32 %98, i32 addrspace(1)* %100
+  %101 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck17 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %102
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %103, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %92
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef22:                                   ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef24:                                   ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef26:                                   ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef28:                                   ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef30:                                   ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef32:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef34:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef36:                                   ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange38:                           ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef40:                                   ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef42:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef44:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef46:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef48:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef50:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -5200,8 +6368,8 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -5232,9 +6400,9 @@ Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
 Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
-Failed to read String.MakeSeparatorList[loadElemA]
+Failed to read String.MakeSeparatorList[storeElem]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
-Failed to read String.InternalSplitKeepEmptyEntries[loadElem]
+Failed to read String.InternalSplitKeepEmptyEntries[storeElem]
 INFO:  jitting method Path::IsRelative using LLILCJit
 Successfully read Path.IsRelative
 
@@ -5243,8 +6411,8 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -5254,8 +6422,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
@@ -5271,8 +6439,8 @@ entry:
 
 ; <label>:17                                      ; preds = %7
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
@@ -5288,8 +6456,8 @@ entry:
 
 ; <label>:29                                      ; preds = %19
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %31
 
 ; <label>:31                                      ; preds = %29
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
@@ -5300,8 +6468,8 @@ entry:
 
 ; <label>:36                                      ; preds = %31
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
-  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %37, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
@@ -5312,8 +6480,8 @@ entry:
 
 ; <label>:43                                      ; preds = %31, %38
   %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
-  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %45
 
 ; <label>:45                                      ; preds = %43
   %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
@@ -5324,8 +6492,8 @@ entry:
 
 ; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %50
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
@@ -5336,8 +6504,8 @@ entry:
 
 ; <label>:57                                      ; preds = %1, %7, %19, %45, %52
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
-  br i1 %NullCheck14, label %59, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %59
 
 ; <label>:59                                      ; preds = %57
   %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
@@ -5347,8 +6515,8 @@ entry:
 
 ; <label>:63                                      ; preds = %59
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
@@ -5359,8 +6527,8 @@ entry:
 
 ; <label>:70                                      ; preds = %65
   %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
-  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.String addrspace(1)* %71, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %72
 
 ; <label>:72                                      ; preds = %70
   %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
@@ -5379,39 +6547,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %17
+ThrowNullRef4:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %29
+ThrowNullRef6:                                    ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %36
+ThrowNullRef8:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %43
+ThrowNullRef10:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %50
+ThrowNullRef12:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %57
+ThrowNullRef14:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %63
+ThrowNullRef16:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %70
+ThrowNullRef18:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5419,7 +6587,293 @@ ThrowNullRef17:                                   ; preds = %70
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
-Failed to read String.TrimHelper[loadElem]
+Successfully read String.TrimHelper
+
+define %System.String addrspace(1)* @String.TrimHelper(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i16
+  %loc4 = alloca i32
+  %loc5 = alloca i16
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = sub i32 %3, 1
+  store i32 %4, i32* %loc0
+  store i32 0, i32* %loc1
+  %5 = load i32, i32* %arg2
+  %6 = icmp eq i32 %5, 1
+  br i1 %6, label %62, label %7
+
+; <label>:7                                       ; preds = %1
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:8                                       ; preds = %58
+  store i32 0, i32* %loc2
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load i32, i32* %loc1
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2, i32 %10
+  %13 = load i16, i16 addrspace(1)* %12
+  %14 = zext i16 %13 to i32
+  %15 = trunc i32 %14 to i16
+  store i16 %15, i16* %loc3
+  store i32 0, i32* %loc2
+  br label %34
+
+; <label>:16                                      ; preds = %37
+  %17 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %18 = load i32, i32* %loc2
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %17, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %19
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = zext i32 %18 to i64
+  %BoundsCheck = icmp uge i64 %23, %22
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %24
+
+; <label>:24                                      ; preds = %19
+  %25 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 3, i32 %18
+  %26 = load i16, i16 addrspace(1)* %25, align 8
+  %27 = zext i16 %26 to i32
+  %28 = load i16, i16* %loc3
+  %29 = zext i16 %28 to i32
+  %30 = icmp eq i32 %27, %29
+  br i1 %30, label %43, label %31
+
+; <label>:31                                      ; preds = %24
+  %32 = load i32, i32* %loc2
+  %33 = add i32 %32, 1
+  store i32 %33, i32* %loc2
+  br label %34
+
+; <label>:34                                      ; preds = %11, %31
+  %35 = load i32, i32* %loc2
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = icmp slt i32 %35, %41
+  br i1 %42, label %16, label %43
+
+; <label>:43                                      ; preds = %24, %37
+  %44 = load i32, i32* %loc2
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %45, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp eq i32 %44, %50
+  br i1 %51, label %62, label %52
+
+; <label>:52                                      ; preds = %46
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %7, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %57, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %58
+
+; <label>:58                                      ; preds = %55
+  %59 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %60 = load i32, i32 addrspace(1)* %59
+  %61 = icmp slt i32 %56, %60
+  br i1 %61, label %8, label %62
+
+; <label>:62                                      ; preds = %1, %46, %58
+  %63 = load i32, i32* %arg2
+  %64 = icmp eq i32 %63, 0
+  br i1 %64, label %122, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %66, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %67
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %66, i32 0, i32 1
+  %69 = load i32, i32 addrspace(1)* %68
+  %70 = sub i32 %69, 1
+  store i32 %70, i32* %loc0
+  br label %118
+
+; <label>:71                                      ; preds = %118
+  store i32 0, i32* %loc4
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %73 = load i32, i32* %loc0
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %74
+
+; <label>:74                                      ; preds = %71
+  %75 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 2, i32 %73
+  %76 = load i16, i16 addrspace(1)* %75
+  %77 = zext i16 %76 to i32
+  %78 = trunc i32 %77 to i16
+  store i16 %78, i16* %loc5
+  store i32 0, i32* %loc4
+  br label %97
+
+; <label>:79                                      ; preds = %100
+  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %81 = load i32, i32* %loc4
+  %NullCheck19 = icmp eq %"System.Char[]" addrspace(1)* %80, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
+
+; <label>:82                                      ; preds = %79
+  %83 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 1
+  %84 = load i32, i32 addrspace(1)* %83
+  %85 = zext i32 %84 to i64
+  %86 = zext i32 %81 to i64
+  %BoundsCheck21 = icmp uge i64 %86, %85
+  br i1 %BoundsCheck21, label %ThrowIndexOutOfRange22, label %87
+
+; <label>:87                                      ; preds = %82
+  %88 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 3, i32 %81
+  %89 = load i16, i16 addrspace(1)* %88, align 8
+  %90 = zext i16 %89 to i32
+  %91 = load i16, i16* %loc5
+  %92 = zext i16 %91 to i32
+  %93 = icmp eq i32 %90, %92
+  br i1 %93, label %106, label %94
+
+; <label>:94                                      ; preds = %87
+  %95 = load i32, i32* %loc4
+  %96 = add i32 %95, 1
+  store i32 %96, i32* %loc4
+  br label %97
+
+; <label>:97                                      ; preds = %74, %94
+  %98 = load i32, i32* %loc4
+  %99 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck15 = icmp eq %"System.Char[]" addrspace(1)* %99, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %100
+
+; <label>:100                                     ; preds = %97
+  %101 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %99, i32 0, i32 1
+  %102 = load i32, i32 addrspace(1)* %101
+  %103 = zext i32 %102 to i64
+  %104 = trunc i64 %103 to i32
+  %105 = icmp slt i32 %98, %104
+  br i1 %105, label %79, label %106
+
+; <label>:106                                     ; preds = %87, %100
+  %107 = load i32, i32* %loc4
+  %108 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck17 = icmp eq %"System.Char[]" addrspace(1)* %108, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %109
+
+; <label>:109                                     ; preds = %106
+  %110 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %108, i32 0, i32 1
+  %111 = load i32, i32 addrspace(1)* %110
+  %112 = zext i32 %111 to i64
+  %113 = trunc i64 %112 to i32
+  %114 = icmp eq i32 %107, %113
+  br i1 %114, label %122, label %115
+
+; <label>:115                                     ; preds = %109
+  %116 = load i32, i32* %loc0
+  %117 = sub i32 %116, 1
+  store i32 %117, i32* %loc0
+  br label %118
+
+; <label>:118                                     ; preds = %67, %115
+  %119 = load i32, i32* %loc0
+  %120 = load i32, i32* %loc1
+  %121 = icmp sge i32 %119, %120
+  br i1 %121, label %71, label %122
+
+; <label>:122                                     ; preds = %62, %109, %118
+  %123 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %124 = load i32, i32* %loc1
+  %125 = load i32, i32* %loc0
+  %126 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %123, i32 %124, i32 %125)
+  ret %System.String addrspace(1)* %126
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %97
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange22:                           ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
 Successfully read String.CreateTrimmedString
 
@@ -5439,8 +6893,8 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
@@ -5535,8 +6989,8 @@ entry:
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i64 2872
   %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
   %8 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %7
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %3
   %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
@@ -5553,8 +7007,8 @@ entry:
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 2864
   %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
   %21 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %20
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
-  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %22
 
 ; <label>:22                                      ; preds = %16
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
@@ -5569,7 +7023,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %16
+ThrowNullRef2:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5586,8 +7040,8 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5613,8 +7067,8 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
@@ -5632,8 +7086,8 @@ entry:
 
 ; <label>:12                                      ; preds = %4
   %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
@@ -5644,8 +7098,8 @@ entry:
 
 ; <label>:19                                      ; preds = %14
   %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %19
   %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
@@ -5660,21 +7114,21 @@ entry:
   %31 = zext i16 %30 to i32
   %32 = bitcast i8* %29 to i16*
   %33 = trunc i32 %31 to i16
-  %NullCheck6 = icmp ne i16* %32, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i16* %32, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %21
   store i16 %33, i16* %32, align 8
   %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %36
 
 ; <label>:36                                      ; preds = %34
   %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
   %38 = load i32, i32 addrspace(1)* %37, align 8
   %39 = add i32 %38, 1
-  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %40
 
 ; <label>:40                                      ; preds = %36
   %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
@@ -5683,16 +7137,16 @@ entry:
 
 ; <label>:42                                      ; preds = %14
   %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
-  br i1 %NullCheck12, label %44, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
   %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
   %47 = load i16, i16* %arg1
   %48 = zext i16 %47 to i32
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = trunc i32 %48 to i16
@@ -5703,31 +7157,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %19
+ThrowNullRef4:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %21
+ThrowNullRef6:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %36
+ThrowNullRef10:                                   ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %42
+ThrowNullRef12:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %44
+ThrowNullRef14:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5740,8 +7194,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -5752,8 +7206,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
@@ -5762,14 +7216,14 @@ entry:
 
 ; <label>:11                                      ; preds = %1
   %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
@@ -5779,15 +7233,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5808,8 +7262,8 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5822,8 +7276,8 @@ entry:
 
 ; <label>:8                                       ; preds = %3
   %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
@@ -5842,15 +7296,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
-  br i1 %NullCheck4, label %22, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
   %24 = load i16*, i16* addrspace(1)* %23, align 8
   %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %25, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
@@ -5859,8 +7313,8 @@ entry:
   store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
@@ -5874,8 +7328,8 @@ entry:
 
 ; <label>:37                                      ; preds = %65
   %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %37
   %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
@@ -5886,16 +7340,16 @@ entry:
   %45 = bitcast i16* %41 to i8*
   %46 = getelementptr inbounds i8, i8* %45, i64 %44
   %47 = bitcast i8* %46 to i16*
-  %NullCheck14 = icmp ne i16* %47, null
-  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %47, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %48
 
 ; <label>:48                                      ; preds = %39
   %49 = load i16, i16* %47, align 8
   %50 = zext i16 %49 to i32
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %52 = load i32, i32* %loc1
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %53
 
 ; <label>:53                                      ; preds = %48
   %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
@@ -5916,8 +7370,8 @@ entry:
 ; <label>:62                                      ; preds = %36, %59
   %63 = load i32, i32* %loc1
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck10, label %65, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %65
 
 ; <label>:65                                      ; preds = %62
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
@@ -5936,15 +7390,15 @@ entry:
 
 ; <label>:74                                      ; preds = %70
   %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
-  br i1 %NullCheck18, label %76, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %76
 
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
   %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
-  br i1 %NullCheck20, label %80, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
   %81 = load i64, i64 addrspace(1)* %79
@@ -5958,8 +7412,8 @@ entry:
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
   %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
-  br i1 %NullCheck22, label %92, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.String addrspace(1)* %90, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %92
 
 ; <label>:92                                      ; preds = %80
   %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
@@ -5969,15 +7423,15 @@ entry:
 
 ; <label>:96                                      ; preds = %70
   %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
-  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %98
 
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
   %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
-  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
   %103 = load i64, i64 addrspace(1)* %101
@@ -5991,8 +7445,8 @@ entry:
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
   %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
-  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.String addrspace(1)* %112, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %114
 
 ; <label>:114                                     ; preds = %102
   %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
@@ -6004,59 +7458,59 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %20
+ThrowNullRef4:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %22
+ThrowNullRef6:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %26
+ThrowNullRef8:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %62
+ThrowNullRef10:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %48
+ThrowNullRef16:                                   ; preds = %48
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %74
+ThrowNullRef18:                                   ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %76
+ThrowNullRef20:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %80
+ThrowNullRef22:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %96
+ThrowNullRef24:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %98
+ThrowNullRef26:                                   ; preds = %98
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %102
+ThrowNullRef28:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6069,15 +7523,15 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
   %3 = load i16*, i16* addrspace(1)* %2, align 8
   %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
@@ -6087,8 +7541,8 @@ entry:
   %10 = bitcast i16* %3 to i8*
   %11 = getelementptr inbounds i8, i8* %10, i64 %9
   %12 = bitcast i8* %11 to i16*
-  %NullCheck4 = icmp ne i16* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %5
   store i16 0, i16* %12, align 8
@@ -6098,11 +7552,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6119,8 +7573,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -6131,8 +7585,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
@@ -6144,15 +7598,15 @@ entry:
 
 ; <label>:14                                      ; preds = %1
   %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
   %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
   %21 = load i64, i64 addrspace(1)* %19
@@ -6171,15 +7625,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %14
+ThrowNullRef4:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %16
+ThrowNullRef6:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6302,14 +7756,6 @@ entry:
   ret %System.String addrspace(1)* %57
 }
 
-INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
-Successfully read RuntimeHelpers.get_OffsetToStringData
-
-define i32 @RuntimeHelpers.get_OffsetToStringData() {
-entry:
-  ret i32 12
-}
-
 INFO:  jitting method String::Equals using LLILCJit
 Successfully read String.Equals
 
@@ -6381,8 +7827,8 @@ entry:
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
-  br i1 %NullCheck24, label %29, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
   %30 = load i64, i64 addrspace(1)* %28
@@ -6397,8 +7843,8 @@ entry:
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
-  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
   %43 = load i64, i64 addrspace(1)* %41
@@ -6418,8 +7864,8 @@ entry:
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
   %59 = load i64, i64 addrspace(1)* %57
@@ -6434,8 +7880,8 @@ entry:
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck22, label %71, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
   %72 = load i64, i64 addrspace(1)* %70
@@ -6455,8 +7901,8 @@ entry:
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
-  br i1 %NullCheck16, label %87, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = load i64, i64 addrspace(1)* %86
@@ -6471,8 +7917,8 @@ entry:
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck18, label %100, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
   %101 = load i64, i64 addrspace(1)* %99
@@ -6492,8 +7938,8 @@ entry:
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
-  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
   %117 = load i64, i64 addrspace(1)* %115
@@ -6508,8 +7954,8 @@ entry:
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
-  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
   %130 = load i64, i64 addrspace(1)* %128
@@ -6528,15 +7974,15 @@ entry:
 
 ; <label>:142                                     ; preds = %22
   %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
-  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %143, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %144
 
 ; <label>:144                                     ; preds = %142
   %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
   %146 = load i32, i32 addrspace(1)* %145
   %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
-  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %147, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %148
 
 ; <label>:148                                     ; preds = %144
   %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
@@ -6557,15 +8003,15 @@ entry:
 
 ; <label>:159                                     ; preds = %22
   %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
-  br i1 %NullCheck, label %161, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %ThrowNullRef, label %161
 
 ; <label>:161                                     ; preds = %159
   %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
   %163 = load i32, i32 addrspace(1)* %162
   %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
-  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %164, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %165
 
 ; <label>:165                                     ; preds = %161
   %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
@@ -6578,8 +8024,8 @@ entry:
 
 ; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
-  br i1 %NullCheck4, label %172, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %171, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %172
 
 ; <label>:172                                     ; preds = %170
   %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
@@ -6589,8 +8035,8 @@ entry:
 
 ; <label>:176                                     ; preds = %172
   %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
-  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %177, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %178
 
 ; <label>:178                                     ; preds = %176
   %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
@@ -6629,55 +8075,55 @@ ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %161
+ThrowNullRef2:                                    ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %170
+ThrowNullRef4:                                    ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %176
+ThrowNullRef6:                                    ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %142
+ThrowNullRef8:                                    ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %144
+ThrowNullRef10:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %113
+ThrowNullRef12:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %116
+ThrowNullRef14:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %84
+ThrowNullRef16:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %87
+ThrowNullRef18:                                   ; preds = %87
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %55
+ThrowNullRef20:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %58
+ThrowNullRef22:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %26
+ThrowNullRef24:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %29
+ThrowNullRef26:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,8 +8161,8 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck, label %14, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %ThrowNullRef, label %14
 
 ; <label>:14                                      ; preds = %8
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
@@ -6760,8 +8206,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
@@ -6770,14 +8216,14 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32, i32* %loc0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %10
   %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
   %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
@@ -6790,15 +8236,15 @@ entry:
 ; <label>:25                                      ; preds = %19
   %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
-  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
   %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
@@ -6807,8 +8253,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %37 = load i32, i32* %loc0
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %38, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %38
 
 ; <label>:38                                      ; preds = %32
   %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
@@ -6817,14 +8263,14 @@ entry:
 
 ; <label>:40                                      ; preds = %19
   %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %40
   %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
   %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
-  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
-  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
@@ -6832,8 +8278,8 @@ entry:
   %48 = zext i32 %47 to i64
   %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
-  br i1 %NullCheck16, label %51, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %51
 
 ; <label>:51                                      ; preds = %45
   %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
@@ -6847,15 +8293,15 @@ entry:
 ; <label>:57                                      ; preds = %51
   %58 = load i16*, i16** %arg1
   %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
-  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %60
 
 ; <label>:60                                      ; preds = %57
   %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
   %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
-  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %64
 
 ; <label>:64                                      ; preds = %60
   %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
@@ -6864,22 +8310,22 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
   %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
-  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %70
 
 ; <label>:70                                      ; preds = %64
   %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
   %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
-  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
-  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
   %75 = load i32, i32 addrspace(1)* %74
   %76 = zext i32 %75 to i64
   %77 = trunc i64 %76 to i32
-  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
-  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %78
 
 ; <label>:78                                      ; preds = %73
   %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
@@ -6901,8 +8347,8 @@ entry:
   %90 = bitcast i16* %86 to i8*
   %91 = getelementptr inbounds i8, i8* %90, i64 %89
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %93
 
 ; <label>:93                                      ; preds = %80
   %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
@@ -6912,8 +8358,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %99 = load i32, i32* %loc2
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %100
 
 ; <label>:100                                     ; preds = %93
   %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
@@ -6928,63 +8374,63 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %25
+ThrowNullRef6:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %32
+ThrowNullRef10:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %40
+ThrowNullRef12:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %45
+ThrowNullRef16:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %57
+ThrowNullRef18:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %60
+ThrowNullRef20:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %64
+ThrowNullRef22:                                   ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %70
+ThrowNullRef24:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %73
+ThrowNullRef26:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %80
+ThrowNullRef28:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %93
+ThrowNullRef30:                                   ; preds = %93
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7004,8 +8450,8 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
@@ -7033,43 +8479,43 @@ entry:
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %14
   %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
   %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   %28 = load i32, i32 addrspace(1)* %27, align 8
   %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
-  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %30
 
 ; <label>:30                                      ; preds = %26
   %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
   %32 = load i32, i32 addrspace(1)* %31, align 8
   %33 = add i32 %28, %32
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %34
 
 ; <label>:34                                      ; preds = %30
   %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   store i32 %33, i32 addrspace(1)* %35
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
   store i32 0, i32 addrspace(1)* %38
   %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %40
 
 ; <label>:40                                      ; preds = %37
   %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
@@ -7082,8 +8528,8 @@ entry:
 
 ; <label>:47                                      ; preds = %40
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
@@ -7098,8 +8544,8 @@ entry:
   %54 = load i32, i32* %loc0
   %55 = sext i32 %54 to i64
   %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
-  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %57
 
 ; <label>:57                                      ; preds = %52
   %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
@@ -7110,68 +8556,35 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %14
+ThrowNullRef2:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %23
+ThrowNullRef4:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %26
+ThrowNullRef6:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %30
+ThrowNullRef8:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %34
+ThrowNullRef10:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %47
+ThrowNullRef14:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %52
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-}
-
-INFO:  jitting method StringBuilder::get_Length using LLILCJit
-Successfully read StringBuilder.get_Length
-
-define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.StringBuilder addrspace(1)*
-  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
-  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
-
-; <label>:1                                       ; preds = %entry
-  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %3 = load i32, i32 addrspace(1)* %2, align 8
-  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
-
-; <label>:5                                       ; preds = %1
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = add i32 %3, %7
-  ret i32 %8
-
-ThrowNullRef:                                     ; preds = %entry
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef16:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7213,70 +8626,70 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
   %6 = load i32, i32 addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
   store i32 %6, i32 addrspace(1)* %8
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
   %13 = load i32, i32 addrspace(1)* %12, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
   store i32 %13, i32 addrspace(1)* %15
   %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
-  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %18
 
 ; <label>:18                                      ; preds = %14
   %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
   %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
   %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
   %34 = load i32, i32 addrspace(1)* %33, align 8
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
-  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
@@ -7287,39 +8700,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %28
+ThrowNullRef16:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %32
+ThrowNullRef18:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7455,13 +8868,13 @@ entry:
 ; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
@@ -7477,16 +8890,16 @@ entry:
 
 ; <label>:18                                      ; preds = %15
   %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
   store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
   %22 = load i32, i32* %loc0
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %24
 
 ; <label>:24                                      ; preds = %20
   %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
@@ -7498,13 +8911,13 @@ entry:
 ; <label>:28                                      ; preds = %15, %24
   %29 = load i32, i32* %arg1
   %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %31
   %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
@@ -7517,20 +8930,20 @@ entry:
   %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
-  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
   %46 = load i32, i32 addrspace(1)* %45, align 8
   %47 = sub i32 %40, %46
-  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
-  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i32 addrspace(1)* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %48
 
 ; <label>:48                                      ; preds = %44
   store i32 %47, i32 addrspace(1)* %39, align 8
@@ -7538,21 +8951,21 @@ entry:
 
 ; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
-  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %51
 
 ; <label>:51                                      ; preds = %49
   %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %53
 
 ; <label>:53                                      ; preds = %51
   %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
   %55 = load i32, i32 addrspace(1)* %54, align 8
   %56 = load i32, i32* %arg2
   %57 = sub i32 %55, %56
-  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %58
 
 ; <label>:58                                      ; preds = %53
   %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
@@ -7562,13 +8975,13 @@ entry:
 ; <label>:60                                      ; preds = %33, %58
   %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
   %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
-  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %63
 
 ; <label>:63                                      ; preds = %60
   %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
-  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
-  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
@@ -7578,15 +8991,15 @@ entry:
 
 ; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
-  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i32 addrspace(1)* %69, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %70
 
 ; <label>:70                                      ; preds = %68
   %71 = load i32, i32 addrspace(1)* %69, align 8
   store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
-  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
@@ -7596,8 +9009,8 @@ entry:
   store i32 %77, i32* %loc4
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
-  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %80
 
 ; <label>:80                                      ; preds = %73
   %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
@@ -7607,71 +9020,71 @@ entry:
 ; <label>:83                                      ; preds = %80
   store i32 0, i32* %loc3
   %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
-  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
-  br i1 %NullCheck26, label %88, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i32 addrspace(1)* %87, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %88
 
 ; <label>:88                                      ; preds = %85
   %89 = load i32, i32 addrspace(1)* %87, align 8
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
-  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %90
 
 ; <label>:90                                      ; preds = %88
   %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
   store i32 %89, i32 addrspace(1)* %91
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
-  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
-  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %96
 
 ; <label>:96                                      ; preds = %94
   %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
-  br i1 %NullCheck34, label %100, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %100
 
 ; <label>:100                                     ; preds = %96
   %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
-  br i1 %NullCheck36, label %102, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %102
 
 ; <label>:102                                     ; preds = %100
   %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
   %104 = load i32, i32 addrspace(1)* %103, align 8
   %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
-  br i1 %NullCheck38, label %106, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %106
 
 ; <label>:106                                     ; preds = %102
   %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
-  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
-  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %108
 
 ; <label>:108                                     ; preds = %106
   %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
   %110 = load i32, i32 addrspace(1)* %109, align 8
   %111 = add i32 %104, %110
-  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %112
 
 ; <label>:112                                     ; preds = %108
   %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
   store i32 %111, i32 addrspace(1)* %113
   %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
-  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i32 addrspace(1)* %114, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %115
 
 ; <label>:115                                     ; preds = %112
   %116 = load i32, i32 addrspace(1)* %114, align 8
@@ -7681,19 +9094,19 @@ entry:
 ; <label>:118                                     ; preds = %115
   %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
-  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %121
 
 ; <label>:121                                     ; preds = %118
   %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
-  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
-  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %123
 
 ; <label>:123                                     ; preds = %121
   %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
   %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
-  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
-  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %126
 
 ; <label>:126                                     ; preds = %123
   %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
@@ -7705,8 +9118,8 @@ entry:
 
 ; <label>:130                                     ; preds = %80, %115, %126
   %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %132
 
 ; <label>:132                                     ; preds = %130
   %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7715,8 +9128,8 @@ entry:
   %136 = load i32, i32* %loc3
   %137 = sub i32 %135, %136
   %138 = sub i32 %134, %137
-  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %139
 
 ; <label>:139                                     ; preds = %132
   %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7728,16 +9141,16 @@ entry:
 
 ; <label>:144                                     ; preds = %139
   %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
-  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %146
 
 ; <label>:146                                     ; preds = %144
   %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
   %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
   %149 = load i32, i32* %loc2
   %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
-  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %151
 
 ; <label>:151                                     ; preds = %146
   %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
@@ -7754,145 +9167,249 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %18
+ThrowNullRef4:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %31
+ThrowNullRef10:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %44
+ThrowNullRef16:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %68
+ThrowNullRef18:                                   ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %70
+ThrowNullRef20:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %73
+ThrowNullRef22:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %83
+ThrowNullRef24:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %85
+ThrowNullRef26:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %88
+ThrowNullRef28:                                   ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %90
+ThrowNullRef30:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %94
+ThrowNullRef32:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %96
+ThrowNullRef34:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %100
+ThrowNullRef36:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %102
+ThrowNullRef38:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %106
+ThrowNullRef40:                                   ; preds = %106
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %108
+ThrowNullRef42:                                   ; preds = %108
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %112
+ThrowNullRef44:                                   ; preds = %112
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %118
+ThrowNullRef46:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %121
+ThrowNullRef48:                                   ; preds = %121
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %123
+ThrowNullRef50:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %130
+ThrowNullRef52:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %132
+ThrowNullRef54:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %144
+ThrowNullRef56:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %146
+ThrowNullRef58:                                   ; preds = %146
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %60
+ThrowNullRef60:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %63
+ThrowNullRef62:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %49
+ThrowNullRef64:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %51
+ThrowNullRef66:                                   ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %53
+ThrowNullRef68:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(%"System.Char[]" addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %arg0 = alloca %"System.Char[]" addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store %"System.Char[]" addrspace(1)* %param0, %"System.Char[]" addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load i32, i32* %arg4
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %43, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %38, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg1
+  %13 = load i32, i32* %arg4
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %38, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %24 = load i32, i32* %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %35 = load i32, i32* %arg3
+  %36 = load i32, i32* %arg4
+  %37 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %37, %"System.Char[]" addrspace(1)* %34, i32 %35, i32 %36)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:38                                      ; preds = %5, %16
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Successfully read Buffer._Memmove
 
@@ -7914,7 +9431,7 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[loadElem]
+Failed to read AppDomain.SetDataHelper[storeElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -7923,8 +9440,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
@@ -7934,8 +9451,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
@@ -7947,15 +9464,15 @@ entry:
   %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
   %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
@@ -7966,15 +9483,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7992,7 +9509,79 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
-Failed to read Dictionary`2.TryGetValue[loadElemA]
+Successfully read Dictionary`2.TryGetValue
+
+define i8 @"Dictionary`2.TryGetValue"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)* addrspace(1)* %param2) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  %arg2 = alloca %System.__Canon addrspace(1)* addrspace(1)*
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  store %System.__Canon addrspace(1)* addrspace(1)* %param2, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  store i32 %2, i32* %loc0
+  %3 = load i32, i32* %loc0
+  %4 = icmp slt i32 %3, 0
+  br i1 %4, label %22, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 2
+  %10 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %9, align 8
+  %11 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = zext i32 %11 to i64
+  %BoundsCheck = icmp uge i64 %16, %15
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 3, i32 %11
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %20, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %6, %System.__Canon addrspace(1)* %21)
+  ret i8 1
+
+; <label>:22                                      ; preds = %entry
+  %23 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %23, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -8058,8 +9647,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
@@ -8091,8 +9680,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
@@ -8171,15 +9760,15 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck, label %19, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %ThrowNullRef, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
   %21 = load i32, i32 addrspace(1)* %20
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
@@ -8202,7 +9791,7 @@ ThrowNullRef:                                     ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %19
+ThrowNullRef2:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8248,8 +9837,8 @@ entry:
   %0 = alloca %System.AppDomainHandle
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %1 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %1, i32 0, i32 15
@@ -8269,8 +9858,8 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
@@ -8286,7 +9875,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -8299,8 +9888,8 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -8327,8 +9916,8 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
@@ -8352,8 +9941,8 @@ entry:
   %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
   store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
@@ -8363,8 +9952,8 @@ entry:
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
@@ -8374,8 +9963,8 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %9
   %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
@@ -8384,8 +9973,8 @@ entry:
 
 ; <label>:18                                      ; preds = %3, %16
   %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
@@ -8397,15 +9986,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %18
+ThrowNullRef6:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8418,8 +10007,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
@@ -8453,15 +10042,15 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
@@ -8473,7 +10062,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8481,7 +10070,7 @@ ThrowNullRef1:                                    ; preds = %1
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
 Failed to read Dictionary`2.System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
@@ -8506,8 +10095,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
@@ -8524,8 +10113,8 @@ entry:
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -8544,7 +10133,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8577,8 +10166,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = load i64, i64* %arg2
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = trunc i32 %3 to i8
@@ -8634,46 +10223,46 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
   %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
-  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
-  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
-  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
@@ -8684,27 +10273,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %20
+ThrowNullRef12:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8717,8 +10306,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -8756,22 +10345,22 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
   %9 = load i64, i64 addrspace(1)* %8, align 8
   %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
   %13 = load i64, i64 addrspace(1)* %12, align 8
   %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %11
   %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
@@ -8788,11 +10377,11 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8882,8 +10471,8 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
@@ -8900,8 +10489,8 @@ entry:
 ; <label>:8                                       ; preds = %1
   %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
   %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
@@ -8911,15 +10500,15 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
   %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
   %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
-  br i1 %NullCheck6, label %21, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
@@ -8946,15 +10535,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8992,15 +10581,15 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
   store i8 %3, i8 addrspace(1)* %5
   %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
@@ -9011,7 +10600,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9027,8 +10616,8 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -9041,8 +10630,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
@@ -9058,7 +10647,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9080,8 +10669,8 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
@@ -9096,8 +10685,8 @@ entry:
 ; <label>:12                                      ; preds = %6
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
@@ -9112,8 +10701,8 @@ entry:
 ; <label>:21                                      ; preds = %15
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
@@ -9128,8 +10717,8 @@ entry:
 ; <label>:30                                      ; preds = %24
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %31, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
@@ -9144,8 +10733,8 @@ entry:
 ; <label>:39                                      ; preds = %33
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
-  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %40, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %42
 
 ; <label>:42                                      ; preds = %39
   %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
@@ -9164,19 +10753,19 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %21
+ThrowNullRef4:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %30
+ThrowNullRef6:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %39
+ThrowNullRef8:                                    ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9243,8 +10832,8 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
@@ -9264,57 +10853,57 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
   store i8 0, i8 addrspace(1)* %2
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
   store i8 0, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
   store i8 0, i8 addrspace(1)* %17
   %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
   store i8 0, i8 addrspace(1)* %20
   %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
-  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
@@ -9325,31 +10914,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %19
+ThrowNullRef14:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9367,8 +10956,8 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
@@ -9380,8 +10969,8 @@ entry:
 
 ; <label>:9                                       ; preds = %4
   %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %9
   %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
@@ -9395,7 +10984,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef2:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9420,8 +11009,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
@@ -9512,8 +11101,8 @@ entry:
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
@@ -9524,8 +11113,8 @@ entry:
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = load i64, i64 addrspace(1)* %12
@@ -9537,8 +11126,8 @@ entry:
   %20 = load i64, i64* %19
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
-  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %13
   %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
@@ -9555,8 +11144,8 @@ entry:
 ; <label>:30                                      ; preds = %25
   %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %32 = load i32, i32* %arg2
-  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
-  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
@@ -9570,15 +11159,15 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %30
+ThrowNullRef2:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9622,87 +11211,87 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
   %10 = load i8, i8 addrspace(1)* %9, align 8
   %11 = zext i8 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %8
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
   store i8 %12, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
   %19 = load i8, i8 addrspace(1)* %18, align 8
   %20 = zext i8 %19 to i32
   %21 = trunc i32 %20 to i8
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
   store i8 %21, i8 addrspace(1)* %23
   %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
   %28 = load i8, i8 addrspace(1)* %27, align 8
   %29 = zext i8 %28 to i32
   %30 = trunc i32 %29 to i8
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
-  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %31
 
 ; <label>:31                                      ; preds = %26
   %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
   store i8 %30, i8 addrspace(1)* %32
   %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
-  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
-  br i1 %NullCheck14, label %40, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %40
 
 ; <label>:40                                      ; preds = %35
   %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
   store i8 %39, i8 addrspace(1)* %41
   %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
-  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %44
 
 ; <label>:44                                      ; preds = %40
   %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
   %46 = load i8, i8 addrspace(1)* %45, align 8
   %47 = zext i8 %46 to i32
   %48 = trunc i32 %47 to i8
-  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
   store i8 %48, i8 addrspace(1)* %50
   %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
-  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
@@ -9713,29 +11302,29 @@ entry:
 ; <label>:56                                      ; preds = %52
   %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
-  br i1 %NullCheck22, label %59, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
   %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
   %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
-  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
-  br i1 %NullCheck24, label %63, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
   %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
-  br i1 %NullCheck26, label %66, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
   %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
-  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
-  br i1 %NullCheck28, label %69, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %69
 
 ; <label>:69                                      ; preds = %66
   %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
@@ -9744,15 +11333,15 @@ entry:
 
 ; <label>:71                                      ; preds = %105
   %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
-  br i1 %NullCheck34, label %73, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %73
 
 ; <label>:73                                      ; preds = %71
   %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
   %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
   %76 = load i32, i32* %loc0
-  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
-  br i1 %NullCheck36, label %77, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
@@ -9766,8 +11355,8 @@ entry:
 
 ; <label>:83                                      ; preds = %77
   %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
-  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
@@ -9775,14 +11364,14 @@ entry:
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
   %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
-  br i1 %NullCheck40, label %91, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
 ; <label>:91                                      ; preds = %85
   %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
   %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
-  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck42, label %94, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %94
 
 ; <label>:94                                      ; preds = %91
   %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
@@ -9798,14 +11387,14 @@ entry:
 ; <label>:99                                      ; preds = %69, %96
   %100 = load i32, i32* %loc0
   %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
-  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %102
 
 ; <label>:102                                     ; preds = %99
   %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
   %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
-  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
-  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
@@ -9819,87 +11408,87 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %26
+ThrowNullRef10:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %31
+ThrowNullRef12:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %35
+ThrowNullRef14:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %40
+ThrowNullRef16:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %56
+ThrowNullRef22:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %59
+ThrowNullRef24:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %63
+ThrowNullRef26:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %66
+ThrowNullRef28:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %102
+ThrowNullRef32:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %71
+ThrowNullRef34:                                   ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %73
+ThrowNullRef36:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %83
+ThrowNullRef38:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %85
+ThrowNullRef40:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %91
+ThrowNullRef42:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9943,15 +11532,15 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
   %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
@@ -9961,28 +11550,28 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
   %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %12
   %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
   %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
   %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
-  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
@@ -9993,23 +11582,23 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %12
+ThrowNullRef6:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10031,15 +11620,15 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
   %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = load i64, i64 addrspace(1)* %7
@@ -10077,13 +11666,13 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[loadElem]
+Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -10111,8 +11700,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -10156,7 +11745,89 @@ Failed to read BringUpTest.Main[abs]
 INFO:  jitting method BringUpTest::DblFillArray using LLILCJit
 Failed to read BringUpTest.DblFillArray[storeElem]
 INFO:  jitting method BringUpTest::DblArray using LLILCJit
-Failed to read BringUpTest.DblArray[loadElem]
+Successfully read BringUpTest.DblArray
+
+define double @BringUpTest.DblArray(%"System.Double[]" addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %"System.Double[]" addrspace(1)*
+  %loc0 = alloca double
+  %loc1 = alloca i32
+  store %"System.Double[]" addrspace(1)* %param0, %"System.Double[]" addrspace(1)** %arg0
+  store double 0.000000e+00, double* %loc0
+  store i32 0, i32* %loc1
+  br label %15
+
+; <label>:0                                       ; preds = %18
+  %1 = load double, double* %loc0
+  %2 = load %"System.Double[]" addrspace(1)*, %"System.Double[]" addrspace(1)** %arg0
+  %3 = load i32, i32* %loc1
+  %NullCheck3 = icmp eq %"System.Double[]" addrspace(1)* %2, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %4
+
+; <label>:4                                       ; preds = %0
+  %5 = getelementptr inbounds %"System.Double[]", %"System.Double[]" addrspace(1)* %2, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = zext i32 %6 to i64
+  %8 = zext i32 %3 to i64
+  %BoundsCheck = icmp uge i64 %8, %7
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %9
+
+; <label>:9                                       ; preds = %4
+  %10 = getelementptr inbounds %"System.Double[]", %"System.Double[]" addrspace(1)* %2, i32 0, i32 3, i32 %3
+  %11 = load double, double addrspace(1)* %10, align 8
+  %12 = fadd double %1, %11
+  store double %12, double* %loc0
+  %13 = load i32, i32* %loc1
+  %14 = add i32 %13, 1
+  store i32 %14, i32* %loc1
+  br label %15
+
+; <label>:15                                      ; preds = %entry, %9
+  %16 = load i32, i32* %loc1
+  %17 = load %"System.Double[]" addrspace(1)*, %"System.Double[]" addrspace(1)** %arg0
+  %NullCheck = icmp eq %"System.Double[]" addrspace(1)* %17, null
+  br i1 %NullCheck, label %ThrowNullRef, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %"System.Double[]", %"System.Double[]" addrspace(1)* %17, i32 0, i32 1
+  %20 = load i32, i32 addrspace(1)* %19
+  %21 = zext i32 %20 to i64
+  %22 = trunc i64 %21 to i32
+  %23 = icmp slt i32 %16, %22
+  br i1 %23, label %0, label %24
+
+; <label>:24                                      ; preds = %18
+  %25 = load double, double* %loc0
+  %26 = load %"System.Double[]" addrspace(1)*, %"System.Double[]" addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %"System.Double[]" addrspace(1)* %26, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %27
+
+; <label>:27                                      ; preds = %24
+  %28 = getelementptr inbounds %"System.Double[]", %"System.Double[]" addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = zext i32 %29 to i64
+  %31 = trunc i64 %30 to i32
+  %32 = sitofp i32 %31 to double
+  %33 = fdiv double %25, %32
+  ret double %33
+
+ThrowNullRef:                                     ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Console::WriteLine using LLILCJit
 Successfully read Console.WriteLine
 
@@ -10167,8 +11838,8 @@ entry:
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load double, double* %arg0
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -10302,8 +11973,8 @@ entry:
   store i64 %param0, i64* %arg0
   store i64 %param1, i64* %arg1
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
@@ -10311,8 +11982,8 @@ entry:
   %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
   %5 = load i16*, i16* addrspace(1)* %4, align 8
   %6 = addrspacecast i64* %arg1 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = bitcast i64 addrspace(1)* %6 to i8 addrspace(1)*
@@ -10328,7 +11999,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10362,8 +12033,8 @@ entry:
   %1 = load i32, i32* %arg1
   %2 = sext i32 %1 to i64
   %3 = inttoptr i64 %2 to i16*
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -10416,8 +12087,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, i32)*)(%System.IO.ConsoleStream addrspace(1)* %2, i32 %1)
   %3 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %4 = load i64, i64* %arg1
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
@@ -10428,8 +12099,8 @@ entry:
   %10 = icmp eq i32 %9, 3
   %11 = sext i1 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %5
   %14 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, i32 0, i32 5
@@ -10440,7 +12111,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10463,8 +12134,8 @@ entry:
   %5 = icmp eq i32 %4, 1
   %6 = sext i1 %5 to i32
   %7 = trunc i32 %6 to i8
-  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %2, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.ConsoleStream addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
@@ -10475,8 +12146,8 @@ entry:
   %13 = icmp eq i32 %12, 2
   %14 = sext i1 %13 to i32
   %15 = trunc i32 %14 to i8
-  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %10, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.ConsoleStream addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %8
   %17 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %10, i32 0, i32 4
@@ -10487,7 +12158,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10526,8 +12197,8 @@ entry:
   %arg0 = alloca i64
   store i64 %param0, i64* %arg0
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
@@ -10562,8 +12233,8 @@ entry:
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
   %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = load i64, i64 addrspace(1)* %7
@@ -10667,7 +12338,127 @@ entry:
 INFO:  jitting method Encoding::GetEncoding using LLILCJit
 Failed to read Encoding.GetEncoding[convertToHelperArgumentType]
 INFO:  jitting method EncodingProvider::GetEncodingFromProvider using LLILCJit
-Failed to read EncodingProvider.GetEncodingFromProvider[loadElem]
+Successfully read EncodingProvider.GetEncodingFromProvider
+
+define %System.Text.Encoding addrspace(1)* @EncodingProvider.GetEncodingFromProvider(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca %"System.Text.EncodingProvider[]" addrspace(1)*
+  %loc1 = alloca %System.Text.EncodingProvider addrspace(1)*
+  %loc2 = alloca %System.Text.Encoding addrspace(1)*
+  %loc3 = alloca %System.Text.Encoding addrspace(1)*
+  %loc4 = alloca %"System.Text.EncodingProvider[]" addrspace(1)*
+  %loc5 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1059)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2392
+  %2 = addrspacecast i8 addrspace(1)* %1 to %"System.Text.EncodingProvider[]" addrspace(1)**
+  %3 = load volatile %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %2
+  %4 = icmp ne %"System.Text.EncodingProvider[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %entry
+  ret %System.Text.Encoding addrspace(1)* null
+
+; <label>:6                                       ; preds = %entry
+  %7 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1059)
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i64 2392
+  %9 = addrspacecast i8 addrspace(1)* %8 to %"System.Text.EncodingProvider[]" addrspace(1)**
+  %10 = load volatile %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %9
+  store %"System.Text.EncodingProvider[]" addrspace(1)* %10, %"System.Text.EncodingProvider[]" addrspace(1)** %loc0
+  %11 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc0
+  store %"System.Text.EncodingProvider[]" addrspace(1)* %11, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  store i32 0, i32* %loc5
+  br label %43
+
+; <label>:12                                      ; preds = %46
+  %13 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  %14 = load i32, i32* %loc5
+  %NullCheck1 = icmp eq %"System.Text.EncodingProvider[]" addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %13, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = zext i32 %17 to i64
+  %19 = zext i32 %14 to i64
+  %BoundsCheck = icmp uge i64 %19, %18
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %20
+
+; <label>:20                                      ; preds = %15
+  %21 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %13, i32 0, i32 3, i32 %14
+  %22 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)* addrspace(1)* %21, align 8
+  store %System.Text.EncodingProvider addrspace(1)* %22, %System.Text.EncodingProvider addrspace(1)** %loc1
+  %23 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)** %loc1
+  %24 = load i32, i32* %arg0
+  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i64 addrspace(1)*
+  %NullCheck3 = icmp eq i64 addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
+
+; <label>:26                                      ; preds = %20
+  %27 = load i64, i64 addrspace(1)* %25
+  %28 = add i64 %27, 64
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 40
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Text.Encoding addrspace(1)* (%System.Text.EncodingProvider addrspace(1)*, i32)*
+  %35 = call %System.Text.Encoding addrspace(1)* %34(%System.Text.EncodingProvider addrspace(1)* %23, i32 %24)
+  store %System.Text.Encoding addrspace(1)* %35, %System.Text.Encoding addrspace(1)** %loc2
+  %36 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc2
+  %37 = icmp eq %System.Text.Encoding addrspace(1)* %36, null
+  br i1 %37, label %40, label %38
+
+; <label>:38                                      ; preds = %26
+  %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc2
+  store %System.Text.Encoding addrspace(1)* %39, %System.Text.Encoding addrspace(1)** %loc3
+  br label %53
+
+; <label>:40                                      ; preds = %26
+  %41 = load i32, i32* %loc5
+  %42 = add i32 %41, 1
+  store i32 %42, i32* %loc5
+  br label %43
+
+; <label>:43                                      ; preds = %6, %40
+  %44 = load i32, i32* %loc5
+  %45 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  %NullCheck = icmp eq %"System.Text.EncodingProvider[]" addrspace(1)* %45, null
+  br i1 %NullCheck, label %ThrowNullRef, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp slt i32 %44, %50
+  br i1 %51, label %12, label %52
+
+; <label>:52                                      ; preds = %46
+  ret %System.Text.Encoding addrspace(1)* null
+
+; <label>:53                                      ; preds = %38
+  %54 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc3
+  ret %System.Text.Encoding addrspace(1)* %54
+
+ThrowNullRef:                                     ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method EncodingProvider::.cctor using LLILCJit
 Successfully read EncodingProvider..cctor
 
@@ -10686,7 +12477,7 @@ Failed to read Encoding.get_InternalSyncObject[Call HasTypeArg]
 INFO:  jitting method Hashtable::.ctor using LLILCJit
 Failed to read Hashtable..ctor[Volatile store]
 INFO:  jitting method Hashtable::get_Item using LLILCJit
-Failed to read Hashtable.get_Item[loadElemA]
+Failed to read Hashtable.get_Item[loadNonPrimitiveObj]
 INFO:  jitting method Hashtable::InitHash using LLILCJit
 Successfully read Hashtable.InitHash
 
@@ -10706,8 +12497,8 @@ entry:
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -10723,15 +12514,15 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
   %15 = load i32, i32* %loc0
-  %NullCheck2 = icmp ne i32 addrspace(1)* %14, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i32 addrspace(1)* %14, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %3
   store i32 %15, i32 addrspace(1)* %14, align 8
   %17 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %18 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %NullCheck4 = icmp ne i32 addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i32 addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = load i32, i32 addrspace(1)* %18, align 8
@@ -10740,8 +12531,8 @@ entry:
   %23 = sub i32 %22, 1
   %24 = urem i32 %21, %23
   %25 = add i32 1, %24
-  %NullCheck6 = icmp ne i32 addrspace(1)* %17, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32 addrspace(1)* %17, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %19
   store i32 %25, i32 addrspace(1)* %17, align 8
@@ -10752,15 +12543,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %19
+ThrowNullRef6:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10775,8 +12566,8 @@ entry:
   store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
   store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %NullCheck = icmp ne %System.Collections.Hashtable addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Collections.Hashtable addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
@@ -10786,16 +12577,16 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Collections.Hashtable addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Collections.Hashtable addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
   %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck4 = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %9, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
   %13 = inttoptr i64 %11 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
@@ -10805,8 +12596,8 @@ entry:
 ; <label>:15                                      ; preds = %1
   %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -10824,15 +12615,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10846,8 +12637,8 @@ entry:
   store %System.Int32 addrspace(1)* %param0, %System.Int32 addrspace(1)** %this
   %0 = load %System.Int32 addrspace(1)*, %System.Int32 addrspace(1)** %this
   %1 = bitcast %System.Int32 addrspace(1)* %0 to i32 addrspace(1)*
-  %NullCheck = icmp ne i32 addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq i32 addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load i32, i32 addrspace(1)* %1, align 8
@@ -10923,8 +12714,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.UTF8Encoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
@@ -10933,15 +12724,15 @@ entry:
   %9 = load i8, i8* %arg2
   %10 = zext i8 %9 to i32
   %11 = trunc i32 %10 to i8
-  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %8, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %6
   %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %8, i32 0, i32 8
   store i8 %11, i8 addrspace(1)* %13
   %14 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %14, i32 0, i32 8
@@ -10953,8 +12744,8 @@ entry:
 ; <label>:20                                      ; preds = %15
   %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %22, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %22, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = load i64, i64 addrspace(1)* %22
@@ -10976,15 +12767,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %12
+ThrowNullRef4:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10999,8 +12790,8 @@ entry:
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
@@ -11022,16 +12813,16 @@ entry:
 ; <label>:10                                      ; preds = %1
   %11 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
   %12 = load i32, i32* %arg1
-  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %11, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.Encoding addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
   store i32 %12, i32 addrspace(1)* %14
   %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
   %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = load i64, i64 addrspace(1)* %16
@@ -11049,11 +12840,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11066,8 +12857,8 @@ entry:
   %this = alloca %System.Text.UTF8Encoding addrspace(1)*
   store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
   %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.UTF8Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
@@ -11079,16 +12870,16 @@ entry:
 ; <label>:6                                       ; preds = %1
   %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %8 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %10, %System.Text.EncoderFallback addrspace(1)* %8)
   %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %12 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
-  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %11, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %11, i32 0, i32 3
@@ -11101,8 +12892,8 @@ entry:
   %18 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %18, %System.String addrspace(1)* %17)
   %19 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %18 to %System.Text.EncoderFallback addrspace(1)*
-  %NullCheck6 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %16, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %16, i32 0, i32 2
@@ -11112,8 +12903,8 @@ entry:
   %24 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %24, %System.String addrspace(1)* %23)
   %25 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %24 to %System.Text.DecoderFallback addrspace(1)*
-  %NullCheck8 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %22, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %22, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %20
   %27 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %22, i32 0, i32 3
@@ -11124,19 +12915,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %20
+ThrowNullRef8:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11166,8 +12957,8 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load i32, i32* %arg1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -11185,8 +12976,8 @@ entry:
 ; <label>:15                                      ; preds = %8
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %17 = load i32, i32* %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 %17
@@ -11202,7 +12993,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11254,7 +13045,7 @@ entry:
 }
 
 INFO:  jitting method Hashtable::Insert using LLILCJit
-Failed to read Hashtable.Insert[loadElemA]
+Failed to read Hashtable.Insert[storeElem]
 INFO:  jitting method ConsoleEncoding::.ctor using LLILCJit
 Successfully read ConsoleEncoding..ctor
 
@@ -11269,8 +13060,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %1)
   %2 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
@@ -11306,8 +13097,8 @@ entry:
   %2 = call %System.Text.InternalEncoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalEncoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %1)
   %3 = bitcast %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2 to %System.Text.EncoderFallback addrspace(1)*
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
@@ -11317,8 +13108,8 @@ entry:
   %8 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %7)
   %9 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %8 to %System.Text.DecoderFallback addrspace(1)*
-  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %6, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.Encoding addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %4
   %11 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %6, i32 0, i32 3
@@ -11329,7 +13120,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11348,15 +13139,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* %1)
   %2 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   %6 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, i32 0, i32 1
@@ -11367,7 +13158,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11395,8 +13186,8 @@ entry:
   store %System.Text.InternalDecoderBestFitFallback addrspace(1)* %param0, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
   %0 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
@@ -11406,15 +13197,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %4)
   %5 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %6)
   %9 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, i32 0, i32 1
@@ -11425,11 +13216,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11497,8 +13288,8 @@ entry:
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
   %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = load i64, i64 addrspace(1)* %19
@@ -11562,8 +13353,8 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.ConsoleStream addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
@@ -11594,31 +13385,31 @@ entry:
   store i8 %param4, i8* %arg4
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %3, %System.IO.Stream addrspace(1)* %1)
   %4 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %4, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
   %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %4, i32 0, i32 4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %5)
   %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %6
   %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
   %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
   %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = load i64, i64 addrspace(1)* %13
@@ -11630,8 +13421,8 @@ entry:
   %21 = load i64, i64* %20
   %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %8, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %8, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %14
   %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 5
@@ -11649,24 +13440,24 @@ entry:
   %31 = load i32, i32* %arg3
   %32 = sext i32 %31 to i64
   %33 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %32)
-  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %30, null
-  br i1 %NullCheck10, label %34, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.StreamWriter addrspace(1)* %30, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %35, %"System.Char[]" addrspace(1)* %33)
   %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %37, null
-  br i1 %NullCheck12, label %38, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.StreamWriter addrspace(1)* %37, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %38
 
 ; <label>:38                                      ; preds = %34
   %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
   %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
   %41 = load i32, i32* %arg3
   %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %42, null
-  br i1 %NullCheck14, label %43, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %42, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
   %44 = load i64, i64 addrspace(1)* %42
@@ -11680,30 +13471,30 @@ entry:
   %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
   %53 = sext i32 %52 to i64
   %54 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %53)
-  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
-  br i1 %NullCheck16, label %55, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %55
 
 ; <label>:55                                      ; preds = %43
   %56 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %56, %"System.Byte[]" addrspace(1)* %54)
   %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %58 = load i32, i32* %arg3
-  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %57, null
-  br i1 %NullCheck18, label %59, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.StreamWriter addrspace(1)* %57, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %59
 
 ; <label>:59                                      ; preds = %55
   %60 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 10
   store i32 %58, i32 addrspace(1)* %60
   %61 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %61, null
-  br i1 %NullCheck20, label %62, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.IO.StreamWriter addrspace(1)* %61, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %62
 
 ; <label>:62                                      ; preds = %59
   %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
   %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
   %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
   %67 = load i64, i64 addrspace(1)* %65
@@ -11721,15 +13512,15 @@ entry:
 
 ; <label>:78                                      ; preds = %66
   %79 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %79, null
-  br i1 %NullCheck24, label %80, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.StreamWriter addrspace(1)* %79, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %80
 
 ; <label>:80                                      ; preds = %78
   %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
   %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
   %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %83, null
-  br i1 %NullCheck26, label %84, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %83, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
   %85 = load i64, i64 addrspace(1)* %83
@@ -11746,8 +13537,8 @@ entry:
 
 ; <label>:95                                      ; preds = %84
   %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.IO.StreamWriter addrspace(1)* %96, null
-  br i1 %NullCheck28, label %97, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.IO.StreamWriter addrspace(1)* %96, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %97
 
 ; <label>:97                                      ; preds = %95
   %98 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 12
@@ -11761,8 +13552,8 @@ entry:
   %103 = icmp eq i32 %102, 0
   %104 = sext i1 %103 to i32
   %105 = trunc i32 %104 to i8
-  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %100, null
-  br i1 %NullCheck30, label %106, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.IO.StreamWriter addrspace(1)* %100, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %106
 
 ; <label>:106                                     ; preds = %99
   %107 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %100, i32 0, i32 13
@@ -11773,63 +13564,63 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %6
+ThrowNullRef4:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %29
+ThrowNullRef10:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %34
+ThrowNullRef12:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %38
+ThrowNullRef14:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %43
+ThrowNullRef16:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %55
+ThrowNullRef18:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %59
+ThrowNullRef20:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %62
+ThrowNullRef22:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %78
+ThrowNullRef24:                                   ; preds = %78
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %80
+ThrowNullRef26:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %95
+ThrowNullRef28:                                   ; preds = %95
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11842,15 +13633,15 @@ entry:
   %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = load i64, i64 addrspace(1)* %4
@@ -11868,7 +13659,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11918,35 +13709,35 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
   %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderNLS addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %7 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.EncoderNLS addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Text.Encoding addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.Encoding addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Text.EncoderNLS addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.EncoderNLS addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
   %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck8 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = load i64, i64 addrspace(1)* %16
@@ -11965,19 +13756,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12003,8 +13794,8 @@ entry:
   %this = alloca %System.Text.Encoding addrspace(1)*
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
@@ -12024,15 +13815,15 @@ entry:
   %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
   store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
   %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
   store i32 0, i32 addrspace(1)* %2
   %3 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, i32 0, i32 2
@@ -12042,15 +13833,15 @@ entry:
 
 ; <label>:8                                       ; preds = %4
   %9 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
   %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
   %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = load i64, i64 addrspace(1)* %13
@@ -12071,15 +13862,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12094,16 +13885,16 @@ entry:
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = load i32, i32* %arg1
   %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
   %7 = load i64, i64 addrspace(1)* %5
@@ -12121,7 +13912,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12158,8 +13949,8 @@ entry:
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
   %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
   %16 = load i64, i64 addrspace(1)* %14
@@ -12180,8 +13971,8 @@ entry:
   %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
   %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
   %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %31, null
-  br i1 %NullCheck2, label %32, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = load i64, i64 addrspace(1)* %31
@@ -12224,7 +14015,7 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12237,14 +14028,14 @@ entry:
   %this = alloca %System.Text.EncoderReplacementFallback addrspace(1)*
   store %System.Text.EncoderReplacementFallback addrspace(1)* %param0, %System.Text.EncoderReplacementFallback addrspace(1)** %this
   %0 = load %System.Text.EncoderReplacementFallback addrspace(1)*, %System.Text.EncoderReplacementFallback addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -12255,7 +14046,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12285,8 +14076,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
@@ -12318,8 +14109,8 @@ entry:
   %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
   store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
@@ -12331,8 +14122,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Threading.Tasks.Task addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %7)
@@ -12355,7 +14146,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12374,8 +14165,8 @@ entry:
   store i8 %param1, i8* %arg1
   store i8 %param2, i8* %arg2
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
@@ -12389,8 +14180,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1, %5
   %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 9
@@ -12421,8 +14212,8 @@ entry:
 
 ; <label>:25                                      ; preds = %8, %20
   %26 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %26, null
-  br i1 %NullCheck4, label %27, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %26, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %26, i32 0, i32 12
@@ -12433,22 +14224,22 @@ entry:
 
 ; <label>:32                                      ; preds = %27
   %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %33, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.IO.StreamWriter addrspace(1)* %33, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %32
   %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 12
   store i8 1, i8 addrspace(1)* %35
   %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
-  br i1 %NullCheck8, label %37, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
   %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
   %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck10 = icmp ne i64 addrspace(1)* %40, null
-  br i1 %NullCheck10, label %41, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64 addrspace(1)* %40, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i64, i64 addrspace(1)* %40
@@ -12462,8 +14253,8 @@ entry:
   %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
   store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
   %51 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %NullCheck12 = icmp ne %"System.Byte[]" addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Byte[]" addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %41
   %53 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %51, i32 0, i32 1
@@ -12475,16 +14266,16 @@ entry:
 
 ; <label>:58                                      ; preds = %52
   %59 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %59, null
-  br i1 %NullCheck14, label %60, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.IO.StreamWriter addrspace(1)* %59, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %60
 
 ; <label>:60                                      ; preds = %58
   %61 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %59, i32 0, i32 3
   %62 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
   %64 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %NullCheck16 = icmp ne %"System.Byte[]" addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %"System.Byte[]" addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %60
   %66 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %64, i32 0, i32 1
@@ -12492,8 +14283,8 @@ entry:
   %68 = zext i32 %67 to i64
   %69 = trunc i64 %68 to i32
   %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck18, label %71, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
   %72 = load i64, i64 addrspace(1)* %70
@@ -12509,29 +14300,29 @@ entry:
 
 ; <label>:80                                      ; preds = %27, %52, %71
   %81 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %81, null
-  br i1 %NullCheck20, label %82, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.IO.StreamWriter addrspace(1)* %81, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
 
 ; <label>:82                                      ; preds = %80
   %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %81, i32 0, i32 5
   %84 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %83, align 8
   %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.IO.StreamWriter addrspace(1)* %85, null
-  br i1 %NullCheck22, label %86, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.IO.StreamWriter addrspace(1)* %85, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %86
 
 ; <label>:86                                      ; preds = %82
   %87 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 7
   %88 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %87, align 8
   %89 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %89, null
-  br i1 %NullCheck24, label %90, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.StreamWriter addrspace(1)* %89, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %90
 
 ; <label>:90                                      ; preds = %86
   %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %89, i32 0, i32 9
   %92 = load i32, i32 addrspace(1)* %91, align 8
   %93 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.IO.StreamWriter addrspace(1)* %93, null
-  br i1 %NullCheck26, label %94, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.IO.StreamWriter addrspace(1)* %93, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %93, i32 0, i32 6
@@ -12539,8 +14330,8 @@ entry:
   %97 = load i8, i8* %arg2
   %98 = zext i8 %97 to i32
   %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
-  %NullCheck28 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck28, label %100, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
   %101 = load i64, i64 addrspace(1)* %99
@@ -12555,8 +14346,8 @@ entry:
   %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
   store i32 %110, i32* %loc1
   %111 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %111, null
-  br i1 %NullCheck30, label %112, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.IO.StreamWriter addrspace(1)* %111, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %112
 
 ; <label>:112                                     ; preds = %100
   %113 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %111, i32 0, i32 9
@@ -12567,23 +14358,23 @@ entry:
 
 ; <label>:116                                     ; preds = %112
   %117 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck32 = icmp ne %System.IO.StreamWriter addrspace(1)* %117, null
-  br i1 %NullCheck32, label %118, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.IO.StreamWriter addrspace(1)* %117, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %118
 
 ; <label>:118                                     ; preds = %116
   %119 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %117, i32 0, i32 3
   %120 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %119, align 8
   %121 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.IO.StreamWriter addrspace(1)* %121, null
-  br i1 %NullCheck34, label %122, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.IO.StreamWriter addrspace(1)* %121, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %122
 
 ; <label>:122                                     ; preds = %118
   %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
   %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
   %125 = load i32, i32* %loc1
   %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
-  %NullCheck36 = icmp ne i64 addrspace(1)* %126, null
-  br i1 %NullCheck36, label %127, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64 addrspace(1)* %126, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
   %128 = load i64, i64 addrspace(1)* %126
@@ -12605,15 +14396,15 @@ entry:
 
 ; <label>:140                                     ; preds = %136
   %141 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.IO.StreamWriter addrspace(1)* %141, null
-  br i1 %NullCheck38, label %142, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.IO.StreamWriter addrspace(1)* %141, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %142
 
 ; <label>:142                                     ; preds = %140
   %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
   %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
   %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
-  %NullCheck40 = icmp ne i64 addrspace(1)* %145, null
-  br i1 %NullCheck40, label %146, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i64 addrspace(1)* %145, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
   %147 = load i64, i64 addrspace(1)* %145
@@ -12634,83 +14425,83 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %25
+ThrowNullRef4:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %32
+ThrowNullRef6:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %37
+ThrowNullRef10:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %41
+ThrowNullRef12:                                   ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %58
+ThrowNullRef14:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %60
+ThrowNullRef16:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %65
+ThrowNullRef18:                                   ; preds = %65
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %80
+ThrowNullRef20:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %82
+ThrowNullRef22:                                   ; preds = %82
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %86
+ThrowNullRef24:                                   ; preds = %86
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %90
+ThrowNullRef26:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %94
+ThrowNullRef28:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %100
+ThrowNullRef30:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %116
+ThrowNullRef32:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %118
+ThrowNullRef34:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %122
+ThrowNullRef36:                                   ; preds = %122
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %140
+ThrowNullRef38:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %142
+ThrowNullRef40:                                   ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12777,8 +14568,8 @@ entry:
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %1 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
-  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
@@ -12786,8 +14577,8 @@ entry:
   %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
   %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
   %8 = load i64, i64 addrspace(1)* %6
@@ -12803,8 +14594,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %17, %System.IFormatProvider addrspace(1)* %16)
   %18 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %19 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %18, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.SyncTextWriter addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %7
   %21 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %18, i32 0, i32 4
@@ -12815,11 +14606,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12832,8 +14623,8 @@ entry:
   %this = alloca %System.IO.TextWriter addrspace(1)*
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.TextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
@@ -12843,8 +14634,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.Threading.Thread addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Threading.Thread addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %6)
@@ -12853,8 +14644,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1
   %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.TextWriter addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.TextWriter addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %11, i32 0, i32 2
@@ -12865,11 +14656,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13066,8 +14857,8 @@ entry:
   store double %param1, double* %arg1
   store i8 0, i8* %loc1
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
@@ -13077,16 +14868,16 @@ entry:
   %5 = addrspacecast i8* %loc1 to i8 addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %4, i8 addrspace(1)* %5)
   %6 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.SyncTextWriter addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
   %10 = load double, double* %arg1
   %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
   %13 = load i64, i64 addrspace(1)* %11
@@ -13121,11 +14912,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13142,8 +14933,8 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load double, double* %arg1
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -13157,8 +14948,8 @@ entry:
   call void %11(%System.IO.TextWriter addrspace(1)* %0, double %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
   %15 = load i64, i64 addrspace(1)* %13
@@ -13176,7 +14967,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13194,8 +14985,8 @@ entry:
   %1 = addrspacecast double* %arg1 to double addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -13210,8 +15001,8 @@ entry:
   %14 = bitcast double addrspace(1)* %1 to %System.Double addrspace(1)*
   %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Double addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Double addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
   %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
   %18 = load i64, i64 addrspace(1)* %16
@@ -13229,7 +15020,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13245,8 +15036,8 @@ entry:
   store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
   %0 = load %System.Double addrspace(1)*, %System.Double addrspace(1)** %this
   %1 = bitcast %System.Double addrspace(1)* %0 to double addrspace(1)*
-  %NullCheck = icmp ne double addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq double addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load double, double addrspace(1)* %1, align 8
@@ -13271,8 +15062,8 @@ entry:
   %loc0 = alloca %System.Globalization.NumberFormatInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 3
@@ -13282,8 +15073,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
@@ -13293,24 +15084,24 @@ entry:
   store %System.Globalization.NumberFormatInfo addrspace(1)* %10, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
   %11 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %7
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
   %15 = load i8, i8 addrspace(1)* %14, align 8
   %16 = zext i8 %15 to i32
   %17 = trunc i32 %16 to i8
-  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %11, null
-  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %11, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %13
   %19 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %11, i32 0, i32 29
   store i8 %17, i8 addrspace(1)* %19
   %20 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %21 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %20, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %20, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %18
   %23 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %20, i32 0, i32 3
@@ -13319,8 +15110,8 @@ entry:
 
 ; <label>:24                                      ; preds = %1, %22
   %25 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %25, null
-  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %25, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %26
 
 ; <label>:26                                      ; preds = %24
   %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %25, i32 0, i32 3
@@ -13331,23 +15122,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %18
+ThrowNullRef8:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13372,168 +15163,168 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 18
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %8, align 8
-  %NullCheck2 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %5, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %5, i32 0, i32 4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %9)
   %12 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 19
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %15, align 8
-  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %12, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %12, i32 0, i32 5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %16)
   %19 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %20 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %20, null
-  br i1 %NullCheck8, label %21, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %20, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %20, i32 0, i32 23
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  %NullCheck10 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %19, null
-  br i1 %NullCheck10, label %24, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %19, i32 0, i32 7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %25, %System.String addrspace(1)* %23)
   %26 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %27 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %27, i32 0, i32 22
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %29, align 8
-  %NullCheck14 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %26, null
-  br i1 %NullCheck14, label %31, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %26, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %26, i32 0, i32 6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %32, %System.String addrspace(1)* %30)
   %33 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %34 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Globalization.CultureData addrspace(1)* %34, null
-  br i1 %NullCheck16, label %35, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Globalization.CultureData addrspace(1)* %34, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %34, i32 0, i32 51
   %37 = load i32, i32 addrspace(1)* %36, align 8
-  %NullCheck18 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %33, null
-  br i1 %NullCheck18, label %38, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %33, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %33, i32 0, i32 21
   store i32 %37, i32 addrspace(1)* %39
   %40 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %41 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Globalization.CultureData addrspace(1)* %41, null
-  br i1 %NullCheck20, label %42, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Globalization.CultureData addrspace(1)* %41, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %41, i32 0, i32 52
   %44 = load i32, i32 addrspace(1)* %43, align 8
-  %NullCheck22 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %40, null
-  br i1 %NullCheck22, label %45, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %40, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %40, i32 0, i32 25
   store i32 %44, i32 addrspace(1)* %46
   %47 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %48 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.Globalization.CultureData addrspace(1)* %48, null
-  br i1 %NullCheck24, label %49, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Globalization.CultureData addrspace(1)* %48, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %49
 
 ; <label>:49                                      ; preds = %45
   %50 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %48, i32 0, i32 29
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck26 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %47, null
-  br i1 %NullCheck26, label %52, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %47, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %47, i32 0, i32 10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %53, %System.String addrspace(1)* %51)
   %54 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %55 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Globalization.CultureData addrspace(1)* %55, null
-  br i1 %NullCheck28, label %56, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Globalization.CultureData addrspace(1)* %55, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %56
 
 ; <label>:56                                      ; preds = %52
   %57 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %55, i32 0, i32 35
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %57, align 8
-  %NullCheck30 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %54, null
-  br i1 %NullCheck30, label %59, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %54, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %54, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %60, %System.String addrspace(1)* %58)
   %61 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %62 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck32 = icmp ne %System.Globalization.CultureData addrspace(1)* %62, null
-  br i1 %NullCheck32, label %63, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Globalization.CultureData addrspace(1)* %62, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %62, i32 0, i32 34
   %65 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %64, align 8
-  %NullCheck34 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %61, null
-  br i1 %NullCheck34, label %66, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %61, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %61, i32 0, i32 9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %67, %System.String addrspace(1)* %65)
   %68 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %69 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck36 = icmp ne %System.Globalization.CultureData addrspace(1)* %69, null
-  br i1 %NullCheck36, label %70, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Globalization.CultureData addrspace(1)* %69, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %70
 
 ; <label>:70                                      ; preds = %66
   %71 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %69, i32 0, i32 55
   %72 = load i32, i32 addrspace(1)* %71, align 8
-  %NullCheck38 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %68, null
-  br i1 %NullCheck38, label %73, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %68, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %68, i32 0, i32 22
   store i32 %72, i32 addrspace(1)* %74
   %75 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %76 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck40 = icmp ne %System.Globalization.CultureData addrspace(1)* %76, null
-  br i1 %NullCheck40, label %77, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Globalization.CultureData addrspace(1)* %76, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %76, i32 0, i32 57
   %79 = load i32, i32 addrspace(1)* %78, align 8
-  %NullCheck42 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %75, null
-  br i1 %NullCheck42, label %80, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %75, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %80
 
 ; <label>:80                                      ; preds = %77
   %81 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %75, i32 0, i32 24
   store i32 %79, i32 addrspace(1)* %81
   %82 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %83 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck44 = icmp ne %System.Globalization.CultureData addrspace(1)* %83, null
-  br i1 %NullCheck44, label %84, label %ThrowNullRef43
+  %NullCheck43 = icmp eq %System.Globalization.CultureData addrspace(1)* %83, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %84
 
 ; <label>:84                                      ; preds = %80
   %85 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %83, i32 0, i32 56
   %86 = load i32, i32 addrspace(1)* %85, align 8
-  %NullCheck46 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %82, null
-  br i1 %NullCheck46, label %87, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %82, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %82, i32 0, i32 23
@@ -13542,8 +15333,8 @@ entry:
 
 ; <label>:89                                      ; preds = %entry
   %90 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck100 = icmp ne %System.Globalization.CultureData addrspace(1)* %90, null
-  br i1 %NullCheck100, label %91, label %ThrowNullRef99
+  %NullCheck99 = icmp eq %System.Globalization.CultureData addrspace(1)* %90, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %91
 
 ; <label>:91                                      ; preds = %89
   %92 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %90, i32 0, i32 2
@@ -13561,8 +15352,8 @@ entry:
   %102 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %103 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %104 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %103)
-  %NullCheck48 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %102, null
-  br i1 %NullCheck48, label %105, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %102, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %105
 
 ; <label>:105                                     ; preds = %101
   %106 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %102, i32 0, i32 1
@@ -13570,8 +15361,8 @@ entry:
   %107 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %108 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %109 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %108)
-  %NullCheck50 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %107, null
-  br i1 %NullCheck50, label %110, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %107, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %110
 
 ; <label>:110                                     ; preds = %105
   %111 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %107, i32 0, i32 2
@@ -13579,8 +15370,8 @@ entry:
   %112 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %113 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %114 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %113)
-  %NullCheck52 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %112, null
-  br i1 %NullCheck52, label %115, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %112, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %115
 
 ; <label>:115                                     ; preds = %110
   %116 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %112, i32 0, i32 27
@@ -13588,8 +15379,8 @@ entry:
   %117 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %118 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %119 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %118)
-  %NullCheck54 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %117, null
-  br i1 %NullCheck54, label %120, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %117, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %120
 
 ; <label>:120                                     ; preds = %115
   %121 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %117, i32 0, i32 26
@@ -13597,8 +15388,8 @@ entry:
   %122 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %123 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %124 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %123)
-  %NullCheck56 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %122, null
-  br i1 %NullCheck56, label %125, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %122, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %125
 
 ; <label>:125                                     ; preds = %120
   %126 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %122, i32 0, i32 17
@@ -13606,8 +15397,8 @@ entry:
   %127 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %128 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %129 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %128)
-  %NullCheck58 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %127, null
-  br i1 %NullCheck58, label %130, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %127, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %130
 
 ; <label>:130                                     ; preds = %125
   %131 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %127, i32 0, i32 18
@@ -13615,8 +15406,8 @@ entry:
   %132 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %133 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %134 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %133)
-  %NullCheck60 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %132, null
-  br i1 %NullCheck60, label %135, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %132, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %135
 
 ; <label>:135                                     ; preds = %130
   %136 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %132, i32 0, i32 14
@@ -13624,8 +15415,8 @@ entry:
   %137 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %138 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %139 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %138)
-  %NullCheck62 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %137, null
-  br i1 %NullCheck62, label %140, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %137, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %140
 
 ; <label>:140                                     ; preds = %135
   %141 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %137, i32 0, i32 13
@@ -13633,71 +15424,71 @@ entry:
   %142 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %143 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %144 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %143)
-  %NullCheck64 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %142, null
-  br i1 %NullCheck64, label %145, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %142, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %145
 
 ; <label>:145                                     ; preds = %140
   %146 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %142, i32 0, i32 12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %146, %System.String addrspace(1)* %144)
   %147 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %148 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck66 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %148, null
-  br i1 %NullCheck66, label %149, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %148, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %149
 
 ; <label>:149                                     ; preds = %145
   %150 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %148, i32 0, i32 21
   %151 = load i32, i32 addrspace(1)* %150, align 8
-  %NullCheck68 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %147, null
-  br i1 %NullCheck68, label %152, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %147, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %152
 
 ; <label>:152                                     ; preds = %149
   %153 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %147, i32 0, i32 28
   store i32 %151, i32 addrspace(1)* %153
   %154 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %155 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck70 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %155, null
-  br i1 %NullCheck70, label %156, label %ThrowNullRef69
+  %NullCheck69 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %155, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %156
 
 ; <label>:156                                     ; preds = %152
   %157 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %155, i32 0, i32 6
   %158 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %157, align 8
-  %NullCheck72 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %154, null
-  br i1 %NullCheck72, label %159, label %ThrowNullRef71
+  %NullCheck71 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %154, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %159
 
 ; <label>:159                                     ; preds = %156
   %160 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %154, i32 0, i32 15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %160, %System.String addrspace(1)* %158)
   %161 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %162 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck74 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %162, null
-  br i1 %NullCheck74, label %163, label %ThrowNullRef73
+  %NullCheck73 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %162, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %163
 
 ; <label>:163                                     ; preds = %159
   %164 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %162, i32 0, i32 1
   %165 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %164, align 8
-  %NullCheck76 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %161, null
-  br i1 %NullCheck76, label %166, label %ThrowNullRef75
+  %NullCheck75 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %161, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %166
 
 ; <label>:166                                     ; preds = %163
   %167 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %161, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %167, %"System.Int32[]" addrspace(1)* %165)
   %168 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %169 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck78 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %169, null
-  br i1 %NullCheck78, label %170, label %ThrowNullRef77
+  %NullCheck77 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %169, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %170
 
 ; <label>:170                                     ; preds = %166
   %171 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %169, i32 0, i32 7
   %172 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %171, align 8
-  %NullCheck80 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %168, null
-  br i1 %NullCheck80, label %173, label %ThrowNullRef79
+  %NullCheck79 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %168, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %173
 
 ; <label>:173                                     ; preds = %170
   %174 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %168, i32 0, i32 16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %174, %System.String addrspace(1)* %172)
   %175 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck82 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %175, null
-  br i1 %NullCheck82, label %176, label %ThrowNullRef81
+  %NullCheck81 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %175, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %176
 
 ; <label>:176                                     ; preds = %173
   %177 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %175, i32 0, i32 4
@@ -13707,14 +15498,14 @@ entry:
 
 ; <label>:180                                     ; preds = %176
   %181 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck84 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %181, null
-  br i1 %NullCheck84, label %182, label %ThrowNullRef83
+  %NullCheck83 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %181, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %182
 
 ; <label>:182                                     ; preds = %180
   %183 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %181, i32 0, i32 4
   %184 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %183, align 8
-  %NullCheck86 = icmp ne %System.String addrspace(1)* %184, null
-  br i1 %NullCheck86, label %185, label %ThrowNullRef85
+  %NullCheck85 = icmp eq %System.String addrspace(1)* %184, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %185
 
 ; <label>:185                                     ; preds = %182
   %186 = getelementptr inbounds %System.String, %System.String addrspace(1)* %184, i32 0, i32 1
@@ -13725,8 +15516,8 @@ entry:
 ; <label>:189                                     ; preds = %176, %185
   %190 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck98 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %190, null
-  br i1 %NullCheck98, label %192, label %ThrowNullRef97
+  %NullCheck97 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %190, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %192
 
 ; <label>:192                                     ; preds = %189
   %193 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %190, i32 0, i32 4
@@ -13735,8 +15526,8 @@ entry:
 
 ; <label>:194                                     ; preds = %185, %192
   %195 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck88 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %195, null
-  br i1 %NullCheck88, label %196, label %ThrowNullRef87
+  %NullCheck87 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %195, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %196
 
 ; <label>:196                                     ; preds = %194
   %197 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %195, i32 0, i32 9
@@ -13746,14 +15537,14 @@ entry:
 
 ; <label>:200                                     ; preds = %196
   %201 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck90 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %201, null
-  br i1 %NullCheck90, label %202, label %ThrowNullRef89
+  %NullCheck89 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %201, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %202
 
 ; <label>:202                                     ; preds = %200
   %203 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %201, i32 0, i32 9
   %204 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %203, align 8
-  %NullCheck92 = icmp ne %System.String addrspace(1)* %204, null
-  br i1 %NullCheck92, label %205, label %ThrowNullRef91
+  %NullCheck91 = icmp eq %System.String addrspace(1)* %204, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %205
 
 ; <label>:205                                     ; preds = %202
   %206 = getelementptr inbounds %System.String, %System.String addrspace(1)* %204, i32 0, i32 1
@@ -13764,14 +15555,14 @@ entry:
 ; <label>:209                                     ; preds = %196, %205
   %210 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %211 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck94 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %211, null
-  br i1 %NullCheck94, label %212, label %ThrowNullRef93
+  %NullCheck93 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %211, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %212
 
 ; <label>:212                                     ; preds = %209
   %213 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %211, i32 0, i32 6
   %214 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %213, align 8
-  %NullCheck96 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %210, null
-  br i1 %NullCheck96, label %215, label %ThrowNullRef95
+  %NullCheck95 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %210, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %215
 
 ; <label>:215                                     ; preds = %212
   %216 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %210, i32 0, i32 9
@@ -13785,203 +15576,203 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %17
+ThrowNullRef8:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %21
+ThrowNullRef10:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %24
+ThrowNullRef12:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %28
+ThrowNullRef14:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %31
+ThrowNullRef16:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %35
+ThrowNullRef18:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %38
+ThrowNullRef20:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %42
+ThrowNullRef22:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %45
+ThrowNullRef24:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %49
+ThrowNullRef26:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %52
+ThrowNullRef28:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %56
+ThrowNullRef30:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %59
+ThrowNullRef32:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %63
+ThrowNullRef34:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %66
+ThrowNullRef36:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %70
+ThrowNullRef38:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %73
+ThrowNullRef40:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %77
+ThrowNullRef42:                                   ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %80
+ThrowNullRef44:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %84
+ThrowNullRef46:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %101
+ThrowNullRef48:                                   ; preds = %101
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %105
+ThrowNullRef50:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %110
+ThrowNullRef52:                                   ; preds = %110
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %115
+ThrowNullRef54:                                   ; preds = %115
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %120
+ThrowNullRef56:                                   ; preds = %120
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %125
+ThrowNullRef58:                                   ; preds = %125
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %130
+ThrowNullRef60:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %135
+ThrowNullRef62:                                   ; preds = %135
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %140
+ThrowNullRef64:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %145
+ThrowNullRef66:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %149
+ThrowNullRef68:                                   ; preds = %149
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %152
+ThrowNullRef70:                                   ; preds = %152
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %156
+ThrowNullRef72:                                   ; preds = %156
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %159
+ThrowNullRef74:                                   ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %163
+ThrowNullRef76:                                   ; preds = %163
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %166
+ThrowNullRef78:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %170
+ThrowNullRef80:                                   ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %173
+ThrowNullRef82:                                   ; preds = %173
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %180
+ThrowNullRef84:                                   ; preds = %180
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %182
+ThrowNullRef86:                                   ; preds = %182
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %194
+ThrowNullRef88:                                   ; preds = %194
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %200
+ThrowNullRef90:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %202
+ThrowNullRef92:                                   ; preds = %202
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %209
+ThrowNullRef94:                                   ; preds = %209
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %212
+ThrowNullRef96:                                   ; preds = %212
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %189
+ThrowNullRef98:                                   ; preds = %189
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %89
+ThrowNullRef100:                                  ; preds = %89
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14009,8 +15800,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 21
@@ -14023,8 +15814,8 @@ entry:
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 16)
   %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 21
@@ -14033,8 +15824,8 @@ entry:
 
 ; <label>:12                                      ; preds = %1, %10
   %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 21
@@ -14045,11 +15836,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %12
+ThrowNullRef4:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14065,8 +15856,8 @@ entry:
   store i32 %param1, i32* %arg1
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %1 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
@@ -14133,8 +15924,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 33
@@ -14147,8 +15938,8 @@ entry:
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 24)
   %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 33
@@ -14157,8 +15948,8 @@ entry:
 
 ; <label>:12                                      ; preds = %1, %10
   %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 33
@@ -14169,11 +15960,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %12
+ThrowNullRef4:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14186,8 +15977,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 53
@@ -14199,8 +15990,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 116)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 53
@@ -14209,8 +16000,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 53
@@ -14221,11 +16012,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14254,8 +16045,8 @@ entry:
 
 ; <label>:7                                       ; preds = %entry, %4
   %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %7
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 2
@@ -14279,8 +16070,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 54
@@ -14292,8 +16083,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 117)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
@@ -14302,8 +16093,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 54
@@ -14314,11 +16105,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14331,8 +16122,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 27
@@ -14344,8 +16135,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 118)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 27
@@ -14354,8 +16145,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 27
@@ -14366,11 +16157,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14383,8 +16174,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 28
@@ -14396,8 +16187,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 119)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 28
@@ -14406,8 +16197,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 28
@@ -14418,11 +16209,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14435,8 +16226,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 26
@@ -14448,8 +16239,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 107)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 26
@@ -14458,8 +16249,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 26
@@ -14470,11 +16261,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14487,8 +16278,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 25
@@ -14500,8 +16291,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 106)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 25
@@ -14510,8 +16301,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 25
@@ -14522,11 +16313,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14539,8 +16330,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 24
@@ -14552,8 +16343,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 105)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 24
@@ -14562,8 +16353,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 24
@@ -14574,11 +16365,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14603,8 +16394,8 @@ entry:
   %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %3)
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %2
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -14615,15 +16406,15 @@ entry:
 
 ; <label>:8                                       ; preds = %62
   %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 9
   %12 = load i32, i32 addrspace(1)* %11, align 8
   %13 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.IO.StreamWriter addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %13, i32 0, i32 10
@@ -14638,15 +16429,15 @@ entry:
 
 ; <label>:20                                      ; preds = %14, %18
   %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
   %24 = load i32, i32 addrspace(1)* %23, align 8
   %25 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %25, null
-  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.StreamWriter addrspace(1)* %25, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %25, i32 0, i32 9
@@ -14667,36 +16458,36 @@ entry:
   %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %37 = load i32, i32* %loc1
   %38 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.StreamWriter addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %35
   %40 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %38, i32 0, i32 7
   %41 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %40, align 8
   %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
-  br i1 %NullCheck14, label %43, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %39
   %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 9
   %45 = load i32, i32 addrspace(1)* %44, align 8
   %46 = load i32, i32* %loc2
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %36, null
-  br i1 %NullCheck16, label %47, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %36, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %47
 
 ; <label>:47                                      ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %36, i32 %37, %"System.Char[]" addrspace(1)* %41, i32 %45, i32 %46)
   %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
   %51 = load i32, i32 addrspace(1)* %50, align 8
   %52 = load i32, i32* %loc2
   %53 = add i32 %51, %52
-  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
-  br i1 %NullCheck20, label %54, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %54
 
 ; <label>:54                                      ; preds = %49
   %55 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
@@ -14718,8 +16509,8 @@ entry:
 
 ; <label>:65                                      ; preds = %62
   %66 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %66, null
-  br i1 %NullCheck2, label %67, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %66, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %67
 
 ; <label>:67                                      ; preds = %65
   %68 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %66, i32 0, i32 11
@@ -14740,49 +16531,259 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %65
+ThrowNullRef2:                                    ; preds = %65
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %20
+ThrowNullRef8:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %22
+ThrowNullRef10:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %35
+ThrowNullRef12:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %43
+ThrowNullRef16:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %47
+ThrowNullRef18:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method String::CopyTo using LLILCJit
-Failed to read String.CopyTo[loadElemA]
+Successfully read String.CopyTo
+
+define void @String.CopyTo(%System.String addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  %loc1 = alloca i16 addrspace(1)*
+  %loc2 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %1 = icmp ne %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg4
+  %7 = icmp sge i32 %6, 0
+  br i1 %7, label %13, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  unreachable
+
+; <label>:13                                      ; preds = %5
+  %14 = load i32, i32* %arg1
+  %15 = icmp sge i32 %14, 0
+  br i1 %15, label %21, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %18)
+  %20 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %20, %System.String addrspace(1)* %17, %System.String addrspace(1)* %19)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %20) #0
+  unreachable
+
+; <label>:21                                      ; preds = %13
+  %22 = load i32, i32* %arg4
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck, label %ThrowNullRef, label %24
+
+; <label>:24                                      ; preds = %21
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load i32, i32* %arg1
+  %28 = sub i32 %26, %27
+  %29 = icmp sle i32 %22, %28
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34, %System.String addrspace(1)* %31, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %24
+  %36 = load i32, i32* %arg3
+  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %37, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
+
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
+  %40 = load i32, i32 addrspace(1)* %39
+  %41 = zext i32 %40 to i64
+  %42 = trunc i64 %41 to i32
+  %43 = load i32, i32* %arg4
+  %44 = sub i32 %42, %43
+  %45 = icmp sgt i32 %36, %44
+  br i1 %45, label %49, label %46
+
+; <label>:46                                      ; preds = %38
+  %47 = load i32, i32* %arg3
+  %48 = icmp sge i32 %47, 0
+  br i1 %48, label %54, label %49
+
+; <label>:49                                      ; preds = %38, %46
+  %50 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %52 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %51)
+  %53 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53, %System.String addrspace(1)* %50, %System.String addrspace(1)* %52)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53) #0
+  unreachable
+
+; <label>:54                                      ; preds = %46
+  %55 = load i32, i32* %arg4
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %97, label %57
+
+; <label>:57                                      ; preds = %54
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %59
+
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 2
+  %61 = bitcast [0 x i16] addrspace(1)* %60 to i16 addrspace(1)*
+  store i16 addrspace(1)* %61, i16 addrspace(1)** %loc0
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  store %"System.Char[]" addrspace(1)* %62, %"System.Char[]" addrspace(1)** %loc2
+  %63 = icmp eq %"System.Char[]" addrspace(1)* %62, null
+  br i1 %63, label %72, label %64
+
+; <label>:64                                      ; preds = %59
+  %65 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc2
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %65, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %66
+
+; <label>:66                                      ; preds = %64
+  %67 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %65, i32 0, i32 1
+  %68 = load i32, i32 addrspace(1)* %67
+  %69 = zext i32 %68 to i64
+  %70 = trunc i64 %69 to i32
+  %71 = icmp ne i32 %70, 0
+  br i1 %71, label %73, label %72
+
+; <label>:72                                      ; preds = %59, %66
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  br label %81
+
+; <label>:73                                      ; preds = %66
+  %74 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc2
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %74, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %75
+
+; <label>:75                                      ; preds = %73
+  %76 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %74, i32 0, i32 1
+  %77 = load i32, i32 addrspace(1)* %76
+  %78 = zext i32 %77 to i64
+  %BoundsCheck = icmp uge i64 0, %78
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %79
+
+; <label>:79                                      ; preds = %75
+  %80 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %74, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %80, i16 addrspace(1)** %loc1
+  br label %81
+
+; <label>:81                                      ; preds = %72, %79
+  %82 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %83 = ptrtoint i16 addrspace(1)* %82 to i64
+  %84 = load i32, i32* %arg3
+  %85 = sext i32 %84 to i64
+  %86 = mul i64 %85, 2
+  %87 = add i64 %83, %86
+  %88 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %89 = ptrtoint i16 addrspace(1)* %88 to i64
+  %90 = load i32, i32* %arg1
+  %91 = sext i32 %90 to i64
+  %92 = mul i64 %91, 2
+  %93 = add i64 %89, %92
+  %94 = load i32, i32* %arg4
+  %95 = inttoptr i64 %87 to i16*
+  %96 = inttoptr i64 %93 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %95, i16* %96, i32 %94)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  br label %97
+
+; <label>:97                                      ; preds = %54, %81
+  ret void
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
 Successfully read ConsoleEncoding.GetPreamble
 
@@ -14819,7 +16820,365 @@ entry:
 }
 
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[loadElemA]
+Successfully read EncoderNLS.GetBytes
+
+define i32 @EncoderNLS.GetBytes(%System.Text.EncoderNLS addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3, %"System.Byte[]" addrspace(1)* %param4, i32 %param5, i8 %param6) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %arg4 = alloca %"System.Byte[]" addrspace(1)*
+  %arg5 = alloca i32
+  %arg6 = alloca i8
+  %loc0 = alloca i32
+  %loc1 = alloca i16 addrspace(1)*
+  %loc2 = alloca i8 addrspace(1)*
+  %loc3 = alloca i32
+  %loc4 = alloca %"System.Char[]" addrspace(1)*
+  %loc5 = alloca %"System.Byte[]" addrspace(1)*
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  store %"System.Byte[]" addrspace(1)* %param4, %"System.Byte[]" addrspace(1)** %arg4
+  store i32 %param5, i32* %arg5
+  store i8 %param6, i8* %arg6
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %1 = icmp eq %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %17, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %7 = icmp eq %"System.Char[]" addrspace(1)* %6, null
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %12
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %12
+
+; <label>:12                                      ; preds = %8, %10
+  %13 = phi %System.String addrspace(1)* [ %9, %8 ], [ %11, %10 ]
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %14)
+  %16 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16, %System.String addrspace(1)* %13, %System.String addrspace(1)* %15)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16) #0
+  unreachable
+
+; <label>:17                                      ; preds = %2
+  %18 = load i32, i32* %arg2
+  %19 = icmp slt i32 %18, 0
+  br i1 %19, label %23, label %20
+
+; <label>:20                                      ; preds = %17
+  %21 = load i32, i32* %arg3
+  %22 = icmp sge i32 %21, 0
+  br i1 %22, label %35, label %23
+
+; <label>:23                                      ; preds = %17, %20
+  %24 = load i32, i32* %arg2
+  %25 = icmp slt i32 %24, 0
+  br i1 %25, label %28, label %26
+
+; <label>:26                                      ; preds = %23
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %30
+
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %30
+
+; <label>:30                                      ; preds = %26, %28
+  %31 = phi %System.String addrspace(1)* [ %27, %26 ], [ %29, %28 ]
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34, %System.String addrspace(1)* %31, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %20
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck, label %ThrowNullRef, label %37
+
+; <label>:37                                      ; preds = %35
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = load i32, i32* %arg2
+  %43 = sub i32 %41, %42
+  %44 = load i32, i32* %arg3
+  %45 = icmp sge i32 %43, %44
+  br i1 %45, label %51, label %46
+
+; <label>:46                                      ; preds = %37
+  %47 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %48 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %49 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %48)
+  %50 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %50, %System.String addrspace(1)* %47, %System.String addrspace(1)* %49)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %50) #0
+  unreachable
+
+; <label>:51                                      ; preds = %37
+  %52 = load i32, i32* %arg5
+  %53 = icmp slt i32 %52, 0
+  br i1 %53, label %63, label %54
+
+; <label>:54                                      ; preds = %51
+  %55 = load i32, i32* %arg5
+  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck1 = icmp eq %"System.Byte[]" addrspace(1)* %56, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %57
+
+; <label>:57                                      ; preds = %54
+  %58 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = zext i32 %59 to i64
+  %61 = trunc i64 %60 to i32
+  %62 = icmp sle i32 %55, %61
+  br i1 %62, label %68, label %63
+
+; <label>:63                                      ; preds = %51, %57
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %66 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %65)
+  %67 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %67, %System.String addrspace(1)* %64, %System.String addrspace(1)* %66)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %67) #0
+  unreachable
+
+; <label>:68                                      ; preds = %57
+  %69 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %69, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %69, i32 0, i32 1
+  %72 = load i32, i32 addrspace(1)* %71
+  %73 = zext i32 %72 to i64
+  %74 = trunc i64 %73 to i32
+  %75 = icmp ne i32 %74, 0
+  br i1 %75, label %78, label %76
+
+; <label>:76                                      ; preds = %70
+  %77 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1)
+  store %"System.Char[]" addrspace(1)* %77, %"System.Char[]" addrspace(1)** %arg1
+  br label %78
+
+; <label>:78                                      ; preds = %70, %76
+  %79 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck5 = icmp eq %"System.Byte[]" addrspace(1)* %79, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %80
+
+; <label>:80                                      ; preds = %78
+  %81 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %79, i32 0, i32 1
+  %82 = load i32, i32 addrspace(1)* %81
+  %83 = zext i32 %82 to i64
+  %84 = trunc i64 %83 to i32
+  %85 = load i32, i32* %arg5
+  %86 = sub i32 %84, %85
+  store i32 %86, i32* %loc0
+  %87 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck7 = icmp eq %"System.Byte[]" addrspace(1)* %87, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %88
+
+; <label>:88                                      ; preds = %80
+  %89 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %87, i32 0, i32 1
+  %90 = load i32, i32 addrspace(1)* %89
+  %91 = zext i32 %90 to i64
+  %92 = trunc i64 %91 to i32
+  %93 = icmp ne i32 %92, 0
+  br i1 %93, label %96, label %94
+
+; <label>:94                                      ; preds = %88
+  %95 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1)
+  store %"System.Byte[]" addrspace(1)* %95, %"System.Byte[]" addrspace(1)** %arg4
+  br label %96
+
+; <label>:96                                      ; preds = %88, %94
+  %97 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  store %"System.Char[]" addrspace(1)* %97, %"System.Char[]" addrspace(1)** %loc4
+  %98 = icmp eq %"System.Char[]" addrspace(1)* %97, null
+  br i1 %98, label %107, label %99
+
+; <label>:99                                      ; preds = %96
+  %100 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc4
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %100, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %101
+
+; <label>:101                                     ; preds = %99
+  %102 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %100, i32 0, i32 1
+  %103 = load i32, i32 addrspace(1)* %102
+  %104 = zext i32 %103 to i64
+  %105 = trunc i64 %104 to i32
+  %106 = icmp ne i32 %105, 0
+  br i1 %106, label %108, label %107
+
+; <label>:107                                     ; preds = %96, %101
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  br label %116
+
+; <label>:108                                     ; preds = %101
+  %109 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc4
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %109, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %110
+
+; <label>:110                                     ; preds = %108
+  %111 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %109, i32 0, i32 1
+  %112 = load i32, i32 addrspace(1)* %111
+  %113 = zext i32 %112 to i64
+  %BoundsCheck = icmp uge i64 0, %113
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %114
+
+; <label>:114                                     ; preds = %110
+  %115 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %109, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %115, i16 addrspace(1)** %loc1
+  br label %116
+
+; <label>:116                                     ; preds = %107, %114
+  %117 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  store %"System.Byte[]" addrspace(1)* %117, %"System.Byte[]" addrspace(1)** %loc5
+  %118 = icmp eq %"System.Byte[]" addrspace(1)* %117, null
+  br i1 %118, label %127, label %119
+
+; <label>:119                                     ; preds = %116
+  %120 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc5
+  %NullCheck13 = icmp eq %"System.Byte[]" addrspace(1)* %120, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %121
+
+; <label>:121                                     ; preds = %119
+  %122 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %120, i32 0, i32 1
+  %123 = load i32, i32 addrspace(1)* %122
+  %124 = zext i32 %123 to i64
+  %125 = trunc i64 %124 to i32
+  %126 = icmp ne i32 %125, 0
+  br i1 %126, label %128, label %127
+
+; <label>:127                                     ; preds = %116, %121
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc2
+  br label %136
+
+; <label>:128                                     ; preds = %121
+  %129 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc5
+  %NullCheck15 = icmp eq %"System.Byte[]" addrspace(1)* %129, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %130
+
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %129, i32 0, i32 1
+  %132 = load i32, i32 addrspace(1)* %131
+  %133 = zext i32 %132 to i64
+  %BoundsCheck17 = icmp uge i64 0, %133
+  br i1 %BoundsCheck17, label %ThrowIndexOutOfRange18, label %134
+
+; <label>:134                                     ; preds = %130
+  %135 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %129, i32 0, i32 3, i32 0
+  store i8 addrspace(1)* %135, i8 addrspace(1)** %loc2
+  br label %136
+
+; <label>:136                                     ; preds = %127, %134
+  %137 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %138 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %139 = ptrtoint i16 addrspace(1)* %138 to i64
+  %140 = load i32, i32* %arg2
+  %141 = sext i32 %140 to i64
+  %142 = mul i64 %141, 2
+  %143 = add i64 %139, %142
+  %144 = load i32, i32* %arg3
+  %145 = load i8 addrspace(1)*, i8 addrspace(1)** %loc2
+  %146 = ptrtoint i8 addrspace(1)* %145 to i64
+  %147 = load i32, i32* %arg5
+  %148 = sext i32 %147 to i64
+  %149 = add i64 %146, %148
+  %150 = load i32, i32* %loc0
+  %151 = load i8, i8* %arg6
+  %152 = zext i8 %151 to i32
+  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i64 addrspace(1)*
+  %NullCheck19 = icmp eq i64 addrspace(1)* %153, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %154
+
+; <label>:154                                     ; preds = %136
+  %155 = load i64, i64 addrspace(1)* %153
+  %156 = add i64 %155, 72
+  %157 = inttoptr i64 %156 to i64*
+  %158 = load i64, i64* %157
+  %159 = add i64 %158, 0
+  %160 = inttoptr i64 %159 to i64*
+  %161 = load i64, i64* %160
+  %162 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to %System.Text.Encoder addrspace(1)*
+  %163 = inttoptr i64 %143 to i16*
+  %164 = inttoptr i64 %149 to i8*
+  %165 = trunc i32 %152 to i8
+  %166 = inttoptr i64 %161 to i32 (%System.Text.Encoder addrspace(1)*, i16*, i32, i8*, i32, i8)*
+  %167 = call i32 %166(%System.Text.Encoder addrspace(1)* %162, i16* %163, i32 %144, i8* %164, i32 %150, i8 %165)
+  store i32 %167, i32* %loc3
+  br label %168
+
+; <label>:168                                     ; preds = %154
+  %169 = load i32, i32* %loc3
+  ret i32 %169
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %110
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %119
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange18:                           ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
 Successfully read EncoderNLS.GetBytes
 
@@ -14908,22 +17267,22 @@ entry:
   %40 = load i8, i8* %arg5
   %41 = zext i8 %40 to i32
   %42 = trunc i32 %41 to i8
-  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %39, null
-  br i1 %NullCheck, label %43, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderNLS addrspace(1)* %39, null
+  br i1 %NullCheck, label %ThrowNullRef, label %43
 
 ; <label>:43                                      ; preds = %38
   %44 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
   store i8 %42, i8 addrspace(1)* %44
   %45 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %45, null
-  br i1 %NullCheck2, label %46, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.EncoderNLS addrspace(1)* %45, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %46
 
 ; <label>:46                                      ; preds = %43
   %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %45, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %47
   %48 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.EncoderNLS addrspace(1)* %48, null
-  br i1 %NullCheck4, label %49, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.EncoderNLS addrspace(1)* %48, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %49
 
 ; <label>:49                                      ; preds = %46
   %50 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %48, i32 0, i32 3
@@ -14934,8 +17293,8 @@ entry:
   %55 = load i32, i32* %arg4
   %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck6, label %58, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
   %59 = load i64, i64 addrspace(1)* %57
@@ -14953,15 +17312,15 @@ ThrowNullRef:                                     ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %43
+ThrowNullRef2:                                    ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %46
+ThrowNullRef4:                                    ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %49
+ThrowNullRef6:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14989,8 +17348,8 @@ entry:
   %4 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0 to %System.IO.ConsoleStream addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*)(%System.IO.ConsoleStream addrspace(1)* %4, %"System.Byte[]" addrspace(1)* %1, i32 %2, i32 %3)
   %5 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
@@ -15075,8 +17434,8 @@ entry:
 
 ; <label>:22                                      ; preds = %8
   %23 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %23, null
-  br i1 %NullCheck, label %24, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Byte[]" addrspace(1)* %23, null
+  br i1 %NullCheck, label %ThrowNullRef, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
@@ -15098,8 +17457,8 @@ entry:
 
 ; <label>:36                                      ; preds = %24
   %37 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %37, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.ConsoleStream addrspace(1)* %37, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %37, i32 0, i32 4
@@ -15120,13 +17479,138 @@ ThrowNullRef:                                     ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %36
+ThrowNullRef2:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
-Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
+Successfully read WindowsConsoleStream.WriteFileNative
+
+define i32 @WindowsConsoleStream.WriteFileNative(i64 %param0, %"System.Byte[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i64
+  %arg1 = alloca %"System.Byte[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i8 addrspace(1)*
+  %loc2 = alloca %"System.Byte[]" addrspace(1)*
+  %loc3 = alloca i32
+  store i64 %param0, i64* %arg0
+  store %"System.Byte[]" addrspace(1)* %param1, %"System.Byte[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Byte[]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = zext i32 %3 to i64
+  %5 = icmp ne i64 %4, 0
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %1
+  ret i32 0
+
+; <label>:7                                       ; preds = %1
+  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  store %"System.Byte[]" addrspace(1)* %8, %"System.Byte[]" addrspace(1)** %loc2
+  %9 = icmp eq %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %9, label %18, label %10
+
+; <label>:10                                      ; preds = %7
+  %11 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc2
+  %NullCheck1 = icmp eq %"System.Byte[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %11, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp ne i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %7, %12
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc1
+  br label %27
+
+; <label>:19                                      ; preds = %12
+  %20 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc2
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %20, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %BoundsCheck = icmp uge i64 0, %24
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %25
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %20, i32 0, i32 3, i32 0
+  store i8 addrspace(1)* %26, i8 addrspace(1)** %loc1
+  br label %27
+
+; <label>:27                                      ; preds = %18, %25
+  %28 = load i64, i64* %arg0
+  %29 = load i8 addrspace(1)*, i8 addrspace(1)** %loc1
+  %30 = ptrtoint i8 addrspace(1)* %29 to i64
+  %31 = load i32, i32* %arg2
+  %32 = sext i32 %31 to i64
+  %33 = add i64 %30, %32
+  %34 = load i32, i32* %arg3
+  %35 = addrspacecast i32* %loc3 to i32 addrspace(1)*
+  %36 = inttoptr i64 %33 to i8*
+  %37 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i8*, i32, i32 addrspace(1)*, i64)*)(i64 %28, i8* %36, i32 %34, i32 addrspace(1)* %35, i64 0)
+  %38 = icmp ugt i32 %37, 0
+  %39 = sext i1 %38 to i32
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc1
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %42, label %41
+
+; <label>:41                                      ; preds = %27
+  ret i32 0
+
+; <label>:42                                      ; preds = %27
+  %43 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  store i32 %43, i32* %loc0
+  %44 = load i32, i32* %loc0
+  %45 = icmp eq i32 %44, 232
+  br i1 %45, label %49, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = load i32, i32* %loc0
+  %48 = icmp ne i32 %47, 109
+  br i1 %48, label %50, label %49
+
+; <label>:49                                      ; preds = %42, %46
+  ret i32 0
+
+; <label>:50                                      ; preds = %46
+  %51 = load i32, i32* %loc0
+  ret i32 %51
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
 Successfully read WindowsConsoleStream.Flush
 
@@ -15135,8 +17619,8 @@ entry:
   %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
   store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
@@ -15171,8 +17655,8 @@ entry:
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
   %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load i64, i64 addrspace(1)* %1
@@ -15211,15 +17695,15 @@ entry:
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.TextWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
   %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %3, align 8
   %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
   %7 = load i64, i64 addrspace(1)* %5
@@ -15237,7 +17721,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -15266,8 +17750,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %4)
   store i32 0, i32* %loc0
   %5 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Char[]" addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
@@ -15279,15 +17763,15 @@ entry:
 
 ; <label>:11                                      ; preds = %69
   %12 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %12, i32 0, i32 9
   %15 = load i32, i32 addrspace(1)* %14, align 8
   %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.IO.StreamWriter addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %16, i32 0, i32 10
@@ -15302,15 +17786,15 @@ entry:
 
 ; <label>:23                                      ; preds = %17, %21
   %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %24, null
-  br i1 %NullCheck8, label %25, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %24, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 10
   %27 = load i32, i32 addrspace(1)* %26, align 8
   %28 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %28, null
-  br i1 %NullCheck10, label %29, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.StreamWriter addrspace(1)* %28, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %28, i32 0, i32 9
@@ -15332,15 +17816,15 @@ entry:
   %40 = load i32, i32* %loc0
   %41 = mul i32 %40, 2
   %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
-  br i1 %NullCheck12, label %43, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %43
 
 ; <label>:43                                      ; preds = %38
   %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 7
   %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %44, align 8
   %46 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %46, null
-  br i1 %NullCheck14, label %47, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.IO.StreamWriter addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %47
 
 ; <label>:47                                      ; preds = %43
   %48 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %46, i32 0, i32 9
@@ -15352,16 +17836,16 @@ entry:
   %54 = bitcast %"System.Char[]" addrspace(1)* %45 to %System.Array addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %53, i32 %41, %System.Array addrspace(1)* %54, i32 %50, i32 %52)
   %55 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
-  br i1 %NullCheck16, label %56, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %56
 
 ; <label>:56                                      ; preds = %47
   %57 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
   %58 = load i32, i32 addrspace(1)* %57, align 8
   %59 = load i32, i32* %loc2
   %60 = add i32 %58, %59
-  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
-  br i1 %NullCheck18, label %61, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %61
 
 ; <label>:61                                      ; preds = %56
   %62 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
@@ -15383,8 +17867,8 @@ entry:
 
 ; <label>:72                                      ; preds = %69
   %73 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %73, null
-  br i1 %NullCheck2, label %74, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %73, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %74
 
 ; <label>:74                                      ; preds = %72
   %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %73, i32 0, i32 11
@@ -15405,39 +17889,39 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %72
+ThrowNullRef2:                                    ; preds = %72
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %23
+ThrowNullRef8:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef10:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %43
+ThrowNullRef14:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %47
+ThrowNullRef16:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %56
+ThrowNullRef18:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblMul.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblMul.error.txt
@@ -25,8 +25,8 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
@@ -40,8 +40,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
   %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
@@ -75,7 +75,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -90,8 +90,8 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %NullCheck = icmp ne i8 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = load i8, i8 addrspace(1)* %0, align 8
@@ -125,8 +125,8 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
@@ -159,8 +159,8 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -184,8 +184,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
   store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
@@ -195,8 +195,8 @@ entry:
 ; <label>:4                                       ; preds = %1
   %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
   %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
@@ -206,8 +206,8 @@ entry:
   %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
@@ -221,14 +221,14 @@ entry:
 
 ; <label>:17                                      ; preds = %14
   %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
   %21 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
@@ -238,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -249,8 +249,8 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
@@ -261,27 +261,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %30
+ThrowNullRef10:                                   ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -301,7 +301,89 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
-Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
+Successfully read AppDomainSetup.GetUnsecureApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.GetUnsecureApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %NullCheck = icmp eq %"System.String[]" addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %BoundsCheck = icmp uge i64 0, %5
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %6
+
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 3, i32 0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
+  ret %System.String addrspace(1)* %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_Value using LLILCJit
+Successfully read AppDomainSetup.get_Value
+
+define %"System.String[]" addrspace(1)* @AppDomainSetup.get_Value(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.String[]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 18)
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.String[]" addrspace(1)* addrspace(1)*, %"System.String[]" addrspace(1)*)*)(%"System.String[]" addrspace(1)* addrspace(1)* %9, %"System.String[]" addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %11, i32 0, i32 1
+  %14 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %13, align 8
+  ret %"System.String[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -319,8 +401,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -368,16 +450,16 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
   %5 = load i32, i32 addrspace(1)* %4
   %6 = sub i32 %5, 1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -389,7 +471,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -421,8 +503,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
@@ -456,8 +538,8 @@ entry:
 ; <label>:27                                      ; preds = %19
   %28 = load i32, i32* %arg1
   %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
-  br i1 %NullCheck2, label %30, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %29, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %30
 
 ; <label>:30                                      ; preds = %27
   %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
@@ -493,8 +575,8 @@ entry:
 ; <label>:49                                      ; preds = %46
   %50 = load i32, i32* %arg2
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck4, label %52, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
@@ -517,11 +599,11 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %27
+ThrowNullRef2:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %49
+ThrowNullRef4:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -544,16 +626,16 @@ entry:
   %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %0)
   store %System.String addrspace(1)* %1, %System.String addrspace(1)** %loc0
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 2
   %5 = bitcast [0 x i16] addrspace(1)* %4 to i16 addrspace(1)*
   store i16 addrspace(1)* %5, i16 addrspace(1)** %loc1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %3
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2
@@ -580,7 +662,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -691,15 +773,15 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %NullCheck132 = icmp ne i8* %21, null
-  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+  %NullCheck131 = icmp eq i8* %21, null
+  br i1 %NullCheck131, label %ThrowNullRef132, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = load i8, i8* %21, align 8
   %24 = zext i8 %23 to i32
   %25 = trunc i32 %24 to i8
-  %NullCheck134 = icmp ne i8* %20, null
-  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+  %NullCheck133 = icmp eq i8* %20, null
+  br i1 %NullCheck133, label %ThrowNullRef134, label %26
 
 ; <label>:26                                      ; preds = %22
   store i8 %25, i8* %20, align 8
@@ -709,16 +791,16 @@ entry:
   %28 = load i8*, i8** %arg0
   %29 = load i8*, i8** %arg1
   %30 = bitcast i8* %29 to i16*
-  %NullCheck128 = icmp ne i16* %30, null
-  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+  %NullCheck127 = icmp eq i16* %30, null
+  br i1 %NullCheck127, label %ThrowNullRef128, label %31
 
 ; <label>:31                                      ; preds = %27
   %32 = load i16, i16* %30, align 8
   %33 = sext i16 %32 to i32
   %34 = bitcast i8* %28 to i16*
   %35 = trunc i32 %33 to i16
-  %NullCheck130 = icmp ne i16* %34, null
-  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+  %NullCheck129 = icmp eq i16* %34, null
+  br i1 %NullCheck129, label %ThrowNullRef130, label %36
 
 ; <label>:36                                      ; preds = %31
   store i16 %35, i16* %34, align 8
@@ -728,16 +810,16 @@ entry:
   %38 = load i8*, i8** %arg0
   %39 = load i8*, i8** %arg1
   %40 = bitcast i8* %39 to i16*
-  %NullCheck120 = icmp ne i16* %40, null
-  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+  %NullCheck119 = icmp eq i16* %40, null
+  br i1 %NullCheck119, label %ThrowNullRef120, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i16, i16* %40, align 8
   %43 = sext i16 %42 to i32
   %44 = bitcast i8* %38 to i16*
   %45 = trunc i32 %43 to i16
-  %NullCheck122 = icmp ne i16* %44, null
-  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+  %NullCheck121 = icmp eq i16* %44, null
+  br i1 %NullCheck121, label %ThrowNullRef122, label %46
 
 ; <label>:46                                      ; preds = %41
   store i16 %45, i16* %44, align 8
@@ -745,15 +827,15 @@ entry:
   %48 = getelementptr inbounds i8, i8* %47, i64 2
   %49 = load i8*, i8** %arg1
   %50 = getelementptr inbounds i8, i8* %49, i64 2
-  %NullCheck124 = icmp ne i8* %50, null
-  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+  %NullCheck123 = icmp eq i8* %50, null
+  br i1 %NullCheck123, label %ThrowNullRef124, label %51
 
 ; <label>:51                                      ; preds = %46
   %52 = load i8, i8* %50, align 8
   %53 = zext i8 %52 to i32
   %54 = trunc i32 %53 to i8
-  %NullCheck126 = icmp ne i8* %48, null
-  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+  %NullCheck125 = icmp eq i8* %48, null
+  br i1 %NullCheck125, label %ThrowNullRef126, label %55
 
 ; <label>:55                                      ; preds = %51
   store i8 %54, i8* %48, align 8
@@ -763,14 +845,14 @@ entry:
   %57 = load i8*, i8** %arg0
   %58 = load i8*, i8** %arg1
   %59 = bitcast i8* %58 to i32*
-  %NullCheck116 = icmp ne i32* %59, null
-  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+  %NullCheck115 = icmp eq i32* %59, null
+  br i1 %NullCheck115, label %ThrowNullRef116, label %60
 
 ; <label>:60                                      ; preds = %56
   %61 = load i32, i32* %59, align 8
   %62 = bitcast i8* %57 to i32*
-  %NullCheck118 = icmp ne i32* %62, null
-  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+  %NullCheck117 = icmp eq i32* %62, null
+  br i1 %NullCheck117, label %ThrowNullRef118, label %63
 
 ; <label>:63                                      ; preds = %60
   store i32 %61, i32* %62, align 8
@@ -780,14 +862,14 @@ entry:
   %65 = load i8*, i8** %arg0
   %66 = load i8*, i8** %arg1
   %67 = bitcast i8* %66 to i32*
-  %NullCheck108 = icmp ne i32* %67, null
-  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+  %NullCheck107 = icmp eq i32* %67, null
+  br i1 %NullCheck107, label %ThrowNullRef108, label %68
 
 ; <label>:68                                      ; preds = %64
   %69 = load i32, i32* %67, align 8
   %70 = bitcast i8* %65 to i32*
-  %NullCheck110 = icmp ne i32* %70, null
-  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+  %NullCheck109 = icmp eq i32* %70, null
+  br i1 %NullCheck109, label %ThrowNullRef110, label %71
 
 ; <label>:71                                      ; preds = %68
   store i32 %69, i32* %70, align 8
@@ -795,15 +877,15 @@ entry:
   %73 = getelementptr inbounds i8, i8* %72, i64 4
   %74 = load i8*, i8** %arg1
   %75 = getelementptr inbounds i8, i8* %74, i64 4
-  %NullCheck112 = icmp ne i8* %75, null
-  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+  %NullCheck111 = icmp eq i8* %75, null
+  br i1 %NullCheck111, label %ThrowNullRef112, label %76
 
 ; <label>:76                                      ; preds = %71
   %77 = load i8, i8* %75, align 8
   %78 = zext i8 %77 to i32
   %79 = trunc i32 %78 to i8
-  %NullCheck114 = icmp ne i8* %73, null
-  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+  %NullCheck113 = icmp eq i8* %73, null
+  br i1 %NullCheck113, label %ThrowNullRef114, label %80
 
 ; <label>:80                                      ; preds = %76
   store i8 %79, i8* %73, align 8
@@ -813,14 +895,14 @@ entry:
   %82 = load i8*, i8** %arg0
   %83 = load i8*, i8** %arg1
   %84 = bitcast i8* %83 to i32*
-  %NullCheck100 = icmp ne i32* %84, null
-  br i1 %NullCheck100, label %85, label %ThrowNullRef99
+  %NullCheck99 = icmp eq i32* %84, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %85
 
 ; <label>:85                                      ; preds = %81
   %86 = load i32, i32* %84, align 8
   %87 = bitcast i8* %82 to i32*
-  %NullCheck102 = icmp ne i32* %87, null
-  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+  %NullCheck101 = icmp eq i32* %87, null
+  br i1 %NullCheck101, label %ThrowNullRef102, label %88
 
 ; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
@@ -829,16 +911,16 @@ entry:
   %91 = load i8*, i8** %arg1
   %92 = getelementptr inbounds i8, i8* %91, i64 4
   %93 = bitcast i8* %92 to i16*
-  %NullCheck104 = icmp ne i16* %93, null
-  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+  %NullCheck103 = icmp eq i16* %93, null
+  br i1 %NullCheck103, label %ThrowNullRef104, label %94
 
 ; <label>:94                                      ; preds = %88
   %95 = load i16, i16* %93, align 8
   %96 = sext i16 %95 to i32
   %97 = bitcast i8* %90 to i16*
   %98 = trunc i32 %96 to i16
-  %NullCheck106 = icmp ne i16* %97, null
-  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+  %NullCheck105 = icmp eq i16* %97, null
+  br i1 %NullCheck105, label %ThrowNullRef106, label %99
 
 ; <label>:99                                      ; preds = %94
   store i16 %98, i16* %97, align 8
@@ -848,14 +930,14 @@ entry:
   %101 = load i8*, i8** %arg0
   %102 = load i8*, i8** %arg1
   %103 = bitcast i8* %102 to i32*
-  %NullCheck88 = icmp ne i32* %103, null
-  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+  %NullCheck87 = icmp eq i32* %103, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %104
 
 ; <label>:104                                     ; preds = %100
   %105 = load i32, i32* %103, align 8
   %106 = bitcast i8* %101 to i32*
-  %NullCheck90 = icmp ne i32* %106, null
-  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+  %NullCheck89 = icmp eq i32* %106, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %107
 
 ; <label>:107                                     ; preds = %104
   store i32 %105, i32* %106, align 8
@@ -864,16 +946,16 @@ entry:
   %110 = load i8*, i8** %arg1
   %111 = getelementptr inbounds i8, i8* %110, i64 4
   %112 = bitcast i8* %111 to i16*
-  %NullCheck92 = icmp ne i16* %112, null
-  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+  %NullCheck91 = icmp eq i16* %112, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %113
 
 ; <label>:113                                     ; preds = %107
   %114 = load i16, i16* %112, align 8
   %115 = sext i16 %114 to i32
   %116 = bitcast i8* %109 to i16*
   %117 = trunc i32 %115 to i16
-  %NullCheck94 = icmp ne i16* %116, null
-  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+  %NullCheck93 = icmp eq i16* %116, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %118
 
 ; <label>:118                                     ; preds = %113
   store i16 %117, i16* %116, align 8
@@ -881,15 +963,15 @@ entry:
   %120 = getelementptr inbounds i8, i8* %119, i64 6
   %121 = load i8*, i8** %arg1
   %122 = getelementptr inbounds i8, i8* %121, i64 6
-  %NullCheck96 = icmp ne i8* %122, null
-  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+  %NullCheck95 = icmp eq i8* %122, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %123
 
 ; <label>:123                                     ; preds = %118
   %124 = load i8, i8* %122, align 8
   %125 = zext i8 %124 to i32
   %126 = trunc i32 %125 to i8
-  %NullCheck98 = icmp ne i8* %120, null
-  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+  %NullCheck97 = icmp eq i8* %120, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %127
 
 ; <label>:127                                     ; preds = %123
   store i8 %126, i8* %120, align 8
@@ -899,14 +981,14 @@ entry:
   %129 = load i8*, i8** %arg0
   %130 = load i8*, i8** %arg1
   %131 = bitcast i8* %130 to i64*
-  %NullCheck84 = icmp ne i64* %131, null
-  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+  %NullCheck83 = icmp eq i64* %131, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %132
 
 ; <label>:132                                     ; preds = %128
   %133 = load i64, i64* %131, align 8
   %134 = bitcast i8* %129 to i64*
-  %NullCheck86 = icmp ne i64* %134, null
-  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+  %NullCheck85 = icmp eq i64* %134, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %135
 
 ; <label>:135                                     ; preds = %132
   store i64 %133, i64* %134, align 8
@@ -916,14 +998,14 @@ entry:
   %137 = load i8*, i8** %arg0
   %138 = load i8*, i8** %arg1
   %139 = bitcast i8* %138 to i64*
-  %NullCheck76 = icmp ne i64* %139, null
-  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+  %NullCheck75 = icmp eq i64* %139, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %140
 
 ; <label>:140                                     ; preds = %136
   %141 = load i64, i64* %139, align 8
   %142 = bitcast i8* %137 to i64*
-  %NullCheck78 = icmp ne i64* %142, null
-  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+  %NullCheck77 = icmp eq i64* %142, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %143
 
 ; <label>:143                                     ; preds = %140
   store i64 %141, i64* %142, align 8
@@ -931,15 +1013,15 @@ entry:
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %NullCheck80 = icmp ne i8* %147, null
-  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+  %NullCheck79 = icmp eq i8* %147, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %148
 
 ; <label>:148                                     ; preds = %143
   %149 = load i8, i8* %147, align 8
   %150 = zext i8 %149 to i32
   %151 = trunc i32 %150 to i8
-  %NullCheck82 = icmp ne i8* %145, null
-  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+  %NullCheck81 = icmp eq i8* %145, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %152
 
 ; <label>:152                                     ; preds = %148
   store i8 %151, i8* %145, align 8
@@ -949,14 +1031,14 @@ entry:
   %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
   %156 = bitcast i8* %155 to i64*
-  %NullCheck68 = icmp ne i64* %156, null
-  br i1 %NullCheck68, label %157, label %ThrowNullRef67
+  %NullCheck67 = icmp eq i64* %156, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %157
 
 ; <label>:157                                     ; preds = %153
   %158 = load i64, i64* %156, align 8
   %159 = bitcast i8* %154 to i64*
-  %NullCheck70 = icmp ne i64* %159, null
-  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+  %NullCheck69 = icmp eq i64* %159, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %160
 
 ; <label>:160                                     ; preds = %157
   store i64 %158, i64* %159, align 8
@@ -965,16 +1047,16 @@ entry:
   %163 = load i8*, i8** %arg1
   %164 = getelementptr inbounds i8, i8* %163, i64 8
   %165 = bitcast i8* %164 to i16*
-  %NullCheck72 = icmp ne i16* %165, null
-  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+  %NullCheck71 = icmp eq i16* %165, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %166
 
 ; <label>:166                                     ; preds = %160
   %167 = load i16, i16* %165, align 8
   %168 = sext i16 %167 to i32
   %169 = bitcast i8* %162 to i16*
   %170 = trunc i32 %168 to i16
-  %NullCheck74 = icmp ne i16* %169, null
-  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+  %NullCheck73 = icmp eq i16* %169, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %171
 
 ; <label>:171                                     ; preds = %166
   store i16 %170, i16* %169, align 8
@@ -984,14 +1066,14 @@ entry:
   %173 = load i8*, i8** %arg0
   %174 = load i8*, i8** %arg1
   %175 = bitcast i8* %174 to i64*
-  %NullCheck56 = icmp ne i64* %175, null
-  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+  %NullCheck55 = icmp eq i64* %175, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %176
 
 ; <label>:176                                     ; preds = %172
   %177 = load i64, i64* %175, align 8
   %178 = bitcast i8* %173 to i64*
-  %NullCheck58 = icmp ne i64* %178, null
-  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+  %NullCheck57 = icmp eq i64* %178, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %179
 
 ; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
@@ -1000,16 +1082,16 @@ entry:
   %182 = load i8*, i8** %arg1
   %183 = getelementptr inbounds i8, i8* %182, i64 8
   %184 = bitcast i8* %183 to i16*
-  %NullCheck60 = icmp ne i16* %184, null
-  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+  %NullCheck59 = icmp eq i16* %184, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %185
 
 ; <label>:185                                     ; preds = %179
   %186 = load i16, i16* %184, align 8
   %187 = sext i16 %186 to i32
   %188 = bitcast i8* %181 to i16*
   %189 = trunc i32 %187 to i16
-  %NullCheck62 = icmp ne i16* %188, null
-  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+  %NullCheck61 = icmp eq i16* %188, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %190
 
 ; <label>:190                                     ; preds = %185
   store i16 %189, i16* %188, align 8
@@ -1017,15 +1099,15 @@ entry:
   %192 = getelementptr inbounds i8, i8* %191, i64 10
   %193 = load i8*, i8** %arg1
   %194 = getelementptr inbounds i8, i8* %193, i64 10
-  %NullCheck64 = icmp ne i8* %194, null
-  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+  %NullCheck63 = icmp eq i8* %194, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %195
 
 ; <label>:195                                     ; preds = %190
   %196 = load i8, i8* %194, align 8
   %197 = zext i8 %196 to i32
   %198 = trunc i32 %197 to i8
-  %NullCheck66 = icmp ne i8* %192, null
-  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+  %NullCheck65 = icmp eq i8* %192, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %199
 
 ; <label>:199                                     ; preds = %195
   store i8 %198, i8* %192, align 8
@@ -1035,14 +1117,14 @@ entry:
   %201 = load i8*, i8** %arg0
   %202 = load i8*, i8** %arg1
   %203 = bitcast i8* %202 to i64*
-  %NullCheck48 = icmp ne i64* %203, null
-  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+  %NullCheck47 = icmp eq i64* %203, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %204
 
 ; <label>:204                                     ; preds = %200
   %205 = load i64, i64* %203, align 8
   %206 = bitcast i8* %201 to i64*
-  %NullCheck50 = icmp ne i64* %206, null
-  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+  %NullCheck49 = icmp eq i64* %206, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %207
 
 ; <label>:207                                     ; preds = %204
   store i64 %205, i64* %206, align 8
@@ -1051,14 +1133,14 @@ entry:
   %210 = load i8*, i8** %arg1
   %211 = getelementptr inbounds i8, i8* %210, i64 8
   %212 = bitcast i8* %211 to i32*
-  %NullCheck52 = icmp ne i32* %212, null
-  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+  %NullCheck51 = icmp eq i32* %212, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %213
 
 ; <label>:213                                     ; preds = %207
   %214 = load i32, i32* %212, align 8
   %215 = bitcast i8* %209 to i32*
-  %NullCheck54 = icmp ne i32* %215, null
-  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+  %NullCheck53 = icmp eq i32* %215, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %216
 
 ; <label>:216                                     ; preds = %213
   store i32 %214, i32* %215, align 8
@@ -1068,14 +1150,14 @@ entry:
   %218 = load i8*, i8** %arg0
   %219 = load i8*, i8** %arg1
   %220 = bitcast i8* %219 to i64*
-  %NullCheck36 = icmp ne i64* %220, null
-  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64* %220, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %221
 
 ; <label>:221                                     ; preds = %217
   %222 = load i64, i64* %220, align 8
   %223 = bitcast i8* %218 to i64*
-  %NullCheck38 = icmp ne i64* %223, null
-  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+  %NullCheck37 = icmp eq i64* %223, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %224
 
 ; <label>:224                                     ; preds = %221
   store i64 %222, i64* %223, align 8
@@ -1084,14 +1166,14 @@ entry:
   %227 = load i8*, i8** %arg1
   %228 = getelementptr inbounds i8, i8* %227, i64 8
   %229 = bitcast i8* %228 to i32*
-  %NullCheck40 = icmp ne i32* %229, null
-  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i32* %229, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %230
 
 ; <label>:230                                     ; preds = %224
   %231 = load i32, i32* %229, align 8
   %232 = bitcast i8* %226 to i32*
-  %NullCheck42 = icmp ne i32* %232, null
-  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+  %NullCheck41 = icmp eq i32* %232, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %233
 
 ; <label>:233                                     ; preds = %230
   store i32 %231, i32* %232, align 8
@@ -1099,15 +1181,15 @@ entry:
   %235 = getelementptr inbounds i8, i8* %234, i64 12
   %236 = load i8*, i8** %arg1
   %237 = getelementptr inbounds i8, i8* %236, i64 12
-  %NullCheck44 = icmp ne i8* %237, null
-  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i8* %237, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %238
 
 ; <label>:238                                     ; preds = %233
   %239 = load i8, i8* %237, align 8
   %240 = zext i8 %239 to i32
   %241 = trunc i32 %240 to i8
-  %NullCheck46 = icmp ne i8* %235, null
-  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+  %NullCheck45 = icmp eq i8* %235, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %242
 
 ; <label>:242                                     ; preds = %238
   store i8 %241, i8* %235, align 8
@@ -1117,14 +1199,14 @@ entry:
   %244 = load i8*, i8** %arg0
   %245 = load i8*, i8** %arg1
   %246 = bitcast i8* %245 to i64*
-  %NullCheck24 = icmp ne i64* %246, null
-  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64* %246, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %247
 
 ; <label>:247                                     ; preds = %243
   %248 = load i64, i64* %246, align 8
   %249 = bitcast i8* %244 to i64*
-  %NullCheck26 = icmp ne i64* %249, null
-  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64* %249, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %250
 
 ; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
@@ -1133,14 +1215,14 @@ entry:
   %253 = load i8*, i8** %arg1
   %254 = getelementptr inbounds i8, i8* %253, i64 8
   %255 = bitcast i8* %254 to i32*
-  %NullCheck28 = icmp ne i32* %255, null
-  br i1 %NullCheck28, label %256, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i32* %255, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %256
 
 ; <label>:256                                     ; preds = %250
   %257 = load i32, i32* %255, align 8
   %258 = bitcast i8* %252 to i32*
-  %NullCheck30 = icmp ne i32* %258, null
-  br i1 %NullCheck30, label %259, label %ThrowNullRef29
+  %NullCheck29 = icmp eq i32* %258, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %259
 
 ; <label>:259                                     ; preds = %256
   store i32 %257, i32* %258, align 8
@@ -1149,16 +1231,16 @@ entry:
   %262 = load i8*, i8** %arg1
   %263 = getelementptr inbounds i8, i8* %262, i64 12
   %264 = bitcast i8* %263 to i16*
-  %NullCheck32 = icmp ne i16* %264, null
-  br i1 %NullCheck32, label %265, label %ThrowNullRef31
+  %NullCheck31 = icmp eq i16* %264, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %265
 
 ; <label>:265                                     ; preds = %259
   %266 = load i16, i16* %264, align 8
   %267 = sext i16 %266 to i32
   %268 = bitcast i8* %261 to i16*
   %269 = trunc i32 %267 to i16
-  %NullCheck34 = icmp ne i16* %268, null
-  br i1 %NullCheck34, label %270, label %ThrowNullRef33
+  %NullCheck33 = icmp eq i16* %268, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %270
 
 ; <label>:270                                     ; preds = %265
   store i16 %269, i16* %268, align 8
@@ -1168,14 +1250,14 @@ entry:
   %272 = load i8*, i8** %arg0
   %273 = load i8*, i8** %arg1
   %274 = bitcast i8* %273 to i64*
-  %NullCheck8 = icmp ne i64* %274, null
-  br i1 %NullCheck8, label %275, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64* %274, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %275
 
 ; <label>:275                                     ; preds = %271
   %276 = load i64, i64* %274, align 8
   %277 = bitcast i8* %272 to i64*
-  %NullCheck10 = icmp ne i64* %277, null
-  br i1 %NullCheck10, label %278, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %277, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %278
 
 ; <label>:278                                     ; preds = %275
   store i64 %276, i64* %277, align 8
@@ -1184,14 +1266,14 @@ entry:
   %281 = load i8*, i8** %arg1
   %282 = getelementptr inbounds i8, i8* %281, i64 8
   %283 = bitcast i8* %282 to i32*
-  %NullCheck12 = icmp ne i32* %283, null
-  br i1 %NullCheck12, label %284, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i32* %283, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %284
 
 ; <label>:284                                     ; preds = %278
   %285 = load i32, i32* %283, align 8
   %286 = bitcast i8* %280 to i32*
-  %NullCheck14 = icmp ne i32* %286, null
-  br i1 %NullCheck14, label %287, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i32* %286, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %287
 
 ; <label>:287                                     ; preds = %284
   store i32 %285, i32* %286, align 8
@@ -1200,16 +1282,16 @@ entry:
   %290 = load i8*, i8** %arg1
   %291 = getelementptr inbounds i8, i8* %290, i64 12
   %292 = bitcast i8* %291 to i16*
-  %NullCheck16 = icmp ne i16* %292, null
-  br i1 %NullCheck16, label %293, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i16* %292, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %293
 
 ; <label>:293                                     ; preds = %287
   %294 = load i16, i16* %292, align 8
   %295 = sext i16 %294 to i32
   %296 = bitcast i8* %289 to i16*
   %297 = trunc i32 %295 to i16
-  %NullCheck18 = icmp ne i16* %296, null
-  br i1 %NullCheck18, label %298, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i16* %296, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %298
 
 ; <label>:298                                     ; preds = %293
   store i16 %297, i16* %296, align 8
@@ -1217,15 +1299,15 @@ entry:
   %300 = getelementptr inbounds i8, i8* %299, i64 14
   %301 = load i8*, i8** %arg1
   %302 = getelementptr inbounds i8, i8* %301, i64 14
-  %NullCheck20 = icmp ne i8* %302, null
-  br i1 %NullCheck20, label %303, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i8* %302, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %303
 
 ; <label>:303                                     ; preds = %298
   %304 = load i8, i8* %302, align 8
   %305 = zext i8 %304 to i32
   %306 = trunc i32 %305 to i8
-  %NullCheck22 = icmp ne i8* %300, null
-  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i8* %300, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %307
 
 ; <label>:307                                     ; preds = %303
   store i8 %306, i8* %300, align 8
@@ -1235,14 +1317,14 @@ entry:
   %309 = load i8*, i8** %arg0
   %310 = load i8*, i8** %arg1
   %311 = bitcast i8* %310 to i64*
-  %NullCheck = icmp ne i64* %311, null
-  br i1 %NullCheck, label %312, label %ThrowNullRef
+  %NullCheck = icmp eq i64* %311, null
+  br i1 %NullCheck, label %ThrowNullRef, label %312
 
 ; <label>:312                                     ; preds = %308
   %313 = load i64, i64* %311, align 8
   %314 = bitcast i8* %309 to i64*
-  %NullCheck2 = icmp ne i64* %314, null
-  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64* %314, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %315
 
 ; <label>:315                                     ; preds = %312
   store i64 %313, i64* %314, align 8
@@ -1251,14 +1333,14 @@ entry:
   %318 = load i8*, i8** %arg1
   %319 = getelementptr inbounds i8, i8* %318, i64 8
   %320 = bitcast i8* %319 to i64*
-  %NullCheck4 = icmp ne i64* %320, null
-  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64* %320, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %321
 
 ; <label>:321                                     ; preds = %315
   %322 = load i64, i64* %320, align 8
   %323 = bitcast i8* %317 to i64*
-  %NullCheck6 = icmp ne i64* %323, null
-  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64* %323, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %324
 
 ; <label>:324                                     ; preds = %321
   store i64 %322, i64* %323, align 8
@@ -1286,15 +1368,15 @@ entry:
 ; <label>:338                                     ; preds = %333
   %339 = load i8*, i8** %arg0
   %340 = load i8*, i8** %arg1
-  %NullCheck136 = icmp ne i8* %340, null
-  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+  %NullCheck135 = icmp eq i8* %340, null
+  br i1 %NullCheck135, label %ThrowNullRef136, label %341
 
 ; <label>:341                                     ; preds = %338
   %342 = load i8, i8* %340, align 8
   %343 = zext i8 %342 to i32
   %344 = trunc i32 %343 to i8
-  %NullCheck138 = icmp ne i8* %339, null
-  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+  %NullCheck137 = icmp eq i8* %339, null
+  br i1 %NullCheck137, label %ThrowNullRef138, label %345
 
 ; <label>:345                                     ; preds = %341
   store i8 %344, i8* %339, align 8
@@ -1317,16 +1399,16 @@ entry:
   %357 = load i8*, i8** %arg0
   %358 = load i8*, i8** %arg1
   %359 = bitcast i8* %358 to i16*
-  %NullCheck140 = icmp ne i16* %359, null
-  br i1 %NullCheck140, label %360, label %ThrowNullRef139
+  %NullCheck139 = icmp eq i16* %359, null
+  br i1 %NullCheck139, label %ThrowNullRef140, label %360
 
 ; <label>:360                                     ; preds = %356
   %361 = load i16, i16* %359, align 8
   %362 = sext i16 %361 to i32
   %363 = bitcast i8* %357 to i16*
   %364 = trunc i32 %362 to i16
-  %NullCheck142 = icmp ne i16* %363, null
-  br i1 %NullCheck142, label %365, label %ThrowNullRef141
+  %NullCheck141 = icmp eq i16* %363, null
+  br i1 %NullCheck141, label %ThrowNullRef142, label %365
 
 ; <label>:365                                     ; preds = %360
   store i16 %364, i16* %363, align 8
@@ -1352,14 +1434,14 @@ entry:
   %378 = load i8*, i8** %arg0
   %379 = load i8*, i8** %arg1
   %380 = bitcast i8* %379 to i32*
-  %NullCheck144 = icmp ne i32* %380, null
-  br i1 %NullCheck144, label %381, label %ThrowNullRef143
+  %NullCheck143 = icmp eq i32* %380, null
+  br i1 %NullCheck143, label %ThrowNullRef144, label %381
 
 ; <label>:381                                     ; preds = %377
   %382 = load i32, i32* %380, align 8
   %383 = bitcast i8* %378 to i32*
-  %NullCheck146 = icmp ne i32* %383, null
-  br i1 %NullCheck146, label %384, label %ThrowNullRef145
+  %NullCheck145 = icmp eq i32* %383, null
+  br i1 %NullCheck145, label %ThrowNullRef146, label %384
 
 ; <label>:384                                     ; preds = %381
   store i32 %382, i32* %383, align 8
@@ -1384,14 +1466,14 @@ entry:
   %395 = load i8*, i8** %arg0
   %396 = load i8*, i8** %arg1
   %397 = bitcast i8* %396 to i64*
-  %NullCheck164 = icmp ne i64* %397, null
-  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+  %NullCheck163 = icmp eq i64* %397, null
+  br i1 %NullCheck163, label %ThrowNullRef164, label %398
 
 ; <label>:398                                     ; preds = %394
   %399 = load i64, i64* %397, align 8
   %400 = bitcast i8* %395 to i64*
-  %NullCheck166 = icmp ne i64* %400, null
-  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+  %NullCheck165 = icmp eq i64* %400, null
+  br i1 %NullCheck165, label %ThrowNullRef166, label %401
 
 ; <label>:401                                     ; preds = %398
   store i64 %399, i64* %400, align 8
@@ -1400,14 +1482,14 @@ entry:
   %404 = load i8*, i8** %arg1
   %405 = getelementptr inbounds i8, i8* %404, i64 8
   %406 = bitcast i8* %405 to i64*
-  %NullCheck168 = icmp ne i64* %406, null
-  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+  %NullCheck167 = icmp eq i64* %406, null
+  br i1 %NullCheck167, label %ThrowNullRef168, label %407
 
 ; <label>:407                                     ; preds = %401
   %408 = load i64, i64* %406, align 8
   %409 = bitcast i8* %403 to i64*
-  %NullCheck170 = icmp ne i64* %409, null
-  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+  %NullCheck169 = icmp eq i64* %409, null
+  br i1 %NullCheck169, label %ThrowNullRef170, label %410
 
 ; <label>:410                                     ; preds = %407
   store i64 %408, i64* %409, align 8
@@ -1437,14 +1519,14 @@ entry:
   %425 = load i8*, i8** %arg0
   %426 = load i8*, i8** %arg1
   %427 = bitcast i8* %426 to i64*
-  %NullCheck148 = icmp ne i64* %427, null
-  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+  %NullCheck147 = icmp eq i64* %427, null
+  br i1 %NullCheck147, label %ThrowNullRef148, label %428
 
 ; <label>:428                                     ; preds = %424
   %429 = load i64, i64* %427, align 8
   %430 = bitcast i8* %425 to i64*
-  %NullCheck150 = icmp ne i64* %430, null
-  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+  %NullCheck149 = icmp eq i64* %430, null
+  br i1 %NullCheck149, label %ThrowNullRef150, label %431
 
 ; <label>:431                                     ; preds = %428
   store i64 %429, i64* %430, align 8
@@ -1466,14 +1548,14 @@ entry:
   %441 = load i8*, i8** %arg0
   %442 = load i8*, i8** %arg1
   %443 = bitcast i8* %442 to i32*
-  %NullCheck152 = icmp ne i32* %443, null
-  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+  %NullCheck151 = icmp eq i32* %443, null
+  br i1 %NullCheck151, label %ThrowNullRef152, label %444
 
 ; <label>:444                                     ; preds = %440
   %445 = load i32, i32* %443, align 8
   %446 = bitcast i8* %441 to i32*
-  %NullCheck154 = icmp ne i32* %446, null
-  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+  %NullCheck153 = icmp eq i32* %446, null
+  br i1 %NullCheck153, label %ThrowNullRef154, label %447
 
 ; <label>:447                                     ; preds = %444
   store i32 %445, i32* %446, align 8
@@ -1495,16 +1577,16 @@ entry:
   %457 = load i8*, i8** %arg0
   %458 = load i8*, i8** %arg1
   %459 = bitcast i8* %458 to i16*
-  %NullCheck156 = icmp ne i16* %459, null
-  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+  %NullCheck155 = icmp eq i16* %459, null
+  br i1 %NullCheck155, label %ThrowNullRef156, label %460
 
 ; <label>:460                                     ; preds = %456
   %461 = load i16, i16* %459, align 8
   %462 = sext i16 %461 to i32
   %463 = bitcast i8* %457 to i16*
   %464 = trunc i32 %462 to i16
-  %NullCheck158 = icmp ne i16* %463, null
-  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+  %NullCheck157 = icmp eq i16* %463, null
+  br i1 %NullCheck157, label %ThrowNullRef158, label %465
 
 ; <label>:465                                     ; preds = %460
   store i16 %464, i16* %463, align 8
@@ -1525,15 +1607,15 @@ entry:
 ; <label>:474                                     ; preds = %470
   %475 = load i8*, i8** %arg0
   %476 = load i8*, i8** %arg1
-  %NullCheck160 = icmp ne i8* %476, null
-  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+  %NullCheck159 = icmp eq i8* %476, null
+  br i1 %NullCheck159, label %ThrowNullRef160, label %477
 
 ; <label>:477                                     ; preds = %474
   %478 = load i8, i8* %476, align 8
   %479 = zext i8 %478 to i32
   %480 = trunc i32 %479 to i8
-  %NullCheck162 = icmp ne i8* %475, null
-  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+  %NullCheck161 = icmp eq i8* %475, null
+  br i1 %NullCheck161, label %ThrowNullRef162, label %481
 
 ; <label>:481                                     ; preds = %477
   store i8 %480, i8* %475, align 8
@@ -1553,343 +1635,343 @@ ThrowNullRef:                                     ; preds = %308
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %312
+ThrowNullRef2:                                    ; preds = %312
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %315
+ThrowNullRef4:                                    ; preds = %315
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %321
+ThrowNullRef6:                                    ; preds = %321
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %271
+ThrowNullRef8:                                    ; preds = %271
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %275
+ThrowNullRef10:                                   ; preds = %275
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %278
+ThrowNullRef12:                                   ; preds = %278
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %284
+ThrowNullRef14:                                   ; preds = %284
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %287
+ThrowNullRef16:                                   ; preds = %287
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %293
+ThrowNullRef18:                                   ; preds = %293
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %298
+ThrowNullRef20:                                   ; preds = %298
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %303
+ThrowNullRef22:                                   ; preds = %303
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %243
+ThrowNullRef24:                                   ; preds = %243
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %247
+ThrowNullRef26:                                   ; preds = %247
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %250
+ThrowNullRef28:                                   ; preds = %250
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %256
+ThrowNullRef30:                                   ; preds = %256
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %259
+ThrowNullRef32:                                   ; preds = %259
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %265
+ThrowNullRef34:                                   ; preds = %265
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %217
+ThrowNullRef36:                                   ; preds = %217
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %221
+ThrowNullRef38:                                   ; preds = %221
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %224
+ThrowNullRef40:                                   ; preds = %224
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %230
+ThrowNullRef42:                                   ; preds = %230
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %233
+ThrowNullRef44:                                   ; preds = %233
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %238
+ThrowNullRef46:                                   ; preds = %238
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %200
+ThrowNullRef48:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %204
+ThrowNullRef50:                                   ; preds = %204
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %207
+ThrowNullRef52:                                   ; preds = %207
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %213
+ThrowNullRef54:                                   ; preds = %213
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %172
+ThrowNullRef56:                                   ; preds = %172
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %176
+ThrowNullRef58:                                   ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %179
+ThrowNullRef60:                                   ; preds = %179
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %185
+ThrowNullRef62:                                   ; preds = %185
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %190
+ThrowNullRef64:                                   ; preds = %190
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %195
+ThrowNullRef66:                                   ; preds = %195
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %153
+ThrowNullRef68:                                   ; preds = %153
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %157
+ThrowNullRef70:                                   ; preds = %157
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %160
+ThrowNullRef72:                                   ; preds = %160
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %166
+ThrowNullRef74:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %136
+ThrowNullRef76:                                   ; preds = %136
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %140
+ThrowNullRef78:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %143
+ThrowNullRef80:                                   ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %148
+ThrowNullRef82:                                   ; preds = %148
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %128
+ThrowNullRef84:                                   ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %132
+ThrowNullRef86:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %100
+ThrowNullRef88:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %104
+ThrowNullRef90:                                   ; preds = %104
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %107
+ThrowNullRef92:                                   ; preds = %107
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %113
+ThrowNullRef94:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %118
+ThrowNullRef96:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %123
+ThrowNullRef98:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %81
+ThrowNullRef100:                                  ; preds = %81
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef101:                                  ; preds = %85
+ThrowNullRef102:                                  ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef103:                                  ; preds = %88
+ThrowNullRef104:                                  ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef105:                                  ; preds = %94
+ThrowNullRef106:                                  ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef107:                                  ; preds = %64
+ThrowNullRef108:                                  ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef109:                                  ; preds = %68
+ThrowNullRef110:                                  ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef111:                                  ; preds = %71
+ThrowNullRef112:                                  ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef113:                                  ; preds = %76
+ThrowNullRef114:                                  ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef115:                                  ; preds = %56
+ThrowNullRef116:                                  ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef117:                                  ; preds = %60
+ThrowNullRef118:                                  ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef119:                                  ; preds = %37
+ThrowNullRef120:                                  ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef121:                                  ; preds = %41
+ThrowNullRef122:                                  ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef123:                                  ; preds = %46
+ThrowNullRef124:                                  ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef125:                                  ; preds = %51
+ThrowNullRef126:                                  ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef127:                                  ; preds = %27
+ThrowNullRef128:                                  ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef129:                                  ; preds = %31
+ThrowNullRef130:                                  ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef131:                                  ; preds = %19
+ThrowNullRef132:                                  ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef133:                                  ; preds = %22
+ThrowNullRef134:                                  ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef135:                                  ; preds = %338
+ThrowNullRef136:                                  ; preds = %338
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef137:                                  ; preds = %341
+ThrowNullRef138:                                  ; preds = %341
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef139:                                  ; preds = %356
+ThrowNullRef140:                                  ; preds = %356
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef141:                                  ; preds = %360
+ThrowNullRef142:                                  ; preds = %360
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef143:                                  ; preds = %377
+ThrowNullRef144:                                  ; preds = %377
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef145:                                  ; preds = %381
+ThrowNullRef146:                                  ; preds = %381
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef147:                                  ; preds = %424
+ThrowNullRef148:                                  ; preds = %424
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef149:                                  ; preds = %428
+ThrowNullRef150:                                  ; preds = %428
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef151:                                  ; preds = %440
+ThrowNullRef152:                                  ; preds = %440
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef153:                                  ; preds = %444
+ThrowNullRef154:                                  ; preds = %444
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef155:                                  ; preds = %456
+ThrowNullRef156:                                  ; preds = %456
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef157:                                  ; preds = %460
+ThrowNullRef158:                                  ; preds = %460
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef159:                                  ; preds = %474
+ThrowNullRef160:                                  ; preds = %474
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef161:                                  ; preds = %477
+ThrowNullRef162:                                  ; preds = %477
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef163:                                  ; preds = %394
+ThrowNullRef164:                                  ; preds = %394
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef165:                                  ; preds = %398
+ThrowNullRef166:                                  ; preds = %398
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef167:                                  ; preds = %401
+ThrowNullRef168:                                  ; preds = %401
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef169:                                  ; preds = %407
+ThrowNullRef170:                                  ; preds = %407
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1939,8 +2021,8 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
-  br i1 %NullCheck, label %22, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %ThrowNullRef, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
@@ -1948,8 +2030,8 @@ entry:
   store i32 %24, i32* %loc0
   %25 = load i32, i32* %loc0
   %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %26, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %27
 
 ; <label>:27                                      ; preds = %22
   %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
@@ -1971,7 +2053,7 @@ ThrowNullRef:                                     ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1989,8 +2071,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -2022,15 +2104,15 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2048,16 +2130,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
   %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
   store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %15
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
@@ -2072,8 +2154,8 @@ entry:
   %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
   %29 = ptrtoint i16 addrspace(1)* %28 to i64
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %19
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
@@ -2089,19 +2171,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2114,8 +2196,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
@@ -2128,7 +2210,7 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[loadElem]
+Failed to read AppDomain.PrepareDataForSetup[storeElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
@@ -2202,8 +2284,8 @@ entry:
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
-  br i1 %NullCheck24, label %27, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = load i64, i64 addrspace(1)* %26
@@ -2218,8 +2300,8 @@ entry:
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
-  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
   %41 = load i64, i64 addrspace(1)* %39
@@ -2236,8 +2318,8 @@ entry:
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
-  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
   %54 = load i64, i64 addrspace(1)* %52
@@ -2252,8 +2334,8 @@ entry:
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
   %67 = load i64, i64 addrspace(1)* %65
@@ -2270,8 +2352,8 @@ entry:
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
-  br i1 %NullCheck16, label %79, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
   %80 = load i64, i64 addrspace(1)* %78
@@ -2286,8 +2368,8 @@ entry:
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
-  br i1 %NullCheck18, label %92, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
   %93 = load i64, i64 addrspace(1)* %91
@@ -2304,8 +2386,8 @@ entry:
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
-  br i1 %NullCheck12, label %105, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = load i64, i64 addrspace(1)* %104
@@ -2320,8 +2402,8 @@ entry:
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
-  br i1 %NullCheck14, label %118, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
   %119 = load i64, i64 addrspace(1)* %117
@@ -2337,8 +2419,8 @@ entry:
 
 ; <label>:128                                     ; preds = %20
   %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
-  br i1 %NullCheck4, label %130, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %129, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %130
 
 ; <label>:130                                     ; preds = %128
   %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
@@ -2346,8 +2428,8 @@ entry:
   %133 = load i16, i16 addrspace(1)* %132, align 8
   %134 = zext i16 %133 to i32
   %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
-  br i1 %NullCheck6, label %136, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %135, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %136
 
 ; <label>:136                                     ; preds = %130
   %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
@@ -2360,8 +2442,8 @@ entry:
 
 ; <label>:143                                     ; preds = %136
   %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
-  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %144, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %145
 
 ; <label>:145                                     ; preds = %143
   %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
@@ -2369,8 +2451,8 @@ entry:
   %148 = load i16, i16 addrspace(1)* %147, align 8
   %149 = zext i16 %148 to i32
   %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %150, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %151
 
 ; <label>:151                                     ; preds = %145
   %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
@@ -2388,8 +2470,8 @@ entry:
 
 ; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
-  br i1 %NullCheck, label %163, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %ThrowNullRef, label %163
 
 ; <label>:163                                     ; preds = %161
   %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
@@ -2399,8 +2481,8 @@ entry:
 
 ; <label>:167                                     ; preds = %163
   %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
-  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %168, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %169
 
 ; <label>:169                                     ; preds = %167
   %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
@@ -2432,55 +2514,55 @@ ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %167
+ThrowNullRef2:                                    ; preds = %167
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %128
+ThrowNullRef4:                                    ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %130
+ThrowNullRef6:                                    ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %143
+ThrowNullRef8:                                    ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %145
+ThrowNullRef10:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %102
+ThrowNullRef12:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %105
+ThrowNullRef14:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %76
+ThrowNullRef16:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %79
+ThrowNullRef18:                                   ; preds = %79
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %50
+ThrowNullRef20:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %53
+ThrowNullRef22:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %24
+ThrowNullRef24:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %27
+ThrowNullRef26:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2503,15 +2585,15 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2519,16 +2601,16 @@ entry:
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
   store i32 %8, i32* %loc0
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
   %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
   store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
@@ -2546,16 +2628,16 @@ entry:
 
 ; <label>:23                                      ; preds = %64
   %24 = load i16*, i16** %loc3
-  %NullCheck12 = icmp ne i16* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i16* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
   store i32 %27, i32* %loc5
   %28 = load i16*, i16** %loc4
-  %NullCheck14 = icmp ne i16* %28, null
-  br i1 %NullCheck14, label %29, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %28, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = load i16, i16* %28, align 8
@@ -2620,15 +2702,15 @@ entry:
 
 ; <label>:67                                      ; preds = %64
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
-  br i1 %NullCheck8, label %69, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %68, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %69
 
 ; <label>:69                                      ; preds = %67
   %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
   %71 = load i32, i32 addrspace(1)* %70
   %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
-  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %73
 
 ; <label>:73                                      ; preds = %69
   %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
@@ -2645,31 +2727,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %67
+ThrowNullRef8:                                    ; preds = %67
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %69
+ThrowNullRef10:                                   ; preds = %69
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2710,14 +2792,14 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
   %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
@@ -2730,14 +2812,14 @@ entry:
 
 ; <label>:11                                      ; preds = %4
   %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
   %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
@@ -2749,14 +2831,14 @@ entry:
 
 ; <label>:22                                      ; preds = %16
   %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
   %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
-  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
-  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
@@ -2804,23 +2886,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2836,7 +2918,280 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[loadElem]
+Successfully read RuntimeType.IsAssignableFrom
+
+define i8 @RuntimeType.IsAssignableFrom(%System.RuntimeType addrspace(1)* %param0, %System.Type addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.RuntimeType addrspace(1)*
+  %arg1 = alloca %System.Type addrspace(1)*
+  %loc0 = alloca %System.RuntimeType addrspace(1)*
+  %loc1 = alloca %"System.Type[]" addrspace(1)*
+  %loc2 = alloca i32
+  store %System.RuntimeType addrspace(1)* %param0, %System.RuntimeType addrspace(1)** %this
+  store %System.Type addrspace(1)* %param1, %System.Type addrspace(1)** %arg1
+  %0 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %1 = icmp ne %System.Type addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i8 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %5 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %6 = bitcast %System.Type addrspace(1)* %4 to %System.Object addrspace(1)*
+  %7 = bitcast %System.RuntimeType addrspace(1)* %5 to %System.Object addrspace(1)*
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %6, %System.Object addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %3
+  ret i8 1
+
+; <label>:12                                      ; preds = %3
+  %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 152
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 32
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
+  %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
+  %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
+  store %System.RuntimeType addrspace(1)* %25, %System.RuntimeType addrspace(1)** %loc0
+  %26 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %27 = icmp eq %System.RuntimeType addrspace(1)* %26, null
+  br i1 %27, label %34, label %28
+
+; <label>:28                                      ; preds = %15
+  %29 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %30 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)*)*)(%System.RuntimeType addrspace(1)* %29, %System.RuntimeType addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+; <label>:34                                      ; preds = %15
+  %35 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %36 = call %System.Reflection.Emit.TypeBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Reflection.Emit.TypeBuilder addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %35)
+  %37 = icmp eq %System.Reflection.Emit.TypeBuilder addrspace(1)* %36, null
+  br i1 %37, label %139, label %38
+
+; <label>:38                                      ; preds = %34
+  %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %42
+
+; <label>:42                                      ; preds = %38
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 152
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 40
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
+  %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
+  %53 = zext i8 %52 to i32
+  %54 = icmp eq i32 %53, 0
+  br i1 %54, label %56, label %55
+
+; <label>:55                                      ; preds = %42
+  ret i8 1
+
+; <label>:56                                      ; preds = %42
+  %57 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %58 = bitcast %System.RuntimeType addrspace(1)* %57 to %System.Type addrspace(1)*
+  %59 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %58)
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %64 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.Type addrspace(1)* %63, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = bitcast %System.RuntimeType addrspace(1)* %64 to %System.Type addrspace(1)*
+  %67 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %63, %System.Type addrspace(1)* %66)
+  %68 = zext i8 %67 to i32
+  %69 = trunc i32 %68 to i8
+  ret i8 %69
+
+; <label>:70                                      ; preds = %56
+  %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
+  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %73
+
+; <label>:73                                      ; preds = %70
+  %74 = load i64, i64 addrspace(1)* %72
+  %75 = add i64 %74, 128
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = add i64 %77, 0
+  %79 = inttoptr i64 %78 to i64*
+  %80 = load i64, i64* %79
+  %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
+  %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
+  %83 = call i8 %82(%System.Type addrspace(1)* %81)
+  %84 = zext i8 %83 to i32
+  %85 = icmp eq i32 %84, 0
+  br i1 %85, label %139, label %86
+
+; <label>:86                                      ; preds = %73
+  %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
+  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %89
+
+; <label>:89                                      ; preds = %86
+  %90 = load i64, i64 addrspace(1)* %88
+  %91 = add i64 %90, 128
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = add i64 %93, 24
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
+  %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
+  %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
+  store %"System.Type[]" addrspace(1)* %99, %"System.Type[]" addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %129
+
+; <label>:100                                     ; preds = %132
+  %101 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %102 = load i32, i32* %loc2
+  %NullCheck11 = icmp eq %"System.Type[]" addrspace(1)* %101, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %103
+
+; <label>:103                                     ; preds = %100
+  %104 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 1
+  %105 = load i32, i32 addrspace(1)* %104
+  %106 = zext i32 %105 to i64
+  %107 = zext i32 %102 to i64
+  %BoundsCheck = icmp uge i64 %107, %106
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %108
+
+; <label>:108                                     ; preds = %103
+  %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
+  %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
+  %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
+  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %113
+
+; <label>:113                                     ; preds = %108
+  %114 = load i64, i64 addrspace(1)* %112
+  %115 = add i64 %114, 152
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = add i64 %117, 56
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
+  %123 = zext i8 %122 to i32
+  %124 = icmp ne i32 %123, 0
+  br i1 %124, label %126, label %125
+
+; <label>:125                                     ; preds = %113
+  ret i8 0
+
+; <label>:126                                     ; preds = %113
+  %127 = load i32, i32* %loc2
+  %128 = add i32 %127, 1
+  store i32 %128, i32* %loc2
+  br label %129
+
+; <label>:129                                     ; preds = %89, %126
+  %130 = load i32, i32* %loc2
+  %131 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %NullCheck9 = icmp eq %"System.Type[]" addrspace(1)* %131, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %132
+
+; <label>:132                                     ; preds = %129
+  %133 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %131, i32 0, i32 1
+  %134 = load i32, i32 addrspace(1)* %133
+  %135 = zext i32 %134 to i64
+  %136 = trunc i64 %135 to i32
+  %137 = icmp slt i32 %130, %136
+  br i1 %137, label %100, label %138
+
+; <label>:138                                     ; preds = %132
+  ret i8 1
+
+; <label>:139                                     ; preds = %34, %73
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %129
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %103
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -2893,7 +3248,7 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElem]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -2904,8 +3259,8 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -2997,8 +3352,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
@@ -3059,8 +3414,8 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -3087,8 +3442,8 @@ entry:
 
 ; <label>:17                                      ; preds = %5, %11
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
@@ -3097,8 +3452,8 @@ entry:
 
 ; <label>:22                                      ; preds = %1, %11
   %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
@@ -3109,11 +3464,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %17
+ThrowNullRef2:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %22
+ThrowNullRef4:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3167,15 +3522,15 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
   %15 = load i32, i32 addrspace(1)* %14
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
@@ -3198,7 +3553,7 @@ ThrowNullRef:                                     ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef2:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3232,8 +3587,8 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
@@ -3312,8 +3667,8 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -3327,8 +3682,8 @@ entry:
 ; <label>:5                                       ; preds = %43
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %7 = load i32, i32* %loc1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck6, label %8, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
@@ -3366,8 +3721,8 @@ entry:
 ; <label>:32                                      ; preds = %21, %25
   %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
   %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
-  br i1 %NullCheck8, label %35, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = trunc i32 %34 to i16
@@ -3380,8 +3735,8 @@ entry:
 ; <label>:40                                      ; preds = %1, %35
   %41 = load i32, i32* %loc1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
-  br i1 %NullCheck2, label %43, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %42, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
@@ -3392,8 +3747,8 @@ entry:
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
   %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
-  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
   %51 = load i64, i64 addrspace(1)* %49
@@ -3412,19 +3767,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %40
+ThrowNullRef2:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %47
+ThrowNullRef4:                                    ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %5
+ThrowNullRef6:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %32
+ThrowNullRef8:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3467,8 +3822,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
@@ -3492,11 +3847,391 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(i16* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store i16* %param0, i16** %arg0
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load i32, i32* %arg3
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %42, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %37, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg2
+  %13 = load i32, i32* %arg3
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %37, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %24 = load i32, i32* %arg2
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load i16*, i16** %arg0
+  %35 = load i32, i32* %arg3
+  %36 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %36, i16* %34, i32 %35)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:37                                      ; preds = %5, %16
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %39)
+  %41 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41, %System.String addrspace(1)* %38, %System.String addrspace(1)* %40)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41) #0
+  unreachable
+
+; <label>:42                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
-Failed to read StringBuilder.ToString[loadElemA]
+Successfully read StringBuilder.ToString
+
+define %System.String addrspace(1)* @StringBuilder.ToString(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i16*
+  %loc3 = alloca %"System.Char[]" addrspace(1)*
+  %loc4 = alloca i32
+  %loc5 = alloca i32
+  %loc6 = alloca i16 addrspace(1)*
+  %loc7 = alloca %System.String addrspace(1)*
+  %loc8 = alloca %"System.Char[]" addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %0)
+  %2 = icmp ne i32 %1, 0
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %4
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %6)
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %7)
+  store %System.String addrspace(1)* %8, %System.String addrspace(1)** %loc0
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.Text.StringBuilder addrspace(1)* %9, %System.Text.StringBuilder addrspace(1)** %loc1
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  store %System.String addrspace(1)* %10, %System.String addrspace(1)** %loc7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc7
+  %12 = ptrtoint %System.String addrspace(1)* %11 to i64
+  %13 = icmp eq i64 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %5
+  %15 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %16 = sext i32 %15 to i64
+  %17 = add i64 %12, %16
+  br label %18
+
+; <label>:18                                      ; preds = %5, %14
+  %19 = phi i64 [ %12, %5 ], [ %17, %14 ]
+  %20 = inttoptr i64 %19 to i16*
+  store i16* %20, i16** %loc2
+  br label %21
+
+; <label>:21                                      ; preds = %98, %18
+  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %22, null
+  br i1 %NullCheck, label %ThrowNullRef, label %23
+
+; <label>:23                                      ; preds = %21
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 3
+  %25 = load i32, i32 addrspace(1)* %24, align 8
+  %26 = icmp sle i32 %25, 0
+  br i1 %26, label %96, label %27
+
+; <label>:27                                      ; preds = %23
+  %28 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %28, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %29
+
+; <label>:29                                      ; preds = %27
+  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %28, i32 0, i32 1
+  %31 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %30, align 8
+  store %"System.Char[]" addrspace(1)* %31, %"System.Char[]" addrspace(1)** %loc3
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %33
+
+; <label>:33                                      ; preds = %29
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  store i32 %35, i32* %loc4
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  %39 = load i32, i32 addrspace(1)* %38, align 8
+  store i32 %39, i32* %loc5
+  %40 = load i32, i32* %loc5
+  %41 = load i32, i32* %loc4
+  %42 = add i32 %40, %41
+  %43 = zext i32 %42 to i64
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %45
+
+; <label>:45                                      ; preds = %37
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = sext i32 %47 to i64
+  %49 = icmp sgt i64 %43, %48
+  br i1 %49, label %91, label %50
+
+; <label>:50                                      ; preds = %45
+  %51 = load i32, i32* %loc5
+  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %52, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %53
+
+; <label>:53                                      ; preds = %50
+  %54 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %52, i32 0, i32 1
+  %55 = load i32, i32 addrspace(1)* %54
+  %56 = zext i32 %55 to i64
+  %57 = trunc i64 %56 to i32
+  %58 = icmp ugt i32 %51, %57
+  br i1 %58, label %91, label %59
+
+; <label>:59                                      ; preds = %53
+  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  store %"System.Char[]" addrspace(1)* %60, %"System.Char[]" addrspace(1)** %loc8
+  %61 = icmp eq %"System.Char[]" addrspace(1)* %60, null
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %63, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %64
+
+; <label>:64                                      ; preds = %62
+  %65 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %63, i32 0, i32 1
+  %66 = load i32, i32 addrspace(1)* %65
+  %67 = zext i32 %66 to i64
+  %68 = trunc i64 %67 to i32
+  %69 = icmp ne i32 %68, 0
+  br i1 %69, label %71, label %70
+
+; <label>:70                                      ; preds = %59, %64
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:71                                      ; preds = %64
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %73
+
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %BoundsCheck = icmp uge i64 0, %76
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %77
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %78, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:79                                      ; preds = %70, %77
+  %80 = load i16*, i16** %loc2
+  %81 = load i32, i32* %loc4
+  %82 = sext i32 %81 to i64
+  %83 = mul i64 %82, 2
+  %84 = bitcast i16* %80 to i8*
+  %85 = getelementptr inbounds i8, i8* %84, i64 %83
+  %86 = load i16 addrspace(1)*, i16 addrspace(1)** %loc6
+  %87 = ptrtoint i16 addrspace(1)* %86 to i64
+  %88 = load i32, i32* %loc5
+  %89 = bitcast i8* %85 to i16*
+  %90 = inttoptr i64 %87 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %89, i16* %90, i32 %88)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %96
+
+; <label>:91                                      ; preds = %45, %53
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %94 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %93)
+  %95 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95, %System.String addrspace(1)* %92, %System.String addrspace(1)* %94)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95) #0
+  unreachable
+
+; <label>:96                                      ; preds = %23, %79
+  %97 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %97, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %98
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %97, i32 0, i32 2
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  store %System.Text.StringBuilder addrspace(1)* %100, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %102 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %102, label %21, label %103
+
+; <label>:103                                     ; preds = %98
+  store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc7
+  %104 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  ret %System.String addrspace(1)* %104
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method StringBuilder::get_Length using LLILCJit
+Successfully read StringBuilder.get_Length
+
+define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
+Successfully read RuntimeHelpers.get_OffsetToStringData
+
+define i32 @RuntimeHelpers.get_OffsetToStringData() {
+entry:
+  ret i32 12
+}
+
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
 Successfully read CultureData.CreateCultureData
 
@@ -3514,23 +4249,23 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
   store i8 %4, i8 addrspace(1)* %6
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
@@ -3549,11 +4284,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3566,50 +4301,50 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
   store i32 -1, i32 addrspace(1)* %2
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
   store i32 -1, i32 addrspace(1)* %8
   %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
   store i32 -1, i32 addrspace(1)* %14
   %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
   store i32 -1, i32 addrspace(1)* %17
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
@@ -3623,27 +4358,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3675,7 +4410,136 @@ Failed to read Dictionary`2.Insert[non-const derefAddress]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
 Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
-Failed to read HashHelpers.GetPrime[loadElem]
+Successfully read HashHelpers.GetPrime
+
+define i32 @HashHelpers.GetPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %6, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5, %System.String addrspace(1)* %4)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5) #0
+  unreachable
+
+; <label>:6                                       ; preds = %entry
+  store i32 0, i32* %loc0
+  br label %29
+
+; <label>:7                                       ; preds = %35
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 1296
+  %10 = addrspacecast i8 addrspace(1)* %9 to %"System.Int32[]" addrspace(1)**
+  %11 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %10
+  %12 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Int32[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = zext i32 %15 to i64
+  %17 = zext i32 %12 to i64
+  %BoundsCheck = icmp uge i64 %17, %16
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 3, i32 %12
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  store i32 %20, i32* %loc1
+  %21 = load i32, i32* %loc1
+  %22 = load i32, i32* %arg0
+  %23 = icmp slt i32 %21, %22
+  br i1 %23, label %26, label %24
+
+; <label>:24                                      ; preds = %18
+  %25 = load i32, i32* %loc1
+  ret i32 %25
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %loc0
+  %28 = add i32 %27, 1
+  store i32 %28, i32* %loc0
+  br label %29
+
+; <label>:29                                      ; preds = %6, %26
+  %30 = load i32, i32* %loc0
+  %31 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %32 = getelementptr inbounds i8, i8 addrspace(1)* %31, i64 1296
+  %33 = addrspacecast i8 addrspace(1)* %32 to %"System.Int32[]" addrspace(1)**
+  %34 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %33
+  %NullCheck = icmp eq %"System.Int32[]" addrspace(1)* %34, null
+  br i1 %NullCheck, label %ThrowNullRef, label %35
+
+; <label>:35                                      ; preds = %29
+  %36 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %34, i32 0, i32 1
+  %37 = load i32, i32 addrspace(1)* %36
+  %38 = zext i32 %37 to i64
+  %39 = trunc i64 %38 to i32
+  %40 = icmp slt i32 %30, %39
+  br i1 %40, label %7, label %41
+
+; <label>:41                                      ; preds = %35
+  %42 = load i32, i32* %arg0
+  %43 = or i32 %42, 1
+  store i32 %43, i32* %loc2
+  br label %59
+
+; <label>:44                                      ; preds = %59
+  %45 = load i32, i32* %loc2
+  %46 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %45)
+  %47 = zext i8 %46 to i32
+  %48 = icmp eq i32 %47, 0
+  br i1 %48, label %56, label %49
+
+; <label>:49                                      ; preds = %44
+  %50 = load i32, i32* %loc2
+  %51 = sub i32 %50, 1
+  %52 = srem i32 %51, 101
+  %53 = icmp eq i32 %52, 0
+  br i1 %53, label %56, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = load i32, i32* %loc2
+  ret i32 %55
+
+; <label>:56                                      ; preds = %44, %49
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %57, 2
+  store i32 %58, i32* %loc2
+  br label %59
+
+; <label>:59                                      ; preds = %41, %56
+  %60 = load i32, i32* %loc2
+  %61 = icmp slt i32 %60, 2147483647
+  br i1 %61, label %44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load i32, i32* %arg0
+  ret i32 %63
+
+ThrowNullRef:                                     ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
 Successfully read GenericEqualityComparer`1.GetHashCode
 
@@ -3694,14 +4558,14 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
   %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load i64, i64 addrspace(1)* %7
@@ -3720,7 +4584,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3750,8 +4614,8 @@ entry:
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
@@ -3796,8 +4660,8 @@ entry:
   %35 = bitcast i16* %34 to i8*
   %36 = getelementptr inbounds i8, i8* %35, i64 2
   %37 = bitcast i8* %36 to i16*
-  %NullCheck4 = icmp ne i16* %37, null
-  br i1 %NullCheck4, label %38, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %37, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %38
 
 ; <label>:38                                      ; preds = %27
   %39 = load i16, i16* %37, align 8
@@ -3824,8 +4688,8 @@ entry:
 
 ; <label>:54                                      ; preds = %22, %43
   %55 = load i16*, i16** %loc4
-  %NullCheck2 = icmp ne i16* %55, null
-  br i1 %NullCheck2, label %56, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i16* %55, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %56
 
 ; <label>:56                                      ; preds = %54
   %57 = load i16, i16* %55, align 8
@@ -3850,11 +4714,11 @@ ThrowNullRef:                                     ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %54
+ThrowNullRef2:                                    ; preds = %54
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %27
+ThrowNullRef4:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3871,8 +4735,8 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -3907,8 +4771,8 @@ entry:
 
 ; <label>:26                                      ; preds = %19
   %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
-  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %28
 
 ; <label>:28                                      ; preds = %26
   %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
@@ -3920,7 +4784,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3972,8 +4836,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
@@ -3984,26 +4848,26 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
-  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
@@ -4014,8 +4878,8 @@ entry:
 ; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
@@ -4024,8 +4888,8 @@ entry:
 
 ; <label>:25                                      ; preds = %1, %16, %23
   %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
-  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
@@ -4036,27 +4900,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %20
+ThrowNullRef10:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4069,8 +4933,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -4081,8 +4945,8 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
@@ -4091,8 +4955,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1, %8
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
@@ -4103,11 +4967,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4128,24 +4992,24 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   store i32 %3, i32* %loc0
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
   %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
   store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck4, label %9, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
@@ -4164,15 +5028,15 @@ entry:
 ; <label>:18                                      ; preds = %70
   %19 = load i16*, i16** %loc3
   %20 = bitcast i16* %19 to i64*
-  %NullCheck10 = icmp ne i64* %20, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %20, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = load i64, i64* %20, align 8
   %23 = load i16*, i16** %loc4
   %24 = bitcast i16* %23 to i64*
-  %NullCheck12 = icmp ne i64* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = load i64, i64* %24, align 8
@@ -4188,8 +5052,8 @@ entry:
   %31 = bitcast i16* %30 to i8*
   %32 = getelementptr inbounds i8, i8* %31, i64 8
   %33 = bitcast i8* %32 to i64*
-  %NullCheck14 = icmp ne i64* %33, null
-  br i1 %NullCheck14, label %34, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = load i64, i64* %33, align 8
@@ -4197,8 +5061,8 @@ entry:
   %37 = bitcast i16* %36 to i8*
   %38 = getelementptr inbounds i8, i8* %37, i64 8
   %39 = bitcast i8* %38 to i64*
-  %NullCheck16 = icmp ne i64* %39, null
-  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %40
 
 ; <label>:40                                      ; preds = %34
   %41 = load i64, i64* %39, align 8
@@ -4214,8 +5078,8 @@ entry:
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %NullCheck18 = icmp ne i64* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = load i64, i64* %48, align 8
@@ -4223,8 +5087,8 @@ entry:
   %52 = bitcast i16* %51 to i8*
   %53 = getelementptr inbounds i8, i8* %52, i64 16
   %54 = bitcast i8* %53 to i64*
-  %NullCheck20 = icmp ne i64* %54, null
-  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64* %54, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %55
 
 ; <label>:55                                      ; preds = %49
   %56 = load i64, i64* %54, align 8
@@ -4262,15 +5126,15 @@ entry:
 ; <label>:74                                      ; preds = %95
   %75 = load i16*, i16** %loc3
   %76 = bitcast i16* %75 to i32*
-  %NullCheck6 = icmp ne i32* %76, null
-  br i1 %NullCheck6, label %77, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32* %76, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %77
 
 ; <label>:77                                      ; preds = %74
   %78 = load i32, i32* %76, align 8
   %79 = load i16*, i16** %loc4
   %80 = bitcast i16* %79 to i32*
-  %NullCheck8 = icmp ne i32* %80, null
-  br i1 %NullCheck8, label %81, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i32* %80, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %81
 
 ; <label>:81                                      ; preds = %77
   %82 = load i32, i32* %80, align 8
@@ -4318,43 +5182,43 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %74
+ThrowNullRef6:                                    ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %77
+ThrowNullRef8:                                    ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %29
+ThrowNullRef14:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %34
+ThrowNullRef16:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4376,8 +5240,8 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load i64, i64 addrspace(1)* %4
@@ -4389,8 +5253,8 @@ entry:
   %12 = load i64, i64* %11
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %5
   %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
@@ -4399,8 +5263,8 @@ entry:
   %18 = load i8, i8* %arg2
   %19 = zext i8 %18 to i32
   %20 = trunc i32 %19 to i8
-  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %15
   %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
@@ -4411,11 +5275,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4442,8 +5306,8 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
@@ -4466,16 +5330,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
   %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = load i64, i64 addrspace(1)* %19
@@ -4500,8 +5364,8 @@ entry:
 ; <label>:35                                      ; preds = %30
   %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
@@ -4514,8 +5378,8 @@ entry:
 
 ; <label>:42                                      ; preds = %1, %38
   %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
-  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
@@ -4526,19 +5390,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %35
+ThrowNullRef2:                                    ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %42
+ThrowNullRef8:                                    ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4551,14 +5415,14 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
@@ -4570,7 +5434,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4583,8 +5447,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
@@ -4613,51 +5477,51 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
   %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
   %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
   %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
   %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
-  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
   store i64 %21, i64 addrspace(1)* %23
   %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %25 = load i64, i64* %loc0
-  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
@@ -4668,27 +5532,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %22
+ThrowNullRef12:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4701,8 +5565,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
@@ -4713,19 +5577,19 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
@@ -4734,8 +5598,8 @@ entry:
 
 ; <label>:15                                      ; preds = %1, %13
   %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
@@ -4746,19 +5610,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %15
+ThrowNullRef8:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4771,8 +5635,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -4831,8 +5695,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
@@ -4882,8 +5746,8 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
-  br i1 %NullCheck, label %17, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %ThrowNullRef, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
@@ -4894,15 +5758,15 @@ entry:
 
 ; <label>:22                                      ; preds = %17
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
-  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
   %26 = load i32, i32 addrspace(1)* %25
   %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
-  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %27, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
@@ -4925,8 +5789,8 @@ entry:
 ; <label>:40                                      ; preds = %17
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
-  br i1 %NullCheck6, label %43, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %41, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
@@ -4938,34 +5802,17 @@ ThrowNullRef:                                     ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %24
+ThrowNullRef4:                                    ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %40
+ThrowNullRef6:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
-}
-
-INFO:  jitting method Object::ReferenceEquals using LLILCJit
-Successfully read Object.ReferenceEquals
-
-define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
-entry:
-  %arg0 = alloca %System.Object addrspace(1)*
-  %arg1 = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
-  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
-  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = icmp eq %System.Object addrspace(1)* %0, %1
-  %3 = sext i1 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
 }
 
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
@@ -4978,21 +5825,21 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
   %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
-  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
@@ -5007,28 +5854,28 @@ entry:
 ; <label>:13                                      ; preds = %8, %12
   %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
   %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
   %21 = load i32, i32 addrspace(1)* %20, align 8
   %22 = add i32 %21, 1
-  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
   store i32 %22, i32 addrspace(1)* %24
   %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
@@ -5039,27 +5886,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5077,7 +5924,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::Setup using LLILCJit
-Failed to read AppDomain.Setup[loadElem]
+Failed to read AppDomain.Setup[unbox]
 INFO:  jitting method Thread::GetDomain using LLILCJit
 Successfully read Thread.GetDomain
 
@@ -5108,8 +5955,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
@@ -5122,14 +5969,14 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
   %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
@@ -5141,11 +5988,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5173,8 +6020,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -5189,7 +6036,328 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
 Failed to read KeyCollection.System.Collections.Generic.IEnumerable<TKey>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Successfully read Enumerator.MoveNext
+
+define i8 @Enumerator.MoveNext(%"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.RuntimeTypeHandle* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*
+  %"$TypeArg" = alloca %System.RuntimeTypeHandle*
+  store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
+  %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 8
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %76, label %12
+
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
+  br label %76
+
+; <label>:13                                      ; preds = %85
+  %14 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck19 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %15
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, i32 0, i32 0
+  %17 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %16, align 8
+  %NullCheck21 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, i32 0, i32 2
+  %20 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %19, align 8
+  %21 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck23 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %22
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, i32 0, i32 2
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %NullCheck25 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 3, i32 %24
+  %NullCheck27 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %32
+
+; <label>:32                                      ; preds = %30
+  %33 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, i32 0, i32 2
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = icmp slt i32 %34, 0
+  br i1 %35, label %68, label %36
+
+; <label>:36                                      ; preds = %32
+  %37 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %38 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck29 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %39
+
+; <label>:39                                      ; preds = %36
+  %40 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, i32 0, i32 0
+  %41 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %40, align 8
+  %NullCheck31 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, i32 0, i32 2
+  %44 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %43, align 8
+  %45 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck33 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, i32 0, i32 2
+  %48 = load i32, i32 addrspace(1)* %47, align 8
+  %NullCheck35 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %49
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = zext i32 %51 to i64
+  %53 = zext i32 %48 to i64
+  %BoundsCheck37 = icmp uge i64 %53, %52
+  br i1 %BoundsCheck37, label %ThrowIndexOutOfRange38, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 3, i32 %48
+  %NullCheck39 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %56
+
+; <label>:56                                      ; preds = %54
+  %57 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, i32 0, i32 0
+  %58 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck41 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %59
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %60, %System.__Canon addrspace(1)* %58)
+  %61 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck43 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  %64 = load i32, i32 addrspace(1)* %63, align 8
+  %65 = add i32 %64, 1
+  %NullCheck45 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  store i32 %65, i32 addrspace(1)* %67
+  ret i8 1
+
+; <label>:68                                      ; preds = %32
+  %69 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck47 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %73 = add i32 %72, 1
+  %NullCheck49 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %74
+
+; <label>:74                                      ; preds = %70
+  %75 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  store i32 %73, i32 addrspace(1)* %75
+  br label %76
+
+; <label>:76                                      ; preds = %8, %12, %74
+  %77 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %78
+
+; <label>:78                                      ; preds = %76
+  %79 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, i32 0, i32 2
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck7 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %82
+
+; <label>:82                                      ; preds = %78
+  %83 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, i32 0, i32 0
+  %84 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %83, align 8
+  %NullCheck9 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %85
+
+; <label>:85                                      ; preds = %82
+  %86 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, i32 0, i32 7
+  %87 = load i32, i32 addrspace(1)* %86, align 8
+  %88 = icmp ult i32 %80, %87
+  br i1 %88, label %13, label %89
+
+; <label>:89                                      ; preds = %85
+  %90 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %91 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck11 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %92
+
+; <label>:92                                      ; preds = %89
+  %93 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, i32 0, i32 0
+  %94 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck13 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %95
+
+; <label>:95                                      ; preds = %92
+  %96 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, i32 0, i32 7
+  %97 = load i32, i32 addrspace(1)* %96, align 8
+  %98 = add i32 %97, 1
+  %NullCheck15 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %99
+
+; <label>:99                                      ; preds = %95
+  %100 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, i32 0, i32 2
+  store i32 %98, i32 addrspace(1)* %100
+  %101 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck17 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %102
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %103, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %92
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef22:                                   ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef24:                                   ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef26:                                   ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef28:                                   ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef30:                                   ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef32:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef34:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef36:                                   ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange38:                           ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef40:                                   ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef42:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef44:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef46:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef48:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef50:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -5200,8 +6368,8 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -5232,9 +6400,9 @@ Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
 Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
-Failed to read String.MakeSeparatorList[loadElemA]
+Failed to read String.MakeSeparatorList[storeElem]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
-Failed to read String.InternalSplitKeepEmptyEntries[loadElem]
+Failed to read String.InternalSplitKeepEmptyEntries[storeElem]
 INFO:  jitting method Path::IsRelative using LLILCJit
 Successfully read Path.IsRelative
 
@@ -5243,8 +6411,8 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -5254,8 +6422,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
@@ -5271,8 +6439,8 @@ entry:
 
 ; <label>:17                                      ; preds = %7
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
@@ -5288,8 +6456,8 @@ entry:
 
 ; <label>:29                                      ; preds = %19
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %31
 
 ; <label>:31                                      ; preds = %29
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
@@ -5300,8 +6468,8 @@ entry:
 
 ; <label>:36                                      ; preds = %31
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
-  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %37, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
@@ -5312,8 +6480,8 @@ entry:
 
 ; <label>:43                                      ; preds = %31, %38
   %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
-  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %45
 
 ; <label>:45                                      ; preds = %43
   %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
@@ -5324,8 +6492,8 @@ entry:
 
 ; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %50
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
@@ -5336,8 +6504,8 @@ entry:
 
 ; <label>:57                                      ; preds = %1, %7, %19, %45, %52
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
-  br i1 %NullCheck14, label %59, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %59
 
 ; <label>:59                                      ; preds = %57
   %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
@@ -5347,8 +6515,8 @@ entry:
 
 ; <label>:63                                      ; preds = %59
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
@@ -5359,8 +6527,8 @@ entry:
 
 ; <label>:70                                      ; preds = %65
   %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
-  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.String addrspace(1)* %71, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %72
 
 ; <label>:72                                      ; preds = %70
   %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
@@ -5379,39 +6547,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %17
+ThrowNullRef4:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %29
+ThrowNullRef6:                                    ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %36
+ThrowNullRef8:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %43
+ThrowNullRef10:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %50
+ThrowNullRef12:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %57
+ThrowNullRef14:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %63
+ThrowNullRef16:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %70
+ThrowNullRef18:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5419,7 +6587,293 @@ ThrowNullRef17:                                   ; preds = %70
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
-Failed to read String.TrimHelper[loadElem]
+Successfully read String.TrimHelper
+
+define %System.String addrspace(1)* @String.TrimHelper(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i16
+  %loc4 = alloca i32
+  %loc5 = alloca i16
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = sub i32 %3, 1
+  store i32 %4, i32* %loc0
+  store i32 0, i32* %loc1
+  %5 = load i32, i32* %arg2
+  %6 = icmp eq i32 %5, 1
+  br i1 %6, label %62, label %7
+
+; <label>:7                                       ; preds = %1
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:8                                       ; preds = %58
+  store i32 0, i32* %loc2
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load i32, i32* %loc1
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2, i32 %10
+  %13 = load i16, i16 addrspace(1)* %12
+  %14 = zext i16 %13 to i32
+  %15 = trunc i32 %14 to i16
+  store i16 %15, i16* %loc3
+  store i32 0, i32* %loc2
+  br label %34
+
+; <label>:16                                      ; preds = %37
+  %17 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %18 = load i32, i32* %loc2
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %17, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %19
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = zext i32 %18 to i64
+  %BoundsCheck = icmp uge i64 %23, %22
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %24
+
+; <label>:24                                      ; preds = %19
+  %25 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 3, i32 %18
+  %26 = load i16, i16 addrspace(1)* %25, align 8
+  %27 = zext i16 %26 to i32
+  %28 = load i16, i16* %loc3
+  %29 = zext i16 %28 to i32
+  %30 = icmp eq i32 %27, %29
+  br i1 %30, label %43, label %31
+
+; <label>:31                                      ; preds = %24
+  %32 = load i32, i32* %loc2
+  %33 = add i32 %32, 1
+  store i32 %33, i32* %loc2
+  br label %34
+
+; <label>:34                                      ; preds = %11, %31
+  %35 = load i32, i32* %loc2
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = icmp slt i32 %35, %41
+  br i1 %42, label %16, label %43
+
+; <label>:43                                      ; preds = %24, %37
+  %44 = load i32, i32* %loc2
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %45, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp eq i32 %44, %50
+  br i1 %51, label %62, label %52
+
+; <label>:52                                      ; preds = %46
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %7, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %57, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %58
+
+; <label>:58                                      ; preds = %55
+  %59 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %60 = load i32, i32 addrspace(1)* %59
+  %61 = icmp slt i32 %56, %60
+  br i1 %61, label %8, label %62
+
+; <label>:62                                      ; preds = %1, %46, %58
+  %63 = load i32, i32* %arg2
+  %64 = icmp eq i32 %63, 0
+  br i1 %64, label %122, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %66, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %67
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %66, i32 0, i32 1
+  %69 = load i32, i32 addrspace(1)* %68
+  %70 = sub i32 %69, 1
+  store i32 %70, i32* %loc0
+  br label %118
+
+; <label>:71                                      ; preds = %118
+  store i32 0, i32* %loc4
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %73 = load i32, i32* %loc0
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %74
+
+; <label>:74                                      ; preds = %71
+  %75 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 2, i32 %73
+  %76 = load i16, i16 addrspace(1)* %75
+  %77 = zext i16 %76 to i32
+  %78 = trunc i32 %77 to i16
+  store i16 %78, i16* %loc5
+  store i32 0, i32* %loc4
+  br label %97
+
+; <label>:79                                      ; preds = %100
+  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %81 = load i32, i32* %loc4
+  %NullCheck19 = icmp eq %"System.Char[]" addrspace(1)* %80, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
+
+; <label>:82                                      ; preds = %79
+  %83 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 1
+  %84 = load i32, i32 addrspace(1)* %83
+  %85 = zext i32 %84 to i64
+  %86 = zext i32 %81 to i64
+  %BoundsCheck21 = icmp uge i64 %86, %85
+  br i1 %BoundsCheck21, label %ThrowIndexOutOfRange22, label %87
+
+; <label>:87                                      ; preds = %82
+  %88 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 3, i32 %81
+  %89 = load i16, i16 addrspace(1)* %88, align 8
+  %90 = zext i16 %89 to i32
+  %91 = load i16, i16* %loc5
+  %92 = zext i16 %91 to i32
+  %93 = icmp eq i32 %90, %92
+  br i1 %93, label %106, label %94
+
+; <label>:94                                      ; preds = %87
+  %95 = load i32, i32* %loc4
+  %96 = add i32 %95, 1
+  store i32 %96, i32* %loc4
+  br label %97
+
+; <label>:97                                      ; preds = %74, %94
+  %98 = load i32, i32* %loc4
+  %99 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck15 = icmp eq %"System.Char[]" addrspace(1)* %99, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %100
+
+; <label>:100                                     ; preds = %97
+  %101 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %99, i32 0, i32 1
+  %102 = load i32, i32 addrspace(1)* %101
+  %103 = zext i32 %102 to i64
+  %104 = trunc i64 %103 to i32
+  %105 = icmp slt i32 %98, %104
+  br i1 %105, label %79, label %106
+
+; <label>:106                                     ; preds = %87, %100
+  %107 = load i32, i32* %loc4
+  %108 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck17 = icmp eq %"System.Char[]" addrspace(1)* %108, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %109
+
+; <label>:109                                     ; preds = %106
+  %110 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %108, i32 0, i32 1
+  %111 = load i32, i32 addrspace(1)* %110
+  %112 = zext i32 %111 to i64
+  %113 = trunc i64 %112 to i32
+  %114 = icmp eq i32 %107, %113
+  br i1 %114, label %122, label %115
+
+; <label>:115                                     ; preds = %109
+  %116 = load i32, i32* %loc0
+  %117 = sub i32 %116, 1
+  store i32 %117, i32* %loc0
+  br label %118
+
+; <label>:118                                     ; preds = %67, %115
+  %119 = load i32, i32* %loc0
+  %120 = load i32, i32* %loc1
+  %121 = icmp sge i32 %119, %120
+  br i1 %121, label %71, label %122
+
+; <label>:122                                     ; preds = %62, %109, %118
+  %123 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %124 = load i32, i32* %loc1
+  %125 = load i32, i32* %loc0
+  %126 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %123, i32 %124, i32 %125)
+  ret %System.String addrspace(1)* %126
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %97
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange22:                           ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
 Successfully read String.CreateTrimmedString
 
@@ -5439,8 +6893,8 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
@@ -5535,8 +6989,8 @@ entry:
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i64 2872
   %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
   %8 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %7
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %3
   %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
@@ -5553,8 +7007,8 @@ entry:
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 2864
   %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
   %21 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %20
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
-  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %22
 
 ; <label>:22                                      ; preds = %16
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
@@ -5569,7 +7023,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %16
+ThrowNullRef2:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5586,8 +7040,8 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5613,8 +7067,8 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
@@ -5632,8 +7086,8 @@ entry:
 
 ; <label>:12                                      ; preds = %4
   %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
@@ -5644,8 +7098,8 @@ entry:
 
 ; <label>:19                                      ; preds = %14
   %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %19
   %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
@@ -5660,21 +7114,21 @@ entry:
   %31 = zext i16 %30 to i32
   %32 = bitcast i8* %29 to i16*
   %33 = trunc i32 %31 to i16
-  %NullCheck6 = icmp ne i16* %32, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i16* %32, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %21
   store i16 %33, i16* %32, align 8
   %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %36
 
 ; <label>:36                                      ; preds = %34
   %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
   %38 = load i32, i32 addrspace(1)* %37, align 8
   %39 = add i32 %38, 1
-  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %40
 
 ; <label>:40                                      ; preds = %36
   %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
@@ -5683,16 +7137,16 @@ entry:
 
 ; <label>:42                                      ; preds = %14
   %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
-  br i1 %NullCheck12, label %44, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
   %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
   %47 = load i16, i16* %arg1
   %48 = zext i16 %47 to i32
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = trunc i32 %48 to i16
@@ -5703,31 +7157,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %19
+ThrowNullRef4:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %21
+ThrowNullRef6:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %36
+ThrowNullRef10:                                   ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %42
+ThrowNullRef12:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %44
+ThrowNullRef14:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5740,8 +7194,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -5752,8 +7206,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
@@ -5762,14 +7216,14 @@ entry:
 
 ; <label>:11                                      ; preds = %1
   %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
@@ -5779,15 +7233,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5808,8 +7262,8 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5822,8 +7276,8 @@ entry:
 
 ; <label>:8                                       ; preds = %3
   %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
@@ -5842,15 +7296,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
-  br i1 %NullCheck4, label %22, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
   %24 = load i16*, i16* addrspace(1)* %23, align 8
   %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %25, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
@@ -5859,8 +7313,8 @@ entry:
   store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
@@ -5874,8 +7328,8 @@ entry:
 
 ; <label>:37                                      ; preds = %65
   %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %37
   %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
@@ -5886,16 +7340,16 @@ entry:
   %45 = bitcast i16* %41 to i8*
   %46 = getelementptr inbounds i8, i8* %45, i64 %44
   %47 = bitcast i8* %46 to i16*
-  %NullCheck14 = icmp ne i16* %47, null
-  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %47, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %48
 
 ; <label>:48                                      ; preds = %39
   %49 = load i16, i16* %47, align 8
   %50 = zext i16 %49 to i32
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %52 = load i32, i32* %loc1
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %53
 
 ; <label>:53                                      ; preds = %48
   %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
@@ -5916,8 +7370,8 @@ entry:
 ; <label>:62                                      ; preds = %36, %59
   %63 = load i32, i32* %loc1
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck10, label %65, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %65
 
 ; <label>:65                                      ; preds = %62
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
@@ -5936,15 +7390,15 @@ entry:
 
 ; <label>:74                                      ; preds = %70
   %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
-  br i1 %NullCheck18, label %76, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %76
 
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
   %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
-  br i1 %NullCheck20, label %80, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
   %81 = load i64, i64 addrspace(1)* %79
@@ -5958,8 +7412,8 @@ entry:
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
   %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
-  br i1 %NullCheck22, label %92, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.String addrspace(1)* %90, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %92
 
 ; <label>:92                                      ; preds = %80
   %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
@@ -5969,15 +7423,15 @@ entry:
 
 ; <label>:96                                      ; preds = %70
   %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
-  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %98
 
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
   %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
-  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
   %103 = load i64, i64 addrspace(1)* %101
@@ -5991,8 +7445,8 @@ entry:
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
   %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
-  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.String addrspace(1)* %112, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %114
 
 ; <label>:114                                     ; preds = %102
   %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
@@ -6004,59 +7458,59 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %20
+ThrowNullRef4:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %22
+ThrowNullRef6:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %26
+ThrowNullRef8:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %62
+ThrowNullRef10:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %48
+ThrowNullRef16:                                   ; preds = %48
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %74
+ThrowNullRef18:                                   ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %76
+ThrowNullRef20:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %80
+ThrowNullRef22:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %96
+ThrowNullRef24:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %98
+ThrowNullRef26:                                   ; preds = %98
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %102
+ThrowNullRef28:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6069,15 +7523,15 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
   %3 = load i16*, i16* addrspace(1)* %2, align 8
   %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
@@ -6087,8 +7541,8 @@ entry:
   %10 = bitcast i16* %3 to i8*
   %11 = getelementptr inbounds i8, i8* %10, i64 %9
   %12 = bitcast i8* %11 to i16*
-  %NullCheck4 = icmp ne i16* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %5
   store i16 0, i16* %12, align 8
@@ -6098,11 +7552,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6119,8 +7573,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -6131,8 +7585,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
@@ -6144,15 +7598,15 @@ entry:
 
 ; <label>:14                                      ; preds = %1
   %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
   %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
   %21 = load i64, i64 addrspace(1)* %19
@@ -6171,15 +7625,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %14
+ThrowNullRef4:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %16
+ThrowNullRef6:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6302,14 +7756,6 @@ entry:
   ret %System.String addrspace(1)* %57
 }
 
-INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
-Successfully read RuntimeHelpers.get_OffsetToStringData
-
-define i32 @RuntimeHelpers.get_OffsetToStringData() {
-entry:
-  ret i32 12
-}
-
 INFO:  jitting method String::Equals using LLILCJit
 Successfully read String.Equals
 
@@ -6381,8 +7827,8 @@ entry:
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
-  br i1 %NullCheck24, label %29, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
   %30 = load i64, i64 addrspace(1)* %28
@@ -6397,8 +7843,8 @@ entry:
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
-  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
   %43 = load i64, i64 addrspace(1)* %41
@@ -6418,8 +7864,8 @@ entry:
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
   %59 = load i64, i64 addrspace(1)* %57
@@ -6434,8 +7880,8 @@ entry:
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck22, label %71, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
   %72 = load i64, i64 addrspace(1)* %70
@@ -6455,8 +7901,8 @@ entry:
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
-  br i1 %NullCheck16, label %87, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = load i64, i64 addrspace(1)* %86
@@ -6471,8 +7917,8 @@ entry:
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck18, label %100, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
   %101 = load i64, i64 addrspace(1)* %99
@@ -6492,8 +7938,8 @@ entry:
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
-  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
   %117 = load i64, i64 addrspace(1)* %115
@@ -6508,8 +7954,8 @@ entry:
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
-  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
   %130 = load i64, i64 addrspace(1)* %128
@@ -6528,15 +7974,15 @@ entry:
 
 ; <label>:142                                     ; preds = %22
   %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
-  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %143, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %144
 
 ; <label>:144                                     ; preds = %142
   %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
   %146 = load i32, i32 addrspace(1)* %145
   %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
-  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %147, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %148
 
 ; <label>:148                                     ; preds = %144
   %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
@@ -6557,15 +8003,15 @@ entry:
 
 ; <label>:159                                     ; preds = %22
   %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
-  br i1 %NullCheck, label %161, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %ThrowNullRef, label %161
 
 ; <label>:161                                     ; preds = %159
   %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
   %163 = load i32, i32 addrspace(1)* %162
   %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
-  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %164, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %165
 
 ; <label>:165                                     ; preds = %161
   %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
@@ -6578,8 +8024,8 @@ entry:
 
 ; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
-  br i1 %NullCheck4, label %172, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %171, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %172
 
 ; <label>:172                                     ; preds = %170
   %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
@@ -6589,8 +8035,8 @@ entry:
 
 ; <label>:176                                     ; preds = %172
   %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
-  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %177, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %178
 
 ; <label>:178                                     ; preds = %176
   %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
@@ -6629,55 +8075,55 @@ ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %161
+ThrowNullRef2:                                    ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %170
+ThrowNullRef4:                                    ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %176
+ThrowNullRef6:                                    ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %142
+ThrowNullRef8:                                    ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %144
+ThrowNullRef10:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %113
+ThrowNullRef12:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %116
+ThrowNullRef14:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %84
+ThrowNullRef16:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %87
+ThrowNullRef18:                                   ; preds = %87
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %55
+ThrowNullRef20:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %58
+ThrowNullRef22:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %26
+ThrowNullRef24:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %29
+ThrowNullRef26:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,8 +8161,8 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck, label %14, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %ThrowNullRef, label %14
 
 ; <label>:14                                      ; preds = %8
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
@@ -6760,8 +8206,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
@@ -6770,14 +8216,14 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32, i32* %loc0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %10
   %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
   %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
@@ -6790,15 +8236,15 @@ entry:
 ; <label>:25                                      ; preds = %19
   %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
-  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
   %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
@@ -6807,8 +8253,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %37 = load i32, i32* %loc0
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %38, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %38
 
 ; <label>:38                                      ; preds = %32
   %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
@@ -6817,14 +8263,14 @@ entry:
 
 ; <label>:40                                      ; preds = %19
   %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %40
   %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
   %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
-  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
-  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
@@ -6832,8 +8278,8 @@ entry:
   %48 = zext i32 %47 to i64
   %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
-  br i1 %NullCheck16, label %51, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %51
 
 ; <label>:51                                      ; preds = %45
   %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
@@ -6847,15 +8293,15 @@ entry:
 ; <label>:57                                      ; preds = %51
   %58 = load i16*, i16** %arg1
   %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
-  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %60
 
 ; <label>:60                                      ; preds = %57
   %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
   %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
-  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %64
 
 ; <label>:64                                      ; preds = %60
   %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
@@ -6864,22 +8310,22 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
   %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
-  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %70
 
 ; <label>:70                                      ; preds = %64
   %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
   %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
-  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
-  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
   %75 = load i32, i32 addrspace(1)* %74
   %76 = zext i32 %75 to i64
   %77 = trunc i64 %76 to i32
-  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
-  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %78
 
 ; <label>:78                                      ; preds = %73
   %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
@@ -6901,8 +8347,8 @@ entry:
   %90 = bitcast i16* %86 to i8*
   %91 = getelementptr inbounds i8, i8* %90, i64 %89
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %93
 
 ; <label>:93                                      ; preds = %80
   %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
@@ -6912,8 +8358,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %99 = load i32, i32* %loc2
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %100
 
 ; <label>:100                                     ; preds = %93
   %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
@@ -6928,63 +8374,63 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %25
+ThrowNullRef6:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %32
+ThrowNullRef10:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %40
+ThrowNullRef12:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %45
+ThrowNullRef16:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %57
+ThrowNullRef18:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %60
+ThrowNullRef20:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %64
+ThrowNullRef22:                                   ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %70
+ThrowNullRef24:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %73
+ThrowNullRef26:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %80
+ThrowNullRef28:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %93
+ThrowNullRef30:                                   ; preds = %93
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7004,8 +8450,8 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
@@ -7033,43 +8479,43 @@ entry:
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %14
   %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
   %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   %28 = load i32, i32 addrspace(1)* %27, align 8
   %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
-  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %30
 
 ; <label>:30                                      ; preds = %26
   %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
   %32 = load i32, i32 addrspace(1)* %31, align 8
   %33 = add i32 %28, %32
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %34
 
 ; <label>:34                                      ; preds = %30
   %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   store i32 %33, i32 addrspace(1)* %35
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
   store i32 0, i32 addrspace(1)* %38
   %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %40
 
 ; <label>:40                                      ; preds = %37
   %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
@@ -7082,8 +8528,8 @@ entry:
 
 ; <label>:47                                      ; preds = %40
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
@@ -7098,8 +8544,8 @@ entry:
   %54 = load i32, i32* %loc0
   %55 = sext i32 %54 to i64
   %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
-  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %57
 
 ; <label>:57                                      ; preds = %52
   %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
@@ -7110,68 +8556,35 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %14
+ThrowNullRef2:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %23
+ThrowNullRef4:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %26
+ThrowNullRef6:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %30
+ThrowNullRef8:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %34
+ThrowNullRef10:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %47
+ThrowNullRef14:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %52
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-}
-
-INFO:  jitting method StringBuilder::get_Length using LLILCJit
-Successfully read StringBuilder.get_Length
-
-define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.StringBuilder addrspace(1)*
-  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
-  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
-
-; <label>:1                                       ; preds = %entry
-  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %3 = load i32, i32 addrspace(1)* %2, align 8
-  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
-
-; <label>:5                                       ; preds = %1
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = add i32 %3, %7
-  ret i32 %8
-
-ThrowNullRef:                                     ; preds = %entry
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef16:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7213,70 +8626,70 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
   %6 = load i32, i32 addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
   store i32 %6, i32 addrspace(1)* %8
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
   %13 = load i32, i32 addrspace(1)* %12, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
   store i32 %13, i32 addrspace(1)* %15
   %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
-  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %18
 
 ; <label>:18                                      ; preds = %14
   %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
   %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
   %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
   %34 = load i32, i32 addrspace(1)* %33, align 8
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
-  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
@@ -7287,39 +8700,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %28
+ThrowNullRef16:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %32
+ThrowNullRef18:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7455,13 +8868,13 @@ entry:
 ; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
@@ -7477,16 +8890,16 @@ entry:
 
 ; <label>:18                                      ; preds = %15
   %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
   store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
   %22 = load i32, i32* %loc0
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %24
 
 ; <label>:24                                      ; preds = %20
   %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
@@ -7498,13 +8911,13 @@ entry:
 ; <label>:28                                      ; preds = %15, %24
   %29 = load i32, i32* %arg1
   %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %31
   %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
@@ -7517,20 +8930,20 @@ entry:
   %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
-  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
   %46 = load i32, i32 addrspace(1)* %45, align 8
   %47 = sub i32 %40, %46
-  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
-  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i32 addrspace(1)* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %48
 
 ; <label>:48                                      ; preds = %44
   store i32 %47, i32 addrspace(1)* %39, align 8
@@ -7538,21 +8951,21 @@ entry:
 
 ; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
-  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %51
 
 ; <label>:51                                      ; preds = %49
   %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %53
 
 ; <label>:53                                      ; preds = %51
   %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
   %55 = load i32, i32 addrspace(1)* %54, align 8
   %56 = load i32, i32* %arg2
   %57 = sub i32 %55, %56
-  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %58
 
 ; <label>:58                                      ; preds = %53
   %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
@@ -7562,13 +8975,13 @@ entry:
 ; <label>:60                                      ; preds = %33, %58
   %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
   %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
-  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %63
 
 ; <label>:63                                      ; preds = %60
   %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
-  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
-  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
@@ -7578,15 +8991,15 @@ entry:
 
 ; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
-  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i32 addrspace(1)* %69, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %70
 
 ; <label>:70                                      ; preds = %68
   %71 = load i32, i32 addrspace(1)* %69, align 8
   store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
-  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
@@ -7596,8 +9009,8 @@ entry:
   store i32 %77, i32* %loc4
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
-  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %80
 
 ; <label>:80                                      ; preds = %73
   %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
@@ -7607,71 +9020,71 @@ entry:
 ; <label>:83                                      ; preds = %80
   store i32 0, i32* %loc3
   %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
-  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
-  br i1 %NullCheck26, label %88, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i32 addrspace(1)* %87, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %88
 
 ; <label>:88                                      ; preds = %85
   %89 = load i32, i32 addrspace(1)* %87, align 8
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
-  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %90
 
 ; <label>:90                                      ; preds = %88
   %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
   store i32 %89, i32 addrspace(1)* %91
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
-  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
-  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %96
 
 ; <label>:96                                      ; preds = %94
   %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
-  br i1 %NullCheck34, label %100, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %100
 
 ; <label>:100                                     ; preds = %96
   %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
-  br i1 %NullCheck36, label %102, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %102
 
 ; <label>:102                                     ; preds = %100
   %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
   %104 = load i32, i32 addrspace(1)* %103, align 8
   %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
-  br i1 %NullCheck38, label %106, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %106
 
 ; <label>:106                                     ; preds = %102
   %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
-  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
-  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %108
 
 ; <label>:108                                     ; preds = %106
   %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
   %110 = load i32, i32 addrspace(1)* %109, align 8
   %111 = add i32 %104, %110
-  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %112
 
 ; <label>:112                                     ; preds = %108
   %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
   store i32 %111, i32 addrspace(1)* %113
   %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
-  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i32 addrspace(1)* %114, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %115
 
 ; <label>:115                                     ; preds = %112
   %116 = load i32, i32 addrspace(1)* %114, align 8
@@ -7681,19 +9094,19 @@ entry:
 ; <label>:118                                     ; preds = %115
   %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
-  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %121
 
 ; <label>:121                                     ; preds = %118
   %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
-  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
-  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %123
 
 ; <label>:123                                     ; preds = %121
   %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
   %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
-  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
-  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %126
 
 ; <label>:126                                     ; preds = %123
   %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
@@ -7705,8 +9118,8 @@ entry:
 
 ; <label>:130                                     ; preds = %80, %115, %126
   %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %132
 
 ; <label>:132                                     ; preds = %130
   %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7715,8 +9128,8 @@ entry:
   %136 = load i32, i32* %loc3
   %137 = sub i32 %135, %136
   %138 = sub i32 %134, %137
-  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %139
 
 ; <label>:139                                     ; preds = %132
   %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7728,16 +9141,16 @@ entry:
 
 ; <label>:144                                     ; preds = %139
   %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
-  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %146
 
 ; <label>:146                                     ; preds = %144
   %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
   %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
   %149 = load i32, i32* %loc2
   %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
-  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %151
 
 ; <label>:151                                     ; preds = %146
   %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
@@ -7754,145 +9167,249 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %18
+ThrowNullRef4:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %31
+ThrowNullRef10:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %44
+ThrowNullRef16:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %68
+ThrowNullRef18:                                   ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %70
+ThrowNullRef20:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %73
+ThrowNullRef22:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %83
+ThrowNullRef24:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %85
+ThrowNullRef26:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %88
+ThrowNullRef28:                                   ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %90
+ThrowNullRef30:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %94
+ThrowNullRef32:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %96
+ThrowNullRef34:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %100
+ThrowNullRef36:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %102
+ThrowNullRef38:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %106
+ThrowNullRef40:                                   ; preds = %106
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %108
+ThrowNullRef42:                                   ; preds = %108
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %112
+ThrowNullRef44:                                   ; preds = %112
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %118
+ThrowNullRef46:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %121
+ThrowNullRef48:                                   ; preds = %121
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %123
+ThrowNullRef50:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %130
+ThrowNullRef52:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %132
+ThrowNullRef54:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %144
+ThrowNullRef56:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %146
+ThrowNullRef58:                                   ; preds = %146
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %60
+ThrowNullRef60:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %63
+ThrowNullRef62:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %49
+ThrowNullRef64:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %51
+ThrowNullRef66:                                   ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %53
+ThrowNullRef68:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(%"System.Char[]" addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %arg0 = alloca %"System.Char[]" addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store %"System.Char[]" addrspace(1)* %param0, %"System.Char[]" addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load i32, i32* %arg4
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %43, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %38, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg1
+  %13 = load i32, i32* %arg4
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %38, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %24 = load i32, i32* %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %35 = load i32, i32* %arg3
+  %36 = load i32, i32* %arg4
+  %37 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %37, %"System.Char[]" addrspace(1)* %34, i32 %35, i32 %36)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:38                                      ; preds = %5, %16
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Successfully read Buffer._Memmove
 
@@ -7914,7 +9431,7 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[loadElem]
+Failed to read AppDomain.SetDataHelper[storeElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -7923,8 +9440,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
@@ -7934,8 +9451,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
@@ -7947,15 +9464,15 @@ entry:
   %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
   %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
@@ -7966,15 +9483,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7992,7 +9509,79 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
-Failed to read Dictionary`2.TryGetValue[loadElemA]
+Successfully read Dictionary`2.TryGetValue
+
+define i8 @"Dictionary`2.TryGetValue"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)* addrspace(1)* %param2) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  %arg2 = alloca %System.__Canon addrspace(1)* addrspace(1)*
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  store %System.__Canon addrspace(1)* addrspace(1)* %param2, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  store i32 %2, i32* %loc0
+  %3 = load i32, i32* %loc0
+  %4 = icmp slt i32 %3, 0
+  br i1 %4, label %22, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 2
+  %10 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %9, align 8
+  %11 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = zext i32 %11 to i64
+  %BoundsCheck = icmp uge i64 %16, %15
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 3, i32 %11
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %20, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %6, %System.__Canon addrspace(1)* %21)
+  ret i8 1
+
+; <label>:22                                      ; preds = %entry
+  %23 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %23, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -8058,8 +9647,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
@@ -8091,8 +9680,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
@@ -8171,15 +9760,15 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck, label %19, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %ThrowNullRef, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
   %21 = load i32, i32 addrspace(1)* %20
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
@@ -8202,7 +9791,7 @@ ThrowNullRef:                                     ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %19
+ThrowNullRef2:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8248,8 +9837,8 @@ entry:
   %0 = alloca %System.AppDomainHandle
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %1 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %1, i32 0, i32 15
@@ -8269,8 +9858,8 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
@@ -8286,7 +9875,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -8299,8 +9888,8 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -8327,8 +9916,8 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
@@ -8352,8 +9941,8 @@ entry:
   %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
   store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
@@ -8363,8 +9952,8 @@ entry:
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
@@ -8374,8 +9963,8 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %9
   %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
@@ -8384,8 +9973,8 @@ entry:
 
 ; <label>:18                                      ; preds = %3, %16
   %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
@@ -8397,15 +9986,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %18
+ThrowNullRef6:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8418,8 +10007,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
@@ -8453,15 +10042,15 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
@@ -8473,7 +10062,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8481,7 +10070,7 @@ ThrowNullRef1:                                    ; preds = %1
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
 Failed to read Dictionary`2.System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
@@ -8506,8 +10095,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
@@ -8524,8 +10113,8 @@ entry:
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -8544,7 +10133,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8577,8 +10166,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = load i64, i64* %arg2
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = trunc i32 %3 to i8
@@ -8634,46 +10223,46 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
   %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
-  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
-  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
-  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
@@ -8684,27 +10273,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %20
+ThrowNullRef12:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8717,8 +10306,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -8756,22 +10345,22 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
   %9 = load i64, i64 addrspace(1)* %8, align 8
   %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
   %13 = load i64, i64 addrspace(1)* %12, align 8
   %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %11
   %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
@@ -8788,11 +10377,11 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8882,8 +10471,8 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
@@ -8900,8 +10489,8 @@ entry:
 ; <label>:8                                       ; preds = %1
   %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
   %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
@@ -8911,15 +10500,15 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
   %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
   %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
-  br i1 %NullCheck6, label %21, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
@@ -8946,15 +10535,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8992,15 +10581,15 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
   store i8 %3, i8 addrspace(1)* %5
   %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
@@ -9011,7 +10600,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9027,8 +10616,8 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -9041,8 +10630,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
@@ -9058,7 +10647,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9080,8 +10669,8 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
@@ -9096,8 +10685,8 @@ entry:
 ; <label>:12                                      ; preds = %6
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
@@ -9112,8 +10701,8 @@ entry:
 ; <label>:21                                      ; preds = %15
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
@@ -9128,8 +10717,8 @@ entry:
 ; <label>:30                                      ; preds = %24
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %31, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
@@ -9144,8 +10733,8 @@ entry:
 ; <label>:39                                      ; preds = %33
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
-  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %40, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %42
 
 ; <label>:42                                      ; preds = %39
   %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
@@ -9164,19 +10753,19 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %21
+ThrowNullRef4:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %30
+ThrowNullRef6:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %39
+ThrowNullRef8:                                    ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9243,8 +10832,8 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
@@ -9264,57 +10853,57 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
   store i8 0, i8 addrspace(1)* %2
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
   store i8 0, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
   store i8 0, i8 addrspace(1)* %17
   %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
   store i8 0, i8 addrspace(1)* %20
   %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
-  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
@@ -9325,31 +10914,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %19
+ThrowNullRef14:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9367,8 +10956,8 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
@@ -9380,8 +10969,8 @@ entry:
 
 ; <label>:9                                       ; preds = %4
   %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %9
   %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
@@ -9395,7 +10984,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef2:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9420,8 +11009,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
@@ -9512,8 +11101,8 @@ entry:
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
@@ -9524,8 +11113,8 @@ entry:
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = load i64, i64 addrspace(1)* %12
@@ -9537,8 +11126,8 @@ entry:
   %20 = load i64, i64* %19
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
-  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %13
   %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
@@ -9555,8 +11144,8 @@ entry:
 ; <label>:30                                      ; preds = %25
   %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %32 = load i32, i32* %arg2
-  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
-  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
@@ -9570,15 +11159,15 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %30
+ThrowNullRef2:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9622,87 +11211,87 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
   %10 = load i8, i8 addrspace(1)* %9, align 8
   %11 = zext i8 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %8
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
   store i8 %12, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
   %19 = load i8, i8 addrspace(1)* %18, align 8
   %20 = zext i8 %19 to i32
   %21 = trunc i32 %20 to i8
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
   store i8 %21, i8 addrspace(1)* %23
   %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
   %28 = load i8, i8 addrspace(1)* %27, align 8
   %29 = zext i8 %28 to i32
   %30 = trunc i32 %29 to i8
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
-  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %31
 
 ; <label>:31                                      ; preds = %26
   %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
   store i8 %30, i8 addrspace(1)* %32
   %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
-  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
-  br i1 %NullCheck14, label %40, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %40
 
 ; <label>:40                                      ; preds = %35
   %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
   store i8 %39, i8 addrspace(1)* %41
   %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
-  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %44
 
 ; <label>:44                                      ; preds = %40
   %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
   %46 = load i8, i8 addrspace(1)* %45, align 8
   %47 = zext i8 %46 to i32
   %48 = trunc i32 %47 to i8
-  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
   store i8 %48, i8 addrspace(1)* %50
   %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
-  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
@@ -9713,29 +11302,29 @@ entry:
 ; <label>:56                                      ; preds = %52
   %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
-  br i1 %NullCheck22, label %59, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
   %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
   %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
-  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
-  br i1 %NullCheck24, label %63, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
   %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
-  br i1 %NullCheck26, label %66, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
   %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
-  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
-  br i1 %NullCheck28, label %69, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %69
 
 ; <label>:69                                      ; preds = %66
   %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
@@ -9744,15 +11333,15 @@ entry:
 
 ; <label>:71                                      ; preds = %105
   %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
-  br i1 %NullCheck34, label %73, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %73
 
 ; <label>:73                                      ; preds = %71
   %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
   %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
   %76 = load i32, i32* %loc0
-  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
-  br i1 %NullCheck36, label %77, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
@@ -9766,8 +11355,8 @@ entry:
 
 ; <label>:83                                      ; preds = %77
   %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
-  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
@@ -9775,14 +11364,14 @@ entry:
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
   %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
-  br i1 %NullCheck40, label %91, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
 ; <label>:91                                      ; preds = %85
   %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
   %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
-  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck42, label %94, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %94
 
 ; <label>:94                                      ; preds = %91
   %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
@@ -9798,14 +11387,14 @@ entry:
 ; <label>:99                                      ; preds = %69, %96
   %100 = load i32, i32* %loc0
   %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
-  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %102
 
 ; <label>:102                                     ; preds = %99
   %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
   %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
-  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
-  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
@@ -9819,87 +11408,87 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %26
+ThrowNullRef10:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %31
+ThrowNullRef12:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %35
+ThrowNullRef14:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %40
+ThrowNullRef16:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %56
+ThrowNullRef22:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %59
+ThrowNullRef24:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %63
+ThrowNullRef26:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %66
+ThrowNullRef28:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %102
+ThrowNullRef32:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %71
+ThrowNullRef34:                                   ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %73
+ThrowNullRef36:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %83
+ThrowNullRef38:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %85
+ThrowNullRef40:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %91
+ThrowNullRef42:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9943,15 +11532,15 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
   %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
@@ -9961,28 +11550,28 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
   %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %12
   %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
   %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
   %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
-  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
@@ -9993,23 +11582,23 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %12
+ThrowNullRef6:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10031,15 +11620,15 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
   %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = load i64, i64 addrspace(1)* %7
@@ -10077,13 +11666,13 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[loadElem]
+Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -10111,8 +11700,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -10178,8 +11767,8 @@ entry:
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load double, double* %arg0
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -10313,8 +11902,8 @@ entry:
   store i64 %param0, i64* %arg0
   store i64 %param1, i64* %arg1
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
@@ -10322,8 +11911,8 @@ entry:
   %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
   %5 = load i16*, i16* addrspace(1)* %4, align 8
   %6 = addrspacecast i64* %arg1 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = bitcast i64 addrspace(1)* %6 to i8 addrspace(1)*
@@ -10339,7 +11928,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10373,8 +11962,8 @@ entry:
   %1 = load i32, i32* %arg1
   %2 = sext i32 %1 to i64
   %3 = inttoptr i64 %2 to i16*
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -10427,8 +12016,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, i32)*)(%System.IO.ConsoleStream addrspace(1)* %2, i32 %1)
   %3 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %4 = load i64, i64* %arg1
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
@@ -10439,8 +12028,8 @@ entry:
   %10 = icmp eq i32 %9, 3
   %11 = sext i1 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %5
   %14 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, i32 0, i32 5
@@ -10451,7 +12040,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10474,8 +12063,8 @@ entry:
   %5 = icmp eq i32 %4, 1
   %6 = sext i1 %5 to i32
   %7 = trunc i32 %6 to i8
-  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %2, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.ConsoleStream addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
@@ -10486,8 +12075,8 @@ entry:
   %13 = icmp eq i32 %12, 2
   %14 = sext i1 %13 to i32
   %15 = trunc i32 %14 to i8
-  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %10, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.ConsoleStream addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %8
   %17 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %10, i32 0, i32 4
@@ -10498,7 +12087,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10537,8 +12126,8 @@ entry:
   %arg0 = alloca i64
   store i64 %param0, i64* %arg0
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
@@ -10573,8 +12162,8 @@ entry:
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
   %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = load i64, i64 addrspace(1)* %7
@@ -10678,7 +12267,127 @@ entry:
 INFO:  jitting method Encoding::GetEncoding using LLILCJit
 Failed to read Encoding.GetEncoding[convertToHelperArgumentType]
 INFO:  jitting method EncodingProvider::GetEncodingFromProvider using LLILCJit
-Failed to read EncodingProvider.GetEncodingFromProvider[loadElem]
+Successfully read EncodingProvider.GetEncodingFromProvider
+
+define %System.Text.Encoding addrspace(1)* @EncodingProvider.GetEncodingFromProvider(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca %"System.Text.EncodingProvider[]" addrspace(1)*
+  %loc1 = alloca %System.Text.EncodingProvider addrspace(1)*
+  %loc2 = alloca %System.Text.Encoding addrspace(1)*
+  %loc3 = alloca %System.Text.Encoding addrspace(1)*
+  %loc4 = alloca %"System.Text.EncodingProvider[]" addrspace(1)*
+  %loc5 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1059)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2392
+  %2 = addrspacecast i8 addrspace(1)* %1 to %"System.Text.EncodingProvider[]" addrspace(1)**
+  %3 = load volatile %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %2
+  %4 = icmp ne %"System.Text.EncodingProvider[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %entry
+  ret %System.Text.Encoding addrspace(1)* null
+
+; <label>:6                                       ; preds = %entry
+  %7 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1059)
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i64 2392
+  %9 = addrspacecast i8 addrspace(1)* %8 to %"System.Text.EncodingProvider[]" addrspace(1)**
+  %10 = load volatile %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %9
+  store %"System.Text.EncodingProvider[]" addrspace(1)* %10, %"System.Text.EncodingProvider[]" addrspace(1)** %loc0
+  %11 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc0
+  store %"System.Text.EncodingProvider[]" addrspace(1)* %11, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  store i32 0, i32* %loc5
+  br label %43
+
+; <label>:12                                      ; preds = %46
+  %13 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  %14 = load i32, i32* %loc5
+  %NullCheck1 = icmp eq %"System.Text.EncodingProvider[]" addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %13, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = zext i32 %17 to i64
+  %19 = zext i32 %14 to i64
+  %BoundsCheck = icmp uge i64 %19, %18
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %20
+
+; <label>:20                                      ; preds = %15
+  %21 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %13, i32 0, i32 3, i32 %14
+  %22 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)* addrspace(1)* %21, align 8
+  store %System.Text.EncodingProvider addrspace(1)* %22, %System.Text.EncodingProvider addrspace(1)** %loc1
+  %23 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)** %loc1
+  %24 = load i32, i32* %arg0
+  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i64 addrspace(1)*
+  %NullCheck3 = icmp eq i64 addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
+
+; <label>:26                                      ; preds = %20
+  %27 = load i64, i64 addrspace(1)* %25
+  %28 = add i64 %27, 64
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 40
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Text.Encoding addrspace(1)* (%System.Text.EncodingProvider addrspace(1)*, i32)*
+  %35 = call %System.Text.Encoding addrspace(1)* %34(%System.Text.EncodingProvider addrspace(1)* %23, i32 %24)
+  store %System.Text.Encoding addrspace(1)* %35, %System.Text.Encoding addrspace(1)** %loc2
+  %36 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc2
+  %37 = icmp eq %System.Text.Encoding addrspace(1)* %36, null
+  br i1 %37, label %40, label %38
+
+; <label>:38                                      ; preds = %26
+  %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc2
+  store %System.Text.Encoding addrspace(1)* %39, %System.Text.Encoding addrspace(1)** %loc3
+  br label %53
+
+; <label>:40                                      ; preds = %26
+  %41 = load i32, i32* %loc5
+  %42 = add i32 %41, 1
+  store i32 %42, i32* %loc5
+  br label %43
+
+; <label>:43                                      ; preds = %6, %40
+  %44 = load i32, i32* %loc5
+  %45 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  %NullCheck = icmp eq %"System.Text.EncodingProvider[]" addrspace(1)* %45, null
+  br i1 %NullCheck, label %ThrowNullRef, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp slt i32 %44, %50
+  br i1 %51, label %12, label %52
+
+; <label>:52                                      ; preds = %46
+  ret %System.Text.Encoding addrspace(1)* null
+
+; <label>:53                                      ; preds = %38
+  %54 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc3
+  ret %System.Text.Encoding addrspace(1)* %54
+
+ThrowNullRef:                                     ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method EncodingProvider::.cctor using LLILCJit
 Successfully read EncodingProvider..cctor
 
@@ -10697,7 +12406,7 @@ Failed to read Encoding.get_InternalSyncObject[Call HasTypeArg]
 INFO:  jitting method Hashtable::.ctor using LLILCJit
 Failed to read Hashtable..ctor[Volatile store]
 INFO:  jitting method Hashtable::get_Item using LLILCJit
-Failed to read Hashtable.get_Item[loadElemA]
+Failed to read Hashtable.get_Item[loadNonPrimitiveObj]
 INFO:  jitting method Hashtable::InitHash using LLILCJit
 Successfully read Hashtable.InitHash
 
@@ -10717,8 +12426,8 @@ entry:
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -10734,15 +12443,15 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
   %15 = load i32, i32* %loc0
-  %NullCheck2 = icmp ne i32 addrspace(1)* %14, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i32 addrspace(1)* %14, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %3
   store i32 %15, i32 addrspace(1)* %14, align 8
   %17 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %18 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %NullCheck4 = icmp ne i32 addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i32 addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = load i32, i32 addrspace(1)* %18, align 8
@@ -10751,8 +12460,8 @@ entry:
   %23 = sub i32 %22, 1
   %24 = urem i32 %21, %23
   %25 = add i32 1, %24
-  %NullCheck6 = icmp ne i32 addrspace(1)* %17, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32 addrspace(1)* %17, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %19
   store i32 %25, i32 addrspace(1)* %17, align 8
@@ -10763,15 +12472,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %19
+ThrowNullRef6:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10786,8 +12495,8 @@ entry:
   store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
   store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %NullCheck = icmp ne %System.Collections.Hashtable addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Collections.Hashtable addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
@@ -10797,16 +12506,16 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Collections.Hashtable addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Collections.Hashtable addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
   %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck4 = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %9, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
   %13 = inttoptr i64 %11 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
@@ -10816,8 +12525,8 @@ entry:
 ; <label>:15                                      ; preds = %1
   %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -10835,15 +12544,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10857,8 +12566,8 @@ entry:
   store %System.Int32 addrspace(1)* %param0, %System.Int32 addrspace(1)** %this
   %0 = load %System.Int32 addrspace(1)*, %System.Int32 addrspace(1)** %this
   %1 = bitcast %System.Int32 addrspace(1)* %0 to i32 addrspace(1)*
-  %NullCheck = icmp ne i32 addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq i32 addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load i32, i32 addrspace(1)* %1, align 8
@@ -10934,8 +12643,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.UTF8Encoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
@@ -10944,15 +12653,15 @@ entry:
   %9 = load i8, i8* %arg2
   %10 = zext i8 %9 to i32
   %11 = trunc i32 %10 to i8
-  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %8, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %6
   %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %8, i32 0, i32 8
   store i8 %11, i8 addrspace(1)* %13
   %14 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %14, i32 0, i32 8
@@ -10964,8 +12673,8 @@ entry:
 ; <label>:20                                      ; preds = %15
   %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %22, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %22, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = load i64, i64 addrspace(1)* %22
@@ -10987,15 +12696,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %12
+ThrowNullRef4:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11010,8 +12719,8 @@ entry:
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
@@ -11033,16 +12742,16 @@ entry:
 ; <label>:10                                      ; preds = %1
   %11 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
   %12 = load i32, i32* %arg1
-  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %11, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.Encoding addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
   store i32 %12, i32 addrspace(1)* %14
   %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
   %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = load i64, i64 addrspace(1)* %16
@@ -11060,11 +12769,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11077,8 +12786,8 @@ entry:
   %this = alloca %System.Text.UTF8Encoding addrspace(1)*
   store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
   %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.UTF8Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
@@ -11090,16 +12799,16 @@ entry:
 ; <label>:6                                       ; preds = %1
   %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %8 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %10, %System.Text.EncoderFallback addrspace(1)* %8)
   %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %12 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
-  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %11, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %11, i32 0, i32 3
@@ -11112,8 +12821,8 @@ entry:
   %18 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %18, %System.String addrspace(1)* %17)
   %19 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %18 to %System.Text.EncoderFallback addrspace(1)*
-  %NullCheck6 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %16, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %16, i32 0, i32 2
@@ -11123,8 +12832,8 @@ entry:
   %24 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %24, %System.String addrspace(1)* %23)
   %25 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %24 to %System.Text.DecoderFallback addrspace(1)*
-  %NullCheck8 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %22, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %22, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %20
   %27 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %22, i32 0, i32 3
@@ -11135,19 +12844,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %20
+ThrowNullRef8:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11177,8 +12886,8 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load i32, i32* %arg1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -11196,8 +12905,8 @@ entry:
 ; <label>:15                                      ; preds = %8
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %17 = load i32, i32* %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 %17
@@ -11213,7 +12922,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11265,7 +12974,7 @@ entry:
 }
 
 INFO:  jitting method Hashtable::Insert using LLILCJit
-Failed to read Hashtable.Insert[loadElemA]
+Failed to read Hashtable.Insert[storeElem]
 INFO:  jitting method ConsoleEncoding::.ctor using LLILCJit
 Successfully read ConsoleEncoding..ctor
 
@@ -11280,8 +12989,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %1)
   %2 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
@@ -11317,8 +13026,8 @@ entry:
   %2 = call %System.Text.InternalEncoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalEncoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %1)
   %3 = bitcast %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2 to %System.Text.EncoderFallback addrspace(1)*
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
@@ -11328,8 +13037,8 @@ entry:
   %8 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %7)
   %9 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %8 to %System.Text.DecoderFallback addrspace(1)*
-  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %6, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.Encoding addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %4
   %11 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %6, i32 0, i32 3
@@ -11340,7 +13049,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11359,15 +13068,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* %1)
   %2 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   %6 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, i32 0, i32 1
@@ -11378,7 +13087,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11406,8 +13115,8 @@ entry:
   store %System.Text.InternalDecoderBestFitFallback addrspace(1)* %param0, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
   %0 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
@@ -11417,15 +13126,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %4)
   %5 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %6)
   %9 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, i32 0, i32 1
@@ -11436,11 +13145,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11508,8 +13217,8 @@ entry:
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
   %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = load i64, i64 addrspace(1)* %19
@@ -11573,8 +13282,8 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.ConsoleStream addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
@@ -11605,31 +13314,31 @@ entry:
   store i8 %param4, i8* %arg4
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %3, %System.IO.Stream addrspace(1)* %1)
   %4 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %4, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
   %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %4, i32 0, i32 4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %5)
   %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %6
   %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
   %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
   %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = load i64, i64 addrspace(1)* %13
@@ -11641,8 +13350,8 @@ entry:
   %21 = load i64, i64* %20
   %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %8, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %8, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %14
   %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 5
@@ -11660,24 +13369,24 @@ entry:
   %31 = load i32, i32* %arg3
   %32 = sext i32 %31 to i64
   %33 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %32)
-  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %30, null
-  br i1 %NullCheck10, label %34, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.StreamWriter addrspace(1)* %30, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %35, %"System.Char[]" addrspace(1)* %33)
   %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %37, null
-  br i1 %NullCheck12, label %38, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.StreamWriter addrspace(1)* %37, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %38
 
 ; <label>:38                                      ; preds = %34
   %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
   %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
   %41 = load i32, i32* %arg3
   %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %42, null
-  br i1 %NullCheck14, label %43, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %42, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
   %44 = load i64, i64 addrspace(1)* %42
@@ -11691,30 +13400,30 @@ entry:
   %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
   %53 = sext i32 %52 to i64
   %54 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %53)
-  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
-  br i1 %NullCheck16, label %55, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %55
 
 ; <label>:55                                      ; preds = %43
   %56 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %56, %"System.Byte[]" addrspace(1)* %54)
   %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %58 = load i32, i32* %arg3
-  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %57, null
-  br i1 %NullCheck18, label %59, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.StreamWriter addrspace(1)* %57, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %59
 
 ; <label>:59                                      ; preds = %55
   %60 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 10
   store i32 %58, i32 addrspace(1)* %60
   %61 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %61, null
-  br i1 %NullCheck20, label %62, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.IO.StreamWriter addrspace(1)* %61, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %62
 
 ; <label>:62                                      ; preds = %59
   %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
   %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
   %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
   %67 = load i64, i64 addrspace(1)* %65
@@ -11732,15 +13441,15 @@ entry:
 
 ; <label>:78                                      ; preds = %66
   %79 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %79, null
-  br i1 %NullCheck24, label %80, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.StreamWriter addrspace(1)* %79, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %80
 
 ; <label>:80                                      ; preds = %78
   %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
   %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
   %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %83, null
-  br i1 %NullCheck26, label %84, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %83, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
   %85 = load i64, i64 addrspace(1)* %83
@@ -11757,8 +13466,8 @@ entry:
 
 ; <label>:95                                      ; preds = %84
   %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.IO.StreamWriter addrspace(1)* %96, null
-  br i1 %NullCheck28, label %97, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.IO.StreamWriter addrspace(1)* %96, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %97
 
 ; <label>:97                                      ; preds = %95
   %98 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 12
@@ -11772,8 +13481,8 @@ entry:
   %103 = icmp eq i32 %102, 0
   %104 = sext i1 %103 to i32
   %105 = trunc i32 %104 to i8
-  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %100, null
-  br i1 %NullCheck30, label %106, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.IO.StreamWriter addrspace(1)* %100, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %106
 
 ; <label>:106                                     ; preds = %99
   %107 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %100, i32 0, i32 13
@@ -11784,63 +13493,63 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %6
+ThrowNullRef4:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %29
+ThrowNullRef10:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %34
+ThrowNullRef12:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %38
+ThrowNullRef14:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %43
+ThrowNullRef16:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %55
+ThrowNullRef18:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %59
+ThrowNullRef20:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %62
+ThrowNullRef22:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %78
+ThrowNullRef24:                                   ; preds = %78
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %80
+ThrowNullRef26:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %95
+ThrowNullRef28:                                   ; preds = %95
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11853,15 +13562,15 @@ entry:
   %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = load i64, i64 addrspace(1)* %4
@@ -11879,7 +13588,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11929,35 +13638,35 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
   %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderNLS addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %7 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.EncoderNLS addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Text.Encoding addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.Encoding addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Text.EncoderNLS addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.EncoderNLS addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
   %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck8 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = load i64, i64 addrspace(1)* %16
@@ -11976,19 +13685,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12014,8 +13723,8 @@ entry:
   %this = alloca %System.Text.Encoding addrspace(1)*
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
@@ -12035,15 +13744,15 @@ entry:
   %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
   store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
   %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
   store i32 0, i32 addrspace(1)* %2
   %3 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, i32 0, i32 2
@@ -12053,15 +13762,15 @@ entry:
 
 ; <label>:8                                       ; preds = %4
   %9 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
   %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
   %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = load i64, i64 addrspace(1)* %13
@@ -12082,15 +13791,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12105,16 +13814,16 @@ entry:
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = load i32, i32* %arg1
   %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
   %7 = load i64, i64 addrspace(1)* %5
@@ -12132,7 +13841,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12169,8 +13878,8 @@ entry:
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
   %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
   %16 = load i64, i64 addrspace(1)* %14
@@ -12191,8 +13900,8 @@ entry:
   %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
   %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
   %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %31, null
-  br i1 %NullCheck2, label %32, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = load i64, i64 addrspace(1)* %31
@@ -12235,7 +13944,7 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12248,14 +13957,14 @@ entry:
   %this = alloca %System.Text.EncoderReplacementFallback addrspace(1)*
   store %System.Text.EncoderReplacementFallback addrspace(1)* %param0, %System.Text.EncoderReplacementFallback addrspace(1)** %this
   %0 = load %System.Text.EncoderReplacementFallback addrspace(1)*, %System.Text.EncoderReplacementFallback addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -12266,7 +13975,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12296,8 +14005,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
@@ -12329,8 +14038,8 @@ entry:
   %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
   store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
@@ -12342,8 +14051,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Threading.Tasks.Task addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %7)
@@ -12366,7 +14075,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12385,8 +14094,8 @@ entry:
   store i8 %param1, i8* %arg1
   store i8 %param2, i8* %arg2
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
@@ -12400,8 +14109,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1, %5
   %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 9
@@ -12432,8 +14141,8 @@ entry:
 
 ; <label>:25                                      ; preds = %8, %20
   %26 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %26, null
-  br i1 %NullCheck4, label %27, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %26, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %26, i32 0, i32 12
@@ -12444,22 +14153,22 @@ entry:
 
 ; <label>:32                                      ; preds = %27
   %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %33, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.IO.StreamWriter addrspace(1)* %33, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %32
   %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 12
   store i8 1, i8 addrspace(1)* %35
   %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
-  br i1 %NullCheck8, label %37, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
   %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
   %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck10 = icmp ne i64 addrspace(1)* %40, null
-  br i1 %NullCheck10, label %41, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64 addrspace(1)* %40, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i64, i64 addrspace(1)* %40
@@ -12473,8 +14182,8 @@ entry:
   %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
   store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
   %51 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %NullCheck12 = icmp ne %"System.Byte[]" addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Byte[]" addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %41
   %53 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %51, i32 0, i32 1
@@ -12486,16 +14195,16 @@ entry:
 
 ; <label>:58                                      ; preds = %52
   %59 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %59, null
-  br i1 %NullCheck14, label %60, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.IO.StreamWriter addrspace(1)* %59, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %60
 
 ; <label>:60                                      ; preds = %58
   %61 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %59, i32 0, i32 3
   %62 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
   %64 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %NullCheck16 = icmp ne %"System.Byte[]" addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %"System.Byte[]" addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %60
   %66 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %64, i32 0, i32 1
@@ -12503,8 +14212,8 @@ entry:
   %68 = zext i32 %67 to i64
   %69 = trunc i64 %68 to i32
   %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck18, label %71, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
   %72 = load i64, i64 addrspace(1)* %70
@@ -12520,29 +14229,29 @@ entry:
 
 ; <label>:80                                      ; preds = %27, %52, %71
   %81 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %81, null
-  br i1 %NullCheck20, label %82, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.IO.StreamWriter addrspace(1)* %81, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
 
 ; <label>:82                                      ; preds = %80
   %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %81, i32 0, i32 5
   %84 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %83, align 8
   %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.IO.StreamWriter addrspace(1)* %85, null
-  br i1 %NullCheck22, label %86, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.IO.StreamWriter addrspace(1)* %85, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %86
 
 ; <label>:86                                      ; preds = %82
   %87 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 7
   %88 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %87, align 8
   %89 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %89, null
-  br i1 %NullCheck24, label %90, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.StreamWriter addrspace(1)* %89, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %90
 
 ; <label>:90                                      ; preds = %86
   %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %89, i32 0, i32 9
   %92 = load i32, i32 addrspace(1)* %91, align 8
   %93 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.IO.StreamWriter addrspace(1)* %93, null
-  br i1 %NullCheck26, label %94, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.IO.StreamWriter addrspace(1)* %93, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %93, i32 0, i32 6
@@ -12550,8 +14259,8 @@ entry:
   %97 = load i8, i8* %arg2
   %98 = zext i8 %97 to i32
   %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
-  %NullCheck28 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck28, label %100, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
   %101 = load i64, i64 addrspace(1)* %99
@@ -12566,8 +14275,8 @@ entry:
   %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
   store i32 %110, i32* %loc1
   %111 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %111, null
-  br i1 %NullCheck30, label %112, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.IO.StreamWriter addrspace(1)* %111, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %112
 
 ; <label>:112                                     ; preds = %100
   %113 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %111, i32 0, i32 9
@@ -12578,23 +14287,23 @@ entry:
 
 ; <label>:116                                     ; preds = %112
   %117 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck32 = icmp ne %System.IO.StreamWriter addrspace(1)* %117, null
-  br i1 %NullCheck32, label %118, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.IO.StreamWriter addrspace(1)* %117, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %118
 
 ; <label>:118                                     ; preds = %116
   %119 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %117, i32 0, i32 3
   %120 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %119, align 8
   %121 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.IO.StreamWriter addrspace(1)* %121, null
-  br i1 %NullCheck34, label %122, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.IO.StreamWriter addrspace(1)* %121, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %122
 
 ; <label>:122                                     ; preds = %118
   %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
   %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
   %125 = load i32, i32* %loc1
   %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
-  %NullCheck36 = icmp ne i64 addrspace(1)* %126, null
-  br i1 %NullCheck36, label %127, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64 addrspace(1)* %126, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
   %128 = load i64, i64 addrspace(1)* %126
@@ -12616,15 +14325,15 @@ entry:
 
 ; <label>:140                                     ; preds = %136
   %141 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.IO.StreamWriter addrspace(1)* %141, null
-  br i1 %NullCheck38, label %142, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.IO.StreamWriter addrspace(1)* %141, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %142
 
 ; <label>:142                                     ; preds = %140
   %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
   %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
   %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
-  %NullCheck40 = icmp ne i64 addrspace(1)* %145, null
-  br i1 %NullCheck40, label %146, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i64 addrspace(1)* %145, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
   %147 = load i64, i64 addrspace(1)* %145
@@ -12645,83 +14354,83 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %25
+ThrowNullRef4:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %32
+ThrowNullRef6:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %37
+ThrowNullRef10:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %41
+ThrowNullRef12:                                   ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %58
+ThrowNullRef14:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %60
+ThrowNullRef16:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %65
+ThrowNullRef18:                                   ; preds = %65
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %80
+ThrowNullRef20:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %82
+ThrowNullRef22:                                   ; preds = %82
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %86
+ThrowNullRef24:                                   ; preds = %86
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %90
+ThrowNullRef26:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %94
+ThrowNullRef28:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %100
+ThrowNullRef30:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %116
+ThrowNullRef32:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %118
+ThrowNullRef34:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %122
+ThrowNullRef36:                                   ; preds = %122
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %140
+ThrowNullRef38:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %142
+ThrowNullRef40:                                   ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12788,8 +14497,8 @@ entry:
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %1 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
-  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
@@ -12797,8 +14506,8 @@ entry:
   %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
   %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
   %8 = load i64, i64 addrspace(1)* %6
@@ -12814,8 +14523,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %17, %System.IFormatProvider addrspace(1)* %16)
   %18 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %19 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %18, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.SyncTextWriter addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %7
   %21 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %18, i32 0, i32 4
@@ -12826,11 +14535,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12843,8 +14552,8 @@ entry:
   %this = alloca %System.IO.TextWriter addrspace(1)*
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.TextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
@@ -12854,8 +14563,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.Threading.Thread addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Threading.Thread addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %6)
@@ -12864,8 +14573,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1
   %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.TextWriter addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.TextWriter addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %11, i32 0, i32 2
@@ -12876,11 +14585,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13077,8 +14786,8 @@ entry:
   store double %param1, double* %arg1
   store i8 0, i8* %loc1
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
@@ -13088,16 +14797,16 @@ entry:
   %5 = addrspacecast i8* %loc1 to i8 addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %4, i8 addrspace(1)* %5)
   %6 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.SyncTextWriter addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
   %10 = load double, double* %arg1
   %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
   %13 = load i64, i64 addrspace(1)* %11
@@ -13132,11 +14841,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13153,8 +14862,8 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load double, double* %arg1
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -13168,8 +14877,8 @@ entry:
   call void %11(%System.IO.TextWriter addrspace(1)* %0, double %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
   %15 = load i64, i64 addrspace(1)* %13
@@ -13187,7 +14896,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13205,8 +14914,8 @@ entry:
   %1 = addrspacecast double* %arg1 to double addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -13221,8 +14930,8 @@ entry:
   %14 = bitcast double addrspace(1)* %1 to %System.Double addrspace(1)*
   %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Double addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Double addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
   %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
   %18 = load i64, i64 addrspace(1)* %16
@@ -13240,7 +14949,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13256,8 +14965,8 @@ entry:
   store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
   %0 = load %System.Double addrspace(1)*, %System.Double addrspace(1)** %this
   %1 = bitcast %System.Double addrspace(1)* %0 to double addrspace(1)*
-  %NullCheck = icmp ne double addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq double addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load double, double addrspace(1)* %1, align 8
@@ -13282,8 +14991,8 @@ entry:
   %loc0 = alloca %System.Globalization.NumberFormatInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 3
@@ -13293,8 +15002,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
@@ -13304,24 +15013,24 @@ entry:
   store %System.Globalization.NumberFormatInfo addrspace(1)* %10, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
   %11 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %7
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
   %15 = load i8, i8 addrspace(1)* %14, align 8
   %16 = zext i8 %15 to i32
   %17 = trunc i32 %16 to i8
-  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %11, null
-  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %11, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %13
   %19 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %11, i32 0, i32 29
   store i8 %17, i8 addrspace(1)* %19
   %20 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %21 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %20, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %20, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %18
   %23 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %20, i32 0, i32 3
@@ -13330,8 +15039,8 @@ entry:
 
 ; <label>:24                                      ; preds = %1, %22
   %25 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %25, null
-  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %25, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %26
 
 ; <label>:26                                      ; preds = %24
   %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %25, i32 0, i32 3
@@ -13342,23 +15051,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %18
+ThrowNullRef8:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13383,168 +15092,168 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 18
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %8, align 8
-  %NullCheck2 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %5, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %5, i32 0, i32 4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %9)
   %12 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 19
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %15, align 8
-  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %12, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %12, i32 0, i32 5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %16)
   %19 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %20 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %20, null
-  br i1 %NullCheck8, label %21, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %20, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %20, i32 0, i32 23
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  %NullCheck10 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %19, null
-  br i1 %NullCheck10, label %24, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %19, i32 0, i32 7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %25, %System.String addrspace(1)* %23)
   %26 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %27 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %27, i32 0, i32 22
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %29, align 8
-  %NullCheck14 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %26, null
-  br i1 %NullCheck14, label %31, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %26, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %26, i32 0, i32 6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %32, %System.String addrspace(1)* %30)
   %33 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %34 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Globalization.CultureData addrspace(1)* %34, null
-  br i1 %NullCheck16, label %35, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Globalization.CultureData addrspace(1)* %34, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %34, i32 0, i32 51
   %37 = load i32, i32 addrspace(1)* %36, align 8
-  %NullCheck18 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %33, null
-  br i1 %NullCheck18, label %38, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %33, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %33, i32 0, i32 21
   store i32 %37, i32 addrspace(1)* %39
   %40 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %41 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Globalization.CultureData addrspace(1)* %41, null
-  br i1 %NullCheck20, label %42, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Globalization.CultureData addrspace(1)* %41, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %41, i32 0, i32 52
   %44 = load i32, i32 addrspace(1)* %43, align 8
-  %NullCheck22 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %40, null
-  br i1 %NullCheck22, label %45, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %40, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %40, i32 0, i32 25
   store i32 %44, i32 addrspace(1)* %46
   %47 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %48 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.Globalization.CultureData addrspace(1)* %48, null
-  br i1 %NullCheck24, label %49, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Globalization.CultureData addrspace(1)* %48, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %49
 
 ; <label>:49                                      ; preds = %45
   %50 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %48, i32 0, i32 29
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck26 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %47, null
-  br i1 %NullCheck26, label %52, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %47, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %47, i32 0, i32 10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %53, %System.String addrspace(1)* %51)
   %54 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %55 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Globalization.CultureData addrspace(1)* %55, null
-  br i1 %NullCheck28, label %56, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Globalization.CultureData addrspace(1)* %55, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %56
 
 ; <label>:56                                      ; preds = %52
   %57 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %55, i32 0, i32 35
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %57, align 8
-  %NullCheck30 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %54, null
-  br i1 %NullCheck30, label %59, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %54, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %54, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %60, %System.String addrspace(1)* %58)
   %61 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %62 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck32 = icmp ne %System.Globalization.CultureData addrspace(1)* %62, null
-  br i1 %NullCheck32, label %63, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Globalization.CultureData addrspace(1)* %62, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %62, i32 0, i32 34
   %65 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %64, align 8
-  %NullCheck34 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %61, null
-  br i1 %NullCheck34, label %66, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %61, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %61, i32 0, i32 9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %67, %System.String addrspace(1)* %65)
   %68 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %69 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck36 = icmp ne %System.Globalization.CultureData addrspace(1)* %69, null
-  br i1 %NullCheck36, label %70, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Globalization.CultureData addrspace(1)* %69, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %70
 
 ; <label>:70                                      ; preds = %66
   %71 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %69, i32 0, i32 55
   %72 = load i32, i32 addrspace(1)* %71, align 8
-  %NullCheck38 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %68, null
-  br i1 %NullCheck38, label %73, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %68, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %68, i32 0, i32 22
   store i32 %72, i32 addrspace(1)* %74
   %75 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %76 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck40 = icmp ne %System.Globalization.CultureData addrspace(1)* %76, null
-  br i1 %NullCheck40, label %77, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Globalization.CultureData addrspace(1)* %76, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %76, i32 0, i32 57
   %79 = load i32, i32 addrspace(1)* %78, align 8
-  %NullCheck42 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %75, null
-  br i1 %NullCheck42, label %80, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %75, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %80
 
 ; <label>:80                                      ; preds = %77
   %81 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %75, i32 0, i32 24
   store i32 %79, i32 addrspace(1)* %81
   %82 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %83 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck44 = icmp ne %System.Globalization.CultureData addrspace(1)* %83, null
-  br i1 %NullCheck44, label %84, label %ThrowNullRef43
+  %NullCheck43 = icmp eq %System.Globalization.CultureData addrspace(1)* %83, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %84
 
 ; <label>:84                                      ; preds = %80
   %85 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %83, i32 0, i32 56
   %86 = load i32, i32 addrspace(1)* %85, align 8
-  %NullCheck46 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %82, null
-  br i1 %NullCheck46, label %87, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %82, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %82, i32 0, i32 23
@@ -13553,8 +15262,8 @@ entry:
 
 ; <label>:89                                      ; preds = %entry
   %90 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck100 = icmp ne %System.Globalization.CultureData addrspace(1)* %90, null
-  br i1 %NullCheck100, label %91, label %ThrowNullRef99
+  %NullCheck99 = icmp eq %System.Globalization.CultureData addrspace(1)* %90, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %91
 
 ; <label>:91                                      ; preds = %89
   %92 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %90, i32 0, i32 2
@@ -13572,8 +15281,8 @@ entry:
   %102 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %103 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %104 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %103)
-  %NullCheck48 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %102, null
-  br i1 %NullCheck48, label %105, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %102, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %105
 
 ; <label>:105                                     ; preds = %101
   %106 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %102, i32 0, i32 1
@@ -13581,8 +15290,8 @@ entry:
   %107 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %108 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %109 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %108)
-  %NullCheck50 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %107, null
-  br i1 %NullCheck50, label %110, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %107, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %110
 
 ; <label>:110                                     ; preds = %105
   %111 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %107, i32 0, i32 2
@@ -13590,8 +15299,8 @@ entry:
   %112 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %113 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %114 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %113)
-  %NullCheck52 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %112, null
-  br i1 %NullCheck52, label %115, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %112, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %115
 
 ; <label>:115                                     ; preds = %110
   %116 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %112, i32 0, i32 27
@@ -13599,8 +15308,8 @@ entry:
   %117 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %118 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %119 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %118)
-  %NullCheck54 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %117, null
-  br i1 %NullCheck54, label %120, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %117, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %120
 
 ; <label>:120                                     ; preds = %115
   %121 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %117, i32 0, i32 26
@@ -13608,8 +15317,8 @@ entry:
   %122 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %123 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %124 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %123)
-  %NullCheck56 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %122, null
-  br i1 %NullCheck56, label %125, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %122, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %125
 
 ; <label>:125                                     ; preds = %120
   %126 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %122, i32 0, i32 17
@@ -13617,8 +15326,8 @@ entry:
   %127 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %128 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %129 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %128)
-  %NullCheck58 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %127, null
-  br i1 %NullCheck58, label %130, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %127, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %130
 
 ; <label>:130                                     ; preds = %125
   %131 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %127, i32 0, i32 18
@@ -13626,8 +15335,8 @@ entry:
   %132 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %133 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %134 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %133)
-  %NullCheck60 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %132, null
-  br i1 %NullCheck60, label %135, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %132, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %135
 
 ; <label>:135                                     ; preds = %130
   %136 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %132, i32 0, i32 14
@@ -13635,8 +15344,8 @@ entry:
   %137 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %138 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %139 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %138)
-  %NullCheck62 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %137, null
-  br i1 %NullCheck62, label %140, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %137, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %140
 
 ; <label>:140                                     ; preds = %135
   %141 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %137, i32 0, i32 13
@@ -13644,71 +15353,71 @@ entry:
   %142 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %143 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %144 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %143)
-  %NullCheck64 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %142, null
-  br i1 %NullCheck64, label %145, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %142, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %145
 
 ; <label>:145                                     ; preds = %140
   %146 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %142, i32 0, i32 12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %146, %System.String addrspace(1)* %144)
   %147 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %148 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck66 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %148, null
-  br i1 %NullCheck66, label %149, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %148, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %149
 
 ; <label>:149                                     ; preds = %145
   %150 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %148, i32 0, i32 21
   %151 = load i32, i32 addrspace(1)* %150, align 8
-  %NullCheck68 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %147, null
-  br i1 %NullCheck68, label %152, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %147, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %152
 
 ; <label>:152                                     ; preds = %149
   %153 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %147, i32 0, i32 28
   store i32 %151, i32 addrspace(1)* %153
   %154 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %155 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck70 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %155, null
-  br i1 %NullCheck70, label %156, label %ThrowNullRef69
+  %NullCheck69 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %155, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %156
 
 ; <label>:156                                     ; preds = %152
   %157 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %155, i32 0, i32 6
   %158 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %157, align 8
-  %NullCheck72 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %154, null
-  br i1 %NullCheck72, label %159, label %ThrowNullRef71
+  %NullCheck71 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %154, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %159
 
 ; <label>:159                                     ; preds = %156
   %160 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %154, i32 0, i32 15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %160, %System.String addrspace(1)* %158)
   %161 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %162 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck74 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %162, null
-  br i1 %NullCheck74, label %163, label %ThrowNullRef73
+  %NullCheck73 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %162, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %163
 
 ; <label>:163                                     ; preds = %159
   %164 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %162, i32 0, i32 1
   %165 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %164, align 8
-  %NullCheck76 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %161, null
-  br i1 %NullCheck76, label %166, label %ThrowNullRef75
+  %NullCheck75 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %161, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %166
 
 ; <label>:166                                     ; preds = %163
   %167 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %161, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %167, %"System.Int32[]" addrspace(1)* %165)
   %168 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %169 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck78 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %169, null
-  br i1 %NullCheck78, label %170, label %ThrowNullRef77
+  %NullCheck77 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %169, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %170
 
 ; <label>:170                                     ; preds = %166
   %171 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %169, i32 0, i32 7
   %172 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %171, align 8
-  %NullCheck80 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %168, null
-  br i1 %NullCheck80, label %173, label %ThrowNullRef79
+  %NullCheck79 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %168, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %173
 
 ; <label>:173                                     ; preds = %170
   %174 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %168, i32 0, i32 16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %174, %System.String addrspace(1)* %172)
   %175 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck82 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %175, null
-  br i1 %NullCheck82, label %176, label %ThrowNullRef81
+  %NullCheck81 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %175, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %176
 
 ; <label>:176                                     ; preds = %173
   %177 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %175, i32 0, i32 4
@@ -13718,14 +15427,14 @@ entry:
 
 ; <label>:180                                     ; preds = %176
   %181 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck84 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %181, null
-  br i1 %NullCheck84, label %182, label %ThrowNullRef83
+  %NullCheck83 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %181, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %182
 
 ; <label>:182                                     ; preds = %180
   %183 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %181, i32 0, i32 4
   %184 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %183, align 8
-  %NullCheck86 = icmp ne %System.String addrspace(1)* %184, null
-  br i1 %NullCheck86, label %185, label %ThrowNullRef85
+  %NullCheck85 = icmp eq %System.String addrspace(1)* %184, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %185
 
 ; <label>:185                                     ; preds = %182
   %186 = getelementptr inbounds %System.String, %System.String addrspace(1)* %184, i32 0, i32 1
@@ -13736,8 +15445,8 @@ entry:
 ; <label>:189                                     ; preds = %176, %185
   %190 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck98 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %190, null
-  br i1 %NullCheck98, label %192, label %ThrowNullRef97
+  %NullCheck97 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %190, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %192
 
 ; <label>:192                                     ; preds = %189
   %193 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %190, i32 0, i32 4
@@ -13746,8 +15455,8 @@ entry:
 
 ; <label>:194                                     ; preds = %185, %192
   %195 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck88 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %195, null
-  br i1 %NullCheck88, label %196, label %ThrowNullRef87
+  %NullCheck87 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %195, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %196
 
 ; <label>:196                                     ; preds = %194
   %197 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %195, i32 0, i32 9
@@ -13757,14 +15466,14 @@ entry:
 
 ; <label>:200                                     ; preds = %196
   %201 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck90 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %201, null
-  br i1 %NullCheck90, label %202, label %ThrowNullRef89
+  %NullCheck89 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %201, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %202
 
 ; <label>:202                                     ; preds = %200
   %203 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %201, i32 0, i32 9
   %204 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %203, align 8
-  %NullCheck92 = icmp ne %System.String addrspace(1)* %204, null
-  br i1 %NullCheck92, label %205, label %ThrowNullRef91
+  %NullCheck91 = icmp eq %System.String addrspace(1)* %204, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %205
 
 ; <label>:205                                     ; preds = %202
   %206 = getelementptr inbounds %System.String, %System.String addrspace(1)* %204, i32 0, i32 1
@@ -13775,14 +15484,14 @@ entry:
 ; <label>:209                                     ; preds = %196, %205
   %210 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %211 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck94 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %211, null
-  br i1 %NullCheck94, label %212, label %ThrowNullRef93
+  %NullCheck93 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %211, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %212
 
 ; <label>:212                                     ; preds = %209
   %213 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %211, i32 0, i32 6
   %214 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %213, align 8
-  %NullCheck96 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %210, null
-  br i1 %NullCheck96, label %215, label %ThrowNullRef95
+  %NullCheck95 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %210, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %215
 
 ; <label>:215                                     ; preds = %212
   %216 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %210, i32 0, i32 9
@@ -13796,203 +15505,203 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %17
+ThrowNullRef8:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %21
+ThrowNullRef10:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %24
+ThrowNullRef12:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %28
+ThrowNullRef14:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %31
+ThrowNullRef16:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %35
+ThrowNullRef18:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %38
+ThrowNullRef20:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %42
+ThrowNullRef22:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %45
+ThrowNullRef24:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %49
+ThrowNullRef26:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %52
+ThrowNullRef28:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %56
+ThrowNullRef30:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %59
+ThrowNullRef32:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %63
+ThrowNullRef34:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %66
+ThrowNullRef36:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %70
+ThrowNullRef38:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %73
+ThrowNullRef40:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %77
+ThrowNullRef42:                                   ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %80
+ThrowNullRef44:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %84
+ThrowNullRef46:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %101
+ThrowNullRef48:                                   ; preds = %101
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %105
+ThrowNullRef50:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %110
+ThrowNullRef52:                                   ; preds = %110
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %115
+ThrowNullRef54:                                   ; preds = %115
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %120
+ThrowNullRef56:                                   ; preds = %120
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %125
+ThrowNullRef58:                                   ; preds = %125
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %130
+ThrowNullRef60:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %135
+ThrowNullRef62:                                   ; preds = %135
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %140
+ThrowNullRef64:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %145
+ThrowNullRef66:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %149
+ThrowNullRef68:                                   ; preds = %149
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %152
+ThrowNullRef70:                                   ; preds = %152
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %156
+ThrowNullRef72:                                   ; preds = %156
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %159
+ThrowNullRef74:                                   ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %163
+ThrowNullRef76:                                   ; preds = %163
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %166
+ThrowNullRef78:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %170
+ThrowNullRef80:                                   ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %173
+ThrowNullRef82:                                   ; preds = %173
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %180
+ThrowNullRef84:                                   ; preds = %180
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %182
+ThrowNullRef86:                                   ; preds = %182
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %194
+ThrowNullRef88:                                   ; preds = %194
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %200
+ThrowNullRef90:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %202
+ThrowNullRef92:                                   ; preds = %202
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %209
+ThrowNullRef94:                                   ; preds = %209
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %212
+ThrowNullRef96:                                   ; preds = %212
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %189
+ThrowNullRef98:                                   ; preds = %189
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %89
+ThrowNullRef100:                                  ; preds = %89
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14020,8 +15729,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 21
@@ -14034,8 +15743,8 @@ entry:
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 16)
   %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 21
@@ -14044,8 +15753,8 @@ entry:
 
 ; <label>:12                                      ; preds = %1, %10
   %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 21
@@ -14056,11 +15765,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %12
+ThrowNullRef4:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14076,8 +15785,8 @@ entry:
   store i32 %param1, i32* %arg1
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %1 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
@@ -14144,8 +15853,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 33
@@ -14158,8 +15867,8 @@ entry:
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 24)
   %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 33
@@ -14168,8 +15877,8 @@ entry:
 
 ; <label>:12                                      ; preds = %1, %10
   %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 33
@@ -14180,11 +15889,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %12
+ThrowNullRef4:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14197,8 +15906,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 53
@@ -14210,8 +15919,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 116)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 53
@@ -14220,8 +15929,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 53
@@ -14232,11 +15941,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14265,8 +15974,8 @@ entry:
 
 ; <label>:7                                       ; preds = %entry, %4
   %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %7
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 2
@@ -14290,8 +15999,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 54
@@ -14303,8 +16012,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 117)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
@@ -14313,8 +16022,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 54
@@ -14325,11 +16034,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14342,8 +16051,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 27
@@ -14355,8 +16064,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 118)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 27
@@ -14365,8 +16074,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 27
@@ -14377,11 +16086,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14394,8 +16103,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 28
@@ -14407,8 +16116,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 119)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 28
@@ -14417,8 +16126,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 28
@@ -14429,11 +16138,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14446,8 +16155,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 26
@@ -14459,8 +16168,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 107)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 26
@@ -14469,8 +16178,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 26
@@ -14481,11 +16190,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14498,8 +16207,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 25
@@ -14511,8 +16220,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 106)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 25
@@ -14521,8 +16230,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 25
@@ -14533,11 +16242,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14550,8 +16259,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 24
@@ -14563,8 +16272,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 105)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 24
@@ -14573,8 +16282,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 24
@@ -14585,11 +16294,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14614,8 +16323,8 @@ entry:
   %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %3)
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %2
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -14626,15 +16335,15 @@ entry:
 
 ; <label>:8                                       ; preds = %62
   %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 9
   %12 = load i32, i32 addrspace(1)* %11, align 8
   %13 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.IO.StreamWriter addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %13, i32 0, i32 10
@@ -14649,15 +16358,15 @@ entry:
 
 ; <label>:20                                      ; preds = %14, %18
   %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
   %24 = load i32, i32 addrspace(1)* %23, align 8
   %25 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %25, null
-  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.StreamWriter addrspace(1)* %25, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %25, i32 0, i32 9
@@ -14678,36 +16387,36 @@ entry:
   %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %37 = load i32, i32* %loc1
   %38 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.StreamWriter addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %35
   %40 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %38, i32 0, i32 7
   %41 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %40, align 8
   %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
-  br i1 %NullCheck14, label %43, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %39
   %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 9
   %45 = load i32, i32 addrspace(1)* %44, align 8
   %46 = load i32, i32* %loc2
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %36, null
-  br i1 %NullCheck16, label %47, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %36, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %47
 
 ; <label>:47                                      ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %36, i32 %37, %"System.Char[]" addrspace(1)* %41, i32 %45, i32 %46)
   %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
   %51 = load i32, i32 addrspace(1)* %50, align 8
   %52 = load i32, i32* %loc2
   %53 = add i32 %51, %52
-  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
-  br i1 %NullCheck20, label %54, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %54
 
 ; <label>:54                                      ; preds = %49
   %55 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
@@ -14729,8 +16438,8 @@ entry:
 
 ; <label>:65                                      ; preds = %62
   %66 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %66, null
-  br i1 %NullCheck2, label %67, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %66, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %67
 
 ; <label>:67                                      ; preds = %65
   %68 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %66, i32 0, i32 11
@@ -14751,49 +16460,259 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %65
+ThrowNullRef2:                                    ; preds = %65
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %20
+ThrowNullRef8:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %22
+ThrowNullRef10:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %35
+ThrowNullRef12:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %43
+ThrowNullRef16:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %47
+ThrowNullRef18:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method String::CopyTo using LLILCJit
-Failed to read String.CopyTo[loadElemA]
+Successfully read String.CopyTo
+
+define void @String.CopyTo(%System.String addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  %loc1 = alloca i16 addrspace(1)*
+  %loc2 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %1 = icmp ne %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg4
+  %7 = icmp sge i32 %6, 0
+  br i1 %7, label %13, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  unreachable
+
+; <label>:13                                      ; preds = %5
+  %14 = load i32, i32* %arg1
+  %15 = icmp sge i32 %14, 0
+  br i1 %15, label %21, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %18)
+  %20 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %20, %System.String addrspace(1)* %17, %System.String addrspace(1)* %19)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %20) #0
+  unreachable
+
+; <label>:21                                      ; preds = %13
+  %22 = load i32, i32* %arg4
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck, label %ThrowNullRef, label %24
+
+; <label>:24                                      ; preds = %21
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load i32, i32* %arg1
+  %28 = sub i32 %26, %27
+  %29 = icmp sle i32 %22, %28
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34, %System.String addrspace(1)* %31, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %24
+  %36 = load i32, i32* %arg3
+  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %37, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
+
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
+  %40 = load i32, i32 addrspace(1)* %39
+  %41 = zext i32 %40 to i64
+  %42 = trunc i64 %41 to i32
+  %43 = load i32, i32* %arg4
+  %44 = sub i32 %42, %43
+  %45 = icmp sgt i32 %36, %44
+  br i1 %45, label %49, label %46
+
+; <label>:46                                      ; preds = %38
+  %47 = load i32, i32* %arg3
+  %48 = icmp sge i32 %47, 0
+  br i1 %48, label %54, label %49
+
+; <label>:49                                      ; preds = %38, %46
+  %50 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %52 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %51)
+  %53 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53, %System.String addrspace(1)* %50, %System.String addrspace(1)* %52)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53) #0
+  unreachable
+
+; <label>:54                                      ; preds = %46
+  %55 = load i32, i32* %arg4
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %97, label %57
+
+; <label>:57                                      ; preds = %54
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %59
+
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 2
+  %61 = bitcast [0 x i16] addrspace(1)* %60 to i16 addrspace(1)*
+  store i16 addrspace(1)* %61, i16 addrspace(1)** %loc0
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  store %"System.Char[]" addrspace(1)* %62, %"System.Char[]" addrspace(1)** %loc2
+  %63 = icmp eq %"System.Char[]" addrspace(1)* %62, null
+  br i1 %63, label %72, label %64
+
+; <label>:64                                      ; preds = %59
+  %65 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc2
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %65, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %66
+
+; <label>:66                                      ; preds = %64
+  %67 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %65, i32 0, i32 1
+  %68 = load i32, i32 addrspace(1)* %67
+  %69 = zext i32 %68 to i64
+  %70 = trunc i64 %69 to i32
+  %71 = icmp ne i32 %70, 0
+  br i1 %71, label %73, label %72
+
+; <label>:72                                      ; preds = %59, %66
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  br label %81
+
+; <label>:73                                      ; preds = %66
+  %74 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc2
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %74, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %75
+
+; <label>:75                                      ; preds = %73
+  %76 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %74, i32 0, i32 1
+  %77 = load i32, i32 addrspace(1)* %76
+  %78 = zext i32 %77 to i64
+  %BoundsCheck = icmp uge i64 0, %78
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %79
+
+; <label>:79                                      ; preds = %75
+  %80 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %74, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %80, i16 addrspace(1)** %loc1
+  br label %81
+
+; <label>:81                                      ; preds = %72, %79
+  %82 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %83 = ptrtoint i16 addrspace(1)* %82 to i64
+  %84 = load i32, i32* %arg3
+  %85 = sext i32 %84 to i64
+  %86 = mul i64 %85, 2
+  %87 = add i64 %83, %86
+  %88 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %89 = ptrtoint i16 addrspace(1)* %88 to i64
+  %90 = load i32, i32* %arg1
+  %91 = sext i32 %90 to i64
+  %92 = mul i64 %91, 2
+  %93 = add i64 %89, %92
+  %94 = load i32, i32* %arg4
+  %95 = inttoptr i64 %87 to i16*
+  %96 = inttoptr i64 %93 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %95, i16* %96, i32 %94)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  br label %97
+
+; <label>:97                                      ; preds = %54, %81
+  ret void
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
 Successfully read ConsoleEncoding.GetPreamble
 
@@ -14830,7 +16749,365 @@ entry:
 }
 
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[loadElemA]
+Successfully read EncoderNLS.GetBytes
+
+define i32 @EncoderNLS.GetBytes(%System.Text.EncoderNLS addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3, %"System.Byte[]" addrspace(1)* %param4, i32 %param5, i8 %param6) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %arg4 = alloca %"System.Byte[]" addrspace(1)*
+  %arg5 = alloca i32
+  %arg6 = alloca i8
+  %loc0 = alloca i32
+  %loc1 = alloca i16 addrspace(1)*
+  %loc2 = alloca i8 addrspace(1)*
+  %loc3 = alloca i32
+  %loc4 = alloca %"System.Char[]" addrspace(1)*
+  %loc5 = alloca %"System.Byte[]" addrspace(1)*
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  store %"System.Byte[]" addrspace(1)* %param4, %"System.Byte[]" addrspace(1)** %arg4
+  store i32 %param5, i32* %arg5
+  store i8 %param6, i8* %arg6
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %1 = icmp eq %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %17, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %7 = icmp eq %"System.Char[]" addrspace(1)* %6, null
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %12
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %12
+
+; <label>:12                                      ; preds = %8, %10
+  %13 = phi %System.String addrspace(1)* [ %9, %8 ], [ %11, %10 ]
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %14)
+  %16 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16, %System.String addrspace(1)* %13, %System.String addrspace(1)* %15)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16) #0
+  unreachable
+
+; <label>:17                                      ; preds = %2
+  %18 = load i32, i32* %arg2
+  %19 = icmp slt i32 %18, 0
+  br i1 %19, label %23, label %20
+
+; <label>:20                                      ; preds = %17
+  %21 = load i32, i32* %arg3
+  %22 = icmp sge i32 %21, 0
+  br i1 %22, label %35, label %23
+
+; <label>:23                                      ; preds = %17, %20
+  %24 = load i32, i32* %arg2
+  %25 = icmp slt i32 %24, 0
+  br i1 %25, label %28, label %26
+
+; <label>:26                                      ; preds = %23
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %30
+
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %30
+
+; <label>:30                                      ; preds = %26, %28
+  %31 = phi %System.String addrspace(1)* [ %27, %26 ], [ %29, %28 ]
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34, %System.String addrspace(1)* %31, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %20
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck, label %ThrowNullRef, label %37
+
+; <label>:37                                      ; preds = %35
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = load i32, i32* %arg2
+  %43 = sub i32 %41, %42
+  %44 = load i32, i32* %arg3
+  %45 = icmp sge i32 %43, %44
+  br i1 %45, label %51, label %46
+
+; <label>:46                                      ; preds = %37
+  %47 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %48 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %49 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %48)
+  %50 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %50, %System.String addrspace(1)* %47, %System.String addrspace(1)* %49)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %50) #0
+  unreachable
+
+; <label>:51                                      ; preds = %37
+  %52 = load i32, i32* %arg5
+  %53 = icmp slt i32 %52, 0
+  br i1 %53, label %63, label %54
+
+; <label>:54                                      ; preds = %51
+  %55 = load i32, i32* %arg5
+  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck1 = icmp eq %"System.Byte[]" addrspace(1)* %56, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %57
+
+; <label>:57                                      ; preds = %54
+  %58 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = zext i32 %59 to i64
+  %61 = trunc i64 %60 to i32
+  %62 = icmp sle i32 %55, %61
+  br i1 %62, label %68, label %63
+
+; <label>:63                                      ; preds = %51, %57
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %66 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %65)
+  %67 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %67, %System.String addrspace(1)* %64, %System.String addrspace(1)* %66)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %67) #0
+  unreachable
+
+; <label>:68                                      ; preds = %57
+  %69 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %69, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %69, i32 0, i32 1
+  %72 = load i32, i32 addrspace(1)* %71
+  %73 = zext i32 %72 to i64
+  %74 = trunc i64 %73 to i32
+  %75 = icmp ne i32 %74, 0
+  br i1 %75, label %78, label %76
+
+; <label>:76                                      ; preds = %70
+  %77 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1)
+  store %"System.Char[]" addrspace(1)* %77, %"System.Char[]" addrspace(1)** %arg1
+  br label %78
+
+; <label>:78                                      ; preds = %70, %76
+  %79 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck5 = icmp eq %"System.Byte[]" addrspace(1)* %79, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %80
+
+; <label>:80                                      ; preds = %78
+  %81 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %79, i32 0, i32 1
+  %82 = load i32, i32 addrspace(1)* %81
+  %83 = zext i32 %82 to i64
+  %84 = trunc i64 %83 to i32
+  %85 = load i32, i32* %arg5
+  %86 = sub i32 %84, %85
+  store i32 %86, i32* %loc0
+  %87 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck7 = icmp eq %"System.Byte[]" addrspace(1)* %87, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %88
+
+; <label>:88                                      ; preds = %80
+  %89 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %87, i32 0, i32 1
+  %90 = load i32, i32 addrspace(1)* %89
+  %91 = zext i32 %90 to i64
+  %92 = trunc i64 %91 to i32
+  %93 = icmp ne i32 %92, 0
+  br i1 %93, label %96, label %94
+
+; <label>:94                                      ; preds = %88
+  %95 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1)
+  store %"System.Byte[]" addrspace(1)* %95, %"System.Byte[]" addrspace(1)** %arg4
+  br label %96
+
+; <label>:96                                      ; preds = %88, %94
+  %97 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  store %"System.Char[]" addrspace(1)* %97, %"System.Char[]" addrspace(1)** %loc4
+  %98 = icmp eq %"System.Char[]" addrspace(1)* %97, null
+  br i1 %98, label %107, label %99
+
+; <label>:99                                      ; preds = %96
+  %100 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc4
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %100, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %101
+
+; <label>:101                                     ; preds = %99
+  %102 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %100, i32 0, i32 1
+  %103 = load i32, i32 addrspace(1)* %102
+  %104 = zext i32 %103 to i64
+  %105 = trunc i64 %104 to i32
+  %106 = icmp ne i32 %105, 0
+  br i1 %106, label %108, label %107
+
+; <label>:107                                     ; preds = %96, %101
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  br label %116
+
+; <label>:108                                     ; preds = %101
+  %109 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc4
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %109, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %110
+
+; <label>:110                                     ; preds = %108
+  %111 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %109, i32 0, i32 1
+  %112 = load i32, i32 addrspace(1)* %111
+  %113 = zext i32 %112 to i64
+  %BoundsCheck = icmp uge i64 0, %113
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %114
+
+; <label>:114                                     ; preds = %110
+  %115 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %109, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %115, i16 addrspace(1)** %loc1
+  br label %116
+
+; <label>:116                                     ; preds = %107, %114
+  %117 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  store %"System.Byte[]" addrspace(1)* %117, %"System.Byte[]" addrspace(1)** %loc5
+  %118 = icmp eq %"System.Byte[]" addrspace(1)* %117, null
+  br i1 %118, label %127, label %119
+
+; <label>:119                                     ; preds = %116
+  %120 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc5
+  %NullCheck13 = icmp eq %"System.Byte[]" addrspace(1)* %120, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %121
+
+; <label>:121                                     ; preds = %119
+  %122 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %120, i32 0, i32 1
+  %123 = load i32, i32 addrspace(1)* %122
+  %124 = zext i32 %123 to i64
+  %125 = trunc i64 %124 to i32
+  %126 = icmp ne i32 %125, 0
+  br i1 %126, label %128, label %127
+
+; <label>:127                                     ; preds = %116, %121
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc2
+  br label %136
+
+; <label>:128                                     ; preds = %121
+  %129 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc5
+  %NullCheck15 = icmp eq %"System.Byte[]" addrspace(1)* %129, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %130
+
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %129, i32 0, i32 1
+  %132 = load i32, i32 addrspace(1)* %131
+  %133 = zext i32 %132 to i64
+  %BoundsCheck17 = icmp uge i64 0, %133
+  br i1 %BoundsCheck17, label %ThrowIndexOutOfRange18, label %134
+
+; <label>:134                                     ; preds = %130
+  %135 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %129, i32 0, i32 3, i32 0
+  store i8 addrspace(1)* %135, i8 addrspace(1)** %loc2
+  br label %136
+
+; <label>:136                                     ; preds = %127, %134
+  %137 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %138 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %139 = ptrtoint i16 addrspace(1)* %138 to i64
+  %140 = load i32, i32* %arg2
+  %141 = sext i32 %140 to i64
+  %142 = mul i64 %141, 2
+  %143 = add i64 %139, %142
+  %144 = load i32, i32* %arg3
+  %145 = load i8 addrspace(1)*, i8 addrspace(1)** %loc2
+  %146 = ptrtoint i8 addrspace(1)* %145 to i64
+  %147 = load i32, i32* %arg5
+  %148 = sext i32 %147 to i64
+  %149 = add i64 %146, %148
+  %150 = load i32, i32* %loc0
+  %151 = load i8, i8* %arg6
+  %152 = zext i8 %151 to i32
+  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i64 addrspace(1)*
+  %NullCheck19 = icmp eq i64 addrspace(1)* %153, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %154
+
+; <label>:154                                     ; preds = %136
+  %155 = load i64, i64 addrspace(1)* %153
+  %156 = add i64 %155, 72
+  %157 = inttoptr i64 %156 to i64*
+  %158 = load i64, i64* %157
+  %159 = add i64 %158, 0
+  %160 = inttoptr i64 %159 to i64*
+  %161 = load i64, i64* %160
+  %162 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to %System.Text.Encoder addrspace(1)*
+  %163 = inttoptr i64 %143 to i16*
+  %164 = inttoptr i64 %149 to i8*
+  %165 = trunc i32 %152 to i8
+  %166 = inttoptr i64 %161 to i32 (%System.Text.Encoder addrspace(1)*, i16*, i32, i8*, i32, i8)*
+  %167 = call i32 %166(%System.Text.Encoder addrspace(1)* %162, i16* %163, i32 %144, i8* %164, i32 %150, i8 %165)
+  store i32 %167, i32* %loc3
+  br label %168
+
+; <label>:168                                     ; preds = %154
+  %169 = load i32, i32* %loc3
+  ret i32 %169
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %110
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %119
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange18:                           ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
 Successfully read EncoderNLS.GetBytes
 
@@ -14919,22 +17196,22 @@ entry:
   %40 = load i8, i8* %arg5
   %41 = zext i8 %40 to i32
   %42 = trunc i32 %41 to i8
-  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %39, null
-  br i1 %NullCheck, label %43, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderNLS addrspace(1)* %39, null
+  br i1 %NullCheck, label %ThrowNullRef, label %43
 
 ; <label>:43                                      ; preds = %38
   %44 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
   store i8 %42, i8 addrspace(1)* %44
   %45 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %45, null
-  br i1 %NullCheck2, label %46, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.EncoderNLS addrspace(1)* %45, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %46
 
 ; <label>:46                                      ; preds = %43
   %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %45, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %47
   %48 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.EncoderNLS addrspace(1)* %48, null
-  br i1 %NullCheck4, label %49, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.EncoderNLS addrspace(1)* %48, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %49
 
 ; <label>:49                                      ; preds = %46
   %50 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %48, i32 0, i32 3
@@ -14945,8 +17222,8 @@ entry:
   %55 = load i32, i32* %arg4
   %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck6, label %58, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
   %59 = load i64, i64 addrspace(1)* %57
@@ -14964,15 +17241,15 @@ ThrowNullRef:                                     ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %43
+ThrowNullRef2:                                    ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %46
+ThrowNullRef4:                                    ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %49
+ThrowNullRef6:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -15000,8 +17277,8 @@ entry:
   %4 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0 to %System.IO.ConsoleStream addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*)(%System.IO.ConsoleStream addrspace(1)* %4, %"System.Byte[]" addrspace(1)* %1, i32 %2, i32 %3)
   %5 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
@@ -15086,8 +17363,8 @@ entry:
 
 ; <label>:22                                      ; preds = %8
   %23 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %23, null
-  br i1 %NullCheck, label %24, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Byte[]" addrspace(1)* %23, null
+  br i1 %NullCheck, label %ThrowNullRef, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
@@ -15109,8 +17386,8 @@ entry:
 
 ; <label>:36                                      ; preds = %24
   %37 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %37, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.ConsoleStream addrspace(1)* %37, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %37, i32 0, i32 4
@@ -15131,13 +17408,138 @@ ThrowNullRef:                                     ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %36
+ThrowNullRef2:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
-Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
+Successfully read WindowsConsoleStream.WriteFileNative
+
+define i32 @WindowsConsoleStream.WriteFileNative(i64 %param0, %"System.Byte[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i64
+  %arg1 = alloca %"System.Byte[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i8 addrspace(1)*
+  %loc2 = alloca %"System.Byte[]" addrspace(1)*
+  %loc3 = alloca i32
+  store i64 %param0, i64* %arg0
+  store %"System.Byte[]" addrspace(1)* %param1, %"System.Byte[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Byte[]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = zext i32 %3 to i64
+  %5 = icmp ne i64 %4, 0
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %1
+  ret i32 0
+
+; <label>:7                                       ; preds = %1
+  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  store %"System.Byte[]" addrspace(1)* %8, %"System.Byte[]" addrspace(1)** %loc2
+  %9 = icmp eq %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %9, label %18, label %10
+
+; <label>:10                                      ; preds = %7
+  %11 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc2
+  %NullCheck1 = icmp eq %"System.Byte[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %11, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp ne i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %7, %12
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc1
+  br label %27
+
+; <label>:19                                      ; preds = %12
+  %20 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc2
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %20, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %BoundsCheck = icmp uge i64 0, %24
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %25
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %20, i32 0, i32 3, i32 0
+  store i8 addrspace(1)* %26, i8 addrspace(1)** %loc1
+  br label %27
+
+; <label>:27                                      ; preds = %18, %25
+  %28 = load i64, i64* %arg0
+  %29 = load i8 addrspace(1)*, i8 addrspace(1)** %loc1
+  %30 = ptrtoint i8 addrspace(1)* %29 to i64
+  %31 = load i32, i32* %arg2
+  %32 = sext i32 %31 to i64
+  %33 = add i64 %30, %32
+  %34 = load i32, i32* %arg3
+  %35 = addrspacecast i32* %loc3 to i32 addrspace(1)*
+  %36 = inttoptr i64 %33 to i8*
+  %37 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i8*, i32, i32 addrspace(1)*, i64)*)(i64 %28, i8* %36, i32 %34, i32 addrspace(1)* %35, i64 0)
+  %38 = icmp ugt i32 %37, 0
+  %39 = sext i1 %38 to i32
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc1
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %42, label %41
+
+; <label>:41                                      ; preds = %27
+  ret i32 0
+
+; <label>:42                                      ; preds = %27
+  %43 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  store i32 %43, i32* %loc0
+  %44 = load i32, i32* %loc0
+  %45 = icmp eq i32 %44, 232
+  br i1 %45, label %49, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = load i32, i32* %loc0
+  %48 = icmp ne i32 %47, 109
+  br i1 %48, label %50, label %49
+
+; <label>:49                                      ; preds = %42, %46
+  ret i32 0
+
+; <label>:50                                      ; preds = %46
+  %51 = load i32, i32* %loc0
+  ret i32 %51
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
 Successfully read WindowsConsoleStream.Flush
 
@@ -15146,8 +17548,8 @@ entry:
   %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
   store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
@@ -15182,8 +17584,8 @@ entry:
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
   %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load i64, i64 addrspace(1)* %1
@@ -15222,15 +17624,15 @@ entry:
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.TextWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
   %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %3, align 8
   %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
   %7 = load i64, i64 addrspace(1)* %5
@@ -15248,7 +17650,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -15277,8 +17679,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %4)
   store i32 0, i32* %loc0
   %5 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Char[]" addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
@@ -15290,15 +17692,15 @@ entry:
 
 ; <label>:11                                      ; preds = %69
   %12 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %12, i32 0, i32 9
   %15 = load i32, i32 addrspace(1)* %14, align 8
   %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.IO.StreamWriter addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %16, i32 0, i32 10
@@ -15313,15 +17715,15 @@ entry:
 
 ; <label>:23                                      ; preds = %17, %21
   %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %24, null
-  br i1 %NullCheck8, label %25, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %24, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 10
   %27 = load i32, i32 addrspace(1)* %26, align 8
   %28 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %28, null
-  br i1 %NullCheck10, label %29, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.StreamWriter addrspace(1)* %28, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %28, i32 0, i32 9
@@ -15343,15 +17745,15 @@ entry:
   %40 = load i32, i32* %loc0
   %41 = mul i32 %40, 2
   %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
-  br i1 %NullCheck12, label %43, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %43
 
 ; <label>:43                                      ; preds = %38
   %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 7
   %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %44, align 8
   %46 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %46, null
-  br i1 %NullCheck14, label %47, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.IO.StreamWriter addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %47
 
 ; <label>:47                                      ; preds = %43
   %48 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %46, i32 0, i32 9
@@ -15363,16 +17765,16 @@ entry:
   %54 = bitcast %"System.Char[]" addrspace(1)* %45 to %System.Array addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %53, i32 %41, %System.Array addrspace(1)* %54, i32 %50, i32 %52)
   %55 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
-  br i1 %NullCheck16, label %56, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %56
 
 ; <label>:56                                      ; preds = %47
   %57 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
   %58 = load i32, i32 addrspace(1)* %57, align 8
   %59 = load i32, i32* %loc2
   %60 = add i32 %58, %59
-  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
-  br i1 %NullCheck18, label %61, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %61
 
 ; <label>:61                                      ; preds = %56
   %62 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
@@ -15394,8 +17796,8 @@ entry:
 
 ; <label>:72                                      ; preds = %69
   %73 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %73, null
-  br i1 %NullCheck2, label %74, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %73, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %74
 
 ; <label>:74                                      ; preds = %72
   %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %73, i32 0, i32 11
@@ -15416,39 +17818,39 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %72
+ThrowNullRef2:                                    ; preds = %72
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %23
+ThrowNullRef8:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef10:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %43
+ThrowNullRef14:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %47
+ThrowNullRef16:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %56
+ThrowNullRef18:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblMulConst.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblMulConst.error.txt
@@ -25,8 +25,8 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
@@ -40,8 +40,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
   %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
@@ -75,7 +75,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -90,8 +90,8 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %NullCheck = icmp ne i8 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = load i8, i8 addrspace(1)* %0, align 8
@@ -125,8 +125,8 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
@@ -159,8 +159,8 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -184,8 +184,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
   store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
@@ -195,8 +195,8 @@ entry:
 ; <label>:4                                       ; preds = %1
   %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
   %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
@@ -206,8 +206,8 @@ entry:
   %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
@@ -221,14 +221,14 @@ entry:
 
 ; <label>:17                                      ; preds = %14
   %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
   %21 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
@@ -238,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -249,8 +249,8 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
@@ -261,27 +261,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %30
+ThrowNullRef10:                                   ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -301,7 +301,89 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
-Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
+Successfully read AppDomainSetup.GetUnsecureApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.GetUnsecureApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %NullCheck = icmp eq %"System.String[]" addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %BoundsCheck = icmp uge i64 0, %5
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %6
+
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 3, i32 0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
+  ret %System.String addrspace(1)* %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_Value using LLILCJit
+Successfully read AppDomainSetup.get_Value
+
+define %"System.String[]" addrspace(1)* @AppDomainSetup.get_Value(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.String[]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 18)
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.String[]" addrspace(1)* addrspace(1)*, %"System.String[]" addrspace(1)*)*)(%"System.String[]" addrspace(1)* addrspace(1)* %9, %"System.String[]" addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %11, i32 0, i32 1
+  %14 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %13, align 8
+  ret %"System.String[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -319,8 +401,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -368,16 +450,16 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
   %5 = load i32, i32 addrspace(1)* %4
   %6 = sub i32 %5, 1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -389,7 +471,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -421,8 +503,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
@@ -456,8 +538,8 @@ entry:
 ; <label>:27                                      ; preds = %19
   %28 = load i32, i32* %arg1
   %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
-  br i1 %NullCheck2, label %30, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %29, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %30
 
 ; <label>:30                                      ; preds = %27
   %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
@@ -493,8 +575,8 @@ entry:
 ; <label>:49                                      ; preds = %46
   %50 = load i32, i32* %arg2
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck4, label %52, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
@@ -517,11 +599,11 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %27
+ThrowNullRef2:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %49
+ThrowNullRef4:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -544,16 +626,16 @@ entry:
   %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %0)
   store %System.String addrspace(1)* %1, %System.String addrspace(1)** %loc0
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 2
   %5 = bitcast [0 x i16] addrspace(1)* %4 to i16 addrspace(1)*
   store i16 addrspace(1)* %5, i16 addrspace(1)** %loc1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %3
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2
@@ -580,7 +662,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -691,15 +773,15 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %NullCheck132 = icmp ne i8* %21, null
-  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+  %NullCheck131 = icmp eq i8* %21, null
+  br i1 %NullCheck131, label %ThrowNullRef132, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = load i8, i8* %21, align 8
   %24 = zext i8 %23 to i32
   %25 = trunc i32 %24 to i8
-  %NullCheck134 = icmp ne i8* %20, null
-  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+  %NullCheck133 = icmp eq i8* %20, null
+  br i1 %NullCheck133, label %ThrowNullRef134, label %26
 
 ; <label>:26                                      ; preds = %22
   store i8 %25, i8* %20, align 8
@@ -709,16 +791,16 @@ entry:
   %28 = load i8*, i8** %arg0
   %29 = load i8*, i8** %arg1
   %30 = bitcast i8* %29 to i16*
-  %NullCheck128 = icmp ne i16* %30, null
-  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+  %NullCheck127 = icmp eq i16* %30, null
+  br i1 %NullCheck127, label %ThrowNullRef128, label %31
 
 ; <label>:31                                      ; preds = %27
   %32 = load i16, i16* %30, align 8
   %33 = sext i16 %32 to i32
   %34 = bitcast i8* %28 to i16*
   %35 = trunc i32 %33 to i16
-  %NullCheck130 = icmp ne i16* %34, null
-  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+  %NullCheck129 = icmp eq i16* %34, null
+  br i1 %NullCheck129, label %ThrowNullRef130, label %36
 
 ; <label>:36                                      ; preds = %31
   store i16 %35, i16* %34, align 8
@@ -728,16 +810,16 @@ entry:
   %38 = load i8*, i8** %arg0
   %39 = load i8*, i8** %arg1
   %40 = bitcast i8* %39 to i16*
-  %NullCheck120 = icmp ne i16* %40, null
-  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+  %NullCheck119 = icmp eq i16* %40, null
+  br i1 %NullCheck119, label %ThrowNullRef120, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i16, i16* %40, align 8
   %43 = sext i16 %42 to i32
   %44 = bitcast i8* %38 to i16*
   %45 = trunc i32 %43 to i16
-  %NullCheck122 = icmp ne i16* %44, null
-  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+  %NullCheck121 = icmp eq i16* %44, null
+  br i1 %NullCheck121, label %ThrowNullRef122, label %46
 
 ; <label>:46                                      ; preds = %41
   store i16 %45, i16* %44, align 8
@@ -745,15 +827,15 @@ entry:
   %48 = getelementptr inbounds i8, i8* %47, i64 2
   %49 = load i8*, i8** %arg1
   %50 = getelementptr inbounds i8, i8* %49, i64 2
-  %NullCheck124 = icmp ne i8* %50, null
-  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+  %NullCheck123 = icmp eq i8* %50, null
+  br i1 %NullCheck123, label %ThrowNullRef124, label %51
 
 ; <label>:51                                      ; preds = %46
   %52 = load i8, i8* %50, align 8
   %53 = zext i8 %52 to i32
   %54 = trunc i32 %53 to i8
-  %NullCheck126 = icmp ne i8* %48, null
-  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+  %NullCheck125 = icmp eq i8* %48, null
+  br i1 %NullCheck125, label %ThrowNullRef126, label %55
 
 ; <label>:55                                      ; preds = %51
   store i8 %54, i8* %48, align 8
@@ -763,14 +845,14 @@ entry:
   %57 = load i8*, i8** %arg0
   %58 = load i8*, i8** %arg1
   %59 = bitcast i8* %58 to i32*
-  %NullCheck116 = icmp ne i32* %59, null
-  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+  %NullCheck115 = icmp eq i32* %59, null
+  br i1 %NullCheck115, label %ThrowNullRef116, label %60
 
 ; <label>:60                                      ; preds = %56
   %61 = load i32, i32* %59, align 8
   %62 = bitcast i8* %57 to i32*
-  %NullCheck118 = icmp ne i32* %62, null
-  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+  %NullCheck117 = icmp eq i32* %62, null
+  br i1 %NullCheck117, label %ThrowNullRef118, label %63
 
 ; <label>:63                                      ; preds = %60
   store i32 %61, i32* %62, align 8
@@ -780,14 +862,14 @@ entry:
   %65 = load i8*, i8** %arg0
   %66 = load i8*, i8** %arg1
   %67 = bitcast i8* %66 to i32*
-  %NullCheck108 = icmp ne i32* %67, null
-  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+  %NullCheck107 = icmp eq i32* %67, null
+  br i1 %NullCheck107, label %ThrowNullRef108, label %68
 
 ; <label>:68                                      ; preds = %64
   %69 = load i32, i32* %67, align 8
   %70 = bitcast i8* %65 to i32*
-  %NullCheck110 = icmp ne i32* %70, null
-  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+  %NullCheck109 = icmp eq i32* %70, null
+  br i1 %NullCheck109, label %ThrowNullRef110, label %71
 
 ; <label>:71                                      ; preds = %68
   store i32 %69, i32* %70, align 8
@@ -795,15 +877,15 @@ entry:
   %73 = getelementptr inbounds i8, i8* %72, i64 4
   %74 = load i8*, i8** %arg1
   %75 = getelementptr inbounds i8, i8* %74, i64 4
-  %NullCheck112 = icmp ne i8* %75, null
-  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+  %NullCheck111 = icmp eq i8* %75, null
+  br i1 %NullCheck111, label %ThrowNullRef112, label %76
 
 ; <label>:76                                      ; preds = %71
   %77 = load i8, i8* %75, align 8
   %78 = zext i8 %77 to i32
   %79 = trunc i32 %78 to i8
-  %NullCheck114 = icmp ne i8* %73, null
-  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+  %NullCheck113 = icmp eq i8* %73, null
+  br i1 %NullCheck113, label %ThrowNullRef114, label %80
 
 ; <label>:80                                      ; preds = %76
   store i8 %79, i8* %73, align 8
@@ -813,14 +895,14 @@ entry:
   %82 = load i8*, i8** %arg0
   %83 = load i8*, i8** %arg1
   %84 = bitcast i8* %83 to i32*
-  %NullCheck100 = icmp ne i32* %84, null
-  br i1 %NullCheck100, label %85, label %ThrowNullRef99
+  %NullCheck99 = icmp eq i32* %84, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %85
 
 ; <label>:85                                      ; preds = %81
   %86 = load i32, i32* %84, align 8
   %87 = bitcast i8* %82 to i32*
-  %NullCheck102 = icmp ne i32* %87, null
-  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+  %NullCheck101 = icmp eq i32* %87, null
+  br i1 %NullCheck101, label %ThrowNullRef102, label %88
 
 ; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
@@ -829,16 +911,16 @@ entry:
   %91 = load i8*, i8** %arg1
   %92 = getelementptr inbounds i8, i8* %91, i64 4
   %93 = bitcast i8* %92 to i16*
-  %NullCheck104 = icmp ne i16* %93, null
-  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+  %NullCheck103 = icmp eq i16* %93, null
+  br i1 %NullCheck103, label %ThrowNullRef104, label %94
 
 ; <label>:94                                      ; preds = %88
   %95 = load i16, i16* %93, align 8
   %96 = sext i16 %95 to i32
   %97 = bitcast i8* %90 to i16*
   %98 = trunc i32 %96 to i16
-  %NullCheck106 = icmp ne i16* %97, null
-  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+  %NullCheck105 = icmp eq i16* %97, null
+  br i1 %NullCheck105, label %ThrowNullRef106, label %99
 
 ; <label>:99                                      ; preds = %94
   store i16 %98, i16* %97, align 8
@@ -848,14 +930,14 @@ entry:
   %101 = load i8*, i8** %arg0
   %102 = load i8*, i8** %arg1
   %103 = bitcast i8* %102 to i32*
-  %NullCheck88 = icmp ne i32* %103, null
-  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+  %NullCheck87 = icmp eq i32* %103, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %104
 
 ; <label>:104                                     ; preds = %100
   %105 = load i32, i32* %103, align 8
   %106 = bitcast i8* %101 to i32*
-  %NullCheck90 = icmp ne i32* %106, null
-  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+  %NullCheck89 = icmp eq i32* %106, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %107
 
 ; <label>:107                                     ; preds = %104
   store i32 %105, i32* %106, align 8
@@ -864,16 +946,16 @@ entry:
   %110 = load i8*, i8** %arg1
   %111 = getelementptr inbounds i8, i8* %110, i64 4
   %112 = bitcast i8* %111 to i16*
-  %NullCheck92 = icmp ne i16* %112, null
-  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+  %NullCheck91 = icmp eq i16* %112, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %113
 
 ; <label>:113                                     ; preds = %107
   %114 = load i16, i16* %112, align 8
   %115 = sext i16 %114 to i32
   %116 = bitcast i8* %109 to i16*
   %117 = trunc i32 %115 to i16
-  %NullCheck94 = icmp ne i16* %116, null
-  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+  %NullCheck93 = icmp eq i16* %116, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %118
 
 ; <label>:118                                     ; preds = %113
   store i16 %117, i16* %116, align 8
@@ -881,15 +963,15 @@ entry:
   %120 = getelementptr inbounds i8, i8* %119, i64 6
   %121 = load i8*, i8** %arg1
   %122 = getelementptr inbounds i8, i8* %121, i64 6
-  %NullCheck96 = icmp ne i8* %122, null
-  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+  %NullCheck95 = icmp eq i8* %122, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %123
 
 ; <label>:123                                     ; preds = %118
   %124 = load i8, i8* %122, align 8
   %125 = zext i8 %124 to i32
   %126 = trunc i32 %125 to i8
-  %NullCheck98 = icmp ne i8* %120, null
-  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+  %NullCheck97 = icmp eq i8* %120, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %127
 
 ; <label>:127                                     ; preds = %123
   store i8 %126, i8* %120, align 8
@@ -899,14 +981,14 @@ entry:
   %129 = load i8*, i8** %arg0
   %130 = load i8*, i8** %arg1
   %131 = bitcast i8* %130 to i64*
-  %NullCheck84 = icmp ne i64* %131, null
-  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+  %NullCheck83 = icmp eq i64* %131, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %132
 
 ; <label>:132                                     ; preds = %128
   %133 = load i64, i64* %131, align 8
   %134 = bitcast i8* %129 to i64*
-  %NullCheck86 = icmp ne i64* %134, null
-  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+  %NullCheck85 = icmp eq i64* %134, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %135
 
 ; <label>:135                                     ; preds = %132
   store i64 %133, i64* %134, align 8
@@ -916,14 +998,14 @@ entry:
   %137 = load i8*, i8** %arg0
   %138 = load i8*, i8** %arg1
   %139 = bitcast i8* %138 to i64*
-  %NullCheck76 = icmp ne i64* %139, null
-  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+  %NullCheck75 = icmp eq i64* %139, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %140
 
 ; <label>:140                                     ; preds = %136
   %141 = load i64, i64* %139, align 8
   %142 = bitcast i8* %137 to i64*
-  %NullCheck78 = icmp ne i64* %142, null
-  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+  %NullCheck77 = icmp eq i64* %142, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %143
 
 ; <label>:143                                     ; preds = %140
   store i64 %141, i64* %142, align 8
@@ -931,15 +1013,15 @@ entry:
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %NullCheck80 = icmp ne i8* %147, null
-  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+  %NullCheck79 = icmp eq i8* %147, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %148
 
 ; <label>:148                                     ; preds = %143
   %149 = load i8, i8* %147, align 8
   %150 = zext i8 %149 to i32
   %151 = trunc i32 %150 to i8
-  %NullCheck82 = icmp ne i8* %145, null
-  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+  %NullCheck81 = icmp eq i8* %145, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %152
 
 ; <label>:152                                     ; preds = %148
   store i8 %151, i8* %145, align 8
@@ -949,14 +1031,14 @@ entry:
   %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
   %156 = bitcast i8* %155 to i64*
-  %NullCheck68 = icmp ne i64* %156, null
-  br i1 %NullCheck68, label %157, label %ThrowNullRef67
+  %NullCheck67 = icmp eq i64* %156, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %157
 
 ; <label>:157                                     ; preds = %153
   %158 = load i64, i64* %156, align 8
   %159 = bitcast i8* %154 to i64*
-  %NullCheck70 = icmp ne i64* %159, null
-  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+  %NullCheck69 = icmp eq i64* %159, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %160
 
 ; <label>:160                                     ; preds = %157
   store i64 %158, i64* %159, align 8
@@ -965,16 +1047,16 @@ entry:
   %163 = load i8*, i8** %arg1
   %164 = getelementptr inbounds i8, i8* %163, i64 8
   %165 = bitcast i8* %164 to i16*
-  %NullCheck72 = icmp ne i16* %165, null
-  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+  %NullCheck71 = icmp eq i16* %165, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %166
 
 ; <label>:166                                     ; preds = %160
   %167 = load i16, i16* %165, align 8
   %168 = sext i16 %167 to i32
   %169 = bitcast i8* %162 to i16*
   %170 = trunc i32 %168 to i16
-  %NullCheck74 = icmp ne i16* %169, null
-  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+  %NullCheck73 = icmp eq i16* %169, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %171
 
 ; <label>:171                                     ; preds = %166
   store i16 %170, i16* %169, align 8
@@ -984,14 +1066,14 @@ entry:
   %173 = load i8*, i8** %arg0
   %174 = load i8*, i8** %arg1
   %175 = bitcast i8* %174 to i64*
-  %NullCheck56 = icmp ne i64* %175, null
-  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+  %NullCheck55 = icmp eq i64* %175, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %176
 
 ; <label>:176                                     ; preds = %172
   %177 = load i64, i64* %175, align 8
   %178 = bitcast i8* %173 to i64*
-  %NullCheck58 = icmp ne i64* %178, null
-  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+  %NullCheck57 = icmp eq i64* %178, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %179
 
 ; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
@@ -1000,16 +1082,16 @@ entry:
   %182 = load i8*, i8** %arg1
   %183 = getelementptr inbounds i8, i8* %182, i64 8
   %184 = bitcast i8* %183 to i16*
-  %NullCheck60 = icmp ne i16* %184, null
-  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+  %NullCheck59 = icmp eq i16* %184, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %185
 
 ; <label>:185                                     ; preds = %179
   %186 = load i16, i16* %184, align 8
   %187 = sext i16 %186 to i32
   %188 = bitcast i8* %181 to i16*
   %189 = trunc i32 %187 to i16
-  %NullCheck62 = icmp ne i16* %188, null
-  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+  %NullCheck61 = icmp eq i16* %188, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %190
 
 ; <label>:190                                     ; preds = %185
   store i16 %189, i16* %188, align 8
@@ -1017,15 +1099,15 @@ entry:
   %192 = getelementptr inbounds i8, i8* %191, i64 10
   %193 = load i8*, i8** %arg1
   %194 = getelementptr inbounds i8, i8* %193, i64 10
-  %NullCheck64 = icmp ne i8* %194, null
-  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+  %NullCheck63 = icmp eq i8* %194, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %195
 
 ; <label>:195                                     ; preds = %190
   %196 = load i8, i8* %194, align 8
   %197 = zext i8 %196 to i32
   %198 = trunc i32 %197 to i8
-  %NullCheck66 = icmp ne i8* %192, null
-  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+  %NullCheck65 = icmp eq i8* %192, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %199
 
 ; <label>:199                                     ; preds = %195
   store i8 %198, i8* %192, align 8
@@ -1035,14 +1117,14 @@ entry:
   %201 = load i8*, i8** %arg0
   %202 = load i8*, i8** %arg1
   %203 = bitcast i8* %202 to i64*
-  %NullCheck48 = icmp ne i64* %203, null
-  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+  %NullCheck47 = icmp eq i64* %203, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %204
 
 ; <label>:204                                     ; preds = %200
   %205 = load i64, i64* %203, align 8
   %206 = bitcast i8* %201 to i64*
-  %NullCheck50 = icmp ne i64* %206, null
-  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+  %NullCheck49 = icmp eq i64* %206, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %207
 
 ; <label>:207                                     ; preds = %204
   store i64 %205, i64* %206, align 8
@@ -1051,14 +1133,14 @@ entry:
   %210 = load i8*, i8** %arg1
   %211 = getelementptr inbounds i8, i8* %210, i64 8
   %212 = bitcast i8* %211 to i32*
-  %NullCheck52 = icmp ne i32* %212, null
-  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+  %NullCheck51 = icmp eq i32* %212, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %213
 
 ; <label>:213                                     ; preds = %207
   %214 = load i32, i32* %212, align 8
   %215 = bitcast i8* %209 to i32*
-  %NullCheck54 = icmp ne i32* %215, null
-  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+  %NullCheck53 = icmp eq i32* %215, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %216
 
 ; <label>:216                                     ; preds = %213
   store i32 %214, i32* %215, align 8
@@ -1068,14 +1150,14 @@ entry:
   %218 = load i8*, i8** %arg0
   %219 = load i8*, i8** %arg1
   %220 = bitcast i8* %219 to i64*
-  %NullCheck36 = icmp ne i64* %220, null
-  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64* %220, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %221
 
 ; <label>:221                                     ; preds = %217
   %222 = load i64, i64* %220, align 8
   %223 = bitcast i8* %218 to i64*
-  %NullCheck38 = icmp ne i64* %223, null
-  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+  %NullCheck37 = icmp eq i64* %223, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %224
 
 ; <label>:224                                     ; preds = %221
   store i64 %222, i64* %223, align 8
@@ -1084,14 +1166,14 @@ entry:
   %227 = load i8*, i8** %arg1
   %228 = getelementptr inbounds i8, i8* %227, i64 8
   %229 = bitcast i8* %228 to i32*
-  %NullCheck40 = icmp ne i32* %229, null
-  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i32* %229, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %230
 
 ; <label>:230                                     ; preds = %224
   %231 = load i32, i32* %229, align 8
   %232 = bitcast i8* %226 to i32*
-  %NullCheck42 = icmp ne i32* %232, null
-  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+  %NullCheck41 = icmp eq i32* %232, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %233
 
 ; <label>:233                                     ; preds = %230
   store i32 %231, i32* %232, align 8
@@ -1099,15 +1181,15 @@ entry:
   %235 = getelementptr inbounds i8, i8* %234, i64 12
   %236 = load i8*, i8** %arg1
   %237 = getelementptr inbounds i8, i8* %236, i64 12
-  %NullCheck44 = icmp ne i8* %237, null
-  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i8* %237, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %238
 
 ; <label>:238                                     ; preds = %233
   %239 = load i8, i8* %237, align 8
   %240 = zext i8 %239 to i32
   %241 = trunc i32 %240 to i8
-  %NullCheck46 = icmp ne i8* %235, null
-  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+  %NullCheck45 = icmp eq i8* %235, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %242
 
 ; <label>:242                                     ; preds = %238
   store i8 %241, i8* %235, align 8
@@ -1117,14 +1199,14 @@ entry:
   %244 = load i8*, i8** %arg0
   %245 = load i8*, i8** %arg1
   %246 = bitcast i8* %245 to i64*
-  %NullCheck24 = icmp ne i64* %246, null
-  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64* %246, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %247
 
 ; <label>:247                                     ; preds = %243
   %248 = load i64, i64* %246, align 8
   %249 = bitcast i8* %244 to i64*
-  %NullCheck26 = icmp ne i64* %249, null
-  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64* %249, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %250
 
 ; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
@@ -1133,14 +1215,14 @@ entry:
   %253 = load i8*, i8** %arg1
   %254 = getelementptr inbounds i8, i8* %253, i64 8
   %255 = bitcast i8* %254 to i32*
-  %NullCheck28 = icmp ne i32* %255, null
-  br i1 %NullCheck28, label %256, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i32* %255, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %256
 
 ; <label>:256                                     ; preds = %250
   %257 = load i32, i32* %255, align 8
   %258 = bitcast i8* %252 to i32*
-  %NullCheck30 = icmp ne i32* %258, null
-  br i1 %NullCheck30, label %259, label %ThrowNullRef29
+  %NullCheck29 = icmp eq i32* %258, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %259
 
 ; <label>:259                                     ; preds = %256
   store i32 %257, i32* %258, align 8
@@ -1149,16 +1231,16 @@ entry:
   %262 = load i8*, i8** %arg1
   %263 = getelementptr inbounds i8, i8* %262, i64 12
   %264 = bitcast i8* %263 to i16*
-  %NullCheck32 = icmp ne i16* %264, null
-  br i1 %NullCheck32, label %265, label %ThrowNullRef31
+  %NullCheck31 = icmp eq i16* %264, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %265
 
 ; <label>:265                                     ; preds = %259
   %266 = load i16, i16* %264, align 8
   %267 = sext i16 %266 to i32
   %268 = bitcast i8* %261 to i16*
   %269 = trunc i32 %267 to i16
-  %NullCheck34 = icmp ne i16* %268, null
-  br i1 %NullCheck34, label %270, label %ThrowNullRef33
+  %NullCheck33 = icmp eq i16* %268, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %270
 
 ; <label>:270                                     ; preds = %265
   store i16 %269, i16* %268, align 8
@@ -1168,14 +1250,14 @@ entry:
   %272 = load i8*, i8** %arg0
   %273 = load i8*, i8** %arg1
   %274 = bitcast i8* %273 to i64*
-  %NullCheck8 = icmp ne i64* %274, null
-  br i1 %NullCheck8, label %275, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64* %274, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %275
 
 ; <label>:275                                     ; preds = %271
   %276 = load i64, i64* %274, align 8
   %277 = bitcast i8* %272 to i64*
-  %NullCheck10 = icmp ne i64* %277, null
-  br i1 %NullCheck10, label %278, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %277, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %278
 
 ; <label>:278                                     ; preds = %275
   store i64 %276, i64* %277, align 8
@@ -1184,14 +1266,14 @@ entry:
   %281 = load i8*, i8** %arg1
   %282 = getelementptr inbounds i8, i8* %281, i64 8
   %283 = bitcast i8* %282 to i32*
-  %NullCheck12 = icmp ne i32* %283, null
-  br i1 %NullCheck12, label %284, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i32* %283, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %284
 
 ; <label>:284                                     ; preds = %278
   %285 = load i32, i32* %283, align 8
   %286 = bitcast i8* %280 to i32*
-  %NullCheck14 = icmp ne i32* %286, null
-  br i1 %NullCheck14, label %287, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i32* %286, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %287
 
 ; <label>:287                                     ; preds = %284
   store i32 %285, i32* %286, align 8
@@ -1200,16 +1282,16 @@ entry:
   %290 = load i8*, i8** %arg1
   %291 = getelementptr inbounds i8, i8* %290, i64 12
   %292 = bitcast i8* %291 to i16*
-  %NullCheck16 = icmp ne i16* %292, null
-  br i1 %NullCheck16, label %293, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i16* %292, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %293
 
 ; <label>:293                                     ; preds = %287
   %294 = load i16, i16* %292, align 8
   %295 = sext i16 %294 to i32
   %296 = bitcast i8* %289 to i16*
   %297 = trunc i32 %295 to i16
-  %NullCheck18 = icmp ne i16* %296, null
-  br i1 %NullCheck18, label %298, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i16* %296, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %298
 
 ; <label>:298                                     ; preds = %293
   store i16 %297, i16* %296, align 8
@@ -1217,15 +1299,15 @@ entry:
   %300 = getelementptr inbounds i8, i8* %299, i64 14
   %301 = load i8*, i8** %arg1
   %302 = getelementptr inbounds i8, i8* %301, i64 14
-  %NullCheck20 = icmp ne i8* %302, null
-  br i1 %NullCheck20, label %303, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i8* %302, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %303
 
 ; <label>:303                                     ; preds = %298
   %304 = load i8, i8* %302, align 8
   %305 = zext i8 %304 to i32
   %306 = trunc i32 %305 to i8
-  %NullCheck22 = icmp ne i8* %300, null
-  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i8* %300, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %307
 
 ; <label>:307                                     ; preds = %303
   store i8 %306, i8* %300, align 8
@@ -1235,14 +1317,14 @@ entry:
   %309 = load i8*, i8** %arg0
   %310 = load i8*, i8** %arg1
   %311 = bitcast i8* %310 to i64*
-  %NullCheck = icmp ne i64* %311, null
-  br i1 %NullCheck, label %312, label %ThrowNullRef
+  %NullCheck = icmp eq i64* %311, null
+  br i1 %NullCheck, label %ThrowNullRef, label %312
 
 ; <label>:312                                     ; preds = %308
   %313 = load i64, i64* %311, align 8
   %314 = bitcast i8* %309 to i64*
-  %NullCheck2 = icmp ne i64* %314, null
-  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64* %314, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %315
 
 ; <label>:315                                     ; preds = %312
   store i64 %313, i64* %314, align 8
@@ -1251,14 +1333,14 @@ entry:
   %318 = load i8*, i8** %arg1
   %319 = getelementptr inbounds i8, i8* %318, i64 8
   %320 = bitcast i8* %319 to i64*
-  %NullCheck4 = icmp ne i64* %320, null
-  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64* %320, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %321
 
 ; <label>:321                                     ; preds = %315
   %322 = load i64, i64* %320, align 8
   %323 = bitcast i8* %317 to i64*
-  %NullCheck6 = icmp ne i64* %323, null
-  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64* %323, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %324
 
 ; <label>:324                                     ; preds = %321
   store i64 %322, i64* %323, align 8
@@ -1286,15 +1368,15 @@ entry:
 ; <label>:338                                     ; preds = %333
   %339 = load i8*, i8** %arg0
   %340 = load i8*, i8** %arg1
-  %NullCheck136 = icmp ne i8* %340, null
-  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+  %NullCheck135 = icmp eq i8* %340, null
+  br i1 %NullCheck135, label %ThrowNullRef136, label %341
 
 ; <label>:341                                     ; preds = %338
   %342 = load i8, i8* %340, align 8
   %343 = zext i8 %342 to i32
   %344 = trunc i32 %343 to i8
-  %NullCheck138 = icmp ne i8* %339, null
-  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+  %NullCheck137 = icmp eq i8* %339, null
+  br i1 %NullCheck137, label %ThrowNullRef138, label %345
 
 ; <label>:345                                     ; preds = %341
   store i8 %344, i8* %339, align 8
@@ -1317,16 +1399,16 @@ entry:
   %357 = load i8*, i8** %arg0
   %358 = load i8*, i8** %arg1
   %359 = bitcast i8* %358 to i16*
-  %NullCheck140 = icmp ne i16* %359, null
-  br i1 %NullCheck140, label %360, label %ThrowNullRef139
+  %NullCheck139 = icmp eq i16* %359, null
+  br i1 %NullCheck139, label %ThrowNullRef140, label %360
 
 ; <label>:360                                     ; preds = %356
   %361 = load i16, i16* %359, align 8
   %362 = sext i16 %361 to i32
   %363 = bitcast i8* %357 to i16*
   %364 = trunc i32 %362 to i16
-  %NullCheck142 = icmp ne i16* %363, null
-  br i1 %NullCheck142, label %365, label %ThrowNullRef141
+  %NullCheck141 = icmp eq i16* %363, null
+  br i1 %NullCheck141, label %ThrowNullRef142, label %365
 
 ; <label>:365                                     ; preds = %360
   store i16 %364, i16* %363, align 8
@@ -1352,14 +1434,14 @@ entry:
   %378 = load i8*, i8** %arg0
   %379 = load i8*, i8** %arg1
   %380 = bitcast i8* %379 to i32*
-  %NullCheck144 = icmp ne i32* %380, null
-  br i1 %NullCheck144, label %381, label %ThrowNullRef143
+  %NullCheck143 = icmp eq i32* %380, null
+  br i1 %NullCheck143, label %ThrowNullRef144, label %381
 
 ; <label>:381                                     ; preds = %377
   %382 = load i32, i32* %380, align 8
   %383 = bitcast i8* %378 to i32*
-  %NullCheck146 = icmp ne i32* %383, null
-  br i1 %NullCheck146, label %384, label %ThrowNullRef145
+  %NullCheck145 = icmp eq i32* %383, null
+  br i1 %NullCheck145, label %ThrowNullRef146, label %384
 
 ; <label>:384                                     ; preds = %381
   store i32 %382, i32* %383, align 8
@@ -1384,14 +1466,14 @@ entry:
   %395 = load i8*, i8** %arg0
   %396 = load i8*, i8** %arg1
   %397 = bitcast i8* %396 to i64*
-  %NullCheck164 = icmp ne i64* %397, null
-  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+  %NullCheck163 = icmp eq i64* %397, null
+  br i1 %NullCheck163, label %ThrowNullRef164, label %398
 
 ; <label>:398                                     ; preds = %394
   %399 = load i64, i64* %397, align 8
   %400 = bitcast i8* %395 to i64*
-  %NullCheck166 = icmp ne i64* %400, null
-  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+  %NullCheck165 = icmp eq i64* %400, null
+  br i1 %NullCheck165, label %ThrowNullRef166, label %401
 
 ; <label>:401                                     ; preds = %398
   store i64 %399, i64* %400, align 8
@@ -1400,14 +1482,14 @@ entry:
   %404 = load i8*, i8** %arg1
   %405 = getelementptr inbounds i8, i8* %404, i64 8
   %406 = bitcast i8* %405 to i64*
-  %NullCheck168 = icmp ne i64* %406, null
-  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+  %NullCheck167 = icmp eq i64* %406, null
+  br i1 %NullCheck167, label %ThrowNullRef168, label %407
 
 ; <label>:407                                     ; preds = %401
   %408 = load i64, i64* %406, align 8
   %409 = bitcast i8* %403 to i64*
-  %NullCheck170 = icmp ne i64* %409, null
-  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+  %NullCheck169 = icmp eq i64* %409, null
+  br i1 %NullCheck169, label %ThrowNullRef170, label %410
 
 ; <label>:410                                     ; preds = %407
   store i64 %408, i64* %409, align 8
@@ -1437,14 +1519,14 @@ entry:
   %425 = load i8*, i8** %arg0
   %426 = load i8*, i8** %arg1
   %427 = bitcast i8* %426 to i64*
-  %NullCheck148 = icmp ne i64* %427, null
-  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+  %NullCheck147 = icmp eq i64* %427, null
+  br i1 %NullCheck147, label %ThrowNullRef148, label %428
 
 ; <label>:428                                     ; preds = %424
   %429 = load i64, i64* %427, align 8
   %430 = bitcast i8* %425 to i64*
-  %NullCheck150 = icmp ne i64* %430, null
-  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+  %NullCheck149 = icmp eq i64* %430, null
+  br i1 %NullCheck149, label %ThrowNullRef150, label %431
 
 ; <label>:431                                     ; preds = %428
   store i64 %429, i64* %430, align 8
@@ -1466,14 +1548,14 @@ entry:
   %441 = load i8*, i8** %arg0
   %442 = load i8*, i8** %arg1
   %443 = bitcast i8* %442 to i32*
-  %NullCheck152 = icmp ne i32* %443, null
-  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+  %NullCheck151 = icmp eq i32* %443, null
+  br i1 %NullCheck151, label %ThrowNullRef152, label %444
 
 ; <label>:444                                     ; preds = %440
   %445 = load i32, i32* %443, align 8
   %446 = bitcast i8* %441 to i32*
-  %NullCheck154 = icmp ne i32* %446, null
-  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+  %NullCheck153 = icmp eq i32* %446, null
+  br i1 %NullCheck153, label %ThrowNullRef154, label %447
 
 ; <label>:447                                     ; preds = %444
   store i32 %445, i32* %446, align 8
@@ -1495,16 +1577,16 @@ entry:
   %457 = load i8*, i8** %arg0
   %458 = load i8*, i8** %arg1
   %459 = bitcast i8* %458 to i16*
-  %NullCheck156 = icmp ne i16* %459, null
-  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+  %NullCheck155 = icmp eq i16* %459, null
+  br i1 %NullCheck155, label %ThrowNullRef156, label %460
 
 ; <label>:460                                     ; preds = %456
   %461 = load i16, i16* %459, align 8
   %462 = sext i16 %461 to i32
   %463 = bitcast i8* %457 to i16*
   %464 = trunc i32 %462 to i16
-  %NullCheck158 = icmp ne i16* %463, null
-  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+  %NullCheck157 = icmp eq i16* %463, null
+  br i1 %NullCheck157, label %ThrowNullRef158, label %465
 
 ; <label>:465                                     ; preds = %460
   store i16 %464, i16* %463, align 8
@@ -1525,15 +1607,15 @@ entry:
 ; <label>:474                                     ; preds = %470
   %475 = load i8*, i8** %arg0
   %476 = load i8*, i8** %arg1
-  %NullCheck160 = icmp ne i8* %476, null
-  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+  %NullCheck159 = icmp eq i8* %476, null
+  br i1 %NullCheck159, label %ThrowNullRef160, label %477
 
 ; <label>:477                                     ; preds = %474
   %478 = load i8, i8* %476, align 8
   %479 = zext i8 %478 to i32
   %480 = trunc i32 %479 to i8
-  %NullCheck162 = icmp ne i8* %475, null
-  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+  %NullCheck161 = icmp eq i8* %475, null
+  br i1 %NullCheck161, label %ThrowNullRef162, label %481
 
 ; <label>:481                                     ; preds = %477
   store i8 %480, i8* %475, align 8
@@ -1553,343 +1635,343 @@ ThrowNullRef:                                     ; preds = %308
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %312
+ThrowNullRef2:                                    ; preds = %312
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %315
+ThrowNullRef4:                                    ; preds = %315
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %321
+ThrowNullRef6:                                    ; preds = %321
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %271
+ThrowNullRef8:                                    ; preds = %271
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %275
+ThrowNullRef10:                                   ; preds = %275
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %278
+ThrowNullRef12:                                   ; preds = %278
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %284
+ThrowNullRef14:                                   ; preds = %284
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %287
+ThrowNullRef16:                                   ; preds = %287
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %293
+ThrowNullRef18:                                   ; preds = %293
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %298
+ThrowNullRef20:                                   ; preds = %298
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %303
+ThrowNullRef22:                                   ; preds = %303
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %243
+ThrowNullRef24:                                   ; preds = %243
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %247
+ThrowNullRef26:                                   ; preds = %247
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %250
+ThrowNullRef28:                                   ; preds = %250
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %256
+ThrowNullRef30:                                   ; preds = %256
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %259
+ThrowNullRef32:                                   ; preds = %259
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %265
+ThrowNullRef34:                                   ; preds = %265
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %217
+ThrowNullRef36:                                   ; preds = %217
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %221
+ThrowNullRef38:                                   ; preds = %221
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %224
+ThrowNullRef40:                                   ; preds = %224
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %230
+ThrowNullRef42:                                   ; preds = %230
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %233
+ThrowNullRef44:                                   ; preds = %233
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %238
+ThrowNullRef46:                                   ; preds = %238
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %200
+ThrowNullRef48:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %204
+ThrowNullRef50:                                   ; preds = %204
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %207
+ThrowNullRef52:                                   ; preds = %207
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %213
+ThrowNullRef54:                                   ; preds = %213
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %172
+ThrowNullRef56:                                   ; preds = %172
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %176
+ThrowNullRef58:                                   ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %179
+ThrowNullRef60:                                   ; preds = %179
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %185
+ThrowNullRef62:                                   ; preds = %185
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %190
+ThrowNullRef64:                                   ; preds = %190
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %195
+ThrowNullRef66:                                   ; preds = %195
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %153
+ThrowNullRef68:                                   ; preds = %153
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %157
+ThrowNullRef70:                                   ; preds = %157
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %160
+ThrowNullRef72:                                   ; preds = %160
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %166
+ThrowNullRef74:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %136
+ThrowNullRef76:                                   ; preds = %136
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %140
+ThrowNullRef78:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %143
+ThrowNullRef80:                                   ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %148
+ThrowNullRef82:                                   ; preds = %148
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %128
+ThrowNullRef84:                                   ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %132
+ThrowNullRef86:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %100
+ThrowNullRef88:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %104
+ThrowNullRef90:                                   ; preds = %104
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %107
+ThrowNullRef92:                                   ; preds = %107
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %113
+ThrowNullRef94:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %118
+ThrowNullRef96:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %123
+ThrowNullRef98:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %81
+ThrowNullRef100:                                  ; preds = %81
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef101:                                  ; preds = %85
+ThrowNullRef102:                                  ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef103:                                  ; preds = %88
+ThrowNullRef104:                                  ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef105:                                  ; preds = %94
+ThrowNullRef106:                                  ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef107:                                  ; preds = %64
+ThrowNullRef108:                                  ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef109:                                  ; preds = %68
+ThrowNullRef110:                                  ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef111:                                  ; preds = %71
+ThrowNullRef112:                                  ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef113:                                  ; preds = %76
+ThrowNullRef114:                                  ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef115:                                  ; preds = %56
+ThrowNullRef116:                                  ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef117:                                  ; preds = %60
+ThrowNullRef118:                                  ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef119:                                  ; preds = %37
+ThrowNullRef120:                                  ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef121:                                  ; preds = %41
+ThrowNullRef122:                                  ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef123:                                  ; preds = %46
+ThrowNullRef124:                                  ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef125:                                  ; preds = %51
+ThrowNullRef126:                                  ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef127:                                  ; preds = %27
+ThrowNullRef128:                                  ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef129:                                  ; preds = %31
+ThrowNullRef130:                                  ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef131:                                  ; preds = %19
+ThrowNullRef132:                                  ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef133:                                  ; preds = %22
+ThrowNullRef134:                                  ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef135:                                  ; preds = %338
+ThrowNullRef136:                                  ; preds = %338
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef137:                                  ; preds = %341
+ThrowNullRef138:                                  ; preds = %341
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef139:                                  ; preds = %356
+ThrowNullRef140:                                  ; preds = %356
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef141:                                  ; preds = %360
+ThrowNullRef142:                                  ; preds = %360
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef143:                                  ; preds = %377
+ThrowNullRef144:                                  ; preds = %377
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef145:                                  ; preds = %381
+ThrowNullRef146:                                  ; preds = %381
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef147:                                  ; preds = %424
+ThrowNullRef148:                                  ; preds = %424
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef149:                                  ; preds = %428
+ThrowNullRef150:                                  ; preds = %428
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef151:                                  ; preds = %440
+ThrowNullRef152:                                  ; preds = %440
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef153:                                  ; preds = %444
+ThrowNullRef154:                                  ; preds = %444
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef155:                                  ; preds = %456
+ThrowNullRef156:                                  ; preds = %456
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef157:                                  ; preds = %460
+ThrowNullRef158:                                  ; preds = %460
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef159:                                  ; preds = %474
+ThrowNullRef160:                                  ; preds = %474
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef161:                                  ; preds = %477
+ThrowNullRef162:                                  ; preds = %477
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef163:                                  ; preds = %394
+ThrowNullRef164:                                  ; preds = %394
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef165:                                  ; preds = %398
+ThrowNullRef166:                                  ; preds = %398
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef167:                                  ; preds = %401
+ThrowNullRef168:                                  ; preds = %401
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef169:                                  ; preds = %407
+ThrowNullRef170:                                  ; preds = %407
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1939,8 +2021,8 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
-  br i1 %NullCheck, label %22, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %ThrowNullRef, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
@@ -1948,8 +2030,8 @@ entry:
   store i32 %24, i32* %loc0
   %25 = load i32, i32* %loc0
   %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %26, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %27
 
 ; <label>:27                                      ; preds = %22
   %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
@@ -1971,7 +2053,7 @@ ThrowNullRef:                                     ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1989,8 +2071,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -2022,15 +2104,15 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2048,16 +2130,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
   %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
   store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %15
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
@@ -2072,8 +2154,8 @@ entry:
   %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
   %29 = ptrtoint i16 addrspace(1)* %28 to i64
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %19
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
@@ -2089,19 +2171,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2114,8 +2196,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
@@ -2128,7 +2210,7 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[loadElem]
+Failed to read AppDomain.PrepareDataForSetup[storeElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
@@ -2202,8 +2284,8 @@ entry:
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
-  br i1 %NullCheck24, label %27, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = load i64, i64 addrspace(1)* %26
@@ -2218,8 +2300,8 @@ entry:
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
-  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
   %41 = load i64, i64 addrspace(1)* %39
@@ -2236,8 +2318,8 @@ entry:
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
-  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
   %54 = load i64, i64 addrspace(1)* %52
@@ -2252,8 +2334,8 @@ entry:
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
   %67 = load i64, i64 addrspace(1)* %65
@@ -2270,8 +2352,8 @@ entry:
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
-  br i1 %NullCheck16, label %79, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
   %80 = load i64, i64 addrspace(1)* %78
@@ -2286,8 +2368,8 @@ entry:
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
-  br i1 %NullCheck18, label %92, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
   %93 = load i64, i64 addrspace(1)* %91
@@ -2304,8 +2386,8 @@ entry:
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
-  br i1 %NullCheck12, label %105, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = load i64, i64 addrspace(1)* %104
@@ -2320,8 +2402,8 @@ entry:
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
-  br i1 %NullCheck14, label %118, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
   %119 = load i64, i64 addrspace(1)* %117
@@ -2337,8 +2419,8 @@ entry:
 
 ; <label>:128                                     ; preds = %20
   %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
-  br i1 %NullCheck4, label %130, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %129, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %130
 
 ; <label>:130                                     ; preds = %128
   %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
@@ -2346,8 +2428,8 @@ entry:
   %133 = load i16, i16 addrspace(1)* %132, align 8
   %134 = zext i16 %133 to i32
   %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
-  br i1 %NullCheck6, label %136, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %135, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %136
 
 ; <label>:136                                     ; preds = %130
   %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
@@ -2360,8 +2442,8 @@ entry:
 
 ; <label>:143                                     ; preds = %136
   %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
-  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %144, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %145
 
 ; <label>:145                                     ; preds = %143
   %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
@@ -2369,8 +2451,8 @@ entry:
   %148 = load i16, i16 addrspace(1)* %147, align 8
   %149 = zext i16 %148 to i32
   %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %150, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %151
 
 ; <label>:151                                     ; preds = %145
   %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
@@ -2388,8 +2470,8 @@ entry:
 
 ; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
-  br i1 %NullCheck, label %163, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %ThrowNullRef, label %163
 
 ; <label>:163                                     ; preds = %161
   %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
@@ -2399,8 +2481,8 @@ entry:
 
 ; <label>:167                                     ; preds = %163
   %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
-  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %168, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %169
 
 ; <label>:169                                     ; preds = %167
   %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
@@ -2432,55 +2514,55 @@ ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %167
+ThrowNullRef2:                                    ; preds = %167
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %128
+ThrowNullRef4:                                    ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %130
+ThrowNullRef6:                                    ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %143
+ThrowNullRef8:                                    ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %145
+ThrowNullRef10:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %102
+ThrowNullRef12:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %105
+ThrowNullRef14:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %76
+ThrowNullRef16:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %79
+ThrowNullRef18:                                   ; preds = %79
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %50
+ThrowNullRef20:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %53
+ThrowNullRef22:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %24
+ThrowNullRef24:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %27
+ThrowNullRef26:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2503,15 +2585,15 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2519,16 +2601,16 @@ entry:
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
   store i32 %8, i32* %loc0
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
   %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
   store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
@@ -2546,16 +2628,16 @@ entry:
 
 ; <label>:23                                      ; preds = %64
   %24 = load i16*, i16** %loc3
-  %NullCheck12 = icmp ne i16* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i16* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
   store i32 %27, i32* %loc5
   %28 = load i16*, i16** %loc4
-  %NullCheck14 = icmp ne i16* %28, null
-  br i1 %NullCheck14, label %29, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %28, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = load i16, i16* %28, align 8
@@ -2620,15 +2702,15 @@ entry:
 
 ; <label>:67                                      ; preds = %64
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
-  br i1 %NullCheck8, label %69, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %68, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %69
 
 ; <label>:69                                      ; preds = %67
   %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
   %71 = load i32, i32 addrspace(1)* %70
   %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
-  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %73
 
 ; <label>:73                                      ; preds = %69
   %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
@@ -2645,31 +2727,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %67
+ThrowNullRef8:                                    ; preds = %67
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %69
+ThrowNullRef10:                                   ; preds = %69
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2710,14 +2792,14 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
   %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
@@ -2730,14 +2812,14 @@ entry:
 
 ; <label>:11                                      ; preds = %4
   %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
   %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
@@ -2749,14 +2831,14 @@ entry:
 
 ; <label>:22                                      ; preds = %16
   %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
   %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
-  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
-  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
@@ -2804,23 +2886,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2836,7 +2918,280 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[loadElem]
+Successfully read RuntimeType.IsAssignableFrom
+
+define i8 @RuntimeType.IsAssignableFrom(%System.RuntimeType addrspace(1)* %param0, %System.Type addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.RuntimeType addrspace(1)*
+  %arg1 = alloca %System.Type addrspace(1)*
+  %loc0 = alloca %System.RuntimeType addrspace(1)*
+  %loc1 = alloca %"System.Type[]" addrspace(1)*
+  %loc2 = alloca i32
+  store %System.RuntimeType addrspace(1)* %param0, %System.RuntimeType addrspace(1)** %this
+  store %System.Type addrspace(1)* %param1, %System.Type addrspace(1)** %arg1
+  %0 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %1 = icmp ne %System.Type addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i8 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %5 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %6 = bitcast %System.Type addrspace(1)* %4 to %System.Object addrspace(1)*
+  %7 = bitcast %System.RuntimeType addrspace(1)* %5 to %System.Object addrspace(1)*
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %6, %System.Object addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %3
+  ret i8 1
+
+; <label>:12                                      ; preds = %3
+  %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 152
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 32
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
+  %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
+  %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
+  store %System.RuntimeType addrspace(1)* %25, %System.RuntimeType addrspace(1)** %loc0
+  %26 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %27 = icmp eq %System.RuntimeType addrspace(1)* %26, null
+  br i1 %27, label %34, label %28
+
+; <label>:28                                      ; preds = %15
+  %29 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %30 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)*)*)(%System.RuntimeType addrspace(1)* %29, %System.RuntimeType addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+; <label>:34                                      ; preds = %15
+  %35 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %36 = call %System.Reflection.Emit.TypeBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Reflection.Emit.TypeBuilder addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %35)
+  %37 = icmp eq %System.Reflection.Emit.TypeBuilder addrspace(1)* %36, null
+  br i1 %37, label %139, label %38
+
+; <label>:38                                      ; preds = %34
+  %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %42
+
+; <label>:42                                      ; preds = %38
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 152
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 40
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
+  %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
+  %53 = zext i8 %52 to i32
+  %54 = icmp eq i32 %53, 0
+  br i1 %54, label %56, label %55
+
+; <label>:55                                      ; preds = %42
+  ret i8 1
+
+; <label>:56                                      ; preds = %42
+  %57 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %58 = bitcast %System.RuntimeType addrspace(1)* %57 to %System.Type addrspace(1)*
+  %59 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %58)
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %64 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.Type addrspace(1)* %63, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = bitcast %System.RuntimeType addrspace(1)* %64 to %System.Type addrspace(1)*
+  %67 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %63, %System.Type addrspace(1)* %66)
+  %68 = zext i8 %67 to i32
+  %69 = trunc i32 %68 to i8
+  ret i8 %69
+
+; <label>:70                                      ; preds = %56
+  %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
+  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %73
+
+; <label>:73                                      ; preds = %70
+  %74 = load i64, i64 addrspace(1)* %72
+  %75 = add i64 %74, 128
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = add i64 %77, 0
+  %79 = inttoptr i64 %78 to i64*
+  %80 = load i64, i64* %79
+  %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
+  %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
+  %83 = call i8 %82(%System.Type addrspace(1)* %81)
+  %84 = zext i8 %83 to i32
+  %85 = icmp eq i32 %84, 0
+  br i1 %85, label %139, label %86
+
+; <label>:86                                      ; preds = %73
+  %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
+  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %89
+
+; <label>:89                                      ; preds = %86
+  %90 = load i64, i64 addrspace(1)* %88
+  %91 = add i64 %90, 128
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = add i64 %93, 24
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
+  %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
+  %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
+  store %"System.Type[]" addrspace(1)* %99, %"System.Type[]" addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %129
+
+; <label>:100                                     ; preds = %132
+  %101 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %102 = load i32, i32* %loc2
+  %NullCheck11 = icmp eq %"System.Type[]" addrspace(1)* %101, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %103
+
+; <label>:103                                     ; preds = %100
+  %104 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 1
+  %105 = load i32, i32 addrspace(1)* %104
+  %106 = zext i32 %105 to i64
+  %107 = zext i32 %102 to i64
+  %BoundsCheck = icmp uge i64 %107, %106
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %108
+
+; <label>:108                                     ; preds = %103
+  %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
+  %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
+  %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
+  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %113
+
+; <label>:113                                     ; preds = %108
+  %114 = load i64, i64 addrspace(1)* %112
+  %115 = add i64 %114, 152
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = add i64 %117, 56
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
+  %123 = zext i8 %122 to i32
+  %124 = icmp ne i32 %123, 0
+  br i1 %124, label %126, label %125
+
+; <label>:125                                     ; preds = %113
+  ret i8 0
+
+; <label>:126                                     ; preds = %113
+  %127 = load i32, i32* %loc2
+  %128 = add i32 %127, 1
+  store i32 %128, i32* %loc2
+  br label %129
+
+; <label>:129                                     ; preds = %89, %126
+  %130 = load i32, i32* %loc2
+  %131 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %NullCheck9 = icmp eq %"System.Type[]" addrspace(1)* %131, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %132
+
+; <label>:132                                     ; preds = %129
+  %133 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %131, i32 0, i32 1
+  %134 = load i32, i32 addrspace(1)* %133
+  %135 = zext i32 %134 to i64
+  %136 = trunc i64 %135 to i32
+  %137 = icmp slt i32 %130, %136
+  br i1 %137, label %100, label %138
+
+; <label>:138                                     ; preds = %132
+  ret i8 1
+
+; <label>:139                                     ; preds = %34, %73
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %129
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %103
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -2893,7 +3248,7 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElem]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -2904,8 +3259,8 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -2997,8 +3352,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
@@ -3059,8 +3414,8 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -3087,8 +3442,8 @@ entry:
 
 ; <label>:17                                      ; preds = %5, %11
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
@@ -3097,8 +3452,8 @@ entry:
 
 ; <label>:22                                      ; preds = %1, %11
   %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
@@ -3109,11 +3464,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %17
+ThrowNullRef2:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %22
+ThrowNullRef4:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3167,15 +3522,15 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
   %15 = load i32, i32 addrspace(1)* %14
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
@@ -3198,7 +3553,7 @@ ThrowNullRef:                                     ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef2:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3232,8 +3587,8 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
@@ -3312,8 +3667,8 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -3327,8 +3682,8 @@ entry:
 ; <label>:5                                       ; preds = %43
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %7 = load i32, i32* %loc1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck6, label %8, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
@@ -3366,8 +3721,8 @@ entry:
 ; <label>:32                                      ; preds = %21, %25
   %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
   %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
-  br i1 %NullCheck8, label %35, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = trunc i32 %34 to i16
@@ -3380,8 +3735,8 @@ entry:
 ; <label>:40                                      ; preds = %1, %35
   %41 = load i32, i32* %loc1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
-  br i1 %NullCheck2, label %43, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %42, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
@@ -3392,8 +3747,8 @@ entry:
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
   %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
-  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
   %51 = load i64, i64 addrspace(1)* %49
@@ -3412,19 +3767,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %40
+ThrowNullRef2:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %47
+ThrowNullRef4:                                    ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %5
+ThrowNullRef6:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %32
+ThrowNullRef8:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3467,8 +3822,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
@@ -3492,11 +3847,391 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(i16* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store i16* %param0, i16** %arg0
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load i32, i32* %arg3
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %42, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %37, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg2
+  %13 = load i32, i32* %arg3
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %37, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %24 = load i32, i32* %arg2
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load i16*, i16** %arg0
+  %35 = load i32, i32* %arg3
+  %36 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %36, i16* %34, i32 %35)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:37                                      ; preds = %5, %16
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %39)
+  %41 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41, %System.String addrspace(1)* %38, %System.String addrspace(1)* %40)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41) #0
+  unreachable
+
+; <label>:42                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
-Failed to read StringBuilder.ToString[loadElemA]
+Successfully read StringBuilder.ToString
+
+define %System.String addrspace(1)* @StringBuilder.ToString(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i16*
+  %loc3 = alloca %"System.Char[]" addrspace(1)*
+  %loc4 = alloca i32
+  %loc5 = alloca i32
+  %loc6 = alloca i16 addrspace(1)*
+  %loc7 = alloca %System.String addrspace(1)*
+  %loc8 = alloca %"System.Char[]" addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %0)
+  %2 = icmp ne i32 %1, 0
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %4
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %6)
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %7)
+  store %System.String addrspace(1)* %8, %System.String addrspace(1)** %loc0
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.Text.StringBuilder addrspace(1)* %9, %System.Text.StringBuilder addrspace(1)** %loc1
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  store %System.String addrspace(1)* %10, %System.String addrspace(1)** %loc7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc7
+  %12 = ptrtoint %System.String addrspace(1)* %11 to i64
+  %13 = icmp eq i64 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %5
+  %15 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %16 = sext i32 %15 to i64
+  %17 = add i64 %12, %16
+  br label %18
+
+; <label>:18                                      ; preds = %5, %14
+  %19 = phi i64 [ %12, %5 ], [ %17, %14 ]
+  %20 = inttoptr i64 %19 to i16*
+  store i16* %20, i16** %loc2
+  br label %21
+
+; <label>:21                                      ; preds = %98, %18
+  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %22, null
+  br i1 %NullCheck, label %ThrowNullRef, label %23
+
+; <label>:23                                      ; preds = %21
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 3
+  %25 = load i32, i32 addrspace(1)* %24, align 8
+  %26 = icmp sle i32 %25, 0
+  br i1 %26, label %96, label %27
+
+; <label>:27                                      ; preds = %23
+  %28 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %28, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %29
+
+; <label>:29                                      ; preds = %27
+  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %28, i32 0, i32 1
+  %31 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %30, align 8
+  store %"System.Char[]" addrspace(1)* %31, %"System.Char[]" addrspace(1)** %loc3
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %33
+
+; <label>:33                                      ; preds = %29
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  store i32 %35, i32* %loc4
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  %39 = load i32, i32 addrspace(1)* %38, align 8
+  store i32 %39, i32* %loc5
+  %40 = load i32, i32* %loc5
+  %41 = load i32, i32* %loc4
+  %42 = add i32 %40, %41
+  %43 = zext i32 %42 to i64
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %45
+
+; <label>:45                                      ; preds = %37
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = sext i32 %47 to i64
+  %49 = icmp sgt i64 %43, %48
+  br i1 %49, label %91, label %50
+
+; <label>:50                                      ; preds = %45
+  %51 = load i32, i32* %loc5
+  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %52, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %53
+
+; <label>:53                                      ; preds = %50
+  %54 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %52, i32 0, i32 1
+  %55 = load i32, i32 addrspace(1)* %54
+  %56 = zext i32 %55 to i64
+  %57 = trunc i64 %56 to i32
+  %58 = icmp ugt i32 %51, %57
+  br i1 %58, label %91, label %59
+
+; <label>:59                                      ; preds = %53
+  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  store %"System.Char[]" addrspace(1)* %60, %"System.Char[]" addrspace(1)** %loc8
+  %61 = icmp eq %"System.Char[]" addrspace(1)* %60, null
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %63, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %64
+
+; <label>:64                                      ; preds = %62
+  %65 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %63, i32 0, i32 1
+  %66 = load i32, i32 addrspace(1)* %65
+  %67 = zext i32 %66 to i64
+  %68 = trunc i64 %67 to i32
+  %69 = icmp ne i32 %68, 0
+  br i1 %69, label %71, label %70
+
+; <label>:70                                      ; preds = %59, %64
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:71                                      ; preds = %64
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %73
+
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %BoundsCheck = icmp uge i64 0, %76
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %77
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %78, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:79                                      ; preds = %70, %77
+  %80 = load i16*, i16** %loc2
+  %81 = load i32, i32* %loc4
+  %82 = sext i32 %81 to i64
+  %83 = mul i64 %82, 2
+  %84 = bitcast i16* %80 to i8*
+  %85 = getelementptr inbounds i8, i8* %84, i64 %83
+  %86 = load i16 addrspace(1)*, i16 addrspace(1)** %loc6
+  %87 = ptrtoint i16 addrspace(1)* %86 to i64
+  %88 = load i32, i32* %loc5
+  %89 = bitcast i8* %85 to i16*
+  %90 = inttoptr i64 %87 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %89, i16* %90, i32 %88)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %96
+
+; <label>:91                                      ; preds = %45, %53
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %94 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %93)
+  %95 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95, %System.String addrspace(1)* %92, %System.String addrspace(1)* %94)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95) #0
+  unreachable
+
+; <label>:96                                      ; preds = %23, %79
+  %97 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %97, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %98
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %97, i32 0, i32 2
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  store %System.Text.StringBuilder addrspace(1)* %100, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %102 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %102, label %21, label %103
+
+; <label>:103                                     ; preds = %98
+  store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc7
+  %104 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  ret %System.String addrspace(1)* %104
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method StringBuilder::get_Length using LLILCJit
+Successfully read StringBuilder.get_Length
+
+define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
+Successfully read RuntimeHelpers.get_OffsetToStringData
+
+define i32 @RuntimeHelpers.get_OffsetToStringData() {
+entry:
+  ret i32 12
+}
+
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
 Successfully read CultureData.CreateCultureData
 
@@ -3514,23 +4249,23 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
   store i8 %4, i8 addrspace(1)* %6
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
@@ -3549,11 +4284,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3566,50 +4301,50 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
   store i32 -1, i32 addrspace(1)* %2
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
   store i32 -1, i32 addrspace(1)* %8
   %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
   store i32 -1, i32 addrspace(1)* %14
   %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
   store i32 -1, i32 addrspace(1)* %17
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
@@ -3623,27 +4358,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3675,7 +4410,136 @@ Failed to read Dictionary`2.Insert[non-const derefAddress]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
 Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
-Failed to read HashHelpers.GetPrime[loadElem]
+Successfully read HashHelpers.GetPrime
+
+define i32 @HashHelpers.GetPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %6, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5, %System.String addrspace(1)* %4)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5) #0
+  unreachable
+
+; <label>:6                                       ; preds = %entry
+  store i32 0, i32* %loc0
+  br label %29
+
+; <label>:7                                       ; preds = %35
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 1296
+  %10 = addrspacecast i8 addrspace(1)* %9 to %"System.Int32[]" addrspace(1)**
+  %11 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %10
+  %12 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Int32[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = zext i32 %15 to i64
+  %17 = zext i32 %12 to i64
+  %BoundsCheck = icmp uge i64 %17, %16
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 3, i32 %12
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  store i32 %20, i32* %loc1
+  %21 = load i32, i32* %loc1
+  %22 = load i32, i32* %arg0
+  %23 = icmp slt i32 %21, %22
+  br i1 %23, label %26, label %24
+
+; <label>:24                                      ; preds = %18
+  %25 = load i32, i32* %loc1
+  ret i32 %25
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %loc0
+  %28 = add i32 %27, 1
+  store i32 %28, i32* %loc0
+  br label %29
+
+; <label>:29                                      ; preds = %6, %26
+  %30 = load i32, i32* %loc0
+  %31 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %32 = getelementptr inbounds i8, i8 addrspace(1)* %31, i64 1296
+  %33 = addrspacecast i8 addrspace(1)* %32 to %"System.Int32[]" addrspace(1)**
+  %34 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %33
+  %NullCheck = icmp eq %"System.Int32[]" addrspace(1)* %34, null
+  br i1 %NullCheck, label %ThrowNullRef, label %35
+
+; <label>:35                                      ; preds = %29
+  %36 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %34, i32 0, i32 1
+  %37 = load i32, i32 addrspace(1)* %36
+  %38 = zext i32 %37 to i64
+  %39 = trunc i64 %38 to i32
+  %40 = icmp slt i32 %30, %39
+  br i1 %40, label %7, label %41
+
+; <label>:41                                      ; preds = %35
+  %42 = load i32, i32* %arg0
+  %43 = or i32 %42, 1
+  store i32 %43, i32* %loc2
+  br label %59
+
+; <label>:44                                      ; preds = %59
+  %45 = load i32, i32* %loc2
+  %46 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %45)
+  %47 = zext i8 %46 to i32
+  %48 = icmp eq i32 %47, 0
+  br i1 %48, label %56, label %49
+
+; <label>:49                                      ; preds = %44
+  %50 = load i32, i32* %loc2
+  %51 = sub i32 %50, 1
+  %52 = srem i32 %51, 101
+  %53 = icmp eq i32 %52, 0
+  br i1 %53, label %56, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = load i32, i32* %loc2
+  ret i32 %55
+
+; <label>:56                                      ; preds = %44, %49
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %57, 2
+  store i32 %58, i32* %loc2
+  br label %59
+
+; <label>:59                                      ; preds = %41, %56
+  %60 = load i32, i32* %loc2
+  %61 = icmp slt i32 %60, 2147483647
+  br i1 %61, label %44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load i32, i32* %arg0
+  ret i32 %63
+
+ThrowNullRef:                                     ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
 Successfully read GenericEqualityComparer`1.GetHashCode
 
@@ -3694,14 +4558,14 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
   %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load i64, i64 addrspace(1)* %7
@@ -3720,7 +4584,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3750,8 +4614,8 @@ entry:
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
@@ -3796,8 +4660,8 @@ entry:
   %35 = bitcast i16* %34 to i8*
   %36 = getelementptr inbounds i8, i8* %35, i64 2
   %37 = bitcast i8* %36 to i16*
-  %NullCheck4 = icmp ne i16* %37, null
-  br i1 %NullCheck4, label %38, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %37, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %38
 
 ; <label>:38                                      ; preds = %27
   %39 = load i16, i16* %37, align 8
@@ -3824,8 +4688,8 @@ entry:
 
 ; <label>:54                                      ; preds = %22, %43
   %55 = load i16*, i16** %loc4
-  %NullCheck2 = icmp ne i16* %55, null
-  br i1 %NullCheck2, label %56, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i16* %55, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %56
 
 ; <label>:56                                      ; preds = %54
   %57 = load i16, i16* %55, align 8
@@ -3850,11 +4714,11 @@ ThrowNullRef:                                     ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %54
+ThrowNullRef2:                                    ; preds = %54
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %27
+ThrowNullRef4:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3871,8 +4735,8 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -3907,8 +4771,8 @@ entry:
 
 ; <label>:26                                      ; preds = %19
   %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
-  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %28
 
 ; <label>:28                                      ; preds = %26
   %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
@@ -3920,7 +4784,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3972,8 +4836,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
@@ -3984,26 +4848,26 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
-  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
@@ -4014,8 +4878,8 @@ entry:
 ; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
@@ -4024,8 +4888,8 @@ entry:
 
 ; <label>:25                                      ; preds = %1, %16, %23
   %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
-  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
@@ -4036,27 +4900,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %20
+ThrowNullRef10:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4069,8 +4933,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -4081,8 +4945,8 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
@@ -4091,8 +4955,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1, %8
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
@@ -4103,11 +4967,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4128,24 +4992,24 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   store i32 %3, i32* %loc0
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
   %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
   store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck4, label %9, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
@@ -4164,15 +5028,15 @@ entry:
 ; <label>:18                                      ; preds = %70
   %19 = load i16*, i16** %loc3
   %20 = bitcast i16* %19 to i64*
-  %NullCheck10 = icmp ne i64* %20, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %20, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = load i64, i64* %20, align 8
   %23 = load i16*, i16** %loc4
   %24 = bitcast i16* %23 to i64*
-  %NullCheck12 = icmp ne i64* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = load i64, i64* %24, align 8
@@ -4188,8 +5052,8 @@ entry:
   %31 = bitcast i16* %30 to i8*
   %32 = getelementptr inbounds i8, i8* %31, i64 8
   %33 = bitcast i8* %32 to i64*
-  %NullCheck14 = icmp ne i64* %33, null
-  br i1 %NullCheck14, label %34, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = load i64, i64* %33, align 8
@@ -4197,8 +5061,8 @@ entry:
   %37 = bitcast i16* %36 to i8*
   %38 = getelementptr inbounds i8, i8* %37, i64 8
   %39 = bitcast i8* %38 to i64*
-  %NullCheck16 = icmp ne i64* %39, null
-  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %40
 
 ; <label>:40                                      ; preds = %34
   %41 = load i64, i64* %39, align 8
@@ -4214,8 +5078,8 @@ entry:
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %NullCheck18 = icmp ne i64* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = load i64, i64* %48, align 8
@@ -4223,8 +5087,8 @@ entry:
   %52 = bitcast i16* %51 to i8*
   %53 = getelementptr inbounds i8, i8* %52, i64 16
   %54 = bitcast i8* %53 to i64*
-  %NullCheck20 = icmp ne i64* %54, null
-  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64* %54, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %55
 
 ; <label>:55                                      ; preds = %49
   %56 = load i64, i64* %54, align 8
@@ -4262,15 +5126,15 @@ entry:
 ; <label>:74                                      ; preds = %95
   %75 = load i16*, i16** %loc3
   %76 = bitcast i16* %75 to i32*
-  %NullCheck6 = icmp ne i32* %76, null
-  br i1 %NullCheck6, label %77, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32* %76, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %77
 
 ; <label>:77                                      ; preds = %74
   %78 = load i32, i32* %76, align 8
   %79 = load i16*, i16** %loc4
   %80 = bitcast i16* %79 to i32*
-  %NullCheck8 = icmp ne i32* %80, null
-  br i1 %NullCheck8, label %81, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i32* %80, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %81
 
 ; <label>:81                                      ; preds = %77
   %82 = load i32, i32* %80, align 8
@@ -4318,43 +5182,43 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %74
+ThrowNullRef6:                                    ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %77
+ThrowNullRef8:                                    ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %29
+ThrowNullRef14:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %34
+ThrowNullRef16:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4376,8 +5240,8 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load i64, i64 addrspace(1)* %4
@@ -4389,8 +5253,8 @@ entry:
   %12 = load i64, i64* %11
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %5
   %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
@@ -4399,8 +5263,8 @@ entry:
   %18 = load i8, i8* %arg2
   %19 = zext i8 %18 to i32
   %20 = trunc i32 %19 to i8
-  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %15
   %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
@@ -4411,11 +5275,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4442,8 +5306,8 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
@@ -4466,16 +5330,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
   %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = load i64, i64 addrspace(1)* %19
@@ -4500,8 +5364,8 @@ entry:
 ; <label>:35                                      ; preds = %30
   %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
@@ -4514,8 +5378,8 @@ entry:
 
 ; <label>:42                                      ; preds = %1, %38
   %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
-  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
@@ -4526,19 +5390,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %35
+ThrowNullRef2:                                    ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %42
+ThrowNullRef8:                                    ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4551,14 +5415,14 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
@@ -4570,7 +5434,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4583,8 +5447,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
@@ -4613,51 +5477,51 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
   %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
   %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
   %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
   %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
-  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
   store i64 %21, i64 addrspace(1)* %23
   %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %25 = load i64, i64* %loc0
-  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
@@ -4668,27 +5532,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %22
+ThrowNullRef12:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4701,8 +5565,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
@@ -4713,19 +5577,19 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
@@ -4734,8 +5598,8 @@ entry:
 
 ; <label>:15                                      ; preds = %1, %13
   %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
@@ -4746,19 +5610,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %15
+ThrowNullRef8:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4771,8 +5635,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -4831,8 +5695,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
@@ -4882,8 +5746,8 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
-  br i1 %NullCheck, label %17, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %ThrowNullRef, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
@@ -4894,15 +5758,15 @@ entry:
 
 ; <label>:22                                      ; preds = %17
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
-  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
   %26 = load i32, i32 addrspace(1)* %25
   %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
-  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %27, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
@@ -4925,8 +5789,8 @@ entry:
 ; <label>:40                                      ; preds = %17
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
-  br i1 %NullCheck6, label %43, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %41, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
@@ -4938,34 +5802,17 @@ ThrowNullRef:                                     ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %24
+ThrowNullRef4:                                    ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %40
+ThrowNullRef6:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
-}
-
-INFO:  jitting method Object::ReferenceEquals using LLILCJit
-Successfully read Object.ReferenceEquals
-
-define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
-entry:
-  %arg0 = alloca %System.Object addrspace(1)*
-  %arg1 = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
-  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
-  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = icmp eq %System.Object addrspace(1)* %0, %1
-  %3 = sext i1 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
 }
 
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
@@ -4978,21 +5825,21 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
   %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
-  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
@@ -5007,28 +5854,28 @@ entry:
 ; <label>:13                                      ; preds = %8, %12
   %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
   %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
   %21 = load i32, i32 addrspace(1)* %20, align 8
   %22 = add i32 %21, 1
-  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
   store i32 %22, i32 addrspace(1)* %24
   %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
@@ -5039,27 +5886,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5077,7 +5924,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::Setup using LLILCJit
-Failed to read AppDomain.Setup[loadElem]
+Failed to read AppDomain.Setup[unbox]
 INFO:  jitting method Thread::GetDomain using LLILCJit
 Successfully read Thread.GetDomain
 
@@ -5108,8 +5955,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
@@ -5122,14 +5969,14 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
   %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
@@ -5141,11 +5988,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5173,8 +6020,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -5189,7 +6036,328 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
 Failed to read KeyCollection.System.Collections.Generic.IEnumerable<TKey>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Successfully read Enumerator.MoveNext
+
+define i8 @Enumerator.MoveNext(%"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.RuntimeTypeHandle* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*
+  %"$TypeArg" = alloca %System.RuntimeTypeHandle*
+  store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
+  %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 8
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %76, label %12
+
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
+  br label %76
+
+; <label>:13                                      ; preds = %85
+  %14 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck19 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %15
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, i32 0, i32 0
+  %17 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %16, align 8
+  %NullCheck21 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, i32 0, i32 2
+  %20 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %19, align 8
+  %21 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck23 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %22
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, i32 0, i32 2
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %NullCheck25 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 3, i32 %24
+  %NullCheck27 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %32
+
+; <label>:32                                      ; preds = %30
+  %33 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, i32 0, i32 2
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = icmp slt i32 %34, 0
+  br i1 %35, label %68, label %36
+
+; <label>:36                                      ; preds = %32
+  %37 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %38 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck29 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %39
+
+; <label>:39                                      ; preds = %36
+  %40 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, i32 0, i32 0
+  %41 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %40, align 8
+  %NullCheck31 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, i32 0, i32 2
+  %44 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %43, align 8
+  %45 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck33 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, i32 0, i32 2
+  %48 = load i32, i32 addrspace(1)* %47, align 8
+  %NullCheck35 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %49
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = zext i32 %51 to i64
+  %53 = zext i32 %48 to i64
+  %BoundsCheck37 = icmp uge i64 %53, %52
+  br i1 %BoundsCheck37, label %ThrowIndexOutOfRange38, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 3, i32 %48
+  %NullCheck39 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %56
+
+; <label>:56                                      ; preds = %54
+  %57 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, i32 0, i32 0
+  %58 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck41 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %59
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %60, %System.__Canon addrspace(1)* %58)
+  %61 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck43 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  %64 = load i32, i32 addrspace(1)* %63, align 8
+  %65 = add i32 %64, 1
+  %NullCheck45 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  store i32 %65, i32 addrspace(1)* %67
+  ret i8 1
+
+; <label>:68                                      ; preds = %32
+  %69 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck47 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %73 = add i32 %72, 1
+  %NullCheck49 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %74
+
+; <label>:74                                      ; preds = %70
+  %75 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  store i32 %73, i32 addrspace(1)* %75
+  br label %76
+
+; <label>:76                                      ; preds = %8, %12, %74
+  %77 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %78
+
+; <label>:78                                      ; preds = %76
+  %79 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, i32 0, i32 2
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck7 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %82
+
+; <label>:82                                      ; preds = %78
+  %83 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, i32 0, i32 0
+  %84 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %83, align 8
+  %NullCheck9 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %85
+
+; <label>:85                                      ; preds = %82
+  %86 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, i32 0, i32 7
+  %87 = load i32, i32 addrspace(1)* %86, align 8
+  %88 = icmp ult i32 %80, %87
+  br i1 %88, label %13, label %89
+
+; <label>:89                                      ; preds = %85
+  %90 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %91 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck11 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %92
+
+; <label>:92                                      ; preds = %89
+  %93 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, i32 0, i32 0
+  %94 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck13 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %95
+
+; <label>:95                                      ; preds = %92
+  %96 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, i32 0, i32 7
+  %97 = load i32, i32 addrspace(1)* %96, align 8
+  %98 = add i32 %97, 1
+  %NullCheck15 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %99
+
+; <label>:99                                      ; preds = %95
+  %100 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, i32 0, i32 2
+  store i32 %98, i32 addrspace(1)* %100
+  %101 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck17 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %102
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %103, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %92
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef22:                                   ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef24:                                   ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef26:                                   ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef28:                                   ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef30:                                   ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef32:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef34:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef36:                                   ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange38:                           ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef40:                                   ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef42:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef44:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef46:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef48:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef50:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -5200,8 +6368,8 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -5232,9 +6400,9 @@ Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
 Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
-Failed to read String.MakeSeparatorList[loadElemA]
+Failed to read String.MakeSeparatorList[storeElem]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
-Failed to read String.InternalSplitKeepEmptyEntries[loadElem]
+Failed to read String.InternalSplitKeepEmptyEntries[storeElem]
 INFO:  jitting method Path::IsRelative using LLILCJit
 Successfully read Path.IsRelative
 
@@ -5243,8 +6411,8 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -5254,8 +6422,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
@@ -5271,8 +6439,8 @@ entry:
 
 ; <label>:17                                      ; preds = %7
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
@@ -5288,8 +6456,8 @@ entry:
 
 ; <label>:29                                      ; preds = %19
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %31
 
 ; <label>:31                                      ; preds = %29
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
@@ -5300,8 +6468,8 @@ entry:
 
 ; <label>:36                                      ; preds = %31
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
-  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %37, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
@@ -5312,8 +6480,8 @@ entry:
 
 ; <label>:43                                      ; preds = %31, %38
   %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
-  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %45
 
 ; <label>:45                                      ; preds = %43
   %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
@@ -5324,8 +6492,8 @@ entry:
 
 ; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %50
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
@@ -5336,8 +6504,8 @@ entry:
 
 ; <label>:57                                      ; preds = %1, %7, %19, %45, %52
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
-  br i1 %NullCheck14, label %59, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %59
 
 ; <label>:59                                      ; preds = %57
   %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
@@ -5347,8 +6515,8 @@ entry:
 
 ; <label>:63                                      ; preds = %59
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
@@ -5359,8 +6527,8 @@ entry:
 
 ; <label>:70                                      ; preds = %65
   %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
-  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.String addrspace(1)* %71, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %72
 
 ; <label>:72                                      ; preds = %70
   %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
@@ -5379,39 +6547,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %17
+ThrowNullRef4:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %29
+ThrowNullRef6:                                    ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %36
+ThrowNullRef8:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %43
+ThrowNullRef10:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %50
+ThrowNullRef12:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %57
+ThrowNullRef14:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %63
+ThrowNullRef16:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %70
+ThrowNullRef18:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5419,7 +6587,293 @@ ThrowNullRef17:                                   ; preds = %70
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
-Failed to read String.TrimHelper[loadElem]
+Successfully read String.TrimHelper
+
+define %System.String addrspace(1)* @String.TrimHelper(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i16
+  %loc4 = alloca i32
+  %loc5 = alloca i16
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = sub i32 %3, 1
+  store i32 %4, i32* %loc0
+  store i32 0, i32* %loc1
+  %5 = load i32, i32* %arg2
+  %6 = icmp eq i32 %5, 1
+  br i1 %6, label %62, label %7
+
+; <label>:7                                       ; preds = %1
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:8                                       ; preds = %58
+  store i32 0, i32* %loc2
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load i32, i32* %loc1
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2, i32 %10
+  %13 = load i16, i16 addrspace(1)* %12
+  %14 = zext i16 %13 to i32
+  %15 = trunc i32 %14 to i16
+  store i16 %15, i16* %loc3
+  store i32 0, i32* %loc2
+  br label %34
+
+; <label>:16                                      ; preds = %37
+  %17 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %18 = load i32, i32* %loc2
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %17, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %19
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = zext i32 %18 to i64
+  %BoundsCheck = icmp uge i64 %23, %22
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %24
+
+; <label>:24                                      ; preds = %19
+  %25 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 3, i32 %18
+  %26 = load i16, i16 addrspace(1)* %25, align 8
+  %27 = zext i16 %26 to i32
+  %28 = load i16, i16* %loc3
+  %29 = zext i16 %28 to i32
+  %30 = icmp eq i32 %27, %29
+  br i1 %30, label %43, label %31
+
+; <label>:31                                      ; preds = %24
+  %32 = load i32, i32* %loc2
+  %33 = add i32 %32, 1
+  store i32 %33, i32* %loc2
+  br label %34
+
+; <label>:34                                      ; preds = %11, %31
+  %35 = load i32, i32* %loc2
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = icmp slt i32 %35, %41
+  br i1 %42, label %16, label %43
+
+; <label>:43                                      ; preds = %24, %37
+  %44 = load i32, i32* %loc2
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %45, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp eq i32 %44, %50
+  br i1 %51, label %62, label %52
+
+; <label>:52                                      ; preds = %46
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %7, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %57, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %58
+
+; <label>:58                                      ; preds = %55
+  %59 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %60 = load i32, i32 addrspace(1)* %59
+  %61 = icmp slt i32 %56, %60
+  br i1 %61, label %8, label %62
+
+; <label>:62                                      ; preds = %1, %46, %58
+  %63 = load i32, i32* %arg2
+  %64 = icmp eq i32 %63, 0
+  br i1 %64, label %122, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %66, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %67
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %66, i32 0, i32 1
+  %69 = load i32, i32 addrspace(1)* %68
+  %70 = sub i32 %69, 1
+  store i32 %70, i32* %loc0
+  br label %118
+
+; <label>:71                                      ; preds = %118
+  store i32 0, i32* %loc4
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %73 = load i32, i32* %loc0
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %74
+
+; <label>:74                                      ; preds = %71
+  %75 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 2, i32 %73
+  %76 = load i16, i16 addrspace(1)* %75
+  %77 = zext i16 %76 to i32
+  %78 = trunc i32 %77 to i16
+  store i16 %78, i16* %loc5
+  store i32 0, i32* %loc4
+  br label %97
+
+; <label>:79                                      ; preds = %100
+  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %81 = load i32, i32* %loc4
+  %NullCheck19 = icmp eq %"System.Char[]" addrspace(1)* %80, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
+
+; <label>:82                                      ; preds = %79
+  %83 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 1
+  %84 = load i32, i32 addrspace(1)* %83
+  %85 = zext i32 %84 to i64
+  %86 = zext i32 %81 to i64
+  %BoundsCheck21 = icmp uge i64 %86, %85
+  br i1 %BoundsCheck21, label %ThrowIndexOutOfRange22, label %87
+
+; <label>:87                                      ; preds = %82
+  %88 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 3, i32 %81
+  %89 = load i16, i16 addrspace(1)* %88, align 8
+  %90 = zext i16 %89 to i32
+  %91 = load i16, i16* %loc5
+  %92 = zext i16 %91 to i32
+  %93 = icmp eq i32 %90, %92
+  br i1 %93, label %106, label %94
+
+; <label>:94                                      ; preds = %87
+  %95 = load i32, i32* %loc4
+  %96 = add i32 %95, 1
+  store i32 %96, i32* %loc4
+  br label %97
+
+; <label>:97                                      ; preds = %74, %94
+  %98 = load i32, i32* %loc4
+  %99 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck15 = icmp eq %"System.Char[]" addrspace(1)* %99, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %100
+
+; <label>:100                                     ; preds = %97
+  %101 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %99, i32 0, i32 1
+  %102 = load i32, i32 addrspace(1)* %101
+  %103 = zext i32 %102 to i64
+  %104 = trunc i64 %103 to i32
+  %105 = icmp slt i32 %98, %104
+  br i1 %105, label %79, label %106
+
+; <label>:106                                     ; preds = %87, %100
+  %107 = load i32, i32* %loc4
+  %108 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck17 = icmp eq %"System.Char[]" addrspace(1)* %108, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %109
+
+; <label>:109                                     ; preds = %106
+  %110 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %108, i32 0, i32 1
+  %111 = load i32, i32 addrspace(1)* %110
+  %112 = zext i32 %111 to i64
+  %113 = trunc i64 %112 to i32
+  %114 = icmp eq i32 %107, %113
+  br i1 %114, label %122, label %115
+
+; <label>:115                                     ; preds = %109
+  %116 = load i32, i32* %loc0
+  %117 = sub i32 %116, 1
+  store i32 %117, i32* %loc0
+  br label %118
+
+; <label>:118                                     ; preds = %67, %115
+  %119 = load i32, i32* %loc0
+  %120 = load i32, i32* %loc1
+  %121 = icmp sge i32 %119, %120
+  br i1 %121, label %71, label %122
+
+; <label>:122                                     ; preds = %62, %109, %118
+  %123 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %124 = load i32, i32* %loc1
+  %125 = load i32, i32* %loc0
+  %126 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %123, i32 %124, i32 %125)
+  ret %System.String addrspace(1)* %126
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %97
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange22:                           ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
 Successfully read String.CreateTrimmedString
 
@@ -5439,8 +6893,8 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
@@ -5535,8 +6989,8 @@ entry:
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i64 2872
   %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
   %8 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %7
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %3
   %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
@@ -5553,8 +7007,8 @@ entry:
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 2864
   %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
   %21 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %20
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
-  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %22
 
 ; <label>:22                                      ; preds = %16
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
@@ -5569,7 +7023,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %16
+ThrowNullRef2:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5586,8 +7040,8 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5613,8 +7067,8 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
@@ -5632,8 +7086,8 @@ entry:
 
 ; <label>:12                                      ; preds = %4
   %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
@@ -5644,8 +7098,8 @@ entry:
 
 ; <label>:19                                      ; preds = %14
   %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %19
   %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
@@ -5660,21 +7114,21 @@ entry:
   %31 = zext i16 %30 to i32
   %32 = bitcast i8* %29 to i16*
   %33 = trunc i32 %31 to i16
-  %NullCheck6 = icmp ne i16* %32, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i16* %32, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %21
   store i16 %33, i16* %32, align 8
   %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %36
 
 ; <label>:36                                      ; preds = %34
   %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
   %38 = load i32, i32 addrspace(1)* %37, align 8
   %39 = add i32 %38, 1
-  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %40
 
 ; <label>:40                                      ; preds = %36
   %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
@@ -5683,16 +7137,16 @@ entry:
 
 ; <label>:42                                      ; preds = %14
   %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
-  br i1 %NullCheck12, label %44, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
   %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
   %47 = load i16, i16* %arg1
   %48 = zext i16 %47 to i32
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = trunc i32 %48 to i16
@@ -5703,31 +7157,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %19
+ThrowNullRef4:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %21
+ThrowNullRef6:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %36
+ThrowNullRef10:                                   ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %42
+ThrowNullRef12:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %44
+ThrowNullRef14:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5740,8 +7194,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -5752,8 +7206,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
@@ -5762,14 +7216,14 @@ entry:
 
 ; <label>:11                                      ; preds = %1
   %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
@@ -5779,15 +7233,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5808,8 +7262,8 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5822,8 +7276,8 @@ entry:
 
 ; <label>:8                                       ; preds = %3
   %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
@@ -5842,15 +7296,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
-  br i1 %NullCheck4, label %22, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
   %24 = load i16*, i16* addrspace(1)* %23, align 8
   %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %25, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
@@ -5859,8 +7313,8 @@ entry:
   store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
@@ -5874,8 +7328,8 @@ entry:
 
 ; <label>:37                                      ; preds = %65
   %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %37
   %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
@@ -5886,16 +7340,16 @@ entry:
   %45 = bitcast i16* %41 to i8*
   %46 = getelementptr inbounds i8, i8* %45, i64 %44
   %47 = bitcast i8* %46 to i16*
-  %NullCheck14 = icmp ne i16* %47, null
-  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %47, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %48
 
 ; <label>:48                                      ; preds = %39
   %49 = load i16, i16* %47, align 8
   %50 = zext i16 %49 to i32
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %52 = load i32, i32* %loc1
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %53
 
 ; <label>:53                                      ; preds = %48
   %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
@@ -5916,8 +7370,8 @@ entry:
 ; <label>:62                                      ; preds = %36, %59
   %63 = load i32, i32* %loc1
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck10, label %65, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %65
 
 ; <label>:65                                      ; preds = %62
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
@@ -5936,15 +7390,15 @@ entry:
 
 ; <label>:74                                      ; preds = %70
   %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
-  br i1 %NullCheck18, label %76, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %76
 
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
   %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
-  br i1 %NullCheck20, label %80, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
   %81 = load i64, i64 addrspace(1)* %79
@@ -5958,8 +7412,8 @@ entry:
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
   %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
-  br i1 %NullCheck22, label %92, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.String addrspace(1)* %90, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %92
 
 ; <label>:92                                      ; preds = %80
   %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
@@ -5969,15 +7423,15 @@ entry:
 
 ; <label>:96                                      ; preds = %70
   %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
-  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %98
 
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
   %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
-  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
   %103 = load i64, i64 addrspace(1)* %101
@@ -5991,8 +7445,8 @@ entry:
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
   %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
-  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.String addrspace(1)* %112, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %114
 
 ; <label>:114                                     ; preds = %102
   %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
@@ -6004,59 +7458,59 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %20
+ThrowNullRef4:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %22
+ThrowNullRef6:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %26
+ThrowNullRef8:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %62
+ThrowNullRef10:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %48
+ThrowNullRef16:                                   ; preds = %48
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %74
+ThrowNullRef18:                                   ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %76
+ThrowNullRef20:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %80
+ThrowNullRef22:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %96
+ThrowNullRef24:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %98
+ThrowNullRef26:                                   ; preds = %98
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %102
+ThrowNullRef28:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6069,15 +7523,15 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
   %3 = load i16*, i16* addrspace(1)* %2, align 8
   %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
@@ -6087,8 +7541,8 @@ entry:
   %10 = bitcast i16* %3 to i8*
   %11 = getelementptr inbounds i8, i8* %10, i64 %9
   %12 = bitcast i8* %11 to i16*
-  %NullCheck4 = icmp ne i16* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %5
   store i16 0, i16* %12, align 8
@@ -6098,11 +7552,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6119,8 +7573,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -6131,8 +7585,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
@@ -6144,15 +7598,15 @@ entry:
 
 ; <label>:14                                      ; preds = %1
   %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
   %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
   %21 = load i64, i64 addrspace(1)* %19
@@ -6171,15 +7625,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %14
+ThrowNullRef4:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %16
+ThrowNullRef6:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6302,14 +7756,6 @@ entry:
   ret %System.String addrspace(1)* %57
 }
 
-INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
-Successfully read RuntimeHelpers.get_OffsetToStringData
-
-define i32 @RuntimeHelpers.get_OffsetToStringData() {
-entry:
-  ret i32 12
-}
-
 INFO:  jitting method String::Equals using LLILCJit
 Successfully read String.Equals
 
@@ -6381,8 +7827,8 @@ entry:
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
-  br i1 %NullCheck24, label %29, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
   %30 = load i64, i64 addrspace(1)* %28
@@ -6397,8 +7843,8 @@ entry:
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
-  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
   %43 = load i64, i64 addrspace(1)* %41
@@ -6418,8 +7864,8 @@ entry:
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
   %59 = load i64, i64 addrspace(1)* %57
@@ -6434,8 +7880,8 @@ entry:
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck22, label %71, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
   %72 = load i64, i64 addrspace(1)* %70
@@ -6455,8 +7901,8 @@ entry:
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
-  br i1 %NullCheck16, label %87, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = load i64, i64 addrspace(1)* %86
@@ -6471,8 +7917,8 @@ entry:
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck18, label %100, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
   %101 = load i64, i64 addrspace(1)* %99
@@ -6492,8 +7938,8 @@ entry:
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
-  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
   %117 = load i64, i64 addrspace(1)* %115
@@ -6508,8 +7954,8 @@ entry:
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
-  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
   %130 = load i64, i64 addrspace(1)* %128
@@ -6528,15 +7974,15 @@ entry:
 
 ; <label>:142                                     ; preds = %22
   %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
-  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %143, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %144
 
 ; <label>:144                                     ; preds = %142
   %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
   %146 = load i32, i32 addrspace(1)* %145
   %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
-  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %147, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %148
 
 ; <label>:148                                     ; preds = %144
   %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
@@ -6557,15 +8003,15 @@ entry:
 
 ; <label>:159                                     ; preds = %22
   %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
-  br i1 %NullCheck, label %161, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %ThrowNullRef, label %161
 
 ; <label>:161                                     ; preds = %159
   %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
   %163 = load i32, i32 addrspace(1)* %162
   %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
-  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %164, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %165
 
 ; <label>:165                                     ; preds = %161
   %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
@@ -6578,8 +8024,8 @@ entry:
 
 ; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
-  br i1 %NullCheck4, label %172, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %171, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %172
 
 ; <label>:172                                     ; preds = %170
   %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
@@ -6589,8 +8035,8 @@ entry:
 
 ; <label>:176                                     ; preds = %172
   %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
-  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %177, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %178
 
 ; <label>:178                                     ; preds = %176
   %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
@@ -6629,55 +8075,55 @@ ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %161
+ThrowNullRef2:                                    ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %170
+ThrowNullRef4:                                    ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %176
+ThrowNullRef6:                                    ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %142
+ThrowNullRef8:                                    ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %144
+ThrowNullRef10:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %113
+ThrowNullRef12:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %116
+ThrowNullRef14:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %84
+ThrowNullRef16:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %87
+ThrowNullRef18:                                   ; preds = %87
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %55
+ThrowNullRef20:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %58
+ThrowNullRef22:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %26
+ThrowNullRef24:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %29
+ThrowNullRef26:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,8 +8161,8 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck, label %14, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %ThrowNullRef, label %14
 
 ; <label>:14                                      ; preds = %8
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
@@ -6760,8 +8206,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
@@ -6770,14 +8216,14 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32, i32* %loc0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %10
   %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
   %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
@@ -6790,15 +8236,15 @@ entry:
 ; <label>:25                                      ; preds = %19
   %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
-  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
   %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
@@ -6807,8 +8253,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %37 = load i32, i32* %loc0
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %38, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %38
 
 ; <label>:38                                      ; preds = %32
   %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
@@ -6817,14 +8263,14 @@ entry:
 
 ; <label>:40                                      ; preds = %19
   %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %40
   %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
   %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
-  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
-  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
@@ -6832,8 +8278,8 @@ entry:
   %48 = zext i32 %47 to i64
   %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
-  br i1 %NullCheck16, label %51, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %51
 
 ; <label>:51                                      ; preds = %45
   %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
@@ -6847,15 +8293,15 @@ entry:
 ; <label>:57                                      ; preds = %51
   %58 = load i16*, i16** %arg1
   %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
-  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %60
 
 ; <label>:60                                      ; preds = %57
   %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
   %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
-  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %64
 
 ; <label>:64                                      ; preds = %60
   %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
@@ -6864,22 +8310,22 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
   %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
-  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %70
 
 ; <label>:70                                      ; preds = %64
   %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
   %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
-  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
-  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
   %75 = load i32, i32 addrspace(1)* %74
   %76 = zext i32 %75 to i64
   %77 = trunc i64 %76 to i32
-  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
-  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %78
 
 ; <label>:78                                      ; preds = %73
   %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
@@ -6901,8 +8347,8 @@ entry:
   %90 = bitcast i16* %86 to i8*
   %91 = getelementptr inbounds i8, i8* %90, i64 %89
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %93
 
 ; <label>:93                                      ; preds = %80
   %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
@@ -6912,8 +8358,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %99 = load i32, i32* %loc2
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %100
 
 ; <label>:100                                     ; preds = %93
   %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
@@ -6928,63 +8374,63 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %25
+ThrowNullRef6:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %32
+ThrowNullRef10:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %40
+ThrowNullRef12:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %45
+ThrowNullRef16:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %57
+ThrowNullRef18:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %60
+ThrowNullRef20:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %64
+ThrowNullRef22:                                   ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %70
+ThrowNullRef24:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %73
+ThrowNullRef26:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %80
+ThrowNullRef28:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %93
+ThrowNullRef30:                                   ; preds = %93
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7004,8 +8450,8 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
@@ -7033,43 +8479,43 @@ entry:
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %14
   %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
   %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   %28 = load i32, i32 addrspace(1)* %27, align 8
   %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
-  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %30
 
 ; <label>:30                                      ; preds = %26
   %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
   %32 = load i32, i32 addrspace(1)* %31, align 8
   %33 = add i32 %28, %32
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %34
 
 ; <label>:34                                      ; preds = %30
   %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   store i32 %33, i32 addrspace(1)* %35
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
   store i32 0, i32 addrspace(1)* %38
   %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %40
 
 ; <label>:40                                      ; preds = %37
   %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
@@ -7082,8 +8528,8 @@ entry:
 
 ; <label>:47                                      ; preds = %40
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
@@ -7098,8 +8544,8 @@ entry:
   %54 = load i32, i32* %loc0
   %55 = sext i32 %54 to i64
   %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
-  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %57
 
 ; <label>:57                                      ; preds = %52
   %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
@@ -7110,68 +8556,35 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %14
+ThrowNullRef2:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %23
+ThrowNullRef4:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %26
+ThrowNullRef6:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %30
+ThrowNullRef8:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %34
+ThrowNullRef10:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %47
+ThrowNullRef14:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %52
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-}
-
-INFO:  jitting method StringBuilder::get_Length using LLILCJit
-Successfully read StringBuilder.get_Length
-
-define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.StringBuilder addrspace(1)*
-  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
-  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
-
-; <label>:1                                       ; preds = %entry
-  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %3 = load i32, i32 addrspace(1)* %2, align 8
-  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
-
-; <label>:5                                       ; preds = %1
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = add i32 %3, %7
-  ret i32 %8
-
-ThrowNullRef:                                     ; preds = %entry
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef16:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7213,70 +8626,70 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
   %6 = load i32, i32 addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
   store i32 %6, i32 addrspace(1)* %8
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
   %13 = load i32, i32 addrspace(1)* %12, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
   store i32 %13, i32 addrspace(1)* %15
   %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
-  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %18
 
 ; <label>:18                                      ; preds = %14
   %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
   %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
   %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
   %34 = load i32, i32 addrspace(1)* %33, align 8
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
-  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
@@ -7287,39 +8700,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %28
+ThrowNullRef16:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %32
+ThrowNullRef18:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7455,13 +8868,13 @@ entry:
 ; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
@@ -7477,16 +8890,16 @@ entry:
 
 ; <label>:18                                      ; preds = %15
   %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
   store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
   %22 = load i32, i32* %loc0
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %24
 
 ; <label>:24                                      ; preds = %20
   %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
@@ -7498,13 +8911,13 @@ entry:
 ; <label>:28                                      ; preds = %15, %24
   %29 = load i32, i32* %arg1
   %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %31
   %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
@@ -7517,20 +8930,20 @@ entry:
   %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
-  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
   %46 = load i32, i32 addrspace(1)* %45, align 8
   %47 = sub i32 %40, %46
-  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
-  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i32 addrspace(1)* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %48
 
 ; <label>:48                                      ; preds = %44
   store i32 %47, i32 addrspace(1)* %39, align 8
@@ -7538,21 +8951,21 @@ entry:
 
 ; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
-  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %51
 
 ; <label>:51                                      ; preds = %49
   %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %53
 
 ; <label>:53                                      ; preds = %51
   %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
   %55 = load i32, i32 addrspace(1)* %54, align 8
   %56 = load i32, i32* %arg2
   %57 = sub i32 %55, %56
-  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %58
 
 ; <label>:58                                      ; preds = %53
   %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
@@ -7562,13 +8975,13 @@ entry:
 ; <label>:60                                      ; preds = %33, %58
   %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
   %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
-  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %63
 
 ; <label>:63                                      ; preds = %60
   %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
-  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
-  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
@@ -7578,15 +8991,15 @@ entry:
 
 ; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
-  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i32 addrspace(1)* %69, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %70
 
 ; <label>:70                                      ; preds = %68
   %71 = load i32, i32 addrspace(1)* %69, align 8
   store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
-  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
@@ -7596,8 +9009,8 @@ entry:
   store i32 %77, i32* %loc4
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
-  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %80
 
 ; <label>:80                                      ; preds = %73
   %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
@@ -7607,71 +9020,71 @@ entry:
 ; <label>:83                                      ; preds = %80
   store i32 0, i32* %loc3
   %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
-  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
-  br i1 %NullCheck26, label %88, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i32 addrspace(1)* %87, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %88
 
 ; <label>:88                                      ; preds = %85
   %89 = load i32, i32 addrspace(1)* %87, align 8
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
-  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %90
 
 ; <label>:90                                      ; preds = %88
   %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
   store i32 %89, i32 addrspace(1)* %91
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
-  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
-  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %96
 
 ; <label>:96                                      ; preds = %94
   %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
-  br i1 %NullCheck34, label %100, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %100
 
 ; <label>:100                                     ; preds = %96
   %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
-  br i1 %NullCheck36, label %102, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %102
 
 ; <label>:102                                     ; preds = %100
   %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
   %104 = load i32, i32 addrspace(1)* %103, align 8
   %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
-  br i1 %NullCheck38, label %106, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %106
 
 ; <label>:106                                     ; preds = %102
   %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
-  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
-  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %108
 
 ; <label>:108                                     ; preds = %106
   %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
   %110 = load i32, i32 addrspace(1)* %109, align 8
   %111 = add i32 %104, %110
-  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %112
 
 ; <label>:112                                     ; preds = %108
   %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
   store i32 %111, i32 addrspace(1)* %113
   %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
-  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i32 addrspace(1)* %114, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %115
 
 ; <label>:115                                     ; preds = %112
   %116 = load i32, i32 addrspace(1)* %114, align 8
@@ -7681,19 +9094,19 @@ entry:
 ; <label>:118                                     ; preds = %115
   %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
-  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %121
 
 ; <label>:121                                     ; preds = %118
   %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
-  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
-  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %123
 
 ; <label>:123                                     ; preds = %121
   %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
   %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
-  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
-  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %126
 
 ; <label>:126                                     ; preds = %123
   %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
@@ -7705,8 +9118,8 @@ entry:
 
 ; <label>:130                                     ; preds = %80, %115, %126
   %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %132
 
 ; <label>:132                                     ; preds = %130
   %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7715,8 +9128,8 @@ entry:
   %136 = load i32, i32* %loc3
   %137 = sub i32 %135, %136
   %138 = sub i32 %134, %137
-  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %139
 
 ; <label>:139                                     ; preds = %132
   %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7728,16 +9141,16 @@ entry:
 
 ; <label>:144                                     ; preds = %139
   %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
-  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %146
 
 ; <label>:146                                     ; preds = %144
   %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
   %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
   %149 = load i32, i32* %loc2
   %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
-  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %151
 
 ; <label>:151                                     ; preds = %146
   %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
@@ -7754,145 +9167,249 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %18
+ThrowNullRef4:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %31
+ThrowNullRef10:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %44
+ThrowNullRef16:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %68
+ThrowNullRef18:                                   ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %70
+ThrowNullRef20:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %73
+ThrowNullRef22:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %83
+ThrowNullRef24:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %85
+ThrowNullRef26:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %88
+ThrowNullRef28:                                   ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %90
+ThrowNullRef30:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %94
+ThrowNullRef32:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %96
+ThrowNullRef34:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %100
+ThrowNullRef36:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %102
+ThrowNullRef38:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %106
+ThrowNullRef40:                                   ; preds = %106
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %108
+ThrowNullRef42:                                   ; preds = %108
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %112
+ThrowNullRef44:                                   ; preds = %112
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %118
+ThrowNullRef46:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %121
+ThrowNullRef48:                                   ; preds = %121
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %123
+ThrowNullRef50:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %130
+ThrowNullRef52:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %132
+ThrowNullRef54:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %144
+ThrowNullRef56:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %146
+ThrowNullRef58:                                   ; preds = %146
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %60
+ThrowNullRef60:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %63
+ThrowNullRef62:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %49
+ThrowNullRef64:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %51
+ThrowNullRef66:                                   ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %53
+ThrowNullRef68:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(%"System.Char[]" addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %arg0 = alloca %"System.Char[]" addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store %"System.Char[]" addrspace(1)* %param0, %"System.Char[]" addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load i32, i32* %arg4
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %43, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %38, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg1
+  %13 = load i32, i32* %arg4
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %38, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %24 = load i32, i32* %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %35 = load i32, i32* %arg3
+  %36 = load i32, i32* %arg4
+  %37 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %37, %"System.Char[]" addrspace(1)* %34, i32 %35, i32 %36)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:38                                      ; preds = %5, %16
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Successfully read Buffer._Memmove
 
@@ -7914,7 +9431,7 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[loadElem]
+Failed to read AppDomain.SetDataHelper[storeElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -7923,8 +9440,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
@@ -7934,8 +9451,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
@@ -7947,15 +9464,15 @@ entry:
   %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
   %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
@@ -7966,15 +9483,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7992,7 +9509,79 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
-Failed to read Dictionary`2.TryGetValue[loadElemA]
+Successfully read Dictionary`2.TryGetValue
+
+define i8 @"Dictionary`2.TryGetValue"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)* addrspace(1)* %param2) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  %arg2 = alloca %System.__Canon addrspace(1)* addrspace(1)*
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  store %System.__Canon addrspace(1)* addrspace(1)* %param2, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  store i32 %2, i32* %loc0
+  %3 = load i32, i32* %loc0
+  %4 = icmp slt i32 %3, 0
+  br i1 %4, label %22, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 2
+  %10 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %9, align 8
+  %11 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = zext i32 %11 to i64
+  %BoundsCheck = icmp uge i64 %16, %15
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 3, i32 %11
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %20, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %6, %System.__Canon addrspace(1)* %21)
+  ret i8 1
+
+; <label>:22                                      ; preds = %entry
+  %23 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %23, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -8058,8 +9647,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
@@ -8091,8 +9680,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
@@ -8171,15 +9760,15 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck, label %19, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %ThrowNullRef, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
   %21 = load i32, i32 addrspace(1)* %20
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
@@ -8202,7 +9791,7 @@ ThrowNullRef:                                     ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %19
+ThrowNullRef2:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8248,8 +9837,8 @@ entry:
   %0 = alloca %System.AppDomainHandle
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %1 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %1, i32 0, i32 15
@@ -8269,8 +9858,8 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
@@ -8286,7 +9875,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -8299,8 +9888,8 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -8327,8 +9916,8 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
@@ -8352,8 +9941,8 @@ entry:
   %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
   store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
@@ -8363,8 +9952,8 @@ entry:
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
@@ -8374,8 +9963,8 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %9
   %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
@@ -8384,8 +9973,8 @@ entry:
 
 ; <label>:18                                      ; preds = %3, %16
   %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
@@ -8397,15 +9986,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %18
+ThrowNullRef6:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8418,8 +10007,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
@@ -8453,15 +10042,15 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
@@ -8473,7 +10062,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8481,7 +10070,7 @@ ThrowNullRef1:                                    ; preds = %1
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
 Failed to read Dictionary`2.System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
@@ -8506,8 +10095,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
@@ -8524,8 +10113,8 @@ entry:
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -8544,7 +10133,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8577,8 +10166,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = load i64, i64* %arg2
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = trunc i32 %3 to i8
@@ -8634,46 +10223,46 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
   %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
-  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
-  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
-  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
@@ -8684,27 +10273,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %20
+ThrowNullRef12:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8717,8 +10306,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -8756,22 +10345,22 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
   %9 = load i64, i64 addrspace(1)* %8, align 8
   %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
   %13 = load i64, i64 addrspace(1)* %12, align 8
   %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %11
   %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
@@ -8788,11 +10377,11 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8882,8 +10471,8 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
@@ -8900,8 +10489,8 @@ entry:
 ; <label>:8                                       ; preds = %1
   %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
   %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
@@ -8911,15 +10500,15 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
   %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
   %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
-  br i1 %NullCheck6, label %21, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
@@ -8946,15 +10535,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8992,15 +10581,15 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
   store i8 %3, i8 addrspace(1)* %5
   %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
@@ -9011,7 +10600,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9027,8 +10616,8 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -9041,8 +10630,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
@@ -9058,7 +10647,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9080,8 +10669,8 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
@@ -9096,8 +10685,8 @@ entry:
 ; <label>:12                                      ; preds = %6
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
@@ -9112,8 +10701,8 @@ entry:
 ; <label>:21                                      ; preds = %15
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
@@ -9128,8 +10717,8 @@ entry:
 ; <label>:30                                      ; preds = %24
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %31, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
@@ -9144,8 +10733,8 @@ entry:
 ; <label>:39                                      ; preds = %33
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
-  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %40, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %42
 
 ; <label>:42                                      ; preds = %39
   %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
@@ -9164,19 +10753,19 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %21
+ThrowNullRef4:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %30
+ThrowNullRef6:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %39
+ThrowNullRef8:                                    ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9243,8 +10832,8 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
@@ -9264,57 +10853,57 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
   store i8 0, i8 addrspace(1)* %2
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
   store i8 0, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
   store i8 0, i8 addrspace(1)* %17
   %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
   store i8 0, i8 addrspace(1)* %20
   %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
-  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
@@ -9325,31 +10914,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %19
+ThrowNullRef14:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9367,8 +10956,8 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
@@ -9380,8 +10969,8 @@ entry:
 
 ; <label>:9                                       ; preds = %4
   %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %9
   %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
@@ -9395,7 +10984,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef2:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9420,8 +11009,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
@@ -9512,8 +11101,8 @@ entry:
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
@@ -9524,8 +11113,8 @@ entry:
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = load i64, i64 addrspace(1)* %12
@@ -9537,8 +11126,8 @@ entry:
   %20 = load i64, i64* %19
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
-  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %13
   %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
@@ -9555,8 +11144,8 @@ entry:
 ; <label>:30                                      ; preds = %25
   %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %32 = load i32, i32* %arg2
-  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
-  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
@@ -9570,15 +11159,15 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %30
+ThrowNullRef2:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9622,87 +11211,87 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
   %10 = load i8, i8 addrspace(1)* %9, align 8
   %11 = zext i8 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %8
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
   store i8 %12, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
   %19 = load i8, i8 addrspace(1)* %18, align 8
   %20 = zext i8 %19 to i32
   %21 = trunc i32 %20 to i8
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
   store i8 %21, i8 addrspace(1)* %23
   %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
   %28 = load i8, i8 addrspace(1)* %27, align 8
   %29 = zext i8 %28 to i32
   %30 = trunc i32 %29 to i8
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
-  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %31
 
 ; <label>:31                                      ; preds = %26
   %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
   store i8 %30, i8 addrspace(1)* %32
   %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
-  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
-  br i1 %NullCheck14, label %40, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %40
 
 ; <label>:40                                      ; preds = %35
   %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
   store i8 %39, i8 addrspace(1)* %41
   %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
-  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %44
 
 ; <label>:44                                      ; preds = %40
   %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
   %46 = load i8, i8 addrspace(1)* %45, align 8
   %47 = zext i8 %46 to i32
   %48 = trunc i32 %47 to i8
-  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
   store i8 %48, i8 addrspace(1)* %50
   %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
-  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
@@ -9713,29 +11302,29 @@ entry:
 ; <label>:56                                      ; preds = %52
   %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
-  br i1 %NullCheck22, label %59, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
   %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
   %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
-  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
-  br i1 %NullCheck24, label %63, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
   %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
-  br i1 %NullCheck26, label %66, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
   %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
-  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
-  br i1 %NullCheck28, label %69, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %69
 
 ; <label>:69                                      ; preds = %66
   %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
@@ -9744,15 +11333,15 @@ entry:
 
 ; <label>:71                                      ; preds = %105
   %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
-  br i1 %NullCheck34, label %73, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %73
 
 ; <label>:73                                      ; preds = %71
   %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
   %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
   %76 = load i32, i32* %loc0
-  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
-  br i1 %NullCheck36, label %77, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
@@ -9766,8 +11355,8 @@ entry:
 
 ; <label>:83                                      ; preds = %77
   %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
-  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
@@ -9775,14 +11364,14 @@ entry:
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
   %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
-  br i1 %NullCheck40, label %91, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
 ; <label>:91                                      ; preds = %85
   %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
   %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
-  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck42, label %94, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %94
 
 ; <label>:94                                      ; preds = %91
   %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
@@ -9798,14 +11387,14 @@ entry:
 ; <label>:99                                      ; preds = %69, %96
   %100 = load i32, i32* %loc0
   %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
-  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %102
 
 ; <label>:102                                     ; preds = %99
   %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
   %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
-  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
-  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
@@ -9819,87 +11408,87 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %26
+ThrowNullRef10:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %31
+ThrowNullRef12:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %35
+ThrowNullRef14:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %40
+ThrowNullRef16:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %56
+ThrowNullRef22:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %59
+ThrowNullRef24:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %63
+ThrowNullRef26:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %66
+ThrowNullRef28:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %102
+ThrowNullRef32:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %71
+ThrowNullRef34:                                   ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %73
+ThrowNullRef36:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %83
+ThrowNullRef38:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %85
+ThrowNullRef40:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %91
+ThrowNullRef42:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9943,15 +11532,15 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
   %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
@@ -9961,28 +11550,28 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
   %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %12
   %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
   %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
   %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
-  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
@@ -9993,23 +11582,23 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %12
+ThrowNullRef6:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10031,15 +11620,15 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
   %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = load i64, i64 addrspace(1)* %7
@@ -10077,13 +11666,13 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[loadElem]
+Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -10111,8 +11700,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -10177,8 +11766,8 @@ entry:
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load double, double* %arg0
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -10312,8 +11901,8 @@ entry:
   store i64 %param0, i64* %arg0
   store i64 %param1, i64* %arg1
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
@@ -10321,8 +11910,8 @@ entry:
   %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
   %5 = load i16*, i16* addrspace(1)* %4, align 8
   %6 = addrspacecast i64* %arg1 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = bitcast i64 addrspace(1)* %6 to i8 addrspace(1)*
@@ -10338,7 +11927,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10372,8 +11961,8 @@ entry:
   %1 = load i32, i32* %arg1
   %2 = sext i32 %1 to i64
   %3 = inttoptr i64 %2 to i16*
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -10426,8 +12015,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, i32)*)(%System.IO.ConsoleStream addrspace(1)* %2, i32 %1)
   %3 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %4 = load i64, i64* %arg1
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
@@ -10438,8 +12027,8 @@ entry:
   %10 = icmp eq i32 %9, 3
   %11 = sext i1 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %5
   %14 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, i32 0, i32 5
@@ -10450,7 +12039,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10473,8 +12062,8 @@ entry:
   %5 = icmp eq i32 %4, 1
   %6 = sext i1 %5 to i32
   %7 = trunc i32 %6 to i8
-  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %2, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.ConsoleStream addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
@@ -10485,8 +12074,8 @@ entry:
   %13 = icmp eq i32 %12, 2
   %14 = sext i1 %13 to i32
   %15 = trunc i32 %14 to i8
-  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %10, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.ConsoleStream addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %8
   %17 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %10, i32 0, i32 4
@@ -10497,7 +12086,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10536,8 +12125,8 @@ entry:
   %arg0 = alloca i64
   store i64 %param0, i64* %arg0
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
@@ -10572,8 +12161,8 @@ entry:
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
   %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = load i64, i64 addrspace(1)* %7
@@ -10677,7 +12266,127 @@ entry:
 INFO:  jitting method Encoding::GetEncoding using LLILCJit
 Failed to read Encoding.GetEncoding[convertToHelperArgumentType]
 INFO:  jitting method EncodingProvider::GetEncodingFromProvider using LLILCJit
-Failed to read EncodingProvider.GetEncodingFromProvider[loadElem]
+Successfully read EncodingProvider.GetEncodingFromProvider
+
+define %System.Text.Encoding addrspace(1)* @EncodingProvider.GetEncodingFromProvider(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca %"System.Text.EncodingProvider[]" addrspace(1)*
+  %loc1 = alloca %System.Text.EncodingProvider addrspace(1)*
+  %loc2 = alloca %System.Text.Encoding addrspace(1)*
+  %loc3 = alloca %System.Text.Encoding addrspace(1)*
+  %loc4 = alloca %"System.Text.EncodingProvider[]" addrspace(1)*
+  %loc5 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1059)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2392
+  %2 = addrspacecast i8 addrspace(1)* %1 to %"System.Text.EncodingProvider[]" addrspace(1)**
+  %3 = load volatile %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %2
+  %4 = icmp ne %"System.Text.EncodingProvider[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %entry
+  ret %System.Text.Encoding addrspace(1)* null
+
+; <label>:6                                       ; preds = %entry
+  %7 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1059)
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i64 2392
+  %9 = addrspacecast i8 addrspace(1)* %8 to %"System.Text.EncodingProvider[]" addrspace(1)**
+  %10 = load volatile %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %9
+  store %"System.Text.EncodingProvider[]" addrspace(1)* %10, %"System.Text.EncodingProvider[]" addrspace(1)** %loc0
+  %11 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc0
+  store %"System.Text.EncodingProvider[]" addrspace(1)* %11, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  store i32 0, i32* %loc5
+  br label %43
+
+; <label>:12                                      ; preds = %46
+  %13 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  %14 = load i32, i32* %loc5
+  %NullCheck1 = icmp eq %"System.Text.EncodingProvider[]" addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %13, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = zext i32 %17 to i64
+  %19 = zext i32 %14 to i64
+  %BoundsCheck = icmp uge i64 %19, %18
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %20
+
+; <label>:20                                      ; preds = %15
+  %21 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %13, i32 0, i32 3, i32 %14
+  %22 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)* addrspace(1)* %21, align 8
+  store %System.Text.EncodingProvider addrspace(1)* %22, %System.Text.EncodingProvider addrspace(1)** %loc1
+  %23 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)** %loc1
+  %24 = load i32, i32* %arg0
+  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i64 addrspace(1)*
+  %NullCheck3 = icmp eq i64 addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
+
+; <label>:26                                      ; preds = %20
+  %27 = load i64, i64 addrspace(1)* %25
+  %28 = add i64 %27, 64
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 40
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Text.Encoding addrspace(1)* (%System.Text.EncodingProvider addrspace(1)*, i32)*
+  %35 = call %System.Text.Encoding addrspace(1)* %34(%System.Text.EncodingProvider addrspace(1)* %23, i32 %24)
+  store %System.Text.Encoding addrspace(1)* %35, %System.Text.Encoding addrspace(1)** %loc2
+  %36 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc2
+  %37 = icmp eq %System.Text.Encoding addrspace(1)* %36, null
+  br i1 %37, label %40, label %38
+
+; <label>:38                                      ; preds = %26
+  %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc2
+  store %System.Text.Encoding addrspace(1)* %39, %System.Text.Encoding addrspace(1)** %loc3
+  br label %53
+
+; <label>:40                                      ; preds = %26
+  %41 = load i32, i32* %loc5
+  %42 = add i32 %41, 1
+  store i32 %42, i32* %loc5
+  br label %43
+
+; <label>:43                                      ; preds = %6, %40
+  %44 = load i32, i32* %loc5
+  %45 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  %NullCheck = icmp eq %"System.Text.EncodingProvider[]" addrspace(1)* %45, null
+  br i1 %NullCheck, label %ThrowNullRef, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp slt i32 %44, %50
+  br i1 %51, label %12, label %52
+
+; <label>:52                                      ; preds = %46
+  ret %System.Text.Encoding addrspace(1)* null
+
+; <label>:53                                      ; preds = %38
+  %54 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc3
+  ret %System.Text.Encoding addrspace(1)* %54
+
+ThrowNullRef:                                     ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method EncodingProvider::.cctor using LLILCJit
 Successfully read EncodingProvider..cctor
 
@@ -10696,7 +12405,7 @@ Failed to read Encoding.get_InternalSyncObject[Call HasTypeArg]
 INFO:  jitting method Hashtable::.ctor using LLILCJit
 Failed to read Hashtable..ctor[Volatile store]
 INFO:  jitting method Hashtable::get_Item using LLILCJit
-Failed to read Hashtable.get_Item[loadElemA]
+Failed to read Hashtable.get_Item[loadNonPrimitiveObj]
 INFO:  jitting method Hashtable::InitHash using LLILCJit
 Successfully read Hashtable.InitHash
 
@@ -10716,8 +12425,8 @@ entry:
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -10733,15 +12442,15 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
   %15 = load i32, i32* %loc0
-  %NullCheck2 = icmp ne i32 addrspace(1)* %14, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i32 addrspace(1)* %14, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %3
   store i32 %15, i32 addrspace(1)* %14, align 8
   %17 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %18 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %NullCheck4 = icmp ne i32 addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i32 addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = load i32, i32 addrspace(1)* %18, align 8
@@ -10750,8 +12459,8 @@ entry:
   %23 = sub i32 %22, 1
   %24 = urem i32 %21, %23
   %25 = add i32 1, %24
-  %NullCheck6 = icmp ne i32 addrspace(1)* %17, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32 addrspace(1)* %17, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %19
   store i32 %25, i32 addrspace(1)* %17, align 8
@@ -10762,15 +12471,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %19
+ThrowNullRef6:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10785,8 +12494,8 @@ entry:
   store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
   store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %NullCheck = icmp ne %System.Collections.Hashtable addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Collections.Hashtable addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
@@ -10796,16 +12505,16 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Collections.Hashtable addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Collections.Hashtable addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
   %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck4 = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %9, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
   %13 = inttoptr i64 %11 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
@@ -10815,8 +12524,8 @@ entry:
 ; <label>:15                                      ; preds = %1
   %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -10834,15 +12543,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10856,8 +12565,8 @@ entry:
   store %System.Int32 addrspace(1)* %param0, %System.Int32 addrspace(1)** %this
   %0 = load %System.Int32 addrspace(1)*, %System.Int32 addrspace(1)** %this
   %1 = bitcast %System.Int32 addrspace(1)* %0 to i32 addrspace(1)*
-  %NullCheck = icmp ne i32 addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq i32 addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load i32, i32 addrspace(1)* %1, align 8
@@ -10933,8 +12642,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.UTF8Encoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
@@ -10943,15 +12652,15 @@ entry:
   %9 = load i8, i8* %arg2
   %10 = zext i8 %9 to i32
   %11 = trunc i32 %10 to i8
-  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %8, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %6
   %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %8, i32 0, i32 8
   store i8 %11, i8 addrspace(1)* %13
   %14 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %14, i32 0, i32 8
@@ -10963,8 +12672,8 @@ entry:
 ; <label>:20                                      ; preds = %15
   %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %22, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %22, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = load i64, i64 addrspace(1)* %22
@@ -10986,15 +12695,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %12
+ThrowNullRef4:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11009,8 +12718,8 @@ entry:
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
@@ -11032,16 +12741,16 @@ entry:
 ; <label>:10                                      ; preds = %1
   %11 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
   %12 = load i32, i32* %arg1
-  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %11, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.Encoding addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
   store i32 %12, i32 addrspace(1)* %14
   %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
   %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = load i64, i64 addrspace(1)* %16
@@ -11059,11 +12768,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11076,8 +12785,8 @@ entry:
   %this = alloca %System.Text.UTF8Encoding addrspace(1)*
   store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
   %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.UTF8Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
@@ -11089,16 +12798,16 @@ entry:
 ; <label>:6                                       ; preds = %1
   %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %8 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %10, %System.Text.EncoderFallback addrspace(1)* %8)
   %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %12 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
-  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %11, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %11, i32 0, i32 3
@@ -11111,8 +12820,8 @@ entry:
   %18 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %18, %System.String addrspace(1)* %17)
   %19 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %18 to %System.Text.EncoderFallback addrspace(1)*
-  %NullCheck6 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %16, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %16, i32 0, i32 2
@@ -11122,8 +12831,8 @@ entry:
   %24 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %24, %System.String addrspace(1)* %23)
   %25 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %24 to %System.Text.DecoderFallback addrspace(1)*
-  %NullCheck8 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %22, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %22, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %20
   %27 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %22, i32 0, i32 3
@@ -11134,19 +12843,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %20
+ThrowNullRef8:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11176,8 +12885,8 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load i32, i32* %arg1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -11195,8 +12904,8 @@ entry:
 ; <label>:15                                      ; preds = %8
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %17 = load i32, i32* %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 %17
@@ -11212,7 +12921,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11264,7 +12973,7 @@ entry:
 }
 
 INFO:  jitting method Hashtable::Insert using LLILCJit
-Failed to read Hashtable.Insert[loadElemA]
+Failed to read Hashtable.Insert[storeElem]
 INFO:  jitting method ConsoleEncoding::.ctor using LLILCJit
 Successfully read ConsoleEncoding..ctor
 
@@ -11279,8 +12988,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %1)
   %2 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
@@ -11316,8 +13025,8 @@ entry:
   %2 = call %System.Text.InternalEncoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalEncoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %1)
   %3 = bitcast %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2 to %System.Text.EncoderFallback addrspace(1)*
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
@@ -11327,8 +13036,8 @@ entry:
   %8 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %7)
   %9 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %8 to %System.Text.DecoderFallback addrspace(1)*
-  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %6, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.Encoding addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %4
   %11 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %6, i32 0, i32 3
@@ -11339,7 +13048,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11358,15 +13067,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* %1)
   %2 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   %6 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, i32 0, i32 1
@@ -11377,7 +13086,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11405,8 +13114,8 @@ entry:
   store %System.Text.InternalDecoderBestFitFallback addrspace(1)* %param0, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
   %0 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
@@ -11416,15 +13125,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %4)
   %5 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %6)
   %9 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, i32 0, i32 1
@@ -11435,11 +13144,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11507,8 +13216,8 @@ entry:
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
   %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = load i64, i64 addrspace(1)* %19
@@ -11572,8 +13281,8 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.ConsoleStream addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
@@ -11604,31 +13313,31 @@ entry:
   store i8 %param4, i8* %arg4
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %3, %System.IO.Stream addrspace(1)* %1)
   %4 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %4, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
   %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %4, i32 0, i32 4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %5)
   %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %6
   %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
   %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
   %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = load i64, i64 addrspace(1)* %13
@@ -11640,8 +13349,8 @@ entry:
   %21 = load i64, i64* %20
   %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %8, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %8, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %14
   %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 5
@@ -11659,24 +13368,24 @@ entry:
   %31 = load i32, i32* %arg3
   %32 = sext i32 %31 to i64
   %33 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %32)
-  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %30, null
-  br i1 %NullCheck10, label %34, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.StreamWriter addrspace(1)* %30, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %35, %"System.Char[]" addrspace(1)* %33)
   %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %37, null
-  br i1 %NullCheck12, label %38, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.StreamWriter addrspace(1)* %37, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %38
 
 ; <label>:38                                      ; preds = %34
   %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
   %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
   %41 = load i32, i32* %arg3
   %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %42, null
-  br i1 %NullCheck14, label %43, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %42, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
   %44 = load i64, i64 addrspace(1)* %42
@@ -11690,30 +13399,30 @@ entry:
   %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
   %53 = sext i32 %52 to i64
   %54 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %53)
-  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
-  br i1 %NullCheck16, label %55, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %55
 
 ; <label>:55                                      ; preds = %43
   %56 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %56, %"System.Byte[]" addrspace(1)* %54)
   %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %58 = load i32, i32* %arg3
-  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %57, null
-  br i1 %NullCheck18, label %59, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.StreamWriter addrspace(1)* %57, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %59
 
 ; <label>:59                                      ; preds = %55
   %60 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 10
   store i32 %58, i32 addrspace(1)* %60
   %61 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %61, null
-  br i1 %NullCheck20, label %62, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.IO.StreamWriter addrspace(1)* %61, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %62
 
 ; <label>:62                                      ; preds = %59
   %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
   %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
   %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
   %67 = load i64, i64 addrspace(1)* %65
@@ -11731,15 +13440,15 @@ entry:
 
 ; <label>:78                                      ; preds = %66
   %79 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %79, null
-  br i1 %NullCheck24, label %80, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.StreamWriter addrspace(1)* %79, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %80
 
 ; <label>:80                                      ; preds = %78
   %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
   %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
   %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %83, null
-  br i1 %NullCheck26, label %84, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %83, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
   %85 = load i64, i64 addrspace(1)* %83
@@ -11756,8 +13465,8 @@ entry:
 
 ; <label>:95                                      ; preds = %84
   %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.IO.StreamWriter addrspace(1)* %96, null
-  br i1 %NullCheck28, label %97, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.IO.StreamWriter addrspace(1)* %96, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %97
 
 ; <label>:97                                      ; preds = %95
   %98 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 12
@@ -11771,8 +13480,8 @@ entry:
   %103 = icmp eq i32 %102, 0
   %104 = sext i1 %103 to i32
   %105 = trunc i32 %104 to i8
-  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %100, null
-  br i1 %NullCheck30, label %106, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.IO.StreamWriter addrspace(1)* %100, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %106
 
 ; <label>:106                                     ; preds = %99
   %107 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %100, i32 0, i32 13
@@ -11783,63 +13492,63 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %6
+ThrowNullRef4:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %29
+ThrowNullRef10:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %34
+ThrowNullRef12:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %38
+ThrowNullRef14:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %43
+ThrowNullRef16:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %55
+ThrowNullRef18:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %59
+ThrowNullRef20:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %62
+ThrowNullRef22:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %78
+ThrowNullRef24:                                   ; preds = %78
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %80
+ThrowNullRef26:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %95
+ThrowNullRef28:                                   ; preds = %95
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11852,15 +13561,15 @@ entry:
   %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = load i64, i64 addrspace(1)* %4
@@ -11878,7 +13587,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11928,35 +13637,35 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
   %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderNLS addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %7 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.EncoderNLS addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Text.Encoding addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.Encoding addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Text.EncoderNLS addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.EncoderNLS addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
   %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck8 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = load i64, i64 addrspace(1)* %16
@@ -11975,19 +13684,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12013,8 +13722,8 @@ entry:
   %this = alloca %System.Text.Encoding addrspace(1)*
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
@@ -12034,15 +13743,15 @@ entry:
   %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
   store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
   %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
   store i32 0, i32 addrspace(1)* %2
   %3 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, i32 0, i32 2
@@ -12052,15 +13761,15 @@ entry:
 
 ; <label>:8                                       ; preds = %4
   %9 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
   %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
   %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = load i64, i64 addrspace(1)* %13
@@ -12081,15 +13790,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12104,16 +13813,16 @@ entry:
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = load i32, i32* %arg1
   %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
   %7 = load i64, i64 addrspace(1)* %5
@@ -12131,7 +13840,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12168,8 +13877,8 @@ entry:
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
   %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
   %16 = load i64, i64 addrspace(1)* %14
@@ -12190,8 +13899,8 @@ entry:
   %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
   %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
   %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %31, null
-  br i1 %NullCheck2, label %32, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = load i64, i64 addrspace(1)* %31
@@ -12234,7 +13943,7 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12247,14 +13956,14 @@ entry:
   %this = alloca %System.Text.EncoderReplacementFallback addrspace(1)*
   store %System.Text.EncoderReplacementFallback addrspace(1)* %param0, %System.Text.EncoderReplacementFallback addrspace(1)** %this
   %0 = load %System.Text.EncoderReplacementFallback addrspace(1)*, %System.Text.EncoderReplacementFallback addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -12265,7 +13974,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12295,8 +14004,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
@@ -12328,8 +14037,8 @@ entry:
   %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
   store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
@@ -12341,8 +14050,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Threading.Tasks.Task addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %7)
@@ -12365,7 +14074,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12384,8 +14093,8 @@ entry:
   store i8 %param1, i8* %arg1
   store i8 %param2, i8* %arg2
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
@@ -12399,8 +14108,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1, %5
   %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 9
@@ -12431,8 +14140,8 @@ entry:
 
 ; <label>:25                                      ; preds = %8, %20
   %26 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %26, null
-  br i1 %NullCheck4, label %27, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %26, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %26, i32 0, i32 12
@@ -12443,22 +14152,22 @@ entry:
 
 ; <label>:32                                      ; preds = %27
   %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %33, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.IO.StreamWriter addrspace(1)* %33, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %32
   %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 12
   store i8 1, i8 addrspace(1)* %35
   %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
-  br i1 %NullCheck8, label %37, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
   %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
   %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck10 = icmp ne i64 addrspace(1)* %40, null
-  br i1 %NullCheck10, label %41, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64 addrspace(1)* %40, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i64, i64 addrspace(1)* %40
@@ -12472,8 +14181,8 @@ entry:
   %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
   store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
   %51 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %NullCheck12 = icmp ne %"System.Byte[]" addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Byte[]" addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %41
   %53 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %51, i32 0, i32 1
@@ -12485,16 +14194,16 @@ entry:
 
 ; <label>:58                                      ; preds = %52
   %59 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %59, null
-  br i1 %NullCheck14, label %60, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.IO.StreamWriter addrspace(1)* %59, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %60
 
 ; <label>:60                                      ; preds = %58
   %61 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %59, i32 0, i32 3
   %62 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
   %64 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %NullCheck16 = icmp ne %"System.Byte[]" addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %"System.Byte[]" addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %60
   %66 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %64, i32 0, i32 1
@@ -12502,8 +14211,8 @@ entry:
   %68 = zext i32 %67 to i64
   %69 = trunc i64 %68 to i32
   %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck18, label %71, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
   %72 = load i64, i64 addrspace(1)* %70
@@ -12519,29 +14228,29 @@ entry:
 
 ; <label>:80                                      ; preds = %27, %52, %71
   %81 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %81, null
-  br i1 %NullCheck20, label %82, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.IO.StreamWriter addrspace(1)* %81, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
 
 ; <label>:82                                      ; preds = %80
   %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %81, i32 0, i32 5
   %84 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %83, align 8
   %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.IO.StreamWriter addrspace(1)* %85, null
-  br i1 %NullCheck22, label %86, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.IO.StreamWriter addrspace(1)* %85, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %86
 
 ; <label>:86                                      ; preds = %82
   %87 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 7
   %88 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %87, align 8
   %89 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %89, null
-  br i1 %NullCheck24, label %90, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.StreamWriter addrspace(1)* %89, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %90
 
 ; <label>:90                                      ; preds = %86
   %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %89, i32 0, i32 9
   %92 = load i32, i32 addrspace(1)* %91, align 8
   %93 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.IO.StreamWriter addrspace(1)* %93, null
-  br i1 %NullCheck26, label %94, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.IO.StreamWriter addrspace(1)* %93, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %93, i32 0, i32 6
@@ -12549,8 +14258,8 @@ entry:
   %97 = load i8, i8* %arg2
   %98 = zext i8 %97 to i32
   %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
-  %NullCheck28 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck28, label %100, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
   %101 = load i64, i64 addrspace(1)* %99
@@ -12565,8 +14274,8 @@ entry:
   %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
   store i32 %110, i32* %loc1
   %111 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %111, null
-  br i1 %NullCheck30, label %112, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.IO.StreamWriter addrspace(1)* %111, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %112
 
 ; <label>:112                                     ; preds = %100
   %113 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %111, i32 0, i32 9
@@ -12577,23 +14286,23 @@ entry:
 
 ; <label>:116                                     ; preds = %112
   %117 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck32 = icmp ne %System.IO.StreamWriter addrspace(1)* %117, null
-  br i1 %NullCheck32, label %118, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.IO.StreamWriter addrspace(1)* %117, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %118
 
 ; <label>:118                                     ; preds = %116
   %119 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %117, i32 0, i32 3
   %120 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %119, align 8
   %121 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.IO.StreamWriter addrspace(1)* %121, null
-  br i1 %NullCheck34, label %122, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.IO.StreamWriter addrspace(1)* %121, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %122
 
 ; <label>:122                                     ; preds = %118
   %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
   %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
   %125 = load i32, i32* %loc1
   %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
-  %NullCheck36 = icmp ne i64 addrspace(1)* %126, null
-  br i1 %NullCheck36, label %127, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64 addrspace(1)* %126, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
   %128 = load i64, i64 addrspace(1)* %126
@@ -12615,15 +14324,15 @@ entry:
 
 ; <label>:140                                     ; preds = %136
   %141 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.IO.StreamWriter addrspace(1)* %141, null
-  br i1 %NullCheck38, label %142, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.IO.StreamWriter addrspace(1)* %141, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %142
 
 ; <label>:142                                     ; preds = %140
   %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
   %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
   %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
-  %NullCheck40 = icmp ne i64 addrspace(1)* %145, null
-  br i1 %NullCheck40, label %146, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i64 addrspace(1)* %145, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
   %147 = load i64, i64 addrspace(1)* %145
@@ -12644,83 +14353,83 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %25
+ThrowNullRef4:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %32
+ThrowNullRef6:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %37
+ThrowNullRef10:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %41
+ThrowNullRef12:                                   ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %58
+ThrowNullRef14:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %60
+ThrowNullRef16:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %65
+ThrowNullRef18:                                   ; preds = %65
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %80
+ThrowNullRef20:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %82
+ThrowNullRef22:                                   ; preds = %82
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %86
+ThrowNullRef24:                                   ; preds = %86
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %90
+ThrowNullRef26:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %94
+ThrowNullRef28:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %100
+ThrowNullRef30:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %116
+ThrowNullRef32:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %118
+ThrowNullRef34:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %122
+ThrowNullRef36:                                   ; preds = %122
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %140
+ThrowNullRef38:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %142
+ThrowNullRef40:                                   ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12787,8 +14496,8 @@ entry:
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %1 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
-  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
@@ -12796,8 +14505,8 @@ entry:
   %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
   %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
   %8 = load i64, i64 addrspace(1)* %6
@@ -12813,8 +14522,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %17, %System.IFormatProvider addrspace(1)* %16)
   %18 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %19 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %18, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.SyncTextWriter addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %7
   %21 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %18, i32 0, i32 4
@@ -12825,11 +14534,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12842,8 +14551,8 @@ entry:
   %this = alloca %System.IO.TextWriter addrspace(1)*
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.TextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
@@ -12853,8 +14562,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.Threading.Thread addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Threading.Thread addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %6)
@@ -12863,8 +14572,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1
   %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.TextWriter addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.TextWriter addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %11, i32 0, i32 2
@@ -12875,11 +14584,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13076,8 +14785,8 @@ entry:
   store double %param1, double* %arg1
   store i8 0, i8* %loc1
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
@@ -13087,16 +14796,16 @@ entry:
   %5 = addrspacecast i8* %loc1 to i8 addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %4, i8 addrspace(1)* %5)
   %6 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.SyncTextWriter addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
   %10 = load double, double* %arg1
   %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
   %13 = load i64, i64 addrspace(1)* %11
@@ -13131,11 +14840,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13152,8 +14861,8 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load double, double* %arg1
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -13167,8 +14876,8 @@ entry:
   call void %11(%System.IO.TextWriter addrspace(1)* %0, double %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
   %15 = load i64, i64 addrspace(1)* %13
@@ -13186,7 +14895,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13204,8 +14913,8 @@ entry:
   %1 = addrspacecast double* %arg1 to double addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -13220,8 +14929,8 @@ entry:
   %14 = bitcast double addrspace(1)* %1 to %System.Double addrspace(1)*
   %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Double addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Double addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
   %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
   %18 = load i64, i64 addrspace(1)* %16
@@ -13239,7 +14948,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13255,8 +14964,8 @@ entry:
   store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
   %0 = load %System.Double addrspace(1)*, %System.Double addrspace(1)** %this
   %1 = bitcast %System.Double addrspace(1)* %0 to double addrspace(1)*
-  %NullCheck = icmp ne double addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq double addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load double, double addrspace(1)* %1, align 8
@@ -13281,8 +14990,8 @@ entry:
   %loc0 = alloca %System.Globalization.NumberFormatInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 3
@@ -13292,8 +15001,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
@@ -13303,24 +15012,24 @@ entry:
   store %System.Globalization.NumberFormatInfo addrspace(1)* %10, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
   %11 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %7
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
   %15 = load i8, i8 addrspace(1)* %14, align 8
   %16 = zext i8 %15 to i32
   %17 = trunc i32 %16 to i8
-  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %11, null
-  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %11, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %13
   %19 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %11, i32 0, i32 29
   store i8 %17, i8 addrspace(1)* %19
   %20 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %21 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %20, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %20, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %18
   %23 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %20, i32 0, i32 3
@@ -13329,8 +15038,8 @@ entry:
 
 ; <label>:24                                      ; preds = %1, %22
   %25 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %25, null
-  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %25, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %26
 
 ; <label>:26                                      ; preds = %24
   %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %25, i32 0, i32 3
@@ -13341,23 +15050,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %18
+ThrowNullRef8:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13382,168 +15091,168 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 18
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %8, align 8
-  %NullCheck2 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %5, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %5, i32 0, i32 4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %9)
   %12 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 19
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %15, align 8
-  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %12, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %12, i32 0, i32 5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %16)
   %19 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %20 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %20, null
-  br i1 %NullCheck8, label %21, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %20, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %20, i32 0, i32 23
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  %NullCheck10 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %19, null
-  br i1 %NullCheck10, label %24, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %19, i32 0, i32 7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %25, %System.String addrspace(1)* %23)
   %26 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %27 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %27, i32 0, i32 22
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %29, align 8
-  %NullCheck14 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %26, null
-  br i1 %NullCheck14, label %31, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %26, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %26, i32 0, i32 6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %32, %System.String addrspace(1)* %30)
   %33 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %34 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Globalization.CultureData addrspace(1)* %34, null
-  br i1 %NullCheck16, label %35, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Globalization.CultureData addrspace(1)* %34, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %34, i32 0, i32 51
   %37 = load i32, i32 addrspace(1)* %36, align 8
-  %NullCheck18 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %33, null
-  br i1 %NullCheck18, label %38, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %33, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %33, i32 0, i32 21
   store i32 %37, i32 addrspace(1)* %39
   %40 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %41 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Globalization.CultureData addrspace(1)* %41, null
-  br i1 %NullCheck20, label %42, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Globalization.CultureData addrspace(1)* %41, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %41, i32 0, i32 52
   %44 = load i32, i32 addrspace(1)* %43, align 8
-  %NullCheck22 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %40, null
-  br i1 %NullCheck22, label %45, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %40, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %40, i32 0, i32 25
   store i32 %44, i32 addrspace(1)* %46
   %47 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %48 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.Globalization.CultureData addrspace(1)* %48, null
-  br i1 %NullCheck24, label %49, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Globalization.CultureData addrspace(1)* %48, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %49
 
 ; <label>:49                                      ; preds = %45
   %50 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %48, i32 0, i32 29
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck26 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %47, null
-  br i1 %NullCheck26, label %52, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %47, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %47, i32 0, i32 10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %53, %System.String addrspace(1)* %51)
   %54 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %55 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Globalization.CultureData addrspace(1)* %55, null
-  br i1 %NullCheck28, label %56, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Globalization.CultureData addrspace(1)* %55, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %56
 
 ; <label>:56                                      ; preds = %52
   %57 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %55, i32 0, i32 35
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %57, align 8
-  %NullCheck30 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %54, null
-  br i1 %NullCheck30, label %59, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %54, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %54, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %60, %System.String addrspace(1)* %58)
   %61 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %62 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck32 = icmp ne %System.Globalization.CultureData addrspace(1)* %62, null
-  br i1 %NullCheck32, label %63, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Globalization.CultureData addrspace(1)* %62, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %62, i32 0, i32 34
   %65 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %64, align 8
-  %NullCheck34 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %61, null
-  br i1 %NullCheck34, label %66, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %61, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %61, i32 0, i32 9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %67, %System.String addrspace(1)* %65)
   %68 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %69 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck36 = icmp ne %System.Globalization.CultureData addrspace(1)* %69, null
-  br i1 %NullCheck36, label %70, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Globalization.CultureData addrspace(1)* %69, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %70
 
 ; <label>:70                                      ; preds = %66
   %71 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %69, i32 0, i32 55
   %72 = load i32, i32 addrspace(1)* %71, align 8
-  %NullCheck38 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %68, null
-  br i1 %NullCheck38, label %73, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %68, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %68, i32 0, i32 22
   store i32 %72, i32 addrspace(1)* %74
   %75 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %76 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck40 = icmp ne %System.Globalization.CultureData addrspace(1)* %76, null
-  br i1 %NullCheck40, label %77, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Globalization.CultureData addrspace(1)* %76, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %76, i32 0, i32 57
   %79 = load i32, i32 addrspace(1)* %78, align 8
-  %NullCheck42 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %75, null
-  br i1 %NullCheck42, label %80, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %75, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %80
 
 ; <label>:80                                      ; preds = %77
   %81 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %75, i32 0, i32 24
   store i32 %79, i32 addrspace(1)* %81
   %82 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %83 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck44 = icmp ne %System.Globalization.CultureData addrspace(1)* %83, null
-  br i1 %NullCheck44, label %84, label %ThrowNullRef43
+  %NullCheck43 = icmp eq %System.Globalization.CultureData addrspace(1)* %83, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %84
 
 ; <label>:84                                      ; preds = %80
   %85 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %83, i32 0, i32 56
   %86 = load i32, i32 addrspace(1)* %85, align 8
-  %NullCheck46 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %82, null
-  br i1 %NullCheck46, label %87, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %82, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %82, i32 0, i32 23
@@ -13552,8 +15261,8 @@ entry:
 
 ; <label>:89                                      ; preds = %entry
   %90 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck100 = icmp ne %System.Globalization.CultureData addrspace(1)* %90, null
-  br i1 %NullCheck100, label %91, label %ThrowNullRef99
+  %NullCheck99 = icmp eq %System.Globalization.CultureData addrspace(1)* %90, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %91
 
 ; <label>:91                                      ; preds = %89
   %92 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %90, i32 0, i32 2
@@ -13571,8 +15280,8 @@ entry:
   %102 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %103 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %104 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %103)
-  %NullCheck48 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %102, null
-  br i1 %NullCheck48, label %105, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %102, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %105
 
 ; <label>:105                                     ; preds = %101
   %106 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %102, i32 0, i32 1
@@ -13580,8 +15289,8 @@ entry:
   %107 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %108 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %109 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %108)
-  %NullCheck50 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %107, null
-  br i1 %NullCheck50, label %110, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %107, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %110
 
 ; <label>:110                                     ; preds = %105
   %111 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %107, i32 0, i32 2
@@ -13589,8 +15298,8 @@ entry:
   %112 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %113 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %114 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %113)
-  %NullCheck52 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %112, null
-  br i1 %NullCheck52, label %115, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %112, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %115
 
 ; <label>:115                                     ; preds = %110
   %116 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %112, i32 0, i32 27
@@ -13598,8 +15307,8 @@ entry:
   %117 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %118 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %119 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %118)
-  %NullCheck54 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %117, null
-  br i1 %NullCheck54, label %120, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %117, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %120
 
 ; <label>:120                                     ; preds = %115
   %121 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %117, i32 0, i32 26
@@ -13607,8 +15316,8 @@ entry:
   %122 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %123 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %124 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %123)
-  %NullCheck56 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %122, null
-  br i1 %NullCheck56, label %125, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %122, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %125
 
 ; <label>:125                                     ; preds = %120
   %126 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %122, i32 0, i32 17
@@ -13616,8 +15325,8 @@ entry:
   %127 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %128 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %129 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %128)
-  %NullCheck58 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %127, null
-  br i1 %NullCheck58, label %130, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %127, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %130
 
 ; <label>:130                                     ; preds = %125
   %131 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %127, i32 0, i32 18
@@ -13625,8 +15334,8 @@ entry:
   %132 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %133 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %134 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %133)
-  %NullCheck60 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %132, null
-  br i1 %NullCheck60, label %135, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %132, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %135
 
 ; <label>:135                                     ; preds = %130
   %136 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %132, i32 0, i32 14
@@ -13634,8 +15343,8 @@ entry:
   %137 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %138 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %139 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %138)
-  %NullCheck62 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %137, null
-  br i1 %NullCheck62, label %140, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %137, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %140
 
 ; <label>:140                                     ; preds = %135
   %141 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %137, i32 0, i32 13
@@ -13643,71 +15352,71 @@ entry:
   %142 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %143 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %144 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %143)
-  %NullCheck64 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %142, null
-  br i1 %NullCheck64, label %145, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %142, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %145
 
 ; <label>:145                                     ; preds = %140
   %146 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %142, i32 0, i32 12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %146, %System.String addrspace(1)* %144)
   %147 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %148 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck66 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %148, null
-  br i1 %NullCheck66, label %149, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %148, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %149
 
 ; <label>:149                                     ; preds = %145
   %150 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %148, i32 0, i32 21
   %151 = load i32, i32 addrspace(1)* %150, align 8
-  %NullCheck68 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %147, null
-  br i1 %NullCheck68, label %152, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %147, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %152
 
 ; <label>:152                                     ; preds = %149
   %153 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %147, i32 0, i32 28
   store i32 %151, i32 addrspace(1)* %153
   %154 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %155 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck70 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %155, null
-  br i1 %NullCheck70, label %156, label %ThrowNullRef69
+  %NullCheck69 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %155, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %156
 
 ; <label>:156                                     ; preds = %152
   %157 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %155, i32 0, i32 6
   %158 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %157, align 8
-  %NullCheck72 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %154, null
-  br i1 %NullCheck72, label %159, label %ThrowNullRef71
+  %NullCheck71 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %154, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %159
 
 ; <label>:159                                     ; preds = %156
   %160 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %154, i32 0, i32 15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %160, %System.String addrspace(1)* %158)
   %161 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %162 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck74 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %162, null
-  br i1 %NullCheck74, label %163, label %ThrowNullRef73
+  %NullCheck73 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %162, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %163
 
 ; <label>:163                                     ; preds = %159
   %164 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %162, i32 0, i32 1
   %165 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %164, align 8
-  %NullCheck76 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %161, null
-  br i1 %NullCheck76, label %166, label %ThrowNullRef75
+  %NullCheck75 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %161, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %166
 
 ; <label>:166                                     ; preds = %163
   %167 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %161, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %167, %"System.Int32[]" addrspace(1)* %165)
   %168 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %169 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck78 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %169, null
-  br i1 %NullCheck78, label %170, label %ThrowNullRef77
+  %NullCheck77 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %169, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %170
 
 ; <label>:170                                     ; preds = %166
   %171 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %169, i32 0, i32 7
   %172 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %171, align 8
-  %NullCheck80 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %168, null
-  br i1 %NullCheck80, label %173, label %ThrowNullRef79
+  %NullCheck79 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %168, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %173
 
 ; <label>:173                                     ; preds = %170
   %174 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %168, i32 0, i32 16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %174, %System.String addrspace(1)* %172)
   %175 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck82 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %175, null
-  br i1 %NullCheck82, label %176, label %ThrowNullRef81
+  %NullCheck81 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %175, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %176
 
 ; <label>:176                                     ; preds = %173
   %177 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %175, i32 0, i32 4
@@ -13717,14 +15426,14 @@ entry:
 
 ; <label>:180                                     ; preds = %176
   %181 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck84 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %181, null
-  br i1 %NullCheck84, label %182, label %ThrowNullRef83
+  %NullCheck83 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %181, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %182
 
 ; <label>:182                                     ; preds = %180
   %183 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %181, i32 0, i32 4
   %184 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %183, align 8
-  %NullCheck86 = icmp ne %System.String addrspace(1)* %184, null
-  br i1 %NullCheck86, label %185, label %ThrowNullRef85
+  %NullCheck85 = icmp eq %System.String addrspace(1)* %184, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %185
 
 ; <label>:185                                     ; preds = %182
   %186 = getelementptr inbounds %System.String, %System.String addrspace(1)* %184, i32 0, i32 1
@@ -13735,8 +15444,8 @@ entry:
 ; <label>:189                                     ; preds = %176, %185
   %190 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck98 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %190, null
-  br i1 %NullCheck98, label %192, label %ThrowNullRef97
+  %NullCheck97 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %190, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %192
 
 ; <label>:192                                     ; preds = %189
   %193 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %190, i32 0, i32 4
@@ -13745,8 +15454,8 @@ entry:
 
 ; <label>:194                                     ; preds = %185, %192
   %195 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck88 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %195, null
-  br i1 %NullCheck88, label %196, label %ThrowNullRef87
+  %NullCheck87 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %195, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %196
 
 ; <label>:196                                     ; preds = %194
   %197 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %195, i32 0, i32 9
@@ -13756,14 +15465,14 @@ entry:
 
 ; <label>:200                                     ; preds = %196
   %201 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck90 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %201, null
-  br i1 %NullCheck90, label %202, label %ThrowNullRef89
+  %NullCheck89 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %201, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %202
 
 ; <label>:202                                     ; preds = %200
   %203 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %201, i32 0, i32 9
   %204 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %203, align 8
-  %NullCheck92 = icmp ne %System.String addrspace(1)* %204, null
-  br i1 %NullCheck92, label %205, label %ThrowNullRef91
+  %NullCheck91 = icmp eq %System.String addrspace(1)* %204, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %205
 
 ; <label>:205                                     ; preds = %202
   %206 = getelementptr inbounds %System.String, %System.String addrspace(1)* %204, i32 0, i32 1
@@ -13774,14 +15483,14 @@ entry:
 ; <label>:209                                     ; preds = %196, %205
   %210 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %211 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck94 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %211, null
-  br i1 %NullCheck94, label %212, label %ThrowNullRef93
+  %NullCheck93 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %211, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %212
 
 ; <label>:212                                     ; preds = %209
   %213 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %211, i32 0, i32 6
   %214 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %213, align 8
-  %NullCheck96 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %210, null
-  br i1 %NullCheck96, label %215, label %ThrowNullRef95
+  %NullCheck95 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %210, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %215
 
 ; <label>:215                                     ; preds = %212
   %216 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %210, i32 0, i32 9
@@ -13795,203 +15504,203 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %17
+ThrowNullRef8:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %21
+ThrowNullRef10:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %24
+ThrowNullRef12:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %28
+ThrowNullRef14:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %31
+ThrowNullRef16:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %35
+ThrowNullRef18:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %38
+ThrowNullRef20:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %42
+ThrowNullRef22:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %45
+ThrowNullRef24:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %49
+ThrowNullRef26:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %52
+ThrowNullRef28:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %56
+ThrowNullRef30:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %59
+ThrowNullRef32:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %63
+ThrowNullRef34:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %66
+ThrowNullRef36:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %70
+ThrowNullRef38:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %73
+ThrowNullRef40:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %77
+ThrowNullRef42:                                   ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %80
+ThrowNullRef44:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %84
+ThrowNullRef46:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %101
+ThrowNullRef48:                                   ; preds = %101
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %105
+ThrowNullRef50:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %110
+ThrowNullRef52:                                   ; preds = %110
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %115
+ThrowNullRef54:                                   ; preds = %115
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %120
+ThrowNullRef56:                                   ; preds = %120
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %125
+ThrowNullRef58:                                   ; preds = %125
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %130
+ThrowNullRef60:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %135
+ThrowNullRef62:                                   ; preds = %135
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %140
+ThrowNullRef64:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %145
+ThrowNullRef66:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %149
+ThrowNullRef68:                                   ; preds = %149
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %152
+ThrowNullRef70:                                   ; preds = %152
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %156
+ThrowNullRef72:                                   ; preds = %156
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %159
+ThrowNullRef74:                                   ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %163
+ThrowNullRef76:                                   ; preds = %163
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %166
+ThrowNullRef78:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %170
+ThrowNullRef80:                                   ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %173
+ThrowNullRef82:                                   ; preds = %173
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %180
+ThrowNullRef84:                                   ; preds = %180
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %182
+ThrowNullRef86:                                   ; preds = %182
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %194
+ThrowNullRef88:                                   ; preds = %194
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %200
+ThrowNullRef90:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %202
+ThrowNullRef92:                                   ; preds = %202
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %209
+ThrowNullRef94:                                   ; preds = %209
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %212
+ThrowNullRef96:                                   ; preds = %212
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %189
+ThrowNullRef98:                                   ; preds = %189
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %89
+ThrowNullRef100:                                  ; preds = %89
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14019,8 +15728,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 21
@@ -14033,8 +15742,8 @@ entry:
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 16)
   %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 21
@@ -14043,8 +15752,8 @@ entry:
 
 ; <label>:12                                      ; preds = %1, %10
   %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 21
@@ -14055,11 +15764,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %12
+ThrowNullRef4:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14075,8 +15784,8 @@ entry:
   store i32 %param1, i32* %arg1
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %1 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
@@ -14143,8 +15852,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 33
@@ -14157,8 +15866,8 @@ entry:
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 24)
   %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 33
@@ -14167,8 +15876,8 @@ entry:
 
 ; <label>:12                                      ; preds = %1, %10
   %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 33
@@ -14179,11 +15888,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %12
+ThrowNullRef4:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14196,8 +15905,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 53
@@ -14209,8 +15918,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 116)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 53
@@ -14219,8 +15928,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 53
@@ -14231,11 +15940,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14264,8 +15973,8 @@ entry:
 
 ; <label>:7                                       ; preds = %entry, %4
   %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %7
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 2
@@ -14289,8 +15998,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 54
@@ -14302,8 +16011,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 117)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
@@ -14312,8 +16021,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 54
@@ -14324,11 +16033,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14341,8 +16050,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 27
@@ -14354,8 +16063,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 118)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 27
@@ -14364,8 +16073,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 27
@@ -14376,11 +16085,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14393,8 +16102,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 28
@@ -14406,8 +16115,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 119)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 28
@@ -14416,8 +16125,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 28
@@ -14428,11 +16137,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14445,8 +16154,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 26
@@ -14458,8 +16167,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 107)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 26
@@ -14468,8 +16177,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 26
@@ -14480,11 +16189,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14497,8 +16206,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 25
@@ -14510,8 +16219,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 106)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 25
@@ -14520,8 +16229,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 25
@@ -14532,11 +16241,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14549,8 +16258,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 24
@@ -14562,8 +16271,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 105)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 24
@@ -14572,8 +16281,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 24
@@ -14584,11 +16293,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14613,8 +16322,8 @@ entry:
   %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %3)
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %2
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -14625,15 +16334,15 @@ entry:
 
 ; <label>:8                                       ; preds = %62
   %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 9
   %12 = load i32, i32 addrspace(1)* %11, align 8
   %13 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.IO.StreamWriter addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %13, i32 0, i32 10
@@ -14648,15 +16357,15 @@ entry:
 
 ; <label>:20                                      ; preds = %14, %18
   %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
   %24 = load i32, i32 addrspace(1)* %23, align 8
   %25 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %25, null
-  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.StreamWriter addrspace(1)* %25, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %25, i32 0, i32 9
@@ -14677,36 +16386,36 @@ entry:
   %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %37 = load i32, i32* %loc1
   %38 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.StreamWriter addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %35
   %40 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %38, i32 0, i32 7
   %41 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %40, align 8
   %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
-  br i1 %NullCheck14, label %43, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %39
   %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 9
   %45 = load i32, i32 addrspace(1)* %44, align 8
   %46 = load i32, i32* %loc2
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %36, null
-  br i1 %NullCheck16, label %47, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %36, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %47
 
 ; <label>:47                                      ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %36, i32 %37, %"System.Char[]" addrspace(1)* %41, i32 %45, i32 %46)
   %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
   %51 = load i32, i32 addrspace(1)* %50, align 8
   %52 = load i32, i32* %loc2
   %53 = add i32 %51, %52
-  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
-  br i1 %NullCheck20, label %54, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %54
 
 ; <label>:54                                      ; preds = %49
   %55 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
@@ -14728,8 +16437,8 @@ entry:
 
 ; <label>:65                                      ; preds = %62
   %66 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %66, null
-  br i1 %NullCheck2, label %67, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %66, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %67
 
 ; <label>:67                                      ; preds = %65
   %68 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %66, i32 0, i32 11
@@ -14750,49 +16459,259 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %65
+ThrowNullRef2:                                    ; preds = %65
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %20
+ThrowNullRef8:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %22
+ThrowNullRef10:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %35
+ThrowNullRef12:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %43
+ThrowNullRef16:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %47
+ThrowNullRef18:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method String::CopyTo using LLILCJit
-Failed to read String.CopyTo[loadElemA]
+Successfully read String.CopyTo
+
+define void @String.CopyTo(%System.String addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  %loc1 = alloca i16 addrspace(1)*
+  %loc2 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %1 = icmp ne %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg4
+  %7 = icmp sge i32 %6, 0
+  br i1 %7, label %13, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  unreachable
+
+; <label>:13                                      ; preds = %5
+  %14 = load i32, i32* %arg1
+  %15 = icmp sge i32 %14, 0
+  br i1 %15, label %21, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %18)
+  %20 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %20, %System.String addrspace(1)* %17, %System.String addrspace(1)* %19)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %20) #0
+  unreachable
+
+; <label>:21                                      ; preds = %13
+  %22 = load i32, i32* %arg4
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck, label %ThrowNullRef, label %24
+
+; <label>:24                                      ; preds = %21
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load i32, i32* %arg1
+  %28 = sub i32 %26, %27
+  %29 = icmp sle i32 %22, %28
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34, %System.String addrspace(1)* %31, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %24
+  %36 = load i32, i32* %arg3
+  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %37, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
+
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
+  %40 = load i32, i32 addrspace(1)* %39
+  %41 = zext i32 %40 to i64
+  %42 = trunc i64 %41 to i32
+  %43 = load i32, i32* %arg4
+  %44 = sub i32 %42, %43
+  %45 = icmp sgt i32 %36, %44
+  br i1 %45, label %49, label %46
+
+; <label>:46                                      ; preds = %38
+  %47 = load i32, i32* %arg3
+  %48 = icmp sge i32 %47, 0
+  br i1 %48, label %54, label %49
+
+; <label>:49                                      ; preds = %38, %46
+  %50 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %52 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %51)
+  %53 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53, %System.String addrspace(1)* %50, %System.String addrspace(1)* %52)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53) #0
+  unreachable
+
+; <label>:54                                      ; preds = %46
+  %55 = load i32, i32* %arg4
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %97, label %57
+
+; <label>:57                                      ; preds = %54
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %59
+
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 2
+  %61 = bitcast [0 x i16] addrspace(1)* %60 to i16 addrspace(1)*
+  store i16 addrspace(1)* %61, i16 addrspace(1)** %loc0
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  store %"System.Char[]" addrspace(1)* %62, %"System.Char[]" addrspace(1)** %loc2
+  %63 = icmp eq %"System.Char[]" addrspace(1)* %62, null
+  br i1 %63, label %72, label %64
+
+; <label>:64                                      ; preds = %59
+  %65 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc2
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %65, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %66
+
+; <label>:66                                      ; preds = %64
+  %67 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %65, i32 0, i32 1
+  %68 = load i32, i32 addrspace(1)* %67
+  %69 = zext i32 %68 to i64
+  %70 = trunc i64 %69 to i32
+  %71 = icmp ne i32 %70, 0
+  br i1 %71, label %73, label %72
+
+; <label>:72                                      ; preds = %59, %66
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  br label %81
+
+; <label>:73                                      ; preds = %66
+  %74 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc2
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %74, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %75
+
+; <label>:75                                      ; preds = %73
+  %76 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %74, i32 0, i32 1
+  %77 = load i32, i32 addrspace(1)* %76
+  %78 = zext i32 %77 to i64
+  %BoundsCheck = icmp uge i64 0, %78
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %79
+
+; <label>:79                                      ; preds = %75
+  %80 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %74, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %80, i16 addrspace(1)** %loc1
+  br label %81
+
+; <label>:81                                      ; preds = %72, %79
+  %82 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %83 = ptrtoint i16 addrspace(1)* %82 to i64
+  %84 = load i32, i32* %arg3
+  %85 = sext i32 %84 to i64
+  %86 = mul i64 %85, 2
+  %87 = add i64 %83, %86
+  %88 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %89 = ptrtoint i16 addrspace(1)* %88 to i64
+  %90 = load i32, i32* %arg1
+  %91 = sext i32 %90 to i64
+  %92 = mul i64 %91, 2
+  %93 = add i64 %89, %92
+  %94 = load i32, i32* %arg4
+  %95 = inttoptr i64 %87 to i16*
+  %96 = inttoptr i64 %93 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %95, i16* %96, i32 %94)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  br label %97
+
+; <label>:97                                      ; preds = %54, %81
+  ret void
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
 Successfully read ConsoleEncoding.GetPreamble
 
@@ -14829,7 +16748,365 @@ entry:
 }
 
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[loadElemA]
+Successfully read EncoderNLS.GetBytes
+
+define i32 @EncoderNLS.GetBytes(%System.Text.EncoderNLS addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3, %"System.Byte[]" addrspace(1)* %param4, i32 %param5, i8 %param6) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %arg4 = alloca %"System.Byte[]" addrspace(1)*
+  %arg5 = alloca i32
+  %arg6 = alloca i8
+  %loc0 = alloca i32
+  %loc1 = alloca i16 addrspace(1)*
+  %loc2 = alloca i8 addrspace(1)*
+  %loc3 = alloca i32
+  %loc4 = alloca %"System.Char[]" addrspace(1)*
+  %loc5 = alloca %"System.Byte[]" addrspace(1)*
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  store %"System.Byte[]" addrspace(1)* %param4, %"System.Byte[]" addrspace(1)** %arg4
+  store i32 %param5, i32* %arg5
+  store i8 %param6, i8* %arg6
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %1 = icmp eq %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %17, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %7 = icmp eq %"System.Char[]" addrspace(1)* %6, null
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %12
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %12
+
+; <label>:12                                      ; preds = %8, %10
+  %13 = phi %System.String addrspace(1)* [ %9, %8 ], [ %11, %10 ]
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %14)
+  %16 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16, %System.String addrspace(1)* %13, %System.String addrspace(1)* %15)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16) #0
+  unreachable
+
+; <label>:17                                      ; preds = %2
+  %18 = load i32, i32* %arg2
+  %19 = icmp slt i32 %18, 0
+  br i1 %19, label %23, label %20
+
+; <label>:20                                      ; preds = %17
+  %21 = load i32, i32* %arg3
+  %22 = icmp sge i32 %21, 0
+  br i1 %22, label %35, label %23
+
+; <label>:23                                      ; preds = %17, %20
+  %24 = load i32, i32* %arg2
+  %25 = icmp slt i32 %24, 0
+  br i1 %25, label %28, label %26
+
+; <label>:26                                      ; preds = %23
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %30
+
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %30
+
+; <label>:30                                      ; preds = %26, %28
+  %31 = phi %System.String addrspace(1)* [ %27, %26 ], [ %29, %28 ]
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34, %System.String addrspace(1)* %31, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %20
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck, label %ThrowNullRef, label %37
+
+; <label>:37                                      ; preds = %35
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = load i32, i32* %arg2
+  %43 = sub i32 %41, %42
+  %44 = load i32, i32* %arg3
+  %45 = icmp sge i32 %43, %44
+  br i1 %45, label %51, label %46
+
+; <label>:46                                      ; preds = %37
+  %47 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %48 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %49 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %48)
+  %50 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %50, %System.String addrspace(1)* %47, %System.String addrspace(1)* %49)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %50) #0
+  unreachable
+
+; <label>:51                                      ; preds = %37
+  %52 = load i32, i32* %arg5
+  %53 = icmp slt i32 %52, 0
+  br i1 %53, label %63, label %54
+
+; <label>:54                                      ; preds = %51
+  %55 = load i32, i32* %arg5
+  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck1 = icmp eq %"System.Byte[]" addrspace(1)* %56, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %57
+
+; <label>:57                                      ; preds = %54
+  %58 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = zext i32 %59 to i64
+  %61 = trunc i64 %60 to i32
+  %62 = icmp sle i32 %55, %61
+  br i1 %62, label %68, label %63
+
+; <label>:63                                      ; preds = %51, %57
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %66 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %65)
+  %67 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %67, %System.String addrspace(1)* %64, %System.String addrspace(1)* %66)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %67) #0
+  unreachable
+
+; <label>:68                                      ; preds = %57
+  %69 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %69, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %69, i32 0, i32 1
+  %72 = load i32, i32 addrspace(1)* %71
+  %73 = zext i32 %72 to i64
+  %74 = trunc i64 %73 to i32
+  %75 = icmp ne i32 %74, 0
+  br i1 %75, label %78, label %76
+
+; <label>:76                                      ; preds = %70
+  %77 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1)
+  store %"System.Char[]" addrspace(1)* %77, %"System.Char[]" addrspace(1)** %arg1
+  br label %78
+
+; <label>:78                                      ; preds = %70, %76
+  %79 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck5 = icmp eq %"System.Byte[]" addrspace(1)* %79, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %80
+
+; <label>:80                                      ; preds = %78
+  %81 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %79, i32 0, i32 1
+  %82 = load i32, i32 addrspace(1)* %81
+  %83 = zext i32 %82 to i64
+  %84 = trunc i64 %83 to i32
+  %85 = load i32, i32* %arg5
+  %86 = sub i32 %84, %85
+  store i32 %86, i32* %loc0
+  %87 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck7 = icmp eq %"System.Byte[]" addrspace(1)* %87, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %88
+
+; <label>:88                                      ; preds = %80
+  %89 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %87, i32 0, i32 1
+  %90 = load i32, i32 addrspace(1)* %89
+  %91 = zext i32 %90 to i64
+  %92 = trunc i64 %91 to i32
+  %93 = icmp ne i32 %92, 0
+  br i1 %93, label %96, label %94
+
+; <label>:94                                      ; preds = %88
+  %95 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1)
+  store %"System.Byte[]" addrspace(1)* %95, %"System.Byte[]" addrspace(1)** %arg4
+  br label %96
+
+; <label>:96                                      ; preds = %88, %94
+  %97 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  store %"System.Char[]" addrspace(1)* %97, %"System.Char[]" addrspace(1)** %loc4
+  %98 = icmp eq %"System.Char[]" addrspace(1)* %97, null
+  br i1 %98, label %107, label %99
+
+; <label>:99                                      ; preds = %96
+  %100 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc4
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %100, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %101
+
+; <label>:101                                     ; preds = %99
+  %102 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %100, i32 0, i32 1
+  %103 = load i32, i32 addrspace(1)* %102
+  %104 = zext i32 %103 to i64
+  %105 = trunc i64 %104 to i32
+  %106 = icmp ne i32 %105, 0
+  br i1 %106, label %108, label %107
+
+; <label>:107                                     ; preds = %96, %101
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  br label %116
+
+; <label>:108                                     ; preds = %101
+  %109 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc4
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %109, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %110
+
+; <label>:110                                     ; preds = %108
+  %111 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %109, i32 0, i32 1
+  %112 = load i32, i32 addrspace(1)* %111
+  %113 = zext i32 %112 to i64
+  %BoundsCheck = icmp uge i64 0, %113
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %114
+
+; <label>:114                                     ; preds = %110
+  %115 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %109, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %115, i16 addrspace(1)** %loc1
+  br label %116
+
+; <label>:116                                     ; preds = %107, %114
+  %117 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  store %"System.Byte[]" addrspace(1)* %117, %"System.Byte[]" addrspace(1)** %loc5
+  %118 = icmp eq %"System.Byte[]" addrspace(1)* %117, null
+  br i1 %118, label %127, label %119
+
+; <label>:119                                     ; preds = %116
+  %120 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc5
+  %NullCheck13 = icmp eq %"System.Byte[]" addrspace(1)* %120, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %121
+
+; <label>:121                                     ; preds = %119
+  %122 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %120, i32 0, i32 1
+  %123 = load i32, i32 addrspace(1)* %122
+  %124 = zext i32 %123 to i64
+  %125 = trunc i64 %124 to i32
+  %126 = icmp ne i32 %125, 0
+  br i1 %126, label %128, label %127
+
+; <label>:127                                     ; preds = %116, %121
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc2
+  br label %136
+
+; <label>:128                                     ; preds = %121
+  %129 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc5
+  %NullCheck15 = icmp eq %"System.Byte[]" addrspace(1)* %129, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %130
+
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %129, i32 0, i32 1
+  %132 = load i32, i32 addrspace(1)* %131
+  %133 = zext i32 %132 to i64
+  %BoundsCheck17 = icmp uge i64 0, %133
+  br i1 %BoundsCheck17, label %ThrowIndexOutOfRange18, label %134
+
+; <label>:134                                     ; preds = %130
+  %135 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %129, i32 0, i32 3, i32 0
+  store i8 addrspace(1)* %135, i8 addrspace(1)** %loc2
+  br label %136
+
+; <label>:136                                     ; preds = %127, %134
+  %137 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %138 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %139 = ptrtoint i16 addrspace(1)* %138 to i64
+  %140 = load i32, i32* %arg2
+  %141 = sext i32 %140 to i64
+  %142 = mul i64 %141, 2
+  %143 = add i64 %139, %142
+  %144 = load i32, i32* %arg3
+  %145 = load i8 addrspace(1)*, i8 addrspace(1)** %loc2
+  %146 = ptrtoint i8 addrspace(1)* %145 to i64
+  %147 = load i32, i32* %arg5
+  %148 = sext i32 %147 to i64
+  %149 = add i64 %146, %148
+  %150 = load i32, i32* %loc0
+  %151 = load i8, i8* %arg6
+  %152 = zext i8 %151 to i32
+  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i64 addrspace(1)*
+  %NullCheck19 = icmp eq i64 addrspace(1)* %153, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %154
+
+; <label>:154                                     ; preds = %136
+  %155 = load i64, i64 addrspace(1)* %153
+  %156 = add i64 %155, 72
+  %157 = inttoptr i64 %156 to i64*
+  %158 = load i64, i64* %157
+  %159 = add i64 %158, 0
+  %160 = inttoptr i64 %159 to i64*
+  %161 = load i64, i64* %160
+  %162 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to %System.Text.Encoder addrspace(1)*
+  %163 = inttoptr i64 %143 to i16*
+  %164 = inttoptr i64 %149 to i8*
+  %165 = trunc i32 %152 to i8
+  %166 = inttoptr i64 %161 to i32 (%System.Text.Encoder addrspace(1)*, i16*, i32, i8*, i32, i8)*
+  %167 = call i32 %166(%System.Text.Encoder addrspace(1)* %162, i16* %163, i32 %144, i8* %164, i32 %150, i8 %165)
+  store i32 %167, i32* %loc3
+  br label %168
+
+; <label>:168                                     ; preds = %154
+  %169 = load i32, i32* %loc3
+  ret i32 %169
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %110
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %119
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange18:                           ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
 Successfully read EncoderNLS.GetBytes
 
@@ -14918,22 +17195,22 @@ entry:
   %40 = load i8, i8* %arg5
   %41 = zext i8 %40 to i32
   %42 = trunc i32 %41 to i8
-  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %39, null
-  br i1 %NullCheck, label %43, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderNLS addrspace(1)* %39, null
+  br i1 %NullCheck, label %ThrowNullRef, label %43
 
 ; <label>:43                                      ; preds = %38
   %44 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
   store i8 %42, i8 addrspace(1)* %44
   %45 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %45, null
-  br i1 %NullCheck2, label %46, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.EncoderNLS addrspace(1)* %45, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %46
 
 ; <label>:46                                      ; preds = %43
   %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %45, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %47
   %48 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.EncoderNLS addrspace(1)* %48, null
-  br i1 %NullCheck4, label %49, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.EncoderNLS addrspace(1)* %48, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %49
 
 ; <label>:49                                      ; preds = %46
   %50 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %48, i32 0, i32 3
@@ -14944,8 +17221,8 @@ entry:
   %55 = load i32, i32* %arg4
   %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck6, label %58, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
   %59 = load i64, i64 addrspace(1)* %57
@@ -14963,15 +17240,15 @@ ThrowNullRef:                                     ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %43
+ThrowNullRef2:                                    ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %46
+ThrowNullRef4:                                    ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %49
+ThrowNullRef6:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14999,8 +17276,8 @@ entry:
   %4 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0 to %System.IO.ConsoleStream addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*)(%System.IO.ConsoleStream addrspace(1)* %4, %"System.Byte[]" addrspace(1)* %1, i32 %2, i32 %3)
   %5 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
@@ -15085,8 +17362,8 @@ entry:
 
 ; <label>:22                                      ; preds = %8
   %23 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %23, null
-  br i1 %NullCheck, label %24, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Byte[]" addrspace(1)* %23, null
+  br i1 %NullCheck, label %ThrowNullRef, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
@@ -15108,8 +17385,8 @@ entry:
 
 ; <label>:36                                      ; preds = %24
   %37 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %37, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.ConsoleStream addrspace(1)* %37, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %37, i32 0, i32 4
@@ -15130,13 +17407,138 @@ ThrowNullRef:                                     ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %36
+ThrowNullRef2:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
-Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
+Successfully read WindowsConsoleStream.WriteFileNative
+
+define i32 @WindowsConsoleStream.WriteFileNative(i64 %param0, %"System.Byte[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i64
+  %arg1 = alloca %"System.Byte[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i8 addrspace(1)*
+  %loc2 = alloca %"System.Byte[]" addrspace(1)*
+  %loc3 = alloca i32
+  store i64 %param0, i64* %arg0
+  store %"System.Byte[]" addrspace(1)* %param1, %"System.Byte[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Byte[]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = zext i32 %3 to i64
+  %5 = icmp ne i64 %4, 0
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %1
+  ret i32 0
+
+; <label>:7                                       ; preds = %1
+  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  store %"System.Byte[]" addrspace(1)* %8, %"System.Byte[]" addrspace(1)** %loc2
+  %9 = icmp eq %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %9, label %18, label %10
+
+; <label>:10                                      ; preds = %7
+  %11 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc2
+  %NullCheck1 = icmp eq %"System.Byte[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %11, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp ne i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %7, %12
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc1
+  br label %27
+
+; <label>:19                                      ; preds = %12
+  %20 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc2
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %20, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %BoundsCheck = icmp uge i64 0, %24
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %25
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %20, i32 0, i32 3, i32 0
+  store i8 addrspace(1)* %26, i8 addrspace(1)** %loc1
+  br label %27
+
+; <label>:27                                      ; preds = %18, %25
+  %28 = load i64, i64* %arg0
+  %29 = load i8 addrspace(1)*, i8 addrspace(1)** %loc1
+  %30 = ptrtoint i8 addrspace(1)* %29 to i64
+  %31 = load i32, i32* %arg2
+  %32 = sext i32 %31 to i64
+  %33 = add i64 %30, %32
+  %34 = load i32, i32* %arg3
+  %35 = addrspacecast i32* %loc3 to i32 addrspace(1)*
+  %36 = inttoptr i64 %33 to i8*
+  %37 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i8*, i32, i32 addrspace(1)*, i64)*)(i64 %28, i8* %36, i32 %34, i32 addrspace(1)* %35, i64 0)
+  %38 = icmp ugt i32 %37, 0
+  %39 = sext i1 %38 to i32
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc1
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %42, label %41
+
+; <label>:41                                      ; preds = %27
+  ret i32 0
+
+; <label>:42                                      ; preds = %27
+  %43 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  store i32 %43, i32* %loc0
+  %44 = load i32, i32* %loc0
+  %45 = icmp eq i32 %44, 232
+  br i1 %45, label %49, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = load i32, i32* %loc0
+  %48 = icmp ne i32 %47, 109
+  br i1 %48, label %50, label %49
+
+; <label>:49                                      ; preds = %42, %46
+  ret i32 0
+
+; <label>:50                                      ; preds = %46
+  %51 = load i32, i32* %loc0
+  ret i32 %51
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
 Successfully read WindowsConsoleStream.Flush
 
@@ -15145,8 +17547,8 @@ entry:
   %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
   store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
@@ -15181,8 +17583,8 @@ entry:
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
   %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load i64, i64 addrspace(1)* %1
@@ -15221,15 +17623,15 @@ entry:
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.TextWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
   %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %3, align 8
   %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
   %7 = load i64, i64 addrspace(1)* %5
@@ -15247,7 +17649,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -15276,8 +17678,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %4)
   store i32 0, i32* %loc0
   %5 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Char[]" addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
@@ -15289,15 +17691,15 @@ entry:
 
 ; <label>:11                                      ; preds = %69
   %12 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %12, i32 0, i32 9
   %15 = load i32, i32 addrspace(1)* %14, align 8
   %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.IO.StreamWriter addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %16, i32 0, i32 10
@@ -15312,15 +17714,15 @@ entry:
 
 ; <label>:23                                      ; preds = %17, %21
   %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %24, null
-  br i1 %NullCheck8, label %25, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %24, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 10
   %27 = load i32, i32 addrspace(1)* %26, align 8
   %28 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %28, null
-  br i1 %NullCheck10, label %29, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.StreamWriter addrspace(1)* %28, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %28, i32 0, i32 9
@@ -15342,15 +17744,15 @@ entry:
   %40 = load i32, i32* %loc0
   %41 = mul i32 %40, 2
   %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
-  br i1 %NullCheck12, label %43, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %43
 
 ; <label>:43                                      ; preds = %38
   %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 7
   %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %44, align 8
   %46 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %46, null
-  br i1 %NullCheck14, label %47, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.IO.StreamWriter addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %47
 
 ; <label>:47                                      ; preds = %43
   %48 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %46, i32 0, i32 9
@@ -15362,16 +17764,16 @@ entry:
   %54 = bitcast %"System.Char[]" addrspace(1)* %45 to %System.Array addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %53, i32 %41, %System.Array addrspace(1)* %54, i32 %50, i32 %52)
   %55 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
-  br i1 %NullCheck16, label %56, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %56
 
 ; <label>:56                                      ; preds = %47
   %57 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
   %58 = load i32, i32 addrspace(1)* %57, align 8
   %59 = load i32, i32* %loc2
   %60 = add i32 %58, %59
-  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
-  br i1 %NullCheck18, label %61, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %61
 
 ; <label>:61                                      ; preds = %56
   %62 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
@@ -15393,8 +17795,8 @@ entry:
 
 ; <label>:72                                      ; preds = %69
   %73 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %73, null
-  br i1 %NullCheck2, label %74, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %73, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %74
 
 ; <label>:74                                      ; preds = %72
   %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %73, i32 0, i32 11
@@ -15415,39 +17817,39 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %72
+ThrowNullRef2:                                    ; preds = %72
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %23
+ThrowNullRef8:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef10:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %43
+ThrowNullRef14:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %47
+ThrowNullRef16:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %56
+ThrowNullRef18:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblNeg.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblNeg.error.txt
@@ -25,8 +25,8 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
@@ -40,8 +40,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
   %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
@@ -75,7 +75,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -90,8 +90,8 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %NullCheck = icmp ne i8 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = load i8, i8 addrspace(1)* %0, align 8
@@ -125,8 +125,8 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
@@ -159,8 +159,8 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -184,8 +184,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
   store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
@@ -195,8 +195,8 @@ entry:
 ; <label>:4                                       ; preds = %1
   %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
   %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
@@ -206,8 +206,8 @@ entry:
   %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
@@ -221,14 +221,14 @@ entry:
 
 ; <label>:17                                      ; preds = %14
   %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
   %21 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
@@ -238,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -249,8 +249,8 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
@@ -261,27 +261,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %30
+ThrowNullRef10:                                   ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -301,7 +301,89 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
-Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
+Successfully read AppDomainSetup.GetUnsecureApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.GetUnsecureApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %NullCheck = icmp eq %"System.String[]" addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %BoundsCheck = icmp uge i64 0, %5
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %6
+
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 3, i32 0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
+  ret %System.String addrspace(1)* %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_Value using LLILCJit
+Successfully read AppDomainSetup.get_Value
+
+define %"System.String[]" addrspace(1)* @AppDomainSetup.get_Value(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.String[]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 18)
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.String[]" addrspace(1)* addrspace(1)*, %"System.String[]" addrspace(1)*)*)(%"System.String[]" addrspace(1)* addrspace(1)* %9, %"System.String[]" addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %11, i32 0, i32 1
+  %14 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %13, align 8
+  ret %"System.String[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -319,8 +401,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -368,16 +450,16 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
   %5 = load i32, i32 addrspace(1)* %4
   %6 = sub i32 %5, 1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -389,7 +471,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -421,8 +503,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
@@ -456,8 +538,8 @@ entry:
 ; <label>:27                                      ; preds = %19
   %28 = load i32, i32* %arg1
   %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
-  br i1 %NullCheck2, label %30, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %29, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %30
 
 ; <label>:30                                      ; preds = %27
   %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
@@ -493,8 +575,8 @@ entry:
 ; <label>:49                                      ; preds = %46
   %50 = load i32, i32* %arg2
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck4, label %52, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
@@ -517,11 +599,11 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %27
+ThrowNullRef2:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %49
+ThrowNullRef4:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -544,16 +626,16 @@ entry:
   %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %0)
   store %System.String addrspace(1)* %1, %System.String addrspace(1)** %loc0
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 2
   %5 = bitcast [0 x i16] addrspace(1)* %4 to i16 addrspace(1)*
   store i16 addrspace(1)* %5, i16 addrspace(1)** %loc1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %3
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2
@@ -580,7 +662,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -691,15 +773,15 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %NullCheck132 = icmp ne i8* %21, null
-  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+  %NullCheck131 = icmp eq i8* %21, null
+  br i1 %NullCheck131, label %ThrowNullRef132, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = load i8, i8* %21, align 8
   %24 = zext i8 %23 to i32
   %25 = trunc i32 %24 to i8
-  %NullCheck134 = icmp ne i8* %20, null
-  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+  %NullCheck133 = icmp eq i8* %20, null
+  br i1 %NullCheck133, label %ThrowNullRef134, label %26
 
 ; <label>:26                                      ; preds = %22
   store i8 %25, i8* %20, align 8
@@ -709,16 +791,16 @@ entry:
   %28 = load i8*, i8** %arg0
   %29 = load i8*, i8** %arg1
   %30 = bitcast i8* %29 to i16*
-  %NullCheck128 = icmp ne i16* %30, null
-  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+  %NullCheck127 = icmp eq i16* %30, null
+  br i1 %NullCheck127, label %ThrowNullRef128, label %31
 
 ; <label>:31                                      ; preds = %27
   %32 = load i16, i16* %30, align 8
   %33 = sext i16 %32 to i32
   %34 = bitcast i8* %28 to i16*
   %35 = trunc i32 %33 to i16
-  %NullCheck130 = icmp ne i16* %34, null
-  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+  %NullCheck129 = icmp eq i16* %34, null
+  br i1 %NullCheck129, label %ThrowNullRef130, label %36
 
 ; <label>:36                                      ; preds = %31
   store i16 %35, i16* %34, align 8
@@ -728,16 +810,16 @@ entry:
   %38 = load i8*, i8** %arg0
   %39 = load i8*, i8** %arg1
   %40 = bitcast i8* %39 to i16*
-  %NullCheck120 = icmp ne i16* %40, null
-  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+  %NullCheck119 = icmp eq i16* %40, null
+  br i1 %NullCheck119, label %ThrowNullRef120, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i16, i16* %40, align 8
   %43 = sext i16 %42 to i32
   %44 = bitcast i8* %38 to i16*
   %45 = trunc i32 %43 to i16
-  %NullCheck122 = icmp ne i16* %44, null
-  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+  %NullCheck121 = icmp eq i16* %44, null
+  br i1 %NullCheck121, label %ThrowNullRef122, label %46
 
 ; <label>:46                                      ; preds = %41
   store i16 %45, i16* %44, align 8
@@ -745,15 +827,15 @@ entry:
   %48 = getelementptr inbounds i8, i8* %47, i64 2
   %49 = load i8*, i8** %arg1
   %50 = getelementptr inbounds i8, i8* %49, i64 2
-  %NullCheck124 = icmp ne i8* %50, null
-  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+  %NullCheck123 = icmp eq i8* %50, null
+  br i1 %NullCheck123, label %ThrowNullRef124, label %51
 
 ; <label>:51                                      ; preds = %46
   %52 = load i8, i8* %50, align 8
   %53 = zext i8 %52 to i32
   %54 = trunc i32 %53 to i8
-  %NullCheck126 = icmp ne i8* %48, null
-  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+  %NullCheck125 = icmp eq i8* %48, null
+  br i1 %NullCheck125, label %ThrowNullRef126, label %55
 
 ; <label>:55                                      ; preds = %51
   store i8 %54, i8* %48, align 8
@@ -763,14 +845,14 @@ entry:
   %57 = load i8*, i8** %arg0
   %58 = load i8*, i8** %arg1
   %59 = bitcast i8* %58 to i32*
-  %NullCheck116 = icmp ne i32* %59, null
-  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+  %NullCheck115 = icmp eq i32* %59, null
+  br i1 %NullCheck115, label %ThrowNullRef116, label %60
 
 ; <label>:60                                      ; preds = %56
   %61 = load i32, i32* %59, align 8
   %62 = bitcast i8* %57 to i32*
-  %NullCheck118 = icmp ne i32* %62, null
-  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+  %NullCheck117 = icmp eq i32* %62, null
+  br i1 %NullCheck117, label %ThrowNullRef118, label %63
 
 ; <label>:63                                      ; preds = %60
   store i32 %61, i32* %62, align 8
@@ -780,14 +862,14 @@ entry:
   %65 = load i8*, i8** %arg0
   %66 = load i8*, i8** %arg1
   %67 = bitcast i8* %66 to i32*
-  %NullCheck108 = icmp ne i32* %67, null
-  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+  %NullCheck107 = icmp eq i32* %67, null
+  br i1 %NullCheck107, label %ThrowNullRef108, label %68
 
 ; <label>:68                                      ; preds = %64
   %69 = load i32, i32* %67, align 8
   %70 = bitcast i8* %65 to i32*
-  %NullCheck110 = icmp ne i32* %70, null
-  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+  %NullCheck109 = icmp eq i32* %70, null
+  br i1 %NullCheck109, label %ThrowNullRef110, label %71
 
 ; <label>:71                                      ; preds = %68
   store i32 %69, i32* %70, align 8
@@ -795,15 +877,15 @@ entry:
   %73 = getelementptr inbounds i8, i8* %72, i64 4
   %74 = load i8*, i8** %arg1
   %75 = getelementptr inbounds i8, i8* %74, i64 4
-  %NullCheck112 = icmp ne i8* %75, null
-  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+  %NullCheck111 = icmp eq i8* %75, null
+  br i1 %NullCheck111, label %ThrowNullRef112, label %76
 
 ; <label>:76                                      ; preds = %71
   %77 = load i8, i8* %75, align 8
   %78 = zext i8 %77 to i32
   %79 = trunc i32 %78 to i8
-  %NullCheck114 = icmp ne i8* %73, null
-  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+  %NullCheck113 = icmp eq i8* %73, null
+  br i1 %NullCheck113, label %ThrowNullRef114, label %80
 
 ; <label>:80                                      ; preds = %76
   store i8 %79, i8* %73, align 8
@@ -813,14 +895,14 @@ entry:
   %82 = load i8*, i8** %arg0
   %83 = load i8*, i8** %arg1
   %84 = bitcast i8* %83 to i32*
-  %NullCheck100 = icmp ne i32* %84, null
-  br i1 %NullCheck100, label %85, label %ThrowNullRef99
+  %NullCheck99 = icmp eq i32* %84, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %85
 
 ; <label>:85                                      ; preds = %81
   %86 = load i32, i32* %84, align 8
   %87 = bitcast i8* %82 to i32*
-  %NullCheck102 = icmp ne i32* %87, null
-  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+  %NullCheck101 = icmp eq i32* %87, null
+  br i1 %NullCheck101, label %ThrowNullRef102, label %88
 
 ; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
@@ -829,16 +911,16 @@ entry:
   %91 = load i8*, i8** %arg1
   %92 = getelementptr inbounds i8, i8* %91, i64 4
   %93 = bitcast i8* %92 to i16*
-  %NullCheck104 = icmp ne i16* %93, null
-  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+  %NullCheck103 = icmp eq i16* %93, null
+  br i1 %NullCheck103, label %ThrowNullRef104, label %94
 
 ; <label>:94                                      ; preds = %88
   %95 = load i16, i16* %93, align 8
   %96 = sext i16 %95 to i32
   %97 = bitcast i8* %90 to i16*
   %98 = trunc i32 %96 to i16
-  %NullCheck106 = icmp ne i16* %97, null
-  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+  %NullCheck105 = icmp eq i16* %97, null
+  br i1 %NullCheck105, label %ThrowNullRef106, label %99
 
 ; <label>:99                                      ; preds = %94
   store i16 %98, i16* %97, align 8
@@ -848,14 +930,14 @@ entry:
   %101 = load i8*, i8** %arg0
   %102 = load i8*, i8** %arg1
   %103 = bitcast i8* %102 to i32*
-  %NullCheck88 = icmp ne i32* %103, null
-  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+  %NullCheck87 = icmp eq i32* %103, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %104
 
 ; <label>:104                                     ; preds = %100
   %105 = load i32, i32* %103, align 8
   %106 = bitcast i8* %101 to i32*
-  %NullCheck90 = icmp ne i32* %106, null
-  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+  %NullCheck89 = icmp eq i32* %106, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %107
 
 ; <label>:107                                     ; preds = %104
   store i32 %105, i32* %106, align 8
@@ -864,16 +946,16 @@ entry:
   %110 = load i8*, i8** %arg1
   %111 = getelementptr inbounds i8, i8* %110, i64 4
   %112 = bitcast i8* %111 to i16*
-  %NullCheck92 = icmp ne i16* %112, null
-  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+  %NullCheck91 = icmp eq i16* %112, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %113
 
 ; <label>:113                                     ; preds = %107
   %114 = load i16, i16* %112, align 8
   %115 = sext i16 %114 to i32
   %116 = bitcast i8* %109 to i16*
   %117 = trunc i32 %115 to i16
-  %NullCheck94 = icmp ne i16* %116, null
-  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+  %NullCheck93 = icmp eq i16* %116, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %118
 
 ; <label>:118                                     ; preds = %113
   store i16 %117, i16* %116, align 8
@@ -881,15 +963,15 @@ entry:
   %120 = getelementptr inbounds i8, i8* %119, i64 6
   %121 = load i8*, i8** %arg1
   %122 = getelementptr inbounds i8, i8* %121, i64 6
-  %NullCheck96 = icmp ne i8* %122, null
-  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+  %NullCheck95 = icmp eq i8* %122, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %123
 
 ; <label>:123                                     ; preds = %118
   %124 = load i8, i8* %122, align 8
   %125 = zext i8 %124 to i32
   %126 = trunc i32 %125 to i8
-  %NullCheck98 = icmp ne i8* %120, null
-  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+  %NullCheck97 = icmp eq i8* %120, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %127
 
 ; <label>:127                                     ; preds = %123
   store i8 %126, i8* %120, align 8
@@ -899,14 +981,14 @@ entry:
   %129 = load i8*, i8** %arg0
   %130 = load i8*, i8** %arg1
   %131 = bitcast i8* %130 to i64*
-  %NullCheck84 = icmp ne i64* %131, null
-  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+  %NullCheck83 = icmp eq i64* %131, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %132
 
 ; <label>:132                                     ; preds = %128
   %133 = load i64, i64* %131, align 8
   %134 = bitcast i8* %129 to i64*
-  %NullCheck86 = icmp ne i64* %134, null
-  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+  %NullCheck85 = icmp eq i64* %134, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %135
 
 ; <label>:135                                     ; preds = %132
   store i64 %133, i64* %134, align 8
@@ -916,14 +998,14 @@ entry:
   %137 = load i8*, i8** %arg0
   %138 = load i8*, i8** %arg1
   %139 = bitcast i8* %138 to i64*
-  %NullCheck76 = icmp ne i64* %139, null
-  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+  %NullCheck75 = icmp eq i64* %139, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %140
 
 ; <label>:140                                     ; preds = %136
   %141 = load i64, i64* %139, align 8
   %142 = bitcast i8* %137 to i64*
-  %NullCheck78 = icmp ne i64* %142, null
-  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+  %NullCheck77 = icmp eq i64* %142, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %143
 
 ; <label>:143                                     ; preds = %140
   store i64 %141, i64* %142, align 8
@@ -931,15 +1013,15 @@ entry:
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %NullCheck80 = icmp ne i8* %147, null
-  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+  %NullCheck79 = icmp eq i8* %147, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %148
 
 ; <label>:148                                     ; preds = %143
   %149 = load i8, i8* %147, align 8
   %150 = zext i8 %149 to i32
   %151 = trunc i32 %150 to i8
-  %NullCheck82 = icmp ne i8* %145, null
-  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+  %NullCheck81 = icmp eq i8* %145, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %152
 
 ; <label>:152                                     ; preds = %148
   store i8 %151, i8* %145, align 8
@@ -949,14 +1031,14 @@ entry:
   %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
   %156 = bitcast i8* %155 to i64*
-  %NullCheck68 = icmp ne i64* %156, null
-  br i1 %NullCheck68, label %157, label %ThrowNullRef67
+  %NullCheck67 = icmp eq i64* %156, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %157
 
 ; <label>:157                                     ; preds = %153
   %158 = load i64, i64* %156, align 8
   %159 = bitcast i8* %154 to i64*
-  %NullCheck70 = icmp ne i64* %159, null
-  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+  %NullCheck69 = icmp eq i64* %159, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %160
 
 ; <label>:160                                     ; preds = %157
   store i64 %158, i64* %159, align 8
@@ -965,16 +1047,16 @@ entry:
   %163 = load i8*, i8** %arg1
   %164 = getelementptr inbounds i8, i8* %163, i64 8
   %165 = bitcast i8* %164 to i16*
-  %NullCheck72 = icmp ne i16* %165, null
-  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+  %NullCheck71 = icmp eq i16* %165, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %166
 
 ; <label>:166                                     ; preds = %160
   %167 = load i16, i16* %165, align 8
   %168 = sext i16 %167 to i32
   %169 = bitcast i8* %162 to i16*
   %170 = trunc i32 %168 to i16
-  %NullCheck74 = icmp ne i16* %169, null
-  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+  %NullCheck73 = icmp eq i16* %169, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %171
 
 ; <label>:171                                     ; preds = %166
   store i16 %170, i16* %169, align 8
@@ -984,14 +1066,14 @@ entry:
   %173 = load i8*, i8** %arg0
   %174 = load i8*, i8** %arg1
   %175 = bitcast i8* %174 to i64*
-  %NullCheck56 = icmp ne i64* %175, null
-  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+  %NullCheck55 = icmp eq i64* %175, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %176
 
 ; <label>:176                                     ; preds = %172
   %177 = load i64, i64* %175, align 8
   %178 = bitcast i8* %173 to i64*
-  %NullCheck58 = icmp ne i64* %178, null
-  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+  %NullCheck57 = icmp eq i64* %178, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %179
 
 ; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
@@ -1000,16 +1082,16 @@ entry:
   %182 = load i8*, i8** %arg1
   %183 = getelementptr inbounds i8, i8* %182, i64 8
   %184 = bitcast i8* %183 to i16*
-  %NullCheck60 = icmp ne i16* %184, null
-  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+  %NullCheck59 = icmp eq i16* %184, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %185
 
 ; <label>:185                                     ; preds = %179
   %186 = load i16, i16* %184, align 8
   %187 = sext i16 %186 to i32
   %188 = bitcast i8* %181 to i16*
   %189 = trunc i32 %187 to i16
-  %NullCheck62 = icmp ne i16* %188, null
-  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+  %NullCheck61 = icmp eq i16* %188, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %190
 
 ; <label>:190                                     ; preds = %185
   store i16 %189, i16* %188, align 8
@@ -1017,15 +1099,15 @@ entry:
   %192 = getelementptr inbounds i8, i8* %191, i64 10
   %193 = load i8*, i8** %arg1
   %194 = getelementptr inbounds i8, i8* %193, i64 10
-  %NullCheck64 = icmp ne i8* %194, null
-  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+  %NullCheck63 = icmp eq i8* %194, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %195
 
 ; <label>:195                                     ; preds = %190
   %196 = load i8, i8* %194, align 8
   %197 = zext i8 %196 to i32
   %198 = trunc i32 %197 to i8
-  %NullCheck66 = icmp ne i8* %192, null
-  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+  %NullCheck65 = icmp eq i8* %192, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %199
 
 ; <label>:199                                     ; preds = %195
   store i8 %198, i8* %192, align 8
@@ -1035,14 +1117,14 @@ entry:
   %201 = load i8*, i8** %arg0
   %202 = load i8*, i8** %arg1
   %203 = bitcast i8* %202 to i64*
-  %NullCheck48 = icmp ne i64* %203, null
-  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+  %NullCheck47 = icmp eq i64* %203, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %204
 
 ; <label>:204                                     ; preds = %200
   %205 = load i64, i64* %203, align 8
   %206 = bitcast i8* %201 to i64*
-  %NullCheck50 = icmp ne i64* %206, null
-  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+  %NullCheck49 = icmp eq i64* %206, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %207
 
 ; <label>:207                                     ; preds = %204
   store i64 %205, i64* %206, align 8
@@ -1051,14 +1133,14 @@ entry:
   %210 = load i8*, i8** %arg1
   %211 = getelementptr inbounds i8, i8* %210, i64 8
   %212 = bitcast i8* %211 to i32*
-  %NullCheck52 = icmp ne i32* %212, null
-  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+  %NullCheck51 = icmp eq i32* %212, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %213
 
 ; <label>:213                                     ; preds = %207
   %214 = load i32, i32* %212, align 8
   %215 = bitcast i8* %209 to i32*
-  %NullCheck54 = icmp ne i32* %215, null
-  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+  %NullCheck53 = icmp eq i32* %215, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %216
 
 ; <label>:216                                     ; preds = %213
   store i32 %214, i32* %215, align 8
@@ -1068,14 +1150,14 @@ entry:
   %218 = load i8*, i8** %arg0
   %219 = load i8*, i8** %arg1
   %220 = bitcast i8* %219 to i64*
-  %NullCheck36 = icmp ne i64* %220, null
-  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64* %220, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %221
 
 ; <label>:221                                     ; preds = %217
   %222 = load i64, i64* %220, align 8
   %223 = bitcast i8* %218 to i64*
-  %NullCheck38 = icmp ne i64* %223, null
-  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+  %NullCheck37 = icmp eq i64* %223, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %224
 
 ; <label>:224                                     ; preds = %221
   store i64 %222, i64* %223, align 8
@@ -1084,14 +1166,14 @@ entry:
   %227 = load i8*, i8** %arg1
   %228 = getelementptr inbounds i8, i8* %227, i64 8
   %229 = bitcast i8* %228 to i32*
-  %NullCheck40 = icmp ne i32* %229, null
-  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i32* %229, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %230
 
 ; <label>:230                                     ; preds = %224
   %231 = load i32, i32* %229, align 8
   %232 = bitcast i8* %226 to i32*
-  %NullCheck42 = icmp ne i32* %232, null
-  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+  %NullCheck41 = icmp eq i32* %232, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %233
 
 ; <label>:233                                     ; preds = %230
   store i32 %231, i32* %232, align 8
@@ -1099,15 +1181,15 @@ entry:
   %235 = getelementptr inbounds i8, i8* %234, i64 12
   %236 = load i8*, i8** %arg1
   %237 = getelementptr inbounds i8, i8* %236, i64 12
-  %NullCheck44 = icmp ne i8* %237, null
-  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i8* %237, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %238
 
 ; <label>:238                                     ; preds = %233
   %239 = load i8, i8* %237, align 8
   %240 = zext i8 %239 to i32
   %241 = trunc i32 %240 to i8
-  %NullCheck46 = icmp ne i8* %235, null
-  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+  %NullCheck45 = icmp eq i8* %235, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %242
 
 ; <label>:242                                     ; preds = %238
   store i8 %241, i8* %235, align 8
@@ -1117,14 +1199,14 @@ entry:
   %244 = load i8*, i8** %arg0
   %245 = load i8*, i8** %arg1
   %246 = bitcast i8* %245 to i64*
-  %NullCheck24 = icmp ne i64* %246, null
-  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64* %246, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %247
 
 ; <label>:247                                     ; preds = %243
   %248 = load i64, i64* %246, align 8
   %249 = bitcast i8* %244 to i64*
-  %NullCheck26 = icmp ne i64* %249, null
-  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64* %249, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %250
 
 ; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
@@ -1133,14 +1215,14 @@ entry:
   %253 = load i8*, i8** %arg1
   %254 = getelementptr inbounds i8, i8* %253, i64 8
   %255 = bitcast i8* %254 to i32*
-  %NullCheck28 = icmp ne i32* %255, null
-  br i1 %NullCheck28, label %256, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i32* %255, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %256
 
 ; <label>:256                                     ; preds = %250
   %257 = load i32, i32* %255, align 8
   %258 = bitcast i8* %252 to i32*
-  %NullCheck30 = icmp ne i32* %258, null
-  br i1 %NullCheck30, label %259, label %ThrowNullRef29
+  %NullCheck29 = icmp eq i32* %258, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %259
 
 ; <label>:259                                     ; preds = %256
   store i32 %257, i32* %258, align 8
@@ -1149,16 +1231,16 @@ entry:
   %262 = load i8*, i8** %arg1
   %263 = getelementptr inbounds i8, i8* %262, i64 12
   %264 = bitcast i8* %263 to i16*
-  %NullCheck32 = icmp ne i16* %264, null
-  br i1 %NullCheck32, label %265, label %ThrowNullRef31
+  %NullCheck31 = icmp eq i16* %264, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %265
 
 ; <label>:265                                     ; preds = %259
   %266 = load i16, i16* %264, align 8
   %267 = sext i16 %266 to i32
   %268 = bitcast i8* %261 to i16*
   %269 = trunc i32 %267 to i16
-  %NullCheck34 = icmp ne i16* %268, null
-  br i1 %NullCheck34, label %270, label %ThrowNullRef33
+  %NullCheck33 = icmp eq i16* %268, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %270
 
 ; <label>:270                                     ; preds = %265
   store i16 %269, i16* %268, align 8
@@ -1168,14 +1250,14 @@ entry:
   %272 = load i8*, i8** %arg0
   %273 = load i8*, i8** %arg1
   %274 = bitcast i8* %273 to i64*
-  %NullCheck8 = icmp ne i64* %274, null
-  br i1 %NullCheck8, label %275, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64* %274, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %275
 
 ; <label>:275                                     ; preds = %271
   %276 = load i64, i64* %274, align 8
   %277 = bitcast i8* %272 to i64*
-  %NullCheck10 = icmp ne i64* %277, null
-  br i1 %NullCheck10, label %278, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %277, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %278
 
 ; <label>:278                                     ; preds = %275
   store i64 %276, i64* %277, align 8
@@ -1184,14 +1266,14 @@ entry:
   %281 = load i8*, i8** %arg1
   %282 = getelementptr inbounds i8, i8* %281, i64 8
   %283 = bitcast i8* %282 to i32*
-  %NullCheck12 = icmp ne i32* %283, null
-  br i1 %NullCheck12, label %284, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i32* %283, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %284
 
 ; <label>:284                                     ; preds = %278
   %285 = load i32, i32* %283, align 8
   %286 = bitcast i8* %280 to i32*
-  %NullCheck14 = icmp ne i32* %286, null
-  br i1 %NullCheck14, label %287, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i32* %286, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %287
 
 ; <label>:287                                     ; preds = %284
   store i32 %285, i32* %286, align 8
@@ -1200,16 +1282,16 @@ entry:
   %290 = load i8*, i8** %arg1
   %291 = getelementptr inbounds i8, i8* %290, i64 12
   %292 = bitcast i8* %291 to i16*
-  %NullCheck16 = icmp ne i16* %292, null
-  br i1 %NullCheck16, label %293, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i16* %292, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %293
 
 ; <label>:293                                     ; preds = %287
   %294 = load i16, i16* %292, align 8
   %295 = sext i16 %294 to i32
   %296 = bitcast i8* %289 to i16*
   %297 = trunc i32 %295 to i16
-  %NullCheck18 = icmp ne i16* %296, null
-  br i1 %NullCheck18, label %298, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i16* %296, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %298
 
 ; <label>:298                                     ; preds = %293
   store i16 %297, i16* %296, align 8
@@ -1217,15 +1299,15 @@ entry:
   %300 = getelementptr inbounds i8, i8* %299, i64 14
   %301 = load i8*, i8** %arg1
   %302 = getelementptr inbounds i8, i8* %301, i64 14
-  %NullCheck20 = icmp ne i8* %302, null
-  br i1 %NullCheck20, label %303, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i8* %302, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %303
 
 ; <label>:303                                     ; preds = %298
   %304 = load i8, i8* %302, align 8
   %305 = zext i8 %304 to i32
   %306 = trunc i32 %305 to i8
-  %NullCheck22 = icmp ne i8* %300, null
-  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i8* %300, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %307
 
 ; <label>:307                                     ; preds = %303
   store i8 %306, i8* %300, align 8
@@ -1235,14 +1317,14 @@ entry:
   %309 = load i8*, i8** %arg0
   %310 = load i8*, i8** %arg1
   %311 = bitcast i8* %310 to i64*
-  %NullCheck = icmp ne i64* %311, null
-  br i1 %NullCheck, label %312, label %ThrowNullRef
+  %NullCheck = icmp eq i64* %311, null
+  br i1 %NullCheck, label %ThrowNullRef, label %312
 
 ; <label>:312                                     ; preds = %308
   %313 = load i64, i64* %311, align 8
   %314 = bitcast i8* %309 to i64*
-  %NullCheck2 = icmp ne i64* %314, null
-  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64* %314, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %315
 
 ; <label>:315                                     ; preds = %312
   store i64 %313, i64* %314, align 8
@@ -1251,14 +1333,14 @@ entry:
   %318 = load i8*, i8** %arg1
   %319 = getelementptr inbounds i8, i8* %318, i64 8
   %320 = bitcast i8* %319 to i64*
-  %NullCheck4 = icmp ne i64* %320, null
-  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64* %320, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %321
 
 ; <label>:321                                     ; preds = %315
   %322 = load i64, i64* %320, align 8
   %323 = bitcast i8* %317 to i64*
-  %NullCheck6 = icmp ne i64* %323, null
-  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64* %323, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %324
 
 ; <label>:324                                     ; preds = %321
   store i64 %322, i64* %323, align 8
@@ -1286,15 +1368,15 @@ entry:
 ; <label>:338                                     ; preds = %333
   %339 = load i8*, i8** %arg0
   %340 = load i8*, i8** %arg1
-  %NullCheck136 = icmp ne i8* %340, null
-  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+  %NullCheck135 = icmp eq i8* %340, null
+  br i1 %NullCheck135, label %ThrowNullRef136, label %341
 
 ; <label>:341                                     ; preds = %338
   %342 = load i8, i8* %340, align 8
   %343 = zext i8 %342 to i32
   %344 = trunc i32 %343 to i8
-  %NullCheck138 = icmp ne i8* %339, null
-  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+  %NullCheck137 = icmp eq i8* %339, null
+  br i1 %NullCheck137, label %ThrowNullRef138, label %345
 
 ; <label>:345                                     ; preds = %341
   store i8 %344, i8* %339, align 8
@@ -1317,16 +1399,16 @@ entry:
   %357 = load i8*, i8** %arg0
   %358 = load i8*, i8** %arg1
   %359 = bitcast i8* %358 to i16*
-  %NullCheck140 = icmp ne i16* %359, null
-  br i1 %NullCheck140, label %360, label %ThrowNullRef139
+  %NullCheck139 = icmp eq i16* %359, null
+  br i1 %NullCheck139, label %ThrowNullRef140, label %360
 
 ; <label>:360                                     ; preds = %356
   %361 = load i16, i16* %359, align 8
   %362 = sext i16 %361 to i32
   %363 = bitcast i8* %357 to i16*
   %364 = trunc i32 %362 to i16
-  %NullCheck142 = icmp ne i16* %363, null
-  br i1 %NullCheck142, label %365, label %ThrowNullRef141
+  %NullCheck141 = icmp eq i16* %363, null
+  br i1 %NullCheck141, label %ThrowNullRef142, label %365
 
 ; <label>:365                                     ; preds = %360
   store i16 %364, i16* %363, align 8
@@ -1352,14 +1434,14 @@ entry:
   %378 = load i8*, i8** %arg0
   %379 = load i8*, i8** %arg1
   %380 = bitcast i8* %379 to i32*
-  %NullCheck144 = icmp ne i32* %380, null
-  br i1 %NullCheck144, label %381, label %ThrowNullRef143
+  %NullCheck143 = icmp eq i32* %380, null
+  br i1 %NullCheck143, label %ThrowNullRef144, label %381
 
 ; <label>:381                                     ; preds = %377
   %382 = load i32, i32* %380, align 8
   %383 = bitcast i8* %378 to i32*
-  %NullCheck146 = icmp ne i32* %383, null
-  br i1 %NullCheck146, label %384, label %ThrowNullRef145
+  %NullCheck145 = icmp eq i32* %383, null
+  br i1 %NullCheck145, label %ThrowNullRef146, label %384
 
 ; <label>:384                                     ; preds = %381
   store i32 %382, i32* %383, align 8
@@ -1384,14 +1466,14 @@ entry:
   %395 = load i8*, i8** %arg0
   %396 = load i8*, i8** %arg1
   %397 = bitcast i8* %396 to i64*
-  %NullCheck164 = icmp ne i64* %397, null
-  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+  %NullCheck163 = icmp eq i64* %397, null
+  br i1 %NullCheck163, label %ThrowNullRef164, label %398
 
 ; <label>:398                                     ; preds = %394
   %399 = load i64, i64* %397, align 8
   %400 = bitcast i8* %395 to i64*
-  %NullCheck166 = icmp ne i64* %400, null
-  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+  %NullCheck165 = icmp eq i64* %400, null
+  br i1 %NullCheck165, label %ThrowNullRef166, label %401
 
 ; <label>:401                                     ; preds = %398
   store i64 %399, i64* %400, align 8
@@ -1400,14 +1482,14 @@ entry:
   %404 = load i8*, i8** %arg1
   %405 = getelementptr inbounds i8, i8* %404, i64 8
   %406 = bitcast i8* %405 to i64*
-  %NullCheck168 = icmp ne i64* %406, null
-  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+  %NullCheck167 = icmp eq i64* %406, null
+  br i1 %NullCheck167, label %ThrowNullRef168, label %407
 
 ; <label>:407                                     ; preds = %401
   %408 = load i64, i64* %406, align 8
   %409 = bitcast i8* %403 to i64*
-  %NullCheck170 = icmp ne i64* %409, null
-  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+  %NullCheck169 = icmp eq i64* %409, null
+  br i1 %NullCheck169, label %ThrowNullRef170, label %410
 
 ; <label>:410                                     ; preds = %407
   store i64 %408, i64* %409, align 8
@@ -1437,14 +1519,14 @@ entry:
   %425 = load i8*, i8** %arg0
   %426 = load i8*, i8** %arg1
   %427 = bitcast i8* %426 to i64*
-  %NullCheck148 = icmp ne i64* %427, null
-  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+  %NullCheck147 = icmp eq i64* %427, null
+  br i1 %NullCheck147, label %ThrowNullRef148, label %428
 
 ; <label>:428                                     ; preds = %424
   %429 = load i64, i64* %427, align 8
   %430 = bitcast i8* %425 to i64*
-  %NullCheck150 = icmp ne i64* %430, null
-  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+  %NullCheck149 = icmp eq i64* %430, null
+  br i1 %NullCheck149, label %ThrowNullRef150, label %431
 
 ; <label>:431                                     ; preds = %428
   store i64 %429, i64* %430, align 8
@@ -1466,14 +1548,14 @@ entry:
   %441 = load i8*, i8** %arg0
   %442 = load i8*, i8** %arg1
   %443 = bitcast i8* %442 to i32*
-  %NullCheck152 = icmp ne i32* %443, null
-  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+  %NullCheck151 = icmp eq i32* %443, null
+  br i1 %NullCheck151, label %ThrowNullRef152, label %444
 
 ; <label>:444                                     ; preds = %440
   %445 = load i32, i32* %443, align 8
   %446 = bitcast i8* %441 to i32*
-  %NullCheck154 = icmp ne i32* %446, null
-  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+  %NullCheck153 = icmp eq i32* %446, null
+  br i1 %NullCheck153, label %ThrowNullRef154, label %447
 
 ; <label>:447                                     ; preds = %444
   store i32 %445, i32* %446, align 8
@@ -1495,16 +1577,16 @@ entry:
   %457 = load i8*, i8** %arg0
   %458 = load i8*, i8** %arg1
   %459 = bitcast i8* %458 to i16*
-  %NullCheck156 = icmp ne i16* %459, null
-  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+  %NullCheck155 = icmp eq i16* %459, null
+  br i1 %NullCheck155, label %ThrowNullRef156, label %460
 
 ; <label>:460                                     ; preds = %456
   %461 = load i16, i16* %459, align 8
   %462 = sext i16 %461 to i32
   %463 = bitcast i8* %457 to i16*
   %464 = trunc i32 %462 to i16
-  %NullCheck158 = icmp ne i16* %463, null
-  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+  %NullCheck157 = icmp eq i16* %463, null
+  br i1 %NullCheck157, label %ThrowNullRef158, label %465
 
 ; <label>:465                                     ; preds = %460
   store i16 %464, i16* %463, align 8
@@ -1525,15 +1607,15 @@ entry:
 ; <label>:474                                     ; preds = %470
   %475 = load i8*, i8** %arg0
   %476 = load i8*, i8** %arg1
-  %NullCheck160 = icmp ne i8* %476, null
-  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+  %NullCheck159 = icmp eq i8* %476, null
+  br i1 %NullCheck159, label %ThrowNullRef160, label %477
 
 ; <label>:477                                     ; preds = %474
   %478 = load i8, i8* %476, align 8
   %479 = zext i8 %478 to i32
   %480 = trunc i32 %479 to i8
-  %NullCheck162 = icmp ne i8* %475, null
-  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+  %NullCheck161 = icmp eq i8* %475, null
+  br i1 %NullCheck161, label %ThrowNullRef162, label %481
 
 ; <label>:481                                     ; preds = %477
   store i8 %480, i8* %475, align 8
@@ -1553,343 +1635,343 @@ ThrowNullRef:                                     ; preds = %308
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %312
+ThrowNullRef2:                                    ; preds = %312
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %315
+ThrowNullRef4:                                    ; preds = %315
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %321
+ThrowNullRef6:                                    ; preds = %321
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %271
+ThrowNullRef8:                                    ; preds = %271
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %275
+ThrowNullRef10:                                   ; preds = %275
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %278
+ThrowNullRef12:                                   ; preds = %278
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %284
+ThrowNullRef14:                                   ; preds = %284
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %287
+ThrowNullRef16:                                   ; preds = %287
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %293
+ThrowNullRef18:                                   ; preds = %293
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %298
+ThrowNullRef20:                                   ; preds = %298
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %303
+ThrowNullRef22:                                   ; preds = %303
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %243
+ThrowNullRef24:                                   ; preds = %243
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %247
+ThrowNullRef26:                                   ; preds = %247
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %250
+ThrowNullRef28:                                   ; preds = %250
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %256
+ThrowNullRef30:                                   ; preds = %256
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %259
+ThrowNullRef32:                                   ; preds = %259
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %265
+ThrowNullRef34:                                   ; preds = %265
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %217
+ThrowNullRef36:                                   ; preds = %217
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %221
+ThrowNullRef38:                                   ; preds = %221
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %224
+ThrowNullRef40:                                   ; preds = %224
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %230
+ThrowNullRef42:                                   ; preds = %230
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %233
+ThrowNullRef44:                                   ; preds = %233
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %238
+ThrowNullRef46:                                   ; preds = %238
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %200
+ThrowNullRef48:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %204
+ThrowNullRef50:                                   ; preds = %204
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %207
+ThrowNullRef52:                                   ; preds = %207
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %213
+ThrowNullRef54:                                   ; preds = %213
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %172
+ThrowNullRef56:                                   ; preds = %172
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %176
+ThrowNullRef58:                                   ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %179
+ThrowNullRef60:                                   ; preds = %179
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %185
+ThrowNullRef62:                                   ; preds = %185
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %190
+ThrowNullRef64:                                   ; preds = %190
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %195
+ThrowNullRef66:                                   ; preds = %195
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %153
+ThrowNullRef68:                                   ; preds = %153
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %157
+ThrowNullRef70:                                   ; preds = %157
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %160
+ThrowNullRef72:                                   ; preds = %160
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %166
+ThrowNullRef74:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %136
+ThrowNullRef76:                                   ; preds = %136
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %140
+ThrowNullRef78:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %143
+ThrowNullRef80:                                   ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %148
+ThrowNullRef82:                                   ; preds = %148
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %128
+ThrowNullRef84:                                   ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %132
+ThrowNullRef86:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %100
+ThrowNullRef88:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %104
+ThrowNullRef90:                                   ; preds = %104
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %107
+ThrowNullRef92:                                   ; preds = %107
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %113
+ThrowNullRef94:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %118
+ThrowNullRef96:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %123
+ThrowNullRef98:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %81
+ThrowNullRef100:                                  ; preds = %81
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef101:                                  ; preds = %85
+ThrowNullRef102:                                  ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef103:                                  ; preds = %88
+ThrowNullRef104:                                  ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef105:                                  ; preds = %94
+ThrowNullRef106:                                  ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef107:                                  ; preds = %64
+ThrowNullRef108:                                  ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef109:                                  ; preds = %68
+ThrowNullRef110:                                  ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef111:                                  ; preds = %71
+ThrowNullRef112:                                  ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef113:                                  ; preds = %76
+ThrowNullRef114:                                  ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef115:                                  ; preds = %56
+ThrowNullRef116:                                  ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef117:                                  ; preds = %60
+ThrowNullRef118:                                  ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef119:                                  ; preds = %37
+ThrowNullRef120:                                  ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef121:                                  ; preds = %41
+ThrowNullRef122:                                  ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef123:                                  ; preds = %46
+ThrowNullRef124:                                  ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef125:                                  ; preds = %51
+ThrowNullRef126:                                  ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef127:                                  ; preds = %27
+ThrowNullRef128:                                  ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef129:                                  ; preds = %31
+ThrowNullRef130:                                  ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef131:                                  ; preds = %19
+ThrowNullRef132:                                  ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef133:                                  ; preds = %22
+ThrowNullRef134:                                  ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef135:                                  ; preds = %338
+ThrowNullRef136:                                  ; preds = %338
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef137:                                  ; preds = %341
+ThrowNullRef138:                                  ; preds = %341
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef139:                                  ; preds = %356
+ThrowNullRef140:                                  ; preds = %356
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef141:                                  ; preds = %360
+ThrowNullRef142:                                  ; preds = %360
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef143:                                  ; preds = %377
+ThrowNullRef144:                                  ; preds = %377
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef145:                                  ; preds = %381
+ThrowNullRef146:                                  ; preds = %381
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef147:                                  ; preds = %424
+ThrowNullRef148:                                  ; preds = %424
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef149:                                  ; preds = %428
+ThrowNullRef150:                                  ; preds = %428
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef151:                                  ; preds = %440
+ThrowNullRef152:                                  ; preds = %440
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef153:                                  ; preds = %444
+ThrowNullRef154:                                  ; preds = %444
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef155:                                  ; preds = %456
+ThrowNullRef156:                                  ; preds = %456
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef157:                                  ; preds = %460
+ThrowNullRef158:                                  ; preds = %460
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef159:                                  ; preds = %474
+ThrowNullRef160:                                  ; preds = %474
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef161:                                  ; preds = %477
+ThrowNullRef162:                                  ; preds = %477
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef163:                                  ; preds = %394
+ThrowNullRef164:                                  ; preds = %394
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef165:                                  ; preds = %398
+ThrowNullRef166:                                  ; preds = %398
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef167:                                  ; preds = %401
+ThrowNullRef168:                                  ; preds = %401
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef169:                                  ; preds = %407
+ThrowNullRef170:                                  ; preds = %407
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1939,8 +2021,8 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
-  br i1 %NullCheck, label %22, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %ThrowNullRef, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
@@ -1948,8 +2030,8 @@ entry:
   store i32 %24, i32* %loc0
   %25 = load i32, i32* %loc0
   %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %26, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %27
 
 ; <label>:27                                      ; preds = %22
   %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
@@ -1971,7 +2053,7 @@ ThrowNullRef:                                     ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1989,8 +2071,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -2022,15 +2104,15 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2048,16 +2130,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
   %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
   store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %15
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
@@ -2072,8 +2154,8 @@ entry:
   %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
   %29 = ptrtoint i16 addrspace(1)* %28 to i64
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %19
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
@@ -2089,19 +2171,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2114,8 +2196,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
@@ -2128,7 +2210,7 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[loadElem]
+Failed to read AppDomain.PrepareDataForSetup[storeElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
@@ -2202,8 +2284,8 @@ entry:
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
-  br i1 %NullCheck24, label %27, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = load i64, i64 addrspace(1)* %26
@@ -2218,8 +2300,8 @@ entry:
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
-  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
   %41 = load i64, i64 addrspace(1)* %39
@@ -2236,8 +2318,8 @@ entry:
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
-  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
   %54 = load i64, i64 addrspace(1)* %52
@@ -2252,8 +2334,8 @@ entry:
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
   %67 = load i64, i64 addrspace(1)* %65
@@ -2270,8 +2352,8 @@ entry:
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
-  br i1 %NullCheck16, label %79, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
   %80 = load i64, i64 addrspace(1)* %78
@@ -2286,8 +2368,8 @@ entry:
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
-  br i1 %NullCheck18, label %92, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
   %93 = load i64, i64 addrspace(1)* %91
@@ -2304,8 +2386,8 @@ entry:
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
-  br i1 %NullCheck12, label %105, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = load i64, i64 addrspace(1)* %104
@@ -2320,8 +2402,8 @@ entry:
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
-  br i1 %NullCheck14, label %118, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
   %119 = load i64, i64 addrspace(1)* %117
@@ -2337,8 +2419,8 @@ entry:
 
 ; <label>:128                                     ; preds = %20
   %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
-  br i1 %NullCheck4, label %130, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %129, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %130
 
 ; <label>:130                                     ; preds = %128
   %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
@@ -2346,8 +2428,8 @@ entry:
   %133 = load i16, i16 addrspace(1)* %132, align 8
   %134 = zext i16 %133 to i32
   %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
-  br i1 %NullCheck6, label %136, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %135, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %136
 
 ; <label>:136                                     ; preds = %130
   %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
@@ -2360,8 +2442,8 @@ entry:
 
 ; <label>:143                                     ; preds = %136
   %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
-  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %144, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %145
 
 ; <label>:145                                     ; preds = %143
   %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
@@ -2369,8 +2451,8 @@ entry:
   %148 = load i16, i16 addrspace(1)* %147, align 8
   %149 = zext i16 %148 to i32
   %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %150, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %151
 
 ; <label>:151                                     ; preds = %145
   %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
@@ -2388,8 +2470,8 @@ entry:
 
 ; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
-  br i1 %NullCheck, label %163, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %ThrowNullRef, label %163
 
 ; <label>:163                                     ; preds = %161
   %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
@@ -2399,8 +2481,8 @@ entry:
 
 ; <label>:167                                     ; preds = %163
   %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
-  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %168, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %169
 
 ; <label>:169                                     ; preds = %167
   %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
@@ -2432,55 +2514,55 @@ ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %167
+ThrowNullRef2:                                    ; preds = %167
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %128
+ThrowNullRef4:                                    ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %130
+ThrowNullRef6:                                    ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %143
+ThrowNullRef8:                                    ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %145
+ThrowNullRef10:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %102
+ThrowNullRef12:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %105
+ThrowNullRef14:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %76
+ThrowNullRef16:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %79
+ThrowNullRef18:                                   ; preds = %79
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %50
+ThrowNullRef20:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %53
+ThrowNullRef22:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %24
+ThrowNullRef24:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %27
+ThrowNullRef26:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2503,15 +2585,15 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2519,16 +2601,16 @@ entry:
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
   store i32 %8, i32* %loc0
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
   %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
   store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
@@ -2546,16 +2628,16 @@ entry:
 
 ; <label>:23                                      ; preds = %64
   %24 = load i16*, i16** %loc3
-  %NullCheck12 = icmp ne i16* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i16* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
   store i32 %27, i32* %loc5
   %28 = load i16*, i16** %loc4
-  %NullCheck14 = icmp ne i16* %28, null
-  br i1 %NullCheck14, label %29, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %28, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = load i16, i16* %28, align 8
@@ -2620,15 +2702,15 @@ entry:
 
 ; <label>:67                                      ; preds = %64
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
-  br i1 %NullCheck8, label %69, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %68, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %69
 
 ; <label>:69                                      ; preds = %67
   %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
   %71 = load i32, i32 addrspace(1)* %70
   %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
-  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %73
 
 ; <label>:73                                      ; preds = %69
   %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
@@ -2645,31 +2727,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %67
+ThrowNullRef8:                                    ; preds = %67
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %69
+ThrowNullRef10:                                   ; preds = %69
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2710,14 +2792,14 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
   %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
@@ -2730,14 +2812,14 @@ entry:
 
 ; <label>:11                                      ; preds = %4
   %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
   %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
@@ -2749,14 +2831,14 @@ entry:
 
 ; <label>:22                                      ; preds = %16
   %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
   %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
-  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
-  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
@@ -2804,23 +2886,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2836,7 +2918,280 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[loadElem]
+Successfully read RuntimeType.IsAssignableFrom
+
+define i8 @RuntimeType.IsAssignableFrom(%System.RuntimeType addrspace(1)* %param0, %System.Type addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.RuntimeType addrspace(1)*
+  %arg1 = alloca %System.Type addrspace(1)*
+  %loc0 = alloca %System.RuntimeType addrspace(1)*
+  %loc1 = alloca %"System.Type[]" addrspace(1)*
+  %loc2 = alloca i32
+  store %System.RuntimeType addrspace(1)* %param0, %System.RuntimeType addrspace(1)** %this
+  store %System.Type addrspace(1)* %param1, %System.Type addrspace(1)** %arg1
+  %0 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %1 = icmp ne %System.Type addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i8 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %5 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %6 = bitcast %System.Type addrspace(1)* %4 to %System.Object addrspace(1)*
+  %7 = bitcast %System.RuntimeType addrspace(1)* %5 to %System.Object addrspace(1)*
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %6, %System.Object addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %3
+  ret i8 1
+
+; <label>:12                                      ; preds = %3
+  %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 152
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 32
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
+  %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
+  %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
+  store %System.RuntimeType addrspace(1)* %25, %System.RuntimeType addrspace(1)** %loc0
+  %26 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %27 = icmp eq %System.RuntimeType addrspace(1)* %26, null
+  br i1 %27, label %34, label %28
+
+; <label>:28                                      ; preds = %15
+  %29 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %30 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)*)*)(%System.RuntimeType addrspace(1)* %29, %System.RuntimeType addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+; <label>:34                                      ; preds = %15
+  %35 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %36 = call %System.Reflection.Emit.TypeBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Reflection.Emit.TypeBuilder addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %35)
+  %37 = icmp eq %System.Reflection.Emit.TypeBuilder addrspace(1)* %36, null
+  br i1 %37, label %139, label %38
+
+; <label>:38                                      ; preds = %34
+  %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %42
+
+; <label>:42                                      ; preds = %38
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 152
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 40
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
+  %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
+  %53 = zext i8 %52 to i32
+  %54 = icmp eq i32 %53, 0
+  br i1 %54, label %56, label %55
+
+; <label>:55                                      ; preds = %42
+  ret i8 1
+
+; <label>:56                                      ; preds = %42
+  %57 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %58 = bitcast %System.RuntimeType addrspace(1)* %57 to %System.Type addrspace(1)*
+  %59 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %58)
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %64 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.Type addrspace(1)* %63, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = bitcast %System.RuntimeType addrspace(1)* %64 to %System.Type addrspace(1)*
+  %67 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %63, %System.Type addrspace(1)* %66)
+  %68 = zext i8 %67 to i32
+  %69 = trunc i32 %68 to i8
+  ret i8 %69
+
+; <label>:70                                      ; preds = %56
+  %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
+  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %73
+
+; <label>:73                                      ; preds = %70
+  %74 = load i64, i64 addrspace(1)* %72
+  %75 = add i64 %74, 128
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = add i64 %77, 0
+  %79 = inttoptr i64 %78 to i64*
+  %80 = load i64, i64* %79
+  %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
+  %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
+  %83 = call i8 %82(%System.Type addrspace(1)* %81)
+  %84 = zext i8 %83 to i32
+  %85 = icmp eq i32 %84, 0
+  br i1 %85, label %139, label %86
+
+; <label>:86                                      ; preds = %73
+  %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
+  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %89
+
+; <label>:89                                      ; preds = %86
+  %90 = load i64, i64 addrspace(1)* %88
+  %91 = add i64 %90, 128
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = add i64 %93, 24
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
+  %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
+  %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
+  store %"System.Type[]" addrspace(1)* %99, %"System.Type[]" addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %129
+
+; <label>:100                                     ; preds = %132
+  %101 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %102 = load i32, i32* %loc2
+  %NullCheck11 = icmp eq %"System.Type[]" addrspace(1)* %101, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %103
+
+; <label>:103                                     ; preds = %100
+  %104 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 1
+  %105 = load i32, i32 addrspace(1)* %104
+  %106 = zext i32 %105 to i64
+  %107 = zext i32 %102 to i64
+  %BoundsCheck = icmp uge i64 %107, %106
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %108
+
+; <label>:108                                     ; preds = %103
+  %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
+  %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
+  %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
+  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %113
+
+; <label>:113                                     ; preds = %108
+  %114 = load i64, i64 addrspace(1)* %112
+  %115 = add i64 %114, 152
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = add i64 %117, 56
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
+  %123 = zext i8 %122 to i32
+  %124 = icmp ne i32 %123, 0
+  br i1 %124, label %126, label %125
+
+; <label>:125                                     ; preds = %113
+  ret i8 0
+
+; <label>:126                                     ; preds = %113
+  %127 = load i32, i32* %loc2
+  %128 = add i32 %127, 1
+  store i32 %128, i32* %loc2
+  br label %129
+
+; <label>:129                                     ; preds = %89, %126
+  %130 = load i32, i32* %loc2
+  %131 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %NullCheck9 = icmp eq %"System.Type[]" addrspace(1)* %131, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %132
+
+; <label>:132                                     ; preds = %129
+  %133 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %131, i32 0, i32 1
+  %134 = load i32, i32 addrspace(1)* %133
+  %135 = zext i32 %134 to i64
+  %136 = trunc i64 %135 to i32
+  %137 = icmp slt i32 %130, %136
+  br i1 %137, label %100, label %138
+
+; <label>:138                                     ; preds = %132
+  ret i8 1
+
+; <label>:139                                     ; preds = %34, %73
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %129
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %103
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -2893,7 +3248,7 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElem]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -2904,8 +3259,8 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -2997,8 +3352,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
@@ -3059,8 +3414,8 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -3087,8 +3442,8 @@ entry:
 
 ; <label>:17                                      ; preds = %5, %11
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
@@ -3097,8 +3452,8 @@ entry:
 
 ; <label>:22                                      ; preds = %1, %11
   %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
@@ -3109,11 +3464,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %17
+ThrowNullRef2:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %22
+ThrowNullRef4:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3167,15 +3522,15 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
   %15 = load i32, i32 addrspace(1)* %14
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
@@ -3198,7 +3553,7 @@ ThrowNullRef:                                     ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef2:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3232,8 +3587,8 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
@@ -3312,8 +3667,8 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -3327,8 +3682,8 @@ entry:
 ; <label>:5                                       ; preds = %43
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %7 = load i32, i32* %loc1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck6, label %8, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
@@ -3366,8 +3721,8 @@ entry:
 ; <label>:32                                      ; preds = %21, %25
   %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
   %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
-  br i1 %NullCheck8, label %35, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = trunc i32 %34 to i16
@@ -3380,8 +3735,8 @@ entry:
 ; <label>:40                                      ; preds = %1, %35
   %41 = load i32, i32* %loc1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
-  br i1 %NullCheck2, label %43, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %42, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
@@ -3392,8 +3747,8 @@ entry:
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
   %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
-  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
   %51 = load i64, i64 addrspace(1)* %49
@@ -3412,19 +3767,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %40
+ThrowNullRef2:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %47
+ThrowNullRef4:                                    ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %5
+ThrowNullRef6:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %32
+ThrowNullRef8:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3467,8 +3822,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
@@ -3492,11 +3847,391 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(i16* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store i16* %param0, i16** %arg0
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load i32, i32* %arg3
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %42, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %37, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg2
+  %13 = load i32, i32* %arg3
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %37, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %24 = load i32, i32* %arg2
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load i16*, i16** %arg0
+  %35 = load i32, i32* %arg3
+  %36 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %36, i16* %34, i32 %35)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:37                                      ; preds = %5, %16
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %39)
+  %41 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41, %System.String addrspace(1)* %38, %System.String addrspace(1)* %40)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41) #0
+  unreachable
+
+; <label>:42                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
-Failed to read StringBuilder.ToString[loadElemA]
+Successfully read StringBuilder.ToString
+
+define %System.String addrspace(1)* @StringBuilder.ToString(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i16*
+  %loc3 = alloca %"System.Char[]" addrspace(1)*
+  %loc4 = alloca i32
+  %loc5 = alloca i32
+  %loc6 = alloca i16 addrspace(1)*
+  %loc7 = alloca %System.String addrspace(1)*
+  %loc8 = alloca %"System.Char[]" addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %0)
+  %2 = icmp ne i32 %1, 0
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %4
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %6)
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %7)
+  store %System.String addrspace(1)* %8, %System.String addrspace(1)** %loc0
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.Text.StringBuilder addrspace(1)* %9, %System.Text.StringBuilder addrspace(1)** %loc1
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  store %System.String addrspace(1)* %10, %System.String addrspace(1)** %loc7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc7
+  %12 = ptrtoint %System.String addrspace(1)* %11 to i64
+  %13 = icmp eq i64 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %5
+  %15 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %16 = sext i32 %15 to i64
+  %17 = add i64 %12, %16
+  br label %18
+
+; <label>:18                                      ; preds = %5, %14
+  %19 = phi i64 [ %12, %5 ], [ %17, %14 ]
+  %20 = inttoptr i64 %19 to i16*
+  store i16* %20, i16** %loc2
+  br label %21
+
+; <label>:21                                      ; preds = %98, %18
+  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %22, null
+  br i1 %NullCheck, label %ThrowNullRef, label %23
+
+; <label>:23                                      ; preds = %21
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 3
+  %25 = load i32, i32 addrspace(1)* %24, align 8
+  %26 = icmp sle i32 %25, 0
+  br i1 %26, label %96, label %27
+
+; <label>:27                                      ; preds = %23
+  %28 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %28, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %29
+
+; <label>:29                                      ; preds = %27
+  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %28, i32 0, i32 1
+  %31 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %30, align 8
+  store %"System.Char[]" addrspace(1)* %31, %"System.Char[]" addrspace(1)** %loc3
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %33
+
+; <label>:33                                      ; preds = %29
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  store i32 %35, i32* %loc4
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  %39 = load i32, i32 addrspace(1)* %38, align 8
+  store i32 %39, i32* %loc5
+  %40 = load i32, i32* %loc5
+  %41 = load i32, i32* %loc4
+  %42 = add i32 %40, %41
+  %43 = zext i32 %42 to i64
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %45
+
+; <label>:45                                      ; preds = %37
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = sext i32 %47 to i64
+  %49 = icmp sgt i64 %43, %48
+  br i1 %49, label %91, label %50
+
+; <label>:50                                      ; preds = %45
+  %51 = load i32, i32* %loc5
+  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %52, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %53
+
+; <label>:53                                      ; preds = %50
+  %54 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %52, i32 0, i32 1
+  %55 = load i32, i32 addrspace(1)* %54
+  %56 = zext i32 %55 to i64
+  %57 = trunc i64 %56 to i32
+  %58 = icmp ugt i32 %51, %57
+  br i1 %58, label %91, label %59
+
+; <label>:59                                      ; preds = %53
+  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  store %"System.Char[]" addrspace(1)* %60, %"System.Char[]" addrspace(1)** %loc8
+  %61 = icmp eq %"System.Char[]" addrspace(1)* %60, null
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %63, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %64
+
+; <label>:64                                      ; preds = %62
+  %65 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %63, i32 0, i32 1
+  %66 = load i32, i32 addrspace(1)* %65
+  %67 = zext i32 %66 to i64
+  %68 = trunc i64 %67 to i32
+  %69 = icmp ne i32 %68, 0
+  br i1 %69, label %71, label %70
+
+; <label>:70                                      ; preds = %59, %64
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:71                                      ; preds = %64
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %73
+
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %BoundsCheck = icmp uge i64 0, %76
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %77
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %78, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:79                                      ; preds = %70, %77
+  %80 = load i16*, i16** %loc2
+  %81 = load i32, i32* %loc4
+  %82 = sext i32 %81 to i64
+  %83 = mul i64 %82, 2
+  %84 = bitcast i16* %80 to i8*
+  %85 = getelementptr inbounds i8, i8* %84, i64 %83
+  %86 = load i16 addrspace(1)*, i16 addrspace(1)** %loc6
+  %87 = ptrtoint i16 addrspace(1)* %86 to i64
+  %88 = load i32, i32* %loc5
+  %89 = bitcast i8* %85 to i16*
+  %90 = inttoptr i64 %87 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %89, i16* %90, i32 %88)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %96
+
+; <label>:91                                      ; preds = %45, %53
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %94 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %93)
+  %95 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95, %System.String addrspace(1)* %92, %System.String addrspace(1)* %94)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95) #0
+  unreachable
+
+; <label>:96                                      ; preds = %23, %79
+  %97 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %97, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %98
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %97, i32 0, i32 2
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  store %System.Text.StringBuilder addrspace(1)* %100, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %102 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %102, label %21, label %103
+
+; <label>:103                                     ; preds = %98
+  store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc7
+  %104 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  ret %System.String addrspace(1)* %104
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method StringBuilder::get_Length using LLILCJit
+Successfully read StringBuilder.get_Length
+
+define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
+Successfully read RuntimeHelpers.get_OffsetToStringData
+
+define i32 @RuntimeHelpers.get_OffsetToStringData() {
+entry:
+  ret i32 12
+}
+
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
 Successfully read CultureData.CreateCultureData
 
@@ -3514,23 +4249,23 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
   store i8 %4, i8 addrspace(1)* %6
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
@@ -3549,11 +4284,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3566,50 +4301,50 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
   store i32 -1, i32 addrspace(1)* %2
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
   store i32 -1, i32 addrspace(1)* %8
   %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
   store i32 -1, i32 addrspace(1)* %14
   %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
   store i32 -1, i32 addrspace(1)* %17
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
@@ -3623,27 +4358,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3675,7 +4410,136 @@ Failed to read Dictionary`2.Insert[non-const derefAddress]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
 Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
-Failed to read HashHelpers.GetPrime[loadElem]
+Successfully read HashHelpers.GetPrime
+
+define i32 @HashHelpers.GetPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %6, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5, %System.String addrspace(1)* %4)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5) #0
+  unreachable
+
+; <label>:6                                       ; preds = %entry
+  store i32 0, i32* %loc0
+  br label %29
+
+; <label>:7                                       ; preds = %35
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 1296
+  %10 = addrspacecast i8 addrspace(1)* %9 to %"System.Int32[]" addrspace(1)**
+  %11 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %10
+  %12 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Int32[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = zext i32 %15 to i64
+  %17 = zext i32 %12 to i64
+  %BoundsCheck = icmp uge i64 %17, %16
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 3, i32 %12
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  store i32 %20, i32* %loc1
+  %21 = load i32, i32* %loc1
+  %22 = load i32, i32* %arg0
+  %23 = icmp slt i32 %21, %22
+  br i1 %23, label %26, label %24
+
+; <label>:24                                      ; preds = %18
+  %25 = load i32, i32* %loc1
+  ret i32 %25
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %loc0
+  %28 = add i32 %27, 1
+  store i32 %28, i32* %loc0
+  br label %29
+
+; <label>:29                                      ; preds = %6, %26
+  %30 = load i32, i32* %loc0
+  %31 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %32 = getelementptr inbounds i8, i8 addrspace(1)* %31, i64 1296
+  %33 = addrspacecast i8 addrspace(1)* %32 to %"System.Int32[]" addrspace(1)**
+  %34 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %33
+  %NullCheck = icmp eq %"System.Int32[]" addrspace(1)* %34, null
+  br i1 %NullCheck, label %ThrowNullRef, label %35
+
+; <label>:35                                      ; preds = %29
+  %36 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %34, i32 0, i32 1
+  %37 = load i32, i32 addrspace(1)* %36
+  %38 = zext i32 %37 to i64
+  %39 = trunc i64 %38 to i32
+  %40 = icmp slt i32 %30, %39
+  br i1 %40, label %7, label %41
+
+; <label>:41                                      ; preds = %35
+  %42 = load i32, i32* %arg0
+  %43 = or i32 %42, 1
+  store i32 %43, i32* %loc2
+  br label %59
+
+; <label>:44                                      ; preds = %59
+  %45 = load i32, i32* %loc2
+  %46 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %45)
+  %47 = zext i8 %46 to i32
+  %48 = icmp eq i32 %47, 0
+  br i1 %48, label %56, label %49
+
+; <label>:49                                      ; preds = %44
+  %50 = load i32, i32* %loc2
+  %51 = sub i32 %50, 1
+  %52 = srem i32 %51, 101
+  %53 = icmp eq i32 %52, 0
+  br i1 %53, label %56, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = load i32, i32* %loc2
+  ret i32 %55
+
+; <label>:56                                      ; preds = %44, %49
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %57, 2
+  store i32 %58, i32* %loc2
+  br label %59
+
+; <label>:59                                      ; preds = %41, %56
+  %60 = load i32, i32* %loc2
+  %61 = icmp slt i32 %60, 2147483647
+  br i1 %61, label %44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load i32, i32* %arg0
+  ret i32 %63
+
+ThrowNullRef:                                     ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
 Successfully read GenericEqualityComparer`1.GetHashCode
 
@@ -3694,14 +4558,14 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
   %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load i64, i64 addrspace(1)* %7
@@ -3720,7 +4584,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3750,8 +4614,8 @@ entry:
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
@@ -3796,8 +4660,8 @@ entry:
   %35 = bitcast i16* %34 to i8*
   %36 = getelementptr inbounds i8, i8* %35, i64 2
   %37 = bitcast i8* %36 to i16*
-  %NullCheck4 = icmp ne i16* %37, null
-  br i1 %NullCheck4, label %38, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %37, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %38
 
 ; <label>:38                                      ; preds = %27
   %39 = load i16, i16* %37, align 8
@@ -3824,8 +4688,8 @@ entry:
 
 ; <label>:54                                      ; preds = %22, %43
   %55 = load i16*, i16** %loc4
-  %NullCheck2 = icmp ne i16* %55, null
-  br i1 %NullCheck2, label %56, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i16* %55, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %56
 
 ; <label>:56                                      ; preds = %54
   %57 = load i16, i16* %55, align 8
@@ -3850,11 +4714,11 @@ ThrowNullRef:                                     ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %54
+ThrowNullRef2:                                    ; preds = %54
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %27
+ThrowNullRef4:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3871,8 +4735,8 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -3907,8 +4771,8 @@ entry:
 
 ; <label>:26                                      ; preds = %19
   %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
-  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %28
 
 ; <label>:28                                      ; preds = %26
   %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
@@ -3920,7 +4784,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3972,8 +4836,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
@@ -3984,26 +4848,26 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
-  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
@@ -4014,8 +4878,8 @@ entry:
 ; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
@@ -4024,8 +4888,8 @@ entry:
 
 ; <label>:25                                      ; preds = %1, %16, %23
   %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
-  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
@@ -4036,27 +4900,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %20
+ThrowNullRef10:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4069,8 +4933,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -4081,8 +4945,8 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
@@ -4091,8 +4955,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1, %8
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
@@ -4103,11 +4967,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4128,24 +4992,24 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   store i32 %3, i32* %loc0
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
   %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
   store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck4, label %9, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
@@ -4164,15 +5028,15 @@ entry:
 ; <label>:18                                      ; preds = %70
   %19 = load i16*, i16** %loc3
   %20 = bitcast i16* %19 to i64*
-  %NullCheck10 = icmp ne i64* %20, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %20, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = load i64, i64* %20, align 8
   %23 = load i16*, i16** %loc4
   %24 = bitcast i16* %23 to i64*
-  %NullCheck12 = icmp ne i64* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = load i64, i64* %24, align 8
@@ -4188,8 +5052,8 @@ entry:
   %31 = bitcast i16* %30 to i8*
   %32 = getelementptr inbounds i8, i8* %31, i64 8
   %33 = bitcast i8* %32 to i64*
-  %NullCheck14 = icmp ne i64* %33, null
-  br i1 %NullCheck14, label %34, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = load i64, i64* %33, align 8
@@ -4197,8 +5061,8 @@ entry:
   %37 = bitcast i16* %36 to i8*
   %38 = getelementptr inbounds i8, i8* %37, i64 8
   %39 = bitcast i8* %38 to i64*
-  %NullCheck16 = icmp ne i64* %39, null
-  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %40
 
 ; <label>:40                                      ; preds = %34
   %41 = load i64, i64* %39, align 8
@@ -4214,8 +5078,8 @@ entry:
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %NullCheck18 = icmp ne i64* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = load i64, i64* %48, align 8
@@ -4223,8 +5087,8 @@ entry:
   %52 = bitcast i16* %51 to i8*
   %53 = getelementptr inbounds i8, i8* %52, i64 16
   %54 = bitcast i8* %53 to i64*
-  %NullCheck20 = icmp ne i64* %54, null
-  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64* %54, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %55
 
 ; <label>:55                                      ; preds = %49
   %56 = load i64, i64* %54, align 8
@@ -4262,15 +5126,15 @@ entry:
 ; <label>:74                                      ; preds = %95
   %75 = load i16*, i16** %loc3
   %76 = bitcast i16* %75 to i32*
-  %NullCheck6 = icmp ne i32* %76, null
-  br i1 %NullCheck6, label %77, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32* %76, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %77
 
 ; <label>:77                                      ; preds = %74
   %78 = load i32, i32* %76, align 8
   %79 = load i16*, i16** %loc4
   %80 = bitcast i16* %79 to i32*
-  %NullCheck8 = icmp ne i32* %80, null
-  br i1 %NullCheck8, label %81, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i32* %80, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %81
 
 ; <label>:81                                      ; preds = %77
   %82 = load i32, i32* %80, align 8
@@ -4318,43 +5182,43 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %74
+ThrowNullRef6:                                    ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %77
+ThrowNullRef8:                                    ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %29
+ThrowNullRef14:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %34
+ThrowNullRef16:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4376,8 +5240,8 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load i64, i64 addrspace(1)* %4
@@ -4389,8 +5253,8 @@ entry:
   %12 = load i64, i64* %11
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %5
   %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
@@ -4399,8 +5263,8 @@ entry:
   %18 = load i8, i8* %arg2
   %19 = zext i8 %18 to i32
   %20 = trunc i32 %19 to i8
-  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %15
   %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
@@ -4411,11 +5275,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4442,8 +5306,8 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
@@ -4466,16 +5330,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
   %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = load i64, i64 addrspace(1)* %19
@@ -4500,8 +5364,8 @@ entry:
 ; <label>:35                                      ; preds = %30
   %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
@@ -4514,8 +5378,8 @@ entry:
 
 ; <label>:42                                      ; preds = %1, %38
   %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
-  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
@@ -4526,19 +5390,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %35
+ThrowNullRef2:                                    ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %42
+ThrowNullRef8:                                    ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4551,14 +5415,14 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
@@ -4570,7 +5434,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4583,8 +5447,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
@@ -4613,51 +5477,51 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
   %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
   %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
   %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
   %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
-  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
   store i64 %21, i64 addrspace(1)* %23
   %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %25 = load i64, i64* %loc0
-  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
@@ -4668,27 +5532,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %22
+ThrowNullRef12:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4701,8 +5565,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
@@ -4713,19 +5577,19 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
@@ -4734,8 +5598,8 @@ entry:
 
 ; <label>:15                                      ; preds = %1, %13
   %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
@@ -4746,19 +5610,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %15
+ThrowNullRef8:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4771,8 +5635,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -4831,8 +5695,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
@@ -4882,8 +5746,8 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
-  br i1 %NullCheck, label %17, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %ThrowNullRef, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
@@ -4894,15 +5758,15 @@ entry:
 
 ; <label>:22                                      ; preds = %17
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
-  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
   %26 = load i32, i32 addrspace(1)* %25
   %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
-  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %27, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
@@ -4925,8 +5789,8 @@ entry:
 ; <label>:40                                      ; preds = %17
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
-  br i1 %NullCheck6, label %43, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %41, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
@@ -4938,34 +5802,17 @@ ThrowNullRef:                                     ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %24
+ThrowNullRef4:                                    ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %40
+ThrowNullRef6:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
-}
-
-INFO:  jitting method Object::ReferenceEquals using LLILCJit
-Successfully read Object.ReferenceEquals
-
-define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
-entry:
-  %arg0 = alloca %System.Object addrspace(1)*
-  %arg1 = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
-  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
-  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = icmp eq %System.Object addrspace(1)* %0, %1
-  %3 = sext i1 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
 }
 
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
@@ -4978,21 +5825,21 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
   %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
-  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
@@ -5007,28 +5854,28 @@ entry:
 ; <label>:13                                      ; preds = %8, %12
   %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
   %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
   %21 = load i32, i32 addrspace(1)* %20, align 8
   %22 = add i32 %21, 1
-  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
   store i32 %22, i32 addrspace(1)* %24
   %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
@@ -5039,27 +5886,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5077,7 +5924,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::Setup using LLILCJit
-Failed to read AppDomain.Setup[loadElem]
+Failed to read AppDomain.Setup[unbox]
 INFO:  jitting method Thread::GetDomain using LLILCJit
 Successfully read Thread.GetDomain
 
@@ -5108,8 +5955,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
@@ -5122,14 +5969,14 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
   %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
@@ -5141,11 +5988,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5173,8 +6020,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -5189,7 +6036,328 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
 Failed to read KeyCollection.System.Collections.Generic.IEnumerable<TKey>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Successfully read Enumerator.MoveNext
+
+define i8 @Enumerator.MoveNext(%"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.RuntimeTypeHandle* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*
+  %"$TypeArg" = alloca %System.RuntimeTypeHandle*
+  store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
+  %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 8
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %76, label %12
+
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
+  br label %76
+
+; <label>:13                                      ; preds = %85
+  %14 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck19 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %15
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, i32 0, i32 0
+  %17 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %16, align 8
+  %NullCheck21 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, i32 0, i32 2
+  %20 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %19, align 8
+  %21 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck23 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %22
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, i32 0, i32 2
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %NullCheck25 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 3, i32 %24
+  %NullCheck27 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %32
+
+; <label>:32                                      ; preds = %30
+  %33 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, i32 0, i32 2
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = icmp slt i32 %34, 0
+  br i1 %35, label %68, label %36
+
+; <label>:36                                      ; preds = %32
+  %37 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %38 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck29 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %39
+
+; <label>:39                                      ; preds = %36
+  %40 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, i32 0, i32 0
+  %41 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %40, align 8
+  %NullCheck31 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, i32 0, i32 2
+  %44 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %43, align 8
+  %45 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck33 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, i32 0, i32 2
+  %48 = load i32, i32 addrspace(1)* %47, align 8
+  %NullCheck35 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %49
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = zext i32 %51 to i64
+  %53 = zext i32 %48 to i64
+  %BoundsCheck37 = icmp uge i64 %53, %52
+  br i1 %BoundsCheck37, label %ThrowIndexOutOfRange38, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 3, i32 %48
+  %NullCheck39 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %56
+
+; <label>:56                                      ; preds = %54
+  %57 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, i32 0, i32 0
+  %58 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck41 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %59
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %60, %System.__Canon addrspace(1)* %58)
+  %61 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck43 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  %64 = load i32, i32 addrspace(1)* %63, align 8
+  %65 = add i32 %64, 1
+  %NullCheck45 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  store i32 %65, i32 addrspace(1)* %67
+  ret i8 1
+
+; <label>:68                                      ; preds = %32
+  %69 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck47 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %73 = add i32 %72, 1
+  %NullCheck49 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %74
+
+; <label>:74                                      ; preds = %70
+  %75 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  store i32 %73, i32 addrspace(1)* %75
+  br label %76
+
+; <label>:76                                      ; preds = %8, %12, %74
+  %77 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %78
+
+; <label>:78                                      ; preds = %76
+  %79 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, i32 0, i32 2
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck7 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %82
+
+; <label>:82                                      ; preds = %78
+  %83 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, i32 0, i32 0
+  %84 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %83, align 8
+  %NullCheck9 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %85
+
+; <label>:85                                      ; preds = %82
+  %86 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, i32 0, i32 7
+  %87 = load i32, i32 addrspace(1)* %86, align 8
+  %88 = icmp ult i32 %80, %87
+  br i1 %88, label %13, label %89
+
+; <label>:89                                      ; preds = %85
+  %90 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %91 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck11 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %92
+
+; <label>:92                                      ; preds = %89
+  %93 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, i32 0, i32 0
+  %94 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck13 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %95
+
+; <label>:95                                      ; preds = %92
+  %96 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, i32 0, i32 7
+  %97 = load i32, i32 addrspace(1)* %96, align 8
+  %98 = add i32 %97, 1
+  %NullCheck15 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %99
+
+; <label>:99                                      ; preds = %95
+  %100 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, i32 0, i32 2
+  store i32 %98, i32 addrspace(1)* %100
+  %101 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck17 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %102
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %103, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %92
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef22:                                   ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef24:                                   ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef26:                                   ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef28:                                   ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef30:                                   ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef32:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef34:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef36:                                   ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange38:                           ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef40:                                   ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef42:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef44:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef46:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef48:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef50:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -5200,8 +6368,8 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -5232,9 +6400,9 @@ Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
 Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
-Failed to read String.MakeSeparatorList[loadElemA]
+Failed to read String.MakeSeparatorList[storeElem]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
-Failed to read String.InternalSplitKeepEmptyEntries[loadElem]
+Failed to read String.InternalSplitKeepEmptyEntries[storeElem]
 INFO:  jitting method Path::IsRelative using LLILCJit
 Successfully read Path.IsRelative
 
@@ -5243,8 +6411,8 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -5254,8 +6422,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
@@ -5271,8 +6439,8 @@ entry:
 
 ; <label>:17                                      ; preds = %7
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
@@ -5288,8 +6456,8 @@ entry:
 
 ; <label>:29                                      ; preds = %19
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %31
 
 ; <label>:31                                      ; preds = %29
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
@@ -5300,8 +6468,8 @@ entry:
 
 ; <label>:36                                      ; preds = %31
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
-  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %37, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
@@ -5312,8 +6480,8 @@ entry:
 
 ; <label>:43                                      ; preds = %31, %38
   %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
-  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %45
 
 ; <label>:45                                      ; preds = %43
   %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
@@ -5324,8 +6492,8 @@ entry:
 
 ; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %50
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
@@ -5336,8 +6504,8 @@ entry:
 
 ; <label>:57                                      ; preds = %1, %7, %19, %45, %52
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
-  br i1 %NullCheck14, label %59, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %59
 
 ; <label>:59                                      ; preds = %57
   %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
@@ -5347,8 +6515,8 @@ entry:
 
 ; <label>:63                                      ; preds = %59
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
@@ -5359,8 +6527,8 @@ entry:
 
 ; <label>:70                                      ; preds = %65
   %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
-  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.String addrspace(1)* %71, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %72
 
 ; <label>:72                                      ; preds = %70
   %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
@@ -5379,39 +6547,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %17
+ThrowNullRef4:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %29
+ThrowNullRef6:                                    ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %36
+ThrowNullRef8:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %43
+ThrowNullRef10:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %50
+ThrowNullRef12:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %57
+ThrowNullRef14:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %63
+ThrowNullRef16:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %70
+ThrowNullRef18:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5419,7 +6587,293 @@ ThrowNullRef17:                                   ; preds = %70
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
-Failed to read String.TrimHelper[loadElem]
+Successfully read String.TrimHelper
+
+define %System.String addrspace(1)* @String.TrimHelper(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i16
+  %loc4 = alloca i32
+  %loc5 = alloca i16
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = sub i32 %3, 1
+  store i32 %4, i32* %loc0
+  store i32 0, i32* %loc1
+  %5 = load i32, i32* %arg2
+  %6 = icmp eq i32 %5, 1
+  br i1 %6, label %62, label %7
+
+; <label>:7                                       ; preds = %1
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:8                                       ; preds = %58
+  store i32 0, i32* %loc2
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load i32, i32* %loc1
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2, i32 %10
+  %13 = load i16, i16 addrspace(1)* %12
+  %14 = zext i16 %13 to i32
+  %15 = trunc i32 %14 to i16
+  store i16 %15, i16* %loc3
+  store i32 0, i32* %loc2
+  br label %34
+
+; <label>:16                                      ; preds = %37
+  %17 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %18 = load i32, i32* %loc2
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %17, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %19
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = zext i32 %18 to i64
+  %BoundsCheck = icmp uge i64 %23, %22
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %24
+
+; <label>:24                                      ; preds = %19
+  %25 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 3, i32 %18
+  %26 = load i16, i16 addrspace(1)* %25, align 8
+  %27 = zext i16 %26 to i32
+  %28 = load i16, i16* %loc3
+  %29 = zext i16 %28 to i32
+  %30 = icmp eq i32 %27, %29
+  br i1 %30, label %43, label %31
+
+; <label>:31                                      ; preds = %24
+  %32 = load i32, i32* %loc2
+  %33 = add i32 %32, 1
+  store i32 %33, i32* %loc2
+  br label %34
+
+; <label>:34                                      ; preds = %11, %31
+  %35 = load i32, i32* %loc2
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = icmp slt i32 %35, %41
+  br i1 %42, label %16, label %43
+
+; <label>:43                                      ; preds = %24, %37
+  %44 = load i32, i32* %loc2
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %45, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp eq i32 %44, %50
+  br i1 %51, label %62, label %52
+
+; <label>:52                                      ; preds = %46
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %7, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %57, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %58
+
+; <label>:58                                      ; preds = %55
+  %59 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %60 = load i32, i32 addrspace(1)* %59
+  %61 = icmp slt i32 %56, %60
+  br i1 %61, label %8, label %62
+
+; <label>:62                                      ; preds = %1, %46, %58
+  %63 = load i32, i32* %arg2
+  %64 = icmp eq i32 %63, 0
+  br i1 %64, label %122, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %66, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %67
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %66, i32 0, i32 1
+  %69 = load i32, i32 addrspace(1)* %68
+  %70 = sub i32 %69, 1
+  store i32 %70, i32* %loc0
+  br label %118
+
+; <label>:71                                      ; preds = %118
+  store i32 0, i32* %loc4
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %73 = load i32, i32* %loc0
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %74
+
+; <label>:74                                      ; preds = %71
+  %75 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 2, i32 %73
+  %76 = load i16, i16 addrspace(1)* %75
+  %77 = zext i16 %76 to i32
+  %78 = trunc i32 %77 to i16
+  store i16 %78, i16* %loc5
+  store i32 0, i32* %loc4
+  br label %97
+
+; <label>:79                                      ; preds = %100
+  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %81 = load i32, i32* %loc4
+  %NullCheck19 = icmp eq %"System.Char[]" addrspace(1)* %80, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
+
+; <label>:82                                      ; preds = %79
+  %83 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 1
+  %84 = load i32, i32 addrspace(1)* %83
+  %85 = zext i32 %84 to i64
+  %86 = zext i32 %81 to i64
+  %BoundsCheck21 = icmp uge i64 %86, %85
+  br i1 %BoundsCheck21, label %ThrowIndexOutOfRange22, label %87
+
+; <label>:87                                      ; preds = %82
+  %88 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 3, i32 %81
+  %89 = load i16, i16 addrspace(1)* %88, align 8
+  %90 = zext i16 %89 to i32
+  %91 = load i16, i16* %loc5
+  %92 = zext i16 %91 to i32
+  %93 = icmp eq i32 %90, %92
+  br i1 %93, label %106, label %94
+
+; <label>:94                                      ; preds = %87
+  %95 = load i32, i32* %loc4
+  %96 = add i32 %95, 1
+  store i32 %96, i32* %loc4
+  br label %97
+
+; <label>:97                                      ; preds = %74, %94
+  %98 = load i32, i32* %loc4
+  %99 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck15 = icmp eq %"System.Char[]" addrspace(1)* %99, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %100
+
+; <label>:100                                     ; preds = %97
+  %101 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %99, i32 0, i32 1
+  %102 = load i32, i32 addrspace(1)* %101
+  %103 = zext i32 %102 to i64
+  %104 = trunc i64 %103 to i32
+  %105 = icmp slt i32 %98, %104
+  br i1 %105, label %79, label %106
+
+; <label>:106                                     ; preds = %87, %100
+  %107 = load i32, i32* %loc4
+  %108 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck17 = icmp eq %"System.Char[]" addrspace(1)* %108, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %109
+
+; <label>:109                                     ; preds = %106
+  %110 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %108, i32 0, i32 1
+  %111 = load i32, i32 addrspace(1)* %110
+  %112 = zext i32 %111 to i64
+  %113 = trunc i64 %112 to i32
+  %114 = icmp eq i32 %107, %113
+  br i1 %114, label %122, label %115
+
+; <label>:115                                     ; preds = %109
+  %116 = load i32, i32* %loc0
+  %117 = sub i32 %116, 1
+  store i32 %117, i32* %loc0
+  br label %118
+
+; <label>:118                                     ; preds = %67, %115
+  %119 = load i32, i32* %loc0
+  %120 = load i32, i32* %loc1
+  %121 = icmp sge i32 %119, %120
+  br i1 %121, label %71, label %122
+
+; <label>:122                                     ; preds = %62, %109, %118
+  %123 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %124 = load i32, i32* %loc1
+  %125 = load i32, i32* %loc0
+  %126 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %123, i32 %124, i32 %125)
+  ret %System.String addrspace(1)* %126
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %97
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange22:                           ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
 Successfully read String.CreateTrimmedString
 
@@ -5439,8 +6893,8 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
@@ -5535,8 +6989,8 @@ entry:
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i64 2872
   %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
   %8 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %7
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %3
   %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
@@ -5553,8 +7007,8 @@ entry:
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 2864
   %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
   %21 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %20
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
-  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %22
 
 ; <label>:22                                      ; preds = %16
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
@@ -5569,7 +7023,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %16
+ThrowNullRef2:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5586,8 +7040,8 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5613,8 +7067,8 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
@@ -5632,8 +7086,8 @@ entry:
 
 ; <label>:12                                      ; preds = %4
   %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
@@ -5644,8 +7098,8 @@ entry:
 
 ; <label>:19                                      ; preds = %14
   %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %19
   %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
@@ -5660,21 +7114,21 @@ entry:
   %31 = zext i16 %30 to i32
   %32 = bitcast i8* %29 to i16*
   %33 = trunc i32 %31 to i16
-  %NullCheck6 = icmp ne i16* %32, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i16* %32, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %21
   store i16 %33, i16* %32, align 8
   %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %36
 
 ; <label>:36                                      ; preds = %34
   %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
   %38 = load i32, i32 addrspace(1)* %37, align 8
   %39 = add i32 %38, 1
-  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %40
 
 ; <label>:40                                      ; preds = %36
   %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
@@ -5683,16 +7137,16 @@ entry:
 
 ; <label>:42                                      ; preds = %14
   %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
-  br i1 %NullCheck12, label %44, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
   %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
   %47 = load i16, i16* %arg1
   %48 = zext i16 %47 to i32
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = trunc i32 %48 to i16
@@ -5703,31 +7157,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %19
+ThrowNullRef4:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %21
+ThrowNullRef6:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %36
+ThrowNullRef10:                                   ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %42
+ThrowNullRef12:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %44
+ThrowNullRef14:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5740,8 +7194,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -5752,8 +7206,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
@@ -5762,14 +7216,14 @@ entry:
 
 ; <label>:11                                      ; preds = %1
   %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
@@ -5779,15 +7233,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5808,8 +7262,8 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5822,8 +7276,8 @@ entry:
 
 ; <label>:8                                       ; preds = %3
   %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
@@ -5842,15 +7296,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
-  br i1 %NullCheck4, label %22, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
   %24 = load i16*, i16* addrspace(1)* %23, align 8
   %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %25, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
@@ -5859,8 +7313,8 @@ entry:
   store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
@@ -5874,8 +7328,8 @@ entry:
 
 ; <label>:37                                      ; preds = %65
   %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %37
   %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
@@ -5886,16 +7340,16 @@ entry:
   %45 = bitcast i16* %41 to i8*
   %46 = getelementptr inbounds i8, i8* %45, i64 %44
   %47 = bitcast i8* %46 to i16*
-  %NullCheck14 = icmp ne i16* %47, null
-  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %47, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %48
 
 ; <label>:48                                      ; preds = %39
   %49 = load i16, i16* %47, align 8
   %50 = zext i16 %49 to i32
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %52 = load i32, i32* %loc1
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %53
 
 ; <label>:53                                      ; preds = %48
   %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
@@ -5916,8 +7370,8 @@ entry:
 ; <label>:62                                      ; preds = %36, %59
   %63 = load i32, i32* %loc1
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck10, label %65, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %65
 
 ; <label>:65                                      ; preds = %62
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
@@ -5936,15 +7390,15 @@ entry:
 
 ; <label>:74                                      ; preds = %70
   %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
-  br i1 %NullCheck18, label %76, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %76
 
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
   %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
-  br i1 %NullCheck20, label %80, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
   %81 = load i64, i64 addrspace(1)* %79
@@ -5958,8 +7412,8 @@ entry:
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
   %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
-  br i1 %NullCheck22, label %92, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.String addrspace(1)* %90, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %92
 
 ; <label>:92                                      ; preds = %80
   %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
@@ -5969,15 +7423,15 @@ entry:
 
 ; <label>:96                                      ; preds = %70
   %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
-  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %98
 
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
   %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
-  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
   %103 = load i64, i64 addrspace(1)* %101
@@ -5991,8 +7445,8 @@ entry:
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
   %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
-  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.String addrspace(1)* %112, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %114
 
 ; <label>:114                                     ; preds = %102
   %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
@@ -6004,59 +7458,59 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %20
+ThrowNullRef4:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %22
+ThrowNullRef6:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %26
+ThrowNullRef8:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %62
+ThrowNullRef10:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %48
+ThrowNullRef16:                                   ; preds = %48
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %74
+ThrowNullRef18:                                   ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %76
+ThrowNullRef20:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %80
+ThrowNullRef22:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %96
+ThrowNullRef24:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %98
+ThrowNullRef26:                                   ; preds = %98
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %102
+ThrowNullRef28:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6069,15 +7523,15 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
   %3 = load i16*, i16* addrspace(1)* %2, align 8
   %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
@@ -6087,8 +7541,8 @@ entry:
   %10 = bitcast i16* %3 to i8*
   %11 = getelementptr inbounds i8, i8* %10, i64 %9
   %12 = bitcast i8* %11 to i16*
-  %NullCheck4 = icmp ne i16* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %5
   store i16 0, i16* %12, align 8
@@ -6098,11 +7552,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6119,8 +7573,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -6131,8 +7585,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
@@ -6144,15 +7598,15 @@ entry:
 
 ; <label>:14                                      ; preds = %1
   %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
   %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
   %21 = load i64, i64 addrspace(1)* %19
@@ -6171,15 +7625,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %14
+ThrowNullRef4:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %16
+ThrowNullRef6:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6302,14 +7756,6 @@ entry:
   ret %System.String addrspace(1)* %57
 }
 
-INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
-Successfully read RuntimeHelpers.get_OffsetToStringData
-
-define i32 @RuntimeHelpers.get_OffsetToStringData() {
-entry:
-  ret i32 12
-}
-
 INFO:  jitting method String::Equals using LLILCJit
 Successfully read String.Equals
 
@@ -6381,8 +7827,8 @@ entry:
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
-  br i1 %NullCheck24, label %29, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
   %30 = load i64, i64 addrspace(1)* %28
@@ -6397,8 +7843,8 @@ entry:
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
-  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
   %43 = load i64, i64 addrspace(1)* %41
@@ -6418,8 +7864,8 @@ entry:
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
   %59 = load i64, i64 addrspace(1)* %57
@@ -6434,8 +7880,8 @@ entry:
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck22, label %71, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
   %72 = load i64, i64 addrspace(1)* %70
@@ -6455,8 +7901,8 @@ entry:
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
-  br i1 %NullCheck16, label %87, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = load i64, i64 addrspace(1)* %86
@@ -6471,8 +7917,8 @@ entry:
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck18, label %100, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
   %101 = load i64, i64 addrspace(1)* %99
@@ -6492,8 +7938,8 @@ entry:
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
-  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
   %117 = load i64, i64 addrspace(1)* %115
@@ -6508,8 +7954,8 @@ entry:
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
-  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
   %130 = load i64, i64 addrspace(1)* %128
@@ -6528,15 +7974,15 @@ entry:
 
 ; <label>:142                                     ; preds = %22
   %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
-  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %143, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %144
 
 ; <label>:144                                     ; preds = %142
   %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
   %146 = load i32, i32 addrspace(1)* %145
   %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
-  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %147, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %148
 
 ; <label>:148                                     ; preds = %144
   %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
@@ -6557,15 +8003,15 @@ entry:
 
 ; <label>:159                                     ; preds = %22
   %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
-  br i1 %NullCheck, label %161, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %ThrowNullRef, label %161
 
 ; <label>:161                                     ; preds = %159
   %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
   %163 = load i32, i32 addrspace(1)* %162
   %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
-  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %164, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %165
 
 ; <label>:165                                     ; preds = %161
   %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
@@ -6578,8 +8024,8 @@ entry:
 
 ; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
-  br i1 %NullCheck4, label %172, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %171, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %172
 
 ; <label>:172                                     ; preds = %170
   %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
@@ -6589,8 +8035,8 @@ entry:
 
 ; <label>:176                                     ; preds = %172
   %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
-  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %177, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %178
 
 ; <label>:178                                     ; preds = %176
   %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
@@ -6629,55 +8075,55 @@ ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %161
+ThrowNullRef2:                                    ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %170
+ThrowNullRef4:                                    ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %176
+ThrowNullRef6:                                    ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %142
+ThrowNullRef8:                                    ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %144
+ThrowNullRef10:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %113
+ThrowNullRef12:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %116
+ThrowNullRef14:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %84
+ThrowNullRef16:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %87
+ThrowNullRef18:                                   ; preds = %87
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %55
+ThrowNullRef20:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %58
+ThrowNullRef22:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %26
+ThrowNullRef24:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %29
+ThrowNullRef26:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,8 +8161,8 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck, label %14, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %ThrowNullRef, label %14
 
 ; <label>:14                                      ; preds = %8
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
@@ -6760,8 +8206,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
@@ -6770,14 +8216,14 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32, i32* %loc0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %10
   %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
   %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
@@ -6790,15 +8236,15 @@ entry:
 ; <label>:25                                      ; preds = %19
   %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
-  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
   %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
@@ -6807,8 +8253,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %37 = load i32, i32* %loc0
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %38, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %38
 
 ; <label>:38                                      ; preds = %32
   %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
@@ -6817,14 +8263,14 @@ entry:
 
 ; <label>:40                                      ; preds = %19
   %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %40
   %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
   %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
-  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
-  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
@@ -6832,8 +8278,8 @@ entry:
   %48 = zext i32 %47 to i64
   %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
-  br i1 %NullCheck16, label %51, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %51
 
 ; <label>:51                                      ; preds = %45
   %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
@@ -6847,15 +8293,15 @@ entry:
 ; <label>:57                                      ; preds = %51
   %58 = load i16*, i16** %arg1
   %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
-  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %60
 
 ; <label>:60                                      ; preds = %57
   %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
   %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
-  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %64
 
 ; <label>:64                                      ; preds = %60
   %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
@@ -6864,22 +8310,22 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
   %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
-  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %70
 
 ; <label>:70                                      ; preds = %64
   %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
   %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
-  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
-  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
   %75 = load i32, i32 addrspace(1)* %74
   %76 = zext i32 %75 to i64
   %77 = trunc i64 %76 to i32
-  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
-  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %78
 
 ; <label>:78                                      ; preds = %73
   %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
@@ -6901,8 +8347,8 @@ entry:
   %90 = bitcast i16* %86 to i8*
   %91 = getelementptr inbounds i8, i8* %90, i64 %89
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %93
 
 ; <label>:93                                      ; preds = %80
   %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
@@ -6912,8 +8358,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %99 = load i32, i32* %loc2
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %100
 
 ; <label>:100                                     ; preds = %93
   %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
@@ -6928,63 +8374,63 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %25
+ThrowNullRef6:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %32
+ThrowNullRef10:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %40
+ThrowNullRef12:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %45
+ThrowNullRef16:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %57
+ThrowNullRef18:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %60
+ThrowNullRef20:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %64
+ThrowNullRef22:                                   ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %70
+ThrowNullRef24:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %73
+ThrowNullRef26:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %80
+ThrowNullRef28:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %93
+ThrowNullRef30:                                   ; preds = %93
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7004,8 +8450,8 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
@@ -7033,43 +8479,43 @@ entry:
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %14
   %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
   %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   %28 = load i32, i32 addrspace(1)* %27, align 8
   %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
-  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %30
 
 ; <label>:30                                      ; preds = %26
   %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
   %32 = load i32, i32 addrspace(1)* %31, align 8
   %33 = add i32 %28, %32
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %34
 
 ; <label>:34                                      ; preds = %30
   %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   store i32 %33, i32 addrspace(1)* %35
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
   store i32 0, i32 addrspace(1)* %38
   %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %40
 
 ; <label>:40                                      ; preds = %37
   %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
@@ -7082,8 +8528,8 @@ entry:
 
 ; <label>:47                                      ; preds = %40
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
@@ -7098,8 +8544,8 @@ entry:
   %54 = load i32, i32* %loc0
   %55 = sext i32 %54 to i64
   %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
-  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %57
 
 ; <label>:57                                      ; preds = %52
   %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
@@ -7110,68 +8556,35 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %14
+ThrowNullRef2:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %23
+ThrowNullRef4:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %26
+ThrowNullRef6:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %30
+ThrowNullRef8:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %34
+ThrowNullRef10:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %47
+ThrowNullRef14:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %52
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-}
-
-INFO:  jitting method StringBuilder::get_Length using LLILCJit
-Successfully read StringBuilder.get_Length
-
-define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.StringBuilder addrspace(1)*
-  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
-  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
-
-; <label>:1                                       ; preds = %entry
-  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %3 = load i32, i32 addrspace(1)* %2, align 8
-  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
-
-; <label>:5                                       ; preds = %1
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = add i32 %3, %7
-  ret i32 %8
-
-ThrowNullRef:                                     ; preds = %entry
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef16:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7213,70 +8626,70 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
   %6 = load i32, i32 addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
   store i32 %6, i32 addrspace(1)* %8
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
   %13 = load i32, i32 addrspace(1)* %12, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
   store i32 %13, i32 addrspace(1)* %15
   %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
-  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %18
 
 ; <label>:18                                      ; preds = %14
   %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
   %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
   %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
   %34 = load i32, i32 addrspace(1)* %33, align 8
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
-  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
@@ -7287,39 +8700,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %28
+ThrowNullRef16:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %32
+ThrowNullRef18:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7455,13 +8868,13 @@ entry:
 ; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
@@ -7477,16 +8890,16 @@ entry:
 
 ; <label>:18                                      ; preds = %15
   %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
   store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
   %22 = load i32, i32* %loc0
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %24
 
 ; <label>:24                                      ; preds = %20
   %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
@@ -7498,13 +8911,13 @@ entry:
 ; <label>:28                                      ; preds = %15, %24
   %29 = load i32, i32* %arg1
   %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %31
   %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
@@ -7517,20 +8930,20 @@ entry:
   %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
-  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
   %46 = load i32, i32 addrspace(1)* %45, align 8
   %47 = sub i32 %40, %46
-  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
-  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i32 addrspace(1)* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %48
 
 ; <label>:48                                      ; preds = %44
   store i32 %47, i32 addrspace(1)* %39, align 8
@@ -7538,21 +8951,21 @@ entry:
 
 ; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
-  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %51
 
 ; <label>:51                                      ; preds = %49
   %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %53
 
 ; <label>:53                                      ; preds = %51
   %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
   %55 = load i32, i32 addrspace(1)* %54, align 8
   %56 = load i32, i32* %arg2
   %57 = sub i32 %55, %56
-  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %58
 
 ; <label>:58                                      ; preds = %53
   %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
@@ -7562,13 +8975,13 @@ entry:
 ; <label>:60                                      ; preds = %33, %58
   %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
   %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
-  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %63
 
 ; <label>:63                                      ; preds = %60
   %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
-  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
-  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
@@ -7578,15 +8991,15 @@ entry:
 
 ; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
-  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i32 addrspace(1)* %69, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %70
 
 ; <label>:70                                      ; preds = %68
   %71 = load i32, i32 addrspace(1)* %69, align 8
   store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
-  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
@@ -7596,8 +9009,8 @@ entry:
   store i32 %77, i32* %loc4
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
-  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %80
 
 ; <label>:80                                      ; preds = %73
   %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
@@ -7607,71 +9020,71 @@ entry:
 ; <label>:83                                      ; preds = %80
   store i32 0, i32* %loc3
   %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
-  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
-  br i1 %NullCheck26, label %88, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i32 addrspace(1)* %87, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %88
 
 ; <label>:88                                      ; preds = %85
   %89 = load i32, i32 addrspace(1)* %87, align 8
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
-  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %90
 
 ; <label>:90                                      ; preds = %88
   %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
   store i32 %89, i32 addrspace(1)* %91
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
-  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
-  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %96
 
 ; <label>:96                                      ; preds = %94
   %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
-  br i1 %NullCheck34, label %100, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %100
 
 ; <label>:100                                     ; preds = %96
   %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
-  br i1 %NullCheck36, label %102, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %102
 
 ; <label>:102                                     ; preds = %100
   %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
   %104 = load i32, i32 addrspace(1)* %103, align 8
   %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
-  br i1 %NullCheck38, label %106, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %106
 
 ; <label>:106                                     ; preds = %102
   %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
-  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
-  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %108
 
 ; <label>:108                                     ; preds = %106
   %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
   %110 = load i32, i32 addrspace(1)* %109, align 8
   %111 = add i32 %104, %110
-  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %112
 
 ; <label>:112                                     ; preds = %108
   %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
   store i32 %111, i32 addrspace(1)* %113
   %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
-  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i32 addrspace(1)* %114, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %115
 
 ; <label>:115                                     ; preds = %112
   %116 = load i32, i32 addrspace(1)* %114, align 8
@@ -7681,19 +9094,19 @@ entry:
 ; <label>:118                                     ; preds = %115
   %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
-  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %121
 
 ; <label>:121                                     ; preds = %118
   %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
-  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
-  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %123
 
 ; <label>:123                                     ; preds = %121
   %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
   %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
-  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
-  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %126
 
 ; <label>:126                                     ; preds = %123
   %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
@@ -7705,8 +9118,8 @@ entry:
 
 ; <label>:130                                     ; preds = %80, %115, %126
   %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %132
 
 ; <label>:132                                     ; preds = %130
   %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7715,8 +9128,8 @@ entry:
   %136 = load i32, i32* %loc3
   %137 = sub i32 %135, %136
   %138 = sub i32 %134, %137
-  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %139
 
 ; <label>:139                                     ; preds = %132
   %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7728,16 +9141,16 @@ entry:
 
 ; <label>:144                                     ; preds = %139
   %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
-  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %146
 
 ; <label>:146                                     ; preds = %144
   %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
   %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
   %149 = load i32, i32* %loc2
   %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
-  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %151
 
 ; <label>:151                                     ; preds = %146
   %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
@@ -7754,145 +9167,249 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %18
+ThrowNullRef4:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %31
+ThrowNullRef10:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %44
+ThrowNullRef16:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %68
+ThrowNullRef18:                                   ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %70
+ThrowNullRef20:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %73
+ThrowNullRef22:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %83
+ThrowNullRef24:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %85
+ThrowNullRef26:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %88
+ThrowNullRef28:                                   ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %90
+ThrowNullRef30:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %94
+ThrowNullRef32:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %96
+ThrowNullRef34:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %100
+ThrowNullRef36:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %102
+ThrowNullRef38:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %106
+ThrowNullRef40:                                   ; preds = %106
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %108
+ThrowNullRef42:                                   ; preds = %108
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %112
+ThrowNullRef44:                                   ; preds = %112
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %118
+ThrowNullRef46:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %121
+ThrowNullRef48:                                   ; preds = %121
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %123
+ThrowNullRef50:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %130
+ThrowNullRef52:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %132
+ThrowNullRef54:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %144
+ThrowNullRef56:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %146
+ThrowNullRef58:                                   ; preds = %146
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %60
+ThrowNullRef60:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %63
+ThrowNullRef62:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %49
+ThrowNullRef64:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %51
+ThrowNullRef66:                                   ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %53
+ThrowNullRef68:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(%"System.Char[]" addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %arg0 = alloca %"System.Char[]" addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store %"System.Char[]" addrspace(1)* %param0, %"System.Char[]" addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load i32, i32* %arg4
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %43, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %38, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg1
+  %13 = load i32, i32* %arg4
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %38, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %24 = load i32, i32* %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %35 = load i32, i32* %arg3
+  %36 = load i32, i32* %arg4
+  %37 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %37, %"System.Char[]" addrspace(1)* %34, i32 %35, i32 %36)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:38                                      ; preds = %5, %16
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Successfully read Buffer._Memmove
 
@@ -7914,7 +9431,7 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[loadElem]
+Failed to read AppDomain.SetDataHelper[storeElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -7923,8 +9440,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
@@ -7934,8 +9451,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
@@ -7947,15 +9464,15 @@ entry:
   %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
   %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
@@ -7966,15 +9483,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7992,7 +9509,79 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
-Failed to read Dictionary`2.TryGetValue[loadElemA]
+Successfully read Dictionary`2.TryGetValue
+
+define i8 @"Dictionary`2.TryGetValue"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)* addrspace(1)* %param2) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  %arg2 = alloca %System.__Canon addrspace(1)* addrspace(1)*
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  store %System.__Canon addrspace(1)* addrspace(1)* %param2, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  store i32 %2, i32* %loc0
+  %3 = load i32, i32* %loc0
+  %4 = icmp slt i32 %3, 0
+  br i1 %4, label %22, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 2
+  %10 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %9, align 8
+  %11 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = zext i32 %11 to i64
+  %BoundsCheck = icmp uge i64 %16, %15
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 3, i32 %11
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %20, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %6, %System.__Canon addrspace(1)* %21)
+  ret i8 1
+
+; <label>:22                                      ; preds = %entry
+  %23 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %23, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -8058,8 +9647,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
@@ -8091,8 +9680,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
@@ -8171,15 +9760,15 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck, label %19, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %ThrowNullRef, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
   %21 = load i32, i32 addrspace(1)* %20
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
@@ -8202,7 +9791,7 @@ ThrowNullRef:                                     ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %19
+ThrowNullRef2:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8248,8 +9837,8 @@ entry:
   %0 = alloca %System.AppDomainHandle
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %1 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %1, i32 0, i32 15
@@ -8269,8 +9858,8 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
@@ -8286,7 +9875,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -8299,8 +9888,8 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -8327,8 +9916,8 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
@@ -8352,8 +9941,8 @@ entry:
   %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
   store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
@@ -8363,8 +9952,8 @@ entry:
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
@@ -8374,8 +9963,8 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %9
   %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
@@ -8384,8 +9973,8 @@ entry:
 
 ; <label>:18                                      ; preds = %3, %16
   %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
@@ -8397,15 +9986,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %18
+ThrowNullRef6:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8418,8 +10007,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
@@ -8453,15 +10042,15 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
@@ -8473,7 +10062,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8481,7 +10070,7 @@ ThrowNullRef1:                                    ; preds = %1
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
 Failed to read Dictionary`2.System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
@@ -8506,8 +10095,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
@@ -8524,8 +10113,8 @@ entry:
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -8544,7 +10133,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8577,8 +10166,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = load i64, i64* %arg2
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = trunc i32 %3 to i8
@@ -8634,46 +10223,46 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
   %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
-  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
-  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
-  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
@@ -8684,27 +10273,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %20
+ThrowNullRef12:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8717,8 +10306,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -8756,22 +10345,22 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
   %9 = load i64, i64 addrspace(1)* %8, align 8
   %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
   %13 = load i64, i64 addrspace(1)* %12, align 8
   %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %11
   %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
@@ -8788,11 +10377,11 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8882,8 +10471,8 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
@@ -8900,8 +10489,8 @@ entry:
 ; <label>:8                                       ; preds = %1
   %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
   %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
@@ -8911,15 +10500,15 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
   %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
   %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
-  br i1 %NullCheck6, label %21, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
@@ -8946,15 +10535,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8992,15 +10581,15 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
   store i8 %3, i8 addrspace(1)* %5
   %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
@@ -9011,7 +10600,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9027,8 +10616,8 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -9041,8 +10630,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
@@ -9058,7 +10647,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9080,8 +10669,8 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
@@ -9096,8 +10685,8 @@ entry:
 ; <label>:12                                      ; preds = %6
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
@@ -9112,8 +10701,8 @@ entry:
 ; <label>:21                                      ; preds = %15
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
@@ -9128,8 +10717,8 @@ entry:
 ; <label>:30                                      ; preds = %24
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %31, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
@@ -9144,8 +10733,8 @@ entry:
 ; <label>:39                                      ; preds = %33
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
-  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %40, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %42
 
 ; <label>:42                                      ; preds = %39
   %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
@@ -9164,19 +10753,19 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %21
+ThrowNullRef4:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %30
+ThrowNullRef6:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %39
+ThrowNullRef8:                                    ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9243,8 +10832,8 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
@@ -9264,57 +10853,57 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
   store i8 0, i8 addrspace(1)* %2
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
   store i8 0, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
   store i8 0, i8 addrspace(1)* %17
   %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
   store i8 0, i8 addrspace(1)* %20
   %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
-  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
@@ -9325,31 +10914,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %19
+ThrowNullRef14:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9367,8 +10956,8 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
@@ -9380,8 +10969,8 @@ entry:
 
 ; <label>:9                                       ; preds = %4
   %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %9
   %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
@@ -9395,7 +10984,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef2:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9420,8 +11009,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
@@ -9512,8 +11101,8 @@ entry:
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
@@ -9524,8 +11113,8 @@ entry:
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = load i64, i64 addrspace(1)* %12
@@ -9537,8 +11126,8 @@ entry:
   %20 = load i64, i64* %19
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
-  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %13
   %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
@@ -9555,8 +11144,8 @@ entry:
 ; <label>:30                                      ; preds = %25
   %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %32 = load i32, i32* %arg2
-  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
-  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
@@ -9570,15 +11159,15 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %30
+ThrowNullRef2:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9622,87 +11211,87 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
   %10 = load i8, i8 addrspace(1)* %9, align 8
   %11 = zext i8 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %8
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
   store i8 %12, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
   %19 = load i8, i8 addrspace(1)* %18, align 8
   %20 = zext i8 %19 to i32
   %21 = trunc i32 %20 to i8
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
   store i8 %21, i8 addrspace(1)* %23
   %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
   %28 = load i8, i8 addrspace(1)* %27, align 8
   %29 = zext i8 %28 to i32
   %30 = trunc i32 %29 to i8
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
-  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %31
 
 ; <label>:31                                      ; preds = %26
   %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
   store i8 %30, i8 addrspace(1)* %32
   %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
-  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
-  br i1 %NullCheck14, label %40, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %40
 
 ; <label>:40                                      ; preds = %35
   %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
   store i8 %39, i8 addrspace(1)* %41
   %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
-  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %44
 
 ; <label>:44                                      ; preds = %40
   %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
   %46 = load i8, i8 addrspace(1)* %45, align 8
   %47 = zext i8 %46 to i32
   %48 = trunc i32 %47 to i8
-  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
   store i8 %48, i8 addrspace(1)* %50
   %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
-  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
@@ -9713,29 +11302,29 @@ entry:
 ; <label>:56                                      ; preds = %52
   %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
-  br i1 %NullCheck22, label %59, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
   %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
   %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
-  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
-  br i1 %NullCheck24, label %63, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
   %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
-  br i1 %NullCheck26, label %66, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
   %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
-  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
-  br i1 %NullCheck28, label %69, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %69
 
 ; <label>:69                                      ; preds = %66
   %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
@@ -9744,15 +11333,15 @@ entry:
 
 ; <label>:71                                      ; preds = %105
   %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
-  br i1 %NullCheck34, label %73, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %73
 
 ; <label>:73                                      ; preds = %71
   %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
   %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
   %76 = load i32, i32* %loc0
-  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
-  br i1 %NullCheck36, label %77, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
@@ -9766,8 +11355,8 @@ entry:
 
 ; <label>:83                                      ; preds = %77
   %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
-  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
@@ -9775,14 +11364,14 @@ entry:
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
   %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
-  br i1 %NullCheck40, label %91, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
 ; <label>:91                                      ; preds = %85
   %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
   %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
-  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck42, label %94, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %94
 
 ; <label>:94                                      ; preds = %91
   %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
@@ -9798,14 +11387,14 @@ entry:
 ; <label>:99                                      ; preds = %69, %96
   %100 = load i32, i32* %loc0
   %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
-  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %102
 
 ; <label>:102                                     ; preds = %99
   %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
   %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
-  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
-  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
@@ -9819,87 +11408,87 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %26
+ThrowNullRef10:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %31
+ThrowNullRef12:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %35
+ThrowNullRef14:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %40
+ThrowNullRef16:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %56
+ThrowNullRef22:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %59
+ThrowNullRef24:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %63
+ThrowNullRef26:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %66
+ThrowNullRef28:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %102
+ThrowNullRef32:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %71
+ThrowNullRef34:                                   ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %73
+ThrowNullRef36:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %83
+ThrowNullRef38:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %85
+ThrowNullRef40:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %91
+ThrowNullRef42:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9943,15 +11532,15 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
   %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
@@ -9961,28 +11550,28 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
   %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %12
   %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
   %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
   %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
-  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
@@ -9993,23 +11582,23 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %12
+ThrowNullRef6:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10031,15 +11620,15 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
   %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = load i64, i64 addrspace(1)* %7
@@ -10077,13 +11666,13 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[loadElem]
+Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -10111,8 +11700,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -10175,8 +11764,8 @@ entry:
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load double, double* %arg0
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -10310,8 +11899,8 @@ entry:
   store i64 %param0, i64* %arg0
   store i64 %param1, i64* %arg1
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
@@ -10319,8 +11908,8 @@ entry:
   %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
   %5 = load i16*, i16* addrspace(1)* %4, align 8
   %6 = addrspacecast i64* %arg1 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = bitcast i64 addrspace(1)* %6 to i8 addrspace(1)*
@@ -10336,7 +11925,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10370,8 +11959,8 @@ entry:
   %1 = load i32, i32* %arg1
   %2 = sext i32 %1 to i64
   %3 = inttoptr i64 %2 to i16*
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -10424,8 +12013,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, i32)*)(%System.IO.ConsoleStream addrspace(1)* %2, i32 %1)
   %3 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %4 = load i64, i64* %arg1
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
@@ -10436,8 +12025,8 @@ entry:
   %10 = icmp eq i32 %9, 3
   %11 = sext i1 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %5
   %14 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, i32 0, i32 5
@@ -10448,7 +12037,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10471,8 +12060,8 @@ entry:
   %5 = icmp eq i32 %4, 1
   %6 = sext i1 %5 to i32
   %7 = trunc i32 %6 to i8
-  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %2, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.ConsoleStream addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
@@ -10483,8 +12072,8 @@ entry:
   %13 = icmp eq i32 %12, 2
   %14 = sext i1 %13 to i32
   %15 = trunc i32 %14 to i8
-  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %10, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.ConsoleStream addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %8
   %17 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %10, i32 0, i32 4
@@ -10495,7 +12084,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10534,8 +12123,8 @@ entry:
   %arg0 = alloca i64
   store i64 %param0, i64* %arg0
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
@@ -10570,8 +12159,8 @@ entry:
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
   %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = load i64, i64 addrspace(1)* %7
@@ -10675,7 +12264,127 @@ entry:
 INFO:  jitting method Encoding::GetEncoding using LLILCJit
 Failed to read Encoding.GetEncoding[convertToHelperArgumentType]
 INFO:  jitting method EncodingProvider::GetEncodingFromProvider using LLILCJit
-Failed to read EncodingProvider.GetEncodingFromProvider[loadElem]
+Successfully read EncodingProvider.GetEncodingFromProvider
+
+define %System.Text.Encoding addrspace(1)* @EncodingProvider.GetEncodingFromProvider(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca %"System.Text.EncodingProvider[]" addrspace(1)*
+  %loc1 = alloca %System.Text.EncodingProvider addrspace(1)*
+  %loc2 = alloca %System.Text.Encoding addrspace(1)*
+  %loc3 = alloca %System.Text.Encoding addrspace(1)*
+  %loc4 = alloca %"System.Text.EncodingProvider[]" addrspace(1)*
+  %loc5 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1059)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2392
+  %2 = addrspacecast i8 addrspace(1)* %1 to %"System.Text.EncodingProvider[]" addrspace(1)**
+  %3 = load volatile %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %2
+  %4 = icmp ne %"System.Text.EncodingProvider[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %entry
+  ret %System.Text.Encoding addrspace(1)* null
+
+; <label>:6                                       ; preds = %entry
+  %7 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1059)
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i64 2392
+  %9 = addrspacecast i8 addrspace(1)* %8 to %"System.Text.EncodingProvider[]" addrspace(1)**
+  %10 = load volatile %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %9
+  store %"System.Text.EncodingProvider[]" addrspace(1)* %10, %"System.Text.EncodingProvider[]" addrspace(1)** %loc0
+  %11 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc0
+  store %"System.Text.EncodingProvider[]" addrspace(1)* %11, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  store i32 0, i32* %loc5
+  br label %43
+
+; <label>:12                                      ; preds = %46
+  %13 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  %14 = load i32, i32* %loc5
+  %NullCheck1 = icmp eq %"System.Text.EncodingProvider[]" addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %13, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = zext i32 %17 to i64
+  %19 = zext i32 %14 to i64
+  %BoundsCheck = icmp uge i64 %19, %18
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %20
+
+; <label>:20                                      ; preds = %15
+  %21 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %13, i32 0, i32 3, i32 %14
+  %22 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)* addrspace(1)* %21, align 8
+  store %System.Text.EncodingProvider addrspace(1)* %22, %System.Text.EncodingProvider addrspace(1)** %loc1
+  %23 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)** %loc1
+  %24 = load i32, i32* %arg0
+  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i64 addrspace(1)*
+  %NullCheck3 = icmp eq i64 addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
+
+; <label>:26                                      ; preds = %20
+  %27 = load i64, i64 addrspace(1)* %25
+  %28 = add i64 %27, 64
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 40
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Text.Encoding addrspace(1)* (%System.Text.EncodingProvider addrspace(1)*, i32)*
+  %35 = call %System.Text.Encoding addrspace(1)* %34(%System.Text.EncodingProvider addrspace(1)* %23, i32 %24)
+  store %System.Text.Encoding addrspace(1)* %35, %System.Text.Encoding addrspace(1)** %loc2
+  %36 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc2
+  %37 = icmp eq %System.Text.Encoding addrspace(1)* %36, null
+  br i1 %37, label %40, label %38
+
+; <label>:38                                      ; preds = %26
+  %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc2
+  store %System.Text.Encoding addrspace(1)* %39, %System.Text.Encoding addrspace(1)** %loc3
+  br label %53
+
+; <label>:40                                      ; preds = %26
+  %41 = load i32, i32* %loc5
+  %42 = add i32 %41, 1
+  store i32 %42, i32* %loc5
+  br label %43
+
+; <label>:43                                      ; preds = %6, %40
+  %44 = load i32, i32* %loc5
+  %45 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  %NullCheck = icmp eq %"System.Text.EncodingProvider[]" addrspace(1)* %45, null
+  br i1 %NullCheck, label %ThrowNullRef, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp slt i32 %44, %50
+  br i1 %51, label %12, label %52
+
+; <label>:52                                      ; preds = %46
+  ret %System.Text.Encoding addrspace(1)* null
+
+; <label>:53                                      ; preds = %38
+  %54 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc3
+  ret %System.Text.Encoding addrspace(1)* %54
+
+ThrowNullRef:                                     ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method EncodingProvider::.cctor using LLILCJit
 Successfully read EncodingProvider..cctor
 
@@ -10694,7 +12403,7 @@ Failed to read Encoding.get_InternalSyncObject[Call HasTypeArg]
 INFO:  jitting method Hashtable::.ctor using LLILCJit
 Failed to read Hashtable..ctor[Volatile store]
 INFO:  jitting method Hashtable::get_Item using LLILCJit
-Failed to read Hashtable.get_Item[loadElemA]
+Failed to read Hashtable.get_Item[loadNonPrimitiveObj]
 INFO:  jitting method Hashtable::InitHash using LLILCJit
 Successfully read Hashtable.InitHash
 
@@ -10714,8 +12423,8 @@ entry:
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -10731,15 +12440,15 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
   %15 = load i32, i32* %loc0
-  %NullCheck2 = icmp ne i32 addrspace(1)* %14, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i32 addrspace(1)* %14, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %3
   store i32 %15, i32 addrspace(1)* %14, align 8
   %17 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %18 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %NullCheck4 = icmp ne i32 addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i32 addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = load i32, i32 addrspace(1)* %18, align 8
@@ -10748,8 +12457,8 @@ entry:
   %23 = sub i32 %22, 1
   %24 = urem i32 %21, %23
   %25 = add i32 1, %24
-  %NullCheck6 = icmp ne i32 addrspace(1)* %17, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32 addrspace(1)* %17, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %19
   store i32 %25, i32 addrspace(1)* %17, align 8
@@ -10760,15 +12469,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %19
+ThrowNullRef6:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10783,8 +12492,8 @@ entry:
   store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
   store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %NullCheck = icmp ne %System.Collections.Hashtable addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Collections.Hashtable addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
@@ -10794,16 +12503,16 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Collections.Hashtable addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Collections.Hashtable addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
   %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck4 = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %9, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
   %13 = inttoptr i64 %11 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
@@ -10813,8 +12522,8 @@ entry:
 ; <label>:15                                      ; preds = %1
   %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -10832,15 +12541,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10854,8 +12563,8 @@ entry:
   store %System.Int32 addrspace(1)* %param0, %System.Int32 addrspace(1)** %this
   %0 = load %System.Int32 addrspace(1)*, %System.Int32 addrspace(1)** %this
   %1 = bitcast %System.Int32 addrspace(1)* %0 to i32 addrspace(1)*
-  %NullCheck = icmp ne i32 addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq i32 addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load i32, i32 addrspace(1)* %1, align 8
@@ -10931,8 +12640,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.UTF8Encoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
@@ -10941,15 +12650,15 @@ entry:
   %9 = load i8, i8* %arg2
   %10 = zext i8 %9 to i32
   %11 = trunc i32 %10 to i8
-  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %8, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %6
   %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %8, i32 0, i32 8
   store i8 %11, i8 addrspace(1)* %13
   %14 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %14, i32 0, i32 8
@@ -10961,8 +12670,8 @@ entry:
 ; <label>:20                                      ; preds = %15
   %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %22, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %22, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = load i64, i64 addrspace(1)* %22
@@ -10984,15 +12693,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %12
+ThrowNullRef4:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11007,8 +12716,8 @@ entry:
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
@@ -11030,16 +12739,16 @@ entry:
 ; <label>:10                                      ; preds = %1
   %11 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
   %12 = load i32, i32* %arg1
-  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %11, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.Encoding addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
   store i32 %12, i32 addrspace(1)* %14
   %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
   %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = load i64, i64 addrspace(1)* %16
@@ -11057,11 +12766,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11074,8 +12783,8 @@ entry:
   %this = alloca %System.Text.UTF8Encoding addrspace(1)*
   store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
   %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.UTF8Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
@@ -11087,16 +12796,16 @@ entry:
 ; <label>:6                                       ; preds = %1
   %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %8 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %10, %System.Text.EncoderFallback addrspace(1)* %8)
   %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %12 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
-  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %11, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %11, i32 0, i32 3
@@ -11109,8 +12818,8 @@ entry:
   %18 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %18, %System.String addrspace(1)* %17)
   %19 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %18 to %System.Text.EncoderFallback addrspace(1)*
-  %NullCheck6 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %16, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %16, i32 0, i32 2
@@ -11120,8 +12829,8 @@ entry:
   %24 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %24, %System.String addrspace(1)* %23)
   %25 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %24 to %System.Text.DecoderFallback addrspace(1)*
-  %NullCheck8 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %22, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %22, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %20
   %27 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %22, i32 0, i32 3
@@ -11132,19 +12841,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %20
+ThrowNullRef8:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11174,8 +12883,8 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load i32, i32* %arg1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -11193,8 +12902,8 @@ entry:
 ; <label>:15                                      ; preds = %8
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %17 = load i32, i32* %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 %17
@@ -11210,7 +12919,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11262,7 +12971,7 @@ entry:
 }
 
 INFO:  jitting method Hashtable::Insert using LLILCJit
-Failed to read Hashtable.Insert[loadElemA]
+Failed to read Hashtable.Insert[storeElem]
 INFO:  jitting method ConsoleEncoding::.ctor using LLILCJit
 Successfully read ConsoleEncoding..ctor
 
@@ -11277,8 +12986,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %1)
   %2 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
@@ -11314,8 +13023,8 @@ entry:
   %2 = call %System.Text.InternalEncoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalEncoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %1)
   %3 = bitcast %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2 to %System.Text.EncoderFallback addrspace(1)*
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
@@ -11325,8 +13034,8 @@ entry:
   %8 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %7)
   %9 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %8 to %System.Text.DecoderFallback addrspace(1)*
-  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %6, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.Encoding addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %4
   %11 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %6, i32 0, i32 3
@@ -11337,7 +13046,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11356,15 +13065,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* %1)
   %2 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   %6 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, i32 0, i32 1
@@ -11375,7 +13084,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11403,8 +13112,8 @@ entry:
   store %System.Text.InternalDecoderBestFitFallback addrspace(1)* %param0, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
   %0 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
@@ -11414,15 +13123,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %4)
   %5 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %6)
   %9 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, i32 0, i32 1
@@ -11433,11 +13142,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11505,8 +13214,8 @@ entry:
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
   %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = load i64, i64 addrspace(1)* %19
@@ -11570,8 +13279,8 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.ConsoleStream addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
@@ -11602,31 +13311,31 @@ entry:
   store i8 %param4, i8* %arg4
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %3, %System.IO.Stream addrspace(1)* %1)
   %4 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %4, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
   %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %4, i32 0, i32 4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %5)
   %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %6
   %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
   %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
   %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = load i64, i64 addrspace(1)* %13
@@ -11638,8 +13347,8 @@ entry:
   %21 = load i64, i64* %20
   %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %8, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %8, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %14
   %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 5
@@ -11657,24 +13366,24 @@ entry:
   %31 = load i32, i32* %arg3
   %32 = sext i32 %31 to i64
   %33 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %32)
-  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %30, null
-  br i1 %NullCheck10, label %34, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.StreamWriter addrspace(1)* %30, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %35, %"System.Char[]" addrspace(1)* %33)
   %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %37, null
-  br i1 %NullCheck12, label %38, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.StreamWriter addrspace(1)* %37, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %38
 
 ; <label>:38                                      ; preds = %34
   %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
   %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
   %41 = load i32, i32* %arg3
   %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %42, null
-  br i1 %NullCheck14, label %43, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %42, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
   %44 = load i64, i64 addrspace(1)* %42
@@ -11688,30 +13397,30 @@ entry:
   %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
   %53 = sext i32 %52 to i64
   %54 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %53)
-  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
-  br i1 %NullCheck16, label %55, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %55
 
 ; <label>:55                                      ; preds = %43
   %56 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %56, %"System.Byte[]" addrspace(1)* %54)
   %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %58 = load i32, i32* %arg3
-  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %57, null
-  br i1 %NullCheck18, label %59, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.StreamWriter addrspace(1)* %57, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %59
 
 ; <label>:59                                      ; preds = %55
   %60 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 10
   store i32 %58, i32 addrspace(1)* %60
   %61 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %61, null
-  br i1 %NullCheck20, label %62, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.IO.StreamWriter addrspace(1)* %61, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %62
 
 ; <label>:62                                      ; preds = %59
   %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
   %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
   %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
   %67 = load i64, i64 addrspace(1)* %65
@@ -11729,15 +13438,15 @@ entry:
 
 ; <label>:78                                      ; preds = %66
   %79 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %79, null
-  br i1 %NullCheck24, label %80, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.StreamWriter addrspace(1)* %79, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %80
 
 ; <label>:80                                      ; preds = %78
   %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
   %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
   %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %83, null
-  br i1 %NullCheck26, label %84, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %83, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
   %85 = load i64, i64 addrspace(1)* %83
@@ -11754,8 +13463,8 @@ entry:
 
 ; <label>:95                                      ; preds = %84
   %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.IO.StreamWriter addrspace(1)* %96, null
-  br i1 %NullCheck28, label %97, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.IO.StreamWriter addrspace(1)* %96, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %97
 
 ; <label>:97                                      ; preds = %95
   %98 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 12
@@ -11769,8 +13478,8 @@ entry:
   %103 = icmp eq i32 %102, 0
   %104 = sext i1 %103 to i32
   %105 = trunc i32 %104 to i8
-  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %100, null
-  br i1 %NullCheck30, label %106, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.IO.StreamWriter addrspace(1)* %100, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %106
 
 ; <label>:106                                     ; preds = %99
   %107 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %100, i32 0, i32 13
@@ -11781,63 +13490,63 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %6
+ThrowNullRef4:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %29
+ThrowNullRef10:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %34
+ThrowNullRef12:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %38
+ThrowNullRef14:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %43
+ThrowNullRef16:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %55
+ThrowNullRef18:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %59
+ThrowNullRef20:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %62
+ThrowNullRef22:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %78
+ThrowNullRef24:                                   ; preds = %78
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %80
+ThrowNullRef26:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %95
+ThrowNullRef28:                                   ; preds = %95
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11850,15 +13559,15 @@ entry:
   %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = load i64, i64 addrspace(1)* %4
@@ -11876,7 +13585,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11926,35 +13635,35 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
   %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderNLS addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %7 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.EncoderNLS addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Text.Encoding addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.Encoding addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Text.EncoderNLS addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.EncoderNLS addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
   %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck8 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = load i64, i64 addrspace(1)* %16
@@ -11973,19 +13682,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12011,8 +13720,8 @@ entry:
   %this = alloca %System.Text.Encoding addrspace(1)*
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
@@ -12032,15 +13741,15 @@ entry:
   %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
   store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
   %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
   store i32 0, i32 addrspace(1)* %2
   %3 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, i32 0, i32 2
@@ -12050,15 +13759,15 @@ entry:
 
 ; <label>:8                                       ; preds = %4
   %9 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
   %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
   %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = load i64, i64 addrspace(1)* %13
@@ -12079,15 +13788,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12102,16 +13811,16 @@ entry:
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = load i32, i32* %arg1
   %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
   %7 = load i64, i64 addrspace(1)* %5
@@ -12129,7 +13838,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12166,8 +13875,8 @@ entry:
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
   %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
   %16 = load i64, i64 addrspace(1)* %14
@@ -12188,8 +13897,8 @@ entry:
   %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
   %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
   %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %31, null
-  br i1 %NullCheck2, label %32, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = load i64, i64 addrspace(1)* %31
@@ -12232,7 +13941,7 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12245,14 +13954,14 @@ entry:
   %this = alloca %System.Text.EncoderReplacementFallback addrspace(1)*
   store %System.Text.EncoderReplacementFallback addrspace(1)* %param0, %System.Text.EncoderReplacementFallback addrspace(1)** %this
   %0 = load %System.Text.EncoderReplacementFallback addrspace(1)*, %System.Text.EncoderReplacementFallback addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -12263,7 +13972,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12293,8 +14002,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
@@ -12326,8 +14035,8 @@ entry:
   %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
   store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
@@ -12339,8 +14048,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Threading.Tasks.Task addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %7)
@@ -12363,7 +14072,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12382,8 +14091,8 @@ entry:
   store i8 %param1, i8* %arg1
   store i8 %param2, i8* %arg2
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
@@ -12397,8 +14106,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1, %5
   %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 9
@@ -12429,8 +14138,8 @@ entry:
 
 ; <label>:25                                      ; preds = %8, %20
   %26 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %26, null
-  br i1 %NullCheck4, label %27, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %26, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %26, i32 0, i32 12
@@ -12441,22 +14150,22 @@ entry:
 
 ; <label>:32                                      ; preds = %27
   %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %33, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.IO.StreamWriter addrspace(1)* %33, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %32
   %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 12
   store i8 1, i8 addrspace(1)* %35
   %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
-  br i1 %NullCheck8, label %37, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
   %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
   %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck10 = icmp ne i64 addrspace(1)* %40, null
-  br i1 %NullCheck10, label %41, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64 addrspace(1)* %40, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i64, i64 addrspace(1)* %40
@@ -12470,8 +14179,8 @@ entry:
   %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
   store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
   %51 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %NullCheck12 = icmp ne %"System.Byte[]" addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Byte[]" addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %41
   %53 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %51, i32 0, i32 1
@@ -12483,16 +14192,16 @@ entry:
 
 ; <label>:58                                      ; preds = %52
   %59 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %59, null
-  br i1 %NullCheck14, label %60, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.IO.StreamWriter addrspace(1)* %59, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %60
 
 ; <label>:60                                      ; preds = %58
   %61 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %59, i32 0, i32 3
   %62 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
   %64 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %NullCheck16 = icmp ne %"System.Byte[]" addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %"System.Byte[]" addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %60
   %66 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %64, i32 0, i32 1
@@ -12500,8 +14209,8 @@ entry:
   %68 = zext i32 %67 to i64
   %69 = trunc i64 %68 to i32
   %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck18, label %71, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
   %72 = load i64, i64 addrspace(1)* %70
@@ -12517,29 +14226,29 @@ entry:
 
 ; <label>:80                                      ; preds = %27, %52, %71
   %81 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %81, null
-  br i1 %NullCheck20, label %82, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.IO.StreamWriter addrspace(1)* %81, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
 
 ; <label>:82                                      ; preds = %80
   %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %81, i32 0, i32 5
   %84 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %83, align 8
   %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.IO.StreamWriter addrspace(1)* %85, null
-  br i1 %NullCheck22, label %86, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.IO.StreamWriter addrspace(1)* %85, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %86
 
 ; <label>:86                                      ; preds = %82
   %87 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 7
   %88 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %87, align 8
   %89 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %89, null
-  br i1 %NullCheck24, label %90, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.StreamWriter addrspace(1)* %89, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %90
 
 ; <label>:90                                      ; preds = %86
   %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %89, i32 0, i32 9
   %92 = load i32, i32 addrspace(1)* %91, align 8
   %93 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.IO.StreamWriter addrspace(1)* %93, null
-  br i1 %NullCheck26, label %94, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.IO.StreamWriter addrspace(1)* %93, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %93, i32 0, i32 6
@@ -12547,8 +14256,8 @@ entry:
   %97 = load i8, i8* %arg2
   %98 = zext i8 %97 to i32
   %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
-  %NullCheck28 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck28, label %100, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
   %101 = load i64, i64 addrspace(1)* %99
@@ -12563,8 +14272,8 @@ entry:
   %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
   store i32 %110, i32* %loc1
   %111 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %111, null
-  br i1 %NullCheck30, label %112, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.IO.StreamWriter addrspace(1)* %111, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %112
 
 ; <label>:112                                     ; preds = %100
   %113 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %111, i32 0, i32 9
@@ -12575,23 +14284,23 @@ entry:
 
 ; <label>:116                                     ; preds = %112
   %117 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck32 = icmp ne %System.IO.StreamWriter addrspace(1)* %117, null
-  br i1 %NullCheck32, label %118, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.IO.StreamWriter addrspace(1)* %117, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %118
 
 ; <label>:118                                     ; preds = %116
   %119 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %117, i32 0, i32 3
   %120 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %119, align 8
   %121 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.IO.StreamWriter addrspace(1)* %121, null
-  br i1 %NullCheck34, label %122, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.IO.StreamWriter addrspace(1)* %121, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %122
 
 ; <label>:122                                     ; preds = %118
   %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
   %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
   %125 = load i32, i32* %loc1
   %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
-  %NullCheck36 = icmp ne i64 addrspace(1)* %126, null
-  br i1 %NullCheck36, label %127, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64 addrspace(1)* %126, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
   %128 = load i64, i64 addrspace(1)* %126
@@ -12613,15 +14322,15 @@ entry:
 
 ; <label>:140                                     ; preds = %136
   %141 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.IO.StreamWriter addrspace(1)* %141, null
-  br i1 %NullCheck38, label %142, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.IO.StreamWriter addrspace(1)* %141, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %142
 
 ; <label>:142                                     ; preds = %140
   %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
   %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
   %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
-  %NullCheck40 = icmp ne i64 addrspace(1)* %145, null
-  br i1 %NullCheck40, label %146, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i64 addrspace(1)* %145, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
   %147 = load i64, i64 addrspace(1)* %145
@@ -12642,83 +14351,83 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %25
+ThrowNullRef4:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %32
+ThrowNullRef6:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %37
+ThrowNullRef10:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %41
+ThrowNullRef12:                                   ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %58
+ThrowNullRef14:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %60
+ThrowNullRef16:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %65
+ThrowNullRef18:                                   ; preds = %65
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %80
+ThrowNullRef20:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %82
+ThrowNullRef22:                                   ; preds = %82
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %86
+ThrowNullRef24:                                   ; preds = %86
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %90
+ThrowNullRef26:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %94
+ThrowNullRef28:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %100
+ThrowNullRef30:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %116
+ThrowNullRef32:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %118
+ThrowNullRef34:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %122
+ThrowNullRef36:                                   ; preds = %122
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %140
+ThrowNullRef38:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %142
+ThrowNullRef40:                                   ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12785,8 +14494,8 @@ entry:
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %1 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
-  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
@@ -12794,8 +14503,8 @@ entry:
   %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
   %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
   %8 = load i64, i64 addrspace(1)* %6
@@ -12811,8 +14520,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %17, %System.IFormatProvider addrspace(1)* %16)
   %18 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %19 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %18, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.SyncTextWriter addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %7
   %21 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %18, i32 0, i32 4
@@ -12823,11 +14532,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12840,8 +14549,8 @@ entry:
   %this = alloca %System.IO.TextWriter addrspace(1)*
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.TextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
@@ -12851,8 +14560,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.Threading.Thread addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Threading.Thread addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %6)
@@ -12861,8 +14570,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1
   %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.TextWriter addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.TextWriter addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %11, i32 0, i32 2
@@ -12873,11 +14582,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13074,8 +14783,8 @@ entry:
   store double %param1, double* %arg1
   store i8 0, i8* %loc1
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
@@ -13085,16 +14794,16 @@ entry:
   %5 = addrspacecast i8* %loc1 to i8 addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %4, i8 addrspace(1)* %5)
   %6 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.SyncTextWriter addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
   %10 = load double, double* %arg1
   %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
   %13 = load i64, i64 addrspace(1)* %11
@@ -13129,11 +14838,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13150,8 +14859,8 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load double, double* %arg1
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -13165,8 +14874,8 @@ entry:
   call void %11(%System.IO.TextWriter addrspace(1)* %0, double %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
   %15 = load i64, i64 addrspace(1)* %13
@@ -13184,7 +14893,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13202,8 +14911,8 @@ entry:
   %1 = addrspacecast double* %arg1 to double addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -13218,8 +14927,8 @@ entry:
   %14 = bitcast double addrspace(1)* %1 to %System.Double addrspace(1)*
   %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Double addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Double addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
   %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
   %18 = load i64, i64 addrspace(1)* %16
@@ -13237,7 +14946,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13253,8 +14962,8 @@ entry:
   store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
   %0 = load %System.Double addrspace(1)*, %System.Double addrspace(1)** %this
   %1 = bitcast %System.Double addrspace(1)* %0 to double addrspace(1)*
-  %NullCheck = icmp ne double addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq double addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load double, double addrspace(1)* %1, align 8
@@ -13279,8 +14988,8 @@ entry:
   %loc0 = alloca %System.Globalization.NumberFormatInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 3
@@ -13290,8 +14999,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
@@ -13301,24 +15010,24 @@ entry:
   store %System.Globalization.NumberFormatInfo addrspace(1)* %10, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
   %11 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %7
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
   %15 = load i8, i8 addrspace(1)* %14, align 8
   %16 = zext i8 %15 to i32
   %17 = trunc i32 %16 to i8
-  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %11, null
-  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %11, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %13
   %19 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %11, i32 0, i32 29
   store i8 %17, i8 addrspace(1)* %19
   %20 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %21 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %20, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %20, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %18
   %23 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %20, i32 0, i32 3
@@ -13327,8 +15036,8 @@ entry:
 
 ; <label>:24                                      ; preds = %1, %22
   %25 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %25, null
-  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %25, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %26
 
 ; <label>:26                                      ; preds = %24
   %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %25, i32 0, i32 3
@@ -13339,23 +15048,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %18
+ThrowNullRef8:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13380,168 +15089,168 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 18
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %8, align 8
-  %NullCheck2 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %5, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %5, i32 0, i32 4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %9)
   %12 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 19
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %15, align 8
-  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %12, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %12, i32 0, i32 5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %16)
   %19 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %20 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %20, null
-  br i1 %NullCheck8, label %21, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %20, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %20, i32 0, i32 23
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  %NullCheck10 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %19, null
-  br i1 %NullCheck10, label %24, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %19, i32 0, i32 7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %25, %System.String addrspace(1)* %23)
   %26 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %27 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %27, i32 0, i32 22
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %29, align 8
-  %NullCheck14 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %26, null
-  br i1 %NullCheck14, label %31, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %26, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %26, i32 0, i32 6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %32, %System.String addrspace(1)* %30)
   %33 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %34 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Globalization.CultureData addrspace(1)* %34, null
-  br i1 %NullCheck16, label %35, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Globalization.CultureData addrspace(1)* %34, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %34, i32 0, i32 51
   %37 = load i32, i32 addrspace(1)* %36, align 8
-  %NullCheck18 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %33, null
-  br i1 %NullCheck18, label %38, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %33, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %33, i32 0, i32 21
   store i32 %37, i32 addrspace(1)* %39
   %40 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %41 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Globalization.CultureData addrspace(1)* %41, null
-  br i1 %NullCheck20, label %42, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Globalization.CultureData addrspace(1)* %41, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %41, i32 0, i32 52
   %44 = load i32, i32 addrspace(1)* %43, align 8
-  %NullCheck22 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %40, null
-  br i1 %NullCheck22, label %45, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %40, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %40, i32 0, i32 25
   store i32 %44, i32 addrspace(1)* %46
   %47 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %48 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.Globalization.CultureData addrspace(1)* %48, null
-  br i1 %NullCheck24, label %49, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Globalization.CultureData addrspace(1)* %48, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %49
 
 ; <label>:49                                      ; preds = %45
   %50 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %48, i32 0, i32 29
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck26 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %47, null
-  br i1 %NullCheck26, label %52, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %47, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %47, i32 0, i32 10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %53, %System.String addrspace(1)* %51)
   %54 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %55 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Globalization.CultureData addrspace(1)* %55, null
-  br i1 %NullCheck28, label %56, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Globalization.CultureData addrspace(1)* %55, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %56
 
 ; <label>:56                                      ; preds = %52
   %57 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %55, i32 0, i32 35
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %57, align 8
-  %NullCheck30 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %54, null
-  br i1 %NullCheck30, label %59, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %54, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %54, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %60, %System.String addrspace(1)* %58)
   %61 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %62 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck32 = icmp ne %System.Globalization.CultureData addrspace(1)* %62, null
-  br i1 %NullCheck32, label %63, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Globalization.CultureData addrspace(1)* %62, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %62, i32 0, i32 34
   %65 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %64, align 8
-  %NullCheck34 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %61, null
-  br i1 %NullCheck34, label %66, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %61, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %61, i32 0, i32 9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %67, %System.String addrspace(1)* %65)
   %68 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %69 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck36 = icmp ne %System.Globalization.CultureData addrspace(1)* %69, null
-  br i1 %NullCheck36, label %70, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Globalization.CultureData addrspace(1)* %69, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %70
 
 ; <label>:70                                      ; preds = %66
   %71 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %69, i32 0, i32 55
   %72 = load i32, i32 addrspace(1)* %71, align 8
-  %NullCheck38 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %68, null
-  br i1 %NullCheck38, label %73, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %68, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %68, i32 0, i32 22
   store i32 %72, i32 addrspace(1)* %74
   %75 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %76 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck40 = icmp ne %System.Globalization.CultureData addrspace(1)* %76, null
-  br i1 %NullCheck40, label %77, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Globalization.CultureData addrspace(1)* %76, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %76, i32 0, i32 57
   %79 = load i32, i32 addrspace(1)* %78, align 8
-  %NullCheck42 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %75, null
-  br i1 %NullCheck42, label %80, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %75, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %80
 
 ; <label>:80                                      ; preds = %77
   %81 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %75, i32 0, i32 24
   store i32 %79, i32 addrspace(1)* %81
   %82 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %83 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck44 = icmp ne %System.Globalization.CultureData addrspace(1)* %83, null
-  br i1 %NullCheck44, label %84, label %ThrowNullRef43
+  %NullCheck43 = icmp eq %System.Globalization.CultureData addrspace(1)* %83, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %84
 
 ; <label>:84                                      ; preds = %80
   %85 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %83, i32 0, i32 56
   %86 = load i32, i32 addrspace(1)* %85, align 8
-  %NullCheck46 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %82, null
-  br i1 %NullCheck46, label %87, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %82, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %82, i32 0, i32 23
@@ -13550,8 +15259,8 @@ entry:
 
 ; <label>:89                                      ; preds = %entry
   %90 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck100 = icmp ne %System.Globalization.CultureData addrspace(1)* %90, null
-  br i1 %NullCheck100, label %91, label %ThrowNullRef99
+  %NullCheck99 = icmp eq %System.Globalization.CultureData addrspace(1)* %90, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %91
 
 ; <label>:91                                      ; preds = %89
   %92 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %90, i32 0, i32 2
@@ -13569,8 +15278,8 @@ entry:
   %102 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %103 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %104 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %103)
-  %NullCheck48 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %102, null
-  br i1 %NullCheck48, label %105, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %102, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %105
 
 ; <label>:105                                     ; preds = %101
   %106 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %102, i32 0, i32 1
@@ -13578,8 +15287,8 @@ entry:
   %107 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %108 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %109 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %108)
-  %NullCheck50 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %107, null
-  br i1 %NullCheck50, label %110, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %107, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %110
 
 ; <label>:110                                     ; preds = %105
   %111 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %107, i32 0, i32 2
@@ -13587,8 +15296,8 @@ entry:
   %112 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %113 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %114 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %113)
-  %NullCheck52 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %112, null
-  br i1 %NullCheck52, label %115, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %112, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %115
 
 ; <label>:115                                     ; preds = %110
   %116 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %112, i32 0, i32 27
@@ -13596,8 +15305,8 @@ entry:
   %117 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %118 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %119 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %118)
-  %NullCheck54 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %117, null
-  br i1 %NullCheck54, label %120, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %117, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %120
 
 ; <label>:120                                     ; preds = %115
   %121 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %117, i32 0, i32 26
@@ -13605,8 +15314,8 @@ entry:
   %122 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %123 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %124 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %123)
-  %NullCheck56 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %122, null
-  br i1 %NullCheck56, label %125, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %122, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %125
 
 ; <label>:125                                     ; preds = %120
   %126 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %122, i32 0, i32 17
@@ -13614,8 +15323,8 @@ entry:
   %127 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %128 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %129 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %128)
-  %NullCheck58 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %127, null
-  br i1 %NullCheck58, label %130, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %127, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %130
 
 ; <label>:130                                     ; preds = %125
   %131 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %127, i32 0, i32 18
@@ -13623,8 +15332,8 @@ entry:
   %132 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %133 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %134 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %133)
-  %NullCheck60 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %132, null
-  br i1 %NullCheck60, label %135, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %132, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %135
 
 ; <label>:135                                     ; preds = %130
   %136 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %132, i32 0, i32 14
@@ -13632,8 +15341,8 @@ entry:
   %137 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %138 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %139 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %138)
-  %NullCheck62 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %137, null
-  br i1 %NullCheck62, label %140, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %137, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %140
 
 ; <label>:140                                     ; preds = %135
   %141 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %137, i32 0, i32 13
@@ -13641,71 +15350,71 @@ entry:
   %142 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %143 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %144 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %143)
-  %NullCheck64 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %142, null
-  br i1 %NullCheck64, label %145, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %142, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %145
 
 ; <label>:145                                     ; preds = %140
   %146 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %142, i32 0, i32 12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %146, %System.String addrspace(1)* %144)
   %147 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %148 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck66 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %148, null
-  br i1 %NullCheck66, label %149, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %148, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %149
 
 ; <label>:149                                     ; preds = %145
   %150 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %148, i32 0, i32 21
   %151 = load i32, i32 addrspace(1)* %150, align 8
-  %NullCheck68 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %147, null
-  br i1 %NullCheck68, label %152, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %147, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %152
 
 ; <label>:152                                     ; preds = %149
   %153 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %147, i32 0, i32 28
   store i32 %151, i32 addrspace(1)* %153
   %154 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %155 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck70 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %155, null
-  br i1 %NullCheck70, label %156, label %ThrowNullRef69
+  %NullCheck69 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %155, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %156
 
 ; <label>:156                                     ; preds = %152
   %157 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %155, i32 0, i32 6
   %158 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %157, align 8
-  %NullCheck72 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %154, null
-  br i1 %NullCheck72, label %159, label %ThrowNullRef71
+  %NullCheck71 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %154, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %159
 
 ; <label>:159                                     ; preds = %156
   %160 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %154, i32 0, i32 15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %160, %System.String addrspace(1)* %158)
   %161 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %162 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck74 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %162, null
-  br i1 %NullCheck74, label %163, label %ThrowNullRef73
+  %NullCheck73 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %162, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %163
 
 ; <label>:163                                     ; preds = %159
   %164 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %162, i32 0, i32 1
   %165 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %164, align 8
-  %NullCheck76 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %161, null
-  br i1 %NullCheck76, label %166, label %ThrowNullRef75
+  %NullCheck75 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %161, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %166
 
 ; <label>:166                                     ; preds = %163
   %167 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %161, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %167, %"System.Int32[]" addrspace(1)* %165)
   %168 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %169 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck78 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %169, null
-  br i1 %NullCheck78, label %170, label %ThrowNullRef77
+  %NullCheck77 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %169, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %170
 
 ; <label>:170                                     ; preds = %166
   %171 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %169, i32 0, i32 7
   %172 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %171, align 8
-  %NullCheck80 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %168, null
-  br i1 %NullCheck80, label %173, label %ThrowNullRef79
+  %NullCheck79 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %168, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %173
 
 ; <label>:173                                     ; preds = %170
   %174 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %168, i32 0, i32 16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %174, %System.String addrspace(1)* %172)
   %175 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck82 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %175, null
-  br i1 %NullCheck82, label %176, label %ThrowNullRef81
+  %NullCheck81 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %175, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %176
 
 ; <label>:176                                     ; preds = %173
   %177 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %175, i32 0, i32 4
@@ -13715,14 +15424,14 @@ entry:
 
 ; <label>:180                                     ; preds = %176
   %181 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck84 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %181, null
-  br i1 %NullCheck84, label %182, label %ThrowNullRef83
+  %NullCheck83 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %181, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %182
 
 ; <label>:182                                     ; preds = %180
   %183 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %181, i32 0, i32 4
   %184 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %183, align 8
-  %NullCheck86 = icmp ne %System.String addrspace(1)* %184, null
-  br i1 %NullCheck86, label %185, label %ThrowNullRef85
+  %NullCheck85 = icmp eq %System.String addrspace(1)* %184, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %185
 
 ; <label>:185                                     ; preds = %182
   %186 = getelementptr inbounds %System.String, %System.String addrspace(1)* %184, i32 0, i32 1
@@ -13733,8 +15442,8 @@ entry:
 ; <label>:189                                     ; preds = %176, %185
   %190 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck98 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %190, null
-  br i1 %NullCheck98, label %192, label %ThrowNullRef97
+  %NullCheck97 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %190, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %192
 
 ; <label>:192                                     ; preds = %189
   %193 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %190, i32 0, i32 4
@@ -13743,8 +15452,8 @@ entry:
 
 ; <label>:194                                     ; preds = %185, %192
   %195 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck88 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %195, null
-  br i1 %NullCheck88, label %196, label %ThrowNullRef87
+  %NullCheck87 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %195, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %196
 
 ; <label>:196                                     ; preds = %194
   %197 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %195, i32 0, i32 9
@@ -13754,14 +15463,14 @@ entry:
 
 ; <label>:200                                     ; preds = %196
   %201 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck90 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %201, null
-  br i1 %NullCheck90, label %202, label %ThrowNullRef89
+  %NullCheck89 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %201, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %202
 
 ; <label>:202                                     ; preds = %200
   %203 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %201, i32 0, i32 9
   %204 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %203, align 8
-  %NullCheck92 = icmp ne %System.String addrspace(1)* %204, null
-  br i1 %NullCheck92, label %205, label %ThrowNullRef91
+  %NullCheck91 = icmp eq %System.String addrspace(1)* %204, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %205
 
 ; <label>:205                                     ; preds = %202
   %206 = getelementptr inbounds %System.String, %System.String addrspace(1)* %204, i32 0, i32 1
@@ -13772,14 +15481,14 @@ entry:
 ; <label>:209                                     ; preds = %196, %205
   %210 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %211 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck94 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %211, null
-  br i1 %NullCheck94, label %212, label %ThrowNullRef93
+  %NullCheck93 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %211, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %212
 
 ; <label>:212                                     ; preds = %209
   %213 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %211, i32 0, i32 6
   %214 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %213, align 8
-  %NullCheck96 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %210, null
-  br i1 %NullCheck96, label %215, label %ThrowNullRef95
+  %NullCheck95 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %210, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %215
 
 ; <label>:215                                     ; preds = %212
   %216 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %210, i32 0, i32 9
@@ -13793,203 +15502,203 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %17
+ThrowNullRef8:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %21
+ThrowNullRef10:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %24
+ThrowNullRef12:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %28
+ThrowNullRef14:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %31
+ThrowNullRef16:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %35
+ThrowNullRef18:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %38
+ThrowNullRef20:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %42
+ThrowNullRef22:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %45
+ThrowNullRef24:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %49
+ThrowNullRef26:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %52
+ThrowNullRef28:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %56
+ThrowNullRef30:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %59
+ThrowNullRef32:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %63
+ThrowNullRef34:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %66
+ThrowNullRef36:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %70
+ThrowNullRef38:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %73
+ThrowNullRef40:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %77
+ThrowNullRef42:                                   ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %80
+ThrowNullRef44:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %84
+ThrowNullRef46:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %101
+ThrowNullRef48:                                   ; preds = %101
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %105
+ThrowNullRef50:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %110
+ThrowNullRef52:                                   ; preds = %110
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %115
+ThrowNullRef54:                                   ; preds = %115
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %120
+ThrowNullRef56:                                   ; preds = %120
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %125
+ThrowNullRef58:                                   ; preds = %125
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %130
+ThrowNullRef60:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %135
+ThrowNullRef62:                                   ; preds = %135
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %140
+ThrowNullRef64:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %145
+ThrowNullRef66:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %149
+ThrowNullRef68:                                   ; preds = %149
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %152
+ThrowNullRef70:                                   ; preds = %152
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %156
+ThrowNullRef72:                                   ; preds = %156
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %159
+ThrowNullRef74:                                   ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %163
+ThrowNullRef76:                                   ; preds = %163
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %166
+ThrowNullRef78:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %170
+ThrowNullRef80:                                   ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %173
+ThrowNullRef82:                                   ; preds = %173
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %180
+ThrowNullRef84:                                   ; preds = %180
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %182
+ThrowNullRef86:                                   ; preds = %182
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %194
+ThrowNullRef88:                                   ; preds = %194
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %200
+ThrowNullRef90:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %202
+ThrowNullRef92:                                   ; preds = %202
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %209
+ThrowNullRef94:                                   ; preds = %209
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %212
+ThrowNullRef96:                                   ; preds = %212
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %189
+ThrowNullRef98:                                   ; preds = %189
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %89
+ThrowNullRef100:                                  ; preds = %89
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14017,8 +15726,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 21
@@ -14031,8 +15740,8 @@ entry:
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 16)
   %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 21
@@ -14041,8 +15750,8 @@ entry:
 
 ; <label>:12                                      ; preds = %1, %10
   %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 21
@@ -14053,11 +15762,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %12
+ThrowNullRef4:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14073,8 +15782,8 @@ entry:
   store i32 %param1, i32* %arg1
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %1 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
@@ -14141,8 +15850,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 33
@@ -14155,8 +15864,8 @@ entry:
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 24)
   %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 33
@@ -14165,8 +15874,8 @@ entry:
 
 ; <label>:12                                      ; preds = %1, %10
   %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 33
@@ -14177,11 +15886,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %12
+ThrowNullRef4:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14194,8 +15903,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 53
@@ -14207,8 +15916,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 116)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 53
@@ -14217,8 +15926,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 53
@@ -14229,11 +15938,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14262,8 +15971,8 @@ entry:
 
 ; <label>:7                                       ; preds = %entry, %4
   %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %7
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 2
@@ -14287,8 +15996,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 54
@@ -14300,8 +16009,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 117)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
@@ -14310,8 +16019,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 54
@@ -14322,11 +16031,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14339,8 +16048,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 27
@@ -14352,8 +16061,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 118)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 27
@@ -14362,8 +16071,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 27
@@ -14374,11 +16083,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14391,8 +16100,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 28
@@ -14404,8 +16113,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 119)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 28
@@ -14414,8 +16123,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 28
@@ -14426,11 +16135,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14443,8 +16152,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 26
@@ -14456,8 +16165,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 107)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 26
@@ -14466,8 +16175,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 26
@@ -14478,11 +16187,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14495,8 +16204,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 25
@@ -14508,8 +16217,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 106)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 25
@@ -14518,8 +16227,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 25
@@ -14530,11 +16239,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14547,8 +16256,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 24
@@ -14560,8 +16269,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 105)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 24
@@ -14570,8 +16279,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 24
@@ -14582,11 +16291,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14611,8 +16320,8 @@ entry:
   %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %3)
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %2
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -14623,15 +16332,15 @@ entry:
 
 ; <label>:8                                       ; preds = %62
   %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 9
   %12 = load i32, i32 addrspace(1)* %11, align 8
   %13 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.IO.StreamWriter addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %13, i32 0, i32 10
@@ -14646,15 +16355,15 @@ entry:
 
 ; <label>:20                                      ; preds = %14, %18
   %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
   %24 = load i32, i32 addrspace(1)* %23, align 8
   %25 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %25, null
-  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.StreamWriter addrspace(1)* %25, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %25, i32 0, i32 9
@@ -14675,36 +16384,36 @@ entry:
   %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %37 = load i32, i32* %loc1
   %38 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.StreamWriter addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %35
   %40 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %38, i32 0, i32 7
   %41 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %40, align 8
   %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
-  br i1 %NullCheck14, label %43, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %39
   %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 9
   %45 = load i32, i32 addrspace(1)* %44, align 8
   %46 = load i32, i32* %loc2
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %36, null
-  br i1 %NullCheck16, label %47, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %36, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %47
 
 ; <label>:47                                      ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %36, i32 %37, %"System.Char[]" addrspace(1)* %41, i32 %45, i32 %46)
   %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
   %51 = load i32, i32 addrspace(1)* %50, align 8
   %52 = load i32, i32* %loc2
   %53 = add i32 %51, %52
-  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
-  br i1 %NullCheck20, label %54, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %54
 
 ; <label>:54                                      ; preds = %49
   %55 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
@@ -14726,8 +16435,8 @@ entry:
 
 ; <label>:65                                      ; preds = %62
   %66 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %66, null
-  br i1 %NullCheck2, label %67, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %66, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %67
 
 ; <label>:67                                      ; preds = %65
   %68 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %66, i32 0, i32 11
@@ -14748,49 +16457,259 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %65
+ThrowNullRef2:                                    ; preds = %65
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %20
+ThrowNullRef8:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %22
+ThrowNullRef10:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %35
+ThrowNullRef12:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %43
+ThrowNullRef16:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %47
+ThrowNullRef18:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method String::CopyTo using LLILCJit
-Failed to read String.CopyTo[loadElemA]
+Successfully read String.CopyTo
+
+define void @String.CopyTo(%System.String addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  %loc1 = alloca i16 addrspace(1)*
+  %loc2 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %1 = icmp ne %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg4
+  %7 = icmp sge i32 %6, 0
+  br i1 %7, label %13, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  unreachable
+
+; <label>:13                                      ; preds = %5
+  %14 = load i32, i32* %arg1
+  %15 = icmp sge i32 %14, 0
+  br i1 %15, label %21, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %18)
+  %20 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %20, %System.String addrspace(1)* %17, %System.String addrspace(1)* %19)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %20) #0
+  unreachable
+
+; <label>:21                                      ; preds = %13
+  %22 = load i32, i32* %arg4
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck, label %ThrowNullRef, label %24
+
+; <label>:24                                      ; preds = %21
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load i32, i32* %arg1
+  %28 = sub i32 %26, %27
+  %29 = icmp sle i32 %22, %28
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34, %System.String addrspace(1)* %31, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %24
+  %36 = load i32, i32* %arg3
+  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %37, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
+
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
+  %40 = load i32, i32 addrspace(1)* %39
+  %41 = zext i32 %40 to i64
+  %42 = trunc i64 %41 to i32
+  %43 = load i32, i32* %arg4
+  %44 = sub i32 %42, %43
+  %45 = icmp sgt i32 %36, %44
+  br i1 %45, label %49, label %46
+
+; <label>:46                                      ; preds = %38
+  %47 = load i32, i32* %arg3
+  %48 = icmp sge i32 %47, 0
+  br i1 %48, label %54, label %49
+
+; <label>:49                                      ; preds = %38, %46
+  %50 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %52 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %51)
+  %53 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53, %System.String addrspace(1)* %50, %System.String addrspace(1)* %52)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53) #0
+  unreachable
+
+; <label>:54                                      ; preds = %46
+  %55 = load i32, i32* %arg4
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %97, label %57
+
+; <label>:57                                      ; preds = %54
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %59
+
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 2
+  %61 = bitcast [0 x i16] addrspace(1)* %60 to i16 addrspace(1)*
+  store i16 addrspace(1)* %61, i16 addrspace(1)** %loc0
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  store %"System.Char[]" addrspace(1)* %62, %"System.Char[]" addrspace(1)** %loc2
+  %63 = icmp eq %"System.Char[]" addrspace(1)* %62, null
+  br i1 %63, label %72, label %64
+
+; <label>:64                                      ; preds = %59
+  %65 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc2
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %65, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %66
+
+; <label>:66                                      ; preds = %64
+  %67 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %65, i32 0, i32 1
+  %68 = load i32, i32 addrspace(1)* %67
+  %69 = zext i32 %68 to i64
+  %70 = trunc i64 %69 to i32
+  %71 = icmp ne i32 %70, 0
+  br i1 %71, label %73, label %72
+
+; <label>:72                                      ; preds = %59, %66
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  br label %81
+
+; <label>:73                                      ; preds = %66
+  %74 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc2
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %74, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %75
+
+; <label>:75                                      ; preds = %73
+  %76 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %74, i32 0, i32 1
+  %77 = load i32, i32 addrspace(1)* %76
+  %78 = zext i32 %77 to i64
+  %BoundsCheck = icmp uge i64 0, %78
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %79
+
+; <label>:79                                      ; preds = %75
+  %80 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %74, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %80, i16 addrspace(1)** %loc1
+  br label %81
+
+; <label>:81                                      ; preds = %72, %79
+  %82 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %83 = ptrtoint i16 addrspace(1)* %82 to i64
+  %84 = load i32, i32* %arg3
+  %85 = sext i32 %84 to i64
+  %86 = mul i64 %85, 2
+  %87 = add i64 %83, %86
+  %88 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %89 = ptrtoint i16 addrspace(1)* %88 to i64
+  %90 = load i32, i32* %arg1
+  %91 = sext i32 %90 to i64
+  %92 = mul i64 %91, 2
+  %93 = add i64 %89, %92
+  %94 = load i32, i32* %arg4
+  %95 = inttoptr i64 %87 to i16*
+  %96 = inttoptr i64 %93 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %95, i16* %96, i32 %94)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  br label %97
+
+; <label>:97                                      ; preds = %54, %81
+  ret void
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
 Successfully read ConsoleEncoding.GetPreamble
 
@@ -14827,7 +16746,365 @@ entry:
 }
 
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[loadElemA]
+Successfully read EncoderNLS.GetBytes
+
+define i32 @EncoderNLS.GetBytes(%System.Text.EncoderNLS addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3, %"System.Byte[]" addrspace(1)* %param4, i32 %param5, i8 %param6) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %arg4 = alloca %"System.Byte[]" addrspace(1)*
+  %arg5 = alloca i32
+  %arg6 = alloca i8
+  %loc0 = alloca i32
+  %loc1 = alloca i16 addrspace(1)*
+  %loc2 = alloca i8 addrspace(1)*
+  %loc3 = alloca i32
+  %loc4 = alloca %"System.Char[]" addrspace(1)*
+  %loc5 = alloca %"System.Byte[]" addrspace(1)*
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  store %"System.Byte[]" addrspace(1)* %param4, %"System.Byte[]" addrspace(1)** %arg4
+  store i32 %param5, i32* %arg5
+  store i8 %param6, i8* %arg6
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %1 = icmp eq %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %17, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %7 = icmp eq %"System.Char[]" addrspace(1)* %6, null
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %12
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %12
+
+; <label>:12                                      ; preds = %8, %10
+  %13 = phi %System.String addrspace(1)* [ %9, %8 ], [ %11, %10 ]
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %14)
+  %16 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16, %System.String addrspace(1)* %13, %System.String addrspace(1)* %15)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16) #0
+  unreachable
+
+; <label>:17                                      ; preds = %2
+  %18 = load i32, i32* %arg2
+  %19 = icmp slt i32 %18, 0
+  br i1 %19, label %23, label %20
+
+; <label>:20                                      ; preds = %17
+  %21 = load i32, i32* %arg3
+  %22 = icmp sge i32 %21, 0
+  br i1 %22, label %35, label %23
+
+; <label>:23                                      ; preds = %17, %20
+  %24 = load i32, i32* %arg2
+  %25 = icmp slt i32 %24, 0
+  br i1 %25, label %28, label %26
+
+; <label>:26                                      ; preds = %23
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %30
+
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %30
+
+; <label>:30                                      ; preds = %26, %28
+  %31 = phi %System.String addrspace(1)* [ %27, %26 ], [ %29, %28 ]
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34, %System.String addrspace(1)* %31, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %20
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck, label %ThrowNullRef, label %37
+
+; <label>:37                                      ; preds = %35
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = load i32, i32* %arg2
+  %43 = sub i32 %41, %42
+  %44 = load i32, i32* %arg3
+  %45 = icmp sge i32 %43, %44
+  br i1 %45, label %51, label %46
+
+; <label>:46                                      ; preds = %37
+  %47 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %48 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %49 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %48)
+  %50 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %50, %System.String addrspace(1)* %47, %System.String addrspace(1)* %49)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %50) #0
+  unreachable
+
+; <label>:51                                      ; preds = %37
+  %52 = load i32, i32* %arg5
+  %53 = icmp slt i32 %52, 0
+  br i1 %53, label %63, label %54
+
+; <label>:54                                      ; preds = %51
+  %55 = load i32, i32* %arg5
+  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck1 = icmp eq %"System.Byte[]" addrspace(1)* %56, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %57
+
+; <label>:57                                      ; preds = %54
+  %58 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = zext i32 %59 to i64
+  %61 = trunc i64 %60 to i32
+  %62 = icmp sle i32 %55, %61
+  br i1 %62, label %68, label %63
+
+; <label>:63                                      ; preds = %51, %57
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %66 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %65)
+  %67 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %67, %System.String addrspace(1)* %64, %System.String addrspace(1)* %66)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %67) #0
+  unreachable
+
+; <label>:68                                      ; preds = %57
+  %69 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %69, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %69, i32 0, i32 1
+  %72 = load i32, i32 addrspace(1)* %71
+  %73 = zext i32 %72 to i64
+  %74 = trunc i64 %73 to i32
+  %75 = icmp ne i32 %74, 0
+  br i1 %75, label %78, label %76
+
+; <label>:76                                      ; preds = %70
+  %77 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1)
+  store %"System.Char[]" addrspace(1)* %77, %"System.Char[]" addrspace(1)** %arg1
+  br label %78
+
+; <label>:78                                      ; preds = %70, %76
+  %79 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck5 = icmp eq %"System.Byte[]" addrspace(1)* %79, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %80
+
+; <label>:80                                      ; preds = %78
+  %81 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %79, i32 0, i32 1
+  %82 = load i32, i32 addrspace(1)* %81
+  %83 = zext i32 %82 to i64
+  %84 = trunc i64 %83 to i32
+  %85 = load i32, i32* %arg5
+  %86 = sub i32 %84, %85
+  store i32 %86, i32* %loc0
+  %87 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck7 = icmp eq %"System.Byte[]" addrspace(1)* %87, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %88
+
+; <label>:88                                      ; preds = %80
+  %89 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %87, i32 0, i32 1
+  %90 = load i32, i32 addrspace(1)* %89
+  %91 = zext i32 %90 to i64
+  %92 = trunc i64 %91 to i32
+  %93 = icmp ne i32 %92, 0
+  br i1 %93, label %96, label %94
+
+; <label>:94                                      ; preds = %88
+  %95 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1)
+  store %"System.Byte[]" addrspace(1)* %95, %"System.Byte[]" addrspace(1)** %arg4
+  br label %96
+
+; <label>:96                                      ; preds = %88, %94
+  %97 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  store %"System.Char[]" addrspace(1)* %97, %"System.Char[]" addrspace(1)** %loc4
+  %98 = icmp eq %"System.Char[]" addrspace(1)* %97, null
+  br i1 %98, label %107, label %99
+
+; <label>:99                                      ; preds = %96
+  %100 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc4
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %100, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %101
+
+; <label>:101                                     ; preds = %99
+  %102 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %100, i32 0, i32 1
+  %103 = load i32, i32 addrspace(1)* %102
+  %104 = zext i32 %103 to i64
+  %105 = trunc i64 %104 to i32
+  %106 = icmp ne i32 %105, 0
+  br i1 %106, label %108, label %107
+
+; <label>:107                                     ; preds = %96, %101
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  br label %116
+
+; <label>:108                                     ; preds = %101
+  %109 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc4
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %109, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %110
+
+; <label>:110                                     ; preds = %108
+  %111 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %109, i32 0, i32 1
+  %112 = load i32, i32 addrspace(1)* %111
+  %113 = zext i32 %112 to i64
+  %BoundsCheck = icmp uge i64 0, %113
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %114
+
+; <label>:114                                     ; preds = %110
+  %115 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %109, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %115, i16 addrspace(1)** %loc1
+  br label %116
+
+; <label>:116                                     ; preds = %107, %114
+  %117 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  store %"System.Byte[]" addrspace(1)* %117, %"System.Byte[]" addrspace(1)** %loc5
+  %118 = icmp eq %"System.Byte[]" addrspace(1)* %117, null
+  br i1 %118, label %127, label %119
+
+; <label>:119                                     ; preds = %116
+  %120 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc5
+  %NullCheck13 = icmp eq %"System.Byte[]" addrspace(1)* %120, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %121
+
+; <label>:121                                     ; preds = %119
+  %122 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %120, i32 0, i32 1
+  %123 = load i32, i32 addrspace(1)* %122
+  %124 = zext i32 %123 to i64
+  %125 = trunc i64 %124 to i32
+  %126 = icmp ne i32 %125, 0
+  br i1 %126, label %128, label %127
+
+; <label>:127                                     ; preds = %116, %121
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc2
+  br label %136
+
+; <label>:128                                     ; preds = %121
+  %129 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc5
+  %NullCheck15 = icmp eq %"System.Byte[]" addrspace(1)* %129, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %130
+
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %129, i32 0, i32 1
+  %132 = load i32, i32 addrspace(1)* %131
+  %133 = zext i32 %132 to i64
+  %BoundsCheck17 = icmp uge i64 0, %133
+  br i1 %BoundsCheck17, label %ThrowIndexOutOfRange18, label %134
+
+; <label>:134                                     ; preds = %130
+  %135 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %129, i32 0, i32 3, i32 0
+  store i8 addrspace(1)* %135, i8 addrspace(1)** %loc2
+  br label %136
+
+; <label>:136                                     ; preds = %127, %134
+  %137 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %138 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %139 = ptrtoint i16 addrspace(1)* %138 to i64
+  %140 = load i32, i32* %arg2
+  %141 = sext i32 %140 to i64
+  %142 = mul i64 %141, 2
+  %143 = add i64 %139, %142
+  %144 = load i32, i32* %arg3
+  %145 = load i8 addrspace(1)*, i8 addrspace(1)** %loc2
+  %146 = ptrtoint i8 addrspace(1)* %145 to i64
+  %147 = load i32, i32* %arg5
+  %148 = sext i32 %147 to i64
+  %149 = add i64 %146, %148
+  %150 = load i32, i32* %loc0
+  %151 = load i8, i8* %arg6
+  %152 = zext i8 %151 to i32
+  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i64 addrspace(1)*
+  %NullCheck19 = icmp eq i64 addrspace(1)* %153, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %154
+
+; <label>:154                                     ; preds = %136
+  %155 = load i64, i64 addrspace(1)* %153
+  %156 = add i64 %155, 72
+  %157 = inttoptr i64 %156 to i64*
+  %158 = load i64, i64* %157
+  %159 = add i64 %158, 0
+  %160 = inttoptr i64 %159 to i64*
+  %161 = load i64, i64* %160
+  %162 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to %System.Text.Encoder addrspace(1)*
+  %163 = inttoptr i64 %143 to i16*
+  %164 = inttoptr i64 %149 to i8*
+  %165 = trunc i32 %152 to i8
+  %166 = inttoptr i64 %161 to i32 (%System.Text.Encoder addrspace(1)*, i16*, i32, i8*, i32, i8)*
+  %167 = call i32 %166(%System.Text.Encoder addrspace(1)* %162, i16* %163, i32 %144, i8* %164, i32 %150, i8 %165)
+  store i32 %167, i32* %loc3
+  br label %168
+
+; <label>:168                                     ; preds = %154
+  %169 = load i32, i32* %loc3
+  ret i32 %169
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %110
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %119
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange18:                           ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
 Successfully read EncoderNLS.GetBytes
 
@@ -14916,22 +17193,22 @@ entry:
   %40 = load i8, i8* %arg5
   %41 = zext i8 %40 to i32
   %42 = trunc i32 %41 to i8
-  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %39, null
-  br i1 %NullCheck, label %43, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderNLS addrspace(1)* %39, null
+  br i1 %NullCheck, label %ThrowNullRef, label %43
 
 ; <label>:43                                      ; preds = %38
   %44 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
   store i8 %42, i8 addrspace(1)* %44
   %45 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %45, null
-  br i1 %NullCheck2, label %46, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.EncoderNLS addrspace(1)* %45, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %46
 
 ; <label>:46                                      ; preds = %43
   %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %45, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %47
   %48 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.EncoderNLS addrspace(1)* %48, null
-  br i1 %NullCheck4, label %49, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.EncoderNLS addrspace(1)* %48, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %49
 
 ; <label>:49                                      ; preds = %46
   %50 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %48, i32 0, i32 3
@@ -14942,8 +17219,8 @@ entry:
   %55 = load i32, i32* %arg4
   %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck6, label %58, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
   %59 = load i64, i64 addrspace(1)* %57
@@ -14961,15 +17238,15 @@ ThrowNullRef:                                     ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %43
+ThrowNullRef2:                                    ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %46
+ThrowNullRef4:                                    ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %49
+ThrowNullRef6:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14997,8 +17274,8 @@ entry:
   %4 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0 to %System.IO.ConsoleStream addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*)(%System.IO.ConsoleStream addrspace(1)* %4, %"System.Byte[]" addrspace(1)* %1, i32 %2, i32 %3)
   %5 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
@@ -15083,8 +17360,8 @@ entry:
 
 ; <label>:22                                      ; preds = %8
   %23 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %23, null
-  br i1 %NullCheck, label %24, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Byte[]" addrspace(1)* %23, null
+  br i1 %NullCheck, label %ThrowNullRef, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
@@ -15106,8 +17383,8 @@ entry:
 
 ; <label>:36                                      ; preds = %24
   %37 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %37, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.ConsoleStream addrspace(1)* %37, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %37, i32 0, i32 4
@@ -15128,13 +17405,138 @@ ThrowNullRef:                                     ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %36
+ThrowNullRef2:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
-Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
+Successfully read WindowsConsoleStream.WriteFileNative
+
+define i32 @WindowsConsoleStream.WriteFileNative(i64 %param0, %"System.Byte[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i64
+  %arg1 = alloca %"System.Byte[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i8 addrspace(1)*
+  %loc2 = alloca %"System.Byte[]" addrspace(1)*
+  %loc3 = alloca i32
+  store i64 %param0, i64* %arg0
+  store %"System.Byte[]" addrspace(1)* %param1, %"System.Byte[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Byte[]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = zext i32 %3 to i64
+  %5 = icmp ne i64 %4, 0
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %1
+  ret i32 0
+
+; <label>:7                                       ; preds = %1
+  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  store %"System.Byte[]" addrspace(1)* %8, %"System.Byte[]" addrspace(1)** %loc2
+  %9 = icmp eq %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %9, label %18, label %10
+
+; <label>:10                                      ; preds = %7
+  %11 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc2
+  %NullCheck1 = icmp eq %"System.Byte[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %11, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp ne i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %7, %12
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc1
+  br label %27
+
+; <label>:19                                      ; preds = %12
+  %20 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc2
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %20, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %BoundsCheck = icmp uge i64 0, %24
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %25
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %20, i32 0, i32 3, i32 0
+  store i8 addrspace(1)* %26, i8 addrspace(1)** %loc1
+  br label %27
+
+; <label>:27                                      ; preds = %18, %25
+  %28 = load i64, i64* %arg0
+  %29 = load i8 addrspace(1)*, i8 addrspace(1)** %loc1
+  %30 = ptrtoint i8 addrspace(1)* %29 to i64
+  %31 = load i32, i32* %arg2
+  %32 = sext i32 %31 to i64
+  %33 = add i64 %30, %32
+  %34 = load i32, i32* %arg3
+  %35 = addrspacecast i32* %loc3 to i32 addrspace(1)*
+  %36 = inttoptr i64 %33 to i8*
+  %37 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i8*, i32, i32 addrspace(1)*, i64)*)(i64 %28, i8* %36, i32 %34, i32 addrspace(1)* %35, i64 0)
+  %38 = icmp ugt i32 %37, 0
+  %39 = sext i1 %38 to i32
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc1
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %42, label %41
+
+; <label>:41                                      ; preds = %27
+  ret i32 0
+
+; <label>:42                                      ; preds = %27
+  %43 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  store i32 %43, i32* %loc0
+  %44 = load i32, i32* %loc0
+  %45 = icmp eq i32 %44, 232
+  br i1 %45, label %49, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = load i32, i32* %loc0
+  %48 = icmp ne i32 %47, 109
+  br i1 %48, label %50, label %49
+
+; <label>:49                                      ; preds = %42, %46
+  ret i32 0
+
+; <label>:50                                      ; preds = %46
+  %51 = load i32, i32* %loc0
+  ret i32 %51
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
 Successfully read WindowsConsoleStream.Flush
 
@@ -15143,8 +17545,8 @@ entry:
   %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
   store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
@@ -15179,8 +17581,8 @@ entry:
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
   %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load i64, i64 addrspace(1)* %1
@@ -15219,15 +17621,15 @@ entry:
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.TextWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
   %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %3, align 8
   %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
   %7 = load i64, i64 addrspace(1)* %5
@@ -15245,7 +17647,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -15274,8 +17676,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %4)
   store i32 0, i32* %loc0
   %5 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Char[]" addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
@@ -15287,15 +17689,15 @@ entry:
 
 ; <label>:11                                      ; preds = %69
   %12 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %12, i32 0, i32 9
   %15 = load i32, i32 addrspace(1)* %14, align 8
   %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.IO.StreamWriter addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %16, i32 0, i32 10
@@ -15310,15 +17712,15 @@ entry:
 
 ; <label>:23                                      ; preds = %17, %21
   %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %24, null
-  br i1 %NullCheck8, label %25, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %24, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 10
   %27 = load i32, i32 addrspace(1)* %26, align 8
   %28 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %28, null
-  br i1 %NullCheck10, label %29, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.StreamWriter addrspace(1)* %28, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %28, i32 0, i32 9
@@ -15340,15 +17742,15 @@ entry:
   %40 = load i32, i32* %loc0
   %41 = mul i32 %40, 2
   %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
-  br i1 %NullCheck12, label %43, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %43
 
 ; <label>:43                                      ; preds = %38
   %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 7
   %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %44, align 8
   %46 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %46, null
-  br i1 %NullCheck14, label %47, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.IO.StreamWriter addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %47
 
 ; <label>:47                                      ; preds = %43
   %48 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %46, i32 0, i32 9
@@ -15360,16 +17762,16 @@ entry:
   %54 = bitcast %"System.Char[]" addrspace(1)* %45 to %System.Array addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %53, i32 %41, %System.Array addrspace(1)* %54, i32 %50, i32 %52)
   %55 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
-  br i1 %NullCheck16, label %56, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %56
 
 ; <label>:56                                      ; preds = %47
   %57 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
   %58 = load i32, i32 addrspace(1)* %57, align 8
   %59 = load i32, i32* %loc2
   %60 = add i32 %58, %59
-  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
-  br i1 %NullCheck18, label %61, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %61
 
 ; <label>:61                                      ; preds = %56
   %62 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
@@ -15391,8 +17793,8 @@ entry:
 
 ; <label>:72                                      ; preds = %69
   %73 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %73, null
-  br i1 %NullCheck2, label %74, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %73, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %74
 
 ; <label>:74                                      ; preds = %72
   %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %73, i32 0, i32 11
@@ -15413,39 +17815,39 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %72
+ThrowNullRef2:                                    ; preds = %72
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %23
+ThrowNullRef8:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef10:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %43
+ThrowNullRef14:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %47
+ThrowNullRef16:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %56
+ThrowNullRef18:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblRem.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblRem.error.txt
@@ -25,8 +25,8 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
@@ -40,8 +40,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
   %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
@@ -75,7 +75,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -90,8 +90,8 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %NullCheck = icmp ne i8 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = load i8, i8 addrspace(1)* %0, align 8
@@ -125,8 +125,8 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
@@ -159,8 +159,8 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -184,8 +184,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
   store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
@@ -195,8 +195,8 @@ entry:
 ; <label>:4                                       ; preds = %1
   %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
   %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
@@ -206,8 +206,8 @@ entry:
   %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
@@ -221,14 +221,14 @@ entry:
 
 ; <label>:17                                      ; preds = %14
   %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
   %21 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
@@ -238,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -249,8 +249,8 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
@@ -261,27 +261,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %30
+ThrowNullRef10:                                   ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -301,7 +301,89 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
-Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
+Successfully read AppDomainSetup.GetUnsecureApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.GetUnsecureApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %NullCheck = icmp eq %"System.String[]" addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %BoundsCheck = icmp uge i64 0, %5
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %6
+
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 3, i32 0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
+  ret %System.String addrspace(1)* %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_Value using LLILCJit
+Successfully read AppDomainSetup.get_Value
+
+define %"System.String[]" addrspace(1)* @AppDomainSetup.get_Value(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.String[]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 18)
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.String[]" addrspace(1)* addrspace(1)*, %"System.String[]" addrspace(1)*)*)(%"System.String[]" addrspace(1)* addrspace(1)* %9, %"System.String[]" addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %11, i32 0, i32 1
+  %14 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %13, align 8
+  ret %"System.String[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -319,8 +401,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -368,16 +450,16 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
   %5 = load i32, i32 addrspace(1)* %4
   %6 = sub i32 %5, 1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -389,7 +471,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -421,8 +503,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
@@ -456,8 +538,8 @@ entry:
 ; <label>:27                                      ; preds = %19
   %28 = load i32, i32* %arg1
   %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
-  br i1 %NullCheck2, label %30, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %29, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %30
 
 ; <label>:30                                      ; preds = %27
   %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
@@ -493,8 +575,8 @@ entry:
 ; <label>:49                                      ; preds = %46
   %50 = load i32, i32* %arg2
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck4, label %52, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
@@ -517,11 +599,11 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %27
+ThrowNullRef2:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %49
+ThrowNullRef4:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -544,16 +626,16 @@ entry:
   %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %0)
   store %System.String addrspace(1)* %1, %System.String addrspace(1)** %loc0
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 2
   %5 = bitcast [0 x i16] addrspace(1)* %4 to i16 addrspace(1)*
   store i16 addrspace(1)* %5, i16 addrspace(1)** %loc1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %3
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2
@@ -580,7 +662,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -691,15 +773,15 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %NullCheck132 = icmp ne i8* %21, null
-  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+  %NullCheck131 = icmp eq i8* %21, null
+  br i1 %NullCheck131, label %ThrowNullRef132, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = load i8, i8* %21, align 8
   %24 = zext i8 %23 to i32
   %25 = trunc i32 %24 to i8
-  %NullCheck134 = icmp ne i8* %20, null
-  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+  %NullCheck133 = icmp eq i8* %20, null
+  br i1 %NullCheck133, label %ThrowNullRef134, label %26
 
 ; <label>:26                                      ; preds = %22
   store i8 %25, i8* %20, align 8
@@ -709,16 +791,16 @@ entry:
   %28 = load i8*, i8** %arg0
   %29 = load i8*, i8** %arg1
   %30 = bitcast i8* %29 to i16*
-  %NullCheck128 = icmp ne i16* %30, null
-  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+  %NullCheck127 = icmp eq i16* %30, null
+  br i1 %NullCheck127, label %ThrowNullRef128, label %31
 
 ; <label>:31                                      ; preds = %27
   %32 = load i16, i16* %30, align 8
   %33 = sext i16 %32 to i32
   %34 = bitcast i8* %28 to i16*
   %35 = trunc i32 %33 to i16
-  %NullCheck130 = icmp ne i16* %34, null
-  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+  %NullCheck129 = icmp eq i16* %34, null
+  br i1 %NullCheck129, label %ThrowNullRef130, label %36
 
 ; <label>:36                                      ; preds = %31
   store i16 %35, i16* %34, align 8
@@ -728,16 +810,16 @@ entry:
   %38 = load i8*, i8** %arg0
   %39 = load i8*, i8** %arg1
   %40 = bitcast i8* %39 to i16*
-  %NullCheck120 = icmp ne i16* %40, null
-  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+  %NullCheck119 = icmp eq i16* %40, null
+  br i1 %NullCheck119, label %ThrowNullRef120, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i16, i16* %40, align 8
   %43 = sext i16 %42 to i32
   %44 = bitcast i8* %38 to i16*
   %45 = trunc i32 %43 to i16
-  %NullCheck122 = icmp ne i16* %44, null
-  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+  %NullCheck121 = icmp eq i16* %44, null
+  br i1 %NullCheck121, label %ThrowNullRef122, label %46
 
 ; <label>:46                                      ; preds = %41
   store i16 %45, i16* %44, align 8
@@ -745,15 +827,15 @@ entry:
   %48 = getelementptr inbounds i8, i8* %47, i64 2
   %49 = load i8*, i8** %arg1
   %50 = getelementptr inbounds i8, i8* %49, i64 2
-  %NullCheck124 = icmp ne i8* %50, null
-  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+  %NullCheck123 = icmp eq i8* %50, null
+  br i1 %NullCheck123, label %ThrowNullRef124, label %51
 
 ; <label>:51                                      ; preds = %46
   %52 = load i8, i8* %50, align 8
   %53 = zext i8 %52 to i32
   %54 = trunc i32 %53 to i8
-  %NullCheck126 = icmp ne i8* %48, null
-  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+  %NullCheck125 = icmp eq i8* %48, null
+  br i1 %NullCheck125, label %ThrowNullRef126, label %55
 
 ; <label>:55                                      ; preds = %51
   store i8 %54, i8* %48, align 8
@@ -763,14 +845,14 @@ entry:
   %57 = load i8*, i8** %arg0
   %58 = load i8*, i8** %arg1
   %59 = bitcast i8* %58 to i32*
-  %NullCheck116 = icmp ne i32* %59, null
-  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+  %NullCheck115 = icmp eq i32* %59, null
+  br i1 %NullCheck115, label %ThrowNullRef116, label %60
 
 ; <label>:60                                      ; preds = %56
   %61 = load i32, i32* %59, align 8
   %62 = bitcast i8* %57 to i32*
-  %NullCheck118 = icmp ne i32* %62, null
-  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+  %NullCheck117 = icmp eq i32* %62, null
+  br i1 %NullCheck117, label %ThrowNullRef118, label %63
 
 ; <label>:63                                      ; preds = %60
   store i32 %61, i32* %62, align 8
@@ -780,14 +862,14 @@ entry:
   %65 = load i8*, i8** %arg0
   %66 = load i8*, i8** %arg1
   %67 = bitcast i8* %66 to i32*
-  %NullCheck108 = icmp ne i32* %67, null
-  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+  %NullCheck107 = icmp eq i32* %67, null
+  br i1 %NullCheck107, label %ThrowNullRef108, label %68
 
 ; <label>:68                                      ; preds = %64
   %69 = load i32, i32* %67, align 8
   %70 = bitcast i8* %65 to i32*
-  %NullCheck110 = icmp ne i32* %70, null
-  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+  %NullCheck109 = icmp eq i32* %70, null
+  br i1 %NullCheck109, label %ThrowNullRef110, label %71
 
 ; <label>:71                                      ; preds = %68
   store i32 %69, i32* %70, align 8
@@ -795,15 +877,15 @@ entry:
   %73 = getelementptr inbounds i8, i8* %72, i64 4
   %74 = load i8*, i8** %arg1
   %75 = getelementptr inbounds i8, i8* %74, i64 4
-  %NullCheck112 = icmp ne i8* %75, null
-  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+  %NullCheck111 = icmp eq i8* %75, null
+  br i1 %NullCheck111, label %ThrowNullRef112, label %76
 
 ; <label>:76                                      ; preds = %71
   %77 = load i8, i8* %75, align 8
   %78 = zext i8 %77 to i32
   %79 = trunc i32 %78 to i8
-  %NullCheck114 = icmp ne i8* %73, null
-  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+  %NullCheck113 = icmp eq i8* %73, null
+  br i1 %NullCheck113, label %ThrowNullRef114, label %80
 
 ; <label>:80                                      ; preds = %76
   store i8 %79, i8* %73, align 8
@@ -813,14 +895,14 @@ entry:
   %82 = load i8*, i8** %arg0
   %83 = load i8*, i8** %arg1
   %84 = bitcast i8* %83 to i32*
-  %NullCheck100 = icmp ne i32* %84, null
-  br i1 %NullCheck100, label %85, label %ThrowNullRef99
+  %NullCheck99 = icmp eq i32* %84, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %85
 
 ; <label>:85                                      ; preds = %81
   %86 = load i32, i32* %84, align 8
   %87 = bitcast i8* %82 to i32*
-  %NullCheck102 = icmp ne i32* %87, null
-  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+  %NullCheck101 = icmp eq i32* %87, null
+  br i1 %NullCheck101, label %ThrowNullRef102, label %88
 
 ; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
@@ -829,16 +911,16 @@ entry:
   %91 = load i8*, i8** %arg1
   %92 = getelementptr inbounds i8, i8* %91, i64 4
   %93 = bitcast i8* %92 to i16*
-  %NullCheck104 = icmp ne i16* %93, null
-  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+  %NullCheck103 = icmp eq i16* %93, null
+  br i1 %NullCheck103, label %ThrowNullRef104, label %94
 
 ; <label>:94                                      ; preds = %88
   %95 = load i16, i16* %93, align 8
   %96 = sext i16 %95 to i32
   %97 = bitcast i8* %90 to i16*
   %98 = trunc i32 %96 to i16
-  %NullCheck106 = icmp ne i16* %97, null
-  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+  %NullCheck105 = icmp eq i16* %97, null
+  br i1 %NullCheck105, label %ThrowNullRef106, label %99
 
 ; <label>:99                                      ; preds = %94
   store i16 %98, i16* %97, align 8
@@ -848,14 +930,14 @@ entry:
   %101 = load i8*, i8** %arg0
   %102 = load i8*, i8** %arg1
   %103 = bitcast i8* %102 to i32*
-  %NullCheck88 = icmp ne i32* %103, null
-  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+  %NullCheck87 = icmp eq i32* %103, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %104
 
 ; <label>:104                                     ; preds = %100
   %105 = load i32, i32* %103, align 8
   %106 = bitcast i8* %101 to i32*
-  %NullCheck90 = icmp ne i32* %106, null
-  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+  %NullCheck89 = icmp eq i32* %106, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %107
 
 ; <label>:107                                     ; preds = %104
   store i32 %105, i32* %106, align 8
@@ -864,16 +946,16 @@ entry:
   %110 = load i8*, i8** %arg1
   %111 = getelementptr inbounds i8, i8* %110, i64 4
   %112 = bitcast i8* %111 to i16*
-  %NullCheck92 = icmp ne i16* %112, null
-  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+  %NullCheck91 = icmp eq i16* %112, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %113
 
 ; <label>:113                                     ; preds = %107
   %114 = load i16, i16* %112, align 8
   %115 = sext i16 %114 to i32
   %116 = bitcast i8* %109 to i16*
   %117 = trunc i32 %115 to i16
-  %NullCheck94 = icmp ne i16* %116, null
-  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+  %NullCheck93 = icmp eq i16* %116, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %118
 
 ; <label>:118                                     ; preds = %113
   store i16 %117, i16* %116, align 8
@@ -881,15 +963,15 @@ entry:
   %120 = getelementptr inbounds i8, i8* %119, i64 6
   %121 = load i8*, i8** %arg1
   %122 = getelementptr inbounds i8, i8* %121, i64 6
-  %NullCheck96 = icmp ne i8* %122, null
-  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+  %NullCheck95 = icmp eq i8* %122, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %123
 
 ; <label>:123                                     ; preds = %118
   %124 = load i8, i8* %122, align 8
   %125 = zext i8 %124 to i32
   %126 = trunc i32 %125 to i8
-  %NullCheck98 = icmp ne i8* %120, null
-  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+  %NullCheck97 = icmp eq i8* %120, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %127
 
 ; <label>:127                                     ; preds = %123
   store i8 %126, i8* %120, align 8
@@ -899,14 +981,14 @@ entry:
   %129 = load i8*, i8** %arg0
   %130 = load i8*, i8** %arg1
   %131 = bitcast i8* %130 to i64*
-  %NullCheck84 = icmp ne i64* %131, null
-  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+  %NullCheck83 = icmp eq i64* %131, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %132
 
 ; <label>:132                                     ; preds = %128
   %133 = load i64, i64* %131, align 8
   %134 = bitcast i8* %129 to i64*
-  %NullCheck86 = icmp ne i64* %134, null
-  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+  %NullCheck85 = icmp eq i64* %134, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %135
 
 ; <label>:135                                     ; preds = %132
   store i64 %133, i64* %134, align 8
@@ -916,14 +998,14 @@ entry:
   %137 = load i8*, i8** %arg0
   %138 = load i8*, i8** %arg1
   %139 = bitcast i8* %138 to i64*
-  %NullCheck76 = icmp ne i64* %139, null
-  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+  %NullCheck75 = icmp eq i64* %139, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %140
 
 ; <label>:140                                     ; preds = %136
   %141 = load i64, i64* %139, align 8
   %142 = bitcast i8* %137 to i64*
-  %NullCheck78 = icmp ne i64* %142, null
-  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+  %NullCheck77 = icmp eq i64* %142, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %143
 
 ; <label>:143                                     ; preds = %140
   store i64 %141, i64* %142, align 8
@@ -931,15 +1013,15 @@ entry:
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %NullCheck80 = icmp ne i8* %147, null
-  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+  %NullCheck79 = icmp eq i8* %147, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %148
 
 ; <label>:148                                     ; preds = %143
   %149 = load i8, i8* %147, align 8
   %150 = zext i8 %149 to i32
   %151 = trunc i32 %150 to i8
-  %NullCheck82 = icmp ne i8* %145, null
-  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+  %NullCheck81 = icmp eq i8* %145, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %152
 
 ; <label>:152                                     ; preds = %148
   store i8 %151, i8* %145, align 8
@@ -949,14 +1031,14 @@ entry:
   %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
   %156 = bitcast i8* %155 to i64*
-  %NullCheck68 = icmp ne i64* %156, null
-  br i1 %NullCheck68, label %157, label %ThrowNullRef67
+  %NullCheck67 = icmp eq i64* %156, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %157
 
 ; <label>:157                                     ; preds = %153
   %158 = load i64, i64* %156, align 8
   %159 = bitcast i8* %154 to i64*
-  %NullCheck70 = icmp ne i64* %159, null
-  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+  %NullCheck69 = icmp eq i64* %159, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %160
 
 ; <label>:160                                     ; preds = %157
   store i64 %158, i64* %159, align 8
@@ -965,16 +1047,16 @@ entry:
   %163 = load i8*, i8** %arg1
   %164 = getelementptr inbounds i8, i8* %163, i64 8
   %165 = bitcast i8* %164 to i16*
-  %NullCheck72 = icmp ne i16* %165, null
-  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+  %NullCheck71 = icmp eq i16* %165, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %166
 
 ; <label>:166                                     ; preds = %160
   %167 = load i16, i16* %165, align 8
   %168 = sext i16 %167 to i32
   %169 = bitcast i8* %162 to i16*
   %170 = trunc i32 %168 to i16
-  %NullCheck74 = icmp ne i16* %169, null
-  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+  %NullCheck73 = icmp eq i16* %169, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %171
 
 ; <label>:171                                     ; preds = %166
   store i16 %170, i16* %169, align 8
@@ -984,14 +1066,14 @@ entry:
   %173 = load i8*, i8** %arg0
   %174 = load i8*, i8** %arg1
   %175 = bitcast i8* %174 to i64*
-  %NullCheck56 = icmp ne i64* %175, null
-  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+  %NullCheck55 = icmp eq i64* %175, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %176
 
 ; <label>:176                                     ; preds = %172
   %177 = load i64, i64* %175, align 8
   %178 = bitcast i8* %173 to i64*
-  %NullCheck58 = icmp ne i64* %178, null
-  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+  %NullCheck57 = icmp eq i64* %178, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %179
 
 ; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
@@ -1000,16 +1082,16 @@ entry:
   %182 = load i8*, i8** %arg1
   %183 = getelementptr inbounds i8, i8* %182, i64 8
   %184 = bitcast i8* %183 to i16*
-  %NullCheck60 = icmp ne i16* %184, null
-  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+  %NullCheck59 = icmp eq i16* %184, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %185
 
 ; <label>:185                                     ; preds = %179
   %186 = load i16, i16* %184, align 8
   %187 = sext i16 %186 to i32
   %188 = bitcast i8* %181 to i16*
   %189 = trunc i32 %187 to i16
-  %NullCheck62 = icmp ne i16* %188, null
-  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+  %NullCheck61 = icmp eq i16* %188, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %190
 
 ; <label>:190                                     ; preds = %185
   store i16 %189, i16* %188, align 8
@@ -1017,15 +1099,15 @@ entry:
   %192 = getelementptr inbounds i8, i8* %191, i64 10
   %193 = load i8*, i8** %arg1
   %194 = getelementptr inbounds i8, i8* %193, i64 10
-  %NullCheck64 = icmp ne i8* %194, null
-  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+  %NullCheck63 = icmp eq i8* %194, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %195
 
 ; <label>:195                                     ; preds = %190
   %196 = load i8, i8* %194, align 8
   %197 = zext i8 %196 to i32
   %198 = trunc i32 %197 to i8
-  %NullCheck66 = icmp ne i8* %192, null
-  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+  %NullCheck65 = icmp eq i8* %192, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %199
 
 ; <label>:199                                     ; preds = %195
   store i8 %198, i8* %192, align 8
@@ -1035,14 +1117,14 @@ entry:
   %201 = load i8*, i8** %arg0
   %202 = load i8*, i8** %arg1
   %203 = bitcast i8* %202 to i64*
-  %NullCheck48 = icmp ne i64* %203, null
-  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+  %NullCheck47 = icmp eq i64* %203, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %204
 
 ; <label>:204                                     ; preds = %200
   %205 = load i64, i64* %203, align 8
   %206 = bitcast i8* %201 to i64*
-  %NullCheck50 = icmp ne i64* %206, null
-  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+  %NullCheck49 = icmp eq i64* %206, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %207
 
 ; <label>:207                                     ; preds = %204
   store i64 %205, i64* %206, align 8
@@ -1051,14 +1133,14 @@ entry:
   %210 = load i8*, i8** %arg1
   %211 = getelementptr inbounds i8, i8* %210, i64 8
   %212 = bitcast i8* %211 to i32*
-  %NullCheck52 = icmp ne i32* %212, null
-  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+  %NullCheck51 = icmp eq i32* %212, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %213
 
 ; <label>:213                                     ; preds = %207
   %214 = load i32, i32* %212, align 8
   %215 = bitcast i8* %209 to i32*
-  %NullCheck54 = icmp ne i32* %215, null
-  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+  %NullCheck53 = icmp eq i32* %215, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %216
 
 ; <label>:216                                     ; preds = %213
   store i32 %214, i32* %215, align 8
@@ -1068,14 +1150,14 @@ entry:
   %218 = load i8*, i8** %arg0
   %219 = load i8*, i8** %arg1
   %220 = bitcast i8* %219 to i64*
-  %NullCheck36 = icmp ne i64* %220, null
-  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64* %220, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %221
 
 ; <label>:221                                     ; preds = %217
   %222 = load i64, i64* %220, align 8
   %223 = bitcast i8* %218 to i64*
-  %NullCheck38 = icmp ne i64* %223, null
-  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+  %NullCheck37 = icmp eq i64* %223, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %224
 
 ; <label>:224                                     ; preds = %221
   store i64 %222, i64* %223, align 8
@@ -1084,14 +1166,14 @@ entry:
   %227 = load i8*, i8** %arg1
   %228 = getelementptr inbounds i8, i8* %227, i64 8
   %229 = bitcast i8* %228 to i32*
-  %NullCheck40 = icmp ne i32* %229, null
-  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i32* %229, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %230
 
 ; <label>:230                                     ; preds = %224
   %231 = load i32, i32* %229, align 8
   %232 = bitcast i8* %226 to i32*
-  %NullCheck42 = icmp ne i32* %232, null
-  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+  %NullCheck41 = icmp eq i32* %232, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %233
 
 ; <label>:233                                     ; preds = %230
   store i32 %231, i32* %232, align 8
@@ -1099,15 +1181,15 @@ entry:
   %235 = getelementptr inbounds i8, i8* %234, i64 12
   %236 = load i8*, i8** %arg1
   %237 = getelementptr inbounds i8, i8* %236, i64 12
-  %NullCheck44 = icmp ne i8* %237, null
-  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i8* %237, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %238
 
 ; <label>:238                                     ; preds = %233
   %239 = load i8, i8* %237, align 8
   %240 = zext i8 %239 to i32
   %241 = trunc i32 %240 to i8
-  %NullCheck46 = icmp ne i8* %235, null
-  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+  %NullCheck45 = icmp eq i8* %235, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %242
 
 ; <label>:242                                     ; preds = %238
   store i8 %241, i8* %235, align 8
@@ -1117,14 +1199,14 @@ entry:
   %244 = load i8*, i8** %arg0
   %245 = load i8*, i8** %arg1
   %246 = bitcast i8* %245 to i64*
-  %NullCheck24 = icmp ne i64* %246, null
-  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64* %246, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %247
 
 ; <label>:247                                     ; preds = %243
   %248 = load i64, i64* %246, align 8
   %249 = bitcast i8* %244 to i64*
-  %NullCheck26 = icmp ne i64* %249, null
-  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64* %249, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %250
 
 ; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
@@ -1133,14 +1215,14 @@ entry:
   %253 = load i8*, i8** %arg1
   %254 = getelementptr inbounds i8, i8* %253, i64 8
   %255 = bitcast i8* %254 to i32*
-  %NullCheck28 = icmp ne i32* %255, null
-  br i1 %NullCheck28, label %256, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i32* %255, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %256
 
 ; <label>:256                                     ; preds = %250
   %257 = load i32, i32* %255, align 8
   %258 = bitcast i8* %252 to i32*
-  %NullCheck30 = icmp ne i32* %258, null
-  br i1 %NullCheck30, label %259, label %ThrowNullRef29
+  %NullCheck29 = icmp eq i32* %258, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %259
 
 ; <label>:259                                     ; preds = %256
   store i32 %257, i32* %258, align 8
@@ -1149,16 +1231,16 @@ entry:
   %262 = load i8*, i8** %arg1
   %263 = getelementptr inbounds i8, i8* %262, i64 12
   %264 = bitcast i8* %263 to i16*
-  %NullCheck32 = icmp ne i16* %264, null
-  br i1 %NullCheck32, label %265, label %ThrowNullRef31
+  %NullCheck31 = icmp eq i16* %264, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %265
 
 ; <label>:265                                     ; preds = %259
   %266 = load i16, i16* %264, align 8
   %267 = sext i16 %266 to i32
   %268 = bitcast i8* %261 to i16*
   %269 = trunc i32 %267 to i16
-  %NullCheck34 = icmp ne i16* %268, null
-  br i1 %NullCheck34, label %270, label %ThrowNullRef33
+  %NullCheck33 = icmp eq i16* %268, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %270
 
 ; <label>:270                                     ; preds = %265
   store i16 %269, i16* %268, align 8
@@ -1168,14 +1250,14 @@ entry:
   %272 = load i8*, i8** %arg0
   %273 = load i8*, i8** %arg1
   %274 = bitcast i8* %273 to i64*
-  %NullCheck8 = icmp ne i64* %274, null
-  br i1 %NullCheck8, label %275, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64* %274, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %275
 
 ; <label>:275                                     ; preds = %271
   %276 = load i64, i64* %274, align 8
   %277 = bitcast i8* %272 to i64*
-  %NullCheck10 = icmp ne i64* %277, null
-  br i1 %NullCheck10, label %278, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %277, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %278
 
 ; <label>:278                                     ; preds = %275
   store i64 %276, i64* %277, align 8
@@ -1184,14 +1266,14 @@ entry:
   %281 = load i8*, i8** %arg1
   %282 = getelementptr inbounds i8, i8* %281, i64 8
   %283 = bitcast i8* %282 to i32*
-  %NullCheck12 = icmp ne i32* %283, null
-  br i1 %NullCheck12, label %284, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i32* %283, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %284
 
 ; <label>:284                                     ; preds = %278
   %285 = load i32, i32* %283, align 8
   %286 = bitcast i8* %280 to i32*
-  %NullCheck14 = icmp ne i32* %286, null
-  br i1 %NullCheck14, label %287, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i32* %286, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %287
 
 ; <label>:287                                     ; preds = %284
   store i32 %285, i32* %286, align 8
@@ -1200,16 +1282,16 @@ entry:
   %290 = load i8*, i8** %arg1
   %291 = getelementptr inbounds i8, i8* %290, i64 12
   %292 = bitcast i8* %291 to i16*
-  %NullCheck16 = icmp ne i16* %292, null
-  br i1 %NullCheck16, label %293, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i16* %292, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %293
 
 ; <label>:293                                     ; preds = %287
   %294 = load i16, i16* %292, align 8
   %295 = sext i16 %294 to i32
   %296 = bitcast i8* %289 to i16*
   %297 = trunc i32 %295 to i16
-  %NullCheck18 = icmp ne i16* %296, null
-  br i1 %NullCheck18, label %298, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i16* %296, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %298
 
 ; <label>:298                                     ; preds = %293
   store i16 %297, i16* %296, align 8
@@ -1217,15 +1299,15 @@ entry:
   %300 = getelementptr inbounds i8, i8* %299, i64 14
   %301 = load i8*, i8** %arg1
   %302 = getelementptr inbounds i8, i8* %301, i64 14
-  %NullCheck20 = icmp ne i8* %302, null
-  br i1 %NullCheck20, label %303, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i8* %302, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %303
 
 ; <label>:303                                     ; preds = %298
   %304 = load i8, i8* %302, align 8
   %305 = zext i8 %304 to i32
   %306 = trunc i32 %305 to i8
-  %NullCheck22 = icmp ne i8* %300, null
-  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i8* %300, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %307
 
 ; <label>:307                                     ; preds = %303
   store i8 %306, i8* %300, align 8
@@ -1235,14 +1317,14 @@ entry:
   %309 = load i8*, i8** %arg0
   %310 = load i8*, i8** %arg1
   %311 = bitcast i8* %310 to i64*
-  %NullCheck = icmp ne i64* %311, null
-  br i1 %NullCheck, label %312, label %ThrowNullRef
+  %NullCheck = icmp eq i64* %311, null
+  br i1 %NullCheck, label %ThrowNullRef, label %312
 
 ; <label>:312                                     ; preds = %308
   %313 = load i64, i64* %311, align 8
   %314 = bitcast i8* %309 to i64*
-  %NullCheck2 = icmp ne i64* %314, null
-  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64* %314, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %315
 
 ; <label>:315                                     ; preds = %312
   store i64 %313, i64* %314, align 8
@@ -1251,14 +1333,14 @@ entry:
   %318 = load i8*, i8** %arg1
   %319 = getelementptr inbounds i8, i8* %318, i64 8
   %320 = bitcast i8* %319 to i64*
-  %NullCheck4 = icmp ne i64* %320, null
-  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64* %320, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %321
 
 ; <label>:321                                     ; preds = %315
   %322 = load i64, i64* %320, align 8
   %323 = bitcast i8* %317 to i64*
-  %NullCheck6 = icmp ne i64* %323, null
-  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64* %323, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %324
 
 ; <label>:324                                     ; preds = %321
   store i64 %322, i64* %323, align 8
@@ -1286,15 +1368,15 @@ entry:
 ; <label>:338                                     ; preds = %333
   %339 = load i8*, i8** %arg0
   %340 = load i8*, i8** %arg1
-  %NullCheck136 = icmp ne i8* %340, null
-  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+  %NullCheck135 = icmp eq i8* %340, null
+  br i1 %NullCheck135, label %ThrowNullRef136, label %341
 
 ; <label>:341                                     ; preds = %338
   %342 = load i8, i8* %340, align 8
   %343 = zext i8 %342 to i32
   %344 = trunc i32 %343 to i8
-  %NullCheck138 = icmp ne i8* %339, null
-  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+  %NullCheck137 = icmp eq i8* %339, null
+  br i1 %NullCheck137, label %ThrowNullRef138, label %345
 
 ; <label>:345                                     ; preds = %341
   store i8 %344, i8* %339, align 8
@@ -1317,16 +1399,16 @@ entry:
   %357 = load i8*, i8** %arg0
   %358 = load i8*, i8** %arg1
   %359 = bitcast i8* %358 to i16*
-  %NullCheck140 = icmp ne i16* %359, null
-  br i1 %NullCheck140, label %360, label %ThrowNullRef139
+  %NullCheck139 = icmp eq i16* %359, null
+  br i1 %NullCheck139, label %ThrowNullRef140, label %360
 
 ; <label>:360                                     ; preds = %356
   %361 = load i16, i16* %359, align 8
   %362 = sext i16 %361 to i32
   %363 = bitcast i8* %357 to i16*
   %364 = trunc i32 %362 to i16
-  %NullCheck142 = icmp ne i16* %363, null
-  br i1 %NullCheck142, label %365, label %ThrowNullRef141
+  %NullCheck141 = icmp eq i16* %363, null
+  br i1 %NullCheck141, label %ThrowNullRef142, label %365
 
 ; <label>:365                                     ; preds = %360
   store i16 %364, i16* %363, align 8
@@ -1352,14 +1434,14 @@ entry:
   %378 = load i8*, i8** %arg0
   %379 = load i8*, i8** %arg1
   %380 = bitcast i8* %379 to i32*
-  %NullCheck144 = icmp ne i32* %380, null
-  br i1 %NullCheck144, label %381, label %ThrowNullRef143
+  %NullCheck143 = icmp eq i32* %380, null
+  br i1 %NullCheck143, label %ThrowNullRef144, label %381
 
 ; <label>:381                                     ; preds = %377
   %382 = load i32, i32* %380, align 8
   %383 = bitcast i8* %378 to i32*
-  %NullCheck146 = icmp ne i32* %383, null
-  br i1 %NullCheck146, label %384, label %ThrowNullRef145
+  %NullCheck145 = icmp eq i32* %383, null
+  br i1 %NullCheck145, label %ThrowNullRef146, label %384
 
 ; <label>:384                                     ; preds = %381
   store i32 %382, i32* %383, align 8
@@ -1384,14 +1466,14 @@ entry:
   %395 = load i8*, i8** %arg0
   %396 = load i8*, i8** %arg1
   %397 = bitcast i8* %396 to i64*
-  %NullCheck164 = icmp ne i64* %397, null
-  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+  %NullCheck163 = icmp eq i64* %397, null
+  br i1 %NullCheck163, label %ThrowNullRef164, label %398
 
 ; <label>:398                                     ; preds = %394
   %399 = load i64, i64* %397, align 8
   %400 = bitcast i8* %395 to i64*
-  %NullCheck166 = icmp ne i64* %400, null
-  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+  %NullCheck165 = icmp eq i64* %400, null
+  br i1 %NullCheck165, label %ThrowNullRef166, label %401
 
 ; <label>:401                                     ; preds = %398
   store i64 %399, i64* %400, align 8
@@ -1400,14 +1482,14 @@ entry:
   %404 = load i8*, i8** %arg1
   %405 = getelementptr inbounds i8, i8* %404, i64 8
   %406 = bitcast i8* %405 to i64*
-  %NullCheck168 = icmp ne i64* %406, null
-  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+  %NullCheck167 = icmp eq i64* %406, null
+  br i1 %NullCheck167, label %ThrowNullRef168, label %407
 
 ; <label>:407                                     ; preds = %401
   %408 = load i64, i64* %406, align 8
   %409 = bitcast i8* %403 to i64*
-  %NullCheck170 = icmp ne i64* %409, null
-  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+  %NullCheck169 = icmp eq i64* %409, null
+  br i1 %NullCheck169, label %ThrowNullRef170, label %410
 
 ; <label>:410                                     ; preds = %407
   store i64 %408, i64* %409, align 8
@@ -1437,14 +1519,14 @@ entry:
   %425 = load i8*, i8** %arg0
   %426 = load i8*, i8** %arg1
   %427 = bitcast i8* %426 to i64*
-  %NullCheck148 = icmp ne i64* %427, null
-  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+  %NullCheck147 = icmp eq i64* %427, null
+  br i1 %NullCheck147, label %ThrowNullRef148, label %428
 
 ; <label>:428                                     ; preds = %424
   %429 = load i64, i64* %427, align 8
   %430 = bitcast i8* %425 to i64*
-  %NullCheck150 = icmp ne i64* %430, null
-  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+  %NullCheck149 = icmp eq i64* %430, null
+  br i1 %NullCheck149, label %ThrowNullRef150, label %431
 
 ; <label>:431                                     ; preds = %428
   store i64 %429, i64* %430, align 8
@@ -1466,14 +1548,14 @@ entry:
   %441 = load i8*, i8** %arg0
   %442 = load i8*, i8** %arg1
   %443 = bitcast i8* %442 to i32*
-  %NullCheck152 = icmp ne i32* %443, null
-  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+  %NullCheck151 = icmp eq i32* %443, null
+  br i1 %NullCheck151, label %ThrowNullRef152, label %444
 
 ; <label>:444                                     ; preds = %440
   %445 = load i32, i32* %443, align 8
   %446 = bitcast i8* %441 to i32*
-  %NullCheck154 = icmp ne i32* %446, null
-  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+  %NullCheck153 = icmp eq i32* %446, null
+  br i1 %NullCheck153, label %ThrowNullRef154, label %447
 
 ; <label>:447                                     ; preds = %444
   store i32 %445, i32* %446, align 8
@@ -1495,16 +1577,16 @@ entry:
   %457 = load i8*, i8** %arg0
   %458 = load i8*, i8** %arg1
   %459 = bitcast i8* %458 to i16*
-  %NullCheck156 = icmp ne i16* %459, null
-  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+  %NullCheck155 = icmp eq i16* %459, null
+  br i1 %NullCheck155, label %ThrowNullRef156, label %460
 
 ; <label>:460                                     ; preds = %456
   %461 = load i16, i16* %459, align 8
   %462 = sext i16 %461 to i32
   %463 = bitcast i8* %457 to i16*
   %464 = trunc i32 %462 to i16
-  %NullCheck158 = icmp ne i16* %463, null
-  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+  %NullCheck157 = icmp eq i16* %463, null
+  br i1 %NullCheck157, label %ThrowNullRef158, label %465
 
 ; <label>:465                                     ; preds = %460
   store i16 %464, i16* %463, align 8
@@ -1525,15 +1607,15 @@ entry:
 ; <label>:474                                     ; preds = %470
   %475 = load i8*, i8** %arg0
   %476 = load i8*, i8** %arg1
-  %NullCheck160 = icmp ne i8* %476, null
-  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+  %NullCheck159 = icmp eq i8* %476, null
+  br i1 %NullCheck159, label %ThrowNullRef160, label %477
 
 ; <label>:477                                     ; preds = %474
   %478 = load i8, i8* %476, align 8
   %479 = zext i8 %478 to i32
   %480 = trunc i32 %479 to i8
-  %NullCheck162 = icmp ne i8* %475, null
-  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+  %NullCheck161 = icmp eq i8* %475, null
+  br i1 %NullCheck161, label %ThrowNullRef162, label %481
 
 ; <label>:481                                     ; preds = %477
   store i8 %480, i8* %475, align 8
@@ -1553,343 +1635,343 @@ ThrowNullRef:                                     ; preds = %308
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %312
+ThrowNullRef2:                                    ; preds = %312
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %315
+ThrowNullRef4:                                    ; preds = %315
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %321
+ThrowNullRef6:                                    ; preds = %321
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %271
+ThrowNullRef8:                                    ; preds = %271
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %275
+ThrowNullRef10:                                   ; preds = %275
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %278
+ThrowNullRef12:                                   ; preds = %278
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %284
+ThrowNullRef14:                                   ; preds = %284
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %287
+ThrowNullRef16:                                   ; preds = %287
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %293
+ThrowNullRef18:                                   ; preds = %293
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %298
+ThrowNullRef20:                                   ; preds = %298
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %303
+ThrowNullRef22:                                   ; preds = %303
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %243
+ThrowNullRef24:                                   ; preds = %243
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %247
+ThrowNullRef26:                                   ; preds = %247
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %250
+ThrowNullRef28:                                   ; preds = %250
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %256
+ThrowNullRef30:                                   ; preds = %256
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %259
+ThrowNullRef32:                                   ; preds = %259
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %265
+ThrowNullRef34:                                   ; preds = %265
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %217
+ThrowNullRef36:                                   ; preds = %217
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %221
+ThrowNullRef38:                                   ; preds = %221
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %224
+ThrowNullRef40:                                   ; preds = %224
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %230
+ThrowNullRef42:                                   ; preds = %230
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %233
+ThrowNullRef44:                                   ; preds = %233
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %238
+ThrowNullRef46:                                   ; preds = %238
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %200
+ThrowNullRef48:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %204
+ThrowNullRef50:                                   ; preds = %204
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %207
+ThrowNullRef52:                                   ; preds = %207
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %213
+ThrowNullRef54:                                   ; preds = %213
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %172
+ThrowNullRef56:                                   ; preds = %172
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %176
+ThrowNullRef58:                                   ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %179
+ThrowNullRef60:                                   ; preds = %179
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %185
+ThrowNullRef62:                                   ; preds = %185
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %190
+ThrowNullRef64:                                   ; preds = %190
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %195
+ThrowNullRef66:                                   ; preds = %195
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %153
+ThrowNullRef68:                                   ; preds = %153
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %157
+ThrowNullRef70:                                   ; preds = %157
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %160
+ThrowNullRef72:                                   ; preds = %160
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %166
+ThrowNullRef74:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %136
+ThrowNullRef76:                                   ; preds = %136
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %140
+ThrowNullRef78:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %143
+ThrowNullRef80:                                   ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %148
+ThrowNullRef82:                                   ; preds = %148
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %128
+ThrowNullRef84:                                   ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %132
+ThrowNullRef86:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %100
+ThrowNullRef88:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %104
+ThrowNullRef90:                                   ; preds = %104
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %107
+ThrowNullRef92:                                   ; preds = %107
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %113
+ThrowNullRef94:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %118
+ThrowNullRef96:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %123
+ThrowNullRef98:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %81
+ThrowNullRef100:                                  ; preds = %81
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef101:                                  ; preds = %85
+ThrowNullRef102:                                  ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef103:                                  ; preds = %88
+ThrowNullRef104:                                  ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef105:                                  ; preds = %94
+ThrowNullRef106:                                  ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef107:                                  ; preds = %64
+ThrowNullRef108:                                  ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef109:                                  ; preds = %68
+ThrowNullRef110:                                  ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef111:                                  ; preds = %71
+ThrowNullRef112:                                  ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef113:                                  ; preds = %76
+ThrowNullRef114:                                  ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef115:                                  ; preds = %56
+ThrowNullRef116:                                  ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef117:                                  ; preds = %60
+ThrowNullRef118:                                  ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef119:                                  ; preds = %37
+ThrowNullRef120:                                  ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef121:                                  ; preds = %41
+ThrowNullRef122:                                  ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef123:                                  ; preds = %46
+ThrowNullRef124:                                  ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef125:                                  ; preds = %51
+ThrowNullRef126:                                  ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef127:                                  ; preds = %27
+ThrowNullRef128:                                  ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef129:                                  ; preds = %31
+ThrowNullRef130:                                  ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef131:                                  ; preds = %19
+ThrowNullRef132:                                  ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef133:                                  ; preds = %22
+ThrowNullRef134:                                  ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef135:                                  ; preds = %338
+ThrowNullRef136:                                  ; preds = %338
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef137:                                  ; preds = %341
+ThrowNullRef138:                                  ; preds = %341
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef139:                                  ; preds = %356
+ThrowNullRef140:                                  ; preds = %356
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef141:                                  ; preds = %360
+ThrowNullRef142:                                  ; preds = %360
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef143:                                  ; preds = %377
+ThrowNullRef144:                                  ; preds = %377
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef145:                                  ; preds = %381
+ThrowNullRef146:                                  ; preds = %381
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef147:                                  ; preds = %424
+ThrowNullRef148:                                  ; preds = %424
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef149:                                  ; preds = %428
+ThrowNullRef150:                                  ; preds = %428
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef151:                                  ; preds = %440
+ThrowNullRef152:                                  ; preds = %440
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef153:                                  ; preds = %444
+ThrowNullRef154:                                  ; preds = %444
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef155:                                  ; preds = %456
+ThrowNullRef156:                                  ; preds = %456
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef157:                                  ; preds = %460
+ThrowNullRef158:                                  ; preds = %460
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef159:                                  ; preds = %474
+ThrowNullRef160:                                  ; preds = %474
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef161:                                  ; preds = %477
+ThrowNullRef162:                                  ; preds = %477
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef163:                                  ; preds = %394
+ThrowNullRef164:                                  ; preds = %394
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef165:                                  ; preds = %398
+ThrowNullRef166:                                  ; preds = %398
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef167:                                  ; preds = %401
+ThrowNullRef168:                                  ; preds = %401
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef169:                                  ; preds = %407
+ThrowNullRef170:                                  ; preds = %407
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1939,8 +2021,8 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
-  br i1 %NullCheck, label %22, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %ThrowNullRef, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
@@ -1948,8 +2030,8 @@ entry:
   store i32 %24, i32* %loc0
   %25 = load i32, i32* %loc0
   %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %26, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %27
 
 ; <label>:27                                      ; preds = %22
   %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
@@ -1971,7 +2053,7 @@ ThrowNullRef:                                     ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1989,8 +2071,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -2022,15 +2104,15 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2048,16 +2130,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
   %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
   store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %15
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
@@ -2072,8 +2154,8 @@ entry:
   %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
   %29 = ptrtoint i16 addrspace(1)* %28 to i64
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %19
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
@@ -2089,19 +2171,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2114,8 +2196,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
@@ -2128,7 +2210,7 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[loadElem]
+Failed to read AppDomain.PrepareDataForSetup[storeElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
@@ -2202,8 +2284,8 @@ entry:
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
-  br i1 %NullCheck24, label %27, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = load i64, i64 addrspace(1)* %26
@@ -2218,8 +2300,8 @@ entry:
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
-  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
   %41 = load i64, i64 addrspace(1)* %39
@@ -2236,8 +2318,8 @@ entry:
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
-  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
   %54 = load i64, i64 addrspace(1)* %52
@@ -2252,8 +2334,8 @@ entry:
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
   %67 = load i64, i64 addrspace(1)* %65
@@ -2270,8 +2352,8 @@ entry:
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
-  br i1 %NullCheck16, label %79, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
   %80 = load i64, i64 addrspace(1)* %78
@@ -2286,8 +2368,8 @@ entry:
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
-  br i1 %NullCheck18, label %92, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
   %93 = load i64, i64 addrspace(1)* %91
@@ -2304,8 +2386,8 @@ entry:
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
-  br i1 %NullCheck12, label %105, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = load i64, i64 addrspace(1)* %104
@@ -2320,8 +2402,8 @@ entry:
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
-  br i1 %NullCheck14, label %118, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
   %119 = load i64, i64 addrspace(1)* %117
@@ -2337,8 +2419,8 @@ entry:
 
 ; <label>:128                                     ; preds = %20
   %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
-  br i1 %NullCheck4, label %130, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %129, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %130
 
 ; <label>:130                                     ; preds = %128
   %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
@@ -2346,8 +2428,8 @@ entry:
   %133 = load i16, i16 addrspace(1)* %132, align 8
   %134 = zext i16 %133 to i32
   %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
-  br i1 %NullCheck6, label %136, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %135, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %136
 
 ; <label>:136                                     ; preds = %130
   %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
@@ -2360,8 +2442,8 @@ entry:
 
 ; <label>:143                                     ; preds = %136
   %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
-  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %144, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %145
 
 ; <label>:145                                     ; preds = %143
   %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
@@ -2369,8 +2451,8 @@ entry:
   %148 = load i16, i16 addrspace(1)* %147, align 8
   %149 = zext i16 %148 to i32
   %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %150, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %151
 
 ; <label>:151                                     ; preds = %145
   %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
@@ -2388,8 +2470,8 @@ entry:
 
 ; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
-  br i1 %NullCheck, label %163, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %ThrowNullRef, label %163
 
 ; <label>:163                                     ; preds = %161
   %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
@@ -2399,8 +2481,8 @@ entry:
 
 ; <label>:167                                     ; preds = %163
   %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
-  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %168, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %169
 
 ; <label>:169                                     ; preds = %167
   %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
@@ -2432,55 +2514,55 @@ ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %167
+ThrowNullRef2:                                    ; preds = %167
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %128
+ThrowNullRef4:                                    ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %130
+ThrowNullRef6:                                    ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %143
+ThrowNullRef8:                                    ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %145
+ThrowNullRef10:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %102
+ThrowNullRef12:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %105
+ThrowNullRef14:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %76
+ThrowNullRef16:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %79
+ThrowNullRef18:                                   ; preds = %79
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %50
+ThrowNullRef20:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %53
+ThrowNullRef22:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %24
+ThrowNullRef24:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %27
+ThrowNullRef26:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2503,15 +2585,15 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2519,16 +2601,16 @@ entry:
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
   store i32 %8, i32* %loc0
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
   %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
   store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
@@ -2546,16 +2628,16 @@ entry:
 
 ; <label>:23                                      ; preds = %64
   %24 = load i16*, i16** %loc3
-  %NullCheck12 = icmp ne i16* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i16* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
   store i32 %27, i32* %loc5
   %28 = load i16*, i16** %loc4
-  %NullCheck14 = icmp ne i16* %28, null
-  br i1 %NullCheck14, label %29, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %28, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = load i16, i16* %28, align 8
@@ -2620,15 +2702,15 @@ entry:
 
 ; <label>:67                                      ; preds = %64
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
-  br i1 %NullCheck8, label %69, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %68, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %69
 
 ; <label>:69                                      ; preds = %67
   %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
   %71 = load i32, i32 addrspace(1)* %70
   %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
-  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %73
 
 ; <label>:73                                      ; preds = %69
   %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
@@ -2645,31 +2727,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %67
+ThrowNullRef8:                                    ; preds = %67
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %69
+ThrowNullRef10:                                   ; preds = %69
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2710,14 +2792,14 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
   %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
@@ -2730,14 +2812,14 @@ entry:
 
 ; <label>:11                                      ; preds = %4
   %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
   %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
@@ -2749,14 +2831,14 @@ entry:
 
 ; <label>:22                                      ; preds = %16
   %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
   %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
-  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
-  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
@@ -2804,23 +2886,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2836,7 +2918,280 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[loadElem]
+Successfully read RuntimeType.IsAssignableFrom
+
+define i8 @RuntimeType.IsAssignableFrom(%System.RuntimeType addrspace(1)* %param0, %System.Type addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.RuntimeType addrspace(1)*
+  %arg1 = alloca %System.Type addrspace(1)*
+  %loc0 = alloca %System.RuntimeType addrspace(1)*
+  %loc1 = alloca %"System.Type[]" addrspace(1)*
+  %loc2 = alloca i32
+  store %System.RuntimeType addrspace(1)* %param0, %System.RuntimeType addrspace(1)** %this
+  store %System.Type addrspace(1)* %param1, %System.Type addrspace(1)** %arg1
+  %0 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %1 = icmp ne %System.Type addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i8 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %5 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %6 = bitcast %System.Type addrspace(1)* %4 to %System.Object addrspace(1)*
+  %7 = bitcast %System.RuntimeType addrspace(1)* %5 to %System.Object addrspace(1)*
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %6, %System.Object addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %3
+  ret i8 1
+
+; <label>:12                                      ; preds = %3
+  %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 152
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 32
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
+  %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
+  %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
+  store %System.RuntimeType addrspace(1)* %25, %System.RuntimeType addrspace(1)** %loc0
+  %26 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %27 = icmp eq %System.RuntimeType addrspace(1)* %26, null
+  br i1 %27, label %34, label %28
+
+; <label>:28                                      ; preds = %15
+  %29 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %30 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)*)*)(%System.RuntimeType addrspace(1)* %29, %System.RuntimeType addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+; <label>:34                                      ; preds = %15
+  %35 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %36 = call %System.Reflection.Emit.TypeBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Reflection.Emit.TypeBuilder addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %35)
+  %37 = icmp eq %System.Reflection.Emit.TypeBuilder addrspace(1)* %36, null
+  br i1 %37, label %139, label %38
+
+; <label>:38                                      ; preds = %34
+  %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %42
+
+; <label>:42                                      ; preds = %38
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 152
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 40
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
+  %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
+  %53 = zext i8 %52 to i32
+  %54 = icmp eq i32 %53, 0
+  br i1 %54, label %56, label %55
+
+; <label>:55                                      ; preds = %42
+  ret i8 1
+
+; <label>:56                                      ; preds = %42
+  %57 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %58 = bitcast %System.RuntimeType addrspace(1)* %57 to %System.Type addrspace(1)*
+  %59 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %58)
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %64 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.Type addrspace(1)* %63, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = bitcast %System.RuntimeType addrspace(1)* %64 to %System.Type addrspace(1)*
+  %67 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %63, %System.Type addrspace(1)* %66)
+  %68 = zext i8 %67 to i32
+  %69 = trunc i32 %68 to i8
+  ret i8 %69
+
+; <label>:70                                      ; preds = %56
+  %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
+  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %73
+
+; <label>:73                                      ; preds = %70
+  %74 = load i64, i64 addrspace(1)* %72
+  %75 = add i64 %74, 128
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = add i64 %77, 0
+  %79 = inttoptr i64 %78 to i64*
+  %80 = load i64, i64* %79
+  %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
+  %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
+  %83 = call i8 %82(%System.Type addrspace(1)* %81)
+  %84 = zext i8 %83 to i32
+  %85 = icmp eq i32 %84, 0
+  br i1 %85, label %139, label %86
+
+; <label>:86                                      ; preds = %73
+  %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
+  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %89
+
+; <label>:89                                      ; preds = %86
+  %90 = load i64, i64 addrspace(1)* %88
+  %91 = add i64 %90, 128
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = add i64 %93, 24
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
+  %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
+  %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
+  store %"System.Type[]" addrspace(1)* %99, %"System.Type[]" addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %129
+
+; <label>:100                                     ; preds = %132
+  %101 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %102 = load i32, i32* %loc2
+  %NullCheck11 = icmp eq %"System.Type[]" addrspace(1)* %101, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %103
+
+; <label>:103                                     ; preds = %100
+  %104 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 1
+  %105 = load i32, i32 addrspace(1)* %104
+  %106 = zext i32 %105 to i64
+  %107 = zext i32 %102 to i64
+  %BoundsCheck = icmp uge i64 %107, %106
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %108
+
+; <label>:108                                     ; preds = %103
+  %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
+  %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
+  %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
+  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %113
+
+; <label>:113                                     ; preds = %108
+  %114 = load i64, i64 addrspace(1)* %112
+  %115 = add i64 %114, 152
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = add i64 %117, 56
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
+  %123 = zext i8 %122 to i32
+  %124 = icmp ne i32 %123, 0
+  br i1 %124, label %126, label %125
+
+; <label>:125                                     ; preds = %113
+  ret i8 0
+
+; <label>:126                                     ; preds = %113
+  %127 = load i32, i32* %loc2
+  %128 = add i32 %127, 1
+  store i32 %128, i32* %loc2
+  br label %129
+
+; <label>:129                                     ; preds = %89, %126
+  %130 = load i32, i32* %loc2
+  %131 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %NullCheck9 = icmp eq %"System.Type[]" addrspace(1)* %131, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %132
+
+; <label>:132                                     ; preds = %129
+  %133 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %131, i32 0, i32 1
+  %134 = load i32, i32 addrspace(1)* %133
+  %135 = zext i32 %134 to i64
+  %136 = trunc i64 %135 to i32
+  %137 = icmp slt i32 %130, %136
+  br i1 %137, label %100, label %138
+
+; <label>:138                                     ; preds = %132
+  ret i8 1
+
+; <label>:139                                     ; preds = %34, %73
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %129
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %103
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -2893,7 +3248,7 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElem]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -2904,8 +3259,8 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -2997,8 +3352,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
@@ -3059,8 +3414,8 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -3087,8 +3442,8 @@ entry:
 
 ; <label>:17                                      ; preds = %5, %11
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
@@ -3097,8 +3452,8 @@ entry:
 
 ; <label>:22                                      ; preds = %1, %11
   %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
@@ -3109,11 +3464,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %17
+ThrowNullRef2:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %22
+ThrowNullRef4:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3167,15 +3522,15 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
   %15 = load i32, i32 addrspace(1)* %14
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
@@ -3198,7 +3553,7 @@ ThrowNullRef:                                     ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef2:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3232,8 +3587,8 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
@@ -3312,8 +3667,8 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -3327,8 +3682,8 @@ entry:
 ; <label>:5                                       ; preds = %43
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %7 = load i32, i32* %loc1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck6, label %8, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
@@ -3366,8 +3721,8 @@ entry:
 ; <label>:32                                      ; preds = %21, %25
   %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
   %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
-  br i1 %NullCheck8, label %35, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = trunc i32 %34 to i16
@@ -3380,8 +3735,8 @@ entry:
 ; <label>:40                                      ; preds = %1, %35
   %41 = load i32, i32* %loc1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
-  br i1 %NullCheck2, label %43, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %42, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
@@ -3392,8 +3747,8 @@ entry:
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
   %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
-  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
   %51 = load i64, i64 addrspace(1)* %49
@@ -3412,19 +3767,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %40
+ThrowNullRef2:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %47
+ThrowNullRef4:                                    ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %5
+ThrowNullRef6:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %32
+ThrowNullRef8:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3467,8 +3822,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
@@ -3492,11 +3847,391 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(i16* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store i16* %param0, i16** %arg0
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load i32, i32* %arg3
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %42, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %37, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg2
+  %13 = load i32, i32* %arg3
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %37, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %24 = load i32, i32* %arg2
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load i16*, i16** %arg0
+  %35 = load i32, i32* %arg3
+  %36 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %36, i16* %34, i32 %35)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:37                                      ; preds = %5, %16
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %39)
+  %41 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41, %System.String addrspace(1)* %38, %System.String addrspace(1)* %40)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41) #0
+  unreachable
+
+; <label>:42                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
-Failed to read StringBuilder.ToString[loadElemA]
+Successfully read StringBuilder.ToString
+
+define %System.String addrspace(1)* @StringBuilder.ToString(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i16*
+  %loc3 = alloca %"System.Char[]" addrspace(1)*
+  %loc4 = alloca i32
+  %loc5 = alloca i32
+  %loc6 = alloca i16 addrspace(1)*
+  %loc7 = alloca %System.String addrspace(1)*
+  %loc8 = alloca %"System.Char[]" addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %0)
+  %2 = icmp ne i32 %1, 0
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %4
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %6)
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %7)
+  store %System.String addrspace(1)* %8, %System.String addrspace(1)** %loc0
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.Text.StringBuilder addrspace(1)* %9, %System.Text.StringBuilder addrspace(1)** %loc1
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  store %System.String addrspace(1)* %10, %System.String addrspace(1)** %loc7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc7
+  %12 = ptrtoint %System.String addrspace(1)* %11 to i64
+  %13 = icmp eq i64 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %5
+  %15 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %16 = sext i32 %15 to i64
+  %17 = add i64 %12, %16
+  br label %18
+
+; <label>:18                                      ; preds = %5, %14
+  %19 = phi i64 [ %12, %5 ], [ %17, %14 ]
+  %20 = inttoptr i64 %19 to i16*
+  store i16* %20, i16** %loc2
+  br label %21
+
+; <label>:21                                      ; preds = %98, %18
+  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %22, null
+  br i1 %NullCheck, label %ThrowNullRef, label %23
+
+; <label>:23                                      ; preds = %21
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 3
+  %25 = load i32, i32 addrspace(1)* %24, align 8
+  %26 = icmp sle i32 %25, 0
+  br i1 %26, label %96, label %27
+
+; <label>:27                                      ; preds = %23
+  %28 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %28, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %29
+
+; <label>:29                                      ; preds = %27
+  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %28, i32 0, i32 1
+  %31 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %30, align 8
+  store %"System.Char[]" addrspace(1)* %31, %"System.Char[]" addrspace(1)** %loc3
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %33
+
+; <label>:33                                      ; preds = %29
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  store i32 %35, i32* %loc4
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  %39 = load i32, i32 addrspace(1)* %38, align 8
+  store i32 %39, i32* %loc5
+  %40 = load i32, i32* %loc5
+  %41 = load i32, i32* %loc4
+  %42 = add i32 %40, %41
+  %43 = zext i32 %42 to i64
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %45
+
+; <label>:45                                      ; preds = %37
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = sext i32 %47 to i64
+  %49 = icmp sgt i64 %43, %48
+  br i1 %49, label %91, label %50
+
+; <label>:50                                      ; preds = %45
+  %51 = load i32, i32* %loc5
+  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %52, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %53
+
+; <label>:53                                      ; preds = %50
+  %54 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %52, i32 0, i32 1
+  %55 = load i32, i32 addrspace(1)* %54
+  %56 = zext i32 %55 to i64
+  %57 = trunc i64 %56 to i32
+  %58 = icmp ugt i32 %51, %57
+  br i1 %58, label %91, label %59
+
+; <label>:59                                      ; preds = %53
+  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  store %"System.Char[]" addrspace(1)* %60, %"System.Char[]" addrspace(1)** %loc8
+  %61 = icmp eq %"System.Char[]" addrspace(1)* %60, null
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %63, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %64
+
+; <label>:64                                      ; preds = %62
+  %65 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %63, i32 0, i32 1
+  %66 = load i32, i32 addrspace(1)* %65
+  %67 = zext i32 %66 to i64
+  %68 = trunc i64 %67 to i32
+  %69 = icmp ne i32 %68, 0
+  br i1 %69, label %71, label %70
+
+; <label>:70                                      ; preds = %59, %64
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:71                                      ; preds = %64
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %73
+
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %BoundsCheck = icmp uge i64 0, %76
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %77
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %78, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:79                                      ; preds = %70, %77
+  %80 = load i16*, i16** %loc2
+  %81 = load i32, i32* %loc4
+  %82 = sext i32 %81 to i64
+  %83 = mul i64 %82, 2
+  %84 = bitcast i16* %80 to i8*
+  %85 = getelementptr inbounds i8, i8* %84, i64 %83
+  %86 = load i16 addrspace(1)*, i16 addrspace(1)** %loc6
+  %87 = ptrtoint i16 addrspace(1)* %86 to i64
+  %88 = load i32, i32* %loc5
+  %89 = bitcast i8* %85 to i16*
+  %90 = inttoptr i64 %87 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %89, i16* %90, i32 %88)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %96
+
+; <label>:91                                      ; preds = %45, %53
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %94 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %93)
+  %95 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95, %System.String addrspace(1)* %92, %System.String addrspace(1)* %94)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95) #0
+  unreachable
+
+; <label>:96                                      ; preds = %23, %79
+  %97 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %97, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %98
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %97, i32 0, i32 2
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  store %System.Text.StringBuilder addrspace(1)* %100, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %102 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %102, label %21, label %103
+
+; <label>:103                                     ; preds = %98
+  store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc7
+  %104 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  ret %System.String addrspace(1)* %104
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method StringBuilder::get_Length using LLILCJit
+Successfully read StringBuilder.get_Length
+
+define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
+Successfully read RuntimeHelpers.get_OffsetToStringData
+
+define i32 @RuntimeHelpers.get_OffsetToStringData() {
+entry:
+  ret i32 12
+}
+
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
 Successfully read CultureData.CreateCultureData
 
@@ -3514,23 +4249,23 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
   store i8 %4, i8 addrspace(1)* %6
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
@@ -3549,11 +4284,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3566,50 +4301,50 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
   store i32 -1, i32 addrspace(1)* %2
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
   store i32 -1, i32 addrspace(1)* %8
   %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
   store i32 -1, i32 addrspace(1)* %14
   %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
   store i32 -1, i32 addrspace(1)* %17
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
@@ -3623,27 +4358,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3675,7 +4410,136 @@ Failed to read Dictionary`2.Insert[non-const derefAddress]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
 Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
-Failed to read HashHelpers.GetPrime[loadElem]
+Successfully read HashHelpers.GetPrime
+
+define i32 @HashHelpers.GetPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %6, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5, %System.String addrspace(1)* %4)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5) #0
+  unreachable
+
+; <label>:6                                       ; preds = %entry
+  store i32 0, i32* %loc0
+  br label %29
+
+; <label>:7                                       ; preds = %35
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 1296
+  %10 = addrspacecast i8 addrspace(1)* %9 to %"System.Int32[]" addrspace(1)**
+  %11 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %10
+  %12 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Int32[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = zext i32 %15 to i64
+  %17 = zext i32 %12 to i64
+  %BoundsCheck = icmp uge i64 %17, %16
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 3, i32 %12
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  store i32 %20, i32* %loc1
+  %21 = load i32, i32* %loc1
+  %22 = load i32, i32* %arg0
+  %23 = icmp slt i32 %21, %22
+  br i1 %23, label %26, label %24
+
+; <label>:24                                      ; preds = %18
+  %25 = load i32, i32* %loc1
+  ret i32 %25
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %loc0
+  %28 = add i32 %27, 1
+  store i32 %28, i32* %loc0
+  br label %29
+
+; <label>:29                                      ; preds = %6, %26
+  %30 = load i32, i32* %loc0
+  %31 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %32 = getelementptr inbounds i8, i8 addrspace(1)* %31, i64 1296
+  %33 = addrspacecast i8 addrspace(1)* %32 to %"System.Int32[]" addrspace(1)**
+  %34 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %33
+  %NullCheck = icmp eq %"System.Int32[]" addrspace(1)* %34, null
+  br i1 %NullCheck, label %ThrowNullRef, label %35
+
+; <label>:35                                      ; preds = %29
+  %36 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %34, i32 0, i32 1
+  %37 = load i32, i32 addrspace(1)* %36
+  %38 = zext i32 %37 to i64
+  %39 = trunc i64 %38 to i32
+  %40 = icmp slt i32 %30, %39
+  br i1 %40, label %7, label %41
+
+; <label>:41                                      ; preds = %35
+  %42 = load i32, i32* %arg0
+  %43 = or i32 %42, 1
+  store i32 %43, i32* %loc2
+  br label %59
+
+; <label>:44                                      ; preds = %59
+  %45 = load i32, i32* %loc2
+  %46 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %45)
+  %47 = zext i8 %46 to i32
+  %48 = icmp eq i32 %47, 0
+  br i1 %48, label %56, label %49
+
+; <label>:49                                      ; preds = %44
+  %50 = load i32, i32* %loc2
+  %51 = sub i32 %50, 1
+  %52 = srem i32 %51, 101
+  %53 = icmp eq i32 %52, 0
+  br i1 %53, label %56, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = load i32, i32* %loc2
+  ret i32 %55
+
+; <label>:56                                      ; preds = %44, %49
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %57, 2
+  store i32 %58, i32* %loc2
+  br label %59
+
+; <label>:59                                      ; preds = %41, %56
+  %60 = load i32, i32* %loc2
+  %61 = icmp slt i32 %60, 2147483647
+  br i1 %61, label %44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load i32, i32* %arg0
+  ret i32 %63
+
+ThrowNullRef:                                     ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
 Successfully read GenericEqualityComparer`1.GetHashCode
 
@@ -3694,14 +4558,14 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
   %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load i64, i64 addrspace(1)* %7
@@ -3720,7 +4584,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3750,8 +4614,8 @@ entry:
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
@@ -3796,8 +4660,8 @@ entry:
   %35 = bitcast i16* %34 to i8*
   %36 = getelementptr inbounds i8, i8* %35, i64 2
   %37 = bitcast i8* %36 to i16*
-  %NullCheck4 = icmp ne i16* %37, null
-  br i1 %NullCheck4, label %38, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %37, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %38
 
 ; <label>:38                                      ; preds = %27
   %39 = load i16, i16* %37, align 8
@@ -3824,8 +4688,8 @@ entry:
 
 ; <label>:54                                      ; preds = %22, %43
   %55 = load i16*, i16** %loc4
-  %NullCheck2 = icmp ne i16* %55, null
-  br i1 %NullCheck2, label %56, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i16* %55, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %56
 
 ; <label>:56                                      ; preds = %54
   %57 = load i16, i16* %55, align 8
@@ -3850,11 +4714,11 @@ ThrowNullRef:                                     ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %54
+ThrowNullRef2:                                    ; preds = %54
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %27
+ThrowNullRef4:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3871,8 +4735,8 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -3907,8 +4771,8 @@ entry:
 
 ; <label>:26                                      ; preds = %19
   %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
-  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %28
 
 ; <label>:28                                      ; preds = %26
   %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
@@ -3920,7 +4784,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3972,8 +4836,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
@@ -3984,26 +4848,26 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
-  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
@@ -4014,8 +4878,8 @@ entry:
 ; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
@@ -4024,8 +4888,8 @@ entry:
 
 ; <label>:25                                      ; preds = %1, %16, %23
   %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
-  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
@@ -4036,27 +4900,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %20
+ThrowNullRef10:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4069,8 +4933,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -4081,8 +4945,8 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
@@ -4091,8 +4955,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1, %8
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
@@ -4103,11 +4967,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4128,24 +4992,24 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   store i32 %3, i32* %loc0
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
   %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
   store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck4, label %9, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
@@ -4164,15 +5028,15 @@ entry:
 ; <label>:18                                      ; preds = %70
   %19 = load i16*, i16** %loc3
   %20 = bitcast i16* %19 to i64*
-  %NullCheck10 = icmp ne i64* %20, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %20, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = load i64, i64* %20, align 8
   %23 = load i16*, i16** %loc4
   %24 = bitcast i16* %23 to i64*
-  %NullCheck12 = icmp ne i64* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = load i64, i64* %24, align 8
@@ -4188,8 +5052,8 @@ entry:
   %31 = bitcast i16* %30 to i8*
   %32 = getelementptr inbounds i8, i8* %31, i64 8
   %33 = bitcast i8* %32 to i64*
-  %NullCheck14 = icmp ne i64* %33, null
-  br i1 %NullCheck14, label %34, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = load i64, i64* %33, align 8
@@ -4197,8 +5061,8 @@ entry:
   %37 = bitcast i16* %36 to i8*
   %38 = getelementptr inbounds i8, i8* %37, i64 8
   %39 = bitcast i8* %38 to i64*
-  %NullCheck16 = icmp ne i64* %39, null
-  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %40
 
 ; <label>:40                                      ; preds = %34
   %41 = load i64, i64* %39, align 8
@@ -4214,8 +5078,8 @@ entry:
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %NullCheck18 = icmp ne i64* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = load i64, i64* %48, align 8
@@ -4223,8 +5087,8 @@ entry:
   %52 = bitcast i16* %51 to i8*
   %53 = getelementptr inbounds i8, i8* %52, i64 16
   %54 = bitcast i8* %53 to i64*
-  %NullCheck20 = icmp ne i64* %54, null
-  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64* %54, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %55
 
 ; <label>:55                                      ; preds = %49
   %56 = load i64, i64* %54, align 8
@@ -4262,15 +5126,15 @@ entry:
 ; <label>:74                                      ; preds = %95
   %75 = load i16*, i16** %loc3
   %76 = bitcast i16* %75 to i32*
-  %NullCheck6 = icmp ne i32* %76, null
-  br i1 %NullCheck6, label %77, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32* %76, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %77
 
 ; <label>:77                                      ; preds = %74
   %78 = load i32, i32* %76, align 8
   %79 = load i16*, i16** %loc4
   %80 = bitcast i16* %79 to i32*
-  %NullCheck8 = icmp ne i32* %80, null
-  br i1 %NullCheck8, label %81, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i32* %80, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %81
 
 ; <label>:81                                      ; preds = %77
   %82 = load i32, i32* %80, align 8
@@ -4318,43 +5182,43 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %74
+ThrowNullRef6:                                    ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %77
+ThrowNullRef8:                                    ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %29
+ThrowNullRef14:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %34
+ThrowNullRef16:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4376,8 +5240,8 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load i64, i64 addrspace(1)* %4
@@ -4389,8 +5253,8 @@ entry:
   %12 = load i64, i64* %11
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %5
   %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
@@ -4399,8 +5263,8 @@ entry:
   %18 = load i8, i8* %arg2
   %19 = zext i8 %18 to i32
   %20 = trunc i32 %19 to i8
-  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %15
   %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
@@ -4411,11 +5275,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4442,8 +5306,8 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
@@ -4466,16 +5330,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
   %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = load i64, i64 addrspace(1)* %19
@@ -4500,8 +5364,8 @@ entry:
 ; <label>:35                                      ; preds = %30
   %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
@@ -4514,8 +5378,8 @@ entry:
 
 ; <label>:42                                      ; preds = %1, %38
   %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
-  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
@@ -4526,19 +5390,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %35
+ThrowNullRef2:                                    ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %42
+ThrowNullRef8:                                    ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4551,14 +5415,14 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
@@ -4570,7 +5434,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4583,8 +5447,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
@@ -4613,51 +5477,51 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
   %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
   %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
   %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
   %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
-  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
   store i64 %21, i64 addrspace(1)* %23
   %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %25 = load i64, i64* %loc0
-  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
@@ -4668,27 +5532,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %22
+ThrowNullRef12:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4701,8 +5565,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
@@ -4713,19 +5577,19 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
@@ -4734,8 +5598,8 @@ entry:
 
 ; <label>:15                                      ; preds = %1, %13
   %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
@@ -4746,19 +5610,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %15
+ThrowNullRef8:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4771,8 +5635,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -4831,8 +5695,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
@@ -4882,8 +5746,8 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
-  br i1 %NullCheck, label %17, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %ThrowNullRef, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
@@ -4894,15 +5758,15 @@ entry:
 
 ; <label>:22                                      ; preds = %17
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
-  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
   %26 = load i32, i32 addrspace(1)* %25
   %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
-  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %27, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
@@ -4925,8 +5789,8 @@ entry:
 ; <label>:40                                      ; preds = %17
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
-  br i1 %NullCheck6, label %43, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %41, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
@@ -4938,34 +5802,17 @@ ThrowNullRef:                                     ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %24
+ThrowNullRef4:                                    ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %40
+ThrowNullRef6:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
-}
-
-INFO:  jitting method Object::ReferenceEquals using LLILCJit
-Successfully read Object.ReferenceEquals
-
-define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
-entry:
-  %arg0 = alloca %System.Object addrspace(1)*
-  %arg1 = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
-  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
-  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = icmp eq %System.Object addrspace(1)* %0, %1
-  %3 = sext i1 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
 }
 
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
@@ -4978,21 +5825,21 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
   %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
-  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
@@ -5007,28 +5854,28 @@ entry:
 ; <label>:13                                      ; preds = %8, %12
   %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
   %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
   %21 = load i32, i32 addrspace(1)* %20, align 8
   %22 = add i32 %21, 1
-  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
   store i32 %22, i32 addrspace(1)* %24
   %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
@@ -5039,27 +5886,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5077,7 +5924,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::Setup using LLILCJit
-Failed to read AppDomain.Setup[loadElem]
+Failed to read AppDomain.Setup[unbox]
 INFO:  jitting method Thread::GetDomain using LLILCJit
 Successfully read Thread.GetDomain
 
@@ -5108,8 +5955,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
@@ -5122,14 +5969,14 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
   %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
@@ -5141,11 +5988,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5173,8 +6020,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -5189,7 +6036,328 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
 Failed to read KeyCollection.System.Collections.Generic.IEnumerable<TKey>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Successfully read Enumerator.MoveNext
+
+define i8 @Enumerator.MoveNext(%"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.RuntimeTypeHandle* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*
+  %"$TypeArg" = alloca %System.RuntimeTypeHandle*
+  store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
+  %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 8
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %76, label %12
+
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
+  br label %76
+
+; <label>:13                                      ; preds = %85
+  %14 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck19 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %15
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, i32 0, i32 0
+  %17 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %16, align 8
+  %NullCheck21 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, i32 0, i32 2
+  %20 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %19, align 8
+  %21 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck23 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %22
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, i32 0, i32 2
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %NullCheck25 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 3, i32 %24
+  %NullCheck27 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %32
+
+; <label>:32                                      ; preds = %30
+  %33 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, i32 0, i32 2
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = icmp slt i32 %34, 0
+  br i1 %35, label %68, label %36
+
+; <label>:36                                      ; preds = %32
+  %37 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %38 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck29 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %39
+
+; <label>:39                                      ; preds = %36
+  %40 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, i32 0, i32 0
+  %41 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %40, align 8
+  %NullCheck31 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, i32 0, i32 2
+  %44 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %43, align 8
+  %45 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck33 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, i32 0, i32 2
+  %48 = load i32, i32 addrspace(1)* %47, align 8
+  %NullCheck35 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %49
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = zext i32 %51 to i64
+  %53 = zext i32 %48 to i64
+  %BoundsCheck37 = icmp uge i64 %53, %52
+  br i1 %BoundsCheck37, label %ThrowIndexOutOfRange38, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 3, i32 %48
+  %NullCheck39 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %56
+
+; <label>:56                                      ; preds = %54
+  %57 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, i32 0, i32 0
+  %58 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck41 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %59
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %60, %System.__Canon addrspace(1)* %58)
+  %61 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck43 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  %64 = load i32, i32 addrspace(1)* %63, align 8
+  %65 = add i32 %64, 1
+  %NullCheck45 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  store i32 %65, i32 addrspace(1)* %67
+  ret i8 1
+
+; <label>:68                                      ; preds = %32
+  %69 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck47 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %73 = add i32 %72, 1
+  %NullCheck49 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %74
+
+; <label>:74                                      ; preds = %70
+  %75 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  store i32 %73, i32 addrspace(1)* %75
+  br label %76
+
+; <label>:76                                      ; preds = %8, %12, %74
+  %77 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %78
+
+; <label>:78                                      ; preds = %76
+  %79 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, i32 0, i32 2
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck7 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %82
+
+; <label>:82                                      ; preds = %78
+  %83 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, i32 0, i32 0
+  %84 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %83, align 8
+  %NullCheck9 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %85
+
+; <label>:85                                      ; preds = %82
+  %86 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, i32 0, i32 7
+  %87 = load i32, i32 addrspace(1)* %86, align 8
+  %88 = icmp ult i32 %80, %87
+  br i1 %88, label %13, label %89
+
+; <label>:89                                      ; preds = %85
+  %90 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %91 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck11 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %92
+
+; <label>:92                                      ; preds = %89
+  %93 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, i32 0, i32 0
+  %94 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck13 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %95
+
+; <label>:95                                      ; preds = %92
+  %96 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, i32 0, i32 7
+  %97 = load i32, i32 addrspace(1)* %96, align 8
+  %98 = add i32 %97, 1
+  %NullCheck15 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %99
+
+; <label>:99                                      ; preds = %95
+  %100 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, i32 0, i32 2
+  store i32 %98, i32 addrspace(1)* %100
+  %101 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck17 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %102
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %103, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %92
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef22:                                   ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef24:                                   ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef26:                                   ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef28:                                   ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef30:                                   ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef32:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef34:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef36:                                   ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange38:                           ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef40:                                   ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef42:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef44:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef46:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef48:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef50:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -5200,8 +6368,8 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -5232,9 +6400,9 @@ Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
 Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
-Failed to read String.MakeSeparatorList[loadElemA]
+Failed to read String.MakeSeparatorList[storeElem]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
-Failed to read String.InternalSplitKeepEmptyEntries[loadElem]
+Failed to read String.InternalSplitKeepEmptyEntries[storeElem]
 INFO:  jitting method Path::IsRelative using LLILCJit
 Successfully read Path.IsRelative
 
@@ -5243,8 +6411,8 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -5254,8 +6422,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
@@ -5271,8 +6439,8 @@ entry:
 
 ; <label>:17                                      ; preds = %7
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
@@ -5288,8 +6456,8 @@ entry:
 
 ; <label>:29                                      ; preds = %19
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %31
 
 ; <label>:31                                      ; preds = %29
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
@@ -5300,8 +6468,8 @@ entry:
 
 ; <label>:36                                      ; preds = %31
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
-  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %37, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
@@ -5312,8 +6480,8 @@ entry:
 
 ; <label>:43                                      ; preds = %31, %38
   %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
-  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %45
 
 ; <label>:45                                      ; preds = %43
   %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
@@ -5324,8 +6492,8 @@ entry:
 
 ; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %50
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
@@ -5336,8 +6504,8 @@ entry:
 
 ; <label>:57                                      ; preds = %1, %7, %19, %45, %52
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
-  br i1 %NullCheck14, label %59, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %59
 
 ; <label>:59                                      ; preds = %57
   %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
@@ -5347,8 +6515,8 @@ entry:
 
 ; <label>:63                                      ; preds = %59
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
@@ -5359,8 +6527,8 @@ entry:
 
 ; <label>:70                                      ; preds = %65
   %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
-  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.String addrspace(1)* %71, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %72
 
 ; <label>:72                                      ; preds = %70
   %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
@@ -5379,39 +6547,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %17
+ThrowNullRef4:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %29
+ThrowNullRef6:                                    ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %36
+ThrowNullRef8:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %43
+ThrowNullRef10:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %50
+ThrowNullRef12:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %57
+ThrowNullRef14:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %63
+ThrowNullRef16:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %70
+ThrowNullRef18:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5419,7 +6587,293 @@ ThrowNullRef17:                                   ; preds = %70
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
-Failed to read String.TrimHelper[loadElem]
+Successfully read String.TrimHelper
+
+define %System.String addrspace(1)* @String.TrimHelper(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i16
+  %loc4 = alloca i32
+  %loc5 = alloca i16
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = sub i32 %3, 1
+  store i32 %4, i32* %loc0
+  store i32 0, i32* %loc1
+  %5 = load i32, i32* %arg2
+  %6 = icmp eq i32 %5, 1
+  br i1 %6, label %62, label %7
+
+; <label>:7                                       ; preds = %1
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:8                                       ; preds = %58
+  store i32 0, i32* %loc2
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load i32, i32* %loc1
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2, i32 %10
+  %13 = load i16, i16 addrspace(1)* %12
+  %14 = zext i16 %13 to i32
+  %15 = trunc i32 %14 to i16
+  store i16 %15, i16* %loc3
+  store i32 0, i32* %loc2
+  br label %34
+
+; <label>:16                                      ; preds = %37
+  %17 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %18 = load i32, i32* %loc2
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %17, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %19
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = zext i32 %18 to i64
+  %BoundsCheck = icmp uge i64 %23, %22
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %24
+
+; <label>:24                                      ; preds = %19
+  %25 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 3, i32 %18
+  %26 = load i16, i16 addrspace(1)* %25, align 8
+  %27 = zext i16 %26 to i32
+  %28 = load i16, i16* %loc3
+  %29 = zext i16 %28 to i32
+  %30 = icmp eq i32 %27, %29
+  br i1 %30, label %43, label %31
+
+; <label>:31                                      ; preds = %24
+  %32 = load i32, i32* %loc2
+  %33 = add i32 %32, 1
+  store i32 %33, i32* %loc2
+  br label %34
+
+; <label>:34                                      ; preds = %11, %31
+  %35 = load i32, i32* %loc2
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = icmp slt i32 %35, %41
+  br i1 %42, label %16, label %43
+
+; <label>:43                                      ; preds = %24, %37
+  %44 = load i32, i32* %loc2
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %45, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp eq i32 %44, %50
+  br i1 %51, label %62, label %52
+
+; <label>:52                                      ; preds = %46
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %7, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %57, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %58
+
+; <label>:58                                      ; preds = %55
+  %59 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %60 = load i32, i32 addrspace(1)* %59
+  %61 = icmp slt i32 %56, %60
+  br i1 %61, label %8, label %62
+
+; <label>:62                                      ; preds = %1, %46, %58
+  %63 = load i32, i32* %arg2
+  %64 = icmp eq i32 %63, 0
+  br i1 %64, label %122, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %66, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %67
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %66, i32 0, i32 1
+  %69 = load i32, i32 addrspace(1)* %68
+  %70 = sub i32 %69, 1
+  store i32 %70, i32* %loc0
+  br label %118
+
+; <label>:71                                      ; preds = %118
+  store i32 0, i32* %loc4
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %73 = load i32, i32* %loc0
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %74
+
+; <label>:74                                      ; preds = %71
+  %75 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 2, i32 %73
+  %76 = load i16, i16 addrspace(1)* %75
+  %77 = zext i16 %76 to i32
+  %78 = trunc i32 %77 to i16
+  store i16 %78, i16* %loc5
+  store i32 0, i32* %loc4
+  br label %97
+
+; <label>:79                                      ; preds = %100
+  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %81 = load i32, i32* %loc4
+  %NullCheck19 = icmp eq %"System.Char[]" addrspace(1)* %80, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
+
+; <label>:82                                      ; preds = %79
+  %83 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 1
+  %84 = load i32, i32 addrspace(1)* %83
+  %85 = zext i32 %84 to i64
+  %86 = zext i32 %81 to i64
+  %BoundsCheck21 = icmp uge i64 %86, %85
+  br i1 %BoundsCheck21, label %ThrowIndexOutOfRange22, label %87
+
+; <label>:87                                      ; preds = %82
+  %88 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 3, i32 %81
+  %89 = load i16, i16 addrspace(1)* %88, align 8
+  %90 = zext i16 %89 to i32
+  %91 = load i16, i16* %loc5
+  %92 = zext i16 %91 to i32
+  %93 = icmp eq i32 %90, %92
+  br i1 %93, label %106, label %94
+
+; <label>:94                                      ; preds = %87
+  %95 = load i32, i32* %loc4
+  %96 = add i32 %95, 1
+  store i32 %96, i32* %loc4
+  br label %97
+
+; <label>:97                                      ; preds = %74, %94
+  %98 = load i32, i32* %loc4
+  %99 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck15 = icmp eq %"System.Char[]" addrspace(1)* %99, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %100
+
+; <label>:100                                     ; preds = %97
+  %101 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %99, i32 0, i32 1
+  %102 = load i32, i32 addrspace(1)* %101
+  %103 = zext i32 %102 to i64
+  %104 = trunc i64 %103 to i32
+  %105 = icmp slt i32 %98, %104
+  br i1 %105, label %79, label %106
+
+; <label>:106                                     ; preds = %87, %100
+  %107 = load i32, i32* %loc4
+  %108 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck17 = icmp eq %"System.Char[]" addrspace(1)* %108, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %109
+
+; <label>:109                                     ; preds = %106
+  %110 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %108, i32 0, i32 1
+  %111 = load i32, i32 addrspace(1)* %110
+  %112 = zext i32 %111 to i64
+  %113 = trunc i64 %112 to i32
+  %114 = icmp eq i32 %107, %113
+  br i1 %114, label %122, label %115
+
+; <label>:115                                     ; preds = %109
+  %116 = load i32, i32* %loc0
+  %117 = sub i32 %116, 1
+  store i32 %117, i32* %loc0
+  br label %118
+
+; <label>:118                                     ; preds = %67, %115
+  %119 = load i32, i32* %loc0
+  %120 = load i32, i32* %loc1
+  %121 = icmp sge i32 %119, %120
+  br i1 %121, label %71, label %122
+
+; <label>:122                                     ; preds = %62, %109, %118
+  %123 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %124 = load i32, i32* %loc1
+  %125 = load i32, i32* %loc0
+  %126 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %123, i32 %124, i32 %125)
+  ret %System.String addrspace(1)* %126
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %97
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange22:                           ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
 Successfully read String.CreateTrimmedString
 
@@ -5439,8 +6893,8 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
@@ -5535,8 +6989,8 @@ entry:
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i64 2872
   %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
   %8 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %7
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %3
   %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
@@ -5553,8 +7007,8 @@ entry:
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 2864
   %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
   %21 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %20
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
-  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %22
 
 ; <label>:22                                      ; preds = %16
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
@@ -5569,7 +7023,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %16
+ThrowNullRef2:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5586,8 +7040,8 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5613,8 +7067,8 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
@@ -5632,8 +7086,8 @@ entry:
 
 ; <label>:12                                      ; preds = %4
   %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
@@ -5644,8 +7098,8 @@ entry:
 
 ; <label>:19                                      ; preds = %14
   %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %19
   %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
@@ -5660,21 +7114,21 @@ entry:
   %31 = zext i16 %30 to i32
   %32 = bitcast i8* %29 to i16*
   %33 = trunc i32 %31 to i16
-  %NullCheck6 = icmp ne i16* %32, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i16* %32, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %21
   store i16 %33, i16* %32, align 8
   %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %36
 
 ; <label>:36                                      ; preds = %34
   %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
   %38 = load i32, i32 addrspace(1)* %37, align 8
   %39 = add i32 %38, 1
-  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %40
 
 ; <label>:40                                      ; preds = %36
   %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
@@ -5683,16 +7137,16 @@ entry:
 
 ; <label>:42                                      ; preds = %14
   %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
-  br i1 %NullCheck12, label %44, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
   %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
   %47 = load i16, i16* %arg1
   %48 = zext i16 %47 to i32
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = trunc i32 %48 to i16
@@ -5703,31 +7157,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %19
+ThrowNullRef4:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %21
+ThrowNullRef6:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %36
+ThrowNullRef10:                                   ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %42
+ThrowNullRef12:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %44
+ThrowNullRef14:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5740,8 +7194,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -5752,8 +7206,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
@@ -5762,14 +7216,14 @@ entry:
 
 ; <label>:11                                      ; preds = %1
   %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
@@ -5779,15 +7233,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5808,8 +7262,8 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5822,8 +7276,8 @@ entry:
 
 ; <label>:8                                       ; preds = %3
   %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
@@ -5842,15 +7296,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
-  br i1 %NullCheck4, label %22, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
   %24 = load i16*, i16* addrspace(1)* %23, align 8
   %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %25, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
@@ -5859,8 +7313,8 @@ entry:
   store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
@@ -5874,8 +7328,8 @@ entry:
 
 ; <label>:37                                      ; preds = %65
   %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %37
   %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
@@ -5886,16 +7340,16 @@ entry:
   %45 = bitcast i16* %41 to i8*
   %46 = getelementptr inbounds i8, i8* %45, i64 %44
   %47 = bitcast i8* %46 to i16*
-  %NullCheck14 = icmp ne i16* %47, null
-  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %47, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %48
 
 ; <label>:48                                      ; preds = %39
   %49 = load i16, i16* %47, align 8
   %50 = zext i16 %49 to i32
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %52 = load i32, i32* %loc1
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %53
 
 ; <label>:53                                      ; preds = %48
   %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
@@ -5916,8 +7370,8 @@ entry:
 ; <label>:62                                      ; preds = %36, %59
   %63 = load i32, i32* %loc1
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck10, label %65, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %65
 
 ; <label>:65                                      ; preds = %62
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
@@ -5936,15 +7390,15 @@ entry:
 
 ; <label>:74                                      ; preds = %70
   %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
-  br i1 %NullCheck18, label %76, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %76
 
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
   %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
-  br i1 %NullCheck20, label %80, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
   %81 = load i64, i64 addrspace(1)* %79
@@ -5958,8 +7412,8 @@ entry:
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
   %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
-  br i1 %NullCheck22, label %92, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.String addrspace(1)* %90, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %92
 
 ; <label>:92                                      ; preds = %80
   %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
@@ -5969,15 +7423,15 @@ entry:
 
 ; <label>:96                                      ; preds = %70
   %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
-  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %98
 
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
   %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
-  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
   %103 = load i64, i64 addrspace(1)* %101
@@ -5991,8 +7445,8 @@ entry:
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
   %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
-  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.String addrspace(1)* %112, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %114
 
 ; <label>:114                                     ; preds = %102
   %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
@@ -6004,59 +7458,59 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %20
+ThrowNullRef4:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %22
+ThrowNullRef6:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %26
+ThrowNullRef8:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %62
+ThrowNullRef10:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %48
+ThrowNullRef16:                                   ; preds = %48
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %74
+ThrowNullRef18:                                   ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %76
+ThrowNullRef20:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %80
+ThrowNullRef22:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %96
+ThrowNullRef24:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %98
+ThrowNullRef26:                                   ; preds = %98
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %102
+ThrowNullRef28:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6069,15 +7523,15 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
   %3 = load i16*, i16* addrspace(1)* %2, align 8
   %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
@@ -6087,8 +7541,8 @@ entry:
   %10 = bitcast i16* %3 to i8*
   %11 = getelementptr inbounds i8, i8* %10, i64 %9
   %12 = bitcast i8* %11 to i16*
-  %NullCheck4 = icmp ne i16* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %5
   store i16 0, i16* %12, align 8
@@ -6098,11 +7552,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6119,8 +7573,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -6131,8 +7585,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
@@ -6144,15 +7598,15 @@ entry:
 
 ; <label>:14                                      ; preds = %1
   %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
   %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
   %21 = load i64, i64 addrspace(1)* %19
@@ -6171,15 +7625,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %14
+ThrowNullRef4:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %16
+ThrowNullRef6:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6302,14 +7756,6 @@ entry:
   ret %System.String addrspace(1)* %57
 }
 
-INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
-Successfully read RuntimeHelpers.get_OffsetToStringData
-
-define i32 @RuntimeHelpers.get_OffsetToStringData() {
-entry:
-  ret i32 12
-}
-
 INFO:  jitting method String::Equals using LLILCJit
 Successfully read String.Equals
 
@@ -6381,8 +7827,8 @@ entry:
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
-  br i1 %NullCheck24, label %29, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
   %30 = load i64, i64 addrspace(1)* %28
@@ -6397,8 +7843,8 @@ entry:
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
-  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
   %43 = load i64, i64 addrspace(1)* %41
@@ -6418,8 +7864,8 @@ entry:
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
   %59 = load i64, i64 addrspace(1)* %57
@@ -6434,8 +7880,8 @@ entry:
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck22, label %71, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
   %72 = load i64, i64 addrspace(1)* %70
@@ -6455,8 +7901,8 @@ entry:
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
-  br i1 %NullCheck16, label %87, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = load i64, i64 addrspace(1)* %86
@@ -6471,8 +7917,8 @@ entry:
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck18, label %100, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
   %101 = load i64, i64 addrspace(1)* %99
@@ -6492,8 +7938,8 @@ entry:
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
-  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
   %117 = load i64, i64 addrspace(1)* %115
@@ -6508,8 +7954,8 @@ entry:
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
-  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
   %130 = load i64, i64 addrspace(1)* %128
@@ -6528,15 +7974,15 @@ entry:
 
 ; <label>:142                                     ; preds = %22
   %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
-  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %143, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %144
 
 ; <label>:144                                     ; preds = %142
   %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
   %146 = load i32, i32 addrspace(1)* %145
   %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
-  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %147, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %148
 
 ; <label>:148                                     ; preds = %144
   %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
@@ -6557,15 +8003,15 @@ entry:
 
 ; <label>:159                                     ; preds = %22
   %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
-  br i1 %NullCheck, label %161, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %ThrowNullRef, label %161
 
 ; <label>:161                                     ; preds = %159
   %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
   %163 = load i32, i32 addrspace(1)* %162
   %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
-  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %164, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %165
 
 ; <label>:165                                     ; preds = %161
   %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
@@ -6578,8 +8024,8 @@ entry:
 
 ; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
-  br i1 %NullCheck4, label %172, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %171, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %172
 
 ; <label>:172                                     ; preds = %170
   %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
@@ -6589,8 +8035,8 @@ entry:
 
 ; <label>:176                                     ; preds = %172
   %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
-  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %177, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %178
 
 ; <label>:178                                     ; preds = %176
   %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
@@ -6629,55 +8075,55 @@ ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %161
+ThrowNullRef2:                                    ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %170
+ThrowNullRef4:                                    ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %176
+ThrowNullRef6:                                    ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %142
+ThrowNullRef8:                                    ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %144
+ThrowNullRef10:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %113
+ThrowNullRef12:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %116
+ThrowNullRef14:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %84
+ThrowNullRef16:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %87
+ThrowNullRef18:                                   ; preds = %87
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %55
+ThrowNullRef20:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %58
+ThrowNullRef22:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %26
+ThrowNullRef24:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %29
+ThrowNullRef26:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,8 +8161,8 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck, label %14, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %ThrowNullRef, label %14
 
 ; <label>:14                                      ; preds = %8
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
@@ -6760,8 +8206,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
@@ -6770,14 +8216,14 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32, i32* %loc0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %10
   %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
   %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
@@ -6790,15 +8236,15 @@ entry:
 ; <label>:25                                      ; preds = %19
   %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
-  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
   %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
@@ -6807,8 +8253,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %37 = load i32, i32* %loc0
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %38, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %38
 
 ; <label>:38                                      ; preds = %32
   %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
@@ -6817,14 +8263,14 @@ entry:
 
 ; <label>:40                                      ; preds = %19
   %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %40
   %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
   %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
-  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
-  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
@@ -6832,8 +8278,8 @@ entry:
   %48 = zext i32 %47 to i64
   %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
-  br i1 %NullCheck16, label %51, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %51
 
 ; <label>:51                                      ; preds = %45
   %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
@@ -6847,15 +8293,15 @@ entry:
 ; <label>:57                                      ; preds = %51
   %58 = load i16*, i16** %arg1
   %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
-  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %60
 
 ; <label>:60                                      ; preds = %57
   %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
   %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
-  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %64
 
 ; <label>:64                                      ; preds = %60
   %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
@@ -6864,22 +8310,22 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
   %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
-  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %70
 
 ; <label>:70                                      ; preds = %64
   %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
   %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
-  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
-  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
   %75 = load i32, i32 addrspace(1)* %74
   %76 = zext i32 %75 to i64
   %77 = trunc i64 %76 to i32
-  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
-  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %78
 
 ; <label>:78                                      ; preds = %73
   %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
@@ -6901,8 +8347,8 @@ entry:
   %90 = bitcast i16* %86 to i8*
   %91 = getelementptr inbounds i8, i8* %90, i64 %89
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %93
 
 ; <label>:93                                      ; preds = %80
   %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
@@ -6912,8 +8358,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %99 = load i32, i32* %loc2
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %100
 
 ; <label>:100                                     ; preds = %93
   %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
@@ -6928,63 +8374,63 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %25
+ThrowNullRef6:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %32
+ThrowNullRef10:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %40
+ThrowNullRef12:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %45
+ThrowNullRef16:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %57
+ThrowNullRef18:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %60
+ThrowNullRef20:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %64
+ThrowNullRef22:                                   ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %70
+ThrowNullRef24:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %73
+ThrowNullRef26:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %80
+ThrowNullRef28:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %93
+ThrowNullRef30:                                   ; preds = %93
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7004,8 +8450,8 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
@@ -7033,43 +8479,43 @@ entry:
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %14
   %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
   %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   %28 = load i32, i32 addrspace(1)* %27, align 8
   %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
-  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %30
 
 ; <label>:30                                      ; preds = %26
   %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
   %32 = load i32, i32 addrspace(1)* %31, align 8
   %33 = add i32 %28, %32
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %34
 
 ; <label>:34                                      ; preds = %30
   %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   store i32 %33, i32 addrspace(1)* %35
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
   store i32 0, i32 addrspace(1)* %38
   %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %40
 
 ; <label>:40                                      ; preds = %37
   %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
@@ -7082,8 +8528,8 @@ entry:
 
 ; <label>:47                                      ; preds = %40
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
@@ -7098,8 +8544,8 @@ entry:
   %54 = load i32, i32* %loc0
   %55 = sext i32 %54 to i64
   %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
-  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %57
 
 ; <label>:57                                      ; preds = %52
   %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
@@ -7110,68 +8556,35 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %14
+ThrowNullRef2:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %23
+ThrowNullRef4:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %26
+ThrowNullRef6:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %30
+ThrowNullRef8:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %34
+ThrowNullRef10:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %47
+ThrowNullRef14:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %52
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-}
-
-INFO:  jitting method StringBuilder::get_Length using LLILCJit
-Successfully read StringBuilder.get_Length
-
-define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.StringBuilder addrspace(1)*
-  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
-  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
-
-; <label>:1                                       ; preds = %entry
-  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %3 = load i32, i32 addrspace(1)* %2, align 8
-  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
-
-; <label>:5                                       ; preds = %1
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = add i32 %3, %7
-  ret i32 %8
-
-ThrowNullRef:                                     ; preds = %entry
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef16:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7213,70 +8626,70 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
   %6 = load i32, i32 addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
   store i32 %6, i32 addrspace(1)* %8
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
   %13 = load i32, i32 addrspace(1)* %12, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
   store i32 %13, i32 addrspace(1)* %15
   %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
-  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %18
 
 ; <label>:18                                      ; preds = %14
   %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
   %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
   %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
   %34 = load i32, i32 addrspace(1)* %33, align 8
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
-  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
@@ -7287,39 +8700,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %28
+ThrowNullRef16:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %32
+ThrowNullRef18:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7455,13 +8868,13 @@ entry:
 ; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
@@ -7477,16 +8890,16 @@ entry:
 
 ; <label>:18                                      ; preds = %15
   %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
   store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
   %22 = load i32, i32* %loc0
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %24
 
 ; <label>:24                                      ; preds = %20
   %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
@@ -7498,13 +8911,13 @@ entry:
 ; <label>:28                                      ; preds = %15, %24
   %29 = load i32, i32* %arg1
   %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %31
   %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
@@ -7517,20 +8930,20 @@ entry:
   %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
-  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
   %46 = load i32, i32 addrspace(1)* %45, align 8
   %47 = sub i32 %40, %46
-  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
-  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i32 addrspace(1)* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %48
 
 ; <label>:48                                      ; preds = %44
   store i32 %47, i32 addrspace(1)* %39, align 8
@@ -7538,21 +8951,21 @@ entry:
 
 ; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
-  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %51
 
 ; <label>:51                                      ; preds = %49
   %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %53
 
 ; <label>:53                                      ; preds = %51
   %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
   %55 = load i32, i32 addrspace(1)* %54, align 8
   %56 = load i32, i32* %arg2
   %57 = sub i32 %55, %56
-  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %58
 
 ; <label>:58                                      ; preds = %53
   %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
@@ -7562,13 +8975,13 @@ entry:
 ; <label>:60                                      ; preds = %33, %58
   %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
   %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
-  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %63
 
 ; <label>:63                                      ; preds = %60
   %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
-  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
-  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
@@ -7578,15 +8991,15 @@ entry:
 
 ; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
-  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i32 addrspace(1)* %69, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %70
 
 ; <label>:70                                      ; preds = %68
   %71 = load i32, i32 addrspace(1)* %69, align 8
   store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
-  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
@@ -7596,8 +9009,8 @@ entry:
   store i32 %77, i32* %loc4
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
-  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %80
 
 ; <label>:80                                      ; preds = %73
   %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
@@ -7607,71 +9020,71 @@ entry:
 ; <label>:83                                      ; preds = %80
   store i32 0, i32* %loc3
   %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
-  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
-  br i1 %NullCheck26, label %88, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i32 addrspace(1)* %87, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %88
 
 ; <label>:88                                      ; preds = %85
   %89 = load i32, i32 addrspace(1)* %87, align 8
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
-  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %90
 
 ; <label>:90                                      ; preds = %88
   %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
   store i32 %89, i32 addrspace(1)* %91
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
-  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
-  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %96
 
 ; <label>:96                                      ; preds = %94
   %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
-  br i1 %NullCheck34, label %100, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %100
 
 ; <label>:100                                     ; preds = %96
   %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
-  br i1 %NullCheck36, label %102, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %102
 
 ; <label>:102                                     ; preds = %100
   %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
   %104 = load i32, i32 addrspace(1)* %103, align 8
   %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
-  br i1 %NullCheck38, label %106, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %106
 
 ; <label>:106                                     ; preds = %102
   %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
-  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
-  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %108
 
 ; <label>:108                                     ; preds = %106
   %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
   %110 = load i32, i32 addrspace(1)* %109, align 8
   %111 = add i32 %104, %110
-  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %112
 
 ; <label>:112                                     ; preds = %108
   %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
   store i32 %111, i32 addrspace(1)* %113
   %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
-  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i32 addrspace(1)* %114, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %115
 
 ; <label>:115                                     ; preds = %112
   %116 = load i32, i32 addrspace(1)* %114, align 8
@@ -7681,19 +9094,19 @@ entry:
 ; <label>:118                                     ; preds = %115
   %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
-  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %121
 
 ; <label>:121                                     ; preds = %118
   %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
-  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
-  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %123
 
 ; <label>:123                                     ; preds = %121
   %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
   %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
-  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
-  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %126
 
 ; <label>:126                                     ; preds = %123
   %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
@@ -7705,8 +9118,8 @@ entry:
 
 ; <label>:130                                     ; preds = %80, %115, %126
   %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %132
 
 ; <label>:132                                     ; preds = %130
   %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7715,8 +9128,8 @@ entry:
   %136 = load i32, i32* %loc3
   %137 = sub i32 %135, %136
   %138 = sub i32 %134, %137
-  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %139
 
 ; <label>:139                                     ; preds = %132
   %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7728,16 +9141,16 @@ entry:
 
 ; <label>:144                                     ; preds = %139
   %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
-  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %146
 
 ; <label>:146                                     ; preds = %144
   %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
   %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
   %149 = load i32, i32* %loc2
   %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
-  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %151
 
 ; <label>:151                                     ; preds = %146
   %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
@@ -7754,145 +9167,249 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %18
+ThrowNullRef4:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %31
+ThrowNullRef10:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %44
+ThrowNullRef16:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %68
+ThrowNullRef18:                                   ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %70
+ThrowNullRef20:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %73
+ThrowNullRef22:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %83
+ThrowNullRef24:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %85
+ThrowNullRef26:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %88
+ThrowNullRef28:                                   ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %90
+ThrowNullRef30:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %94
+ThrowNullRef32:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %96
+ThrowNullRef34:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %100
+ThrowNullRef36:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %102
+ThrowNullRef38:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %106
+ThrowNullRef40:                                   ; preds = %106
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %108
+ThrowNullRef42:                                   ; preds = %108
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %112
+ThrowNullRef44:                                   ; preds = %112
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %118
+ThrowNullRef46:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %121
+ThrowNullRef48:                                   ; preds = %121
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %123
+ThrowNullRef50:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %130
+ThrowNullRef52:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %132
+ThrowNullRef54:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %144
+ThrowNullRef56:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %146
+ThrowNullRef58:                                   ; preds = %146
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %60
+ThrowNullRef60:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %63
+ThrowNullRef62:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %49
+ThrowNullRef64:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %51
+ThrowNullRef66:                                   ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %53
+ThrowNullRef68:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(%"System.Char[]" addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %arg0 = alloca %"System.Char[]" addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store %"System.Char[]" addrspace(1)* %param0, %"System.Char[]" addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load i32, i32* %arg4
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %43, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %38, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg1
+  %13 = load i32, i32* %arg4
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %38, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %24 = load i32, i32* %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %35 = load i32, i32* %arg3
+  %36 = load i32, i32* %arg4
+  %37 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %37, %"System.Char[]" addrspace(1)* %34, i32 %35, i32 %36)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:38                                      ; preds = %5, %16
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Successfully read Buffer._Memmove
 
@@ -7914,7 +9431,7 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[loadElem]
+Failed to read AppDomain.SetDataHelper[storeElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -7923,8 +9440,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
@@ -7934,8 +9451,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
@@ -7947,15 +9464,15 @@ entry:
   %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
   %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
@@ -7966,15 +9483,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7992,7 +9509,79 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
-Failed to read Dictionary`2.TryGetValue[loadElemA]
+Successfully read Dictionary`2.TryGetValue
+
+define i8 @"Dictionary`2.TryGetValue"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)* addrspace(1)* %param2) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  %arg2 = alloca %System.__Canon addrspace(1)* addrspace(1)*
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  store %System.__Canon addrspace(1)* addrspace(1)* %param2, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  store i32 %2, i32* %loc0
+  %3 = load i32, i32* %loc0
+  %4 = icmp slt i32 %3, 0
+  br i1 %4, label %22, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 2
+  %10 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %9, align 8
+  %11 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = zext i32 %11 to i64
+  %BoundsCheck = icmp uge i64 %16, %15
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 3, i32 %11
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %20, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %6, %System.__Canon addrspace(1)* %21)
+  ret i8 1
+
+; <label>:22                                      ; preds = %entry
+  %23 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %23, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -8058,8 +9647,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
@@ -8091,8 +9680,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
@@ -8171,15 +9760,15 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck, label %19, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %ThrowNullRef, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
   %21 = load i32, i32 addrspace(1)* %20
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
@@ -8202,7 +9791,7 @@ ThrowNullRef:                                     ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %19
+ThrowNullRef2:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8248,8 +9837,8 @@ entry:
   %0 = alloca %System.AppDomainHandle
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %1 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %1, i32 0, i32 15
@@ -8269,8 +9858,8 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
@@ -8286,7 +9875,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -8299,8 +9888,8 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -8327,8 +9916,8 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
@@ -8352,8 +9941,8 @@ entry:
   %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
   store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
@@ -8363,8 +9952,8 @@ entry:
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
@@ -8374,8 +9963,8 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %9
   %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
@@ -8384,8 +9973,8 @@ entry:
 
 ; <label>:18                                      ; preds = %3, %16
   %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
@@ -8397,15 +9986,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %18
+ThrowNullRef6:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8418,8 +10007,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
@@ -8453,15 +10042,15 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
@@ -8473,7 +10062,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8481,7 +10070,7 @@ ThrowNullRef1:                                    ; preds = %1
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
 Failed to read Dictionary`2.System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
@@ -8506,8 +10095,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
@@ -8524,8 +10113,8 @@ entry:
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -8544,7 +10133,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8577,8 +10166,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = load i64, i64* %arg2
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = trunc i32 %3 to i8
@@ -8634,46 +10223,46 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
   %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
-  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
-  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
-  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
@@ -8684,27 +10273,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %20
+ThrowNullRef12:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8717,8 +10306,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -8756,22 +10345,22 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
   %9 = load i64, i64 addrspace(1)* %8, align 8
   %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
   %13 = load i64, i64 addrspace(1)* %12, align 8
   %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %11
   %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
@@ -8788,11 +10377,11 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8882,8 +10471,8 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
@@ -8900,8 +10489,8 @@ entry:
 ; <label>:8                                       ; preds = %1
   %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
   %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
@@ -8911,15 +10500,15 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
   %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
   %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
-  br i1 %NullCheck6, label %21, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
@@ -8946,15 +10535,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8992,15 +10581,15 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
   store i8 %3, i8 addrspace(1)* %5
   %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
@@ -9011,7 +10600,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9027,8 +10616,8 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -9041,8 +10630,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
@@ -9058,7 +10647,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9080,8 +10669,8 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
@@ -9096,8 +10685,8 @@ entry:
 ; <label>:12                                      ; preds = %6
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
@@ -9112,8 +10701,8 @@ entry:
 ; <label>:21                                      ; preds = %15
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
@@ -9128,8 +10717,8 @@ entry:
 ; <label>:30                                      ; preds = %24
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %31, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
@@ -9144,8 +10733,8 @@ entry:
 ; <label>:39                                      ; preds = %33
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
-  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %40, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %42
 
 ; <label>:42                                      ; preds = %39
   %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
@@ -9164,19 +10753,19 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %21
+ThrowNullRef4:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %30
+ThrowNullRef6:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %39
+ThrowNullRef8:                                    ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9243,8 +10832,8 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
@@ -9264,57 +10853,57 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
   store i8 0, i8 addrspace(1)* %2
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
   store i8 0, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
   store i8 0, i8 addrspace(1)* %17
   %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
   store i8 0, i8 addrspace(1)* %20
   %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
-  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
@@ -9325,31 +10914,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %19
+ThrowNullRef14:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9367,8 +10956,8 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
@@ -9380,8 +10969,8 @@ entry:
 
 ; <label>:9                                       ; preds = %4
   %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %9
   %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
@@ -9395,7 +10984,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef2:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9420,8 +11009,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
@@ -9512,8 +11101,8 @@ entry:
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
@@ -9524,8 +11113,8 @@ entry:
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = load i64, i64 addrspace(1)* %12
@@ -9537,8 +11126,8 @@ entry:
   %20 = load i64, i64* %19
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
-  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %13
   %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
@@ -9555,8 +11144,8 @@ entry:
 ; <label>:30                                      ; preds = %25
   %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %32 = load i32, i32* %arg2
-  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
-  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
@@ -9570,15 +11159,15 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %30
+ThrowNullRef2:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9622,87 +11211,87 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
   %10 = load i8, i8 addrspace(1)* %9, align 8
   %11 = zext i8 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %8
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
   store i8 %12, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
   %19 = load i8, i8 addrspace(1)* %18, align 8
   %20 = zext i8 %19 to i32
   %21 = trunc i32 %20 to i8
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
   store i8 %21, i8 addrspace(1)* %23
   %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
   %28 = load i8, i8 addrspace(1)* %27, align 8
   %29 = zext i8 %28 to i32
   %30 = trunc i32 %29 to i8
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
-  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %31
 
 ; <label>:31                                      ; preds = %26
   %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
   store i8 %30, i8 addrspace(1)* %32
   %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
-  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
-  br i1 %NullCheck14, label %40, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %40
 
 ; <label>:40                                      ; preds = %35
   %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
   store i8 %39, i8 addrspace(1)* %41
   %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
-  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %44
 
 ; <label>:44                                      ; preds = %40
   %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
   %46 = load i8, i8 addrspace(1)* %45, align 8
   %47 = zext i8 %46 to i32
   %48 = trunc i32 %47 to i8
-  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
   store i8 %48, i8 addrspace(1)* %50
   %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
-  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
@@ -9713,29 +11302,29 @@ entry:
 ; <label>:56                                      ; preds = %52
   %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
-  br i1 %NullCheck22, label %59, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
   %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
   %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
-  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
-  br i1 %NullCheck24, label %63, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
   %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
-  br i1 %NullCheck26, label %66, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
   %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
-  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
-  br i1 %NullCheck28, label %69, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %69
 
 ; <label>:69                                      ; preds = %66
   %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
@@ -9744,15 +11333,15 @@ entry:
 
 ; <label>:71                                      ; preds = %105
   %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
-  br i1 %NullCheck34, label %73, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %73
 
 ; <label>:73                                      ; preds = %71
   %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
   %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
   %76 = load i32, i32* %loc0
-  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
-  br i1 %NullCheck36, label %77, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
@@ -9766,8 +11355,8 @@ entry:
 
 ; <label>:83                                      ; preds = %77
   %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
-  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
@@ -9775,14 +11364,14 @@ entry:
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
   %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
-  br i1 %NullCheck40, label %91, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
 ; <label>:91                                      ; preds = %85
   %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
   %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
-  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck42, label %94, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %94
 
 ; <label>:94                                      ; preds = %91
   %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
@@ -9798,14 +11387,14 @@ entry:
 ; <label>:99                                      ; preds = %69, %96
   %100 = load i32, i32* %loc0
   %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
-  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %102
 
 ; <label>:102                                     ; preds = %99
   %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
   %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
-  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
-  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
@@ -9819,87 +11408,87 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %26
+ThrowNullRef10:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %31
+ThrowNullRef12:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %35
+ThrowNullRef14:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %40
+ThrowNullRef16:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %56
+ThrowNullRef22:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %59
+ThrowNullRef24:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %63
+ThrowNullRef26:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %66
+ThrowNullRef28:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %102
+ThrowNullRef32:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %71
+ThrowNullRef34:                                   ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %73
+ThrowNullRef36:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %83
+ThrowNullRef38:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %85
+ThrowNullRef40:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %91
+ThrowNullRef42:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9943,15 +11532,15 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
   %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
@@ -9961,28 +11550,28 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
   %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %12
   %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
   %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
   %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
-  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
@@ -9993,23 +11582,23 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %12
+ThrowNullRef6:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10031,15 +11620,15 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
   %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = load i64, i64 addrspace(1)* %7
@@ -10077,13 +11666,13 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[loadElem]
+Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -10111,8 +11700,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -10178,8 +11767,8 @@ entry:
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load double, double* %arg0
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -10313,8 +11902,8 @@ entry:
   store i64 %param0, i64* %arg0
   store i64 %param1, i64* %arg1
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
@@ -10322,8 +11911,8 @@ entry:
   %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
   %5 = load i16*, i16* addrspace(1)* %4, align 8
   %6 = addrspacecast i64* %arg1 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = bitcast i64 addrspace(1)* %6 to i8 addrspace(1)*
@@ -10339,7 +11928,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10373,8 +11962,8 @@ entry:
   %1 = load i32, i32* %arg1
   %2 = sext i32 %1 to i64
   %3 = inttoptr i64 %2 to i16*
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -10427,8 +12016,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, i32)*)(%System.IO.ConsoleStream addrspace(1)* %2, i32 %1)
   %3 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %4 = load i64, i64* %arg1
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
@@ -10439,8 +12028,8 @@ entry:
   %10 = icmp eq i32 %9, 3
   %11 = sext i1 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %5
   %14 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, i32 0, i32 5
@@ -10451,7 +12040,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10474,8 +12063,8 @@ entry:
   %5 = icmp eq i32 %4, 1
   %6 = sext i1 %5 to i32
   %7 = trunc i32 %6 to i8
-  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %2, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.ConsoleStream addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
@@ -10486,8 +12075,8 @@ entry:
   %13 = icmp eq i32 %12, 2
   %14 = sext i1 %13 to i32
   %15 = trunc i32 %14 to i8
-  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %10, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.ConsoleStream addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %8
   %17 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %10, i32 0, i32 4
@@ -10498,7 +12087,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10537,8 +12126,8 @@ entry:
   %arg0 = alloca i64
   store i64 %param0, i64* %arg0
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
@@ -10573,8 +12162,8 @@ entry:
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
   %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = load i64, i64 addrspace(1)* %7
@@ -10678,7 +12267,127 @@ entry:
 INFO:  jitting method Encoding::GetEncoding using LLILCJit
 Failed to read Encoding.GetEncoding[convertToHelperArgumentType]
 INFO:  jitting method EncodingProvider::GetEncodingFromProvider using LLILCJit
-Failed to read EncodingProvider.GetEncodingFromProvider[loadElem]
+Successfully read EncodingProvider.GetEncodingFromProvider
+
+define %System.Text.Encoding addrspace(1)* @EncodingProvider.GetEncodingFromProvider(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca %"System.Text.EncodingProvider[]" addrspace(1)*
+  %loc1 = alloca %System.Text.EncodingProvider addrspace(1)*
+  %loc2 = alloca %System.Text.Encoding addrspace(1)*
+  %loc3 = alloca %System.Text.Encoding addrspace(1)*
+  %loc4 = alloca %"System.Text.EncodingProvider[]" addrspace(1)*
+  %loc5 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1059)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2392
+  %2 = addrspacecast i8 addrspace(1)* %1 to %"System.Text.EncodingProvider[]" addrspace(1)**
+  %3 = load volatile %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %2
+  %4 = icmp ne %"System.Text.EncodingProvider[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %entry
+  ret %System.Text.Encoding addrspace(1)* null
+
+; <label>:6                                       ; preds = %entry
+  %7 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1059)
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i64 2392
+  %9 = addrspacecast i8 addrspace(1)* %8 to %"System.Text.EncodingProvider[]" addrspace(1)**
+  %10 = load volatile %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %9
+  store %"System.Text.EncodingProvider[]" addrspace(1)* %10, %"System.Text.EncodingProvider[]" addrspace(1)** %loc0
+  %11 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc0
+  store %"System.Text.EncodingProvider[]" addrspace(1)* %11, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  store i32 0, i32* %loc5
+  br label %43
+
+; <label>:12                                      ; preds = %46
+  %13 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  %14 = load i32, i32* %loc5
+  %NullCheck1 = icmp eq %"System.Text.EncodingProvider[]" addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %13, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = zext i32 %17 to i64
+  %19 = zext i32 %14 to i64
+  %BoundsCheck = icmp uge i64 %19, %18
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %20
+
+; <label>:20                                      ; preds = %15
+  %21 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %13, i32 0, i32 3, i32 %14
+  %22 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)* addrspace(1)* %21, align 8
+  store %System.Text.EncodingProvider addrspace(1)* %22, %System.Text.EncodingProvider addrspace(1)** %loc1
+  %23 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)** %loc1
+  %24 = load i32, i32* %arg0
+  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i64 addrspace(1)*
+  %NullCheck3 = icmp eq i64 addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
+
+; <label>:26                                      ; preds = %20
+  %27 = load i64, i64 addrspace(1)* %25
+  %28 = add i64 %27, 64
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 40
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Text.Encoding addrspace(1)* (%System.Text.EncodingProvider addrspace(1)*, i32)*
+  %35 = call %System.Text.Encoding addrspace(1)* %34(%System.Text.EncodingProvider addrspace(1)* %23, i32 %24)
+  store %System.Text.Encoding addrspace(1)* %35, %System.Text.Encoding addrspace(1)** %loc2
+  %36 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc2
+  %37 = icmp eq %System.Text.Encoding addrspace(1)* %36, null
+  br i1 %37, label %40, label %38
+
+; <label>:38                                      ; preds = %26
+  %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc2
+  store %System.Text.Encoding addrspace(1)* %39, %System.Text.Encoding addrspace(1)** %loc3
+  br label %53
+
+; <label>:40                                      ; preds = %26
+  %41 = load i32, i32* %loc5
+  %42 = add i32 %41, 1
+  store i32 %42, i32* %loc5
+  br label %43
+
+; <label>:43                                      ; preds = %6, %40
+  %44 = load i32, i32* %loc5
+  %45 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  %NullCheck = icmp eq %"System.Text.EncodingProvider[]" addrspace(1)* %45, null
+  br i1 %NullCheck, label %ThrowNullRef, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp slt i32 %44, %50
+  br i1 %51, label %12, label %52
+
+; <label>:52                                      ; preds = %46
+  ret %System.Text.Encoding addrspace(1)* null
+
+; <label>:53                                      ; preds = %38
+  %54 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc3
+  ret %System.Text.Encoding addrspace(1)* %54
+
+ThrowNullRef:                                     ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method EncodingProvider::.cctor using LLILCJit
 Successfully read EncodingProvider..cctor
 
@@ -10697,7 +12406,7 @@ Failed to read Encoding.get_InternalSyncObject[Call HasTypeArg]
 INFO:  jitting method Hashtable::.ctor using LLILCJit
 Failed to read Hashtable..ctor[Volatile store]
 INFO:  jitting method Hashtable::get_Item using LLILCJit
-Failed to read Hashtable.get_Item[loadElemA]
+Failed to read Hashtable.get_Item[loadNonPrimitiveObj]
 INFO:  jitting method Hashtable::InitHash using LLILCJit
 Successfully read Hashtable.InitHash
 
@@ -10717,8 +12426,8 @@ entry:
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -10734,15 +12443,15 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
   %15 = load i32, i32* %loc0
-  %NullCheck2 = icmp ne i32 addrspace(1)* %14, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i32 addrspace(1)* %14, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %3
   store i32 %15, i32 addrspace(1)* %14, align 8
   %17 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %18 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %NullCheck4 = icmp ne i32 addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i32 addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = load i32, i32 addrspace(1)* %18, align 8
@@ -10751,8 +12460,8 @@ entry:
   %23 = sub i32 %22, 1
   %24 = urem i32 %21, %23
   %25 = add i32 1, %24
-  %NullCheck6 = icmp ne i32 addrspace(1)* %17, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32 addrspace(1)* %17, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %19
   store i32 %25, i32 addrspace(1)* %17, align 8
@@ -10763,15 +12472,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %19
+ThrowNullRef6:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10786,8 +12495,8 @@ entry:
   store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
   store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %NullCheck = icmp ne %System.Collections.Hashtable addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Collections.Hashtable addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
@@ -10797,16 +12506,16 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Collections.Hashtable addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Collections.Hashtable addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
   %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck4 = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %9, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
   %13 = inttoptr i64 %11 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
@@ -10816,8 +12525,8 @@ entry:
 ; <label>:15                                      ; preds = %1
   %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -10835,15 +12544,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10857,8 +12566,8 @@ entry:
   store %System.Int32 addrspace(1)* %param0, %System.Int32 addrspace(1)** %this
   %0 = load %System.Int32 addrspace(1)*, %System.Int32 addrspace(1)** %this
   %1 = bitcast %System.Int32 addrspace(1)* %0 to i32 addrspace(1)*
-  %NullCheck = icmp ne i32 addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq i32 addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load i32, i32 addrspace(1)* %1, align 8
@@ -10934,8 +12643,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.UTF8Encoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
@@ -10944,15 +12653,15 @@ entry:
   %9 = load i8, i8* %arg2
   %10 = zext i8 %9 to i32
   %11 = trunc i32 %10 to i8
-  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %8, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %6
   %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %8, i32 0, i32 8
   store i8 %11, i8 addrspace(1)* %13
   %14 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %14, i32 0, i32 8
@@ -10964,8 +12673,8 @@ entry:
 ; <label>:20                                      ; preds = %15
   %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %22, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %22, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = load i64, i64 addrspace(1)* %22
@@ -10987,15 +12696,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %12
+ThrowNullRef4:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11010,8 +12719,8 @@ entry:
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
@@ -11033,16 +12742,16 @@ entry:
 ; <label>:10                                      ; preds = %1
   %11 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
   %12 = load i32, i32* %arg1
-  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %11, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.Encoding addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
   store i32 %12, i32 addrspace(1)* %14
   %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
   %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = load i64, i64 addrspace(1)* %16
@@ -11060,11 +12769,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11077,8 +12786,8 @@ entry:
   %this = alloca %System.Text.UTF8Encoding addrspace(1)*
   store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
   %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.UTF8Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
@@ -11090,16 +12799,16 @@ entry:
 ; <label>:6                                       ; preds = %1
   %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %8 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %10, %System.Text.EncoderFallback addrspace(1)* %8)
   %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %12 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
-  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %11, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %11, i32 0, i32 3
@@ -11112,8 +12821,8 @@ entry:
   %18 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %18, %System.String addrspace(1)* %17)
   %19 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %18 to %System.Text.EncoderFallback addrspace(1)*
-  %NullCheck6 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %16, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %16, i32 0, i32 2
@@ -11123,8 +12832,8 @@ entry:
   %24 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %24, %System.String addrspace(1)* %23)
   %25 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %24 to %System.Text.DecoderFallback addrspace(1)*
-  %NullCheck8 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %22, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %22, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %20
   %27 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %22, i32 0, i32 3
@@ -11135,19 +12844,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %20
+ThrowNullRef8:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11177,8 +12886,8 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load i32, i32* %arg1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -11196,8 +12905,8 @@ entry:
 ; <label>:15                                      ; preds = %8
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %17 = load i32, i32* %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 %17
@@ -11213,7 +12922,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11265,7 +12974,7 @@ entry:
 }
 
 INFO:  jitting method Hashtable::Insert using LLILCJit
-Failed to read Hashtable.Insert[loadElemA]
+Failed to read Hashtable.Insert[storeElem]
 INFO:  jitting method ConsoleEncoding::.ctor using LLILCJit
 Successfully read ConsoleEncoding..ctor
 
@@ -11280,8 +12989,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %1)
   %2 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
@@ -11317,8 +13026,8 @@ entry:
   %2 = call %System.Text.InternalEncoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalEncoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %1)
   %3 = bitcast %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2 to %System.Text.EncoderFallback addrspace(1)*
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
@@ -11328,8 +13037,8 @@ entry:
   %8 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %7)
   %9 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %8 to %System.Text.DecoderFallback addrspace(1)*
-  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %6, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.Encoding addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %4
   %11 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %6, i32 0, i32 3
@@ -11340,7 +13049,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11359,15 +13068,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* %1)
   %2 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   %6 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, i32 0, i32 1
@@ -11378,7 +13087,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11406,8 +13115,8 @@ entry:
   store %System.Text.InternalDecoderBestFitFallback addrspace(1)* %param0, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
   %0 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
@@ -11417,15 +13126,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %4)
   %5 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %6)
   %9 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, i32 0, i32 1
@@ -11436,11 +13145,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11508,8 +13217,8 @@ entry:
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
   %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = load i64, i64 addrspace(1)* %19
@@ -11573,8 +13282,8 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.ConsoleStream addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
@@ -11605,31 +13314,31 @@ entry:
   store i8 %param4, i8* %arg4
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %3, %System.IO.Stream addrspace(1)* %1)
   %4 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %4, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
   %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %4, i32 0, i32 4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %5)
   %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %6
   %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
   %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
   %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = load i64, i64 addrspace(1)* %13
@@ -11641,8 +13350,8 @@ entry:
   %21 = load i64, i64* %20
   %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %8, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %8, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %14
   %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 5
@@ -11660,24 +13369,24 @@ entry:
   %31 = load i32, i32* %arg3
   %32 = sext i32 %31 to i64
   %33 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %32)
-  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %30, null
-  br i1 %NullCheck10, label %34, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.StreamWriter addrspace(1)* %30, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %35, %"System.Char[]" addrspace(1)* %33)
   %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %37, null
-  br i1 %NullCheck12, label %38, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.StreamWriter addrspace(1)* %37, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %38
 
 ; <label>:38                                      ; preds = %34
   %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
   %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
   %41 = load i32, i32* %arg3
   %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %42, null
-  br i1 %NullCheck14, label %43, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %42, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
   %44 = load i64, i64 addrspace(1)* %42
@@ -11691,30 +13400,30 @@ entry:
   %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
   %53 = sext i32 %52 to i64
   %54 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %53)
-  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
-  br i1 %NullCheck16, label %55, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %55
 
 ; <label>:55                                      ; preds = %43
   %56 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %56, %"System.Byte[]" addrspace(1)* %54)
   %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %58 = load i32, i32* %arg3
-  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %57, null
-  br i1 %NullCheck18, label %59, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.StreamWriter addrspace(1)* %57, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %59
 
 ; <label>:59                                      ; preds = %55
   %60 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 10
   store i32 %58, i32 addrspace(1)* %60
   %61 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %61, null
-  br i1 %NullCheck20, label %62, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.IO.StreamWriter addrspace(1)* %61, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %62
 
 ; <label>:62                                      ; preds = %59
   %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
   %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
   %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
   %67 = load i64, i64 addrspace(1)* %65
@@ -11732,15 +13441,15 @@ entry:
 
 ; <label>:78                                      ; preds = %66
   %79 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %79, null
-  br i1 %NullCheck24, label %80, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.StreamWriter addrspace(1)* %79, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %80
 
 ; <label>:80                                      ; preds = %78
   %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
   %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
   %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %83, null
-  br i1 %NullCheck26, label %84, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %83, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
   %85 = load i64, i64 addrspace(1)* %83
@@ -11757,8 +13466,8 @@ entry:
 
 ; <label>:95                                      ; preds = %84
   %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.IO.StreamWriter addrspace(1)* %96, null
-  br i1 %NullCheck28, label %97, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.IO.StreamWriter addrspace(1)* %96, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %97
 
 ; <label>:97                                      ; preds = %95
   %98 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 12
@@ -11772,8 +13481,8 @@ entry:
   %103 = icmp eq i32 %102, 0
   %104 = sext i1 %103 to i32
   %105 = trunc i32 %104 to i8
-  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %100, null
-  br i1 %NullCheck30, label %106, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.IO.StreamWriter addrspace(1)* %100, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %106
 
 ; <label>:106                                     ; preds = %99
   %107 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %100, i32 0, i32 13
@@ -11784,63 +13493,63 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %6
+ThrowNullRef4:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %29
+ThrowNullRef10:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %34
+ThrowNullRef12:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %38
+ThrowNullRef14:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %43
+ThrowNullRef16:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %55
+ThrowNullRef18:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %59
+ThrowNullRef20:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %62
+ThrowNullRef22:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %78
+ThrowNullRef24:                                   ; preds = %78
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %80
+ThrowNullRef26:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %95
+ThrowNullRef28:                                   ; preds = %95
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11853,15 +13562,15 @@ entry:
   %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = load i64, i64 addrspace(1)* %4
@@ -11879,7 +13588,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11929,35 +13638,35 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
   %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderNLS addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %7 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.EncoderNLS addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Text.Encoding addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.Encoding addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Text.EncoderNLS addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.EncoderNLS addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
   %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck8 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = load i64, i64 addrspace(1)* %16
@@ -11976,19 +13685,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12014,8 +13723,8 @@ entry:
   %this = alloca %System.Text.Encoding addrspace(1)*
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
@@ -12035,15 +13744,15 @@ entry:
   %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
   store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
   %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
   store i32 0, i32 addrspace(1)* %2
   %3 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, i32 0, i32 2
@@ -12053,15 +13762,15 @@ entry:
 
 ; <label>:8                                       ; preds = %4
   %9 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
   %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
   %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = load i64, i64 addrspace(1)* %13
@@ -12082,15 +13791,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12105,16 +13814,16 @@ entry:
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = load i32, i32* %arg1
   %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
   %7 = load i64, i64 addrspace(1)* %5
@@ -12132,7 +13841,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12169,8 +13878,8 @@ entry:
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
   %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
   %16 = load i64, i64 addrspace(1)* %14
@@ -12191,8 +13900,8 @@ entry:
   %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
   %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
   %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %31, null
-  br i1 %NullCheck2, label %32, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = load i64, i64 addrspace(1)* %31
@@ -12235,7 +13944,7 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12248,14 +13957,14 @@ entry:
   %this = alloca %System.Text.EncoderReplacementFallback addrspace(1)*
   store %System.Text.EncoderReplacementFallback addrspace(1)* %param0, %System.Text.EncoderReplacementFallback addrspace(1)** %this
   %0 = load %System.Text.EncoderReplacementFallback addrspace(1)*, %System.Text.EncoderReplacementFallback addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -12266,7 +13975,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12296,8 +14005,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
@@ -12329,8 +14038,8 @@ entry:
   %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
   store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
@@ -12342,8 +14051,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Threading.Tasks.Task addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %7)
@@ -12366,7 +14075,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12385,8 +14094,8 @@ entry:
   store i8 %param1, i8* %arg1
   store i8 %param2, i8* %arg2
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
@@ -12400,8 +14109,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1, %5
   %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 9
@@ -12432,8 +14141,8 @@ entry:
 
 ; <label>:25                                      ; preds = %8, %20
   %26 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %26, null
-  br i1 %NullCheck4, label %27, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %26, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %26, i32 0, i32 12
@@ -12444,22 +14153,22 @@ entry:
 
 ; <label>:32                                      ; preds = %27
   %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %33, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.IO.StreamWriter addrspace(1)* %33, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %32
   %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 12
   store i8 1, i8 addrspace(1)* %35
   %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
-  br i1 %NullCheck8, label %37, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
   %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
   %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck10 = icmp ne i64 addrspace(1)* %40, null
-  br i1 %NullCheck10, label %41, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64 addrspace(1)* %40, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i64, i64 addrspace(1)* %40
@@ -12473,8 +14182,8 @@ entry:
   %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
   store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
   %51 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %NullCheck12 = icmp ne %"System.Byte[]" addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Byte[]" addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %41
   %53 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %51, i32 0, i32 1
@@ -12486,16 +14195,16 @@ entry:
 
 ; <label>:58                                      ; preds = %52
   %59 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %59, null
-  br i1 %NullCheck14, label %60, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.IO.StreamWriter addrspace(1)* %59, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %60
 
 ; <label>:60                                      ; preds = %58
   %61 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %59, i32 0, i32 3
   %62 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
   %64 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %NullCheck16 = icmp ne %"System.Byte[]" addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %"System.Byte[]" addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %60
   %66 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %64, i32 0, i32 1
@@ -12503,8 +14212,8 @@ entry:
   %68 = zext i32 %67 to i64
   %69 = trunc i64 %68 to i32
   %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck18, label %71, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
   %72 = load i64, i64 addrspace(1)* %70
@@ -12520,29 +14229,29 @@ entry:
 
 ; <label>:80                                      ; preds = %27, %52, %71
   %81 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %81, null
-  br i1 %NullCheck20, label %82, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.IO.StreamWriter addrspace(1)* %81, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
 
 ; <label>:82                                      ; preds = %80
   %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %81, i32 0, i32 5
   %84 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %83, align 8
   %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.IO.StreamWriter addrspace(1)* %85, null
-  br i1 %NullCheck22, label %86, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.IO.StreamWriter addrspace(1)* %85, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %86
 
 ; <label>:86                                      ; preds = %82
   %87 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 7
   %88 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %87, align 8
   %89 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %89, null
-  br i1 %NullCheck24, label %90, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.StreamWriter addrspace(1)* %89, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %90
 
 ; <label>:90                                      ; preds = %86
   %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %89, i32 0, i32 9
   %92 = load i32, i32 addrspace(1)* %91, align 8
   %93 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.IO.StreamWriter addrspace(1)* %93, null
-  br i1 %NullCheck26, label %94, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.IO.StreamWriter addrspace(1)* %93, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %93, i32 0, i32 6
@@ -12550,8 +14259,8 @@ entry:
   %97 = load i8, i8* %arg2
   %98 = zext i8 %97 to i32
   %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
-  %NullCheck28 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck28, label %100, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
   %101 = load i64, i64 addrspace(1)* %99
@@ -12566,8 +14275,8 @@ entry:
   %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
   store i32 %110, i32* %loc1
   %111 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %111, null
-  br i1 %NullCheck30, label %112, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.IO.StreamWriter addrspace(1)* %111, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %112
 
 ; <label>:112                                     ; preds = %100
   %113 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %111, i32 0, i32 9
@@ -12578,23 +14287,23 @@ entry:
 
 ; <label>:116                                     ; preds = %112
   %117 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck32 = icmp ne %System.IO.StreamWriter addrspace(1)* %117, null
-  br i1 %NullCheck32, label %118, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.IO.StreamWriter addrspace(1)* %117, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %118
 
 ; <label>:118                                     ; preds = %116
   %119 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %117, i32 0, i32 3
   %120 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %119, align 8
   %121 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.IO.StreamWriter addrspace(1)* %121, null
-  br i1 %NullCheck34, label %122, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.IO.StreamWriter addrspace(1)* %121, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %122
 
 ; <label>:122                                     ; preds = %118
   %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
   %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
   %125 = load i32, i32* %loc1
   %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
-  %NullCheck36 = icmp ne i64 addrspace(1)* %126, null
-  br i1 %NullCheck36, label %127, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64 addrspace(1)* %126, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
   %128 = load i64, i64 addrspace(1)* %126
@@ -12616,15 +14325,15 @@ entry:
 
 ; <label>:140                                     ; preds = %136
   %141 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.IO.StreamWriter addrspace(1)* %141, null
-  br i1 %NullCheck38, label %142, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.IO.StreamWriter addrspace(1)* %141, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %142
 
 ; <label>:142                                     ; preds = %140
   %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
   %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
   %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
-  %NullCheck40 = icmp ne i64 addrspace(1)* %145, null
-  br i1 %NullCheck40, label %146, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i64 addrspace(1)* %145, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
   %147 = load i64, i64 addrspace(1)* %145
@@ -12645,83 +14354,83 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %25
+ThrowNullRef4:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %32
+ThrowNullRef6:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %37
+ThrowNullRef10:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %41
+ThrowNullRef12:                                   ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %58
+ThrowNullRef14:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %60
+ThrowNullRef16:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %65
+ThrowNullRef18:                                   ; preds = %65
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %80
+ThrowNullRef20:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %82
+ThrowNullRef22:                                   ; preds = %82
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %86
+ThrowNullRef24:                                   ; preds = %86
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %90
+ThrowNullRef26:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %94
+ThrowNullRef28:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %100
+ThrowNullRef30:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %116
+ThrowNullRef32:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %118
+ThrowNullRef34:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %122
+ThrowNullRef36:                                   ; preds = %122
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %140
+ThrowNullRef38:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %142
+ThrowNullRef40:                                   ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12788,8 +14497,8 @@ entry:
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %1 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
-  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
@@ -12797,8 +14506,8 @@ entry:
   %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
   %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
   %8 = load i64, i64 addrspace(1)* %6
@@ -12814,8 +14523,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %17, %System.IFormatProvider addrspace(1)* %16)
   %18 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %19 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %18, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.SyncTextWriter addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %7
   %21 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %18, i32 0, i32 4
@@ -12826,11 +14535,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12843,8 +14552,8 @@ entry:
   %this = alloca %System.IO.TextWriter addrspace(1)*
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.TextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
@@ -12854,8 +14563,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.Threading.Thread addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Threading.Thread addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %6)
@@ -12864,8 +14573,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1
   %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.TextWriter addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.TextWriter addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %11, i32 0, i32 2
@@ -12876,11 +14585,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13077,8 +14786,8 @@ entry:
   store double %param1, double* %arg1
   store i8 0, i8* %loc1
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
@@ -13088,16 +14797,16 @@ entry:
   %5 = addrspacecast i8* %loc1 to i8 addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %4, i8 addrspace(1)* %5)
   %6 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.SyncTextWriter addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
   %10 = load double, double* %arg1
   %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
   %13 = load i64, i64 addrspace(1)* %11
@@ -13132,11 +14841,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13153,8 +14862,8 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load double, double* %arg1
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -13168,8 +14877,8 @@ entry:
   call void %11(%System.IO.TextWriter addrspace(1)* %0, double %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
   %15 = load i64, i64 addrspace(1)* %13
@@ -13187,7 +14896,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13205,8 +14914,8 @@ entry:
   %1 = addrspacecast double* %arg1 to double addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -13221,8 +14930,8 @@ entry:
   %14 = bitcast double addrspace(1)* %1 to %System.Double addrspace(1)*
   %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Double addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Double addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
   %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
   %18 = load i64, i64 addrspace(1)* %16
@@ -13240,7 +14949,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13256,8 +14965,8 @@ entry:
   store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
   %0 = load %System.Double addrspace(1)*, %System.Double addrspace(1)** %this
   %1 = bitcast %System.Double addrspace(1)* %0 to double addrspace(1)*
-  %NullCheck = icmp ne double addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq double addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load double, double addrspace(1)* %1, align 8
@@ -13282,8 +14991,8 @@ entry:
   %loc0 = alloca %System.Globalization.NumberFormatInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 3
@@ -13293,8 +15002,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
@@ -13304,24 +15013,24 @@ entry:
   store %System.Globalization.NumberFormatInfo addrspace(1)* %10, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
   %11 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %7
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
   %15 = load i8, i8 addrspace(1)* %14, align 8
   %16 = zext i8 %15 to i32
   %17 = trunc i32 %16 to i8
-  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %11, null
-  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %11, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %13
   %19 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %11, i32 0, i32 29
   store i8 %17, i8 addrspace(1)* %19
   %20 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %21 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %20, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %20, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %18
   %23 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %20, i32 0, i32 3
@@ -13330,8 +15039,8 @@ entry:
 
 ; <label>:24                                      ; preds = %1, %22
   %25 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %25, null
-  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %25, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %26
 
 ; <label>:26                                      ; preds = %24
   %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %25, i32 0, i32 3
@@ -13342,23 +15051,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %18
+ThrowNullRef8:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13383,168 +15092,168 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 18
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %8, align 8
-  %NullCheck2 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %5, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %5, i32 0, i32 4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %9)
   %12 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 19
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %15, align 8
-  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %12, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %12, i32 0, i32 5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %16)
   %19 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %20 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %20, null
-  br i1 %NullCheck8, label %21, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %20, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %20, i32 0, i32 23
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  %NullCheck10 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %19, null
-  br i1 %NullCheck10, label %24, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %19, i32 0, i32 7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %25, %System.String addrspace(1)* %23)
   %26 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %27 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %27, i32 0, i32 22
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %29, align 8
-  %NullCheck14 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %26, null
-  br i1 %NullCheck14, label %31, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %26, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %26, i32 0, i32 6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %32, %System.String addrspace(1)* %30)
   %33 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %34 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Globalization.CultureData addrspace(1)* %34, null
-  br i1 %NullCheck16, label %35, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Globalization.CultureData addrspace(1)* %34, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %34, i32 0, i32 51
   %37 = load i32, i32 addrspace(1)* %36, align 8
-  %NullCheck18 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %33, null
-  br i1 %NullCheck18, label %38, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %33, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %33, i32 0, i32 21
   store i32 %37, i32 addrspace(1)* %39
   %40 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %41 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Globalization.CultureData addrspace(1)* %41, null
-  br i1 %NullCheck20, label %42, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Globalization.CultureData addrspace(1)* %41, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %41, i32 0, i32 52
   %44 = load i32, i32 addrspace(1)* %43, align 8
-  %NullCheck22 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %40, null
-  br i1 %NullCheck22, label %45, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %40, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %40, i32 0, i32 25
   store i32 %44, i32 addrspace(1)* %46
   %47 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %48 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.Globalization.CultureData addrspace(1)* %48, null
-  br i1 %NullCheck24, label %49, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Globalization.CultureData addrspace(1)* %48, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %49
 
 ; <label>:49                                      ; preds = %45
   %50 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %48, i32 0, i32 29
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck26 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %47, null
-  br i1 %NullCheck26, label %52, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %47, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %47, i32 0, i32 10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %53, %System.String addrspace(1)* %51)
   %54 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %55 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Globalization.CultureData addrspace(1)* %55, null
-  br i1 %NullCheck28, label %56, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Globalization.CultureData addrspace(1)* %55, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %56
 
 ; <label>:56                                      ; preds = %52
   %57 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %55, i32 0, i32 35
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %57, align 8
-  %NullCheck30 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %54, null
-  br i1 %NullCheck30, label %59, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %54, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %54, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %60, %System.String addrspace(1)* %58)
   %61 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %62 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck32 = icmp ne %System.Globalization.CultureData addrspace(1)* %62, null
-  br i1 %NullCheck32, label %63, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Globalization.CultureData addrspace(1)* %62, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %62, i32 0, i32 34
   %65 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %64, align 8
-  %NullCheck34 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %61, null
-  br i1 %NullCheck34, label %66, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %61, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %61, i32 0, i32 9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %67, %System.String addrspace(1)* %65)
   %68 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %69 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck36 = icmp ne %System.Globalization.CultureData addrspace(1)* %69, null
-  br i1 %NullCheck36, label %70, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Globalization.CultureData addrspace(1)* %69, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %70
 
 ; <label>:70                                      ; preds = %66
   %71 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %69, i32 0, i32 55
   %72 = load i32, i32 addrspace(1)* %71, align 8
-  %NullCheck38 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %68, null
-  br i1 %NullCheck38, label %73, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %68, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %68, i32 0, i32 22
   store i32 %72, i32 addrspace(1)* %74
   %75 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %76 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck40 = icmp ne %System.Globalization.CultureData addrspace(1)* %76, null
-  br i1 %NullCheck40, label %77, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Globalization.CultureData addrspace(1)* %76, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %76, i32 0, i32 57
   %79 = load i32, i32 addrspace(1)* %78, align 8
-  %NullCheck42 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %75, null
-  br i1 %NullCheck42, label %80, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %75, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %80
 
 ; <label>:80                                      ; preds = %77
   %81 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %75, i32 0, i32 24
   store i32 %79, i32 addrspace(1)* %81
   %82 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %83 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck44 = icmp ne %System.Globalization.CultureData addrspace(1)* %83, null
-  br i1 %NullCheck44, label %84, label %ThrowNullRef43
+  %NullCheck43 = icmp eq %System.Globalization.CultureData addrspace(1)* %83, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %84
 
 ; <label>:84                                      ; preds = %80
   %85 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %83, i32 0, i32 56
   %86 = load i32, i32 addrspace(1)* %85, align 8
-  %NullCheck46 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %82, null
-  br i1 %NullCheck46, label %87, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %82, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %82, i32 0, i32 23
@@ -13553,8 +15262,8 @@ entry:
 
 ; <label>:89                                      ; preds = %entry
   %90 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck100 = icmp ne %System.Globalization.CultureData addrspace(1)* %90, null
-  br i1 %NullCheck100, label %91, label %ThrowNullRef99
+  %NullCheck99 = icmp eq %System.Globalization.CultureData addrspace(1)* %90, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %91
 
 ; <label>:91                                      ; preds = %89
   %92 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %90, i32 0, i32 2
@@ -13572,8 +15281,8 @@ entry:
   %102 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %103 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %104 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %103)
-  %NullCheck48 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %102, null
-  br i1 %NullCheck48, label %105, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %102, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %105
 
 ; <label>:105                                     ; preds = %101
   %106 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %102, i32 0, i32 1
@@ -13581,8 +15290,8 @@ entry:
   %107 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %108 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %109 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %108)
-  %NullCheck50 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %107, null
-  br i1 %NullCheck50, label %110, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %107, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %110
 
 ; <label>:110                                     ; preds = %105
   %111 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %107, i32 0, i32 2
@@ -13590,8 +15299,8 @@ entry:
   %112 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %113 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %114 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %113)
-  %NullCheck52 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %112, null
-  br i1 %NullCheck52, label %115, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %112, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %115
 
 ; <label>:115                                     ; preds = %110
   %116 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %112, i32 0, i32 27
@@ -13599,8 +15308,8 @@ entry:
   %117 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %118 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %119 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %118)
-  %NullCheck54 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %117, null
-  br i1 %NullCheck54, label %120, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %117, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %120
 
 ; <label>:120                                     ; preds = %115
   %121 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %117, i32 0, i32 26
@@ -13608,8 +15317,8 @@ entry:
   %122 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %123 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %124 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %123)
-  %NullCheck56 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %122, null
-  br i1 %NullCheck56, label %125, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %122, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %125
 
 ; <label>:125                                     ; preds = %120
   %126 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %122, i32 0, i32 17
@@ -13617,8 +15326,8 @@ entry:
   %127 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %128 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %129 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %128)
-  %NullCheck58 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %127, null
-  br i1 %NullCheck58, label %130, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %127, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %130
 
 ; <label>:130                                     ; preds = %125
   %131 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %127, i32 0, i32 18
@@ -13626,8 +15335,8 @@ entry:
   %132 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %133 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %134 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %133)
-  %NullCheck60 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %132, null
-  br i1 %NullCheck60, label %135, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %132, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %135
 
 ; <label>:135                                     ; preds = %130
   %136 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %132, i32 0, i32 14
@@ -13635,8 +15344,8 @@ entry:
   %137 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %138 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %139 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %138)
-  %NullCheck62 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %137, null
-  br i1 %NullCheck62, label %140, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %137, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %140
 
 ; <label>:140                                     ; preds = %135
   %141 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %137, i32 0, i32 13
@@ -13644,71 +15353,71 @@ entry:
   %142 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %143 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %144 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %143)
-  %NullCheck64 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %142, null
-  br i1 %NullCheck64, label %145, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %142, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %145
 
 ; <label>:145                                     ; preds = %140
   %146 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %142, i32 0, i32 12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %146, %System.String addrspace(1)* %144)
   %147 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %148 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck66 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %148, null
-  br i1 %NullCheck66, label %149, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %148, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %149
 
 ; <label>:149                                     ; preds = %145
   %150 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %148, i32 0, i32 21
   %151 = load i32, i32 addrspace(1)* %150, align 8
-  %NullCheck68 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %147, null
-  br i1 %NullCheck68, label %152, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %147, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %152
 
 ; <label>:152                                     ; preds = %149
   %153 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %147, i32 0, i32 28
   store i32 %151, i32 addrspace(1)* %153
   %154 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %155 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck70 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %155, null
-  br i1 %NullCheck70, label %156, label %ThrowNullRef69
+  %NullCheck69 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %155, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %156
 
 ; <label>:156                                     ; preds = %152
   %157 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %155, i32 0, i32 6
   %158 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %157, align 8
-  %NullCheck72 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %154, null
-  br i1 %NullCheck72, label %159, label %ThrowNullRef71
+  %NullCheck71 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %154, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %159
 
 ; <label>:159                                     ; preds = %156
   %160 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %154, i32 0, i32 15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %160, %System.String addrspace(1)* %158)
   %161 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %162 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck74 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %162, null
-  br i1 %NullCheck74, label %163, label %ThrowNullRef73
+  %NullCheck73 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %162, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %163
 
 ; <label>:163                                     ; preds = %159
   %164 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %162, i32 0, i32 1
   %165 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %164, align 8
-  %NullCheck76 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %161, null
-  br i1 %NullCheck76, label %166, label %ThrowNullRef75
+  %NullCheck75 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %161, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %166
 
 ; <label>:166                                     ; preds = %163
   %167 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %161, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %167, %"System.Int32[]" addrspace(1)* %165)
   %168 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %169 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck78 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %169, null
-  br i1 %NullCheck78, label %170, label %ThrowNullRef77
+  %NullCheck77 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %169, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %170
 
 ; <label>:170                                     ; preds = %166
   %171 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %169, i32 0, i32 7
   %172 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %171, align 8
-  %NullCheck80 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %168, null
-  br i1 %NullCheck80, label %173, label %ThrowNullRef79
+  %NullCheck79 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %168, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %173
 
 ; <label>:173                                     ; preds = %170
   %174 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %168, i32 0, i32 16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %174, %System.String addrspace(1)* %172)
   %175 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck82 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %175, null
-  br i1 %NullCheck82, label %176, label %ThrowNullRef81
+  %NullCheck81 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %175, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %176
 
 ; <label>:176                                     ; preds = %173
   %177 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %175, i32 0, i32 4
@@ -13718,14 +15427,14 @@ entry:
 
 ; <label>:180                                     ; preds = %176
   %181 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck84 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %181, null
-  br i1 %NullCheck84, label %182, label %ThrowNullRef83
+  %NullCheck83 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %181, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %182
 
 ; <label>:182                                     ; preds = %180
   %183 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %181, i32 0, i32 4
   %184 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %183, align 8
-  %NullCheck86 = icmp ne %System.String addrspace(1)* %184, null
-  br i1 %NullCheck86, label %185, label %ThrowNullRef85
+  %NullCheck85 = icmp eq %System.String addrspace(1)* %184, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %185
 
 ; <label>:185                                     ; preds = %182
   %186 = getelementptr inbounds %System.String, %System.String addrspace(1)* %184, i32 0, i32 1
@@ -13736,8 +15445,8 @@ entry:
 ; <label>:189                                     ; preds = %176, %185
   %190 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck98 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %190, null
-  br i1 %NullCheck98, label %192, label %ThrowNullRef97
+  %NullCheck97 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %190, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %192
 
 ; <label>:192                                     ; preds = %189
   %193 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %190, i32 0, i32 4
@@ -13746,8 +15455,8 @@ entry:
 
 ; <label>:194                                     ; preds = %185, %192
   %195 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck88 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %195, null
-  br i1 %NullCheck88, label %196, label %ThrowNullRef87
+  %NullCheck87 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %195, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %196
 
 ; <label>:196                                     ; preds = %194
   %197 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %195, i32 0, i32 9
@@ -13757,14 +15466,14 @@ entry:
 
 ; <label>:200                                     ; preds = %196
   %201 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck90 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %201, null
-  br i1 %NullCheck90, label %202, label %ThrowNullRef89
+  %NullCheck89 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %201, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %202
 
 ; <label>:202                                     ; preds = %200
   %203 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %201, i32 0, i32 9
   %204 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %203, align 8
-  %NullCheck92 = icmp ne %System.String addrspace(1)* %204, null
-  br i1 %NullCheck92, label %205, label %ThrowNullRef91
+  %NullCheck91 = icmp eq %System.String addrspace(1)* %204, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %205
 
 ; <label>:205                                     ; preds = %202
   %206 = getelementptr inbounds %System.String, %System.String addrspace(1)* %204, i32 0, i32 1
@@ -13775,14 +15484,14 @@ entry:
 ; <label>:209                                     ; preds = %196, %205
   %210 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %211 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck94 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %211, null
-  br i1 %NullCheck94, label %212, label %ThrowNullRef93
+  %NullCheck93 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %211, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %212
 
 ; <label>:212                                     ; preds = %209
   %213 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %211, i32 0, i32 6
   %214 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %213, align 8
-  %NullCheck96 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %210, null
-  br i1 %NullCheck96, label %215, label %ThrowNullRef95
+  %NullCheck95 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %210, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %215
 
 ; <label>:215                                     ; preds = %212
   %216 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %210, i32 0, i32 9
@@ -13796,203 +15505,203 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %17
+ThrowNullRef8:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %21
+ThrowNullRef10:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %24
+ThrowNullRef12:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %28
+ThrowNullRef14:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %31
+ThrowNullRef16:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %35
+ThrowNullRef18:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %38
+ThrowNullRef20:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %42
+ThrowNullRef22:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %45
+ThrowNullRef24:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %49
+ThrowNullRef26:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %52
+ThrowNullRef28:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %56
+ThrowNullRef30:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %59
+ThrowNullRef32:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %63
+ThrowNullRef34:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %66
+ThrowNullRef36:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %70
+ThrowNullRef38:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %73
+ThrowNullRef40:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %77
+ThrowNullRef42:                                   ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %80
+ThrowNullRef44:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %84
+ThrowNullRef46:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %101
+ThrowNullRef48:                                   ; preds = %101
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %105
+ThrowNullRef50:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %110
+ThrowNullRef52:                                   ; preds = %110
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %115
+ThrowNullRef54:                                   ; preds = %115
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %120
+ThrowNullRef56:                                   ; preds = %120
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %125
+ThrowNullRef58:                                   ; preds = %125
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %130
+ThrowNullRef60:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %135
+ThrowNullRef62:                                   ; preds = %135
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %140
+ThrowNullRef64:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %145
+ThrowNullRef66:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %149
+ThrowNullRef68:                                   ; preds = %149
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %152
+ThrowNullRef70:                                   ; preds = %152
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %156
+ThrowNullRef72:                                   ; preds = %156
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %159
+ThrowNullRef74:                                   ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %163
+ThrowNullRef76:                                   ; preds = %163
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %166
+ThrowNullRef78:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %170
+ThrowNullRef80:                                   ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %173
+ThrowNullRef82:                                   ; preds = %173
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %180
+ThrowNullRef84:                                   ; preds = %180
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %182
+ThrowNullRef86:                                   ; preds = %182
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %194
+ThrowNullRef88:                                   ; preds = %194
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %200
+ThrowNullRef90:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %202
+ThrowNullRef92:                                   ; preds = %202
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %209
+ThrowNullRef94:                                   ; preds = %209
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %212
+ThrowNullRef96:                                   ; preds = %212
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %189
+ThrowNullRef98:                                   ; preds = %189
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %89
+ThrowNullRef100:                                  ; preds = %89
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14020,8 +15729,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 21
@@ -14034,8 +15743,8 @@ entry:
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 16)
   %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 21
@@ -14044,8 +15753,8 @@ entry:
 
 ; <label>:12                                      ; preds = %1, %10
   %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 21
@@ -14056,11 +15765,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %12
+ThrowNullRef4:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14076,8 +15785,8 @@ entry:
   store i32 %param1, i32* %arg1
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %1 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
@@ -14144,8 +15853,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 33
@@ -14158,8 +15867,8 @@ entry:
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 24)
   %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 33
@@ -14168,8 +15877,8 @@ entry:
 
 ; <label>:12                                      ; preds = %1, %10
   %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 33
@@ -14180,11 +15889,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %12
+ThrowNullRef4:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14197,8 +15906,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 53
@@ -14210,8 +15919,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 116)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 53
@@ -14220,8 +15929,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 53
@@ -14232,11 +15941,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14265,8 +15974,8 @@ entry:
 
 ; <label>:7                                       ; preds = %entry, %4
   %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %7
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 2
@@ -14290,8 +15999,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 54
@@ -14303,8 +16012,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 117)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
@@ -14313,8 +16022,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 54
@@ -14325,11 +16034,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14342,8 +16051,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 27
@@ -14355,8 +16064,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 118)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 27
@@ -14365,8 +16074,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 27
@@ -14377,11 +16086,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14394,8 +16103,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 28
@@ -14407,8 +16116,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 119)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 28
@@ -14417,8 +16126,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 28
@@ -14429,11 +16138,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14446,8 +16155,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 26
@@ -14459,8 +16168,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 107)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 26
@@ -14469,8 +16178,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 26
@@ -14481,11 +16190,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14498,8 +16207,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 25
@@ -14511,8 +16220,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 106)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 25
@@ -14521,8 +16230,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 25
@@ -14533,11 +16242,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14550,8 +16259,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 24
@@ -14563,8 +16272,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 105)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 24
@@ -14573,8 +16282,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 24
@@ -14585,11 +16294,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14614,8 +16323,8 @@ entry:
   %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %3)
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %2
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -14626,15 +16335,15 @@ entry:
 
 ; <label>:8                                       ; preds = %62
   %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 9
   %12 = load i32, i32 addrspace(1)* %11, align 8
   %13 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.IO.StreamWriter addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %13, i32 0, i32 10
@@ -14649,15 +16358,15 @@ entry:
 
 ; <label>:20                                      ; preds = %14, %18
   %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
   %24 = load i32, i32 addrspace(1)* %23, align 8
   %25 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %25, null
-  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.StreamWriter addrspace(1)* %25, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %25, i32 0, i32 9
@@ -14678,36 +16387,36 @@ entry:
   %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %37 = load i32, i32* %loc1
   %38 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.StreamWriter addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %35
   %40 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %38, i32 0, i32 7
   %41 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %40, align 8
   %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
-  br i1 %NullCheck14, label %43, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %39
   %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 9
   %45 = load i32, i32 addrspace(1)* %44, align 8
   %46 = load i32, i32* %loc2
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %36, null
-  br i1 %NullCheck16, label %47, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %36, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %47
 
 ; <label>:47                                      ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %36, i32 %37, %"System.Char[]" addrspace(1)* %41, i32 %45, i32 %46)
   %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
   %51 = load i32, i32 addrspace(1)* %50, align 8
   %52 = load i32, i32* %loc2
   %53 = add i32 %51, %52
-  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
-  br i1 %NullCheck20, label %54, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %54
 
 ; <label>:54                                      ; preds = %49
   %55 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
@@ -14729,8 +16438,8 @@ entry:
 
 ; <label>:65                                      ; preds = %62
   %66 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %66, null
-  br i1 %NullCheck2, label %67, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %66, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %67
 
 ; <label>:67                                      ; preds = %65
   %68 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %66, i32 0, i32 11
@@ -14751,49 +16460,259 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %65
+ThrowNullRef2:                                    ; preds = %65
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %20
+ThrowNullRef8:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %22
+ThrowNullRef10:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %35
+ThrowNullRef12:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %43
+ThrowNullRef16:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %47
+ThrowNullRef18:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method String::CopyTo using LLILCJit
-Failed to read String.CopyTo[loadElemA]
+Successfully read String.CopyTo
+
+define void @String.CopyTo(%System.String addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  %loc1 = alloca i16 addrspace(1)*
+  %loc2 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %1 = icmp ne %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg4
+  %7 = icmp sge i32 %6, 0
+  br i1 %7, label %13, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  unreachable
+
+; <label>:13                                      ; preds = %5
+  %14 = load i32, i32* %arg1
+  %15 = icmp sge i32 %14, 0
+  br i1 %15, label %21, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %18)
+  %20 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %20, %System.String addrspace(1)* %17, %System.String addrspace(1)* %19)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %20) #0
+  unreachable
+
+; <label>:21                                      ; preds = %13
+  %22 = load i32, i32* %arg4
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck, label %ThrowNullRef, label %24
+
+; <label>:24                                      ; preds = %21
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load i32, i32* %arg1
+  %28 = sub i32 %26, %27
+  %29 = icmp sle i32 %22, %28
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34, %System.String addrspace(1)* %31, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %24
+  %36 = load i32, i32* %arg3
+  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %37, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
+
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
+  %40 = load i32, i32 addrspace(1)* %39
+  %41 = zext i32 %40 to i64
+  %42 = trunc i64 %41 to i32
+  %43 = load i32, i32* %arg4
+  %44 = sub i32 %42, %43
+  %45 = icmp sgt i32 %36, %44
+  br i1 %45, label %49, label %46
+
+; <label>:46                                      ; preds = %38
+  %47 = load i32, i32* %arg3
+  %48 = icmp sge i32 %47, 0
+  br i1 %48, label %54, label %49
+
+; <label>:49                                      ; preds = %38, %46
+  %50 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %52 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %51)
+  %53 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53, %System.String addrspace(1)* %50, %System.String addrspace(1)* %52)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53) #0
+  unreachable
+
+; <label>:54                                      ; preds = %46
+  %55 = load i32, i32* %arg4
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %97, label %57
+
+; <label>:57                                      ; preds = %54
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %59
+
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 2
+  %61 = bitcast [0 x i16] addrspace(1)* %60 to i16 addrspace(1)*
+  store i16 addrspace(1)* %61, i16 addrspace(1)** %loc0
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  store %"System.Char[]" addrspace(1)* %62, %"System.Char[]" addrspace(1)** %loc2
+  %63 = icmp eq %"System.Char[]" addrspace(1)* %62, null
+  br i1 %63, label %72, label %64
+
+; <label>:64                                      ; preds = %59
+  %65 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc2
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %65, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %66
+
+; <label>:66                                      ; preds = %64
+  %67 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %65, i32 0, i32 1
+  %68 = load i32, i32 addrspace(1)* %67
+  %69 = zext i32 %68 to i64
+  %70 = trunc i64 %69 to i32
+  %71 = icmp ne i32 %70, 0
+  br i1 %71, label %73, label %72
+
+; <label>:72                                      ; preds = %59, %66
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  br label %81
+
+; <label>:73                                      ; preds = %66
+  %74 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc2
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %74, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %75
+
+; <label>:75                                      ; preds = %73
+  %76 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %74, i32 0, i32 1
+  %77 = load i32, i32 addrspace(1)* %76
+  %78 = zext i32 %77 to i64
+  %BoundsCheck = icmp uge i64 0, %78
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %79
+
+; <label>:79                                      ; preds = %75
+  %80 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %74, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %80, i16 addrspace(1)** %loc1
+  br label %81
+
+; <label>:81                                      ; preds = %72, %79
+  %82 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %83 = ptrtoint i16 addrspace(1)* %82 to i64
+  %84 = load i32, i32* %arg3
+  %85 = sext i32 %84 to i64
+  %86 = mul i64 %85, 2
+  %87 = add i64 %83, %86
+  %88 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %89 = ptrtoint i16 addrspace(1)* %88 to i64
+  %90 = load i32, i32* %arg1
+  %91 = sext i32 %90 to i64
+  %92 = mul i64 %91, 2
+  %93 = add i64 %89, %92
+  %94 = load i32, i32* %arg4
+  %95 = inttoptr i64 %87 to i16*
+  %96 = inttoptr i64 %93 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %95, i16* %96, i32 %94)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  br label %97
+
+; <label>:97                                      ; preds = %54, %81
+  ret void
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
 Successfully read ConsoleEncoding.GetPreamble
 
@@ -14830,7 +16749,365 @@ entry:
 }
 
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[loadElemA]
+Successfully read EncoderNLS.GetBytes
+
+define i32 @EncoderNLS.GetBytes(%System.Text.EncoderNLS addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3, %"System.Byte[]" addrspace(1)* %param4, i32 %param5, i8 %param6) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %arg4 = alloca %"System.Byte[]" addrspace(1)*
+  %arg5 = alloca i32
+  %arg6 = alloca i8
+  %loc0 = alloca i32
+  %loc1 = alloca i16 addrspace(1)*
+  %loc2 = alloca i8 addrspace(1)*
+  %loc3 = alloca i32
+  %loc4 = alloca %"System.Char[]" addrspace(1)*
+  %loc5 = alloca %"System.Byte[]" addrspace(1)*
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  store %"System.Byte[]" addrspace(1)* %param4, %"System.Byte[]" addrspace(1)** %arg4
+  store i32 %param5, i32* %arg5
+  store i8 %param6, i8* %arg6
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %1 = icmp eq %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %17, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %7 = icmp eq %"System.Char[]" addrspace(1)* %6, null
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %12
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %12
+
+; <label>:12                                      ; preds = %8, %10
+  %13 = phi %System.String addrspace(1)* [ %9, %8 ], [ %11, %10 ]
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %14)
+  %16 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16, %System.String addrspace(1)* %13, %System.String addrspace(1)* %15)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16) #0
+  unreachable
+
+; <label>:17                                      ; preds = %2
+  %18 = load i32, i32* %arg2
+  %19 = icmp slt i32 %18, 0
+  br i1 %19, label %23, label %20
+
+; <label>:20                                      ; preds = %17
+  %21 = load i32, i32* %arg3
+  %22 = icmp sge i32 %21, 0
+  br i1 %22, label %35, label %23
+
+; <label>:23                                      ; preds = %17, %20
+  %24 = load i32, i32* %arg2
+  %25 = icmp slt i32 %24, 0
+  br i1 %25, label %28, label %26
+
+; <label>:26                                      ; preds = %23
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %30
+
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %30
+
+; <label>:30                                      ; preds = %26, %28
+  %31 = phi %System.String addrspace(1)* [ %27, %26 ], [ %29, %28 ]
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34, %System.String addrspace(1)* %31, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %20
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck, label %ThrowNullRef, label %37
+
+; <label>:37                                      ; preds = %35
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = load i32, i32* %arg2
+  %43 = sub i32 %41, %42
+  %44 = load i32, i32* %arg3
+  %45 = icmp sge i32 %43, %44
+  br i1 %45, label %51, label %46
+
+; <label>:46                                      ; preds = %37
+  %47 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %48 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %49 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %48)
+  %50 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %50, %System.String addrspace(1)* %47, %System.String addrspace(1)* %49)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %50) #0
+  unreachable
+
+; <label>:51                                      ; preds = %37
+  %52 = load i32, i32* %arg5
+  %53 = icmp slt i32 %52, 0
+  br i1 %53, label %63, label %54
+
+; <label>:54                                      ; preds = %51
+  %55 = load i32, i32* %arg5
+  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck1 = icmp eq %"System.Byte[]" addrspace(1)* %56, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %57
+
+; <label>:57                                      ; preds = %54
+  %58 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = zext i32 %59 to i64
+  %61 = trunc i64 %60 to i32
+  %62 = icmp sle i32 %55, %61
+  br i1 %62, label %68, label %63
+
+; <label>:63                                      ; preds = %51, %57
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %66 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %65)
+  %67 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %67, %System.String addrspace(1)* %64, %System.String addrspace(1)* %66)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %67) #0
+  unreachable
+
+; <label>:68                                      ; preds = %57
+  %69 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %69, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %69, i32 0, i32 1
+  %72 = load i32, i32 addrspace(1)* %71
+  %73 = zext i32 %72 to i64
+  %74 = trunc i64 %73 to i32
+  %75 = icmp ne i32 %74, 0
+  br i1 %75, label %78, label %76
+
+; <label>:76                                      ; preds = %70
+  %77 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1)
+  store %"System.Char[]" addrspace(1)* %77, %"System.Char[]" addrspace(1)** %arg1
+  br label %78
+
+; <label>:78                                      ; preds = %70, %76
+  %79 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck5 = icmp eq %"System.Byte[]" addrspace(1)* %79, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %80
+
+; <label>:80                                      ; preds = %78
+  %81 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %79, i32 0, i32 1
+  %82 = load i32, i32 addrspace(1)* %81
+  %83 = zext i32 %82 to i64
+  %84 = trunc i64 %83 to i32
+  %85 = load i32, i32* %arg5
+  %86 = sub i32 %84, %85
+  store i32 %86, i32* %loc0
+  %87 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck7 = icmp eq %"System.Byte[]" addrspace(1)* %87, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %88
+
+; <label>:88                                      ; preds = %80
+  %89 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %87, i32 0, i32 1
+  %90 = load i32, i32 addrspace(1)* %89
+  %91 = zext i32 %90 to i64
+  %92 = trunc i64 %91 to i32
+  %93 = icmp ne i32 %92, 0
+  br i1 %93, label %96, label %94
+
+; <label>:94                                      ; preds = %88
+  %95 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1)
+  store %"System.Byte[]" addrspace(1)* %95, %"System.Byte[]" addrspace(1)** %arg4
+  br label %96
+
+; <label>:96                                      ; preds = %88, %94
+  %97 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  store %"System.Char[]" addrspace(1)* %97, %"System.Char[]" addrspace(1)** %loc4
+  %98 = icmp eq %"System.Char[]" addrspace(1)* %97, null
+  br i1 %98, label %107, label %99
+
+; <label>:99                                      ; preds = %96
+  %100 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc4
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %100, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %101
+
+; <label>:101                                     ; preds = %99
+  %102 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %100, i32 0, i32 1
+  %103 = load i32, i32 addrspace(1)* %102
+  %104 = zext i32 %103 to i64
+  %105 = trunc i64 %104 to i32
+  %106 = icmp ne i32 %105, 0
+  br i1 %106, label %108, label %107
+
+; <label>:107                                     ; preds = %96, %101
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  br label %116
+
+; <label>:108                                     ; preds = %101
+  %109 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc4
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %109, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %110
+
+; <label>:110                                     ; preds = %108
+  %111 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %109, i32 0, i32 1
+  %112 = load i32, i32 addrspace(1)* %111
+  %113 = zext i32 %112 to i64
+  %BoundsCheck = icmp uge i64 0, %113
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %114
+
+; <label>:114                                     ; preds = %110
+  %115 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %109, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %115, i16 addrspace(1)** %loc1
+  br label %116
+
+; <label>:116                                     ; preds = %107, %114
+  %117 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  store %"System.Byte[]" addrspace(1)* %117, %"System.Byte[]" addrspace(1)** %loc5
+  %118 = icmp eq %"System.Byte[]" addrspace(1)* %117, null
+  br i1 %118, label %127, label %119
+
+; <label>:119                                     ; preds = %116
+  %120 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc5
+  %NullCheck13 = icmp eq %"System.Byte[]" addrspace(1)* %120, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %121
+
+; <label>:121                                     ; preds = %119
+  %122 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %120, i32 0, i32 1
+  %123 = load i32, i32 addrspace(1)* %122
+  %124 = zext i32 %123 to i64
+  %125 = trunc i64 %124 to i32
+  %126 = icmp ne i32 %125, 0
+  br i1 %126, label %128, label %127
+
+; <label>:127                                     ; preds = %116, %121
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc2
+  br label %136
+
+; <label>:128                                     ; preds = %121
+  %129 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc5
+  %NullCheck15 = icmp eq %"System.Byte[]" addrspace(1)* %129, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %130
+
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %129, i32 0, i32 1
+  %132 = load i32, i32 addrspace(1)* %131
+  %133 = zext i32 %132 to i64
+  %BoundsCheck17 = icmp uge i64 0, %133
+  br i1 %BoundsCheck17, label %ThrowIndexOutOfRange18, label %134
+
+; <label>:134                                     ; preds = %130
+  %135 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %129, i32 0, i32 3, i32 0
+  store i8 addrspace(1)* %135, i8 addrspace(1)** %loc2
+  br label %136
+
+; <label>:136                                     ; preds = %127, %134
+  %137 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %138 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %139 = ptrtoint i16 addrspace(1)* %138 to i64
+  %140 = load i32, i32* %arg2
+  %141 = sext i32 %140 to i64
+  %142 = mul i64 %141, 2
+  %143 = add i64 %139, %142
+  %144 = load i32, i32* %arg3
+  %145 = load i8 addrspace(1)*, i8 addrspace(1)** %loc2
+  %146 = ptrtoint i8 addrspace(1)* %145 to i64
+  %147 = load i32, i32* %arg5
+  %148 = sext i32 %147 to i64
+  %149 = add i64 %146, %148
+  %150 = load i32, i32* %loc0
+  %151 = load i8, i8* %arg6
+  %152 = zext i8 %151 to i32
+  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i64 addrspace(1)*
+  %NullCheck19 = icmp eq i64 addrspace(1)* %153, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %154
+
+; <label>:154                                     ; preds = %136
+  %155 = load i64, i64 addrspace(1)* %153
+  %156 = add i64 %155, 72
+  %157 = inttoptr i64 %156 to i64*
+  %158 = load i64, i64* %157
+  %159 = add i64 %158, 0
+  %160 = inttoptr i64 %159 to i64*
+  %161 = load i64, i64* %160
+  %162 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to %System.Text.Encoder addrspace(1)*
+  %163 = inttoptr i64 %143 to i16*
+  %164 = inttoptr i64 %149 to i8*
+  %165 = trunc i32 %152 to i8
+  %166 = inttoptr i64 %161 to i32 (%System.Text.Encoder addrspace(1)*, i16*, i32, i8*, i32, i8)*
+  %167 = call i32 %166(%System.Text.Encoder addrspace(1)* %162, i16* %163, i32 %144, i8* %164, i32 %150, i8 %165)
+  store i32 %167, i32* %loc3
+  br label %168
+
+; <label>:168                                     ; preds = %154
+  %169 = load i32, i32* %loc3
+  ret i32 %169
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %110
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %119
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange18:                           ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
 Successfully read EncoderNLS.GetBytes
 
@@ -14919,22 +17196,22 @@ entry:
   %40 = load i8, i8* %arg5
   %41 = zext i8 %40 to i32
   %42 = trunc i32 %41 to i8
-  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %39, null
-  br i1 %NullCheck, label %43, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderNLS addrspace(1)* %39, null
+  br i1 %NullCheck, label %ThrowNullRef, label %43
 
 ; <label>:43                                      ; preds = %38
   %44 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
   store i8 %42, i8 addrspace(1)* %44
   %45 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %45, null
-  br i1 %NullCheck2, label %46, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.EncoderNLS addrspace(1)* %45, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %46
 
 ; <label>:46                                      ; preds = %43
   %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %45, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %47
   %48 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.EncoderNLS addrspace(1)* %48, null
-  br i1 %NullCheck4, label %49, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.EncoderNLS addrspace(1)* %48, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %49
 
 ; <label>:49                                      ; preds = %46
   %50 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %48, i32 0, i32 3
@@ -14945,8 +17222,8 @@ entry:
   %55 = load i32, i32* %arg4
   %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck6, label %58, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
   %59 = load i64, i64 addrspace(1)* %57
@@ -14964,15 +17241,15 @@ ThrowNullRef:                                     ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %43
+ThrowNullRef2:                                    ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %46
+ThrowNullRef4:                                    ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %49
+ThrowNullRef6:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -15000,8 +17277,8 @@ entry:
   %4 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0 to %System.IO.ConsoleStream addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*)(%System.IO.ConsoleStream addrspace(1)* %4, %"System.Byte[]" addrspace(1)* %1, i32 %2, i32 %3)
   %5 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
@@ -15086,8 +17363,8 @@ entry:
 
 ; <label>:22                                      ; preds = %8
   %23 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %23, null
-  br i1 %NullCheck, label %24, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Byte[]" addrspace(1)* %23, null
+  br i1 %NullCheck, label %ThrowNullRef, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
@@ -15109,8 +17386,8 @@ entry:
 
 ; <label>:36                                      ; preds = %24
   %37 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %37, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.ConsoleStream addrspace(1)* %37, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %37, i32 0, i32 4
@@ -15131,13 +17408,138 @@ ThrowNullRef:                                     ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %36
+ThrowNullRef2:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
-Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
+Successfully read WindowsConsoleStream.WriteFileNative
+
+define i32 @WindowsConsoleStream.WriteFileNative(i64 %param0, %"System.Byte[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i64
+  %arg1 = alloca %"System.Byte[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i8 addrspace(1)*
+  %loc2 = alloca %"System.Byte[]" addrspace(1)*
+  %loc3 = alloca i32
+  store i64 %param0, i64* %arg0
+  store %"System.Byte[]" addrspace(1)* %param1, %"System.Byte[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Byte[]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = zext i32 %3 to i64
+  %5 = icmp ne i64 %4, 0
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %1
+  ret i32 0
+
+; <label>:7                                       ; preds = %1
+  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  store %"System.Byte[]" addrspace(1)* %8, %"System.Byte[]" addrspace(1)** %loc2
+  %9 = icmp eq %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %9, label %18, label %10
+
+; <label>:10                                      ; preds = %7
+  %11 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc2
+  %NullCheck1 = icmp eq %"System.Byte[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %11, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp ne i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %7, %12
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc1
+  br label %27
+
+; <label>:19                                      ; preds = %12
+  %20 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc2
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %20, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %BoundsCheck = icmp uge i64 0, %24
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %25
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %20, i32 0, i32 3, i32 0
+  store i8 addrspace(1)* %26, i8 addrspace(1)** %loc1
+  br label %27
+
+; <label>:27                                      ; preds = %18, %25
+  %28 = load i64, i64* %arg0
+  %29 = load i8 addrspace(1)*, i8 addrspace(1)** %loc1
+  %30 = ptrtoint i8 addrspace(1)* %29 to i64
+  %31 = load i32, i32* %arg2
+  %32 = sext i32 %31 to i64
+  %33 = add i64 %30, %32
+  %34 = load i32, i32* %arg3
+  %35 = addrspacecast i32* %loc3 to i32 addrspace(1)*
+  %36 = inttoptr i64 %33 to i8*
+  %37 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i8*, i32, i32 addrspace(1)*, i64)*)(i64 %28, i8* %36, i32 %34, i32 addrspace(1)* %35, i64 0)
+  %38 = icmp ugt i32 %37, 0
+  %39 = sext i1 %38 to i32
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc1
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %42, label %41
+
+; <label>:41                                      ; preds = %27
+  ret i32 0
+
+; <label>:42                                      ; preds = %27
+  %43 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  store i32 %43, i32* %loc0
+  %44 = load i32, i32* %loc0
+  %45 = icmp eq i32 %44, 232
+  br i1 %45, label %49, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = load i32, i32* %loc0
+  %48 = icmp ne i32 %47, 109
+  br i1 %48, label %50, label %49
+
+; <label>:49                                      ; preds = %42, %46
+  ret i32 0
+
+; <label>:50                                      ; preds = %46
+  %51 = load i32, i32* %loc0
+  ret i32 %51
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
 Successfully read WindowsConsoleStream.Flush
 
@@ -15146,8 +17548,8 @@ entry:
   %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
   store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
@@ -15182,8 +17584,8 @@ entry:
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
   %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load i64, i64 addrspace(1)* %1
@@ -15222,15 +17624,15 @@ entry:
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.TextWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
   %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %3, align 8
   %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
   %7 = load i64, i64 addrspace(1)* %5
@@ -15248,7 +17650,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -15277,8 +17679,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %4)
   store i32 0, i32* %loc0
   %5 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Char[]" addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
@@ -15290,15 +17692,15 @@ entry:
 
 ; <label>:11                                      ; preds = %69
   %12 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %12, i32 0, i32 9
   %15 = load i32, i32 addrspace(1)* %14, align 8
   %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.IO.StreamWriter addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %16, i32 0, i32 10
@@ -15313,15 +17715,15 @@ entry:
 
 ; <label>:23                                      ; preds = %17, %21
   %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %24, null
-  br i1 %NullCheck8, label %25, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %24, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 10
   %27 = load i32, i32 addrspace(1)* %26, align 8
   %28 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %28, null
-  br i1 %NullCheck10, label %29, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.StreamWriter addrspace(1)* %28, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %28, i32 0, i32 9
@@ -15343,15 +17745,15 @@ entry:
   %40 = load i32, i32* %loc0
   %41 = mul i32 %40, 2
   %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
-  br i1 %NullCheck12, label %43, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %43
 
 ; <label>:43                                      ; preds = %38
   %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 7
   %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %44, align 8
   %46 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %46, null
-  br i1 %NullCheck14, label %47, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.IO.StreamWriter addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %47
 
 ; <label>:47                                      ; preds = %43
   %48 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %46, i32 0, i32 9
@@ -15363,16 +17765,16 @@ entry:
   %54 = bitcast %"System.Char[]" addrspace(1)* %45 to %System.Array addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %53, i32 %41, %System.Array addrspace(1)* %54, i32 %50, i32 %52)
   %55 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
-  br i1 %NullCheck16, label %56, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %56
 
 ; <label>:56                                      ; preds = %47
   %57 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
   %58 = load i32, i32 addrspace(1)* %57, align 8
   %59 = load i32, i32* %loc2
   %60 = add i32 %58, %59
-  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
-  br i1 %NullCheck18, label %61, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %61
 
 ; <label>:61                                      ; preds = %56
   %62 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
@@ -15394,8 +17796,8 @@ entry:
 
 ; <label>:72                                      ; preds = %69
   %73 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %73, null
-  br i1 %NullCheck2, label %74, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %73, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %74
 
 ; <label>:74                                      ; preds = %72
   %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %73, i32 0, i32 11
@@ -15416,39 +17818,39 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %72
+ThrowNullRef2:                                    ; preds = %72
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %23
+ThrowNullRef8:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef10:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %43
+ThrowNullRef14:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %47
+ThrowNullRef16:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %56
+ThrowNullRef18:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblRoots.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblRoots.error.txt
@@ -25,8 +25,8 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
@@ -40,8 +40,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
   %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
@@ -75,7 +75,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -90,8 +90,8 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %NullCheck = icmp ne i8 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = load i8, i8 addrspace(1)* %0, align 8
@@ -125,8 +125,8 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
@@ -159,8 +159,8 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -184,8 +184,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
   store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
@@ -195,8 +195,8 @@ entry:
 ; <label>:4                                       ; preds = %1
   %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
   %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
@@ -206,8 +206,8 @@ entry:
   %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
@@ -221,14 +221,14 @@ entry:
 
 ; <label>:17                                      ; preds = %14
   %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
   %21 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
@@ -238,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -249,8 +249,8 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
@@ -261,27 +261,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %30
+ThrowNullRef10:                                   ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -301,7 +301,89 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
-Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
+Successfully read AppDomainSetup.GetUnsecureApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.GetUnsecureApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %NullCheck = icmp eq %"System.String[]" addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %BoundsCheck = icmp uge i64 0, %5
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %6
+
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 3, i32 0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
+  ret %System.String addrspace(1)* %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_Value using LLILCJit
+Successfully read AppDomainSetup.get_Value
+
+define %"System.String[]" addrspace(1)* @AppDomainSetup.get_Value(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.String[]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 18)
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.String[]" addrspace(1)* addrspace(1)*, %"System.String[]" addrspace(1)*)*)(%"System.String[]" addrspace(1)* addrspace(1)* %9, %"System.String[]" addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %11, i32 0, i32 1
+  %14 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %13, align 8
+  ret %"System.String[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -319,8 +401,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -368,16 +450,16 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
   %5 = load i32, i32 addrspace(1)* %4
   %6 = sub i32 %5, 1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -389,7 +471,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -421,8 +503,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
@@ -456,8 +538,8 @@ entry:
 ; <label>:27                                      ; preds = %19
   %28 = load i32, i32* %arg1
   %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
-  br i1 %NullCheck2, label %30, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %29, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %30
 
 ; <label>:30                                      ; preds = %27
   %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
@@ -493,8 +575,8 @@ entry:
 ; <label>:49                                      ; preds = %46
   %50 = load i32, i32* %arg2
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck4, label %52, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
@@ -517,11 +599,11 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %27
+ThrowNullRef2:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %49
+ThrowNullRef4:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -544,16 +626,16 @@ entry:
   %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %0)
   store %System.String addrspace(1)* %1, %System.String addrspace(1)** %loc0
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 2
   %5 = bitcast [0 x i16] addrspace(1)* %4 to i16 addrspace(1)*
   store i16 addrspace(1)* %5, i16 addrspace(1)** %loc1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %3
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2
@@ -580,7 +662,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -691,15 +773,15 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %NullCheck132 = icmp ne i8* %21, null
-  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+  %NullCheck131 = icmp eq i8* %21, null
+  br i1 %NullCheck131, label %ThrowNullRef132, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = load i8, i8* %21, align 8
   %24 = zext i8 %23 to i32
   %25 = trunc i32 %24 to i8
-  %NullCheck134 = icmp ne i8* %20, null
-  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+  %NullCheck133 = icmp eq i8* %20, null
+  br i1 %NullCheck133, label %ThrowNullRef134, label %26
 
 ; <label>:26                                      ; preds = %22
   store i8 %25, i8* %20, align 8
@@ -709,16 +791,16 @@ entry:
   %28 = load i8*, i8** %arg0
   %29 = load i8*, i8** %arg1
   %30 = bitcast i8* %29 to i16*
-  %NullCheck128 = icmp ne i16* %30, null
-  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+  %NullCheck127 = icmp eq i16* %30, null
+  br i1 %NullCheck127, label %ThrowNullRef128, label %31
 
 ; <label>:31                                      ; preds = %27
   %32 = load i16, i16* %30, align 8
   %33 = sext i16 %32 to i32
   %34 = bitcast i8* %28 to i16*
   %35 = trunc i32 %33 to i16
-  %NullCheck130 = icmp ne i16* %34, null
-  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+  %NullCheck129 = icmp eq i16* %34, null
+  br i1 %NullCheck129, label %ThrowNullRef130, label %36
 
 ; <label>:36                                      ; preds = %31
   store i16 %35, i16* %34, align 8
@@ -728,16 +810,16 @@ entry:
   %38 = load i8*, i8** %arg0
   %39 = load i8*, i8** %arg1
   %40 = bitcast i8* %39 to i16*
-  %NullCheck120 = icmp ne i16* %40, null
-  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+  %NullCheck119 = icmp eq i16* %40, null
+  br i1 %NullCheck119, label %ThrowNullRef120, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i16, i16* %40, align 8
   %43 = sext i16 %42 to i32
   %44 = bitcast i8* %38 to i16*
   %45 = trunc i32 %43 to i16
-  %NullCheck122 = icmp ne i16* %44, null
-  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+  %NullCheck121 = icmp eq i16* %44, null
+  br i1 %NullCheck121, label %ThrowNullRef122, label %46
 
 ; <label>:46                                      ; preds = %41
   store i16 %45, i16* %44, align 8
@@ -745,15 +827,15 @@ entry:
   %48 = getelementptr inbounds i8, i8* %47, i64 2
   %49 = load i8*, i8** %arg1
   %50 = getelementptr inbounds i8, i8* %49, i64 2
-  %NullCheck124 = icmp ne i8* %50, null
-  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+  %NullCheck123 = icmp eq i8* %50, null
+  br i1 %NullCheck123, label %ThrowNullRef124, label %51
 
 ; <label>:51                                      ; preds = %46
   %52 = load i8, i8* %50, align 8
   %53 = zext i8 %52 to i32
   %54 = trunc i32 %53 to i8
-  %NullCheck126 = icmp ne i8* %48, null
-  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+  %NullCheck125 = icmp eq i8* %48, null
+  br i1 %NullCheck125, label %ThrowNullRef126, label %55
 
 ; <label>:55                                      ; preds = %51
   store i8 %54, i8* %48, align 8
@@ -763,14 +845,14 @@ entry:
   %57 = load i8*, i8** %arg0
   %58 = load i8*, i8** %arg1
   %59 = bitcast i8* %58 to i32*
-  %NullCheck116 = icmp ne i32* %59, null
-  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+  %NullCheck115 = icmp eq i32* %59, null
+  br i1 %NullCheck115, label %ThrowNullRef116, label %60
 
 ; <label>:60                                      ; preds = %56
   %61 = load i32, i32* %59, align 8
   %62 = bitcast i8* %57 to i32*
-  %NullCheck118 = icmp ne i32* %62, null
-  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+  %NullCheck117 = icmp eq i32* %62, null
+  br i1 %NullCheck117, label %ThrowNullRef118, label %63
 
 ; <label>:63                                      ; preds = %60
   store i32 %61, i32* %62, align 8
@@ -780,14 +862,14 @@ entry:
   %65 = load i8*, i8** %arg0
   %66 = load i8*, i8** %arg1
   %67 = bitcast i8* %66 to i32*
-  %NullCheck108 = icmp ne i32* %67, null
-  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+  %NullCheck107 = icmp eq i32* %67, null
+  br i1 %NullCheck107, label %ThrowNullRef108, label %68
 
 ; <label>:68                                      ; preds = %64
   %69 = load i32, i32* %67, align 8
   %70 = bitcast i8* %65 to i32*
-  %NullCheck110 = icmp ne i32* %70, null
-  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+  %NullCheck109 = icmp eq i32* %70, null
+  br i1 %NullCheck109, label %ThrowNullRef110, label %71
 
 ; <label>:71                                      ; preds = %68
   store i32 %69, i32* %70, align 8
@@ -795,15 +877,15 @@ entry:
   %73 = getelementptr inbounds i8, i8* %72, i64 4
   %74 = load i8*, i8** %arg1
   %75 = getelementptr inbounds i8, i8* %74, i64 4
-  %NullCheck112 = icmp ne i8* %75, null
-  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+  %NullCheck111 = icmp eq i8* %75, null
+  br i1 %NullCheck111, label %ThrowNullRef112, label %76
 
 ; <label>:76                                      ; preds = %71
   %77 = load i8, i8* %75, align 8
   %78 = zext i8 %77 to i32
   %79 = trunc i32 %78 to i8
-  %NullCheck114 = icmp ne i8* %73, null
-  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+  %NullCheck113 = icmp eq i8* %73, null
+  br i1 %NullCheck113, label %ThrowNullRef114, label %80
 
 ; <label>:80                                      ; preds = %76
   store i8 %79, i8* %73, align 8
@@ -813,14 +895,14 @@ entry:
   %82 = load i8*, i8** %arg0
   %83 = load i8*, i8** %arg1
   %84 = bitcast i8* %83 to i32*
-  %NullCheck100 = icmp ne i32* %84, null
-  br i1 %NullCheck100, label %85, label %ThrowNullRef99
+  %NullCheck99 = icmp eq i32* %84, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %85
 
 ; <label>:85                                      ; preds = %81
   %86 = load i32, i32* %84, align 8
   %87 = bitcast i8* %82 to i32*
-  %NullCheck102 = icmp ne i32* %87, null
-  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+  %NullCheck101 = icmp eq i32* %87, null
+  br i1 %NullCheck101, label %ThrowNullRef102, label %88
 
 ; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
@@ -829,16 +911,16 @@ entry:
   %91 = load i8*, i8** %arg1
   %92 = getelementptr inbounds i8, i8* %91, i64 4
   %93 = bitcast i8* %92 to i16*
-  %NullCheck104 = icmp ne i16* %93, null
-  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+  %NullCheck103 = icmp eq i16* %93, null
+  br i1 %NullCheck103, label %ThrowNullRef104, label %94
 
 ; <label>:94                                      ; preds = %88
   %95 = load i16, i16* %93, align 8
   %96 = sext i16 %95 to i32
   %97 = bitcast i8* %90 to i16*
   %98 = trunc i32 %96 to i16
-  %NullCheck106 = icmp ne i16* %97, null
-  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+  %NullCheck105 = icmp eq i16* %97, null
+  br i1 %NullCheck105, label %ThrowNullRef106, label %99
 
 ; <label>:99                                      ; preds = %94
   store i16 %98, i16* %97, align 8
@@ -848,14 +930,14 @@ entry:
   %101 = load i8*, i8** %arg0
   %102 = load i8*, i8** %arg1
   %103 = bitcast i8* %102 to i32*
-  %NullCheck88 = icmp ne i32* %103, null
-  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+  %NullCheck87 = icmp eq i32* %103, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %104
 
 ; <label>:104                                     ; preds = %100
   %105 = load i32, i32* %103, align 8
   %106 = bitcast i8* %101 to i32*
-  %NullCheck90 = icmp ne i32* %106, null
-  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+  %NullCheck89 = icmp eq i32* %106, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %107
 
 ; <label>:107                                     ; preds = %104
   store i32 %105, i32* %106, align 8
@@ -864,16 +946,16 @@ entry:
   %110 = load i8*, i8** %arg1
   %111 = getelementptr inbounds i8, i8* %110, i64 4
   %112 = bitcast i8* %111 to i16*
-  %NullCheck92 = icmp ne i16* %112, null
-  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+  %NullCheck91 = icmp eq i16* %112, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %113
 
 ; <label>:113                                     ; preds = %107
   %114 = load i16, i16* %112, align 8
   %115 = sext i16 %114 to i32
   %116 = bitcast i8* %109 to i16*
   %117 = trunc i32 %115 to i16
-  %NullCheck94 = icmp ne i16* %116, null
-  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+  %NullCheck93 = icmp eq i16* %116, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %118
 
 ; <label>:118                                     ; preds = %113
   store i16 %117, i16* %116, align 8
@@ -881,15 +963,15 @@ entry:
   %120 = getelementptr inbounds i8, i8* %119, i64 6
   %121 = load i8*, i8** %arg1
   %122 = getelementptr inbounds i8, i8* %121, i64 6
-  %NullCheck96 = icmp ne i8* %122, null
-  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+  %NullCheck95 = icmp eq i8* %122, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %123
 
 ; <label>:123                                     ; preds = %118
   %124 = load i8, i8* %122, align 8
   %125 = zext i8 %124 to i32
   %126 = trunc i32 %125 to i8
-  %NullCheck98 = icmp ne i8* %120, null
-  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+  %NullCheck97 = icmp eq i8* %120, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %127
 
 ; <label>:127                                     ; preds = %123
   store i8 %126, i8* %120, align 8
@@ -899,14 +981,14 @@ entry:
   %129 = load i8*, i8** %arg0
   %130 = load i8*, i8** %arg1
   %131 = bitcast i8* %130 to i64*
-  %NullCheck84 = icmp ne i64* %131, null
-  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+  %NullCheck83 = icmp eq i64* %131, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %132
 
 ; <label>:132                                     ; preds = %128
   %133 = load i64, i64* %131, align 8
   %134 = bitcast i8* %129 to i64*
-  %NullCheck86 = icmp ne i64* %134, null
-  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+  %NullCheck85 = icmp eq i64* %134, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %135
 
 ; <label>:135                                     ; preds = %132
   store i64 %133, i64* %134, align 8
@@ -916,14 +998,14 @@ entry:
   %137 = load i8*, i8** %arg0
   %138 = load i8*, i8** %arg1
   %139 = bitcast i8* %138 to i64*
-  %NullCheck76 = icmp ne i64* %139, null
-  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+  %NullCheck75 = icmp eq i64* %139, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %140
 
 ; <label>:140                                     ; preds = %136
   %141 = load i64, i64* %139, align 8
   %142 = bitcast i8* %137 to i64*
-  %NullCheck78 = icmp ne i64* %142, null
-  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+  %NullCheck77 = icmp eq i64* %142, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %143
 
 ; <label>:143                                     ; preds = %140
   store i64 %141, i64* %142, align 8
@@ -931,15 +1013,15 @@ entry:
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %NullCheck80 = icmp ne i8* %147, null
-  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+  %NullCheck79 = icmp eq i8* %147, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %148
 
 ; <label>:148                                     ; preds = %143
   %149 = load i8, i8* %147, align 8
   %150 = zext i8 %149 to i32
   %151 = trunc i32 %150 to i8
-  %NullCheck82 = icmp ne i8* %145, null
-  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+  %NullCheck81 = icmp eq i8* %145, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %152
 
 ; <label>:152                                     ; preds = %148
   store i8 %151, i8* %145, align 8
@@ -949,14 +1031,14 @@ entry:
   %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
   %156 = bitcast i8* %155 to i64*
-  %NullCheck68 = icmp ne i64* %156, null
-  br i1 %NullCheck68, label %157, label %ThrowNullRef67
+  %NullCheck67 = icmp eq i64* %156, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %157
 
 ; <label>:157                                     ; preds = %153
   %158 = load i64, i64* %156, align 8
   %159 = bitcast i8* %154 to i64*
-  %NullCheck70 = icmp ne i64* %159, null
-  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+  %NullCheck69 = icmp eq i64* %159, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %160
 
 ; <label>:160                                     ; preds = %157
   store i64 %158, i64* %159, align 8
@@ -965,16 +1047,16 @@ entry:
   %163 = load i8*, i8** %arg1
   %164 = getelementptr inbounds i8, i8* %163, i64 8
   %165 = bitcast i8* %164 to i16*
-  %NullCheck72 = icmp ne i16* %165, null
-  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+  %NullCheck71 = icmp eq i16* %165, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %166
 
 ; <label>:166                                     ; preds = %160
   %167 = load i16, i16* %165, align 8
   %168 = sext i16 %167 to i32
   %169 = bitcast i8* %162 to i16*
   %170 = trunc i32 %168 to i16
-  %NullCheck74 = icmp ne i16* %169, null
-  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+  %NullCheck73 = icmp eq i16* %169, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %171
 
 ; <label>:171                                     ; preds = %166
   store i16 %170, i16* %169, align 8
@@ -984,14 +1066,14 @@ entry:
   %173 = load i8*, i8** %arg0
   %174 = load i8*, i8** %arg1
   %175 = bitcast i8* %174 to i64*
-  %NullCheck56 = icmp ne i64* %175, null
-  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+  %NullCheck55 = icmp eq i64* %175, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %176
 
 ; <label>:176                                     ; preds = %172
   %177 = load i64, i64* %175, align 8
   %178 = bitcast i8* %173 to i64*
-  %NullCheck58 = icmp ne i64* %178, null
-  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+  %NullCheck57 = icmp eq i64* %178, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %179
 
 ; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
@@ -1000,16 +1082,16 @@ entry:
   %182 = load i8*, i8** %arg1
   %183 = getelementptr inbounds i8, i8* %182, i64 8
   %184 = bitcast i8* %183 to i16*
-  %NullCheck60 = icmp ne i16* %184, null
-  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+  %NullCheck59 = icmp eq i16* %184, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %185
 
 ; <label>:185                                     ; preds = %179
   %186 = load i16, i16* %184, align 8
   %187 = sext i16 %186 to i32
   %188 = bitcast i8* %181 to i16*
   %189 = trunc i32 %187 to i16
-  %NullCheck62 = icmp ne i16* %188, null
-  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+  %NullCheck61 = icmp eq i16* %188, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %190
 
 ; <label>:190                                     ; preds = %185
   store i16 %189, i16* %188, align 8
@@ -1017,15 +1099,15 @@ entry:
   %192 = getelementptr inbounds i8, i8* %191, i64 10
   %193 = load i8*, i8** %arg1
   %194 = getelementptr inbounds i8, i8* %193, i64 10
-  %NullCheck64 = icmp ne i8* %194, null
-  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+  %NullCheck63 = icmp eq i8* %194, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %195
 
 ; <label>:195                                     ; preds = %190
   %196 = load i8, i8* %194, align 8
   %197 = zext i8 %196 to i32
   %198 = trunc i32 %197 to i8
-  %NullCheck66 = icmp ne i8* %192, null
-  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+  %NullCheck65 = icmp eq i8* %192, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %199
 
 ; <label>:199                                     ; preds = %195
   store i8 %198, i8* %192, align 8
@@ -1035,14 +1117,14 @@ entry:
   %201 = load i8*, i8** %arg0
   %202 = load i8*, i8** %arg1
   %203 = bitcast i8* %202 to i64*
-  %NullCheck48 = icmp ne i64* %203, null
-  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+  %NullCheck47 = icmp eq i64* %203, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %204
 
 ; <label>:204                                     ; preds = %200
   %205 = load i64, i64* %203, align 8
   %206 = bitcast i8* %201 to i64*
-  %NullCheck50 = icmp ne i64* %206, null
-  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+  %NullCheck49 = icmp eq i64* %206, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %207
 
 ; <label>:207                                     ; preds = %204
   store i64 %205, i64* %206, align 8
@@ -1051,14 +1133,14 @@ entry:
   %210 = load i8*, i8** %arg1
   %211 = getelementptr inbounds i8, i8* %210, i64 8
   %212 = bitcast i8* %211 to i32*
-  %NullCheck52 = icmp ne i32* %212, null
-  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+  %NullCheck51 = icmp eq i32* %212, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %213
 
 ; <label>:213                                     ; preds = %207
   %214 = load i32, i32* %212, align 8
   %215 = bitcast i8* %209 to i32*
-  %NullCheck54 = icmp ne i32* %215, null
-  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+  %NullCheck53 = icmp eq i32* %215, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %216
 
 ; <label>:216                                     ; preds = %213
   store i32 %214, i32* %215, align 8
@@ -1068,14 +1150,14 @@ entry:
   %218 = load i8*, i8** %arg0
   %219 = load i8*, i8** %arg1
   %220 = bitcast i8* %219 to i64*
-  %NullCheck36 = icmp ne i64* %220, null
-  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64* %220, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %221
 
 ; <label>:221                                     ; preds = %217
   %222 = load i64, i64* %220, align 8
   %223 = bitcast i8* %218 to i64*
-  %NullCheck38 = icmp ne i64* %223, null
-  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+  %NullCheck37 = icmp eq i64* %223, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %224
 
 ; <label>:224                                     ; preds = %221
   store i64 %222, i64* %223, align 8
@@ -1084,14 +1166,14 @@ entry:
   %227 = load i8*, i8** %arg1
   %228 = getelementptr inbounds i8, i8* %227, i64 8
   %229 = bitcast i8* %228 to i32*
-  %NullCheck40 = icmp ne i32* %229, null
-  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i32* %229, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %230
 
 ; <label>:230                                     ; preds = %224
   %231 = load i32, i32* %229, align 8
   %232 = bitcast i8* %226 to i32*
-  %NullCheck42 = icmp ne i32* %232, null
-  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+  %NullCheck41 = icmp eq i32* %232, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %233
 
 ; <label>:233                                     ; preds = %230
   store i32 %231, i32* %232, align 8
@@ -1099,15 +1181,15 @@ entry:
   %235 = getelementptr inbounds i8, i8* %234, i64 12
   %236 = load i8*, i8** %arg1
   %237 = getelementptr inbounds i8, i8* %236, i64 12
-  %NullCheck44 = icmp ne i8* %237, null
-  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i8* %237, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %238
 
 ; <label>:238                                     ; preds = %233
   %239 = load i8, i8* %237, align 8
   %240 = zext i8 %239 to i32
   %241 = trunc i32 %240 to i8
-  %NullCheck46 = icmp ne i8* %235, null
-  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+  %NullCheck45 = icmp eq i8* %235, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %242
 
 ; <label>:242                                     ; preds = %238
   store i8 %241, i8* %235, align 8
@@ -1117,14 +1199,14 @@ entry:
   %244 = load i8*, i8** %arg0
   %245 = load i8*, i8** %arg1
   %246 = bitcast i8* %245 to i64*
-  %NullCheck24 = icmp ne i64* %246, null
-  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64* %246, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %247
 
 ; <label>:247                                     ; preds = %243
   %248 = load i64, i64* %246, align 8
   %249 = bitcast i8* %244 to i64*
-  %NullCheck26 = icmp ne i64* %249, null
-  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64* %249, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %250
 
 ; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
@@ -1133,14 +1215,14 @@ entry:
   %253 = load i8*, i8** %arg1
   %254 = getelementptr inbounds i8, i8* %253, i64 8
   %255 = bitcast i8* %254 to i32*
-  %NullCheck28 = icmp ne i32* %255, null
-  br i1 %NullCheck28, label %256, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i32* %255, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %256
 
 ; <label>:256                                     ; preds = %250
   %257 = load i32, i32* %255, align 8
   %258 = bitcast i8* %252 to i32*
-  %NullCheck30 = icmp ne i32* %258, null
-  br i1 %NullCheck30, label %259, label %ThrowNullRef29
+  %NullCheck29 = icmp eq i32* %258, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %259
 
 ; <label>:259                                     ; preds = %256
   store i32 %257, i32* %258, align 8
@@ -1149,16 +1231,16 @@ entry:
   %262 = load i8*, i8** %arg1
   %263 = getelementptr inbounds i8, i8* %262, i64 12
   %264 = bitcast i8* %263 to i16*
-  %NullCheck32 = icmp ne i16* %264, null
-  br i1 %NullCheck32, label %265, label %ThrowNullRef31
+  %NullCheck31 = icmp eq i16* %264, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %265
 
 ; <label>:265                                     ; preds = %259
   %266 = load i16, i16* %264, align 8
   %267 = sext i16 %266 to i32
   %268 = bitcast i8* %261 to i16*
   %269 = trunc i32 %267 to i16
-  %NullCheck34 = icmp ne i16* %268, null
-  br i1 %NullCheck34, label %270, label %ThrowNullRef33
+  %NullCheck33 = icmp eq i16* %268, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %270
 
 ; <label>:270                                     ; preds = %265
   store i16 %269, i16* %268, align 8
@@ -1168,14 +1250,14 @@ entry:
   %272 = load i8*, i8** %arg0
   %273 = load i8*, i8** %arg1
   %274 = bitcast i8* %273 to i64*
-  %NullCheck8 = icmp ne i64* %274, null
-  br i1 %NullCheck8, label %275, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64* %274, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %275
 
 ; <label>:275                                     ; preds = %271
   %276 = load i64, i64* %274, align 8
   %277 = bitcast i8* %272 to i64*
-  %NullCheck10 = icmp ne i64* %277, null
-  br i1 %NullCheck10, label %278, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %277, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %278
 
 ; <label>:278                                     ; preds = %275
   store i64 %276, i64* %277, align 8
@@ -1184,14 +1266,14 @@ entry:
   %281 = load i8*, i8** %arg1
   %282 = getelementptr inbounds i8, i8* %281, i64 8
   %283 = bitcast i8* %282 to i32*
-  %NullCheck12 = icmp ne i32* %283, null
-  br i1 %NullCheck12, label %284, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i32* %283, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %284
 
 ; <label>:284                                     ; preds = %278
   %285 = load i32, i32* %283, align 8
   %286 = bitcast i8* %280 to i32*
-  %NullCheck14 = icmp ne i32* %286, null
-  br i1 %NullCheck14, label %287, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i32* %286, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %287
 
 ; <label>:287                                     ; preds = %284
   store i32 %285, i32* %286, align 8
@@ -1200,16 +1282,16 @@ entry:
   %290 = load i8*, i8** %arg1
   %291 = getelementptr inbounds i8, i8* %290, i64 12
   %292 = bitcast i8* %291 to i16*
-  %NullCheck16 = icmp ne i16* %292, null
-  br i1 %NullCheck16, label %293, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i16* %292, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %293
 
 ; <label>:293                                     ; preds = %287
   %294 = load i16, i16* %292, align 8
   %295 = sext i16 %294 to i32
   %296 = bitcast i8* %289 to i16*
   %297 = trunc i32 %295 to i16
-  %NullCheck18 = icmp ne i16* %296, null
-  br i1 %NullCheck18, label %298, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i16* %296, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %298
 
 ; <label>:298                                     ; preds = %293
   store i16 %297, i16* %296, align 8
@@ -1217,15 +1299,15 @@ entry:
   %300 = getelementptr inbounds i8, i8* %299, i64 14
   %301 = load i8*, i8** %arg1
   %302 = getelementptr inbounds i8, i8* %301, i64 14
-  %NullCheck20 = icmp ne i8* %302, null
-  br i1 %NullCheck20, label %303, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i8* %302, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %303
 
 ; <label>:303                                     ; preds = %298
   %304 = load i8, i8* %302, align 8
   %305 = zext i8 %304 to i32
   %306 = trunc i32 %305 to i8
-  %NullCheck22 = icmp ne i8* %300, null
-  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i8* %300, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %307
 
 ; <label>:307                                     ; preds = %303
   store i8 %306, i8* %300, align 8
@@ -1235,14 +1317,14 @@ entry:
   %309 = load i8*, i8** %arg0
   %310 = load i8*, i8** %arg1
   %311 = bitcast i8* %310 to i64*
-  %NullCheck = icmp ne i64* %311, null
-  br i1 %NullCheck, label %312, label %ThrowNullRef
+  %NullCheck = icmp eq i64* %311, null
+  br i1 %NullCheck, label %ThrowNullRef, label %312
 
 ; <label>:312                                     ; preds = %308
   %313 = load i64, i64* %311, align 8
   %314 = bitcast i8* %309 to i64*
-  %NullCheck2 = icmp ne i64* %314, null
-  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64* %314, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %315
 
 ; <label>:315                                     ; preds = %312
   store i64 %313, i64* %314, align 8
@@ -1251,14 +1333,14 @@ entry:
   %318 = load i8*, i8** %arg1
   %319 = getelementptr inbounds i8, i8* %318, i64 8
   %320 = bitcast i8* %319 to i64*
-  %NullCheck4 = icmp ne i64* %320, null
-  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64* %320, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %321
 
 ; <label>:321                                     ; preds = %315
   %322 = load i64, i64* %320, align 8
   %323 = bitcast i8* %317 to i64*
-  %NullCheck6 = icmp ne i64* %323, null
-  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64* %323, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %324
 
 ; <label>:324                                     ; preds = %321
   store i64 %322, i64* %323, align 8
@@ -1286,15 +1368,15 @@ entry:
 ; <label>:338                                     ; preds = %333
   %339 = load i8*, i8** %arg0
   %340 = load i8*, i8** %arg1
-  %NullCheck136 = icmp ne i8* %340, null
-  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+  %NullCheck135 = icmp eq i8* %340, null
+  br i1 %NullCheck135, label %ThrowNullRef136, label %341
 
 ; <label>:341                                     ; preds = %338
   %342 = load i8, i8* %340, align 8
   %343 = zext i8 %342 to i32
   %344 = trunc i32 %343 to i8
-  %NullCheck138 = icmp ne i8* %339, null
-  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+  %NullCheck137 = icmp eq i8* %339, null
+  br i1 %NullCheck137, label %ThrowNullRef138, label %345
 
 ; <label>:345                                     ; preds = %341
   store i8 %344, i8* %339, align 8
@@ -1317,16 +1399,16 @@ entry:
   %357 = load i8*, i8** %arg0
   %358 = load i8*, i8** %arg1
   %359 = bitcast i8* %358 to i16*
-  %NullCheck140 = icmp ne i16* %359, null
-  br i1 %NullCheck140, label %360, label %ThrowNullRef139
+  %NullCheck139 = icmp eq i16* %359, null
+  br i1 %NullCheck139, label %ThrowNullRef140, label %360
 
 ; <label>:360                                     ; preds = %356
   %361 = load i16, i16* %359, align 8
   %362 = sext i16 %361 to i32
   %363 = bitcast i8* %357 to i16*
   %364 = trunc i32 %362 to i16
-  %NullCheck142 = icmp ne i16* %363, null
-  br i1 %NullCheck142, label %365, label %ThrowNullRef141
+  %NullCheck141 = icmp eq i16* %363, null
+  br i1 %NullCheck141, label %ThrowNullRef142, label %365
 
 ; <label>:365                                     ; preds = %360
   store i16 %364, i16* %363, align 8
@@ -1352,14 +1434,14 @@ entry:
   %378 = load i8*, i8** %arg0
   %379 = load i8*, i8** %arg1
   %380 = bitcast i8* %379 to i32*
-  %NullCheck144 = icmp ne i32* %380, null
-  br i1 %NullCheck144, label %381, label %ThrowNullRef143
+  %NullCheck143 = icmp eq i32* %380, null
+  br i1 %NullCheck143, label %ThrowNullRef144, label %381
 
 ; <label>:381                                     ; preds = %377
   %382 = load i32, i32* %380, align 8
   %383 = bitcast i8* %378 to i32*
-  %NullCheck146 = icmp ne i32* %383, null
-  br i1 %NullCheck146, label %384, label %ThrowNullRef145
+  %NullCheck145 = icmp eq i32* %383, null
+  br i1 %NullCheck145, label %ThrowNullRef146, label %384
 
 ; <label>:384                                     ; preds = %381
   store i32 %382, i32* %383, align 8
@@ -1384,14 +1466,14 @@ entry:
   %395 = load i8*, i8** %arg0
   %396 = load i8*, i8** %arg1
   %397 = bitcast i8* %396 to i64*
-  %NullCheck164 = icmp ne i64* %397, null
-  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+  %NullCheck163 = icmp eq i64* %397, null
+  br i1 %NullCheck163, label %ThrowNullRef164, label %398
 
 ; <label>:398                                     ; preds = %394
   %399 = load i64, i64* %397, align 8
   %400 = bitcast i8* %395 to i64*
-  %NullCheck166 = icmp ne i64* %400, null
-  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+  %NullCheck165 = icmp eq i64* %400, null
+  br i1 %NullCheck165, label %ThrowNullRef166, label %401
 
 ; <label>:401                                     ; preds = %398
   store i64 %399, i64* %400, align 8
@@ -1400,14 +1482,14 @@ entry:
   %404 = load i8*, i8** %arg1
   %405 = getelementptr inbounds i8, i8* %404, i64 8
   %406 = bitcast i8* %405 to i64*
-  %NullCheck168 = icmp ne i64* %406, null
-  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+  %NullCheck167 = icmp eq i64* %406, null
+  br i1 %NullCheck167, label %ThrowNullRef168, label %407
 
 ; <label>:407                                     ; preds = %401
   %408 = load i64, i64* %406, align 8
   %409 = bitcast i8* %403 to i64*
-  %NullCheck170 = icmp ne i64* %409, null
-  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+  %NullCheck169 = icmp eq i64* %409, null
+  br i1 %NullCheck169, label %ThrowNullRef170, label %410
 
 ; <label>:410                                     ; preds = %407
   store i64 %408, i64* %409, align 8
@@ -1437,14 +1519,14 @@ entry:
   %425 = load i8*, i8** %arg0
   %426 = load i8*, i8** %arg1
   %427 = bitcast i8* %426 to i64*
-  %NullCheck148 = icmp ne i64* %427, null
-  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+  %NullCheck147 = icmp eq i64* %427, null
+  br i1 %NullCheck147, label %ThrowNullRef148, label %428
 
 ; <label>:428                                     ; preds = %424
   %429 = load i64, i64* %427, align 8
   %430 = bitcast i8* %425 to i64*
-  %NullCheck150 = icmp ne i64* %430, null
-  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+  %NullCheck149 = icmp eq i64* %430, null
+  br i1 %NullCheck149, label %ThrowNullRef150, label %431
 
 ; <label>:431                                     ; preds = %428
   store i64 %429, i64* %430, align 8
@@ -1466,14 +1548,14 @@ entry:
   %441 = load i8*, i8** %arg0
   %442 = load i8*, i8** %arg1
   %443 = bitcast i8* %442 to i32*
-  %NullCheck152 = icmp ne i32* %443, null
-  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+  %NullCheck151 = icmp eq i32* %443, null
+  br i1 %NullCheck151, label %ThrowNullRef152, label %444
 
 ; <label>:444                                     ; preds = %440
   %445 = load i32, i32* %443, align 8
   %446 = bitcast i8* %441 to i32*
-  %NullCheck154 = icmp ne i32* %446, null
-  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+  %NullCheck153 = icmp eq i32* %446, null
+  br i1 %NullCheck153, label %ThrowNullRef154, label %447
 
 ; <label>:447                                     ; preds = %444
   store i32 %445, i32* %446, align 8
@@ -1495,16 +1577,16 @@ entry:
   %457 = load i8*, i8** %arg0
   %458 = load i8*, i8** %arg1
   %459 = bitcast i8* %458 to i16*
-  %NullCheck156 = icmp ne i16* %459, null
-  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+  %NullCheck155 = icmp eq i16* %459, null
+  br i1 %NullCheck155, label %ThrowNullRef156, label %460
 
 ; <label>:460                                     ; preds = %456
   %461 = load i16, i16* %459, align 8
   %462 = sext i16 %461 to i32
   %463 = bitcast i8* %457 to i16*
   %464 = trunc i32 %462 to i16
-  %NullCheck158 = icmp ne i16* %463, null
-  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+  %NullCheck157 = icmp eq i16* %463, null
+  br i1 %NullCheck157, label %ThrowNullRef158, label %465
 
 ; <label>:465                                     ; preds = %460
   store i16 %464, i16* %463, align 8
@@ -1525,15 +1607,15 @@ entry:
 ; <label>:474                                     ; preds = %470
   %475 = load i8*, i8** %arg0
   %476 = load i8*, i8** %arg1
-  %NullCheck160 = icmp ne i8* %476, null
-  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+  %NullCheck159 = icmp eq i8* %476, null
+  br i1 %NullCheck159, label %ThrowNullRef160, label %477
 
 ; <label>:477                                     ; preds = %474
   %478 = load i8, i8* %476, align 8
   %479 = zext i8 %478 to i32
   %480 = trunc i32 %479 to i8
-  %NullCheck162 = icmp ne i8* %475, null
-  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+  %NullCheck161 = icmp eq i8* %475, null
+  br i1 %NullCheck161, label %ThrowNullRef162, label %481
 
 ; <label>:481                                     ; preds = %477
   store i8 %480, i8* %475, align 8
@@ -1553,343 +1635,343 @@ ThrowNullRef:                                     ; preds = %308
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %312
+ThrowNullRef2:                                    ; preds = %312
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %315
+ThrowNullRef4:                                    ; preds = %315
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %321
+ThrowNullRef6:                                    ; preds = %321
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %271
+ThrowNullRef8:                                    ; preds = %271
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %275
+ThrowNullRef10:                                   ; preds = %275
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %278
+ThrowNullRef12:                                   ; preds = %278
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %284
+ThrowNullRef14:                                   ; preds = %284
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %287
+ThrowNullRef16:                                   ; preds = %287
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %293
+ThrowNullRef18:                                   ; preds = %293
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %298
+ThrowNullRef20:                                   ; preds = %298
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %303
+ThrowNullRef22:                                   ; preds = %303
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %243
+ThrowNullRef24:                                   ; preds = %243
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %247
+ThrowNullRef26:                                   ; preds = %247
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %250
+ThrowNullRef28:                                   ; preds = %250
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %256
+ThrowNullRef30:                                   ; preds = %256
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %259
+ThrowNullRef32:                                   ; preds = %259
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %265
+ThrowNullRef34:                                   ; preds = %265
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %217
+ThrowNullRef36:                                   ; preds = %217
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %221
+ThrowNullRef38:                                   ; preds = %221
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %224
+ThrowNullRef40:                                   ; preds = %224
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %230
+ThrowNullRef42:                                   ; preds = %230
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %233
+ThrowNullRef44:                                   ; preds = %233
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %238
+ThrowNullRef46:                                   ; preds = %238
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %200
+ThrowNullRef48:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %204
+ThrowNullRef50:                                   ; preds = %204
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %207
+ThrowNullRef52:                                   ; preds = %207
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %213
+ThrowNullRef54:                                   ; preds = %213
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %172
+ThrowNullRef56:                                   ; preds = %172
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %176
+ThrowNullRef58:                                   ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %179
+ThrowNullRef60:                                   ; preds = %179
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %185
+ThrowNullRef62:                                   ; preds = %185
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %190
+ThrowNullRef64:                                   ; preds = %190
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %195
+ThrowNullRef66:                                   ; preds = %195
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %153
+ThrowNullRef68:                                   ; preds = %153
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %157
+ThrowNullRef70:                                   ; preds = %157
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %160
+ThrowNullRef72:                                   ; preds = %160
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %166
+ThrowNullRef74:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %136
+ThrowNullRef76:                                   ; preds = %136
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %140
+ThrowNullRef78:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %143
+ThrowNullRef80:                                   ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %148
+ThrowNullRef82:                                   ; preds = %148
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %128
+ThrowNullRef84:                                   ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %132
+ThrowNullRef86:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %100
+ThrowNullRef88:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %104
+ThrowNullRef90:                                   ; preds = %104
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %107
+ThrowNullRef92:                                   ; preds = %107
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %113
+ThrowNullRef94:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %118
+ThrowNullRef96:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %123
+ThrowNullRef98:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %81
+ThrowNullRef100:                                  ; preds = %81
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef101:                                  ; preds = %85
+ThrowNullRef102:                                  ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef103:                                  ; preds = %88
+ThrowNullRef104:                                  ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef105:                                  ; preds = %94
+ThrowNullRef106:                                  ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef107:                                  ; preds = %64
+ThrowNullRef108:                                  ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef109:                                  ; preds = %68
+ThrowNullRef110:                                  ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef111:                                  ; preds = %71
+ThrowNullRef112:                                  ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef113:                                  ; preds = %76
+ThrowNullRef114:                                  ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef115:                                  ; preds = %56
+ThrowNullRef116:                                  ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef117:                                  ; preds = %60
+ThrowNullRef118:                                  ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef119:                                  ; preds = %37
+ThrowNullRef120:                                  ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef121:                                  ; preds = %41
+ThrowNullRef122:                                  ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef123:                                  ; preds = %46
+ThrowNullRef124:                                  ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef125:                                  ; preds = %51
+ThrowNullRef126:                                  ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef127:                                  ; preds = %27
+ThrowNullRef128:                                  ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef129:                                  ; preds = %31
+ThrowNullRef130:                                  ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef131:                                  ; preds = %19
+ThrowNullRef132:                                  ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef133:                                  ; preds = %22
+ThrowNullRef134:                                  ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef135:                                  ; preds = %338
+ThrowNullRef136:                                  ; preds = %338
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef137:                                  ; preds = %341
+ThrowNullRef138:                                  ; preds = %341
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef139:                                  ; preds = %356
+ThrowNullRef140:                                  ; preds = %356
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef141:                                  ; preds = %360
+ThrowNullRef142:                                  ; preds = %360
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef143:                                  ; preds = %377
+ThrowNullRef144:                                  ; preds = %377
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef145:                                  ; preds = %381
+ThrowNullRef146:                                  ; preds = %381
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef147:                                  ; preds = %424
+ThrowNullRef148:                                  ; preds = %424
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef149:                                  ; preds = %428
+ThrowNullRef150:                                  ; preds = %428
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef151:                                  ; preds = %440
+ThrowNullRef152:                                  ; preds = %440
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef153:                                  ; preds = %444
+ThrowNullRef154:                                  ; preds = %444
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef155:                                  ; preds = %456
+ThrowNullRef156:                                  ; preds = %456
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef157:                                  ; preds = %460
+ThrowNullRef158:                                  ; preds = %460
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef159:                                  ; preds = %474
+ThrowNullRef160:                                  ; preds = %474
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef161:                                  ; preds = %477
+ThrowNullRef162:                                  ; preds = %477
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef163:                                  ; preds = %394
+ThrowNullRef164:                                  ; preds = %394
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef165:                                  ; preds = %398
+ThrowNullRef166:                                  ; preds = %398
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef167:                                  ; preds = %401
+ThrowNullRef168:                                  ; preds = %401
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef169:                                  ; preds = %407
+ThrowNullRef170:                                  ; preds = %407
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1939,8 +2021,8 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
-  br i1 %NullCheck, label %22, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %ThrowNullRef, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
@@ -1948,8 +2030,8 @@ entry:
   store i32 %24, i32* %loc0
   %25 = load i32, i32* %loc0
   %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %26, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %27
 
 ; <label>:27                                      ; preds = %22
   %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
@@ -1971,7 +2053,7 @@ ThrowNullRef:                                     ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1989,8 +2071,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -2022,15 +2104,15 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2048,16 +2130,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
   %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
   store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %15
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
@@ -2072,8 +2154,8 @@ entry:
   %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
   %29 = ptrtoint i16 addrspace(1)* %28 to i64
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %19
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
@@ -2089,19 +2171,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2114,8 +2196,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
@@ -2128,7 +2210,7 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[loadElem]
+Failed to read AppDomain.PrepareDataForSetup[storeElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
@@ -2202,8 +2284,8 @@ entry:
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
-  br i1 %NullCheck24, label %27, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = load i64, i64 addrspace(1)* %26
@@ -2218,8 +2300,8 @@ entry:
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
-  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
   %41 = load i64, i64 addrspace(1)* %39
@@ -2236,8 +2318,8 @@ entry:
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
-  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
   %54 = load i64, i64 addrspace(1)* %52
@@ -2252,8 +2334,8 @@ entry:
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
   %67 = load i64, i64 addrspace(1)* %65
@@ -2270,8 +2352,8 @@ entry:
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
-  br i1 %NullCheck16, label %79, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
   %80 = load i64, i64 addrspace(1)* %78
@@ -2286,8 +2368,8 @@ entry:
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
-  br i1 %NullCheck18, label %92, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
   %93 = load i64, i64 addrspace(1)* %91
@@ -2304,8 +2386,8 @@ entry:
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
-  br i1 %NullCheck12, label %105, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = load i64, i64 addrspace(1)* %104
@@ -2320,8 +2402,8 @@ entry:
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
-  br i1 %NullCheck14, label %118, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
   %119 = load i64, i64 addrspace(1)* %117
@@ -2337,8 +2419,8 @@ entry:
 
 ; <label>:128                                     ; preds = %20
   %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
-  br i1 %NullCheck4, label %130, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %129, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %130
 
 ; <label>:130                                     ; preds = %128
   %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
@@ -2346,8 +2428,8 @@ entry:
   %133 = load i16, i16 addrspace(1)* %132, align 8
   %134 = zext i16 %133 to i32
   %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
-  br i1 %NullCheck6, label %136, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %135, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %136
 
 ; <label>:136                                     ; preds = %130
   %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
@@ -2360,8 +2442,8 @@ entry:
 
 ; <label>:143                                     ; preds = %136
   %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
-  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %144, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %145
 
 ; <label>:145                                     ; preds = %143
   %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
@@ -2369,8 +2451,8 @@ entry:
   %148 = load i16, i16 addrspace(1)* %147, align 8
   %149 = zext i16 %148 to i32
   %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %150, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %151
 
 ; <label>:151                                     ; preds = %145
   %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
@@ -2388,8 +2470,8 @@ entry:
 
 ; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
-  br i1 %NullCheck, label %163, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %ThrowNullRef, label %163
 
 ; <label>:163                                     ; preds = %161
   %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
@@ -2399,8 +2481,8 @@ entry:
 
 ; <label>:167                                     ; preds = %163
   %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
-  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %168, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %169
 
 ; <label>:169                                     ; preds = %167
   %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
@@ -2432,55 +2514,55 @@ ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %167
+ThrowNullRef2:                                    ; preds = %167
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %128
+ThrowNullRef4:                                    ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %130
+ThrowNullRef6:                                    ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %143
+ThrowNullRef8:                                    ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %145
+ThrowNullRef10:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %102
+ThrowNullRef12:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %105
+ThrowNullRef14:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %76
+ThrowNullRef16:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %79
+ThrowNullRef18:                                   ; preds = %79
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %50
+ThrowNullRef20:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %53
+ThrowNullRef22:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %24
+ThrowNullRef24:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %27
+ThrowNullRef26:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2503,15 +2585,15 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2519,16 +2601,16 @@ entry:
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
   store i32 %8, i32* %loc0
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
   %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
   store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
@@ -2546,16 +2628,16 @@ entry:
 
 ; <label>:23                                      ; preds = %64
   %24 = load i16*, i16** %loc3
-  %NullCheck12 = icmp ne i16* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i16* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
   store i32 %27, i32* %loc5
   %28 = load i16*, i16** %loc4
-  %NullCheck14 = icmp ne i16* %28, null
-  br i1 %NullCheck14, label %29, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %28, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = load i16, i16* %28, align 8
@@ -2620,15 +2702,15 @@ entry:
 
 ; <label>:67                                      ; preds = %64
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
-  br i1 %NullCheck8, label %69, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %68, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %69
 
 ; <label>:69                                      ; preds = %67
   %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
   %71 = load i32, i32 addrspace(1)* %70
   %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
-  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %73
 
 ; <label>:73                                      ; preds = %69
   %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
@@ -2645,31 +2727,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %67
+ThrowNullRef8:                                    ; preds = %67
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %69
+ThrowNullRef10:                                   ; preds = %69
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2710,14 +2792,14 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
   %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
@@ -2730,14 +2812,14 @@ entry:
 
 ; <label>:11                                      ; preds = %4
   %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
   %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
@@ -2749,14 +2831,14 @@ entry:
 
 ; <label>:22                                      ; preds = %16
   %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
   %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
-  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
-  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
@@ -2804,23 +2886,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2836,7 +2918,280 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[loadElem]
+Successfully read RuntimeType.IsAssignableFrom
+
+define i8 @RuntimeType.IsAssignableFrom(%System.RuntimeType addrspace(1)* %param0, %System.Type addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.RuntimeType addrspace(1)*
+  %arg1 = alloca %System.Type addrspace(1)*
+  %loc0 = alloca %System.RuntimeType addrspace(1)*
+  %loc1 = alloca %"System.Type[]" addrspace(1)*
+  %loc2 = alloca i32
+  store %System.RuntimeType addrspace(1)* %param0, %System.RuntimeType addrspace(1)** %this
+  store %System.Type addrspace(1)* %param1, %System.Type addrspace(1)** %arg1
+  %0 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %1 = icmp ne %System.Type addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i8 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %5 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %6 = bitcast %System.Type addrspace(1)* %4 to %System.Object addrspace(1)*
+  %7 = bitcast %System.RuntimeType addrspace(1)* %5 to %System.Object addrspace(1)*
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %6, %System.Object addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %3
+  ret i8 1
+
+; <label>:12                                      ; preds = %3
+  %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 152
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 32
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
+  %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
+  %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
+  store %System.RuntimeType addrspace(1)* %25, %System.RuntimeType addrspace(1)** %loc0
+  %26 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %27 = icmp eq %System.RuntimeType addrspace(1)* %26, null
+  br i1 %27, label %34, label %28
+
+; <label>:28                                      ; preds = %15
+  %29 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %30 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)*)*)(%System.RuntimeType addrspace(1)* %29, %System.RuntimeType addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+; <label>:34                                      ; preds = %15
+  %35 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %36 = call %System.Reflection.Emit.TypeBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Reflection.Emit.TypeBuilder addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %35)
+  %37 = icmp eq %System.Reflection.Emit.TypeBuilder addrspace(1)* %36, null
+  br i1 %37, label %139, label %38
+
+; <label>:38                                      ; preds = %34
+  %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %42
+
+; <label>:42                                      ; preds = %38
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 152
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 40
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
+  %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
+  %53 = zext i8 %52 to i32
+  %54 = icmp eq i32 %53, 0
+  br i1 %54, label %56, label %55
+
+; <label>:55                                      ; preds = %42
+  ret i8 1
+
+; <label>:56                                      ; preds = %42
+  %57 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %58 = bitcast %System.RuntimeType addrspace(1)* %57 to %System.Type addrspace(1)*
+  %59 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %58)
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %64 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.Type addrspace(1)* %63, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = bitcast %System.RuntimeType addrspace(1)* %64 to %System.Type addrspace(1)*
+  %67 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %63, %System.Type addrspace(1)* %66)
+  %68 = zext i8 %67 to i32
+  %69 = trunc i32 %68 to i8
+  ret i8 %69
+
+; <label>:70                                      ; preds = %56
+  %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
+  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %73
+
+; <label>:73                                      ; preds = %70
+  %74 = load i64, i64 addrspace(1)* %72
+  %75 = add i64 %74, 128
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = add i64 %77, 0
+  %79 = inttoptr i64 %78 to i64*
+  %80 = load i64, i64* %79
+  %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
+  %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
+  %83 = call i8 %82(%System.Type addrspace(1)* %81)
+  %84 = zext i8 %83 to i32
+  %85 = icmp eq i32 %84, 0
+  br i1 %85, label %139, label %86
+
+; <label>:86                                      ; preds = %73
+  %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
+  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %89
+
+; <label>:89                                      ; preds = %86
+  %90 = load i64, i64 addrspace(1)* %88
+  %91 = add i64 %90, 128
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = add i64 %93, 24
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
+  %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
+  %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
+  store %"System.Type[]" addrspace(1)* %99, %"System.Type[]" addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %129
+
+; <label>:100                                     ; preds = %132
+  %101 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %102 = load i32, i32* %loc2
+  %NullCheck11 = icmp eq %"System.Type[]" addrspace(1)* %101, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %103
+
+; <label>:103                                     ; preds = %100
+  %104 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 1
+  %105 = load i32, i32 addrspace(1)* %104
+  %106 = zext i32 %105 to i64
+  %107 = zext i32 %102 to i64
+  %BoundsCheck = icmp uge i64 %107, %106
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %108
+
+; <label>:108                                     ; preds = %103
+  %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
+  %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
+  %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
+  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %113
+
+; <label>:113                                     ; preds = %108
+  %114 = load i64, i64 addrspace(1)* %112
+  %115 = add i64 %114, 152
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = add i64 %117, 56
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
+  %123 = zext i8 %122 to i32
+  %124 = icmp ne i32 %123, 0
+  br i1 %124, label %126, label %125
+
+; <label>:125                                     ; preds = %113
+  ret i8 0
+
+; <label>:126                                     ; preds = %113
+  %127 = load i32, i32* %loc2
+  %128 = add i32 %127, 1
+  store i32 %128, i32* %loc2
+  br label %129
+
+; <label>:129                                     ; preds = %89, %126
+  %130 = load i32, i32* %loc2
+  %131 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %NullCheck9 = icmp eq %"System.Type[]" addrspace(1)* %131, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %132
+
+; <label>:132                                     ; preds = %129
+  %133 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %131, i32 0, i32 1
+  %134 = load i32, i32 addrspace(1)* %133
+  %135 = zext i32 %134 to i64
+  %136 = trunc i64 %135 to i32
+  %137 = icmp slt i32 %130, %136
+  br i1 %137, label %100, label %138
+
+; <label>:138                                     ; preds = %132
+  ret i8 1
+
+; <label>:139                                     ; preds = %34, %73
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %129
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %103
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -2893,7 +3248,7 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElem]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -2904,8 +3259,8 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -2997,8 +3352,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
@@ -3059,8 +3414,8 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -3087,8 +3442,8 @@ entry:
 
 ; <label>:17                                      ; preds = %5, %11
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
@@ -3097,8 +3452,8 @@ entry:
 
 ; <label>:22                                      ; preds = %1, %11
   %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
@@ -3109,11 +3464,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %17
+ThrowNullRef2:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %22
+ThrowNullRef4:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3167,15 +3522,15 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
   %15 = load i32, i32 addrspace(1)* %14
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
@@ -3198,7 +3553,7 @@ ThrowNullRef:                                     ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef2:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3232,8 +3587,8 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
@@ -3312,8 +3667,8 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -3327,8 +3682,8 @@ entry:
 ; <label>:5                                       ; preds = %43
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %7 = load i32, i32* %loc1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck6, label %8, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
@@ -3366,8 +3721,8 @@ entry:
 ; <label>:32                                      ; preds = %21, %25
   %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
   %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
-  br i1 %NullCheck8, label %35, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = trunc i32 %34 to i16
@@ -3380,8 +3735,8 @@ entry:
 ; <label>:40                                      ; preds = %1, %35
   %41 = load i32, i32* %loc1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
-  br i1 %NullCheck2, label %43, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %42, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
@@ -3392,8 +3747,8 @@ entry:
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
   %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
-  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
   %51 = load i64, i64 addrspace(1)* %49
@@ -3412,19 +3767,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %40
+ThrowNullRef2:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %47
+ThrowNullRef4:                                    ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %5
+ThrowNullRef6:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %32
+ThrowNullRef8:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3467,8 +3822,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
@@ -3492,11 +3847,391 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(i16* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store i16* %param0, i16** %arg0
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load i32, i32* %arg3
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %42, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %37, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg2
+  %13 = load i32, i32* %arg3
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %37, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %24 = load i32, i32* %arg2
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load i16*, i16** %arg0
+  %35 = load i32, i32* %arg3
+  %36 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %36, i16* %34, i32 %35)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:37                                      ; preds = %5, %16
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %39)
+  %41 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41, %System.String addrspace(1)* %38, %System.String addrspace(1)* %40)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41) #0
+  unreachable
+
+; <label>:42                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
-Failed to read StringBuilder.ToString[loadElemA]
+Successfully read StringBuilder.ToString
+
+define %System.String addrspace(1)* @StringBuilder.ToString(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i16*
+  %loc3 = alloca %"System.Char[]" addrspace(1)*
+  %loc4 = alloca i32
+  %loc5 = alloca i32
+  %loc6 = alloca i16 addrspace(1)*
+  %loc7 = alloca %System.String addrspace(1)*
+  %loc8 = alloca %"System.Char[]" addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %0)
+  %2 = icmp ne i32 %1, 0
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %4
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %6)
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %7)
+  store %System.String addrspace(1)* %8, %System.String addrspace(1)** %loc0
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.Text.StringBuilder addrspace(1)* %9, %System.Text.StringBuilder addrspace(1)** %loc1
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  store %System.String addrspace(1)* %10, %System.String addrspace(1)** %loc7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc7
+  %12 = ptrtoint %System.String addrspace(1)* %11 to i64
+  %13 = icmp eq i64 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %5
+  %15 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %16 = sext i32 %15 to i64
+  %17 = add i64 %12, %16
+  br label %18
+
+; <label>:18                                      ; preds = %5, %14
+  %19 = phi i64 [ %12, %5 ], [ %17, %14 ]
+  %20 = inttoptr i64 %19 to i16*
+  store i16* %20, i16** %loc2
+  br label %21
+
+; <label>:21                                      ; preds = %98, %18
+  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %22, null
+  br i1 %NullCheck, label %ThrowNullRef, label %23
+
+; <label>:23                                      ; preds = %21
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 3
+  %25 = load i32, i32 addrspace(1)* %24, align 8
+  %26 = icmp sle i32 %25, 0
+  br i1 %26, label %96, label %27
+
+; <label>:27                                      ; preds = %23
+  %28 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %28, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %29
+
+; <label>:29                                      ; preds = %27
+  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %28, i32 0, i32 1
+  %31 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %30, align 8
+  store %"System.Char[]" addrspace(1)* %31, %"System.Char[]" addrspace(1)** %loc3
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %33
+
+; <label>:33                                      ; preds = %29
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  store i32 %35, i32* %loc4
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  %39 = load i32, i32 addrspace(1)* %38, align 8
+  store i32 %39, i32* %loc5
+  %40 = load i32, i32* %loc5
+  %41 = load i32, i32* %loc4
+  %42 = add i32 %40, %41
+  %43 = zext i32 %42 to i64
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %45
+
+; <label>:45                                      ; preds = %37
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = sext i32 %47 to i64
+  %49 = icmp sgt i64 %43, %48
+  br i1 %49, label %91, label %50
+
+; <label>:50                                      ; preds = %45
+  %51 = load i32, i32* %loc5
+  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %52, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %53
+
+; <label>:53                                      ; preds = %50
+  %54 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %52, i32 0, i32 1
+  %55 = load i32, i32 addrspace(1)* %54
+  %56 = zext i32 %55 to i64
+  %57 = trunc i64 %56 to i32
+  %58 = icmp ugt i32 %51, %57
+  br i1 %58, label %91, label %59
+
+; <label>:59                                      ; preds = %53
+  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  store %"System.Char[]" addrspace(1)* %60, %"System.Char[]" addrspace(1)** %loc8
+  %61 = icmp eq %"System.Char[]" addrspace(1)* %60, null
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %63, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %64
+
+; <label>:64                                      ; preds = %62
+  %65 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %63, i32 0, i32 1
+  %66 = load i32, i32 addrspace(1)* %65
+  %67 = zext i32 %66 to i64
+  %68 = trunc i64 %67 to i32
+  %69 = icmp ne i32 %68, 0
+  br i1 %69, label %71, label %70
+
+; <label>:70                                      ; preds = %59, %64
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:71                                      ; preds = %64
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %73
+
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %BoundsCheck = icmp uge i64 0, %76
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %77
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %78, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:79                                      ; preds = %70, %77
+  %80 = load i16*, i16** %loc2
+  %81 = load i32, i32* %loc4
+  %82 = sext i32 %81 to i64
+  %83 = mul i64 %82, 2
+  %84 = bitcast i16* %80 to i8*
+  %85 = getelementptr inbounds i8, i8* %84, i64 %83
+  %86 = load i16 addrspace(1)*, i16 addrspace(1)** %loc6
+  %87 = ptrtoint i16 addrspace(1)* %86 to i64
+  %88 = load i32, i32* %loc5
+  %89 = bitcast i8* %85 to i16*
+  %90 = inttoptr i64 %87 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %89, i16* %90, i32 %88)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %96
+
+; <label>:91                                      ; preds = %45, %53
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %94 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %93)
+  %95 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95, %System.String addrspace(1)* %92, %System.String addrspace(1)* %94)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95) #0
+  unreachable
+
+; <label>:96                                      ; preds = %23, %79
+  %97 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %97, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %98
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %97, i32 0, i32 2
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  store %System.Text.StringBuilder addrspace(1)* %100, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %102 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %102, label %21, label %103
+
+; <label>:103                                     ; preds = %98
+  store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc7
+  %104 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  ret %System.String addrspace(1)* %104
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method StringBuilder::get_Length using LLILCJit
+Successfully read StringBuilder.get_Length
+
+define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
+Successfully read RuntimeHelpers.get_OffsetToStringData
+
+define i32 @RuntimeHelpers.get_OffsetToStringData() {
+entry:
+  ret i32 12
+}
+
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
 Successfully read CultureData.CreateCultureData
 
@@ -3514,23 +4249,23 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
   store i8 %4, i8 addrspace(1)* %6
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
@@ -3549,11 +4284,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3566,50 +4301,50 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
   store i32 -1, i32 addrspace(1)* %2
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
   store i32 -1, i32 addrspace(1)* %8
   %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
   store i32 -1, i32 addrspace(1)* %14
   %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
   store i32 -1, i32 addrspace(1)* %17
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
@@ -3623,27 +4358,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3675,7 +4410,136 @@ Failed to read Dictionary`2.Insert[non-const derefAddress]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
 Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
-Failed to read HashHelpers.GetPrime[loadElem]
+Successfully read HashHelpers.GetPrime
+
+define i32 @HashHelpers.GetPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %6, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5, %System.String addrspace(1)* %4)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5) #0
+  unreachable
+
+; <label>:6                                       ; preds = %entry
+  store i32 0, i32* %loc0
+  br label %29
+
+; <label>:7                                       ; preds = %35
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 1296
+  %10 = addrspacecast i8 addrspace(1)* %9 to %"System.Int32[]" addrspace(1)**
+  %11 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %10
+  %12 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Int32[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = zext i32 %15 to i64
+  %17 = zext i32 %12 to i64
+  %BoundsCheck = icmp uge i64 %17, %16
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 3, i32 %12
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  store i32 %20, i32* %loc1
+  %21 = load i32, i32* %loc1
+  %22 = load i32, i32* %arg0
+  %23 = icmp slt i32 %21, %22
+  br i1 %23, label %26, label %24
+
+; <label>:24                                      ; preds = %18
+  %25 = load i32, i32* %loc1
+  ret i32 %25
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %loc0
+  %28 = add i32 %27, 1
+  store i32 %28, i32* %loc0
+  br label %29
+
+; <label>:29                                      ; preds = %6, %26
+  %30 = load i32, i32* %loc0
+  %31 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %32 = getelementptr inbounds i8, i8 addrspace(1)* %31, i64 1296
+  %33 = addrspacecast i8 addrspace(1)* %32 to %"System.Int32[]" addrspace(1)**
+  %34 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %33
+  %NullCheck = icmp eq %"System.Int32[]" addrspace(1)* %34, null
+  br i1 %NullCheck, label %ThrowNullRef, label %35
+
+; <label>:35                                      ; preds = %29
+  %36 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %34, i32 0, i32 1
+  %37 = load i32, i32 addrspace(1)* %36
+  %38 = zext i32 %37 to i64
+  %39 = trunc i64 %38 to i32
+  %40 = icmp slt i32 %30, %39
+  br i1 %40, label %7, label %41
+
+; <label>:41                                      ; preds = %35
+  %42 = load i32, i32* %arg0
+  %43 = or i32 %42, 1
+  store i32 %43, i32* %loc2
+  br label %59
+
+; <label>:44                                      ; preds = %59
+  %45 = load i32, i32* %loc2
+  %46 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %45)
+  %47 = zext i8 %46 to i32
+  %48 = icmp eq i32 %47, 0
+  br i1 %48, label %56, label %49
+
+; <label>:49                                      ; preds = %44
+  %50 = load i32, i32* %loc2
+  %51 = sub i32 %50, 1
+  %52 = srem i32 %51, 101
+  %53 = icmp eq i32 %52, 0
+  br i1 %53, label %56, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = load i32, i32* %loc2
+  ret i32 %55
+
+; <label>:56                                      ; preds = %44, %49
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %57, 2
+  store i32 %58, i32* %loc2
+  br label %59
+
+; <label>:59                                      ; preds = %41, %56
+  %60 = load i32, i32* %loc2
+  %61 = icmp slt i32 %60, 2147483647
+  br i1 %61, label %44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load i32, i32* %arg0
+  ret i32 %63
+
+ThrowNullRef:                                     ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
 Successfully read GenericEqualityComparer`1.GetHashCode
 
@@ -3694,14 +4558,14 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
   %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load i64, i64 addrspace(1)* %7
@@ -3720,7 +4584,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3750,8 +4614,8 @@ entry:
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
@@ -3796,8 +4660,8 @@ entry:
   %35 = bitcast i16* %34 to i8*
   %36 = getelementptr inbounds i8, i8* %35, i64 2
   %37 = bitcast i8* %36 to i16*
-  %NullCheck4 = icmp ne i16* %37, null
-  br i1 %NullCheck4, label %38, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %37, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %38
 
 ; <label>:38                                      ; preds = %27
   %39 = load i16, i16* %37, align 8
@@ -3824,8 +4688,8 @@ entry:
 
 ; <label>:54                                      ; preds = %22, %43
   %55 = load i16*, i16** %loc4
-  %NullCheck2 = icmp ne i16* %55, null
-  br i1 %NullCheck2, label %56, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i16* %55, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %56
 
 ; <label>:56                                      ; preds = %54
   %57 = load i16, i16* %55, align 8
@@ -3850,11 +4714,11 @@ ThrowNullRef:                                     ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %54
+ThrowNullRef2:                                    ; preds = %54
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %27
+ThrowNullRef4:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3871,8 +4735,8 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -3907,8 +4771,8 @@ entry:
 
 ; <label>:26                                      ; preds = %19
   %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
-  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %28
 
 ; <label>:28                                      ; preds = %26
   %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
@@ -3920,7 +4784,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3972,8 +4836,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
@@ -3984,26 +4848,26 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
-  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
@@ -4014,8 +4878,8 @@ entry:
 ; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
@@ -4024,8 +4888,8 @@ entry:
 
 ; <label>:25                                      ; preds = %1, %16, %23
   %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
-  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
@@ -4036,27 +4900,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %20
+ThrowNullRef10:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4069,8 +4933,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -4081,8 +4945,8 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
@@ -4091,8 +4955,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1, %8
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
@@ -4103,11 +4967,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4128,24 +4992,24 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   store i32 %3, i32* %loc0
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
   %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
   store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck4, label %9, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
@@ -4164,15 +5028,15 @@ entry:
 ; <label>:18                                      ; preds = %70
   %19 = load i16*, i16** %loc3
   %20 = bitcast i16* %19 to i64*
-  %NullCheck10 = icmp ne i64* %20, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %20, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = load i64, i64* %20, align 8
   %23 = load i16*, i16** %loc4
   %24 = bitcast i16* %23 to i64*
-  %NullCheck12 = icmp ne i64* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = load i64, i64* %24, align 8
@@ -4188,8 +5052,8 @@ entry:
   %31 = bitcast i16* %30 to i8*
   %32 = getelementptr inbounds i8, i8* %31, i64 8
   %33 = bitcast i8* %32 to i64*
-  %NullCheck14 = icmp ne i64* %33, null
-  br i1 %NullCheck14, label %34, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = load i64, i64* %33, align 8
@@ -4197,8 +5061,8 @@ entry:
   %37 = bitcast i16* %36 to i8*
   %38 = getelementptr inbounds i8, i8* %37, i64 8
   %39 = bitcast i8* %38 to i64*
-  %NullCheck16 = icmp ne i64* %39, null
-  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %40
 
 ; <label>:40                                      ; preds = %34
   %41 = load i64, i64* %39, align 8
@@ -4214,8 +5078,8 @@ entry:
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %NullCheck18 = icmp ne i64* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = load i64, i64* %48, align 8
@@ -4223,8 +5087,8 @@ entry:
   %52 = bitcast i16* %51 to i8*
   %53 = getelementptr inbounds i8, i8* %52, i64 16
   %54 = bitcast i8* %53 to i64*
-  %NullCheck20 = icmp ne i64* %54, null
-  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64* %54, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %55
 
 ; <label>:55                                      ; preds = %49
   %56 = load i64, i64* %54, align 8
@@ -4262,15 +5126,15 @@ entry:
 ; <label>:74                                      ; preds = %95
   %75 = load i16*, i16** %loc3
   %76 = bitcast i16* %75 to i32*
-  %NullCheck6 = icmp ne i32* %76, null
-  br i1 %NullCheck6, label %77, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32* %76, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %77
 
 ; <label>:77                                      ; preds = %74
   %78 = load i32, i32* %76, align 8
   %79 = load i16*, i16** %loc4
   %80 = bitcast i16* %79 to i32*
-  %NullCheck8 = icmp ne i32* %80, null
-  br i1 %NullCheck8, label %81, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i32* %80, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %81
 
 ; <label>:81                                      ; preds = %77
   %82 = load i32, i32* %80, align 8
@@ -4318,43 +5182,43 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %74
+ThrowNullRef6:                                    ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %77
+ThrowNullRef8:                                    ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %29
+ThrowNullRef14:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %34
+ThrowNullRef16:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4376,8 +5240,8 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load i64, i64 addrspace(1)* %4
@@ -4389,8 +5253,8 @@ entry:
   %12 = load i64, i64* %11
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %5
   %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
@@ -4399,8 +5263,8 @@ entry:
   %18 = load i8, i8* %arg2
   %19 = zext i8 %18 to i32
   %20 = trunc i32 %19 to i8
-  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %15
   %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
@@ -4411,11 +5275,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4442,8 +5306,8 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
@@ -4466,16 +5330,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
   %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = load i64, i64 addrspace(1)* %19
@@ -4500,8 +5364,8 @@ entry:
 ; <label>:35                                      ; preds = %30
   %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
@@ -4514,8 +5378,8 @@ entry:
 
 ; <label>:42                                      ; preds = %1, %38
   %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
-  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
@@ -4526,19 +5390,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %35
+ThrowNullRef2:                                    ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %42
+ThrowNullRef8:                                    ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4551,14 +5415,14 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
@@ -4570,7 +5434,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4583,8 +5447,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
@@ -4613,51 +5477,51 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
   %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
   %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
   %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
   %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
-  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
   store i64 %21, i64 addrspace(1)* %23
   %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %25 = load i64, i64* %loc0
-  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
@@ -4668,27 +5532,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %22
+ThrowNullRef12:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4701,8 +5565,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
@@ -4713,19 +5577,19 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
@@ -4734,8 +5598,8 @@ entry:
 
 ; <label>:15                                      ; preds = %1, %13
   %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
@@ -4746,19 +5610,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %15
+ThrowNullRef8:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4771,8 +5635,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -4831,8 +5695,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
@@ -4882,8 +5746,8 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
-  br i1 %NullCheck, label %17, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %ThrowNullRef, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
@@ -4894,15 +5758,15 @@ entry:
 
 ; <label>:22                                      ; preds = %17
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
-  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
   %26 = load i32, i32 addrspace(1)* %25
   %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
-  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %27, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
@@ -4925,8 +5789,8 @@ entry:
 ; <label>:40                                      ; preds = %17
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
-  br i1 %NullCheck6, label %43, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %41, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
@@ -4938,34 +5802,17 @@ ThrowNullRef:                                     ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %24
+ThrowNullRef4:                                    ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %40
+ThrowNullRef6:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
-}
-
-INFO:  jitting method Object::ReferenceEquals using LLILCJit
-Successfully read Object.ReferenceEquals
-
-define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
-entry:
-  %arg0 = alloca %System.Object addrspace(1)*
-  %arg1 = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
-  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
-  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = icmp eq %System.Object addrspace(1)* %0, %1
-  %3 = sext i1 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
 }
 
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
@@ -4978,21 +5825,21 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
   %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
-  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
@@ -5007,28 +5854,28 @@ entry:
 ; <label>:13                                      ; preds = %8, %12
   %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
   %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
   %21 = load i32, i32 addrspace(1)* %20, align 8
   %22 = add i32 %21, 1
-  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
   store i32 %22, i32 addrspace(1)* %24
   %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
@@ -5039,27 +5886,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5077,7 +5924,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::Setup using LLILCJit
-Failed to read AppDomain.Setup[loadElem]
+Failed to read AppDomain.Setup[unbox]
 INFO:  jitting method Thread::GetDomain using LLILCJit
 Successfully read Thread.GetDomain
 
@@ -5108,8 +5955,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
@@ -5122,14 +5969,14 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
   %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
@@ -5141,11 +5988,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5173,8 +6020,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -5189,7 +6036,328 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
 Failed to read KeyCollection.System.Collections.Generic.IEnumerable<TKey>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Successfully read Enumerator.MoveNext
+
+define i8 @Enumerator.MoveNext(%"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.RuntimeTypeHandle* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*
+  %"$TypeArg" = alloca %System.RuntimeTypeHandle*
+  store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
+  %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 8
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %76, label %12
+
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
+  br label %76
+
+; <label>:13                                      ; preds = %85
+  %14 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck19 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %15
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, i32 0, i32 0
+  %17 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %16, align 8
+  %NullCheck21 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, i32 0, i32 2
+  %20 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %19, align 8
+  %21 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck23 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %22
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, i32 0, i32 2
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %NullCheck25 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 3, i32 %24
+  %NullCheck27 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %32
+
+; <label>:32                                      ; preds = %30
+  %33 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, i32 0, i32 2
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = icmp slt i32 %34, 0
+  br i1 %35, label %68, label %36
+
+; <label>:36                                      ; preds = %32
+  %37 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %38 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck29 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %39
+
+; <label>:39                                      ; preds = %36
+  %40 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, i32 0, i32 0
+  %41 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %40, align 8
+  %NullCheck31 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, i32 0, i32 2
+  %44 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %43, align 8
+  %45 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck33 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, i32 0, i32 2
+  %48 = load i32, i32 addrspace(1)* %47, align 8
+  %NullCheck35 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %49
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = zext i32 %51 to i64
+  %53 = zext i32 %48 to i64
+  %BoundsCheck37 = icmp uge i64 %53, %52
+  br i1 %BoundsCheck37, label %ThrowIndexOutOfRange38, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 3, i32 %48
+  %NullCheck39 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %56
+
+; <label>:56                                      ; preds = %54
+  %57 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, i32 0, i32 0
+  %58 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck41 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %59
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %60, %System.__Canon addrspace(1)* %58)
+  %61 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck43 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  %64 = load i32, i32 addrspace(1)* %63, align 8
+  %65 = add i32 %64, 1
+  %NullCheck45 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  store i32 %65, i32 addrspace(1)* %67
+  ret i8 1
+
+; <label>:68                                      ; preds = %32
+  %69 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck47 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %73 = add i32 %72, 1
+  %NullCheck49 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %74
+
+; <label>:74                                      ; preds = %70
+  %75 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  store i32 %73, i32 addrspace(1)* %75
+  br label %76
+
+; <label>:76                                      ; preds = %8, %12, %74
+  %77 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %78
+
+; <label>:78                                      ; preds = %76
+  %79 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, i32 0, i32 2
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck7 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %82
+
+; <label>:82                                      ; preds = %78
+  %83 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, i32 0, i32 0
+  %84 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %83, align 8
+  %NullCheck9 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %85
+
+; <label>:85                                      ; preds = %82
+  %86 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, i32 0, i32 7
+  %87 = load i32, i32 addrspace(1)* %86, align 8
+  %88 = icmp ult i32 %80, %87
+  br i1 %88, label %13, label %89
+
+; <label>:89                                      ; preds = %85
+  %90 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %91 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck11 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %92
+
+; <label>:92                                      ; preds = %89
+  %93 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, i32 0, i32 0
+  %94 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck13 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %95
+
+; <label>:95                                      ; preds = %92
+  %96 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, i32 0, i32 7
+  %97 = load i32, i32 addrspace(1)* %96, align 8
+  %98 = add i32 %97, 1
+  %NullCheck15 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %99
+
+; <label>:99                                      ; preds = %95
+  %100 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, i32 0, i32 2
+  store i32 %98, i32 addrspace(1)* %100
+  %101 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck17 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %102
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %103, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %92
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef22:                                   ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef24:                                   ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef26:                                   ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef28:                                   ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef30:                                   ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef32:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef34:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef36:                                   ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange38:                           ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef40:                                   ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef42:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef44:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef46:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef48:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef50:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -5200,8 +6368,8 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -5232,9 +6400,9 @@ Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
 Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
-Failed to read String.MakeSeparatorList[loadElemA]
+Failed to read String.MakeSeparatorList[storeElem]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
-Failed to read String.InternalSplitKeepEmptyEntries[loadElem]
+Failed to read String.InternalSplitKeepEmptyEntries[storeElem]
 INFO:  jitting method Path::IsRelative using LLILCJit
 Successfully read Path.IsRelative
 
@@ -5243,8 +6411,8 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -5254,8 +6422,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
@@ -5271,8 +6439,8 @@ entry:
 
 ; <label>:17                                      ; preds = %7
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
@@ -5288,8 +6456,8 @@ entry:
 
 ; <label>:29                                      ; preds = %19
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %31
 
 ; <label>:31                                      ; preds = %29
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
@@ -5300,8 +6468,8 @@ entry:
 
 ; <label>:36                                      ; preds = %31
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
-  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %37, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
@@ -5312,8 +6480,8 @@ entry:
 
 ; <label>:43                                      ; preds = %31, %38
   %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
-  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %45
 
 ; <label>:45                                      ; preds = %43
   %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
@@ -5324,8 +6492,8 @@ entry:
 
 ; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %50
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
@@ -5336,8 +6504,8 @@ entry:
 
 ; <label>:57                                      ; preds = %1, %7, %19, %45, %52
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
-  br i1 %NullCheck14, label %59, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %59
 
 ; <label>:59                                      ; preds = %57
   %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
@@ -5347,8 +6515,8 @@ entry:
 
 ; <label>:63                                      ; preds = %59
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
@@ -5359,8 +6527,8 @@ entry:
 
 ; <label>:70                                      ; preds = %65
   %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
-  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.String addrspace(1)* %71, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %72
 
 ; <label>:72                                      ; preds = %70
   %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
@@ -5379,39 +6547,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %17
+ThrowNullRef4:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %29
+ThrowNullRef6:                                    ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %36
+ThrowNullRef8:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %43
+ThrowNullRef10:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %50
+ThrowNullRef12:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %57
+ThrowNullRef14:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %63
+ThrowNullRef16:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %70
+ThrowNullRef18:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5419,7 +6587,293 @@ ThrowNullRef17:                                   ; preds = %70
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
-Failed to read String.TrimHelper[loadElem]
+Successfully read String.TrimHelper
+
+define %System.String addrspace(1)* @String.TrimHelper(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i16
+  %loc4 = alloca i32
+  %loc5 = alloca i16
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = sub i32 %3, 1
+  store i32 %4, i32* %loc0
+  store i32 0, i32* %loc1
+  %5 = load i32, i32* %arg2
+  %6 = icmp eq i32 %5, 1
+  br i1 %6, label %62, label %7
+
+; <label>:7                                       ; preds = %1
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:8                                       ; preds = %58
+  store i32 0, i32* %loc2
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load i32, i32* %loc1
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2, i32 %10
+  %13 = load i16, i16 addrspace(1)* %12
+  %14 = zext i16 %13 to i32
+  %15 = trunc i32 %14 to i16
+  store i16 %15, i16* %loc3
+  store i32 0, i32* %loc2
+  br label %34
+
+; <label>:16                                      ; preds = %37
+  %17 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %18 = load i32, i32* %loc2
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %17, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %19
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = zext i32 %18 to i64
+  %BoundsCheck = icmp uge i64 %23, %22
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %24
+
+; <label>:24                                      ; preds = %19
+  %25 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 3, i32 %18
+  %26 = load i16, i16 addrspace(1)* %25, align 8
+  %27 = zext i16 %26 to i32
+  %28 = load i16, i16* %loc3
+  %29 = zext i16 %28 to i32
+  %30 = icmp eq i32 %27, %29
+  br i1 %30, label %43, label %31
+
+; <label>:31                                      ; preds = %24
+  %32 = load i32, i32* %loc2
+  %33 = add i32 %32, 1
+  store i32 %33, i32* %loc2
+  br label %34
+
+; <label>:34                                      ; preds = %11, %31
+  %35 = load i32, i32* %loc2
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = icmp slt i32 %35, %41
+  br i1 %42, label %16, label %43
+
+; <label>:43                                      ; preds = %24, %37
+  %44 = load i32, i32* %loc2
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %45, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp eq i32 %44, %50
+  br i1 %51, label %62, label %52
+
+; <label>:52                                      ; preds = %46
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %7, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %57, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %58
+
+; <label>:58                                      ; preds = %55
+  %59 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %60 = load i32, i32 addrspace(1)* %59
+  %61 = icmp slt i32 %56, %60
+  br i1 %61, label %8, label %62
+
+; <label>:62                                      ; preds = %1, %46, %58
+  %63 = load i32, i32* %arg2
+  %64 = icmp eq i32 %63, 0
+  br i1 %64, label %122, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %66, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %67
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %66, i32 0, i32 1
+  %69 = load i32, i32 addrspace(1)* %68
+  %70 = sub i32 %69, 1
+  store i32 %70, i32* %loc0
+  br label %118
+
+; <label>:71                                      ; preds = %118
+  store i32 0, i32* %loc4
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %73 = load i32, i32* %loc0
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %74
+
+; <label>:74                                      ; preds = %71
+  %75 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 2, i32 %73
+  %76 = load i16, i16 addrspace(1)* %75
+  %77 = zext i16 %76 to i32
+  %78 = trunc i32 %77 to i16
+  store i16 %78, i16* %loc5
+  store i32 0, i32* %loc4
+  br label %97
+
+; <label>:79                                      ; preds = %100
+  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %81 = load i32, i32* %loc4
+  %NullCheck19 = icmp eq %"System.Char[]" addrspace(1)* %80, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
+
+; <label>:82                                      ; preds = %79
+  %83 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 1
+  %84 = load i32, i32 addrspace(1)* %83
+  %85 = zext i32 %84 to i64
+  %86 = zext i32 %81 to i64
+  %BoundsCheck21 = icmp uge i64 %86, %85
+  br i1 %BoundsCheck21, label %ThrowIndexOutOfRange22, label %87
+
+; <label>:87                                      ; preds = %82
+  %88 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 3, i32 %81
+  %89 = load i16, i16 addrspace(1)* %88, align 8
+  %90 = zext i16 %89 to i32
+  %91 = load i16, i16* %loc5
+  %92 = zext i16 %91 to i32
+  %93 = icmp eq i32 %90, %92
+  br i1 %93, label %106, label %94
+
+; <label>:94                                      ; preds = %87
+  %95 = load i32, i32* %loc4
+  %96 = add i32 %95, 1
+  store i32 %96, i32* %loc4
+  br label %97
+
+; <label>:97                                      ; preds = %74, %94
+  %98 = load i32, i32* %loc4
+  %99 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck15 = icmp eq %"System.Char[]" addrspace(1)* %99, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %100
+
+; <label>:100                                     ; preds = %97
+  %101 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %99, i32 0, i32 1
+  %102 = load i32, i32 addrspace(1)* %101
+  %103 = zext i32 %102 to i64
+  %104 = trunc i64 %103 to i32
+  %105 = icmp slt i32 %98, %104
+  br i1 %105, label %79, label %106
+
+; <label>:106                                     ; preds = %87, %100
+  %107 = load i32, i32* %loc4
+  %108 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck17 = icmp eq %"System.Char[]" addrspace(1)* %108, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %109
+
+; <label>:109                                     ; preds = %106
+  %110 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %108, i32 0, i32 1
+  %111 = load i32, i32 addrspace(1)* %110
+  %112 = zext i32 %111 to i64
+  %113 = trunc i64 %112 to i32
+  %114 = icmp eq i32 %107, %113
+  br i1 %114, label %122, label %115
+
+; <label>:115                                     ; preds = %109
+  %116 = load i32, i32* %loc0
+  %117 = sub i32 %116, 1
+  store i32 %117, i32* %loc0
+  br label %118
+
+; <label>:118                                     ; preds = %67, %115
+  %119 = load i32, i32* %loc0
+  %120 = load i32, i32* %loc1
+  %121 = icmp sge i32 %119, %120
+  br i1 %121, label %71, label %122
+
+; <label>:122                                     ; preds = %62, %109, %118
+  %123 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %124 = load i32, i32* %loc1
+  %125 = load i32, i32* %loc0
+  %126 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %123, i32 %124, i32 %125)
+  ret %System.String addrspace(1)* %126
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %97
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange22:                           ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
 Successfully read String.CreateTrimmedString
 
@@ -5439,8 +6893,8 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
@@ -5535,8 +6989,8 @@ entry:
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i64 2872
   %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
   %8 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %7
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %3
   %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
@@ -5553,8 +7007,8 @@ entry:
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 2864
   %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
   %21 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %20
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
-  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %22
 
 ; <label>:22                                      ; preds = %16
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
@@ -5569,7 +7023,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %16
+ThrowNullRef2:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5586,8 +7040,8 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5613,8 +7067,8 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
@@ -5632,8 +7086,8 @@ entry:
 
 ; <label>:12                                      ; preds = %4
   %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
@@ -5644,8 +7098,8 @@ entry:
 
 ; <label>:19                                      ; preds = %14
   %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %19
   %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
@@ -5660,21 +7114,21 @@ entry:
   %31 = zext i16 %30 to i32
   %32 = bitcast i8* %29 to i16*
   %33 = trunc i32 %31 to i16
-  %NullCheck6 = icmp ne i16* %32, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i16* %32, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %21
   store i16 %33, i16* %32, align 8
   %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %36
 
 ; <label>:36                                      ; preds = %34
   %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
   %38 = load i32, i32 addrspace(1)* %37, align 8
   %39 = add i32 %38, 1
-  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %40
 
 ; <label>:40                                      ; preds = %36
   %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
@@ -5683,16 +7137,16 @@ entry:
 
 ; <label>:42                                      ; preds = %14
   %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
-  br i1 %NullCheck12, label %44, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
   %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
   %47 = load i16, i16* %arg1
   %48 = zext i16 %47 to i32
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = trunc i32 %48 to i16
@@ -5703,31 +7157,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %19
+ThrowNullRef4:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %21
+ThrowNullRef6:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %36
+ThrowNullRef10:                                   ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %42
+ThrowNullRef12:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %44
+ThrowNullRef14:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5740,8 +7194,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -5752,8 +7206,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
@@ -5762,14 +7216,14 @@ entry:
 
 ; <label>:11                                      ; preds = %1
   %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
@@ -5779,15 +7233,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5808,8 +7262,8 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5822,8 +7276,8 @@ entry:
 
 ; <label>:8                                       ; preds = %3
   %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
@@ -5842,15 +7296,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
-  br i1 %NullCheck4, label %22, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
   %24 = load i16*, i16* addrspace(1)* %23, align 8
   %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %25, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
@@ -5859,8 +7313,8 @@ entry:
   store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
@@ -5874,8 +7328,8 @@ entry:
 
 ; <label>:37                                      ; preds = %65
   %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %37
   %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
@@ -5886,16 +7340,16 @@ entry:
   %45 = bitcast i16* %41 to i8*
   %46 = getelementptr inbounds i8, i8* %45, i64 %44
   %47 = bitcast i8* %46 to i16*
-  %NullCheck14 = icmp ne i16* %47, null
-  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %47, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %48
 
 ; <label>:48                                      ; preds = %39
   %49 = load i16, i16* %47, align 8
   %50 = zext i16 %49 to i32
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %52 = load i32, i32* %loc1
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %53
 
 ; <label>:53                                      ; preds = %48
   %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
@@ -5916,8 +7370,8 @@ entry:
 ; <label>:62                                      ; preds = %36, %59
   %63 = load i32, i32* %loc1
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck10, label %65, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %65
 
 ; <label>:65                                      ; preds = %62
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
@@ -5936,15 +7390,15 @@ entry:
 
 ; <label>:74                                      ; preds = %70
   %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
-  br i1 %NullCheck18, label %76, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %76
 
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
   %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
-  br i1 %NullCheck20, label %80, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
   %81 = load i64, i64 addrspace(1)* %79
@@ -5958,8 +7412,8 @@ entry:
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
   %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
-  br i1 %NullCheck22, label %92, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.String addrspace(1)* %90, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %92
 
 ; <label>:92                                      ; preds = %80
   %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
@@ -5969,15 +7423,15 @@ entry:
 
 ; <label>:96                                      ; preds = %70
   %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
-  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %98
 
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
   %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
-  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
   %103 = load i64, i64 addrspace(1)* %101
@@ -5991,8 +7445,8 @@ entry:
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
   %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
-  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.String addrspace(1)* %112, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %114
 
 ; <label>:114                                     ; preds = %102
   %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
@@ -6004,59 +7458,59 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %20
+ThrowNullRef4:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %22
+ThrowNullRef6:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %26
+ThrowNullRef8:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %62
+ThrowNullRef10:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %48
+ThrowNullRef16:                                   ; preds = %48
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %74
+ThrowNullRef18:                                   ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %76
+ThrowNullRef20:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %80
+ThrowNullRef22:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %96
+ThrowNullRef24:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %98
+ThrowNullRef26:                                   ; preds = %98
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %102
+ThrowNullRef28:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6069,15 +7523,15 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
   %3 = load i16*, i16* addrspace(1)* %2, align 8
   %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
@@ -6087,8 +7541,8 @@ entry:
   %10 = bitcast i16* %3 to i8*
   %11 = getelementptr inbounds i8, i8* %10, i64 %9
   %12 = bitcast i8* %11 to i16*
-  %NullCheck4 = icmp ne i16* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %5
   store i16 0, i16* %12, align 8
@@ -6098,11 +7552,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6119,8 +7573,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -6131,8 +7585,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
@@ -6144,15 +7598,15 @@ entry:
 
 ; <label>:14                                      ; preds = %1
   %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
   %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
   %21 = load i64, i64 addrspace(1)* %19
@@ -6171,15 +7625,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %14
+ThrowNullRef4:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %16
+ThrowNullRef6:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6302,14 +7756,6 @@ entry:
   ret %System.String addrspace(1)* %57
 }
 
-INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
-Successfully read RuntimeHelpers.get_OffsetToStringData
-
-define i32 @RuntimeHelpers.get_OffsetToStringData() {
-entry:
-  ret i32 12
-}
-
 INFO:  jitting method String::Equals using LLILCJit
 Successfully read String.Equals
 
@@ -6381,8 +7827,8 @@ entry:
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
-  br i1 %NullCheck24, label %29, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
   %30 = load i64, i64 addrspace(1)* %28
@@ -6397,8 +7843,8 @@ entry:
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
-  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
   %43 = load i64, i64 addrspace(1)* %41
@@ -6418,8 +7864,8 @@ entry:
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
   %59 = load i64, i64 addrspace(1)* %57
@@ -6434,8 +7880,8 @@ entry:
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck22, label %71, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
   %72 = load i64, i64 addrspace(1)* %70
@@ -6455,8 +7901,8 @@ entry:
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
-  br i1 %NullCheck16, label %87, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = load i64, i64 addrspace(1)* %86
@@ -6471,8 +7917,8 @@ entry:
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck18, label %100, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
   %101 = load i64, i64 addrspace(1)* %99
@@ -6492,8 +7938,8 @@ entry:
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
-  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
   %117 = load i64, i64 addrspace(1)* %115
@@ -6508,8 +7954,8 @@ entry:
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
-  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
   %130 = load i64, i64 addrspace(1)* %128
@@ -6528,15 +7974,15 @@ entry:
 
 ; <label>:142                                     ; preds = %22
   %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
-  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %143, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %144
 
 ; <label>:144                                     ; preds = %142
   %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
   %146 = load i32, i32 addrspace(1)* %145
   %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
-  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %147, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %148
 
 ; <label>:148                                     ; preds = %144
   %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
@@ -6557,15 +8003,15 @@ entry:
 
 ; <label>:159                                     ; preds = %22
   %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
-  br i1 %NullCheck, label %161, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %ThrowNullRef, label %161
 
 ; <label>:161                                     ; preds = %159
   %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
   %163 = load i32, i32 addrspace(1)* %162
   %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
-  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %164, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %165
 
 ; <label>:165                                     ; preds = %161
   %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
@@ -6578,8 +8024,8 @@ entry:
 
 ; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
-  br i1 %NullCheck4, label %172, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %171, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %172
 
 ; <label>:172                                     ; preds = %170
   %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
@@ -6589,8 +8035,8 @@ entry:
 
 ; <label>:176                                     ; preds = %172
   %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
-  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %177, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %178
 
 ; <label>:178                                     ; preds = %176
   %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
@@ -6629,55 +8075,55 @@ ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %161
+ThrowNullRef2:                                    ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %170
+ThrowNullRef4:                                    ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %176
+ThrowNullRef6:                                    ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %142
+ThrowNullRef8:                                    ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %144
+ThrowNullRef10:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %113
+ThrowNullRef12:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %116
+ThrowNullRef14:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %84
+ThrowNullRef16:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %87
+ThrowNullRef18:                                   ; preds = %87
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %55
+ThrowNullRef20:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %58
+ThrowNullRef22:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %26
+ThrowNullRef24:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %29
+ThrowNullRef26:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,8 +8161,8 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck, label %14, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %ThrowNullRef, label %14
 
 ; <label>:14                                      ; preds = %8
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
@@ -6760,8 +8206,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
@@ -6770,14 +8216,14 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32, i32* %loc0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %10
   %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
   %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
@@ -6790,15 +8236,15 @@ entry:
 ; <label>:25                                      ; preds = %19
   %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
-  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
   %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
@@ -6807,8 +8253,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %37 = load i32, i32* %loc0
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %38, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %38
 
 ; <label>:38                                      ; preds = %32
   %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
@@ -6817,14 +8263,14 @@ entry:
 
 ; <label>:40                                      ; preds = %19
   %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %40
   %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
   %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
-  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
-  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
@@ -6832,8 +8278,8 @@ entry:
   %48 = zext i32 %47 to i64
   %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
-  br i1 %NullCheck16, label %51, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %51
 
 ; <label>:51                                      ; preds = %45
   %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
@@ -6847,15 +8293,15 @@ entry:
 ; <label>:57                                      ; preds = %51
   %58 = load i16*, i16** %arg1
   %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
-  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %60
 
 ; <label>:60                                      ; preds = %57
   %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
   %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
-  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %64
 
 ; <label>:64                                      ; preds = %60
   %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
@@ -6864,22 +8310,22 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
   %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
-  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %70
 
 ; <label>:70                                      ; preds = %64
   %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
   %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
-  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
-  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
   %75 = load i32, i32 addrspace(1)* %74
   %76 = zext i32 %75 to i64
   %77 = trunc i64 %76 to i32
-  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
-  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %78
 
 ; <label>:78                                      ; preds = %73
   %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
@@ -6901,8 +8347,8 @@ entry:
   %90 = bitcast i16* %86 to i8*
   %91 = getelementptr inbounds i8, i8* %90, i64 %89
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %93
 
 ; <label>:93                                      ; preds = %80
   %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
@@ -6912,8 +8358,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %99 = load i32, i32* %loc2
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %100
 
 ; <label>:100                                     ; preds = %93
   %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
@@ -6928,63 +8374,63 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %25
+ThrowNullRef6:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %32
+ThrowNullRef10:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %40
+ThrowNullRef12:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %45
+ThrowNullRef16:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %57
+ThrowNullRef18:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %60
+ThrowNullRef20:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %64
+ThrowNullRef22:                                   ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %70
+ThrowNullRef24:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %73
+ThrowNullRef26:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %80
+ThrowNullRef28:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %93
+ThrowNullRef30:                                   ; preds = %93
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7004,8 +8450,8 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
@@ -7033,43 +8479,43 @@ entry:
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %14
   %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
   %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   %28 = load i32, i32 addrspace(1)* %27, align 8
   %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
-  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %30
 
 ; <label>:30                                      ; preds = %26
   %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
   %32 = load i32, i32 addrspace(1)* %31, align 8
   %33 = add i32 %28, %32
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %34
 
 ; <label>:34                                      ; preds = %30
   %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   store i32 %33, i32 addrspace(1)* %35
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
   store i32 0, i32 addrspace(1)* %38
   %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %40
 
 ; <label>:40                                      ; preds = %37
   %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
@@ -7082,8 +8528,8 @@ entry:
 
 ; <label>:47                                      ; preds = %40
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
@@ -7098,8 +8544,8 @@ entry:
   %54 = load i32, i32* %loc0
   %55 = sext i32 %54 to i64
   %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
-  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %57
 
 ; <label>:57                                      ; preds = %52
   %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
@@ -7110,68 +8556,35 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %14
+ThrowNullRef2:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %23
+ThrowNullRef4:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %26
+ThrowNullRef6:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %30
+ThrowNullRef8:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %34
+ThrowNullRef10:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %47
+ThrowNullRef14:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %52
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-}
-
-INFO:  jitting method StringBuilder::get_Length using LLILCJit
-Successfully read StringBuilder.get_Length
-
-define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.StringBuilder addrspace(1)*
-  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
-  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
-
-; <label>:1                                       ; preds = %entry
-  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %3 = load i32, i32 addrspace(1)* %2, align 8
-  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
-
-; <label>:5                                       ; preds = %1
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = add i32 %3, %7
-  ret i32 %8
-
-ThrowNullRef:                                     ; preds = %entry
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef16:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7213,70 +8626,70 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
   %6 = load i32, i32 addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
   store i32 %6, i32 addrspace(1)* %8
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
   %13 = load i32, i32 addrspace(1)* %12, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
   store i32 %13, i32 addrspace(1)* %15
   %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
-  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %18
 
 ; <label>:18                                      ; preds = %14
   %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
   %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
   %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
   %34 = load i32, i32 addrspace(1)* %33, align 8
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
-  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
@@ -7287,39 +8700,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %28
+ThrowNullRef16:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %32
+ThrowNullRef18:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7455,13 +8868,13 @@ entry:
 ; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
@@ -7477,16 +8890,16 @@ entry:
 
 ; <label>:18                                      ; preds = %15
   %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
   store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
   %22 = load i32, i32* %loc0
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %24
 
 ; <label>:24                                      ; preds = %20
   %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
@@ -7498,13 +8911,13 @@ entry:
 ; <label>:28                                      ; preds = %15, %24
   %29 = load i32, i32* %arg1
   %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %31
   %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
@@ -7517,20 +8930,20 @@ entry:
   %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
-  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
   %46 = load i32, i32 addrspace(1)* %45, align 8
   %47 = sub i32 %40, %46
-  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
-  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i32 addrspace(1)* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %48
 
 ; <label>:48                                      ; preds = %44
   store i32 %47, i32 addrspace(1)* %39, align 8
@@ -7538,21 +8951,21 @@ entry:
 
 ; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
-  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %51
 
 ; <label>:51                                      ; preds = %49
   %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %53
 
 ; <label>:53                                      ; preds = %51
   %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
   %55 = load i32, i32 addrspace(1)* %54, align 8
   %56 = load i32, i32* %arg2
   %57 = sub i32 %55, %56
-  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %58
 
 ; <label>:58                                      ; preds = %53
   %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
@@ -7562,13 +8975,13 @@ entry:
 ; <label>:60                                      ; preds = %33, %58
   %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
   %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
-  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %63
 
 ; <label>:63                                      ; preds = %60
   %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
-  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
-  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
@@ -7578,15 +8991,15 @@ entry:
 
 ; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
-  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i32 addrspace(1)* %69, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %70
 
 ; <label>:70                                      ; preds = %68
   %71 = load i32, i32 addrspace(1)* %69, align 8
   store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
-  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
@@ -7596,8 +9009,8 @@ entry:
   store i32 %77, i32* %loc4
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
-  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %80
 
 ; <label>:80                                      ; preds = %73
   %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
@@ -7607,71 +9020,71 @@ entry:
 ; <label>:83                                      ; preds = %80
   store i32 0, i32* %loc3
   %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
-  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
-  br i1 %NullCheck26, label %88, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i32 addrspace(1)* %87, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %88
 
 ; <label>:88                                      ; preds = %85
   %89 = load i32, i32 addrspace(1)* %87, align 8
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
-  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %90
 
 ; <label>:90                                      ; preds = %88
   %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
   store i32 %89, i32 addrspace(1)* %91
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
-  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
-  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %96
 
 ; <label>:96                                      ; preds = %94
   %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
-  br i1 %NullCheck34, label %100, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %100
 
 ; <label>:100                                     ; preds = %96
   %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
-  br i1 %NullCheck36, label %102, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %102
 
 ; <label>:102                                     ; preds = %100
   %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
   %104 = load i32, i32 addrspace(1)* %103, align 8
   %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
-  br i1 %NullCheck38, label %106, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %106
 
 ; <label>:106                                     ; preds = %102
   %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
-  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
-  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %108
 
 ; <label>:108                                     ; preds = %106
   %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
   %110 = load i32, i32 addrspace(1)* %109, align 8
   %111 = add i32 %104, %110
-  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %112
 
 ; <label>:112                                     ; preds = %108
   %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
   store i32 %111, i32 addrspace(1)* %113
   %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
-  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i32 addrspace(1)* %114, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %115
 
 ; <label>:115                                     ; preds = %112
   %116 = load i32, i32 addrspace(1)* %114, align 8
@@ -7681,19 +9094,19 @@ entry:
 ; <label>:118                                     ; preds = %115
   %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
-  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %121
 
 ; <label>:121                                     ; preds = %118
   %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
-  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
-  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %123
 
 ; <label>:123                                     ; preds = %121
   %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
   %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
-  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
-  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %126
 
 ; <label>:126                                     ; preds = %123
   %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
@@ -7705,8 +9118,8 @@ entry:
 
 ; <label>:130                                     ; preds = %80, %115, %126
   %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %132
 
 ; <label>:132                                     ; preds = %130
   %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7715,8 +9128,8 @@ entry:
   %136 = load i32, i32* %loc3
   %137 = sub i32 %135, %136
   %138 = sub i32 %134, %137
-  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %139
 
 ; <label>:139                                     ; preds = %132
   %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7728,16 +9141,16 @@ entry:
 
 ; <label>:144                                     ; preds = %139
   %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
-  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %146
 
 ; <label>:146                                     ; preds = %144
   %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
   %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
   %149 = load i32, i32* %loc2
   %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
-  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %151
 
 ; <label>:151                                     ; preds = %146
   %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
@@ -7754,145 +9167,249 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %18
+ThrowNullRef4:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %31
+ThrowNullRef10:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %44
+ThrowNullRef16:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %68
+ThrowNullRef18:                                   ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %70
+ThrowNullRef20:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %73
+ThrowNullRef22:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %83
+ThrowNullRef24:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %85
+ThrowNullRef26:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %88
+ThrowNullRef28:                                   ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %90
+ThrowNullRef30:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %94
+ThrowNullRef32:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %96
+ThrowNullRef34:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %100
+ThrowNullRef36:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %102
+ThrowNullRef38:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %106
+ThrowNullRef40:                                   ; preds = %106
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %108
+ThrowNullRef42:                                   ; preds = %108
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %112
+ThrowNullRef44:                                   ; preds = %112
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %118
+ThrowNullRef46:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %121
+ThrowNullRef48:                                   ; preds = %121
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %123
+ThrowNullRef50:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %130
+ThrowNullRef52:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %132
+ThrowNullRef54:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %144
+ThrowNullRef56:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %146
+ThrowNullRef58:                                   ; preds = %146
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %60
+ThrowNullRef60:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %63
+ThrowNullRef62:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %49
+ThrowNullRef64:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %51
+ThrowNullRef66:                                   ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %53
+ThrowNullRef68:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(%"System.Char[]" addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %arg0 = alloca %"System.Char[]" addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store %"System.Char[]" addrspace(1)* %param0, %"System.Char[]" addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load i32, i32* %arg4
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %43, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %38, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg1
+  %13 = load i32, i32* %arg4
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %38, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %24 = load i32, i32* %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %35 = load i32, i32* %arg3
+  %36 = load i32, i32* %arg4
+  %37 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %37, %"System.Char[]" addrspace(1)* %34, i32 %35, i32 %36)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:38                                      ; preds = %5, %16
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Successfully read Buffer._Memmove
 
@@ -7914,7 +9431,7 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[loadElem]
+Failed to read AppDomain.SetDataHelper[storeElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -7923,8 +9440,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
@@ -7934,8 +9451,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
@@ -7947,15 +9464,15 @@ entry:
   %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
   %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
@@ -7966,15 +9483,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7992,7 +9509,79 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
-Failed to read Dictionary`2.TryGetValue[loadElemA]
+Successfully read Dictionary`2.TryGetValue
+
+define i8 @"Dictionary`2.TryGetValue"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)* addrspace(1)* %param2) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  %arg2 = alloca %System.__Canon addrspace(1)* addrspace(1)*
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  store %System.__Canon addrspace(1)* addrspace(1)* %param2, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  store i32 %2, i32* %loc0
+  %3 = load i32, i32* %loc0
+  %4 = icmp slt i32 %3, 0
+  br i1 %4, label %22, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 2
+  %10 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %9, align 8
+  %11 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = zext i32 %11 to i64
+  %BoundsCheck = icmp uge i64 %16, %15
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 3, i32 %11
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %20, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %6, %System.__Canon addrspace(1)* %21)
+  ret i8 1
+
+; <label>:22                                      ; preds = %entry
+  %23 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %23, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -8058,8 +9647,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
@@ -8091,8 +9680,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
@@ -8171,15 +9760,15 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck, label %19, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %ThrowNullRef, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
   %21 = load i32, i32 addrspace(1)* %20
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
@@ -8202,7 +9791,7 @@ ThrowNullRef:                                     ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %19
+ThrowNullRef2:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8248,8 +9837,8 @@ entry:
   %0 = alloca %System.AppDomainHandle
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %1 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %1, i32 0, i32 15
@@ -8269,8 +9858,8 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
@@ -8286,7 +9875,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -8299,8 +9888,8 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -8327,8 +9916,8 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
@@ -8352,8 +9941,8 @@ entry:
   %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
   store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
@@ -8363,8 +9952,8 @@ entry:
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
@@ -8374,8 +9963,8 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %9
   %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
@@ -8384,8 +9973,8 @@ entry:
 
 ; <label>:18                                      ; preds = %3, %16
   %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
@@ -8397,15 +9986,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %18
+ThrowNullRef6:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8418,8 +10007,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
@@ -8453,15 +10042,15 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
@@ -8473,7 +10062,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8481,7 +10070,7 @@ ThrowNullRef1:                                    ; preds = %1
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
 Failed to read Dictionary`2.System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
@@ -8506,8 +10095,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
@@ -8524,8 +10113,8 @@ entry:
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -8544,7 +10133,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8577,8 +10166,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = load i64, i64* %arg2
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = trunc i32 %3 to i8
@@ -8634,46 +10223,46 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
   %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
-  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
-  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
-  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
@@ -8684,27 +10273,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %20
+ThrowNullRef12:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8717,8 +10306,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -8756,22 +10345,22 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
   %9 = load i64, i64 addrspace(1)* %8, align 8
   %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
   %13 = load i64, i64 addrspace(1)* %12, align 8
   %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %11
   %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
@@ -8788,11 +10377,11 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8882,8 +10471,8 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
@@ -8900,8 +10489,8 @@ entry:
 ; <label>:8                                       ; preds = %1
   %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
   %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
@@ -8911,15 +10500,15 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
   %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
   %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
-  br i1 %NullCheck6, label %21, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
@@ -8946,15 +10535,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8992,15 +10581,15 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
   store i8 %3, i8 addrspace(1)* %5
   %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
@@ -9011,7 +10600,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9027,8 +10616,8 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -9041,8 +10630,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
@@ -9058,7 +10647,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9080,8 +10669,8 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
@@ -9096,8 +10685,8 @@ entry:
 ; <label>:12                                      ; preds = %6
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
@@ -9112,8 +10701,8 @@ entry:
 ; <label>:21                                      ; preds = %15
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
@@ -9128,8 +10717,8 @@ entry:
 ; <label>:30                                      ; preds = %24
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %31, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
@@ -9144,8 +10733,8 @@ entry:
 ; <label>:39                                      ; preds = %33
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
-  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %40, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %42
 
 ; <label>:42                                      ; preds = %39
   %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
@@ -9164,19 +10753,19 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %21
+ThrowNullRef4:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %30
+ThrowNullRef6:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %39
+ThrowNullRef8:                                    ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9243,8 +10832,8 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
@@ -9264,57 +10853,57 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
   store i8 0, i8 addrspace(1)* %2
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
   store i8 0, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
   store i8 0, i8 addrspace(1)* %17
   %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
   store i8 0, i8 addrspace(1)* %20
   %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
-  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
@@ -9325,31 +10914,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %19
+ThrowNullRef14:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9367,8 +10956,8 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
@@ -9380,8 +10969,8 @@ entry:
 
 ; <label>:9                                       ; preds = %4
   %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %9
   %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
@@ -9395,7 +10984,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef2:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9420,8 +11009,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
@@ -9512,8 +11101,8 @@ entry:
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
@@ -9524,8 +11113,8 @@ entry:
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = load i64, i64 addrspace(1)* %12
@@ -9537,8 +11126,8 @@ entry:
   %20 = load i64, i64* %19
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
-  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %13
   %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
@@ -9555,8 +11144,8 @@ entry:
 ; <label>:30                                      ; preds = %25
   %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %32 = load i32, i32* %arg2
-  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
-  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
@@ -9570,15 +11159,15 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %30
+ThrowNullRef2:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9622,87 +11211,87 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
   %10 = load i8, i8 addrspace(1)* %9, align 8
   %11 = zext i8 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %8
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
   store i8 %12, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
   %19 = load i8, i8 addrspace(1)* %18, align 8
   %20 = zext i8 %19 to i32
   %21 = trunc i32 %20 to i8
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
   store i8 %21, i8 addrspace(1)* %23
   %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
   %28 = load i8, i8 addrspace(1)* %27, align 8
   %29 = zext i8 %28 to i32
   %30 = trunc i32 %29 to i8
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
-  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %31
 
 ; <label>:31                                      ; preds = %26
   %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
   store i8 %30, i8 addrspace(1)* %32
   %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
-  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
-  br i1 %NullCheck14, label %40, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %40
 
 ; <label>:40                                      ; preds = %35
   %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
   store i8 %39, i8 addrspace(1)* %41
   %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
-  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %44
 
 ; <label>:44                                      ; preds = %40
   %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
   %46 = load i8, i8 addrspace(1)* %45, align 8
   %47 = zext i8 %46 to i32
   %48 = trunc i32 %47 to i8
-  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
   store i8 %48, i8 addrspace(1)* %50
   %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
-  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
@@ -9713,29 +11302,29 @@ entry:
 ; <label>:56                                      ; preds = %52
   %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
-  br i1 %NullCheck22, label %59, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
   %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
   %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
-  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
-  br i1 %NullCheck24, label %63, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
   %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
-  br i1 %NullCheck26, label %66, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
   %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
-  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
-  br i1 %NullCheck28, label %69, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %69
 
 ; <label>:69                                      ; preds = %66
   %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
@@ -9744,15 +11333,15 @@ entry:
 
 ; <label>:71                                      ; preds = %105
   %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
-  br i1 %NullCheck34, label %73, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %73
 
 ; <label>:73                                      ; preds = %71
   %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
   %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
   %76 = load i32, i32* %loc0
-  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
-  br i1 %NullCheck36, label %77, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
@@ -9766,8 +11355,8 @@ entry:
 
 ; <label>:83                                      ; preds = %77
   %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
-  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
@@ -9775,14 +11364,14 @@ entry:
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
   %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
-  br i1 %NullCheck40, label %91, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
 ; <label>:91                                      ; preds = %85
   %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
   %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
-  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck42, label %94, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %94
 
 ; <label>:94                                      ; preds = %91
   %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
@@ -9798,14 +11387,14 @@ entry:
 ; <label>:99                                      ; preds = %69, %96
   %100 = load i32, i32* %loc0
   %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
-  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %102
 
 ; <label>:102                                     ; preds = %99
   %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
   %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
-  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
-  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
@@ -9819,87 +11408,87 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %26
+ThrowNullRef10:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %31
+ThrowNullRef12:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %35
+ThrowNullRef14:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %40
+ThrowNullRef16:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %56
+ThrowNullRef22:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %59
+ThrowNullRef24:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %63
+ThrowNullRef26:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %66
+ThrowNullRef28:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %102
+ThrowNullRef32:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %71
+ThrowNullRef34:                                   ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %73
+ThrowNullRef36:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %83
+ThrowNullRef38:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %85
+ThrowNullRef40:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %91
+ThrowNullRef42:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9943,15 +11532,15 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
   %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
@@ -9961,28 +11550,28 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
   %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %12
   %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
   %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
   %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
-  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
@@ -9993,23 +11582,23 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %12
+ThrowNullRef6:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10031,15 +11620,15 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
   %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = load i64, i64 addrspace(1)* %7
@@ -10077,13 +11666,13 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[loadElem]
+Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -10111,8 +11700,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -10201,8 +11790,8 @@ entry:
 ; <label>:17                                      ; preds = %11, %14
   %18 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
   %19 = bitcast %System.Object addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = load i64, i64 addrspace(1)* %19
@@ -10216,8 +11805,8 @@ entry:
   %29 = call %System.String addrspace(1)* %28(%System.Object addrspace(1)* %18)
   %30 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %31 = bitcast %System.Object addrspace(1)* %30 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %31, null
-  br i1 %NullCheck2, label %32, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %20
   %33 = load i64, i64 addrspace(1)* %31
@@ -10231,8 +11820,8 @@ entry:
   %41 = call %System.String addrspace(1)* %40(%System.Object addrspace(1)* %30)
   %42 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg2
   %43 = bitcast %System.Object addrspace(1)* %42 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %43, null
-  br i1 %NullCheck4, label %44, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %43, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %44
 
 ; <label>:44                                      ; preds = %32
   %45 = load i64, i64 addrspace(1)* %43
@@ -10251,11 +11840,11 @@ ThrowNullRef:                                     ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %20
+ThrowNullRef2:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %32
+ThrowNullRef4:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10269,8 +11858,8 @@ entry:
   store %System.Double addrspace(1)* %param0, %System.Double addrspace(1)** %this
   %0 = load %System.Double addrspace(1)*, %System.Double addrspace(1)** %this
   %1 = bitcast %System.Double addrspace(1)* %0 to double addrspace(1)*
-  %NullCheck = icmp ne double addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq double addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load double, double addrspace(1)* %1, align 8
@@ -10473,8 +12062,8 @@ entry:
   %loc0 = alloca %System.Globalization.NumberFormatInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 3
@@ -10484,8 +12073,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
@@ -10495,24 +12084,24 @@ entry:
   store %System.Globalization.NumberFormatInfo addrspace(1)* %10, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
   %11 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %7
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
   %15 = load i8, i8 addrspace(1)* %14, align 8
   %16 = zext i8 %15 to i32
   %17 = trunc i32 %16 to i8
-  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %11, null
-  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %11, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %13
   %19 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %11, i32 0, i32 29
   store i8 %17, i8 addrspace(1)* %19
   %20 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %21 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %20, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %20, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %18
   %23 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %20, i32 0, i32 3
@@ -10521,8 +12110,8 @@ entry:
 
 ; <label>:24                                      ; preds = %1, %22
   %25 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %25, null
-  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %25, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %26
 
 ; <label>:26                                      ; preds = %24
   %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %25, i32 0, i32 3
@@ -10533,23 +12122,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %18
+ThrowNullRef8:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10574,168 +12163,168 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 18
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %8, align 8
-  %NullCheck2 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %5, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %5, i32 0, i32 4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %9)
   %12 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 19
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %15, align 8
-  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %12, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %12, i32 0, i32 5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %16)
   %19 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %20 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %20, null
-  br i1 %NullCheck8, label %21, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %20, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %20, i32 0, i32 23
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  %NullCheck10 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %19, null
-  br i1 %NullCheck10, label %24, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %19, i32 0, i32 7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %25, %System.String addrspace(1)* %23)
   %26 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %27 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %27, i32 0, i32 22
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %29, align 8
-  %NullCheck14 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %26, null
-  br i1 %NullCheck14, label %31, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %26, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %26, i32 0, i32 6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %32, %System.String addrspace(1)* %30)
   %33 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %34 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Globalization.CultureData addrspace(1)* %34, null
-  br i1 %NullCheck16, label %35, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Globalization.CultureData addrspace(1)* %34, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %34, i32 0, i32 51
   %37 = load i32, i32 addrspace(1)* %36, align 8
-  %NullCheck18 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %33, null
-  br i1 %NullCheck18, label %38, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %33, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %33, i32 0, i32 21
   store i32 %37, i32 addrspace(1)* %39
   %40 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %41 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Globalization.CultureData addrspace(1)* %41, null
-  br i1 %NullCheck20, label %42, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Globalization.CultureData addrspace(1)* %41, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %41, i32 0, i32 52
   %44 = load i32, i32 addrspace(1)* %43, align 8
-  %NullCheck22 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %40, null
-  br i1 %NullCheck22, label %45, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %40, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %40, i32 0, i32 25
   store i32 %44, i32 addrspace(1)* %46
   %47 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %48 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.Globalization.CultureData addrspace(1)* %48, null
-  br i1 %NullCheck24, label %49, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Globalization.CultureData addrspace(1)* %48, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %49
 
 ; <label>:49                                      ; preds = %45
   %50 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %48, i32 0, i32 29
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck26 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %47, null
-  br i1 %NullCheck26, label %52, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %47, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %47, i32 0, i32 10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %53, %System.String addrspace(1)* %51)
   %54 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %55 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Globalization.CultureData addrspace(1)* %55, null
-  br i1 %NullCheck28, label %56, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Globalization.CultureData addrspace(1)* %55, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %56
 
 ; <label>:56                                      ; preds = %52
   %57 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %55, i32 0, i32 35
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %57, align 8
-  %NullCheck30 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %54, null
-  br i1 %NullCheck30, label %59, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %54, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %54, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %60, %System.String addrspace(1)* %58)
   %61 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %62 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck32 = icmp ne %System.Globalization.CultureData addrspace(1)* %62, null
-  br i1 %NullCheck32, label %63, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Globalization.CultureData addrspace(1)* %62, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %62, i32 0, i32 34
   %65 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %64, align 8
-  %NullCheck34 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %61, null
-  br i1 %NullCheck34, label %66, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %61, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %61, i32 0, i32 9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %67, %System.String addrspace(1)* %65)
   %68 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %69 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck36 = icmp ne %System.Globalization.CultureData addrspace(1)* %69, null
-  br i1 %NullCheck36, label %70, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Globalization.CultureData addrspace(1)* %69, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %70
 
 ; <label>:70                                      ; preds = %66
   %71 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %69, i32 0, i32 55
   %72 = load i32, i32 addrspace(1)* %71, align 8
-  %NullCheck38 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %68, null
-  br i1 %NullCheck38, label %73, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %68, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %68, i32 0, i32 22
   store i32 %72, i32 addrspace(1)* %74
   %75 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %76 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck40 = icmp ne %System.Globalization.CultureData addrspace(1)* %76, null
-  br i1 %NullCheck40, label %77, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Globalization.CultureData addrspace(1)* %76, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %76, i32 0, i32 57
   %79 = load i32, i32 addrspace(1)* %78, align 8
-  %NullCheck42 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %75, null
-  br i1 %NullCheck42, label %80, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %75, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %80
 
 ; <label>:80                                      ; preds = %77
   %81 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %75, i32 0, i32 24
   store i32 %79, i32 addrspace(1)* %81
   %82 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %83 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck44 = icmp ne %System.Globalization.CultureData addrspace(1)* %83, null
-  br i1 %NullCheck44, label %84, label %ThrowNullRef43
+  %NullCheck43 = icmp eq %System.Globalization.CultureData addrspace(1)* %83, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %84
 
 ; <label>:84                                      ; preds = %80
   %85 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %83, i32 0, i32 56
   %86 = load i32, i32 addrspace(1)* %85, align 8
-  %NullCheck46 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %82, null
-  br i1 %NullCheck46, label %87, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %82, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %82, i32 0, i32 23
@@ -10744,8 +12333,8 @@ entry:
 
 ; <label>:89                                      ; preds = %entry
   %90 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck100 = icmp ne %System.Globalization.CultureData addrspace(1)* %90, null
-  br i1 %NullCheck100, label %91, label %ThrowNullRef99
+  %NullCheck99 = icmp eq %System.Globalization.CultureData addrspace(1)* %90, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %91
 
 ; <label>:91                                      ; preds = %89
   %92 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %90, i32 0, i32 2
@@ -10763,8 +12352,8 @@ entry:
   %102 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %103 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %104 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %103)
-  %NullCheck48 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %102, null
-  br i1 %NullCheck48, label %105, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %102, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %105
 
 ; <label>:105                                     ; preds = %101
   %106 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %102, i32 0, i32 1
@@ -10772,8 +12361,8 @@ entry:
   %107 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %108 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %109 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %108)
-  %NullCheck50 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %107, null
-  br i1 %NullCheck50, label %110, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %107, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %110
 
 ; <label>:110                                     ; preds = %105
   %111 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %107, i32 0, i32 2
@@ -10781,8 +12370,8 @@ entry:
   %112 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %113 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %114 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %113)
-  %NullCheck52 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %112, null
-  br i1 %NullCheck52, label %115, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %112, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %115
 
 ; <label>:115                                     ; preds = %110
   %116 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %112, i32 0, i32 27
@@ -10790,8 +12379,8 @@ entry:
   %117 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %118 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %119 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %118)
-  %NullCheck54 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %117, null
-  br i1 %NullCheck54, label %120, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %117, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %120
 
 ; <label>:120                                     ; preds = %115
   %121 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %117, i32 0, i32 26
@@ -10799,8 +12388,8 @@ entry:
   %122 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %123 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %124 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %123)
-  %NullCheck56 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %122, null
-  br i1 %NullCheck56, label %125, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %122, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %125
 
 ; <label>:125                                     ; preds = %120
   %126 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %122, i32 0, i32 17
@@ -10808,8 +12397,8 @@ entry:
   %127 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %128 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %129 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %128)
-  %NullCheck58 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %127, null
-  br i1 %NullCheck58, label %130, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %127, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %130
 
 ; <label>:130                                     ; preds = %125
   %131 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %127, i32 0, i32 18
@@ -10817,8 +12406,8 @@ entry:
   %132 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %133 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %134 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %133)
-  %NullCheck60 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %132, null
-  br i1 %NullCheck60, label %135, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %132, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %135
 
 ; <label>:135                                     ; preds = %130
   %136 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %132, i32 0, i32 14
@@ -10826,8 +12415,8 @@ entry:
   %137 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %138 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %139 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %138)
-  %NullCheck62 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %137, null
-  br i1 %NullCheck62, label %140, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %137, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %140
 
 ; <label>:140                                     ; preds = %135
   %141 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %137, i32 0, i32 13
@@ -10835,71 +12424,71 @@ entry:
   %142 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %143 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %144 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %143)
-  %NullCheck64 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %142, null
-  br i1 %NullCheck64, label %145, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %142, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %145
 
 ; <label>:145                                     ; preds = %140
   %146 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %142, i32 0, i32 12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %146, %System.String addrspace(1)* %144)
   %147 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %148 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck66 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %148, null
-  br i1 %NullCheck66, label %149, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %148, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %149
 
 ; <label>:149                                     ; preds = %145
   %150 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %148, i32 0, i32 21
   %151 = load i32, i32 addrspace(1)* %150, align 8
-  %NullCheck68 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %147, null
-  br i1 %NullCheck68, label %152, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %147, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %152
 
 ; <label>:152                                     ; preds = %149
   %153 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %147, i32 0, i32 28
   store i32 %151, i32 addrspace(1)* %153
   %154 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %155 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck70 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %155, null
-  br i1 %NullCheck70, label %156, label %ThrowNullRef69
+  %NullCheck69 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %155, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %156
 
 ; <label>:156                                     ; preds = %152
   %157 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %155, i32 0, i32 6
   %158 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %157, align 8
-  %NullCheck72 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %154, null
-  br i1 %NullCheck72, label %159, label %ThrowNullRef71
+  %NullCheck71 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %154, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %159
 
 ; <label>:159                                     ; preds = %156
   %160 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %154, i32 0, i32 15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %160, %System.String addrspace(1)* %158)
   %161 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %162 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck74 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %162, null
-  br i1 %NullCheck74, label %163, label %ThrowNullRef73
+  %NullCheck73 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %162, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %163
 
 ; <label>:163                                     ; preds = %159
   %164 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %162, i32 0, i32 1
   %165 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %164, align 8
-  %NullCheck76 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %161, null
-  br i1 %NullCheck76, label %166, label %ThrowNullRef75
+  %NullCheck75 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %161, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %166
 
 ; <label>:166                                     ; preds = %163
   %167 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %161, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %167, %"System.Int32[]" addrspace(1)* %165)
   %168 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %169 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck78 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %169, null
-  br i1 %NullCheck78, label %170, label %ThrowNullRef77
+  %NullCheck77 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %169, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %170
 
 ; <label>:170                                     ; preds = %166
   %171 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %169, i32 0, i32 7
   %172 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %171, align 8
-  %NullCheck80 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %168, null
-  br i1 %NullCheck80, label %173, label %ThrowNullRef79
+  %NullCheck79 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %168, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %173
 
 ; <label>:173                                     ; preds = %170
   %174 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %168, i32 0, i32 16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %174, %System.String addrspace(1)* %172)
   %175 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck82 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %175, null
-  br i1 %NullCheck82, label %176, label %ThrowNullRef81
+  %NullCheck81 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %175, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %176
 
 ; <label>:176                                     ; preds = %173
   %177 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %175, i32 0, i32 4
@@ -10909,14 +12498,14 @@ entry:
 
 ; <label>:180                                     ; preds = %176
   %181 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck84 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %181, null
-  br i1 %NullCheck84, label %182, label %ThrowNullRef83
+  %NullCheck83 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %181, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %182
 
 ; <label>:182                                     ; preds = %180
   %183 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %181, i32 0, i32 4
   %184 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %183, align 8
-  %NullCheck86 = icmp ne %System.String addrspace(1)* %184, null
-  br i1 %NullCheck86, label %185, label %ThrowNullRef85
+  %NullCheck85 = icmp eq %System.String addrspace(1)* %184, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %185
 
 ; <label>:185                                     ; preds = %182
   %186 = getelementptr inbounds %System.String, %System.String addrspace(1)* %184, i32 0, i32 1
@@ -10927,8 +12516,8 @@ entry:
 ; <label>:189                                     ; preds = %176, %185
   %190 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck98 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %190, null
-  br i1 %NullCheck98, label %192, label %ThrowNullRef97
+  %NullCheck97 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %190, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %192
 
 ; <label>:192                                     ; preds = %189
   %193 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %190, i32 0, i32 4
@@ -10937,8 +12526,8 @@ entry:
 
 ; <label>:194                                     ; preds = %185, %192
   %195 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck88 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %195, null
-  br i1 %NullCheck88, label %196, label %ThrowNullRef87
+  %NullCheck87 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %195, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %196
 
 ; <label>:196                                     ; preds = %194
   %197 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %195, i32 0, i32 9
@@ -10948,14 +12537,14 @@ entry:
 
 ; <label>:200                                     ; preds = %196
   %201 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck90 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %201, null
-  br i1 %NullCheck90, label %202, label %ThrowNullRef89
+  %NullCheck89 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %201, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %202
 
 ; <label>:202                                     ; preds = %200
   %203 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %201, i32 0, i32 9
   %204 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %203, align 8
-  %NullCheck92 = icmp ne %System.String addrspace(1)* %204, null
-  br i1 %NullCheck92, label %205, label %ThrowNullRef91
+  %NullCheck91 = icmp eq %System.String addrspace(1)* %204, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %205
 
 ; <label>:205                                     ; preds = %202
   %206 = getelementptr inbounds %System.String, %System.String addrspace(1)* %204, i32 0, i32 1
@@ -10966,14 +12555,14 @@ entry:
 ; <label>:209                                     ; preds = %196, %205
   %210 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %211 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck94 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %211, null
-  br i1 %NullCheck94, label %212, label %ThrowNullRef93
+  %NullCheck93 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %211, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %212
 
 ; <label>:212                                     ; preds = %209
   %213 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %211, i32 0, i32 6
   %214 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %213, align 8
-  %NullCheck96 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %210, null
-  br i1 %NullCheck96, label %215, label %ThrowNullRef95
+  %NullCheck95 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %210, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %215
 
 ; <label>:215                                     ; preds = %212
   %216 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %210, i32 0, i32 9
@@ -10987,203 +12576,203 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %17
+ThrowNullRef8:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %21
+ThrowNullRef10:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %24
+ThrowNullRef12:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %28
+ThrowNullRef14:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %31
+ThrowNullRef16:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %35
+ThrowNullRef18:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %38
+ThrowNullRef20:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %42
+ThrowNullRef22:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %45
+ThrowNullRef24:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %49
+ThrowNullRef26:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %52
+ThrowNullRef28:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %56
+ThrowNullRef30:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %59
+ThrowNullRef32:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %63
+ThrowNullRef34:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %66
+ThrowNullRef36:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %70
+ThrowNullRef38:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %73
+ThrowNullRef40:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %77
+ThrowNullRef42:                                   ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %80
+ThrowNullRef44:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %84
+ThrowNullRef46:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %101
+ThrowNullRef48:                                   ; preds = %101
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %105
+ThrowNullRef50:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %110
+ThrowNullRef52:                                   ; preds = %110
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %115
+ThrowNullRef54:                                   ; preds = %115
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %120
+ThrowNullRef56:                                   ; preds = %120
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %125
+ThrowNullRef58:                                   ; preds = %125
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %130
+ThrowNullRef60:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %135
+ThrowNullRef62:                                   ; preds = %135
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %140
+ThrowNullRef64:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %145
+ThrowNullRef66:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %149
+ThrowNullRef68:                                   ; preds = %149
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %152
+ThrowNullRef70:                                   ; preds = %152
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %156
+ThrowNullRef72:                                   ; preds = %156
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %159
+ThrowNullRef74:                                   ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %163
+ThrowNullRef76:                                   ; preds = %163
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %166
+ThrowNullRef78:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %170
+ThrowNullRef80:                                   ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %173
+ThrowNullRef82:                                   ; preds = %173
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %180
+ThrowNullRef84:                                   ; preds = %180
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %182
+ThrowNullRef86:                                   ; preds = %182
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %194
+ThrowNullRef88:                                   ; preds = %194
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %200
+ThrowNullRef90:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %202
+ThrowNullRef92:                                   ; preds = %202
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %209
+ThrowNullRef94:                                   ; preds = %209
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %212
+ThrowNullRef96:                                   ; preds = %212
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %189
+ThrowNullRef98:                                   ; preds = %189
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %89
+ThrowNullRef100:                                  ; preds = %89
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11211,8 +12800,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 21
@@ -11225,8 +12814,8 @@ entry:
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 16)
   %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 21
@@ -11235,8 +12824,8 @@ entry:
 
 ; <label>:12                                      ; preds = %1, %10
   %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 21
@@ -11247,11 +12836,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %12
+ThrowNullRef4:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11267,8 +12856,8 @@ entry:
   store i32 %param1, i32* %arg1
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %1 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
@@ -11335,8 +12924,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 33
@@ -11349,8 +12938,8 @@ entry:
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 24)
   %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 33
@@ -11359,8 +12948,8 @@ entry:
 
 ; <label>:12                                      ; preds = %1, %10
   %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 33
@@ -11371,11 +12960,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %12
+ThrowNullRef4:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11388,8 +12977,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 53
@@ -11401,8 +12990,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 116)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 53
@@ -11411,8 +13000,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 53
@@ -11423,11 +13012,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11456,8 +13045,8 @@ entry:
 
 ; <label>:7                                       ; preds = %entry, %4
   %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %7
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 2
@@ -11481,8 +13070,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 54
@@ -11494,8 +13083,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 117)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
@@ -11504,8 +13093,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 54
@@ -11516,11 +13105,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11533,8 +13122,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 27
@@ -11546,8 +13135,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 118)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 27
@@ -11556,8 +13145,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 27
@@ -11568,11 +13157,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11585,8 +13174,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 28
@@ -11598,8 +13187,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 119)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 28
@@ -11608,8 +13197,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 28
@@ -11620,11 +13209,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11637,8 +13226,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 26
@@ -11650,8 +13239,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 107)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 26
@@ -11660,8 +13249,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 26
@@ -11672,11 +13261,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11689,8 +13278,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 25
@@ -11702,8 +13291,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 106)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 25
@@ -11712,8 +13301,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 25
@@ -11724,11 +13313,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11741,8 +13330,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 24
@@ -11754,8 +13343,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 105)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 24
@@ -11764,8 +13353,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 24
@@ -11776,11 +13365,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11859,23 +13448,23 @@ entry:
 
 ; <label>:25                                      ; preds = %20, %23
   %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck, label %27, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %26, null
+  br i1 %NullCheck, label %ThrowNullRef, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
   %29 = load i32, i32 addrspace(1)* %28
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck2, label %31, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %31
 
 ; <label>:31                                      ; preds = %27
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
   %33 = load i32, i32 addrspace(1)* %32
   %34 = add i32 %29, %33
   %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %35, null
-  br i1 %NullCheck4, label %36, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %35, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %36
 
 ; <label>:36                                      ; preds = %31
   %37 = getelementptr inbounds %System.String, %System.String addrspace(1)* %35, i32 0, i32 1
@@ -11890,8 +13479,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %42, i32 0, %System.String addrspace(1)* %43)
   %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
   %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %45, null
-  br i1 %NullCheck6, label %46, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %45, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %46
 
 ; <label>:46                                      ; preds = %36
   %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 1
@@ -11900,15 +13489,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %44, i32 %48, %System.String addrspace(1)* %49)
   %50 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck8, label %52, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %52
 
 ; <label>:52                                      ; preds = %46
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
   %54 = load i32, i32 addrspace(1)* %53
   %55 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %55, null
-  br i1 %NullCheck10, label %56, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %55, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %56
 
 ; <label>:56                                      ; preds = %52
   %57 = getelementptr inbounds %System.String, %System.String addrspace(1)* %55, i32 0, i32 1
@@ -11923,23 +13512,23 @@ ThrowNullRef:                                     ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %27
+ThrowNullRef2:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %31
+ThrowNullRef4:                                    ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %36
+ThrowNullRef6:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %46
+ThrowNullRef8:                                    ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %52
+ThrowNullRef10:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11954,8 +13543,8 @@ entry:
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -12089,8 +13678,8 @@ entry:
   store i64 %param0, i64* %arg0
   store i64 %param1, i64* %arg1
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
@@ -12098,8 +13687,8 @@ entry:
   %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
   %5 = load i16*, i16* addrspace(1)* %4, align 8
   %6 = addrspacecast i64* %arg1 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = bitcast i64 addrspace(1)* %6 to i8 addrspace(1)*
@@ -12115,7 +13704,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12149,8 +13738,8 @@ entry:
   %1 = load i32, i32* %arg1
   %2 = sext i32 %1 to i64
   %3 = inttoptr i64 %2 to i16*
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -12203,8 +13792,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, i32)*)(%System.IO.ConsoleStream addrspace(1)* %2, i32 %1)
   %3 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %4 = load i64, i64* %arg1
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
@@ -12215,8 +13804,8 @@ entry:
   %10 = icmp eq i32 %9, 3
   %11 = sext i1 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %5
   %14 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, i32 0, i32 5
@@ -12227,7 +13816,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12250,8 +13839,8 @@ entry:
   %5 = icmp eq i32 %4, 1
   %6 = sext i1 %5 to i32
   %7 = trunc i32 %6 to i8
-  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %2, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.ConsoleStream addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
@@ -12262,8 +13851,8 @@ entry:
   %13 = icmp eq i32 %12, 2
   %14 = sext i1 %13 to i32
   %15 = trunc i32 %14 to i8
-  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %10, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.ConsoleStream addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %8
   %17 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %10, i32 0, i32 4
@@ -12274,7 +13863,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12313,8 +13902,8 @@ entry:
   %arg0 = alloca i64
   store i64 %param0, i64* %arg0
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
@@ -12349,8 +13938,8 @@ entry:
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
   %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = load i64, i64 addrspace(1)* %7
@@ -12454,7 +14043,127 @@ entry:
 INFO:  jitting method Encoding::GetEncoding using LLILCJit
 Failed to read Encoding.GetEncoding[convertToHelperArgumentType]
 INFO:  jitting method EncodingProvider::GetEncodingFromProvider using LLILCJit
-Failed to read EncodingProvider.GetEncodingFromProvider[loadElem]
+Successfully read EncodingProvider.GetEncodingFromProvider
+
+define %System.Text.Encoding addrspace(1)* @EncodingProvider.GetEncodingFromProvider(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca %"System.Text.EncodingProvider[]" addrspace(1)*
+  %loc1 = alloca %System.Text.EncodingProvider addrspace(1)*
+  %loc2 = alloca %System.Text.Encoding addrspace(1)*
+  %loc3 = alloca %System.Text.Encoding addrspace(1)*
+  %loc4 = alloca %"System.Text.EncodingProvider[]" addrspace(1)*
+  %loc5 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1059)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2392
+  %2 = addrspacecast i8 addrspace(1)* %1 to %"System.Text.EncodingProvider[]" addrspace(1)**
+  %3 = load volatile %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %2
+  %4 = icmp ne %"System.Text.EncodingProvider[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %entry
+  ret %System.Text.Encoding addrspace(1)* null
+
+; <label>:6                                       ; preds = %entry
+  %7 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1059)
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i64 2392
+  %9 = addrspacecast i8 addrspace(1)* %8 to %"System.Text.EncodingProvider[]" addrspace(1)**
+  %10 = load volatile %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %9
+  store %"System.Text.EncodingProvider[]" addrspace(1)* %10, %"System.Text.EncodingProvider[]" addrspace(1)** %loc0
+  %11 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc0
+  store %"System.Text.EncodingProvider[]" addrspace(1)* %11, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  store i32 0, i32* %loc5
+  br label %43
+
+; <label>:12                                      ; preds = %46
+  %13 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  %14 = load i32, i32* %loc5
+  %NullCheck1 = icmp eq %"System.Text.EncodingProvider[]" addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %13, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = zext i32 %17 to i64
+  %19 = zext i32 %14 to i64
+  %BoundsCheck = icmp uge i64 %19, %18
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %20
+
+; <label>:20                                      ; preds = %15
+  %21 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %13, i32 0, i32 3, i32 %14
+  %22 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)* addrspace(1)* %21, align 8
+  store %System.Text.EncodingProvider addrspace(1)* %22, %System.Text.EncodingProvider addrspace(1)** %loc1
+  %23 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)** %loc1
+  %24 = load i32, i32* %arg0
+  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i64 addrspace(1)*
+  %NullCheck3 = icmp eq i64 addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
+
+; <label>:26                                      ; preds = %20
+  %27 = load i64, i64 addrspace(1)* %25
+  %28 = add i64 %27, 64
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 40
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Text.Encoding addrspace(1)* (%System.Text.EncodingProvider addrspace(1)*, i32)*
+  %35 = call %System.Text.Encoding addrspace(1)* %34(%System.Text.EncodingProvider addrspace(1)* %23, i32 %24)
+  store %System.Text.Encoding addrspace(1)* %35, %System.Text.Encoding addrspace(1)** %loc2
+  %36 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc2
+  %37 = icmp eq %System.Text.Encoding addrspace(1)* %36, null
+  br i1 %37, label %40, label %38
+
+; <label>:38                                      ; preds = %26
+  %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc2
+  store %System.Text.Encoding addrspace(1)* %39, %System.Text.Encoding addrspace(1)** %loc3
+  br label %53
+
+; <label>:40                                      ; preds = %26
+  %41 = load i32, i32* %loc5
+  %42 = add i32 %41, 1
+  store i32 %42, i32* %loc5
+  br label %43
+
+; <label>:43                                      ; preds = %6, %40
+  %44 = load i32, i32* %loc5
+  %45 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  %NullCheck = icmp eq %"System.Text.EncodingProvider[]" addrspace(1)* %45, null
+  br i1 %NullCheck, label %ThrowNullRef, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp slt i32 %44, %50
+  br i1 %51, label %12, label %52
+
+; <label>:52                                      ; preds = %46
+  ret %System.Text.Encoding addrspace(1)* null
+
+; <label>:53                                      ; preds = %38
+  %54 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc3
+  ret %System.Text.Encoding addrspace(1)* %54
+
+ThrowNullRef:                                     ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method EncodingProvider::.cctor using LLILCJit
 Successfully read EncodingProvider..cctor
 
@@ -12473,7 +14182,7 @@ Failed to read Encoding.get_InternalSyncObject[Call HasTypeArg]
 INFO:  jitting method Hashtable::.ctor using LLILCJit
 Failed to read Hashtable..ctor[Volatile store]
 INFO:  jitting method Hashtable::get_Item using LLILCJit
-Failed to read Hashtable.get_Item[loadElemA]
+Failed to read Hashtable.get_Item[loadNonPrimitiveObj]
 INFO:  jitting method Hashtable::InitHash using LLILCJit
 Successfully read Hashtable.InitHash
 
@@ -12493,8 +14202,8 @@ entry:
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -12510,15 +14219,15 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
   %15 = load i32, i32* %loc0
-  %NullCheck2 = icmp ne i32 addrspace(1)* %14, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i32 addrspace(1)* %14, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %3
   store i32 %15, i32 addrspace(1)* %14, align 8
   %17 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %18 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %NullCheck4 = icmp ne i32 addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i32 addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = load i32, i32 addrspace(1)* %18, align 8
@@ -12527,8 +14236,8 @@ entry:
   %23 = sub i32 %22, 1
   %24 = urem i32 %21, %23
   %25 = add i32 1, %24
-  %NullCheck6 = icmp ne i32 addrspace(1)* %17, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32 addrspace(1)* %17, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %19
   store i32 %25, i32 addrspace(1)* %17, align 8
@@ -12539,15 +14248,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %19
+ThrowNullRef6:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12562,8 +14271,8 @@ entry:
   store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
   store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %NullCheck = icmp ne %System.Collections.Hashtable addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Collections.Hashtable addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
@@ -12573,16 +14282,16 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Collections.Hashtable addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Collections.Hashtable addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
   %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck4 = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %9, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
   %13 = inttoptr i64 %11 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
@@ -12592,8 +14301,8 @@ entry:
 ; <label>:15                                      ; preds = %1
   %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -12611,15 +14320,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12633,8 +14342,8 @@ entry:
   store %System.Int32 addrspace(1)* %param0, %System.Int32 addrspace(1)** %this
   %0 = load %System.Int32 addrspace(1)*, %System.Int32 addrspace(1)** %this
   %1 = bitcast %System.Int32 addrspace(1)* %0 to i32 addrspace(1)*
-  %NullCheck = icmp ne i32 addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq i32 addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load i32, i32 addrspace(1)* %1, align 8
@@ -12710,8 +14419,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.UTF8Encoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
@@ -12720,15 +14429,15 @@ entry:
   %9 = load i8, i8* %arg2
   %10 = zext i8 %9 to i32
   %11 = trunc i32 %10 to i8
-  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %8, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %6
   %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %8, i32 0, i32 8
   store i8 %11, i8 addrspace(1)* %13
   %14 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %14, i32 0, i32 8
@@ -12740,8 +14449,8 @@ entry:
 ; <label>:20                                      ; preds = %15
   %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %22, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %22, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = load i64, i64 addrspace(1)* %22
@@ -12763,15 +14472,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %12
+ThrowNullRef4:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12786,8 +14495,8 @@ entry:
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
@@ -12809,16 +14518,16 @@ entry:
 ; <label>:10                                      ; preds = %1
   %11 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
   %12 = load i32, i32* %arg1
-  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %11, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.Encoding addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
   store i32 %12, i32 addrspace(1)* %14
   %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
   %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = load i64, i64 addrspace(1)* %16
@@ -12836,11 +14545,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12853,8 +14562,8 @@ entry:
   %this = alloca %System.Text.UTF8Encoding addrspace(1)*
   store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
   %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.UTF8Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
@@ -12866,16 +14575,16 @@ entry:
 ; <label>:6                                       ; preds = %1
   %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %8 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %10, %System.Text.EncoderFallback addrspace(1)* %8)
   %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %12 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
-  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %11, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %11, i32 0, i32 3
@@ -12888,8 +14597,8 @@ entry:
   %18 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %18, %System.String addrspace(1)* %17)
   %19 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %18 to %System.Text.EncoderFallback addrspace(1)*
-  %NullCheck6 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %16, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %16, i32 0, i32 2
@@ -12899,8 +14608,8 @@ entry:
   %24 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %24, %System.String addrspace(1)* %23)
   %25 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %24 to %System.Text.DecoderFallback addrspace(1)*
-  %NullCheck8 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %22, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %22, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %20
   %27 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %22, i32 0, i32 3
@@ -12911,19 +14620,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %20
+ThrowNullRef8:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12953,8 +14662,8 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load i32, i32* %arg1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -12972,8 +14681,8 @@ entry:
 ; <label>:15                                      ; preds = %8
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %17 = load i32, i32* %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 %17
@@ -12989,7 +14698,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13041,7 +14750,7 @@ entry:
 }
 
 INFO:  jitting method Hashtable::Insert using LLILCJit
-Failed to read Hashtable.Insert[loadElemA]
+Failed to read Hashtable.Insert[storeElem]
 INFO:  jitting method ConsoleEncoding::.ctor using LLILCJit
 Successfully read ConsoleEncoding..ctor
 
@@ -13056,8 +14765,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %1)
   %2 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
@@ -13093,8 +14802,8 @@ entry:
   %2 = call %System.Text.InternalEncoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalEncoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %1)
   %3 = bitcast %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2 to %System.Text.EncoderFallback addrspace(1)*
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
@@ -13104,8 +14813,8 @@ entry:
   %8 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %7)
   %9 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %8 to %System.Text.DecoderFallback addrspace(1)*
-  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %6, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.Encoding addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %4
   %11 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %6, i32 0, i32 3
@@ -13116,7 +14825,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13135,15 +14844,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* %1)
   %2 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   %6 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, i32 0, i32 1
@@ -13154,7 +14863,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13182,8 +14891,8 @@ entry:
   store %System.Text.InternalDecoderBestFitFallback addrspace(1)* %param0, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
   %0 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
@@ -13193,15 +14902,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %4)
   %5 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %6)
   %9 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, i32 0, i32 1
@@ -13212,11 +14921,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13284,8 +14993,8 @@ entry:
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
   %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = load i64, i64 addrspace(1)* %19
@@ -13349,8 +15058,8 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.ConsoleStream addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
@@ -13381,31 +15090,31 @@ entry:
   store i8 %param4, i8* %arg4
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %3, %System.IO.Stream addrspace(1)* %1)
   %4 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %4, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
   %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %4, i32 0, i32 4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %5)
   %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %6
   %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
   %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
   %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = load i64, i64 addrspace(1)* %13
@@ -13417,8 +15126,8 @@ entry:
   %21 = load i64, i64* %20
   %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %8, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %8, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %14
   %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 5
@@ -13436,24 +15145,24 @@ entry:
   %31 = load i32, i32* %arg3
   %32 = sext i32 %31 to i64
   %33 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %32)
-  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %30, null
-  br i1 %NullCheck10, label %34, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.StreamWriter addrspace(1)* %30, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %35, %"System.Char[]" addrspace(1)* %33)
   %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %37, null
-  br i1 %NullCheck12, label %38, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.StreamWriter addrspace(1)* %37, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %38
 
 ; <label>:38                                      ; preds = %34
   %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
   %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
   %41 = load i32, i32* %arg3
   %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %42, null
-  br i1 %NullCheck14, label %43, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %42, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
   %44 = load i64, i64 addrspace(1)* %42
@@ -13467,30 +15176,30 @@ entry:
   %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
   %53 = sext i32 %52 to i64
   %54 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %53)
-  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
-  br i1 %NullCheck16, label %55, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %55
 
 ; <label>:55                                      ; preds = %43
   %56 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %56, %"System.Byte[]" addrspace(1)* %54)
   %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %58 = load i32, i32* %arg3
-  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %57, null
-  br i1 %NullCheck18, label %59, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.StreamWriter addrspace(1)* %57, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %59
 
 ; <label>:59                                      ; preds = %55
   %60 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 10
   store i32 %58, i32 addrspace(1)* %60
   %61 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %61, null
-  br i1 %NullCheck20, label %62, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.IO.StreamWriter addrspace(1)* %61, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %62
 
 ; <label>:62                                      ; preds = %59
   %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
   %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
   %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
   %67 = load i64, i64 addrspace(1)* %65
@@ -13508,15 +15217,15 @@ entry:
 
 ; <label>:78                                      ; preds = %66
   %79 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %79, null
-  br i1 %NullCheck24, label %80, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.StreamWriter addrspace(1)* %79, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %80
 
 ; <label>:80                                      ; preds = %78
   %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
   %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
   %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %83, null
-  br i1 %NullCheck26, label %84, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %83, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
   %85 = load i64, i64 addrspace(1)* %83
@@ -13533,8 +15242,8 @@ entry:
 
 ; <label>:95                                      ; preds = %84
   %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.IO.StreamWriter addrspace(1)* %96, null
-  br i1 %NullCheck28, label %97, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.IO.StreamWriter addrspace(1)* %96, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %97
 
 ; <label>:97                                      ; preds = %95
   %98 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 12
@@ -13548,8 +15257,8 @@ entry:
   %103 = icmp eq i32 %102, 0
   %104 = sext i1 %103 to i32
   %105 = trunc i32 %104 to i8
-  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %100, null
-  br i1 %NullCheck30, label %106, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.IO.StreamWriter addrspace(1)* %100, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %106
 
 ; <label>:106                                     ; preds = %99
   %107 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %100, i32 0, i32 13
@@ -13560,63 +15269,63 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %6
+ThrowNullRef4:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %29
+ThrowNullRef10:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %34
+ThrowNullRef12:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %38
+ThrowNullRef14:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %43
+ThrowNullRef16:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %55
+ThrowNullRef18:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %59
+ThrowNullRef20:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %62
+ThrowNullRef22:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %78
+ThrowNullRef24:                                   ; preds = %78
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %80
+ThrowNullRef26:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %95
+ThrowNullRef28:                                   ; preds = %95
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13629,15 +15338,15 @@ entry:
   %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = load i64, i64 addrspace(1)* %4
@@ -13655,7 +15364,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13705,35 +15414,35 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
   %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderNLS addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %7 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.EncoderNLS addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Text.Encoding addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.Encoding addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Text.EncoderNLS addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.EncoderNLS addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
   %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck8 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = load i64, i64 addrspace(1)* %16
@@ -13752,19 +15461,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13790,8 +15499,8 @@ entry:
   %this = alloca %System.Text.Encoding addrspace(1)*
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
@@ -13811,15 +15520,15 @@ entry:
   %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
   store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
   %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
   store i32 0, i32 addrspace(1)* %2
   %3 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, i32 0, i32 2
@@ -13829,15 +15538,15 @@ entry:
 
 ; <label>:8                                       ; preds = %4
   %9 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
   %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
   %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = load i64, i64 addrspace(1)* %13
@@ -13858,15 +15567,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13881,16 +15590,16 @@ entry:
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = load i32, i32* %arg1
   %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
   %7 = load i64, i64 addrspace(1)* %5
@@ -13908,7 +15617,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13945,8 +15654,8 @@ entry:
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
   %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
   %16 = load i64, i64 addrspace(1)* %14
@@ -13967,8 +15676,8 @@ entry:
   %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
   %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
   %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %31, null
-  br i1 %NullCheck2, label %32, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = load i64, i64 addrspace(1)* %31
@@ -14011,7 +15720,7 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14024,14 +15733,14 @@ entry:
   %this = alloca %System.Text.EncoderReplacementFallback addrspace(1)*
   store %System.Text.EncoderReplacementFallback addrspace(1)* %param0, %System.Text.EncoderReplacementFallback addrspace(1)** %this
   %0 = load %System.Text.EncoderReplacementFallback addrspace(1)*, %System.Text.EncoderReplacementFallback addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -14042,7 +15751,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14072,8 +15781,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
@@ -14105,8 +15814,8 @@ entry:
   %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
   store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
@@ -14118,8 +15827,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Threading.Tasks.Task addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %7)
@@ -14142,7 +15851,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14161,8 +15870,8 @@ entry:
   store i8 %param1, i8* %arg1
   store i8 %param2, i8* %arg2
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
@@ -14176,8 +15885,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1, %5
   %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 9
@@ -14208,8 +15917,8 @@ entry:
 
 ; <label>:25                                      ; preds = %8, %20
   %26 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %26, null
-  br i1 %NullCheck4, label %27, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %26, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %26, i32 0, i32 12
@@ -14220,22 +15929,22 @@ entry:
 
 ; <label>:32                                      ; preds = %27
   %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %33, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.IO.StreamWriter addrspace(1)* %33, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %32
   %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 12
   store i8 1, i8 addrspace(1)* %35
   %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
-  br i1 %NullCheck8, label %37, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
   %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
   %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck10 = icmp ne i64 addrspace(1)* %40, null
-  br i1 %NullCheck10, label %41, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64 addrspace(1)* %40, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i64, i64 addrspace(1)* %40
@@ -14249,8 +15958,8 @@ entry:
   %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
   store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
   %51 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %NullCheck12 = icmp ne %"System.Byte[]" addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Byte[]" addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %41
   %53 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %51, i32 0, i32 1
@@ -14262,16 +15971,16 @@ entry:
 
 ; <label>:58                                      ; preds = %52
   %59 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %59, null
-  br i1 %NullCheck14, label %60, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.IO.StreamWriter addrspace(1)* %59, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %60
 
 ; <label>:60                                      ; preds = %58
   %61 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %59, i32 0, i32 3
   %62 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
   %64 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %NullCheck16 = icmp ne %"System.Byte[]" addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %"System.Byte[]" addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %60
   %66 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %64, i32 0, i32 1
@@ -14279,8 +15988,8 @@ entry:
   %68 = zext i32 %67 to i64
   %69 = trunc i64 %68 to i32
   %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck18, label %71, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
   %72 = load i64, i64 addrspace(1)* %70
@@ -14296,29 +16005,29 @@ entry:
 
 ; <label>:80                                      ; preds = %27, %52, %71
   %81 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %81, null
-  br i1 %NullCheck20, label %82, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.IO.StreamWriter addrspace(1)* %81, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
 
 ; <label>:82                                      ; preds = %80
   %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %81, i32 0, i32 5
   %84 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %83, align 8
   %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.IO.StreamWriter addrspace(1)* %85, null
-  br i1 %NullCheck22, label %86, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.IO.StreamWriter addrspace(1)* %85, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %86
 
 ; <label>:86                                      ; preds = %82
   %87 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 7
   %88 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %87, align 8
   %89 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %89, null
-  br i1 %NullCheck24, label %90, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.StreamWriter addrspace(1)* %89, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %90
 
 ; <label>:90                                      ; preds = %86
   %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %89, i32 0, i32 9
   %92 = load i32, i32 addrspace(1)* %91, align 8
   %93 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.IO.StreamWriter addrspace(1)* %93, null
-  br i1 %NullCheck26, label %94, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.IO.StreamWriter addrspace(1)* %93, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %93, i32 0, i32 6
@@ -14326,8 +16035,8 @@ entry:
   %97 = load i8, i8* %arg2
   %98 = zext i8 %97 to i32
   %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
-  %NullCheck28 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck28, label %100, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
   %101 = load i64, i64 addrspace(1)* %99
@@ -14342,8 +16051,8 @@ entry:
   %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
   store i32 %110, i32* %loc1
   %111 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %111, null
-  br i1 %NullCheck30, label %112, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.IO.StreamWriter addrspace(1)* %111, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %112
 
 ; <label>:112                                     ; preds = %100
   %113 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %111, i32 0, i32 9
@@ -14354,23 +16063,23 @@ entry:
 
 ; <label>:116                                     ; preds = %112
   %117 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck32 = icmp ne %System.IO.StreamWriter addrspace(1)* %117, null
-  br i1 %NullCheck32, label %118, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.IO.StreamWriter addrspace(1)* %117, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %118
 
 ; <label>:118                                     ; preds = %116
   %119 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %117, i32 0, i32 3
   %120 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %119, align 8
   %121 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.IO.StreamWriter addrspace(1)* %121, null
-  br i1 %NullCheck34, label %122, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.IO.StreamWriter addrspace(1)* %121, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %122
 
 ; <label>:122                                     ; preds = %118
   %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
   %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
   %125 = load i32, i32* %loc1
   %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
-  %NullCheck36 = icmp ne i64 addrspace(1)* %126, null
-  br i1 %NullCheck36, label %127, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64 addrspace(1)* %126, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
   %128 = load i64, i64 addrspace(1)* %126
@@ -14392,15 +16101,15 @@ entry:
 
 ; <label>:140                                     ; preds = %136
   %141 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.IO.StreamWriter addrspace(1)* %141, null
-  br i1 %NullCheck38, label %142, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.IO.StreamWriter addrspace(1)* %141, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %142
 
 ; <label>:142                                     ; preds = %140
   %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
   %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
   %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
-  %NullCheck40 = icmp ne i64 addrspace(1)* %145, null
-  br i1 %NullCheck40, label %146, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i64 addrspace(1)* %145, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
   %147 = load i64, i64 addrspace(1)* %145
@@ -14421,83 +16130,83 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %25
+ThrowNullRef4:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %32
+ThrowNullRef6:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %37
+ThrowNullRef10:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %41
+ThrowNullRef12:                                   ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %58
+ThrowNullRef14:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %60
+ThrowNullRef16:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %65
+ThrowNullRef18:                                   ; preds = %65
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %80
+ThrowNullRef20:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %82
+ThrowNullRef22:                                   ; preds = %82
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %86
+ThrowNullRef24:                                   ; preds = %86
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %90
+ThrowNullRef26:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %94
+ThrowNullRef28:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %100
+ThrowNullRef30:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %116
+ThrowNullRef32:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %118
+ThrowNullRef34:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %122
+ThrowNullRef36:                                   ; preds = %122
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %140
+ThrowNullRef38:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %142
+ThrowNullRef40:                                   ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14564,8 +16273,8 @@ entry:
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %1 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
-  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
@@ -14573,8 +16282,8 @@ entry:
   %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
   %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
   %8 = load i64, i64 addrspace(1)* %6
@@ -14590,8 +16299,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %17, %System.IFormatProvider addrspace(1)* %16)
   %18 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %19 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %18, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.SyncTextWriter addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %7
   %21 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %18, i32 0, i32 4
@@ -14602,11 +16311,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14619,8 +16328,8 @@ entry:
   %this = alloca %System.IO.TextWriter addrspace(1)*
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.TextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
@@ -14630,8 +16339,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.Threading.Thread addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Threading.Thread addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %6)
@@ -14640,8 +16349,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1
   %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.TextWriter addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.TextWriter addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %11, i32 0, i32 2
@@ -14652,11 +16361,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14676,8 +16385,8 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   store i8 0, i8* %loc1
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
@@ -14687,16 +16396,16 @@ entry:
   %5 = addrspacecast i8* %loc1 to i8 addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %4, i8 addrspace(1)* %5)
   %6 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.SyncTextWriter addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
   %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
   %13 = load i64, i64 addrspace(1)* %11
@@ -14731,19 +16440,229 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
-Failed to read TextWriter.WriteLine[loadElem]
+Failed to read TextWriter.WriteLine[storeElem]
 INFO:  jitting method String::CopyTo using LLILCJit
-Failed to read String.CopyTo[loadElemA]
+Successfully read String.CopyTo
+
+define void @String.CopyTo(%System.String addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  %loc1 = alloca i16 addrspace(1)*
+  %loc2 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %1 = icmp ne %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg4
+  %7 = icmp sge i32 %6, 0
+  br i1 %7, label %13, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  unreachable
+
+; <label>:13                                      ; preds = %5
+  %14 = load i32, i32* %arg1
+  %15 = icmp sge i32 %14, 0
+  br i1 %15, label %21, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %18)
+  %20 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %20, %System.String addrspace(1)* %17, %System.String addrspace(1)* %19)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %20) #0
+  unreachable
+
+; <label>:21                                      ; preds = %13
+  %22 = load i32, i32* %arg4
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck, label %ThrowNullRef, label %24
+
+; <label>:24                                      ; preds = %21
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load i32, i32* %arg1
+  %28 = sub i32 %26, %27
+  %29 = icmp sle i32 %22, %28
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34, %System.String addrspace(1)* %31, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %24
+  %36 = load i32, i32* %arg3
+  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %37, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
+
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
+  %40 = load i32, i32 addrspace(1)* %39
+  %41 = zext i32 %40 to i64
+  %42 = trunc i64 %41 to i32
+  %43 = load i32, i32* %arg4
+  %44 = sub i32 %42, %43
+  %45 = icmp sgt i32 %36, %44
+  br i1 %45, label %49, label %46
+
+; <label>:46                                      ; preds = %38
+  %47 = load i32, i32* %arg3
+  %48 = icmp sge i32 %47, 0
+  br i1 %48, label %54, label %49
+
+; <label>:49                                      ; preds = %38, %46
+  %50 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %52 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %51)
+  %53 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53, %System.String addrspace(1)* %50, %System.String addrspace(1)* %52)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53) #0
+  unreachable
+
+; <label>:54                                      ; preds = %46
+  %55 = load i32, i32* %arg4
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %97, label %57
+
+; <label>:57                                      ; preds = %54
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %59
+
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 2
+  %61 = bitcast [0 x i16] addrspace(1)* %60 to i16 addrspace(1)*
+  store i16 addrspace(1)* %61, i16 addrspace(1)** %loc0
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  store %"System.Char[]" addrspace(1)* %62, %"System.Char[]" addrspace(1)** %loc2
+  %63 = icmp eq %"System.Char[]" addrspace(1)* %62, null
+  br i1 %63, label %72, label %64
+
+; <label>:64                                      ; preds = %59
+  %65 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc2
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %65, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %66
+
+; <label>:66                                      ; preds = %64
+  %67 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %65, i32 0, i32 1
+  %68 = load i32, i32 addrspace(1)* %67
+  %69 = zext i32 %68 to i64
+  %70 = trunc i64 %69 to i32
+  %71 = icmp ne i32 %70, 0
+  br i1 %71, label %73, label %72
+
+; <label>:72                                      ; preds = %59, %66
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  br label %81
+
+; <label>:73                                      ; preds = %66
+  %74 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc2
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %74, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %75
+
+; <label>:75                                      ; preds = %73
+  %76 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %74, i32 0, i32 1
+  %77 = load i32, i32 addrspace(1)* %76
+  %78 = zext i32 %77 to i64
+  %BoundsCheck = icmp uge i64 0, %78
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %79
+
+; <label>:79                                      ; preds = %75
+  %80 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %74, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %80, i16 addrspace(1)** %loc1
+  br label %81
+
+; <label>:81                                      ; preds = %72, %79
+  %82 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %83 = ptrtoint i16 addrspace(1)* %82 to i64
+  %84 = load i32, i32* %arg3
+  %85 = sext i32 %84 to i64
+  %86 = mul i64 %85, 2
+  %87 = add i64 %83, %86
+  %88 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %89 = ptrtoint i16 addrspace(1)* %88 to i64
+  %90 = load i32, i32* %arg1
+  %91 = sext i32 %90 to i64
+  %92 = mul i64 %91, 2
+  %93 = add i64 %89, %92
+  %94 = load i32, i32* %arg4
+  %95 = inttoptr i64 %87 to i16*
+  %96 = inttoptr i64 %93 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %95, i16* %96, i32 %94)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  br label %97
+
+; <label>:97                                      ; preds = %54, %81
+  ret void
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StreamWriter::Write using LLILCJit
 Successfully read StreamWriter.Write
 
@@ -14801,8 +16720,8 @@ entry:
 
 ; <label>:23                                      ; preds = %15
   %24 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Char[]" addrspace(1)* %24, null
-  br i1 %NullCheck, label %25, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %24, null
+  br i1 %NullCheck, label %ThrowNullRef, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %24, i32 0, i32 1
@@ -14830,15 +16749,15 @@ entry:
 
 ; <label>:40                                      ; preds = %98
   %41 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %41, null
-  br i1 %NullCheck4, label %42, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %41, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %42
 
 ; <label>:42                                      ; preds = %40
   %43 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
   %44 = load i32, i32 addrspace(1)* %43, align 8
   %45 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %45, null
-  br i1 %NullCheck6, label %46, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.IO.StreamWriter addrspace(1)* %45, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %46
 
 ; <label>:46                                      ; preds = %42
   %47 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %45, i32 0, i32 10
@@ -14853,15 +16772,15 @@ entry:
 
 ; <label>:52                                      ; preds = %46, %50
   %53 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %53, null
-  br i1 %NullCheck8, label %54, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %53, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %54
 
 ; <label>:54                                      ; preds = %52
   %55 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %53, i32 0, i32 10
   %56 = load i32, i32 addrspace(1)* %55, align 8
   %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %57, null
-  br i1 %NullCheck10, label %58, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.StreamWriter addrspace(1)* %57, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %58
 
 ; <label>:58                                      ; preds = %54
   %59 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 9
@@ -14883,15 +16802,15 @@ entry:
   %69 = load i32, i32* %arg2
   %70 = mul i32 %69, 2
   %71 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %71, null
-  br i1 %NullCheck12, label %72, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.StreamWriter addrspace(1)* %71, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %72
 
 ; <label>:72                                      ; preds = %67
   %73 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %71, i32 0, i32 7
   %74 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %73, align 8
   %75 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %75, null
-  br i1 %NullCheck14, label %76, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.IO.StreamWriter addrspace(1)* %75, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %76
 
 ; <label>:76                                      ; preds = %72
   %77 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %75, i32 0, i32 9
@@ -14903,16 +16822,16 @@ entry:
   %83 = bitcast %"System.Char[]" addrspace(1)* %74 to %System.Array addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %82, i32 %70, %System.Array addrspace(1)* %83, i32 %79, i32 %81)
   %84 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %84, null
-  br i1 %NullCheck16, label %85, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.IO.StreamWriter addrspace(1)* %84, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %85
 
 ; <label>:85                                      ; preds = %76
   %86 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %84, i32 0, i32 9
   %87 = load i32, i32 addrspace(1)* %86, align 8
   %88 = load i32, i32* %loc0
   %89 = add i32 %87, %88
-  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %84, null
-  br i1 %NullCheck18, label %90, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.StreamWriter addrspace(1)* %84, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %90
 
 ; <label>:90                                      ; preds = %85
   %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %84, i32 0, i32 9
@@ -14934,8 +16853,8 @@ entry:
 
 ; <label>:101                                     ; preds = %98
   %102 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %102, null
-  br i1 %NullCheck2, label %103, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %102, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %103
 
 ; <label>:103                                     ; preds = %101
   %104 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %102, i32 0, i32 11
@@ -14956,39 +16875,39 @@ ThrowNullRef:                                     ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %101
+ThrowNullRef2:                                    ; preds = %101
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %40
+ThrowNullRef4:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %42
+ThrowNullRef6:                                    ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %52
+ThrowNullRef8:                                    ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %54
+ThrowNullRef10:                                   ; preds = %54
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %67
+ThrowNullRef12:                                   ; preds = %67
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %72
+ThrowNullRef14:                                   ; preds = %72
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %76
+ThrowNullRef16:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %85
+ThrowNullRef18:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -15029,7 +16948,365 @@ entry:
 }
 
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[loadElemA]
+Successfully read EncoderNLS.GetBytes
+
+define i32 @EncoderNLS.GetBytes(%System.Text.EncoderNLS addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3, %"System.Byte[]" addrspace(1)* %param4, i32 %param5, i8 %param6) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %arg4 = alloca %"System.Byte[]" addrspace(1)*
+  %arg5 = alloca i32
+  %arg6 = alloca i8
+  %loc0 = alloca i32
+  %loc1 = alloca i16 addrspace(1)*
+  %loc2 = alloca i8 addrspace(1)*
+  %loc3 = alloca i32
+  %loc4 = alloca %"System.Char[]" addrspace(1)*
+  %loc5 = alloca %"System.Byte[]" addrspace(1)*
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  store %"System.Byte[]" addrspace(1)* %param4, %"System.Byte[]" addrspace(1)** %arg4
+  store i32 %param5, i32* %arg5
+  store i8 %param6, i8* %arg6
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %1 = icmp eq %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %17, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %7 = icmp eq %"System.Char[]" addrspace(1)* %6, null
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %12
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %12
+
+; <label>:12                                      ; preds = %8, %10
+  %13 = phi %System.String addrspace(1)* [ %9, %8 ], [ %11, %10 ]
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %14)
+  %16 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16, %System.String addrspace(1)* %13, %System.String addrspace(1)* %15)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16) #0
+  unreachable
+
+; <label>:17                                      ; preds = %2
+  %18 = load i32, i32* %arg2
+  %19 = icmp slt i32 %18, 0
+  br i1 %19, label %23, label %20
+
+; <label>:20                                      ; preds = %17
+  %21 = load i32, i32* %arg3
+  %22 = icmp sge i32 %21, 0
+  br i1 %22, label %35, label %23
+
+; <label>:23                                      ; preds = %17, %20
+  %24 = load i32, i32* %arg2
+  %25 = icmp slt i32 %24, 0
+  br i1 %25, label %28, label %26
+
+; <label>:26                                      ; preds = %23
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %30
+
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %30
+
+; <label>:30                                      ; preds = %26, %28
+  %31 = phi %System.String addrspace(1)* [ %27, %26 ], [ %29, %28 ]
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34, %System.String addrspace(1)* %31, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %20
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck, label %ThrowNullRef, label %37
+
+; <label>:37                                      ; preds = %35
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = load i32, i32* %arg2
+  %43 = sub i32 %41, %42
+  %44 = load i32, i32* %arg3
+  %45 = icmp sge i32 %43, %44
+  br i1 %45, label %51, label %46
+
+; <label>:46                                      ; preds = %37
+  %47 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %48 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %49 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %48)
+  %50 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %50, %System.String addrspace(1)* %47, %System.String addrspace(1)* %49)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %50) #0
+  unreachable
+
+; <label>:51                                      ; preds = %37
+  %52 = load i32, i32* %arg5
+  %53 = icmp slt i32 %52, 0
+  br i1 %53, label %63, label %54
+
+; <label>:54                                      ; preds = %51
+  %55 = load i32, i32* %arg5
+  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck1 = icmp eq %"System.Byte[]" addrspace(1)* %56, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %57
+
+; <label>:57                                      ; preds = %54
+  %58 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = zext i32 %59 to i64
+  %61 = trunc i64 %60 to i32
+  %62 = icmp sle i32 %55, %61
+  br i1 %62, label %68, label %63
+
+; <label>:63                                      ; preds = %51, %57
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %66 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %65)
+  %67 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %67, %System.String addrspace(1)* %64, %System.String addrspace(1)* %66)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %67) #0
+  unreachable
+
+; <label>:68                                      ; preds = %57
+  %69 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %69, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %69, i32 0, i32 1
+  %72 = load i32, i32 addrspace(1)* %71
+  %73 = zext i32 %72 to i64
+  %74 = trunc i64 %73 to i32
+  %75 = icmp ne i32 %74, 0
+  br i1 %75, label %78, label %76
+
+; <label>:76                                      ; preds = %70
+  %77 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1)
+  store %"System.Char[]" addrspace(1)* %77, %"System.Char[]" addrspace(1)** %arg1
+  br label %78
+
+; <label>:78                                      ; preds = %70, %76
+  %79 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck5 = icmp eq %"System.Byte[]" addrspace(1)* %79, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %80
+
+; <label>:80                                      ; preds = %78
+  %81 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %79, i32 0, i32 1
+  %82 = load i32, i32 addrspace(1)* %81
+  %83 = zext i32 %82 to i64
+  %84 = trunc i64 %83 to i32
+  %85 = load i32, i32* %arg5
+  %86 = sub i32 %84, %85
+  store i32 %86, i32* %loc0
+  %87 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck7 = icmp eq %"System.Byte[]" addrspace(1)* %87, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %88
+
+; <label>:88                                      ; preds = %80
+  %89 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %87, i32 0, i32 1
+  %90 = load i32, i32 addrspace(1)* %89
+  %91 = zext i32 %90 to i64
+  %92 = trunc i64 %91 to i32
+  %93 = icmp ne i32 %92, 0
+  br i1 %93, label %96, label %94
+
+; <label>:94                                      ; preds = %88
+  %95 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1)
+  store %"System.Byte[]" addrspace(1)* %95, %"System.Byte[]" addrspace(1)** %arg4
+  br label %96
+
+; <label>:96                                      ; preds = %88, %94
+  %97 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  store %"System.Char[]" addrspace(1)* %97, %"System.Char[]" addrspace(1)** %loc4
+  %98 = icmp eq %"System.Char[]" addrspace(1)* %97, null
+  br i1 %98, label %107, label %99
+
+; <label>:99                                      ; preds = %96
+  %100 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc4
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %100, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %101
+
+; <label>:101                                     ; preds = %99
+  %102 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %100, i32 0, i32 1
+  %103 = load i32, i32 addrspace(1)* %102
+  %104 = zext i32 %103 to i64
+  %105 = trunc i64 %104 to i32
+  %106 = icmp ne i32 %105, 0
+  br i1 %106, label %108, label %107
+
+; <label>:107                                     ; preds = %96, %101
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  br label %116
+
+; <label>:108                                     ; preds = %101
+  %109 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc4
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %109, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %110
+
+; <label>:110                                     ; preds = %108
+  %111 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %109, i32 0, i32 1
+  %112 = load i32, i32 addrspace(1)* %111
+  %113 = zext i32 %112 to i64
+  %BoundsCheck = icmp uge i64 0, %113
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %114
+
+; <label>:114                                     ; preds = %110
+  %115 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %109, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %115, i16 addrspace(1)** %loc1
+  br label %116
+
+; <label>:116                                     ; preds = %107, %114
+  %117 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  store %"System.Byte[]" addrspace(1)* %117, %"System.Byte[]" addrspace(1)** %loc5
+  %118 = icmp eq %"System.Byte[]" addrspace(1)* %117, null
+  br i1 %118, label %127, label %119
+
+; <label>:119                                     ; preds = %116
+  %120 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc5
+  %NullCheck13 = icmp eq %"System.Byte[]" addrspace(1)* %120, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %121
+
+; <label>:121                                     ; preds = %119
+  %122 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %120, i32 0, i32 1
+  %123 = load i32, i32 addrspace(1)* %122
+  %124 = zext i32 %123 to i64
+  %125 = trunc i64 %124 to i32
+  %126 = icmp ne i32 %125, 0
+  br i1 %126, label %128, label %127
+
+; <label>:127                                     ; preds = %116, %121
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc2
+  br label %136
+
+; <label>:128                                     ; preds = %121
+  %129 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc5
+  %NullCheck15 = icmp eq %"System.Byte[]" addrspace(1)* %129, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %130
+
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %129, i32 0, i32 1
+  %132 = load i32, i32 addrspace(1)* %131
+  %133 = zext i32 %132 to i64
+  %BoundsCheck17 = icmp uge i64 0, %133
+  br i1 %BoundsCheck17, label %ThrowIndexOutOfRange18, label %134
+
+; <label>:134                                     ; preds = %130
+  %135 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %129, i32 0, i32 3, i32 0
+  store i8 addrspace(1)* %135, i8 addrspace(1)** %loc2
+  br label %136
+
+; <label>:136                                     ; preds = %127, %134
+  %137 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %138 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %139 = ptrtoint i16 addrspace(1)* %138 to i64
+  %140 = load i32, i32* %arg2
+  %141 = sext i32 %140 to i64
+  %142 = mul i64 %141, 2
+  %143 = add i64 %139, %142
+  %144 = load i32, i32* %arg3
+  %145 = load i8 addrspace(1)*, i8 addrspace(1)** %loc2
+  %146 = ptrtoint i8 addrspace(1)* %145 to i64
+  %147 = load i32, i32* %arg5
+  %148 = sext i32 %147 to i64
+  %149 = add i64 %146, %148
+  %150 = load i32, i32* %loc0
+  %151 = load i8, i8* %arg6
+  %152 = zext i8 %151 to i32
+  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i64 addrspace(1)*
+  %NullCheck19 = icmp eq i64 addrspace(1)* %153, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %154
+
+; <label>:154                                     ; preds = %136
+  %155 = load i64, i64 addrspace(1)* %153
+  %156 = add i64 %155, 72
+  %157 = inttoptr i64 %156 to i64*
+  %158 = load i64, i64* %157
+  %159 = add i64 %158, 0
+  %160 = inttoptr i64 %159 to i64*
+  %161 = load i64, i64* %160
+  %162 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to %System.Text.Encoder addrspace(1)*
+  %163 = inttoptr i64 %143 to i16*
+  %164 = inttoptr i64 %149 to i8*
+  %165 = trunc i32 %152 to i8
+  %166 = inttoptr i64 %161 to i32 (%System.Text.Encoder addrspace(1)*, i16*, i32, i8*, i32, i8)*
+  %167 = call i32 %166(%System.Text.Encoder addrspace(1)* %162, i16* %163, i32 %144, i8* %164, i32 %150, i8 %165)
+  store i32 %167, i32* %loc3
+  br label %168
+
+; <label>:168                                     ; preds = %154
+  %169 = load i32, i32* %loc3
+  ret i32 %169
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %110
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %119
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange18:                           ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
 Successfully read EncoderNLS.GetBytes
 
@@ -15118,22 +17395,22 @@ entry:
   %40 = load i8, i8* %arg5
   %41 = zext i8 %40 to i32
   %42 = trunc i32 %41 to i8
-  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %39, null
-  br i1 %NullCheck, label %43, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderNLS addrspace(1)* %39, null
+  br i1 %NullCheck, label %ThrowNullRef, label %43
 
 ; <label>:43                                      ; preds = %38
   %44 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
   store i8 %42, i8 addrspace(1)* %44
   %45 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %45, null
-  br i1 %NullCheck2, label %46, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.EncoderNLS addrspace(1)* %45, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %46
 
 ; <label>:46                                      ; preds = %43
   %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %45, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %47
   %48 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.EncoderNLS addrspace(1)* %48, null
-  br i1 %NullCheck4, label %49, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.EncoderNLS addrspace(1)* %48, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %49
 
 ; <label>:49                                      ; preds = %46
   %50 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %48, i32 0, i32 3
@@ -15144,8 +17421,8 @@ entry:
   %55 = load i32, i32* %arg4
   %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck6, label %58, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
   %59 = load i64, i64 addrspace(1)* %57
@@ -15163,15 +17440,15 @@ ThrowNullRef:                                     ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %43
+ThrowNullRef2:                                    ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %46
+ThrowNullRef4:                                    ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %49
+ThrowNullRef6:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -15199,8 +17476,8 @@ entry:
   %4 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0 to %System.IO.ConsoleStream addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*)(%System.IO.ConsoleStream addrspace(1)* %4, %"System.Byte[]" addrspace(1)* %1, i32 %2, i32 %3)
   %5 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
@@ -15285,8 +17562,8 @@ entry:
 
 ; <label>:22                                      ; preds = %8
   %23 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %23, null
-  br i1 %NullCheck, label %24, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Byte[]" addrspace(1)* %23, null
+  br i1 %NullCheck, label %ThrowNullRef, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
@@ -15308,8 +17585,8 @@ entry:
 
 ; <label>:36                                      ; preds = %24
   %37 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %37, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.ConsoleStream addrspace(1)* %37, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %37, i32 0, i32 4
@@ -15330,13 +17607,138 @@ ThrowNullRef:                                     ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %36
+ThrowNullRef2:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
-Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
+Successfully read WindowsConsoleStream.WriteFileNative
+
+define i32 @WindowsConsoleStream.WriteFileNative(i64 %param0, %"System.Byte[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i64
+  %arg1 = alloca %"System.Byte[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i8 addrspace(1)*
+  %loc2 = alloca %"System.Byte[]" addrspace(1)*
+  %loc3 = alloca i32
+  store i64 %param0, i64* %arg0
+  store %"System.Byte[]" addrspace(1)* %param1, %"System.Byte[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Byte[]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = zext i32 %3 to i64
+  %5 = icmp ne i64 %4, 0
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %1
+  ret i32 0
+
+; <label>:7                                       ; preds = %1
+  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  store %"System.Byte[]" addrspace(1)* %8, %"System.Byte[]" addrspace(1)** %loc2
+  %9 = icmp eq %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %9, label %18, label %10
+
+; <label>:10                                      ; preds = %7
+  %11 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc2
+  %NullCheck1 = icmp eq %"System.Byte[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %11, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp ne i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %7, %12
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc1
+  br label %27
+
+; <label>:19                                      ; preds = %12
+  %20 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc2
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %20, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %BoundsCheck = icmp uge i64 0, %24
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %25
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %20, i32 0, i32 3, i32 0
+  store i8 addrspace(1)* %26, i8 addrspace(1)** %loc1
+  br label %27
+
+; <label>:27                                      ; preds = %18, %25
+  %28 = load i64, i64* %arg0
+  %29 = load i8 addrspace(1)*, i8 addrspace(1)** %loc1
+  %30 = ptrtoint i8 addrspace(1)* %29 to i64
+  %31 = load i32, i32* %arg2
+  %32 = sext i32 %31 to i64
+  %33 = add i64 %30, %32
+  %34 = load i32, i32* %arg3
+  %35 = addrspacecast i32* %loc3 to i32 addrspace(1)*
+  %36 = inttoptr i64 %33 to i8*
+  %37 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i8*, i32, i32 addrspace(1)*, i64)*)(i64 %28, i8* %36, i32 %34, i32 addrspace(1)* %35, i64 0)
+  %38 = icmp ugt i32 %37, 0
+  %39 = sext i1 %38 to i32
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc1
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %42, label %41
+
+; <label>:41                                      ; preds = %27
+  ret i32 0
+
+; <label>:42                                      ; preds = %27
+  %43 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  store i32 %43, i32* %loc0
+  %44 = load i32, i32* %loc0
+  %45 = icmp eq i32 %44, 232
+  br i1 %45, label %49, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = load i32, i32* %loc0
+  %48 = icmp ne i32 %47, 109
+  br i1 %48, label %50, label %49
+
+; <label>:49                                      ; preds = %42, %46
+  ret i32 0
+
+; <label>:50                                      ; preds = %46
+  %51 = load i32, i32* %loc0
+  ret i32 %51
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
 Successfully read WindowsConsoleStream.Flush
 
@@ -15345,8 +17747,8 @@ entry:
   %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
   store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
@@ -15381,8 +17783,8 @@ entry:
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
   %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load i64, i64 addrspace(1)* %1

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblSub.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblSub.error.txt
@@ -25,8 +25,8 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
@@ -40,8 +40,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
   %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
@@ -75,7 +75,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -90,8 +90,8 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %NullCheck = icmp ne i8 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = load i8, i8 addrspace(1)* %0, align 8
@@ -125,8 +125,8 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
@@ -159,8 +159,8 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -184,8 +184,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
   store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
@@ -195,8 +195,8 @@ entry:
 ; <label>:4                                       ; preds = %1
   %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
   %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
@@ -206,8 +206,8 @@ entry:
   %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
@@ -221,14 +221,14 @@ entry:
 
 ; <label>:17                                      ; preds = %14
   %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
   %21 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
@@ -238,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -249,8 +249,8 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
@@ -261,27 +261,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %30
+ThrowNullRef10:                                   ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -301,7 +301,89 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
-Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
+Successfully read AppDomainSetup.GetUnsecureApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.GetUnsecureApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %NullCheck = icmp eq %"System.String[]" addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %BoundsCheck = icmp uge i64 0, %5
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %6
+
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 3, i32 0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
+  ret %System.String addrspace(1)* %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_Value using LLILCJit
+Successfully read AppDomainSetup.get_Value
+
+define %"System.String[]" addrspace(1)* @AppDomainSetup.get_Value(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.String[]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 18)
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.String[]" addrspace(1)* addrspace(1)*, %"System.String[]" addrspace(1)*)*)(%"System.String[]" addrspace(1)* addrspace(1)* %9, %"System.String[]" addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %11, i32 0, i32 1
+  %14 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %13, align 8
+  ret %"System.String[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -319,8 +401,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -368,16 +450,16 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
   %5 = load i32, i32 addrspace(1)* %4
   %6 = sub i32 %5, 1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -389,7 +471,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -421,8 +503,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
@@ -456,8 +538,8 @@ entry:
 ; <label>:27                                      ; preds = %19
   %28 = load i32, i32* %arg1
   %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
-  br i1 %NullCheck2, label %30, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %29, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %30
 
 ; <label>:30                                      ; preds = %27
   %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
@@ -493,8 +575,8 @@ entry:
 ; <label>:49                                      ; preds = %46
   %50 = load i32, i32* %arg2
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck4, label %52, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
@@ -517,11 +599,11 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %27
+ThrowNullRef2:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %49
+ThrowNullRef4:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -544,16 +626,16 @@ entry:
   %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %0)
   store %System.String addrspace(1)* %1, %System.String addrspace(1)** %loc0
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 2
   %5 = bitcast [0 x i16] addrspace(1)* %4 to i16 addrspace(1)*
   store i16 addrspace(1)* %5, i16 addrspace(1)** %loc1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %3
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2
@@ -580,7 +662,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -691,15 +773,15 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %NullCheck132 = icmp ne i8* %21, null
-  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+  %NullCheck131 = icmp eq i8* %21, null
+  br i1 %NullCheck131, label %ThrowNullRef132, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = load i8, i8* %21, align 8
   %24 = zext i8 %23 to i32
   %25 = trunc i32 %24 to i8
-  %NullCheck134 = icmp ne i8* %20, null
-  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+  %NullCheck133 = icmp eq i8* %20, null
+  br i1 %NullCheck133, label %ThrowNullRef134, label %26
 
 ; <label>:26                                      ; preds = %22
   store i8 %25, i8* %20, align 8
@@ -709,16 +791,16 @@ entry:
   %28 = load i8*, i8** %arg0
   %29 = load i8*, i8** %arg1
   %30 = bitcast i8* %29 to i16*
-  %NullCheck128 = icmp ne i16* %30, null
-  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+  %NullCheck127 = icmp eq i16* %30, null
+  br i1 %NullCheck127, label %ThrowNullRef128, label %31
 
 ; <label>:31                                      ; preds = %27
   %32 = load i16, i16* %30, align 8
   %33 = sext i16 %32 to i32
   %34 = bitcast i8* %28 to i16*
   %35 = trunc i32 %33 to i16
-  %NullCheck130 = icmp ne i16* %34, null
-  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+  %NullCheck129 = icmp eq i16* %34, null
+  br i1 %NullCheck129, label %ThrowNullRef130, label %36
 
 ; <label>:36                                      ; preds = %31
   store i16 %35, i16* %34, align 8
@@ -728,16 +810,16 @@ entry:
   %38 = load i8*, i8** %arg0
   %39 = load i8*, i8** %arg1
   %40 = bitcast i8* %39 to i16*
-  %NullCheck120 = icmp ne i16* %40, null
-  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+  %NullCheck119 = icmp eq i16* %40, null
+  br i1 %NullCheck119, label %ThrowNullRef120, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i16, i16* %40, align 8
   %43 = sext i16 %42 to i32
   %44 = bitcast i8* %38 to i16*
   %45 = trunc i32 %43 to i16
-  %NullCheck122 = icmp ne i16* %44, null
-  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+  %NullCheck121 = icmp eq i16* %44, null
+  br i1 %NullCheck121, label %ThrowNullRef122, label %46
 
 ; <label>:46                                      ; preds = %41
   store i16 %45, i16* %44, align 8
@@ -745,15 +827,15 @@ entry:
   %48 = getelementptr inbounds i8, i8* %47, i64 2
   %49 = load i8*, i8** %arg1
   %50 = getelementptr inbounds i8, i8* %49, i64 2
-  %NullCheck124 = icmp ne i8* %50, null
-  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+  %NullCheck123 = icmp eq i8* %50, null
+  br i1 %NullCheck123, label %ThrowNullRef124, label %51
 
 ; <label>:51                                      ; preds = %46
   %52 = load i8, i8* %50, align 8
   %53 = zext i8 %52 to i32
   %54 = trunc i32 %53 to i8
-  %NullCheck126 = icmp ne i8* %48, null
-  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+  %NullCheck125 = icmp eq i8* %48, null
+  br i1 %NullCheck125, label %ThrowNullRef126, label %55
 
 ; <label>:55                                      ; preds = %51
   store i8 %54, i8* %48, align 8
@@ -763,14 +845,14 @@ entry:
   %57 = load i8*, i8** %arg0
   %58 = load i8*, i8** %arg1
   %59 = bitcast i8* %58 to i32*
-  %NullCheck116 = icmp ne i32* %59, null
-  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+  %NullCheck115 = icmp eq i32* %59, null
+  br i1 %NullCheck115, label %ThrowNullRef116, label %60
 
 ; <label>:60                                      ; preds = %56
   %61 = load i32, i32* %59, align 8
   %62 = bitcast i8* %57 to i32*
-  %NullCheck118 = icmp ne i32* %62, null
-  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+  %NullCheck117 = icmp eq i32* %62, null
+  br i1 %NullCheck117, label %ThrowNullRef118, label %63
 
 ; <label>:63                                      ; preds = %60
   store i32 %61, i32* %62, align 8
@@ -780,14 +862,14 @@ entry:
   %65 = load i8*, i8** %arg0
   %66 = load i8*, i8** %arg1
   %67 = bitcast i8* %66 to i32*
-  %NullCheck108 = icmp ne i32* %67, null
-  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+  %NullCheck107 = icmp eq i32* %67, null
+  br i1 %NullCheck107, label %ThrowNullRef108, label %68
 
 ; <label>:68                                      ; preds = %64
   %69 = load i32, i32* %67, align 8
   %70 = bitcast i8* %65 to i32*
-  %NullCheck110 = icmp ne i32* %70, null
-  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+  %NullCheck109 = icmp eq i32* %70, null
+  br i1 %NullCheck109, label %ThrowNullRef110, label %71
 
 ; <label>:71                                      ; preds = %68
   store i32 %69, i32* %70, align 8
@@ -795,15 +877,15 @@ entry:
   %73 = getelementptr inbounds i8, i8* %72, i64 4
   %74 = load i8*, i8** %arg1
   %75 = getelementptr inbounds i8, i8* %74, i64 4
-  %NullCheck112 = icmp ne i8* %75, null
-  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+  %NullCheck111 = icmp eq i8* %75, null
+  br i1 %NullCheck111, label %ThrowNullRef112, label %76
 
 ; <label>:76                                      ; preds = %71
   %77 = load i8, i8* %75, align 8
   %78 = zext i8 %77 to i32
   %79 = trunc i32 %78 to i8
-  %NullCheck114 = icmp ne i8* %73, null
-  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+  %NullCheck113 = icmp eq i8* %73, null
+  br i1 %NullCheck113, label %ThrowNullRef114, label %80
 
 ; <label>:80                                      ; preds = %76
   store i8 %79, i8* %73, align 8
@@ -813,14 +895,14 @@ entry:
   %82 = load i8*, i8** %arg0
   %83 = load i8*, i8** %arg1
   %84 = bitcast i8* %83 to i32*
-  %NullCheck100 = icmp ne i32* %84, null
-  br i1 %NullCheck100, label %85, label %ThrowNullRef99
+  %NullCheck99 = icmp eq i32* %84, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %85
 
 ; <label>:85                                      ; preds = %81
   %86 = load i32, i32* %84, align 8
   %87 = bitcast i8* %82 to i32*
-  %NullCheck102 = icmp ne i32* %87, null
-  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+  %NullCheck101 = icmp eq i32* %87, null
+  br i1 %NullCheck101, label %ThrowNullRef102, label %88
 
 ; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
@@ -829,16 +911,16 @@ entry:
   %91 = load i8*, i8** %arg1
   %92 = getelementptr inbounds i8, i8* %91, i64 4
   %93 = bitcast i8* %92 to i16*
-  %NullCheck104 = icmp ne i16* %93, null
-  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+  %NullCheck103 = icmp eq i16* %93, null
+  br i1 %NullCheck103, label %ThrowNullRef104, label %94
 
 ; <label>:94                                      ; preds = %88
   %95 = load i16, i16* %93, align 8
   %96 = sext i16 %95 to i32
   %97 = bitcast i8* %90 to i16*
   %98 = trunc i32 %96 to i16
-  %NullCheck106 = icmp ne i16* %97, null
-  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+  %NullCheck105 = icmp eq i16* %97, null
+  br i1 %NullCheck105, label %ThrowNullRef106, label %99
 
 ; <label>:99                                      ; preds = %94
   store i16 %98, i16* %97, align 8
@@ -848,14 +930,14 @@ entry:
   %101 = load i8*, i8** %arg0
   %102 = load i8*, i8** %arg1
   %103 = bitcast i8* %102 to i32*
-  %NullCheck88 = icmp ne i32* %103, null
-  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+  %NullCheck87 = icmp eq i32* %103, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %104
 
 ; <label>:104                                     ; preds = %100
   %105 = load i32, i32* %103, align 8
   %106 = bitcast i8* %101 to i32*
-  %NullCheck90 = icmp ne i32* %106, null
-  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+  %NullCheck89 = icmp eq i32* %106, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %107
 
 ; <label>:107                                     ; preds = %104
   store i32 %105, i32* %106, align 8
@@ -864,16 +946,16 @@ entry:
   %110 = load i8*, i8** %arg1
   %111 = getelementptr inbounds i8, i8* %110, i64 4
   %112 = bitcast i8* %111 to i16*
-  %NullCheck92 = icmp ne i16* %112, null
-  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+  %NullCheck91 = icmp eq i16* %112, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %113
 
 ; <label>:113                                     ; preds = %107
   %114 = load i16, i16* %112, align 8
   %115 = sext i16 %114 to i32
   %116 = bitcast i8* %109 to i16*
   %117 = trunc i32 %115 to i16
-  %NullCheck94 = icmp ne i16* %116, null
-  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+  %NullCheck93 = icmp eq i16* %116, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %118
 
 ; <label>:118                                     ; preds = %113
   store i16 %117, i16* %116, align 8
@@ -881,15 +963,15 @@ entry:
   %120 = getelementptr inbounds i8, i8* %119, i64 6
   %121 = load i8*, i8** %arg1
   %122 = getelementptr inbounds i8, i8* %121, i64 6
-  %NullCheck96 = icmp ne i8* %122, null
-  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+  %NullCheck95 = icmp eq i8* %122, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %123
 
 ; <label>:123                                     ; preds = %118
   %124 = load i8, i8* %122, align 8
   %125 = zext i8 %124 to i32
   %126 = trunc i32 %125 to i8
-  %NullCheck98 = icmp ne i8* %120, null
-  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+  %NullCheck97 = icmp eq i8* %120, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %127
 
 ; <label>:127                                     ; preds = %123
   store i8 %126, i8* %120, align 8
@@ -899,14 +981,14 @@ entry:
   %129 = load i8*, i8** %arg0
   %130 = load i8*, i8** %arg1
   %131 = bitcast i8* %130 to i64*
-  %NullCheck84 = icmp ne i64* %131, null
-  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+  %NullCheck83 = icmp eq i64* %131, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %132
 
 ; <label>:132                                     ; preds = %128
   %133 = load i64, i64* %131, align 8
   %134 = bitcast i8* %129 to i64*
-  %NullCheck86 = icmp ne i64* %134, null
-  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+  %NullCheck85 = icmp eq i64* %134, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %135
 
 ; <label>:135                                     ; preds = %132
   store i64 %133, i64* %134, align 8
@@ -916,14 +998,14 @@ entry:
   %137 = load i8*, i8** %arg0
   %138 = load i8*, i8** %arg1
   %139 = bitcast i8* %138 to i64*
-  %NullCheck76 = icmp ne i64* %139, null
-  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+  %NullCheck75 = icmp eq i64* %139, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %140
 
 ; <label>:140                                     ; preds = %136
   %141 = load i64, i64* %139, align 8
   %142 = bitcast i8* %137 to i64*
-  %NullCheck78 = icmp ne i64* %142, null
-  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+  %NullCheck77 = icmp eq i64* %142, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %143
 
 ; <label>:143                                     ; preds = %140
   store i64 %141, i64* %142, align 8
@@ -931,15 +1013,15 @@ entry:
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %NullCheck80 = icmp ne i8* %147, null
-  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+  %NullCheck79 = icmp eq i8* %147, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %148
 
 ; <label>:148                                     ; preds = %143
   %149 = load i8, i8* %147, align 8
   %150 = zext i8 %149 to i32
   %151 = trunc i32 %150 to i8
-  %NullCheck82 = icmp ne i8* %145, null
-  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+  %NullCheck81 = icmp eq i8* %145, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %152
 
 ; <label>:152                                     ; preds = %148
   store i8 %151, i8* %145, align 8
@@ -949,14 +1031,14 @@ entry:
   %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
   %156 = bitcast i8* %155 to i64*
-  %NullCheck68 = icmp ne i64* %156, null
-  br i1 %NullCheck68, label %157, label %ThrowNullRef67
+  %NullCheck67 = icmp eq i64* %156, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %157
 
 ; <label>:157                                     ; preds = %153
   %158 = load i64, i64* %156, align 8
   %159 = bitcast i8* %154 to i64*
-  %NullCheck70 = icmp ne i64* %159, null
-  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+  %NullCheck69 = icmp eq i64* %159, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %160
 
 ; <label>:160                                     ; preds = %157
   store i64 %158, i64* %159, align 8
@@ -965,16 +1047,16 @@ entry:
   %163 = load i8*, i8** %arg1
   %164 = getelementptr inbounds i8, i8* %163, i64 8
   %165 = bitcast i8* %164 to i16*
-  %NullCheck72 = icmp ne i16* %165, null
-  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+  %NullCheck71 = icmp eq i16* %165, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %166
 
 ; <label>:166                                     ; preds = %160
   %167 = load i16, i16* %165, align 8
   %168 = sext i16 %167 to i32
   %169 = bitcast i8* %162 to i16*
   %170 = trunc i32 %168 to i16
-  %NullCheck74 = icmp ne i16* %169, null
-  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+  %NullCheck73 = icmp eq i16* %169, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %171
 
 ; <label>:171                                     ; preds = %166
   store i16 %170, i16* %169, align 8
@@ -984,14 +1066,14 @@ entry:
   %173 = load i8*, i8** %arg0
   %174 = load i8*, i8** %arg1
   %175 = bitcast i8* %174 to i64*
-  %NullCheck56 = icmp ne i64* %175, null
-  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+  %NullCheck55 = icmp eq i64* %175, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %176
 
 ; <label>:176                                     ; preds = %172
   %177 = load i64, i64* %175, align 8
   %178 = bitcast i8* %173 to i64*
-  %NullCheck58 = icmp ne i64* %178, null
-  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+  %NullCheck57 = icmp eq i64* %178, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %179
 
 ; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
@@ -1000,16 +1082,16 @@ entry:
   %182 = load i8*, i8** %arg1
   %183 = getelementptr inbounds i8, i8* %182, i64 8
   %184 = bitcast i8* %183 to i16*
-  %NullCheck60 = icmp ne i16* %184, null
-  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+  %NullCheck59 = icmp eq i16* %184, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %185
 
 ; <label>:185                                     ; preds = %179
   %186 = load i16, i16* %184, align 8
   %187 = sext i16 %186 to i32
   %188 = bitcast i8* %181 to i16*
   %189 = trunc i32 %187 to i16
-  %NullCheck62 = icmp ne i16* %188, null
-  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+  %NullCheck61 = icmp eq i16* %188, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %190
 
 ; <label>:190                                     ; preds = %185
   store i16 %189, i16* %188, align 8
@@ -1017,15 +1099,15 @@ entry:
   %192 = getelementptr inbounds i8, i8* %191, i64 10
   %193 = load i8*, i8** %arg1
   %194 = getelementptr inbounds i8, i8* %193, i64 10
-  %NullCheck64 = icmp ne i8* %194, null
-  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+  %NullCheck63 = icmp eq i8* %194, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %195
 
 ; <label>:195                                     ; preds = %190
   %196 = load i8, i8* %194, align 8
   %197 = zext i8 %196 to i32
   %198 = trunc i32 %197 to i8
-  %NullCheck66 = icmp ne i8* %192, null
-  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+  %NullCheck65 = icmp eq i8* %192, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %199
 
 ; <label>:199                                     ; preds = %195
   store i8 %198, i8* %192, align 8
@@ -1035,14 +1117,14 @@ entry:
   %201 = load i8*, i8** %arg0
   %202 = load i8*, i8** %arg1
   %203 = bitcast i8* %202 to i64*
-  %NullCheck48 = icmp ne i64* %203, null
-  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+  %NullCheck47 = icmp eq i64* %203, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %204
 
 ; <label>:204                                     ; preds = %200
   %205 = load i64, i64* %203, align 8
   %206 = bitcast i8* %201 to i64*
-  %NullCheck50 = icmp ne i64* %206, null
-  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+  %NullCheck49 = icmp eq i64* %206, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %207
 
 ; <label>:207                                     ; preds = %204
   store i64 %205, i64* %206, align 8
@@ -1051,14 +1133,14 @@ entry:
   %210 = load i8*, i8** %arg1
   %211 = getelementptr inbounds i8, i8* %210, i64 8
   %212 = bitcast i8* %211 to i32*
-  %NullCheck52 = icmp ne i32* %212, null
-  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+  %NullCheck51 = icmp eq i32* %212, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %213
 
 ; <label>:213                                     ; preds = %207
   %214 = load i32, i32* %212, align 8
   %215 = bitcast i8* %209 to i32*
-  %NullCheck54 = icmp ne i32* %215, null
-  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+  %NullCheck53 = icmp eq i32* %215, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %216
 
 ; <label>:216                                     ; preds = %213
   store i32 %214, i32* %215, align 8
@@ -1068,14 +1150,14 @@ entry:
   %218 = load i8*, i8** %arg0
   %219 = load i8*, i8** %arg1
   %220 = bitcast i8* %219 to i64*
-  %NullCheck36 = icmp ne i64* %220, null
-  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64* %220, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %221
 
 ; <label>:221                                     ; preds = %217
   %222 = load i64, i64* %220, align 8
   %223 = bitcast i8* %218 to i64*
-  %NullCheck38 = icmp ne i64* %223, null
-  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+  %NullCheck37 = icmp eq i64* %223, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %224
 
 ; <label>:224                                     ; preds = %221
   store i64 %222, i64* %223, align 8
@@ -1084,14 +1166,14 @@ entry:
   %227 = load i8*, i8** %arg1
   %228 = getelementptr inbounds i8, i8* %227, i64 8
   %229 = bitcast i8* %228 to i32*
-  %NullCheck40 = icmp ne i32* %229, null
-  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i32* %229, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %230
 
 ; <label>:230                                     ; preds = %224
   %231 = load i32, i32* %229, align 8
   %232 = bitcast i8* %226 to i32*
-  %NullCheck42 = icmp ne i32* %232, null
-  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+  %NullCheck41 = icmp eq i32* %232, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %233
 
 ; <label>:233                                     ; preds = %230
   store i32 %231, i32* %232, align 8
@@ -1099,15 +1181,15 @@ entry:
   %235 = getelementptr inbounds i8, i8* %234, i64 12
   %236 = load i8*, i8** %arg1
   %237 = getelementptr inbounds i8, i8* %236, i64 12
-  %NullCheck44 = icmp ne i8* %237, null
-  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i8* %237, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %238
 
 ; <label>:238                                     ; preds = %233
   %239 = load i8, i8* %237, align 8
   %240 = zext i8 %239 to i32
   %241 = trunc i32 %240 to i8
-  %NullCheck46 = icmp ne i8* %235, null
-  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+  %NullCheck45 = icmp eq i8* %235, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %242
 
 ; <label>:242                                     ; preds = %238
   store i8 %241, i8* %235, align 8
@@ -1117,14 +1199,14 @@ entry:
   %244 = load i8*, i8** %arg0
   %245 = load i8*, i8** %arg1
   %246 = bitcast i8* %245 to i64*
-  %NullCheck24 = icmp ne i64* %246, null
-  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64* %246, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %247
 
 ; <label>:247                                     ; preds = %243
   %248 = load i64, i64* %246, align 8
   %249 = bitcast i8* %244 to i64*
-  %NullCheck26 = icmp ne i64* %249, null
-  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64* %249, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %250
 
 ; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
@@ -1133,14 +1215,14 @@ entry:
   %253 = load i8*, i8** %arg1
   %254 = getelementptr inbounds i8, i8* %253, i64 8
   %255 = bitcast i8* %254 to i32*
-  %NullCheck28 = icmp ne i32* %255, null
-  br i1 %NullCheck28, label %256, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i32* %255, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %256
 
 ; <label>:256                                     ; preds = %250
   %257 = load i32, i32* %255, align 8
   %258 = bitcast i8* %252 to i32*
-  %NullCheck30 = icmp ne i32* %258, null
-  br i1 %NullCheck30, label %259, label %ThrowNullRef29
+  %NullCheck29 = icmp eq i32* %258, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %259
 
 ; <label>:259                                     ; preds = %256
   store i32 %257, i32* %258, align 8
@@ -1149,16 +1231,16 @@ entry:
   %262 = load i8*, i8** %arg1
   %263 = getelementptr inbounds i8, i8* %262, i64 12
   %264 = bitcast i8* %263 to i16*
-  %NullCheck32 = icmp ne i16* %264, null
-  br i1 %NullCheck32, label %265, label %ThrowNullRef31
+  %NullCheck31 = icmp eq i16* %264, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %265
 
 ; <label>:265                                     ; preds = %259
   %266 = load i16, i16* %264, align 8
   %267 = sext i16 %266 to i32
   %268 = bitcast i8* %261 to i16*
   %269 = trunc i32 %267 to i16
-  %NullCheck34 = icmp ne i16* %268, null
-  br i1 %NullCheck34, label %270, label %ThrowNullRef33
+  %NullCheck33 = icmp eq i16* %268, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %270
 
 ; <label>:270                                     ; preds = %265
   store i16 %269, i16* %268, align 8
@@ -1168,14 +1250,14 @@ entry:
   %272 = load i8*, i8** %arg0
   %273 = load i8*, i8** %arg1
   %274 = bitcast i8* %273 to i64*
-  %NullCheck8 = icmp ne i64* %274, null
-  br i1 %NullCheck8, label %275, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64* %274, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %275
 
 ; <label>:275                                     ; preds = %271
   %276 = load i64, i64* %274, align 8
   %277 = bitcast i8* %272 to i64*
-  %NullCheck10 = icmp ne i64* %277, null
-  br i1 %NullCheck10, label %278, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %277, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %278
 
 ; <label>:278                                     ; preds = %275
   store i64 %276, i64* %277, align 8
@@ -1184,14 +1266,14 @@ entry:
   %281 = load i8*, i8** %arg1
   %282 = getelementptr inbounds i8, i8* %281, i64 8
   %283 = bitcast i8* %282 to i32*
-  %NullCheck12 = icmp ne i32* %283, null
-  br i1 %NullCheck12, label %284, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i32* %283, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %284
 
 ; <label>:284                                     ; preds = %278
   %285 = load i32, i32* %283, align 8
   %286 = bitcast i8* %280 to i32*
-  %NullCheck14 = icmp ne i32* %286, null
-  br i1 %NullCheck14, label %287, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i32* %286, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %287
 
 ; <label>:287                                     ; preds = %284
   store i32 %285, i32* %286, align 8
@@ -1200,16 +1282,16 @@ entry:
   %290 = load i8*, i8** %arg1
   %291 = getelementptr inbounds i8, i8* %290, i64 12
   %292 = bitcast i8* %291 to i16*
-  %NullCheck16 = icmp ne i16* %292, null
-  br i1 %NullCheck16, label %293, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i16* %292, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %293
 
 ; <label>:293                                     ; preds = %287
   %294 = load i16, i16* %292, align 8
   %295 = sext i16 %294 to i32
   %296 = bitcast i8* %289 to i16*
   %297 = trunc i32 %295 to i16
-  %NullCheck18 = icmp ne i16* %296, null
-  br i1 %NullCheck18, label %298, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i16* %296, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %298
 
 ; <label>:298                                     ; preds = %293
   store i16 %297, i16* %296, align 8
@@ -1217,15 +1299,15 @@ entry:
   %300 = getelementptr inbounds i8, i8* %299, i64 14
   %301 = load i8*, i8** %arg1
   %302 = getelementptr inbounds i8, i8* %301, i64 14
-  %NullCheck20 = icmp ne i8* %302, null
-  br i1 %NullCheck20, label %303, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i8* %302, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %303
 
 ; <label>:303                                     ; preds = %298
   %304 = load i8, i8* %302, align 8
   %305 = zext i8 %304 to i32
   %306 = trunc i32 %305 to i8
-  %NullCheck22 = icmp ne i8* %300, null
-  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i8* %300, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %307
 
 ; <label>:307                                     ; preds = %303
   store i8 %306, i8* %300, align 8
@@ -1235,14 +1317,14 @@ entry:
   %309 = load i8*, i8** %arg0
   %310 = load i8*, i8** %arg1
   %311 = bitcast i8* %310 to i64*
-  %NullCheck = icmp ne i64* %311, null
-  br i1 %NullCheck, label %312, label %ThrowNullRef
+  %NullCheck = icmp eq i64* %311, null
+  br i1 %NullCheck, label %ThrowNullRef, label %312
 
 ; <label>:312                                     ; preds = %308
   %313 = load i64, i64* %311, align 8
   %314 = bitcast i8* %309 to i64*
-  %NullCheck2 = icmp ne i64* %314, null
-  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64* %314, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %315
 
 ; <label>:315                                     ; preds = %312
   store i64 %313, i64* %314, align 8
@@ -1251,14 +1333,14 @@ entry:
   %318 = load i8*, i8** %arg1
   %319 = getelementptr inbounds i8, i8* %318, i64 8
   %320 = bitcast i8* %319 to i64*
-  %NullCheck4 = icmp ne i64* %320, null
-  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64* %320, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %321
 
 ; <label>:321                                     ; preds = %315
   %322 = load i64, i64* %320, align 8
   %323 = bitcast i8* %317 to i64*
-  %NullCheck6 = icmp ne i64* %323, null
-  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64* %323, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %324
 
 ; <label>:324                                     ; preds = %321
   store i64 %322, i64* %323, align 8
@@ -1286,15 +1368,15 @@ entry:
 ; <label>:338                                     ; preds = %333
   %339 = load i8*, i8** %arg0
   %340 = load i8*, i8** %arg1
-  %NullCheck136 = icmp ne i8* %340, null
-  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+  %NullCheck135 = icmp eq i8* %340, null
+  br i1 %NullCheck135, label %ThrowNullRef136, label %341
 
 ; <label>:341                                     ; preds = %338
   %342 = load i8, i8* %340, align 8
   %343 = zext i8 %342 to i32
   %344 = trunc i32 %343 to i8
-  %NullCheck138 = icmp ne i8* %339, null
-  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+  %NullCheck137 = icmp eq i8* %339, null
+  br i1 %NullCheck137, label %ThrowNullRef138, label %345
 
 ; <label>:345                                     ; preds = %341
   store i8 %344, i8* %339, align 8
@@ -1317,16 +1399,16 @@ entry:
   %357 = load i8*, i8** %arg0
   %358 = load i8*, i8** %arg1
   %359 = bitcast i8* %358 to i16*
-  %NullCheck140 = icmp ne i16* %359, null
-  br i1 %NullCheck140, label %360, label %ThrowNullRef139
+  %NullCheck139 = icmp eq i16* %359, null
+  br i1 %NullCheck139, label %ThrowNullRef140, label %360
 
 ; <label>:360                                     ; preds = %356
   %361 = load i16, i16* %359, align 8
   %362 = sext i16 %361 to i32
   %363 = bitcast i8* %357 to i16*
   %364 = trunc i32 %362 to i16
-  %NullCheck142 = icmp ne i16* %363, null
-  br i1 %NullCheck142, label %365, label %ThrowNullRef141
+  %NullCheck141 = icmp eq i16* %363, null
+  br i1 %NullCheck141, label %ThrowNullRef142, label %365
 
 ; <label>:365                                     ; preds = %360
   store i16 %364, i16* %363, align 8
@@ -1352,14 +1434,14 @@ entry:
   %378 = load i8*, i8** %arg0
   %379 = load i8*, i8** %arg1
   %380 = bitcast i8* %379 to i32*
-  %NullCheck144 = icmp ne i32* %380, null
-  br i1 %NullCheck144, label %381, label %ThrowNullRef143
+  %NullCheck143 = icmp eq i32* %380, null
+  br i1 %NullCheck143, label %ThrowNullRef144, label %381
 
 ; <label>:381                                     ; preds = %377
   %382 = load i32, i32* %380, align 8
   %383 = bitcast i8* %378 to i32*
-  %NullCheck146 = icmp ne i32* %383, null
-  br i1 %NullCheck146, label %384, label %ThrowNullRef145
+  %NullCheck145 = icmp eq i32* %383, null
+  br i1 %NullCheck145, label %ThrowNullRef146, label %384
 
 ; <label>:384                                     ; preds = %381
   store i32 %382, i32* %383, align 8
@@ -1384,14 +1466,14 @@ entry:
   %395 = load i8*, i8** %arg0
   %396 = load i8*, i8** %arg1
   %397 = bitcast i8* %396 to i64*
-  %NullCheck164 = icmp ne i64* %397, null
-  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+  %NullCheck163 = icmp eq i64* %397, null
+  br i1 %NullCheck163, label %ThrowNullRef164, label %398
 
 ; <label>:398                                     ; preds = %394
   %399 = load i64, i64* %397, align 8
   %400 = bitcast i8* %395 to i64*
-  %NullCheck166 = icmp ne i64* %400, null
-  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+  %NullCheck165 = icmp eq i64* %400, null
+  br i1 %NullCheck165, label %ThrowNullRef166, label %401
 
 ; <label>:401                                     ; preds = %398
   store i64 %399, i64* %400, align 8
@@ -1400,14 +1482,14 @@ entry:
   %404 = load i8*, i8** %arg1
   %405 = getelementptr inbounds i8, i8* %404, i64 8
   %406 = bitcast i8* %405 to i64*
-  %NullCheck168 = icmp ne i64* %406, null
-  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+  %NullCheck167 = icmp eq i64* %406, null
+  br i1 %NullCheck167, label %ThrowNullRef168, label %407
 
 ; <label>:407                                     ; preds = %401
   %408 = load i64, i64* %406, align 8
   %409 = bitcast i8* %403 to i64*
-  %NullCheck170 = icmp ne i64* %409, null
-  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+  %NullCheck169 = icmp eq i64* %409, null
+  br i1 %NullCheck169, label %ThrowNullRef170, label %410
 
 ; <label>:410                                     ; preds = %407
   store i64 %408, i64* %409, align 8
@@ -1437,14 +1519,14 @@ entry:
   %425 = load i8*, i8** %arg0
   %426 = load i8*, i8** %arg1
   %427 = bitcast i8* %426 to i64*
-  %NullCheck148 = icmp ne i64* %427, null
-  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+  %NullCheck147 = icmp eq i64* %427, null
+  br i1 %NullCheck147, label %ThrowNullRef148, label %428
 
 ; <label>:428                                     ; preds = %424
   %429 = load i64, i64* %427, align 8
   %430 = bitcast i8* %425 to i64*
-  %NullCheck150 = icmp ne i64* %430, null
-  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+  %NullCheck149 = icmp eq i64* %430, null
+  br i1 %NullCheck149, label %ThrowNullRef150, label %431
 
 ; <label>:431                                     ; preds = %428
   store i64 %429, i64* %430, align 8
@@ -1466,14 +1548,14 @@ entry:
   %441 = load i8*, i8** %arg0
   %442 = load i8*, i8** %arg1
   %443 = bitcast i8* %442 to i32*
-  %NullCheck152 = icmp ne i32* %443, null
-  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+  %NullCheck151 = icmp eq i32* %443, null
+  br i1 %NullCheck151, label %ThrowNullRef152, label %444
 
 ; <label>:444                                     ; preds = %440
   %445 = load i32, i32* %443, align 8
   %446 = bitcast i8* %441 to i32*
-  %NullCheck154 = icmp ne i32* %446, null
-  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+  %NullCheck153 = icmp eq i32* %446, null
+  br i1 %NullCheck153, label %ThrowNullRef154, label %447
 
 ; <label>:447                                     ; preds = %444
   store i32 %445, i32* %446, align 8
@@ -1495,16 +1577,16 @@ entry:
   %457 = load i8*, i8** %arg0
   %458 = load i8*, i8** %arg1
   %459 = bitcast i8* %458 to i16*
-  %NullCheck156 = icmp ne i16* %459, null
-  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+  %NullCheck155 = icmp eq i16* %459, null
+  br i1 %NullCheck155, label %ThrowNullRef156, label %460
 
 ; <label>:460                                     ; preds = %456
   %461 = load i16, i16* %459, align 8
   %462 = sext i16 %461 to i32
   %463 = bitcast i8* %457 to i16*
   %464 = trunc i32 %462 to i16
-  %NullCheck158 = icmp ne i16* %463, null
-  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+  %NullCheck157 = icmp eq i16* %463, null
+  br i1 %NullCheck157, label %ThrowNullRef158, label %465
 
 ; <label>:465                                     ; preds = %460
   store i16 %464, i16* %463, align 8
@@ -1525,15 +1607,15 @@ entry:
 ; <label>:474                                     ; preds = %470
   %475 = load i8*, i8** %arg0
   %476 = load i8*, i8** %arg1
-  %NullCheck160 = icmp ne i8* %476, null
-  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+  %NullCheck159 = icmp eq i8* %476, null
+  br i1 %NullCheck159, label %ThrowNullRef160, label %477
 
 ; <label>:477                                     ; preds = %474
   %478 = load i8, i8* %476, align 8
   %479 = zext i8 %478 to i32
   %480 = trunc i32 %479 to i8
-  %NullCheck162 = icmp ne i8* %475, null
-  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+  %NullCheck161 = icmp eq i8* %475, null
+  br i1 %NullCheck161, label %ThrowNullRef162, label %481
 
 ; <label>:481                                     ; preds = %477
   store i8 %480, i8* %475, align 8
@@ -1553,343 +1635,343 @@ ThrowNullRef:                                     ; preds = %308
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %312
+ThrowNullRef2:                                    ; preds = %312
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %315
+ThrowNullRef4:                                    ; preds = %315
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %321
+ThrowNullRef6:                                    ; preds = %321
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %271
+ThrowNullRef8:                                    ; preds = %271
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %275
+ThrowNullRef10:                                   ; preds = %275
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %278
+ThrowNullRef12:                                   ; preds = %278
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %284
+ThrowNullRef14:                                   ; preds = %284
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %287
+ThrowNullRef16:                                   ; preds = %287
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %293
+ThrowNullRef18:                                   ; preds = %293
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %298
+ThrowNullRef20:                                   ; preds = %298
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %303
+ThrowNullRef22:                                   ; preds = %303
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %243
+ThrowNullRef24:                                   ; preds = %243
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %247
+ThrowNullRef26:                                   ; preds = %247
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %250
+ThrowNullRef28:                                   ; preds = %250
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %256
+ThrowNullRef30:                                   ; preds = %256
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %259
+ThrowNullRef32:                                   ; preds = %259
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %265
+ThrowNullRef34:                                   ; preds = %265
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %217
+ThrowNullRef36:                                   ; preds = %217
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %221
+ThrowNullRef38:                                   ; preds = %221
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %224
+ThrowNullRef40:                                   ; preds = %224
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %230
+ThrowNullRef42:                                   ; preds = %230
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %233
+ThrowNullRef44:                                   ; preds = %233
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %238
+ThrowNullRef46:                                   ; preds = %238
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %200
+ThrowNullRef48:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %204
+ThrowNullRef50:                                   ; preds = %204
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %207
+ThrowNullRef52:                                   ; preds = %207
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %213
+ThrowNullRef54:                                   ; preds = %213
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %172
+ThrowNullRef56:                                   ; preds = %172
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %176
+ThrowNullRef58:                                   ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %179
+ThrowNullRef60:                                   ; preds = %179
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %185
+ThrowNullRef62:                                   ; preds = %185
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %190
+ThrowNullRef64:                                   ; preds = %190
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %195
+ThrowNullRef66:                                   ; preds = %195
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %153
+ThrowNullRef68:                                   ; preds = %153
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %157
+ThrowNullRef70:                                   ; preds = %157
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %160
+ThrowNullRef72:                                   ; preds = %160
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %166
+ThrowNullRef74:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %136
+ThrowNullRef76:                                   ; preds = %136
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %140
+ThrowNullRef78:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %143
+ThrowNullRef80:                                   ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %148
+ThrowNullRef82:                                   ; preds = %148
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %128
+ThrowNullRef84:                                   ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %132
+ThrowNullRef86:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %100
+ThrowNullRef88:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %104
+ThrowNullRef90:                                   ; preds = %104
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %107
+ThrowNullRef92:                                   ; preds = %107
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %113
+ThrowNullRef94:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %118
+ThrowNullRef96:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %123
+ThrowNullRef98:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %81
+ThrowNullRef100:                                  ; preds = %81
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef101:                                  ; preds = %85
+ThrowNullRef102:                                  ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef103:                                  ; preds = %88
+ThrowNullRef104:                                  ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef105:                                  ; preds = %94
+ThrowNullRef106:                                  ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef107:                                  ; preds = %64
+ThrowNullRef108:                                  ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef109:                                  ; preds = %68
+ThrowNullRef110:                                  ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef111:                                  ; preds = %71
+ThrowNullRef112:                                  ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef113:                                  ; preds = %76
+ThrowNullRef114:                                  ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef115:                                  ; preds = %56
+ThrowNullRef116:                                  ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef117:                                  ; preds = %60
+ThrowNullRef118:                                  ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef119:                                  ; preds = %37
+ThrowNullRef120:                                  ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef121:                                  ; preds = %41
+ThrowNullRef122:                                  ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef123:                                  ; preds = %46
+ThrowNullRef124:                                  ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef125:                                  ; preds = %51
+ThrowNullRef126:                                  ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef127:                                  ; preds = %27
+ThrowNullRef128:                                  ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef129:                                  ; preds = %31
+ThrowNullRef130:                                  ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef131:                                  ; preds = %19
+ThrowNullRef132:                                  ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef133:                                  ; preds = %22
+ThrowNullRef134:                                  ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef135:                                  ; preds = %338
+ThrowNullRef136:                                  ; preds = %338
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef137:                                  ; preds = %341
+ThrowNullRef138:                                  ; preds = %341
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef139:                                  ; preds = %356
+ThrowNullRef140:                                  ; preds = %356
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef141:                                  ; preds = %360
+ThrowNullRef142:                                  ; preds = %360
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef143:                                  ; preds = %377
+ThrowNullRef144:                                  ; preds = %377
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef145:                                  ; preds = %381
+ThrowNullRef146:                                  ; preds = %381
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef147:                                  ; preds = %424
+ThrowNullRef148:                                  ; preds = %424
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef149:                                  ; preds = %428
+ThrowNullRef150:                                  ; preds = %428
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef151:                                  ; preds = %440
+ThrowNullRef152:                                  ; preds = %440
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef153:                                  ; preds = %444
+ThrowNullRef154:                                  ; preds = %444
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef155:                                  ; preds = %456
+ThrowNullRef156:                                  ; preds = %456
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef157:                                  ; preds = %460
+ThrowNullRef158:                                  ; preds = %460
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef159:                                  ; preds = %474
+ThrowNullRef160:                                  ; preds = %474
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef161:                                  ; preds = %477
+ThrowNullRef162:                                  ; preds = %477
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef163:                                  ; preds = %394
+ThrowNullRef164:                                  ; preds = %394
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef165:                                  ; preds = %398
+ThrowNullRef166:                                  ; preds = %398
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef167:                                  ; preds = %401
+ThrowNullRef168:                                  ; preds = %401
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef169:                                  ; preds = %407
+ThrowNullRef170:                                  ; preds = %407
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1939,8 +2021,8 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
-  br i1 %NullCheck, label %22, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %ThrowNullRef, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
@@ -1948,8 +2030,8 @@ entry:
   store i32 %24, i32* %loc0
   %25 = load i32, i32* %loc0
   %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %26, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %27
 
 ; <label>:27                                      ; preds = %22
   %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
@@ -1971,7 +2053,7 @@ ThrowNullRef:                                     ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1989,8 +2071,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -2022,15 +2104,15 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2048,16 +2130,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
   %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
   store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %15
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
@@ -2072,8 +2154,8 @@ entry:
   %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
   %29 = ptrtoint i16 addrspace(1)* %28 to i64
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %19
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
@@ -2089,19 +2171,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2114,8 +2196,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
@@ -2128,7 +2210,7 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[loadElem]
+Failed to read AppDomain.PrepareDataForSetup[storeElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
@@ -2202,8 +2284,8 @@ entry:
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
-  br i1 %NullCheck24, label %27, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = load i64, i64 addrspace(1)* %26
@@ -2218,8 +2300,8 @@ entry:
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
-  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
   %41 = load i64, i64 addrspace(1)* %39
@@ -2236,8 +2318,8 @@ entry:
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
-  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
   %54 = load i64, i64 addrspace(1)* %52
@@ -2252,8 +2334,8 @@ entry:
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
   %67 = load i64, i64 addrspace(1)* %65
@@ -2270,8 +2352,8 @@ entry:
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
-  br i1 %NullCheck16, label %79, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
   %80 = load i64, i64 addrspace(1)* %78
@@ -2286,8 +2368,8 @@ entry:
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
-  br i1 %NullCheck18, label %92, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
   %93 = load i64, i64 addrspace(1)* %91
@@ -2304,8 +2386,8 @@ entry:
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
-  br i1 %NullCheck12, label %105, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = load i64, i64 addrspace(1)* %104
@@ -2320,8 +2402,8 @@ entry:
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
-  br i1 %NullCheck14, label %118, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
   %119 = load i64, i64 addrspace(1)* %117
@@ -2337,8 +2419,8 @@ entry:
 
 ; <label>:128                                     ; preds = %20
   %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
-  br i1 %NullCheck4, label %130, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %129, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %130
 
 ; <label>:130                                     ; preds = %128
   %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
@@ -2346,8 +2428,8 @@ entry:
   %133 = load i16, i16 addrspace(1)* %132, align 8
   %134 = zext i16 %133 to i32
   %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
-  br i1 %NullCheck6, label %136, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %135, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %136
 
 ; <label>:136                                     ; preds = %130
   %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
@@ -2360,8 +2442,8 @@ entry:
 
 ; <label>:143                                     ; preds = %136
   %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
-  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %144, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %145
 
 ; <label>:145                                     ; preds = %143
   %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
@@ -2369,8 +2451,8 @@ entry:
   %148 = load i16, i16 addrspace(1)* %147, align 8
   %149 = zext i16 %148 to i32
   %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %150, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %151
 
 ; <label>:151                                     ; preds = %145
   %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
@@ -2388,8 +2470,8 @@ entry:
 
 ; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
-  br i1 %NullCheck, label %163, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %ThrowNullRef, label %163
 
 ; <label>:163                                     ; preds = %161
   %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
@@ -2399,8 +2481,8 @@ entry:
 
 ; <label>:167                                     ; preds = %163
   %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
-  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %168, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %169
 
 ; <label>:169                                     ; preds = %167
   %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
@@ -2432,55 +2514,55 @@ ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %167
+ThrowNullRef2:                                    ; preds = %167
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %128
+ThrowNullRef4:                                    ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %130
+ThrowNullRef6:                                    ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %143
+ThrowNullRef8:                                    ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %145
+ThrowNullRef10:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %102
+ThrowNullRef12:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %105
+ThrowNullRef14:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %76
+ThrowNullRef16:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %79
+ThrowNullRef18:                                   ; preds = %79
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %50
+ThrowNullRef20:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %53
+ThrowNullRef22:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %24
+ThrowNullRef24:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %27
+ThrowNullRef26:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2503,15 +2585,15 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2519,16 +2601,16 @@ entry:
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
   store i32 %8, i32* %loc0
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
   %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
   store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
@@ -2546,16 +2628,16 @@ entry:
 
 ; <label>:23                                      ; preds = %64
   %24 = load i16*, i16** %loc3
-  %NullCheck12 = icmp ne i16* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i16* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
   store i32 %27, i32* %loc5
   %28 = load i16*, i16** %loc4
-  %NullCheck14 = icmp ne i16* %28, null
-  br i1 %NullCheck14, label %29, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %28, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = load i16, i16* %28, align 8
@@ -2620,15 +2702,15 @@ entry:
 
 ; <label>:67                                      ; preds = %64
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
-  br i1 %NullCheck8, label %69, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %68, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %69
 
 ; <label>:69                                      ; preds = %67
   %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
   %71 = load i32, i32 addrspace(1)* %70
   %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
-  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %73
 
 ; <label>:73                                      ; preds = %69
   %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
@@ -2645,31 +2727,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %67
+ThrowNullRef8:                                    ; preds = %67
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %69
+ThrowNullRef10:                                   ; preds = %69
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2710,14 +2792,14 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
   %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
@@ -2730,14 +2812,14 @@ entry:
 
 ; <label>:11                                      ; preds = %4
   %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
   %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
@@ -2749,14 +2831,14 @@ entry:
 
 ; <label>:22                                      ; preds = %16
   %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
   %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
-  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
-  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
@@ -2804,23 +2886,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2836,7 +2918,280 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[loadElem]
+Successfully read RuntimeType.IsAssignableFrom
+
+define i8 @RuntimeType.IsAssignableFrom(%System.RuntimeType addrspace(1)* %param0, %System.Type addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.RuntimeType addrspace(1)*
+  %arg1 = alloca %System.Type addrspace(1)*
+  %loc0 = alloca %System.RuntimeType addrspace(1)*
+  %loc1 = alloca %"System.Type[]" addrspace(1)*
+  %loc2 = alloca i32
+  store %System.RuntimeType addrspace(1)* %param0, %System.RuntimeType addrspace(1)** %this
+  store %System.Type addrspace(1)* %param1, %System.Type addrspace(1)** %arg1
+  %0 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %1 = icmp ne %System.Type addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i8 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %5 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %6 = bitcast %System.Type addrspace(1)* %4 to %System.Object addrspace(1)*
+  %7 = bitcast %System.RuntimeType addrspace(1)* %5 to %System.Object addrspace(1)*
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %6, %System.Object addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %3
+  ret i8 1
+
+; <label>:12                                      ; preds = %3
+  %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 152
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 32
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
+  %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
+  %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
+  store %System.RuntimeType addrspace(1)* %25, %System.RuntimeType addrspace(1)** %loc0
+  %26 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %27 = icmp eq %System.RuntimeType addrspace(1)* %26, null
+  br i1 %27, label %34, label %28
+
+; <label>:28                                      ; preds = %15
+  %29 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %30 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)*)*)(%System.RuntimeType addrspace(1)* %29, %System.RuntimeType addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+; <label>:34                                      ; preds = %15
+  %35 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %36 = call %System.Reflection.Emit.TypeBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Reflection.Emit.TypeBuilder addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %35)
+  %37 = icmp eq %System.Reflection.Emit.TypeBuilder addrspace(1)* %36, null
+  br i1 %37, label %139, label %38
+
+; <label>:38                                      ; preds = %34
+  %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %42
+
+; <label>:42                                      ; preds = %38
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 152
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 40
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
+  %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
+  %53 = zext i8 %52 to i32
+  %54 = icmp eq i32 %53, 0
+  br i1 %54, label %56, label %55
+
+; <label>:55                                      ; preds = %42
+  ret i8 1
+
+; <label>:56                                      ; preds = %42
+  %57 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %58 = bitcast %System.RuntimeType addrspace(1)* %57 to %System.Type addrspace(1)*
+  %59 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %58)
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %64 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.Type addrspace(1)* %63, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = bitcast %System.RuntimeType addrspace(1)* %64 to %System.Type addrspace(1)*
+  %67 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %63, %System.Type addrspace(1)* %66)
+  %68 = zext i8 %67 to i32
+  %69 = trunc i32 %68 to i8
+  ret i8 %69
+
+; <label>:70                                      ; preds = %56
+  %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
+  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %73
+
+; <label>:73                                      ; preds = %70
+  %74 = load i64, i64 addrspace(1)* %72
+  %75 = add i64 %74, 128
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = add i64 %77, 0
+  %79 = inttoptr i64 %78 to i64*
+  %80 = load i64, i64* %79
+  %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
+  %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
+  %83 = call i8 %82(%System.Type addrspace(1)* %81)
+  %84 = zext i8 %83 to i32
+  %85 = icmp eq i32 %84, 0
+  br i1 %85, label %139, label %86
+
+; <label>:86                                      ; preds = %73
+  %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
+  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %89
+
+; <label>:89                                      ; preds = %86
+  %90 = load i64, i64 addrspace(1)* %88
+  %91 = add i64 %90, 128
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = add i64 %93, 24
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
+  %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
+  %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
+  store %"System.Type[]" addrspace(1)* %99, %"System.Type[]" addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %129
+
+; <label>:100                                     ; preds = %132
+  %101 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %102 = load i32, i32* %loc2
+  %NullCheck11 = icmp eq %"System.Type[]" addrspace(1)* %101, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %103
+
+; <label>:103                                     ; preds = %100
+  %104 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 1
+  %105 = load i32, i32 addrspace(1)* %104
+  %106 = zext i32 %105 to i64
+  %107 = zext i32 %102 to i64
+  %BoundsCheck = icmp uge i64 %107, %106
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %108
+
+; <label>:108                                     ; preds = %103
+  %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
+  %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
+  %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
+  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %113
+
+; <label>:113                                     ; preds = %108
+  %114 = load i64, i64 addrspace(1)* %112
+  %115 = add i64 %114, 152
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = add i64 %117, 56
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
+  %123 = zext i8 %122 to i32
+  %124 = icmp ne i32 %123, 0
+  br i1 %124, label %126, label %125
+
+; <label>:125                                     ; preds = %113
+  ret i8 0
+
+; <label>:126                                     ; preds = %113
+  %127 = load i32, i32* %loc2
+  %128 = add i32 %127, 1
+  store i32 %128, i32* %loc2
+  br label %129
+
+; <label>:129                                     ; preds = %89, %126
+  %130 = load i32, i32* %loc2
+  %131 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %NullCheck9 = icmp eq %"System.Type[]" addrspace(1)* %131, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %132
+
+; <label>:132                                     ; preds = %129
+  %133 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %131, i32 0, i32 1
+  %134 = load i32, i32 addrspace(1)* %133
+  %135 = zext i32 %134 to i64
+  %136 = trunc i64 %135 to i32
+  %137 = icmp slt i32 %130, %136
+  br i1 %137, label %100, label %138
+
+; <label>:138                                     ; preds = %132
+  ret i8 1
+
+; <label>:139                                     ; preds = %34, %73
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %129
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %103
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -2893,7 +3248,7 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElem]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -2904,8 +3259,8 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -2997,8 +3352,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
@@ -3059,8 +3414,8 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -3087,8 +3442,8 @@ entry:
 
 ; <label>:17                                      ; preds = %5, %11
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
@@ -3097,8 +3452,8 @@ entry:
 
 ; <label>:22                                      ; preds = %1, %11
   %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
@@ -3109,11 +3464,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %17
+ThrowNullRef2:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %22
+ThrowNullRef4:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3167,15 +3522,15 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
   %15 = load i32, i32 addrspace(1)* %14
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
@@ -3198,7 +3553,7 @@ ThrowNullRef:                                     ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef2:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3232,8 +3587,8 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
@@ -3312,8 +3667,8 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -3327,8 +3682,8 @@ entry:
 ; <label>:5                                       ; preds = %43
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %7 = load i32, i32* %loc1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck6, label %8, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
@@ -3366,8 +3721,8 @@ entry:
 ; <label>:32                                      ; preds = %21, %25
   %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
   %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
-  br i1 %NullCheck8, label %35, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = trunc i32 %34 to i16
@@ -3380,8 +3735,8 @@ entry:
 ; <label>:40                                      ; preds = %1, %35
   %41 = load i32, i32* %loc1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
-  br i1 %NullCheck2, label %43, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %42, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
@@ -3392,8 +3747,8 @@ entry:
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
   %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
-  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
   %51 = load i64, i64 addrspace(1)* %49
@@ -3412,19 +3767,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %40
+ThrowNullRef2:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %47
+ThrowNullRef4:                                    ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %5
+ThrowNullRef6:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %32
+ThrowNullRef8:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3467,8 +3822,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
@@ -3492,11 +3847,391 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(i16* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store i16* %param0, i16** %arg0
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load i32, i32* %arg3
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %42, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %37, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg2
+  %13 = load i32, i32* %arg3
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %37, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %24 = load i32, i32* %arg2
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load i16*, i16** %arg0
+  %35 = load i32, i32* %arg3
+  %36 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %36, i16* %34, i32 %35)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:37                                      ; preds = %5, %16
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %39)
+  %41 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41, %System.String addrspace(1)* %38, %System.String addrspace(1)* %40)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41) #0
+  unreachable
+
+; <label>:42                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
-Failed to read StringBuilder.ToString[loadElemA]
+Successfully read StringBuilder.ToString
+
+define %System.String addrspace(1)* @StringBuilder.ToString(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i16*
+  %loc3 = alloca %"System.Char[]" addrspace(1)*
+  %loc4 = alloca i32
+  %loc5 = alloca i32
+  %loc6 = alloca i16 addrspace(1)*
+  %loc7 = alloca %System.String addrspace(1)*
+  %loc8 = alloca %"System.Char[]" addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %0)
+  %2 = icmp ne i32 %1, 0
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %4
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %6)
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %7)
+  store %System.String addrspace(1)* %8, %System.String addrspace(1)** %loc0
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.Text.StringBuilder addrspace(1)* %9, %System.Text.StringBuilder addrspace(1)** %loc1
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  store %System.String addrspace(1)* %10, %System.String addrspace(1)** %loc7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc7
+  %12 = ptrtoint %System.String addrspace(1)* %11 to i64
+  %13 = icmp eq i64 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %5
+  %15 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %16 = sext i32 %15 to i64
+  %17 = add i64 %12, %16
+  br label %18
+
+; <label>:18                                      ; preds = %5, %14
+  %19 = phi i64 [ %12, %5 ], [ %17, %14 ]
+  %20 = inttoptr i64 %19 to i16*
+  store i16* %20, i16** %loc2
+  br label %21
+
+; <label>:21                                      ; preds = %98, %18
+  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %22, null
+  br i1 %NullCheck, label %ThrowNullRef, label %23
+
+; <label>:23                                      ; preds = %21
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 3
+  %25 = load i32, i32 addrspace(1)* %24, align 8
+  %26 = icmp sle i32 %25, 0
+  br i1 %26, label %96, label %27
+
+; <label>:27                                      ; preds = %23
+  %28 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %28, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %29
+
+; <label>:29                                      ; preds = %27
+  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %28, i32 0, i32 1
+  %31 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %30, align 8
+  store %"System.Char[]" addrspace(1)* %31, %"System.Char[]" addrspace(1)** %loc3
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %33
+
+; <label>:33                                      ; preds = %29
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  store i32 %35, i32* %loc4
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  %39 = load i32, i32 addrspace(1)* %38, align 8
+  store i32 %39, i32* %loc5
+  %40 = load i32, i32* %loc5
+  %41 = load i32, i32* %loc4
+  %42 = add i32 %40, %41
+  %43 = zext i32 %42 to i64
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %45
+
+; <label>:45                                      ; preds = %37
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = sext i32 %47 to i64
+  %49 = icmp sgt i64 %43, %48
+  br i1 %49, label %91, label %50
+
+; <label>:50                                      ; preds = %45
+  %51 = load i32, i32* %loc5
+  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %52, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %53
+
+; <label>:53                                      ; preds = %50
+  %54 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %52, i32 0, i32 1
+  %55 = load i32, i32 addrspace(1)* %54
+  %56 = zext i32 %55 to i64
+  %57 = trunc i64 %56 to i32
+  %58 = icmp ugt i32 %51, %57
+  br i1 %58, label %91, label %59
+
+; <label>:59                                      ; preds = %53
+  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  store %"System.Char[]" addrspace(1)* %60, %"System.Char[]" addrspace(1)** %loc8
+  %61 = icmp eq %"System.Char[]" addrspace(1)* %60, null
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %63, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %64
+
+; <label>:64                                      ; preds = %62
+  %65 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %63, i32 0, i32 1
+  %66 = load i32, i32 addrspace(1)* %65
+  %67 = zext i32 %66 to i64
+  %68 = trunc i64 %67 to i32
+  %69 = icmp ne i32 %68, 0
+  br i1 %69, label %71, label %70
+
+; <label>:70                                      ; preds = %59, %64
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:71                                      ; preds = %64
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %73
+
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %BoundsCheck = icmp uge i64 0, %76
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %77
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %78, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:79                                      ; preds = %70, %77
+  %80 = load i16*, i16** %loc2
+  %81 = load i32, i32* %loc4
+  %82 = sext i32 %81 to i64
+  %83 = mul i64 %82, 2
+  %84 = bitcast i16* %80 to i8*
+  %85 = getelementptr inbounds i8, i8* %84, i64 %83
+  %86 = load i16 addrspace(1)*, i16 addrspace(1)** %loc6
+  %87 = ptrtoint i16 addrspace(1)* %86 to i64
+  %88 = load i32, i32* %loc5
+  %89 = bitcast i8* %85 to i16*
+  %90 = inttoptr i64 %87 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %89, i16* %90, i32 %88)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %96
+
+; <label>:91                                      ; preds = %45, %53
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %94 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %93)
+  %95 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95, %System.String addrspace(1)* %92, %System.String addrspace(1)* %94)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95) #0
+  unreachable
+
+; <label>:96                                      ; preds = %23, %79
+  %97 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %97, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %98
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %97, i32 0, i32 2
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  store %System.Text.StringBuilder addrspace(1)* %100, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %102 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %102, label %21, label %103
+
+; <label>:103                                     ; preds = %98
+  store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc7
+  %104 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  ret %System.String addrspace(1)* %104
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method StringBuilder::get_Length using LLILCJit
+Successfully read StringBuilder.get_Length
+
+define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
+Successfully read RuntimeHelpers.get_OffsetToStringData
+
+define i32 @RuntimeHelpers.get_OffsetToStringData() {
+entry:
+  ret i32 12
+}
+
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
 Successfully read CultureData.CreateCultureData
 
@@ -3514,23 +4249,23 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
   store i8 %4, i8 addrspace(1)* %6
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
@@ -3549,11 +4284,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3566,50 +4301,50 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
   store i32 -1, i32 addrspace(1)* %2
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
   store i32 -1, i32 addrspace(1)* %8
   %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
   store i32 -1, i32 addrspace(1)* %14
   %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
   store i32 -1, i32 addrspace(1)* %17
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
@@ -3623,27 +4358,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3675,7 +4410,136 @@ Failed to read Dictionary`2.Insert[non-const derefAddress]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
 Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
-Failed to read HashHelpers.GetPrime[loadElem]
+Successfully read HashHelpers.GetPrime
+
+define i32 @HashHelpers.GetPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %6, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5, %System.String addrspace(1)* %4)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5) #0
+  unreachable
+
+; <label>:6                                       ; preds = %entry
+  store i32 0, i32* %loc0
+  br label %29
+
+; <label>:7                                       ; preds = %35
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 1296
+  %10 = addrspacecast i8 addrspace(1)* %9 to %"System.Int32[]" addrspace(1)**
+  %11 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %10
+  %12 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Int32[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = zext i32 %15 to i64
+  %17 = zext i32 %12 to i64
+  %BoundsCheck = icmp uge i64 %17, %16
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 3, i32 %12
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  store i32 %20, i32* %loc1
+  %21 = load i32, i32* %loc1
+  %22 = load i32, i32* %arg0
+  %23 = icmp slt i32 %21, %22
+  br i1 %23, label %26, label %24
+
+; <label>:24                                      ; preds = %18
+  %25 = load i32, i32* %loc1
+  ret i32 %25
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %loc0
+  %28 = add i32 %27, 1
+  store i32 %28, i32* %loc0
+  br label %29
+
+; <label>:29                                      ; preds = %6, %26
+  %30 = load i32, i32* %loc0
+  %31 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %32 = getelementptr inbounds i8, i8 addrspace(1)* %31, i64 1296
+  %33 = addrspacecast i8 addrspace(1)* %32 to %"System.Int32[]" addrspace(1)**
+  %34 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %33
+  %NullCheck = icmp eq %"System.Int32[]" addrspace(1)* %34, null
+  br i1 %NullCheck, label %ThrowNullRef, label %35
+
+; <label>:35                                      ; preds = %29
+  %36 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %34, i32 0, i32 1
+  %37 = load i32, i32 addrspace(1)* %36
+  %38 = zext i32 %37 to i64
+  %39 = trunc i64 %38 to i32
+  %40 = icmp slt i32 %30, %39
+  br i1 %40, label %7, label %41
+
+; <label>:41                                      ; preds = %35
+  %42 = load i32, i32* %arg0
+  %43 = or i32 %42, 1
+  store i32 %43, i32* %loc2
+  br label %59
+
+; <label>:44                                      ; preds = %59
+  %45 = load i32, i32* %loc2
+  %46 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %45)
+  %47 = zext i8 %46 to i32
+  %48 = icmp eq i32 %47, 0
+  br i1 %48, label %56, label %49
+
+; <label>:49                                      ; preds = %44
+  %50 = load i32, i32* %loc2
+  %51 = sub i32 %50, 1
+  %52 = srem i32 %51, 101
+  %53 = icmp eq i32 %52, 0
+  br i1 %53, label %56, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = load i32, i32* %loc2
+  ret i32 %55
+
+; <label>:56                                      ; preds = %44, %49
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %57, 2
+  store i32 %58, i32* %loc2
+  br label %59
+
+; <label>:59                                      ; preds = %41, %56
+  %60 = load i32, i32* %loc2
+  %61 = icmp slt i32 %60, 2147483647
+  br i1 %61, label %44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load i32, i32* %arg0
+  ret i32 %63
+
+ThrowNullRef:                                     ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
 Successfully read GenericEqualityComparer`1.GetHashCode
 
@@ -3694,14 +4558,14 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
   %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load i64, i64 addrspace(1)* %7
@@ -3720,7 +4584,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3750,8 +4614,8 @@ entry:
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
@@ -3796,8 +4660,8 @@ entry:
   %35 = bitcast i16* %34 to i8*
   %36 = getelementptr inbounds i8, i8* %35, i64 2
   %37 = bitcast i8* %36 to i16*
-  %NullCheck4 = icmp ne i16* %37, null
-  br i1 %NullCheck4, label %38, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %37, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %38
 
 ; <label>:38                                      ; preds = %27
   %39 = load i16, i16* %37, align 8
@@ -3824,8 +4688,8 @@ entry:
 
 ; <label>:54                                      ; preds = %22, %43
   %55 = load i16*, i16** %loc4
-  %NullCheck2 = icmp ne i16* %55, null
-  br i1 %NullCheck2, label %56, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i16* %55, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %56
 
 ; <label>:56                                      ; preds = %54
   %57 = load i16, i16* %55, align 8
@@ -3850,11 +4714,11 @@ ThrowNullRef:                                     ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %54
+ThrowNullRef2:                                    ; preds = %54
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %27
+ThrowNullRef4:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3871,8 +4735,8 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -3907,8 +4771,8 @@ entry:
 
 ; <label>:26                                      ; preds = %19
   %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
-  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %28
 
 ; <label>:28                                      ; preds = %26
   %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
@@ -3920,7 +4784,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3972,8 +4836,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
@@ -3984,26 +4848,26 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
-  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
@@ -4014,8 +4878,8 @@ entry:
 ; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
@@ -4024,8 +4888,8 @@ entry:
 
 ; <label>:25                                      ; preds = %1, %16, %23
   %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
-  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
@@ -4036,27 +4900,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %20
+ThrowNullRef10:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4069,8 +4933,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -4081,8 +4945,8 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
@@ -4091,8 +4955,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1, %8
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
@@ -4103,11 +4967,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4128,24 +4992,24 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   store i32 %3, i32* %loc0
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
   %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
   store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck4, label %9, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
@@ -4164,15 +5028,15 @@ entry:
 ; <label>:18                                      ; preds = %70
   %19 = load i16*, i16** %loc3
   %20 = bitcast i16* %19 to i64*
-  %NullCheck10 = icmp ne i64* %20, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %20, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = load i64, i64* %20, align 8
   %23 = load i16*, i16** %loc4
   %24 = bitcast i16* %23 to i64*
-  %NullCheck12 = icmp ne i64* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = load i64, i64* %24, align 8
@@ -4188,8 +5052,8 @@ entry:
   %31 = bitcast i16* %30 to i8*
   %32 = getelementptr inbounds i8, i8* %31, i64 8
   %33 = bitcast i8* %32 to i64*
-  %NullCheck14 = icmp ne i64* %33, null
-  br i1 %NullCheck14, label %34, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = load i64, i64* %33, align 8
@@ -4197,8 +5061,8 @@ entry:
   %37 = bitcast i16* %36 to i8*
   %38 = getelementptr inbounds i8, i8* %37, i64 8
   %39 = bitcast i8* %38 to i64*
-  %NullCheck16 = icmp ne i64* %39, null
-  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %40
 
 ; <label>:40                                      ; preds = %34
   %41 = load i64, i64* %39, align 8
@@ -4214,8 +5078,8 @@ entry:
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %NullCheck18 = icmp ne i64* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = load i64, i64* %48, align 8
@@ -4223,8 +5087,8 @@ entry:
   %52 = bitcast i16* %51 to i8*
   %53 = getelementptr inbounds i8, i8* %52, i64 16
   %54 = bitcast i8* %53 to i64*
-  %NullCheck20 = icmp ne i64* %54, null
-  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64* %54, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %55
 
 ; <label>:55                                      ; preds = %49
   %56 = load i64, i64* %54, align 8
@@ -4262,15 +5126,15 @@ entry:
 ; <label>:74                                      ; preds = %95
   %75 = load i16*, i16** %loc3
   %76 = bitcast i16* %75 to i32*
-  %NullCheck6 = icmp ne i32* %76, null
-  br i1 %NullCheck6, label %77, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32* %76, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %77
 
 ; <label>:77                                      ; preds = %74
   %78 = load i32, i32* %76, align 8
   %79 = load i16*, i16** %loc4
   %80 = bitcast i16* %79 to i32*
-  %NullCheck8 = icmp ne i32* %80, null
-  br i1 %NullCheck8, label %81, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i32* %80, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %81
 
 ; <label>:81                                      ; preds = %77
   %82 = load i32, i32* %80, align 8
@@ -4318,43 +5182,43 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %74
+ThrowNullRef6:                                    ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %77
+ThrowNullRef8:                                    ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %29
+ThrowNullRef14:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %34
+ThrowNullRef16:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4376,8 +5240,8 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load i64, i64 addrspace(1)* %4
@@ -4389,8 +5253,8 @@ entry:
   %12 = load i64, i64* %11
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %5
   %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
@@ -4399,8 +5263,8 @@ entry:
   %18 = load i8, i8* %arg2
   %19 = zext i8 %18 to i32
   %20 = trunc i32 %19 to i8
-  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %15
   %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
@@ -4411,11 +5275,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4442,8 +5306,8 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
@@ -4466,16 +5330,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
   %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = load i64, i64 addrspace(1)* %19
@@ -4500,8 +5364,8 @@ entry:
 ; <label>:35                                      ; preds = %30
   %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
@@ -4514,8 +5378,8 @@ entry:
 
 ; <label>:42                                      ; preds = %1, %38
   %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
-  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
@@ -4526,19 +5390,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %35
+ThrowNullRef2:                                    ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %42
+ThrowNullRef8:                                    ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4551,14 +5415,14 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
@@ -4570,7 +5434,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4583,8 +5447,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
@@ -4613,51 +5477,51 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
   %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
   %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
   %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
   %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
-  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
   store i64 %21, i64 addrspace(1)* %23
   %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %25 = load i64, i64* %loc0
-  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
@@ -4668,27 +5532,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %22
+ThrowNullRef12:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4701,8 +5565,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
@@ -4713,19 +5577,19 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
@@ -4734,8 +5598,8 @@ entry:
 
 ; <label>:15                                      ; preds = %1, %13
   %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
@@ -4746,19 +5610,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %15
+ThrowNullRef8:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4771,8 +5635,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -4831,8 +5695,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
@@ -4882,8 +5746,8 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
-  br i1 %NullCheck, label %17, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %ThrowNullRef, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
@@ -4894,15 +5758,15 @@ entry:
 
 ; <label>:22                                      ; preds = %17
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
-  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
   %26 = load i32, i32 addrspace(1)* %25
   %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
-  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %27, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
@@ -4925,8 +5789,8 @@ entry:
 ; <label>:40                                      ; preds = %17
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
-  br i1 %NullCheck6, label %43, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %41, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
@@ -4938,34 +5802,17 @@ ThrowNullRef:                                     ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %24
+ThrowNullRef4:                                    ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %40
+ThrowNullRef6:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
-}
-
-INFO:  jitting method Object::ReferenceEquals using LLILCJit
-Successfully read Object.ReferenceEquals
-
-define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
-entry:
-  %arg0 = alloca %System.Object addrspace(1)*
-  %arg1 = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
-  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
-  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = icmp eq %System.Object addrspace(1)* %0, %1
-  %3 = sext i1 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
 }
 
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
@@ -4978,21 +5825,21 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
   %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
-  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
@@ -5007,28 +5854,28 @@ entry:
 ; <label>:13                                      ; preds = %8, %12
   %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
   %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
   %21 = load i32, i32 addrspace(1)* %20, align 8
   %22 = add i32 %21, 1
-  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
   store i32 %22, i32 addrspace(1)* %24
   %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
@@ -5039,27 +5886,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5077,7 +5924,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::Setup using LLILCJit
-Failed to read AppDomain.Setup[loadElem]
+Failed to read AppDomain.Setup[unbox]
 INFO:  jitting method Thread::GetDomain using LLILCJit
 Successfully read Thread.GetDomain
 
@@ -5108,8 +5955,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
@@ -5122,14 +5969,14 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
   %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
@@ -5141,11 +5988,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5173,8 +6020,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -5189,7 +6036,328 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
 Failed to read KeyCollection.System.Collections.Generic.IEnumerable<TKey>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Successfully read Enumerator.MoveNext
+
+define i8 @Enumerator.MoveNext(%"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.RuntimeTypeHandle* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*
+  %"$TypeArg" = alloca %System.RuntimeTypeHandle*
+  store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
+  %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 8
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %76, label %12
+
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
+  br label %76
+
+; <label>:13                                      ; preds = %85
+  %14 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck19 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %15
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, i32 0, i32 0
+  %17 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %16, align 8
+  %NullCheck21 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, i32 0, i32 2
+  %20 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %19, align 8
+  %21 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck23 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %22
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, i32 0, i32 2
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %NullCheck25 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 3, i32 %24
+  %NullCheck27 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %32
+
+; <label>:32                                      ; preds = %30
+  %33 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, i32 0, i32 2
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = icmp slt i32 %34, 0
+  br i1 %35, label %68, label %36
+
+; <label>:36                                      ; preds = %32
+  %37 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %38 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck29 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %39
+
+; <label>:39                                      ; preds = %36
+  %40 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, i32 0, i32 0
+  %41 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %40, align 8
+  %NullCheck31 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, i32 0, i32 2
+  %44 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %43, align 8
+  %45 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck33 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, i32 0, i32 2
+  %48 = load i32, i32 addrspace(1)* %47, align 8
+  %NullCheck35 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %49
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = zext i32 %51 to i64
+  %53 = zext i32 %48 to i64
+  %BoundsCheck37 = icmp uge i64 %53, %52
+  br i1 %BoundsCheck37, label %ThrowIndexOutOfRange38, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 3, i32 %48
+  %NullCheck39 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %56
+
+; <label>:56                                      ; preds = %54
+  %57 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, i32 0, i32 0
+  %58 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck41 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %59
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %60, %System.__Canon addrspace(1)* %58)
+  %61 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck43 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  %64 = load i32, i32 addrspace(1)* %63, align 8
+  %65 = add i32 %64, 1
+  %NullCheck45 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  store i32 %65, i32 addrspace(1)* %67
+  ret i8 1
+
+; <label>:68                                      ; preds = %32
+  %69 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck47 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %73 = add i32 %72, 1
+  %NullCheck49 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %74
+
+; <label>:74                                      ; preds = %70
+  %75 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  store i32 %73, i32 addrspace(1)* %75
+  br label %76
+
+; <label>:76                                      ; preds = %8, %12, %74
+  %77 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %78
+
+; <label>:78                                      ; preds = %76
+  %79 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, i32 0, i32 2
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck7 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %82
+
+; <label>:82                                      ; preds = %78
+  %83 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, i32 0, i32 0
+  %84 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %83, align 8
+  %NullCheck9 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %85
+
+; <label>:85                                      ; preds = %82
+  %86 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, i32 0, i32 7
+  %87 = load i32, i32 addrspace(1)* %86, align 8
+  %88 = icmp ult i32 %80, %87
+  br i1 %88, label %13, label %89
+
+; <label>:89                                      ; preds = %85
+  %90 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %91 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck11 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %92
+
+; <label>:92                                      ; preds = %89
+  %93 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, i32 0, i32 0
+  %94 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck13 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %95
+
+; <label>:95                                      ; preds = %92
+  %96 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, i32 0, i32 7
+  %97 = load i32, i32 addrspace(1)* %96, align 8
+  %98 = add i32 %97, 1
+  %NullCheck15 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %99
+
+; <label>:99                                      ; preds = %95
+  %100 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, i32 0, i32 2
+  store i32 %98, i32 addrspace(1)* %100
+  %101 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck17 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %102
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %103, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %92
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef22:                                   ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef24:                                   ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef26:                                   ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef28:                                   ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef30:                                   ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef32:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef34:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef36:                                   ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange38:                           ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef40:                                   ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef42:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef44:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef46:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef48:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef50:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -5200,8 +6368,8 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -5232,9 +6400,9 @@ Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
 Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
-Failed to read String.MakeSeparatorList[loadElemA]
+Failed to read String.MakeSeparatorList[storeElem]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
-Failed to read String.InternalSplitKeepEmptyEntries[loadElem]
+Failed to read String.InternalSplitKeepEmptyEntries[storeElem]
 INFO:  jitting method Path::IsRelative using LLILCJit
 Successfully read Path.IsRelative
 
@@ -5243,8 +6411,8 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -5254,8 +6422,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
@@ -5271,8 +6439,8 @@ entry:
 
 ; <label>:17                                      ; preds = %7
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
@@ -5288,8 +6456,8 @@ entry:
 
 ; <label>:29                                      ; preds = %19
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %31
 
 ; <label>:31                                      ; preds = %29
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
@@ -5300,8 +6468,8 @@ entry:
 
 ; <label>:36                                      ; preds = %31
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
-  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %37, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
@@ -5312,8 +6480,8 @@ entry:
 
 ; <label>:43                                      ; preds = %31, %38
   %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
-  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %45
 
 ; <label>:45                                      ; preds = %43
   %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
@@ -5324,8 +6492,8 @@ entry:
 
 ; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %50
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
@@ -5336,8 +6504,8 @@ entry:
 
 ; <label>:57                                      ; preds = %1, %7, %19, %45, %52
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
-  br i1 %NullCheck14, label %59, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %59
 
 ; <label>:59                                      ; preds = %57
   %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
@@ -5347,8 +6515,8 @@ entry:
 
 ; <label>:63                                      ; preds = %59
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
@@ -5359,8 +6527,8 @@ entry:
 
 ; <label>:70                                      ; preds = %65
   %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
-  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.String addrspace(1)* %71, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %72
 
 ; <label>:72                                      ; preds = %70
   %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
@@ -5379,39 +6547,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %17
+ThrowNullRef4:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %29
+ThrowNullRef6:                                    ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %36
+ThrowNullRef8:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %43
+ThrowNullRef10:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %50
+ThrowNullRef12:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %57
+ThrowNullRef14:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %63
+ThrowNullRef16:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %70
+ThrowNullRef18:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5419,7 +6587,293 @@ ThrowNullRef17:                                   ; preds = %70
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
-Failed to read String.TrimHelper[loadElem]
+Successfully read String.TrimHelper
+
+define %System.String addrspace(1)* @String.TrimHelper(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i16
+  %loc4 = alloca i32
+  %loc5 = alloca i16
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = sub i32 %3, 1
+  store i32 %4, i32* %loc0
+  store i32 0, i32* %loc1
+  %5 = load i32, i32* %arg2
+  %6 = icmp eq i32 %5, 1
+  br i1 %6, label %62, label %7
+
+; <label>:7                                       ; preds = %1
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:8                                       ; preds = %58
+  store i32 0, i32* %loc2
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load i32, i32* %loc1
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2, i32 %10
+  %13 = load i16, i16 addrspace(1)* %12
+  %14 = zext i16 %13 to i32
+  %15 = trunc i32 %14 to i16
+  store i16 %15, i16* %loc3
+  store i32 0, i32* %loc2
+  br label %34
+
+; <label>:16                                      ; preds = %37
+  %17 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %18 = load i32, i32* %loc2
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %17, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %19
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = zext i32 %18 to i64
+  %BoundsCheck = icmp uge i64 %23, %22
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %24
+
+; <label>:24                                      ; preds = %19
+  %25 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 3, i32 %18
+  %26 = load i16, i16 addrspace(1)* %25, align 8
+  %27 = zext i16 %26 to i32
+  %28 = load i16, i16* %loc3
+  %29 = zext i16 %28 to i32
+  %30 = icmp eq i32 %27, %29
+  br i1 %30, label %43, label %31
+
+; <label>:31                                      ; preds = %24
+  %32 = load i32, i32* %loc2
+  %33 = add i32 %32, 1
+  store i32 %33, i32* %loc2
+  br label %34
+
+; <label>:34                                      ; preds = %11, %31
+  %35 = load i32, i32* %loc2
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = icmp slt i32 %35, %41
+  br i1 %42, label %16, label %43
+
+; <label>:43                                      ; preds = %24, %37
+  %44 = load i32, i32* %loc2
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %45, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp eq i32 %44, %50
+  br i1 %51, label %62, label %52
+
+; <label>:52                                      ; preds = %46
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %7, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %57, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %58
+
+; <label>:58                                      ; preds = %55
+  %59 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %60 = load i32, i32 addrspace(1)* %59
+  %61 = icmp slt i32 %56, %60
+  br i1 %61, label %8, label %62
+
+; <label>:62                                      ; preds = %1, %46, %58
+  %63 = load i32, i32* %arg2
+  %64 = icmp eq i32 %63, 0
+  br i1 %64, label %122, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %66, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %67
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %66, i32 0, i32 1
+  %69 = load i32, i32 addrspace(1)* %68
+  %70 = sub i32 %69, 1
+  store i32 %70, i32* %loc0
+  br label %118
+
+; <label>:71                                      ; preds = %118
+  store i32 0, i32* %loc4
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %73 = load i32, i32* %loc0
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %74
+
+; <label>:74                                      ; preds = %71
+  %75 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 2, i32 %73
+  %76 = load i16, i16 addrspace(1)* %75
+  %77 = zext i16 %76 to i32
+  %78 = trunc i32 %77 to i16
+  store i16 %78, i16* %loc5
+  store i32 0, i32* %loc4
+  br label %97
+
+; <label>:79                                      ; preds = %100
+  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %81 = load i32, i32* %loc4
+  %NullCheck19 = icmp eq %"System.Char[]" addrspace(1)* %80, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
+
+; <label>:82                                      ; preds = %79
+  %83 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 1
+  %84 = load i32, i32 addrspace(1)* %83
+  %85 = zext i32 %84 to i64
+  %86 = zext i32 %81 to i64
+  %BoundsCheck21 = icmp uge i64 %86, %85
+  br i1 %BoundsCheck21, label %ThrowIndexOutOfRange22, label %87
+
+; <label>:87                                      ; preds = %82
+  %88 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 3, i32 %81
+  %89 = load i16, i16 addrspace(1)* %88, align 8
+  %90 = zext i16 %89 to i32
+  %91 = load i16, i16* %loc5
+  %92 = zext i16 %91 to i32
+  %93 = icmp eq i32 %90, %92
+  br i1 %93, label %106, label %94
+
+; <label>:94                                      ; preds = %87
+  %95 = load i32, i32* %loc4
+  %96 = add i32 %95, 1
+  store i32 %96, i32* %loc4
+  br label %97
+
+; <label>:97                                      ; preds = %74, %94
+  %98 = load i32, i32* %loc4
+  %99 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck15 = icmp eq %"System.Char[]" addrspace(1)* %99, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %100
+
+; <label>:100                                     ; preds = %97
+  %101 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %99, i32 0, i32 1
+  %102 = load i32, i32 addrspace(1)* %101
+  %103 = zext i32 %102 to i64
+  %104 = trunc i64 %103 to i32
+  %105 = icmp slt i32 %98, %104
+  br i1 %105, label %79, label %106
+
+; <label>:106                                     ; preds = %87, %100
+  %107 = load i32, i32* %loc4
+  %108 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck17 = icmp eq %"System.Char[]" addrspace(1)* %108, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %109
+
+; <label>:109                                     ; preds = %106
+  %110 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %108, i32 0, i32 1
+  %111 = load i32, i32 addrspace(1)* %110
+  %112 = zext i32 %111 to i64
+  %113 = trunc i64 %112 to i32
+  %114 = icmp eq i32 %107, %113
+  br i1 %114, label %122, label %115
+
+; <label>:115                                     ; preds = %109
+  %116 = load i32, i32* %loc0
+  %117 = sub i32 %116, 1
+  store i32 %117, i32* %loc0
+  br label %118
+
+; <label>:118                                     ; preds = %67, %115
+  %119 = load i32, i32* %loc0
+  %120 = load i32, i32* %loc1
+  %121 = icmp sge i32 %119, %120
+  br i1 %121, label %71, label %122
+
+; <label>:122                                     ; preds = %62, %109, %118
+  %123 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %124 = load i32, i32* %loc1
+  %125 = load i32, i32* %loc0
+  %126 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %123, i32 %124, i32 %125)
+  ret %System.String addrspace(1)* %126
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %97
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange22:                           ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
 Successfully read String.CreateTrimmedString
 
@@ -5439,8 +6893,8 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
@@ -5535,8 +6989,8 @@ entry:
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i64 2872
   %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
   %8 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %7
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %3
   %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
@@ -5553,8 +7007,8 @@ entry:
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 2864
   %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
   %21 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %20
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
-  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %22
 
 ; <label>:22                                      ; preds = %16
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
@@ -5569,7 +7023,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %16
+ThrowNullRef2:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5586,8 +7040,8 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5613,8 +7067,8 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
@@ -5632,8 +7086,8 @@ entry:
 
 ; <label>:12                                      ; preds = %4
   %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
@@ -5644,8 +7098,8 @@ entry:
 
 ; <label>:19                                      ; preds = %14
   %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %19
   %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
@@ -5660,21 +7114,21 @@ entry:
   %31 = zext i16 %30 to i32
   %32 = bitcast i8* %29 to i16*
   %33 = trunc i32 %31 to i16
-  %NullCheck6 = icmp ne i16* %32, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i16* %32, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %21
   store i16 %33, i16* %32, align 8
   %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %36
 
 ; <label>:36                                      ; preds = %34
   %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
   %38 = load i32, i32 addrspace(1)* %37, align 8
   %39 = add i32 %38, 1
-  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %40
 
 ; <label>:40                                      ; preds = %36
   %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
@@ -5683,16 +7137,16 @@ entry:
 
 ; <label>:42                                      ; preds = %14
   %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
-  br i1 %NullCheck12, label %44, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
   %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
   %47 = load i16, i16* %arg1
   %48 = zext i16 %47 to i32
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = trunc i32 %48 to i16
@@ -5703,31 +7157,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %19
+ThrowNullRef4:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %21
+ThrowNullRef6:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %36
+ThrowNullRef10:                                   ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %42
+ThrowNullRef12:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %44
+ThrowNullRef14:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5740,8 +7194,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -5752,8 +7206,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
@@ -5762,14 +7216,14 @@ entry:
 
 ; <label>:11                                      ; preds = %1
   %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
@@ -5779,15 +7233,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5808,8 +7262,8 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5822,8 +7276,8 @@ entry:
 
 ; <label>:8                                       ; preds = %3
   %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
@@ -5842,15 +7296,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
-  br i1 %NullCheck4, label %22, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
   %24 = load i16*, i16* addrspace(1)* %23, align 8
   %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %25, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
@@ -5859,8 +7313,8 @@ entry:
   store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
@@ -5874,8 +7328,8 @@ entry:
 
 ; <label>:37                                      ; preds = %65
   %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %37
   %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
@@ -5886,16 +7340,16 @@ entry:
   %45 = bitcast i16* %41 to i8*
   %46 = getelementptr inbounds i8, i8* %45, i64 %44
   %47 = bitcast i8* %46 to i16*
-  %NullCheck14 = icmp ne i16* %47, null
-  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %47, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %48
 
 ; <label>:48                                      ; preds = %39
   %49 = load i16, i16* %47, align 8
   %50 = zext i16 %49 to i32
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %52 = load i32, i32* %loc1
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %53
 
 ; <label>:53                                      ; preds = %48
   %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
@@ -5916,8 +7370,8 @@ entry:
 ; <label>:62                                      ; preds = %36, %59
   %63 = load i32, i32* %loc1
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck10, label %65, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %65
 
 ; <label>:65                                      ; preds = %62
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
@@ -5936,15 +7390,15 @@ entry:
 
 ; <label>:74                                      ; preds = %70
   %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
-  br i1 %NullCheck18, label %76, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %76
 
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
   %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
-  br i1 %NullCheck20, label %80, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
   %81 = load i64, i64 addrspace(1)* %79
@@ -5958,8 +7412,8 @@ entry:
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
   %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
-  br i1 %NullCheck22, label %92, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.String addrspace(1)* %90, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %92
 
 ; <label>:92                                      ; preds = %80
   %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
@@ -5969,15 +7423,15 @@ entry:
 
 ; <label>:96                                      ; preds = %70
   %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
-  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %98
 
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
   %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
-  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
   %103 = load i64, i64 addrspace(1)* %101
@@ -5991,8 +7445,8 @@ entry:
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
   %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
-  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.String addrspace(1)* %112, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %114
 
 ; <label>:114                                     ; preds = %102
   %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
@@ -6004,59 +7458,59 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %20
+ThrowNullRef4:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %22
+ThrowNullRef6:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %26
+ThrowNullRef8:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %62
+ThrowNullRef10:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %48
+ThrowNullRef16:                                   ; preds = %48
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %74
+ThrowNullRef18:                                   ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %76
+ThrowNullRef20:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %80
+ThrowNullRef22:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %96
+ThrowNullRef24:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %98
+ThrowNullRef26:                                   ; preds = %98
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %102
+ThrowNullRef28:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6069,15 +7523,15 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
   %3 = load i16*, i16* addrspace(1)* %2, align 8
   %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
@@ -6087,8 +7541,8 @@ entry:
   %10 = bitcast i16* %3 to i8*
   %11 = getelementptr inbounds i8, i8* %10, i64 %9
   %12 = bitcast i8* %11 to i16*
-  %NullCheck4 = icmp ne i16* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %5
   store i16 0, i16* %12, align 8
@@ -6098,11 +7552,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6119,8 +7573,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -6131,8 +7585,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
@@ -6144,15 +7598,15 @@ entry:
 
 ; <label>:14                                      ; preds = %1
   %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
   %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
   %21 = load i64, i64 addrspace(1)* %19
@@ -6171,15 +7625,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %14
+ThrowNullRef4:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %16
+ThrowNullRef6:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6302,14 +7756,6 @@ entry:
   ret %System.String addrspace(1)* %57
 }
 
-INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
-Successfully read RuntimeHelpers.get_OffsetToStringData
-
-define i32 @RuntimeHelpers.get_OffsetToStringData() {
-entry:
-  ret i32 12
-}
-
 INFO:  jitting method String::Equals using LLILCJit
 Successfully read String.Equals
 
@@ -6381,8 +7827,8 @@ entry:
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
-  br i1 %NullCheck24, label %29, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
   %30 = load i64, i64 addrspace(1)* %28
@@ -6397,8 +7843,8 @@ entry:
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
-  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
   %43 = load i64, i64 addrspace(1)* %41
@@ -6418,8 +7864,8 @@ entry:
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
   %59 = load i64, i64 addrspace(1)* %57
@@ -6434,8 +7880,8 @@ entry:
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck22, label %71, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
   %72 = load i64, i64 addrspace(1)* %70
@@ -6455,8 +7901,8 @@ entry:
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
-  br i1 %NullCheck16, label %87, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = load i64, i64 addrspace(1)* %86
@@ -6471,8 +7917,8 @@ entry:
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck18, label %100, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
   %101 = load i64, i64 addrspace(1)* %99
@@ -6492,8 +7938,8 @@ entry:
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
-  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
   %117 = load i64, i64 addrspace(1)* %115
@@ -6508,8 +7954,8 @@ entry:
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
-  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
   %130 = load i64, i64 addrspace(1)* %128
@@ -6528,15 +7974,15 @@ entry:
 
 ; <label>:142                                     ; preds = %22
   %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
-  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %143, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %144
 
 ; <label>:144                                     ; preds = %142
   %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
   %146 = load i32, i32 addrspace(1)* %145
   %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
-  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %147, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %148
 
 ; <label>:148                                     ; preds = %144
   %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
@@ -6557,15 +8003,15 @@ entry:
 
 ; <label>:159                                     ; preds = %22
   %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
-  br i1 %NullCheck, label %161, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %ThrowNullRef, label %161
 
 ; <label>:161                                     ; preds = %159
   %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
   %163 = load i32, i32 addrspace(1)* %162
   %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
-  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %164, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %165
 
 ; <label>:165                                     ; preds = %161
   %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
@@ -6578,8 +8024,8 @@ entry:
 
 ; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
-  br i1 %NullCheck4, label %172, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %171, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %172
 
 ; <label>:172                                     ; preds = %170
   %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
@@ -6589,8 +8035,8 @@ entry:
 
 ; <label>:176                                     ; preds = %172
   %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
-  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %177, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %178
 
 ; <label>:178                                     ; preds = %176
   %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
@@ -6629,55 +8075,55 @@ ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %161
+ThrowNullRef2:                                    ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %170
+ThrowNullRef4:                                    ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %176
+ThrowNullRef6:                                    ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %142
+ThrowNullRef8:                                    ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %144
+ThrowNullRef10:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %113
+ThrowNullRef12:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %116
+ThrowNullRef14:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %84
+ThrowNullRef16:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %87
+ThrowNullRef18:                                   ; preds = %87
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %55
+ThrowNullRef20:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %58
+ThrowNullRef22:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %26
+ThrowNullRef24:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %29
+ThrowNullRef26:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,8 +8161,8 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck, label %14, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %ThrowNullRef, label %14
 
 ; <label>:14                                      ; preds = %8
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
@@ -6760,8 +8206,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
@@ -6770,14 +8216,14 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32, i32* %loc0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %10
   %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
   %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
@@ -6790,15 +8236,15 @@ entry:
 ; <label>:25                                      ; preds = %19
   %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
-  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
   %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
@@ -6807,8 +8253,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %37 = load i32, i32* %loc0
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %38, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %38
 
 ; <label>:38                                      ; preds = %32
   %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
@@ -6817,14 +8263,14 @@ entry:
 
 ; <label>:40                                      ; preds = %19
   %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %40
   %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
   %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
-  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
-  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
@@ -6832,8 +8278,8 @@ entry:
   %48 = zext i32 %47 to i64
   %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
-  br i1 %NullCheck16, label %51, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %51
 
 ; <label>:51                                      ; preds = %45
   %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
@@ -6847,15 +8293,15 @@ entry:
 ; <label>:57                                      ; preds = %51
   %58 = load i16*, i16** %arg1
   %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
-  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %60
 
 ; <label>:60                                      ; preds = %57
   %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
   %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
-  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %64
 
 ; <label>:64                                      ; preds = %60
   %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
@@ -6864,22 +8310,22 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
   %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
-  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %70
 
 ; <label>:70                                      ; preds = %64
   %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
   %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
-  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
-  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
   %75 = load i32, i32 addrspace(1)* %74
   %76 = zext i32 %75 to i64
   %77 = trunc i64 %76 to i32
-  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
-  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %78
 
 ; <label>:78                                      ; preds = %73
   %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
@@ -6901,8 +8347,8 @@ entry:
   %90 = bitcast i16* %86 to i8*
   %91 = getelementptr inbounds i8, i8* %90, i64 %89
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %93
 
 ; <label>:93                                      ; preds = %80
   %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
@@ -6912,8 +8358,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %99 = load i32, i32* %loc2
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %100
 
 ; <label>:100                                     ; preds = %93
   %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
@@ -6928,63 +8374,63 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %25
+ThrowNullRef6:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %32
+ThrowNullRef10:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %40
+ThrowNullRef12:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %45
+ThrowNullRef16:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %57
+ThrowNullRef18:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %60
+ThrowNullRef20:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %64
+ThrowNullRef22:                                   ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %70
+ThrowNullRef24:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %73
+ThrowNullRef26:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %80
+ThrowNullRef28:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %93
+ThrowNullRef30:                                   ; preds = %93
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7004,8 +8450,8 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
@@ -7033,43 +8479,43 @@ entry:
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %14
   %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
   %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   %28 = load i32, i32 addrspace(1)* %27, align 8
   %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
-  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %30
 
 ; <label>:30                                      ; preds = %26
   %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
   %32 = load i32, i32 addrspace(1)* %31, align 8
   %33 = add i32 %28, %32
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %34
 
 ; <label>:34                                      ; preds = %30
   %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   store i32 %33, i32 addrspace(1)* %35
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
   store i32 0, i32 addrspace(1)* %38
   %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %40
 
 ; <label>:40                                      ; preds = %37
   %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
@@ -7082,8 +8528,8 @@ entry:
 
 ; <label>:47                                      ; preds = %40
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
@@ -7098,8 +8544,8 @@ entry:
   %54 = load i32, i32* %loc0
   %55 = sext i32 %54 to i64
   %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
-  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %57
 
 ; <label>:57                                      ; preds = %52
   %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
@@ -7110,68 +8556,35 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %14
+ThrowNullRef2:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %23
+ThrowNullRef4:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %26
+ThrowNullRef6:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %30
+ThrowNullRef8:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %34
+ThrowNullRef10:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %47
+ThrowNullRef14:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %52
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-}
-
-INFO:  jitting method StringBuilder::get_Length using LLILCJit
-Successfully read StringBuilder.get_Length
-
-define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.StringBuilder addrspace(1)*
-  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
-  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
-
-; <label>:1                                       ; preds = %entry
-  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %3 = load i32, i32 addrspace(1)* %2, align 8
-  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
-
-; <label>:5                                       ; preds = %1
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = add i32 %3, %7
-  ret i32 %8
-
-ThrowNullRef:                                     ; preds = %entry
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef16:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7213,70 +8626,70 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
   %6 = load i32, i32 addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
   store i32 %6, i32 addrspace(1)* %8
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
   %13 = load i32, i32 addrspace(1)* %12, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
   store i32 %13, i32 addrspace(1)* %15
   %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
-  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %18
 
 ; <label>:18                                      ; preds = %14
   %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
   %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
   %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
   %34 = load i32, i32 addrspace(1)* %33, align 8
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
-  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
@@ -7287,39 +8700,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %28
+ThrowNullRef16:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %32
+ThrowNullRef18:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7455,13 +8868,13 @@ entry:
 ; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
@@ -7477,16 +8890,16 @@ entry:
 
 ; <label>:18                                      ; preds = %15
   %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
   store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
   %22 = load i32, i32* %loc0
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %24
 
 ; <label>:24                                      ; preds = %20
   %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
@@ -7498,13 +8911,13 @@ entry:
 ; <label>:28                                      ; preds = %15, %24
   %29 = load i32, i32* %arg1
   %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %31
   %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
@@ -7517,20 +8930,20 @@ entry:
   %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
-  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
   %46 = load i32, i32 addrspace(1)* %45, align 8
   %47 = sub i32 %40, %46
-  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
-  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i32 addrspace(1)* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %48
 
 ; <label>:48                                      ; preds = %44
   store i32 %47, i32 addrspace(1)* %39, align 8
@@ -7538,21 +8951,21 @@ entry:
 
 ; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
-  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %51
 
 ; <label>:51                                      ; preds = %49
   %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %53
 
 ; <label>:53                                      ; preds = %51
   %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
   %55 = load i32, i32 addrspace(1)* %54, align 8
   %56 = load i32, i32* %arg2
   %57 = sub i32 %55, %56
-  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %58
 
 ; <label>:58                                      ; preds = %53
   %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
@@ -7562,13 +8975,13 @@ entry:
 ; <label>:60                                      ; preds = %33, %58
   %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
   %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
-  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %63
 
 ; <label>:63                                      ; preds = %60
   %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
-  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
-  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
@@ -7578,15 +8991,15 @@ entry:
 
 ; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
-  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i32 addrspace(1)* %69, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %70
 
 ; <label>:70                                      ; preds = %68
   %71 = load i32, i32 addrspace(1)* %69, align 8
   store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
-  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
@@ -7596,8 +9009,8 @@ entry:
   store i32 %77, i32* %loc4
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
-  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %80
 
 ; <label>:80                                      ; preds = %73
   %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
@@ -7607,71 +9020,71 @@ entry:
 ; <label>:83                                      ; preds = %80
   store i32 0, i32* %loc3
   %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
-  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
-  br i1 %NullCheck26, label %88, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i32 addrspace(1)* %87, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %88
 
 ; <label>:88                                      ; preds = %85
   %89 = load i32, i32 addrspace(1)* %87, align 8
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
-  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %90
 
 ; <label>:90                                      ; preds = %88
   %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
   store i32 %89, i32 addrspace(1)* %91
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
-  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
-  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %96
 
 ; <label>:96                                      ; preds = %94
   %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
-  br i1 %NullCheck34, label %100, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %100
 
 ; <label>:100                                     ; preds = %96
   %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
-  br i1 %NullCheck36, label %102, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %102
 
 ; <label>:102                                     ; preds = %100
   %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
   %104 = load i32, i32 addrspace(1)* %103, align 8
   %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
-  br i1 %NullCheck38, label %106, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %106
 
 ; <label>:106                                     ; preds = %102
   %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
-  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
-  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %108
 
 ; <label>:108                                     ; preds = %106
   %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
   %110 = load i32, i32 addrspace(1)* %109, align 8
   %111 = add i32 %104, %110
-  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %112
 
 ; <label>:112                                     ; preds = %108
   %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
   store i32 %111, i32 addrspace(1)* %113
   %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
-  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i32 addrspace(1)* %114, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %115
 
 ; <label>:115                                     ; preds = %112
   %116 = load i32, i32 addrspace(1)* %114, align 8
@@ -7681,19 +9094,19 @@ entry:
 ; <label>:118                                     ; preds = %115
   %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
-  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %121
 
 ; <label>:121                                     ; preds = %118
   %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
-  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
-  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %123
 
 ; <label>:123                                     ; preds = %121
   %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
   %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
-  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
-  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %126
 
 ; <label>:126                                     ; preds = %123
   %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
@@ -7705,8 +9118,8 @@ entry:
 
 ; <label>:130                                     ; preds = %80, %115, %126
   %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %132
 
 ; <label>:132                                     ; preds = %130
   %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7715,8 +9128,8 @@ entry:
   %136 = load i32, i32* %loc3
   %137 = sub i32 %135, %136
   %138 = sub i32 %134, %137
-  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %139
 
 ; <label>:139                                     ; preds = %132
   %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7728,16 +9141,16 @@ entry:
 
 ; <label>:144                                     ; preds = %139
   %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
-  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %146
 
 ; <label>:146                                     ; preds = %144
   %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
   %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
   %149 = load i32, i32* %loc2
   %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
-  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %151
 
 ; <label>:151                                     ; preds = %146
   %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
@@ -7754,145 +9167,249 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %18
+ThrowNullRef4:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %31
+ThrowNullRef10:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %44
+ThrowNullRef16:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %68
+ThrowNullRef18:                                   ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %70
+ThrowNullRef20:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %73
+ThrowNullRef22:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %83
+ThrowNullRef24:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %85
+ThrowNullRef26:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %88
+ThrowNullRef28:                                   ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %90
+ThrowNullRef30:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %94
+ThrowNullRef32:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %96
+ThrowNullRef34:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %100
+ThrowNullRef36:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %102
+ThrowNullRef38:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %106
+ThrowNullRef40:                                   ; preds = %106
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %108
+ThrowNullRef42:                                   ; preds = %108
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %112
+ThrowNullRef44:                                   ; preds = %112
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %118
+ThrowNullRef46:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %121
+ThrowNullRef48:                                   ; preds = %121
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %123
+ThrowNullRef50:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %130
+ThrowNullRef52:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %132
+ThrowNullRef54:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %144
+ThrowNullRef56:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %146
+ThrowNullRef58:                                   ; preds = %146
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %60
+ThrowNullRef60:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %63
+ThrowNullRef62:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %49
+ThrowNullRef64:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %51
+ThrowNullRef66:                                   ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %53
+ThrowNullRef68:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(%"System.Char[]" addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %arg0 = alloca %"System.Char[]" addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store %"System.Char[]" addrspace(1)* %param0, %"System.Char[]" addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load i32, i32* %arg4
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %43, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %38, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg1
+  %13 = load i32, i32* %arg4
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %38, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %24 = load i32, i32* %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %35 = load i32, i32* %arg3
+  %36 = load i32, i32* %arg4
+  %37 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %37, %"System.Char[]" addrspace(1)* %34, i32 %35, i32 %36)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:38                                      ; preds = %5, %16
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Successfully read Buffer._Memmove
 
@@ -7914,7 +9431,7 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[loadElem]
+Failed to read AppDomain.SetDataHelper[storeElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -7923,8 +9440,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
@@ -7934,8 +9451,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
@@ -7947,15 +9464,15 @@ entry:
   %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
   %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
@@ -7966,15 +9483,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7992,7 +9509,79 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
-Failed to read Dictionary`2.TryGetValue[loadElemA]
+Successfully read Dictionary`2.TryGetValue
+
+define i8 @"Dictionary`2.TryGetValue"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)* addrspace(1)* %param2) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  %arg2 = alloca %System.__Canon addrspace(1)* addrspace(1)*
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  store %System.__Canon addrspace(1)* addrspace(1)* %param2, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  store i32 %2, i32* %loc0
+  %3 = load i32, i32* %loc0
+  %4 = icmp slt i32 %3, 0
+  br i1 %4, label %22, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 2
+  %10 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %9, align 8
+  %11 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = zext i32 %11 to i64
+  %BoundsCheck = icmp uge i64 %16, %15
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 3, i32 %11
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %20, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %6, %System.__Canon addrspace(1)* %21)
+  ret i8 1
+
+; <label>:22                                      ; preds = %entry
+  %23 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %23, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -8058,8 +9647,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
@@ -8091,8 +9680,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
@@ -8171,15 +9760,15 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck, label %19, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %ThrowNullRef, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
   %21 = load i32, i32 addrspace(1)* %20
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
@@ -8202,7 +9791,7 @@ ThrowNullRef:                                     ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %19
+ThrowNullRef2:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8248,8 +9837,8 @@ entry:
   %0 = alloca %System.AppDomainHandle
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %1 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %1, i32 0, i32 15
@@ -8269,8 +9858,8 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
@@ -8286,7 +9875,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -8299,8 +9888,8 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -8327,8 +9916,8 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
@@ -8352,8 +9941,8 @@ entry:
   %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
   store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
@@ -8363,8 +9952,8 @@ entry:
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
@@ -8374,8 +9963,8 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %9
   %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
@@ -8384,8 +9973,8 @@ entry:
 
 ; <label>:18                                      ; preds = %3, %16
   %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
@@ -8397,15 +9986,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %18
+ThrowNullRef6:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8418,8 +10007,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
@@ -8453,15 +10042,15 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
@@ -8473,7 +10062,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8481,7 +10070,7 @@ ThrowNullRef1:                                    ; preds = %1
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
 Failed to read Dictionary`2.System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
@@ -8506,8 +10095,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
@@ -8524,8 +10113,8 @@ entry:
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -8544,7 +10133,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8577,8 +10166,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = load i64, i64* %arg2
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = trunc i32 %3 to i8
@@ -8634,46 +10223,46 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
   %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
-  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
-  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
-  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
@@ -8684,27 +10273,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %20
+ThrowNullRef12:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8717,8 +10306,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -8756,22 +10345,22 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
   %9 = load i64, i64 addrspace(1)* %8, align 8
   %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
   %13 = load i64, i64 addrspace(1)* %12, align 8
   %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %11
   %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
@@ -8788,11 +10377,11 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8882,8 +10471,8 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
@@ -8900,8 +10489,8 @@ entry:
 ; <label>:8                                       ; preds = %1
   %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
   %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
@@ -8911,15 +10500,15 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
   %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
   %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
-  br i1 %NullCheck6, label %21, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
@@ -8946,15 +10535,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8992,15 +10581,15 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
   store i8 %3, i8 addrspace(1)* %5
   %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
@@ -9011,7 +10600,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9027,8 +10616,8 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -9041,8 +10630,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
@@ -9058,7 +10647,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9080,8 +10669,8 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
@@ -9096,8 +10685,8 @@ entry:
 ; <label>:12                                      ; preds = %6
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
@@ -9112,8 +10701,8 @@ entry:
 ; <label>:21                                      ; preds = %15
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
@@ -9128,8 +10717,8 @@ entry:
 ; <label>:30                                      ; preds = %24
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %31, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
@@ -9144,8 +10733,8 @@ entry:
 ; <label>:39                                      ; preds = %33
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
-  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %40, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %42
 
 ; <label>:42                                      ; preds = %39
   %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
@@ -9164,19 +10753,19 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %21
+ThrowNullRef4:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %30
+ThrowNullRef6:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %39
+ThrowNullRef8:                                    ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9243,8 +10832,8 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
@@ -9264,57 +10853,57 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
   store i8 0, i8 addrspace(1)* %2
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
   store i8 0, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
   store i8 0, i8 addrspace(1)* %17
   %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
   store i8 0, i8 addrspace(1)* %20
   %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
-  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
@@ -9325,31 +10914,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %19
+ThrowNullRef14:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9367,8 +10956,8 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
@@ -9380,8 +10969,8 @@ entry:
 
 ; <label>:9                                       ; preds = %4
   %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %9
   %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
@@ -9395,7 +10984,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef2:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9420,8 +11009,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
@@ -9512,8 +11101,8 @@ entry:
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
@@ -9524,8 +11113,8 @@ entry:
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = load i64, i64 addrspace(1)* %12
@@ -9537,8 +11126,8 @@ entry:
   %20 = load i64, i64* %19
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
-  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %13
   %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
@@ -9555,8 +11144,8 @@ entry:
 ; <label>:30                                      ; preds = %25
   %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %32 = load i32, i32* %arg2
-  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
-  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
@@ -9570,15 +11159,15 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %30
+ThrowNullRef2:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9622,87 +11211,87 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
   %10 = load i8, i8 addrspace(1)* %9, align 8
   %11 = zext i8 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %8
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
   store i8 %12, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
   %19 = load i8, i8 addrspace(1)* %18, align 8
   %20 = zext i8 %19 to i32
   %21 = trunc i32 %20 to i8
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
   store i8 %21, i8 addrspace(1)* %23
   %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
   %28 = load i8, i8 addrspace(1)* %27, align 8
   %29 = zext i8 %28 to i32
   %30 = trunc i32 %29 to i8
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
-  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %31
 
 ; <label>:31                                      ; preds = %26
   %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
   store i8 %30, i8 addrspace(1)* %32
   %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
-  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
-  br i1 %NullCheck14, label %40, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %40
 
 ; <label>:40                                      ; preds = %35
   %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
   store i8 %39, i8 addrspace(1)* %41
   %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
-  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %44
 
 ; <label>:44                                      ; preds = %40
   %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
   %46 = load i8, i8 addrspace(1)* %45, align 8
   %47 = zext i8 %46 to i32
   %48 = trunc i32 %47 to i8
-  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
   store i8 %48, i8 addrspace(1)* %50
   %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
-  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
@@ -9713,29 +11302,29 @@ entry:
 ; <label>:56                                      ; preds = %52
   %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
-  br i1 %NullCheck22, label %59, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
   %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
   %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
-  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
-  br i1 %NullCheck24, label %63, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
   %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
-  br i1 %NullCheck26, label %66, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
   %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
-  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
-  br i1 %NullCheck28, label %69, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %69
 
 ; <label>:69                                      ; preds = %66
   %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
@@ -9744,15 +11333,15 @@ entry:
 
 ; <label>:71                                      ; preds = %105
   %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
-  br i1 %NullCheck34, label %73, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %73
 
 ; <label>:73                                      ; preds = %71
   %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
   %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
   %76 = load i32, i32* %loc0
-  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
-  br i1 %NullCheck36, label %77, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
@@ -9766,8 +11355,8 @@ entry:
 
 ; <label>:83                                      ; preds = %77
   %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
-  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
@@ -9775,14 +11364,14 @@ entry:
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
   %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
-  br i1 %NullCheck40, label %91, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
 ; <label>:91                                      ; preds = %85
   %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
   %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
-  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck42, label %94, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %94
 
 ; <label>:94                                      ; preds = %91
   %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
@@ -9798,14 +11387,14 @@ entry:
 ; <label>:99                                      ; preds = %69, %96
   %100 = load i32, i32* %loc0
   %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
-  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %102
 
 ; <label>:102                                     ; preds = %99
   %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
   %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
-  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
-  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
@@ -9819,87 +11408,87 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %26
+ThrowNullRef10:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %31
+ThrowNullRef12:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %35
+ThrowNullRef14:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %40
+ThrowNullRef16:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %56
+ThrowNullRef22:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %59
+ThrowNullRef24:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %63
+ThrowNullRef26:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %66
+ThrowNullRef28:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %102
+ThrowNullRef32:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %71
+ThrowNullRef34:                                   ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %73
+ThrowNullRef36:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %83
+ThrowNullRef38:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %85
+ThrowNullRef40:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %91
+ThrowNullRef42:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9943,15 +11532,15 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
   %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
@@ -9961,28 +11550,28 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
   %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %12
   %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
   %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
   %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
-  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
@@ -9993,23 +11582,23 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %12
+ThrowNullRef6:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10031,15 +11620,15 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
   %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = load i64, i64 addrspace(1)* %7
@@ -10077,13 +11666,13 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[loadElem]
+Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -10111,8 +11700,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -10178,8 +11767,8 @@ entry:
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load double, double* %arg0
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -10313,8 +11902,8 @@ entry:
   store i64 %param0, i64* %arg0
   store i64 %param1, i64* %arg1
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
@@ -10322,8 +11911,8 @@ entry:
   %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
   %5 = load i16*, i16* addrspace(1)* %4, align 8
   %6 = addrspacecast i64* %arg1 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = bitcast i64 addrspace(1)* %6 to i8 addrspace(1)*
@@ -10339,7 +11928,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10373,8 +11962,8 @@ entry:
   %1 = load i32, i32* %arg1
   %2 = sext i32 %1 to i64
   %3 = inttoptr i64 %2 to i16*
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -10427,8 +12016,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, i32)*)(%System.IO.ConsoleStream addrspace(1)* %2, i32 %1)
   %3 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %4 = load i64, i64* %arg1
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
@@ -10439,8 +12028,8 @@ entry:
   %10 = icmp eq i32 %9, 3
   %11 = sext i1 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %5
   %14 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, i32 0, i32 5
@@ -10451,7 +12040,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10474,8 +12063,8 @@ entry:
   %5 = icmp eq i32 %4, 1
   %6 = sext i1 %5 to i32
   %7 = trunc i32 %6 to i8
-  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %2, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.ConsoleStream addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
@@ -10486,8 +12075,8 @@ entry:
   %13 = icmp eq i32 %12, 2
   %14 = sext i1 %13 to i32
   %15 = trunc i32 %14 to i8
-  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %10, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.ConsoleStream addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %8
   %17 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %10, i32 0, i32 4
@@ -10498,7 +12087,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10537,8 +12126,8 @@ entry:
   %arg0 = alloca i64
   store i64 %param0, i64* %arg0
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
@@ -10573,8 +12162,8 @@ entry:
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
   %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = load i64, i64 addrspace(1)* %7
@@ -10678,7 +12267,127 @@ entry:
 INFO:  jitting method Encoding::GetEncoding using LLILCJit
 Failed to read Encoding.GetEncoding[convertToHelperArgumentType]
 INFO:  jitting method EncodingProvider::GetEncodingFromProvider using LLILCJit
-Failed to read EncodingProvider.GetEncodingFromProvider[loadElem]
+Successfully read EncodingProvider.GetEncodingFromProvider
+
+define %System.Text.Encoding addrspace(1)* @EncodingProvider.GetEncodingFromProvider(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca %"System.Text.EncodingProvider[]" addrspace(1)*
+  %loc1 = alloca %System.Text.EncodingProvider addrspace(1)*
+  %loc2 = alloca %System.Text.Encoding addrspace(1)*
+  %loc3 = alloca %System.Text.Encoding addrspace(1)*
+  %loc4 = alloca %"System.Text.EncodingProvider[]" addrspace(1)*
+  %loc5 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1059)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2392
+  %2 = addrspacecast i8 addrspace(1)* %1 to %"System.Text.EncodingProvider[]" addrspace(1)**
+  %3 = load volatile %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %2
+  %4 = icmp ne %"System.Text.EncodingProvider[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %entry
+  ret %System.Text.Encoding addrspace(1)* null
+
+; <label>:6                                       ; preds = %entry
+  %7 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1059)
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i64 2392
+  %9 = addrspacecast i8 addrspace(1)* %8 to %"System.Text.EncodingProvider[]" addrspace(1)**
+  %10 = load volatile %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %9
+  store %"System.Text.EncodingProvider[]" addrspace(1)* %10, %"System.Text.EncodingProvider[]" addrspace(1)** %loc0
+  %11 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc0
+  store %"System.Text.EncodingProvider[]" addrspace(1)* %11, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  store i32 0, i32* %loc5
+  br label %43
+
+; <label>:12                                      ; preds = %46
+  %13 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  %14 = load i32, i32* %loc5
+  %NullCheck1 = icmp eq %"System.Text.EncodingProvider[]" addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %13, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = zext i32 %17 to i64
+  %19 = zext i32 %14 to i64
+  %BoundsCheck = icmp uge i64 %19, %18
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %20
+
+; <label>:20                                      ; preds = %15
+  %21 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %13, i32 0, i32 3, i32 %14
+  %22 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)* addrspace(1)* %21, align 8
+  store %System.Text.EncodingProvider addrspace(1)* %22, %System.Text.EncodingProvider addrspace(1)** %loc1
+  %23 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)** %loc1
+  %24 = load i32, i32* %arg0
+  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i64 addrspace(1)*
+  %NullCheck3 = icmp eq i64 addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
+
+; <label>:26                                      ; preds = %20
+  %27 = load i64, i64 addrspace(1)* %25
+  %28 = add i64 %27, 64
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 40
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Text.Encoding addrspace(1)* (%System.Text.EncodingProvider addrspace(1)*, i32)*
+  %35 = call %System.Text.Encoding addrspace(1)* %34(%System.Text.EncodingProvider addrspace(1)* %23, i32 %24)
+  store %System.Text.Encoding addrspace(1)* %35, %System.Text.Encoding addrspace(1)** %loc2
+  %36 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc2
+  %37 = icmp eq %System.Text.Encoding addrspace(1)* %36, null
+  br i1 %37, label %40, label %38
+
+; <label>:38                                      ; preds = %26
+  %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc2
+  store %System.Text.Encoding addrspace(1)* %39, %System.Text.Encoding addrspace(1)** %loc3
+  br label %53
+
+; <label>:40                                      ; preds = %26
+  %41 = load i32, i32* %loc5
+  %42 = add i32 %41, 1
+  store i32 %42, i32* %loc5
+  br label %43
+
+; <label>:43                                      ; preds = %6, %40
+  %44 = load i32, i32* %loc5
+  %45 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  %NullCheck = icmp eq %"System.Text.EncodingProvider[]" addrspace(1)* %45, null
+  br i1 %NullCheck, label %ThrowNullRef, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp slt i32 %44, %50
+  br i1 %51, label %12, label %52
+
+; <label>:52                                      ; preds = %46
+  ret %System.Text.Encoding addrspace(1)* null
+
+; <label>:53                                      ; preds = %38
+  %54 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc3
+  ret %System.Text.Encoding addrspace(1)* %54
+
+ThrowNullRef:                                     ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method EncodingProvider::.cctor using LLILCJit
 Successfully read EncodingProvider..cctor
 
@@ -10697,7 +12406,7 @@ Failed to read Encoding.get_InternalSyncObject[Call HasTypeArg]
 INFO:  jitting method Hashtable::.ctor using LLILCJit
 Failed to read Hashtable..ctor[Volatile store]
 INFO:  jitting method Hashtable::get_Item using LLILCJit
-Failed to read Hashtable.get_Item[loadElemA]
+Failed to read Hashtable.get_Item[loadNonPrimitiveObj]
 INFO:  jitting method Hashtable::InitHash using LLILCJit
 Successfully read Hashtable.InitHash
 
@@ -10717,8 +12426,8 @@ entry:
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -10734,15 +12443,15 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
   %15 = load i32, i32* %loc0
-  %NullCheck2 = icmp ne i32 addrspace(1)* %14, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i32 addrspace(1)* %14, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %3
   store i32 %15, i32 addrspace(1)* %14, align 8
   %17 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %18 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %NullCheck4 = icmp ne i32 addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i32 addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = load i32, i32 addrspace(1)* %18, align 8
@@ -10751,8 +12460,8 @@ entry:
   %23 = sub i32 %22, 1
   %24 = urem i32 %21, %23
   %25 = add i32 1, %24
-  %NullCheck6 = icmp ne i32 addrspace(1)* %17, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32 addrspace(1)* %17, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %19
   store i32 %25, i32 addrspace(1)* %17, align 8
@@ -10763,15 +12472,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %19
+ThrowNullRef6:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10786,8 +12495,8 @@ entry:
   store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
   store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %NullCheck = icmp ne %System.Collections.Hashtable addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Collections.Hashtable addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
@@ -10797,16 +12506,16 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Collections.Hashtable addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Collections.Hashtable addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
   %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck4 = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %9, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
   %13 = inttoptr i64 %11 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
@@ -10816,8 +12525,8 @@ entry:
 ; <label>:15                                      ; preds = %1
   %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -10835,15 +12544,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10857,8 +12566,8 @@ entry:
   store %System.Int32 addrspace(1)* %param0, %System.Int32 addrspace(1)** %this
   %0 = load %System.Int32 addrspace(1)*, %System.Int32 addrspace(1)** %this
   %1 = bitcast %System.Int32 addrspace(1)* %0 to i32 addrspace(1)*
-  %NullCheck = icmp ne i32 addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq i32 addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load i32, i32 addrspace(1)* %1, align 8
@@ -10934,8 +12643,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.UTF8Encoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
@@ -10944,15 +12653,15 @@ entry:
   %9 = load i8, i8* %arg2
   %10 = zext i8 %9 to i32
   %11 = trunc i32 %10 to i8
-  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %8, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %6
   %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %8, i32 0, i32 8
   store i8 %11, i8 addrspace(1)* %13
   %14 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %14, i32 0, i32 8
@@ -10964,8 +12673,8 @@ entry:
 ; <label>:20                                      ; preds = %15
   %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %22, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %22, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = load i64, i64 addrspace(1)* %22
@@ -10987,15 +12696,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %12
+ThrowNullRef4:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11010,8 +12719,8 @@ entry:
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
@@ -11033,16 +12742,16 @@ entry:
 ; <label>:10                                      ; preds = %1
   %11 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
   %12 = load i32, i32* %arg1
-  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %11, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.Encoding addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
   store i32 %12, i32 addrspace(1)* %14
   %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
   %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = load i64, i64 addrspace(1)* %16
@@ -11060,11 +12769,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11077,8 +12786,8 @@ entry:
   %this = alloca %System.Text.UTF8Encoding addrspace(1)*
   store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
   %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.UTF8Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
@@ -11090,16 +12799,16 @@ entry:
 ; <label>:6                                       ; preds = %1
   %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %8 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %10, %System.Text.EncoderFallback addrspace(1)* %8)
   %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %12 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
-  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %11, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %11, i32 0, i32 3
@@ -11112,8 +12821,8 @@ entry:
   %18 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %18, %System.String addrspace(1)* %17)
   %19 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %18 to %System.Text.EncoderFallback addrspace(1)*
-  %NullCheck6 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %16, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %16, i32 0, i32 2
@@ -11123,8 +12832,8 @@ entry:
   %24 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %24, %System.String addrspace(1)* %23)
   %25 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %24 to %System.Text.DecoderFallback addrspace(1)*
-  %NullCheck8 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %22, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %22, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %20
   %27 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %22, i32 0, i32 3
@@ -11135,19 +12844,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %20
+ThrowNullRef8:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11177,8 +12886,8 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load i32, i32* %arg1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -11196,8 +12905,8 @@ entry:
 ; <label>:15                                      ; preds = %8
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %17 = load i32, i32* %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 %17
@@ -11213,7 +12922,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11265,7 +12974,7 @@ entry:
 }
 
 INFO:  jitting method Hashtable::Insert using LLILCJit
-Failed to read Hashtable.Insert[loadElemA]
+Failed to read Hashtable.Insert[storeElem]
 INFO:  jitting method ConsoleEncoding::.ctor using LLILCJit
 Successfully read ConsoleEncoding..ctor
 
@@ -11280,8 +12989,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %1)
   %2 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
@@ -11317,8 +13026,8 @@ entry:
   %2 = call %System.Text.InternalEncoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalEncoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %1)
   %3 = bitcast %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2 to %System.Text.EncoderFallback addrspace(1)*
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
@@ -11328,8 +13037,8 @@ entry:
   %8 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %7)
   %9 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %8 to %System.Text.DecoderFallback addrspace(1)*
-  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %6, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.Encoding addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %4
   %11 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %6, i32 0, i32 3
@@ -11340,7 +13049,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11359,15 +13068,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* %1)
   %2 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   %6 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, i32 0, i32 1
@@ -11378,7 +13087,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11406,8 +13115,8 @@ entry:
   store %System.Text.InternalDecoderBestFitFallback addrspace(1)* %param0, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
   %0 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
@@ -11417,15 +13126,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %4)
   %5 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %6)
   %9 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, i32 0, i32 1
@@ -11436,11 +13145,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11508,8 +13217,8 @@ entry:
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
   %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = load i64, i64 addrspace(1)* %19
@@ -11573,8 +13282,8 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.ConsoleStream addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
@@ -11605,31 +13314,31 @@ entry:
   store i8 %param4, i8* %arg4
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %3, %System.IO.Stream addrspace(1)* %1)
   %4 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %4, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
   %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %4, i32 0, i32 4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %5)
   %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %6
   %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
   %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
   %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = load i64, i64 addrspace(1)* %13
@@ -11641,8 +13350,8 @@ entry:
   %21 = load i64, i64* %20
   %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %8, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %8, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %14
   %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 5
@@ -11660,24 +13369,24 @@ entry:
   %31 = load i32, i32* %arg3
   %32 = sext i32 %31 to i64
   %33 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %32)
-  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %30, null
-  br i1 %NullCheck10, label %34, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.StreamWriter addrspace(1)* %30, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %35, %"System.Char[]" addrspace(1)* %33)
   %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %37, null
-  br i1 %NullCheck12, label %38, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.StreamWriter addrspace(1)* %37, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %38
 
 ; <label>:38                                      ; preds = %34
   %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
   %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
   %41 = load i32, i32* %arg3
   %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %42, null
-  br i1 %NullCheck14, label %43, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %42, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
   %44 = load i64, i64 addrspace(1)* %42
@@ -11691,30 +13400,30 @@ entry:
   %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
   %53 = sext i32 %52 to i64
   %54 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %53)
-  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
-  br i1 %NullCheck16, label %55, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %55
 
 ; <label>:55                                      ; preds = %43
   %56 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %56, %"System.Byte[]" addrspace(1)* %54)
   %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %58 = load i32, i32* %arg3
-  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %57, null
-  br i1 %NullCheck18, label %59, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.StreamWriter addrspace(1)* %57, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %59
 
 ; <label>:59                                      ; preds = %55
   %60 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 10
   store i32 %58, i32 addrspace(1)* %60
   %61 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %61, null
-  br i1 %NullCheck20, label %62, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.IO.StreamWriter addrspace(1)* %61, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %62
 
 ; <label>:62                                      ; preds = %59
   %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
   %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
   %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
   %67 = load i64, i64 addrspace(1)* %65
@@ -11732,15 +13441,15 @@ entry:
 
 ; <label>:78                                      ; preds = %66
   %79 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %79, null
-  br i1 %NullCheck24, label %80, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.StreamWriter addrspace(1)* %79, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %80
 
 ; <label>:80                                      ; preds = %78
   %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
   %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
   %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %83, null
-  br i1 %NullCheck26, label %84, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %83, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
   %85 = load i64, i64 addrspace(1)* %83
@@ -11757,8 +13466,8 @@ entry:
 
 ; <label>:95                                      ; preds = %84
   %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.IO.StreamWriter addrspace(1)* %96, null
-  br i1 %NullCheck28, label %97, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.IO.StreamWriter addrspace(1)* %96, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %97
 
 ; <label>:97                                      ; preds = %95
   %98 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 12
@@ -11772,8 +13481,8 @@ entry:
   %103 = icmp eq i32 %102, 0
   %104 = sext i1 %103 to i32
   %105 = trunc i32 %104 to i8
-  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %100, null
-  br i1 %NullCheck30, label %106, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.IO.StreamWriter addrspace(1)* %100, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %106
 
 ; <label>:106                                     ; preds = %99
   %107 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %100, i32 0, i32 13
@@ -11784,63 +13493,63 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %6
+ThrowNullRef4:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %29
+ThrowNullRef10:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %34
+ThrowNullRef12:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %38
+ThrowNullRef14:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %43
+ThrowNullRef16:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %55
+ThrowNullRef18:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %59
+ThrowNullRef20:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %62
+ThrowNullRef22:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %78
+ThrowNullRef24:                                   ; preds = %78
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %80
+ThrowNullRef26:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %95
+ThrowNullRef28:                                   ; preds = %95
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11853,15 +13562,15 @@ entry:
   %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = load i64, i64 addrspace(1)* %4
@@ -11879,7 +13588,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11929,35 +13638,35 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
   %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderNLS addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %7 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.EncoderNLS addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Text.Encoding addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.Encoding addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Text.EncoderNLS addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.EncoderNLS addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
   %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck8 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = load i64, i64 addrspace(1)* %16
@@ -11976,19 +13685,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12014,8 +13723,8 @@ entry:
   %this = alloca %System.Text.Encoding addrspace(1)*
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
@@ -12035,15 +13744,15 @@ entry:
   %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
   store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
   %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
   store i32 0, i32 addrspace(1)* %2
   %3 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, i32 0, i32 2
@@ -12053,15 +13762,15 @@ entry:
 
 ; <label>:8                                       ; preds = %4
   %9 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
   %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
   %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = load i64, i64 addrspace(1)* %13
@@ -12082,15 +13791,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12105,16 +13814,16 @@ entry:
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = load i32, i32* %arg1
   %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
   %7 = load i64, i64 addrspace(1)* %5
@@ -12132,7 +13841,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12169,8 +13878,8 @@ entry:
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
   %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
   %16 = load i64, i64 addrspace(1)* %14
@@ -12191,8 +13900,8 @@ entry:
   %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
   %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
   %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %31, null
-  br i1 %NullCheck2, label %32, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = load i64, i64 addrspace(1)* %31
@@ -12235,7 +13944,7 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12248,14 +13957,14 @@ entry:
   %this = alloca %System.Text.EncoderReplacementFallback addrspace(1)*
   store %System.Text.EncoderReplacementFallback addrspace(1)* %param0, %System.Text.EncoderReplacementFallback addrspace(1)** %this
   %0 = load %System.Text.EncoderReplacementFallback addrspace(1)*, %System.Text.EncoderReplacementFallback addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -12266,7 +13975,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12296,8 +14005,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
@@ -12329,8 +14038,8 @@ entry:
   %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
   store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
@@ -12342,8 +14051,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Threading.Tasks.Task addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %7)
@@ -12366,7 +14075,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12385,8 +14094,8 @@ entry:
   store i8 %param1, i8* %arg1
   store i8 %param2, i8* %arg2
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
@@ -12400,8 +14109,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1, %5
   %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 9
@@ -12432,8 +14141,8 @@ entry:
 
 ; <label>:25                                      ; preds = %8, %20
   %26 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %26, null
-  br i1 %NullCheck4, label %27, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %26, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %26, i32 0, i32 12
@@ -12444,22 +14153,22 @@ entry:
 
 ; <label>:32                                      ; preds = %27
   %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %33, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.IO.StreamWriter addrspace(1)* %33, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %32
   %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 12
   store i8 1, i8 addrspace(1)* %35
   %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
-  br i1 %NullCheck8, label %37, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
   %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
   %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck10 = icmp ne i64 addrspace(1)* %40, null
-  br i1 %NullCheck10, label %41, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64 addrspace(1)* %40, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i64, i64 addrspace(1)* %40
@@ -12473,8 +14182,8 @@ entry:
   %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
   store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
   %51 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %NullCheck12 = icmp ne %"System.Byte[]" addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Byte[]" addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %41
   %53 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %51, i32 0, i32 1
@@ -12486,16 +14195,16 @@ entry:
 
 ; <label>:58                                      ; preds = %52
   %59 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %59, null
-  br i1 %NullCheck14, label %60, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.IO.StreamWriter addrspace(1)* %59, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %60
 
 ; <label>:60                                      ; preds = %58
   %61 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %59, i32 0, i32 3
   %62 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
   %64 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %NullCheck16 = icmp ne %"System.Byte[]" addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %"System.Byte[]" addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %60
   %66 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %64, i32 0, i32 1
@@ -12503,8 +14212,8 @@ entry:
   %68 = zext i32 %67 to i64
   %69 = trunc i64 %68 to i32
   %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck18, label %71, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
   %72 = load i64, i64 addrspace(1)* %70
@@ -12520,29 +14229,29 @@ entry:
 
 ; <label>:80                                      ; preds = %27, %52, %71
   %81 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %81, null
-  br i1 %NullCheck20, label %82, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.IO.StreamWriter addrspace(1)* %81, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
 
 ; <label>:82                                      ; preds = %80
   %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %81, i32 0, i32 5
   %84 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %83, align 8
   %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.IO.StreamWriter addrspace(1)* %85, null
-  br i1 %NullCheck22, label %86, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.IO.StreamWriter addrspace(1)* %85, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %86
 
 ; <label>:86                                      ; preds = %82
   %87 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 7
   %88 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %87, align 8
   %89 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %89, null
-  br i1 %NullCheck24, label %90, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.StreamWriter addrspace(1)* %89, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %90
 
 ; <label>:90                                      ; preds = %86
   %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %89, i32 0, i32 9
   %92 = load i32, i32 addrspace(1)* %91, align 8
   %93 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.IO.StreamWriter addrspace(1)* %93, null
-  br i1 %NullCheck26, label %94, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.IO.StreamWriter addrspace(1)* %93, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %93, i32 0, i32 6
@@ -12550,8 +14259,8 @@ entry:
   %97 = load i8, i8* %arg2
   %98 = zext i8 %97 to i32
   %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
-  %NullCheck28 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck28, label %100, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
   %101 = load i64, i64 addrspace(1)* %99
@@ -12566,8 +14275,8 @@ entry:
   %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
   store i32 %110, i32* %loc1
   %111 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %111, null
-  br i1 %NullCheck30, label %112, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.IO.StreamWriter addrspace(1)* %111, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %112
 
 ; <label>:112                                     ; preds = %100
   %113 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %111, i32 0, i32 9
@@ -12578,23 +14287,23 @@ entry:
 
 ; <label>:116                                     ; preds = %112
   %117 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck32 = icmp ne %System.IO.StreamWriter addrspace(1)* %117, null
-  br i1 %NullCheck32, label %118, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.IO.StreamWriter addrspace(1)* %117, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %118
 
 ; <label>:118                                     ; preds = %116
   %119 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %117, i32 0, i32 3
   %120 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %119, align 8
   %121 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.IO.StreamWriter addrspace(1)* %121, null
-  br i1 %NullCheck34, label %122, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.IO.StreamWriter addrspace(1)* %121, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %122
 
 ; <label>:122                                     ; preds = %118
   %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
   %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
   %125 = load i32, i32* %loc1
   %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
-  %NullCheck36 = icmp ne i64 addrspace(1)* %126, null
-  br i1 %NullCheck36, label %127, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64 addrspace(1)* %126, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
   %128 = load i64, i64 addrspace(1)* %126
@@ -12616,15 +14325,15 @@ entry:
 
 ; <label>:140                                     ; preds = %136
   %141 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.IO.StreamWriter addrspace(1)* %141, null
-  br i1 %NullCheck38, label %142, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.IO.StreamWriter addrspace(1)* %141, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %142
 
 ; <label>:142                                     ; preds = %140
   %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
   %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
   %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
-  %NullCheck40 = icmp ne i64 addrspace(1)* %145, null
-  br i1 %NullCheck40, label %146, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i64 addrspace(1)* %145, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
   %147 = load i64, i64 addrspace(1)* %145
@@ -12645,83 +14354,83 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %25
+ThrowNullRef4:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %32
+ThrowNullRef6:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %37
+ThrowNullRef10:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %41
+ThrowNullRef12:                                   ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %58
+ThrowNullRef14:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %60
+ThrowNullRef16:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %65
+ThrowNullRef18:                                   ; preds = %65
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %80
+ThrowNullRef20:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %82
+ThrowNullRef22:                                   ; preds = %82
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %86
+ThrowNullRef24:                                   ; preds = %86
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %90
+ThrowNullRef26:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %94
+ThrowNullRef28:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %100
+ThrowNullRef30:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %116
+ThrowNullRef32:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %118
+ThrowNullRef34:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %122
+ThrowNullRef36:                                   ; preds = %122
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %140
+ThrowNullRef38:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %142
+ThrowNullRef40:                                   ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12788,8 +14497,8 @@ entry:
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %1 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
-  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
@@ -12797,8 +14506,8 @@ entry:
   %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
   %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
   %8 = load i64, i64 addrspace(1)* %6
@@ -12814,8 +14523,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %17, %System.IFormatProvider addrspace(1)* %16)
   %18 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %19 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %18, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.SyncTextWriter addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %7
   %21 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %18, i32 0, i32 4
@@ -12826,11 +14535,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12843,8 +14552,8 @@ entry:
   %this = alloca %System.IO.TextWriter addrspace(1)*
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.TextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
@@ -12854,8 +14563,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.Threading.Thread addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Threading.Thread addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %6)
@@ -12864,8 +14573,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1
   %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.TextWriter addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.TextWriter addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %11, i32 0, i32 2
@@ -12876,11 +14585,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13077,8 +14786,8 @@ entry:
   store double %param1, double* %arg1
   store i8 0, i8* %loc1
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
@@ -13088,16 +14797,16 @@ entry:
   %5 = addrspacecast i8* %loc1 to i8 addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %4, i8 addrspace(1)* %5)
   %6 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.SyncTextWriter addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
   %10 = load double, double* %arg1
   %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
   %13 = load i64, i64 addrspace(1)* %11
@@ -13132,11 +14841,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13153,8 +14862,8 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load double, double* %arg1
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -13168,8 +14877,8 @@ entry:
   call void %11(%System.IO.TextWriter addrspace(1)* %0, double %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
   %15 = load i64, i64 addrspace(1)* %13
@@ -13187,7 +14896,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13205,8 +14914,8 @@ entry:
   %1 = addrspacecast double* %arg1 to double addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -13221,8 +14930,8 @@ entry:
   %14 = bitcast double addrspace(1)* %1 to %System.Double addrspace(1)*
   %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Double addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Double addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
   %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
   %18 = load i64, i64 addrspace(1)* %16
@@ -13240,7 +14949,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13256,8 +14965,8 @@ entry:
   store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
   %0 = load %System.Double addrspace(1)*, %System.Double addrspace(1)** %this
   %1 = bitcast %System.Double addrspace(1)* %0 to double addrspace(1)*
-  %NullCheck = icmp ne double addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq double addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load double, double addrspace(1)* %1, align 8
@@ -13282,8 +14991,8 @@ entry:
   %loc0 = alloca %System.Globalization.NumberFormatInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 3
@@ -13293,8 +15002,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
@@ -13304,24 +15013,24 @@ entry:
   store %System.Globalization.NumberFormatInfo addrspace(1)* %10, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
   %11 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %7
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
   %15 = load i8, i8 addrspace(1)* %14, align 8
   %16 = zext i8 %15 to i32
   %17 = trunc i32 %16 to i8
-  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %11, null
-  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %11, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %13
   %19 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %11, i32 0, i32 29
   store i8 %17, i8 addrspace(1)* %19
   %20 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %21 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %20, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %20, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %18
   %23 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %20, i32 0, i32 3
@@ -13330,8 +15039,8 @@ entry:
 
 ; <label>:24                                      ; preds = %1, %22
   %25 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %25, null
-  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %25, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %26
 
 ; <label>:26                                      ; preds = %24
   %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %25, i32 0, i32 3
@@ -13342,23 +15051,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %18
+ThrowNullRef8:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13383,168 +15092,168 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 18
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %8, align 8
-  %NullCheck2 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %5, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %5, i32 0, i32 4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %9)
   %12 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 19
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %15, align 8
-  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %12, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %12, i32 0, i32 5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %16)
   %19 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %20 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %20, null
-  br i1 %NullCheck8, label %21, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %20, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %20, i32 0, i32 23
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  %NullCheck10 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %19, null
-  br i1 %NullCheck10, label %24, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %19, i32 0, i32 7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %25, %System.String addrspace(1)* %23)
   %26 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %27 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %27, i32 0, i32 22
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %29, align 8
-  %NullCheck14 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %26, null
-  br i1 %NullCheck14, label %31, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %26, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %26, i32 0, i32 6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %32, %System.String addrspace(1)* %30)
   %33 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %34 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Globalization.CultureData addrspace(1)* %34, null
-  br i1 %NullCheck16, label %35, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Globalization.CultureData addrspace(1)* %34, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %34, i32 0, i32 51
   %37 = load i32, i32 addrspace(1)* %36, align 8
-  %NullCheck18 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %33, null
-  br i1 %NullCheck18, label %38, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %33, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %33, i32 0, i32 21
   store i32 %37, i32 addrspace(1)* %39
   %40 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %41 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Globalization.CultureData addrspace(1)* %41, null
-  br i1 %NullCheck20, label %42, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Globalization.CultureData addrspace(1)* %41, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %41, i32 0, i32 52
   %44 = load i32, i32 addrspace(1)* %43, align 8
-  %NullCheck22 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %40, null
-  br i1 %NullCheck22, label %45, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %40, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %40, i32 0, i32 25
   store i32 %44, i32 addrspace(1)* %46
   %47 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %48 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.Globalization.CultureData addrspace(1)* %48, null
-  br i1 %NullCheck24, label %49, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Globalization.CultureData addrspace(1)* %48, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %49
 
 ; <label>:49                                      ; preds = %45
   %50 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %48, i32 0, i32 29
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck26 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %47, null
-  br i1 %NullCheck26, label %52, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %47, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %47, i32 0, i32 10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %53, %System.String addrspace(1)* %51)
   %54 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %55 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Globalization.CultureData addrspace(1)* %55, null
-  br i1 %NullCheck28, label %56, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Globalization.CultureData addrspace(1)* %55, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %56
 
 ; <label>:56                                      ; preds = %52
   %57 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %55, i32 0, i32 35
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %57, align 8
-  %NullCheck30 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %54, null
-  br i1 %NullCheck30, label %59, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %54, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %54, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %60, %System.String addrspace(1)* %58)
   %61 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %62 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck32 = icmp ne %System.Globalization.CultureData addrspace(1)* %62, null
-  br i1 %NullCheck32, label %63, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Globalization.CultureData addrspace(1)* %62, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %62, i32 0, i32 34
   %65 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %64, align 8
-  %NullCheck34 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %61, null
-  br i1 %NullCheck34, label %66, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %61, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %61, i32 0, i32 9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %67, %System.String addrspace(1)* %65)
   %68 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %69 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck36 = icmp ne %System.Globalization.CultureData addrspace(1)* %69, null
-  br i1 %NullCheck36, label %70, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Globalization.CultureData addrspace(1)* %69, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %70
 
 ; <label>:70                                      ; preds = %66
   %71 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %69, i32 0, i32 55
   %72 = load i32, i32 addrspace(1)* %71, align 8
-  %NullCheck38 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %68, null
-  br i1 %NullCheck38, label %73, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %68, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %68, i32 0, i32 22
   store i32 %72, i32 addrspace(1)* %74
   %75 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %76 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck40 = icmp ne %System.Globalization.CultureData addrspace(1)* %76, null
-  br i1 %NullCheck40, label %77, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Globalization.CultureData addrspace(1)* %76, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %76, i32 0, i32 57
   %79 = load i32, i32 addrspace(1)* %78, align 8
-  %NullCheck42 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %75, null
-  br i1 %NullCheck42, label %80, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %75, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %80
 
 ; <label>:80                                      ; preds = %77
   %81 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %75, i32 0, i32 24
   store i32 %79, i32 addrspace(1)* %81
   %82 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %83 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck44 = icmp ne %System.Globalization.CultureData addrspace(1)* %83, null
-  br i1 %NullCheck44, label %84, label %ThrowNullRef43
+  %NullCheck43 = icmp eq %System.Globalization.CultureData addrspace(1)* %83, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %84
 
 ; <label>:84                                      ; preds = %80
   %85 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %83, i32 0, i32 56
   %86 = load i32, i32 addrspace(1)* %85, align 8
-  %NullCheck46 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %82, null
-  br i1 %NullCheck46, label %87, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %82, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %82, i32 0, i32 23
@@ -13553,8 +15262,8 @@ entry:
 
 ; <label>:89                                      ; preds = %entry
   %90 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck100 = icmp ne %System.Globalization.CultureData addrspace(1)* %90, null
-  br i1 %NullCheck100, label %91, label %ThrowNullRef99
+  %NullCheck99 = icmp eq %System.Globalization.CultureData addrspace(1)* %90, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %91
 
 ; <label>:91                                      ; preds = %89
   %92 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %90, i32 0, i32 2
@@ -13572,8 +15281,8 @@ entry:
   %102 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %103 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %104 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %103)
-  %NullCheck48 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %102, null
-  br i1 %NullCheck48, label %105, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %102, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %105
 
 ; <label>:105                                     ; preds = %101
   %106 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %102, i32 0, i32 1
@@ -13581,8 +15290,8 @@ entry:
   %107 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %108 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %109 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %108)
-  %NullCheck50 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %107, null
-  br i1 %NullCheck50, label %110, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %107, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %110
 
 ; <label>:110                                     ; preds = %105
   %111 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %107, i32 0, i32 2
@@ -13590,8 +15299,8 @@ entry:
   %112 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %113 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %114 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %113)
-  %NullCheck52 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %112, null
-  br i1 %NullCheck52, label %115, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %112, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %115
 
 ; <label>:115                                     ; preds = %110
   %116 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %112, i32 0, i32 27
@@ -13599,8 +15308,8 @@ entry:
   %117 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %118 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %119 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %118)
-  %NullCheck54 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %117, null
-  br i1 %NullCheck54, label %120, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %117, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %120
 
 ; <label>:120                                     ; preds = %115
   %121 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %117, i32 0, i32 26
@@ -13608,8 +15317,8 @@ entry:
   %122 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %123 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %124 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %123)
-  %NullCheck56 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %122, null
-  br i1 %NullCheck56, label %125, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %122, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %125
 
 ; <label>:125                                     ; preds = %120
   %126 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %122, i32 0, i32 17
@@ -13617,8 +15326,8 @@ entry:
   %127 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %128 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %129 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %128)
-  %NullCheck58 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %127, null
-  br i1 %NullCheck58, label %130, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %127, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %130
 
 ; <label>:130                                     ; preds = %125
   %131 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %127, i32 0, i32 18
@@ -13626,8 +15335,8 @@ entry:
   %132 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %133 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %134 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %133)
-  %NullCheck60 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %132, null
-  br i1 %NullCheck60, label %135, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %132, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %135
 
 ; <label>:135                                     ; preds = %130
   %136 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %132, i32 0, i32 14
@@ -13635,8 +15344,8 @@ entry:
   %137 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %138 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %139 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %138)
-  %NullCheck62 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %137, null
-  br i1 %NullCheck62, label %140, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %137, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %140
 
 ; <label>:140                                     ; preds = %135
   %141 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %137, i32 0, i32 13
@@ -13644,71 +15353,71 @@ entry:
   %142 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %143 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %144 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %143)
-  %NullCheck64 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %142, null
-  br i1 %NullCheck64, label %145, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %142, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %145
 
 ; <label>:145                                     ; preds = %140
   %146 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %142, i32 0, i32 12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %146, %System.String addrspace(1)* %144)
   %147 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %148 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck66 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %148, null
-  br i1 %NullCheck66, label %149, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %148, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %149
 
 ; <label>:149                                     ; preds = %145
   %150 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %148, i32 0, i32 21
   %151 = load i32, i32 addrspace(1)* %150, align 8
-  %NullCheck68 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %147, null
-  br i1 %NullCheck68, label %152, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %147, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %152
 
 ; <label>:152                                     ; preds = %149
   %153 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %147, i32 0, i32 28
   store i32 %151, i32 addrspace(1)* %153
   %154 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %155 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck70 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %155, null
-  br i1 %NullCheck70, label %156, label %ThrowNullRef69
+  %NullCheck69 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %155, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %156
 
 ; <label>:156                                     ; preds = %152
   %157 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %155, i32 0, i32 6
   %158 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %157, align 8
-  %NullCheck72 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %154, null
-  br i1 %NullCheck72, label %159, label %ThrowNullRef71
+  %NullCheck71 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %154, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %159
 
 ; <label>:159                                     ; preds = %156
   %160 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %154, i32 0, i32 15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %160, %System.String addrspace(1)* %158)
   %161 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %162 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck74 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %162, null
-  br i1 %NullCheck74, label %163, label %ThrowNullRef73
+  %NullCheck73 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %162, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %163
 
 ; <label>:163                                     ; preds = %159
   %164 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %162, i32 0, i32 1
   %165 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %164, align 8
-  %NullCheck76 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %161, null
-  br i1 %NullCheck76, label %166, label %ThrowNullRef75
+  %NullCheck75 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %161, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %166
 
 ; <label>:166                                     ; preds = %163
   %167 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %161, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %167, %"System.Int32[]" addrspace(1)* %165)
   %168 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %169 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck78 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %169, null
-  br i1 %NullCheck78, label %170, label %ThrowNullRef77
+  %NullCheck77 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %169, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %170
 
 ; <label>:170                                     ; preds = %166
   %171 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %169, i32 0, i32 7
   %172 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %171, align 8
-  %NullCheck80 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %168, null
-  br i1 %NullCheck80, label %173, label %ThrowNullRef79
+  %NullCheck79 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %168, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %173
 
 ; <label>:173                                     ; preds = %170
   %174 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %168, i32 0, i32 16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %174, %System.String addrspace(1)* %172)
   %175 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck82 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %175, null
-  br i1 %NullCheck82, label %176, label %ThrowNullRef81
+  %NullCheck81 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %175, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %176
 
 ; <label>:176                                     ; preds = %173
   %177 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %175, i32 0, i32 4
@@ -13718,14 +15427,14 @@ entry:
 
 ; <label>:180                                     ; preds = %176
   %181 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck84 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %181, null
-  br i1 %NullCheck84, label %182, label %ThrowNullRef83
+  %NullCheck83 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %181, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %182
 
 ; <label>:182                                     ; preds = %180
   %183 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %181, i32 0, i32 4
   %184 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %183, align 8
-  %NullCheck86 = icmp ne %System.String addrspace(1)* %184, null
-  br i1 %NullCheck86, label %185, label %ThrowNullRef85
+  %NullCheck85 = icmp eq %System.String addrspace(1)* %184, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %185
 
 ; <label>:185                                     ; preds = %182
   %186 = getelementptr inbounds %System.String, %System.String addrspace(1)* %184, i32 0, i32 1
@@ -13736,8 +15445,8 @@ entry:
 ; <label>:189                                     ; preds = %176, %185
   %190 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck98 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %190, null
-  br i1 %NullCheck98, label %192, label %ThrowNullRef97
+  %NullCheck97 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %190, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %192
 
 ; <label>:192                                     ; preds = %189
   %193 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %190, i32 0, i32 4
@@ -13746,8 +15455,8 @@ entry:
 
 ; <label>:194                                     ; preds = %185, %192
   %195 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck88 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %195, null
-  br i1 %NullCheck88, label %196, label %ThrowNullRef87
+  %NullCheck87 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %195, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %196
 
 ; <label>:196                                     ; preds = %194
   %197 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %195, i32 0, i32 9
@@ -13757,14 +15466,14 @@ entry:
 
 ; <label>:200                                     ; preds = %196
   %201 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck90 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %201, null
-  br i1 %NullCheck90, label %202, label %ThrowNullRef89
+  %NullCheck89 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %201, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %202
 
 ; <label>:202                                     ; preds = %200
   %203 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %201, i32 0, i32 9
   %204 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %203, align 8
-  %NullCheck92 = icmp ne %System.String addrspace(1)* %204, null
-  br i1 %NullCheck92, label %205, label %ThrowNullRef91
+  %NullCheck91 = icmp eq %System.String addrspace(1)* %204, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %205
 
 ; <label>:205                                     ; preds = %202
   %206 = getelementptr inbounds %System.String, %System.String addrspace(1)* %204, i32 0, i32 1
@@ -13775,14 +15484,14 @@ entry:
 ; <label>:209                                     ; preds = %196, %205
   %210 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %211 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck94 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %211, null
-  br i1 %NullCheck94, label %212, label %ThrowNullRef93
+  %NullCheck93 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %211, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %212
 
 ; <label>:212                                     ; preds = %209
   %213 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %211, i32 0, i32 6
   %214 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %213, align 8
-  %NullCheck96 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %210, null
-  br i1 %NullCheck96, label %215, label %ThrowNullRef95
+  %NullCheck95 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %210, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %215
 
 ; <label>:215                                     ; preds = %212
   %216 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %210, i32 0, i32 9
@@ -13796,203 +15505,203 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %17
+ThrowNullRef8:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %21
+ThrowNullRef10:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %24
+ThrowNullRef12:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %28
+ThrowNullRef14:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %31
+ThrowNullRef16:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %35
+ThrowNullRef18:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %38
+ThrowNullRef20:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %42
+ThrowNullRef22:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %45
+ThrowNullRef24:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %49
+ThrowNullRef26:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %52
+ThrowNullRef28:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %56
+ThrowNullRef30:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %59
+ThrowNullRef32:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %63
+ThrowNullRef34:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %66
+ThrowNullRef36:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %70
+ThrowNullRef38:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %73
+ThrowNullRef40:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %77
+ThrowNullRef42:                                   ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %80
+ThrowNullRef44:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %84
+ThrowNullRef46:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %101
+ThrowNullRef48:                                   ; preds = %101
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %105
+ThrowNullRef50:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %110
+ThrowNullRef52:                                   ; preds = %110
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %115
+ThrowNullRef54:                                   ; preds = %115
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %120
+ThrowNullRef56:                                   ; preds = %120
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %125
+ThrowNullRef58:                                   ; preds = %125
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %130
+ThrowNullRef60:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %135
+ThrowNullRef62:                                   ; preds = %135
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %140
+ThrowNullRef64:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %145
+ThrowNullRef66:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %149
+ThrowNullRef68:                                   ; preds = %149
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %152
+ThrowNullRef70:                                   ; preds = %152
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %156
+ThrowNullRef72:                                   ; preds = %156
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %159
+ThrowNullRef74:                                   ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %163
+ThrowNullRef76:                                   ; preds = %163
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %166
+ThrowNullRef78:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %170
+ThrowNullRef80:                                   ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %173
+ThrowNullRef82:                                   ; preds = %173
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %180
+ThrowNullRef84:                                   ; preds = %180
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %182
+ThrowNullRef86:                                   ; preds = %182
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %194
+ThrowNullRef88:                                   ; preds = %194
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %200
+ThrowNullRef90:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %202
+ThrowNullRef92:                                   ; preds = %202
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %209
+ThrowNullRef94:                                   ; preds = %209
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %212
+ThrowNullRef96:                                   ; preds = %212
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %189
+ThrowNullRef98:                                   ; preds = %189
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %89
+ThrowNullRef100:                                  ; preds = %89
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14020,8 +15729,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 21
@@ -14034,8 +15743,8 @@ entry:
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 16)
   %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 21
@@ -14044,8 +15753,8 @@ entry:
 
 ; <label>:12                                      ; preds = %1, %10
   %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 21
@@ -14056,11 +15765,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %12
+ThrowNullRef4:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14076,8 +15785,8 @@ entry:
   store i32 %param1, i32* %arg1
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %1 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
@@ -14144,8 +15853,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 33
@@ -14158,8 +15867,8 @@ entry:
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 24)
   %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 33
@@ -14168,8 +15877,8 @@ entry:
 
 ; <label>:12                                      ; preds = %1, %10
   %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 33
@@ -14180,11 +15889,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %12
+ThrowNullRef4:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14197,8 +15906,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 53
@@ -14210,8 +15919,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 116)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 53
@@ -14220,8 +15929,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 53
@@ -14232,11 +15941,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14265,8 +15974,8 @@ entry:
 
 ; <label>:7                                       ; preds = %entry, %4
   %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %7
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 2
@@ -14290,8 +15999,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 54
@@ -14303,8 +16012,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 117)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
@@ -14313,8 +16022,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 54
@@ -14325,11 +16034,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14342,8 +16051,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 27
@@ -14355,8 +16064,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 118)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 27
@@ -14365,8 +16074,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 27
@@ -14377,11 +16086,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14394,8 +16103,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 28
@@ -14407,8 +16116,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 119)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 28
@@ -14417,8 +16126,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 28
@@ -14429,11 +16138,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14446,8 +16155,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 26
@@ -14459,8 +16168,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 107)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 26
@@ -14469,8 +16178,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 26
@@ -14481,11 +16190,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14498,8 +16207,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 25
@@ -14511,8 +16220,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 106)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 25
@@ -14521,8 +16230,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 25
@@ -14533,11 +16242,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14550,8 +16259,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 24
@@ -14563,8 +16272,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 105)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 24
@@ -14573,8 +16282,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 24
@@ -14585,11 +16294,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14614,8 +16323,8 @@ entry:
   %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %3)
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %2
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -14626,15 +16335,15 @@ entry:
 
 ; <label>:8                                       ; preds = %62
   %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 9
   %12 = load i32, i32 addrspace(1)* %11, align 8
   %13 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.IO.StreamWriter addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %13, i32 0, i32 10
@@ -14649,15 +16358,15 @@ entry:
 
 ; <label>:20                                      ; preds = %14, %18
   %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
   %24 = load i32, i32 addrspace(1)* %23, align 8
   %25 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %25, null
-  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.StreamWriter addrspace(1)* %25, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %25, i32 0, i32 9
@@ -14678,36 +16387,36 @@ entry:
   %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %37 = load i32, i32* %loc1
   %38 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.StreamWriter addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %35
   %40 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %38, i32 0, i32 7
   %41 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %40, align 8
   %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
-  br i1 %NullCheck14, label %43, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %39
   %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 9
   %45 = load i32, i32 addrspace(1)* %44, align 8
   %46 = load i32, i32* %loc2
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %36, null
-  br i1 %NullCheck16, label %47, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %36, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %47
 
 ; <label>:47                                      ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %36, i32 %37, %"System.Char[]" addrspace(1)* %41, i32 %45, i32 %46)
   %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
   %51 = load i32, i32 addrspace(1)* %50, align 8
   %52 = load i32, i32* %loc2
   %53 = add i32 %51, %52
-  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
-  br i1 %NullCheck20, label %54, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %54
 
 ; <label>:54                                      ; preds = %49
   %55 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
@@ -14729,8 +16438,8 @@ entry:
 
 ; <label>:65                                      ; preds = %62
   %66 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %66, null
-  br i1 %NullCheck2, label %67, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %66, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %67
 
 ; <label>:67                                      ; preds = %65
   %68 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %66, i32 0, i32 11
@@ -14751,49 +16460,259 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %65
+ThrowNullRef2:                                    ; preds = %65
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %20
+ThrowNullRef8:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %22
+ThrowNullRef10:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %35
+ThrowNullRef12:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %43
+ThrowNullRef16:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %47
+ThrowNullRef18:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method String::CopyTo using LLILCJit
-Failed to read String.CopyTo[loadElemA]
+Successfully read String.CopyTo
+
+define void @String.CopyTo(%System.String addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  %loc1 = alloca i16 addrspace(1)*
+  %loc2 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %1 = icmp ne %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg4
+  %7 = icmp sge i32 %6, 0
+  br i1 %7, label %13, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  unreachable
+
+; <label>:13                                      ; preds = %5
+  %14 = load i32, i32* %arg1
+  %15 = icmp sge i32 %14, 0
+  br i1 %15, label %21, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %18)
+  %20 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %20, %System.String addrspace(1)* %17, %System.String addrspace(1)* %19)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %20) #0
+  unreachable
+
+; <label>:21                                      ; preds = %13
+  %22 = load i32, i32* %arg4
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck, label %ThrowNullRef, label %24
+
+; <label>:24                                      ; preds = %21
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load i32, i32* %arg1
+  %28 = sub i32 %26, %27
+  %29 = icmp sle i32 %22, %28
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34, %System.String addrspace(1)* %31, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %24
+  %36 = load i32, i32* %arg3
+  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %37, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
+
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
+  %40 = load i32, i32 addrspace(1)* %39
+  %41 = zext i32 %40 to i64
+  %42 = trunc i64 %41 to i32
+  %43 = load i32, i32* %arg4
+  %44 = sub i32 %42, %43
+  %45 = icmp sgt i32 %36, %44
+  br i1 %45, label %49, label %46
+
+; <label>:46                                      ; preds = %38
+  %47 = load i32, i32* %arg3
+  %48 = icmp sge i32 %47, 0
+  br i1 %48, label %54, label %49
+
+; <label>:49                                      ; preds = %38, %46
+  %50 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %52 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %51)
+  %53 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53, %System.String addrspace(1)* %50, %System.String addrspace(1)* %52)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53) #0
+  unreachable
+
+; <label>:54                                      ; preds = %46
+  %55 = load i32, i32* %arg4
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %97, label %57
+
+; <label>:57                                      ; preds = %54
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %59
+
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 2
+  %61 = bitcast [0 x i16] addrspace(1)* %60 to i16 addrspace(1)*
+  store i16 addrspace(1)* %61, i16 addrspace(1)** %loc0
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  store %"System.Char[]" addrspace(1)* %62, %"System.Char[]" addrspace(1)** %loc2
+  %63 = icmp eq %"System.Char[]" addrspace(1)* %62, null
+  br i1 %63, label %72, label %64
+
+; <label>:64                                      ; preds = %59
+  %65 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc2
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %65, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %66
+
+; <label>:66                                      ; preds = %64
+  %67 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %65, i32 0, i32 1
+  %68 = load i32, i32 addrspace(1)* %67
+  %69 = zext i32 %68 to i64
+  %70 = trunc i64 %69 to i32
+  %71 = icmp ne i32 %70, 0
+  br i1 %71, label %73, label %72
+
+; <label>:72                                      ; preds = %59, %66
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  br label %81
+
+; <label>:73                                      ; preds = %66
+  %74 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc2
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %74, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %75
+
+; <label>:75                                      ; preds = %73
+  %76 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %74, i32 0, i32 1
+  %77 = load i32, i32 addrspace(1)* %76
+  %78 = zext i32 %77 to i64
+  %BoundsCheck = icmp uge i64 0, %78
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %79
+
+; <label>:79                                      ; preds = %75
+  %80 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %74, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %80, i16 addrspace(1)** %loc1
+  br label %81
+
+; <label>:81                                      ; preds = %72, %79
+  %82 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %83 = ptrtoint i16 addrspace(1)* %82 to i64
+  %84 = load i32, i32* %arg3
+  %85 = sext i32 %84 to i64
+  %86 = mul i64 %85, 2
+  %87 = add i64 %83, %86
+  %88 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %89 = ptrtoint i16 addrspace(1)* %88 to i64
+  %90 = load i32, i32* %arg1
+  %91 = sext i32 %90 to i64
+  %92 = mul i64 %91, 2
+  %93 = add i64 %89, %92
+  %94 = load i32, i32* %arg4
+  %95 = inttoptr i64 %87 to i16*
+  %96 = inttoptr i64 %93 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %95, i16* %96, i32 %94)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  br label %97
+
+; <label>:97                                      ; preds = %54, %81
+  ret void
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
 Successfully read ConsoleEncoding.GetPreamble
 
@@ -14830,7 +16749,365 @@ entry:
 }
 
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[loadElemA]
+Successfully read EncoderNLS.GetBytes
+
+define i32 @EncoderNLS.GetBytes(%System.Text.EncoderNLS addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3, %"System.Byte[]" addrspace(1)* %param4, i32 %param5, i8 %param6) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %arg4 = alloca %"System.Byte[]" addrspace(1)*
+  %arg5 = alloca i32
+  %arg6 = alloca i8
+  %loc0 = alloca i32
+  %loc1 = alloca i16 addrspace(1)*
+  %loc2 = alloca i8 addrspace(1)*
+  %loc3 = alloca i32
+  %loc4 = alloca %"System.Char[]" addrspace(1)*
+  %loc5 = alloca %"System.Byte[]" addrspace(1)*
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  store %"System.Byte[]" addrspace(1)* %param4, %"System.Byte[]" addrspace(1)** %arg4
+  store i32 %param5, i32* %arg5
+  store i8 %param6, i8* %arg6
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %1 = icmp eq %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %17, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %7 = icmp eq %"System.Char[]" addrspace(1)* %6, null
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %12
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %12
+
+; <label>:12                                      ; preds = %8, %10
+  %13 = phi %System.String addrspace(1)* [ %9, %8 ], [ %11, %10 ]
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %14)
+  %16 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16, %System.String addrspace(1)* %13, %System.String addrspace(1)* %15)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16) #0
+  unreachable
+
+; <label>:17                                      ; preds = %2
+  %18 = load i32, i32* %arg2
+  %19 = icmp slt i32 %18, 0
+  br i1 %19, label %23, label %20
+
+; <label>:20                                      ; preds = %17
+  %21 = load i32, i32* %arg3
+  %22 = icmp sge i32 %21, 0
+  br i1 %22, label %35, label %23
+
+; <label>:23                                      ; preds = %17, %20
+  %24 = load i32, i32* %arg2
+  %25 = icmp slt i32 %24, 0
+  br i1 %25, label %28, label %26
+
+; <label>:26                                      ; preds = %23
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %30
+
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %30
+
+; <label>:30                                      ; preds = %26, %28
+  %31 = phi %System.String addrspace(1)* [ %27, %26 ], [ %29, %28 ]
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34, %System.String addrspace(1)* %31, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %20
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck, label %ThrowNullRef, label %37
+
+; <label>:37                                      ; preds = %35
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = load i32, i32* %arg2
+  %43 = sub i32 %41, %42
+  %44 = load i32, i32* %arg3
+  %45 = icmp sge i32 %43, %44
+  br i1 %45, label %51, label %46
+
+; <label>:46                                      ; preds = %37
+  %47 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %48 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %49 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %48)
+  %50 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %50, %System.String addrspace(1)* %47, %System.String addrspace(1)* %49)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %50) #0
+  unreachable
+
+; <label>:51                                      ; preds = %37
+  %52 = load i32, i32* %arg5
+  %53 = icmp slt i32 %52, 0
+  br i1 %53, label %63, label %54
+
+; <label>:54                                      ; preds = %51
+  %55 = load i32, i32* %arg5
+  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck1 = icmp eq %"System.Byte[]" addrspace(1)* %56, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %57
+
+; <label>:57                                      ; preds = %54
+  %58 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = zext i32 %59 to i64
+  %61 = trunc i64 %60 to i32
+  %62 = icmp sle i32 %55, %61
+  br i1 %62, label %68, label %63
+
+; <label>:63                                      ; preds = %51, %57
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %66 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %65)
+  %67 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %67, %System.String addrspace(1)* %64, %System.String addrspace(1)* %66)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %67) #0
+  unreachable
+
+; <label>:68                                      ; preds = %57
+  %69 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %69, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %69, i32 0, i32 1
+  %72 = load i32, i32 addrspace(1)* %71
+  %73 = zext i32 %72 to i64
+  %74 = trunc i64 %73 to i32
+  %75 = icmp ne i32 %74, 0
+  br i1 %75, label %78, label %76
+
+; <label>:76                                      ; preds = %70
+  %77 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1)
+  store %"System.Char[]" addrspace(1)* %77, %"System.Char[]" addrspace(1)** %arg1
+  br label %78
+
+; <label>:78                                      ; preds = %70, %76
+  %79 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck5 = icmp eq %"System.Byte[]" addrspace(1)* %79, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %80
+
+; <label>:80                                      ; preds = %78
+  %81 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %79, i32 0, i32 1
+  %82 = load i32, i32 addrspace(1)* %81
+  %83 = zext i32 %82 to i64
+  %84 = trunc i64 %83 to i32
+  %85 = load i32, i32* %arg5
+  %86 = sub i32 %84, %85
+  store i32 %86, i32* %loc0
+  %87 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck7 = icmp eq %"System.Byte[]" addrspace(1)* %87, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %88
+
+; <label>:88                                      ; preds = %80
+  %89 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %87, i32 0, i32 1
+  %90 = load i32, i32 addrspace(1)* %89
+  %91 = zext i32 %90 to i64
+  %92 = trunc i64 %91 to i32
+  %93 = icmp ne i32 %92, 0
+  br i1 %93, label %96, label %94
+
+; <label>:94                                      ; preds = %88
+  %95 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1)
+  store %"System.Byte[]" addrspace(1)* %95, %"System.Byte[]" addrspace(1)** %arg4
+  br label %96
+
+; <label>:96                                      ; preds = %88, %94
+  %97 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  store %"System.Char[]" addrspace(1)* %97, %"System.Char[]" addrspace(1)** %loc4
+  %98 = icmp eq %"System.Char[]" addrspace(1)* %97, null
+  br i1 %98, label %107, label %99
+
+; <label>:99                                      ; preds = %96
+  %100 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc4
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %100, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %101
+
+; <label>:101                                     ; preds = %99
+  %102 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %100, i32 0, i32 1
+  %103 = load i32, i32 addrspace(1)* %102
+  %104 = zext i32 %103 to i64
+  %105 = trunc i64 %104 to i32
+  %106 = icmp ne i32 %105, 0
+  br i1 %106, label %108, label %107
+
+; <label>:107                                     ; preds = %96, %101
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  br label %116
+
+; <label>:108                                     ; preds = %101
+  %109 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc4
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %109, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %110
+
+; <label>:110                                     ; preds = %108
+  %111 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %109, i32 0, i32 1
+  %112 = load i32, i32 addrspace(1)* %111
+  %113 = zext i32 %112 to i64
+  %BoundsCheck = icmp uge i64 0, %113
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %114
+
+; <label>:114                                     ; preds = %110
+  %115 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %109, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %115, i16 addrspace(1)** %loc1
+  br label %116
+
+; <label>:116                                     ; preds = %107, %114
+  %117 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  store %"System.Byte[]" addrspace(1)* %117, %"System.Byte[]" addrspace(1)** %loc5
+  %118 = icmp eq %"System.Byte[]" addrspace(1)* %117, null
+  br i1 %118, label %127, label %119
+
+; <label>:119                                     ; preds = %116
+  %120 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc5
+  %NullCheck13 = icmp eq %"System.Byte[]" addrspace(1)* %120, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %121
+
+; <label>:121                                     ; preds = %119
+  %122 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %120, i32 0, i32 1
+  %123 = load i32, i32 addrspace(1)* %122
+  %124 = zext i32 %123 to i64
+  %125 = trunc i64 %124 to i32
+  %126 = icmp ne i32 %125, 0
+  br i1 %126, label %128, label %127
+
+; <label>:127                                     ; preds = %116, %121
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc2
+  br label %136
+
+; <label>:128                                     ; preds = %121
+  %129 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc5
+  %NullCheck15 = icmp eq %"System.Byte[]" addrspace(1)* %129, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %130
+
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %129, i32 0, i32 1
+  %132 = load i32, i32 addrspace(1)* %131
+  %133 = zext i32 %132 to i64
+  %BoundsCheck17 = icmp uge i64 0, %133
+  br i1 %BoundsCheck17, label %ThrowIndexOutOfRange18, label %134
+
+; <label>:134                                     ; preds = %130
+  %135 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %129, i32 0, i32 3, i32 0
+  store i8 addrspace(1)* %135, i8 addrspace(1)** %loc2
+  br label %136
+
+; <label>:136                                     ; preds = %127, %134
+  %137 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %138 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %139 = ptrtoint i16 addrspace(1)* %138 to i64
+  %140 = load i32, i32* %arg2
+  %141 = sext i32 %140 to i64
+  %142 = mul i64 %141, 2
+  %143 = add i64 %139, %142
+  %144 = load i32, i32* %arg3
+  %145 = load i8 addrspace(1)*, i8 addrspace(1)** %loc2
+  %146 = ptrtoint i8 addrspace(1)* %145 to i64
+  %147 = load i32, i32* %arg5
+  %148 = sext i32 %147 to i64
+  %149 = add i64 %146, %148
+  %150 = load i32, i32* %loc0
+  %151 = load i8, i8* %arg6
+  %152 = zext i8 %151 to i32
+  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i64 addrspace(1)*
+  %NullCheck19 = icmp eq i64 addrspace(1)* %153, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %154
+
+; <label>:154                                     ; preds = %136
+  %155 = load i64, i64 addrspace(1)* %153
+  %156 = add i64 %155, 72
+  %157 = inttoptr i64 %156 to i64*
+  %158 = load i64, i64* %157
+  %159 = add i64 %158, 0
+  %160 = inttoptr i64 %159 to i64*
+  %161 = load i64, i64* %160
+  %162 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to %System.Text.Encoder addrspace(1)*
+  %163 = inttoptr i64 %143 to i16*
+  %164 = inttoptr i64 %149 to i8*
+  %165 = trunc i32 %152 to i8
+  %166 = inttoptr i64 %161 to i32 (%System.Text.Encoder addrspace(1)*, i16*, i32, i8*, i32, i8)*
+  %167 = call i32 %166(%System.Text.Encoder addrspace(1)* %162, i16* %163, i32 %144, i8* %164, i32 %150, i8 %165)
+  store i32 %167, i32* %loc3
+  br label %168
+
+; <label>:168                                     ; preds = %154
+  %169 = load i32, i32* %loc3
+  ret i32 %169
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %110
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %119
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange18:                           ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
 Successfully read EncoderNLS.GetBytes
 
@@ -14919,22 +17196,22 @@ entry:
   %40 = load i8, i8* %arg5
   %41 = zext i8 %40 to i32
   %42 = trunc i32 %41 to i8
-  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %39, null
-  br i1 %NullCheck, label %43, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderNLS addrspace(1)* %39, null
+  br i1 %NullCheck, label %ThrowNullRef, label %43
 
 ; <label>:43                                      ; preds = %38
   %44 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
   store i8 %42, i8 addrspace(1)* %44
   %45 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %45, null
-  br i1 %NullCheck2, label %46, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.EncoderNLS addrspace(1)* %45, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %46
 
 ; <label>:46                                      ; preds = %43
   %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %45, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %47
   %48 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.EncoderNLS addrspace(1)* %48, null
-  br i1 %NullCheck4, label %49, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.EncoderNLS addrspace(1)* %48, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %49
 
 ; <label>:49                                      ; preds = %46
   %50 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %48, i32 0, i32 3
@@ -14945,8 +17222,8 @@ entry:
   %55 = load i32, i32* %arg4
   %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck6, label %58, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
   %59 = load i64, i64 addrspace(1)* %57
@@ -14964,15 +17241,15 @@ ThrowNullRef:                                     ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %43
+ThrowNullRef2:                                    ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %46
+ThrowNullRef4:                                    ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %49
+ThrowNullRef6:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -15000,8 +17277,8 @@ entry:
   %4 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0 to %System.IO.ConsoleStream addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*)(%System.IO.ConsoleStream addrspace(1)* %4, %"System.Byte[]" addrspace(1)* %1, i32 %2, i32 %3)
   %5 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
@@ -15086,8 +17363,8 @@ entry:
 
 ; <label>:22                                      ; preds = %8
   %23 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %23, null
-  br i1 %NullCheck, label %24, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Byte[]" addrspace(1)* %23, null
+  br i1 %NullCheck, label %ThrowNullRef, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
@@ -15109,8 +17386,8 @@ entry:
 
 ; <label>:36                                      ; preds = %24
   %37 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %37, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.ConsoleStream addrspace(1)* %37, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %37, i32 0, i32 4
@@ -15131,13 +17408,138 @@ ThrowNullRef:                                     ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %36
+ThrowNullRef2:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
-Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
+Successfully read WindowsConsoleStream.WriteFileNative
+
+define i32 @WindowsConsoleStream.WriteFileNative(i64 %param0, %"System.Byte[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i64
+  %arg1 = alloca %"System.Byte[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i8 addrspace(1)*
+  %loc2 = alloca %"System.Byte[]" addrspace(1)*
+  %loc3 = alloca i32
+  store i64 %param0, i64* %arg0
+  store %"System.Byte[]" addrspace(1)* %param1, %"System.Byte[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Byte[]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = zext i32 %3 to i64
+  %5 = icmp ne i64 %4, 0
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %1
+  ret i32 0
+
+; <label>:7                                       ; preds = %1
+  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  store %"System.Byte[]" addrspace(1)* %8, %"System.Byte[]" addrspace(1)** %loc2
+  %9 = icmp eq %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %9, label %18, label %10
+
+; <label>:10                                      ; preds = %7
+  %11 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc2
+  %NullCheck1 = icmp eq %"System.Byte[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %11, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp ne i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %7, %12
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc1
+  br label %27
+
+; <label>:19                                      ; preds = %12
+  %20 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc2
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %20, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %BoundsCheck = icmp uge i64 0, %24
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %25
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %20, i32 0, i32 3, i32 0
+  store i8 addrspace(1)* %26, i8 addrspace(1)** %loc1
+  br label %27
+
+; <label>:27                                      ; preds = %18, %25
+  %28 = load i64, i64* %arg0
+  %29 = load i8 addrspace(1)*, i8 addrspace(1)** %loc1
+  %30 = ptrtoint i8 addrspace(1)* %29 to i64
+  %31 = load i32, i32* %arg2
+  %32 = sext i32 %31 to i64
+  %33 = add i64 %30, %32
+  %34 = load i32, i32* %arg3
+  %35 = addrspacecast i32* %loc3 to i32 addrspace(1)*
+  %36 = inttoptr i64 %33 to i8*
+  %37 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i8*, i32, i32 addrspace(1)*, i64)*)(i64 %28, i8* %36, i32 %34, i32 addrspace(1)* %35, i64 0)
+  %38 = icmp ugt i32 %37, 0
+  %39 = sext i1 %38 to i32
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc1
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %42, label %41
+
+; <label>:41                                      ; preds = %27
+  ret i32 0
+
+; <label>:42                                      ; preds = %27
+  %43 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  store i32 %43, i32* %loc0
+  %44 = load i32, i32* %loc0
+  %45 = icmp eq i32 %44, 232
+  br i1 %45, label %49, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = load i32, i32* %loc0
+  %48 = icmp ne i32 %47, 109
+  br i1 %48, label %50, label %49
+
+; <label>:49                                      ; preds = %42, %46
+  ret i32 0
+
+; <label>:50                                      ; preds = %46
+  %51 = load i32, i32* %loc0
+  ret i32 %51
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
 Successfully read WindowsConsoleStream.Flush
 
@@ -15146,8 +17548,8 @@ entry:
   %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
   store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
@@ -15182,8 +17584,8 @@ entry:
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
   %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load i64, i64 addrspace(1)* %1
@@ -15222,15 +17624,15 @@ entry:
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.TextWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
   %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %3, align 8
   %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
   %7 = load i64, i64 addrspace(1)* %5
@@ -15248,7 +17650,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -15277,8 +17679,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %4)
   store i32 0, i32* %loc0
   %5 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Char[]" addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
@@ -15290,15 +17692,15 @@ entry:
 
 ; <label>:11                                      ; preds = %69
   %12 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %12, i32 0, i32 9
   %15 = load i32, i32 addrspace(1)* %14, align 8
   %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.IO.StreamWriter addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %16, i32 0, i32 10
@@ -15313,15 +17715,15 @@ entry:
 
 ; <label>:23                                      ; preds = %17, %21
   %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %24, null
-  br i1 %NullCheck8, label %25, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %24, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 10
   %27 = load i32, i32 addrspace(1)* %26, align 8
   %28 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %28, null
-  br i1 %NullCheck10, label %29, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.StreamWriter addrspace(1)* %28, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %28, i32 0, i32 9
@@ -15343,15 +17745,15 @@ entry:
   %40 = load i32, i32* %loc0
   %41 = mul i32 %40, 2
   %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
-  br i1 %NullCheck12, label %43, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %43
 
 ; <label>:43                                      ; preds = %38
   %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 7
   %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %44, align 8
   %46 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %46, null
-  br i1 %NullCheck14, label %47, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.IO.StreamWriter addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %47
 
 ; <label>:47                                      ; preds = %43
   %48 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %46, i32 0, i32 9
@@ -15363,16 +17765,16 @@ entry:
   %54 = bitcast %"System.Char[]" addrspace(1)* %45 to %System.Array addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %53, i32 %41, %System.Array addrspace(1)* %54, i32 %50, i32 %52)
   %55 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
-  br i1 %NullCheck16, label %56, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %56
 
 ; <label>:56                                      ; preds = %47
   %57 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
   %58 = load i32, i32 addrspace(1)* %57, align 8
   %59 = load i32, i32* %loc2
   %60 = add i32 %58, %59
-  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
-  br i1 %NullCheck18, label %61, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %61
 
 ; <label>:61                                      ; preds = %56
   %62 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
@@ -15394,8 +17796,8 @@ entry:
 
 ; <label>:72                                      ; preds = %69
   %73 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %73, null
-  br i1 %NullCheck2, label %74, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %73, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %74
 
 ; <label>:74                                      ; preds = %72
   %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %73, i32 0, i32 11
@@ -15416,39 +17818,39 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %72
+ThrowNullRef2:                                    ; preds = %72
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %23
+ThrowNullRef8:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef10:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %43
+ThrowNullRef14:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %47
+ThrowNullRef16:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %56
+ThrowNullRef18:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblSubConst.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblSubConst.error.txt
@@ -25,8 +25,8 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
@@ -40,8 +40,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
   %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
@@ -75,7 +75,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -90,8 +90,8 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %NullCheck = icmp ne i8 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = load i8, i8 addrspace(1)* %0, align 8
@@ -125,8 +125,8 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
@@ -159,8 +159,8 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -184,8 +184,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
   store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
@@ -195,8 +195,8 @@ entry:
 ; <label>:4                                       ; preds = %1
   %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
   %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
@@ -206,8 +206,8 @@ entry:
   %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
@@ -221,14 +221,14 @@ entry:
 
 ; <label>:17                                      ; preds = %14
   %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
   %21 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
@@ -238,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -249,8 +249,8 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
@@ -261,27 +261,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %30
+ThrowNullRef10:                                   ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -301,7 +301,89 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
-Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
+Successfully read AppDomainSetup.GetUnsecureApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.GetUnsecureApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %NullCheck = icmp eq %"System.String[]" addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %BoundsCheck = icmp uge i64 0, %5
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %6
+
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 3, i32 0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
+  ret %System.String addrspace(1)* %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_Value using LLILCJit
+Successfully read AppDomainSetup.get_Value
+
+define %"System.String[]" addrspace(1)* @AppDomainSetup.get_Value(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.String[]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 18)
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.String[]" addrspace(1)* addrspace(1)*, %"System.String[]" addrspace(1)*)*)(%"System.String[]" addrspace(1)* addrspace(1)* %9, %"System.String[]" addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %11, i32 0, i32 1
+  %14 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %13, align 8
+  ret %"System.String[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -319,8 +401,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -368,16 +450,16 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
   %5 = load i32, i32 addrspace(1)* %4
   %6 = sub i32 %5, 1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -389,7 +471,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -421,8 +503,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
@@ -456,8 +538,8 @@ entry:
 ; <label>:27                                      ; preds = %19
   %28 = load i32, i32* %arg1
   %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
-  br i1 %NullCheck2, label %30, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %29, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %30
 
 ; <label>:30                                      ; preds = %27
   %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
@@ -493,8 +575,8 @@ entry:
 ; <label>:49                                      ; preds = %46
   %50 = load i32, i32* %arg2
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck4, label %52, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
@@ -517,11 +599,11 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %27
+ThrowNullRef2:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %49
+ThrowNullRef4:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -544,16 +626,16 @@ entry:
   %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %0)
   store %System.String addrspace(1)* %1, %System.String addrspace(1)** %loc0
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 2
   %5 = bitcast [0 x i16] addrspace(1)* %4 to i16 addrspace(1)*
   store i16 addrspace(1)* %5, i16 addrspace(1)** %loc1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %3
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2
@@ -580,7 +662,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -691,15 +773,15 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %NullCheck132 = icmp ne i8* %21, null
-  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+  %NullCheck131 = icmp eq i8* %21, null
+  br i1 %NullCheck131, label %ThrowNullRef132, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = load i8, i8* %21, align 8
   %24 = zext i8 %23 to i32
   %25 = trunc i32 %24 to i8
-  %NullCheck134 = icmp ne i8* %20, null
-  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+  %NullCheck133 = icmp eq i8* %20, null
+  br i1 %NullCheck133, label %ThrowNullRef134, label %26
 
 ; <label>:26                                      ; preds = %22
   store i8 %25, i8* %20, align 8
@@ -709,16 +791,16 @@ entry:
   %28 = load i8*, i8** %arg0
   %29 = load i8*, i8** %arg1
   %30 = bitcast i8* %29 to i16*
-  %NullCheck128 = icmp ne i16* %30, null
-  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+  %NullCheck127 = icmp eq i16* %30, null
+  br i1 %NullCheck127, label %ThrowNullRef128, label %31
 
 ; <label>:31                                      ; preds = %27
   %32 = load i16, i16* %30, align 8
   %33 = sext i16 %32 to i32
   %34 = bitcast i8* %28 to i16*
   %35 = trunc i32 %33 to i16
-  %NullCheck130 = icmp ne i16* %34, null
-  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+  %NullCheck129 = icmp eq i16* %34, null
+  br i1 %NullCheck129, label %ThrowNullRef130, label %36
 
 ; <label>:36                                      ; preds = %31
   store i16 %35, i16* %34, align 8
@@ -728,16 +810,16 @@ entry:
   %38 = load i8*, i8** %arg0
   %39 = load i8*, i8** %arg1
   %40 = bitcast i8* %39 to i16*
-  %NullCheck120 = icmp ne i16* %40, null
-  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+  %NullCheck119 = icmp eq i16* %40, null
+  br i1 %NullCheck119, label %ThrowNullRef120, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i16, i16* %40, align 8
   %43 = sext i16 %42 to i32
   %44 = bitcast i8* %38 to i16*
   %45 = trunc i32 %43 to i16
-  %NullCheck122 = icmp ne i16* %44, null
-  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+  %NullCheck121 = icmp eq i16* %44, null
+  br i1 %NullCheck121, label %ThrowNullRef122, label %46
 
 ; <label>:46                                      ; preds = %41
   store i16 %45, i16* %44, align 8
@@ -745,15 +827,15 @@ entry:
   %48 = getelementptr inbounds i8, i8* %47, i64 2
   %49 = load i8*, i8** %arg1
   %50 = getelementptr inbounds i8, i8* %49, i64 2
-  %NullCheck124 = icmp ne i8* %50, null
-  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+  %NullCheck123 = icmp eq i8* %50, null
+  br i1 %NullCheck123, label %ThrowNullRef124, label %51
 
 ; <label>:51                                      ; preds = %46
   %52 = load i8, i8* %50, align 8
   %53 = zext i8 %52 to i32
   %54 = trunc i32 %53 to i8
-  %NullCheck126 = icmp ne i8* %48, null
-  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+  %NullCheck125 = icmp eq i8* %48, null
+  br i1 %NullCheck125, label %ThrowNullRef126, label %55
 
 ; <label>:55                                      ; preds = %51
   store i8 %54, i8* %48, align 8
@@ -763,14 +845,14 @@ entry:
   %57 = load i8*, i8** %arg0
   %58 = load i8*, i8** %arg1
   %59 = bitcast i8* %58 to i32*
-  %NullCheck116 = icmp ne i32* %59, null
-  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+  %NullCheck115 = icmp eq i32* %59, null
+  br i1 %NullCheck115, label %ThrowNullRef116, label %60
 
 ; <label>:60                                      ; preds = %56
   %61 = load i32, i32* %59, align 8
   %62 = bitcast i8* %57 to i32*
-  %NullCheck118 = icmp ne i32* %62, null
-  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+  %NullCheck117 = icmp eq i32* %62, null
+  br i1 %NullCheck117, label %ThrowNullRef118, label %63
 
 ; <label>:63                                      ; preds = %60
   store i32 %61, i32* %62, align 8
@@ -780,14 +862,14 @@ entry:
   %65 = load i8*, i8** %arg0
   %66 = load i8*, i8** %arg1
   %67 = bitcast i8* %66 to i32*
-  %NullCheck108 = icmp ne i32* %67, null
-  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+  %NullCheck107 = icmp eq i32* %67, null
+  br i1 %NullCheck107, label %ThrowNullRef108, label %68
 
 ; <label>:68                                      ; preds = %64
   %69 = load i32, i32* %67, align 8
   %70 = bitcast i8* %65 to i32*
-  %NullCheck110 = icmp ne i32* %70, null
-  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+  %NullCheck109 = icmp eq i32* %70, null
+  br i1 %NullCheck109, label %ThrowNullRef110, label %71
 
 ; <label>:71                                      ; preds = %68
   store i32 %69, i32* %70, align 8
@@ -795,15 +877,15 @@ entry:
   %73 = getelementptr inbounds i8, i8* %72, i64 4
   %74 = load i8*, i8** %arg1
   %75 = getelementptr inbounds i8, i8* %74, i64 4
-  %NullCheck112 = icmp ne i8* %75, null
-  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+  %NullCheck111 = icmp eq i8* %75, null
+  br i1 %NullCheck111, label %ThrowNullRef112, label %76
 
 ; <label>:76                                      ; preds = %71
   %77 = load i8, i8* %75, align 8
   %78 = zext i8 %77 to i32
   %79 = trunc i32 %78 to i8
-  %NullCheck114 = icmp ne i8* %73, null
-  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+  %NullCheck113 = icmp eq i8* %73, null
+  br i1 %NullCheck113, label %ThrowNullRef114, label %80
 
 ; <label>:80                                      ; preds = %76
   store i8 %79, i8* %73, align 8
@@ -813,14 +895,14 @@ entry:
   %82 = load i8*, i8** %arg0
   %83 = load i8*, i8** %arg1
   %84 = bitcast i8* %83 to i32*
-  %NullCheck100 = icmp ne i32* %84, null
-  br i1 %NullCheck100, label %85, label %ThrowNullRef99
+  %NullCheck99 = icmp eq i32* %84, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %85
 
 ; <label>:85                                      ; preds = %81
   %86 = load i32, i32* %84, align 8
   %87 = bitcast i8* %82 to i32*
-  %NullCheck102 = icmp ne i32* %87, null
-  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+  %NullCheck101 = icmp eq i32* %87, null
+  br i1 %NullCheck101, label %ThrowNullRef102, label %88
 
 ; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
@@ -829,16 +911,16 @@ entry:
   %91 = load i8*, i8** %arg1
   %92 = getelementptr inbounds i8, i8* %91, i64 4
   %93 = bitcast i8* %92 to i16*
-  %NullCheck104 = icmp ne i16* %93, null
-  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+  %NullCheck103 = icmp eq i16* %93, null
+  br i1 %NullCheck103, label %ThrowNullRef104, label %94
 
 ; <label>:94                                      ; preds = %88
   %95 = load i16, i16* %93, align 8
   %96 = sext i16 %95 to i32
   %97 = bitcast i8* %90 to i16*
   %98 = trunc i32 %96 to i16
-  %NullCheck106 = icmp ne i16* %97, null
-  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+  %NullCheck105 = icmp eq i16* %97, null
+  br i1 %NullCheck105, label %ThrowNullRef106, label %99
 
 ; <label>:99                                      ; preds = %94
   store i16 %98, i16* %97, align 8
@@ -848,14 +930,14 @@ entry:
   %101 = load i8*, i8** %arg0
   %102 = load i8*, i8** %arg1
   %103 = bitcast i8* %102 to i32*
-  %NullCheck88 = icmp ne i32* %103, null
-  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+  %NullCheck87 = icmp eq i32* %103, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %104
 
 ; <label>:104                                     ; preds = %100
   %105 = load i32, i32* %103, align 8
   %106 = bitcast i8* %101 to i32*
-  %NullCheck90 = icmp ne i32* %106, null
-  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+  %NullCheck89 = icmp eq i32* %106, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %107
 
 ; <label>:107                                     ; preds = %104
   store i32 %105, i32* %106, align 8
@@ -864,16 +946,16 @@ entry:
   %110 = load i8*, i8** %arg1
   %111 = getelementptr inbounds i8, i8* %110, i64 4
   %112 = bitcast i8* %111 to i16*
-  %NullCheck92 = icmp ne i16* %112, null
-  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+  %NullCheck91 = icmp eq i16* %112, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %113
 
 ; <label>:113                                     ; preds = %107
   %114 = load i16, i16* %112, align 8
   %115 = sext i16 %114 to i32
   %116 = bitcast i8* %109 to i16*
   %117 = trunc i32 %115 to i16
-  %NullCheck94 = icmp ne i16* %116, null
-  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+  %NullCheck93 = icmp eq i16* %116, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %118
 
 ; <label>:118                                     ; preds = %113
   store i16 %117, i16* %116, align 8
@@ -881,15 +963,15 @@ entry:
   %120 = getelementptr inbounds i8, i8* %119, i64 6
   %121 = load i8*, i8** %arg1
   %122 = getelementptr inbounds i8, i8* %121, i64 6
-  %NullCheck96 = icmp ne i8* %122, null
-  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+  %NullCheck95 = icmp eq i8* %122, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %123
 
 ; <label>:123                                     ; preds = %118
   %124 = load i8, i8* %122, align 8
   %125 = zext i8 %124 to i32
   %126 = trunc i32 %125 to i8
-  %NullCheck98 = icmp ne i8* %120, null
-  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+  %NullCheck97 = icmp eq i8* %120, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %127
 
 ; <label>:127                                     ; preds = %123
   store i8 %126, i8* %120, align 8
@@ -899,14 +981,14 @@ entry:
   %129 = load i8*, i8** %arg0
   %130 = load i8*, i8** %arg1
   %131 = bitcast i8* %130 to i64*
-  %NullCheck84 = icmp ne i64* %131, null
-  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+  %NullCheck83 = icmp eq i64* %131, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %132
 
 ; <label>:132                                     ; preds = %128
   %133 = load i64, i64* %131, align 8
   %134 = bitcast i8* %129 to i64*
-  %NullCheck86 = icmp ne i64* %134, null
-  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+  %NullCheck85 = icmp eq i64* %134, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %135
 
 ; <label>:135                                     ; preds = %132
   store i64 %133, i64* %134, align 8
@@ -916,14 +998,14 @@ entry:
   %137 = load i8*, i8** %arg0
   %138 = load i8*, i8** %arg1
   %139 = bitcast i8* %138 to i64*
-  %NullCheck76 = icmp ne i64* %139, null
-  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+  %NullCheck75 = icmp eq i64* %139, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %140
 
 ; <label>:140                                     ; preds = %136
   %141 = load i64, i64* %139, align 8
   %142 = bitcast i8* %137 to i64*
-  %NullCheck78 = icmp ne i64* %142, null
-  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+  %NullCheck77 = icmp eq i64* %142, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %143
 
 ; <label>:143                                     ; preds = %140
   store i64 %141, i64* %142, align 8
@@ -931,15 +1013,15 @@ entry:
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %NullCheck80 = icmp ne i8* %147, null
-  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+  %NullCheck79 = icmp eq i8* %147, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %148
 
 ; <label>:148                                     ; preds = %143
   %149 = load i8, i8* %147, align 8
   %150 = zext i8 %149 to i32
   %151 = trunc i32 %150 to i8
-  %NullCheck82 = icmp ne i8* %145, null
-  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+  %NullCheck81 = icmp eq i8* %145, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %152
 
 ; <label>:152                                     ; preds = %148
   store i8 %151, i8* %145, align 8
@@ -949,14 +1031,14 @@ entry:
   %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
   %156 = bitcast i8* %155 to i64*
-  %NullCheck68 = icmp ne i64* %156, null
-  br i1 %NullCheck68, label %157, label %ThrowNullRef67
+  %NullCheck67 = icmp eq i64* %156, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %157
 
 ; <label>:157                                     ; preds = %153
   %158 = load i64, i64* %156, align 8
   %159 = bitcast i8* %154 to i64*
-  %NullCheck70 = icmp ne i64* %159, null
-  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+  %NullCheck69 = icmp eq i64* %159, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %160
 
 ; <label>:160                                     ; preds = %157
   store i64 %158, i64* %159, align 8
@@ -965,16 +1047,16 @@ entry:
   %163 = load i8*, i8** %arg1
   %164 = getelementptr inbounds i8, i8* %163, i64 8
   %165 = bitcast i8* %164 to i16*
-  %NullCheck72 = icmp ne i16* %165, null
-  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+  %NullCheck71 = icmp eq i16* %165, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %166
 
 ; <label>:166                                     ; preds = %160
   %167 = load i16, i16* %165, align 8
   %168 = sext i16 %167 to i32
   %169 = bitcast i8* %162 to i16*
   %170 = trunc i32 %168 to i16
-  %NullCheck74 = icmp ne i16* %169, null
-  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+  %NullCheck73 = icmp eq i16* %169, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %171
 
 ; <label>:171                                     ; preds = %166
   store i16 %170, i16* %169, align 8
@@ -984,14 +1066,14 @@ entry:
   %173 = load i8*, i8** %arg0
   %174 = load i8*, i8** %arg1
   %175 = bitcast i8* %174 to i64*
-  %NullCheck56 = icmp ne i64* %175, null
-  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+  %NullCheck55 = icmp eq i64* %175, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %176
 
 ; <label>:176                                     ; preds = %172
   %177 = load i64, i64* %175, align 8
   %178 = bitcast i8* %173 to i64*
-  %NullCheck58 = icmp ne i64* %178, null
-  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+  %NullCheck57 = icmp eq i64* %178, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %179
 
 ; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
@@ -1000,16 +1082,16 @@ entry:
   %182 = load i8*, i8** %arg1
   %183 = getelementptr inbounds i8, i8* %182, i64 8
   %184 = bitcast i8* %183 to i16*
-  %NullCheck60 = icmp ne i16* %184, null
-  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+  %NullCheck59 = icmp eq i16* %184, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %185
 
 ; <label>:185                                     ; preds = %179
   %186 = load i16, i16* %184, align 8
   %187 = sext i16 %186 to i32
   %188 = bitcast i8* %181 to i16*
   %189 = trunc i32 %187 to i16
-  %NullCheck62 = icmp ne i16* %188, null
-  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+  %NullCheck61 = icmp eq i16* %188, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %190
 
 ; <label>:190                                     ; preds = %185
   store i16 %189, i16* %188, align 8
@@ -1017,15 +1099,15 @@ entry:
   %192 = getelementptr inbounds i8, i8* %191, i64 10
   %193 = load i8*, i8** %arg1
   %194 = getelementptr inbounds i8, i8* %193, i64 10
-  %NullCheck64 = icmp ne i8* %194, null
-  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+  %NullCheck63 = icmp eq i8* %194, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %195
 
 ; <label>:195                                     ; preds = %190
   %196 = load i8, i8* %194, align 8
   %197 = zext i8 %196 to i32
   %198 = trunc i32 %197 to i8
-  %NullCheck66 = icmp ne i8* %192, null
-  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+  %NullCheck65 = icmp eq i8* %192, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %199
 
 ; <label>:199                                     ; preds = %195
   store i8 %198, i8* %192, align 8
@@ -1035,14 +1117,14 @@ entry:
   %201 = load i8*, i8** %arg0
   %202 = load i8*, i8** %arg1
   %203 = bitcast i8* %202 to i64*
-  %NullCheck48 = icmp ne i64* %203, null
-  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+  %NullCheck47 = icmp eq i64* %203, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %204
 
 ; <label>:204                                     ; preds = %200
   %205 = load i64, i64* %203, align 8
   %206 = bitcast i8* %201 to i64*
-  %NullCheck50 = icmp ne i64* %206, null
-  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+  %NullCheck49 = icmp eq i64* %206, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %207
 
 ; <label>:207                                     ; preds = %204
   store i64 %205, i64* %206, align 8
@@ -1051,14 +1133,14 @@ entry:
   %210 = load i8*, i8** %arg1
   %211 = getelementptr inbounds i8, i8* %210, i64 8
   %212 = bitcast i8* %211 to i32*
-  %NullCheck52 = icmp ne i32* %212, null
-  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+  %NullCheck51 = icmp eq i32* %212, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %213
 
 ; <label>:213                                     ; preds = %207
   %214 = load i32, i32* %212, align 8
   %215 = bitcast i8* %209 to i32*
-  %NullCheck54 = icmp ne i32* %215, null
-  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+  %NullCheck53 = icmp eq i32* %215, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %216
 
 ; <label>:216                                     ; preds = %213
   store i32 %214, i32* %215, align 8
@@ -1068,14 +1150,14 @@ entry:
   %218 = load i8*, i8** %arg0
   %219 = load i8*, i8** %arg1
   %220 = bitcast i8* %219 to i64*
-  %NullCheck36 = icmp ne i64* %220, null
-  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64* %220, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %221
 
 ; <label>:221                                     ; preds = %217
   %222 = load i64, i64* %220, align 8
   %223 = bitcast i8* %218 to i64*
-  %NullCheck38 = icmp ne i64* %223, null
-  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+  %NullCheck37 = icmp eq i64* %223, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %224
 
 ; <label>:224                                     ; preds = %221
   store i64 %222, i64* %223, align 8
@@ -1084,14 +1166,14 @@ entry:
   %227 = load i8*, i8** %arg1
   %228 = getelementptr inbounds i8, i8* %227, i64 8
   %229 = bitcast i8* %228 to i32*
-  %NullCheck40 = icmp ne i32* %229, null
-  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i32* %229, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %230
 
 ; <label>:230                                     ; preds = %224
   %231 = load i32, i32* %229, align 8
   %232 = bitcast i8* %226 to i32*
-  %NullCheck42 = icmp ne i32* %232, null
-  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+  %NullCheck41 = icmp eq i32* %232, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %233
 
 ; <label>:233                                     ; preds = %230
   store i32 %231, i32* %232, align 8
@@ -1099,15 +1181,15 @@ entry:
   %235 = getelementptr inbounds i8, i8* %234, i64 12
   %236 = load i8*, i8** %arg1
   %237 = getelementptr inbounds i8, i8* %236, i64 12
-  %NullCheck44 = icmp ne i8* %237, null
-  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i8* %237, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %238
 
 ; <label>:238                                     ; preds = %233
   %239 = load i8, i8* %237, align 8
   %240 = zext i8 %239 to i32
   %241 = trunc i32 %240 to i8
-  %NullCheck46 = icmp ne i8* %235, null
-  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+  %NullCheck45 = icmp eq i8* %235, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %242
 
 ; <label>:242                                     ; preds = %238
   store i8 %241, i8* %235, align 8
@@ -1117,14 +1199,14 @@ entry:
   %244 = load i8*, i8** %arg0
   %245 = load i8*, i8** %arg1
   %246 = bitcast i8* %245 to i64*
-  %NullCheck24 = icmp ne i64* %246, null
-  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64* %246, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %247
 
 ; <label>:247                                     ; preds = %243
   %248 = load i64, i64* %246, align 8
   %249 = bitcast i8* %244 to i64*
-  %NullCheck26 = icmp ne i64* %249, null
-  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64* %249, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %250
 
 ; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
@@ -1133,14 +1215,14 @@ entry:
   %253 = load i8*, i8** %arg1
   %254 = getelementptr inbounds i8, i8* %253, i64 8
   %255 = bitcast i8* %254 to i32*
-  %NullCheck28 = icmp ne i32* %255, null
-  br i1 %NullCheck28, label %256, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i32* %255, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %256
 
 ; <label>:256                                     ; preds = %250
   %257 = load i32, i32* %255, align 8
   %258 = bitcast i8* %252 to i32*
-  %NullCheck30 = icmp ne i32* %258, null
-  br i1 %NullCheck30, label %259, label %ThrowNullRef29
+  %NullCheck29 = icmp eq i32* %258, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %259
 
 ; <label>:259                                     ; preds = %256
   store i32 %257, i32* %258, align 8
@@ -1149,16 +1231,16 @@ entry:
   %262 = load i8*, i8** %arg1
   %263 = getelementptr inbounds i8, i8* %262, i64 12
   %264 = bitcast i8* %263 to i16*
-  %NullCheck32 = icmp ne i16* %264, null
-  br i1 %NullCheck32, label %265, label %ThrowNullRef31
+  %NullCheck31 = icmp eq i16* %264, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %265
 
 ; <label>:265                                     ; preds = %259
   %266 = load i16, i16* %264, align 8
   %267 = sext i16 %266 to i32
   %268 = bitcast i8* %261 to i16*
   %269 = trunc i32 %267 to i16
-  %NullCheck34 = icmp ne i16* %268, null
-  br i1 %NullCheck34, label %270, label %ThrowNullRef33
+  %NullCheck33 = icmp eq i16* %268, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %270
 
 ; <label>:270                                     ; preds = %265
   store i16 %269, i16* %268, align 8
@@ -1168,14 +1250,14 @@ entry:
   %272 = load i8*, i8** %arg0
   %273 = load i8*, i8** %arg1
   %274 = bitcast i8* %273 to i64*
-  %NullCheck8 = icmp ne i64* %274, null
-  br i1 %NullCheck8, label %275, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64* %274, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %275
 
 ; <label>:275                                     ; preds = %271
   %276 = load i64, i64* %274, align 8
   %277 = bitcast i8* %272 to i64*
-  %NullCheck10 = icmp ne i64* %277, null
-  br i1 %NullCheck10, label %278, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %277, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %278
 
 ; <label>:278                                     ; preds = %275
   store i64 %276, i64* %277, align 8
@@ -1184,14 +1266,14 @@ entry:
   %281 = load i8*, i8** %arg1
   %282 = getelementptr inbounds i8, i8* %281, i64 8
   %283 = bitcast i8* %282 to i32*
-  %NullCheck12 = icmp ne i32* %283, null
-  br i1 %NullCheck12, label %284, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i32* %283, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %284
 
 ; <label>:284                                     ; preds = %278
   %285 = load i32, i32* %283, align 8
   %286 = bitcast i8* %280 to i32*
-  %NullCheck14 = icmp ne i32* %286, null
-  br i1 %NullCheck14, label %287, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i32* %286, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %287
 
 ; <label>:287                                     ; preds = %284
   store i32 %285, i32* %286, align 8
@@ -1200,16 +1282,16 @@ entry:
   %290 = load i8*, i8** %arg1
   %291 = getelementptr inbounds i8, i8* %290, i64 12
   %292 = bitcast i8* %291 to i16*
-  %NullCheck16 = icmp ne i16* %292, null
-  br i1 %NullCheck16, label %293, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i16* %292, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %293
 
 ; <label>:293                                     ; preds = %287
   %294 = load i16, i16* %292, align 8
   %295 = sext i16 %294 to i32
   %296 = bitcast i8* %289 to i16*
   %297 = trunc i32 %295 to i16
-  %NullCheck18 = icmp ne i16* %296, null
-  br i1 %NullCheck18, label %298, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i16* %296, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %298
 
 ; <label>:298                                     ; preds = %293
   store i16 %297, i16* %296, align 8
@@ -1217,15 +1299,15 @@ entry:
   %300 = getelementptr inbounds i8, i8* %299, i64 14
   %301 = load i8*, i8** %arg1
   %302 = getelementptr inbounds i8, i8* %301, i64 14
-  %NullCheck20 = icmp ne i8* %302, null
-  br i1 %NullCheck20, label %303, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i8* %302, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %303
 
 ; <label>:303                                     ; preds = %298
   %304 = load i8, i8* %302, align 8
   %305 = zext i8 %304 to i32
   %306 = trunc i32 %305 to i8
-  %NullCheck22 = icmp ne i8* %300, null
-  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i8* %300, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %307
 
 ; <label>:307                                     ; preds = %303
   store i8 %306, i8* %300, align 8
@@ -1235,14 +1317,14 @@ entry:
   %309 = load i8*, i8** %arg0
   %310 = load i8*, i8** %arg1
   %311 = bitcast i8* %310 to i64*
-  %NullCheck = icmp ne i64* %311, null
-  br i1 %NullCheck, label %312, label %ThrowNullRef
+  %NullCheck = icmp eq i64* %311, null
+  br i1 %NullCheck, label %ThrowNullRef, label %312
 
 ; <label>:312                                     ; preds = %308
   %313 = load i64, i64* %311, align 8
   %314 = bitcast i8* %309 to i64*
-  %NullCheck2 = icmp ne i64* %314, null
-  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64* %314, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %315
 
 ; <label>:315                                     ; preds = %312
   store i64 %313, i64* %314, align 8
@@ -1251,14 +1333,14 @@ entry:
   %318 = load i8*, i8** %arg1
   %319 = getelementptr inbounds i8, i8* %318, i64 8
   %320 = bitcast i8* %319 to i64*
-  %NullCheck4 = icmp ne i64* %320, null
-  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64* %320, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %321
 
 ; <label>:321                                     ; preds = %315
   %322 = load i64, i64* %320, align 8
   %323 = bitcast i8* %317 to i64*
-  %NullCheck6 = icmp ne i64* %323, null
-  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64* %323, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %324
 
 ; <label>:324                                     ; preds = %321
   store i64 %322, i64* %323, align 8
@@ -1286,15 +1368,15 @@ entry:
 ; <label>:338                                     ; preds = %333
   %339 = load i8*, i8** %arg0
   %340 = load i8*, i8** %arg1
-  %NullCheck136 = icmp ne i8* %340, null
-  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+  %NullCheck135 = icmp eq i8* %340, null
+  br i1 %NullCheck135, label %ThrowNullRef136, label %341
 
 ; <label>:341                                     ; preds = %338
   %342 = load i8, i8* %340, align 8
   %343 = zext i8 %342 to i32
   %344 = trunc i32 %343 to i8
-  %NullCheck138 = icmp ne i8* %339, null
-  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+  %NullCheck137 = icmp eq i8* %339, null
+  br i1 %NullCheck137, label %ThrowNullRef138, label %345
 
 ; <label>:345                                     ; preds = %341
   store i8 %344, i8* %339, align 8
@@ -1317,16 +1399,16 @@ entry:
   %357 = load i8*, i8** %arg0
   %358 = load i8*, i8** %arg1
   %359 = bitcast i8* %358 to i16*
-  %NullCheck140 = icmp ne i16* %359, null
-  br i1 %NullCheck140, label %360, label %ThrowNullRef139
+  %NullCheck139 = icmp eq i16* %359, null
+  br i1 %NullCheck139, label %ThrowNullRef140, label %360
 
 ; <label>:360                                     ; preds = %356
   %361 = load i16, i16* %359, align 8
   %362 = sext i16 %361 to i32
   %363 = bitcast i8* %357 to i16*
   %364 = trunc i32 %362 to i16
-  %NullCheck142 = icmp ne i16* %363, null
-  br i1 %NullCheck142, label %365, label %ThrowNullRef141
+  %NullCheck141 = icmp eq i16* %363, null
+  br i1 %NullCheck141, label %ThrowNullRef142, label %365
 
 ; <label>:365                                     ; preds = %360
   store i16 %364, i16* %363, align 8
@@ -1352,14 +1434,14 @@ entry:
   %378 = load i8*, i8** %arg0
   %379 = load i8*, i8** %arg1
   %380 = bitcast i8* %379 to i32*
-  %NullCheck144 = icmp ne i32* %380, null
-  br i1 %NullCheck144, label %381, label %ThrowNullRef143
+  %NullCheck143 = icmp eq i32* %380, null
+  br i1 %NullCheck143, label %ThrowNullRef144, label %381
 
 ; <label>:381                                     ; preds = %377
   %382 = load i32, i32* %380, align 8
   %383 = bitcast i8* %378 to i32*
-  %NullCheck146 = icmp ne i32* %383, null
-  br i1 %NullCheck146, label %384, label %ThrowNullRef145
+  %NullCheck145 = icmp eq i32* %383, null
+  br i1 %NullCheck145, label %ThrowNullRef146, label %384
 
 ; <label>:384                                     ; preds = %381
   store i32 %382, i32* %383, align 8
@@ -1384,14 +1466,14 @@ entry:
   %395 = load i8*, i8** %arg0
   %396 = load i8*, i8** %arg1
   %397 = bitcast i8* %396 to i64*
-  %NullCheck164 = icmp ne i64* %397, null
-  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+  %NullCheck163 = icmp eq i64* %397, null
+  br i1 %NullCheck163, label %ThrowNullRef164, label %398
 
 ; <label>:398                                     ; preds = %394
   %399 = load i64, i64* %397, align 8
   %400 = bitcast i8* %395 to i64*
-  %NullCheck166 = icmp ne i64* %400, null
-  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+  %NullCheck165 = icmp eq i64* %400, null
+  br i1 %NullCheck165, label %ThrowNullRef166, label %401
 
 ; <label>:401                                     ; preds = %398
   store i64 %399, i64* %400, align 8
@@ -1400,14 +1482,14 @@ entry:
   %404 = load i8*, i8** %arg1
   %405 = getelementptr inbounds i8, i8* %404, i64 8
   %406 = bitcast i8* %405 to i64*
-  %NullCheck168 = icmp ne i64* %406, null
-  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+  %NullCheck167 = icmp eq i64* %406, null
+  br i1 %NullCheck167, label %ThrowNullRef168, label %407
 
 ; <label>:407                                     ; preds = %401
   %408 = load i64, i64* %406, align 8
   %409 = bitcast i8* %403 to i64*
-  %NullCheck170 = icmp ne i64* %409, null
-  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+  %NullCheck169 = icmp eq i64* %409, null
+  br i1 %NullCheck169, label %ThrowNullRef170, label %410
 
 ; <label>:410                                     ; preds = %407
   store i64 %408, i64* %409, align 8
@@ -1437,14 +1519,14 @@ entry:
   %425 = load i8*, i8** %arg0
   %426 = load i8*, i8** %arg1
   %427 = bitcast i8* %426 to i64*
-  %NullCheck148 = icmp ne i64* %427, null
-  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+  %NullCheck147 = icmp eq i64* %427, null
+  br i1 %NullCheck147, label %ThrowNullRef148, label %428
 
 ; <label>:428                                     ; preds = %424
   %429 = load i64, i64* %427, align 8
   %430 = bitcast i8* %425 to i64*
-  %NullCheck150 = icmp ne i64* %430, null
-  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+  %NullCheck149 = icmp eq i64* %430, null
+  br i1 %NullCheck149, label %ThrowNullRef150, label %431
 
 ; <label>:431                                     ; preds = %428
   store i64 %429, i64* %430, align 8
@@ -1466,14 +1548,14 @@ entry:
   %441 = load i8*, i8** %arg0
   %442 = load i8*, i8** %arg1
   %443 = bitcast i8* %442 to i32*
-  %NullCheck152 = icmp ne i32* %443, null
-  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+  %NullCheck151 = icmp eq i32* %443, null
+  br i1 %NullCheck151, label %ThrowNullRef152, label %444
 
 ; <label>:444                                     ; preds = %440
   %445 = load i32, i32* %443, align 8
   %446 = bitcast i8* %441 to i32*
-  %NullCheck154 = icmp ne i32* %446, null
-  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+  %NullCheck153 = icmp eq i32* %446, null
+  br i1 %NullCheck153, label %ThrowNullRef154, label %447
 
 ; <label>:447                                     ; preds = %444
   store i32 %445, i32* %446, align 8
@@ -1495,16 +1577,16 @@ entry:
   %457 = load i8*, i8** %arg0
   %458 = load i8*, i8** %arg1
   %459 = bitcast i8* %458 to i16*
-  %NullCheck156 = icmp ne i16* %459, null
-  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+  %NullCheck155 = icmp eq i16* %459, null
+  br i1 %NullCheck155, label %ThrowNullRef156, label %460
 
 ; <label>:460                                     ; preds = %456
   %461 = load i16, i16* %459, align 8
   %462 = sext i16 %461 to i32
   %463 = bitcast i8* %457 to i16*
   %464 = trunc i32 %462 to i16
-  %NullCheck158 = icmp ne i16* %463, null
-  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+  %NullCheck157 = icmp eq i16* %463, null
+  br i1 %NullCheck157, label %ThrowNullRef158, label %465
 
 ; <label>:465                                     ; preds = %460
   store i16 %464, i16* %463, align 8
@@ -1525,15 +1607,15 @@ entry:
 ; <label>:474                                     ; preds = %470
   %475 = load i8*, i8** %arg0
   %476 = load i8*, i8** %arg1
-  %NullCheck160 = icmp ne i8* %476, null
-  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+  %NullCheck159 = icmp eq i8* %476, null
+  br i1 %NullCheck159, label %ThrowNullRef160, label %477
 
 ; <label>:477                                     ; preds = %474
   %478 = load i8, i8* %476, align 8
   %479 = zext i8 %478 to i32
   %480 = trunc i32 %479 to i8
-  %NullCheck162 = icmp ne i8* %475, null
-  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+  %NullCheck161 = icmp eq i8* %475, null
+  br i1 %NullCheck161, label %ThrowNullRef162, label %481
 
 ; <label>:481                                     ; preds = %477
   store i8 %480, i8* %475, align 8
@@ -1553,343 +1635,343 @@ ThrowNullRef:                                     ; preds = %308
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %312
+ThrowNullRef2:                                    ; preds = %312
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %315
+ThrowNullRef4:                                    ; preds = %315
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %321
+ThrowNullRef6:                                    ; preds = %321
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %271
+ThrowNullRef8:                                    ; preds = %271
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %275
+ThrowNullRef10:                                   ; preds = %275
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %278
+ThrowNullRef12:                                   ; preds = %278
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %284
+ThrowNullRef14:                                   ; preds = %284
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %287
+ThrowNullRef16:                                   ; preds = %287
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %293
+ThrowNullRef18:                                   ; preds = %293
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %298
+ThrowNullRef20:                                   ; preds = %298
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %303
+ThrowNullRef22:                                   ; preds = %303
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %243
+ThrowNullRef24:                                   ; preds = %243
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %247
+ThrowNullRef26:                                   ; preds = %247
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %250
+ThrowNullRef28:                                   ; preds = %250
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %256
+ThrowNullRef30:                                   ; preds = %256
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %259
+ThrowNullRef32:                                   ; preds = %259
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %265
+ThrowNullRef34:                                   ; preds = %265
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %217
+ThrowNullRef36:                                   ; preds = %217
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %221
+ThrowNullRef38:                                   ; preds = %221
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %224
+ThrowNullRef40:                                   ; preds = %224
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %230
+ThrowNullRef42:                                   ; preds = %230
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %233
+ThrowNullRef44:                                   ; preds = %233
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %238
+ThrowNullRef46:                                   ; preds = %238
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %200
+ThrowNullRef48:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %204
+ThrowNullRef50:                                   ; preds = %204
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %207
+ThrowNullRef52:                                   ; preds = %207
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %213
+ThrowNullRef54:                                   ; preds = %213
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %172
+ThrowNullRef56:                                   ; preds = %172
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %176
+ThrowNullRef58:                                   ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %179
+ThrowNullRef60:                                   ; preds = %179
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %185
+ThrowNullRef62:                                   ; preds = %185
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %190
+ThrowNullRef64:                                   ; preds = %190
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %195
+ThrowNullRef66:                                   ; preds = %195
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %153
+ThrowNullRef68:                                   ; preds = %153
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %157
+ThrowNullRef70:                                   ; preds = %157
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %160
+ThrowNullRef72:                                   ; preds = %160
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %166
+ThrowNullRef74:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %136
+ThrowNullRef76:                                   ; preds = %136
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %140
+ThrowNullRef78:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %143
+ThrowNullRef80:                                   ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %148
+ThrowNullRef82:                                   ; preds = %148
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %128
+ThrowNullRef84:                                   ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %132
+ThrowNullRef86:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %100
+ThrowNullRef88:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %104
+ThrowNullRef90:                                   ; preds = %104
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %107
+ThrowNullRef92:                                   ; preds = %107
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %113
+ThrowNullRef94:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %118
+ThrowNullRef96:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %123
+ThrowNullRef98:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %81
+ThrowNullRef100:                                  ; preds = %81
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef101:                                  ; preds = %85
+ThrowNullRef102:                                  ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef103:                                  ; preds = %88
+ThrowNullRef104:                                  ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef105:                                  ; preds = %94
+ThrowNullRef106:                                  ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef107:                                  ; preds = %64
+ThrowNullRef108:                                  ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef109:                                  ; preds = %68
+ThrowNullRef110:                                  ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef111:                                  ; preds = %71
+ThrowNullRef112:                                  ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef113:                                  ; preds = %76
+ThrowNullRef114:                                  ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef115:                                  ; preds = %56
+ThrowNullRef116:                                  ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef117:                                  ; preds = %60
+ThrowNullRef118:                                  ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef119:                                  ; preds = %37
+ThrowNullRef120:                                  ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef121:                                  ; preds = %41
+ThrowNullRef122:                                  ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef123:                                  ; preds = %46
+ThrowNullRef124:                                  ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef125:                                  ; preds = %51
+ThrowNullRef126:                                  ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef127:                                  ; preds = %27
+ThrowNullRef128:                                  ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef129:                                  ; preds = %31
+ThrowNullRef130:                                  ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef131:                                  ; preds = %19
+ThrowNullRef132:                                  ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef133:                                  ; preds = %22
+ThrowNullRef134:                                  ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef135:                                  ; preds = %338
+ThrowNullRef136:                                  ; preds = %338
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef137:                                  ; preds = %341
+ThrowNullRef138:                                  ; preds = %341
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef139:                                  ; preds = %356
+ThrowNullRef140:                                  ; preds = %356
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef141:                                  ; preds = %360
+ThrowNullRef142:                                  ; preds = %360
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef143:                                  ; preds = %377
+ThrowNullRef144:                                  ; preds = %377
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef145:                                  ; preds = %381
+ThrowNullRef146:                                  ; preds = %381
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef147:                                  ; preds = %424
+ThrowNullRef148:                                  ; preds = %424
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef149:                                  ; preds = %428
+ThrowNullRef150:                                  ; preds = %428
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef151:                                  ; preds = %440
+ThrowNullRef152:                                  ; preds = %440
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef153:                                  ; preds = %444
+ThrowNullRef154:                                  ; preds = %444
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef155:                                  ; preds = %456
+ThrowNullRef156:                                  ; preds = %456
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef157:                                  ; preds = %460
+ThrowNullRef158:                                  ; preds = %460
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef159:                                  ; preds = %474
+ThrowNullRef160:                                  ; preds = %474
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef161:                                  ; preds = %477
+ThrowNullRef162:                                  ; preds = %477
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef163:                                  ; preds = %394
+ThrowNullRef164:                                  ; preds = %394
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef165:                                  ; preds = %398
+ThrowNullRef166:                                  ; preds = %398
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef167:                                  ; preds = %401
+ThrowNullRef168:                                  ; preds = %401
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef169:                                  ; preds = %407
+ThrowNullRef170:                                  ; preds = %407
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1939,8 +2021,8 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
-  br i1 %NullCheck, label %22, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %ThrowNullRef, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
@@ -1948,8 +2030,8 @@ entry:
   store i32 %24, i32* %loc0
   %25 = load i32, i32* %loc0
   %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %26, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %27
 
 ; <label>:27                                      ; preds = %22
   %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
@@ -1971,7 +2053,7 @@ ThrowNullRef:                                     ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1989,8 +2071,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -2022,15 +2104,15 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2048,16 +2130,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
   %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
   store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %15
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
@@ -2072,8 +2154,8 @@ entry:
   %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
   %29 = ptrtoint i16 addrspace(1)* %28 to i64
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %19
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
@@ -2089,19 +2171,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2114,8 +2196,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
@@ -2128,7 +2210,7 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[loadElem]
+Failed to read AppDomain.PrepareDataForSetup[storeElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
@@ -2202,8 +2284,8 @@ entry:
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
-  br i1 %NullCheck24, label %27, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = load i64, i64 addrspace(1)* %26
@@ -2218,8 +2300,8 @@ entry:
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
-  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
   %41 = load i64, i64 addrspace(1)* %39
@@ -2236,8 +2318,8 @@ entry:
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
-  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
   %54 = load i64, i64 addrspace(1)* %52
@@ -2252,8 +2334,8 @@ entry:
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
   %67 = load i64, i64 addrspace(1)* %65
@@ -2270,8 +2352,8 @@ entry:
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
-  br i1 %NullCheck16, label %79, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
   %80 = load i64, i64 addrspace(1)* %78
@@ -2286,8 +2368,8 @@ entry:
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
-  br i1 %NullCheck18, label %92, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
   %93 = load i64, i64 addrspace(1)* %91
@@ -2304,8 +2386,8 @@ entry:
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
-  br i1 %NullCheck12, label %105, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = load i64, i64 addrspace(1)* %104
@@ -2320,8 +2402,8 @@ entry:
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
-  br i1 %NullCheck14, label %118, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
   %119 = load i64, i64 addrspace(1)* %117
@@ -2337,8 +2419,8 @@ entry:
 
 ; <label>:128                                     ; preds = %20
   %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
-  br i1 %NullCheck4, label %130, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %129, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %130
 
 ; <label>:130                                     ; preds = %128
   %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
@@ -2346,8 +2428,8 @@ entry:
   %133 = load i16, i16 addrspace(1)* %132, align 8
   %134 = zext i16 %133 to i32
   %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
-  br i1 %NullCheck6, label %136, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %135, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %136
 
 ; <label>:136                                     ; preds = %130
   %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
@@ -2360,8 +2442,8 @@ entry:
 
 ; <label>:143                                     ; preds = %136
   %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
-  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %144, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %145
 
 ; <label>:145                                     ; preds = %143
   %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
@@ -2369,8 +2451,8 @@ entry:
   %148 = load i16, i16 addrspace(1)* %147, align 8
   %149 = zext i16 %148 to i32
   %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %150, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %151
 
 ; <label>:151                                     ; preds = %145
   %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
@@ -2388,8 +2470,8 @@ entry:
 
 ; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
-  br i1 %NullCheck, label %163, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %ThrowNullRef, label %163
 
 ; <label>:163                                     ; preds = %161
   %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
@@ -2399,8 +2481,8 @@ entry:
 
 ; <label>:167                                     ; preds = %163
   %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
-  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %168, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %169
 
 ; <label>:169                                     ; preds = %167
   %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
@@ -2432,55 +2514,55 @@ ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %167
+ThrowNullRef2:                                    ; preds = %167
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %128
+ThrowNullRef4:                                    ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %130
+ThrowNullRef6:                                    ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %143
+ThrowNullRef8:                                    ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %145
+ThrowNullRef10:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %102
+ThrowNullRef12:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %105
+ThrowNullRef14:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %76
+ThrowNullRef16:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %79
+ThrowNullRef18:                                   ; preds = %79
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %50
+ThrowNullRef20:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %53
+ThrowNullRef22:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %24
+ThrowNullRef24:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %27
+ThrowNullRef26:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2503,15 +2585,15 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2519,16 +2601,16 @@ entry:
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
   store i32 %8, i32* %loc0
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
   %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
   store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
@@ -2546,16 +2628,16 @@ entry:
 
 ; <label>:23                                      ; preds = %64
   %24 = load i16*, i16** %loc3
-  %NullCheck12 = icmp ne i16* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i16* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
   store i32 %27, i32* %loc5
   %28 = load i16*, i16** %loc4
-  %NullCheck14 = icmp ne i16* %28, null
-  br i1 %NullCheck14, label %29, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %28, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = load i16, i16* %28, align 8
@@ -2620,15 +2702,15 @@ entry:
 
 ; <label>:67                                      ; preds = %64
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
-  br i1 %NullCheck8, label %69, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %68, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %69
 
 ; <label>:69                                      ; preds = %67
   %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
   %71 = load i32, i32 addrspace(1)* %70
   %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
-  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %73
 
 ; <label>:73                                      ; preds = %69
   %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
@@ -2645,31 +2727,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %67
+ThrowNullRef8:                                    ; preds = %67
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %69
+ThrowNullRef10:                                   ; preds = %69
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2710,14 +2792,14 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
   %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
@@ -2730,14 +2812,14 @@ entry:
 
 ; <label>:11                                      ; preds = %4
   %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
   %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
@@ -2749,14 +2831,14 @@ entry:
 
 ; <label>:22                                      ; preds = %16
   %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
   %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
-  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
-  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
@@ -2804,23 +2886,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2836,7 +2918,280 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[loadElem]
+Successfully read RuntimeType.IsAssignableFrom
+
+define i8 @RuntimeType.IsAssignableFrom(%System.RuntimeType addrspace(1)* %param0, %System.Type addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.RuntimeType addrspace(1)*
+  %arg1 = alloca %System.Type addrspace(1)*
+  %loc0 = alloca %System.RuntimeType addrspace(1)*
+  %loc1 = alloca %"System.Type[]" addrspace(1)*
+  %loc2 = alloca i32
+  store %System.RuntimeType addrspace(1)* %param0, %System.RuntimeType addrspace(1)** %this
+  store %System.Type addrspace(1)* %param1, %System.Type addrspace(1)** %arg1
+  %0 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %1 = icmp ne %System.Type addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i8 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %5 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %6 = bitcast %System.Type addrspace(1)* %4 to %System.Object addrspace(1)*
+  %7 = bitcast %System.RuntimeType addrspace(1)* %5 to %System.Object addrspace(1)*
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %6, %System.Object addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %3
+  ret i8 1
+
+; <label>:12                                      ; preds = %3
+  %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 152
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 32
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
+  %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
+  %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
+  store %System.RuntimeType addrspace(1)* %25, %System.RuntimeType addrspace(1)** %loc0
+  %26 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %27 = icmp eq %System.RuntimeType addrspace(1)* %26, null
+  br i1 %27, label %34, label %28
+
+; <label>:28                                      ; preds = %15
+  %29 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %30 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)*)*)(%System.RuntimeType addrspace(1)* %29, %System.RuntimeType addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+; <label>:34                                      ; preds = %15
+  %35 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %36 = call %System.Reflection.Emit.TypeBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Reflection.Emit.TypeBuilder addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %35)
+  %37 = icmp eq %System.Reflection.Emit.TypeBuilder addrspace(1)* %36, null
+  br i1 %37, label %139, label %38
+
+; <label>:38                                      ; preds = %34
+  %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %42
+
+; <label>:42                                      ; preds = %38
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 152
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 40
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
+  %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
+  %53 = zext i8 %52 to i32
+  %54 = icmp eq i32 %53, 0
+  br i1 %54, label %56, label %55
+
+; <label>:55                                      ; preds = %42
+  ret i8 1
+
+; <label>:56                                      ; preds = %42
+  %57 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %58 = bitcast %System.RuntimeType addrspace(1)* %57 to %System.Type addrspace(1)*
+  %59 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %58)
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %64 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.Type addrspace(1)* %63, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = bitcast %System.RuntimeType addrspace(1)* %64 to %System.Type addrspace(1)*
+  %67 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %63, %System.Type addrspace(1)* %66)
+  %68 = zext i8 %67 to i32
+  %69 = trunc i32 %68 to i8
+  ret i8 %69
+
+; <label>:70                                      ; preds = %56
+  %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
+  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %73
+
+; <label>:73                                      ; preds = %70
+  %74 = load i64, i64 addrspace(1)* %72
+  %75 = add i64 %74, 128
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = add i64 %77, 0
+  %79 = inttoptr i64 %78 to i64*
+  %80 = load i64, i64* %79
+  %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
+  %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
+  %83 = call i8 %82(%System.Type addrspace(1)* %81)
+  %84 = zext i8 %83 to i32
+  %85 = icmp eq i32 %84, 0
+  br i1 %85, label %139, label %86
+
+; <label>:86                                      ; preds = %73
+  %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
+  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %89
+
+; <label>:89                                      ; preds = %86
+  %90 = load i64, i64 addrspace(1)* %88
+  %91 = add i64 %90, 128
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = add i64 %93, 24
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
+  %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
+  %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
+  store %"System.Type[]" addrspace(1)* %99, %"System.Type[]" addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %129
+
+; <label>:100                                     ; preds = %132
+  %101 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %102 = load i32, i32* %loc2
+  %NullCheck11 = icmp eq %"System.Type[]" addrspace(1)* %101, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %103
+
+; <label>:103                                     ; preds = %100
+  %104 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 1
+  %105 = load i32, i32 addrspace(1)* %104
+  %106 = zext i32 %105 to i64
+  %107 = zext i32 %102 to i64
+  %BoundsCheck = icmp uge i64 %107, %106
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %108
+
+; <label>:108                                     ; preds = %103
+  %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
+  %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
+  %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
+  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %113
+
+; <label>:113                                     ; preds = %108
+  %114 = load i64, i64 addrspace(1)* %112
+  %115 = add i64 %114, 152
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = add i64 %117, 56
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
+  %123 = zext i8 %122 to i32
+  %124 = icmp ne i32 %123, 0
+  br i1 %124, label %126, label %125
+
+; <label>:125                                     ; preds = %113
+  ret i8 0
+
+; <label>:126                                     ; preds = %113
+  %127 = load i32, i32* %loc2
+  %128 = add i32 %127, 1
+  store i32 %128, i32* %loc2
+  br label %129
+
+; <label>:129                                     ; preds = %89, %126
+  %130 = load i32, i32* %loc2
+  %131 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %NullCheck9 = icmp eq %"System.Type[]" addrspace(1)* %131, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %132
+
+; <label>:132                                     ; preds = %129
+  %133 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %131, i32 0, i32 1
+  %134 = load i32, i32 addrspace(1)* %133
+  %135 = zext i32 %134 to i64
+  %136 = trunc i64 %135 to i32
+  %137 = icmp slt i32 %130, %136
+  br i1 %137, label %100, label %138
+
+; <label>:138                                     ; preds = %132
+  ret i8 1
+
+; <label>:139                                     ; preds = %34, %73
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %129
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %103
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -2893,7 +3248,7 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElem]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -2904,8 +3259,8 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -2997,8 +3352,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
@@ -3059,8 +3414,8 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -3087,8 +3442,8 @@ entry:
 
 ; <label>:17                                      ; preds = %5, %11
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
@@ -3097,8 +3452,8 @@ entry:
 
 ; <label>:22                                      ; preds = %1, %11
   %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
@@ -3109,11 +3464,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %17
+ThrowNullRef2:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %22
+ThrowNullRef4:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3167,15 +3522,15 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
   %15 = load i32, i32 addrspace(1)* %14
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
@@ -3198,7 +3553,7 @@ ThrowNullRef:                                     ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef2:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3232,8 +3587,8 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
@@ -3312,8 +3667,8 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -3327,8 +3682,8 @@ entry:
 ; <label>:5                                       ; preds = %43
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %7 = load i32, i32* %loc1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck6, label %8, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
@@ -3366,8 +3721,8 @@ entry:
 ; <label>:32                                      ; preds = %21, %25
   %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
   %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
-  br i1 %NullCheck8, label %35, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = trunc i32 %34 to i16
@@ -3380,8 +3735,8 @@ entry:
 ; <label>:40                                      ; preds = %1, %35
   %41 = load i32, i32* %loc1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
-  br i1 %NullCheck2, label %43, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %42, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
@@ -3392,8 +3747,8 @@ entry:
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
   %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
-  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
   %51 = load i64, i64 addrspace(1)* %49
@@ -3412,19 +3767,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %40
+ThrowNullRef2:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %47
+ThrowNullRef4:                                    ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %5
+ThrowNullRef6:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %32
+ThrowNullRef8:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3467,8 +3822,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
@@ -3492,11 +3847,391 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(i16* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store i16* %param0, i16** %arg0
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load i32, i32* %arg3
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %42, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %37, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg2
+  %13 = load i32, i32* %arg3
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %37, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %24 = load i32, i32* %arg2
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load i16*, i16** %arg0
+  %35 = load i32, i32* %arg3
+  %36 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %36, i16* %34, i32 %35)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:37                                      ; preds = %5, %16
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %39)
+  %41 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41, %System.String addrspace(1)* %38, %System.String addrspace(1)* %40)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41) #0
+  unreachable
+
+; <label>:42                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
-Failed to read StringBuilder.ToString[loadElemA]
+Successfully read StringBuilder.ToString
+
+define %System.String addrspace(1)* @StringBuilder.ToString(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i16*
+  %loc3 = alloca %"System.Char[]" addrspace(1)*
+  %loc4 = alloca i32
+  %loc5 = alloca i32
+  %loc6 = alloca i16 addrspace(1)*
+  %loc7 = alloca %System.String addrspace(1)*
+  %loc8 = alloca %"System.Char[]" addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %0)
+  %2 = icmp ne i32 %1, 0
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %4
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %6)
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %7)
+  store %System.String addrspace(1)* %8, %System.String addrspace(1)** %loc0
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.Text.StringBuilder addrspace(1)* %9, %System.Text.StringBuilder addrspace(1)** %loc1
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  store %System.String addrspace(1)* %10, %System.String addrspace(1)** %loc7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc7
+  %12 = ptrtoint %System.String addrspace(1)* %11 to i64
+  %13 = icmp eq i64 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %5
+  %15 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %16 = sext i32 %15 to i64
+  %17 = add i64 %12, %16
+  br label %18
+
+; <label>:18                                      ; preds = %5, %14
+  %19 = phi i64 [ %12, %5 ], [ %17, %14 ]
+  %20 = inttoptr i64 %19 to i16*
+  store i16* %20, i16** %loc2
+  br label %21
+
+; <label>:21                                      ; preds = %98, %18
+  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %22, null
+  br i1 %NullCheck, label %ThrowNullRef, label %23
+
+; <label>:23                                      ; preds = %21
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 3
+  %25 = load i32, i32 addrspace(1)* %24, align 8
+  %26 = icmp sle i32 %25, 0
+  br i1 %26, label %96, label %27
+
+; <label>:27                                      ; preds = %23
+  %28 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %28, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %29
+
+; <label>:29                                      ; preds = %27
+  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %28, i32 0, i32 1
+  %31 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %30, align 8
+  store %"System.Char[]" addrspace(1)* %31, %"System.Char[]" addrspace(1)** %loc3
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %33
+
+; <label>:33                                      ; preds = %29
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  store i32 %35, i32* %loc4
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  %39 = load i32, i32 addrspace(1)* %38, align 8
+  store i32 %39, i32* %loc5
+  %40 = load i32, i32* %loc5
+  %41 = load i32, i32* %loc4
+  %42 = add i32 %40, %41
+  %43 = zext i32 %42 to i64
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %45
+
+; <label>:45                                      ; preds = %37
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = sext i32 %47 to i64
+  %49 = icmp sgt i64 %43, %48
+  br i1 %49, label %91, label %50
+
+; <label>:50                                      ; preds = %45
+  %51 = load i32, i32* %loc5
+  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %52, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %53
+
+; <label>:53                                      ; preds = %50
+  %54 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %52, i32 0, i32 1
+  %55 = load i32, i32 addrspace(1)* %54
+  %56 = zext i32 %55 to i64
+  %57 = trunc i64 %56 to i32
+  %58 = icmp ugt i32 %51, %57
+  br i1 %58, label %91, label %59
+
+; <label>:59                                      ; preds = %53
+  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  store %"System.Char[]" addrspace(1)* %60, %"System.Char[]" addrspace(1)** %loc8
+  %61 = icmp eq %"System.Char[]" addrspace(1)* %60, null
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %63, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %64
+
+; <label>:64                                      ; preds = %62
+  %65 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %63, i32 0, i32 1
+  %66 = load i32, i32 addrspace(1)* %65
+  %67 = zext i32 %66 to i64
+  %68 = trunc i64 %67 to i32
+  %69 = icmp ne i32 %68, 0
+  br i1 %69, label %71, label %70
+
+; <label>:70                                      ; preds = %59, %64
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:71                                      ; preds = %64
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %73
+
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %BoundsCheck = icmp uge i64 0, %76
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %77
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %78, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:79                                      ; preds = %70, %77
+  %80 = load i16*, i16** %loc2
+  %81 = load i32, i32* %loc4
+  %82 = sext i32 %81 to i64
+  %83 = mul i64 %82, 2
+  %84 = bitcast i16* %80 to i8*
+  %85 = getelementptr inbounds i8, i8* %84, i64 %83
+  %86 = load i16 addrspace(1)*, i16 addrspace(1)** %loc6
+  %87 = ptrtoint i16 addrspace(1)* %86 to i64
+  %88 = load i32, i32* %loc5
+  %89 = bitcast i8* %85 to i16*
+  %90 = inttoptr i64 %87 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %89, i16* %90, i32 %88)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %96
+
+; <label>:91                                      ; preds = %45, %53
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %94 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %93)
+  %95 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95, %System.String addrspace(1)* %92, %System.String addrspace(1)* %94)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95) #0
+  unreachable
+
+; <label>:96                                      ; preds = %23, %79
+  %97 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %97, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %98
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %97, i32 0, i32 2
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  store %System.Text.StringBuilder addrspace(1)* %100, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %102 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %102, label %21, label %103
+
+; <label>:103                                     ; preds = %98
+  store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc7
+  %104 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  ret %System.String addrspace(1)* %104
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method StringBuilder::get_Length using LLILCJit
+Successfully read StringBuilder.get_Length
+
+define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
+Successfully read RuntimeHelpers.get_OffsetToStringData
+
+define i32 @RuntimeHelpers.get_OffsetToStringData() {
+entry:
+  ret i32 12
+}
+
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
 Successfully read CultureData.CreateCultureData
 
@@ -3514,23 +4249,23 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
   store i8 %4, i8 addrspace(1)* %6
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
@@ -3549,11 +4284,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3566,50 +4301,50 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
   store i32 -1, i32 addrspace(1)* %2
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
   store i32 -1, i32 addrspace(1)* %8
   %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
   store i32 -1, i32 addrspace(1)* %14
   %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
   store i32 -1, i32 addrspace(1)* %17
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
@@ -3623,27 +4358,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3675,7 +4410,136 @@ Failed to read Dictionary`2.Insert[non-const derefAddress]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
 Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
-Failed to read HashHelpers.GetPrime[loadElem]
+Successfully read HashHelpers.GetPrime
+
+define i32 @HashHelpers.GetPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %6, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5, %System.String addrspace(1)* %4)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5) #0
+  unreachable
+
+; <label>:6                                       ; preds = %entry
+  store i32 0, i32* %loc0
+  br label %29
+
+; <label>:7                                       ; preds = %35
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 1296
+  %10 = addrspacecast i8 addrspace(1)* %9 to %"System.Int32[]" addrspace(1)**
+  %11 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %10
+  %12 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Int32[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = zext i32 %15 to i64
+  %17 = zext i32 %12 to i64
+  %BoundsCheck = icmp uge i64 %17, %16
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 3, i32 %12
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  store i32 %20, i32* %loc1
+  %21 = load i32, i32* %loc1
+  %22 = load i32, i32* %arg0
+  %23 = icmp slt i32 %21, %22
+  br i1 %23, label %26, label %24
+
+; <label>:24                                      ; preds = %18
+  %25 = load i32, i32* %loc1
+  ret i32 %25
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %loc0
+  %28 = add i32 %27, 1
+  store i32 %28, i32* %loc0
+  br label %29
+
+; <label>:29                                      ; preds = %6, %26
+  %30 = load i32, i32* %loc0
+  %31 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %32 = getelementptr inbounds i8, i8 addrspace(1)* %31, i64 1296
+  %33 = addrspacecast i8 addrspace(1)* %32 to %"System.Int32[]" addrspace(1)**
+  %34 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %33
+  %NullCheck = icmp eq %"System.Int32[]" addrspace(1)* %34, null
+  br i1 %NullCheck, label %ThrowNullRef, label %35
+
+; <label>:35                                      ; preds = %29
+  %36 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %34, i32 0, i32 1
+  %37 = load i32, i32 addrspace(1)* %36
+  %38 = zext i32 %37 to i64
+  %39 = trunc i64 %38 to i32
+  %40 = icmp slt i32 %30, %39
+  br i1 %40, label %7, label %41
+
+; <label>:41                                      ; preds = %35
+  %42 = load i32, i32* %arg0
+  %43 = or i32 %42, 1
+  store i32 %43, i32* %loc2
+  br label %59
+
+; <label>:44                                      ; preds = %59
+  %45 = load i32, i32* %loc2
+  %46 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %45)
+  %47 = zext i8 %46 to i32
+  %48 = icmp eq i32 %47, 0
+  br i1 %48, label %56, label %49
+
+; <label>:49                                      ; preds = %44
+  %50 = load i32, i32* %loc2
+  %51 = sub i32 %50, 1
+  %52 = srem i32 %51, 101
+  %53 = icmp eq i32 %52, 0
+  br i1 %53, label %56, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = load i32, i32* %loc2
+  ret i32 %55
+
+; <label>:56                                      ; preds = %44, %49
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %57, 2
+  store i32 %58, i32* %loc2
+  br label %59
+
+; <label>:59                                      ; preds = %41, %56
+  %60 = load i32, i32* %loc2
+  %61 = icmp slt i32 %60, 2147483647
+  br i1 %61, label %44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load i32, i32* %arg0
+  ret i32 %63
+
+ThrowNullRef:                                     ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
 Successfully read GenericEqualityComparer`1.GetHashCode
 
@@ -3694,14 +4558,14 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
   %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load i64, i64 addrspace(1)* %7
@@ -3720,7 +4584,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3750,8 +4614,8 @@ entry:
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
@@ -3796,8 +4660,8 @@ entry:
   %35 = bitcast i16* %34 to i8*
   %36 = getelementptr inbounds i8, i8* %35, i64 2
   %37 = bitcast i8* %36 to i16*
-  %NullCheck4 = icmp ne i16* %37, null
-  br i1 %NullCheck4, label %38, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %37, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %38
 
 ; <label>:38                                      ; preds = %27
   %39 = load i16, i16* %37, align 8
@@ -3824,8 +4688,8 @@ entry:
 
 ; <label>:54                                      ; preds = %22, %43
   %55 = load i16*, i16** %loc4
-  %NullCheck2 = icmp ne i16* %55, null
-  br i1 %NullCheck2, label %56, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i16* %55, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %56
 
 ; <label>:56                                      ; preds = %54
   %57 = load i16, i16* %55, align 8
@@ -3850,11 +4714,11 @@ ThrowNullRef:                                     ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %54
+ThrowNullRef2:                                    ; preds = %54
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %27
+ThrowNullRef4:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3871,8 +4735,8 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -3907,8 +4771,8 @@ entry:
 
 ; <label>:26                                      ; preds = %19
   %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
-  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %28
 
 ; <label>:28                                      ; preds = %26
   %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
@@ -3920,7 +4784,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3972,8 +4836,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
@@ -3984,26 +4848,26 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
-  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
@@ -4014,8 +4878,8 @@ entry:
 ; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
@@ -4024,8 +4888,8 @@ entry:
 
 ; <label>:25                                      ; preds = %1, %16, %23
   %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
-  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
@@ -4036,27 +4900,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %20
+ThrowNullRef10:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4069,8 +4933,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -4081,8 +4945,8 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
@@ -4091,8 +4955,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1, %8
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
@@ -4103,11 +4967,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4128,24 +4992,24 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   store i32 %3, i32* %loc0
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
   %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
   store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck4, label %9, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
@@ -4164,15 +5028,15 @@ entry:
 ; <label>:18                                      ; preds = %70
   %19 = load i16*, i16** %loc3
   %20 = bitcast i16* %19 to i64*
-  %NullCheck10 = icmp ne i64* %20, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %20, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = load i64, i64* %20, align 8
   %23 = load i16*, i16** %loc4
   %24 = bitcast i16* %23 to i64*
-  %NullCheck12 = icmp ne i64* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = load i64, i64* %24, align 8
@@ -4188,8 +5052,8 @@ entry:
   %31 = bitcast i16* %30 to i8*
   %32 = getelementptr inbounds i8, i8* %31, i64 8
   %33 = bitcast i8* %32 to i64*
-  %NullCheck14 = icmp ne i64* %33, null
-  br i1 %NullCheck14, label %34, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = load i64, i64* %33, align 8
@@ -4197,8 +5061,8 @@ entry:
   %37 = bitcast i16* %36 to i8*
   %38 = getelementptr inbounds i8, i8* %37, i64 8
   %39 = bitcast i8* %38 to i64*
-  %NullCheck16 = icmp ne i64* %39, null
-  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %40
 
 ; <label>:40                                      ; preds = %34
   %41 = load i64, i64* %39, align 8
@@ -4214,8 +5078,8 @@ entry:
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %NullCheck18 = icmp ne i64* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = load i64, i64* %48, align 8
@@ -4223,8 +5087,8 @@ entry:
   %52 = bitcast i16* %51 to i8*
   %53 = getelementptr inbounds i8, i8* %52, i64 16
   %54 = bitcast i8* %53 to i64*
-  %NullCheck20 = icmp ne i64* %54, null
-  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64* %54, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %55
 
 ; <label>:55                                      ; preds = %49
   %56 = load i64, i64* %54, align 8
@@ -4262,15 +5126,15 @@ entry:
 ; <label>:74                                      ; preds = %95
   %75 = load i16*, i16** %loc3
   %76 = bitcast i16* %75 to i32*
-  %NullCheck6 = icmp ne i32* %76, null
-  br i1 %NullCheck6, label %77, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32* %76, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %77
 
 ; <label>:77                                      ; preds = %74
   %78 = load i32, i32* %76, align 8
   %79 = load i16*, i16** %loc4
   %80 = bitcast i16* %79 to i32*
-  %NullCheck8 = icmp ne i32* %80, null
-  br i1 %NullCheck8, label %81, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i32* %80, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %81
 
 ; <label>:81                                      ; preds = %77
   %82 = load i32, i32* %80, align 8
@@ -4318,43 +5182,43 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %74
+ThrowNullRef6:                                    ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %77
+ThrowNullRef8:                                    ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %29
+ThrowNullRef14:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %34
+ThrowNullRef16:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4376,8 +5240,8 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load i64, i64 addrspace(1)* %4
@@ -4389,8 +5253,8 @@ entry:
   %12 = load i64, i64* %11
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %5
   %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
@@ -4399,8 +5263,8 @@ entry:
   %18 = load i8, i8* %arg2
   %19 = zext i8 %18 to i32
   %20 = trunc i32 %19 to i8
-  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %15
   %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
@@ -4411,11 +5275,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4442,8 +5306,8 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
@@ -4466,16 +5330,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
   %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = load i64, i64 addrspace(1)* %19
@@ -4500,8 +5364,8 @@ entry:
 ; <label>:35                                      ; preds = %30
   %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
@@ -4514,8 +5378,8 @@ entry:
 
 ; <label>:42                                      ; preds = %1, %38
   %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
-  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
@@ -4526,19 +5390,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %35
+ThrowNullRef2:                                    ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %42
+ThrowNullRef8:                                    ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4551,14 +5415,14 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
@@ -4570,7 +5434,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4583,8 +5447,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
@@ -4613,51 +5477,51 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
   %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
   %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
   %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
   %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
-  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
   store i64 %21, i64 addrspace(1)* %23
   %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %25 = load i64, i64* %loc0
-  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
@@ -4668,27 +5532,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %22
+ThrowNullRef12:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4701,8 +5565,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
@@ -4713,19 +5577,19 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
@@ -4734,8 +5598,8 @@ entry:
 
 ; <label>:15                                      ; preds = %1, %13
   %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
@@ -4746,19 +5610,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %15
+ThrowNullRef8:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4771,8 +5635,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -4831,8 +5695,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
@@ -4882,8 +5746,8 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
-  br i1 %NullCheck, label %17, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %ThrowNullRef, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
@@ -4894,15 +5758,15 @@ entry:
 
 ; <label>:22                                      ; preds = %17
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
-  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
   %26 = load i32, i32 addrspace(1)* %25
   %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
-  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %27, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
@@ -4925,8 +5789,8 @@ entry:
 ; <label>:40                                      ; preds = %17
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
-  br i1 %NullCheck6, label %43, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %41, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
@@ -4938,34 +5802,17 @@ ThrowNullRef:                                     ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %24
+ThrowNullRef4:                                    ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %40
+ThrowNullRef6:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
-}
-
-INFO:  jitting method Object::ReferenceEquals using LLILCJit
-Successfully read Object.ReferenceEquals
-
-define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
-entry:
-  %arg0 = alloca %System.Object addrspace(1)*
-  %arg1 = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
-  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
-  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = icmp eq %System.Object addrspace(1)* %0, %1
-  %3 = sext i1 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
 }
 
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
@@ -4978,21 +5825,21 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
   %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
-  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
@@ -5007,28 +5854,28 @@ entry:
 ; <label>:13                                      ; preds = %8, %12
   %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
   %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
   %21 = load i32, i32 addrspace(1)* %20, align 8
   %22 = add i32 %21, 1
-  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
   store i32 %22, i32 addrspace(1)* %24
   %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
@@ -5039,27 +5886,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5077,7 +5924,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::Setup using LLILCJit
-Failed to read AppDomain.Setup[loadElem]
+Failed to read AppDomain.Setup[unbox]
 INFO:  jitting method Thread::GetDomain using LLILCJit
 Successfully read Thread.GetDomain
 
@@ -5108,8 +5955,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
@@ -5122,14 +5969,14 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
   %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
@@ -5141,11 +5988,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5173,8 +6020,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -5189,7 +6036,328 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
 Failed to read KeyCollection.System.Collections.Generic.IEnumerable<TKey>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Successfully read Enumerator.MoveNext
+
+define i8 @Enumerator.MoveNext(%"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.RuntimeTypeHandle* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*
+  %"$TypeArg" = alloca %System.RuntimeTypeHandle*
+  store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
+  %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 8
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %76, label %12
+
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
+  br label %76
+
+; <label>:13                                      ; preds = %85
+  %14 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck19 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %15
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, i32 0, i32 0
+  %17 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %16, align 8
+  %NullCheck21 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, i32 0, i32 2
+  %20 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %19, align 8
+  %21 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck23 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %22
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, i32 0, i32 2
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %NullCheck25 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 3, i32 %24
+  %NullCheck27 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %32
+
+; <label>:32                                      ; preds = %30
+  %33 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, i32 0, i32 2
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = icmp slt i32 %34, 0
+  br i1 %35, label %68, label %36
+
+; <label>:36                                      ; preds = %32
+  %37 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %38 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck29 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %39
+
+; <label>:39                                      ; preds = %36
+  %40 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, i32 0, i32 0
+  %41 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %40, align 8
+  %NullCheck31 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, i32 0, i32 2
+  %44 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %43, align 8
+  %45 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck33 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, i32 0, i32 2
+  %48 = load i32, i32 addrspace(1)* %47, align 8
+  %NullCheck35 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %49
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = zext i32 %51 to i64
+  %53 = zext i32 %48 to i64
+  %BoundsCheck37 = icmp uge i64 %53, %52
+  br i1 %BoundsCheck37, label %ThrowIndexOutOfRange38, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 3, i32 %48
+  %NullCheck39 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %56
+
+; <label>:56                                      ; preds = %54
+  %57 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, i32 0, i32 0
+  %58 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck41 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %59
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %60, %System.__Canon addrspace(1)* %58)
+  %61 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck43 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  %64 = load i32, i32 addrspace(1)* %63, align 8
+  %65 = add i32 %64, 1
+  %NullCheck45 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  store i32 %65, i32 addrspace(1)* %67
+  ret i8 1
+
+; <label>:68                                      ; preds = %32
+  %69 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck47 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %73 = add i32 %72, 1
+  %NullCheck49 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %74
+
+; <label>:74                                      ; preds = %70
+  %75 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  store i32 %73, i32 addrspace(1)* %75
+  br label %76
+
+; <label>:76                                      ; preds = %8, %12, %74
+  %77 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %78
+
+; <label>:78                                      ; preds = %76
+  %79 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, i32 0, i32 2
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck7 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %82
+
+; <label>:82                                      ; preds = %78
+  %83 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, i32 0, i32 0
+  %84 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %83, align 8
+  %NullCheck9 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %85
+
+; <label>:85                                      ; preds = %82
+  %86 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, i32 0, i32 7
+  %87 = load i32, i32 addrspace(1)* %86, align 8
+  %88 = icmp ult i32 %80, %87
+  br i1 %88, label %13, label %89
+
+; <label>:89                                      ; preds = %85
+  %90 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %91 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck11 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %92
+
+; <label>:92                                      ; preds = %89
+  %93 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, i32 0, i32 0
+  %94 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck13 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %95
+
+; <label>:95                                      ; preds = %92
+  %96 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, i32 0, i32 7
+  %97 = load i32, i32 addrspace(1)* %96, align 8
+  %98 = add i32 %97, 1
+  %NullCheck15 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %99
+
+; <label>:99                                      ; preds = %95
+  %100 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, i32 0, i32 2
+  store i32 %98, i32 addrspace(1)* %100
+  %101 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck17 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %102
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %103, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %92
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef22:                                   ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef24:                                   ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef26:                                   ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef28:                                   ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef30:                                   ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef32:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef34:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef36:                                   ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange38:                           ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef40:                                   ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef42:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef44:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef46:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef48:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef50:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -5200,8 +6368,8 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -5232,9 +6400,9 @@ Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
 Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
-Failed to read String.MakeSeparatorList[loadElemA]
+Failed to read String.MakeSeparatorList[storeElem]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
-Failed to read String.InternalSplitKeepEmptyEntries[loadElem]
+Failed to read String.InternalSplitKeepEmptyEntries[storeElem]
 INFO:  jitting method Path::IsRelative using LLILCJit
 Successfully read Path.IsRelative
 
@@ -5243,8 +6411,8 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -5254,8 +6422,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
@@ -5271,8 +6439,8 @@ entry:
 
 ; <label>:17                                      ; preds = %7
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
@@ -5288,8 +6456,8 @@ entry:
 
 ; <label>:29                                      ; preds = %19
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %31
 
 ; <label>:31                                      ; preds = %29
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
@@ -5300,8 +6468,8 @@ entry:
 
 ; <label>:36                                      ; preds = %31
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
-  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %37, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
@@ -5312,8 +6480,8 @@ entry:
 
 ; <label>:43                                      ; preds = %31, %38
   %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
-  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %45
 
 ; <label>:45                                      ; preds = %43
   %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
@@ -5324,8 +6492,8 @@ entry:
 
 ; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %50
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
@@ -5336,8 +6504,8 @@ entry:
 
 ; <label>:57                                      ; preds = %1, %7, %19, %45, %52
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
-  br i1 %NullCheck14, label %59, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %59
 
 ; <label>:59                                      ; preds = %57
   %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
@@ -5347,8 +6515,8 @@ entry:
 
 ; <label>:63                                      ; preds = %59
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
@@ -5359,8 +6527,8 @@ entry:
 
 ; <label>:70                                      ; preds = %65
   %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
-  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.String addrspace(1)* %71, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %72
 
 ; <label>:72                                      ; preds = %70
   %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
@@ -5379,39 +6547,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %17
+ThrowNullRef4:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %29
+ThrowNullRef6:                                    ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %36
+ThrowNullRef8:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %43
+ThrowNullRef10:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %50
+ThrowNullRef12:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %57
+ThrowNullRef14:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %63
+ThrowNullRef16:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %70
+ThrowNullRef18:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5419,7 +6587,293 @@ ThrowNullRef17:                                   ; preds = %70
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
-Failed to read String.TrimHelper[loadElem]
+Successfully read String.TrimHelper
+
+define %System.String addrspace(1)* @String.TrimHelper(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i16
+  %loc4 = alloca i32
+  %loc5 = alloca i16
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = sub i32 %3, 1
+  store i32 %4, i32* %loc0
+  store i32 0, i32* %loc1
+  %5 = load i32, i32* %arg2
+  %6 = icmp eq i32 %5, 1
+  br i1 %6, label %62, label %7
+
+; <label>:7                                       ; preds = %1
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:8                                       ; preds = %58
+  store i32 0, i32* %loc2
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load i32, i32* %loc1
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2, i32 %10
+  %13 = load i16, i16 addrspace(1)* %12
+  %14 = zext i16 %13 to i32
+  %15 = trunc i32 %14 to i16
+  store i16 %15, i16* %loc3
+  store i32 0, i32* %loc2
+  br label %34
+
+; <label>:16                                      ; preds = %37
+  %17 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %18 = load i32, i32* %loc2
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %17, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %19
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = zext i32 %18 to i64
+  %BoundsCheck = icmp uge i64 %23, %22
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %24
+
+; <label>:24                                      ; preds = %19
+  %25 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 3, i32 %18
+  %26 = load i16, i16 addrspace(1)* %25, align 8
+  %27 = zext i16 %26 to i32
+  %28 = load i16, i16* %loc3
+  %29 = zext i16 %28 to i32
+  %30 = icmp eq i32 %27, %29
+  br i1 %30, label %43, label %31
+
+; <label>:31                                      ; preds = %24
+  %32 = load i32, i32* %loc2
+  %33 = add i32 %32, 1
+  store i32 %33, i32* %loc2
+  br label %34
+
+; <label>:34                                      ; preds = %11, %31
+  %35 = load i32, i32* %loc2
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = icmp slt i32 %35, %41
+  br i1 %42, label %16, label %43
+
+; <label>:43                                      ; preds = %24, %37
+  %44 = load i32, i32* %loc2
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %45, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp eq i32 %44, %50
+  br i1 %51, label %62, label %52
+
+; <label>:52                                      ; preds = %46
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %7, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %57, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %58
+
+; <label>:58                                      ; preds = %55
+  %59 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %60 = load i32, i32 addrspace(1)* %59
+  %61 = icmp slt i32 %56, %60
+  br i1 %61, label %8, label %62
+
+; <label>:62                                      ; preds = %1, %46, %58
+  %63 = load i32, i32* %arg2
+  %64 = icmp eq i32 %63, 0
+  br i1 %64, label %122, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %66, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %67
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %66, i32 0, i32 1
+  %69 = load i32, i32 addrspace(1)* %68
+  %70 = sub i32 %69, 1
+  store i32 %70, i32* %loc0
+  br label %118
+
+; <label>:71                                      ; preds = %118
+  store i32 0, i32* %loc4
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %73 = load i32, i32* %loc0
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %74
+
+; <label>:74                                      ; preds = %71
+  %75 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 2, i32 %73
+  %76 = load i16, i16 addrspace(1)* %75
+  %77 = zext i16 %76 to i32
+  %78 = trunc i32 %77 to i16
+  store i16 %78, i16* %loc5
+  store i32 0, i32* %loc4
+  br label %97
+
+; <label>:79                                      ; preds = %100
+  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %81 = load i32, i32* %loc4
+  %NullCheck19 = icmp eq %"System.Char[]" addrspace(1)* %80, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
+
+; <label>:82                                      ; preds = %79
+  %83 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 1
+  %84 = load i32, i32 addrspace(1)* %83
+  %85 = zext i32 %84 to i64
+  %86 = zext i32 %81 to i64
+  %BoundsCheck21 = icmp uge i64 %86, %85
+  br i1 %BoundsCheck21, label %ThrowIndexOutOfRange22, label %87
+
+; <label>:87                                      ; preds = %82
+  %88 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 3, i32 %81
+  %89 = load i16, i16 addrspace(1)* %88, align 8
+  %90 = zext i16 %89 to i32
+  %91 = load i16, i16* %loc5
+  %92 = zext i16 %91 to i32
+  %93 = icmp eq i32 %90, %92
+  br i1 %93, label %106, label %94
+
+; <label>:94                                      ; preds = %87
+  %95 = load i32, i32* %loc4
+  %96 = add i32 %95, 1
+  store i32 %96, i32* %loc4
+  br label %97
+
+; <label>:97                                      ; preds = %74, %94
+  %98 = load i32, i32* %loc4
+  %99 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck15 = icmp eq %"System.Char[]" addrspace(1)* %99, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %100
+
+; <label>:100                                     ; preds = %97
+  %101 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %99, i32 0, i32 1
+  %102 = load i32, i32 addrspace(1)* %101
+  %103 = zext i32 %102 to i64
+  %104 = trunc i64 %103 to i32
+  %105 = icmp slt i32 %98, %104
+  br i1 %105, label %79, label %106
+
+; <label>:106                                     ; preds = %87, %100
+  %107 = load i32, i32* %loc4
+  %108 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck17 = icmp eq %"System.Char[]" addrspace(1)* %108, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %109
+
+; <label>:109                                     ; preds = %106
+  %110 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %108, i32 0, i32 1
+  %111 = load i32, i32 addrspace(1)* %110
+  %112 = zext i32 %111 to i64
+  %113 = trunc i64 %112 to i32
+  %114 = icmp eq i32 %107, %113
+  br i1 %114, label %122, label %115
+
+; <label>:115                                     ; preds = %109
+  %116 = load i32, i32* %loc0
+  %117 = sub i32 %116, 1
+  store i32 %117, i32* %loc0
+  br label %118
+
+; <label>:118                                     ; preds = %67, %115
+  %119 = load i32, i32* %loc0
+  %120 = load i32, i32* %loc1
+  %121 = icmp sge i32 %119, %120
+  br i1 %121, label %71, label %122
+
+; <label>:122                                     ; preds = %62, %109, %118
+  %123 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %124 = load i32, i32* %loc1
+  %125 = load i32, i32* %loc0
+  %126 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %123, i32 %124, i32 %125)
+  ret %System.String addrspace(1)* %126
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %97
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange22:                           ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
 Successfully read String.CreateTrimmedString
 
@@ -5439,8 +6893,8 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
@@ -5535,8 +6989,8 @@ entry:
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i64 2872
   %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
   %8 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %7
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %3
   %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
@@ -5553,8 +7007,8 @@ entry:
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 2864
   %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
   %21 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %20
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
-  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %22
 
 ; <label>:22                                      ; preds = %16
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
@@ -5569,7 +7023,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %16
+ThrowNullRef2:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5586,8 +7040,8 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5613,8 +7067,8 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
@@ -5632,8 +7086,8 @@ entry:
 
 ; <label>:12                                      ; preds = %4
   %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
@@ -5644,8 +7098,8 @@ entry:
 
 ; <label>:19                                      ; preds = %14
   %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %19
   %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
@@ -5660,21 +7114,21 @@ entry:
   %31 = zext i16 %30 to i32
   %32 = bitcast i8* %29 to i16*
   %33 = trunc i32 %31 to i16
-  %NullCheck6 = icmp ne i16* %32, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i16* %32, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %21
   store i16 %33, i16* %32, align 8
   %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %36
 
 ; <label>:36                                      ; preds = %34
   %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
   %38 = load i32, i32 addrspace(1)* %37, align 8
   %39 = add i32 %38, 1
-  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %40
 
 ; <label>:40                                      ; preds = %36
   %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
@@ -5683,16 +7137,16 @@ entry:
 
 ; <label>:42                                      ; preds = %14
   %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
-  br i1 %NullCheck12, label %44, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
   %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
   %47 = load i16, i16* %arg1
   %48 = zext i16 %47 to i32
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = trunc i32 %48 to i16
@@ -5703,31 +7157,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %19
+ThrowNullRef4:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %21
+ThrowNullRef6:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %36
+ThrowNullRef10:                                   ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %42
+ThrowNullRef12:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %44
+ThrowNullRef14:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5740,8 +7194,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -5752,8 +7206,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
@@ -5762,14 +7216,14 @@ entry:
 
 ; <label>:11                                      ; preds = %1
   %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
@@ -5779,15 +7233,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5808,8 +7262,8 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5822,8 +7276,8 @@ entry:
 
 ; <label>:8                                       ; preds = %3
   %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
@@ -5842,15 +7296,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
-  br i1 %NullCheck4, label %22, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
   %24 = load i16*, i16* addrspace(1)* %23, align 8
   %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %25, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
@@ -5859,8 +7313,8 @@ entry:
   store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
@@ -5874,8 +7328,8 @@ entry:
 
 ; <label>:37                                      ; preds = %65
   %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %37
   %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
@@ -5886,16 +7340,16 @@ entry:
   %45 = bitcast i16* %41 to i8*
   %46 = getelementptr inbounds i8, i8* %45, i64 %44
   %47 = bitcast i8* %46 to i16*
-  %NullCheck14 = icmp ne i16* %47, null
-  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %47, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %48
 
 ; <label>:48                                      ; preds = %39
   %49 = load i16, i16* %47, align 8
   %50 = zext i16 %49 to i32
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %52 = load i32, i32* %loc1
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %53
 
 ; <label>:53                                      ; preds = %48
   %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
@@ -5916,8 +7370,8 @@ entry:
 ; <label>:62                                      ; preds = %36, %59
   %63 = load i32, i32* %loc1
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck10, label %65, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %65
 
 ; <label>:65                                      ; preds = %62
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
@@ -5936,15 +7390,15 @@ entry:
 
 ; <label>:74                                      ; preds = %70
   %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
-  br i1 %NullCheck18, label %76, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %76
 
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
   %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
-  br i1 %NullCheck20, label %80, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
   %81 = load i64, i64 addrspace(1)* %79
@@ -5958,8 +7412,8 @@ entry:
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
   %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
-  br i1 %NullCheck22, label %92, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.String addrspace(1)* %90, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %92
 
 ; <label>:92                                      ; preds = %80
   %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
@@ -5969,15 +7423,15 @@ entry:
 
 ; <label>:96                                      ; preds = %70
   %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
-  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %98
 
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
   %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
-  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
   %103 = load i64, i64 addrspace(1)* %101
@@ -5991,8 +7445,8 @@ entry:
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
   %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
-  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.String addrspace(1)* %112, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %114
 
 ; <label>:114                                     ; preds = %102
   %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
@@ -6004,59 +7458,59 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %20
+ThrowNullRef4:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %22
+ThrowNullRef6:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %26
+ThrowNullRef8:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %62
+ThrowNullRef10:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %48
+ThrowNullRef16:                                   ; preds = %48
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %74
+ThrowNullRef18:                                   ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %76
+ThrowNullRef20:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %80
+ThrowNullRef22:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %96
+ThrowNullRef24:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %98
+ThrowNullRef26:                                   ; preds = %98
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %102
+ThrowNullRef28:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6069,15 +7523,15 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
   %3 = load i16*, i16* addrspace(1)* %2, align 8
   %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
@@ -6087,8 +7541,8 @@ entry:
   %10 = bitcast i16* %3 to i8*
   %11 = getelementptr inbounds i8, i8* %10, i64 %9
   %12 = bitcast i8* %11 to i16*
-  %NullCheck4 = icmp ne i16* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %5
   store i16 0, i16* %12, align 8
@@ -6098,11 +7552,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6119,8 +7573,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -6131,8 +7585,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
@@ -6144,15 +7598,15 @@ entry:
 
 ; <label>:14                                      ; preds = %1
   %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
   %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
   %21 = load i64, i64 addrspace(1)* %19
@@ -6171,15 +7625,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %14
+ThrowNullRef4:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %16
+ThrowNullRef6:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6302,14 +7756,6 @@ entry:
   ret %System.String addrspace(1)* %57
 }
 
-INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
-Successfully read RuntimeHelpers.get_OffsetToStringData
-
-define i32 @RuntimeHelpers.get_OffsetToStringData() {
-entry:
-  ret i32 12
-}
-
 INFO:  jitting method String::Equals using LLILCJit
 Successfully read String.Equals
 
@@ -6381,8 +7827,8 @@ entry:
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
-  br i1 %NullCheck24, label %29, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
   %30 = load i64, i64 addrspace(1)* %28
@@ -6397,8 +7843,8 @@ entry:
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
-  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
   %43 = load i64, i64 addrspace(1)* %41
@@ -6418,8 +7864,8 @@ entry:
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
   %59 = load i64, i64 addrspace(1)* %57
@@ -6434,8 +7880,8 @@ entry:
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck22, label %71, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
   %72 = load i64, i64 addrspace(1)* %70
@@ -6455,8 +7901,8 @@ entry:
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
-  br i1 %NullCheck16, label %87, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = load i64, i64 addrspace(1)* %86
@@ -6471,8 +7917,8 @@ entry:
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck18, label %100, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
   %101 = load i64, i64 addrspace(1)* %99
@@ -6492,8 +7938,8 @@ entry:
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
-  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
   %117 = load i64, i64 addrspace(1)* %115
@@ -6508,8 +7954,8 @@ entry:
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
-  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
   %130 = load i64, i64 addrspace(1)* %128
@@ -6528,15 +7974,15 @@ entry:
 
 ; <label>:142                                     ; preds = %22
   %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
-  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %143, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %144
 
 ; <label>:144                                     ; preds = %142
   %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
   %146 = load i32, i32 addrspace(1)* %145
   %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
-  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %147, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %148
 
 ; <label>:148                                     ; preds = %144
   %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
@@ -6557,15 +8003,15 @@ entry:
 
 ; <label>:159                                     ; preds = %22
   %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
-  br i1 %NullCheck, label %161, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %ThrowNullRef, label %161
 
 ; <label>:161                                     ; preds = %159
   %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
   %163 = load i32, i32 addrspace(1)* %162
   %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
-  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %164, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %165
 
 ; <label>:165                                     ; preds = %161
   %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
@@ -6578,8 +8024,8 @@ entry:
 
 ; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
-  br i1 %NullCheck4, label %172, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %171, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %172
 
 ; <label>:172                                     ; preds = %170
   %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
@@ -6589,8 +8035,8 @@ entry:
 
 ; <label>:176                                     ; preds = %172
   %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
-  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %177, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %178
 
 ; <label>:178                                     ; preds = %176
   %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
@@ -6629,55 +8075,55 @@ ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %161
+ThrowNullRef2:                                    ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %170
+ThrowNullRef4:                                    ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %176
+ThrowNullRef6:                                    ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %142
+ThrowNullRef8:                                    ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %144
+ThrowNullRef10:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %113
+ThrowNullRef12:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %116
+ThrowNullRef14:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %84
+ThrowNullRef16:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %87
+ThrowNullRef18:                                   ; preds = %87
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %55
+ThrowNullRef20:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %58
+ThrowNullRef22:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %26
+ThrowNullRef24:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %29
+ThrowNullRef26:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,8 +8161,8 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck, label %14, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %ThrowNullRef, label %14
 
 ; <label>:14                                      ; preds = %8
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
@@ -6760,8 +8206,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
@@ -6770,14 +8216,14 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32, i32* %loc0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %10
   %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
   %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
@@ -6790,15 +8236,15 @@ entry:
 ; <label>:25                                      ; preds = %19
   %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
-  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
   %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
@@ -6807,8 +8253,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %37 = load i32, i32* %loc0
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %38, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %38
 
 ; <label>:38                                      ; preds = %32
   %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
@@ -6817,14 +8263,14 @@ entry:
 
 ; <label>:40                                      ; preds = %19
   %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %40
   %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
   %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
-  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
-  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
@@ -6832,8 +8278,8 @@ entry:
   %48 = zext i32 %47 to i64
   %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
-  br i1 %NullCheck16, label %51, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %51
 
 ; <label>:51                                      ; preds = %45
   %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
@@ -6847,15 +8293,15 @@ entry:
 ; <label>:57                                      ; preds = %51
   %58 = load i16*, i16** %arg1
   %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
-  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %60
 
 ; <label>:60                                      ; preds = %57
   %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
   %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
-  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %64
 
 ; <label>:64                                      ; preds = %60
   %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
@@ -6864,22 +8310,22 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
   %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
-  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %70
 
 ; <label>:70                                      ; preds = %64
   %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
   %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
-  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
-  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
   %75 = load i32, i32 addrspace(1)* %74
   %76 = zext i32 %75 to i64
   %77 = trunc i64 %76 to i32
-  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
-  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %78
 
 ; <label>:78                                      ; preds = %73
   %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
@@ -6901,8 +8347,8 @@ entry:
   %90 = bitcast i16* %86 to i8*
   %91 = getelementptr inbounds i8, i8* %90, i64 %89
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %93
 
 ; <label>:93                                      ; preds = %80
   %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
@@ -6912,8 +8358,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %99 = load i32, i32* %loc2
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %100
 
 ; <label>:100                                     ; preds = %93
   %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
@@ -6928,63 +8374,63 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %25
+ThrowNullRef6:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %32
+ThrowNullRef10:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %40
+ThrowNullRef12:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %45
+ThrowNullRef16:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %57
+ThrowNullRef18:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %60
+ThrowNullRef20:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %64
+ThrowNullRef22:                                   ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %70
+ThrowNullRef24:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %73
+ThrowNullRef26:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %80
+ThrowNullRef28:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %93
+ThrowNullRef30:                                   ; preds = %93
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7004,8 +8450,8 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
@@ -7033,43 +8479,43 @@ entry:
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %14
   %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
   %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   %28 = load i32, i32 addrspace(1)* %27, align 8
   %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
-  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %30
 
 ; <label>:30                                      ; preds = %26
   %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
   %32 = load i32, i32 addrspace(1)* %31, align 8
   %33 = add i32 %28, %32
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %34
 
 ; <label>:34                                      ; preds = %30
   %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   store i32 %33, i32 addrspace(1)* %35
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
   store i32 0, i32 addrspace(1)* %38
   %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %40
 
 ; <label>:40                                      ; preds = %37
   %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
@@ -7082,8 +8528,8 @@ entry:
 
 ; <label>:47                                      ; preds = %40
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
@@ -7098,8 +8544,8 @@ entry:
   %54 = load i32, i32* %loc0
   %55 = sext i32 %54 to i64
   %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
-  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %57
 
 ; <label>:57                                      ; preds = %52
   %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
@@ -7110,68 +8556,35 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %14
+ThrowNullRef2:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %23
+ThrowNullRef4:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %26
+ThrowNullRef6:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %30
+ThrowNullRef8:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %34
+ThrowNullRef10:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %47
+ThrowNullRef14:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %52
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-}
-
-INFO:  jitting method StringBuilder::get_Length using LLILCJit
-Successfully read StringBuilder.get_Length
-
-define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.StringBuilder addrspace(1)*
-  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
-  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
-
-; <label>:1                                       ; preds = %entry
-  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %3 = load i32, i32 addrspace(1)* %2, align 8
-  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
-
-; <label>:5                                       ; preds = %1
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = add i32 %3, %7
-  ret i32 %8
-
-ThrowNullRef:                                     ; preds = %entry
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef16:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7213,70 +8626,70 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
   %6 = load i32, i32 addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
   store i32 %6, i32 addrspace(1)* %8
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
   %13 = load i32, i32 addrspace(1)* %12, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
   store i32 %13, i32 addrspace(1)* %15
   %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
-  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %18
 
 ; <label>:18                                      ; preds = %14
   %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
   %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
   %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
   %34 = load i32, i32 addrspace(1)* %33, align 8
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
-  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
@@ -7287,39 +8700,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %28
+ThrowNullRef16:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %32
+ThrowNullRef18:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7455,13 +8868,13 @@ entry:
 ; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
@@ -7477,16 +8890,16 @@ entry:
 
 ; <label>:18                                      ; preds = %15
   %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
   store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
   %22 = load i32, i32* %loc0
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %24
 
 ; <label>:24                                      ; preds = %20
   %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
@@ -7498,13 +8911,13 @@ entry:
 ; <label>:28                                      ; preds = %15, %24
   %29 = load i32, i32* %arg1
   %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %31
   %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
@@ -7517,20 +8930,20 @@ entry:
   %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
-  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
   %46 = load i32, i32 addrspace(1)* %45, align 8
   %47 = sub i32 %40, %46
-  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
-  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i32 addrspace(1)* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %48
 
 ; <label>:48                                      ; preds = %44
   store i32 %47, i32 addrspace(1)* %39, align 8
@@ -7538,21 +8951,21 @@ entry:
 
 ; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
-  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %51
 
 ; <label>:51                                      ; preds = %49
   %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %53
 
 ; <label>:53                                      ; preds = %51
   %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
   %55 = load i32, i32 addrspace(1)* %54, align 8
   %56 = load i32, i32* %arg2
   %57 = sub i32 %55, %56
-  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %58
 
 ; <label>:58                                      ; preds = %53
   %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
@@ -7562,13 +8975,13 @@ entry:
 ; <label>:60                                      ; preds = %33, %58
   %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
   %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
-  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %63
 
 ; <label>:63                                      ; preds = %60
   %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
-  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
-  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
@@ -7578,15 +8991,15 @@ entry:
 
 ; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
-  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i32 addrspace(1)* %69, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %70
 
 ; <label>:70                                      ; preds = %68
   %71 = load i32, i32 addrspace(1)* %69, align 8
   store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
-  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
@@ -7596,8 +9009,8 @@ entry:
   store i32 %77, i32* %loc4
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
-  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %80
 
 ; <label>:80                                      ; preds = %73
   %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
@@ -7607,71 +9020,71 @@ entry:
 ; <label>:83                                      ; preds = %80
   store i32 0, i32* %loc3
   %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
-  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
-  br i1 %NullCheck26, label %88, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i32 addrspace(1)* %87, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %88
 
 ; <label>:88                                      ; preds = %85
   %89 = load i32, i32 addrspace(1)* %87, align 8
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
-  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %90
 
 ; <label>:90                                      ; preds = %88
   %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
   store i32 %89, i32 addrspace(1)* %91
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
-  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
-  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %96
 
 ; <label>:96                                      ; preds = %94
   %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
-  br i1 %NullCheck34, label %100, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %100
 
 ; <label>:100                                     ; preds = %96
   %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
-  br i1 %NullCheck36, label %102, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %102
 
 ; <label>:102                                     ; preds = %100
   %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
   %104 = load i32, i32 addrspace(1)* %103, align 8
   %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
-  br i1 %NullCheck38, label %106, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %106
 
 ; <label>:106                                     ; preds = %102
   %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
-  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
-  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %108
 
 ; <label>:108                                     ; preds = %106
   %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
   %110 = load i32, i32 addrspace(1)* %109, align 8
   %111 = add i32 %104, %110
-  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %112
 
 ; <label>:112                                     ; preds = %108
   %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
   store i32 %111, i32 addrspace(1)* %113
   %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
-  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i32 addrspace(1)* %114, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %115
 
 ; <label>:115                                     ; preds = %112
   %116 = load i32, i32 addrspace(1)* %114, align 8
@@ -7681,19 +9094,19 @@ entry:
 ; <label>:118                                     ; preds = %115
   %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
-  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %121
 
 ; <label>:121                                     ; preds = %118
   %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
-  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
-  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %123
 
 ; <label>:123                                     ; preds = %121
   %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
   %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
-  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
-  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %126
 
 ; <label>:126                                     ; preds = %123
   %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
@@ -7705,8 +9118,8 @@ entry:
 
 ; <label>:130                                     ; preds = %80, %115, %126
   %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %132
 
 ; <label>:132                                     ; preds = %130
   %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7715,8 +9128,8 @@ entry:
   %136 = load i32, i32* %loc3
   %137 = sub i32 %135, %136
   %138 = sub i32 %134, %137
-  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %139
 
 ; <label>:139                                     ; preds = %132
   %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7728,16 +9141,16 @@ entry:
 
 ; <label>:144                                     ; preds = %139
   %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
-  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %146
 
 ; <label>:146                                     ; preds = %144
   %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
   %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
   %149 = load i32, i32* %loc2
   %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
-  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %151
 
 ; <label>:151                                     ; preds = %146
   %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
@@ -7754,145 +9167,249 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %18
+ThrowNullRef4:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %31
+ThrowNullRef10:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %44
+ThrowNullRef16:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %68
+ThrowNullRef18:                                   ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %70
+ThrowNullRef20:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %73
+ThrowNullRef22:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %83
+ThrowNullRef24:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %85
+ThrowNullRef26:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %88
+ThrowNullRef28:                                   ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %90
+ThrowNullRef30:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %94
+ThrowNullRef32:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %96
+ThrowNullRef34:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %100
+ThrowNullRef36:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %102
+ThrowNullRef38:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %106
+ThrowNullRef40:                                   ; preds = %106
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %108
+ThrowNullRef42:                                   ; preds = %108
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %112
+ThrowNullRef44:                                   ; preds = %112
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %118
+ThrowNullRef46:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %121
+ThrowNullRef48:                                   ; preds = %121
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %123
+ThrowNullRef50:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %130
+ThrowNullRef52:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %132
+ThrowNullRef54:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %144
+ThrowNullRef56:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %146
+ThrowNullRef58:                                   ; preds = %146
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %60
+ThrowNullRef60:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %63
+ThrowNullRef62:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %49
+ThrowNullRef64:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %51
+ThrowNullRef66:                                   ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %53
+ThrowNullRef68:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(%"System.Char[]" addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %arg0 = alloca %"System.Char[]" addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store %"System.Char[]" addrspace(1)* %param0, %"System.Char[]" addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load i32, i32* %arg4
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %43, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %38, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg1
+  %13 = load i32, i32* %arg4
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %38, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %24 = load i32, i32* %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %35 = load i32, i32* %arg3
+  %36 = load i32, i32* %arg4
+  %37 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %37, %"System.Char[]" addrspace(1)* %34, i32 %35, i32 %36)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:38                                      ; preds = %5, %16
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Successfully read Buffer._Memmove
 
@@ -7914,7 +9431,7 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[loadElem]
+Failed to read AppDomain.SetDataHelper[storeElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -7923,8 +9440,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
@@ -7934,8 +9451,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
@@ -7947,15 +9464,15 @@ entry:
   %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
   %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
@@ -7966,15 +9483,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7992,7 +9509,79 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
-Failed to read Dictionary`2.TryGetValue[loadElemA]
+Successfully read Dictionary`2.TryGetValue
+
+define i8 @"Dictionary`2.TryGetValue"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)* addrspace(1)* %param2) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  %arg2 = alloca %System.__Canon addrspace(1)* addrspace(1)*
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  store %System.__Canon addrspace(1)* addrspace(1)* %param2, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  store i32 %2, i32* %loc0
+  %3 = load i32, i32* %loc0
+  %4 = icmp slt i32 %3, 0
+  br i1 %4, label %22, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 2
+  %10 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %9, align 8
+  %11 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = zext i32 %11 to i64
+  %BoundsCheck = icmp uge i64 %16, %15
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 3, i32 %11
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %20, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %6, %System.__Canon addrspace(1)* %21)
+  ret i8 1
+
+; <label>:22                                      ; preds = %entry
+  %23 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %23, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -8058,8 +9647,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
@@ -8091,8 +9680,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
@@ -8171,15 +9760,15 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck, label %19, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %ThrowNullRef, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
   %21 = load i32, i32 addrspace(1)* %20
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
@@ -8202,7 +9791,7 @@ ThrowNullRef:                                     ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %19
+ThrowNullRef2:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8248,8 +9837,8 @@ entry:
   %0 = alloca %System.AppDomainHandle
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %1 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %1, i32 0, i32 15
@@ -8269,8 +9858,8 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
@@ -8286,7 +9875,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -8299,8 +9888,8 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -8327,8 +9916,8 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
@@ -8352,8 +9941,8 @@ entry:
   %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
   store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
@@ -8363,8 +9952,8 @@ entry:
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
@@ -8374,8 +9963,8 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %9
   %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
@@ -8384,8 +9973,8 @@ entry:
 
 ; <label>:18                                      ; preds = %3, %16
   %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
@@ -8397,15 +9986,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %18
+ThrowNullRef6:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8418,8 +10007,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
@@ -8453,15 +10042,15 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
@@ -8473,7 +10062,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8481,7 +10070,7 @@ ThrowNullRef1:                                    ; preds = %1
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
 Failed to read Dictionary`2.System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
@@ -8506,8 +10095,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
@@ -8524,8 +10113,8 @@ entry:
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -8544,7 +10133,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8577,8 +10166,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = load i64, i64* %arg2
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = trunc i32 %3 to i8
@@ -8634,46 +10223,46 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
   %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
-  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
-  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
-  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
@@ -8684,27 +10273,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %20
+ThrowNullRef12:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8717,8 +10306,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -8756,22 +10345,22 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
   %9 = load i64, i64 addrspace(1)* %8, align 8
   %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
   %13 = load i64, i64 addrspace(1)* %12, align 8
   %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %11
   %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
@@ -8788,11 +10377,11 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8882,8 +10471,8 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
@@ -8900,8 +10489,8 @@ entry:
 ; <label>:8                                       ; preds = %1
   %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
   %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
@@ -8911,15 +10500,15 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
   %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
   %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
-  br i1 %NullCheck6, label %21, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
@@ -8946,15 +10535,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8992,15 +10581,15 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
   store i8 %3, i8 addrspace(1)* %5
   %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
@@ -9011,7 +10600,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9027,8 +10616,8 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -9041,8 +10630,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
@@ -9058,7 +10647,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9080,8 +10669,8 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
@@ -9096,8 +10685,8 @@ entry:
 ; <label>:12                                      ; preds = %6
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
@@ -9112,8 +10701,8 @@ entry:
 ; <label>:21                                      ; preds = %15
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
@@ -9128,8 +10717,8 @@ entry:
 ; <label>:30                                      ; preds = %24
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %31, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
@@ -9144,8 +10733,8 @@ entry:
 ; <label>:39                                      ; preds = %33
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
-  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %40, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %42
 
 ; <label>:42                                      ; preds = %39
   %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
@@ -9164,19 +10753,19 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %21
+ThrowNullRef4:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %30
+ThrowNullRef6:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %39
+ThrowNullRef8:                                    ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9243,8 +10832,8 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
@@ -9264,57 +10853,57 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
   store i8 0, i8 addrspace(1)* %2
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
   store i8 0, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
   store i8 0, i8 addrspace(1)* %17
   %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
   store i8 0, i8 addrspace(1)* %20
   %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
-  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
@@ -9325,31 +10914,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %19
+ThrowNullRef14:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9367,8 +10956,8 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
@@ -9380,8 +10969,8 @@ entry:
 
 ; <label>:9                                       ; preds = %4
   %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %9
   %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
@@ -9395,7 +10984,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef2:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9420,8 +11009,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
@@ -9512,8 +11101,8 @@ entry:
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
@@ -9524,8 +11113,8 @@ entry:
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = load i64, i64 addrspace(1)* %12
@@ -9537,8 +11126,8 @@ entry:
   %20 = load i64, i64* %19
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
-  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %13
   %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
@@ -9555,8 +11144,8 @@ entry:
 ; <label>:30                                      ; preds = %25
   %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %32 = load i32, i32* %arg2
-  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
-  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
@@ -9570,15 +11159,15 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %30
+ThrowNullRef2:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9622,87 +11211,87 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
   %10 = load i8, i8 addrspace(1)* %9, align 8
   %11 = zext i8 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %8
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
   store i8 %12, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
   %19 = load i8, i8 addrspace(1)* %18, align 8
   %20 = zext i8 %19 to i32
   %21 = trunc i32 %20 to i8
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
   store i8 %21, i8 addrspace(1)* %23
   %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
   %28 = load i8, i8 addrspace(1)* %27, align 8
   %29 = zext i8 %28 to i32
   %30 = trunc i32 %29 to i8
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
-  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %31
 
 ; <label>:31                                      ; preds = %26
   %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
   store i8 %30, i8 addrspace(1)* %32
   %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
-  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
-  br i1 %NullCheck14, label %40, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %40
 
 ; <label>:40                                      ; preds = %35
   %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
   store i8 %39, i8 addrspace(1)* %41
   %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
-  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %44
 
 ; <label>:44                                      ; preds = %40
   %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
   %46 = load i8, i8 addrspace(1)* %45, align 8
   %47 = zext i8 %46 to i32
   %48 = trunc i32 %47 to i8
-  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
   store i8 %48, i8 addrspace(1)* %50
   %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
-  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
@@ -9713,29 +11302,29 @@ entry:
 ; <label>:56                                      ; preds = %52
   %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
-  br i1 %NullCheck22, label %59, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
   %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
   %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
-  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
-  br i1 %NullCheck24, label %63, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
   %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
-  br i1 %NullCheck26, label %66, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
   %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
-  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
-  br i1 %NullCheck28, label %69, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %69
 
 ; <label>:69                                      ; preds = %66
   %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
@@ -9744,15 +11333,15 @@ entry:
 
 ; <label>:71                                      ; preds = %105
   %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
-  br i1 %NullCheck34, label %73, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %73
 
 ; <label>:73                                      ; preds = %71
   %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
   %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
   %76 = load i32, i32* %loc0
-  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
-  br i1 %NullCheck36, label %77, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
@@ -9766,8 +11355,8 @@ entry:
 
 ; <label>:83                                      ; preds = %77
   %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
-  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
@@ -9775,14 +11364,14 @@ entry:
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
   %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
-  br i1 %NullCheck40, label %91, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
 ; <label>:91                                      ; preds = %85
   %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
   %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
-  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck42, label %94, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %94
 
 ; <label>:94                                      ; preds = %91
   %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
@@ -9798,14 +11387,14 @@ entry:
 ; <label>:99                                      ; preds = %69, %96
   %100 = load i32, i32* %loc0
   %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
-  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %102
 
 ; <label>:102                                     ; preds = %99
   %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
   %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
-  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
-  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
@@ -9819,87 +11408,87 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %26
+ThrowNullRef10:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %31
+ThrowNullRef12:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %35
+ThrowNullRef14:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %40
+ThrowNullRef16:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %56
+ThrowNullRef22:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %59
+ThrowNullRef24:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %63
+ThrowNullRef26:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %66
+ThrowNullRef28:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %102
+ThrowNullRef32:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %71
+ThrowNullRef34:                                   ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %73
+ThrowNullRef36:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %83
+ThrowNullRef38:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %85
+ThrowNullRef40:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %91
+ThrowNullRef42:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9943,15 +11532,15 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
   %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
@@ -9961,28 +11550,28 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
   %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %12
   %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
   %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
   %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
-  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
@@ -9993,23 +11582,23 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %12
+ThrowNullRef6:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10031,15 +11620,15 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
   %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = load i64, i64 addrspace(1)* %7
@@ -10077,13 +11666,13 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[loadElem]
+Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -10111,8 +11700,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -10175,8 +11764,8 @@ entry:
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load double, double* %arg0
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -10310,8 +11899,8 @@ entry:
   store i64 %param0, i64* %arg0
   store i64 %param1, i64* %arg1
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
@@ -10319,8 +11908,8 @@ entry:
   %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
   %5 = load i16*, i16* addrspace(1)* %4, align 8
   %6 = addrspacecast i64* %arg1 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = bitcast i64 addrspace(1)* %6 to i8 addrspace(1)*
@@ -10336,7 +11925,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10370,8 +11959,8 @@ entry:
   %1 = load i32, i32* %arg1
   %2 = sext i32 %1 to i64
   %3 = inttoptr i64 %2 to i16*
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -10424,8 +12013,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, i32)*)(%System.IO.ConsoleStream addrspace(1)* %2, i32 %1)
   %3 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %4 = load i64, i64* %arg1
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
@@ -10436,8 +12025,8 @@ entry:
   %10 = icmp eq i32 %9, 3
   %11 = sext i1 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %5
   %14 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, i32 0, i32 5
@@ -10448,7 +12037,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10471,8 +12060,8 @@ entry:
   %5 = icmp eq i32 %4, 1
   %6 = sext i1 %5 to i32
   %7 = trunc i32 %6 to i8
-  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %2, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.ConsoleStream addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
@@ -10483,8 +12072,8 @@ entry:
   %13 = icmp eq i32 %12, 2
   %14 = sext i1 %13 to i32
   %15 = trunc i32 %14 to i8
-  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %10, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.ConsoleStream addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %8
   %17 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %10, i32 0, i32 4
@@ -10495,7 +12084,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10534,8 +12123,8 @@ entry:
   %arg0 = alloca i64
   store i64 %param0, i64* %arg0
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
@@ -10570,8 +12159,8 @@ entry:
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
   %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = load i64, i64 addrspace(1)* %7
@@ -10675,7 +12264,127 @@ entry:
 INFO:  jitting method Encoding::GetEncoding using LLILCJit
 Failed to read Encoding.GetEncoding[convertToHelperArgumentType]
 INFO:  jitting method EncodingProvider::GetEncodingFromProvider using LLILCJit
-Failed to read EncodingProvider.GetEncodingFromProvider[loadElem]
+Successfully read EncodingProvider.GetEncodingFromProvider
+
+define %System.Text.Encoding addrspace(1)* @EncodingProvider.GetEncodingFromProvider(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca %"System.Text.EncodingProvider[]" addrspace(1)*
+  %loc1 = alloca %System.Text.EncodingProvider addrspace(1)*
+  %loc2 = alloca %System.Text.Encoding addrspace(1)*
+  %loc3 = alloca %System.Text.Encoding addrspace(1)*
+  %loc4 = alloca %"System.Text.EncodingProvider[]" addrspace(1)*
+  %loc5 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1059)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2392
+  %2 = addrspacecast i8 addrspace(1)* %1 to %"System.Text.EncodingProvider[]" addrspace(1)**
+  %3 = load volatile %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %2
+  %4 = icmp ne %"System.Text.EncodingProvider[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %entry
+  ret %System.Text.Encoding addrspace(1)* null
+
+; <label>:6                                       ; preds = %entry
+  %7 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1059)
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i64 2392
+  %9 = addrspacecast i8 addrspace(1)* %8 to %"System.Text.EncodingProvider[]" addrspace(1)**
+  %10 = load volatile %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %9
+  store %"System.Text.EncodingProvider[]" addrspace(1)* %10, %"System.Text.EncodingProvider[]" addrspace(1)** %loc0
+  %11 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc0
+  store %"System.Text.EncodingProvider[]" addrspace(1)* %11, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  store i32 0, i32* %loc5
+  br label %43
+
+; <label>:12                                      ; preds = %46
+  %13 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  %14 = load i32, i32* %loc5
+  %NullCheck1 = icmp eq %"System.Text.EncodingProvider[]" addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %13, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = zext i32 %17 to i64
+  %19 = zext i32 %14 to i64
+  %BoundsCheck = icmp uge i64 %19, %18
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %20
+
+; <label>:20                                      ; preds = %15
+  %21 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %13, i32 0, i32 3, i32 %14
+  %22 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)* addrspace(1)* %21, align 8
+  store %System.Text.EncodingProvider addrspace(1)* %22, %System.Text.EncodingProvider addrspace(1)** %loc1
+  %23 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)** %loc1
+  %24 = load i32, i32* %arg0
+  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i64 addrspace(1)*
+  %NullCheck3 = icmp eq i64 addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
+
+; <label>:26                                      ; preds = %20
+  %27 = load i64, i64 addrspace(1)* %25
+  %28 = add i64 %27, 64
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 40
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Text.Encoding addrspace(1)* (%System.Text.EncodingProvider addrspace(1)*, i32)*
+  %35 = call %System.Text.Encoding addrspace(1)* %34(%System.Text.EncodingProvider addrspace(1)* %23, i32 %24)
+  store %System.Text.Encoding addrspace(1)* %35, %System.Text.Encoding addrspace(1)** %loc2
+  %36 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc2
+  %37 = icmp eq %System.Text.Encoding addrspace(1)* %36, null
+  br i1 %37, label %40, label %38
+
+; <label>:38                                      ; preds = %26
+  %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc2
+  store %System.Text.Encoding addrspace(1)* %39, %System.Text.Encoding addrspace(1)** %loc3
+  br label %53
+
+; <label>:40                                      ; preds = %26
+  %41 = load i32, i32* %loc5
+  %42 = add i32 %41, 1
+  store i32 %42, i32* %loc5
+  br label %43
+
+; <label>:43                                      ; preds = %6, %40
+  %44 = load i32, i32* %loc5
+  %45 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  %NullCheck = icmp eq %"System.Text.EncodingProvider[]" addrspace(1)* %45, null
+  br i1 %NullCheck, label %ThrowNullRef, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp slt i32 %44, %50
+  br i1 %51, label %12, label %52
+
+; <label>:52                                      ; preds = %46
+  ret %System.Text.Encoding addrspace(1)* null
+
+; <label>:53                                      ; preds = %38
+  %54 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc3
+  ret %System.Text.Encoding addrspace(1)* %54
+
+ThrowNullRef:                                     ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method EncodingProvider::.cctor using LLILCJit
 Successfully read EncodingProvider..cctor
 
@@ -10694,7 +12403,7 @@ Failed to read Encoding.get_InternalSyncObject[Call HasTypeArg]
 INFO:  jitting method Hashtable::.ctor using LLILCJit
 Failed to read Hashtable..ctor[Volatile store]
 INFO:  jitting method Hashtable::get_Item using LLILCJit
-Failed to read Hashtable.get_Item[loadElemA]
+Failed to read Hashtable.get_Item[loadNonPrimitiveObj]
 INFO:  jitting method Hashtable::InitHash using LLILCJit
 Successfully read Hashtable.InitHash
 
@@ -10714,8 +12423,8 @@ entry:
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -10731,15 +12440,15 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
   %15 = load i32, i32* %loc0
-  %NullCheck2 = icmp ne i32 addrspace(1)* %14, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i32 addrspace(1)* %14, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %3
   store i32 %15, i32 addrspace(1)* %14, align 8
   %17 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %18 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %NullCheck4 = icmp ne i32 addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i32 addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = load i32, i32 addrspace(1)* %18, align 8
@@ -10748,8 +12457,8 @@ entry:
   %23 = sub i32 %22, 1
   %24 = urem i32 %21, %23
   %25 = add i32 1, %24
-  %NullCheck6 = icmp ne i32 addrspace(1)* %17, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32 addrspace(1)* %17, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %19
   store i32 %25, i32 addrspace(1)* %17, align 8
@@ -10760,15 +12469,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %19
+ThrowNullRef6:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10783,8 +12492,8 @@ entry:
   store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
   store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %NullCheck = icmp ne %System.Collections.Hashtable addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Collections.Hashtable addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
@@ -10794,16 +12503,16 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Collections.Hashtable addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Collections.Hashtable addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
   %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck4 = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %9, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
   %13 = inttoptr i64 %11 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
@@ -10813,8 +12522,8 @@ entry:
 ; <label>:15                                      ; preds = %1
   %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -10832,15 +12541,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10854,8 +12563,8 @@ entry:
   store %System.Int32 addrspace(1)* %param0, %System.Int32 addrspace(1)** %this
   %0 = load %System.Int32 addrspace(1)*, %System.Int32 addrspace(1)** %this
   %1 = bitcast %System.Int32 addrspace(1)* %0 to i32 addrspace(1)*
-  %NullCheck = icmp ne i32 addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq i32 addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load i32, i32 addrspace(1)* %1, align 8
@@ -10931,8 +12640,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.UTF8Encoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
@@ -10941,15 +12650,15 @@ entry:
   %9 = load i8, i8* %arg2
   %10 = zext i8 %9 to i32
   %11 = trunc i32 %10 to i8
-  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %8, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %6
   %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %8, i32 0, i32 8
   store i8 %11, i8 addrspace(1)* %13
   %14 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %14, i32 0, i32 8
@@ -10961,8 +12670,8 @@ entry:
 ; <label>:20                                      ; preds = %15
   %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %22, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %22, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = load i64, i64 addrspace(1)* %22
@@ -10984,15 +12693,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %12
+ThrowNullRef4:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11007,8 +12716,8 @@ entry:
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
@@ -11030,16 +12739,16 @@ entry:
 ; <label>:10                                      ; preds = %1
   %11 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
   %12 = load i32, i32* %arg1
-  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %11, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.Encoding addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
   store i32 %12, i32 addrspace(1)* %14
   %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
   %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = load i64, i64 addrspace(1)* %16
@@ -11057,11 +12766,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11074,8 +12783,8 @@ entry:
   %this = alloca %System.Text.UTF8Encoding addrspace(1)*
   store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
   %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.UTF8Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
@@ -11087,16 +12796,16 @@ entry:
 ; <label>:6                                       ; preds = %1
   %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %8 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %10, %System.Text.EncoderFallback addrspace(1)* %8)
   %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %12 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
-  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %11, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %11, i32 0, i32 3
@@ -11109,8 +12818,8 @@ entry:
   %18 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %18, %System.String addrspace(1)* %17)
   %19 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %18 to %System.Text.EncoderFallback addrspace(1)*
-  %NullCheck6 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %16, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %16, i32 0, i32 2
@@ -11120,8 +12829,8 @@ entry:
   %24 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %24, %System.String addrspace(1)* %23)
   %25 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %24 to %System.Text.DecoderFallback addrspace(1)*
-  %NullCheck8 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %22, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %22, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %20
   %27 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %22, i32 0, i32 3
@@ -11132,19 +12841,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %20
+ThrowNullRef8:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11174,8 +12883,8 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load i32, i32* %arg1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -11193,8 +12902,8 @@ entry:
 ; <label>:15                                      ; preds = %8
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %17 = load i32, i32* %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 %17
@@ -11210,7 +12919,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11262,7 +12971,7 @@ entry:
 }
 
 INFO:  jitting method Hashtable::Insert using LLILCJit
-Failed to read Hashtable.Insert[loadElemA]
+Failed to read Hashtable.Insert[storeElem]
 INFO:  jitting method ConsoleEncoding::.ctor using LLILCJit
 Successfully read ConsoleEncoding..ctor
 
@@ -11277,8 +12986,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %1)
   %2 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
@@ -11314,8 +13023,8 @@ entry:
   %2 = call %System.Text.InternalEncoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalEncoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %1)
   %3 = bitcast %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2 to %System.Text.EncoderFallback addrspace(1)*
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
@@ -11325,8 +13034,8 @@ entry:
   %8 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %7)
   %9 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %8 to %System.Text.DecoderFallback addrspace(1)*
-  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %6, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.Encoding addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %4
   %11 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %6, i32 0, i32 3
@@ -11337,7 +13046,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11356,15 +13065,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* %1)
   %2 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   %6 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, i32 0, i32 1
@@ -11375,7 +13084,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11403,8 +13112,8 @@ entry:
   store %System.Text.InternalDecoderBestFitFallback addrspace(1)* %param0, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
   %0 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
@@ -11414,15 +13123,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %4)
   %5 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %6)
   %9 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, i32 0, i32 1
@@ -11433,11 +13142,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11505,8 +13214,8 @@ entry:
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
   %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = load i64, i64 addrspace(1)* %19
@@ -11570,8 +13279,8 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.ConsoleStream addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
@@ -11602,31 +13311,31 @@ entry:
   store i8 %param4, i8* %arg4
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %3, %System.IO.Stream addrspace(1)* %1)
   %4 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %4, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
   %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %4, i32 0, i32 4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %5)
   %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %6
   %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
   %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
   %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = load i64, i64 addrspace(1)* %13
@@ -11638,8 +13347,8 @@ entry:
   %21 = load i64, i64* %20
   %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %8, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %8, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %14
   %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 5
@@ -11657,24 +13366,24 @@ entry:
   %31 = load i32, i32* %arg3
   %32 = sext i32 %31 to i64
   %33 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %32)
-  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %30, null
-  br i1 %NullCheck10, label %34, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.StreamWriter addrspace(1)* %30, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %35, %"System.Char[]" addrspace(1)* %33)
   %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %37, null
-  br i1 %NullCheck12, label %38, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.StreamWriter addrspace(1)* %37, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %38
 
 ; <label>:38                                      ; preds = %34
   %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
   %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
   %41 = load i32, i32* %arg3
   %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %42, null
-  br i1 %NullCheck14, label %43, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %42, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
   %44 = load i64, i64 addrspace(1)* %42
@@ -11688,30 +13397,30 @@ entry:
   %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
   %53 = sext i32 %52 to i64
   %54 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %53)
-  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
-  br i1 %NullCheck16, label %55, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %55
 
 ; <label>:55                                      ; preds = %43
   %56 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %56, %"System.Byte[]" addrspace(1)* %54)
   %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %58 = load i32, i32* %arg3
-  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %57, null
-  br i1 %NullCheck18, label %59, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.StreamWriter addrspace(1)* %57, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %59
 
 ; <label>:59                                      ; preds = %55
   %60 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 10
   store i32 %58, i32 addrspace(1)* %60
   %61 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %61, null
-  br i1 %NullCheck20, label %62, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.IO.StreamWriter addrspace(1)* %61, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %62
 
 ; <label>:62                                      ; preds = %59
   %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
   %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
   %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
   %67 = load i64, i64 addrspace(1)* %65
@@ -11729,15 +13438,15 @@ entry:
 
 ; <label>:78                                      ; preds = %66
   %79 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %79, null
-  br i1 %NullCheck24, label %80, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.StreamWriter addrspace(1)* %79, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %80
 
 ; <label>:80                                      ; preds = %78
   %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
   %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
   %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %83, null
-  br i1 %NullCheck26, label %84, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %83, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
   %85 = load i64, i64 addrspace(1)* %83
@@ -11754,8 +13463,8 @@ entry:
 
 ; <label>:95                                      ; preds = %84
   %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.IO.StreamWriter addrspace(1)* %96, null
-  br i1 %NullCheck28, label %97, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.IO.StreamWriter addrspace(1)* %96, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %97
 
 ; <label>:97                                      ; preds = %95
   %98 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 12
@@ -11769,8 +13478,8 @@ entry:
   %103 = icmp eq i32 %102, 0
   %104 = sext i1 %103 to i32
   %105 = trunc i32 %104 to i8
-  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %100, null
-  br i1 %NullCheck30, label %106, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.IO.StreamWriter addrspace(1)* %100, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %106
 
 ; <label>:106                                     ; preds = %99
   %107 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %100, i32 0, i32 13
@@ -11781,63 +13490,63 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %6
+ThrowNullRef4:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %29
+ThrowNullRef10:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %34
+ThrowNullRef12:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %38
+ThrowNullRef14:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %43
+ThrowNullRef16:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %55
+ThrowNullRef18:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %59
+ThrowNullRef20:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %62
+ThrowNullRef22:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %78
+ThrowNullRef24:                                   ; preds = %78
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %80
+ThrowNullRef26:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %95
+ThrowNullRef28:                                   ; preds = %95
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11850,15 +13559,15 @@ entry:
   %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = load i64, i64 addrspace(1)* %4
@@ -11876,7 +13585,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11926,35 +13635,35 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
   %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderNLS addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %7 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.EncoderNLS addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Text.Encoding addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.Encoding addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Text.EncoderNLS addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.EncoderNLS addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
   %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck8 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = load i64, i64 addrspace(1)* %16
@@ -11973,19 +13682,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12011,8 +13720,8 @@ entry:
   %this = alloca %System.Text.Encoding addrspace(1)*
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
@@ -12032,15 +13741,15 @@ entry:
   %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
   store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
   %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
   store i32 0, i32 addrspace(1)* %2
   %3 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, i32 0, i32 2
@@ -12050,15 +13759,15 @@ entry:
 
 ; <label>:8                                       ; preds = %4
   %9 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
   %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
   %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = load i64, i64 addrspace(1)* %13
@@ -12079,15 +13788,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12102,16 +13811,16 @@ entry:
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = load i32, i32* %arg1
   %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
   %7 = load i64, i64 addrspace(1)* %5
@@ -12129,7 +13838,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12166,8 +13875,8 @@ entry:
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
   %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
   %16 = load i64, i64 addrspace(1)* %14
@@ -12188,8 +13897,8 @@ entry:
   %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
   %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
   %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %31, null
-  br i1 %NullCheck2, label %32, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = load i64, i64 addrspace(1)* %31
@@ -12232,7 +13941,7 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12245,14 +13954,14 @@ entry:
   %this = alloca %System.Text.EncoderReplacementFallback addrspace(1)*
   store %System.Text.EncoderReplacementFallback addrspace(1)* %param0, %System.Text.EncoderReplacementFallback addrspace(1)** %this
   %0 = load %System.Text.EncoderReplacementFallback addrspace(1)*, %System.Text.EncoderReplacementFallback addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -12263,7 +13972,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12293,8 +14002,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
@@ -12326,8 +14035,8 @@ entry:
   %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
   store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
@@ -12339,8 +14048,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Threading.Tasks.Task addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %7)
@@ -12363,7 +14072,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12382,8 +14091,8 @@ entry:
   store i8 %param1, i8* %arg1
   store i8 %param2, i8* %arg2
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
@@ -12397,8 +14106,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1, %5
   %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 9
@@ -12429,8 +14138,8 @@ entry:
 
 ; <label>:25                                      ; preds = %8, %20
   %26 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %26, null
-  br i1 %NullCheck4, label %27, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %26, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %26, i32 0, i32 12
@@ -12441,22 +14150,22 @@ entry:
 
 ; <label>:32                                      ; preds = %27
   %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %33, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.IO.StreamWriter addrspace(1)* %33, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %32
   %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 12
   store i8 1, i8 addrspace(1)* %35
   %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
-  br i1 %NullCheck8, label %37, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
   %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
   %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck10 = icmp ne i64 addrspace(1)* %40, null
-  br i1 %NullCheck10, label %41, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64 addrspace(1)* %40, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i64, i64 addrspace(1)* %40
@@ -12470,8 +14179,8 @@ entry:
   %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
   store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
   %51 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %NullCheck12 = icmp ne %"System.Byte[]" addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Byte[]" addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %41
   %53 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %51, i32 0, i32 1
@@ -12483,16 +14192,16 @@ entry:
 
 ; <label>:58                                      ; preds = %52
   %59 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %59, null
-  br i1 %NullCheck14, label %60, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.IO.StreamWriter addrspace(1)* %59, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %60
 
 ; <label>:60                                      ; preds = %58
   %61 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %59, i32 0, i32 3
   %62 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
   %64 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %NullCheck16 = icmp ne %"System.Byte[]" addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %"System.Byte[]" addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %60
   %66 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %64, i32 0, i32 1
@@ -12500,8 +14209,8 @@ entry:
   %68 = zext i32 %67 to i64
   %69 = trunc i64 %68 to i32
   %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck18, label %71, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
   %72 = load i64, i64 addrspace(1)* %70
@@ -12517,29 +14226,29 @@ entry:
 
 ; <label>:80                                      ; preds = %27, %52, %71
   %81 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %81, null
-  br i1 %NullCheck20, label %82, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.IO.StreamWriter addrspace(1)* %81, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
 
 ; <label>:82                                      ; preds = %80
   %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %81, i32 0, i32 5
   %84 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %83, align 8
   %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.IO.StreamWriter addrspace(1)* %85, null
-  br i1 %NullCheck22, label %86, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.IO.StreamWriter addrspace(1)* %85, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %86
 
 ; <label>:86                                      ; preds = %82
   %87 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 7
   %88 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %87, align 8
   %89 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %89, null
-  br i1 %NullCheck24, label %90, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.StreamWriter addrspace(1)* %89, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %90
 
 ; <label>:90                                      ; preds = %86
   %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %89, i32 0, i32 9
   %92 = load i32, i32 addrspace(1)* %91, align 8
   %93 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.IO.StreamWriter addrspace(1)* %93, null
-  br i1 %NullCheck26, label %94, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.IO.StreamWriter addrspace(1)* %93, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %93, i32 0, i32 6
@@ -12547,8 +14256,8 @@ entry:
   %97 = load i8, i8* %arg2
   %98 = zext i8 %97 to i32
   %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
-  %NullCheck28 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck28, label %100, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
   %101 = load i64, i64 addrspace(1)* %99
@@ -12563,8 +14272,8 @@ entry:
   %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
   store i32 %110, i32* %loc1
   %111 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %111, null
-  br i1 %NullCheck30, label %112, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.IO.StreamWriter addrspace(1)* %111, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %112
 
 ; <label>:112                                     ; preds = %100
   %113 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %111, i32 0, i32 9
@@ -12575,23 +14284,23 @@ entry:
 
 ; <label>:116                                     ; preds = %112
   %117 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck32 = icmp ne %System.IO.StreamWriter addrspace(1)* %117, null
-  br i1 %NullCheck32, label %118, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.IO.StreamWriter addrspace(1)* %117, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %118
 
 ; <label>:118                                     ; preds = %116
   %119 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %117, i32 0, i32 3
   %120 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %119, align 8
   %121 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.IO.StreamWriter addrspace(1)* %121, null
-  br i1 %NullCheck34, label %122, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.IO.StreamWriter addrspace(1)* %121, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %122
 
 ; <label>:122                                     ; preds = %118
   %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
   %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
   %125 = load i32, i32* %loc1
   %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
-  %NullCheck36 = icmp ne i64 addrspace(1)* %126, null
-  br i1 %NullCheck36, label %127, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64 addrspace(1)* %126, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
   %128 = load i64, i64 addrspace(1)* %126
@@ -12613,15 +14322,15 @@ entry:
 
 ; <label>:140                                     ; preds = %136
   %141 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.IO.StreamWriter addrspace(1)* %141, null
-  br i1 %NullCheck38, label %142, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.IO.StreamWriter addrspace(1)* %141, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %142
 
 ; <label>:142                                     ; preds = %140
   %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
   %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
   %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
-  %NullCheck40 = icmp ne i64 addrspace(1)* %145, null
-  br i1 %NullCheck40, label %146, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i64 addrspace(1)* %145, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
   %147 = load i64, i64 addrspace(1)* %145
@@ -12642,83 +14351,83 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %25
+ThrowNullRef4:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %32
+ThrowNullRef6:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %37
+ThrowNullRef10:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %41
+ThrowNullRef12:                                   ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %58
+ThrowNullRef14:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %60
+ThrowNullRef16:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %65
+ThrowNullRef18:                                   ; preds = %65
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %80
+ThrowNullRef20:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %82
+ThrowNullRef22:                                   ; preds = %82
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %86
+ThrowNullRef24:                                   ; preds = %86
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %90
+ThrowNullRef26:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %94
+ThrowNullRef28:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %100
+ThrowNullRef30:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %116
+ThrowNullRef32:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %118
+ThrowNullRef34:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %122
+ThrowNullRef36:                                   ; preds = %122
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %140
+ThrowNullRef38:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %142
+ThrowNullRef40:                                   ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12785,8 +14494,8 @@ entry:
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %1 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
-  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
@@ -12794,8 +14503,8 @@ entry:
   %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
   %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
   %8 = load i64, i64 addrspace(1)* %6
@@ -12811,8 +14520,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %17, %System.IFormatProvider addrspace(1)* %16)
   %18 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %19 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %18, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.SyncTextWriter addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %7
   %21 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %18, i32 0, i32 4
@@ -12823,11 +14532,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12840,8 +14549,8 @@ entry:
   %this = alloca %System.IO.TextWriter addrspace(1)*
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.TextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
@@ -12851,8 +14560,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.Threading.Thread addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Threading.Thread addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %6)
@@ -12861,8 +14570,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1
   %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.TextWriter addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.TextWriter addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %11, i32 0, i32 2
@@ -12873,11 +14582,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13074,8 +14783,8 @@ entry:
   store double %param1, double* %arg1
   store i8 0, i8* %loc1
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
@@ -13085,16 +14794,16 @@ entry:
   %5 = addrspacecast i8* %loc1 to i8 addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %4, i8 addrspace(1)* %5)
   %6 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.SyncTextWriter addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
   %10 = load double, double* %arg1
   %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
   %13 = load i64, i64 addrspace(1)* %11
@@ -13129,11 +14838,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13150,8 +14859,8 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load double, double* %arg1
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -13165,8 +14874,8 @@ entry:
   call void %11(%System.IO.TextWriter addrspace(1)* %0, double %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
   %15 = load i64, i64 addrspace(1)* %13
@@ -13184,7 +14893,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13202,8 +14911,8 @@ entry:
   %1 = addrspacecast double* %arg1 to double addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -13218,8 +14927,8 @@ entry:
   %14 = bitcast double addrspace(1)* %1 to %System.Double addrspace(1)*
   %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Double addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Double addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
   %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
   %18 = load i64, i64 addrspace(1)* %16
@@ -13237,7 +14946,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13253,8 +14962,8 @@ entry:
   store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
   %0 = load %System.Double addrspace(1)*, %System.Double addrspace(1)** %this
   %1 = bitcast %System.Double addrspace(1)* %0 to double addrspace(1)*
-  %NullCheck = icmp ne double addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq double addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load double, double addrspace(1)* %1, align 8
@@ -13279,8 +14988,8 @@ entry:
   %loc0 = alloca %System.Globalization.NumberFormatInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 3
@@ -13290,8 +14999,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
@@ -13301,24 +15010,24 @@ entry:
   store %System.Globalization.NumberFormatInfo addrspace(1)* %10, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
   %11 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %7
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
   %15 = load i8, i8 addrspace(1)* %14, align 8
   %16 = zext i8 %15 to i32
   %17 = trunc i32 %16 to i8
-  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %11, null
-  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %11, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %13
   %19 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %11, i32 0, i32 29
   store i8 %17, i8 addrspace(1)* %19
   %20 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %21 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %20, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %20, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %18
   %23 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %20, i32 0, i32 3
@@ -13327,8 +15036,8 @@ entry:
 
 ; <label>:24                                      ; preds = %1, %22
   %25 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %25, null
-  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %25, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %26
 
 ; <label>:26                                      ; preds = %24
   %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %25, i32 0, i32 3
@@ -13339,23 +15048,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %18
+ThrowNullRef8:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13380,168 +15089,168 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 18
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %8, align 8
-  %NullCheck2 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %5, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %5, i32 0, i32 4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %9)
   %12 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 19
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %15, align 8
-  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %12, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %12, i32 0, i32 5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %16)
   %19 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %20 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %20, null
-  br i1 %NullCheck8, label %21, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %20, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %20, i32 0, i32 23
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  %NullCheck10 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %19, null
-  br i1 %NullCheck10, label %24, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %19, i32 0, i32 7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %25, %System.String addrspace(1)* %23)
   %26 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %27 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %27, i32 0, i32 22
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %29, align 8
-  %NullCheck14 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %26, null
-  br i1 %NullCheck14, label %31, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %26, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %26, i32 0, i32 6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %32, %System.String addrspace(1)* %30)
   %33 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %34 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Globalization.CultureData addrspace(1)* %34, null
-  br i1 %NullCheck16, label %35, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Globalization.CultureData addrspace(1)* %34, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %34, i32 0, i32 51
   %37 = load i32, i32 addrspace(1)* %36, align 8
-  %NullCheck18 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %33, null
-  br i1 %NullCheck18, label %38, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %33, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %33, i32 0, i32 21
   store i32 %37, i32 addrspace(1)* %39
   %40 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %41 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Globalization.CultureData addrspace(1)* %41, null
-  br i1 %NullCheck20, label %42, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Globalization.CultureData addrspace(1)* %41, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %41, i32 0, i32 52
   %44 = load i32, i32 addrspace(1)* %43, align 8
-  %NullCheck22 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %40, null
-  br i1 %NullCheck22, label %45, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %40, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %40, i32 0, i32 25
   store i32 %44, i32 addrspace(1)* %46
   %47 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %48 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.Globalization.CultureData addrspace(1)* %48, null
-  br i1 %NullCheck24, label %49, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Globalization.CultureData addrspace(1)* %48, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %49
 
 ; <label>:49                                      ; preds = %45
   %50 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %48, i32 0, i32 29
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck26 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %47, null
-  br i1 %NullCheck26, label %52, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %47, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %47, i32 0, i32 10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %53, %System.String addrspace(1)* %51)
   %54 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %55 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Globalization.CultureData addrspace(1)* %55, null
-  br i1 %NullCheck28, label %56, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Globalization.CultureData addrspace(1)* %55, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %56
 
 ; <label>:56                                      ; preds = %52
   %57 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %55, i32 0, i32 35
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %57, align 8
-  %NullCheck30 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %54, null
-  br i1 %NullCheck30, label %59, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %54, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %54, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %60, %System.String addrspace(1)* %58)
   %61 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %62 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck32 = icmp ne %System.Globalization.CultureData addrspace(1)* %62, null
-  br i1 %NullCheck32, label %63, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Globalization.CultureData addrspace(1)* %62, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %62, i32 0, i32 34
   %65 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %64, align 8
-  %NullCheck34 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %61, null
-  br i1 %NullCheck34, label %66, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %61, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %61, i32 0, i32 9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %67, %System.String addrspace(1)* %65)
   %68 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %69 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck36 = icmp ne %System.Globalization.CultureData addrspace(1)* %69, null
-  br i1 %NullCheck36, label %70, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Globalization.CultureData addrspace(1)* %69, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %70
 
 ; <label>:70                                      ; preds = %66
   %71 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %69, i32 0, i32 55
   %72 = load i32, i32 addrspace(1)* %71, align 8
-  %NullCheck38 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %68, null
-  br i1 %NullCheck38, label %73, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %68, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %68, i32 0, i32 22
   store i32 %72, i32 addrspace(1)* %74
   %75 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %76 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck40 = icmp ne %System.Globalization.CultureData addrspace(1)* %76, null
-  br i1 %NullCheck40, label %77, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Globalization.CultureData addrspace(1)* %76, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %76, i32 0, i32 57
   %79 = load i32, i32 addrspace(1)* %78, align 8
-  %NullCheck42 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %75, null
-  br i1 %NullCheck42, label %80, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %75, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %80
 
 ; <label>:80                                      ; preds = %77
   %81 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %75, i32 0, i32 24
   store i32 %79, i32 addrspace(1)* %81
   %82 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %83 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck44 = icmp ne %System.Globalization.CultureData addrspace(1)* %83, null
-  br i1 %NullCheck44, label %84, label %ThrowNullRef43
+  %NullCheck43 = icmp eq %System.Globalization.CultureData addrspace(1)* %83, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %84
 
 ; <label>:84                                      ; preds = %80
   %85 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %83, i32 0, i32 56
   %86 = load i32, i32 addrspace(1)* %85, align 8
-  %NullCheck46 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %82, null
-  br i1 %NullCheck46, label %87, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %82, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %82, i32 0, i32 23
@@ -13550,8 +15259,8 @@ entry:
 
 ; <label>:89                                      ; preds = %entry
   %90 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck100 = icmp ne %System.Globalization.CultureData addrspace(1)* %90, null
-  br i1 %NullCheck100, label %91, label %ThrowNullRef99
+  %NullCheck99 = icmp eq %System.Globalization.CultureData addrspace(1)* %90, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %91
 
 ; <label>:91                                      ; preds = %89
   %92 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %90, i32 0, i32 2
@@ -13569,8 +15278,8 @@ entry:
   %102 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %103 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %104 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %103)
-  %NullCheck48 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %102, null
-  br i1 %NullCheck48, label %105, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %102, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %105
 
 ; <label>:105                                     ; preds = %101
   %106 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %102, i32 0, i32 1
@@ -13578,8 +15287,8 @@ entry:
   %107 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %108 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %109 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %108)
-  %NullCheck50 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %107, null
-  br i1 %NullCheck50, label %110, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %107, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %110
 
 ; <label>:110                                     ; preds = %105
   %111 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %107, i32 0, i32 2
@@ -13587,8 +15296,8 @@ entry:
   %112 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %113 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %114 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %113)
-  %NullCheck52 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %112, null
-  br i1 %NullCheck52, label %115, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %112, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %115
 
 ; <label>:115                                     ; preds = %110
   %116 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %112, i32 0, i32 27
@@ -13596,8 +15305,8 @@ entry:
   %117 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %118 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %119 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %118)
-  %NullCheck54 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %117, null
-  br i1 %NullCheck54, label %120, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %117, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %120
 
 ; <label>:120                                     ; preds = %115
   %121 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %117, i32 0, i32 26
@@ -13605,8 +15314,8 @@ entry:
   %122 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %123 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %124 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %123)
-  %NullCheck56 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %122, null
-  br i1 %NullCheck56, label %125, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %122, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %125
 
 ; <label>:125                                     ; preds = %120
   %126 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %122, i32 0, i32 17
@@ -13614,8 +15323,8 @@ entry:
   %127 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %128 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %129 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %128)
-  %NullCheck58 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %127, null
-  br i1 %NullCheck58, label %130, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %127, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %130
 
 ; <label>:130                                     ; preds = %125
   %131 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %127, i32 0, i32 18
@@ -13623,8 +15332,8 @@ entry:
   %132 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %133 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %134 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %133)
-  %NullCheck60 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %132, null
-  br i1 %NullCheck60, label %135, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %132, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %135
 
 ; <label>:135                                     ; preds = %130
   %136 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %132, i32 0, i32 14
@@ -13632,8 +15341,8 @@ entry:
   %137 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %138 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %139 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %138)
-  %NullCheck62 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %137, null
-  br i1 %NullCheck62, label %140, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %137, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %140
 
 ; <label>:140                                     ; preds = %135
   %141 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %137, i32 0, i32 13
@@ -13641,71 +15350,71 @@ entry:
   %142 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %143 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %144 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %143)
-  %NullCheck64 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %142, null
-  br i1 %NullCheck64, label %145, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %142, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %145
 
 ; <label>:145                                     ; preds = %140
   %146 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %142, i32 0, i32 12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %146, %System.String addrspace(1)* %144)
   %147 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %148 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck66 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %148, null
-  br i1 %NullCheck66, label %149, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %148, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %149
 
 ; <label>:149                                     ; preds = %145
   %150 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %148, i32 0, i32 21
   %151 = load i32, i32 addrspace(1)* %150, align 8
-  %NullCheck68 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %147, null
-  br i1 %NullCheck68, label %152, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %147, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %152
 
 ; <label>:152                                     ; preds = %149
   %153 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %147, i32 0, i32 28
   store i32 %151, i32 addrspace(1)* %153
   %154 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %155 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck70 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %155, null
-  br i1 %NullCheck70, label %156, label %ThrowNullRef69
+  %NullCheck69 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %155, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %156
 
 ; <label>:156                                     ; preds = %152
   %157 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %155, i32 0, i32 6
   %158 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %157, align 8
-  %NullCheck72 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %154, null
-  br i1 %NullCheck72, label %159, label %ThrowNullRef71
+  %NullCheck71 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %154, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %159
 
 ; <label>:159                                     ; preds = %156
   %160 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %154, i32 0, i32 15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %160, %System.String addrspace(1)* %158)
   %161 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %162 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck74 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %162, null
-  br i1 %NullCheck74, label %163, label %ThrowNullRef73
+  %NullCheck73 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %162, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %163
 
 ; <label>:163                                     ; preds = %159
   %164 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %162, i32 0, i32 1
   %165 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %164, align 8
-  %NullCheck76 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %161, null
-  br i1 %NullCheck76, label %166, label %ThrowNullRef75
+  %NullCheck75 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %161, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %166
 
 ; <label>:166                                     ; preds = %163
   %167 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %161, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %167, %"System.Int32[]" addrspace(1)* %165)
   %168 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %169 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck78 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %169, null
-  br i1 %NullCheck78, label %170, label %ThrowNullRef77
+  %NullCheck77 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %169, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %170
 
 ; <label>:170                                     ; preds = %166
   %171 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %169, i32 0, i32 7
   %172 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %171, align 8
-  %NullCheck80 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %168, null
-  br i1 %NullCheck80, label %173, label %ThrowNullRef79
+  %NullCheck79 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %168, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %173
 
 ; <label>:173                                     ; preds = %170
   %174 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %168, i32 0, i32 16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %174, %System.String addrspace(1)* %172)
   %175 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck82 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %175, null
-  br i1 %NullCheck82, label %176, label %ThrowNullRef81
+  %NullCheck81 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %175, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %176
 
 ; <label>:176                                     ; preds = %173
   %177 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %175, i32 0, i32 4
@@ -13715,14 +15424,14 @@ entry:
 
 ; <label>:180                                     ; preds = %176
   %181 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck84 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %181, null
-  br i1 %NullCheck84, label %182, label %ThrowNullRef83
+  %NullCheck83 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %181, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %182
 
 ; <label>:182                                     ; preds = %180
   %183 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %181, i32 0, i32 4
   %184 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %183, align 8
-  %NullCheck86 = icmp ne %System.String addrspace(1)* %184, null
-  br i1 %NullCheck86, label %185, label %ThrowNullRef85
+  %NullCheck85 = icmp eq %System.String addrspace(1)* %184, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %185
 
 ; <label>:185                                     ; preds = %182
   %186 = getelementptr inbounds %System.String, %System.String addrspace(1)* %184, i32 0, i32 1
@@ -13733,8 +15442,8 @@ entry:
 ; <label>:189                                     ; preds = %176, %185
   %190 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck98 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %190, null
-  br i1 %NullCheck98, label %192, label %ThrowNullRef97
+  %NullCheck97 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %190, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %192
 
 ; <label>:192                                     ; preds = %189
   %193 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %190, i32 0, i32 4
@@ -13743,8 +15452,8 @@ entry:
 
 ; <label>:194                                     ; preds = %185, %192
   %195 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck88 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %195, null
-  br i1 %NullCheck88, label %196, label %ThrowNullRef87
+  %NullCheck87 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %195, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %196
 
 ; <label>:196                                     ; preds = %194
   %197 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %195, i32 0, i32 9
@@ -13754,14 +15463,14 @@ entry:
 
 ; <label>:200                                     ; preds = %196
   %201 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck90 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %201, null
-  br i1 %NullCheck90, label %202, label %ThrowNullRef89
+  %NullCheck89 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %201, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %202
 
 ; <label>:202                                     ; preds = %200
   %203 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %201, i32 0, i32 9
   %204 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %203, align 8
-  %NullCheck92 = icmp ne %System.String addrspace(1)* %204, null
-  br i1 %NullCheck92, label %205, label %ThrowNullRef91
+  %NullCheck91 = icmp eq %System.String addrspace(1)* %204, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %205
 
 ; <label>:205                                     ; preds = %202
   %206 = getelementptr inbounds %System.String, %System.String addrspace(1)* %204, i32 0, i32 1
@@ -13772,14 +15481,14 @@ entry:
 ; <label>:209                                     ; preds = %196, %205
   %210 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %211 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck94 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %211, null
-  br i1 %NullCheck94, label %212, label %ThrowNullRef93
+  %NullCheck93 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %211, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %212
 
 ; <label>:212                                     ; preds = %209
   %213 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %211, i32 0, i32 6
   %214 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %213, align 8
-  %NullCheck96 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %210, null
-  br i1 %NullCheck96, label %215, label %ThrowNullRef95
+  %NullCheck95 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %210, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %215
 
 ; <label>:215                                     ; preds = %212
   %216 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %210, i32 0, i32 9
@@ -13793,203 +15502,203 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %17
+ThrowNullRef8:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %21
+ThrowNullRef10:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %24
+ThrowNullRef12:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %28
+ThrowNullRef14:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %31
+ThrowNullRef16:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %35
+ThrowNullRef18:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %38
+ThrowNullRef20:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %42
+ThrowNullRef22:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %45
+ThrowNullRef24:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %49
+ThrowNullRef26:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %52
+ThrowNullRef28:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %56
+ThrowNullRef30:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %59
+ThrowNullRef32:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %63
+ThrowNullRef34:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %66
+ThrowNullRef36:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %70
+ThrowNullRef38:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %73
+ThrowNullRef40:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %77
+ThrowNullRef42:                                   ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %80
+ThrowNullRef44:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %84
+ThrowNullRef46:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %101
+ThrowNullRef48:                                   ; preds = %101
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %105
+ThrowNullRef50:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %110
+ThrowNullRef52:                                   ; preds = %110
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %115
+ThrowNullRef54:                                   ; preds = %115
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %120
+ThrowNullRef56:                                   ; preds = %120
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %125
+ThrowNullRef58:                                   ; preds = %125
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %130
+ThrowNullRef60:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %135
+ThrowNullRef62:                                   ; preds = %135
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %140
+ThrowNullRef64:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %145
+ThrowNullRef66:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %149
+ThrowNullRef68:                                   ; preds = %149
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %152
+ThrowNullRef70:                                   ; preds = %152
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %156
+ThrowNullRef72:                                   ; preds = %156
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %159
+ThrowNullRef74:                                   ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %163
+ThrowNullRef76:                                   ; preds = %163
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %166
+ThrowNullRef78:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %170
+ThrowNullRef80:                                   ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %173
+ThrowNullRef82:                                   ; preds = %173
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %180
+ThrowNullRef84:                                   ; preds = %180
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %182
+ThrowNullRef86:                                   ; preds = %182
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %194
+ThrowNullRef88:                                   ; preds = %194
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %200
+ThrowNullRef90:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %202
+ThrowNullRef92:                                   ; preds = %202
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %209
+ThrowNullRef94:                                   ; preds = %209
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %212
+ThrowNullRef96:                                   ; preds = %212
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %189
+ThrowNullRef98:                                   ; preds = %189
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %89
+ThrowNullRef100:                                  ; preds = %89
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14017,8 +15726,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 21
@@ -14031,8 +15740,8 @@ entry:
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 16)
   %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 21
@@ -14041,8 +15750,8 @@ entry:
 
 ; <label>:12                                      ; preds = %1, %10
   %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 21
@@ -14053,11 +15762,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %12
+ThrowNullRef4:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14073,8 +15782,8 @@ entry:
   store i32 %param1, i32* %arg1
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %1 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
@@ -14141,8 +15850,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 33
@@ -14155,8 +15864,8 @@ entry:
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 24)
   %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 33
@@ -14165,8 +15874,8 @@ entry:
 
 ; <label>:12                                      ; preds = %1, %10
   %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 33
@@ -14177,11 +15886,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %12
+ThrowNullRef4:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14194,8 +15903,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 53
@@ -14207,8 +15916,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 116)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 53
@@ -14217,8 +15926,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 53
@@ -14229,11 +15938,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14262,8 +15971,8 @@ entry:
 
 ; <label>:7                                       ; preds = %entry, %4
   %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %7
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 2
@@ -14287,8 +15996,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 54
@@ -14300,8 +16009,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 117)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
@@ -14310,8 +16019,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 54
@@ -14322,11 +16031,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14339,8 +16048,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 27
@@ -14352,8 +16061,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 118)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 27
@@ -14362,8 +16071,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 27
@@ -14374,11 +16083,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14391,8 +16100,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 28
@@ -14404,8 +16113,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 119)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 28
@@ -14414,8 +16123,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 28
@@ -14426,11 +16135,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14443,8 +16152,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 26
@@ -14456,8 +16165,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 107)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 26
@@ -14466,8 +16175,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 26
@@ -14478,11 +16187,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14495,8 +16204,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 25
@@ -14508,8 +16217,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 106)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 25
@@ -14518,8 +16227,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 25
@@ -14530,11 +16239,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14547,8 +16256,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 24
@@ -14560,8 +16269,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 105)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 24
@@ -14570,8 +16279,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 24
@@ -14582,11 +16291,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14611,8 +16320,8 @@ entry:
   %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %3)
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %2
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -14623,15 +16332,15 @@ entry:
 
 ; <label>:8                                       ; preds = %62
   %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 9
   %12 = load i32, i32 addrspace(1)* %11, align 8
   %13 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.IO.StreamWriter addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %13, i32 0, i32 10
@@ -14646,15 +16355,15 @@ entry:
 
 ; <label>:20                                      ; preds = %14, %18
   %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
   %24 = load i32, i32 addrspace(1)* %23, align 8
   %25 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %25, null
-  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.StreamWriter addrspace(1)* %25, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %25, i32 0, i32 9
@@ -14675,36 +16384,36 @@ entry:
   %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %37 = load i32, i32* %loc1
   %38 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.StreamWriter addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %35
   %40 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %38, i32 0, i32 7
   %41 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %40, align 8
   %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
-  br i1 %NullCheck14, label %43, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %39
   %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 9
   %45 = load i32, i32 addrspace(1)* %44, align 8
   %46 = load i32, i32* %loc2
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %36, null
-  br i1 %NullCheck16, label %47, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %36, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %47
 
 ; <label>:47                                      ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %36, i32 %37, %"System.Char[]" addrspace(1)* %41, i32 %45, i32 %46)
   %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
   %51 = load i32, i32 addrspace(1)* %50, align 8
   %52 = load i32, i32* %loc2
   %53 = add i32 %51, %52
-  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
-  br i1 %NullCheck20, label %54, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %54
 
 ; <label>:54                                      ; preds = %49
   %55 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
@@ -14726,8 +16435,8 @@ entry:
 
 ; <label>:65                                      ; preds = %62
   %66 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %66, null
-  br i1 %NullCheck2, label %67, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %66, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %67
 
 ; <label>:67                                      ; preds = %65
   %68 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %66, i32 0, i32 11
@@ -14748,49 +16457,259 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %65
+ThrowNullRef2:                                    ; preds = %65
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %20
+ThrowNullRef8:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %22
+ThrowNullRef10:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %35
+ThrowNullRef12:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %43
+ThrowNullRef16:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %47
+ThrowNullRef18:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method String::CopyTo using LLILCJit
-Failed to read String.CopyTo[loadElemA]
+Successfully read String.CopyTo
+
+define void @String.CopyTo(%System.String addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  %loc1 = alloca i16 addrspace(1)*
+  %loc2 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %1 = icmp ne %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg4
+  %7 = icmp sge i32 %6, 0
+  br i1 %7, label %13, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  unreachable
+
+; <label>:13                                      ; preds = %5
+  %14 = load i32, i32* %arg1
+  %15 = icmp sge i32 %14, 0
+  br i1 %15, label %21, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %18)
+  %20 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %20, %System.String addrspace(1)* %17, %System.String addrspace(1)* %19)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %20) #0
+  unreachable
+
+; <label>:21                                      ; preds = %13
+  %22 = load i32, i32* %arg4
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck, label %ThrowNullRef, label %24
+
+; <label>:24                                      ; preds = %21
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load i32, i32* %arg1
+  %28 = sub i32 %26, %27
+  %29 = icmp sle i32 %22, %28
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34, %System.String addrspace(1)* %31, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %24
+  %36 = load i32, i32* %arg3
+  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %37, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
+
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
+  %40 = load i32, i32 addrspace(1)* %39
+  %41 = zext i32 %40 to i64
+  %42 = trunc i64 %41 to i32
+  %43 = load i32, i32* %arg4
+  %44 = sub i32 %42, %43
+  %45 = icmp sgt i32 %36, %44
+  br i1 %45, label %49, label %46
+
+; <label>:46                                      ; preds = %38
+  %47 = load i32, i32* %arg3
+  %48 = icmp sge i32 %47, 0
+  br i1 %48, label %54, label %49
+
+; <label>:49                                      ; preds = %38, %46
+  %50 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %52 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %51)
+  %53 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53, %System.String addrspace(1)* %50, %System.String addrspace(1)* %52)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53) #0
+  unreachable
+
+; <label>:54                                      ; preds = %46
+  %55 = load i32, i32* %arg4
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %97, label %57
+
+; <label>:57                                      ; preds = %54
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %59
+
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 2
+  %61 = bitcast [0 x i16] addrspace(1)* %60 to i16 addrspace(1)*
+  store i16 addrspace(1)* %61, i16 addrspace(1)** %loc0
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  store %"System.Char[]" addrspace(1)* %62, %"System.Char[]" addrspace(1)** %loc2
+  %63 = icmp eq %"System.Char[]" addrspace(1)* %62, null
+  br i1 %63, label %72, label %64
+
+; <label>:64                                      ; preds = %59
+  %65 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc2
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %65, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %66
+
+; <label>:66                                      ; preds = %64
+  %67 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %65, i32 0, i32 1
+  %68 = load i32, i32 addrspace(1)* %67
+  %69 = zext i32 %68 to i64
+  %70 = trunc i64 %69 to i32
+  %71 = icmp ne i32 %70, 0
+  br i1 %71, label %73, label %72
+
+; <label>:72                                      ; preds = %59, %66
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  br label %81
+
+; <label>:73                                      ; preds = %66
+  %74 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc2
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %74, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %75
+
+; <label>:75                                      ; preds = %73
+  %76 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %74, i32 0, i32 1
+  %77 = load i32, i32 addrspace(1)* %76
+  %78 = zext i32 %77 to i64
+  %BoundsCheck = icmp uge i64 0, %78
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %79
+
+; <label>:79                                      ; preds = %75
+  %80 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %74, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %80, i16 addrspace(1)** %loc1
+  br label %81
+
+; <label>:81                                      ; preds = %72, %79
+  %82 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %83 = ptrtoint i16 addrspace(1)* %82 to i64
+  %84 = load i32, i32* %arg3
+  %85 = sext i32 %84 to i64
+  %86 = mul i64 %85, 2
+  %87 = add i64 %83, %86
+  %88 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %89 = ptrtoint i16 addrspace(1)* %88 to i64
+  %90 = load i32, i32* %arg1
+  %91 = sext i32 %90 to i64
+  %92 = mul i64 %91, 2
+  %93 = add i64 %89, %92
+  %94 = load i32, i32* %arg4
+  %95 = inttoptr i64 %87 to i16*
+  %96 = inttoptr i64 %93 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %95, i16* %96, i32 %94)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  br label %97
+
+; <label>:97                                      ; preds = %54, %81
+  ret void
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
 Successfully read ConsoleEncoding.GetPreamble
 
@@ -14827,7 +16746,365 @@ entry:
 }
 
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[loadElemA]
+Successfully read EncoderNLS.GetBytes
+
+define i32 @EncoderNLS.GetBytes(%System.Text.EncoderNLS addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3, %"System.Byte[]" addrspace(1)* %param4, i32 %param5, i8 %param6) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %arg4 = alloca %"System.Byte[]" addrspace(1)*
+  %arg5 = alloca i32
+  %arg6 = alloca i8
+  %loc0 = alloca i32
+  %loc1 = alloca i16 addrspace(1)*
+  %loc2 = alloca i8 addrspace(1)*
+  %loc3 = alloca i32
+  %loc4 = alloca %"System.Char[]" addrspace(1)*
+  %loc5 = alloca %"System.Byte[]" addrspace(1)*
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  store %"System.Byte[]" addrspace(1)* %param4, %"System.Byte[]" addrspace(1)** %arg4
+  store i32 %param5, i32* %arg5
+  store i8 %param6, i8* %arg6
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %1 = icmp eq %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %17, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %7 = icmp eq %"System.Char[]" addrspace(1)* %6, null
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %12
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %12
+
+; <label>:12                                      ; preds = %8, %10
+  %13 = phi %System.String addrspace(1)* [ %9, %8 ], [ %11, %10 ]
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %14)
+  %16 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16, %System.String addrspace(1)* %13, %System.String addrspace(1)* %15)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16) #0
+  unreachable
+
+; <label>:17                                      ; preds = %2
+  %18 = load i32, i32* %arg2
+  %19 = icmp slt i32 %18, 0
+  br i1 %19, label %23, label %20
+
+; <label>:20                                      ; preds = %17
+  %21 = load i32, i32* %arg3
+  %22 = icmp sge i32 %21, 0
+  br i1 %22, label %35, label %23
+
+; <label>:23                                      ; preds = %17, %20
+  %24 = load i32, i32* %arg2
+  %25 = icmp slt i32 %24, 0
+  br i1 %25, label %28, label %26
+
+; <label>:26                                      ; preds = %23
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %30
+
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %30
+
+; <label>:30                                      ; preds = %26, %28
+  %31 = phi %System.String addrspace(1)* [ %27, %26 ], [ %29, %28 ]
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34, %System.String addrspace(1)* %31, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %20
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck, label %ThrowNullRef, label %37
+
+; <label>:37                                      ; preds = %35
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = load i32, i32* %arg2
+  %43 = sub i32 %41, %42
+  %44 = load i32, i32* %arg3
+  %45 = icmp sge i32 %43, %44
+  br i1 %45, label %51, label %46
+
+; <label>:46                                      ; preds = %37
+  %47 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %48 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %49 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %48)
+  %50 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %50, %System.String addrspace(1)* %47, %System.String addrspace(1)* %49)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %50) #0
+  unreachable
+
+; <label>:51                                      ; preds = %37
+  %52 = load i32, i32* %arg5
+  %53 = icmp slt i32 %52, 0
+  br i1 %53, label %63, label %54
+
+; <label>:54                                      ; preds = %51
+  %55 = load i32, i32* %arg5
+  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck1 = icmp eq %"System.Byte[]" addrspace(1)* %56, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %57
+
+; <label>:57                                      ; preds = %54
+  %58 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = zext i32 %59 to i64
+  %61 = trunc i64 %60 to i32
+  %62 = icmp sle i32 %55, %61
+  br i1 %62, label %68, label %63
+
+; <label>:63                                      ; preds = %51, %57
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %66 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %65)
+  %67 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %67, %System.String addrspace(1)* %64, %System.String addrspace(1)* %66)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %67) #0
+  unreachable
+
+; <label>:68                                      ; preds = %57
+  %69 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %69, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %69, i32 0, i32 1
+  %72 = load i32, i32 addrspace(1)* %71
+  %73 = zext i32 %72 to i64
+  %74 = trunc i64 %73 to i32
+  %75 = icmp ne i32 %74, 0
+  br i1 %75, label %78, label %76
+
+; <label>:76                                      ; preds = %70
+  %77 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1)
+  store %"System.Char[]" addrspace(1)* %77, %"System.Char[]" addrspace(1)** %arg1
+  br label %78
+
+; <label>:78                                      ; preds = %70, %76
+  %79 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck5 = icmp eq %"System.Byte[]" addrspace(1)* %79, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %80
+
+; <label>:80                                      ; preds = %78
+  %81 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %79, i32 0, i32 1
+  %82 = load i32, i32 addrspace(1)* %81
+  %83 = zext i32 %82 to i64
+  %84 = trunc i64 %83 to i32
+  %85 = load i32, i32* %arg5
+  %86 = sub i32 %84, %85
+  store i32 %86, i32* %loc0
+  %87 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck7 = icmp eq %"System.Byte[]" addrspace(1)* %87, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %88
+
+; <label>:88                                      ; preds = %80
+  %89 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %87, i32 0, i32 1
+  %90 = load i32, i32 addrspace(1)* %89
+  %91 = zext i32 %90 to i64
+  %92 = trunc i64 %91 to i32
+  %93 = icmp ne i32 %92, 0
+  br i1 %93, label %96, label %94
+
+; <label>:94                                      ; preds = %88
+  %95 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1)
+  store %"System.Byte[]" addrspace(1)* %95, %"System.Byte[]" addrspace(1)** %arg4
+  br label %96
+
+; <label>:96                                      ; preds = %88, %94
+  %97 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  store %"System.Char[]" addrspace(1)* %97, %"System.Char[]" addrspace(1)** %loc4
+  %98 = icmp eq %"System.Char[]" addrspace(1)* %97, null
+  br i1 %98, label %107, label %99
+
+; <label>:99                                      ; preds = %96
+  %100 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc4
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %100, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %101
+
+; <label>:101                                     ; preds = %99
+  %102 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %100, i32 0, i32 1
+  %103 = load i32, i32 addrspace(1)* %102
+  %104 = zext i32 %103 to i64
+  %105 = trunc i64 %104 to i32
+  %106 = icmp ne i32 %105, 0
+  br i1 %106, label %108, label %107
+
+; <label>:107                                     ; preds = %96, %101
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  br label %116
+
+; <label>:108                                     ; preds = %101
+  %109 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc4
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %109, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %110
+
+; <label>:110                                     ; preds = %108
+  %111 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %109, i32 0, i32 1
+  %112 = load i32, i32 addrspace(1)* %111
+  %113 = zext i32 %112 to i64
+  %BoundsCheck = icmp uge i64 0, %113
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %114
+
+; <label>:114                                     ; preds = %110
+  %115 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %109, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %115, i16 addrspace(1)** %loc1
+  br label %116
+
+; <label>:116                                     ; preds = %107, %114
+  %117 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  store %"System.Byte[]" addrspace(1)* %117, %"System.Byte[]" addrspace(1)** %loc5
+  %118 = icmp eq %"System.Byte[]" addrspace(1)* %117, null
+  br i1 %118, label %127, label %119
+
+; <label>:119                                     ; preds = %116
+  %120 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc5
+  %NullCheck13 = icmp eq %"System.Byte[]" addrspace(1)* %120, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %121
+
+; <label>:121                                     ; preds = %119
+  %122 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %120, i32 0, i32 1
+  %123 = load i32, i32 addrspace(1)* %122
+  %124 = zext i32 %123 to i64
+  %125 = trunc i64 %124 to i32
+  %126 = icmp ne i32 %125, 0
+  br i1 %126, label %128, label %127
+
+; <label>:127                                     ; preds = %116, %121
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc2
+  br label %136
+
+; <label>:128                                     ; preds = %121
+  %129 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc5
+  %NullCheck15 = icmp eq %"System.Byte[]" addrspace(1)* %129, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %130
+
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %129, i32 0, i32 1
+  %132 = load i32, i32 addrspace(1)* %131
+  %133 = zext i32 %132 to i64
+  %BoundsCheck17 = icmp uge i64 0, %133
+  br i1 %BoundsCheck17, label %ThrowIndexOutOfRange18, label %134
+
+; <label>:134                                     ; preds = %130
+  %135 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %129, i32 0, i32 3, i32 0
+  store i8 addrspace(1)* %135, i8 addrspace(1)** %loc2
+  br label %136
+
+; <label>:136                                     ; preds = %127, %134
+  %137 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %138 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %139 = ptrtoint i16 addrspace(1)* %138 to i64
+  %140 = load i32, i32* %arg2
+  %141 = sext i32 %140 to i64
+  %142 = mul i64 %141, 2
+  %143 = add i64 %139, %142
+  %144 = load i32, i32* %arg3
+  %145 = load i8 addrspace(1)*, i8 addrspace(1)** %loc2
+  %146 = ptrtoint i8 addrspace(1)* %145 to i64
+  %147 = load i32, i32* %arg5
+  %148 = sext i32 %147 to i64
+  %149 = add i64 %146, %148
+  %150 = load i32, i32* %loc0
+  %151 = load i8, i8* %arg6
+  %152 = zext i8 %151 to i32
+  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i64 addrspace(1)*
+  %NullCheck19 = icmp eq i64 addrspace(1)* %153, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %154
+
+; <label>:154                                     ; preds = %136
+  %155 = load i64, i64 addrspace(1)* %153
+  %156 = add i64 %155, 72
+  %157 = inttoptr i64 %156 to i64*
+  %158 = load i64, i64* %157
+  %159 = add i64 %158, 0
+  %160 = inttoptr i64 %159 to i64*
+  %161 = load i64, i64* %160
+  %162 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to %System.Text.Encoder addrspace(1)*
+  %163 = inttoptr i64 %143 to i16*
+  %164 = inttoptr i64 %149 to i8*
+  %165 = trunc i32 %152 to i8
+  %166 = inttoptr i64 %161 to i32 (%System.Text.Encoder addrspace(1)*, i16*, i32, i8*, i32, i8)*
+  %167 = call i32 %166(%System.Text.Encoder addrspace(1)* %162, i16* %163, i32 %144, i8* %164, i32 %150, i8 %165)
+  store i32 %167, i32* %loc3
+  br label %168
+
+; <label>:168                                     ; preds = %154
+  %169 = load i32, i32* %loc3
+  ret i32 %169
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %110
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %119
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange18:                           ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
 Successfully read EncoderNLS.GetBytes
 
@@ -14916,22 +17193,22 @@ entry:
   %40 = load i8, i8* %arg5
   %41 = zext i8 %40 to i32
   %42 = trunc i32 %41 to i8
-  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %39, null
-  br i1 %NullCheck, label %43, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderNLS addrspace(1)* %39, null
+  br i1 %NullCheck, label %ThrowNullRef, label %43
 
 ; <label>:43                                      ; preds = %38
   %44 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
   store i8 %42, i8 addrspace(1)* %44
   %45 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %45, null
-  br i1 %NullCheck2, label %46, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.EncoderNLS addrspace(1)* %45, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %46
 
 ; <label>:46                                      ; preds = %43
   %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %45, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %47
   %48 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.EncoderNLS addrspace(1)* %48, null
-  br i1 %NullCheck4, label %49, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.EncoderNLS addrspace(1)* %48, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %49
 
 ; <label>:49                                      ; preds = %46
   %50 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %48, i32 0, i32 3
@@ -14942,8 +17219,8 @@ entry:
   %55 = load i32, i32* %arg4
   %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck6, label %58, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
   %59 = load i64, i64 addrspace(1)* %57
@@ -14961,15 +17238,15 @@ ThrowNullRef:                                     ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %43
+ThrowNullRef2:                                    ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %46
+ThrowNullRef4:                                    ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %49
+ThrowNullRef6:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14997,8 +17274,8 @@ entry:
   %4 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0 to %System.IO.ConsoleStream addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*)(%System.IO.ConsoleStream addrspace(1)* %4, %"System.Byte[]" addrspace(1)* %1, i32 %2, i32 %3)
   %5 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
@@ -15083,8 +17360,8 @@ entry:
 
 ; <label>:22                                      ; preds = %8
   %23 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %23, null
-  br i1 %NullCheck, label %24, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Byte[]" addrspace(1)* %23, null
+  br i1 %NullCheck, label %ThrowNullRef, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
@@ -15106,8 +17383,8 @@ entry:
 
 ; <label>:36                                      ; preds = %24
   %37 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %37, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.ConsoleStream addrspace(1)* %37, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %37, i32 0, i32 4
@@ -15128,13 +17405,138 @@ ThrowNullRef:                                     ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %36
+ThrowNullRef2:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
-Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
+Successfully read WindowsConsoleStream.WriteFileNative
+
+define i32 @WindowsConsoleStream.WriteFileNative(i64 %param0, %"System.Byte[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i64
+  %arg1 = alloca %"System.Byte[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i8 addrspace(1)*
+  %loc2 = alloca %"System.Byte[]" addrspace(1)*
+  %loc3 = alloca i32
+  store i64 %param0, i64* %arg0
+  store %"System.Byte[]" addrspace(1)* %param1, %"System.Byte[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Byte[]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = zext i32 %3 to i64
+  %5 = icmp ne i64 %4, 0
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %1
+  ret i32 0
+
+; <label>:7                                       ; preds = %1
+  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  store %"System.Byte[]" addrspace(1)* %8, %"System.Byte[]" addrspace(1)** %loc2
+  %9 = icmp eq %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %9, label %18, label %10
+
+; <label>:10                                      ; preds = %7
+  %11 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc2
+  %NullCheck1 = icmp eq %"System.Byte[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %11, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp ne i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %7, %12
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc1
+  br label %27
+
+; <label>:19                                      ; preds = %12
+  %20 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc2
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %20, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %BoundsCheck = icmp uge i64 0, %24
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %25
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %20, i32 0, i32 3, i32 0
+  store i8 addrspace(1)* %26, i8 addrspace(1)** %loc1
+  br label %27
+
+; <label>:27                                      ; preds = %18, %25
+  %28 = load i64, i64* %arg0
+  %29 = load i8 addrspace(1)*, i8 addrspace(1)** %loc1
+  %30 = ptrtoint i8 addrspace(1)* %29 to i64
+  %31 = load i32, i32* %arg2
+  %32 = sext i32 %31 to i64
+  %33 = add i64 %30, %32
+  %34 = load i32, i32* %arg3
+  %35 = addrspacecast i32* %loc3 to i32 addrspace(1)*
+  %36 = inttoptr i64 %33 to i8*
+  %37 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i8*, i32, i32 addrspace(1)*, i64)*)(i64 %28, i8* %36, i32 %34, i32 addrspace(1)* %35, i64 0)
+  %38 = icmp ugt i32 %37, 0
+  %39 = sext i1 %38 to i32
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc1
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %42, label %41
+
+; <label>:41                                      ; preds = %27
+  ret i32 0
+
+; <label>:42                                      ; preds = %27
+  %43 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  store i32 %43, i32* %loc0
+  %44 = load i32, i32* %loc0
+  %45 = icmp eq i32 %44, 232
+  br i1 %45, label %49, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = load i32, i32* %loc0
+  %48 = icmp ne i32 %47, 109
+  br i1 %48, label %50, label %49
+
+; <label>:49                                      ; preds = %42, %46
+  ret i32 0
+
+; <label>:50                                      ; preds = %46
+  %51 = load i32, i32* %loc0
+  ret i32 %51
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
 Successfully read WindowsConsoleStream.Flush
 
@@ -15143,8 +17545,8 @@ entry:
   %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
   store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
@@ -15179,8 +17581,8 @@ entry:
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
   %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load i64, i64 addrspace(1)* %1
@@ -15219,15 +17621,15 @@ entry:
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.TextWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
   %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %3, align 8
   %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
   %7 = load i64, i64 addrspace(1)* %5
@@ -15245,7 +17647,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -15274,8 +17676,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %4)
   store i32 0, i32* %loc0
   %5 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Char[]" addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
@@ -15287,15 +17689,15 @@ entry:
 
 ; <label>:11                                      ; preds = %69
   %12 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %12, i32 0, i32 9
   %15 = load i32, i32 addrspace(1)* %14, align 8
   %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.IO.StreamWriter addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %16, i32 0, i32 10
@@ -15310,15 +17712,15 @@ entry:
 
 ; <label>:23                                      ; preds = %17, %21
   %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %24, null
-  br i1 %NullCheck8, label %25, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %24, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 10
   %27 = load i32, i32 addrspace(1)* %26, align 8
   %28 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %28, null
-  br i1 %NullCheck10, label %29, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.StreamWriter addrspace(1)* %28, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %28, i32 0, i32 9
@@ -15340,15 +17742,15 @@ entry:
   %40 = load i32, i32* %loc0
   %41 = mul i32 %40, 2
   %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
-  br i1 %NullCheck12, label %43, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %43
 
 ; <label>:43                                      ; preds = %38
   %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 7
   %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %44, align 8
   %46 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %46, null
-  br i1 %NullCheck14, label %47, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.IO.StreamWriter addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %47
 
 ; <label>:47                                      ; preds = %43
   %48 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %46, i32 0, i32 9
@@ -15360,16 +17762,16 @@ entry:
   %54 = bitcast %"System.Char[]" addrspace(1)* %45 to %System.Array addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %53, i32 %41, %System.Array addrspace(1)* %54, i32 %50, i32 %52)
   %55 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
-  br i1 %NullCheck16, label %56, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %56
 
 ; <label>:56                                      ; preds = %47
   %57 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
   %58 = load i32, i32 addrspace(1)* %57, align 8
   %59 = load i32, i32* %loc2
   %60 = add i32 %58, %59
-  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
-  br i1 %NullCheck18, label %61, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %61
 
 ; <label>:61                                      ; preds = %56
   %62 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
@@ -15391,8 +17793,8 @@ entry:
 
 ; <label>:72                                      ; preds = %69
   %73 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %73, null
-  br i1 %NullCheck2, label %74, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %73, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %74
 
 ; <label>:74                                      ; preds = %72
   %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %73, i32 0, i32 11
@@ -15413,39 +17815,39 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %72
+ThrowNullRef2:                                    ; preds = %72
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %23
+ThrowNullRef8:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef10:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %43
+ThrowNullRef14:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %47
+ThrowNullRef16:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %56
+ThrowNullRef18:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblVar.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblVar.error.txt
@@ -25,8 +25,8 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
@@ -40,8 +40,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
   %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
@@ -75,7 +75,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -90,8 +90,8 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %NullCheck = icmp ne i8 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = load i8, i8 addrspace(1)* %0, align 8
@@ -125,8 +125,8 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
@@ -159,8 +159,8 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -184,8 +184,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
   store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
@@ -195,8 +195,8 @@ entry:
 ; <label>:4                                       ; preds = %1
   %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
   %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
@@ -206,8 +206,8 @@ entry:
   %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
@@ -221,14 +221,14 @@ entry:
 
 ; <label>:17                                      ; preds = %14
   %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
   %21 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
@@ -238,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -249,8 +249,8 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
@@ -261,27 +261,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %30
+ThrowNullRef10:                                   ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -301,7 +301,89 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
-Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
+Successfully read AppDomainSetup.GetUnsecureApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.GetUnsecureApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %NullCheck = icmp eq %"System.String[]" addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %BoundsCheck = icmp uge i64 0, %5
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %6
+
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 3, i32 0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
+  ret %System.String addrspace(1)* %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_Value using LLILCJit
+Successfully read AppDomainSetup.get_Value
+
+define %"System.String[]" addrspace(1)* @AppDomainSetup.get_Value(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.String[]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 18)
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.String[]" addrspace(1)* addrspace(1)*, %"System.String[]" addrspace(1)*)*)(%"System.String[]" addrspace(1)* addrspace(1)* %9, %"System.String[]" addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %11, i32 0, i32 1
+  %14 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %13, align 8
+  ret %"System.String[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -319,8 +401,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -368,16 +450,16 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
   %5 = load i32, i32 addrspace(1)* %4
   %6 = sub i32 %5, 1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -389,7 +471,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -421,8 +503,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
@@ -456,8 +538,8 @@ entry:
 ; <label>:27                                      ; preds = %19
   %28 = load i32, i32* %arg1
   %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
-  br i1 %NullCheck2, label %30, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %29, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %30
 
 ; <label>:30                                      ; preds = %27
   %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
@@ -493,8 +575,8 @@ entry:
 ; <label>:49                                      ; preds = %46
   %50 = load i32, i32* %arg2
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck4, label %52, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
@@ -517,11 +599,11 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %27
+ThrowNullRef2:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %49
+ThrowNullRef4:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -544,16 +626,16 @@ entry:
   %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %0)
   store %System.String addrspace(1)* %1, %System.String addrspace(1)** %loc0
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 2
   %5 = bitcast [0 x i16] addrspace(1)* %4 to i16 addrspace(1)*
   store i16 addrspace(1)* %5, i16 addrspace(1)** %loc1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %3
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2
@@ -580,7 +662,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -691,15 +773,15 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %NullCheck132 = icmp ne i8* %21, null
-  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+  %NullCheck131 = icmp eq i8* %21, null
+  br i1 %NullCheck131, label %ThrowNullRef132, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = load i8, i8* %21, align 8
   %24 = zext i8 %23 to i32
   %25 = trunc i32 %24 to i8
-  %NullCheck134 = icmp ne i8* %20, null
-  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+  %NullCheck133 = icmp eq i8* %20, null
+  br i1 %NullCheck133, label %ThrowNullRef134, label %26
 
 ; <label>:26                                      ; preds = %22
   store i8 %25, i8* %20, align 8
@@ -709,16 +791,16 @@ entry:
   %28 = load i8*, i8** %arg0
   %29 = load i8*, i8** %arg1
   %30 = bitcast i8* %29 to i16*
-  %NullCheck128 = icmp ne i16* %30, null
-  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+  %NullCheck127 = icmp eq i16* %30, null
+  br i1 %NullCheck127, label %ThrowNullRef128, label %31
 
 ; <label>:31                                      ; preds = %27
   %32 = load i16, i16* %30, align 8
   %33 = sext i16 %32 to i32
   %34 = bitcast i8* %28 to i16*
   %35 = trunc i32 %33 to i16
-  %NullCheck130 = icmp ne i16* %34, null
-  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+  %NullCheck129 = icmp eq i16* %34, null
+  br i1 %NullCheck129, label %ThrowNullRef130, label %36
 
 ; <label>:36                                      ; preds = %31
   store i16 %35, i16* %34, align 8
@@ -728,16 +810,16 @@ entry:
   %38 = load i8*, i8** %arg0
   %39 = load i8*, i8** %arg1
   %40 = bitcast i8* %39 to i16*
-  %NullCheck120 = icmp ne i16* %40, null
-  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+  %NullCheck119 = icmp eq i16* %40, null
+  br i1 %NullCheck119, label %ThrowNullRef120, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i16, i16* %40, align 8
   %43 = sext i16 %42 to i32
   %44 = bitcast i8* %38 to i16*
   %45 = trunc i32 %43 to i16
-  %NullCheck122 = icmp ne i16* %44, null
-  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+  %NullCheck121 = icmp eq i16* %44, null
+  br i1 %NullCheck121, label %ThrowNullRef122, label %46
 
 ; <label>:46                                      ; preds = %41
   store i16 %45, i16* %44, align 8
@@ -745,15 +827,15 @@ entry:
   %48 = getelementptr inbounds i8, i8* %47, i64 2
   %49 = load i8*, i8** %arg1
   %50 = getelementptr inbounds i8, i8* %49, i64 2
-  %NullCheck124 = icmp ne i8* %50, null
-  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+  %NullCheck123 = icmp eq i8* %50, null
+  br i1 %NullCheck123, label %ThrowNullRef124, label %51
 
 ; <label>:51                                      ; preds = %46
   %52 = load i8, i8* %50, align 8
   %53 = zext i8 %52 to i32
   %54 = trunc i32 %53 to i8
-  %NullCheck126 = icmp ne i8* %48, null
-  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+  %NullCheck125 = icmp eq i8* %48, null
+  br i1 %NullCheck125, label %ThrowNullRef126, label %55
 
 ; <label>:55                                      ; preds = %51
   store i8 %54, i8* %48, align 8
@@ -763,14 +845,14 @@ entry:
   %57 = load i8*, i8** %arg0
   %58 = load i8*, i8** %arg1
   %59 = bitcast i8* %58 to i32*
-  %NullCheck116 = icmp ne i32* %59, null
-  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+  %NullCheck115 = icmp eq i32* %59, null
+  br i1 %NullCheck115, label %ThrowNullRef116, label %60
 
 ; <label>:60                                      ; preds = %56
   %61 = load i32, i32* %59, align 8
   %62 = bitcast i8* %57 to i32*
-  %NullCheck118 = icmp ne i32* %62, null
-  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+  %NullCheck117 = icmp eq i32* %62, null
+  br i1 %NullCheck117, label %ThrowNullRef118, label %63
 
 ; <label>:63                                      ; preds = %60
   store i32 %61, i32* %62, align 8
@@ -780,14 +862,14 @@ entry:
   %65 = load i8*, i8** %arg0
   %66 = load i8*, i8** %arg1
   %67 = bitcast i8* %66 to i32*
-  %NullCheck108 = icmp ne i32* %67, null
-  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+  %NullCheck107 = icmp eq i32* %67, null
+  br i1 %NullCheck107, label %ThrowNullRef108, label %68
 
 ; <label>:68                                      ; preds = %64
   %69 = load i32, i32* %67, align 8
   %70 = bitcast i8* %65 to i32*
-  %NullCheck110 = icmp ne i32* %70, null
-  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+  %NullCheck109 = icmp eq i32* %70, null
+  br i1 %NullCheck109, label %ThrowNullRef110, label %71
 
 ; <label>:71                                      ; preds = %68
   store i32 %69, i32* %70, align 8
@@ -795,15 +877,15 @@ entry:
   %73 = getelementptr inbounds i8, i8* %72, i64 4
   %74 = load i8*, i8** %arg1
   %75 = getelementptr inbounds i8, i8* %74, i64 4
-  %NullCheck112 = icmp ne i8* %75, null
-  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+  %NullCheck111 = icmp eq i8* %75, null
+  br i1 %NullCheck111, label %ThrowNullRef112, label %76
 
 ; <label>:76                                      ; preds = %71
   %77 = load i8, i8* %75, align 8
   %78 = zext i8 %77 to i32
   %79 = trunc i32 %78 to i8
-  %NullCheck114 = icmp ne i8* %73, null
-  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+  %NullCheck113 = icmp eq i8* %73, null
+  br i1 %NullCheck113, label %ThrowNullRef114, label %80
 
 ; <label>:80                                      ; preds = %76
   store i8 %79, i8* %73, align 8
@@ -813,14 +895,14 @@ entry:
   %82 = load i8*, i8** %arg0
   %83 = load i8*, i8** %arg1
   %84 = bitcast i8* %83 to i32*
-  %NullCheck100 = icmp ne i32* %84, null
-  br i1 %NullCheck100, label %85, label %ThrowNullRef99
+  %NullCheck99 = icmp eq i32* %84, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %85
 
 ; <label>:85                                      ; preds = %81
   %86 = load i32, i32* %84, align 8
   %87 = bitcast i8* %82 to i32*
-  %NullCheck102 = icmp ne i32* %87, null
-  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+  %NullCheck101 = icmp eq i32* %87, null
+  br i1 %NullCheck101, label %ThrowNullRef102, label %88
 
 ; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
@@ -829,16 +911,16 @@ entry:
   %91 = load i8*, i8** %arg1
   %92 = getelementptr inbounds i8, i8* %91, i64 4
   %93 = bitcast i8* %92 to i16*
-  %NullCheck104 = icmp ne i16* %93, null
-  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+  %NullCheck103 = icmp eq i16* %93, null
+  br i1 %NullCheck103, label %ThrowNullRef104, label %94
 
 ; <label>:94                                      ; preds = %88
   %95 = load i16, i16* %93, align 8
   %96 = sext i16 %95 to i32
   %97 = bitcast i8* %90 to i16*
   %98 = trunc i32 %96 to i16
-  %NullCheck106 = icmp ne i16* %97, null
-  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+  %NullCheck105 = icmp eq i16* %97, null
+  br i1 %NullCheck105, label %ThrowNullRef106, label %99
 
 ; <label>:99                                      ; preds = %94
   store i16 %98, i16* %97, align 8
@@ -848,14 +930,14 @@ entry:
   %101 = load i8*, i8** %arg0
   %102 = load i8*, i8** %arg1
   %103 = bitcast i8* %102 to i32*
-  %NullCheck88 = icmp ne i32* %103, null
-  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+  %NullCheck87 = icmp eq i32* %103, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %104
 
 ; <label>:104                                     ; preds = %100
   %105 = load i32, i32* %103, align 8
   %106 = bitcast i8* %101 to i32*
-  %NullCheck90 = icmp ne i32* %106, null
-  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+  %NullCheck89 = icmp eq i32* %106, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %107
 
 ; <label>:107                                     ; preds = %104
   store i32 %105, i32* %106, align 8
@@ -864,16 +946,16 @@ entry:
   %110 = load i8*, i8** %arg1
   %111 = getelementptr inbounds i8, i8* %110, i64 4
   %112 = bitcast i8* %111 to i16*
-  %NullCheck92 = icmp ne i16* %112, null
-  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+  %NullCheck91 = icmp eq i16* %112, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %113
 
 ; <label>:113                                     ; preds = %107
   %114 = load i16, i16* %112, align 8
   %115 = sext i16 %114 to i32
   %116 = bitcast i8* %109 to i16*
   %117 = trunc i32 %115 to i16
-  %NullCheck94 = icmp ne i16* %116, null
-  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+  %NullCheck93 = icmp eq i16* %116, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %118
 
 ; <label>:118                                     ; preds = %113
   store i16 %117, i16* %116, align 8
@@ -881,15 +963,15 @@ entry:
   %120 = getelementptr inbounds i8, i8* %119, i64 6
   %121 = load i8*, i8** %arg1
   %122 = getelementptr inbounds i8, i8* %121, i64 6
-  %NullCheck96 = icmp ne i8* %122, null
-  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+  %NullCheck95 = icmp eq i8* %122, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %123
 
 ; <label>:123                                     ; preds = %118
   %124 = load i8, i8* %122, align 8
   %125 = zext i8 %124 to i32
   %126 = trunc i32 %125 to i8
-  %NullCheck98 = icmp ne i8* %120, null
-  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+  %NullCheck97 = icmp eq i8* %120, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %127
 
 ; <label>:127                                     ; preds = %123
   store i8 %126, i8* %120, align 8
@@ -899,14 +981,14 @@ entry:
   %129 = load i8*, i8** %arg0
   %130 = load i8*, i8** %arg1
   %131 = bitcast i8* %130 to i64*
-  %NullCheck84 = icmp ne i64* %131, null
-  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+  %NullCheck83 = icmp eq i64* %131, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %132
 
 ; <label>:132                                     ; preds = %128
   %133 = load i64, i64* %131, align 8
   %134 = bitcast i8* %129 to i64*
-  %NullCheck86 = icmp ne i64* %134, null
-  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+  %NullCheck85 = icmp eq i64* %134, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %135
 
 ; <label>:135                                     ; preds = %132
   store i64 %133, i64* %134, align 8
@@ -916,14 +998,14 @@ entry:
   %137 = load i8*, i8** %arg0
   %138 = load i8*, i8** %arg1
   %139 = bitcast i8* %138 to i64*
-  %NullCheck76 = icmp ne i64* %139, null
-  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+  %NullCheck75 = icmp eq i64* %139, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %140
 
 ; <label>:140                                     ; preds = %136
   %141 = load i64, i64* %139, align 8
   %142 = bitcast i8* %137 to i64*
-  %NullCheck78 = icmp ne i64* %142, null
-  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+  %NullCheck77 = icmp eq i64* %142, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %143
 
 ; <label>:143                                     ; preds = %140
   store i64 %141, i64* %142, align 8
@@ -931,15 +1013,15 @@ entry:
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %NullCheck80 = icmp ne i8* %147, null
-  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+  %NullCheck79 = icmp eq i8* %147, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %148
 
 ; <label>:148                                     ; preds = %143
   %149 = load i8, i8* %147, align 8
   %150 = zext i8 %149 to i32
   %151 = trunc i32 %150 to i8
-  %NullCheck82 = icmp ne i8* %145, null
-  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+  %NullCheck81 = icmp eq i8* %145, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %152
 
 ; <label>:152                                     ; preds = %148
   store i8 %151, i8* %145, align 8
@@ -949,14 +1031,14 @@ entry:
   %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
   %156 = bitcast i8* %155 to i64*
-  %NullCheck68 = icmp ne i64* %156, null
-  br i1 %NullCheck68, label %157, label %ThrowNullRef67
+  %NullCheck67 = icmp eq i64* %156, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %157
 
 ; <label>:157                                     ; preds = %153
   %158 = load i64, i64* %156, align 8
   %159 = bitcast i8* %154 to i64*
-  %NullCheck70 = icmp ne i64* %159, null
-  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+  %NullCheck69 = icmp eq i64* %159, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %160
 
 ; <label>:160                                     ; preds = %157
   store i64 %158, i64* %159, align 8
@@ -965,16 +1047,16 @@ entry:
   %163 = load i8*, i8** %arg1
   %164 = getelementptr inbounds i8, i8* %163, i64 8
   %165 = bitcast i8* %164 to i16*
-  %NullCheck72 = icmp ne i16* %165, null
-  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+  %NullCheck71 = icmp eq i16* %165, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %166
 
 ; <label>:166                                     ; preds = %160
   %167 = load i16, i16* %165, align 8
   %168 = sext i16 %167 to i32
   %169 = bitcast i8* %162 to i16*
   %170 = trunc i32 %168 to i16
-  %NullCheck74 = icmp ne i16* %169, null
-  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+  %NullCheck73 = icmp eq i16* %169, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %171
 
 ; <label>:171                                     ; preds = %166
   store i16 %170, i16* %169, align 8
@@ -984,14 +1066,14 @@ entry:
   %173 = load i8*, i8** %arg0
   %174 = load i8*, i8** %arg1
   %175 = bitcast i8* %174 to i64*
-  %NullCheck56 = icmp ne i64* %175, null
-  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+  %NullCheck55 = icmp eq i64* %175, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %176
 
 ; <label>:176                                     ; preds = %172
   %177 = load i64, i64* %175, align 8
   %178 = bitcast i8* %173 to i64*
-  %NullCheck58 = icmp ne i64* %178, null
-  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+  %NullCheck57 = icmp eq i64* %178, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %179
 
 ; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
@@ -1000,16 +1082,16 @@ entry:
   %182 = load i8*, i8** %arg1
   %183 = getelementptr inbounds i8, i8* %182, i64 8
   %184 = bitcast i8* %183 to i16*
-  %NullCheck60 = icmp ne i16* %184, null
-  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+  %NullCheck59 = icmp eq i16* %184, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %185
 
 ; <label>:185                                     ; preds = %179
   %186 = load i16, i16* %184, align 8
   %187 = sext i16 %186 to i32
   %188 = bitcast i8* %181 to i16*
   %189 = trunc i32 %187 to i16
-  %NullCheck62 = icmp ne i16* %188, null
-  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+  %NullCheck61 = icmp eq i16* %188, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %190
 
 ; <label>:190                                     ; preds = %185
   store i16 %189, i16* %188, align 8
@@ -1017,15 +1099,15 @@ entry:
   %192 = getelementptr inbounds i8, i8* %191, i64 10
   %193 = load i8*, i8** %arg1
   %194 = getelementptr inbounds i8, i8* %193, i64 10
-  %NullCheck64 = icmp ne i8* %194, null
-  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+  %NullCheck63 = icmp eq i8* %194, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %195
 
 ; <label>:195                                     ; preds = %190
   %196 = load i8, i8* %194, align 8
   %197 = zext i8 %196 to i32
   %198 = trunc i32 %197 to i8
-  %NullCheck66 = icmp ne i8* %192, null
-  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+  %NullCheck65 = icmp eq i8* %192, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %199
 
 ; <label>:199                                     ; preds = %195
   store i8 %198, i8* %192, align 8
@@ -1035,14 +1117,14 @@ entry:
   %201 = load i8*, i8** %arg0
   %202 = load i8*, i8** %arg1
   %203 = bitcast i8* %202 to i64*
-  %NullCheck48 = icmp ne i64* %203, null
-  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+  %NullCheck47 = icmp eq i64* %203, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %204
 
 ; <label>:204                                     ; preds = %200
   %205 = load i64, i64* %203, align 8
   %206 = bitcast i8* %201 to i64*
-  %NullCheck50 = icmp ne i64* %206, null
-  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+  %NullCheck49 = icmp eq i64* %206, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %207
 
 ; <label>:207                                     ; preds = %204
   store i64 %205, i64* %206, align 8
@@ -1051,14 +1133,14 @@ entry:
   %210 = load i8*, i8** %arg1
   %211 = getelementptr inbounds i8, i8* %210, i64 8
   %212 = bitcast i8* %211 to i32*
-  %NullCheck52 = icmp ne i32* %212, null
-  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+  %NullCheck51 = icmp eq i32* %212, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %213
 
 ; <label>:213                                     ; preds = %207
   %214 = load i32, i32* %212, align 8
   %215 = bitcast i8* %209 to i32*
-  %NullCheck54 = icmp ne i32* %215, null
-  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+  %NullCheck53 = icmp eq i32* %215, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %216
 
 ; <label>:216                                     ; preds = %213
   store i32 %214, i32* %215, align 8
@@ -1068,14 +1150,14 @@ entry:
   %218 = load i8*, i8** %arg0
   %219 = load i8*, i8** %arg1
   %220 = bitcast i8* %219 to i64*
-  %NullCheck36 = icmp ne i64* %220, null
-  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64* %220, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %221
 
 ; <label>:221                                     ; preds = %217
   %222 = load i64, i64* %220, align 8
   %223 = bitcast i8* %218 to i64*
-  %NullCheck38 = icmp ne i64* %223, null
-  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+  %NullCheck37 = icmp eq i64* %223, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %224
 
 ; <label>:224                                     ; preds = %221
   store i64 %222, i64* %223, align 8
@@ -1084,14 +1166,14 @@ entry:
   %227 = load i8*, i8** %arg1
   %228 = getelementptr inbounds i8, i8* %227, i64 8
   %229 = bitcast i8* %228 to i32*
-  %NullCheck40 = icmp ne i32* %229, null
-  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i32* %229, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %230
 
 ; <label>:230                                     ; preds = %224
   %231 = load i32, i32* %229, align 8
   %232 = bitcast i8* %226 to i32*
-  %NullCheck42 = icmp ne i32* %232, null
-  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+  %NullCheck41 = icmp eq i32* %232, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %233
 
 ; <label>:233                                     ; preds = %230
   store i32 %231, i32* %232, align 8
@@ -1099,15 +1181,15 @@ entry:
   %235 = getelementptr inbounds i8, i8* %234, i64 12
   %236 = load i8*, i8** %arg1
   %237 = getelementptr inbounds i8, i8* %236, i64 12
-  %NullCheck44 = icmp ne i8* %237, null
-  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i8* %237, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %238
 
 ; <label>:238                                     ; preds = %233
   %239 = load i8, i8* %237, align 8
   %240 = zext i8 %239 to i32
   %241 = trunc i32 %240 to i8
-  %NullCheck46 = icmp ne i8* %235, null
-  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+  %NullCheck45 = icmp eq i8* %235, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %242
 
 ; <label>:242                                     ; preds = %238
   store i8 %241, i8* %235, align 8
@@ -1117,14 +1199,14 @@ entry:
   %244 = load i8*, i8** %arg0
   %245 = load i8*, i8** %arg1
   %246 = bitcast i8* %245 to i64*
-  %NullCheck24 = icmp ne i64* %246, null
-  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64* %246, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %247
 
 ; <label>:247                                     ; preds = %243
   %248 = load i64, i64* %246, align 8
   %249 = bitcast i8* %244 to i64*
-  %NullCheck26 = icmp ne i64* %249, null
-  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64* %249, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %250
 
 ; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
@@ -1133,14 +1215,14 @@ entry:
   %253 = load i8*, i8** %arg1
   %254 = getelementptr inbounds i8, i8* %253, i64 8
   %255 = bitcast i8* %254 to i32*
-  %NullCheck28 = icmp ne i32* %255, null
-  br i1 %NullCheck28, label %256, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i32* %255, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %256
 
 ; <label>:256                                     ; preds = %250
   %257 = load i32, i32* %255, align 8
   %258 = bitcast i8* %252 to i32*
-  %NullCheck30 = icmp ne i32* %258, null
-  br i1 %NullCheck30, label %259, label %ThrowNullRef29
+  %NullCheck29 = icmp eq i32* %258, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %259
 
 ; <label>:259                                     ; preds = %256
   store i32 %257, i32* %258, align 8
@@ -1149,16 +1231,16 @@ entry:
   %262 = load i8*, i8** %arg1
   %263 = getelementptr inbounds i8, i8* %262, i64 12
   %264 = bitcast i8* %263 to i16*
-  %NullCheck32 = icmp ne i16* %264, null
-  br i1 %NullCheck32, label %265, label %ThrowNullRef31
+  %NullCheck31 = icmp eq i16* %264, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %265
 
 ; <label>:265                                     ; preds = %259
   %266 = load i16, i16* %264, align 8
   %267 = sext i16 %266 to i32
   %268 = bitcast i8* %261 to i16*
   %269 = trunc i32 %267 to i16
-  %NullCheck34 = icmp ne i16* %268, null
-  br i1 %NullCheck34, label %270, label %ThrowNullRef33
+  %NullCheck33 = icmp eq i16* %268, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %270
 
 ; <label>:270                                     ; preds = %265
   store i16 %269, i16* %268, align 8
@@ -1168,14 +1250,14 @@ entry:
   %272 = load i8*, i8** %arg0
   %273 = load i8*, i8** %arg1
   %274 = bitcast i8* %273 to i64*
-  %NullCheck8 = icmp ne i64* %274, null
-  br i1 %NullCheck8, label %275, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64* %274, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %275
 
 ; <label>:275                                     ; preds = %271
   %276 = load i64, i64* %274, align 8
   %277 = bitcast i8* %272 to i64*
-  %NullCheck10 = icmp ne i64* %277, null
-  br i1 %NullCheck10, label %278, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %277, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %278
 
 ; <label>:278                                     ; preds = %275
   store i64 %276, i64* %277, align 8
@@ -1184,14 +1266,14 @@ entry:
   %281 = load i8*, i8** %arg1
   %282 = getelementptr inbounds i8, i8* %281, i64 8
   %283 = bitcast i8* %282 to i32*
-  %NullCheck12 = icmp ne i32* %283, null
-  br i1 %NullCheck12, label %284, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i32* %283, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %284
 
 ; <label>:284                                     ; preds = %278
   %285 = load i32, i32* %283, align 8
   %286 = bitcast i8* %280 to i32*
-  %NullCheck14 = icmp ne i32* %286, null
-  br i1 %NullCheck14, label %287, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i32* %286, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %287
 
 ; <label>:287                                     ; preds = %284
   store i32 %285, i32* %286, align 8
@@ -1200,16 +1282,16 @@ entry:
   %290 = load i8*, i8** %arg1
   %291 = getelementptr inbounds i8, i8* %290, i64 12
   %292 = bitcast i8* %291 to i16*
-  %NullCheck16 = icmp ne i16* %292, null
-  br i1 %NullCheck16, label %293, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i16* %292, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %293
 
 ; <label>:293                                     ; preds = %287
   %294 = load i16, i16* %292, align 8
   %295 = sext i16 %294 to i32
   %296 = bitcast i8* %289 to i16*
   %297 = trunc i32 %295 to i16
-  %NullCheck18 = icmp ne i16* %296, null
-  br i1 %NullCheck18, label %298, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i16* %296, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %298
 
 ; <label>:298                                     ; preds = %293
   store i16 %297, i16* %296, align 8
@@ -1217,15 +1299,15 @@ entry:
   %300 = getelementptr inbounds i8, i8* %299, i64 14
   %301 = load i8*, i8** %arg1
   %302 = getelementptr inbounds i8, i8* %301, i64 14
-  %NullCheck20 = icmp ne i8* %302, null
-  br i1 %NullCheck20, label %303, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i8* %302, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %303
 
 ; <label>:303                                     ; preds = %298
   %304 = load i8, i8* %302, align 8
   %305 = zext i8 %304 to i32
   %306 = trunc i32 %305 to i8
-  %NullCheck22 = icmp ne i8* %300, null
-  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i8* %300, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %307
 
 ; <label>:307                                     ; preds = %303
   store i8 %306, i8* %300, align 8
@@ -1235,14 +1317,14 @@ entry:
   %309 = load i8*, i8** %arg0
   %310 = load i8*, i8** %arg1
   %311 = bitcast i8* %310 to i64*
-  %NullCheck = icmp ne i64* %311, null
-  br i1 %NullCheck, label %312, label %ThrowNullRef
+  %NullCheck = icmp eq i64* %311, null
+  br i1 %NullCheck, label %ThrowNullRef, label %312
 
 ; <label>:312                                     ; preds = %308
   %313 = load i64, i64* %311, align 8
   %314 = bitcast i8* %309 to i64*
-  %NullCheck2 = icmp ne i64* %314, null
-  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64* %314, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %315
 
 ; <label>:315                                     ; preds = %312
   store i64 %313, i64* %314, align 8
@@ -1251,14 +1333,14 @@ entry:
   %318 = load i8*, i8** %arg1
   %319 = getelementptr inbounds i8, i8* %318, i64 8
   %320 = bitcast i8* %319 to i64*
-  %NullCheck4 = icmp ne i64* %320, null
-  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64* %320, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %321
 
 ; <label>:321                                     ; preds = %315
   %322 = load i64, i64* %320, align 8
   %323 = bitcast i8* %317 to i64*
-  %NullCheck6 = icmp ne i64* %323, null
-  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64* %323, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %324
 
 ; <label>:324                                     ; preds = %321
   store i64 %322, i64* %323, align 8
@@ -1286,15 +1368,15 @@ entry:
 ; <label>:338                                     ; preds = %333
   %339 = load i8*, i8** %arg0
   %340 = load i8*, i8** %arg1
-  %NullCheck136 = icmp ne i8* %340, null
-  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+  %NullCheck135 = icmp eq i8* %340, null
+  br i1 %NullCheck135, label %ThrowNullRef136, label %341
 
 ; <label>:341                                     ; preds = %338
   %342 = load i8, i8* %340, align 8
   %343 = zext i8 %342 to i32
   %344 = trunc i32 %343 to i8
-  %NullCheck138 = icmp ne i8* %339, null
-  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+  %NullCheck137 = icmp eq i8* %339, null
+  br i1 %NullCheck137, label %ThrowNullRef138, label %345
 
 ; <label>:345                                     ; preds = %341
   store i8 %344, i8* %339, align 8
@@ -1317,16 +1399,16 @@ entry:
   %357 = load i8*, i8** %arg0
   %358 = load i8*, i8** %arg1
   %359 = bitcast i8* %358 to i16*
-  %NullCheck140 = icmp ne i16* %359, null
-  br i1 %NullCheck140, label %360, label %ThrowNullRef139
+  %NullCheck139 = icmp eq i16* %359, null
+  br i1 %NullCheck139, label %ThrowNullRef140, label %360
 
 ; <label>:360                                     ; preds = %356
   %361 = load i16, i16* %359, align 8
   %362 = sext i16 %361 to i32
   %363 = bitcast i8* %357 to i16*
   %364 = trunc i32 %362 to i16
-  %NullCheck142 = icmp ne i16* %363, null
-  br i1 %NullCheck142, label %365, label %ThrowNullRef141
+  %NullCheck141 = icmp eq i16* %363, null
+  br i1 %NullCheck141, label %ThrowNullRef142, label %365
 
 ; <label>:365                                     ; preds = %360
   store i16 %364, i16* %363, align 8
@@ -1352,14 +1434,14 @@ entry:
   %378 = load i8*, i8** %arg0
   %379 = load i8*, i8** %arg1
   %380 = bitcast i8* %379 to i32*
-  %NullCheck144 = icmp ne i32* %380, null
-  br i1 %NullCheck144, label %381, label %ThrowNullRef143
+  %NullCheck143 = icmp eq i32* %380, null
+  br i1 %NullCheck143, label %ThrowNullRef144, label %381
 
 ; <label>:381                                     ; preds = %377
   %382 = load i32, i32* %380, align 8
   %383 = bitcast i8* %378 to i32*
-  %NullCheck146 = icmp ne i32* %383, null
-  br i1 %NullCheck146, label %384, label %ThrowNullRef145
+  %NullCheck145 = icmp eq i32* %383, null
+  br i1 %NullCheck145, label %ThrowNullRef146, label %384
 
 ; <label>:384                                     ; preds = %381
   store i32 %382, i32* %383, align 8
@@ -1384,14 +1466,14 @@ entry:
   %395 = load i8*, i8** %arg0
   %396 = load i8*, i8** %arg1
   %397 = bitcast i8* %396 to i64*
-  %NullCheck164 = icmp ne i64* %397, null
-  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+  %NullCheck163 = icmp eq i64* %397, null
+  br i1 %NullCheck163, label %ThrowNullRef164, label %398
 
 ; <label>:398                                     ; preds = %394
   %399 = load i64, i64* %397, align 8
   %400 = bitcast i8* %395 to i64*
-  %NullCheck166 = icmp ne i64* %400, null
-  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+  %NullCheck165 = icmp eq i64* %400, null
+  br i1 %NullCheck165, label %ThrowNullRef166, label %401
 
 ; <label>:401                                     ; preds = %398
   store i64 %399, i64* %400, align 8
@@ -1400,14 +1482,14 @@ entry:
   %404 = load i8*, i8** %arg1
   %405 = getelementptr inbounds i8, i8* %404, i64 8
   %406 = bitcast i8* %405 to i64*
-  %NullCheck168 = icmp ne i64* %406, null
-  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+  %NullCheck167 = icmp eq i64* %406, null
+  br i1 %NullCheck167, label %ThrowNullRef168, label %407
 
 ; <label>:407                                     ; preds = %401
   %408 = load i64, i64* %406, align 8
   %409 = bitcast i8* %403 to i64*
-  %NullCheck170 = icmp ne i64* %409, null
-  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+  %NullCheck169 = icmp eq i64* %409, null
+  br i1 %NullCheck169, label %ThrowNullRef170, label %410
 
 ; <label>:410                                     ; preds = %407
   store i64 %408, i64* %409, align 8
@@ -1437,14 +1519,14 @@ entry:
   %425 = load i8*, i8** %arg0
   %426 = load i8*, i8** %arg1
   %427 = bitcast i8* %426 to i64*
-  %NullCheck148 = icmp ne i64* %427, null
-  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+  %NullCheck147 = icmp eq i64* %427, null
+  br i1 %NullCheck147, label %ThrowNullRef148, label %428
 
 ; <label>:428                                     ; preds = %424
   %429 = load i64, i64* %427, align 8
   %430 = bitcast i8* %425 to i64*
-  %NullCheck150 = icmp ne i64* %430, null
-  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+  %NullCheck149 = icmp eq i64* %430, null
+  br i1 %NullCheck149, label %ThrowNullRef150, label %431
 
 ; <label>:431                                     ; preds = %428
   store i64 %429, i64* %430, align 8
@@ -1466,14 +1548,14 @@ entry:
   %441 = load i8*, i8** %arg0
   %442 = load i8*, i8** %arg1
   %443 = bitcast i8* %442 to i32*
-  %NullCheck152 = icmp ne i32* %443, null
-  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+  %NullCheck151 = icmp eq i32* %443, null
+  br i1 %NullCheck151, label %ThrowNullRef152, label %444
 
 ; <label>:444                                     ; preds = %440
   %445 = load i32, i32* %443, align 8
   %446 = bitcast i8* %441 to i32*
-  %NullCheck154 = icmp ne i32* %446, null
-  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+  %NullCheck153 = icmp eq i32* %446, null
+  br i1 %NullCheck153, label %ThrowNullRef154, label %447
 
 ; <label>:447                                     ; preds = %444
   store i32 %445, i32* %446, align 8
@@ -1495,16 +1577,16 @@ entry:
   %457 = load i8*, i8** %arg0
   %458 = load i8*, i8** %arg1
   %459 = bitcast i8* %458 to i16*
-  %NullCheck156 = icmp ne i16* %459, null
-  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+  %NullCheck155 = icmp eq i16* %459, null
+  br i1 %NullCheck155, label %ThrowNullRef156, label %460
 
 ; <label>:460                                     ; preds = %456
   %461 = load i16, i16* %459, align 8
   %462 = sext i16 %461 to i32
   %463 = bitcast i8* %457 to i16*
   %464 = trunc i32 %462 to i16
-  %NullCheck158 = icmp ne i16* %463, null
-  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+  %NullCheck157 = icmp eq i16* %463, null
+  br i1 %NullCheck157, label %ThrowNullRef158, label %465
 
 ; <label>:465                                     ; preds = %460
   store i16 %464, i16* %463, align 8
@@ -1525,15 +1607,15 @@ entry:
 ; <label>:474                                     ; preds = %470
   %475 = load i8*, i8** %arg0
   %476 = load i8*, i8** %arg1
-  %NullCheck160 = icmp ne i8* %476, null
-  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+  %NullCheck159 = icmp eq i8* %476, null
+  br i1 %NullCheck159, label %ThrowNullRef160, label %477
 
 ; <label>:477                                     ; preds = %474
   %478 = load i8, i8* %476, align 8
   %479 = zext i8 %478 to i32
   %480 = trunc i32 %479 to i8
-  %NullCheck162 = icmp ne i8* %475, null
-  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+  %NullCheck161 = icmp eq i8* %475, null
+  br i1 %NullCheck161, label %ThrowNullRef162, label %481
 
 ; <label>:481                                     ; preds = %477
   store i8 %480, i8* %475, align 8
@@ -1553,343 +1635,343 @@ ThrowNullRef:                                     ; preds = %308
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %312
+ThrowNullRef2:                                    ; preds = %312
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %315
+ThrowNullRef4:                                    ; preds = %315
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %321
+ThrowNullRef6:                                    ; preds = %321
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %271
+ThrowNullRef8:                                    ; preds = %271
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %275
+ThrowNullRef10:                                   ; preds = %275
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %278
+ThrowNullRef12:                                   ; preds = %278
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %284
+ThrowNullRef14:                                   ; preds = %284
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %287
+ThrowNullRef16:                                   ; preds = %287
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %293
+ThrowNullRef18:                                   ; preds = %293
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %298
+ThrowNullRef20:                                   ; preds = %298
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %303
+ThrowNullRef22:                                   ; preds = %303
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %243
+ThrowNullRef24:                                   ; preds = %243
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %247
+ThrowNullRef26:                                   ; preds = %247
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %250
+ThrowNullRef28:                                   ; preds = %250
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %256
+ThrowNullRef30:                                   ; preds = %256
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %259
+ThrowNullRef32:                                   ; preds = %259
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %265
+ThrowNullRef34:                                   ; preds = %265
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %217
+ThrowNullRef36:                                   ; preds = %217
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %221
+ThrowNullRef38:                                   ; preds = %221
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %224
+ThrowNullRef40:                                   ; preds = %224
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %230
+ThrowNullRef42:                                   ; preds = %230
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %233
+ThrowNullRef44:                                   ; preds = %233
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %238
+ThrowNullRef46:                                   ; preds = %238
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %200
+ThrowNullRef48:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %204
+ThrowNullRef50:                                   ; preds = %204
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %207
+ThrowNullRef52:                                   ; preds = %207
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %213
+ThrowNullRef54:                                   ; preds = %213
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %172
+ThrowNullRef56:                                   ; preds = %172
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %176
+ThrowNullRef58:                                   ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %179
+ThrowNullRef60:                                   ; preds = %179
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %185
+ThrowNullRef62:                                   ; preds = %185
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %190
+ThrowNullRef64:                                   ; preds = %190
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %195
+ThrowNullRef66:                                   ; preds = %195
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %153
+ThrowNullRef68:                                   ; preds = %153
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %157
+ThrowNullRef70:                                   ; preds = %157
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %160
+ThrowNullRef72:                                   ; preds = %160
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %166
+ThrowNullRef74:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %136
+ThrowNullRef76:                                   ; preds = %136
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %140
+ThrowNullRef78:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %143
+ThrowNullRef80:                                   ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %148
+ThrowNullRef82:                                   ; preds = %148
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %128
+ThrowNullRef84:                                   ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %132
+ThrowNullRef86:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %100
+ThrowNullRef88:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %104
+ThrowNullRef90:                                   ; preds = %104
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %107
+ThrowNullRef92:                                   ; preds = %107
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %113
+ThrowNullRef94:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %118
+ThrowNullRef96:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %123
+ThrowNullRef98:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %81
+ThrowNullRef100:                                  ; preds = %81
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef101:                                  ; preds = %85
+ThrowNullRef102:                                  ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef103:                                  ; preds = %88
+ThrowNullRef104:                                  ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef105:                                  ; preds = %94
+ThrowNullRef106:                                  ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef107:                                  ; preds = %64
+ThrowNullRef108:                                  ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef109:                                  ; preds = %68
+ThrowNullRef110:                                  ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef111:                                  ; preds = %71
+ThrowNullRef112:                                  ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef113:                                  ; preds = %76
+ThrowNullRef114:                                  ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef115:                                  ; preds = %56
+ThrowNullRef116:                                  ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef117:                                  ; preds = %60
+ThrowNullRef118:                                  ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef119:                                  ; preds = %37
+ThrowNullRef120:                                  ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef121:                                  ; preds = %41
+ThrowNullRef122:                                  ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef123:                                  ; preds = %46
+ThrowNullRef124:                                  ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef125:                                  ; preds = %51
+ThrowNullRef126:                                  ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef127:                                  ; preds = %27
+ThrowNullRef128:                                  ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef129:                                  ; preds = %31
+ThrowNullRef130:                                  ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef131:                                  ; preds = %19
+ThrowNullRef132:                                  ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef133:                                  ; preds = %22
+ThrowNullRef134:                                  ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef135:                                  ; preds = %338
+ThrowNullRef136:                                  ; preds = %338
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef137:                                  ; preds = %341
+ThrowNullRef138:                                  ; preds = %341
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef139:                                  ; preds = %356
+ThrowNullRef140:                                  ; preds = %356
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef141:                                  ; preds = %360
+ThrowNullRef142:                                  ; preds = %360
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef143:                                  ; preds = %377
+ThrowNullRef144:                                  ; preds = %377
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef145:                                  ; preds = %381
+ThrowNullRef146:                                  ; preds = %381
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef147:                                  ; preds = %424
+ThrowNullRef148:                                  ; preds = %424
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef149:                                  ; preds = %428
+ThrowNullRef150:                                  ; preds = %428
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef151:                                  ; preds = %440
+ThrowNullRef152:                                  ; preds = %440
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef153:                                  ; preds = %444
+ThrowNullRef154:                                  ; preds = %444
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef155:                                  ; preds = %456
+ThrowNullRef156:                                  ; preds = %456
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef157:                                  ; preds = %460
+ThrowNullRef158:                                  ; preds = %460
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef159:                                  ; preds = %474
+ThrowNullRef160:                                  ; preds = %474
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef161:                                  ; preds = %477
+ThrowNullRef162:                                  ; preds = %477
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef163:                                  ; preds = %394
+ThrowNullRef164:                                  ; preds = %394
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef165:                                  ; preds = %398
+ThrowNullRef166:                                  ; preds = %398
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef167:                                  ; preds = %401
+ThrowNullRef168:                                  ; preds = %401
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef169:                                  ; preds = %407
+ThrowNullRef170:                                  ; preds = %407
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1939,8 +2021,8 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
-  br i1 %NullCheck, label %22, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %ThrowNullRef, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
@@ -1948,8 +2030,8 @@ entry:
   store i32 %24, i32* %loc0
   %25 = load i32, i32* %loc0
   %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %26, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %27
 
 ; <label>:27                                      ; preds = %22
   %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
@@ -1971,7 +2053,7 @@ ThrowNullRef:                                     ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1989,8 +2071,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -2022,15 +2104,15 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2048,16 +2130,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
   %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
   store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %15
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
@@ -2072,8 +2154,8 @@ entry:
   %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
   %29 = ptrtoint i16 addrspace(1)* %28 to i64
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %19
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
@@ -2089,19 +2171,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2114,8 +2196,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
@@ -2128,7 +2210,7 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[loadElem]
+Failed to read AppDomain.PrepareDataForSetup[storeElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
@@ -2202,8 +2284,8 @@ entry:
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
-  br i1 %NullCheck24, label %27, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = load i64, i64 addrspace(1)* %26
@@ -2218,8 +2300,8 @@ entry:
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
-  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
   %41 = load i64, i64 addrspace(1)* %39
@@ -2236,8 +2318,8 @@ entry:
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
-  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
   %54 = load i64, i64 addrspace(1)* %52
@@ -2252,8 +2334,8 @@ entry:
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
   %67 = load i64, i64 addrspace(1)* %65
@@ -2270,8 +2352,8 @@ entry:
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
-  br i1 %NullCheck16, label %79, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
   %80 = load i64, i64 addrspace(1)* %78
@@ -2286,8 +2368,8 @@ entry:
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
-  br i1 %NullCheck18, label %92, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
   %93 = load i64, i64 addrspace(1)* %91
@@ -2304,8 +2386,8 @@ entry:
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
-  br i1 %NullCheck12, label %105, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = load i64, i64 addrspace(1)* %104
@@ -2320,8 +2402,8 @@ entry:
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
-  br i1 %NullCheck14, label %118, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
   %119 = load i64, i64 addrspace(1)* %117
@@ -2337,8 +2419,8 @@ entry:
 
 ; <label>:128                                     ; preds = %20
   %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
-  br i1 %NullCheck4, label %130, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %129, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %130
 
 ; <label>:130                                     ; preds = %128
   %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
@@ -2346,8 +2428,8 @@ entry:
   %133 = load i16, i16 addrspace(1)* %132, align 8
   %134 = zext i16 %133 to i32
   %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
-  br i1 %NullCheck6, label %136, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %135, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %136
 
 ; <label>:136                                     ; preds = %130
   %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
@@ -2360,8 +2442,8 @@ entry:
 
 ; <label>:143                                     ; preds = %136
   %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
-  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %144, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %145
 
 ; <label>:145                                     ; preds = %143
   %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
@@ -2369,8 +2451,8 @@ entry:
   %148 = load i16, i16 addrspace(1)* %147, align 8
   %149 = zext i16 %148 to i32
   %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %150, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %151
 
 ; <label>:151                                     ; preds = %145
   %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
@@ -2388,8 +2470,8 @@ entry:
 
 ; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
-  br i1 %NullCheck, label %163, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %ThrowNullRef, label %163
 
 ; <label>:163                                     ; preds = %161
   %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
@@ -2399,8 +2481,8 @@ entry:
 
 ; <label>:167                                     ; preds = %163
   %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
-  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %168, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %169
 
 ; <label>:169                                     ; preds = %167
   %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
@@ -2432,55 +2514,55 @@ ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %167
+ThrowNullRef2:                                    ; preds = %167
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %128
+ThrowNullRef4:                                    ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %130
+ThrowNullRef6:                                    ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %143
+ThrowNullRef8:                                    ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %145
+ThrowNullRef10:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %102
+ThrowNullRef12:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %105
+ThrowNullRef14:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %76
+ThrowNullRef16:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %79
+ThrowNullRef18:                                   ; preds = %79
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %50
+ThrowNullRef20:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %53
+ThrowNullRef22:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %24
+ThrowNullRef24:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %27
+ThrowNullRef26:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2503,15 +2585,15 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2519,16 +2601,16 @@ entry:
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
   store i32 %8, i32* %loc0
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
   %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
   store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
@@ -2546,16 +2628,16 @@ entry:
 
 ; <label>:23                                      ; preds = %64
   %24 = load i16*, i16** %loc3
-  %NullCheck12 = icmp ne i16* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i16* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
   store i32 %27, i32* %loc5
   %28 = load i16*, i16** %loc4
-  %NullCheck14 = icmp ne i16* %28, null
-  br i1 %NullCheck14, label %29, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %28, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = load i16, i16* %28, align 8
@@ -2620,15 +2702,15 @@ entry:
 
 ; <label>:67                                      ; preds = %64
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
-  br i1 %NullCheck8, label %69, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %68, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %69
 
 ; <label>:69                                      ; preds = %67
   %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
   %71 = load i32, i32 addrspace(1)* %70
   %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
-  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %73
 
 ; <label>:73                                      ; preds = %69
   %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
@@ -2645,31 +2727,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %67
+ThrowNullRef8:                                    ; preds = %67
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %69
+ThrowNullRef10:                                   ; preds = %69
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2710,14 +2792,14 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
   %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
@@ -2730,14 +2812,14 @@ entry:
 
 ; <label>:11                                      ; preds = %4
   %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
   %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
@@ -2749,14 +2831,14 @@ entry:
 
 ; <label>:22                                      ; preds = %16
   %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
   %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
-  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
-  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
@@ -2804,23 +2886,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2836,7 +2918,280 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[loadElem]
+Successfully read RuntimeType.IsAssignableFrom
+
+define i8 @RuntimeType.IsAssignableFrom(%System.RuntimeType addrspace(1)* %param0, %System.Type addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.RuntimeType addrspace(1)*
+  %arg1 = alloca %System.Type addrspace(1)*
+  %loc0 = alloca %System.RuntimeType addrspace(1)*
+  %loc1 = alloca %"System.Type[]" addrspace(1)*
+  %loc2 = alloca i32
+  store %System.RuntimeType addrspace(1)* %param0, %System.RuntimeType addrspace(1)** %this
+  store %System.Type addrspace(1)* %param1, %System.Type addrspace(1)** %arg1
+  %0 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %1 = icmp ne %System.Type addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i8 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %5 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %6 = bitcast %System.Type addrspace(1)* %4 to %System.Object addrspace(1)*
+  %7 = bitcast %System.RuntimeType addrspace(1)* %5 to %System.Object addrspace(1)*
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %6, %System.Object addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %3
+  ret i8 1
+
+; <label>:12                                      ; preds = %3
+  %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 152
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 32
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
+  %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
+  %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
+  store %System.RuntimeType addrspace(1)* %25, %System.RuntimeType addrspace(1)** %loc0
+  %26 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %27 = icmp eq %System.RuntimeType addrspace(1)* %26, null
+  br i1 %27, label %34, label %28
+
+; <label>:28                                      ; preds = %15
+  %29 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %30 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)*)*)(%System.RuntimeType addrspace(1)* %29, %System.RuntimeType addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+; <label>:34                                      ; preds = %15
+  %35 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %36 = call %System.Reflection.Emit.TypeBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Reflection.Emit.TypeBuilder addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %35)
+  %37 = icmp eq %System.Reflection.Emit.TypeBuilder addrspace(1)* %36, null
+  br i1 %37, label %139, label %38
+
+; <label>:38                                      ; preds = %34
+  %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %42
+
+; <label>:42                                      ; preds = %38
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 152
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 40
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
+  %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
+  %53 = zext i8 %52 to i32
+  %54 = icmp eq i32 %53, 0
+  br i1 %54, label %56, label %55
+
+; <label>:55                                      ; preds = %42
+  ret i8 1
+
+; <label>:56                                      ; preds = %42
+  %57 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %58 = bitcast %System.RuntimeType addrspace(1)* %57 to %System.Type addrspace(1)*
+  %59 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %58)
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %64 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.Type addrspace(1)* %63, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = bitcast %System.RuntimeType addrspace(1)* %64 to %System.Type addrspace(1)*
+  %67 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %63, %System.Type addrspace(1)* %66)
+  %68 = zext i8 %67 to i32
+  %69 = trunc i32 %68 to i8
+  ret i8 %69
+
+; <label>:70                                      ; preds = %56
+  %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
+  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %73
+
+; <label>:73                                      ; preds = %70
+  %74 = load i64, i64 addrspace(1)* %72
+  %75 = add i64 %74, 128
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = add i64 %77, 0
+  %79 = inttoptr i64 %78 to i64*
+  %80 = load i64, i64* %79
+  %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
+  %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
+  %83 = call i8 %82(%System.Type addrspace(1)* %81)
+  %84 = zext i8 %83 to i32
+  %85 = icmp eq i32 %84, 0
+  br i1 %85, label %139, label %86
+
+; <label>:86                                      ; preds = %73
+  %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
+  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %89
+
+; <label>:89                                      ; preds = %86
+  %90 = load i64, i64 addrspace(1)* %88
+  %91 = add i64 %90, 128
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = add i64 %93, 24
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
+  %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
+  %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
+  store %"System.Type[]" addrspace(1)* %99, %"System.Type[]" addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %129
+
+; <label>:100                                     ; preds = %132
+  %101 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %102 = load i32, i32* %loc2
+  %NullCheck11 = icmp eq %"System.Type[]" addrspace(1)* %101, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %103
+
+; <label>:103                                     ; preds = %100
+  %104 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 1
+  %105 = load i32, i32 addrspace(1)* %104
+  %106 = zext i32 %105 to i64
+  %107 = zext i32 %102 to i64
+  %BoundsCheck = icmp uge i64 %107, %106
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %108
+
+; <label>:108                                     ; preds = %103
+  %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
+  %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
+  %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
+  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %113
+
+; <label>:113                                     ; preds = %108
+  %114 = load i64, i64 addrspace(1)* %112
+  %115 = add i64 %114, 152
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = add i64 %117, 56
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
+  %123 = zext i8 %122 to i32
+  %124 = icmp ne i32 %123, 0
+  br i1 %124, label %126, label %125
+
+; <label>:125                                     ; preds = %113
+  ret i8 0
+
+; <label>:126                                     ; preds = %113
+  %127 = load i32, i32* %loc2
+  %128 = add i32 %127, 1
+  store i32 %128, i32* %loc2
+  br label %129
+
+; <label>:129                                     ; preds = %89, %126
+  %130 = load i32, i32* %loc2
+  %131 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %NullCheck9 = icmp eq %"System.Type[]" addrspace(1)* %131, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %132
+
+; <label>:132                                     ; preds = %129
+  %133 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %131, i32 0, i32 1
+  %134 = load i32, i32 addrspace(1)* %133
+  %135 = zext i32 %134 to i64
+  %136 = trunc i64 %135 to i32
+  %137 = icmp slt i32 %130, %136
+  br i1 %137, label %100, label %138
+
+; <label>:138                                     ; preds = %132
+  ret i8 1
+
+; <label>:139                                     ; preds = %34, %73
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %129
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %103
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -2893,7 +3248,7 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElem]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -2904,8 +3259,8 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -2997,8 +3352,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
@@ -3059,8 +3414,8 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -3087,8 +3442,8 @@ entry:
 
 ; <label>:17                                      ; preds = %5, %11
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
@@ -3097,8 +3452,8 @@ entry:
 
 ; <label>:22                                      ; preds = %1, %11
   %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
@@ -3109,11 +3464,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %17
+ThrowNullRef2:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %22
+ThrowNullRef4:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3167,15 +3522,15 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
   %15 = load i32, i32 addrspace(1)* %14
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
@@ -3198,7 +3553,7 @@ ThrowNullRef:                                     ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef2:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3232,8 +3587,8 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
@@ -3312,8 +3667,8 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -3327,8 +3682,8 @@ entry:
 ; <label>:5                                       ; preds = %43
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %7 = load i32, i32* %loc1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck6, label %8, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
@@ -3366,8 +3721,8 @@ entry:
 ; <label>:32                                      ; preds = %21, %25
   %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
   %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
-  br i1 %NullCheck8, label %35, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = trunc i32 %34 to i16
@@ -3380,8 +3735,8 @@ entry:
 ; <label>:40                                      ; preds = %1, %35
   %41 = load i32, i32* %loc1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
-  br i1 %NullCheck2, label %43, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %42, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
@@ -3392,8 +3747,8 @@ entry:
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
   %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
-  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
   %51 = load i64, i64 addrspace(1)* %49
@@ -3412,19 +3767,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %40
+ThrowNullRef2:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %47
+ThrowNullRef4:                                    ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %5
+ThrowNullRef6:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %32
+ThrowNullRef8:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3467,8 +3822,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
@@ -3492,11 +3847,391 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(i16* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store i16* %param0, i16** %arg0
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load i32, i32* %arg3
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %42, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %37, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg2
+  %13 = load i32, i32* %arg3
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %37, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %24 = load i32, i32* %arg2
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load i16*, i16** %arg0
+  %35 = load i32, i32* %arg3
+  %36 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %36, i16* %34, i32 %35)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:37                                      ; preds = %5, %16
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %39)
+  %41 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41, %System.String addrspace(1)* %38, %System.String addrspace(1)* %40)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41) #0
+  unreachable
+
+; <label>:42                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
-Failed to read StringBuilder.ToString[loadElemA]
+Successfully read StringBuilder.ToString
+
+define %System.String addrspace(1)* @StringBuilder.ToString(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i16*
+  %loc3 = alloca %"System.Char[]" addrspace(1)*
+  %loc4 = alloca i32
+  %loc5 = alloca i32
+  %loc6 = alloca i16 addrspace(1)*
+  %loc7 = alloca %System.String addrspace(1)*
+  %loc8 = alloca %"System.Char[]" addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %0)
+  %2 = icmp ne i32 %1, 0
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %4
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %6)
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %7)
+  store %System.String addrspace(1)* %8, %System.String addrspace(1)** %loc0
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.Text.StringBuilder addrspace(1)* %9, %System.Text.StringBuilder addrspace(1)** %loc1
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  store %System.String addrspace(1)* %10, %System.String addrspace(1)** %loc7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc7
+  %12 = ptrtoint %System.String addrspace(1)* %11 to i64
+  %13 = icmp eq i64 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %5
+  %15 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %16 = sext i32 %15 to i64
+  %17 = add i64 %12, %16
+  br label %18
+
+; <label>:18                                      ; preds = %5, %14
+  %19 = phi i64 [ %12, %5 ], [ %17, %14 ]
+  %20 = inttoptr i64 %19 to i16*
+  store i16* %20, i16** %loc2
+  br label %21
+
+; <label>:21                                      ; preds = %98, %18
+  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %22, null
+  br i1 %NullCheck, label %ThrowNullRef, label %23
+
+; <label>:23                                      ; preds = %21
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 3
+  %25 = load i32, i32 addrspace(1)* %24, align 8
+  %26 = icmp sle i32 %25, 0
+  br i1 %26, label %96, label %27
+
+; <label>:27                                      ; preds = %23
+  %28 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %28, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %29
+
+; <label>:29                                      ; preds = %27
+  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %28, i32 0, i32 1
+  %31 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %30, align 8
+  store %"System.Char[]" addrspace(1)* %31, %"System.Char[]" addrspace(1)** %loc3
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %33
+
+; <label>:33                                      ; preds = %29
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  store i32 %35, i32* %loc4
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  %39 = load i32, i32 addrspace(1)* %38, align 8
+  store i32 %39, i32* %loc5
+  %40 = load i32, i32* %loc5
+  %41 = load i32, i32* %loc4
+  %42 = add i32 %40, %41
+  %43 = zext i32 %42 to i64
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %45
+
+; <label>:45                                      ; preds = %37
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = sext i32 %47 to i64
+  %49 = icmp sgt i64 %43, %48
+  br i1 %49, label %91, label %50
+
+; <label>:50                                      ; preds = %45
+  %51 = load i32, i32* %loc5
+  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %52, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %53
+
+; <label>:53                                      ; preds = %50
+  %54 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %52, i32 0, i32 1
+  %55 = load i32, i32 addrspace(1)* %54
+  %56 = zext i32 %55 to i64
+  %57 = trunc i64 %56 to i32
+  %58 = icmp ugt i32 %51, %57
+  br i1 %58, label %91, label %59
+
+; <label>:59                                      ; preds = %53
+  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  store %"System.Char[]" addrspace(1)* %60, %"System.Char[]" addrspace(1)** %loc8
+  %61 = icmp eq %"System.Char[]" addrspace(1)* %60, null
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %63, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %64
+
+; <label>:64                                      ; preds = %62
+  %65 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %63, i32 0, i32 1
+  %66 = load i32, i32 addrspace(1)* %65
+  %67 = zext i32 %66 to i64
+  %68 = trunc i64 %67 to i32
+  %69 = icmp ne i32 %68, 0
+  br i1 %69, label %71, label %70
+
+; <label>:70                                      ; preds = %59, %64
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:71                                      ; preds = %64
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %73
+
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %BoundsCheck = icmp uge i64 0, %76
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %77
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %78, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:79                                      ; preds = %70, %77
+  %80 = load i16*, i16** %loc2
+  %81 = load i32, i32* %loc4
+  %82 = sext i32 %81 to i64
+  %83 = mul i64 %82, 2
+  %84 = bitcast i16* %80 to i8*
+  %85 = getelementptr inbounds i8, i8* %84, i64 %83
+  %86 = load i16 addrspace(1)*, i16 addrspace(1)** %loc6
+  %87 = ptrtoint i16 addrspace(1)* %86 to i64
+  %88 = load i32, i32* %loc5
+  %89 = bitcast i8* %85 to i16*
+  %90 = inttoptr i64 %87 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %89, i16* %90, i32 %88)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %96
+
+; <label>:91                                      ; preds = %45, %53
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %94 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %93)
+  %95 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95, %System.String addrspace(1)* %92, %System.String addrspace(1)* %94)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95) #0
+  unreachable
+
+; <label>:96                                      ; preds = %23, %79
+  %97 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %97, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %98
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %97, i32 0, i32 2
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  store %System.Text.StringBuilder addrspace(1)* %100, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %102 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %102, label %21, label %103
+
+; <label>:103                                     ; preds = %98
+  store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc7
+  %104 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  ret %System.String addrspace(1)* %104
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method StringBuilder::get_Length using LLILCJit
+Successfully read StringBuilder.get_Length
+
+define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
+Successfully read RuntimeHelpers.get_OffsetToStringData
+
+define i32 @RuntimeHelpers.get_OffsetToStringData() {
+entry:
+  ret i32 12
+}
+
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
 Successfully read CultureData.CreateCultureData
 
@@ -3514,23 +4249,23 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
   store i8 %4, i8 addrspace(1)* %6
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
@@ -3549,11 +4284,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3566,50 +4301,50 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
   store i32 -1, i32 addrspace(1)* %2
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
   store i32 -1, i32 addrspace(1)* %8
   %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
   store i32 -1, i32 addrspace(1)* %14
   %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
   store i32 -1, i32 addrspace(1)* %17
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
@@ -3623,27 +4358,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3675,7 +4410,136 @@ Failed to read Dictionary`2.Insert[non-const derefAddress]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
 Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
-Failed to read HashHelpers.GetPrime[loadElem]
+Successfully read HashHelpers.GetPrime
+
+define i32 @HashHelpers.GetPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %6, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5, %System.String addrspace(1)* %4)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5) #0
+  unreachable
+
+; <label>:6                                       ; preds = %entry
+  store i32 0, i32* %loc0
+  br label %29
+
+; <label>:7                                       ; preds = %35
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 1296
+  %10 = addrspacecast i8 addrspace(1)* %9 to %"System.Int32[]" addrspace(1)**
+  %11 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %10
+  %12 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Int32[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = zext i32 %15 to i64
+  %17 = zext i32 %12 to i64
+  %BoundsCheck = icmp uge i64 %17, %16
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 3, i32 %12
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  store i32 %20, i32* %loc1
+  %21 = load i32, i32* %loc1
+  %22 = load i32, i32* %arg0
+  %23 = icmp slt i32 %21, %22
+  br i1 %23, label %26, label %24
+
+; <label>:24                                      ; preds = %18
+  %25 = load i32, i32* %loc1
+  ret i32 %25
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %loc0
+  %28 = add i32 %27, 1
+  store i32 %28, i32* %loc0
+  br label %29
+
+; <label>:29                                      ; preds = %6, %26
+  %30 = load i32, i32* %loc0
+  %31 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %32 = getelementptr inbounds i8, i8 addrspace(1)* %31, i64 1296
+  %33 = addrspacecast i8 addrspace(1)* %32 to %"System.Int32[]" addrspace(1)**
+  %34 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %33
+  %NullCheck = icmp eq %"System.Int32[]" addrspace(1)* %34, null
+  br i1 %NullCheck, label %ThrowNullRef, label %35
+
+; <label>:35                                      ; preds = %29
+  %36 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %34, i32 0, i32 1
+  %37 = load i32, i32 addrspace(1)* %36
+  %38 = zext i32 %37 to i64
+  %39 = trunc i64 %38 to i32
+  %40 = icmp slt i32 %30, %39
+  br i1 %40, label %7, label %41
+
+; <label>:41                                      ; preds = %35
+  %42 = load i32, i32* %arg0
+  %43 = or i32 %42, 1
+  store i32 %43, i32* %loc2
+  br label %59
+
+; <label>:44                                      ; preds = %59
+  %45 = load i32, i32* %loc2
+  %46 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %45)
+  %47 = zext i8 %46 to i32
+  %48 = icmp eq i32 %47, 0
+  br i1 %48, label %56, label %49
+
+; <label>:49                                      ; preds = %44
+  %50 = load i32, i32* %loc2
+  %51 = sub i32 %50, 1
+  %52 = srem i32 %51, 101
+  %53 = icmp eq i32 %52, 0
+  br i1 %53, label %56, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = load i32, i32* %loc2
+  ret i32 %55
+
+; <label>:56                                      ; preds = %44, %49
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %57, 2
+  store i32 %58, i32* %loc2
+  br label %59
+
+; <label>:59                                      ; preds = %41, %56
+  %60 = load i32, i32* %loc2
+  %61 = icmp slt i32 %60, 2147483647
+  br i1 %61, label %44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load i32, i32* %arg0
+  ret i32 %63
+
+ThrowNullRef:                                     ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
 Successfully read GenericEqualityComparer`1.GetHashCode
 
@@ -3694,14 +4558,14 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
   %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load i64, i64 addrspace(1)* %7
@@ -3720,7 +4584,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3750,8 +4614,8 @@ entry:
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
@@ -3796,8 +4660,8 @@ entry:
   %35 = bitcast i16* %34 to i8*
   %36 = getelementptr inbounds i8, i8* %35, i64 2
   %37 = bitcast i8* %36 to i16*
-  %NullCheck4 = icmp ne i16* %37, null
-  br i1 %NullCheck4, label %38, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %37, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %38
 
 ; <label>:38                                      ; preds = %27
   %39 = load i16, i16* %37, align 8
@@ -3824,8 +4688,8 @@ entry:
 
 ; <label>:54                                      ; preds = %22, %43
   %55 = load i16*, i16** %loc4
-  %NullCheck2 = icmp ne i16* %55, null
-  br i1 %NullCheck2, label %56, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i16* %55, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %56
 
 ; <label>:56                                      ; preds = %54
   %57 = load i16, i16* %55, align 8
@@ -3850,11 +4714,11 @@ ThrowNullRef:                                     ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %54
+ThrowNullRef2:                                    ; preds = %54
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %27
+ThrowNullRef4:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3871,8 +4735,8 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -3907,8 +4771,8 @@ entry:
 
 ; <label>:26                                      ; preds = %19
   %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
-  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %28
 
 ; <label>:28                                      ; preds = %26
   %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
@@ -3920,7 +4784,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3972,8 +4836,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
@@ -3984,26 +4848,26 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
-  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
@@ -4014,8 +4878,8 @@ entry:
 ; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
@@ -4024,8 +4888,8 @@ entry:
 
 ; <label>:25                                      ; preds = %1, %16, %23
   %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
-  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
@@ -4036,27 +4900,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %20
+ThrowNullRef10:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4069,8 +4933,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -4081,8 +4945,8 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
@@ -4091,8 +4955,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1, %8
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
@@ -4103,11 +4967,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4128,24 +4992,24 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   store i32 %3, i32* %loc0
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
   %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
   store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck4, label %9, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
@@ -4164,15 +5028,15 @@ entry:
 ; <label>:18                                      ; preds = %70
   %19 = load i16*, i16** %loc3
   %20 = bitcast i16* %19 to i64*
-  %NullCheck10 = icmp ne i64* %20, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %20, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = load i64, i64* %20, align 8
   %23 = load i16*, i16** %loc4
   %24 = bitcast i16* %23 to i64*
-  %NullCheck12 = icmp ne i64* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = load i64, i64* %24, align 8
@@ -4188,8 +5052,8 @@ entry:
   %31 = bitcast i16* %30 to i8*
   %32 = getelementptr inbounds i8, i8* %31, i64 8
   %33 = bitcast i8* %32 to i64*
-  %NullCheck14 = icmp ne i64* %33, null
-  br i1 %NullCheck14, label %34, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = load i64, i64* %33, align 8
@@ -4197,8 +5061,8 @@ entry:
   %37 = bitcast i16* %36 to i8*
   %38 = getelementptr inbounds i8, i8* %37, i64 8
   %39 = bitcast i8* %38 to i64*
-  %NullCheck16 = icmp ne i64* %39, null
-  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %40
 
 ; <label>:40                                      ; preds = %34
   %41 = load i64, i64* %39, align 8
@@ -4214,8 +5078,8 @@ entry:
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %NullCheck18 = icmp ne i64* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = load i64, i64* %48, align 8
@@ -4223,8 +5087,8 @@ entry:
   %52 = bitcast i16* %51 to i8*
   %53 = getelementptr inbounds i8, i8* %52, i64 16
   %54 = bitcast i8* %53 to i64*
-  %NullCheck20 = icmp ne i64* %54, null
-  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64* %54, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %55
 
 ; <label>:55                                      ; preds = %49
   %56 = load i64, i64* %54, align 8
@@ -4262,15 +5126,15 @@ entry:
 ; <label>:74                                      ; preds = %95
   %75 = load i16*, i16** %loc3
   %76 = bitcast i16* %75 to i32*
-  %NullCheck6 = icmp ne i32* %76, null
-  br i1 %NullCheck6, label %77, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32* %76, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %77
 
 ; <label>:77                                      ; preds = %74
   %78 = load i32, i32* %76, align 8
   %79 = load i16*, i16** %loc4
   %80 = bitcast i16* %79 to i32*
-  %NullCheck8 = icmp ne i32* %80, null
-  br i1 %NullCheck8, label %81, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i32* %80, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %81
 
 ; <label>:81                                      ; preds = %77
   %82 = load i32, i32* %80, align 8
@@ -4318,43 +5182,43 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %74
+ThrowNullRef6:                                    ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %77
+ThrowNullRef8:                                    ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %29
+ThrowNullRef14:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %34
+ThrowNullRef16:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4376,8 +5240,8 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load i64, i64 addrspace(1)* %4
@@ -4389,8 +5253,8 @@ entry:
   %12 = load i64, i64* %11
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %5
   %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
@@ -4399,8 +5263,8 @@ entry:
   %18 = load i8, i8* %arg2
   %19 = zext i8 %18 to i32
   %20 = trunc i32 %19 to i8
-  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %15
   %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
@@ -4411,11 +5275,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4442,8 +5306,8 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
@@ -4466,16 +5330,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
   %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = load i64, i64 addrspace(1)* %19
@@ -4500,8 +5364,8 @@ entry:
 ; <label>:35                                      ; preds = %30
   %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
@@ -4514,8 +5378,8 @@ entry:
 
 ; <label>:42                                      ; preds = %1, %38
   %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
-  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
@@ -4526,19 +5390,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %35
+ThrowNullRef2:                                    ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %42
+ThrowNullRef8:                                    ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4551,14 +5415,14 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
@@ -4570,7 +5434,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4583,8 +5447,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
@@ -4613,51 +5477,51 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
   %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
   %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
   %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
   %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
-  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
   store i64 %21, i64 addrspace(1)* %23
   %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %25 = load i64, i64* %loc0
-  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
@@ -4668,27 +5532,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %22
+ThrowNullRef12:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4701,8 +5565,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
@@ -4713,19 +5577,19 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
@@ -4734,8 +5598,8 @@ entry:
 
 ; <label>:15                                      ; preds = %1, %13
   %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
@@ -4746,19 +5610,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %15
+ThrowNullRef8:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4771,8 +5635,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -4831,8 +5695,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
@@ -4882,8 +5746,8 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
-  br i1 %NullCheck, label %17, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %ThrowNullRef, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
@@ -4894,15 +5758,15 @@ entry:
 
 ; <label>:22                                      ; preds = %17
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
-  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
   %26 = load i32, i32 addrspace(1)* %25
   %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
-  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %27, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
@@ -4925,8 +5789,8 @@ entry:
 ; <label>:40                                      ; preds = %17
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
-  br i1 %NullCheck6, label %43, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %41, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
@@ -4938,34 +5802,17 @@ ThrowNullRef:                                     ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %24
+ThrowNullRef4:                                    ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %40
+ThrowNullRef6:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
-}
-
-INFO:  jitting method Object::ReferenceEquals using LLILCJit
-Successfully read Object.ReferenceEquals
-
-define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
-entry:
-  %arg0 = alloca %System.Object addrspace(1)*
-  %arg1 = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
-  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
-  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = icmp eq %System.Object addrspace(1)* %0, %1
-  %3 = sext i1 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
 }
 
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
@@ -4978,21 +5825,21 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
   %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
-  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
@@ -5007,28 +5854,28 @@ entry:
 ; <label>:13                                      ; preds = %8, %12
   %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
   %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
   %21 = load i32, i32 addrspace(1)* %20, align 8
   %22 = add i32 %21, 1
-  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
   store i32 %22, i32 addrspace(1)* %24
   %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
@@ -5039,27 +5886,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5077,7 +5924,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::Setup using LLILCJit
-Failed to read AppDomain.Setup[loadElem]
+Failed to read AppDomain.Setup[unbox]
 INFO:  jitting method Thread::GetDomain using LLILCJit
 Successfully read Thread.GetDomain
 
@@ -5108,8 +5955,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
@@ -5122,14 +5969,14 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
   %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
@@ -5141,11 +5988,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5173,8 +6020,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -5189,7 +6036,328 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
 Failed to read KeyCollection.System.Collections.Generic.IEnumerable<TKey>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Successfully read Enumerator.MoveNext
+
+define i8 @Enumerator.MoveNext(%"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.RuntimeTypeHandle* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*
+  %"$TypeArg" = alloca %System.RuntimeTypeHandle*
+  store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
+  %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 8
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %76, label %12
+
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
+  br label %76
+
+; <label>:13                                      ; preds = %85
+  %14 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck19 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %15
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, i32 0, i32 0
+  %17 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %16, align 8
+  %NullCheck21 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, i32 0, i32 2
+  %20 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %19, align 8
+  %21 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck23 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %22
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, i32 0, i32 2
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %NullCheck25 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 3, i32 %24
+  %NullCheck27 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %32
+
+; <label>:32                                      ; preds = %30
+  %33 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, i32 0, i32 2
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = icmp slt i32 %34, 0
+  br i1 %35, label %68, label %36
+
+; <label>:36                                      ; preds = %32
+  %37 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %38 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck29 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %39
+
+; <label>:39                                      ; preds = %36
+  %40 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, i32 0, i32 0
+  %41 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %40, align 8
+  %NullCheck31 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, i32 0, i32 2
+  %44 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %43, align 8
+  %45 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck33 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, i32 0, i32 2
+  %48 = load i32, i32 addrspace(1)* %47, align 8
+  %NullCheck35 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %49
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = zext i32 %51 to i64
+  %53 = zext i32 %48 to i64
+  %BoundsCheck37 = icmp uge i64 %53, %52
+  br i1 %BoundsCheck37, label %ThrowIndexOutOfRange38, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 3, i32 %48
+  %NullCheck39 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %56
+
+; <label>:56                                      ; preds = %54
+  %57 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, i32 0, i32 0
+  %58 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck41 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %59
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %60, %System.__Canon addrspace(1)* %58)
+  %61 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck43 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  %64 = load i32, i32 addrspace(1)* %63, align 8
+  %65 = add i32 %64, 1
+  %NullCheck45 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  store i32 %65, i32 addrspace(1)* %67
+  ret i8 1
+
+; <label>:68                                      ; preds = %32
+  %69 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck47 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %73 = add i32 %72, 1
+  %NullCheck49 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %74
+
+; <label>:74                                      ; preds = %70
+  %75 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  store i32 %73, i32 addrspace(1)* %75
+  br label %76
+
+; <label>:76                                      ; preds = %8, %12, %74
+  %77 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %78
+
+; <label>:78                                      ; preds = %76
+  %79 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, i32 0, i32 2
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck7 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %82
+
+; <label>:82                                      ; preds = %78
+  %83 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, i32 0, i32 0
+  %84 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %83, align 8
+  %NullCheck9 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %85
+
+; <label>:85                                      ; preds = %82
+  %86 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, i32 0, i32 7
+  %87 = load i32, i32 addrspace(1)* %86, align 8
+  %88 = icmp ult i32 %80, %87
+  br i1 %88, label %13, label %89
+
+; <label>:89                                      ; preds = %85
+  %90 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %91 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck11 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %92
+
+; <label>:92                                      ; preds = %89
+  %93 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, i32 0, i32 0
+  %94 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck13 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %95
+
+; <label>:95                                      ; preds = %92
+  %96 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, i32 0, i32 7
+  %97 = load i32, i32 addrspace(1)* %96, align 8
+  %98 = add i32 %97, 1
+  %NullCheck15 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %99
+
+; <label>:99                                      ; preds = %95
+  %100 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, i32 0, i32 2
+  store i32 %98, i32 addrspace(1)* %100
+  %101 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck17 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %102
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %103, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %92
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef22:                                   ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef24:                                   ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef26:                                   ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef28:                                   ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef30:                                   ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef32:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef34:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef36:                                   ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange38:                           ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef40:                                   ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef42:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef44:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef46:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef48:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef50:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -5200,8 +6368,8 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -5232,9 +6400,9 @@ Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
 Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
-Failed to read String.MakeSeparatorList[loadElemA]
+Failed to read String.MakeSeparatorList[storeElem]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
-Failed to read String.InternalSplitKeepEmptyEntries[loadElem]
+Failed to read String.InternalSplitKeepEmptyEntries[storeElem]
 INFO:  jitting method Path::IsRelative using LLILCJit
 Successfully read Path.IsRelative
 
@@ -5243,8 +6411,8 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -5254,8 +6422,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
@@ -5271,8 +6439,8 @@ entry:
 
 ; <label>:17                                      ; preds = %7
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
@@ -5288,8 +6456,8 @@ entry:
 
 ; <label>:29                                      ; preds = %19
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %31
 
 ; <label>:31                                      ; preds = %29
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
@@ -5300,8 +6468,8 @@ entry:
 
 ; <label>:36                                      ; preds = %31
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
-  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %37, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
@@ -5312,8 +6480,8 @@ entry:
 
 ; <label>:43                                      ; preds = %31, %38
   %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
-  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %45
 
 ; <label>:45                                      ; preds = %43
   %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
@@ -5324,8 +6492,8 @@ entry:
 
 ; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %50
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
@@ -5336,8 +6504,8 @@ entry:
 
 ; <label>:57                                      ; preds = %1, %7, %19, %45, %52
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
-  br i1 %NullCheck14, label %59, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %59
 
 ; <label>:59                                      ; preds = %57
   %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
@@ -5347,8 +6515,8 @@ entry:
 
 ; <label>:63                                      ; preds = %59
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
@@ -5359,8 +6527,8 @@ entry:
 
 ; <label>:70                                      ; preds = %65
   %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
-  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.String addrspace(1)* %71, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %72
 
 ; <label>:72                                      ; preds = %70
   %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
@@ -5379,39 +6547,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %17
+ThrowNullRef4:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %29
+ThrowNullRef6:                                    ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %36
+ThrowNullRef8:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %43
+ThrowNullRef10:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %50
+ThrowNullRef12:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %57
+ThrowNullRef14:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %63
+ThrowNullRef16:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %70
+ThrowNullRef18:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5419,7 +6587,293 @@ ThrowNullRef17:                                   ; preds = %70
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
-Failed to read String.TrimHelper[loadElem]
+Successfully read String.TrimHelper
+
+define %System.String addrspace(1)* @String.TrimHelper(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i16
+  %loc4 = alloca i32
+  %loc5 = alloca i16
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = sub i32 %3, 1
+  store i32 %4, i32* %loc0
+  store i32 0, i32* %loc1
+  %5 = load i32, i32* %arg2
+  %6 = icmp eq i32 %5, 1
+  br i1 %6, label %62, label %7
+
+; <label>:7                                       ; preds = %1
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:8                                       ; preds = %58
+  store i32 0, i32* %loc2
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load i32, i32* %loc1
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2, i32 %10
+  %13 = load i16, i16 addrspace(1)* %12
+  %14 = zext i16 %13 to i32
+  %15 = trunc i32 %14 to i16
+  store i16 %15, i16* %loc3
+  store i32 0, i32* %loc2
+  br label %34
+
+; <label>:16                                      ; preds = %37
+  %17 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %18 = load i32, i32* %loc2
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %17, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %19
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = zext i32 %18 to i64
+  %BoundsCheck = icmp uge i64 %23, %22
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %24
+
+; <label>:24                                      ; preds = %19
+  %25 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 3, i32 %18
+  %26 = load i16, i16 addrspace(1)* %25, align 8
+  %27 = zext i16 %26 to i32
+  %28 = load i16, i16* %loc3
+  %29 = zext i16 %28 to i32
+  %30 = icmp eq i32 %27, %29
+  br i1 %30, label %43, label %31
+
+; <label>:31                                      ; preds = %24
+  %32 = load i32, i32* %loc2
+  %33 = add i32 %32, 1
+  store i32 %33, i32* %loc2
+  br label %34
+
+; <label>:34                                      ; preds = %11, %31
+  %35 = load i32, i32* %loc2
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = icmp slt i32 %35, %41
+  br i1 %42, label %16, label %43
+
+; <label>:43                                      ; preds = %24, %37
+  %44 = load i32, i32* %loc2
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %45, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp eq i32 %44, %50
+  br i1 %51, label %62, label %52
+
+; <label>:52                                      ; preds = %46
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %7, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %57, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %58
+
+; <label>:58                                      ; preds = %55
+  %59 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %60 = load i32, i32 addrspace(1)* %59
+  %61 = icmp slt i32 %56, %60
+  br i1 %61, label %8, label %62
+
+; <label>:62                                      ; preds = %1, %46, %58
+  %63 = load i32, i32* %arg2
+  %64 = icmp eq i32 %63, 0
+  br i1 %64, label %122, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %66, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %67
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %66, i32 0, i32 1
+  %69 = load i32, i32 addrspace(1)* %68
+  %70 = sub i32 %69, 1
+  store i32 %70, i32* %loc0
+  br label %118
+
+; <label>:71                                      ; preds = %118
+  store i32 0, i32* %loc4
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %73 = load i32, i32* %loc0
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %74
+
+; <label>:74                                      ; preds = %71
+  %75 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 2, i32 %73
+  %76 = load i16, i16 addrspace(1)* %75
+  %77 = zext i16 %76 to i32
+  %78 = trunc i32 %77 to i16
+  store i16 %78, i16* %loc5
+  store i32 0, i32* %loc4
+  br label %97
+
+; <label>:79                                      ; preds = %100
+  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %81 = load i32, i32* %loc4
+  %NullCheck19 = icmp eq %"System.Char[]" addrspace(1)* %80, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
+
+; <label>:82                                      ; preds = %79
+  %83 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 1
+  %84 = load i32, i32 addrspace(1)* %83
+  %85 = zext i32 %84 to i64
+  %86 = zext i32 %81 to i64
+  %BoundsCheck21 = icmp uge i64 %86, %85
+  br i1 %BoundsCheck21, label %ThrowIndexOutOfRange22, label %87
+
+; <label>:87                                      ; preds = %82
+  %88 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 3, i32 %81
+  %89 = load i16, i16 addrspace(1)* %88, align 8
+  %90 = zext i16 %89 to i32
+  %91 = load i16, i16* %loc5
+  %92 = zext i16 %91 to i32
+  %93 = icmp eq i32 %90, %92
+  br i1 %93, label %106, label %94
+
+; <label>:94                                      ; preds = %87
+  %95 = load i32, i32* %loc4
+  %96 = add i32 %95, 1
+  store i32 %96, i32* %loc4
+  br label %97
+
+; <label>:97                                      ; preds = %74, %94
+  %98 = load i32, i32* %loc4
+  %99 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck15 = icmp eq %"System.Char[]" addrspace(1)* %99, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %100
+
+; <label>:100                                     ; preds = %97
+  %101 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %99, i32 0, i32 1
+  %102 = load i32, i32 addrspace(1)* %101
+  %103 = zext i32 %102 to i64
+  %104 = trunc i64 %103 to i32
+  %105 = icmp slt i32 %98, %104
+  br i1 %105, label %79, label %106
+
+; <label>:106                                     ; preds = %87, %100
+  %107 = load i32, i32* %loc4
+  %108 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck17 = icmp eq %"System.Char[]" addrspace(1)* %108, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %109
+
+; <label>:109                                     ; preds = %106
+  %110 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %108, i32 0, i32 1
+  %111 = load i32, i32 addrspace(1)* %110
+  %112 = zext i32 %111 to i64
+  %113 = trunc i64 %112 to i32
+  %114 = icmp eq i32 %107, %113
+  br i1 %114, label %122, label %115
+
+; <label>:115                                     ; preds = %109
+  %116 = load i32, i32* %loc0
+  %117 = sub i32 %116, 1
+  store i32 %117, i32* %loc0
+  br label %118
+
+; <label>:118                                     ; preds = %67, %115
+  %119 = load i32, i32* %loc0
+  %120 = load i32, i32* %loc1
+  %121 = icmp sge i32 %119, %120
+  br i1 %121, label %71, label %122
+
+; <label>:122                                     ; preds = %62, %109, %118
+  %123 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %124 = load i32, i32* %loc1
+  %125 = load i32, i32* %loc0
+  %126 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %123, i32 %124, i32 %125)
+  ret %System.String addrspace(1)* %126
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %97
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange22:                           ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
 Successfully read String.CreateTrimmedString
 
@@ -5439,8 +6893,8 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
@@ -5535,8 +6989,8 @@ entry:
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i64 2872
   %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
   %8 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %7
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %3
   %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
@@ -5553,8 +7007,8 @@ entry:
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 2864
   %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
   %21 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %20
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
-  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %22
 
 ; <label>:22                                      ; preds = %16
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
@@ -5569,7 +7023,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %16
+ThrowNullRef2:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5586,8 +7040,8 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5613,8 +7067,8 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
@@ -5632,8 +7086,8 @@ entry:
 
 ; <label>:12                                      ; preds = %4
   %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
@@ -5644,8 +7098,8 @@ entry:
 
 ; <label>:19                                      ; preds = %14
   %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %19
   %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
@@ -5660,21 +7114,21 @@ entry:
   %31 = zext i16 %30 to i32
   %32 = bitcast i8* %29 to i16*
   %33 = trunc i32 %31 to i16
-  %NullCheck6 = icmp ne i16* %32, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i16* %32, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %21
   store i16 %33, i16* %32, align 8
   %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %36
 
 ; <label>:36                                      ; preds = %34
   %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
   %38 = load i32, i32 addrspace(1)* %37, align 8
   %39 = add i32 %38, 1
-  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %40
 
 ; <label>:40                                      ; preds = %36
   %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
@@ -5683,16 +7137,16 @@ entry:
 
 ; <label>:42                                      ; preds = %14
   %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
-  br i1 %NullCheck12, label %44, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
   %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
   %47 = load i16, i16* %arg1
   %48 = zext i16 %47 to i32
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = trunc i32 %48 to i16
@@ -5703,31 +7157,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %19
+ThrowNullRef4:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %21
+ThrowNullRef6:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %36
+ThrowNullRef10:                                   ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %42
+ThrowNullRef12:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %44
+ThrowNullRef14:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5740,8 +7194,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -5752,8 +7206,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
@@ -5762,14 +7216,14 @@ entry:
 
 ; <label>:11                                      ; preds = %1
   %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
@@ -5779,15 +7233,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5808,8 +7262,8 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5822,8 +7276,8 @@ entry:
 
 ; <label>:8                                       ; preds = %3
   %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
@@ -5842,15 +7296,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
-  br i1 %NullCheck4, label %22, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
   %24 = load i16*, i16* addrspace(1)* %23, align 8
   %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %25, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
@@ -5859,8 +7313,8 @@ entry:
   store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
@@ -5874,8 +7328,8 @@ entry:
 
 ; <label>:37                                      ; preds = %65
   %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %37
   %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
@@ -5886,16 +7340,16 @@ entry:
   %45 = bitcast i16* %41 to i8*
   %46 = getelementptr inbounds i8, i8* %45, i64 %44
   %47 = bitcast i8* %46 to i16*
-  %NullCheck14 = icmp ne i16* %47, null
-  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %47, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %48
 
 ; <label>:48                                      ; preds = %39
   %49 = load i16, i16* %47, align 8
   %50 = zext i16 %49 to i32
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %52 = load i32, i32* %loc1
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %53
 
 ; <label>:53                                      ; preds = %48
   %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
@@ -5916,8 +7370,8 @@ entry:
 ; <label>:62                                      ; preds = %36, %59
   %63 = load i32, i32* %loc1
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck10, label %65, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %65
 
 ; <label>:65                                      ; preds = %62
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
@@ -5936,15 +7390,15 @@ entry:
 
 ; <label>:74                                      ; preds = %70
   %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
-  br i1 %NullCheck18, label %76, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %76
 
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
   %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
-  br i1 %NullCheck20, label %80, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
   %81 = load i64, i64 addrspace(1)* %79
@@ -5958,8 +7412,8 @@ entry:
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
   %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
-  br i1 %NullCheck22, label %92, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.String addrspace(1)* %90, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %92
 
 ; <label>:92                                      ; preds = %80
   %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
@@ -5969,15 +7423,15 @@ entry:
 
 ; <label>:96                                      ; preds = %70
   %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
-  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %98
 
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
   %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
-  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
   %103 = load i64, i64 addrspace(1)* %101
@@ -5991,8 +7445,8 @@ entry:
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
   %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
-  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.String addrspace(1)* %112, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %114
 
 ; <label>:114                                     ; preds = %102
   %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
@@ -6004,59 +7458,59 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %20
+ThrowNullRef4:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %22
+ThrowNullRef6:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %26
+ThrowNullRef8:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %62
+ThrowNullRef10:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %48
+ThrowNullRef16:                                   ; preds = %48
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %74
+ThrowNullRef18:                                   ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %76
+ThrowNullRef20:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %80
+ThrowNullRef22:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %96
+ThrowNullRef24:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %98
+ThrowNullRef26:                                   ; preds = %98
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %102
+ThrowNullRef28:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6069,15 +7523,15 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
   %3 = load i16*, i16* addrspace(1)* %2, align 8
   %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
@@ -6087,8 +7541,8 @@ entry:
   %10 = bitcast i16* %3 to i8*
   %11 = getelementptr inbounds i8, i8* %10, i64 %9
   %12 = bitcast i8* %11 to i16*
-  %NullCheck4 = icmp ne i16* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %5
   store i16 0, i16* %12, align 8
@@ -6098,11 +7552,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6119,8 +7573,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -6131,8 +7585,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
@@ -6144,15 +7598,15 @@ entry:
 
 ; <label>:14                                      ; preds = %1
   %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
   %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
   %21 = load i64, i64 addrspace(1)* %19
@@ -6171,15 +7625,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %14
+ThrowNullRef4:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %16
+ThrowNullRef6:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6302,14 +7756,6 @@ entry:
   ret %System.String addrspace(1)* %57
 }
 
-INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
-Successfully read RuntimeHelpers.get_OffsetToStringData
-
-define i32 @RuntimeHelpers.get_OffsetToStringData() {
-entry:
-  ret i32 12
-}
-
 INFO:  jitting method String::Equals using LLILCJit
 Successfully read String.Equals
 
@@ -6381,8 +7827,8 @@ entry:
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
-  br i1 %NullCheck24, label %29, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
   %30 = load i64, i64 addrspace(1)* %28
@@ -6397,8 +7843,8 @@ entry:
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
-  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
   %43 = load i64, i64 addrspace(1)* %41
@@ -6418,8 +7864,8 @@ entry:
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
   %59 = load i64, i64 addrspace(1)* %57
@@ -6434,8 +7880,8 @@ entry:
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck22, label %71, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
   %72 = load i64, i64 addrspace(1)* %70
@@ -6455,8 +7901,8 @@ entry:
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
-  br i1 %NullCheck16, label %87, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = load i64, i64 addrspace(1)* %86
@@ -6471,8 +7917,8 @@ entry:
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck18, label %100, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
   %101 = load i64, i64 addrspace(1)* %99
@@ -6492,8 +7938,8 @@ entry:
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
-  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
   %117 = load i64, i64 addrspace(1)* %115
@@ -6508,8 +7954,8 @@ entry:
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
-  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
   %130 = load i64, i64 addrspace(1)* %128
@@ -6528,15 +7974,15 @@ entry:
 
 ; <label>:142                                     ; preds = %22
   %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
-  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %143, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %144
 
 ; <label>:144                                     ; preds = %142
   %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
   %146 = load i32, i32 addrspace(1)* %145
   %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
-  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %147, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %148
 
 ; <label>:148                                     ; preds = %144
   %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
@@ -6557,15 +8003,15 @@ entry:
 
 ; <label>:159                                     ; preds = %22
   %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
-  br i1 %NullCheck, label %161, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %ThrowNullRef, label %161
 
 ; <label>:161                                     ; preds = %159
   %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
   %163 = load i32, i32 addrspace(1)* %162
   %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
-  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %164, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %165
 
 ; <label>:165                                     ; preds = %161
   %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
@@ -6578,8 +8024,8 @@ entry:
 
 ; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
-  br i1 %NullCheck4, label %172, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %171, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %172
 
 ; <label>:172                                     ; preds = %170
   %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
@@ -6589,8 +8035,8 @@ entry:
 
 ; <label>:176                                     ; preds = %172
   %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
-  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %177, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %178
 
 ; <label>:178                                     ; preds = %176
   %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
@@ -6629,55 +8075,55 @@ ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %161
+ThrowNullRef2:                                    ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %170
+ThrowNullRef4:                                    ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %176
+ThrowNullRef6:                                    ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %142
+ThrowNullRef8:                                    ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %144
+ThrowNullRef10:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %113
+ThrowNullRef12:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %116
+ThrowNullRef14:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %84
+ThrowNullRef16:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %87
+ThrowNullRef18:                                   ; preds = %87
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %55
+ThrowNullRef20:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %58
+ThrowNullRef22:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %26
+ThrowNullRef24:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %29
+ThrowNullRef26:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,8 +8161,8 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck, label %14, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %ThrowNullRef, label %14
 
 ; <label>:14                                      ; preds = %8
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
@@ -6760,8 +8206,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
@@ -6770,14 +8216,14 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32, i32* %loc0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %10
   %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
   %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
@@ -6790,15 +8236,15 @@ entry:
 ; <label>:25                                      ; preds = %19
   %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
-  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
   %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
@@ -6807,8 +8253,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %37 = load i32, i32* %loc0
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %38, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %38
 
 ; <label>:38                                      ; preds = %32
   %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
@@ -6817,14 +8263,14 @@ entry:
 
 ; <label>:40                                      ; preds = %19
   %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %40
   %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
   %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
-  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
-  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
@@ -6832,8 +8278,8 @@ entry:
   %48 = zext i32 %47 to i64
   %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
-  br i1 %NullCheck16, label %51, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %51
 
 ; <label>:51                                      ; preds = %45
   %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
@@ -6847,15 +8293,15 @@ entry:
 ; <label>:57                                      ; preds = %51
   %58 = load i16*, i16** %arg1
   %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
-  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %60
 
 ; <label>:60                                      ; preds = %57
   %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
   %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
-  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %64
 
 ; <label>:64                                      ; preds = %60
   %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
@@ -6864,22 +8310,22 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
   %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
-  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %70
 
 ; <label>:70                                      ; preds = %64
   %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
   %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
-  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
-  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
   %75 = load i32, i32 addrspace(1)* %74
   %76 = zext i32 %75 to i64
   %77 = trunc i64 %76 to i32
-  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
-  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %78
 
 ; <label>:78                                      ; preds = %73
   %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
@@ -6901,8 +8347,8 @@ entry:
   %90 = bitcast i16* %86 to i8*
   %91 = getelementptr inbounds i8, i8* %90, i64 %89
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %93
 
 ; <label>:93                                      ; preds = %80
   %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
@@ -6912,8 +8358,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %99 = load i32, i32* %loc2
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %100
 
 ; <label>:100                                     ; preds = %93
   %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
@@ -6928,63 +8374,63 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %25
+ThrowNullRef6:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %32
+ThrowNullRef10:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %40
+ThrowNullRef12:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %45
+ThrowNullRef16:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %57
+ThrowNullRef18:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %60
+ThrowNullRef20:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %64
+ThrowNullRef22:                                   ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %70
+ThrowNullRef24:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %73
+ThrowNullRef26:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %80
+ThrowNullRef28:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %93
+ThrowNullRef30:                                   ; preds = %93
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7004,8 +8450,8 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
@@ -7033,43 +8479,43 @@ entry:
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %14
   %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
   %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   %28 = load i32, i32 addrspace(1)* %27, align 8
   %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
-  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %30
 
 ; <label>:30                                      ; preds = %26
   %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
   %32 = load i32, i32 addrspace(1)* %31, align 8
   %33 = add i32 %28, %32
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %34
 
 ; <label>:34                                      ; preds = %30
   %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   store i32 %33, i32 addrspace(1)* %35
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
   store i32 0, i32 addrspace(1)* %38
   %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %40
 
 ; <label>:40                                      ; preds = %37
   %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
@@ -7082,8 +8528,8 @@ entry:
 
 ; <label>:47                                      ; preds = %40
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
@@ -7098,8 +8544,8 @@ entry:
   %54 = load i32, i32* %loc0
   %55 = sext i32 %54 to i64
   %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
-  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %57
 
 ; <label>:57                                      ; preds = %52
   %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
@@ -7110,68 +8556,35 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %14
+ThrowNullRef2:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %23
+ThrowNullRef4:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %26
+ThrowNullRef6:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %30
+ThrowNullRef8:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %34
+ThrowNullRef10:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %47
+ThrowNullRef14:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %52
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-}
-
-INFO:  jitting method StringBuilder::get_Length using LLILCJit
-Successfully read StringBuilder.get_Length
-
-define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.StringBuilder addrspace(1)*
-  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
-  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
-
-; <label>:1                                       ; preds = %entry
-  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %3 = load i32, i32 addrspace(1)* %2, align 8
-  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
-
-; <label>:5                                       ; preds = %1
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = add i32 %3, %7
-  ret i32 %8
-
-ThrowNullRef:                                     ; preds = %entry
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef16:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7213,70 +8626,70 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
   %6 = load i32, i32 addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
   store i32 %6, i32 addrspace(1)* %8
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
   %13 = load i32, i32 addrspace(1)* %12, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
   store i32 %13, i32 addrspace(1)* %15
   %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
-  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %18
 
 ; <label>:18                                      ; preds = %14
   %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
   %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
   %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
   %34 = load i32, i32 addrspace(1)* %33, align 8
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
-  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
@@ -7287,39 +8700,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %28
+ThrowNullRef16:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %32
+ThrowNullRef18:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7455,13 +8868,13 @@ entry:
 ; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
@@ -7477,16 +8890,16 @@ entry:
 
 ; <label>:18                                      ; preds = %15
   %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
   store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
   %22 = load i32, i32* %loc0
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %24
 
 ; <label>:24                                      ; preds = %20
   %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
@@ -7498,13 +8911,13 @@ entry:
 ; <label>:28                                      ; preds = %15, %24
   %29 = load i32, i32* %arg1
   %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %31
   %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
@@ -7517,20 +8930,20 @@ entry:
   %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
-  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
   %46 = load i32, i32 addrspace(1)* %45, align 8
   %47 = sub i32 %40, %46
-  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
-  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i32 addrspace(1)* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %48
 
 ; <label>:48                                      ; preds = %44
   store i32 %47, i32 addrspace(1)* %39, align 8
@@ -7538,21 +8951,21 @@ entry:
 
 ; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
-  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %51
 
 ; <label>:51                                      ; preds = %49
   %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %53
 
 ; <label>:53                                      ; preds = %51
   %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
   %55 = load i32, i32 addrspace(1)* %54, align 8
   %56 = load i32, i32* %arg2
   %57 = sub i32 %55, %56
-  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %58
 
 ; <label>:58                                      ; preds = %53
   %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
@@ -7562,13 +8975,13 @@ entry:
 ; <label>:60                                      ; preds = %33, %58
   %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
   %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
-  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %63
 
 ; <label>:63                                      ; preds = %60
   %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
-  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
-  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
@@ -7578,15 +8991,15 @@ entry:
 
 ; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
-  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i32 addrspace(1)* %69, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %70
 
 ; <label>:70                                      ; preds = %68
   %71 = load i32, i32 addrspace(1)* %69, align 8
   store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
-  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
@@ -7596,8 +9009,8 @@ entry:
   store i32 %77, i32* %loc4
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
-  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %80
 
 ; <label>:80                                      ; preds = %73
   %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
@@ -7607,71 +9020,71 @@ entry:
 ; <label>:83                                      ; preds = %80
   store i32 0, i32* %loc3
   %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
-  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
-  br i1 %NullCheck26, label %88, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i32 addrspace(1)* %87, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %88
 
 ; <label>:88                                      ; preds = %85
   %89 = load i32, i32 addrspace(1)* %87, align 8
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
-  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %90
 
 ; <label>:90                                      ; preds = %88
   %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
   store i32 %89, i32 addrspace(1)* %91
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
-  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
-  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %96
 
 ; <label>:96                                      ; preds = %94
   %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
-  br i1 %NullCheck34, label %100, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %100
 
 ; <label>:100                                     ; preds = %96
   %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
-  br i1 %NullCheck36, label %102, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %102
 
 ; <label>:102                                     ; preds = %100
   %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
   %104 = load i32, i32 addrspace(1)* %103, align 8
   %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
-  br i1 %NullCheck38, label %106, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %106
 
 ; <label>:106                                     ; preds = %102
   %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
-  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
-  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %108
 
 ; <label>:108                                     ; preds = %106
   %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
   %110 = load i32, i32 addrspace(1)* %109, align 8
   %111 = add i32 %104, %110
-  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %112
 
 ; <label>:112                                     ; preds = %108
   %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
   store i32 %111, i32 addrspace(1)* %113
   %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
-  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i32 addrspace(1)* %114, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %115
 
 ; <label>:115                                     ; preds = %112
   %116 = load i32, i32 addrspace(1)* %114, align 8
@@ -7681,19 +9094,19 @@ entry:
 ; <label>:118                                     ; preds = %115
   %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
-  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %121
 
 ; <label>:121                                     ; preds = %118
   %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
-  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
-  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %123
 
 ; <label>:123                                     ; preds = %121
   %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
   %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
-  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
-  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %126
 
 ; <label>:126                                     ; preds = %123
   %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
@@ -7705,8 +9118,8 @@ entry:
 
 ; <label>:130                                     ; preds = %80, %115, %126
   %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %132
 
 ; <label>:132                                     ; preds = %130
   %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7715,8 +9128,8 @@ entry:
   %136 = load i32, i32* %loc3
   %137 = sub i32 %135, %136
   %138 = sub i32 %134, %137
-  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %139
 
 ; <label>:139                                     ; preds = %132
   %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7728,16 +9141,16 @@ entry:
 
 ; <label>:144                                     ; preds = %139
   %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
-  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %146
 
 ; <label>:146                                     ; preds = %144
   %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
   %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
   %149 = load i32, i32* %loc2
   %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
-  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %151
 
 ; <label>:151                                     ; preds = %146
   %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
@@ -7754,145 +9167,249 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %18
+ThrowNullRef4:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %31
+ThrowNullRef10:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %44
+ThrowNullRef16:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %68
+ThrowNullRef18:                                   ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %70
+ThrowNullRef20:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %73
+ThrowNullRef22:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %83
+ThrowNullRef24:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %85
+ThrowNullRef26:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %88
+ThrowNullRef28:                                   ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %90
+ThrowNullRef30:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %94
+ThrowNullRef32:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %96
+ThrowNullRef34:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %100
+ThrowNullRef36:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %102
+ThrowNullRef38:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %106
+ThrowNullRef40:                                   ; preds = %106
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %108
+ThrowNullRef42:                                   ; preds = %108
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %112
+ThrowNullRef44:                                   ; preds = %112
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %118
+ThrowNullRef46:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %121
+ThrowNullRef48:                                   ; preds = %121
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %123
+ThrowNullRef50:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %130
+ThrowNullRef52:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %132
+ThrowNullRef54:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %144
+ThrowNullRef56:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %146
+ThrowNullRef58:                                   ; preds = %146
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %60
+ThrowNullRef60:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %63
+ThrowNullRef62:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %49
+ThrowNullRef64:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %51
+ThrowNullRef66:                                   ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %53
+ThrowNullRef68:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(%"System.Char[]" addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %arg0 = alloca %"System.Char[]" addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store %"System.Char[]" addrspace(1)* %param0, %"System.Char[]" addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load i32, i32* %arg4
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %43, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %38, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg1
+  %13 = load i32, i32* %arg4
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %38, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %24 = load i32, i32* %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %35 = load i32, i32* %arg3
+  %36 = load i32, i32* %arg4
+  %37 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %37, %"System.Char[]" addrspace(1)* %34, i32 %35, i32 %36)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:38                                      ; preds = %5, %16
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Successfully read Buffer._Memmove
 
@@ -7914,7 +9431,7 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[loadElem]
+Failed to read AppDomain.SetDataHelper[storeElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -7923,8 +9440,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
@@ -7934,8 +9451,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
@@ -7947,15 +9464,15 @@ entry:
   %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
   %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
@@ -7966,15 +9483,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7992,7 +9509,79 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
-Failed to read Dictionary`2.TryGetValue[loadElemA]
+Successfully read Dictionary`2.TryGetValue
+
+define i8 @"Dictionary`2.TryGetValue"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)* addrspace(1)* %param2) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  %arg2 = alloca %System.__Canon addrspace(1)* addrspace(1)*
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  store %System.__Canon addrspace(1)* addrspace(1)* %param2, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  store i32 %2, i32* %loc0
+  %3 = load i32, i32* %loc0
+  %4 = icmp slt i32 %3, 0
+  br i1 %4, label %22, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 2
+  %10 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %9, align 8
+  %11 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = zext i32 %11 to i64
+  %BoundsCheck = icmp uge i64 %16, %15
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 3, i32 %11
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %20, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %6, %System.__Canon addrspace(1)* %21)
+  ret i8 1
+
+; <label>:22                                      ; preds = %entry
+  %23 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %23, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -8058,8 +9647,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
@@ -8091,8 +9680,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
@@ -8171,15 +9760,15 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck, label %19, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %ThrowNullRef, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
   %21 = load i32, i32 addrspace(1)* %20
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
@@ -8202,7 +9791,7 @@ ThrowNullRef:                                     ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %19
+ThrowNullRef2:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8248,8 +9837,8 @@ entry:
   %0 = alloca %System.AppDomainHandle
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %1 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %1, i32 0, i32 15
@@ -8269,8 +9858,8 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
@@ -8286,7 +9875,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -8299,8 +9888,8 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -8327,8 +9916,8 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
@@ -8352,8 +9941,8 @@ entry:
   %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
   store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
@@ -8363,8 +9952,8 @@ entry:
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
@@ -8374,8 +9963,8 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %9
   %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
@@ -8384,8 +9973,8 @@ entry:
 
 ; <label>:18                                      ; preds = %3, %16
   %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
@@ -8397,15 +9986,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %18
+ThrowNullRef6:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8418,8 +10007,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
@@ -8453,15 +10042,15 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
@@ -8473,7 +10062,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8481,7 +10070,7 @@ ThrowNullRef1:                                    ; preds = %1
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
 Failed to read Dictionary`2.System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
@@ -8506,8 +10095,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
@@ -8524,8 +10113,8 @@ entry:
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -8544,7 +10133,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8577,8 +10166,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = load i64, i64* %arg2
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = trunc i32 %3 to i8
@@ -8634,46 +10223,46 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
   %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
-  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
-  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
-  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
@@ -8684,27 +10273,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %20
+ThrowNullRef12:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8717,8 +10306,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -8756,22 +10345,22 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
   %9 = load i64, i64 addrspace(1)* %8, align 8
   %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
   %13 = load i64, i64 addrspace(1)* %12, align 8
   %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %11
   %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
@@ -8788,11 +10377,11 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8882,8 +10471,8 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
@@ -8900,8 +10489,8 @@ entry:
 ; <label>:8                                       ; preds = %1
   %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
   %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
@@ -8911,15 +10500,15 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
   %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
   %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
-  br i1 %NullCheck6, label %21, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
@@ -8946,15 +10535,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8992,15 +10581,15 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
   store i8 %3, i8 addrspace(1)* %5
   %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
@@ -9011,7 +10600,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9027,8 +10616,8 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -9041,8 +10630,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
@@ -9058,7 +10647,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9080,8 +10669,8 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
@@ -9096,8 +10685,8 @@ entry:
 ; <label>:12                                      ; preds = %6
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
@@ -9112,8 +10701,8 @@ entry:
 ; <label>:21                                      ; preds = %15
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
@@ -9128,8 +10717,8 @@ entry:
 ; <label>:30                                      ; preds = %24
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %31, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
@@ -9144,8 +10733,8 @@ entry:
 ; <label>:39                                      ; preds = %33
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
-  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %40, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %42
 
 ; <label>:42                                      ; preds = %39
   %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
@@ -9164,19 +10753,19 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %21
+ThrowNullRef4:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %30
+ThrowNullRef6:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %39
+ThrowNullRef8:                                    ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9243,8 +10832,8 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
@@ -9264,57 +10853,57 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
   store i8 0, i8 addrspace(1)* %2
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
   store i8 0, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
   store i8 0, i8 addrspace(1)* %17
   %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
   store i8 0, i8 addrspace(1)* %20
   %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
-  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
@@ -9325,31 +10914,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %19
+ThrowNullRef14:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9367,8 +10956,8 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
@@ -9380,8 +10969,8 @@ entry:
 
 ; <label>:9                                       ; preds = %4
   %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %9
   %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
@@ -9395,7 +10984,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef2:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9420,8 +11009,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
@@ -9512,8 +11101,8 @@ entry:
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
@@ -9524,8 +11113,8 @@ entry:
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = load i64, i64 addrspace(1)* %12
@@ -9537,8 +11126,8 @@ entry:
   %20 = load i64, i64* %19
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
-  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %13
   %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
@@ -9555,8 +11144,8 @@ entry:
 ; <label>:30                                      ; preds = %25
   %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %32 = load i32, i32* %arg2
-  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
-  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
@@ -9570,15 +11159,15 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %30
+ThrowNullRef2:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9622,87 +11211,87 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
   %10 = load i8, i8 addrspace(1)* %9, align 8
   %11 = zext i8 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %8
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
   store i8 %12, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
   %19 = load i8, i8 addrspace(1)* %18, align 8
   %20 = zext i8 %19 to i32
   %21 = trunc i32 %20 to i8
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
   store i8 %21, i8 addrspace(1)* %23
   %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
   %28 = load i8, i8 addrspace(1)* %27, align 8
   %29 = zext i8 %28 to i32
   %30 = trunc i32 %29 to i8
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
-  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %31
 
 ; <label>:31                                      ; preds = %26
   %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
   store i8 %30, i8 addrspace(1)* %32
   %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
-  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
-  br i1 %NullCheck14, label %40, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %40
 
 ; <label>:40                                      ; preds = %35
   %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
   store i8 %39, i8 addrspace(1)* %41
   %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
-  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %44
 
 ; <label>:44                                      ; preds = %40
   %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
   %46 = load i8, i8 addrspace(1)* %45, align 8
   %47 = zext i8 %46 to i32
   %48 = trunc i32 %47 to i8
-  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
   store i8 %48, i8 addrspace(1)* %50
   %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
-  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
@@ -9713,29 +11302,29 @@ entry:
 ; <label>:56                                      ; preds = %52
   %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
-  br i1 %NullCheck22, label %59, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
   %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
   %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
-  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
-  br i1 %NullCheck24, label %63, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
   %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
-  br i1 %NullCheck26, label %66, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
   %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
-  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
-  br i1 %NullCheck28, label %69, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %69
 
 ; <label>:69                                      ; preds = %66
   %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
@@ -9744,15 +11333,15 @@ entry:
 
 ; <label>:71                                      ; preds = %105
   %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
-  br i1 %NullCheck34, label %73, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %73
 
 ; <label>:73                                      ; preds = %71
   %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
   %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
   %76 = load i32, i32* %loc0
-  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
-  br i1 %NullCheck36, label %77, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
@@ -9766,8 +11355,8 @@ entry:
 
 ; <label>:83                                      ; preds = %77
   %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
-  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
@@ -9775,14 +11364,14 @@ entry:
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
   %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
-  br i1 %NullCheck40, label %91, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
 ; <label>:91                                      ; preds = %85
   %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
   %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
-  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck42, label %94, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %94
 
 ; <label>:94                                      ; preds = %91
   %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
@@ -9798,14 +11387,14 @@ entry:
 ; <label>:99                                      ; preds = %69, %96
   %100 = load i32, i32* %loc0
   %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
-  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %102
 
 ; <label>:102                                     ; preds = %99
   %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
   %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
-  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
-  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
@@ -9819,87 +11408,87 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %26
+ThrowNullRef10:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %31
+ThrowNullRef12:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %35
+ThrowNullRef14:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %40
+ThrowNullRef16:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %56
+ThrowNullRef22:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %59
+ThrowNullRef24:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %63
+ThrowNullRef26:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %66
+ThrowNullRef28:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %102
+ThrowNullRef32:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %71
+ThrowNullRef34:                                   ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %73
+ThrowNullRef36:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %83
+ThrowNullRef38:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %85
+ThrowNullRef40:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %91
+ThrowNullRef42:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9943,15 +11532,15 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
   %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
@@ -9961,28 +11550,28 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
   %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %12
   %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
   %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
   %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
-  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
@@ -9993,23 +11582,23 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %12
+ThrowNullRef6:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10031,15 +11620,15 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
   %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = load i64, i64 addrspace(1)* %7
@@ -10077,13 +11666,13 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[loadElem]
+Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -10111,8 +11700,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -10181,8 +11770,8 @@ entry:
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load double, double* %arg0
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -10316,8 +11905,8 @@ entry:
   store i64 %param0, i64* %arg0
   store i64 %param1, i64* %arg1
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
@@ -10325,8 +11914,8 @@ entry:
   %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
   %5 = load i16*, i16* addrspace(1)* %4, align 8
   %6 = addrspacecast i64* %arg1 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = bitcast i64 addrspace(1)* %6 to i8 addrspace(1)*
@@ -10342,7 +11931,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10376,8 +11965,8 @@ entry:
   %1 = load i32, i32* %arg1
   %2 = sext i32 %1 to i64
   %3 = inttoptr i64 %2 to i16*
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -10430,8 +12019,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, i32)*)(%System.IO.ConsoleStream addrspace(1)* %2, i32 %1)
   %3 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %4 = load i64, i64* %arg1
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
@@ -10442,8 +12031,8 @@ entry:
   %10 = icmp eq i32 %9, 3
   %11 = sext i1 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %5
   %14 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, i32 0, i32 5
@@ -10454,7 +12043,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10477,8 +12066,8 @@ entry:
   %5 = icmp eq i32 %4, 1
   %6 = sext i1 %5 to i32
   %7 = trunc i32 %6 to i8
-  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %2, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.ConsoleStream addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
@@ -10489,8 +12078,8 @@ entry:
   %13 = icmp eq i32 %12, 2
   %14 = sext i1 %13 to i32
   %15 = trunc i32 %14 to i8
-  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %10, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.ConsoleStream addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %8
   %17 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %10, i32 0, i32 4
@@ -10501,7 +12090,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10540,8 +12129,8 @@ entry:
   %arg0 = alloca i64
   store i64 %param0, i64* %arg0
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
@@ -10576,8 +12165,8 @@ entry:
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
   %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = load i64, i64 addrspace(1)* %7
@@ -10681,7 +12270,127 @@ entry:
 INFO:  jitting method Encoding::GetEncoding using LLILCJit
 Failed to read Encoding.GetEncoding[convertToHelperArgumentType]
 INFO:  jitting method EncodingProvider::GetEncodingFromProvider using LLILCJit
-Failed to read EncodingProvider.GetEncodingFromProvider[loadElem]
+Successfully read EncodingProvider.GetEncodingFromProvider
+
+define %System.Text.Encoding addrspace(1)* @EncodingProvider.GetEncodingFromProvider(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca %"System.Text.EncodingProvider[]" addrspace(1)*
+  %loc1 = alloca %System.Text.EncodingProvider addrspace(1)*
+  %loc2 = alloca %System.Text.Encoding addrspace(1)*
+  %loc3 = alloca %System.Text.Encoding addrspace(1)*
+  %loc4 = alloca %"System.Text.EncodingProvider[]" addrspace(1)*
+  %loc5 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1059)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2392
+  %2 = addrspacecast i8 addrspace(1)* %1 to %"System.Text.EncodingProvider[]" addrspace(1)**
+  %3 = load volatile %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %2
+  %4 = icmp ne %"System.Text.EncodingProvider[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %entry
+  ret %System.Text.Encoding addrspace(1)* null
+
+; <label>:6                                       ; preds = %entry
+  %7 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1059)
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i64 2392
+  %9 = addrspacecast i8 addrspace(1)* %8 to %"System.Text.EncodingProvider[]" addrspace(1)**
+  %10 = load volatile %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %9
+  store %"System.Text.EncodingProvider[]" addrspace(1)* %10, %"System.Text.EncodingProvider[]" addrspace(1)** %loc0
+  %11 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc0
+  store %"System.Text.EncodingProvider[]" addrspace(1)* %11, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  store i32 0, i32* %loc5
+  br label %43
+
+; <label>:12                                      ; preds = %46
+  %13 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  %14 = load i32, i32* %loc5
+  %NullCheck1 = icmp eq %"System.Text.EncodingProvider[]" addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %13, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = zext i32 %17 to i64
+  %19 = zext i32 %14 to i64
+  %BoundsCheck = icmp uge i64 %19, %18
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %20
+
+; <label>:20                                      ; preds = %15
+  %21 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %13, i32 0, i32 3, i32 %14
+  %22 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)* addrspace(1)* %21, align 8
+  store %System.Text.EncodingProvider addrspace(1)* %22, %System.Text.EncodingProvider addrspace(1)** %loc1
+  %23 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)** %loc1
+  %24 = load i32, i32* %arg0
+  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i64 addrspace(1)*
+  %NullCheck3 = icmp eq i64 addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
+
+; <label>:26                                      ; preds = %20
+  %27 = load i64, i64 addrspace(1)* %25
+  %28 = add i64 %27, 64
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 40
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Text.Encoding addrspace(1)* (%System.Text.EncodingProvider addrspace(1)*, i32)*
+  %35 = call %System.Text.Encoding addrspace(1)* %34(%System.Text.EncodingProvider addrspace(1)* %23, i32 %24)
+  store %System.Text.Encoding addrspace(1)* %35, %System.Text.Encoding addrspace(1)** %loc2
+  %36 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc2
+  %37 = icmp eq %System.Text.Encoding addrspace(1)* %36, null
+  br i1 %37, label %40, label %38
+
+; <label>:38                                      ; preds = %26
+  %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc2
+  store %System.Text.Encoding addrspace(1)* %39, %System.Text.Encoding addrspace(1)** %loc3
+  br label %53
+
+; <label>:40                                      ; preds = %26
+  %41 = load i32, i32* %loc5
+  %42 = add i32 %41, 1
+  store i32 %42, i32* %loc5
+  br label %43
+
+; <label>:43                                      ; preds = %6, %40
+  %44 = load i32, i32* %loc5
+  %45 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  %NullCheck = icmp eq %"System.Text.EncodingProvider[]" addrspace(1)* %45, null
+  br i1 %NullCheck, label %ThrowNullRef, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp slt i32 %44, %50
+  br i1 %51, label %12, label %52
+
+; <label>:52                                      ; preds = %46
+  ret %System.Text.Encoding addrspace(1)* null
+
+; <label>:53                                      ; preds = %38
+  %54 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc3
+  ret %System.Text.Encoding addrspace(1)* %54
+
+ThrowNullRef:                                     ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method EncodingProvider::.cctor using LLILCJit
 Successfully read EncodingProvider..cctor
 
@@ -10700,7 +12409,7 @@ Failed to read Encoding.get_InternalSyncObject[Call HasTypeArg]
 INFO:  jitting method Hashtable::.ctor using LLILCJit
 Failed to read Hashtable..ctor[Volatile store]
 INFO:  jitting method Hashtable::get_Item using LLILCJit
-Failed to read Hashtable.get_Item[loadElemA]
+Failed to read Hashtable.get_Item[loadNonPrimitiveObj]
 INFO:  jitting method Hashtable::InitHash using LLILCJit
 Successfully read Hashtable.InitHash
 
@@ -10720,8 +12429,8 @@ entry:
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -10737,15 +12446,15 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
   %15 = load i32, i32* %loc0
-  %NullCheck2 = icmp ne i32 addrspace(1)* %14, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i32 addrspace(1)* %14, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %3
   store i32 %15, i32 addrspace(1)* %14, align 8
   %17 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %18 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %NullCheck4 = icmp ne i32 addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i32 addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = load i32, i32 addrspace(1)* %18, align 8
@@ -10754,8 +12463,8 @@ entry:
   %23 = sub i32 %22, 1
   %24 = urem i32 %21, %23
   %25 = add i32 1, %24
-  %NullCheck6 = icmp ne i32 addrspace(1)* %17, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32 addrspace(1)* %17, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %19
   store i32 %25, i32 addrspace(1)* %17, align 8
@@ -10766,15 +12475,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %19
+ThrowNullRef6:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10789,8 +12498,8 @@ entry:
   store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
   store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %NullCheck = icmp ne %System.Collections.Hashtable addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Collections.Hashtable addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
@@ -10800,16 +12509,16 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Collections.Hashtable addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Collections.Hashtable addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
   %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck4 = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %9, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
   %13 = inttoptr i64 %11 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
@@ -10819,8 +12528,8 @@ entry:
 ; <label>:15                                      ; preds = %1
   %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -10838,15 +12547,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10860,8 +12569,8 @@ entry:
   store %System.Int32 addrspace(1)* %param0, %System.Int32 addrspace(1)** %this
   %0 = load %System.Int32 addrspace(1)*, %System.Int32 addrspace(1)** %this
   %1 = bitcast %System.Int32 addrspace(1)* %0 to i32 addrspace(1)*
-  %NullCheck = icmp ne i32 addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq i32 addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load i32, i32 addrspace(1)* %1, align 8
@@ -10937,8 +12646,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.UTF8Encoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
@@ -10947,15 +12656,15 @@ entry:
   %9 = load i8, i8* %arg2
   %10 = zext i8 %9 to i32
   %11 = trunc i32 %10 to i8
-  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %8, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %6
   %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %8, i32 0, i32 8
   store i8 %11, i8 addrspace(1)* %13
   %14 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %14, i32 0, i32 8
@@ -10967,8 +12676,8 @@ entry:
 ; <label>:20                                      ; preds = %15
   %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %22, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %22, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = load i64, i64 addrspace(1)* %22
@@ -10990,15 +12699,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %12
+ThrowNullRef4:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11013,8 +12722,8 @@ entry:
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
@@ -11036,16 +12745,16 @@ entry:
 ; <label>:10                                      ; preds = %1
   %11 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
   %12 = load i32, i32* %arg1
-  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %11, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.Encoding addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
   store i32 %12, i32 addrspace(1)* %14
   %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
   %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = load i64, i64 addrspace(1)* %16
@@ -11063,11 +12772,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11080,8 +12789,8 @@ entry:
   %this = alloca %System.Text.UTF8Encoding addrspace(1)*
   store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
   %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.UTF8Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
@@ -11093,16 +12802,16 @@ entry:
 ; <label>:6                                       ; preds = %1
   %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %8 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %10, %System.Text.EncoderFallback addrspace(1)* %8)
   %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %12 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
-  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %11, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %11, i32 0, i32 3
@@ -11115,8 +12824,8 @@ entry:
   %18 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %18, %System.String addrspace(1)* %17)
   %19 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %18 to %System.Text.EncoderFallback addrspace(1)*
-  %NullCheck6 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %16, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %16, i32 0, i32 2
@@ -11126,8 +12835,8 @@ entry:
   %24 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %24, %System.String addrspace(1)* %23)
   %25 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %24 to %System.Text.DecoderFallback addrspace(1)*
-  %NullCheck8 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %22, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %22, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %20
   %27 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %22, i32 0, i32 3
@@ -11138,19 +12847,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %20
+ThrowNullRef8:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11180,8 +12889,8 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load i32, i32* %arg1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -11199,8 +12908,8 @@ entry:
 ; <label>:15                                      ; preds = %8
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %17 = load i32, i32* %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 %17
@@ -11216,7 +12925,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11268,7 +12977,7 @@ entry:
 }
 
 INFO:  jitting method Hashtable::Insert using LLILCJit
-Failed to read Hashtable.Insert[loadElemA]
+Failed to read Hashtable.Insert[storeElem]
 INFO:  jitting method ConsoleEncoding::.ctor using LLILCJit
 Successfully read ConsoleEncoding..ctor
 
@@ -11283,8 +12992,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %1)
   %2 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
@@ -11320,8 +13029,8 @@ entry:
   %2 = call %System.Text.InternalEncoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalEncoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %1)
   %3 = bitcast %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2 to %System.Text.EncoderFallback addrspace(1)*
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
@@ -11331,8 +13040,8 @@ entry:
   %8 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %7)
   %9 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %8 to %System.Text.DecoderFallback addrspace(1)*
-  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %6, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.Encoding addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %4
   %11 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %6, i32 0, i32 3
@@ -11343,7 +13052,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11362,15 +13071,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* %1)
   %2 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   %6 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, i32 0, i32 1
@@ -11381,7 +13090,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11409,8 +13118,8 @@ entry:
   store %System.Text.InternalDecoderBestFitFallback addrspace(1)* %param0, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
   %0 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
@@ -11420,15 +13129,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %4)
   %5 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %6)
   %9 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, i32 0, i32 1
@@ -11439,11 +13148,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11511,8 +13220,8 @@ entry:
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
   %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = load i64, i64 addrspace(1)* %19
@@ -11576,8 +13285,8 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.ConsoleStream addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
@@ -11608,31 +13317,31 @@ entry:
   store i8 %param4, i8* %arg4
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %3, %System.IO.Stream addrspace(1)* %1)
   %4 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %4, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
   %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %4, i32 0, i32 4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %5)
   %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %6
   %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
   %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
   %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = load i64, i64 addrspace(1)* %13
@@ -11644,8 +13353,8 @@ entry:
   %21 = load i64, i64* %20
   %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %8, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %8, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %14
   %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 5
@@ -11663,24 +13372,24 @@ entry:
   %31 = load i32, i32* %arg3
   %32 = sext i32 %31 to i64
   %33 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %32)
-  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %30, null
-  br i1 %NullCheck10, label %34, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.StreamWriter addrspace(1)* %30, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %35, %"System.Char[]" addrspace(1)* %33)
   %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %37, null
-  br i1 %NullCheck12, label %38, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.StreamWriter addrspace(1)* %37, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %38
 
 ; <label>:38                                      ; preds = %34
   %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
   %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
   %41 = load i32, i32* %arg3
   %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %42, null
-  br i1 %NullCheck14, label %43, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %42, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
   %44 = load i64, i64 addrspace(1)* %42
@@ -11694,30 +13403,30 @@ entry:
   %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
   %53 = sext i32 %52 to i64
   %54 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %53)
-  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
-  br i1 %NullCheck16, label %55, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %55
 
 ; <label>:55                                      ; preds = %43
   %56 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %56, %"System.Byte[]" addrspace(1)* %54)
   %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %58 = load i32, i32* %arg3
-  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %57, null
-  br i1 %NullCheck18, label %59, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.StreamWriter addrspace(1)* %57, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %59
 
 ; <label>:59                                      ; preds = %55
   %60 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 10
   store i32 %58, i32 addrspace(1)* %60
   %61 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %61, null
-  br i1 %NullCheck20, label %62, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.IO.StreamWriter addrspace(1)* %61, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %62
 
 ; <label>:62                                      ; preds = %59
   %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
   %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
   %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
   %67 = load i64, i64 addrspace(1)* %65
@@ -11735,15 +13444,15 @@ entry:
 
 ; <label>:78                                      ; preds = %66
   %79 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %79, null
-  br i1 %NullCheck24, label %80, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.StreamWriter addrspace(1)* %79, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %80
 
 ; <label>:80                                      ; preds = %78
   %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
   %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
   %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %83, null
-  br i1 %NullCheck26, label %84, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %83, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
   %85 = load i64, i64 addrspace(1)* %83
@@ -11760,8 +13469,8 @@ entry:
 
 ; <label>:95                                      ; preds = %84
   %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.IO.StreamWriter addrspace(1)* %96, null
-  br i1 %NullCheck28, label %97, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.IO.StreamWriter addrspace(1)* %96, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %97
 
 ; <label>:97                                      ; preds = %95
   %98 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 12
@@ -11775,8 +13484,8 @@ entry:
   %103 = icmp eq i32 %102, 0
   %104 = sext i1 %103 to i32
   %105 = trunc i32 %104 to i8
-  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %100, null
-  br i1 %NullCheck30, label %106, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.IO.StreamWriter addrspace(1)* %100, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %106
 
 ; <label>:106                                     ; preds = %99
   %107 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %100, i32 0, i32 13
@@ -11787,63 +13496,63 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %6
+ThrowNullRef4:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %29
+ThrowNullRef10:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %34
+ThrowNullRef12:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %38
+ThrowNullRef14:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %43
+ThrowNullRef16:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %55
+ThrowNullRef18:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %59
+ThrowNullRef20:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %62
+ThrowNullRef22:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %78
+ThrowNullRef24:                                   ; preds = %78
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %80
+ThrowNullRef26:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %95
+ThrowNullRef28:                                   ; preds = %95
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11856,15 +13565,15 @@ entry:
   %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = load i64, i64 addrspace(1)* %4
@@ -11882,7 +13591,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11932,35 +13641,35 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
   %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderNLS addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %7 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.EncoderNLS addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Text.Encoding addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.Encoding addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Text.EncoderNLS addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.EncoderNLS addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
   %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck8 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = load i64, i64 addrspace(1)* %16
@@ -11979,19 +13688,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12017,8 +13726,8 @@ entry:
   %this = alloca %System.Text.Encoding addrspace(1)*
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
@@ -12038,15 +13747,15 @@ entry:
   %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
   store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
   %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
   store i32 0, i32 addrspace(1)* %2
   %3 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, i32 0, i32 2
@@ -12056,15 +13765,15 @@ entry:
 
 ; <label>:8                                       ; preds = %4
   %9 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
   %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
   %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = load i64, i64 addrspace(1)* %13
@@ -12085,15 +13794,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12108,16 +13817,16 @@ entry:
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = load i32, i32* %arg1
   %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
   %7 = load i64, i64 addrspace(1)* %5
@@ -12135,7 +13844,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12172,8 +13881,8 @@ entry:
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
   %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
   %16 = load i64, i64 addrspace(1)* %14
@@ -12194,8 +13903,8 @@ entry:
   %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
   %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
   %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %31, null
-  br i1 %NullCheck2, label %32, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = load i64, i64 addrspace(1)* %31
@@ -12238,7 +13947,7 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12251,14 +13960,14 @@ entry:
   %this = alloca %System.Text.EncoderReplacementFallback addrspace(1)*
   store %System.Text.EncoderReplacementFallback addrspace(1)* %param0, %System.Text.EncoderReplacementFallback addrspace(1)** %this
   %0 = load %System.Text.EncoderReplacementFallback addrspace(1)*, %System.Text.EncoderReplacementFallback addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -12269,7 +13978,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12299,8 +14008,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
@@ -12332,8 +14041,8 @@ entry:
   %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
   store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
@@ -12345,8 +14054,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Threading.Tasks.Task addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %7)
@@ -12369,7 +14078,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12388,8 +14097,8 @@ entry:
   store i8 %param1, i8* %arg1
   store i8 %param2, i8* %arg2
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
@@ -12403,8 +14112,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1, %5
   %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 9
@@ -12435,8 +14144,8 @@ entry:
 
 ; <label>:25                                      ; preds = %8, %20
   %26 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %26, null
-  br i1 %NullCheck4, label %27, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %26, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %26, i32 0, i32 12
@@ -12447,22 +14156,22 @@ entry:
 
 ; <label>:32                                      ; preds = %27
   %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %33, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.IO.StreamWriter addrspace(1)* %33, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %32
   %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 12
   store i8 1, i8 addrspace(1)* %35
   %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
-  br i1 %NullCheck8, label %37, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
   %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
   %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck10 = icmp ne i64 addrspace(1)* %40, null
-  br i1 %NullCheck10, label %41, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64 addrspace(1)* %40, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i64, i64 addrspace(1)* %40
@@ -12476,8 +14185,8 @@ entry:
   %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
   store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
   %51 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %NullCheck12 = icmp ne %"System.Byte[]" addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Byte[]" addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %41
   %53 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %51, i32 0, i32 1
@@ -12489,16 +14198,16 @@ entry:
 
 ; <label>:58                                      ; preds = %52
   %59 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %59, null
-  br i1 %NullCheck14, label %60, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.IO.StreamWriter addrspace(1)* %59, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %60
 
 ; <label>:60                                      ; preds = %58
   %61 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %59, i32 0, i32 3
   %62 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
   %64 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %NullCheck16 = icmp ne %"System.Byte[]" addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %"System.Byte[]" addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %60
   %66 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %64, i32 0, i32 1
@@ -12506,8 +14215,8 @@ entry:
   %68 = zext i32 %67 to i64
   %69 = trunc i64 %68 to i32
   %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck18, label %71, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
   %72 = load i64, i64 addrspace(1)* %70
@@ -12523,29 +14232,29 @@ entry:
 
 ; <label>:80                                      ; preds = %27, %52, %71
   %81 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %81, null
-  br i1 %NullCheck20, label %82, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.IO.StreamWriter addrspace(1)* %81, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
 
 ; <label>:82                                      ; preds = %80
   %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %81, i32 0, i32 5
   %84 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %83, align 8
   %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.IO.StreamWriter addrspace(1)* %85, null
-  br i1 %NullCheck22, label %86, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.IO.StreamWriter addrspace(1)* %85, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %86
 
 ; <label>:86                                      ; preds = %82
   %87 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 7
   %88 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %87, align 8
   %89 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %89, null
-  br i1 %NullCheck24, label %90, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.StreamWriter addrspace(1)* %89, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %90
 
 ; <label>:90                                      ; preds = %86
   %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %89, i32 0, i32 9
   %92 = load i32, i32 addrspace(1)* %91, align 8
   %93 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.IO.StreamWriter addrspace(1)* %93, null
-  br i1 %NullCheck26, label %94, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.IO.StreamWriter addrspace(1)* %93, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %93, i32 0, i32 6
@@ -12553,8 +14262,8 @@ entry:
   %97 = load i8, i8* %arg2
   %98 = zext i8 %97 to i32
   %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
-  %NullCheck28 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck28, label %100, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
   %101 = load i64, i64 addrspace(1)* %99
@@ -12569,8 +14278,8 @@ entry:
   %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
   store i32 %110, i32* %loc1
   %111 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %111, null
-  br i1 %NullCheck30, label %112, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.IO.StreamWriter addrspace(1)* %111, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %112
 
 ; <label>:112                                     ; preds = %100
   %113 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %111, i32 0, i32 9
@@ -12581,23 +14290,23 @@ entry:
 
 ; <label>:116                                     ; preds = %112
   %117 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck32 = icmp ne %System.IO.StreamWriter addrspace(1)* %117, null
-  br i1 %NullCheck32, label %118, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.IO.StreamWriter addrspace(1)* %117, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %118
 
 ; <label>:118                                     ; preds = %116
   %119 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %117, i32 0, i32 3
   %120 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %119, align 8
   %121 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.IO.StreamWriter addrspace(1)* %121, null
-  br i1 %NullCheck34, label %122, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.IO.StreamWriter addrspace(1)* %121, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %122
 
 ; <label>:122                                     ; preds = %118
   %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
   %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
   %125 = load i32, i32* %loc1
   %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
-  %NullCheck36 = icmp ne i64 addrspace(1)* %126, null
-  br i1 %NullCheck36, label %127, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64 addrspace(1)* %126, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
   %128 = load i64, i64 addrspace(1)* %126
@@ -12619,15 +14328,15 @@ entry:
 
 ; <label>:140                                     ; preds = %136
   %141 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.IO.StreamWriter addrspace(1)* %141, null
-  br i1 %NullCheck38, label %142, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.IO.StreamWriter addrspace(1)* %141, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %142
 
 ; <label>:142                                     ; preds = %140
   %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
   %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
   %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
-  %NullCheck40 = icmp ne i64 addrspace(1)* %145, null
-  br i1 %NullCheck40, label %146, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i64 addrspace(1)* %145, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
   %147 = load i64, i64 addrspace(1)* %145
@@ -12648,83 +14357,83 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %25
+ThrowNullRef4:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %32
+ThrowNullRef6:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %37
+ThrowNullRef10:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %41
+ThrowNullRef12:                                   ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %58
+ThrowNullRef14:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %60
+ThrowNullRef16:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %65
+ThrowNullRef18:                                   ; preds = %65
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %80
+ThrowNullRef20:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %82
+ThrowNullRef22:                                   ; preds = %82
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %86
+ThrowNullRef24:                                   ; preds = %86
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %90
+ThrowNullRef26:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %94
+ThrowNullRef28:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %100
+ThrowNullRef30:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %116
+ThrowNullRef32:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %118
+ThrowNullRef34:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %122
+ThrowNullRef36:                                   ; preds = %122
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %140
+ThrowNullRef38:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %142
+ThrowNullRef40:                                   ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12791,8 +14500,8 @@ entry:
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %1 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
-  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
@@ -12800,8 +14509,8 @@ entry:
   %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
   %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
   %8 = load i64, i64 addrspace(1)* %6
@@ -12817,8 +14526,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %17, %System.IFormatProvider addrspace(1)* %16)
   %18 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %19 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %18, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.SyncTextWriter addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %7
   %21 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %18, i32 0, i32 4
@@ -12829,11 +14538,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12846,8 +14555,8 @@ entry:
   %this = alloca %System.IO.TextWriter addrspace(1)*
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.TextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
@@ -12857,8 +14566,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.Threading.Thread addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Threading.Thread addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %6)
@@ -12867,8 +14576,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1
   %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.TextWriter addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.TextWriter addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %11, i32 0, i32 2
@@ -12879,11 +14588,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13080,8 +14789,8 @@ entry:
   store double %param1, double* %arg1
   store i8 0, i8* %loc1
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
@@ -13091,16 +14800,16 @@ entry:
   %5 = addrspacecast i8* %loc1 to i8 addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %4, i8 addrspace(1)* %5)
   %6 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.SyncTextWriter addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
   %10 = load double, double* %arg1
   %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
   %13 = load i64, i64 addrspace(1)* %11
@@ -13135,11 +14844,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13156,8 +14865,8 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load double, double* %arg1
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -13171,8 +14880,8 @@ entry:
   call void %11(%System.IO.TextWriter addrspace(1)* %0, double %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
   %15 = load i64, i64 addrspace(1)* %13
@@ -13190,7 +14899,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13208,8 +14917,8 @@ entry:
   %1 = addrspacecast double* %arg1 to double addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -13224,8 +14933,8 @@ entry:
   %14 = bitcast double addrspace(1)* %1 to %System.Double addrspace(1)*
   %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Double addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Double addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
   %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
   %18 = load i64, i64 addrspace(1)* %16
@@ -13243,7 +14952,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13259,8 +14968,8 @@ entry:
   store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
   %0 = load %System.Double addrspace(1)*, %System.Double addrspace(1)** %this
   %1 = bitcast %System.Double addrspace(1)* %0 to double addrspace(1)*
-  %NullCheck = icmp ne double addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq double addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load double, double addrspace(1)* %1, align 8
@@ -13285,8 +14994,8 @@ entry:
   %loc0 = alloca %System.Globalization.NumberFormatInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 3
@@ -13296,8 +15005,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
@@ -13307,24 +15016,24 @@ entry:
   store %System.Globalization.NumberFormatInfo addrspace(1)* %10, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
   %11 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %7
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
   %15 = load i8, i8 addrspace(1)* %14, align 8
   %16 = zext i8 %15 to i32
   %17 = trunc i32 %16 to i8
-  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %11, null
-  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %11, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %13
   %19 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %11, i32 0, i32 29
   store i8 %17, i8 addrspace(1)* %19
   %20 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %21 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %20, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %20, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %18
   %23 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %20, i32 0, i32 3
@@ -13333,8 +15042,8 @@ entry:
 
 ; <label>:24                                      ; preds = %1, %22
   %25 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %25, null
-  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %25, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %26
 
 ; <label>:26                                      ; preds = %24
   %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %25, i32 0, i32 3
@@ -13345,23 +15054,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %18
+ThrowNullRef8:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13386,168 +15095,168 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 18
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %8, align 8
-  %NullCheck2 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %5, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %5, i32 0, i32 4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %9)
   %12 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 19
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %15, align 8
-  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %12, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %12, i32 0, i32 5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %16)
   %19 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %20 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %20, null
-  br i1 %NullCheck8, label %21, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %20, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %20, i32 0, i32 23
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  %NullCheck10 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %19, null
-  br i1 %NullCheck10, label %24, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %19, i32 0, i32 7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %25, %System.String addrspace(1)* %23)
   %26 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %27 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %27, i32 0, i32 22
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %29, align 8
-  %NullCheck14 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %26, null
-  br i1 %NullCheck14, label %31, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %26, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %26, i32 0, i32 6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %32, %System.String addrspace(1)* %30)
   %33 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %34 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Globalization.CultureData addrspace(1)* %34, null
-  br i1 %NullCheck16, label %35, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Globalization.CultureData addrspace(1)* %34, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %34, i32 0, i32 51
   %37 = load i32, i32 addrspace(1)* %36, align 8
-  %NullCheck18 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %33, null
-  br i1 %NullCheck18, label %38, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %33, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %33, i32 0, i32 21
   store i32 %37, i32 addrspace(1)* %39
   %40 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %41 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Globalization.CultureData addrspace(1)* %41, null
-  br i1 %NullCheck20, label %42, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Globalization.CultureData addrspace(1)* %41, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %41, i32 0, i32 52
   %44 = load i32, i32 addrspace(1)* %43, align 8
-  %NullCheck22 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %40, null
-  br i1 %NullCheck22, label %45, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %40, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %40, i32 0, i32 25
   store i32 %44, i32 addrspace(1)* %46
   %47 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %48 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.Globalization.CultureData addrspace(1)* %48, null
-  br i1 %NullCheck24, label %49, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Globalization.CultureData addrspace(1)* %48, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %49
 
 ; <label>:49                                      ; preds = %45
   %50 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %48, i32 0, i32 29
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck26 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %47, null
-  br i1 %NullCheck26, label %52, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %47, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %47, i32 0, i32 10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %53, %System.String addrspace(1)* %51)
   %54 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %55 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Globalization.CultureData addrspace(1)* %55, null
-  br i1 %NullCheck28, label %56, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Globalization.CultureData addrspace(1)* %55, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %56
 
 ; <label>:56                                      ; preds = %52
   %57 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %55, i32 0, i32 35
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %57, align 8
-  %NullCheck30 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %54, null
-  br i1 %NullCheck30, label %59, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %54, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %54, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %60, %System.String addrspace(1)* %58)
   %61 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %62 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck32 = icmp ne %System.Globalization.CultureData addrspace(1)* %62, null
-  br i1 %NullCheck32, label %63, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Globalization.CultureData addrspace(1)* %62, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %62, i32 0, i32 34
   %65 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %64, align 8
-  %NullCheck34 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %61, null
-  br i1 %NullCheck34, label %66, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %61, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %61, i32 0, i32 9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %67, %System.String addrspace(1)* %65)
   %68 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %69 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck36 = icmp ne %System.Globalization.CultureData addrspace(1)* %69, null
-  br i1 %NullCheck36, label %70, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Globalization.CultureData addrspace(1)* %69, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %70
 
 ; <label>:70                                      ; preds = %66
   %71 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %69, i32 0, i32 55
   %72 = load i32, i32 addrspace(1)* %71, align 8
-  %NullCheck38 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %68, null
-  br i1 %NullCheck38, label %73, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %68, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %68, i32 0, i32 22
   store i32 %72, i32 addrspace(1)* %74
   %75 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %76 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck40 = icmp ne %System.Globalization.CultureData addrspace(1)* %76, null
-  br i1 %NullCheck40, label %77, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Globalization.CultureData addrspace(1)* %76, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %76, i32 0, i32 57
   %79 = load i32, i32 addrspace(1)* %78, align 8
-  %NullCheck42 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %75, null
-  br i1 %NullCheck42, label %80, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %75, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %80
 
 ; <label>:80                                      ; preds = %77
   %81 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %75, i32 0, i32 24
   store i32 %79, i32 addrspace(1)* %81
   %82 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %83 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck44 = icmp ne %System.Globalization.CultureData addrspace(1)* %83, null
-  br i1 %NullCheck44, label %84, label %ThrowNullRef43
+  %NullCheck43 = icmp eq %System.Globalization.CultureData addrspace(1)* %83, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %84
 
 ; <label>:84                                      ; preds = %80
   %85 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %83, i32 0, i32 56
   %86 = load i32, i32 addrspace(1)* %85, align 8
-  %NullCheck46 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %82, null
-  br i1 %NullCheck46, label %87, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %82, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %82, i32 0, i32 23
@@ -13556,8 +15265,8 @@ entry:
 
 ; <label>:89                                      ; preds = %entry
   %90 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck100 = icmp ne %System.Globalization.CultureData addrspace(1)* %90, null
-  br i1 %NullCheck100, label %91, label %ThrowNullRef99
+  %NullCheck99 = icmp eq %System.Globalization.CultureData addrspace(1)* %90, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %91
 
 ; <label>:91                                      ; preds = %89
   %92 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %90, i32 0, i32 2
@@ -13575,8 +15284,8 @@ entry:
   %102 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %103 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %104 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %103)
-  %NullCheck48 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %102, null
-  br i1 %NullCheck48, label %105, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %102, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %105
 
 ; <label>:105                                     ; preds = %101
   %106 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %102, i32 0, i32 1
@@ -13584,8 +15293,8 @@ entry:
   %107 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %108 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %109 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %108)
-  %NullCheck50 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %107, null
-  br i1 %NullCheck50, label %110, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %107, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %110
 
 ; <label>:110                                     ; preds = %105
   %111 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %107, i32 0, i32 2
@@ -13593,8 +15302,8 @@ entry:
   %112 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %113 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %114 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %113)
-  %NullCheck52 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %112, null
-  br i1 %NullCheck52, label %115, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %112, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %115
 
 ; <label>:115                                     ; preds = %110
   %116 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %112, i32 0, i32 27
@@ -13602,8 +15311,8 @@ entry:
   %117 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %118 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %119 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %118)
-  %NullCheck54 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %117, null
-  br i1 %NullCheck54, label %120, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %117, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %120
 
 ; <label>:120                                     ; preds = %115
   %121 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %117, i32 0, i32 26
@@ -13611,8 +15320,8 @@ entry:
   %122 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %123 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %124 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %123)
-  %NullCheck56 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %122, null
-  br i1 %NullCheck56, label %125, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %122, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %125
 
 ; <label>:125                                     ; preds = %120
   %126 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %122, i32 0, i32 17
@@ -13620,8 +15329,8 @@ entry:
   %127 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %128 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %129 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %128)
-  %NullCheck58 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %127, null
-  br i1 %NullCheck58, label %130, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %127, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %130
 
 ; <label>:130                                     ; preds = %125
   %131 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %127, i32 0, i32 18
@@ -13629,8 +15338,8 @@ entry:
   %132 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %133 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %134 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %133)
-  %NullCheck60 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %132, null
-  br i1 %NullCheck60, label %135, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %132, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %135
 
 ; <label>:135                                     ; preds = %130
   %136 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %132, i32 0, i32 14
@@ -13638,8 +15347,8 @@ entry:
   %137 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %138 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %139 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %138)
-  %NullCheck62 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %137, null
-  br i1 %NullCheck62, label %140, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %137, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %140
 
 ; <label>:140                                     ; preds = %135
   %141 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %137, i32 0, i32 13
@@ -13647,71 +15356,71 @@ entry:
   %142 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %143 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %144 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %143)
-  %NullCheck64 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %142, null
-  br i1 %NullCheck64, label %145, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %142, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %145
 
 ; <label>:145                                     ; preds = %140
   %146 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %142, i32 0, i32 12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %146, %System.String addrspace(1)* %144)
   %147 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %148 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck66 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %148, null
-  br i1 %NullCheck66, label %149, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %148, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %149
 
 ; <label>:149                                     ; preds = %145
   %150 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %148, i32 0, i32 21
   %151 = load i32, i32 addrspace(1)* %150, align 8
-  %NullCheck68 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %147, null
-  br i1 %NullCheck68, label %152, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %147, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %152
 
 ; <label>:152                                     ; preds = %149
   %153 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %147, i32 0, i32 28
   store i32 %151, i32 addrspace(1)* %153
   %154 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %155 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck70 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %155, null
-  br i1 %NullCheck70, label %156, label %ThrowNullRef69
+  %NullCheck69 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %155, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %156
 
 ; <label>:156                                     ; preds = %152
   %157 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %155, i32 0, i32 6
   %158 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %157, align 8
-  %NullCheck72 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %154, null
-  br i1 %NullCheck72, label %159, label %ThrowNullRef71
+  %NullCheck71 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %154, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %159
 
 ; <label>:159                                     ; preds = %156
   %160 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %154, i32 0, i32 15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %160, %System.String addrspace(1)* %158)
   %161 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %162 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck74 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %162, null
-  br i1 %NullCheck74, label %163, label %ThrowNullRef73
+  %NullCheck73 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %162, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %163
 
 ; <label>:163                                     ; preds = %159
   %164 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %162, i32 0, i32 1
   %165 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %164, align 8
-  %NullCheck76 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %161, null
-  br i1 %NullCheck76, label %166, label %ThrowNullRef75
+  %NullCheck75 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %161, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %166
 
 ; <label>:166                                     ; preds = %163
   %167 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %161, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %167, %"System.Int32[]" addrspace(1)* %165)
   %168 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %169 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck78 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %169, null
-  br i1 %NullCheck78, label %170, label %ThrowNullRef77
+  %NullCheck77 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %169, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %170
 
 ; <label>:170                                     ; preds = %166
   %171 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %169, i32 0, i32 7
   %172 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %171, align 8
-  %NullCheck80 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %168, null
-  br i1 %NullCheck80, label %173, label %ThrowNullRef79
+  %NullCheck79 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %168, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %173
 
 ; <label>:173                                     ; preds = %170
   %174 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %168, i32 0, i32 16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %174, %System.String addrspace(1)* %172)
   %175 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck82 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %175, null
-  br i1 %NullCheck82, label %176, label %ThrowNullRef81
+  %NullCheck81 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %175, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %176
 
 ; <label>:176                                     ; preds = %173
   %177 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %175, i32 0, i32 4
@@ -13721,14 +15430,14 @@ entry:
 
 ; <label>:180                                     ; preds = %176
   %181 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck84 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %181, null
-  br i1 %NullCheck84, label %182, label %ThrowNullRef83
+  %NullCheck83 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %181, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %182
 
 ; <label>:182                                     ; preds = %180
   %183 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %181, i32 0, i32 4
   %184 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %183, align 8
-  %NullCheck86 = icmp ne %System.String addrspace(1)* %184, null
-  br i1 %NullCheck86, label %185, label %ThrowNullRef85
+  %NullCheck85 = icmp eq %System.String addrspace(1)* %184, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %185
 
 ; <label>:185                                     ; preds = %182
   %186 = getelementptr inbounds %System.String, %System.String addrspace(1)* %184, i32 0, i32 1
@@ -13739,8 +15448,8 @@ entry:
 ; <label>:189                                     ; preds = %176, %185
   %190 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck98 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %190, null
-  br i1 %NullCheck98, label %192, label %ThrowNullRef97
+  %NullCheck97 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %190, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %192
 
 ; <label>:192                                     ; preds = %189
   %193 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %190, i32 0, i32 4
@@ -13749,8 +15458,8 @@ entry:
 
 ; <label>:194                                     ; preds = %185, %192
   %195 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck88 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %195, null
-  br i1 %NullCheck88, label %196, label %ThrowNullRef87
+  %NullCheck87 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %195, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %196
 
 ; <label>:196                                     ; preds = %194
   %197 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %195, i32 0, i32 9
@@ -13760,14 +15469,14 @@ entry:
 
 ; <label>:200                                     ; preds = %196
   %201 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck90 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %201, null
-  br i1 %NullCheck90, label %202, label %ThrowNullRef89
+  %NullCheck89 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %201, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %202
 
 ; <label>:202                                     ; preds = %200
   %203 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %201, i32 0, i32 9
   %204 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %203, align 8
-  %NullCheck92 = icmp ne %System.String addrspace(1)* %204, null
-  br i1 %NullCheck92, label %205, label %ThrowNullRef91
+  %NullCheck91 = icmp eq %System.String addrspace(1)* %204, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %205
 
 ; <label>:205                                     ; preds = %202
   %206 = getelementptr inbounds %System.String, %System.String addrspace(1)* %204, i32 0, i32 1
@@ -13778,14 +15487,14 @@ entry:
 ; <label>:209                                     ; preds = %196, %205
   %210 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %211 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck94 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %211, null
-  br i1 %NullCheck94, label %212, label %ThrowNullRef93
+  %NullCheck93 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %211, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %212
 
 ; <label>:212                                     ; preds = %209
   %213 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %211, i32 0, i32 6
   %214 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %213, align 8
-  %NullCheck96 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %210, null
-  br i1 %NullCheck96, label %215, label %ThrowNullRef95
+  %NullCheck95 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %210, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %215
 
 ; <label>:215                                     ; preds = %212
   %216 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %210, i32 0, i32 9
@@ -13799,203 +15508,203 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %17
+ThrowNullRef8:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %21
+ThrowNullRef10:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %24
+ThrowNullRef12:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %28
+ThrowNullRef14:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %31
+ThrowNullRef16:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %35
+ThrowNullRef18:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %38
+ThrowNullRef20:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %42
+ThrowNullRef22:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %45
+ThrowNullRef24:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %49
+ThrowNullRef26:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %52
+ThrowNullRef28:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %56
+ThrowNullRef30:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %59
+ThrowNullRef32:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %63
+ThrowNullRef34:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %66
+ThrowNullRef36:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %70
+ThrowNullRef38:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %73
+ThrowNullRef40:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %77
+ThrowNullRef42:                                   ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %80
+ThrowNullRef44:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %84
+ThrowNullRef46:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %101
+ThrowNullRef48:                                   ; preds = %101
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %105
+ThrowNullRef50:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %110
+ThrowNullRef52:                                   ; preds = %110
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %115
+ThrowNullRef54:                                   ; preds = %115
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %120
+ThrowNullRef56:                                   ; preds = %120
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %125
+ThrowNullRef58:                                   ; preds = %125
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %130
+ThrowNullRef60:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %135
+ThrowNullRef62:                                   ; preds = %135
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %140
+ThrowNullRef64:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %145
+ThrowNullRef66:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %149
+ThrowNullRef68:                                   ; preds = %149
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %152
+ThrowNullRef70:                                   ; preds = %152
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %156
+ThrowNullRef72:                                   ; preds = %156
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %159
+ThrowNullRef74:                                   ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %163
+ThrowNullRef76:                                   ; preds = %163
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %166
+ThrowNullRef78:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %170
+ThrowNullRef80:                                   ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %173
+ThrowNullRef82:                                   ; preds = %173
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %180
+ThrowNullRef84:                                   ; preds = %180
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %182
+ThrowNullRef86:                                   ; preds = %182
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %194
+ThrowNullRef88:                                   ; preds = %194
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %200
+ThrowNullRef90:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %202
+ThrowNullRef92:                                   ; preds = %202
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %209
+ThrowNullRef94:                                   ; preds = %209
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %212
+ThrowNullRef96:                                   ; preds = %212
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %189
+ThrowNullRef98:                                   ; preds = %189
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %89
+ThrowNullRef100:                                  ; preds = %89
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14023,8 +15732,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 21
@@ -14037,8 +15746,8 @@ entry:
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 16)
   %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 21
@@ -14047,8 +15756,8 @@ entry:
 
 ; <label>:12                                      ; preds = %1, %10
   %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 21
@@ -14059,11 +15768,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %12
+ThrowNullRef4:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14079,8 +15788,8 @@ entry:
   store i32 %param1, i32* %arg1
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %1 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
@@ -14147,8 +15856,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 33
@@ -14161,8 +15870,8 @@ entry:
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 24)
   %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 33
@@ -14171,8 +15880,8 @@ entry:
 
 ; <label>:12                                      ; preds = %1, %10
   %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 33
@@ -14183,11 +15892,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %12
+ThrowNullRef4:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14200,8 +15909,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 53
@@ -14213,8 +15922,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 116)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 53
@@ -14223,8 +15932,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 53
@@ -14235,11 +15944,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14268,8 +15977,8 @@ entry:
 
 ; <label>:7                                       ; preds = %entry, %4
   %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %7
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 2
@@ -14293,8 +16002,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 54
@@ -14306,8 +16015,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 117)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
@@ -14316,8 +16025,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 54
@@ -14328,11 +16037,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14345,8 +16054,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 27
@@ -14358,8 +16067,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 118)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 27
@@ -14368,8 +16077,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 27
@@ -14380,11 +16089,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14397,8 +16106,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 28
@@ -14410,8 +16119,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 119)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 28
@@ -14420,8 +16129,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 28
@@ -14432,11 +16141,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14449,8 +16158,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 26
@@ -14462,8 +16171,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 107)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 26
@@ -14472,8 +16181,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 26
@@ -14484,11 +16193,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14501,8 +16210,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 25
@@ -14514,8 +16223,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 106)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 25
@@ -14524,8 +16233,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 25
@@ -14536,11 +16245,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14553,8 +16262,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 24
@@ -14566,8 +16275,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 105)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 24
@@ -14576,8 +16285,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 24
@@ -14588,11 +16297,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14617,8 +16326,8 @@ entry:
   %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %3)
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %2
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -14629,15 +16338,15 @@ entry:
 
 ; <label>:8                                       ; preds = %62
   %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 9
   %12 = load i32, i32 addrspace(1)* %11, align 8
   %13 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.IO.StreamWriter addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %13, i32 0, i32 10
@@ -14652,15 +16361,15 @@ entry:
 
 ; <label>:20                                      ; preds = %14, %18
   %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
   %24 = load i32, i32 addrspace(1)* %23, align 8
   %25 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %25, null
-  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.StreamWriter addrspace(1)* %25, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %25, i32 0, i32 9
@@ -14681,36 +16390,36 @@ entry:
   %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %37 = load i32, i32* %loc1
   %38 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.StreamWriter addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %35
   %40 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %38, i32 0, i32 7
   %41 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %40, align 8
   %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
-  br i1 %NullCheck14, label %43, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %39
   %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 9
   %45 = load i32, i32 addrspace(1)* %44, align 8
   %46 = load i32, i32* %loc2
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %36, null
-  br i1 %NullCheck16, label %47, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %36, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %47
 
 ; <label>:47                                      ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %36, i32 %37, %"System.Char[]" addrspace(1)* %41, i32 %45, i32 %46)
   %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
   %51 = load i32, i32 addrspace(1)* %50, align 8
   %52 = load i32, i32* %loc2
   %53 = add i32 %51, %52
-  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
-  br i1 %NullCheck20, label %54, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %54
 
 ; <label>:54                                      ; preds = %49
   %55 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
@@ -14732,8 +16441,8 @@ entry:
 
 ; <label>:65                                      ; preds = %62
   %66 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %66, null
-  br i1 %NullCheck2, label %67, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %66, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %67
 
 ; <label>:67                                      ; preds = %65
   %68 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %66, i32 0, i32 11
@@ -14754,49 +16463,259 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %65
+ThrowNullRef2:                                    ; preds = %65
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %20
+ThrowNullRef8:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %22
+ThrowNullRef10:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %35
+ThrowNullRef12:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %43
+ThrowNullRef16:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %47
+ThrowNullRef18:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method String::CopyTo using LLILCJit
-Failed to read String.CopyTo[loadElemA]
+Successfully read String.CopyTo
+
+define void @String.CopyTo(%System.String addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  %loc1 = alloca i16 addrspace(1)*
+  %loc2 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %1 = icmp ne %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg4
+  %7 = icmp sge i32 %6, 0
+  br i1 %7, label %13, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  unreachable
+
+; <label>:13                                      ; preds = %5
+  %14 = load i32, i32* %arg1
+  %15 = icmp sge i32 %14, 0
+  br i1 %15, label %21, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %18)
+  %20 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %20, %System.String addrspace(1)* %17, %System.String addrspace(1)* %19)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %20) #0
+  unreachable
+
+; <label>:21                                      ; preds = %13
+  %22 = load i32, i32* %arg4
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck, label %ThrowNullRef, label %24
+
+; <label>:24                                      ; preds = %21
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load i32, i32* %arg1
+  %28 = sub i32 %26, %27
+  %29 = icmp sle i32 %22, %28
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34, %System.String addrspace(1)* %31, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %24
+  %36 = load i32, i32* %arg3
+  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %37, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
+
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
+  %40 = load i32, i32 addrspace(1)* %39
+  %41 = zext i32 %40 to i64
+  %42 = trunc i64 %41 to i32
+  %43 = load i32, i32* %arg4
+  %44 = sub i32 %42, %43
+  %45 = icmp sgt i32 %36, %44
+  br i1 %45, label %49, label %46
+
+; <label>:46                                      ; preds = %38
+  %47 = load i32, i32* %arg3
+  %48 = icmp sge i32 %47, 0
+  br i1 %48, label %54, label %49
+
+; <label>:49                                      ; preds = %38, %46
+  %50 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %52 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %51)
+  %53 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53, %System.String addrspace(1)* %50, %System.String addrspace(1)* %52)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53) #0
+  unreachable
+
+; <label>:54                                      ; preds = %46
+  %55 = load i32, i32* %arg4
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %97, label %57
+
+; <label>:57                                      ; preds = %54
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %59
+
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 2
+  %61 = bitcast [0 x i16] addrspace(1)* %60 to i16 addrspace(1)*
+  store i16 addrspace(1)* %61, i16 addrspace(1)** %loc0
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  store %"System.Char[]" addrspace(1)* %62, %"System.Char[]" addrspace(1)** %loc2
+  %63 = icmp eq %"System.Char[]" addrspace(1)* %62, null
+  br i1 %63, label %72, label %64
+
+; <label>:64                                      ; preds = %59
+  %65 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc2
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %65, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %66
+
+; <label>:66                                      ; preds = %64
+  %67 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %65, i32 0, i32 1
+  %68 = load i32, i32 addrspace(1)* %67
+  %69 = zext i32 %68 to i64
+  %70 = trunc i64 %69 to i32
+  %71 = icmp ne i32 %70, 0
+  br i1 %71, label %73, label %72
+
+; <label>:72                                      ; preds = %59, %66
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  br label %81
+
+; <label>:73                                      ; preds = %66
+  %74 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc2
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %74, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %75
+
+; <label>:75                                      ; preds = %73
+  %76 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %74, i32 0, i32 1
+  %77 = load i32, i32 addrspace(1)* %76
+  %78 = zext i32 %77 to i64
+  %BoundsCheck = icmp uge i64 0, %78
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %79
+
+; <label>:79                                      ; preds = %75
+  %80 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %74, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %80, i16 addrspace(1)** %loc1
+  br label %81
+
+; <label>:81                                      ; preds = %72, %79
+  %82 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %83 = ptrtoint i16 addrspace(1)* %82 to i64
+  %84 = load i32, i32* %arg3
+  %85 = sext i32 %84 to i64
+  %86 = mul i64 %85, 2
+  %87 = add i64 %83, %86
+  %88 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %89 = ptrtoint i16 addrspace(1)* %88 to i64
+  %90 = load i32, i32* %arg1
+  %91 = sext i32 %90 to i64
+  %92 = mul i64 %91, 2
+  %93 = add i64 %89, %92
+  %94 = load i32, i32* %arg4
+  %95 = inttoptr i64 %87 to i16*
+  %96 = inttoptr i64 %93 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %95, i16* %96, i32 %94)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  br label %97
+
+; <label>:97                                      ; preds = %54, %81
+  ret void
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
 Successfully read ConsoleEncoding.GetPreamble
 
@@ -14833,7 +16752,365 @@ entry:
 }
 
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[loadElemA]
+Successfully read EncoderNLS.GetBytes
+
+define i32 @EncoderNLS.GetBytes(%System.Text.EncoderNLS addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3, %"System.Byte[]" addrspace(1)* %param4, i32 %param5, i8 %param6) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %arg4 = alloca %"System.Byte[]" addrspace(1)*
+  %arg5 = alloca i32
+  %arg6 = alloca i8
+  %loc0 = alloca i32
+  %loc1 = alloca i16 addrspace(1)*
+  %loc2 = alloca i8 addrspace(1)*
+  %loc3 = alloca i32
+  %loc4 = alloca %"System.Char[]" addrspace(1)*
+  %loc5 = alloca %"System.Byte[]" addrspace(1)*
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  store %"System.Byte[]" addrspace(1)* %param4, %"System.Byte[]" addrspace(1)** %arg4
+  store i32 %param5, i32* %arg5
+  store i8 %param6, i8* %arg6
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %1 = icmp eq %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %17, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %7 = icmp eq %"System.Char[]" addrspace(1)* %6, null
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %12
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %12
+
+; <label>:12                                      ; preds = %8, %10
+  %13 = phi %System.String addrspace(1)* [ %9, %8 ], [ %11, %10 ]
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %14)
+  %16 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16, %System.String addrspace(1)* %13, %System.String addrspace(1)* %15)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16) #0
+  unreachable
+
+; <label>:17                                      ; preds = %2
+  %18 = load i32, i32* %arg2
+  %19 = icmp slt i32 %18, 0
+  br i1 %19, label %23, label %20
+
+; <label>:20                                      ; preds = %17
+  %21 = load i32, i32* %arg3
+  %22 = icmp sge i32 %21, 0
+  br i1 %22, label %35, label %23
+
+; <label>:23                                      ; preds = %17, %20
+  %24 = load i32, i32* %arg2
+  %25 = icmp slt i32 %24, 0
+  br i1 %25, label %28, label %26
+
+; <label>:26                                      ; preds = %23
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %30
+
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %30
+
+; <label>:30                                      ; preds = %26, %28
+  %31 = phi %System.String addrspace(1)* [ %27, %26 ], [ %29, %28 ]
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34, %System.String addrspace(1)* %31, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %20
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck, label %ThrowNullRef, label %37
+
+; <label>:37                                      ; preds = %35
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = load i32, i32* %arg2
+  %43 = sub i32 %41, %42
+  %44 = load i32, i32* %arg3
+  %45 = icmp sge i32 %43, %44
+  br i1 %45, label %51, label %46
+
+; <label>:46                                      ; preds = %37
+  %47 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %48 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %49 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %48)
+  %50 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %50, %System.String addrspace(1)* %47, %System.String addrspace(1)* %49)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %50) #0
+  unreachable
+
+; <label>:51                                      ; preds = %37
+  %52 = load i32, i32* %arg5
+  %53 = icmp slt i32 %52, 0
+  br i1 %53, label %63, label %54
+
+; <label>:54                                      ; preds = %51
+  %55 = load i32, i32* %arg5
+  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck1 = icmp eq %"System.Byte[]" addrspace(1)* %56, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %57
+
+; <label>:57                                      ; preds = %54
+  %58 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = zext i32 %59 to i64
+  %61 = trunc i64 %60 to i32
+  %62 = icmp sle i32 %55, %61
+  br i1 %62, label %68, label %63
+
+; <label>:63                                      ; preds = %51, %57
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %66 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %65)
+  %67 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %67, %System.String addrspace(1)* %64, %System.String addrspace(1)* %66)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %67) #0
+  unreachable
+
+; <label>:68                                      ; preds = %57
+  %69 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %69, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %69, i32 0, i32 1
+  %72 = load i32, i32 addrspace(1)* %71
+  %73 = zext i32 %72 to i64
+  %74 = trunc i64 %73 to i32
+  %75 = icmp ne i32 %74, 0
+  br i1 %75, label %78, label %76
+
+; <label>:76                                      ; preds = %70
+  %77 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1)
+  store %"System.Char[]" addrspace(1)* %77, %"System.Char[]" addrspace(1)** %arg1
+  br label %78
+
+; <label>:78                                      ; preds = %70, %76
+  %79 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck5 = icmp eq %"System.Byte[]" addrspace(1)* %79, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %80
+
+; <label>:80                                      ; preds = %78
+  %81 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %79, i32 0, i32 1
+  %82 = load i32, i32 addrspace(1)* %81
+  %83 = zext i32 %82 to i64
+  %84 = trunc i64 %83 to i32
+  %85 = load i32, i32* %arg5
+  %86 = sub i32 %84, %85
+  store i32 %86, i32* %loc0
+  %87 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck7 = icmp eq %"System.Byte[]" addrspace(1)* %87, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %88
+
+; <label>:88                                      ; preds = %80
+  %89 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %87, i32 0, i32 1
+  %90 = load i32, i32 addrspace(1)* %89
+  %91 = zext i32 %90 to i64
+  %92 = trunc i64 %91 to i32
+  %93 = icmp ne i32 %92, 0
+  br i1 %93, label %96, label %94
+
+; <label>:94                                      ; preds = %88
+  %95 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1)
+  store %"System.Byte[]" addrspace(1)* %95, %"System.Byte[]" addrspace(1)** %arg4
+  br label %96
+
+; <label>:96                                      ; preds = %88, %94
+  %97 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  store %"System.Char[]" addrspace(1)* %97, %"System.Char[]" addrspace(1)** %loc4
+  %98 = icmp eq %"System.Char[]" addrspace(1)* %97, null
+  br i1 %98, label %107, label %99
+
+; <label>:99                                      ; preds = %96
+  %100 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc4
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %100, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %101
+
+; <label>:101                                     ; preds = %99
+  %102 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %100, i32 0, i32 1
+  %103 = load i32, i32 addrspace(1)* %102
+  %104 = zext i32 %103 to i64
+  %105 = trunc i64 %104 to i32
+  %106 = icmp ne i32 %105, 0
+  br i1 %106, label %108, label %107
+
+; <label>:107                                     ; preds = %96, %101
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  br label %116
+
+; <label>:108                                     ; preds = %101
+  %109 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc4
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %109, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %110
+
+; <label>:110                                     ; preds = %108
+  %111 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %109, i32 0, i32 1
+  %112 = load i32, i32 addrspace(1)* %111
+  %113 = zext i32 %112 to i64
+  %BoundsCheck = icmp uge i64 0, %113
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %114
+
+; <label>:114                                     ; preds = %110
+  %115 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %109, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %115, i16 addrspace(1)** %loc1
+  br label %116
+
+; <label>:116                                     ; preds = %107, %114
+  %117 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  store %"System.Byte[]" addrspace(1)* %117, %"System.Byte[]" addrspace(1)** %loc5
+  %118 = icmp eq %"System.Byte[]" addrspace(1)* %117, null
+  br i1 %118, label %127, label %119
+
+; <label>:119                                     ; preds = %116
+  %120 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc5
+  %NullCheck13 = icmp eq %"System.Byte[]" addrspace(1)* %120, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %121
+
+; <label>:121                                     ; preds = %119
+  %122 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %120, i32 0, i32 1
+  %123 = load i32, i32 addrspace(1)* %122
+  %124 = zext i32 %123 to i64
+  %125 = trunc i64 %124 to i32
+  %126 = icmp ne i32 %125, 0
+  br i1 %126, label %128, label %127
+
+; <label>:127                                     ; preds = %116, %121
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc2
+  br label %136
+
+; <label>:128                                     ; preds = %121
+  %129 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc5
+  %NullCheck15 = icmp eq %"System.Byte[]" addrspace(1)* %129, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %130
+
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %129, i32 0, i32 1
+  %132 = load i32, i32 addrspace(1)* %131
+  %133 = zext i32 %132 to i64
+  %BoundsCheck17 = icmp uge i64 0, %133
+  br i1 %BoundsCheck17, label %ThrowIndexOutOfRange18, label %134
+
+; <label>:134                                     ; preds = %130
+  %135 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %129, i32 0, i32 3, i32 0
+  store i8 addrspace(1)* %135, i8 addrspace(1)** %loc2
+  br label %136
+
+; <label>:136                                     ; preds = %127, %134
+  %137 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %138 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %139 = ptrtoint i16 addrspace(1)* %138 to i64
+  %140 = load i32, i32* %arg2
+  %141 = sext i32 %140 to i64
+  %142 = mul i64 %141, 2
+  %143 = add i64 %139, %142
+  %144 = load i32, i32* %arg3
+  %145 = load i8 addrspace(1)*, i8 addrspace(1)** %loc2
+  %146 = ptrtoint i8 addrspace(1)* %145 to i64
+  %147 = load i32, i32* %arg5
+  %148 = sext i32 %147 to i64
+  %149 = add i64 %146, %148
+  %150 = load i32, i32* %loc0
+  %151 = load i8, i8* %arg6
+  %152 = zext i8 %151 to i32
+  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i64 addrspace(1)*
+  %NullCheck19 = icmp eq i64 addrspace(1)* %153, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %154
+
+; <label>:154                                     ; preds = %136
+  %155 = load i64, i64 addrspace(1)* %153
+  %156 = add i64 %155, 72
+  %157 = inttoptr i64 %156 to i64*
+  %158 = load i64, i64* %157
+  %159 = add i64 %158, 0
+  %160 = inttoptr i64 %159 to i64*
+  %161 = load i64, i64* %160
+  %162 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to %System.Text.Encoder addrspace(1)*
+  %163 = inttoptr i64 %143 to i16*
+  %164 = inttoptr i64 %149 to i8*
+  %165 = trunc i32 %152 to i8
+  %166 = inttoptr i64 %161 to i32 (%System.Text.Encoder addrspace(1)*, i16*, i32, i8*, i32, i8)*
+  %167 = call i32 %166(%System.Text.Encoder addrspace(1)* %162, i16* %163, i32 %144, i8* %164, i32 %150, i8 %165)
+  store i32 %167, i32* %loc3
+  br label %168
+
+; <label>:168                                     ; preds = %154
+  %169 = load i32, i32* %loc3
+  ret i32 %169
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %110
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %119
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange18:                           ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
 Successfully read EncoderNLS.GetBytes
 
@@ -14922,22 +17199,22 @@ entry:
   %40 = load i8, i8* %arg5
   %41 = zext i8 %40 to i32
   %42 = trunc i32 %41 to i8
-  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %39, null
-  br i1 %NullCheck, label %43, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderNLS addrspace(1)* %39, null
+  br i1 %NullCheck, label %ThrowNullRef, label %43
 
 ; <label>:43                                      ; preds = %38
   %44 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
   store i8 %42, i8 addrspace(1)* %44
   %45 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %45, null
-  br i1 %NullCheck2, label %46, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.EncoderNLS addrspace(1)* %45, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %46
 
 ; <label>:46                                      ; preds = %43
   %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %45, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %47
   %48 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.EncoderNLS addrspace(1)* %48, null
-  br i1 %NullCheck4, label %49, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.EncoderNLS addrspace(1)* %48, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %49
 
 ; <label>:49                                      ; preds = %46
   %50 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %48, i32 0, i32 3
@@ -14948,8 +17225,8 @@ entry:
   %55 = load i32, i32* %arg4
   %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck6, label %58, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
   %59 = load i64, i64 addrspace(1)* %57
@@ -14967,15 +17244,15 @@ ThrowNullRef:                                     ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %43
+ThrowNullRef2:                                    ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %46
+ThrowNullRef4:                                    ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %49
+ThrowNullRef6:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -15003,8 +17280,8 @@ entry:
   %4 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0 to %System.IO.ConsoleStream addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*)(%System.IO.ConsoleStream addrspace(1)* %4, %"System.Byte[]" addrspace(1)* %1, i32 %2, i32 %3)
   %5 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
@@ -15089,8 +17366,8 @@ entry:
 
 ; <label>:22                                      ; preds = %8
   %23 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %23, null
-  br i1 %NullCheck, label %24, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Byte[]" addrspace(1)* %23, null
+  br i1 %NullCheck, label %ThrowNullRef, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
@@ -15112,8 +17389,8 @@ entry:
 
 ; <label>:36                                      ; preds = %24
   %37 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %37, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.ConsoleStream addrspace(1)* %37, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %37, i32 0, i32 4
@@ -15134,13 +17411,138 @@ ThrowNullRef:                                     ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %36
+ThrowNullRef2:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
-Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
+Successfully read WindowsConsoleStream.WriteFileNative
+
+define i32 @WindowsConsoleStream.WriteFileNative(i64 %param0, %"System.Byte[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i64
+  %arg1 = alloca %"System.Byte[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i8 addrspace(1)*
+  %loc2 = alloca %"System.Byte[]" addrspace(1)*
+  %loc3 = alloca i32
+  store i64 %param0, i64* %arg0
+  store %"System.Byte[]" addrspace(1)* %param1, %"System.Byte[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Byte[]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = zext i32 %3 to i64
+  %5 = icmp ne i64 %4, 0
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %1
+  ret i32 0
+
+; <label>:7                                       ; preds = %1
+  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  store %"System.Byte[]" addrspace(1)* %8, %"System.Byte[]" addrspace(1)** %loc2
+  %9 = icmp eq %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %9, label %18, label %10
+
+; <label>:10                                      ; preds = %7
+  %11 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc2
+  %NullCheck1 = icmp eq %"System.Byte[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %11, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp ne i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %7, %12
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc1
+  br label %27
+
+; <label>:19                                      ; preds = %12
+  %20 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc2
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %20, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %BoundsCheck = icmp uge i64 0, %24
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %25
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %20, i32 0, i32 3, i32 0
+  store i8 addrspace(1)* %26, i8 addrspace(1)** %loc1
+  br label %27
+
+; <label>:27                                      ; preds = %18, %25
+  %28 = load i64, i64* %arg0
+  %29 = load i8 addrspace(1)*, i8 addrspace(1)** %loc1
+  %30 = ptrtoint i8 addrspace(1)* %29 to i64
+  %31 = load i32, i32* %arg2
+  %32 = sext i32 %31 to i64
+  %33 = add i64 %30, %32
+  %34 = load i32, i32* %arg3
+  %35 = addrspacecast i32* %loc3 to i32 addrspace(1)*
+  %36 = inttoptr i64 %33 to i8*
+  %37 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i8*, i32, i32 addrspace(1)*, i64)*)(i64 %28, i8* %36, i32 %34, i32 addrspace(1)* %35, i64 0)
+  %38 = icmp ugt i32 %37, 0
+  %39 = sext i1 %38 to i32
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc1
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %42, label %41
+
+; <label>:41                                      ; preds = %27
+  ret i32 0
+
+; <label>:42                                      ; preds = %27
+  %43 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  store i32 %43, i32* %loc0
+  %44 = load i32, i32* %loc0
+  %45 = icmp eq i32 %44, 232
+  br i1 %45, label %49, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = load i32, i32* %loc0
+  %48 = icmp ne i32 %47, 109
+  br i1 %48, label %50, label %49
+
+; <label>:49                                      ; preds = %42, %46
+  ret i32 0
+
+; <label>:50                                      ; preds = %46
+  %51 = load i32, i32* %loc0
+  ret i32 %51
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
 Successfully read WindowsConsoleStream.Flush
 
@@ -15149,8 +17551,8 @@ entry:
   %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
   store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
@@ -15185,8 +17587,8 @@ entry:
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
   %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load i64, i64 addrspace(1)* %1
@@ -15225,15 +17627,15 @@ entry:
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.TextWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
   %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %3, align 8
   %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
   %7 = load i64, i64 addrspace(1)* %5
@@ -15251,7 +17653,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -15280,8 +17682,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %4)
   store i32 0, i32* %loc0
   %5 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Char[]" addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
@@ -15293,15 +17695,15 @@ entry:
 
 ; <label>:11                                      ; preds = %69
   %12 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %12, i32 0, i32 9
   %15 = load i32, i32 addrspace(1)* %14, align 8
   %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.IO.StreamWriter addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %16, i32 0, i32 10
@@ -15316,15 +17718,15 @@ entry:
 
 ; <label>:23                                      ; preds = %17, %21
   %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %24, null
-  br i1 %NullCheck8, label %25, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %24, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 10
   %27 = load i32, i32 addrspace(1)* %26, align 8
   %28 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %28, null
-  br i1 %NullCheck10, label %29, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.StreamWriter addrspace(1)* %28, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %28, i32 0, i32 9
@@ -15346,15 +17748,15 @@ entry:
   %40 = load i32, i32* %loc0
   %41 = mul i32 %40, 2
   %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
-  br i1 %NullCheck12, label %43, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %43
 
 ; <label>:43                                      ; preds = %38
   %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 7
   %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %44, align 8
   %46 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %46, null
-  br i1 %NullCheck14, label %47, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.IO.StreamWriter addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %47
 
 ; <label>:47                                      ; preds = %43
   %48 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %46, i32 0, i32 9
@@ -15366,16 +17768,16 @@ entry:
   %54 = bitcast %"System.Char[]" addrspace(1)* %45 to %System.Array addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %53, i32 %41, %System.Array addrspace(1)* %54, i32 %50, i32 %52)
   %55 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
-  br i1 %NullCheck16, label %56, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %56
 
 ; <label>:56                                      ; preds = %47
   %57 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
   %58 = load i32, i32 addrspace(1)* %57, align 8
   %59 = load i32, i32* %loc2
   %60 = add i32 %58, %59
-  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
-  br i1 %NullCheck18, label %61, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %61
 
 ; <label>:61                                      ; preds = %56
   %62 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
@@ -15397,8 +17799,8 @@ entry:
 
 ; <label>:72                                      ; preds = %69
   %73 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %73, null
-  br i1 %NullCheck2, label %74, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %73, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %74
 
 ; <label>:74                                      ; preds = %72
   %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %73, i32 0, i32 11
@@ -15419,39 +17821,39 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %72
+ThrowNullRef2:                                    ; preds = %72
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %23
+ThrowNullRef8:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef10:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %43
+ThrowNullRef14:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %47
+ThrowNullRef16:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %56
+ThrowNullRef18:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Eq1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Eq1.error.txt
@@ -25,8 +25,8 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
@@ -40,8 +40,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
   %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
@@ -75,7 +75,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -90,8 +90,8 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %NullCheck = icmp ne i8 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = load i8, i8 addrspace(1)* %0, align 8
@@ -125,8 +125,8 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
@@ -159,8 +159,8 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -184,8 +184,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
   store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
@@ -195,8 +195,8 @@ entry:
 ; <label>:4                                       ; preds = %1
   %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
   %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
@@ -206,8 +206,8 @@ entry:
   %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
@@ -221,14 +221,14 @@ entry:
 
 ; <label>:17                                      ; preds = %14
   %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
   %21 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
@@ -238,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -249,8 +249,8 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
@@ -261,27 +261,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %30
+ThrowNullRef10:                                   ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -301,7 +301,89 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
-Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
+Successfully read AppDomainSetup.GetUnsecureApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.GetUnsecureApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %NullCheck = icmp eq %"System.String[]" addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %BoundsCheck = icmp uge i64 0, %5
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %6
+
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 3, i32 0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
+  ret %System.String addrspace(1)* %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_Value using LLILCJit
+Successfully read AppDomainSetup.get_Value
+
+define %"System.String[]" addrspace(1)* @AppDomainSetup.get_Value(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.String[]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 18)
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.String[]" addrspace(1)* addrspace(1)*, %"System.String[]" addrspace(1)*)*)(%"System.String[]" addrspace(1)* addrspace(1)* %9, %"System.String[]" addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %11, i32 0, i32 1
+  %14 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %13, align 8
+  ret %"System.String[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -319,8 +401,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -368,16 +450,16 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
   %5 = load i32, i32 addrspace(1)* %4
   %6 = sub i32 %5, 1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -389,7 +471,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -421,8 +503,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
@@ -456,8 +538,8 @@ entry:
 ; <label>:27                                      ; preds = %19
   %28 = load i32, i32* %arg1
   %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
-  br i1 %NullCheck2, label %30, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %29, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %30
 
 ; <label>:30                                      ; preds = %27
   %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
@@ -493,8 +575,8 @@ entry:
 ; <label>:49                                      ; preds = %46
   %50 = load i32, i32* %arg2
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck4, label %52, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
@@ -517,11 +599,11 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %27
+ThrowNullRef2:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %49
+ThrowNullRef4:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -544,16 +626,16 @@ entry:
   %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %0)
   store %System.String addrspace(1)* %1, %System.String addrspace(1)** %loc0
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 2
   %5 = bitcast [0 x i16] addrspace(1)* %4 to i16 addrspace(1)*
   store i16 addrspace(1)* %5, i16 addrspace(1)** %loc1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %3
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2
@@ -580,7 +662,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -691,15 +773,15 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %NullCheck132 = icmp ne i8* %21, null
-  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+  %NullCheck131 = icmp eq i8* %21, null
+  br i1 %NullCheck131, label %ThrowNullRef132, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = load i8, i8* %21, align 8
   %24 = zext i8 %23 to i32
   %25 = trunc i32 %24 to i8
-  %NullCheck134 = icmp ne i8* %20, null
-  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+  %NullCheck133 = icmp eq i8* %20, null
+  br i1 %NullCheck133, label %ThrowNullRef134, label %26
 
 ; <label>:26                                      ; preds = %22
   store i8 %25, i8* %20, align 8
@@ -709,16 +791,16 @@ entry:
   %28 = load i8*, i8** %arg0
   %29 = load i8*, i8** %arg1
   %30 = bitcast i8* %29 to i16*
-  %NullCheck128 = icmp ne i16* %30, null
-  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+  %NullCheck127 = icmp eq i16* %30, null
+  br i1 %NullCheck127, label %ThrowNullRef128, label %31
 
 ; <label>:31                                      ; preds = %27
   %32 = load i16, i16* %30, align 8
   %33 = sext i16 %32 to i32
   %34 = bitcast i8* %28 to i16*
   %35 = trunc i32 %33 to i16
-  %NullCheck130 = icmp ne i16* %34, null
-  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+  %NullCheck129 = icmp eq i16* %34, null
+  br i1 %NullCheck129, label %ThrowNullRef130, label %36
 
 ; <label>:36                                      ; preds = %31
   store i16 %35, i16* %34, align 8
@@ -728,16 +810,16 @@ entry:
   %38 = load i8*, i8** %arg0
   %39 = load i8*, i8** %arg1
   %40 = bitcast i8* %39 to i16*
-  %NullCheck120 = icmp ne i16* %40, null
-  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+  %NullCheck119 = icmp eq i16* %40, null
+  br i1 %NullCheck119, label %ThrowNullRef120, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i16, i16* %40, align 8
   %43 = sext i16 %42 to i32
   %44 = bitcast i8* %38 to i16*
   %45 = trunc i32 %43 to i16
-  %NullCheck122 = icmp ne i16* %44, null
-  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+  %NullCheck121 = icmp eq i16* %44, null
+  br i1 %NullCheck121, label %ThrowNullRef122, label %46
 
 ; <label>:46                                      ; preds = %41
   store i16 %45, i16* %44, align 8
@@ -745,15 +827,15 @@ entry:
   %48 = getelementptr inbounds i8, i8* %47, i64 2
   %49 = load i8*, i8** %arg1
   %50 = getelementptr inbounds i8, i8* %49, i64 2
-  %NullCheck124 = icmp ne i8* %50, null
-  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+  %NullCheck123 = icmp eq i8* %50, null
+  br i1 %NullCheck123, label %ThrowNullRef124, label %51
 
 ; <label>:51                                      ; preds = %46
   %52 = load i8, i8* %50, align 8
   %53 = zext i8 %52 to i32
   %54 = trunc i32 %53 to i8
-  %NullCheck126 = icmp ne i8* %48, null
-  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+  %NullCheck125 = icmp eq i8* %48, null
+  br i1 %NullCheck125, label %ThrowNullRef126, label %55
 
 ; <label>:55                                      ; preds = %51
   store i8 %54, i8* %48, align 8
@@ -763,14 +845,14 @@ entry:
   %57 = load i8*, i8** %arg0
   %58 = load i8*, i8** %arg1
   %59 = bitcast i8* %58 to i32*
-  %NullCheck116 = icmp ne i32* %59, null
-  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+  %NullCheck115 = icmp eq i32* %59, null
+  br i1 %NullCheck115, label %ThrowNullRef116, label %60
 
 ; <label>:60                                      ; preds = %56
   %61 = load i32, i32* %59, align 8
   %62 = bitcast i8* %57 to i32*
-  %NullCheck118 = icmp ne i32* %62, null
-  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+  %NullCheck117 = icmp eq i32* %62, null
+  br i1 %NullCheck117, label %ThrowNullRef118, label %63
 
 ; <label>:63                                      ; preds = %60
   store i32 %61, i32* %62, align 8
@@ -780,14 +862,14 @@ entry:
   %65 = load i8*, i8** %arg0
   %66 = load i8*, i8** %arg1
   %67 = bitcast i8* %66 to i32*
-  %NullCheck108 = icmp ne i32* %67, null
-  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+  %NullCheck107 = icmp eq i32* %67, null
+  br i1 %NullCheck107, label %ThrowNullRef108, label %68
 
 ; <label>:68                                      ; preds = %64
   %69 = load i32, i32* %67, align 8
   %70 = bitcast i8* %65 to i32*
-  %NullCheck110 = icmp ne i32* %70, null
-  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+  %NullCheck109 = icmp eq i32* %70, null
+  br i1 %NullCheck109, label %ThrowNullRef110, label %71
 
 ; <label>:71                                      ; preds = %68
   store i32 %69, i32* %70, align 8
@@ -795,15 +877,15 @@ entry:
   %73 = getelementptr inbounds i8, i8* %72, i64 4
   %74 = load i8*, i8** %arg1
   %75 = getelementptr inbounds i8, i8* %74, i64 4
-  %NullCheck112 = icmp ne i8* %75, null
-  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+  %NullCheck111 = icmp eq i8* %75, null
+  br i1 %NullCheck111, label %ThrowNullRef112, label %76
 
 ; <label>:76                                      ; preds = %71
   %77 = load i8, i8* %75, align 8
   %78 = zext i8 %77 to i32
   %79 = trunc i32 %78 to i8
-  %NullCheck114 = icmp ne i8* %73, null
-  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+  %NullCheck113 = icmp eq i8* %73, null
+  br i1 %NullCheck113, label %ThrowNullRef114, label %80
 
 ; <label>:80                                      ; preds = %76
   store i8 %79, i8* %73, align 8
@@ -813,14 +895,14 @@ entry:
   %82 = load i8*, i8** %arg0
   %83 = load i8*, i8** %arg1
   %84 = bitcast i8* %83 to i32*
-  %NullCheck100 = icmp ne i32* %84, null
-  br i1 %NullCheck100, label %85, label %ThrowNullRef99
+  %NullCheck99 = icmp eq i32* %84, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %85
 
 ; <label>:85                                      ; preds = %81
   %86 = load i32, i32* %84, align 8
   %87 = bitcast i8* %82 to i32*
-  %NullCheck102 = icmp ne i32* %87, null
-  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+  %NullCheck101 = icmp eq i32* %87, null
+  br i1 %NullCheck101, label %ThrowNullRef102, label %88
 
 ; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
@@ -829,16 +911,16 @@ entry:
   %91 = load i8*, i8** %arg1
   %92 = getelementptr inbounds i8, i8* %91, i64 4
   %93 = bitcast i8* %92 to i16*
-  %NullCheck104 = icmp ne i16* %93, null
-  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+  %NullCheck103 = icmp eq i16* %93, null
+  br i1 %NullCheck103, label %ThrowNullRef104, label %94
 
 ; <label>:94                                      ; preds = %88
   %95 = load i16, i16* %93, align 8
   %96 = sext i16 %95 to i32
   %97 = bitcast i8* %90 to i16*
   %98 = trunc i32 %96 to i16
-  %NullCheck106 = icmp ne i16* %97, null
-  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+  %NullCheck105 = icmp eq i16* %97, null
+  br i1 %NullCheck105, label %ThrowNullRef106, label %99
 
 ; <label>:99                                      ; preds = %94
   store i16 %98, i16* %97, align 8
@@ -848,14 +930,14 @@ entry:
   %101 = load i8*, i8** %arg0
   %102 = load i8*, i8** %arg1
   %103 = bitcast i8* %102 to i32*
-  %NullCheck88 = icmp ne i32* %103, null
-  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+  %NullCheck87 = icmp eq i32* %103, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %104
 
 ; <label>:104                                     ; preds = %100
   %105 = load i32, i32* %103, align 8
   %106 = bitcast i8* %101 to i32*
-  %NullCheck90 = icmp ne i32* %106, null
-  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+  %NullCheck89 = icmp eq i32* %106, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %107
 
 ; <label>:107                                     ; preds = %104
   store i32 %105, i32* %106, align 8
@@ -864,16 +946,16 @@ entry:
   %110 = load i8*, i8** %arg1
   %111 = getelementptr inbounds i8, i8* %110, i64 4
   %112 = bitcast i8* %111 to i16*
-  %NullCheck92 = icmp ne i16* %112, null
-  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+  %NullCheck91 = icmp eq i16* %112, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %113
 
 ; <label>:113                                     ; preds = %107
   %114 = load i16, i16* %112, align 8
   %115 = sext i16 %114 to i32
   %116 = bitcast i8* %109 to i16*
   %117 = trunc i32 %115 to i16
-  %NullCheck94 = icmp ne i16* %116, null
-  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+  %NullCheck93 = icmp eq i16* %116, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %118
 
 ; <label>:118                                     ; preds = %113
   store i16 %117, i16* %116, align 8
@@ -881,15 +963,15 @@ entry:
   %120 = getelementptr inbounds i8, i8* %119, i64 6
   %121 = load i8*, i8** %arg1
   %122 = getelementptr inbounds i8, i8* %121, i64 6
-  %NullCheck96 = icmp ne i8* %122, null
-  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+  %NullCheck95 = icmp eq i8* %122, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %123
 
 ; <label>:123                                     ; preds = %118
   %124 = load i8, i8* %122, align 8
   %125 = zext i8 %124 to i32
   %126 = trunc i32 %125 to i8
-  %NullCheck98 = icmp ne i8* %120, null
-  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+  %NullCheck97 = icmp eq i8* %120, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %127
 
 ; <label>:127                                     ; preds = %123
   store i8 %126, i8* %120, align 8
@@ -899,14 +981,14 @@ entry:
   %129 = load i8*, i8** %arg0
   %130 = load i8*, i8** %arg1
   %131 = bitcast i8* %130 to i64*
-  %NullCheck84 = icmp ne i64* %131, null
-  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+  %NullCheck83 = icmp eq i64* %131, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %132
 
 ; <label>:132                                     ; preds = %128
   %133 = load i64, i64* %131, align 8
   %134 = bitcast i8* %129 to i64*
-  %NullCheck86 = icmp ne i64* %134, null
-  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+  %NullCheck85 = icmp eq i64* %134, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %135
 
 ; <label>:135                                     ; preds = %132
   store i64 %133, i64* %134, align 8
@@ -916,14 +998,14 @@ entry:
   %137 = load i8*, i8** %arg0
   %138 = load i8*, i8** %arg1
   %139 = bitcast i8* %138 to i64*
-  %NullCheck76 = icmp ne i64* %139, null
-  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+  %NullCheck75 = icmp eq i64* %139, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %140
 
 ; <label>:140                                     ; preds = %136
   %141 = load i64, i64* %139, align 8
   %142 = bitcast i8* %137 to i64*
-  %NullCheck78 = icmp ne i64* %142, null
-  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+  %NullCheck77 = icmp eq i64* %142, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %143
 
 ; <label>:143                                     ; preds = %140
   store i64 %141, i64* %142, align 8
@@ -931,15 +1013,15 @@ entry:
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %NullCheck80 = icmp ne i8* %147, null
-  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+  %NullCheck79 = icmp eq i8* %147, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %148
 
 ; <label>:148                                     ; preds = %143
   %149 = load i8, i8* %147, align 8
   %150 = zext i8 %149 to i32
   %151 = trunc i32 %150 to i8
-  %NullCheck82 = icmp ne i8* %145, null
-  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+  %NullCheck81 = icmp eq i8* %145, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %152
 
 ; <label>:152                                     ; preds = %148
   store i8 %151, i8* %145, align 8
@@ -949,14 +1031,14 @@ entry:
   %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
   %156 = bitcast i8* %155 to i64*
-  %NullCheck68 = icmp ne i64* %156, null
-  br i1 %NullCheck68, label %157, label %ThrowNullRef67
+  %NullCheck67 = icmp eq i64* %156, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %157
 
 ; <label>:157                                     ; preds = %153
   %158 = load i64, i64* %156, align 8
   %159 = bitcast i8* %154 to i64*
-  %NullCheck70 = icmp ne i64* %159, null
-  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+  %NullCheck69 = icmp eq i64* %159, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %160
 
 ; <label>:160                                     ; preds = %157
   store i64 %158, i64* %159, align 8
@@ -965,16 +1047,16 @@ entry:
   %163 = load i8*, i8** %arg1
   %164 = getelementptr inbounds i8, i8* %163, i64 8
   %165 = bitcast i8* %164 to i16*
-  %NullCheck72 = icmp ne i16* %165, null
-  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+  %NullCheck71 = icmp eq i16* %165, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %166
 
 ; <label>:166                                     ; preds = %160
   %167 = load i16, i16* %165, align 8
   %168 = sext i16 %167 to i32
   %169 = bitcast i8* %162 to i16*
   %170 = trunc i32 %168 to i16
-  %NullCheck74 = icmp ne i16* %169, null
-  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+  %NullCheck73 = icmp eq i16* %169, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %171
 
 ; <label>:171                                     ; preds = %166
   store i16 %170, i16* %169, align 8
@@ -984,14 +1066,14 @@ entry:
   %173 = load i8*, i8** %arg0
   %174 = load i8*, i8** %arg1
   %175 = bitcast i8* %174 to i64*
-  %NullCheck56 = icmp ne i64* %175, null
-  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+  %NullCheck55 = icmp eq i64* %175, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %176
 
 ; <label>:176                                     ; preds = %172
   %177 = load i64, i64* %175, align 8
   %178 = bitcast i8* %173 to i64*
-  %NullCheck58 = icmp ne i64* %178, null
-  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+  %NullCheck57 = icmp eq i64* %178, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %179
 
 ; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
@@ -1000,16 +1082,16 @@ entry:
   %182 = load i8*, i8** %arg1
   %183 = getelementptr inbounds i8, i8* %182, i64 8
   %184 = bitcast i8* %183 to i16*
-  %NullCheck60 = icmp ne i16* %184, null
-  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+  %NullCheck59 = icmp eq i16* %184, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %185
 
 ; <label>:185                                     ; preds = %179
   %186 = load i16, i16* %184, align 8
   %187 = sext i16 %186 to i32
   %188 = bitcast i8* %181 to i16*
   %189 = trunc i32 %187 to i16
-  %NullCheck62 = icmp ne i16* %188, null
-  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+  %NullCheck61 = icmp eq i16* %188, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %190
 
 ; <label>:190                                     ; preds = %185
   store i16 %189, i16* %188, align 8
@@ -1017,15 +1099,15 @@ entry:
   %192 = getelementptr inbounds i8, i8* %191, i64 10
   %193 = load i8*, i8** %arg1
   %194 = getelementptr inbounds i8, i8* %193, i64 10
-  %NullCheck64 = icmp ne i8* %194, null
-  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+  %NullCheck63 = icmp eq i8* %194, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %195
 
 ; <label>:195                                     ; preds = %190
   %196 = load i8, i8* %194, align 8
   %197 = zext i8 %196 to i32
   %198 = trunc i32 %197 to i8
-  %NullCheck66 = icmp ne i8* %192, null
-  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+  %NullCheck65 = icmp eq i8* %192, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %199
 
 ; <label>:199                                     ; preds = %195
   store i8 %198, i8* %192, align 8
@@ -1035,14 +1117,14 @@ entry:
   %201 = load i8*, i8** %arg0
   %202 = load i8*, i8** %arg1
   %203 = bitcast i8* %202 to i64*
-  %NullCheck48 = icmp ne i64* %203, null
-  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+  %NullCheck47 = icmp eq i64* %203, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %204
 
 ; <label>:204                                     ; preds = %200
   %205 = load i64, i64* %203, align 8
   %206 = bitcast i8* %201 to i64*
-  %NullCheck50 = icmp ne i64* %206, null
-  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+  %NullCheck49 = icmp eq i64* %206, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %207
 
 ; <label>:207                                     ; preds = %204
   store i64 %205, i64* %206, align 8
@@ -1051,14 +1133,14 @@ entry:
   %210 = load i8*, i8** %arg1
   %211 = getelementptr inbounds i8, i8* %210, i64 8
   %212 = bitcast i8* %211 to i32*
-  %NullCheck52 = icmp ne i32* %212, null
-  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+  %NullCheck51 = icmp eq i32* %212, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %213
 
 ; <label>:213                                     ; preds = %207
   %214 = load i32, i32* %212, align 8
   %215 = bitcast i8* %209 to i32*
-  %NullCheck54 = icmp ne i32* %215, null
-  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+  %NullCheck53 = icmp eq i32* %215, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %216
 
 ; <label>:216                                     ; preds = %213
   store i32 %214, i32* %215, align 8
@@ -1068,14 +1150,14 @@ entry:
   %218 = load i8*, i8** %arg0
   %219 = load i8*, i8** %arg1
   %220 = bitcast i8* %219 to i64*
-  %NullCheck36 = icmp ne i64* %220, null
-  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64* %220, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %221
 
 ; <label>:221                                     ; preds = %217
   %222 = load i64, i64* %220, align 8
   %223 = bitcast i8* %218 to i64*
-  %NullCheck38 = icmp ne i64* %223, null
-  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+  %NullCheck37 = icmp eq i64* %223, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %224
 
 ; <label>:224                                     ; preds = %221
   store i64 %222, i64* %223, align 8
@@ -1084,14 +1166,14 @@ entry:
   %227 = load i8*, i8** %arg1
   %228 = getelementptr inbounds i8, i8* %227, i64 8
   %229 = bitcast i8* %228 to i32*
-  %NullCheck40 = icmp ne i32* %229, null
-  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i32* %229, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %230
 
 ; <label>:230                                     ; preds = %224
   %231 = load i32, i32* %229, align 8
   %232 = bitcast i8* %226 to i32*
-  %NullCheck42 = icmp ne i32* %232, null
-  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+  %NullCheck41 = icmp eq i32* %232, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %233
 
 ; <label>:233                                     ; preds = %230
   store i32 %231, i32* %232, align 8
@@ -1099,15 +1181,15 @@ entry:
   %235 = getelementptr inbounds i8, i8* %234, i64 12
   %236 = load i8*, i8** %arg1
   %237 = getelementptr inbounds i8, i8* %236, i64 12
-  %NullCheck44 = icmp ne i8* %237, null
-  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i8* %237, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %238
 
 ; <label>:238                                     ; preds = %233
   %239 = load i8, i8* %237, align 8
   %240 = zext i8 %239 to i32
   %241 = trunc i32 %240 to i8
-  %NullCheck46 = icmp ne i8* %235, null
-  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+  %NullCheck45 = icmp eq i8* %235, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %242
 
 ; <label>:242                                     ; preds = %238
   store i8 %241, i8* %235, align 8
@@ -1117,14 +1199,14 @@ entry:
   %244 = load i8*, i8** %arg0
   %245 = load i8*, i8** %arg1
   %246 = bitcast i8* %245 to i64*
-  %NullCheck24 = icmp ne i64* %246, null
-  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64* %246, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %247
 
 ; <label>:247                                     ; preds = %243
   %248 = load i64, i64* %246, align 8
   %249 = bitcast i8* %244 to i64*
-  %NullCheck26 = icmp ne i64* %249, null
-  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64* %249, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %250
 
 ; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
@@ -1133,14 +1215,14 @@ entry:
   %253 = load i8*, i8** %arg1
   %254 = getelementptr inbounds i8, i8* %253, i64 8
   %255 = bitcast i8* %254 to i32*
-  %NullCheck28 = icmp ne i32* %255, null
-  br i1 %NullCheck28, label %256, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i32* %255, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %256
 
 ; <label>:256                                     ; preds = %250
   %257 = load i32, i32* %255, align 8
   %258 = bitcast i8* %252 to i32*
-  %NullCheck30 = icmp ne i32* %258, null
-  br i1 %NullCheck30, label %259, label %ThrowNullRef29
+  %NullCheck29 = icmp eq i32* %258, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %259
 
 ; <label>:259                                     ; preds = %256
   store i32 %257, i32* %258, align 8
@@ -1149,16 +1231,16 @@ entry:
   %262 = load i8*, i8** %arg1
   %263 = getelementptr inbounds i8, i8* %262, i64 12
   %264 = bitcast i8* %263 to i16*
-  %NullCheck32 = icmp ne i16* %264, null
-  br i1 %NullCheck32, label %265, label %ThrowNullRef31
+  %NullCheck31 = icmp eq i16* %264, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %265
 
 ; <label>:265                                     ; preds = %259
   %266 = load i16, i16* %264, align 8
   %267 = sext i16 %266 to i32
   %268 = bitcast i8* %261 to i16*
   %269 = trunc i32 %267 to i16
-  %NullCheck34 = icmp ne i16* %268, null
-  br i1 %NullCheck34, label %270, label %ThrowNullRef33
+  %NullCheck33 = icmp eq i16* %268, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %270
 
 ; <label>:270                                     ; preds = %265
   store i16 %269, i16* %268, align 8
@@ -1168,14 +1250,14 @@ entry:
   %272 = load i8*, i8** %arg0
   %273 = load i8*, i8** %arg1
   %274 = bitcast i8* %273 to i64*
-  %NullCheck8 = icmp ne i64* %274, null
-  br i1 %NullCheck8, label %275, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64* %274, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %275
 
 ; <label>:275                                     ; preds = %271
   %276 = load i64, i64* %274, align 8
   %277 = bitcast i8* %272 to i64*
-  %NullCheck10 = icmp ne i64* %277, null
-  br i1 %NullCheck10, label %278, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %277, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %278
 
 ; <label>:278                                     ; preds = %275
   store i64 %276, i64* %277, align 8
@@ -1184,14 +1266,14 @@ entry:
   %281 = load i8*, i8** %arg1
   %282 = getelementptr inbounds i8, i8* %281, i64 8
   %283 = bitcast i8* %282 to i32*
-  %NullCheck12 = icmp ne i32* %283, null
-  br i1 %NullCheck12, label %284, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i32* %283, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %284
 
 ; <label>:284                                     ; preds = %278
   %285 = load i32, i32* %283, align 8
   %286 = bitcast i8* %280 to i32*
-  %NullCheck14 = icmp ne i32* %286, null
-  br i1 %NullCheck14, label %287, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i32* %286, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %287
 
 ; <label>:287                                     ; preds = %284
   store i32 %285, i32* %286, align 8
@@ -1200,16 +1282,16 @@ entry:
   %290 = load i8*, i8** %arg1
   %291 = getelementptr inbounds i8, i8* %290, i64 12
   %292 = bitcast i8* %291 to i16*
-  %NullCheck16 = icmp ne i16* %292, null
-  br i1 %NullCheck16, label %293, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i16* %292, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %293
 
 ; <label>:293                                     ; preds = %287
   %294 = load i16, i16* %292, align 8
   %295 = sext i16 %294 to i32
   %296 = bitcast i8* %289 to i16*
   %297 = trunc i32 %295 to i16
-  %NullCheck18 = icmp ne i16* %296, null
-  br i1 %NullCheck18, label %298, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i16* %296, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %298
 
 ; <label>:298                                     ; preds = %293
   store i16 %297, i16* %296, align 8
@@ -1217,15 +1299,15 @@ entry:
   %300 = getelementptr inbounds i8, i8* %299, i64 14
   %301 = load i8*, i8** %arg1
   %302 = getelementptr inbounds i8, i8* %301, i64 14
-  %NullCheck20 = icmp ne i8* %302, null
-  br i1 %NullCheck20, label %303, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i8* %302, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %303
 
 ; <label>:303                                     ; preds = %298
   %304 = load i8, i8* %302, align 8
   %305 = zext i8 %304 to i32
   %306 = trunc i32 %305 to i8
-  %NullCheck22 = icmp ne i8* %300, null
-  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i8* %300, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %307
 
 ; <label>:307                                     ; preds = %303
   store i8 %306, i8* %300, align 8
@@ -1235,14 +1317,14 @@ entry:
   %309 = load i8*, i8** %arg0
   %310 = load i8*, i8** %arg1
   %311 = bitcast i8* %310 to i64*
-  %NullCheck = icmp ne i64* %311, null
-  br i1 %NullCheck, label %312, label %ThrowNullRef
+  %NullCheck = icmp eq i64* %311, null
+  br i1 %NullCheck, label %ThrowNullRef, label %312
 
 ; <label>:312                                     ; preds = %308
   %313 = load i64, i64* %311, align 8
   %314 = bitcast i8* %309 to i64*
-  %NullCheck2 = icmp ne i64* %314, null
-  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64* %314, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %315
 
 ; <label>:315                                     ; preds = %312
   store i64 %313, i64* %314, align 8
@@ -1251,14 +1333,14 @@ entry:
   %318 = load i8*, i8** %arg1
   %319 = getelementptr inbounds i8, i8* %318, i64 8
   %320 = bitcast i8* %319 to i64*
-  %NullCheck4 = icmp ne i64* %320, null
-  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64* %320, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %321
 
 ; <label>:321                                     ; preds = %315
   %322 = load i64, i64* %320, align 8
   %323 = bitcast i8* %317 to i64*
-  %NullCheck6 = icmp ne i64* %323, null
-  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64* %323, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %324
 
 ; <label>:324                                     ; preds = %321
   store i64 %322, i64* %323, align 8
@@ -1286,15 +1368,15 @@ entry:
 ; <label>:338                                     ; preds = %333
   %339 = load i8*, i8** %arg0
   %340 = load i8*, i8** %arg1
-  %NullCheck136 = icmp ne i8* %340, null
-  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+  %NullCheck135 = icmp eq i8* %340, null
+  br i1 %NullCheck135, label %ThrowNullRef136, label %341
 
 ; <label>:341                                     ; preds = %338
   %342 = load i8, i8* %340, align 8
   %343 = zext i8 %342 to i32
   %344 = trunc i32 %343 to i8
-  %NullCheck138 = icmp ne i8* %339, null
-  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+  %NullCheck137 = icmp eq i8* %339, null
+  br i1 %NullCheck137, label %ThrowNullRef138, label %345
 
 ; <label>:345                                     ; preds = %341
   store i8 %344, i8* %339, align 8
@@ -1317,16 +1399,16 @@ entry:
   %357 = load i8*, i8** %arg0
   %358 = load i8*, i8** %arg1
   %359 = bitcast i8* %358 to i16*
-  %NullCheck140 = icmp ne i16* %359, null
-  br i1 %NullCheck140, label %360, label %ThrowNullRef139
+  %NullCheck139 = icmp eq i16* %359, null
+  br i1 %NullCheck139, label %ThrowNullRef140, label %360
 
 ; <label>:360                                     ; preds = %356
   %361 = load i16, i16* %359, align 8
   %362 = sext i16 %361 to i32
   %363 = bitcast i8* %357 to i16*
   %364 = trunc i32 %362 to i16
-  %NullCheck142 = icmp ne i16* %363, null
-  br i1 %NullCheck142, label %365, label %ThrowNullRef141
+  %NullCheck141 = icmp eq i16* %363, null
+  br i1 %NullCheck141, label %ThrowNullRef142, label %365
 
 ; <label>:365                                     ; preds = %360
   store i16 %364, i16* %363, align 8
@@ -1352,14 +1434,14 @@ entry:
   %378 = load i8*, i8** %arg0
   %379 = load i8*, i8** %arg1
   %380 = bitcast i8* %379 to i32*
-  %NullCheck144 = icmp ne i32* %380, null
-  br i1 %NullCheck144, label %381, label %ThrowNullRef143
+  %NullCheck143 = icmp eq i32* %380, null
+  br i1 %NullCheck143, label %ThrowNullRef144, label %381
 
 ; <label>:381                                     ; preds = %377
   %382 = load i32, i32* %380, align 8
   %383 = bitcast i8* %378 to i32*
-  %NullCheck146 = icmp ne i32* %383, null
-  br i1 %NullCheck146, label %384, label %ThrowNullRef145
+  %NullCheck145 = icmp eq i32* %383, null
+  br i1 %NullCheck145, label %ThrowNullRef146, label %384
 
 ; <label>:384                                     ; preds = %381
   store i32 %382, i32* %383, align 8
@@ -1384,14 +1466,14 @@ entry:
   %395 = load i8*, i8** %arg0
   %396 = load i8*, i8** %arg1
   %397 = bitcast i8* %396 to i64*
-  %NullCheck164 = icmp ne i64* %397, null
-  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+  %NullCheck163 = icmp eq i64* %397, null
+  br i1 %NullCheck163, label %ThrowNullRef164, label %398
 
 ; <label>:398                                     ; preds = %394
   %399 = load i64, i64* %397, align 8
   %400 = bitcast i8* %395 to i64*
-  %NullCheck166 = icmp ne i64* %400, null
-  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+  %NullCheck165 = icmp eq i64* %400, null
+  br i1 %NullCheck165, label %ThrowNullRef166, label %401
 
 ; <label>:401                                     ; preds = %398
   store i64 %399, i64* %400, align 8
@@ -1400,14 +1482,14 @@ entry:
   %404 = load i8*, i8** %arg1
   %405 = getelementptr inbounds i8, i8* %404, i64 8
   %406 = bitcast i8* %405 to i64*
-  %NullCheck168 = icmp ne i64* %406, null
-  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+  %NullCheck167 = icmp eq i64* %406, null
+  br i1 %NullCheck167, label %ThrowNullRef168, label %407
 
 ; <label>:407                                     ; preds = %401
   %408 = load i64, i64* %406, align 8
   %409 = bitcast i8* %403 to i64*
-  %NullCheck170 = icmp ne i64* %409, null
-  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+  %NullCheck169 = icmp eq i64* %409, null
+  br i1 %NullCheck169, label %ThrowNullRef170, label %410
 
 ; <label>:410                                     ; preds = %407
   store i64 %408, i64* %409, align 8
@@ -1437,14 +1519,14 @@ entry:
   %425 = load i8*, i8** %arg0
   %426 = load i8*, i8** %arg1
   %427 = bitcast i8* %426 to i64*
-  %NullCheck148 = icmp ne i64* %427, null
-  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+  %NullCheck147 = icmp eq i64* %427, null
+  br i1 %NullCheck147, label %ThrowNullRef148, label %428
 
 ; <label>:428                                     ; preds = %424
   %429 = load i64, i64* %427, align 8
   %430 = bitcast i8* %425 to i64*
-  %NullCheck150 = icmp ne i64* %430, null
-  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+  %NullCheck149 = icmp eq i64* %430, null
+  br i1 %NullCheck149, label %ThrowNullRef150, label %431
 
 ; <label>:431                                     ; preds = %428
   store i64 %429, i64* %430, align 8
@@ -1466,14 +1548,14 @@ entry:
   %441 = load i8*, i8** %arg0
   %442 = load i8*, i8** %arg1
   %443 = bitcast i8* %442 to i32*
-  %NullCheck152 = icmp ne i32* %443, null
-  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+  %NullCheck151 = icmp eq i32* %443, null
+  br i1 %NullCheck151, label %ThrowNullRef152, label %444
 
 ; <label>:444                                     ; preds = %440
   %445 = load i32, i32* %443, align 8
   %446 = bitcast i8* %441 to i32*
-  %NullCheck154 = icmp ne i32* %446, null
-  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+  %NullCheck153 = icmp eq i32* %446, null
+  br i1 %NullCheck153, label %ThrowNullRef154, label %447
 
 ; <label>:447                                     ; preds = %444
   store i32 %445, i32* %446, align 8
@@ -1495,16 +1577,16 @@ entry:
   %457 = load i8*, i8** %arg0
   %458 = load i8*, i8** %arg1
   %459 = bitcast i8* %458 to i16*
-  %NullCheck156 = icmp ne i16* %459, null
-  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+  %NullCheck155 = icmp eq i16* %459, null
+  br i1 %NullCheck155, label %ThrowNullRef156, label %460
 
 ; <label>:460                                     ; preds = %456
   %461 = load i16, i16* %459, align 8
   %462 = sext i16 %461 to i32
   %463 = bitcast i8* %457 to i16*
   %464 = trunc i32 %462 to i16
-  %NullCheck158 = icmp ne i16* %463, null
-  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+  %NullCheck157 = icmp eq i16* %463, null
+  br i1 %NullCheck157, label %ThrowNullRef158, label %465
 
 ; <label>:465                                     ; preds = %460
   store i16 %464, i16* %463, align 8
@@ -1525,15 +1607,15 @@ entry:
 ; <label>:474                                     ; preds = %470
   %475 = load i8*, i8** %arg0
   %476 = load i8*, i8** %arg1
-  %NullCheck160 = icmp ne i8* %476, null
-  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+  %NullCheck159 = icmp eq i8* %476, null
+  br i1 %NullCheck159, label %ThrowNullRef160, label %477
 
 ; <label>:477                                     ; preds = %474
   %478 = load i8, i8* %476, align 8
   %479 = zext i8 %478 to i32
   %480 = trunc i32 %479 to i8
-  %NullCheck162 = icmp ne i8* %475, null
-  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+  %NullCheck161 = icmp eq i8* %475, null
+  br i1 %NullCheck161, label %ThrowNullRef162, label %481
 
 ; <label>:481                                     ; preds = %477
   store i8 %480, i8* %475, align 8
@@ -1553,343 +1635,343 @@ ThrowNullRef:                                     ; preds = %308
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %312
+ThrowNullRef2:                                    ; preds = %312
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %315
+ThrowNullRef4:                                    ; preds = %315
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %321
+ThrowNullRef6:                                    ; preds = %321
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %271
+ThrowNullRef8:                                    ; preds = %271
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %275
+ThrowNullRef10:                                   ; preds = %275
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %278
+ThrowNullRef12:                                   ; preds = %278
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %284
+ThrowNullRef14:                                   ; preds = %284
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %287
+ThrowNullRef16:                                   ; preds = %287
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %293
+ThrowNullRef18:                                   ; preds = %293
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %298
+ThrowNullRef20:                                   ; preds = %298
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %303
+ThrowNullRef22:                                   ; preds = %303
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %243
+ThrowNullRef24:                                   ; preds = %243
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %247
+ThrowNullRef26:                                   ; preds = %247
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %250
+ThrowNullRef28:                                   ; preds = %250
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %256
+ThrowNullRef30:                                   ; preds = %256
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %259
+ThrowNullRef32:                                   ; preds = %259
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %265
+ThrowNullRef34:                                   ; preds = %265
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %217
+ThrowNullRef36:                                   ; preds = %217
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %221
+ThrowNullRef38:                                   ; preds = %221
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %224
+ThrowNullRef40:                                   ; preds = %224
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %230
+ThrowNullRef42:                                   ; preds = %230
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %233
+ThrowNullRef44:                                   ; preds = %233
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %238
+ThrowNullRef46:                                   ; preds = %238
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %200
+ThrowNullRef48:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %204
+ThrowNullRef50:                                   ; preds = %204
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %207
+ThrowNullRef52:                                   ; preds = %207
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %213
+ThrowNullRef54:                                   ; preds = %213
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %172
+ThrowNullRef56:                                   ; preds = %172
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %176
+ThrowNullRef58:                                   ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %179
+ThrowNullRef60:                                   ; preds = %179
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %185
+ThrowNullRef62:                                   ; preds = %185
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %190
+ThrowNullRef64:                                   ; preds = %190
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %195
+ThrowNullRef66:                                   ; preds = %195
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %153
+ThrowNullRef68:                                   ; preds = %153
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %157
+ThrowNullRef70:                                   ; preds = %157
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %160
+ThrowNullRef72:                                   ; preds = %160
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %166
+ThrowNullRef74:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %136
+ThrowNullRef76:                                   ; preds = %136
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %140
+ThrowNullRef78:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %143
+ThrowNullRef80:                                   ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %148
+ThrowNullRef82:                                   ; preds = %148
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %128
+ThrowNullRef84:                                   ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %132
+ThrowNullRef86:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %100
+ThrowNullRef88:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %104
+ThrowNullRef90:                                   ; preds = %104
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %107
+ThrowNullRef92:                                   ; preds = %107
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %113
+ThrowNullRef94:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %118
+ThrowNullRef96:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %123
+ThrowNullRef98:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %81
+ThrowNullRef100:                                  ; preds = %81
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef101:                                  ; preds = %85
+ThrowNullRef102:                                  ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef103:                                  ; preds = %88
+ThrowNullRef104:                                  ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef105:                                  ; preds = %94
+ThrowNullRef106:                                  ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef107:                                  ; preds = %64
+ThrowNullRef108:                                  ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef109:                                  ; preds = %68
+ThrowNullRef110:                                  ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef111:                                  ; preds = %71
+ThrowNullRef112:                                  ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef113:                                  ; preds = %76
+ThrowNullRef114:                                  ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef115:                                  ; preds = %56
+ThrowNullRef116:                                  ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef117:                                  ; preds = %60
+ThrowNullRef118:                                  ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef119:                                  ; preds = %37
+ThrowNullRef120:                                  ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef121:                                  ; preds = %41
+ThrowNullRef122:                                  ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef123:                                  ; preds = %46
+ThrowNullRef124:                                  ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef125:                                  ; preds = %51
+ThrowNullRef126:                                  ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef127:                                  ; preds = %27
+ThrowNullRef128:                                  ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef129:                                  ; preds = %31
+ThrowNullRef130:                                  ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef131:                                  ; preds = %19
+ThrowNullRef132:                                  ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef133:                                  ; preds = %22
+ThrowNullRef134:                                  ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef135:                                  ; preds = %338
+ThrowNullRef136:                                  ; preds = %338
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef137:                                  ; preds = %341
+ThrowNullRef138:                                  ; preds = %341
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef139:                                  ; preds = %356
+ThrowNullRef140:                                  ; preds = %356
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef141:                                  ; preds = %360
+ThrowNullRef142:                                  ; preds = %360
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef143:                                  ; preds = %377
+ThrowNullRef144:                                  ; preds = %377
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef145:                                  ; preds = %381
+ThrowNullRef146:                                  ; preds = %381
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef147:                                  ; preds = %424
+ThrowNullRef148:                                  ; preds = %424
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef149:                                  ; preds = %428
+ThrowNullRef150:                                  ; preds = %428
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef151:                                  ; preds = %440
+ThrowNullRef152:                                  ; preds = %440
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef153:                                  ; preds = %444
+ThrowNullRef154:                                  ; preds = %444
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef155:                                  ; preds = %456
+ThrowNullRef156:                                  ; preds = %456
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef157:                                  ; preds = %460
+ThrowNullRef158:                                  ; preds = %460
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef159:                                  ; preds = %474
+ThrowNullRef160:                                  ; preds = %474
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef161:                                  ; preds = %477
+ThrowNullRef162:                                  ; preds = %477
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef163:                                  ; preds = %394
+ThrowNullRef164:                                  ; preds = %394
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef165:                                  ; preds = %398
+ThrowNullRef166:                                  ; preds = %398
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef167:                                  ; preds = %401
+ThrowNullRef168:                                  ; preds = %401
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef169:                                  ; preds = %407
+ThrowNullRef170:                                  ; preds = %407
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1939,8 +2021,8 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
-  br i1 %NullCheck, label %22, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %ThrowNullRef, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
@@ -1948,8 +2030,8 @@ entry:
   store i32 %24, i32* %loc0
   %25 = load i32, i32* %loc0
   %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %26, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %27
 
 ; <label>:27                                      ; preds = %22
   %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
@@ -1971,7 +2053,7 @@ ThrowNullRef:                                     ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1989,8 +2071,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -2022,15 +2104,15 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2048,16 +2130,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
   %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
   store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %15
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
@@ -2072,8 +2154,8 @@ entry:
   %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
   %29 = ptrtoint i16 addrspace(1)* %28 to i64
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %19
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
@@ -2089,19 +2171,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2114,8 +2196,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
@@ -2128,7 +2210,7 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[loadElem]
+Failed to read AppDomain.PrepareDataForSetup[storeElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
@@ -2202,8 +2284,8 @@ entry:
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
-  br i1 %NullCheck24, label %27, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = load i64, i64 addrspace(1)* %26
@@ -2218,8 +2300,8 @@ entry:
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
-  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
   %41 = load i64, i64 addrspace(1)* %39
@@ -2236,8 +2318,8 @@ entry:
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
-  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
   %54 = load i64, i64 addrspace(1)* %52
@@ -2252,8 +2334,8 @@ entry:
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
   %67 = load i64, i64 addrspace(1)* %65
@@ -2270,8 +2352,8 @@ entry:
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
-  br i1 %NullCheck16, label %79, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
   %80 = load i64, i64 addrspace(1)* %78
@@ -2286,8 +2368,8 @@ entry:
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
-  br i1 %NullCheck18, label %92, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
   %93 = load i64, i64 addrspace(1)* %91
@@ -2304,8 +2386,8 @@ entry:
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
-  br i1 %NullCheck12, label %105, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = load i64, i64 addrspace(1)* %104
@@ -2320,8 +2402,8 @@ entry:
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
-  br i1 %NullCheck14, label %118, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
   %119 = load i64, i64 addrspace(1)* %117
@@ -2337,8 +2419,8 @@ entry:
 
 ; <label>:128                                     ; preds = %20
   %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
-  br i1 %NullCheck4, label %130, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %129, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %130
 
 ; <label>:130                                     ; preds = %128
   %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
@@ -2346,8 +2428,8 @@ entry:
   %133 = load i16, i16 addrspace(1)* %132, align 8
   %134 = zext i16 %133 to i32
   %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
-  br i1 %NullCheck6, label %136, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %135, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %136
 
 ; <label>:136                                     ; preds = %130
   %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
@@ -2360,8 +2442,8 @@ entry:
 
 ; <label>:143                                     ; preds = %136
   %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
-  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %144, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %145
 
 ; <label>:145                                     ; preds = %143
   %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
@@ -2369,8 +2451,8 @@ entry:
   %148 = load i16, i16 addrspace(1)* %147, align 8
   %149 = zext i16 %148 to i32
   %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %150, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %151
 
 ; <label>:151                                     ; preds = %145
   %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
@@ -2388,8 +2470,8 @@ entry:
 
 ; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
-  br i1 %NullCheck, label %163, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %ThrowNullRef, label %163
 
 ; <label>:163                                     ; preds = %161
   %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
@@ -2399,8 +2481,8 @@ entry:
 
 ; <label>:167                                     ; preds = %163
   %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
-  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %168, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %169
 
 ; <label>:169                                     ; preds = %167
   %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
@@ -2432,55 +2514,55 @@ ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %167
+ThrowNullRef2:                                    ; preds = %167
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %128
+ThrowNullRef4:                                    ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %130
+ThrowNullRef6:                                    ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %143
+ThrowNullRef8:                                    ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %145
+ThrowNullRef10:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %102
+ThrowNullRef12:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %105
+ThrowNullRef14:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %76
+ThrowNullRef16:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %79
+ThrowNullRef18:                                   ; preds = %79
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %50
+ThrowNullRef20:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %53
+ThrowNullRef22:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %24
+ThrowNullRef24:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %27
+ThrowNullRef26:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2503,15 +2585,15 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2519,16 +2601,16 @@ entry:
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
   store i32 %8, i32* %loc0
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
   %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
   store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
@@ -2546,16 +2628,16 @@ entry:
 
 ; <label>:23                                      ; preds = %64
   %24 = load i16*, i16** %loc3
-  %NullCheck12 = icmp ne i16* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i16* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
   store i32 %27, i32* %loc5
   %28 = load i16*, i16** %loc4
-  %NullCheck14 = icmp ne i16* %28, null
-  br i1 %NullCheck14, label %29, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %28, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = load i16, i16* %28, align 8
@@ -2620,15 +2702,15 @@ entry:
 
 ; <label>:67                                      ; preds = %64
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
-  br i1 %NullCheck8, label %69, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %68, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %69
 
 ; <label>:69                                      ; preds = %67
   %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
   %71 = load i32, i32 addrspace(1)* %70
   %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
-  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %73
 
 ; <label>:73                                      ; preds = %69
   %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
@@ -2645,31 +2727,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %67
+ThrowNullRef8:                                    ; preds = %67
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %69
+ThrowNullRef10:                                   ; preds = %69
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2710,14 +2792,14 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
   %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
@@ -2730,14 +2812,14 @@ entry:
 
 ; <label>:11                                      ; preds = %4
   %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
   %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
@@ -2749,14 +2831,14 @@ entry:
 
 ; <label>:22                                      ; preds = %16
   %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
   %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
-  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
-  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
@@ -2804,23 +2886,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2836,7 +2918,280 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[loadElem]
+Successfully read RuntimeType.IsAssignableFrom
+
+define i8 @RuntimeType.IsAssignableFrom(%System.RuntimeType addrspace(1)* %param0, %System.Type addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.RuntimeType addrspace(1)*
+  %arg1 = alloca %System.Type addrspace(1)*
+  %loc0 = alloca %System.RuntimeType addrspace(1)*
+  %loc1 = alloca %"System.Type[]" addrspace(1)*
+  %loc2 = alloca i32
+  store %System.RuntimeType addrspace(1)* %param0, %System.RuntimeType addrspace(1)** %this
+  store %System.Type addrspace(1)* %param1, %System.Type addrspace(1)** %arg1
+  %0 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %1 = icmp ne %System.Type addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i8 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %5 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %6 = bitcast %System.Type addrspace(1)* %4 to %System.Object addrspace(1)*
+  %7 = bitcast %System.RuntimeType addrspace(1)* %5 to %System.Object addrspace(1)*
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %6, %System.Object addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %3
+  ret i8 1
+
+; <label>:12                                      ; preds = %3
+  %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 152
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 32
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
+  %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
+  %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
+  store %System.RuntimeType addrspace(1)* %25, %System.RuntimeType addrspace(1)** %loc0
+  %26 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %27 = icmp eq %System.RuntimeType addrspace(1)* %26, null
+  br i1 %27, label %34, label %28
+
+; <label>:28                                      ; preds = %15
+  %29 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %30 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)*)*)(%System.RuntimeType addrspace(1)* %29, %System.RuntimeType addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+; <label>:34                                      ; preds = %15
+  %35 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %36 = call %System.Reflection.Emit.TypeBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Reflection.Emit.TypeBuilder addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %35)
+  %37 = icmp eq %System.Reflection.Emit.TypeBuilder addrspace(1)* %36, null
+  br i1 %37, label %139, label %38
+
+; <label>:38                                      ; preds = %34
+  %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %42
+
+; <label>:42                                      ; preds = %38
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 152
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 40
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
+  %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
+  %53 = zext i8 %52 to i32
+  %54 = icmp eq i32 %53, 0
+  br i1 %54, label %56, label %55
+
+; <label>:55                                      ; preds = %42
+  ret i8 1
+
+; <label>:56                                      ; preds = %42
+  %57 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %58 = bitcast %System.RuntimeType addrspace(1)* %57 to %System.Type addrspace(1)*
+  %59 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %58)
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %64 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.Type addrspace(1)* %63, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = bitcast %System.RuntimeType addrspace(1)* %64 to %System.Type addrspace(1)*
+  %67 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %63, %System.Type addrspace(1)* %66)
+  %68 = zext i8 %67 to i32
+  %69 = trunc i32 %68 to i8
+  ret i8 %69
+
+; <label>:70                                      ; preds = %56
+  %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
+  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %73
+
+; <label>:73                                      ; preds = %70
+  %74 = load i64, i64 addrspace(1)* %72
+  %75 = add i64 %74, 128
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = add i64 %77, 0
+  %79 = inttoptr i64 %78 to i64*
+  %80 = load i64, i64* %79
+  %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
+  %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
+  %83 = call i8 %82(%System.Type addrspace(1)* %81)
+  %84 = zext i8 %83 to i32
+  %85 = icmp eq i32 %84, 0
+  br i1 %85, label %139, label %86
+
+; <label>:86                                      ; preds = %73
+  %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
+  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %89
+
+; <label>:89                                      ; preds = %86
+  %90 = load i64, i64 addrspace(1)* %88
+  %91 = add i64 %90, 128
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = add i64 %93, 24
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
+  %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
+  %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
+  store %"System.Type[]" addrspace(1)* %99, %"System.Type[]" addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %129
+
+; <label>:100                                     ; preds = %132
+  %101 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %102 = load i32, i32* %loc2
+  %NullCheck11 = icmp eq %"System.Type[]" addrspace(1)* %101, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %103
+
+; <label>:103                                     ; preds = %100
+  %104 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 1
+  %105 = load i32, i32 addrspace(1)* %104
+  %106 = zext i32 %105 to i64
+  %107 = zext i32 %102 to i64
+  %BoundsCheck = icmp uge i64 %107, %106
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %108
+
+; <label>:108                                     ; preds = %103
+  %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
+  %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
+  %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
+  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %113
+
+; <label>:113                                     ; preds = %108
+  %114 = load i64, i64 addrspace(1)* %112
+  %115 = add i64 %114, 152
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = add i64 %117, 56
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
+  %123 = zext i8 %122 to i32
+  %124 = icmp ne i32 %123, 0
+  br i1 %124, label %126, label %125
+
+; <label>:125                                     ; preds = %113
+  ret i8 0
+
+; <label>:126                                     ; preds = %113
+  %127 = load i32, i32* %loc2
+  %128 = add i32 %127, 1
+  store i32 %128, i32* %loc2
+  br label %129
+
+; <label>:129                                     ; preds = %89, %126
+  %130 = load i32, i32* %loc2
+  %131 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %NullCheck9 = icmp eq %"System.Type[]" addrspace(1)* %131, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %132
+
+; <label>:132                                     ; preds = %129
+  %133 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %131, i32 0, i32 1
+  %134 = load i32, i32 addrspace(1)* %133
+  %135 = zext i32 %134 to i64
+  %136 = trunc i64 %135 to i32
+  %137 = icmp slt i32 %130, %136
+  br i1 %137, label %100, label %138
+
+; <label>:138                                     ; preds = %132
+  ret i8 1
+
+; <label>:139                                     ; preds = %34, %73
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %129
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %103
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -2893,7 +3248,7 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElem]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -2904,8 +3259,8 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -2997,8 +3352,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
@@ -3059,8 +3414,8 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -3087,8 +3442,8 @@ entry:
 
 ; <label>:17                                      ; preds = %5, %11
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
@@ -3097,8 +3452,8 @@ entry:
 
 ; <label>:22                                      ; preds = %1, %11
   %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
@@ -3109,11 +3464,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %17
+ThrowNullRef2:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %22
+ThrowNullRef4:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3167,15 +3522,15 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
   %15 = load i32, i32 addrspace(1)* %14
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
@@ -3198,7 +3553,7 @@ ThrowNullRef:                                     ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef2:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3232,8 +3587,8 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
@@ -3312,8 +3667,8 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -3327,8 +3682,8 @@ entry:
 ; <label>:5                                       ; preds = %43
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %7 = load i32, i32* %loc1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck6, label %8, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
@@ -3366,8 +3721,8 @@ entry:
 ; <label>:32                                      ; preds = %21, %25
   %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
   %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
-  br i1 %NullCheck8, label %35, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = trunc i32 %34 to i16
@@ -3380,8 +3735,8 @@ entry:
 ; <label>:40                                      ; preds = %1, %35
   %41 = load i32, i32* %loc1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
-  br i1 %NullCheck2, label %43, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %42, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
@@ -3392,8 +3747,8 @@ entry:
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
   %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
-  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
   %51 = load i64, i64 addrspace(1)* %49
@@ -3412,19 +3767,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %40
+ThrowNullRef2:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %47
+ThrowNullRef4:                                    ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %5
+ThrowNullRef6:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %32
+ThrowNullRef8:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3467,8 +3822,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
@@ -3492,11 +3847,391 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(i16* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store i16* %param0, i16** %arg0
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load i32, i32* %arg3
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %42, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %37, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg2
+  %13 = load i32, i32* %arg3
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %37, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %24 = load i32, i32* %arg2
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load i16*, i16** %arg0
+  %35 = load i32, i32* %arg3
+  %36 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %36, i16* %34, i32 %35)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:37                                      ; preds = %5, %16
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %39)
+  %41 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41, %System.String addrspace(1)* %38, %System.String addrspace(1)* %40)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41) #0
+  unreachable
+
+; <label>:42                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
-Failed to read StringBuilder.ToString[loadElemA]
+Successfully read StringBuilder.ToString
+
+define %System.String addrspace(1)* @StringBuilder.ToString(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i16*
+  %loc3 = alloca %"System.Char[]" addrspace(1)*
+  %loc4 = alloca i32
+  %loc5 = alloca i32
+  %loc6 = alloca i16 addrspace(1)*
+  %loc7 = alloca %System.String addrspace(1)*
+  %loc8 = alloca %"System.Char[]" addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %0)
+  %2 = icmp ne i32 %1, 0
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %4
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %6)
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %7)
+  store %System.String addrspace(1)* %8, %System.String addrspace(1)** %loc0
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.Text.StringBuilder addrspace(1)* %9, %System.Text.StringBuilder addrspace(1)** %loc1
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  store %System.String addrspace(1)* %10, %System.String addrspace(1)** %loc7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc7
+  %12 = ptrtoint %System.String addrspace(1)* %11 to i64
+  %13 = icmp eq i64 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %5
+  %15 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %16 = sext i32 %15 to i64
+  %17 = add i64 %12, %16
+  br label %18
+
+; <label>:18                                      ; preds = %5, %14
+  %19 = phi i64 [ %12, %5 ], [ %17, %14 ]
+  %20 = inttoptr i64 %19 to i16*
+  store i16* %20, i16** %loc2
+  br label %21
+
+; <label>:21                                      ; preds = %98, %18
+  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %22, null
+  br i1 %NullCheck, label %ThrowNullRef, label %23
+
+; <label>:23                                      ; preds = %21
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 3
+  %25 = load i32, i32 addrspace(1)* %24, align 8
+  %26 = icmp sle i32 %25, 0
+  br i1 %26, label %96, label %27
+
+; <label>:27                                      ; preds = %23
+  %28 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %28, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %29
+
+; <label>:29                                      ; preds = %27
+  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %28, i32 0, i32 1
+  %31 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %30, align 8
+  store %"System.Char[]" addrspace(1)* %31, %"System.Char[]" addrspace(1)** %loc3
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %33
+
+; <label>:33                                      ; preds = %29
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  store i32 %35, i32* %loc4
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  %39 = load i32, i32 addrspace(1)* %38, align 8
+  store i32 %39, i32* %loc5
+  %40 = load i32, i32* %loc5
+  %41 = load i32, i32* %loc4
+  %42 = add i32 %40, %41
+  %43 = zext i32 %42 to i64
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %45
+
+; <label>:45                                      ; preds = %37
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = sext i32 %47 to i64
+  %49 = icmp sgt i64 %43, %48
+  br i1 %49, label %91, label %50
+
+; <label>:50                                      ; preds = %45
+  %51 = load i32, i32* %loc5
+  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %52, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %53
+
+; <label>:53                                      ; preds = %50
+  %54 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %52, i32 0, i32 1
+  %55 = load i32, i32 addrspace(1)* %54
+  %56 = zext i32 %55 to i64
+  %57 = trunc i64 %56 to i32
+  %58 = icmp ugt i32 %51, %57
+  br i1 %58, label %91, label %59
+
+; <label>:59                                      ; preds = %53
+  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  store %"System.Char[]" addrspace(1)* %60, %"System.Char[]" addrspace(1)** %loc8
+  %61 = icmp eq %"System.Char[]" addrspace(1)* %60, null
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %63, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %64
+
+; <label>:64                                      ; preds = %62
+  %65 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %63, i32 0, i32 1
+  %66 = load i32, i32 addrspace(1)* %65
+  %67 = zext i32 %66 to i64
+  %68 = trunc i64 %67 to i32
+  %69 = icmp ne i32 %68, 0
+  br i1 %69, label %71, label %70
+
+; <label>:70                                      ; preds = %59, %64
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:71                                      ; preds = %64
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %73
+
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %BoundsCheck = icmp uge i64 0, %76
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %77
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %78, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:79                                      ; preds = %70, %77
+  %80 = load i16*, i16** %loc2
+  %81 = load i32, i32* %loc4
+  %82 = sext i32 %81 to i64
+  %83 = mul i64 %82, 2
+  %84 = bitcast i16* %80 to i8*
+  %85 = getelementptr inbounds i8, i8* %84, i64 %83
+  %86 = load i16 addrspace(1)*, i16 addrspace(1)** %loc6
+  %87 = ptrtoint i16 addrspace(1)* %86 to i64
+  %88 = load i32, i32* %loc5
+  %89 = bitcast i8* %85 to i16*
+  %90 = inttoptr i64 %87 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %89, i16* %90, i32 %88)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %96
+
+; <label>:91                                      ; preds = %45, %53
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %94 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %93)
+  %95 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95, %System.String addrspace(1)* %92, %System.String addrspace(1)* %94)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95) #0
+  unreachable
+
+; <label>:96                                      ; preds = %23, %79
+  %97 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %97, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %98
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %97, i32 0, i32 2
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  store %System.Text.StringBuilder addrspace(1)* %100, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %102 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %102, label %21, label %103
+
+; <label>:103                                     ; preds = %98
+  store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc7
+  %104 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  ret %System.String addrspace(1)* %104
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method StringBuilder::get_Length using LLILCJit
+Successfully read StringBuilder.get_Length
+
+define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
+Successfully read RuntimeHelpers.get_OffsetToStringData
+
+define i32 @RuntimeHelpers.get_OffsetToStringData() {
+entry:
+  ret i32 12
+}
+
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
 Successfully read CultureData.CreateCultureData
 
@@ -3514,23 +4249,23 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
   store i8 %4, i8 addrspace(1)* %6
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
@@ -3549,11 +4284,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3566,50 +4301,50 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
   store i32 -1, i32 addrspace(1)* %2
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
   store i32 -1, i32 addrspace(1)* %8
   %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
   store i32 -1, i32 addrspace(1)* %14
   %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
   store i32 -1, i32 addrspace(1)* %17
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
@@ -3623,27 +4358,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3675,7 +4410,136 @@ Failed to read Dictionary`2.Insert[non-const derefAddress]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
 Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
-Failed to read HashHelpers.GetPrime[loadElem]
+Successfully read HashHelpers.GetPrime
+
+define i32 @HashHelpers.GetPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %6, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5, %System.String addrspace(1)* %4)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5) #0
+  unreachable
+
+; <label>:6                                       ; preds = %entry
+  store i32 0, i32* %loc0
+  br label %29
+
+; <label>:7                                       ; preds = %35
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 1296
+  %10 = addrspacecast i8 addrspace(1)* %9 to %"System.Int32[]" addrspace(1)**
+  %11 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %10
+  %12 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Int32[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = zext i32 %15 to i64
+  %17 = zext i32 %12 to i64
+  %BoundsCheck = icmp uge i64 %17, %16
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 3, i32 %12
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  store i32 %20, i32* %loc1
+  %21 = load i32, i32* %loc1
+  %22 = load i32, i32* %arg0
+  %23 = icmp slt i32 %21, %22
+  br i1 %23, label %26, label %24
+
+; <label>:24                                      ; preds = %18
+  %25 = load i32, i32* %loc1
+  ret i32 %25
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %loc0
+  %28 = add i32 %27, 1
+  store i32 %28, i32* %loc0
+  br label %29
+
+; <label>:29                                      ; preds = %6, %26
+  %30 = load i32, i32* %loc0
+  %31 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %32 = getelementptr inbounds i8, i8 addrspace(1)* %31, i64 1296
+  %33 = addrspacecast i8 addrspace(1)* %32 to %"System.Int32[]" addrspace(1)**
+  %34 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %33
+  %NullCheck = icmp eq %"System.Int32[]" addrspace(1)* %34, null
+  br i1 %NullCheck, label %ThrowNullRef, label %35
+
+; <label>:35                                      ; preds = %29
+  %36 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %34, i32 0, i32 1
+  %37 = load i32, i32 addrspace(1)* %36
+  %38 = zext i32 %37 to i64
+  %39 = trunc i64 %38 to i32
+  %40 = icmp slt i32 %30, %39
+  br i1 %40, label %7, label %41
+
+; <label>:41                                      ; preds = %35
+  %42 = load i32, i32* %arg0
+  %43 = or i32 %42, 1
+  store i32 %43, i32* %loc2
+  br label %59
+
+; <label>:44                                      ; preds = %59
+  %45 = load i32, i32* %loc2
+  %46 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %45)
+  %47 = zext i8 %46 to i32
+  %48 = icmp eq i32 %47, 0
+  br i1 %48, label %56, label %49
+
+; <label>:49                                      ; preds = %44
+  %50 = load i32, i32* %loc2
+  %51 = sub i32 %50, 1
+  %52 = srem i32 %51, 101
+  %53 = icmp eq i32 %52, 0
+  br i1 %53, label %56, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = load i32, i32* %loc2
+  ret i32 %55
+
+; <label>:56                                      ; preds = %44, %49
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %57, 2
+  store i32 %58, i32* %loc2
+  br label %59
+
+; <label>:59                                      ; preds = %41, %56
+  %60 = load i32, i32* %loc2
+  %61 = icmp slt i32 %60, 2147483647
+  br i1 %61, label %44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load i32, i32* %arg0
+  ret i32 %63
+
+ThrowNullRef:                                     ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
 Successfully read GenericEqualityComparer`1.GetHashCode
 
@@ -3694,14 +4558,14 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
   %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load i64, i64 addrspace(1)* %7
@@ -3720,7 +4584,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3750,8 +4614,8 @@ entry:
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
@@ -3796,8 +4660,8 @@ entry:
   %35 = bitcast i16* %34 to i8*
   %36 = getelementptr inbounds i8, i8* %35, i64 2
   %37 = bitcast i8* %36 to i16*
-  %NullCheck4 = icmp ne i16* %37, null
-  br i1 %NullCheck4, label %38, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %37, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %38
 
 ; <label>:38                                      ; preds = %27
   %39 = load i16, i16* %37, align 8
@@ -3824,8 +4688,8 @@ entry:
 
 ; <label>:54                                      ; preds = %22, %43
   %55 = load i16*, i16** %loc4
-  %NullCheck2 = icmp ne i16* %55, null
-  br i1 %NullCheck2, label %56, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i16* %55, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %56
 
 ; <label>:56                                      ; preds = %54
   %57 = load i16, i16* %55, align 8
@@ -3850,11 +4714,11 @@ ThrowNullRef:                                     ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %54
+ThrowNullRef2:                                    ; preds = %54
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %27
+ThrowNullRef4:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3871,8 +4735,8 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -3907,8 +4771,8 @@ entry:
 
 ; <label>:26                                      ; preds = %19
   %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
-  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %28
 
 ; <label>:28                                      ; preds = %26
   %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
@@ -3920,7 +4784,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3972,8 +4836,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
@@ -3984,26 +4848,26 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
-  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
@@ -4014,8 +4878,8 @@ entry:
 ; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
@@ -4024,8 +4888,8 @@ entry:
 
 ; <label>:25                                      ; preds = %1, %16, %23
   %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
-  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
@@ -4036,27 +4900,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %20
+ThrowNullRef10:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4069,8 +4933,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -4081,8 +4945,8 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
@@ -4091,8 +4955,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1, %8
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
@@ -4103,11 +4967,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4128,24 +4992,24 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   store i32 %3, i32* %loc0
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
   %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
   store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck4, label %9, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
@@ -4164,15 +5028,15 @@ entry:
 ; <label>:18                                      ; preds = %70
   %19 = load i16*, i16** %loc3
   %20 = bitcast i16* %19 to i64*
-  %NullCheck10 = icmp ne i64* %20, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %20, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = load i64, i64* %20, align 8
   %23 = load i16*, i16** %loc4
   %24 = bitcast i16* %23 to i64*
-  %NullCheck12 = icmp ne i64* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = load i64, i64* %24, align 8
@@ -4188,8 +5052,8 @@ entry:
   %31 = bitcast i16* %30 to i8*
   %32 = getelementptr inbounds i8, i8* %31, i64 8
   %33 = bitcast i8* %32 to i64*
-  %NullCheck14 = icmp ne i64* %33, null
-  br i1 %NullCheck14, label %34, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = load i64, i64* %33, align 8
@@ -4197,8 +5061,8 @@ entry:
   %37 = bitcast i16* %36 to i8*
   %38 = getelementptr inbounds i8, i8* %37, i64 8
   %39 = bitcast i8* %38 to i64*
-  %NullCheck16 = icmp ne i64* %39, null
-  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %40
 
 ; <label>:40                                      ; preds = %34
   %41 = load i64, i64* %39, align 8
@@ -4214,8 +5078,8 @@ entry:
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %NullCheck18 = icmp ne i64* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = load i64, i64* %48, align 8
@@ -4223,8 +5087,8 @@ entry:
   %52 = bitcast i16* %51 to i8*
   %53 = getelementptr inbounds i8, i8* %52, i64 16
   %54 = bitcast i8* %53 to i64*
-  %NullCheck20 = icmp ne i64* %54, null
-  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64* %54, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %55
 
 ; <label>:55                                      ; preds = %49
   %56 = load i64, i64* %54, align 8
@@ -4262,15 +5126,15 @@ entry:
 ; <label>:74                                      ; preds = %95
   %75 = load i16*, i16** %loc3
   %76 = bitcast i16* %75 to i32*
-  %NullCheck6 = icmp ne i32* %76, null
-  br i1 %NullCheck6, label %77, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32* %76, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %77
 
 ; <label>:77                                      ; preds = %74
   %78 = load i32, i32* %76, align 8
   %79 = load i16*, i16** %loc4
   %80 = bitcast i16* %79 to i32*
-  %NullCheck8 = icmp ne i32* %80, null
-  br i1 %NullCheck8, label %81, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i32* %80, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %81
 
 ; <label>:81                                      ; preds = %77
   %82 = load i32, i32* %80, align 8
@@ -4318,43 +5182,43 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %74
+ThrowNullRef6:                                    ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %77
+ThrowNullRef8:                                    ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %29
+ThrowNullRef14:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %34
+ThrowNullRef16:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4376,8 +5240,8 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load i64, i64 addrspace(1)* %4
@@ -4389,8 +5253,8 @@ entry:
   %12 = load i64, i64* %11
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %5
   %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
@@ -4399,8 +5263,8 @@ entry:
   %18 = load i8, i8* %arg2
   %19 = zext i8 %18 to i32
   %20 = trunc i32 %19 to i8
-  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %15
   %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
@@ -4411,11 +5275,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4442,8 +5306,8 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
@@ -4466,16 +5330,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
   %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = load i64, i64 addrspace(1)* %19
@@ -4500,8 +5364,8 @@ entry:
 ; <label>:35                                      ; preds = %30
   %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
@@ -4514,8 +5378,8 @@ entry:
 
 ; <label>:42                                      ; preds = %1, %38
   %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
-  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
@@ -4526,19 +5390,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %35
+ThrowNullRef2:                                    ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %42
+ThrowNullRef8:                                    ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4551,14 +5415,14 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
@@ -4570,7 +5434,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4583,8 +5447,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
@@ -4613,51 +5477,51 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
   %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
   %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
   %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
   %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
-  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
   store i64 %21, i64 addrspace(1)* %23
   %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %25 = load i64, i64* %loc0
-  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
@@ -4668,27 +5532,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %22
+ThrowNullRef12:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4701,8 +5565,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
@@ -4713,19 +5577,19 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
@@ -4734,8 +5598,8 @@ entry:
 
 ; <label>:15                                      ; preds = %1, %13
   %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
@@ -4746,19 +5610,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %15
+ThrowNullRef8:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4771,8 +5635,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -4831,8 +5695,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
@@ -4882,8 +5746,8 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
-  br i1 %NullCheck, label %17, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %ThrowNullRef, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
@@ -4894,15 +5758,15 @@ entry:
 
 ; <label>:22                                      ; preds = %17
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
-  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
   %26 = load i32, i32 addrspace(1)* %25
   %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
-  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %27, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
@@ -4925,8 +5789,8 @@ entry:
 ; <label>:40                                      ; preds = %17
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
-  br i1 %NullCheck6, label %43, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %41, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
@@ -4938,34 +5802,17 @@ ThrowNullRef:                                     ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %24
+ThrowNullRef4:                                    ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %40
+ThrowNullRef6:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
-}
-
-INFO:  jitting method Object::ReferenceEquals using LLILCJit
-Successfully read Object.ReferenceEquals
-
-define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
-entry:
-  %arg0 = alloca %System.Object addrspace(1)*
-  %arg1 = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
-  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
-  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = icmp eq %System.Object addrspace(1)* %0, %1
-  %3 = sext i1 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
 }
 
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
@@ -4978,21 +5825,21 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
   %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
-  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
@@ -5007,28 +5854,28 @@ entry:
 ; <label>:13                                      ; preds = %8, %12
   %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
   %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
   %21 = load i32, i32 addrspace(1)* %20, align 8
   %22 = add i32 %21, 1
-  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
   store i32 %22, i32 addrspace(1)* %24
   %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
@@ -5039,27 +5886,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5077,7 +5924,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::Setup using LLILCJit
-Failed to read AppDomain.Setup[loadElem]
+Failed to read AppDomain.Setup[unbox]
 INFO:  jitting method Thread::GetDomain using LLILCJit
 Successfully read Thread.GetDomain
 
@@ -5108,8 +5955,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
@@ -5122,14 +5969,14 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
   %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
@@ -5141,11 +5988,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5173,8 +6020,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -5189,7 +6036,328 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
 Failed to read KeyCollection.System.Collections.Generic.IEnumerable<TKey>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Successfully read Enumerator.MoveNext
+
+define i8 @Enumerator.MoveNext(%"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.RuntimeTypeHandle* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*
+  %"$TypeArg" = alloca %System.RuntimeTypeHandle*
+  store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
+  %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 8
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %76, label %12
+
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
+  br label %76
+
+; <label>:13                                      ; preds = %85
+  %14 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck19 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %15
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, i32 0, i32 0
+  %17 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %16, align 8
+  %NullCheck21 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, i32 0, i32 2
+  %20 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %19, align 8
+  %21 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck23 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %22
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, i32 0, i32 2
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %NullCheck25 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 3, i32 %24
+  %NullCheck27 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %32
+
+; <label>:32                                      ; preds = %30
+  %33 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, i32 0, i32 2
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = icmp slt i32 %34, 0
+  br i1 %35, label %68, label %36
+
+; <label>:36                                      ; preds = %32
+  %37 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %38 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck29 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %39
+
+; <label>:39                                      ; preds = %36
+  %40 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, i32 0, i32 0
+  %41 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %40, align 8
+  %NullCheck31 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, i32 0, i32 2
+  %44 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %43, align 8
+  %45 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck33 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, i32 0, i32 2
+  %48 = load i32, i32 addrspace(1)* %47, align 8
+  %NullCheck35 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %49
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = zext i32 %51 to i64
+  %53 = zext i32 %48 to i64
+  %BoundsCheck37 = icmp uge i64 %53, %52
+  br i1 %BoundsCheck37, label %ThrowIndexOutOfRange38, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 3, i32 %48
+  %NullCheck39 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %56
+
+; <label>:56                                      ; preds = %54
+  %57 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, i32 0, i32 0
+  %58 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck41 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %59
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %60, %System.__Canon addrspace(1)* %58)
+  %61 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck43 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  %64 = load i32, i32 addrspace(1)* %63, align 8
+  %65 = add i32 %64, 1
+  %NullCheck45 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  store i32 %65, i32 addrspace(1)* %67
+  ret i8 1
+
+; <label>:68                                      ; preds = %32
+  %69 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck47 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %73 = add i32 %72, 1
+  %NullCheck49 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %74
+
+; <label>:74                                      ; preds = %70
+  %75 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  store i32 %73, i32 addrspace(1)* %75
+  br label %76
+
+; <label>:76                                      ; preds = %8, %12, %74
+  %77 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %78
+
+; <label>:78                                      ; preds = %76
+  %79 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, i32 0, i32 2
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck7 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %82
+
+; <label>:82                                      ; preds = %78
+  %83 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, i32 0, i32 0
+  %84 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %83, align 8
+  %NullCheck9 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %85
+
+; <label>:85                                      ; preds = %82
+  %86 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, i32 0, i32 7
+  %87 = load i32, i32 addrspace(1)* %86, align 8
+  %88 = icmp ult i32 %80, %87
+  br i1 %88, label %13, label %89
+
+; <label>:89                                      ; preds = %85
+  %90 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %91 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck11 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %92
+
+; <label>:92                                      ; preds = %89
+  %93 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, i32 0, i32 0
+  %94 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck13 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %95
+
+; <label>:95                                      ; preds = %92
+  %96 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, i32 0, i32 7
+  %97 = load i32, i32 addrspace(1)* %96, align 8
+  %98 = add i32 %97, 1
+  %NullCheck15 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %99
+
+; <label>:99                                      ; preds = %95
+  %100 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, i32 0, i32 2
+  store i32 %98, i32 addrspace(1)* %100
+  %101 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck17 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %102
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %103, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %92
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef22:                                   ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef24:                                   ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef26:                                   ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef28:                                   ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef30:                                   ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef32:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef34:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef36:                                   ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange38:                           ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef40:                                   ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef42:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef44:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef46:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef48:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef50:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -5200,8 +6368,8 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -5232,9 +6400,9 @@ Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
 Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
-Failed to read String.MakeSeparatorList[loadElemA]
+Failed to read String.MakeSeparatorList[storeElem]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
-Failed to read String.InternalSplitKeepEmptyEntries[loadElem]
+Failed to read String.InternalSplitKeepEmptyEntries[storeElem]
 INFO:  jitting method Path::IsRelative using LLILCJit
 Successfully read Path.IsRelative
 
@@ -5243,8 +6411,8 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -5254,8 +6422,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
@@ -5271,8 +6439,8 @@ entry:
 
 ; <label>:17                                      ; preds = %7
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
@@ -5288,8 +6456,8 @@ entry:
 
 ; <label>:29                                      ; preds = %19
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %31
 
 ; <label>:31                                      ; preds = %29
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
@@ -5300,8 +6468,8 @@ entry:
 
 ; <label>:36                                      ; preds = %31
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
-  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %37, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
@@ -5312,8 +6480,8 @@ entry:
 
 ; <label>:43                                      ; preds = %31, %38
   %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
-  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %45
 
 ; <label>:45                                      ; preds = %43
   %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
@@ -5324,8 +6492,8 @@ entry:
 
 ; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %50
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
@@ -5336,8 +6504,8 @@ entry:
 
 ; <label>:57                                      ; preds = %1, %7, %19, %45, %52
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
-  br i1 %NullCheck14, label %59, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %59
 
 ; <label>:59                                      ; preds = %57
   %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
@@ -5347,8 +6515,8 @@ entry:
 
 ; <label>:63                                      ; preds = %59
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
@@ -5359,8 +6527,8 @@ entry:
 
 ; <label>:70                                      ; preds = %65
   %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
-  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.String addrspace(1)* %71, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %72
 
 ; <label>:72                                      ; preds = %70
   %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
@@ -5379,39 +6547,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %17
+ThrowNullRef4:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %29
+ThrowNullRef6:                                    ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %36
+ThrowNullRef8:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %43
+ThrowNullRef10:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %50
+ThrowNullRef12:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %57
+ThrowNullRef14:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %63
+ThrowNullRef16:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %70
+ThrowNullRef18:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5419,7 +6587,293 @@ ThrowNullRef17:                                   ; preds = %70
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
-Failed to read String.TrimHelper[loadElem]
+Successfully read String.TrimHelper
+
+define %System.String addrspace(1)* @String.TrimHelper(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i16
+  %loc4 = alloca i32
+  %loc5 = alloca i16
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = sub i32 %3, 1
+  store i32 %4, i32* %loc0
+  store i32 0, i32* %loc1
+  %5 = load i32, i32* %arg2
+  %6 = icmp eq i32 %5, 1
+  br i1 %6, label %62, label %7
+
+; <label>:7                                       ; preds = %1
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:8                                       ; preds = %58
+  store i32 0, i32* %loc2
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load i32, i32* %loc1
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2, i32 %10
+  %13 = load i16, i16 addrspace(1)* %12
+  %14 = zext i16 %13 to i32
+  %15 = trunc i32 %14 to i16
+  store i16 %15, i16* %loc3
+  store i32 0, i32* %loc2
+  br label %34
+
+; <label>:16                                      ; preds = %37
+  %17 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %18 = load i32, i32* %loc2
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %17, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %19
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = zext i32 %18 to i64
+  %BoundsCheck = icmp uge i64 %23, %22
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %24
+
+; <label>:24                                      ; preds = %19
+  %25 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 3, i32 %18
+  %26 = load i16, i16 addrspace(1)* %25, align 8
+  %27 = zext i16 %26 to i32
+  %28 = load i16, i16* %loc3
+  %29 = zext i16 %28 to i32
+  %30 = icmp eq i32 %27, %29
+  br i1 %30, label %43, label %31
+
+; <label>:31                                      ; preds = %24
+  %32 = load i32, i32* %loc2
+  %33 = add i32 %32, 1
+  store i32 %33, i32* %loc2
+  br label %34
+
+; <label>:34                                      ; preds = %11, %31
+  %35 = load i32, i32* %loc2
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = icmp slt i32 %35, %41
+  br i1 %42, label %16, label %43
+
+; <label>:43                                      ; preds = %24, %37
+  %44 = load i32, i32* %loc2
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %45, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp eq i32 %44, %50
+  br i1 %51, label %62, label %52
+
+; <label>:52                                      ; preds = %46
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %7, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %57, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %58
+
+; <label>:58                                      ; preds = %55
+  %59 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %60 = load i32, i32 addrspace(1)* %59
+  %61 = icmp slt i32 %56, %60
+  br i1 %61, label %8, label %62
+
+; <label>:62                                      ; preds = %1, %46, %58
+  %63 = load i32, i32* %arg2
+  %64 = icmp eq i32 %63, 0
+  br i1 %64, label %122, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %66, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %67
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %66, i32 0, i32 1
+  %69 = load i32, i32 addrspace(1)* %68
+  %70 = sub i32 %69, 1
+  store i32 %70, i32* %loc0
+  br label %118
+
+; <label>:71                                      ; preds = %118
+  store i32 0, i32* %loc4
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %73 = load i32, i32* %loc0
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %74
+
+; <label>:74                                      ; preds = %71
+  %75 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 2, i32 %73
+  %76 = load i16, i16 addrspace(1)* %75
+  %77 = zext i16 %76 to i32
+  %78 = trunc i32 %77 to i16
+  store i16 %78, i16* %loc5
+  store i32 0, i32* %loc4
+  br label %97
+
+; <label>:79                                      ; preds = %100
+  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %81 = load i32, i32* %loc4
+  %NullCheck19 = icmp eq %"System.Char[]" addrspace(1)* %80, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
+
+; <label>:82                                      ; preds = %79
+  %83 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 1
+  %84 = load i32, i32 addrspace(1)* %83
+  %85 = zext i32 %84 to i64
+  %86 = zext i32 %81 to i64
+  %BoundsCheck21 = icmp uge i64 %86, %85
+  br i1 %BoundsCheck21, label %ThrowIndexOutOfRange22, label %87
+
+; <label>:87                                      ; preds = %82
+  %88 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 3, i32 %81
+  %89 = load i16, i16 addrspace(1)* %88, align 8
+  %90 = zext i16 %89 to i32
+  %91 = load i16, i16* %loc5
+  %92 = zext i16 %91 to i32
+  %93 = icmp eq i32 %90, %92
+  br i1 %93, label %106, label %94
+
+; <label>:94                                      ; preds = %87
+  %95 = load i32, i32* %loc4
+  %96 = add i32 %95, 1
+  store i32 %96, i32* %loc4
+  br label %97
+
+; <label>:97                                      ; preds = %74, %94
+  %98 = load i32, i32* %loc4
+  %99 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck15 = icmp eq %"System.Char[]" addrspace(1)* %99, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %100
+
+; <label>:100                                     ; preds = %97
+  %101 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %99, i32 0, i32 1
+  %102 = load i32, i32 addrspace(1)* %101
+  %103 = zext i32 %102 to i64
+  %104 = trunc i64 %103 to i32
+  %105 = icmp slt i32 %98, %104
+  br i1 %105, label %79, label %106
+
+; <label>:106                                     ; preds = %87, %100
+  %107 = load i32, i32* %loc4
+  %108 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck17 = icmp eq %"System.Char[]" addrspace(1)* %108, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %109
+
+; <label>:109                                     ; preds = %106
+  %110 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %108, i32 0, i32 1
+  %111 = load i32, i32 addrspace(1)* %110
+  %112 = zext i32 %111 to i64
+  %113 = trunc i64 %112 to i32
+  %114 = icmp eq i32 %107, %113
+  br i1 %114, label %122, label %115
+
+; <label>:115                                     ; preds = %109
+  %116 = load i32, i32* %loc0
+  %117 = sub i32 %116, 1
+  store i32 %117, i32* %loc0
+  br label %118
+
+; <label>:118                                     ; preds = %67, %115
+  %119 = load i32, i32* %loc0
+  %120 = load i32, i32* %loc1
+  %121 = icmp sge i32 %119, %120
+  br i1 %121, label %71, label %122
+
+; <label>:122                                     ; preds = %62, %109, %118
+  %123 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %124 = load i32, i32* %loc1
+  %125 = load i32, i32* %loc0
+  %126 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %123, i32 %124, i32 %125)
+  ret %System.String addrspace(1)* %126
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %97
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange22:                           ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
 Successfully read String.CreateTrimmedString
 
@@ -5439,8 +6893,8 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
@@ -5535,8 +6989,8 @@ entry:
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i64 2872
   %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
   %8 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %7
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %3
   %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
@@ -5553,8 +7007,8 @@ entry:
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 2864
   %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
   %21 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %20
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
-  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %22
 
 ; <label>:22                                      ; preds = %16
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
@@ -5569,7 +7023,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %16
+ThrowNullRef2:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5586,8 +7040,8 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5613,8 +7067,8 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
@@ -5632,8 +7086,8 @@ entry:
 
 ; <label>:12                                      ; preds = %4
   %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
@@ -5644,8 +7098,8 @@ entry:
 
 ; <label>:19                                      ; preds = %14
   %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %19
   %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
@@ -5660,21 +7114,21 @@ entry:
   %31 = zext i16 %30 to i32
   %32 = bitcast i8* %29 to i16*
   %33 = trunc i32 %31 to i16
-  %NullCheck6 = icmp ne i16* %32, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i16* %32, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %21
   store i16 %33, i16* %32, align 8
   %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %36
 
 ; <label>:36                                      ; preds = %34
   %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
   %38 = load i32, i32 addrspace(1)* %37, align 8
   %39 = add i32 %38, 1
-  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %40
 
 ; <label>:40                                      ; preds = %36
   %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
@@ -5683,16 +7137,16 @@ entry:
 
 ; <label>:42                                      ; preds = %14
   %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
-  br i1 %NullCheck12, label %44, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
   %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
   %47 = load i16, i16* %arg1
   %48 = zext i16 %47 to i32
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = trunc i32 %48 to i16
@@ -5703,31 +7157,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %19
+ThrowNullRef4:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %21
+ThrowNullRef6:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %36
+ThrowNullRef10:                                   ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %42
+ThrowNullRef12:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %44
+ThrowNullRef14:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5740,8 +7194,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -5752,8 +7206,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
@@ -5762,14 +7216,14 @@ entry:
 
 ; <label>:11                                      ; preds = %1
   %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
@@ -5779,15 +7233,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5808,8 +7262,8 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5822,8 +7276,8 @@ entry:
 
 ; <label>:8                                       ; preds = %3
   %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
@@ -5842,15 +7296,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
-  br i1 %NullCheck4, label %22, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
   %24 = load i16*, i16* addrspace(1)* %23, align 8
   %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %25, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
@@ -5859,8 +7313,8 @@ entry:
   store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
@@ -5874,8 +7328,8 @@ entry:
 
 ; <label>:37                                      ; preds = %65
   %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %37
   %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
@@ -5886,16 +7340,16 @@ entry:
   %45 = bitcast i16* %41 to i8*
   %46 = getelementptr inbounds i8, i8* %45, i64 %44
   %47 = bitcast i8* %46 to i16*
-  %NullCheck14 = icmp ne i16* %47, null
-  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %47, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %48
 
 ; <label>:48                                      ; preds = %39
   %49 = load i16, i16* %47, align 8
   %50 = zext i16 %49 to i32
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %52 = load i32, i32* %loc1
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %53
 
 ; <label>:53                                      ; preds = %48
   %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
@@ -5916,8 +7370,8 @@ entry:
 ; <label>:62                                      ; preds = %36, %59
   %63 = load i32, i32* %loc1
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck10, label %65, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %65
 
 ; <label>:65                                      ; preds = %62
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
@@ -5936,15 +7390,15 @@ entry:
 
 ; <label>:74                                      ; preds = %70
   %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
-  br i1 %NullCheck18, label %76, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %76
 
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
   %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
-  br i1 %NullCheck20, label %80, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
   %81 = load i64, i64 addrspace(1)* %79
@@ -5958,8 +7412,8 @@ entry:
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
   %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
-  br i1 %NullCheck22, label %92, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.String addrspace(1)* %90, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %92
 
 ; <label>:92                                      ; preds = %80
   %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
@@ -5969,15 +7423,15 @@ entry:
 
 ; <label>:96                                      ; preds = %70
   %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
-  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %98
 
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
   %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
-  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
   %103 = load i64, i64 addrspace(1)* %101
@@ -5991,8 +7445,8 @@ entry:
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
   %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
-  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.String addrspace(1)* %112, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %114
 
 ; <label>:114                                     ; preds = %102
   %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
@@ -6004,59 +7458,59 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %20
+ThrowNullRef4:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %22
+ThrowNullRef6:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %26
+ThrowNullRef8:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %62
+ThrowNullRef10:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %48
+ThrowNullRef16:                                   ; preds = %48
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %74
+ThrowNullRef18:                                   ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %76
+ThrowNullRef20:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %80
+ThrowNullRef22:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %96
+ThrowNullRef24:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %98
+ThrowNullRef26:                                   ; preds = %98
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %102
+ThrowNullRef28:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6069,15 +7523,15 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
   %3 = load i16*, i16* addrspace(1)* %2, align 8
   %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
@@ -6087,8 +7541,8 @@ entry:
   %10 = bitcast i16* %3 to i8*
   %11 = getelementptr inbounds i8, i8* %10, i64 %9
   %12 = bitcast i8* %11 to i16*
-  %NullCheck4 = icmp ne i16* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %5
   store i16 0, i16* %12, align 8
@@ -6098,11 +7552,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6119,8 +7573,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -6131,8 +7585,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
@@ -6144,15 +7598,15 @@ entry:
 
 ; <label>:14                                      ; preds = %1
   %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
   %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
   %21 = load i64, i64 addrspace(1)* %19
@@ -6171,15 +7625,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %14
+ThrowNullRef4:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %16
+ThrowNullRef6:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6302,14 +7756,6 @@ entry:
   ret %System.String addrspace(1)* %57
 }
 
-INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
-Successfully read RuntimeHelpers.get_OffsetToStringData
-
-define i32 @RuntimeHelpers.get_OffsetToStringData() {
-entry:
-  ret i32 12
-}
-
 INFO:  jitting method String::Equals using LLILCJit
 Successfully read String.Equals
 
@@ -6381,8 +7827,8 @@ entry:
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
-  br i1 %NullCheck24, label %29, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
   %30 = load i64, i64 addrspace(1)* %28
@@ -6397,8 +7843,8 @@ entry:
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
-  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
   %43 = load i64, i64 addrspace(1)* %41
@@ -6418,8 +7864,8 @@ entry:
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
   %59 = load i64, i64 addrspace(1)* %57
@@ -6434,8 +7880,8 @@ entry:
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck22, label %71, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
   %72 = load i64, i64 addrspace(1)* %70
@@ -6455,8 +7901,8 @@ entry:
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
-  br i1 %NullCheck16, label %87, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = load i64, i64 addrspace(1)* %86
@@ -6471,8 +7917,8 @@ entry:
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck18, label %100, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
   %101 = load i64, i64 addrspace(1)* %99
@@ -6492,8 +7938,8 @@ entry:
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
-  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
   %117 = load i64, i64 addrspace(1)* %115
@@ -6508,8 +7954,8 @@ entry:
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
-  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
   %130 = load i64, i64 addrspace(1)* %128
@@ -6528,15 +7974,15 @@ entry:
 
 ; <label>:142                                     ; preds = %22
   %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
-  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %143, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %144
 
 ; <label>:144                                     ; preds = %142
   %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
   %146 = load i32, i32 addrspace(1)* %145
   %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
-  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %147, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %148
 
 ; <label>:148                                     ; preds = %144
   %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
@@ -6557,15 +8003,15 @@ entry:
 
 ; <label>:159                                     ; preds = %22
   %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
-  br i1 %NullCheck, label %161, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %ThrowNullRef, label %161
 
 ; <label>:161                                     ; preds = %159
   %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
   %163 = load i32, i32 addrspace(1)* %162
   %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
-  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %164, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %165
 
 ; <label>:165                                     ; preds = %161
   %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
@@ -6578,8 +8024,8 @@ entry:
 
 ; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
-  br i1 %NullCheck4, label %172, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %171, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %172
 
 ; <label>:172                                     ; preds = %170
   %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
@@ -6589,8 +8035,8 @@ entry:
 
 ; <label>:176                                     ; preds = %172
   %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
-  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %177, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %178
 
 ; <label>:178                                     ; preds = %176
   %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
@@ -6629,55 +8075,55 @@ ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %161
+ThrowNullRef2:                                    ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %170
+ThrowNullRef4:                                    ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %176
+ThrowNullRef6:                                    ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %142
+ThrowNullRef8:                                    ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %144
+ThrowNullRef10:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %113
+ThrowNullRef12:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %116
+ThrowNullRef14:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %84
+ThrowNullRef16:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %87
+ThrowNullRef18:                                   ; preds = %87
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %55
+ThrowNullRef20:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %58
+ThrowNullRef22:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %26
+ThrowNullRef24:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %29
+ThrowNullRef26:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,8 +8161,8 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck, label %14, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %ThrowNullRef, label %14
 
 ; <label>:14                                      ; preds = %8
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
@@ -6760,8 +8206,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
@@ -6770,14 +8216,14 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32, i32* %loc0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %10
   %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
   %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
@@ -6790,15 +8236,15 @@ entry:
 ; <label>:25                                      ; preds = %19
   %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
-  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
   %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
@@ -6807,8 +8253,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %37 = load i32, i32* %loc0
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %38, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %38
 
 ; <label>:38                                      ; preds = %32
   %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
@@ -6817,14 +8263,14 @@ entry:
 
 ; <label>:40                                      ; preds = %19
   %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %40
   %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
   %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
-  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
-  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
@@ -6832,8 +8278,8 @@ entry:
   %48 = zext i32 %47 to i64
   %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
-  br i1 %NullCheck16, label %51, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %51
 
 ; <label>:51                                      ; preds = %45
   %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
@@ -6847,15 +8293,15 @@ entry:
 ; <label>:57                                      ; preds = %51
   %58 = load i16*, i16** %arg1
   %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
-  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %60
 
 ; <label>:60                                      ; preds = %57
   %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
   %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
-  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %64
 
 ; <label>:64                                      ; preds = %60
   %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
@@ -6864,22 +8310,22 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
   %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
-  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %70
 
 ; <label>:70                                      ; preds = %64
   %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
   %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
-  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
-  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
   %75 = load i32, i32 addrspace(1)* %74
   %76 = zext i32 %75 to i64
   %77 = trunc i64 %76 to i32
-  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
-  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %78
 
 ; <label>:78                                      ; preds = %73
   %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
@@ -6901,8 +8347,8 @@ entry:
   %90 = bitcast i16* %86 to i8*
   %91 = getelementptr inbounds i8, i8* %90, i64 %89
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %93
 
 ; <label>:93                                      ; preds = %80
   %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
@@ -6912,8 +8358,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %99 = load i32, i32* %loc2
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %100
 
 ; <label>:100                                     ; preds = %93
   %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
@@ -6928,63 +8374,63 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %25
+ThrowNullRef6:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %32
+ThrowNullRef10:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %40
+ThrowNullRef12:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %45
+ThrowNullRef16:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %57
+ThrowNullRef18:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %60
+ThrowNullRef20:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %64
+ThrowNullRef22:                                   ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %70
+ThrowNullRef24:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %73
+ThrowNullRef26:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %80
+ThrowNullRef28:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %93
+ThrowNullRef30:                                   ; preds = %93
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7004,8 +8450,8 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
@@ -7033,43 +8479,43 @@ entry:
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %14
   %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
   %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   %28 = load i32, i32 addrspace(1)* %27, align 8
   %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
-  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %30
 
 ; <label>:30                                      ; preds = %26
   %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
   %32 = load i32, i32 addrspace(1)* %31, align 8
   %33 = add i32 %28, %32
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %34
 
 ; <label>:34                                      ; preds = %30
   %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   store i32 %33, i32 addrspace(1)* %35
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
   store i32 0, i32 addrspace(1)* %38
   %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %40
 
 ; <label>:40                                      ; preds = %37
   %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
@@ -7082,8 +8528,8 @@ entry:
 
 ; <label>:47                                      ; preds = %40
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
@@ -7098,8 +8544,8 @@ entry:
   %54 = load i32, i32* %loc0
   %55 = sext i32 %54 to i64
   %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
-  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %57
 
 ; <label>:57                                      ; preds = %52
   %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
@@ -7110,68 +8556,35 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %14
+ThrowNullRef2:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %23
+ThrowNullRef4:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %26
+ThrowNullRef6:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %30
+ThrowNullRef8:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %34
+ThrowNullRef10:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %47
+ThrowNullRef14:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %52
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-}
-
-INFO:  jitting method StringBuilder::get_Length using LLILCJit
-Successfully read StringBuilder.get_Length
-
-define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.StringBuilder addrspace(1)*
-  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
-  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
-
-; <label>:1                                       ; preds = %entry
-  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %3 = load i32, i32 addrspace(1)* %2, align 8
-  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
-
-; <label>:5                                       ; preds = %1
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = add i32 %3, %7
-  ret i32 %8
-
-ThrowNullRef:                                     ; preds = %entry
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef16:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7213,70 +8626,70 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
   %6 = load i32, i32 addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
   store i32 %6, i32 addrspace(1)* %8
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
   %13 = load i32, i32 addrspace(1)* %12, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
   store i32 %13, i32 addrspace(1)* %15
   %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
-  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %18
 
 ; <label>:18                                      ; preds = %14
   %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
   %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
   %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
   %34 = load i32, i32 addrspace(1)* %33, align 8
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
-  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
@@ -7287,39 +8700,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %28
+ThrowNullRef16:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %32
+ThrowNullRef18:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7455,13 +8868,13 @@ entry:
 ; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
@@ -7477,16 +8890,16 @@ entry:
 
 ; <label>:18                                      ; preds = %15
   %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
   store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
   %22 = load i32, i32* %loc0
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %24
 
 ; <label>:24                                      ; preds = %20
   %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
@@ -7498,13 +8911,13 @@ entry:
 ; <label>:28                                      ; preds = %15, %24
   %29 = load i32, i32* %arg1
   %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %31
   %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
@@ -7517,20 +8930,20 @@ entry:
   %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
-  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
   %46 = load i32, i32 addrspace(1)* %45, align 8
   %47 = sub i32 %40, %46
-  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
-  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i32 addrspace(1)* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %48
 
 ; <label>:48                                      ; preds = %44
   store i32 %47, i32 addrspace(1)* %39, align 8
@@ -7538,21 +8951,21 @@ entry:
 
 ; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
-  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %51
 
 ; <label>:51                                      ; preds = %49
   %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %53
 
 ; <label>:53                                      ; preds = %51
   %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
   %55 = load i32, i32 addrspace(1)* %54, align 8
   %56 = load i32, i32* %arg2
   %57 = sub i32 %55, %56
-  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %58
 
 ; <label>:58                                      ; preds = %53
   %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
@@ -7562,13 +8975,13 @@ entry:
 ; <label>:60                                      ; preds = %33, %58
   %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
   %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
-  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %63
 
 ; <label>:63                                      ; preds = %60
   %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
-  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
-  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
@@ -7578,15 +8991,15 @@ entry:
 
 ; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
-  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i32 addrspace(1)* %69, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %70
 
 ; <label>:70                                      ; preds = %68
   %71 = load i32, i32 addrspace(1)* %69, align 8
   store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
-  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
@@ -7596,8 +9009,8 @@ entry:
   store i32 %77, i32* %loc4
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
-  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %80
 
 ; <label>:80                                      ; preds = %73
   %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
@@ -7607,71 +9020,71 @@ entry:
 ; <label>:83                                      ; preds = %80
   store i32 0, i32* %loc3
   %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
-  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
-  br i1 %NullCheck26, label %88, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i32 addrspace(1)* %87, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %88
 
 ; <label>:88                                      ; preds = %85
   %89 = load i32, i32 addrspace(1)* %87, align 8
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
-  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %90
 
 ; <label>:90                                      ; preds = %88
   %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
   store i32 %89, i32 addrspace(1)* %91
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
-  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
-  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %96
 
 ; <label>:96                                      ; preds = %94
   %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
-  br i1 %NullCheck34, label %100, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %100
 
 ; <label>:100                                     ; preds = %96
   %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
-  br i1 %NullCheck36, label %102, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %102
 
 ; <label>:102                                     ; preds = %100
   %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
   %104 = load i32, i32 addrspace(1)* %103, align 8
   %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
-  br i1 %NullCheck38, label %106, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %106
 
 ; <label>:106                                     ; preds = %102
   %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
-  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
-  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %108
 
 ; <label>:108                                     ; preds = %106
   %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
   %110 = load i32, i32 addrspace(1)* %109, align 8
   %111 = add i32 %104, %110
-  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %112
 
 ; <label>:112                                     ; preds = %108
   %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
   store i32 %111, i32 addrspace(1)* %113
   %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
-  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i32 addrspace(1)* %114, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %115
 
 ; <label>:115                                     ; preds = %112
   %116 = load i32, i32 addrspace(1)* %114, align 8
@@ -7681,19 +9094,19 @@ entry:
 ; <label>:118                                     ; preds = %115
   %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
-  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %121
 
 ; <label>:121                                     ; preds = %118
   %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
-  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
-  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %123
 
 ; <label>:123                                     ; preds = %121
   %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
   %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
-  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
-  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %126
 
 ; <label>:126                                     ; preds = %123
   %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
@@ -7705,8 +9118,8 @@ entry:
 
 ; <label>:130                                     ; preds = %80, %115, %126
   %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %132
 
 ; <label>:132                                     ; preds = %130
   %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7715,8 +9128,8 @@ entry:
   %136 = load i32, i32* %loc3
   %137 = sub i32 %135, %136
   %138 = sub i32 %134, %137
-  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %139
 
 ; <label>:139                                     ; preds = %132
   %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7728,16 +9141,16 @@ entry:
 
 ; <label>:144                                     ; preds = %139
   %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
-  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %146
 
 ; <label>:146                                     ; preds = %144
   %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
   %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
   %149 = load i32, i32* %loc2
   %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
-  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %151
 
 ; <label>:151                                     ; preds = %146
   %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
@@ -7754,145 +9167,249 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %18
+ThrowNullRef4:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %31
+ThrowNullRef10:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %44
+ThrowNullRef16:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %68
+ThrowNullRef18:                                   ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %70
+ThrowNullRef20:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %73
+ThrowNullRef22:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %83
+ThrowNullRef24:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %85
+ThrowNullRef26:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %88
+ThrowNullRef28:                                   ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %90
+ThrowNullRef30:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %94
+ThrowNullRef32:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %96
+ThrowNullRef34:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %100
+ThrowNullRef36:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %102
+ThrowNullRef38:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %106
+ThrowNullRef40:                                   ; preds = %106
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %108
+ThrowNullRef42:                                   ; preds = %108
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %112
+ThrowNullRef44:                                   ; preds = %112
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %118
+ThrowNullRef46:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %121
+ThrowNullRef48:                                   ; preds = %121
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %123
+ThrowNullRef50:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %130
+ThrowNullRef52:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %132
+ThrowNullRef54:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %144
+ThrowNullRef56:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %146
+ThrowNullRef58:                                   ; preds = %146
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %60
+ThrowNullRef60:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %63
+ThrowNullRef62:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %49
+ThrowNullRef64:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %51
+ThrowNullRef66:                                   ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %53
+ThrowNullRef68:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(%"System.Char[]" addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %arg0 = alloca %"System.Char[]" addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store %"System.Char[]" addrspace(1)* %param0, %"System.Char[]" addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load i32, i32* %arg4
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %43, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %38, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg1
+  %13 = load i32, i32* %arg4
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %38, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %24 = load i32, i32* %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %35 = load i32, i32* %arg3
+  %36 = load i32, i32* %arg4
+  %37 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %37, %"System.Char[]" addrspace(1)* %34, i32 %35, i32 %36)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:38                                      ; preds = %5, %16
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Successfully read Buffer._Memmove
 
@@ -7914,7 +9431,7 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[loadElem]
+Failed to read AppDomain.SetDataHelper[storeElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -7923,8 +9440,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
@@ -7934,8 +9451,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
@@ -7947,15 +9464,15 @@ entry:
   %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
   %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
@@ -7966,15 +9483,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7992,7 +9509,79 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
-Failed to read Dictionary`2.TryGetValue[loadElemA]
+Successfully read Dictionary`2.TryGetValue
+
+define i8 @"Dictionary`2.TryGetValue"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)* addrspace(1)* %param2) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  %arg2 = alloca %System.__Canon addrspace(1)* addrspace(1)*
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  store %System.__Canon addrspace(1)* addrspace(1)* %param2, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  store i32 %2, i32* %loc0
+  %3 = load i32, i32* %loc0
+  %4 = icmp slt i32 %3, 0
+  br i1 %4, label %22, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 2
+  %10 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %9, align 8
+  %11 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = zext i32 %11 to i64
+  %BoundsCheck = icmp uge i64 %16, %15
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 3, i32 %11
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %20, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %6, %System.__Canon addrspace(1)* %21)
+  ret i8 1
+
+; <label>:22                                      ; preds = %entry
+  %23 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %23, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -8058,8 +9647,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
@@ -8091,8 +9680,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
@@ -8171,15 +9760,15 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck, label %19, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %ThrowNullRef, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
   %21 = load i32, i32 addrspace(1)* %20
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
@@ -8202,7 +9791,7 @@ ThrowNullRef:                                     ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %19
+ThrowNullRef2:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8248,8 +9837,8 @@ entry:
   %0 = alloca %System.AppDomainHandle
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %1 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %1, i32 0, i32 15
@@ -8269,8 +9858,8 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
@@ -8286,7 +9875,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -8299,8 +9888,8 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -8327,8 +9916,8 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
@@ -8352,8 +9941,8 @@ entry:
   %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
   store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
@@ -8363,8 +9952,8 @@ entry:
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
@@ -8374,8 +9963,8 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %9
   %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
@@ -8384,8 +9973,8 @@ entry:
 
 ; <label>:18                                      ; preds = %3, %16
   %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
@@ -8397,15 +9986,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %18
+ThrowNullRef6:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8418,8 +10007,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
@@ -8453,15 +10042,15 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
@@ -8473,7 +10062,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8481,7 +10070,7 @@ ThrowNullRef1:                                    ; preds = %1
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
 Failed to read Dictionary`2.System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
@@ -8506,8 +10095,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
@@ -8524,8 +10113,8 @@ entry:
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -8544,7 +10133,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8577,8 +10166,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = load i64, i64* %arg2
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = trunc i32 %3 to i8
@@ -8634,46 +10223,46 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
   %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
-  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
-  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
-  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
@@ -8684,27 +10273,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %20
+ThrowNullRef12:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8717,8 +10306,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -8756,22 +10345,22 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
   %9 = load i64, i64 addrspace(1)* %8, align 8
   %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
   %13 = load i64, i64 addrspace(1)* %12, align 8
   %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %11
   %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
@@ -8788,11 +10377,11 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8882,8 +10471,8 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
@@ -8900,8 +10489,8 @@ entry:
 ; <label>:8                                       ; preds = %1
   %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
   %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
@@ -8911,15 +10500,15 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
   %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
   %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
-  br i1 %NullCheck6, label %21, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
@@ -8946,15 +10535,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8992,15 +10581,15 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
   store i8 %3, i8 addrspace(1)* %5
   %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
@@ -9011,7 +10600,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9027,8 +10616,8 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -9041,8 +10630,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
@@ -9058,7 +10647,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9080,8 +10669,8 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
@@ -9096,8 +10685,8 @@ entry:
 ; <label>:12                                      ; preds = %6
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
@@ -9112,8 +10701,8 @@ entry:
 ; <label>:21                                      ; preds = %15
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
@@ -9128,8 +10717,8 @@ entry:
 ; <label>:30                                      ; preds = %24
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %31, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
@@ -9144,8 +10733,8 @@ entry:
 ; <label>:39                                      ; preds = %33
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
-  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %40, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %42
 
 ; <label>:42                                      ; preds = %39
   %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
@@ -9164,19 +10753,19 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %21
+ThrowNullRef4:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %30
+ThrowNullRef6:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %39
+ThrowNullRef8:                                    ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9243,8 +10832,8 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
@@ -9264,57 +10853,57 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
   store i8 0, i8 addrspace(1)* %2
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
   store i8 0, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
   store i8 0, i8 addrspace(1)* %17
   %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
   store i8 0, i8 addrspace(1)* %20
   %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
-  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
@@ -9325,31 +10914,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %19
+ThrowNullRef14:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9367,8 +10956,8 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
@@ -9380,8 +10969,8 @@ entry:
 
 ; <label>:9                                       ; preds = %4
   %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %9
   %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
@@ -9395,7 +10984,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef2:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9420,8 +11009,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
@@ -9512,8 +11101,8 @@ entry:
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
@@ -9524,8 +11113,8 @@ entry:
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = load i64, i64 addrspace(1)* %12
@@ -9537,8 +11126,8 @@ entry:
   %20 = load i64, i64* %19
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
-  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %13
   %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
@@ -9555,8 +11144,8 @@ entry:
 ; <label>:30                                      ; preds = %25
   %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %32 = load i32, i32* %arg2
-  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
-  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
@@ -9570,15 +11159,15 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %30
+ThrowNullRef2:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9622,87 +11211,87 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
   %10 = load i8, i8 addrspace(1)* %9, align 8
   %11 = zext i8 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %8
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
   store i8 %12, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
   %19 = load i8, i8 addrspace(1)* %18, align 8
   %20 = zext i8 %19 to i32
   %21 = trunc i32 %20 to i8
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
   store i8 %21, i8 addrspace(1)* %23
   %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
   %28 = load i8, i8 addrspace(1)* %27, align 8
   %29 = zext i8 %28 to i32
   %30 = trunc i32 %29 to i8
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
-  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %31
 
 ; <label>:31                                      ; preds = %26
   %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
   store i8 %30, i8 addrspace(1)* %32
   %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
-  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
-  br i1 %NullCheck14, label %40, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %40
 
 ; <label>:40                                      ; preds = %35
   %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
   store i8 %39, i8 addrspace(1)* %41
   %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
-  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %44
 
 ; <label>:44                                      ; preds = %40
   %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
   %46 = load i8, i8 addrspace(1)* %45, align 8
   %47 = zext i8 %46 to i32
   %48 = trunc i32 %47 to i8
-  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
   store i8 %48, i8 addrspace(1)* %50
   %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
-  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
@@ -9713,29 +11302,29 @@ entry:
 ; <label>:56                                      ; preds = %52
   %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
-  br i1 %NullCheck22, label %59, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
   %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
   %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
-  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
-  br i1 %NullCheck24, label %63, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
   %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
-  br i1 %NullCheck26, label %66, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
   %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
-  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
-  br i1 %NullCheck28, label %69, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %69
 
 ; <label>:69                                      ; preds = %66
   %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
@@ -9744,15 +11333,15 @@ entry:
 
 ; <label>:71                                      ; preds = %105
   %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
-  br i1 %NullCheck34, label %73, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %73
 
 ; <label>:73                                      ; preds = %71
   %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
   %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
   %76 = load i32, i32* %loc0
-  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
-  br i1 %NullCheck36, label %77, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
@@ -9766,8 +11355,8 @@ entry:
 
 ; <label>:83                                      ; preds = %77
   %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
-  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
@@ -9775,14 +11364,14 @@ entry:
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
   %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
-  br i1 %NullCheck40, label %91, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
 ; <label>:91                                      ; preds = %85
   %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
   %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
-  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck42, label %94, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %94
 
 ; <label>:94                                      ; preds = %91
   %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
@@ -9798,14 +11387,14 @@ entry:
 ; <label>:99                                      ; preds = %69, %96
   %100 = load i32, i32* %loc0
   %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
-  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %102
 
 ; <label>:102                                     ; preds = %99
   %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
   %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
-  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
-  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
@@ -9819,87 +11408,87 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %26
+ThrowNullRef10:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %31
+ThrowNullRef12:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %35
+ThrowNullRef14:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %40
+ThrowNullRef16:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %56
+ThrowNullRef22:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %59
+ThrowNullRef24:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %63
+ThrowNullRef26:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %66
+ThrowNullRef28:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %102
+ThrowNullRef32:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %71
+ThrowNullRef34:                                   ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %73
+ThrowNullRef36:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %83
+ThrowNullRef38:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %85
+ThrowNullRef40:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %91
+ThrowNullRef42:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9943,15 +11532,15 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
   %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
@@ -9961,28 +11550,28 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
   %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %12
   %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
   %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
   %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
-  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
@@ -9993,23 +11582,23 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %12
+ThrowNullRef6:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10031,15 +11620,15 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
   %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = load i64, i64 addrspace(1)* %7
@@ -10077,13 +11666,13 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[loadElem]
+Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -10111,8 +11700,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPAdd.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPAdd.error.txt
@@ -25,8 +25,8 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
@@ -40,8 +40,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
   %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
@@ -75,7 +75,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -90,8 +90,8 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %NullCheck = icmp ne i8 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = load i8, i8 addrspace(1)* %0, align 8
@@ -125,8 +125,8 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
@@ -159,8 +159,8 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -184,8 +184,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
   store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
@@ -195,8 +195,8 @@ entry:
 ; <label>:4                                       ; preds = %1
   %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
   %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
@@ -206,8 +206,8 @@ entry:
   %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
@@ -221,14 +221,14 @@ entry:
 
 ; <label>:17                                      ; preds = %14
   %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
   %21 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
@@ -238,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -249,8 +249,8 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
@@ -261,27 +261,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %30
+ThrowNullRef10:                                   ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -301,7 +301,89 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
-Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
+Successfully read AppDomainSetup.GetUnsecureApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.GetUnsecureApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %NullCheck = icmp eq %"System.String[]" addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %BoundsCheck = icmp uge i64 0, %5
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %6
+
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 3, i32 0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
+  ret %System.String addrspace(1)* %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_Value using LLILCJit
+Successfully read AppDomainSetup.get_Value
+
+define %"System.String[]" addrspace(1)* @AppDomainSetup.get_Value(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.String[]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 18)
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.String[]" addrspace(1)* addrspace(1)*, %"System.String[]" addrspace(1)*)*)(%"System.String[]" addrspace(1)* addrspace(1)* %9, %"System.String[]" addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %11, i32 0, i32 1
+  %14 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %13, align 8
+  ret %"System.String[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -319,8 +401,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -368,16 +450,16 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
   %5 = load i32, i32 addrspace(1)* %4
   %6 = sub i32 %5, 1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -389,7 +471,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -421,8 +503,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
@@ -456,8 +538,8 @@ entry:
 ; <label>:27                                      ; preds = %19
   %28 = load i32, i32* %arg1
   %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
-  br i1 %NullCheck2, label %30, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %29, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %30
 
 ; <label>:30                                      ; preds = %27
   %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
@@ -493,8 +575,8 @@ entry:
 ; <label>:49                                      ; preds = %46
   %50 = load i32, i32* %arg2
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck4, label %52, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
@@ -517,11 +599,11 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %27
+ThrowNullRef2:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %49
+ThrowNullRef4:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -544,16 +626,16 @@ entry:
   %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %0)
   store %System.String addrspace(1)* %1, %System.String addrspace(1)** %loc0
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 2
   %5 = bitcast [0 x i16] addrspace(1)* %4 to i16 addrspace(1)*
   store i16 addrspace(1)* %5, i16 addrspace(1)** %loc1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %3
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2
@@ -580,7 +662,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -691,15 +773,15 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %NullCheck132 = icmp ne i8* %21, null
-  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+  %NullCheck131 = icmp eq i8* %21, null
+  br i1 %NullCheck131, label %ThrowNullRef132, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = load i8, i8* %21, align 8
   %24 = zext i8 %23 to i32
   %25 = trunc i32 %24 to i8
-  %NullCheck134 = icmp ne i8* %20, null
-  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+  %NullCheck133 = icmp eq i8* %20, null
+  br i1 %NullCheck133, label %ThrowNullRef134, label %26
 
 ; <label>:26                                      ; preds = %22
   store i8 %25, i8* %20, align 8
@@ -709,16 +791,16 @@ entry:
   %28 = load i8*, i8** %arg0
   %29 = load i8*, i8** %arg1
   %30 = bitcast i8* %29 to i16*
-  %NullCheck128 = icmp ne i16* %30, null
-  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+  %NullCheck127 = icmp eq i16* %30, null
+  br i1 %NullCheck127, label %ThrowNullRef128, label %31
 
 ; <label>:31                                      ; preds = %27
   %32 = load i16, i16* %30, align 8
   %33 = sext i16 %32 to i32
   %34 = bitcast i8* %28 to i16*
   %35 = trunc i32 %33 to i16
-  %NullCheck130 = icmp ne i16* %34, null
-  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+  %NullCheck129 = icmp eq i16* %34, null
+  br i1 %NullCheck129, label %ThrowNullRef130, label %36
 
 ; <label>:36                                      ; preds = %31
   store i16 %35, i16* %34, align 8
@@ -728,16 +810,16 @@ entry:
   %38 = load i8*, i8** %arg0
   %39 = load i8*, i8** %arg1
   %40 = bitcast i8* %39 to i16*
-  %NullCheck120 = icmp ne i16* %40, null
-  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+  %NullCheck119 = icmp eq i16* %40, null
+  br i1 %NullCheck119, label %ThrowNullRef120, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i16, i16* %40, align 8
   %43 = sext i16 %42 to i32
   %44 = bitcast i8* %38 to i16*
   %45 = trunc i32 %43 to i16
-  %NullCheck122 = icmp ne i16* %44, null
-  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+  %NullCheck121 = icmp eq i16* %44, null
+  br i1 %NullCheck121, label %ThrowNullRef122, label %46
 
 ; <label>:46                                      ; preds = %41
   store i16 %45, i16* %44, align 8
@@ -745,15 +827,15 @@ entry:
   %48 = getelementptr inbounds i8, i8* %47, i64 2
   %49 = load i8*, i8** %arg1
   %50 = getelementptr inbounds i8, i8* %49, i64 2
-  %NullCheck124 = icmp ne i8* %50, null
-  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+  %NullCheck123 = icmp eq i8* %50, null
+  br i1 %NullCheck123, label %ThrowNullRef124, label %51
 
 ; <label>:51                                      ; preds = %46
   %52 = load i8, i8* %50, align 8
   %53 = zext i8 %52 to i32
   %54 = trunc i32 %53 to i8
-  %NullCheck126 = icmp ne i8* %48, null
-  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+  %NullCheck125 = icmp eq i8* %48, null
+  br i1 %NullCheck125, label %ThrowNullRef126, label %55
 
 ; <label>:55                                      ; preds = %51
   store i8 %54, i8* %48, align 8
@@ -763,14 +845,14 @@ entry:
   %57 = load i8*, i8** %arg0
   %58 = load i8*, i8** %arg1
   %59 = bitcast i8* %58 to i32*
-  %NullCheck116 = icmp ne i32* %59, null
-  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+  %NullCheck115 = icmp eq i32* %59, null
+  br i1 %NullCheck115, label %ThrowNullRef116, label %60
 
 ; <label>:60                                      ; preds = %56
   %61 = load i32, i32* %59, align 8
   %62 = bitcast i8* %57 to i32*
-  %NullCheck118 = icmp ne i32* %62, null
-  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+  %NullCheck117 = icmp eq i32* %62, null
+  br i1 %NullCheck117, label %ThrowNullRef118, label %63
 
 ; <label>:63                                      ; preds = %60
   store i32 %61, i32* %62, align 8
@@ -780,14 +862,14 @@ entry:
   %65 = load i8*, i8** %arg0
   %66 = load i8*, i8** %arg1
   %67 = bitcast i8* %66 to i32*
-  %NullCheck108 = icmp ne i32* %67, null
-  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+  %NullCheck107 = icmp eq i32* %67, null
+  br i1 %NullCheck107, label %ThrowNullRef108, label %68
 
 ; <label>:68                                      ; preds = %64
   %69 = load i32, i32* %67, align 8
   %70 = bitcast i8* %65 to i32*
-  %NullCheck110 = icmp ne i32* %70, null
-  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+  %NullCheck109 = icmp eq i32* %70, null
+  br i1 %NullCheck109, label %ThrowNullRef110, label %71
 
 ; <label>:71                                      ; preds = %68
   store i32 %69, i32* %70, align 8
@@ -795,15 +877,15 @@ entry:
   %73 = getelementptr inbounds i8, i8* %72, i64 4
   %74 = load i8*, i8** %arg1
   %75 = getelementptr inbounds i8, i8* %74, i64 4
-  %NullCheck112 = icmp ne i8* %75, null
-  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+  %NullCheck111 = icmp eq i8* %75, null
+  br i1 %NullCheck111, label %ThrowNullRef112, label %76
 
 ; <label>:76                                      ; preds = %71
   %77 = load i8, i8* %75, align 8
   %78 = zext i8 %77 to i32
   %79 = trunc i32 %78 to i8
-  %NullCheck114 = icmp ne i8* %73, null
-  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+  %NullCheck113 = icmp eq i8* %73, null
+  br i1 %NullCheck113, label %ThrowNullRef114, label %80
 
 ; <label>:80                                      ; preds = %76
   store i8 %79, i8* %73, align 8
@@ -813,14 +895,14 @@ entry:
   %82 = load i8*, i8** %arg0
   %83 = load i8*, i8** %arg1
   %84 = bitcast i8* %83 to i32*
-  %NullCheck100 = icmp ne i32* %84, null
-  br i1 %NullCheck100, label %85, label %ThrowNullRef99
+  %NullCheck99 = icmp eq i32* %84, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %85
 
 ; <label>:85                                      ; preds = %81
   %86 = load i32, i32* %84, align 8
   %87 = bitcast i8* %82 to i32*
-  %NullCheck102 = icmp ne i32* %87, null
-  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+  %NullCheck101 = icmp eq i32* %87, null
+  br i1 %NullCheck101, label %ThrowNullRef102, label %88
 
 ; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
@@ -829,16 +911,16 @@ entry:
   %91 = load i8*, i8** %arg1
   %92 = getelementptr inbounds i8, i8* %91, i64 4
   %93 = bitcast i8* %92 to i16*
-  %NullCheck104 = icmp ne i16* %93, null
-  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+  %NullCheck103 = icmp eq i16* %93, null
+  br i1 %NullCheck103, label %ThrowNullRef104, label %94
 
 ; <label>:94                                      ; preds = %88
   %95 = load i16, i16* %93, align 8
   %96 = sext i16 %95 to i32
   %97 = bitcast i8* %90 to i16*
   %98 = trunc i32 %96 to i16
-  %NullCheck106 = icmp ne i16* %97, null
-  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+  %NullCheck105 = icmp eq i16* %97, null
+  br i1 %NullCheck105, label %ThrowNullRef106, label %99
 
 ; <label>:99                                      ; preds = %94
   store i16 %98, i16* %97, align 8
@@ -848,14 +930,14 @@ entry:
   %101 = load i8*, i8** %arg0
   %102 = load i8*, i8** %arg1
   %103 = bitcast i8* %102 to i32*
-  %NullCheck88 = icmp ne i32* %103, null
-  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+  %NullCheck87 = icmp eq i32* %103, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %104
 
 ; <label>:104                                     ; preds = %100
   %105 = load i32, i32* %103, align 8
   %106 = bitcast i8* %101 to i32*
-  %NullCheck90 = icmp ne i32* %106, null
-  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+  %NullCheck89 = icmp eq i32* %106, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %107
 
 ; <label>:107                                     ; preds = %104
   store i32 %105, i32* %106, align 8
@@ -864,16 +946,16 @@ entry:
   %110 = load i8*, i8** %arg1
   %111 = getelementptr inbounds i8, i8* %110, i64 4
   %112 = bitcast i8* %111 to i16*
-  %NullCheck92 = icmp ne i16* %112, null
-  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+  %NullCheck91 = icmp eq i16* %112, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %113
 
 ; <label>:113                                     ; preds = %107
   %114 = load i16, i16* %112, align 8
   %115 = sext i16 %114 to i32
   %116 = bitcast i8* %109 to i16*
   %117 = trunc i32 %115 to i16
-  %NullCheck94 = icmp ne i16* %116, null
-  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+  %NullCheck93 = icmp eq i16* %116, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %118
 
 ; <label>:118                                     ; preds = %113
   store i16 %117, i16* %116, align 8
@@ -881,15 +963,15 @@ entry:
   %120 = getelementptr inbounds i8, i8* %119, i64 6
   %121 = load i8*, i8** %arg1
   %122 = getelementptr inbounds i8, i8* %121, i64 6
-  %NullCheck96 = icmp ne i8* %122, null
-  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+  %NullCheck95 = icmp eq i8* %122, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %123
 
 ; <label>:123                                     ; preds = %118
   %124 = load i8, i8* %122, align 8
   %125 = zext i8 %124 to i32
   %126 = trunc i32 %125 to i8
-  %NullCheck98 = icmp ne i8* %120, null
-  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+  %NullCheck97 = icmp eq i8* %120, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %127
 
 ; <label>:127                                     ; preds = %123
   store i8 %126, i8* %120, align 8
@@ -899,14 +981,14 @@ entry:
   %129 = load i8*, i8** %arg0
   %130 = load i8*, i8** %arg1
   %131 = bitcast i8* %130 to i64*
-  %NullCheck84 = icmp ne i64* %131, null
-  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+  %NullCheck83 = icmp eq i64* %131, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %132
 
 ; <label>:132                                     ; preds = %128
   %133 = load i64, i64* %131, align 8
   %134 = bitcast i8* %129 to i64*
-  %NullCheck86 = icmp ne i64* %134, null
-  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+  %NullCheck85 = icmp eq i64* %134, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %135
 
 ; <label>:135                                     ; preds = %132
   store i64 %133, i64* %134, align 8
@@ -916,14 +998,14 @@ entry:
   %137 = load i8*, i8** %arg0
   %138 = load i8*, i8** %arg1
   %139 = bitcast i8* %138 to i64*
-  %NullCheck76 = icmp ne i64* %139, null
-  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+  %NullCheck75 = icmp eq i64* %139, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %140
 
 ; <label>:140                                     ; preds = %136
   %141 = load i64, i64* %139, align 8
   %142 = bitcast i8* %137 to i64*
-  %NullCheck78 = icmp ne i64* %142, null
-  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+  %NullCheck77 = icmp eq i64* %142, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %143
 
 ; <label>:143                                     ; preds = %140
   store i64 %141, i64* %142, align 8
@@ -931,15 +1013,15 @@ entry:
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %NullCheck80 = icmp ne i8* %147, null
-  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+  %NullCheck79 = icmp eq i8* %147, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %148
 
 ; <label>:148                                     ; preds = %143
   %149 = load i8, i8* %147, align 8
   %150 = zext i8 %149 to i32
   %151 = trunc i32 %150 to i8
-  %NullCheck82 = icmp ne i8* %145, null
-  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+  %NullCheck81 = icmp eq i8* %145, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %152
 
 ; <label>:152                                     ; preds = %148
   store i8 %151, i8* %145, align 8
@@ -949,14 +1031,14 @@ entry:
   %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
   %156 = bitcast i8* %155 to i64*
-  %NullCheck68 = icmp ne i64* %156, null
-  br i1 %NullCheck68, label %157, label %ThrowNullRef67
+  %NullCheck67 = icmp eq i64* %156, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %157
 
 ; <label>:157                                     ; preds = %153
   %158 = load i64, i64* %156, align 8
   %159 = bitcast i8* %154 to i64*
-  %NullCheck70 = icmp ne i64* %159, null
-  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+  %NullCheck69 = icmp eq i64* %159, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %160
 
 ; <label>:160                                     ; preds = %157
   store i64 %158, i64* %159, align 8
@@ -965,16 +1047,16 @@ entry:
   %163 = load i8*, i8** %arg1
   %164 = getelementptr inbounds i8, i8* %163, i64 8
   %165 = bitcast i8* %164 to i16*
-  %NullCheck72 = icmp ne i16* %165, null
-  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+  %NullCheck71 = icmp eq i16* %165, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %166
 
 ; <label>:166                                     ; preds = %160
   %167 = load i16, i16* %165, align 8
   %168 = sext i16 %167 to i32
   %169 = bitcast i8* %162 to i16*
   %170 = trunc i32 %168 to i16
-  %NullCheck74 = icmp ne i16* %169, null
-  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+  %NullCheck73 = icmp eq i16* %169, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %171
 
 ; <label>:171                                     ; preds = %166
   store i16 %170, i16* %169, align 8
@@ -984,14 +1066,14 @@ entry:
   %173 = load i8*, i8** %arg0
   %174 = load i8*, i8** %arg1
   %175 = bitcast i8* %174 to i64*
-  %NullCheck56 = icmp ne i64* %175, null
-  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+  %NullCheck55 = icmp eq i64* %175, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %176
 
 ; <label>:176                                     ; preds = %172
   %177 = load i64, i64* %175, align 8
   %178 = bitcast i8* %173 to i64*
-  %NullCheck58 = icmp ne i64* %178, null
-  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+  %NullCheck57 = icmp eq i64* %178, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %179
 
 ; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
@@ -1000,16 +1082,16 @@ entry:
   %182 = load i8*, i8** %arg1
   %183 = getelementptr inbounds i8, i8* %182, i64 8
   %184 = bitcast i8* %183 to i16*
-  %NullCheck60 = icmp ne i16* %184, null
-  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+  %NullCheck59 = icmp eq i16* %184, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %185
 
 ; <label>:185                                     ; preds = %179
   %186 = load i16, i16* %184, align 8
   %187 = sext i16 %186 to i32
   %188 = bitcast i8* %181 to i16*
   %189 = trunc i32 %187 to i16
-  %NullCheck62 = icmp ne i16* %188, null
-  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+  %NullCheck61 = icmp eq i16* %188, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %190
 
 ; <label>:190                                     ; preds = %185
   store i16 %189, i16* %188, align 8
@@ -1017,15 +1099,15 @@ entry:
   %192 = getelementptr inbounds i8, i8* %191, i64 10
   %193 = load i8*, i8** %arg1
   %194 = getelementptr inbounds i8, i8* %193, i64 10
-  %NullCheck64 = icmp ne i8* %194, null
-  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+  %NullCheck63 = icmp eq i8* %194, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %195
 
 ; <label>:195                                     ; preds = %190
   %196 = load i8, i8* %194, align 8
   %197 = zext i8 %196 to i32
   %198 = trunc i32 %197 to i8
-  %NullCheck66 = icmp ne i8* %192, null
-  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+  %NullCheck65 = icmp eq i8* %192, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %199
 
 ; <label>:199                                     ; preds = %195
   store i8 %198, i8* %192, align 8
@@ -1035,14 +1117,14 @@ entry:
   %201 = load i8*, i8** %arg0
   %202 = load i8*, i8** %arg1
   %203 = bitcast i8* %202 to i64*
-  %NullCheck48 = icmp ne i64* %203, null
-  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+  %NullCheck47 = icmp eq i64* %203, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %204
 
 ; <label>:204                                     ; preds = %200
   %205 = load i64, i64* %203, align 8
   %206 = bitcast i8* %201 to i64*
-  %NullCheck50 = icmp ne i64* %206, null
-  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+  %NullCheck49 = icmp eq i64* %206, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %207
 
 ; <label>:207                                     ; preds = %204
   store i64 %205, i64* %206, align 8
@@ -1051,14 +1133,14 @@ entry:
   %210 = load i8*, i8** %arg1
   %211 = getelementptr inbounds i8, i8* %210, i64 8
   %212 = bitcast i8* %211 to i32*
-  %NullCheck52 = icmp ne i32* %212, null
-  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+  %NullCheck51 = icmp eq i32* %212, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %213
 
 ; <label>:213                                     ; preds = %207
   %214 = load i32, i32* %212, align 8
   %215 = bitcast i8* %209 to i32*
-  %NullCheck54 = icmp ne i32* %215, null
-  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+  %NullCheck53 = icmp eq i32* %215, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %216
 
 ; <label>:216                                     ; preds = %213
   store i32 %214, i32* %215, align 8
@@ -1068,14 +1150,14 @@ entry:
   %218 = load i8*, i8** %arg0
   %219 = load i8*, i8** %arg1
   %220 = bitcast i8* %219 to i64*
-  %NullCheck36 = icmp ne i64* %220, null
-  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64* %220, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %221
 
 ; <label>:221                                     ; preds = %217
   %222 = load i64, i64* %220, align 8
   %223 = bitcast i8* %218 to i64*
-  %NullCheck38 = icmp ne i64* %223, null
-  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+  %NullCheck37 = icmp eq i64* %223, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %224
 
 ; <label>:224                                     ; preds = %221
   store i64 %222, i64* %223, align 8
@@ -1084,14 +1166,14 @@ entry:
   %227 = load i8*, i8** %arg1
   %228 = getelementptr inbounds i8, i8* %227, i64 8
   %229 = bitcast i8* %228 to i32*
-  %NullCheck40 = icmp ne i32* %229, null
-  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i32* %229, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %230
 
 ; <label>:230                                     ; preds = %224
   %231 = load i32, i32* %229, align 8
   %232 = bitcast i8* %226 to i32*
-  %NullCheck42 = icmp ne i32* %232, null
-  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+  %NullCheck41 = icmp eq i32* %232, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %233
 
 ; <label>:233                                     ; preds = %230
   store i32 %231, i32* %232, align 8
@@ -1099,15 +1181,15 @@ entry:
   %235 = getelementptr inbounds i8, i8* %234, i64 12
   %236 = load i8*, i8** %arg1
   %237 = getelementptr inbounds i8, i8* %236, i64 12
-  %NullCheck44 = icmp ne i8* %237, null
-  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i8* %237, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %238
 
 ; <label>:238                                     ; preds = %233
   %239 = load i8, i8* %237, align 8
   %240 = zext i8 %239 to i32
   %241 = trunc i32 %240 to i8
-  %NullCheck46 = icmp ne i8* %235, null
-  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+  %NullCheck45 = icmp eq i8* %235, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %242
 
 ; <label>:242                                     ; preds = %238
   store i8 %241, i8* %235, align 8
@@ -1117,14 +1199,14 @@ entry:
   %244 = load i8*, i8** %arg0
   %245 = load i8*, i8** %arg1
   %246 = bitcast i8* %245 to i64*
-  %NullCheck24 = icmp ne i64* %246, null
-  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64* %246, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %247
 
 ; <label>:247                                     ; preds = %243
   %248 = load i64, i64* %246, align 8
   %249 = bitcast i8* %244 to i64*
-  %NullCheck26 = icmp ne i64* %249, null
-  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64* %249, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %250
 
 ; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
@@ -1133,14 +1215,14 @@ entry:
   %253 = load i8*, i8** %arg1
   %254 = getelementptr inbounds i8, i8* %253, i64 8
   %255 = bitcast i8* %254 to i32*
-  %NullCheck28 = icmp ne i32* %255, null
-  br i1 %NullCheck28, label %256, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i32* %255, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %256
 
 ; <label>:256                                     ; preds = %250
   %257 = load i32, i32* %255, align 8
   %258 = bitcast i8* %252 to i32*
-  %NullCheck30 = icmp ne i32* %258, null
-  br i1 %NullCheck30, label %259, label %ThrowNullRef29
+  %NullCheck29 = icmp eq i32* %258, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %259
 
 ; <label>:259                                     ; preds = %256
   store i32 %257, i32* %258, align 8
@@ -1149,16 +1231,16 @@ entry:
   %262 = load i8*, i8** %arg1
   %263 = getelementptr inbounds i8, i8* %262, i64 12
   %264 = bitcast i8* %263 to i16*
-  %NullCheck32 = icmp ne i16* %264, null
-  br i1 %NullCheck32, label %265, label %ThrowNullRef31
+  %NullCheck31 = icmp eq i16* %264, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %265
 
 ; <label>:265                                     ; preds = %259
   %266 = load i16, i16* %264, align 8
   %267 = sext i16 %266 to i32
   %268 = bitcast i8* %261 to i16*
   %269 = trunc i32 %267 to i16
-  %NullCheck34 = icmp ne i16* %268, null
-  br i1 %NullCheck34, label %270, label %ThrowNullRef33
+  %NullCheck33 = icmp eq i16* %268, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %270
 
 ; <label>:270                                     ; preds = %265
   store i16 %269, i16* %268, align 8
@@ -1168,14 +1250,14 @@ entry:
   %272 = load i8*, i8** %arg0
   %273 = load i8*, i8** %arg1
   %274 = bitcast i8* %273 to i64*
-  %NullCheck8 = icmp ne i64* %274, null
-  br i1 %NullCheck8, label %275, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64* %274, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %275
 
 ; <label>:275                                     ; preds = %271
   %276 = load i64, i64* %274, align 8
   %277 = bitcast i8* %272 to i64*
-  %NullCheck10 = icmp ne i64* %277, null
-  br i1 %NullCheck10, label %278, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %277, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %278
 
 ; <label>:278                                     ; preds = %275
   store i64 %276, i64* %277, align 8
@@ -1184,14 +1266,14 @@ entry:
   %281 = load i8*, i8** %arg1
   %282 = getelementptr inbounds i8, i8* %281, i64 8
   %283 = bitcast i8* %282 to i32*
-  %NullCheck12 = icmp ne i32* %283, null
-  br i1 %NullCheck12, label %284, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i32* %283, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %284
 
 ; <label>:284                                     ; preds = %278
   %285 = load i32, i32* %283, align 8
   %286 = bitcast i8* %280 to i32*
-  %NullCheck14 = icmp ne i32* %286, null
-  br i1 %NullCheck14, label %287, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i32* %286, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %287
 
 ; <label>:287                                     ; preds = %284
   store i32 %285, i32* %286, align 8
@@ -1200,16 +1282,16 @@ entry:
   %290 = load i8*, i8** %arg1
   %291 = getelementptr inbounds i8, i8* %290, i64 12
   %292 = bitcast i8* %291 to i16*
-  %NullCheck16 = icmp ne i16* %292, null
-  br i1 %NullCheck16, label %293, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i16* %292, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %293
 
 ; <label>:293                                     ; preds = %287
   %294 = load i16, i16* %292, align 8
   %295 = sext i16 %294 to i32
   %296 = bitcast i8* %289 to i16*
   %297 = trunc i32 %295 to i16
-  %NullCheck18 = icmp ne i16* %296, null
-  br i1 %NullCheck18, label %298, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i16* %296, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %298
 
 ; <label>:298                                     ; preds = %293
   store i16 %297, i16* %296, align 8
@@ -1217,15 +1299,15 @@ entry:
   %300 = getelementptr inbounds i8, i8* %299, i64 14
   %301 = load i8*, i8** %arg1
   %302 = getelementptr inbounds i8, i8* %301, i64 14
-  %NullCheck20 = icmp ne i8* %302, null
-  br i1 %NullCheck20, label %303, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i8* %302, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %303
 
 ; <label>:303                                     ; preds = %298
   %304 = load i8, i8* %302, align 8
   %305 = zext i8 %304 to i32
   %306 = trunc i32 %305 to i8
-  %NullCheck22 = icmp ne i8* %300, null
-  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i8* %300, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %307
 
 ; <label>:307                                     ; preds = %303
   store i8 %306, i8* %300, align 8
@@ -1235,14 +1317,14 @@ entry:
   %309 = load i8*, i8** %arg0
   %310 = load i8*, i8** %arg1
   %311 = bitcast i8* %310 to i64*
-  %NullCheck = icmp ne i64* %311, null
-  br i1 %NullCheck, label %312, label %ThrowNullRef
+  %NullCheck = icmp eq i64* %311, null
+  br i1 %NullCheck, label %ThrowNullRef, label %312
 
 ; <label>:312                                     ; preds = %308
   %313 = load i64, i64* %311, align 8
   %314 = bitcast i8* %309 to i64*
-  %NullCheck2 = icmp ne i64* %314, null
-  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64* %314, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %315
 
 ; <label>:315                                     ; preds = %312
   store i64 %313, i64* %314, align 8
@@ -1251,14 +1333,14 @@ entry:
   %318 = load i8*, i8** %arg1
   %319 = getelementptr inbounds i8, i8* %318, i64 8
   %320 = bitcast i8* %319 to i64*
-  %NullCheck4 = icmp ne i64* %320, null
-  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64* %320, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %321
 
 ; <label>:321                                     ; preds = %315
   %322 = load i64, i64* %320, align 8
   %323 = bitcast i8* %317 to i64*
-  %NullCheck6 = icmp ne i64* %323, null
-  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64* %323, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %324
 
 ; <label>:324                                     ; preds = %321
   store i64 %322, i64* %323, align 8
@@ -1286,15 +1368,15 @@ entry:
 ; <label>:338                                     ; preds = %333
   %339 = load i8*, i8** %arg0
   %340 = load i8*, i8** %arg1
-  %NullCheck136 = icmp ne i8* %340, null
-  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+  %NullCheck135 = icmp eq i8* %340, null
+  br i1 %NullCheck135, label %ThrowNullRef136, label %341
 
 ; <label>:341                                     ; preds = %338
   %342 = load i8, i8* %340, align 8
   %343 = zext i8 %342 to i32
   %344 = trunc i32 %343 to i8
-  %NullCheck138 = icmp ne i8* %339, null
-  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+  %NullCheck137 = icmp eq i8* %339, null
+  br i1 %NullCheck137, label %ThrowNullRef138, label %345
 
 ; <label>:345                                     ; preds = %341
   store i8 %344, i8* %339, align 8
@@ -1317,16 +1399,16 @@ entry:
   %357 = load i8*, i8** %arg0
   %358 = load i8*, i8** %arg1
   %359 = bitcast i8* %358 to i16*
-  %NullCheck140 = icmp ne i16* %359, null
-  br i1 %NullCheck140, label %360, label %ThrowNullRef139
+  %NullCheck139 = icmp eq i16* %359, null
+  br i1 %NullCheck139, label %ThrowNullRef140, label %360
 
 ; <label>:360                                     ; preds = %356
   %361 = load i16, i16* %359, align 8
   %362 = sext i16 %361 to i32
   %363 = bitcast i8* %357 to i16*
   %364 = trunc i32 %362 to i16
-  %NullCheck142 = icmp ne i16* %363, null
-  br i1 %NullCheck142, label %365, label %ThrowNullRef141
+  %NullCheck141 = icmp eq i16* %363, null
+  br i1 %NullCheck141, label %ThrowNullRef142, label %365
 
 ; <label>:365                                     ; preds = %360
   store i16 %364, i16* %363, align 8
@@ -1352,14 +1434,14 @@ entry:
   %378 = load i8*, i8** %arg0
   %379 = load i8*, i8** %arg1
   %380 = bitcast i8* %379 to i32*
-  %NullCheck144 = icmp ne i32* %380, null
-  br i1 %NullCheck144, label %381, label %ThrowNullRef143
+  %NullCheck143 = icmp eq i32* %380, null
+  br i1 %NullCheck143, label %ThrowNullRef144, label %381
 
 ; <label>:381                                     ; preds = %377
   %382 = load i32, i32* %380, align 8
   %383 = bitcast i8* %378 to i32*
-  %NullCheck146 = icmp ne i32* %383, null
-  br i1 %NullCheck146, label %384, label %ThrowNullRef145
+  %NullCheck145 = icmp eq i32* %383, null
+  br i1 %NullCheck145, label %ThrowNullRef146, label %384
 
 ; <label>:384                                     ; preds = %381
   store i32 %382, i32* %383, align 8
@@ -1384,14 +1466,14 @@ entry:
   %395 = load i8*, i8** %arg0
   %396 = load i8*, i8** %arg1
   %397 = bitcast i8* %396 to i64*
-  %NullCheck164 = icmp ne i64* %397, null
-  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+  %NullCheck163 = icmp eq i64* %397, null
+  br i1 %NullCheck163, label %ThrowNullRef164, label %398
 
 ; <label>:398                                     ; preds = %394
   %399 = load i64, i64* %397, align 8
   %400 = bitcast i8* %395 to i64*
-  %NullCheck166 = icmp ne i64* %400, null
-  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+  %NullCheck165 = icmp eq i64* %400, null
+  br i1 %NullCheck165, label %ThrowNullRef166, label %401
 
 ; <label>:401                                     ; preds = %398
   store i64 %399, i64* %400, align 8
@@ -1400,14 +1482,14 @@ entry:
   %404 = load i8*, i8** %arg1
   %405 = getelementptr inbounds i8, i8* %404, i64 8
   %406 = bitcast i8* %405 to i64*
-  %NullCheck168 = icmp ne i64* %406, null
-  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+  %NullCheck167 = icmp eq i64* %406, null
+  br i1 %NullCheck167, label %ThrowNullRef168, label %407
 
 ; <label>:407                                     ; preds = %401
   %408 = load i64, i64* %406, align 8
   %409 = bitcast i8* %403 to i64*
-  %NullCheck170 = icmp ne i64* %409, null
-  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+  %NullCheck169 = icmp eq i64* %409, null
+  br i1 %NullCheck169, label %ThrowNullRef170, label %410
 
 ; <label>:410                                     ; preds = %407
   store i64 %408, i64* %409, align 8
@@ -1437,14 +1519,14 @@ entry:
   %425 = load i8*, i8** %arg0
   %426 = load i8*, i8** %arg1
   %427 = bitcast i8* %426 to i64*
-  %NullCheck148 = icmp ne i64* %427, null
-  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+  %NullCheck147 = icmp eq i64* %427, null
+  br i1 %NullCheck147, label %ThrowNullRef148, label %428
 
 ; <label>:428                                     ; preds = %424
   %429 = load i64, i64* %427, align 8
   %430 = bitcast i8* %425 to i64*
-  %NullCheck150 = icmp ne i64* %430, null
-  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+  %NullCheck149 = icmp eq i64* %430, null
+  br i1 %NullCheck149, label %ThrowNullRef150, label %431
 
 ; <label>:431                                     ; preds = %428
   store i64 %429, i64* %430, align 8
@@ -1466,14 +1548,14 @@ entry:
   %441 = load i8*, i8** %arg0
   %442 = load i8*, i8** %arg1
   %443 = bitcast i8* %442 to i32*
-  %NullCheck152 = icmp ne i32* %443, null
-  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+  %NullCheck151 = icmp eq i32* %443, null
+  br i1 %NullCheck151, label %ThrowNullRef152, label %444
 
 ; <label>:444                                     ; preds = %440
   %445 = load i32, i32* %443, align 8
   %446 = bitcast i8* %441 to i32*
-  %NullCheck154 = icmp ne i32* %446, null
-  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+  %NullCheck153 = icmp eq i32* %446, null
+  br i1 %NullCheck153, label %ThrowNullRef154, label %447
 
 ; <label>:447                                     ; preds = %444
   store i32 %445, i32* %446, align 8
@@ -1495,16 +1577,16 @@ entry:
   %457 = load i8*, i8** %arg0
   %458 = load i8*, i8** %arg1
   %459 = bitcast i8* %458 to i16*
-  %NullCheck156 = icmp ne i16* %459, null
-  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+  %NullCheck155 = icmp eq i16* %459, null
+  br i1 %NullCheck155, label %ThrowNullRef156, label %460
 
 ; <label>:460                                     ; preds = %456
   %461 = load i16, i16* %459, align 8
   %462 = sext i16 %461 to i32
   %463 = bitcast i8* %457 to i16*
   %464 = trunc i32 %462 to i16
-  %NullCheck158 = icmp ne i16* %463, null
-  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+  %NullCheck157 = icmp eq i16* %463, null
+  br i1 %NullCheck157, label %ThrowNullRef158, label %465
 
 ; <label>:465                                     ; preds = %460
   store i16 %464, i16* %463, align 8
@@ -1525,15 +1607,15 @@ entry:
 ; <label>:474                                     ; preds = %470
   %475 = load i8*, i8** %arg0
   %476 = load i8*, i8** %arg1
-  %NullCheck160 = icmp ne i8* %476, null
-  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+  %NullCheck159 = icmp eq i8* %476, null
+  br i1 %NullCheck159, label %ThrowNullRef160, label %477
 
 ; <label>:477                                     ; preds = %474
   %478 = load i8, i8* %476, align 8
   %479 = zext i8 %478 to i32
   %480 = trunc i32 %479 to i8
-  %NullCheck162 = icmp ne i8* %475, null
-  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+  %NullCheck161 = icmp eq i8* %475, null
+  br i1 %NullCheck161, label %ThrowNullRef162, label %481
 
 ; <label>:481                                     ; preds = %477
   store i8 %480, i8* %475, align 8
@@ -1553,343 +1635,343 @@ ThrowNullRef:                                     ; preds = %308
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %312
+ThrowNullRef2:                                    ; preds = %312
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %315
+ThrowNullRef4:                                    ; preds = %315
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %321
+ThrowNullRef6:                                    ; preds = %321
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %271
+ThrowNullRef8:                                    ; preds = %271
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %275
+ThrowNullRef10:                                   ; preds = %275
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %278
+ThrowNullRef12:                                   ; preds = %278
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %284
+ThrowNullRef14:                                   ; preds = %284
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %287
+ThrowNullRef16:                                   ; preds = %287
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %293
+ThrowNullRef18:                                   ; preds = %293
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %298
+ThrowNullRef20:                                   ; preds = %298
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %303
+ThrowNullRef22:                                   ; preds = %303
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %243
+ThrowNullRef24:                                   ; preds = %243
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %247
+ThrowNullRef26:                                   ; preds = %247
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %250
+ThrowNullRef28:                                   ; preds = %250
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %256
+ThrowNullRef30:                                   ; preds = %256
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %259
+ThrowNullRef32:                                   ; preds = %259
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %265
+ThrowNullRef34:                                   ; preds = %265
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %217
+ThrowNullRef36:                                   ; preds = %217
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %221
+ThrowNullRef38:                                   ; preds = %221
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %224
+ThrowNullRef40:                                   ; preds = %224
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %230
+ThrowNullRef42:                                   ; preds = %230
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %233
+ThrowNullRef44:                                   ; preds = %233
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %238
+ThrowNullRef46:                                   ; preds = %238
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %200
+ThrowNullRef48:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %204
+ThrowNullRef50:                                   ; preds = %204
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %207
+ThrowNullRef52:                                   ; preds = %207
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %213
+ThrowNullRef54:                                   ; preds = %213
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %172
+ThrowNullRef56:                                   ; preds = %172
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %176
+ThrowNullRef58:                                   ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %179
+ThrowNullRef60:                                   ; preds = %179
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %185
+ThrowNullRef62:                                   ; preds = %185
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %190
+ThrowNullRef64:                                   ; preds = %190
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %195
+ThrowNullRef66:                                   ; preds = %195
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %153
+ThrowNullRef68:                                   ; preds = %153
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %157
+ThrowNullRef70:                                   ; preds = %157
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %160
+ThrowNullRef72:                                   ; preds = %160
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %166
+ThrowNullRef74:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %136
+ThrowNullRef76:                                   ; preds = %136
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %140
+ThrowNullRef78:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %143
+ThrowNullRef80:                                   ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %148
+ThrowNullRef82:                                   ; preds = %148
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %128
+ThrowNullRef84:                                   ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %132
+ThrowNullRef86:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %100
+ThrowNullRef88:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %104
+ThrowNullRef90:                                   ; preds = %104
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %107
+ThrowNullRef92:                                   ; preds = %107
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %113
+ThrowNullRef94:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %118
+ThrowNullRef96:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %123
+ThrowNullRef98:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %81
+ThrowNullRef100:                                  ; preds = %81
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef101:                                  ; preds = %85
+ThrowNullRef102:                                  ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef103:                                  ; preds = %88
+ThrowNullRef104:                                  ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef105:                                  ; preds = %94
+ThrowNullRef106:                                  ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef107:                                  ; preds = %64
+ThrowNullRef108:                                  ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef109:                                  ; preds = %68
+ThrowNullRef110:                                  ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef111:                                  ; preds = %71
+ThrowNullRef112:                                  ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef113:                                  ; preds = %76
+ThrowNullRef114:                                  ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef115:                                  ; preds = %56
+ThrowNullRef116:                                  ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef117:                                  ; preds = %60
+ThrowNullRef118:                                  ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef119:                                  ; preds = %37
+ThrowNullRef120:                                  ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef121:                                  ; preds = %41
+ThrowNullRef122:                                  ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef123:                                  ; preds = %46
+ThrowNullRef124:                                  ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef125:                                  ; preds = %51
+ThrowNullRef126:                                  ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef127:                                  ; preds = %27
+ThrowNullRef128:                                  ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef129:                                  ; preds = %31
+ThrowNullRef130:                                  ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef131:                                  ; preds = %19
+ThrowNullRef132:                                  ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef133:                                  ; preds = %22
+ThrowNullRef134:                                  ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef135:                                  ; preds = %338
+ThrowNullRef136:                                  ; preds = %338
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef137:                                  ; preds = %341
+ThrowNullRef138:                                  ; preds = %341
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef139:                                  ; preds = %356
+ThrowNullRef140:                                  ; preds = %356
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef141:                                  ; preds = %360
+ThrowNullRef142:                                  ; preds = %360
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef143:                                  ; preds = %377
+ThrowNullRef144:                                  ; preds = %377
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef145:                                  ; preds = %381
+ThrowNullRef146:                                  ; preds = %381
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef147:                                  ; preds = %424
+ThrowNullRef148:                                  ; preds = %424
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef149:                                  ; preds = %428
+ThrowNullRef150:                                  ; preds = %428
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef151:                                  ; preds = %440
+ThrowNullRef152:                                  ; preds = %440
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef153:                                  ; preds = %444
+ThrowNullRef154:                                  ; preds = %444
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef155:                                  ; preds = %456
+ThrowNullRef156:                                  ; preds = %456
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef157:                                  ; preds = %460
+ThrowNullRef158:                                  ; preds = %460
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef159:                                  ; preds = %474
+ThrowNullRef160:                                  ; preds = %474
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef161:                                  ; preds = %477
+ThrowNullRef162:                                  ; preds = %477
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef163:                                  ; preds = %394
+ThrowNullRef164:                                  ; preds = %394
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef165:                                  ; preds = %398
+ThrowNullRef166:                                  ; preds = %398
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef167:                                  ; preds = %401
+ThrowNullRef168:                                  ; preds = %401
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef169:                                  ; preds = %407
+ThrowNullRef170:                                  ; preds = %407
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1939,8 +2021,8 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
-  br i1 %NullCheck, label %22, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %ThrowNullRef, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
@@ -1948,8 +2030,8 @@ entry:
   store i32 %24, i32* %loc0
   %25 = load i32, i32* %loc0
   %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %26, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %27
 
 ; <label>:27                                      ; preds = %22
   %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
@@ -1971,7 +2053,7 @@ ThrowNullRef:                                     ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1989,8 +2071,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -2022,15 +2104,15 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2048,16 +2130,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
   %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
   store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %15
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
@@ -2072,8 +2154,8 @@ entry:
   %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
   %29 = ptrtoint i16 addrspace(1)* %28 to i64
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %19
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
@@ -2089,19 +2171,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2114,8 +2196,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
@@ -2128,7 +2210,7 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[loadElem]
+Failed to read AppDomain.PrepareDataForSetup[storeElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
@@ -2202,8 +2284,8 @@ entry:
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
-  br i1 %NullCheck24, label %27, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = load i64, i64 addrspace(1)* %26
@@ -2218,8 +2300,8 @@ entry:
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
-  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
   %41 = load i64, i64 addrspace(1)* %39
@@ -2236,8 +2318,8 @@ entry:
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
-  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
   %54 = load i64, i64 addrspace(1)* %52
@@ -2252,8 +2334,8 @@ entry:
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
   %67 = load i64, i64 addrspace(1)* %65
@@ -2270,8 +2352,8 @@ entry:
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
-  br i1 %NullCheck16, label %79, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
   %80 = load i64, i64 addrspace(1)* %78
@@ -2286,8 +2368,8 @@ entry:
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
-  br i1 %NullCheck18, label %92, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
   %93 = load i64, i64 addrspace(1)* %91
@@ -2304,8 +2386,8 @@ entry:
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
-  br i1 %NullCheck12, label %105, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = load i64, i64 addrspace(1)* %104
@@ -2320,8 +2402,8 @@ entry:
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
-  br i1 %NullCheck14, label %118, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
   %119 = load i64, i64 addrspace(1)* %117
@@ -2337,8 +2419,8 @@ entry:
 
 ; <label>:128                                     ; preds = %20
   %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
-  br i1 %NullCheck4, label %130, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %129, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %130
 
 ; <label>:130                                     ; preds = %128
   %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
@@ -2346,8 +2428,8 @@ entry:
   %133 = load i16, i16 addrspace(1)* %132, align 8
   %134 = zext i16 %133 to i32
   %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
-  br i1 %NullCheck6, label %136, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %135, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %136
 
 ; <label>:136                                     ; preds = %130
   %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
@@ -2360,8 +2442,8 @@ entry:
 
 ; <label>:143                                     ; preds = %136
   %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
-  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %144, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %145
 
 ; <label>:145                                     ; preds = %143
   %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
@@ -2369,8 +2451,8 @@ entry:
   %148 = load i16, i16 addrspace(1)* %147, align 8
   %149 = zext i16 %148 to i32
   %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %150, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %151
 
 ; <label>:151                                     ; preds = %145
   %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
@@ -2388,8 +2470,8 @@ entry:
 
 ; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
-  br i1 %NullCheck, label %163, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %ThrowNullRef, label %163
 
 ; <label>:163                                     ; preds = %161
   %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
@@ -2399,8 +2481,8 @@ entry:
 
 ; <label>:167                                     ; preds = %163
   %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
-  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %168, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %169
 
 ; <label>:169                                     ; preds = %167
   %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
@@ -2432,55 +2514,55 @@ ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %167
+ThrowNullRef2:                                    ; preds = %167
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %128
+ThrowNullRef4:                                    ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %130
+ThrowNullRef6:                                    ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %143
+ThrowNullRef8:                                    ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %145
+ThrowNullRef10:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %102
+ThrowNullRef12:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %105
+ThrowNullRef14:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %76
+ThrowNullRef16:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %79
+ThrowNullRef18:                                   ; preds = %79
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %50
+ThrowNullRef20:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %53
+ThrowNullRef22:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %24
+ThrowNullRef24:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %27
+ThrowNullRef26:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2503,15 +2585,15 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2519,16 +2601,16 @@ entry:
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
   store i32 %8, i32* %loc0
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
   %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
   store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
@@ -2546,16 +2628,16 @@ entry:
 
 ; <label>:23                                      ; preds = %64
   %24 = load i16*, i16** %loc3
-  %NullCheck12 = icmp ne i16* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i16* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
   store i32 %27, i32* %loc5
   %28 = load i16*, i16** %loc4
-  %NullCheck14 = icmp ne i16* %28, null
-  br i1 %NullCheck14, label %29, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %28, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = load i16, i16* %28, align 8
@@ -2620,15 +2702,15 @@ entry:
 
 ; <label>:67                                      ; preds = %64
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
-  br i1 %NullCheck8, label %69, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %68, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %69
 
 ; <label>:69                                      ; preds = %67
   %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
   %71 = load i32, i32 addrspace(1)* %70
   %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
-  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %73
 
 ; <label>:73                                      ; preds = %69
   %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
@@ -2645,31 +2727,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %67
+ThrowNullRef8:                                    ; preds = %67
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %69
+ThrowNullRef10:                                   ; preds = %69
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2710,14 +2792,14 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
   %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
@@ -2730,14 +2812,14 @@ entry:
 
 ; <label>:11                                      ; preds = %4
   %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
   %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
@@ -2749,14 +2831,14 @@ entry:
 
 ; <label>:22                                      ; preds = %16
   %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
   %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
-  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
-  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
@@ -2804,23 +2886,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2836,7 +2918,280 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[loadElem]
+Successfully read RuntimeType.IsAssignableFrom
+
+define i8 @RuntimeType.IsAssignableFrom(%System.RuntimeType addrspace(1)* %param0, %System.Type addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.RuntimeType addrspace(1)*
+  %arg1 = alloca %System.Type addrspace(1)*
+  %loc0 = alloca %System.RuntimeType addrspace(1)*
+  %loc1 = alloca %"System.Type[]" addrspace(1)*
+  %loc2 = alloca i32
+  store %System.RuntimeType addrspace(1)* %param0, %System.RuntimeType addrspace(1)** %this
+  store %System.Type addrspace(1)* %param1, %System.Type addrspace(1)** %arg1
+  %0 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %1 = icmp ne %System.Type addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i8 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %5 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %6 = bitcast %System.Type addrspace(1)* %4 to %System.Object addrspace(1)*
+  %7 = bitcast %System.RuntimeType addrspace(1)* %5 to %System.Object addrspace(1)*
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %6, %System.Object addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %3
+  ret i8 1
+
+; <label>:12                                      ; preds = %3
+  %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 152
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 32
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
+  %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
+  %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
+  store %System.RuntimeType addrspace(1)* %25, %System.RuntimeType addrspace(1)** %loc0
+  %26 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %27 = icmp eq %System.RuntimeType addrspace(1)* %26, null
+  br i1 %27, label %34, label %28
+
+; <label>:28                                      ; preds = %15
+  %29 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %30 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)*)*)(%System.RuntimeType addrspace(1)* %29, %System.RuntimeType addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+; <label>:34                                      ; preds = %15
+  %35 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %36 = call %System.Reflection.Emit.TypeBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Reflection.Emit.TypeBuilder addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %35)
+  %37 = icmp eq %System.Reflection.Emit.TypeBuilder addrspace(1)* %36, null
+  br i1 %37, label %139, label %38
+
+; <label>:38                                      ; preds = %34
+  %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %42
+
+; <label>:42                                      ; preds = %38
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 152
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 40
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
+  %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
+  %53 = zext i8 %52 to i32
+  %54 = icmp eq i32 %53, 0
+  br i1 %54, label %56, label %55
+
+; <label>:55                                      ; preds = %42
+  ret i8 1
+
+; <label>:56                                      ; preds = %42
+  %57 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %58 = bitcast %System.RuntimeType addrspace(1)* %57 to %System.Type addrspace(1)*
+  %59 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %58)
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %64 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.Type addrspace(1)* %63, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = bitcast %System.RuntimeType addrspace(1)* %64 to %System.Type addrspace(1)*
+  %67 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %63, %System.Type addrspace(1)* %66)
+  %68 = zext i8 %67 to i32
+  %69 = trunc i32 %68 to i8
+  ret i8 %69
+
+; <label>:70                                      ; preds = %56
+  %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
+  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %73
+
+; <label>:73                                      ; preds = %70
+  %74 = load i64, i64 addrspace(1)* %72
+  %75 = add i64 %74, 128
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = add i64 %77, 0
+  %79 = inttoptr i64 %78 to i64*
+  %80 = load i64, i64* %79
+  %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
+  %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
+  %83 = call i8 %82(%System.Type addrspace(1)* %81)
+  %84 = zext i8 %83 to i32
+  %85 = icmp eq i32 %84, 0
+  br i1 %85, label %139, label %86
+
+; <label>:86                                      ; preds = %73
+  %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
+  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %89
+
+; <label>:89                                      ; preds = %86
+  %90 = load i64, i64 addrspace(1)* %88
+  %91 = add i64 %90, 128
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = add i64 %93, 24
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
+  %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
+  %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
+  store %"System.Type[]" addrspace(1)* %99, %"System.Type[]" addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %129
+
+; <label>:100                                     ; preds = %132
+  %101 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %102 = load i32, i32* %loc2
+  %NullCheck11 = icmp eq %"System.Type[]" addrspace(1)* %101, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %103
+
+; <label>:103                                     ; preds = %100
+  %104 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 1
+  %105 = load i32, i32 addrspace(1)* %104
+  %106 = zext i32 %105 to i64
+  %107 = zext i32 %102 to i64
+  %BoundsCheck = icmp uge i64 %107, %106
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %108
+
+; <label>:108                                     ; preds = %103
+  %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
+  %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
+  %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
+  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %113
+
+; <label>:113                                     ; preds = %108
+  %114 = load i64, i64 addrspace(1)* %112
+  %115 = add i64 %114, 152
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = add i64 %117, 56
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
+  %123 = zext i8 %122 to i32
+  %124 = icmp ne i32 %123, 0
+  br i1 %124, label %126, label %125
+
+; <label>:125                                     ; preds = %113
+  ret i8 0
+
+; <label>:126                                     ; preds = %113
+  %127 = load i32, i32* %loc2
+  %128 = add i32 %127, 1
+  store i32 %128, i32* %loc2
+  br label %129
+
+; <label>:129                                     ; preds = %89, %126
+  %130 = load i32, i32* %loc2
+  %131 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %NullCheck9 = icmp eq %"System.Type[]" addrspace(1)* %131, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %132
+
+; <label>:132                                     ; preds = %129
+  %133 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %131, i32 0, i32 1
+  %134 = load i32, i32 addrspace(1)* %133
+  %135 = zext i32 %134 to i64
+  %136 = trunc i64 %135 to i32
+  %137 = icmp slt i32 %130, %136
+  br i1 %137, label %100, label %138
+
+; <label>:138                                     ; preds = %132
+  ret i8 1
+
+; <label>:139                                     ; preds = %34, %73
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %129
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %103
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -2893,7 +3248,7 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElem]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -2904,8 +3259,8 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -2997,8 +3352,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
@@ -3059,8 +3414,8 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -3087,8 +3442,8 @@ entry:
 
 ; <label>:17                                      ; preds = %5, %11
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
@@ -3097,8 +3452,8 @@ entry:
 
 ; <label>:22                                      ; preds = %1, %11
   %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
@@ -3109,11 +3464,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %17
+ThrowNullRef2:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %22
+ThrowNullRef4:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3167,15 +3522,15 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
   %15 = load i32, i32 addrspace(1)* %14
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
@@ -3198,7 +3553,7 @@ ThrowNullRef:                                     ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef2:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3232,8 +3587,8 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
@@ -3312,8 +3667,8 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -3327,8 +3682,8 @@ entry:
 ; <label>:5                                       ; preds = %43
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %7 = load i32, i32* %loc1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck6, label %8, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
@@ -3366,8 +3721,8 @@ entry:
 ; <label>:32                                      ; preds = %21, %25
   %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
   %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
-  br i1 %NullCheck8, label %35, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = trunc i32 %34 to i16
@@ -3380,8 +3735,8 @@ entry:
 ; <label>:40                                      ; preds = %1, %35
   %41 = load i32, i32* %loc1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
-  br i1 %NullCheck2, label %43, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %42, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
@@ -3392,8 +3747,8 @@ entry:
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
   %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
-  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
   %51 = load i64, i64 addrspace(1)* %49
@@ -3412,19 +3767,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %40
+ThrowNullRef2:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %47
+ThrowNullRef4:                                    ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %5
+ThrowNullRef6:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %32
+ThrowNullRef8:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3467,8 +3822,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
@@ -3492,11 +3847,391 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(i16* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store i16* %param0, i16** %arg0
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load i32, i32* %arg3
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %42, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %37, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg2
+  %13 = load i32, i32* %arg3
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %37, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %24 = load i32, i32* %arg2
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load i16*, i16** %arg0
+  %35 = load i32, i32* %arg3
+  %36 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %36, i16* %34, i32 %35)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:37                                      ; preds = %5, %16
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %39)
+  %41 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41, %System.String addrspace(1)* %38, %System.String addrspace(1)* %40)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41) #0
+  unreachable
+
+; <label>:42                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
-Failed to read StringBuilder.ToString[loadElemA]
+Successfully read StringBuilder.ToString
+
+define %System.String addrspace(1)* @StringBuilder.ToString(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i16*
+  %loc3 = alloca %"System.Char[]" addrspace(1)*
+  %loc4 = alloca i32
+  %loc5 = alloca i32
+  %loc6 = alloca i16 addrspace(1)*
+  %loc7 = alloca %System.String addrspace(1)*
+  %loc8 = alloca %"System.Char[]" addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %0)
+  %2 = icmp ne i32 %1, 0
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %4
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %6)
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %7)
+  store %System.String addrspace(1)* %8, %System.String addrspace(1)** %loc0
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.Text.StringBuilder addrspace(1)* %9, %System.Text.StringBuilder addrspace(1)** %loc1
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  store %System.String addrspace(1)* %10, %System.String addrspace(1)** %loc7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc7
+  %12 = ptrtoint %System.String addrspace(1)* %11 to i64
+  %13 = icmp eq i64 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %5
+  %15 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %16 = sext i32 %15 to i64
+  %17 = add i64 %12, %16
+  br label %18
+
+; <label>:18                                      ; preds = %5, %14
+  %19 = phi i64 [ %12, %5 ], [ %17, %14 ]
+  %20 = inttoptr i64 %19 to i16*
+  store i16* %20, i16** %loc2
+  br label %21
+
+; <label>:21                                      ; preds = %98, %18
+  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %22, null
+  br i1 %NullCheck, label %ThrowNullRef, label %23
+
+; <label>:23                                      ; preds = %21
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 3
+  %25 = load i32, i32 addrspace(1)* %24, align 8
+  %26 = icmp sle i32 %25, 0
+  br i1 %26, label %96, label %27
+
+; <label>:27                                      ; preds = %23
+  %28 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %28, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %29
+
+; <label>:29                                      ; preds = %27
+  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %28, i32 0, i32 1
+  %31 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %30, align 8
+  store %"System.Char[]" addrspace(1)* %31, %"System.Char[]" addrspace(1)** %loc3
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %33
+
+; <label>:33                                      ; preds = %29
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  store i32 %35, i32* %loc4
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  %39 = load i32, i32 addrspace(1)* %38, align 8
+  store i32 %39, i32* %loc5
+  %40 = load i32, i32* %loc5
+  %41 = load i32, i32* %loc4
+  %42 = add i32 %40, %41
+  %43 = zext i32 %42 to i64
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %45
+
+; <label>:45                                      ; preds = %37
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = sext i32 %47 to i64
+  %49 = icmp sgt i64 %43, %48
+  br i1 %49, label %91, label %50
+
+; <label>:50                                      ; preds = %45
+  %51 = load i32, i32* %loc5
+  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %52, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %53
+
+; <label>:53                                      ; preds = %50
+  %54 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %52, i32 0, i32 1
+  %55 = load i32, i32 addrspace(1)* %54
+  %56 = zext i32 %55 to i64
+  %57 = trunc i64 %56 to i32
+  %58 = icmp ugt i32 %51, %57
+  br i1 %58, label %91, label %59
+
+; <label>:59                                      ; preds = %53
+  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  store %"System.Char[]" addrspace(1)* %60, %"System.Char[]" addrspace(1)** %loc8
+  %61 = icmp eq %"System.Char[]" addrspace(1)* %60, null
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %63, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %64
+
+; <label>:64                                      ; preds = %62
+  %65 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %63, i32 0, i32 1
+  %66 = load i32, i32 addrspace(1)* %65
+  %67 = zext i32 %66 to i64
+  %68 = trunc i64 %67 to i32
+  %69 = icmp ne i32 %68, 0
+  br i1 %69, label %71, label %70
+
+; <label>:70                                      ; preds = %59, %64
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:71                                      ; preds = %64
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %73
+
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %BoundsCheck = icmp uge i64 0, %76
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %77
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %78, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:79                                      ; preds = %70, %77
+  %80 = load i16*, i16** %loc2
+  %81 = load i32, i32* %loc4
+  %82 = sext i32 %81 to i64
+  %83 = mul i64 %82, 2
+  %84 = bitcast i16* %80 to i8*
+  %85 = getelementptr inbounds i8, i8* %84, i64 %83
+  %86 = load i16 addrspace(1)*, i16 addrspace(1)** %loc6
+  %87 = ptrtoint i16 addrspace(1)* %86 to i64
+  %88 = load i32, i32* %loc5
+  %89 = bitcast i8* %85 to i16*
+  %90 = inttoptr i64 %87 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %89, i16* %90, i32 %88)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %96
+
+; <label>:91                                      ; preds = %45, %53
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %94 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %93)
+  %95 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95, %System.String addrspace(1)* %92, %System.String addrspace(1)* %94)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95) #0
+  unreachable
+
+; <label>:96                                      ; preds = %23, %79
+  %97 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %97, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %98
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %97, i32 0, i32 2
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  store %System.Text.StringBuilder addrspace(1)* %100, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %102 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %102, label %21, label %103
+
+; <label>:103                                     ; preds = %98
+  store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc7
+  %104 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  ret %System.String addrspace(1)* %104
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method StringBuilder::get_Length using LLILCJit
+Successfully read StringBuilder.get_Length
+
+define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
+Successfully read RuntimeHelpers.get_OffsetToStringData
+
+define i32 @RuntimeHelpers.get_OffsetToStringData() {
+entry:
+  ret i32 12
+}
+
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
 Successfully read CultureData.CreateCultureData
 
@@ -3514,23 +4249,23 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
   store i8 %4, i8 addrspace(1)* %6
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
@@ -3549,11 +4284,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3566,50 +4301,50 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
   store i32 -1, i32 addrspace(1)* %2
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
   store i32 -1, i32 addrspace(1)* %8
   %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
   store i32 -1, i32 addrspace(1)* %14
   %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
   store i32 -1, i32 addrspace(1)* %17
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
@@ -3623,27 +4358,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3675,7 +4410,136 @@ Failed to read Dictionary`2.Insert[non-const derefAddress]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
 Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
-Failed to read HashHelpers.GetPrime[loadElem]
+Successfully read HashHelpers.GetPrime
+
+define i32 @HashHelpers.GetPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %6, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5, %System.String addrspace(1)* %4)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5) #0
+  unreachable
+
+; <label>:6                                       ; preds = %entry
+  store i32 0, i32* %loc0
+  br label %29
+
+; <label>:7                                       ; preds = %35
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 1296
+  %10 = addrspacecast i8 addrspace(1)* %9 to %"System.Int32[]" addrspace(1)**
+  %11 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %10
+  %12 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Int32[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = zext i32 %15 to i64
+  %17 = zext i32 %12 to i64
+  %BoundsCheck = icmp uge i64 %17, %16
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 3, i32 %12
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  store i32 %20, i32* %loc1
+  %21 = load i32, i32* %loc1
+  %22 = load i32, i32* %arg0
+  %23 = icmp slt i32 %21, %22
+  br i1 %23, label %26, label %24
+
+; <label>:24                                      ; preds = %18
+  %25 = load i32, i32* %loc1
+  ret i32 %25
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %loc0
+  %28 = add i32 %27, 1
+  store i32 %28, i32* %loc0
+  br label %29
+
+; <label>:29                                      ; preds = %6, %26
+  %30 = load i32, i32* %loc0
+  %31 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %32 = getelementptr inbounds i8, i8 addrspace(1)* %31, i64 1296
+  %33 = addrspacecast i8 addrspace(1)* %32 to %"System.Int32[]" addrspace(1)**
+  %34 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %33
+  %NullCheck = icmp eq %"System.Int32[]" addrspace(1)* %34, null
+  br i1 %NullCheck, label %ThrowNullRef, label %35
+
+; <label>:35                                      ; preds = %29
+  %36 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %34, i32 0, i32 1
+  %37 = load i32, i32 addrspace(1)* %36
+  %38 = zext i32 %37 to i64
+  %39 = trunc i64 %38 to i32
+  %40 = icmp slt i32 %30, %39
+  br i1 %40, label %7, label %41
+
+; <label>:41                                      ; preds = %35
+  %42 = load i32, i32* %arg0
+  %43 = or i32 %42, 1
+  store i32 %43, i32* %loc2
+  br label %59
+
+; <label>:44                                      ; preds = %59
+  %45 = load i32, i32* %loc2
+  %46 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %45)
+  %47 = zext i8 %46 to i32
+  %48 = icmp eq i32 %47, 0
+  br i1 %48, label %56, label %49
+
+; <label>:49                                      ; preds = %44
+  %50 = load i32, i32* %loc2
+  %51 = sub i32 %50, 1
+  %52 = srem i32 %51, 101
+  %53 = icmp eq i32 %52, 0
+  br i1 %53, label %56, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = load i32, i32* %loc2
+  ret i32 %55
+
+; <label>:56                                      ; preds = %44, %49
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %57, 2
+  store i32 %58, i32* %loc2
+  br label %59
+
+; <label>:59                                      ; preds = %41, %56
+  %60 = load i32, i32* %loc2
+  %61 = icmp slt i32 %60, 2147483647
+  br i1 %61, label %44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load i32, i32* %arg0
+  ret i32 %63
+
+ThrowNullRef:                                     ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
 Successfully read GenericEqualityComparer`1.GetHashCode
 
@@ -3694,14 +4558,14 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
   %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load i64, i64 addrspace(1)* %7
@@ -3720,7 +4584,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3750,8 +4614,8 @@ entry:
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
@@ -3796,8 +4660,8 @@ entry:
   %35 = bitcast i16* %34 to i8*
   %36 = getelementptr inbounds i8, i8* %35, i64 2
   %37 = bitcast i8* %36 to i16*
-  %NullCheck4 = icmp ne i16* %37, null
-  br i1 %NullCheck4, label %38, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %37, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %38
 
 ; <label>:38                                      ; preds = %27
   %39 = load i16, i16* %37, align 8
@@ -3824,8 +4688,8 @@ entry:
 
 ; <label>:54                                      ; preds = %22, %43
   %55 = load i16*, i16** %loc4
-  %NullCheck2 = icmp ne i16* %55, null
-  br i1 %NullCheck2, label %56, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i16* %55, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %56
 
 ; <label>:56                                      ; preds = %54
   %57 = load i16, i16* %55, align 8
@@ -3850,11 +4714,11 @@ ThrowNullRef:                                     ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %54
+ThrowNullRef2:                                    ; preds = %54
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %27
+ThrowNullRef4:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3871,8 +4735,8 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -3907,8 +4771,8 @@ entry:
 
 ; <label>:26                                      ; preds = %19
   %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
-  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %28
 
 ; <label>:28                                      ; preds = %26
   %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
@@ -3920,7 +4784,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3972,8 +4836,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
@@ -3984,26 +4848,26 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
-  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
@@ -4014,8 +4878,8 @@ entry:
 ; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
@@ -4024,8 +4888,8 @@ entry:
 
 ; <label>:25                                      ; preds = %1, %16, %23
   %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
-  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
@@ -4036,27 +4900,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %20
+ThrowNullRef10:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4069,8 +4933,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -4081,8 +4945,8 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
@@ -4091,8 +4955,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1, %8
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
@@ -4103,11 +4967,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4128,24 +4992,24 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   store i32 %3, i32* %loc0
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
   %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
   store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck4, label %9, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
@@ -4164,15 +5028,15 @@ entry:
 ; <label>:18                                      ; preds = %70
   %19 = load i16*, i16** %loc3
   %20 = bitcast i16* %19 to i64*
-  %NullCheck10 = icmp ne i64* %20, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %20, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = load i64, i64* %20, align 8
   %23 = load i16*, i16** %loc4
   %24 = bitcast i16* %23 to i64*
-  %NullCheck12 = icmp ne i64* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = load i64, i64* %24, align 8
@@ -4188,8 +5052,8 @@ entry:
   %31 = bitcast i16* %30 to i8*
   %32 = getelementptr inbounds i8, i8* %31, i64 8
   %33 = bitcast i8* %32 to i64*
-  %NullCheck14 = icmp ne i64* %33, null
-  br i1 %NullCheck14, label %34, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = load i64, i64* %33, align 8
@@ -4197,8 +5061,8 @@ entry:
   %37 = bitcast i16* %36 to i8*
   %38 = getelementptr inbounds i8, i8* %37, i64 8
   %39 = bitcast i8* %38 to i64*
-  %NullCheck16 = icmp ne i64* %39, null
-  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %40
 
 ; <label>:40                                      ; preds = %34
   %41 = load i64, i64* %39, align 8
@@ -4214,8 +5078,8 @@ entry:
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %NullCheck18 = icmp ne i64* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = load i64, i64* %48, align 8
@@ -4223,8 +5087,8 @@ entry:
   %52 = bitcast i16* %51 to i8*
   %53 = getelementptr inbounds i8, i8* %52, i64 16
   %54 = bitcast i8* %53 to i64*
-  %NullCheck20 = icmp ne i64* %54, null
-  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64* %54, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %55
 
 ; <label>:55                                      ; preds = %49
   %56 = load i64, i64* %54, align 8
@@ -4262,15 +5126,15 @@ entry:
 ; <label>:74                                      ; preds = %95
   %75 = load i16*, i16** %loc3
   %76 = bitcast i16* %75 to i32*
-  %NullCheck6 = icmp ne i32* %76, null
-  br i1 %NullCheck6, label %77, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32* %76, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %77
 
 ; <label>:77                                      ; preds = %74
   %78 = load i32, i32* %76, align 8
   %79 = load i16*, i16** %loc4
   %80 = bitcast i16* %79 to i32*
-  %NullCheck8 = icmp ne i32* %80, null
-  br i1 %NullCheck8, label %81, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i32* %80, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %81
 
 ; <label>:81                                      ; preds = %77
   %82 = load i32, i32* %80, align 8
@@ -4318,43 +5182,43 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %74
+ThrowNullRef6:                                    ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %77
+ThrowNullRef8:                                    ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %29
+ThrowNullRef14:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %34
+ThrowNullRef16:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4376,8 +5240,8 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load i64, i64 addrspace(1)* %4
@@ -4389,8 +5253,8 @@ entry:
   %12 = load i64, i64* %11
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %5
   %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
@@ -4399,8 +5263,8 @@ entry:
   %18 = load i8, i8* %arg2
   %19 = zext i8 %18 to i32
   %20 = trunc i32 %19 to i8
-  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %15
   %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
@@ -4411,11 +5275,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4442,8 +5306,8 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
@@ -4466,16 +5330,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
   %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = load i64, i64 addrspace(1)* %19
@@ -4500,8 +5364,8 @@ entry:
 ; <label>:35                                      ; preds = %30
   %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
@@ -4514,8 +5378,8 @@ entry:
 
 ; <label>:42                                      ; preds = %1, %38
   %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
-  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
@@ -4526,19 +5390,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %35
+ThrowNullRef2:                                    ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %42
+ThrowNullRef8:                                    ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4551,14 +5415,14 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
@@ -4570,7 +5434,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4583,8 +5447,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
@@ -4613,51 +5477,51 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
   %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
   %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
   %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
   %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
-  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
   store i64 %21, i64 addrspace(1)* %23
   %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %25 = load i64, i64* %loc0
-  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
@@ -4668,27 +5532,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %22
+ThrowNullRef12:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4701,8 +5565,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
@@ -4713,19 +5577,19 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
@@ -4734,8 +5598,8 @@ entry:
 
 ; <label>:15                                      ; preds = %1, %13
   %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
@@ -4746,19 +5610,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %15
+ThrowNullRef8:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4771,8 +5635,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -4831,8 +5695,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
@@ -4882,8 +5746,8 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
-  br i1 %NullCheck, label %17, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %ThrowNullRef, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
@@ -4894,15 +5758,15 @@ entry:
 
 ; <label>:22                                      ; preds = %17
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
-  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
   %26 = load i32, i32 addrspace(1)* %25
   %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
-  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %27, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
@@ -4925,8 +5789,8 @@ entry:
 ; <label>:40                                      ; preds = %17
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
-  br i1 %NullCheck6, label %43, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %41, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
@@ -4938,34 +5802,17 @@ ThrowNullRef:                                     ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %24
+ThrowNullRef4:                                    ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %40
+ThrowNullRef6:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
-}
-
-INFO:  jitting method Object::ReferenceEquals using LLILCJit
-Successfully read Object.ReferenceEquals
-
-define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
-entry:
-  %arg0 = alloca %System.Object addrspace(1)*
-  %arg1 = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
-  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
-  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = icmp eq %System.Object addrspace(1)* %0, %1
-  %3 = sext i1 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
 }
 
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
@@ -4978,21 +5825,21 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
   %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
-  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
@@ -5007,28 +5854,28 @@ entry:
 ; <label>:13                                      ; preds = %8, %12
   %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
   %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
   %21 = load i32, i32 addrspace(1)* %20, align 8
   %22 = add i32 %21, 1
-  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
   store i32 %22, i32 addrspace(1)* %24
   %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
@@ -5039,27 +5886,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5077,7 +5924,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::Setup using LLILCJit
-Failed to read AppDomain.Setup[loadElem]
+Failed to read AppDomain.Setup[unbox]
 INFO:  jitting method Thread::GetDomain using LLILCJit
 Successfully read Thread.GetDomain
 
@@ -5108,8 +5955,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
@@ -5122,14 +5969,14 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
   %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
@@ -5141,11 +5988,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5173,8 +6020,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -5189,7 +6036,328 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
 Failed to read KeyCollection.System.Collections.Generic.IEnumerable<TKey>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Successfully read Enumerator.MoveNext
+
+define i8 @Enumerator.MoveNext(%"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.RuntimeTypeHandle* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*
+  %"$TypeArg" = alloca %System.RuntimeTypeHandle*
+  store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
+  %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 8
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %76, label %12
+
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
+  br label %76
+
+; <label>:13                                      ; preds = %85
+  %14 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck19 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %15
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, i32 0, i32 0
+  %17 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %16, align 8
+  %NullCheck21 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, i32 0, i32 2
+  %20 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %19, align 8
+  %21 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck23 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %22
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, i32 0, i32 2
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %NullCheck25 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 3, i32 %24
+  %NullCheck27 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %32
+
+; <label>:32                                      ; preds = %30
+  %33 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, i32 0, i32 2
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = icmp slt i32 %34, 0
+  br i1 %35, label %68, label %36
+
+; <label>:36                                      ; preds = %32
+  %37 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %38 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck29 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %39
+
+; <label>:39                                      ; preds = %36
+  %40 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, i32 0, i32 0
+  %41 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %40, align 8
+  %NullCheck31 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, i32 0, i32 2
+  %44 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %43, align 8
+  %45 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck33 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, i32 0, i32 2
+  %48 = load i32, i32 addrspace(1)* %47, align 8
+  %NullCheck35 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %49
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = zext i32 %51 to i64
+  %53 = zext i32 %48 to i64
+  %BoundsCheck37 = icmp uge i64 %53, %52
+  br i1 %BoundsCheck37, label %ThrowIndexOutOfRange38, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 3, i32 %48
+  %NullCheck39 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %56
+
+; <label>:56                                      ; preds = %54
+  %57 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, i32 0, i32 0
+  %58 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck41 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %59
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %60, %System.__Canon addrspace(1)* %58)
+  %61 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck43 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  %64 = load i32, i32 addrspace(1)* %63, align 8
+  %65 = add i32 %64, 1
+  %NullCheck45 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  store i32 %65, i32 addrspace(1)* %67
+  ret i8 1
+
+; <label>:68                                      ; preds = %32
+  %69 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck47 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %73 = add i32 %72, 1
+  %NullCheck49 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %74
+
+; <label>:74                                      ; preds = %70
+  %75 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  store i32 %73, i32 addrspace(1)* %75
+  br label %76
+
+; <label>:76                                      ; preds = %8, %12, %74
+  %77 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %78
+
+; <label>:78                                      ; preds = %76
+  %79 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, i32 0, i32 2
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck7 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %82
+
+; <label>:82                                      ; preds = %78
+  %83 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, i32 0, i32 0
+  %84 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %83, align 8
+  %NullCheck9 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %85
+
+; <label>:85                                      ; preds = %82
+  %86 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, i32 0, i32 7
+  %87 = load i32, i32 addrspace(1)* %86, align 8
+  %88 = icmp ult i32 %80, %87
+  br i1 %88, label %13, label %89
+
+; <label>:89                                      ; preds = %85
+  %90 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %91 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck11 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %92
+
+; <label>:92                                      ; preds = %89
+  %93 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, i32 0, i32 0
+  %94 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck13 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %95
+
+; <label>:95                                      ; preds = %92
+  %96 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, i32 0, i32 7
+  %97 = load i32, i32 addrspace(1)* %96, align 8
+  %98 = add i32 %97, 1
+  %NullCheck15 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %99
+
+; <label>:99                                      ; preds = %95
+  %100 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, i32 0, i32 2
+  store i32 %98, i32 addrspace(1)* %100
+  %101 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck17 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %102
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %103, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %92
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef22:                                   ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef24:                                   ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef26:                                   ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef28:                                   ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef30:                                   ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef32:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef34:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef36:                                   ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange38:                           ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef40:                                   ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef42:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef44:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef46:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef48:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef50:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -5200,8 +6368,8 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -5232,9 +6400,9 @@ Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
 Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
-Failed to read String.MakeSeparatorList[loadElemA]
+Failed to read String.MakeSeparatorList[storeElem]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
-Failed to read String.InternalSplitKeepEmptyEntries[loadElem]
+Failed to read String.InternalSplitKeepEmptyEntries[storeElem]
 INFO:  jitting method Path::IsRelative using LLILCJit
 Successfully read Path.IsRelative
 
@@ -5243,8 +6411,8 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -5254,8 +6422,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
@@ -5271,8 +6439,8 @@ entry:
 
 ; <label>:17                                      ; preds = %7
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
@@ -5288,8 +6456,8 @@ entry:
 
 ; <label>:29                                      ; preds = %19
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %31
 
 ; <label>:31                                      ; preds = %29
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
@@ -5300,8 +6468,8 @@ entry:
 
 ; <label>:36                                      ; preds = %31
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
-  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %37, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
@@ -5312,8 +6480,8 @@ entry:
 
 ; <label>:43                                      ; preds = %31, %38
   %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
-  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %45
 
 ; <label>:45                                      ; preds = %43
   %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
@@ -5324,8 +6492,8 @@ entry:
 
 ; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %50
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
@@ -5336,8 +6504,8 @@ entry:
 
 ; <label>:57                                      ; preds = %1, %7, %19, %45, %52
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
-  br i1 %NullCheck14, label %59, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %59
 
 ; <label>:59                                      ; preds = %57
   %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
@@ -5347,8 +6515,8 @@ entry:
 
 ; <label>:63                                      ; preds = %59
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
@@ -5359,8 +6527,8 @@ entry:
 
 ; <label>:70                                      ; preds = %65
   %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
-  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.String addrspace(1)* %71, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %72
 
 ; <label>:72                                      ; preds = %70
   %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
@@ -5379,39 +6547,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %17
+ThrowNullRef4:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %29
+ThrowNullRef6:                                    ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %36
+ThrowNullRef8:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %43
+ThrowNullRef10:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %50
+ThrowNullRef12:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %57
+ThrowNullRef14:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %63
+ThrowNullRef16:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %70
+ThrowNullRef18:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5419,7 +6587,293 @@ ThrowNullRef17:                                   ; preds = %70
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
-Failed to read String.TrimHelper[loadElem]
+Successfully read String.TrimHelper
+
+define %System.String addrspace(1)* @String.TrimHelper(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i16
+  %loc4 = alloca i32
+  %loc5 = alloca i16
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = sub i32 %3, 1
+  store i32 %4, i32* %loc0
+  store i32 0, i32* %loc1
+  %5 = load i32, i32* %arg2
+  %6 = icmp eq i32 %5, 1
+  br i1 %6, label %62, label %7
+
+; <label>:7                                       ; preds = %1
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:8                                       ; preds = %58
+  store i32 0, i32* %loc2
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load i32, i32* %loc1
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2, i32 %10
+  %13 = load i16, i16 addrspace(1)* %12
+  %14 = zext i16 %13 to i32
+  %15 = trunc i32 %14 to i16
+  store i16 %15, i16* %loc3
+  store i32 0, i32* %loc2
+  br label %34
+
+; <label>:16                                      ; preds = %37
+  %17 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %18 = load i32, i32* %loc2
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %17, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %19
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = zext i32 %18 to i64
+  %BoundsCheck = icmp uge i64 %23, %22
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %24
+
+; <label>:24                                      ; preds = %19
+  %25 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 3, i32 %18
+  %26 = load i16, i16 addrspace(1)* %25, align 8
+  %27 = zext i16 %26 to i32
+  %28 = load i16, i16* %loc3
+  %29 = zext i16 %28 to i32
+  %30 = icmp eq i32 %27, %29
+  br i1 %30, label %43, label %31
+
+; <label>:31                                      ; preds = %24
+  %32 = load i32, i32* %loc2
+  %33 = add i32 %32, 1
+  store i32 %33, i32* %loc2
+  br label %34
+
+; <label>:34                                      ; preds = %11, %31
+  %35 = load i32, i32* %loc2
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = icmp slt i32 %35, %41
+  br i1 %42, label %16, label %43
+
+; <label>:43                                      ; preds = %24, %37
+  %44 = load i32, i32* %loc2
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %45, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp eq i32 %44, %50
+  br i1 %51, label %62, label %52
+
+; <label>:52                                      ; preds = %46
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %7, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %57, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %58
+
+; <label>:58                                      ; preds = %55
+  %59 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %60 = load i32, i32 addrspace(1)* %59
+  %61 = icmp slt i32 %56, %60
+  br i1 %61, label %8, label %62
+
+; <label>:62                                      ; preds = %1, %46, %58
+  %63 = load i32, i32* %arg2
+  %64 = icmp eq i32 %63, 0
+  br i1 %64, label %122, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %66, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %67
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %66, i32 0, i32 1
+  %69 = load i32, i32 addrspace(1)* %68
+  %70 = sub i32 %69, 1
+  store i32 %70, i32* %loc0
+  br label %118
+
+; <label>:71                                      ; preds = %118
+  store i32 0, i32* %loc4
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %73 = load i32, i32* %loc0
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %74
+
+; <label>:74                                      ; preds = %71
+  %75 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 2, i32 %73
+  %76 = load i16, i16 addrspace(1)* %75
+  %77 = zext i16 %76 to i32
+  %78 = trunc i32 %77 to i16
+  store i16 %78, i16* %loc5
+  store i32 0, i32* %loc4
+  br label %97
+
+; <label>:79                                      ; preds = %100
+  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %81 = load i32, i32* %loc4
+  %NullCheck19 = icmp eq %"System.Char[]" addrspace(1)* %80, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
+
+; <label>:82                                      ; preds = %79
+  %83 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 1
+  %84 = load i32, i32 addrspace(1)* %83
+  %85 = zext i32 %84 to i64
+  %86 = zext i32 %81 to i64
+  %BoundsCheck21 = icmp uge i64 %86, %85
+  br i1 %BoundsCheck21, label %ThrowIndexOutOfRange22, label %87
+
+; <label>:87                                      ; preds = %82
+  %88 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 3, i32 %81
+  %89 = load i16, i16 addrspace(1)* %88, align 8
+  %90 = zext i16 %89 to i32
+  %91 = load i16, i16* %loc5
+  %92 = zext i16 %91 to i32
+  %93 = icmp eq i32 %90, %92
+  br i1 %93, label %106, label %94
+
+; <label>:94                                      ; preds = %87
+  %95 = load i32, i32* %loc4
+  %96 = add i32 %95, 1
+  store i32 %96, i32* %loc4
+  br label %97
+
+; <label>:97                                      ; preds = %74, %94
+  %98 = load i32, i32* %loc4
+  %99 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck15 = icmp eq %"System.Char[]" addrspace(1)* %99, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %100
+
+; <label>:100                                     ; preds = %97
+  %101 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %99, i32 0, i32 1
+  %102 = load i32, i32 addrspace(1)* %101
+  %103 = zext i32 %102 to i64
+  %104 = trunc i64 %103 to i32
+  %105 = icmp slt i32 %98, %104
+  br i1 %105, label %79, label %106
+
+; <label>:106                                     ; preds = %87, %100
+  %107 = load i32, i32* %loc4
+  %108 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck17 = icmp eq %"System.Char[]" addrspace(1)* %108, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %109
+
+; <label>:109                                     ; preds = %106
+  %110 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %108, i32 0, i32 1
+  %111 = load i32, i32 addrspace(1)* %110
+  %112 = zext i32 %111 to i64
+  %113 = trunc i64 %112 to i32
+  %114 = icmp eq i32 %107, %113
+  br i1 %114, label %122, label %115
+
+; <label>:115                                     ; preds = %109
+  %116 = load i32, i32* %loc0
+  %117 = sub i32 %116, 1
+  store i32 %117, i32* %loc0
+  br label %118
+
+; <label>:118                                     ; preds = %67, %115
+  %119 = load i32, i32* %loc0
+  %120 = load i32, i32* %loc1
+  %121 = icmp sge i32 %119, %120
+  br i1 %121, label %71, label %122
+
+; <label>:122                                     ; preds = %62, %109, %118
+  %123 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %124 = load i32, i32* %loc1
+  %125 = load i32, i32* %loc0
+  %126 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %123, i32 %124, i32 %125)
+  ret %System.String addrspace(1)* %126
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %97
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange22:                           ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
 Successfully read String.CreateTrimmedString
 
@@ -5439,8 +6893,8 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
@@ -5535,8 +6989,8 @@ entry:
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i64 2872
   %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
   %8 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %7
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %3
   %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
@@ -5553,8 +7007,8 @@ entry:
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 2864
   %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
   %21 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %20
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
-  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %22
 
 ; <label>:22                                      ; preds = %16
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
@@ -5569,7 +7023,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %16
+ThrowNullRef2:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5586,8 +7040,8 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5613,8 +7067,8 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
@@ -5632,8 +7086,8 @@ entry:
 
 ; <label>:12                                      ; preds = %4
   %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
@@ -5644,8 +7098,8 @@ entry:
 
 ; <label>:19                                      ; preds = %14
   %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %19
   %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
@@ -5660,21 +7114,21 @@ entry:
   %31 = zext i16 %30 to i32
   %32 = bitcast i8* %29 to i16*
   %33 = trunc i32 %31 to i16
-  %NullCheck6 = icmp ne i16* %32, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i16* %32, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %21
   store i16 %33, i16* %32, align 8
   %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %36
 
 ; <label>:36                                      ; preds = %34
   %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
   %38 = load i32, i32 addrspace(1)* %37, align 8
   %39 = add i32 %38, 1
-  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %40
 
 ; <label>:40                                      ; preds = %36
   %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
@@ -5683,16 +7137,16 @@ entry:
 
 ; <label>:42                                      ; preds = %14
   %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
-  br i1 %NullCheck12, label %44, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
   %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
   %47 = load i16, i16* %arg1
   %48 = zext i16 %47 to i32
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = trunc i32 %48 to i16
@@ -5703,31 +7157,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %19
+ThrowNullRef4:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %21
+ThrowNullRef6:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %36
+ThrowNullRef10:                                   ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %42
+ThrowNullRef12:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %44
+ThrowNullRef14:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5740,8 +7194,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -5752,8 +7206,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
@@ -5762,14 +7216,14 @@ entry:
 
 ; <label>:11                                      ; preds = %1
   %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
@@ -5779,15 +7233,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5808,8 +7262,8 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5822,8 +7276,8 @@ entry:
 
 ; <label>:8                                       ; preds = %3
   %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
@@ -5842,15 +7296,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
-  br i1 %NullCheck4, label %22, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
   %24 = load i16*, i16* addrspace(1)* %23, align 8
   %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %25, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
@@ -5859,8 +7313,8 @@ entry:
   store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
@@ -5874,8 +7328,8 @@ entry:
 
 ; <label>:37                                      ; preds = %65
   %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %37
   %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
@@ -5886,16 +7340,16 @@ entry:
   %45 = bitcast i16* %41 to i8*
   %46 = getelementptr inbounds i8, i8* %45, i64 %44
   %47 = bitcast i8* %46 to i16*
-  %NullCheck14 = icmp ne i16* %47, null
-  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %47, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %48
 
 ; <label>:48                                      ; preds = %39
   %49 = load i16, i16* %47, align 8
   %50 = zext i16 %49 to i32
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %52 = load i32, i32* %loc1
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %53
 
 ; <label>:53                                      ; preds = %48
   %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
@@ -5916,8 +7370,8 @@ entry:
 ; <label>:62                                      ; preds = %36, %59
   %63 = load i32, i32* %loc1
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck10, label %65, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %65
 
 ; <label>:65                                      ; preds = %62
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
@@ -5936,15 +7390,15 @@ entry:
 
 ; <label>:74                                      ; preds = %70
   %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
-  br i1 %NullCheck18, label %76, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %76
 
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
   %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
-  br i1 %NullCheck20, label %80, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
   %81 = load i64, i64 addrspace(1)* %79
@@ -5958,8 +7412,8 @@ entry:
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
   %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
-  br i1 %NullCheck22, label %92, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.String addrspace(1)* %90, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %92
 
 ; <label>:92                                      ; preds = %80
   %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
@@ -5969,15 +7423,15 @@ entry:
 
 ; <label>:96                                      ; preds = %70
   %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
-  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %98
 
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
   %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
-  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
   %103 = load i64, i64 addrspace(1)* %101
@@ -5991,8 +7445,8 @@ entry:
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
   %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
-  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.String addrspace(1)* %112, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %114
 
 ; <label>:114                                     ; preds = %102
   %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
@@ -6004,59 +7458,59 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %20
+ThrowNullRef4:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %22
+ThrowNullRef6:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %26
+ThrowNullRef8:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %62
+ThrowNullRef10:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %48
+ThrowNullRef16:                                   ; preds = %48
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %74
+ThrowNullRef18:                                   ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %76
+ThrowNullRef20:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %80
+ThrowNullRef22:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %96
+ThrowNullRef24:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %98
+ThrowNullRef26:                                   ; preds = %98
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %102
+ThrowNullRef28:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6069,15 +7523,15 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
   %3 = load i16*, i16* addrspace(1)* %2, align 8
   %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
@@ -6087,8 +7541,8 @@ entry:
   %10 = bitcast i16* %3 to i8*
   %11 = getelementptr inbounds i8, i8* %10, i64 %9
   %12 = bitcast i8* %11 to i16*
-  %NullCheck4 = icmp ne i16* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %5
   store i16 0, i16* %12, align 8
@@ -6098,11 +7552,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6119,8 +7573,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -6131,8 +7585,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
@@ -6144,15 +7598,15 @@ entry:
 
 ; <label>:14                                      ; preds = %1
   %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
   %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
   %21 = load i64, i64 addrspace(1)* %19
@@ -6171,15 +7625,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %14
+ThrowNullRef4:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %16
+ThrowNullRef6:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6302,14 +7756,6 @@ entry:
   ret %System.String addrspace(1)* %57
 }
 
-INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
-Successfully read RuntimeHelpers.get_OffsetToStringData
-
-define i32 @RuntimeHelpers.get_OffsetToStringData() {
-entry:
-  ret i32 12
-}
-
 INFO:  jitting method String::Equals using LLILCJit
 Successfully read String.Equals
 
@@ -6381,8 +7827,8 @@ entry:
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
-  br i1 %NullCheck24, label %29, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
   %30 = load i64, i64 addrspace(1)* %28
@@ -6397,8 +7843,8 @@ entry:
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
-  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
   %43 = load i64, i64 addrspace(1)* %41
@@ -6418,8 +7864,8 @@ entry:
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
   %59 = load i64, i64 addrspace(1)* %57
@@ -6434,8 +7880,8 @@ entry:
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck22, label %71, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
   %72 = load i64, i64 addrspace(1)* %70
@@ -6455,8 +7901,8 @@ entry:
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
-  br i1 %NullCheck16, label %87, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = load i64, i64 addrspace(1)* %86
@@ -6471,8 +7917,8 @@ entry:
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck18, label %100, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
   %101 = load i64, i64 addrspace(1)* %99
@@ -6492,8 +7938,8 @@ entry:
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
-  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
   %117 = load i64, i64 addrspace(1)* %115
@@ -6508,8 +7954,8 @@ entry:
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
-  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
   %130 = load i64, i64 addrspace(1)* %128
@@ -6528,15 +7974,15 @@ entry:
 
 ; <label>:142                                     ; preds = %22
   %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
-  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %143, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %144
 
 ; <label>:144                                     ; preds = %142
   %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
   %146 = load i32, i32 addrspace(1)* %145
   %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
-  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %147, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %148
 
 ; <label>:148                                     ; preds = %144
   %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
@@ -6557,15 +8003,15 @@ entry:
 
 ; <label>:159                                     ; preds = %22
   %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
-  br i1 %NullCheck, label %161, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %ThrowNullRef, label %161
 
 ; <label>:161                                     ; preds = %159
   %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
   %163 = load i32, i32 addrspace(1)* %162
   %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
-  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %164, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %165
 
 ; <label>:165                                     ; preds = %161
   %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
@@ -6578,8 +8024,8 @@ entry:
 
 ; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
-  br i1 %NullCheck4, label %172, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %171, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %172
 
 ; <label>:172                                     ; preds = %170
   %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
@@ -6589,8 +8035,8 @@ entry:
 
 ; <label>:176                                     ; preds = %172
   %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
-  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %177, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %178
 
 ; <label>:178                                     ; preds = %176
   %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
@@ -6629,55 +8075,55 @@ ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %161
+ThrowNullRef2:                                    ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %170
+ThrowNullRef4:                                    ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %176
+ThrowNullRef6:                                    ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %142
+ThrowNullRef8:                                    ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %144
+ThrowNullRef10:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %113
+ThrowNullRef12:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %116
+ThrowNullRef14:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %84
+ThrowNullRef16:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %87
+ThrowNullRef18:                                   ; preds = %87
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %55
+ThrowNullRef20:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %58
+ThrowNullRef22:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %26
+ThrowNullRef24:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %29
+ThrowNullRef26:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,8 +8161,8 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck, label %14, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %ThrowNullRef, label %14
 
 ; <label>:14                                      ; preds = %8
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
@@ -6760,8 +8206,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
@@ -6770,14 +8216,14 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32, i32* %loc0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %10
   %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
   %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
@@ -6790,15 +8236,15 @@ entry:
 ; <label>:25                                      ; preds = %19
   %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
-  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
   %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
@@ -6807,8 +8253,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %37 = load i32, i32* %loc0
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %38, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %38
 
 ; <label>:38                                      ; preds = %32
   %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
@@ -6817,14 +8263,14 @@ entry:
 
 ; <label>:40                                      ; preds = %19
   %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %40
   %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
   %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
-  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
-  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
@@ -6832,8 +8278,8 @@ entry:
   %48 = zext i32 %47 to i64
   %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
-  br i1 %NullCheck16, label %51, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %51
 
 ; <label>:51                                      ; preds = %45
   %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
@@ -6847,15 +8293,15 @@ entry:
 ; <label>:57                                      ; preds = %51
   %58 = load i16*, i16** %arg1
   %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
-  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %60
 
 ; <label>:60                                      ; preds = %57
   %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
   %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
-  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %64
 
 ; <label>:64                                      ; preds = %60
   %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
@@ -6864,22 +8310,22 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
   %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
-  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %70
 
 ; <label>:70                                      ; preds = %64
   %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
   %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
-  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
-  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
   %75 = load i32, i32 addrspace(1)* %74
   %76 = zext i32 %75 to i64
   %77 = trunc i64 %76 to i32
-  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
-  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %78
 
 ; <label>:78                                      ; preds = %73
   %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
@@ -6901,8 +8347,8 @@ entry:
   %90 = bitcast i16* %86 to i8*
   %91 = getelementptr inbounds i8, i8* %90, i64 %89
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %93
 
 ; <label>:93                                      ; preds = %80
   %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
@@ -6912,8 +8358,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %99 = load i32, i32* %loc2
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %100
 
 ; <label>:100                                     ; preds = %93
   %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
@@ -6928,63 +8374,63 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %25
+ThrowNullRef6:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %32
+ThrowNullRef10:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %40
+ThrowNullRef12:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %45
+ThrowNullRef16:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %57
+ThrowNullRef18:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %60
+ThrowNullRef20:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %64
+ThrowNullRef22:                                   ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %70
+ThrowNullRef24:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %73
+ThrowNullRef26:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %80
+ThrowNullRef28:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %93
+ThrowNullRef30:                                   ; preds = %93
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7004,8 +8450,8 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
@@ -7033,43 +8479,43 @@ entry:
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %14
   %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
   %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   %28 = load i32, i32 addrspace(1)* %27, align 8
   %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
-  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %30
 
 ; <label>:30                                      ; preds = %26
   %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
   %32 = load i32, i32 addrspace(1)* %31, align 8
   %33 = add i32 %28, %32
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %34
 
 ; <label>:34                                      ; preds = %30
   %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   store i32 %33, i32 addrspace(1)* %35
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
   store i32 0, i32 addrspace(1)* %38
   %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %40
 
 ; <label>:40                                      ; preds = %37
   %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
@@ -7082,8 +8528,8 @@ entry:
 
 ; <label>:47                                      ; preds = %40
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
@@ -7098,8 +8544,8 @@ entry:
   %54 = load i32, i32* %loc0
   %55 = sext i32 %54 to i64
   %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
-  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %57
 
 ; <label>:57                                      ; preds = %52
   %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
@@ -7110,68 +8556,35 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %14
+ThrowNullRef2:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %23
+ThrowNullRef4:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %26
+ThrowNullRef6:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %30
+ThrowNullRef8:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %34
+ThrowNullRef10:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %47
+ThrowNullRef14:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %52
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-}
-
-INFO:  jitting method StringBuilder::get_Length using LLILCJit
-Successfully read StringBuilder.get_Length
-
-define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.StringBuilder addrspace(1)*
-  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
-  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
-
-; <label>:1                                       ; preds = %entry
-  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %3 = load i32, i32 addrspace(1)* %2, align 8
-  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
-
-; <label>:5                                       ; preds = %1
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = add i32 %3, %7
-  ret i32 %8
-
-ThrowNullRef:                                     ; preds = %entry
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef16:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7213,70 +8626,70 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
   %6 = load i32, i32 addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
   store i32 %6, i32 addrspace(1)* %8
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
   %13 = load i32, i32 addrspace(1)* %12, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
   store i32 %13, i32 addrspace(1)* %15
   %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
-  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %18
 
 ; <label>:18                                      ; preds = %14
   %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
   %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
   %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
   %34 = load i32, i32 addrspace(1)* %33, align 8
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
-  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
@@ -7287,39 +8700,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %28
+ThrowNullRef16:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %32
+ThrowNullRef18:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7455,13 +8868,13 @@ entry:
 ; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
@@ -7477,16 +8890,16 @@ entry:
 
 ; <label>:18                                      ; preds = %15
   %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
   store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
   %22 = load i32, i32* %loc0
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %24
 
 ; <label>:24                                      ; preds = %20
   %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
@@ -7498,13 +8911,13 @@ entry:
 ; <label>:28                                      ; preds = %15, %24
   %29 = load i32, i32* %arg1
   %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %31
   %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
@@ -7517,20 +8930,20 @@ entry:
   %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
-  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
   %46 = load i32, i32 addrspace(1)* %45, align 8
   %47 = sub i32 %40, %46
-  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
-  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i32 addrspace(1)* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %48
 
 ; <label>:48                                      ; preds = %44
   store i32 %47, i32 addrspace(1)* %39, align 8
@@ -7538,21 +8951,21 @@ entry:
 
 ; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
-  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %51
 
 ; <label>:51                                      ; preds = %49
   %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %53
 
 ; <label>:53                                      ; preds = %51
   %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
   %55 = load i32, i32 addrspace(1)* %54, align 8
   %56 = load i32, i32* %arg2
   %57 = sub i32 %55, %56
-  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %58
 
 ; <label>:58                                      ; preds = %53
   %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
@@ -7562,13 +8975,13 @@ entry:
 ; <label>:60                                      ; preds = %33, %58
   %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
   %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
-  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %63
 
 ; <label>:63                                      ; preds = %60
   %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
-  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
-  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
@@ -7578,15 +8991,15 @@ entry:
 
 ; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
-  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i32 addrspace(1)* %69, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %70
 
 ; <label>:70                                      ; preds = %68
   %71 = load i32, i32 addrspace(1)* %69, align 8
   store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
-  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
@@ -7596,8 +9009,8 @@ entry:
   store i32 %77, i32* %loc4
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
-  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %80
 
 ; <label>:80                                      ; preds = %73
   %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
@@ -7607,71 +9020,71 @@ entry:
 ; <label>:83                                      ; preds = %80
   store i32 0, i32* %loc3
   %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
-  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
-  br i1 %NullCheck26, label %88, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i32 addrspace(1)* %87, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %88
 
 ; <label>:88                                      ; preds = %85
   %89 = load i32, i32 addrspace(1)* %87, align 8
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
-  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %90
 
 ; <label>:90                                      ; preds = %88
   %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
   store i32 %89, i32 addrspace(1)* %91
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
-  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
-  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %96
 
 ; <label>:96                                      ; preds = %94
   %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
-  br i1 %NullCheck34, label %100, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %100
 
 ; <label>:100                                     ; preds = %96
   %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
-  br i1 %NullCheck36, label %102, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %102
 
 ; <label>:102                                     ; preds = %100
   %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
   %104 = load i32, i32 addrspace(1)* %103, align 8
   %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
-  br i1 %NullCheck38, label %106, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %106
 
 ; <label>:106                                     ; preds = %102
   %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
-  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
-  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %108
 
 ; <label>:108                                     ; preds = %106
   %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
   %110 = load i32, i32 addrspace(1)* %109, align 8
   %111 = add i32 %104, %110
-  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %112
 
 ; <label>:112                                     ; preds = %108
   %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
   store i32 %111, i32 addrspace(1)* %113
   %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
-  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i32 addrspace(1)* %114, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %115
 
 ; <label>:115                                     ; preds = %112
   %116 = load i32, i32 addrspace(1)* %114, align 8
@@ -7681,19 +9094,19 @@ entry:
 ; <label>:118                                     ; preds = %115
   %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
-  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %121
 
 ; <label>:121                                     ; preds = %118
   %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
-  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
-  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %123
 
 ; <label>:123                                     ; preds = %121
   %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
   %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
-  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
-  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %126
 
 ; <label>:126                                     ; preds = %123
   %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
@@ -7705,8 +9118,8 @@ entry:
 
 ; <label>:130                                     ; preds = %80, %115, %126
   %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %132
 
 ; <label>:132                                     ; preds = %130
   %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7715,8 +9128,8 @@ entry:
   %136 = load i32, i32* %loc3
   %137 = sub i32 %135, %136
   %138 = sub i32 %134, %137
-  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %139
 
 ; <label>:139                                     ; preds = %132
   %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7728,16 +9141,16 @@ entry:
 
 ; <label>:144                                     ; preds = %139
   %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
-  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %146
 
 ; <label>:146                                     ; preds = %144
   %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
   %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
   %149 = load i32, i32* %loc2
   %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
-  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %151
 
 ; <label>:151                                     ; preds = %146
   %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
@@ -7754,145 +9167,249 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %18
+ThrowNullRef4:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %31
+ThrowNullRef10:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %44
+ThrowNullRef16:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %68
+ThrowNullRef18:                                   ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %70
+ThrowNullRef20:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %73
+ThrowNullRef22:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %83
+ThrowNullRef24:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %85
+ThrowNullRef26:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %88
+ThrowNullRef28:                                   ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %90
+ThrowNullRef30:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %94
+ThrowNullRef32:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %96
+ThrowNullRef34:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %100
+ThrowNullRef36:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %102
+ThrowNullRef38:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %106
+ThrowNullRef40:                                   ; preds = %106
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %108
+ThrowNullRef42:                                   ; preds = %108
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %112
+ThrowNullRef44:                                   ; preds = %112
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %118
+ThrowNullRef46:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %121
+ThrowNullRef48:                                   ; preds = %121
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %123
+ThrowNullRef50:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %130
+ThrowNullRef52:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %132
+ThrowNullRef54:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %144
+ThrowNullRef56:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %146
+ThrowNullRef58:                                   ; preds = %146
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %60
+ThrowNullRef60:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %63
+ThrowNullRef62:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %49
+ThrowNullRef64:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %51
+ThrowNullRef66:                                   ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %53
+ThrowNullRef68:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(%"System.Char[]" addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %arg0 = alloca %"System.Char[]" addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store %"System.Char[]" addrspace(1)* %param0, %"System.Char[]" addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load i32, i32* %arg4
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %43, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %38, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg1
+  %13 = load i32, i32* %arg4
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %38, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %24 = load i32, i32* %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %35 = load i32, i32* %arg3
+  %36 = load i32, i32* %arg4
+  %37 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %37, %"System.Char[]" addrspace(1)* %34, i32 %35, i32 %36)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:38                                      ; preds = %5, %16
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Successfully read Buffer._Memmove
 
@@ -7914,7 +9431,7 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[loadElem]
+Failed to read AppDomain.SetDataHelper[storeElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -7923,8 +9440,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
@@ -7934,8 +9451,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
@@ -7947,15 +9464,15 @@ entry:
   %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
   %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
@@ -7966,15 +9483,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7992,7 +9509,79 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
-Failed to read Dictionary`2.TryGetValue[loadElemA]
+Successfully read Dictionary`2.TryGetValue
+
+define i8 @"Dictionary`2.TryGetValue"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)* addrspace(1)* %param2) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  %arg2 = alloca %System.__Canon addrspace(1)* addrspace(1)*
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  store %System.__Canon addrspace(1)* addrspace(1)* %param2, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  store i32 %2, i32* %loc0
+  %3 = load i32, i32* %loc0
+  %4 = icmp slt i32 %3, 0
+  br i1 %4, label %22, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 2
+  %10 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %9, align 8
+  %11 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = zext i32 %11 to i64
+  %BoundsCheck = icmp uge i64 %16, %15
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 3, i32 %11
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %20, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %6, %System.__Canon addrspace(1)* %21)
+  ret i8 1
+
+; <label>:22                                      ; preds = %entry
+  %23 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %23, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -8058,8 +9647,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
@@ -8091,8 +9680,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
@@ -8171,15 +9760,15 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck, label %19, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %ThrowNullRef, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
   %21 = load i32, i32 addrspace(1)* %20
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
@@ -8202,7 +9791,7 @@ ThrowNullRef:                                     ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %19
+ThrowNullRef2:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8248,8 +9837,8 @@ entry:
   %0 = alloca %System.AppDomainHandle
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %1 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %1, i32 0, i32 15
@@ -8269,8 +9858,8 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
@@ -8286,7 +9875,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -8299,8 +9888,8 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -8327,8 +9916,8 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
@@ -8352,8 +9941,8 @@ entry:
   %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
   store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
@@ -8363,8 +9952,8 @@ entry:
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
@@ -8374,8 +9963,8 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %9
   %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
@@ -8384,8 +9973,8 @@ entry:
 
 ; <label>:18                                      ; preds = %3, %16
   %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
@@ -8397,15 +9986,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %18
+ThrowNullRef6:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8418,8 +10007,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
@@ -8453,15 +10042,15 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
@@ -8473,7 +10062,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8481,7 +10070,7 @@ ThrowNullRef1:                                    ; preds = %1
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
 Failed to read Dictionary`2.System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
@@ -8506,8 +10095,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
@@ -8524,8 +10113,8 @@ entry:
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -8544,7 +10133,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8577,8 +10166,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = load i64, i64* %arg2
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = trunc i32 %3 to i8
@@ -8634,46 +10223,46 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
   %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
-  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
-  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
-  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
@@ -8684,27 +10273,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %20
+ThrowNullRef12:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8717,8 +10306,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -8756,22 +10345,22 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
   %9 = load i64, i64 addrspace(1)* %8, align 8
   %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
   %13 = load i64, i64 addrspace(1)* %12, align 8
   %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %11
   %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
@@ -8788,11 +10377,11 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8882,8 +10471,8 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
@@ -8900,8 +10489,8 @@ entry:
 ; <label>:8                                       ; preds = %1
   %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
   %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
@@ -8911,15 +10500,15 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
   %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
   %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
-  br i1 %NullCheck6, label %21, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
@@ -8946,15 +10535,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8992,15 +10581,15 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
   store i8 %3, i8 addrspace(1)* %5
   %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
@@ -9011,7 +10600,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9027,8 +10616,8 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -9041,8 +10630,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
@@ -9058,7 +10647,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9080,8 +10669,8 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
@@ -9096,8 +10685,8 @@ entry:
 ; <label>:12                                      ; preds = %6
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
@@ -9112,8 +10701,8 @@ entry:
 ; <label>:21                                      ; preds = %15
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
@@ -9128,8 +10717,8 @@ entry:
 ; <label>:30                                      ; preds = %24
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %31, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
@@ -9144,8 +10733,8 @@ entry:
 ; <label>:39                                      ; preds = %33
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
-  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %40, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %42
 
 ; <label>:42                                      ; preds = %39
   %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
@@ -9164,19 +10753,19 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %21
+ThrowNullRef4:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %30
+ThrowNullRef6:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %39
+ThrowNullRef8:                                    ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9243,8 +10832,8 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
@@ -9264,57 +10853,57 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
   store i8 0, i8 addrspace(1)* %2
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
   store i8 0, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
   store i8 0, i8 addrspace(1)* %17
   %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
   store i8 0, i8 addrspace(1)* %20
   %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
-  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
@@ -9325,31 +10914,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %19
+ThrowNullRef14:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9367,8 +10956,8 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
@@ -9380,8 +10969,8 @@ entry:
 
 ; <label>:9                                       ; preds = %4
   %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %9
   %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
@@ -9395,7 +10984,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef2:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9420,8 +11009,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
@@ -9512,8 +11101,8 @@ entry:
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
@@ -9524,8 +11113,8 @@ entry:
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = load i64, i64 addrspace(1)* %12
@@ -9537,8 +11126,8 @@ entry:
   %20 = load i64, i64* %19
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
-  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %13
   %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
@@ -9555,8 +11144,8 @@ entry:
 ; <label>:30                                      ; preds = %25
   %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %32 = load i32, i32* %arg2
-  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
-  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
@@ -9570,15 +11159,15 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %30
+ThrowNullRef2:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9622,87 +11211,87 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
   %10 = load i8, i8 addrspace(1)* %9, align 8
   %11 = zext i8 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %8
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
   store i8 %12, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
   %19 = load i8, i8 addrspace(1)* %18, align 8
   %20 = zext i8 %19 to i32
   %21 = trunc i32 %20 to i8
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
   store i8 %21, i8 addrspace(1)* %23
   %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
   %28 = load i8, i8 addrspace(1)* %27, align 8
   %29 = zext i8 %28 to i32
   %30 = trunc i32 %29 to i8
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
-  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %31
 
 ; <label>:31                                      ; preds = %26
   %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
   store i8 %30, i8 addrspace(1)* %32
   %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
-  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
-  br i1 %NullCheck14, label %40, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %40
 
 ; <label>:40                                      ; preds = %35
   %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
   store i8 %39, i8 addrspace(1)* %41
   %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
-  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %44
 
 ; <label>:44                                      ; preds = %40
   %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
   %46 = load i8, i8 addrspace(1)* %45, align 8
   %47 = zext i8 %46 to i32
   %48 = trunc i32 %47 to i8
-  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
   store i8 %48, i8 addrspace(1)* %50
   %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
-  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
@@ -9713,29 +11302,29 @@ entry:
 ; <label>:56                                      ; preds = %52
   %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
-  br i1 %NullCheck22, label %59, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
   %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
   %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
-  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
-  br i1 %NullCheck24, label %63, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
   %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
-  br i1 %NullCheck26, label %66, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
   %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
-  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
-  br i1 %NullCheck28, label %69, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %69
 
 ; <label>:69                                      ; preds = %66
   %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
@@ -9744,15 +11333,15 @@ entry:
 
 ; <label>:71                                      ; preds = %105
   %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
-  br i1 %NullCheck34, label %73, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %73
 
 ; <label>:73                                      ; preds = %71
   %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
   %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
   %76 = load i32, i32* %loc0
-  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
-  br i1 %NullCheck36, label %77, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
@@ -9766,8 +11355,8 @@ entry:
 
 ; <label>:83                                      ; preds = %77
   %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
-  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
@@ -9775,14 +11364,14 @@ entry:
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
   %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
-  br i1 %NullCheck40, label %91, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
 ; <label>:91                                      ; preds = %85
   %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
   %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
-  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck42, label %94, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %94
 
 ; <label>:94                                      ; preds = %91
   %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
@@ -9798,14 +11387,14 @@ entry:
 ; <label>:99                                      ; preds = %69, %96
   %100 = load i32, i32* %loc0
   %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
-  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %102
 
 ; <label>:102                                     ; preds = %99
   %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
   %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
-  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
-  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
@@ -9819,87 +11408,87 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %26
+ThrowNullRef10:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %31
+ThrowNullRef12:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %35
+ThrowNullRef14:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %40
+ThrowNullRef16:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %56
+ThrowNullRef22:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %59
+ThrowNullRef24:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %63
+ThrowNullRef26:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %66
+ThrowNullRef28:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %102
+ThrowNullRef32:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %71
+ThrowNullRef34:                                   ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %73
+ThrowNullRef36:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %83
+ThrowNullRef38:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %85
+ThrowNullRef40:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %91
+ThrowNullRef42:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9943,15 +11532,15 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
   %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
@@ -9961,28 +11550,28 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
   %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %12
   %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
   %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
   %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
-  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
@@ -9993,23 +11582,23 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %12
+ThrowNullRef6:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10031,15 +11620,15 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
   %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = load i64, i64 addrspace(1)* %7
@@ -10077,13 +11666,13 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[loadElem]
+Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -10111,8 +11700,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -10178,8 +11767,8 @@ entry:
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load float, float* %arg0
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -10313,8 +11902,8 @@ entry:
   store i64 %param0, i64* %arg0
   store i64 %param1, i64* %arg1
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
@@ -10322,8 +11911,8 @@ entry:
   %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
   %5 = load i16*, i16* addrspace(1)* %4, align 8
   %6 = addrspacecast i64* %arg1 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = bitcast i64 addrspace(1)* %6 to i8 addrspace(1)*
@@ -10339,7 +11928,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10373,8 +11962,8 @@ entry:
   %1 = load i32, i32* %arg1
   %2 = sext i32 %1 to i64
   %3 = inttoptr i64 %2 to i16*
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -10427,8 +12016,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, i32)*)(%System.IO.ConsoleStream addrspace(1)* %2, i32 %1)
   %3 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %4 = load i64, i64* %arg1
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
@@ -10439,8 +12028,8 @@ entry:
   %10 = icmp eq i32 %9, 3
   %11 = sext i1 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %5
   %14 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, i32 0, i32 5
@@ -10451,7 +12040,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10474,8 +12063,8 @@ entry:
   %5 = icmp eq i32 %4, 1
   %6 = sext i1 %5 to i32
   %7 = trunc i32 %6 to i8
-  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %2, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.ConsoleStream addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
@@ -10486,8 +12075,8 @@ entry:
   %13 = icmp eq i32 %12, 2
   %14 = sext i1 %13 to i32
   %15 = trunc i32 %14 to i8
-  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %10, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.ConsoleStream addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %8
   %17 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %10, i32 0, i32 4
@@ -10498,7 +12087,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10537,8 +12126,8 @@ entry:
   %arg0 = alloca i64
   store i64 %param0, i64* %arg0
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
@@ -10573,8 +12162,8 @@ entry:
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
   %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = load i64, i64 addrspace(1)* %7
@@ -10678,7 +12267,127 @@ entry:
 INFO:  jitting method Encoding::GetEncoding using LLILCJit
 Failed to read Encoding.GetEncoding[convertToHelperArgumentType]
 INFO:  jitting method EncodingProvider::GetEncodingFromProvider using LLILCJit
-Failed to read EncodingProvider.GetEncodingFromProvider[loadElem]
+Successfully read EncodingProvider.GetEncodingFromProvider
+
+define %System.Text.Encoding addrspace(1)* @EncodingProvider.GetEncodingFromProvider(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca %"System.Text.EncodingProvider[]" addrspace(1)*
+  %loc1 = alloca %System.Text.EncodingProvider addrspace(1)*
+  %loc2 = alloca %System.Text.Encoding addrspace(1)*
+  %loc3 = alloca %System.Text.Encoding addrspace(1)*
+  %loc4 = alloca %"System.Text.EncodingProvider[]" addrspace(1)*
+  %loc5 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1059)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2392
+  %2 = addrspacecast i8 addrspace(1)* %1 to %"System.Text.EncodingProvider[]" addrspace(1)**
+  %3 = load volatile %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %2
+  %4 = icmp ne %"System.Text.EncodingProvider[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %entry
+  ret %System.Text.Encoding addrspace(1)* null
+
+; <label>:6                                       ; preds = %entry
+  %7 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1059)
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i64 2392
+  %9 = addrspacecast i8 addrspace(1)* %8 to %"System.Text.EncodingProvider[]" addrspace(1)**
+  %10 = load volatile %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %9
+  store %"System.Text.EncodingProvider[]" addrspace(1)* %10, %"System.Text.EncodingProvider[]" addrspace(1)** %loc0
+  %11 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc0
+  store %"System.Text.EncodingProvider[]" addrspace(1)* %11, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  store i32 0, i32* %loc5
+  br label %43
+
+; <label>:12                                      ; preds = %46
+  %13 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  %14 = load i32, i32* %loc5
+  %NullCheck1 = icmp eq %"System.Text.EncodingProvider[]" addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %13, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = zext i32 %17 to i64
+  %19 = zext i32 %14 to i64
+  %BoundsCheck = icmp uge i64 %19, %18
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %20
+
+; <label>:20                                      ; preds = %15
+  %21 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %13, i32 0, i32 3, i32 %14
+  %22 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)* addrspace(1)* %21, align 8
+  store %System.Text.EncodingProvider addrspace(1)* %22, %System.Text.EncodingProvider addrspace(1)** %loc1
+  %23 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)** %loc1
+  %24 = load i32, i32* %arg0
+  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i64 addrspace(1)*
+  %NullCheck3 = icmp eq i64 addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
+
+; <label>:26                                      ; preds = %20
+  %27 = load i64, i64 addrspace(1)* %25
+  %28 = add i64 %27, 64
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 40
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Text.Encoding addrspace(1)* (%System.Text.EncodingProvider addrspace(1)*, i32)*
+  %35 = call %System.Text.Encoding addrspace(1)* %34(%System.Text.EncodingProvider addrspace(1)* %23, i32 %24)
+  store %System.Text.Encoding addrspace(1)* %35, %System.Text.Encoding addrspace(1)** %loc2
+  %36 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc2
+  %37 = icmp eq %System.Text.Encoding addrspace(1)* %36, null
+  br i1 %37, label %40, label %38
+
+; <label>:38                                      ; preds = %26
+  %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc2
+  store %System.Text.Encoding addrspace(1)* %39, %System.Text.Encoding addrspace(1)** %loc3
+  br label %53
+
+; <label>:40                                      ; preds = %26
+  %41 = load i32, i32* %loc5
+  %42 = add i32 %41, 1
+  store i32 %42, i32* %loc5
+  br label %43
+
+; <label>:43                                      ; preds = %6, %40
+  %44 = load i32, i32* %loc5
+  %45 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  %NullCheck = icmp eq %"System.Text.EncodingProvider[]" addrspace(1)* %45, null
+  br i1 %NullCheck, label %ThrowNullRef, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp slt i32 %44, %50
+  br i1 %51, label %12, label %52
+
+; <label>:52                                      ; preds = %46
+  ret %System.Text.Encoding addrspace(1)* null
+
+; <label>:53                                      ; preds = %38
+  %54 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc3
+  ret %System.Text.Encoding addrspace(1)* %54
+
+ThrowNullRef:                                     ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method EncodingProvider::.cctor using LLILCJit
 Successfully read EncodingProvider..cctor
 
@@ -10697,7 +12406,7 @@ Failed to read Encoding.get_InternalSyncObject[Call HasTypeArg]
 INFO:  jitting method Hashtable::.ctor using LLILCJit
 Failed to read Hashtable..ctor[Volatile store]
 INFO:  jitting method Hashtable::get_Item using LLILCJit
-Failed to read Hashtable.get_Item[loadElemA]
+Failed to read Hashtable.get_Item[loadNonPrimitiveObj]
 INFO:  jitting method Hashtable::InitHash using LLILCJit
 Successfully read Hashtable.InitHash
 
@@ -10717,8 +12426,8 @@ entry:
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -10734,15 +12443,15 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
   %15 = load i32, i32* %loc0
-  %NullCheck2 = icmp ne i32 addrspace(1)* %14, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i32 addrspace(1)* %14, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %3
   store i32 %15, i32 addrspace(1)* %14, align 8
   %17 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %18 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %NullCheck4 = icmp ne i32 addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i32 addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = load i32, i32 addrspace(1)* %18, align 8
@@ -10751,8 +12460,8 @@ entry:
   %23 = sub i32 %22, 1
   %24 = urem i32 %21, %23
   %25 = add i32 1, %24
-  %NullCheck6 = icmp ne i32 addrspace(1)* %17, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32 addrspace(1)* %17, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %19
   store i32 %25, i32 addrspace(1)* %17, align 8
@@ -10763,15 +12472,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %19
+ThrowNullRef6:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10786,8 +12495,8 @@ entry:
   store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
   store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %NullCheck = icmp ne %System.Collections.Hashtable addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Collections.Hashtable addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
@@ -10797,16 +12506,16 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Collections.Hashtable addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Collections.Hashtable addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
   %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck4 = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %9, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
   %13 = inttoptr i64 %11 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
@@ -10816,8 +12525,8 @@ entry:
 ; <label>:15                                      ; preds = %1
   %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -10835,15 +12544,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10857,8 +12566,8 @@ entry:
   store %System.Int32 addrspace(1)* %param0, %System.Int32 addrspace(1)** %this
   %0 = load %System.Int32 addrspace(1)*, %System.Int32 addrspace(1)** %this
   %1 = bitcast %System.Int32 addrspace(1)* %0 to i32 addrspace(1)*
-  %NullCheck = icmp ne i32 addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq i32 addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load i32, i32 addrspace(1)* %1, align 8
@@ -10934,8 +12643,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.UTF8Encoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
@@ -10944,15 +12653,15 @@ entry:
   %9 = load i8, i8* %arg2
   %10 = zext i8 %9 to i32
   %11 = trunc i32 %10 to i8
-  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %8, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %6
   %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %8, i32 0, i32 8
   store i8 %11, i8 addrspace(1)* %13
   %14 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %14, i32 0, i32 8
@@ -10964,8 +12673,8 @@ entry:
 ; <label>:20                                      ; preds = %15
   %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %22, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %22, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = load i64, i64 addrspace(1)* %22
@@ -10987,15 +12696,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %12
+ThrowNullRef4:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11010,8 +12719,8 @@ entry:
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
@@ -11033,16 +12742,16 @@ entry:
 ; <label>:10                                      ; preds = %1
   %11 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
   %12 = load i32, i32* %arg1
-  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %11, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.Encoding addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
   store i32 %12, i32 addrspace(1)* %14
   %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
   %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = load i64, i64 addrspace(1)* %16
@@ -11060,11 +12769,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11077,8 +12786,8 @@ entry:
   %this = alloca %System.Text.UTF8Encoding addrspace(1)*
   store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
   %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.UTF8Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
@@ -11090,16 +12799,16 @@ entry:
 ; <label>:6                                       ; preds = %1
   %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %8 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %10, %System.Text.EncoderFallback addrspace(1)* %8)
   %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %12 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
-  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %11, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %11, i32 0, i32 3
@@ -11112,8 +12821,8 @@ entry:
   %18 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %18, %System.String addrspace(1)* %17)
   %19 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %18 to %System.Text.EncoderFallback addrspace(1)*
-  %NullCheck6 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %16, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %16, i32 0, i32 2
@@ -11123,8 +12832,8 @@ entry:
   %24 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %24, %System.String addrspace(1)* %23)
   %25 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %24 to %System.Text.DecoderFallback addrspace(1)*
-  %NullCheck8 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %22, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %22, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %20
   %27 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %22, i32 0, i32 3
@@ -11135,19 +12844,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %20
+ThrowNullRef8:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11177,8 +12886,8 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load i32, i32* %arg1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -11196,8 +12905,8 @@ entry:
 ; <label>:15                                      ; preds = %8
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %17 = load i32, i32* %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 %17
@@ -11213,7 +12922,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11265,7 +12974,7 @@ entry:
 }
 
 INFO:  jitting method Hashtable::Insert using LLILCJit
-Failed to read Hashtable.Insert[loadElemA]
+Failed to read Hashtable.Insert[storeElem]
 INFO:  jitting method ConsoleEncoding::.ctor using LLILCJit
 Successfully read ConsoleEncoding..ctor
 
@@ -11280,8 +12989,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %1)
   %2 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
@@ -11317,8 +13026,8 @@ entry:
   %2 = call %System.Text.InternalEncoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalEncoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %1)
   %3 = bitcast %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2 to %System.Text.EncoderFallback addrspace(1)*
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
@@ -11328,8 +13037,8 @@ entry:
   %8 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %7)
   %9 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %8 to %System.Text.DecoderFallback addrspace(1)*
-  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %6, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.Encoding addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %4
   %11 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %6, i32 0, i32 3
@@ -11340,7 +13049,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11359,15 +13068,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* %1)
   %2 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   %6 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, i32 0, i32 1
@@ -11378,7 +13087,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11406,8 +13115,8 @@ entry:
   store %System.Text.InternalDecoderBestFitFallback addrspace(1)* %param0, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
   %0 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
@@ -11417,15 +13126,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %4)
   %5 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %6)
   %9 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, i32 0, i32 1
@@ -11436,11 +13145,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11508,8 +13217,8 @@ entry:
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
   %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = load i64, i64 addrspace(1)* %19
@@ -11573,8 +13282,8 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.ConsoleStream addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
@@ -11605,31 +13314,31 @@ entry:
   store i8 %param4, i8* %arg4
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %3, %System.IO.Stream addrspace(1)* %1)
   %4 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %4, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
   %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %4, i32 0, i32 4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %5)
   %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %6
   %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
   %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
   %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = load i64, i64 addrspace(1)* %13
@@ -11641,8 +13350,8 @@ entry:
   %21 = load i64, i64* %20
   %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %8, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %8, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %14
   %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 5
@@ -11660,24 +13369,24 @@ entry:
   %31 = load i32, i32* %arg3
   %32 = sext i32 %31 to i64
   %33 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %32)
-  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %30, null
-  br i1 %NullCheck10, label %34, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.StreamWriter addrspace(1)* %30, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %35, %"System.Char[]" addrspace(1)* %33)
   %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %37, null
-  br i1 %NullCheck12, label %38, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.StreamWriter addrspace(1)* %37, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %38
 
 ; <label>:38                                      ; preds = %34
   %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
   %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
   %41 = load i32, i32* %arg3
   %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %42, null
-  br i1 %NullCheck14, label %43, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %42, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
   %44 = load i64, i64 addrspace(1)* %42
@@ -11691,30 +13400,30 @@ entry:
   %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
   %53 = sext i32 %52 to i64
   %54 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %53)
-  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
-  br i1 %NullCheck16, label %55, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %55
 
 ; <label>:55                                      ; preds = %43
   %56 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %56, %"System.Byte[]" addrspace(1)* %54)
   %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %58 = load i32, i32* %arg3
-  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %57, null
-  br i1 %NullCheck18, label %59, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.StreamWriter addrspace(1)* %57, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %59
 
 ; <label>:59                                      ; preds = %55
   %60 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 10
   store i32 %58, i32 addrspace(1)* %60
   %61 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %61, null
-  br i1 %NullCheck20, label %62, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.IO.StreamWriter addrspace(1)* %61, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %62
 
 ; <label>:62                                      ; preds = %59
   %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
   %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
   %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
   %67 = load i64, i64 addrspace(1)* %65
@@ -11732,15 +13441,15 @@ entry:
 
 ; <label>:78                                      ; preds = %66
   %79 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %79, null
-  br i1 %NullCheck24, label %80, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.StreamWriter addrspace(1)* %79, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %80
 
 ; <label>:80                                      ; preds = %78
   %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
   %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
   %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %83, null
-  br i1 %NullCheck26, label %84, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %83, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
   %85 = load i64, i64 addrspace(1)* %83
@@ -11757,8 +13466,8 @@ entry:
 
 ; <label>:95                                      ; preds = %84
   %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.IO.StreamWriter addrspace(1)* %96, null
-  br i1 %NullCheck28, label %97, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.IO.StreamWriter addrspace(1)* %96, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %97
 
 ; <label>:97                                      ; preds = %95
   %98 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 12
@@ -11772,8 +13481,8 @@ entry:
   %103 = icmp eq i32 %102, 0
   %104 = sext i1 %103 to i32
   %105 = trunc i32 %104 to i8
-  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %100, null
-  br i1 %NullCheck30, label %106, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.IO.StreamWriter addrspace(1)* %100, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %106
 
 ; <label>:106                                     ; preds = %99
   %107 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %100, i32 0, i32 13
@@ -11784,63 +13493,63 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %6
+ThrowNullRef4:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %29
+ThrowNullRef10:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %34
+ThrowNullRef12:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %38
+ThrowNullRef14:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %43
+ThrowNullRef16:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %55
+ThrowNullRef18:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %59
+ThrowNullRef20:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %62
+ThrowNullRef22:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %78
+ThrowNullRef24:                                   ; preds = %78
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %80
+ThrowNullRef26:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %95
+ThrowNullRef28:                                   ; preds = %95
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11853,15 +13562,15 @@ entry:
   %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = load i64, i64 addrspace(1)* %4
@@ -11879,7 +13588,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11929,35 +13638,35 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
   %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderNLS addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %7 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.EncoderNLS addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Text.Encoding addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.Encoding addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Text.EncoderNLS addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.EncoderNLS addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
   %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck8 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = load i64, i64 addrspace(1)* %16
@@ -11976,19 +13685,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12014,8 +13723,8 @@ entry:
   %this = alloca %System.Text.Encoding addrspace(1)*
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
@@ -12035,15 +13744,15 @@ entry:
   %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
   store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
   %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
   store i32 0, i32 addrspace(1)* %2
   %3 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, i32 0, i32 2
@@ -12053,15 +13762,15 @@ entry:
 
 ; <label>:8                                       ; preds = %4
   %9 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
   %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
   %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = load i64, i64 addrspace(1)* %13
@@ -12082,15 +13791,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12105,16 +13814,16 @@ entry:
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = load i32, i32* %arg1
   %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
   %7 = load i64, i64 addrspace(1)* %5
@@ -12132,7 +13841,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12169,8 +13878,8 @@ entry:
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
   %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
   %16 = load i64, i64 addrspace(1)* %14
@@ -12191,8 +13900,8 @@ entry:
   %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
   %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
   %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %31, null
-  br i1 %NullCheck2, label %32, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = load i64, i64 addrspace(1)* %31
@@ -12235,7 +13944,7 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12248,14 +13957,14 @@ entry:
   %this = alloca %System.Text.EncoderReplacementFallback addrspace(1)*
   store %System.Text.EncoderReplacementFallback addrspace(1)* %param0, %System.Text.EncoderReplacementFallback addrspace(1)** %this
   %0 = load %System.Text.EncoderReplacementFallback addrspace(1)*, %System.Text.EncoderReplacementFallback addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -12266,7 +13975,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12296,8 +14005,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
@@ -12329,8 +14038,8 @@ entry:
   %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
   store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
@@ -12342,8 +14051,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Threading.Tasks.Task addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %7)
@@ -12366,7 +14075,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12385,8 +14094,8 @@ entry:
   store i8 %param1, i8* %arg1
   store i8 %param2, i8* %arg2
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
@@ -12400,8 +14109,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1, %5
   %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 9
@@ -12432,8 +14141,8 @@ entry:
 
 ; <label>:25                                      ; preds = %8, %20
   %26 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %26, null
-  br i1 %NullCheck4, label %27, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %26, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %26, i32 0, i32 12
@@ -12444,22 +14153,22 @@ entry:
 
 ; <label>:32                                      ; preds = %27
   %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %33, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.IO.StreamWriter addrspace(1)* %33, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %32
   %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 12
   store i8 1, i8 addrspace(1)* %35
   %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
-  br i1 %NullCheck8, label %37, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
   %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
   %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck10 = icmp ne i64 addrspace(1)* %40, null
-  br i1 %NullCheck10, label %41, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64 addrspace(1)* %40, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i64, i64 addrspace(1)* %40
@@ -12473,8 +14182,8 @@ entry:
   %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
   store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
   %51 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %NullCheck12 = icmp ne %"System.Byte[]" addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Byte[]" addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %41
   %53 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %51, i32 0, i32 1
@@ -12486,16 +14195,16 @@ entry:
 
 ; <label>:58                                      ; preds = %52
   %59 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %59, null
-  br i1 %NullCheck14, label %60, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.IO.StreamWriter addrspace(1)* %59, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %60
 
 ; <label>:60                                      ; preds = %58
   %61 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %59, i32 0, i32 3
   %62 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
   %64 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %NullCheck16 = icmp ne %"System.Byte[]" addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %"System.Byte[]" addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %60
   %66 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %64, i32 0, i32 1
@@ -12503,8 +14212,8 @@ entry:
   %68 = zext i32 %67 to i64
   %69 = trunc i64 %68 to i32
   %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck18, label %71, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
   %72 = load i64, i64 addrspace(1)* %70
@@ -12520,29 +14229,29 @@ entry:
 
 ; <label>:80                                      ; preds = %27, %52, %71
   %81 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %81, null
-  br i1 %NullCheck20, label %82, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.IO.StreamWriter addrspace(1)* %81, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
 
 ; <label>:82                                      ; preds = %80
   %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %81, i32 0, i32 5
   %84 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %83, align 8
   %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.IO.StreamWriter addrspace(1)* %85, null
-  br i1 %NullCheck22, label %86, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.IO.StreamWriter addrspace(1)* %85, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %86
 
 ; <label>:86                                      ; preds = %82
   %87 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 7
   %88 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %87, align 8
   %89 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %89, null
-  br i1 %NullCheck24, label %90, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.StreamWriter addrspace(1)* %89, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %90
 
 ; <label>:90                                      ; preds = %86
   %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %89, i32 0, i32 9
   %92 = load i32, i32 addrspace(1)* %91, align 8
   %93 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.IO.StreamWriter addrspace(1)* %93, null
-  br i1 %NullCheck26, label %94, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.IO.StreamWriter addrspace(1)* %93, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %93, i32 0, i32 6
@@ -12550,8 +14259,8 @@ entry:
   %97 = load i8, i8* %arg2
   %98 = zext i8 %97 to i32
   %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
-  %NullCheck28 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck28, label %100, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
   %101 = load i64, i64 addrspace(1)* %99
@@ -12566,8 +14275,8 @@ entry:
   %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
   store i32 %110, i32* %loc1
   %111 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %111, null
-  br i1 %NullCheck30, label %112, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.IO.StreamWriter addrspace(1)* %111, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %112
 
 ; <label>:112                                     ; preds = %100
   %113 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %111, i32 0, i32 9
@@ -12578,23 +14287,23 @@ entry:
 
 ; <label>:116                                     ; preds = %112
   %117 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck32 = icmp ne %System.IO.StreamWriter addrspace(1)* %117, null
-  br i1 %NullCheck32, label %118, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.IO.StreamWriter addrspace(1)* %117, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %118
 
 ; <label>:118                                     ; preds = %116
   %119 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %117, i32 0, i32 3
   %120 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %119, align 8
   %121 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.IO.StreamWriter addrspace(1)* %121, null
-  br i1 %NullCheck34, label %122, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.IO.StreamWriter addrspace(1)* %121, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %122
 
 ; <label>:122                                     ; preds = %118
   %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
   %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
   %125 = load i32, i32* %loc1
   %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
-  %NullCheck36 = icmp ne i64 addrspace(1)* %126, null
-  br i1 %NullCheck36, label %127, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64 addrspace(1)* %126, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
   %128 = load i64, i64 addrspace(1)* %126
@@ -12616,15 +14325,15 @@ entry:
 
 ; <label>:140                                     ; preds = %136
   %141 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.IO.StreamWriter addrspace(1)* %141, null
-  br i1 %NullCheck38, label %142, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.IO.StreamWriter addrspace(1)* %141, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %142
 
 ; <label>:142                                     ; preds = %140
   %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
   %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
   %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
-  %NullCheck40 = icmp ne i64 addrspace(1)* %145, null
-  br i1 %NullCheck40, label %146, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i64 addrspace(1)* %145, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
   %147 = load i64, i64 addrspace(1)* %145
@@ -12645,83 +14354,83 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %25
+ThrowNullRef4:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %32
+ThrowNullRef6:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %37
+ThrowNullRef10:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %41
+ThrowNullRef12:                                   ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %58
+ThrowNullRef14:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %60
+ThrowNullRef16:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %65
+ThrowNullRef18:                                   ; preds = %65
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %80
+ThrowNullRef20:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %82
+ThrowNullRef22:                                   ; preds = %82
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %86
+ThrowNullRef24:                                   ; preds = %86
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %90
+ThrowNullRef26:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %94
+ThrowNullRef28:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %100
+ThrowNullRef30:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %116
+ThrowNullRef32:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %118
+ThrowNullRef34:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %122
+ThrowNullRef36:                                   ; preds = %122
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %140
+ThrowNullRef38:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %142
+ThrowNullRef40:                                   ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12788,8 +14497,8 @@ entry:
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %1 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
-  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
@@ -12797,8 +14506,8 @@ entry:
   %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
   %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
   %8 = load i64, i64 addrspace(1)* %6
@@ -12814,8 +14523,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %17, %System.IFormatProvider addrspace(1)* %16)
   %18 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %19 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %18, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.SyncTextWriter addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %7
   %21 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %18, i32 0, i32 4
@@ -12826,11 +14535,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12843,8 +14552,8 @@ entry:
   %this = alloca %System.IO.TextWriter addrspace(1)*
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.TextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
@@ -12854,8 +14563,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.Threading.Thread addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Threading.Thread addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %6)
@@ -12864,8 +14573,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1
   %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.TextWriter addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.TextWriter addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %11, i32 0, i32 2
@@ -12876,11 +14585,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13077,8 +14786,8 @@ entry:
   store float %param1, float* %arg1
   store i8 0, i8* %loc1
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
@@ -13088,16 +14797,16 @@ entry:
   %5 = addrspacecast i8* %loc1 to i8 addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %4, i8 addrspace(1)* %5)
   %6 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.SyncTextWriter addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
   %10 = load float, float* %arg1
   %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
   %13 = load i64, i64 addrspace(1)* %11
@@ -13132,11 +14841,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13153,8 +14862,8 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load float, float* %arg1
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -13168,8 +14877,8 @@ entry:
   call void %11(%System.IO.TextWriter addrspace(1)* %0, float %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
   %15 = load i64, i64 addrspace(1)* %13
@@ -13187,7 +14896,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13205,8 +14914,8 @@ entry:
   %1 = addrspacecast float* %arg1 to float addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -13221,8 +14930,8 @@ entry:
   %14 = bitcast float addrspace(1)* %1 to %System.Single addrspace(1)*
   %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Single addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Single addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
   %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
   %18 = load i64, i64 addrspace(1)* %16
@@ -13240,7 +14949,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13256,8 +14965,8 @@ entry:
   store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
   %0 = load %System.Single addrspace(1)*, %System.Single addrspace(1)** %this
   %1 = bitcast %System.Single addrspace(1)* %0 to float addrspace(1)*
-  %NullCheck = icmp ne float addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq float addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load float, float addrspace(1)* %1, align 8
@@ -13282,8 +14991,8 @@ entry:
   %loc0 = alloca %System.Globalization.NumberFormatInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 3
@@ -13293,8 +15002,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
@@ -13304,24 +15013,24 @@ entry:
   store %System.Globalization.NumberFormatInfo addrspace(1)* %10, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
   %11 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %7
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
   %15 = load i8, i8 addrspace(1)* %14, align 8
   %16 = zext i8 %15 to i32
   %17 = trunc i32 %16 to i8
-  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %11, null
-  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %11, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %13
   %19 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %11, i32 0, i32 29
   store i8 %17, i8 addrspace(1)* %19
   %20 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %21 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %20, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %20, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %18
   %23 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %20, i32 0, i32 3
@@ -13330,8 +15039,8 @@ entry:
 
 ; <label>:24                                      ; preds = %1, %22
   %25 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %25, null
-  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %25, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %26
 
 ; <label>:26                                      ; preds = %24
   %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %25, i32 0, i32 3
@@ -13342,23 +15051,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %18
+ThrowNullRef8:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13383,168 +15092,168 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 18
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %8, align 8
-  %NullCheck2 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %5, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %5, i32 0, i32 4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %9)
   %12 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 19
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %15, align 8
-  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %12, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %12, i32 0, i32 5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %16)
   %19 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %20 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %20, null
-  br i1 %NullCheck8, label %21, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %20, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %20, i32 0, i32 23
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  %NullCheck10 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %19, null
-  br i1 %NullCheck10, label %24, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %19, i32 0, i32 7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %25, %System.String addrspace(1)* %23)
   %26 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %27 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %27, i32 0, i32 22
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %29, align 8
-  %NullCheck14 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %26, null
-  br i1 %NullCheck14, label %31, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %26, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %26, i32 0, i32 6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %32, %System.String addrspace(1)* %30)
   %33 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %34 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Globalization.CultureData addrspace(1)* %34, null
-  br i1 %NullCheck16, label %35, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Globalization.CultureData addrspace(1)* %34, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %34, i32 0, i32 51
   %37 = load i32, i32 addrspace(1)* %36, align 8
-  %NullCheck18 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %33, null
-  br i1 %NullCheck18, label %38, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %33, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %33, i32 0, i32 21
   store i32 %37, i32 addrspace(1)* %39
   %40 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %41 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Globalization.CultureData addrspace(1)* %41, null
-  br i1 %NullCheck20, label %42, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Globalization.CultureData addrspace(1)* %41, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %41, i32 0, i32 52
   %44 = load i32, i32 addrspace(1)* %43, align 8
-  %NullCheck22 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %40, null
-  br i1 %NullCheck22, label %45, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %40, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %40, i32 0, i32 25
   store i32 %44, i32 addrspace(1)* %46
   %47 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %48 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.Globalization.CultureData addrspace(1)* %48, null
-  br i1 %NullCheck24, label %49, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Globalization.CultureData addrspace(1)* %48, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %49
 
 ; <label>:49                                      ; preds = %45
   %50 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %48, i32 0, i32 29
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck26 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %47, null
-  br i1 %NullCheck26, label %52, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %47, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %47, i32 0, i32 10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %53, %System.String addrspace(1)* %51)
   %54 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %55 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Globalization.CultureData addrspace(1)* %55, null
-  br i1 %NullCheck28, label %56, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Globalization.CultureData addrspace(1)* %55, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %56
 
 ; <label>:56                                      ; preds = %52
   %57 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %55, i32 0, i32 35
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %57, align 8
-  %NullCheck30 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %54, null
-  br i1 %NullCheck30, label %59, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %54, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %54, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %60, %System.String addrspace(1)* %58)
   %61 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %62 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck32 = icmp ne %System.Globalization.CultureData addrspace(1)* %62, null
-  br i1 %NullCheck32, label %63, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Globalization.CultureData addrspace(1)* %62, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %62, i32 0, i32 34
   %65 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %64, align 8
-  %NullCheck34 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %61, null
-  br i1 %NullCheck34, label %66, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %61, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %61, i32 0, i32 9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %67, %System.String addrspace(1)* %65)
   %68 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %69 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck36 = icmp ne %System.Globalization.CultureData addrspace(1)* %69, null
-  br i1 %NullCheck36, label %70, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Globalization.CultureData addrspace(1)* %69, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %70
 
 ; <label>:70                                      ; preds = %66
   %71 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %69, i32 0, i32 55
   %72 = load i32, i32 addrspace(1)* %71, align 8
-  %NullCheck38 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %68, null
-  br i1 %NullCheck38, label %73, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %68, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %68, i32 0, i32 22
   store i32 %72, i32 addrspace(1)* %74
   %75 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %76 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck40 = icmp ne %System.Globalization.CultureData addrspace(1)* %76, null
-  br i1 %NullCheck40, label %77, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Globalization.CultureData addrspace(1)* %76, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %76, i32 0, i32 57
   %79 = load i32, i32 addrspace(1)* %78, align 8
-  %NullCheck42 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %75, null
-  br i1 %NullCheck42, label %80, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %75, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %80
 
 ; <label>:80                                      ; preds = %77
   %81 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %75, i32 0, i32 24
   store i32 %79, i32 addrspace(1)* %81
   %82 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %83 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck44 = icmp ne %System.Globalization.CultureData addrspace(1)* %83, null
-  br i1 %NullCheck44, label %84, label %ThrowNullRef43
+  %NullCheck43 = icmp eq %System.Globalization.CultureData addrspace(1)* %83, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %84
 
 ; <label>:84                                      ; preds = %80
   %85 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %83, i32 0, i32 56
   %86 = load i32, i32 addrspace(1)* %85, align 8
-  %NullCheck46 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %82, null
-  br i1 %NullCheck46, label %87, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %82, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %82, i32 0, i32 23
@@ -13553,8 +15262,8 @@ entry:
 
 ; <label>:89                                      ; preds = %entry
   %90 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck100 = icmp ne %System.Globalization.CultureData addrspace(1)* %90, null
-  br i1 %NullCheck100, label %91, label %ThrowNullRef99
+  %NullCheck99 = icmp eq %System.Globalization.CultureData addrspace(1)* %90, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %91
 
 ; <label>:91                                      ; preds = %89
   %92 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %90, i32 0, i32 2
@@ -13572,8 +15281,8 @@ entry:
   %102 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %103 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %104 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %103)
-  %NullCheck48 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %102, null
-  br i1 %NullCheck48, label %105, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %102, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %105
 
 ; <label>:105                                     ; preds = %101
   %106 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %102, i32 0, i32 1
@@ -13581,8 +15290,8 @@ entry:
   %107 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %108 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %109 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %108)
-  %NullCheck50 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %107, null
-  br i1 %NullCheck50, label %110, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %107, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %110
 
 ; <label>:110                                     ; preds = %105
   %111 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %107, i32 0, i32 2
@@ -13590,8 +15299,8 @@ entry:
   %112 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %113 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %114 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %113)
-  %NullCheck52 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %112, null
-  br i1 %NullCheck52, label %115, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %112, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %115
 
 ; <label>:115                                     ; preds = %110
   %116 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %112, i32 0, i32 27
@@ -13599,8 +15308,8 @@ entry:
   %117 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %118 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %119 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %118)
-  %NullCheck54 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %117, null
-  br i1 %NullCheck54, label %120, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %117, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %120
 
 ; <label>:120                                     ; preds = %115
   %121 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %117, i32 0, i32 26
@@ -13608,8 +15317,8 @@ entry:
   %122 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %123 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %124 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %123)
-  %NullCheck56 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %122, null
-  br i1 %NullCheck56, label %125, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %122, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %125
 
 ; <label>:125                                     ; preds = %120
   %126 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %122, i32 0, i32 17
@@ -13617,8 +15326,8 @@ entry:
   %127 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %128 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %129 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %128)
-  %NullCheck58 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %127, null
-  br i1 %NullCheck58, label %130, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %127, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %130
 
 ; <label>:130                                     ; preds = %125
   %131 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %127, i32 0, i32 18
@@ -13626,8 +15335,8 @@ entry:
   %132 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %133 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %134 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %133)
-  %NullCheck60 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %132, null
-  br i1 %NullCheck60, label %135, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %132, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %135
 
 ; <label>:135                                     ; preds = %130
   %136 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %132, i32 0, i32 14
@@ -13635,8 +15344,8 @@ entry:
   %137 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %138 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %139 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %138)
-  %NullCheck62 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %137, null
-  br i1 %NullCheck62, label %140, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %137, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %140
 
 ; <label>:140                                     ; preds = %135
   %141 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %137, i32 0, i32 13
@@ -13644,71 +15353,71 @@ entry:
   %142 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %143 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %144 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %143)
-  %NullCheck64 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %142, null
-  br i1 %NullCheck64, label %145, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %142, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %145
 
 ; <label>:145                                     ; preds = %140
   %146 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %142, i32 0, i32 12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %146, %System.String addrspace(1)* %144)
   %147 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %148 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck66 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %148, null
-  br i1 %NullCheck66, label %149, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %148, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %149
 
 ; <label>:149                                     ; preds = %145
   %150 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %148, i32 0, i32 21
   %151 = load i32, i32 addrspace(1)* %150, align 8
-  %NullCheck68 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %147, null
-  br i1 %NullCheck68, label %152, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %147, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %152
 
 ; <label>:152                                     ; preds = %149
   %153 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %147, i32 0, i32 28
   store i32 %151, i32 addrspace(1)* %153
   %154 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %155 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck70 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %155, null
-  br i1 %NullCheck70, label %156, label %ThrowNullRef69
+  %NullCheck69 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %155, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %156
 
 ; <label>:156                                     ; preds = %152
   %157 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %155, i32 0, i32 6
   %158 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %157, align 8
-  %NullCheck72 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %154, null
-  br i1 %NullCheck72, label %159, label %ThrowNullRef71
+  %NullCheck71 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %154, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %159
 
 ; <label>:159                                     ; preds = %156
   %160 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %154, i32 0, i32 15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %160, %System.String addrspace(1)* %158)
   %161 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %162 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck74 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %162, null
-  br i1 %NullCheck74, label %163, label %ThrowNullRef73
+  %NullCheck73 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %162, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %163
 
 ; <label>:163                                     ; preds = %159
   %164 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %162, i32 0, i32 1
   %165 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %164, align 8
-  %NullCheck76 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %161, null
-  br i1 %NullCheck76, label %166, label %ThrowNullRef75
+  %NullCheck75 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %161, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %166
 
 ; <label>:166                                     ; preds = %163
   %167 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %161, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %167, %"System.Int32[]" addrspace(1)* %165)
   %168 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %169 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck78 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %169, null
-  br i1 %NullCheck78, label %170, label %ThrowNullRef77
+  %NullCheck77 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %169, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %170
 
 ; <label>:170                                     ; preds = %166
   %171 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %169, i32 0, i32 7
   %172 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %171, align 8
-  %NullCheck80 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %168, null
-  br i1 %NullCheck80, label %173, label %ThrowNullRef79
+  %NullCheck79 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %168, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %173
 
 ; <label>:173                                     ; preds = %170
   %174 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %168, i32 0, i32 16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %174, %System.String addrspace(1)* %172)
   %175 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck82 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %175, null
-  br i1 %NullCheck82, label %176, label %ThrowNullRef81
+  %NullCheck81 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %175, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %176
 
 ; <label>:176                                     ; preds = %173
   %177 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %175, i32 0, i32 4
@@ -13718,14 +15427,14 @@ entry:
 
 ; <label>:180                                     ; preds = %176
   %181 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck84 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %181, null
-  br i1 %NullCheck84, label %182, label %ThrowNullRef83
+  %NullCheck83 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %181, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %182
 
 ; <label>:182                                     ; preds = %180
   %183 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %181, i32 0, i32 4
   %184 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %183, align 8
-  %NullCheck86 = icmp ne %System.String addrspace(1)* %184, null
-  br i1 %NullCheck86, label %185, label %ThrowNullRef85
+  %NullCheck85 = icmp eq %System.String addrspace(1)* %184, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %185
 
 ; <label>:185                                     ; preds = %182
   %186 = getelementptr inbounds %System.String, %System.String addrspace(1)* %184, i32 0, i32 1
@@ -13736,8 +15445,8 @@ entry:
 ; <label>:189                                     ; preds = %176, %185
   %190 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck98 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %190, null
-  br i1 %NullCheck98, label %192, label %ThrowNullRef97
+  %NullCheck97 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %190, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %192
 
 ; <label>:192                                     ; preds = %189
   %193 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %190, i32 0, i32 4
@@ -13746,8 +15455,8 @@ entry:
 
 ; <label>:194                                     ; preds = %185, %192
   %195 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck88 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %195, null
-  br i1 %NullCheck88, label %196, label %ThrowNullRef87
+  %NullCheck87 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %195, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %196
 
 ; <label>:196                                     ; preds = %194
   %197 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %195, i32 0, i32 9
@@ -13757,14 +15466,14 @@ entry:
 
 ; <label>:200                                     ; preds = %196
   %201 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck90 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %201, null
-  br i1 %NullCheck90, label %202, label %ThrowNullRef89
+  %NullCheck89 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %201, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %202
 
 ; <label>:202                                     ; preds = %200
   %203 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %201, i32 0, i32 9
   %204 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %203, align 8
-  %NullCheck92 = icmp ne %System.String addrspace(1)* %204, null
-  br i1 %NullCheck92, label %205, label %ThrowNullRef91
+  %NullCheck91 = icmp eq %System.String addrspace(1)* %204, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %205
 
 ; <label>:205                                     ; preds = %202
   %206 = getelementptr inbounds %System.String, %System.String addrspace(1)* %204, i32 0, i32 1
@@ -13775,14 +15484,14 @@ entry:
 ; <label>:209                                     ; preds = %196, %205
   %210 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %211 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck94 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %211, null
-  br i1 %NullCheck94, label %212, label %ThrowNullRef93
+  %NullCheck93 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %211, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %212
 
 ; <label>:212                                     ; preds = %209
   %213 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %211, i32 0, i32 6
   %214 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %213, align 8
-  %NullCheck96 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %210, null
-  br i1 %NullCheck96, label %215, label %ThrowNullRef95
+  %NullCheck95 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %210, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %215
 
 ; <label>:215                                     ; preds = %212
   %216 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %210, i32 0, i32 9
@@ -13796,203 +15505,203 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %17
+ThrowNullRef8:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %21
+ThrowNullRef10:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %24
+ThrowNullRef12:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %28
+ThrowNullRef14:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %31
+ThrowNullRef16:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %35
+ThrowNullRef18:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %38
+ThrowNullRef20:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %42
+ThrowNullRef22:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %45
+ThrowNullRef24:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %49
+ThrowNullRef26:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %52
+ThrowNullRef28:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %56
+ThrowNullRef30:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %59
+ThrowNullRef32:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %63
+ThrowNullRef34:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %66
+ThrowNullRef36:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %70
+ThrowNullRef38:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %73
+ThrowNullRef40:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %77
+ThrowNullRef42:                                   ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %80
+ThrowNullRef44:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %84
+ThrowNullRef46:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %101
+ThrowNullRef48:                                   ; preds = %101
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %105
+ThrowNullRef50:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %110
+ThrowNullRef52:                                   ; preds = %110
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %115
+ThrowNullRef54:                                   ; preds = %115
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %120
+ThrowNullRef56:                                   ; preds = %120
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %125
+ThrowNullRef58:                                   ; preds = %125
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %130
+ThrowNullRef60:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %135
+ThrowNullRef62:                                   ; preds = %135
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %140
+ThrowNullRef64:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %145
+ThrowNullRef66:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %149
+ThrowNullRef68:                                   ; preds = %149
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %152
+ThrowNullRef70:                                   ; preds = %152
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %156
+ThrowNullRef72:                                   ; preds = %156
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %159
+ThrowNullRef74:                                   ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %163
+ThrowNullRef76:                                   ; preds = %163
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %166
+ThrowNullRef78:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %170
+ThrowNullRef80:                                   ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %173
+ThrowNullRef82:                                   ; preds = %173
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %180
+ThrowNullRef84:                                   ; preds = %180
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %182
+ThrowNullRef86:                                   ; preds = %182
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %194
+ThrowNullRef88:                                   ; preds = %194
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %200
+ThrowNullRef90:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %202
+ThrowNullRef92:                                   ; preds = %202
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %209
+ThrowNullRef94:                                   ; preds = %209
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %212
+ThrowNullRef96:                                   ; preds = %212
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %189
+ThrowNullRef98:                                   ; preds = %189
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %89
+ThrowNullRef100:                                  ; preds = %89
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14020,8 +15729,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 21
@@ -14034,8 +15743,8 @@ entry:
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 16)
   %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 21
@@ -14044,8 +15753,8 @@ entry:
 
 ; <label>:12                                      ; preds = %1, %10
   %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 21
@@ -14056,11 +15765,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %12
+ThrowNullRef4:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14076,8 +15785,8 @@ entry:
   store i32 %param1, i32* %arg1
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %1 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
@@ -14144,8 +15853,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 33
@@ -14158,8 +15867,8 @@ entry:
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 24)
   %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 33
@@ -14168,8 +15877,8 @@ entry:
 
 ; <label>:12                                      ; preds = %1, %10
   %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 33
@@ -14180,11 +15889,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %12
+ThrowNullRef4:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14197,8 +15906,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 53
@@ -14210,8 +15919,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 116)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 53
@@ -14220,8 +15929,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 53
@@ -14232,11 +15941,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14265,8 +15974,8 @@ entry:
 
 ; <label>:7                                       ; preds = %entry, %4
   %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %7
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 2
@@ -14290,8 +15999,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 54
@@ -14303,8 +16012,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 117)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
@@ -14313,8 +16022,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 54
@@ -14325,11 +16034,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14342,8 +16051,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 27
@@ -14355,8 +16064,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 118)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 27
@@ -14365,8 +16074,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 27
@@ -14377,11 +16086,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14394,8 +16103,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 28
@@ -14407,8 +16116,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 119)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 28
@@ -14417,8 +16126,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 28
@@ -14429,11 +16138,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14446,8 +16155,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 26
@@ -14459,8 +16168,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 107)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 26
@@ -14469,8 +16178,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 26
@@ -14481,11 +16190,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14498,8 +16207,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 25
@@ -14511,8 +16220,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 106)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 25
@@ -14521,8 +16230,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 25
@@ -14533,11 +16242,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14550,8 +16259,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 24
@@ -14563,8 +16272,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 105)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 24
@@ -14573,8 +16282,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 24
@@ -14585,11 +16294,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14614,8 +16323,8 @@ entry:
   %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %3)
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %2
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -14626,15 +16335,15 @@ entry:
 
 ; <label>:8                                       ; preds = %62
   %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 9
   %12 = load i32, i32 addrspace(1)* %11, align 8
   %13 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.IO.StreamWriter addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %13, i32 0, i32 10
@@ -14649,15 +16358,15 @@ entry:
 
 ; <label>:20                                      ; preds = %14, %18
   %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
   %24 = load i32, i32 addrspace(1)* %23, align 8
   %25 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %25, null
-  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.StreamWriter addrspace(1)* %25, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %25, i32 0, i32 9
@@ -14678,36 +16387,36 @@ entry:
   %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %37 = load i32, i32* %loc1
   %38 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.StreamWriter addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %35
   %40 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %38, i32 0, i32 7
   %41 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %40, align 8
   %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
-  br i1 %NullCheck14, label %43, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %39
   %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 9
   %45 = load i32, i32 addrspace(1)* %44, align 8
   %46 = load i32, i32* %loc2
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %36, null
-  br i1 %NullCheck16, label %47, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %36, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %47
 
 ; <label>:47                                      ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %36, i32 %37, %"System.Char[]" addrspace(1)* %41, i32 %45, i32 %46)
   %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
   %51 = load i32, i32 addrspace(1)* %50, align 8
   %52 = load i32, i32* %loc2
   %53 = add i32 %51, %52
-  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
-  br i1 %NullCheck20, label %54, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %54
 
 ; <label>:54                                      ; preds = %49
   %55 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
@@ -14729,8 +16438,8 @@ entry:
 
 ; <label>:65                                      ; preds = %62
   %66 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %66, null
-  br i1 %NullCheck2, label %67, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %66, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %67
 
 ; <label>:67                                      ; preds = %65
   %68 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %66, i32 0, i32 11
@@ -14751,49 +16460,259 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %65
+ThrowNullRef2:                                    ; preds = %65
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %20
+ThrowNullRef8:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %22
+ThrowNullRef10:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %35
+ThrowNullRef12:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %43
+ThrowNullRef16:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %47
+ThrowNullRef18:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method String::CopyTo using LLILCJit
-Failed to read String.CopyTo[loadElemA]
+Successfully read String.CopyTo
+
+define void @String.CopyTo(%System.String addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  %loc1 = alloca i16 addrspace(1)*
+  %loc2 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %1 = icmp ne %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg4
+  %7 = icmp sge i32 %6, 0
+  br i1 %7, label %13, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  unreachable
+
+; <label>:13                                      ; preds = %5
+  %14 = load i32, i32* %arg1
+  %15 = icmp sge i32 %14, 0
+  br i1 %15, label %21, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %18)
+  %20 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %20, %System.String addrspace(1)* %17, %System.String addrspace(1)* %19)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %20) #0
+  unreachable
+
+; <label>:21                                      ; preds = %13
+  %22 = load i32, i32* %arg4
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck, label %ThrowNullRef, label %24
+
+; <label>:24                                      ; preds = %21
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load i32, i32* %arg1
+  %28 = sub i32 %26, %27
+  %29 = icmp sle i32 %22, %28
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34, %System.String addrspace(1)* %31, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %24
+  %36 = load i32, i32* %arg3
+  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %37, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
+
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
+  %40 = load i32, i32 addrspace(1)* %39
+  %41 = zext i32 %40 to i64
+  %42 = trunc i64 %41 to i32
+  %43 = load i32, i32* %arg4
+  %44 = sub i32 %42, %43
+  %45 = icmp sgt i32 %36, %44
+  br i1 %45, label %49, label %46
+
+; <label>:46                                      ; preds = %38
+  %47 = load i32, i32* %arg3
+  %48 = icmp sge i32 %47, 0
+  br i1 %48, label %54, label %49
+
+; <label>:49                                      ; preds = %38, %46
+  %50 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %52 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %51)
+  %53 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53, %System.String addrspace(1)* %50, %System.String addrspace(1)* %52)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53) #0
+  unreachable
+
+; <label>:54                                      ; preds = %46
+  %55 = load i32, i32* %arg4
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %97, label %57
+
+; <label>:57                                      ; preds = %54
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %59
+
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 2
+  %61 = bitcast [0 x i16] addrspace(1)* %60 to i16 addrspace(1)*
+  store i16 addrspace(1)* %61, i16 addrspace(1)** %loc0
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  store %"System.Char[]" addrspace(1)* %62, %"System.Char[]" addrspace(1)** %loc2
+  %63 = icmp eq %"System.Char[]" addrspace(1)* %62, null
+  br i1 %63, label %72, label %64
+
+; <label>:64                                      ; preds = %59
+  %65 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc2
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %65, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %66
+
+; <label>:66                                      ; preds = %64
+  %67 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %65, i32 0, i32 1
+  %68 = load i32, i32 addrspace(1)* %67
+  %69 = zext i32 %68 to i64
+  %70 = trunc i64 %69 to i32
+  %71 = icmp ne i32 %70, 0
+  br i1 %71, label %73, label %72
+
+; <label>:72                                      ; preds = %59, %66
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  br label %81
+
+; <label>:73                                      ; preds = %66
+  %74 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc2
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %74, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %75
+
+; <label>:75                                      ; preds = %73
+  %76 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %74, i32 0, i32 1
+  %77 = load i32, i32 addrspace(1)* %76
+  %78 = zext i32 %77 to i64
+  %BoundsCheck = icmp uge i64 0, %78
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %79
+
+; <label>:79                                      ; preds = %75
+  %80 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %74, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %80, i16 addrspace(1)** %loc1
+  br label %81
+
+; <label>:81                                      ; preds = %72, %79
+  %82 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %83 = ptrtoint i16 addrspace(1)* %82 to i64
+  %84 = load i32, i32* %arg3
+  %85 = sext i32 %84 to i64
+  %86 = mul i64 %85, 2
+  %87 = add i64 %83, %86
+  %88 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %89 = ptrtoint i16 addrspace(1)* %88 to i64
+  %90 = load i32, i32* %arg1
+  %91 = sext i32 %90 to i64
+  %92 = mul i64 %91, 2
+  %93 = add i64 %89, %92
+  %94 = load i32, i32* %arg4
+  %95 = inttoptr i64 %87 to i16*
+  %96 = inttoptr i64 %93 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %95, i16* %96, i32 %94)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  br label %97
+
+; <label>:97                                      ; preds = %54, %81
+  ret void
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
 Successfully read ConsoleEncoding.GetPreamble
 
@@ -14830,7 +16749,365 @@ entry:
 }
 
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[loadElemA]
+Successfully read EncoderNLS.GetBytes
+
+define i32 @EncoderNLS.GetBytes(%System.Text.EncoderNLS addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3, %"System.Byte[]" addrspace(1)* %param4, i32 %param5, i8 %param6) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %arg4 = alloca %"System.Byte[]" addrspace(1)*
+  %arg5 = alloca i32
+  %arg6 = alloca i8
+  %loc0 = alloca i32
+  %loc1 = alloca i16 addrspace(1)*
+  %loc2 = alloca i8 addrspace(1)*
+  %loc3 = alloca i32
+  %loc4 = alloca %"System.Char[]" addrspace(1)*
+  %loc5 = alloca %"System.Byte[]" addrspace(1)*
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  store %"System.Byte[]" addrspace(1)* %param4, %"System.Byte[]" addrspace(1)** %arg4
+  store i32 %param5, i32* %arg5
+  store i8 %param6, i8* %arg6
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %1 = icmp eq %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %17, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %7 = icmp eq %"System.Char[]" addrspace(1)* %6, null
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %12
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %12
+
+; <label>:12                                      ; preds = %8, %10
+  %13 = phi %System.String addrspace(1)* [ %9, %8 ], [ %11, %10 ]
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %14)
+  %16 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16, %System.String addrspace(1)* %13, %System.String addrspace(1)* %15)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16) #0
+  unreachable
+
+; <label>:17                                      ; preds = %2
+  %18 = load i32, i32* %arg2
+  %19 = icmp slt i32 %18, 0
+  br i1 %19, label %23, label %20
+
+; <label>:20                                      ; preds = %17
+  %21 = load i32, i32* %arg3
+  %22 = icmp sge i32 %21, 0
+  br i1 %22, label %35, label %23
+
+; <label>:23                                      ; preds = %17, %20
+  %24 = load i32, i32* %arg2
+  %25 = icmp slt i32 %24, 0
+  br i1 %25, label %28, label %26
+
+; <label>:26                                      ; preds = %23
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %30
+
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %30
+
+; <label>:30                                      ; preds = %26, %28
+  %31 = phi %System.String addrspace(1)* [ %27, %26 ], [ %29, %28 ]
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34, %System.String addrspace(1)* %31, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %20
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck, label %ThrowNullRef, label %37
+
+; <label>:37                                      ; preds = %35
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = load i32, i32* %arg2
+  %43 = sub i32 %41, %42
+  %44 = load i32, i32* %arg3
+  %45 = icmp sge i32 %43, %44
+  br i1 %45, label %51, label %46
+
+; <label>:46                                      ; preds = %37
+  %47 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %48 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %49 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %48)
+  %50 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %50, %System.String addrspace(1)* %47, %System.String addrspace(1)* %49)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %50) #0
+  unreachable
+
+; <label>:51                                      ; preds = %37
+  %52 = load i32, i32* %arg5
+  %53 = icmp slt i32 %52, 0
+  br i1 %53, label %63, label %54
+
+; <label>:54                                      ; preds = %51
+  %55 = load i32, i32* %arg5
+  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck1 = icmp eq %"System.Byte[]" addrspace(1)* %56, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %57
+
+; <label>:57                                      ; preds = %54
+  %58 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = zext i32 %59 to i64
+  %61 = trunc i64 %60 to i32
+  %62 = icmp sle i32 %55, %61
+  br i1 %62, label %68, label %63
+
+; <label>:63                                      ; preds = %51, %57
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %66 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %65)
+  %67 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %67, %System.String addrspace(1)* %64, %System.String addrspace(1)* %66)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %67) #0
+  unreachable
+
+; <label>:68                                      ; preds = %57
+  %69 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %69, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %69, i32 0, i32 1
+  %72 = load i32, i32 addrspace(1)* %71
+  %73 = zext i32 %72 to i64
+  %74 = trunc i64 %73 to i32
+  %75 = icmp ne i32 %74, 0
+  br i1 %75, label %78, label %76
+
+; <label>:76                                      ; preds = %70
+  %77 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1)
+  store %"System.Char[]" addrspace(1)* %77, %"System.Char[]" addrspace(1)** %arg1
+  br label %78
+
+; <label>:78                                      ; preds = %70, %76
+  %79 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck5 = icmp eq %"System.Byte[]" addrspace(1)* %79, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %80
+
+; <label>:80                                      ; preds = %78
+  %81 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %79, i32 0, i32 1
+  %82 = load i32, i32 addrspace(1)* %81
+  %83 = zext i32 %82 to i64
+  %84 = trunc i64 %83 to i32
+  %85 = load i32, i32* %arg5
+  %86 = sub i32 %84, %85
+  store i32 %86, i32* %loc0
+  %87 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck7 = icmp eq %"System.Byte[]" addrspace(1)* %87, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %88
+
+; <label>:88                                      ; preds = %80
+  %89 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %87, i32 0, i32 1
+  %90 = load i32, i32 addrspace(1)* %89
+  %91 = zext i32 %90 to i64
+  %92 = trunc i64 %91 to i32
+  %93 = icmp ne i32 %92, 0
+  br i1 %93, label %96, label %94
+
+; <label>:94                                      ; preds = %88
+  %95 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1)
+  store %"System.Byte[]" addrspace(1)* %95, %"System.Byte[]" addrspace(1)** %arg4
+  br label %96
+
+; <label>:96                                      ; preds = %88, %94
+  %97 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  store %"System.Char[]" addrspace(1)* %97, %"System.Char[]" addrspace(1)** %loc4
+  %98 = icmp eq %"System.Char[]" addrspace(1)* %97, null
+  br i1 %98, label %107, label %99
+
+; <label>:99                                      ; preds = %96
+  %100 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc4
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %100, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %101
+
+; <label>:101                                     ; preds = %99
+  %102 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %100, i32 0, i32 1
+  %103 = load i32, i32 addrspace(1)* %102
+  %104 = zext i32 %103 to i64
+  %105 = trunc i64 %104 to i32
+  %106 = icmp ne i32 %105, 0
+  br i1 %106, label %108, label %107
+
+; <label>:107                                     ; preds = %96, %101
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  br label %116
+
+; <label>:108                                     ; preds = %101
+  %109 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc4
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %109, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %110
+
+; <label>:110                                     ; preds = %108
+  %111 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %109, i32 0, i32 1
+  %112 = load i32, i32 addrspace(1)* %111
+  %113 = zext i32 %112 to i64
+  %BoundsCheck = icmp uge i64 0, %113
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %114
+
+; <label>:114                                     ; preds = %110
+  %115 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %109, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %115, i16 addrspace(1)** %loc1
+  br label %116
+
+; <label>:116                                     ; preds = %107, %114
+  %117 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  store %"System.Byte[]" addrspace(1)* %117, %"System.Byte[]" addrspace(1)** %loc5
+  %118 = icmp eq %"System.Byte[]" addrspace(1)* %117, null
+  br i1 %118, label %127, label %119
+
+; <label>:119                                     ; preds = %116
+  %120 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc5
+  %NullCheck13 = icmp eq %"System.Byte[]" addrspace(1)* %120, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %121
+
+; <label>:121                                     ; preds = %119
+  %122 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %120, i32 0, i32 1
+  %123 = load i32, i32 addrspace(1)* %122
+  %124 = zext i32 %123 to i64
+  %125 = trunc i64 %124 to i32
+  %126 = icmp ne i32 %125, 0
+  br i1 %126, label %128, label %127
+
+; <label>:127                                     ; preds = %116, %121
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc2
+  br label %136
+
+; <label>:128                                     ; preds = %121
+  %129 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc5
+  %NullCheck15 = icmp eq %"System.Byte[]" addrspace(1)* %129, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %130
+
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %129, i32 0, i32 1
+  %132 = load i32, i32 addrspace(1)* %131
+  %133 = zext i32 %132 to i64
+  %BoundsCheck17 = icmp uge i64 0, %133
+  br i1 %BoundsCheck17, label %ThrowIndexOutOfRange18, label %134
+
+; <label>:134                                     ; preds = %130
+  %135 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %129, i32 0, i32 3, i32 0
+  store i8 addrspace(1)* %135, i8 addrspace(1)** %loc2
+  br label %136
+
+; <label>:136                                     ; preds = %127, %134
+  %137 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %138 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %139 = ptrtoint i16 addrspace(1)* %138 to i64
+  %140 = load i32, i32* %arg2
+  %141 = sext i32 %140 to i64
+  %142 = mul i64 %141, 2
+  %143 = add i64 %139, %142
+  %144 = load i32, i32* %arg3
+  %145 = load i8 addrspace(1)*, i8 addrspace(1)** %loc2
+  %146 = ptrtoint i8 addrspace(1)* %145 to i64
+  %147 = load i32, i32* %arg5
+  %148 = sext i32 %147 to i64
+  %149 = add i64 %146, %148
+  %150 = load i32, i32* %loc0
+  %151 = load i8, i8* %arg6
+  %152 = zext i8 %151 to i32
+  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i64 addrspace(1)*
+  %NullCheck19 = icmp eq i64 addrspace(1)* %153, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %154
+
+; <label>:154                                     ; preds = %136
+  %155 = load i64, i64 addrspace(1)* %153
+  %156 = add i64 %155, 72
+  %157 = inttoptr i64 %156 to i64*
+  %158 = load i64, i64* %157
+  %159 = add i64 %158, 0
+  %160 = inttoptr i64 %159 to i64*
+  %161 = load i64, i64* %160
+  %162 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to %System.Text.Encoder addrspace(1)*
+  %163 = inttoptr i64 %143 to i16*
+  %164 = inttoptr i64 %149 to i8*
+  %165 = trunc i32 %152 to i8
+  %166 = inttoptr i64 %161 to i32 (%System.Text.Encoder addrspace(1)*, i16*, i32, i8*, i32, i8)*
+  %167 = call i32 %166(%System.Text.Encoder addrspace(1)* %162, i16* %163, i32 %144, i8* %164, i32 %150, i8 %165)
+  store i32 %167, i32* %loc3
+  br label %168
+
+; <label>:168                                     ; preds = %154
+  %169 = load i32, i32* %loc3
+  ret i32 %169
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %110
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %119
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange18:                           ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
 Successfully read EncoderNLS.GetBytes
 
@@ -14919,22 +17196,22 @@ entry:
   %40 = load i8, i8* %arg5
   %41 = zext i8 %40 to i32
   %42 = trunc i32 %41 to i8
-  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %39, null
-  br i1 %NullCheck, label %43, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderNLS addrspace(1)* %39, null
+  br i1 %NullCheck, label %ThrowNullRef, label %43
 
 ; <label>:43                                      ; preds = %38
   %44 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
   store i8 %42, i8 addrspace(1)* %44
   %45 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %45, null
-  br i1 %NullCheck2, label %46, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.EncoderNLS addrspace(1)* %45, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %46
 
 ; <label>:46                                      ; preds = %43
   %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %45, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %47
   %48 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.EncoderNLS addrspace(1)* %48, null
-  br i1 %NullCheck4, label %49, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.EncoderNLS addrspace(1)* %48, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %49
 
 ; <label>:49                                      ; preds = %46
   %50 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %48, i32 0, i32 3
@@ -14945,8 +17222,8 @@ entry:
   %55 = load i32, i32* %arg4
   %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck6, label %58, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
   %59 = load i64, i64 addrspace(1)* %57
@@ -14964,15 +17241,15 @@ ThrowNullRef:                                     ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %43
+ThrowNullRef2:                                    ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %46
+ThrowNullRef4:                                    ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %49
+ThrowNullRef6:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -15000,8 +17277,8 @@ entry:
   %4 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0 to %System.IO.ConsoleStream addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*)(%System.IO.ConsoleStream addrspace(1)* %4, %"System.Byte[]" addrspace(1)* %1, i32 %2, i32 %3)
   %5 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
@@ -15086,8 +17363,8 @@ entry:
 
 ; <label>:22                                      ; preds = %8
   %23 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %23, null
-  br i1 %NullCheck, label %24, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Byte[]" addrspace(1)* %23, null
+  br i1 %NullCheck, label %ThrowNullRef, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
@@ -15109,8 +17386,8 @@ entry:
 
 ; <label>:36                                      ; preds = %24
   %37 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %37, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.ConsoleStream addrspace(1)* %37, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %37, i32 0, i32 4
@@ -15131,13 +17408,138 @@ ThrowNullRef:                                     ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %36
+ThrowNullRef2:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
-Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
+Successfully read WindowsConsoleStream.WriteFileNative
+
+define i32 @WindowsConsoleStream.WriteFileNative(i64 %param0, %"System.Byte[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i64
+  %arg1 = alloca %"System.Byte[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i8 addrspace(1)*
+  %loc2 = alloca %"System.Byte[]" addrspace(1)*
+  %loc3 = alloca i32
+  store i64 %param0, i64* %arg0
+  store %"System.Byte[]" addrspace(1)* %param1, %"System.Byte[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Byte[]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = zext i32 %3 to i64
+  %5 = icmp ne i64 %4, 0
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %1
+  ret i32 0
+
+; <label>:7                                       ; preds = %1
+  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  store %"System.Byte[]" addrspace(1)* %8, %"System.Byte[]" addrspace(1)** %loc2
+  %9 = icmp eq %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %9, label %18, label %10
+
+; <label>:10                                      ; preds = %7
+  %11 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc2
+  %NullCheck1 = icmp eq %"System.Byte[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %11, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp ne i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %7, %12
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc1
+  br label %27
+
+; <label>:19                                      ; preds = %12
+  %20 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc2
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %20, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %BoundsCheck = icmp uge i64 0, %24
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %25
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %20, i32 0, i32 3, i32 0
+  store i8 addrspace(1)* %26, i8 addrspace(1)** %loc1
+  br label %27
+
+; <label>:27                                      ; preds = %18, %25
+  %28 = load i64, i64* %arg0
+  %29 = load i8 addrspace(1)*, i8 addrspace(1)** %loc1
+  %30 = ptrtoint i8 addrspace(1)* %29 to i64
+  %31 = load i32, i32* %arg2
+  %32 = sext i32 %31 to i64
+  %33 = add i64 %30, %32
+  %34 = load i32, i32* %arg3
+  %35 = addrspacecast i32* %loc3 to i32 addrspace(1)*
+  %36 = inttoptr i64 %33 to i8*
+  %37 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i8*, i32, i32 addrspace(1)*, i64)*)(i64 %28, i8* %36, i32 %34, i32 addrspace(1)* %35, i64 0)
+  %38 = icmp ugt i32 %37, 0
+  %39 = sext i1 %38 to i32
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc1
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %42, label %41
+
+; <label>:41                                      ; preds = %27
+  ret i32 0
+
+; <label>:42                                      ; preds = %27
+  %43 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  store i32 %43, i32* %loc0
+  %44 = load i32, i32* %loc0
+  %45 = icmp eq i32 %44, 232
+  br i1 %45, label %49, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = load i32, i32* %loc0
+  %48 = icmp ne i32 %47, 109
+  br i1 %48, label %50, label %49
+
+; <label>:49                                      ; preds = %42, %46
+  ret i32 0
+
+; <label>:50                                      ; preds = %46
+  %51 = load i32, i32* %loc0
+  ret i32 %51
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
 Successfully read WindowsConsoleStream.Flush
 
@@ -15146,8 +17548,8 @@ entry:
   %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
   store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
@@ -15182,8 +17584,8 @@ entry:
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
   %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load i64, i64 addrspace(1)* %1
@@ -15222,15 +17624,15 @@ entry:
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.TextWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
   %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %3, align 8
   %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
   %7 = load i64, i64 addrspace(1)* %5
@@ -15248,7 +17650,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -15277,8 +17679,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %4)
   store i32 0, i32* %loc0
   %5 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Char[]" addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
@@ -15290,15 +17692,15 @@ entry:
 
 ; <label>:11                                      ; preds = %69
   %12 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %12, i32 0, i32 9
   %15 = load i32, i32 addrspace(1)* %14, align 8
   %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.IO.StreamWriter addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %16, i32 0, i32 10
@@ -15313,15 +17715,15 @@ entry:
 
 ; <label>:23                                      ; preds = %17, %21
   %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %24, null
-  br i1 %NullCheck8, label %25, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %24, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 10
   %27 = load i32, i32 addrspace(1)* %26, align 8
   %28 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %28, null
-  br i1 %NullCheck10, label %29, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.StreamWriter addrspace(1)* %28, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %28, i32 0, i32 9
@@ -15343,15 +17745,15 @@ entry:
   %40 = load i32, i32* %loc0
   %41 = mul i32 %40, 2
   %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
-  br i1 %NullCheck12, label %43, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %43
 
 ; <label>:43                                      ; preds = %38
   %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 7
   %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %44, align 8
   %46 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %46, null
-  br i1 %NullCheck14, label %47, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.IO.StreamWriter addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %47
 
 ; <label>:47                                      ; preds = %43
   %48 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %46, i32 0, i32 9
@@ -15363,16 +17765,16 @@ entry:
   %54 = bitcast %"System.Char[]" addrspace(1)* %45 to %System.Array addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %53, i32 %41, %System.Array addrspace(1)* %54, i32 %50, i32 %52)
   %55 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
-  br i1 %NullCheck16, label %56, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %56
 
 ; <label>:56                                      ; preds = %47
   %57 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
   %58 = load i32, i32 addrspace(1)* %57, align 8
   %59 = load i32, i32* %loc2
   %60 = add i32 %58, %59
-  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
-  br i1 %NullCheck18, label %61, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %61
 
 ; <label>:61                                      ; preds = %56
   %62 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
@@ -15394,8 +17796,8 @@ entry:
 
 ; <label>:72                                      ; preds = %69
   %73 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %73, null
-  br i1 %NullCheck2, label %74, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %73, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %74
 
 ; <label>:74                                      ; preds = %72
   %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %73, i32 0, i32 11
@@ -15416,39 +17818,39 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %72
+ThrowNullRef2:                                    ; preds = %72
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %23
+ThrowNullRef8:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef10:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %43
+ThrowNullRef14:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %47
+ThrowNullRef16:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %56
+ThrowNullRef18:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPAddConst.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPAddConst.error.txt
@@ -25,8 +25,8 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
@@ -40,8 +40,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
   %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
@@ -75,7 +75,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -90,8 +90,8 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %NullCheck = icmp ne i8 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = load i8, i8 addrspace(1)* %0, align 8
@@ -125,8 +125,8 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
@@ -159,8 +159,8 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -184,8 +184,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
   store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
@@ -195,8 +195,8 @@ entry:
 ; <label>:4                                       ; preds = %1
   %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
   %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
@@ -206,8 +206,8 @@ entry:
   %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
@@ -221,14 +221,14 @@ entry:
 
 ; <label>:17                                      ; preds = %14
   %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
   %21 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
@@ -238,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -249,8 +249,8 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
@@ -261,27 +261,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %30
+ThrowNullRef10:                                   ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -301,7 +301,89 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
-Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
+Successfully read AppDomainSetup.GetUnsecureApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.GetUnsecureApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %NullCheck = icmp eq %"System.String[]" addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %BoundsCheck = icmp uge i64 0, %5
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %6
+
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 3, i32 0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
+  ret %System.String addrspace(1)* %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_Value using LLILCJit
+Successfully read AppDomainSetup.get_Value
+
+define %"System.String[]" addrspace(1)* @AppDomainSetup.get_Value(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.String[]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 18)
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.String[]" addrspace(1)* addrspace(1)*, %"System.String[]" addrspace(1)*)*)(%"System.String[]" addrspace(1)* addrspace(1)* %9, %"System.String[]" addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %11, i32 0, i32 1
+  %14 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %13, align 8
+  ret %"System.String[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -319,8 +401,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -368,16 +450,16 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
   %5 = load i32, i32 addrspace(1)* %4
   %6 = sub i32 %5, 1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -389,7 +471,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -421,8 +503,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
@@ -456,8 +538,8 @@ entry:
 ; <label>:27                                      ; preds = %19
   %28 = load i32, i32* %arg1
   %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
-  br i1 %NullCheck2, label %30, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %29, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %30
 
 ; <label>:30                                      ; preds = %27
   %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
@@ -493,8 +575,8 @@ entry:
 ; <label>:49                                      ; preds = %46
   %50 = load i32, i32* %arg2
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck4, label %52, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
@@ -517,11 +599,11 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %27
+ThrowNullRef2:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %49
+ThrowNullRef4:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -544,16 +626,16 @@ entry:
   %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %0)
   store %System.String addrspace(1)* %1, %System.String addrspace(1)** %loc0
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 2
   %5 = bitcast [0 x i16] addrspace(1)* %4 to i16 addrspace(1)*
   store i16 addrspace(1)* %5, i16 addrspace(1)** %loc1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %3
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2
@@ -580,7 +662,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -691,15 +773,15 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %NullCheck132 = icmp ne i8* %21, null
-  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+  %NullCheck131 = icmp eq i8* %21, null
+  br i1 %NullCheck131, label %ThrowNullRef132, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = load i8, i8* %21, align 8
   %24 = zext i8 %23 to i32
   %25 = trunc i32 %24 to i8
-  %NullCheck134 = icmp ne i8* %20, null
-  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+  %NullCheck133 = icmp eq i8* %20, null
+  br i1 %NullCheck133, label %ThrowNullRef134, label %26
 
 ; <label>:26                                      ; preds = %22
   store i8 %25, i8* %20, align 8
@@ -709,16 +791,16 @@ entry:
   %28 = load i8*, i8** %arg0
   %29 = load i8*, i8** %arg1
   %30 = bitcast i8* %29 to i16*
-  %NullCheck128 = icmp ne i16* %30, null
-  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+  %NullCheck127 = icmp eq i16* %30, null
+  br i1 %NullCheck127, label %ThrowNullRef128, label %31
 
 ; <label>:31                                      ; preds = %27
   %32 = load i16, i16* %30, align 8
   %33 = sext i16 %32 to i32
   %34 = bitcast i8* %28 to i16*
   %35 = trunc i32 %33 to i16
-  %NullCheck130 = icmp ne i16* %34, null
-  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+  %NullCheck129 = icmp eq i16* %34, null
+  br i1 %NullCheck129, label %ThrowNullRef130, label %36
 
 ; <label>:36                                      ; preds = %31
   store i16 %35, i16* %34, align 8
@@ -728,16 +810,16 @@ entry:
   %38 = load i8*, i8** %arg0
   %39 = load i8*, i8** %arg1
   %40 = bitcast i8* %39 to i16*
-  %NullCheck120 = icmp ne i16* %40, null
-  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+  %NullCheck119 = icmp eq i16* %40, null
+  br i1 %NullCheck119, label %ThrowNullRef120, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i16, i16* %40, align 8
   %43 = sext i16 %42 to i32
   %44 = bitcast i8* %38 to i16*
   %45 = trunc i32 %43 to i16
-  %NullCheck122 = icmp ne i16* %44, null
-  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+  %NullCheck121 = icmp eq i16* %44, null
+  br i1 %NullCheck121, label %ThrowNullRef122, label %46
 
 ; <label>:46                                      ; preds = %41
   store i16 %45, i16* %44, align 8
@@ -745,15 +827,15 @@ entry:
   %48 = getelementptr inbounds i8, i8* %47, i64 2
   %49 = load i8*, i8** %arg1
   %50 = getelementptr inbounds i8, i8* %49, i64 2
-  %NullCheck124 = icmp ne i8* %50, null
-  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+  %NullCheck123 = icmp eq i8* %50, null
+  br i1 %NullCheck123, label %ThrowNullRef124, label %51
 
 ; <label>:51                                      ; preds = %46
   %52 = load i8, i8* %50, align 8
   %53 = zext i8 %52 to i32
   %54 = trunc i32 %53 to i8
-  %NullCheck126 = icmp ne i8* %48, null
-  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+  %NullCheck125 = icmp eq i8* %48, null
+  br i1 %NullCheck125, label %ThrowNullRef126, label %55
 
 ; <label>:55                                      ; preds = %51
   store i8 %54, i8* %48, align 8
@@ -763,14 +845,14 @@ entry:
   %57 = load i8*, i8** %arg0
   %58 = load i8*, i8** %arg1
   %59 = bitcast i8* %58 to i32*
-  %NullCheck116 = icmp ne i32* %59, null
-  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+  %NullCheck115 = icmp eq i32* %59, null
+  br i1 %NullCheck115, label %ThrowNullRef116, label %60
 
 ; <label>:60                                      ; preds = %56
   %61 = load i32, i32* %59, align 8
   %62 = bitcast i8* %57 to i32*
-  %NullCheck118 = icmp ne i32* %62, null
-  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+  %NullCheck117 = icmp eq i32* %62, null
+  br i1 %NullCheck117, label %ThrowNullRef118, label %63
 
 ; <label>:63                                      ; preds = %60
   store i32 %61, i32* %62, align 8
@@ -780,14 +862,14 @@ entry:
   %65 = load i8*, i8** %arg0
   %66 = load i8*, i8** %arg1
   %67 = bitcast i8* %66 to i32*
-  %NullCheck108 = icmp ne i32* %67, null
-  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+  %NullCheck107 = icmp eq i32* %67, null
+  br i1 %NullCheck107, label %ThrowNullRef108, label %68
 
 ; <label>:68                                      ; preds = %64
   %69 = load i32, i32* %67, align 8
   %70 = bitcast i8* %65 to i32*
-  %NullCheck110 = icmp ne i32* %70, null
-  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+  %NullCheck109 = icmp eq i32* %70, null
+  br i1 %NullCheck109, label %ThrowNullRef110, label %71
 
 ; <label>:71                                      ; preds = %68
   store i32 %69, i32* %70, align 8
@@ -795,15 +877,15 @@ entry:
   %73 = getelementptr inbounds i8, i8* %72, i64 4
   %74 = load i8*, i8** %arg1
   %75 = getelementptr inbounds i8, i8* %74, i64 4
-  %NullCheck112 = icmp ne i8* %75, null
-  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+  %NullCheck111 = icmp eq i8* %75, null
+  br i1 %NullCheck111, label %ThrowNullRef112, label %76
 
 ; <label>:76                                      ; preds = %71
   %77 = load i8, i8* %75, align 8
   %78 = zext i8 %77 to i32
   %79 = trunc i32 %78 to i8
-  %NullCheck114 = icmp ne i8* %73, null
-  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+  %NullCheck113 = icmp eq i8* %73, null
+  br i1 %NullCheck113, label %ThrowNullRef114, label %80
 
 ; <label>:80                                      ; preds = %76
   store i8 %79, i8* %73, align 8
@@ -813,14 +895,14 @@ entry:
   %82 = load i8*, i8** %arg0
   %83 = load i8*, i8** %arg1
   %84 = bitcast i8* %83 to i32*
-  %NullCheck100 = icmp ne i32* %84, null
-  br i1 %NullCheck100, label %85, label %ThrowNullRef99
+  %NullCheck99 = icmp eq i32* %84, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %85
 
 ; <label>:85                                      ; preds = %81
   %86 = load i32, i32* %84, align 8
   %87 = bitcast i8* %82 to i32*
-  %NullCheck102 = icmp ne i32* %87, null
-  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+  %NullCheck101 = icmp eq i32* %87, null
+  br i1 %NullCheck101, label %ThrowNullRef102, label %88
 
 ; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
@@ -829,16 +911,16 @@ entry:
   %91 = load i8*, i8** %arg1
   %92 = getelementptr inbounds i8, i8* %91, i64 4
   %93 = bitcast i8* %92 to i16*
-  %NullCheck104 = icmp ne i16* %93, null
-  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+  %NullCheck103 = icmp eq i16* %93, null
+  br i1 %NullCheck103, label %ThrowNullRef104, label %94
 
 ; <label>:94                                      ; preds = %88
   %95 = load i16, i16* %93, align 8
   %96 = sext i16 %95 to i32
   %97 = bitcast i8* %90 to i16*
   %98 = trunc i32 %96 to i16
-  %NullCheck106 = icmp ne i16* %97, null
-  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+  %NullCheck105 = icmp eq i16* %97, null
+  br i1 %NullCheck105, label %ThrowNullRef106, label %99
 
 ; <label>:99                                      ; preds = %94
   store i16 %98, i16* %97, align 8
@@ -848,14 +930,14 @@ entry:
   %101 = load i8*, i8** %arg0
   %102 = load i8*, i8** %arg1
   %103 = bitcast i8* %102 to i32*
-  %NullCheck88 = icmp ne i32* %103, null
-  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+  %NullCheck87 = icmp eq i32* %103, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %104
 
 ; <label>:104                                     ; preds = %100
   %105 = load i32, i32* %103, align 8
   %106 = bitcast i8* %101 to i32*
-  %NullCheck90 = icmp ne i32* %106, null
-  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+  %NullCheck89 = icmp eq i32* %106, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %107
 
 ; <label>:107                                     ; preds = %104
   store i32 %105, i32* %106, align 8
@@ -864,16 +946,16 @@ entry:
   %110 = load i8*, i8** %arg1
   %111 = getelementptr inbounds i8, i8* %110, i64 4
   %112 = bitcast i8* %111 to i16*
-  %NullCheck92 = icmp ne i16* %112, null
-  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+  %NullCheck91 = icmp eq i16* %112, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %113
 
 ; <label>:113                                     ; preds = %107
   %114 = load i16, i16* %112, align 8
   %115 = sext i16 %114 to i32
   %116 = bitcast i8* %109 to i16*
   %117 = trunc i32 %115 to i16
-  %NullCheck94 = icmp ne i16* %116, null
-  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+  %NullCheck93 = icmp eq i16* %116, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %118
 
 ; <label>:118                                     ; preds = %113
   store i16 %117, i16* %116, align 8
@@ -881,15 +963,15 @@ entry:
   %120 = getelementptr inbounds i8, i8* %119, i64 6
   %121 = load i8*, i8** %arg1
   %122 = getelementptr inbounds i8, i8* %121, i64 6
-  %NullCheck96 = icmp ne i8* %122, null
-  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+  %NullCheck95 = icmp eq i8* %122, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %123
 
 ; <label>:123                                     ; preds = %118
   %124 = load i8, i8* %122, align 8
   %125 = zext i8 %124 to i32
   %126 = trunc i32 %125 to i8
-  %NullCheck98 = icmp ne i8* %120, null
-  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+  %NullCheck97 = icmp eq i8* %120, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %127
 
 ; <label>:127                                     ; preds = %123
   store i8 %126, i8* %120, align 8
@@ -899,14 +981,14 @@ entry:
   %129 = load i8*, i8** %arg0
   %130 = load i8*, i8** %arg1
   %131 = bitcast i8* %130 to i64*
-  %NullCheck84 = icmp ne i64* %131, null
-  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+  %NullCheck83 = icmp eq i64* %131, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %132
 
 ; <label>:132                                     ; preds = %128
   %133 = load i64, i64* %131, align 8
   %134 = bitcast i8* %129 to i64*
-  %NullCheck86 = icmp ne i64* %134, null
-  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+  %NullCheck85 = icmp eq i64* %134, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %135
 
 ; <label>:135                                     ; preds = %132
   store i64 %133, i64* %134, align 8
@@ -916,14 +998,14 @@ entry:
   %137 = load i8*, i8** %arg0
   %138 = load i8*, i8** %arg1
   %139 = bitcast i8* %138 to i64*
-  %NullCheck76 = icmp ne i64* %139, null
-  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+  %NullCheck75 = icmp eq i64* %139, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %140
 
 ; <label>:140                                     ; preds = %136
   %141 = load i64, i64* %139, align 8
   %142 = bitcast i8* %137 to i64*
-  %NullCheck78 = icmp ne i64* %142, null
-  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+  %NullCheck77 = icmp eq i64* %142, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %143
 
 ; <label>:143                                     ; preds = %140
   store i64 %141, i64* %142, align 8
@@ -931,15 +1013,15 @@ entry:
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %NullCheck80 = icmp ne i8* %147, null
-  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+  %NullCheck79 = icmp eq i8* %147, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %148
 
 ; <label>:148                                     ; preds = %143
   %149 = load i8, i8* %147, align 8
   %150 = zext i8 %149 to i32
   %151 = trunc i32 %150 to i8
-  %NullCheck82 = icmp ne i8* %145, null
-  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+  %NullCheck81 = icmp eq i8* %145, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %152
 
 ; <label>:152                                     ; preds = %148
   store i8 %151, i8* %145, align 8
@@ -949,14 +1031,14 @@ entry:
   %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
   %156 = bitcast i8* %155 to i64*
-  %NullCheck68 = icmp ne i64* %156, null
-  br i1 %NullCheck68, label %157, label %ThrowNullRef67
+  %NullCheck67 = icmp eq i64* %156, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %157
 
 ; <label>:157                                     ; preds = %153
   %158 = load i64, i64* %156, align 8
   %159 = bitcast i8* %154 to i64*
-  %NullCheck70 = icmp ne i64* %159, null
-  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+  %NullCheck69 = icmp eq i64* %159, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %160
 
 ; <label>:160                                     ; preds = %157
   store i64 %158, i64* %159, align 8
@@ -965,16 +1047,16 @@ entry:
   %163 = load i8*, i8** %arg1
   %164 = getelementptr inbounds i8, i8* %163, i64 8
   %165 = bitcast i8* %164 to i16*
-  %NullCheck72 = icmp ne i16* %165, null
-  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+  %NullCheck71 = icmp eq i16* %165, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %166
 
 ; <label>:166                                     ; preds = %160
   %167 = load i16, i16* %165, align 8
   %168 = sext i16 %167 to i32
   %169 = bitcast i8* %162 to i16*
   %170 = trunc i32 %168 to i16
-  %NullCheck74 = icmp ne i16* %169, null
-  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+  %NullCheck73 = icmp eq i16* %169, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %171
 
 ; <label>:171                                     ; preds = %166
   store i16 %170, i16* %169, align 8
@@ -984,14 +1066,14 @@ entry:
   %173 = load i8*, i8** %arg0
   %174 = load i8*, i8** %arg1
   %175 = bitcast i8* %174 to i64*
-  %NullCheck56 = icmp ne i64* %175, null
-  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+  %NullCheck55 = icmp eq i64* %175, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %176
 
 ; <label>:176                                     ; preds = %172
   %177 = load i64, i64* %175, align 8
   %178 = bitcast i8* %173 to i64*
-  %NullCheck58 = icmp ne i64* %178, null
-  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+  %NullCheck57 = icmp eq i64* %178, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %179
 
 ; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
@@ -1000,16 +1082,16 @@ entry:
   %182 = load i8*, i8** %arg1
   %183 = getelementptr inbounds i8, i8* %182, i64 8
   %184 = bitcast i8* %183 to i16*
-  %NullCheck60 = icmp ne i16* %184, null
-  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+  %NullCheck59 = icmp eq i16* %184, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %185
 
 ; <label>:185                                     ; preds = %179
   %186 = load i16, i16* %184, align 8
   %187 = sext i16 %186 to i32
   %188 = bitcast i8* %181 to i16*
   %189 = trunc i32 %187 to i16
-  %NullCheck62 = icmp ne i16* %188, null
-  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+  %NullCheck61 = icmp eq i16* %188, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %190
 
 ; <label>:190                                     ; preds = %185
   store i16 %189, i16* %188, align 8
@@ -1017,15 +1099,15 @@ entry:
   %192 = getelementptr inbounds i8, i8* %191, i64 10
   %193 = load i8*, i8** %arg1
   %194 = getelementptr inbounds i8, i8* %193, i64 10
-  %NullCheck64 = icmp ne i8* %194, null
-  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+  %NullCheck63 = icmp eq i8* %194, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %195
 
 ; <label>:195                                     ; preds = %190
   %196 = load i8, i8* %194, align 8
   %197 = zext i8 %196 to i32
   %198 = trunc i32 %197 to i8
-  %NullCheck66 = icmp ne i8* %192, null
-  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+  %NullCheck65 = icmp eq i8* %192, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %199
 
 ; <label>:199                                     ; preds = %195
   store i8 %198, i8* %192, align 8
@@ -1035,14 +1117,14 @@ entry:
   %201 = load i8*, i8** %arg0
   %202 = load i8*, i8** %arg1
   %203 = bitcast i8* %202 to i64*
-  %NullCheck48 = icmp ne i64* %203, null
-  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+  %NullCheck47 = icmp eq i64* %203, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %204
 
 ; <label>:204                                     ; preds = %200
   %205 = load i64, i64* %203, align 8
   %206 = bitcast i8* %201 to i64*
-  %NullCheck50 = icmp ne i64* %206, null
-  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+  %NullCheck49 = icmp eq i64* %206, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %207
 
 ; <label>:207                                     ; preds = %204
   store i64 %205, i64* %206, align 8
@@ -1051,14 +1133,14 @@ entry:
   %210 = load i8*, i8** %arg1
   %211 = getelementptr inbounds i8, i8* %210, i64 8
   %212 = bitcast i8* %211 to i32*
-  %NullCheck52 = icmp ne i32* %212, null
-  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+  %NullCheck51 = icmp eq i32* %212, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %213
 
 ; <label>:213                                     ; preds = %207
   %214 = load i32, i32* %212, align 8
   %215 = bitcast i8* %209 to i32*
-  %NullCheck54 = icmp ne i32* %215, null
-  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+  %NullCheck53 = icmp eq i32* %215, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %216
 
 ; <label>:216                                     ; preds = %213
   store i32 %214, i32* %215, align 8
@@ -1068,14 +1150,14 @@ entry:
   %218 = load i8*, i8** %arg0
   %219 = load i8*, i8** %arg1
   %220 = bitcast i8* %219 to i64*
-  %NullCheck36 = icmp ne i64* %220, null
-  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64* %220, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %221
 
 ; <label>:221                                     ; preds = %217
   %222 = load i64, i64* %220, align 8
   %223 = bitcast i8* %218 to i64*
-  %NullCheck38 = icmp ne i64* %223, null
-  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+  %NullCheck37 = icmp eq i64* %223, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %224
 
 ; <label>:224                                     ; preds = %221
   store i64 %222, i64* %223, align 8
@@ -1084,14 +1166,14 @@ entry:
   %227 = load i8*, i8** %arg1
   %228 = getelementptr inbounds i8, i8* %227, i64 8
   %229 = bitcast i8* %228 to i32*
-  %NullCheck40 = icmp ne i32* %229, null
-  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i32* %229, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %230
 
 ; <label>:230                                     ; preds = %224
   %231 = load i32, i32* %229, align 8
   %232 = bitcast i8* %226 to i32*
-  %NullCheck42 = icmp ne i32* %232, null
-  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+  %NullCheck41 = icmp eq i32* %232, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %233
 
 ; <label>:233                                     ; preds = %230
   store i32 %231, i32* %232, align 8
@@ -1099,15 +1181,15 @@ entry:
   %235 = getelementptr inbounds i8, i8* %234, i64 12
   %236 = load i8*, i8** %arg1
   %237 = getelementptr inbounds i8, i8* %236, i64 12
-  %NullCheck44 = icmp ne i8* %237, null
-  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i8* %237, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %238
 
 ; <label>:238                                     ; preds = %233
   %239 = load i8, i8* %237, align 8
   %240 = zext i8 %239 to i32
   %241 = trunc i32 %240 to i8
-  %NullCheck46 = icmp ne i8* %235, null
-  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+  %NullCheck45 = icmp eq i8* %235, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %242
 
 ; <label>:242                                     ; preds = %238
   store i8 %241, i8* %235, align 8
@@ -1117,14 +1199,14 @@ entry:
   %244 = load i8*, i8** %arg0
   %245 = load i8*, i8** %arg1
   %246 = bitcast i8* %245 to i64*
-  %NullCheck24 = icmp ne i64* %246, null
-  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64* %246, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %247
 
 ; <label>:247                                     ; preds = %243
   %248 = load i64, i64* %246, align 8
   %249 = bitcast i8* %244 to i64*
-  %NullCheck26 = icmp ne i64* %249, null
-  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64* %249, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %250
 
 ; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
@@ -1133,14 +1215,14 @@ entry:
   %253 = load i8*, i8** %arg1
   %254 = getelementptr inbounds i8, i8* %253, i64 8
   %255 = bitcast i8* %254 to i32*
-  %NullCheck28 = icmp ne i32* %255, null
-  br i1 %NullCheck28, label %256, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i32* %255, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %256
 
 ; <label>:256                                     ; preds = %250
   %257 = load i32, i32* %255, align 8
   %258 = bitcast i8* %252 to i32*
-  %NullCheck30 = icmp ne i32* %258, null
-  br i1 %NullCheck30, label %259, label %ThrowNullRef29
+  %NullCheck29 = icmp eq i32* %258, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %259
 
 ; <label>:259                                     ; preds = %256
   store i32 %257, i32* %258, align 8
@@ -1149,16 +1231,16 @@ entry:
   %262 = load i8*, i8** %arg1
   %263 = getelementptr inbounds i8, i8* %262, i64 12
   %264 = bitcast i8* %263 to i16*
-  %NullCheck32 = icmp ne i16* %264, null
-  br i1 %NullCheck32, label %265, label %ThrowNullRef31
+  %NullCheck31 = icmp eq i16* %264, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %265
 
 ; <label>:265                                     ; preds = %259
   %266 = load i16, i16* %264, align 8
   %267 = sext i16 %266 to i32
   %268 = bitcast i8* %261 to i16*
   %269 = trunc i32 %267 to i16
-  %NullCheck34 = icmp ne i16* %268, null
-  br i1 %NullCheck34, label %270, label %ThrowNullRef33
+  %NullCheck33 = icmp eq i16* %268, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %270
 
 ; <label>:270                                     ; preds = %265
   store i16 %269, i16* %268, align 8
@@ -1168,14 +1250,14 @@ entry:
   %272 = load i8*, i8** %arg0
   %273 = load i8*, i8** %arg1
   %274 = bitcast i8* %273 to i64*
-  %NullCheck8 = icmp ne i64* %274, null
-  br i1 %NullCheck8, label %275, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64* %274, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %275
 
 ; <label>:275                                     ; preds = %271
   %276 = load i64, i64* %274, align 8
   %277 = bitcast i8* %272 to i64*
-  %NullCheck10 = icmp ne i64* %277, null
-  br i1 %NullCheck10, label %278, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %277, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %278
 
 ; <label>:278                                     ; preds = %275
   store i64 %276, i64* %277, align 8
@@ -1184,14 +1266,14 @@ entry:
   %281 = load i8*, i8** %arg1
   %282 = getelementptr inbounds i8, i8* %281, i64 8
   %283 = bitcast i8* %282 to i32*
-  %NullCheck12 = icmp ne i32* %283, null
-  br i1 %NullCheck12, label %284, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i32* %283, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %284
 
 ; <label>:284                                     ; preds = %278
   %285 = load i32, i32* %283, align 8
   %286 = bitcast i8* %280 to i32*
-  %NullCheck14 = icmp ne i32* %286, null
-  br i1 %NullCheck14, label %287, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i32* %286, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %287
 
 ; <label>:287                                     ; preds = %284
   store i32 %285, i32* %286, align 8
@@ -1200,16 +1282,16 @@ entry:
   %290 = load i8*, i8** %arg1
   %291 = getelementptr inbounds i8, i8* %290, i64 12
   %292 = bitcast i8* %291 to i16*
-  %NullCheck16 = icmp ne i16* %292, null
-  br i1 %NullCheck16, label %293, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i16* %292, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %293
 
 ; <label>:293                                     ; preds = %287
   %294 = load i16, i16* %292, align 8
   %295 = sext i16 %294 to i32
   %296 = bitcast i8* %289 to i16*
   %297 = trunc i32 %295 to i16
-  %NullCheck18 = icmp ne i16* %296, null
-  br i1 %NullCheck18, label %298, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i16* %296, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %298
 
 ; <label>:298                                     ; preds = %293
   store i16 %297, i16* %296, align 8
@@ -1217,15 +1299,15 @@ entry:
   %300 = getelementptr inbounds i8, i8* %299, i64 14
   %301 = load i8*, i8** %arg1
   %302 = getelementptr inbounds i8, i8* %301, i64 14
-  %NullCheck20 = icmp ne i8* %302, null
-  br i1 %NullCheck20, label %303, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i8* %302, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %303
 
 ; <label>:303                                     ; preds = %298
   %304 = load i8, i8* %302, align 8
   %305 = zext i8 %304 to i32
   %306 = trunc i32 %305 to i8
-  %NullCheck22 = icmp ne i8* %300, null
-  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i8* %300, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %307
 
 ; <label>:307                                     ; preds = %303
   store i8 %306, i8* %300, align 8
@@ -1235,14 +1317,14 @@ entry:
   %309 = load i8*, i8** %arg0
   %310 = load i8*, i8** %arg1
   %311 = bitcast i8* %310 to i64*
-  %NullCheck = icmp ne i64* %311, null
-  br i1 %NullCheck, label %312, label %ThrowNullRef
+  %NullCheck = icmp eq i64* %311, null
+  br i1 %NullCheck, label %ThrowNullRef, label %312
 
 ; <label>:312                                     ; preds = %308
   %313 = load i64, i64* %311, align 8
   %314 = bitcast i8* %309 to i64*
-  %NullCheck2 = icmp ne i64* %314, null
-  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64* %314, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %315
 
 ; <label>:315                                     ; preds = %312
   store i64 %313, i64* %314, align 8
@@ -1251,14 +1333,14 @@ entry:
   %318 = load i8*, i8** %arg1
   %319 = getelementptr inbounds i8, i8* %318, i64 8
   %320 = bitcast i8* %319 to i64*
-  %NullCheck4 = icmp ne i64* %320, null
-  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64* %320, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %321
 
 ; <label>:321                                     ; preds = %315
   %322 = load i64, i64* %320, align 8
   %323 = bitcast i8* %317 to i64*
-  %NullCheck6 = icmp ne i64* %323, null
-  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64* %323, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %324
 
 ; <label>:324                                     ; preds = %321
   store i64 %322, i64* %323, align 8
@@ -1286,15 +1368,15 @@ entry:
 ; <label>:338                                     ; preds = %333
   %339 = load i8*, i8** %arg0
   %340 = load i8*, i8** %arg1
-  %NullCheck136 = icmp ne i8* %340, null
-  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+  %NullCheck135 = icmp eq i8* %340, null
+  br i1 %NullCheck135, label %ThrowNullRef136, label %341
 
 ; <label>:341                                     ; preds = %338
   %342 = load i8, i8* %340, align 8
   %343 = zext i8 %342 to i32
   %344 = trunc i32 %343 to i8
-  %NullCheck138 = icmp ne i8* %339, null
-  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+  %NullCheck137 = icmp eq i8* %339, null
+  br i1 %NullCheck137, label %ThrowNullRef138, label %345
 
 ; <label>:345                                     ; preds = %341
   store i8 %344, i8* %339, align 8
@@ -1317,16 +1399,16 @@ entry:
   %357 = load i8*, i8** %arg0
   %358 = load i8*, i8** %arg1
   %359 = bitcast i8* %358 to i16*
-  %NullCheck140 = icmp ne i16* %359, null
-  br i1 %NullCheck140, label %360, label %ThrowNullRef139
+  %NullCheck139 = icmp eq i16* %359, null
+  br i1 %NullCheck139, label %ThrowNullRef140, label %360
 
 ; <label>:360                                     ; preds = %356
   %361 = load i16, i16* %359, align 8
   %362 = sext i16 %361 to i32
   %363 = bitcast i8* %357 to i16*
   %364 = trunc i32 %362 to i16
-  %NullCheck142 = icmp ne i16* %363, null
-  br i1 %NullCheck142, label %365, label %ThrowNullRef141
+  %NullCheck141 = icmp eq i16* %363, null
+  br i1 %NullCheck141, label %ThrowNullRef142, label %365
 
 ; <label>:365                                     ; preds = %360
   store i16 %364, i16* %363, align 8
@@ -1352,14 +1434,14 @@ entry:
   %378 = load i8*, i8** %arg0
   %379 = load i8*, i8** %arg1
   %380 = bitcast i8* %379 to i32*
-  %NullCheck144 = icmp ne i32* %380, null
-  br i1 %NullCheck144, label %381, label %ThrowNullRef143
+  %NullCheck143 = icmp eq i32* %380, null
+  br i1 %NullCheck143, label %ThrowNullRef144, label %381
 
 ; <label>:381                                     ; preds = %377
   %382 = load i32, i32* %380, align 8
   %383 = bitcast i8* %378 to i32*
-  %NullCheck146 = icmp ne i32* %383, null
-  br i1 %NullCheck146, label %384, label %ThrowNullRef145
+  %NullCheck145 = icmp eq i32* %383, null
+  br i1 %NullCheck145, label %ThrowNullRef146, label %384
 
 ; <label>:384                                     ; preds = %381
   store i32 %382, i32* %383, align 8
@@ -1384,14 +1466,14 @@ entry:
   %395 = load i8*, i8** %arg0
   %396 = load i8*, i8** %arg1
   %397 = bitcast i8* %396 to i64*
-  %NullCheck164 = icmp ne i64* %397, null
-  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+  %NullCheck163 = icmp eq i64* %397, null
+  br i1 %NullCheck163, label %ThrowNullRef164, label %398
 
 ; <label>:398                                     ; preds = %394
   %399 = load i64, i64* %397, align 8
   %400 = bitcast i8* %395 to i64*
-  %NullCheck166 = icmp ne i64* %400, null
-  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+  %NullCheck165 = icmp eq i64* %400, null
+  br i1 %NullCheck165, label %ThrowNullRef166, label %401
 
 ; <label>:401                                     ; preds = %398
   store i64 %399, i64* %400, align 8
@@ -1400,14 +1482,14 @@ entry:
   %404 = load i8*, i8** %arg1
   %405 = getelementptr inbounds i8, i8* %404, i64 8
   %406 = bitcast i8* %405 to i64*
-  %NullCheck168 = icmp ne i64* %406, null
-  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+  %NullCheck167 = icmp eq i64* %406, null
+  br i1 %NullCheck167, label %ThrowNullRef168, label %407
 
 ; <label>:407                                     ; preds = %401
   %408 = load i64, i64* %406, align 8
   %409 = bitcast i8* %403 to i64*
-  %NullCheck170 = icmp ne i64* %409, null
-  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+  %NullCheck169 = icmp eq i64* %409, null
+  br i1 %NullCheck169, label %ThrowNullRef170, label %410
 
 ; <label>:410                                     ; preds = %407
   store i64 %408, i64* %409, align 8
@@ -1437,14 +1519,14 @@ entry:
   %425 = load i8*, i8** %arg0
   %426 = load i8*, i8** %arg1
   %427 = bitcast i8* %426 to i64*
-  %NullCheck148 = icmp ne i64* %427, null
-  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+  %NullCheck147 = icmp eq i64* %427, null
+  br i1 %NullCheck147, label %ThrowNullRef148, label %428
 
 ; <label>:428                                     ; preds = %424
   %429 = load i64, i64* %427, align 8
   %430 = bitcast i8* %425 to i64*
-  %NullCheck150 = icmp ne i64* %430, null
-  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+  %NullCheck149 = icmp eq i64* %430, null
+  br i1 %NullCheck149, label %ThrowNullRef150, label %431
 
 ; <label>:431                                     ; preds = %428
   store i64 %429, i64* %430, align 8
@@ -1466,14 +1548,14 @@ entry:
   %441 = load i8*, i8** %arg0
   %442 = load i8*, i8** %arg1
   %443 = bitcast i8* %442 to i32*
-  %NullCheck152 = icmp ne i32* %443, null
-  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+  %NullCheck151 = icmp eq i32* %443, null
+  br i1 %NullCheck151, label %ThrowNullRef152, label %444
 
 ; <label>:444                                     ; preds = %440
   %445 = load i32, i32* %443, align 8
   %446 = bitcast i8* %441 to i32*
-  %NullCheck154 = icmp ne i32* %446, null
-  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+  %NullCheck153 = icmp eq i32* %446, null
+  br i1 %NullCheck153, label %ThrowNullRef154, label %447
 
 ; <label>:447                                     ; preds = %444
   store i32 %445, i32* %446, align 8
@@ -1495,16 +1577,16 @@ entry:
   %457 = load i8*, i8** %arg0
   %458 = load i8*, i8** %arg1
   %459 = bitcast i8* %458 to i16*
-  %NullCheck156 = icmp ne i16* %459, null
-  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+  %NullCheck155 = icmp eq i16* %459, null
+  br i1 %NullCheck155, label %ThrowNullRef156, label %460
 
 ; <label>:460                                     ; preds = %456
   %461 = load i16, i16* %459, align 8
   %462 = sext i16 %461 to i32
   %463 = bitcast i8* %457 to i16*
   %464 = trunc i32 %462 to i16
-  %NullCheck158 = icmp ne i16* %463, null
-  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+  %NullCheck157 = icmp eq i16* %463, null
+  br i1 %NullCheck157, label %ThrowNullRef158, label %465
 
 ; <label>:465                                     ; preds = %460
   store i16 %464, i16* %463, align 8
@@ -1525,15 +1607,15 @@ entry:
 ; <label>:474                                     ; preds = %470
   %475 = load i8*, i8** %arg0
   %476 = load i8*, i8** %arg1
-  %NullCheck160 = icmp ne i8* %476, null
-  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+  %NullCheck159 = icmp eq i8* %476, null
+  br i1 %NullCheck159, label %ThrowNullRef160, label %477
 
 ; <label>:477                                     ; preds = %474
   %478 = load i8, i8* %476, align 8
   %479 = zext i8 %478 to i32
   %480 = trunc i32 %479 to i8
-  %NullCheck162 = icmp ne i8* %475, null
-  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+  %NullCheck161 = icmp eq i8* %475, null
+  br i1 %NullCheck161, label %ThrowNullRef162, label %481
 
 ; <label>:481                                     ; preds = %477
   store i8 %480, i8* %475, align 8
@@ -1553,343 +1635,343 @@ ThrowNullRef:                                     ; preds = %308
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %312
+ThrowNullRef2:                                    ; preds = %312
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %315
+ThrowNullRef4:                                    ; preds = %315
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %321
+ThrowNullRef6:                                    ; preds = %321
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %271
+ThrowNullRef8:                                    ; preds = %271
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %275
+ThrowNullRef10:                                   ; preds = %275
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %278
+ThrowNullRef12:                                   ; preds = %278
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %284
+ThrowNullRef14:                                   ; preds = %284
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %287
+ThrowNullRef16:                                   ; preds = %287
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %293
+ThrowNullRef18:                                   ; preds = %293
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %298
+ThrowNullRef20:                                   ; preds = %298
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %303
+ThrowNullRef22:                                   ; preds = %303
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %243
+ThrowNullRef24:                                   ; preds = %243
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %247
+ThrowNullRef26:                                   ; preds = %247
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %250
+ThrowNullRef28:                                   ; preds = %250
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %256
+ThrowNullRef30:                                   ; preds = %256
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %259
+ThrowNullRef32:                                   ; preds = %259
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %265
+ThrowNullRef34:                                   ; preds = %265
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %217
+ThrowNullRef36:                                   ; preds = %217
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %221
+ThrowNullRef38:                                   ; preds = %221
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %224
+ThrowNullRef40:                                   ; preds = %224
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %230
+ThrowNullRef42:                                   ; preds = %230
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %233
+ThrowNullRef44:                                   ; preds = %233
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %238
+ThrowNullRef46:                                   ; preds = %238
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %200
+ThrowNullRef48:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %204
+ThrowNullRef50:                                   ; preds = %204
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %207
+ThrowNullRef52:                                   ; preds = %207
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %213
+ThrowNullRef54:                                   ; preds = %213
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %172
+ThrowNullRef56:                                   ; preds = %172
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %176
+ThrowNullRef58:                                   ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %179
+ThrowNullRef60:                                   ; preds = %179
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %185
+ThrowNullRef62:                                   ; preds = %185
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %190
+ThrowNullRef64:                                   ; preds = %190
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %195
+ThrowNullRef66:                                   ; preds = %195
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %153
+ThrowNullRef68:                                   ; preds = %153
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %157
+ThrowNullRef70:                                   ; preds = %157
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %160
+ThrowNullRef72:                                   ; preds = %160
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %166
+ThrowNullRef74:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %136
+ThrowNullRef76:                                   ; preds = %136
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %140
+ThrowNullRef78:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %143
+ThrowNullRef80:                                   ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %148
+ThrowNullRef82:                                   ; preds = %148
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %128
+ThrowNullRef84:                                   ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %132
+ThrowNullRef86:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %100
+ThrowNullRef88:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %104
+ThrowNullRef90:                                   ; preds = %104
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %107
+ThrowNullRef92:                                   ; preds = %107
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %113
+ThrowNullRef94:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %118
+ThrowNullRef96:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %123
+ThrowNullRef98:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %81
+ThrowNullRef100:                                  ; preds = %81
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef101:                                  ; preds = %85
+ThrowNullRef102:                                  ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef103:                                  ; preds = %88
+ThrowNullRef104:                                  ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef105:                                  ; preds = %94
+ThrowNullRef106:                                  ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef107:                                  ; preds = %64
+ThrowNullRef108:                                  ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef109:                                  ; preds = %68
+ThrowNullRef110:                                  ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef111:                                  ; preds = %71
+ThrowNullRef112:                                  ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef113:                                  ; preds = %76
+ThrowNullRef114:                                  ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef115:                                  ; preds = %56
+ThrowNullRef116:                                  ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef117:                                  ; preds = %60
+ThrowNullRef118:                                  ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef119:                                  ; preds = %37
+ThrowNullRef120:                                  ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef121:                                  ; preds = %41
+ThrowNullRef122:                                  ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef123:                                  ; preds = %46
+ThrowNullRef124:                                  ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef125:                                  ; preds = %51
+ThrowNullRef126:                                  ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef127:                                  ; preds = %27
+ThrowNullRef128:                                  ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef129:                                  ; preds = %31
+ThrowNullRef130:                                  ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef131:                                  ; preds = %19
+ThrowNullRef132:                                  ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef133:                                  ; preds = %22
+ThrowNullRef134:                                  ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef135:                                  ; preds = %338
+ThrowNullRef136:                                  ; preds = %338
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef137:                                  ; preds = %341
+ThrowNullRef138:                                  ; preds = %341
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef139:                                  ; preds = %356
+ThrowNullRef140:                                  ; preds = %356
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef141:                                  ; preds = %360
+ThrowNullRef142:                                  ; preds = %360
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef143:                                  ; preds = %377
+ThrowNullRef144:                                  ; preds = %377
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef145:                                  ; preds = %381
+ThrowNullRef146:                                  ; preds = %381
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef147:                                  ; preds = %424
+ThrowNullRef148:                                  ; preds = %424
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef149:                                  ; preds = %428
+ThrowNullRef150:                                  ; preds = %428
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef151:                                  ; preds = %440
+ThrowNullRef152:                                  ; preds = %440
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef153:                                  ; preds = %444
+ThrowNullRef154:                                  ; preds = %444
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef155:                                  ; preds = %456
+ThrowNullRef156:                                  ; preds = %456
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef157:                                  ; preds = %460
+ThrowNullRef158:                                  ; preds = %460
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef159:                                  ; preds = %474
+ThrowNullRef160:                                  ; preds = %474
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef161:                                  ; preds = %477
+ThrowNullRef162:                                  ; preds = %477
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef163:                                  ; preds = %394
+ThrowNullRef164:                                  ; preds = %394
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef165:                                  ; preds = %398
+ThrowNullRef166:                                  ; preds = %398
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef167:                                  ; preds = %401
+ThrowNullRef168:                                  ; preds = %401
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef169:                                  ; preds = %407
+ThrowNullRef170:                                  ; preds = %407
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1939,8 +2021,8 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
-  br i1 %NullCheck, label %22, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %ThrowNullRef, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
@@ -1948,8 +2030,8 @@ entry:
   store i32 %24, i32* %loc0
   %25 = load i32, i32* %loc0
   %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %26, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %27
 
 ; <label>:27                                      ; preds = %22
   %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
@@ -1971,7 +2053,7 @@ ThrowNullRef:                                     ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1989,8 +2071,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -2022,15 +2104,15 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2048,16 +2130,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
   %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
   store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %15
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
@@ -2072,8 +2154,8 @@ entry:
   %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
   %29 = ptrtoint i16 addrspace(1)* %28 to i64
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %19
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
@@ -2089,19 +2171,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2114,8 +2196,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
@@ -2128,7 +2210,7 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[loadElem]
+Failed to read AppDomain.PrepareDataForSetup[storeElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
@@ -2202,8 +2284,8 @@ entry:
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
-  br i1 %NullCheck24, label %27, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = load i64, i64 addrspace(1)* %26
@@ -2218,8 +2300,8 @@ entry:
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
-  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
   %41 = load i64, i64 addrspace(1)* %39
@@ -2236,8 +2318,8 @@ entry:
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
-  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
   %54 = load i64, i64 addrspace(1)* %52
@@ -2252,8 +2334,8 @@ entry:
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
   %67 = load i64, i64 addrspace(1)* %65
@@ -2270,8 +2352,8 @@ entry:
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
-  br i1 %NullCheck16, label %79, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
   %80 = load i64, i64 addrspace(1)* %78
@@ -2286,8 +2368,8 @@ entry:
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
-  br i1 %NullCheck18, label %92, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
   %93 = load i64, i64 addrspace(1)* %91
@@ -2304,8 +2386,8 @@ entry:
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
-  br i1 %NullCheck12, label %105, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = load i64, i64 addrspace(1)* %104
@@ -2320,8 +2402,8 @@ entry:
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
-  br i1 %NullCheck14, label %118, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
   %119 = load i64, i64 addrspace(1)* %117
@@ -2337,8 +2419,8 @@ entry:
 
 ; <label>:128                                     ; preds = %20
   %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
-  br i1 %NullCheck4, label %130, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %129, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %130
 
 ; <label>:130                                     ; preds = %128
   %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
@@ -2346,8 +2428,8 @@ entry:
   %133 = load i16, i16 addrspace(1)* %132, align 8
   %134 = zext i16 %133 to i32
   %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
-  br i1 %NullCheck6, label %136, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %135, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %136
 
 ; <label>:136                                     ; preds = %130
   %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
@@ -2360,8 +2442,8 @@ entry:
 
 ; <label>:143                                     ; preds = %136
   %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
-  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %144, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %145
 
 ; <label>:145                                     ; preds = %143
   %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
@@ -2369,8 +2451,8 @@ entry:
   %148 = load i16, i16 addrspace(1)* %147, align 8
   %149 = zext i16 %148 to i32
   %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %150, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %151
 
 ; <label>:151                                     ; preds = %145
   %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
@@ -2388,8 +2470,8 @@ entry:
 
 ; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
-  br i1 %NullCheck, label %163, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %ThrowNullRef, label %163
 
 ; <label>:163                                     ; preds = %161
   %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
@@ -2399,8 +2481,8 @@ entry:
 
 ; <label>:167                                     ; preds = %163
   %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
-  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %168, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %169
 
 ; <label>:169                                     ; preds = %167
   %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
@@ -2432,55 +2514,55 @@ ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %167
+ThrowNullRef2:                                    ; preds = %167
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %128
+ThrowNullRef4:                                    ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %130
+ThrowNullRef6:                                    ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %143
+ThrowNullRef8:                                    ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %145
+ThrowNullRef10:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %102
+ThrowNullRef12:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %105
+ThrowNullRef14:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %76
+ThrowNullRef16:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %79
+ThrowNullRef18:                                   ; preds = %79
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %50
+ThrowNullRef20:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %53
+ThrowNullRef22:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %24
+ThrowNullRef24:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %27
+ThrowNullRef26:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2503,15 +2585,15 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2519,16 +2601,16 @@ entry:
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
   store i32 %8, i32* %loc0
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
   %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
   store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
@@ -2546,16 +2628,16 @@ entry:
 
 ; <label>:23                                      ; preds = %64
   %24 = load i16*, i16** %loc3
-  %NullCheck12 = icmp ne i16* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i16* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
   store i32 %27, i32* %loc5
   %28 = load i16*, i16** %loc4
-  %NullCheck14 = icmp ne i16* %28, null
-  br i1 %NullCheck14, label %29, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %28, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = load i16, i16* %28, align 8
@@ -2620,15 +2702,15 @@ entry:
 
 ; <label>:67                                      ; preds = %64
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
-  br i1 %NullCheck8, label %69, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %68, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %69
 
 ; <label>:69                                      ; preds = %67
   %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
   %71 = load i32, i32 addrspace(1)* %70
   %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
-  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %73
 
 ; <label>:73                                      ; preds = %69
   %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
@@ -2645,31 +2727,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %67
+ThrowNullRef8:                                    ; preds = %67
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %69
+ThrowNullRef10:                                   ; preds = %69
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2710,14 +2792,14 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
   %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
@@ -2730,14 +2812,14 @@ entry:
 
 ; <label>:11                                      ; preds = %4
   %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
   %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
@@ -2749,14 +2831,14 @@ entry:
 
 ; <label>:22                                      ; preds = %16
   %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
   %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
-  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
-  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
@@ -2804,23 +2886,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2836,7 +2918,280 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[loadElem]
+Successfully read RuntimeType.IsAssignableFrom
+
+define i8 @RuntimeType.IsAssignableFrom(%System.RuntimeType addrspace(1)* %param0, %System.Type addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.RuntimeType addrspace(1)*
+  %arg1 = alloca %System.Type addrspace(1)*
+  %loc0 = alloca %System.RuntimeType addrspace(1)*
+  %loc1 = alloca %"System.Type[]" addrspace(1)*
+  %loc2 = alloca i32
+  store %System.RuntimeType addrspace(1)* %param0, %System.RuntimeType addrspace(1)** %this
+  store %System.Type addrspace(1)* %param1, %System.Type addrspace(1)** %arg1
+  %0 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %1 = icmp ne %System.Type addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i8 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %5 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %6 = bitcast %System.Type addrspace(1)* %4 to %System.Object addrspace(1)*
+  %7 = bitcast %System.RuntimeType addrspace(1)* %5 to %System.Object addrspace(1)*
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %6, %System.Object addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %3
+  ret i8 1
+
+; <label>:12                                      ; preds = %3
+  %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 152
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 32
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
+  %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
+  %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
+  store %System.RuntimeType addrspace(1)* %25, %System.RuntimeType addrspace(1)** %loc0
+  %26 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %27 = icmp eq %System.RuntimeType addrspace(1)* %26, null
+  br i1 %27, label %34, label %28
+
+; <label>:28                                      ; preds = %15
+  %29 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %30 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)*)*)(%System.RuntimeType addrspace(1)* %29, %System.RuntimeType addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+; <label>:34                                      ; preds = %15
+  %35 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %36 = call %System.Reflection.Emit.TypeBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Reflection.Emit.TypeBuilder addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %35)
+  %37 = icmp eq %System.Reflection.Emit.TypeBuilder addrspace(1)* %36, null
+  br i1 %37, label %139, label %38
+
+; <label>:38                                      ; preds = %34
+  %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %42
+
+; <label>:42                                      ; preds = %38
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 152
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 40
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
+  %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
+  %53 = zext i8 %52 to i32
+  %54 = icmp eq i32 %53, 0
+  br i1 %54, label %56, label %55
+
+; <label>:55                                      ; preds = %42
+  ret i8 1
+
+; <label>:56                                      ; preds = %42
+  %57 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %58 = bitcast %System.RuntimeType addrspace(1)* %57 to %System.Type addrspace(1)*
+  %59 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %58)
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %64 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.Type addrspace(1)* %63, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = bitcast %System.RuntimeType addrspace(1)* %64 to %System.Type addrspace(1)*
+  %67 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %63, %System.Type addrspace(1)* %66)
+  %68 = zext i8 %67 to i32
+  %69 = trunc i32 %68 to i8
+  ret i8 %69
+
+; <label>:70                                      ; preds = %56
+  %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
+  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %73
+
+; <label>:73                                      ; preds = %70
+  %74 = load i64, i64 addrspace(1)* %72
+  %75 = add i64 %74, 128
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = add i64 %77, 0
+  %79 = inttoptr i64 %78 to i64*
+  %80 = load i64, i64* %79
+  %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
+  %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
+  %83 = call i8 %82(%System.Type addrspace(1)* %81)
+  %84 = zext i8 %83 to i32
+  %85 = icmp eq i32 %84, 0
+  br i1 %85, label %139, label %86
+
+; <label>:86                                      ; preds = %73
+  %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
+  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %89
+
+; <label>:89                                      ; preds = %86
+  %90 = load i64, i64 addrspace(1)* %88
+  %91 = add i64 %90, 128
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = add i64 %93, 24
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
+  %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
+  %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
+  store %"System.Type[]" addrspace(1)* %99, %"System.Type[]" addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %129
+
+; <label>:100                                     ; preds = %132
+  %101 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %102 = load i32, i32* %loc2
+  %NullCheck11 = icmp eq %"System.Type[]" addrspace(1)* %101, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %103
+
+; <label>:103                                     ; preds = %100
+  %104 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 1
+  %105 = load i32, i32 addrspace(1)* %104
+  %106 = zext i32 %105 to i64
+  %107 = zext i32 %102 to i64
+  %BoundsCheck = icmp uge i64 %107, %106
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %108
+
+; <label>:108                                     ; preds = %103
+  %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
+  %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
+  %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
+  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %113
+
+; <label>:113                                     ; preds = %108
+  %114 = load i64, i64 addrspace(1)* %112
+  %115 = add i64 %114, 152
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = add i64 %117, 56
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
+  %123 = zext i8 %122 to i32
+  %124 = icmp ne i32 %123, 0
+  br i1 %124, label %126, label %125
+
+; <label>:125                                     ; preds = %113
+  ret i8 0
+
+; <label>:126                                     ; preds = %113
+  %127 = load i32, i32* %loc2
+  %128 = add i32 %127, 1
+  store i32 %128, i32* %loc2
+  br label %129
+
+; <label>:129                                     ; preds = %89, %126
+  %130 = load i32, i32* %loc2
+  %131 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %NullCheck9 = icmp eq %"System.Type[]" addrspace(1)* %131, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %132
+
+; <label>:132                                     ; preds = %129
+  %133 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %131, i32 0, i32 1
+  %134 = load i32, i32 addrspace(1)* %133
+  %135 = zext i32 %134 to i64
+  %136 = trunc i64 %135 to i32
+  %137 = icmp slt i32 %130, %136
+  br i1 %137, label %100, label %138
+
+; <label>:138                                     ; preds = %132
+  ret i8 1
+
+; <label>:139                                     ; preds = %34, %73
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %129
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %103
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -2893,7 +3248,7 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElem]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -2904,8 +3259,8 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -2997,8 +3352,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
@@ -3059,8 +3414,8 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -3087,8 +3442,8 @@ entry:
 
 ; <label>:17                                      ; preds = %5, %11
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
@@ -3097,8 +3452,8 @@ entry:
 
 ; <label>:22                                      ; preds = %1, %11
   %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
@@ -3109,11 +3464,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %17
+ThrowNullRef2:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %22
+ThrowNullRef4:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3167,15 +3522,15 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
   %15 = load i32, i32 addrspace(1)* %14
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
@@ -3198,7 +3553,7 @@ ThrowNullRef:                                     ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef2:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3232,8 +3587,8 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
@@ -3312,8 +3667,8 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -3327,8 +3682,8 @@ entry:
 ; <label>:5                                       ; preds = %43
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %7 = load i32, i32* %loc1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck6, label %8, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
@@ -3366,8 +3721,8 @@ entry:
 ; <label>:32                                      ; preds = %21, %25
   %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
   %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
-  br i1 %NullCheck8, label %35, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = trunc i32 %34 to i16
@@ -3380,8 +3735,8 @@ entry:
 ; <label>:40                                      ; preds = %1, %35
   %41 = load i32, i32* %loc1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
-  br i1 %NullCheck2, label %43, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %42, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
@@ -3392,8 +3747,8 @@ entry:
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
   %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
-  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
   %51 = load i64, i64 addrspace(1)* %49
@@ -3412,19 +3767,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %40
+ThrowNullRef2:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %47
+ThrowNullRef4:                                    ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %5
+ThrowNullRef6:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %32
+ThrowNullRef8:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3467,8 +3822,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
@@ -3492,11 +3847,391 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(i16* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store i16* %param0, i16** %arg0
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load i32, i32* %arg3
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %42, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %37, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg2
+  %13 = load i32, i32* %arg3
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %37, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %24 = load i32, i32* %arg2
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load i16*, i16** %arg0
+  %35 = load i32, i32* %arg3
+  %36 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %36, i16* %34, i32 %35)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:37                                      ; preds = %5, %16
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %39)
+  %41 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41, %System.String addrspace(1)* %38, %System.String addrspace(1)* %40)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41) #0
+  unreachable
+
+; <label>:42                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
-Failed to read StringBuilder.ToString[loadElemA]
+Successfully read StringBuilder.ToString
+
+define %System.String addrspace(1)* @StringBuilder.ToString(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i16*
+  %loc3 = alloca %"System.Char[]" addrspace(1)*
+  %loc4 = alloca i32
+  %loc5 = alloca i32
+  %loc6 = alloca i16 addrspace(1)*
+  %loc7 = alloca %System.String addrspace(1)*
+  %loc8 = alloca %"System.Char[]" addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %0)
+  %2 = icmp ne i32 %1, 0
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %4
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %6)
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %7)
+  store %System.String addrspace(1)* %8, %System.String addrspace(1)** %loc0
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.Text.StringBuilder addrspace(1)* %9, %System.Text.StringBuilder addrspace(1)** %loc1
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  store %System.String addrspace(1)* %10, %System.String addrspace(1)** %loc7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc7
+  %12 = ptrtoint %System.String addrspace(1)* %11 to i64
+  %13 = icmp eq i64 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %5
+  %15 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %16 = sext i32 %15 to i64
+  %17 = add i64 %12, %16
+  br label %18
+
+; <label>:18                                      ; preds = %5, %14
+  %19 = phi i64 [ %12, %5 ], [ %17, %14 ]
+  %20 = inttoptr i64 %19 to i16*
+  store i16* %20, i16** %loc2
+  br label %21
+
+; <label>:21                                      ; preds = %98, %18
+  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %22, null
+  br i1 %NullCheck, label %ThrowNullRef, label %23
+
+; <label>:23                                      ; preds = %21
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 3
+  %25 = load i32, i32 addrspace(1)* %24, align 8
+  %26 = icmp sle i32 %25, 0
+  br i1 %26, label %96, label %27
+
+; <label>:27                                      ; preds = %23
+  %28 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %28, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %29
+
+; <label>:29                                      ; preds = %27
+  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %28, i32 0, i32 1
+  %31 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %30, align 8
+  store %"System.Char[]" addrspace(1)* %31, %"System.Char[]" addrspace(1)** %loc3
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %33
+
+; <label>:33                                      ; preds = %29
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  store i32 %35, i32* %loc4
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  %39 = load i32, i32 addrspace(1)* %38, align 8
+  store i32 %39, i32* %loc5
+  %40 = load i32, i32* %loc5
+  %41 = load i32, i32* %loc4
+  %42 = add i32 %40, %41
+  %43 = zext i32 %42 to i64
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %45
+
+; <label>:45                                      ; preds = %37
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = sext i32 %47 to i64
+  %49 = icmp sgt i64 %43, %48
+  br i1 %49, label %91, label %50
+
+; <label>:50                                      ; preds = %45
+  %51 = load i32, i32* %loc5
+  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %52, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %53
+
+; <label>:53                                      ; preds = %50
+  %54 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %52, i32 0, i32 1
+  %55 = load i32, i32 addrspace(1)* %54
+  %56 = zext i32 %55 to i64
+  %57 = trunc i64 %56 to i32
+  %58 = icmp ugt i32 %51, %57
+  br i1 %58, label %91, label %59
+
+; <label>:59                                      ; preds = %53
+  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  store %"System.Char[]" addrspace(1)* %60, %"System.Char[]" addrspace(1)** %loc8
+  %61 = icmp eq %"System.Char[]" addrspace(1)* %60, null
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %63, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %64
+
+; <label>:64                                      ; preds = %62
+  %65 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %63, i32 0, i32 1
+  %66 = load i32, i32 addrspace(1)* %65
+  %67 = zext i32 %66 to i64
+  %68 = trunc i64 %67 to i32
+  %69 = icmp ne i32 %68, 0
+  br i1 %69, label %71, label %70
+
+; <label>:70                                      ; preds = %59, %64
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:71                                      ; preds = %64
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %73
+
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %BoundsCheck = icmp uge i64 0, %76
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %77
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %78, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:79                                      ; preds = %70, %77
+  %80 = load i16*, i16** %loc2
+  %81 = load i32, i32* %loc4
+  %82 = sext i32 %81 to i64
+  %83 = mul i64 %82, 2
+  %84 = bitcast i16* %80 to i8*
+  %85 = getelementptr inbounds i8, i8* %84, i64 %83
+  %86 = load i16 addrspace(1)*, i16 addrspace(1)** %loc6
+  %87 = ptrtoint i16 addrspace(1)* %86 to i64
+  %88 = load i32, i32* %loc5
+  %89 = bitcast i8* %85 to i16*
+  %90 = inttoptr i64 %87 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %89, i16* %90, i32 %88)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %96
+
+; <label>:91                                      ; preds = %45, %53
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %94 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %93)
+  %95 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95, %System.String addrspace(1)* %92, %System.String addrspace(1)* %94)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95) #0
+  unreachable
+
+; <label>:96                                      ; preds = %23, %79
+  %97 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %97, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %98
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %97, i32 0, i32 2
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  store %System.Text.StringBuilder addrspace(1)* %100, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %102 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %102, label %21, label %103
+
+; <label>:103                                     ; preds = %98
+  store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc7
+  %104 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  ret %System.String addrspace(1)* %104
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method StringBuilder::get_Length using LLILCJit
+Successfully read StringBuilder.get_Length
+
+define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
+Successfully read RuntimeHelpers.get_OffsetToStringData
+
+define i32 @RuntimeHelpers.get_OffsetToStringData() {
+entry:
+  ret i32 12
+}
+
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
 Successfully read CultureData.CreateCultureData
 
@@ -3514,23 +4249,23 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
   store i8 %4, i8 addrspace(1)* %6
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
@@ -3549,11 +4284,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3566,50 +4301,50 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
   store i32 -1, i32 addrspace(1)* %2
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
   store i32 -1, i32 addrspace(1)* %8
   %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
   store i32 -1, i32 addrspace(1)* %14
   %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
   store i32 -1, i32 addrspace(1)* %17
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
@@ -3623,27 +4358,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3675,7 +4410,136 @@ Failed to read Dictionary`2.Insert[non-const derefAddress]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
 Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
-Failed to read HashHelpers.GetPrime[loadElem]
+Successfully read HashHelpers.GetPrime
+
+define i32 @HashHelpers.GetPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %6, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5, %System.String addrspace(1)* %4)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5) #0
+  unreachable
+
+; <label>:6                                       ; preds = %entry
+  store i32 0, i32* %loc0
+  br label %29
+
+; <label>:7                                       ; preds = %35
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 1296
+  %10 = addrspacecast i8 addrspace(1)* %9 to %"System.Int32[]" addrspace(1)**
+  %11 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %10
+  %12 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Int32[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = zext i32 %15 to i64
+  %17 = zext i32 %12 to i64
+  %BoundsCheck = icmp uge i64 %17, %16
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 3, i32 %12
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  store i32 %20, i32* %loc1
+  %21 = load i32, i32* %loc1
+  %22 = load i32, i32* %arg0
+  %23 = icmp slt i32 %21, %22
+  br i1 %23, label %26, label %24
+
+; <label>:24                                      ; preds = %18
+  %25 = load i32, i32* %loc1
+  ret i32 %25
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %loc0
+  %28 = add i32 %27, 1
+  store i32 %28, i32* %loc0
+  br label %29
+
+; <label>:29                                      ; preds = %6, %26
+  %30 = load i32, i32* %loc0
+  %31 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %32 = getelementptr inbounds i8, i8 addrspace(1)* %31, i64 1296
+  %33 = addrspacecast i8 addrspace(1)* %32 to %"System.Int32[]" addrspace(1)**
+  %34 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %33
+  %NullCheck = icmp eq %"System.Int32[]" addrspace(1)* %34, null
+  br i1 %NullCheck, label %ThrowNullRef, label %35
+
+; <label>:35                                      ; preds = %29
+  %36 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %34, i32 0, i32 1
+  %37 = load i32, i32 addrspace(1)* %36
+  %38 = zext i32 %37 to i64
+  %39 = trunc i64 %38 to i32
+  %40 = icmp slt i32 %30, %39
+  br i1 %40, label %7, label %41
+
+; <label>:41                                      ; preds = %35
+  %42 = load i32, i32* %arg0
+  %43 = or i32 %42, 1
+  store i32 %43, i32* %loc2
+  br label %59
+
+; <label>:44                                      ; preds = %59
+  %45 = load i32, i32* %loc2
+  %46 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %45)
+  %47 = zext i8 %46 to i32
+  %48 = icmp eq i32 %47, 0
+  br i1 %48, label %56, label %49
+
+; <label>:49                                      ; preds = %44
+  %50 = load i32, i32* %loc2
+  %51 = sub i32 %50, 1
+  %52 = srem i32 %51, 101
+  %53 = icmp eq i32 %52, 0
+  br i1 %53, label %56, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = load i32, i32* %loc2
+  ret i32 %55
+
+; <label>:56                                      ; preds = %44, %49
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %57, 2
+  store i32 %58, i32* %loc2
+  br label %59
+
+; <label>:59                                      ; preds = %41, %56
+  %60 = load i32, i32* %loc2
+  %61 = icmp slt i32 %60, 2147483647
+  br i1 %61, label %44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load i32, i32* %arg0
+  ret i32 %63
+
+ThrowNullRef:                                     ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
 Successfully read GenericEqualityComparer`1.GetHashCode
 
@@ -3694,14 +4558,14 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
   %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load i64, i64 addrspace(1)* %7
@@ -3720,7 +4584,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3750,8 +4614,8 @@ entry:
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
@@ -3796,8 +4660,8 @@ entry:
   %35 = bitcast i16* %34 to i8*
   %36 = getelementptr inbounds i8, i8* %35, i64 2
   %37 = bitcast i8* %36 to i16*
-  %NullCheck4 = icmp ne i16* %37, null
-  br i1 %NullCheck4, label %38, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %37, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %38
 
 ; <label>:38                                      ; preds = %27
   %39 = load i16, i16* %37, align 8
@@ -3824,8 +4688,8 @@ entry:
 
 ; <label>:54                                      ; preds = %22, %43
   %55 = load i16*, i16** %loc4
-  %NullCheck2 = icmp ne i16* %55, null
-  br i1 %NullCheck2, label %56, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i16* %55, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %56
 
 ; <label>:56                                      ; preds = %54
   %57 = load i16, i16* %55, align 8
@@ -3850,11 +4714,11 @@ ThrowNullRef:                                     ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %54
+ThrowNullRef2:                                    ; preds = %54
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %27
+ThrowNullRef4:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3871,8 +4735,8 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -3907,8 +4771,8 @@ entry:
 
 ; <label>:26                                      ; preds = %19
   %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
-  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %28
 
 ; <label>:28                                      ; preds = %26
   %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
@@ -3920,7 +4784,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3972,8 +4836,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
@@ -3984,26 +4848,26 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
-  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
@@ -4014,8 +4878,8 @@ entry:
 ; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
@@ -4024,8 +4888,8 @@ entry:
 
 ; <label>:25                                      ; preds = %1, %16, %23
   %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
-  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
@@ -4036,27 +4900,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %20
+ThrowNullRef10:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4069,8 +4933,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -4081,8 +4945,8 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
@@ -4091,8 +4955,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1, %8
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
@@ -4103,11 +4967,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4128,24 +4992,24 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   store i32 %3, i32* %loc0
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
   %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
   store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck4, label %9, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
@@ -4164,15 +5028,15 @@ entry:
 ; <label>:18                                      ; preds = %70
   %19 = load i16*, i16** %loc3
   %20 = bitcast i16* %19 to i64*
-  %NullCheck10 = icmp ne i64* %20, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %20, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = load i64, i64* %20, align 8
   %23 = load i16*, i16** %loc4
   %24 = bitcast i16* %23 to i64*
-  %NullCheck12 = icmp ne i64* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = load i64, i64* %24, align 8
@@ -4188,8 +5052,8 @@ entry:
   %31 = bitcast i16* %30 to i8*
   %32 = getelementptr inbounds i8, i8* %31, i64 8
   %33 = bitcast i8* %32 to i64*
-  %NullCheck14 = icmp ne i64* %33, null
-  br i1 %NullCheck14, label %34, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = load i64, i64* %33, align 8
@@ -4197,8 +5061,8 @@ entry:
   %37 = bitcast i16* %36 to i8*
   %38 = getelementptr inbounds i8, i8* %37, i64 8
   %39 = bitcast i8* %38 to i64*
-  %NullCheck16 = icmp ne i64* %39, null
-  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %40
 
 ; <label>:40                                      ; preds = %34
   %41 = load i64, i64* %39, align 8
@@ -4214,8 +5078,8 @@ entry:
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %NullCheck18 = icmp ne i64* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = load i64, i64* %48, align 8
@@ -4223,8 +5087,8 @@ entry:
   %52 = bitcast i16* %51 to i8*
   %53 = getelementptr inbounds i8, i8* %52, i64 16
   %54 = bitcast i8* %53 to i64*
-  %NullCheck20 = icmp ne i64* %54, null
-  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64* %54, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %55
 
 ; <label>:55                                      ; preds = %49
   %56 = load i64, i64* %54, align 8
@@ -4262,15 +5126,15 @@ entry:
 ; <label>:74                                      ; preds = %95
   %75 = load i16*, i16** %loc3
   %76 = bitcast i16* %75 to i32*
-  %NullCheck6 = icmp ne i32* %76, null
-  br i1 %NullCheck6, label %77, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32* %76, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %77
 
 ; <label>:77                                      ; preds = %74
   %78 = load i32, i32* %76, align 8
   %79 = load i16*, i16** %loc4
   %80 = bitcast i16* %79 to i32*
-  %NullCheck8 = icmp ne i32* %80, null
-  br i1 %NullCheck8, label %81, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i32* %80, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %81
 
 ; <label>:81                                      ; preds = %77
   %82 = load i32, i32* %80, align 8
@@ -4318,43 +5182,43 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %74
+ThrowNullRef6:                                    ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %77
+ThrowNullRef8:                                    ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %29
+ThrowNullRef14:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %34
+ThrowNullRef16:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4376,8 +5240,8 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load i64, i64 addrspace(1)* %4
@@ -4389,8 +5253,8 @@ entry:
   %12 = load i64, i64* %11
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %5
   %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
@@ -4399,8 +5263,8 @@ entry:
   %18 = load i8, i8* %arg2
   %19 = zext i8 %18 to i32
   %20 = trunc i32 %19 to i8
-  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %15
   %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
@@ -4411,11 +5275,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4442,8 +5306,8 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
@@ -4466,16 +5330,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
   %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = load i64, i64 addrspace(1)* %19
@@ -4500,8 +5364,8 @@ entry:
 ; <label>:35                                      ; preds = %30
   %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
@@ -4514,8 +5378,8 @@ entry:
 
 ; <label>:42                                      ; preds = %1, %38
   %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
-  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
@@ -4526,19 +5390,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %35
+ThrowNullRef2:                                    ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %42
+ThrowNullRef8:                                    ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4551,14 +5415,14 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
@@ -4570,7 +5434,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4583,8 +5447,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
@@ -4613,51 +5477,51 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
   %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
   %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
   %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
   %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
-  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
   store i64 %21, i64 addrspace(1)* %23
   %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %25 = load i64, i64* %loc0
-  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
@@ -4668,27 +5532,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %22
+ThrowNullRef12:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4701,8 +5565,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
@@ -4713,19 +5577,19 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
@@ -4734,8 +5598,8 @@ entry:
 
 ; <label>:15                                      ; preds = %1, %13
   %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
@@ -4746,19 +5610,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %15
+ThrowNullRef8:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4771,8 +5635,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -4831,8 +5695,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
@@ -4882,8 +5746,8 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
-  br i1 %NullCheck, label %17, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %ThrowNullRef, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
@@ -4894,15 +5758,15 @@ entry:
 
 ; <label>:22                                      ; preds = %17
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
-  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
   %26 = load i32, i32 addrspace(1)* %25
   %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
-  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %27, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
@@ -4925,8 +5789,8 @@ entry:
 ; <label>:40                                      ; preds = %17
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
-  br i1 %NullCheck6, label %43, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %41, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
@@ -4938,34 +5802,17 @@ ThrowNullRef:                                     ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %24
+ThrowNullRef4:                                    ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %40
+ThrowNullRef6:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
-}
-
-INFO:  jitting method Object::ReferenceEquals using LLILCJit
-Successfully read Object.ReferenceEquals
-
-define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
-entry:
-  %arg0 = alloca %System.Object addrspace(1)*
-  %arg1 = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
-  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
-  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = icmp eq %System.Object addrspace(1)* %0, %1
-  %3 = sext i1 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
 }
 
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
@@ -4978,21 +5825,21 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
   %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
-  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
@@ -5007,28 +5854,28 @@ entry:
 ; <label>:13                                      ; preds = %8, %12
   %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
   %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
   %21 = load i32, i32 addrspace(1)* %20, align 8
   %22 = add i32 %21, 1
-  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
   store i32 %22, i32 addrspace(1)* %24
   %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
@@ -5039,27 +5886,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5077,7 +5924,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::Setup using LLILCJit
-Failed to read AppDomain.Setup[loadElem]
+Failed to read AppDomain.Setup[unbox]
 INFO:  jitting method Thread::GetDomain using LLILCJit
 Successfully read Thread.GetDomain
 
@@ -5108,8 +5955,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
@@ -5122,14 +5969,14 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
   %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
@@ -5141,11 +5988,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5173,8 +6020,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -5189,7 +6036,328 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
 Failed to read KeyCollection.System.Collections.Generic.IEnumerable<TKey>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Successfully read Enumerator.MoveNext
+
+define i8 @Enumerator.MoveNext(%"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.RuntimeTypeHandle* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*
+  %"$TypeArg" = alloca %System.RuntimeTypeHandle*
+  store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
+  %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 8
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %76, label %12
+
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
+  br label %76
+
+; <label>:13                                      ; preds = %85
+  %14 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck19 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %15
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, i32 0, i32 0
+  %17 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %16, align 8
+  %NullCheck21 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, i32 0, i32 2
+  %20 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %19, align 8
+  %21 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck23 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %22
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, i32 0, i32 2
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %NullCheck25 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 3, i32 %24
+  %NullCheck27 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %32
+
+; <label>:32                                      ; preds = %30
+  %33 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, i32 0, i32 2
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = icmp slt i32 %34, 0
+  br i1 %35, label %68, label %36
+
+; <label>:36                                      ; preds = %32
+  %37 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %38 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck29 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %39
+
+; <label>:39                                      ; preds = %36
+  %40 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, i32 0, i32 0
+  %41 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %40, align 8
+  %NullCheck31 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, i32 0, i32 2
+  %44 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %43, align 8
+  %45 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck33 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, i32 0, i32 2
+  %48 = load i32, i32 addrspace(1)* %47, align 8
+  %NullCheck35 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %49
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = zext i32 %51 to i64
+  %53 = zext i32 %48 to i64
+  %BoundsCheck37 = icmp uge i64 %53, %52
+  br i1 %BoundsCheck37, label %ThrowIndexOutOfRange38, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 3, i32 %48
+  %NullCheck39 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %56
+
+; <label>:56                                      ; preds = %54
+  %57 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, i32 0, i32 0
+  %58 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck41 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %59
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %60, %System.__Canon addrspace(1)* %58)
+  %61 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck43 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  %64 = load i32, i32 addrspace(1)* %63, align 8
+  %65 = add i32 %64, 1
+  %NullCheck45 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  store i32 %65, i32 addrspace(1)* %67
+  ret i8 1
+
+; <label>:68                                      ; preds = %32
+  %69 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck47 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %73 = add i32 %72, 1
+  %NullCheck49 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %74
+
+; <label>:74                                      ; preds = %70
+  %75 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  store i32 %73, i32 addrspace(1)* %75
+  br label %76
+
+; <label>:76                                      ; preds = %8, %12, %74
+  %77 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %78
+
+; <label>:78                                      ; preds = %76
+  %79 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, i32 0, i32 2
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck7 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %82
+
+; <label>:82                                      ; preds = %78
+  %83 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, i32 0, i32 0
+  %84 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %83, align 8
+  %NullCheck9 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %85
+
+; <label>:85                                      ; preds = %82
+  %86 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, i32 0, i32 7
+  %87 = load i32, i32 addrspace(1)* %86, align 8
+  %88 = icmp ult i32 %80, %87
+  br i1 %88, label %13, label %89
+
+; <label>:89                                      ; preds = %85
+  %90 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %91 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck11 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %92
+
+; <label>:92                                      ; preds = %89
+  %93 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, i32 0, i32 0
+  %94 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck13 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %95
+
+; <label>:95                                      ; preds = %92
+  %96 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, i32 0, i32 7
+  %97 = load i32, i32 addrspace(1)* %96, align 8
+  %98 = add i32 %97, 1
+  %NullCheck15 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %99
+
+; <label>:99                                      ; preds = %95
+  %100 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, i32 0, i32 2
+  store i32 %98, i32 addrspace(1)* %100
+  %101 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck17 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %102
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %103, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %92
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef22:                                   ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef24:                                   ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef26:                                   ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef28:                                   ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef30:                                   ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef32:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef34:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef36:                                   ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange38:                           ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef40:                                   ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef42:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef44:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef46:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef48:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef50:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -5200,8 +6368,8 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -5232,9 +6400,9 @@ Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
 Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
-Failed to read String.MakeSeparatorList[loadElemA]
+Failed to read String.MakeSeparatorList[storeElem]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
-Failed to read String.InternalSplitKeepEmptyEntries[loadElem]
+Failed to read String.InternalSplitKeepEmptyEntries[storeElem]
 INFO:  jitting method Path::IsRelative using LLILCJit
 Successfully read Path.IsRelative
 
@@ -5243,8 +6411,8 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -5254,8 +6422,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
@@ -5271,8 +6439,8 @@ entry:
 
 ; <label>:17                                      ; preds = %7
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
@@ -5288,8 +6456,8 @@ entry:
 
 ; <label>:29                                      ; preds = %19
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %31
 
 ; <label>:31                                      ; preds = %29
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
@@ -5300,8 +6468,8 @@ entry:
 
 ; <label>:36                                      ; preds = %31
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
-  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %37, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
@@ -5312,8 +6480,8 @@ entry:
 
 ; <label>:43                                      ; preds = %31, %38
   %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
-  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %45
 
 ; <label>:45                                      ; preds = %43
   %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
@@ -5324,8 +6492,8 @@ entry:
 
 ; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %50
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
@@ -5336,8 +6504,8 @@ entry:
 
 ; <label>:57                                      ; preds = %1, %7, %19, %45, %52
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
-  br i1 %NullCheck14, label %59, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %59
 
 ; <label>:59                                      ; preds = %57
   %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
@@ -5347,8 +6515,8 @@ entry:
 
 ; <label>:63                                      ; preds = %59
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
@@ -5359,8 +6527,8 @@ entry:
 
 ; <label>:70                                      ; preds = %65
   %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
-  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.String addrspace(1)* %71, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %72
 
 ; <label>:72                                      ; preds = %70
   %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
@@ -5379,39 +6547,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %17
+ThrowNullRef4:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %29
+ThrowNullRef6:                                    ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %36
+ThrowNullRef8:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %43
+ThrowNullRef10:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %50
+ThrowNullRef12:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %57
+ThrowNullRef14:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %63
+ThrowNullRef16:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %70
+ThrowNullRef18:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5419,7 +6587,293 @@ ThrowNullRef17:                                   ; preds = %70
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
-Failed to read String.TrimHelper[loadElem]
+Successfully read String.TrimHelper
+
+define %System.String addrspace(1)* @String.TrimHelper(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i16
+  %loc4 = alloca i32
+  %loc5 = alloca i16
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = sub i32 %3, 1
+  store i32 %4, i32* %loc0
+  store i32 0, i32* %loc1
+  %5 = load i32, i32* %arg2
+  %6 = icmp eq i32 %5, 1
+  br i1 %6, label %62, label %7
+
+; <label>:7                                       ; preds = %1
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:8                                       ; preds = %58
+  store i32 0, i32* %loc2
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load i32, i32* %loc1
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2, i32 %10
+  %13 = load i16, i16 addrspace(1)* %12
+  %14 = zext i16 %13 to i32
+  %15 = trunc i32 %14 to i16
+  store i16 %15, i16* %loc3
+  store i32 0, i32* %loc2
+  br label %34
+
+; <label>:16                                      ; preds = %37
+  %17 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %18 = load i32, i32* %loc2
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %17, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %19
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = zext i32 %18 to i64
+  %BoundsCheck = icmp uge i64 %23, %22
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %24
+
+; <label>:24                                      ; preds = %19
+  %25 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 3, i32 %18
+  %26 = load i16, i16 addrspace(1)* %25, align 8
+  %27 = zext i16 %26 to i32
+  %28 = load i16, i16* %loc3
+  %29 = zext i16 %28 to i32
+  %30 = icmp eq i32 %27, %29
+  br i1 %30, label %43, label %31
+
+; <label>:31                                      ; preds = %24
+  %32 = load i32, i32* %loc2
+  %33 = add i32 %32, 1
+  store i32 %33, i32* %loc2
+  br label %34
+
+; <label>:34                                      ; preds = %11, %31
+  %35 = load i32, i32* %loc2
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = icmp slt i32 %35, %41
+  br i1 %42, label %16, label %43
+
+; <label>:43                                      ; preds = %24, %37
+  %44 = load i32, i32* %loc2
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %45, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp eq i32 %44, %50
+  br i1 %51, label %62, label %52
+
+; <label>:52                                      ; preds = %46
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %7, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %57, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %58
+
+; <label>:58                                      ; preds = %55
+  %59 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %60 = load i32, i32 addrspace(1)* %59
+  %61 = icmp slt i32 %56, %60
+  br i1 %61, label %8, label %62
+
+; <label>:62                                      ; preds = %1, %46, %58
+  %63 = load i32, i32* %arg2
+  %64 = icmp eq i32 %63, 0
+  br i1 %64, label %122, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %66, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %67
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %66, i32 0, i32 1
+  %69 = load i32, i32 addrspace(1)* %68
+  %70 = sub i32 %69, 1
+  store i32 %70, i32* %loc0
+  br label %118
+
+; <label>:71                                      ; preds = %118
+  store i32 0, i32* %loc4
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %73 = load i32, i32* %loc0
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %74
+
+; <label>:74                                      ; preds = %71
+  %75 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 2, i32 %73
+  %76 = load i16, i16 addrspace(1)* %75
+  %77 = zext i16 %76 to i32
+  %78 = trunc i32 %77 to i16
+  store i16 %78, i16* %loc5
+  store i32 0, i32* %loc4
+  br label %97
+
+; <label>:79                                      ; preds = %100
+  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %81 = load i32, i32* %loc4
+  %NullCheck19 = icmp eq %"System.Char[]" addrspace(1)* %80, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
+
+; <label>:82                                      ; preds = %79
+  %83 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 1
+  %84 = load i32, i32 addrspace(1)* %83
+  %85 = zext i32 %84 to i64
+  %86 = zext i32 %81 to i64
+  %BoundsCheck21 = icmp uge i64 %86, %85
+  br i1 %BoundsCheck21, label %ThrowIndexOutOfRange22, label %87
+
+; <label>:87                                      ; preds = %82
+  %88 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 3, i32 %81
+  %89 = load i16, i16 addrspace(1)* %88, align 8
+  %90 = zext i16 %89 to i32
+  %91 = load i16, i16* %loc5
+  %92 = zext i16 %91 to i32
+  %93 = icmp eq i32 %90, %92
+  br i1 %93, label %106, label %94
+
+; <label>:94                                      ; preds = %87
+  %95 = load i32, i32* %loc4
+  %96 = add i32 %95, 1
+  store i32 %96, i32* %loc4
+  br label %97
+
+; <label>:97                                      ; preds = %74, %94
+  %98 = load i32, i32* %loc4
+  %99 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck15 = icmp eq %"System.Char[]" addrspace(1)* %99, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %100
+
+; <label>:100                                     ; preds = %97
+  %101 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %99, i32 0, i32 1
+  %102 = load i32, i32 addrspace(1)* %101
+  %103 = zext i32 %102 to i64
+  %104 = trunc i64 %103 to i32
+  %105 = icmp slt i32 %98, %104
+  br i1 %105, label %79, label %106
+
+; <label>:106                                     ; preds = %87, %100
+  %107 = load i32, i32* %loc4
+  %108 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck17 = icmp eq %"System.Char[]" addrspace(1)* %108, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %109
+
+; <label>:109                                     ; preds = %106
+  %110 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %108, i32 0, i32 1
+  %111 = load i32, i32 addrspace(1)* %110
+  %112 = zext i32 %111 to i64
+  %113 = trunc i64 %112 to i32
+  %114 = icmp eq i32 %107, %113
+  br i1 %114, label %122, label %115
+
+; <label>:115                                     ; preds = %109
+  %116 = load i32, i32* %loc0
+  %117 = sub i32 %116, 1
+  store i32 %117, i32* %loc0
+  br label %118
+
+; <label>:118                                     ; preds = %67, %115
+  %119 = load i32, i32* %loc0
+  %120 = load i32, i32* %loc1
+  %121 = icmp sge i32 %119, %120
+  br i1 %121, label %71, label %122
+
+; <label>:122                                     ; preds = %62, %109, %118
+  %123 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %124 = load i32, i32* %loc1
+  %125 = load i32, i32* %loc0
+  %126 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %123, i32 %124, i32 %125)
+  ret %System.String addrspace(1)* %126
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %97
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange22:                           ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
 Successfully read String.CreateTrimmedString
 
@@ -5439,8 +6893,8 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
@@ -5535,8 +6989,8 @@ entry:
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i64 2872
   %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
   %8 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %7
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %3
   %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
@@ -5553,8 +7007,8 @@ entry:
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 2864
   %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
   %21 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %20
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
-  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %22
 
 ; <label>:22                                      ; preds = %16
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
@@ -5569,7 +7023,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %16
+ThrowNullRef2:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5586,8 +7040,8 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5613,8 +7067,8 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
@@ -5632,8 +7086,8 @@ entry:
 
 ; <label>:12                                      ; preds = %4
   %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
@@ -5644,8 +7098,8 @@ entry:
 
 ; <label>:19                                      ; preds = %14
   %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %19
   %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
@@ -5660,21 +7114,21 @@ entry:
   %31 = zext i16 %30 to i32
   %32 = bitcast i8* %29 to i16*
   %33 = trunc i32 %31 to i16
-  %NullCheck6 = icmp ne i16* %32, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i16* %32, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %21
   store i16 %33, i16* %32, align 8
   %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %36
 
 ; <label>:36                                      ; preds = %34
   %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
   %38 = load i32, i32 addrspace(1)* %37, align 8
   %39 = add i32 %38, 1
-  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %40
 
 ; <label>:40                                      ; preds = %36
   %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
@@ -5683,16 +7137,16 @@ entry:
 
 ; <label>:42                                      ; preds = %14
   %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
-  br i1 %NullCheck12, label %44, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
   %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
   %47 = load i16, i16* %arg1
   %48 = zext i16 %47 to i32
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = trunc i32 %48 to i16
@@ -5703,31 +7157,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %19
+ThrowNullRef4:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %21
+ThrowNullRef6:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %36
+ThrowNullRef10:                                   ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %42
+ThrowNullRef12:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %44
+ThrowNullRef14:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5740,8 +7194,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -5752,8 +7206,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
@@ -5762,14 +7216,14 @@ entry:
 
 ; <label>:11                                      ; preds = %1
   %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
@@ -5779,15 +7233,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5808,8 +7262,8 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5822,8 +7276,8 @@ entry:
 
 ; <label>:8                                       ; preds = %3
   %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
@@ -5842,15 +7296,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
-  br i1 %NullCheck4, label %22, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
   %24 = load i16*, i16* addrspace(1)* %23, align 8
   %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %25, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
@@ -5859,8 +7313,8 @@ entry:
   store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
@@ -5874,8 +7328,8 @@ entry:
 
 ; <label>:37                                      ; preds = %65
   %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %37
   %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
@@ -5886,16 +7340,16 @@ entry:
   %45 = bitcast i16* %41 to i8*
   %46 = getelementptr inbounds i8, i8* %45, i64 %44
   %47 = bitcast i8* %46 to i16*
-  %NullCheck14 = icmp ne i16* %47, null
-  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %47, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %48
 
 ; <label>:48                                      ; preds = %39
   %49 = load i16, i16* %47, align 8
   %50 = zext i16 %49 to i32
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %52 = load i32, i32* %loc1
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %53
 
 ; <label>:53                                      ; preds = %48
   %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
@@ -5916,8 +7370,8 @@ entry:
 ; <label>:62                                      ; preds = %36, %59
   %63 = load i32, i32* %loc1
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck10, label %65, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %65
 
 ; <label>:65                                      ; preds = %62
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
@@ -5936,15 +7390,15 @@ entry:
 
 ; <label>:74                                      ; preds = %70
   %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
-  br i1 %NullCheck18, label %76, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %76
 
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
   %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
-  br i1 %NullCheck20, label %80, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
   %81 = load i64, i64 addrspace(1)* %79
@@ -5958,8 +7412,8 @@ entry:
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
   %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
-  br i1 %NullCheck22, label %92, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.String addrspace(1)* %90, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %92
 
 ; <label>:92                                      ; preds = %80
   %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
@@ -5969,15 +7423,15 @@ entry:
 
 ; <label>:96                                      ; preds = %70
   %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
-  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %98
 
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
   %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
-  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
   %103 = load i64, i64 addrspace(1)* %101
@@ -5991,8 +7445,8 @@ entry:
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
   %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
-  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.String addrspace(1)* %112, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %114
 
 ; <label>:114                                     ; preds = %102
   %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
@@ -6004,59 +7458,59 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %20
+ThrowNullRef4:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %22
+ThrowNullRef6:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %26
+ThrowNullRef8:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %62
+ThrowNullRef10:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %48
+ThrowNullRef16:                                   ; preds = %48
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %74
+ThrowNullRef18:                                   ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %76
+ThrowNullRef20:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %80
+ThrowNullRef22:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %96
+ThrowNullRef24:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %98
+ThrowNullRef26:                                   ; preds = %98
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %102
+ThrowNullRef28:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6069,15 +7523,15 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
   %3 = load i16*, i16* addrspace(1)* %2, align 8
   %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
@@ -6087,8 +7541,8 @@ entry:
   %10 = bitcast i16* %3 to i8*
   %11 = getelementptr inbounds i8, i8* %10, i64 %9
   %12 = bitcast i8* %11 to i16*
-  %NullCheck4 = icmp ne i16* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %5
   store i16 0, i16* %12, align 8
@@ -6098,11 +7552,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6119,8 +7573,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -6131,8 +7585,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
@@ -6144,15 +7598,15 @@ entry:
 
 ; <label>:14                                      ; preds = %1
   %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
   %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
   %21 = load i64, i64 addrspace(1)* %19
@@ -6171,15 +7625,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %14
+ThrowNullRef4:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %16
+ThrowNullRef6:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6302,14 +7756,6 @@ entry:
   ret %System.String addrspace(1)* %57
 }
 
-INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
-Successfully read RuntimeHelpers.get_OffsetToStringData
-
-define i32 @RuntimeHelpers.get_OffsetToStringData() {
-entry:
-  ret i32 12
-}
-
 INFO:  jitting method String::Equals using LLILCJit
 Successfully read String.Equals
 
@@ -6381,8 +7827,8 @@ entry:
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
-  br i1 %NullCheck24, label %29, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
   %30 = load i64, i64 addrspace(1)* %28
@@ -6397,8 +7843,8 @@ entry:
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
-  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
   %43 = load i64, i64 addrspace(1)* %41
@@ -6418,8 +7864,8 @@ entry:
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
   %59 = load i64, i64 addrspace(1)* %57
@@ -6434,8 +7880,8 @@ entry:
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck22, label %71, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
   %72 = load i64, i64 addrspace(1)* %70
@@ -6455,8 +7901,8 @@ entry:
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
-  br i1 %NullCheck16, label %87, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = load i64, i64 addrspace(1)* %86
@@ -6471,8 +7917,8 @@ entry:
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck18, label %100, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
   %101 = load i64, i64 addrspace(1)* %99
@@ -6492,8 +7938,8 @@ entry:
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
-  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
   %117 = load i64, i64 addrspace(1)* %115
@@ -6508,8 +7954,8 @@ entry:
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
-  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
   %130 = load i64, i64 addrspace(1)* %128
@@ -6528,15 +7974,15 @@ entry:
 
 ; <label>:142                                     ; preds = %22
   %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
-  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %143, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %144
 
 ; <label>:144                                     ; preds = %142
   %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
   %146 = load i32, i32 addrspace(1)* %145
   %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
-  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %147, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %148
 
 ; <label>:148                                     ; preds = %144
   %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
@@ -6557,15 +8003,15 @@ entry:
 
 ; <label>:159                                     ; preds = %22
   %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
-  br i1 %NullCheck, label %161, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %ThrowNullRef, label %161
 
 ; <label>:161                                     ; preds = %159
   %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
   %163 = load i32, i32 addrspace(1)* %162
   %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
-  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %164, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %165
 
 ; <label>:165                                     ; preds = %161
   %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
@@ -6578,8 +8024,8 @@ entry:
 
 ; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
-  br i1 %NullCheck4, label %172, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %171, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %172
 
 ; <label>:172                                     ; preds = %170
   %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
@@ -6589,8 +8035,8 @@ entry:
 
 ; <label>:176                                     ; preds = %172
   %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
-  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %177, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %178
 
 ; <label>:178                                     ; preds = %176
   %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
@@ -6629,55 +8075,55 @@ ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %161
+ThrowNullRef2:                                    ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %170
+ThrowNullRef4:                                    ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %176
+ThrowNullRef6:                                    ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %142
+ThrowNullRef8:                                    ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %144
+ThrowNullRef10:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %113
+ThrowNullRef12:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %116
+ThrowNullRef14:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %84
+ThrowNullRef16:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %87
+ThrowNullRef18:                                   ; preds = %87
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %55
+ThrowNullRef20:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %58
+ThrowNullRef22:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %26
+ThrowNullRef24:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %29
+ThrowNullRef26:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,8 +8161,8 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck, label %14, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %ThrowNullRef, label %14
 
 ; <label>:14                                      ; preds = %8
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
@@ -6760,8 +8206,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
@@ -6770,14 +8216,14 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32, i32* %loc0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %10
   %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
   %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
@@ -6790,15 +8236,15 @@ entry:
 ; <label>:25                                      ; preds = %19
   %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
-  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
   %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
@@ -6807,8 +8253,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %37 = load i32, i32* %loc0
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %38, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %38
 
 ; <label>:38                                      ; preds = %32
   %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
@@ -6817,14 +8263,14 @@ entry:
 
 ; <label>:40                                      ; preds = %19
   %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %40
   %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
   %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
-  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
-  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
@@ -6832,8 +8278,8 @@ entry:
   %48 = zext i32 %47 to i64
   %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
-  br i1 %NullCheck16, label %51, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %51
 
 ; <label>:51                                      ; preds = %45
   %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
@@ -6847,15 +8293,15 @@ entry:
 ; <label>:57                                      ; preds = %51
   %58 = load i16*, i16** %arg1
   %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
-  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %60
 
 ; <label>:60                                      ; preds = %57
   %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
   %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
-  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %64
 
 ; <label>:64                                      ; preds = %60
   %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
@@ -6864,22 +8310,22 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
   %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
-  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %70
 
 ; <label>:70                                      ; preds = %64
   %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
   %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
-  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
-  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
   %75 = load i32, i32 addrspace(1)* %74
   %76 = zext i32 %75 to i64
   %77 = trunc i64 %76 to i32
-  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
-  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %78
 
 ; <label>:78                                      ; preds = %73
   %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
@@ -6901,8 +8347,8 @@ entry:
   %90 = bitcast i16* %86 to i8*
   %91 = getelementptr inbounds i8, i8* %90, i64 %89
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %93
 
 ; <label>:93                                      ; preds = %80
   %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
@@ -6912,8 +8358,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %99 = load i32, i32* %loc2
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %100
 
 ; <label>:100                                     ; preds = %93
   %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
@@ -6928,63 +8374,63 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %25
+ThrowNullRef6:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %32
+ThrowNullRef10:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %40
+ThrowNullRef12:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %45
+ThrowNullRef16:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %57
+ThrowNullRef18:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %60
+ThrowNullRef20:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %64
+ThrowNullRef22:                                   ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %70
+ThrowNullRef24:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %73
+ThrowNullRef26:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %80
+ThrowNullRef28:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %93
+ThrowNullRef30:                                   ; preds = %93
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7004,8 +8450,8 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
@@ -7033,43 +8479,43 @@ entry:
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %14
   %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
   %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   %28 = load i32, i32 addrspace(1)* %27, align 8
   %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
-  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %30
 
 ; <label>:30                                      ; preds = %26
   %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
   %32 = load i32, i32 addrspace(1)* %31, align 8
   %33 = add i32 %28, %32
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %34
 
 ; <label>:34                                      ; preds = %30
   %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   store i32 %33, i32 addrspace(1)* %35
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
   store i32 0, i32 addrspace(1)* %38
   %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %40
 
 ; <label>:40                                      ; preds = %37
   %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
@@ -7082,8 +8528,8 @@ entry:
 
 ; <label>:47                                      ; preds = %40
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
@@ -7098,8 +8544,8 @@ entry:
   %54 = load i32, i32* %loc0
   %55 = sext i32 %54 to i64
   %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
-  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %57
 
 ; <label>:57                                      ; preds = %52
   %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
@@ -7110,68 +8556,35 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %14
+ThrowNullRef2:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %23
+ThrowNullRef4:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %26
+ThrowNullRef6:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %30
+ThrowNullRef8:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %34
+ThrowNullRef10:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %47
+ThrowNullRef14:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %52
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-}
-
-INFO:  jitting method StringBuilder::get_Length using LLILCJit
-Successfully read StringBuilder.get_Length
-
-define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.StringBuilder addrspace(1)*
-  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
-  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
-
-; <label>:1                                       ; preds = %entry
-  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %3 = load i32, i32 addrspace(1)* %2, align 8
-  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
-
-; <label>:5                                       ; preds = %1
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = add i32 %3, %7
-  ret i32 %8
-
-ThrowNullRef:                                     ; preds = %entry
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef16:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7213,70 +8626,70 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
   %6 = load i32, i32 addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
   store i32 %6, i32 addrspace(1)* %8
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
   %13 = load i32, i32 addrspace(1)* %12, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
   store i32 %13, i32 addrspace(1)* %15
   %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
-  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %18
 
 ; <label>:18                                      ; preds = %14
   %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
   %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
   %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
   %34 = load i32, i32 addrspace(1)* %33, align 8
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
-  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
@@ -7287,39 +8700,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %28
+ThrowNullRef16:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %32
+ThrowNullRef18:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7455,13 +8868,13 @@ entry:
 ; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
@@ -7477,16 +8890,16 @@ entry:
 
 ; <label>:18                                      ; preds = %15
   %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
   store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
   %22 = load i32, i32* %loc0
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %24
 
 ; <label>:24                                      ; preds = %20
   %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
@@ -7498,13 +8911,13 @@ entry:
 ; <label>:28                                      ; preds = %15, %24
   %29 = load i32, i32* %arg1
   %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %31
   %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
@@ -7517,20 +8930,20 @@ entry:
   %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
-  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
   %46 = load i32, i32 addrspace(1)* %45, align 8
   %47 = sub i32 %40, %46
-  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
-  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i32 addrspace(1)* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %48
 
 ; <label>:48                                      ; preds = %44
   store i32 %47, i32 addrspace(1)* %39, align 8
@@ -7538,21 +8951,21 @@ entry:
 
 ; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
-  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %51
 
 ; <label>:51                                      ; preds = %49
   %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %53
 
 ; <label>:53                                      ; preds = %51
   %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
   %55 = load i32, i32 addrspace(1)* %54, align 8
   %56 = load i32, i32* %arg2
   %57 = sub i32 %55, %56
-  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %58
 
 ; <label>:58                                      ; preds = %53
   %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
@@ -7562,13 +8975,13 @@ entry:
 ; <label>:60                                      ; preds = %33, %58
   %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
   %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
-  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %63
 
 ; <label>:63                                      ; preds = %60
   %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
-  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
-  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
@@ -7578,15 +8991,15 @@ entry:
 
 ; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
-  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i32 addrspace(1)* %69, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %70
 
 ; <label>:70                                      ; preds = %68
   %71 = load i32, i32 addrspace(1)* %69, align 8
   store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
-  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
@@ -7596,8 +9009,8 @@ entry:
   store i32 %77, i32* %loc4
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
-  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %80
 
 ; <label>:80                                      ; preds = %73
   %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
@@ -7607,71 +9020,71 @@ entry:
 ; <label>:83                                      ; preds = %80
   store i32 0, i32* %loc3
   %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
-  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
-  br i1 %NullCheck26, label %88, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i32 addrspace(1)* %87, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %88
 
 ; <label>:88                                      ; preds = %85
   %89 = load i32, i32 addrspace(1)* %87, align 8
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
-  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %90
 
 ; <label>:90                                      ; preds = %88
   %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
   store i32 %89, i32 addrspace(1)* %91
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
-  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
-  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %96
 
 ; <label>:96                                      ; preds = %94
   %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
-  br i1 %NullCheck34, label %100, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %100
 
 ; <label>:100                                     ; preds = %96
   %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
-  br i1 %NullCheck36, label %102, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %102
 
 ; <label>:102                                     ; preds = %100
   %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
   %104 = load i32, i32 addrspace(1)* %103, align 8
   %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
-  br i1 %NullCheck38, label %106, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %106
 
 ; <label>:106                                     ; preds = %102
   %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
-  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
-  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %108
 
 ; <label>:108                                     ; preds = %106
   %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
   %110 = load i32, i32 addrspace(1)* %109, align 8
   %111 = add i32 %104, %110
-  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %112
 
 ; <label>:112                                     ; preds = %108
   %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
   store i32 %111, i32 addrspace(1)* %113
   %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
-  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i32 addrspace(1)* %114, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %115
 
 ; <label>:115                                     ; preds = %112
   %116 = load i32, i32 addrspace(1)* %114, align 8
@@ -7681,19 +9094,19 @@ entry:
 ; <label>:118                                     ; preds = %115
   %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
-  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %121
 
 ; <label>:121                                     ; preds = %118
   %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
-  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
-  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %123
 
 ; <label>:123                                     ; preds = %121
   %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
   %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
-  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
-  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %126
 
 ; <label>:126                                     ; preds = %123
   %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
@@ -7705,8 +9118,8 @@ entry:
 
 ; <label>:130                                     ; preds = %80, %115, %126
   %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %132
 
 ; <label>:132                                     ; preds = %130
   %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7715,8 +9128,8 @@ entry:
   %136 = load i32, i32* %loc3
   %137 = sub i32 %135, %136
   %138 = sub i32 %134, %137
-  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %139
 
 ; <label>:139                                     ; preds = %132
   %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7728,16 +9141,16 @@ entry:
 
 ; <label>:144                                     ; preds = %139
   %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
-  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %146
 
 ; <label>:146                                     ; preds = %144
   %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
   %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
   %149 = load i32, i32* %loc2
   %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
-  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %151
 
 ; <label>:151                                     ; preds = %146
   %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
@@ -7754,145 +9167,249 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %18
+ThrowNullRef4:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %31
+ThrowNullRef10:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %44
+ThrowNullRef16:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %68
+ThrowNullRef18:                                   ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %70
+ThrowNullRef20:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %73
+ThrowNullRef22:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %83
+ThrowNullRef24:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %85
+ThrowNullRef26:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %88
+ThrowNullRef28:                                   ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %90
+ThrowNullRef30:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %94
+ThrowNullRef32:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %96
+ThrowNullRef34:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %100
+ThrowNullRef36:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %102
+ThrowNullRef38:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %106
+ThrowNullRef40:                                   ; preds = %106
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %108
+ThrowNullRef42:                                   ; preds = %108
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %112
+ThrowNullRef44:                                   ; preds = %112
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %118
+ThrowNullRef46:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %121
+ThrowNullRef48:                                   ; preds = %121
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %123
+ThrowNullRef50:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %130
+ThrowNullRef52:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %132
+ThrowNullRef54:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %144
+ThrowNullRef56:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %146
+ThrowNullRef58:                                   ; preds = %146
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %60
+ThrowNullRef60:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %63
+ThrowNullRef62:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %49
+ThrowNullRef64:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %51
+ThrowNullRef66:                                   ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %53
+ThrowNullRef68:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(%"System.Char[]" addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %arg0 = alloca %"System.Char[]" addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store %"System.Char[]" addrspace(1)* %param0, %"System.Char[]" addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load i32, i32* %arg4
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %43, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %38, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg1
+  %13 = load i32, i32* %arg4
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %38, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %24 = load i32, i32* %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %35 = load i32, i32* %arg3
+  %36 = load i32, i32* %arg4
+  %37 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %37, %"System.Char[]" addrspace(1)* %34, i32 %35, i32 %36)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:38                                      ; preds = %5, %16
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Successfully read Buffer._Memmove
 
@@ -7914,7 +9431,7 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[loadElem]
+Failed to read AppDomain.SetDataHelper[storeElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -7923,8 +9440,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
@@ -7934,8 +9451,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
@@ -7947,15 +9464,15 @@ entry:
   %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
   %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
@@ -7966,15 +9483,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7992,7 +9509,79 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
-Failed to read Dictionary`2.TryGetValue[loadElemA]
+Successfully read Dictionary`2.TryGetValue
+
+define i8 @"Dictionary`2.TryGetValue"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)* addrspace(1)* %param2) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  %arg2 = alloca %System.__Canon addrspace(1)* addrspace(1)*
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  store %System.__Canon addrspace(1)* addrspace(1)* %param2, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  store i32 %2, i32* %loc0
+  %3 = load i32, i32* %loc0
+  %4 = icmp slt i32 %3, 0
+  br i1 %4, label %22, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 2
+  %10 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %9, align 8
+  %11 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = zext i32 %11 to i64
+  %BoundsCheck = icmp uge i64 %16, %15
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 3, i32 %11
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %20, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %6, %System.__Canon addrspace(1)* %21)
+  ret i8 1
+
+; <label>:22                                      ; preds = %entry
+  %23 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %23, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -8058,8 +9647,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
@@ -8091,8 +9680,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
@@ -8171,15 +9760,15 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck, label %19, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %ThrowNullRef, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
   %21 = load i32, i32 addrspace(1)* %20
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
@@ -8202,7 +9791,7 @@ ThrowNullRef:                                     ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %19
+ThrowNullRef2:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8248,8 +9837,8 @@ entry:
   %0 = alloca %System.AppDomainHandle
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %1 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %1, i32 0, i32 15
@@ -8269,8 +9858,8 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
@@ -8286,7 +9875,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -8299,8 +9888,8 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -8327,8 +9916,8 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
@@ -8352,8 +9941,8 @@ entry:
   %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
   store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
@@ -8363,8 +9952,8 @@ entry:
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
@@ -8374,8 +9963,8 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %9
   %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
@@ -8384,8 +9973,8 @@ entry:
 
 ; <label>:18                                      ; preds = %3, %16
   %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
@@ -8397,15 +9986,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %18
+ThrowNullRef6:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8418,8 +10007,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
@@ -8453,15 +10042,15 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
@@ -8473,7 +10062,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8481,7 +10070,7 @@ ThrowNullRef1:                                    ; preds = %1
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
 Failed to read Dictionary`2.System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
@@ -8506,8 +10095,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
@@ -8524,8 +10113,8 @@ entry:
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -8544,7 +10133,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8577,8 +10166,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = load i64, i64* %arg2
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = trunc i32 %3 to i8
@@ -8634,46 +10223,46 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
   %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
-  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
-  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
-  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
@@ -8684,27 +10273,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %20
+ThrowNullRef12:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8717,8 +10306,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -8756,22 +10345,22 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
   %9 = load i64, i64 addrspace(1)* %8, align 8
   %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
   %13 = load i64, i64 addrspace(1)* %12, align 8
   %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %11
   %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
@@ -8788,11 +10377,11 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8882,8 +10471,8 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
@@ -8900,8 +10489,8 @@ entry:
 ; <label>:8                                       ; preds = %1
   %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
   %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
@@ -8911,15 +10500,15 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
   %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
   %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
-  br i1 %NullCheck6, label %21, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
@@ -8946,15 +10535,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8992,15 +10581,15 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
   store i8 %3, i8 addrspace(1)* %5
   %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
@@ -9011,7 +10600,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9027,8 +10616,8 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -9041,8 +10630,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
@@ -9058,7 +10647,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9080,8 +10669,8 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
@@ -9096,8 +10685,8 @@ entry:
 ; <label>:12                                      ; preds = %6
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
@@ -9112,8 +10701,8 @@ entry:
 ; <label>:21                                      ; preds = %15
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
@@ -9128,8 +10717,8 @@ entry:
 ; <label>:30                                      ; preds = %24
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %31, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
@@ -9144,8 +10733,8 @@ entry:
 ; <label>:39                                      ; preds = %33
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
-  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %40, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %42
 
 ; <label>:42                                      ; preds = %39
   %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
@@ -9164,19 +10753,19 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %21
+ThrowNullRef4:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %30
+ThrowNullRef6:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %39
+ThrowNullRef8:                                    ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9243,8 +10832,8 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
@@ -9264,57 +10853,57 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
   store i8 0, i8 addrspace(1)* %2
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
   store i8 0, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
   store i8 0, i8 addrspace(1)* %17
   %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
   store i8 0, i8 addrspace(1)* %20
   %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
-  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
@@ -9325,31 +10914,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %19
+ThrowNullRef14:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9367,8 +10956,8 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
@@ -9380,8 +10969,8 @@ entry:
 
 ; <label>:9                                       ; preds = %4
   %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %9
   %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
@@ -9395,7 +10984,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef2:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9420,8 +11009,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
@@ -9512,8 +11101,8 @@ entry:
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
@@ -9524,8 +11113,8 @@ entry:
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = load i64, i64 addrspace(1)* %12
@@ -9537,8 +11126,8 @@ entry:
   %20 = load i64, i64* %19
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
-  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %13
   %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
@@ -9555,8 +11144,8 @@ entry:
 ; <label>:30                                      ; preds = %25
   %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %32 = load i32, i32* %arg2
-  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
-  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
@@ -9570,15 +11159,15 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %30
+ThrowNullRef2:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9622,87 +11211,87 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
   %10 = load i8, i8 addrspace(1)* %9, align 8
   %11 = zext i8 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %8
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
   store i8 %12, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
   %19 = load i8, i8 addrspace(1)* %18, align 8
   %20 = zext i8 %19 to i32
   %21 = trunc i32 %20 to i8
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
   store i8 %21, i8 addrspace(1)* %23
   %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
   %28 = load i8, i8 addrspace(1)* %27, align 8
   %29 = zext i8 %28 to i32
   %30 = trunc i32 %29 to i8
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
-  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %31
 
 ; <label>:31                                      ; preds = %26
   %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
   store i8 %30, i8 addrspace(1)* %32
   %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
-  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
-  br i1 %NullCheck14, label %40, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %40
 
 ; <label>:40                                      ; preds = %35
   %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
   store i8 %39, i8 addrspace(1)* %41
   %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
-  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %44
 
 ; <label>:44                                      ; preds = %40
   %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
   %46 = load i8, i8 addrspace(1)* %45, align 8
   %47 = zext i8 %46 to i32
   %48 = trunc i32 %47 to i8
-  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
   store i8 %48, i8 addrspace(1)* %50
   %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
-  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
@@ -9713,29 +11302,29 @@ entry:
 ; <label>:56                                      ; preds = %52
   %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
-  br i1 %NullCheck22, label %59, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
   %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
   %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
-  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
-  br i1 %NullCheck24, label %63, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
   %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
-  br i1 %NullCheck26, label %66, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
   %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
-  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
-  br i1 %NullCheck28, label %69, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %69
 
 ; <label>:69                                      ; preds = %66
   %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
@@ -9744,15 +11333,15 @@ entry:
 
 ; <label>:71                                      ; preds = %105
   %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
-  br i1 %NullCheck34, label %73, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %73
 
 ; <label>:73                                      ; preds = %71
   %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
   %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
   %76 = load i32, i32* %loc0
-  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
-  br i1 %NullCheck36, label %77, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
@@ -9766,8 +11355,8 @@ entry:
 
 ; <label>:83                                      ; preds = %77
   %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
-  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
@@ -9775,14 +11364,14 @@ entry:
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
   %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
-  br i1 %NullCheck40, label %91, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
 ; <label>:91                                      ; preds = %85
   %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
   %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
-  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck42, label %94, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %94
 
 ; <label>:94                                      ; preds = %91
   %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
@@ -9798,14 +11387,14 @@ entry:
 ; <label>:99                                      ; preds = %69, %96
   %100 = load i32, i32* %loc0
   %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
-  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %102
 
 ; <label>:102                                     ; preds = %99
   %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
   %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
-  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
-  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
@@ -9819,87 +11408,87 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %26
+ThrowNullRef10:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %31
+ThrowNullRef12:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %35
+ThrowNullRef14:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %40
+ThrowNullRef16:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %56
+ThrowNullRef22:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %59
+ThrowNullRef24:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %63
+ThrowNullRef26:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %66
+ThrowNullRef28:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %102
+ThrowNullRef32:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %71
+ThrowNullRef34:                                   ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %73
+ThrowNullRef36:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %83
+ThrowNullRef38:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %85
+ThrowNullRef40:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %91
+ThrowNullRef42:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9943,15 +11532,15 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
   %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
@@ -9961,28 +11550,28 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
   %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %12
   %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
   %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
   %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
-  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
@@ -9993,23 +11582,23 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %12
+ThrowNullRef6:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10031,15 +11620,15 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
   %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = load i64, i64 addrspace(1)* %7
@@ -10077,13 +11666,13 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[loadElem]
+Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -10111,8 +11700,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -10175,8 +11764,8 @@ entry:
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load float, float* %arg0
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -10310,8 +11899,8 @@ entry:
   store i64 %param0, i64* %arg0
   store i64 %param1, i64* %arg1
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
@@ -10319,8 +11908,8 @@ entry:
   %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
   %5 = load i16*, i16* addrspace(1)* %4, align 8
   %6 = addrspacecast i64* %arg1 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = bitcast i64 addrspace(1)* %6 to i8 addrspace(1)*
@@ -10336,7 +11925,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10370,8 +11959,8 @@ entry:
   %1 = load i32, i32* %arg1
   %2 = sext i32 %1 to i64
   %3 = inttoptr i64 %2 to i16*
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -10424,8 +12013,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, i32)*)(%System.IO.ConsoleStream addrspace(1)* %2, i32 %1)
   %3 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %4 = load i64, i64* %arg1
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
@@ -10436,8 +12025,8 @@ entry:
   %10 = icmp eq i32 %9, 3
   %11 = sext i1 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %5
   %14 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, i32 0, i32 5
@@ -10448,7 +12037,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10471,8 +12060,8 @@ entry:
   %5 = icmp eq i32 %4, 1
   %6 = sext i1 %5 to i32
   %7 = trunc i32 %6 to i8
-  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %2, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.ConsoleStream addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
@@ -10483,8 +12072,8 @@ entry:
   %13 = icmp eq i32 %12, 2
   %14 = sext i1 %13 to i32
   %15 = trunc i32 %14 to i8
-  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %10, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.ConsoleStream addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %8
   %17 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %10, i32 0, i32 4
@@ -10495,7 +12084,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10534,8 +12123,8 @@ entry:
   %arg0 = alloca i64
   store i64 %param0, i64* %arg0
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
@@ -10570,8 +12159,8 @@ entry:
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
   %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = load i64, i64 addrspace(1)* %7
@@ -10675,7 +12264,127 @@ entry:
 INFO:  jitting method Encoding::GetEncoding using LLILCJit
 Failed to read Encoding.GetEncoding[convertToHelperArgumentType]
 INFO:  jitting method EncodingProvider::GetEncodingFromProvider using LLILCJit
-Failed to read EncodingProvider.GetEncodingFromProvider[loadElem]
+Successfully read EncodingProvider.GetEncodingFromProvider
+
+define %System.Text.Encoding addrspace(1)* @EncodingProvider.GetEncodingFromProvider(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca %"System.Text.EncodingProvider[]" addrspace(1)*
+  %loc1 = alloca %System.Text.EncodingProvider addrspace(1)*
+  %loc2 = alloca %System.Text.Encoding addrspace(1)*
+  %loc3 = alloca %System.Text.Encoding addrspace(1)*
+  %loc4 = alloca %"System.Text.EncodingProvider[]" addrspace(1)*
+  %loc5 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1059)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2392
+  %2 = addrspacecast i8 addrspace(1)* %1 to %"System.Text.EncodingProvider[]" addrspace(1)**
+  %3 = load volatile %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %2
+  %4 = icmp ne %"System.Text.EncodingProvider[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %entry
+  ret %System.Text.Encoding addrspace(1)* null
+
+; <label>:6                                       ; preds = %entry
+  %7 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1059)
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i64 2392
+  %9 = addrspacecast i8 addrspace(1)* %8 to %"System.Text.EncodingProvider[]" addrspace(1)**
+  %10 = load volatile %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %9
+  store %"System.Text.EncodingProvider[]" addrspace(1)* %10, %"System.Text.EncodingProvider[]" addrspace(1)** %loc0
+  %11 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc0
+  store %"System.Text.EncodingProvider[]" addrspace(1)* %11, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  store i32 0, i32* %loc5
+  br label %43
+
+; <label>:12                                      ; preds = %46
+  %13 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  %14 = load i32, i32* %loc5
+  %NullCheck1 = icmp eq %"System.Text.EncodingProvider[]" addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %13, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = zext i32 %17 to i64
+  %19 = zext i32 %14 to i64
+  %BoundsCheck = icmp uge i64 %19, %18
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %20
+
+; <label>:20                                      ; preds = %15
+  %21 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %13, i32 0, i32 3, i32 %14
+  %22 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)* addrspace(1)* %21, align 8
+  store %System.Text.EncodingProvider addrspace(1)* %22, %System.Text.EncodingProvider addrspace(1)** %loc1
+  %23 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)** %loc1
+  %24 = load i32, i32* %arg0
+  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i64 addrspace(1)*
+  %NullCheck3 = icmp eq i64 addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
+
+; <label>:26                                      ; preds = %20
+  %27 = load i64, i64 addrspace(1)* %25
+  %28 = add i64 %27, 64
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 40
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Text.Encoding addrspace(1)* (%System.Text.EncodingProvider addrspace(1)*, i32)*
+  %35 = call %System.Text.Encoding addrspace(1)* %34(%System.Text.EncodingProvider addrspace(1)* %23, i32 %24)
+  store %System.Text.Encoding addrspace(1)* %35, %System.Text.Encoding addrspace(1)** %loc2
+  %36 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc2
+  %37 = icmp eq %System.Text.Encoding addrspace(1)* %36, null
+  br i1 %37, label %40, label %38
+
+; <label>:38                                      ; preds = %26
+  %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc2
+  store %System.Text.Encoding addrspace(1)* %39, %System.Text.Encoding addrspace(1)** %loc3
+  br label %53
+
+; <label>:40                                      ; preds = %26
+  %41 = load i32, i32* %loc5
+  %42 = add i32 %41, 1
+  store i32 %42, i32* %loc5
+  br label %43
+
+; <label>:43                                      ; preds = %6, %40
+  %44 = load i32, i32* %loc5
+  %45 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  %NullCheck = icmp eq %"System.Text.EncodingProvider[]" addrspace(1)* %45, null
+  br i1 %NullCheck, label %ThrowNullRef, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp slt i32 %44, %50
+  br i1 %51, label %12, label %52
+
+; <label>:52                                      ; preds = %46
+  ret %System.Text.Encoding addrspace(1)* null
+
+; <label>:53                                      ; preds = %38
+  %54 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc3
+  ret %System.Text.Encoding addrspace(1)* %54
+
+ThrowNullRef:                                     ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method EncodingProvider::.cctor using LLILCJit
 Successfully read EncodingProvider..cctor
 
@@ -10694,7 +12403,7 @@ Failed to read Encoding.get_InternalSyncObject[Call HasTypeArg]
 INFO:  jitting method Hashtable::.ctor using LLILCJit
 Failed to read Hashtable..ctor[Volatile store]
 INFO:  jitting method Hashtable::get_Item using LLILCJit
-Failed to read Hashtable.get_Item[loadElemA]
+Failed to read Hashtable.get_Item[loadNonPrimitiveObj]
 INFO:  jitting method Hashtable::InitHash using LLILCJit
 Successfully read Hashtable.InitHash
 
@@ -10714,8 +12423,8 @@ entry:
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -10731,15 +12440,15 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
   %15 = load i32, i32* %loc0
-  %NullCheck2 = icmp ne i32 addrspace(1)* %14, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i32 addrspace(1)* %14, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %3
   store i32 %15, i32 addrspace(1)* %14, align 8
   %17 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %18 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %NullCheck4 = icmp ne i32 addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i32 addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = load i32, i32 addrspace(1)* %18, align 8
@@ -10748,8 +12457,8 @@ entry:
   %23 = sub i32 %22, 1
   %24 = urem i32 %21, %23
   %25 = add i32 1, %24
-  %NullCheck6 = icmp ne i32 addrspace(1)* %17, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32 addrspace(1)* %17, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %19
   store i32 %25, i32 addrspace(1)* %17, align 8
@@ -10760,15 +12469,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %19
+ThrowNullRef6:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10783,8 +12492,8 @@ entry:
   store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
   store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %NullCheck = icmp ne %System.Collections.Hashtable addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Collections.Hashtable addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
@@ -10794,16 +12503,16 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Collections.Hashtable addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Collections.Hashtable addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
   %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck4 = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %9, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
   %13 = inttoptr i64 %11 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
@@ -10813,8 +12522,8 @@ entry:
 ; <label>:15                                      ; preds = %1
   %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -10832,15 +12541,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10854,8 +12563,8 @@ entry:
   store %System.Int32 addrspace(1)* %param0, %System.Int32 addrspace(1)** %this
   %0 = load %System.Int32 addrspace(1)*, %System.Int32 addrspace(1)** %this
   %1 = bitcast %System.Int32 addrspace(1)* %0 to i32 addrspace(1)*
-  %NullCheck = icmp ne i32 addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq i32 addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load i32, i32 addrspace(1)* %1, align 8
@@ -10931,8 +12640,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.UTF8Encoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
@@ -10941,15 +12650,15 @@ entry:
   %9 = load i8, i8* %arg2
   %10 = zext i8 %9 to i32
   %11 = trunc i32 %10 to i8
-  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %8, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %6
   %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %8, i32 0, i32 8
   store i8 %11, i8 addrspace(1)* %13
   %14 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %14, i32 0, i32 8
@@ -10961,8 +12670,8 @@ entry:
 ; <label>:20                                      ; preds = %15
   %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %22, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %22, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = load i64, i64 addrspace(1)* %22
@@ -10984,15 +12693,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %12
+ThrowNullRef4:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11007,8 +12716,8 @@ entry:
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
@@ -11030,16 +12739,16 @@ entry:
 ; <label>:10                                      ; preds = %1
   %11 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
   %12 = load i32, i32* %arg1
-  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %11, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.Encoding addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
   store i32 %12, i32 addrspace(1)* %14
   %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
   %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = load i64, i64 addrspace(1)* %16
@@ -11057,11 +12766,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11074,8 +12783,8 @@ entry:
   %this = alloca %System.Text.UTF8Encoding addrspace(1)*
   store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
   %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.UTF8Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
@@ -11087,16 +12796,16 @@ entry:
 ; <label>:6                                       ; preds = %1
   %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %8 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %10, %System.Text.EncoderFallback addrspace(1)* %8)
   %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %12 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
-  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %11, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %11, i32 0, i32 3
@@ -11109,8 +12818,8 @@ entry:
   %18 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %18, %System.String addrspace(1)* %17)
   %19 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %18 to %System.Text.EncoderFallback addrspace(1)*
-  %NullCheck6 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %16, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %16, i32 0, i32 2
@@ -11120,8 +12829,8 @@ entry:
   %24 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %24, %System.String addrspace(1)* %23)
   %25 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %24 to %System.Text.DecoderFallback addrspace(1)*
-  %NullCheck8 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %22, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %22, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %20
   %27 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %22, i32 0, i32 3
@@ -11132,19 +12841,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %20
+ThrowNullRef8:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11174,8 +12883,8 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load i32, i32* %arg1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -11193,8 +12902,8 @@ entry:
 ; <label>:15                                      ; preds = %8
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %17 = load i32, i32* %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 %17
@@ -11210,7 +12919,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11262,7 +12971,7 @@ entry:
 }
 
 INFO:  jitting method Hashtable::Insert using LLILCJit
-Failed to read Hashtable.Insert[loadElemA]
+Failed to read Hashtable.Insert[storeElem]
 INFO:  jitting method ConsoleEncoding::.ctor using LLILCJit
 Successfully read ConsoleEncoding..ctor
 
@@ -11277,8 +12986,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %1)
   %2 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
@@ -11314,8 +13023,8 @@ entry:
   %2 = call %System.Text.InternalEncoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalEncoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %1)
   %3 = bitcast %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2 to %System.Text.EncoderFallback addrspace(1)*
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
@@ -11325,8 +13034,8 @@ entry:
   %8 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %7)
   %9 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %8 to %System.Text.DecoderFallback addrspace(1)*
-  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %6, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.Encoding addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %4
   %11 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %6, i32 0, i32 3
@@ -11337,7 +13046,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11356,15 +13065,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* %1)
   %2 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   %6 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, i32 0, i32 1
@@ -11375,7 +13084,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11403,8 +13112,8 @@ entry:
   store %System.Text.InternalDecoderBestFitFallback addrspace(1)* %param0, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
   %0 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
@@ -11414,15 +13123,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %4)
   %5 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %6)
   %9 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, i32 0, i32 1
@@ -11433,11 +13142,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11505,8 +13214,8 @@ entry:
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
   %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = load i64, i64 addrspace(1)* %19
@@ -11570,8 +13279,8 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.ConsoleStream addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
@@ -11602,31 +13311,31 @@ entry:
   store i8 %param4, i8* %arg4
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %3, %System.IO.Stream addrspace(1)* %1)
   %4 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %4, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
   %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %4, i32 0, i32 4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %5)
   %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %6
   %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
   %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
   %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = load i64, i64 addrspace(1)* %13
@@ -11638,8 +13347,8 @@ entry:
   %21 = load i64, i64* %20
   %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %8, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %8, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %14
   %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 5
@@ -11657,24 +13366,24 @@ entry:
   %31 = load i32, i32* %arg3
   %32 = sext i32 %31 to i64
   %33 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %32)
-  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %30, null
-  br i1 %NullCheck10, label %34, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.StreamWriter addrspace(1)* %30, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %35, %"System.Char[]" addrspace(1)* %33)
   %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %37, null
-  br i1 %NullCheck12, label %38, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.StreamWriter addrspace(1)* %37, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %38
 
 ; <label>:38                                      ; preds = %34
   %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
   %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
   %41 = load i32, i32* %arg3
   %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %42, null
-  br i1 %NullCheck14, label %43, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %42, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
   %44 = load i64, i64 addrspace(1)* %42
@@ -11688,30 +13397,30 @@ entry:
   %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
   %53 = sext i32 %52 to i64
   %54 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %53)
-  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
-  br i1 %NullCheck16, label %55, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %55
 
 ; <label>:55                                      ; preds = %43
   %56 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %56, %"System.Byte[]" addrspace(1)* %54)
   %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %58 = load i32, i32* %arg3
-  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %57, null
-  br i1 %NullCheck18, label %59, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.StreamWriter addrspace(1)* %57, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %59
 
 ; <label>:59                                      ; preds = %55
   %60 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 10
   store i32 %58, i32 addrspace(1)* %60
   %61 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %61, null
-  br i1 %NullCheck20, label %62, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.IO.StreamWriter addrspace(1)* %61, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %62
 
 ; <label>:62                                      ; preds = %59
   %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
   %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
   %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
   %67 = load i64, i64 addrspace(1)* %65
@@ -11729,15 +13438,15 @@ entry:
 
 ; <label>:78                                      ; preds = %66
   %79 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %79, null
-  br i1 %NullCheck24, label %80, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.StreamWriter addrspace(1)* %79, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %80
 
 ; <label>:80                                      ; preds = %78
   %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
   %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
   %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %83, null
-  br i1 %NullCheck26, label %84, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %83, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
   %85 = load i64, i64 addrspace(1)* %83
@@ -11754,8 +13463,8 @@ entry:
 
 ; <label>:95                                      ; preds = %84
   %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.IO.StreamWriter addrspace(1)* %96, null
-  br i1 %NullCheck28, label %97, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.IO.StreamWriter addrspace(1)* %96, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %97
 
 ; <label>:97                                      ; preds = %95
   %98 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 12
@@ -11769,8 +13478,8 @@ entry:
   %103 = icmp eq i32 %102, 0
   %104 = sext i1 %103 to i32
   %105 = trunc i32 %104 to i8
-  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %100, null
-  br i1 %NullCheck30, label %106, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.IO.StreamWriter addrspace(1)* %100, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %106
 
 ; <label>:106                                     ; preds = %99
   %107 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %100, i32 0, i32 13
@@ -11781,63 +13490,63 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %6
+ThrowNullRef4:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %29
+ThrowNullRef10:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %34
+ThrowNullRef12:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %38
+ThrowNullRef14:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %43
+ThrowNullRef16:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %55
+ThrowNullRef18:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %59
+ThrowNullRef20:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %62
+ThrowNullRef22:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %78
+ThrowNullRef24:                                   ; preds = %78
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %80
+ThrowNullRef26:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %95
+ThrowNullRef28:                                   ; preds = %95
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11850,15 +13559,15 @@ entry:
   %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = load i64, i64 addrspace(1)* %4
@@ -11876,7 +13585,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11926,35 +13635,35 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
   %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderNLS addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %7 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.EncoderNLS addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Text.Encoding addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.Encoding addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Text.EncoderNLS addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.EncoderNLS addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
   %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck8 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = load i64, i64 addrspace(1)* %16
@@ -11973,19 +13682,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12011,8 +13720,8 @@ entry:
   %this = alloca %System.Text.Encoding addrspace(1)*
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
@@ -12032,15 +13741,15 @@ entry:
   %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
   store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
   %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
   store i32 0, i32 addrspace(1)* %2
   %3 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, i32 0, i32 2
@@ -12050,15 +13759,15 @@ entry:
 
 ; <label>:8                                       ; preds = %4
   %9 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
   %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
   %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = load i64, i64 addrspace(1)* %13
@@ -12079,15 +13788,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12102,16 +13811,16 @@ entry:
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = load i32, i32* %arg1
   %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
   %7 = load i64, i64 addrspace(1)* %5
@@ -12129,7 +13838,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12166,8 +13875,8 @@ entry:
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
   %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
   %16 = load i64, i64 addrspace(1)* %14
@@ -12188,8 +13897,8 @@ entry:
   %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
   %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
   %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %31, null
-  br i1 %NullCheck2, label %32, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = load i64, i64 addrspace(1)* %31
@@ -12232,7 +13941,7 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12245,14 +13954,14 @@ entry:
   %this = alloca %System.Text.EncoderReplacementFallback addrspace(1)*
   store %System.Text.EncoderReplacementFallback addrspace(1)* %param0, %System.Text.EncoderReplacementFallback addrspace(1)** %this
   %0 = load %System.Text.EncoderReplacementFallback addrspace(1)*, %System.Text.EncoderReplacementFallback addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -12263,7 +13972,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12293,8 +14002,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
@@ -12326,8 +14035,8 @@ entry:
   %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
   store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
@@ -12339,8 +14048,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Threading.Tasks.Task addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %7)
@@ -12363,7 +14072,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12382,8 +14091,8 @@ entry:
   store i8 %param1, i8* %arg1
   store i8 %param2, i8* %arg2
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
@@ -12397,8 +14106,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1, %5
   %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 9
@@ -12429,8 +14138,8 @@ entry:
 
 ; <label>:25                                      ; preds = %8, %20
   %26 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %26, null
-  br i1 %NullCheck4, label %27, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %26, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %26, i32 0, i32 12
@@ -12441,22 +14150,22 @@ entry:
 
 ; <label>:32                                      ; preds = %27
   %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %33, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.IO.StreamWriter addrspace(1)* %33, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %32
   %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 12
   store i8 1, i8 addrspace(1)* %35
   %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
-  br i1 %NullCheck8, label %37, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
   %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
   %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck10 = icmp ne i64 addrspace(1)* %40, null
-  br i1 %NullCheck10, label %41, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64 addrspace(1)* %40, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i64, i64 addrspace(1)* %40
@@ -12470,8 +14179,8 @@ entry:
   %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
   store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
   %51 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %NullCheck12 = icmp ne %"System.Byte[]" addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Byte[]" addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %41
   %53 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %51, i32 0, i32 1
@@ -12483,16 +14192,16 @@ entry:
 
 ; <label>:58                                      ; preds = %52
   %59 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %59, null
-  br i1 %NullCheck14, label %60, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.IO.StreamWriter addrspace(1)* %59, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %60
 
 ; <label>:60                                      ; preds = %58
   %61 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %59, i32 0, i32 3
   %62 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
   %64 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %NullCheck16 = icmp ne %"System.Byte[]" addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %"System.Byte[]" addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %60
   %66 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %64, i32 0, i32 1
@@ -12500,8 +14209,8 @@ entry:
   %68 = zext i32 %67 to i64
   %69 = trunc i64 %68 to i32
   %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck18, label %71, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
   %72 = load i64, i64 addrspace(1)* %70
@@ -12517,29 +14226,29 @@ entry:
 
 ; <label>:80                                      ; preds = %27, %52, %71
   %81 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %81, null
-  br i1 %NullCheck20, label %82, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.IO.StreamWriter addrspace(1)* %81, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
 
 ; <label>:82                                      ; preds = %80
   %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %81, i32 0, i32 5
   %84 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %83, align 8
   %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.IO.StreamWriter addrspace(1)* %85, null
-  br i1 %NullCheck22, label %86, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.IO.StreamWriter addrspace(1)* %85, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %86
 
 ; <label>:86                                      ; preds = %82
   %87 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 7
   %88 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %87, align 8
   %89 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %89, null
-  br i1 %NullCheck24, label %90, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.StreamWriter addrspace(1)* %89, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %90
 
 ; <label>:90                                      ; preds = %86
   %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %89, i32 0, i32 9
   %92 = load i32, i32 addrspace(1)* %91, align 8
   %93 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.IO.StreamWriter addrspace(1)* %93, null
-  br i1 %NullCheck26, label %94, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.IO.StreamWriter addrspace(1)* %93, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %93, i32 0, i32 6
@@ -12547,8 +14256,8 @@ entry:
   %97 = load i8, i8* %arg2
   %98 = zext i8 %97 to i32
   %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
-  %NullCheck28 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck28, label %100, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
   %101 = load i64, i64 addrspace(1)* %99
@@ -12563,8 +14272,8 @@ entry:
   %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
   store i32 %110, i32* %loc1
   %111 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %111, null
-  br i1 %NullCheck30, label %112, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.IO.StreamWriter addrspace(1)* %111, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %112
 
 ; <label>:112                                     ; preds = %100
   %113 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %111, i32 0, i32 9
@@ -12575,23 +14284,23 @@ entry:
 
 ; <label>:116                                     ; preds = %112
   %117 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck32 = icmp ne %System.IO.StreamWriter addrspace(1)* %117, null
-  br i1 %NullCheck32, label %118, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.IO.StreamWriter addrspace(1)* %117, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %118
 
 ; <label>:118                                     ; preds = %116
   %119 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %117, i32 0, i32 3
   %120 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %119, align 8
   %121 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.IO.StreamWriter addrspace(1)* %121, null
-  br i1 %NullCheck34, label %122, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.IO.StreamWriter addrspace(1)* %121, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %122
 
 ; <label>:122                                     ; preds = %118
   %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
   %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
   %125 = load i32, i32* %loc1
   %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
-  %NullCheck36 = icmp ne i64 addrspace(1)* %126, null
-  br i1 %NullCheck36, label %127, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64 addrspace(1)* %126, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
   %128 = load i64, i64 addrspace(1)* %126
@@ -12613,15 +14322,15 @@ entry:
 
 ; <label>:140                                     ; preds = %136
   %141 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.IO.StreamWriter addrspace(1)* %141, null
-  br i1 %NullCheck38, label %142, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.IO.StreamWriter addrspace(1)* %141, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %142
 
 ; <label>:142                                     ; preds = %140
   %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
   %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
   %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
-  %NullCheck40 = icmp ne i64 addrspace(1)* %145, null
-  br i1 %NullCheck40, label %146, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i64 addrspace(1)* %145, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
   %147 = load i64, i64 addrspace(1)* %145
@@ -12642,83 +14351,83 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %25
+ThrowNullRef4:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %32
+ThrowNullRef6:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %37
+ThrowNullRef10:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %41
+ThrowNullRef12:                                   ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %58
+ThrowNullRef14:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %60
+ThrowNullRef16:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %65
+ThrowNullRef18:                                   ; preds = %65
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %80
+ThrowNullRef20:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %82
+ThrowNullRef22:                                   ; preds = %82
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %86
+ThrowNullRef24:                                   ; preds = %86
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %90
+ThrowNullRef26:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %94
+ThrowNullRef28:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %100
+ThrowNullRef30:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %116
+ThrowNullRef32:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %118
+ThrowNullRef34:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %122
+ThrowNullRef36:                                   ; preds = %122
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %140
+ThrowNullRef38:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %142
+ThrowNullRef40:                                   ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12785,8 +14494,8 @@ entry:
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %1 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
-  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
@@ -12794,8 +14503,8 @@ entry:
   %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
   %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
   %8 = load i64, i64 addrspace(1)* %6
@@ -12811,8 +14520,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %17, %System.IFormatProvider addrspace(1)* %16)
   %18 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %19 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %18, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.SyncTextWriter addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %7
   %21 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %18, i32 0, i32 4
@@ -12823,11 +14532,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12840,8 +14549,8 @@ entry:
   %this = alloca %System.IO.TextWriter addrspace(1)*
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.TextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
@@ -12851,8 +14560,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.Threading.Thread addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Threading.Thread addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %6)
@@ -12861,8 +14570,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1
   %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.TextWriter addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.TextWriter addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %11, i32 0, i32 2
@@ -12873,11 +14582,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13074,8 +14783,8 @@ entry:
   store float %param1, float* %arg1
   store i8 0, i8* %loc1
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
@@ -13085,16 +14794,16 @@ entry:
   %5 = addrspacecast i8* %loc1 to i8 addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %4, i8 addrspace(1)* %5)
   %6 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.SyncTextWriter addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
   %10 = load float, float* %arg1
   %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
   %13 = load i64, i64 addrspace(1)* %11
@@ -13129,11 +14838,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13150,8 +14859,8 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load float, float* %arg1
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -13165,8 +14874,8 @@ entry:
   call void %11(%System.IO.TextWriter addrspace(1)* %0, float %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
   %15 = load i64, i64 addrspace(1)* %13
@@ -13184,7 +14893,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13202,8 +14911,8 @@ entry:
   %1 = addrspacecast float* %arg1 to float addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -13218,8 +14927,8 @@ entry:
   %14 = bitcast float addrspace(1)* %1 to %System.Single addrspace(1)*
   %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Single addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Single addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
   %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
   %18 = load i64, i64 addrspace(1)* %16
@@ -13237,7 +14946,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13253,8 +14962,8 @@ entry:
   store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
   %0 = load %System.Single addrspace(1)*, %System.Single addrspace(1)** %this
   %1 = bitcast %System.Single addrspace(1)* %0 to float addrspace(1)*
-  %NullCheck = icmp ne float addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq float addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load float, float addrspace(1)* %1, align 8
@@ -13279,8 +14988,8 @@ entry:
   %loc0 = alloca %System.Globalization.NumberFormatInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 3
@@ -13290,8 +14999,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
@@ -13301,24 +15010,24 @@ entry:
   store %System.Globalization.NumberFormatInfo addrspace(1)* %10, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
   %11 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %7
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
   %15 = load i8, i8 addrspace(1)* %14, align 8
   %16 = zext i8 %15 to i32
   %17 = trunc i32 %16 to i8
-  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %11, null
-  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %11, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %13
   %19 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %11, i32 0, i32 29
   store i8 %17, i8 addrspace(1)* %19
   %20 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %21 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %20, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %20, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %18
   %23 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %20, i32 0, i32 3
@@ -13327,8 +15036,8 @@ entry:
 
 ; <label>:24                                      ; preds = %1, %22
   %25 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %25, null
-  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %25, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %26
 
 ; <label>:26                                      ; preds = %24
   %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %25, i32 0, i32 3
@@ -13339,23 +15048,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %18
+ThrowNullRef8:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13380,168 +15089,168 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 18
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %8, align 8
-  %NullCheck2 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %5, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %5, i32 0, i32 4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %9)
   %12 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 19
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %15, align 8
-  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %12, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %12, i32 0, i32 5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %16)
   %19 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %20 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %20, null
-  br i1 %NullCheck8, label %21, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %20, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %20, i32 0, i32 23
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  %NullCheck10 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %19, null
-  br i1 %NullCheck10, label %24, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %19, i32 0, i32 7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %25, %System.String addrspace(1)* %23)
   %26 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %27 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %27, i32 0, i32 22
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %29, align 8
-  %NullCheck14 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %26, null
-  br i1 %NullCheck14, label %31, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %26, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %26, i32 0, i32 6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %32, %System.String addrspace(1)* %30)
   %33 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %34 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Globalization.CultureData addrspace(1)* %34, null
-  br i1 %NullCheck16, label %35, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Globalization.CultureData addrspace(1)* %34, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %34, i32 0, i32 51
   %37 = load i32, i32 addrspace(1)* %36, align 8
-  %NullCheck18 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %33, null
-  br i1 %NullCheck18, label %38, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %33, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %33, i32 0, i32 21
   store i32 %37, i32 addrspace(1)* %39
   %40 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %41 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Globalization.CultureData addrspace(1)* %41, null
-  br i1 %NullCheck20, label %42, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Globalization.CultureData addrspace(1)* %41, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %41, i32 0, i32 52
   %44 = load i32, i32 addrspace(1)* %43, align 8
-  %NullCheck22 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %40, null
-  br i1 %NullCheck22, label %45, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %40, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %40, i32 0, i32 25
   store i32 %44, i32 addrspace(1)* %46
   %47 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %48 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.Globalization.CultureData addrspace(1)* %48, null
-  br i1 %NullCheck24, label %49, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Globalization.CultureData addrspace(1)* %48, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %49
 
 ; <label>:49                                      ; preds = %45
   %50 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %48, i32 0, i32 29
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck26 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %47, null
-  br i1 %NullCheck26, label %52, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %47, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %47, i32 0, i32 10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %53, %System.String addrspace(1)* %51)
   %54 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %55 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Globalization.CultureData addrspace(1)* %55, null
-  br i1 %NullCheck28, label %56, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Globalization.CultureData addrspace(1)* %55, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %56
 
 ; <label>:56                                      ; preds = %52
   %57 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %55, i32 0, i32 35
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %57, align 8
-  %NullCheck30 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %54, null
-  br i1 %NullCheck30, label %59, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %54, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %54, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %60, %System.String addrspace(1)* %58)
   %61 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %62 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck32 = icmp ne %System.Globalization.CultureData addrspace(1)* %62, null
-  br i1 %NullCheck32, label %63, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Globalization.CultureData addrspace(1)* %62, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %62, i32 0, i32 34
   %65 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %64, align 8
-  %NullCheck34 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %61, null
-  br i1 %NullCheck34, label %66, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %61, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %61, i32 0, i32 9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %67, %System.String addrspace(1)* %65)
   %68 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %69 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck36 = icmp ne %System.Globalization.CultureData addrspace(1)* %69, null
-  br i1 %NullCheck36, label %70, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Globalization.CultureData addrspace(1)* %69, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %70
 
 ; <label>:70                                      ; preds = %66
   %71 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %69, i32 0, i32 55
   %72 = load i32, i32 addrspace(1)* %71, align 8
-  %NullCheck38 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %68, null
-  br i1 %NullCheck38, label %73, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %68, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %68, i32 0, i32 22
   store i32 %72, i32 addrspace(1)* %74
   %75 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %76 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck40 = icmp ne %System.Globalization.CultureData addrspace(1)* %76, null
-  br i1 %NullCheck40, label %77, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Globalization.CultureData addrspace(1)* %76, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %76, i32 0, i32 57
   %79 = load i32, i32 addrspace(1)* %78, align 8
-  %NullCheck42 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %75, null
-  br i1 %NullCheck42, label %80, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %75, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %80
 
 ; <label>:80                                      ; preds = %77
   %81 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %75, i32 0, i32 24
   store i32 %79, i32 addrspace(1)* %81
   %82 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %83 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck44 = icmp ne %System.Globalization.CultureData addrspace(1)* %83, null
-  br i1 %NullCheck44, label %84, label %ThrowNullRef43
+  %NullCheck43 = icmp eq %System.Globalization.CultureData addrspace(1)* %83, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %84
 
 ; <label>:84                                      ; preds = %80
   %85 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %83, i32 0, i32 56
   %86 = load i32, i32 addrspace(1)* %85, align 8
-  %NullCheck46 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %82, null
-  br i1 %NullCheck46, label %87, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %82, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %82, i32 0, i32 23
@@ -13550,8 +15259,8 @@ entry:
 
 ; <label>:89                                      ; preds = %entry
   %90 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck100 = icmp ne %System.Globalization.CultureData addrspace(1)* %90, null
-  br i1 %NullCheck100, label %91, label %ThrowNullRef99
+  %NullCheck99 = icmp eq %System.Globalization.CultureData addrspace(1)* %90, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %91
 
 ; <label>:91                                      ; preds = %89
   %92 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %90, i32 0, i32 2
@@ -13569,8 +15278,8 @@ entry:
   %102 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %103 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %104 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %103)
-  %NullCheck48 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %102, null
-  br i1 %NullCheck48, label %105, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %102, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %105
 
 ; <label>:105                                     ; preds = %101
   %106 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %102, i32 0, i32 1
@@ -13578,8 +15287,8 @@ entry:
   %107 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %108 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %109 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %108)
-  %NullCheck50 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %107, null
-  br i1 %NullCheck50, label %110, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %107, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %110
 
 ; <label>:110                                     ; preds = %105
   %111 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %107, i32 0, i32 2
@@ -13587,8 +15296,8 @@ entry:
   %112 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %113 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %114 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %113)
-  %NullCheck52 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %112, null
-  br i1 %NullCheck52, label %115, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %112, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %115
 
 ; <label>:115                                     ; preds = %110
   %116 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %112, i32 0, i32 27
@@ -13596,8 +15305,8 @@ entry:
   %117 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %118 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %119 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %118)
-  %NullCheck54 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %117, null
-  br i1 %NullCheck54, label %120, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %117, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %120
 
 ; <label>:120                                     ; preds = %115
   %121 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %117, i32 0, i32 26
@@ -13605,8 +15314,8 @@ entry:
   %122 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %123 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %124 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %123)
-  %NullCheck56 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %122, null
-  br i1 %NullCheck56, label %125, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %122, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %125
 
 ; <label>:125                                     ; preds = %120
   %126 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %122, i32 0, i32 17
@@ -13614,8 +15323,8 @@ entry:
   %127 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %128 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %129 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %128)
-  %NullCheck58 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %127, null
-  br i1 %NullCheck58, label %130, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %127, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %130
 
 ; <label>:130                                     ; preds = %125
   %131 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %127, i32 0, i32 18
@@ -13623,8 +15332,8 @@ entry:
   %132 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %133 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %134 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %133)
-  %NullCheck60 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %132, null
-  br i1 %NullCheck60, label %135, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %132, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %135
 
 ; <label>:135                                     ; preds = %130
   %136 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %132, i32 0, i32 14
@@ -13632,8 +15341,8 @@ entry:
   %137 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %138 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %139 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %138)
-  %NullCheck62 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %137, null
-  br i1 %NullCheck62, label %140, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %137, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %140
 
 ; <label>:140                                     ; preds = %135
   %141 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %137, i32 0, i32 13
@@ -13641,71 +15350,71 @@ entry:
   %142 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %143 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %144 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %143)
-  %NullCheck64 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %142, null
-  br i1 %NullCheck64, label %145, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %142, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %145
 
 ; <label>:145                                     ; preds = %140
   %146 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %142, i32 0, i32 12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %146, %System.String addrspace(1)* %144)
   %147 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %148 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck66 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %148, null
-  br i1 %NullCheck66, label %149, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %148, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %149
 
 ; <label>:149                                     ; preds = %145
   %150 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %148, i32 0, i32 21
   %151 = load i32, i32 addrspace(1)* %150, align 8
-  %NullCheck68 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %147, null
-  br i1 %NullCheck68, label %152, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %147, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %152
 
 ; <label>:152                                     ; preds = %149
   %153 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %147, i32 0, i32 28
   store i32 %151, i32 addrspace(1)* %153
   %154 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %155 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck70 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %155, null
-  br i1 %NullCheck70, label %156, label %ThrowNullRef69
+  %NullCheck69 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %155, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %156
 
 ; <label>:156                                     ; preds = %152
   %157 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %155, i32 0, i32 6
   %158 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %157, align 8
-  %NullCheck72 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %154, null
-  br i1 %NullCheck72, label %159, label %ThrowNullRef71
+  %NullCheck71 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %154, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %159
 
 ; <label>:159                                     ; preds = %156
   %160 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %154, i32 0, i32 15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %160, %System.String addrspace(1)* %158)
   %161 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %162 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck74 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %162, null
-  br i1 %NullCheck74, label %163, label %ThrowNullRef73
+  %NullCheck73 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %162, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %163
 
 ; <label>:163                                     ; preds = %159
   %164 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %162, i32 0, i32 1
   %165 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %164, align 8
-  %NullCheck76 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %161, null
-  br i1 %NullCheck76, label %166, label %ThrowNullRef75
+  %NullCheck75 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %161, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %166
 
 ; <label>:166                                     ; preds = %163
   %167 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %161, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %167, %"System.Int32[]" addrspace(1)* %165)
   %168 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %169 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck78 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %169, null
-  br i1 %NullCheck78, label %170, label %ThrowNullRef77
+  %NullCheck77 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %169, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %170
 
 ; <label>:170                                     ; preds = %166
   %171 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %169, i32 0, i32 7
   %172 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %171, align 8
-  %NullCheck80 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %168, null
-  br i1 %NullCheck80, label %173, label %ThrowNullRef79
+  %NullCheck79 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %168, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %173
 
 ; <label>:173                                     ; preds = %170
   %174 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %168, i32 0, i32 16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %174, %System.String addrspace(1)* %172)
   %175 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck82 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %175, null
-  br i1 %NullCheck82, label %176, label %ThrowNullRef81
+  %NullCheck81 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %175, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %176
 
 ; <label>:176                                     ; preds = %173
   %177 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %175, i32 0, i32 4
@@ -13715,14 +15424,14 @@ entry:
 
 ; <label>:180                                     ; preds = %176
   %181 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck84 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %181, null
-  br i1 %NullCheck84, label %182, label %ThrowNullRef83
+  %NullCheck83 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %181, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %182
 
 ; <label>:182                                     ; preds = %180
   %183 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %181, i32 0, i32 4
   %184 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %183, align 8
-  %NullCheck86 = icmp ne %System.String addrspace(1)* %184, null
-  br i1 %NullCheck86, label %185, label %ThrowNullRef85
+  %NullCheck85 = icmp eq %System.String addrspace(1)* %184, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %185
 
 ; <label>:185                                     ; preds = %182
   %186 = getelementptr inbounds %System.String, %System.String addrspace(1)* %184, i32 0, i32 1
@@ -13733,8 +15442,8 @@ entry:
 ; <label>:189                                     ; preds = %176, %185
   %190 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck98 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %190, null
-  br i1 %NullCheck98, label %192, label %ThrowNullRef97
+  %NullCheck97 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %190, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %192
 
 ; <label>:192                                     ; preds = %189
   %193 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %190, i32 0, i32 4
@@ -13743,8 +15452,8 @@ entry:
 
 ; <label>:194                                     ; preds = %185, %192
   %195 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck88 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %195, null
-  br i1 %NullCheck88, label %196, label %ThrowNullRef87
+  %NullCheck87 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %195, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %196
 
 ; <label>:196                                     ; preds = %194
   %197 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %195, i32 0, i32 9
@@ -13754,14 +15463,14 @@ entry:
 
 ; <label>:200                                     ; preds = %196
   %201 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck90 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %201, null
-  br i1 %NullCheck90, label %202, label %ThrowNullRef89
+  %NullCheck89 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %201, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %202
 
 ; <label>:202                                     ; preds = %200
   %203 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %201, i32 0, i32 9
   %204 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %203, align 8
-  %NullCheck92 = icmp ne %System.String addrspace(1)* %204, null
-  br i1 %NullCheck92, label %205, label %ThrowNullRef91
+  %NullCheck91 = icmp eq %System.String addrspace(1)* %204, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %205
 
 ; <label>:205                                     ; preds = %202
   %206 = getelementptr inbounds %System.String, %System.String addrspace(1)* %204, i32 0, i32 1
@@ -13772,14 +15481,14 @@ entry:
 ; <label>:209                                     ; preds = %196, %205
   %210 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %211 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck94 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %211, null
-  br i1 %NullCheck94, label %212, label %ThrowNullRef93
+  %NullCheck93 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %211, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %212
 
 ; <label>:212                                     ; preds = %209
   %213 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %211, i32 0, i32 6
   %214 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %213, align 8
-  %NullCheck96 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %210, null
-  br i1 %NullCheck96, label %215, label %ThrowNullRef95
+  %NullCheck95 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %210, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %215
 
 ; <label>:215                                     ; preds = %212
   %216 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %210, i32 0, i32 9
@@ -13793,203 +15502,203 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %17
+ThrowNullRef8:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %21
+ThrowNullRef10:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %24
+ThrowNullRef12:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %28
+ThrowNullRef14:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %31
+ThrowNullRef16:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %35
+ThrowNullRef18:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %38
+ThrowNullRef20:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %42
+ThrowNullRef22:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %45
+ThrowNullRef24:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %49
+ThrowNullRef26:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %52
+ThrowNullRef28:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %56
+ThrowNullRef30:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %59
+ThrowNullRef32:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %63
+ThrowNullRef34:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %66
+ThrowNullRef36:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %70
+ThrowNullRef38:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %73
+ThrowNullRef40:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %77
+ThrowNullRef42:                                   ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %80
+ThrowNullRef44:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %84
+ThrowNullRef46:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %101
+ThrowNullRef48:                                   ; preds = %101
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %105
+ThrowNullRef50:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %110
+ThrowNullRef52:                                   ; preds = %110
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %115
+ThrowNullRef54:                                   ; preds = %115
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %120
+ThrowNullRef56:                                   ; preds = %120
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %125
+ThrowNullRef58:                                   ; preds = %125
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %130
+ThrowNullRef60:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %135
+ThrowNullRef62:                                   ; preds = %135
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %140
+ThrowNullRef64:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %145
+ThrowNullRef66:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %149
+ThrowNullRef68:                                   ; preds = %149
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %152
+ThrowNullRef70:                                   ; preds = %152
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %156
+ThrowNullRef72:                                   ; preds = %156
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %159
+ThrowNullRef74:                                   ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %163
+ThrowNullRef76:                                   ; preds = %163
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %166
+ThrowNullRef78:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %170
+ThrowNullRef80:                                   ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %173
+ThrowNullRef82:                                   ; preds = %173
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %180
+ThrowNullRef84:                                   ; preds = %180
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %182
+ThrowNullRef86:                                   ; preds = %182
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %194
+ThrowNullRef88:                                   ; preds = %194
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %200
+ThrowNullRef90:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %202
+ThrowNullRef92:                                   ; preds = %202
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %209
+ThrowNullRef94:                                   ; preds = %209
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %212
+ThrowNullRef96:                                   ; preds = %212
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %189
+ThrowNullRef98:                                   ; preds = %189
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %89
+ThrowNullRef100:                                  ; preds = %89
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14017,8 +15726,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 21
@@ -14031,8 +15740,8 @@ entry:
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 16)
   %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 21
@@ -14041,8 +15750,8 @@ entry:
 
 ; <label>:12                                      ; preds = %1, %10
   %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 21
@@ -14053,11 +15762,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %12
+ThrowNullRef4:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14073,8 +15782,8 @@ entry:
   store i32 %param1, i32* %arg1
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %1 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
@@ -14141,8 +15850,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 33
@@ -14155,8 +15864,8 @@ entry:
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 24)
   %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 33
@@ -14165,8 +15874,8 @@ entry:
 
 ; <label>:12                                      ; preds = %1, %10
   %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 33
@@ -14177,11 +15886,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %12
+ThrowNullRef4:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14194,8 +15903,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 53
@@ -14207,8 +15916,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 116)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 53
@@ -14217,8 +15926,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 53
@@ -14229,11 +15938,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14262,8 +15971,8 @@ entry:
 
 ; <label>:7                                       ; preds = %entry, %4
   %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %7
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 2
@@ -14287,8 +15996,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 54
@@ -14300,8 +16009,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 117)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
@@ -14310,8 +16019,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 54
@@ -14322,11 +16031,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14339,8 +16048,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 27
@@ -14352,8 +16061,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 118)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 27
@@ -14362,8 +16071,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 27
@@ -14374,11 +16083,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14391,8 +16100,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 28
@@ -14404,8 +16113,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 119)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 28
@@ -14414,8 +16123,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 28
@@ -14426,11 +16135,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14443,8 +16152,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 26
@@ -14456,8 +16165,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 107)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 26
@@ -14466,8 +16175,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 26
@@ -14478,11 +16187,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14495,8 +16204,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 25
@@ -14508,8 +16217,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 106)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 25
@@ -14518,8 +16227,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 25
@@ -14530,11 +16239,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14547,8 +16256,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 24
@@ -14560,8 +16269,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 105)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 24
@@ -14570,8 +16279,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 24
@@ -14582,11 +16291,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14611,8 +16320,8 @@ entry:
   %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %3)
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %2
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -14623,15 +16332,15 @@ entry:
 
 ; <label>:8                                       ; preds = %62
   %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 9
   %12 = load i32, i32 addrspace(1)* %11, align 8
   %13 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.IO.StreamWriter addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %13, i32 0, i32 10
@@ -14646,15 +16355,15 @@ entry:
 
 ; <label>:20                                      ; preds = %14, %18
   %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
   %24 = load i32, i32 addrspace(1)* %23, align 8
   %25 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %25, null
-  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.StreamWriter addrspace(1)* %25, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %25, i32 0, i32 9
@@ -14675,36 +16384,36 @@ entry:
   %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %37 = load i32, i32* %loc1
   %38 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.StreamWriter addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %35
   %40 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %38, i32 0, i32 7
   %41 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %40, align 8
   %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
-  br i1 %NullCheck14, label %43, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %39
   %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 9
   %45 = load i32, i32 addrspace(1)* %44, align 8
   %46 = load i32, i32* %loc2
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %36, null
-  br i1 %NullCheck16, label %47, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %36, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %47
 
 ; <label>:47                                      ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %36, i32 %37, %"System.Char[]" addrspace(1)* %41, i32 %45, i32 %46)
   %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
   %51 = load i32, i32 addrspace(1)* %50, align 8
   %52 = load i32, i32* %loc2
   %53 = add i32 %51, %52
-  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
-  br i1 %NullCheck20, label %54, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %54
 
 ; <label>:54                                      ; preds = %49
   %55 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
@@ -14726,8 +16435,8 @@ entry:
 
 ; <label>:65                                      ; preds = %62
   %66 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %66, null
-  br i1 %NullCheck2, label %67, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %66, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %67
 
 ; <label>:67                                      ; preds = %65
   %68 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %66, i32 0, i32 11
@@ -14748,49 +16457,259 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %65
+ThrowNullRef2:                                    ; preds = %65
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %20
+ThrowNullRef8:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %22
+ThrowNullRef10:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %35
+ThrowNullRef12:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %43
+ThrowNullRef16:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %47
+ThrowNullRef18:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method String::CopyTo using LLILCJit
-Failed to read String.CopyTo[loadElemA]
+Successfully read String.CopyTo
+
+define void @String.CopyTo(%System.String addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  %loc1 = alloca i16 addrspace(1)*
+  %loc2 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %1 = icmp ne %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg4
+  %7 = icmp sge i32 %6, 0
+  br i1 %7, label %13, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  unreachable
+
+; <label>:13                                      ; preds = %5
+  %14 = load i32, i32* %arg1
+  %15 = icmp sge i32 %14, 0
+  br i1 %15, label %21, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %18)
+  %20 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %20, %System.String addrspace(1)* %17, %System.String addrspace(1)* %19)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %20) #0
+  unreachable
+
+; <label>:21                                      ; preds = %13
+  %22 = load i32, i32* %arg4
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck, label %ThrowNullRef, label %24
+
+; <label>:24                                      ; preds = %21
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load i32, i32* %arg1
+  %28 = sub i32 %26, %27
+  %29 = icmp sle i32 %22, %28
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34, %System.String addrspace(1)* %31, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %24
+  %36 = load i32, i32* %arg3
+  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %37, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
+
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
+  %40 = load i32, i32 addrspace(1)* %39
+  %41 = zext i32 %40 to i64
+  %42 = trunc i64 %41 to i32
+  %43 = load i32, i32* %arg4
+  %44 = sub i32 %42, %43
+  %45 = icmp sgt i32 %36, %44
+  br i1 %45, label %49, label %46
+
+; <label>:46                                      ; preds = %38
+  %47 = load i32, i32* %arg3
+  %48 = icmp sge i32 %47, 0
+  br i1 %48, label %54, label %49
+
+; <label>:49                                      ; preds = %38, %46
+  %50 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %52 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %51)
+  %53 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53, %System.String addrspace(1)* %50, %System.String addrspace(1)* %52)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53) #0
+  unreachable
+
+; <label>:54                                      ; preds = %46
+  %55 = load i32, i32* %arg4
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %97, label %57
+
+; <label>:57                                      ; preds = %54
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %59
+
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 2
+  %61 = bitcast [0 x i16] addrspace(1)* %60 to i16 addrspace(1)*
+  store i16 addrspace(1)* %61, i16 addrspace(1)** %loc0
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  store %"System.Char[]" addrspace(1)* %62, %"System.Char[]" addrspace(1)** %loc2
+  %63 = icmp eq %"System.Char[]" addrspace(1)* %62, null
+  br i1 %63, label %72, label %64
+
+; <label>:64                                      ; preds = %59
+  %65 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc2
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %65, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %66
+
+; <label>:66                                      ; preds = %64
+  %67 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %65, i32 0, i32 1
+  %68 = load i32, i32 addrspace(1)* %67
+  %69 = zext i32 %68 to i64
+  %70 = trunc i64 %69 to i32
+  %71 = icmp ne i32 %70, 0
+  br i1 %71, label %73, label %72
+
+; <label>:72                                      ; preds = %59, %66
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  br label %81
+
+; <label>:73                                      ; preds = %66
+  %74 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc2
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %74, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %75
+
+; <label>:75                                      ; preds = %73
+  %76 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %74, i32 0, i32 1
+  %77 = load i32, i32 addrspace(1)* %76
+  %78 = zext i32 %77 to i64
+  %BoundsCheck = icmp uge i64 0, %78
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %79
+
+; <label>:79                                      ; preds = %75
+  %80 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %74, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %80, i16 addrspace(1)** %loc1
+  br label %81
+
+; <label>:81                                      ; preds = %72, %79
+  %82 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %83 = ptrtoint i16 addrspace(1)* %82 to i64
+  %84 = load i32, i32* %arg3
+  %85 = sext i32 %84 to i64
+  %86 = mul i64 %85, 2
+  %87 = add i64 %83, %86
+  %88 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %89 = ptrtoint i16 addrspace(1)* %88 to i64
+  %90 = load i32, i32* %arg1
+  %91 = sext i32 %90 to i64
+  %92 = mul i64 %91, 2
+  %93 = add i64 %89, %92
+  %94 = load i32, i32* %arg4
+  %95 = inttoptr i64 %87 to i16*
+  %96 = inttoptr i64 %93 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %95, i16* %96, i32 %94)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  br label %97
+
+; <label>:97                                      ; preds = %54, %81
+  ret void
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
 Successfully read ConsoleEncoding.GetPreamble
 
@@ -14827,7 +16746,365 @@ entry:
 }
 
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[loadElemA]
+Successfully read EncoderNLS.GetBytes
+
+define i32 @EncoderNLS.GetBytes(%System.Text.EncoderNLS addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3, %"System.Byte[]" addrspace(1)* %param4, i32 %param5, i8 %param6) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %arg4 = alloca %"System.Byte[]" addrspace(1)*
+  %arg5 = alloca i32
+  %arg6 = alloca i8
+  %loc0 = alloca i32
+  %loc1 = alloca i16 addrspace(1)*
+  %loc2 = alloca i8 addrspace(1)*
+  %loc3 = alloca i32
+  %loc4 = alloca %"System.Char[]" addrspace(1)*
+  %loc5 = alloca %"System.Byte[]" addrspace(1)*
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  store %"System.Byte[]" addrspace(1)* %param4, %"System.Byte[]" addrspace(1)** %arg4
+  store i32 %param5, i32* %arg5
+  store i8 %param6, i8* %arg6
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %1 = icmp eq %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %17, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %7 = icmp eq %"System.Char[]" addrspace(1)* %6, null
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %12
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %12
+
+; <label>:12                                      ; preds = %8, %10
+  %13 = phi %System.String addrspace(1)* [ %9, %8 ], [ %11, %10 ]
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %14)
+  %16 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16, %System.String addrspace(1)* %13, %System.String addrspace(1)* %15)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16) #0
+  unreachable
+
+; <label>:17                                      ; preds = %2
+  %18 = load i32, i32* %arg2
+  %19 = icmp slt i32 %18, 0
+  br i1 %19, label %23, label %20
+
+; <label>:20                                      ; preds = %17
+  %21 = load i32, i32* %arg3
+  %22 = icmp sge i32 %21, 0
+  br i1 %22, label %35, label %23
+
+; <label>:23                                      ; preds = %17, %20
+  %24 = load i32, i32* %arg2
+  %25 = icmp slt i32 %24, 0
+  br i1 %25, label %28, label %26
+
+; <label>:26                                      ; preds = %23
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %30
+
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %30
+
+; <label>:30                                      ; preds = %26, %28
+  %31 = phi %System.String addrspace(1)* [ %27, %26 ], [ %29, %28 ]
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34, %System.String addrspace(1)* %31, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %20
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck, label %ThrowNullRef, label %37
+
+; <label>:37                                      ; preds = %35
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = load i32, i32* %arg2
+  %43 = sub i32 %41, %42
+  %44 = load i32, i32* %arg3
+  %45 = icmp sge i32 %43, %44
+  br i1 %45, label %51, label %46
+
+; <label>:46                                      ; preds = %37
+  %47 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %48 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %49 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %48)
+  %50 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %50, %System.String addrspace(1)* %47, %System.String addrspace(1)* %49)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %50) #0
+  unreachable
+
+; <label>:51                                      ; preds = %37
+  %52 = load i32, i32* %arg5
+  %53 = icmp slt i32 %52, 0
+  br i1 %53, label %63, label %54
+
+; <label>:54                                      ; preds = %51
+  %55 = load i32, i32* %arg5
+  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck1 = icmp eq %"System.Byte[]" addrspace(1)* %56, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %57
+
+; <label>:57                                      ; preds = %54
+  %58 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = zext i32 %59 to i64
+  %61 = trunc i64 %60 to i32
+  %62 = icmp sle i32 %55, %61
+  br i1 %62, label %68, label %63
+
+; <label>:63                                      ; preds = %51, %57
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %66 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %65)
+  %67 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %67, %System.String addrspace(1)* %64, %System.String addrspace(1)* %66)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %67) #0
+  unreachable
+
+; <label>:68                                      ; preds = %57
+  %69 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %69, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %69, i32 0, i32 1
+  %72 = load i32, i32 addrspace(1)* %71
+  %73 = zext i32 %72 to i64
+  %74 = trunc i64 %73 to i32
+  %75 = icmp ne i32 %74, 0
+  br i1 %75, label %78, label %76
+
+; <label>:76                                      ; preds = %70
+  %77 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1)
+  store %"System.Char[]" addrspace(1)* %77, %"System.Char[]" addrspace(1)** %arg1
+  br label %78
+
+; <label>:78                                      ; preds = %70, %76
+  %79 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck5 = icmp eq %"System.Byte[]" addrspace(1)* %79, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %80
+
+; <label>:80                                      ; preds = %78
+  %81 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %79, i32 0, i32 1
+  %82 = load i32, i32 addrspace(1)* %81
+  %83 = zext i32 %82 to i64
+  %84 = trunc i64 %83 to i32
+  %85 = load i32, i32* %arg5
+  %86 = sub i32 %84, %85
+  store i32 %86, i32* %loc0
+  %87 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck7 = icmp eq %"System.Byte[]" addrspace(1)* %87, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %88
+
+; <label>:88                                      ; preds = %80
+  %89 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %87, i32 0, i32 1
+  %90 = load i32, i32 addrspace(1)* %89
+  %91 = zext i32 %90 to i64
+  %92 = trunc i64 %91 to i32
+  %93 = icmp ne i32 %92, 0
+  br i1 %93, label %96, label %94
+
+; <label>:94                                      ; preds = %88
+  %95 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1)
+  store %"System.Byte[]" addrspace(1)* %95, %"System.Byte[]" addrspace(1)** %arg4
+  br label %96
+
+; <label>:96                                      ; preds = %88, %94
+  %97 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  store %"System.Char[]" addrspace(1)* %97, %"System.Char[]" addrspace(1)** %loc4
+  %98 = icmp eq %"System.Char[]" addrspace(1)* %97, null
+  br i1 %98, label %107, label %99
+
+; <label>:99                                      ; preds = %96
+  %100 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc4
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %100, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %101
+
+; <label>:101                                     ; preds = %99
+  %102 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %100, i32 0, i32 1
+  %103 = load i32, i32 addrspace(1)* %102
+  %104 = zext i32 %103 to i64
+  %105 = trunc i64 %104 to i32
+  %106 = icmp ne i32 %105, 0
+  br i1 %106, label %108, label %107
+
+; <label>:107                                     ; preds = %96, %101
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  br label %116
+
+; <label>:108                                     ; preds = %101
+  %109 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc4
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %109, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %110
+
+; <label>:110                                     ; preds = %108
+  %111 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %109, i32 0, i32 1
+  %112 = load i32, i32 addrspace(1)* %111
+  %113 = zext i32 %112 to i64
+  %BoundsCheck = icmp uge i64 0, %113
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %114
+
+; <label>:114                                     ; preds = %110
+  %115 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %109, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %115, i16 addrspace(1)** %loc1
+  br label %116
+
+; <label>:116                                     ; preds = %107, %114
+  %117 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  store %"System.Byte[]" addrspace(1)* %117, %"System.Byte[]" addrspace(1)** %loc5
+  %118 = icmp eq %"System.Byte[]" addrspace(1)* %117, null
+  br i1 %118, label %127, label %119
+
+; <label>:119                                     ; preds = %116
+  %120 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc5
+  %NullCheck13 = icmp eq %"System.Byte[]" addrspace(1)* %120, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %121
+
+; <label>:121                                     ; preds = %119
+  %122 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %120, i32 0, i32 1
+  %123 = load i32, i32 addrspace(1)* %122
+  %124 = zext i32 %123 to i64
+  %125 = trunc i64 %124 to i32
+  %126 = icmp ne i32 %125, 0
+  br i1 %126, label %128, label %127
+
+; <label>:127                                     ; preds = %116, %121
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc2
+  br label %136
+
+; <label>:128                                     ; preds = %121
+  %129 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc5
+  %NullCheck15 = icmp eq %"System.Byte[]" addrspace(1)* %129, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %130
+
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %129, i32 0, i32 1
+  %132 = load i32, i32 addrspace(1)* %131
+  %133 = zext i32 %132 to i64
+  %BoundsCheck17 = icmp uge i64 0, %133
+  br i1 %BoundsCheck17, label %ThrowIndexOutOfRange18, label %134
+
+; <label>:134                                     ; preds = %130
+  %135 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %129, i32 0, i32 3, i32 0
+  store i8 addrspace(1)* %135, i8 addrspace(1)** %loc2
+  br label %136
+
+; <label>:136                                     ; preds = %127, %134
+  %137 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %138 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %139 = ptrtoint i16 addrspace(1)* %138 to i64
+  %140 = load i32, i32* %arg2
+  %141 = sext i32 %140 to i64
+  %142 = mul i64 %141, 2
+  %143 = add i64 %139, %142
+  %144 = load i32, i32* %arg3
+  %145 = load i8 addrspace(1)*, i8 addrspace(1)** %loc2
+  %146 = ptrtoint i8 addrspace(1)* %145 to i64
+  %147 = load i32, i32* %arg5
+  %148 = sext i32 %147 to i64
+  %149 = add i64 %146, %148
+  %150 = load i32, i32* %loc0
+  %151 = load i8, i8* %arg6
+  %152 = zext i8 %151 to i32
+  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i64 addrspace(1)*
+  %NullCheck19 = icmp eq i64 addrspace(1)* %153, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %154
+
+; <label>:154                                     ; preds = %136
+  %155 = load i64, i64 addrspace(1)* %153
+  %156 = add i64 %155, 72
+  %157 = inttoptr i64 %156 to i64*
+  %158 = load i64, i64* %157
+  %159 = add i64 %158, 0
+  %160 = inttoptr i64 %159 to i64*
+  %161 = load i64, i64* %160
+  %162 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to %System.Text.Encoder addrspace(1)*
+  %163 = inttoptr i64 %143 to i16*
+  %164 = inttoptr i64 %149 to i8*
+  %165 = trunc i32 %152 to i8
+  %166 = inttoptr i64 %161 to i32 (%System.Text.Encoder addrspace(1)*, i16*, i32, i8*, i32, i8)*
+  %167 = call i32 %166(%System.Text.Encoder addrspace(1)* %162, i16* %163, i32 %144, i8* %164, i32 %150, i8 %165)
+  store i32 %167, i32* %loc3
+  br label %168
+
+; <label>:168                                     ; preds = %154
+  %169 = load i32, i32* %loc3
+  ret i32 %169
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %110
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %119
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange18:                           ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
 Successfully read EncoderNLS.GetBytes
 
@@ -14916,22 +17193,22 @@ entry:
   %40 = load i8, i8* %arg5
   %41 = zext i8 %40 to i32
   %42 = trunc i32 %41 to i8
-  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %39, null
-  br i1 %NullCheck, label %43, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderNLS addrspace(1)* %39, null
+  br i1 %NullCheck, label %ThrowNullRef, label %43
 
 ; <label>:43                                      ; preds = %38
   %44 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
   store i8 %42, i8 addrspace(1)* %44
   %45 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %45, null
-  br i1 %NullCheck2, label %46, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.EncoderNLS addrspace(1)* %45, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %46
 
 ; <label>:46                                      ; preds = %43
   %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %45, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %47
   %48 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.EncoderNLS addrspace(1)* %48, null
-  br i1 %NullCheck4, label %49, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.EncoderNLS addrspace(1)* %48, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %49
 
 ; <label>:49                                      ; preds = %46
   %50 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %48, i32 0, i32 3
@@ -14942,8 +17219,8 @@ entry:
   %55 = load i32, i32* %arg4
   %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck6, label %58, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
   %59 = load i64, i64 addrspace(1)* %57
@@ -14961,15 +17238,15 @@ ThrowNullRef:                                     ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %43
+ThrowNullRef2:                                    ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %46
+ThrowNullRef4:                                    ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %49
+ThrowNullRef6:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14997,8 +17274,8 @@ entry:
   %4 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0 to %System.IO.ConsoleStream addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*)(%System.IO.ConsoleStream addrspace(1)* %4, %"System.Byte[]" addrspace(1)* %1, i32 %2, i32 %3)
   %5 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
@@ -15083,8 +17360,8 @@ entry:
 
 ; <label>:22                                      ; preds = %8
   %23 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %23, null
-  br i1 %NullCheck, label %24, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Byte[]" addrspace(1)* %23, null
+  br i1 %NullCheck, label %ThrowNullRef, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
@@ -15106,8 +17383,8 @@ entry:
 
 ; <label>:36                                      ; preds = %24
   %37 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %37, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.ConsoleStream addrspace(1)* %37, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %37, i32 0, i32 4
@@ -15128,13 +17405,138 @@ ThrowNullRef:                                     ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %36
+ThrowNullRef2:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
-Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
+Successfully read WindowsConsoleStream.WriteFileNative
+
+define i32 @WindowsConsoleStream.WriteFileNative(i64 %param0, %"System.Byte[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i64
+  %arg1 = alloca %"System.Byte[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i8 addrspace(1)*
+  %loc2 = alloca %"System.Byte[]" addrspace(1)*
+  %loc3 = alloca i32
+  store i64 %param0, i64* %arg0
+  store %"System.Byte[]" addrspace(1)* %param1, %"System.Byte[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Byte[]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = zext i32 %3 to i64
+  %5 = icmp ne i64 %4, 0
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %1
+  ret i32 0
+
+; <label>:7                                       ; preds = %1
+  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  store %"System.Byte[]" addrspace(1)* %8, %"System.Byte[]" addrspace(1)** %loc2
+  %9 = icmp eq %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %9, label %18, label %10
+
+; <label>:10                                      ; preds = %7
+  %11 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc2
+  %NullCheck1 = icmp eq %"System.Byte[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %11, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp ne i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %7, %12
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc1
+  br label %27
+
+; <label>:19                                      ; preds = %12
+  %20 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc2
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %20, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %BoundsCheck = icmp uge i64 0, %24
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %25
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %20, i32 0, i32 3, i32 0
+  store i8 addrspace(1)* %26, i8 addrspace(1)** %loc1
+  br label %27
+
+; <label>:27                                      ; preds = %18, %25
+  %28 = load i64, i64* %arg0
+  %29 = load i8 addrspace(1)*, i8 addrspace(1)** %loc1
+  %30 = ptrtoint i8 addrspace(1)* %29 to i64
+  %31 = load i32, i32* %arg2
+  %32 = sext i32 %31 to i64
+  %33 = add i64 %30, %32
+  %34 = load i32, i32* %arg3
+  %35 = addrspacecast i32* %loc3 to i32 addrspace(1)*
+  %36 = inttoptr i64 %33 to i8*
+  %37 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i8*, i32, i32 addrspace(1)*, i64)*)(i64 %28, i8* %36, i32 %34, i32 addrspace(1)* %35, i64 0)
+  %38 = icmp ugt i32 %37, 0
+  %39 = sext i1 %38 to i32
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc1
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %42, label %41
+
+; <label>:41                                      ; preds = %27
+  ret i32 0
+
+; <label>:42                                      ; preds = %27
+  %43 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  store i32 %43, i32* %loc0
+  %44 = load i32, i32* %loc0
+  %45 = icmp eq i32 %44, 232
+  br i1 %45, label %49, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = load i32, i32* %loc0
+  %48 = icmp ne i32 %47, 109
+  br i1 %48, label %50, label %49
+
+; <label>:49                                      ; preds = %42, %46
+  ret i32 0
+
+; <label>:50                                      ; preds = %46
+  %51 = load i32, i32* %loc0
+  ret i32 %51
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
 Successfully read WindowsConsoleStream.Flush
 
@@ -15143,8 +17545,8 @@ entry:
   %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
   store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
@@ -15179,8 +17581,8 @@ entry:
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
   %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load i64, i64 addrspace(1)* %1
@@ -15219,15 +17621,15 @@ entry:
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.TextWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
   %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %3, align 8
   %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
   %7 = load i64, i64 addrspace(1)* %5
@@ -15245,7 +17647,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -15274,8 +17676,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %4)
   store i32 0, i32* %loc0
   %5 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Char[]" addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
@@ -15287,15 +17689,15 @@ entry:
 
 ; <label>:11                                      ; preds = %69
   %12 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %12, i32 0, i32 9
   %15 = load i32, i32 addrspace(1)* %14, align 8
   %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.IO.StreamWriter addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %16, i32 0, i32 10
@@ -15310,15 +17712,15 @@ entry:
 
 ; <label>:23                                      ; preds = %17, %21
   %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %24, null
-  br i1 %NullCheck8, label %25, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %24, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 10
   %27 = load i32, i32 addrspace(1)* %26, align 8
   %28 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %28, null
-  br i1 %NullCheck10, label %29, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.StreamWriter addrspace(1)* %28, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %28, i32 0, i32 9
@@ -15340,15 +17742,15 @@ entry:
   %40 = load i32, i32* %loc0
   %41 = mul i32 %40, 2
   %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
-  br i1 %NullCheck12, label %43, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %43
 
 ; <label>:43                                      ; preds = %38
   %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 7
   %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %44, align 8
   %46 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %46, null
-  br i1 %NullCheck14, label %47, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.IO.StreamWriter addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %47
 
 ; <label>:47                                      ; preds = %43
   %48 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %46, i32 0, i32 9
@@ -15360,16 +17762,16 @@ entry:
   %54 = bitcast %"System.Char[]" addrspace(1)* %45 to %System.Array addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %53, i32 %41, %System.Array addrspace(1)* %54, i32 %50, i32 %52)
   %55 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
-  br i1 %NullCheck16, label %56, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %56
 
 ; <label>:56                                      ; preds = %47
   %57 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
   %58 = load i32, i32 addrspace(1)* %57, align 8
   %59 = load i32, i32* %loc2
   %60 = add i32 %58, %59
-  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
-  br i1 %NullCheck18, label %61, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %61
 
 ; <label>:61                                      ; preds = %56
   %62 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
@@ -15391,8 +17793,8 @@ entry:
 
 ; <label>:72                                      ; preds = %69
   %73 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %73, null
-  br i1 %NullCheck2, label %74, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %73, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %74
 
 ; <label>:74                                      ; preds = %72
   %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %73, i32 0, i32 11
@@ -15413,39 +17815,39 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %72
+ThrowNullRef2:                                    ; preds = %72
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %23
+ThrowNullRef8:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef10:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %43
+ThrowNullRef14:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %47
+ThrowNullRef16:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %56
+ThrowNullRef18:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPArea.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPArea.error.txt
@@ -25,8 +25,8 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
@@ -40,8 +40,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
   %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
@@ -75,7 +75,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -90,8 +90,8 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %NullCheck = icmp ne i8 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = load i8, i8 addrspace(1)* %0, align 8
@@ -125,8 +125,8 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
@@ -159,8 +159,8 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -184,8 +184,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
   store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
@@ -195,8 +195,8 @@ entry:
 ; <label>:4                                       ; preds = %1
   %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
   %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
@@ -206,8 +206,8 @@ entry:
   %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
@@ -221,14 +221,14 @@ entry:
 
 ; <label>:17                                      ; preds = %14
   %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
   %21 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
@@ -238,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -249,8 +249,8 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
@@ -261,27 +261,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %30
+ThrowNullRef10:                                   ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -301,7 +301,89 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
-Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
+Successfully read AppDomainSetup.GetUnsecureApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.GetUnsecureApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %NullCheck = icmp eq %"System.String[]" addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %BoundsCheck = icmp uge i64 0, %5
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %6
+
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 3, i32 0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
+  ret %System.String addrspace(1)* %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_Value using LLILCJit
+Successfully read AppDomainSetup.get_Value
+
+define %"System.String[]" addrspace(1)* @AppDomainSetup.get_Value(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.String[]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 18)
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.String[]" addrspace(1)* addrspace(1)*, %"System.String[]" addrspace(1)*)*)(%"System.String[]" addrspace(1)* addrspace(1)* %9, %"System.String[]" addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %11, i32 0, i32 1
+  %14 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %13, align 8
+  ret %"System.String[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -319,8 +401,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -368,16 +450,16 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
   %5 = load i32, i32 addrspace(1)* %4
   %6 = sub i32 %5, 1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -389,7 +471,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -421,8 +503,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
@@ -456,8 +538,8 @@ entry:
 ; <label>:27                                      ; preds = %19
   %28 = load i32, i32* %arg1
   %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
-  br i1 %NullCheck2, label %30, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %29, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %30
 
 ; <label>:30                                      ; preds = %27
   %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
@@ -493,8 +575,8 @@ entry:
 ; <label>:49                                      ; preds = %46
   %50 = load i32, i32* %arg2
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck4, label %52, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
@@ -517,11 +599,11 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %27
+ThrowNullRef2:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %49
+ThrowNullRef4:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -544,16 +626,16 @@ entry:
   %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %0)
   store %System.String addrspace(1)* %1, %System.String addrspace(1)** %loc0
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 2
   %5 = bitcast [0 x i16] addrspace(1)* %4 to i16 addrspace(1)*
   store i16 addrspace(1)* %5, i16 addrspace(1)** %loc1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %3
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2
@@ -580,7 +662,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -691,15 +773,15 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %NullCheck132 = icmp ne i8* %21, null
-  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+  %NullCheck131 = icmp eq i8* %21, null
+  br i1 %NullCheck131, label %ThrowNullRef132, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = load i8, i8* %21, align 8
   %24 = zext i8 %23 to i32
   %25 = trunc i32 %24 to i8
-  %NullCheck134 = icmp ne i8* %20, null
-  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+  %NullCheck133 = icmp eq i8* %20, null
+  br i1 %NullCheck133, label %ThrowNullRef134, label %26
 
 ; <label>:26                                      ; preds = %22
   store i8 %25, i8* %20, align 8
@@ -709,16 +791,16 @@ entry:
   %28 = load i8*, i8** %arg0
   %29 = load i8*, i8** %arg1
   %30 = bitcast i8* %29 to i16*
-  %NullCheck128 = icmp ne i16* %30, null
-  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+  %NullCheck127 = icmp eq i16* %30, null
+  br i1 %NullCheck127, label %ThrowNullRef128, label %31
 
 ; <label>:31                                      ; preds = %27
   %32 = load i16, i16* %30, align 8
   %33 = sext i16 %32 to i32
   %34 = bitcast i8* %28 to i16*
   %35 = trunc i32 %33 to i16
-  %NullCheck130 = icmp ne i16* %34, null
-  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+  %NullCheck129 = icmp eq i16* %34, null
+  br i1 %NullCheck129, label %ThrowNullRef130, label %36
 
 ; <label>:36                                      ; preds = %31
   store i16 %35, i16* %34, align 8
@@ -728,16 +810,16 @@ entry:
   %38 = load i8*, i8** %arg0
   %39 = load i8*, i8** %arg1
   %40 = bitcast i8* %39 to i16*
-  %NullCheck120 = icmp ne i16* %40, null
-  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+  %NullCheck119 = icmp eq i16* %40, null
+  br i1 %NullCheck119, label %ThrowNullRef120, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i16, i16* %40, align 8
   %43 = sext i16 %42 to i32
   %44 = bitcast i8* %38 to i16*
   %45 = trunc i32 %43 to i16
-  %NullCheck122 = icmp ne i16* %44, null
-  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+  %NullCheck121 = icmp eq i16* %44, null
+  br i1 %NullCheck121, label %ThrowNullRef122, label %46
 
 ; <label>:46                                      ; preds = %41
   store i16 %45, i16* %44, align 8
@@ -745,15 +827,15 @@ entry:
   %48 = getelementptr inbounds i8, i8* %47, i64 2
   %49 = load i8*, i8** %arg1
   %50 = getelementptr inbounds i8, i8* %49, i64 2
-  %NullCheck124 = icmp ne i8* %50, null
-  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+  %NullCheck123 = icmp eq i8* %50, null
+  br i1 %NullCheck123, label %ThrowNullRef124, label %51
 
 ; <label>:51                                      ; preds = %46
   %52 = load i8, i8* %50, align 8
   %53 = zext i8 %52 to i32
   %54 = trunc i32 %53 to i8
-  %NullCheck126 = icmp ne i8* %48, null
-  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+  %NullCheck125 = icmp eq i8* %48, null
+  br i1 %NullCheck125, label %ThrowNullRef126, label %55
 
 ; <label>:55                                      ; preds = %51
   store i8 %54, i8* %48, align 8
@@ -763,14 +845,14 @@ entry:
   %57 = load i8*, i8** %arg0
   %58 = load i8*, i8** %arg1
   %59 = bitcast i8* %58 to i32*
-  %NullCheck116 = icmp ne i32* %59, null
-  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+  %NullCheck115 = icmp eq i32* %59, null
+  br i1 %NullCheck115, label %ThrowNullRef116, label %60
 
 ; <label>:60                                      ; preds = %56
   %61 = load i32, i32* %59, align 8
   %62 = bitcast i8* %57 to i32*
-  %NullCheck118 = icmp ne i32* %62, null
-  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+  %NullCheck117 = icmp eq i32* %62, null
+  br i1 %NullCheck117, label %ThrowNullRef118, label %63
 
 ; <label>:63                                      ; preds = %60
   store i32 %61, i32* %62, align 8
@@ -780,14 +862,14 @@ entry:
   %65 = load i8*, i8** %arg0
   %66 = load i8*, i8** %arg1
   %67 = bitcast i8* %66 to i32*
-  %NullCheck108 = icmp ne i32* %67, null
-  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+  %NullCheck107 = icmp eq i32* %67, null
+  br i1 %NullCheck107, label %ThrowNullRef108, label %68
 
 ; <label>:68                                      ; preds = %64
   %69 = load i32, i32* %67, align 8
   %70 = bitcast i8* %65 to i32*
-  %NullCheck110 = icmp ne i32* %70, null
-  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+  %NullCheck109 = icmp eq i32* %70, null
+  br i1 %NullCheck109, label %ThrowNullRef110, label %71
 
 ; <label>:71                                      ; preds = %68
   store i32 %69, i32* %70, align 8
@@ -795,15 +877,15 @@ entry:
   %73 = getelementptr inbounds i8, i8* %72, i64 4
   %74 = load i8*, i8** %arg1
   %75 = getelementptr inbounds i8, i8* %74, i64 4
-  %NullCheck112 = icmp ne i8* %75, null
-  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+  %NullCheck111 = icmp eq i8* %75, null
+  br i1 %NullCheck111, label %ThrowNullRef112, label %76
 
 ; <label>:76                                      ; preds = %71
   %77 = load i8, i8* %75, align 8
   %78 = zext i8 %77 to i32
   %79 = trunc i32 %78 to i8
-  %NullCheck114 = icmp ne i8* %73, null
-  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+  %NullCheck113 = icmp eq i8* %73, null
+  br i1 %NullCheck113, label %ThrowNullRef114, label %80
 
 ; <label>:80                                      ; preds = %76
   store i8 %79, i8* %73, align 8
@@ -813,14 +895,14 @@ entry:
   %82 = load i8*, i8** %arg0
   %83 = load i8*, i8** %arg1
   %84 = bitcast i8* %83 to i32*
-  %NullCheck100 = icmp ne i32* %84, null
-  br i1 %NullCheck100, label %85, label %ThrowNullRef99
+  %NullCheck99 = icmp eq i32* %84, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %85
 
 ; <label>:85                                      ; preds = %81
   %86 = load i32, i32* %84, align 8
   %87 = bitcast i8* %82 to i32*
-  %NullCheck102 = icmp ne i32* %87, null
-  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+  %NullCheck101 = icmp eq i32* %87, null
+  br i1 %NullCheck101, label %ThrowNullRef102, label %88
 
 ; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
@@ -829,16 +911,16 @@ entry:
   %91 = load i8*, i8** %arg1
   %92 = getelementptr inbounds i8, i8* %91, i64 4
   %93 = bitcast i8* %92 to i16*
-  %NullCheck104 = icmp ne i16* %93, null
-  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+  %NullCheck103 = icmp eq i16* %93, null
+  br i1 %NullCheck103, label %ThrowNullRef104, label %94
 
 ; <label>:94                                      ; preds = %88
   %95 = load i16, i16* %93, align 8
   %96 = sext i16 %95 to i32
   %97 = bitcast i8* %90 to i16*
   %98 = trunc i32 %96 to i16
-  %NullCheck106 = icmp ne i16* %97, null
-  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+  %NullCheck105 = icmp eq i16* %97, null
+  br i1 %NullCheck105, label %ThrowNullRef106, label %99
 
 ; <label>:99                                      ; preds = %94
   store i16 %98, i16* %97, align 8
@@ -848,14 +930,14 @@ entry:
   %101 = load i8*, i8** %arg0
   %102 = load i8*, i8** %arg1
   %103 = bitcast i8* %102 to i32*
-  %NullCheck88 = icmp ne i32* %103, null
-  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+  %NullCheck87 = icmp eq i32* %103, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %104
 
 ; <label>:104                                     ; preds = %100
   %105 = load i32, i32* %103, align 8
   %106 = bitcast i8* %101 to i32*
-  %NullCheck90 = icmp ne i32* %106, null
-  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+  %NullCheck89 = icmp eq i32* %106, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %107
 
 ; <label>:107                                     ; preds = %104
   store i32 %105, i32* %106, align 8
@@ -864,16 +946,16 @@ entry:
   %110 = load i8*, i8** %arg1
   %111 = getelementptr inbounds i8, i8* %110, i64 4
   %112 = bitcast i8* %111 to i16*
-  %NullCheck92 = icmp ne i16* %112, null
-  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+  %NullCheck91 = icmp eq i16* %112, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %113
 
 ; <label>:113                                     ; preds = %107
   %114 = load i16, i16* %112, align 8
   %115 = sext i16 %114 to i32
   %116 = bitcast i8* %109 to i16*
   %117 = trunc i32 %115 to i16
-  %NullCheck94 = icmp ne i16* %116, null
-  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+  %NullCheck93 = icmp eq i16* %116, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %118
 
 ; <label>:118                                     ; preds = %113
   store i16 %117, i16* %116, align 8
@@ -881,15 +963,15 @@ entry:
   %120 = getelementptr inbounds i8, i8* %119, i64 6
   %121 = load i8*, i8** %arg1
   %122 = getelementptr inbounds i8, i8* %121, i64 6
-  %NullCheck96 = icmp ne i8* %122, null
-  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+  %NullCheck95 = icmp eq i8* %122, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %123
 
 ; <label>:123                                     ; preds = %118
   %124 = load i8, i8* %122, align 8
   %125 = zext i8 %124 to i32
   %126 = trunc i32 %125 to i8
-  %NullCheck98 = icmp ne i8* %120, null
-  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+  %NullCheck97 = icmp eq i8* %120, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %127
 
 ; <label>:127                                     ; preds = %123
   store i8 %126, i8* %120, align 8
@@ -899,14 +981,14 @@ entry:
   %129 = load i8*, i8** %arg0
   %130 = load i8*, i8** %arg1
   %131 = bitcast i8* %130 to i64*
-  %NullCheck84 = icmp ne i64* %131, null
-  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+  %NullCheck83 = icmp eq i64* %131, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %132
 
 ; <label>:132                                     ; preds = %128
   %133 = load i64, i64* %131, align 8
   %134 = bitcast i8* %129 to i64*
-  %NullCheck86 = icmp ne i64* %134, null
-  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+  %NullCheck85 = icmp eq i64* %134, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %135
 
 ; <label>:135                                     ; preds = %132
   store i64 %133, i64* %134, align 8
@@ -916,14 +998,14 @@ entry:
   %137 = load i8*, i8** %arg0
   %138 = load i8*, i8** %arg1
   %139 = bitcast i8* %138 to i64*
-  %NullCheck76 = icmp ne i64* %139, null
-  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+  %NullCheck75 = icmp eq i64* %139, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %140
 
 ; <label>:140                                     ; preds = %136
   %141 = load i64, i64* %139, align 8
   %142 = bitcast i8* %137 to i64*
-  %NullCheck78 = icmp ne i64* %142, null
-  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+  %NullCheck77 = icmp eq i64* %142, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %143
 
 ; <label>:143                                     ; preds = %140
   store i64 %141, i64* %142, align 8
@@ -931,15 +1013,15 @@ entry:
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %NullCheck80 = icmp ne i8* %147, null
-  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+  %NullCheck79 = icmp eq i8* %147, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %148
 
 ; <label>:148                                     ; preds = %143
   %149 = load i8, i8* %147, align 8
   %150 = zext i8 %149 to i32
   %151 = trunc i32 %150 to i8
-  %NullCheck82 = icmp ne i8* %145, null
-  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+  %NullCheck81 = icmp eq i8* %145, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %152
 
 ; <label>:152                                     ; preds = %148
   store i8 %151, i8* %145, align 8
@@ -949,14 +1031,14 @@ entry:
   %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
   %156 = bitcast i8* %155 to i64*
-  %NullCheck68 = icmp ne i64* %156, null
-  br i1 %NullCheck68, label %157, label %ThrowNullRef67
+  %NullCheck67 = icmp eq i64* %156, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %157
 
 ; <label>:157                                     ; preds = %153
   %158 = load i64, i64* %156, align 8
   %159 = bitcast i8* %154 to i64*
-  %NullCheck70 = icmp ne i64* %159, null
-  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+  %NullCheck69 = icmp eq i64* %159, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %160
 
 ; <label>:160                                     ; preds = %157
   store i64 %158, i64* %159, align 8
@@ -965,16 +1047,16 @@ entry:
   %163 = load i8*, i8** %arg1
   %164 = getelementptr inbounds i8, i8* %163, i64 8
   %165 = bitcast i8* %164 to i16*
-  %NullCheck72 = icmp ne i16* %165, null
-  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+  %NullCheck71 = icmp eq i16* %165, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %166
 
 ; <label>:166                                     ; preds = %160
   %167 = load i16, i16* %165, align 8
   %168 = sext i16 %167 to i32
   %169 = bitcast i8* %162 to i16*
   %170 = trunc i32 %168 to i16
-  %NullCheck74 = icmp ne i16* %169, null
-  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+  %NullCheck73 = icmp eq i16* %169, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %171
 
 ; <label>:171                                     ; preds = %166
   store i16 %170, i16* %169, align 8
@@ -984,14 +1066,14 @@ entry:
   %173 = load i8*, i8** %arg0
   %174 = load i8*, i8** %arg1
   %175 = bitcast i8* %174 to i64*
-  %NullCheck56 = icmp ne i64* %175, null
-  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+  %NullCheck55 = icmp eq i64* %175, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %176
 
 ; <label>:176                                     ; preds = %172
   %177 = load i64, i64* %175, align 8
   %178 = bitcast i8* %173 to i64*
-  %NullCheck58 = icmp ne i64* %178, null
-  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+  %NullCheck57 = icmp eq i64* %178, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %179
 
 ; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
@@ -1000,16 +1082,16 @@ entry:
   %182 = load i8*, i8** %arg1
   %183 = getelementptr inbounds i8, i8* %182, i64 8
   %184 = bitcast i8* %183 to i16*
-  %NullCheck60 = icmp ne i16* %184, null
-  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+  %NullCheck59 = icmp eq i16* %184, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %185
 
 ; <label>:185                                     ; preds = %179
   %186 = load i16, i16* %184, align 8
   %187 = sext i16 %186 to i32
   %188 = bitcast i8* %181 to i16*
   %189 = trunc i32 %187 to i16
-  %NullCheck62 = icmp ne i16* %188, null
-  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+  %NullCheck61 = icmp eq i16* %188, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %190
 
 ; <label>:190                                     ; preds = %185
   store i16 %189, i16* %188, align 8
@@ -1017,15 +1099,15 @@ entry:
   %192 = getelementptr inbounds i8, i8* %191, i64 10
   %193 = load i8*, i8** %arg1
   %194 = getelementptr inbounds i8, i8* %193, i64 10
-  %NullCheck64 = icmp ne i8* %194, null
-  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+  %NullCheck63 = icmp eq i8* %194, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %195
 
 ; <label>:195                                     ; preds = %190
   %196 = load i8, i8* %194, align 8
   %197 = zext i8 %196 to i32
   %198 = trunc i32 %197 to i8
-  %NullCheck66 = icmp ne i8* %192, null
-  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+  %NullCheck65 = icmp eq i8* %192, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %199
 
 ; <label>:199                                     ; preds = %195
   store i8 %198, i8* %192, align 8
@@ -1035,14 +1117,14 @@ entry:
   %201 = load i8*, i8** %arg0
   %202 = load i8*, i8** %arg1
   %203 = bitcast i8* %202 to i64*
-  %NullCheck48 = icmp ne i64* %203, null
-  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+  %NullCheck47 = icmp eq i64* %203, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %204
 
 ; <label>:204                                     ; preds = %200
   %205 = load i64, i64* %203, align 8
   %206 = bitcast i8* %201 to i64*
-  %NullCheck50 = icmp ne i64* %206, null
-  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+  %NullCheck49 = icmp eq i64* %206, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %207
 
 ; <label>:207                                     ; preds = %204
   store i64 %205, i64* %206, align 8
@@ -1051,14 +1133,14 @@ entry:
   %210 = load i8*, i8** %arg1
   %211 = getelementptr inbounds i8, i8* %210, i64 8
   %212 = bitcast i8* %211 to i32*
-  %NullCheck52 = icmp ne i32* %212, null
-  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+  %NullCheck51 = icmp eq i32* %212, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %213
 
 ; <label>:213                                     ; preds = %207
   %214 = load i32, i32* %212, align 8
   %215 = bitcast i8* %209 to i32*
-  %NullCheck54 = icmp ne i32* %215, null
-  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+  %NullCheck53 = icmp eq i32* %215, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %216
 
 ; <label>:216                                     ; preds = %213
   store i32 %214, i32* %215, align 8
@@ -1068,14 +1150,14 @@ entry:
   %218 = load i8*, i8** %arg0
   %219 = load i8*, i8** %arg1
   %220 = bitcast i8* %219 to i64*
-  %NullCheck36 = icmp ne i64* %220, null
-  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64* %220, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %221
 
 ; <label>:221                                     ; preds = %217
   %222 = load i64, i64* %220, align 8
   %223 = bitcast i8* %218 to i64*
-  %NullCheck38 = icmp ne i64* %223, null
-  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+  %NullCheck37 = icmp eq i64* %223, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %224
 
 ; <label>:224                                     ; preds = %221
   store i64 %222, i64* %223, align 8
@@ -1084,14 +1166,14 @@ entry:
   %227 = load i8*, i8** %arg1
   %228 = getelementptr inbounds i8, i8* %227, i64 8
   %229 = bitcast i8* %228 to i32*
-  %NullCheck40 = icmp ne i32* %229, null
-  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i32* %229, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %230
 
 ; <label>:230                                     ; preds = %224
   %231 = load i32, i32* %229, align 8
   %232 = bitcast i8* %226 to i32*
-  %NullCheck42 = icmp ne i32* %232, null
-  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+  %NullCheck41 = icmp eq i32* %232, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %233
 
 ; <label>:233                                     ; preds = %230
   store i32 %231, i32* %232, align 8
@@ -1099,15 +1181,15 @@ entry:
   %235 = getelementptr inbounds i8, i8* %234, i64 12
   %236 = load i8*, i8** %arg1
   %237 = getelementptr inbounds i8, i8* %236, i64 12
-  %NullCheck44 = icmp ne i8* %237, null
-  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i8* %237, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %238
 
 ; <label>:238                                     ; preds = %233
   %239 = load i8, i8* %237, align 8
   %240 = zext i8 %239 to i32
   %241 = trunc i32 %240 to i8
-  %NullCheck46 = icmp ne i8* %235, null
-  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+  %NullCheck45 = icmp eq i8* %235, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %242
 
 ; <label>:242                                     ; preds = %238
   store i8 %241, i8* %235, align 8
@@ -1117,14 +1199,14 @@ entry:
   %244 = load i8*, i8** %arg0
   %245 = load i8*, i8** %arg1
   %246 = bitcast i8* %245 to i64*
-  %NullCheck24 = icmp ne i64* %246, null
-  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64* %246, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %247
 
 ; <label>:247                                     ; preds = %243
   %248 = load i64, i64* %246, align 8
   %249 = bitcast i8* %244 to i64*
-  %NullCheck26 = icmp ne i64* %249, null
-  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64* %249, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %250
 
 ; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
@@ -1133,14 +1215,14 @@ entry:
   %253 = load i8*, i8** %arg1
   %254 = getelementptr inbounds i8, i8* %253, i64 8
   %255 = bitcast i8* %254 to i32*
-  %NullCheck28 = icmp ne i32* %255, null
-  br i1 %NullCheck28, label %256, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i32* %255, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %256
 
 ; <label>:256                                     ; preds = %250
   %257 = load i32, i32* %255, align 8
   %258 = bitcast i8* %252 to i32*
-  %NullCheck30 = icmp ne i32* %258, null
-  br i1 %NullCheck30, label %259, label %ThrowNullRef29
+  %NullCheck29 = icmp eq i32* %258, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %259
 
 ; <label>:259                                     ; preds = %256
   store i32 %257, i32* %258, align 8
@@ -1149,16 +1231,16 @@ entry:
   %262 = load i8*, i8** %arg1
   %263 = getelementptr inbounds i8, i8* %262, i64 12
   %264 = bitcast i8* %263 to i16*
-  %NullCheck32 = icmp ne i16* %264, null
-  br i1 %NullCheck32, label %265, label %ThrowNullRef31
+  %NullCheck31 = icmp eq i16* %264, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %265
 
 ; <label>:265                                     ; preds = %259
   %266 = load i16, i16* %264, align 8
   %267 = sext i16 %266 to i32
   %268 = bitcast i8* %261 to i16*
   %269 = trunc i32 %267 to i16
-  %NullCheck34 = icmp ne i16* %268, null
-  br i1 %NullCheck34, label %270, label %ThrowNullRef33
+  %NullCheck33 = icmp eq i16* %268, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %270
 
 ; <label>:270                                     ; preds = %265
   store i16 %269, i16* %268, align 8
@@ -1168,14 +1250,14 @@ entry:
   %272 = load i8*, i8** %arg0
   %273 = load i8*, i8** %arg1
   %274 = bitcast i8* %273 to i64*
-  %NullCheck8 = icmp ne i64* %274, null
-  br i1 %NullCheck8, label %275, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64* %274, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %275
 
 ; <label>:275                                     ; preds = %271
   %276 = load i64, i64* %274, align 8
   %277 = bitcast i8* %272 to i64*
-  %NullCheck10 = icmp ne i64* %277, null
-  br i1 %NullCheck10, label %278, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %277, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %278
 
 ; <label>:278                                     ; preds = %275
   store i64 %276, i64* %277, align 8
@@ -1184,14 +1266,14 @@ entry:
   %281 = load i8*, i8** %arg1
   %282 = getelementptr inbounds i8, i8* %281, i64 8
   %283 = bitcast i8* %282 to i32*
-  %NullCheck12 = icmp ne i32* %283, null
-  br i1 %NullCheck12, label %284, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i32* %283, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %284
 
 ; <label>:284                                     ; preds = %278
   %285 = load i32, i32* %283, align 8
   %286 = bitcast i8* %280 to i32*
-  %NullCheck14 = icmp ne i32* %286, null
-  br i1 %NullCheck14, label %287, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i32* %286, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %287
 
 ; <label>:287                                     ; preds = %284
   store i32 %285, i32* %286, align 8
@@ -1200,16 +1282,16 @@ entry:
   %290 = load i8*, i8** %arg1
   %291 = getelementptr inbounds i8, i8* %290, i64 12
   %292 = bitcast i8* %291 to i16*
-  %NullCheck16 = icmp ne i16* %292, null
-  br i1 %NullCheck16, label %293, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i16* %292, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %293
 
 ; <label>:293                                     ; preds = %287
   %294 = load i16, i16* %292, align 8
   %295 = sext i16 %294 to i32
   %296 = bitcast i8* %289 to i16*
   %297 = trunc i32 %295 to i16
-  %NullCheck18 = icmp ne i16* %296, null
-  br i1 %NullCheck18, label %298, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i16* %296, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %298
 
 ; <label>:298                                     ; preds = %293
   store i16 %297, i16* %296, align 8
@@ -1217,15 +1299,15 @@ entry:
   %300 = getelementptr inbounds i8, i8* %299, i64 14
   %301 = load i8*, i8** %arg1
   %302 = getelementptr inbounds i8, i8* %301, i64 14
-  %NullCheck20 = icmp ne i8* %302, null
-  br i1 %NullCheck20, label %303, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i8* %302, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %303
 
 ; <label>:303                                     ; preds = %298
   %304 = load i8, i8* %302, align 8
   %305 = zext i8 %304 to i32
   %306 = trunc i32 %305 to i8
-  %NullCheck22 = icmp ne i8* %300, null
-  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i8* %300, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %307
 
 ; <label>:307                                     ; preds = %303
   store i8 %306, i8* %300, align 8
@@ -1235,14 +1317,14 @@ entry:
   %309 = load i8*, i8** %arg0
   %310 = load i8*, i8** %arg1
   %311 = bitcast i8* %310 to i64*
-  %NullCheck = icmp ne i64* %311, null
-  br i1 %NullCheck, label %312, label %ThrowNullRef
+  %NullCheck = icmp eq i64* %311, null
+  br i1 %NullCheck, label %ThrowNullRef, label %312
 
 ; <label>:312                                     ; preds = %308
   %313 = load i64, i64* %311, align 8
   %314 = bitcast i8* %309 to i64*
-  %NullCheck2 = icmp ne i64* %314, null
-  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64* %314, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %315
 
 ; <label>:315                                     ; preds = %312
   store i64 %313, i64* %314, align 8
@@ -1251,14 +1333,14 @@ entry:
   %318 = load i8*, i8** %arg1
   %319 = getelementptr inbounds i8, i8* %318, i64 8
   %320 = bitcast i8* %319 to i64*
-  %NullCheck4 = icmp ne i64* %320, null
-  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64* %320, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %321
 
 ; <label>:321                                     ; preds = %315
   %322 = load i64, i64* %320, align 8
   %323 = bitcast i8* %317 to i64*
-  %NullCheck6 = icmp ne i64* %323, null
-  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64* %323, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %324
 
 ; <label>:324                                     ; preds = %321
   store i64 %322, i64* %323, align 8
@@ -1286,15 +1368,15 @@ entry:
 ; <label>:338                                     ; preds = %333
   %339 = load i8*, i8** %arg0
   %340 = load i8*, i8** %arg1
-  %NullCheck136 = icmp ne i8* %340, null
-  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+  %NullCheck135 = icmp eq i8* %340, null
+  br i1 %NullCheck135, label %ThrowNullRef136, label %341
 
 ; <label>:341                                     ; preds = %338
   %342 = load i8, i8* %340, align 8
   %343 = zext i8 %342 to i32
   %344 = trunc i32 %343 to i8
-  %NullCheck138 = icmp ne i8* %339, null
-  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+  %NullCheck137 = icmp eq i8* %339, null
+  br i1 %NullCheck137, label %ThrowNullRef138, label %345
 
 ; <label>:345                                     ; preds = %341
   store i8 %344, i8* %339, align 8
@@ -1317,16 +1399,16 @@ entry:
   %357 = load i8*, i8** %arg0
   %358 = load i8*, i8** %arg1
   %359 = bitcast i8* %358 to i16*
-  %NullCheck140 = icmp ne i16* %359, null
-  br i1 %NullCheck140, label %360, label %ThrowNullRef139
+  %NullCheck139 = icmp eq i16* %359, null
+  br i1 %NullCheck139, label %ThrowNullRef140, label %360
 
 ; <label>:360                                     ; preds = %356
   %361 = load i16, i16* %359, align 8
   %362 = sext i16 %361 to i32
   %363 = bitcast i8* %357 to i16*
   %364 = trunc i32 %362 to i16
-  %NullCheck142 = icmp ne i16* %363, null
-  br i1 %NullCheck142, label %365, label %ThrowNullRef141
+  %NullCheck141 = icmp eq i16* %363, null
+  br i1 %NullCheck141, label %ThrowNullRef142, label %365
 
 ; <label>:365                                     ; preds = %360
   store i16 %364, i16* %363, align 8
@@ -1352,14 +1434,14 @@ entry:
   %378 = load i8*, i8** %arg0
   %379 = load i8*, i8** %arg1
   %380 = bitcast i8* %379 to i32*
-  %NullCheck144 = icmp ne i32* %380, null
-  br i1 %NullCheck144, label %381, label %ThrowNullRef143
+  %NullCheck143 = icmp eq i32* %380, null
+  br i1 %NullCheck143, label %ThrowNullRef144, label %381
 
 ; <label>:381                                     ; preds = %377
   %382 = load i32, i32* %380, align 8
   %383 = bitcast i8* %378 to i32*
-  %NullCheck146 = icmp ne i32* %383, null
-  br i1 %NullCheck146, label %384, label %ThrowNullRef145
+  %NullCheck145 = icmp eq i32* %383, null
+  br i1 %NullCheck145, label %ThrowNullRef146, label %384
 
 ; <label>:384                                     ; preds = %381
   store i32 %382, i32* %383, align 8
@@ -1384,14 +1466,14 @@ entry:
   %395 = load i8*, i8** %arg0
   %396 = load i8*, i8** %arg1
   %397 = bitcast i8* %396 to i64*
-  %NullCheck164 = icmp ne i64* %397, null
-  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+  %NullCheck163 = icmp eq i64* %397, null
+  br i1 %NullCheck163, label %ThrowNullRef164, label %398
 
 ; <label>:398                                     ; preds = %394
   %399 = load i64, i64* %397, align 8
   %400 = bitcast i8* %395 to i64*
-  %NullCheck166 = icmp ne i64* %400, null
-  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+  %NullCheck165 = icmp eq i64* %400, null
+  br i1 %NullCheck165, label %ThrowNullRef166, label %401
 
 ; <label>:401                                     ; preds = %398
   store i64 %399, i64* %400, align 8
@@ -1400,14 +1482,14 @@ entry:
   %404 = load i8*, i8** %arg1
   %405 = getelementptr inbounds i8, i8* %404, i64 8
   %406 = bitcast i8* %405 to i64*
-  %NullCheck168 = icmp ne i64* %406, null
-  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+  %NullCheck167 = icmp eq i64* %406, null
+  br i1 %NullCheck167, label %ThrowNullRef168, label %407
 
 ; <label>:407                                     ; preds = %401
   %408 = load i64, i64* %406, align 8
   %409 = bitcast i8* %403 to i64*
-  %NullCheck170 = icmp ne i64* %409, null
-  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+  %NullCheck169 = icmp eq i64* %409, null
+  br i1 %NullCheck169, label %ThrowNullRef170, label %410
 
 ; <label>:410                                     ; preds = %407
   store i64 %408, i64* %409, align 8
@@ -1437,14 +1519,14 @@ entry:
   %425 = load i8*, i8** %arg0
   %426 = load i8*, i8** %arg1
   %427 = bitcast i8* %426 to i64*
-  %NullCheck148 = icmp ne i64* %427, null
-  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+  %NullCheck147 = icmp eq i64* %427, null
+  br i1 %NullCheck147, label %ThrowNullRef148, label %428
 
 ; <label>:428                                     ; preds = %424
   %429 = load i64, i64* %427, align 8
   %430 = bitcast i8* %425 to i64*
-  %NullCheck150 = icmp ne i64* %430, null
-  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+  %NullCheck149 = icmp eq i64* %430, null
+  br i1 %NullCheck149, label %ThrowNullRef150, label %431
 
 ; <label>:431                                     ; preds = %428
   store i64 %429, i64* %430, align 8
@@ -1466,14 +1548,14 @@ entry:
   %441 = load i8*, i8** %arg0
   %442 = load i8*, i8** %arg1
   %443 = bitcast i8* %442 to i32*
-  %NullCheck152 = icmp ne i32* %443, null
-  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+  %NullCheck151 = icmp eq i32* %443, null
+  br i1 %NullCheck151, label %ThrowNullRef152, label %444
 
 ; <label>:444                                     ; preds = %440
   %445 = load i32, i32* %443, align 8
   %446 = bitcast i8* %441 to i32*
-  %NullCheck154 = icmp ne i32* %446, null
-  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+  %NullCheck153 = icmp eq i32* %446, null
+  br i1 %NullCheck153, label %ThrowNullRef154, label %447
 
 ; <label>:447                                     ; preds = %444
   store i32 %445, i32* %446, align 8
@@ -1495,16 +1577,16 @@ entry:
   %457 = load i8*, i8** %arg0
   %458 = load i8*, i8** %arg1
   %459 = bitcast i8* %458 to i16*
-  %NullCheck156 = icmp ne i16* %459, null
-  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+  %NullCheck155 = icmp eq i16* %459, null
+  br i1 %NullCheck155, label %ThrowNullRef156, label %460
 
 ; <label>:460                                     ; preds = %456
   %461 = load i16, i16* %459, align 8
   %462 = sext i16 %461 to i32
   %463 = bitcast i8* %457 to i16*
   %464 = trunc i32 %462 to i16
-  %NullCheck158 = icmp ne i16* %463, null
-  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+  %NullCheck157 = icmp eq i16* %463, null
+  br i1 %NullCheck157, label %ThrowNullRef158, label %465
 
 ; <label>:465                                     ; preds = %460
   store i16 %464, i16* %463, align 8
@@ -1525,15 +1607,15 @@ entry:
 ; <label>:474                                     ; preds = %470
   %475 = load i8*, i8** %arg0
   %476 = load i8*, i8** %arg1
-  %NullCheck160 = icmp ne i8* %476, null
-  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+  %NullCheck159 = icmp eq i8* %476, null
+  br i1 %NullCheck159, label %ThrowNullRef160, label %477
 
 ; <label>:477                                     ; preds = %474
   %478 = load i8, i8* %476, align 8
   %479 = zext i8 %478 to i32
   %480 = trunc i32 %479 to i8
-  %NullCheck162 = icmp ne i8* %475, null
-  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+  %NullCheck161 = icmp eq i8* %475, null
+  br i1 %NullCheck161, label %ThrowNullRef162, label %481
 
 ; <label>:481                                     ; preds = %477
   store i8 %480, i8* %475, align 8
@@ -1553,343 +1635,343 @@ ThrowNullRef:                                     ; preds = %308
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %312
+ThrowNullRef2:                                    ; preds = %312
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %315
+ThrowNullRef4:                                    ; preds = %315
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %321
+ThrowNullRef6:                                    ; preds = %321
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %271
+ThrowNullRef8:                                    ; preds = %271
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %275
+ThrowNullRef10:                                   ; preds = %275
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %278
+ThrowNullRef12:                                   ; preds = %278
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %284
+ThrowNullRef14:                                   ; preds = %284
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %287
+ThrowNullRef16:                                   ; preds = %287
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %293
+ThrowNullRef18:                                   ; preds = %293
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %298
+ThrowNullRef20:                                   ; preds = %298
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %303
+ThrowNullRef22:                                   ; preds = %303
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %243
+ThrowNullRef24:                                   ; preds = %243
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %247
+ThrowNullRef26:                                   ; preds = %247
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %250
+ThrowNullRef28:                                   ; preds = %250
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %256
+ThrowNullRef30:                                   ; preds = %256
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %259
+ThrowNullRef32:                                   ; preds = %259
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %265
+ThrowNullRef34:                                   ; preds = %265
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %217
+ThrowNullRef36:                                   ; preds = %217
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %221
+ThrowNullRef38:                                   ; preds = %221
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %224
+ThrowNullRef40:                                   ; preds = %224
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %230
+ThrowNullRef42:                                   ; preds = %230
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %233
+ThrowNullRef44:                                   ; preds = %233
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %238
+ThrowNullRef46:                                   ; preds = %238
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %200
+ThrowNullRef48:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %204
+ThrowNullRef50:                                   ; preds = %204
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %207
+ThrowNullRef52:                                   ; preds = %207
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %213
+ThrowNullRef54:                                   ; preds = %213
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %172
+ThrowNullRef56:                                   ; preds = %172
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %176
+ThrowNullRef58:                                   ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %179
+ThrowNullRef60:                                   ; preds = %179
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %185
+ThrowNullRef62:                                   ; preds = %185
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %190
+ThrowNullRef64:                                   ; preds = %190
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %195
+ThrowNullRef66:                                   ; preds = %195
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %153
+ThrowNullRef68:                                   ; preds = %153
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %157
+ThrowNullRef70:                                   ; preds = %157
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %160
+ThrowNullRef72:                                   ; preds = %160
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %166
+ThrowNullRef74:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %136
+ThrowNullRef76:                                   ; preds = %136
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %140
+ThrowNullRef78:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %143
+ThrowNullRef80:                                   ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %148
+ThrowNullRef82:                                   ; preds = %148
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %128
+ThrowNullRef84:                                   ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %132
+ThrowNullRef86:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %100
+ThrowNullRef88:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %104
+ThrowNullRef90:                                   ; preds = %104
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %107
+ThrowNullRef92:                                   ; preds = %107
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %113
+ThrowNullRef94:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %118
+ThrowNullRef96:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %123
+ThrowNullRef98:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %81
+ThrowNullRef100:                                  ; preds = %81
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef101:                                  ; preds = %85
+ThrowNullRef102:                                  ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef103:                                  ; preds = %88
+ThrowNullRef104:                                  ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef105:                                  ; preds = %94
+ThrowNullRef106:                                  ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef107:                                  ; preds = %64
+ThrowNullRef108:                                  ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef109:                                  ; preds = %68
+ThrowNullRef110:                                  ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef111:                                  ; preds = %71
+ThrowNullRef112:                                  ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef113:                                  ; preds = %76
+ThrowNullRef114:                                  ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef115:                                  ; preds = %56
+ThrowNullRef116:                                  ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef117:                                  ; preds = %60
+ThrowNullRef118:                                  ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef119:                                  ; preds = %37
+ThrowNullRef120:                                  ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef121:                                  ; preds = %41
+ThrowNullRef122:                                  ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef123:                                  ; preds = %46
+ThrowNullRef124:                                  ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef125:                                  ; preds = %51
+ThrowNullRef126:                                  ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef127:                                  ; preds = %27
+ThrowNullRef128:                                  ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef129:                                  ; preds = %31
+ThrowNullRef130:                                  ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef131:                                  ; preds = %19
+ThrowNullRef132:                                  ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef133:                                  ; preds = %22
+ThrowNullRef134:                                  ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef135:                                  ; preds = %338
+ThrowNullRef136:                                  ; preds = %338
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef137:                                  ; preds = %341
+ThrowNullRef138:                                  ; preds = %341
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef139:                                  ; preds = %356
+ThrowNullRef140:                                  ; preds = %356
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef141:                                  ; preds = %360
+ThrowNullRef142:                                  ; preds = %360
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef143:                                  ; preds = %377
+ThrowNullRef144:                                  ; preds = %377
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef145:                                  ; preds = %381
+ThrowNullRef146:                                  ; preds = %381
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef147:                                  ; preds = %424
+ThrowNullRef148:                                  ; preds = %424
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef149:                                  ; preds = %428
+ThrowNullRef150:                                  ; preds = %428
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef151:                                  ; preds = %440
+ThrowNullRef152:                                  ; preds = %440
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef153:                                  ; preds = %444
+ThrowNullRef154:                                  ; preds = %444
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef155:                                  ; preds = %456
+ThrowNullRef156:                                  ; preds = %456
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef157:                                  ; preds = %460
+ThrowNullRef158:                                  ; preds = %460
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef159:                                  ; preds = %474
+ThrowNullRef160:                                  ; preds = %474
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef161:                                  ; preds = %477
+ThrowNullRef162:                                  ; preds = %477
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef163:                                  ; preds = %394
+ThrowNullRef164:                                  ; preds = %394
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef165:                                  ; preds = %398
+ThrowNullRef166:                                  ; preds = %398
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef167:                                  ; preds = %401
+ThrowNullRef168:                                  ; preds = %401
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef169:                                  ; preds = %407
+ThrowNullRef170:                                  ; preds = %407
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1939,8 +2021,8 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
-  br i1 %NullCheck, label %22, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %ThrowNullRef, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
@@ -1948,8 +2030,8 @@ entry:
   store i32 %24, i32* %loc0
   %25 = load i32, i32* %loc0
   %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %26, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %27
 
 ; <label>:27                                      ; preds = %22
   %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
@@ -1971,7 +2053,7 @@ ThrowNullRef:                                     ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1989,8 +2071,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -2022,15 +2104,15 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2048,16 +2130,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
   %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
   store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %15
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
@@ -2072,8 +2154,8 @@ entry:
   %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
   %29 = ptrtoint i16 addrspace(1)* %28 to i64
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %19
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
@@ -2089,19 +2171,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2114,8 +2196,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
@@ -2128,7 +2210,7 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[loadElem]
+Failed to read AppDomain.PrepareDataForSetup[storeElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
@@ -2202,8 +2284,8 @@ entry:
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
-  br i1 %NullCheck24, label %27, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = load i64, i64 addrspace(1)* %26
@@ -2218,8 +2300,8 @@ entry:
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
-  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
   %41 = load i64, i64 addrspace(1)* %39
@@ -2236,8 +2318,8 @@ entry:
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
-  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
   %54 = load i64, i64 addrspace(1)* %52
@@ -2252,8 +2334,8 @@ entry:
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
   %67 = load i64, i64 addrspace(1)* %65
@@ -2270,8 +2352,8 @@ entry:
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
-  br i1 %NullCheck16, label %79, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
   %80 = load i64, i64 addrspace(1)* %78
@@ -2286,8 +2368,8 @@ entry:
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
-  br i1 %NullCheck18, label %92, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
   %93 = load i64, i64 addrspace(1)* %91
@@ -2304,8 +2386,8 @@ entry:
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
-  br i1 %NullCheck12, label %105, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = load i64, i64 addrspace(1)* %104
@@ -2320,8 +2402,8 @@ entry:
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
-  br i1 %NullCheck14, label %118, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
   %119 = load i64, i64 addrspace(1)* %117
@@ -2337,8 +2419,8 @@ entry:
 
 ; <label>:128                                     ; preds = %20
   %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
-  br i1 %NullCheck4, label %130, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %129, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %130
 
 ; <label>:130                                     ; preds = %128
   %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
@@ -2346,8 +2428,8 @@ entry:
   %133 = load i16, i16 addrspace(1)* %132, align 8
   %134 = zext i16 %133 to i32
   %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
-  br i1 %NullCheck6, label %136, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %135, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %136
 
 ; <label>:136                                     ; preds = %130
   %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
@@ -2360,8 +2442,8 @@ entry:
 
 ; <label>:143                                     ; preds = %136
   %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
-  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %144, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %145
 
 ; <label>:145                                     ; preds = %143
   %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
@@ -2369,8 +2451,8 @@ entry:
   %148 = load i16, i16 addrspace(1)* %147, align 8
   %149 = zext i16 %148 to i32
   %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %150, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %151
 
 ; <label>:151                                     ; preds = %145
   %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
@@ -2388,8 +2470,8 @@ entry:
 
 ; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
-  br i1 %NullCheck, label %163, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %ThrowNullRef, label %163
 
 ; <label>:163                                     ; preds = %161
   %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
@@ -2399,8 +2481,8 @@ entry:
 
 ; <label>:167                                     ; preds = %163
   %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
-  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %168, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %169
 
 ; <label>:169                                     ; preds = %167
   %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
@@ -2432,55 +2514,55 @@ ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %167
+ThrowNullRef2:                                    ; preds = %167
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %128
+ThrowNullRef4:                                    ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %130
+ThrowNullRef6:                                    ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %143
+ThrowNullRef8:                                    ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %145
+ThrowNullRef10:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %102
+ThrowNullRef12:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %105
+ThrowNullRef14:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %76
+ThrowNullRef16:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %79
+ThrowNullRef18:                                   ; preds = %79
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %50
+ThrowNullRef20:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %53
+ThrowNullRef22:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %24
+ThrowNullRef24:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %27
+ThrowNullRef26:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2503,15 +2585,15 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2519,16 +2601,16 @@ entry:
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
   store i32 %8, i32* %loc0
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
   %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
   store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
@@ -2546,16 +2628,16 @@ entry:
 
 ; <label>:23                                      ; preds = %64
   %24 = load i16*, i16** %loc3
-  %NullCheck12 = icmp ne i16* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i16* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
   store i32 %27, i32* %loc5
   %28 = load i16*, i16** %loc4
-  %NullCheck14 = icmp ne i16* %28, null
-  br i1 %NullCheck14, label %29, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %28, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = load i16, i16* %28, align 8
@@ -2620,15 +2702,15 @@ entry:
 
 ; <label>:67                                      ; preds = %64
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
-  br i1 %NullCheck8, label %69, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %68, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %69
 
 ; <label>:69                                      ; preds = %67
   %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
   %71 = load i32, i32 addrspace(1)* %70
   %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
-  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %73
 
 ; <label>:73                                      ; preds = %69
   %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
@@ -2645,31 +2727,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %67
+ThrowNullRef8:                                    ; preds = %67
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %69
+ThrowNullRef10:                                   ; preds = %69
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2710,14 +2792,14 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
   %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
@@ -2730,14 +2812,14 @@ entry:
 
 ; <label>:11                                      ; preds = %4
   %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
   %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
@@ -2749,14 +2831,14 @@ entry:
 
 ; <label>:22                                      ; preds = %16
   %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
   %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
-  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
-  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
@@ -2804,23 +2886,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2836,7 +2918,280 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[loadElem]
+Successfully read RuntimeType.IsAssignableFrom
+
+define i8 @RuntimeType.IsAssignableFrom(%System.RuntimeType addrspace(1)* %param0, %System.Type addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.RuntimeType addrspace(1)*
+  %arg1 = alloca %System.Type addrspace(1)*
+  %loc0 = alloca %System.RuntimeType addrspace(1)*
+  %loc1 = alloca %"System.Type[]" addrspace(1)*
+  %loc2 = alloca i32
+  store %System.RuntimeType addrspace(1)* %param0, %System.RuntimeType addrspace(1)** %this
+  store %System.Type addrspace(1)* %param1, %System.Type addrspace(1)** %arg1
+  %0 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %1 = icmp ne %System.Type addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i8 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %5 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %6 = bitcast %System.Type addrspace(1)* %4 to %System.Object addrspace(1)*
+  %7 = bitcast %System.RuntimeType addrspace(1)* %5 to %System.Object addrspace(1)*
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %6, %System.Object addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %3
+  ret i8 1
+
+; <label>:12                                      ; preds = %3
+  %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 152
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 32
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
+  %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
+  %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
+  store %System.RuntimeType addrspace(1)* %25, %System.RuntimeType addrspace(1)** %loc0
+  %26 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %27 = icmp eq %System.RuntimeType addrspace(1)* %26, null
+  br i1 %27, label %34, label %28
+
+; <label>:28                                      ; preds = %15
+  %29 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %30 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)*)*)(%System.RuntimeType addrspace(1)* %29, %System.RuntimeType addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+; <label>:34                                      ; preds = %15
+  %35 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %36 = call %System.Reflection.Emit.TypeBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Reflection.Emit.TypeBuilder addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %35)
+  %37 = icmp eq %System.Reflection.Emit.TypeBuilder addrspace(1)* %36, null
+  br i1 %37, label %139, label %38
+
+; <label>:38                                      ; preds = %34
+  %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %42
+
+; <label>:42                                      ; preds = %38
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 152
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 40
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
+  %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
+  %53 = zext i8 %52 to i32
+  %54 = icmp eq i32 %53, 0
+  br i1 %54, label %56, label %55
+
+; <label>:55                                      ; preds = %42
+  ret i8 1
+
+; <label>:56                                      ; preds = %42
+  %57 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %58 = bitcast %System.RuntimeType addrspace(1)* %57 to %System.Type addrspace(1)*
+  %59 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %58)
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %64 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.Type addrspace(1)* %63, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = bitcast %System.RuntimeType addrspace(1)* %64 to %System.Type addrspace(1)*
+  %67 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %63, %System.Type addrspace(1)* %66)
+  %68 = zext i8 %67 to i32
+  %69 = trunc i32 %68 to i8
+  ret i8 %69
+
+; <label>:70                                      ; preds = %56
+  %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
+  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %73
+
+; <label>:73                                      ; preds = %70
+  %74 = load i64, i64 addrspace(1)* %72
+  %75 = add i64 %74, 128
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = add i64 %77, 0
+  %79 = inttoptr i64 %78 to i64*
+  %80 = load i64, i64* %79
+  %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
+  %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
+  %83 = call i8 %82(%System.Type addrspace(1)* %81)
+  %84 = zext i8 %83 to i32
+  %85 = icmp eq i32 %84, 0
+  br i1 %85, label %139, label %86
+
+; <label>:86                                      ; preds = %73
+  %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
+  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %89
+
+; <label>:89                                      ; preds = %86
+  %90 = load i64, i64 addrspace(1)* %88
+  %91 = add i64 %90, 128
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = add i64 %93, 24
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
+  %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
+  %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
+  store %"System.Type[]" addrspace(1)* %99, %"System.Type[]" addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %129
+
+; <label>:100                                     ; preds = %132
+  %101 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %102 = load i32, i32* %loc2
+  %NullCheck11 = icmp eq %"System.Type[]" addrspace(1)* %101, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %103
+
+; <label>:103                                     ; preds = %100
+  %104 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 1
+  %105 = load i32, i32 addrspace(1)* %104
+  %106 = zext i32 %105 to i64
+  %107 = zext i32 %102 to i64
+  %BoundsCheck = icmp uge i64 %107, %106
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %108
+
+; <label>:108                                     ; preds = %103
+  %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
+  %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
+  %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
+  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %113
+
+; <label>:113                                     ; preds = %108
+  %114 = load i64, i64 addrspace(1)* %112
+  %115 = add i64 %114, 152
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = add i64 %117, 56
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
+  %123 = zext i8 %122 to i32
+  %124 = icmp ne i32 %123, 0
+  br i1 %124, label %126, label %125
+
+; <label>:125                                     ; preds = %113
+  ret i8 0
+
+; <label>:126                                     ; preds = %113
+  %127 = load i32, i32* %loc2
+  %128 = add i32 %127, 1
+  store i32 %128, i32* %loc2
+  br label %129
+
+; <label>:129                                     ; preds = %89, %126
+  %130 = load i32, i32* %loc2
+  %131 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %NullCheck9 = icmp eq %"System.Type[]" addrspace(1)* %131, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %132
+
+; <label>:132                                     ; preds = %129
+  %133 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %131, i32 0, i32 1
+  %134 = load i32, i32 addrspace(1)* %133
+  %135 = zext i32 %134 to i64
+  %136 = trunc i64 %135 to i32
+  %137 = icmp slt i32 %130, %136
+  br i1 %137, label %100, label %138
+
+; <label>:138                                     ; preds = %132
+  ret i8 1
+
+; <label>:139                                     ; preds = %34, %73
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %129
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %103
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -2893,7 +3248,7 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElem]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -2904,8 +3259,8 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -2997,8 +3352,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
@@ -3059,8 +3414,8 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -3087,8 +3442,8 @@ entry:
 
 ; <label>:17                                      ; preds = %5, %11
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
@@ -3097,8 +3452,8 @@ entry:
 
 ; <label>:22                                      ; preds = %1, %11
   %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
@@ -3109,11 +3464,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %17
+ThrowNullRef2:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %22
+ThrowNullRef4:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3167,15 +3522,15 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
   %15 = load i32, i32 addrspace(1)* %14
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
@@ -3198,7 +3553,7 @@ ThrowNullRef:                                     ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef2:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3232,8 +3587,8 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
@@ -3312,8 +3667,8 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -3327,8 +3682,8 @@ entry:
 ; <label>:5                                       ; preds = %43
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %7 = load i32, i32* %loc1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck6, label %8, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
@@ -3366,8 +3721,8 @@ entry:
 ; <label>:32                                      ; preds = %21, %25
   %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
   %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
-  br i1 %NullCheck8, label %35, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = trunc i32 %34 to i16
@@ -3380,8 +3735,8 @@ entry:
 ; <label>:40                                      ; preds = %1, %35
   %41 = load i32, i32* %loc1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
-  br i1 %NullCheck2, label %43, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %42, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
@@ -3392,8 +3747,8 @@ entry:
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
   %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
-  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
   %51 = load i64, i64 addrspace(1)* %49
@@ -3412,19 +3767,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %40
+ThrowNullRef2:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %47
+ThrowNullRef4:                                    ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %5
+ThrowNullRef6:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %32
+ThrowNullRef8:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3467,8 +3822,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
@@ -3492,11 +3847,391 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(i16* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store i16* %param0, i16** %arg0
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load i32, i32* %arg3
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %42, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %37, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg2
+  %13 = load i32, i32* %arg3
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %37, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %24 = load i32, i32* %arg2
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load i16*, i16** %arg0
+  %35 = load i32, i32* %arg3
+  %36 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %36, i16* %34, i32 %35)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:37                                      ; preds = %5, %16
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %39)
+  %41 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41, %System.String addrspace(1)* %38, %System.String addrspace(1)* %40)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41) #0
+  unreachable
+
+; <label>:42                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
-Failed to read StringBuilder.ToString[loadElemA]
+Successfully read StringBuilder.ToString
+
+define %System.String addrspace(1)* @StringBuilder.ToString(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i16*
+  %loc3 = alloca %"System.Char[]" addrspace(1)*
+  %loc4 = alloca i32
+  %loc5 = alloca i32
+  %loc6 = alloca i16 addrspace(1)*
+  %loc7 = alloca %System.String addrspace(1)*
+  %loc8 = alloca %"System.Char[]" addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %0)
+  %2 = icmp ne i32 %1, 0
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %4
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %6)
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %7)
+  store %System.String addrspace(1)* %8, %System.String addrspace(1)** %loc0
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.Text.StringBuilder addrspace(1)* %9, %System.Text.StringBuilder addrspace(1)** %loc1
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  store %System.String addrspace(1)* %10, %System.String addrspace(1)** %loc7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc7
+  %12 = ptrtoint %System.String addrspace(1)* %11 to i64
+  %13 = icmp eq i64 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %5
+  %15 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %16 = sext i32 %15 to i64
+  %17 = add i64 %12, %16
+  br label %18
+
+; <label>:18                                      ; preds = %5, %14
+  %19 = phi i64 [ %12, %5 ], [ %17, %14 ]
+  %20 = inttoptr i64 %19 to i16*
+  store i16* %20, i16** %loc2
+  br label %21
+
+; <label>:21                                      ; preds = %98, %18
+  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %22, null
+  br i1 %NullCheck, label %ThrowNullRef, label %23
+
+; <label>:23                                      ; preds = %21
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 3
+  %25 = load i32, i32 addrspace(1)* %24, align 8
+  %26 = icmp sle i32 %25, 0
+  br i1 %26, label %96, label %27
+
+; <label>:27                                      ; preds = %23
+  %28 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %28, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %29
+
+; <label>:29                                      ; preds = %27
+  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %28, i32 0, i32 1
+  %31 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %30, align 8
+  store %"System.Char[]" addrspace(1)* %31, %"System.Char[]" addrspace(1)** %loc3
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %33
+
+; <label>:33                                      ; preds = %29
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  store i32 %35, i32* %loc4
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  %39 = load i32, i32 addrspace(1)* %38, align 8
+  store i32 %39, i32* %loc5
+  %40 = load i32, i32* %loc5
+  %41 = load i32, i32* %loc4
+  %42 = add i32 %40, %41
+  %43 = zext i32 %42 to i64
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %45
+
+; <label>:45                                      ; preds = %37
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = sext i32 %47 to i64
+  %49 = icmp sgt i64 %43, %48
+  br i1 %49, label %91, label %50
+
+; <label>:50                                      ; preds = %45
+  %51 = load i32, i32* %loc5
+  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %52, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %53
+
+; <label>:53                                      ; preds = %50
+  %54 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %52, i32 0, i32 1
+  %55 = load i32, i32 addrspace(1)* %54
+  %56 = zext i32 %55 to i64
+  %57 = trunc i64 %56 to i32
+  %58 = icmp ugt i32 %51, %57
+  br i1 %58, label %91, label %59
+
+; <label>:59                                      ; preds = %53
+  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  store %"System.Char[]" addrspace(1)* %60, %"System.Char[]" addrspace(1)** %loc8
+  %61 = icmp eq %"System.Char[]" addrspace(1)* %60, null
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %63, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %64
+
+; <label>:64                                      ; preds = %62
+  %65 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %63, i32 0, i32 1
+  %66 = load i32, i32 addrspace(1)* %65
+  %67 = zext i32 %66 to i64
+  %68 = trunc i64 %67 to i32
+  %69 = icmp ne i32 %68, 0
+  br i1 %69, label %71, label %70
+
+; <label>:70                                      ; preds = %59, %64
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:71                                      ; preds = %64
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %73
+
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %BoundsCheck = icmp uge i64 0, %76
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %77
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %78, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:79                                      ; preds = %70, %77
+  %80 = load i16*, i16** %loc2
+  %81 = load i32, i32* %loc4
+  %82 = sext i32 %81 to i64
+  %83 = mul i64 %82, 2
+  %84 = bitcast i16* %80 to i8*
+  %85 = getelementptr inbounds i8, i8* %84, i64 %83
+  %86 = load i16 addrspace(1)*, i16 addrspace(1)** %loc6
+  %87 = ptrtoint i16 addrspace(1)* %86 to i64
+  %88 = load i32, i32* %loc5
+  %89 = bitcast i8* %85 to i16*
+  %90 = inttoptr i64 %87 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %89, i16* %90, i32 %88)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %96
+
+; <label>:91                                      ; preds = %45, %53
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %94 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %93)
+  %95 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95, %System.String addrspace(1)* %92, %System.String addrspace(1)* %94)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95) #0
+  unreachable
+
+; <label>:96                                      ; preds = %23, %79
+  %97 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %97, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %98
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %97, i32 0, i32 2
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  store %System.Text.StringBuilder addrspace(1)* %100, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %102 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %102, label %21, label %103
+
+; <label>:103                                     ; preds = %98
+  store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc7
+  %104 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  ret %System.String addrspace(1)* %104
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method StringBuilder::get_Length using LLILCJit
+Successfully read StringBuilder.get_Length
+
+define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
+Successfully read RuntimeHelpers.get_OffsetToStringData
+
+define i32 @RuntimeHelpers.get_OffsetToStringData() {
+entry:
+  ret i32 12
+}
+
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
 Successfully read CultureData.CreateCultureData
 
@@ -3514,23 +4249,23 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
   store i8 %4, i8 addrspace(1)* %6
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
@@ -3549,11 +4284,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3566,50 +4301,50 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
   store i32 -1, i32 addrspace(1)* %2
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
   store i32 -1, i32 addrspace(1)* %8
   %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
   store i32 -1, i32 addrspace(1)* %14
   %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
   store i32 -1, i32 addrspace(1)* %17
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
@@ -3623,27 +4358,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3675,7 +4410,136 @@ Failed to read Dictionary`2.Insert[non-const derefAddress]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
 Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
-Failed to read HashHelpers.GetPrime[loadElem]
+Successfully read HashHelpers.GetPrime
+
+define i32 @HashHelpers.GetPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %6, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5, %System.String addrspace(1)* %4)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5) #0
+  unreachable
+
+; <label>:6                                       ; preds = %entry
+  store i32 0, i32* %loc0
+  br label %29
+
+; <label>:7                                       ; preds = %35
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 1296
+  %10 = addrspacecast i8 addrspace(1)* %9 to %"System.Int32[]" addrspace(1)**
+  %11 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %10
+  %12 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Int32[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = zext i32 %15 to i64
+  %17 = zext i32 %12 to i64
+  %BoundsCheck = icmp uge i64 %17, %16
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 3, i32 %12
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  store i32 %20, i32* %loc1
+  %21 = load i32, i32* %loc1
+  %22 = load i32, i32* %arg0
+  %23 = icmp slt i32 %21, %22
+  br i1 %23, label %26, label %24
+
+; <label>:24                                      ; preds = %18
+  %25 = load i32, i32* %loc1
+  ret i32 %25
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %loc0
+  %28 = add i32 %27, 1
+  store i32 %28, i32* %loc0
+  br label %29
+
+; <label>:29                                      ; preds = %6, %26
+  %30 = load i32, i32* %loc0
+  %31 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %32 = getelementptr inbounds i8, i8 addrspace(1)* %31, i64 1296
+  %33 = addrspacecast i8 addrspace(1)* %32 to %"System.Int32[]" addrspace(1)**
+  %34 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %33
+  %NullCheck = icmp eq %"System.Int32[]" addrspace(1)* %34, null
+  br i1 %NullCheck, label %ThrowNullRef, label %35
+
+; <label>:35                                      ; preds = %29
+  %36 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %34, i32 0, i32 1
+  %37 = load i32, i32 addrspace(1)* %36
+  %38 = zext i32 %37 to i64
+  %39 = trunc i64 %38 to i32
+  %40 = icmp slt i32 %30, %39
+  br i1 %40, label %7, label %41
+
+; <label>:41                                      ; preds = %35
+  %42 = load i32, i32* %arg0
+  %43 = or i32 %42, 1
+  store i32 %43, i32* %loc2
+  br label %59
+
+; <label>:44                                      ; preds = %59
+  %45 = load i32, i32* %loc2
+  %46 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %45)
+  %47 = zext i8 %46 to i32
+  %48 = icmp eq i32 %47, 0
+  br i1 %48, label %56, label %49
+
+; <label>:49                                      ; preds = %44
+  %50 = load i32, i32* %loc2
+  %51 = sub i32 %50, 1
+  %52 = srem i32 %51, 101
+  %53 = icmp eq i32 %52, 0
+  br i1 %53, label %56, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = load i32, i32* %loc2
+  ret i32 %55
+
+; <label>:56                                      ; preds = %44, %49
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %57, 2
+  store i32 %58, i32* %loc2
+  br label %59
+
+; <label>:59                                      ; preds = %41, %56
+  %60 = load i32, i32* %loc2
+  %61 = icmp slt i32 %60, 2147483647
+  br i1 %61, label %44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load i32, i32* %arg0
+  ret i32 %63
+
+ThrowNullRef:                                     ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
 Successfully read GenericEqualityComparer`1.GetHashCode
 
@@ -3694,14 +4558,14 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
   %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load i64, i64 addrspace(1)* %7
@@ -3720,7 +4584,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3750,8 +4614,8 @@ entry:
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
@@ -3796,8 +4660,8 @@ entry:
   %35 = bitcast i16* %34 to i8*
   %36 = getelementptr inbounds i8, i8* %35, i64 2
   %37 = bitcast i8* %36 to i16*
-  %NullCheck4 = icmp ne i16* %37, null
-  br i1 %NullCheck4, label %38, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %37, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %38
 
 ; <label>:38                                      ; preds = %27
   %39 = load i16, i16* %37, align 8
@@ -3824,8 +4688,8 @@ entry:
 
 ; <label>:54                                      ; preds = %22, %43
   %55 = load i16*, i16** %loc4
-  %NullCheck2 = icmp ne i16* %55, null
-  br i1 %NullCheck2, label %56, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i16* %55, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %56
 
 ; <label>:56                                      ; preds = %54
   %57 = load i16, i16* %55, align 8
@@ -3850,11 +4714,11 @@ ThrowNullRef:                                     ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %54
+ThrowNullRef2:                                    ; preds = %54
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %27
+ThrowNullRef4:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3871,8 +4735,8 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -3907,8 +4771,8 @@ entry:
 
 ; <label>:26                                      ; preds = %19
   %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
-  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %28
 
 ; <label>:28                                      ; preds = %26
   %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
@@ -3920,7 +4784,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3972,8 +4836,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
@@ -3984,26 +4848,26 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
-  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
@@ -4014,8 +4878,8 @@ entry:
 ; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
@@ -4024,8 +4888,8 @@ entry:
 
 ; <label>:25                                      ; preds = %1, %16, %23
   %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
-  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
@@ -4036,27 +4900,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %20
+ThrowNullRef10:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4069,8 +4933,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -4081,8 +4945,8 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
@@ -4091,8 +4955,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1, %8
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
@@ -4103,11 +4967,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4128,24 +4992,24 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   store i32 %3, i32* %loc0
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
   %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
   store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck4, label %9, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
@@ -4164,15 +5028,15 @@ entry:
 ; <label>:18                                      ; preds = %70
   %19 = load i16*, i16** %loc3
   %20 = bitcast i16* %19 to i64*
-  %NullCheck10 = icmp ne i64* %20, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %20, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = load i64, i64* %20, align 8
   %23 = load i16*, i16** %loc4
   %24 = bitcast i16* %23 to i64*
-  %NullCheck12 = icmp ne i64* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = load i64, i64* %24, align 8
@@ -4188,8 +5052,8 @@ entry:
   %31 = bitcast i16* %30 to i8*
   %32 = getelementptr inbounds i8, i8* %31, i64 8
   %33 = bitcast i8* %32 to i64*
-  %NullCheck14 = icmp ne i64* %33, null
-  br i1 %NullCheck14, label %34, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = load i64, i64* %33, align 8
@@ -4197,8 +5061,8 @@ entry:
   %37 = bitcast i16* %36 to i8*
   %38 = getelementptr inbounds i8, i8* %37, i64 8
   %39 = bitcast i8* %38 to i64*
-  %NullCheck16 = icmp ne i64* %39, null
-  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %40
 
 ; <label>:40                                      ; preds = %34
   %41 = load i64, i64* %39, align 8
@@ -4214,8 +5078,8 @@ entry:
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %NullCheck18 = icmp ne i64* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = load i64, i64* %48, align 8
@@ -4223,8 +5087,8 @@ entry:
   %52 = bitcast i16* %51 to i8*
   %53 = getelementptr inbounds i8, i8* %52, i64 16
   %54 = bitcast i8* %53 to i64*
-  %NullCheck20 = icmp ne i64* %54, null
-  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64* %54, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %55
 
 ; <label>:55                                      ; preds = %49
   %56 = load i64, i64* %54, align 8
@@ -4262,15 +5126,15 @@ entry:
 ; <label>:74                                      ; preds = %95
   %75 = load i16*, i16** %loc3
   %76 = bitcast i16* %75 to i32*
-  %NullCheck6 = icmp ne i32* %76, null
-  br i1 %NullCheck6, label %77, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32* %76, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %77
 
 ; <label>:77                                      ; preds = %74
   %78 = load i32, i32* %76, align 8
   %79 = load i16*, i16** %loc4
   %80 = bitcast i16* %79 to i32*
-  %NullCheck8 = icmp ne i32* %80, null
-  br i1 %NullCheck8, label %81, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i32* %80, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %81
 
 ; <label>:81                                      ; preds = %77
   %82 = load i32, i32* %80, align 8
@@ -4318,43 +5182,43 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %74
+ThrowNullRef6:                                    ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %77
+ThrowNullRef8:                                    ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %29
+ThrowNullRef14:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %34
+ThrowNullRef16:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4376,8 +5240,8 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load i64, i64 addrspace(1)* %4
@@ -4389,8 +5253,8 @@ entry:
   %12 = load i64, i64* %11
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %5
   %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
@@ -4399,8 +5263,8 @@ entry:
   %18 = load i8, i8* %arg2
   %19 = zext i8 %18 to i32
   %20 = trunc i32 %19 to i8
-  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %15
   %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
@@ -4411,11 +5275,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4442,8 +5306,8 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
@@ -4466,16 +5330,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
   %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = load i64, i64 addrspace(1)* %19
@@ -4500,8 +5364,8 @@ entry:
 ; <label>:35                                      ; preds = %30
   %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
@@ -4514,8 +5378,8 @@ entry:
 
 ; <label>:42                                      ; preds = %1, %38
   %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
-  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
@@ -4526,19 +5390,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %35
+ThrowNullRef2:                                    ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %42
+ThrowNullRef8:                                    ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4551,14 +5415,14 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
@@ -4570,7 +5434,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4583,8 +5447,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
@@ -4613,51 +5477,51 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
   %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
   %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
   %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
   %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
-  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
   store i64 %21, i64 addrspace(1)* %23
   %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %25 = load i64, i64* %loc0
-  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
@@ -4668,27 +5532,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %22
+ThrowNullRef12:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4701,8 +5565,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
@@ -4713,19 +5577,19 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
@@ -4734,8 +5598,8 @@ entry:
 
 ; <label>:15                                      ; preds = %1, %13
   %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
@@ -4746,19 +5610,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %15
+ThrowNullRef8:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4771,8 +5635,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -4831,8 +5695,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
@@ -4882,8 +5746,8 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
-  br i1 %NullCheck, label %17, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %ThrowNullRef, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
@@ -4894,15 +5758,15 @@ entry:
 
 ; <label>:22                                      ; preds = %17
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
-  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
   %26 = load i32, i32 addrspace(1)* %25
   %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
-  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %27, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
@@ -4925,8 +5789,8 @@ entry:
 ; <label>:40                                      ; preds = %17
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
-  br i1 %NullCheck6, label %43, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %41, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
@@ -4938,34 +5802,17 @@ ThrowNullRef:                                     ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %24
+ThrowNullRef4:                                    ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %40
+ThrowNullRef6:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
-}
-
-INFO:  jitting method Object::ReferenceEquals using LLILCJit
-Successfully read Object.ReferenceEquals
-
-define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
-entry:
-  %arg0 = alloca %System.Object addrspace(1)*
-  %arg1 = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
-  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
-  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = icmp eq %System.Object addrspace(1)* %0, %1
-  %3 = sext i1 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
 }
 
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
@@ -4978,21 +5825,21 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
   %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
-  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
@@ -5007,28 +5854,28 @@ entry:
 ; <label>:13                                      ; preds = %8, %12
   %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
   %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
   %21 = load i32, i32 addrspace(1)* %20, align 8
   %22 = add i32 %21, 1
-  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
   store i32 %22, i32 addrspace(1)* %24
   %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
@@ -5039,27 +5886,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5077,7 +5924,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::Setup using LLILCJit
-Failed to read AppDomain.Setup[loadElem]
+Failed to read AppDomain.Setup[unbox]
 INFO:  jitting method Thread::GetDomain using LLILCJit
 Successfully read Thread.GetDomain
 
@@ -5108,8 +5955,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
@@ -5122,14 +5969,14 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
   %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
@@ -5141,11 +5988,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5173,8 +6020,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -5189,7 +6036,328 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
 Failed to read KeyCollection.System.Collections.Generic.IEnumerable<TKey>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Successfully read Enumerator.MoveNext
+
+define i8 @Enumerator.MoveNext(%"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.RuntimeTypeHandle* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*
+  %"$TypeArg" = alloca %System.RuntimeTypeHandle*
+  store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
+  %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 8
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %76, label %12
+
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
+  br label %76
+
+; <label>:13                                      ; preds = %85
+  %14 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck19 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %15
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, i32 0, i32 0
+  %17 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %16, align 8
+  %NullCheck21 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, i32 0, i32 2
+  %20 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %19, align 8
+  %21 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck23 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %22
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, i32 0, i32 2
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %NullCheck25 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 3, i32 %24
+  %NullCheck27 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %32
+
+; <label>:32                                      ; preds = %30
+  %33 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, i32 0, i32 2
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = icmp slt i32 %34, 0
+  br i1 %35, label %68, label %36
+
+; <label>:36                                      ; preds = %32
+  %37 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %38 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck29 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %39
+
+; <label>:39                                      ; preds = %36
+  %40 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, i32 0, i32 0
+  %41 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %40, align 8
+  %NullCheck31 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, i32 0, i32 2
+  %44 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %43, align 8
+  %45 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck33 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, i32 0, i32 2
+  %48 = load i32, i32 addrspace(1)* %47, align 8
+  %NullCheck35 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %49
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = zext i32 %51 to i64
+  %53 = zext i32 %48 to i64
+  %BoundsCheck37 = icmp uge i64 %53, %52
+  br i1 %BoundsCheck37, label %ThrowIndexOutOfRange38, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 3, i32 %48
+  %NullCheck39 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %56
+
+; <label>:56                                      ; preds = %54
+  %57 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, i32 0, i32 0
+  %58 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck41 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %59
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %60, %System.__Canon addrspace(1)* %58)
+  %61 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck43 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  %64 = load i32, i32 addrspace(1)* %63, align 8
+  %65 = add i32 %64, 1
+  %NullCheck45 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  store i32 %65, i32 addrspace(1)* %67
+  ret i8 1
+
+; <label>:68                                      ; preds = %32
+  %69 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck47 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %73 = add i32 %72, 1
+  %NullCheck49 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %74
+
+; <label>:74                                      ; preds = %70
+  %75 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  store i32 %73, i32 addrspace(1)* %75
+  br label %76
+
+; <label>:76                                      ; preds = %8, %12, %74
+  %77 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %78
+
+; <label>:78                                      ; preds = %76
+  %79 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, i32 0, i32 2
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck7 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %82
+
+; <label>:82                                      ; preds = %78
+  %83 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, i32 0, i32 0
+  %84 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %83, align 8
+  %NullCheck9 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %85
+
+; <label>:85                                      ; preds = %82
+  %86 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, i32 0, i32 7
+  %87 = load i32, i32 addrspace(1)* %86, align 8
+  %88 = icmp ult i32 %80, %87
+  br i1 %88, label %13, label %89
+
+; <label>:89                                      ; preds = %85
+  %90 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %91 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck11 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %92
+
+; <label>:92                                      ; preds = %89
+  %93 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, i32 0, i32 0
+  %94 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck13 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %95
+
+; <label>:95                                      ; preds = %92
+  %96 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, i32 0, i32 7
+  %97 = load i32, i32 addrspace(1)* %96, align 8
+  %98 = add i32 %97, 1
+  %NullCheck15 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %99
+
+; <label>:99                                      ; preds = %95
+  %100 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, i32 0, i32 2
+  store i32 %98, i32 addrspace(1)* %100
+  %101 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck17 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %102
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %103, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %92
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef22:                                   ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef24:                                   ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef26:                                   ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef28:                                   ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef30:                                   ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef32:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef34:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef36:                                   ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange38:                           ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef40:                                   ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef42:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef44:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef46:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef48:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef50:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -5200,8 +6368,8 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -5232,9 +6400,9 @@ Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
 Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
-Failed to read String.MakeSeparatorList[loadElemA]
+Failed to read String.MakeSeparatorList[storeElem]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
-Failed to read String.InternalSplitKeepEmptyEntries[loadElem]
+Failed to read String.InternalSplitKeepEmptyEntries[storeElem]
 INFO:  jitting method Path::IsRelative using LLILCJit
 Successfully read Path.IsRelative
 
@@ -5243,8 +6411,8 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -5254,8 +6422,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
@@ -5271,8 +6439,8 @@ entry:
 
 ; <label>:17                                      ; preds = %7
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
@@ -5288,8 +6456,8 @@ entry:
 
 ; <label>:29                                      ; preds = %19
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %31
 
 ; <label>:31                                      ; preds = %29
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
@@ -5300,8 +6468,8 @@ entry:
 
 ; <label>:36                                      ; preds = %31
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
-  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %37, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
@@ -5312,8 +6480,8 @@ entry:
 
 ; <label>:43                                      ; preds = %31, %38
   %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
-  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %45
 
 ; <label>:45                                      ; preds = %43
   %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
@@ -5324,8 +6492,8 @@ entry:
 
 ; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %50
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
@@ -5336,8 +6504,8 @@ entry:
 
 ; <label>:57                                      ; preds = %1, %7, %19, %45, %52
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
-  br i1 %NullCheck14, label %59, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %59
 
 ; <label>:59                                      ; preds = %57
   %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
@@ -5347,8 +6515,8 @@ entry:
 
 ; <label>:63                                      ; preds = %59
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
@@ -5359,8 +6527,8 @@ entry:
 
 ; <label>:70                                      ; preds = %65
   %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
-  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.String addrspace(1)* %71, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %72
 
 ; <label>:72                                      ; preds = %70
   %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
@@ -5379,39 +6547,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %17
+ThrowNullRef4:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %29
+ThrowNullRef6:                                    ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %36
+ThrowNullRef8:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %43
+ThrowNullRef10:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %50
+ThrowNullRef12:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %57
+ThrowNullRef14:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %63
+ThrowNullRef16:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %70
+ThrowNullRef18:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5419,7 +6587,293 @@ ThrowNullRef17:                                   ; preds = %70
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
-Failed to read String.TrimHelper[loadElem]
+Successfully read String.TrimHelper
+
+define %System.String addrspace(1)* @String.TrimHelper(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i16
+  %loc4 = alloca i32
+  %loc5 = alloca i16
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = sub i32 %3, 1
+  store i32 %4, i32* %loc0
+  store i32 0, i32* %loc1
+  %5 = load i32, i32* %arg2
+  %6 = icmp eq i32 %5, 1
+  br i1 %6, label %62, label %7
+
+; <label>:7                                       ; preds = %1
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:8                                       ; preds = %58
+  store i32 0, i32* %loc2
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load i32, i32* %loc1
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2, i32 %10
+  %13 = load i16, i16 addrspace(1)* %12
+  %14 = zext i16 %13 to i32
+  %15 = trunc i32 %14 to i16
+  store i16 %15, i16* %loc3
+  store i32 0, i32* %loc2
+  br label %34
+
+; <label>:16                                      ; preds = %37
+  %17 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %18 = load i32, i32* %loc2
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %17, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %19
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = zext i32 %18 to i64
+  %BoundsCheck = icmp uge i64 %23, %22
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %24
+
+; <label>:24                                      ; preds = %19
+  %25 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 3, i32 %18
+  %26 = load i16, i16 addrspace(1)* %25, align 8
+  %27 = zext i16 %26 to i32
+  %28 = load i16, i16* %loc3
+  %29 = zext i16 %28 to i32
+  %30 = icmp eq i32 %27, %29
+  br i1 %30, label %43, label %31
+
+; <label>:31                                      ; preds = %24
+  %32 = load i32, i32* %loc2
+  %33 = add i32 %32, 1
+  store i32 %33, i32* %loc2
+  br label %34
+
+; <label>:34                                      ; preds = %11, %31
+  %35 = load i32, i32* %loc2
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = icmp slt i32 %35, %41
+  br i1 %42, label %16, label %43
+
+; <label>:43                                      ; preds = %24, %37
+  %44 = load i32, i32* %loc2
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %45, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp eq i32 %44, %50
+  br i1 %51, label %62, label %52
+
+; <label>:52                                      ; preds = %46
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %7, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %57, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %58
+
+; <label>:58                                      ; preds = %55
+  %59 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %60 = load i32, i32 addrspace(1)* %59
+  %61 = icmp slt i32 %56, %60
+  br i1 %61, label %8, label %62
+
+; <label>:62                                      ; preds = %1, %46, %58
+  %63 = load i32, i32* %arg2
+  %64 = icmp eq i32 %63, 0
+  br i1 %64, label %122, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %66, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %67
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %66, i32 0, i32 1
+  %69 = load i32, i32 addrspace(1)* %68
+  %70 = sub i32 %69, 1
+  store i32 %70, i32* %loc0
+  br label %118
+
+; <label>:71                                      ; preds = %118
+  store i32 0, i32* %loc4
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %73 = load i32, i32* %loc0
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %74
+
+; <label>:74                                      ; preds = %71
+  %75 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 2, i32 %73
+  %76 = load i16, i16 addrspace(1)* %75
+  %77 = zext i16 %76 to i32
+  %78 = trunc i32 %77 to i16
+  store i16 %78, i16* %loc5
+  store i32 0, i32* %loc4
+  br label %97
+
+; <label>:79                                      ; preds = %100
+  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %81 = load i32, i32* %loc4
+  %NullCheck19 = icmp eq %"System.Char[]" addrspace(1)* %80, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
+
+; <label>:82                                      ; preds = %79
+  %83 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 1
+  %84 = load i32, i32 addrspace(1)* %83
+  %85 = zext i32 %84 to i64
+  %86 = zext i32 %81 to i64
+  %BoundsCheck21 = icmp uge i64 %86, %85
+  br i1 %BoundsCheck21, label %ThrowIndexOutOfRange22, label %87
+
+; <label>:87                                      ; preds = %82
+  %88 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 3, i32 %81
+  %89 = load i16, i16 addrspace(1)* %88, align 8
+  %90 = zext i16 %89 to i32
+  %91 = load i16, i16* %loc5
+  %92 = zext i16 %91 to i32
+  %93 = icmp eq i32 %90, %92
+  br i1 %93, label %106, label %94
+
+; <label>:94                                      ; preds = %87
+  %95 = load i32, i32* %loc4
+  %96 = add i32 %95, 1
+  store i32 %96, i32* %loc4
+  br label %97
+
+; <label>:97                                      ; preds = %74, %94
+  %98 = load i32, i32* %loc4
+  %99 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck15 = icmp eq %"System.Char[]" addrspace(1)* %99, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %100
+
+; <label>:100                                     ; preds = %97
+  %101 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %99, i32 0, i32 1
+  %102 = load i32, i32 addrspace(1)* %101
+  %103 = zext i32 %102 to i64
+  %104 = trunc i64 %103 to i32
+  %105 = icmp slt i32 %98, %104
+  br i1 %105, label %79, label %106
+
+; <label>:106                                     ; preds = %87, %100
+  %107 = load i32, i32* %loc4
+  %108 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck17 = icmp eq %"System.Char[]" addrspace(1)* %108, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %109
+
+; <label>:109                                     ; preds = %106
+  %110 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %108, i32 0, i32 1
+  %111 = load i32, i32 addrspace(1)* %110
+  %112 = zext i32 %111 to i64
+  %113 = trunc i64 %112 to i32
+  %114 = icmp eq i32 %107, %113
+  br i1 %114, label %122, label %115
+
+; <label>:115                                     ; preds = %109
+  %116 = load i32, i32* %loc0
+  %117 = sub i32 %116, 1
+  store i32 %117, i32* %loc0
+  br label %118
+
+; <label>:118                                     ; preds = %67, %115
+  %119 = load i32, i32* %loc0
+  %120 = load i32, i32* %loc1
+  %121 = icmp sge i32 %119, %120
+  br i1 %121, label %71, label %122
+
+; <label>:122                                     ; preds = %62, %109, %118
+  %123 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %124 = load i32, i32* %loc1
+  %125 = load i32, i32* %loc0
+  %126 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %123, i32 %124, i32 %125)
+  ret %System.String addrspace(1)* %126
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %97
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange22:                           ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
 Successfully read String.CreateTrimmedString
 
@@ -5439,8 +6893,8 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
@@ -5535,8 +6989,8 @@ entry:
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i64 2872
   %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
   %8 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %7
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %3
   %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
@@ -5553,8 +7007,8 @@ entry:
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 2864
   %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
   %21 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %20
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
-  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %22
 
 ; <label>:22                                      ; preds = %16
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
@@ -5569,7 +7023,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %16
+ThrowNullRef2:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5586,8 +7040,8 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5613,8 +7067,8 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
@@ -5632,8 +7086,8 @@ entry:
 
 ; <label>:12                                      ; preds = %4
   %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
@@ -5644,8 +7098,8 @@ entry:
 
 ; <label>:19                                      ; preds = %14
   %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %19
   %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
@@ -5660,21 +7114,21 @@ entry:
   %31 = zext i16 %30 to i32
   %32 = bitcast i8* %29 to i16*
   %33 = trunc i32 %31 to i16
-  %NullCheck6 = icmp ne i16* %32, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i16* %32, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %21
   store i16 %33, i16* %32, align 8
   %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %36
 
 ; <label>:36                                      ; preds = %34
   %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
   %38 = load i32, i32 addrspace(1)* %37, align 8
   %39 = add i32 %38, 1
-  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %40
 
 ; <label>:40                                      ; preds = %36
   %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
@@ -5683,16 +7137,16 @@ entry:
 
 ; <label>:42                                      ; preds = %14
   %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
-  br i1 %NullCheck12, label %44, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
   %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
   %47 = load i16, i16* %arg1
   %48 = zext i16 %47 to i32
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = trunc i32 %48 to i16
@@ -5703,31 +7157,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %19
+ThrowNullRef4:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %21
+ThrowNullRef6:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %36
+ThrowNullRef10:                                   ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %42
+ThrowNullRef12:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %44
+ThrowNullRef14:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5740,8 +7194,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -5752,8 +7206,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
@@ -5762,14 +7216,14 @@ entry:
 
 ; <label>:11                                      ; preds = %1
   %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
@@ -5779,15 +7233,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5808,8 +7262,8 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5822,8 +7276,8 @@ entry:
 
 ; <label>:8                                       ; preds = %3
   %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
@@ -5842,15 +7296,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
-  br i1 %NullCheck4, label %22, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
   %24 = load i16*, i16* addrspace(1)* %23, align 8
   %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %25, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
@@ -5859,8 +7313,8 @@ entry:
   store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
@@ -5874,8 +7328,8 @@ entry:
 
 ; <label>:37                                      ; preds = %65
   %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %37
   %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
@@ -5886,16 +7340,16 @@ entry:
   %45 = bitcast i16* %41 to i8*
   %46 = getelementptr inbounds i8, i8* %45, i64 %44
   %47 = bitcast i8* %46 to i16*
-  %NullCheck14 = icmp ne i16* %47, null
-  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %47, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %48
 
 ; <label>:48                                      ; preds = %39
   %49 = load i16, i16* %47, align 8
   %50 = zext i16 %49 to i32
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %52 = load i32, i32* %loc1
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %53
 
 ; <label>:53                                      ; preds = %48
   %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
@@ -5916,8 +7370,8 @@ entry:
 ; <label>:62                                      ; preds = %36, %59
   %63 = load i32, i32* %loc1
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck10, label %65, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %65
 
 ; <label>:65                                      ; preds = %62
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
@@ -5936,15 +7390,15 @@ entry:
 
 ; <label>:74                                      ; preds = %70
   %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
-  br i1 %NullCheck18, label %76, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %76
 
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
   %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
-  br i1 %NullCheck20, label %80, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
   %81 = load i64, i64 addrspace(1)* %79
@@ -5958,8 +7412,8 @@ entry:
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
   %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
-  br i1 %NullCheck22, label %92, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.String addrspace(1)* %90, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %92
 
 ; <label>:92                                      ; preds = %80
   %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
@@ -5969,15 +7423,15 @@ entry:
 
 ; <label>:96                                      ; preds = %70
   %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
-  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %98
 
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
   %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
-  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
   %103 = load i64, i64 addrspace(1)* %101
@@ -5991,8 +7445,8 @@ entry:
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
   %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
-  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.String addrspace(1)* %112, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %114
 
 ; <label>:114                                     ; preds = %102
   %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
@@ -6004,59 +7458,59 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %20
+ThrowNullRef4:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %22
+ThrowNullRef6:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %26
+ThrowNullRef8:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %62
+ThrowNullRef10:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %48
+ThrowNullRef16:                                   ; preds = %48
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %74
+ThrowNullRef18:                                   ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %76
+ThrowNullRef20:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %80
+ThrowNullRef22:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %96
+ThrowNullRef24:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %98
+ThrowNullRef26:                                   ; preds = %98
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %102
+ThrowNullRef28:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6069,15 +7523,15 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
   %3 = load i16*, i16* addrspace(1)* %2, align 8
   %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
@@ -6087,8 +7541,8 @@ entry:
   %10 = bitcast i16* %3 to i8*
   %11 = getelementptr inbounds i8, i8* %10, i64 %9
   %12 = bitcast i8* %11 to i16*
-  %NullCheck4 = icmp ne i16* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %5
   store i16 0, i16* %12, align 8
@@ -6098,11 +7552,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6119,8 +7573,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -6131,8 +7585,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
@@ -6144,15 +7598,15 @@ entry:
 
 ; <label>:14                                      ; preds = %1
   %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
   %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
   %21 = load i64, i64 addrspace(1)* %19
@@ -6171,15 +7625,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %14
+ThrowNullRef4:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %16
+ThrowNullRef6:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6302,14 +7756,6 @@ entry:
   ret %System.String addrspace(1)* %57
 }
 
-INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
-Successfully read RuntimeHelpers.get_OffsetToStringData
-
-define i32 @RuntimeHelpers.get_OffsetToStringData() {
-entry:
-  ret i32 12
-}
-
 INFO:  jitting method String::Equals using LLILCJit
 Successfully read String.Equals
 
@@ -6381,8 +7827,8 @@ entry:
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
-  br i1 %NullCheck24, label %29, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
   %30 = load i64, i64 addrspace(1)* %28
@@ -6397,8 +7843,8 @@ entry:
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
-  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
   %43 = load i64, i64 addrspace(1)* %41
@@ -6418,8 +7864,8 @@ entry:
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
   %59 = load i64, i64 addrspace(1)* %57
@@ -6434,8 +7880,8 @@ entry:
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck22, label %71, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
   %72 = load i64, i64 addrspace(1)* %70
@@ -6455,8 +7901,8 @@ entry:
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
-  br i1 %NullCheck16, label %87, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = load i64, i64 addrspace(1)* %86
@@ -6471,8 +7917,8 @@ entry:
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck18, label %100, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
   %101 = load i64, i64 addrspace(1)* %99
@@ -6492,8 +7938,8 @@ entry:
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
-  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
   %117 = load i64, i64 addrspace(1)* %115
@@ -6508,8 +7954,8 @@ entry:
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
-  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
   %130 = load i64, i64 addrspace(1)* %128
@@ -6528,15 +7974,15 @@ entry:
 
 ; <label>:142                                     ; preds = %22
   %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
-  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %143, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %144
 
 ; <label>:144                                     ; preds = %142
   %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
   %146 = load i32, i32 addrspace(1)* %145
   %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
-  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %147, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %148
 
 ; <label>:148                                     ; preds = %144
   %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
@@ -6557,15 +8003,15 @@ entry:
 
 ; <label>:159                                     ; preds = %22
   %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
-  br i1 %NullCheck, label %161, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %ThrowNullRef, label %161
 
 ; <label>:161                                     ; preds = %159
   %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
   %163 = load i32, i32 addrspace(1)* %162
   %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
-  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %164, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %165
 
 ; <label>:165                                     ; preds = %161
   %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
@@ -6578,8 +8024,8 @@ entry:
 
 ; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
-  br i1 %NullCheck4, label %172, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %171, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %172
 
 ; <label>:172                                     ; preds = %170
   %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
@@ -6589,8 +8035,8 @@ entry:
 
 ; <label>:176                                     ; preds = %172
   %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
-  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %177, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %178
 
 ; <label>:178                                     ; preds = %176
   %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
@@ -6629,55 +8075,55 @@ ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %161
+ThrowNullRef2:                                    ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %170
+ThrowNullRef4:                                    ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %176
+ThrowNullRef6:                                    ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %142
+ThrowNullRef8:                                    ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %144
+ThrowNullRef10:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %113
+ThrowNullRef12:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %116
+ThrowNullRef14:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %84
+ThrowNullRef16:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %87
+ThrowNullRef18:                                   ; preds = %87
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %55
+ThrowNullRef20:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %58
+ThrowNullRef22:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %26
+ThrowNullRef24:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %29
+ThrowNullRef26:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,8 +8161,8 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck, label %14, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %ThrowNullRef, label %14
 
 ; <label>:14                                      ; preds = %8
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
@@ -6760,8 +8206,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
@@ -6770,14 +8216,14 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32, i32* %loc0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %10
   %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
   %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
@@ -6790,15 +8236,15 @@ entry:
 ; <label>:25                                      ; preds = %19
   %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
-  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
   %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
@@ -6807,8 +8253,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %37 = load i32, i32* %loc0
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %38, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %38
 
 ; <label>:38                                      ; preds = %32
   %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
@@ -6817,14 +8263,14 @@ entry:
 
 ; <label>:40                                      ; preds = %19
   %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %40
   %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
   %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
-  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
-  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
@@ -6832,8 +8278,8 @@ entry:
   %48 = zext i32 %47 to i64
   %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
-  br i1 %NullCheck16, label %51, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %51
 
 ; <label>:51                                      ; preds = %45
   %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
@@ -6847,15 +8293,15 @@ entry:
 ; <label>:57                                      ; preds = %51
   %58 = load i16*, i16** %arg1
   %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
-  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %60
 
 ; <label>:60                                      ; preds = %57
   %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
   %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
-  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %64
 
 ; <label>:64                                      ; preds = %60
   %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
@@ -6864,22 +8310,22 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
   %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
-  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %70
 
 ; <label>:70                                      ; preds = %64
   %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
   %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
-  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
-  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
   %75 = load i32, i32 addrspace(1)* %74
   %76 = zext i32 %75 to i64
   %77 = trunc i64 %76 to i32
-  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
-  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %78
 
 ; <label>:78                                      ; preds = %73
   %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
@@ -6901,8 +8347,8 @@ entry:
   %90 = bitcast i16* %86 to i8*
   %91 = getelementptr inbounds i8, i8* %90, i64 %89
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %93
 
 ; <label>:93                                      ; preds = %80
   %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
@@ -6912,8 +8358,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %99 = load i32, i32* %loc2
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %100
 
 ; <label>:100                                     ; preds = %93
   %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
@@ -6928,63 +8374,63 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %25
+ThrowNullRef6:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %32
+ThrowNullRef10:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %40
+ThrowNullRef12:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %45
+ThrowNullRef16:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %57
+ThrowNullRef18:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %60
+ThrowNullRef20:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %64
+ThrowNullRef22:                                   ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %70
+ThrowNullRef24:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %73
+ThrowNullRef26:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %80
+ThrowNullRef28:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %93
+ThrowNullRef30:                                   ; preds = %93
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7004,8 +8450,8 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
@@ -7033,43 +8479,43 @@ entry:
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %14
   %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
   %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   %28 = load i32, i32 addrspace(1)* %27, align 8
   %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
-  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %30
 
 ; <label>:30                                      ; preds = %26
   %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
   %32 = load i32, i32 addrspace(1)* %31, align 8
   %33 = add i32 %28, %32
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %34
 
 ; <label>:34                                      ; preds = %30
   %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   store i32 %33, i32 addrspace(1)* %35
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
   store i32 0, i32 addrspace(1)* %38
   %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %40
 
 ; <label>:40                                      ; preds = %37
   %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
@@ -7082,8 +8528,8 @@ entry:
 
 ; <label>:47                                      ; preds = %40
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
@@ -7098,8 +8544,8 @@ entry:
   %54 = load i32, i32* %loc0
   %55 = sext i32 %54 to i64
   %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
-  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %57
 
 ; <label>:57                                      ; preds = %52
   %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
@@ -7110,68 +8556,35 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %14
+ThrowNullRef2:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %23
+ThrowNullRef4:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %26
+ThrowNullRef6:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %30
+ThrowNullRef8:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %34
+ThrowNullRef10:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %47
+ThrowNullRef14:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %52
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-}
-
-INFO:  jitting method StringBuilder::get_Length using LLILCJit
-Successfully read StringBuilder.get_Length
-
-define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.StringBuilder addrspace(1)*
-  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
-  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
-
-; <label>:1                                       ; preds = %entry
-  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %3 = load i32, i32 addrspace(1)* %2, align 8
-  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
-
-; <label>:5                                       ; preds = %1
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = add i32 %3, %7
-  ret i32 %8
-
-ThrowNullRef:                                     ; preds = %entry
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef16:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7213,70 +8626,70 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
   %6 = load i32, i32 addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
   store i32 %6, i32 addrspace(1)* %8
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
   %13 = load i32, i32 addrspace(1)* %12, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
   store i32 %13, i32 addrspace(1)* %15
   %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
-  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %18
 
 ; <label>:18                                      ; preds = %14
   %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
   %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
   %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
   %34 = load i32, i32 addrspace(1)* %33, align 8
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
-  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
@@ -7287,39 +8700,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %28
+ThrowNullRef16:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %32
+ThrowNullRef18:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7455,13 +8868,13 @@ entry:
 ; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
@@ -7477,16 +8890,16 @@ entry:
 
 ; <label>:18                                      ; preds = %15
   %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
   store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
   %22 = load i32, i32* %loc0
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %24
 
 ; <label>:24                                      ; preds = %20
   %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
@@ -7498,13 +8911,13 @@ entry:
 ; <label>:28                                      ; preds = %15, %24
   %29 = load i32, i32* %arg1
   %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %31
   %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
@@ -7517,20 +8930,20 @@ entry:
   %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
-  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
   %46 = load i32, i32 addrspace(1)* %45, align 8
   %47 = sub i32 %40, %46
-  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
-  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i32 addrspace(1)* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %48
 
 ; <label>:48                                      ; preds = %44
   store i32 %47, i32 addrspace(1)* %39, align 8
@@ -7538,21 +8951,21 @@ entry:
 
 ; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
-  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %51
 
 ; <label>:51                                      ; preds = %49
   %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %53
 
 ; <label>:53                                      ; preds = %51
   %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
   %55 = load i32, i32 addrspace(1)* %54, align 8
   %56 = load i32, i32* %arg2
   %57 = sub i32 %55, %56
-  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %58
 
 ; <label>:58                                      ; preds = %53
   %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
@@ -7562,13 +8975,13 @@ entry:
 ; <label>:60                                      ; preds = %33, %58
   %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
   %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
-  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %63
 
 ; <label>:63                                      ; preds = %60
   %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
-  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
-  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
@@ -7578,15 +8991,15 @@ entry:
 
 ; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
-  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i32 addrspace(1)* %69, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %70
 
 ; <label>:70                                      ; preds = %68
   %71 = load i32, i32 addrspace(1)* %69, align 8
   store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
-  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
@@ -7596,8 +9009,8 @@ entry:
   store i32 %77, i32* %loc4
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
-  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %80
 
 ; <label>:80                                      ; preds = %73
   %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
@@ -7607,71 +9020,71 @@ entry:
 ; <label>:83                                      ; preds = %80
   store i32 0, i32* %loc3
   %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
-  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
-  br i1 %NullCheck26, label %88, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i32 addrspace(1)* %87, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %88
 
 ; <label>:88                                      ; preds = %85
   %89 = load i32, i32 addrspace(1)* %87, align 8
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
-  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %90
 
 ; <label>:90                                      ; preds = %88
   %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
   store i32 %89, i32 addrspace(1)* %91
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
-  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
-  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %96
 
 ; <label>:96                                      ; preds = %94
   %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
-  br i1 %NullCheck34, label %100, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %100
 
 ; <label>:100                                     ; preds = %96
   %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
-  br i1 %NullCheck36, label %102, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %102
 
 ; <label>:102                                     ; preds = %100
   %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
   %104 = load i32, i32 addrspace(1)* %103, align 8
   %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
-  br i1 %NullCheck38, label %106, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %106
 
 ; <label>:106                                     ; preds = %102
   %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
-  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
-  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %108
 
 ; <label>:108                                     ; preds = %106
   %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
   %110 = load i32, i32 addrspace(1)* %109, align 8
   %111 = add i32 %104, %110
-  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %112
 
 ; <label>:112                                     ; preds = %108
   %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
   store i32 %111, i32 addrspace(1)* %113
   %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
-  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i32 addrspace(1)* %114, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %115
 
 ; <label>:115                                     ; preds = %112
   %116 = load i32, i32 addrspace(1)* %114, align 8
@@ -7681,19 +9094,19 @@ entry:
 ; <label>:118                                     ; preds = %115
   %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
-  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %121
 
 ; <label>:121                                     ; preds = %118
   %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
-  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
-  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %123
 
 ; <label>:123                                     ; preds = %121
   %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
   %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
-  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
-  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %126
 
 ; <label>:126                                     ; preds = %123
   %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
@@ -7705,8 +9118,8 @@ entry:
 
 ; <label>:130                                     ; preds = %80, %115, %126
   %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %132
 
 ; <label>:132                                     ; preds = %130
   %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7715,8 +9128,8 @@ entry:
   %136 = load i32, i32* %loc3
   %137 = sub i32 %135, %136
   %138 = sub i32 %134, %137
-  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %139
 
 ; <label>:139                                     ; preds = %132
   %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7728,16 +9141,16 @@ entry:
 
 ; <label>:144                                     ; preds = %139
   %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
-  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %146
 
 ; <label>:146                                     ; preds = %144
   %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
   %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
   %149 = load i32, i32* %loc2
   %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
-  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %151
 
 ; <label>:151                                     ; preds = %146
   %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
@@ -7754,145 +9167,249 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %18
+ThrowNullRef4:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %31
+ThrowNullRef10:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %44
+ThrowNullRef16:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %68
+ThrowNullRef18:                                   ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %70
+ThrowNullRef20:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %73
+ThrowNullRef22:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %83
+ThrowNullRef24:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %85
+ThrowNullRef26:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %88
+ThrowNullRef28:                                   ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %90
+ThrowNullRef30:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %94
+ThrowNullRef32:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %96
+ThrowNullRef34:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %100
+ThrowNullRef36:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %102
+ThrowNullRef38:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %106
+ThrowNullRef40:                                   ; preds = %106
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %108
+ThrowNullRef42:                                   ; preds = %108
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %112
+ThrowNullRef44:                                   ; preds = %112
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %118
+ThrowNullRef46:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %121
+ThrowNullRef48:                                   ; preds = %121
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %123
+ThrowNullRef50:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %130
+ThrowNullRef52:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %132
+ThrowNullRef54:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %144
+ThrowNullRef56:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %146
+ThrowNullRef58:                                   ; preds = %146
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %60
+ThrowNullRef60:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %63
+ThrowNullRef62:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %49
+ThrowNullRef64:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %51
+ThrowNullRef66:                                   ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %53
+ThrowNullRef68:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(%"System.Char[]" addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %arg0 = alloca %"System.Char[]" addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store %"System.Char[]" addrspace(1)* %param0, %"System.Char[]" addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load i32, i32* %arg4
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %43, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %38, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg1
+  %13 = load i32, i32* %arg4
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %38, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %24 = load i32, i32* %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %35 = load i32, i32* %arg3
+  %36 = load i32, i32* %arg4
+  %37 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %37, %"System.Char[]" addrspace(1)* %34, i32 %35, i32 %36)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:38                                      ; preds = %5, %16
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Successfully read Buffer._Memmove
 
@@ -7914,7 +9431,7 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[loadElem]
+Failed to read AppDomain.SetDataHelper[storeElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -7923,8 +9440,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
@@ -7934,8 +9451,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
@@ -7947,15 +9464,15 @@ entry:
   %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
   %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
@@ -7966,15 +9483,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7992,7 +9509,79 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
-Failed to read Dictionary`2.TryGetValue[loadElemA]
+Successfully read Dictionary`2.TryGetValue
+
+define i8 @"Dictionary`2.TryGetValue"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)* addrspace(1)* %param2) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  %arg2 = alloca %System.__Canon addrspace(1)* addrspace(1)*
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  store %System.__Canon addrspace(1)* addrspace(1)* %param2, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  store i32 %2, i32* %loc0
+  %3 = load i32, i32* %loc0
+  %4 = icmp slt i32 %3, 0
+  br i1 %4, label %22, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 2
+  %10 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %9, align 8
+  %11 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = zext i32 %11 to i64
+  %BoundsCheck = icmp uge i64 %16, %15
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 3, i32 %11
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %20, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %6, %System.__Canon addrspace(1)* %21)
+  ret i8 1
+
+; <label>:22                                      ; preds = %entry
+  %23 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %23, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -8058,8 +9647,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
@@ -8091,8 +9680,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
@@ -8171,15 +9760,15 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck, label %19, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %ThrowNullRef, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
   %21 = load i32, i32 addrspace(1)* %20
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
@@ -8202,7 +9791,7 @@ ThrowNullRef:                                     ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %19
+ThrowNullRef2:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8248,8 +9837,8 @@ entry:
   %0 = alloca %System.AppDomainHandle
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %1 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %1, i32 0, i32 15
@@ -8269,8 +9858,8 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
@@ -8286,7 +9875,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -8299,8 +9888,8 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -8327,8 +9916,8 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
@@ -8352,8 +9941,8 @@ entry:
   %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
   store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
@@ -8363,8 +9952,8 @@ entry:
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
@@ -8374,8 +9963,8 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %9
   %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
@@ -8384,8 +9973,8 @@ entry:
 
 ; <label>:18                                      ; preds = %3, %16
   %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
@@ -8397,15 +9986,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %18
+ThrowNullRef6:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8418,8 +10007,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
@@ -8453,15 +10042,15 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
@@ -8473,7 +10062,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8481,7 +10070,7 @@ ThrowNullRef1:                                    ; preds = %1
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
 Failed to read Dictionary`2.System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
@@ -8506,8 +10095,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
@@ -8524,8 +10113,8 @@ entry:
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -8544,7 +10133,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8577,8 +10166,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = load i64, i64* %arg2
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = trunc i32 %3 to i8
@@ -8634,46 +10223,46 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
   %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
-  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
-  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
-  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
@@ -8684,27 +10273,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %20
+ThrowNullRef12:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8717,8 +10306,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -8756,22 +10345,22 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
   %9 = load i64, i64 addrspace(1)* %8, align 8
   %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
   %13 = load i64, i64 addrspace(1)* %12, align 8
   %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %11
   %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
@@ -8788,11 +10377,11 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8882,8 +10471,8 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
@@ -8900,8 +10489,8 @@ entry:
 ; <label>:8                                       ; preds = %1
   %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
   %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
@@ -8911,15 +10500,15 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
   %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
   %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
-  br i1 %NullCheck6, label %21, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
@@ -8946,15 +10535,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8992,15 +10581,15 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
   store i8 %3, i8 addrspace(1)* %5
   %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
@@ -9011,7 +10600,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9027,8 +10616,8 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -9041,8 +10630,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
@@ -9058,7 +10647,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9080,8 +10669,8 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
@@ -9096,8 +10685,8 @@ entry:
 ; <label>:12                                      ; preds = %6
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
@@ -9112,8 +10701,8 @@ entry:
 ; <label>:21                                      ; preds = %15
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
@@ -9128,8 +10717,8 @@ entry:
 ; <label>:30                                      ; preds = %24
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %31, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
@@ -9144,8 +10733,8 @@ entry:
 ; <label>:39                                      ; preds = %33
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
-  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %40, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %42
 
 ; <label>:42                                      ; preds = %39
   %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
@@ -9164,19 +10753,19 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %21
+ThrowNullRef4:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %30
+ThrowNullRef6:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %39
+ThrowNullRef8:                                    ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9243,8 +10832,8 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
@@ -9264,57 +10853,57 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
   store i8 0, i8 addrspace(1)* %2
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
   store i8 0, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
   store i8 0, i8 addrspace(1)* %17
   %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
   store i8 0, i8 addrspace(1)* %20
   %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
-  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
@@ -9325,31 +10914,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %19
+ThrowNullRef14:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9367,8 +10956,8 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
@@ -9380,8 +10969,8 @@ entry:
 
 ; <label>:9                                       ; preds = %4
   %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %9
   %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
@@ -9395,7 +10984,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef2:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9420,8 +11009,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
@@ -9512,8 +11101,8 @@ entry:
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
@@ -9524,8 +11113,8 @@ entry:
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = load i64, i64 addrspace(1)* %12
@@ -9537,8 +11126,8 @@ entry:
   %20 = load i64, i64* %19
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
-  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %13
   %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
@@ -9555,8 +11144,8 @@ entry:
 ; <label>:30                                      ; preds = %25
   %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %32 = load i32, i32* %arg2
-  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
-  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
@@ -9570,15 +11159,15 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %30
+ThrowNullRef2:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9622,87 +11211,87 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
   %10 = load i8, i8 addrspace(1)* %9, align 8
   %11 = zext i8 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %8
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
   store i8 %12, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
   %19 = load i8, i8 addrspace(1)* %18, align 8
   %20 = zext i8 %19 to i32
   %21 = trunc i32 %20 to i8
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
   store i8 %21, i8 addrspace(1)* %23
   %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
   %28 = load i8, i8 addrspace(1)* %27, align 8
   %29 = zext i8 %28 to i32
   %30 = trunc i32 %29 to i8
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
-  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %31
 
 ; <label>:31                                      ; preds = %26
   %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
   store i8 %30, i8 addrspace(1)* %32
   %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
-  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
-  br i1 %NullCheck14, label %40, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %40
 
 ; <label>:40                                      ; preds = %35
   %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
   store i8 %39, i8 addrspace(1)* %41
   %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
-  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %44
 
 ; <label>:44                                      ; preds = %40
   %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
   %46 = load i8, i8 addrspace(1)* %45, align 8
   %47 = zext i8 %46 to i32
   %48 = trunc i32 %47 to i8
-  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
   store i8 %48, i8 addrspace(1)* %50
   %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
-  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
@@ -9713,29 +11302,29 @@ entry:
 ; <label>:56                                      ; preds = %52
   %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
-  br i1 %NullCheck22, label %59, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
   %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
   %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
-  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
-  br i1 %NullCheck24, label %63, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
   %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
-  br i1 %NullCheck26, label %66, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
   %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
-  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
-  br i1 %NullCheck28, label %69, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %69
 
 ; <label>:69                                      ; preds = %66
   %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
@@ -9744,15 +11333,15 @@ entry:
 
 ; <label>:71                                      ; preds = %105
   %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
-  br i1 %NullCheck34, label %73, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %73
 
 ; <label>:73                                      ; preds = %71
   %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
   %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
   %76 = load i32, i32* %loc0
-  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
-  br i1 %NullCheck36, label %77, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
@@ -9766,8 +11355,8 @@ entry:
 
 ; <label>:83                                      ; preds = %77
   %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
-  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
@@ -9775,14 +11364,14 @@ entry:
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
   %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
-  br i1 %NullCheck40, label %91, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
 ; <label>:91                                      ; preds = %85
   %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
   %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
-  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck42, label %94, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %94
 
 ; <label>:94                                      ; preds = %91
   %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
@@ -9798,14 +11387,14 @@ entry:
 ; <label>:99                                      ; preds = %69, %96
   %100 = load i32, i32* %loc0
   %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
-  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %102
 
 ; <label>:102                                     ; preds = %99
   %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
   %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
-  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
-  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
@@ -9819,87 +11408,87 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %26
+ThrowNullRef10:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %31
+ThrowNullRef12:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %35
+ThrowNullRef14:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %40
+ThrowNullRef16:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %56
+ThrowNullRef22:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %59
+ThrowNullRef24:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %63
+ThrowNullRef26:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %66
+ThrowNullRef28:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %102
+ThrowNullRef32:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %71
+ThrowNullRef34:                                   ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %73
+ThrowNullRef36:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %83
+ThrowNullRef38:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %85
+ThrowNullRef40:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %91
+ThrowNullRef42:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9943,15 +11532,15 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
   %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
@@ -9961,28 +11550,28 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
   %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %12
   %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
   %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
   %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
-  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
@@ -9993,23 +11582,23 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %12
+ThrowNullRef6:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10031,15 +11620,15 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
   %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = load i64, i64 addrspace(1)* %7
@@ -10077,13 +11666,13 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[loadElem]
+Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -10111,8 +11700,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -10201,8 +11790,8 @@ entry:
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load float, float* %arg0
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -10336,8 +11925,8 @@ entry:
   store i64 %param0, i64* %arg0
   store i64 %param1, i64* %arg1
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
@@ -10345,8 +11934,8 @@ entry:
   %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
   %5 = load i16*, i16* addrspace(1)* %4, align 8
   %6 = addrspacecast i64* %arg1 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = bitcast i64 addrspace(1)* %6 to i8 addrspace(1)*
@@ -10362,7 +11951,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10396,8 +11985,8 @@ entry:
   %1 = load i32, i32* %arg1
   %2 = sext i32 %1 to i64
   %3 = inttoptr i64 %2 to i16*
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -10450,8 +12039,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, i32)*)(%System.IO.ConsoleStream addrspace(1)* %2, i32 %1)
   %3 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %4 = load i64, i64* %arg1
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
@@ -10462,8 +12051,8 @@ entry:
   %10 = icmp eq i32 %9, 3
   %11 = sext i1 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %5
   %14 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, i32 0, i32 5
@@ -10474,7 +12063,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10497,8 +12086,8 @@ entry:
   %5 = icmp eq i32 %4, 1
   %6 = sext i1 %5 to i32
   %7 = trunc i32 %6 to i8
-  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %2, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.ConsoleStream addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
@@ -10509,8 +12098,8 @@ entry:
   %13 = icmp eq i32 %12, 2
   %14 = sext i1 %13 to i32
   %15 = trunc i32 %14 to i8
-  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %10, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.ConsoleStream addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %8
   %17 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %10, i32 0, i32 4
@@ -10521,7 +12110,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10560,8 +12149,8 @@ entry:
   %arg0 = alloca i64
   store i64 %param0, i64* %arg0
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
@@ -10596,8 +12185,8 @@ entry:
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
   %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = load i64, i64 addrspace(1)* %7
@@ -10701,7 +12290,127 @@ entry:
 INFO:  jitting method Encoding::GetEncoding using LLILCJit
 Failed to read Encoding.GetEncoding[convertToHelperArgumentType]
 INFO:  jitting method EncodingProvider::GetEncodingFromProvider using LLILCJit
-Failed to read EncodingProvider.GetEncodingFromProvider[loadElem]
+Successfully read EncodingProvider.GetEncodingFromProvider
+
+define %System.Text.Encoding addrspace(1)* @EncodingProvider.GetEncodingFromProvider(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca %"System.Text.EncodingProvider[]" addrspace(1)*
+  %loc1 = alloca %System.Text.EncodingProvider addrspace(1)*
+  %loc2 = alloca %System.Text.Encoding addrspace(1)*
+  %loc3 = alloca %System.Text.Encoding addrspace(1)*
+  %loc4 = alloca %"System.Text.EncodingProvider[]" addrspace(1)*
+  %loc5 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1059)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2392
+  %2 = addrspacecast i8 addrspace(1)* %1 to %"System.Text.EncodingProvider[]" addrspace(1)**
+  %3 = load volatile %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %2
+  %4 = icmp ne %"System.Text.EncodingProvider[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %entry
+  ret %System.Text.Encoding addrspace(1)* null
+
+; <label>:6                                       ; preds = %entry
+  %7 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1059)
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i64 2392
+  %9 = addrspacecast i8 addrspace(1)* %8 to %"System.Text.EncodingProvider[]" addrspace(1)**
+  %10 = load volatile %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %9
+  store %"System.Text.EncodingProvider[]" addrspace(1)* %10, %"System.Text.EncodingProvider[]" addrspace(1)** %loc0
+  %11 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc0
+  store %"System.Text.EncodingProvider[]" addrspace(1)* %11, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  store i32 0, i32* %loc5
+  br label %43
+
+; <label>:12                                      ; preds = %46
+  %13 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  %14 = load i32, i32* %loc5
+  %NullCheck1 = icmp eq %"System.Text.EncodingProvider[]" addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %13, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = zext i32 %17 to i64
+  %19 = zext i32 %14 to i64
+  %BoundsCheck = icmp uge i64 %19, %18
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %20
+
+; <label>:20                                      ; preds = %15
+  %21 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %13, i32 0, i32 3, i32 %14
+  %22 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)* addrspace(1)* %21, align 8
+  store %System.Text.EncodingProvider addrspace(1)* %22, %System.Text.EncodingProvider addrspace(1)** %loc1
+  %23 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)** %loc1
+  %24 = load i32, i32* %arg0
+  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i64 addrspace(1)*
+  %NullCheck3 = icmp eq i64 addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
+
+; <label>:26                                      ; preds = %20
+  %27 = load i64, i64 addrspace(1)* %25
+  %28 = add i64 %27, 64
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 40
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Text.Encoding addrspace(1)* (%System.Text.EncodingProvider addrspace(1)*, i32)*
+  %35 = call %System.Text.Encoding addrspace(1)* %34(%System.Text.EncodingProvider addrspace(1)* %23, i32 %24)
+  store %System.Text.Encoding addrspace(1)* %35, %System.Text.Encoding addrspace(1)** %loc2
+  %36 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc2
+  %37 = icmp eq %System.Text.Encoding addrspace(1)* %36, null
+  br i1 %37, label %40, label %38
+
+; <label>:38                                      ; preds = %26
+  %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc2
+  store %System.Text.Encoding addrspace(1)* %39, %System.Text.Encoding addrspace(1)** %loc3
+  br label %53
+
+; <label>:40                                      ; preds = %26
+  %41 = load i32, i32* %loc5
+  %42 = add i32 %41, 1
+  store i32 %42, i32* %loc5
+  br label %43
+
+; <label>:43                                      ; preds = %6, %40
+  %44 = load i32, i32* %loc5
+  %45 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  %NullCheck = icmp eq %"System.Text.EncodingProvider[]" addrspace(1)* %45, null
+  br i1 %NullCheck, label %ThrowNullRef, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp slt i32 %44, %50
+  br i1 %51, label %12, label %52
+
+; <label>:52                                      ; preds = %46
+  ret %System.Text.Encoding addrspace(1)* null
+
+; <label>:53                                      ; preds = %38
+  %54 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc3
+  ret %System.Text.Encoding addrspace(1)* %54
+
+ThrowNullRef:                                     ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method EncodingProvider::.cctor using LLILCJit
 Successfully read EncodingProvider..cctor
 
@@ -10720,7 +12429,7 @@ Failed to read Encoding.get_InternalSyncObject[Call HasTypeArg]
 INFO:  jitting method Hashtable::.ctor using LLILCJit
 Failed to read Hashtable..ctor[Volatile store]
 INFO:  jitting method Hashtable::get_Item using LLILCJit
-Failed to read Hashtable.get_Item[loadElemA]
+Failed to read Hashtable.get_Item[loadNonPrimitiveObj]
 INFO:  jitting method Hashtable::InitHash using LLILCJit
 Successfully read Hashtable.InitHash
 
@@ -10740,8 +12449,8 @@ entry:
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -10757,15 +12466,15 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
   %15 = load i32, i32* %loc0
-  %NullCheck2 = icmp ne i32 addrspace(1)* %14, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i32 addrspace(1)* %14, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %3
   store i32 %15, i32 addrspace(1)* %14, align 8
   %17 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %18 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %NullCheck4 = icmp ne i32 addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i32 addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = load i32, i32 addrspace(1)* %18, align 8
@@ -10774,8 +12483,8 @@ entry:
   %23 = sub i32 %22, 1
   %24 = urem i32 %21, %23
   %25 = add i32 1, %24
-  %NullCheck6 = icmp ne i32 addrspace(1)* %17, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32 addrspace(1)* %17, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %19
   store i32 %25, i32 addrspace(1)* %17, align 8
@@ -10786,15 +12495,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %19
+ThrowNullRef6:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10809,8 +12518,8 @@ entry:
   store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
   store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %NullCheck = icmp ne %System.Collections.Hashtable addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Collections.Hashtable addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
@@ -10820,16 +12529,16 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Collections.Hashtable addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Collections.Hashtable addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
   %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck4 = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %9, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
   %13 = inttoptr i64 %11 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
@@ -10839,8 +12548,8 @@ entry:
 ; <label>:15                                      ; preds = %1
   %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -10858,15 +12567,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10880,8 +12589,8 @@ entry:
   store %System.Int32 addrspace(1)* %param0, %System.Int32 addrspace(1)** %this
   %0 = load %System.Int32 addrspace(1)*, %System.Int32 addrspace(1)** %this
   %1 = bitcast %System.Int32 addrspace(1)* %0 to i32 addrspace(1)*
-  %NullCheck = icmp ne i32 addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq i32 addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load i32, i32 addrspace(1)* %1, align 8
@@ -10957,8 +12666,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.UTF8Encoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
@@ -10967,15 +12676,15 @@ entry:
   %9 = load i8, i8* %arg2
   %10 = zext i8 %9 to i32
   %11 = trunc i32 %10 to i8
-  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %8, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %6
   %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %8, i32 0, i32 8
   store i8 %11, i8 addrspace(1)* %13
   %14 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %14, i32 0, i32 8
@@ -10987,8 +12696,8 @@ entry:
 ; <label>:20                                      ; preds = %15
   %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %22, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %22, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = load i64, i64 addrspace(1)* %22
@@ -11010,15 +12719,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %12
+ThrowNullRef4:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11033,8 +12742,8 @@ entry:
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
@@ -11056,16 +12765,16 @@ entry:
 ; <label>:10                                      ; preds = %1
   %11 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
   %12 = load i32, i32* %arg1
-  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %11, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.Encoding addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
   store i32 %12, i32 addrspace(1)* %14
   %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
   %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = load i64, i64 addrspace(1)* %16
@@ -11083,11 +12792,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11100,8 +12809,8 @@ entry:
   %this = alloca %System.Text.UTF8Encoding addrspace(1)*
   store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
   %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.UTF8Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
@@ -11113,16 +12822,16 @@ entry:
 ; <label>:6                                       ; preds = %1
   %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %8 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %10, %System.Text.EncoderFallback addrspace(1)* %8)
   %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %12 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
-  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %11, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %11, i32 0, i32 3
@@ -11135,8 +12844,8 @@ entry:
   %18 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %18, %System.String addrspace(1)* %17)
   %19 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %18 to %System.Text.EncoderFallback addrspace(1)*
-  %NullCheck6 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %16, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %16, i32 0, i32 2
@@ -11146,8 +12855,8 @@ entry:
   %24 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %24, %System.String addrspace(1)* %23)
   %25 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %24 to %System.Text.DecoderFallback addrspace(1)*
-  %NullCheck8 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %22, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %22, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %20
   %27 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %22, i32 0, i32 3
@@ -11158,19 +12867,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %20
+ThrowNullRef8:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11200,8 +12909,8 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load i32, i32* %arg1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -11219,8 +12928,8 @@ entry:
 ; <label>:15                                      ; preds = %8
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %17 = load i32, i32* %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 %17
@@ -11236,7 +12945,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11288,7 +12997,7 @@ entry:
 }
 
 INFO:  jitting method Hashtable::Insert using LLILCJit
-Failed to read Hashtable.Insert[loadElemA]
+Failed to read Hashtable.Insert[storeElem]
 INFO:  jitting method ConsoleEncoding::.ctor using LLILCJit
 Successfully read ConsoleEncoding..ctor
 
@@ -11303,8 +13012,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %1)
   %2 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
@@ -11340,8 +13049,8 @@ entry:
   %2 = call %System.Text.InternalEncoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalEncoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %1)
   %3 = bitcast %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2 to %System.Text.EncoderFallback addrspace(1)*
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
@@ -11351,8 +13060,8 @@ entry:
   %8 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %7)
   %9 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %8 to %System.Text.DecoderFallback addrspace(1)*
-  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %6, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.Encoding addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %4
   %11 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %6, i32 0, i32 3
@@ -11363,7 +13072,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11382,15 +13091,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* %1)
   %2 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   %6 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, i32 0, i32 1
@@ -11401,7 +13110,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11429,8 +13138,8 @@ entry:
   store %System.Text.InternalDecoderBestFitFallback addrspace(1)* %param0, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
   %0 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
@@ -11440,15 +13149,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %4)
   %5 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %6)
   %9 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, i32 0, i32 1
@@ -11459,11 +13168,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11531,8 +13240,8 @@ entry:
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
   %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = load i64, i64 addrspace(1)* %19
@@ -11596,8 +13305,8 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.ConsoleStream addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
@@ -11628,31 +13337,31 @@ entry:
   store i8 %param4, i8* %arg4
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %3, %System.IO.Stream addrspace(1)* %1)
   %4 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %4, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
   %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %4, i32 0, i32 4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %5)
   %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %6
   %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
   %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
   %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = load i64, i64 addrspace(1)* %13
@@ -11664,8 +13373,8 @@ entry:
   %21 = load i64, i64* %20
   %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %8, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %8, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %14
   %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 5
@@ -11683,24 +13392,24 @@ entry:
   %31 = load i32, i32* %arg3
   %32 = sext i32 %31 to i64
   %33 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %32)
-  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %30, null
-  br i1 %NullCheck10, label %34, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.StreamWriter addrspace(1)* %30, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %35, %"System.Char[]" addrspace(1)* %33)
   %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %37, null
-  br i1 %NullCheck12, label %38, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.StreamWriter addrspace(1)* %37, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %38
 
 ; <label>:38                                      ; preds = %34
   %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
   %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
   %41 = load i32, i32* %arg3
   %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %42, null
-  br i1 %NullCheck14, label %43, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %42, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
   %44 = load i64, i64 addrspace(1)* %42
@@ -11714,30 +13423,30 @@ entry:
   %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
   %53 = sext i32 %52 to i64
   %54 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %53)
-  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
-  br i1 %NullCheck16, label %55, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %55
 
 ; <label>:55                                      ; preds = %43
   %56 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %56, %"System.Byte[]" addrspace(1)* %54)
   %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %58 = load i32, i32* %arg3
-  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %57, null
-  br i1 %NullCheck18, label %59, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.StreamWriter addrspace(1)* %57, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %59
 
 ; <label>:59                                      ; preds = %55
   %60 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 10
   store i32 %58, i32 addrspace(1)* %60
   %61 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %61, null
-  br i1 %NullCheck20, label %62, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.IO.StreamWriter addrspace(1)* %61, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %62
 
 ; <label>:62                                      ; preds = %59
   %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
   %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
   %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
   %67 = load i64, i64 addrspace(1)* %65
@@ -11755,15 +13464,15 @@ entry:
 
 ; <label>:78                                      ; preds = %66
   %79 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %79, null
-  br i1 %NullCheck24, label %80, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.StreamWriter addrspace(1)* %79, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %80
 
 ; <label>:80                                      ; preds = %78
   %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
   %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
   %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %83, null
-  br i1 %NullCheck26, label %84, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %83, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
   %85 = load i64, i64 addrspace(1)* %83
@@ -11780,8 +13489,8 @@ entry:
 
 ; <label>:95                                      ; preds = %84
   %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.IO.StreamWriter addrspace(1)* %96, null
-  br i1 %NullCheck28, label %97, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.IO.StreamWriter addrspace(1)* %96, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %97
 
 ; <label>:97                                      ; preds = %95
   %98 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 12
@@ -11795,8 +13504,8 @@ entry:
   %103 = icmp eq i32 %102, 0
   %104 = sext i1 %103 to i32
   %105 = trunc i32 %104 to i8
-  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %100, null
-  br i1 %NullCheck30, label %106, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.IO.StreamWriter addrspace(1)* %100, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %106
 
 ; <label>:106                                     ; preds = %99
   %107 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %100, i32 0, i32 13
@@ -11807,63 +13516,63 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %6
+ThrowNullRef4:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %29
+ThrowNullRef10:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %34
+ThrowNullRef12:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %38
+ThrowNullRef14:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %43
+ThrowNullRef16:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %55
+ThrowNullRef18:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %59
+ThrowNullRef20:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %62
+ThrowNullRef22:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %78
+ThrowNullRef24:                                   ; preds = %78
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %80
+ThrowNullRef26:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %95
+ThrowNullRef28:                                   ; preds = %95
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11876,15 +13585,15 @@ entry:
   %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = load i64, i64 addrspace(1)* %4
@@ -11902,7 +13611,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11952,35 +13661,35 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
   %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderNLS addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %7 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.EncoderNLS addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Text.Encoding addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.Encoding addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Text.EncoderNLS addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.EncoderNLS addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
   %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck8 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = load i64, i64 addrspace(1)* %16
@@ -11999,19 +13708,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12037,8 +13746,8 @@ entry:
   %this = alloca %System.Text.Encoding addrspace(1)*
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
@@ -12058,15 +13767,15 @@ entry:
   %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
   store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
   %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
   store i32 0, i32 addrspace(1)* %2
   %3 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, i32 0, i32 2
@@ -12076,15 +13785,15 @@ entry:
 
 ; <label>:8                                       ; preds = %4
   %9 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
   %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
   %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = load i64, i64 addrspace(1)* %13
@@ -12105,15 +13814,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12128,16 +13837,16 @@ entry:
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = load i32, i32* %arg1
   %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
   %7 = load i64, i64 addrspace(1)* %5
@@ -12155,7 +13864,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12192,8 +13901,8 @@ entry:
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
   %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
   %16 = load i64, i64 addrspace(1)* %14
@@ -12214,8 +13923,8 @@ entry:
   %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
   %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
   %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %31, null
-  br i1 %NullCheck2, label %32, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = load i64, i64 addrspace(1)* %31
@@ -12258,7 +13967,7 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12271,14 +13980,14 @@ entry:
   %this = alloca %System.Text.EncoderReplacementFallback addrspace(1)*
   store %System.Text.EncoderReplacementFallback addrspace(1)* %param0, %System.Text.EncoderReplacementFallback addrspace(1)** %this
   %0 = load %System.Text.EncoderReplacementFallback addrspace(1)*, %System.Text.EncoderReplacementFallback addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -12289,7 +13998,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12319,8 +14028,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
@@ -12352,8 +14061,8 @@ entry:
   %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
   store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
@@ -12365,8 +14074,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Threading.Tasks.Task addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %7)
@@ -12389,7 +14098,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12408,8 +14117,8 @@ entry:
   store i8 %param1, i8* %arg1
   store i8 %param2, i8* %arg2
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
@@ -12423,8 +14132,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1, %5
   %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 9
@@ -12455,8 +14164,8 @@ entry:
 
 ; <label>:25                                      ; preds = %8, %20
   %26 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %26, null
-  br i1 %NullCheck4, label %27, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %26, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %26, i32 0, i32 12
@@ -12467,22 +14176,22 @@ entry:
 
 ; <label>:32                                      ; preds = %27
   %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %33, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.IO.StreamWriter addrspace(1)* %33, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %32
   %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 12
   store i8 1, i8 addrspace(1)* %35
   %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
-  br i1 %NullCheck8, label %37, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
   %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
   %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck10 = icmp ne i64 addrspace(1)* %40, null
-  br i1 %NullCheck10, label %41, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64 addrspace(1)* %40, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i64, i64 addrspace(1)* %40
@@ -12496,8 +14205,8 @@ entry:
   %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
   store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
   %51 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %NullCheck12 = icmp ne %"System.Byte[]" addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Byte[]" addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %41
   %53 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %51, i32 0, i32 1
@@ -12509,16 +14218,16 @@ entry:
 
 ; <label>:58                                      ; preds = %52
   %59 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %59, null
-  br i1 %NullCheck14, label %60, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.IO.StreamWriter addrspace(1)* %59, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %60
 
 ; <label>:60                                      ; preds = %58
   %61 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %59, i32 0, i32 3
   %62 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
   %64 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %NullCheck16 = icmp ne %"System.Byte[]" addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %"System.Byte[]" addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %60
   %66 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %64, i32 0, i32 1
@@ -12526,8 +14235,8 @@ entry:
   %68 = zext i32 %67 to i64
   %69 = trunc i64 %68 to i32
   %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck18, label %71, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
   %72 = load i64, i64 addrspace(1)* %70
@@ -12543,29 +14252,29 @@ entry:
 
 ; <label>:80                                      ; preds = %27, %52, %71
   %81 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %81, null
-  br i1 %NullCheck20, label %82, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.IO.StreamWriter addrspace(1)* %81, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
 
 ; <label>:82                                      ; preds = %80
   %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %81, i32 0, i32 5
   %84 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %83, align 8
   %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.IO.StreamWriter addrspace(1)* %85, null
-  br i1 %NullCheck22, label %86, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.IO.StreamWriter addrspace(1)* %85, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %86
 
 ; <label>:86                                      ; preds = %82
   %87 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 7
   %88 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %87, align 8
   %89 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %89, null
-  br i1 %NullCheck24, label %90, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.StreamWriter addrspace(1)* %89, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %90
 
 ; <label>:90                                      ; preds = %86
   %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %89, i32 0, i32 9
   %92 = load i32, i32 addrspace(1)* %91, align 8
   %93 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.IO.StreamWriter addrspace(1)* %93, null
-  br i1 %NullCheck26, label %94, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.IO.StreamWriter addrspace(1)* %93, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %93, i32 0, i32 6
@@ -12573,8 +14282,8 @@ entry:
   %97 = load i8, i8* %arg2
   %98 = zext i8 %97 to i32
   %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
-  %NullCheck28 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck28, label %100, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
   %101 = load i64, i64 addrspace(1)* %99
@@ -12589,8 +14298,8 @@ entry:
   %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
   store i32 %110, i32* %loc1
   %111 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %111, null
-  br i1 %NullCheck30, label %112, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.IO.StreamWriter addrspace(1)* %111, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %112
 
 ; <label>:112                                     ; preds = %100
   %113 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %111, i32 0, i32 9
@@ -12601,23 +14310,23 @@ entry:
 
 ; <label>:116                                     ; preds = %112
   %117 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck32 = icmp ne %System.IO.StreamWriter addrspace(1)* %117, null
-  br i1 %NullCheck32, label %118, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.IO.StreamWriter addrspace(1)* %117, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %118
 
 ; <label>:118                                     ; preds = %116
   %119 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %117, i32 0, i32 3
   %120 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %119, align 8
   %121 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.IO.StreamWriter addrspace(1)* %121, null
-  br i1 %NullCheck34, label %122, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.IO.StreamWriter addrspace(1)* %121, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %122
 
 ; <label>:122                                     ; preds = %118
   %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
   %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
   %125 = load i32, i32* %loc1
   %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
-  %NullCheck36 = icmp ne i64 addrspace(1)* %126, null
-  br i1 %NullCheck36, label %127, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64 addrspace(1)* %126, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
   %128 = load i64, i64 addrspace(1)* %126
@@ -12639,15 +14348,15 @@ entry:
 
 ; <label>:140                                     ; preds = %136
   %141 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.IO.StreamWriter addrspace(1)* %141, null
-  br i1 %NullCheck38, label %142, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.IO.StreamWriter addrspace(1)* %141, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %142
 
 ; <label>:142                                     ; preds = %140
   %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
   %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
   %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
-  %NullCheck40 = icmp ne i64 addrspace(1)* %145, null
-  br i1 %NullCheck40, label %146, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i64 addrspace(1)* %145, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
   %147 = load i64, i64 addrspace(1)* %145
@@ -12668,83 +14377,83 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %25
+ThrowNullRef4:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %32
+ThrowNullRef6:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %37
+ThrowNullRef10:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %41
+ThrowNullRef12:                                   ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %58
+ThrowNullRef14:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %60
+ThrowNullRef16:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %65
+ThrowNullRef18:                                   ; preds = %65
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %80
+ThrowNullRef20:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %82
+ThrowNullRef22:                                   ; preds = %82
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %86
+ThrowNullRef24:                                   ; preds = %86
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %90
+ThrowNullRef26:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %94
+ThrowNullRef28:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %100
+ThrowNullRef30:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %116
+ThrowNullRef32:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %118
+ThrowNullRef34:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %122
+ThrowNullRef36:                                   ; preds = %122
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %140
+ThrowNullRef38:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %142
+ThrowNullRef40:                                   ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12811,8 +14520,8 @@ entry:
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %1 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
-  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
@@ -12820,8 +14529,8 @@ entry:
   %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
   %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
   %8 = load i64, i64 addrspace(1)* %6
@@ -12837,8 +14546,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %17, %System.IFormatProvider addrspace(1)* %16)
   %18 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %19 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %18, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.SyncTextWriter addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %7
   %21 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %18, i32 0, i32 4
@@ -12849,11 +14558,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12866,8 +14575,8 @@ entry:
   %this = alloca %System.IO.TextWriter addrspace(1)*
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.TextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
@@ -12877,8 +14586,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.Threading.Thread addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Threading.Thread addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %6)
@@ -12887,8 +14596,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1
   %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.TextWriter addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.TextWriter addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %11, i32 0, i32 2
@@ -12899,11 +14608,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13100,8 +14809,8 @@ entry:
   store float %param1, float* %arg1
   store i8 0, i8* %loc1
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
@@ -13111,16 +14820,16 @@ entry:
   %5 = addrspacecast i8* %loc1 to i8 addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %4, i8 addrspace(1)* %5)
   %6 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.SyncTextWriter addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
   %10 = load float, float* %arg1
   %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
   %13 = load i64, i64 addrspace(1)* %11
@@ -13155,11 +14864,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13176,8 +14885,8 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load float, float* %arg1
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -13191,8 +14900,8 @@ entry:
   call void %11(%System.IO.TextWriter addrspace(1)* %0, float %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
   %15 = load i64, i64 addrspace(1)* %13
@@ -13210,7 +14919,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13228,8 +14937,8 @@ entry:
   %1 = addrspacecast float* %arg1 to float addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -13244,8 +14953,8 @@ entry:
   %14 = bitcast float addrspace(1)* %1 to %System.Single addrspace(1)*
   %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Single addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Single addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
   %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
   %18 = load i64, i64 addrspace(1)* %16
@@ -13263,7 +14972,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13279,8 +14988,8 @@ entry:
   store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
   %0 = load %System.Single addrspace(1)*, %System.Single addrspace(1)** %this
   %1 = bitcast %System.Single addrspace(1)* %0 to float addrspace(1)*
-  %NullCheck = icmp ne float addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq float addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load float, float addrspace(1)* %1, align 8
@@ -13305,8 +15014,8 @@ entry:
   %loc0 = alloca %System.Globalization.NumberFormatInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 3
@@ -13316,8 +15025,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
@@ -13327,24 +15036,24 @@ entry:
   store %System.Globalization.NumberFormatInfo addrspace(1)* %10, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
   %11 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %7
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
   %15 = load i8, i8 addrspace(1)* %14, align 8
   %16 = zext i8 %15 to i32
   %17 = trunc i32 %16 to i8
-  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %11, null
-  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %11, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %13
   %19 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %11, i32 0, i32 29
   store i8 %17, i8 addrspace(1)* %19
   %20 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %21 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %20, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %20, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %18
   %23 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %20, i32 0, i32 3
@@ -13353,8 +15062,8 @@ entry:
 
 ; <label>:24                                      ; preds = %1, %22
   %25 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %25, null
-  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %25, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %26
 
 ; <label>:26                                      ; preds = %24
   %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %25, i32 0, i32 3
@@ -13365,23 +15074,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %18
+ThrowNullRef8:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13406,168 +15115,168 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 18
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %8, align 8
-  %NullCheck2 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %5, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %5, i32 0, i32 4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %9)
   %12 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 19
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %15, align 8
-  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %12, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %12, i32 0, i32 5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %16)
   %19 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %20 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %20, null
-  br i1 %NullCheck8, label %21, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %20, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %20, i32 0, i32 23
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  %NullCheck10 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %19, null
-  br i1 %NullCheck10, label %24, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %19, i32 0, i32 7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %25, %System.String addrspace(1)* %23)
   %26 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %27 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %27, i32 0, i32 22
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %29, align 8
-  %NullCheck14 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %26, null
-  br i1 %NullCheck14, label %31, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %26, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %26, i32 0, i32 6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %32, %System.String addrspace(1)* %30)
   %33 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %34 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Globalization.CultureData addrspace(1)* %34, null
-  br i1 %NullCheck16, label %35, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Globalization.CultureData addrspace(1)* %34, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %34, i32 0, i32 51
   %37 = load i32, i32 addrspace(1)* %36, align 8
-  %NullCheck18 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %33, null
-  br i1 %NullCheck18, label %38, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %33, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %33, i32 0, i32 21
   store i32 %37, i32 addrspace(1)* %39
   %40 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %41 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Globalization.CultureData addrspace(1)* %41, null
-  br i1 %NullCheck20, label %42, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Globalization.CultureData addrspace(1)* %41, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %41, i32 0, i32 52
   %44 = load i32, i32 addrspace(1)* %43, align 8
-  %NullCheck22 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %40, null
-  br i1 %NullCheck22, label %45, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %40, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %40, i32 0, i32 25
   store i32 %44, i32 addrspace(1)* %46
   %47 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %48 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.Globalization.CultureData addrspace(1)* %48, null
-  br i1 %NullCheck24, label %49, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Globalization.CultureData addrspace(1)* %48, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %49
 
 ; <label>:49                                      ; preds = %45
   %50 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %48, i32 0, i32 29
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck26 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %47, null
-  br i1 %NullCheck26, label %52, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %47, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %47, i32 0, i32 10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %53, %System.String addrspace(1)* %51)
   %54 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %55 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Globalization.CultureData addrspace(1)* %55, null
-  br i1 %NullCheck28, label %56, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Globalization.CultureData addrspace(1)* %55, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %56
 
 ; <label>:56                                      ; preds = %52
   %57 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %55, i32 0, i32 35
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %57, align 8
-  %NullCheck30 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %54, null
-  br i1 %NullCheck30, label %59, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %54, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %54, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %60, %System.String addrspace(1)* %58)
   %61 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %62 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck32 = icmp ne %System.Globalization.CultureData addrspace(1)* %62, null
-  br i1 %NullCheck32, label %63, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Globalization.CultureData addrspace(1)* %62, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %62, i32 0, i32 34
   %65 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %64, align 8
-  %NullCheck34 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %61, null
-  br i1 %NullCheck34, label %66, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %61, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %61, i32 0, i32 9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %67, %System.String addrspace(1)* %65)
   %68 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %69 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck36 = icmp ne %System.Globalization.CultureData addrspace(1)* %69, null
-  br i1 %NullCheck36, label %70, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Globalization.CultureData addrspace(1)* %69, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %70
 
 ; <label>:70                                      ; preds = %66
   %71 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %69, i32 0, i32 55
   %72 = load i32, i32 addrspace(1)* %71, align 8
-  %NullCheck38 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %68, null
-  br i1 %NullCheck38, label %73, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %68, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %68, i32 0, i32 22
   store i32 %72, i32 addrspace(1)* %74
   %75 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %76 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck40 = icmp ne %System.Globalization.CultureData addrspace(1)* %76, null
-  br i1 %NullCheck40, label %77, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Globalization.CultureData addrspace(1)* %76, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %76, i32 0, i32 57
   %79 = load i32, i32 addrspace(1)* %78, align 8
-  %NullCheck42 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %75, null
-  br i1 %NullCheck42, label %80, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %75, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %80
 
 ; <label>:80                                      ; preds = %77
   %81 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %75, i32 0, i32 24
   store i32 %79, i32 addrspace(1)* %81
   %82 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %83 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck44 = icmp ne %System.Globalization.CultureData addrspace(1)* %83, null
-  br i1 %NullCheck44, label %84, label %ThrowNullRef43
+  %NullCheck43 = icmp eq %System.Globalization.CultureData addrspace(1)* %83, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %84
 
 ; <label>:84                                      ; preds = %80
   %85 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %83, i32 0, i32 56
   %86 = load i32, i32 addrspace(1)* %85, align 8
-  %NullCheck46 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %82, null
-  br i1 %NullCheck46, label %87, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %82, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %82, i32 0, i32 23
@@ -13576,8 +15285,8 @@ entry:
 
 ; <label>:89                                      ; preds = %entry
   %90 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck100 = icmp ne %System.Globalization.CultureData addrspace(1)* %90, null
-  br i1 %NullCheck100, label %91, label %ThrowNullRef99
+  %NullCheck99 = icmp eq %System.Globalization.CultureData addrspace(1)* %90, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %91
 
 ; <label>:91                                      ; preds = %89
   %92 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %90, i32 0, i32 2
@@ -13595,8 +15304,8 @@ entry:
   %102 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %103 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %104 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %103)
-  %NullCheck48 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %102, null
-  br i1 %NullCheck48, label %105, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %102, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %105
 
 ; <label>:105                                     ; preds = %101
   %106 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %102, i32 0, i32 1
@@ -13604,8 +15313,8 @@ entry:
   %107 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %108 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %109 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %108)
-  %NullCheck50 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %107, null
-  br i1 %NullCheck50, label %110, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %107, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %110
 
 ; <label>:110                                     ; preds = %105
   %111 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %107, i32 0, i32 2
@@ -13613,8 +15322,8 @@ entry:
   %112 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %113 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %114 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %113)
-  %NullCheck52 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %112, null
-  br i1 %NullCheck52, label %115, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %112, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %115
 
 ; <label>:115                                     ; preds = %110
   %116 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %112, i32 0, i32 27
@@ -13622,8 +15331,8 @@ entry:
   %117 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %118 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %119 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %118)
-  %NullCheck54 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %117, null
-  br i1 %NullCheck54, label %120, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %117, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %120
 
 ; <label>:120                                     ; preds = %115
   %121 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %117, i32 0, i32 26
@@ -13631,8 +15340,8 @@ entry:
   %122 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %123 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %124 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %123)
-  %NullCheck56 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %122, null
-  br i1 %NullCheck56, label %125, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %122, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %125
 
 ; <label>:125                                     ; preds = %120
   %126 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %122, i32 0, i32 17
@@ -13640,8 +15349,8 @@ entry:
   %127 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %128 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %129 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %128)
-  %NullCheck58 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %127, null
-  br i1 %NullCheck58, label %130, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %127, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %130
 
 ; <label>:130                                     ; preds = %125
   %131 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %127, i32 0, i32 18
@@ -13649,8 +15358,8 @@ entry:
   %132 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %133 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %134 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %133)
-  %NullCheck60 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %132, null
-  br i1 %NullCheck60, label %135, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %132, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %135
 
 ; <label>:135                                     ; preds = %130
   %136 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %132, i32 0, i32 14
@@ -13658,8 +15367,8 @@ entry:
   %137 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %138 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %139 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %138)
-  %NullCheck62 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %137, null
-  br i1 %NullCheck62, label %140, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %137, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %140
 
 ; <label>:140                                     ; preds = %135
   %141 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %137, i32 0, i32 13
@@ -13667,71 +15376,71 @@ entry:
   %142 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %143 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %144 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %143)
-  %NullCheck64 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %142, null
-  br i1 %NullCheck64, label %145, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %142, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %145
 
 ; <label>:145                                     ; preds = %140
   %146 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %142, i32 0, i32 12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %146, %System.String addrspace(1)* %144)
   %147 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %148 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck66 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %148, null
-  br i1 %NullCheck66, label %149, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %148, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %149
 
 ; <label>:149                                     ; preds = %145
   %150 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %148, i32 0, i32 21
   %151 = load i32, i32 addrspace(1)* %150, align 8
-  %NullCheck68 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %147, null
-  br i1 %NullCheck68, label %152, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %147, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %152
 
 ; <label>:152                                     ; preds = %149
   %153 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %147, i32 0, i32 28
   store i32 %151, i32 addrspace(1)* %153
   %154 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %155 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck70 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %155, null
-  br i1 %NullCheck70, label %156, label %ThrowNullRef69
+  %NullCheck69 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %155, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %156
 
 ; <label>:156                                     ; preds = %152
   %157 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %155, i32 0, i32 6
   %158 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %157, align 8
-  %NullCheck72 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %154, null
-  br i1 %NullCheck72, label %159, label %ThrowNullRef71
+  %NullCheck71 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %154, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %159
 
 ; <label>:159                                     ; preds = %156
   %160 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %154, i32 0, i32 15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %160, %System.String addrspace(1)* %158)
   %161 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %162 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck74 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %162, null
-  br i1 %NullCheck74, label %163, label %ThrowNullRef73
+  %NullCheck73 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %162, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %163
 
 ; <label>:163                                     ; preds = %159
   %164 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %162, i32 0, i32 1
   %165 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %164, align 8
-  %NullCheck76 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %161, null
-  br i1 %NullCheck76, label %166, label %ThrowNullRef75
+  %NullCheck75 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %161, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %166
 
 ; <label>:166                                     ; preds = %163
   %167 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %161, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %167, %"System.Int32[]" addrspace(1)* %165)
   %168 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %169 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck78 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %169, null
-  br i1 %NullCheck78, label %170, label %ThrowNullRef77
+  %NullCheck77 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %169, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %170
 
 ; <label>:170                                     ; preds = %166
   %171 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %169, i32 0, i32 7
   %172 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %171, align 8
-  %NullCheck80 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %168, null
-  br i1 %NullCheck80, label %173, label %ThrowNullRef79
+  %NullCheck79 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %168, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %173
 
 ; <label>:173                                     ; preds = %170
   %174 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %168, i32 0, i32 16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %174, %System.String addrspace(1)* %172)
   %175 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck82 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %175, null
-  br i1 %NullCheck82, label %176, label %ThrowNullRef81
+  %NullCheck81 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %175, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %176
 
 ; <label>:176                                     ; preds = %173
   %177 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %175, i32 0, i32 4
@@ -13741,14 +15450,14 @@ entry:
 
 ; <label>:180                                     ; preds = %176
   %181 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck84 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %181, null
-  br i1 %NullCheck84, label %182, label %ThrowNullRef83
+  %NullCheck83 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %181, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %182
 
 ; <label>:182                                     ; preds = %180
   %183 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %181, i32 0, i32 4
   %184 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %183, align 8
-  %NullCheck86 = icmp ne %System.String addrspace(1)* %184, null
-  br i1 %NullCheck86, label %185, label %ThrowNullRef85
+  %NullCheck85 = icmp eq %System.String addrspace(1)* %184, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %185
 
 ; <label>:185                                     ; preds = %182
   %186 = getelementptr inbounds %System.String, %System.String addrspace(1)* %184, i32 0, i32 1
@@ -13759,8 +15468,8 @@ entry:
 ; <label>:189                                     ; preds = %176, %185
   %190 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck98 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %190, null
-  br i1 %NullCheck98, label %192, label %ThrowNullRef97
+  %NullCheck97 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %190, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %192
 
 ; <label>:192                                     ; preds = %189
   %193 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %190, i32 0, i32 4
@@ -13769,8 +15478,8 @@ entry:
 
 ; <label>:194                                     ; preds = %185, %192
   %195 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck88 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %195, null
-  br i1 %NullCheck88, label %196, label %ThrowNullRef87
+  %NullCheck87 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %195, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %196
 
 ; <label>:196                                     ; preds = %194
   %197 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %195, i32 0, i32 9
@@ -13780,14 +15489,14 @@ entry:
 
 ; <label>:200                                     ; preds = %196
   %201 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck90 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %201, null
-  br i1 %NullCheck90, label %202, label %ThrowNullRef89
+  %NullCheck89 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %201, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %202
 
 ; <label>:202                                     ; preds = %200
   %203 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %201, i32 0, i32 9
   %204 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %203, align 8
-  %NullCheck92 = icmp ne %System.String addrspace(1)* %204, null
-  br i1 %NullCheck92, label %205, label %ThrowNullRef91
+  %NullCheck91 = icmp eq %System.String addrspace(1)* %204, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %205
 
 ; <label>:205                                     ; preds = %202
   %206 = getelementptr inbounds %System.String, %System.String addrspace(1)* %204, i32 0, i32 1
@@ -13798,14 +15507,14 @@ entry:
 ; <label>:209                                     ; preds = %196, %205
   %210 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %211 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck94 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %211, null
-  br i1 %NullCheck94, label %212, label %ThrowNullRef93
+  %NullCheck93 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %211, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %212
 
 ; <label>:212                                     ; preds = %209
   %213 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %211, i32 0, i32 6
   %214 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %213, align 8
-  %NullCheck96 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %210, null
-  br i1 %NullCheck96, label %215, label %ThrowNullRef95
+  %NullCheck95 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %210, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %215
 
 ; <label>:215                                     ; preds = %212
   %216 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %210, i32 0, i32 9
@@ -13819,203 +15528,203 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %17
+ThrowNullRef8:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %21
+ThrowNullRef10:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %24
+ThrowNullRef12:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %28
+ThrowNullRef14:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %31
+ThrowNullRef16:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %35
+ThrowNullRef18:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %38
+ThrowNullRef20:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %42
+ThrowNullRef22:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %45
+ThrowNullRef24:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %49
+ThrowNullRef26:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %52
+ThrowNullRef28:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %56
+ThrowNullRef30:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %59
+ThrowNullRef32:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %63
+ThrowNullRef34:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %66
+ThrowNullRef36:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %70
+ThrowNullRef38:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %73
+ThrowNullRef40:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %77
+ThrowNullRef42:                                   ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %80
+ThrowNullRef44:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %84
+ThrowNullRef46:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %101
+ThrowNullRef48:                                   ; preds = %101
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %105
+ThrowNullRef50:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %110
+ThrowNullRef52:                                   ; preds = %110
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %115
+ThrowNullRef54:                                   ; preds = %115
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %120
+ThrowNullRef56:                                   ; preds = %120
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %125
+ThrowNullRef58:                                   ; preds = %125
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %130
+ThrowNullRef60:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %135
+ThrowNullRef62:                                   ; preds = %135
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %140
+ThrowNullRef64:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %145
+ThrowNullRef66:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %149
+ThrowNullRef68:                                   ; preds = %149
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %152
+ThrowNullRef70:                                   ; preds = %152
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %156
+ThrowNullRef72:                                   ; preds = %156
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %159
+ThrowNullRef74:                                   ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %163
+ThrowNullRef76:                                   ; preds = %163
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %166
+ThrowNullRef78:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %170
+ThrowNullRef80:                                   ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %173
+ThrowNullRef82:                                   ; preds = %173
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %180
+ThrowNullRef84:                                   ; preds = %180
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %182
+ThrowNullRef86:                                   ; preds = %182
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %194
+ThrowNullRef88:                                   ; preds = %194
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %200
+ThrowNullRef90:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %202
+ThrowNullRef92:                                   ; preds = %202
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %209
+ThrowNullRef94:                                   ; preds = %209
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %212
+ThrowNullRef96:                                   ; preds = %212
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %189
+ThrowNullRef98:                                   ; preds = %189
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %89
+ThrowNullRef100:                                  ; preds = %89
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14043,8 +15752,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 21
@@ -14057,8 +15766,8 @@ entry:
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 16)
   %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 21
@@ -14067,8 +15776,8 @@ entry:
 
 ; <label>:12                                      ; preds = %1, %10
   %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 21
@@ -14079,11 +15788,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %12
+ThrowNullRef4:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14099,8 +15808,8 @@ entry:
   store i32 %param1, i32* %arg1
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %1 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
@@ -14167,8 +15876,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 33
@@ -14181,8 +15890,8 @@ entry:
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 24)
   %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 33
@@ -14191,8 +15900,8 @@ entry:
 
 ; <label>:12                                      ; preds = %1, %10
   %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 33
@@ -14203,11 +15912,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %12
+ThrowNullRef4:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14220,8 +15929,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 53
@@ -14233,8 +15942,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 116)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 53
@@ -14243,8 +15952,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 53
@@ -14255,11 +15964,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14288,8 +15997,8 @@ entry:
 
 ; <label>:7                                       ; preds = %entry, %4
   %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %7
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 2
@@ -14313,8 +16022,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 54
@@ -14326,8 +16035,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 117)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
@@ -14336,8 +16045,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 54
@@ -14348,11 +16057,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14365,8 +16074,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 27
@@ -14378,8 +16087,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 118)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 27
@@ -14388,8 +16097,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 27
@@ -14400,11 +16109,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14417,8 +16126,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 28
@@ -14430,8 +16139,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 119)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 28
@@ -14440,8 +16149,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 28
@@ -14452,11 +16161,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14469,8 +16178,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 26
@@ -14482,8 +16191,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 107)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 26
@@ -14492,8 +16201,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 26
@@ -14504,11 +16213,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14521,8 +16230,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 25
@@ -14534,8 +16243,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 106)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 25
@@ -14544,8 +16253,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 25
@@ -14556,11 +16265,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14573,8 +16282,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 24
@@ -14586,8 +16295,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 105)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 24
@@ -14596,8 +16305,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 24
@@ -14608,11 +16317,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14637,8 +16346,8 @@ entry:
   %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %3)
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %2
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -14649,15 +16358,15 @@ entry:
 
 ; <label>:8                                       ; preds = %62
   %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 9
   %12 = load i32, i32 addrspace(1)* %11, align 8
   %13 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.IO.StreamWriter addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %13, i32 0, i32 10
@@ -14672,15 +16381,15 @@ entry:
 
 ; <label>:20                                      ; preds = %14, %18
   %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
   %24 = load i32, i32 addrspace(1)* %23, align 8
   %25 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %25, null
-  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.StreamWriter addrspace(1)* %25, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %25, i32 0, i32 9
@@ -14701,36 +16410,36 @@ entry:
   %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %37 = load i32, i32* %loc1
   %38 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.StreamWriter addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %35
   %40 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %38, i32 0, i32 7
   %41 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %40, align 8
   %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
-  br i1 %NullCheck14, label %43, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %39
   %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 9
   %45 = load i32, i32 addrspace(1)* %44, align 8
   %46 = load i32, i32* %loc2
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %36, null
-  br i1 %NullCheck16, label %47, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %36, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %47
 
 ; <label>:47                                      ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %36, i32 %37, %"System.Char[]" addrspace(1)* %41, i32 %45, i32 %46)
   %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
   %51 = load i32, i32 addrspace(1)* %50, align 8
   %52 = load i32, i32* %loc2
   %53 = add i32 %51, %52
-  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
-  br i1 %NullCheck20, label %54, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %54
 
 ; <label>:54                                      ; preds = %49
   %55 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
@@ -14752,8 +16461,8 @@ entry:
 
 ; <label>:65                                      ; preds = %62
   %66 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %66, null
-  br i1 %NullCheck2, label %67, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %66, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %67
 
 ; <label>:67                                      ; preds = %65
   %68 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %66, i32 0, i32 11
@@ -14774,49 +16483,259 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %65
+ThrowNullRef2:                                    ; preds = %65
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %20
+ThrowNullRef8:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %22
+ThrowNullRef10:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %35
+ThrowNullRef12:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %43
+ThrowNullRef16:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %47
+ThrowNullRef18:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method String::CopyTo using LLILCJit
-Failed to read String.CopyTo[loadElemA]
+Successfully read String.CopyTo
+
+define void @String.CopyTo(%System.String addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  %loc1 = alloca i16 addrspace(1)*
+  %loc2 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %1 = icmp ne %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg4
+  %7 = icmp sge i32 %6, 0
+  br i1 %7, label %13, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  unreachable
+
+; <label>:13                                      ; preds = %5
+  %14 = load i32, i32* %arg1
+  %15 = icmp sge i32 %14, 0
+  br i1 %15, label %21, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %18)
+  %20 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %20, %System.String addrspace(1)* %17, %System.String addrspace(1)* %19)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %20) #0
+  unreachable
+
+; <label>:21                                      ; preds = %13
+  %22 = load i32, i32* %arg4
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck, label %ThrowNullRef, label %24
+
+; <label>:24                                      ; preds = %21
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load i32, i32* %arg1
+  %28 = sub i32 %26, %27
+  %29 = icmp sle i32 %22, %28
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34, %System.String addrspace(1)* %31, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %24
+  %36 = load i32, i32* %arg3
+  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %37, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
+
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
+  %40 = load i32, i32 addrspace(1)* %39
+  %41 = zext i32 %40 to i64
+  %42 = trunc i64 %41 to i32
+  %43 = load i32, i32* %arg4
+  %44 = sub i32 %42, %43
+  %45 = icmp sgt i32 %36, %44
+  br i1 %45, label %49, label %46
+
+; <label>:46                                      ; preds = %38
+  %47 = load i32, i32* %arg3
+  %48 = icmp sge i32 %47, 0
+  br i1 %48, label %54, label %49
+
+; <label>:49                                      ; preds = %38, %46
+  %50 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %52 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %51)
+  %53 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53, %System.String addrspace(1)* %50, %System.String addrspace(1)* %52)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53) #0
+  unreachable
+
+; <label>:54                                      ; preds = %46
+  %55 = load i32, i32* %arg4
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %97, label %57
+
+; <label>:57                                      ; preds = %54
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %59
+
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 2
+  %61 = bitcast [0 x i16] addrspace(1)* %60 to i16 addrspace(1)*
+  store i16 addrspace(1)* %61, i16 addrspace(1)** %loc0
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  store %"System.Char[]" addrspace(1)* %62, %"System.Char[]" addrspace(1)** %loc2
+  %63 = icmp eq %"System.Char[]" addrspace(1)* %62, null
+  br i1 %63, label %72, label %64
+
+; <label>:64                                      ; preds = %59
+  %65 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc2
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %65, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %66
+
+; <label>:66                                      ; preds = %64
+  %67 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %65, i32 0, i32 1
+  %68 = load i32, i32 addrspace(1)* %67
+  %69 = zext i32 %68 to i64
+  %70 = trunc i64 %69 to i32
+  %71 = icmp ne i32 %70, 0
+  br i1 %71, label %73, label %72
+
+; <label>:72                                      ; preds = %59, %66
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  br label %81
+
+; <label>:73                                      ; preds = %66
+  %74 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc2
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %74, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %75
+
+; <label>:75                                      ; preds = %73
+  %76 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %74, i32 0, i32 1
+  %77 = load i32, i32 addrspace(1)* %76
+  %78 = zext i32 %77 to i64
+  %BoundsCheck = icmp uge i64 0, %78
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %79
+
+; <label>:79                                      ; preds = %75
+  %80 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %74, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %80, i16 addrspace(1)** %loc1
+  br label %81
+
+; <label>:81                                      ; preds = %72, %79
+  %82 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %83 = ptrtoint i16 addrspace(1)* %82 to i64
+  %84 = load i32, i32* %arg3
+  %85 = sext i32 %84 to i64
+  %86 = mul i64 %85, 2
+  %87 = add i64 %83, %86
+  %88 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %89 = ptrtoint i16 addrspace(1)* %88 to i64
+  %90 = load i32, i32* %arg1
+  %91 = sext i32 %90 to i64
+  %92 = mul i64 %91, 2
+  %93 = add i64 %89, %92
+  %94 = load i32, i32* %arg4
+  %95 = inttoptr i64 %87 to i16*
+  %96 = inttoptr i64 %93 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %95, i16* %96, i32 %94)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  br label %97
+
+; <label>:97                                      ; preds = %54, %81
+  ret void
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
 Successfully read ConsoleEncoding.GetPreamble
 
@@ -14853,7 +16772,365 @@ entry:
 }
 
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[loadElemA]
+Successfully read EncoderNLS.GetBytes
+
+define i32 @EncoderNLS.GetBytes(%System.Text.EncoderNLS addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3, %"System.Byte[]" addrspace(1)* %param4, i32 %param5, i8 %param6) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %arg4 = alloca %"System.Byte[]" addrspace(1)*
+  %arg5 = alloca i32
+  %arg6 = alloca i8
+  %loc0 = alloca i32
+  %loc1 = alloca i16 addrspace(1)*
+  %loc2 = alloca i8 addrspace(1)*
+  %loc3 = alloca i32
+  %loc4 = alloca %"System.Char[]" addrspace(1)*
+  %loc5 = alloca %"System.Byte[]" addrspace(1)*
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  store %"System.Byte[]" addrspace(1)* %param4, %"System.Byte[]" addrspace(1)** %arg4
+  store i32 %param5, i32* %arg5
+  store i8 %param6, i8* %arg6
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %1 = icmp eq %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %17, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %7 = icmp eq %"System.Char[]" addrspace(1)* %6, null
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %12
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %12
+
+; <label>:12                                      ; preds = %8, %10
+  %13 = phi %System.String addrspace(1)* [ %9, %8 ], [ %11, %10 ]
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %14)
+  %16 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16, %System.String addrspace(1)* %13, %System.String addrspace(1)* %15)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16) #0
+  unreachable
+
+; <label>:17                                      ; preds = %2
+  %18 = load i32, i32* %arg2
+  %19 = icmp slt i32 %18, 0
+  br i1 %19, label %23, label %20
+
+; <label>:20                                      ; preds = %17
+  %21 = load i32, i32* %arg3
+  %22 = icmp sge i32 %21, 0
+  br i1 %22, label %35, label %23
+
+; <label>:23                                      ; preds = %17, %20
+  %24 = load i32, i32* %arg2
+  %25 = icmp slt i32 %24, 0
+  br i1 %25, label %28, label %26
+
+; <label>:26                                      ; preds = %23
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %30
+
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %30
+
+; <label>:30                                      ; preds = %26, %28
+  %31 = phi %System.String addrspace(1)* [ %27, %26 ], [ %29, %28 ]
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34, %System.String addrspace(1)* %31, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %20
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck, label %ThrowNullRef, label %37
+
+; <label>:37                                      ; preds = %35
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = load i32, i32* %arg2
+  %43 = sub i32 %41, %42
+  %44 = load i32, i32* %arg3
+  %45 = icmp sge i32 %43, %44
+  br i1 %45, label %51, label %46
+
+; <label>:46                                      ; preds = %37
+  %47 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %48 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %49 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %48)
+  %50 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %50, %System.String addrspace(1)* %47, %System.String addrspace(1)* %49)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %50) #0
+  unreachable
+
+; <label>:51                                      ; preds = %37
+  %52 = load i32, i32* %arg5
+  %53 = icmp slt i32 %52, 0
+  br i1 %53, label %63, label %54
+
+; <label>:54                                      ; preds = %51
+  %55 = load i32, i32* %arg5
+  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck1 = icmp eq %"System.Byte[]" addrspace(1)* %56, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %57
+
+; <label>:57                                      ; preds = %54
+  %58 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = zext i32 %59 to i64
+  %61 = trunc i64 %60 to i32
+  %62 = icmp sle i32 %55, %61
+  br i1 %62, label %68, label %63
+
+; <label>:63                                      ; preds = %51, %57
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %66 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %65)
+  %67 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %67, %System.String addrspace(1)* %64, %System.String addrspace(1)* %66)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %67) #0
+  unreachable
+
+; <label>:68                                      ; preds = %57
+  %69 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %69, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %69, i32 0, i32 1
+  %72 = load i32, i32 addrspace(1)* %71
+  %73 = zext i32 %72 to i64
+  %74 = trunc i64 %73 to i32
+  %75 = icmp ne i32 %74, 0
+  br i1 %75, label %78, label %76
+
+; <label>:76                                      ; preds = %70
+  %77 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1)
+  store %"System.Char[]" addrspace(1)* %77, %"System.Char[]" addrspace(1)** %arg1
+  br label %78
+
+; <label>:78                                      ; preds = %70, %76
+  %79 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck5 = icmp eq %"System.Byte[]" addrspace(1)* %79, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %80
+
+; <label>:80                                      ; preds = %78
+  %81 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %79, i32 0, i32 1
+  %82 = load i32, i32 addrspace(1)* %81
+  %83 = zext i32 %82 to i64
+  %84 = trunc i64 %83 to i32
+  %85 = load i32, i32* %arg5
+  %86 = sub i32 %84, %85
+  store i32 %86, i32* %loc0
+  %87 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck7 = icmp eq %"System.Byte[]" addrspace(1)* %87, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %88
+
+; <label>:88                                      ; preds = %80
+  %89 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %87, i32 0, i32 1
+  %90 = load i32, i32 addrspace(1)* %89
+  %91 = zext i32 %90 to i64
+  %92 = trunc i64 %91 to i32
+  %93 = icmp ne i32 %92, 0
+  br i1 %93, label %96, label %94
+
+; <label>:94                                      ; preds = %88
+  %95 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1)
+  store %"System.Byte[]" addrspace(1)* %95, %"System.Byte[]" addrspace(1)** %arg4
+  br label %96
+
+; <label>:96                                      ; preds = %88, %94
+  %97 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  store %"System.Char[]" addrspace(1)* %97, %"System.Char[]" addrspace(1)** %loc4
+  %98 = icmp eq %"System.Char[]" addrspace(1)* %97, null
+  br i1 %98, label %107, label %99
+
+; <label>:99                                      ; preds = %96
+  %100 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc4
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %100, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %101
+
+; <label>:101                                     ; preds = %99
+  %102 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %100, i32 0, i32 1
+  %103 = load i32, i32 addrspace(1)* %102
+  %104 = zext i32 %103 to i64
+  %105 = trunc i64 %104 to i32
+  %106 = icmp ne i32 %105, 0
+  br i1 %106, label %108, label %107
+
+; <label>:107                                     ; preds = %96, %101
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  br label %116
+
+; <label>:108                                     ; preds = %101
+  %109 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc4
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %109, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %110
+
+; <label>:110                                     ; preds = %108
+  %111 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %109, i32 0, i32 1
+  %112 = load i32, i32 addrspace(1)* %111
+  %113 = zext i32 %112 to i64
+  %BoundsCheck = icmp uge i64 0, %113
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %114
+
+; <label>:114                                     ; preds = %110
+  %115 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %109, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %115, i16 addrspace(1)** %loc1
+  br label %116
+
+; <label>:116                                     ; preds = %107, %114
+  %117 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  store %"System.Byte[]" addrspace(1)* %117, %"System.Byte[]" addrspace(1)** %loc5
+  %118 = icmp eq %"System.Byte[]" addrspace(1)* %117, null
+  br i1 %118, label %127, label %119
+
+; <label>:119                                     ; preds = %116
+  %120 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc5
+  %NullCheck13 = icmp eq %"System.Byte[]" addrspace(1)* %120, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %121
+
+; <label>:121                                     ; preds = %119
+  %122 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %120, i32 0, i32 1
+  %123 = load i32, i32 addrspace(1)* %122
+  %124 = zext i32 %123 to i64
+  %125 = trunc i64 %124 to i32
+  %126 = icmp ne i32 %125, 0
+  br i1 %126, label %128, label %127
+
+; <label>:127                                     ; preds = %116, %121
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc2
+  br label %136
+
+; <label>:128                                     ; preds = %121
+  %129 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc5
+  %NullCheck15 = icmp eq %"System.Byte[]" addrspace(1)* %129, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %130
+
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %129, i32 0, i32 1
+  %132 = load i32, i32 addrspace(1)* %131
+  %133 = zext i32 %132 to i64
+  %BoundsCheck17 = icmp uge i64 0, %133
+  br i1 %BoundsCheck17, label %ThrowIndexOutOfRange18, label %134
+
+; <label>:134                                     ; preds = %130
+  %135 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %129, i32 0, i32 3, i32 0
+  store i8 addrspace(1)* %135, i8 addrspace(1)** %loc2
+  br label %136
+
+; <label>:136                                     ; preds = %127, %134
+  %137 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %138 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %139 = ptrtoint i16 addrspace(1)* %138 to i64
+  %140 = load i32, i32* %arg2
+  %141 = sext i32 %140 to i64
+  %142 = mul i64 %141, 2
+  %143 = add i64 %139, %142
+  %144 = load i32, i32* %arg3
+  %145 = load i8 addrspace(1)*, i8 addrspace(1)** %loc2
+  %146 = ptrtoint i8 addrspace(1)* %145 to i64
+  %147 = load i32, i32* %arg5
+  %148 = sext i32 %147 to i64
+  %149 = add i64 %146, %148
+  %150 = load i32, i32* %loc0
+  %151 = load i8, i8* %arg6
+  %152 = zext i8 %151 to i32
+  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i64 addrspace(1)*
+  %NullCheck19 = icmp eq i64 addrspace(1)* %153, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %154
+
+; <label>:154                                     ; preds = %136
+  %155 = load i64, i64 addrspace(1)* %153
+  %156 = add i64 %155, 72
+  %157 = inttoptr i64 %156 to i64*
+  %158 = load i64, i64* %157
+  %159 = add i64 %158, 0
+  %160 = inttoptr i64 %159 to i64*
+  %161 = load i64, i64* %160
+  %162 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to %System.Text.Encoder addrspace(1)*
+  %163 = inttoptr i64 %143 to i16*
+  %164 = inttoptr i64 %149 to i8*
+  %165 = trunc i32 %152 to i8
+  %166 = inttoptr i64 %161 to i32 (%System.Text.Encoder addrspace(1)*, i16*, i32, i8*, i32, i8)*
+  %167 = call i32 %166(%System.Text.Encoder addrspace(1)* %162, i16* %163, i32 %144, i8* %164, i32 %150, i8 %165)
+  store i32 %167, i32* %loc3
+  br label %168
+
+; <label>:168                                     ; preds = %154
+  %169 = load i32, i32* %loc3
+  ret i32 %169
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %110
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %119
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange18:                           ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
 Successfully read EncoderNLS.GetBytes
 
@@ -14942,22 +17219,22 @@ entry:
   %40 = load i8, i8* %arg5
   %41 = zext i8 %40 to i32
   %42 = trunc i32 %41 to i8
-  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %39, null
-  br i1 %NullCheck, label %43, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderNLS addrspace(1)* %39, null
+  br i1 %NullCheck, label %ThrowNullRef, label %43
 
 ; <label>:43                                      ; preds = %38
   %44 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
   store i8 %42, i8 addrspace(1)* %44
   %45 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %45, null
-  br i1 %NullCheck2, label %46, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.EncoderNLS addrspace(1)* %45, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %46
 
 ; <label>:46                                      ; preds = %43
   %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %45, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %47
   %48 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.EncoderNLS addrspace(1)* %48, null
-  br i1 %NullCheck4, label %49, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.EncoderNLS addrspace(1)* %48, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %49
 
 ; <label>:49                                      ; preds = %46
   %50 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %48, i32 0, i32 3
@@ -14968,8 +17245,8 @@ entry:
   %55 = load i32, i32* %arg4
   %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck6, label %58, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
   %59 = load i64, i64 addrspace(1)* %57
@@ -14987,15 +17264,15 @@ ThrowNullRef:                                     ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %43
+ThrowNullRef2:                                    ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %46
+ThrowNullRef4:                                    ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %49
+ThrowNullRef6:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -15023,8 +17300,8 @@ entry:
   %4 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0 to %System.IO.ConsoleStream addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*)(%System.IO.ConsoleStream addrspace(1)* %4, %"System.Byte[]" addrspace(1)* %1, i32 %2, i32 %3)
   %5 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
@@ -15109,8 +17386,8 @@ entry:
 
 ; <label>:22                                      ; preds = %8
   %23 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %23, null
-  br i1 %NullCheck, label %24, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Byte[]" addrspace(1)* %23, null
+  br i1 %NullCheck, label %ThrowNullRef, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
@@ -15132,8 +17409,8 @@ entry:
 
 ; <label>:36                                      ; preds = %24
   %37 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %37, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.ConsoleStream addrspace(1)* %37, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %37, i32 0, i32 4
@@ -15154,13 +17431,138 @@ ThrowNullRef:                                     ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %36
+ThrowNullRef2:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
-Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
+Successfully read WindowsConsoleStream.WriteFileNative
+
+define i32 @WindowsConsoleStream.WriteFileNative(i64 %param0, %"System.Byte[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i64
+  %arg1 = alloca %"System.Byte[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i8 addrspace(1)*
+  %loc2 = alloca %"System.Byte[]" addrspace(1)*
+  %loc3 = alloca i32
+  store i64 %param0, i64* %arg0
+  store %"System.Byte[]" addrspace(1)* %param1, %"System.Byte[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Byte[]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = zext i32 %3 to i64
+  %5 = icmp ne i64 %4, 0
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %1
+  ret i32 0
+
+; <label>:7                                       ; preds = %1
+  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  store %"System.Byte[]" addrspace(1)* %8, %"System.Byte[]" addrspace(1)** %loc2
+  %9 = icmp eq %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %9, label %18, label %10
+
+; <label>:10                                      ; preds = %7
+  %11 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc2
+  %NullCheck1 = icmp eq %"System.Byte[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %11, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp ne i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %7, %12
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc1
+  br label %27
+
+; <label>:19                                      ; preds = %12
+  %20 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc2
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %20, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %BoundsCheck = icmp uge i64 0, %24
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %25
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %20, i32 0, i32 3, i32 0
+  store i8 addrspace(1)* %26, i8 addrspace(1)** %loc1
+  br label %27
+
+; <label>:27                                      ; preds = %18, %25
+  %28 = load i64, i64* %arg0
+  %29 = load i8 addrspace(1)*, i8 addrspace(1)** %loc1
+  %30 = ptrtoint i8 addrspace(1)* %29 to i64
+  %31 = load i32, i32* %arg2
+  %32 = sext i32 %31 to i64
+  %33 = add i64 %30, %32
+  %34 = load i32, i32* %arg3
+  %35 = addrspacecast i32* %loc3 to i32 addrspace(1)*
+  %36 = inttoptr i64 %33 to i8*
+  %37 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i8*, i32, i32 addrspace(1)*, i64)*)(i64 %28, i8* %36, i32 %34, i32 addrspace(1)* %35, i64 0)
+  %38 = icmp ugt i32 %37, 0
+  %39 = sext i1 %38 to i32
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc1
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %42, label %41
+
+; <label>:41                                      ; preds = %27
+  ret i32 0
+
+; <label>:42                                      ; preds = %27
+  %43 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  store i32 %43, i32* %loc0
+  %44 = load i32, i32* %loc0
+  %45 = icmp eq i32 %44, 232
+  br i1 %45, label %49, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = load i32, i32* %loc0
+  %48 = icmp ne i32 %47, 109
+  br i1 %48, label %50, label %49
+
+; <label>:49                                      ; preds = %42, %46
+  ret i32 0
+
+; <label>:50                                      ; preds = %46
+  %51 = load i32, i32* %loc0
+  ret i32 %51
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
 Successfully read WindowsConsoleStream.Flush
 
@@ -15169,8 +17571,8 @@ entry:
   %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
   store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
@@ -15205,8 +17607,8 @@ entry:
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
   %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load i64, i64 addrspace(1)* %1
@@ -15245,15 +17647,15 @@ entry:
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.TextWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
   %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %3, align 8
   %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
   %7 = load i64, i64 addrspace(1)* %5
@@ -15271,7 +17673,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -15300,8 +17702,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %4)
   store i32 0, i32* %loc0
   %5 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Char[]" addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
@@ -15313,15 +17715,15 @@ entry:
 
 ; <label>:11                                      ; preds = %69
   %12 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %12, i32 0, i32 9
   %15 = load i32, i32 addrspace(1)* %14, align 8
   %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.IO.StreamWriter addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %16, i32 0, i32 10
@@ -15336,15 +17738,15 @@ entry:
 
 ; <label>:23                                      ; preds = %17, %21
   %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %24, null
-  br i1 %NullCheck8, label %25, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %24, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 10
   %27 = load i32, i32 addrspace(1)* %26, align 8
   %28 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %28, null
-  br i1 %NullCheck10, label %29, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.StreamWriter addrspace(1)* %28, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %28, i32 0, i32 9
@@ -15366,15 +17768,15 @@ entry:
   %40 = load i32, i32* %loc0
   %41 = mul i32 %40, 2
   %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
-  br i1 %NullCheck12, label %43, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %43
 
 ; <label>:43                                      ; preds = %38
   %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 7
   %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %44, align 8
   %46 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %46, null
-  br i1 %NullCheck14, label %47, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.IO.StreamWriter addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %47
 
 ; <label>:47                                      ; preds = %43
   %48 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %46, i32 0, i32 9
@@ -15386,16 +17788,16 @@ entry:
   %54 = bitcast %"System.Char[]" addrspace(1)* %45 to %System.Array addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %53, i32 %41, %System.Array addrspace(1)* %54, i32 %50, i32 %52)
   %55 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
-  br i1 %NullCheck16, label %56, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %56
 
 ; <label>:56                                      ; preds = %47
   %57 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
   %58 = load i32, i32 addrspace(1)* %57, align 8
   %59 = load i32, i32* %loc2
   %60 = add i32 %58, %59
-  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
-  br i1 %NullCheck18, label %61, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %61
 
 ; <label>:61                                      ; preds = %56
   %62 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
@@ -15417,8 +17819,8 @@ entry:
 
 ; <label>:72                                      ; preds = %69
   %73 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %73, null
-  br i1 %NullCheck2, label %74, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %73, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %74
 
 ; <label>:74                                      ; preds = %72
   %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %73, i32 0, i32 11
@@ -15439,39 +17841,39 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %72
+ThrowNullRef2:                                    ; preds = %72
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %23
+ThrowNullRef8:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef10:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %43
+ThrowNullRef14:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %47
+ThrowNullRef16:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %56
+ThrowNullRef18:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPArray.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPArray.error.txt
@@ -25,8 +25,8 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
@@ -40,8 +40,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
   %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
@@ -75,7 +75,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -90,8 +90,8 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %NullCheck = icmp ne i8 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = load i8, i8 addrspace(1)* %0, align 8
@@ -125,8 +125,8 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
@@ -159,8 +159,8 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -184,8 +184,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
   store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
@@ -195,8 +195,8 @@ entry:
 ; <label>:4                                       ; preds = %1
   %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
   %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
@@ -206,8 +206,8 @@ entry:
   %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
@@ -221,14 +221,14 @@ entry:
 
 ; <label>:17                                      ; preds = %14
   %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
   %21 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
@@ -238,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -249,8 +249,8 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
@@ -261,27 +261,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %30
+ThrowNullRef10:                                   ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -301,7 +301,89 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
-Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
+Successfully read AppDomainSetup.GetUnsecureApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.GetUnsecureApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %NullCheck = icmp eq %"System.String[]" addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %BoundsCheck = icmp uge i64 0, %5
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %6
+
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 3, i32 0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
+  ret %System.String addrspace(1)* %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_Value using LLILCJit
+Successfully read AppDomainSetup.get_Value
+
+define %"System.String[]" addrspace(1)* @AppDomainSetup.get_Value(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.String[]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 18)
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.String[]" addrspace(1)* addrspace(1)*, %"System.String[]" addrspace(1)*)*)(%"System.String[]" addrspace(1)* addrspace(1)* %9, %"System.String[]" addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %11, i32 0, i32 1
+  %14 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %13, align 8
+  ret %"System.String[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -319,8 +401,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -368,16 +450,16 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
   %5 = load i32, i32 addrspace(1)* %4
   %6 = sub i32 %5, 1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -389,7 +471,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -421,8 +503,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
@@ -456,8 +538,8 @@ entry:
 ; <label>:27                                      ; preds = %19
   %28 = load i32, i32* %arg1
   %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
-  br i1 %NullCheck2, label %30, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %29, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %30
 
 ; <label>:30                                      ; preds = %27
   %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
@@ -493,8 +575,8 @@ entry:
 ; <label>:49                                      ; preds = %46
   %50 = load i32, i32* %arg2
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck4, label %52, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
@@ -517,11 +599,11 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %27
+ThrowNullRef2:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %49
+ThrowNullRef4:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -544,16 +626,16 @@ entry:
   %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %0)
   store %System.String addrspace(1)* %1, %System.String addrspace(1)** %loc0
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 2
   %5 = bitcast [0 x i16] addrspace(1)* %4 to i16 addrspace(1)*
   store i16 addrspace(1)* %5, i16 addrspace(1)** %loc1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %3
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2
@@ -580,7 +662,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -691,15 +773,15 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %NullCheck132 = icmp ne i8* %21, null
-  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+  %NullCheck131 = icmp eq i8* %21, null
+  br i1 %NullCheck131, label %ThrowNullRef132, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = load i8, i8* %21, align 8
   %24 = zext i8 %23 to i32
   %25 = trunc i32 %24 to i8
-  %NullCheck134 = icmp ne i8* %20, null
-  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+  %NullCheck133 = icmp eq i8* %20, null
+  br i1 %NullCheck133, label %ThrowNullRef134, label %26
 
 ; <label>:26                                      ; preds = %22
   store i8 %25, i8* %20, align 8
@@ -709,16 +791,16 @@ entry:
   %28 = load i8*, i8** %arg0
   %29 = load i8*, i8** %arg1
   %30 = bitcast i8* %29 to i16*
-  %NullCheck128 = icmp ne i16* %30, null
-  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+  %NullCheck127 = icmp eq i16* %30, null
+  br i1 %NullCheck127, label %ThrowNullRef128, label %31
 
 ; <label>:31                                      ; preds = %27
   %32 = load i16, i16* %30, align 8
   %33 = sext i16 %32 to i32
   %34 = bitcast i8* %28 to i16*
   %35 = trunc i32 %33 to i16
-  %NullCheck130 = icmp ne i16* %34, null
-  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+  %NullCheck129 = icmp eq i16* %34, null
+  br i1 %NullCheck129, label %ThrowNullRef130, label %36
 
 ; <label>:36                                      ; preds = %31
   store i16 %35, i16* %34, align 8
@@ -728,16 +810,16 @@ entry:
   %38 = load i8*, i8** %arg0
   %39 = load i8*, i8** %arg1
   %40 = bitcast i8* %39 to i16*
-  %NullCheck120 = icmp ne i16* %40, null
-  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+  %NullCheck119 = icmp eq i16* %40, null
+  br i1 %NullCheck119, label %ThrowNullRef120, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i16, i16* %40, align 8
   %43 = sext i16 %42 to i32
   %44 = bitcast i8* %38 to i16*
   %45 = trunc i32 %43 to i16
-  %NullCheck122 = icmp ne i16* %44, null
-  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+  %NullCheck121 = icmp eq i16* %44, null
+  br i1 %NullCheck121, label %ThrowNullRef122, label %46
 
 ; <label>:46                                      ; preds = %41
   store i16 %45, i16* %44, align 8
@@ -745,15 +827,15 @@ entry:
   %48 = getelementptr inbounds i8, i8* %47, i64 2
   %49 = load i8*, i8** %arg1
   %50 = getelementptr inbounds i8, i8* %49, i64 2
-  %NullCheck124 = icmp ne i8* %50, null
-  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+  %NullCheck123 = icmp eq i8* %50, null
+  br i1 %NullCheck123, label %ThrowNullRef124, label %51
 
 ; <label>:51                                      ; preds = %46
   %52 = load i8, i8* %50, align 8
   %53 = zext i8 %52 to i32
   %54 = trunc i32 %53 to i8
-  %NullCheck126 = icmp ne i8* %48, null
-  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+  %NullCheck125 = icmp eq i8* %48, null
+  br i1 %NullCheck125, label %ThrowNullRef126, label %55
 
 ; <label>:55                                      ; preds = %51
   store i8 %54, i8* %48, align 8
@@ -763,14 +845,14 @@ entry:
   %57 = load i8*, i8** %arg0
   %58 = load i8*, i8** %arg1
   %59 = bitcast i8* %58 to i32*
-  %NullCheck116 = icmp ne i32* %59, null
-  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+  %NullCheck115 = icmp eq i32* %59, null
+  br i1 %NullCheck115, label %ThrowNullRef116, label %60
 
 ; <label>:60                                      ; preds = %56
   %61 = load i32, i32* %59, align 8
   %62 = bitcast i8* %57 to i32*
-  %NullCheck118 = icmp ne i32* %62, null
-  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+  %NullCheck117 = icmp eq i32* %62, null
+  br i1 %NullCheck117, label %ThrowNullRef118, label %63
 
 ; <label>:63                                      ; preds = %60
   store i32 %61, i32* %62, align 8
@@ -780,14 +862,14 @@ entry:
   %65 = load i8*, i8** %arg0
   %66 = load i8*, i8** %arg1
   %67 = bitcast i8* %66 to i32*
-  %NullCheck108 = icmp ne i32* %67, null
-  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+  %NullCheck107 = icmp eq i32* %67, null
+  br i1 %NullCheck107, label %ThrowNullRef108, label %68
 
 ; <label>:68                                      ; preds = %64
   %69 = load i32, i32* %67, align 8
   %70 = bitcast i8* %65 to i32*
-  %NullCheck110 = icmp ne i32* %70, null
-  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+  %NullCheck109 = icmp eq i32* %70, null
+  br i1 %NullCheck109, label %ThrowNullRef110, label %71
 
 ; <label>:71                                      ; preds = %68
   store i32 %69, i32* %70, align 8
@@ -795,15 +877,15 @@ entry:
   %73 = getelementptr inbounds i8, i8* %72, i64 4
   %74 = load i8*, i8** %arg1
   %75 = getelementptr inbounds i8, i8* %74, i64 4
-  %NullCheck112 = icmp ne i8* %75, null
-  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+  %NullCheck111 = icmp eq i8* %75, null
+  br i1 %NullCheck111, label %ThrowNullRef112, label %76
 
 ; <label>:76                                      ; preds = %71
   %77 = load i8, i8* %75, align 8
   %78 = zext i8 %77 to i32
   %79 = trunc i32 %78 to i8
-  %NullCheck114 = icmp ne i8* %73, null
-  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+  %NullCheck113 = icmp eq i8* %73, null
+  br i1 %NullCheck113, label %ThrowNullRef114, label %80
 
 ; <label>:80                                      ; preds = %76
   store i8 %79, i8* %73, align 8
@@ -813,14 +895,14 @@ entry:
   %82 = load i8*, i8** %arg0
   %83 = load i8*, i8** %arg1
   %84 = bitcast i8* %83 to i32*
-  %NullCheck100 = icmp ne i32* %84, null
-  br i1 %NullCheck100, label %85, label %ThrowNullRef99
+  %NullCheck99 = icmp eq i32* %84, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %85
 
 ; <label>:85                                      ; preds = %81
   %86 = load i32, i32* %84, align 8
   %87 = bitcast i8* %82 to i32*
-  %NullCheck102 = icmp ne i32* %87, null
-  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+  %NullCheck101 = icmp eq i32* %87, null
+  br i1 %NullCheck101, label %ThrowNullRef102, label %88
 
 ; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
@@ -829,16 +911,16 @@ entry:
   %91 = load i8*, i8** %arg1
   %92 = getelementptr inbounds i8, i8* %91, i64 4
   %93 = bitcast i8* %92 to i16*
-  %NullCheck104 = icmp ne i16* %93, null
-  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+  %NullCheck103 = icmp eq i16* %93, null
+  br i1 %NullCheck103, label %ThrowNullRef104, label %94
 
 ; <label>:94                                      ; preds = %88
   %95 = load i16, i16* %93, align 8
   %96 = sext i16 %95 to i32
   %97 = bitcast i8* %90 to i16*
   %98 = trunc i32 %96 to i16
-  %NullCheck106 = icmp ne i16* %97, null
-  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+  %NullCheck105 = icmp eq i16* %97, null
+  br i1 %NullCheck105, label %ThrowNullRef106, label %99
 
 ; <label>:99                                      ; preds = %94
   store i16 %98, i16* %97, align 8
@@ -848,14 +930,14 @@ entry:
   %101 = load i8*, i8** %arg0
   %102 = load i8*, i8** %arg1
   %103 = bitcast i8* %102 to i32*
-  %NullCheck88 = icmp ne i32* %103, null
-  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+  %NullCheck87 = icmp eq i32* %103, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %104
 
 ; <label>:104                                     ; preds = %100
   %105 = load i32, i32* %103, align 8
   %106 = bitcast i8* %101 to i32*
-  %NullCheck90 = icmp ne i32* %106, null
-  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+  %NullCheck89 = icmp eq i32* %106, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %107
 
 ; <label>:107                                     ; preds = %104
   store i32 %105, i32* %106, align 8
@@ -864,16 +946,16 @@ entry:
   %110 = load i8*, i8** %arg1
   %111 = getelementptr inbounds i8, i8* %110, i64 4
   %112 = bitcast i8* %111 to i16*
-  %NullCheck92 = icmp ne i16* %112, null
-  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+  %NullCheck91 = icmp eq i16* %112, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %113
 
 ; <label>:113                                     ; preds = %107
   %114 = load i16, i16* %112, align 8
   %115 = sext i16 %114 to i32
   %116 = bitcast i8* %109 to i16*
   %117 = trunc i32 %115 to i16
-  %NullCheck94 = icmp ne i16* %116, null
-  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+  %NullCheck93 = icmp eq i16* %116, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %118
 
 ; <label>:118                                     ; preds = %113
   store i16 %117, i16* %116, align 8
@@ -881,15 +963,15 @@ entry:
   %120 = getelementptr inbounds i8, i8* %119, i64 6
   %121 = load i8*, i8** %arg1
   %122 = getelementptr inbounds i8, i8* %121, i64 6
-  %NullCheck96 = icmp ne i8* %122, null
-  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+  %NullCheck95 = icmp eq i8* %122, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %123
 
 ; <label>:123                                     ; preds = %118
   %124 = load i8, i8* %122, align 8
   %125 = zext i8 %124 to i32
   %126 = trunc i32 %125 to i8
-  %NullCheck98 = icmp ne i8* %120, null
-  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+  %NullCheck97 = icmp eq i8* %120, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %127
 
 ; <label>:127                                     ; preds = %123
   store i8 %126, i8* %120, align 8
@@ -899,14 +981,14 @@ entry:
   %129 = load i8*, i8** %arg0
   %130 = load i8*, i8** %arg1
   %131 = bitcast i8* %130 to i64*
-  %NullCheck84 = icmp ne i64* %131, null
-  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+  %NullCheck83 = icmp eq i64* %131, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %132
 
 ; <label>:132                                     ; preds = %128
   %133 = load i64, i64* %131, align 8
   %134 = bitcast i8* %129 to i64*
-  %NullCheck86 = icmp ne i64* %134, null
-  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+  %NullCheck85 = icmp eq i64* %134, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %135
 
 ; <label>:135                                     ; preds = %132
   store i64 %133, i64* %134, align 8
@@ -916,14 +998,14 @@ entry:
   %137 = load i8*, i8** %arg0
   %138 = load i8*, i8** %arg1
   %139 = bitcast i8* %138 to i64*
-  %NullCheck76 = icmp ne i64* %139, null
-  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+  %NullCheck75 = icmp eq i64* %139, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %140
 
 ; <label>:140                                     ; preds = %136
   %141 = load i64, i64* %139, align 8
   %142 = bitcast i8* %137 to i64*
-  %NullCheck78 = icmp ne i64* %142, null
-  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+  %NullCheck77 = icmp eq i64* %142, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %143
 
 ; <label>:143                                     ; preds = %140
   store i64 %141, i64* %142, align 8
@@ -931,15 +1013,15 @@ entry:
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %NullCheck80 = icmp ne i8* %147, null
-  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+  %NullCheck79 = icmp eq i8* %147, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %148
 
 ; <label>:148                                     ; preds = %143
   %149 = load i8, i8* %147, align 8
   %150 = zext i8 %149 to i32
   %151 = trunc i32 %150 to i8
-  %NullCheck82 = icmp ne i8* %145, null
-  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+  %NullCheck81 = icmp eq i8* %145, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %152
 
 ; <label>:152                                     ; preds = %148
   store i8 %151, i8* %145, align 8
@@ -949,14 +1031,14 @@ entry:
   %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
   %156 = bitcast i8* %155 to i64*
-  %NullCheck68 = icmp ne i64* %156, null
-  br i1 %NullCheck68, label %157, label %ThrowNullRef67
+  %NullCheck67 = icmp eq i64* %156, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %157
 
 ; <label>:157                                     ; preds = %153
   %158 = load i64, i64* %156, align 8
   %159 = bitcast i8* %154 to i64*
-  %NullCheck70 = icmp ne i64* %159, null
-  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+  %NullCheck69 = icmp eq i64* %159, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %160
 
 ; <label>:160                                     ; preds = %157
   store i64 %158, i64* %159, align 8
@@ -965,16 +1047,16 @@ entry:
   %163 = load i8*, i8** %arg1
   %164 = getelementptr inbounds i8, i8* %163, i64 8
   %165 = bitcast i8* %164 to i16*
-  %NullCheck72 = icmp ne i16* %165, null
-  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+  %NullCheck71 = icmp eq i16* %165, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %166
 
 ; <label>:166                                     ; preds = %160
   %167 = load i16, i16* %165, align 8
   %168 = sext i16 %167 to i32
   %169 = bitcast i8* %162 to i16*
   %170 = trunc i32 %168 to i16
-  %NullCheck74 = icmp ne i16* %169, null
-  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+  %NullCheck73 = icmp eq i16* %169, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %171
 
 ; <label>:171                                     ; preds = %166
   store i16 %170, i16* %169, align 8
@@ -984,14 +1066,14 @@ entry:
   %173 = load i8*, i8** %arg0
   %174 = load i8*, i8** %arg1
   %175 = bitcast i8* %174 to i64*
-  %NullCheck56 = icmp ne i64* %175, null
-  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+  %NullCheck55 = icmp eq i64* %175, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %176
 
 ; <label>:176                                     ; preds = %172
   %177 = load i64, i64* %175, align 8
   %178 = bitcast i8* %173 to i64*
-  %NullCheck58 = icmp ne i64* %178, null
-  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+  %NullCheck57 = icmp eq i64* %178, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %179
 
 ; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
@@ -1000,16 +1082,16 @@ entry:
   %182 = load i8*, i8** %arg1
   %183 = getelementptr inbounds i8, i8* %182, i64 8
   %184 = bitcast i8* %183 to i16*
-  %NullCheck60 = icmp ne i16* %184, null
-  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+  %NullCheck59 = icmp eq i16* %184, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %185
 
 ; <label>:185                                     ; preds = %179
   %186 = load i16, i16* %184, align 8
   %187 = sext i16 %186 to i32
   %188 = bitcast i8* %181 to i16*
   %189 = trunc i32 %187 to i16
-  %NullCheck62 = icmp ne i16* %188, null
-  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+  %NullCheck61 = icmp eq i16* %188, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %190
 
 ; <label>:190                                     ; preds = %185
   store i16 %189, i16* %188, align 8
@@ -1017,15 +1099,15 @@ entry:
   %192 = getelementptr inbounds i8, i8* %191, i64 10
   %193 = load i8*, i8** %arg1
   %194 = getelementptr inbounds i8, i8* %193, i64 10
-  %NullCheck64 = icmp ne i8* %194, null
-  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+  %NullCheck63 = icmp eq i8* %194, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %195
 
 ; <label>:195                                     ; preds = %190
   %196 = load i8, i8* %194, align 8
   %197 = zext i8 %196 to i32
   %198 = trunc i32 %197 to i8
-  %NullCheck66 = icmp ne i8* %192, null
-  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+  %NullCheck65 = icmp eq i8* %192, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %199
 
 ; <label>:199                                     ; preds = %195
   store i8 %198, i8* %192, align 8
@@ -1035,14 +1117,14 @@ entry:
   %201 = load i8*, i8** %arg0
   %202 = load i8*, i8** %arg1
   %203 = bitcast i8* %202 to i64*
-  %NullCheck48 = icmp ne i64* %203, null
-  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+  %NullCheck47 = icmp eq i64* %203, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %204
 
 ; <label>:204                                     ; preds = %200
   %205 = load i64, i64* %203, align 8
   %206 = bitcast i8* %201 to i64*
-  %NullCheck50 = icmp ne i64* %206, null
-  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+  %NullCheck49 = icmp eq i64* %206, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %207
 
 ; <label>:207                                     ; preds = %204
   store i64 %205, i64* %206, align 8
@@ -1051,14 +1133,14 @@ entry:
   %210 = load i8*, i8** %arg1
   %211 = getelementptr inbounds i8, i8* %210, i64 8
   %212 = bitcast i8* %211 to i32*
-  %NullCheck52 = icmp ne i32* %212, null
-  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+  %NullCheck51 = icmp eq i32* %212, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %213
 
 ; <label>:213                                     ; preds = %207
   %214 = load i32, i32* %212, align 8
   %215 = bitcast i8* %209 to i32*
-  %NullCheck54 = icmp ne i32* %215, null
-  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+  %NullCheck53 = icmp eq i32* %215, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %216
 
 ; <label>:216                                     ; preds = %213
   store i32 %214, i32* %215, align 8
@@ -1068,14 +1150,14 @@ entry:
   %218 = load i8*, i8** %arg0
   %219 = load i8*, i8** %arg1
   %220 = bitcast i8* %219 to i64*
-  %NullCheck36 = icmp ne i64* %220, null
-  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64* %220, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %221
 
 ; <label>:221                                     ; preds = %217
   %222 = load i64, i64* %220, align 8
   %223 = bitcast i8* %218 to i64*
-  %NullCheck38 = icmp ne i64* %223, null
-  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+  %NullCheck37 = icmp eq i64* %223, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %224
 
 ; <label>:224                                     ; preds = %221
   store i64 %222, i64* %223, align 8
@@ -1084,14 +1166,14 @@ entry:
   %227 = load i8*, i8** %arg1
   %228 = getelementptr inbounds i8, i8* %227, i64 8
   %229 = bitcast i8* %228 to i32*
-  %NullCheck40 = icmp ne i32* %229, null
-  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i32* %229, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %230
 
 ; <label>:230                                     ; preds = %224
   %231 = load i32, i32* %229, align 8
   %232 = bitcast i8* %226 to i32*
-  %NullCheck42 = icmp ne i32* %232, null
-  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+  %NullCheck41 = icmp eq i32* %232, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %233
 
 ; <label>:233                                     ; preds = %230
   store i32 %231, i32* %232, align 8
@@ -1099,15 +1181,15 @@ entry:
   %235 = getelementptr inbounds i8, i8* %234, i64 12
   %236 = load i8*, i8** %arg1
   %237 = getelementptr inbounds i8, i8* %236, i64 12
-  %NullCheck44 = icmp ne i8* %237, null
-  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i8* %237, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %238
 
 ; <label>:238                                     ; preds = %233
   %239 = load i8, i8* %237, align 8
   %240 = zext i8 %239 to i32
   %241 = trunc i32 %240 to i8
-  %NullCheck46 = icmp ne i8* %235, null
-  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+  %NullCheck45 = icmp eq i8* %235, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %242
 
 ; <label>:242                                     ; preds = %238
   store i8 %241, i8* %235, align 8
@@ -1117,14 +1199,14 @@ entry:
   %244 = load i8*, i8** %arg0
   %245 = load i8*, i8** %arg1
   %246 = bitcast i8* %245 to i64*
-  %NullCheck24 = icmp ne i64* %246, null
-  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64* %246, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %247
 
 ; <label>:247                                     ; preds = %243
   %248 = load i64, i64* %246, align 8
   %249 = bitcast i8* %244 to i64*
-  %NullCheck26 = icmp ne i64* %249, null
-  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64* %249, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %250
 
 ; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
@@ -1133,14 +1215,14 @@ entry:
   %253 = load i8*, i8** %arg1
   %254 = getelementptr inbounds i8, i8* %253, i64 8
   %255 = bitcast i8* %254 to i32*
-  %NullCheck28 = icmp ne i32* %255, null
-  br i1 %NullCheck28, label %256, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i32* %255, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %256
 
 ; <label>:256                                     ; preds = %250
   %257 = load i32, i32* %255, align 8
   %258 = bitcast i8* %252 to i32*
-  %NullCheck30 = icmp ne i32* %258, null
-  br i1 %NullCheck30, label %259, label %ThrowNullRef29
+  %NullCheck29 = icmp eq i32* %258, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %259
 
 ; <label>:259                                     ; preds = %256
   store i32 %257, i32* %258, align 8
@@ -1149,16 +1231,16 @@ entry:
   %262 = load i8*, i8** %arg1
   %263 = getelementptr inbounds i8, i8* %262, i64 12
   %264 = bitcast i8* %263 to i16*
-  %NullCheck32 = icmp ne i16* %264, null
-  br i1 %NullCheck32, label %265, label %ThrowNullRef31
+  %NullCheck31 = icmp eq i16* %264, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %265
 
 ; <label>:265                                     ; preds = %259
   %266 = load i16, i16* %264, align 8
   %267 = sext i16 %266 to i32
   %268 = bitcast i8* %261 to i16*
   %269 = trunc i32 %267 to i16
-  %NullCheck34 = icmp ne i16* %268, null
-  br i1 %NullCheck34, label %270, label %ThrowNullRef33
+  %NullCheck33 = icmp eq i16* %268, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %270
 
 ; <label>:270                                     ; preds = %265
   store i16 %269, i16* %268, align 8
@@ -1168,14 +1250,14 @@ entry:
   %272 = load i8*, i8** %arg0
   %273 = load i8*, i8** %arg1
   %274 = bitcast i8* %273 to i64*
-  %NullCheck8 = icmp ne i64* %274, null
-  br i1 %NullCheck8, label %275, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64* %274, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %275
 
 ; <label>:275                                     ; preds = %271
   %276 = load i64, i64* %274, align 8
   %277 = bitcast i8* %272 to i64*
-  %NullCheck10 = icmp ne i64* %277, null
-  br i1 %NullCheck10, label %278, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %277, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %278
 
 ; <label>:278                                     ; preds = %275
   store i64 %276, i64* %277, align 8
@@ -1184,14 +1266,14 @@ entry:
   %281 = load i8*, i8** %arg1
   %282 = getelementptr inbounds i8, i8* %281, i64 8
   %283 = bitcast i8* %282 to i32*
-  %NullCheck12 = icmp ne i32* %283, null
-  br i1 %NullCheck12, label %284, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i32* %283, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %284
 
 ; <label>:284                                     ; preds = %278
   %285 = load i32, i32* %283, align 8
   %286 = bitcast i8* %280 to i32*
-  %NullCheck14 = icmp ne i32* %286, null
-  br i1 %NullCheck14, label %287, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i32* %286, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %287
 
 ; <label>:287                                     ; preds = %284
   store i32 %285, i32* %286, align 8
@@ -1200,16 +1282,16 @@ entry:
   %290 = load i8*, i8** %arg1
   %291 = getelementptr inbounds i8, i8* %290, i64 12
   %292 = bitcast i8* %291 to i16*
-  %NullCheck16 = icmp ne i16* %292, null
-  br i1 %NullCheck16, label %293, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i16* %292, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %293
 
 ; <label>:293                                     ; preds = %287
   %294 = load i16, i16* %292, align 8
   %295 = sext i16 %294 to i32
   %296 = bitcast i8* %289 to i16*
   %297 = trunc i32 %295 to i16
-  %NullCheck18 = icmp ne i16* %296, null
-  br i1 %NullCheck18, label %298, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i16* %296, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %298
 
 ; <label>:298                                     ; preds = %293
   store i16 %297, i16* %296, align 8
@@ -1217,15 +1299,15 @@ entry:
   %300 = getelementptr inbounds i8, i8* %299, i64 14
   %301 = load i8*, i8** %arg1
   %302 = getelementptr inbounds i8, i8* %301, i64 14
-  %NullCheck20 = icmp ne i8* %302, null
-  br i1 %NullCheck20, label %303, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i8* %302, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %303
 
 ; <label>:303                                     ; preds = %298
   %304 = load i8, i8* %302, align 8
   %305 = zext i8 %304 to i32
   %306 = trunc i32 %305 to i8
-  %NullCheck22 = icmp ne i8* %300, null
-  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i8* %300, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %307
 
 ; <label>:307                                     ; preds = %303
   store i8 %306, i8* %300, align 8
@@ -1235,14 +1317,14 @@ entry:
   %309 = load i8*, i8** %arg0
   %310 = load i8*, i8** %arg1
   %311 = bitcast i8* %310 to i64*
-  %NullCheck = icmp ne i64* %311, null
-  br i1 %NullCheck, label %312, label %ThrowNullRef
+  %NullCheck = icmp eq i64* %311, null
+  br i1 %NullCheck, label %ThrowNullRef, label %312
 
 ; <label>:312                                     ; preds = %308
   %313 = load i64, i64* %311, align 8
   %314 = bitcast i8* %309 to i64*
-  %NullCheck2 = icmp ne i64* %314, null
-  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64* %314, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %315
 
 ; <label>:315                                     ; preds = %312
   store i64 %313, i64* %314, align 8
@@ -1251,14 +1333,14 @@ entry:
   %318 = load i8*, i8** %arg1
   %319 = getelementptr inbounds i8, i8* %318, i64 8
   %320 = bitcast i8* %319 to i64*
-  %NullCheck4 = icmp ne i64* %320, null
-  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64* %320, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %321
 
 ; <label>:321                                     ; preds = %315
   %322 = load i64, i64* %320, align 8
   %323 = bitcast i8* %317 to i64*
-  %NullCheck6 = icmp ne i64* %323, null
-  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64* %323, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %324
 
 ; <label>:324                                     ; preds = %321
   store i64 %322, i64* %323, align 8
@@ -1286,15 +1368,15 @@ entry:
 ; <label>:338                                     ; preds = %333
   %339 = load i8*, i8** %arg0
   %340 = load i8*, i8** %arg1
-  %NullCheck136 = icmp ne i8* %340, null
-  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+  %NullCheck135 = icmp eq i8* %340, null
+  br i1 %NullCheck135, label %ThrowNullRef136, label %341
 
 ; <label>:341                                     ; preds = %338
   %342 = load i8, i8* %340, align 8
   %343 = zext i8 %342 to i32
   %344 = trunc i32 %343 to i8
-  %NullCheck138 = icmp ne i8* %339, null
-  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+  %NullCheck137 = icmp eq i8* %339, null
+  br i1 %NullCheck137, label %ThrowNullRef138, label %345
 
 ; <label>:345                                     ; preds = %341
   store i8 %344, i8* %339, align 8
@@ -1317,16 +1399,16 @@ entry:
   %357 = load i8*, i8** %arg0
   %358 = load i8*, i8** %arg1
   %359 = bitcast i8* %358 to i16*
-  %NullCheck140 = icmp ne i16* %359, null
-  br i1 %NullCheck140, label %360, label %ThrowNullRef139
+  %NullCheck139 = icmp eq i16* %359, null
+  br i1 %NullCheck139, label %ThrowNullRef140, label %360
 
 ; <label>:360                                     ; preds = %356
   %361 = load i16, i16* %359, align 8
   %362 = sext i16 %361 to i32
   %363 = bitcast i8* %357 to i16*
   %364 = trunc i32 %362 to i16
-  %NullCheck142 = icmp ne i16* %363, null
-  br i1 %NullCheck142, label %365, label %ThrowNullRef141
+  %NullCheck141 = icmp eq i16* %363, null
+  br i1 %NullCheck141, label %ThrowNullRef142, label %365
 
 ; <label>:365                                     ; preds = %360
   store i16 %364, i16* %363, align 8
@@ -1352,14 +1434,14 @@ entry:
   %378 = load i8*, i8** %arg0
   %379 = load i8*, i8** %arg1
   %380 = bitcast i8* %379 to i32*
-  %NullCheck144 = icmp ne i32* %380, null
-  br i1 %NullCheck144, label %381, label %ThrowNullRef143
+  %NullCheck143 = icmp eq i32* %380, null
+  br i1 %NullCheck143, label %ThrowNullRef144, label %381
 
 ; <label>:381                                     ; preds = %377
   %382 = load i32, i32* %380, align 8
   %383 = bitcast i8* %378 to i32*
-  %NullCheck146 = icmp ne i32* %383, null
-  br i1 %NullCheck146, label %384, label %ThrowNullRef145
+  %NullCheck145 = icmp eq i32* %383, null
+  br i1 %NullCheck145, label %ThrowNullRef146, label %384
 
 ; <label>:384                                     ; preds = %381
   store i32 %382, i32* %383, align 8
@@ -1384,14 +1466,14 @@ entry:
   %395 = load i8*, i8** %arg0
   %396 = load i8*, i8** %arg1
   %397 = bitcast i8* %396 to i64*
-  %NullCheck164 = icmp ne i64* %397, null
-  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+  %NullCheck163 = icmp eq i64* %397, null
+  br i1 %NullCheck163, label %ThrowNullRef164, label %398
 
 ; <label>:398                                     ; preds = %394
   %399 = load i64, i64* %397, align 8
   %400 = bitcast i8* %395 to i64*
-  %NullCheck166 = icmp ne i64* %400, null
-  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+  %NullCheck165 = icmp eq i64* %400, null
+  br i1 %NullCheck165, label %ThrowNullRef166, label %401
 
 ; <label>:401                                     ; preds = %398
   store i64 %399, i64* %400, align 8
@@ -1400,14 +1482,14 @@ entry:
   %404 = load i8*, i8** %arg1
   %405 = getelementptr inbounds i8, i8* %404, i64 8
   %406 = bitcast i8* %405 to i64*
-  %NullCheck168 = icmp ne i64* %406, null
-  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+  %NullCheck167 = icmp eq i64* %406, null
+  br i1 %NullCheck167, label %ThrowNullRef168, label %407
 
 ; <label>:407                                     ; preds = %401
   %408 = load i64, i64* %406, align 8
   %409 = bitcast i8* %403 to i64*
-  %NullCheck170 = icmp ne i64* %409, null
-  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+  %NullCheck169 = icmp eq i64* %409, null
+  br i1 %NullCheck169, label %ThrowNullRef170, label %410
 
 ; <label>:410                                     ; preds = %407
   store i64 %408, i64* %409, align 8
@@ -1437,14 +1519,14 @@ entry:
   %425 = load i8*, i8** %arg0
   %426 = load i8*, i8** %arg1
   %427 = bitcast i8* %426 to i64*
-  %NullCheck148 = icmp ne i64* %427, null
-  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+  %NullCheck147 = icmp eq i64* %427, null
+  br i1 %NullCheck147, label %ThrowNullRef148, label %428
 
 ; <label>:428                                     ; preds = %424
   %429 = load i64, i64* %427, align 8
   %430 = bitcast i8* %425 to i64*
-  %NullCheck150 = icmp ne i64* %430, null
-  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+  %NullCheck149 = icmp eq i64* %430, null
+  br i1 %NullCheck149, label %ThrowNullRef150, label %431
 
 ; <label>:431                                     ; preds = %428
   store i64 %429, i64* %430, align 8
@@ -1466,14 +1548,14 @@ entry:
   %441 = load i8*, i8** %arg0
   %442 = load i8*, i8** %arg1
   %443 = bitcast i8* %442 to i32*
-  %NullCheck152 = icmp ne i32* %443, null
-  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+  %NullCheck151 = icmp eq i32* %443, null
+  br i1 %NullCheck151, label %ThrowNullRef152, label %444
 
 ; <label>:444                                     ; preds = %440
   %445 = load i32, i32* %443, align 8
   %446 = bitcast i8* %441 to i32*
-  %NullCheck154 = icmp ne i32* %446, null
-  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+  %NullCheck153 = icmp eq i32* %446, null
+  br i1 %NullCheck153, label %ThrowNullRef154, label %447
 
 ; <label>:447                                     ; preds = %444
   store i32 %445, i32* %446, align 8
@@ -1495,16 +1577,16 @@ entry:
   %457 = load i8*, i8** %arg0
   %458 = load i8*, i8** %arg1
   %459 = bitcast i8* %458 to i16*
-  %NullCheck156 = icmp ne i16* %459, null
-  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+  %NullCheck155 = icmp eq i16* %459, null
+  br i1 %NullCheck155, label %ThrowNullRef156, label %460
 
 ; <label>:460                                     ; preds = %456
   %461 = load i16, i16* %459, align 8
   %462 = sext i16 %461 to i32
   %463 = bitcast i8* %457 to i16*
   %464 = trunc i32 %462 to i16
-  %NullCheck158 = icmp ne i16* %463, null
-  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+  %NullCheck157 = icmp eq i16* %463, null
+  br i1 %NullCheck157, label %ThrowNullRef158, label %465
 
 ; <label>:465                                     ; preds = %460
   store i16 %464, i16* %463, align 8
@@ -1525,15 +1607,15 @@ entry:
 ; <label>:474                                     ; preds = %470
   %475 = load i8*, i8** %arg0
   %476 = load i8*, i8** %arg1
-  %NullCheck160 = icmp ne i8* %476, null
-  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+  %NullCheck159 = icmp eq i8* %476, null
+  br i1 %NullCheck159, label %ThrowNullRef160, label %477
 
 ; <label>:477                                     ; preds = %474
   %478 = load i8, i8* %476, align 8
   %479 = zext i8 %478 to i32
   %480 = trunc i32 %479 to i8
-  %NullCheck162 = icmp ne i8* %475, null
-  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+  %NullCheck161 = icmp eq i8* %475, null
+  br i1 %NullCheck161, label %ThrowNullRef162, label %481
 
 ; <label>:481                                     ; preds = %477
   store i8 %480, i8* %475, align 8
@@ -1553,343 +1635,343 @@ ThrowNullRef:                                     ; preds = %308
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %312
+ThrowNullRef2:                                    ; preds = %312
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %315
+ThrowNullRef4:                                    ; preds = %315
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %321
+ThrowNullRef6:                                    ; preds = %321
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %271
+ThrowNullRef8:                                    ; preds = %271
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %275
+ThrowNullRef10:                                   ; preds = %275
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %278
+ThrowNullRef12:                                   ; preds = %278
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %284
+ThrowNullRef14:                                   ; preds = %284
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %287
+ThrowNullRef16:                                   ; preds = %287
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %293
+ThrowNullRef18:                                   ; preds = %293
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %298
+ThrowNullRef20:                                   ; preds = %298
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %303
+ThrowNullRef22:                                   ; preds = %303
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %243
+ThrowNullRef24:                                   ; preds = %243
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %247
+ThrowNullRef26:                                   ; preds = %247
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %250
+ThrowNullRef28:                                   ; preds = %250
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %256
+ThrowNullRef30:                                   ; preds = %256
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %259
+ThrowNullRef32:                                   ; preds = %259
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %265
+ThrowNullRef34:                                   ; preds = %265
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %217
+ThrowNullRef36:                                   ; preds = %217
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %221
+ThrowNullRef38:                                   ; preds = %221
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %224
+ThrowNullRef40:                                   ; preds = %224
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %230
+ThrowNullRef42:                                   ; preds = %230
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %233
+ThrowNullRef44:                                   ; preds = %233
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %238
+ThrowNullRef46:                                   ; preds = %238
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %200
+ThrowNullRef48:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %204
+ThrowNullRef50:                                   ; preds = %204
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %207
+ThrowNullRef52:                                   ; preds = %207
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %213
+ThrowNullRef54:                                   ; preds = %213
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %172
+ThrowNullRef56:                                   ; preds = %172
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %176
+ThrowNullRef58:                                   ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %179
+ThrowNullRef60:                                   ; preds = %179
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %185
+ThrowNullRef62:                                   ; preds = %185
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %190
+ThrowNullRef64:                                   ; preds = %190
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %195
+ThrowNullRef66:                                   ; preds = %195
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %153
+ThrowNullRef68:                                   ; preds = %153
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %157
+ThrowNullRef70:                                   ; preds = %157
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %160
+ThrowNullRef72:                                   ; preds = %160
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %166
+ThrowNullRef74:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %136
+ThrowNullRef76:                                   ; preds = %136
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %140
+ThrowNullRef78:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %143
+ThrowNullRef80:                                   ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %148
+ThrowNullRef82:                                   ; preds = %148
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %128
+ThrowNullRef84:                                   ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %132
+ThrowNullRef86:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %100
+ThrowNullRef88:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %104
+ThrowNullRef90:                                   ; preds = %104
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %107
+ThrowNullRef92:                                   ; preds = %107
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %113
+ThrowNullRef94:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %118
+ThrowNullRef96:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %123
+ThrowNullRef98:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %81
+ThrowNullRef100:                                  ; preds = %81
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef101:                                  ; preds = %85
+ThrowNullRef102:                                  ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef103:                                  ; preds = %88
+ThrowNullRef104:                                  ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef105:                                  ; preds = %94
+ThrowNullRef106:                                  ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef107:                                  ; preds = %64
+ThrowNullRef108:                                  ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef109:                                  ; preds = %68
+ThrowNullRef110:                                  ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef111:                                  ; preds = %71
+ThrowNullRef112:                                  ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef113:                                  ; preds = %76
+ThrowNullRef114:                                  ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef115:                                  ; preds = %56
+ThrowNullRef116:                                  ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef117:                                  ; preds = %60
+ThrowNullRef118:                                  ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef119:                                  ; preds = %37
+ThrowNullRef120:                                  ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef121:                                  ; preds = %41
+ThrowNullRef122:                                  ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef123:                                  ; preds = %46
+ThrowNullRef124:                                  ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef125:                                  ; preds = %51
+ThrowNullRef126:                                  ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef127:                                  ; preds = %27
+ThrowNullRef128:                                  ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef129:                                  ; preds = %31
+ThrowNullRef130:                                  ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef131:                                  ; preds = %19
+ThrowNullRef132:                                  ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef133:                                  ; preds = %22
+ThrowNullRef134:                                  ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef135:                                  ; preds = %338
+ThrowNullRef136:                                  ; preds = %338
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef137:                                  ; preds = %341
+ThrowNullRef138:                                  ; preds = %341
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef139:                                  ; preds = %356
+ThrowNullRef140:                                  ; preds = %356
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef141:                                  ; preds = %360
+ThrowNullRef142:                                  ; preds = %360
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef143:                                  ; preds = %377
+ThrowNullRef144:                                  ; preds = %377
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef145:                                  ; preds = %381
+ThrowNullRef146:                                  ; preds = %381
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef147:                                  ; preds = %424
+ThrowNullRef148:                                  ; preds = %424
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef149:                                  ; preds = %428
+ThrowNullRef150:                                  ; preds = %428
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef151:                                  ; preds = %440
+ThrowNullRef152:                                  ; preds = %440
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef153:                                  ; preds = %444
+ThrowNullRef154:                                  ; preds = %444
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef155:                                  ; preds = %456
+ThrowNullRef156:                                  ; preds = %456
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef157:                                  ; preds = %460
+ThrowNullRef158:                                  ; preds = %460
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef159:                                  ; preds = %474
+ThrowNullRef160:                                  ; preds = %474
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef161:                                  ; preds = %477
+ThrowNullRef162:                                  ; preds = %477
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef163:                                  ; preds = %394
+ThrowNullRef164:                                  ; preds = %394
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef165:                                  ; preds = %398
+ThrowNullRef166:                                  ; preds = %398
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef167:                                  ; preds = %401
+ThrowNullRef168:                                  ; preds = %401
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef169:                                  ; preds = %407
+ThrowNullRef170:                                  ; preds = %407
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1939,8 +2021,8 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
-  br i1 %NullCheck, label %22, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %ThrowNullRef, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
@@ -1948,8 +2030,8 @@ entry:
   store i32 %24, i32* %loc0
   %25 = load i32, i32* %loc0
   %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %26, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %27
 
 ; <label>:27                                      ; preds = %22
   %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
@@ -1971,7 +2053,7 @@ ThrowNullRef:                                     ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1989,8 +2071,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -2022,15 +2104,15 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2048,16 +2130,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
   %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
   store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %15
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
@@ -2072,8 +2154,8 @@ entry:
   %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
   %29 = ptrtoint i16 addrspace(1)* %28 to i64
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %19
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
@@ -2089,19 +2171,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2114,8 +2196,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
@@ -2128,7 +2210,7 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[loadElem]
+Failed to read AppDomain.PrepareDataForSetup[storeElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
@@ -2202,8 +2284,8 @@ entry:
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
-  br i1 %NullCheck24, label %27, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = load i64, i64 addrspace(1)* %26
@@ -2218,8 +2300,8 @@ entry:
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
-  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
   %41 = load i64, i64 addrspace(1)* %39
@@ -2236,8 +2318,8 @@ entry:
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
-  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
   %54 = load i64, i64 addrspace(1)* %52
@@ -2252,8 +2334,8 @@ entry:
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
   %67 = load i64, i64 addrspace(1)* %65
@@ -2270,8 +2352,8 @@ entry:
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
-  br i1 %NullCheck16, label %79, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
   %80 = load i64, i64 addrspace(1)* %78
@@ -2286,8 +2368,8 @@ entry:
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
-  br i1 %NullCheck18, label %92, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
   %93 = load i64, i64 addrspace(1)* %91
@@ -2304,8 +2386,8 @@ entry:
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
-  br i1 %NullCheck12, label %105, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = load i64, i64 addrspace(1)* %104
@@ -2320,8 +2402,8 @@ entry:
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
-  br i1 %NullCheck14, label %118, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
   %119 = load i64, i64 addrspace(1)* %117
@@ -2337,8 +2419,8 @@ entry:
 
 ; <label>:128                                     ; preds = %20
   %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
-  br i1 %NullCheck4, label %130, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %129, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %130
 
 ; <label>:130                                     ; preds = %128
   %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
@@ -2346,8 +2428,8 @@ entry:
   %133 = load i16, i16 addrspace(1)* %132, align 8
   %134 = zext i16 %133 to i32
   %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
-  br i1 %NullCheck6, label %136, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %135, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %136
 
 ; <label>:136                                     ; preds = %130
   %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
@@ -2360,8 +2442,8 @@ entry:
 
 ; <label>:143                                     ; preds = %136
   %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
-  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %144, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %145
 
 ; <label>:145                                     ; preds = %143
   %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
@@ -2369,8 +2451,8 @@ entry:
   %148 = load i16, i16 addrspace(1)* %147, align 8
   %149 = zext i16 %148 to i32
   %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %150, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %151
 
 ; <label>:151                                     ; preds = %145
   %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
@@ -2388,8 +2470,8 @@ entry:
 
 ; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
-  br i1 %NullCheck, label %163, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %ThrowNullRef, label %163
 
 ; <label>:163                                     ; preds = %161
   %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
@@ -2399,8 +2481,8 @@ entry:
 
 ; <label>:167                                     ; preds = %163
   %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
-  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %168, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %169
 
 ; <label>:169                                     ; preds = %167
   %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
@@ -2432,55 +2514,55 @@ ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %167
+ThrowNullRef2:                                    ; preds = %167
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %128
+ThrowNullRef4:                                    ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %130
+ThrowNullRef6:                                    ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %143
+ThrowNullRef8:                                    ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %145
+ThrowNullRef10:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %102
+ThrowNullRef12:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %105
+ThrowNullRef14:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %76
+ThrowNullRef16:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %79
+ThrowNullRef18:                                   ; preds = %79
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %50
+ThrowNullRef20:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %53
+ThrowNullRef22:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %24
+ThrowNullRef24:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %27
+ThrowNullRef26:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2503,15 +2585,15 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2519,16 +2601,16 @@ entry:
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
   store i32 %8, i32* %loc0
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
   %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
   store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
@@ -2546,16 +2628,16 @@ entry:
 
 ; <label>:23                                      ; preds = %64
   %24 = load i16*, i16** %loc3
-  %NullCheck12 = icmp ne i16* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i16* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
   store i32 %27, i32* %loc5
   %28 = load i16*, i16** %loc4
-  %NullCheck14 = icmp ne i16* %28, null
-  br i1 %NullCheck14, label %29, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %28, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = load i16, i16* %28, align 8
@@ -2620,15 +2702,15 @@ entry:
 
 ; <label>:67                                      ; preds = %64
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
-  br i1 %NullCheck8, label %69, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %68, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %69
 
 ; <label>:69                                      ; preds = %67
   %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
   %71 = load i32, i32 addrspace(1)* %70
   %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
-  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %73
 
 ; <label>:73                                      ; preds = %69
   %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
@@ -2645,31 +2727,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %67
+ThrowNullRef8:                                    ; preds = %67
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %69
+ThrowNullRef10:                                   ; preds = %69
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2710,14 +2792,14 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
   %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
@@ -2730,14 +2812,14 @@ entry:
 
 ; <label>:11                                      ; preds = %4
   %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
   %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
@@ -2749,14 +2831,14 @@ entry:
 
 ; <label>:22                                      ; preds = %16
   %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
   %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
-  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
-  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
@@ -2804,23 +2886,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2836,7 +2918,280 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[loadElem]
+Successfully read RuntimeType.IsAssignableFrom
+
+define i8 @RuntimeType.IsAssignableFrom(%System.RuntimeType addrspace(1)* %param0, %System.Type addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.RuntimeType addrspace(1)*
+  %arg1 = alloca %System.Type addrspace(1)*
+  %loc0 = alloca %System.RuntimeType addrspace(1)*
+  %loc1 = alloca %"System.Type[]" addrspace(1)*
+  %loc2 = alloca i32
+  store %System.RuntimeType addrspace(1)* %param0, %System.RuntimeType addrspace(1)** %this
+  store %System.Type addrspace(1)* %param1, %System.Type addrspace(1)** %arg1
+  %0 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %1 = icmp ne %System.Type addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i8 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %5 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %6 = bitcast %System.Type addrspace(1)* %4 to %System.Object addrspace(1)*
+  %7 = bitcast %System.RuntimeType addrspace(1)* %5 to %System.Object addrspace(1)*
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %6, %System.Object addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %3
+  ret i8 1
+
+; <label>:12                                      ; preds = %3
+  %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 152
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 32
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
+  %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
+  %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
+  store %System.RuntimeType addrspace(1)* %25, %System.RuntimeType addrspace(1)** %loc0
+  %26 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %27 = icmp eq %System.RuntimeType addrspace(1)* %26, null
+  br i1 %27, label %34, label %28
+
+; <label>:28                                      ; preds = %15
+  %29 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %30 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)*)*)(%System.RuntimeType addrspace(1)* %29, %System.RuntimeType addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+; <label>:34                                      ; preds = %15
+  %35 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %36 = call %System.Reflection.Emit.TypeBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Reflection.Emit.TypeBuilder addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %35)
+  %37 = icmp eq %System.Reflection.Emit.TypeBuilder addrspace(1)* %36, null
+  br i1 %37, label %139, label %38
+
+; <label>:38                                      ; preds = %34
+  %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %42
+
+; <label>:42                                      ; preds = %38
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 152
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 40
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
+  %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
+  %53 = zext i8 %52 to i32
+  %54 = icmp eq i32 %53, 0
+  br i1 %54, label %56, label %55
+
+; <label>:55                                      ; preds = %42
+  ret i8 1
+
+; <label>:56                                      ; preds = %42
+  %57 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %58 = bitcast %System.RuntimeType addrspace(1)* %57 to %System.Type addrspace(1)*
+  %59 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %58)
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %64 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.Type addrspace(1)* %63, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = bitcast %System.RuntimeType addrspace(1)* %64 to %System.Type addrspace(1)*
+  %67 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %63, %System.Type addrspace(1)* %66)
+  %68 = zext i8 %67 to i32
+  %69 = trunc i32 %68 to i8
+  ret i8 %69
+
+; <label>:70                                      ; preds = %56
+  %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
+  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %73
+
+; <label>:73                                      ; preds = %70
+  %74 = load i64, i64 addrspace(1)* %72
+  %75 = add i64 %74, 128
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = add i64 %77, 0
+  %79 = inttoptr i64 %78 to i64*
+  %80 = load i64, i64* %79
+  %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
+  %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
+  %83 = call i8 %82(%System.Type addrspace(1)* %81)
+  %84 = zext i8 %83 to i32
+  %85 = icmp eq i32 %84, 0
+  br i1 %85, label %139, label %86
+
+; <label>:86                                      ; preds = %73
+  %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
+  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %89
+
+; <label>:89                                      ; preds = %86
+  %90 = load i64, i64 addrspace(1)* %88
+  %91 = add i64 %90, 128
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = add i64 %93, 24
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
+  %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
+  %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
+  store %"System.Type[]" addrspace(1)* %99, %"System.Type[]" addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %129
+
+; <label>:100                                     ; preds = %132
+  %101 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %102 = load i32, i32* %loc2
+  %NullCheck11 = icmp eq %"System.Type[]" addrspace(1)* %101, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %103
+
+; <label>:103                                     ; preds = %100
+  %104 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 1
+  %105 = load i32, i32 addrspace(1)* %104
+  %106 = zext i32 %105 to i64
+  %107 = zext i32 %102 to i64
+  %BoundsCheck = icmp uge i64 %107, %106
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %108
+
+; <label>:108                                     ; preds = %103
+  %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
+  %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
+  %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
+  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %113
+
+; <label>:113                                     ; preds = %108
+  %114 = load i64, i64 addrspace(1)* %112
+  %115 = add i64 %114, 152
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = add i64 %117, 56
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
+  %123 = zext i8 %122 to i32
+  %124 = icmp ne i32 %123, 0
+  br i1 %124, label %126, label %125
+
+; <label>:125                                     ; preds = %113
+  ret i8 0
+
+; <label>:126                                     ; preds = %113
+  %127 = load i32, i32* %loc2
+  %128 = add i32 %127, 1
+  store i32 %128, i32* %loc2
+  br label %129
+
+; <label>:129                                     ; preds = %89, %126
+  %130 = load i32, i32* %loc2
+  %131 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %NullCheck9 = icmp eq %"System.Type[]" addrspace(1)* %131, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %132
+
+; <label>:132                                     ; preds = %129
+  %133 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %131, i32 0, i32 1
+  %134 = load i32, i32 addrspace(1)* %133
+  %135 = zext i32 %134 to i64
+  %136 = trunc i64 %135 to i32
+  %137 = icmp slt i32 %130, %136
+  br i1 %137, label %100, label %138
+
+; <label>:138                                     ; preds = %132
+  ret i8 1
+
+; <label>:139                                     ; preds = %34, %73
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %129
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %103
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -2893,7 +3248,7 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElem]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -2904,8 +3259,8 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -2997,8 +3352,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
@@ -3059,8 +3414,8 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -3087,8 +3442,8 @@ entry:
 
 ; <label>:17                                      ; preds = %5, %11
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
@@ -3097,8 +3452,8 @@ entry:
 
 ; <label>:22                                      ; preds = %1, %11
   %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
@@ -3109,11 +3464,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %17
+ThrowNullRef2:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %22
+ThrowNullRef4:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3167,15 +3522,15 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
   %15 = load i32, i32 addrspace(1)* %14
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
@@ -3198,7 +3553,7 @@ ThrowNullRef:                                     ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef2:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3232,8 +3587,8 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
@@ -3312,8 +3667,8 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -3327,8 +3682,8 @@ entry:
 ; <label>:5                                       ; preds = %43
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %7 = load i32, i32* %loc1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck6, label %8, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
@@ -3366,8 +3721,8 @@ entry:
 ; <label>:32                                      ; preds = %21, %25
   %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
   %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
-  br i1 %NullCheck8, label %35, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = trunc i32 %34 to i16
@@ -3380,8 +3735,8 @@ entry:
 ; <label>:40                                      ; preds = %1, %35
   %41 = load i32, i32* %loc1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
-  br i1 %NullCheck2, label %43, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %42, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
@@ -3392,8 +3747,8 @@ entry:
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
   %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
-  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
   %51 = load i64, i64 addrspace(1)* %49
@@ -3412,19 +3767,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %40
+ThrowNullRef2:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %47
+ThrowNullRef4:                                    ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %5
+ThrowNullRef6:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %32
+ThrowNullRef8:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3467,8 +3822,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
@@ -3492,11 +3847,391 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(i16* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store i16* %param0, i16** %arg0
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load i32, i32* %arg3
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %42, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %37, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg2
+  %13 = load i32, i32* %arg3
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %37, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %24 = load i32, i32* %arg2
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load i16*, i16** %arg0
+  %35 = load i32, i32* %arg3
+  %36 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %36, i16* %34, i32 %35)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:37                                      ; preds = %5, %16
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %39)
+  %41 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41, %System.String addrspace(1)* %38, %System.String addrspace(1)* %40)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41) #0
+  unreachable
+
+; <label>:42                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
-Failed to read StringBuilder.ToString[loadElemA]
+Successfully read StringBuilder.ToString
+
+define %System.String addrspace(1)* @StringBuilder.ToString(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i16*
+  %loc3 = alloca %"System.Char[]" addrspace(1)*
+  %loc4 = alloca i32
+  %loc5 = alloca i32
+  %loc6 = alloca i16 addrspace(1)*
+  %loc7 = alloca %System.String addrspace(1)*
+  %loc8 = alloca %"System.Char[]" addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %0)
+  %2 = icmp ne i32 %1, 0
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %4
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %6)
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %7)
+  store %System.String addrspace(1)* %8, %System.String addrspace(1)** %loc0
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.Text.StringBuilder addrspace(1)* %9, %System.Text.StringBuilder addrspace(1)** %loc1
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  store %System.String addrspace(1)* %10, %System.String addrspace(1)** %loc7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc7
+  %12 = ptrtoint %System.String addrspace(1)* %11 to i64
+  %13 = icmp eq i64 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %5
+  %15 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %16 = sext i32 %15 to i64
+  %17 = add i64 %12, %16
+  br label %18
+
+; <label>:18                                      ; preds = %5, %14
+  %19 = phi i64 [ %12, %5 ], [ %17, %14 ]
+  %20 = inttoptr i64 %19 to i16*
+  store i16* %20, i16** %loc2
+  br label %21
+
+; <label>:21                                      ; preds = %98, %18
+  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %22, null
+  br i1 %NullCheck, label %ThrowNullRef, label %23
+
+; <label>:23                                      ; preds = %21
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 3
+  %25 = load i32, i32 addrspace(1)* %24, align 8
+  %26 = icmp sle i32 %25, 0
+  br i1 %26, label %96, label %27
+
+; <label>:27                                      ; preds = %23
+  %28 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %28, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %29
+
+; <label>:29                                      ; preds = %27
+  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %28, i32 0, i32 1
+  %31 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %30, align 8
+  store %"System.Char[]" addrspace(1)* %31, %"System.Char[]" addrspace(1)** %loc3
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %33
+
+; <label>:33                                      ; preds = %29
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  store i32 %35, i32* %loc4
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  %39 = load i32, i32 addrspace(1)* %38, align 8
+  store i32 %39, i32* %loc5
+  %40 = load i32, i32* %loc5
+  %41 = load i32, i32* %loc4
+  %42 = add i32 %40, %41
+  %43 = zext i32 %42 to i64
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %45
+
+; <label>:45                                      ; preds = %37
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = sext i32 %47 to i64
+  %49 = icmp sgt i64 %43, %48
+  br i1 %49, label %91, label %50
+
+; <label>:50                                      ; preds = %45
+  %51 = load i32, i32* %loc5
+  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %52, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %53
+
+; <label>:53                                      ; preds = %50
+  %54 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %52, i32 0, i32 1
+  %55 = load i32, i32 addrspace(1)* %54
+  %56 = zext i32 %55 to i64
+  %57 = trunc i64 %56 to i32
+  %58 = icmp ugt i32 %51, %57
+  br i1 %58, label %91, label %59
+
+; <label>:59                                      ; preds = %53
+  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  store %"System.Char[]" addrspace(1)* %60, %"System.Char[]" addrspace(1)** %loc8
+  %61 = icmp eq %"System.Char[]" addrspace(1)* %60, null
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %63, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %64
+
+; <label>:64                                      ; preds = %62
+  %65 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %63, i32 0, i32 1
+  %66 = load i32, i32 addrspace(1)* %65
+  %67 = zext i32 %66 to i64
+  %68 = trunc i64 %67 to i32
+  %69 = icmp ne i32 %68, 0
+  br i1 %69, label %71, label %70
+
+; <label>:70                                      ; preds = %59, %64
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:71                                      ; preds = %64
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %73
+
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %BoundsCheck = icmp uge i64 0, %76
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %77
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %78, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:79                                      ; preds = %70, %77
+  %80 = load i16*, i16** %loc2
+  %81 = load i32, i32* %loc4
+  %82 = sext i32 %81 to i64
+  %83 = mul i64 %82, 2
+  %84 = bitcast i16* %80 to i8*
+  %85 = getelementptr inbounds i8, i8* %84, i64 %83
+  %86 = load i16 addrspace(1)*, i16 addrspace(1)** %loc6
+  %87 = ptrtoint i16 addrspace(1)* %86 to i64
+  %88 = load i32, i32* %loc5
+  %89 = bitcast i8* %85 to i16*
+  %90 = inttoptr i64 %87 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %89, i16* %90, i32 %88)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %96
+
+; <label>:91                                      ; preds = %45, %53
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %94 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %93)
+  %95 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95, %System.String addrspace(1)* %92, %System.String addrspace(1)* %94)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95) #0
+  unreachable
+
+; <label>:96                                      ; preds = %23, %79
+  %97 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %97, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %98
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %97, i32 0, i32 2
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  store %System.Text.StringBuilder addrspace(1)* %100, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %102 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %102, label %21, label %103
+
+; <label>:103                                     ; preds = %98
+  store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc7
+  %104 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  ret %System.String addrspace(1)* %104
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method StringBuilder::get_Length using LLILCJit
+Successfully read StringBuilder.get_Length
+
+define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
+Successfully read RuntimeHelpers.get_OffsetToStringData
+
+define i32 @RuntimeHelpers.get_OffsetToStringData() {
+entry:
+  ret i32 12
+}
+
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
 Successfully read CultureData.CreateCultureData
 
@@ -3514,23 +4249,23 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
   store i8 %4, i8 addrspace(1)* %6
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
@@ -3549,11 +4284,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3566,50 +4301,50 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
   store i32 -1, i32 addrspace(1)* %2
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
   store i32 -1, i32 addrspace(1)* %8
   %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
   store i32 -1, i32 addrspace(1)* %14
   %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
   store i32 -1, i32 addrspace(1)* %17
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
@@ -3623,27 +4358,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3675,7 +4410,136 @@ Failed to read Dictionary`2.Insert[non-const derefAddress]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
 Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
-Failed to read HashHelpers.GetPrime[loadElem]
+Successfully read HashHelpers.GetPrime
+
+define i32 @HashHelpers.GetPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %6, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5, %System.String addrspace(1)* %4)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5) #0
+  unreachable
+
+; <label>:6                                       ; preds = %entry
+  store i32 0, i32* %loc0
+  br label %29
+
+; <label>:7                                       ; preds = %35
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 1296
+  %10 = addrspacecast i8 addrspace(1)* %9 to %"System.Int32[]" addrspace(1)**
+  %11 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %10
+  %12 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Int32[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = zext i32 %15 to i64
+  %17 = zext i32 %12 to i64
+  %BoundsCheck = icmp uge i64 %17, %16
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 3, i32 %12
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  store i32 %20, i32* %loc1
+  %21 = load i32, i32* %loc1
+  %22 = load i32, i32* %arg0
+  %23 = icmp slt i32 %21, %22
+  br i1 %23, label %26, label %24
+
+; <label>:24                                      ; preds = %18
+  %25 = load i32, i32* %loc1
+  ret i32 %25
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %loc0
+  %28 = add i32 %27, 1
+  store i32 %28, i32* %loc0
+  br label %29
+
+; <label>:29                                      ; preds = %6, %26
+  %30 = load i32, i32* %loc0
+  %31 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %32 = getelementptr inbounds i8, i8 addrspace(1)* %31, i64 1296
+  %33 = addrspacecast i8 addrspace(1)* %32 to %"System.Int32[]" addrspace(1)**
+  %34 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %33
+  %NullCheck = icmp eq %"System.Int32[]" addrspace(1)* %34, null
+  br i1 %NullCheck, label %ThrowNullRef, label %35
+
+; <label>:35                                      ; preds = %29
+  %36 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %34, i32 0, i32 1
+  %37 = load i32, i32 addrspace(1)* %36
+  %38 = zext i32 %37 to i64
+  %39 = trunc i64 %38 to i32
+  %40 = icmp slt i32 %30, %39
+  br i1 %40, label %7, label %41
+
+; <label>:41                                      ; preds = %35
+  %42 = load i32, i32* %arg0
+  %43 = or i32 %42, 1
+  store i32 %43, i32* %loc2
+  br label %59
+
+; <label>:44                                      ; preds = %59
+  %45 = load i32, i32* %loc2
+  %46 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %45)
+  %47 = zext i8 %46 to i32
+  %48 = icmp eq i32 %47, 0
+  br i1 %48, label %56, label %49
+
+; <label>:49                                      ; preds = %44
+  %50 = load i32, i32* %loc2
+  %51 = sub i32 %50, 1
+  %52 = srem i32 %51, 101
+  %53 = icmp eq i32 %52, 0
+  br i1 %53, label %56, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = load i32, i32* %loc2
+  ret i32 %55
+
+; <label>:56                                      ; preds = %44, %49
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %57, 2
+  store i32 %58, i32* %loc2
+  br label %59
+
+; <label>:59                                      ; preds = %41, %56
+  %60 = load i32, i32* %loc2
+  %61 = icmp slt i32 %60, 2147483647
+  br i1 %61, label %44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load i32, i32* %arg0
+  ret i32 %63
+
+ThrowNullRef:                                     ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
 Successfully read GenericEqualityComparer`1.GetHashCode
 
@@ -3694,14 +4558,14 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
   %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load i64, i64 addrspace(1)* %7
@@ -3720,7 +4584,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3750,8 +4614,8 @@ entry:
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
@@ -3796,8 +4660,8 @@ entry:
   %35 = bitcast i16* %34 to i8*
   %36 = getelementptr inbounds i8, i8* %35, i64 2
   %37 = bitcast i8* %36 to i16*
-  %NullCheck4 = icmp ne i16* %37, null
-  br i1 %NullCheck4, label %38, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %37, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %38
 
 ; <label>:38                                      ; preds = %27
   %39 = load i16, i16* %37, align 8
@@ -3824,8 +4688,8 @@ entry:
 
 ; <label>:54                                      ; preds = %22, %43
   %55 = load i16*, i16** %loc4
-  %NullCheck2 = icmp ne i16* %55, null
-  br i1 %NullCheck2, label %56, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i16* %55, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %56
 
 ; <label>:56                                      ; preds = %54
   %57 = load i16, i16* %55, align 8
@@ -3850,11 +4714,11 @@ ThrowNullRef:                                     ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %54
+ThrowNullRef2:                                    ; preds = %54
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %27
+ThrowNullRef4:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3871,8 +4735,8 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -3907,8 +4771,8 @@ entry:
 
 ; <label>:26                                      ; preds = %19
   %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
-  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %28
 
 ; <label>:28                                      ; preds = %26
   %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
@@ -3920,7 +4784,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3972,8 +4836,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
@@ -3984,26 +4848,26 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
-  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
@@ -4014,8 +4878,8 @@ entry:
 ; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
@@ -4024,8 +4888,8 @@ entry:
 
 ; <label>:25                                      ; preds = %1, %16, %23
   %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
-  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
@@ -4036,27 +4900,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %20
+ThrowNullRef10:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4069,8 +4933,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -4081,8 +4945,8 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
@@ -4091,8 +4955,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1, %8
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
@@ -4103,11 +4967,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4128,24 +4992,24 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   store i32 %3, i32* %loc0
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
   %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
   store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck4, label %9, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
@@ -4164,15 +5028,15 @@ entry:
 ; <label>:18                                      ; preds = %70
   %19 = load i16*, i16** %loc3
   %20 = bitcast i16* %19 to i64*
-  %NullCheck10 = icmp ne i64* %20, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %20, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = load i64, i64* %20, align 8
   %23 = load i16*, i16** %loc4
   %24 = bitcast i16* %23 to i64*
-  %NullCheck12 = icmp ne i64* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = load i64, i64* %24, align 8
@@ -4188,8 +5052,8 @@ entry:
   %31 = bitcast i16* %30 to i8*
   %32 = getelementptr inbounds i8, i8* %31, i64 8
   %33 = bitcast i8* %32 to i64*
-  %NullCheck14 = icmp ne i64* %33, null
-  br i1 %NullCheck14, label %34, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = load i64, i64* %33, align 8
@@ -4197,8 +5061,8 @@ entry:
   %37 = bitcast i16* %36 to i8*
   %38 = getelementptr inbounds i8, i8* %37, i64 8
   %39 = bitcast i8* %38 to i64*
-  %NullCheck16 = icmp ne i64* %39, null
-  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %40
 
 ; <label>:40                                      ; preds = %34
   %41 = load i64, i64* %39, align 8
@@ -4214,8 +5078,8 @@ entry:
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %NullCheck18 = icmp ne i64* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = load i64, i64* %48, align 8
@@ -4223,8 +5087,8 @@ entry:
   %52 = bitcast i16* %51 to i8*
   %53 = getelementptr inbounds i8, i8* %52, i64 16
   %54 = bitcast i8* %53 to i64*
-  %NullCheck20 = icmp ne i64* %54, null
-  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64* %54, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %55
 
 ; <label>:55                                      ; preds = %49
   %56 = load i64, i64* %54, align 8
@@ -4262,15 +5126,15 @@ entry:
 ; <label>:74                                      ; preds = %95
   %75 = load i16*, i16** %loc3
   %76 = bitcast i16* %75 to i32*
-  %NullCheck6 = icmp ne i32* %76, null
-  br i1 %NullCheck6, label %77, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32* %76, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %77
 
 ; <label>:77                                      ; preds = %74
   %78 = load i32, i32* %76, align 8
   %79 = load i16*, i16** %loc4
   %80 = bitcast i16* %79 to i32*
-  %NullCheck8 = icmp ne i32* %80, null
-  br i1 %NullCheck8, label %81, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i32* %80, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %81
 
 ; <label>:81                                      ; preds = %77
   %82 = load i32, i32* %80, align 8
@@ -4318,43 +5182,43 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %74
+ThrowNullRef6:                                    ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %77
+ThrowNullRef8:                                    ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %29
+ThrowNullRef14:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %34
+ThrowNullRef16:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4376,8 +5240,8 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load i64, i64 addrspace(1)* %4
@@ -4389,8 +5253,8 @@ entry:
   %12 = load i64, i64* %11
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %5
   %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
@@ -4399,8 +5263,8 @@ entry:
   %18 = load i8, i8* %arg2
   %19 = zext i8 %18 to i32
   %20 = trunc i32 %19 to i8
-  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %15
   %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
@@ -4411,11 +5275,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4442,8 +5306,8 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
@@ -4466,16 +5330,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
   %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = load i64, i64 addrspace(1)* %19
@@ -4500,8 +5364,8 @@ entry:
 ; <label>:35                                      ; preds = %30
   %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
@@ -4514,8 +5378,8 @@ entry:
 
 ; <label>:42                                      ; preds = %1, %38
   %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
-  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
@@ -4526,19 +5390,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %35
+ThrowNullRef2:                                    ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %42
+ThrowNullRef8:                                    ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4551,14 +5415,14 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
@@ -4570,7 +5434,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4583,8 +5447,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
@@ -4613,51 +5477,51 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
   %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
   %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
   %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
   %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
-  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
   store i64 %21, i64 addrspace(1)* %23
   %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %25 = load i64, i64* %loc0
-  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
@@ -4668,27 +5532,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %22
+ThrowNullRef12:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4701,8 +5565,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
@@ -4713,19 +5577,19 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
@@ -4734,8 +5598,8 @@ entry:
 
 ; <label>:15                                      ; preds = %1, %13
   %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
@@ -4746,19 +5610,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %15
+ThrowNullRef8:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4771,8 +5635,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -4831,8 +5695,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
@@ -4882,8 +5746,8 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
-  br i1 %NullCheck, label %17, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %ThrowNullRef, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
@@ -4894,15 +5758,15 @@ entry:
 
 ; <label>:22                                      ; preds = %17
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
-  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
   %26 = load i32, i32 addrspace(1)* %25
   %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
-  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %27, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
@@ -4925,8 +5789,8 @@ entry:
 ; <label>:40                                      ; preds = %17
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
-  br i1 %NullCheck6, label %43, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %41, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
@@ -4938,34 +5802,17 @@ ThrowNullRef:                                     ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %24
+ThrowNullRef4:                                    ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %40
+ThrowNullRef6:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
-}
-
-INFO:  jitting method Object::ReferenceEquals using LLILCJit
-Successfully read Object.ReferenceEquals
-
-define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
-entry:
-  %arg0 = alloca %System.Object addrspace(1)*
-  %arg1 = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
-  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
-  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = icmp eq %System.Object addrspace(1)* %0, %1
-  %3 = sext i1 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
 }
 
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
@@ -4978,21 +5825,21 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
   %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
-  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
@@ -5007,28 +5854,28 @@ entry:
 ; <label>:13                                      ; preds = %8, %12
   %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
   %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
   %21 = load i32, i32 addrspace(1)* %20, align 8
   %22 = add i32 %21, 1
-  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
   store i32 %22, i32 addrspace(1)* %24
   %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
@@ -5039,27 +5886,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5077,7 +5924,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::Setup using LLILCJit
-Failed to read AppDomain.Setup[loadElem]
+Failed to read AppDomain.Setup[unbox]
 INFO:  jitting method Thread::GetDomain using LLILCJit
 Successfully read Thread.GetDomain
 
@@ -5108,8 +5955,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
@@ -5122,14 +5969,14 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
   %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
@@ -5141,11 +5988,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5173,8 +6020,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -5189,7 +6036,328 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
 Failed to read KeyCollection.System.Collections.Generic.IEnumerable<TKey>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Successfully read Enumerator.MoveNext
+
+define i8 @Enumerator.MoveNext(%"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.RuntimeTypeHandle* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*
+  %"$TypeArg" = alloca %System.RuntimeTypeHandle*
+  store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
+  %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 8
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %76, label %12
+
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
+  br label %76
+
+; <label>:13                                      ; preds = %85
+  %14 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck19 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %15
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, i32 0, i32 0
+  %17 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %16, align 8
+  %NullCheck21 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, i32 0, i32 2
+  %20 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %19, align 8
+  %21 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck23 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %22
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, i32 0, i32 2
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %NullCheck25 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 3, i32 %24
+  %NullCheck27 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %32
+
+; <label>:32                                      ; preds = %30
+  %33 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, i32 0, i32 2
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = icmp slt i32 %34, 0
+  br i1 %35, label %68, label %36
+
+; <label>:36                                      ; preds = %32
+  %37 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %38 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck29 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %39
+
+; <label>:39                                      ; preds = %36
+  %40 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, i32 0, i32 0
+  %41 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %40, align 8
+  %NullCheck31 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, i32 0, i32 2
+  %44 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %43, align 8
+  %45 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck33 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, i32 0, i32 2
+  %48 = load i32, i32 addrspace(1)* %47, align 8
+  %NullCheck35 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %49
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = zext i32 %51 to i64
+  %53 = zext i32 %48 to i64
+  %BoundsCheck37 = icmp uge i64 %53, %52
+  br i1 %BoundsCheck37, label %ThrowIndexOutOfRange38, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 3, i32 %48
+  %NullCheck39 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %56
+
+; <label>:56                                      ; preds = %54
+  %57 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, i32 0, i32 0
+  %58 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck41 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %59
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %60, %System.__Canon addrspace(1)* %58)
+  %61 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck43 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  %64 = load i32, i32 addrspace(1)* %63, align 8
+  %65 = add i32 %64, 1
+  %NullCheck45 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  store i32 %65, i32 addrspace(1)* %67
+  ret i8 1
+
+; <label>:68                                      ; preds = %32
+  %69 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck47 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %73 = add i32 %72, 1
+  %NullCheck49 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %74
+
+; <label>:74                                      ; preds = %70
+  %75 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  store i32 %73, i32 addrspace(1)* %75
+  br label %76
+
+; <label>:76                                      ; preds = %8, %12, %74
+  %77 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %78
+
+; <label>:78                                      ; preds = %76
+  %79 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, i32 0, i32 2
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck7 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %82
+
+; <label>:82                                      ; preds = %78
+  %83 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, i32 0, i32 0
+  %84 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %83, align 8
+  %NullCheck9 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %85
+
+; <label>:85                                      ; preds = %82
+  %86 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, i32 0, i32 7
+  %87 = load i32, i32 addrspace(1)* %86, align 8
+  %88 = icmp ult i32 %80, %87
+  br i1 %88, label %13, label %89
+
+; <label>:89                                      ; preds = %85
+  %90 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %91 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck11 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %92
+
+; <label>:92                                      ; preds = %89
+  %93 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, i32 0, i32 0
+  %94 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck13 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %95
+
+; <label>:95                                      ; preds = %92
+  %96 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, i32 0, i32 7
+  %97 = load i32, i32 addrspace(1)* %96, align 8
+  %98 = add i32 %97, 1
+  %NullCheck15 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %99
+
+; <label>:99                                      ; preds = %95
+  %100 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, i32 0, i32 2
+  store i32 %98, i32 addrspace(1)* %100
+  %101 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck17 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %102
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %103, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %92
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef22:                                   ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef24:                                   ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef26:                                   ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef28:                                   ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef30:                                   ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef32:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef34:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef36:                                   ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange38:                           ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef40:                                   ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef42:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef44:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef46:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef48:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef50:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -5200,8 +6368,8 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -5232,9 +6400,9 @@ Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
 Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
-Failed to read String.MakeSeparatorList[loadElemA]
+Failed to read String.MakeSeparatorList[storeElem]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
-Failed to read String.InternalSplitKeepEmptyEntries[loadElem]
+Failed to read String.InternalSplitKeepEmptyEntries[storeElem]
 INFO:  jitting method Path::IsRelative using LLILCJit
 Successfully read Path.IsRelative
 
@@ -5243,8 +6411,8 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -5254,8 +6422,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
@@ -5271,8 +6439,8 @@ entry:
 
 ; <label>:17                                      ; preds = %7
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
@@ -5288,8 +6456,8 @@ entry:
 
 ; <label>:29                                      ; preds = %19
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %31
 
 ; <label>:31                                      ; preds = %29
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
@@ -5300,8 +6468,8 @@ entry:
 
 ; <label>:36                                      ; preds = %31
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
-  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %37, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
@@ -5312,8 +6480,8 @@ entry:
 
 ; <label>:43                                      ; preds = %31, %38
   %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
-  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %45
 
 ; <label>:45                                      ; preds = %43
   %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
@@ -5324,8 +6492,8 @@ entry:
 
 ; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %50
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
@@ -5336,8 +6504,8 @@ entry:
 
 ; <label>:57                                      ; preds = %1, %7, %19, %45, %52
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
-  br i1 %NullCheck14, label %59, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %59
 
 ; <label>:59                                      ; preds = %57
   %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
@@ -5347,8 +6515,8 @@ entry:
 
 ; <label>:63                                      ; preds = %59
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
@@ -5359,8 +6527,8 @@ entry:
 
 ; <label>:70                                      ; preds = %65
   %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
-  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.String addrspace(1)* %71, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %72
 
 ; <label>:72                                      ; preds = %70
   %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
@@ -5379,39 +6547,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %17
+ThrowNullRef4:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %29
+ThrowNullRef6:                                    ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %36
+ThrowNullRef8:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %43
+ThrowNullRef10:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %50
+ThrowNullRef12:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %57
+ThrowNullRef14:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %63
+ThrowNullRef16:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %70
+ThrowNullRef18:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5419,7 +6587,293 @@ ThrowNullRef17:                                   ; preds = %70
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
-Failed to read String.TrimHelper[loadElem]
+Successfully read String.TrimHelper
+
+define %System.String addrspace(1)* @String.TrimHelper(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i16
+  %loc4 = alloca i32
+  %loc5 = alloca i16
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = sub i32 %3, 1
+  store i32 %4, i32* %loc0
+  store i32 0, i32* %loc1
+  %5 = load i32, i32* %arg2
+  %6 = icmp eq i32 %5, 1
+  br i1 %6, label %62, label %7
+
+; <label>:7                                       ; preds = %1
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:8                                       ; preds = %58
+  store i32 0, i32* %loc2
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load i32, i32* %loc1
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2, i32 %10
+  %13 = load i16, i16 addrspace(1)* %12
+  %14 = zext i16 %13 to i32
+  %15 = trunc i32 %14 to i16
+  store i16 %15, i16* %loc3
+  store i32 0, i32* %loc2
+  br label %34
+
+; <label>:16                                      ; preds = %37
+  %17 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %18 = load i32, i32* %loc2
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %17, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %19
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = zext i32 %18 to i64
+  %BoundsCheck = icmp uge i64 %23, %22
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %24
+
+; <label>:24                                      ; preds = %19
+  %25 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 3, i32 %18
+  %26 = load i16, i16 addrspace(1)* %25, align 8
+  %27 = zext i16 %26 to i32
+  %28 = load i16, i16* %loc3
+  %29 = zext i16 %28 to i32
+  %30 = icmp eq i32 %27, %29
+  br i1 %30, label %43, label %31
+
+; <label>:31                                      ; preds = %24
+  %32 = load i32, i32* %loc2
+  %33 = add i32 %32, 1
+  store i32 %33, i32* %loc2
+  br label %34
+
+; <label>:34                                      ; preds = %11, %31
+  %35 = load i32, i32* %loc2
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = icmp slt i32 %35, %41
+  br i1 %42, label %16, label %43
+
+; <label>:43                                      ; preds = %24, %37
+  %44 = load i32, i32* %loc2
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %45, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp eq i32 %44, %50
+  br i1 %51, label %62, label %52
+
+; <label>:52                                      ; preds = %46
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %7, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %57, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %58
+
+; <label>:58                                      ; preds = %55
+  %59 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %60 = load i32, i32 addrspace(1)* %59
+  %61 = icmp slt i32 %56, %60
+  br i1 %61, label %8, label %62
+
+; <label>:62                                      ; preds = %1, %46, %58
+  %63 = load i32, i32* %arg2
+  %64 = icmp eq i32 %63, 0
+  br i1 %64, label %122, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %66, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %67
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %66, i32 0, i32 1
+  %69 = load i32, i32 addrspace(1)* %68
+  %70 = sub i32 %69, 1
+  store i32 %70, i32* %loc0
+  br label %118
+
+; <label>:71                                      ; preds = %118
+  store i32 0, i32* %loc4
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %73 = load i32, i32* %loc0
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %74
+
+; <label>:74                                      ; preds = %71
+  %75 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 2, i32 %73
+  %76 = load i16, i16 addrspace(1)* %75
+  %77 = zext i16 %76 to i32
+  %78 = trunc i32 %77 to i16
+  store i16 %78, i16* %loc5
+  store i32 0, i32* %loc4
+  br label %97
+
+; <label>:79                                      ; preds = %100
+  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %81 = load i32, i32* %loc4
+  %NullCheck19 = icmp eq %"System.Char[]" addrspace(1)* %80, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
+
+; <label>:82                                      ; preds = %79
+  %83 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 1
+  %84 = load i32, i32 addrspace(1)* %83
+  %85 = zext i32 %84 to i64
+  %86 = zext i32 %81 to i64
+  %BoundsCheck21 = icmp uge i64 %86, %85
+  br i1 %BoundsCheck21, label %ThrowIndexOutOfRange22, label %87
+
+; <label>:87                                      ; preds = %82
+  %88 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 3, i32 %81
+  %89 = load i16, i16 addrspace(1)* %88, align 8
+  %90 = zext i16 %89 to i32
+  %91 = load i16, i16* %loc5
+  %92 = zext i16 %91 to i32
+  %93 = icmp eq i32 %90, %92
+  br i1 %93, label %106, label %94
+
+; <label>:94                                      ; preds = %87
+  %95 = load i32, i32* %loc4
+  %96 = add i32 %95, 1
+  store i32 %96, i32* %loc4
+  br label %97
+
+; <label>:97                                      ; preds = %74, %94
+  %98 = load i32, i32* %loc4
+  %99 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck15 = icmp eq %"System.Char[]" addrspace(1)* %99, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %100
+
+; <label>:100                                     ; preds = %97
+  %101 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %99, i32 0, i32 1
+  %102 = load i32, i32 addrspace(1)* %101
+  %103 = zext i32 %102 to i64
+  %104 = trunc i64 %103 to i32
+  %105 = icmp slt i32 %98, %104
+  br i1 %105, label %79, label %106
+
+; <label>:106                                     ; preds = %87, %100
+  %107 = load i32, i32* %loc4
+  %108 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck17 = icmp eq %"System.Char[]" addrspace(1)* %108, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %109
+
+; <label>:109                                     ; preds = %106
+  %110 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %108, i32 0, i32 1
+  %111 = load i32, i32 addrspace(1)* %110
+  %112 = zext i32 %111 to i64
+  %113 = trunc i64 %112 to i32
+  %114 = icmp eq i32 %107, %113
+  br i1 %114, label %122, label %115
+
+; <label>:115                                     ; preds = %109
+  %116 = load i32, i32* %loc0
+  %117 = sub i32 %116, 1
+  store i32 %117, i32* %loc0
+  br label %118
+
+; <label>:118                                     ; preds = %67, %115
+  %119 = load i32, i32* %loc0
+  %120 = load i32, i32* %loc1
+  %121 = icmp sge i32 %119, %120
+  br i1 %121, label %71, label %122
+
+; <label>:122                                     ; preds = %62, %109, %118
+  %123 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %124 = load i32, i32* %loc1
+  %125 = load i32, i32* %loc0
+  %126 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %123, i32 %124, i32 %125)
+  ret %System.String addrspace(1)* %126
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %97
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange22:                           ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
 Successfully read String.CreateTrimmedString
 
@@ -5439,8 +6893,8 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
@@ -5535,8 +6989,8 @@ entry:
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i64 2872
   %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
   %8 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %7
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %3
   %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
@@ -5553,8 +7007,8 @@ entry:
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 2864
   %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
   %21 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %20
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
-  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %22
 
 ; <label>:22                                      ; preds = %16
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
@@ -5569,7 +7023,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %16
+ThrowNullRef2:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5586,8 +7040,8 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5613,8 +7067,8 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
@@ -5632,8 +7086,8 @@ entry:
 
 ; <label>:12                                      ; preds = %4
   %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
@@ -5644,8 +7098,8 @@ entry:
 
 ; <label>:19                                      ; preds = %14
   %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %19
   %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
@@ -5660,21 +7114,21 @@ entry:
   %31 = zext i16 %30 to i32
   %32 = bitcast i8* %29 to i16*
   %33 = trunc i32 %31 to i16
-  %NullCheck6 = icmp ne i16* %32, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i16* %32, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %21
   store i16 %33, i16* %32, align 8
   %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %36
 
 ; <label>:36                                      ; preds = %34
   %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
   %38 = load i32, i32 addrspace(1)* %37, align 8
   %39 = add i32 %38, 1
-  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %40
 
 ; <label>:40                                      ; preds = %36
   %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
@@ -5683,16 +7137,16 @@ entry:
 
 ; <label>:42                                      ; preds = %14
   %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
-  br i1 %NullCheck12, label %44, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
   %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
   %47 = load i16, i16* %arg1
   %48 = zext i16 %47 to i32
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = trunc i32 %48 to i16
@@ -5703,31 +7157,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %19
+ThrowNullRef4:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %21
+ThrowNullRef6:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %36
+ThrowNullRef10:                                   ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %42
+ThrowNullRef12:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %44
+ThrowNullRef14:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5740,8 +7194,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -5752,8 +7206,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
@@ -5762,14 +7216,14 @@ entry:
 
 ; <label>:11                                      ; preds = %1
   %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
@@ -5779,15 +7233,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5808,8 +7262,8 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5822,8 +7276,8 @@ entry:
 
 ; <label>:8                                       ; preds = %3
   %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
@@ -5842,15 +7296,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
-  br i1 %NullCheck4, label %22, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
   %24 = load i16*, i16* addrspace(1)* %23, align 8
   %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %25, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
@@ -5859,8 +7313,8 @@ entry:
   store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
@@ -5874,8 +7328,8 @@ entry:
 
 ; <label>:37                                      ; preds = %65
   %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %37
   %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
@@ -5886,16 +7340,16 @@ entry:
   %45 = bitcast i16* %41 to i8*
   %46 = getelementptr inbounds i8, i8* %45, i64 %44
   %47 = bitcast i8* %46 to i16*
-  %NullCheck14 = icmp ne i16* %47, null
-  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %47, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %48
 
 ; <label>:48                                      ; preds = %39
   %49 = load i16, i16* %47, align 8
   %50 = zext i16 %49 to i32
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %52 = load i32, i32* %loc1
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %53
 
 ; <label>:53                                      ; preds = %48
   %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
@@ -5916,8 +7370,8 @@ entry:
 ; <label>:62                                      ; preds = %36, %59
   %63 = load i32, i32* %loc1
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck10, label %65, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %65
 
 ; <label>:65                                      ; preds = %62
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
@@ -5936,15 +7390,15 @@ entry:
 
 ; <label>:74                                      ; preds = %70
   %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
-  br i1 %NullCheck18, label %76, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %76
 
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
   %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
-  br i1 %NullCheck20, label %80, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
   %81 = load i64, i64 addrspace(1)* %79
@@ -5958,8 +7412,8 @@ entry:
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
   %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
-  br i1 %NullCheck22, label %92, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.String addrspace(1)* %90, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %92
 
 ; <label>:92                                      ; preds = %80
   %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
@@ -5969,15 +7423,15 @@ entry:
 
 ; <label>:96                                      ; preds = %70
   %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
-  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %98
 
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
   %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
-  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
   %103 = load i64, i64 addrspace(1)* %101
@@ -5991,8 +7445,8 @@ entry:
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
   %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
-  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.String addrspace(1)* %112, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %114
 
 ; <label>:114                                     ; preds = %102
   %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
@@ -6004,59 +7458,59 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %20
+ThrowNullRef4:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %22
+ThrowNullRef6:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %26
+ThrowNullRef8:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %62
+ThrowNullRef10:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %48
+ThrowNullRef16:                                   ; preds = %48
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %74
+ThrowNullRef18:                                   ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %76
+ThrowNullRef20:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %80
+ThrowNullRef22:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %96
+ThrowNullRef24:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %98
+ThrowNullRef26:                                   ; preds = %98
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %102
+ThrowNullRef28:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6069,15 +7523,15 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
   %3 = load i16*, i16* addrspace(1)* %2, align 8
   %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
@@ -6087,8 +7541,8 @@ entry:
   %10 = bitcast i16* %3 to i8*
   %11 = getelementptr inbounds i8, i8* %10, i64 %9
   %12 = bitcast i8* %11 to i16*
-  %NullCheck4 = icmp ne i16* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %5
   store i16 0, i16* %12, align 8
@@ -6098,11 +7552,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6119,8 +7573,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -6131,8 +7585,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
@@ -6144,15 +7598,15 @@ entry:
 
 ; <label>:14                                      ; preds = %1
   %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
   %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
   %21 = load i64, i64 addrspace(1)* %19
@@ -6171,15 +7625,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %14
+ThrowNullRef4:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %16
+ThrowNullRef6:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6302,14 +7756,6 @@ entry:
   ret %System.String addrspace(1)* %57
 }
 
-INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
-Successfully read RuntimeHelpers.get_OffsetToStringData
-
-define i32 @RuntimeHelpers.get_OffsetToStringData() {
-entry:
-  ret i32 12
-}
-
 INFO:  jitting method String::Equals using LLILCJit
 Successfully read String.Equals
 
@@ -6381,8 +7827,8 @@ entry:
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
-  br i1 %NullCheck24, label %29, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
   %30 = load i64, i64 addrspace(1)* %28
@@ -6397,8 +7843,8 @@ entry:
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
-  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
   %43 = load i64, i64 addrspace(1)* %41
@@ -6418,8 +7864,8 @@ entry:
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
   %59 = load i64, i64 addrspace(1)* %57
@@ -6434,8 +7880,8 @@ entry:
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck22, label %71, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
   %72 = load i64, i64 addrspace(1)* %70
@@ -6455,8 +7901,8 @@ entry:
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
-  br i1 %NullCheck16, label %87, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = load i64, i64 addrspace(1)* %86
@@ -6471,8 +7917,8 @@ entry:
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck18, label %100, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
   %101 = load i64, i64 addrspace(1)* %99
@@ -6492,8 +7938,8 @@ entry:
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
-  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
   %117 = load i64, i64 addrspace(1)* %115
@@ -6508,8 +7954,8 @@ entry:
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
-  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
   %130 = load i64, i64 addrspace(1)* %128
@@ -6528,15 +7974,15 @@ entry:
 
 ; <label>:142                                     ; preds = %22
   %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
-  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %143, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %144
 
 ; <label>:144                                     ; preds = %142
   %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
   %146 = load i32, i32 addrspace(1)* %145
   %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
-  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %147, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %148
 
 ; <label>:148                                     ; preds = %144
   %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
@@ -6557,15 +8003,15 @@ entry:
 
 ; <label>:159                                     ; preds = %22
   %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
-  br i1 %NullCheck, label %161, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %ThrowNullRef, label %161
 
 ; <label>:161                                     ; preds = %159
   %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
   %163 = load i32, i32 addrspace(1)* %162
   %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
-  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %164, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %165
 
 ; <label>:165                                     ; preds = %161
   %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
@@ -6578,8 +8024,8 @@ entry:
 
 ; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
-  br i1 %NullCheck4, label %172, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %171, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %172
 
 ; <label>:172                                     ; preds = %170
   %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
@@ -6589,8 +8035,8 @@ entry:
 
 ; <label>:176                                     ; preds = %172
   %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
-  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %177, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %178
 
 ; <label>:178                                     ; preds = %176
   %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
@@ -6629,55 +8075,55 @@ ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %161
+ThrowNullRef2:                                    ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %170
+ThrowNullRef4:                                    ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %176
+ThrowNullRef6:                                    ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %142
+ThrowNullRef8:                                    ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %144
+ThrowNullRef10:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %113
+ThrowNullRef12:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %116
+ThrowNullRef14:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %84
+ThrowNullRef16:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %87
+ThrowNullRef18:                                   ; preds = %87
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %55
+ThrowNullRef20:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %58
+ThrowNullRef22:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %26
+ThrowNullRef24:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %29
+ThrowNullRef26:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,8 +8161,8 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck, label %14, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %ThrowNullRef, label %14
 
 ; <label>:14                                      ; preds = %8
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
@@ -6760,8 +8206,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
@@ -6770,14 +8216,14 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32, i32* %loc0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %10
   %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
   %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
@@ -6790,15 +8236,15 @@ entry:
 ; <label>:25                                      ; preds = %19
   %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
-  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
   %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
@@ -6807,8 +8253,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %37 = load i32, i32* %loc0
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %38, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %38
 
 ; <label>:38                                      ; preds = %32
   %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
@@ -6817,14 +8263,14 @@ entry:
 
 ; <label>:40                                      ; preds = %19
   %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %40
   %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
   %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
-  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
-  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
@@ -6832,8 +8278,8 @@ entry:
   %48 = zext i32 %47 to i64
   %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
-  br i1 %NullCheck16, label %51, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %51
 
 ; <label>:51                                      ; preds = %45
   %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
@@ -6847,15 +8293,15 @@ entry:
 ; <label>:57                                      ; preds = %51
   %58 = load i16*, i16** %arg1
   %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
-  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %60
 
 ; <label>:60                                      ; preds = %57
   %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
   %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
-  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %64
 
 ; <label>:64                                      ; preds = %60
   %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
@@ -6864,22 +8310,22 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
   %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
-  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %70
 
 ; <label>:70                                      ; preds = %64
   %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
   %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
-  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
-  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
   %75 = load i32, i32 addrspace(1)* %74
   %76 = zext i32 %75 to i64
   %77 = trunc i64 %76 to i32
-  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
-  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %78
 
 ; <label>:78                                      ; preds = %73
   %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
@@ -6901,8 +8347,8 @@ entry:
   %90 = bitcast i16* %86 to i8*
   %91 = getelementptr inbounds i8, i8* %90, i64 %89
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %93
 
 ; <label>:93                                      ; preds = %80
   %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
@@ -6912,8 +8358,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %99 = load i32, i32* %loc2
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %100
 
 ; <label>:100                                     ; preds = %93
   %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
@@ -6928,63 +8374,63 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %25
+ThrowNullRef6:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %32
+ThrowNullRef10:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %40
+ThrowNullRef12:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %45
+ThrowNullRef16:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %57
+ThrowNullRef18:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %60
+ThrowNullRef20:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %64
+ThrowNullRef22:                                   ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %70
+ThrowNullRef24:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %73
+ThrowNullRef26:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %80
+ThrowNullRef28:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %93
+ThrowNullRef30:                                   ; preds = %93
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7004,8 +8450,8 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
@@ -7033,43 +8479,43 @@ entry:
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %14
   %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
   %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   %28 = load i32, i32 addrspace(1)* %27, align 8
   %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
-  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %30
 
 ; <label>:30                                      ; preds = %26
   %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
   %32 = load i32, i32 addrspace(1)* %31, align 8
   %33 = add i32 %28, %32
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %34
 
 ; <label>:34                                      ; preds = %30
   %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   store i32 %33, i32 addrspace(1)* %35
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
   store i32 0, i32 addrspace(1)* %38
   %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %40
 
 ; <label>:40                                      ; preds = %37
   %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
@@ -7082,8 +8528,8 @@ entry:
 
 ; <label>:47                                      ; preds = %40
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
@@ -7098,8 +8544,8 @@ entry:
   %54 = load i32, i32* %loc0
   %55 = sext i32 %54 to i64
   %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
-  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %57
 
 ; <label>:57                                      ; preds = %52
   %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
@@ -7110,68 +8556,35 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %14
+ThrowNullRef2:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %23
+ThrowNullRef4:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %26
+ThrowNullRef6:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %30
+ThrowNullRef8:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %34
+ThrowNullRef10:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %47
+ThrowNullRef14:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %52
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-}
-
-INFO:  jitting method StringBuilder::get_Length using LLILCJit
-Successfully read StringBuilder.get_Length
-
-define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.StringBuilder addrspace(1)*
-  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
-  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
-
-; <label>:1                                       ; preds = %entry
-  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %3 = load i32, i32 addrspace(1)* %2, align 8
-  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
-
-; <label>:5                                       ; preds = %1
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = add i32 %3, %7
-  ret i32 %8
-
-ThrowNullRef:                                     ; preds = %entry
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef16:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7213,70 +8626,70 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
   %6 = load i32, i32 addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
   store i32 %6, i32 addrspace(1)* %8
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
   %13 = load i32, i32 addrspace(1)* %12, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
   store i32 %13, i32 addrspace(1)* %15
   %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
-  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %18
 
 ; <label>:18                                      ; preds = %14
   %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
   %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
   %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
   %34 = load i32, i32 addrspace(1)* %33, align 8
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
-  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
@@ -7287,39 +8700,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %28
+ThrowNullRef16:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %32
+ThrowNullRef18:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7455,13 +8868,13 @@ entry:
 ; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
@@ -7477,16 +8890,16 @@ entry:
 
 ; <label>:18                                      ; preds = %15
   %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
   store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
   %22 = load i32, i32* %loc0
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %24
 
 ; <label>:24                                      ; preds = %20
   %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
@@ -7498,13 +8911,13 @@ entry:
 ; <label>:28                                      ; preds = %15, %24
   %29 = load i32, i32* %arg1
   %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %31
   %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
@@ -7517,20 +8930,20 @@ entry:
   %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
-  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
   %46 = load i32, i32 addrspace(1)* %45, align 8
   %47 = sub i32 %40, %46
-  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
-  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i32 addrspace(1)* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %48
 
 ; <label>:48                                      ; preds = %44
   store i32 %47, i32 addrspace(1)* %39, align 8
@@ -7538,21 +8951,21 @@ entry:
 
 ; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
-  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %51
 
 ; <label>:51                                      ; preds = %49
   %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %53
 
 ; <label>:53                                      ; preds = %51
   %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
   %55 = load i32, i32 addrspace(1)* %54, align 8
   %56 = load i32, i32* %arg2
   %57 = sub i32 %55, %56
-  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %58
 
 ; <label>:58                                      ; preds = %53
   %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
@@ -7562,13 +8975,13 @@ entry:
 ; <label>:60                                      ; preds = %33, %58
   %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
   %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
-  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %63
 
 ; <label>:63                                      ; preds = %60
   %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
-  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
-  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
@@ -7578,15 +8991,15 @@ entry:
 
 ; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
-  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i32 addrspace(1)* %69, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %70
 
 ; <label>:70                                      ; preds = %68
   %71 = load i32, i32 addrspace(1)* %69, align 8
   store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
-  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
@@ -7596,8 +9009,8 @@ entry:
   store i32 %77, i32* %loc4
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
-  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %80
 
 ; <label>:80                                      ; preds = %73
   %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
@@ -7607,71 +9020,71 @@ entry:
 ; <label>:83                                      ; preds = %80
   store i32 0, i32* %loc3
   %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
-  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
-  br i1 %NullCheck26, label %88, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i32 addrspace(1)* %87, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %88
 
 ; <label>:88                                      ; preds = %85
   %89 = load i32, i32 addrspace(1)* %87, align 8
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
-  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %90
 
 ; <label>:90                                      ; preds = %88
   %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
   store i32 %89, i32 addrspace(1)* %91
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
-  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
-  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %96
 
 ; <label>:96                                      ; preds = %94
   %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
-  br i1 %NullCheck34, label %100, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %100
 
 ; <label>:100                                     ; preds = %96
   %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
-  br i1 %NullCheck36, label %102, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %102
 
 ; <label>:102                                     ; preds = %100
   %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
   %104 = load i32, i32 addrspace(1)* %103, align 8
   %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
-  br i1 %NullCheck38, label %106, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %106
 
 ; <label>:106                                     ; preds = %102
   %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
-  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
-  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %108
 
 ; <label>:108                                     ; preds = %106
   %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
   %110 = load i32, i32 addrspace(1)* %109, align 8
   %111 = add i32 %104, %110
-  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %112
 
 ; <label>:112                                     ; preds = %108
   %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
   store i32 %111, i32 addrspace(1)* %113
   %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
-  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i32 addrspace(1)* %114, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %115
 
 ; <label>:115                                     ; preds = %112
   %116 = load i32, i32 addrspace(1)* %114, align 8
@@ -7681,19 +9094,19 @@ entry:
 ; <label>:118                                     ; preds = %115
   %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
-  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %121
 
 ; <label>:121                                     ; preds = %118
   %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
-  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
-  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %123
 
 ; <label>:123                                     ; preds = %121
   %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
   %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
-  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
-  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %126
 
 ; <label>:126                                     ; preds = %123
   %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
@@ -7705,8 +9118,8 @@ entry:
 
 ; <label>:130                                     ; preds = %80, %115, %126
   %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %132
 
 ; <label>:132                                     ; preds = %130
   %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7715,8 +9128,8 @@ entry:
   %136 = load i32, i32* %loc3
   %137 = sub i32 %135, %136
   %138 = sub i32 %134, %137
-  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %139
 
 ; <label>:139                                     ; preds = %132
   %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7728,16 +9141,16 @@ entry:
 
 ; <label>:144                                     ; preds = %139
   %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
-  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %146
 
 ; <label>:146                                     ; preds = %144
   %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
   %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
   %149 = load i32, i32* %loc2
   %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
-  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %151
 
 ; <label>:151                                     ; preds = %146
   %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
@@ -7754,145 +9167,249 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %18
+ThrowNullRef4:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %31
+ThrowNullRef10:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %44
+ThrowNullRef16:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %68
+ThrowNullRef18:                                   ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %70
+ThrowNullRef20:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %73
+ThrowNullRef22:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %83
+ThrowNullRef24:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %85
+ThrowNullRef26:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %88
+ThrowNullRef28:                                   ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %90
+ThrowNullRef30:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %94
+ThrowNullRef32:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %96
+ThrowNullRef34:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %100
+ThrowNullRef36:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %102
+ThrowNullRef38:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %106
+ThrowNullRef40:                                   ; preds = %106
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %108
+ThrowNullRef42:                                   ; preds = %108
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %112
+ThrowNullRef44:                                   ; preds = %112
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %118
+ThrowNullRef46:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %121
+ThrowNullRef48:                                   ; preds = %121
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %123
+ThrowNullRef50:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %130
+ThrowNullRef52:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %132
+ThrowNullRef54:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %144
+ThrowNullRef56:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %146
+ThrowNullRef58:                                   ; preds = %146
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %60
+ThrowNullRef60:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %63
+ThrowNullRef62:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %49
+ThrowNullRef64:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %51
+ThrowNullRef66:                                   ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %53
+ThrowNullRef68:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(%"System.Char[]" addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %arg0 = alloca %"System.Char[]" addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store %"System.Char[]" addrspace(1)* %param0, %"System.Char[]" addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load i32, i32* %arg4
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %43, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %38, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg1
+  %13 = load i32, i32* %arg4
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %38, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %24 = load i32, i32* %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %35 = load i32, i32* %arg3
+  %36 = load i32, i32* %arg4
+  %37 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %37, %"System.Char[]" addrspace(1)* %34, i32 %35, i32 %36)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:38                                      ; preds = %5, %16
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Successfully read Buffer._Memmove
 
@@ -7914,7 +9431,7 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[loadElem]
+Failed to read AppDomain.SetDataHelper[storeElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -7923,8 +9440,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
@@ -7934,8 +9451,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
@@ -7947,15 +9464,15 @@ entry:
   %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
   %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
@@ -7966,15 +9483,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7992,7 +9509,79 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
-Failed to read Dictionary`2.TryGetValue[loadElemA]
+Successfully read Dictionary`2.TryGetValue
+
+define i8 @"Dictionary`2.TryGetValue"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)* addrspace(1)* %param2) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  %arg2 = alloca %System.__Canon addrspace(1)* addrspace(1)*
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  store %System.__Canon addrspace(1)* addrspace(1)* %param2, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  store i32 %2, i32* %loc0
+  %3 = load i32, i32* %loc0
+  %4 = icmp slt i32 %3, 0
+  br i1 %4, label %22, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 2
+  %10 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %9, align 8
+  %11 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = zext i32 %11 to i64
+  %BoundsCheck = icmp uge i64 %16, %15
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 3, i32 %11
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %20, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %6, %System.__Canon addrspace(1)* %21)
+  ret i8 1
+
+; <label>:22                                      ; preds = %entry
+  %23 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %23, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -8058,8 +9647,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
@@ -8091,8 +9680,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
@@ -8171,15 +9760,15 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck, label %19, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %ThrowNullRef, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
   %21 = load i32, i32 addrspace(1)* %20
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
@@ -8202,7 +9791,7 @@ ThrowNullRef:                                     ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %19
+ThrowNullRef2:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8248,8 +9837,8 @@ entry:
   %0 = alloca %System.AppDomainHandle
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %1 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %1, i32 0, i32 15
@@ -8269,8 +9858,8 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
@@ -8286,7 +9875,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -8299,8 +9888,8 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -8327,8 +9916,8 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
@@ -8352,8 +9941,8 @@ entry:
   %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
   store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
@@ -8363,8 +9952,8 @@ entry:
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
@@ -8374,8 +9963,8 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %9
   %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
@@ -8384,8 +9973,8 @@ entry:
 
 ; <label>:18                                      ; preds = %3, %16
   %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
@@ -8397,15 +9986,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %18
+ThrowNullRef6:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8418,8 +10007,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
@@ -8453,15 +10042,15 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
@@ -8473,7 +10062,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8481,7 +10070,7 @@ ThrowNullRef1:                                    ; preds = %1
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
 Failed to read Dictionary`2.System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
@@ -8506,8 +10095,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
@@ -8524,8 +10113,8 @@ entry:
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -8544,7 +10133,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8577,8 +10166,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = load i64, i64* %arg2
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = trunc i32 %3 to i8
@@ -8634,46 +10223,46 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
   %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
-  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
-  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
-  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
@@ -8684,27 +10273,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %20
+ThrowNullRef12:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8717,8 +10306,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -8756,22 +10345,22 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
   %9 = load i64, i64 addrspace(1)* %8, align 8
   %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
   %13 = load i64, i64 addrspace(1)* %12, align 8
   %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %11
   %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
@@ -8788,11 +10377,11 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8882,8 +10471,8 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
@@ -8900,8 +10489,8 @@ entry:
 ; <label>:8                                       ; preds = %1
   %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
   %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
@@ -8911,15 +10500,15 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
   %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
   %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
-  br i1 %NullCheck6, label %21, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
@@ -8946,15 +10535,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8992,15 +10581,15 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
   store i8 %3, i8 addrspace(1)* %5
   %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
@@ -9011,7 +10600,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9027,8 +10616,8 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -9041,8 +10630,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
@@ -9058,7 +10647,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9080,8 +10669,8 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
@@ -9096,8 +10685,8 @@ entry:
 ; <label>:12                                      ; preds = %6
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
@@ -9112,8 +10701,8 @@ entry:
 ; <label>:21                                      ; preds = %15
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
@@ -9128,8 +10717,8 @@ entry:
 ; <label>:30                                      ; preds = %24
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %31, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
@@ -9144,8 +10733,8 @@ entry:
 ; <label>:39                                      ; preds = %33
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
-  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %40, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %42
 
 ; <label>:42                                      ; preds = %39
   %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
@@ -9164,19 +10753,19 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %21
+ThrowNullRef4:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %30
+ThrowNullRef6:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %39
+ThrowNullRef8:                                    ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9243,8 +10832,8 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
@@ -9264,57 +10853,57 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
   store i8 0, i8 addrspace(1)* %2
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
   store i8 0, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
   store i8 0, i8 addrspace(1)* %17
   %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
   store i8 0, i8 addrspace(1)* %20
   %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
-  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
@@ -9325,31 +10914,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %19
+ThrowNullRef14:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9367,8 +10956,8 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
@@ -9380,8 +10969,8 @@ entry:
 
 ; <label>:9                                       ; preds = %4
   %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %9
   %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
@@ -9395,7 +10984,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef2:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9420,8 +11009,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
@@ -9512,8 +11101,8 @@ entry:
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
@@ -9524,8 +11113,8 @@ entry:
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = load i64, i64 addrspace(1)* %12
@@ -9537,8 +11126,8 @@ entry:
   %20 = load i64, i64* %19
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
-  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %13
   %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
@@ -9555,8 +11144,8 @@ entry:
 ; <label>:30                                      ; preds = %25
   %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %32 = load i32, i32* %arg2
-  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
-  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
@@ -9570,15 +11159,15 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %30
+ThrowNullRef2:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9622,87 +11211,87 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
   %10 = load i8, i8 addrspace(1)* %9, align 8
   %11 = zext i8 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %8
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
   store i8 %12, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
   %19 = load i8, i8 addrspace(1)* %18, align 8
   %20 = zext i8 %19 to i32
   %21 = trunc i32 %20 to i8
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
   store i8 %21, i8 addrspace(1)* %23
   %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
   %28 = load i8, i8 addrspace(1)* %27, align 8
   %29 = zext i8 %28 to i32
   %30 = trunc i32 %29 to i8
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
-  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %31
 
 ; <label>:31                                      ; preds = %26
   %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
   store i8 %30, i8 addrspace(1)* %32
   %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
-  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
-  br i1 %NullCheck14, label %40, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %40
 
 ; <label>:40                                      ; preds = %35
   %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
   store i8 %39, i8 addrspace(1)* %41
   %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
-  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %44
 
 ; <label>:44                                      ; preds = %40
   %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
   %46 = load i8, i8 addrspace(1)* %45, align 8
   %47 = zext i8 %46 to i32
   %48 = trunc i32 %47 to i8
-  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
   store i8 %48, i8 addrspace(1)* %50
   %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
-  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
@@ -9713,29 +11302,29 @@ entry:
 ; <label>:56                                      ; preds = %52
   %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
-  br i1 %NullCheck22, label %59, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
   %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
   %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
-  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
-  br i1 %NullCheck24, label %63, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
   %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
-  br i1 %NullCheck26, label %66, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
   %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
-  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
-  br i1 %NullCheck28, label %69, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %69
 
 ; <label>:69                                      ; preds = %66
   %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
@@ -9744,15 +11333,15 @@ entry:
 
 ; <label>:71                                      ; preds = %105
   %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
-  br i1 %NullCheck34, label %73, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %73
 
 ; <label>:73                                      ; preds = %71
   %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
   %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
   %76 = load i32, i32* %loc0
-  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
-  br i1 %NullCheck36, label %77, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
@@ -9766,8 +11355,8 @@ entry:
 
 ; <label>:83                                      ; preds = %77
   %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
-  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
@@ -9775,14 +11364,14 @@ entry:
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
   %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
-  br i1 %NullCheck40, label %91, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
 ; <label>:91                                      ; preds = %85
   %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
   %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
-  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck42, label %94, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %94
 
 ; <label>:94                                      ; preds = %91
   %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
@@ -9798,14 +11387,14 @@ entry:
 ; <label>:99                                      ; preds = %69, %96
   %100 = load i32, i32* %loc0
   %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
-  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %102
 
 ; <label>:102                                     ; preds = %99
   %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
   %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
-  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
-  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
@@ -9819,87 +11408,87 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %26
+ThrowNullRef10:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %31
+ThrowNullRef12:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %35
+ThrowNullRef14:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %40
+ThrowNullRef16:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %56
+ThrowNullRef22:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %59
+ThrowNullRef24:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %63
+ThrowNullRef26:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %66
+ThrowNullRef28:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %102
+ThrowNullRef32:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %71
+ThrowNullRef34:                                   ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %73
+ThrowNullRef36:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %83
+ThrowNullRef38:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %85
+ThrowNullRef40:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %91
+ThrowNullRef42:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9943,15 +11532,15 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
   %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
@@ -9961,28 +11550,28 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
   %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %12
   %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
   %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
   %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
-  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
@@ -9993,23 +11582,23 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %12
+ThrowNullRef6:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10031,15 +11620,15 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
   %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = load i64, i64 addrspace(1)* %7
@@ -10077,13 +11666,13 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[loadElem]
+Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -10111,8 +11700,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -10154,7 +11743,78 @@ entry:
 INFO:  jitting method BringUpTest::Main using LLILCJit
 Failed to read BringUpTest.Main[convertHandle]
 INFO:  jitting method BringUpTest::FPArray using LLILCJit
-Failed to read BringUpTest.FPArray[loadElem]
+Successfully read BringUpTest.FPArray
+
+define float @BringUpTest.FPArray(%"System.Single[]" addrspace(1)* %param0, float %param1) {
+entry:
+  %arg0 = alloca %"System.Single[]" addrspace(1)*
+  %arg1 = alloca float
+  %loc0 = alloca float
+  %loc1 = alloca i32
+  store %"System.Single[]" addrspace(1)* %param0, %"System.Single[]" addrspace(1)** %arg0
+  store float %param1, float* %arg1
+  store float 0.000000e+00, float* %loc0
+  store i32 0, i32* %loc1
+  br label %15
+
+; <label>:0                                       ; preds = %18
+  %1 = load float, float* %loc0
+  %2 = load %"System.Single[]" addrspace(1)*, %"System.Single[]" addrspace(1)** %arg0
+  %3 = load i32, i32* %loc1
+  %NullCheck1 = icmp eq %"System.Single[]" addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
+
+; <label>:4                                       ; preds = %0
+  %5 = getelementptr inbounds %"System.Single[]", %"System.Single[]" addrspace(1)* %2, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = zext i32 %6 to i64
+  %8 = zext i32 %3 to i64
+  %BoundsCheck = icmp uge i64 %8, %7
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %9
+
+; <label>:9                                       ; preds = %4
+  %10 = getelementptr inbounds %"System.Single[]", %"System.Single[]" addrspace(1)* %2, i32 0, i32 3, i32 %3
+  %11 = load float, float addrspace(1)* %10, align 8
+  %12 = fadd float %1, %11
+  store float %12, float* %loc0
+  %13 = load i32, i32* %loc1
+  %14 = add i32 %13, 1
+  store i32 %14, i32* %loc1
+  br label %15
+
+; <label>:15                                      ; preds = %entry, %9
+  %16 = load i32, i32* %loc1
+  %17 = load %"System.Single[]" addrspace(1)*, %"System.Single[]" addrspace(1)** %arg0
+  %NullCheck = icmp eq %"System.Single[]" addrspace(1)* %17, null
+  br i1 %NullCheck, label %ThrowNullRef, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %"System.Single[]", %"System.Single[]" addrspace(1)* %17, i32 0, i32 1
+  %20 = load i32, i32 addrspace(1)* %19
+  %21 = zext i32 %20 to i64
+  %22 = trunc i64 %21 to i32
+  %23 = icmp slt i32 %16, %22
+  br i1 %23, label %0, label %24
+
+; <label>:24                                      ; preds = %18
+  %25 = load float, float* %loc0
+  %26 = load float, float* %arg1
+  %27 = fdiv float %25, %26
+  ret float %27
+
+ThrowNullRef:                                     ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Console::WriteLine using LLILCJit
 Successfully read Console.WriteLine
 
@@ -10165,8 +11825,8 @@ entry:
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load float, float* %arg0
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -10300,8 +11960,8 @@ entry:
   store i64 %param0, i64* %arg0
   store i64 %param1, i64* %arg1
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
@@ -10309,8 +11969,8 @@ entry:
   %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
   %5 = load i16*, i16* addrspace(1)* %4, align 8
   %6 = addrspacecast i64* %arg1 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = bitcast i64 addrspace(1)* %6 to i8 addrspace(1)*
@@ -10326,7 +11986,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10360,8 +12020,8 @@ entry:
   %1 = load i32, i32* %arg1
   %2 = sext i32 %1 to i64
   %3 = inttoptr i64 %2 to i16*
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -10414,8 +12074,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, i32)*)(%System.IO.ConsoleStream addrspace(1)* %2, i32 %1)
   %3 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %4 = load i64, i64* %arg1
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
@@ -10426,8 +12086,8 @@ entry:
   %10 = icmp eq i32 %9, 3
   %11 = sext i1 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %5
   %14 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, i32 0, i32 5
@@ -10438,7 +12098,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10461,8 +12121,8 @@ entry:
   %5 = icmp eq i32 %4, 1
   %6 = sext i1 %5 to i32
   %7 = trunc i32 %6 to i8
-  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %2, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.ConsoleStream addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
@@ -10473,8 +12133,8 @@ entry:
   %13 = icmp eq i32 %12, 2
   %14 = sext i1 %13 to i32
   %15 = trunc i32 %14 to i8
-  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %10, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.ConsoleStream addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %8
   %17 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %10, i32 0, i32 4
@@ -10485,7 +12145,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10524,8 +12184,8 @@ entry:
   %arg0 = alloca i64
   store i64 %param0, i64* %arg0
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
@@ -10560,8 +12220,8 @@ entry:
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
   %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = load i64, i64 addrspace(1)* %7
@@ -10665,7 +12325,127 @@ entry:
 INFO:  jitting method Encoding::GetEncoding using LLILCJit
 Failed to read Encoding.GetEncoding[convertToHelperArgumentType]
 INFO:  jitting method EncodingProvider::GetEncodingFromProvider using LLILCJit
-Failed to read EncodingProvider.GetEncodingFromProvider[loadElem]
+Successfully read EncodingProvider.GetEncodingFromProvider
+
+define %System.Text.Encoding addrspace(1)* @EncodingProvider.GetEncodingFromProvider(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca %"System.Text.EncodingProvider[]" addrspace(1)*
+  %loc1 = alloca %System.Text.EncodingProvider addrspace(1)*
+  %loc2 = alloca %System.Text.Encoding addrspace(1)*
+  %loc3 = alloca %System.Text.Encoding addrspace(1)*
+  %loc4 = alloca %"System.Text.EncodingProvider[]" addrspace(1)*
+  %loc5 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1059)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2392
+  %2 = addrspacecast i8 addrspace(1)* %1 to %"System.Text.EncodingProvider[]" addrspace(1)**
+  %3 = load volatile %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %2
+  %4 = icmp ne %"System.Text.EncodingProvider[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %entry
+  ret %System.Text.Encoding addrspace(1)* null
+
+; <label>:6                                       ; preds = %entry
+  %7 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1059)
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i64 2392
+  %9 = addrspacecast i8 addrspace(1)* %8 to %"System.Text.EncodingProvider[]" addrspace(1)**
+  %10 = load volatile %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %9
+  store %"System.Text.EncodingProvider[]" addrspace(1)* %10, %"System.Text.EncodingProvider[]" addrspace(1)** %loc0
+  %11 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc0
+  store %"System.Text.EncodingProvider[]" addrspace(1)* %11, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  store i32 0, i32* %loc5
+  br label %43
+
+; <label>:12                                      ; preds = %46
+  %13 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  %14 = load i32, i32* %loc5
+  %NullCheck1 = icmp eq %"System.Text.EncodingProvider[]" addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %13, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = zext i32 %17 to i64
+  %19 = zext i32 %14 to i64
+  %BoundsCheck = icmp uge i64 %19, %18
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %20
+
+; <label>:20                                      ; preds = %15
+  %21 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %13, i32 0, i32 3, i32 %14
+  %22 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)* addrspace(1)* %21, align 8
+  store %System.Text.EncodingProvider addrspace(1)* %22, %System.Text.EncodingProvider addrspace(1)** %loc1
+  %23 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)** %loc1
+  %24 = load i32, i32* %arg0
+  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i64 addrspace(1)*
+  %NullCheck3 = icmp eq i64 addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
+
+; <label>:26                                      ; preds = %20
+  %27 = load i64, i64 addrspace(1)* %25
+  %28 = add i64 %27, 64
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 40
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Text.Encoding addrspace(1)* (%System.Text.EncodingProvider addrspace(1)*, i32)*
+  %35 = call %System.Text.Encoding addrspace(1)* %34(%System.Text.EncodingProvider addrspace(1)* %23, i32 %24)
+  store %System.Text.Encoding addrspace(1)* %35, %System.Text.Encoding addrspace(1)** %loc2
+  %36 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc2
+  %37 = icmp eq %System.Text.Encoding addrspace(1)* %36, null
+  br i1 %37, label %40, label %38
+
+; <label>:38                                      ; preds = %26
+  %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc2
+  store %System.Text.Encoding addrspace(1)* %39, %System.Text.Encoding addrspace(1)** %loc3
+  br label %53
+
+; <label>:40                                      ; preds = %26
+  %41 = load i32, i32* %loc5
+  %42 = add i32 %41, 1
+  store i32 %42, i32* %loc5
+  br label %43
+
+; <label>:43                                      ; preds = %6, %40
+  %44 = load i32, i32* %loc5
+  %45 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  %NullCheck = icmp eq %"System.Text.EncodingProvider[]" addrspace(1)* %45, null
+  br i1 %NullCheck, label %ThrowNullRef, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp slt i32 %44, %50
+  br i1 %51, label %12, label %52
+
+; <label>:52                                      ; preds = %46
+  ret %System.Text.Encoding addrspace(1)* null
+
+; <label>:53                                      ; preds = %38
+  %54 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc3
+  ret %System.Text.Encoding addrspace(1)* %54
+
+ThrowNullRef:                                     ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method EncodingProvider::.cctor using LLILCJit
 Successfully read EncodingProvider..cctor
 
@@ -10684,7 +12464,7 @@ Failed to read Encoding.get_InternalSyncObject[Call HasTypeArg]
 INFO:  jitting method Hashtable::.ctor using LLILCJit
 Failed to read Hashtable..ctor[Volatile store]
 INFO:  jitting method Hashtable::get_Item using LLILCJit
-Failed to read Hashtable.get_Item[loadElemA]
+Failed to read Hashtable.get_Item[loadNonPrimitiveObj]
 INFO:  jitting method Hashtable::InitHash using LLILCJit
 Successfully read Hashtable.InitHash
 
@@ -10704,8 +12484,8 @@ entry:
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -10721,15 +12501,15 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
   %15 = load i32, i32* %loc0
-  %NullCheck2 = icmp ne i32 addrspace(1)* %14, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i32 addrspace(1)* %14, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %3
   store i32 %15, i32 addrspace(1)* %14, align 8
   %17 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %18 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %NullCheck4 = icmp ne i32 addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i32 addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = load i32, i32 addrspace(1)* %18, align 8
@@ -10738,8 +12518,8 @@ entry:
   %23 = sub i32 %22, 1
   %24 = urem i32 %21, %23
   %25 = add i32 1, %24
-  %NullCheck6 = icmp ne i32 addrspace(1)* %17, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32 addrspace(1)* %17, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %19
   store i32 %25, i32 addrspace(1)* %17, align 8
@@ -10750,15 +12530,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %19
+ThrowNullRef6:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10773,8 +12553,8 @@ entry:
   store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
   store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %NullCheck = icmp ne %System.Collections.Hashtable addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Collections.Hashtable addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
@@ -10784,16 +12564,16 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Collections.Hashtable addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Collections.Hashtable addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
   %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck4 = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %9, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
   %13 = inttoptr i64 %11 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
@@ -10803,8 +12583,8 @@ entry:
 ; <label>:15                                      ; preds = %1
   %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -10822,15 +12602,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10844,8 +12624,8 @@ entry:
   store %System.Int32 addrspace(1)* %param0, %System.Int32 addrspace(1)** %this
   %0 = load %System.Int32 addrspace(1)*, %System.Int32 addrspace(1)** %this
   %1 = bitcast %System.Int32 addrspace(1)* %0 to i32 addrspace(1)*
-  %NullCheck = icmp ne i32 addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq i32 addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load i32, i32 addrspace(1)* %1, align 8
@@ -10921,8 +12701,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.UTF8Encoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
@@ -10931,15 +12711,15 @@ entry:
   %9 = load i8, i8* %arg2
   %10 = zext i8 %9 to i32
   %11 = trunc i32 %10 to i8
-  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %8, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %6
   %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %8, i32 0, i32 8
   store i8 %11, i8 addrspace(1)* %13
   %14 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %14, i32 0, i32 8
@@ -10951,8 +12731,8 @@ entry:
 ; <label>:20                                      ; preds = %15
   %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %22, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %22, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = load i64, i64 addrspace(1)* %22
@@ -10974,15 +12754,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %12
+ThrowNullRef4:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10997,8 +12777,8 @@ entry:
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
@@ -11020,16 +12800,16 @@ entry:
 ; <label>:10                                      ; preds = %1
   %11 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
   %12 = load i32, i32* %arg1
-  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %11, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.Encoding addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
   store i32 %12, i32 addrspace(1)* %14
   %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
   %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = load i64, i64 addrspace(1)* %16
@@ -11047,11 +12827,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11064,8 +12844,8 @@ entry:
   %this = alloca %System.Text.UTF8Encoding addrspace(1)*
   store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
   %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.UTF8Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
@@ -11077,16 +12857,16 @@ entry:
 ; <label>:6                                       ; preds = %1
   %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %8 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %10, %System.Text.EncoderFallback addrspace(1)* %8)
   %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %12 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
-  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %11, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %11, i32 0, i32 3
@@ -11099,8 +12879,8 @@ entry:
   %18 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %18, %System.String addrspace(1)* %17)
   %19 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %18 to %System.Text.EncoderFallback addrspace(1)*
-  %NullCheck6 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %16, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %16, i32 0, i32 2
@@ -11110,8 +12890,8 @@ entry:
   %24 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %24, %System.String addrspace(1)* %23)
   %25 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %24 to %System.Text.DecoderFallback addrspace(1)*
-  %NullCheck8 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %22, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %22, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %20
   %27 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %22, i32 0, i32 3
@@ -11122,19 +12902,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %20
+ThrowNullRef8:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11164,8 +12944,8 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load i32, i32* %arg1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -11183,8 +12963,8 @@ entry:
 ; <label>:15                                      ; preds = %8
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %17 = load i32, i32* %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 %17
@@ -11200,7 +12980,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11252,7 +13032,7 @@ entry:
 }
 
 INFO:  jitting method Hashtable::Insert using LLILCJit
-Failed to read Hashtable.Insert[loadElemA]
+Failed to read Hashtable.Insert[storeElem]
 INFO:  jitting method ConsoleEncoding::.ctor using LLILCJit
 Successfully read ConsoleEncoding..ctor
 
@@ -11267,8 +13047,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %1)
   %2 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
@@ -11304,8 +13084,8 @@ entry:
   %2 = call %System.Text.InternalEncoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalEncoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %1)
   %3 = bitcast %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2 to %System.Text.EncoderFallback addrspace(1)*
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
@@ -11315,8 +13095,8 @@ entry:
   %8 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %7)
   %9 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %8 to %System.Text.DecoderFallback addrspace(1)*
-  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %6, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.Encoding addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %4
   %11 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %6, i32 0, i32 3
@@ -11327,7 +13107,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11346,15 +13126,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* %1)
   %2 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   %6 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, i32 0, i32 1
@@ -11365,7 +13145,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11393,8 +13173,8 @@ entry:
   store %System.Text.InternalDecoderBestFitFallback addrspace(1)* %param0, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
   %0 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
@@ -11404,15 +13184,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %4)
   %5 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %6)
   %9 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, i32 0, i32 1
@@ -11423,11 +13203,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11495,8 +13275,8 @@ entry:
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
   %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = load i64, i64 addrspace(1)* %19
@@ -11560,8 +13340,8 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.ConsoleStream addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
@@ -11592,31 +13372,31 @@ entry:
   store i8 %param4, i8* %arg4
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %3, %System.IO.Stream addrspace(1)* %1)
   %4 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %4, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
   %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %4, i32 0, i32 4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %5)
   %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %6
   %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
   %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
   %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = load i64, i64 addrspace(1)* %13
@@ -11628,8 +13408,8 @@ entry:
   %21 = load i64, i64* %20
   %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %8, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %8, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %14
   %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 5
@@ -11647,24 +13427,24 @@ entry:
   %31 = load i32, i32* %arg3
   %32 = sext i32 %31 to i64
   %33 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %32)
-  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %30, null
-  br i1 %NullCheck10, label %34, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.StreamWriter addrspace(1)* %30, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %35, %"System.Char[]" addrspace(1)* %33)
   %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %37, null
-  br i1 %NullCheck12, label %38, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.StreamWriter addrspace(1)* %37, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %38
 
 ; <label>:38                                      ; preds = %34
   %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
   %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
   %41 = load i32, i32* %arg3
   %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %42, null
-  br i1 %NullCheck14, label %43, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %42, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
   %44 = load i64, i64 addrspace(1)* %42
@@ -11678,30 +13458,30 @@ entry:
   %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
   %53 = sext i32 %52 to i64
   %54 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %53)
-  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
-  br i1 %NullCheck16, label %55, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %55
 
 ; <label>:55                                      ; preds = %43
   %56 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %56, %"System.Byte[]" addrspace(1)* %54)
   %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %58 = load i32, i32* %arg3
-  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %57, null
-  br i1 %NullCheck18, label %59, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.StreamWriter addrspace(1)* %57, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %59
 
 ; <label>:59                                      ; preds = %55
   %60 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 10
   store i32 %58, i32 addrspace(1)* %60
   %61 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %61, null
-  br i1 %NullCheck20, label %62, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.IO.StreamWriter addrspace(1)* %61, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %62
 
 ; <label>:62                                      ; preds = %59
   %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
   %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
   %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
   %67 = load i64, i64 addrspace(1)* %65
@@ -11719,15 +13499,15 @@ entry:
 
 ; <label>:78                                      ; preds = %66
   %79 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %79, null
-  br i1 %NullCheck24, label %80, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.StreamWriter addrspace(1)* %79, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %80
 
 ; <label>:80                                      ; preds = %78
   %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
   %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
   %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %83, null
-  br i1 %NullCheck26, label %84, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %83, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
   %85 = load i64, i64 addrspace(1)* %83
@@ -11744,8 +13524,8 @@ entry:
 
 ; <label>:95                                      ; preds = %84
   %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.IO.StreamWriter addrspace(1)* %96, null
-  br i1 %NullCheck28, label %97, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.IO.StreamWriter addrspace(1)* %96, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %97
 
 ; <label>:97                                      ; preds = %95
   %98 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 12
@@ -11759,8 +13539,8 @@ entry:
   %103 = icmp eq i32 %102, 0
   %104 = sext i1 %103 to i32
   %105 = trunc i32 %104 to i8
-  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %100, null
-  br i1 %NullCheck30, label %106, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.IO.StreamWriter addrspace(1)* %100, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %106
 
 ; <label>:106                                     ; preds = %99
   %107 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %100, i32 0, i32 13
@@ -11771,63 +13551,63 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %6
+ThrowNullRef4:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %29
+ThrowNullRef10:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %34
+ThrowNullRef12:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %38
+ThrowNullRef14:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %43
+ThrowNullRef16:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %55
+ThrowNullRef18:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %59
+ThrowNullRef20:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %62
+ThrowNullRef22:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %78
+ThrowNullRef24:                                   ; preds = %78
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %80
+ThrowNullRef26:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %95
+ThrowNullRef28:                                   ; preds = %95
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11840,15 +13620,15 @@ entry:
   %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = load i64, i64 addrspace(1)* %4
@@ -11866,7 +13646,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11916,35 +13696,35 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
   %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderNLS addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %7 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.EncoderNLS addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Text.Encoding addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.Encoding addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Text.EncoderNLS addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.EncoderNLS addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
   %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck8 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = load i64, i64 addrspace(1)* %16
@@ -11963,19 +13743,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12001,8 +13781,8 @@ entry:
   %this = alloca %System.Text.Encoding addrspace(1)*
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
@@ -12022,15 +13802,15 @@ entry:
   %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
   store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
   %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
   store i32 0, i32 addrspace(1)* %2
   %3 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, i32 0, i32 2
@@ -12040,15 +13820,15 @@ entry:
 
 ; <label>:8                                       ; preds = %4
   %9 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
   %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
   %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = load i64, i64 addrspace(1)* %13
@@ -12069,15 +13849,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12092,16 +13872,16 @@ entry:
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = load i32, i32* %arg1
   %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
   %7 = load i64, i64 addrspace(1)* %5
@@ -12119,7 +13899,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12156,8 +13936,8 @@ entry:
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
   %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
   %16 = load i64, i64 addrspace(1)* %14
@@ -12178,8 +13958,8 @@ entry:
   %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
   %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
   %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %31, null
-  br i1 %NullCheck2, label %32, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = load i64, i64 addrspace(1)* %31
@@ -12222,7 +14002,7 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12235,14 +14015,14 @@ entry:
   %this = alloca %System.Text.EncoderReplacementFallback addrspace(1)*
   store %System.Text.EncoderReplacementFallback addrspace(1)* %param0, %System.Text.EncoderReplacementFallback addrspace(1)** %this
   %0 = load %System.Text.EncoderReplacementFallback addrspace(1)*, %System.Text.EncoderReplacementFallback addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -12253,7 +14033,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12283,8 +14063,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
@@ -12316,8 +14096,8 @@ entry:
   %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
   store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
@@ -12329,8 +14109,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Threading.Tasks.Task addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %7)
@@ -12353,7 +14133,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12372,8 +14152,8 @@ entry:
   store i8 %param1, i8* %arg1
   store i8 %param2, i8* %arg2
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
@@ -12387,8 +14167,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1, %5
   %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 9
@@ -12419,8 +14199,8 @@ entry:
 
 ; <label>:25                                      ; preds = %8, %20
   %26 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %26, null
-  br i1 %NullCheck4, label %27, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %26, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %26, i32 0, i32 12
@@ -12431,22 +14211,22 @@ entry:
 
 ; <label>:32                                      ; preds = %27
   %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %33, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.IO.StreamWriter addrspace(1)* %33, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %32
   %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 12
   store i8 1, i8 addrspace(1)* %35
   %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
-  br i1 %NullCheck8, label %37, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
   %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
   %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck10 = icmp ne i64 addrspace(1)* %40, null
-  br i1 %NullCheck10, label %41, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64 addrspace(1)* %40, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i64, i64 addrspace(1)* %40
@@ -12460,8 +14240,8 @@ entry:
   %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
   store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
   %51 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %NullCheck12 = icmp ne %"System.Byte[]" addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Byte[]" addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %41
   %53 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %51, i32 0, i32 1
@@ -12473,16 +14253,16 @@ entry:
 
 ; <label>:58                                      ; preds = %52
   %59 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %59, null
-  br i1 %NullCheck14, label %60, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.IO.StreamWriter addrspace(1)* %59, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %60
 
 ; <label>:60                                      ; preds = %58
   %61 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %59, i32 0, i32 3
   %62 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
   %64 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %NullCheck16 = icmp ne %"System.Byte[]" addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %"System.Byte[]" addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %60
   %66 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %64, i32 0, i32 1
@@ -12490,8 +14270,8 @@ entry:
   %68 = zext i32 %67 to i64
   %69 = trunc i64 %68 to i32
   %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck18, label %71, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
   %72 = load i64, i64 addrspace(1)* %70
@@ -12507,29 +14287,29 @@ entry:
 
 ; <label>:80                                      ; preds = %27, %52, %71
   %81 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %81, null
-  br i1 %NullCheck20, label %82, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.IO.StreamWriter addrspace(1)* %81, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
 
 ; <label>:82                                      ; preds = %80
   %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %81, i32 0, i32 5
   %84 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %83, align 8
   %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.IO.StreamWriter addrspace(1)* %85, null
-  br i1 %NullCheck22, label %86, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.IO.StreamWriter addrspace(1)* %85, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %86
 
 ; <label>:86                                      ; preds = %82
   %87 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 7
   %88 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %87, align 8
   %89 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %89, null
-  br i1 %NullCheck24, label %90, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.StreamWriter addrspace(1)* %89, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %90
 
 ; <label>:90                                      ; preds = %86
   %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %89, i32 0, i32 9
   %92 = load i32, i32 addrspace(1)* %91, align 8
   %93 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.IO.StreamWriter addrspace(1)* %93, null
-  br i1 %NullCheck26, label %94, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.IO.StreamWriter addrspace(1)* %93, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %93, i32 0, i32 6
@@ -12537,8 +14317,8 @@ entry:
   %97 = load i8, i8* %arg2
   %98 = zext i8 %97 to i32
   %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
-  %NullCheck28 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck28, label %100, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
   %101 = load i64, i64 addrspace(1)* %99
@@ -12553,8 +14333,8 @@ entry:
   %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
   store i32 %110, i32* %loc1
   %111 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %111, null
-  br i1 %NullCheck30, label %112, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.IO.StreamWriter addrspace(1)* %111, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %112
 
 ; <label>:112                                     ; preds = %100
   %113 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %111, i32 0, i32 9
@@ -12565,23 +14345,23 @@ entry:
 
 ; <label>:116                                     ; preds = %112
   %117 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck32 = icmp ne %System.IO.StreamWriter addrspace(1)* %117, null
-  br i1 %NullCheck32, label %118, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.IO.StreamWriter addrspace(1)* %117, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %118
 
 ; <label>:118                                     ; preds = %116
   %119 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %117, i32 0, i32 3
   %120 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %119, align 8
   %121 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.IO.StreamWriter addrspace(1)* %121, null
-  br i1 %NullCheck34, label %122, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.IO.StreamWriter addrspace(1)* %121, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %122
 
 ; <label>:122                                     ; preds = %118
   %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
   %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
   %125 = load i32, i32* %loc1
   %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
-  %NullCheck36 = icmp ne i64 addrspace(1)* %126, null
-  br i1 %NullCheck36, label %127, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64 addrspace(1)* %126, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
   %128 = load i64, i64 addrspace(1)* %126
@@ -12603,15 +14383,15 @@ entry:
 
 ; <label>:140                                     ; preds = %136
   %141 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.IO.StreamWriter addrspace(1)* %141, null
-  br i1 %NullCheck38, label %142, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.IO.StreamWriter addrspace(1)* %141, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %142
 
 ; <label>:142                                     ; preds = %140
   %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
   %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
   %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
-  %NullCheck40 = icmp ne i64 addrspace(1)* %145, null
-  br i1 %NullCheck40, label %146, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i64 addrspace(1)* %145, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
   %147 = load i64, i64 addrspace(1)* %145
@@ -12632,83 +14412,83 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %25
+ThrowNullRef4:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %32
+ThrowNullRef6:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %37
+ThrowNullRef10:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %41
+ThrowNullRef12:                                   ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %58
+ThrowNullRef14:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %60
+ThrowNullRef16:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %65
+ThrowNullRef18:                                   ; preds = %65
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %80
+ThrowNullRef20:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %82
+ThrowNullRef22:                                   ; preds = %82
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %86
+ThrowNullRef24:                                   ; preds = %86
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %90
+ThrowNullRef26:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %94
+ThrowNullRef28:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %100
+ThrowNullRef30:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %116
+ThrowNullRef32:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %118
+ThrowNullRef34:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %122
+ThrowNullRef36:                                   ; preds = %122
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %140
+ThrowNullRef38:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %142
+ThrowNullRef40:                                   ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12775,8 +14555,8 @@ entry:
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %1 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
-  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
@@ -12784,8 +14564,8 @@ entry:
   %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
   %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
   %8 = load i64, i64 addrspace(1)* %6
@@ -12801,8 +14581,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %17, %System.IFormatProvider addrspace(1)* %16)
   %18 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %19 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %18, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.SyncTextWriter addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %7
   %21 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %18, i32 0, i32 4
@@ -12813,11 +14593,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12830,8 +14610,8 @@ entry:
   %this = alloca %System.IO.TextWriter addrspace(1)*
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.TextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
@@ -12841,8 +14621,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.Threading.Thread addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Threading.Thread addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %6)
@@ -12851,8 +14631,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1
   %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.TextWriter addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.TextWriter addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %11, i32 0, i32 2
@@ -12863,11 +14643,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13064,8 +14844,8 @@ entry:
   store float %param1, float* %arg1
   store i8 0, i8* %loc1
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
@@ -13075,16 +14855,16 @@ entry:
   %5 = addrspacecast i8* %loc1 to i8 addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %4, i8 addrspace(1)* %5)
   %6 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.SyncTextWriter addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
   %10 = load float, float* %arg1
   %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
   %13 = load i64, i64 addrspace(1)* %11
@@ -13119,11 +14899,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13140,8 +14920,8 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load float, float* %arg1
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -13155,8 +14935,8 @@ entry:
   call void %11(%System.IO.TextWriter addrspace(1)* %0, float %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
   %15 = load i64, i64 addrspace(1)* %13
@@ -13174,7 +14954,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13192,8 +14972,8 @@ entry:
   %1 = addrspacecast float* %arg1 to float addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -13208,8 +14988,8 @@ entry:
   %14 = bitcast float addrspace(1)* %1 to %System.Single addrspace(1)*
   %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Single addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Single addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
   %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
   %18 = load i64, i64 addrspace(1)* %16
@@ -13227,7 +15007,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13243,8 +15023,8 @@ entry:
   store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
   %0 = load %System.Single addrspace(1)*, %System.Single addrspace(1)** %this
   %1 = bitcast %System.Single addrspace(1)* %0 to float addrspace(1)*
-  %NullCheck = icmp ne float addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq float addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load float, float addrspace(1)* %1, align 8
@@ -13269,8 +15049,8 @@ entry:
   %loc0 = alloca %System.Globalization.NumberFormatInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 3
@@ -13280,8 +15060,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
@@ -13291,24 +15071,24 @@ entry:
   store %System.Globalization.NumberFormatInfo addrspace(1)* %10, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
   %11 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %7
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
   %15 = load i8, i8 addrspace(1)* %14, align 8
   %16 = zext i8 %15 to i32
   %17 = trunc i32 %16 to i8
-  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %11, null
-  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %11, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %13
   %19 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %11, i32 0, i32 29
   store i8 %17, i8 addrspace(1)* %19
   %20 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %21 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %20, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %20, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %18
   %23 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %20, i32 0, i32 3
@@ -13317,8 +15097,8 @@ entry:
 
 ; <label>:24                                      ; preds = %1, %22
   %25 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %25, null
-  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %25, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %26
 
 ; <label>:26                                      ; preds = %24
   %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %25, i32 0, i32 3
@@ -13329,23 +15109,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %18
+ThrowNullRef8:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13370,168 +15150,168 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 18
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %8, align 8
-  %NullCheck2 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %5, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %5, i32 0, i32 4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %9)
   %12 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 19
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %15, align 8
-  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %12, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %12, i32 0, i32 5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %16)
   %19 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %20 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %20, null
-  br i1 %NullCheck8, label %21, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %20, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %20, i32 0, i32 23
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  %NullCheck10 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %19, null
-  br i1 %NullCheck10, label %24, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %19, i32 0, i32 7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %25, %System.String addrspace(1)* %23)
   %26 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %27 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %27, i32 0, i32 22
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %29, align 8
-  %NullCheck14 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %26, null
-  br i1 %NullCheck14, label %31, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %26, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %26, i32 0, i32 6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %32, %System.String addrspace(1)* %30)
   %33 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %34 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Globalization.CultureData addrspace(1)* %34, null
-  br i1 %NullCheck16, label %35, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Globalization.CultureData addrspace(1)* %34, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %34, i32 0, i32 51
   %37 = load i32, i32 addrspace(1)* %36, align 8
-  %NullCheck18 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %33, null
-  br i1 %NullCheck18, label %38, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %33, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %33, i32 0, i32 21
   store i32 %37, i32 addrspace(1)* %39
   %40 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %41 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Globalization.CultureData addrspace(1)* %41, null
-  br i1 %NullCheck20, label %42, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Globalization.CultureData addrspace(1)* %41, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %41, i32 0, i32 52
   %44 = load i32, i32 addrspace(1)* %43, align 8
-  %NullCheck22 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %40, null
-  br i1 %NullCheck22, label %45, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %40, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %40, i32 0, i32 25
   store i32 %44, i32 addrspace(1)* %46
   %47 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %48 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.Globalization.CultureData addrspace(1)* %48, null
-  br i1 %NullCheck24, label %49, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Globalization.CultureData addrspace(1)* %48, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %49
 
 ; <label>:49                                      ; preds = %45
   %50 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %48, i32 0, i32 29
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck26 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %47, null
-  br i1 %NullCheck26, label %52, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %47, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %47, i32 0, i32 10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %53, %System.String addrspace(1)* %51)
   %54 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %55 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Globalization.CultureData addrspace(1)* %55, null
-  br i1 %NullCheck28, label %56, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Globalization.CultureData addrspace(1)* %55, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %56
 
 ; <label>:56                                      ; preds = %52
   %57 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %55, i32 0, i32 35
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %57, align 8
-  %NullCheck30 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %54, null
-  br i1 %NullCheck30, label %59, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %54, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %54, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %60, %System.String addrspace(1)* %58)
   %61 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %62 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck32 = icmp ne %System.Globalization.CultureData addrspace(1)* %62, null
-  br i1 %NullCheck32, label %63, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Globalization.CultureData addrspace(1)* %62, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %62, i32 0, i32 34
   %65 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %64, align 8
-  %NullCheck34 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %61, null
-  br i1 %NullCheck34, label %66, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %61, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %61, i32 0, i32 9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %67, %System.String addrspace(1)* %65)
   %68 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %69 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck36 = icmp ne %System.Globalization.CultureData addrspace(1)* %69, null
-  br i1 %NullCheck36, label %70, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Globalization.CultureData addrspace(1)* %69, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %70
 
 ; <label>:70                                      ; preds = %66
   %71 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %69, i32 0, i32 55
   %72 = load i32, i32 addrspace(1)* %71, align 8
-  %NullCheck38 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %68, null
-  br i1 %NullCheck38, label %73, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %68, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %68, i32 0, i32 22
   store i32 %72, i32 addrspace(1)* %74
   %75 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %76 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck40 = icmp ne %System.Globalization.CultureData addrspace(1)* %76, null
-  br i1 %NullCheck40, label %77, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Globalization.CultureData addrspace(1)* %76, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %76, i32 0, i32 57
   %79 = load i32, i32 addrspace(1)* %78, align 8
-  %NullCheck42 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %75, null
-  br i1 %NullCheck42, label %80, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %75, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %80
 
 ; <label>:80                                      ; preds = %77
   %81 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %75, i32 0, i32 24
   store i32 %79, i32 addrspace(1)* %81
   %82 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %83 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck44 = icmp ne %System.Globalization.CultureData addrspace(1)* %83, null
-  br i1 %NullCheck44, label %84, label %ThrowNullRef43
+  %NullCheck43 = icmp eq %System.Globalization.CultureData addrspace(1)* %83, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %84
 
 ; <label>:84                                      ; preds = %80
   %85 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %83, i32 0, i32 56
   %86 = load i32, i32 addrspace(1)* %85, align 8
-  %NullCheck46 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %82, null
-  br i1 %NullCheck46, label %87, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %82, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %82, i32 0, i32 23
@@ -13540,8 +15320,8 @@ entry:
 
 ; <label>:89                                      ; preds = %entry
   %90 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck100 = icmp ne %System.Globalization.CultureData addrspace(1)* %90, null
-  br i1 %NullCheck100, label %91, label %ThrowNullRef99
+  %NullCheck99 = icmp eq %System.Globalization.CultureData addrspace(1)* %90, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %91
 
 ; <label>:91                                      ; preds = %89
   %92 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %90, i32 0, i32 2
@@ -13559,8 +15339,8 @@ entry:
   %102 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %103 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %104 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %103)
-  %NullCheck48 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %102, null
-  br i1 %NullCheck48, label %105, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %102, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %105
 
 ; <label>:105                                     ; preds = %101
   %106 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %102, i32 0, i32 1
@@ -13568,8 +15348,8 @@ entry:
   %107 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %108 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %109 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %108)
-  %NullCheck50 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %107, null
-  br i1 %NullCheck50, label %110, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %107, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %110
 
 ; <label>:110                                     ; preds = %105
   %111 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %107, i32 0, i32 2
@@ -13577,8 +15357,8 @@ entry:
   %112 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %113 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %114 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %113)
-  %NullCheck52 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %112, null
-  br i1 %NullCheck52, label %115, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %112, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %115
 
 ; <label>:115                                     ; preds = %110
   %116 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %112, i32 0, i32 27
@@ -13586,8 +15366,8 @@ entry:
   %117 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %118 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %119 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %118)
-  %NullCheck54 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %117, null
-  br i1 %NullCheck54, label %120, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %117, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %120
 
 ; <label>:120                                     ; preds = %115
   %121 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %117, i32 0, i32 26
@@ -13595,8 +15375,8 @@ entry:
   %122 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %123 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %124 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %123)
-  %NullCheck56 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %122, null
-  br i1 %NullCheck56, label %125, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %122, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %125
 
 ; <label>:125                                     ; preds = %120
   %126 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %122, i32 0, i32 17
@@ -13604,8 +15384,8 @@ entry:
   %127 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %128 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %129 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %128)
-  %NullCheck58 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %127, null
-  br i1 %NullCheck58, label %130, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %127, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %130
 
 ; <label>:130                                     ; preds = %125
   %131 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %127, i32 0, i32 18
@@ -13613,8 +15393,8 @@ entry:
   %132 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %133 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %134 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %133)
-  %NullCheck60 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %132, null
-  br i1 %NullCheck60, label %135, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %132, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %135
 
 ; <label>:135                                     ; preds = %130
   %136 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %132, i32 0, i32 14
@@ -13622,8 +15402,8 @@ entry:
   %137 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %138 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %139 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %138)
-  %NullCheck62 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %137, null
-  br i1 %NullCheck62, label %140, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %137, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %140
 
 ; <label>:140                                     ; preds = %135
   %141 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %137, i32 0, i32 13
@@ -13631,71 +15411,71 @@ entry:
   %142 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %143 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %144 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %143)
-  %NullCheck64 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %142, null
-  br i1 %NullCheck64, label %145, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %142, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %145
 
 ; <label>:145                                     ; preds = %140
   %146 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %142, i32 0, i32 12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %146, %System.String addrspace(1)* %144)
   %147 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %148 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck66 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %148, null
-  br i1 %NullCheck66, label %149, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %148, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %149
 
 ; <label>:149                                     ; preds = %145
   %150 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %148, i32 0, i32 21
   %151 = load i32, i32 addrspace(1)* %150, align 8
-  %NullCheck68 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %147, null
-  br i1 %NullCheck68, label %152, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %147, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %152
 
 ; <label>:152                                     ; preds = %149
   %153 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %147, i32 0, i32 28
   store i32 %151, i32 addrspace(1)* %153
   %154 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %155 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck70 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %155, null
-  br i1 %NullCheck70, label %156, label %ThrowNullRef69
+  %NullCheck69 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %155, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %156
 
 ; <label>:156                                     ; preds = %152
   %157 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %155, i32 0, i32 6
   %158 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %157, align 8
-  %NullCheck72 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %154, null
-  br i1 %NullCheck72, label %159, label %ThrowNullRef71
+  %NullCheck71 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %154, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %159
 
 ; <label>:159                                     ; preds = %156
   %160 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %154, i32 0, i32 15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %160, %System.String addrspace(1)* %158)
   %161 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %162 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck74 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %162, null
-  br i1 %NullCheck74, label %163, label %ThrowNullRef73
+  %NullCheck73 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %162, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %163
 
 ; <label>:163                                     ; preds = %159
   %164 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %162, i32 0, i32 1
   %165 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %164, align 8
-  %NullCheck76 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %161, null
-  br i1 %NullCheck76, label %166, label %ThrowNullRef75
+  %NullCheck75 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %161, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %166
 
 ; <label>:166                                     ; preds = %163
   %167 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %161, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %167, %"System.Int32[]" addrspace(1)* %165)
   %168 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %169 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck78 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %169, null
-  br i1 %NullCheck78, label %170, label %ThrowNullRef77
+  %NullCheck77 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %169, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %170
 
 ; <label>:170                                     ; preds = %166
   %171 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %169, i32 0, i32 7
   %172 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %171, align 8
-  %NullCheck80 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %168, null
-  br i1 %NullCheck80, label %173, label %ThrowNullRef79
+  %NullCheck79 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %168, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %173
 
 ; <label>:173                                     ; preds = %170
   %174 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %168, i32 0, i32 16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %174, %System.String addrspace(1)* %172)
   %175 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck82 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %175, null
-  br i1 %NullCheck82, label %176, label %ThrowNullRef81
+  %NullCheck81 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %175, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %176
 
 ; <label>:176                                     ; preds = %173
   %177 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %175, i32 0, i32 4
@@ -13705,14 +15485,14 @@ entry:
 
 ; <label>:180                                     ; preds = %176
   %181 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck84 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %181, null
-  br i1 %NullCheck84, label %182, label %ThrowNullRef83
+  %NullCheck83 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %181, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %182
 
 ; <label>:182                                     ; preds = %180
   %183 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %181, i32 0, i32 4
   %184 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %183, align 8
-  %NullCheck86 = icmp ne %System.String addrspace(1)* %184, null
-  br i1 %NullCheck86, label %185, label %ThrowNullRef85
+  %NullCheck85 = icmp eq %System.String addrspace(1)* %184, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %185
 
 ; <label>:185                                     ; preds = %182
   %186 = getelementptr inbounds %System.String, %System.String addrspace(1)* %184, i32 0, i32 1
@@ -13723,8 +15503,8 @@ entry:
 ; <label>:189                                     ; preds = %176, %185
   %190 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck98 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %190, null
-  br i1 %NullCheck98, label %192, label %ThrowNullRef97
+  %NullCheck97 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %190, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %192
 
 ; <label>:192                                     ; preds = %189
   %193 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %190, i32 0, i32 4
@@ -13733,8 +15513,8 @@ entry:
 
 ; <label>:194                                     ; preds = %185, %192
   %195 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck88 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %195, null
-  br i1 %NullCheck88, label %196, label %ThrowNullRef87
+  %NullCheck87 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %195, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %196
 
 ; <label>:196                                     ; preds = %194
   %197 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %195, i32 0, i32 9
@@ -13744,14 +15524,14 @@ entry:
 
 ; <label>:200                                     ; preds = %196
   %201 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck90 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %201, null
-  br i1 %NullCheck90, label %202, label %ThrowNullRef89
+  %NullCheck89 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %201, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %202
 
 ; <label>:202                                     ; preds = %200
   %203 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %201, i32 0, i32 9
   %204 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %203, align 8
-  %NullCheck92 = icmp ne %System.String addrspace(1)* %204, null
-  br i1 %NullCheck92, label %205, label %ThrowNullRef91
+  %NullCheck91 = icmp eq %System.String addrspace(1)* %204, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %205
 
 ; <label>:205                                     ; preds = %202
   %206 = getelementptr inbounds %System.String, %System.String addrspace(1)* %204, i32 0, i32 1
@@ -13762,14 +15542,14 @@ entry:
 ; <label>:209                                     ; preds = %196, %205
   %210 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %211 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck94 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %211, null
-  br i1 %NullCheck94, label %212, label %ThrowNullRef93
+  %NullCheck93 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %211, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %212
 
 ; <label>:212                                     ; preds = %209
   %213 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %211, i32 0, i32 6
   %214 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %213, align 8
-  %NullCheck96 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %210, null
-  br i1 %NullCheck96, label %215, label %ThrowNullRef95
+  %NullCheck95 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %210, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %215
 
 ; <label>:215                                     ; preds = %212
   %216 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %210, i32 0, i32 9
@@ -13783,203 +15563,203 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %17
+ThrowNullRef8:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %21
+ThrowNullRef10:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %24
+ThrowNullRef12:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %28
+ThrowNullRef14:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %31
+ThrowNullRef16:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %35
+ThrowNullRef18:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %38
+ThrowNullRef20:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %42
+ThrowNullRef22:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %45
+ThrowNullRef24:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %49
+ThrowNullRef26:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %52
+ThrowNullRef28:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %56
+ThrowNullRef30:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %59
+ThrowNullRef32:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %63
+ThrowNullRef34:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %66
+ThrowNullRef36:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %70
+ThrowNullRef38:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %73
+ThrowNullRef40:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %77
+ThrowNullRef42:                                   ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %80
+ThrowNullRef44:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %84
+ThrowNullRef46:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %101
+ThrowNullRef48:                                   ; preds = %101
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %105
+ThrowNullRef50:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %110
+ThrowNullRef52:                                   ; preds = %110
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %115
+ThrowNullRef54:                                   ; preds = %115
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %120
+ThrowNullRef56:                                   ; preds = %120
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %125
+ThrowNullRef58:                                   ; preds = %125
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %130
+ThrowNullRef60:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %135
+ThrowNullRef62:                                   ; preds = %135
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %140
+ThrowNullRef64:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %145
+ThrowNullRef66:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %149
+ThrowNullRef68:                                   ; preds = %149
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %152
+ThrowNullRef70:                                   ; preds = %152
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %156
+ThrowNullRef72:                                   ; preds = %156
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %159
+ThrowNullRef74:                                   ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %163
+ThrowNullRef76:                                   ; preds = %163
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %166
+ThrowNullRef78:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %170
+ThrowNullRef80:                                   ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %173
+ThrowNullRef82:                                   ; preds = %173
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %180
+ThrowNullRef84:                                   ; preds = %180
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %182
+ThrowNullRef86:                                   ; preds = %182
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %194
+ThrowNullRef88:                                   ; preds = %194
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %200
+ThrowNullRef90:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %202
+ThrowNullRef92:                                   ; preds = %202
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %209
+ThrowNullRef94:                                   ; preds = %209
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %212
+ThrowNullRef96:                                   ; preds = %212
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %189
+ThrowNullRef98:                                   ; preds = %189
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %89
+ThrowNullRef100:                                  ; preds = %89
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14007,8 +15787,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 21
@@ -14021,8 +15801,8 @@ entry:
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 16)
   %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 21
@@ -14031,8 +15811,8 @@ entry:
 
 ; <label>:12                                      ; preds = %1, %10
   %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 21
@@ -14043,11 +15823,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %12
+ThrowNullRef4:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14063,8 +15843,8 @@ entry:
   store i32 %param1, i32* %arg1
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %1 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
@@ -14131,8 +15911,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 33
@@ -14145,8 +15925,8 @@ entry:
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 24)
   %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 33
@@ -14155,8 +15935,8 @@ entry:
 
 ; <label>:12                                      ; preds = %1, %10
   %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 33
@@ -14167,11 +15947,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %12
+ThrowNullRef4:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14184,8 +15964,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 53
@@ -14197,8 +15977,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 116)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 53
@@ -14207,8 +15987,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 53
@@ -14219,11 +15999,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14252,8 +16032,8 @@ entry:
 
 ; <label>:7                                       ; preds = %entry, %4
   %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %7
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 2
@@ -14277,8 +16057,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 54
@@ -14290,8 +16070,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 117)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
@@ -14300,8 +16080,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 54
@@ -14312,11 +16092,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14329,8 +16109,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 27
@@ -14342,8 +16122,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 118)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 27
@@ -14352,8 +16132,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 27
@@ -14364,11 +16144,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14381,8 +16161,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 28
@@ -14394,8 +16174,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 119)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 28
@@ -14404,8 +16184,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 28
@@ -14416,11 +16196,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14433,8 +16213,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 26
@@ -14446,8 +16226,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 107)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 26
@@ -14456,8 +16236,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 26
@@ -14468,11 +16248,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14485,8 +16265,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 25
@@ -14498,8 +16278,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 106)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 25
@@ -14508,8 +16288,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 25
@@ -14520,11 +16300,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14537,8 +16317,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 24
@@ -14550,8 +16330,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 105)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 24
@@ -14560,8 +16340,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 24
@@ -14572,11 +16352,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14601,8 +16381,8 @@ entry:
   %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %3)
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %2
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -14613,15 +16393,15 @@ entry:
 
 ; <label>:8                                       ; preds = %62
   %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 9
   %12 = load i32, i32 addrspace(1)* %11, align 8
   %13 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.IO.StreamWriter addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %13, i32 0, i32 10
@@ -14636,15 +16416,15 @@ entry:
 
 ; <label>:20                                      ; preds = %14, %18
   %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
   %24 = load i32, i32 addrspace(1)* %23, align 8
   %25 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %25, null
-  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.StreamWriter addrspace(1)* %25, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %25, i32 0, i32 9
@@ -14665,36 +16445,36 @@ entry:
   %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %37 = load i32, i32* %loc1
   %38 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.StreamWriter addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %35
   %40 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %38, i32 0, i32 7
   %41 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %40, align 8
   %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
-  br i1 %NullCheck14, label %43, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %39
   %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 9
   %45 = load i32, i32 addrspace(1)* %44, align 8
   %46 = load i32, i32* %loc2
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %36, null
-  br i1 %NullCheck16, label %47, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %36, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %47
 
 ; <label>:47                                      ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %36, i32 %37, %"System.Char[]" addrspace(1)* %41, i32 %45, i32 %46)
   %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
   %51 = load i32, i32 addrspace(1)* %50, align 8
   %52 = load i32, i32* %loc2
   %53 = add i32 %51, %52
-  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
-  br i1 %NullCheck20, label %54, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %54
 
 ; <label>:54                                      ; preds = %49
   %55 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
@@ -14716,8 +16496,8 @@ entry:
 
 ; <label>:65                                      ; preds = %62
   %66 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %66, null
-  br i1 %NullCheck2, label %67, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %66, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %67
 
 ; <label>:67                                      ; preds = %65
   %68 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %66, i32 0, i32 11
@@ -14738,49 +16518,259 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %65
+ThrowNullRef2:                                    ; preds = %65
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %20
+ThrowNullRef8:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %22
+ThrowNullRef10:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %35
+ThrowNullRef12:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %43
+ThrowNullRef16:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %47
+ThrowNullRef18:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method String::CopyTo using LLILCJit
-Failed to read String.CopyTo[loadElemA]
+Successfully read String.CopyTo
+
+define void @String.CopyTo(%System.String addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  %loc1 = alloca i16 addrspace(1)*
+  %loc2 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %1 = icmp ne %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg4
+  %7 = icmp sge i32 %6, 0
+  br i1 %7, label %13, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  unreachable
+
+; <label>:13                                      ; preds = %5
+  %14 = load i32, i32* %arg1
+  %15 = icmp sge i32 %14, 0
+  br i1 %15, label %21, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %18)
+  %20 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %20, %System.String addrspace(1)* %17, %System.String addrspace(1)* %19)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %20) #0
+  unreachable
+
+; <label>:21                                      ; preds = %13
+  %22 = load i32, i32* %arg4
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck, label %ThrowNullRef, label %24
+
+; <label>:24                                      ; preds = %21
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load i32, i32* %arg1
+  %28 = sub i32 %26, %27
+  %29 = icmp sle i32 %22, %28
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34, %System.String addrspace(1)* %31, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %24
+  %36 = load i32, i32* %arg3
+  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %37, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
+
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
+  %40 = load i32, i32 addrspace(1)* %39
+  %41 = zext i32 %40 to i64
+  %42 = trunc i64 %41 to i32
+  %43 = load i32, i32* %arg4
+  %44 = sub i32 %42, %43
+  %45 = icmp sgt i32 %36, %44
+  br i1 %45, label %49, label %46
+
+; <label>:46                                      ; preds = %38
+  %47 = load i32, i32* %arg3
+  %48 = icmp sge i32 %47, 0
+  br i1 %48, label %54, label %49
+
+; <label>:49                                      ; preds = %38, %46
+  %50 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %52 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %51)
+  %53 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53, %System.String addrspace(1)* %50, %System.String addrspace(1)* %52)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53) #0
+  unreachable
+
+; <label>:54                                      ; preds = %46
+  %55 = load i32, i32* %arg4
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %97, label %57
+
+; <label>:57                                      ; preds = %54
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %59
+
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 2
+  %61 = bitcast [0 x i16] addrspace(1)* %60 to i16 addrspace(1)*
+  store i16 addrspace(1)* %61, i16 addrspace(1)** %loc0
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  store %"System.Char[]" addrspace(1)* %62, %"System.Char[]" addrspace(1)** %loc2
+  %63 = icmp eq %"System.Char[]" addrspace(1)* %62, null
+  br i1 %63, label %72, label %64
+
+; <label>:64                                      ; preds = %59
+  %65 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc2
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %65, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %66
+
+; <label>:66                                      ; preds = %64
+  %67 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %65, i32 0, i32 1
+  %68 = load i32, i32 addrspace(1)* %67
+  %69 = zext i32 %68 to i64
+  %70 = trunc i64 %69 to i32
+  %71 = icmp ne i32 %70, 0
+  br i1 %71, label %73, label %72
+
+; <label>:72                                      ; preds = %59, %66
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  br label %81
+
+; <label>:73                                      ; preds = %66
+  %74 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc2
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %74, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %75
+
+; <label>:75                                      ; preds = %73
+  %76 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %74, i32 0, i32 1
+  %77 = load i32, i32 addrspace(1)* %76
+  %78 = zext i32 %77 to i64
+  %BoundsCheck = icmp uge i64 0, %78
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %79
+
+; <label>:79                                      ; preds = %75
+  %80 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %74, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %80, i16 addrspace(1)** %loc1
+  br label %81
+
+; <label>:81                                      ; preds = %72, %79
+  %82 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %83 = ptrtoint i16 addrspace(1)* %82 to i64
+  %84 = load i32, i32* %arg3
+  %85 = sext i32 %84 to i64
+  %86 = mul i64 %85, 2
+  %87 = add i64 %83, %86
+  %88 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %89 = ptrtoint i16 addrspace(1)* %88 to i64
+  %90 = load i32, i32* %arg1
+  %91 = sext i32 %90 to i64
+  %92 = mul i64 %91, 2
+  %93 = add i64 %89, %92
+  %94 = load i32, i32* %arg4
+  %95 = inttoptr i64 %87 to i16*
+  %96 = inttoptr i64 %93 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %95, i16* %96, i32 %94)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  br label %97
+
+; <label>:97                                      ; preds = %54, %81
+  ret void
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
 Successfully read ConsoleEncoding.GetPreamble
 
@@ -14817,7 +16807,365 @@ entry:
 }
 
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[loadElemA]
+Successfully read EncoderNLS.GetBytes
+
+define i32 @EncoderNLS.GetBytes(%System.Text.EncoderNLS addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3, %"System.Byte[]" addrspace(1)* %param4, i32 %param5, i8 %param6) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %arg4 = alloca %"System.Byte[]" addrspace(1)*
+  %arg5 = alloca i32
+  %arg6 = alloca i8
+  %loc0 = alloca i32
+  %loc1 = alloca i16 addrspace(1)*
+  %loc2 = alloca i8 addrspace(1)*
+  %loc3 = alloca i32
+  %loc4 = alloca %"System.Char[]" addrspace(1)*
+  %loc5 = alloca %"System.Byte[]" addrspace(1)*
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  store %"System.Byte[]" addrspace(1)* %param4, %"System.Byte[]" addrspace(1)** %arg4
+  store i32 %param5, i32* %arg5
+  store i8 %param6, i8* %arg6
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %1 = icmp eq %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %17, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %7 = icmp eq %"System.Char[]" addrspace(1)* %6, null
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %12
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %12
+
+; <label>:12                                      ; preds = %8, %10
+  %13 = phi %System.String addrspace(1)* [ %9, %8 ], [ %11, %10 ]
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %14)
+  %16 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16, %System.String addrspace(1)* %13, %System.String addrspace(1)* %15)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16) #0
+  unreachable
+
+; <label>:17                                      ; preds = %2
+  %18 = load i32, i32* %arg2
+  %19 = icmp slt i32 %18, 0
+  br i1 %19, label %23, label %20
+
+; <label>:20                                      ; preds = %17
+  %21 = load i32, i32* %arg3
+  %22 = icmp sge i32 %21, 0
+  br i1 %22, label %35, label %23
+
+; <label>:23                                      ; preds = %17, %20
+  %24 = load i32, i32* %arg2
+  %25 = icmp slt i32 %24, 0
+  br i1 %25, label %28, label %26
+
+; <label>:26                                      ; preds = %23
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %30
+
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %30
+
+; <label>:30                                      ; preds = %26, %28
+  %31 = phi %System.String addrspace(1)* [ %27, %26 ], [ %29, %28 ]
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34, %System.String addrspace(1)* %31, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %20
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck, label %ThrowNullRef, label %37
+
+; <label>:37                                      ; preds = %35
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = load i32, i32* %arg2
+  %43 = sub i32 %41, %42
+  %44 = load i32, i32* %arg3
+  %45 = icmp sge i32 %43, %44
+  br i1 %45, label %51, label %46
+
+; <label>:46                                      ; preds = %37
+  %47 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %48 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %49 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %48)
+  %50 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %50, %System.String addrspace(1)* %47, %System.String addrspace(1)* %49)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %50) #0
+  unreachable
+
+; <label>:51                                      ; preds = %37
+  %52 = load i32, i32* %arg5
+  %53 = icmp slt i32 %52, 0
+  br i1 %53, label %63, label %54
+
+; <label>:54                                      ; preds = %51
+  %55 = load i32, i32* %arg5
+  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck1 = icmp eq %"System.Byte[]" addrspace(1)* %56, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %57
+
+; <label>:57                                      ; preds = %54
+  %58 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = zext i32 %59 to i64
+  %61 = trunc i64 %60 to i32
+  %62 = icmp sle i32 %55, %61
+  br i1 %62, label %68, label %63
+
+; <label>:63                                      ; preds = %51, %57
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %66 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %65)
+  %67 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %67, %System.String addrspace(1)* %64, %System.String addrspace(1)* %66)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %67) #0
+  unreachable
+
+; <label>:68                                      ; preds = %57
+  %69 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %69, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %69, i32 0, i32 1
+  %72 = load i32, i32 addrspace(1)* %71
+  %73 = zext i32 %72 to i64
+  %74 = trunc i64 %73 to i32
+  %75 = icmp ne i32 %74, 0
+  br i1 %75, label %78, label %76
+
+; <label>:76                                      ; preds = %70
+  %77 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1)
+  store %"System.Char[]" addrspace(1)* %77, %"System.Char[]" addrspace(1)** %arg1
+  br label %78
+
+; <label>:78                                      ; preds = %70, %76
+  %79 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck5 = icmp eq %"System.Byte[]" addrspace(1)* %79, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %80
+
+; <label>:80                                      ; preds = %78
+  %81 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %79, i32 0, i32 1
+  %82 = load i32, i32 addrspace(1)* %81
+  %83 = zext i32 %82 to i64
+  %84 = trunc i64 %83 to i32
+  %85 = load i32, i32* %arg5
+  %86 = sub i32 %84, %85
+  store i32 %86, i32* %loc0
+  %87 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck7 = icmp eq %"System.Byte[]" addrspace(1)* %87, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %88
+
+; <label>:88                                      ; preds = %80
+  %89 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %87, i32 0, i32 1
+  %90 = load i32, i32 addrspace(1)* %89
+  %91 = zext i32 %90 to i64
+  %92 = trunc i64 %91 to i32
+  %93 = icmp ne i32 %92, 0
+  br i1 %93, label %96, label %94
+
+; <label>:94                                      ; preds = %88
+  %95 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1)
+  store %"System.Byte[]" addrspace(1)* %95, %"System.Byte[]" addrspace(1)** %arg4
+  br label %96
+
+; <label>:96                                      ; preds = %88, %94
+  %97 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  store %"System.Char[]" addrspace(1)* %97, %"System.Char[]" addrspace(1)** %loc4
+  %98 = icmp eq %"System.Char[]" addrspace(1)* %97, null
+  br i1 %98, label %107, label %99
+
+; <label>:99                                      ; preds = %96
+  %100 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc4
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %100, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %101
+
+; <label>:101                                     ; preds = %99
+  %102 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %100, i32 0, i32 1
+  %103 = load i32, i32 addrspace(1)* %102
+  %104 = zext i32 %103 to i64
+  %105 = trunc i64 %104 to i32
+  %106 = icmp ne i32 %105, 0
+  br i1 %106, label %108, label %107
+
+; <label>:107                                     ; preds = %96, %101
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  br label %116
+
+; <label>:108                                     ; preds = %101
+  %109 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc4
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %109, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %110
+
+; <label>:110                                     ; preds = %108
+  %111 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %109, i32 0, i32 1
+  %112 = load i32, i32 addrspace(1)* %111
+  %113 = zext i32 %112 to i64
+  %BoundsCheck = icmp uge i64 0, %113
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %114
+
+; <label>:114                                     ; preds = %110
+  %115 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %109, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %115, i16 addrspace(1)** %loc1
+  br label %116
+
+; <label>:116                                     ; preds = %107, %114
+  %117 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  store %"System.Byte[]" addrspace(1)* %117, %"System.Byte[]" addrspace(1)** %loc5
+  %118 = icmp eq %"System.Byte[]" addrspace(1)* %117, null
+  br i1 %118, label %127, label %119
+
+; <label>:119                                     ; preds = %116
+  %120 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc5
+  %NullCheck13 = icmp eq %"System.Byte[]" addrspace(1)* %120, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %121
+
+; <label>:121                                     ; preds = %119
+  %122 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %120, i32 0, i32 1
+  %123 = load i32, i32 addrspace(1)* %122
+  %124 = zext i32 %123 to i64
+  %125 = trunc i64 %124 to i32
+  %126 = icmp ne i32 %125, 0
+  br i1 %126, label %128, label %127
+
+; <label>:127                                     ; preds = %116, %121
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc2
+  br label %136
+
+; <label>:128                                     ; preds = %121
+  %129 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc5
+  %NullCheck15 = icmp eq %"System.Byte[]" addrspace(1)* %129, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %130
+
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %129, i32 0, i32 1
+  %132 = load i32, i32 addrspace(1)* %131
+  %133 = zext i32 %132 to i64
+  %BoundsCheck17 = icmp uge i64 0, %133
+  br i1 %BoundsCheck17, label %ThrowIndexOutOfRange18, label %134
+
+; <label>:134                                     ; preds = %130
+  %135 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %129, i32 0, i32 3, i32 0
+  store i8 addrspace(1)* %135, i8 addrspace(1)** %loc2
+  br label %136
+
+; <label>:136                                     ; preds = %127, %134
+  %137 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %138 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %139 = ptrtoint i16 addrspace(1)* %138 to i64
+  %140 = load i32, i32* %arg2
+  %141 = sext i32 %140 to i64
+  %142 = mul i64 %141, 2
+  %143 = add i64 %139, %142
+  %144 = load i32, i32* %arg3
+  %145 = load i8 addrspace(1)*, i8 addrspace(1)** %loc2
+  %146 = ptrtoint i8 addrspace(1)* %145 to i64
+  %147 = load i32, i32* %arg5
+  %148 = sext i32 %147 to i64
+  %149 = add i64 %146, %148
+  %150 = load i32, i32* %loc0
+  %151 = load i8, i8* %arg6
+  %152 = zext i8 %151 to i32
+  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i64 addrspace(1)*
+  %NullCheck19 = icmp eq i64 addrspace(1)* %153, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %154
+
+; <label>:154                                     ; preds = %136
+  %155 = load i64, i64 addrspace(1)* %153
+  %156 = add i64 %155, 72
+  %157 = inttoptr i64 %156 to i64*
+  %158 = load i64, i64* %157
+  %159 = add i64 %158, 0
+  %160 = inttoptr i64 %159 to i64*
+  %161 = load i64, i64* %160
+  %162 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to %System.Text.Encoder addrspace(1)*
+  %163 = inttoptr i64 %143 to i16*
+  %164 = inttoptr i64 %149 to i8*
+  %165 = trunc i32 %152 to i8
+  %166 = inttoptr i64 %161 to i32 (%System.Text.Encoder addrspace(1)*, i16*, i32, i8*, i32, i8)*
+  %167 = call i32 %166(%System.Text.Encoder addrspace(1)* %162, i16* %163, i32 %144, i8* %164, i32 %150, i8 %165)
+  store i32 %167, i32* %loc3
+  br label %168
+
+; <label>:168                                     ; preds = %154
+  %169 = load i32, i32* %loc3
+  ret i32 %169
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %110
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %119
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange18:                           ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
 Successfully read EncoderNLS.GetBytes
 
@@ -14906,22 +17254,22 @@ entry:
   %40 = load i8, i8* %arg5
   %41 = zext i8 %40 to i32
   %42 = trunc i32 %41 to i8
-  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %39, null
-  br i1 %NullCheck, label %43, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderNLS addrspace(1)* %39, null
+  br i1 %NullCheck, label %ThrowNullRef, label %43
 
 ; <label>:43                                      ; preds = %38
   %44 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
   store i8 %42, i8 addrspace(1)* %44
   %45 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %45, null
-  br i1 %NullCheck2, label %46, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.EncoderNLS addrspace(1)* %45, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %46
 
 ; <label>:46                                      ; preds = %43
   %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %45, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %47
   %48 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.EncoderNLS addrspace(1)* %48, null
-  br i1 %NullCheck4, label %49, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.EncoderNLS addrspace(1)* %48, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %49
 
 ; <label>:49                                      ; preds = %46
   %50 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %48, i32 0, i32 3
@@ -14932,8 +17280,8 @@ entry:
   %55 = load i32, i32* %arg4
   %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck6, label %58, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
   %59 = load i64, i64 addrspace(1)* %57
@@ -14951,15 +17299,15 @@ ThrowNullRef:                                     ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %43
+ThrowNullRef2:                                    ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %46
+ThrowNullRef4:                                    ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %49
+ThrowNullRef6:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14987,8 +17335,8 @@ entry:
   %4 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0 to %System.IO.ConsoleStream addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*)(%System.IO.ConsoleStream addrspace(1)* %4, %"System.Byte[]" addrspace(1)* %1, i32 %2, i32 %3)
   %5 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
@@ -15073,8 +17421,8 @@ entry:
 
 ; <label>:22                                      ; preds = %8
   %23 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %23, null
-  br i1 %NullCheck, label %24, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Byte[]" addrspace(1)* %23, null
+  br i1 %NullCheck, label %ThrowNullRef, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
@@ -15096,8 +17444,8 @@ entry:
 
 ; <label>:36                                      ; preds = %24
   %37 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %37, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.ConsoleStream addrspace(1)* %37, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %37, i32 0, i32 4
@@ -15118,13 +17466,138 @@ ThrowNullRef:                                     ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %36
+ThrowNullRef2:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
-Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
+Successfully read WindowsConsoleStream.WriteFileNative
+
+define i32 @WindowsConsoleStream.WriteFileNative(i64 %param0, %"System.Byte[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i64
+  %arg1 = alloca %"System.Byte[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i8 addrspace(1)*
+  %loc2 = alloca %"System.Byte[]" addrspace(1)*
+  %loc3 = alloca i32
+  store i64 %param0, i64* %arg0
+  store %"System.Byte[]" addrspace(1)* %param1, %"System.Byte[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Byte[]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = zext i32 %3 to i64
+  %5 = icmp ne i64 %4, 0
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %1
+  ret i32 0
+
+; <label>:7                                       ; preds = %1
+  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  store %"System.Byte[]" addrspace(1)* %8, %"System.Byte[]" addrspace(1)** %loc2
+  %9 = icmp eq %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %9, label %18, label %10
+
+; <label>:10                                      ; preds = %7
+  %11 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc2
+  %NullCheck1 = icmp eq %"System.Byte[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %11, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp ne i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %7, %12
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc1
+  br label %27
+
+; <label>:19                                      ; preds = %12
+  %20 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc2
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %20, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %BoundsCheck = icmp uge i64 0, %24
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %25
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %20, i32 0, i32 3, i32 0
+  store i8 addrspace(1)* %26, i8 addrspace(1)** %loc1
+  br label %27
+
+; <label>:27                                      ; preds = %18, %25
+  %28 = load i64, i64* %arg0
+  %29 = load i8 addrspace(1)*, i8 addrspace(1)** %loc1
+  %30 = ptrtoint i8 addrspace(1)* %29 to i64
+  %31 = load i32, i32* %arg2
+  %32 = sext i32 %31 to i64
+  %33 = add i64 %30, %32
+  %34 = load i32, i32* %arg3
+  %35 = addrspacecast i32* %loc3 to i32 addrspace(1)*
+  %36 = inttoptr i64 %33 to i8*
+  %37 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i8*, i32, i32 addrspace(1)*, i64)*)(i64 %28, i8* %36, i32 %34, i32 addrspace(1)* %35, i64 0)
+  %38 = icmp ugt i32 %37, 0
+  %39 = sext i1 %38 to i32
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc1
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %42, label %41
+
+; <label>:41                                      ; preds = %27
+  ret i32 0
+
+; <label>:42                                      ; preds = %27
+  %43 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  store i32 %43, i32* %loc0
+  %44 = load i32, i32* %loc0
+  %45 = icmp eq i32 %44, 232
+  br i1 %45, label %49, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = load i32, i32* %loc0
+  %48 = icmp ne i32 %47, 109
+  br i1 %48, label %50, label %49
+
+; <label>:49                                      ; preds = %42, %46
+  ret i32 0
+
+; <label>:50                                      ; preds = %46
+  %51 = load i32, i32* %loc0
+  ret i32 %51
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
 Successfully read WindowsConsoleStream.Flush
 
@@ -15133,8 +17606,8 @@ entry:
   %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
   store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
@@ -15169,8 +17642,8 @@ entry:
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
   %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load i64, i64 addrspace(1)* %1
@@ -15209,15 +17682,15 @@ entry:
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.TextWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
   %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %3, align 8
   %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
   %7 = load i64, i64 addrspace(1)* %5
@@ -15235,7 +17708,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -15264,8 +17737,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %4)
   store i32 0, i32* %loc0
   %5 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Char[]" addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
@@ -15277,15 +17750,15 @@ entry:
 
 ; <label>:11                                      ; preds = %69
   %12 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %12, i32 0, i32 9
   %15 = load i32, i32 addrspace(1)* %14, align 8
   %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.IO.StreamWriter addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %16, i32 0, i32 10
@@ -15300,15 +17773,15 @@ entry:
 
 ; <label>:23                                      ; preds = %17, %21
   %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %24, null
-  br i1 %NullCheck8, label %25, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %24, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 10
   %27 = load i32, i32 addrspace(1)* %26, align 8
   %28 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %28, null
-  br i1 %NullCheck10, label %29, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.StreamWriter addrspace(1)* %28, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %28, i32 0, i32 9
@@ -15330,15 +17803,15 @@ entry:
   %40 = load i32, i32* %loc0
   %41 = mul i32 %40, 2
   %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
-  br i1 %NullCheck12, label %43, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %43
 
 ; <label>:43                                      ; preds = %38
   %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 7
   %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %44, align 8
   %46 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %46, null
-  br i1 %NullCheck14, label %47, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.IO.StreamWriter addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %47
 
 ; <label>:47                                      ; preds = %43
   %48 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %46, i32 0, i32 9
@@ -15350,16 +17823,16 @@ entry:
   %54 = bitcast %"System.Char[]" addrspace(1)* %45 to %System.Array addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %53, i32 %41, %System.Array addrspace(1)* %54, i32 %50, i32 %52)
   %55 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
-  br i1 %NullCheck16, label %56, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %56
 
 ; <label>:56                                      ; preds = %47
   %57 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
   %58 = load i32, i32 addrspace(1)* %57, align 8
   %59 = load i32, i32* %loc2
   %60 = add i32 %58, %59
-  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
-  br i1 %NullCheck18, label %61, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %61
 
 ; <label>:61                                      ; preds = %56
   %62 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
@@ -15381,8 +17854,8 @@ entry:
 
 ; <label>:72                                      ; preds = %69
   %73 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %73, null
-  br i1 %NullCheck2, label %74, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %73, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %74
 
 ; <label>:74                                      ; preds = %72
   %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %73, i32 0, i32 11
@@ -15403,39 +17876,39 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %72
+ThrowNullRef2:                                    ; preds = %72
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %23
+ThrowNullRef8:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef10:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %43
+ThrowNullRef14:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %47
+ThrowNullRef16:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %56
+ThrowNullRef18:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPAvg2.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPAvg2.error.txt
@@ -25,8 +25,8 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
@@ -40,8 +40,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
   %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
@@ -75,7 +75,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -90,8 +90,8 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %NullCheck = icmp ne i8 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = load i8, i8 addrspace(1)* %0, align 8
@@ -125,8 +125,8 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
@@ -159,8 +159,8 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -184,8 +184,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
   store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
@@ -195,8 +195,8 @@ entry:
 ; <label>:4                                       ; preds = %1
   %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
   %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
@@ -206,8 +206,8 @@ entry:
   %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
@@ -221,14 +221,14 @@ entry:
 
 ; <label>:17                                      ; preds = %14
   %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
   %21 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
@@ -238,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -249,8 +249,8 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
@@ -261,27 +261,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %30
+ThrowNullRef10:                                   ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -301,7 +301,89 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
-Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
+Successfully read AppDomainSetup.GetUnsecureApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.GetUnsecureApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %NullCheck = icmp eq %"System.String[]" addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %BoundsCheck = icmp uge i64 0, %5
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %6
+
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 3, i32 0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
+  ret %System.String addrspace(1)* %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_Value using LLILCJit
+Successfully read AppDomainSetup.get_Value
+
+define %"System.String[]" addrspace(1)* @AppDomainSetup.get_Value(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.String[]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 18)
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.String[]" addrspace(1)* addrspace(1)*, %"System.String[]" addrspace(1)*)*)(%"System.String[]" addrspace(1)* addrspace(1)* %9, %"System.String[]" addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %11, i32 0, i32 1
+  %14 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %13, align 8
+  ret %"System.String[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -319,8 +401,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -368,16 +450,16 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
   %5 = load i32, i32 addrspace(1)* %4
   %6 = sub i32 %5, 1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -389,7 +471,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -421,8 +503,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
@@ -456,8 +538,8 @@ entry:
 ; <label>:27                                      ; preds = %19
   %28 = load i32, i32* %arg1
   %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
-  br i1 %NullCheck2, label %30, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %29, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %30
 
 ; <label>:30                                      ; preds = %27
   %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
@@ -493,8 +575,8 @@ entry:
 ; <label>:49                                      ; preds = %46
   %50 = load i32, i32* %arg2
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck4, label %52, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
@@ -517,11 +599,11 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %27
+ThrowNullRef2:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %49
+ThrowNullRef4:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -544,16 +626,16 @@ entry:
   %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %0)
   store %System.String addrspace(1)* %1, %System.String addrspace(1)** %loc0
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 2
   %5 = bitcast [0 x i16] addrspace(1)* %4 to i16 addrspace(1)*
   store i16 addrspace(1)* %5, i16 addrspace(1)** %loc1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %3
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2
@@ -580,7 +662,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -691,15 +773,15 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %NullCheck132 = icmp ne i8* %21, null
-  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+  %NullCheck131 = icmp eq i8* %21, null
+  br i1 %NullCheck131, label %ThrowNullRef132, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = load i8, i8* %21, align 8
   %24 = zext i8 %23 to i32
   %25 = trunc i32 %24 to i8
-  %NullCheck134 = icmp ne i8* %20, null
-  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+  %NullCheck133 = icmp eq i8* %20, null
+  br i1 %NullCheck133, label %ThrowNullRef134, label %26
 
 ; <label>:26                                      ; preds = %22
   store i8 %25, i8* %20, align 8
@@ -709,16 +791,16 @@ entry:
   %28 = load i8*, i8** %arg0
   %29 = load i8*, i8** %arg1
   %30 = bitcast i8* %29 to i16*
-  %NullCheck128 = icmp ne i16* %30, null
-  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+  %NullCheck127 = icmp eq i16* %30, null
+  br i1 %NullCheck127, label %ThrowNullRef128, label %31
 
 ; <label>:31                                      ; preds = %27
   %32 = load i16, i16* %30, align 8
   %33 = sext i16 %32 to i32
   %34 = bitcast i8* %28 to i16*
   %35 = trunc i32 %33 to i16
-  %NullCheck130 = icmp ne i16* %34, null
-  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+  %NullCheck129 = icmp eq i16* %34, null
+  br i1 %NullCheck129, label %ThrowNullRef130, label %36
 
 ; <label>:36                                      ; preds = %31
   store i16 %35, i16* %34, align 8
@@ -728,16 +810,16 @@ entry:
   %38 = load i8*, i8** %arg0
   %39 = load i8*, i8** %arg1
   %40 = bitcast i8* %39 to i16*
-  %NullCheck120 = icmp ne i16* %40, null
-  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+  %NullCheck119 = icmp eq i16* %40, null
+  br i1 %NullCheck119, label %ThrowNullRef120, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i16, i16* %40, align 8
   %43 = sext i16 %42 to i32
   %44 = bitcast i8* %38 to i16*
   %45 = trunc i32 %43 to i16
-  %NullCheck122 = icmp ne i16* %44, null
-  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+  %NullCheck121 = icmp eq i16* %44, null
+  br i1 %NullCheck121, label %ThrowNullRef122, label %46
 
 ; <label>:46                                      ; preds = %41
   store i16 %45, i16* %44, align 8
@@ -745,15 +827,15 @@ entry:
   %48 = getelementptr inbounds i8, i8* %47, i64 2
   %49 = load i8*, i8** %arg1
   %50 = getelementptr inbounds i8, i8* %49, i64 2
-  %NullCheck124 = icmp ne i8* %50, null
-  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+  %NullCheck123 = icmp eq i8* %50, null
+  br i1 %NullCheck123, label %ThrowNullRef124, label %51
 
 ; <label>:51                                      ; preds = %46
   %52 = load i8, i8* %50, align 8
   %53 = zext i8 %52 to i32
   %54 = trunc i32 %53 to i8
-  %NullCheck126 = icmp ne i8* %48, null
-  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+  %NullCheck125 = icmp eq i8* %48, null
+  br i1 %NullCheck125, label %ThrowNullRef126, label %55
 
 ; <label>:55                                      ; preds = %51
   store i8 %54, i8* %48, align 8
@@ -763,14 +845,14 @@ entry:
   %57 = load i8*, i8** %arg0
   %58 = load i8*, i8** %arg1
   %59 = bitcast i8* %58 to i32*
-  %NullCheck116 = icmp ne i32* %59, null
-  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+  %NullCheck115 = icmp eq i32* %59, null
+  br i1 %NullCheck115, label %ThrowNullRef116, label %60
 
 ; <label>:60                                      ; preds = %56
   %61 = load i32, i32* %59, align 8
   %62 = bitcast i8* %57 to i32*
-  %NullCheck118 = icmp ne i32* %62, null
-  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+  %NullCheck117 = icmp eq i32* %62, null
+  br i1 %NullCheck117, label %ThrowNullRef118, label %63
 
 ; <label>:63                                      ; preds = %60
   store i32 %61, i32* %62, align 8
@@ -780,14 +862,14 @@ entry:
   %65 = load i8*, i8** %arg0
   %66 = load i8*, i8** %arg1
   %67 = bitcast i8* %66 to i32*
-  %NullCheck108 = icmp ne i32* %67, null
-  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+  %NullCheck107 = icmp eq i32* %67, null
+  br i1 %NullCheck107, label %ThrowNullRef108, label %68
 
 ; <label>:68                                      ; preds = %64
   %69 = load i32, i32* %67, align 8
   %70 = bitcast i8* %65 to i32*
-  %NullCheck110 = icmp ne i32* %70, null
-  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+  %NullCheck109 = icmp eq i32* %70, null
+  br i1 %NullCheck109, label %ThrowNullRef110, label %71
 
 ; <label>:71                                      ; preds = %68
   store i32 %69, i32* %70, align 8
@@ -795,15 +877,15 @@ entry:
   %73 = getelementptr inbounds i8, i8* %72, i64 4
   %74 = load i8*, i8** %arg1
   %75 = getelementptr inbounds i8, i8* %74, i64 4
-  %NullCheck112 = icmp ne i8* %75, null
-  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+  %NullCheck111 = icmp eq i8* %75, null
+  br i1 %NullCheck111, label %ThrowNullRef112, label %76
 
 ; <label>:76                                      ; preds = %71
   %77 = load i8, i8* %75, align 8
   %78 = zext i8 %77 to i32
   %79 = trunc i32 %78 to i8
-  %NullCheck114 = icmp ne i8* %73, null
-  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+  %NullCheck113 = icmp eq i8* %73, null
+  br i1 %NullCheck113, label %ThrowNullRef114, label %80
 
 ; <label>:80                                      ; preds = %76
   store i8 %79, i8* %73, align 8
@@ -813,14 +895,14 @@ entry:
   %82 = load i8*, i8** %arg0
   %83 = load i8*, i8** %arg1
   %84 = bitcast i8* %83 to i32*
-  %NullCheck100 = icmp ne i32* %84, null
-  br i1 %NullCheck100, label %85, label %ThrowNullRef99
+  %NullCheck99 = icmp eq i32* %84, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %85
 
 ; <label>:85                                      ; preds = %81
   %86 = load i32, i32* %84, align 8
   %87 = bitcast i8* %82 to i32*
-  %NullCheck102 = icmp ne i32* %87, null
-  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+  %NullCheck101 = icmp eq i32* %87, null
+  br i1 %NullCheck101, label %ThrowNullRef102, label %88
 
 ; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
@@ -829,16 +911,16 @@ entry:
   %91 = load i8*, i8** %arg1
   %92 = getelementptr inbounds i8, i8* %91, i64 4
   %93 = bitcast i8* %92 to i16*
-  %NullCheck104 = icmp ne i16* %93, null
-  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+  %NullCheck103 = icmp eq i16* %93, null
+  br i1 %NullCheck103, label %ThrowNullRef104, label %94
 
 ; <label>:94                                      ; preds = %88
   %95 = load i16, i16* %93, align 8
   %96 = sext i16 %95 to i32
   %97 = bitcast i8* %90 to i16*
   %98 = trunc i32 %96 to i16
-  %NullCheck106 = icmp ne i16* %97, null
-  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+  %NullCheck105 = icmp eq i16* %97, null
+  br i1 %NullCheck105, label %ThrowNullRef106, label %99
 
 ; <label>:99                                      ; preds = %94
   store i16 %98, i16* %97, align 8
@@ -848,14 +930,14 @@ entry:
   %101 = load i8*, i8** %arg0
   %102 = load i8*, i8** %arg1
   %103 = bitcast i8* %102 to i32*
-  %NullCheck88 = icmp ne i32* %103, null
-  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+  %NullCheck87 = icmp eq i32* %103, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %104
 
 ; <label>:104                                     ; preds = %100
   %105 = load i32, i32* %103, align 8
   %106 = bitcast i8* %101 to i32*
-  %NullCheck90 = icmp ne i32* %106, null
-  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+  %NullCheck89 = icmp eq i32* %106, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %107
 
 ; <label>:107                                     ; preds = %104
   store i32 %105, i32* %106, align 8
@@ -864,16 +946,16 @@ entry:
   %110 = load i8*, i8** %arg1
   %111 = getelementptr inbounds i8, i8* %110, i64 4
   %112 = bitcast i8* %111 to i16*
-  %NullCheck92 = icmp ne i16* %112, null
-  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+  %NullCheck91 = icmp eq i16* %112, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %113
 
 ; <label>:113                                     ; preds = %107
   %114 = load i16, i16* %112, align 8
   %115 = sext i16 %114 to i32
   %116 = bitcast i8* %109 to i16*
   %117 = trunc i32 %115 to i16
-  %NullCheck94 = icmp ne i16* %116, null
-  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+  %NullCheck93 = icmp eq i16* %116, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %118
 
 ; <label>:118                                     ; preds = %113
   store i16 %117, i16* %116, align 8
@@ -881,15 +963,15 @@ entry:
   %120 = getelementptr inbounds i8, i8* %119, i64 6
   %121 = load i8*, i8** %arg1
   %122 = getelementptr inbounds i8, i8* %121, i64 6
-  %NullCheck96 = icmp ne i8* %122, null
-  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+  %NullCheck95 = icmp eq i8* %122, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %123
 
 ; <label>:123                                     ; preds = %118
   %124 = load i8, i8* %122, align 8
   %125 = zext i8 %124 to i32
   %126 = trunc i32 %125 to i8
-  %NullCheck98 = icmp ne i8* %120, null
-  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+  %NullCheck97 = icmp eq i8* %120, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %127
 
 ; <label>:127                                     ; preds = %123
   store i8 %126, i8* %120, align 8
@@ -899,14 +981,14 @@ entry:
   %129 = load i8*, i8** %arg0
   %130 = load i8*, i8** %arg1
   %131 = bitcast i8* %130 to i64*
-  %NullCheck84 = icmp ne i64* %131, null
-  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+  %NullCheck83 = icmp eq i64* %131, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %132
 
 ; <label>:132                                     ; preds = %128
   %133 = load i64, i64* %131, align 8
   %134 = bitcast i8* %129 to i64*
-  %NullCheck86 = icmp ne i64* %134, null
-  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+  %NullCheck85 = icmp eq i64* %134, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %135
 
 ; <label>:135                                     ; preds = %132
   store i64 %133, i64* %134, align 8
@@ -916,14 +998,14 @@ entry:
   %137 = load i8*, i8** %arg0
   %138 = load i8*, i8** %arg1
   %139 = bitcast i8* %138 to i64*
-  %NullCheck76 = icmp ne i64* %139, null
-  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+  %NullCheck75 = icmp eq i64* %139, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %140
 
 ; <label>:140                                     ; preds = %136
   %141 = load i64, i64* %139, align 8
   %142 = bitcast i8* %137 to i64*
-  %NullCheck78 = icmp ne i64* %142, null
-  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+  %NullCheck77 = icmp eq i64* %142, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %143
 
 ; <label>:143                                     ; preds = %140
   store i64 %141, i64* %142, align 8
@@ -931,15 +1013,15 @@ entry:
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %NullCheck80 = icmp ne i8* %147, null
-  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+  %NullCheck79 = icmp eq i8* %147, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %148
 
 ; <label>:148                                     ; preds = %143
   %149 = load i8, i8* %147, align 8
   %150 = zext i8 %149 to i32
   %151 = trunc i32 %150 to i8
-  %NullCheck82 = icmp ne i8* %145, null
-  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+  %NullCheck81 = icmp eq i8* %145, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %152
 
 ; <label>:152                                     ; preds = %148
   store i8 %151, i8* %145, align 8
@@ -949,14 +1031,14 @@ entry:
   %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
   %156 = bitcast i8* %155 to i64*
-  %NullCheck68 = icmp ne i64* %156, null
-  br i1 %NullCheck68, label %157, label %ThrowNullRef67
+  %NullCheck67 = icmp eq i64* %156, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %157
 
 ; <label>:157                                     ; preds = %153
   %158 = load i64, i64* %156, align 8
   %159 = bitcast i8* %154 to i64*
-  %NullCheck70 = icmp ne i64* %159, null
-  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+  %NullCheck69 = icmp eq i64* %159, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %160
 
 ; <label>:160                                     ; preds = %157
   store i64 %158, i64* %159, align 8
@@ -965,16 +1047,16 @@ entry:
   %163 = load i8*, i8** %arg1
   %164 = getelementptr inbounds i8, i8* %163, i64 8
   %165 = bitcast i8* %164 to i16*
-  %NullCheck72 = icmp ne i16* %165, null
-  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+  %NullCheck71 = icmp eq i16* %165, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %166
 
 ; <label>:166                                     ; preds = %160
   %167 = load i16, i16* %165, align 8
   %168 = sext i16 %167 to i32
   %169 = bitcast i8* %162 to i16*
   %170 = trunc i32 %168 to i16
-  %NullCheck74 = icmp ne i16* %169, null
-  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+  %NullCheck73 = icmp eq i16* %169, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %171
 
 ; <label>:171                                     ; preds = %166
   store i16 %170, i16* %169, align 8
@@ -984,14 +1066,14 @@ entry:
   %173 = load i8*, i8** %arg0
   %174 = load i8*, i8** %arg1
   %175 = bitcast i8* %174 to i64*
-  %NullCheck56 = icmp ne i64* %175, null
-  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+  %NullCheck55 = icmp eq i64* %175, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %176
 
 ; <label>:176                                     ; preds = %172
   %177 = load i64, i64* %175, align 8
   %178 = bitcast i8* %173 to i64*
-  %NullCheck58 = icmp ne i64* %178, null
-  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+  %NullCheck57 = icmp eq i64* %178, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %179
 
 ; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
@@ -1000,16 +1082,16 @@ entry:
   %182 = load i8*, i8** %arg1
   %183 = getelementptr inbounds i8, i8* %182, i64 8
   %184 = bitcast i8* %183 to i16*
-  %NullCheck60 = icmp ne i16* %184, null
-  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+  %NullCheck59 = icmp eq i16* %184, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %185
 
 ; <label>:185                                     ; preds = %179
   %186 = load i16, i16* %184, align 8
   %187 = sext i16 %186 to i32
   %188 = bitcast i8* %181 to i16*
   %189 = trunc i32 %187 to i16
-  %NullCheck62 = icmp ne i16* %188, null
-  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+  %NullCheck61 = icmp eq i16* %188, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %190
 
 ; <label>:190                                     ; preds = %185
   store i16 %189, i16* %188, align 8
@@ -1017,15 +1099,15 @@ entry:
   %192 = getelementptr inbounds i8, i8* %191, i64 10
   %193 = load i8*, i8** %arg1
   %194 = getelementptr inbounds i8, i8* %193, i64 10
-  %NullCheck64 = icmp ne i8* %194, null
-  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+  %NullCheck63 = icmp eq i8* %194, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %195
 
 ; <label>:195                                     ; preds = %190
   %196 = load i8, i8* %194, align 8
   %197 = zext i8 %196 to i32
   %198 = trunc i32 %197 to i8
-  %NullCheck66 = icmp ne i8* %192, null
-  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+  %NullCheck65 = icmp eq i8* %192, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %199
 
 ; <label>:199                                     ; preds = %195
   store i8 %198, i8* %192, align 8
@@ -1035,14 +1117,14 @@ entry:
   %201 = load i8*, i8** %arg0
   %202 = load i8*, i8** %arg1
   %203 = bitcast i8* %202 to i64*
-  %NullCheck48 = icmp ne i64* %203, null
-  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+  %NullCheck47 = icmp eq i64* %203, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %204
 
 ; <label>:204                                     ; preds = %200
   %205 = load i64, i64* %203, align 8
   %206 = bitcast i8* %201 to i64*
-  %NullCheck50 = icmp ne i64* %206, null
-  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+  %NullCheck49 = icmp eq i64* %206, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %207
 
 ; <label>:207                                     ; preds = %204
   store i64 %205, i64* %206, align 8
@@ -1051,14 +1133,14 @@ entry:
   %210 = load i8*, i8** %arg1
   %211 = getelementptr inbounds i8, i8* %210, i64 8
   %212 = bitcast i8* %211 to i32*
-  %NullCheck52 = icmp ne i32* %212, null
-  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+  %NullCheck51 = icmp eq i32* %212, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %213
 
 ; <label>:213                                     ; preds = %207
   %214 = load i32, i32* %212, align 8
   %215 = bitcast i8* %209 to i32*
-  %NullCheck54 = icmp ne i32* %215, null
-  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+  %NullCheck53 = icmp eq i32* %215, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %216
 
 ; <label>:216                                     ; preds = %213
   store i32 %214, i32* %215, align 8
@@ -1068,14 +1150,14 @@ entry:
   %218 = load i8*, i8** %arg0
   %219 = load i8*, i8** %arg1
   %220 = bitcast i8* %219 to i64*
-  %NullCheck36 = icmp ne i64* %220, null
-  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64* %220, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %221
 
 ; <label>:221                                     ; preds = %217
   %222 = load i64, i64* %220, align 8
   %223 = bitcast i8* %218 to i64*
-  %NullCheck38 = icmp ne i64* %223, null
-  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+  %NullCheck37 = icmp eq i64* %223, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %224
 
 ; <label>:224                                     ; preds = %221
   store i64 %222, i64* %223, align 8
@@ -1084,14 +1166,14 @@ entry:
   %227 = load i8*, i8** %arg1
   %228 = getelementptr inbounds i8, i8* %227, i64 8
   %229 = bitcast i8* %228 to i32*
-  %NullCheck40 = icmp ne i32* %229, null
-  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i32* %229, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %230
 
 ; <label>:230                                     ; preds = %224
   %231 = load i32, i32* %229, align 8
   %232 = bitcast i8* %226 to i32*
-  %NullCheck42 = icmp ne i32* %232, null
-  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+  %NullCheck41 = icmp eq i32* %232, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %233
 
 ; <label>:233                                     ; preds = %230
   store i32 %231, i32* %232, align 8
@@ -1099,15 +1181,15 @@ entry:
   %235 = getelementptr inbounds i8, i8* %234, i64 12
   %236 = load i8*, i8** %arg1
   %237 = getelementptr inbounds i8, i8* %236, i64 12
-  %NullCheck44 = icmp ne i8* %237, null
-  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i8* %237, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %238
 
 ; <label>:238                                     ; preds = %233
   %239 = load i8, i8* %237, align 8
   %240 = zext i8 %239 to i32
   %241 = trunc i32 %240 to i8
-  %NullCheck46 = icmp ne i8* %235, null
-  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+  %NullCheck45 = icmp eq i8* %235, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %242
 
 ; <label>:242                                     ; preds = %238
   store i8 %241, i8* %235, align 8
@@ -1117,14 +1199,14 @@ entry:
   %244 = load i8*, i8** %arg0
   %245 = load i8*, i8** %arg1
   %246 = bitcast i8* %245 to i64*
-  %NullCheck24 = icmp ne i64* %246, null
-  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64* %246, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %247
 
 ; <label>:247                                     ; preds = %243
   %248 = load i64, i64* %246, align 8
   %249 = bitcast i8* %244 to i64*
-  %NullCheck26 = icmp ne i64* %249, null
-  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64* %249, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %250
 
 ; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
@@ -1133,14 +1215,14 @@ entry:
   %253 = load i8*, i8** %arg1
   %254 = getelementptr inbounds i8, i8* %253, i64 8
   %255 = bitcast i8* %254 to i32*
-  %NullCheck28 = icmp ne i32* %255, null
-  br i1 %NullCheck28, label %256, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i32* %255, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %256
 
 ; <label>:256                                     ; preds = %250
   %257 = load i32, i32* %255, align 8
   %258 = bitcast i8* %252 to i32*
-  %NullCheck30 = icmp ne i32* %258, null
-  br i1 %NullCheck30, label %259, label %ThrowNullRef29
+  %NullCheck29 = icmp eq i32* %258, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %259
 
 ; <label>:259                                     ; preds = %256
   store i32 %257, i32* %258, align 8
@@ -1149,16 +1231,16 @@ entry:
   %262 = load i8*, i8** %arg1
   %263 = getelementptr inbounds i8, i8* %262, i64 12
   %264 = bitcast i8* %263 to i16*
-  %NullCheck32 = icmp ne i16* %264, null
-  br i1 %NullCheck32, label %265, label %ThrowNullRef31
+  %NullCheck31 = icmp eq i16* %264, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %265
 
 ; <label>:265                                     ; preds = %259
   %266 = load i16, i16* %264, align 8
   %267 = sext i16 %266 to i32
   %268 = bitcast i8* %261 to i16*
   %269 = trunc i32 %267 to i16
-  %NullCheck34 = icmp ne i16* %268, null
-  br i1 %NullCheck34, label %270, label %ThrowNullRef33
+  %NullCheck33 = icmp eq i16* %268, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %270
 
 ; <label>:270                                     ; preds = %265
   store i16 %269, i16* %268, align 8
@@ -1168,14 +1250,14 @@ entry:
   %272 = load i8*, i8** %arg0
   %273 = load i8*, i8** %arg1
   %274 = bitcast i8* %273 to i64*
-  %NullCheck8 = icmp ne i64* %274, null
-  br i1 %NullCheck8, label %275, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64* %274, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %275
 
 ; <label>:275                                     ; preds = %271
   %276 = load i64, i64* %274, align 8
   %277 = bitcast i8* %272 to i64*
-  %NullCheck10 = icmp ne i64* %277, null
-  br i1 %NullCheck10, label %278, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %277, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %278
 
 ; <label>:278                                     ; preds = %275
   store i64 %276, i64* %277, align 8
@@ -1184,14 +1266,14 @@ entry:
   %281 = load i8*, i8** %arg1
   %282 = getelementptr inbounds i8, i8* %281, i64 8
   %283 = bitcast i8* %282 to i32*
-  %NullCheck12 = icmp ne i32* %283, null
-  br i1 %NullCheck12, label %284, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i32* %283, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %284
 
 ; <label>:284                                     ; preds = %278
   %285 = load i32, i32* %283, align 8
   %286 = bitcast i8* %280 to i32*
-  %NullCheck14 = icmp ne i32* %286, null
-  br i1 %NullCheck14, label %287, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i32* %286, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %287
 
 ; <label>:287                                     ; preds = %284
   store i32 %285, i32* %286, align 8
@@ -1200,16 +1282,16 @@ entry:
   %290 = load i8*, i8** %arg1
   %291 = getelementptr inbounds i8, i8* %290, i64 12
   %292 = bitcast i8* %291 to i16*
-  %NullCheck16 = icmp ne i16* %292, null
-  br i1 %NullCheck16, label %293, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i16* %292, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %293
 
 ; <label>:293                                     ; preds = %287
   %294 = load i16, i16* %292, align 8
   %295 = sext i16 %294 to i32
   %296 = bitcast i8* %289 to i16*
   %297 = trunc i32 %295 to i16
-  %NullCheck18 = icmp ne i16* %296, null
-  br i1 %NullCheck18, label %298, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i16* %296, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %298
 
 ; <label>:298                                     ; preds = %293
   store i16 %297, i16* %296, align 8
@@ -1217,15 +1299,15 @@ entry:
   %300 = getelementptr inbounds i8, i8* %299, i64 14
   %301 = load i8*, i8** %arg1
   %302 = getelementptr inbounds i8, i8* %301, i64 14
-  %NullCheck20 = icmp ne i8* %302, null
-  br i1 %NullCheck20, label %303, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i8* %302, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %303
 
 ; <label>:303                                     ; preds = %298
   %304 = load i8, i8* %302, align 8
   %305 = zext i8 %304 to i32
   %306 = trunc i32 %305 to i8
-  %NullCheck22 = icmp ne i8* %300, null
-  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i8* %300, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %307
 
 ; <label>:307                                     ; preds = %303
   store i8 %306, i8* %300, align 8
@@ -1235,14 +1317,14 @@ entry:
   %309 = load i8*, i8** %arg0
   %310 = load i8*, i8** %arg1
   %311 = bitcast i8* %310 to i64*
-  %NullCheck = icmp ne i64* %311, null
-  br i1 %NullCheck, label %312, label %ThrowNullRef
+  %NullCheck = icmp eq i64* %311, null
+  br i1 %NullCheck, label %ThrowNullRef, label %312
 
 ; <label>:312                                     ; preds = %308
   %313 = load i64, i64* %311, align 8
   %314 = bitcast i8* %309 to i64*
-  %NullCheck2 = icmp ne i64* %314, null
-  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64* %314, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %315
 
 ; <label>:315                                     ; preds = %312
   store i64 %313, i64* %314, align 8
@@ -1251,14 +1333,14 @@ entry:
   %318 = load i8*, i8** %arg1
   %319 = getelementptr inbounds i8, i8* %318, i64 8
   %320 = bitcast i8* %319 to i64*
-  %NullCheck4 = icmp ne i64* %320, null
-  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64* %320, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %321
 
 ; <label>:321                                     ; preds = %315
   %322 = load i64, i64* %320, align 8
   %323 = bitcast i8* %317 to i64*
-  %NullCheck6 = icmp ne i64* %323, null
-  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64* %323, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %324
 
 ; <label>:324                                     ; preds = %321
   store i64 %322, i64* %323, align 8
@@ -1286,15 +1368,15 @@ entry:
 ; <label>:338                                     ; preds = %333
   %339 = load i8*, i8** %arg0
   %340 = load i8*, i8** %arg1
-  %NullCheck136 = icmp ne i8* %340, null
-  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+  %NullCheck135 = icmp eq i8* %340, null
+  br i1 %NullCheck135, label %ThrowNullRef136, label %341
 
 ; <label>:341                                     ; preds = %338
   %342 = load i8, i8* %340, align 8
   %343 = zext i8 %342 to i32
   %344 = trunc i32 %343 to i8
-  %NullCheck138 = icmp ne i8* %339, null
-  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+  %NullCheck137 = icmp eq i8* %339, null
+  br i1 %NullCheck137, label %ThrowNullRef138, label %345
 
 ; <label>:345                                     ; preds = %341
   store i8 %344, i8* %339, align 8
@@ -1317,16 +1399,16 @@ entry:
   %357 = load i8*, i8** %arg0
   %358 = load i8*, i8** %arg1
   %359 = bitcast i8* %358 to i16*
-  %NullCheck140 = icmp ne i16* %359, null
-  br i1 %NullCheck140, label %360, label %ThrowNullRef139
+  %NullCheck139 = icmp eq i16* %359, null
+  br i1 %NullCheck139, label %ThrowNullRef140, label %360
 
 ; <label>:360                                     ; preds = %356
   %361 = load i16, i16* %359, align 8
   %362 = sext i16 %361 to i32
   %363 = bitcast i8* %357 to i16*
   %364 = trunc i32 %362 to i16
-  %NullCheck142 = icmp ne i16* %363, null
-  br i1 %NullCheck142, label %365, label %ThrowNullRef141
+  %NullCheck141 = icmp eq i16* %363, null
+  br i1 %NullCheck141, label %ThrowNullRef142, label %365
 
 ; <label>:365                                     ; preds = %360
   store i16 %364, i16* %363, align 8
@@ -1352,14 +1434,14 @@ entry:
   %378 = load i8*, i8** %arg0
   %379 = load i8*, i8** %arg1
   %380 = bitcast i8* %379 to i32*
-  %NullCheck144 = icmp ne i32* %380, null
-  br i1 %NullCheck144, label %381, label %ThrowNullRef143
+  %NullCheck143 = icmp eq i32* %380, null
+  br i1 %NullCheck143, label %ThrowNullRef144, label %381
 
 ; <label>:381                                     ; preds = %377
   %382 = load i32, i32* %380, align 8
   %383 = bitcast i8* %378 to i32*
-  %NullCheck146 = icmp ne i32* %383, null
-  br i1 %NullCheck146, label %384, label %ThrowNullRef145
+  %NullCheck145 = icmp eq i32* %383, null
+  br i1 %NullCheck145, label %ThrowNullRef146, label %384
 
 ; <label>:384                                     ; preds = %381
   store i32 %382, i32* %383, align 8
@@ -1384,14 +1466,14 @@ entry:
   %395 = load i8*, i8** %arg0
   %396 = load i8*, i8** %arg1
   %397 = bitcast i8* %396 to i64*
-  %NullCheck164 = icmp ne i64* %397, null
-  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+  %NullCheck163 = icmp eq i64* %397, null
+  br i1 %NullCheck163, label %ThrowNullRef164, label %398
 
 ; <label>:398                                     ; preds = %394
   %399 = load i64, i64* %397, align 8
   %400 = bitcast i8* %395 to i64*
-  %NullCheck166 = icmp ne i64* %400, null
-  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+  %NullCheck165 = icmp eq i64* %400, null
+  br i1 %NullCheck165, label %ThrowNullRef166, label %401
 
 ; <label>:401                                     ; preds = %398
   store i64 %399, i64* %400, align 8
@@ -1400,14 +1482,14 @@ entry:
   %404 = load i8*, i8** %arg1
   %405 = getelementptr inbounds i8, i8* %404, i64 8
   %406 = bitcast i8* %405 to i64*
-  %NullCheck168 = icmp ne i64* %406, null
-  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+  %NullCheck167 = icmp eq i64* %406, null
+  br i1 %NullCheck167, label %ThrowNullRef168, label %407
 
 ; <label>:407                                     ; preds = %401
   %408 = load i64, i64* %406, align 8
   %409 = bitcast i8* %403 to i64*
-  %NullCheck170 = icmp ne i64* %409, null
-  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+  %NullCheck169 = icmp eq i64* %409, null
+  br i1 %NullCheck169, label %ThrowNullRef170, label %410
 
 ; <label>:410                                     ; preds = %407
   store i64 %408, i64* %409, align 8
@@ -1437,14 +1519,14 @@ entry:
   %425 = load i8*, i8** %arg0
   %426 = load i8*, i8** %arg1
   %427 = bitcast i8* %426 to i64*
-  %NullCheck148 = icmp ne i64* %427, null
-  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+  %NullCheck147 = icmp eq i64* %427, null
+  br i1 %NullCheck147, label %ThrowNullRef148, label %428
 
 ; <label>:428                                     ; preds = %424
   %429 = load i64, i64* %427, align 8
   %430 = bitcast i8* %425 to i64*
-  %NullCheck150 = icmp ne i64* %430, null
-  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+  %NullCheck149 = icmp eq i64* %430, null
+  br i1 %NullCheck149, label %ThrowNullRef150, label %431
 
 ; <label>:431                                     ; preds = %428
   store i64 %429, i64* %430, align 8
@@ -1466,14 +1548,14 @@ entry:
   %441 = load i8*, i8** %arg0
   %442 = load i8*, i8** %arg1
   %443 = bitcast i8* %442 to i32*
-  %NullCheck152 = icmp ne i32* %443, null
-  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+  %NullCheck151 = icmp eq i32* %443, null
+  br i1 %NullCheck151, label %ThrowNullRef152, label %444
 
 ; <label>:444                                     ; preds = %440
   %445 = load i32, i32* %443, align 8
   %446 = bitcast i8* %441 to i32*
-  %NullCheck154 = icmp ne i32* %446, null
-  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+  %NullCheck153 = icmp eq i32* %446, null
+  br i1 %NullCheck153, label %ThrowNullRef154, label %447
 
 ; <label>:447                                     ; preds = %444
   store i32 %445, i32* %446, align 8
@@ -1495,16 +1577,16 @@ entry:
   %457 = load i8*, i8** %arg0
   %458 = load i8*, i8** %arg1
   %459 = bitcast i8* %458 to i16*
-  %NullCheck156 = icmp ne i16* %459, null
-  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+  %NullCheck155 = icmp eq i16* %459, null
+  br i1 %NullCheck155, label %ThrowNullRef156, label %460
 
 ; <label>:460                                     ; preds = %456
   %461 = load i16, i16* %459, align 8
   %462 = sext i16 %461 to i32
   %463 = bitcast i8* %457 to i16*
   %464 = trunc i32 %462 to i16
-  %NullCheck158 = icmp ne i16* %463, null
-  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+  %NullCheck157 = icmp eq i16* %463, null
+  br i1 %NullCheck157, label %ThrowNullRef158, label %465
 
 ; <label>:465                                     ; preds = %460
   store i16 %464, i16* %463, align 8
@@ -1525,15 +1607,15 @@ entry:
 ; <label>:474                                     ; preds = %470
   %475 = load i8*, i8** %arg0
   %476 = load i8*, i8** %arg1
-  %NullCheck160 = icmp ne i8* %476, null
-  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+  %NullCheck159 = icmp eq i8* %476, null
+  br i1 %NullCheck159, label %ThrowNullRef160, label %477
 
 ; <label>:477                                     ; preds = %474
   %478 = load i8, i8* %476, align 8
   %479 = zext i8 %478 to i32
   %480 = trunc i32 %479 to i8
-  %NullCheck162 = icmp ne i8* %475, null
-  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+  %NullCheck161 = icmp eq i8* %475, null
+  br i1 %NullCheck161, label %ThrowNullRef162, label %481
 
 ; <label>:481                                     ; preds = %477
   store i8 %480, i8* %475, align 8
@@ -1553,343 +1635,343 @@ ThrowNullRef:                                     ; preds = %308
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %312
+ThrowNullRef2:                                    ; preds = %312
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %315
+ThrowNullRef4:                                    ; preds = %315
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %321
+ThrowNullRef6:                                    ; preds = %321
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %271
+ThrowNullRef8:                                    ; preds = %271
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %275
+ThrowNullRef10:                                   ; preds = %275
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %278
+ThrowNullRef12:                                   ; preds = %278
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %284
+ThrowNullRef14:                                   ; preds = %284
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %287
+ThrowNullRef16:                                   ; preds = %287
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %293
+ThrowNullRef18:                                   ; preds = %293
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %298
+ThrowNullRef20:                                   ; preds = %298
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %303
+ThrowNullRef22:                                   ; preds = %303
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %243
+ThrowNullRef24:                                   ; preds = %243
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %247
+ThrowNullRef26:                                   ; preds = %247
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %250
+ThrowNullRef28:                                   ; preds = %250
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %256
+ThrowNullRef30:                                   ; preds = %256
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %259
+ThrowNullRef32:                                   ; preds = %259
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %265
+ThrowNullRef34:                                   ; preds = %265
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %217
+ThrowNullRef36:                                   ; preds = %217
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %221
+ThrowNullRef38:                                   ; preds = %221
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %224
+ThrowNullRef40:                                   ; preds = %224
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %230
+ThrowNullRef42:                                   ; preds = %230
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %233
+ThrowNullRef44:                                   ; preds = %233
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %238
+ThrowNullRef46:                                   ; preds = %238
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %200
+ThrowNullRef48:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %204
+ThrowNullRef50:                                   ; preds = %204
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %207
+ThrowNullRef52:                                   ; preds = %207
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %213
+ThrowNullRef54:                                   ; preds = %213
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %172
+ThrowNullRef56:                                   ; preds = %172
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %176
+ThrowNullRef58:                                   ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %179
+ThrowNullRef60:                                   ; preds = %179
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %185
+ThrowNullRef62:                                   ; preds = %185
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %190
+ThrowNullRef64:                                   ; preds = %190
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %195
+ThrowNullRef66:                                   ; preds = %195
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %153
+ThrowNullRef68:                                   ; preds = %153
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %157
+ThrowNullRef70:                                   ; preds = %157
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %160
+ThrowNullRef72:                                   ; preds = %160
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %166
+ThrowNullRef74:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %136
+ThrowNullRef76:                                   ; preds = %136
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %140
+ThrowNullRef78:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %143
+ThrowNullRef80:                                   ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %148
+ThrowNullRef82:                                   ; preds = %148
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %128
+ThrowNullRef84:                                   ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %132
+ThrowNullRef86:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %100
+ThrowNullRef88:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %104
+ThrowNullRef90:                                   ; preds = %104
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %107
+ThrowNullRef92:                                   ; preds = %107
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %113
+ThrowNullRef94:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %118
+ThrowNullRef96:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %123
+ThrowNullRef98:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %81
+ThrowNullRef100:                                  ; preds = %81
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef101:                                  ; preds = %85
+ThrowNullRef102:                                  ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef103:                                  ; preds = %88
+ThrowNullRef104:                                  ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef105:                                  ; preds = %94
+ThrowNullRef106:                                  ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef107:                                  ; preds = %64
+ThrowNullRef108:                                  ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef109:                                  ; preds = %68
+ThrowNullRef110:                                  ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef111:                                  ; preds = %71
+ThrowNullRef112:                                  ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef113:                                  ; preds = %76
+ThrowNullRef114:                                  ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef115:                                  ; preds = %56
+ThrowNullRef116:                                  ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef117:                                  ; preds = %60
+ThrowNullRef118:                                  ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef119:                                  ; preds = %37
+ThrowNullRef120:                                  ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef121:                                  ; preds = %41
+ThrowNullRef122:                                  ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef123:                                  ; preds = %46
+ThrowNullRef124:                                  ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef125:                                  ; preds = %51
+ThrowNullRef126:                                  ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef127:                                  ; preds = %27
+ThrowNullRef128:                                  ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef129:                                  ; preds = %31
+ThrowNullRef130:                                  ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef131:                                  ; preds = %19
+ThrowNullRef132:                                  ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef133:                                  ; preds = %22
+ThrowNullRef134:                                  ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef135:                                  ; preds = %338
+ThrowNullRef136:                                  ; preds = %338
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef137:                                  ; preds = %341
+ThrowNullRef138:                                  ; preds = %341
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef139:                                  ; preds = %356
+ThrowNullRef140:                                  ; preds = %356
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef141:                                  ; preds = %360
+ThrowNullRef142:                                  ; preds = %360
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef143:                                  ; preds = %377
+ThrowNullRef144:                                  ; preds = %377
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef145:                                  ; preds = %381
+ThrowNullRef146:                                  ; preds = %381
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef147:                                  ; preds = %424
+ThrowNullRef148:                                  ; preds = %424
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef149:                                  ; preds = %428
+ThrowNullRef150:                                  ; preds = %428
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef151:                                  ; preds = %440
+ThrowNullRef152:                                  ; preds = %440
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef153:                                  ; preds = %444
+ThrowNullRef154:                                  ; preds = %444
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef155:                                  ; preds = %456
+ThrowNullRef156:                                  ; preds = %456
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef157:                                  ; preds = %460
+ThrowNullRef158:                                  ; preds = %460
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef159:                                  ; preds = %474
+ThrowNullRef160:                                  ; preds = %474
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef161:                                  ; preds = %477
+ThrowNullRef162:                                  ; preds = %477
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef163:                                  ; preds = %394
+ThrowNullRef164:                                  ; preds = %394
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef165:                                  ; preds = %398
+ThrowNullRef166:                                  ; preds = %398
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef167:                                  ; preds = %401
+ThrowNullRef168:                                  ; preds = %401
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef169:                                  ; preds = %407
+ThrowNullRef170:                                  ; preds = %407
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1939,8 +2021,8 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
-  br i1 %NullCheck, label %22, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %ThrowNullRef, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
@@ -1948,8 +2030,8 @@ entry:
   store i32 %24, i32* %loc0
   %25 = load i32, i32* %loc0
   %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %26, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %27
 
 ; <label>:27                                      ; preds = %22
   %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
@@ -1971,7 +2053,7 @@ ThrowNullRef:                                     ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1989,8 +2071,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -2022,15 +2104,15 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2048,16 +2130,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
   %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
   store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %15
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
@@ -2072,8 +2154,8 @@ entry:
   %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
   %29 = ptrtoint i16 addrspace(1)* %28 to i64
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %19
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
@@ -2089,19 +2171,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2114,8 +2196,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
@@ -2128,7 +2210,7 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[loadElem]
+Failed to read AppDomain.PrepareDataForSetup[storeElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
@@ -2202,8 +2284,8 @@ entry:
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
-  br i1 %NullCheck24, label %27, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = load i64, i64 addrspace(1)* %26
@@ -2218,8 +2300,8 @@ entry:
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
-  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
   %41 = load i64, i64 addrspace(1)* %39
@@ -2236,8 +2318,8 @@ entry:
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
-  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
   %54 = load i64, i64 addrspace(1)* %52
@@ -2252,8 +2334,8 @@ entry:
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
   %67 = load i64, i64 addrspace(1)* %65
@@ -2270,8 +2352,8 @@ entry:
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
-  br i1 %NullCheck16, label %79, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
   %80 = load i64, i64 addrspace(1)* %78
@@ -2286,8 +2368,8 @@ entry:
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
-  br i1 %NullCheck18, label %92, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
   %93 = load i64, i64 addrspace(1)* %91
@@ -2304,8 +2386,8 @@ entry:
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
-  br i1 %NullCheck12, label %105, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = load i64, i64 addrspace(1)* %104
@@ -2320,8 +2402,8 @@ entry:
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
-  br i1 %NullCheck14, label %118, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
   %119 = load i64, i64 addrspace(1)* %117
@@ -2337,8 +2419,8 @@ entry:
 
 ; <label>:128                                     ; preds = %20
   %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
-  br i1 %NullCheck4, label %130, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %129, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %130
 
 ; <label>:130                                     ; preds = %128
   %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
@@ -2346,8 +2428,8 @@ entry:
   %133 = load i16, i16 addrspace(1)* %132, align 8
   %134 = zext i16 %133 to i32
   %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
-  br i1 %NullCheck6, label %136, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %135, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %136
 
 ; <label>:136                                     ; preds = %130
   %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
@@ -2360,8 +2442,8 @@ entry:
 
 ; <label>:143                                     ; preds = %136
   %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
-  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %144, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %145
 
 ; <label>:145                                     ; preds = %143
   %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
@@ -2369,8 +2451,8 @@ entry:
   %148 = load i16, i16 addrspace(1)* %147, align 8
   %149 = zext i16 %148 to i32
   %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %150, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %151
 
 ; <label>:151                                     ; preds = %145
   %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
@@ -2388,8 +2470,8 @@ entry:
 
 ; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
-  br i1 %NullCheck, label %163, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %ThrowNullRef, label %163
 
 ; <label>:163                                     ; preds = %161
   %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
@@ -2399,8 +2481,8 @@ entry:
 
 ; <label>:167                                     ; preds = %163
   %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
-  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %168, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %169
 
 ; <label>:169                                     ; preds = %167
   %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
@@ -2432,55 +2514,55 @@ ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %167
+ThrowNullRef2:                                    ; preds = %167
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %128
+ThrowNullRef4:                                    ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %130
+ThrowNullRef6:                                    ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %143
+ThrowNullRef8:                                    ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %145
+ThrowNullRef10:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %102
+ThrowNullRef12:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %105
+ThrowNullRef14:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %76
+ThrowNullRef16:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %79
+ThrowNullRef18:                                   ; preds = %79
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %50
+ThrowNullRef20:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %53
+ThrowNullRef22:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %24
+ThrowNullRef24:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %27
+ThrowNullRef26:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2503,15 +2585,15 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2519,16 +2601,16 @@ entry:
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
   store i32 %8, i32* %loc0
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
   %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
   store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
@@ -2546,16 +2628,16 @@ entry:
 
 ; <label>:23                                      ; preds = %64
   %24 = load i16*, i16** %loc3
-  %NullCheck12 = icmp ne i16* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i16* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
   store i32 %27, i32* %loc5
   %28 = load i16*, i16** %loc4
-  %NullCheck14 = icmp ne i16* %28, null
-  br i1 %NullCheck14, label %29, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %28, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = load i16, i16* %28, align 8
@@ -2620,15 +2702,15 @@ entry:
 
 ; <label>:67                                      ; preds = %64
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
-  br i1 %NullCheck8, label %69, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %68, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %69
 
 ; <label>:69                                      ; preds = %67
   %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
   %71 = load i32, i32 addrspace(1)* %70
   %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
-  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %73
 
 ; <label>:73                                      ; preds = %69
   %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
@@ -2645,31 +2727,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %67
+ThrowNullRef8:                                    ; preds = %67
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %69
+ThrowNullRef10:                                   ; preds = %69
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2710,14 +2792,14 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
   %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
@@ -2730,14 +2812,14 @@ entry:
 
 ; <label>:11                                      ; preds = %4
   %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
   %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
@@ -2749,14 +2831,14 @@ entry:
 
 ; <label>:22                                      ; preds = %16
   %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
   %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
-  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
-  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
@@ -2804,23 +2886,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2836,7 +2918,280 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[loadElem]
+Successfully read RuntimeType.IsAssignableFrom
+
+define i8 @RuntimeType.IsAssignableFrom(%System.RuntimeType addrspace(1)* %param0, %System.Type addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.RuntimeType addrspace(1)*
+  %arg1 = alloca %System.Type addrspace(1)*
+  %loc0 = alloca %System.RuntimeType addrspace(1)*
+  %loc1 = alloca %"System.Type[]" addrspace(1)*
+  %loc2 = alloca i32
+  store %System.RuntimeType addrspace(1)* %param0, %System.RuntimeType addrspace(1)** %this
+  store %System.Type addrspace(1)* %param1, %System.Type addrspace(1)** %arg1
+  %0 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %1 = icmp ne %System.Type addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i8 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %5 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %6 = bitcast %System.Type addrspace(1)* %4 to %System.Object addrspace(1)*
+  %7 = bitcast %System.RuntimeType addrspace(1)* %5 to %System.Object addrspace(1)*
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %6, %System.Object addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %3
+  ret i8 1
+
+; <label>:12                                      ; preds = %3
+  %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 152
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 32
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
+  %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
+  %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
+  store %System.RuntimeType addrspace(1)* %25, %System.RuntimeType addrspace(1)** %loc0
+  %26 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %27 = icmp eq %System.RuntimeType addrspace(1)* %26, null
+  br i1 %27, label %34, label %28
+
+; <label>:28                                      ; preds = %15
+  %29 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %30 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)*)*)(%System.RuntimeType addrspace(1)* %29, %System.RuntimeType addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+; <label>:34                                      ; preds = %15
+  %35 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %36 = call %System.Reflection.Emit.TypeBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Reflection.Emit.TypeBuilder addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %35)
+  %37 = icmp eq %System.Reflection.Emit.TypeBuilder addrspace(1)* %36, null
+  br i1 %37, label %139, label %38
+
+; <label>:38                                      ; preds = %34
+  %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %42
+
+; <label>:42                                      ; preds = %38
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 152
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 40
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
+  %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
+  %53 = zext i8 %52 to i32
+  %54 = icmp eq i32 %53, 0
+  br i1 %54, label %56, label %55
+
+; <label>:55                                      ; preds = %42
+  ret i8 1
+
+; <label>:56                                      ; preds = %42
+  %57 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %58 = bitcast %System.RuntimeType addrspace(1)* %57 to %System.Type addrspace(1)*
+  %59 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %58)
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %64 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.Type addrspace(1)* %63, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = bitcast %System.RuntimeType addrspace(1)* %64 to %System.Type addrspace(1)*
+  %67 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %63, %System.Type addrspace(1)* %66)
+  %68 = zext i8 %67 to i32
+  %69 = trunc i32 %68 to i8
+  ret i8 %69
+
+; <label>:70                                      ; preds = %56
+  %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
+  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %73
+
+; <label>:73                                      ; preds = %70
+  %74 = load i64, i64 addrspace(1)* %72
+  %75 = add i64 %74, 128
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = add i64 %77, 0
+  %79 = inttoptr i64 %78 to i64*
+  %80 = load i64, i64* %79
+  %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
+  %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
+  %83 = call i8 %82(%System.Type addrspace(1)* %81)
+  %84 = zext i8 %83 to i32
+  %85 = icmp eq i32 %84, 0
+  br i1 %85, label %139, label %86
+
+; <label>:86                                      ; preds = %73
+  %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
+  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %89
+
+; <label>:89                                      ; preds = %86
+  %90 = load i64, i64 addrspace(1)* %88
+  %91 = add i64 %90, 128
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = add i64 %93, 24
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
+  %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
+  %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
+  store %"System.Type[]" addrspace(1)* %99, %"System.Type[]" addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %129
+
+; <label>:100                                     ; preds = %132
+  %101 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %102 = load i32, i32* %loc2
+  %NullCheck11 = icmp eq %"System.Type[]" addrspace(1)* %101, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %103
+
+; <label>:103                                     ; preds = %100
+  %104 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 1
+  %105 = load i32, i32 addrspace(1)* %104
+  %106 = zext i32 %105 to i64
+  %107 = zext i32 %102 to i64
+  %BoundsCheck = icmp uge i64 %107, %106
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %108
+
+; <label>:108                                     ; preds = %103
+  %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
+  %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
+  %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
+  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %113
+
+; <label>:113                                     ; preds = %108
+  %114 = load i64, i64 addrspace(1)* %112
+  %115 = add i64 %114, 152
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = add i64 %117, 56
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
+  %123 = zext i8 %122 to i32
+  %124 = icmp ne i32 %123, 0
+  br i1 %124, label %126, label %125
+
+; <label>:125                                     ; preds = %113
+  ret i8 0
+
+; <label>:126                                     ; preds = %113
+  %127 = load i32, i32* %loc2
+  %128 = add i32 %127, 1
+  store i32 %128, i32* %loc2
+  br label %129
+
+; <label>:129                                     ; preds = %89, %126
+  %130 = load i32, i32* %loc2
+  %131 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %NullCheck9 = icmp eq %"System.Type[]" addrspace(1)* %131, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %132
+
+; <label>:132                                     ; preds = %129
+  %133 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %131, i32 0, i32 1
+  %134 = load i32, i32 addrspace(1)* %133
+  %135 = zext i32 %134 to i64
+  %136 = trunc i64 %135 to i32
+  %137 = icmp slt i32 %130, %136
+  br i1 %137, label %100, label %138
+
+; <label>:138                                     ; preds = %132
+  ret i8 1
+
+; <label>:139                                     ; preds = %34, %73
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %129
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %103
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -2893,7 +3248,7 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElem]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -2904,8 +3259,8 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -2997,8 +3352,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
@@ -3059,8 +3414,8 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -3087,8 +3442,8 @@ entry:
 
 ; <label>:17                                      ; preds = %5, %11
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
@@ -3097,8 +3452,8 @@ entry:
 
 ; <label>:22                                      ; preds = %1, %11
   %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
@@ -3109,11 +3464,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %17
+ThrowNullRef2:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %22
+ThrowNullRef4:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3167,15 +3522,15 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
   %15 = load i32, i32 addrspace(1)* %14
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
@@ -3198,7 +3553,7 @@ ThrowNullRef:                                     ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef2:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3232,8 +3587,8 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
@@ -3312,8 +3667,8 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -3327,8 +3682,8 @@ entry:
 ; <label>:5                                       ; preds = %43
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %7 = load i32, i32* %loc1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck6, label %8, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
@@ -3366,8 +3721,8 @@ entry:
 ; <label>:32                                      ; preds = %21, %25
   %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
   %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
-  br i1 %NullCheck8, label %35, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = trunc i32 %34 to i16
@@ -3380,8 +3735,8 @@ entry:
 ; <label>:40                                      ; preds = %1, %35
   %41 = load i32, i32* %loc1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
-  br i1 %NullCheck2, label %43, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %42, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
@@ -3392,8 +3747,8 @@ entry:
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
   %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
-  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
   %51 = load i64, i64 addrspace(1)* %49
@@ -3412,19 +3767,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %40
+ThrowNullRef2:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %47
+ThrowNullRef4:                                    ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %5
+ThrowNullRef6:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %32
+ThrowNullRef8:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3467,8 +3822,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
@@ -3492,11 +3847,391 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(i16* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store i16* %param0, i16** %arg0
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load i32, i32* %arg3
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %42, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %37, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg2
+  %13 = load i32, i32* %arg3
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %37, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %24 = load i32, i32* %arg2
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load i16*, i16** %arg0
+  %35 = load i32, i32* %arg3
+  %36 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %36, i16* %34, i32 %35)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:37                                      ; preds = %5, %16
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %39)
+  %41 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41, %System.String addrspace(1)* %38, %System.String addrspace(1)* %40)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41) #0
+  unreachable
+
+; <label>:42                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
-Failed to read StringBuilder.ToString[loadElemA]
+Successfully read StringBuilder.ToString
+
+define %System.String addrspace(1)* @StringBuilder.ToString(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i16*
+  %loc3 = alloca %"System.Char[]" addrspace(1)*
+  %loc4 = alloca i32
+  %loc5 = alloca i32
+  %loc6 = alloca i16 addrspace(1)*
+  %loc7 = alloca %System.String addrspace(1)*
+  %loc8 = alloca %"System.Char[]" addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %0)
+  %2 = icmp ne i32 %1, 0
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %4
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %6)
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %7)
+  store %System.String addrspace(1)* %8, %System.String addrspace(1)** %loc0
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.Text.StringBuilder addrspace(1)* %9, %System.Text.StringBuilder addrspace(1)** %loc1
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  store %System.String addrspace(1)* %10, %System.String addrspace(1)** %loc7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc7
+  %12 = ptrtoint %System.String addrspace(1)* %11 to i64
+  %13 = icmp eq i64 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %5
+  %15 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %16 = sext i32 %15 to i64
+  %17 = add i64 %12, %16
+  br label %18
+
+; <label>:18                                      ; preds = %5, %14
+  %19 = phi i64 [ %12, %5 ], [ %17, %14 ]
+  %20 = inttoptr i64 %19 to i16*
+  store i16* %20, i16** %loc2
+  br label %21
+
+; <label>:21                                      ; preds = %98, %18
+  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %22, null
+  br i1 %NullCheck, label %ThrowNullRef, label %23
+
+; <label>:23                                      ; preds = %21
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 3
+  %25 = load i32, i32 addrspace(1)* %24, align 8
+  %26 = icmp sle i32 %25, 0
+  br i1 %26, label %96, label %27
+
+; <label>:27                                      ; preds = %23
+  %28 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %28, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %29
+
+; <label>:29                                      ; preds = %27
+  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %28, i32 0, i32 1
+  %31 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %30, align 8
+  store %"System.Char[]" addrspace(1)* %31, %"System.Char[]" addrspace(1)** %loc3
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %33
+
+; <label>:33                                      ; preds = %29
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  store i32 %35, i32* %loc4
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  %39 = load i32, i32 addrspace(1)* %38, align 8
+  store i32 %39, i32* %loc5
+  %40 = load i32, i32* %loc5
+  %41 = load i32, i32* %loc4
+  %42 = add i32 %40, %41
+  %43 = zext i32 %42 to i64
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %45
+
+; <label>:45                                      ; preds = %37
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = sext i32 %47 to i64
+  %49 = icmp sgt i64 %43, %48
+  br i1 %49, label %91, label %50
+
+; <label>:50                                      ; preds = %45
+  %51 = load i32, i32* %loc5
+  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %52, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %53
+
+; <label>:53                                      ; preds = %50
+  %54 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %52, i32 0, i32 1
+  %55 = load i32, i32 addrspace(1)* %54
+  %56 = zext i32 %55 to i64
+  %57 = trunc i64 %56 to i32
+  %58 = icmp ugt i32 %51, %57
+  br i1 %58, label %91, label %59
+
+; <label>:59                                      ; preds = %53
+  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  store %"System.Char[]" addrspace(1)* %60, %"System.Char[]" addrspace(1)** %loc8
+  %61 = icmp eq %"System.Char[]" addrspace(1)* %60, null
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %63, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %64
+
+; <label>:64                                      ; preds = %62
+  %65 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %63, i32 0, i32 1
+  %66 = load i32, i32 addrspace(1)* %65
+  %67 = zext i32 %66 to i64
+  %68 = trunc i64 %67 to i32
+  %69 = icmp ne i32 %68, 0
+  br i1 %69, label %71, label %70
+
+; <label>:70                                      ; preds = %59, %64
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:71                                      ; preds = %64
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %73
+
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %BoundsCheck = icmp uge i64 0, %76
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %77
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %78, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:79                                      ; preds = %70, %77
+  %80 = load i16*, i16** %loc2
+  %81 = load i32, i32* %loc4
+  %82 = sext i32 %81 to i64
+  %83 = mul i64 %82, 2
+  %84 = bitcast i16* %80 to i8*
+  %85 = getelementptr inbounds i8, i8* %84, i64 %83
+  %86 = load i16 addrspace(1)*, i16 addrspace(1)** %loc6
+  %87 = ptrtoint i16 addrspace(1)* %86 to i64
+  %88 = load i32, i32* %loc5
+  %89 = bitcast i8* %85 to i16*
+  %90 = inttoptr i64 %87 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %89, i16* %90, i32 %88)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %96
+
+; <label>:91                                      ; preds = %45, %53
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %94 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %93)
+  %95 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95, %System.String addrspace(1)* %92, %System.String addrspace(1)* %94)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95) #0
+  unreachable
+
+; <label>:96                                      ; preds = %23, %79
+  %97 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %97, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %98
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %97, i32 0, i32 2
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  store %System.Text.StringBuilder addrspace(1)* %100, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %102 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %102, label %21, label %103
+
+; <label>:103                                     ; preds = %98
+  store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc7
+  %104 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  ret %System.String addrspace(1)* %104
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method StringBuilder::get_Length using LLILCJit
+Successfully read StringBuilder.get_Length
+
+define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
+Successfully read RuntimeHelpers.get_OffsetToStringData
+
+define i32 @RuntimeHelpers.get_OffsetToStringData() {
+entry:
+  ret i32 12
+}
+
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
 Successfully read CultureData.CreateCultureData
 
@@ -3514,23 +4249,23 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
   store i8 %4, i8 addrspace(1)* %6
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
@@ -3549,11 +4284,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3566,50 +4301,50 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
   store i32 -1, i32 addrspace(1)* %2
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
   store i32 -1, i32 addrspace(1)* %8
   %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
   store i32 -1, i32 addrspace(1)* %14
   %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
   store i32 -1, i32 addrspace(1)* %17
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
@@ -3623,27 +4358,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3675,7 +4410,136 @@ Failed to read Dictionary`2.Insert[non-const derefAddress]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
 Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
-Failed to read HashHelpers.GetPrime[loadElem]
+Successfully read HashHelpers.GetPrime
+
+define i32 @HashHelpers.GetPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %6, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5, %System.String addrspace(1)* %4)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5) #0
+  unreachable
+
+; <label>:6                                       ; preds = %entry
+  store i32 0, i32* %loc0
+  br label %29
+
+; <label>:7                                       ; preds = %35
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 1296
+  %10 = addrspacecast i8 addrspace(1)* %9 to %"System.Int32[]" addrspace(1)**
+  %11 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %10
+  %12 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Int32[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = zext i32 %15 to i64
+  %17 = zext i32 %12 to i64
+  %BoundsCheck = icmp uge i64 %17, %16
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 3, i32 %12
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  store i32 %20, i32* %loc1
+  %21 = load i32, i32* %loc1
+  %22 = load i32, i32* %arg0
+  %23 = icmp slt i32 %21, %22
+  br i1 %23, label %26, label %24
+
+; <label>:24                                      ; preds = %18
+  %25 = load i32, i32* %loc1
+  ret i32 %25
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %loc0
+  %28 = add i32 %27, 1
+  store i32 %28, i32* %loc0
+  br label %29
+
+; <label>:29                                      ; preds = %6, %26
+  %30 = load i32, i32* %loc0
+  %31 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %32 = getelementptr inbounds i8, i8 addrspace(1)* %31, i64 1296
+  %33 = addrspacecast i8 addrspace(1)* %32 to %"System.Int32[]" addrspace(1)**
+  %34 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %33
+  %NullCheck = icmp eq %"System.Int32[]" addrspace(1)* %34, null
+  br i1 %NullCheck, label %ThrowNullRef, label %35
+
+; <label>:35                                      ; preds = %29
+  %36 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %34, i32 0, i32 1
+  %37 = load i32, i32 addrspace(1)* %36
+  %38 = zext i32 %37 to i64
+  %39 = trunc i64 %38 to i32
+  %40 = icmp slt i32 %30, %39
+  br i1 %40, label %7, label %41
+
+; <label>:41                                      ; preds = %35
+  %42 = load i32, i32* %arg0
+  %43 = or i32 %42, 1
+  store i32 %43, i32* %loc2
+  br label %59
+
+; <label>:44                                      ; preds = %59
+  %45 = load i32, i32* %loc2
+  %46 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %45)
+  %47 = zext i8 %46 to i32
+  %48 = icmp eq i32 %47, 0
+  br i1 %48, label %56, label %49
+
+; <label>:49                                      ; preds = %44
+  %50 = load i32, i32* %loc2
+  %51 = sub i32 %50, 1
+  %52 = srem i32 %51, 101
+  %53 = icmp eq i32 %52, 0
+  br i1 %53, label %56, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = load i32, i32* %loc2
+  ret i32 %55
+
+; <label>:56                                      ; preds = %44, %49
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %57, 2
+  store i32 %58, i32* %loc2
+  br label %59
+
+; <label>:59                                      ; preds = %41, %56
+  %60 = load i32, i32* %loc2
+  %61 = icmp slt i32 %60, 2147483647
+  br i1 %61, label %44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load i32, i32* %arg0
+  ret i32 %63
+
+ThrowNullRef:                                     ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
 Successfully read GenericEqualityComparer`1.GetHashCode
 
@@ -3694,14 +4558,14 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
   %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load i64, i64 addrspace(1)* %7
@@ -3720,7 +4584,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3750,8 +4614,8 @@ entry:
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
@@ -3796,8 +4660,8 @@ entry:
   %35 = bitcast i16* %34 to i8*
   %36 = getelementptr inbounds i8, i8* %35, i64 2
   %37 = bitcast i8* %36 to i16*
-  %NullCheck4 = icmp ne i16* %37, null
-  br i1 %NullCheck4, label %38, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %37, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %38
 
 ; <label>:38                                      ; preds = %27
   %39 = load i16, i16* %37, align 8
@@ -3824,8 +4688,8 @@ entry:
 
 ; <label>:54                                      ; preds = %22, %43
   %55 = load i16*, i16** %loc4
-  %NullCheck2 = icmp ne i16* %55, null
-  br i1 %NullCheck2, label %56, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i16* %55, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %56
 
 ; <label>:56                                      ; preds = %54
   %57 = load i16, i16* %55, align 8
@@ -3850,11 +4714,11 @@ ThrowNullRef:                                     ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %54
+ThrowNullRef2:                                    ; preds = %54
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %27
+ThrowNullRef4:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3871,8 +4735,8 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -3907,8 +4771,8 @@ entry:
 
 ; <label>:26                                      ; preds = %19
   %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
-  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %28
 
 ; <label>:28                                      ; preds = %26
   %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
@@ -3920,7 +4784,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3972,8 +4836,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
@@ -3984,26 +4848,26 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
-  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
@@ -4014,8 +4878,8 @@ entry:
 ; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
@@ -4024,8 +4888,8 @@ entry:
 
 ; <label>:25                                      ; preds = %1, %16, %23
   %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
-  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
@@ -4036,27 +4900,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %20
+ThrowNullRef10:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4069,8 +4933,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -4081,8 +4945,8 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
@@ -4091,8 +4955,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1, %8
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
@@ -4103,11 +4967,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4128,24 +4992,24 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   store i32 %3, i32* %loc0
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
   %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
   store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck4, label %9, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
@@ -4164,15 +5028,15 @@ entry:
 ; <label>:18                                      ; preds = %70
   %19 = load i16*, i16** %loc3
   %20 = bitcast i16* %19 to i64*
-  %NullCheck10 = icmp ne i64* %20, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %20, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = load i64, i64* %20, align 8
   %23 = load i16*, i16** %loc4
   %24 = bitcast i16* %23 to i64*
-  %NullCheck12 = icmp ne i64* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = load i64, i64* %24, align 8
@@ -4188,8 +5052,8 @@ entry:
   %31 = bitcast i16* %30 to i8*
   %32 = getelementptr inbounds i8, i8* %31, i64 8
   %33 = bitcast i8* %32 to i64*
-  %NullCheck14 = icmp ne i64* %33, null
-  br i1 %NullCheck14, label %34, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = load i64, i64* %33, align 8
@@ -4197,8 +5061,8 @@ entry:
   %37 = bitcast i16* %36 to i8*
   %38 = getelementptr inbounds i8, i8* %37, i64 8
   %39 = bitcast i8* %38 to i64*
-  %NullCheck16 = icmp ne i64* %39, null
-  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %40
 
 ; <label>:40                                      ; preds = %34
   %41 = load i64, i64* %39, align 8
@@ -4214,8 +5078,8 @@ entry:
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %NullCheck18 = icmp ne i64* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = load i64, i64* %48, align 8
@@ -4223,8 +5087,8 @@ entry:
   %52 = bitcast i16* %51 to i8*
   %53 = getelementptr inbounds i8, i8* %52, i64 16
   %54 = bitcast i8* %53 to i64*
-  %NullCheck20 = icmp ne i64* %54, null
-  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64* %54, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %55
 
 ; <label>:55                                      ; preds = %49
   %56 = load i64, i64* %54, align 8
@@ -4262,15 +5126,15 @@ entry:
 ; <label>:74                                      ; preds = %95
   %75 = load i16*, i16** %loc3
   %76 = bitcast i16* %75 to i32*
-  %NullCheck6 = icmp ne i32* %76, null
-  br i1 %NullCheck6, label %77, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32* %76, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %77
 
 ; <label>:77                                      ; preds = %74
   %78 = load i32, i32* %76, align 8
   %79 = load i16*, i16** %loc4
   %80 = bitcast i16* %79 to i32*
-  %NullCheck8 = icmp ne i32* %80, null
-  br i1 %NullCheck8, label %81, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i32* %80, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %81
 
 ; <label>:81                                      ; preds = %77
   %82 = load i32, i32* %80, align 8
@@ -4318,43 +5182,43 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %74
+ThrowNullRef6:                                    ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %77
+ThrowNullRef8:                                    ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %29
+ThrowNullRef14:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %34
+ThrowNullRef16:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4376,8 +5240,8 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load i64, i64 addrspace(1)* %4
@@ -4389,8 +5253,8 @@ entry:
   %12 = load i64, i64* %11
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %5
   %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
@@ -4399,8 +5263,8 @@ entry:
   %18 = load i8, i8* %arg2
   %19 = zext i8 %18 to i32
   %20 = trunc i32 %19 to i8
-  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %15
   %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
@@ -4411,11 +5275,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4442,8 +5306,8 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
@@ -4466,16 +5330,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
   %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = load i64, i64 addrspace(1)* %19
@@ -4500,8 +5364,8 @@ entry:
 ; <label>:35                                      ; preds = %30
   %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
@@ -4514,8 +5378,8 @@ entry:
 
 ; <label>:42                                      ; preds = %1, %38
   %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
-  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
@@ -4526,19 +5390,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %35
+ThrowNullRef2:                                    ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %42
+ThrowNullRef8:                                    ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4551,14 +5415,14 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
@@ -4570,7 +5434,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4583,8 +5447,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
@@ -4613,51 +5477,51 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
   %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
   %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
   %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
   %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
-  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
   store i64 %21, i64 addrspace(1)* %23
   %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %25 = load i64, i64* %loc0
-  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
@@ -4668,27 +5532,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %22
+ThrowNullRef12:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4701,8 +5565,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
@@ -4713,19 +5577,19 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
@@ -4734,8 +5598,8 @@ entry:
 
 ; <label>:15                                      ; preds = %1, %13
   %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
@@ -4746,19 +5610,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %15
+ThrowNullRef8:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4771,8 +5635,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -4831,8 +5695,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
@@ -4882,8 +5746,8 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
-  br i1 %NullCheck, label %17, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %ThrowNullRef, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
@@ -4894,15 +5758,15 @@ entry:
 
 ; <label>:22                                      ; preds = %17
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
-  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
   %26 = load i32, i32 addrspace(1)* %25
   %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
-  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %27, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
@@ -4925,8 +5789,8 @@ entry:
 ; <label>:40                                      ; preds = %17
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
-  br i1 %NullCheck6, label %43, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %41, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
@@ -4938,34 +5802,17 @@ ThrowNullRef:                                     ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %24
+ThrowNullRef4:                                    ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %40
+ThrowNullRef6:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
-}
-
-INFO:  jitting method Object::ReferenceEquals using LLILCJit
-Successfully read Object.ReferenceEquals
-
-define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
-entry:
-  %arg0 = alloca %System.Object addrspace(1)*
-  %arg1 = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
-  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
-  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = icmp eq %System.Object addrspace(1)* %0, %1
-  %3 = sext i1 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
 }
 
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
@@ -4978,21 +5825,21 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
   %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
-  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
@@ -5007,28 +5854,28 @@ entry:
 ; <label>:13                                      ; preds = %8, %12
   %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
   %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
   %21 = load i32, i32 addrspace(1)* %20, align 8
   %22 = add i32 %21, 1
-  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
   store i32 %22, i32 addrspace(1)* %24
   %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
@@ -5039,27 +5886,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5077,7 +5924,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::Setup using LLILCJit
-Failed to read AppDomain.Setup[loadElem]
+Failed to read AppDomain.Setup[unbox]
 INFO:  jitting method Thread::GetDomain using LLILCJit
 Successfully read Thread.GetDomain
 
@@ -5108,8 +5955,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
@@ -5122,14 +5969,14 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
   %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
@@ -5141,11 +5988,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5173,8 +6020,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -5189,7 +6036,328 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
 Failed to read KeyCollection.System.Collections.Generic.IEnumerable<TKey>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Successfully read Enumerator.MoveNext
+
+define i8 @Enumerator.MoveNext(%"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.RuntimeTypeHandle* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*
+  %"$TypeArg" = alloca %System.RuntimeTypeHandle*
+  store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
+  %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 8
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %76, label %12
+
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
+  br label %76
+
+; <label>:13                                      ; preds = %85
+  %14 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck19 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %15
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, i32 0, i32 0
+  %17 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %16, align 8
+  %NullCheck21 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, i32 0, i32 2
+  %20 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %19, align 8
+  %21 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck23 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %22
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, i32 0, i32 2
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %NullCheck25 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 3, i32 %24
+  %NullCheck27 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %32
+
+; <label>:32                                      ; preds = %30
+  %33 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, i32 0, i32 2
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = icmp slt i32 %34, 0
+  br i1 %35, label %68, label %36
+
+; <label>:36                                      ; preds = %32
+  %37 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %38 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck29 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %39
+
+; <label>:39                                      ; preds = %36
+  %40 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, i32 0, i32 0
+  %41 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %40, align 8
+  %NullCheck31 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, i32 0, i32 2
+  %44 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %43, align 8
+  %45 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck33 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, i32 0, i32 2
+  %48 = load i32, i32 addrspace(1)* %47, align 8
+  %NullCheck35 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %49
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = zext i32 %51 to i64
+  %53 = zext i32 %48 to i64
+  %BoundsCheck37 = icmp uge i64 %53, %52
+  br i1 %BoundsCheck37, label %ThrowIndexOutOfRange38, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 3, i32 %48
+  %NullCheck39 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %56
+
+; <label>:56                                      ; preds = %54
+  %57 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, i32 0, i32 0
+  %58 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck41 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %59
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %60, %System.__Canon addrspace(1)* %58)
+  %61 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck43 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  %64 = load i32, i32 addrspace(1)* %63, align 8
+  %65 = add i32 %64, 1
+  %NullCheck45 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  store i32 %65, i32 addrspace(1)* %67
+  ret i8 1
+
+; <label>:68                                      ; preds = %32
+  %69 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck47 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %73 = add i32 %72, 1
+  %NullCheck49 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %74
+
+; <label>:74                                      ; preds = %70
+  %75 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  store i32 %73, i32 addrspace(1)* %75
+  br label %76
+
+; <label>:76                                      ; preds = %8, %12, %74
+  %77 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %78
+
+; <label>:78                                      ; preds = %76
+  %79 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, i32 0, i32 2
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck7 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %82
+
+; <label>:82                                      ; preds = %78
+  %83 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, i32 0, i32 0
+  %84 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %83, align 8
+  %NullCheck9 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %85
+
+; <label>:85                                      ; preds = %82
+  %86 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, i32 0, i32 7
+  %87 = load i32, i32 addrspace(1)* %86, align 8
+  %88 = icmp ult i32 %80, %87
+  br i1 %88, label %13, label %89
+
+; <label>:89                                      ; preds = %85
+  %90 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %91 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck11 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %92
+
+; <label>:92                                      ; preds = %89
+  %93 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, i32 0, i32 0
+  %94 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck13 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %95
+
+; <label>:95                                      ; preds = %92
+  %96 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, i32 0, i32 7
+  %97 = load i32, i32 addrspace(1)* %96, align 8
+  %98 = add i32 %97, 1
+  %NullCheck15 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %99
+
+; <label>:99                                      ; preds = %95
+  %100 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, i32 0, i32 2
+  store i32 %98, i32 addrspace(1)* %100
+  %101 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck17 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %102
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %103, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %92
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef22:                                   ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef24:                                   ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef26:                                   ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef28:                                   ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef30:                                   ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef32:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef34:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef36:                                   ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange38:                           ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef40:                                   ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef42:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef44:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef46:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef48:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef50:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -5200,8 +6368,8 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -5232,9 +6400,9 @@ Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
 Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
-Failed to read String.MakeSeparatorList[loadElemA]
+Failed to read String.MakeSeparatorList[storeElem]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
-Failed to read String.InternalSplitKeepEmptyEntries[loadElem]
+Failed to read String.InternalSplitKeepEmptyEntries[storeElem]
 INFO:  jitting method Path::IsRelative using LLILCJit
 Successfully read Path.IsRelative
 
@@ -5243,8 +6411,8 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -5254,8 +6422,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
@@ -5271,8 +6439,8 @@ entry:
 
 ; <label>:17                                      ; preds = %7
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
@@ -5288,8 +6456,8 @@ entry:
 
 ; <label>:29                                      ; preds = %19
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %31
 
 ; <label>:31                                      ; preds = %29
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
@@ -5300,8 +6468,8 @@ entry:
 
 ; <label>:36                                      ; preds = %31
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
-  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %37, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
@@ -5312,8 +6480,8 @@ entry:
 
 ; <label>:43                                      ; preds = %31, %38
   %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
-  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %45
 
 ; <label>:45                                      ; preds = %43
   %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
@@ -5324,8 +6492,8 @@ entry:
 
 ; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %50
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
@@ -5336,8 +6504,8 @@ entry:
 
 ; <label>:57                                      ; preds = %1, %7, %19, %45, %52
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
-  br i1 %NullCheck14, label %59, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %59
 
 ; <label>:59                                      ; preds = %57
   %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
@@ -5347,8 +6515,8 @@ entry:
 
 ; <label>:63                                      ; preds = %59
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
@@ -5359,8 +6527,8 @@ entry:
 
 ; <label>:70                                      ; preds = %65
   %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
-  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.String addrspace(1)* %71, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %72
 
 ; <label>:72                                      ; preds = %70
   %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
@@ -5379,39 +6547,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %17
+ThrowNullRef4:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %29
+ThrowNullRef6:                                    ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %36
+ThrowNullRef8:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %43
+ThrowNullRef10:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %50
+ThrowNullRef12:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %57
+ThrowNullRef14:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %63
+ThrowNullRef16:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %70
+ThrowNullRef18:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5419,7 +6587,293 @@ ThrowNullRef17:                                   ; preds = %70
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
-Failed to read String.TrimHelper[loadElem]
+Successfully read String.TrimHelper
+
+define %System.String addrspace(1)* @String.TrimHelper(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i16
+  %loc4 = alloca i32
+  %loc5 = alloca i16
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = sub i32 %3, 1
+  store i32 %4, i32* %loc0
+  store i32 0, i32* %loc1
+  %5 = load i32, i32* %arg2
+  %6 = icmp eq i32 %5, 1
+  br i1 %6, label %62, label %7
+
+; <label>:7                                       ; preds = %1
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:8                                       ; preds = %58
+  store i32 0, i32* %loc2
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load i32, i32* %loc1
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2, i32 %10
+  %13 = load i16, i16 addrspace(1)* %12
+  %14 = zext i16 %13 to i32
+  %15 = trunc i32 %14 to i16
+  store i16 %15, i16* %loc3
+  store i32 0, i32* %loc2
+  br label %34
+
+; <label>:16                                      ; preds = %37
+  %17 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %18 = load i32, i32* %loc2
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %17, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %19
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = zext i32 %18 to i64
+  %BoundsCheck = icmp uge i64 %23, %22
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %24
+
+; <label>:24                                      ; preds = %19
+  %25 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 3, i32 %18
+  %26 = load i16, i16 addrspace(1)* %25, align 8
+  %27 = zext i16 %26 to i32
+  %28 = load i16, i16* %loc3
+  %29 = zext i16 %28 to i32
+  %30 = icmp eq i32 %27, %29
+  br i1 %30, label %43, label %31
+
+; <label>:31                                      ; preds = %24
+  %32 = load i32, i32* %loc2
+  %33 = add i32 %32, 1
+  store i32 %33, i32* %loc2
+  br label %34
+
+; <label>:34                                      ; preds = %11, %31
+  %35 = load i32, i32* %loc2
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = icmp slt i32 %35, %41
+  br i1 %42, label %16, label %43
+
+; <label>:43                                      ; preds = %24, %37
+  %44 = load i32, i32* %loc2
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %45, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp eq i32 %44, %50
+  br i1 %51, label %62, label %52
+
+; <label>:52                                      ; preds = %46
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %7, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %57, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %58
+
+; <label>:58                                      ; preds = %55
+  %59 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %60 = load i32, i32 addrspace(1)* %59
+  %61 = icmp slt i32 %56, %60
+  br i1 %61, label %8, label %62
+
+; <label>:62                                      ; preds = %1, %46, %58
+  %63 = load i32, i32* %arg2
+  %64 = icmp eq i32 %63, 0
+  br i1 %64, label %122, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %66, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %67
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %66, i32 0, i32 1
+  %69 = load i32, i32 addrspace(1)* %68
+  %70 = sub i32 %69, 1
+  store i32 %70, i32* %loc0
+  br label %118
+
+; <label>:71                                      ; preds = %118
+  store i32 0, i32* %loc4
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %73 = load i32, i32* %loc0
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %74
+
+; <label>:74                                      ; preds = %71
+  %75 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 2, i32 %73
+  %76 = load i16, i16 addrspace(1)* %75
+  %77 = zext i16 %76 to i32
+  %78 = trunc i32 %77 to i16
+  store i16 %78, i16* %loc5
+  store i32 0, i32* %loc4
+  br label %97
+
+; <label>:79                                      ; preds = %100
+  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %81 = load i32, i32* %loc4
+  %NullCheck19 = icmp eq %"System.Char[]" addrspace(1)* %80, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
+
+; <label>:82                                      ; preds = %79
+  %83 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 1
+  %84 = load i32, i32 addrspace(1)* %83
+  %85 = zext i32 %84 to i64
+  %86 = zext i32 %81 to i64
+  %BoundsCheck21 = icmp uge i64 %86, %85
+  br i1 %BoundsCheck21, label %ThrowIndexOutOfRange22, label %87
+
+; <label>:87                                      ; preds = %82
+  %88 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 3, i32 %81
+  %89 = load i16, i16 addrspace(1)* %88, align 8
+  %90 = zext i16 %89 to i32
+  %91 = load i16, i16* %loc5
+  %92 = zext i16 %91 to i32
+  %93 = icmp eq i32 %90, %92
+  br i1 %93, label %106, label %94
+
+; <label>:94                                      ; preds = %87
+  %95 = load i32, i32* %loc4
+  %96 = add i32 %95, 1
+  store i32 %96, i32* %loc4
+  br label %97
+
+; <label>:97                                      ; preds = %74, %94
+  %98 = load i32, i32* %loc4
+  %99 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck15 = icmp eq %"System.Char[]" addrspace(1)* %99, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %100
+
+; <label>:100                                     ; preds = %97
+  %101 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %99, i32 0, i32 1
+  %102 = load i32, i32 addrspace(1)* %101
+  %103 = zext i32 %102 to i64
+  %104 = trunc i64 %103 to i32
+  %105 = icmp slt i32 %98, %104
+  br i1 %105, label %79, label %106
+
+; <label>:106                                     ; preds = %87, %100
+  %107 = load i32, i32* %loc4
+  %108 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck17 = icmp eq %"System.Char[]" addrspace(1)* %108, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %109
+
+; <label>:109                                     ; preds = %106
+  %110 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %108, i32 0, i32 1
+  %111 = load i32, i32 addrspace(1)* %110
+  %112 = zext i32 %111 to i64
+  %113 = trunc i64 %112 to i32
+  %114 = icmp eq i32 %107, %113
+  br i1 %114, label %122, label %115
+
+; <label>:115                                     ; preds = %109
+  %116 = load i32, i32* %loc0
+  %117 = sub i32 %116, 1
+  store i32 %117, i32* %loc0
+  br label %118
+
+; <label>:118                                     ; preds = %67, %115
+  %119 = load i32, i32* %loc0
+  %120 = load i32, i32* %loc1
+  %121 = icmp sge i32 %119, %120
+  br i1 %121, label %71, label %122
+
+; <label>:122                                     ; preds = %62, %109, %118
+  %123 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %124 = load i32, i32* %loc1
+  %125 = load i32, i32* %loc0
+  %126 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %123, i32 %124, i32 %125)
+  ret %System.String addrspace(1)* %126
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %97
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange22:                           ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
 Successfully read String.CreateTrimmedString
 
@@ -5439,8 +6893,8 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
@@ -5535,8 +6989,8 @@ entry:
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i64 2872
   %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
   %8 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %7
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %3
   %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
@@ -5553,8 +7007,8 @@ entry:
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 2864
   %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
   %21 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %20
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
-  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %22
 
 ; <label>:22                                      ; preds = %16
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
@@ -5569,7 +7023,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %16
+ThrowNullRef2:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5586,8 +7040,8 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5613,8 +7067,8 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
@@ -5632,8 +7086,8 @@ entry:
 
 ; <label>:12                                      ; preds = %4
   %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
@@ -5644,8 +7098,8 @@ entry:
 
 ; <label>:19                                      ; preds = %14
   %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %19
   %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
@@ -5660,21 +7114,21 @@ entry:
   %31 = zext i16 %30 to i32
   %32 = bitcast i8* %29 to i16*
   %33 = trunc i32 %31 to i16
-  %NullCheck6 = icmp ne i16* %32, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i16* %32, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %21
   store i16 %33, i16* %32, align 8
   %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %36
 
 ; <label>:36                                      ; preds = %34
   %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
   %38 = load i32, i32 addrspace(1)* %37, align 8
   %39 = add i32 %38, 1
-  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %40
 
 ; <label>:40                                      ; preds = %36
   %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
@@ -5683,16 +7137,16 @@ entry:
 
 ; <label>:42                                      ; preds = %14
   %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
-  br i1 %NullCheck12, label %44, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
   %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
   %47 = load i16, i16* %arg1
   %48 = zext i16 %47 to i32
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = trunc i32 %48 to i16
@@ -5703,31 +7157,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %19
+ThrowNullRef4:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %21
+ThrowNullRef6:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %36
+ThrowNullRef10:                                   ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %42
+ThrowNullRef12:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %44
+ThrowNullRef14:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5740,8 +7194,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -5752,8 +7206,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
@@ -5762,14 +7216,14 @@ entry:
 
 ; <label>:11                                      ; preds = %1
   %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
@@ -5779,15 +7233,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5808,8 +7262,8 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5822,8 +7276,8 @@ entry:
 
 ; <label>:8                                       ; preds = %3
   %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
@@ -5842,15 +7296,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
-  br i1 %NullCheck4, label %22, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
   %24 = load i16*, i16* addrspace(1)* %23, align 8
   %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %25, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
@@ -5859,8 +7313,8 @@ entry:
   store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
@@ -5874,8 +7328,8 @@ entry:
 
 ; <label>:37                                      ; preds = %65
   %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %37
   %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
@@ -5886,16 +7340,16 @@ entry:
   %45 = bitcast i16* %41 to i8*
   %46 = getelementptr inbounds i8, i8* %45, i64 %44
   %47 = bitcast i8* %46 to i16*
-  %NullCheck14 = icmp ne i16* %47, null
-  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %47, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %48
 
 ; <label>:48                                      ; preds = %39
   %49 = load i16, i16* %47, align 8
   %50 = zext i16 %49 to i32
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %52 = load i32, i32* %loc1
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %53
 
 ; <label>:53                                      ; preds = %48
   %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
@@ -5916,8 +7370,8 @@ entry:
 ; <label>:62                                      ; preds = %36, %59
   %63 = load i32, i32* %loc1
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck10, label %65, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %65
 
 ; <label>:65                                      ; preds = %62
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
@@ -5936,15 +7390,15 @@ entry:
 
 ; <label>:74                                      ; preds = %70
   %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
-  br i1 %NullCheck18, label %76, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %76
 
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
   %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
-  br i1 %NullCheck20, label %80, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
   %81 = load i64, i64 addrspace(1)* %79
@@ -5958,8 +7412,8 @@ entry:
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
   %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
-  br i1 %NullCheck22, label %92, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.String addrspace(1)* %90, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %92
 
 ; <label>:92                                      ; preds = %80
   %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
@@ -5969,15 +7423,15 @@ entry:
 
 ; <label>:96                                      ; preds = %70
   %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
-  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %98
 
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
   %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
-  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
   %103 = load i64, i64 addrspace(1)* %101
@@ -5991,8 +7445,8 @@ entry:
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
   %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
-  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.String addrspace(1)* %112, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %114
 
 ; <label>:114                                     ; preds = %102
   %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
@@ -6004,59 +7458,59 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %20
+ThrowNullRef4:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %22
+ThrowNullRef6:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %26
+ThrowNullRef8:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %62
+ThrowNullRef10:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %48
+ThrowNullRef16:                                   ; preds = %48
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %74
+ThrowNullRef18:                                   ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %76
+ThrowNullRef20:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %80
+ThrowNullRef22:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %96
+ThrowNullRef24:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %98
+ThrowNullRef26:                                   ; preds = %98
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %102
+ThrowNullRef28:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6069,15 +7523,15 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
   %3 = load i16*, i16* addrspace(1)* %2, align 8
   %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
@@ -6087,8 +7541,8 @@ entry:
   %10 = bitcast i16* %3 to i8*
   %11 = getelementptr inbounds i8, i8* %10, i64 %9
   %12 = bitcast i8* %11 to i16*
-  %NullCheck4 = icmp ne i16* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %5
   store i16 0, i16* %12, align 8
@@ -6098,11 +7552,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6119,8 +7573,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -6131,8 +7585,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
@@ -6144,15 +7598,15 @@ entry:
 
 ; <label>:14                                      ; preds = %1
   %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
   %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
   %21 = load i64, i64 addrspace(1)* %19
@@ -6171,15 +7625,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %14
+ThrowNullRef4:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %16
+ThrowNullRef6:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6302,14 +7756,6 @@ entry:
   ret %System.String addrspace(1)* %57
 }
 
-INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
-Successfully read RuntimeHelpers.get_OffsetToStringData
-
-define i32 @RuntimeHelpers.get_OffsetToStringData() {
-entry:
-  ret i32 12
-}
-
 INFO:  jitting method String::Equals using LLILCJit
 Successfully read String.Equals
 
@@ -6381,8 +7827,8 @@ entry:
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
-  br i1 %NullCheck24, label %29, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
   %30 = load i64, i64 addrspace(1)* %28
@@ -6397,8 +7843,8 @@ entry:
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
-  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
   %43 = load i64, i64 addrspace(1)* %41
@@ -6418,8 +7864,8 @@ entry:
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
   %59 = load i64, i64 addrspace(1)* %57
@@ -6434,8 +7880,8 @@ entry:
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck22, label %71, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
   %72 = load i64, i64 addrspace(1)* %70
@@ -6455,8 +7901,8 @@ entry:
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
-  br i1 %NullCheck16, label %87, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = load i64, i64 addrspace(1)* %86
@@ -6471,8 +7917,8 @@ entry:
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck18, label %100, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
   %101 = load i64, i64 addrspace(1)* %99
@@ -6492,8 +7938,8 @@ entry:
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
-  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
   %117 = load i64, i64 addrspace(1)* %115
@@ -6508,8 +7954,8 @@ entry:
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
-  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
   %130 = load i64, i64 addrspace(1)* %128
@@ -6528,15 +7974,15 @@ entry:
 
 ; <label>:142                                     ; preds = %22
   %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
-  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %143, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %144
 
 ; <label>:144                                     ; preds = %142
   %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
   %146 = load i32, i32 addrspace(1)* %145
   %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
-  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %147, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %148
 
 ; <label>:148                                     ; preds = %144
   %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
@@ -6557,15 +8003,15 @@ entry:
 
 ; <label>:159                                     ; preds = %22
   %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
-  br i1 %NullCheck, label %161, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %ThrowNullRef, label %161
 
 ; <label>:161                                     ; preds = %159
   %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
   %163 = load i32, i32 addrspace(1)* %162
   %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
-  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %164, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %165
 
 ; <label>:165                                     ; preds = %161
   %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
@@ -6578,8 +8024,8 @@ entry:
 
 ; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
-  br i1 %NullCheck4, label %172, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %171, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %172
 
 ; <label>:172                                     ; preds = %170
   %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
@@ -6589,8 +8035,8 @@ entry:
 
 ; <label>:176                                     ; preds = %172
   %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
-  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %177, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %178
 
 ; <label>:178                                     ; preds = %176
   %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
@@ -6629,55 +8075,55 @@ ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %161
+ThrowNullRef2:                                    ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %170
+ThrowNullRef4:                                    ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %176
+ThrowNullRef6:                                    ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %142
+ThrowNullRef8:                                    ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %144
+ThrowNullRef10:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %113
+ThrowNullRef12:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %116
+ThrowNullRef14:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %84
+ThrowNullRef16:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %87
+ThrowNullRef18:                                   ; preds = %87
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %55
+ThrowNullRef20:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %58
+ThrowNullRef22:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %26
+ThrowNullRef24:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %29
+ThrowNullRef26:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,8 +8161,8 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck, label %14, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %ThrowNullRef, label %14
 
 ; <label>:14                                      ; preds = %8
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
@@ -6760,8 +8206,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
@@ -6770,14 +8216,14 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32, i32* %loc0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %10
   %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
   %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
@@ -6790,15 +8236,15 @@ entry:
 ; <label>:25                                      ; preds = %19
   %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
-  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
   %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
@@ -6807,8 +8253,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %37 = load i32, i32* %loc0
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %38, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %38
 
 ; <label>:38                                      ; preds = %32
   %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
@@ -6817,14 +8263,14 @@ entry:
 
 ; <label>:40                                      ; preds = %19
   %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %40
   %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
   %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
-  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
-  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
@@ -6832,8 +8278,8 @@ entry:
   %48 = zext i32 %47 to i64
   %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
-  br i1 %NullCheck16, label %51, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %51
 
 ; <label>:51                                      ; preds = %45
   %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
@@ -6847,15 +8293,15 @@ entry:
 ; <label>:57                                      ; preds = %51
   %58 = load i16*, i16** %arg1
   %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
-  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %60
 
 ; <label>:60                                      ; preds = %57
   %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
   %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
-  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %64
 
 ; <label>:64                                      ; preds = %60
   %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
@@ -6864,22 +8310,22 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
   %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
-  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %70
 
 ; <label>:70                                      ; preds = %64
   %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
   %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
-  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
-  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
   %75 = load i32, i32 addrspace(1)* %74
   %76 = zext i32 %75 to i64
   %77 = trunc i64 %76 to i32
-  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
-  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %78
 
 ; <label>:78                                      ; preds = %73
   %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
@@ -6901,8 +8347,8 @@ entry:
   %90 = bitcast i16* %86 to i8*
   %91 = getelementptr inbounds i8, i8* %90, i64 %89
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %93
 
 ; <label>:93                                      ; preds = %80
   %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
@@ -6912,8 +8358,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %99 = load i32, i32* %loc2
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %100
 
 ; <label>:100                                     ; preds = %93
   %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
@@ -6928,63 +8374,63 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %25
+ThrowNullRef6:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %32
+ThrowNullRef10:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %40
+ThrowNullRef12:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %45
+ThrowNullRef16:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %57
+ThrowNullRef18:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %60
+ThrowNullRef20:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %64
+ThrowNullRef22:                                   ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %70
+ThrowNullRef24:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %73
+ThrowNullRef26:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %80
+ThrowNullRef28:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %93
+ThrowNullRef30:                                   ; preds = %93
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7004,8 +8450,8 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
@@ -7033,43 +8479,43 @@ entry:
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %14
   %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
   %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   %28 = load i32, i32 addrspace(1)* %27, align 8
   %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
-  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %30
 
 ; <label>:30                                      ; preds = %26
   %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
   %32 = load i32, i32 addrspace(1)* %31, align 8
   %33 = add i32 %28, %32
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %34
 
 ; <label>:34                                      ; preds = %30
   %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   store i32 %33, i32 addrspace(1)* %35
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
   store i32 0, i32 addrspace(1)* %38
   %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %40
 
 ; <label>:40                                      ; preds = %37
   %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
@@ -7082,8 +8528,8 @@ entry:
 
 ; <label>:47                                      ; preds = %40
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
@@ -7098,8 +8544,8 @@ entry:
   %54 = load i32, i32* %loc0
   %55 = sext i32 %54 to i64
   %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
-  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %57
 
 ; <label>:57                                      ; preds = %52
   %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
@@ -7110,68 +8556,35 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %14
+ThrowNullRef2:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %23
+ThrowNullRef4:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %26
+ThrowNullRef6:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %30
+ThrowNullRef8:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %34
+ThrowNullRef10:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %47
+ThrowNullRef14:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %52
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-}
-
-INFO:  jitting method StringBuilder::get_Length using LLILCJit
-Successfully read StringBuilder.get_Length
-
-define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.StringBuilder addrspace(1)*
-  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
-  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
-
-; <label>:1                                       ; preds = %entry
-  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %3 = load i32, i32 addrspace(1)* %2, align 8
-  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
-
-; <label>:5                                       ; preds = %1
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = add i32 %3, %7
-  ret i32 %8
-
-ThrowNullRef:                                     ; preds = %entry
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef16:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7213,70 +8626,70 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
   %6 = load i32, i32 addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
   store i32 %6, i32 addrspace(1)* %8
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
   %13 = load i32, i32 addrspace(1)* %12, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
   store i32 %13, i32 addrspace(1)* %15
   %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
-  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %18
 
 ; <label>:18                                      ; preds = %14
   %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
   %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
   %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
   %34 = load i32, i32 addrspace(1)* %33, align 8
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
-  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
@@ -7287,39 +8700,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %28
+ThrowNullRef16:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %32
+ThrowNullRef18:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7455,13 +8868,13 @@ entry:
 ; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
@@ -7477,16 +8890,16 @@ entry:
 
 ; <label>:18                                      ; preds = %15
   %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
   store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
   %22 = load i32, i32* %loc0
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %24
 
 ; <label>:24                                      ; preds = %20
   %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
@@ -7498,13 +8911,13 @@ entry:
 ; <label>:28                                      ; preds = %15, %24
   %29 = load i32, i32* %arg1
   %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %31
   %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
@@ -7517,20 +8930,20 @@ entry:
   %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
-  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
   %46 = load i32, i32 addrspace(1)* %45, align 8
   %47 = sub i32 %40, %46
-  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
-  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i32 addrspace(1)* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %48
 
 ; <label>:48                                      ; preds = %44
   store i32 %47, i32 addrspace(1)* %39, align 8
@@ -7538,21 +8951,21 @@ entry:
 
 ; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
-  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %51
 
 ; <label>:51                                      ; preds = %49
   %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %53
 
 ; <label>:53                                      ; preds = %51
   %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
   %55 = load i32, i32 addrspace(1)* %54, align 8
   %56 = load i32, i32* %arg2
   %57 = sub i32 %55, %56
-  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %58
 
 ; <label>:58                                      ; preds = %53
   %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
@@ -7562,13 +8975,13 @@ entry:
 ; <label>:60                                      ; preds = %33, %58
   %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
   %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
-  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %63
 
 ; <label>:63                                      ; preds = %60
   %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
-  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
-  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
@@ -7578,15 +8991,15 @@ entry:
 
 ; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
-  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i32 addrspace(1)* %69, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %70
 
 ; <label>:70                                      ; preds = %68
   %71 = load i32, i32 addrspace(1)* %69, align 8
   store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
-  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
@@ -7596,8 +9009,8 @@ entry:
   store i32 %77, i32* %loc4
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
-  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %80
 
 ; <label>:80                                      ; preds = %73
   %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
@@ -7607,71 +9020,71 @@ entry:
 ; <label>:83                                      ; preds = %80
   store i32 0, i32* %loc3
   %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
-  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
-  br i1 %NullCheck26, label %88, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i32 addrspace(1)* %87, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %88
 
 ; <label>:88                                      ; preds = %85
   %89 = load i32, i32 addrspace(1)* %87, align 8
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
-  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %90
 
 ; <label>:90                                      ; preds = %88
   %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
   store i32 %89, i32 addrspace(1)* %91
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
-  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
-  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %96
 
 ; <label>:96                                      ; preds = %94
   %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
-  br i1 %NullCheck34, label %100, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %100
 
 ; <label>:100                                     ; preds = %96
   %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
-  br i1 %NullCheck36, label %102, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %102
 
 ; <label>:102                                     ; preds = %100
   %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
   %104 = load i32, i32 addrspace(1)* %103, align 8
   %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
-  br i1 %NullCheck38, label %106, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %106
 
 ; <label>:106                                     ; preds = %102
   %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
-  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
-  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %108
 
 ; <label>:108                                     ; preds = %106
   %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
   %110 = load i32, i32 addrspace(1)* %109, align 8
   %111 = add i32 %104, %110
-  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %112
 
 ; <label>:112                                     ; preds = %108
   %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
   store i32 %111, i32 addrspace(1)* %113
   %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
-  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i32 addrspace(1)* %114, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %115
 
 ; <label>:115                                     ; preds = %112
   %116 = load i32, i32 addrspace(1)* %114, align 8
@@ -7681,19 +9094,19 @@ entry:
 ; <label>:118                                     ; preds = %115
   %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
-  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %121
 
 ; <label>:121                                     ; preds = %118
   %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
-  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
-  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %123
 
 ; <label>:123                                     ; preds = %121
   %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
   %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
-  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
-  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %126
 
 ; <label>:126                                     ; preds = %123
   %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
@@ -7705,8 +9118,8 @@ entry:
 
 ; <label>:130                                     ; preds = %80, %115, %126
   %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %132
 
 ; <label>:132                                     ; preds = %130
   %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7715,8 +9128,8 @@ entry:
   %136 = load i32, i32* %loc3
   %137 = sub i32 %135, %136
   %138 = sub i32 %134, %137
-  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %139
 
 ; <label>:139                                     ; preds = %132
   %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7728,16 +9141,16 @@ entry:
 
 ; <label>:144                                     ; preds = %139
   %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
-  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %146
 
 ; <label>:146                                     ; preds = %144
   %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
   %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
   %149 = load i32, i32* %loc2
   %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
-  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %151
 
 ; <label>:151                                     ; preds = %146
   %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
@@ -7754,145 +9167,249 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %18
+ThrowNullRef4:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %31
+ThrowNullRef10:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %44
+ThrowNullRef16:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %68
+ThrowNullRef18:                                   ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %70
+ThrowNullRef20:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %73
+ThrowNullRef22:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %83
+ThrowNullRef24:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %85
+ThrowNullRef26:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %88
+ThrowNullRef28:                                   ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %90
+ThrowNullRef30:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %94
+ThrowNullRef32:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %96
+ThrowNullRef34:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %100
+ThrowNullRef36:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %102
+ThrowNullRef38:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %106
+ThrowNullRef40:                                   ; preds = %106
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %108
+ThrowNullRef42:                                   ; preds = %108
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %112
+ThrowNullRef44:                                   ; preds = %112
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %118
+ThrowNullRef46:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %121
+ThrowNullRef48:                                   ; preds = %121
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %123
+ThrowNullRef50:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %130
+ThrowNullRef52:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %132
+ThrowNullRef54:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %144
+ThrowNullRef56:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %146
+ThrowNullRef58:                                   ; preds = %146
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %60
+ThrowNullRef60:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %63
+ThrowNullRef62:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %49
+ThrowNullRef64:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %51
+ThrowNullRef66:                                   ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %53
+ThrowNullRef68:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(%"System.Char[]" addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %arg0 = alloca %"System.Char[]" addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store %"System.Char[]" addrspace(1)* %param0, %"System.Char[]" addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load i32, i32* %arg4
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %43, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %38, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg1
+  %13 = load i32, i32* %arg4
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %38, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %24 = load i32, i32* %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %35 = load i32, i32* %arg3
+  %36 = load i32, i32* %arg4
+  %37 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %37, %"System.Char[]" addrspace(1)* %34, i32 %35, i32 %36)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:38                                      ; preds = %5, %16
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Successfully read Buffer._Memmove
 
@@ -7914,7 +9431,7 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[loadElem]
+Failed to read AppDomain.SetDataHelper[storeElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -7923,8 +9440,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
@@ -7934,8 +9451,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
@@ -7947,15 +9464,15 @@ entry:
   %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
   %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
@@ -7966,15 +9483,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7992,7 +9509,79 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
-Failed to read Dictionary`2.TryGetValue[loadElemA]
+Successfully read Dictionary`2.TryGetValue
+
+define i8 @"Dictionary`2.TryGetValue"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)* addrspace(1)* %param2) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  %arg2 = alloca %System.__Canon addrspace(1)* addrspace(1)*
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  store %System.__Canon addrspace(1)* addrspace(1)* %param2, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  store i32 %2, i32* %loc0
+  %3 = load i32, i32* %loc0
+  %4 = icmp slt i32 %3, 0
+  br i1 %4, label %22, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 2
+  %10 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %9, align 8
+  %11 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = zext i32 %11 to i64
+  %BoundsCheck = icmp uge i64 %16, %15
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 3, i32 %11
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %20, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %6, %System.__Canon addrspace(1)* %21)
+  ret i8 1
+
+; <label>:22                                      ; preds = %entry
+  %23 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %23, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -8058,8 +9647,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
@@ -8091,8 +9680,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
@@ -8171,15 +9760,15 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck, label %19, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %ThrowNullRef, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
   %21 = load i32, i32 addrspace(1)* %20
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
@@ -8202,7 +9791,7 @@ ThrowNullRef:                                     ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %19
+ThrowNullRef2:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8248,8 +9837,8 @@ entry:
   %0 = alloca %System.AppDomainHandle
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %1 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %1, i32 0, i32 15
@@ -8269,8 +9858,8 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
@@ -8286,7 +9875,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -8299,8 +9888,8 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -8327,8 +9916,8 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
@@ -8352,8 +9941,8 @@ entry:
   %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
   store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
@@ -8363,8 +9952,8 @@ entry:
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
@@ -8374,8 +9963,8 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %9
   %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
@@ -8384,8 +9973,8 @@ entry:
 
 ; <label>:18                                      ; preds = %3, %16
   %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
@@ -8397,15 +9986,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %18
+ThrowNullRef6:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8418,8 +10007,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
@@ -8453,15 +10042,15 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
@@ -8473,7 +10062,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8481,7 +10070,7 @@ ThrowNullRef1:                                    ; preds = %1
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
 Failed to read Dictionary`2.System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
@@ -8506,8 +10095,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
@@ -8524,8 +10113,8 @@ entry:
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -8544,7 +10133,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8577,8 +10166,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = load i64, i64* %arg2
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = trunc i32 %3 to i8
@@ -8634,46 +10223,46 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
   %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
-  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
-  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
-  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
@@ -8684,27 +10273,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %20
+ThrowNullRef12:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8717,8 +10306,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -8756,22 +10345,22 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
   %9 = load i64, i64 addrspace(1)* %8, align 8
   %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
   %13 = load i64, i64 addrspace(1)* %12, align 8
   %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %11
   %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
@@ -8788,11 +10377,11 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8882,8 +10471,8 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
@@ -8900,8 +10489,8 @@ entry:
 ; <label>:8                                       ; preds = %1
   %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
   %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
@@ -8911,15 +10500,15 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
   %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
   %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
-  br i1 %NullCheck6, label %21, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
@@ -8946,15 +10535,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8992,15 +10581,15 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
   store i8 %3, i8 addrspace(1)* %5
   %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
@@ -9011,7 +10600,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9027,8 +10616,8 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -9041,8 +10630,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
@@ -9058,7 +10647,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9080,8 +10669,8 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
@@ -9096,8 +10685,8 @@ entry:
 ; <label>:12                                      ; preds = %6
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
@@ -9112,8 +10701,8 @@ entry:
 ; <label>:21                                      ; preds = %15
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
@@ -9128,8 +10717,8 @@ entry:
 ; <label>:30                                      ; preds = %24
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %31, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
@@ -9144,8 +10733,8 @@ entry:
 ; <label>:39                                      ; preds = %33
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
-  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %40, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %42
 
 ; <label>:42                                      ; preds = %39
   %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
@@ -9164,19 +10753,19 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %21
+ThrowNullRef4:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %30
+ThrowNullRef6:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %39
+ThrowNullRef8:                                    ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9243,8 +10832,8 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
@@ -9264,57 +10853,57 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
   store i8 0, i8 addrspace(1)* %2
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
   store i8 0, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
   store i8 0, i8 addrspace(1)* %17
   %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
   store i8 0, i8 addrspace(1)* %20
   %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
-  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
@@ -9325,31 +10914,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %19
+ThrowNullRef14:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9367,8 +10956,8 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
@@ -9380,8 +10969,8 @@ entry:
 
 ; <label>:9                                       ; preds = %4
   %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %9
   %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
@@ -9395,7 +10984,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef2:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9420,8 +11009,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
@@ -9512,8 +11101,8 @@ entry:
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
@@ -9524,8 +11113,8 @@ entry:
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = load i64, i64 addrspace(1)* %12
@@ -9537,8 +11126,8 @@ entry:
   %20 = load i64, i64* %19
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
-  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %13
   %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
@@ -9555,8 +11144,8 @@ entry:
 ; <label>:30                                      ; preds = %25
   %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %32 = load i32, i32* %arg2
-  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
-  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
@@ -9570,15 +11159,15 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %30
+ThrowNullRef2:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9622,87 +11211,87 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
   %10 = load i8, i8 addrspace(1)* %9, align 8
   %11 = zext i8 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %8
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
   store i8 %12, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
   %19 = load i8, i8 addrspace(1)* %18, align 8
   %20 = zext i8 %19 to i32
   %21 = trunc i32 %20 to i8
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
   store i8 %21, i8 addrspace(1)* %23
   %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
   %28 = load i8, i8 addrspace(1)* %27, align 8
   %29 = zext i8 %28 to i32
   %30 = trunc i32 %29 to i8
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
-  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %31
 
 ; <label>:31                                      ; preds = %26
   %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
   store i8 %30, i8 addrspace(1)* %32
   %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
-  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
-  br i1 %NullCheck14, label %40, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %40
 
 ; <label>:40                                      ; preds = %35
   %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
   store i8 %39, i8 addrspace(1)* %41
   %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
-  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %44
 
 ; <label>:44                                      ; preds = %40
   %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
   %46 = load i8, i8 addrspace(1)* %45, align 8
   %47 = zext i8 %46 to i32
   %48 = trunc i32 %47 to i8
-  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
   store i8 %48, i8 addrspace(1)* %50
   %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
-  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
@@ -9713,29 +11302,29 @@ entry:
 ; <label>:56                                      ; preds = %52
   %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
-  br i1 %NullCheck22, label %59, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
   %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
   %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
-  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
-  br i1 %NullCheck24, label %63, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
   %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
-  br i1 %NullCheck26, label %66, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
   %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
-  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
-  br i1 %NullCheck28, label %69, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %69
 
 ; <label>:69                                      ; preds = %66
   %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
@@ -9744,15 +11333,15 @@ entry:
 
 ; <label>:71                                      ; preds = %105
   %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
-  br i1 %NullCheck34, label %73, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %73
 
 ; <label>:73                                      ; preds = %71
   %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
   %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
   %76 = load i32, i32* %loc0
-  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
-  br i1 %NullCheck36, label %77, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
@@ -9766,8 +11355,8 @@ entry:
 
 ; <label>:83                                      ; preds = %77
   %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
-  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
@@ -9775,14 +11364,14 @@ entry:
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
   %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
-  br i1 %NullCheck40, label %91, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
 ; <label>:91                                      ; preds = %85
   %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
   %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
-  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck42, label %94, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %94
 
 ; <label>:94                                      ; preds = %91
   %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
@@ -9798,14 +11387,14 @@ entry:
 ; <label>:99                                      ; preds = %69, %96
   %100 = load i32, i32* %loc0
   %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
-  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %102
 
 ; <label>:102                                     ; preds = %99
   %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
   %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
-  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
-  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
@@ -9819,87 +11408,87 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %26
+ThrowNullRef10:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %31
+ThrowNullRef12:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %35
+ThrowNullRef14:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %40
+ThrowNullRef16:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %56
+ThrowNullRef22:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %59
+ThrowNullRef24:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %63
+ThrowNullRef26:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %66
+ThrowNullRef28:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %102
+ThrowNullRef32:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %71
+ThrowNullRef34:                                   ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %73
+ThrowNullRef36:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %83
+ThrowNullRef38:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %85
+ThrowNullRef40:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %91
+ThrowNullRef42:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9943,15 +11532,15 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
   %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
@@ -9961,28 +11550,28 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
   %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %12
   %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
   %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
   %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
-  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
@@ -9993,23 +11582,23 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %12
+ThrowNullRef6:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10031,15 +11620,15 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
   %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = load i64, i64 addrspace(1)* %7
@@ -10077,13 +11666,13 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[loadElem]
+Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -10111,8 +11700,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -10182,8 +11771,8 @@ entry:
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load float, float* %arg0
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -10317,8 +11906,8 @@ entry:
   store i64 %param0, i64* %arg0
   store i64 %param1, i64* %arg1
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
@@ -10326,8 +11915,8 @@ entry:
   %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
   %5 = load i16*, i16* addrspace(1)* %4, align 8
   %6 = addrspacecast i64* %arg1 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = bitcast i64 addrspace(1)* %6 to i8 addrspace(1)*
@@ -10343,7 +11932,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10377,8 +11966,8 @@ entry:
   %1 = load i32, i32* %arg1
   %2 = sext i32 %1 to i64
   %3 = inttoptr i64 %2 to i16*
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -10431,8 +12020,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, i32)*)(%System.IO.ConsoleStream addrspace(1)* %2, i32 %1)
   %3 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %4 = load i64, i64* %arg1
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
@@ -10443,8 +12032,8 @@ entry:
   %10 = icmp eq i32 %9, 3
   %11 = sext i1 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %5
   %14 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, i32 0, i32 5
@@ -10455,7 +12044,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10478,8 +12067,8 @@ entry:
   %5 = icmp eq i32 %4, 1
   %6 = sext i1 %5 to i32
   %7 = trunc i32 %6 to i8
-  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %2, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.ConsoleStream addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
@@ -10490,8 +12079,8 @@ entry:
   %13 = icmp eq i32 %12, 2
   %14 = sext i1 %13 to i32
   %15 = trunc i32 %14 to i8
-  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %10, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.ConsoleStream addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %8
   %17 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %10, i32 0, i32 4
@@ -10502,7 +12091,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10541,8 +12130,8 @@ entry:
   %arg0 = alloca i64
   store i64 %param0, i64* %arg0
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
@@ -10577,8 +12166,8 @@ entry:
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
   %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = load i64, i64 addrspace(1)* %7
@@ -10682,7 +12271,127 @@ entry:
 INFO:  jitting method Encoding::GetEncoding using LLILCJit
 Failed to read Encoding.GetEncoding[convertToHelperArgumentType]
 INFO:  jitting method EncodingProvider::GetEncodingFromProvider using LLILCJit
-Failed to read EncodingProvider.GetEncodingFromProvider[loadElem]
+Successfully read EncodingProvider.GetEncodingFromProvider
+
+define %System.Text.Encoding addrspace(1)* @EncodingProvider.GetEncodingFromProvider(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca %"System.Text.EncodingProvider[]" addrspace(1)*
+  %loc1 = alloca %System.Text.EncodingProvider addrspace(1)*
+  %loc2 = alloca %System.Text.Encoding addrspace(1)*
+  %loc3 = alloca %System.Text.Encoding addrspace(1)*
+  %loc4 = alloca %"System.Text.EncodingProvider[]" addrspace(1)*
+  %loc5 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1059)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2392
+  %2 = addrspacecast i8 addrspace(1)* %1 to %"System.Text.EncodingProvider[]" addrspace(1)**
+  %3 = load volatile %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %2
+  %4 = icmp ne %"System.Text.EncodingProvider[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %entry
+  ret %System.Text.Encoding addrspace(1)* null
+
+; <label>:6                                       ; preds = %entry
+  %7 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1059)
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i64 2392
+  %9 = addrspacecast i8 addrspace(1)* %8 to %"System.Text.EncodingProvider[]" addrspace(1)**
+  %10 = load volatile %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %9
+  store %"System.Text.EncodingProvider[]" addrspace(1)* %10, %"System.Text.EncodingProvider[]" addrspace(1)** %loc0
+  %11 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc0
+  store %"System.Text.EncodingProvider[]" addrspace(1)* %11, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  store i32 0, i32* %loc5
+  br label %43
+
+; <label>:12                                      ; preds = %46
+  %13 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  %14 = load i32, i32* %loc5
+  %NullCheck1 = icmp eq %"System.Text.EncodingProvider[]" addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %13, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = zext i32 %17 to i64
+  %19 = zext i32 %14 to i64
+  %BoundsCheck = icmp uge i64 %19, %18
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %20
+
+; <label>:20                                      ; preds = %15
+  %21 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %13, i32 0, i32 3, i32 %14
+  %22 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)* addrspace(1)* %21, align 8
+  store %System.Text.EncodingProvider addrspace(1)* %22, %System.Text.EncodingProvider addrspace(1)** %loc1
+  %23 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)** %loc1
+  %24 = load i32, i32* %arg0
+  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i64 addrspace(1)*
+  %NullCheck3 = icmp eq i64 addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
+
+; <label>:26                                      ; preds = %20
+  %27 = load i64, i64 addrspace(1)* %25
+  %28 = add i64 %27, 64
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 40
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Text.Encoding addrspace(1)* (%System.Text.EncodingProvider addrspace(1)*, i32)*
+  %35 = call %System.Text.Encoding addrspace(1)* %34(%System.Text.EncodingProvider addrspace(1)* %23, i32 %24)
+  store %System.Text.Encoding addrspace(1)* %35, %System.Text.Encoding addrspace(1)** %loc2
+  %36 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc2
+  %37 = icmp eq %System.Text.Encoding addrspace(1)* %36, null
+  br i1 %37, label %40, label %38
+
+; <label>:38                                      ; preds = %26
+  %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc2
+  store %System.Text.Encoding addrspace(1)* %39, %System.Text.Encoding addrspace(1)** %loc3
+  br label %53
+
+; <label>:40                                      ; preds = %26
+  %41 = load i32, i32* %loc5
+  %42 = add i32 %41, 1
+  store i32 %42, i32* %loc5
+  br label %43
+
+; <label>:43                                      ; preds = %6, %40
+  %44 = load i32, i32* %loc5
+  %45 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  %NullCheck = icmp eq %"System.Text.EncodingProvider[]" addrspace(1)* %45, null
+  br i1 %NullCheck, label %ThrowNullRef, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp slt i32 %44, %50
+  br i1 %51, label %12, label %52
+
+; <label>:52                                      ; preds = %46
+  ret %System.Text.Encoding addrspace(1)* null
+
+; <label>:53                                      ; preds = %38
+  %54 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc3
+  ret %System.Text.Encoding addrspace(1)* %54
+
+ThrowNullRef:                                     ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method EncodingProvider::.cctor using LLILCJit
 Successfully read EncodingProvider..cctor
 
@@ -10701,7 +12410,7 @@ Failed to read Encoding.get_InternalSyncObject[Call HasTypeArg]
 INFO:  jitting method Hashtable::.ctor using LLILCJit
 Failed to read Hashtable..ctor[Volatile store]
 INFO:  jitting method Hashtable::get_Item using LLILCJit
-Failed to read Hashtable.get_Item[loadElemA]
+Failed to read Hashtable.get_Item[loadNonPrimitiveObj]
 INFO:  jitting method Hashtable::InitHash using LLILCJit
 Successfully read Hashtable.InitHash
 
@@ -10721,8 +12430,8 @@ entry:
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -10738,15 +12447,15 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
   %15 = load i32, i32* %loc0
-  %NullCheck2 = icmp ne i32 addrspace(1)* %14, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i32 addrspace(1)* %14, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %3
   store i32 %15, i32 addrspace(1)* %14, align 8
   %17 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %18 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %NullCheck4 = icmp ne i32 addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i32 addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = load i32, i32 addrspace(1)* %18, align 8
@@ -10755,8 +12464,8 @@ entry:
   %23 = sub i32 %22, 1
   %24 = urem i32 %21, %23
   %25 = add i32 1, %24
-  %NullCheck6 = icmp ne i32 addrspace(1)* %17, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32 addrspace(1)* %17, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %19
   store i32 %25, i32 addrspace(1)* %17, align 8
@@ -10767,15 +12476,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %19
+ThrowNullRef6:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10790,8 +12499,8 @@ entry:
   store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
   store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %NullCheck = icmp ne %System.Collections.Hashtable addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Collections.Hashtable addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
@@ -10801,16 +12510,16 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Collections.Hashtable addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Collections.Hashtable addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
   %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck4 = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %9, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
   %13 = inttoptr i64 %11 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
@@ -10820,8 +12529,8 @@ entry:
 ; <label>:15                                      ; preds = %1
   %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -10839,15 +12548,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10861,8 +12570,8 @@ entry:
   store %System.Int32 addrspace(1)* %param0, %System.Int32 addrspace(1)** %this
   %0 = load %System.Int32 addrspace(1)*, %System.Int32 addrspace(1)** %this
   %1 = bitcast %System.Int32 addrspace(1)* %0 to i32 addrspace(1)*
-  %NullCheck = icmp ne i32 addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq i32 addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load i32, i32 addrspace(1)* %1, align 8
@@ -10938,8 +12647,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.UTF8Encoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
@@ -10948,15 +12657,15 @@ entry:
   %9 = load i8, i8* %arg2
   %10 = zext i8 %9 to i32
   %11 = trunc i32 %10 to i8
-  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %8, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %6
   %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %8, i32 0, i32 8
   store i8 %11, i8 addrspace(1)* %13
   %14 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %14, i32 0, i32 8
@@ -10968,8 +12677,8 @@ entry:
 ; <label>:20                                      ; preds = %15
   %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %22, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %22, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = load i64, i64 addrspace(1)* %22
@@ -10991,15 +12700,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %12
+ThrowNullRef4:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11014,8 +12723,8 @@ entry:
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
@@ -11037,16 +12746,16 @@ entry:
 ; <label>:10                                      ; preds = %1
   %11 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
   %12 = load i32, i32* %arg1
-  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %11, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.Encoding addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
   store i32 %12, i32 addrspace(1)* %14
   %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
   %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = load i64, i64 addrspace(1)* %16
@@ -11064,11 +12773,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11081,8 +12790,8 @@ entry:
   %this = alloca %System.Text.UTF8Encoding addrspace(1)*
   store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
   %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.UTF8Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
@@ -11094,16 +12803,16 @@ entry:
 ; <label>:6                                       ; preds = %1
   %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %8 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %10, %System.Text.EncoderFallback addrspace(1)* %8)
   %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %12 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
-  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %11, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %11, i32 0, i32 3
@@ -11116,8 +12825,8 @@ entry:
   %18 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %18, %System.String addrspace(1)* %17)
   %19 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %18 to %System.Text.EncoderFallback addrspace(1)*
-  %NullCheck6 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %16, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %16, i32 0, i32 2
@@ -11127,8 +12836,8 @@ entry:
   %24 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %24, %System.String addrspace(1)* %23)
   %25 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %24 to %System.Text.DecoderFallback addrspace(1)*
-  %NullCheck8 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %22, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %22, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %20
   %27 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %22, i32 0, i32 3
@@ -11139,19 +12848,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %20
+ThrowNullRef8:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11181,8 +12890,8 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load i32, i32* %arg1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -11200,8 +12909,8 @@ entry:
 ; <label>:15                                      ; preds = %8
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %17 = load i32, i32* %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 %17
@@ -11217,7 +12926,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11269,7 +12978,7 @@ entry:
 }
 
 INFO:  jitting method Hashtable::Insert using LLILCJit
-Failed to read Hashtable.Insert[loadElemA]
+Failed to read Hashtable.Insert[storeElem]
 INFO:  jitting method ConsoleEncoding::.ctor using LLILCJit
 Successfully read ConsoleEncoding..ctor
 
@@ -11284,8 +12993,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %1)
   %2 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
@@ -11321,8 +13030,8 @@ entry:
   %2 = call %System.Text.InternalEncoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalEncoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %1)
   %3 = bitcast %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2 to %System.Text.EncoderFallback addrspace(1)*
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
@@ -11332,8 +13041,8 @@ entry:
   %8 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %7)
   %9 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %8 to %System.Text.DecoderFallback addrspace(1)*
-  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %6, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.Encoding addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %4
   %11 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %6, i32 0, i32 3
@@ -11344,7 +13053,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11363,15 +13072,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* %1)
   %2 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   %6 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, i32 0, i32 1
@@ -11382,7 +13091,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11410,8 +13119,8 @@ entry:
   store %System.Text.InternalDecoderBestFitFallback addrspace(1)* %param0, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
   %0 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
@@ -11421,15 +13130,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %4)
   %5 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %6)
   %9 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, i32 0, i32 1
@@ -11440,11 +13149,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11512,8 +13221,8 @@ entry:
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
   %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = load i64, i64 addrspace(1)* %19
@@ -11577,8 +13286,8 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.ConsoleStream addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
@@ -11609,31 +13318,31 @@ entry:
   store i8 %param4, i8* %arg4
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %3, %System.IO.Stream addrspace(1)* %1)
   %4 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %4, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
   %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %4, i32 0, i32 4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %5)
   %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %6
   %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
   %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
   %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = load i64, i64 addrspace(1)* %13
@@ -11645,8 +13354,8 @@ entry:
   %21 = load i64, i64* %20
   %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %8, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %8, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %14
   %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 5
@@ -11664,24 +13373,24 @@ entry:
   %31 = load i32, i32* %arg3
   %32 = sext i32 %31 to i64
   %33 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %32)
-  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %30, null
-  br i1 %NullCheck10, label %34, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.StreamWriter addrspace(1)* %30, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %35, %"System.Char[]" addrspace(1)* %33)
   %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %37, null
-  br i1 %NullCheck12, label %38, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.StreamWriter addrspace(1)* %37, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %38
 
 ; <label>:38                                      ; preds = %34
   %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
   %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
   %41 = load i32, i32* %arg3
   %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %42, null
-  br i1 %NullCheck14, label %43, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %42, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
   %44 = load i64, i64 addrspace(1)* %42
@@ -11695,30 +13404,30 @@ entry:
   %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
   %53 = sext i32 %52 to i64
   %54 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %53)
-  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
-  br i1 %NullCheck16, label %55, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %55
 
 ; <label>:55                                      ; preds = %43
   %56 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %56, %"System.Byte[]" addrspace(1)* %54)
   %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %58 = load i32, i32* %arg3
-  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %57, null
-  br i1 %NullCheck18, label %59, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.StreamWriter addrspace(1)* %57, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %59
 
 ; <label>:59                                      ; preds = %55
   %60 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 10
   store i32 %58, i32 addrspace(1)* %60
   %61 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %61, null
-  br i1 %NullCheck20, label %62, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.IO.StreamWriter addrspace(1)* %61, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %62
 
 ; <label>:62                                      ; preds = %59
   %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
   %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
   %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
   %67 = load i64, i64 addrspace(1)* %65
@@ -11736,15 +13445,15 @@ entry:
 
 ; <label>:78                                      ; preds = %66
   %79 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %79, null
-  br i1 %NullCheck24, label %80, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.StreamWriter addrspace(1)* %79, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %80
 
 ; <label>:80                                      ; preds = %78
   %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
   %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
   %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %83, null
-  br i1 %NullCheck26, label %84, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %83, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
   %85 = load i64, i64 addrspace(1)* %83
@@ -11761,8 +13470,8 @@ entry:
 
 ; <label>:95                                      ; preds = %84
   %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.IO.StreamWriter addrspace(1)* %96, null
-  br i1 %NullCheck28, label %97, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.IO.StreamWriter addrspace(1)* %96, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %97
 
 ; <label>:97                                      ; preds = %95
   %98 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 12
@@ -11776,8 +13485,8 @@ entry:
   %103 = icmp eq i32 %102, 0
   %104 = sext i1 %103 to i32
   %105 = trunc i32 %104 to i8
-  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %100, null
-  br i1 %NullCheck30, label %106, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.IO.StreamWriter addrspace(1)* %100, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %106
 
 ; <label>:106                                     ; preds = %99
   %107 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %100, i32 0, i32 13
@@ -11788,63 +13497,63 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %6
+ThrowNullRef4:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %29
+ThrowNullRef10:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %34
+ThrowNullRef12:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %38
+ThrowNullRef14:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %43
+ThrowNullRef16:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %55
+ThrowNullRef18:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %59
+ThrowNullRef20:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %62
+ThrowNullRef22:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %78
+ThrowNullRef24:                                   ; preds = %78
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %80
+ThrowNullRef26:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %95
+ThrowNullRef28:                                   ; preds = %95
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11857,15 +13566,15 @@ entry:
   %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = load i64, i64 addrspace(1)* %4
@@ -11883,7 +13592,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11933,35 +13642,35 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
   %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderNLS addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %7 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.EncoderNLS addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Text.Encoding addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.Encoding addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Text.EncoderNLS addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.EncoderNLS addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
   %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck8 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = load i64, i64 addrspace(1)* %16
@@ -11980,19 +13689,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12018,8 +13727,8 @@ entry:
   %this = alloca %System.Text.Encoding addrspace(1)*
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
@@ -12039,15 +13748,15 @@ entry:
   %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
   store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
   %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
   store i32 0, i32 addrspace(1)* %2
   %3 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, i32 0, i32 2
@@ -12057,15 +13766,15 @@ entry:
 
 ; <label>:8                                       ; preds = %4
   %9 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
   %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
   %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = load i64, i64 addrspace(1)* %13
@@ -12086,15 +13795,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12109,16 +13818,16 @@ entry:
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = load i32, i32* %arg1
   %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
   %7 = load i64, i64 addrspace(1)* %5
@@ -12136,7 +13845,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12173,8 +13882,8 @@ entry:
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
   %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
   %16 = load i64, i64 addrspace(1)* %14
@@ -12195,8 +13904,8 @@ entry:
   %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
   %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
   %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %31, null
-  br i1 %NullCheck2, label %32, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = load i64, i64 addrspace(1)* %31
@@ -12239,7 +13948,7 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12252,14 +13961,14 @@ entry:
   %this = alloca %System.Text.EncoderReplacementFallback addrspace(1)*
   store %System.Text.EncoderReplacementFallback addrspace(1)* %param0, %System.Text.EncoderReplacementFallback addrspace(1)** %this
   %0 = load %System.Text.EncoderReplacementFallback addrspace(1)*, %System.Text.EncoderReplacementFallback addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -12270,7 +13979,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12300,8 +14009,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
@@ -12333,8 +14042,8 @@ entry:
   %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
   store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
@@ -12346,8 +14055,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Threading.Tasks.Task addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %7)
@@ -12370,7 +14079,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12389,8 +14098,8 @@ entry:
   store i8 %param1, i8* %arg1
   store i8 %param2, i8* %arg2
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
@@ -12404,8 +14113,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1, %5
   %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 9
@@ -12436,8 +14145,8 @@ entry:
 
 ; <label>:25                                      ; preds = %8, %20
   %26 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %26, null
-  br i1 %NullCheck4, label %27, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %26, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %26, i32 0, i32 12
@@ -12448,22 +14157,22 @@ entry:
 
 ; <label>:32                                      ; preds = %27
   %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %33, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.IO.StreamWriter addrspace(1)* %33, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %32
   %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 12
   store i8 1, i8 addrspace(1)* %35
   %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
-  br i1 %NullCheck8, label %37, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
   %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
   %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck10 = icmp ne i64 addrspace(1)* %40, null
-  br i1 %NullCheck10, label %41, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64 addrspace(1)* %40, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i64, i64 addrspace(1)* %40
@@ -12477,8 +14186,8 @@ entry:
   %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
   store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
   %51 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %NullCheck12 = icmp ne %"System.Byte[]" addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Byte[]" addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %41
   %53 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %51, i32 0, i32 1
@@ -12490,16 +14199,16 @@ entry:
 
 ; <label>:58                                      ; preds = %52
   %59 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %59, null
-  br i1 %NullCheck14, label %60, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.IO.StreamWriter addrspace(1)* %59, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %60
 
 ; <label>:60                                      ; preds = %58
   %61 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %59, i32 0, i32 3
   %62 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
   %64 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %NullCheck16 = icmp ne %"System.Byte[]" addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %"System.Byte[]" addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %60
   %66 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %64, i32 0, i32 1
@@ -12507,8 +14216,8 @@ entry:
   %68 = zext i32 %67 to i64
   %69 = trunc i64 %68 to i32
   %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck18, label %71, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
   %72 = load i64, i64 addrspace(1)* %70
@@ -12524,29 +14233,29 @@ entry:
 
 ; <label>:80                                      ; preds = %27, %52, %71
   %81 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %81, null
-  br i1 %NullCheck20, label %82, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.IO.StreamWriter addrspace(1)* %81, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
 
 ; <label>:82                                      ; preds = %80
   %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %81, i32 0, i32 5
   %84 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %83, align 8
   %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.IO.StreamWriter addrspace(1)* %85, null
-  br i1 %NullCheck22, label %86, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.IO.StreamWriter addrspace(1)* %85, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %86
 
 ; <label>:86                                      ; preds = %82
   %87 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 7
   %88 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %87, align 8
   %89 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %89, null
-  br i1 %NullCheck24, label %90, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.StreamWriter addrspace(1)* %89, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %90
 
 ; <label>:90                                      ; preds = %86
   %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %89, i32 0, i32 9
   %92 = load i32, i32 addrspace(1)* %91, align 8
   %93 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.IO.StreamWriter addrspace(1)* %93, null
-  br i1 %NullCheck26, label %94, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.IO.StreamWriter addrspace(1)* %93, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %93, i32 0, i32 6
@@ -12554,8 +14263,8 @@ entry:
   %97 = load i8, i8* %arg2
   %98 = zext i8 %97 to i32
   %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
-  %NullCheck28 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck28, label %100, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
   %101 = load i64, i64 addrspace(1)* %99
@@ -12570,8 +14279,8 @@ entry:
   %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
   store i32 %110, i32* %loc1
   %111 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %111, null
-  br i1 %NullCheck30, label %112, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.IO.StreamWriter addrspace(1)* %111, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %112
 
 ; <label>:112                                     ; preds = %100
   %113 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %111, i32 0, i32 9
@@ -12582,23 +14291,23 @@ entry:
 
 ; <label>:116                                     ; preds = %112
   %117 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck32 = icmp ne %System.IO.StreamWriter addrspace(1)* %117, null
-  br i1 %NullCheck32, label %118, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.IO.StreamWriter addrspace(1)* %117, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %118
 
 ; <label>:118                                     ; preds = %116
   %119 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %117, i32 0, i32 3
   %120 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %119, align 8
   %121 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.IO.StreamWriter addrspace(1)* %121, null
-  br i1 %NullCheck34, label %122, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.IO.StreamWriter addrspace(1)* %121, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %122
 
 ; <label>:122                                     ; preds = %118
   %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
   %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
   %125 = load i32, i32* %loc1
   %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
-  %NullCheck36 = icmp ne i64 addrspace(1)* %126, null
-  br i1 %NullCheck36, label %127, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64 addrspace(1)* %126, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
   %128 = load i64, i64 addrspace(1)* %126
@@ -12620,15 +14329,15 @@ entry:
 
 ; <label>:140                                     ; preds = %136
   %141 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.IO.StreamWriter addrspace(1)* %141, null
-  br i1 %NullCheck38, label %142, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.IO.StreamWriter addrspace(1)* %141, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %142
 
 ; <label>:142                                     ; preds = %140
   %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
   %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
   %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
-  %NullCheck40 = icmp ne i64 addrspace(1)* %145, null
-  br i1 %NullCheck40, label %146, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i64 addrspace(1)* %145, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
   %147 = load i64, i64 addrspace(1)* %145
@@ -12649,83 +14358,83 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %25
+ThrowNullRef4:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %32
+ThrowNullRef6:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %37
+ThrowNullRef10:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %41
+ThrowNullRef12:                                   ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %58
+ThrowNullRef14:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %60
+ThrowNullRef16:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %65
+ThrowNullRef18:                                   ; preds = %65
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %80
+ThrowNullRef20:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %82
+ThrowNullRef22:                                   ; preds = %82
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %86
+ThrowNullRef24:                                   ; preds = %86
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %90
+ThrowNullRef26:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %94
+ThrowNullRef28:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %100
+ThrowNullRef30:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %116
+ThrowNullRef32:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %118
+ThrowNullRef34:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %122
+ThrowNullRef36:                                   ; preds = %122
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %140
+ThrowNullRef38:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %142
+ThrowNullRef40:                                   ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12792,8 +14501,8 @@ entry:
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %1 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
-  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
@@ -12801,8 +14510,8 @@ entry:
   %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
   %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
   %8 = load i64, i64 addrspace(1)* %6
@@ -12818,8 +14527,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %17, %System.IFormatProvider addrspace(1)* %16)
   %18 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %19 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %18, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.SyncTextWriter addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %7
   %21 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %18, i32 0, i32 4
@@ -12830,11 +14539,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12847,8 +14556,8 @@ entry:
   %this = alloca %System.IO.TextWriter addrspace(1)*
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.TextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
@@ -12858,8 +14567,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.Threading.Thread addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Threading.Thread addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %6)
@@ -12868,8 +14577,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1
   %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.TextWriter addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.TextWriter addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %11, i32 0, i32 2
@@ -12880,11 +14589,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13081,8 +14790,8 @@ entry:
   store float %param1, float* %arg1
   store i8 0, i8* %loc1
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
@@ -13092,16 +14801,16 @@ entry:
   %5 = addrspacecast i8* %loc1 to i8 addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %4, i8 addrspace(1)* %5)
   %6 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.SyncTextWriter addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
   %10 = load float, float* %arg1
   %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
   %13 = load i64, i64 addrspace(1)* %11
@@ -13136,11 +14845,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13157,8 +14866,8 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load float, float* %arg1
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -13172,8 +14881,8 @@ entry:
   call void %11(%System.IO.TextWriter addrspace(1)* %0, float %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
   %15 = load i64, i64 addrspace(1)* %13
@@ -13191,7 +14900,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13209,8 +14918,8 @@ entry:
   %1 = addrspacecast float* %arg1 to float addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -13225,8 +14934,8 @@ entry:
   %14 = bitcast float addrspace(1)* %1 to %System.Single addrspace(1)*
   %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Single addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Single addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
   %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
   %18 = load i64, i64 addrspace(1)* %16
@@ -13244,7 +14953,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13260,8 +14969,8 @@ entry:
   store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
   %0 = load %System.Single addrspace(1)*, %System.Single addrspace(1)** %this
   %1 = bitcast %System.Single addrspace(1)* %0 to float addrspace(1)*
-  %NullCheck = icmp ne float addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq float addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load float, float addrspace(1)* %1, align 8
@@ -13286,8 +14995,8 @@ entry:
   %loc0 = alloca %System.Globalization.NumberFormatInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 3
@@ -13297,8 +15006,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
@@ -13308,24 +15017,24 @@ entry:
   store %System.Globalization.NumberFormatInfo addrspace(1)* %10, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
   %11 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %7
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
   %15 = load i8, i8 addrspace(1)* %14, align 8
   %16 = zext i8 %15 to i32
   %17 = trunc i32 %16 to i8
-  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %11, null
-  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %11, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %13
   %19 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %11, i32 0, i32 29
   store i8 %17, i8 addrspace(1)* %19
   %20 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %21 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %20, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %20, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %18
   %23 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %20, i32 0, i32 3
@@ -13334,8 +15043,8 @@ entry:
 
 ; <label>:24                                      ; preds = %1, %22
   %25 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %25, null
-  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %25, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %26
 
 ; <label>:26                                      ; preds = %24
   %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %25, i32 0, i32 3
@@ -13346,23 +15055,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %18
+ThrowNullRef8:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13387,168 +15096,168 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 18
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %8, align 8
-  %NullCheck2 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %5, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %5, i32 0, i32 4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %9)
   %12 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 19
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %15, align 8
-  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %12, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %12, i32 0, i32 5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %16)
   %19 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %20 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %20, null
-  br i1 %NullCheck8, label %21, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %20, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %20, i32 0, i32 23
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  %NullCheck10 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %19, null
-  br i1 %NullCheck10, label %24, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %19, i32 0, i32 7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %25, %System.String addrspace(1)* %23)
   %26 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %27 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %27, i32 0, i32 22
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %29, align 8
-  %NullCheck14 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %26, null
-  br i1 %NullCheck14, label %31, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %26, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %26, i32 0, i32 6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %32, %System.String addrspace(1)* %30)
   %33 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %34 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Globalization.CultureData addrspace(1)* %34, null
-  br i1 %NullCheck16, label %35, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Globalization.CultureData addrspace(1)* %34, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %34, i32 0, i32 51
   %37 = load i32, i32 addrspace(1)* %36, align 8
-  %NullCheck18 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %33, null
-  br i1 %NullCheck18, label %38, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %33, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %33, i32 0, i32 21
   store i32 %37, i32 addrspace(1)* %39
   %40 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %41 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Globalization.CultureData addrspace(1)* %41, null
-  br i1 %NullCheck20, label %42, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Globalization.CultureData addrspace(1)* %41, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %41, i32 0, i32 52
   %44 = load i32, i32 addrspace(1)* %43, align 8
-  %NullCheck22 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %40, null
-  br i1 %NullCheck22, label %45, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %40, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %40, i32 0, i32 25
   store i32 %44, i32 addrspace(1)* %46
   %47 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %48 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.Globalization.CultureData addrspace(1)* %48, null
-  br i1 %NullCheck24, label %49, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Globalization.CultureData addrspace(1)* %48, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %49
 
 ; <label>:49                                      ; preds = %45
   %50 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %48, i32 0, i32 29
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck26 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %47, null
-  br i1 %NullCheck26, label %52, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %47, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %47, i32 0, i32 10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %53, %System.String addrspace(1)* %51)
   %54 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %55 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Globalization.CultureData addrspace(1)* %55, null
-  br i1 %NullCheck28, label %56, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Globalization.CultureData addrspace(1)* %55, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %56
 
 ; <label>:56                                      ; preds = %52
   %57 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %55, i32 0, i32 35
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %57, align 8
-  %NullCheck30 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %54, null
-  br i1 %NullCheck30, label %59, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %54, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %54, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %60, %System.String addrspace(1)* %58)
   %61 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %62 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck32 = icmp ne %System.Globalization.CultureData addrspace(1)* %62, null
-  br i1 %NullCheck32, label %63, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Globalization.CultureData addrspace(1)* %62, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %62, i32 0, i32 34
   %65 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %64, align 8
-  %NullCheck34 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %61, null
-  br i1 %NullCheck34, label %66, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %61, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %61, i32 0, i32 9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %67, %System.String addrspace(1)* %65)
   %68 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %69 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck36 = icmp ne %System.Globalization.CultureData addrspace(1)* %69, null
-  br i1 %NullCheck36, label %70, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Globalization.CultureData addrspace(1)* %69, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %70
 
 ; <label>:70                                      ; preds = %66
   %71 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %69, i32 0, i32 55
   %72 = load i32, i32 addrspace(1)* %71, align 8
-  %NullCheck38 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %68, null
-  br i1 %NullCheck38, label %73, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %68, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %68, i32 0, i32 22
   store i32 %72, i32 addrspace(1)* %74
   %75 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %76 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck40 = icmp ne %System.Globalization.CultureData addrspace(1)* %76, null
-  br i1 %NullCheck40, label %77, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Globalization.CultureData addrspace(1)* %76, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %76, i32 0, i32 57
   %79 = load i32, i32 addrspace(1)* %78, align 8
-  %NullCheck42 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %75, null
-  br i1 %NullCheck42, label %80, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %75, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %80
 
 ; <label>:80                                      ; preds = %77
   %81 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %75, i32 0, i32 24
   store i32 %79, i32 addrspace(1)* %81
   %82 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %83 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck44 = icmp ne %System.Globalization.CultureData addrspace(1)* %83, null
-  br i1 %NullCheck44, label %84, label %ThrowNullRef43
+  %NullCheck43 = icmp eq %System.Globalization.CultureData addrspace(1)* %83, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %84
 
 ; <label>:84                                      ; preds = %80
   %85 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %83, i32 0, i32 56
   %86 = load i32, i32 addrspace(1)* %85, align 8
-  %NullCheck46 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %82, null
-  br i1 %NullCheck46, label %87, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %82, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %82, i32 0, i32 23
@@ -13557,8 +15266,8 @@ entry:
 
 ; <label>:89                                      ; preds = %entry
   %90 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck100 = icmp ne %System.Globalization.CultureData addrspace(1)* %90, null
-  br i1 %NullCheck100, label %91, label %ThrowNullRef99
+  %NullCheck99 = icmp eq %System.Globalization.CultureData addrspace(1)* %90, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %91
 
 ; <label>:91                                      ; preds = %89
   %92 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %90, i32 0, i32 2
@@ -13576,8 +15285,8 @@ entry:
   %102 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %103 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %104 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %103)
-  %NullCheck48 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %102, null
-  br i1 %NullCheck48, label %105, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %102, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %105
 
 ; <label>:105                                     ; preds = %101
   %106 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %102, i32 0, i32 1
@@ -13585,8 +15294,8 @@ entry:
   %107 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %108 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %109 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %108)
-  %NullCheck50 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %107, null
-  br i1 %NullCheck50, label %110, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %107, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %110
 
 ; <label>:110                                     ; preds = %105
   %111 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %107, i32 0, i32 2
@@ -13594,8 +15303,8 @@ entry:
   %112 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %113 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %114 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %113)
-  %NullCheck52 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %112, null
-  br i1 %NullCheck52, label %115, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %112, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %115
 
 ; <label>:115                                     ; preds = %110
   %116 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %112, i32 0, i32 27
@@ -13603,8 +15312,8 @@ entry:
   %117 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %118 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %119 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %118)
-  %NullCheck54 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %117, null
-  br i1 %NullCheck54, label %120, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %117, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %120
 
 ; <label>:120                                     ; preds = %115
   %121 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %117, i32 0, i32 26
@@ -13612,8 +15321,8 @@ entry:
   %122 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %123 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %124 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %123)
-  %NullCheck56 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %122, null
-  br i1 %NullCheck56, label %125, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %122, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %125
 
 ; <label>:125                                     ; preds = %120
   %126 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %122, i32 0, i32 17
@@ -13621,8 +15330,8 @@ entry:
   %127 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %128 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %129 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %128)
-  %NullCheck58 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %127, null
-  br i1 %NullCheck58, label %130, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %127, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %130
 
 ; <label>:130                                     ; preds = %125
   %131 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %127, i32 0, i32 18
@@ -13630,8 +15339,8 @@ entry:
   %132 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %133 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %134 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %133)
-  %NullCheck60 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %132, null
-  br i1 %NullCheck60, label %135, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %132, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %135
 
 ; <label>:135                                     ; preds = %130
   %136 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %132, i32 0, i32 14
@@ -13639,8 +15348,8 @@ entry:
   %137 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %138 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %139 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %138)
-  %NullCheck62 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %137, null
-  br i1 %NullCheck62, label %140, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %137, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %140
 
 ; <label>:140                                     ; preds = %135
   %141 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %137, i32 0, i32 13
@@ -13648,71 +15357,71 @@ entry:
   %142 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %143 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %144 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %143)
-  %NullCheck64 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %142, null
-  br i1 %NullCheck64, label %145, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %142, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %145
 
 ; <label>:145                                     ; preds = %140
   %146 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %142, i32 0, i32 12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %146, %System.String addrspace(1)* %144)
   %147 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %148 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck66 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %148, null
-  br i1 %NullCheck66, label %149, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %148, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %149
 
 ; <label>:149                                     ; preds = %145
   %150 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %148, i32 0, i32 21
   %151 = load i32, i32 addrspace(1)* %150, align 8
-  %NullCheck68 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %147, null
-  br i1 %NullCheck68, label %152, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %147, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %152
 
 ; <label>:152                                     ; preds = %149
   %153 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %147, i32 0, i32 28
   store i32 %151, i32 addrspace(1)* %153
   %154 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %155 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck70 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %155, null
-  br i1 %NullCheck70, label %156, label %ThrowNullRef69
+  %NullCheck69 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %155, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %156
 
 ; <label>:156                                     ; preds = %152
   %157 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %155, i32 0, i32 6
   %158 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %157, align 8
-  %NullCheck72 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %154, null
-  br i1 %NullCheck72, label %159, label %ThrowNullRef71
+  %NullCheck71 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %154, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %159
 
 ; <label>:159                                     ; preds = %156
   %160 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %154, i32 0, i32 15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %160, %System.String addrspace(1)* %158)
   %161 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %162 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck74 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %162, null
-  br i1 %NullCheck74, label %163, label %ThrowNullRef73
+  %NullCheck73 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %162, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %163
 
 ; <label>:163                                     ; preds = %159
   %164 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %162, i32 0, i32 1
   %165 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %164, align 8
-  %NullCheck76 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %161, null
-  br i1 %NullCheck76, label %166, label %ThrowNullRef75
+  %NullCheck75 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %161, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %166
 
 ; <label>:166                                     ; preds = %163
   %167 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %161, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %167, %"System.Int32[]" addrspace(1)* %165)
   %168 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %169 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck78 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %169, null
-  br i1 %NullCheck78, label %170, label %ThrowNullRef77
+  %NullCheck77 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %169, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %170
 
 ; <label>:170                                     ; preds = %166
   %171 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %169, i32 0, i32 7
   %172 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %171, align 8
-  %NullCheck80 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %168, null
-  br i1 %NullCheck80, label %173, label %ThrowNullRef79
+  %NullCheck79 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %168, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %173
 
 ; <label>:173                                     ; preds = %170
   %174 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %168, i32 0, i32 16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %174, %System.String addrspace(1)* %172)
   %175 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck82 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %175, null
-  br i1 %NullCheck82, label %176, label %ThrowNullRef81
+  %NullCheck81 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %175, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %176
 
 ; <label>:176                                     ; preds = %173
   %177 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %175, i32 0, i32 4
@@ -13722,14 +15431,14 @@ entry:
 
 ; <label>:180                                     ; preds = %176
   %181 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck84 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %181, null
-  br i1 %NullCheck84, label %182, label %ThrowNullRef83
+  %NullCheck83 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %181, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %182
 
 ; <label>:182                                     ; preds = %180
   %183 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %181, i32 0, i32 4
   %184 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %183, align 8
-  %NullCheck86 = icmp ne %System.String addrspace(1)* %184, null
-  br i1 %NullCheck86, label %185, label %ThrowNullRef85
+  %NullCheck85 = icmp eq %System.String addrspace(1)* %184, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %185
 
 ; <label>:185                                     ; preds = %182
   %186 = getelementptr inbounds %System.String, %System.String addrspace(1)* %184, i32 0, i32 1
@@ -13740,8 +15449,8 @@ entry:
 ; <label>:189                                     ; preds = %176, %185
   %190 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck98 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %190, null
-  br i1 %NullCheck98, label %192, label %ThrowNullRef97
+  %NullCheck97 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %190, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %192
 
 ; <label>:192                                     ; preds = %189
   %193 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %190, i32 0, i32 4
@@ -13750,8 +15459,8 @@ entry:
 
 ; <label>:194                                     ; preds = %185, %192
   %195 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck88 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %195, null
-  br i1 %NullCheck88, label %196, label %ThrowNullRef87
+  %NullCheck87 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %195, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %196
 
 ; <label>:196                                     ; preds = %194
   %197 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %195, i32 0, i32 9
@@ -13761,14 +15470,14 @@ entry:
 
 ; <label>:200                                     ; preds = %196
   %201 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck90 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %201, null
-  br i1 %NullCheck90, label %202, label %ThrowNullRef89
+  %NullCheck89 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %201, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %202
 
 ; <label>:202                                     ; preds = %200
   %203 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %201, i32 0, i32 9
   %204 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %203, align 8
-  %NullCheck92 = icmp ne %System.String addrspace(1)* %204, null
-  br i1 %NullCheck92, label %205, label %ThrowNullRef91
+  %NullCheck91 = icmp eq %System.String addrspace(1)* %204, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %205
 
 ; <label>:205                                     ; preds = %202
   %206 = getelementptr inbounds %System.String, %System.String addrspace(1)* %204, i32 0, i32 1
@@ -13779,14 +15488,14 @@ entry:
 ; <label>:209                                     ; preds = %196, %205
   %210 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %211 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck94 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %211, null
-  br i1 %NullCheck94, label %212, label %ThrowNullRef93
+  %NullCheck93 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %211, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %212
 
 ; <label>:212                                     ; preds = %209
   %213 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %211, i32 0, i32 6
   %214 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %213, align 8
-  %NullCheck96 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %210, null
-  br i1 %NullCheck96, label %215, label %ThrowNullRef95
+  %NullCheck95 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %210, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %215
 
 ; <label>:215                                     ; preds = %212
   %216 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %210, i32 0, i32 9
@@ -13800,203 +15509,203 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %17
+ThrowNullRef8:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %21
+ThrowNullRef10:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %24
+ThrowNullRef12:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %28
+ThrowNullRef14:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %31
+ThrowNullRef16:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %35
+ThrowNullRef18:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %38
+ThrowNullRef20:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %42
+ThrowNullRef22:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %45
+ThrowNullRef24:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %49
+ThrowNullRef26:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %52
+ThrowNullRef28:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %56
+ThrowNullRef30:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %59
+ThrowNullRef32:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %63
+ThrowNullRef34:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %66
+ThrowNullRef36:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %70
+ThrowNullRef38:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %73
+ThrowNullRef40:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %77
+ThrowNullRef42:                                   ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %80
+ThrowNullRef44:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %84
+ThrowNullRef46:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %101
+ThrowNullRef48:                                   ; preds = %101
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %105
+ThrowNullRef50:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %110
+ThrowNullRef52:                                   ; preds = %110
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %115
+ThrowNullRef54:                                   ; preds = %115
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %120
+ThrowNullRef56:                                   ; preds = %120
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %125
+ThrowNullRef58:                                   ; preds = %125
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %130
+ThrowNullRef60:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %135
+ThrowNullRef62:                                   ; preds = %135
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %140
+ThrowNullRef64:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %145
+ThrowNullRef66:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %149
+ThrowNullRef68:                                   ; preds = %149
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %152
+ThrowNullRef70:                                   ; preds = %152
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %156
+ThrowNullRef72:                                   ; preds = %156
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %159
+ThrowNullRef74:                                   ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %163
+ThrowNullRef76:                                   ; preds = %163
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %166
+ThrowNullRef78:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %170
+ThrowNullRef80:                                   ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %173
+ThrowNullRef82:                                   ; preds = %173
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %180
+ThrowNullRef84:                                   ; preds = %180
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %182
+ThrowNullRef86:                                   ; preds = %182
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %194
+ThrowNullRef88:                                   ; preds = %194
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %200
+ThrowNullRef90:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %202
+ThrowNullRef92:                                   ; preds = %202
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %209
+ThrowNullRef94:                                   ; preds = %209
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %212
+ThrowNullRef96:                                   ; preds = %212
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %189
+ThrowNullRef98:                                   ; preds = %189
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %89
+ThrowNullRef100:                                  ; preds = %89
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14024,8 +15733,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 21
@@ -14038,8 +15747,8 @@ entry:
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 16)
   %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 21
@@ -14048,8 +15757,8 @@ entry:
 
 ; <label>:12                                      ; preds = %1, %10
   %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 21
@@ -14060,11 +15769,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %12
+ThrowNullRef4:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14080,8 +15789,8 @@ entry:
   store i32 %param1, i32* %arg1
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %1 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
@@ -14148,8 +15857,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 33
@@ -14162,8 +15871,8 @@ entry:
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 24)
   %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 33
@@ -14172,8 +15881,8 @@ entry:
 
 ; <label>:12                                      ; preds = %1, %10
   %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 33
@@ -14184,11 +15893,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %12
+ThrowNullRef4:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14201,8 +15910,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 53
@@ -14214,8 +15923,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 116)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 53
@@ -14224,8 +15933,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 53
@@ -14236,11 +15945,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14269,8 +15978,8 @@ entry:
 
 ; <label>:7                                       ; preds = %entry, %4
   %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %7
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 2
@@ -14294,8 +16003,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 54
@@ -14307,8 +16016,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 117)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
@@ -14317,8 +16026,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 54
@@ -14329,11 +16038,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14346,8 +16055,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 27
@@ -14359,8 +16068,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 118)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 27
@@ -14369,8 +16078,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 27
@@ -14381,11 +16090,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14398,8 +16107,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 28
@@ -14411,8 +16120,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 119)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 28
@@ -14421,8 +16130,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 28
@@ -14433,11 +16142,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14450,8 +16159,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 26
@@ -14463,8 +16172,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 107)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 26
@@ -14473,8 +16182,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 26
@@ -14485,11 +16194,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14502,8 +16211,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 25
@@ -14515,8 +16224,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 106)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 25
@@ -14525,8 +16234,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 25
@@ -14537,11 +16246,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14554,8 +16263,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 24
@@ -14567,8 +16276,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 105)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 24
@@ -14577,8 +16286,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 24
@@ -14589,11 +16298,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14618,8 +16327,8 @@ entry:
   %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %3)
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %2
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -14630,15 +16339,15 @@ entry:
 
 ; <label>:8                                       ; preds = %62
   %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 9
   %12 = load i32, i32 addrspace(1)* %11, align 8
   %13 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.IO.StreamWriter addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %13, i32 0, i32 10
@@ -14653,15 +16362,15 @@ entry:
 
 ; <label>:20                                      ; preds = %14, %18
   %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
   %24 = load i32, i32 addrspace(1)* %23, align 8
   %25 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %25, null
-  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.StreamWriter addrspace(1)* %25, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %25, i32 0, i32 9
@@ -14682,36 +16391,36 @@ entry:
   %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %37 = load i32, i32* %loc1
   %38 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.StreamWriter addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %35
   %40 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %38, i32 0, i32 7
   %41 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %40, align 8
   %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
-  br i1 %NullCheck14, label %43, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %39
   %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 9
   %45 = load i32, i32 addrspace(1)* %44, align 8
   %46 = load i32, i32* %loc2
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %36, null
-  br i1 %NullCheck16, label %47, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %36, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %47
 
 ; <label>:47                                      ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %36, i32 %37, %"System.Char[]" addrspace(1)* %41, i32 %45, i32 %46)
   %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
   %51 = load i32, i32 addrspace(1)* %50, align 8
   %52 = load i32, i32* %loc2
   %53 = add i32 %51, %52
-  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
-  br i1 %NullCheck20, label %54, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %54
 
 ; <label>:54                                      ; preds = %49
   %55 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
@@ -14733,8 +16442,8 @@ entry:
 
 ; <label>:65                                      ; preds = %62
   %66 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %66, null
-  br i1 %NullCheck2, label %67, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %66, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %67
 
 ; <label>:67                                      ; preds = %65
   %68 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %66, i32 0, i32 11
@@ -14755,49 +16464,259 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %65
+ThrowNullRef2:                                    ; preds = %65
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %20
+ThrowNullRef8:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %22
+ThrowNullRef10:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %35
+ThrowNullRef12:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %43
+ThrowNullRef16:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %47
+ThrowNullRef18:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method String::CopyTo using LLILCJit
-Failed to read String.CopyTo[loadElemA]
+Successfully read String.CopyTo
+
+define void @String.CopyTo(%System.String addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  %loc1 = alloca i16 addrspace(1)*
+  %loc2 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %1 = icmp ne %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg4
+  %7 = icmp sge i32 %6, 0
+  br i1 %7, label %13, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  unreachable
+
+; <label>:13                                      ; preds = %5
+  %14 = load i32, i32* %arg1
+  %15 = icmp sge i32 %14, 0
+  br i1 %15, label %21, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %18)
+  %20 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %20, %System.String addrspace(1)* %17, %System.String addrspace(1)* %19)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %20) #0
+  unreachable
+
+; <label>:21                                      ; preds = %13
+  %22 = load i32, i32* %arg4
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck, label %ThrowNullRef, label %24
+
+; <label>:24                                      ; preds = %21
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load i32, i32* %arg1
+  %28 = sub i32 %26, %27
+  %29 = icmp sle i32 %22, %28
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34, %System.String addrspace(1)* %31, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %24
+  %36 = load i32, i32* %arg3
+  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %37, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
+
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
+  %40 = load i32, i32 addrspace(1)* %39
+  %41 = zext i32 %40 to i64
+  %42 = trunc i64 %41 to i32
+  %43 = load i32, i32* %arg4
+  %44 = sub i32 %42, %43
+  %45 = icmp sgt i32 %36, %44
+  br i1 %45, label %49, label %46
+
+; <label>:46                                      ; preds = %38
+  %47 = load i32, i32* %arg3
+  %48 = icmp sge i32 %47, 0
+  br i1 %48, label %54, label %49
+
+; <label>:49                                      ; preds = %38, %46
+  %50 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %52 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %51)
+  %53 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53, %System.String addrspace(1)* %50, %System.String addrspace(1)* %52)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53) #0
+  unreachable
+
+; <label>:54                                      ; preds = %46
+  %55 = load i32, i32* %arg4
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %97, label %57
+
+; <label>:57                                      ; preds = %54
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %59
+
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 2
+  %61 = bitcast [0 x i16] addrspace(1)* %60 to i16 addrspace(1)*
+  store i16 addrspace(1)* %61, i16 addrspace(1)** %loc0
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  store %"System.Char[]" addrspace(1)* %62, %"System.Char[]" addrspace(1)** %loc2
+  %63 = icmp eq %"System.Char[]" addrspace(1)* %62, null
+  br i1 %63, label %72, label %64
+
+; <label>:64                                      ; preds = %59
+  %65 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc2
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %65, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %66
+
+; <label>:66                                      ; preds = %64
+  %67 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %65, i32 0, i32 1
+  %68 = load i32, i32 addrspace(1)* %67
+  %69 = zext i32 %68 to i64
+  %70 = trunc i64 %69 to i32
+  %71 = icmp ne i32 %70, 0
+  br i1 %71, label %73, label %72
+
+; <label>:72                                      ; preds = %59, %66
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  br label %81
+
+; <label>:73                                      ; preds = %66
+  %74 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc2
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %74, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %75
+
+; <label>:75                                      ; preds = %73
+  %76 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %74, i32 0, i32 1
+  %77 = load i32, i32 addrspace(1)* %76
+  %78 = zext i32 %77 to i64
+  %BoundsCheck = icmp uge i64 0, %78
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %79
+
+; <label>:79                                      ; preds = %75
+  %80 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %74, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %80, i16 addrspace(1)** %loc1
+  br label %81
+
+; <label>:81                                      ; preds = %72, %79
+  %82 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %83 = ptrtoint i16 addrspace(1)* %82 to i64
+  %84 = load i32, i32* %arg3
+  %85 = sext i32 %84 to i64
+  %86 = mul i64 %85, 2
+  %87 = add i64 %83, %86
+  %88 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %89 = ptrtoint i16 addrspace(1)* %88 to i64
+  %90 = load i32, i32* %arg1
+  %91 = sext i32 %90 to i64
+  %92 = mul i64 %91, 2
+  %93 = add i64 %89, %92
+  %94 = load i32, i32* %arg4
+  %95 = inttoptr i64 %87 to i16*
+  %96 = inttoptr i64 %93 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %95, i16* %96, i32 %94)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  br label %97
+
+; <label>:97                                      ; preds = %54, %81
+  ret void
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
 Successfully read ConsoleEncoding.GetPreamble
 
@@ -14834,7 +16753,365 @@ entry:
 }
 
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[loadElemA]
+Successfully read EncoderNLS.GetBytes
+
+define i32 @EncoderNLS.GetBytes(%System.Text.EncoderNLS addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3, %"System.Byte[]" addrspace(1)* %param4, i32 %param5, i8 %param6) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %arg4 = alloca %"System.Byte[]" addrspace(1)*
+  %arg5 = alloca i32
+  %arg6 = alloca i8
+  %loc0 = alloca i32
+  %loc1 = alloca i16 addrspace(1)*
+  %loc2 = alloca i8 addrspace(1)*
+  %loc3 = alloca i32
+  %loc4 = alloca %"System.Char[]" addrspace(1)*
+  %loc5 = alloca %"System.Byte[]" addrspace(1)*
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  store %"System.Byte[]" addrspace(1)* %param4, %"System.Byte[]" addrspace(1)** %arg4
+  store i32 %param5, i32* %arg5
+  store i8 %param6, i8* %arg6
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %1 = icmp eq %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %17, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %7 = icmp eq %"System.Char[]" addrspace(1)* %6, null
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %12
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %12
+
+; <label>:12                                      ; preds = %8, %10
+  %13 = phi %System.String addrspace(1)* [ %9, %8 ], [ %11, %10 ]
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %14)
+  %16 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16, %System.String addrspace(1)* %13, %System.String addrspace(1)* %15)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16) #0
+  unreachable
+
+; <label>:17                                      ; preds = %2
+  %18 = load i32, i32* %arg2
+  %19 = icmp slt i32 %18, 0
+  br i1 %19, label %23, label %20
+
+; <label>:20                                      ; preds = %17
+  %21 = load i32, i32* %arg3
+  %22 = icmp sge i32 %21, 0
+  br i1 %22, label %35, label %23
+
+; <label>:23                                      ; preds = %17, %20
+  %24 = load i32, i32* %arg2
+  %25 = icmp slt i32 %24, 0
+  br i1 %25, label %28, label %26
+
+; <label>:26                                      ; preds = %23
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %30
+
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %30
+
+; <label>:30                                      ; preds = %26, %28
+  %31 = phi %System.String addrspace(1)* [ %27, %26 ], [ %29, %28 ]
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34, %System.String addrspace(1)* %31, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %20
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck, label %ThrowNullRef, label %37
+
+; <label>:37                                      ; preds = %35
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = load i32, i32* %arg2
+  %43 = sub i32 %41, %42
+  %44 = load i32, i32* %arg3
+  %45 = icmp sge i32 %43, %44
+  br i1 %45, label %51, label %46
+
+; <label>:46                                      ; preds = %37
+  %47 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %48 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %49 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %48)
+  %50 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %50, %System.String addrspace(1)* %47, %System.String addrspace(1)* %49)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %50) #0
+  unreachable
+
+; <label>:51                                      ; preds = %37
+  %52 = load i32, i32* %arg5
+  %53 = icmp slt i32 %52, 0
+  br i1 %53, label %63, label %54
+
+; <label>:54                                      ; preds = %51
+  %55 = load i32, i32* %arg5
+  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck1 = icmp eq %"System.Byte[]" addrspace(1)* %56, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %57
+
+; <label>:57                                      ; preds = %54
+  %58 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = zext i32 %59 to i64
+  %61 = trunc i64 %60 to i32
+  %62 = icmp sle i32 %55, %61
+  br i1 %62, label %68, label %63
+
+; <label>:63                                      ; preds = %51, %57
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %66 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %65)
+  %67 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %67, %System.String addrspace(1)* %64, %System.String addrspace(1)* %66)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %67) #0
+  unreachable
+
+; <label>:68                                      ; preds = %57
+  %69 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %69, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %69, i32 0, i32 1
+  %72 = load i32, i32 addrspace(1)* %71
+  %73 = zext i32 %72 to i64
+  %74 = trunc i64 %73 to i32
+  %75 = icmp ne i32 %74, 0
+  br i1 %75, label %78, label %76
+
+; <label>:76                                      ; preds = %70
+  %77 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1)
+  store %"System.Char[]" addrspace(1)* %77, %"System.Char[]" addrspace(1)** %arg1
+  br label %78
+
+; <label>:78                                      ; preds = %70, %76
+  %79 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck5 = icmp eq %"System.Byte[]" addrspace(1)* %79, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %80
+
+; <label>:80                                      ; preds = %78
+  %81 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %79, i32 0, i32 1
+  %82 = load i32, i32 addrspace(1)* %81
+  %83 = zext i32 %82 to i64
+  %84 = trunc i64 %83 to i32
+  %85 = load i32, i32* %arg5
+  %86 = sub i32 %84, %85
+  store i32 %86, i32* %loc0
+  %87 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck7 = icmp eq %"System.Byte[]" addrspace(1)* %87, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %88
+
+; <label>:88                                      ; preds = %80
+  %89 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %87, i32 0, i32 1
+  %90 = load i32, i32 addrspace(1)* %89
+  %91 = zext i32 %90 to i64
+  %92 = trunc i64 %91 to i32
+  %93 = icmp ne i32 %92, 0
+  br i1 %93, label %96, label %94
+
+; <label>:94                                      ; preds = %88
+  %95 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1)
+  store %"System.Byte[]" addrspace(1)* %95, %"System.Byte[]" addrspace(1)** %arg4
+  br label %96
+
+; <label>:96                                      ; preds = %88, %94
+  %97 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  store %"System.Char[]" addrspace(1)* %97, %"System.Char[]" addrspace(1)** %loc4
+  %98 = icmp eq %"System.Char[]" addrspace(1)* %97, null
+  br i1 %98, label %107, label %99
+
+; <label>:99                                      ; preds = %96
+  %100 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc4
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %100, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %101
+
+; <label>:101                                     ; preds = %99
+  %102 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %100, i32 0, i32 1
+  %103 = load i32, i32 addrspace(1)* %102
+  %104 = zext i32 %103 to i64
+  %105 = trunc i64 %104 to i32
+  %106 = icmp ne i32 %105, 0
+  br i1 %106, label %108, label %107
+
+; <label>:107                                     ; preds = %96, %101
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  br label %116
+
+; <label>:108                                     ; preds = %101
+  %109 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc4
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %109, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %110
+
+; <label>:110                                     ; preds = %108
+  %111 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %109, i32 0, i32 1
+  %112 = load i32, i32 addrspace(1)* %111
+  %113 = zext i32 %112 to i64
+  %BoundsCheck = icmp uge i64 0, %113
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %114
+
+; <label>:114                                     ; preds = %110
+  %115 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %109, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %115, i16 addrspace(1)** %loc1
+  br label %116
+
+; <label>:116                                     ; preds = %107, %114
+  %117 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  store %"System.Byte[]" addrspace(1)* %117, %"System.Byte[]" addrspace(1)** %loc5
+  %118 = icmp eq %"System.Byte[]" addrspace(1)* %117, null
+  br i1 %118, label %127, label %119
+
+; <label>:119                                     ; preds = %116
+  %120 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc5
+  %NullCheck13 = icmp eq %"System.Byte[]" addrspace(1)* %120, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %121
+
+; <label>:121                                     ; preds = %119
+  %122 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %120, i32 0, i32 1
+  %123 = load i32, i32 addrspace(1)* %122
+  %124 = zext i32 %123 to i64
+  %125 = trunc i64 %124 to i32
+  %126 = icmp ne i32 %125, 0
+  br i1 %126, label %128, label %127
+
+; <label>:127                                     ; preds = %116, %121
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc2
+  br label %136
+
+; <label>:128                                     ; preds = %121
+  %129 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc5
+  %NullCheck15 = icmp eq %"System.Byte[]" addrspace(1)* %129, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %130
+
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %129, i32 0, i32 1
+  %132 = load i32, i32 addrspace(1)* %131
+  %133 = zext i32 %132 to i64
+  %BoundsCheck17 = icmp uge i64 0, %133
+  br i1 %BoundsCheck17, label %ThrowIndexOutOfRange18, label %134
+
+; <label>:134                                     ; preds = %130
+  %135 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %129, i32 0, i32 3, i32 0
+  store i8 addrspace(1)* %135, i8 addrspace(1)** %loc2
+  br label %136
+
+; <label>:136                                     ; preds = %127, %134
+  %137 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %138 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %139 = ptrtoint i16 addrspace(1)* %138 to i64
+  %140 = load i32, i32* %arg2
+  %141 = sext i32 %140 to i64
+  %142 = mul i64 %141, 2
+  %143 = add i64 %139, %142
+  %144 = load i32, i32* %arg3
+  %145 = load i8 addrspace(1)*, i8 addrspace(1)** %loc2
+  %146 = ptrtoint i8 addrspace(1)* %145 to i64
+  %147 = load i32, i32* %arg5
+  %148 = sext i32 %147 to i64
+  %149 = add i64 %146, %148
+  %150 = load i32, i32* %loc0
+  %151 = load i8, i8* %arg6
+  %152 = zext i8 %151 to i32
+  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i64 addrspace(1)*
+  %NullCheck19 = icmp eq i64 addrspace(1)* %153, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %154
+
+; <label>:154                                     ; preds = %136
+  %155 = load i64, i64 addrspace(1)* %153
+  %156 = add i64 %155, 72
+  %157 = inttoptr i64 %156 to i64*
+  %158 = load i64, i64* %157
+  %159 = add i64 %158, 0
+  %160 = inttoptr i64 %159 to i64*
+  %161 = load i64, i64* %160
+  %162 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to %System.Text.Encoder addrspace(1)*
+  %163 = inttoptr i64 %143 to i16*
+  %164 = inttoptr i64 %149 to i8*
+  %165 = trunc i32 %152 to i8
+  %166 = inttoptr i64 %161 to i32 (%System.Text.Encoder addrspace(1)*, i16*, i32, i8*, i32, i8)*
+  %167 = call i32 %166(%System.Text.Encoder addrspace(1)* %162, i16* %163, i32 %144, i8* %164, i32 %150, i8 %165)
+  store i32 %167, i32* %loc3
+  br label %168
+
+; <label>:168                                     ; preds = %154
+  %169 = load i32, i32* %loc3
+  ret i32 %169
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %110
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %119
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange18:                           ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
 Successfully read EncoderNLS.GetBytes
 
@@ -14923,22 +17200,22 @@ entry:
   %40 = load i8, i8* %arg5
   %41 = zext i8 %40 to i32
   %42 = trunc i32 %41 to i8
-  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %39, null
-  br i1 %NullCheck, label %43, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderNLS addrspace(1)* %39, null
+  br i1 %NullCheck, label %ThrowNullRef, label %43
 
 ; <label>:43                                      ; preds = %38
   %44 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
   store i8 %42, i8 addrspace(1)* %44
   %45 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %45, null
-  br i1 %NullCheck2, label %46, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.EncoderNLS addrspace(1)* %45, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %46
 
 ; <label>:46                                      ; preds = %43
   %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %45, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %47
   %48 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.EncoderNLS addrspace(1)* %48, null
-  br i1 %NullCheck4, label %49, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.EncoderNLS addrspace(1)* %48, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %49
 
 ; <label>:49                                      ; preds = %46
   %50 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %48, i32 0, i32 3
@@ -14949,8 +17226,8 @@ entry:
   %55 = load i32, i32* %arg4
   %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck6, label %58, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
   %59 = load i64, i64 addrspace(1)* %57
@@ -14968,15 +17245,15 @@ ThrowNullRef:                                     ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %43
+ThrowNullRef2:                                    ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %46
+ThrowNullRef4:                                    ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %49
+ThrowNullRef6:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -15004,8 +17281,8 @@ entry:
   %4 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0 to %System.IO.ConsoleStream addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*)(%System.IO.ConsoleStream addrspace(1)* %4, %"System.Byte[]" addrspace(1)* %1, i32 %2, i32 %3)
   %5 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
@@ -15090,8 +17367,8 @@ entry:
 
 ; <label>:22                                      ; preds = %8
   %23 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %23, null
-  br i1 %NullCheck, label %24, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Byte[]" addrspace(1)* %23, null
+  br i1 %NullCheck, label %ThrowNullRef, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
@@ -15113,8 +17390,8 @@ entry:
 
 ; <label>:36                                      ; preds = %24
   %37 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %37, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.ConsoleStream addrspace(1)* %37, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %37, i32 0, i32 4
@@ -15135,13 +17412,138 @@ ThrowNullRef:                                     ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %36
+ThrowNullRef2:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
-Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
+Successfully read WindowsConsoleStream.WriteFileNative
+
+define i32 @WindowsConsoleStream.WriteFileNative(i64 %param0, %"System.Byte[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i64
+  %arg1 = alloca %"System.Byte[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i8 addrspace(1)*
+  %loc2 = alloca %"System.Byte[]" addrspace(1)*
+  %loc3 = alloca i32
+  store i64 %param0, i64* %arg0
+  store %"System.Byte[]" addrspace(1)* %param1, %"System.Byte[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Byte[]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = zext i32 %3 to i64
+  %5 = icmp ne i64 %4, 0
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %1
+  ret i32 0
+
+; <label>:7                                       ; preds = %1
+  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  store %"System.Byte[]" addrspace(1)* %8, %"System.Byte[]" addrspace(1)** %loc2
+  %9 = icmp eq %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %9, label %18, label %10
+
+; <label>:10                                      ; preds = %7
+  %11 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc2
+  %NullCheck1 = icmp eq %"System.Byte[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %11, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp ne i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %7, %12
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc1
+  br label %27
+
+; <label>:19                                      ; preds = %12
+  %20 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc2
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %20, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %BoundsCheck = icmp uge i64 0, %24
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %25
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %20, i32 0, i32 3, i32 0
+  store i8 addrspace(1)* %26, i8 addrspace(1)** %loc1
+  br label %27
+
+; <label>:27                                      ; preds = %18, %25
+  %28 = load i64, i64* %arg0
+  %29 = load i8 addrspace(1)*, i8 addrspace(1)** %loc1
+  %30 = ptrtoint i8 addrspace(1)* %29 to i64
+  %31 = load i32, i32* %arg2
+  %32 = sext i32 %31 to i64
+  %33 = add i64 %30, %32
+  %34 = load i32, i32* %arg3
+  %35 = addrspacecast i32* %loc3 to i32 addrspace(1)*
+  %36 = inttoptr i64 %33 to i8*
+  %37 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i8*, i32, i32 addrspace(1)*, i64)*)(i64 %28, i8* %36, i32 %34, i32 addrspace(1)* %35, i64 0)
+  %38 = icmp ugt i32 %37, 0
+  %39 = sext i1 %38 to i32
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc1
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %42, label %41
+
+; <label>:41                                      ; preds = %27
+  ret i32 0
+
+; <label>:42                                      ; preds = %27
+  %43 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  store i32 %43, i32* %loc0
+  %44 = load i32, i32* %loc0
+  %45 = icmp eq i32 %44, 232
+  br i1 %45, label %49, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = load i32, i32* %loc0
+  %48 = icmp ne i32 %47, 109
+  br i1 %48, label %50, label %49
+
+; <label>:49                                      ; preds = %42, %46
+  ret i32 0
+
+; <label>:50                                      ; preds = %46
+  %51 = load i32, i32* %loc0
+  ret i32 %51
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
 Successfully read WindowsConsoleStream.Flush
 
@@ -15150,8 +17552,8 @@ entry:
   %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
   store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
@@ -15186,8 +17588,8 @@ entry:
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
   %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load i64, i64 addrspace(1)* %1
@@ -15226,15 +17628,15 @@ entry:
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.TextWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
   %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %3, align 8
   %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
   %7 = load i64, i64 addrspace(1)* %5
@@ -15252,7 +17654,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -15281,8 +17683,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %4)
   store i32 0, i32* %loc0
   %5 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Char[]" addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
@@ -15294,15 +17696,15 @@ entry:
 
 ; <label>:11                                      ; preds = %69
   %12 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %12, i32 0, i32 9
   %15 = load i32, i32 addrspace(1)* %14, align 8
   %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.IO.StreamWriter addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %16, i32 0, i32 10
@@ -15317,15 +17719,15 @@ entry:
 
 ; <label>:23                                      ; preds = %17, %21
   %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %24, null
-  br i1 %NullCheck8, label %25, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %24, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 10
   %27 = load i32, i32 addrspace(1)* %26, align 8
   %28 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %28, null
-  br i1 %NullCheck10, label %29, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.StreamWriter addrspace(1)* %28, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %28, i32 0, i32 9
@@ -15347,15 +17749,15 @@ entry:
   %40 = load i32, i32* %loc0
   %41 = mul i32 %40, 2
   %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
-  br i1 %NullCheck12, label %43, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %43
 
 ; <label>:43                                      ; preds = %38
   %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 7
   %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %44, align 8
   %46 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %46, null
-  br i1 %NullCheck14, label %47, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.IO.StreamWriter addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %47
 
 ; <label>:47                                      ; preds = %43
   %48 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %46, i32 0, i32 9
@@ -15367,16 +17769,16 @@ entry:
   %54 = bitcast %"System.Char[]" addrspace(1)* %45 to %System.Array addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %53, i32 %41, %System.Array addrspace(1)* %54, i32 %50, i32 %52)
   %55 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
-  br i1 %NullCheck16, label %56, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %56
 
 ; <label>:56                                      ; preds = %47
   %57 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
   %58 = load i32, i32 addrspace(1)* %57, align 8
   %59 = load i32, i32* %loc2
   %60 = add i32 %58, %59
-  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
-  br i1 %NullCheck18, label %61, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %61
 
 ; <label>:61                                      ; preds = %56
   %62 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
@@ -15398,8 +17800,8 @@ entry:
 
 ; <label>:72                                      ; preds = %69
   %73 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %73, null
-  br i1 %NullCheck2, label %74, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %73, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %74
 
 ; <label>:74                                      ; preds = %72
   %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %73, i32 0, i32 11
@@ -15420,39 +17822,39 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %72
+ThrowNullRef2:                                    ; preds = %72
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %23
+ThrowNullRef8:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef10:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %43
+ThrowNullRef14:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %47
+ThrowNullRef16:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %56
+ThrowNullRef18:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPAvg6.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPAvg6.error.txt
@@ -25,8 +25,8 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
@@ -40,8 +40,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
   %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
@@ -75,7 +75,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -90,8 +90,8 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %NullCheck = icmp ne i8 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = load i8, i8 addrspace(1)* %0, align 8
@@ -125,8 +125,8 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
@@ -159,8 +159,8 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -184,8 +184,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
   store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
@@ -195,8 +195,8 @@ entry:
 ; <label>:4                                       ; preds = %1
   %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
   %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
@@ -206,8 +206,8 @@ entry:
   %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
@@ -221,14 +221,14 @@ entry:
 
 ; <label>:17                                      ; preds = %14
   %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
   %21 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
@@ -238,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -249,8 +249,8 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
@@ -261,27 +261,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %30
+ThrowNullRef10:                                   ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -301,7 +301,89 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
-Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
+Successfully read AppDomainSetup.GetUnsecureApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.GetUnsecureApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %NullCheck = icmp eq %"System.String[]" addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %BoundsCheck = icmp uge i64 0, %5
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %6
+
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 3, i32 0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
+  ret %System.String addrspace(1)* %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_Value using LLILCJit
+Successfully read AppDomainSetup.get_Value
+
+define %"System.String[]" addrspace(1)* @AppDomainSetup.get_Value(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.String[]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 18)
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.String[]" addrspace(1)* addrspace(1)*, %"System.String[]" addrspace(1)*)*)(%"System.String[]" addrspace(1)* addrspace(1)* %9, %"System.String[]" addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %11, i32 0, i32 1
+  %14 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %13, align 8
+  ret %"System.String[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -319,8 +401,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -368,16 +450,16 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
   %5 = load i32, i32 addrspace(1)* %4
   %6 = sub i32 %5, 1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -389,7 +471,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -421,8 +503,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
@@ -456,8 +538,8 @@ entry:
 ; <label>:27                                      ; preds = %19
   %28 = load i32, i32* %arg1
   %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
-  br i1 %NullCheck2, label %30, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %29, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %30
 
 ; <label>:30                                      ; preds = %27
   %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
@@ -493,8 +575,8 @@ entry:
 ; <label>:49                                      ; preds = %46
   %50 = load i32, i32* %arg2
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck4, label %52, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
@@ -517,11 +599,11 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %27
+ThrowNullRef2:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %49
+ThrowNullRef4:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -544,16 +626,16 @@ entry:
   %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %0)
   store %System.String addrspace(1)* %1, %System.String addrspace(1)** %loc0
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 2
   %5 = bitcast [0 x i16] addrspace(1)* %4 to i16 addrspace(1)*
   store i16 addrspace(1)* %5, i16 addrspace(1)** %loc1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %3
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2
@@ -580,7 +662,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -691,15 +773,15 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %NullCheck132 = icmp ne i8* %21, null
-  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+  %NullCheck131 = icmp eq i8* %21, null
+  br i1 %NullCheck131, label %ThrowNullRef132, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = load i8, i8* %21, align 8
   %24 = zext i8 %23 to i32
   %25 = trunc i32 %24 to i8
-  %NullCheck134 = icmp ne i8* %20, null
-  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+  %NullCheck133 = icmp eq i8* %20, null
+  br i1 %NullCheck133, label %ThrowNullRef134, label %26
 
 ; <label>:26                                      ; preds = %22
   store i8 %25, i8* %20, align 8
@@ -709,16 +791,16 @@ entry:
   %28 = load i8*, i8** %arg0
   %29 = load i8*, i8** %arg1
   %30 = bitcast i8* %29 to i16*
-  %NullCheck128 = icmp ne i16* %30, null
-  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+  %NullCheck127 = icmp eq i16* %30, null
+  br i1 %NullCheck127, label %ThrowNullRef128, label %31
 
 ; <label>:31                                      ; preds = %27
   %32 = load i16, i16* %30, align 8
   %33 = sext i16 %32 to i32
   %34 = bitcast i8* %28 to i16*
   %35 = trunc i32 %33 to i16
-  %NullCheck130 = icmp ne i16* %34, null
-  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+  %NullCheck129 = icmp eq i16* %34, null
+  br i1 %NullCheck129, label %ThrowNullRef130, label %36
 
 ; <label>:36                                      ; preds = %31
   store i16 %35, i16* %34, align 8
@@ -728,16 +810,16 @@ entry:
   %38 = load i8*, i8** %arg0
   %39 = load i8*, i8** %arg1
   %40 = bitcast i8* %39 to i16*
-  %NullCheck120 = icmp ne i16* %40, null
-  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+  %NullCheck119 = icmp eq i16* %40, null
+  br i1 %NullCheck119, label %ThrowNullRef120, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i16, i16* %40, align 8
   %43 = sext i16 %42 to i32
   %44 = bitcast i8* %38 to i16*
   %45 = trunc i32 %43 to i16
-  %NullCheck122 = icmp ne i16* %44, null
-  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+  %NullCheck121 = icmp eq i16* %44, null
+  br i1 %NullCheck121, label %ThrowNullRef122, label %46
 
 ; <label>:46                                      ; preds = %41
   store i16 %45, i16* %44, align 8
@@ -745,15 +827,15 @@ entry:
   %48 = getelementptr inbounds i8, i8* %47, i64 2
   %49 = load i8*, i8** %arg1
   %50 = getelementptr inbounds i8, i8* %49, i64 2
-  %NullCheck124 = icmp ne i8* %50, null
-  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+  %NullCheck123 = icmp eq i8* %50, null
+  br i1 %NullCheck123, label %ThrowNullRef124, label %51
 
 ; <label>:51                                      ; preds = %46
   %52 = load i8, i8* %50, align 8
   %53 = zext i8 %52 to i32
   %54 = trunc i32 %53 to i8
-  %NullCheck126 = icmp ne i8* %48, null
-  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+  %NullCheck125 = icmp eq i8* %48, null
+  br i1 %NullCheck125, label %ThrowNullRef126, label %55
 
 ; <label>:55                                      ; preds = %51
   store i8 %54, i8* %48, align 8
@@ -763,14 +845,14 @@ entry:
   %57 = load i8*, i8** %arg0
   %58 = load i8*, i8** %arg1
   %59 = bitcast i8* %58 to i32*
-  %NullCheck116 = icmp ne i32* %59, null
-  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+  %NullCheck115 = icmp eq i32* %59, null
+  br i1 %NullCheck115, label %ThrowNullRef116, label %60
 
 ; <label>:60                                      ; preds = %56
   %61 = load i32, i32* %59, align 8
   %62 = bitcast i8* %57 to i32*
-  %NullCheck118 = icmp ne i32* %62, null
-  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+  %NullCheck117 = icmp eq i32* %62, null
+  br i1 %NullCheck117, label %ThrowNullRef118, label %63
 
 ; <label>:63                                      ; preds = %60
   store i32 %61, i32* %62, align 8
@@ -780,14 +862,14 @@ entry:
   %65 = load i8*, i8** %arg0
   %66 = load i8*, i8** %arg1
   %67 = bitcast i8* %66 to i32*
-  %NullCheck108 = icmp ne i32* %67, null
-  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+  %NullCheck107 = icmp eq i32* %67, null
+  br i1 %NullCheck107, label %ThrowNullRef108, label %68
 
 ; <label>:68                                      ; preds = %64
   %69 = load i32, i32* %67, align 8
   %70 = bitcast i8* %65 to i32*
-  %NullCheck110 = icmp ne i32* %70, null
-  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+  %NullCheck109 = icmp eq i32* %70, null
+  br i1 %NullCheck109, label %ThrowNullRef110, label %71
 
 ; <label>:71                                      ; preds = %68
   store i32 %69, i32* %70, align 8
@@ -795,15 +877,15 @@ entry:
   %73 = getelementptr inbounds i8, i8* %72, i64 4
   %74 = load i8*, i8** %arg1
   %75 = getelementptr inbounds i8, i8* %74, i64 4
-  %NullCheck112 = icmp ne i8* %75, null
-  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+  %NullCheck111 = icmp eq i8* %75, null
+  br i1 %NullCheck111, label %ThrowNullRef112, label %76
 
 ; <label>:76                                      ; preds = %71
   %77 = load i8, i8* %75, align 8
   %78 = zext i8 %77 to i32
   %79 = trunc i32 %78 to i8
-  %NullCheck114 = icmp ne i8* %73, null
-  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+  %NullCheck113 = icmp eq i8* %73, null
+  br i1 %NullCheck113, label %ThrowNullRef114, label %80
 
 ; <label>:80                                      ; preds = %76
   store i8 %79, i8* %73, align 8
@@ -813,14 +895,14 @@ entry:
   %82 = load i8*, i8** %arg0
   %83 = load i8*, i8** %arg1
   %84 = bitcast i8* %83 to i32*
-  %NullCheck100 = icmp ne i32* %84, null
-  br i1 %NullCheck100, label %85, label %ThrowNullRef99
+  %NullCheck99 = icmp eq i32* %84, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %85
 
 ; <label>:85                                      ; preds = %81
   %86 = load i32, i32* %84, align 8
   %87 = bitcast i8* %82 to i32*
-  %NullCheck102 = icmp ne i32* %87, null
-  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+  %NullCheck101 = icmp eq i32* %87, null
+  br i1 %NullCheck101, label %ThrowNullRef102, label %88
 
 ; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
@@ -829,16 +911,16 @@ entry:
   %91 = load i8*, i8** %arg1
   %92 = getelementptr inbounds i8, i8* %91, i64 4
   %93 = bitcast i8* %92 to i16*
-  %NullCheck104 = icmp ne i16* %93, null
-  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+  %NullCheck103 = icmp eq i16* %93, null
+  br i1 %NullCheck103, label %ThrowNullRef104, label %94
 
 ; <label>:94                                      ; preds = %88
   %95 = load i16, i16* %93, align 8
   %96 = sext i16 %95 to i32
   %97 = bitcast i8* %90 to i16*
   %98 = trunc i32 %96 to i16
-  %NullCheck106 = icmp ne i16* %97, null
-  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+  %NullCheck105 = icmp eq i16* %97, null
+  br i1 %NullCheck105, label %ThrowNullRef106, label %99
 
 ; <label>:99                                      ; preds = %94
   store i16 %98, i16* %97, align 8
@@ -848,14 +930,14 @@ entry:
   %101 = load i8*, i8** %arg0
   %102 = load i8*, i8** %arg1
   %103 = bitcast i8* %102 to i32*
-  %NullCheck88 = icmp ne i32* %103, null
-  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+  %NullCheck87 = icmp eq i32* %103, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %104
 
 ; <label>:104                                     ; preds = %100
   %105 = load i32, i32* %103, align 8
   %106 = bitcast i8* %101 to i32*
-  %NullCheck90 = icmp ne i32* %106, null
-  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+  %NullCheck89 = icmp eq i32* %106, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %107
 
 ; <label>:107                                     ; preds = %104
   store i32 %105, i32* %106, align 8
@@ -864,16 +946,16 @@ entry:
   %110 = load i8*, i8** %arg1
   %111 = getelementptr inbounds i8, i8* %110, i64 4
   %112 = bitcast i8* %111 to i16*
-  %NullCheck92 = icmp ne i16* %112, null
-  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+  %NullCheck91 = icmp eq i16* %112, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %113
 
 ; <label>:113                                     ; preds = %107
   %114 = load i16, i16* %112, align 8
   %115 = sext i16 %114 to i32
   %116 = bitcast i8* %109 to i16*
   %117 = trunc i32 %115 to i16
-  %NullCheck94 = icmp ne i16* %116, null
-  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+  %NullCheck93 = icmp eq i16* %116, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %118
 
 ; <label>:118                                     ; preds = %113
   store i16 %117, i16* %116, align 8
@@ -881,15 +963,15 @@ entry:
   %120 = getelementptr inbounds i8, i8* %119, i64 6
   %121 = load i8*, i8** %arg1
   %122 = getelementptr inbounds i8, i8* %121, i64 6
-  %NullCheck96 = icmp ne i8* %122, null
-  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+  %NullCheck95 = icmp eq i8* %122, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %123
 
 ; <label>:123                                     ; preds = %118
   %124 = load i8, i8* %122, align 8
   %125 = zext i8 %124 to i32
   %126 = trunc i32 %125 to i8
-  %NullCheck98 = icmp ne i8* %120, null
-  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+  %NullCheck97 = icmp eq i8* %120, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %127
 
 ; <label>:127                                     ; preds = %123
   store i8 %126, i8* %120, align 8
@@ -899,14 +981,14 @@ entry:
   %129 = load i8*, i8** %arg0
   %130 = load i8*, i8** %arg1
   %131 = bitcast i8* %130 to i64*
-  %NullCheck84 = icmp ne i64* %131, null
-  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+  %NullCheck83 = icmp eq i64* %131, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %132
 
 ; <label>:132                                     ; preds = %128
   %133 = load i64, i64* %131, align 8
   %134 = bitcast i8* %129 to i64*
-  %NullCheck86 = icmp ne i64* %134, null
-  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+  %NullCheck85 = icmp eq i64* %134, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %135
 
 ; <label>:135                                     ; preds = %132
   store i64 %133, i64* %134, align 8
@@ -916,14 +998,14 @@ entry:
   %137 = load i8*, i8** %arg0
   %138 = load i8*, i8** %arg1
   %139 = bitcast i8* %138 to i64*
-  %NullCheck76 = icmp ne i64* %139, null
-  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+  %NullCheck75 = icmp eq i64* %139, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %140
 
 ; <label>:140                                     ; preds = %136
   %141 = load i64, i64* %139, align 8
   %142 = bitcast i8* %137 to i64*
-  %NullCheck78 = icmp ne i64* %142, null
-  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+  %NullCheck77 = icmp eq i64* %142, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %143
 
 ; <label>:143                                     ; preds = %140
   store i64 %141, i64* %142, align 8
@@ -931,15 +1013,15 @@ entry:
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %NullCheck80 = icmp ne i8* %147, null
-  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+  %NullCheck79 = icmp eq i8* %147, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %148
 
 ; <label>:148                                     ; preds = %143
   %149 = load i8, i8* %147, align 8
   %150 = zext i8 %149 to i32
   %151 = trunc i32 %150 to i8
-  %NullCheck82 = icmp ne i8* %145, null
-  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+  %NullCheck81 = icmp eq i8* %145, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %152
 
 ; <label>:152                                     ; preds = %148
   store i8 %151, i8* %145, align 8
@@ -949,14 +1031,14 @@ entry:
   %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
   %156 = bitcast i8* %155 to i64*
-  %NullCheck68 = icmp ne i64* %156, null
-  br i1 %NullCheck68, label %157, label %ThrowNullRef67
+  %NullCheck67 = icmp eq i64* %156, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %157
 
 ; <label>:157                                     ; preds = %153
   %158 = load i64, i64* %156, align 8
   %159 = bitcast i8* %154 to i64*
-  %NullCheck70 = icmp ne i64* %159, null
-  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+  %NullCheck69 = icmp eq i64* %159, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %160
 
 ; <label>:160                                     ; preds = %157
   store i64 %158, i64* %159, align 8
@@ -965,16 +1047,16 @@ entry:
   %163 = load i8*, i8** %arg1
   %164 = getelementptr inbounds i8, i8* %163, i64 8
   %165 = bitcast i8* %164 to i16*
-  %NullCheck72 = icmp ne i16* %165, null
-  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+  %NullCheck71 = icmp eq i16* %165, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %166
 
 ; <label>:166                                     ; preds = %160
   %167 = load i16, i16* %165, align 8
   %168 = sext i16 %167 to i32
   %169 = bitcast i8* %162 to i16*
   %170 = trunc i32 %168 to i16
-  %NullCheck74 = icmp ne i16* %169, null
-  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+  %NullCheck73 = icmp eq i16* %169, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %171
 
 ; <label>:171                                     ; preds = %166
   store i16 %170, i16* %169, align 8
@@ -984,14 +1066,14 @@ entry:
   %173 = load i8*, i8** %arg0
   %174 = load i8*, i8** %arg1
   %175 = bitcast i8* %174 to i64*
-  %NullCheck56 = icmp ne i64* %175, null
-  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+  %NullCheck55 = icmp eq i64* %175, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %176
 
 ; <label>:176                                     ; preds = %172
   %177 = load i64, i64* %175, align 8
   %178 = bitcast i8* %173 to i64*
-  %NullCheck58 = icmp ne i64* %178, null
-  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+  %NullCheck57 = icmp eq i64* %178, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %179
 
 ; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
@@ -1000,16 +1082,16 @@ entry:
   %182 = load i8*, i8** %arg1
   %183 = getelementptr inbounds i8, i8* %182, i64 8
   %184 = bitcast i8* %183 to i16*
-  %NullCheck60 = icmp ne i16* %184, null
-  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+  %NullCheck59 = icmp eq i16* %184, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %185
 
 ; <label>:185                                     ; preds = %179
   %186 = load i16, i16* %184, align 8
   %187 = sext i16 %186 to i32
   %188 = bitcast i8* %181 to i16*
   %189 = trunc i32 %187 to i16
-  %NullCheck62 = icmp ne i16* %188, null
-  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+  %NullCheck61 = icmp eq i16* %188, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %190
 
 ; <label>:190                                     ; preds = %185
   store i16 %189, i16* %188, align 8
@@ -1017,15 +1099,15 @@ entry:
   %192 = getelementptr inbounds i8, i8* %191, i64 10
   %193 = load i8*, i8** %arg1
   %194 = getelementptr inbounds i8, i8* %193, i64 10
-  %NullCheck64 = icmp ne i8* %194, null
-  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+  %NullCheck63 = icmp eq i8* %194, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %195
 
 ; <label>:195                                     ; preds = %190
   %196 = load i8, i8* %194, align 8
   %197 = zext i8 %196 to i32
   %198 = trunc i32 %197 to i8
-  %NullCheck66 = icmp ne i8* %192, null
-  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+  %NullCheck65 = icmp eq i8* %192, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %199
 
 ; <label>:199                                     ; preds = %195
   store i8 %198, i8* %192, align 8
@@ -1035,14 +1117,14 @@ entry:
   %201 = load i8*, i8** %arg0
   %202 = load i8*, i8** %arg1
   %203 = bitcast i8* %202 to i64*
-  %NullCheck48 = icmp ne i64* %203, null
-  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+  %NullCheck47 = icmp eq i64* %203, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %204
 
 ; <label>:204                                     ; preds = %200
   %205 = load i64, i64* %203, align 8
   %206 = bitcast i8* %201 to i64*
-  %NullCheck50 = icmp ne i64* %206, null
-  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+  %NullCheck49 = icmp eq i64* %206, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %207
 
 ; <label>:207                                     ; preds = %204
   store i64 %205, i64* %206, align 8
@@ -1051,14 +1133,14 @@ entry:
   %210 = load i8*, i8** %arg1
   %211 = getelementptr inbounds i8, i8* %210, i64 8
   %212 = bitcast i8* %211 to i32*
-  %NullCheck52 = icmp ne i32* %212, null
-  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+  %NullCheck51 = icmp eq i32* %212, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %213
 
 ; <label>:213                                     ; preds = %207
   %214 = load i32, i32* %212, align 8
   %215 = bitcast i8* %209 to i32*
-  %NullCheck54 = icmp ne i32* %215, null
-  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+  %NullCheck53 = icmp eq i32* %215, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %216
 
 ; <label>:216                                     ; preds = %213
   store i32 %214, i32* %215, align 8
@@ -1068,14 +1150,14 @@ entry:
   %218 = load i8*, i8** %arg0
   %219 = load i8*, i8** %arg1
   %220 = bitcast i8* %219 to i64*
-  %NullCheck36 = icmp ne i64* %220, null
-  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64* %220, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %221
 
 ; <label>:221                                     ; preds = %217
   %222 = load i64, i64* %220, align 8
   %223 = bitcast i8* %218 to i64*
-  %NullCheck38 = icmp ne i64* %223, null
-  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+  %NullCheck37 = icmp eq i64* %223, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %224
 
 ; <label>:224                                     ; preds = %221
   store i64 %222, i64* %223, align 8
@@ -1084,14 +1166,14 @@ entry:
   %227 = load i8*, i8** %arg1
   %228 = getelementptr inbounds i8, i8* %227, i64 8
   %229 = bitcast i8* %228 to i32*
-  %NullCheck40 = icmp ne i32* %229, null
-  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i32* %229, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %230
 
 ; <label>:230                                     ; preds = %224
   %231 = load i32, i32* %229, align 8
   %232 = bitcast i8* %226 to i32*
-  %NullCheck42 = icmp ne i32* %232, null
-  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+  %NullCheck41 = icmp eq i32* %232, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %233
 
 ; <label>:233                                     ; preds = %230
   store i32 %231, i32* %232, align 8
@@ -1099,15 +1181,15 @@ entry:
   %235 = getelementptr inbounds i8, i8* %234, i64 12
   %236 = load i8*, i8** %arg1
   %237 = getelementptr inbounds i8, i8* %236, i64 12
-  %NullCheck44 = icmp ne i8* %237, null
-  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i8* %237, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %238
 
 ; <label>:238                                     ; preds = %233
   %239 = load i8, i8* %237, align 8
   %240 = zext i8 %239 to i32
   %241 = trunc i32 %240 to i8
-  %NullCheck46 = icmp ne i8* %235, null
-  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+  %NullCheck45 = icmp eq i8* %235, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %242
 
 ; <label>:242                                     ; preds = %238
   store i8 %241, i8* %235, align 8
@@ -1117,14 +1199,14 @@ entry:
   %244 = load i8*, i8** %arg0
   %245 = load i8*, i8** %arg1
   %246 = bitcast i8* %245 to i64*
-  %NullCheck24 = icmp ne i64* %246, null
-  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64* %246, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %247
 
 ; <label>:247                                     ; preds = %243
   %248 = load i64, i64* %246, align 8
   %249 = bitcast i8* %244 to i64*
-  %NullCheck26 = icmp ne i64* %249, null
-  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64* %249, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %250
 
 ; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
@@ -1133,14 +1215,14 @@ entry:
   %253 = load i8*, i8** %arg1
   %254 = getelementptr inbounds i8, i8* %253, i64 8
   %255 = bitcast i8* %254 to i32*
-  %NullCheck28 = icmp ne i32* %255, null
-  br i1 %NullCheck28, label %256, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i32* %255, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %256
 
 ; <label>:256                                     ; preds = %250
   %257 = load i32, i32* %255, align 8
   %258 = bitcast i8* %252 to i32*
-  %NullCheck30 = icmp ne i32* %258, null
-  br i1 %NullCheck30, label %259, label %ThrowNullRef29
+  %NullCheck29 = icmp eq i32* %258, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %259
 
 ; <label>:259                                     ; preds = %256
   store i32 %257, i32* %258, align 8
@@ -1149,16 +1231,16 @@ entry:
   %262 = load i8*, i8** %arg1
   %263 = getelementptr inbounds i8, i8* %262, i64 12
   %264 = bitcast i8* %263 to i16*
-  %NullCheck32 = icmp ne i16* %264, null
-  br i1 %NullCheck32, label %265, label %ThrowNullRef31
+  %NullCheck31 = icmp eq i16* %264, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %265
 
 ; <label>:265                                     ; preds = %259
   %266 = load i16, i16* %264, align 8
   %267 = sext i16 %266 to i32
   %268 = bitcast i8* %261 to i16*
   %269 = trunc i32 %267 to i16
-  %NullCheck34 = icmp ne i16* %268, null
-  br i1 %NullCheck34, label %270, label %ThrowNullRef33
+  %NullCheck33 = icmp eq i16* %268, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %270
 
 ; <label>:270                                     ; preds = %265
   store i16 %269, i16* %268, align 8
@@ -1168,14 +1250,14 @@ entry:
   %272 = load i8*, i8** %arg0
   %273 = load i8*, i8** %arg1
   %274 = bitcast i8* %273 to i64*
-  %NullCheck8 = icmp ne i64* %274, null
-  br i1 %NullCheck8, label %275, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64* %274, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %275
 
 ; <label>:275                                     ; preds = %271
   %276 = load i64, i64* %274, align 8
   %277 = bitcast i8* %272 to i64*
-  %NullCheck10 = icmp ne i64* %277, null
-  br i1 %NullCheck10, label %278, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %277, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %278
 
 ; <label>:278                                     ; preds = %275
   store i64 %276, i64* %277, align 8
@@ -1184,14 +1266,14 @@ entry:
   %281 = load i8*, i8** %arg1
   %282 = getelementptr inbounds i8, i8* %281, i64 8
   %283 = bitcast i8* %282 to i32*
-  %NullCheck12 = icmp ne i32* %283, null
-  br i1 %NullCheck12, label %284, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i32* %283, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %284
 
 ; <label>:284                                     ; preds = %278
   %285 = load i32, i32* %283, align 8
   %286 = bitcast i8* %280 to i32*
-  %NullCheck14 = icmp ne i32* %286, null
-  br i1 %NullCheck14, label %287, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i32* %286, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %287
 
 ; <label>:287                                     ; preds = %284
   store i32 %285, i32* %286, align 8
@@ -1200,16 +1282,16 @@ entry:
   %290 = load i8*, i8** %arg1
   %291 = getelementptr inbounds i8, i8* %290, i64 12
   %292 = bitcast i8* %291 to i16*
-  %NullCheck16 = icmp ne i16* %292, null
-  br i1 %NullCheck16, label %293, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i16* %292, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %293
 
 ; <label>:293                                     ; preds = %287
   %294 = load i16, i16* %292, align 8
   %295 = sext i16 %294 to i32
   %296 = bitcast i8* %289 to i16*
   %297 = trunc i32 %295 to i16
-  %NullCheck18 = icmp ne i16* %296, null
-  br i1 %NullCheck18, label %298, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i16* %296, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %298
 
 ; <label>:298                                     ; preds = %293
   store i16 %297, i16* %296, align 8
@@ -1217,15 +1299,15 @@ entry:
   %300 = getelementptr inbounds i8, i8* %299, i64 14
   %301 = load i8*, i8** %arg1
   %302 = getelementptr inbounds i8, i8* %301, i64 14
-  %NullCheck20 = icmp ne i8* %302, null
-  br i1 %NullCheck20, label %303, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i8* %302, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %303
 
 ; <label>:303                                     ; preds = %298
   %304 = load i8, i8* %302, align 8
   %305 = zext i8 %304 to i32
   %306 = trunc i32 %305 to i8
-  %NullCheck22 = icmp ne i8* %300, null
-  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i8* %300, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %307
 
 ; <label>:307                                     ; preds = %303
   store i8 %306, i8* %300, align 8
@@ -1235,14 +1317,14 @@ entry:
   %309 = load i8*, i8** %arg0
   %310 = load i8*, i8** %arg1
   %311 = bitcast i8* %310 to i64*
-  %NullCheck = icmp ne i64* %311, null
-  br i1 %NullCheck, label %312, label %ThrowNullRef
+  %NullCheck = icmp eq i64* %311, null
+  br i1 %NullCheck, label %ThrowNullRef, label %312
 
 ; <label>:312                                     ; preds = %308
   %313 = load i64, i64* %311, align 8
   %314 = bitcast i8* %309 to i64*
-  %NullCheck2 = icmp ne i64* %314, null
-  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64* %314, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %315
 
 ; <label>:315                                     ; preds = %312
   store i64 %313, i64* %314, align 8
@@ -1251,14 +1333,14 @@ entry:
   %318 = load i8*, i8** %arg1
   %319 = getelementptr inbounds i8, i8* %318, i64 8
   %320 = bitcast i8* %319 to i64*
-  %NullCheck4 = icmp ne i64* %320, null
-  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64* %320, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %321
 
 ; <label>:321                                     ; preds = %315
   %322 = load i64, i64* %320, align 8
   %323 = bitcast i8* %317 to i64*
-  %NullCheck6 = icmp ne i64* %323, null
-  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64* %323, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %324
 
 ; <label>:324                                     ; preds = %321
   store i64 %322, i64* %323, align 8
@@ -1286,15 +1368,15 @@ entry:
 ; <label>:338                                     ; preds = %333
   %339 = load i8*, i8** %arg0
   %340 = load i8*, i8** %arg1
-  %NullCheck136 = icmp ne i8* %340, null
-  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+  %NullCheck135 = icmp eq i8* %340, null
+  br i1 %NullCheck135, label %ThrowNullRef136, label %341
 
 ; <label>:341                                     ; preds = %338
   %342 = load i8, i8* %340, align 8
   %343 = zext i8 %342 to i32
   %344 = trunc i32 %343 to i8
-  %NullCheck138 = icmp ne i8* %339, null
-  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+  %NullCheck137 = icmp eq i8* %339, null
+  br i1 %NullCheck137, label %ThrowNullRef138, label %345
 
 ; <label>:345                                     ; preds = %341
   store i8 %344, i8* %339, align 8
@@ -1317,16 +1399,16 @@ entry:
   %357 = load i8*, i8** %arg0
   %358 = load i8*, i8** %arg1
   %359 = bitcast i8* %358 to i16*
-  %NullCheck140 = icmp ne i16* %359, null
-  br i1 %NullCheck140, label %360, label %ThrowNullRef139
+  %NullCheck139 = icmp eq i16* %359, null
+  br i1 %NullCheck139, label %ThrowNullRef140, label %360
 
 ; <label>:360                                     ; preds = %356
   %361 = load i16, i16* %359, align 8
   %362 = sext i16 %361 to i32
   %363 = bitcast i8* %357 to i16*
   %364 = trunc i32 %362 to i16
-  %NullCheck142 = icmp ne i16* %363, null
-  br i1 %NullCheck142, label %365, label %ThrowNullRef141
+  %NullCheck141 = icmp eq i16* %363, null
+  br i1 %NullCheck141, label %ThrowNullRef142, label %365
 
 ; <label>:365                                     ; preds = %360
   store i16 %364, i16* %363, align 8
@@ -1352,14 +1434,14 @@ entry:
   %378 = load i8*, i8** %arg0
   %379 = load i8*, i8** %arg1
   %380 = bitcast i8* %379 to i32*
-  %NullCheck144 = icmp ne i32* %380, null
-  br i1 %NullCheck144, label %381, label %ThrowNullRef143
+  %NullCheck143 = icmp eq i32* %380, null
+  br i1 %NullCheck143, label %ThrowNullRef144, label %381
 
 ; <label>:381                                     ; preds = %377
   %382 = load i32, i32* %380, align 8
   %383 = bitcast i8* %378 to i32*
-  %NullCheck146 = icmp ne i32* %383, null
-  br i1 %NullCheck146, label %384, label %ThrowNullRef145
+  %NullCheck145 = icmp eq i32* %383, null
+  br i1 %NullCheck145, label %ThrowNullRef146, label %384
 
 ; <label>:384                                     ; preds = %381
   store i32 %382, i32* %383, align 8
@@ -1384,14 +1466,14 @@ entry:
   %395 = load i8*, i8** %arg0
   %396 = load i8*, i8** %arg1
   %397 = bitcast i8* %396 to i64*
-  %NullCheck164 = icmp ne i64* %397, null
-  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+  %NullCheck163 = icmp eq i64* %397, null
+  br i1 %NullCheck163, label %ThrowNullRef164, label %398
 
 ; <label>:398                                     ; preds = %394
   %399 = load i64, i64* %397, align 8
   %400 = bitcast i8* %395 to i64*
-  %NullCheck166 = icmp ne i64* %400, null
-  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+  %NullCheck165 = icmp eq i64* %400, null
+  br i1 %NullCheck165, label %ThrowNullRef166, label %401
 
 ; <label>:401                                     ; preds = %398
   store i64 %399, i64* %400, align 8
@@ -1400,14 +1482,14 @@ entry:
   %404 = load i8*, i8** %arg1
   %405 = getelementptr inbounds i8, i8* %404, i64 8
   %406 = bitcast i8* %405 to i64*
-  %NullCheck168 = icmp ne i64* %406, null
-  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+  %NullCheck167 = icmp eq i64* %406, null
+  br i1 %NullCheck167, label %ThrowNullRef168, label %407
 
 ; <label>:407                                     ; preds = %401
   %408 = load i64, i64* %406, align 8
   %409 = bitcast i8* %403 to i64*
-  %NullCheck170 = icmp ne i64* %409, null
-  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+  %NullCheck169 = icmp eq i64* %409, null
+  br i1 %NullCheck169, label %ThrowNullRef170, label %410
 
 ; <label>:410                                     ; preds = %407
   store i64 %408, i64* %409, align 8
@@ -1437,14 +1519,14 @@ entry:
   %425 = load i8*, i8** %arg0
   %426 = load i8*, i8** %arg1
   %427 = bitcast i8* %426 to i64*
-  %NullCheck148 = icmp ne i64* %427, null
-  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+  %NullCheck147 = icmp eq i64* %427, null
+  br i1 %NullCheck147, label %ThrowNullRef148, label %428
 
 ; <label>:428                                     ; preds = %424
   %429 = load i64, i64* %427, align 8
   %430 = bitcast i8* %425 to i64*
-  %NullCheck150 = icmp ne i64* %430, null
-  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+  %NullCheck149 = icmp eq i64* %430, null
+  br i1 %NullCheck149, label %ThrowNullRef150, label %431
 
 ; <label>:431                                     ; preds = %428
   store i64 %429, i64* %430, align 8
@@ -1466,14 +1548,14 @@ entry:
   %441 = load i8*, i8** %arg0
   %442 = load i8*, i8** %arg1
   %443 = bitcast i8* %442 to i32*
-  %NullCheck152 = icmp ne i32* %443, null
-  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+  %NullCheck151 = icmp eq i32* %443, null
+  br i1 %NullCheck151, label %ThrowNullRef152, label %444
 
 ; <label>:444                                     ; preds = %440
   %445 = load i32, i32* %443, align 8
   %446 = bitcast i8* %441 to i32*
-  %NullCheck154 = icmp ne i32* %446, null
-  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+  %NullCheck153 = icmp eq i32* %446, null
+  br i1 %NullCheck153, label %ThrowNullRef154, label %447
 
 ; <label>:447                                     ; preds = %444
   store i32 %445, i32* %446, align 8
@@ -1495,16 +1577,16 @@ entry:
   %457 = load i8*, i8** %arg0
   %458 = load i8*, i8** %arg1
   %459 = bitcast i8* %458 to i16*
-  %NullCheck156 = icmp ne i16* %459, null
-  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+  %NullCheck155 = icmp eq i16* %459, null
+  br i1 %NullCheck155, label %ThrowNullRef156, label %460
 
 ; <label>:460                                     ; preds = %456
   %461 = load i16, i16* %459, align 8
   %462 = sext i16 %461 to i32
   %463 = bitcast i8* %457 to i16*
   %464 = trunc i32 %462 to i16
-  %NullCheck158 = icmp ne i16* %463, null
-  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+  %NullCheck157 = icmp eq i16* %463, null
+  br i1 %NullCheck157, label %ThrowNullRef158, label %465
 
 ; <label>:465                                     ; preds = %460
   store i16 %464, i16* %463, align 8
@@ -1525,15 +1607,15 @@ entry:
 ; <label>:474                                     ; preds = %470
   %475 = load i8*, i8** %arg0
   %476 = load i8*, i8** %arg1
-  %NullCheck160 = icmp ne i8* %476, null
-  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+  %NullCheck159 = icmp eq i8* %476, null
+  br i1 %NullCheck159, label %ThrowNullRef160, label %477
 
 ; <label>:477                                     ; preds = %474
   %478 = load i8, i8* %476, align 8
   %479 = zext i8 %478 to i32
   %480 = trunc i32 %479 to i8
-  %NullCheck162 = icmp ne i8* %475, null
-  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+  %NullCheck161 = icmp eq i8* %475, null
+  br i1 %NullCheck161, label %ThrowNullRef162, label %481
 
 ; <label>:481                                     ; preds = %477
   store i8 %480, i8* %475, align 8
@@ -1553,343 +1635,343 @@ ThrowNullRef:                                     ; preds = %308
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %312
+ThrowNullRef2:                                    ; preds = %312
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %315
+ThrowNullRef4:                                    ; preds = %315
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %321
+ThrowNullRef6:                                    ; preds = %321
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %271
+ThrowNullRef8:                                    ; preds = %271
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %275
+ThrowNullRef10:                                   ; preds = %275
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %278
+ThrowNullRef12:                                   ; preds = %278
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %284
+ThrowNullRef14:                                   ; preds = %284
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %287
+ThrowNullRef16:                                   ; preds = %287
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %293
+ThrowNullRef18:                                   ; preds = %293
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %298
+ThrowNullRef20:                                   ; preds = %298
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %303
+ThrowNullRef22:                                   ; preds = %303
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %243
+ThrowNullRef24:                                   ; preds = %243
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %247
+ThrowNullRef26:                                   ; preds = %247
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %250
+ThrowNullRef28:                                   ; preds = %250
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %256
+ThrowNullRef30:                                   ; preds = %256
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %259
+ThrowNullRef32:                                   ; preds = %259
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %265
+ThrowNullRef34:                                   ; preds = %265
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %217
+ThrowNullRef36:                                   ; preds = %217
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %221
+ThrowNullRef38:                                   ; preds = %221
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %224
+ThrowNullRef40:                                   ; preds = %224
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %230
+ThrowNullRef42:                                   ; preds = %230
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %233
+ThrowNullRef44:                                   ; preds = %233
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %238
+ThrowNullRef46:                                   ; preds = %238
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %200
+ThrowNullRef48:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %204
+ThrowNullRef50:                                   ; preds = %204
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %207
+ThrowNullRef52:                                   ; preds = %207
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %213
+ThrowNullRef54:                                   ; preds = %213
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %172
+ThrowNullRef56:                                   ; preds = %172
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %176
+ThrowNullRef58:                                   ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %179
+ThrowNullRef60:                                   ; preds = %179
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %185
+ThrowNullRef62:                                   ; preds = %185
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %190
+ThrowNullRef64:                                   ; preds = %190
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %195
+ThrowNullRef66:                                   ; preds = %195
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %153
+ThrowNullRef68:                                   ; preds = %153
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %157
+ThrowNullRef70:                                   ; preds = %157
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %160
+ThrowNullRef72:                                   ; preds = %160
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %166
+ThrowNullRef74:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %136
+ThrowNullRef76:                                   ; preds = %136
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %140
+ThrowNullRef78:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %143
+ThrowNullRef80:                                   ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %148
+ThrowNullRef82:                                   ; preds = %148
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %128
+ThrowNullRef84:                                   ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %132
+ThrowNullRef86:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %100
+ThrowNullRef88:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %104
+ThrowNullRef90:                                   ; preds = %104
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %107
+ThrowNullRef92:                                   ; preds = %107
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %113
+ThrowNullRef94:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %118
+ThrowNullRef96:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %123
+ThrowNullRef98:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %81
+ThrowNullRef100:                                  ; preds = %81
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef101:                                  ; preds = %85
+ThrowNullRef102:                                  ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef103:                                  ; preds = %88
+ThrowNullRef104:                                  ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef105:                                  ; preds = %94
+ThrowNullRef106:                                  ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef107:                                  ; preds = %64
+ThrowNullRef108:                                  ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef109:                                  ; preds = %68
+ThrowNullRef110:                                  ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef111:                                  ; preds = %71
+ThrowNullRef112:                                  ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef113:                                  ; preds = %76
+ThrowNullRef114:                                  ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef115:                                  ; preds = %56
+ThrowNullRef116:                                  ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef117:                                  ; preds = %60
+ThrowNullRef118:                                  ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef119:                                  ; preds = %37
+ThrowNullRef120:                                  ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef121:                                  ; preds = %41
+ThrowNullRef122:                                  ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef123:                                  ; preds = %46
+ThrowNullRef124:                                  ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef125:                                  ; preds = %51
+ThrowNullRef126:                                  ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef127:                                  ; preds = %27
+ThrowNullRef128:                                  ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef129:                                  ; preds = %31
+ThrowNullRef130:                                  ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef131:                                  ; preds = %19
+ThrowNullRef132:                                  ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef133:                                  ; preds = %22
+ThrowNullRef134:                                  ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef135:                                  ; preds = %338
+ThrowNullRef136:                                  ; preds = %338
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef137:                                  ; preds = %341
+ThrowNullRef138:                                  ; preds = %341
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef139:                                  ; preds = %356
+ThrowNullRef140:                                  ; preds = %356
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef141:                                  ; preds = %360
+ThrowNullRef142:                                  ; preds = %360
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef143:                                  ; preds = %377
+ThrowNullRef144:                                  ; preds = %377
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef145:                                  ; preds = %381
+ThrowNullRef146:                                  ; preds = %381
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef147:                                  ; preds = %424
+ThrowNullRef148:                                  ; preds = %424
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef149:                                  ; preds = %428
+ThrowNullRef150:                                  ; preds = %428
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef151:                                  ; preds = %440
+ThrowNullRef152:                                  ; preds = %440
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef153:                                  ; preds = %444
+ThrowNullRef154:                                  ; preds = %444
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef155:                                  ; preds = %456
+ThrowNullRef156:                                  ; preds = %456
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef157:                                  ; preds = %460
+ThrowNullRef158:                                  ; preds = %460
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef159:                                  ; preds = %474
+ThrowNullRef160:                                  ; preds = %474
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef161:                                  ; preds = %477
+ThrowNullRef162:                                  ; preds = %477
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef163:                                  ; preds = %394
+ThrowNullRef164:                                  ; preds = %394
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef165:                                  ; preds = %398
+ThrowNullRef166:                                  ; preds = %398
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef167:                                  ; preds = %401
+ThrowNullRef168:                                  ; preds = %401
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef169:                                  ; preds = %407
+ThrowNullRef170:                                  ; preds = %407
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1939,8 +2021,8 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
-  br i1 %NullCheck, label %22, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %ThrowNullRef, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
@@ -1948,8 +2030,8 @@ entry:
   store i32 %24, i32* %loc0
   %25 = load i32, i32* %loc0
   %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %26, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %27
 
 ; <label>:27                                      ; preds = %22
   %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
@@ -1971,7 +2053,7 @@ ThrowNullRef:                                     ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1989,8 +2071,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -2022,15 +2104,15 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2048,16 +2130,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
   %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
   store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %15
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
@@ -2072,8 +2154,8 @@ entry:
   %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
   %29 = ptrtoint i16 addrspace(1)* %28 to i64
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %19
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
@@ -2089,19 +2171,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2114,8 +2196,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
@@ -2128,7 +2210,7 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[loadElem]
+Failed to read AppDomain.PrepareDataForSetup[storeElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
@@ -2202,8 +2284,8 @@ entry:
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
-  br i1 %NullCheck24, label %27, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = load i64, i64 addrspace(1)* %26
@@ -2218,8 +2300,8 @@ entry:
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
-  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
   %41 = load i64, i64 addrspace(1)* %39
@@ -2236,8 +2318,8 @@ entry:
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
-  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
   %54 = load i64, i64 addrspace(1)* %52
@@ -2252,8 +2334,8 @@ entry:
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
   %67 = load i64, i64 addrspace(1)* %65
@@ -2270,8 +2352,8 @@ entry:
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
-  br i1 %NullCheck16, label %79, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
   %80 = load i64, i64 addrspace(1)* %78
@@ -2286,8 +2368,8 @@ entry:
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
-  br i1 %NullCheck18, label %92, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
   %93 = load i64, i64 addrspace(1)* %91
@@ -2304,8 +2386,8 @@ entry:
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
-  br i1 %NullCheck12, label %105, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = load i64, i64 addrspace(1)* %104
@@ -2320,8 +2402,8 @@ entry:
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
-  br i1 %NullCheck14, label %118, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
   %119 = load i64, i64 addrspace(1)* %117
@@ -2337,8 +2419,8 @@ entry:
 
 ; <label>:128                                     ; preds = %20
   %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
-  br i1 %NullCheck4, label %130, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %129, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %130
 
 ; <label>:130                                     ; preds = %128
   %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
@@ -2346,8 +2428,8 @@ entry:
   %133 = load i16, i16 addrspace(1)* %132, align 8
   %134 = zext i16 %133 to i32
   %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
-  br i1 %NullCheck6, label %136, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %135, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %136
 
 ; <label>:136                                     ; preds = %130
   %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
@@ -2360,8 +2442,8 @@ entry:
 
 ; <label>:143                                     ; preds = %136
   %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
-  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %144, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %145
 
 ; <label>:145                                     ; preds = %143
   %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
@@ -2369,8 +2451,8 @@ entry:
   %148 = load i16, i16 addrspace(1)* %147, align 8
   %149 = zext i16 %148 to i32
   %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %150, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %151
 
 ; <label>:151                                     ; preds = %145
   %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
@@ -2388,8 +2470,8 @@ entry:
 
 ; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
-  br i1 %NullCheck, label %163, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %ThrowNullRef, label %163
 
 ; <label>:163                                     ; preds = %161
   %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
@@ -2399,8 +2481,8 @@ entry:
 
 ; <label>:167                                     ; preds = %163
   %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
-  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %168, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %169
 
 ; <label>:169                                     ; preds = %167
   %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
@@ -2432,55 +2514,55 @@ ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %167
+ThrowNullRef2:                                    ; preds = %167
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %128
+ThrowNullRef4:                                    ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %130
+ThrowNullRef6:                                    ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %143
+ThrowNullRef8:                                    ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %145
+ThrowNullRef10:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %102
+ThrowNullRef12:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %105
+ThrowNullRef14:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %76
+ThrowNullRef16:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %79
+ThrowNullRef18:                                   ; preds = %79
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %50
+ThrowNullRef20:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %53
+ThrowNullRef22:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %24
+ThrowNullRef24:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %27
+ThrowNullRef26:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2503,15 +2585,15 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2519,16 +2601,16 @@ entry:
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
   store i32 %8, i32* %loc0
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
   %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
   store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
@@ -2546,16 +2628,16 @@ entry:
 
 ; <label>:23                                      ; preds = %64
   %24 = load i16*, i16** %loc3
-  %NullCheck12 = icmp ne i16* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i16* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
   store i32 %27, i32* %loc5
   %28 = load i16*, i16** %loc4
-  %NullCheck14 = icmp ne i16* %28, null
-  br i1 %NullCheck14, label %29, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %28, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = load i16, i16* %28, align 8
@@ -2620,15 +2702,15 @@ entry:
 
 ; <label>:67                                      ; preds = %64
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
-  br i1 %NullCheck8, label %69, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %68, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %69
 
 ; <label>:69                                      ; preds = %67
   %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
   %71 = load i32, i32 addrspace(1)* %70
   %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
-  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %73
 
 ; <label>:73                                      ; preds = %69
   %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
@@ -2645,31 +2727,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %67
+ThrowNullRef8:                                    ; preds = %67
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %69
+ThrowNullRef10:                                   ; preds = %69
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2710,14 +2792,14 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
   %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
@@ -2730,14 +2812,14 @@ entry:
 
 ; <label>:11                                      ; preds = %4
   %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
   %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
@@ -2749,14 +2831,14 @@ entry:
 
 ; <label>:22                                      ; preds = %16
   %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
   %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
-  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
-  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
@@ -2804,23 +2886,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2836,7 +2918,280 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[loadElem]
+Successfully read RuntimeType.IsAssignableFrom
+
+define i8 @RuntimeType.IsAssignableFrom(%System.RuntimeType addrspace(1)* %param0, %System.Type addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.RuntimeType addrspace(1)*
+  %arg1 = alloca %System.Type addrspace(1)*
+  %loc0 = alloca %System.RuntimeType addrspace(1)*
+  %loc1 = alloca %"System.Type[]" addrspace(1)*
+  %loc2 = alloca i32
+  store %System.RuntimeType addrspace(1)* %param0, %System.RuntimeType addrspace(1)** %this
+  store %System.Type addrspace(1)* %param1, %System.Type addrspace(1)** %arg1
+  %0 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %1 = icmp ne %System.Type addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i8 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %5 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %6 = bitcast %System.Type addrspace(1)* %4 to %System.Object addrspace(1)*
+  %7 = bitcast %System.RuntimeType addrspace(1)* %5 to %System.Object addrspace(1)*
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %6, %System.Object addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %3
+  ret i8 1
+
+; <label>:12                                      ; preds = %3
+  %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 152
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 32
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
+  %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
+  %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
+  store %System.RuntimeType addrspace(1)* %25, %System.RuntimeType addrspace(1)** %loc0
+  %26 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %27 = icmp eq %System.RuntimeType addrspace(1)* %26, null
+  br i1 %27, label %34, label %28
+
+; <label>:28                                      ; preds = %15
+  %29 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %30 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)*)*)(%System.RuntimeType addrspace(1)* %29, %System.RuntimeType addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+; <label>:34                                      ; preds = %15
+  %35 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %36 = call %System.Reflection.Emit.TypeBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Reflection.Emit.TypeBuilder addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %35)
+  %37 = icmp eq %System.Reflection.Emit.TypeBuilder addrspace(1)* %36, null
+  br i1 %37, label %139, label %38
+
+; <label>:38                                      ; preds = %34
+  %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %42
+
+; <label>:42                                      ; preds = %38
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 152
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 40
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
+  %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
+  %53 = zext i8 %52 to i32
+  %54 = icmp eq i32 %53, 0
+  br i1 %54, label %56, label %55
+
+; <label>:55                                      ; preds = %42
+  ret i8 1
+
+; <label>:56                                      ; preds = %42
+  %57 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %58 = bitcast %System.RuntimeType addrspace(1)* %57 to %System.Type addrspace(1)*
+  %59 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %58)
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %64 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.Type addrspace(1)* %63, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = bitcast %System.RuntimeType addrspace(1)* %64 to %System.Type addrspace(1)*
+  %67 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %63, %System.Type addrspace(1)* %66)
+  %68 = zext i8 %67 to i32
+  %69 = trunc i32 %68 to i8
+  ret i8 %69
+
+; <label>:70                                      ; preds = %56
+  %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
+  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %73
+
+; <label>:73                                      ; preds = %70
+  %74 = load i64, i64 addrspace(1)* %72
+  %75 = add i64 %74, 128
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = add i64 %77, 0
+  %79 = inttoptr i64 %78 to i64*
+  %80 = load i64, i64* %79
+  %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
+  %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
+  %83 = call i8 %82(%System.Type addrspace(1)* %81)
+  %84 = zext i8 %83 to i32
+  %85 = icmp eq i32 %84, 0
+  br i1 %85, label %139, label %86
+
+; <label>:86                                      ; preds = %73
+  %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
+  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %89
+
+; <label>:89                                      ; preds = %86
+  %90 = load i64, i64 addrspace(1)* %88
+  %91 = add i64 %90, 128
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = add i64 %93, 24
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
+  %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
+  %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
+  store %"System.Type[]" addrspace(1)* %99, %"System.Type[]" addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %129
+
+; <label>:100                                     ; preds = %132
+  %101 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %102 = load i32, i32* %loc2
+  %NullCheck11 = icmp eq %"System.Type[]" addrspace(1)* %101, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %103
+
+; <label>:103                                     ; preds = %100
+  %104 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 1
+  %105 = load i32, i32 addrspace(1)* %104
+  %106 = zext i32 %105 to i64
+  %107 = zext i32 %102 to i64
+  %BoundsCheck = icmp uge i64 %107, %106
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %108
+
+; <label>:108                                     ; preds = %103
+  %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
+  %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
+  %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
+  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %113
+
+; <label>:113                                     ; preds = %108
+  %114 = load i64, i64 addrspace(1)* %112
+  %115 = add i64 %114, 152
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = add i64 %117, 56
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
+  %123 = zext i8 %122 to i32
+  %124 = icmp ne i32 %123, 0
+  br i1 %124, label %126, label %125
+
+; <label>:125                                     ; preds = %113
+  ret i8 0
+
+; <label>:126                                     ; preds = %113
+  %127 = load i32, i32* %loc2
+  %128 = add i32 %127, 1
+  store i32 %128, i32* %loc2
+  br label %129
+
+; <label>:129                                     ; preds = %89, %126
+  %130 = load i32, i32* %loc2
+  %131 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %NullCheck9 = icmp eq %"System.Type[]" addrspace(1)* %131, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %132
+
+; <label>:132                                     ; preds = %129
+  %133 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %131, i32 0, i32 1
+  %134 = load i32, i32 addrspace(1)* %133
+  %135 = zext i32 %134 to i64
+  %136 = trunc i64 %135 to i32
+  %137 = icmp slt i32 %130, %136
+  br i1 %137, label %100, label %138
+
+; <label>:138                                     ; preds = %132
+  ret i8 1
+
+; <label>:139                                     ; preds = %34, %73
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %129
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %103
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -2893,7 +3248,7 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElem]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -2904,8 +3259,8 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -2997,8 +3352,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
@@ -3059,8 +3414,8 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -3087,8 +3442,8 @@ entry:
 
 ; <label>:17                                      ; preds = %5, %11
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
@@ -3097,8 +3452,8 @@ entry:
 
 ; <label>:22                                      ; preds = %1, %11
   %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
@@ -3109,11 +3464,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %17
+ThrowNullRef2:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %22
+ThrowNullRef4:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3167,15 +3522,15 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
   %15 = load i32, i32 addrspace(1)* %14
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
@@ -3198,7 +3553,7 @@ ThrowNullRef:                                     ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef2:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3232,8 +3587,8 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
@@ -3312,8 +3667,8 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -3327,8 +3682,8 @@ entry:
 ; <label>:5                                       ; preds = %43
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %7 = load i32, i32* %loc1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck6, label %8, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
@@ -3366,8 +3721,8 @@ entry:
 ; <label>:32                                      ; preds = %21, %25
   %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
   %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
-  br i1 %NullCheck8, label %35, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = trunc i32 %34 to i16
@@ -3380,8 +3735,8 @@ entry:
 ; <label>:40                                      ; preds = %1, %35
   %41 = load i32, i32* %loc1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
-  br i1 %NullCheck2, label %43, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %42, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
@@ -3392,8 +3747,8 @@ entry:
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
   %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
-  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
   %51 = load i64, i64 addrspace(1)* %49
@@ -3412,19 +3767,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %40
+ThrowNullRef2:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %47
+ThrowNullRef4:                                    ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %5
+ThrowNullRef6:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %32
+ThrowNullRef8:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3467,8 +3822,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
@@ -3492,11 +3847,391 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(i16* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store i16* %param0, i16** %arg0
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load i32, i32* %arg3
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %42, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %37, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg2
+  %13 = load i32, i32* %arg3
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %37, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %24 = load i32, i32* %arg2
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load i16*, i16** %arg0
+  %35 = load i32, i32* %arg3
+  %36 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %36, i16* %34, i32 %35)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:37                                      ; preds = %5, %16
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %39)
+  %41 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41, %System.String addrspace(1)* %38, %System.String addrspace(1)* %40)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41) #0
+  unreachable
+
+; <label>:42                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
-Failed to read StringBuilder.ToString[loadElemA]
+Successfully read StringBuilder.ToString
+
+define %System.String addrspace(1)* @StringBuilder.ToString(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i16*
+  %loc3 = alloca %"System.Char[]" addrspace(1)*
+  %loc4 = alloca i32
+  %loc5 = alloca i32
+  %loc6 = alloca i16 addrspace(1)*
+  %loc7 = alloca %System.String addrspace(1)*
+  %loc8 = alloca %"System.Char[]" addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %0)
+  %2 = icmp ne i32 %1, 0
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %4
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %6)
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %7)
+  store %System.String addrspace(1)* %8, %System.String addrspace(1)** %loc0
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.Text.StringBuilder addrspace(1)* %9, %System.Text.StringBuilder addrspace(1)** %loc1
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  store %System.String addrspace(1)* %10, %System.String addrspace(1)** %loc7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc7
+  %12 = ptrtoint %System.String addrspace(1)* %11 to i64
+  %13 = icmp eq i64 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %5
+  %15 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %16 = sext i32 %15 to i64
+  %17 = add i64 %12, %16
+  br label %18
+
+; <label>:18                                      ; preds = %5, %14
+  %19 = phi i64 [ %12, %5 ], [ %17, %14 ]
+  %20 = inttoptr i64 %19 to i16*
+  store i16* %20, i16** %loc2
+  br label %21
+
+; <label>:21                                      ; preds = %98, %18
+  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %22, null
+  br i1 %NullCheck, label %ThrowNullRef, label %23
+
+; <label>:23                                      ; preds = %21
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 3
+  %25 = load i32, i32 addrspace(1)* %24, align 8
+  %26 = icmp sle i32 %25, 0
+  br i1 %26, label %96, label %27
+
+; <label>:27                                      ; preds = %23
+  %28 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %28, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %29
+
+; <label>:29                                      ; preds = %27
+  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %28, i32 0, i32 1
+  %31 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %30, align 8
+  store %"System.Char[]" addrspace(1)* %31, %"System.Char[]" addrspace(1)** %loc3
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %33
+
+; <label>:33                                      ; preds = %29
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  store i32 %35, i32* %loc4
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  %39 = load i32, i32 addrspace(1)* %38, align 8
+  store i32 %39, i32* %loc5
+  %40 = load i32, i32* %loc5
+  %41 = load i32, i32* %loc4
+  %42 = add i32 %40, %41
+  %43 = zext i32 %42 to i64
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %45
+
+; <label>:45                                      ; preds = %37
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = sext i32 %47 to i64
+  %49 = icmp sgt i64 %43, %48
+  br i1 %49, label %91, label %50
+
+; <label>:50                                      ; preds = %45
+  %51 = load i32, i32* %loc5
+  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %52, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %53
+
+; <label>:53                                      ; preds = %50
+  %54 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %52, i32 0, i32 1
+  %55 = load i32, i32 addrspace(1)* %54
+  %56 = zext i32 %55 to i64
+  %57 = trunc i64 %56 to i32
+  %58 = icmp ugt i32 %51, %57
+  br i1 %58, label %91, label %59
+
+; <label>:59                                      ; preds = %53
+  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  store %"System.Char[]" addrspace(1)* %60, %"System.Char[]" addrspace(1)** %loc8
+  %61 = icmp eq %"System.Char[]" addrspace(1)* %60, null
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %63, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %64
+
+; <label>:64                                      ; preds = %62
+  %65 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %63, i32 0, i32 1
+  %66 = load i32, i32 addrspace(1)* %65
+  %67 = zext i32 %66 to i64
+  %68 = trunc i64 %67 to i32
+  %69 = icmp ne i32 %68, 0
+  br i1 %69, label %71, label %70
+
+; <label>:70                                      ; preds = %59, %64
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:71                                      ; preds = %64
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %73
+
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %BoundsCheck = icmp uge i64 0, %76
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %77
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %78, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:79                                      ; preds = %70, %77
+  %80 = load i16*, i16** %loc2
+  %81 = load i32, i32* %loc4
+  %82 = sext i32 %81 to i64
+  %83 = mul i64 %82, 2
+  %84 = bitcast i16* %80 to i8*
+  %85 = getelementptr inbounds i8, i8* %84, i64 %83
+  %86 = load i16 addrspace(1)*, i16 addrspace(1)** %loc6
+  %87 = ptrtoint i16 addrspace(1)* %86 to i64
+  %88 = load i32, i32* %loc5
+  %89 = bitcast i8* %85 to i16*
+  %90 = inttoptr i64 %87 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %89, i16* %90, i32 %88)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %96
+
+; <label>:91                                      ; preds = %45, %53
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %94 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %93)
+  %95 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95, %System.String addrspace(1)* %92, %System.String addrspace(1)* %94)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95) #0
+  unreachable
+
+; <label>:96                                      ; preds = %23, %79
+  %97 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %97, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %98
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %97, i32 0, i32 2
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  store %System.Text.StringBuilder addrspace(1)* %100, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %102 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %102, label %21, label %103
+
+; <label>:103                                     ; preds = %98
+  store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc7
+  %104 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  ret %System.String addrspace(1)* %104
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method StringBuilder::get_Length using LLILCJit
+Successfully read StringBuilder.get_Length
+
+define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
+Successfully read RuntimeHelpers.get_OffsetToStringData
+
+define i32 @RuntimeHelpers.get_OffsetToStringData() {
+entry:
+  ret i32 12
+}
+
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
 Successfully read CultureData.CreateCultureData
 
@@ -3514,23 +4249,23 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
   store i8 %4, i8 addrspace(1)* %6
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
@@ -3549,11 +4284,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3566,50 +4301,50 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
   store i32 -1, i32 addrspace(1)* %2
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
   store i32 -1, i32 addrspace(1)* %8
   %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
   store i32 -1, i32 addrspace(1)* %14
   %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
   store i32 -1, i32 addrspace(1)* %17
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
@@ -3623,27 +4358,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3675,7 +4410,136 @@ Failed to read Dictionary`2.Insert[non-const derefAddress]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
 Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
-Failed to read HashHelpers.GetPrime[loadElem]
+Successfully read HashHelpers.GetPrime
+
+define i32 @HashHelpers.GetPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %6, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5, %System.String addrspace(1)* %4)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5) #0
+  unreachable
+
+; <label>:6                                       ; preds = %entry
+  store i32 0, i32* %loc0
+  br label %29
+
+; <label>:7                                       ; preds = %35
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 1296
+  %10 = addrspacecast i8 addrspace(1)* %9 to %"System.Int32[]" addrspace(1)**
+  %11 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %10
+  %12 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Int32[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = zext i32 %15 to i64
+  %17 = zext i32 %12 to i64
+  %BoundsCheck = icmp uge i64 %17, %16
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 3, i32 %12
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  store i32 %20, i32* %loc1
+  %21 = load i32, i32* %loc1
+  %22 = load i32, i32* %arg0
+  %23 = icmp slt i32 %21, %22
+  br i1 %23, label %26, label %24
+
+; <label>:24                                      ; preds = %18
+  %25 = load i32, i32* %loc1
+  ret i32 %25
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %loc0
+  %28 = add i32 %27, 1
+  store i32 %28, i32* %loc0
+  br label %29
+
+; <label>:29                                      ; preds = %6, %26
+  %30 = load i32, i32* %loc0
+  %31 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %32 = getelementptr inbounds i8, i8 addrspace(1)* %31, i64 1296
+  %33 = addrspacecast i8 addrspace(1)* %32 to %"System.Int32[]" addrspace(1)**
+  %34 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %33
+  %NullCheck = icmp eq %"System.Int32[]" addrspace(1)* %34, null
+  br i1 %NullCheck, label %ThrowNullRef, label %35
+
+; <label>:35                                      ; preds = %29
+  %36 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %34, i32 0, i32 1
+  %37 = load i32, i32 addrspace(1)* %36
+  %38 = zext i32 %37 to i64
+  %39 = trunc i64 %38 to i32
+  %40 = icmp slt i32 %30, %39
+  br i1 %40, label %7, label %41
+
+; <label>:41                                      ; preds = %35
+  %42 = load i32, i32* %arg0
+  %43 = or i32 %42, 1
+  store i32 %43, i32* %loc2
+  br label %59
+
+; <label>:44                                      ; preds = %59
+  %45 = load i32, i32* %loc2
+  %46 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %45)
+  %47 = zext i8 %46 to i32
+  %48 = icmp eq i32 %47, 0
+  br i1 %48, label %56, label %49
+
+; <label>:49                                      ; preds = %44
+  %50 = load i32, i32* %loc2
+  %51 = sub i32 %50, 1
+  %52 = srem i32 %51, 101
+  %53 = icmp eq i32 %52, 0
+  br i1 %53, label %56, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = load i32, i32* %loc2
+  ret i32 %55
+
+; <label>:56                                      ; preds = %44, %49
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %57, 2
+  store i32 %58, i32* %loc2
+  br label %59
+
+; <label>:59                                      ; preds = %41, %56
+  %60 = load i32, i32* %loc2
+  %61 = icmp slt i32 %60, 2147483647
+  br i1 %61, label %44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load i32, i32* %arg0
+  ret i32 %63
+
+ThrowNullRef:                                     ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
 Successfully read GenericEqualityComparer`1.GetHashCode
 
@@ -3694,14 +4558,14 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
   %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load i64, i64 addrspace(1)* %7
@@ -3720,7 +4584,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3750,8 +4614,8 @@ entry:
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
@@ -3796,8 +4660,8 @@ entry:
   %35 = bitcast i16* %34 to i8*
   %36 = getelementptr inbounds i8, i8* %35, i64 2
   %37 = bitcast i8* %36 to i16*
-  %NullCheck4 = icmp ne i16* %37, null
-  br i1 %NullCheck4, label %38, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %37, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %38
 
 ; <label>:38                                      ; preds = %27
   %39 = load i16, i16* %37, align 8
@@ -3824,8 +4688,8 @@ entry:
 
 ; <label>:54                                      ; preds = %22, %43
   %55 = load i16*, i16** %loc4
-  %NullCheck2 = icmp ne i16* %55, null
-  br i1 %NullCheck2, label %56, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i16* %55, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %56
 
 ; <label>:56                                      ; preds = %54
   %57 = load i16, i16* %55, align 8
@@ -3850,11 +4714,11 @@ ThrowNullRef:                                     ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %54
+ThrowNullRef2:                                    ; preds = %54
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %27
+ThrowNullRef4:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3871,8 +4735,8 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -3907,8 +4771,8 @@ entry:
 
 ; <label>:26                                      ; preds = %19
   %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
-  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %28
 
 ; <label>:28                                      ; preds = %26
   %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
@@ -3920,7 +4784,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3972,8 +4836,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
@@ -3984,26 +4848,26 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
-  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
@@ -4014,8 +4878,8 @@ entry:
 ; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
@@ -4024,8 +4888,8 @@ entry:
 
 ; <label>:25                                      ; preds = %1, %16, %23
   %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
-  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
@@ -4036,27 +4900,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %20
+ThrowNullRef10:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4069,8 +4933,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -4081,8 +4945,8 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
@@ -4091,8 +4955,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1, %8
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
@@ -4103,11 +4967,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4128,24 +4992,24 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   store i32 %3, i32* %loc0
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
   %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
   store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck4, label %9, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
@@ -4164,15 +5028,15 @@ entry:
 ; <label>:18                                      ; preds = %70
   %19 = load i16*, i16** %loc3
   %20 = bitcast i16* %19 to i64*
-  %NullCheck10 = icmp ne i64* %20, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %20, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = load i64, i64* %20, align 8
   %23 = load i16*, i16** %loc4
   %24 = bitcast i16* %23 to i64*
-  %NullCheck12 = icmp ne i64* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = load i64, i64* %24, align 8
@@ -4188,8 +5052,8 @@ entry:
   %31 = bitcast i16* %30 to i8*
   %32 = getelementptr inbounds i8, i8* %31, i64 8
   %33 = bitcast i8* %32 to i64*
-  %NullCheck14 = icmp ne i64* %33, null
-  br i1 %NullCheck14, label %34, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = load i64, i64* %33, align 8
@@ -4197,8 +5061,8 @@ entry:
   %37 = bitcast i16* %36 to i8*
   %38 = getelementptr inbounds i8, i8* %37, i64 8
   %39 = bitcast i8* %38 to i64*
-  %NullCheck16 = icmp ne i64* %39, null
-  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %40
 
 ; <label>:40                                      ; preds = %34
   %41 = load i64, i64* %39, align 8
@@ -4214,8 +5078,8 @@ entry:
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %NullCheck18 = icmp ne i64* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = load i64, i64* %48, align 8
@@ -4223,8 +5087,8 @@ entry:
   %52 = bitcast i16* %51 to i8*
   %53 = getelementptr inbounds i8, i8* %52, i64 16
   %54 = bitcast i8* %53 to i64*
-  %NullCheck20 = icmp ne i64* %54, null
-  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64* %54, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %55
 
 ; <label>:55                                      ; preds = %49
   %56 = load i64, i64* %54, align 8
@@ -4262,15 +5126,15 @@ entry:
 ; <label>:74                                      ; preds = %95
   %75 = load i16*, i16** %loc3
   %76 = bitcast i16* %75 to i32*
-  %NullCheck6 = icmp ne i32* %76, null
-  br i1 %NullCheck6, label %77, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32* %76, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %77
 
 ; <label>:77                                      ; preds = %74
   %78 = load i32, i32* %76, align 8
   %79 = load i16*, i16** %loc4
   %80 = bitcast i16* %79 to i32*
-  %NullCheck8 = icmp ne i32* %80, null
-  br i1 %NullCheck8, label %81, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i32* %80, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %81
 
 ; <label>:81                                      ; preds = %77
   %82 = load i32, i32* %80, align 8
@@ -4318,43 +5182,43 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %74
+ThrowNullRef6:                                    ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %77
+ThrowNullRef8:                                    ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %29
+ThrowNullRef14:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %34
+ThrowNullRef16:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4376,8 +5240,8 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load i64, i64 addrspace(1)* %4
@@ -4389,8 +5253,8 @@ entry:
   %12 = load i64, i64* %11
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %5
   %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
@@ -4399,8 +5263,8 @@ entry:
   %18 = load i8, i8* %arg2
   %19 = zext i8 %18 to i32
   %20 = trunc i32 %19 to i8
-  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %15
   %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
@@ -4411,11 +5275,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4442,8 +5306,8 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
@@ -4466,16 +5330,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
   %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = load i64, i64 addrspace(1)* %19
@@ -4500,8 +5364,8 @@ entry:
 ; <label>:35                                      ; preds = %30
   %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
@@ -4514,8 +5378,8 @@ entry:
 
 ; <label>:42                                      ; preds = %1, %38
   %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
-  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
@@ -4526,19 +5390,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %35
+ThrowNullRef2:                                    ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %42
+ThrowNullRef8:                                    ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4551,14 +5415,14 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
@@ -4570,7 +5434,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4583,8 +5447,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
@@ -4613,51 +5477,51 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
   %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
   %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
   %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
   %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
-  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
   store i64 %21, i64 addrspace(1)* %23
   %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %25 = load i64, i64* %loc0
-  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
@@ -4668,27 +5532,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %22
+ThrowNullRef12:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4701,8 +5565,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
@@ -4713,19 +5577,19 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
@@ -4734,8 +5598,8 @@ entry:
 
 ; <label>:15                                      ; preds = %1, %13
   %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
@@ -4746,19 +5610,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %15
+ThrowNullRef8:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4771,8 +5635,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -4831,8 +5695,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
@@ -4882,8 +5746,8 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
-  br i1 %NullCheck, label %17, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %ThrowNullRef, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
@@ -4894,15 +5758,15 @@ entry:
 
 ; <label>:22                                      ; preds = %17
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
-  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
   %26 = load i32, i32 addrspace(1)* %25
   %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
-  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %27, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
@@ -4925,8 +5789,8 @@ entry:
 ; <label>:40                                      ; preds = %17
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
-  br i1 %NullCheck6, label %43, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %41, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
@@ -4938,34 +5802,17 @@ ThrowNullRef:                                     ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %24
+ThrowNullRef4:                                    ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %40
+ThrowNullRef6:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
-}
-
-INFO:  jitting method Object::ReferenceEquals using LLILCJit
-Successfully read Object.ReferenceEquals
-
-define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
-entry:
-  %arg0 = alloca %System.Object addrspace(1)*
-  %arg1 = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
-  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
-  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = icmp eq %System.Object addrspace(1)* %0, %1
-  %3 = sext i1 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
 }
 
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
@@ -4978,21 +5825,21 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
   %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
-  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
@@ -5007,28 +5854,28 @@ entry:
 ; <label>:13                                      ; preds = %8, %12
   %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
   %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
   %21 = load i32, i32 addrspace(1)* %20, align 8
   %22 = add i32 %21, 1
-  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
   store i32 %22, i32 addrspace(1)* %24
   %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
@@ -5039,27 +5886,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5077,7 +5924,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::Setup using LLILCJit
-Failed to read AppDomain.Setup[loadElem]
+Failed to read AppDomain.Setup[unbox]
 INFO:  jitting method Thread::GetDomain using LLILCJit
 Successfully read Thread.GetDomain
 
@@ -5108,8 +5955,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
@@ -5122,14 +5969,14 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
   %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
@@ -5141,11 +5988,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5173,8 +6020,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -5189,7 +6036,328 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
 Failed to read KeyCollection.System.Collections.Generic.IEnumerable<TKey>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Successfully read Enumerator.MoveNext
+
+define i8 @Enumerator.MoveNext(%"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.RuntimeTypeHandle* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*
+  %"$TypeArg" = alloca %System.RuntimeTypeHandle*
+  store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
+  %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 8
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %76, label %12
+
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
+  br label %76
+
+; <label>:13                                      ; preds = %85
+  %14 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck19 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %15
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, i32 0, i32 0
+  %17 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %16, align 8
+  %NullCheck21 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, i32 0, i32 2
+  %20 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %19, align 8
+  %21 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck23 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %22
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, i32 0, i32 2
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %NullCheck25 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 3, i32 %24
+  %NullCheck27 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %32
+
+; <label>:32                                      ; preds = %30
+  %33 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, i32 0, i32 2
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = icmp slt i32 %34, 0
+  br i1 %35, label %68, label %36
+
+; <label>:36                                      ; preds = %32
+  %37 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %38 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck29 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %39
+
+; <label>:39                                      ; preds = %36
+  %40 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, i32 0, i32 0
+  %41 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %40, align 8
+  %NullCheck31 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, i32 0, i32 2
+  %44 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %43, align 8
+  %45 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck33 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, i32 0, i32 2
+  %48 = load i32, i32 addrspace(1)* %47, align 8
+  %NullCheck35 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %49
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = zext i32 %51 to i64
+  %53 = zext i32 %48 to i64
+  %BoundsCheck37 = icmp uge i64 %53, %52
+  br i1 %BoundsCheck37, label %ThrowIndexOutOfRange38, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 3, i32 %48
+  %NullCheck39 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %56
+
+; <label>:56                                      ; preds = %54
+  %57 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, i32 0, i32 0
+  %58 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck41 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %59
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %60, %System.__Canon addrspace(1)* %58)
+  %61 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck43 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  %64 = load i32, i32 addrspace(1)* %63, align 8
+  %65 = add i32 %64, 1
+  %NullCheck45 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  store i32 %65, i32 addrspace(1)* %67
+  ret i8 1
+
+; <label>:68                                      ; preds = %32
+  %69 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck47 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %73 = add i32 %72, 1
+  %NullCheck49 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %74
+
+; <label>:74                                      ; preds = %70
+  %75 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  store i32 %73, i32 addrspace(1)* %75
+  br label %76
+
+; <label>:76                                      ; preds = %8, %12, %74
+  %77 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %78
+
+; <label>:78                                      ; preds = %76
+  %79 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, i32 0, i32 2
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck7 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %82
+
+; <label>:82                                      ; preds = %78
+  %83 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, i32 0, i32 0
+  %84 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %83, align 8
+  %NullCheck9 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %85
+
+; <label>:85                                      ; preds = %82
+  %86 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, i32 0, i32 7
+  %87 = load i32, i32 addrspace(1)* %86, align 8
+  %88 = icmp ult i32 %80, %87
+  br i1 %88, label %13, label %89
+
+; <label>:89                                      ; preds = %85
+  %90 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %91 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck11 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %92
+
+; <label>:92                                      ; preds = %89
+  %93 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, i32 0, i32 0
+  %94 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck13 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %95
+
+; <label>:95                                      ; preds = %92
+  %96 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, i32 0, i32 7
+  %97 = load i32, i32 addrspace(1)* %96, align 8
+  %98 = add i32 %97, 1
+  %NullCheck15 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %99
+
+; <label>:99                                      ; preds = %95
+  %100 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, i32 0, i32 2
+  store i32 %98, i32 addrspace(1)* %100
+  %101 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck17 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %102
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %103, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %92
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef22:                                   ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef24:                                   ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef26:                                   ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef28:                                   ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef30:                                   ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef32:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef34:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef36:                                   ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange38:                           ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef40:                                   ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef42:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef44:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef46:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef48:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef50:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -5200,8 +6368,8 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -5232,9 +6400,9 @@ Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
 Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
-Failed to read String.MakeSeparatorList[loadElemA]
+Failed to read String.MakeSeparatorList[storeElem]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
-Failed to read String.InternalSplitKeepEmptyEntries[loadElem]
+Failed to read String.InternalSplitKeepEmptyEntries[storeElem]
 INFO:  jitting method Path::IsRelative using LLILCJit
 Successfully read Path.IsRelative
 
@@ -5243,8 +6411,8 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -5254,8 +6422,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
@@ -5271,8 +6439,8 @@ entry:
 
 ; <label>:17                                      ; preds = %7
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
@@ -5288,8 +6456,8 @@ entry:
 
 ; <label>:29                                      ; preds = %19
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %31
 
 ; <label>:31                                      ; preds = %29
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
@@ -5300,8 +6468,8 @@ entry:
 
 ; <label>:36                                      ; preds = %31
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
-  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %37, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
@@ -5312,8 +6480,8 @@ entry:
 
 ; <label>:43                                      ; preds = %31, %38
   %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
-  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %45
 
 ; <label>:45                                      ; preds = %43
   %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
@@ -5324,8 +6492,8 @@ entry:
 
 ; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %50
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
@@ -5336,8 +6504,8 @@ entry:
 
 ; <label>:57                                      ; preds = %1, %7, %19, %45, %52
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
-  br i1 %NullCheck14, label %59, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %59
 
 ; <label>:59                                      ; preds = %57
   %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
@@ -5347,8 +6515,8 @@ entry:
 
 ; <label>:63                                      ; preds = %59
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
@@ -5359,8 +6527,8 @@ entry:
 
 ; <label>:70                                      ; preds = %65
   %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
-  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.String addrspace(1)* %71, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %72
 
 ; <label>:72                                      ; preds = %70
   %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
@@ -5379,39 +6547,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %17
+ThrowNullRef4:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %29
+ThrowNullRef6:                                    ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %36
+ThrowNullRef8:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %43
+ThrowNullRef10:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %50
+ThrowNullRef12:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %57
+ThrowNullRef14:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %63
+ThrowNullRef16:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %70
+ThrowNullRef18:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5419,7 +6587,293 @@ ThrowNullRef17:                                   ; preds = %70
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
-Failed to read String.TrimHelper[loadElem]
+Successfully read String.TrimHelper
+
+define %System.String addrspace(1)* @String.TrimHelper(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i16
+  %loc4 = alloca i32
+  %loc5 = alloca i16
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = sub i32 %3, 1
+  store i32 %4, i32* %loc0
+  store i32 0, i32* %loc1
+  %5 = load i32, i32* %arg2
+  %6 = icmp eq i32 %5, 1
+  br i1 %6, label %62, label %7
+
+; <label>:7                                       ; preds = %1
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:8                                       ; preds = %58
+  store i32 0, i32* %loc2
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load i32, i32* %loc1
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2, i32 %10
+  %13 = load i16, i16 addrspace(1)* %12
+  %14 = zext i16 %13 to i32
+  %15 = trunc i32 %14 to i16
+  store i16 %15, i16* %loc3
+  store i32 0, i32* %loc2
+  br label %34
+
+; <label>:16                                      ; preds = %37
+  %17 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %18 = load i32, i32* %loc2
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %17, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %19
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = zext i32 %18 to i64
+  %BoundsCheck = icmp uge i64 %23, %22
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %24
+
+; <label>:24                                      ; preds = %19
+  %25 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 3, i32 %18
+  %26 = load i16, i16 addrspace(1)* %25, align 8
+  %27 = zext i16 %26 to i32
+  %28 = load i16, i16* %loc3
+  %29 = zext i16 %28 to i32
+  %30 = icmp eq i32 %27, %29
+  br i1 %30, label %43, label %31
+
+; <label>:31                                      ; preds = %24
+  %32 = load i32, i32* %loc2
+  %33 = add i32 %32, 1
+  store i32 %33, i32* %loc2
+  br label %34
+
+; <label>:34                                      ; preds = %11, %31
+  %35 = load i32, i32* %loc2
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = icmp slt i32 %35, %41
+  br i1 %42, label %16, label %43
+
+; <label>:43                                      ; preds = %24, %37
+  %44 = load i32, i32* %loc2
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %45, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp eq i32 %44, %50
+  br i1 %51, label %62, label %52
+
+; <label>:52                                      ; preds = %46
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %7, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %57, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %58
+
+; <label>:58                                      ; preds = %55
+  %59 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %60 = load i32, i32 addrspace(1)* %59
+  %61 = icmp slt i32 %56, %60
+  br i1 %61, label %8, label %62
+
+; <label>:62                                      ; preds = %1, %46, %58
+  %63 = load i32, i32* %arg2
+  %64 = icmp eq i32 %63, 0
+  br i1 %64, label %122, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %66, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %67
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %66, i32 0, i32 1
+  %69 = load i32, i32 addrspace(1)* %68
+  %70 = sub i32 %69, 1
+  store i32 %70, i32* %loc0
+  br label %118
+
+; <label>:71                                      ; preds = %118
+  store i32 0, i32* %loc4
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %73 = load i32, i32* %loc0
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %74
+
+; <label>:74                                      ; preds = %71
+  %75 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 2, i32 %73
+  %76 = load i16, i16 addrspace(1)* %75
+  %77 = zext i16 %76 to i32
+  %78 = trunc i32 %77 to i16
+  store i16 %78, i16* %loc5
+  store i32 0, i32* %loc4
+  br label %97
+
+; <label>:79                                      ; preds = %100
+  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %81 = load i32, i32* %loc4
+  %NullCheck19 = icmp eq %"System.Char[]" addrspace(1)* %80, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
+
+; <label>:82                                      ; preds = %79
+  %83 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 1
+  %84 = load i32, i32 addrspace(1)* %83
+  %85 = zext i32 %84 to i64
+  %86 = zext i32 %81 to i64
+  %BoundsCheck21 = icmp uge i64 %86, %85
+  br i1 %BoundsCheck21, label %ThrowIndexOutOfRange22, label %87
+
+; <label>:87                                      ; preds = %82
+  %88 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 3, i32 %81
+  %89 = load i16, i16 addrspace(1)* %88, align 8
+  %90 = zext i16 %89 to i32
+  %91 = load i16, i16* %loc5
+  %92 = zext i16 %91 to i32
+  %93 = icmp eq i32 %90, %92
+  br i1 %93, label %106, label %94
+
+; <label>:94                                      ; preds = %87
+  %95 = load i32, i32* %loc4
+  %96 = add i32 %95, 1
+  store i32 %96, i32* %loc4
+  br label %97
+
+; <label>:97                                      ; preds = %74, %94
+  %98 = load i32, i32* %loc4
+  %99 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck15 = icmp eq %"System.Char[]" addrspace(1)* %99, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %100
+
+; <label>:100                                     ; preds = %97
+  %101 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %99, i32 0, i32 1
+  %102 = load i32, i32 addrspace(1)* %101
+  %103 = zext i32 %102 to i64
+  %104 = trunc i64 %103 to i32
+  %105 = icmp slt i32 %98, %104
+  br i1 %105, label %79, label %106
+
+; <label>:106                                     ; preds = %87, %100
+  %107 = load i32, i32* %loc4
+  %108 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck17 = icmp eq %"System.Char[]" addrspace(1)* %108, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %109
+
+; <label>:109                                     ; preds = %106
+  %110 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %108, i32 0, i32 1
+  %111 = load i32, i32 addrspace(1)* %110
+  %112 = zext i32 %111 to i64
+  %113 = trunc i64 %112 to i32
+  %114 = icmp eq i32 %107, %113
+  br i1 %114, label %122, label %115
+
+; <label>:115                                     ; preds = %109
+  %116 = load i32, i32* %loc0
+  %117 = sub i32 %116, 1
+  store i32 %117, i32* %loc0
+  br label %118
+
+; <label>:118                                     ; preds = %67, %115
+  %119 = load i32, i32* %loc0
+  %120 = load i32, i32* %loc1
+  %121 = icmp sge i32 %119, %120
+  br i1 %121, label %71, label %122
+
+; <label>:122                                     ; preds = %62, %109, %118
+  %123 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %124 = load i32, i32* %loc1
+  %125 = load i32, i32* %loc0
+  %126 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %123, i32 %124, i32 %125)
+  ret %System.String addrspace(1)* %126
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %97
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange22:                           ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
 Successfully read String.CreateTrimmedString
 
@@ -5439,8 +6893,8 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
@@ -5535,8 +6989,8 @@ entry:
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i64 2872
   %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
   %8 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %7
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %3
   %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
@@ -5553,8 +7007,8 @@ entry:
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 2864
   %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
   %21 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %20
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
-  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %22
 
 ; <label>:22                                      ; preds = %16
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
@@ -5569,7 +7023,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %16
+ThrowNullRef2:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5586,8 +7040,8 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5613,8 +7067,8 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
@@ -5632,8 +7086,8 @@ entry:
 
 ; <label>:12                                      ; preds = %4
   %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
@@ -5644,8 +7098,8 @@ entry:
 
 ; <label>:19                                      ; preds = %14
   %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %19
   %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
@@ -5660,21 +7114,21 @@ entry:
   %31 = zext i16 %30 to i32
   %32 = bitcast i8* %29 to i16*
   %33 = trunc i32 %31 to i16
-  %NullCheck6 = icmp ne i16* %32, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i16* %32, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %21
   store i16 %33, i16* %32, align 8
   %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %36
 
 ; <label>:36                                      ; preds = %34
   %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
   %38 = load i32, i32 addrspace(1)* %37, align 8
   %39 = add i32 %38, 1
-  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %40
 
 ; <label>:40                                      ; preds = %36
   %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
@@ -5683,16 +7137,16 @@ entry:
 
 ; <label>:42                                      ; preds = %14
   %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
-  br i1 %NullCheck12, label %44, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
   %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
   %47 = load i16, i16* %arg1
   %48 = zext i16 %47 to i32
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = trunc i32 %48 to i16
@@ -5703,31 +7157,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %19
+ThrowNullRef4:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %21
+ThrowNullRef6:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %36
+ThrowNullRef10:                                   ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %42
+ThrowNullRef12:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %44
+ThrowNullRef14:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5740,8 +7194,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -5752,8 +7206,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
@@ -5762,14 +7216,14 @@ entry:
 
 ; <label>:11                                      ; preds = %1
   %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
@@ -5779,15 +7233,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5808,8 +7262,8 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5822,8 +7276,8 @@ entry:
 
 ; <label>:8                                       ; preds = %3
   %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
@@ -5842,15 +7296,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
-  br i1 %NullCheck4, label %22, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
   %24 = load i16*, i16* addrspace(1)* %23, align 8
   %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %25, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
@@ -5859,8 +7313,8 @@ entry:
   store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
@@ -5874,8 +7328,8 @@ entry:
 
 ; <label>:37                                      ; preds = %65
   %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %37
   %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
@@ -5886,16 +7340,16 @@ entry:
   %45 = bitcast i16* %41 to i8*
   %46 = getelementptr inbounds i8, i8* %45, i64 %44
   %47 = bitcast i8* %46 to i16*
-  %NullCheck14 = icmp ne i16* %47, null
-  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %47, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %48
 
 ; <label>:48                                      ; preds = %39
   %49 = load i16, i16* %47, align 8
   %50 = zext i16 %49 to i32
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %52 = load i32, i32* %loc1
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %53
 
 ; <label>:53                                      ; preds = %48
   %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
@@ -5916,8 +7370,8 @@ entry:
 ; <label>:62                                      ; preds = %36, %59
   %63 = load i32, i32* %loc1
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck10, label %65, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %65
 
 ; <label>:65                                      ; preds = %62
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
@@ -5936,15 +7390,15 @@ entry:
 
 ; <label>:74                                      ; preds = %70
   %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
-  br i1 %NullCheck18, label %76, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %76
 
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
   %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
-  br i1 %NullCheck20, label %80, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
   %81 = load i64, i64 addrspace(1)* %79
@@ -5958,8 +7412,8 @@ entry:
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
   %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
-  br i1 %NullCheck22, label %92, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.String addrspace(1)* %90, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %92
 
 ; <label>:92                                      ; preds = %80
   %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
@@ -5969,15 +7423,15 @@ entry:
 
 ; <label>:96                                      ; preds = %70
   %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
-  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %98
 
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
   %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
-  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
   %103 = load i64, i64 addrspace(1)* %101
@@ -5991,8 +7445,8 @@ entry:
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
   %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
-  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.String addrspace(1)* %112, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %114
 
 ; <label>:114                                     ; preds = %102
   %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
@@ -6004,59 +7458,59 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %20
+ThrowNullRef4:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %22
+ThrowNullRef6:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %26
+ThrowNullRef8:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %62
+ThrowNullRef10:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %48
+ThrowNullRef16:                                   ; preds = %48
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %74
+ThrowNullRef18:                                   ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %76
+ThrowNullRef20:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %80
+ThrowNullRef22:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %96
+ThrowNullRef24:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %98
+ThrowNullRef26:                                   ; preds = %98
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %102
+ThrowNullRef28:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6069,15 +7523,15 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
   %3 = load i16*, i16* addrspace(1)* %2, align 8
   %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
@@ -6087,8 +7541,8 @@ entry:
   %10 = bitcast i16* %3 to i8*
   %11 = getelementptr inbounds i8, i8* %10, i64 %9
   %12 = bitcast i8* %11 to i16*
-  %NullCheck4 = icmp ne i16* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %5
   store i16 0, i16* %12, align 8
@@ -6098,11 +7552,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6119,8 +7573,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -6131,8 +7585,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
@@ -6144,15 +7598,15 @@ entry:
 
 ; <label>:14                                      ; preds = %1
   %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
   %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
   %21 = load i64, i64 addrspace(1)* %19
@@ -6171,15 +7625,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %14
+ThrowNullRef4:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %16
+ThrowNullRef6:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6302,14 +7756,6 @@ entry:
   ret %System.String addrspace(1)* %57
 }
 
-INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
-Successfully read RuntimeHelpers.get_OffsetToStringData
-
-define i32 @RuntimeHelpers.get_OffsetToStringData() {
-entry:
-  ret i32 12
-}
-
 INFO:  jitting method String::Equals using LLILCJit
 Successfully read String.Equals
 
@@ -6381,8 +7827,8 @@ entry:
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
-  br i1 %NullCheck24, label %29, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
   %30 = load i64, i64 addrspace(1)* %28
@@ -6397,8 +7843,8 @@ entry:
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
-  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
   %43 = load i64, i64 addrspace(1)* %41
@@ -6418,8 +7864,8 @@ entry:
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
   %59 = load i64, i64 addrspace(1)* %57
@@ -6434,8 +7880,8 @@ entry:
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck22, label %71, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
   %72 = load i64, i64 addrspace(1)* %70
@@ -6455,8 +7901,8 @@ entry:
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
-  br i1 %NullCheck16, label %87, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = load i64, i64 addrspace(1)* %86
@@ -6471,8 +7917,8 @@ entry:
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck18, label %100, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
   %101 = load i64, i64 addrspace(1)* %99
@@ -6492,8 +7938,8 @@ entry:
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
-  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
   %117 = load i64, i64 addrspace(1)* %115
@@ -6508,8 +7954,8 @@ entry:
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
-  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
   %130 = load i64, i64 addrspace(1)* %128
@@ -6528,15 +7974,15 @@ entry:
 
 ; <label>:142                                     ; preds = %22
   %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
-  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %143, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %144
 
 ; <label>:144                                     ; preds = %142
   %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
   %146 = load i32, i32 addrspace(1)* %145
   %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
-  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %147, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %148
 
 ; <label>:148                                     ; preds = %144
   %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
@@ -6557,15 +8003,15 @@ entry:
 
 ; <label>:159                                     ; preds = %22
   %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
-  br i1 %NullCheck, label %161, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %ThrowNullRef, label %161
 
 ; <label>:161                                     ; preds = %159
   %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
   %163 = load i32, i32 addrspace(1)* %162
   %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
-  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %164, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %165
 
 ; <label>:165                                     ; preds = %161
   %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
@@ -6578,8 +8024,8 @@ entry:
 
 ; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
-  br i1 %NullCheck4, label %172, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %171, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %172
 
 ; <label>:172                                     ; preds = %170
   %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
@@ -6589,8 +8035,8 @@ entry:
 
 ; <label>:176                                     ; preds = %172
   %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
-  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %177, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %178
 
 ; <label>:178                                     ; preds = %176
   %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
@@ -6629,55 +8075,55 @@ ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %161
+ThrowNullRef2:                                    ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %170
+ThrowNullRef4:                                    ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %176
+ThrowNullRef6:                                    ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %142
+ThrowNullRef8:                                    ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %144
+ThrowNullRef10:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %113
+ThrowNullRef12:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %116
+ThrowNullRef14:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %84
+ThrowNullRef16:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %87
+ThrowNullRef18:                                   ; preds = %87
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %55
+ThrowNullRef20:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %58
+ThrowNullRef22:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %26
+ThrowNullRef24:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %29
+ThrowNullRef26:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,8 +8161,8 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck, label %14, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %ThrowNullRef, label %14
 
 ; <label>:14                                      ; preds = %8
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
@@ -6760,8 +8206,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
@@ -6770,14 +8216,14 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32, i32* %loc0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %10
   %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
   %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
@@ -6790,15 +8236,15 @@ entry:
 ; <label>:25                                      ; preds = %19
   %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
-  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
   %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
@@ -6807,8 +8253,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %37 = load i32, i32* %loc0
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %38, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %38
 
 ; <label>:38                                      ; preds = %32
   %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
@@ -6817,14 +8263,14 @@ entry:
 
 ; <label>:40                                      ; preds = %19
   %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %40
   %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
   %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
-  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
-  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
@@ -6832,8 +8278,8 @@ entry:
   %48 = zext i32 %47 to i64
   %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
-  br i1 %NullCheck16, label %51, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %51
 
 ; <label>:51                                      ; preds = %45
   %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
@@ -6847,15 +8293,15 @@ entry:
 ; <label>:57                                      ; preds = %51
   %58 = load i16*, i16** %arg1
   %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
-  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %60
 
 ; <label>:60                                      ; preds = %57
   %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
   %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
-  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %64
 
 ; <label>:64                                      ; preds = %60
   %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
@@ -6864,22 +8310,22 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
   %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
-  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %70
 
 ; <label>:70                                      ; preds = %64
   %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
   %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
-  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
-  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
   %75 = load i32, i32 addrspace(1)* %74
   %76 = zext i32 %75 to i64
   %77 = trunc i64 %76 to i32
-  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
-  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %78
 
 ; <label>:78                                      ; preds = %73
   %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
@@ -6901,8 +8347,8 @@ entry:
   %90 = bitcast i16* %86 to i8*
   %91 = getelementptr inbounds i8, i8* %90, i64 %89
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %93
 
 ; <label>:93                                      ; preds = %80
   %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
@@ -6912,8 +8358,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %99 = load i32, i32* %loc2
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %100
 
 ; <label>:100                                     ; preds = %93
   %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
@@ -6928,63 +8374,63 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %25
+ThrowNullRef6:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %32
+ThrowNullRef10:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %40
+ThrowNullRef12:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %45
+ThrowNullRef16:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %57
+ThrowNullRef18:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %60
+ThrowNullRef20:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %64
+ThrowNullRef22:                                   ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %70
+ThrowNullRef24:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %73
+ThrowNullRef26:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %80
+ThrowNullRef28:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %93
+ThrowNullRef30:                                   ; preds = %93
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7004,8 +8450,8 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
@@ -7033,43 +8479,43 @@ entry:
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %14
   %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
   %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   %28 = load i32, i32 addrspace(1)* %27, align 8
   %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
-  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %30
 
 ; <label>:30                                      ; preds = %26
   %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
   %32 = load i32, i32 addrspace(1)* %31, align 8
   %33 = add i32 %28, %32
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %34
 
 ; <label>:34                                      ; preds = %30
   %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   store i32 %33, i32 addrspace(1)* %35
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
   store i32 0, i32 addrspace(1)* %38
   %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %40
 
 ; <label>:40                                      ; preds = %37
   %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
@@ -7082,8 +8528,8 @@ entry:
 
 ; <label>:47                                      ; preds = %40
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
@@ -7098,8 +8544,8 @@ entry:
   %54 = load i32, i32* %loc0
   %55 = sext i32 %54 to i64
   %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
-  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %57
 
 ; <label>:57                                      ; preds = %52
   %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
@@ -7110,68 +8556,35 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %14
+ThrowNullRef2:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %23
+ThrowNullRef4:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %26
+ThrowNullRef6:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %30
+ThrowNullRef8:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %34
+ThrowNullRef10:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %47
+ThrowNullRef14:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %52
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-}
-
-INFO:  jitting method StringBuilder::get_Length using LLILCJit
-Successfully read StringBuilder.get_Length
-
-define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.StringBuilder addrspace(1)*
-  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
-  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
-
-; <label>:1                                       ; preds = %entry
-  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %3 = load i32, i32 addrspace(1)* %2, align 8
-  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
-
-; <label>:5                                       ; preds = %1
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = add i32 %3, %7
-  ret i32 %8
-
-ThrowNullRef:                                     ; preds = %entry
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef16:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7213,70 +8626,70 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
   %6 = load i32, i32 addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
   store i32 %6, i32 addrspace(1)* %8
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
   %13 = load i32, i32 addrspace(1)* %12, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
   store i32 %13, i32 addrspace(1)* %15
   %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
-  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %18
 
 ; <label>:18                                      ; preds = %14
   %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
   %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
   %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
   %34 = load i32, i32 addrspace(1)* %33, align 8
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
-  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
@@ -7287,39 +8700,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %28
+ThrowNullRef16:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %32
+ThrowNullRef18:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7455,13 +8868,13 @@ entry:
 ; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
@@ -7477,16 +8890,16 @@ entry:
 
 ; <label>:18                                      ; preds = %15
   %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
   store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
   %22 = load i32, i32* %loc0
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %24
 
 ; <label>:24                                      ; preds = %20
   %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
@@ -7498,13 +8911,13 @@ entry:
 ; <label>:28                                      ; preds = %15, %24
   %29 = load i32, i32* %arg1
   %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %31
   %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
@@ -7517,20 +8930,20 @@ entry:
   %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
-  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
   %46 = load i32, i32 addrspace(1)* %45, align 8
   %47 = sub i32 %40, %46
-  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
-  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i32 addrspace(1)* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %48
 
 ; <label>:48                                      ; preds = %44
   store i32 %47, i32 addrspace(1)* %39, align 8
@@ -7538,21 +8951,21 @@ entry:
 
 ; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
-  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %51
 
 ; <label>:51                                      ; preds = %49
   %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %53
 
 ; <label>:53                                      ; preds = %51
   %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
   %55 = load i32, i32 addrspace(1)* %54, align 8
   %56 = load i32, i32* %arg2
   %57 = sub i32 %55, %56
-  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %58
 
 ; <label>:58                                      ; preds = %53
   %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
@@ -7562,13 +8975,13 @@ entry:
 ; <label>:60                                      ; preds = %33, %58
   %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
   %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
-  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %63
 
 ; <label>:63                                      ; preds = %60
   %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
-  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
-  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
@@ -7578,15 +8991,15 @@ entry:
 
 ; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
-  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i32 addrspace(1)* %69, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %70
 
 ; <label>:70                                      ; preds = %68
   %71 = load i32, i32 addrspace(1)* %69, align 8
   store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
-  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
@@ -7596,8 +9009,8 @@ entry:
   store i32 %77, i32* %loc4
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
-  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %80
 
 ; <label>:80                                      ; preds = %73
   %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
@@ -7607,71 +9020,71 @@ entry:
 ; <label>:83                                      ; preds = %80
   store i32 0, i32* %loc3
   %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
-  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
-  br i1 %NullCheck26, label %88, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i32 addrspace(1)* %87, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %88
 
 ; <label>:88                                      ; preds = %85
   %89 = load i32, i32 addrspace(1)* %87, align 8
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
-  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %90
 
 ; <label>:90                                      ; preds = %88
   %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
   store i32 %89, i32 addrspace(1)* %91
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
-  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
-  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %96
 
 ; <label>:96                                      ; preds = %94
   %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
-  br i1 %NullCheck34, label %100, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %100
 
 ; <label>:100                                     ; preds = %96
   %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
-  br i1 %NullCheck36, label %102, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %102
 
 ; <label>:102                                     ; preds = %100
   %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
   %104 = load i32, i32 addrspace(1)* %103, align 8
   %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
-  br i1 %NullCheck38, label %106, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %106
 
 ; <label>:106                                     ; preds = %102
   %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
-  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
-  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %108
 
 ; <label>:108                                     ; preds = %106
   %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
   %110 = load i32, i32 addrspace(1)* %109, align 8
   %111 = add i32 %104, %110
-  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %112
 
 ; <label>:112                                     ; preds = %108
   %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
   store i32 %111, i32 addrspace(1)* %113
   %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
-  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i32 addrspace(1)* %114, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %115
 
 ; <label>:115                                     ; preds = %112
   %116 = load i32, i32 addrspace(1)* %114, align 8
@@ -7681,19 +9094,19 @@ entry:
 ; <label>:118                                     ; preds = %115
   %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
-  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %121
 
 ; <label>:121                                     ; preds = %118
   %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
-  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
-  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %123
 
 ; <label>:123                                     ; preds = %121
   %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
   %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
-  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
-  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %126
 
 ; <label>:126                                     ; preds = %123
   %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
@@ -7705,8 +9118,8 @@ entry:
 
 ; <label>:130                                     ; preds = %80, %115, %126
   %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %132
 
 ; <label>:132                                     ; preds = %130
   %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7715,8 +9128,8 @@ entry:
   %136 = load i32, i32* %loc3
   %137 = sub i32 %135, %136
   %138 = sub i32 %134, %137
-  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %139
 
 ; <label>:139                                     ; preds = %132
   %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7728,16 +9141,16 @@ entry:
 
 ; <label>:144                                     ; preds = %139
   %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
-  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %146
 
 ; <label>:146                                     ; preds = %144
   %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
   %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
   %149 = load i32, i32* %loc2
   %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
-  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %151
 
 ; <label>:151                                     ; preds = %146
   %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
@@ -7754,145 +9167,249 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %18
+ThrowNullRef4:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %31
+ThrowNullRef10:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %44
+ThrowNullRef16:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %68
+ThrowNullRef18:                                   ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %70
+ThrowNullRef20:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %73
+ThrowNullRef22:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %83
+ThrowNullRef24:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %85
+ThrowNullRef26:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %88
+ThrowNullRef28:                                   ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %90
+ThrowNullRef30:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %94
+ThrowNullRef32:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %96
+ThrowNullRef34:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %100
+ThrowNullRef36:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %102
+ThrowNullRef38:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %106
+ThrowNullRef40:                                   ; preds = %106
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %108
+ThrowNullRef42:                                   ; preds = %108
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %112
+ThrowNullRef44:                                   ; preds = %112
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %118
+ThrowNullRef46:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %121
+ThrowNullRef48:                                   ; preds = %121
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %123
+ThrowNullRef50:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %130
+ThrowNullRef52:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %132
+ThrowNullRef54:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %144
+ThrowNullRef56:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %146
+ThrowNullRef58:                                   ; preds = %146
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %60
+ThrowNullRef60:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %63
+ThrowNullRef62:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %49
+ThrowNullRef64:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %51
+ThrowNullRef66:                                   ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %53
+ThrowNullRef68:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(%"System.Char[]" addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %arg0 = alloca %"System.Char[]" addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store %"System.Char[]" addrspace(1)* %param0, %"System.Char[]" addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load i32, i32* %arg4
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %43, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %38, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg1
+  %13 = load i32, i32* %arg4
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %38, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %24 = load i32, i32* %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %35 = load i32, i32* %arg3
+  %36 = load i32, i32* %arg4
+  %37 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %37, %"System.Char[]" addrspace(1)* %34, i32 %35, i32 %36)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:38                                      ; preds = %5, %16
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Successfully read Buffer._Memmove
 
@@ -7914,7 +9431,7 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[loadElem]
+Failed to read AppDomain.SetDataHelper[storeElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -7923,8 +9440,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
@@ -7934,8 +9451,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
@@ -7947,15 +9464,15 @@ entry:
   %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
   %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
@@ -7966,15 +9483,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7992,7 +9509,79 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
-Failed to read Dictionary`2.TryGetValue[loadElemA]
+Successfully read Dictionary`2.TryGetValue
+
+define i8 @"Dictionary`2.TryGetValue"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)* addrspace(1)* %param2) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  %arg2 = alloca %System.__Canon addrspace(1)* addrspace(1)*
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  store %System.__Canon addrspace(1)* addrspace(1)* %param2, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  store i32 %2, i32* %loc0
+  %3 = load i32, i32* %loc0
+  %4 = icmp slt i32 %3, 0
+  br i1 %4, label %22, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 2
+  %10 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %9, align 8
+  %11 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = zext i32 %11 to i64
+  %BoundsCheck = icmp uge i64 %16, %15
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 3, i32 %11
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %20, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %6, %System.__Canon addrspace(1)* %21)
+  ret i8 1
+
+; <label>:22                                      ; preds = %entry
+  %23 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %23, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -8058,8 +9647,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
@@ -8091,8 +9680,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
@@ -8171,15 +9760,15 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck, label %19, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %ThrowNullRef, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
   %21 = load i32, i32 addrspace(1)* %20
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
@@ -8202,7 +9791,7 @@ ThrowNullRef:                                     ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %19
+ThrowNullRef2:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8248,8 +9837,8 @@ entry:
   %0 = alloca %System.AppDomainHandle
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %1 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %1, i32 0, i32 15
@@ -8269,8 +9858,8 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
@@ -8286,7 +9875,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -8299,8 +9888,8 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -8327,8 +9916,8 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
@@ -8352,8 +9941,8 @@ entry:
   %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
   store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
@@ -8363,8 +9952,8 @@ entry:
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
@@ -8374,8 +9963,8 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %9
   %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
@@ -8384,8 +9973,8 @@ entry:
 
 ; <label>:18                                      ; preds = %3, %16
   %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
@@ -8397,15 +9986,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %18
+ThrowNullRef6:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8418,8 +10007,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
@@ -8453,15 +10042,15 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
@@ -8473,7 +10062,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8481,7 +10070,7 @@ ThrowNullRef1:                                    ; preds = %1
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
 Failed to read Dictionary`2.System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
@@ -8506,8 +10095,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
@@ -8524,8 +10113,8 @@ entry:
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -8544,7 +10133,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8577,8 +10166,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = load i64, i64* %arg2
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = trunc i32 %3 to i8
@@ -8634,46 +10223,46 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
   %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
-  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
-  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
-  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
@@ -8684,27 +10273,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %20
+ThrowNullRef12:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8717,8 +10306,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -8756,22 +10345,22 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
   %9 = load i64, i64 addrspace(1)* %8, align 8
   %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
   %13 = load i64, i64 addrspace(1)* %12, align 8
   %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %11
   %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
@@ -8788,11 +10377,11 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8882,8 +10471,8 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
@@ -8900,8 +10489,8 @@ entry:
 ; <label>:8                                       ; preds = %1
   %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
   %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
@@ -8911,15 +10500,15 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
   %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
   %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
-  br i1 %NullCheck6, label %21, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
@@ -8946,15 +10535,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8992,15 +10581,15 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
   store i8 %3, i8 addrspace(1)* %5
   %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
@@ -9011,7 +10600,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9027,8 +10616,8 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -9041,8 +10630,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
@@ -9058,7 +10647,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9080,8 +10669,8 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
@@ -9096,8 +10685,8 @@ entry:
 ; <label>:12                                      ; preds = %6
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
@@ -9112,8 +10701,8 @@ entry:
 ; <label>:21                                      ; preds = %15
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
@@ -9128,8 +10717,8 @@ entry:
 ; <label>:30                                      ; preds = %24
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %31, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
@@ -9144,8 +10733,8 @@ entry:
 ; <label>:39                                      ; preds = %33
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
-  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %40, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %42
 
 ; <label>:42                                      ; preds = %39
   %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
@@ -9164,19 +10753,19 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %21
+ThrowNullRef4:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %30
+ThrowNullRef6:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %39
+ThrowNullRef8:                                    ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9243,8 +10832,8 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
@@ -9264,57 +10853,57 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
   store i8 0, i8 addrspace(1)* %2
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
   store i8 0, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
   store i8 0, i8 addrspace(1)* %17
   %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
   store i8 0, i8 addrspace(1)* %20
   %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
-  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
@@ -9325,31 +10914,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %19
+ThrowNullRef14:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9367,8 +10956,8 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
@@ -9380,8 +10969,8 @@ entry:
 
 ; <label>:9                                       ; preds = %4
   %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %9
   %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
@@ -9395,7 +10984,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef2:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9420,8 +11009,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
@@ -9512,8 +11101,8 @@ entry:
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
@@ -9524,8 +11113,8 @@ entry:
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = load i64, i64 addrspace(1)* %12
@@ -9537,8 +11126,8 @@ entry:
   %20 = load i64, i64* %19
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
-  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %13
   %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
@@ -9555,8 +11144,8 @@ entry:
 ; <label>:30                                      ; preds = %25
   %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %32 = load i32, i32* %arg2
-  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
-  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
@@ -9570,15 +11159,15 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %30
+ThrowNullRef2:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9622,87 +11211,87 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
   %10 = load i8, i8 addrspace(1)* %9, align 8
   %11 = zext i8 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %8
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
   store i8 %12, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
   %19 = load i8, i8 addrspace(1)* %18, align 8
   %20 = zext i8 %19 to i32
   %21 = trunc i32 %20 to i8
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
   store i8 %21, i8 addrspace(1)* %23
   %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
   %28 = load i8, i8 addrspace(1)* %27, align 8
   %29 = zext i8 %28 to i32
   %30 = trunc i32 %29 to i8
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
-  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %31
 
 ; <label>:31                                      ; preds = %26
   %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
   store i8 %30, i8 addrspace(1)* %32
   %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
-  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
-  br i1 %NullCheck14, label %40, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %40
 
 ; <label>:40                                      ; preds = %35
   %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
   store i8 %39, i8 addrspace(1)* %41
   %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
-  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %44
 
 ; <label>:44                                      ; preds = %40
   %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
   %46 = load i8, i8 addrspace(1)* %45, align 8
   %47 = zext i8 %46 to i32
   %48 = trunc i32 %47 to i8
-  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
   store i8 %48, i8 addrspace(1)* %50
   %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
-  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
@@ -9713,29 +11302,29 @@ entry:
 ; <label>:56                                      ; preds = %52
   %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
-  br i1 %NullCheck22, label %59, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
   %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
   %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
-  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
-  br i1 %NullCheck24, label %63, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
   %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
-  br i1 %NullCheck26, label %66, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
   %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
-  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
-  br i1 %NullCheck28, label %69, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %69
 
 ; <label>:69                                      ; preds = %66
   %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
@@ -9744,15 +11333,15 @@ entry:
 
 ; <label>:71                                      ; preds = %105
   %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
-  br i1 %NullCheck34, label %73, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %73
 
 ; <label>:73                                      ; preds = %71
   %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
   %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
   %76 = load i32, i32* %loc0
-  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
-  br i1 %NullCheck36, label %77, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
@@ -9766,8 +11355,8 @@ entry:
 
 ; <label>:83                                      ; preds = %77
   %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
-  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
@@ -9775,14 +11364,14 @@ entry:
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
   %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
-  br i1 %NullCheck40, label %91, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
 ; <label>:91                                      ; preds = %85
   %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
   %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
-  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck42, label %94, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %94
 
 ; <label>:94                                      ; preds = %91
   %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
@@ -9798,14 +11387,14 @@ entry:
 ; <label>:99                                      ; preds = %69, %96
   %100 = load i32, i32* %loc0
   %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
-  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %102
 
 ; <label>:102                                     ; preds = %99
   %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
   %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
-  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
-  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
@@ -9819,87 +11408,87 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %26
+ThrowNullRef10:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %31
+ThrowNullRef12:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %35
+ThrowNullRef14:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %40
+ThrowNullRef16:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %56
+ThrowNullRef22:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %59
+ThrowNullRef24:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %63
+ThrowNullRef26:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %66
+ThrowNullRef28:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %102
+ThrowNullRef32:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %71
+ThrowNullRef34:                                   ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %73
+ThrowNullRef36:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %83
+ThrowNullRef38:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %85
+ThrowNullRef40:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %91
+ThrowNullRef42:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9943,15 +11532,15 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
   %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
@@ -9961,28 +11550,28 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
   %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %12
   %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
   %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
   %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
-  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
@@ -9993,23 +11582,23 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %12
+ThrowNullRef6:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10031,15 +11620,15 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
   %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = load i64, i64 addrspace(1)* %7
@@ -10077,13 +11666,13 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[loadElem]
+Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -10111,8 +11700,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -10198,8 +11787,8 @@ entry:
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load float, float* %arg0
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -10333,8 +11922,8 @@ entry:
   store i64 %param0, i64* %arg0
   store i64 %param1, i64* %arg1
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
@@ -10342,8 +11931,8 @@ entry:
   %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
   %5 = load i16*, i16* addrspace(1)* %4, align 8
   %6 = addrspacecast i64* %arg1 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = bitcast i64 addrspace(1)* %6 to i8 addrspace(1)*
@@ -10359,7 +11948,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10393,8 +11982,8 @@ entry:
   %1 = load i32, i32* %arg1
   %2 = sext i32 %1 to i64
   %3 = inttoptr i64 %2 to i16*
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -10447,8 +12036,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, i32)*)(%System.IO.ConsoleStream addrspace(1)* %2, i32 %1)
   %3 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %4 = load i64, i64* %arg1
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
@@ -10459,8 +12048,8 @@ entry:
   %10 = icmp eq i32 %9, 3
   %11 = sext i1 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %5
   %14 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, i32 0, i32 5
@@ -10471,7 +12060,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10494,8 +12083,8 @@ entry:
   %5 = icmp eq i32 %4, 1
   %6 = sext i1 %5 to i32
   %7 = trunc i32 %6 to i8
-  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %2, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.ConsoleStream addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
@@ -10506,8 +12095,8 @@ entry:
   %13 = icmp eq i32 %12, 2
   %14 = sext i1 %13 to i32
   %15 = trunc i32 %14 to i8
-  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %10, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.ConsoleStream addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %8
   %17 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %10, i32 0, i32 4
@@ -10518,7 +12107,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10557,8 +12146,8 @@ entry:
   %arg0 = alloca i64
   store i64 %param0, i64* %arg0
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
@@ -10593,8 +12182,8 @@ entry:
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
   %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = load i64, i64 addrspace(1)* %7
@@ -10698,7 +12287,127 @@ entry:
 INFO:  jitting method Encoding::GetEncoding using LLILCJit
 Failed to read Encoding.GetEncoding[convertToHelperArgumentType]
 INFO:  jitting method EncodingProvider::GetEncodingFromProvider using LLILCJit
-Failed to read EncodingProvider.GetEncodingFromProvider[loadElem]
+Successfully read EncodingProvider.GetEncodingFromProvider
+
+define %System.Text.Encoding addrspace(1)* @EncodingProvider.GetEncodingFromProvider(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca %"System.Text.EncodingProvider[]" addrspace(1)*
+  %loc1 = alloca %System.Text.EncodingProvider addrspace(1)*
+  %loc2 = alloca %System.Text.Encoding addrspace(1)*
+  %loc3 = alloca %System.Text.Encoding addrspace(1)*
+  %loc4 = alloca %"System.Text.EncodingProvider[]" addrspace(1)*
+  %loc5 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1059)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2392
+  %2 = addrspacecast i8 addrspace(1)* %1 to %"System.Text.EncodingProvider[]" addrspace(1)**
+  %3 = load volatile %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %2
+  %4 = icmp ne %"System.Text.EncodingProvider[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %entry
+  ret %System.Text.Encoding addrspace(1)* null
+
+; <label>:6                                       ; preds = %entry
+  %7 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1059)
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i64 2392
+  %9 = addrspacecast i8 addrspace(1)* %8 to %"System.Text.EncodingProvider[]" addrspace(1)**
+  %10 = load volatile %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %9
+  store %"System.Text.EncodingProvider[]" addrspace(1)* %10, %"System.Text.EncodingProvider[]" addrspace(1)** %loc0
+  %11 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc0
+  store %"System.Text.EncodingProvider[]" addrspace(1)* %11, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  store i32 0, i32* %loc5
+  br label %43
+
+; <label>:12                                      ; preds = %46
+  %13 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  %14 = load i32, i32* %loc5
+  %NullCheck1 = icmp eq %"System.Text.EncodingProvider[]" addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %13, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = zext i32 %17 to i64
+  %19 = zext i32 %14 to i64
+  %BoundsCheck = icmp uge i64 %19, %18
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %20
+
+; <label>:20                                      ; preds = %15
+  %21 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %13, i32 0, i32 3, i32 %14
+  %22 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)* addrspace(1)* %21, align 8
+  store %System.Text.EncodingProvider addrspace(1)* %22, %System.Text.EncodingProvider addrspace(1)** %loc1
+  %23 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)** %loc1
+  %24 = load i32, i32* %arg0
+  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i64 addrspace(1)*
+  %NullCheck3 = icmp eq i64 addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
+
+; <label>:26                                      ; preds = %20
+  %27 = load i64, i64 addrspace(1)* %25
+  %28 = add i64 %27, 64
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 40
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Text.Encoding addrspace(1)* (%System.Text.EncodingProvider addrspace(1)*, i32)*
+  %35 = call %System.Text.Encoding addrspace(1)* %34(%System.Text.EncodingProvider addrspace(1)* %23, i32 %24)
+  store %System.Text.Encoding addrspace(1)* %35, %System.Text.Encoding addrspace(1)** %loc2
+  %36 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc2
+  %37 = icmp eq %System.Text.Encoding addrspace(1)* %36, null
+  br i1 %37, label %40, label %38
+
+; <label>:38                                      ; preds = %26
+  %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc2
+  store %System.Text.Encoding addrspace(1)* %39, %System.Text.Encoding addrspace(1)** %loc3
+  br label %53
+
+; <label>:40                                      ; preds = %26
+  %41 = load i32, i32* %loc5
+  %42 = add i32 %41, 1
+  store i32 %42, i32* %loc5
+  br label %43
+
+; <label>:43                                      ; preds = %6, %40
+  %44 = load i32, i32* %loc5
+  %45 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  %NullCheck = icmp eq %"System.Text.EncodingProvider[]" addrspace(1)* %45, null
+  br i1 %NullCheck, label %ThrowNullRef, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp slt i32 %44, %50
+  br i1 %51, label %12, label %52
+
+; <label>:52                                      ; preds = %46
+  ret %System.Text.Encoding addrspace(1)* null
+
+; <label>:53                                      ; preds = %38
+  %54 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc3
+  ret %System.Text.Encoding addrspace(1)* %54
+
+ThrowNullRef:                                     ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method EncodingProvider::.cctor using LLILCJit
 Successfully read EncodingProvider..cctor
 
@@ -10717,7 +12426,7 @@ Failed to read Encoding.get_InternalSyncObject[Call HasTypeArg]
 INFO:  jitting method Hashtable::.ctor using LLILCJit
 Failed to read Hashtable..ctor[Volatile store]
 INFO:  jitting method Hashtable::get_Item using LLILCJit
-Failed to read Hashtable.get_Item[loadElemA]
+Failed to read Hashtable.get_Item[loadNonPrimitiveObj]
 INFO:  jitting method Hashtable::InitHash using LLILCJit
 Successfully read Hashtable.InitHash
 
@@ -10737,8 +12446,8 @@ entry:
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -10754,15 +12463,15 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
   %15 = load i32, i32* %loc0
-  %NullCheck2 = icmp ne i32 addrspace(1)* %14, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i32 addrspace(1)* %14, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %3
   store i32 %15, i32 addrspace(1)* %14, align 8
   %17 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %18 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %NullCheck4 = icmp ne i32 addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i32 addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = load i32, i32 addrspace(1)* %18, align 8
@@ -10771,8 +12480,8 @@ entry:
   %23 = sub i32 %22, 1
   %24 = urem i32 %21, %23
   %25 = add i32 1, %24
-  %NullCheck6 = icmp ne i32 addrspace(1)* %17, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32 addrspace(1)* %17, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %19
   store i32 %25, i32 addrspace(1)* %17, align 8
@@ -10783,15 +12492,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %19
+ThrowNullRef6:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10806,8 +12515,8 @@ entry:
   store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
   store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %NullCheck = icmp ne %System.Collections.Hashtable addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Collections.Hashtable addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
@@ -10817,16 +12526,16 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Collections.Hashtable addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Collections.Hashtable addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
   %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck4 = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %9, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
   %13 = inttoptr i64 %11 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
@@ -10836,8 +12545,8 @@ entry:
 ; <label>:15                                      ; preds = %1
   %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -10855,15 +12564,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10877,8 +12586,8 @@ entry:
   store %System.Int32 addrspace(1)* %param0, %System.Int32 addrspace(1)** %this
   %0 = load %System.Int32 addrspace(1)*, %System.Int32 addrspace(1)** %this
   %1 = bitcast %System.Int32 addrspace(1)* %0 to i32 addrspace(1)*
-  %NullCheck = icmp ne i32 addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq i32 addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load i32, i32 addrspace(1)* %1, align 8
@@ -10954,8 +12663,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.UTF8Encoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
@@ -10964,15 +12673,15 @@ entry:
   %9 = load i8, i8* %arg2
   %10 = zext i8 %9 to i32
   %11 = trunc i32 %10 to i8
-  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %8, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %6
   %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %8, i32 0, i32 8
   store i8 %11, i8 addrspace(1)* %13
   %14 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %14, i32 0, i32 8
@@ -10984,8 +12693,8 @@ entry:
 ; <label>:20                                      ; preds = %15
   %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %22, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %22, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = load i64, i64 addrspace(1)* %22
@@ -11007,15 +12716,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %12
+ThrowNullRef4:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11030,8 +12739,8 @@ entry:
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
@@ -11053,16 +12762,16 @@ entry:
 ; <label>:10                                      ; preds = %1
   %11 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
   %12 = load i32, i32* %arg1
-  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %11, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.Encoding addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
   store i32 %12, i32 addrspace(1)* %14
   %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
   %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = load i64, i64 addrspace(1)* %16
@@ -11080,11 +12789,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11097,8 +12806,8 @@ entry:
   %this = alloca %System.Text.UTF8Encoding addrspace(1)*
   store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
   %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.UTF8Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
@@ -11110,16 +12819,16 @@ entry:
 ; <label>:6                                       ; preds = %1
   %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %8 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %10, %System.Text.EncoderFallback addrspace(1)* %8)
   %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %12 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
-  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %11, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %11, i32 0, i32 3
@@ -11132,8 +12841,8 @@ entry:
   %18 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %18, %System.String addrspace(1)* %17)
   %19 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %18 to %System.Text.EncoderFallback addrspace(1)*
-  %NullCheck6 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %16, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %16, i32 0, i32 2
@@ -11143,8 +12852,8 @@ entry:
   %24 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %24, %System.String addrspace(1)* %23)
   %25 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %24 to %System.Text.DecoderFallback addrspace(1)*
-  %NullCheck8 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %22, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %22, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %20
   %27 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %22, i32 0, i32 3
@@ -11155,19 +12864,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %20
+ThrowNullRef8:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11197,8 +12906,8 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load i32, i32* %arg1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -11216,8 +12925,8 @@ entry:
 ; <label>:15                                      ; preds = %8
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %17 = load i32, i32* %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 %17
@@ -11233,7 +12942,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11285,7 +12994,7 @@ entry:
 }
 
 INFO:  jitting method Hashtable::Insert using LLILCJit
-Failed to read Hashtable.Insert[loadElemA]
+Failed to read Hashtable.Insert[storeElem]
 INFO:  jitting method ConsoleEncoding::.ctor using LLILCJit
 Successfully read ConsoleEncoding..ctor
 
@@ -11300,8 +13009,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %1)
   %2 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
@@ -11337,8 +13046,8 @@ entry:
   %2 = call %System.Text.InternalEncoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalEncoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %1)
   %3 = bitcast %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2 to %System.Text.EncoderFallback addrspace(1)*
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
@@ -11348,8 +13057,8 @@ entry:
   %8 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %7)
   %9 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %8 to %System.Text.DecoderFallback addrspace(1)*
-  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %6, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.Encoding addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %4
   %11 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %6, i32 0, i32 3
@@ -11360,7 +13069,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11379,15 +13088,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* %1)
   %2 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   %6 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, i32 0, i32 1
@@ -11398,7 +13107,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11426,8 +13135,8 @@ entry:
   store %System.Text.InternalDecoderBestFitFallback addrspace(1)* %param0, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
   %0 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
@@ -11437,15 +13146,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %4)
   %5 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %6)
   %9 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, i32 0, i32 1
@@ -11456,11 +13165,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11528,8 +13237,8 @@ entry:
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
   %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = load i64, i64 addrspace(1)* %19
@@ -11593,8 +13302,8 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.ConsoleStream addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
@@ -11625,31 +13334,31 @@ entry:
   store i8 %param4, i8* %arg4
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %3, %System.IO.Stream addrspace(1)* %1)
   %4 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %4, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
   %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %4, i32 0, i32 4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %5)
   %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %6
   %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
   %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
   %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = load i64, i64 addrspace(1)* %13
@@ -11661,8 +13370,8 @@ entry:
   %21 = load i64, i64* %20
   %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %8, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %8, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %14
   %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 5
@@ -11680,24 +13389,24 @@ entry:
   %31 = load i32, i32* %arg3
   %32 = sext i32 %31 to i64
   %33 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %32)
-  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %30, null
-  br i1 %NullCheck10, label %34, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.StreamWriter addrspace(1)* %30, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %35, %"System.Char[]" addrspace(1)* %33)
   %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %37, null
-  br i1 %NullCheck12, label %38, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.StreamWriter addrspace(1)* %37, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %38
 
 ; <label>:38                                      ; preds = %34
   %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
   %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
   %41 = load i32, i32* %arg3
   %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %42, null
-  br i1 %NullCheck14, label %43, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %42, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
   %44 = load i64, i64 addrspace(1)* %42
@@ -11711,30 +13420,30 @@ entry:
   %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
   %53 = sext i32 %52 to i64
   %54 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %53)
-  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
-  br i1 %NullCheck16, label %55, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %55
 
 ; <label>:55                                      ; preds = %43
   %56 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %56, %"System.Byte[]" addrspace(1)* %54)
   %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %58 = load i32, i32* %arg3
-  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %57, null
-  br i1 %NullCheck18, label %59, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.StreamWriter addrspace(1)* %57, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %59
 
 ; <label>:59                                      ; preds = %55
   %60 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 10
   store i32 %58, i32 addrspace(1)* %60
   %61 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %61, null
-  br i1 %NullCheck20, label %62, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.IO.StreamWriter addrspace(1)* %61, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %62
 
 ; <label>:62                                      ; preds = %59
   %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
   %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
   %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
   %67 = load i64, i64 addrspace(1)* %65
@@ -11752,15 +13461,15 @@ entry:
 
 ; <label>:78                                      ; preds = %66
   %79 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %79, null
-  br i1 %NullCheck24, label %80, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.StreamWriter addrspace(1)* %79, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %80
 
 ; <label>:80                                      ; preds = %78
   %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
   %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
   %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %83, null
-  br i1 %NullCheck26, label %84, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %83, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
   %85 = load i64, i64 addrspace(1)* %83
@@ -11777,8 +13486,8 @@ entry:
 
 ; <label>:95                                      ; preds = %84
   %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.IO.StreamWriter addrspace(1)* %96, null
-  br i1 %NullCheck28, label %97, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.IO.StreamWriter addrspace(1)* %96, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %97
 
 ; <label>:97                                      ; preds = %95
   %98 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 12
@@ -11792,8 +13501,8 @@ entry:
   %103 = icmp eq i32 %102, 0
   %104 = sext i1 %103 to i32
   %105 = trunc i32 %104 to i8
-  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %100, null
-  br i1 %NullCheck30, label %106, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.IO.StreamWriter addrspace(1)* %100, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %106
 
 ; <label>:106                                     ; preds = %99
   %107 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %100, i32 0, i32 13
@@ -11804,63 +13513,63 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %6
+ThrowNullRef4:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %29
+ThrowNullRef10:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %34
+ThrowNullRef12:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %38
+ThrowNullRef14:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %43
+ThrowNullRef16:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %55
+ThrowNullRef18:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %59
+ThrowNullRef20:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %62
+ThrowNullRef22:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %78
+ThrowNullRef24:                                   ; preds = %78
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %80
+ThrowNullRef26:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %95
+ThrowNullRef28:                                   ; preds = %95
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11873,15 +13582,15 @@ entry:
   %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = load i64, i64 addrspace(1)* %4
@@ -11899,7 +13608,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11949,35 +13658,35 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
   %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderNLS addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %7 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.EncoderNLS addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Text.Encoding addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.Encoding addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Text.EncoderNLS addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.EncoderNLS addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
   %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck8 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = load i64, i64 addrspace(1)* %16
@@ -11996,19 +13705,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12034,8 +13743,8 @@ entry:
   %this = alloca %System.Text.Encoding addrspace(1)*
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
@@ -12055,15 +13764,15 @@ entry:
   %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
   store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
   %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
   store i32 0, i32 addrspace(1)* %2
   %3 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, i32 0, i32 2
@@ -12073,15 +13782,15 @@ entry:
 
 ; <label>:8                                       ; preds = %4
   %9 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
   %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
   %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = load i64, i64 addrspace(1)* %13
@@ -12102,15 +13811,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12125,16 +13834,16 @@ entry:
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = load i32, i32* %arg1
   %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
   %7 = load i64, i64 addrspace(1)* %5
@@ -12152,7 +13861,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12189,8 +13898,8 @@ entry:
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
   %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
   %16 = load i64, i64 addrspace(1)* %14
@@ -12211,8 +13920,8 @@ entry:
   %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
   %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
   %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %31, null
-  br i1 %NullCheck2, label %32, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = load i64, i64 addrspace(1)* %31
@@ -12255,7 +13964,7 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12268,14 +13977,14 @@ entry:
   %this = alloca %System.Text.EncoderReplacementFallback addrspace(1)*
   store %System.Text.EncoderReplacementFallback addrspace(1)* %param0, %System.Text.EncoderReplacementFallback addrspace(1)** %this
   %0 = load %System.Text.EncoderReplacementFallback addrspace(1)*, %System.Text.EncoderReplacementFallback addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -12286,7 +13995,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12316,8 +14025,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
@@ -12349,8 +14058,8 @@ entry:
   %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
   store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
@@ -12362,8 +14071,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Threading.Tasks.Task addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %7)
@@ -12386,7 +14095,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12405,8 +14114,8 @@ entry:
   store i8 %param1, i8* %arg1
   store i8 %param2, i8* %arg2
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
@@ -12420,8 +14129,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1, %5
   %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 9
@@ -12452,8 +14161,8 @@ entry:
 
 ; <label>:25                                      ; preds = %8, %20
   %26 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %26, null
-  br i1 %NullCheck4, label %27, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %26, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %26, i32 0, i32 12
@@ -12464,22 +14173,22 @@ entry:
 
 ; <label>:32                                      ; preds = %27
   %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %33, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.IO.StreamWriter addrspace(1)* %33, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %32
   %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 12
   store i8 1, i8 addrspace(1)* %35
   %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
-  br i1 %NullCheck8, label %37, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
   %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
   %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck10 = icmp ne i64 addrspace(1)* %40, null
-  br i1 %NullCheck10, label %41, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64 addrspace(1)* %40, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i64, i64 addrspace(1)* %40
@@ -12493,8 +14202,8 @@ entry:
   %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
   store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
   %51 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %NullCheck12 = icmp ne %"System.Byte[]" addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Byte[]" addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %41
   %53 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %51, i32 0, i32 1
@@ -12506,16 +14215,16 @@ entry:
 
 ; <label>:58                                      ; preds = %52
   %59 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %59, null
-  br i1 %NullCheck14, label %60, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.IO.StreamWriter addrspace(1)* %59, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %60
 
 ; <label>:60                                      ; preds = %58
   %61 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %59, i32 0, i32 3
   %62 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
   %64 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %NullCheck16 = icmp ne %"System.Byte[]" addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %"System.Byte[]" addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %60
   %66 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %64, i32 0, i32 1
@@ -12523,8 +14232,8 @@ entry:
   %68 = zext i32 %67 to i64
   %69 = trunc i64 %68 to i32
   %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck18, label %71, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
   %72 = load i64, i64 addrspace(1)* %70
@@ -12540,29 +14249,29 @@ entry:
 
 ; <label>:80                                      ; preds = %27, %52, %71
   %81 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %81, null
-  br i1 %NullCheck20, label %82, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.IO.StreamWriter addrspace(1)* %81, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
 
 ; <label>:82                                      ; preds = %80
   %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %81, i32 0, i32 5
   %84 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %83, align 8
   %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.IO.StreamWriter addrspace(1)* %85, null
-  br i1 %NullCheck22, label %86, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.IO.StreamWriter addrspace(1)* %85, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %86
 
 ; <label>:86                                      ; preds = %82
   %87 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 7
   %88 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %87, align 8
   %89 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %89, null
-  br i1 %NullCheck24, label %90, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.StreamWriter addrspace(1)* %89, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %90
 
 ; <label>:90                                      ; preds = %86
   %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %89, i32 0, i32 9
   %92 = load i32, i32 addrspace(1)* %91, align 8
   %93 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.IO.StreamWriter addrspace(1)* %93, null
-  br i1 %NullCheck26, label %94, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.IO.StreamWriter addrspace(1)* %93, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %93, i32 0, i32 6
@@ -12570,8 +14279,8 @@ entry:
   %97 = load i8, i8* %arg2
   %98 = zext i8 %97 to i32
   %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
-  %NullCheck28 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck28, label %100, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
   %101 = load i64, i64 addrspace(1)* %99
@@ -12586,8 +14295,8 @@ entry:
   %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
   store i32 %110, i32* %loc1
   %111 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %111, null
-  br i1 %NullCheck30, label %112, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.IO.StreamWriter addrspace(1)* %111, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %112
 
 ; <label>:112                                     ; preds = %100
   %113 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %111, i32 0, i32 9
@@ -12598,23 +14307,23 @@ entry:
 
 ; <label>:116                                     ; preds = %112
   %117 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck32 = icmp ne %System.IO.StreamWriter addrspace(1)* %117, null
-  br i1 %NullCheck32, label %118, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.IO.StreamWriter addrspace(1)* %117, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %118
 
 ; <label>:118                                     ; preds = %116
   %119 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %117, i32 0, i32 3
   %120 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %119, align 8
   %121 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.IO.StreamWriter addrspace(1)* %121, null
-  br i1 %NullCheck34, label %122, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.IO.StreamWriter addrspace(1)* %121, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %122
 
 ; <label>:122                                     ; preds = %118
   %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
   %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
   %125 = load i32, i32* %loc1
   %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
-  %NullCheck36 = icmp ne i64 addrspace(1)* %126, null
-  br i1 %NullCheck36, label %127, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64 addrspace(1)* %126, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
   %128 = load i64, i64 addrspace(1)* %126
@@ -12636,15 +14345,15 @@ entry:
 
 ; <label>:140                                     ; preds = %136
   %141 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.IO.StreamWriter addrspace(1)* %141, null
-  br i1 %NullCheck38, label %142, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.IO.StreamWriter addrspace(1)* %141, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %142
 
 ; <label>:142                                     ; preds = %140
   %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
   %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
   %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
-  %NullCheck40 = icmp ne i64 addrspace(1)* %145, null
-  br i1 %NullCheck40, label %146, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i64 addrspace(1)* %145, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
   %147 = load i64, i64 addrspace(1)* %145
@@ -12665,83 +14374,83 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %25
+ThrowNullRef4:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %32
+ThrowNullRef6:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %37
+ThrowNullRef10:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %41
+ThrowNullRef12:                                   ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %58
+ThrowNullRef14:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %60
+ThrowNullRef16:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %65
+ThrowNullRef18:                                   ; preds = %65
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %80
+ThrowNullRef20:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %82
+ThrowNullRef22:                                   ; preds = %82
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %86
+ThrowNullRef24:                                   ; preds = %86
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %90
+ThrowNullRef26:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %94
+ThrowNullRef28:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %100
+ThrowNullRef30:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %116
+ThrowNullRef32:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %118
+ThrowNullRef34:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %122
+ThrowNullRef36:                                   ; preds = %122
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %140
+ThrowNullRef38:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %142
+ThrowNullRef40:                                   ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12808,8 +14517,8 @@ entry:
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %1 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
-  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
@@ -12817,8 +14526,8 @@ entry:
   %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
   %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
   %8 = load i64, i64 addrspace(1)* %6
@@ -12834,8 +14543,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %17, %System.IFormatProvider addrspace(1)* %16)
   %18 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %19 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %18, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.SyncTextWriter addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %7
   %21 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %18, i32 0, i32 4
@@ -12846,11 +14555,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12863,8 +14572,8 @@ entry:
   %this = alloca %System.IO.TextWriter addrspace(1)*
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.TextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
@@ -12874,8 +14583,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.Threading.Thread addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Threading.Thread addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %6)
@@ -12884,8 +14593,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1
   %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.TextWriter addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.TextWriter addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %11, i32 0, i32 2
@@ -12896,11 +14605,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13097,8 +14806,8 @@ entry:
   store float %param1, float* %arg1
   store i8 0, i8* %loc1
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
@@ -13108,16 +14817,16 @@ entry:
   %5 = addrspacecast i8* %loc1 to i8 addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %4, i8 addrspace(1)* %5)
   %6 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.SyncTextWriter addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
   %10 = load float, float* %arg1
   %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
   %13 = load i64, i64 addrspace(1)* %11
@@ -13152,11 +14861,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13173,8 +14882,8 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load float, float* %arg1
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -13188,8 +14897,8 @@ entry:
   call void %11(%System.IO.TextWriter addrspace(1)* %0, float %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
   %15 = load i64, i64 addrspace(1)* %13
@@ -13207,7 +14916,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13225,8 +14934,8 @@ entry:
   %1 = addrspacecast float* %arg1 to float addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -13241,8 +14950,8 @@ entry:
   %14 = bitcast float addrspace(1)* %1 to %System.Single addrspace(1)*
   %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Single addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Single addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
   %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
   %18 = load i64, i64 addrspace(1)* %16
@@ -13260,7 +14969,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13276,8 +14985,8 @@ entry:
   store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
   %0 = load %System.Single addrspace(1)*, %System.Single addrspace(1)** %this
   %1 = bitcast %System.Single addrspace(1)* %0 to float addrspace(1)*
-  %NullCheck = icmp ne float addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq float addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load float, float addrspace(1)* %1, align 8
@@ -13302,8 +15011,8 @@ entry:
   %loc0 = alloca %System.Globalization.NumberFormatInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 3
@@ -13313,8 +15022,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
@@ -13324,24 +15033,24 @@ entry:
   store %System.Globalization.NumberFormatInfo addrspace(1)* %10, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
   %11 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %7
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
   %15 = load i8, i8 addrspace(1)* %14, align 8
   %16 = zext i8 %15 to i32
   %17 = trunc i32 %16 to i8
-  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %11, null
-  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %11, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %13
   %19 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %11, i32 0, i32 29
   store i8 %17, i8 addrspace(1)* %19
   %20 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %21 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %20, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %20, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %18
   %23 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %20, i32 0, i32 3
@@ -13350,8 +15059,8 @@ entry:
 
 ; <label>:24                                      ; preds = %1, %22
   %25 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %25, null
-  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %25, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %26
 
 ; <label>:26                                      ; preds = %24
   %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %25, i32 0, i32 3
@@ -13362,23 +15071,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %18
+ThrowNullRef8:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13403,168 +15112,168 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 18
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %8, align 8
-  %NullCheck2 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %5, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %5, i32 0, i32 4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %9)
   %12 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 19
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %15, align 8
-  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %12, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %12, i32 0, i32 5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %16)
   %19 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %20 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %20, null
-  br i1 %NullCheck8, label %21, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %20, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %20, i32 0, i32 23
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  %NullCheck10 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %19, null
-  br i1 %NullCheck10, label %24, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %19, i32 0, i32 7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %25, %System.String addrspace(1)* %23)
   %26 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %27 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %27, i32 0, i32 22
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %29, align 8
-  %NullCheck14 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %26, null
-  br i1 %NullCheck14, label %31, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %26, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %26, i32 0, i32 6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %32, %System.String addrspace(1)* %30)
   %33 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %34 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Globalization.CultureData addrspace(1)* %34, null
-  br i1 %NullCheck16, label %35, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Globalization.CultureData addrspace(1)* %34, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %34, i32 0, i32 51
   %37 = load i32, i32 addrspace(1)* %36, align 8
-  %NullCheck18 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %33, null
-  br i1 %NullCheck18, label %38, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %33, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %33, i32 0, i32 21
   store i32 %37, i32 addrspace(1)* %39
   %40 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %41 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Globalization.CultureData addrspace(1)* %41, null
-  br i1 %NullCheck20, label %42, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Globalization.CultureData addrspace(1)* %41, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %41, i32 0, i32 52
   %44 = load i32, i32 addrspace(1)* %43, align 8
-  %NullCheck22 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %40, null
-  br i1 %NullCheck22, label %45, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %40, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %40, i32 0, i32 25
   store i32 %44, i32 addrspace(1)* %46
   %47 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %48 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.Globalization.CultureData addrspace(1)* %48, null
-  br i1 %NullCheck24, label %49, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Globalization.CultureData addrspace(1)* %48, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %49
 
 ; <label>:49                                      ; preds = %45
   %50 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %48, i32 0, i32 29
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck26 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %47, null
-  br i1 %NullCheck26, label %52, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %47, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %47, i32 0, i32 10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %53, %System.String addrspace(1)* %51)
   %54 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %55 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Globalization.CultureData addrspace(1)* %55, null
-  br i1 %NullCheck28, label %56, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Globalization.CultureData addrspace(1)* %55, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %56
 
 ; <label>:56                                      ; preds = %52
   %57 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %55, i32 0, i32 35
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %57, align 8
-  %NullCheck30 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %54, null
-  br i1 %NullCheck30, label %59, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %54, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %54, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %60, %System.String addrspace(1)* %58)
   %61 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %62 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck32 = icmp ne %System.Globalization.CultureData addrspace(1)* %62, null
-  br i1 %NullCheck32, label %63, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Globalization.CultureData addrspace(1)* %62, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %62, i32 0, i32 34
   %65 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %64, align 8
-  %NullCheck34 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %61, null
-  br i1 %NullCheck34, label %66, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %61, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %61, i32 0, i32 9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %67, %System.String addrspace(1)* %65)
   %68 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %69 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck36 = icmp ne %System.Globalization.CultureData addrspace(1)* %69, null
-  br i1 %NullCheck36, label %70, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Globalization.CultureData addrspace(1)* %69, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %70
 
 ; <label>:70                                      ; preds = %66
   %71 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %69, i32 0, i32 55
   %72 = load i32, i32 addrspace(1)* %71, align 8
-  %NullCheck38 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %68, null
-  br i1 %NullCheck38, label %73, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %68, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %68, i32 0, i32 22
   store i32 %72, i32 addrspace(1)* %74
   %75 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %76 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck40 = icmp ne %System.Globalization.CultureData addrspace(1)* %76, null
-  br i1 %NullCheck40, label %77, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Globalization.CultureData addrspace(1)* %76, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %76, i32 0, i32 57
   %79 = load i32, i32 addrspace(1)* %78, align 8
-  %NullCheck42 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %75, null
-  br i1 %NullCheck42, label %80, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %75, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %80
 
 ; <label>:80                                      ; preds = %77
   %81 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %75, i32 0, i32 24
   store i32 %79, i32 addrspace(1)* %81
   %82 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %83 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck44 = icmp ne %System.Globalization.CultureData addrspace(1)* %83, null
-  br i1 %NullCheck44, label %84, label %ThrowNullRef43
+  %NullCheck43 = icmp eq %System.Globalization.CultureData addrspace(1)* %83, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %84
 
 ; <label>:84                                      ; preds = %80
   %85 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %83, i32 0, i32 56
   %86 = load i32, i32 addrspace(1)* %85, align 8
-  %NullCheck46 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %82, null
-  br i1 %NullCheck46, label %87, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %82, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %82, i32 0, i32 23
@@ -13573,8 +15282,8 @@ entry:
 
 ; <label>:89                                      ; preds = %entry
   %90 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck100 = icmp ne %System.Globalization.CultureData addrspace(1)* %90, null
-  br i1 %NullCheck100, label %91, label %ThrowNullRef99
+  %NullCheck99 = icmp eq %System.Globalization.CultureData addrspace(1)* %90, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %91
 
 ; <label>:91                                      ; preds = %89
   %92 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %90, i32 0, i32 2
@@ -13592,8 +15301,8 @@ entry:
   %102 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %103 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %104 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %103)
-  %NullCheck48 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %102, null
-  br i1 %NullCheck48, label %105, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %102, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %105
 
 ; <label>:105                                     ; preds = %101
   %106 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %102, i32 0, i32 1
@@ -13601,8 +15310,8 @@ entry:
   %107 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %108 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %109 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %108)
-  %NullCheck50 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %107, null
-  br i1 %NullCheck50, label %110, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %107, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %110
 
 ; <label>:110                                     ; preds = %105
   %111 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %107, i32 0, i32 2
@@ -13610,8 +15319,8 @@ entry:
   %112 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %113 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %114 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %113)
-  %NullCheck52 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %112, null
-  br i1 %NullCheck52, label %115, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %112, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %115
 
 ; <label>:115                                     ; preds = %110
   %116 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %112, i32 0, i32 27
@@ -13619,8 +15328,8 @@ entry:
   %117 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %118 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %119 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %118)
-  %NullCheck54 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %117, null
-  br i1 %NullCheck54, label %120, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %117, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %120
 
 ; <label>:120                                     ; preds = %115
   %121 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %117, i32 0, i32 26
@@ -13628,8 +15337,8 @@ entry:
   %122 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %123 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %124 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %123)
-  %NullCheck56 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %122, null
-  br i1 %NullCheck56, label %125, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %122, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %125
 
 ; <label>:125                                     ; preds = %120
   %126 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %122, i32 0, i32 17
@@ -13637,8 +15346,8 @@ entry:
   %127 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %128 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %129 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %128)
-  %NullCheck58 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %127, null
-  br i1 %NullCheck58, label %130, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %127, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %130
 
 ; <label>:130                                     ; preds = %125
   %131 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %127, i32 0, i32 18
@@ -13646,8 +15355,8 @@ entry:
   %132 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %133 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %134 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %133)
-  %NullCheck60 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %132, null
-  br i1 %NullCheck60, label %135, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %132, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %135
 
 ; <label>:135                                     ; preds = %130
   %136 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %132, i32 0, i32 14
@@ -13655,8 +15364,8 @@ entry:
   %137 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %138 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %139 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %138)
-  %NullCheck62 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %137, null
-  br i1 %NullCheck62, label %140, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %137, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %140
 
 ; <label>:140                                     ; preds = %135
   %141 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %137, i32 0, i32 13
@@ -13664,71 +15373,71 @@ entry:
   %142 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %143 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %144 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %143)
-  %NullCheck64 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %142, null
-  br i1 %NullCheck64, label %145, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %142, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %145
 
 ; <label>:145                                     ; preds = %140
   %146 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %142, i32 0, i32 12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %146, %System.String addrspace(1)* %144)
   %147 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %148 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck66 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %148, null
-  br i1 %NullCheck66, label %149, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %148, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %149
 
 ; <label>:149                                     ; preds = %145
   %150 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %148, i32 0, i32 21
   %151 = load i32, i32 addrspace(1)* %150, align 8
-  %NullCheck68 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %147, null
-  br i1 %NullCheck68, label %152, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %147, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %152
 
 ; <label>:152                                     ; preds = %149
   %153 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %147, i32 0, i32 28
   store i32 %151, i32 addrspace(1)* %153
   %154 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %155 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck70 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %155, null
-  br i1 %NullCheck70, label %156, label %ThrowNullRef69
+  %NullCheck69 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %155, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %156
 
 ; <label>:156                                     ; preds = %152
   %157 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %155, i32 0, i32 6
   %158 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %157, align 8
-  %NullCheck72 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %154, null
-  br i1 %NullCheck72, label %159, label %ThrowNullRef71
+  %NullCheck71 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %154, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %159
 
 ; <label>:159                                     ; preds = %156
   %160 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %154, i32 0, i32 15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %160, %System.String addrspace(1)* %158)
   %161 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %162 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck74 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %162, null
-  br i1 %NullCheck74, label %163, label %ThrowNullRef73
+  %NullCheck73 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %162, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %163
 
 ; <label>:163                                     ; preds = %159
   %164 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %162, i32 0, i32 1
   %165 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %164, align 8
-  %NullCheck76 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %161, null
-  br i1 %NullCheck76, label %166, label %ThrowNullRef75
+  %NullCheck75 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %161, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %166
 
 ; <label>:166                                     ; preds = %163
   %167 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %161, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %167, %"System.Int32[]" addrspace(1)* %165)
   %168 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %169 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck78 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %169, null
-  br i1 %NullCheck78, label %170, label %ThrowNullRef77
+  %NullCheck77 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %169, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %170
 
 ; <label>:170                                     ; preds = %166
   %171 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %169, i32 0, i32 7
   %172 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %171, align 8
-  %NullCheck80 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %168, null
-  br i1 %NullCheck80, label %173, label %ThrowNullRef79
+  %NullCheck79 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %168, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %173
 
 ; <label>:173                                     ; preds = %170
   %174 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %168, i32 0, i32 16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %174, %System.String addrspace(1)* %172)
   %175 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck82 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %175, null
-  br i1 %NullCheck82, label %176, label %ThrowNullRef81
+  %NullCheck81 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %175, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %176
 
 ; <label>:176                                     ; preds = %173
   %177 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %175, i32 0, i32 4
@@ -13738,14 +15447,14 @@ entry:
 
 ; <label>:180                                     ; preds = %176
   %181 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck84 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %181, null
-  br i1 %NullCheck84, label %182, label %ThrowNullRef83
+  %NullCheck83 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %181, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %182
 
 ; <label>:182                                     ; preds = %180
   %183 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %181, i32 0, i32 4
   %184 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %183, align 8
-  %NullCheck86 = icmp ne %System.String addrspace(1)* %184, null
-  br i1 %NullCheck86, label %185, label %ThrowNullRef85
+  %NullCheck85 = icmp eq %System.String addrspace(1)* %184, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %185
 
 ; <label>:185                                     ; preds = %182
   %186 = getelementptr inbounds %System.String, %System.String addrspace(1)* %184, i32 0, i32 1
@@ -13756,8 +15465,8 @@ entry:
 ; <label>:189                                     ; preds = %176, %185
   %190 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck98 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %190, null
-  br i1 %NullCheck98, label %192, label %ThrowNullRef97
+  %NullCheck97 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %190, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %192
 
 ; <label>:192                                     ; preds = %189
   %193 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %190, i32 0, i32 4
@@ -13766,8 +15475,8 @@ entry:
 
 ; <label>:194                                     ; preds = %185, %192
   %195 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck88 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %195, null
-  br i1 %NullCheck88, label %196, label %ThrowNullRef87
+  %NullCheck87 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %195, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %196
 
 ; <label>:196                                     ; preds = %194
   %197 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %195, i32 0, i32 9
@@ -13777,14 +15486,14 @@ entry:
 
 ; <label>:200                                     ; preds = %196
   %201 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck90 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %201, null
-  br i1 %NullCheck90, label %202, label %ThrowNullRef89
+  %NullCheck89 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %201, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %202
 
 ; <label>:202                                     ; preds = %200
   %203 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %201, i32 0, i32 9
   %204 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %203, align 8
-  %NullCheck92 = icmp ne %System.String addrspace(1)* %204, null
-  br i1 %NullCheck92, label %205, label %ThrowNullRef91
+  %NullCheck91 = icmp eq %System.String addrspace(1)* %204, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %205
 
 ; <label>:205                                     ; preds = %202
   %206 = getelementptr inbounds %System.String, %System.String addrspace(1)* %204, i32 0, i32 1
@@ -13795,14 +15504,14 @@ entry:
 ; <label>:209                                     ; preds = %196, %205
   %210 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %211 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck94 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %211, null
-  br i1 %NullCheck94, label %212, label %ThrowNullRef93
+  %NullCheck93 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %211, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %212
 
 ; <label>:212                                     ; preds = %209
   %213 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %211, i32 0, i32 6
   %214 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %213, align 8
-  %NullCheck96 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %210, null
-  br i1 %NullCheck96, label %215, label %ThrowNullRef95
+  %NullCheck95 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %210, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %215
 
 ; <label>:215                                     ; preds = %212
   %216 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %210, i32 0, i32 9
@@ -13816,203 +15525,203 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %17
+ThrowNullRef8:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %21
+ThrowNullRef10:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %24
+ThrowNullRef12:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %28
+ThrowNullRef14:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %31
+ThrowNullRef16:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %35
+ThrowNullRef18:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %38
+ThrowNullRef20:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %42
+ThrowNullRef22:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %45
+ThrowNullRef24:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %49
+ThrowNullRef26:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %52
+ThrowNullRef28:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %56
+ThrowNullRef30:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %59
+ThrowNullRef32:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %63
+ThrowNullRef34:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %66
+ThrowNullRef36:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %70
+ThrowNullRef38:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %73
+ThrowNullRef40:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %77
+ThrowNullRef42:                                   ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %80
+ThrowNullRef44:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %84
+ThrowNullRef46:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %101
+ThrowNullRef48:                                   ; preds = %101
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %105
+ThrowNullRef50:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %110
+ThrowNullRef52:                                   ; preds = %110
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %115
+ThrowNullRef54:                                   ; preds = %115
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %120
+ThrowNullRef56:                                   ; preds = %120
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %125
+ThrowNullRef58:                                   ; preds = %125
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %130
+ThrowNullRef60:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %135
+ThrowNullRef62:                                   ; preds = %135
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %140
+ThrowNullRef64:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %145
+ThrowNullRef66:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %149
+ThrowNullRef68:                                   ; preds = %149
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %152
+ThrowNullRef70:                                   ; preds = %152
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %156
+ThrowNullRef72:                                   ; preds = %156
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %159
+ThrowNullRef74:                                   ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %163
+ThrowNullRef76:                                   ; preds = %163
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %166
+ThrowNullRef78:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %170
+ThrowNullRef80:                                   ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %173
+ThrowNullRef82:                                   ; preds = %173
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %180
+ThrowNullRef84:                                   ; preds = %180
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %182
+ThrowNullRef86:                                   ; preds = %182
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %194
+ThrowNullRef88:                                   ; preds = %194
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %200
+ThrowNullRef90:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %202
+ThrowNullRef92:                                   ; preds = %202
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %209
+ThrowNullRef94:                                   ; preds = %209
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %212
+ThrowNullRef96:                                   ; preds = %212
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %189
+ThrowNullRef98:                                   ; preds = %189
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %89
+ThrowNullRef100:                                  ; preds = %89
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14040,8 +15749,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 21
@@ -14054,8 +15763,8 @@ entry:
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 16)
   %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 21
@@ -14064,8 +15773,8 @@ entry:
 
 ; <label>:12                                      ; preds = %1, %10
   %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 21
@@ -14076,11 +15785,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %12
+ThrowNullRef4:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14096,8 +15805,8 @@ entry:
   store i32 %param1, i32* %arg1
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %1 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
@@ -14164,8 +15873,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 33
@@ -14178,8 +15887,8 @@ entry:
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 24)
   %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 33
@@ -14188,8 +15897,8 @@ entry:
 
 ; <label>:12                                      ; preds = %1, %10
   %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 33
@@ -14200,11 +15909,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %12
+ThrowNullRef4:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14217,8 +15926,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 53
@@ -14230,8 +15939,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 116)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 53
@@ -14240,8 +15949,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 53
@@ -14252,11 +15961,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14285,8 +15994,8 @@ entry:
 
 ; <label>:7                                       ; preds = %entry, %4
   %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %7
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 2
@@ -14310,8 +16019,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 54
@@ -14323,8 +16032,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 117)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
@@ -14333,8 +16042,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 54
@@ -14345,11 +16054,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14362,8 +16071,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 27
@@ -14375,8 +16084,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 118)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 27
@@ -14385,8 +16094,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 27
@@ -14397,11 +16106,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14414,8 +16123,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 28
@@ -14427,8 +16136,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 119)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 28
@@ -14437,8 +16146,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 28
@@ -14449,11 +16158,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14466,8 +16175,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 26
@@ -14479,8 +16188,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 107)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 26
@@ -14489,8 +16198,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 26
@@ -14501,11 +16210,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14518,8 +16227,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 25
@@ -14531,8 +16240,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 106)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 25
@@ -14541,8 +16250,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 25
@@ -14553,11 +16262,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14570,8 +16279,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 24
@@ -14583,8 +16292,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 105)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 24
@@ -14593,8 +16302,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 24
@@ -14605,11 +16314,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14634,8 +16343,8 @@ entry:
   %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %3)
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %2
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -14646,15 +16355,15 @@ entry:
 
 ; <label>:8                                       ; preds = %62
   %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 9
   %12 = load i32, i32 addrspace(1)* %11, align 8
   %13 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.IO.StreamWriter addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %13, i32 0, i32 10
@@ -14669,15 +16378,15 @@ entry:
 
 ; <label>:20                                      ; preds = %14, %18
   %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
   %24 = load i32, i32 addrspace(1)* %23, align 8
   %25 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %25, null
-  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.StreamWriter addrspace(1)* %25, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %25, i32 0, i32 9
@@ -14698,36 +16407,36 @@ entry:
   %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %37 = load i32, i32* %loc1
   %38 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.StreamWriter addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %35
   %40 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %38, i32 0, i32 7
   %41 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %40, align 8
   %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
-  br i1 %NullCheck14, label %43, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %39
   %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 9
   %45 = load i32, i32 addrspace(1)* %44, align 8
   %46 = load i32, i32* %loc2
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %36, null
-  br i1 %NullCheck16, label %47, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %36, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %47
 
 ; <label>:47                                      ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %36, i32 %37, %"System.Char[]" addrspace(1)* %41, i32 %45, i32 %46)
   %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
   %51 = load i32, i32 addrspace(1)* %50, align 8
   %52 = load i32, i32* %loc2
   %53 = add i32 %51, %52
-  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
-  br i1 %NullCheck20, label %54, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %54
 
 ; <label>:54                                      ; preds = %49
   %55 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
@@ -14749,8 +16458,8 @@ entry:
 
 ; <label>:65                                      ; preds = %62
   %66 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %66, null
-  br i1 %NullCheck2, label %67, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %66, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %67
 
 ; <label>:67                                      ; preds = %65
   %68 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %66, i32 0, i32 11
@@ -14771,49 +16480,259 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %65
+ThrowNullRef2:                                    ; preds = %65
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %20
+ThrowNullRef8:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %22
+ThrowNullRef10:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %35
+ThrowNullRef12:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %43
+ThrowNullRef16:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %47
+ThrowNullRef18:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method String::CopyTo using LLILCJit
-Failed to read String.CopyTo[loadElemA]
+Successfully read String.CopyTo
+
+define void @String.CopyTo(%System.String addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  %loc1 = alloca i16 addrspace(1)*
+  %loc2 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %1 = icmp ne %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg4
+  %7 = icmp sge i32 %6, 0
+  br i1 %7, label %13, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  unreachable
+
+; <label>:13                                      ; preds = %5
+  %14 = load i32, i32* %arg1
+  %15 = icmp sge i32 %14, 0
+  br i1 %15, label %21, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %18)
+  %20 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %20, %System.String addrspace(1)* %17, %System.String addrspace(1)* %19)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %20) #0
+  unreachable
+
+; <label>:21                                      ; preds = %13
+  %22 = load i32, i32* %arg4
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck, label %ThrowNullRef, label %24
+
+; <label>:24                                      ; preds = %21
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load i32, i32* %arg1
+  %28 = sub i32 %26, %27
+  %29 = icmp sle i32 %22, %28
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34, %System.String addrspace(1)* %31, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %24
+  %36 = load i32, i32* %arg3
+  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %37, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
+
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
+  %40 = load i32, i32 addrspace(1)* %39
+  %41 = zext i32 %40 to i64
+  %42 = trunc i64 %41 to i32
+  %43 = load i32, i32* %arg4
+  %44 = sub i32 %42, %43
+  %45 = icmp sgt i32 %36, %44
+  br i1 %45, label %49, label %46
+
+; <label>:46                                      ; preds = %38
+  %47 = load i32, i32* %arg3
+  %48 = icmp sge i32 %47, 0
+  br i1 %48, label %54, label %49
+
+; <label>:49                                      ; preds = %38, %46
+  %50 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %52 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %51)
+  %53 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53, %System.String addrspace(1)* %50, %System.String addrspace(1)* %52)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53) #0
+  unreachable
+
+; <label>:54                                      ; preds = %46
+  %55 = load i32, i32* %arg4
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %97, label %57
+
+; <label>:57                                      ; preds = %54
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %59
+
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 2
+  %61 = bitcast [0 x i16] addrspace(1)* %60 to i16 addrspace(1)*
+  store i16 addrspace(1)* %61, i16 addrspace(1)** %loc0
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  store %"System.Char[]" addrspace(1)* %62, %"System.Char[]" addrspace(1)** %loc2
+  %63 = icmp eq %"System.Char[]" addrspace(1)* %62, null
+  br i1 %63, label %72, label %64
+
+; <label>:64                                      ; preds = %59
+  %65 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc2
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %65, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %66
+
+; <label>:66                                      ; preds = %64
+  %67 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %65, i32 0, i32 1
+  %68 = load i32, i32 addrspace(1)* %67
+  %69 = zext i32 %68 to i64
+  %70 = trunc i64 %69 to i32
+  %71 = icmp ne i32 %70, 0
+  br i1 %71, label %73, label %72
+
+; <label>:72                                      ; preds = %59, %66
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  br label %81
+
+; <label>:73                                      ; preds = %66
+  %74 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc2
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %74, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %75
+
+; <label>:75                                      ; preds = %73
+  %76 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %74, i32 0, i32 1
+  %77 = load i32, i32 addrspace(1)* %76
+  %78 = zext i32 %77 to i64
+  %BoundsCheck = icmp uge i64 0, %78
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %79
+
+; <label>:79                                      ; preds = %75
+  %80 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %74, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %80, i16 addrspace(1)** %loc1
+  br label %81
+
+; <label>:81                                      ; preds = %72, %79
+  %82 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %83 = ptrtoint i16 addrspace(1)* %82 to i64
+  %84 = load i32, i32* %arg3
+  %85 = sext i32 %84 to i64
+  %86 = mul i64 %85, 2
+  %87 = add i64 %83, %86
+  %88 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %89 = ptrtoint i16 addrspace(1)* %88 to i64
+  %90 = load i32, i32* %arg1
+  %91 = sext i32 %90 to i64
+  %92 = mul i64 %91, 2
+  %93 = add i64 %89, %92
+  %94 = load i32, i32* %arg4
+  %95 = inttoptr i64 %87 to i16*
+  %96 = inttoptr i64 %93 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %95, i16* %96, i32 %94)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  br label %97
+
+; <label>:97                                      ; preds = %54, %81
+  ret void
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
 Successfully read ConsoleEncoding.GetPreamble
 
@@ -14850,7 +16769,365 @@ entry:
 }
 
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[loadElemA]
+Successfully read EncoderNLS.GetBytes
+
+define i32 @EncoderNLS.GetBytes(%System.Text.EncoderNLS addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3, %"System.Byte[]" addrspace(1)* %param4, i32 %param5, i8 %param6) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %arg4 = alloca %"System.Byte[]" addrspace(1)*
+  %arg5 = alloca i32
+  %arg6 = alloca i8
+  %loc0 = alloca i32
+  %loc1 = alloca i16 addrspace(1)*
+  %loc2 = alloca i8 addrspace(1)*
+  %loc3 = alloca i32
+  %loc4 = alloca %"System.Char[]" addrspace(1)*
+  %loc5 = alloca %"System.Byte[]" addrspace(1)*
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  store %"System.Byte[]" addrspace(1)* %param4, %"System.Byte[]" addrspace(1)** %arg4
+  store i32 %param5, i32* %arg5
+  store i8 %param6, i8* %arg6
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %1 = icmp eq %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %17, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %7 = icmp eq %"System.Char[]" addrspace(1)* %6, null
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %12
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %12
+
+; <label>:12                                      ; preds = %8, %10
+  %13 = phi %System.String addrspace(1)* [ %9, %8 ], [ %11, %10 ]
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %14)
+  %16 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16, %System.String addrspace(1)* %13, %System.String addrspace(1)* %15)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16) #0
+  unreachable
+
+; <label>:17                                      ; preds = %2
+  %18 = load i32, i32* %arg2
+  %19 = icmp slt i32 %18, 0
+  br i1 %19, label %23, label %20
+
+; <label>:20                                      ; preds = %17
+  %21 = load i32, i32* %arg3
+  %22 = icmp sge i32 %21, 0
+  br i1 %22, label %35, label %23
+
+; <label>:23                                      ; preds = %17, %20
+  %24 = load i32, i32* %arg2
+  %25 = icmp slt i32 %24, 0
+  br i1 %25, label %28, label %26
+
+; <label>:26                                      ; preds = %23
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %30
+
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %30
+
+; <label>:30                                      ; preds = %26, %28
+  %31 = phi %System.String addrspace(1)* [ %27, %26 ], [ %29, %28 ]
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34, %System.String addrspace(1)* %31, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %20
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck, label %ThrowNullRef, label %37
+
+; <label>:37                                      ; preds = %35
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = load i32, i32* %arg2
+  %43 = sub i32 %41, %42
+  %44 = load i32, i32* %arg3
+  %45 = icmp sge i32 %43, %44
+  br i1 %45, label %51, label %46
+
+; <label>:46                                      ; preds = %37
+  %47 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %48 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %49 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %48)
+  %50 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %50, %System.String addrspace(1)* %47, %System.String addrspace(1)* %49)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %50) #0
+  unreachable
+
+; <label>:51                                      ; preds = %37
+  %52 = load i32, i32* %arg5
+  %53 = icmp slt i32 %52, 0
+  br i1 %53, label %63, label %54
+
+; <label>:54                                      ; preds = %51
+  %55 = load i32, i32* %arg5
+  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck1 = icmp eq %"System.Byte[]" addrspace(1)* %56, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %57
+
+; <label>:57                                      ; preds = %54
+  %58 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = zext i32 %59 to i64
+  %61 = trunc i64 %60 to i32
+  %62 = icmp sle i32 %55, %61
+  br i1 %62, label %68, label %63
+
+; <label>:63                                      ; preds = %51, %57
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %66 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %65)
+  %67 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %67, %System.String addrspace(1)* %64, %System.String addrspace(1)* %66)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %67) #0
+  unreachable
+
+; <label>:68                                      ; preds = %57
+  %69 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %69, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %69, i32 0, i32 1
+  %72 = load i32, i32 addrspace(1)* %71
+  %73 = zext i32 %72 to i64
+  %74 = trunc i64 %73 to i32
+  %75 = icmp ne i32 %74, 0
+  br i1 %75, label %78, label %76
+
+; <label>:76                                      ; preds = %70
+  %77 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1)
+  store %"System.Char[]" addrspace(1)* %77, %"System.Char[]" addrspace(1)** %arg1
+  br label %78
+
+; <label>:78                                      ; preds = %70, %76
+  %79 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck5 = icmp eq %"System.Byte[]" addrspace(1)* %79, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %80
+
+; <label>:80                                      ; preds = %78
+  %81 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %79, i32 0, i32 1
+  %82 = load i32, i32 addrspace(1)* %81
+  %83 = zext i32 %82 to i64
+  %84 = trunc i64 %83 to i32
+  %85 = load i32, i32* %arg5
+  %86 = sub i32 %84, %85
+  store i32 %86, i32* %loc0
+  %87 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck7 = icmp eq %"System.Byte[]" addrspace(1)* %87, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %88
+
+; <label>:88                                      ; preds = %80
+  %89 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %87, i32 0, i32 1
+  %90 = load i32, i32 addrspace(1)* %89
+  %91 = zext i32 %90 to i64
+  %92 = trunc i64 %91 to i32
+  %93 = icmp ne i32 %92, 0
+  br i1 %93, label %96, label %94
+
+; <label>:94                                      ; preds = %88
+  %95 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1)
+  store %"System.Byte[]" addrspace(1)* %95, %"System.Byte[]" addrspace(1)** %arg4
+  br label %96
+
+; <label>:96                                      ; preds = %88, %94
+  %97 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  store %"System.Char[]" addrspace(1)* %97, %"System.Char[]" addrspace(1)** %loc4
+  %98 = icmp eq %"System.Char[]" addrspace(1)* %97, null
+  br i1 %98, label %107, label %99
+
+; <label>:99                                      ; preds = %96
+  %100 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc4
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %100, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %101
+
+; <label>:101                                     ; preds = %99
+  %102 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %100, i32 0, i32 1
+  %103 = load i32, i32 addrspace(1)* %102
+  %104 = zext i32 %103 to i64
+  %105 = trunc i64 %104 to i32
+  %106 = icmp ne i32 %105, 0
+  br i1 %106, label %108, label %107
+
+; <label>:107                                     ; preds = %96, %101
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  br label %116
+
+; <label>:108                                     ; preds = %101
+  %109 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc4
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %109, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %110
+
+; <label>:110                                     ; preds = %108
+  %111 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %109, i32 0, i32 1
+  %112 = load i32, i32 addrspace(1)* %111
+  %113 = zext i32 %112 to i64
+  %BoundsCheck = icmp uge i64 0, %113
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %114
+
+; <label>:114                                     ; preds = %110
+  %115 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %109, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %115, i16 addrspace(1)** %loc1
+  br label %116
+
+; <label>:116                                     ; preds = %107, %114
+  %117 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  store %"System.Byte[]" addrspace(1)* %117, %"System.Byte[]" addrspace(1)** %loc5
+  %118 = icmp eq %"System.Byte[]" addrspace(1)* %117, null
+  br i1 %118, label %127, label %119
+
+; <label>:119                                     ; preds = %116
+  %120 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc5
+  %NullCheck13 = icmp eq %"System.Byte[]" addrspace(1)* %120, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %121
+
+; <label>:121                                     ; preds = %119
+  %122 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %120, i32 0, i32 1
+  %123 = load i32, i32 addrspace(1)* %122
+  %124 = zext i32 %123 to i64
+  %125 = trunc i64 %124 to i32
+  %126 = icmp ne i32 %125, 0
+  br i1 %126, label %128, label %127
+
+; <label>:127                                     ; preds = %116, %121
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc2
+  br label %136
+
+; <label>:128                                     ; preds = %121
+  %129 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc5
+  %NullCheck15 = icmp eq %"System.Byte[]" addrspace(1)* %129, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %130
+
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %129, i32 0, i32 1
+  %132 = load i32, i32 addrspace(1)* %131
+  %133 = zext i32 %132 to i64
+  %BoundsCheck17 = icmp uge i64 0, %133
+  br i1 %BoundsCheck17, label %ThrowIndexOutOfRange18, label %134
+
+; <label>:134                                     ; preds = %130
+  %135 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %129, i32 0, i32 3, i32 0
+  store i8 addrspace(1)* %135, i8 addrspace(1)** %loc2
+  br label %136
+
+; <label>:136                                     ; preds = %127, %134
+  %137 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %138 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %139 = ptrtoint i16 addrspace(1)* %138 to i64
+  %140 = load i32, i32* %arg2
+  %141 = sext i32 %140 to i64
+  %142 = mul i64 %141, 2
+  %143 = add i64 %139, %142
+  %144 = load i32, i32* %arg3
+  %145 = load i8 addrspace(1)*, i8 addrspace(1)** %loc2
+  %146 = ptrtoint i8 addrspace(1)* %145 to i64
+  %147 = load i32, i32* %arg5
+  %148 = sext i32 %147 to i64
+  %149 = add i64 %146, %148
+  %150 = load i32, i32* %loc0
+  %151 = load i8, i8* %arg6
+  %152 = zext i8 %151 to i32
+  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i64 addrspace(1)*
+  %NullCheck19 = icmp eq i64 addrspace(1)* %153, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %154
+
+; <label>:154                                     ; preds = %136
+  %155 = load i64, i64 addrspace(1)* %153
+  %156 = add i64 %155, 72
+  %157 = inttoptr i64 %156 to i64*
+  %158 = load i64, i64* %157
+  %159 = add i64 %158, 0
+  %160 = inttoptr i64 %159 to i64*
+  %161 = load i64, i64* %160
+  %162 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to %System.Text.Encoder addrspace(1)*
+  %163 = inttoptr i64 %143 to i16*
+  %164 = inttoptr i64 %149 to i8*
+  %165 = trunc i32 %152 to i8
+  %166 = inttoptr i64 %161 to i32 (%System.Text.Encoder addrspace(1)*, i16*, i32, i8*, i32, i8)*
+  %167 = call i32 %166(%System.Text.Encoder addrspace(1)* %162, i16* %163, i32 %144, i8* %164, i32 %150, i8 %165)
+  store i32 %167, i32* %loc3
+  br label %168
+
+; <label>:168                                     ; preds = %154
+  %169 = load i32, i32* %loc3
+  ret i32 %169
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %110
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %119
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange18:                           ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
 Successfully read EncoderNLS.GetBytes
 
@@ -14939,22 +17216,22 @@ entry:
   %40 = load i8, i8* %arg5
   %41 = zext i8 %40 to i32
   %42 = trunc i32 %41 to i8
-  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %39, null
-  br i1 %NullCheck, label %43, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderNLS addrspace(1)* %39, null
+  br i1 %NullCheck, label %ThrowNullRef, label %43
 
 ; <label>:43                                      ; preds = %38
   %44 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
   store i8 %42, i8 addrspace(1)* %44
   %45 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %45, null
-  br i1 %NullCheck2, label %46, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.EncoderNLS addrspace(1)* %45, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %46
 
 ; <label>:46                                      ; preds = %43
   %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %45, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %47
   %48 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.EncoderNLS addrspace(1)* %48, null
-  br i1 %NullCheck4, label %49, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.EncoderNLS addrspace(1)* %48, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %49
 
 ; <label>:49                                      ; preds = %46
   %50 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %48, i32 0, i32 3
@@ -14965,8 +17242,8 @@ entry:
   %55 = load i32, i32* %arg4
   %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck6, label %58, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
   %59 = load i64, i64 addrspace(1)* %57
@@ -14984,15 +17261,15 @@ ThrowNullRef:                                     ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %43
+ThrowNullRef2:                                    ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %46
+ThrowNullRef4:                                    ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %49
+ThrowNullRef6:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -15020,8 +17297,8 @@ entry:
   %4 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0 to %System.IO.ConsoleStream addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*)(%System.IO.ConsoleStream addrspace(1)* %4, %"System.Byte[]" addrspace(1)* %1, i32 %2, i32 %3)
   %5 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
@@ -15106,8 +17383,8 @@ entry:
 
 ; <label>:22                                      ; preds = %8
   %23 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %23, null
-  br i1 %NullCheck, label %24, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Byte[]" addrspace(1)* %23, null
+  br i1 %NullCheck, label %ThrowNullRef, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
@@ -15129,8 +17406,8 @@ entry:
 
 ; <label>:36                                      ; preds = %24
   %37 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %37, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.ConsoleStream addrspace(1)* %37, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %37, i32 0, i32 4
@@ -15151,13 +17428,138 @@ ThrowNullRef:                                     ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %36
+ThrowNullRef2:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
-Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
+Successfully read WindowsConsoleStream.WriteFileNative
+
+define i32 @WindowsConsoleStream.WriteFileNative(i64 %param0, %"System.Byte[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i64
+  %arg1 = alloca %"System.Byte[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i8 addrspace(1)*
+  %loc2 = alloca %"System.Byte[]" addrspace(1)*
+  %loc3 = alloca i32
+  store i64 %param0, i64* %arg0
+  store %"System.Byte[]" addrspace(1)* %param1, %"System.Byte[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Byte[]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = zext i32 %3 to i64
+  %5 = icmp ne i64 %4, 0
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %1
+  ret i32 0
+
+; <label>:7                                       ; preds = %1
+  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  store %"System.Byte[]" addrspace(1)* %8, %"System.Byte[]" addrspace(1)** %loc2
+  %9 = icmp eq %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %9, label %18, label %10
+
+; <label>:10                                      ; preds = %7
+  %11 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc2
+  %NullCheck1 = icmp eq %"System.Byte[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %11, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp ne i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %7, %12
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc1
+  br label %27
+
+; <label>:19                                      ; preds = %12
+  %20 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc2
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %20, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %BoundsCheck = icmp uge i64 0, %24
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %25
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %20, i32 0, i32 3, i32 0
+  store i8 addrspace(1)* %26, i8 addrspace(1)** %loc1
+  br label %27
+
+; <label>:27                                      ; preds = %18, %25
+  %28 = load i64, i64* %arg0
+  %29 = load i8 addrspace(1)*, i8 addrspace(1)** %loc1
+  %30 = ptrtoint i8 addrspace(1)* %29 to i64
+  %31 = load i32, i32* %arg2
+  %32 = sext i32 %31 to i64
+  %33 = add i64 %30, %32
+  %34 = load i32, i32* %arg3
+  %35 = addrspacecast i32* %loc3 to i32 addrspace(1)*
+  %36 = inttoptr i64 %33 to i8*
+  %37 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i8*, i32, i32 addrspace(1)*, i64)*)(i64 %28, i8* %36, i32 %34, i32 addrspace(1)* %35, i64 0)
+  %38 = icmp ugt i32 %37, 0
+  %39 = sext i1 %38 to i32
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc1
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %42, label %41
+
+; <label>:41                                      ; preds = %27
+  ret i32 0
+
+; <label>:42                                      ; preds = %27
+  %43 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  store i32 %43, i32* %loc0
+  %44 = load i32, i32* %loc0
+  %45 = icmp eq i32 %44, 232
+  br i1 %45, label %49, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = load i32, i32* %loc0
+  %48 = icmp ne i32 %47, 109
+  br i1 %48, label %50, label %49
+
+; <label>:49                                      ; preds = %42, %46
+  ret i32 0
+
+; <label>:50                                      ; preds = %46
+  %51 = load i32, i32* %loc0
+  ret i32 %51
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
 Successfully read WindowsConsoleStream.Flush
 
@@ -15166,8 +17568,8 @@ entry:
   %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
   store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
@@ -15202,8 +17604,8 @@ entry:
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
   %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load i64, i64 addrspace(1)* %1
@@ -15242,15 +17644,15 @@ entry:
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.TextWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
   %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %3, align 8
   %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
   %7 = load i64, i64 addrspace(1)* %5
@@ -15268,7 +17670,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -15297,8 +17699,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %4)
   store i32 0, i32* %loc0
   %5 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Char[]" addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
@@ -15310,15 +17712,15 @@ entry:
 
 ; <label>:11                                      ; preds = %69
   %12 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %12, i32 0, i32 9
   %15 = load i32, i32 addrspace(1)* %14, align 8
   %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.IO.StreamWriter addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %16, i32 0, i32 10
@@ -15333,15 +17735,15 @@ entry:
 
 ; <label>:23                                      ; preds = %17, %21
   %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %24, null
-  br i1 %NullCheck8, label %25, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %24, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 10
   %27 = load i32, i32 addrspace(1)* %26, align 8
   %28 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %28, null
-  br i1 %NullCheck10, label %29, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.StreamWriter addrspace(1)* %28, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %28, i32 0, i32 9
@@ -15363,15 +17765,15 @@ entry:
   %40 = load i32, i32* %loc0
   %41 = mul i32 %40, 2
   %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
-  br i1 %NullCheck12, label %43, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %43
 
 ; <label>:43                                      ; preds = %38
   %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 7
   %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %44, align 8
   %46 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %46, null
-  br i1 %NullCheck14, label %47, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.IO.StreamWriter addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %47
 
 ; <label>:47                                      ; preds = %43
   %48 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %46, i32 0, i32 9
@@ -15383,16 +17785,16 @@ entry:
   %54 = bitcast %"System.Char[]" addrspace(1)* %45 to %System.Array addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %53, i32 %41, %System.Array addrspace(1)* %54, i32 %50, i32 %52)
   %55 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
-  br i1 %NullCheck16, label %56, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %56
 
 ; <label>:56                                      ; preds = %47
   %57 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
   %58 = load i32, i32 addrspace(1)* %57, align 8
   %59 = load i32, i32* %loc2
   %60 = add i32 %58, %59
-  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
-  br i1 %NullCheck18, label %61, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %61
 
 ; <label>:61                                      ; preds = %56
   %62 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
@@ -15414,8 +17816,8 @@ entry:
 
 ; <label>:72                                      ; preds = %69
   %73 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %73, null
-  br i1 %NullCheck2, label %74, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %73, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %74
 
 ; <label>:74                                      ; preds = %72
   %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %73, i32 0, i32 11
@@ -15436,39 +17838,39 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %72
+ThrowNullRef2:                                    ; preds = %72
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %23
+ThrowNullRef8:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef10:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %43
+ThrowNullRef14:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %47
+ThrowNullRef16:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %56
+ThrowNullRef18:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPCall1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPCall1.error.txt
@@ -25,8 +25,8 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
@@ -40,8 +40,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
   %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
@@ -75,7 +75,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -90,8 +90,8 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %NullCheck = icmp ne i8 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = load i8, i8 addrspace(1)* %0, align 8
@@ -125,8 +125,8 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
@@ -159,8 +159,8 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -184,8 +184,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
   store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
@@ -195,8 +195,8 @@ entry:
 ; <label>:4                                       ; preds = %1
   %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
   %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
@@ -206,8 +206,8 @@ entry:
   %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
@@ -221,14 +221,14 @@ entry:
 
 ; <label>:17                                      ; preds = %14
   %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
   %21 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
@@ -238,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -249,8 +249,8 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
@@ -261,27 +261,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %30
+ThrowNullRef10:                                   ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -301,7 +301,89 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
-Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
+Successfully read AppDomainSetup.GetUnsecureApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.GetUnsecureApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %NullCheck = icmp eq %"System.String[]" addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %BoundsCheck = icmp uge i64 0, %5
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %6
+
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 3, i32 0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
+  ret %System.String addrspace(1)* %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_Value using LLILCJit
+Successfully read AppDomainSetup.get_Value
+
+define %"System.String[]" addrspace(1)* @AppDomainSetup.get_Value(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.String[]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 18)
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.String[]" addrspace(1)* addrspace(1)*, %"System.String[]" addrspace(1)*)*)(%"System.String[]" addrspace(1)* addrspace(1)* %9, %"System.String[]" addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %11, i32 0, i32 1
+  %14 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %13, align 8
+  ret %"System.String[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -319,8 +401,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -368,16 +450,16 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
   %5 = load i32, i32 addrspace(1)* %4
   %6 = sub i32 %5, 1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -389,7 +471,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -421,8 +503,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
@@ -456,8 +538,8 @@ entry:
 ; <label>:27                                      ; preds = %19
   %28 = load i32, i32* %arg1
   %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
-  br i1 %NullCheck2, label %30, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %29, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %30
 
 ; <label>:30                                      ; preds = %27
   %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
@@ -493,8 +575,8 @@ entry:
 ; <label>:49                                      ; preds = %46
   %50 = load i32, i32* %arg2
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck4, label %52, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
@@ -517,11 +599,11 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %27
+ThrowNullRef2:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %49
+ThrowNullRef4:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -544,16 +626,16 @@ entry:
   %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %0)
   store %System.String addrspace(1)* %1, %System.String addrspace(1)** %loc0
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 2
   %5 = bitcast [0 x i16] addrspace(1)* %4 to i16 addrspace(1)*
   store i16 addrspace(1)* %5, i16 addrspace(1)** %loc1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %3
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2
@@ -580,7 +662,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -691,15 +773,15 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %NullCheck132 = icmp ne i8* %21, null
-  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+  %NullCheck131 = icmp eq i8* %21, null
+  br i1 %NullCheck131, label %ThrowNullRef132, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = load i8, i8* %21, align 8
   %24 = zext i8 %23 to i32
   %25 = trunc i32 %24 to i8
-  %NullCheck134 = icmp ne i8* %20, null
-  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+  %NullCheck133 = icmp eq i8* %20, null
+  br i1 %NullCheck133, label %ThrowNullRef134, label %26
 
 ; <label>:26                                      ; preds = %22
   store i8 %25, i8* %20, align 8
@@ -709,16 +791,16 @@ entry:
   %28 = load i8*, i8** %arg0
   %29 = load i8*, i8** %arg1
   %30 = bitcast i8* %29 to i16*
-  %NullCheck128 = icmp ne i16* %30, null
-  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+  %NullCheck127 = icmp eq i16* %30, null
+  br i1 %NullCheck127, label %ThrowNullRef128, label %31
 
 ; <label>:31                                      ; preds = %27
   %32 = load i16, i16* %30, align 8
   %33 = sext i16 %32 to i32
   %34 = bitcast i8* %28 to i16*
   %35 = trunc i32 %33 to i16
-  %NullCheck130 = icmp ne i16* %34, null
-  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+  %NullCheck129 = icmp eq i16* %34, null
+  br i1 %NullCheck129, label %ThrowNullRef130, label %36
 
 ; <label>:36                                      ; preds = %31
   store i16 %35, i16* %34, align 8
@@ -728,16 +810,16 @@ entry:
   %38 = load i8*, i8** %arg0
   %39 = load i8*, i8** %arg1
   %40 = bitcast i8* %39 to i16*
-  %NullCheck120 = icmp ne i16* %40, null
-  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+  %NullCheck119 = icmp eq i16* %40, null
+  br i1 %NullCheck119, label %ThrowNullRef120, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i16, i16* %40, align 8
   %43 = sext i16 %42 to i32
   %44 = bitcast i8* %38 to i16*
   %45 = trunc i32 %43 to i16
-  %NullCheck122 = icmp ne i16* %44, null
-  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+  %NullCheck121 = icmp eq i16* %44, null
+  br i1 %NullCheck121, label %ThrowNullRef122, label %46
 
 ; <label>:46                                      ; preds = %41
   store i16 %45, i16* %44, align 8
@@ -745,15 +827,15 @@ entry:
   %48 = getelementptr inbounds i8, i8* %47, i64 2
   %49 = load i8*, i8** %arg1
   %50 = getelementptr inbounds i8, i8* %49, i64 2
-  %NullCheck124 = icmp ne i8* %50, null
-  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+  %NullCheck123 = icmp eq i8* %50, null
+  br i1 %NullCheck123, label %ThrowNullRef124, label %51
 
 ; <label>:51                                      ; preds = %46
   %52 = load i8, i8* %50, align 8
   %53 = zext i8 %52 to i32
   %54 = trunc i32 %53 to i8
-  %NullCheck126 = icmp ne i8* %48, null
-  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+  %NullCheck125 = icmp eq i8* %48, null
+  br i1 %NullCheck125, label %ThrowNullRef126, label %55
 
 ; <label>:55                                      ; preds = %51
   store i8 %54, i8* %48, align 8
@@ -763,14 +845,14 @@ entry:
   %57 = load i8*, i8** %arg0
   %58 = load i8*, i8** %arg1
   %59 = bitcast i8* %58 to i32*
-  %NullCheck116 = icmp ne i32* %59, null
-  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+  %NullCheck115 = icmp eq i32* %59, null
+  br i1 %NullCheck115, label %ThrowNullRef116, label %60
 
 ; <label>:60                                      ; preds = %56
   %61 = load i32, i32* %59, align 8
   %62 = bitcast i8* %57 to i32*
-  %NullCheck118 = icmp ne i32* %62, null
-  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+  %NullCheck117 = icmp eq i32* %62, null
+  br i1 %NullCheck117, label %ThrowNullRef118, label %63
 
 ; <label>:63                                      ; preds = %60
   store i32 %61, i32* %62, align 8
@@ -780,14 +862,14 @@ entry:
   %65 = load i8*, i8** %arg0
   %66 = load i8*, i8** %arg1
   %67 = bitcast i8* %66 to i32*
-  %NullCheck108 = icmp ne i32* %67, null
-  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+  %NullCheck107 = icmp eq i32* %67, null
+  br i1 %NullCheck107, label %ThrowNullRef108, label %68
 
 ; <label>:68                                      ; preds = %64
   %69 = load i32, i32* %67, align 8
   %70 = bitcast i8* %65 to i32*
-  %NullCheck110 = icmp ne i32* %70, null
-  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+  %NullCheck109 = icmp eq i32* %70, null
+  br i1 %NullCheck109, label %ThrowNullRef110, label %71
 
 ; <label>:71                                      ; preds = %68
   store i32 %69, i32* %70, align 8
@@ -795,15 +877,15 @@ entry:
   %73 = getelementptr inbounds i8, i8* %72, i64 4
   %74 = load i8*, i8** %arg1
   %75 = getelementptr inbounds i8, i8* %74, i64 4
-  %NullCheck112 = icmp ne i8* %75, null
-  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+  %NullCheck111 = icmp eq i8* %75, null
+  br i1 %NullCheck111, label %ThrowNullRef112, label %76
 
 ; <label>:76                                      ; preds = %71
   %77 = load i8, i8* %75, align 8
   %78 = zext i8 %77 to i32
   %79 = trunc i32 %78 to i8
-  %NullCheck114 = icmp ne i8* %73, null
-  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+  %NullCheck113 = icmp eq i8* %73, null
+  br i1 %NullCheck113, label %ThrowNullRef114, label %80
 
 ; <label>:80                                      ; preds = %76
   store i8 %79, i8* %73, align 8
@@ -813,14 +895,14 @@ entry:
   %82 = load i8*, i8** %arg0
   %83 = load i8*, i8** %arg1
   %84 = bitcast i8* %83 to i32*
-  %NullCheck100 = icmp ne i32* %84, null
-  br i1 %NullCheck100, label %85, label %ThrowNullRef99
+  %NullCheck99 = icmp eq i32* %84, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %85
 
 ; <label>:85                                      ; preds = %81
   %86 = load i32, i32* %84, align 8
   %87 = bitcast i8* %82 to i32*
-  %NullCheck102 = icmp ne i32* %87, null
-  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+  %NullCheck101 = icmp eq i32* %87, null
+  br i1 %NullCheck101, label %ThrowNullRef102, label %88
 
 ; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
@@ -829,16 +911,16 @@ entry:
   %91 = load i8*, i8** %arg1
   %92 = getelementptr inbounds i8, i8* %91, i64 4
   %93 = bitcast i8* %92 to i16*
-  %NullCheck104 = icmp ne i16* %93, null
-  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+  %NullCheck103 = icmp eq i16* %93, null
+  br i1 %NullCheck103, label %ThrowNullRef104, label %94
 
 ; <label>:94                                      ; preds = %88
   %95 = load i16, i16* %93, align 8
   %96 = sext i16 %95 to i32
   %97 = bitcast i8* %90 to i16*
   %98 = trunc i32 %96 to i16
-  %NullCheck106 = icmp ne i16* %97, null
-  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+  %NullCheck105 = icmp eq i16* %97, null
+  br i1 %NullCheck105, label %ThrowNullRef106, label %99
 
 ; <label>:99                                      ; preds = %94
   store i16 %98, i16* %97, align 8
@@ -848,14 +930,14 @@ entry:
   %101 = load i8*, i8** %arg0
   %102 = load i8*, i8** %arg1
   %103 = bitcast i8* %102 to i32*
-  %NullCheck88 = icmp ne i32* %103, null
-  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+  %NullCheck87 = icmp eq i32* %103, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %104
 
 ; <label>:104                                     ; preds = %100
   %105 = load i32, i32* %103, align 8
   %106 = bitcast i8* %101 to i32*
-  %NullCheck90 = icmp ne i32* %106, null
-  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+  %NullCheck89 = icmp eq i32* %106, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %107
 
 ; <label>:107                                     ; preds = %104
   store i32 %105, i32* %106, align 8
@@ -864,16 +946,16 @@ entry:
   %110 = load i8*, i8** %arg1
   %111 = getelementptr inbounds i8, i8* %110, i64 4
   %112 = bitcast i8* %111 to i16*
-  %NullCheck92 = icmp ne i16* %112, null
-  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+  %NullCheck91 = icmp eq i16* %112, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %113
 
 ; <label>:113                                     ; preds = %107
   %114 = load i16, i16* %112, align 8
   %115 = sext i16 %114 to i32
   %116 = bitcast i8* %109 to i16*
   %117 = trunc i32 %115 to i16
-  %NullCheck94 = icmp ne i16* %116, null
-  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+  %NullCheck93 = icmp eq i16* %116, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %118
 
 ; <label>:118                                     ; preds = %113
   store i16 %117, i16* %116, align 8
@@ -881,15 +963,15 @@ entry:
   %120 = getelementptr inbounds i8, i8* %119, i64 6
   %121 = load i8*, i8** %arg1
   %122 = getelementptr inbounds i8, i8* %121, i64 6
-  %NullCheck96 = icmp ne i8* %122, null
-  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+  %NullCheck95 = icmp eq i8* %122, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %123
 
 ; <label>:123                                     ; preds = %118
   %124 = load i8, i8* %122, align 8
   %125 = zext i8 %124 to i32
   %126 = trunc i32 %125 to i8
-  %NullCheck98 = icmp ne i8* %120, null
-  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+  %NullCheck97 = icmp eq i8* %120, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %127
 
 ; <label>:127                                     ; preds = %123
   store i8 %126, i8* %120, align 8
@@ -899,14 +981,14 @@ entry:
   %129 = load i8*, i8** %arg0
   %130 = load i8*, i8** %arg1
   %131 = bitcast i8* %130 to i64*
-  %NullCheck84 = icmp ne i64* %131, null
-  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+  %NullCheck83 = icmp eq i64* %131, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %132
 
 ; <label>:132                                     ; preds = %128
   %133 = load i64, i64* %131, align 8
   %134 = bitcast i8* %129 to i64*
-  %NullCheck86 = icmp ne i64* %134, null
-  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+  %NullCheck85 = icmp eq i64* %134, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %135
 
 ; <label>:135                                     ; preds = %132
   store i64 %133, i64* %134, align 8
@@ -916,14 +998,14 @@ entry:
   %137 = load i8*, i8** %arg0
   %138 = load i8*, i8** %arg1
   %139 = bitcast i8* %138 to i64*
-  %NullCheck76 = icmp ne i64* %139, null
-  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+  %NullCheck75 = icmp eq i64* %139, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %140
 
 ; <label>:140                                     ; preds = %136
   %141 = load i64, i64* %139, align 8
   %142 = bitcast i8* %137 to i64*
-  %NullCheck78 = icmp ne i64* %142, null
-  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+  %NullCheck77 = icmp eq i64* %142, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %143
 
 ; <label>:143                                     ; preds = %140
   store i64 %141, i64* %142, align 8
@@ -931,15 +1013,15 @@ entry:
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %NullCheck80 = icmp ne i8* %147, null
-  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+  %NullCheck79 = icmp eq i8* %147, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %148
 
 ; <label>:148                                     ; preds = %143
   %149 = load i8, i8* %147, align 8
   %150 = zext i8 %149 to i32
   %151 = trunc i32 %150 to i8
-  %NullCheck82 = icmp ne i8* %145, null
-  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+  %NullCheck81 = icmp eq i8* %145, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %152
 
 ; <label>:152                                     ; preds = %148
   store i8 %151, i8* %145, align 8
@@ -949,14 +1031,14 @@ entry:
   %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
   %156 = bitcast i8* %155 to i64*
-  %NullCheck68 = icmp ne i64* %156, null
-  br i1 %NullCheck68, label %157, label %ThrowNullRef67
+  %NullCheck67 = icmp eq i64* %156, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %157
 
 ; <label>:157                                     ; preds = %153
   %158 = load i64, i64* %156, align 8
   %159 = bitcast i8* %154 to i64*
-  %NullCheck70 = icmp ne i64* %159, null
-  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+  %NullCheck69 = icmp eq i64* %159, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %160
 
 ; <label>:160                                     ; preds = %157
   store i64 %158, i64* %159, align 8
@@ -965,16 +1047,16 @@ entry:
   %163 = load i8*, i8** %arg1
   %164 = getelementptr inbounds i8, i8* %163, i64 8
   %165 = bitcast i8* %164 to i16*
-  %NullCheck72 = icmp ne i16* %165, null
-  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+  %NullCheck71 = icmp eq i16* %165, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %166
 
 ; <label>:166                                     ; preds = %160
   %167 = load i16, i16* %165, align 8
   %168 = sext i16 %167 to i32
   %169 = bitcast i8* %162 to i16*
   %170 = trunc i32 %168 to i16
-  %NullCheck74 = icmp ne i16* %169, null
-  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+  %NullCheck73 = icmp eq i16* %169, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %171
 
 ; <label>:171                                     ; preds = %166
   store i16 %170, i16* %169, align 8
@@ -984,14 +1066,14 @@ entry:
   %173 = load i8*, i8** %arg0
   %174 = load i8*, i8** %arg1
   %175 = bitcast i8* %174 to i64*
-  %NullCheck56 = icmp ne i64* %175, null
-  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+  %NullCheck55 = icmp eq i64* %175, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %176
 
 ; <label>:176                                     ; preds = %172
   %177 = load i64, i64* %175, align 8
   %178 = bitcast i8* %173 to i64*
-  %NullCheck58 = icmp ne i64* %178, null
-  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+  %NullCheck57 = icmp eq i64* %178, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %179
 
 ; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
@@ -1000,16 +1082,16 @@ entry:
   %182 = load i8*, i8** %arg1
   %183 = getelementptr inbounds i8, i8* %182, i64 8
   %184 = bitcast i8* %183 to i16*
-  %NullCheck60 = icmp ne i16* %184, null
-  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+  %NullCheck59 = icmp eq i16* %184, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %185
 
 ; <label>:185                                     ; preds = %179
   %186 = load i16, i16* %184, align 8
   %187 = sext i16 %186 to i32
   %188 = bitcast i8* %181 to i16*
   %189 = trunc i32 %187 to i16
-  %NullCheck62 = icmp ne i16* %188, null
-  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+  %NullCheck61 = icmp eq i16* %188, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %190
 
 ; <label>:190                                     ; preds = %185
   store i16 %189, i16* %188, align 8
@@ -1017,15 +1099,15 @@ entry:
   %192 = getelementptr inbounds i8, i8* %191, i64 10
   %193 = load i8*, i8** %arg1
   %194 = getelementptr inbounds i8, i8* %193, i64 10
-  %NullCheck64 = icmp ne i8* %194, null
-  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+  %NullCheck63 = icmp eq i8* %194, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %195
 
 ; <label>:195                                     ; preds = %190
   %196 = load i8, i8* %194, align 8
   %197 = zext i8 %196 to i32
   %198 = trunc i32 %197 to i8
-  %NullCheck66 = icmp ne i8* %192, null
-  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+  %NullCheck65 = icmp eq i8* %192, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %199
 
 ; <label>:199                                     ; preds = %195
   store i8 %198, i8* %192, align 8
@@ -1035,14 +1117,14 @@ entry:
   %201 = load i8*, i8** %arg0
   %202 = load i8*, i8** %arg1
   %203 = bitcast i8* %202 to i64*
-  %NullCheck48 = icmp ne i64* %203, null
-  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+  %NullCheck47 = icmp eq i64* %203, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %204
 
 ; <label>:204                                     ; preds = %200
   %205 = load i64, i64* %203, align 8
   %206 = bitcast i8* %201 to i64*
-  %NullCheck50 = icmp ne i64* %206, null
-  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+  %NullCheck49 = icmp eq i64* %206, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %207
 
 ; <label>:207                                     ; preds = %204
   store i64 %205, i64* %206, align 8
@@ -1051,14 +1133,14 @@ entry:
   %210 = load i8*, i8** %arg1
   %211 = getelementptr inbounds i8, i8* %210, i64 8
   %212 = bitcast i8* %211 to i32*
-  %NullCheck52 = icmp ne i32* %212, null
-  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+  %NullCheck51 = icmp eq i32* %212, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %213
 
 ; <label>:213                                     ; preds = %207
   %214 = load i32, i32* %212, align 8
   %215 = bitcast i8* %209 to i32*
-  %NullCheck54 = icmp ne i32* %215, null
-  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+  %NullCheck53 = icmp eq i32* %215, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %216
 
 ; <label>:216                                     ; preds = %213
   store i32 %214, i32* %215, align 8
@@ -1068,14 +1150,14 @@ entry:
   %218 = load i8*, i8** %arg0
   %219 = load i8*, i8** %arg1
   %220 = bitcast i8* %219 to i64*
-  %NullCheck36 = icmp ne i64* %220, null
-  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64* %220, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %221
 
 ; <label>:221                                     ; preds = %217
   %222 = load i64, i64* %220, align 8
   %223 = bitcast i8* %218 to i64*
-  %NullCheck38 = icmp ne i64* %223, null
-  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+  %NullCheck37 = icmp eq i64* %223, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %224
 
 ; <label>:224                                     ; preds = %221
   store i64 %222, i64* %223, align 8
@@ -1084,14 +1166,14 @@ entry:
   %227 = load i8*, i8** %arg1
   %228 = getelementptr inbounds i8, i8* %227, i64 8
   %229 = bitcast i8* %228 to i32*
-  %NullCheck40 = icmp ne i32* %229, null
-  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i32* %229, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %230
 
 ; <label>:230                                     ; preds = %224
   %231 = load i32, i32* %229, align 8
   %232 = bitcast i8* %226 to i32*
-  %NullCheck42 = icmp ne i32* %232, null
-  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+  %NullCheck41 = icmp eq i32* %232, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %233
 
 ; <label>:233                                     ; preds = %230
   store i32 %231, i32* %232, align 8
@@ -1099,15 +1181,15 @@ entry:
   %235 = getelementptr inbounds i8, i8* %234, i64 12
   %236 = load i8*, i8** %arg1
   %237 = getelementptr inbounds i8, i8* %236, i64 12
-  %NullCheck44 = icmp ne i8* %237, null
-  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i8* %237, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %238
 
 ; <label>:238                                     ; preds = %233
   %239 = load i8, i8* %237, align 8
   %240 = zext i8 %239 to i32
   %241 = trunc i32 %240 to i8
-  %NullCheck46 = icmp ne i8* %235, null
-  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+  %NullCheck45 = icmp eq i8* %235, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %242
 
 ; <label>:242                                     ; preds = %238
   store i8 %241, i8* %235, align 8
@@ -1117,14 +1199,14 @@ entry:
   %244 = load i8*, i8** %arg0
   %245 = load i8*, i8** %arg1
   %246 = bitcast i8* %245 to i64*
-  %NullCheck24 = icmp ne i64* %246, null
-  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64* %246, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %247
 
 ; <label>:247                                     ; preds = %243
   %248 = load i64, i64* %246, align 8
   %249 = bitcast i8* %244 to i64*
-  %NullCheck26 = icmp ne i64* %249, null
-  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64* %249, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %250
 
 ; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
@@ -1133,14 +1215,14 @@ entry:
   %253 = load i8*, i8** %arg1
   %254 = getelementptr inbounds i8, i8* %253, i64 8
   %255 = bitcast i8* %254 to i32*
-  %NullCheck28 = icmp ne i32* %255, null
-  br i1 %NullCheck28, label %256, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i32* %255, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %256
 
 ; <label>:256                                     ; preds = %250
   %257 = load i32, i32* %255, align 8
   %258 = bitcast i8* %252 to i32*
-  %NullCheck30 = icmp ne i32* %258, null
-  br i1 %NullCheck30, label %259, label %ThrowNullRef29
+  %NullCheck29 = icmp eq i32* %258, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %259
 
 ; <label>:259                                     ; preds = %256
   store i32 %257, i32* %258, align 8
@@ -1149,16 +1231,16 @@ entry:
   %262 = load i8*, i8** %arg1
   %263 = getelementptr inbounds i8, i8* %262, i64 12
   %264 = bitcast i8* %263 to i16*
-  %NullCheck32 = icmp ne i16* %264, null
-  br i1 %NullCheck32, label %265, label %ThrowNullRef31
+  %NullCheck31 = icmp eq i16* %264, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %265
 
 ; <label>:265                                     ; preds = %259
   %266 = load i16, i16* %264, align 8
   %267 = sext i16 %266 to i32
   %268 = bitcast i8* %261 to i16*
   %269 = trunc i32 %267 to i16
-  %NullCheck34 = icmp ne i16* %268, null
-  br i1 %NullCheck34, label %270, label %ThrowNullRef33
+  %NullCheck33 = icmp eq i16* %268, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %270
 
 ; <label>:270                                     ; preds = %265
   store i16 %269, i16* %268, align 8
@@ -1168,14 +1250,14 @@ entry:
   %272 = load i8*, i8** %arg0
   %273 = load i8*, i8** %arg1
   %274 = bitcast i8* %273 to i64*
-  %NullCheck8 = icmp ne i64* %274, null
-  br i1 %NullCheck8, label %275, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64* %274, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %275
 
 ; <label>:275                                     ; preds = %271
   %276 = load i64, i64* %274, align 8
   %277 = bitcast i8* %272 to i64*
-  %NullCheck10 = icmp ne i64* %277, null
-  br i1 %NullCheck10, label %278, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %277, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %278
 
 ; <label>:278                                     ; preds = %275
   store i64 %276, i64* %277, align 8
@@ -1184,14 +1266,14 @@ entry:
   %281 = load i8*, i8** %arg1
   %282 = getelementptr inbounds i8, i8* %281, i64 8
   %283 = bitcast i8* %282 to i32*
-  %NullCheck12 = icmp ne i32* %283, null
-  br i1 %NullCheck12, label %284, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i32* %283, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %284
 
 ; <label>:284                                     ; preds = %278
   %285 = load i32, i32* %283, align 8
   %286 = bitcast i8* %280 to i32*
-  %NullCheck14 = icmp ne i32* %286, null
-  br i1 %NullCheck14, label %287, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i32* %286, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %287
 
 ; <label>:287                                     ; preds = %284
   store i32 %285, i32* %286, align 8
@@ -1200,16 +1282,16 @@ entry:
   %290 = load i8*, i8** %arg1
   %291 = getelementptr inbounds i8, i8* %290, i64 12
   %292 = bitcast i8* %291 to i16*
-  %NullCheck16 = icmp ne i16* %292, null
-  br i1 %NullCheck16, label %293, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i16* %292, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %293
 
 ; <label>:293                                     ; preds = %287
   %294 = load i16, i16* %292, align 8
   %295 = sext i16 %294 to i32
   %296 = bitcast i8* %289 to i16*
   %297 = trunc i32 %295 to i16
-  %NullCheck18 = icmp ne i16* %296, null
-  br i1 %NullCheck18, label %298, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i16* %296, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %298
 
 ; <label>:298                                     ; preds = %293
   store i16 %297, i16* %296, align 8
@@ -1217,15 +1299,15 @@ entry:
   %300 = getelementptr inbounds i8, i8* %299, i64 14
   %301 = load i8*, i8** %arg1
   %302 = getelementptr inbounds i8, i8* %301, i64 14
-  %NullCheck20 = icmp ne i8* %302, null
-  br i1 %NullCheck20, label %303, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i8* %302, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %303
 
 ; <label>:303                                     ; preds = %298
   %304 = load i8, i8* %302, align 8
   %305 = zext i8 %304 to i32
   %306 = trunc i32 %305 to i8
-  %NullCheck22 = icmp ne i8* %300, null
-  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i8* %300, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %307
 
 ; <label>:307                                     ; preds = %303
   store i8 %306, i8* %300, align 8
@@ -1235,14 +1317,14 @@ entry:
   %309 = load i8*, i8** %arg0
   %310 = load i8*, i8** %arg1
   %311 = bitcast i8* %310 to i64*
-  %NullCheck = icmp ne i64* %311, null
-  br i1 %NullCheck, label %312, label %ThrowNullRef
+  %NullCheck = icmp eq i64* %311, null
+  br i1 %NullCheck, label %ThrowNullRef, label %312
 
 ; <label>:312                                     ; preds = %308
   %313 = load i64, i64* %311, align 8
   %314 = bitcast i8* %309 to i64*
-  %NullCheck2 = icmp ne i64* %314, null
-  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64* %314, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %315
 
 ; <label>:315                                     ; preds = %312
   store i64 %313, i64* %314, align 8
@@ -1251,14 +1333,14 @@ entry:
   %318 = load i8*, i8** %arg1
   %319 = getelementptr inbounds i8, i8* %318, i64 8
   %320 = bitcast i8* %319 to i64*
-  %NullCheck4 = icmp ne i64* %320, null
-  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64* %320, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %321
 
 ; <label>:321                                     ; preds = %315
   %322 = load i64, i64* %320, align 8
   %323 = bitcast i8* %317 to i64*
-  %NullCheck6 = icmp ne i64* %323, null
-  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64* %323, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %324
 
 ; <label>:324                                     ; preds = %321
   store i64 %322, i64* %323, align 8
@@ -1286,15 +1368,15 @@ entry:
 ; <label>:338                                     ; preds = %333
   %339 = load i8*, i8** %arg0
   %340 = load i8*, i8** %arg1
-  %NullCheck136 = icmp ne i8* %340, null
-  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+  %NullCheck135 = icmp eq i8* %340, null
+  br i1 %NullCheck135, label %ThrowNullRef136, label %341
 
 ; <label>:341                                     ; preds = %338
   %342 = load i8, i8* %340, align 8
   %343 = zext i8 %342 to i32
   %344 = trunc i32 %343 to i8
-  %NullCheck138 = icmp ne i8* %339, null
-  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+  %NullCheck137 = icmp eq i8* %339, null
+  br i1 %NullCheck137, label %ThrowNullRef138, label %345
 
 ; <label>:345                                     ; preds = %341
   store i8 %344, i8* %339, align 8
@@ -1317,16 +1399,16 @@ entry:
   %357 = load i8*, i8** %arg0
   %358 = load i8*, i8** %arg1
   %359 = bitcast i8* %358 to i16*
-  %NullCheck140 = icmp ne i16* %359, null
-  br i1 %NullCheck140, label %360, label %ThrowNullRef139
+  %NullCheck139 = icmp eq i16* %359, null
+  br i1 %NullCheck139, label %ThrowNullRef140, label %360
 
 ; <label>:360                                     ; preds = %356
   %361 = load i16, i16* %359, align 8
   %362 = sext i16 %361 to i32
   %363 = bitcast i8* %357 to i16*
   %364 = trunc i32 %362 to i16
-  %NullCheck142 = icmp ne i16* %363, null
-  br i1 %NullCheck142, label %365, label %ThrowNullRef141
+  %NullCheck141 = icmp eq i16* %363, null
+  br i1 %NullCheck141, label %ThrowNullRef142, label %365
 
 ; <label>:365                                     ; preds = %360
   store i16 %364, i16* %363, align 8
@@ -1352,14 +1434,14 @@ entry:
   %378 = load i8*, i8** %arg0
   %379 = load i8*, i8** %arg1
   %380 = bitcast i8* %379 to i32*
-  %NullCheck144 = icmp ne i32* %380, null
-  br i1 %NullCheck144, label %381, label %ThrowNullRef143
+  %NullCheck143 = icmp eq i32* %380, null
+  br i1 %NullCheck143, label %ThrowNullRef144, label %381
 
 ; <label>:381                                     ; preds = %377
   %382 = load i32, i32* %380, align 8
   %383 = bitcast i8* %378 to i32*
-  %NullCheck146 = icmp ne i32* %383, null
-  br i1 %NullCheck146, label %384, label %ThrowNullRef145
+  %NullCheck145 = icmp eq i32* %383, null
+  br i1 %NullCheck145, label %ThrowNullRef146, label %384
 
 ; <label>:384                                     ; preds = %381
   store i32 %382, i32* %383, align 8
@@ -1384,14 +1466,14 @@ entry:
   %395 = load i8*, i8** %arg0
   %396 = load i8*, i8** %arg1
   %397 = bitcast i8* %396 to i64*
-  %NullCheck164 = icmp ne i64* %397, null
-  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+  %NullCheck163 = icmp eq i64* %397, null
+  br i1 %NullCheck163, label %ThrowNullRef164, label %398
 
 ; <label>:398                                     ; preds = %394
   %399 = load i64, i64* %397, align 8
   %400 = bitcast i8* %395 to i64*
-  %NullCheck166 = icmp ne i64* %400, null
-  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+  %NullCheck165 = icmp eq i64* %400, null
+  br i1 %NullCheck165, label %ThrowNullRef166, label %401
 
 ; <label>:401                                     ; preds = %398
   store i64 %399, i64* %400, align 8
@@ -1400,14 +1482,14 @@ entry:
   %404 = load i8*, i8** %arg1
   %405 = getelementptr inbounds i8, i8* %404, i64 8
   %406 = bitcast i8* %405 to i64*
-  %NullCheck168 = icmp ne i64* %406, null
-  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+  %NullCheck167 = icmp eq i64* %406, null
+  br i1 %NullCheck167, label %ThrowNullRef168, label %407
 
 ; <label>:407                                     ; preds = %401
   %408 = load i64, i64* %406, align 8
   %409 = bitcast i8* %403 to i64*
-  %NullCheck170 = icmp ne i64* %409, null
-  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+  %NullCheck169 = icmp eq i64* %409, null
+  br i1 %NullCheck169, label %ThrowNullRef170, label %410
 
 ; <label>:410                                     ; preds = %407
   store i64 %408, i64* %409, align 8
@@ -1437,14 +1519,14 @@ entry:
   %425 = load i8*, i8** %arg0
   %426 = load i8*, i8** %arg1
   %427 = bitcast i8* %426 to i64*
-  %NullCheck148 = icmp ne i64* %427, null
-  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+  %NullCheck147 = icmp eq i64* %427, null
+  br i1 %NullCheck147, label %ThrowNullRef148, label %428
 
 ; <label>:428                                     ; preds = %424
   %429 = load i64, i64* %427, align 8
   %430 = bitcast i8* %425 to i64*
-  %NullCheck150 = icmp ne i64* %430, null
-  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+  %NullCheck149 = icmp eq i64* %430, null
+  br i1 %NullCheck149, label %ThrowNullRef150, label %431
 
 ; <label>:431                                     ; preds = %428
   store i64 %429, i64* %430, align 8
@@ -1466,14 +1548,14 @@ entry:
   %441 = load i8*, i8** %arg0
   %442 = load i8*, i8** %arg1
   %443 = bitcast i8* %442 to i32*
-  %NullCheck152 = icmp ne i32* %443, null
-  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+  %NullCheck151 = icmp eq i32* %443, null
+  br i1 %NullCheck151, label %ThrowNullRef152, label %444
 
 ; <label>:444                                     ; preds = %440
   %445 = load i32, i32* %443, align 8
   %446 = bitcast i8* %441 to i32*
-  %NullCheck154 = icmp ne i32* %446, null
-  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+  %NullCheck153 = icmp eq i32* %446, null
+  br i1 %NullCheck153, label %ThrowNullRef154, label %447
 
 ; <label>:447                                     ; preds = %444
   store i32 %445, i32* %446, align 8
@@ -1495,16 +1577,16 @@ entry:
   %457 = load i8*, i8** %arg0
   %458 = load i8*, i8** %arg1
   %459 = bitcast i8* %458 to i16*
-  %NullCheck156 = icmp ne i16* %459, null
-  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+  %NullCheck155 = icmp eq i16* %459, null
+  br i1 %NullCheck155, label %ThrowNullRef156, label %460
 
 ; <label>:460                                     ; preds = %456
   %461 = load i16, i16* %459, align 8
   %462 = sext i16 %461 to i32
   %463 = bitcast i8* %457 to i16*
   %464 = trunc i32 %462 to i16
-  %NullCheck158 = icmp ne i16* %463, null
-  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+  %NullCheck157 = icmp eq i16* %463, null
+  br i1 %NullCheck157, label %ThrowNullRef158, label %465
 
 ; <label>:465                                     ; preds = %460
   store i16 %464, i16* %463, align 8
@@ -1525,15 +1607,15 @@ entry:
 ; <label>:474                                     ; preds = %470
   %475 = load i8*, i8** %arg0
   %476 = load i8*, i8** %arg1
-  %NullCheck160 = icmp ne i8* %476, null
-  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+  %NullCheck159 = icmp eq i8* %476, null
+  br i1 %NullCheck159, label %ThrowNullRef160, label %477
 
 ; <label>:477                                     ; preds = %474
   %478 = load i8, i8* %476, align 8
   %479 = zext i8 %478 to i32
   %480 = trunc i32 %479 to i8
-  %NullCheck162 = icmp ne i8* %475, null
-  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+  %NullCheck161 = icmp eq i8* %475, null
+  br i1 %NullCheck161, label %ThrowNullRef162, label %481
 
 ; <label>:481                                     ; preds = %477
   store i8 %480, i8* %475, align 8
@@ -1553,343 +1635,343 @@ ThrowNullRef:                                     ; preds = %308
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %312
+ThrowNullRef2:                                    ; preds = %312
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %315
+ThrowNullRef4:                                    ; preds = %315
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %321
+ThrowNullRef6:                                    ; preds = %321
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %271
+ThrowNullRef8:                                    ; preds = %271
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %275
+ThrowNullRef10:                                   ; preds = %275
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %278
+ThrowNullRef12:                                   ; preds = %278
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %284
+ThrowNullRef14:                                   ; preds = %284
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %287
+ThrowNullRef16:                                   ; preds = %287
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %293
+ThrowNullRef18:                                   ; preds = %293
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %298
+ThrowNullRef20:                                   ; preds = %298
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %303
+ThrowNullRef22:                                   ; preds = %303
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %243
+ThrowNullRef24:                                   ; preds = %243
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %247
+ThrowNullRef26:                                   ; preds = %247
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %250
+ThrowNullRef28:                                   ; preds = %250
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %256
+ThrowNullRef30:                                   ; preds = %256
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %259
+ThrowNullRef32:                                   ; preds = %259
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %265
+ThrowNullRef34:                                   ; preds = %265
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %217
+ThrowNullRef36:                                   ; preds = %217
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %221
+ThrowNullRef38:                                   ; preds = %221
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %224
+ThrowNullRef40:                                   ; preds = %224
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %230
+ThrowNullRef42:                                   ; preds = %230
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %233
+ThrowNullRef44:                                   ; preds = %233
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %238
+ThrowNullRef46:                                   ; preds = %238
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %200
+ThrowNullRef48:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %204
+ThrowNullRef50:                                   ; preds = %204
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %207
+ThrowNullRef52:                                   ; preds = %207
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %213
+ThrowNullRef54:                                   ; preds = %213
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %172
+ThrowNullRef56:                                   ; preds = %172
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %176
+ThrowNullRef58:                                   ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %179
+ThrowNullRef60:                                   ; preds = %179
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %185
+ThrowNullRef62:                                   ; preds = %185
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %190
+ThrowNullRef64:                                   ; preds = %190
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %195
+ThrowNullRef66:                                   ; preds = %195
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %153
+ThrowNullRef68:                                   ; preds = %153
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %157
+ThrowNullRef70:                                   ; preds = %157
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %160
+ThrowNullRef72:                                   ; preds = %160
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %166
+ThrowNullRef74:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %136
+ThrowNullRef76:                                   ; preds = %136
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %140
+ThrowNullRef78:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %143
+ThrowNullRef80:                                   ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %148
+ThrowNullRef82:                                   ; preds = %148
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %128
+ThrowNullRef84:                                   ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %132
+ThrowNullRef86:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %100
+ThrowNullRef88:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %104
+ThrowNullRef90:                                   ; preds = %104
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %107
+ThrowNullRef92:                                   ; preds = %107
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %113
+ThrowNullRef94:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %118
+ThrowNullRef96:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %123
+ThrowNullRef98:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %81
+ThrowNullRef100:                                  ; preds = %81
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef101:                                  ; preds = %85
+ThrowNullRef102:                                  ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef103:                                  ; preds = %88
+ThrowNullRef104:                                  ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef105:                                  ; preds = %94
+ThrowNullRef106:                                  ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef107:                                  ; preds = %64
+ThrowNullRef108:                                  ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef109:                                  ; preds = %68
+ThrowNullRef110:                                  ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef111:                                  ; preds = %71
+ThrowNullRef112:                                  ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef113:                                  ; preds = %76
+ThrowNullRef114:                                  ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef115:                                  ; preds = %56
+ThrowNullRef116:                                  ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef117:                                  ; preds = %60
+ThrowNullRef118:                                  ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef119:                                  ; preds = %37
+ThrowNullRef120:                                  ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef121:                                  ; preds = %41
+ThrowNullRef122:                                  ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef123:                                  ; preds = %46
+ThrowNullRef124:                                  ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef125:                                  ; preds = %51
+ThrowNullRef126:                                  ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef127:                                  ; preds = %27
+ThrowNullRef128:                                  ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef129:                                  ; preds = %31
+ThrowNullRef130:                                  ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef131:                                  ; preds = %19
+ThrowNullRef132:                                  ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef133:                                  ; preds = %22
+ThrowNullRef134:                                  ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef135:                                  ; preds = %338
+ThrowNullRef136:                                  ; preds = %338
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef137:                                  ; preds = %341
+ThrowNullRef138:                                  ; preds = %341
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef139:                                  ; preds = %356
+ThrowNullRef140:                                  ; preds = %356
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef141:                                  ; preds = %360
+ThrowNullRef142:                                  ; preds = %360
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef143:                                  ; preds = %377
+ThrowNullRef144:                                  ; preds = %377
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef145:                                  ; preds = %381
+ThrowNullRef146:                                  ; preds = %381
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef147:                                  ; preds = %424
+ThrowNullRef148:                                  ; preds = %424
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef149:                                  ; preds = %428
+ThrowNullRef150:                                  ; preds = %428
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef151:                                  ; preds = %440
+ThrowNullRef152:                                  ; preds = %440
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef153:                                  ; preds = %444
+ThrowNullRef154:                                  ; preds = %444
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef155:                                  ; preds = %456
+ThrowNullRef156:                                  ; preds = %456
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef157:                                  ; preds = %460
+ThrowNullRef158:                                  ; preds = %460
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef159:                                  ; preds = %474
+ThrowNullRef160:                                  ; preds = %474
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef161:                                  ; preds = %477
+ThrowNullRef162:                                  ; preds = %477
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef163:                                  ; preds = %394
+ThrowNullRef164:                                  ; preds = %394
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef165:                                  ; preds = %398
+ThrowNullRef166:                                  ; preds = %398
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef167:                                  ; preds = %401
+ThrowNullRef168:                                  ; preds = %401
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef169:                                  ; preds = %407
+ThrowNullRef170:                                  ; preds = %407
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1939,8 +2021,8 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
-  br i1 %NullCheck, label %22, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %ThrowNullRef, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
@@ -1948,8 +2030,8 @@ entry:
   store i32 %24, i32* %loc0
   %25 = load i32, i32* %loc0
   %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %26, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %27
 
 ; <label>:27                                      ; preds = %22
   %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
@@ -1971,7 +2053,7 @@ ThrowNullRef:                                     ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1989,8 +2071,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -2022,15 +2104,15 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2048,16 +2130,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
   %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
   store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %15
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
@@ -2072,8 +2154,8 @@ entry:
   %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
   %29 = ptrtoint i16 addrspace(1)* %28 to i64
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %19
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
@@ -2089,19 +2171,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2114,8 +2196,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
@@ -2128,7 +2210,7 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[loadElem]
+Failed to read AppDomain.PrepareDataForSetup[storeElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
@@ -2202,8 +2284,8 @@ entry:
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
-  br i1 %NullCheck24, label %27, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = load i64, i64 addrspace(1)* %26
@@ -2218,8 +2300,8 @@ entry:
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
-  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
   %41 = load i64, i64 addrspace(1)* %39
@@ -2236,8 +2318,8 @@ entry:
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
-  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
   %54 = load i64, i64 addrspace(1)* %52
@@ -2252,8 +2334,8 @@ entry:
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
   %67 = load i64, i64 addrspace(1)* %65
@@ -2270,8 +2352,8 @@ entry:
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
-  br i1 %NullCheck16, label %79, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
   %80 = load i64, i64 addrspace(1)* %78
@@ -2286,8 +2368,8 @@ entry:
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
-  br i1 %NullCheck18, label %92, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
   %93 = load i64, i64 addrspace(1)* %91
@@ -2304,8 +2386,8 @@ entry:
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
-  br i1 %NullCheck12, label %105, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = load i64, i64 addrspace(1)* %104
@@ -2320,8 +2402,8 @@ entry:
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
-  br i1 %NullCheck14, label %118, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
   %119 = load i64, i64 addrspace(1)* %117
@@ -2337,8 +2419,8 @@ entry:
 
 ; <label>:128                                     ; preds = %20
   %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
-  br i1 %NullCheck4, label %130, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %129, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %130
 
 ; <label>:130                                     ; preds = %128
   %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
@@ -2346,8 +2428,8 @@ entry:
   %133 = load i16, i16 addrspace(1)* %132, align 8
   %134 = zext i16 %133 to i32
   %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
-  br i1 %NullCheck6, label %136, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %135, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %136
 
 ; <label>:136                                     ; preds = %130
   %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
@@ -2360,8 +2442,8 @@ entry:
 
 ; <label>:143                                     ; preds = %136
   %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
-  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %144, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %145
 
 ; <label>:145                                     ; preds = %143
   %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
@@ -2369,8 +2451,8 @@ entry:
   %148 = load i16, i16 addrspace(1)* %147, align 8
   %149 = zext i16 %148 to i32
   %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %150, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %151
 
 ; <label>:151                                     ; preds = %145
   %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
@@ -2388,8 +2470,8 @@ entry:
 
 ; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
-  br i1 %NullCheck, label %163, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %ThrowNullRef, label %163
 
 ; <label>:163                                     ; preds = %161
   %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
@@ -2399,8 +2481,8 @@ entry:
 
 ; <label>:167                                     ; preds = %163
   %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
-  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %168, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %169
 
 ; <label>:169                                     ; preds = %167
   %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
@@ -2432,55 +2514,55 @@ ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %167
+ThrowNullRef2:                                    ; preds = %167
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %128
+ThrowNullRef4:                                    ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %130
+ThrowNullRef6:                                    ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %143
+ThrowNullRef8:                                    ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %145
+ThrowNullRef10:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %102
+ThrowNullRef12:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %105
+ThrowNullRef14:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %76
+ThrowNullRef16:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %79
+ThrowNullRef18:                                   ; preds = %79
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %50
+ThrowNullRef20:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %53
+ThrowNullRef22:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %24
+ThrowNullRef24:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %27
+ThrowNullRef26:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2503,15 +2585,15 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2519,16 +2601,16 @@ entry:
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
   store i32 %8, i32* %loc0
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
   %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
   store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
@@ -2546,16 +2628,16 @@ entry:
 
 ; <label>:23                                      ; preds = %64
   %24 = load i16*, i16** %loc3
-  %NullCheck12 = icmp ne i16* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i16* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
   store i32 %27, i32* %loc5
   %28 = load i16*, i16** %loc4
-  %NullCheck14 = icmp ne i16* %28, null
-  br i1 %NullCheck14, label %29, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %28, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = load i16, i16* %28, align 8
@@ -2620,15 +2702,15 @@ entry:
 
 ; <label>:67                                      ; preds = %64
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
-  br i1 %NullCheck8, label %69, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %68, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %69
 
 ; <label>:69                                      ; preds = %67
   %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
   %71 = load i32, i32 addrspace(1)* %70
   %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
-  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %73
 
 ; <label>:73                                      ; preds = %69
   %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
@@ -2645,31 +2727,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %67
+ThrowNullRef8:                                    ; preds = %67
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %69
+ThrowNullRef10:                                   ; preds = %69
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2710,14 +2792,14 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
   %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
@@ -2730,14 +2812,14 @@ entry:
 
 ; <label>:11                                      ; preds = %4
   %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
   %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
@@ -2749,14 +2831,14 @@ entry:
 
 ; <label>:22                                      ; preds = %16
   %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
   %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
-  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
-  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
@@ -2804,23 +2886,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2836,7 +2918,280 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[loadElem]
+Successfully read RuntimeType.IsAssignableFrom
+
+define i8 @RuntimeType.IsAssignableFrom(%System.RuntimeType addrspace(1)* %param0, %System.Type addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.RuntimeType addrspace(1)*
+  %arg1 = alloca %System.Type addrspace(1)*
+  %loc0 = alloca %System.RuntimeType addrspace(1)*
+  %loc1 = alloca %"System.Type[]" addrspace(1)*
+  %loc2 = alloca i32
+  store %System.RuntimeType addrspace(1)* %param0, %System.RuntimeType addrspace(1)** %this
+  store %System.Type addrspace(1)* %param1, %System.Type addrspace(1)** %arg1
+  %0 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %1 = icmp ne %System.Type addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i8 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %5 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %6 = bitcast %System.Type addrspace(1)* %4 to %System.Object addrspace(1)*
+  %7 = bitcast %System.RuntimeType addrspace(1)* %5 to %System.Object addrspace(1)*
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %6, %System.Object addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %3
+  ret i8 1
+
+; <label>:12                                      ; preds = %3
+  %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 152
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 32
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
+  %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
+  %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
+  store %System.RuntimeType addrspace(1)* %25, %System.RuntimeType addrspace(1)** %loc0
+  %26 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %27 = icmp eq %System.RuntimeType addrspace(1)* %26, null
+  br i1 %27, label %34, label %28
+
+; <label>:28                                      ; preds = %15
+  %29 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %30 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)*)*)(%System.RuntimeType addrspace(1)* %29, %System.RuntimeType addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+; <label>:34                                      ; preds = %15
+  %35 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %36 = call %System.Reflection.Emit.TypeBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Reflection.Emit.TypeBuilder addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %35)
+  %37 = icmp eq %System.Reflection.Emit.TypeBuilder addrspace(1)* %36, null
+  br i1 %37, label %139, label %38
+
+; <label>:38                                      ; preds = %34
+  %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %42
+
+; <label>:42                                      ; preds = %38
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 152
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 40
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
+  %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
+  %53 = zext i8 %52 to i32
+  %54 = icmp eq i32 %53, 0
+  br i1 %54, label %56, label %55
+
+; <label>:55                                      ; preds = %42
+  ret i8 1
+
+; <label>:56                                      ; preds = %42
+  %57 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %58 = bitcast %System.RuntimeType addrspace(1)* %57 to %System.Type addrspace(1)*
+  %59 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %58)
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %64 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.Type addrspace(1)* %63, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = bitcast %System.RuntimeType addrspace(1)* %64 to %System.Type addrspace(1)*
+  %67 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %63, %System.Type addrspace(1)* %66)
+  %68 = zext i8 %67 to i32
+  %69 = trunc i32 %68 to i8
+  ret i8 %69
+
+; <label>:70                                      ; preds = %56
+  %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
+  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %73
+
+; <label>:73                                      ; preds = %70
+  %74 = load i64, i64 addrspace(1)* %72
+  %75 = add i64 %74, 128
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = add i64 %77, 0
+  %79 = inttoptr i64 %78 to i64*
+  %80 = load i64, i64* %79
+  %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
+  %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
+  %83 = call i8 %82(%System.Type addrspace(1)* %81)
+  %84 = zext i8 %83 to i32
+  %85 = icmp eq i32 %84, 0
+  br i1 %85, label %139, label %86
+
+; <label>:86                                      ; preds = %73
+  %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
+  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %89
+
+; <label>:89                                      ; preds = %86
+  %90 = load i64, i64 addrspace(1)* %88
+  %91 = add i64 %90, 128
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = add i64 %93, 24
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
+  %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
+  %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
+  store %"System.Type[]" addrspace(1)* %99, %"System.Type[]" addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %129
+
+; <label>:100                                     ; preds = %132
+  %101 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %102 = load i32, i32* %loc2
+  %NullCheck11 = icmp eq %"System.Type[]" addrspace(1)* %101, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %103
+
+; <label>:103                                     ; preds = %100
+  %104 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 1
+  %105 = load i32, i32 addrspace(1)* %104
+  %106 = zext i32 %105 to i64
+  %107 = zext i32 %102 to i64
+  %BoundsCheck = icmp uge i64 %107, %106
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %108
+
+; <label>:108                                     ; preds = %103
+  %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
+  %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
+  %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
+  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %113
+
+; <label>:113                                     ; preds = %108
+  %114 = load i64, i64 addrspace(1)* %112
+  %115 = add i64 %114, 152
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = add i64 %117, 56
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
+  %123 = zext i8 %122 to i32
+  %124 = icmp ne i32 %123, 0
+  br i1 %124, label %126, label %125
+
+; <label>:125                                     ; preds = %113
+  ret i8 0
+
+; <label>:126                                     ; preds = %113
+  %127 = load i32, i32* %loc2
+  %128 = add i32 %127, 1
+  store i32 %128, i32* %loc2
+  br label %129
+
+; <label>:129                                     ; preds = %89, %126
+  %130 = load i32, i32* %loc2
+  %131 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %NullCheck9 = icmp eq %"System.Type[]" addrspace(1)* %131, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %132
+
+; <label>:132                                     ; preds = %129
+  %133 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %131, i32 0, i32 1
+  %134 = load i32, i32 addrspace(1)* %133
+  %135 = zext i32 %134 to i64
+  %136 = trunc i64 %135 to i32
+  %137 = icmp slt i32 %130, %136
+  br i1 %137, label %100, label %138
+
+; <label>:138                                     ; preds = %132
+  ret i8 1
+
+; <label>:139                                     ; preds = %34, %73
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %129
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %103
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -2893,7 +3248,7 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElem]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -2904,8 +3259,8 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -2997,8 +3352,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
@@ -3059,8 +3414,8 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -3087,8 +3442,8 @@ entry:
 
 ; <label>:17                                      ; preds = %5, %11
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
@@ -3097,8 +3452,8 @@ entry:
 
 ; <label>:22                                      ; preds = %1, %11
   %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
@@ -3109,11 +3464,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %17
+ThrowNullRef2:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %22
+ThrowNullRef4:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3167,15 +3522,15 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
   %15 = load i32, i32 addrspace(1)* %14
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
@@ -3198,7 +3553,7 @@ ThrowNullRef:                                     ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef2:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3232,8 +3587,8 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
@@ -3312,8 +3667,8 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -3327,8 +3682,8 @@ entry:
 ; <label>:5                                       ; preds = %43
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %7 = load i32, i32* %loc1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck6, label %8, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
@@ -3366,8 +3721,8 @@ entry:
 ; <label>:32                                      ; preds = %21, %25
   %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
   %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
-  br i1 %NullCheck8, label %35, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = trunc i32 %34 to i16
@@ -3380,8 +3735,8 @@ entry:
 ; <label>:40                                      ; preds = %1, %35
   %41 = load i32, i32* %loc1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
-  br i1 %NullCheck2, label %43, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %42, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
@@ -3392,8 +3747,8 @@ entry:
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
   %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
-  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
   %51 = load i64, i64 addrspace(1)* %49
@@ -3412,19 +3767,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %40
+ThrowNullRef2:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %47
+ThrowNullRef4:                                    ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %5
+ThrowNullRef6:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %32
+ThrowNullRef8:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3467,8 +3822,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
@@ -3492,11 +3847,391 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(i16* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store i16* %param0, i16** %arg0
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load i32, i32* %arg3
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %42, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %37, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg2
+  %13 = load i32, i32* %arg3
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %37, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %24 = load i32, i32* %arg2
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load i16*, i16** %arg0
+  %35 = load i32, i32* %arg3
+  %36 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %36, i16* %34, i32 %35)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:37                                      ; preds = %5, %16
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %39)
+  %41 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41, %System.String addrspace(1)* %38, %System.String addrspace(1)* %40)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41) #0
+  unreachable
+
+; <label>:42                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
-Failed to read StringBuilder.ToString[loadElemA]
+Successfully read StringBuilder.ToString
+
+define %System.String addrspace(1)* @StringBuilder.ToString(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i16*
+  %loc3 = alloca %"System.Char[]" addrspace(1)*
+  %loc4 = alloca i32
+  %loc5 = alloca i32
+  %loc6 = alloca i16 addrspace(1)*
+  %loc7 = alloca %System.String addrspace(1)*
+  %loc8 = alloca %"System.Char[]" addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %0)
+  %2 = icmp ne i32 %1, 0
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %4
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %6)
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %7)
+  store %System.String addrspace(1)* %8, %System.String addrspace(1)** %loc0
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.Text.StringBuilder addrspace(1)* %9, %System.Text.StringBuilder addrspace(1)** %loc1
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  store %System.String addrspace(1)* %10, %System.String addrspace(1)** %loc7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc7
+  %12 = ptrtoint %System.String addrspace(1)* %11 to i64
+  %13 = icmp eq i64 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %5
+  %15 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %16 = sext i32 %15 to i64
+  %17 = add i64 %12, %16
+  br label %18
+
+; <label>:18                                      ; preds = %5, %14
+  %19 = phi i64 [ %12, %5 ], [ %17, %14 ]
+  %20 = inttoptr i64 %19 to i16*
+  store i16* %20, i16** %loc2
+  br label %21
+
+; <label>:21                                      ; preds = %98, %18
+  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %22, null
+  br i1 %NullCheck, label %ThrowNullRef, label %23
+
+; <label>:23                                      ; preds = %21
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 3
+  %25 = load i32, i32 addrspace(1)* %24, align 8
+  %26 = icmp sle i32 %25, 0
+  br i1 %26, label %96, label %27
+
+; <label>:27                                      ; preds = %23
+  %28 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %28, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %29
+
+; <label>:29                                      ; preds = %27
+  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %28, i32 0, i32 1
+  %31 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %30, align 8
+  store %"System.Char[]" addrspace(1)* %31, %"System.Char[]" addrspace(1)** %loc3
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %33
+
+; <label>:33                                      ; preds = %29
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  store i32 %35, i32* %loc4
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  %39 = load i32, i32 addrspace(1)* %38, align 8
+  store i32 %39, i32* %loc5
+  %40 = load i32, i32* %loc5
+  %41 = load i32, i32* %loc4
+  %42 = add i32 %40, %41
+  %43 = zext i32 %42 to i64
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %45
+
+; <label>:45                                      ; preds = %37
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = sext i32 %47 to i64
+  %49 = icmp sgt i64 %43, %48
+  br i1 %49, label %91, label %50
+
+; <label>:50                                      ; preds = %45
+  %51 = load i32, i32* %loc5
+  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %52, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %53
+
+; <label>:53                                      ; preds = %50
+  %54 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %52, i32 0, i32 1
+  %55 = load i32, i32 addrspace(1)* %54
+  %56 = zext i32 %55 to i64
+  %57 = trunc i64 %56 to i32
+  %58 = icmp ugt i32 %51, %57
+  br i1 %58, label %91, label %59
+
+; <label>:59                                      ; preds = %53
+  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  store %"System.Char[]" addrspace(1)* %60, %"System.Char[]" addrspace(1)** %loc8
+  %61 = icmp eq %"System.Char[]" addrspace(1)* %60, null
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %63, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %64
+
+; <label>:64                                      ; preds = %62
+  %65 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %63, i32 0, i32 1
+  %66 = load i32, i32 addrspace(1)* %65
+  %67 = zext i32 %66 to i64
+  %68 = trunc i64 %67 to i32
+  %69 = icmp ne i32 %68, 0
+  br i1 %69, label %71, label %70
+
+; <label>:70                                      ; preds = %59, %64
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:71                                      ; preds = %64
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %73
+
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %BoundsCheck = icmp uge i64 0, %76
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %77
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %78, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:79                                      ; preds = %70, %77
+  %80 = load i16*, i16** %loc2
+  %81 = load i32, i32* %loc4
+  %82 = sext i32 %81 to i64
+  %83 = mul i64 %82, 2
+  %84 = bitcast i16* %80 to i8*
+  %85 = getelementptr inbounds i8, i8* %84, i64 %83
+  %86 = load i16 addrspace(1)*, i16 addrspace(1)** %loc6
+  %87 = ptrtoint i16 addrspace(1)* %86 to i64
+  %88 = load i32, i32* %loc5
+  %89 = bitcast i8* %85 to i16*
+  %90 = inttoptr i64 %87 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %89, i16* %90, i32 %88)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %96
+
+; <label>:91                                      ; preds = %45, %53
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %94 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %93)
+  %95 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95, %System.String addrspace(1)* %92, %System.String addrspace(1)* %94)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95) #0
+  unreachable
+
+; <label>:96                                      ; preds = %23, %79
+  %97 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %97, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %98
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %97, i32 0, i32 2
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  store %System.Text.StringBuilder addrspace(1)* %100, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %102 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %102, label %21, label %103
+
+; <label>:103                                     ; preds = %98
+  store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc7
+  %104 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  ret %System.String addrspace(1)* %104
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method StringBuilder::get_Length using LLILCJit
+Successfully read StringBuilder.get_Length
+
+define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
+Successfully read RuntimeHelpers.get_OffsetToStringData
+
+define i32 @RuntimeHelpers.get_OffsetToStringData() {
+entry:
+  ret i32 12
+}
+
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
 Successfully read CultureData.CreateCultureData
 
@@ -3514,23 +4249,23 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
   store i8 %4, i8 addrspace(1)* %6
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
@@ -3549,11 +4284,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3566,50 +4301,50 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
   store i32 -1, i32 addrspace(1)* %2
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
   store i32 -1, i32 addrspace(1)* %8
   %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
   store i32 -1, i32 addrspace(1)* %14
   %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
   store i32 -1, i32 addrspace(1)* %17
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
@@ -3623,27 +4358,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3675,7 +4410,136 @@ Failed to read Dictionary`2.Insert[non-const derefAddress]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
 Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
-Failed to read HashHelpers.GetPrime[loadElem]
+Successfully read HashHelpers.GetPrime
+
+define i32 @HashHelpers.GetPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %6, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5, %System.String addrspace(1)* %4)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5) #0
+  unreachable
+
+; <label>:6                                       ; preds = %entry
+  store i32 0, i32* %loc0
+  br label %29
+
+; <label>:7                                       ; preds = %35
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 1296
+  %10 = addrspacecast i8 addrspace(1)* %9 to %"System.Int32[]" addrspace(1)**
+  %11 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %10
+  %12 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Int32[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = zext i32 %15 to i64
+  %17 = zext i32 %12 to i64
+  %BoundsCheck = icmp uge i64 %17, %16
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 3, i32 %12
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  store i32 %20, i32* %loc1
+  %21 = load i32, i32* %loc1
+  %22 = load i32, i32* %arg0
+  %23 = icmp slt i32 %21, %22
+  br i1 %23, label %26, label %24
+
+; <label>:24                                      ; preds = %18
+  %25 = load i32, i32* %loc1
+  ret i32 %25
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %loc0
+  %28 = add i32 %27, 1
+  store i32 %28, i32* %loc0
+  br label %29
+
+; <label>:29                                      ; preds = %6, %26
+  %30 = load i32, i32* %loc0
+  %31 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %32 = getelementptr inbounds i8, i8 addrspace(1)* %31, i64 1296
+  %33 = addrspacecast i8 addrspace(1)* %32 to %"System.Int32[]" addrspace(1)**
+  %34 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %33
+  %NullCheck = icmp eq %"System.Int32[]" addrspace(1)* %34, null
+  br i1 %NullCheck, label %ThrowNullRef, label %35
+
+; <label>:35                                      ; preds = %29
+  %36 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %34, i32 0, i32 1
+  %37 = load i32, i32 addrspace(1)* %36
+  %38 = zext i32 %37 to i64
+  %39 = trunc i64 %38 to i32
+  %40 = icmp slt i32 %30, %39
+  br i1 %40, label %7, label %41
+
+; <label>:41                                      ; preds = %35
+  %42 = load i32, i32* %arg0
+  %43 = or i32 %42, 1
+  store i32 %43, i32* %loc2
+  br label %59
+
+; <label>:44                                      ; preds = %59
+  %45 = load i32, i32* %loc2
+  %46 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %45)
+  %47 = zext i8 %46 to i32
+  %48 = icmp eq i32 %47, 0
+  br i1 %48, label %56, label %49
+
+; <label>:49                                      ; preds = %44
+  %50 = load i32, i32* %loc2
+  %51 = sub i32 %50, 1
+  %52 = srem i32 %51, 101
+  %53 = icmp eq i32 %52, 0
+  br i1 %53, label %56, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = load i32, i32* %loc2
+  ret i32 %55
+
+; <label>:56                                      ; preds = %44, %49
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %57, 2
+  store i32 %58, i32* %loc2
+  br label %59
+
+; <label>:59                                      ; preds = %41, %56
+  %60 = load i32, i32* %loc2
+  %61 = icmp slt i32 %60, 2147483647
+  br i1 %61, label %44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load i32, i32* %arg0
+  ret i32 %63
+
+ThrowNullRef:                                     ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
 Successfully read GenericEqualityComparer`1.GetHashCode
 
@@ -3694,14 +4558,14 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
   %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load i64, i64 addrspace(1)* %7
@@ -3720,7 +4584,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3750,8 +4614,8 @@ entry:
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
@@ -3796,8 +4660,8 @@ entry:
   %35 = bitcast i16* %34 to i8*
   %36 = getelementptr inbounds i8, i8* %35, i64 2
   %37 = bitcast i8* %36 to i16*
-  %NullCheck4 = icmp ne i16* %37, null
-  br i1 %NullCheck4, label %38, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %37, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %38
 
 ; <label>:38                                      ; preds = %27
   %39 = load i16, i16* %37, align 8
@@ -3824,8 +4688,8 @@ entry:
 
 ; <label>:54                                      ; preds = %22, %43
   %55 = load i16*, i16** %loc4
-  %NullCheck2 = icmp ne i16* %55, null
-  br i1 %NullCheck2, label %56, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i16* %55, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %56
 
 ; <label>:56                                      ; preds = %54
   %57 = load i16, i16* %55, align 8
@@ -3850,11 +4714,11 @@ ThrowNullRef:                                     ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %54
+ThrowNullRef2:                                    ; preds = %54
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %27
+ThrowNullRef4:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3871,8 +4735,8 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -3907,8 +4771,8 @@ entry:
 
 ; <label>:26                                      ; preds = %19
   %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
-  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %28
 
 ; <label>:28                                      ; preds = %26
   %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
@@ -3920,7 +4784,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3972,8 +4836,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
@@ -3984,26 +4848,26 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
-  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
@@ -4014,8 +4878,8 @@ entry:
 ; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
@@ -4024,8 +4888,8 @@ entry:
 
 ; <label>:25                                      ; preds = %1, %16, %23
   %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
-  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
@@ -4036,27 +4900,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %20
+ThrowNullRef10:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4069,8 +4933,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -4081,8 +4945,8 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
@@ -4091,8 +4955,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1, %8
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
@@ -4103,11 +4967,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4128,24 +4992,24 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   store i32 %3, i32* %loc0
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
   %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
   store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck4, label %9, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
@@ -4164,15 +5028,15 @@ entry:
 ; <label>:18                                      ; preds = %70
   %19 = load i16*, i16** %loc3
   %20 = bitcast i16* %19 to i64*
-  %NullCheck10 = icmp ne i64* %20, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %20, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = load i64, i64* %20, align 8
   %23 = load i16*, i16** %loc4
   %24 = bitcast i16* %23 to i64*
-  %NullCheck12 = icmp ne i64* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = load i64, i64* %24, align 8
@@ -4188,8 +5052,8 @@ entry:
   %31 = bitcast i16* %30 to i8*
   %32 = getelementptr inbounds i8, i8* %31, i64 8
   %33 = bitcast i8* %32 to i64*
-  %NullCheck14 = icmp ne i64* %33, null
-  br i1 %NullCheck14, label %34, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = load i64, i64* %33, align 8
@@ -4197,8 +5061,8 @@ entry:
   %37 = bitcast i16* %36 to i8*
   %38 = getelementptr inbounds i8, i8* %37, i64 8
   %39 = bitcast i8* %38 to i64*
-  %NullCheck16 = icmp ne i64* %39, null
-  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %40
 
 ; <label>:40                                      ; preds = %34
   %41 = load i64, i64* %39, align 8
@@ -4214,8 +5078,8 @@ entry:
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %NullCheck18 = icmp ne i64* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = load i64, i64* %48, align 8
@@ -4223,8 +5087,8 @@ entry:
   %52 = bitcast i16* %51 to i8*
   %53 = getelementptr inbounds i8, i8* %52, i64 16
   %54 = bitcast i8* %53 to i64*
-  %NullCheck20 = icmp ne i64* %54, null
-  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64* %54, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %55
 
 ; <label>:55                                      ; preds = %49
   %56 = load i64, i64* %54, align 8
@@ -4262,15 +5126,15 @@ entry:
 ; <label>:74                                      ; preds = %95
   %75 = load i16*, i16** %loc3
   %76 = bitcast i16* %75 to i32*
-  %NullCheck6 = icmp ne i32* %76, null
-  br i1 %NullCheck6, label %77, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32* %76, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %77
 
 ; <label>:77                                      ; preds = %74
   %78 = load i32, i32* %76, align 8
   %79 = load i16*, i16** %loc4
   %80 = bitcast i16* %79 to i32*
-  %NullCheck8 = icmp ne i32* %80, null
-  br i1 %NullCheck8, label %81, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i32* %80, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %81
 
 ; <label>:81                                      ; preds = %77
   %82 = load i32, i32* %80, align 8
@@ -4318,43 +5182,43 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %74
+ThrowNullRef6:                                    ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %77
+ThrowNullRef8:                                    ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %29
+ThrowNullRef14:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %34
+ThrowNullRef16:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4376,8 +5240,8 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load i64, i64 addrspace(1)* %4
@@ -4389,8 +5253,8 @@ entry:
   %12 = load i64, i64* %11
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %5
   %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
@@ -4399,8 +5263,8 @@ entry:
   %18 = load i8, i8* %arg2
   %19 = zext i8 %18 to i32
   %20 = trunc i32 %19 to i8
-  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %15
   %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
@@ -4411,11 +5275,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4442,8 +5306,8 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
@@ -4466,16 +5330,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
   %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = load i64, i64 addrspace(1)* %19
@@ -4500,8 +5364,8 @@ entry:
 ; <label>:35                                      ; preds = %30
   %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
@@ -4514,8 +5378,8 @@ entry:
 
 ; <label>:42                                      ; preds = %1, %38
   %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
-  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
@@ -4526,19 +5390,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %35
+ThrowNullRef2:                                    ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %42
+ThrowNullRef8:                                    ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4551,14 +5415,14 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
@@ -4570,7 +5434,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4583,8 +5447,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
@@ -4613,51 +5477,51 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
   %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
   %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
   %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
   %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
-  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
   store i64 %21, i64 addrspace(1)* %23
   %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %25 = load i64, i64* %loc0
-  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
@@ -4668,27 +5532,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %22
+ThrowNullRef12:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4701,8 +5565,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
@@ -4713,19 +5577,19 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
@@ -4734,8 +5598,8 @@ entry:
 
 ; <label>:15                                      ; preds = %1, %13
   %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
@@ -4746,19 +5610,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %15
+ThrowNullRef8:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4771,8 +5635,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -4831,8 +5695,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
@@ -4882,8 +5746,8 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
-  br i1 %NullCheck, label %17, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %ThrowNullRef, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
@@ -4894,15 +5758,15 @@ entry:
 
 ; <label>:22                                      ; preds = %17
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
-  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
   %26 = load i32, i32 addrspace(1)* %25
   %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
-  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %27, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
@@ -4925,8 +5789,8 @@ entry:
 ; <label>:40                                      ; preds = %17
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
-  br i1 %NullCheck6, label %43, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %41, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
@@ -4938,34 +5802,17 @@ ThrowNullRef:                                     ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %24
+ThrowNullRef4:                                    ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %40
+ThrowNullRef6:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
-}
-
-INFO:  jitting method Object::ReferenceEquals using LLILCJit
-Successfully read Object.ReferenceEquals
-
-define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
-entry:
-  %arg0 = alloca %System.Object addrspace(1)*
-  %arg1 = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
-  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
-  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = icmp eq %System.Object addrspace(1)* %0, %1
-  %3 = sext i1 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
 }
 
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
@@ -4978,21 +5825,21 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
   %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
-  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
@@ -5007,28 +5854,28 @@ entry:
 ; <label>:13                                      ; preds = %8, %12
   %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
   %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
   %21 = load i32, i32 addrspace(1)* %20, align 8
   %22 = add i32 %21, 1
-  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
   store i32 %22, i32 addrspace(1)* %24
   %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
@@ -5039,27 +5886,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5077,7 +5924,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::Setup using LLILCJit
-Failed to read AppDomain.Setup[loadElem]
+Failed to read AppDomain.Setup[unbox]
 INFO:  jitting method Thread::GetDomain using LLILCJit
 Successfully read Thread.GetDomain
 
@@ -5108,8 +5955,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
@@ -5122,14 +5969,14 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
   %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
@@ -5141,11 +5988,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5173,8 +6020,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -5189,7 +6036,328 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
 Failed to read KeyCollection.System.Collections.Generic.IEnumerable<TKey>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Successfully read Enumerator.MoveNext
+
+define i8 @Enumerator.MoveNext(%"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.RuntimeTypeHandle* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*
+  %"$TypeArg" = alloca %System.RuntimeTypeHandle*
+  store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
+  %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 8
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %76, label %12
+
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
+  br label %76
+
+; <label>:13                                      ; preds = %85
+  %14 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck19 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %15
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, i32 0, i32 0
+  %17 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %16, align 8
+  %NullCheck21 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, i32 0, i32 2
+  %20 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %19, align 8
+  %21 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck23 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %22
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, i32 0, i32 2
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %NullCheck25 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 3, i32 %24
+  %NullCheck27 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %32
+
+; <label>:32                                      ; preds = %30
+  %33 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, i32 0, i32 2
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = icmp slt i32 %34, 0
+  br i1 %35, label %68, label %36
+
+; <label>:36                                      ; preds = %32
+  %37 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %38 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck29 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %39
+
+; <label>:39                                      ; preds = %36
+  %40 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, i32 0, i32 0
+  %41 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %40, align 8
+  %NullCheck31 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, i32 0, i32 2
+  %44 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %43, align 8
+  %45 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck33 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, i32 0, i32 2
+  %48 = load i32, i32 addrspace(1)* %47, align 8
+  %NullCheck35 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %49
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = zext i32 %51 to i64
+  %53 = zext i32 %48 to i64
+  %BoundsCheck37 = icmp uge i64 %53, %52
+  br i1 %BoundsCheck37, label %ThrowIndexOutOfRange38, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 3, i32 %48
+  %NullCheck39 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %56
+
+; <label>:56                                      ; preds = %54
+  %57 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, i32 0, i32 0
+  %58 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck41 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %59
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %60, %System.__Canon addrspace(1)* %58)
+  %61 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck43 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  %64 = load i32, i32 addrspace(1)* %63, align 8
+  %65 = add i32 %64, 1
+  %NullCheck45 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  store i32 %65, i32 addrspace(1)* %67
+  ret i8 1
+
+; <label>:68                                      ; preds = %32
+  %69 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck47 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %73 = add i32 %72, 1
+  %NullCheck49 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %74
+
+; <label>:74                                      ; preds = %70
+  %75 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  store i32 %73, i32 addrspace(1)* %75
+  br label %76
+
+; <label>:76                                      ; preds = %8, %12, %74
+  %77 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %78
+
+; <label>:78                                      ; preds = %76
+  %79 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, i32 0, i32 2
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck7 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %82
+
+; <label>:82                                      ; preds = %78
+  %83 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, i32 0, i32 0
+  %84 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %83, align 8
+  %NullCheck9 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %85
+
+; <label>:85                                      ; preds = %82
+  %86 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, i32 0, i32 7
+  %87 = load i32, i32 addrspace(1)* %86, align 8
+  %88 = icmp ult i32 %80, %87
+  br i1 %88, label %13, label %89
+
+; <label>:89                                      ; preds = %85
+  %90 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %91 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck11 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %92
+
+; <label>:92                                      ; preds = %89
+  %93 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, i32 0, i32 0
+  %94 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck13 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %95
+
+; <label>:95                                      ; preds = %92
+  %96 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, i32 0, i32 7
+  %97 = load i32, i32 addrspace(1)* %96, align 8
+  %98 = add i32 %97, 1
+  %NullCheck15 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %99
+
+; <label>:99                                      ; preds = %95
+  %100 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, i32 0, i32 2
+  store i32 %98, i32 addrspace(1)* %100
+  %101 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck17 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %102
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %103, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %92
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef22:                                   ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef24:                                   ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef26:                                   ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef28:                                   ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef30:                                   ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef32:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef34:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef36:                                   ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange38:                           ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef40:                                   ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef42:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef44:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef46:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef48:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef50:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -5200,8 +6368,8 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -5232,9 +6400,9 @@ Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
 Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
-Failed to read String.MakeSeparatorList[loadElemA]
+Failed to read String.MakeSeparatorList[storeElem]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
-Failed to read String.InternalSplitKeepEmptyEntries[loadElem]
+Failed to read String.InternalSplitKeepEmptyEntries[storeElem]
 INFO:  jitting method Path::IsRelative using LLILCJit
 Successfully read Path.IsRelative
 
@@ -5243,8 +6411,8 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -5254,8 +6422,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
@@ -5271,8 +6439,8 @@ entry:
 
 ; <label>:17                                      ; preds = %7
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
@@ -5288,8 +6456,8 @@ entry:
 
 ; <label>:29                                      ; preds = %19
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %31
 
 ; <label>:31                                      ; preds = %29
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
@@ -5300,8 +6468,8 @@ entry:
 
 ; <label>:36                                      ; preds = %31
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
-  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %37, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
@@ -5312,8 +6480,8 @@ entry:
 
 ; <label>:43                                      ; preds = %31, %38
   %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
-  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %45
 
 ; <label>:45                                      ; preds = %43
   %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
@@ -5324,8 +6492,8 @@ entry:
 
 ; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %50
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
@@ -5336,8 +6504,8 @@ entry:
 
 ; <label>:57                                      ; preds = %1, %7, %19, %45, %52
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
-  br i1 %NullCheck14, label %59, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %59
 
 ; <label>:59                                      ; preds = %57
   %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
@@ -5347,8 +6515,8 @@ entry:
 
 ; <label>:63                                      ; preds = %59
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
@@ -5359,8 +6527,8 @@ entry:
 
 ; <label>:70                                      ; preds = %65
   %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
-  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.String addrspace(1)* %71, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %72
 
 ; <label>:72                                      ; preds = %70
   %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
@@ -5379,39 +6547,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %17
+ThrowNullRef4:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %29
+ThrowNullRef6:                                    ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %36
+ThrowNullRef8:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %43
+ThrowNullRef10:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %50
+ThrowNullRef12:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %57
+ThrowNullRef14:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %63
+ThrowNullRef16:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %70
+ThrowNullRef18:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5419,7 +6587,293 @@ ThrowNullRef17:                                   ; preds = %70
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
-Failed to read String.TrimHelper[loadElem]
+Successfully read String.TrimHelper
+
+define %System.String addrspace(1)* @String.TrimHelper(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i16
+  %loc4 = alloca i32
+  %loc5 = alloca i16
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = sub i32 %3, 1
+  store i32 %4, i32* %loc0
+  store i32 0, i32* %loc1
+  %5 = load i32, i32* %arg2
+  %6 = icmp eq i32 %5, 1
+  br i1 %6, label %62, label %7
+
+; <label>:7                                       ; preds = %1
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:8                                       ; preds = %58
+  store i32 0, i32* %loc2
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load i32, i32* %loc1
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2, i32 %10
+  %13 = load i16, i16 addrspace(1)* %12
+  %14 = zext i16 %13 to i32
+  %15 = trunc i32 %14 to i16
+  store i16 %15, i16* %loc3
+  store i32 0, i32* %loc2
+  br label %34
+
+; <label>:16                                      ; preds = %37
+  %17 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %18 = load i32, i32* %loc2
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %17, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %19
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = zext i32 %18 to i64
+  %BoundsCheck = icmp uge i64 %23, %22
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %24
+
+; <label>:24                                      ; preds = %19
+  %25 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 3, i32 %18
+  %26 = load i16, i16 addrspace(1)* %25, align 8
+  %27 = zext i16 %26 to i32
+  %28 = load i16, i16* %loc3
+  %29 = zext i16 %28 to i32
+  %30 = icmp eq i32 %27, %29
+  br i1 %30, label %43, label %31
+
+; <label>:31                                      ; preds = %24
+  %32 = load i32, i32* %loc2
+  %33 = add i32 %32, 1
+  store i32 %33, i32* %loc2
+  br label %34
+
+; <label>:34                                      ; preds = %11, %31
+  %35 = load i32, i32* %loc2
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = icmp slt i32 %35, %41
+  br i1 %42, label %16, label %43
+
+; <label>:43                                      ; preds = %24, %37
+  %44 = load i32, i32* %loc2
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %45, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp eq i32 %44, %50
+  br i1 %51, label %62, label %52
+
+; <label>:52                                      ; preds = %46
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %7, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %57, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %58
+
+; <label>:58                                      ; preds = %55
+  %59 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %60 = load i32, i32 addrspace(1)* %59
+  %61 = icmp slt i32 %56, %60
+  br i1 %61, label %8, label %62
+
+; <label>:62                                      ; preds = %1, %46, %58
+  %63 = load i32, i32* %arg2
+  %64 = icmp eq i32 %63, 0
+  br i1 %64, label %122, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %66, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %67
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %66, i32 0, i32 1
+  %69 = load i32, i32 addrspace(1)* %68
+  %70 = sub i32 %69, 1
+  store i32 %70, i32* %loc0
+  br label %118
+
+; <label>:71                                      ; preds = %118
+  store i32 0, i32* %loc4
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %73 = load i32, i32* %loc0
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %74
+
+; <label>:74                                      ; preds = %71
+  %75 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 2, i32 %73
+  %76 = load i16, i16 addrspace(1)* %75
+  %77 = zext i16 %76 to i32
+  %78 = trunc i32 %77 to i16
+  store i16 %78, i16* %loc5
+  store i32 0, i32* %loc4
+  br label %97
+
+; <label>:79                                      ; preds = %100
+  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %81 = load i32, i32* %loc4
+  %NullCheck19 = icmp eq %"System.Char[]" addrspace(1)* %80, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
+
+; <label>:82                                      ; preds = %79
+  %83 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 1
+  %84 = load i32, i32 addrspace(1)* %83
+  %85 = zext i32 %84 to i64
+  %86 = zext i32 %81 to i64
+  %BoundsCheck21 = icmp uge i64 %86, %85
+  br i1 %BoundsCheck21, label %ThrowIndexOutOfRange22, label %87
+
+; <label>:87                                      ; preds = %82
+  %88 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 3, i32 %81
+  %89 = load i16, i16 addrspace(1)* %88, align 8
+  %90 = zext i16 %89 to i32
+  %91 = load i16, i16* %loc5
+  %92 = zext i16 %91 to i32
+  %93 = icmp eq i32 %90, %92
+  br i1 %93, label %106, label %94
+
+; <label>:94                                      ; preds = %87
+  %95 = load i32, i32* %loc4
+  %96 = add i32 %95, 1
+  store i32 %96, i32* %loc4
+  br label %97
+
+; <label>:97                                      ; preds = %74, %94
+  %98 = load i32, i32* %loc4
+  %99 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck15 = icmp eq %"System.Char[]" addrspace(1)* %99, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %100
+
+; <label>:100                                     ; preds = %97
+  %101 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %99, i32 0, i32 1
+  %102 = load i32, i32 addrspace(1)* %101
+  %103 = zext i32 %102 to i64
+  %104 = trunc i64 %103 to i32
+  %105 = icmp slt i32 %98, %104
+  br i1 %105, label %79, label %106
+
+; <label>:106                                     ; preds = %87, %100
+  %107 = load i32, i32* %loc4
+  %108 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck17 = icmp eq %"System.Char[]" addrspace(1)* %108, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %109
+
+; <label>:109                                     ; preds = %106
+  %110 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %108, i32 0, i32 1
+  %111 = load i32, i32 addrspace(1)* %110
+  %112 = zext i32 %111 to i64
+  %113 = trunc i64 %112 to i32
+  %114 = icmp eq i32 %107, %113
+  br i1 %114, label %122, label %115
+
+; <label>:115                                     ; preds = %109
+  %116 = load i32, i32* %loc0
+  %117 = sub i32 %116, 1
+  store i32 %117, i32* %loc0
+  br label %118
+
+; <label>:118                                     ; preds = %67, %115
+  %119 = load i32, i32* %loc0
+  %120 = load i32, i32* %loc1
+  %121 = icmp sge i32 %119, %120
+  br i1 %121, label %71, label %122
+
+; <label>:122                                     ; preds = %62, %109, %118
+  %123 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %124 = load i32, i32* %loc1
+  %125 = load i32, i32* %loc0
+  %126 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %123, i32 %124, i32 %125)
+  ret %System.String addrspace(1)* %126
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %97
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange22:                           ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
 Successfully read String.CreateTrimmedString
 
@@ -5439,8 +6893,8 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
@@ -5535,8 +6989,8 @@ entry:
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i64 2872
   %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
   %8 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %7
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %3
   %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
@@ -5553,8 +7007,8 @@ entry:
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 2864
   %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
   %21 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %20
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
-  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %22
 
 ; <label>:22                                      ; preds = %16
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
@@ -5569,7 +7023,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %16
+ThrowNullRef2:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5586,8 +7040,8 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5613,8 +7067,8 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
@@ -5632,8 +7086,8 @@ entry:
 
 ; <label>:12                                      ; preds = %4
   %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
@@ -5644,8 +7098,8 @@ entry:
 
 ; <label>:19                                      ; preds = %14
   %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %19
   %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
@@ -5660,21 +7114,21 @@ entry:
   %31 = zext i16 %30 to i32
   %32 = bitcast i8* %29 to i16*
   %33 = trunc i32 %31 to i16
-  %NullCheck6 = icmp ne i16* %32, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i16* %32, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %21
   store i16 %33, i16* %32, align 8
   %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %36
 
 ; <label>:36                                      ; preds = %34
   %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
   %38 = load i32, i32 addrspace(1)* %37, align 8
   %39 = add i32 %38, 1
-  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %40
 
 ; <label>:40                                      ; preds = %36
   %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
@@ -5683,16 +7137,16 @@ entry:
 
 ; <label>:42                                      ; preds = %14
   %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
-  br i1 %NullCheck12, label %44, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
   %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
   %47 = load i16, i16* %arg1
   %48 = zext i16 %47 to i32
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = trunc i32 %48 to i16
@@ -5703,31 +7157,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %19
+ThrowNullRef4:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %21
+ThrowNullRef6:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %36
+ThrowNullRef10:                                   ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %42
+ThrowNullRef12:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %44
+ThrowNullRef14:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5740,8 +7194,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -5752,8 +7206,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
@@ -5762,14 +7216,14 @@ entry:
 
 ; <label>:11                                      ; preds = %1
   %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
@@ -5779,15 +7233,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5808,8 +7262,8 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5822,8 +7276,8 @@ entry:
 
 ; <label>:8                                       ; preds = %3
   %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
@@ -5842,15 +7296,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
-  br i1 %NullCheck4, label %22, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
   %24 = load i16*, i16* addrspace(1)* %23, align 8
   %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %25, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
@@ -5859,8 +7313,8 @@ entry:
   store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
@@ -5874,8 +7328,8 @@ entry:
 
 ; <label>:37                                      ; preds = %65
   %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %37
   %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
@@ -5886,16 +7340,16 @@ entry:
   %45 = bitcast i16* %41 to i8*
   %46 = getelementptr inbounds i8, i8* %45, i64 %44
   %47 = bitcast i8* %46 to i16*
-  %NullCheck14 = icmp ne i16* %47, null
-  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %47, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %48
 
 ; <label>:48                                      ; preds = %39
   %49 = load i16, i16* %47, align 8
   %50 = zext i16 %49 to i32
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %52 = load i32, i32* %loc1
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %53
 
 ; <label>:53                                      ; preds = %48
   %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
@@ -5916,8 +7370,8 @@ entry:
 ; <label>:62                                      ; preds = %36, %59
   %63 = load i32, i32* %loc1
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck10, label %65, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %65
 
 ; <label>:65                                      ; preds = %62
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
@@ -5936,15 +7390,15 @@ entry:
 
 ; <label>:74                                      ; preds = %70
   %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
-  br i1 %NullCheck18, label %76, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %76
 
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
   %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
-  br i1 %NullCheck20, label %80, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
   %81 = load i64, i64 addrspace(1)* %79
@@ -5958,8 +7412,8 @@ entry:
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
   %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
-  br i1 %NullCheck22, label %92, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.String addrspace(1)* %90, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %92
 
 ; <label>:92                                      ; preds = %80
   %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
@@ -5969,15 +7423,15 @@ entry:
 
 ; <label>:96                                      ; preds = %70
   %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
-  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %98
 
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
   %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
-  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
   %103 = load i64, i64 addrspace(1)* %101
@@ -5991,8 +7445,8 @@ entry:
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
   %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
-  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.String addrspace(1)* %112, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %114
 
 ; <label>:114                                     ; preds = %102
   %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
@@ -6004,59 +7458,59 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %20
+ThrowNullRef4:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %22
+ThrowNullRef6:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %26
+ThrowNullRef8:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %62
+ThrowNullRef10:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %48
+ThrowNullRef16:                                   ; preds = %48
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %74
+ThrowNullRef18:                                   ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %76
+ThrowNullRef20:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %80
+ThrowNullRef22:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %96
+ThrowNullRef24:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %98
+ThrowNullRef26:                                   ; preds = %98
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %102
+ThrowNullRef28:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6069,15 +7523,15 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
   %3 = load i16*, i16* addrspace(1)* %2, align 8
   %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
@@ -6087,8 +7541,8 @@ entry:
   %10 = bitcast i16* %3 to i8*
   %11 = getelementptr inbounds i8, i8* %10, i64 %9
   %12 = bitcast i8* %11 to i16*
-  %NullCheck4 = icmp ne i16* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %5
   store i16 0, i16* %12, align 8
@@ -6098,11 +7552,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6119,8 +7573,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -6131,8 +7585,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
@@ -6144,15 +7598,15 @@ entry:
 
 ; <label>:14                                      ; preds = %1
   %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
   %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
   %21 = load i64, i64 addrspace(1)* %19
@@ -6171,15 +7625,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %14
+ThrowNullRef4:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %16
+ThrowNullRef6:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6302,14 +7756,6 @@ entry:
   ret %System.String addrspace(1)* %57
 }
 
-INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
-Successfully read RuntimeHelpers.get_OffsetToStringData
-
-define i32 @RuntimeHelpers.get_OffsetToStringData() {
-entry:
-  ret i32 12
-}
-
 INFO:  jitting method String::Equals using LLILCJit
 Successfully read String.Equals
 
@@ -6381,8 +7827,8 @@ entry:
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
-  br i1 %NullCheck24, label %29, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
   %30 = load i64, i64 addrspace(1)* %28
@@ -6397,8 +7843,8 @@ entry:
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
-  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
   %43 = load i64, i64 addrspace(1)* %41
@@ -6418,8 +7864,8 @@ entry:
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
   %59 = load i64, i64 addrspace(1)* %57
@@ -6434,8 +7880,8 @@ entry:
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck22, label %71, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
   %72 = load i64, i64 addrspace(1)* %70
@@ -6455,8 +7901,8 @@ entry:
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
-  br i1 %NullCheck16, label %87, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = load i64, i64 addrspace(1)* %86
@@ -6471,8 +7917,8 @@ entry:
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck18, label %100, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
   %101 = load i64, i64 addrspace(1)* %99
@@ -6492,8 +7938,8 @@ entry:
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
-  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
   %117 = load i64, i64 addrspace(1)* %115
@@ -6508,8 +7954,8 @@ entry:
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
-  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
   %130 = load i64, i64 addrspace(1)* %128
@@ -6528,15 +7974,15 @@ entry:
 
 ; <label>:142                                     ; preds = %22
   %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
-  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %143, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %144
 
 ; <label>:144                                     ; preds = %142
   %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
   %146 = load i32, i32 addrspace(1)* %145
   %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
-  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %147, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %148
 
 ; <label>:148                                     ; preds = %144
   %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
@@ -6557,15 +8003,15 @@ entry:
 
 ; <label>:159                                     ; preds = %22
   %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
-  br i1 %NullCheck, label %161, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %ThrowNullRef, label %161
 
 ; <label>:161                                     ; preds = %159
   %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
   %163 = load i32, i32 addrspace(1)* %162
   %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
-  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %164, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %165
 
 ; <label>:165                                     ; preds = %161
   %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
@@ -6578,8 +8024,8 @@ entry:
 
 ; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
-  br i1 %NullCheck4, label %172, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %171, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %172
 
 ; <label>:172                                     ; preds = %170
   %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
@@ -6589,8 +8035,8 @@ entry:
 
 ; <label>:176                                     ; preds = %172
   %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
-  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %177, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %178
 
 ; <label>:178                                     ; preds = %176
   %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
@@ -6629,55 +8075,55 @@ ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %161
+ThrowNullRef2:                                    ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %170
+ThrowNullRef4:                                    ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %176
+ThrowNullRef6:                                    ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %142
+ThrowNullRef8:                                    ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %144
+ThrowNullRef10:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %113
+ThrowNullRef12:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %116
+ThrowNullRef14:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %84
+ThrowNullRef16:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %87
+ThrowNullRef18:                                   ; preds = %87
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %55
+ThrowNullRef20:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %58
+ThrowNullRef22:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %26
+ThrowNullRef24:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %29
+ThrowNullRef26:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,8 +8161,8 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck, label %14, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %ThrowNullRef, label %14
 
 ; <label>:14                                      ; preds = %8
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
@@ -6760,8 +8206,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
@@ -6770,14 +8216,14 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32, i32* %loc0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %10
   %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
   %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
@@ -6790,15 +8236,15 @@ entry:
 ; <label>:25                                      ; preds = %19
   %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
-  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
   %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
@@ -6807,8 +8253,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %37 = load i32, i32* %loc0
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %38, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %38
 
 ; <label>:38                                      ; preds = %32
   %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
@@ -6817,14 +8263,14 @@ entry:
 
 ; <label>:40                                      ; preds = %19
   %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %40
   %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
   %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
-  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
-  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
@@ -6832,8 +8278,8 @@ entry:
   %48 = zext i32 %47 to i64
   %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
-  br i1 %NullCheck16, label %51, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %51
 
 ; <label>:51                                      ; preds = %45
   %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
@@ -6847,15 +8293,15 @@ entry:
 ; <label>:57                                      ; preds = %51
   %58 = load i16*, i16** %arg1
   %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
-  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %60
 
 ; <label>:60                                      ; preds = %57
   %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
   %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
-  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %64
 
 ; <label>:64                                      ; preds = %60
   %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
@@ -6864,22 +8310,22 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
   %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
-  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %70
 
 ; <label>:70                                      ; preds = %64
   %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
   %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
-  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
-  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
   %75 = load i32, i32 addrspace(1)* %74
   %76 = zext i32 %75 to i64
   %77 = trunc i64 %76 to i32
-  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
-  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %78
 
 ; <label>:78                                      ; preds = %73
   %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
@@ -6901,8 +8347,8 @@ entry:
   %90 = bitcast i16* %86 to i8*
   %91 = getelementptr inbounds i8, i8* %90, i64 %89
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %93
 
 ; <label>:93                                      ; preds = %80
   %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
@@ -6912,8 +8358,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %99 = load i32, i32* %loc2
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %100
 
 ; <label>:100                                     ; preds = %93
   %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
@@ -6928,63 +8374,63 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %25
+ThrowNullRef6:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %32
+ThrowNullRef10:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %40
+ThrowNullRef12:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %45
+ThrowNullRef16:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %57
+ThrowNullRef18:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %60
+ThrowNullRef20:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %64
+ThrowNullRef22:                                   ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %70
+ThrowNullRef24:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %73
+ThrowNullRef26:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %80
+ThrowNullRef28:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %93
+ThrowNullRef30:                                   ; preds = %93
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7004,8 +8450,8 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
@@ -7033,43 +8479,43 @@ entry:
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %14
   %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
   %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   %28 = load i32, i32 addrspace(1)* %27, align 8
   %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
-  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %30
 
 ; <label>:30                                      ; preds = %26
   %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
   %32 = load i32, i32 addrspace(1)* %31, align 8
   %33 = add i32 %28, %32
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %34
 
 ; <label>:34                                      ; preds = %30
   %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   store i32 %33, i32 addrspace(1)* %35
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
   store i32 0, i32 addrspace(1)* %38
   %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %40
 
 ; <label>:40                                      ; preds = %37
   %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
@@ -7082,8 +8528,8 @@ entry:
 
 ; <label>:47                                      ; preds = %40
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
@@ -7098,8 +8544,8 @@ entry:
   %54 = load i32, i32* %loc0
   %55 = sext i32 %54 to i64
   %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
-  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %57
 
 ; <label>:57                                      ; preds = %52
   %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
@@ -7110,68 +8556,35 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %14
+ThrowNullRef2:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %23
+ThrowNullRef4:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %26
+ThrowNullRef6:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %30
+ThrowNullRef8:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %34
+ThrowNullRef10:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %47
+ThrowNullRef14:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %52
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-}
-
-INFO:  jitting method StringBuilder::get_Length using LLILCJit
-Successfully read StringBuilder.get_Length
-
-define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.StringBuilder addrspace(1)*
-  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
-  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
-
-; <label>:1                                       ; preds = %entry
-  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %3 = load i32, i32 addrspace(1)* %2, align 8
-  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
-
-; <label>:5                                       ; preds = %1
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = add i32 %3, %7
-  ret i32 %8
-
-ThrowNullRef:                                     ; preds = %entry
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef16:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7213,70 +8626,70 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
   %6 = load i32, i32 addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
   store i32 %6, i32 addrspace(1)* %8
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
   %13 = load i32, i32 addrspace(1)* %12, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
   store i32 %13, i32 addrspace(1)* %15
   %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
-  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %18
 
 ; <label>:18                                      ; preds = %14
   %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
   %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
   %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
   %34 = load i32, i32 addrspace(1)* %33, align 8
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
-  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
@@ -7287,39 +8700,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %28
+ThrowNullRef16:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %32
+ThrowNullRef18:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7455,13 +8868,13 @@ entry:
 ; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
@@ -7477,16 +8890,16 @@ entry:
 
 ; <label>:18                                      ; preds = %15
   %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
   store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
   %22 = load i32, i32* %loc0
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %24
 
 ; <label>:24                                      ; preds = %20
   %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
@@ -7498,13 +8911,13 @@ entry:
 ; <label>:28                                      ; preds = %15, %24
   %29 = load i32, i32* %arg1
   %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %31
   %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
@@ -7517,20 +8930,20 @@ entry:
   %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
-  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
   %46 = load i32, i32 addrspace(1)* %45, align 8
   %47 = sub i32 %40, %46
-  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
-  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i32 addrspace(1)* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %48
 
 ; <label>:48                                      ; preds = %44
   store i32 %47, i32 addrspace(1)* %39, align 8
@@ -7538,21 +8951,21 @@ entry:
 
 ; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
-  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %51
 
 ; <label>:51                                      ; preds = %49
   %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %53
 
 ; <label>:53                                      ; preds = %51
   %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
   %55 = load i32, i32 addrspace(1)* %54, align 8
   %56 = load i32, i32* %arg2
   %57 = sub i32 %55, %56
-  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %58
 
 ; <label>:58                                      ; preds = %53
   %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
@@ -7562,13 +8975,13 @@ entry:
 ; <label>:60                                      ; preds = %33, %58
   %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
   %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
-  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %63
 
 ; <label>:63                                      ; preds = %60
   %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
-  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
-  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
@@ -7578,15 +8991,15 @@ entry:
 
 ; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
-  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i32 addrspace(1)* %69, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %70
 
 ; <label>:70                                      ; preds = %68
   %71 = load i32, i32 addrspace(1)* %69, align 8
   store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
-  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
@@ -7596,8 +9009,8 @@ entry:
   store i32 %77, i32* %loc4
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
-  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %80
 
 ; <label>:80                                      ; preds = %73
   %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
@@ -7607,71 +9020,71 @@ entry:
 ; <label>:83                                      ; preds = %80
   store i32 0, i32* %loc3
   %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
-  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
-  br i1 %NullCheck26, label %88, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i32 addrspace(1)* %87, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %88
 
 ; <label>:88                                      ; preds = %85
   %89 = load i32, i32 addrspace(1)* %87, align 8
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
-  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %90
 
 ; <label>:90                                      ; preds = %88
   %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
   store i32 %89, i32 addrspace(1)* %91
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
-  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
-  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %96
 
 ; <label>:96                                      ; preds = %94
   %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
-  br i1 %NullCheck34, label %100, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %100
 
 ; <label>:100                                     ; preds = %96
   %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
-  br i1 %NullCheck36, label %102, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %102
 
 ; <label>:102                                     ; preds = %100
   %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
   %104 = load i32, i32 addrspace(1)* %103, align 8
   %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
-  br i1 %NullCheck38, label %106, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %106
 
 ; <label>:106                                     ; preds = %102
   %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
-  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
-  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %108
 
 ; <label>:108                                     ; preds = %106
   %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
   %110 = load i32, i32 addrspace(1)* %109, align 8
   %111 = add i32 %104, %110
-  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %112
 
 ; <label>:112                                     ; preds = %108
   %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
   store i32 %111, i32 addrspace(1)* %113
   %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
-  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i32 addrspace(1)* %114, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %115
 
 ; <label>:115                                     ; preds = %112
   %116 = load i32, i32 addrspace(1)* %114, align 8
@@ -7681,19 +9094,19 @@ entry:
 ; <label>:118                                     ; preds = %115
   %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
-  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %121
 
 ; <label>:121                                     ; preds = %118
   %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
-  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
-  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %123
 
 ; <label>:123                                     ; preds = %121
   %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
   %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
-  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
-  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %126
 
 ; <label>:126                                     ; preds = %123
   %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
@@ -7705,8 +9118,8 @@ entry:
 
 ; <label>:130                                     ; preds = %80, %115, %126
   %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %132
 
 ; <label>:132                                     ; preds = %130
   %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7715,8 +9128,8 @@ entry:
   %136 = load i32, i32* %loc3
   %137 = sub i32 %135, %136
   %138 = sub i32 %134, %137
-  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %139
 
 ; <label>:139                                     ; preds = %132
   %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7728,16 +9141,16 @@ entry:
 
 ; <label>:144                                     ; preds = %139
   %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
-  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %146
 
 ; <label>:146                                     ; preds = %144
   %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
   %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
   %149 = load i32, i32* %loc2
   %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
-  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %151
 
 ; <label>:151                                     ; preds = %146
   %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
@@ -7754,145 +9167,249 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %18
+ThrowNullRef4:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %31
+ThrowNullRef10:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %44
+ThrowNullRef16:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %68
+ThrowNullRef18:                                   ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %70
+ThrowNullRef20:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %73
+ThrowNullRef22:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %83
+ThrowNullRef24:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %85
+ThrowNullRef26:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %88
+ThrowNullRef28:                                   ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %90
+ThrowNullRef30:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %94
+ThrowNullRef32:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %96
+ThrowNullRef34:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %100
+ThrowNullRef36:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %102
+ThrowNullRef38:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %106
+ThrowNullRef40:                                   ; preds = %106
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %108
+ThrowNullRef42:                                   ; preds = %108
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %112
+ThrowNullRef44:                                   ; preds = %112
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %118
+ThrowNullRef46:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %121
+ThrowNullRef48:                                   ; preds = %121
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %123
+ThrowNullRef50:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %130
+ThrowNullRef52:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %132
+ThrowNullRef54:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %144
+ThrowNullRef56:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %146
+ThrowNullRef58:                                   ; preds = %146
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %60
+ThrowNullRef60:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %63
+ThrowNullRef62:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %49
+ThrowNullRef64:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %51
+ThrowNullRef66:                                   ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %53
+ThrowNullRef68:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(%"System.Char[]" addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %arg0 = alloca %"System.Char[]" addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store %"System.Char[]" addrspace(1)* %param0, %"System.Char[]" addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load i32, i32* %arg4
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %43, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %38, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg1
+  %13 = load i32, i32* %arg4
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %38, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %24 = load i32, i32* %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %35 = load i32, i32* %arg3
+  %36 = load i32, i32* %arg4
+  %37 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %37, %"System.Char[]" addrspace(1)* %34, i32 %35, i32 %36)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:38                                      ; preds = %5, %16
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Successfully read Buffer._Memmove
 
@@ -7914,7 +9431,7 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[loadElem]
+Failed to read AppDomain.SetDataHelper[storeElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -7923,8 +9440,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
@@ -7934,8 +9451,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
@@ -7947,15 +9464,15 @@ entry:
   %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
   %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
@@ -7966,15 +9483,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7992,7 +9509,79 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
-Failed to read Dictionary`2.TryGetValue[loadElemA]
+Successfully read Dictionary`2.TryGetValue
+
+define i8 @"Dictionary`2.TryGetValue"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)* addrspace(1)* %param2) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  %arg2 = alloca %System.__Canon addrspace(1)* addrspace(1)*
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  store %System.__Canon addrspace(1)* addrspace(1)* %param2, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  store i32 %2, i32* %loc0
+  %3 = load i32, i32* %loc0
+  %4 = icmp slt i32 %3, 0
+  br i1 %4, label %22, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 2
+  %10 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %9, align 8
+  %11 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = zext i32 %11 to i64
+  %BoundsCheck = icmp uge i64 %16, %15
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 3, i32 %11
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %20, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %6, %System.__Canon addrspace(1)* %21)
+  ret i8 1
+
+; <label>:22                                      ; preds = %entry
+  %23 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %23, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -8058,8 +9647,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
@@ -8091,8 +9680,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
@@ -8171,15 +9760,15 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck, label %19, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %ThrowNullRef, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
   %21 = load i32, i32 addrspace(1)* %20
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
@@ -8202,7 +9791,7 @@ ThrowNullRef:                                     ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %19
+ThrowNullRef2:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8248,8 +9837,8 @@ entry:
   %0 = alloca %System.AppDomainHandle
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %1 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %1, i32 0, i32 15
@@ -8269,8 +9858,8 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
@@ -8286,7 +9875,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -8299,8 +9888,8 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -8327,8 +9916,8 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
@@ -8352,8 +9941,8 @@ entry:
   %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
   store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
@@ -8363,8 +9952,8 @@ entry:
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
@@ -8374,8 +9963,8 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %9
   %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
@@ -8384,8 +9973,8 @@ entry:
 
 ; <label>:18                                      ; preds = %3, %16
   %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
@@ -8397,15 +9986,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %18
+ThrowNullRef6:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8418,8 +10007,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
@@ -8453,15 +10042,15 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
@@ -8473,7 +10062,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8481,7 +10070,7 @@ ThrowNullRef1:                                    ; preds = %1
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
 Failed to read Dictionary`2.System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
@@ -8506,8 +10095,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
@@ -8524,8 +10113,8 @@ entry:
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -8544,7 +10133,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8577,8 +10166,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = load i64, i64* %arg2
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = trunc i32 %3 to i8
@@ -8634,46 +10223,46 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
   %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
-  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
-  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
-  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
@@ -8684,27 +10273,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %20
+ThrowNullRef12:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8717,8 +10306,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -8756,22 +10345,22 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
   %9 = load i64, i64 addrspace(1)* %8, align 8
   %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
   %13 = load i64, i64 addrspace(1)* %12, align 8
   %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %11
   %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
@@ -8788,11 +10377,11 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8882,8 +10471,8 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
@@ -8900,8 +10489,8 @@ entry:
 ; <label>:8                                       ; preds = %1
   %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
   %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
@@ -8911,15 +10500,15 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
   %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
   %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
-  br i1 %NullCheck6, label %21, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
@@ -8946,15 +10535,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8992,15 +10581,15 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
   store i8 %3, i8 addrspace(1)* %5
   %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
@@ -9011,7 +10600,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9027,8 +10616,8 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -9041,8 +10630,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
@@ -9058,7 +10647,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9080,8 +10669,8 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
@@ -9096,8 +10685,8 @@ entry:
 ; <label>:12                                      ; preds = %6
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
@@ -9112,8 +10701,8 @@ entry:
 ; <label>:21                                      ; preds = %15
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
@@ -9128,8 +10717,8 @@ entry:
 ; <label>:30                                      ; preds = %24
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %31, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
@@ -9144,8 +10733,8 @@ entry:
 ; <label>:39                                      ; preds = %33
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
-  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %40, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %42
 
 ; <label>:42                                      ; preds = %39
   %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
@@ -9164,19 +10753,19 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %21
+ThrowNullRef4:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %30
+ThrowNullRef6:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %39
+ThrowNullRef8:                                    ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9243,8 +10832,8 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
@@ -9264,57 +10853,57 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
   store i8 0, i8 addrspace(1)* %2
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
   store i8 0, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
   store i8 0, i8 addrspace(1)* %17
   %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
   store i8 0, i8 addrspace(1)* %20
   %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
-  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
@@ -9325,31 +10914,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %19
+ThrowNullRef14:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9367,8 +10956,8 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
@@ -9380,8 +10969,8 @@ entry:
 
 ; <label>:9                                       ; preds = %4
   %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %9
   %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
@@ -9395,7 +10984,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef2:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9420,8 +11009,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
@@ -9512,8 +11101,8 @@ entry:
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
@@ -9524,8 +11113,8 @@ entry:
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = load i64, i64 addrspace(1)* %12
@@ -9537,8 +11126,8 @@ entry:
   %20 = load i64, i64* %19
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
-  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %13
   %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
@@ -9555,8 +11144,8 @@ entry:
 ; <label>:30                                      ; preds = %25
   %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %32 = load i32, i32* %arg2
-  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
-  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
@@ -9570,15 +11159,15 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %30
+ThrowNullRef2:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9622,87 +11211,87 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
   %10 = load i8, i8 addrspace(1)* %9, align 8
   %11 = zext i8 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %8
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
   store i8 %12, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
   %19 = load i8, i8 addrspace(1)* %18, align 8
   %20 = zext i8 %19 to i32
   %21 = trunc i32 %20 to i8
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
   store i8 %21, i8 addrspace(1)* %23
   %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
   %28 = load i8, i8 addrspace(1)* %27, align 8
   %29 = zext i8 %28 to i32
   %30 = trunc i32 %29 to i8
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
-  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %31
 
 ; <label>:31                                      ; preds = %26
   %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
   store i8 %30, i8 addrspace(1)* %32
   %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
-  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
-  br i1 %NullCheck14, label %40, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %40
 
 ; <label>:40                                      ; preds = %35
   %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
   store i8 %39, i8 addrspace(1)* %41
   %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
-  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %44
 
 ; <label>:44                                      ; preds = %40
   %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
   %46 = load i8, i8 addrspace(1)* %45, align 8
   %47 = zext i8 %46 to i32
   %48 = trunc i32 %47 to i8
-  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
   store i8 %48, i8 addrspace(1)* %50
   %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
-  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
@@ -9713,29 +11302,29 @@ entry:
 ; <label>:56                                      ; preds = %52
   %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
-  br i1 %NullCheck22, label %59, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
   %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
   %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
-  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
-  br i1 %NullCheck24, label %63, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
   %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
-  br i1 %NullCheck26, label %66, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
   %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
-  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
-  br i1 %NullCheck28, label %69, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %69
 
 ; <label>:69                                      ; preds = %66
   %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
@@ -9744,15 +11333,15 @@ entry:
 
 ; <label>:71                                      ; preds = %105
   %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
-  br i1 %NullCheck34, label %73, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %73
 
 ; <label>:73                                      ; preds = %71
   %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
   %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
   %76 = load i32, i32* %loc0
-  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
-  br i1 %NullCheck36, label %77, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
@@ -9766,8 +11355,8 @@ entry:
 
 ; <label>:83                                      ; preds = %77
   %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
-  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
@@ -9775,14 +11364,14 @@ entry:
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
   %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
-  br i1 %NullCheck40, label %91, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
 ; <label>:91                                      ; preds = %85
   %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
   %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
-  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck42, label %94, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %94
 
 ; <label>:94                                      ; preds = %91
   %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
@@ -9798,14 +11387,14 @@ entry:
 ; <label>:99                                      ; preds = %69, %96
   %100 = load i32, i32* %loc0
   %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
-  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %102
 
 ; <label>:102                                     ; preds = %99
   %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
   %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
-  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
-  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
@@ -9819,87 +11408,87 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %26
+ThrowNullRef10:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %31
+ThrowNullRef12:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %35
+ThrowNullRef14:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %40
+ThrowNullRef16:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %56
+ThrowNullRef22:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %59
+ThrowNullRef24:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %63
+ThrowNullRef26:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %66
+ThrowNullRef28:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %102
+ThrowNullRef32:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %71
+ThrowNullRef34:                                   ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %73
+ThrowNullRef36:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %83
+ThrowNullRef38:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %85
+ThrowNullRef40:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %91
+ThrowNullRef42:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9943,15 +11532,15 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
   %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
@@ -9961,28 +11550,28 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
   %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %12
   %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
   %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
   %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
-  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
@@ -9993,23 +11582,23 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %12
+ThrowNullRef6:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10031,15 +11620,15 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
   %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = load i64, i64 addrspace(1)* %7
@@ -10077,13 +11666,13 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[loadElem]
+Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -10111,8 +11700,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -10195,8 +11784,8 @@ entry:
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load float, float* %arg0
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -10330,8 +11919,8 @@ entry:
   store i64 %param0, i64* %arg0
   store i64 %param1, i64* %arg1
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
@@ -10339,8 +11928,8 @@ entry:
   %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
   %5 = load i16*, i16* addrspace(1)* %4, align 8
   %6 = addrspacecast i64* %arg1 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = bitcast i64 addrspace(1)* %6 to i8 addrspace(1)*
@@ -10356,7 +11945,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10390,8 +11979,8 @@ entry:
   %1 = load i32, i32* %arg1
   %2 = sext i32 %1 to i64
   %3 = inttoptr i64 %2 to i16*
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -10444,8 +12033,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, i32)*)(%System.IO.ConsoleStream addrspace(1)* %2, i32 %1)
   %3 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %4 = load i64, i64* %arg1
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
@@ -10456,8 +12045,8 @@ entry:
   %10 = icmp eq i32 %9, 3
   %11 = sext i1 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %5
   %14 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, i32 0, i32 5
@@ -10468,7 +12057,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10491,8 +12080,8 @@ entry:
   %5 = icmp eq i32 %4, 1
   %6 = sext i1 %5 to i32
   %7 = trunc i32 %6 to i8
-  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %2, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.ConsoleStream addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
@@ -10503,8 +12092,8 @@ entry:
   %13 = icmp eq i32 %12, 2
   %14 = sext i1 %13 to i32
   %15 = trunc i32 %14 to i8
-  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %10, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.ConsoleStream addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %8
   %17 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %10, i32 0, i32 4
@@ -10515,7 +12104,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10554,8 +12143,8 @@ entry:
   %arg0 = alloca i64
   store i64 %param0, i64* %arg0
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
@@ -10590,8 +12179,8 @@ entry:
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
   %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = load i64, i64 addrspace(1)* %7
@@ -10695,7 +12284,127 @@ entry:
 INFO:  jitting method Encoding::GetEncoding using LLILCJit
 Failed to read Encoding.GetEncoding[convertToHelperArgumentType]
 INFO:  jitting method EncodingProvider::GetEncodingFromProvider using LLILCJit
-Failed to read EncodingProvider.GetEncodingFromProvider[loadElem]
+Successfully read EncodingProvider.GetEncodingFromProvider
+
+define %System.Text.Encoding addrspace(1)* @EncodingProvider.GetEncodingFromProvider(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca %"System.Text.EncodingProvider[]" addrspace(1)*
+  %loc1 = alloca %System.Text.EncodingProvider addrspace(1)*
+  %loc2 = alloca %System.Text.Encoding addrspace(1)*
+  %loc3 = alloca %System.Text.Encoding addrspace(1)*
+  %loc4 = alloca %"System.Text.EncodingProvider[]" addrspace(1)*
+  %loc5 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1059)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2392
+  %2 = addrspacecast i8 addrspace(1)* %1 to %"System.Text.EncodingProvider[]" addrspace(1)**
+  %3 = load volatile %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %2
+  %4 = icmp ne %"System.Text.EncodingProvider[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %entry
+  ret %System.Text.Encoding addrspace(1)* null
+
+; <label>:6                                       ; preds = %entry
+  %7 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1059)
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i64 2392
+  %9 = addrspacecast i8 addrspace(1)* %8 to %"System.Text.EncodingProvider[]" addrspace(1)**
+  %10 = load volatile %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %9
+  store %"System.Text.EncodingProvider[]" addrspace(1)* %10, %"System.Text.EncodingProvider[]" addrspace(1)** %loc0
+  %11 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc0
+  store %"System.Text.EncodingProvider[]" addrspace(1)* %11, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  store i32 0, i32* %loc5
+  br label %43
+
+; <label>:12                                      ; preds = %46
+  %13 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  %14 = load i32, i32* %loc5
+  %NullCheck1 = icmp eq %"System.Text.EncodingProvider[]" addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %13, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = zext i32 %17 to i64
+  %19 = zext i32 %14 to i64
+  %BoundsCheck = icmp uge i64 %19, %18
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %20
+
+; <label>:20                                      ; preds = %15
+  %21 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %13, i32 0, i32 3, i32 %14
+  %22 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)* addrspace(1)* %21, align 8
+  store %System.Text.EncodingProvider addrspace(1)* %22, %System.Text.EncodingProvider addrspace(1)** %loc1
+  %23 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)** %loc1
+  %24 = load i32, i32* %arg0
+  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i64 addrspace(1)*
+  %NullCheck3 = icmp eq i64 addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
+
+; <label>:26                                      ; preds = %20
+  %27 = load i64, i64 addrspace(1)* %25
+  %28 = add i64 %27, 64
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 40
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Text.Encoding addrspace(1)* (%System.Text.EncodingProvider addrspace(1)*, i32)*
+  %35 = call %System.Text.Encoding addrspace(1)* %34(%System.Text.EncodingProvider addrspace(1)* %23, i32 %24)
+  store %System.Text.Encoding addrspace(1)* %35, %System.Text.Encoding addrspace(1)** %loc2
+  %36 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc2
+  %37 = icmp eq %System.Text.Encoding addrspace(1)* %36, null
+  br i1 %37, label %40, label %38
+
+; <label>:38                                      ; preds = %26
+  %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc2
+  store %System.Text.Encoding addrspace(1)* %39, %System.Text.Encoding addrspace(1)** %loc3
+  br label %53
+
+; <label>:40                                      ; preds = %26
+  %41 = load i32, i32* %loc5
+  %42 = add i32 %41, 1
+  store i32 %42, i32* %loc5
+  br label %43
+
+; <label>:43                                      ; preds = %6, %40
+  %44 = load i32, i32* %loc5
+  %45 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  %NullCheck = icmp eq %"System.Text.EncodingProvider[]" addrspace(1)* %45, null
+  br i1 %NullCheck, label %ThrowNullRef, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp slt i32 %44, %50
+  br i1 %51, label %12, label %52
+
+; <label>:52                                      ; preds = %46
+  ret %System.Text.Encoding addrspace(1)* null
+
+; <label>:53                                      ; preds = %38
+  %54 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc3
+  ret %System.Text.Encoding addrspace(1)* %54
+
+ThrowNullRef:                                     ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method EncodingProvider::.cctor using LLILCJit
 Successfully read EncodingProvider..cctor
 
@@ -10714,7 +12423,7 @@ Failed to read Encoding.get_InternalSyncObject[Call HasTypeArg]
 INFO:  jitting method Hashtable::.ctor using LLILCJit
 Failed to read Hashtable..ctor[Volatile store]
 INFO:  jitting method Hashtable::get_Item using LLILCJit
-Failed to read Hashtable.get_Item[loadElemA]
+Failed to read Hashtable.get_Item[loadNonPrimitiveObj]
 INFO:  jitting method Hashtable::InitHash using LLILCJit
 Successfully read Hashtable.InitHash
 
@@ -10734,8 +12443,8 @@ entry:
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -10751,15 +12460,15 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
   %15 = load i32, i32* %loc0
-  %NullCheck2 = icmp ne i32 addrspace(1)* %14, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i32 addrspace(1)* %14, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %3
   store i32 %15, i32 addrspace(1)* %14, align 8
   %17 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %18 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %NullCheck4 = icmp ne i32 addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i32 addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = load i32, i32 addrspace(1)* %18, align 8
@@ -10768,8 +12477,8 @@ entry:
   %23 = sub i32 %22, 1
   %24 = urem i32 %21, %23
   %25 = add i32 1, %24
-  %NullCheck6 = icmp ne i32 addrspace(1)* %17, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32 addrspace(1)* %17, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %19
   store i32 %25, i32 addrspace(1)* %17, align 8
@@ -10780,15 +12489,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %19
+ThrowNullRef6:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10803,8 +12512,8 @@ entry:
   store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
   store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %NullCheck = icmp ne %System.Collections.Hashtable addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Collections.Hashtable addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
@@ -10814,16 +12523,16 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Collections.Hashtable addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Collections.Hashtable addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
   %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck4 = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %9, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
   %13 = inttoptr i64 %11 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
@@ -10833,8 +12542,8 @@ entry:
 ; <label>:15                                      ; preds = %1
   %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -10852,15 +12561,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10874,8 +12583,8 @@ entry:
   store %System.Int32 addrspace(1)* %param0, %System.Int32 addrspace(1)** %this
   %0 = load %System.Int32 addrspace(1)*, %System.Int32 addrspace(1)** %this
   %1 = bitcast %System.Int32 addrspace(1)* %0 to i32 addrspace(1)*
-  %NullCheck = icmp ne i32 addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq i32 addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load i32, i32 addrspace(1)* %1, align 8
@@ -10951,8 +12660,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.UTF8Encoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
@@ -10961,15 +12670,15 @@ entry:
   %9 = load i8, i8* %arg2
   %10 = zext i8 %9 to i32
   %11 = trunc i32 %10 to i8
-  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %8, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %6
   %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %8, i32 0, i32 8
   store i8 %11, i8 addrspace(1)* %13
   %14 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %14, i32 0, i32 8
@@ -10981,8 +12690,8 @@ entry:
 ; <label>:20                                      ; preds = %15
   %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %22, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %22, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = load i64, i64 addrspace(1)* %22
@@ -11004,15 +12713,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %12
+ThrowNullRef4:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11027,8 +12736,8 @@ entry:
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
@@ -11050,16 +12759,16 @@ entry:
 ; <label>:10                                      ; preds = %1
   %11 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
   %12 = load i32, i32* %arg1
-  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %11, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.Encoding addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
   store i32 %12, i32 addrspace(1)* %14
   %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
   %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = load i64, i64 addrspace(1)* %16
@@ -11077,11 +12786,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11094,8 +12803,8 @@ entry:
   %this = alloca %System.Text.UTF8Encoding addrspace(1)*
   store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
   %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.UTF8Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
@@ -11107,16 +12816,16 @@ entry:
 ; <label>:6                                       ; preds = %1
   %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %8 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %10, %System.Text.EncoderFallback addrspace(1)* %8)
   %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %12 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
-  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %11, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %11, i32 0, i32 3
@@ -11129,8 +12838,8 @@ entry:
   %18 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %18, %System.String addrspace(1)* %17)
   %19 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %18 to %System.Text.EncoderFallback addrspace(1)*
-  %NullCheck6 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %16, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %16, i32 0, i32 2
@@ -11140,8 +12849,8 @@ entry:
   %24 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %24, %System.String addrspace(1)* %23)
   %25 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %24 to %System.Text.DecoderFallback addrspace(1)*
-  %NullCheck8 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %22, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %22, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %20
   %27 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %22, i32 0, i32 3
@@ -11152,19 +12861,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %20
+ThrowNullRef8:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11194,8 +12903,8 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load i32, i32* %arg1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -11213,8 +12922,8 @@ entry:
 ; <label>:15                                      ; preds = %8
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %17 = load i32, i32* %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 %17
@@ -11230,7 +12939,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11282,7 +12991,7 @@ entry:
 }
 
 INFO:  jitting method Hashtable::Insert using LLILCJit
-Failed to read Hashtable.Insert[loadElemA]
+Failed to read Hashtable.Insert[storeElem]
 INFO:  jitting method ConsoleEncoding::.ctor using LLILCJit
 Successfully read ConsoleEncoding..ctor
 
@@ -11297,8 +13006,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %1)
   %2 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
@@ -11334,8 +13043,8 @@ entry:
   %2 = call %System.Text.InternalEncoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalEncoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %1)
   %3 = bitcast %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2 to %System.Text.EncoderFallback addrspace(1)*
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
@@ -11345,8 +13054,8 @@ entry:
   %8 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %7)
   %9 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %8 to %System.Text.DecoderFallback addrspace(1)*
-  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %6, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.Encoding addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %4
   %11 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %6, i32 0, i32 3
@@ -11357,7 +13066,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11376,15 +13085,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* %1)
   %2 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   %6 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, i32 0, i32 1
@@ -11395,7 +13104,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11423,8 +13132,8 @@ entry:
   store %System.Text.InternalDecoderBestFitFallback addrspace(1)* %param0, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
   %0 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
@@ -11434,15 +13143,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %4)
   %5 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %6)
   %9 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, i32 0, i32 1
@@ -11453,11 +13162,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11525,8 +13234,8 @@ entry:
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
   %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = load i64, i64 addrspace(1)* %19
@@ -11590,8 +13299,8 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.ConsoleStream addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
@@ -11622,31 +13331,31 @@ entry:
   store i8 %param4, i8* %arg4
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %3, %System.IO.Stream addrspace(1)* %1)
   %4 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %4, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
   %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %4, i32 0, i32 4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %5)
   %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %6
   %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
   %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
   %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = load i64, i64 addrspace(1)* %13
@@ -11658,8 +13367,8 @@ entry:
   %21 = load i64, i64* %20
   %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %8, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %8, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %14
   %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 5
@@ -11677,24 +13386,24 @@ entry:
   %31 = load i32, i32* %arg3
   %32 = sext i32 %31 to i64
   %33 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %32)
-  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %30, null
-  br i1 %NullCheck10, label %34, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.StreamWriter addrspace(1)* %30, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %35, %"System.Char[]" addrspace(1)* %33)
   %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %37, null
-  br i1 %NullCheck12, label %38, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.StreamWriter addrspace(1)* %37, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %38
 
 ; <label>:38                                      ; preds = %34
   %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
   %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
   %41 = load i32, i32* %arg3
   %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %42, null
-  br i1 %NullCheck14, label %43, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %42, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
   %44 = load i64, i64 addrspace(1)* %42
@@ -11708,30 +13417,30 @@ entry:
   %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
   %53 = sext i32 %52 to i64
   %54 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %53)
-  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
-  br i1 %NullCheck16, label %55, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %55
 
 ; <label>:55                                      ; preds = %43
   %56 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %56, %"System.Byte[]" addrspace(1)* %54)
   %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %58 = load i32, i32* %arg3
-  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %57, null
-  br i1 %NullCheck18, label %59, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.StreamWriter addrspace(1)* %57, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %59
 
 ; <label>:59                                      ; preds = %55
   %60 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 10
   store i32 %58, i32 addrspace(1)* %60
   %61 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %61, null
-  br i1 %NullCheck20, label %62, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.IO.StreamWriter addrspace(1)* %61, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %62
 
 ; <label>:62                                      ; preds = %59
   %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
   %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
   %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
   %67 = load i64, i64 addrspace(1)* %65
@@ -11749,15 +13458,15 @@ entry:
 
 ; <label>:78                                      ; preds = %66
   %79 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %79, null
-  br i1 %NullCheck24, label %80, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.StreamWriter addrspace(1)* %79, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %80
 
 ; <label>:80                                      ; preds = %78
   %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
   %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
   %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %83, null
-  br i1 %NullCheck26, label %84, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %83, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
   %85 = load i64, i64 addrspace(1)* %83
@@ -11774,8 +13483,8 @@ entry:
 
 ; <label>:95                                      ; preds = %84
   %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.IO.StreamWriter addrspace(1)* %96, null
-  br i1 %NullCheck28, label %97, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.IO.StreamWriter addrspace(1)* %96, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %97
 
 ; <label>:97                                      ; preds = %95
   %98 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 12
@@ -11789,8 +13498,8 @@ entry:
   %103 = icmp eq i32 %102, 0
   %104 = sext i1 %103 to i32
   %105 = trunc i32 %104 to i8
-  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %100, null
-  br i1 %NullCheck30, label %106, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.IO.StreamWriter addrspace(1)* %100, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %106
 
 ; <label>:106                                     ; preds = %99
   %107 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %100, i32 0, i32 13
@@ -11801,63 +13510,63 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %6
+ThrowNullRef4:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %29
+ThrowNullRef10:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %34
+ThrowNullRef12:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %38
+ThrowNullRef14:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %43
+ThrowNullRef16:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %55
+ThrowNullRef18:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %59
+ThrowNullRef20:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %62
+ThrowNullRef22:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %78
+ThrowNullRef24:                                   ; preds = %78
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %80
+ThrowNullRef26:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %95
+ThrowNullRef28:                                   ; preds = %95
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11870,15 +13579,15 @@ entry:
   %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = load i64, i64 addrspace(1)* %4
@@ -11896,7 +13605,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11946,35 +13655,35 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
   %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderNLS addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %7 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.EncoderNLS addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Text.Encoding addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.Encoding addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Text.EncoderNLS addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.EncoderNLS addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
   %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck8 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = load i64, i64 addrspace(1)* %16
@@ -11993,19 +13702,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12031,8 +13740,8 @@ entry:
   %this = alloca %System.Text.Encoding addrspace(1)*
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
@@ -12052,15 +13761,15 @@ entry:
   %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
   store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
   %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
   store i32 0, i32 addrspace(1)* %2
   %3 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, i32 0, i32 2
@@ -12070,15 +13779,15 @@ entry:
 
 ; <label>:8                                       ; preds = %4
   %9 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
   %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
   %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = load i64, i64 addrspace(1)* %13
@@ -12099,15 +13808,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12122,16 +13831,16 @@ entry:
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = load i32, i32* %arg1
   %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
   %7 = load i64, i64 addrspace(1)* %5
@@ -12149,7 +13858,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12186,8 +13895,8 @@ entry:
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
   %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
   %16 = load i64, i64 addrspace(1)* %14
@@ -12208,8 +13917,8 @@ entry:
   %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
   %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
   %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %31, null
-  br i1 %NullCheck2, label %32, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = load i64, i64 addrspace(1)* %31
@@ -12252,7 +13961,7 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12265,14 +13974,14 @@ entry:
   %this = alloca %System.Text.EncoderReplacementFallback addrspace(1)*
   store %System.Text.EncoderReplacementFallback addrspace(1)* %param0, %System.Text.EncoderReplacementFallback addrspace(1)** %this
   %0 = load %System.Text.EncoderReplacementFallback addrspace(1)*, %System.Text.EncoderReplacementFallback addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -12283,7 +13992,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12313,8 +14022,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
@@ -12346,8 +14055,8 @@ entry:
   %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
   store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
@@ -12359,8 +14068,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Threading.Tasks.Task addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %7)
@@ -12383,7 +14092,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12402,8 +14111,8 @@ entry:
   store i8 %param1, i8* %arg1
   store i8 %param2, i8* %arg2
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
@@ -12417,8 +14126,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1, %5
   %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 9
@@ -12449,8 +14158,8 @@ entry:
 
 ; <label>:25                                      ; preds = %8, %20
   %26 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %26, null
-  br i1 %NullCheck4, label %27, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %26, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %26, i32 0, i32 12
@@ -12461,22 +14170,22 @@ entry:
 
 ; <label>:32                                      ; preds = %27
   %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %33, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.IO.StreamWriter addrspace(1)* %33, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %32
   %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 12
   store i8 1, i8 addrspace(1)* %35
   %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
-  br i1 %NullCheck8, label %37, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
   %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
   %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck10 = icmp ne i64 addrspace(1)* %40, null
-  br i1 %NullCheck10, label %41, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64 addrspace(1)* %40, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i64, i64 addrspace(1)* %40
@@ -12490,8 +14199,8 @@ entry:
   %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
   store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
   %51 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %NullCheck12 = icmp ne %"System.Byte[]" addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Byte[]" addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %41
   %53 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %51, i32 0, i32 1
@@ -12503,16 +14212,16 @@ entry:
 
 ; <label>:58                                      ; preds = %52
   %59 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %59, null
-  br i1 %NullCheck14, label %60, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.IO.StreamWriter addrspace(1)* %59, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %60
 
 ; <label>:60                                      ; preds = %58
   %61 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %59, i32 0, i32 3
   %62 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
   %64 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %NullCheck16 = icmp ne %"System.Byte[]" addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %"System.Byte[]" addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %60
   %66 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %64, i32 0, i32 1
@@ -12520,8 +14229,8 @@ entry:
   %68 = zext i32 %67 to i64
   %69 = trunc i64 %68 to i32
   %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck18, label %71, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
   %72 = load i64, i64 addrspace(1)* %70
@@ -12537,29 +14246,29 @@ entry:
 
 ; <label>:80                                      ; preds = %27, %52, %71
   %81 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %81, null
-  br i1 %NullCheck20, label %82, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.IO.StreamWriter addrspace(1)* %81, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
 
 ; <label>:82                                      ; preds = %80
   %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %81, i32 0, i32 5
   %84 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %83, align 8
   %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.IO.StreamWriter addrspace(1)* %85, null
-  br i1 %NullCheck22, label %86, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.IO.StreamWriter addrspace(1)* %85, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %86
 
 ; <label>:86                                      ; preds = %82
   %87 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 7
   %88 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %87, align 8
   %89 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %89, null
-  br i1 %NullCheck24, label %90, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.StreamWriter addrspace(1)* %89, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %90
 
 ; <label>:90                                      ; preds = %86
   %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %89, i32 0, i32 9
   %92 = load i32, i32 addrspace(1)* %91, align 8
   %93 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.IO.StreamWriter addrspace(1)* %93, null
-  br i1 %NullCheck26, label %94, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.IO.StreamWriter addrspace(1)* %93, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %93, i32 0, i32 6
@@ -12567,8 +14276,8 @@ entry:
   %97 = load i8, i8* %arg2
   %98 = zext i8 %97 to i32
   %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
-  %NullCheck28 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck28, label %100, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
   %101 = load i64, i64 addrspace(1)* %99
@@ -12583,8 +14292,8 @@ entry:
   %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
   store i32 %110, i32* %loc1
   %111 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %111, null
-  br i1 %NullCheck30, label %112, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.IO.StreamWriter addrspace(1)* %111, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %112
 
 ; <label>:112                                     ; preds = %100
   %113 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %111, i32 0, i32 9
@@ -12595,23 +14304,23 @@ entry:
 
 ; <label>:116                                     ; preds = %112
   %117 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck32 = icmp ne %System.IO.StreamWriter addrspace(1)* %117, null
-  br i1 %NullCheck32, label %118, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.IO.StreamWriter addrspace(1)* %117, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %118
 
 ; <label>:118                                     ; preds = %116
   %119 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %117, i32 0, i32 3
   %120 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %119, align 8
   %121 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.IO.StreamWriter addrspace(1)* %121, null
-  br i1 %NullCheck34, label %122, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.IO.StreamWriter addrspace(1)* %121, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %122
 
 ; <label>:122                                     ; preds = %118
   %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
   %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
   %125 = load i32, i32* %loc1
   %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
-  %NullCheck36 = icmp ne i64 addrspace(1)* %126, null
-  br i1 %NullCheck36, label %127, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64 addrspace(1)* %126, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
   %128 = load i64, i64 addrspace(1)* %126
@@ -12633,15 +14342,15 @@ entry:
 
 ; <label>:140                                     ; preds = %136
   %141 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.IO.StreamWriter addrspace(1)* %141, null
-  br i1 %NullCheck38, label %142, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.IO.StreamWriter addrspace(1)* %141, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %142
 
 ; <label>:142                                     ; preds = %140
   %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
   %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
   %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
-  %NullCheck40 = icmp ne i64 addrspace(1)* %145, null
-  br i1 %NullCheck40, label %146, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i64 addrspace(1)* %145, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
   %147 = load i64, i64 addrspace(1)* %145
@@ -12662,83 +14371,83 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %25
+ThrowNullRef4:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %32
+ThrowNullRef6:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %37
+ThrowNullRef10:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %41
+ThrowNullRef12:                                   ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %58
+ThrowNullRef14:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %60
+ThrowNullRef16:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %65
+ThrowNullRef18:                                   ; preds = %65
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %80
+ThrowNullRef20:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %82
+ThrowNullRef22:                                   ; preds = %82
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %86
+ThrowNullRef24:                                   ; preds = %86
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %90
+ThrowNullRef26:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %94
+ThrowNullRef28:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %100
+ThrowNullRef30:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %116
+ThrowNullRef32:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %118
+ThrowNullRef34:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %122
+ThrowNullRef36:                                   ; preds = %122
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %140
+ThrowNullRef38:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %142
+ThrowNullRef40:                                   ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12805,8 +14514,8 @@ entry:
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %1 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
-  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
@@ -12814,8 +14523,8 @@ entry:
   %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
   %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
   %8 = load i64, i64 addrspace(1)* %6
@@ -12831,8 +14540,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %17, %System.IFormatProvider addrspace(1)* %16)
   %18 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %19 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %18, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.SyncTextWriter addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %7
   %21 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %18, i32 0, i32 4
@@ -12843,11 +14552,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12860,8 +14569,8 @@ entry:
   %this = alloca %System.IO.TextWriter addrspace(1)*
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.TextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
@@ -12871,8 +14580,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.Threading.Thread addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Threading.Thread addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %6)
@@ -12881,8 +14590,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1
   %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.TextWriter addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.TextWriter addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %11, i32 0, i32 2
@@ -12893,11 +14602,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13094,8 +14803,8 @@ entry:
   store float %param1, float* %arg1
   store i8 0, i8* %loc1
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
@@ -13105,16 +14814,16 @@ entry:
   %5 = addrspacecast i8* %loc1 to i8 addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %4, i8 addrspace(1)* %5)
   %6 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.SyncTextWriter addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
   %10 = load float, float* %arg1
   %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
   %13 = load i64, i64 addrspace(1)* %11
@@ -13149,11 +14858,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13170,8 +14879,8 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load float, float* %arg1
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -13185,8 +14894,8 @@ entry:
   call void %11(%System.IO.TextWriter addrspace(1)* %0, float %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
   %15 = load i64, i64 addrspace(1)* %13
@@ -13204,7 +14913,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13222,8 +14931,8 @@ entry:
   %1 = addrspacecast float* %arg1 to float addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -13238,8 +14947,8 @@ entry:
   %14 = bitcast float addrspace(1)* %1 to %System.Single addrspace(1)*
   %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Single addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Single addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
   %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
   %18 = load i64, i64 addrspace(1)* %16
@@ -13257,7 +14966,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13273,8 +14982,8 @@ entry:
   store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
   %0 = load %System.Single addrspace(1)*, %System.Single addrspace(1)** %this
   %1 = bitcast %System.Single addrspace(1)* %0 to float addrspace(1)*
-  %NullCheck = icmp ne float addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq float addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load float, float addrspace(1)* %1, align 8
@@ -13299,8 +15008,8 @@ entry:
   %loc0 = alloca %System.Globalization.NumberFormatInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 3
@@ -13310,8 +15019,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
@@ -13321,24 +15030,24 @@ entry:
   store %System.Globalization.NumberFormatInfo addrspace(1)* %10, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
   %11 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %7
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
   %15 = load i8, i8 addrspace(1)* %14, align 8
   %16 = zext i8 %15 to i32
   %17 = trunc i32 %16 to i8
-  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %11, null
-  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %11, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %13
   %19 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %11, i32 0, i32 29
   store i8 %17, i8 addrspace(1)* %19
   %20 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %21 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %20, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %20, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %18
   %23 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %20, i32 0, i32 3
@@ -13347,8 +15056,8 @@ entry:
 
 ; <label>:24                                      ; preds = %1, %22
   %25 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %25, null
-  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %25, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %26
 
 ; <label>:26                                      ; preds = %24
   %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %25, i32 0, i32 3
@@ -13359,23 +15068,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %18
+ThrowNullRef8:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13400,168 +15109,168 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 18
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %8, align 8
-  %NullCheck2 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %5, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %5, i32 0, i32 4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %9)
   %12 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 19
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %15, align 8
-  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %12, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %12, i32 0, i32 5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %16)
   %19 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %20 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %20, null
-  br i1 %NullCheck8, label %21, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %20, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %20, i32 0, i32 23
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  %NullCheck10 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %19, null
-  br i1 %NullCheck10, label %24, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %19, i32 0, i32 7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %25, %System.String addrspace(1)* %23)
   %26 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %27 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %27, i32 0, i32 22
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %29, align 8
-  %NullCheck14 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %26, null
-  br i1 %NullCheck14, label %31, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %26, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %26, i32 0, i32 6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %32, %System.String addrspace(1)* %30)
   %33 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %34 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Globalization.CultureData addrspace(1)* %34, null
-  br i1 %NullCheck16, label %35, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Globalization.CultureData addrspace(1)* %34, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %34, i32 0, i32 51
   %37 = load i32, i32 addrspace(1)* %36, align 8
-  %NullCheck18 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %33, null
-  br i1 %NullCheck18, label %38, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %33, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %33, i32 0, i32 21
   store i32 %37, i32 addrspace(1)* %39
   %40 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %41 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Globalization.CultureData addrspace(1)* %41, null
-  br i1 %NullCheck20, label %42, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Globalization.CultureData addrspace(1)* %41, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %41, i32 0, i32 52
   %44 = load i32, i32 addrspace(1)* %43, align 8
-  %NullCheck22 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %40, null
-  br i1 %NullCheck22, label %45, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %40, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %40, i32 0, i32 25
   store i32 %44, i32 addrspace(1)* %46
   %47 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %48 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.Globalization.CultureData addrspace(1)* %48, null
-  br i1 %NullCheck24, label %49, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Globalization.CultureData addrspace(1)* %48, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %49
 
 ; <label>:49                                      ; preds = %45
   %50 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %48, i32 0, i32 29
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck26 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %47, null
-  br i1 %NullCheck26, label %52, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %47, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %47, i32 0, i32 10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %53, %System.String addrspace(1)* %51)
   %54 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %55 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Globalization.CultureData addrspace(1)* %55, null
-  br i1 %NullCheck28, label %56, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Globalization.CultureData addrspace(1)* %55, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %56
 
 ; <label>:56                                      ; preds = %52
   %57 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %55, i32 0, i32 35
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %57, align 8
-  %NullCheck30 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %54, null
-  br i1 %NullCheck30, label %59, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %54, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %54, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %60, %System.String addrspace(1)* %58)
   %61 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %62 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck32 = icmp ne %System.Globalization.CultureData addrspace(1)* %62, null
-  br i1 %NullCheck32, label %63, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Globalization.CultureData addrspace(1)* %62, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %62, i32 0, i32 34
   %65 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %64, align 8
-  %NullCheck34 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %61, null
-  br i1 %NullCheck34, label %66, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %61, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %61, i32 0, i32 9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %67, %System.String addrspace(1)* %65)
   %68 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %69 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck36 = icmp ne %System.Globalization.CultureData addrspace(1)* %69, null
-  br i1 %NullCheck36, label %70, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Globalization.CultureData addrspace(1)* %69, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %70
 
 ; <label>:70                                      ; preds = %66
   %71 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %69, i32 0, i32 55
   %72 = load i32, i32 addrspace(1)* %71, align 8
-  %NullCheck38 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %68, null
-  br i1 %NullCheck38, label %73, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %68, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %68, i32 0, i32 22
   store i32 %72, i32 addrspace(1)* %74
   %75 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %76 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck40 = icmp ne %System.Globalization.CultureData addrspace(1)* %76, null
-  br i1 %NullCheck40, label %77, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Globalization.CultureData addrspace(1)* %76, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %76, i32 0, i32 57
   %79 = load i32, i32 addrspace(1)* %78, align 8
-  %NullCheck42 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %75, null
-  br i1 %NullCheck42, label %80, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %75, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %80
 
 ; <label>:80                                      ; preds = %77
   %81 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %75, i32 0, i32 24
   store i32 %79, i32 addrspace(1)* %81
   %82 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %83 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck44 = icmp ne %System.Globalization.CultureData addrspace(1)* %83, null
-  br i1 %NullCheck44, label %84, label %ThrowNullRef43
+  %NullCheck43 = icmp eq %System.Globalization.CultureData addrspace(1)* %83, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %84
 
 ; <label>:84                                      ; preds = %80
   %85 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %83, i32 0, i32 56
   %86 = load i32, i32 addrspace(1)* %85, align 8
-  %NullCheck46 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %82, null
-  br i1 %NullCheck46, label %87, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %82, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %82, i32 0, i32 23
@@ -13570,8 +15279,8 @@ entry:
 
 ; <label>:89                                      ; preds = %entry
   %90 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck100 = icmp ne %System.Globalization.CultureData addrspace(1)* %90, null
-  br i1 %NullCheck100, label %91, label %ThrowNullRef99
+  %NullCheck99 = icmp eq %System.Globalization.CultureData addrspace(1)* %90, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %91
 
 ; <label>:91                                      ; preds = %89
   %92 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %90, i32 0, i32 2
@@ -13589,8 +15298,8 @@ entry:
   %102 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %103 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %104 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %103)
-  %NullCheck48 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %102, null
-  br i1 %NullCheck48, label %105, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %102, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %105
 
 ; <label>:105                                     ; preds = %101
   %106 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %102, i32 0, i32 1
@@ -13598,8 +15307,8 @@ entry:
   %107 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %108 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %109 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %108)
-  %NullCheck50 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %107, null
-  br i1 %NullCheck50, label %110, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %107, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %110
 
 ; <label>:110                                     ; preds = %105
   %111 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %107, i32 0, i32 2
@@ -13607,8 +15316,8 @@ entry:
   %112 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %113 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %114 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %113)
-  %NullCheck52 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %112, null
-  br i1 %NullCheck52, label %115, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %112, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %115
 
 ; <label>:115                                     ; preds = %110
   %116 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %112, i32 0, i32 27
@@ -13616,8 +15325,8 @@ entry:
   %117 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %118 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %119 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %118)
-  %NullCheck54 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %117, null
-  br i1 %NullCheck54, label %120, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %117, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %120
 
 ; <label>:120                                     ; preds = %115
   %121 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %117, i32 0, i32 26
@@ -13625,8 +15334,8 @@ entry:
   %122 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %123 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %124 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %123)
-  %NullCheck56 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %122, null
-  br i1 %NullCheck56, label %125, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %122, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %125
 
 ; <label>:125                                     ; preds = %120
   %126 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %122, i32 0, i32 17
@@ -13634,8 +15343,8 @@ entry:
   %127 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %128 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %129 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %128)
-  %NullCheck58 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %127, null
-  br i1 %NullCheck58, label %130, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %127, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %130
 
 ; <label>:130                                     ; preds = %125
   %131 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %127, i32 0, i32 18
@@ -13643,8 +15352,8 @@ entry:
   %132 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %133 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %134 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %133)
-  %NullCheck60 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %132, null
-  br i1 %NullCheck60, label %135, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %132, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %135
 
 ; <label>:135                                     ; preds = %130
   %136 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %132, i32 0, i32 14
@@ -13652,8 +15361,8 @@ entry:
   %137 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %138 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %139 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %138)
-  %NullCheck62 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %137, null
-  br i1 %NullCheck62, label %140, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %137, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %140
 
 ; <label>:140                                     ; preds = %135
   %141 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %137, i32 0, i32 13
@@ -13661,71 +15370,71 @@ entry:
   %142 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %143 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %144 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %143)
-  %NullCheck64 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %142, null
-  br i1 %NullCheck64, label %145, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %142, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %145
 
 ; <label>:145                                     ; preds = %140
   %146 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %142, i32 0, i32 12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %146, %System.String addrspace(1)* %144)
   %147 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %148 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck66 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %148, null
-  br i1 %NullCheck66, label %149, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %148, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %149
 
 ; <label>:149                                     ; preds = %145
   %150 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %148, i32 0, i32 21
   %151 = load i32, i32 addrspace(1)* %150, align 8
-  %NullCheck68 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %147, null
-  br i1 %NullCheck68, label %152, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %147, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %152
 
 ; <label>:152                                     ; preds = %149
   %153 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %147, i32 0, i32 28
   store i32 %151, i32 addrspace(1)* %153
   %154 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %155 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck70 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %155, null
-  br i1 %NullCheck70, label %156, label %ThrowNullRef69
+  %NullCheck69 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %155, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %156
 
 ; <label>:156                                     ; preds = %152
   %157 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %155, i32 0, i32 6
   %158 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %157, align 8
-  %NullCheck72 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %154, null
-  br i1 %NullCheck72, label %159, label %ThrowNullRef71
+  %NullCheck71 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %154, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %159
 
 ; <label>:159                                     ; preds = %156
   %160 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %154, i32 0, i32 15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %160, %System.String addrspace(1)* %158)
   %161 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %162 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck74 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %162, null
-  br i1 %NullCheck74, label %163, label %ThrowNullRef73
+  %NullCheck73 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %162, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %163
 
 ; <label>:163                                     ; preds = %159
   %164 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %162, i32 0, i32 1
   %165 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %164, align 8
-  %NullCheck76 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %161, null
-  br i1 %NullCheck76, label %166, label %ThrowNullRef75
+  %NullCheck75 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %161, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %166
 
 ; <label>:166                                     ; preds = %163
   %167 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %161, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %167, %"System.Int32[]" addrspace(1)* %165)
   %168 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %169 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck78 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %169, null
-  br i1 %NullCheck78, label %170, label %ThrowNullRef77
+  %NullCheck77 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %169, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %170
 
 ; <label>:170                                     ; preds = %166
   %171 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %169, i32 0, i32 7
   %172 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %171, align 8
-  %NullCheck80 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %168, null
-  br i1 %NullCheck80, label %173, label %ThrowNullRef79
+  %NullCheck79 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %168, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %173
 
 ; <label>:173                                     ; preds = %170
   %174 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %168, i32 0, i32 16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %174, %System.String addrspace(1)* %172)
   %175 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck82 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %175, null
-  br i1 %NullCheck82, label %176, label %ThrowNullRef81
+  %NullCheck81 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %175, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %176
 
 ; <label>:176                                     ; preds = %173
   %177 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %175, i32 0, i32 4
@@ -13735,14 +15444,14 @@ entry:
 
 ; <label>:180                                     ; preds = %176
   %181 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck84 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %181, null
-  br i1 %NullCheck84, label %182, label %ThrowNullRef83
+  %NullCheck83 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %181, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %182
 
 ; <label>:182                                     ; preds = %180
   %183 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %181, i32 0, i32 4
   %184 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %183, align 8
-  %NullCheck86 = icmp ne %System.String addrspace(1)* %184, null
-  br i1 %NullCheck86, label %185, label %ThrowNullRef85
+  %NullCheck85 = icmp eq %System.String addrspace(1)* %184, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %185
 
 ; <label>:185                                     ; preds = %182
   %186 = getelementptr inbounds %System.String, %System.String addrspace(1)* %184, i32 0, i32 1
@@ -13753,8 +15462,8 @@ entry:
 ; <label>:189                                     ; preds = %176, %185
   %190 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck98 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %190, null
-  br i1 %NullCheck98, label %192, label %ThrowNullRef97
+  %NullCheck97 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %190, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %192
 
 ; <label>:192                                     ; preds = %189
   %193 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %190, i32 0, i32 4
@@ -13763,8 +15472,8 @@ entry:
 
 ; <label>:194                                     ; preds = %185, %192
   %195 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck88 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %195, null
-  br i1 %NullCheck88, label %196, label %ThrowNullRef87
+  %NullCheck87 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %195, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %196
 
 ; <label>:196                                     ; preds = %194
   %197 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %195, i32 0, i32 9
@@ -13774,14 +15483,14 @@ entry:
 
 ; <label>:200                                     ; preds = %196
   %201 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck90 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %201, null
-  br i1 %NullCheck90, label %202, label %ThrowNullRef89
+  %NullCheck89 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %201, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %202
 
 ; <label>:202                                     ; preds = %200
   %203 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %201, i32 0, i32 9
   %204 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %203, align 8
-  %NullCheck92 = icmp ne %System.String addrspace(1)* %204, null
-  br i1 %NullCheck92, label %205, label %ThrowNullRef91
+  %NullCheck91 = icmp eq %System.String addrspace(1)* %204, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %205
 
 ; <label>:205                                     ; preds = %202
   %206 = getelementptr inbounds %System.String, %System.String addrspace(1)* %204, i32 0, i32 1
@@ -13792,14 +15501,14 @@ entry:
 ; <label>:209                                     ; preds = %196, %205
   %210 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %211 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck94 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %211, null
-  br i1 %NullCheck94, label %212, label %ThrowNullRef93
+  %NullCheck93 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %211, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %212
 
 ; <label>:212                                     ; preds = %209
   %213 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %211, i32 0, i32 6
   %214 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %213, align 8
-  %NullCheck96 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %210, null
-  br i1 %NullCheck96, label %215, label %ThrowNullRef95
+  %NullCheck95 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %210, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %215
 
 ; <label>:215                                     ; preds = %212
   %216 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %210, i32 0, i32 9
@@ -13813,203 +15522,203 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %17
+ThrowNullRef8:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %21
+ThrowNullRef10:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %24
+ThrowNullRef12:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %28
+ThrowNullRef14:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %31
+ThrowNullRef16:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %35
+ThrowNullRef18:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %38
+ThrowNullRef20:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %42
+ThrowNullRef22:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %45
+ThrowNullRef24:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %49
+ThrowNullRef26:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %52
+ThrowNullRef28:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %56
+ThrowNullRef30:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %59
+ThrowNullRef32:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %63
+ThrowNullRef34:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %66
+ThrowNullRef36:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %70
+ThrowNullRef38:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %73
+ThrowNullRef40:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %77
+ThrowNullRef42:                                   ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %80
+ThrowNullRef44:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %84
+ThrowNullRef46:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %101
+ThrowNullRef48:                                   ; preds = %101
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %105
+ThrowNullRef50:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %110
+ThrowNullRef52:                                   ; preds = %110
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %115
+ThrowNullRef54:                                   ; preds = %115
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %120
+ThrowNullRef56:                                   ; preds = %120
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %125
+ThrowNullRef58:                                   ; preds = %125
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %130
+ThrowNullRef60:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %135
+ThrowNullRef62:                                   ; preds = %135
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %140
+ThrowNullRef64:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %145
+ThrowNullRef66:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %149
+ThrowNullRef68:                                   ; preds = %149
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %152
+ThrowNullRef70:                                   ; preds = %152
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %156
+ThrowNullRef72:                                   ; preds = %156
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %159
+ThrowNullRef74:                                   ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %163
+ThrowNullRef76:                                   ; preds = %163
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %166
+ThrowNullRef78:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %170
+ThrowNullRef80:                                   ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %173
+ThrowNullRef82:                                   ; preds = %173
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %180
+ThrowNullRef84:                                   ; preds = %180
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %182
+ThrowNullRef86:                                   ; preds = %182
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %194
+ThrowNullRef88:                                   ; preds = %194
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %200
+ThrowNullRef90:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %202
+ThrowNullRef92:                                   ; preds = %202
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %209
+ThrowNullRef94:                                   ; preds = %209
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %212
+ThrowNullRef96:                                   ; preds = %212
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %189
+ThrowNullRef98:                                   ; preds = %189
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %89
+ThrowNullRef100:                                  ; preds = %89
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14037,8 +15746,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 21
@@ -14051,8 +15760,8 @@ entry:
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 16)
   %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 21
@@ -14061,8 +15770,8 @@ entry:
 
 ; <label>:12                                      ; preds = %1, %10
   %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 21
@@ -14073,11 +15782,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %12
+ThrowNullRef4:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14093,8 +15802,8 @@ entry:
   store i32 %param1, i32* %arg1
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %1 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
@@ -14161,8 +15870,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 33
@@ -14175,8 +15884,8 @@ entry:
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 24)
   %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 33
@@ -14185,8 +15894,8 @@ entry:
 
 ; <label>:12                                      ; preds = %1, %10
   %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 33
@@ -14197,11 +15906,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %12
+ThrowNullRef4:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14214,8 +15923,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 53
@@ -14227,8 +15936,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 116)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 53
@@ -14237,8 +15946,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 53
@@ -14249,11 +15958,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14282,8 +15991,8 @@ entry:
 
 ; <label>:7                                       ; preds = %entry, %4
   %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %7
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 2
@@ -14307,8 +16016,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 54
@@ -14320,8 +16029,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 117)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
@@ -14330,8 +16039,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 54
@@ -14342,11 +16051,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14359,8 +16068,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 27
@@ -14372,8 +16081,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 118)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 27
@@ -14382,8 +16091,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 27
@@ -14394,11 +16103,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14411,8 +16120,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 28
@@ -14424,8 +16133,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 119)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 28
@@ -14434,8 +16143,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 28
@@ -14446,11 +16155,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14463,8 +16172,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 26
@@ -14476,8 +16185,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 107)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 26
@@ -14486,8 +16195,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 26
@@ -14498,11 +16207,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14515,8 +16224,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 25
@@ -14528,8 +16237,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 106)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 25
@@ -14538,8 +16247,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 25
@@ -14550,11 +16259,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14567,8 +16276,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 24
@@ -14580,8 +16289,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 105)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 24
@@ -14590,8 +16299,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 24
@@ -14602,11 +16311,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14631,8 +16340,8 @@ entry:
   %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %3)
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %2
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -14643,15 +16352,15 @@ entry:
 
 ; <label>:8                                       ; preds = %62
   %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 9
   %12 = load i32, i32 addrspace(1)* %11, align 8
   %13 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.IO.StreamWriter addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %13, i32 0, i32 10
@@ -14666,15 +16375,15 @@ entry:
 
 ; <label>:20                                      ; preds = %14, %18
   %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
   %24 = load i32, i32 addrspace(1)* %23, align 8
   %25 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %25, null
-  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.StreamWriter addrspace(1)* %25, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %25, i32 0, i32 9
@@ -14695,36 +16404,36 @@ entry:
   %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %37 = load i32, i32* %loc1
   %38 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.StreamWriter addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %35
   %40 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %38, i32 0, i32 7
   %41 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %40, align 8
   %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
-  br i1 %NullCheck14, label %43, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %39
   %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 9
   %45 = load i32, i32 addrspace(1)* %44, align 8
   %46 = load i32, i32* %loc2
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %36, null
-  br i1 %NullCheck16, label %47, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %36, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %47
 
 ; <label>:47                                      ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %36, i32 %37, %"System.Char[]" addrspace(1)* %41, i32 %45, i32 %46)
   %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
   %51 = load i32, i32 addrspace(1)* %50, align 8
   %52 = load i32, i32* %loc2
   %53 = add i32 %51, %52
-  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
-  br i1 %NullCheck20, label %54, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %54
 
 ; <label>:54                                      ; preds = %49
   %55 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
@@ -14746,8 +16455,8 @@ entry:
 
 ; <label>:65                                      ; preds = %62
   %66 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %66, null
-  br i1 %NullCheck2, label %67, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %66, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %67
 
 ; <label>:67                                      ; preds = %65
   %68 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %66, i32 0, i32 11
@@ -14768,49 +16477,259 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %65
+ThrowNullRef2:                                    ; preds = %65
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %20
+ThrowNullRef8:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %22
+ThrowNullRef10:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %35
+ThrowNullRef12:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %43
+ThrowNullRef16:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %47
+ThrowNullRef18:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method String::CopyTo using LLILCJit
-Failed to read String.CopyTo[loadElemA]
+Successfully read String.CopyTo
+
+define void @String.CopyTo(%System.String addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  %loc1 = alloca i16 addrspace(1)*
+  %loc2 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %1 = icmp ne %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg4
+  %7 = icmp sge i32 %6, 0
+  br i1 %7, label %13, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  unreachable
+
+; <label>:13                                      ; preds = %5
+  %14 = load i32, i32* %arg1
+  %15 = icmp sge i32 %14, 0
+  br i1 %15, label %21, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %18)
+  %20 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %20, %System.String addrspace(1)* %17, %System.String addrspace(1)* %19)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %20) #0
+  unreachable
+
+; <label>:21                                      ; preds = %13
+  %22 = load i32, i32* %arg4
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck, label %ThrowNullRef, label %24
+
+; <label>:24                                      ; preds = %21
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load i32, i32* %arg1
+  %28 = sub i32 %26, %27
+  %29 = icmp sle i32 %22, %28
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34, %System.String addrspace(1)* %31, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %24
+  %36 = load i32, i32* %arg3
+  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %37, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
+
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
+  %40 = load i32, i32 addrspace(1)* %39
+  %41 = zext i32 %40 to i64
+  %42 = trunc i64 %41 to i32
+  %43 = load i32, i32* %arg4
+  %44 = sub i32 %42, %43
+  %45 = icmp sgt i32 %36, %44
+  br i1 %45, label %49, label %46
+
+; <label>:46                                      ; preds = %38
+  %47 = load i32, i32* %arg3
+  %48 = icmp sge i32 %47, 0
+  br i1 %48, label %54, label %49
+
+; <label>:49                                      ; preds = %38, %46
+  %50 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %52 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %51)
+  %53 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53, %System.String addrspace(1)* %50, %System.String addrspace(1)* %52)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53) #0
+  unreachable
+
+; <label>:54                                      ; preds = %46
+  %55 = load i32, i32* %arg4
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %97, label %57
+
+; <label>:57                                      ; preds = %54
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %59
+
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 2
+  %61 = bitcast [0 x i16] addrspace(1)* %60 to i16 addrspace(1)*
+  store i16 addrspace(1)* %61, i16 addrspace(1)** %loc0
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  store %"System.Char[]" addrspace(1)* %62, %"System.Char[]" addrspace(1)** %loc2
+  %63 = icmp eq %"System.Char[]" addrspace(1)* %62, null
+  br i1 %63, label %72, label %64
+
+; <label>:64                                      ; preds = %59
+  %65 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc2
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %65, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %66
+
+; <label>:66                                      ; preds = %64
+  %67 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %65, i32 0, i32 1
+  %68 = load i32, i32 addrspace(1)* %67
+  %69 = zext i32 %68 to i64
+  %70 = trunc i64 %69 to i32
+  %71 = icmp ne i32 %70, 0
+  br i1 %71, label %73, label %72
+
+; <label>:72                                      ; preds = %59, %66
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  br label %81
+
+; <label>:73                                      ; preds = %66
+  %74 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc2
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %74, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %75
+
+; <label>:75                                      ; preds = %73
+  %76 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %74, i32 0, i32 1
+  %77 = load i32, i32 addrspace(1)* %76
+  %78 = zext i32 %77 to i64
+  %BoundsCheck = icmp uge i64 0, %78
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %79
+
+; <label>:79                                      ; preds = %75
+  %80 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %74, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %80, i16 addrspace(1)** %loc1
+  br label %81
+
+; <label>:81                                      ; preds = %72, %79
+  %82 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %83 = ptrtoint i16 addrspace(1)* %82 to i64
+  %84 = load i32, i32* %arg3
+  %85 = sext i32 %84 to i64
+  %86 = mul i64 %85, 2
+  %87 = add i64 %83, %86
+  %88 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %89 = ptrtoint i16 addrspace(1)* %88 to i64
+  %90 = load i32, i32* %arg1
+  %91 = sext i32 %90 to i64
+  %92 = mul i64 %91, 2
+  %93 = add i64 %89, %92
+  %94 = load i32, i32* %arg4
+  %95 = inttoptr i64 %87 to i16*
+  %96 = inttoptr i64 %93 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %95, i16* %96, i32 %94)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  br label %97
+
+; <label>:97                                      ; preds = %54, %81
+  ret void
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
 Successfully read ConsoleEncoding.GetPreamble
 
@@ -14847,7 +16766,365 @@ entry:
 }
 
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[loadElemA]
+Successfully read EncoderNLS.GetBytes
+
+define i32 @EncoderNLS.GetBytes(%System.Text.EncoderNLS addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3, %"System.Byte[]" addrspace(1)* %param4, i32 %param5, i8 %param6) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %arg4 = alloca %"System.Byte[]" addrspace(1)*
+  %arg5 = alloca i32
+  %arg6 = alloca i8
+  %loc0 = alloca i32
+  %loc1 = alloca i16 addrspace(1)*
+  %loc2 = alloca i8 addrspace(1)*
+  %loc3 = alloca i32
+  %loc4 = alloca %"System.Char[]" addrspace(1)*
+  %loc5 = alloca %"System.Byte[]" addrspace(1)*
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  store %"System.Byte[]" addrspace(1)* %param4, %"System.Byte[]" addrspace(1)** %arg4
+  store i32 %param5, i32* %arg5
+  store i8 %param6, i8* %arg6
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %1 = icmp eq %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %17, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %7 = icmp eq %"System.Char[]" addrspace(1)* %6, null
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %12
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %12
+
+; <label>:12                                      ; preds = %8, %10
+  %13 = phi %System.String addrspace(1)* [ %9, %8 ], [ %11, %10 ]
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %14)
+  %16 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16, %System.String addrspace(1)* %13, %System.String addrspace(1)* %15)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16) #0
+  unreachable
+
+; <label>:17                                      ; preds = %2
+  %18 = load i32, i32* %arg2
+  %19 = icmp slt i32 %18, 0
+  br i1 %19, label %23, label %20
+
+; <label>:20                                      ; preds = %17
+  %21 = load i32, i32* %arg3
+  %22 = icmp sge i32 %21, 0
+  br i1 %22, label %35, label %23
+
+; <label>:23                                      ; preds = %17, %20
+  %24 = load i32, i32* %arg2
+  %25 = icmp slt i32 %24, 0
+  br i1 %25, label %28, label %26
+
+; <label>:26                                      ; preds = %23
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %30
+
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %30
+
+; <label>:30                                      ; preds = %26, %28
+  %31 = phi %System.String addrspace(1)* [ %27, %26 ], [ %29, %28 ]
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34, %System.String addrspace(1)* %31, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %20
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck, label %ThrowNullRef, label %37
+
+; <label>:37                                      ; preds = %35
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = load i32, i32* %arg2
+  %43 = sub i32 %41, %42
+  %44 = load i32, i32* %arg3
+  %45 = icmp sge i32 %43, %44
+  br i1 %45, label %51, label %46
+
+; <label>:46                                      ; preds = %37
+  %47 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %48 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %49 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %48)
+  %50 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %50, %System.String addrspace(1)* %47, %System.String addrspace(1)* %49)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %50) #0
+  unreachable
+
+; <label>:51                                      ; preds = %37
+  %52 = load i32, i32* %arg5
+  %53 = icmp slt i32 %52, 0
+  br i1 %53, label %63, label %54
+
+; <label>:54                                      ; preds = %51
+  %55 = load i32, i32* %arg5
+  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck1 = icmp eq %"System.Byte[]" addrspace(1)* %56, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %57
+
+; <label>:57                                      ; preds = %54
+  %58 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = zext i32 %59 to i64
+  %61 = trunc i64 %60 to i32
+  %62 = icmp sle i32 %55, %61
+  br i1 %62, label %68, label %63
+
+; <label>:63                                      ; preds = %51, %57
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %66 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %65)
+  %67 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %67, %System.String addrspace(1)* %64, %System.String addrspace(1)* %66)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %67) #0
+  unreachable
+
+; <label>:68                                      ; preds = %57
+  %69 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %69, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %69, i32 0, i32 1
+  %72 = load i32, i32 addrspace(1)* %71
+  %73 = zext i32 %72 to i64
+  %74 = trunc i64 %73 to i32
+  %75 = icmp ne i32 %74, 0
+  br i1 %75, label %78, label %76
+
+; <label>:76                                      ; preds = %70
+  %77 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1)
+  store %"System.Char[]" addrspace(1)* %77, %"System.Char[]" addrspace(1)** %arg1
+  br label %78
+
+; <label>:78                                      ; preds = %70, %76
+  %79 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck5 = icmp eq %"System.Byte[]" addrspace(1)* %79, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %80
+
+; <label>:80                                      ; preds = %78
+  %81 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %79, i32 0, i32 1
+  %82 = load i32, i32 addrspace(1)* %81
+  %83 = zext i32 %82 to i64
+  %84 = trunc i64 %83 to i32
+  %85 = load i32, i32* %arg5
+  %86 = sub i32 %84, %85
+  store i32 %86, i32* %loc0
+  %87 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck7 = icmp eq %"System.Byte[]" addrspace(1)* %87, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %88
+
+; <label>:88                                      ; preds = %80
+  %89 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %87, i32 0, i32 1
+  %90 = load i32, i32 addrspace(1)* %89
+  %91 = zext i32 %90 to i64
+  %92 = trunc i64 %91 to i32
+  %93 = icmp ne i32 %92, 0
+  br i1 %93, label %96, label %94
+
+; <label>:94                                      ; preds = %88
+  %95 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1)
+  store %"System.Byte[]" addrspace(1)* %95, %"System.Byte[]" addrspace(1)** %arg4
+  br label %96
+
+; <label>:96                                      ; preds = %88, %94
+  %97 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  store %"System.Char[]" addrspace(1)* %97, %"System.Char[]" addrspace(1)** %loc4
+  %98 = icmp eq %"System.Char[]" addrspace(1)* %97, null
+  br i1 %98, label %107, label %99
+
+; <label>:99                                      ; preds = %96
+  %100 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc4
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %100, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %101
+
+; <label>:101                                     ; preds = %99
+  %102 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %100, i32 0, i32 1
+  %103 = load i32, i32 addrspace(1)* %102
+  %104 = zext i32 %103 to i64
+  %105 = trunc i64 %104 to i32
+  %106 = icmp ne i32 %105, 0
+  br i1 %106, label %108, label %107
+
+; <label>:107                                     ; preds = %96, %101
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  br label %116
+
+; <label>:108                                     ; preds = %101
+  %109 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc4
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %109, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %110
+
+; <label>:110                                     ; preds = %108
+  %111 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %109, i32 0, i32 1
+  %112 = load i32, i32 addrspace(1)* %111
+  %113 = zext i32 %112 to i64
+  %BoundsCheck = icmp uge i64 0, %113
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %114
+
+; <label>:114                                     ; preds = %110
+  %115 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %109, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %115, i16 addrspace(1)** %loc1
+  br label %116
+
+; <label>:116                                     ; preds = %107, %114
+  %117 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  store %"System.Byte[]" addrspace(1)* %117, %"System.Byte[]" addrspace(1)** %loc5
+  %118 = icmp eq %"System.Byte[]" addrspace(1)* %117, null
+  br i1 %118, label %127, label %119
+
+; <label>:119                                     ; preds = %116
+  %120 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc5
+  %NullCheck13 = icmp eq %"System.Byte[]" addrspace(1)* %120, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %121
+
+; <label>:121                                     ; preds = %119
+  %122 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %120, i32 0, i32 1
+  %123 = load i32, i32 addrspace(1)* %122
+  %124 = zext i32 %123 to i64
+  %125 = trunc i64 %124 to i32
+  %126 = icmp ne i32 %125, 0
+  br i1 %126, label %128, label %127
+
+; <label>:127                                     ; preds = %116, %121
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc2
+  br label %136
+
+; <label>:128                                     ; preds = %121
+  %129 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc5
+  %NullCheck15 = icmp eq %"System.Byte[]" addrspace(1)* %129, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %130
+
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %129, i32 0, i32 1
+  %132 = load i32, i32 addrspace(1)* %131
+  %133 = zext i32 %132 to i64
+  %BoundsCheck17 = icmp uge i64 0, %133
+  br i1 %BoundsCheck17, label %ThrowIndexOutOfRange18, label %134
+
+; <label>:134                                     ; preds = %130
+  %135 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %129, i32 0, i32 3, i32 0
+  store i8 addrspace(1)* %135, i8 addrspace(1)** %loc2
+  br label %136
+
+; <label>:136                                     ; preds = %127, %134
+  %137 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %138 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %139 = ptrtoint i16 addrspace(1)* %138 to i64
+  %140 = load i32, i32* %arg2
+  %141 = sext i32 %140 to i64
+  %142 = mul i64 %141, 2
+  %143 = add i64 %139, %142
+  %144 = load i32, i32* %arg3
+  %145 = load i8 addrspace(1)*, i8 addrspace(1)** %loc2
+  %146 = ptrtoint i8 addrspace(1)* %145 to i64
+  %147 = load i32, i32* %arg5
+  %148 = sext i32 %147 to i64
+  %149 = add i64 %146, %148
+  %150 = load i32, i32* %loc0
+  %151 = load i8, i8* %arg6
+  %152 = zext i8 %151 to i32
+  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i64 addrspace(1)*
+  %NullCheck19 = icmp eq i64 addrspace(1)* %153, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %154
+
+; <label>:154                                     ; preds = %136
+  %155 = load i64, i64 addrspace(1)* %153
+  %156 = add i64 %155, 72
+  %157 = inttoptr i64 %156 to i64*
+  %158 = load i64, i64* %157
+  %159 = add i64 %158, 0
+  %160 = inttoptr i64 %159 to i64*
+  %161 = load i64, i64* %160
+  %162 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to %System.Text.Encoder addrspace(1)*
+  %163 = inttoptr i64 %143 to i16*
+  %164 = inttoptr i64 %149 to i8*
+  %165 = trunc i32 %152 to i8
+  %166 = inttoptr i64 %161 to i32 (%System.Text.Encoder addrspace(1)*, i16*, i32, i8*, i32, i8)*
+  %167 = call i32 %166(%System.Text.Encoder addrspace(1)* %162, i16* %163, i32 %144, i8* %164, i32 %150, i8 %165)
+  store i32 %167, i32* %loc3
+  br label %168
+
+; <label>:168                                     ; preds = %154
+  %169 = load i32, i32* %loc3
+  ret i32 %169
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %110
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %119
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange18:                           ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
 Successfully read EncoderNLS.GetBytes
 
@@ -14936,22 +17213,22 @@ entry:
   %40 = load i8, i8* %arg5
   %41 = zext i8 %40 to i32
   %42 = trunc i32 %41 to i8
-  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %39, null
-  br i1 %NullCheck, label %43, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderNLS addrspace(1)* %39, null
+  br i1 %NullCheck, label %ThrowNullRef, label %43
 
 ; <label>:43                                      ; preds = %38
   %44 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
   store i8 %42, i8 addrspace(1)* %44
   %45 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %45, null
-  br i1 %NullCheck2, label %46, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.EncoderNLS addrspace(1)* %45, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %46
 
 ; <label>:46                                      ; preds = %43
   %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %45, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %47
   %48 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.EncoderNLS addrspace(1)* %48, null
-  br i1 %NullCheck4, label %49, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.EncoderNLS addrspace(1)* %48, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %49
 
 ; <label>:49                                      ; preds = %46
   %50 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %48, i32 0, i32 3
@@ -14962,8 +17239,8 @@ entry:
   %55 = load i32, i32* %arg4
   %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck6, label %58, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
   %59 = load i64, i64 addrspace(1)* %57
@@ -14981,15 +17258,15 @@ ThrowNullRef:                                     ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %43
+ThrowNullRef2:                                    ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %46
+ThrowNullRef4:                                    ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %49
+ThrowNullRef6:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -15017,8 +17294,8 @@ entry:
   %4 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0 to %System.IO.ConsoleStream addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*)(%System.IO.ConsoleStream addrspace(1)* %4, %"System.Byte[]" addrspace(1)* %1, i32 %2, i32 %3)
   %5 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
@@ -15103,8 +17380,8 @@ entry:
 
 ; <label>:22                                      ; preds = %8
   %23 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %23, null
-  br i1 %NullCheck, label %24, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Byte[]" addrspace(1)* %23, null
+  br i1 %NullCheck, label %ThrowNullRef, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
@@ -15126,8 +17403,8 @@ entry:
 
 ; <label>:36                                      ; preds = %24
   %37 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %37, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.ConsoleStream addrspace(1)* %37, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %37, i32 0, i32 4
@@ -15148,13 +17425,138 @@ ThrowNullRef:                                     ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %36
+ThrowNullRef2:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
-Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
+Successfully read WindowsConsoleStream.WriteFileNative
+
+define i32 @WindowsConsoleStream.WriteFileNative(i64 %param0, %"System.Byte[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i64
+  %arg1 = alloca %"System.Byte[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i8 addrspace(1)*
+  %loc2 = alloca %"System.Byte[]" addrspace(1)*
+  %loc3 = alloca i32
+  store i64 %param0, i64* %arg0
+  store %"System.Byte[]" addrspace(1)* %param1, %"System.Byte[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Byte[]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = zext i32 %3 to i64
+  %5 = icmp ne i64 %4, 0
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %1
+  ret i32 0
+
+; <label>:7                                       ; preds = %1
+  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  store %"System.Byte[]" addrspace(1)* %8, %"System.Byte[]" addrspace(1)** %loc2
+  %9 = icmp eq %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %9, label %18, label %10
+
+; <label>:10                                      ; preds = %7
+  %11 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc2
+  %NullCheck1 = icmp eq %"System.Byte[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %11, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp ne i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %7, %12
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc1
+  br label %27
+
+; <label>:19                                      ; preds = %12
+  %20 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc2
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %20, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %BoundsCheck = icmp uge i64 0, %24
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %25
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %20, i32 0, i32 3, i32 0
+  store i8 addrspace(1)* %26, i8 addrspace(1)** %loc1
+  br label %27
+
+; <label>:27                                      ; preds = %18, %25
+  %28 = load i64, i64* %arg0
+  %29 = load i8 addrspace(1)*, i8 addrspace(1)** %loc1
+  %30 = ptrtoint i8 addrspace(1)* %29 to i64
+  %31 = load i32, i32* %arg2
+  %32 = sext i32 %31 to i64
+  %33 = add i64 %30, %32
+  %34 = load i32, i32* %arg3
+  %35 = addrspacecast i32* %loc3 to i32 addrspace(1)*
+  %36 = inttoptr i64 %33 to i8*
+  %37 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i8*, i32, i32 addrspace(1)*, i64)*)(i64 %28, i8* %36, i32 %34, i32 addrspace(1)* %35, i64 0)
+  %38 = icmp ugt i32 %37, 0
+  %39 = sext i1 %38 to i32
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc1
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %42, label %41
+
+; <label>:41                                      ; preds = %27
+  ret i32 0
+
+; <label>:42                                      ; preds = %27
+  %43 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  store i32 %43, i32* %loc0
+  %44 = load i32, i32* %loc0
+  %45 = icmp eq i32 %44, 232
+  br i1 %45, label %49, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = load i32, i32* %loc0
+  %48 = icmp ne i32 %47, 109
+  br i1 %48, label %50, label %49
+
+; <label>:49                                      ; preds = %42, %46
+  ret i32 0
+
+; <label>:50                                      ; preds = %46
+  %51 = load i32, i32* %loc0
+  ret i32 %51
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
 Successfully read WindowsConsoleStream.Flush
 
@@ -15163,8 +17565,8 @@ entry:
   %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
   store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
@@ -15199,8 +17601,8 @@ entry:
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
   %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load i64, i64 addrspace(1)* %1
@@ -15239,15 +17641,15 @@ entry:
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.TextWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
   %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %3, align 8
   %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
   %7 = load i64, i64 addrspace(1)* %5
@@ -15265,7 +17667,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -15294,8 +17696,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %4)
   store i32 0, i32* %loc0
   %5 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Char[]" addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
@@ -15307,15 +17709,15 @@ entry:
 
 ; <label>:11                                      ; preds = %69
   %12 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %12, i32 0, i32 9
   %15 = load i32, i32 addrspace(1)* %14, align 8
   %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.IO.StreamWriter addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %16, i32 0, i32 10
@@ -15330,15 +17732,15 @@ entry:
 
 ; <label>:23                                      ; preds = %17, %21
   %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %24, null
-  br i1 %NullCheck8, label %25, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %24, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 10
   %27 = load i32, i32 addrspace(1)* %26, align 8
   %28 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %28, null
-  br i1 %NullCheck10, label %29, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.StreamWriter addrspace(1)* %28, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %28, i32 0, i32 9
@@ -15360,15 +17762,15 @@ entry:
   %40 = load i32, i32* %loc0
   %41 = mul i32 %40, 2
   %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
-  br i1 %NullCheck12, label %43, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %43
 
 ; <label>:43                                      ; preds = %38
   %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 7
   %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %44, align 8
   %46 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %46, null
-  br i1 %NullCheck14, label %47, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.IO.StreamWriter addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %47
 
 ; <label>:47                                      ; preds = %43
   %48 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %46, i32 0, i32 9
@@ -15380,16 +17782,16 @@ entry:
   %54 = bitcast %"System.Char[]" addrspace(1)* %45 to %System.Array addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %53, i32 %41, %System.Array addrspace(1)* %54, i32 %50, i32 %52)
   %55 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
-  br i1 %NullCheck16, label %56, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %56
 
 ; <label>:56                                      ; preds = %47
   %57 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
   %58 = load i32, i32 addrspace(1)* %57, align 8
   %59 = load i32, i32* %loc2
   %60 = add i32 %58, %59
-  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
-  br i1 %NullCheck18, label %61, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %61
 
 ; <label>:61                                      ; preds = %56
   %62 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
@@ -15411,8 +17813,8 @@ entry:
 
 ; <label>:72                                      ; preds = %69
   %73 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %73, null
-  br i1 %NullCheck2, label %74, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %73, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %74
 
 ; <label>:74                                      ; preds = %72
   %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %73, i32 0, i32 11
@@ -15433,39 +17835,39 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %72
+ThrowNullRef2:                                    ; preds = %72
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %23
+ThrowNullRef8:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef10:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %43
+ThrowNullRef14:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %47
+ThrowNullRef16:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %56
+ThrowNullRef18:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPCall2.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPCall2.error.txt
@@ -25,8 +25,8 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
@@ -40,8 +40,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
   %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
@@ -75,7 +75,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -90,8 +90,8 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %NullCheck = icmp ne i8 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = load i8, i8 addrspace(1)* %0, align 8
@@ -125,8 +125,8 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
@@ -159,8 +159,8 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -184,8 +184,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
   store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
@@ -195,8 +195,8 @@ entry:
 ; <label>:4                                       ; preds = %1
   %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
   %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
@@ -206,8 +206,8 @@ entry:
   %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
@@ -221,14 +221,14 @@ entry:
 
 ; <label>:17                                      ; preds = %14
   %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
   %21 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
@@ -238,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -249,8 +249,8 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
@@ -261,27 +261,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %30
+ThrowNullRef10:                                   ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -301,7 +301,89 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
-Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
+Successfully read AppDomainSetup.GetUnsecureApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.GetUnsecureApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %NullCheck = icmp eq %"System.String[]" addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %BoundsCheck = icmp uge i64 0, %5
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %6
+
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 3, i32 0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
+  ret %System.String addrspace(1)* %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_Value using LLILCJit
+Successfully read AppDomainSetup.get_Value
+
+define %"System.String[]" addrspace(1)* @AppDomainSetup.get_Value(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.String[]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 18)
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.String[]" addrspace(1)* addrspace(1)*, %"System.String[]" addrspace(1)*)*)(%"System.String[]" addrspace(1)* addrspace(1)* %9, %"System.String[]" addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %11, i32 0, i32 1
+  %14 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %13, align 8
+  ret %"System.String[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -319,8 +401,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -368,16 +450,16 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
   %5 = load i32, i32 addrspace(1)* %4
   %6 = sub i32 %5, 1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -389,7 +471,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -421,8 +503,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
@@ -456,8 +538,8 @@ entry:
 ; <label>:27                                      ; preds = %19
   %28 = load i32, i32* %arg1
   %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
-  br i1 %NullCheck2, label %30, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %29, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %30
 
 ; <label>:30                                      ; preds = %27
   %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
@@ -493,8 +575,8 @@ entry:
 ; <label>:49                                      ; preds = %46
   %50 = load i32, i32* %arg2
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck4, label %52, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
@@ -517,11 +599,11 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %27
+ThrowNullRef2:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %49
+ThrowNullRef4:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -544,16 +626,16 @@ entry:
   %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %0)
   store %System.String addrspace(1)* %1, %System.String addrspace(1)** %loc0
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 2
   %5 = bitcast [0 x i16] addrspace(1)* %4 to i16 addrspace(1)*
   store i16 addrspace(1)* %5, i16 addrspace(1)** %loc1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %3
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2
@@ -580,7 +662,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -691,15 +773,15 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %NullCheck132 = icmp ne i8* %21, null
-  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+  %NullCheck131 = icmp eq i8* %21, null
+  br i1 %NullCheck131, label %ThrowNullRef132, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = load i8, i8* %21, align 8
   %24 = zext i8 %23 to i32
   %25 = trunc i32 %24 to i8
-  %NullCheck134 = icmp ne i8* %20, null
-  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+  %NullCheck133 = icmp eq i8* %20, null
+  br i1 %NullCheck133, label %ThrowNullRef134, label %26
 
 ; <label>:26                                      ; preds = %22
   store i8 %25, i8* %20, align 8
@@ -709,16 +791,16 @@ entry:
   %28 = load i8*, i8** %arg0
   %29 = load i8*, i8** %arg1
   %30 = bitcast i8* %29 to i16*
-  %NullCheck128 = icmp ne i16* %30, null
-  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+  %NullCheck127 = icmp eq i16* %30, null
+  br i1 %NullCheck127, label %ThrowNullRef128, label %31
 
 ; <label>:31                                      ; preds = %27
   %32 = load i16, i16* %30, align 8
   %33 = sext i16 %32 to i32
   %34 = bitcast i8* %28 to i16*
   %35 = trunc i32 %33 to i16
-  %NullCheck130 = icmp ne i16* %34, null
-  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+  %NullCheck129 = icmp eq i16* %34, null
+  br i1 %NullCheck129, label %ThrowNullRef130, label %36
 
 ; <label>:36                                      ; preds = %31
   store i16 %35, i16* %34, align 8
@@ -728,16 +810,16 @@ entry:
   %38 = load i8*, i8** %arg0
   %39 = load i8*, i8** %arg1
   %40 = bitcast i8* %39 to i16*
-  %NullCheck120 = icmp ne i16* %40, null
-  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+  %NullCheck119 = icmp eq i16* %40, null
+  br i1 %NullCheck119, label %ThrowNullRef120, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i16, i16* %40, align 8
   %43 = sext i16 %42 to i32
   %44 = bitcast i8* %38 to i16*
   %45 = trunc i32 %43 to i16
-  %NullCheck122 = icmp ne i16* %44, null
-  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+  %NullCheck121 = icmp eq i16* %44, null
+  br i1 %NullCheck121, label %ThrowNullRef122, label %46
 
 ; <label>:46                                      ; preds = %41
   store i16 %45, i16* %44, align 8
@@ -745,15 +827,15 @@ entry:
   %48 = getelementptr inbounds i8, i8* %47, i64 2
   %49 = load i8*, i8** %arg1
   %50 = getelementptr inbounds i8, i8* %49, i64 2
-  %NullCheck124 = icmp ne i8* %50, null
-  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+  %NullCheck123 = icmp eq i8* %50, null
+  br i1 %NullCheck123, label %ThrowNullRef124, label %51
 
 ; <label>:51                                      ; preds = %46
   %52 = load i8, i8* %50, align 8
   %53 = zext i8 %52 to i32
   %54 = trunc i32 %53 to i8
-  %NullCheck126 = icmp ne i8* %48, null
-  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+  %NullCheck125 = icmp eq i8* %48, null
+  br i1 %NullCheck125, label %ThrowNullRef126, label %55
 
 ; <label>:55                                      ; preds = %51
   store i8 %54, i8* %48, align 8
@@ -763,14 +845,14 @@ entry:
   %57 = load i8*, i8** %arg0
   %58 = load i8*, i8** %arg1
   %59 = bitcast i8* %58 to i32*
-  %NullCheck116 = icmp ne i32* %59, null
-  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+  %NullCheck115 = icmp eq i32* %59, null
+  br i1 %NullCheck115, label %ThrowNullRef116, label %60
 
 ; <label>:60                                      ; preds = %56
   %61 = load i32, i32* %59, align 8
   %62 = bitcast i8* %57 to i32*
-  %NullCheck118 = icmp ne i32* %62, null
-  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+  %NullCheck117 = icmp eq i32* %62, null
+  br i1 %NullCheck117, label %ThrowNullRef118, label %63
 
 ; <label>:63                                      ; preds = %60
   store i32 %61, i32* %62, align 8
@@ -780,14 +862,14 @@ entry:
   %65 = load i8*, i8** %arg0
   %66 = load i8*, i8** %arg1
   %67 = bitcast i8* %66 to i32*
-  %NullCheck108 = icmp ne i32* %67, null
-  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+  %NullCheck107 = icmp eq i32* %67, null
+  br i1 %NullCheck107, label %ThrowNullRef108, label %68
 
 ; <label>:68                                      ; preds = %64
   %69 = load i32, i32* %67, align 8
   %70 = bitcast i8* %65 to i32*
-  %NullCheck110 = icmp ne i32* %70, null
-  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+  %NullCheck109 = icmp eq i32* %70, null
+  br i1 %NullCheck109, label %ThrowNullRef110, label %71
 
 ; <label>:71                                      ; preds = %68
   store i32 %69, i32* %70, align 8
@@ -795,15 +877,15 @@ entry:
   %73 = getelementptr inbounds i8, i8* %72, i64 4
   %74 = load i8*, i8** %arg1
   %75 = getelementptr inbounds i8, i8* %74, i64 4
-  %NullCheck112 = icmp ne i8* %75, null
-  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+  %NullCheck111 = icmp eq i8* %75, null
+  br i1 %NullCheck111, label %ThrowNullRef112, label %76
 
 ; <label>:76                                      ; preds = %71
   %77 = load i8, i8* %75, align 8
   %78 = zext i8 %77 to i32
   %79 = trunc i32 %78 to i8
-  %NullCheck114 = icmp ne i8* %73, null
-  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+  %NullCheck113 = icmp eq i8* %73, null
+  br i1 %NullCheck113, label %ThrowNullRef114, label %80
 
 ; <label>:80                                      ; preds = %76
   store i8 %79, i8* %73, align 8
@@ -813,14 +895,14 @@ entry:
   %82 = load i8*, i8** %arg0
   %83 = load i8*, i8** %arg1
   %84 = bitcast i8* %83 to i32*
-  %NullCheck100 = icmp ne i32* %84, null
-  br i1 %NullCheck100, label %85, label %ThrowNullRef99
+  %NullCheck99 = icmp eq i32* %84, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %85
 
 ; <label>:85                                      ; preds = %81
   %86 = load i32, i32* %84, align 8
   %87 = bitcast i8* %82 to i32*
-  %NullCheck102 = icmp ne i32* %87, null
-  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+  %NullCheck101 = icmp eq i32* %87, null
+  br i1 %NullCheck101, label %ThrowNullRef102, label %88
 
 ; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
@@ -829,16 +911,16 @@ entry:
   %91 = load i8*, i8** %arg1
   %92 = getelementptr inbounds i8, i8* %91, i64 4
   %93 = bitcast i8* %92 to i16*
-  %NullCheck104 = icmp ne i16* %93, null
-  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+  %NullCheck103 = icmp eq i16* %93, null
+  br i1 %NullCheck103, label %ThrowNullRef104, label %94
 
 ; <label>:94                                      ; preds = %88
   %95 = load i16, i16* %93, align 8
   %96 = sext i16 %95 to i32
   %97 = bitcast i8* %90 to i16*
   %98 = trunc i32 %96 to i16
-  %NullCheck106 = icmp ne i16* %97, null
-  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+  %NullCheck105 = icmp eq i16* %97, null
+  br i1 %NullCheck105, label %ThrowNullRef106, label %99
 
 ; <label>:99                                      ; preds = %94
   store i16 %98, i16* %97, align 8
@@ -848,14 +930,14 @@ entry:
   %101 = load i8*, i8** %arg0
   %102 = load i8*, i8** %arg1
   %103 = bitcast i8* %102 to i32*
-  %NullCheck88 = icmp ne i32* %103, null
-  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+  %NullCheck87 = icmp eq i32* %103, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %104
 
 ; <label>:104                                     ; preds = %100
   %105 = load i32, i32* %103, align 8
   %106 = bitcast i8* %101 to i32*
-  %NullCheck90 = icmp ne i32* %106, null
-  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+  %NullCheck89 = icmp eq i32* %106, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %107
 
 ; <label>:107                                     ; preds = %104
   store i32 %105, i32* %106, align 8
@@ -864,16 +946,16 @@ entry:
   %110 = load i8*, i8** %arg1
   %111 = getelementptr inbounds i8, i8* %110, i64 4
   %112 = bitcast i8* %111 to i16*
-  %NullCheck92 = icmp ne i16* %112, null
-  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+  %NullCheck91 = icmp eq i16* %112, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %113
 
 ; <label>:113                                     ; preds = %107
   %114 = load i16, i16* %112, align 8
   %115 = sext i16 %114 to i32
   %116 = bitcast i8* %109 to i16*
   %117 = trunc i32 %115 to i16
-  %NullCheck94 = icmp ne i16* %116, null
-  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+  %NullCheck93 = icmp eq i16* %116, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %118
 
 ; <label>:118                                     ; preds = %113
   store i16 %117, i16* %116, align 8
@@ -881,15 +963,15 @@ entry:
   %120 = getelementptr inbounds i8, i8* %119, i64 6
   %121 = load i8*, i8** %arg1
   %122 = getelementptr inbounds i8, i8* %121, i64 6
-  %NullCheck96 = icmp ne i8* %122, null
-  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+  %NullCheck95 = icmp eq i8* %122, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %123
 
 ; <label>:123                                     ; preds = %118
   %124 = load i8, i8* %122, align 8
   %125 = zext i8 %124 to i32
   %126 = trunc i32 %125 to i8
-  %NullCheck98 = icmp ne i8* %120, null
-  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+  %NullCheck97 = icmp eq i8* %120, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %127
 
 ; <label>:127                                     ; preds = %123
   store i8 %126, i8* %120, align 8
@@ -899,14 +981,14 @@ entry:
   %129 = load i8*, i8** %arg0
   %130 = load i8*, i8** %arg1
   %131 = bitcast i8* %130 to i64*
-  %NullCheck84 = icmp ne i64* %131, null
-  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+  %NullCheck83 = icmp eq i64* %131, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %132
 
 ; <label>:132                                     ; preds = %128
   %133 = load i64, i64* %131, align 8
   %134 = bitcast i8* %129 to i64*
-  %NullCheck86 = icmp ne i64* %134, null
-  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+  %NullCheck85 = icmp eq i64* %134, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %135
 
 ; <label>:135                                     ; preds = %132
   store i64 %133, i64* %134, align 8
@@ -916,14 +998,14 @@ entry:
   %137 = load i8*, i8** %arg0
   %138 = load i8*, i8** %arg1
   %139 = bitcast i8* %138 to i64*
-  %NullCheck76 = icmp ne i64* %139, null
-  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+  %NullCheck75 = icmp eq i64* %139, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %140
 
 ; <label>:140                                     ; preds = %136
   %141 = load i64, i64* %139, align 8
   %142 = bitcast i8* %137 to i64*
-  %NullCheck78 = icmp ne i64* %142, null
-  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+  %NullCheck77 = icmp eq i64* %142, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %143
 
 ; <label>:143                                     ; preds = %140
   store i64 %141, i64* %142, align 8
@@ -931,15 +1013,15 @@ entry:
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %NullCheck80 = icmp ne i8* %147, null
-  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+  %NullCheck79 = icmp eq i8* %147, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %148
 
 ; <label>:148                                     ; preds = %143
   %149 = load i8, i8* %147, align 8
   %150 = zext i8 %149 to i32
   %151 = trunc i32 %150 to i8
-  %NullCheck82 = icmp ne i8* %145, null
-  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+  %NullCheck81 = icmp eq i8* %145, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %152
 
 ; <label>:152                                     ; preds = %148
   store i8 %151, i8* %145, align 8
@@ -949,14 +1031,14 @@ entry:
   %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
   %156 = bitcast i8* %155 to i64*
-  %NullCheck68 = icmp ne i64* %156, null
-  br i1 %NullCheck68, label %157, label %ThrowNullRef67
+  %NullCheck67 = icmp eq i64* %156, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %157
 
 ; <label>:157                                     ; preds = %153
   %158 = load i64, i64* %156, align 8
   %159 = bitcast i8* %154 to i64*
-  %NullCheck70 = icmp ne i64* %159, null
-  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+  %NullCheck69 = icmp eq i64* %159, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %160
 
 ; <label>:160                                     ; preds = %157
   store i64 %158, i64* %159, align 8
@@ -965,16 +1047,16 @@ entry:
   %163 = load i8*, i8** %arg1
   %164 = getelementptr inbounds i8, i8* %163, i64 8
   %165 = bitcast i8* %164 to i16*
-  %NullCheck72 = icmp ne i16* %165, null
-  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+  %NullCheck71 = icmp eq i16* %165, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %166
 
 ; <label>:166                                     ; preds = %160
   %167 = load i16, i16* %165, align 8
   %168 = sext i16 %167 to i32
   %169 = bitcast i8* %162 to i16*
   %170 = trunc i32 %168 to i16
-  %NullCheck74 = icmp ne i16* %169, null
-  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+  %NullCheck73 = icmp eq i16* %169, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %171
 
 ; <label>:171                                     ; preds = %166
   store i16 %170, i16* %169, align 8
@@ -984,14 +1066,14 @@ entry:
   %173 = load i8*, i8** %arg0
   %174 = load i8*, i8** %arg1
   %175 = bitcast i8* %174 to i64*
-  %NullCheck56 = icmp ne i64* %175, null
-  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+  %NullCheck55 = icmp eq i64* %175, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %176
 
 ; <label>:176                                     ; preds = %172
   %177 = load i64, i64* %175, align 8
   %178 = bitcast i8* %173 to i64*
-  %NullCheck58 = icmp ne i64* %178, null
-  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+  %NullCheck57 = icmp eq i64* %178, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %179
 
 ; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
@@ -1000,16 +1082,16 @@ entry:
   %182 = load i8*, i8** %arg1
   %183 = getelementptr inbounds i8, i8* %182, i64 8
   %184 = bitcast i8* %183 to i16*
-  %NullCheck60 = icmp ne i16* %184, null
-  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+  %NullCheck59 = icmp eq i16* %184, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %185
 
 ; <label>:185                                     ; preds = %179
   %186 = load i16, i16* %184, align 8
   %187 = sext i16 %186 to i32
   %188 = bitcast i8* %181 to i16*
   %189 = trunc i32 %187 to i16
-  %NullCheck62 = icmp ne i16* %188, null
-  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+  %NullCheck61 = icmp eq i16* %188, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %190
 
 ; <label>:190                                     ; preds = %185
   store i16 %189, i16* %188, align 8
@@ -1017,15 +1099,15 @@ entry:
   %192 = getelementptr inbounds i8, i8* %191, i64 10
   %193 = load i8*, i8** %arg1
   %194 = getelementptr inbounds i8, i8* %193, i64 10
-  %NullCheck64 = icmp ne i8* %194, null
-  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+  %NullCheck63 = icmp eq i8* %194, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %195
 
 ; <label>:195                                     ; preds = %190
   %196 = load i8, i8* %194, align 8
   %197 = zext i8 %196 to i32
   %198 = trunc i32 %197 to i8
-  %NullCheck66 = icmp ne i8* %192, null
-  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+  %NullCheck65 = icmp eq i8* %192, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %199
 
 ; <label>:199                                     ; preds = %195
   store i8 %198, i8* %192, align 8
@@ -1035,14 +1117,14 @@ entry:
   %201 = load i8*, i8** %arg0
   %202 = load i8*, i8** %arg1
   %203 = bitcast i8* %202 to i64*
-  %NullCheck48 = icmp ne i64* %203, null
-  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+  %NullCheck47 = icmp eq i64* %203, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %204
 
 ; <label>:204                                     ; preds = %200
   %205 = load i64, i64* %203, align 8
   %206 = bitcast i8* %201 to i64*
-  %NullCheck50 = icmp ne i64* %206, null
-  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+  %NullCheck49 = icmp eq i64* %206, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %207
 
 ; <label>:207                                     ; preds = %204
   store i64 %205, i64* %206, align 8
@@ -1051,14 +1133,14 @@ entry:
   %210 = load i8*, i8** %arg1
   %211 = getelementptr inbounds i8, i8* %210, i64 8
   %212 = bitcast i8* %211 to i32*
-  %NullCheck52 = icmp ne i32* %212, null
-  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+  %NullCheck51 = icmp eq i32* %212, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %213
 
 ; <label>:213                                     ; preds = %207
   %214 = load i32, i32* %212, align 8
   %215 = bitcast i8* %209 to i32*
-  %NullCheck54 = icmp ne i32* %215, null
-  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+  %NullCheck53 = icmp eq i32* %215, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %216
 
 ; <label>:216                                     ; preds = %213
   store i32 %214, i32* %215, align 8
@@ -1068,14 +1150,14 @@ entry:
   %218 = load i8*, i8** %arg0
   %219 = load i8*, i8** %arg1
   %220 = bitcast i8* %219 to i64*
-  %NullCheck36 = icmp ne i64* %220, null
-  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64* %220, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %221
 
 ; <label>:221                                     ; preds = %217
   %222 = load i64, i64* %220, align 8
   %223 = bitcast i8* %218 to i64*
-  %NullCheck38 = icmp ne i64* %223, null
-  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+  %NullCheck37 = icmp eq i64* %223, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %224
 
 ; <label>:224                                     ; preds = %221
   store i64 %222, i64* %223, align 8
@@ -1084,14 +1166,14 @@ entry:
   %227 = load i8*, i8** %arg1
   %228 = getelementptr inbounds i8, i8* %227, i64 8
   %229 = bitcast i8* %228 to i32*
-  %NullCheck40 = icmp ne i32* %229, null
-  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i32* %229, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %230
 
 ; <label>:230                                     ; preds = %224
   %231 = load i32, i32* %229, align 8
   %232 = bitcast i8* %226 to i32*
-  %NullCheck42 = icmp ne i32* %232, null
-  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+  %NullCheck41 = icmp eq i32* %232, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %233
 
 ; <label>:233                                     ; preds = %230
   store i32 %231, i32* %232, align 8
@@ -1099,15 +1181,15 @@ entry:
   %235 = getelementptr inbounds i8, i8* %234, i64 12
   %236 = load i8*, i8** %arg1
   %237 = getelementptr inbounds i8, i8* %236, i64 12
-  %NullCheck44 = icmp ne i8* %237, null
-  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i8* %237, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %238
 
 ; <label>:238                                     ; preds = %233
   %239 = load i8, i8* %237, align 8
   %240 = zext i8 %239 to i32
   %241 = trunc i32 %240 to i8
-  %NullCheck46 = icmp ne i8* %235, null
-  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+  %NullCheck45 = icmp eq i8* %235, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %242
 
 ; <label>:242                                     ; preds = %238
   store i8 %241, i8* %235, align 8
@@ -1117,14 +1199,14 @@ entry:
   %244 = load i8*, i8** %arg0
   %245 = load i8*, i8** %arg1
   %246 = bitcast i8* %245 to i64*
-  %NullCheck24 = icmp ne i64* %246, null
-  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64* %246, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %247
 
 ; <label>:247                                     ; preds = %243
   %248 = load i64, i64* %246, align 8
   %249 = bitcast i8* %244 to i64*
-  %NullCheck26 = icmp ne i64* %249, null
-  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64* %249, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %250
 
 ; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
@@ -1133,14 +1215,14 @@ entry:
   %253 = load i8*, i8** %arg1
   %254 = getelementptr inbounds i8, i8* %253, i64 8
   %255 = bitcast i8* %254 to i32*
-  %NullCheck28 = icmp ne i32* %255, null
-  br i1 %NullCheck28, label %256, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i32* %255, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %256
 
 ; <label>:256                                     ; preds = %250
   %257 = load i32, i32* %255, align 8
   %258 = bitcast i8* %252 to i32*
-  %NullCheck30 = icmp ne i32* %258, null
-  br i1 %NullCheck30, label %259, label %ThrowNullRef29
+  %NullCheck29 = icmp eq i32* %258, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %259
 
 ; <label>:259                                     ; preds = %256
   store i32 %257, i32* %258, align 8
@@ -1149,16 +1231,16 @@ entry:
   %262 = load i8*, i8** %arg1
   %263 = getelementptr inbounds i8, i8* %262, i64 12
   %264 = bitcast i8* %263 to i16*
-  %NullCheck32 = icmp ne i16* %264, null
-  br i1 %NullCheck32, label %265, label %ThrowNullRef31
+  %NullCheck31 = icmp eq i16* %264, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %265
 
 ; <label>:265                                     ; preds = %259
   %266 = load i16, i16* %264, align 8
   %267 = sext i16 %266 to i32
   %268 = bitcast i8* %261 to i16*
   %269 = trunc i32 %267 to i16
-  %NullCheck34 = icmp ne i16* %268, null
-  br i1 %NullCheck34, label %270, label %ThrowNullRef33
+  %NullCheck33 = icmp eq i16* %268, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %270
 
 ; <label>:270                                     ; preds = %265
   store i16 %269, i16* %268, align 8
@@ -1168,14 +1250,14 @@ entry:
   %272 = load i8*, i8** %arg0
   %273 = load i8*, i8** %arg1
   %274 = bitcast i8* %273 to i64*
-  %NullCheck8 = icmp ne i64* %274, null
-  br i1 %NullCheck8, label %275, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64* %274, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %275
 
 ; <label>:275                                     ; preds = %271
   %276 = load i64, i64* %274, align 8
   %277 = bitcast i8* %272 to i64*
-  %NullCheck10 = icmp ne i64* %277, null
-  br i1 %NullCheck10, label %278, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %277, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %278
 
 ; <label>:278                                     ; preds = %275
   store i64 %276, i64* %277, align 8
@@ -1184,14 +1266,14 @@ entry:
   %281 = load i8*, i8** %arg1
   %282 = getelementptr inbounds i8, i8* %281, i64 8
   %283 = bitcast i8* %282 to i32*
-  %NullCheck12 = icmp ne i32* %283, null
-  br i1 %NullCheck12, label %284, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i32* %283, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %284
 
 ; <label>:284                                     ; preds = %278
   %285 = load i32, i32* %283, align 8
   %286 = bitcast i8* %280 to i32*
-  %NullCheck14 = icmp ne i32* %286, null
-  br i1 %NullCheck14, label %287, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i32* %286, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %287
 
 ; <label>:287                                     ; preds = %284
   store i32 %285, i32* %286, align 8
@@ -1200,16 +1282,16 @@ entry:
   %290 = load i8*, i8** %arg1
   %291 = getelementptr inbounds i8, i8* %290, i64 12
   %292 = bitcast i8* %291 to i16*
-  %NullCheck16 = icmp ne i16* %292, null
-  br i1 %NullCheck16, label %293, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i16* %292, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %293
 
 ; <label>:293                                     ; preds = %287
   %294 = load i16, i16* %292, align 8
   %295 = sext i16 %294 to i32
   %296 = bitcast i8* %289 to i16*
   %297 = trunc i32 %295 to i16
-  %NullCheck18 = icmp ne i16* %296, null
-  br i1 %NullCheck18, label %298, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i16* %296, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %298
 
 ; <label>:298                                     ; preds = %293
   store i16 %297, i16* %296, align 8
@@ -1217,15 +1299,15 @@ entry:
   %300 = getelementptr inbounds i8, i8* %299, i64 14
   %301 = load i8*, i8** %arg1
   %302 = getelementptr inbounds i8, i8* %301, i64 14
-  %NullCheck20 = icmp ne i8* %302, null
-  br i1 %NullCheck20, label %303, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i8* %302, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %303
 
 ; <label>:303                                     ; preds = %298
   %304 = load i8, i8* %302, align 8
   %305 = zext i8 %304 to i32
   %306 = trunc i32 %305 to i8
-  %NullCheck22 = icmp ne i8* %300, null
-  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i8* %300, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %307
 
 ; <label>:307                                     ; preds = %303
   store i8 %306, i8* %300, align 8
@@ -1235,14 +1317,14 @@ entry:
   %309 = load i8*, i8** %arg0
   %310 = load i8*, i8** %arg1
   %311 = bitcast i8* %310 to i64*
-  %NullCheck = icmp ne i64* %311, null
-  br i1 %NullCheck, label %312, label %ThrowNullRef
+  %NullCheck = icmp eq i64* %311, null
+  br i1 %NullCheck, label %ThrowNullRef, label %312
 
 ; <label>:312                                     ; preds = %308
   %313 = load i64, i64* %311, align 8
   %314 = bitcast i8* %309 to i64*
-  %NullCheck2 = icmp ne i64* %314, null
-  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64* %314, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %315
 
 ; <label>:315                                     ; preds = %312
   store i64 %313, i64* %314, align 8
@@ -1251,14 +1333,14 @@ entry:
   %318 = load i8*, i8** %arg1
   %319 = getelementptr inbounds i8, i8* %318, i64 8
   %320 = bitcast i8* %319 to i64*
-  %NullCheck4 = icmp ne i64* %320, null
-  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64* %320, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %321
 
 ; <label>:321                                     ; preds = %315
   %322 = load i64, i64* %320, align 8
   %323 = bitcast i8* %317 to i64*
-  %NullCheck6 = icmp ne i64* %323, null
-  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64* %323, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %324
 
 ; <label>:324                                     ; preds = %321
   store i64 %322, i64* %323, align 8
@@ -1286,15 +1368,15 @@ entry:
 ; <label>:338                                     ; preds = %333
   %339 = load i8*, i8** %arg0
   %340 = load i8*, i8** %arg1
-  %NullCheck136 = icmp ne i8* %340, null
-  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+  %NullCheck135 = icmp eq i8* %340, null
+  br i1 %NullCheck135, label %ThrowNullRef136, label %341
 
 ; <label>:341                                     ; preds = %338
   %342 = load i8, i8* %340, align 8
   %343 = zext i8 %342 to i32
   %344 = trunc i32 %343 to i8
-  %NullCheck138 = icmp ne i8* %339, null
-  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+  %NullCheck137 = icmp eq i8* %339, null
+  br i1 %NullCheck137, label %ThrowNullRef138, label %345
 
 ; <label>:345                                     ; preds = %341
   store i8 %344, i8* %339, align 8
@@ -1317,16 +1399,16 @@ entry:
   %357 = load i8*, i8** %arg0
   %358 = load i8*, i8** %arg1
   %359 = bitcast i8* %358 to i16*
-  %NullCheck140 = icmp ne i16* %359, null
-  br i1 %NullCheck140, label %360, label %ThrowNullRef139
+  %NullCheck139 = icmp eq i16* %359, null
+  br i1 %NullCheck139, label %ThrowNullRef140, label %360
 
 ; <label>:360                                     ; preds = %356
   %361 = load i16, i16* %359, align 8
   %362 = sext i16 %361 to i32
   %363 = bitcast i8* %357 to i16*
   %364 = trunc i32 %362 to i16
-  %NullCheck142 = icmp ne i16* %363, null
-  br i1 %NullCheck142, label %365, label %ThrowNullRef141
+  %NullCheck141 = icmp eq i16* %363, null
+  br i1 %NullCheck141, label %ThrowNullRef142, label %365
 
 ; <label>:365                                     ; preds = %360
   store i16 %364, i16* %363, align 8
@@ -1352,14 +1434,14 @@ entry:
   %378 = load i8*, i8** %arg0
   %379 = load i8*, i8** %arg1
   %380 = bitcast i8* %379 to i32*
-  %NullCheck144 = icmp ne i32* %380, null
-  br i1 %NullCheck144, label %381, label %ThrowNullRef143
+  %NullCheck143 = icmp eq i32* %380, null
+  br i1 %NullCheck143, label %ThrowNullRef144, label %381
 
 ; <label>:381                                     ; preds = %377
   %382 = load i32, i32* %380, align 8
   %383 = bitcast i8* %378 to i32*
-  %NullCheck146 = icmp ne i32* %383, null
-  br i1 %NullCheck146, label %384, label %ThrowNullRef145
+  %NullCheck145 = icmp eq i32* %383, null
+  br i1 %NullCheck145, label %ThrowNullRef146, label %384
 
 ; <label>:384                                     ; preds = %381
   store i32 %382, i32* %383, align 8
@@ -1384,14 +1466,14 @@ entry:
   %395 = load i8*, i8** %arg0
   %396 = load i8*, i8** %arg1
   %397 = bitcast i8* %396 to i64*
-  %NullCheck164 = icmp ne i64* %397, null
-  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+  %NullCheck163 = icmp eq i64* %397, null
+  br i1 %NullCheck163, label %ThrowNullRef164, label %398
 
 ; <label>:398                                     ; preds = %394
   %399 = load i64, i64* %397, align 8
   %400 = bitcast i8* %395 to i64*
-  %NullCheck166 = icmp ne i64* %400, null
-  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+  %NullCheck165 = icmp eq i64* %400, null
+  br i1 %NullCheck165, label %ThrowNullRef166, label %401
 
 ; <label>:401                                     ; preds = %398
   store i64 %399, i64* %400, align 8
@@ -1400,14 +1482,14 @@ entry:
   %404 = load i8*, i8** %arg1
   %405 = getelementptr inbounds i8, i8* %404, i64 8
   %406 = bitcast i8* %405 to i64*
-  %NullCheck168 = icmp ne i64* %406, null
-  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+  %NullCheck167 = icmp eq i64* %406, null
+  br i1 %NullCheck167, label %ThrowNullRef168, label %407
 
 ; <label>:407                                     ; preds = %401
   %408 = load i64, i64* %406, align 8
   %409 = bitcast i8* %403 to i64*
-  %NullCheck170 = icmp ne i64* %409, null
-  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+  %NullCheck169 = icmp eq i64* %409, null
+  br i1 %NullCheck169, label %ThrowNullRef170, label %410
 
 ; <label>:410                                     ; preds = %407
   store i64 %408, i64* %409, align 8
@@ -1437,14 +1519,14 @@ entry:
   %425 = load i8*, i8** %arg0
   %426 = load i8*, i8** %arg1
   %427 = bitcast i8* %426 to i64*
-  %NullCheck148 = icmp ne i64* %427, null
-  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+  %NullCheck147 = icmp eq i64* %427, null
+  br i1 %NullCheck147, label %ThrowNullRef148, label %428
 
 ; <label>:428                                     ; preds = %424
   %429 = load i64, i64* %427, align 8
   %430 = bitcast i8* %425 to i64*
-  %NullCheck150 = icmp ne i64* %430, null
-  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+  %NullCheck149 = icmp eq i64* %430, null
+  br i1 %NullCheck149, label %ThrowNullRef150, label %431
 
 ; <label>:431                                     ; preds = %428
   store i64 %429, i64* %430, align 8
@@ -1466,14 +1548,14 @@ entry:
   %441 = load i8*, i8** %arg0
   %442 = load i8*, i8** %arg1
   %443 = bitcast i8* %442 to i32*
-  %NullCheck152 = icmp ne i32* %443, null
-  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+  %NullCheck151 = icmp eq i32* %443, null
+  br i1 %NullCheck151, label %ThrowNullRef152, label %444
 
 ; <label>:444                                     ; preds = %440
   %445 = load i32, i32* %443, align 8
   %446 = bitcast i8* %441 to i32*
-  %NullCheck154 = icmp ne i32* %446, null
-  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+  %NullCheck153 = icmp eq i32* %446, null
+  br i1 %NullCheck153, label %ThrowNullRef154, label %447
 
 ; <label>:447                                     ; preds = %444
   store i32 %445, i32* %446, align 8
@@ -1495,16 +1577,16 @@ entry:
   %457 = load i8*, i8** %arg0
   %458 = load i8*, i8** %arg1
   %459 = bitcast i8* %458 to i16*
-  %NullCheck156 = icmp ne i16* %459, null
-  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+  %NullCheck155 = icmp eq i16* %459, null
+  br i1 %NullCheck155, label %ThrowNullRef156, label %460
 
 ; <label>:460                                     ; preds = %456
   %461 = load i16, i16* %459, align 8
   %462 = sext i16 %461 to i32
   %463 = bitcast i8* %457 to i16*
   %464 = trunc i32 %462 to i16
-  %NullCheck158 = icmp ne i16* %463, null
-  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+  %NullCheck157 = icmp eq i16* %463, null
+  br i1 %NullCheck157, label %ThrowNullRef158, label %465
 
 ; <label>:465                                     ; preds = %460
   store i16 %464, i16* %463, align 8
@@ -1525,15 +1607,15 @@ entry:
 ; <label>:474                                     ; preds = %470
   %475 = load i8*, i8** %arg0
   %476 = load i8*, i8** %arg1
-  %NullCheck160 = icmp ne i8* %476, null
-  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+  %NullCheck159 = icmp eq i8* %476, null
+  br i1 %NullCheck159, label %ThrowNullRef160, label %477
 
 ; <label>:477                                     ; preds = %474
   %478 = load i8, i8* %476, align 8
   %479 = zext i8 %478 to i32
   %480 = trunc i32 %479 to i8
-  %NullCheck162 = icmp ne i8* %475, null
-  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+  %NullCheck161 = icmp eq i8* %475, null
+  br i1 %NullCheck161, label %ThrowNullRef162, label %481
 
 ; <label>:481                                     ; preds = %477
   store i8 %480, i8* %475, align 8
@@ -1553,343 +1635,343 @@ ThrowNullRef:                                     ; preds = %308
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %312
+ThrowNullRef2:                                    ; preds = %312
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %315
+ThrowNullRef4:                                    ; preds = %315
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %321
+ThrowNullRef6:                                    ; preds = %321
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %271
+ThrowNullRef8:                                    ; preds = %271
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %275
+ThrowNullRef10:                                   ; preds = %275
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %278
+ThrowNullRef12:                                   ; preds = %278
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %284
+ThrowNullRef14:                                   ; preds = %284
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %287
+ThrowNullRef16:                                   ; preds = %287
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %293
+ThrowNullRef18:                                   ; preds = %293
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %298
+ThrowNullRef20:                                   ; preds = %298
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %303
+ThrowNullRef22:                                   ; preds = %303
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %243
+ThrowNullRef24:                                   ; preds = %243
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %247
+ThrowNullRef26:                                   ; preds = %247
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %250
+ThrowNullRef28:                                   ; preds = %250
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %256
+ThrowNullRef30:                                   ; preds = %256
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %259
+ThrowNullRef32:                                   ; preds = %259
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %265
+ThrowNullRef34:                                   ; preds = %265
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %217
+ThrowNullRef36:                                   ; preds = %217
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %221
+ThrowNullRef38:                                   ; preds = %221
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %224
+ThrowNullRef40:                                   ; preds = %224
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %230
+ThrowNullRef42:                                   ; preds = %230
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %233
+ThrowNullRef44:                                   ; preds = %233
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %238
+ThrowNullRef46:                                   ; preds = %238
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %200
+ThrowNullRef48:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %204
+ThrowNullRef50:                                   ; preds = %204
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %207
+ThrowNullRef52:                                   ; preds = %207
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %213
+ThrowNullRef54:                                   ; preds = %213
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %172
+ThrowNullRef56:                                   ; preds = %172
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %176
+ThrowNullRef58:                                   ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %179
+ThrowNullRef60:                                   ; preds = %179
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %185
+ThrowNullRef62:                                   ; preds = %185
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %190
+ThrowNullRef64:                                   ; preds = %190
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %195
+ThrowNullRef66:                                   ; preds = %195
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %153
+ThrowNullRef68:                                   ; preds = %153
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %157
+ThrowNullRef70:                                   ; preds = %157
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %160
+ThrowNullRef72:                                   ; preds = %160
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %166
+ThrowNullRef74:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %136
+ThrowNullRef76:                                   ; preds = %136
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %140
+ThrowNullRef78:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %143
+ThrowNullRef80:                                   ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %148
+ThrowNullRef82:                                   ; preds = %148
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %128
+ThrowNullRef84:                                   ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %132
+ThrowNullRef86:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %100
+ThrowNullRef88:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %104
+ThrowNullRef90:                                   ; preds = %104
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %107
+ThrowNullRef92:                                   ; preds = %107
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %113
+ThrowNullRef94:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %118
+ThrowNullRef96:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %123
+ThrowNullRef98:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %81
+ThrowNullRef100:                                  ; preds = %81
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef101:                                  ; preds = %85
+ThrowNullRef102:                                  ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef103:                                  ; preds = %88
+ThrowNullRef104:                                  ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef105:                                  ; preds = %94
+ThrowNullRef106:                                  ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef107:                                  ; preds = %64
+ThrowNullRef108:                                  ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef109:                                  ; preds = %68
+ThrowNullRef110:                                  ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef111:                                  ; preds = %71
+ThrowNullRef112:                                  ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef113:                                  ; preds = %76
+ThrowNullRef114:                                  ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef115:                                  ; preds = %56
+ThrowNullRef116:                                  ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef117:                                  ; preds = %60
+ThrowNullRef118:                                  ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef119:                                  ; preds = %37
+ThrowNullRef120:                                  ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef121:                                  ; preds = %41
+ThrowNullRef122:                                  ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef123:                                  ; preds = %46
+ThrowNullRef124:                                  ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef125:                                  ; preds = %51
+ThrowNullRef126:                                  ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef127:                                  ; preds = %27
+ThrowNullRef128:                                  ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef129:                                  ; preds = %31
+ThrowNullRef130:                                  ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef131:                                  ; preds = %19
+ThrowNullRef132:                                  ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef133:                                  ; preds = %22
+ThrowNullRef134:                                  ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef135:                                  ; preds = %338
+ThrowNullRef136:                                  ; preds = %338
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef137:                                  ; preds = %341
+ThrowNullRef138:                                  ; preds = %341
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef139:                                  ; preds = %356
+ThrowNullRef140:                                  ; preds = %356
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef141:                                  ; preds = %360
+ThrowNullRef142:                                  ; preds = %360
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef143:                                  ; preds = %377
+ThrowNullRef144:                                  ; preds = %377
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef145:                                  ; preds = %381
+ThrowNullRef146:                                  ; preds = %381
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef147:                                  ; preds = %424
+ThrowNullRef148:                                  ; preds = %424
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef149:                                  ; preds = %428
+ThrowNullRef150:                                  ; preds = %428
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef151:                                  ; preds = %440
+ThrowNullRef152:                                  ; preds = %440
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef153:                                  ; preds = %444
+ThrowNullRef154:                                  ; preds = %444
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef155:                                  ; preds = %456
+ThrowNullRef156:                                  ; preds = %456
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef157:                                  ; preds = %460
+ThrowNullRef158:                                  ; preds = %460
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef159:                                  ; preds = %474
+ThrowNullRef160:                                  ; preds = %474
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef161:                                  ; preds = %477
+ThrowNullRef162:                                  ; preds = %477
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef163:                                  ; preds = %394
+ThrowNullRef164:                                  ; preds = %394
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef165:                                  ; preds = %398
+ThrowNullRef166:                                  ; preds = %398
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef167:                                  ; preds = %401
+ThrowNullRef168:                                  ; preds = %401
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef169:                                  ; preds = %407
+ThrowNullRef170:                                  ; preds = %407
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1939,8 +2021,8 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
-  br i1 %NullCheck, label %22, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %ThrowNullRef, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
@@ -1948,8 +2030,8 @@ entry:
   store i32 %24, i32* %loc0
   %25 = load i32, i32* %loc0
   %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %26, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %27
 
 ; <label>:27                                      ; preds = %22
   %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
@@ -1971,7 +2053,7 @@ ThrowNullRef:                                     ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1989,8 +2071,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -2022,15 +2104,15 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2048,16 +2130,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
   %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
   store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %15
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
@@ -2072,8 +2154,8 @@ entry:
   %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
   %29 = ptrtoint i16 addrspace(1)* %28 to i64
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %19
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
@@ -2089,19 +2171,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2114,8 +2196,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
@@ -2128,7 +2210,7 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[loadElem]
+Failed to read AppDomain.PrepareDataForSetup[storeElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
@@ -2202,8 +2284,8 @@ entry:
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
-  br i1 %NullCheck24, label %27, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = load i64, i64 addrspace(1)* %26
@@ -2218,8 +2300,8 @@ entry:
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
-  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
   %41 = load i64, i64 addrspace(1)* %39
@@ -2236,8 +2318,8 @@ entry:
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
-  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
   %54 = load i64, i64 addrspace(1)* %52
@@ -2252,8 +2334,8 @@ entry:
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
   %67 = load i64, i64 addrspace(1)* %65
@@ -2270,8 +2352,8 @@ entry:
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
-  br i1 %NullCheck16, label %79, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
   %80 = load i64, i64 addrspace(1)* %78
@@ -2286,8 +2368,8 @@ entry:
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
-  br i1 %NullCheck18, label %92, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
   %93 = load i64, i64 addrspace(1)* %91
@@ -2304,8 +2386,8 @@ entry:
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
-  br i1 %NullCheck12, label %105, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = load i64, i64 addrspace(1)* %104
@@ -2320,8 +2402,8 @@ entry:
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
-  br i1 %NullCheck14, label %118, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
   %119 = load i64, i64 addrspace(1)* %117
@@ -2337,8 +2419,8 @@ entry:
 
 ; <label>:128                                     ; preds = %20
   %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
-  br i1 %NullCheck4, label %130, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %129, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %130
 
 ; <label>:130                                     ; preds = %128
   %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
@@ -2346,8 +2428,8 @@ entry:
   %133 = load i16, i16 addrspace(1)* %132, align 8
   %134 = zext i16 %133 to i32
   %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
-  br i1 %NullCheck6, label %136, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %135, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %136
 
 ; <label>:136                                     ; preds = %130
   %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
@@ -2360,8 +2442,8 @@ entry:
 
 ; <label>:143                                     ; preds = %136
   %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
-  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %144, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %145
 
 ; <label>:145                                     ; preds = %143
   %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
@@ -2369,8 +2451,8 @@ entry:
   %148 = load i16, i16 addrspace(1)* %147, align 8
   %149 = zext i16 %148 to i32
   %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %150, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %151
 
 ; <label>:151                                     ; preds = %145
   %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
@@ -2388,8 +2470,8 @@ entry:
 
 ; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
-  br i1 %NullCheck, label %163, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %ThrowNullRef, label %163
 
 ; <label>:163                                     ; preds = %161
   %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
@@ -2399,8 +2481,8 @@ entry:
 
 ; <label>:167                                     ; preds = %163
   %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
-  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %168, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %169
 
 ; <label>:169                                     ; preds = %167
   %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
@@ -2432,55 +2514,55 @@ ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %167
+ThrowNullRef2:                                    ; preds = %167
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %128
+ThrowNullRef4:                                    ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %130
+ThrowNullRef6:                                    ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %143
+ThrowNullRef8:                                    ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %145
+ThrowNullRef10:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %102
+ThrowNullRef12:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %105
+ThrowNullRef14:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %76
+ThrowNullRef16:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %79
+ThrowNullRef18:                                   ; preds = %79
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %50
+ThrowNullRef20:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %53
+ThrowNullRef22:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %24
+ThrowNullRef24:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %27
+ThrowNullRef26:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2503,15 +2585,15 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2519,16 +2601,16 @@ entry:
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
   store i32 %8, i32* %loc0
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
   %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
   store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
@@ -2546,16 +2628,16 @@ entry:
 
 ; <label>:23                                      ; preds = %64
   %24 = load i16*, i16** %loc3
-  %NullCheck12 = icmp ne i16* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i16* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
   store i32 %27, i32* %loc5
   %28 = load i16*, i16** %loc4
-  %NullCheck14 = icmp ne i16* %28, null
-  br i1 %NullCheck14, label %29, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %28, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = load i16, i16* %28, align 8
@@ -2620,15 +2702,15 @@ entry:
 
 ; <label>:67                                      ; preds = %64
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
-  br i1 %NullCheck8, label %69, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %68, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %69
 
 ; <label>:69                                      ; preds = %67
   %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
   %71 = load i32, i32 addrspace(1)* %70
   %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
-  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %73
 
 ; <label>:73                                      ; preds = %69
   %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
@@ -2645,31 +2727,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %67
+ThrowNullRef8:                                    ; preds = %67
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %69
+ThrowNullRef10:                                   ; preds = %69
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2710,14 +2792,14 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
   %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
@@ -2730,14 +2812,14 @@ entry:
 
 ; <label>:11                                      ; preds = %4
   %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
   %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
@@ -2749,14 +2831,14 @@ entry:
 
 ; <label>:22                                      ; preds = %16
   %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
   %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
-  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
-  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
@@ -2804,23 +2886,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2836,7 +2918,280 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[loadElem]
+Successfully read RuntimeType.IsAssignableFrom
+
+define i8 @RuntimeType.IsAssignableFrom(%System.RuntimeType addrspace(1)* %param0, %System.Type addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.RuntimeType addrspace(1)*
+  %arg1 = alloca %System.Type addrspace(1)*
+  %loc0 = alloca %System.RuntimeType addrspace(1)*
+  %loc1 = alloca %"System.Type[]" addrspace(1)*
+  %loc2 = alloca i32
+  store %System.RuntimeType addrspace(1)* %param0, %System.RuntimeType addrspace(1)** %this
+  store %System.Type addrspace(1)* %param1, %System.Type addrspace(1)** %arg1
+  %0 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %1 = icmp ne %System.Type addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i8 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %5 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %6 = bitcast %System.Type addrspace(1)* %4 to %System.Object addrspace(1)*
+  %7 = bitcast %System.RuntimeType addrspace(1)* %5 to %System.Object addrspace(1)*
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %6, %System.Object addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %3
+  ret i8 1
+
+; <label>:12                                      ; preds = %3
+  %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 152
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 32
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
+  %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
+  %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
+  store %System.RuntimeType addrspace(1)* %25, %System.RuntimeType addrspace(1)** %loc0
+  %26 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %27 = icmp eq %System.RuntimeType addrspace(1)* %26, null
+  br i1 %27, label %34, label %28
+
+; <label>:28                                      ; preds = %15
+  %29 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %30 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)*)*)(%System.RuntimeType addrspace(1)* %29, %System.RuntimeType addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+; <label>:34                                      ; preds = %15
+  %35 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %36 = call %System.Reflection.Emit.TypeBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Reflection.Emit.TypeBuilder addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %35)
+  %37 = icmp eq %System.Reflection.Emit.TypeBuilder addrspace(1)* %36, null
+  br i1 %37, label %139, label %38
+
+; <label>:38                                      ; preds = %34
+  %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %42
+
+; <label>:42                                      ; preds = %38
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 152
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 40
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
+  %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
+  %53 = zext i8 %52 to i32
+  %54 = icmp eq i32 %53, 0
+  br i1 %54, label %56, label %55
+
+; <label>:55                                      ; preds = %42
+  ret i8 1
+
+; <label>:56                                      ; preds = %42
+  %57 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %58 = bitcast %System.RuntimeType addrspace(1)* %57 to %System.Type addrspace(1)*
+  %59 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %58)
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %64 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.Type addrspace(1)* %63, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = bitcast %System.RuntimeType addrspace(1)* %64 to %System.Type addrspace(1)*
+  %67 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %63, %System.Type addrspace(1)* %66)
+  %68 = zext i8 %67 to i32
+  %69 = trunc i32 %68 to i8
+  ret i8 %69
+
+; <label>:70                                      ; preds = %56
+  %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
+  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %73
+
+; <label>:73                                      ; preds = %70
+  %74 = load i64, i64 addrspace(1)* %72
+  %75 = add i64 %74, 128
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = add i64 %77, 0
+  %79 = inttoptr i64 %78 to i64*
+  %80 = load i64, i64* %79
+  %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
+  %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
+  %83 = call i8 %82(%System.Type addrspace(1)* %81)
+  %84 = zext i8 %83 to i32
+  %85 = icmp eq i32 %84, 0
+  br i1 %85, label %139, label %86
+
+; <label>:86                                      ; preds = %73
+  %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
+  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %89
+
+; <label>:89                                      ; preds = %86
+  %90 = load i64, i64 addrspace(1)* %88
+  %91 = add i64 %90, 128
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = add i64 %93, 24
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
+  %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
+  %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
+  store %"System.Type[]" addrspace(1)* %99, %"System.Type[]" addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %129
+
+; <label>:100                                     ; preds = %132
+  %101 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %102 = load i32, i32* %loc2
+  %NullCheck11 = icmp eq %"System.Type[]" addrspace(1)* %101, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %103
+
+; <label>:103                                     ; preds = %100
+  %104 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 1
+  %105 = load i32, i32 addrspace(1)* %104
+  %106 = zext i32 %105 to i64
+  %107 = zext i32 %102 to i64
+  %BoundsCheck = icmp uge i64 %107, %106
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %108
+
+; <label>:108                                     ; preds = %103
+  %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
+  %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
+  %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
+  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %113
+
+; <label>:113                                     ; preds = %108
+  %114 = load i64, i64 addrspace(1)* %112
+  %115 = add i64 %114, 152
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = add i64 %117, 56
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
+  %123 = zext i8 %122 to i32
+  %124 = icmp ne i32 %123, 0
+  br i1 %124, label %126, label %125
+
+; <label>:125                                     ; preds = %113
+  ret i8 0
+
+; <label>:126                                     ; preds = %113
+  %127 = load i32, i32* %loc2
+  %128 = add i32 %127, 1
+  store i32 %128, i32* %loc2
+  br label %129
+
+; <label>:129                                     ; preds = %89, %126
+  %130 = load i32, i32* %loc2
+  %131 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %NullCheck9 = icmp eq %"System.Type[]" addrspace(1)* %131, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %132
+
+; <label>:132                                     ; preds = %129
+  %133 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %131, i32 0, i32 1
+  %134 = load i32, i32 addrspace(1)* %133
+  %135 = zext i32 %134 to i64
+  %136 = trunc i64 %135 to i32
+  %137 = icmp slt i32 %130, %136
+  br i1 %137, label %100, label %138
+
+; <label>:138                                     ; preds = %132
+  ret i8 1
+
+; <label>:139                                     ; preds = %34, %73
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %129
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %103
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -2893,7 +3248,7 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElem]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -2904,8 +3259,8 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -2997,8 +3352,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
@@ -3059,8 +3414,8 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -3087,8 +3442,8 @@ entry:
 
 ; <label>:17                                      ; preds = %5, %11
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
@@ -3097,8 +3452,8 @@ entry:
 
 ; <label>:22                                      ; preds = %1, %11
   %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
@@ -3109,11 +3464,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %17
+ThrowNullRef2:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %22
+ThrowNullRef4:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3167,15 +3522,15 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
   %15 = load i32, i32 addrspace(1)* %14
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
@@ -3198,7 +3553,7 @@ ThrowNullRef:                                     ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef2:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3232,8 +3587,8 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
@@ -3312,8 +3667,8 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -3327,8 +3682,8 @@ entry:
 ; <label>:5                                       ; preds = %43
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %7 = load i32, i32* %loc1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck6, label %8, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
@@ -3366,8 +3721,8 @@ entry:
 ; <label>:32                                      ; preds = %21, %25
   %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
   %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
-  br i1 %NullCheck8, label %35, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = trunc i32 %34 to i16
@@ -3380,8 +3735,8 @@ entry:
 ; <label>:40                                      ; preds = %1, %35
   %41 = load i32, i32* %loc1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
-  br i1 %NullCheck2, label %43, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %42, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
@@ -3392,8 +3747,8 @@ entry:
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
   %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
-  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
   %51 = load i64, i64 addrspace(1)* %49
@@ -3412,19 +3767,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %40
+ThrowNullRef2:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %47
+ThrowNullRef4:                                    ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %5
+ThrowNullRef6:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %32
+ThrowNullRef8:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3467,8 +3822,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
@@ -3492,11 +3847,391 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(i16* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store i16* %param0, i16** %arg0
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load i32, i32* %arg3
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %42, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %37, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg2
+  %13 = load i32, i32* %arg3
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %37, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %24 = load i32, i32* %arg2
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load i16*, i16** %arg0
+  %35 = load i32, i32* %arg3
+  %36 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %36, i16* %34, i32 %35)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:37                                      ; preds = %5, %16
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %39)
+  %41 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41, %System.String addrspace(1)* %38, %System.String addrspace(1)* %40)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41) #0
+  unreachable
+
+; <label>:42                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
-Failed to read StringBuilder.ToString[loadElemA]
+Successfully read StringBuilder.ToString
+
+define %System.String addrspace(1)* @StringBuilder.ToString(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i16*
+  %loc3 = alloca %"System.Char[]" addrspace(1)*
+  %loc4 = alloca i32
+  %loc5 = alloca i32
+  %loc6 = alloca i16 addrspace(1)*
+  %loc7 = alloca %System.String addrspace(1)*
+  %loc8 = alloca %"System.Char[]" addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %0)
+  %2 = icmp ne i32 %1, 0
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %4
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %6)
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %7)
+  store %System.String addrspace(1)* %8, %System.String addrspace(1)** %loc0
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.Text.StringBuilder addrspace(1)* %9, %System.Text.StringBuilder addrspace(1)** %loc1
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  store %System.String addrspace(1)* %10, %System.String addrspace(1)** %loc7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc7
+  %12 = ptrtoint %System.String addrspace(1)* %11 to i64
+  %13 = icmp eq i64 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %5
+  %15 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %16 = sext i32 %15 to i64
+  %17 = add i64 %12, %16
+  br label %18
+
+; <label>:18                                      ; preds = %5, %14
+  %19 = phi i64 [ %12, %5 ], [ %17, %14 ]
+  %20 = inttoptr i64 %19 to i16*
+  store i16* %20, i16** %loc2
+  br label %21
+
+; <label>:21                                      ; preds = %98, %18
+  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %22, null
+  br i1 %NullCheck, label %ThrowNullRef, label %23
+
+; <label>:23                                      ; preds = %21
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 3
+  %25 = load i32, i32 addrspace(1)* %24, align 8
+  %26 = icmp sle i32 %25, 0
+  br i1 %26, label %96, label %27
+
+; <label>:27                                      ; preds = %23
+  %28 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %28, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %29
+
+; <label>:29                                      ; preds = %27
+  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %28, i32 0, i32 1
+  %31 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %30, align 8
+  store %"System.Char[]" addrspace(1)* %31, %"System.Char[]" addrspace(1)** %loc3
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %33
+
+; <label>:33                                      ; preds = %29
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  store i32 %35, i32* %loc4
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  %39 = load i32, i32 addrspace(1)* %38, align 8
+  store i32 %39, i32* %loc5
+  %40 = load i32, i32* %loc5
+  %41 = load i32, i32* %loc4
+  %42 = add i32 %40, %41
+  %43 = zext i32 %42 to i64
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %45
+
+; <label>:45                                      ; preds = %37
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = sext i32 %47 to i64
+  %49 = icmp sgt i64 %43, %48
+  br i1 %49, label %91, label %50
+
+; <label>:50                                      ; preds = %45
+  %51 = load i32, i32* %loc5
+  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %52, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %53
+
+; <label>:53                                      ; preds = %50
+  %54 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %52, i32 0, i32 1
+  %55 = load i32, i32 addrspace(1)* %54
+  %56 = zext i32 %55 to i64
+  %57 = trunc i64 %56 to i32
+  %58 = icmp ugt i32 %51, %57
+  br i1 %58, label %91, label %59
+
+; <label>:59                                      ; preds = %53
+  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  store %"System.Char[]" addrspace(1)* %60, %"System.Char[]" addrspace(1)** %loc8
+  %61 = icmp eq %"System.Char[]" addrspace(1)* %60, null
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %63, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %64
+
+; <label>:64                                      ; preds = %62
+  %65 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %63, i32 0, i32 1
+  %66 = load i32, i32 addrspace(1)* %65
+  %67 = zext i32 %66 to i64
+  %68 = trunc i64 %67 to i32
+  %69 = icmp ne i32 %68, 0
+  br i1 %69, label %71, label %70
+
+; <label>:70                                      ; preds = %59, %64
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:71                                      ; preds = %64
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %73
+
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %BoundsCheck = icmp uge i64 0, %76
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %77
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %78, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:79                                      ; preds = %70, %77
+  %80 = load i16*, i16** %loc2
+  %81 = load i32, i32* %loc4
+  %82 = sext i32 %81 to i64
+  %83 = mul i64 %82, 2
+  %84 = bitcast i16* %80 to i8*
+  %85 = getelementptr inbounds i8, i8* %84, i64 %83
+  %86 = load i16 addrspace(1)*, i16 addrspace(1)** %loc6
+  %87 = ptrtoint i16 addrspace(1)* %86 to i64
+  %88 = load i32, i32* %loc5
+  %89 = bitcast i8* %85 to i16*
+  %90 = inttoptr i64 %87 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %89, i16* %90, i32 %88)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %96
+
+; <label>:91                                      ; preds = %45, %53
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %94 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %93)
+  %95 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95, %System.String addrspace(1)* %92, %System.String addrspace(1)* %94)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95) #0
+  unreachable
+
+; <label>:96                                      ; preds = %23, %79
+  %97 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %97, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %98
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %97, i32 0, i32 2
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  store %System.Text.StringBuilder addrspace(1)* %100, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %102 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %102, label %21, label %103
+
+; <label>:103                                     ; preds = %98
+  store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc7
+  %104 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  ret %System.String addrspace(1)* %104
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method StringBuilder::get_Length using LLILCJit
+Successfully read StringBuilder.get_Length
+
+define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
+Successfully read RuntimeHelpers.get_OffsetToStringData
+
+define i32 @RuntimeHelpers.get_OffsetToStringData() {
+entry:
+  ret i32 12
+}
+
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
 Successfully read CultureData.CreateCultureData
 
@@ -3514,23 +4249,23 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
   store i8 %4, i8 addrspace(1)* %6
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
@@ -3549,11 +4284,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3566,50 +4301,50 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
   store i32 -1, i32 addrspace(1)* %2
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
   store i32 -1, i32 addrspace(1)* %8
   %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
   store i32 -1, i32 addrspace(1)* %14
   %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
   store i32 -1, i32 addrspace(1)* %17
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
@@ -3623,27 +4358,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3675,7 +4410,136 @@ Failed to read Dictionary`2.Insert[non-const derefAddress]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
 Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
-Failed to read HashHelpers.GetPrime[loadElem]
+Successfully read HashHelpers.GetPrime
+
+define i32 @HashHelpers.GetPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %6, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5, %System.String addrspace(1)* %4)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5) #0
+  unreachable
+
+; <label>:6                                       ; preds = %entry
+  store i32 0, i32* %loc0
+  br label %29
+
+; <label>:7                                       ; preds = %35
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 1296
+  %10 = addrspacecast i8 addrspace(1)* %9 to %"System.Int32[]" addrspace(1)**
+  %11 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %10
+  %12 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Int32[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = zext i32 %15 to i64
+  %17 = zext i32 %12 to i64
+  %BoundsCheck = icmp uge i64 %17, %16
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 3, i32 %12
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  store i32 %20, i32* %loc1
+  %21 = load i32, i32* %loc1
+  %22 = load i32, i32* %arg0
+  %23 = icmp slt i32 %21, %22
+  br i1 %23, label %26, label %24
+
+; <label>:24                                      ; preds = %18
+  %25 = load i32, i32* %loc1
+  ret i32 %25
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %loc0
+  %28 = add i32 %27, 1
+  store i32 %28, i32* %loc0
+  br label %29
+
+; <label>:29                                      ; preds = %6, %26
+  %30 = load i32, i32* %loc0
+  %31 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %32 = getelementptr inbounds i8, i8 addrspace(1)* %31, i64 1296
+  %33 = addrspacecast i8 addrspace(1)* %32 to %"System.Int32[]" addrspace(1)**
+  %34 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %33
+  %NullCheck = icmp eq %"System.Int32[]" addrspace(1)* %34, null
+  br i1 %NullCheck, label %ThrowNullRef, label %35
+
+; <label>:35                                      ; preds = %29
+  %36 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %34, i32 0, i32 1
+  %37 = load i32, i32 addrspace(1)* %36
+  %38 = zext i32 %37 to i64
+  %39 = trunc i64 %38 to i32
+  %40 = icmp slt i32 %30, %39
+  br i1 %40, label %7, label %41
+
+; <label>:41                                      ; preds = %35
+  %42 = load i32, i32* %arg0
+  %43 = or i32 %42, 1
+  store i32 %43, i32* %loc2
+  br label %59
+
+; <label>:44                                      ; preds = %59
+  %45 = load i32, i32* %loc2
+  %46 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %45)
+  %47 = zext i8 %46 to i32
+  %48 = icmp eq i32 %47, 0
+  br i1 %48, label %56, label %49
+
+; <label>:49                                      ; preds = %44
+  %50 = load i32, i32* %loc2
+  %51 = sub i32 %50, 1
+  %52 = srem i32 %51, 101
+  %53 = icmp eq i32 %52, 0
+  br i1 %53, label %56, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = load i32, i32* %loc2
+  ret i32 %55
+
+; <label>:56                                      ; preds = %44, %49
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %57, 2
+  store i32 %58, i32* %loc2
+  br label %59
+
+; <label>:59                                      ; preds = %41, %56
+  %60 = load i32, i32* %loc2
+  %61 = icmp slt i32 %60, 2147483647
+  br i1 %61, label %44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load i32, i32* %arg0
+  ret i32 %63
+
+ThrowNullRef:                                     ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
 Successfully read GenericEqualityComparer`1.GetHashCode
 
@@ -3694,14 +4558,14 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
   %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load i64, i64 addrspace(1)* %7
@@ -3720,7 +4584,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3750,8 +4614,8 @@ entry:
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
@@ -3796,8 +4660,8 @@ entry:
   %35 = bitcast i16* %34 to i8*
   %36 = getelementptr inbounds i8, i8* %35, i64 2
   %37 = bitcast i8* %36 to i16*
-  %NullCheck4 = icmp ne i16* %37, null
-  br i1 %NullCheck4, label %38, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %37, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %38
 
 ; <label>:38                                      ; preds = %27
   %39 = load i16, i16* %37, align 8
@@ -3824,8 +4688,8 @@ entry:
 
 ; <label>:54                                      ; preds = %22, %43
   %55 = load i16*, i16** %loc4
-  %NullCheck2 = icmp ne i16* %55, null
-  br i1 %NullCheck2, label %56, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i16* %55, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %56
 
 ; <label>:56                                      ; preds = %54
   %57 = load i16, i16* %55, align 8
@@ -3850,11 +4714,11 @@ ThrowNullRef:                                     ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %54
+ThrowNullRef2:                                    ; preds = %54
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %27
+ThrowNullRef4:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3871,8 +4735,8 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -3907,8 +4771,8 @@ entry:
 
 ; <label>:26                                      ; preds = %19
   %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
-  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %28
 
 ; <label>:28                                      ; preds = %26
   %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
@@ -3920,7 +4784,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3972,8 +4836,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
@@ -3984,26 +4848,26 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
-  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
@@ -4014,8 +4878,8 @@ entry:
 ; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
@@ -4024,8 +4888,8 @@ entry:
 
 ; <label>:25                                      ; preds = %1, %16, %23
   %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
-  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
@@ -4036,27 +4900,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %20
+ThrowNullRef10:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4069,8 +4933,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -4081,8 +4945,8 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
@@ -4091,8 +4955,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1, %8
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
@@ -4103,11 +4967,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4128,24 +4992,24 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   store i32 %3, i32* %loc0
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
   %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
   store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck4, label %9, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
@@ -4164,15 +5028,15 @@ entry:
 ; <label>:18                                      ; preds = %70
   %19 = load i16*, i16** %loc3
   %20 = bitcast i16* %19 to i64*
-  %NullCheck10 = icmp ne i64* %20, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %20, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = load i64, i64* %20, align 8
   %23 = load i16*, i16** %loc4
   %24 = bitcast i16* %23 to i64*
-  %NullCheck12 = icmp ne i64* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = load i64, i64* %24, align 8
@@ -4188,8 +5052,8 @@ entry:
   %31 = bitcast i16* %30 to i8*
   %32 = getelementptr inbounds i8, i8* %31, i64 8
   %33 = bitcast i8* %32 to i64*
-  %NullCheck14 = icmp ne i64* %33, null
-  br i1 %NullCheck14, label %34, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = load i64, i64* %33, align 8
@@ -4197,8 +5061,8 @@ entry:
   %37 = bitcast i16* %36 to i8*
   %38 = getelementptr inbounds i8, i8* %37, i64 8
   %39 = bitcast i8* %38 to i64*
-  %NullCheck16 = icmp ne i64* %39, null
-  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %40
 
 ; <label>:40                                      ; preds = %34
   %41 = load i64, i64* %39, align 8
@@ -4214,8 +5078,8 @@ entry:
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %NullCheck18 = icmp ne i64* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = load i64, i64* %48, align 8
@@ -4223,8 +5087,8 @@ entry:
   %52 = bitcast i16* %51 to i8*
   %53 = getelementptr inbounds i8, i8* %52, i64 16
   %54 = bitcast i8* %53 to i64*
-  %NullCheck20 = icmp ne i64* %54, null
-  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64* %54, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %55
 
 ; <label>:55                                      ; preds = %49
   %56 = load i64, i64* %54, align 8
@@ -4262,15 +5126,15 @@ entry:
 ; <label>:74                                      ; preds = %95
   %75 = load i16*, i16** %loc3
   %76 = bitcast i16* %75 to i32*
-  %NullCheck6 = icmp ne i32* %76, null
-  br i1 %NullCheck6, label %77, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32* %76, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %77
 
 ; <label>:77                                      ; preds = %74
   %78 = load i32, i32* %76, align 8
   %79 = load i16*, i16** %loc4
   %80 = bitcast i16* %79 to i32*
-  %NullCheck8 = icmp ne i32* %80, null
-  br i1 %NullCheck8, label %81, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i32* %80, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %81
 
 ; <label>:81                                      ; preds = %77
   %82 = load i32, i32* %80, align 8
@@ -4318,43 +5182,43 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %74
+ThrowNullRef6:                                    ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %77
+ThrowNullRef8:                                    ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %29
+ThrowNullRef14:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %34
+ThrowNullRef16:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4376,8 +5240,8 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load i64, i64 addrspace(1)* %4
@@ -4389,8 +5253,8 @@ entry:
   %12 = load i64, i64* %11
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %5
   %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
@@ -4399,8 +5263,8 @@ entry:
   %18 = load i8, i8* %arg2
   %19 = zext i8 %18 to i32
   %20 = trunc i32 %19 to i8
-  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %15
   %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
@@ -4411,11 +5275,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4442,8 +5306,8 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
@@ -4466,16 +5330,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
   %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = load i64, i64 addrspace(1)* %19
@@ -4500,8 +5364,8 @@ entry:
 ; <label>:35                                      ; preds = %30
   %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
@@ -4514,8 +5378,8 @@ entry:
 
 ; <label>:42                                      ; preds = %1, %38
   %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
-  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
@@ -4526,19 +5390,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %35
+ThrowNullRef2:                                    ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %42
+ThrowNullRef8:                                    ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4551,14 +5415,14 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
@@ -4570,7 +5434,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4583,8 +5447,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
@@ -4613,51 +5477,51 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
   %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
   %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
   %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
   %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
-  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
   store i64 %21, i64 addrspace(1)* %23
   %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %25 = load i64, i64* %loc0
-  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
@@ -4668,27 +5532,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %22
+ThrowNullRef12:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4701,8 +5565,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
@@ -4713,19 +5577,19 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
@@ -4734,8 +5598,8 @@ entry:
 
 ; <label>:15                                      ; preds = %1, %13
   %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
@@ -4746,19 +5610,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %15
+ThrowNullRef8:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4771,8 +5635,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -4831,8 +5695,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
@@ -4882,8 +5746,8 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
-  br i1 %NullCheck, label %17, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %ThrowNullRef, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
@@ -4894,15 +5758,15 @@ entry:
 
 ; <label>:22                                      ; preds = %17
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
-  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
   %26 = load i32, i32 addrspace(1)* %25
   %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
-  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %27, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
@@ -4925,8 +5789,8 @@ entry:
 ; <label>:40                                      ; preds = %17
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
-  br i1 %NullCheck6, label %43, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %41, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
@@ -4938,34 +5802,17 @@ ThrowNullRef:                                     ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %24
+ThrowNullRef4:                                    ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %40
+ThrowNullRef6:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
-}
-
-INFO:  jitting method Object::ReferenceEquals using LLILCJit
-Successfully read Object.ReferenceEquals
-
-define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
-entry:
-  %arg0 = alloca %System.Object addrspace(1)*
-  %arg1 = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
-  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
-  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = icmp eq %System.Object addrspace(1)* %0, %1
-  %3 = sext i1 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
 }
 
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
@@ -4978,21 +5825,21 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
   %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
-  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
@@ -5007,28 +5854,28 @@ entry:
 ; <label>:13                                      ; preds = %8, %12
   %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
   %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
   %21 = load i32, i32 addrspace(1)* %20, align 8
   %22 = add i32 %21, 1
-  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
   store i32 %22, i32 addrspace(1)* %24
   %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
@@ -5039,27 +5886,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5077,7 +5924,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::Setup using LLILCJit
-Failed to read AppDomain.Setup[loadElem]
+Failed to read AppDomain.Setup[unbox]
 INFO:  jitting method Thread::GetDomain using LLILCJit
 Successfully read Thread.GetDomain
 
@@ -5108,8 +5955,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
@@ -5122,14 +5969,14 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
   %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
@@ -5141,11 +5988,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5173,8 +6020,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -5189,7 +6036,328 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
 Failed to read KeyCollection.System.Collections.Generic.IEnumerable<TKey>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Successfully read Enumerator.MoveNext
+
+define i8 @Enumerator.MoveNext(%"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.RuntimeTypeHandle* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*
+  %"$TypeArg" = alloca %System.RuntimeTypeHandle*
+  store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
+  %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 8
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %76, label %12
+
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
+  br label %76
+
+; <label>:13                                      ; preds = %85
+  %14 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck19 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %15
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, i32 0, i32 0
+  %17 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %16, align 8
+  %NullCheck21 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, i32 0, i32 2
+  %20 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %19, align 8
+  %21 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck23 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %22
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, i32 0, i32 2
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %NullCheck25 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 3, i32 %24
+  %NullCheck27 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %32
+
+; <label>:32                                      ; preds = %30
+  %33 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, i32 0, i32 2
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = icmp slt i32 %34, 0
+  br i1 %35, label %68, label %36
+
+; <label>:36                                      ; preds = %32
+  %37 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %38 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck29 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %39
+
+; <label>:39                                      ; preds = %36
+  %40 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, i32 0, i32 0
+  %41 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %40, align 8
+  %NullCheck31 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, i32 0, i32 2
+  %44 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %43, align 8
+  %45 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck33 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, i32 0, i32 2
+  %48 = load i32, i32 addrspace(1)* %47, align 8
+  %NullCheck35 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %49
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = zext i32 %51 to i64
+  %53 = zext i32 %48 to i64
+  %BoundsCheck37 = icmp uge i64 %53, %52
+  br i1 %BoundsCheck37, label %ThrowIndexOutOfRange38, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 3, i32 %48
+  %NullCheck39 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %56
+
+; <label>:56                                      ; preds = %54
+  %57 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, i32 0, i32 0
+  %58 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck41 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %59
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %60, %System.__Canon addrspace(1)* %58)
+  %61 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck43 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  %64 = load i32, i32 addrspace(1)* %63, align 8
+  %65 = add i32 %64, 1
+  %NullCheck45 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  store i32 %65, i32 addrspace(1)* %67
+  ret i8 1
+
+; <label>:68                                      ; preds = %32
+  %69 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck47 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %73 = add i32 %72, 1
+  %NullCheck49 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %74
+
+; <label>:74                                      ; preds = %70
+  %75 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  store i32 %73, i32 addrspace(1)* %75
+  br label %76
+
+; <label>:76                                      ; preds = %8, %12, %74
+  %77 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %78
+
+; <label>:78                                      ; preds = %76
+  %79 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, i32 0, i32 2
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck7 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %82
+
+; <label>:82                                      ; preds = %78
+  %83 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, i32 0, i32 0
+  %84 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %83, align 8
+  %NullCheck9 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %85
+
+; <label>:85                                      ; preds = %82
+  %86 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, i32 0, i32 7
+  %87 = load i32, i32 addrspace(1)* %86, align 8
+  %88 = icmp ult i32 %80, %87
+  br i1 %88, label %13, label %89
+
+; <label>:89                                      ; preds = %85
+  %90 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %91 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck11 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %92
+
+; <label>:92                                      ; preds = %89
+  %93 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, i32 0, i32 0
+  %94 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck13 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %95
+
+; <label>:95                                      ; preds = %92
+  %96 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, i32 0, i32 7
+  %97 = load i32, i32 addrspace(1)* %96, align 8
+  %98 = add i32 %97, 1
+  %NullCheck15 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %99
+
+; <label>:99                                      ; preds = %95
+  %100 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, i32 0, i32 2
+  store i32 %98, i32 addrspace(1)* %100
+  %101 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck17 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %102
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %103, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %92
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef22:                                   ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef24:                                   ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef26:                                   ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef28:                                   ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef30:                                   ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef32:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef34:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef36:                                   ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange38:                           ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef40:                                   ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef42:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef44:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef46:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef48:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef50:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -5200,8 +6368,8 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -5232,9 +6400,9 @@ Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
 Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
-Failed to read String.MakeSeparatorList[loadElemA]
+Failed to read String.MakeSeparatorList[storeElem]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
-Failed to read String.InternalSplitKeepEmptyEntries[loadElem]
+Failed to read String.InternalSplitKeepEmptyEntries[storeElem]
 INFO:  jitting method Path::IsRelative using LLILCJit
 Successfully read Path.IsRelative
 
@@ -5243,8 +6411,8 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -5254,8 +6422,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
@@ -5271,8 +6439,8 @@ entry:
 
 ; <label>:17                                      ; preds = %7
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
@@ -5288,8 +6456,8 @@ entry:
 
 ; <label>:29                                      ; preds = %19
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %31
 
 ; <label>:31                                      ; preds = %29
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
@@ -5300,8 +6468,8 @@ entry:
 
 ; <label>:36                                      ; preds = %31
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
-  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %37, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
@@ -5312,8 +6480,8 @@ entry:
 
 ; <label>:43                                      ; preds = %31, %38
   %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
-  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %45
 
 ; <label>:45                                      ; preds = %43
   %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
@@ -5324,8 +6492,8 @@ entry:
 
 ; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %50
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
@@ -5336,8 +6504,8 @@ entry:
 
 ; <label>:57                                      ; preds = %1, %7, %19, %45, %52
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
-  br i1 %NullCheck14, label %59, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %59
 
 ; <label>:59                                      ; preds = %57
   %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
@@ -5347,8 +6515,8 @@ entry:
 
 ; <label>:63                                      ; preds = %59
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
@@ -5359,8 +6527,8 @@ entry:
 
 ; <label>:70                                      ; preds = %65
   %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
-  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.String addrspace(1)* %71, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %72
 
 ; <label>:72                                      ; preds = %70
   %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
@@ -5379,39 +6547,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %17
+ThrowNullRef4:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %29
+ThrowNullRef6:                                    ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %36
+ThrowNullRef8:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %43
+ThrowNullRef10:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %50
+ThrowNullRef12:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %57
+ThrowNullRef14:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %63
+ThrowNullRef16:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %70
+ThrowNullRef18:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5419,7 +6587,293 @@ ThrowNullRef17:                                   ; preds = %70
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
-Failed to read String.TrimHelper[loadElem]
+Successfully read String.TrimHelper
+
+define %System.String addrspace(1)* @String.TrimHelper(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i16
+  %loc4 = alloca i32
+  %loc5 = alloca i16
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = sub i32 %3, 1
+  store i32 %4, i32* %loc0
+  store i32 0, i32* %loc1
+  %5 = load i32, i32* %arg2
+  %6 = icmp eq i32 %5, 1
+  br i1 %6, label %62, label %7
+
+; <label>:7                                       ; preds = %1
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:8                                       ; preds = %58
+  store i32 0, i32* %loc2
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load i32, i32* %loc1
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2, i32 %10
+  %13 = load i16, i16 addrspace(1)* %12
+  %14 = zext i16 %13 to i32
+  %15 = trunc i32 %14 to i16
+  store i16 %15, i16* %loc3
+  store i32 0, i32* %loc2
+  br label %34
+
+; <label>:16                                      ; preds = %37
+  %17 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %18 = load i32, i32* %loc2
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %17, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %19
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = zext i32 %18 to i64
+  %BoundsCheck = icmp uge i64 %23, %22
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %24
+
+; <label>:24                                      ; preds = %19
+  %25 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 3, i32 %18
+  %26 = load i16, i16 addrspace(1)* %25, align 8
+  %27 = zext i16 %26 to i32
+  %28 = load i16, i16* %loc3
+  %29 = zext i16 %28 to i32
+  %30 = icmp eq i32 %27, %29
+  br i1 %30, label %43, label %31
+
+; <label>:31                                      ; preds = %24
+  %32 = load i32, i32* %loc2
+  %33 = add i32 %32, 1
+  store i32 %33, i32* %loc2
+  br label %34
+
+; <label>:34                                      ; preds = %11, %31
+  %35 = load i32, i32* %loc2
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = icmp slt i32 %35, %41
+  br i1 %42, label %16, label %43
+
+; <label>:43                                      ; preds = %24, %37
+  %44 = load i32, i32* %loc2
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %45, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp eq i32 %44, %50
+  br i1 %51, label %62, label %52
+
+; <label>:52                                      ; preds = %46
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %7, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %57, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %58
+
+; <label>:58                                      ; preds = %55
+  %59 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %60 = load i32, i32 addrspace(1)* %59
+  %61 = icmp slt i32 %56, %60
+  br i1 %61, label %8, label %62
+
+; <label>:62                                      ; preds = %1, %46, %58
+  %63 = load i32, i32* %arg2
+  %64 = icmp eq i32 %63, 0
+  br i1 %64, label %122, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %66, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %67
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %66, i32 0, i32 1
+  %69 = load i32, i32 addrspace(1)* %68
+  %70 = sub i32 %69, 1
+  store i32 %70, i32* %loc0
+  br label %118
+
+; <label>:71                                      ; preds = %118
+  store i32 0, i32* %loc4
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %73 = load i32, i32* %loc0
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %74
+
+; <label>:74                                      ; preds = %71
+  %75 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 2, i32 %73
+  %76 = load i16, i16 addrspace(1)* %75
+  %77 = zext i16 %76 to i32
+  %78 = trunc i32 %77 to i16
+  store i16 %78, i16* %loc5
+  store i32 0, i32* %loc4
+  br label %97
+
+; <label>:79                                      ; preds = %100
+  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %81 = load i32, i32* %loc4
+  %NullCheck19 = icmp eq %"System.Char[]" addrspace(1)* %80, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
+
+; <label>:82                                      ; preds = %79
+  %83 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 1
+  %84 = load i32, i32 addrspace(1)* %83
+  %85 = zext i32 %84 to i64
+  %86 = zext i32 %81 to i64
+  %BoundsCheck21 = icmp uge i64 %86, %85
+  br i1 %BoundsCheck21, label %ThrowIndexOutOfRange22, label %87
+
+; <label>:87                                      ; preds = %82
+  %88 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 3, i32 %81
+  %89 = load i16, i16 addrspace(1)* %88, align 8
+  %90 = zext i16 %89 to i32
+  %91 = load i16, i16* %loc5
+  %92 = zext i16 %91 to i32
+  %93 = icmp eq i32 %90, %92
+  br i1 %93, label %106, label %94
+
+; <label>:94                                      ; preds = %87
+  %95 = load i32, i32* %loc4
+  %96 = add i32 %95, 1
+  store i32 %96, i32* %loc4
+  br label %97
+
+; <label>:97                                      ; preds = %74, %94
+  %98 = load i32, i32* %loc4
+  %99 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck15 = icmp eq %"System.Char[]" addrspace(1)* %99, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %100
+
+; <label>:100                                     ; preds = %97
+  %101 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %99, i32 0, i32 1
+  %102 = load i32, i32 addrspace(1)* %101
+  %103 = zext i32 %102 to i64
+  %104 = trunc i64 %103 to i32
+  %105 = icmp slt i32 %98, %104
+  br i1 %105, label %79, label %106
+
+; <label>:106                                     ; preds = %87, %100
+  %107 = load i32, i32* %loc4
+  %108 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck17 = icmp eq %"System.Char[]" addrspace(1)* %108, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %109
+
+; <label>:109                                     ; preds = %106
+  %110 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %108, i32 0, i32 1
+  %111 = load i32, i32 addrspace(1)* %110
+  %112 = zext i32 %111 to i64
+  %113 = trunc i64 %112 to i32
+  %114 = icmp eq i32 %107, %113
+  br i1 %114, label %122, label %115
+
+; <label>:115                                     ; preds = %109
+  %116 = load i32, i32* %loc0
+  %117 = sub i32 %116, 1
+  store i32 %117, i32* %loc0
+  br label %118
+
+; <label>:118                                     ; preds = %67, %115
+  %119 = load i32, i32* %loc0
+  %120 = load i32, i32* %loc1
+  %121 = icmp sge i32 %119, %120
+  br i1 %121, label %71, label %122
+
+; <label>:122                                     ; preds = %62, %109, %118
+  %123 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %124 = load i32, i32* %loc1
+  %125 = load i32, i32* %loc0
+  %126 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %123, i32 %124, i32 %125)
+  ret %System.String addrspace(1)* %126
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %97
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange22:                           ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
 Successfully read String.CreateTrimmedString
 
@@ -5439,8 +6893,8 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
@@ -5535,8 +6989,8 @@ entry:
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i64 2872
   %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
   %8 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %7
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %3
   %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
@@ -5553,8 +7007,8 @@ entry:
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 2864
   %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
   %21 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %20
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
-  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %22
 
 ; <label>:22                                      ; preds = %16
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
@@ -5569,7 +7023,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %16
+ThrowNullRef2:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5586,8 +7040,8 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5613,8 +7067,8 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
@@ -5632,8 +7086,8 @@ entry:
 
 ; <label>:12                                      ; preds = %4
   %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
@@ -5644,8 +7098,8 @@ entry:
 
 ; <label>:19                                      ; preds = %14
   %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %19
   %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
@@ -5660,21 +7114,21 @@ entry:
   %31 = zext i16 %30 to i32
   %32 = bitcast i8* %29 to i16*
   %33 = trunc i32 %31 to i16
-  %NullCheck6 = icmp ne i16* %32, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i16* %32, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %21
   store i16 %33, i16* %32, align 8
   %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %36
 
 ; <label>:36                                      ; preds = %34
   %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
   %38 = load i32, i32 addrspace(1)* %37, align 8
   %39 = add i32 %38, 1
-  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %40
 
 ; <label>:40                                      ; preds = %36
   %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
@@ -5683,16 +7137,16 @@ entry:
 
 ; <label>:42                                      ; preds = %14
   %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
-  br i1 %NullCheck12, label %44, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
   %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
   %47 = load i16, i16* %arg1
   %48 = zext i16 %47 to i32
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = trunc i32 %48 to i16
@@ -5703,31 +7157,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %19
+ThrowNullRef4:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %21
+ThrowNullRef6:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %36
+ThrowNullRef10:                                   ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %42
+ThrowNullRef12:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %44
+ThrowNullRef14:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5740,8 +7194,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -5752,8 +7206,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
@@ -5762,14 +7216,14 @@ entry:
 
 ; <label>:11                                      ; preds = %1
   %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
@@ -5779,15 +7233,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5808,8 +7262,8 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5822,8 +7276,8 @@ entry:
 
 ; <label>:8                                       ; preds = %3
   %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
@@ -5842,15 +7296,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
-  br i1 %NullCheck4, label %22, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
   %24 = load i16*, i16* addrspace(1)* %23, align 8
   %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %25, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
@@ -5859,8 +7313,8 @@ entry:
   store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
@@ -5874,8 +7328,8 @@ entry:
 
 ; <label>:37                                      ; preds = %65
   %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %37
   %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
@@ -5886,16 +7340,16 @@ entry:
   %45 = bitcast i16* %41 to i8*
   %46 = getelementptr inbounds i8, i8* %45, i64 %44
   %47 = bitcast i8* %46 to i16*
-  %NullCheck14 = icmp ne i16* %47, null
-  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %47, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %48
 
 ; <label>:48                                      ; preds = %39
   %49 = load i16, i16* %47, align 8
   %50 = zext i16 %49 to i32
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %52 = load i32, i32* %loc1
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %53
 
 ; <label>:53                                      ; preds = %48
   %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
@@ -5916,8 +7370,8 @@ entry:
 ; <label>:62                                      ; preds = %36, %59
   %63 = load i32, i32* %loc1
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck10, label %65, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %65
 
 ; <label>:65                                      ; preds = %62
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
@@ -5936,15 +7390,15 @@ entry:
 
 ; <label>:74                                      ; preds = %70
   %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
-  br i1 %NullCheck18, label %76, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %76
 
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
   %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
-  br i1 %NullCheck20, label %80, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
   %81 = load i64, i64 addrspace(1)* %79
@@ -5958,8 +7412,8 @@ entry:
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
   %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
-  br i1 %NullCheck22, label %92, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.String addrspace(1)* %90, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %92
 
 ; <label>:92                                      ; preds = %80
   %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
@@ -5969,15 +7423,15 @@ entry:
 
 ; <label>:96                                      ; preds = %70
   %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
-  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %98
 
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
   %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
-  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
   %103 = load i64, i64 addrspace(1)* %101
@@ -5991,8 +7445,8 @@ entry:
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
   %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
-  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.String addrspace(1)* %112, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %114
 
 ; <label>:114                                     ; preds = %102
   %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
@@ -6004,59 +7458,59 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %20
+ThrowNullRef4:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %22
+ThrowNullRef6:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %26
+ThrowNullRef8:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %62
+ThrowNullRef10:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %48
+ThrowNullRef16:                                   ; preds = %48
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %74
+ThrowNullRef18:                                   ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %76
+ThrowNullRef20:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %80
+ThrowNullRef22:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %96
+ThrowNullRef24:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %98
+ThrowNullRef26:                                   ; preds = %98
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %102
+ThrowNullRef28:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6069,15 +7523,15 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
   %3 = load i16*, i16* addrspace(1)* %2, align 8
   %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
@@ -6087,8 +7541,8 @@ entry:
   %10 = bitcast i16* %3 to i8*
   %11 = getelementptr inbounds i8, i8* %10, i64 %9
   %12 = bitcast i8* %11 to i16*
-  %NullCheck4 = icmp ne i16* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %5
   store i16 0, i16* %12, align 8
@@ -6098,11 +7552,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6119,8 +7573,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -6131,8 +7585,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
@@ -6144,15 +7598,15 @@ entry:
 
 ; <label>:14                                      ; preds = %1
   %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
   %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
   %21 = load i64, i64 addrspace(1)* %19
@@ -6171,15 +7625,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %14
+ThrowNullRef4:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %16
+ThrowNullRef6:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6302,14 +7756,6 @@ entry:
   ret %System.String addrspace(1)* %57
 }
 
-INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
-Successfully read RuntimeHelpers.get_OffsetToStringData
-
-define i32 @RuntimeHelpers.get_OffsetToStringData() {
-entry:
-  ret i32 12
-}
-
 INFO:  jitting method String::Equals using LLILCJit
 Successfully read String.Equals
 
@@ -6381,8 +7827,8 @@ entry:
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
-  br i1 %NullCheck24, label %29, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
   %30 = load i64, i64 addrspace(1)* %28
@@ -6397,8 +7843,8 @@ entry:
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
-  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
   %43 = load i64, i64 addrspace(1)* %41
@@ -6418,8 +7864,8 @@ entry:
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
   %59 = load i64, i64 addrspace(1)* %57
@@ -6434,8 +7880,8 @@ entry:
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck22, label %71, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
   %72 = load i64, i64 addrspace(1)* %70
@@ -6455,8 +7901,8 @@ entry:
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
-  br i1 %NullCheck16, label %87, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = load i64, i64 addrspace(1)* %86
@@ -6471,8 +7917,8 @@ entry:
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck18, label %100, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
   %101 = load i64, i64 addrspace(1)* %99
@@ -6492,8 +7938,8 @@ entry:
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
-  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
   %117 = load i64, i64 addrspace(1)* %115
@@ -6508,8 +7954,8 @@ entry:
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
-  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
   %130 = load i64, i64 addrspace(1)* %128
@@ -6528,15 +7974,15 @@ entry:
 
 ; <label>:142                                     ; preds = %22
   %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
-  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %143, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %144
 
 ; <label>:144                                     ; preds = %142
   %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
   %146 = load i32, i32 addrspace(1)* %145
   %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
-  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %147, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %148
 
 ; <label>:148                                     ; preds = %144
   %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
@@ -6557,15 +8003,15 @@ entry:
 
 ; <label>:159                                     ; preds = %22
   %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
-  br i1 %NullCheck, label %161, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %ThrowNullRef, label %161
 
 ; <label>:161                                     ; preds = %159
   %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
   %163 = load i32, i32 addrspace(1)* %162
   %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
-  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %164, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %165
 
 ; <label>:165                                     ; preds = %161
   %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
@@ -6578,8 +8024,8 @@ entry:
 
 ; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
-  br i1 %NullCheck4, label %172, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %171, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %172
 
 ; <label>:172                                     ; preds = %170
   %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
@@ -6589,8 +8035,8 @@ entry:
 
 ; <label>:176                                     ; preds = %172
   %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
-  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %177, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %178
 
 ; <label>:178                                     ; preds = %176
   %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
@@ -6629,55 +8075,55 @@ ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %161
+ThrowNullRef2:                                    ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %170
+ThrowNullRef4:                                    ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %176
+ThrowNullRef6:                                    ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %142
+ThrowNullRef8:                                    ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %144
+ThrowNullRef10:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %113
+ThrowNullRef12:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %116
+ThrowNullRef14:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %84
+ThrowNullRef16:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %87
+ThrowNullRef18:                                   ; preds = %87
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %55
+ThrowNullRef20:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %58
+ThrowNullRef22:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %26
+ThrowNullRef24:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %29
+ThrowNullRef26:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,8 +8161,8 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck, label %14, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %ThrowNullRef, label %14
 
 ; <label>:14                                      ; preds = %8
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
@@ -6760,8 +8206,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
@@ -6770,14 +8216,14 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32, i32* %loc0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %10
   %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
   %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
@@ -6790,15 +8236,15 @@ entry:
 ; <label>:25                                      ; preds = %19
   %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
-  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
   %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
@@ -6807,8 +8253,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %37 = load i32, i32* %loc0
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %38, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %38
 
 ; <label>:38                                      ; preds = %32
   %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
@@ -6817,14 +8263,14 @@ entry:
 
 ; <label>:40                                      ; preds = %19
   %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %40
   %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
   %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
-  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
-  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
@@ -6832,8 +8278,8 @@ entry:
   %48 = zext i32 %47 to i64
   %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
-  br i1 %NullCheck16, label %51, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %51
 
 ; <label>:51                                      ; preds = %45
   %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
@@ -6847,15 +8293,15 @@ entry:
 ; <label>:57                                      ; preds = %51
   %58 = load i16*, i16** %arg1
   %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
-  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %60
 
 ; <label>:60                                      ; preds = %57
   %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
   %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
-  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %64
 
 ; <label>:64                                      ; preds = %60
   %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
@@ -6864,22 +8310,22 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
   %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
-  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %70
 
 ; <label>:70                                      ; preds = %64
   %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
   %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
-  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
-  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
   %75 = load i32, i32 addrspace(1)* %74
   %76 = zext i32 %75 to i64
   %77 = trunc i64 %76 to i32
-  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
-  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %78
 
 ; <label>:78                                      ; preds = %73
   %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
@@ -6901,8 +8347,8 @@ entry:
   %90 = bitcast i16* %86 to i8*
   %91 = getelementptr inbounds i8, i8* %90, i64 %89
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %93
 
 ; <label>:93                                      ; preds = %80
   %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
@@ -6912,8 +8358,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %99 = load i32, i32* %loc2
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %100
 
 ; <label>:100                                     ; preds = %93
   %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
@@ -6928,63 +8374,63 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %25
+ThrowNullRef6:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %32
+ThrowNullRef10:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %40
+ThrowNullRef12:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %45
+ThrowNullRef16:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %57
+ThrowNullRef18:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %60
+ThrowNullRef20:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %64
+ThrowNullRef22:                                   ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %70
+ThrowNullRef24:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %73
+ThrowNullRef26:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %80
+ThrowNullRef28:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %93
+ThrowNullRef30:                                   ; preds = %93
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7004,8 +8450,8 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
@@ -7033,43 +8479,43 @@ entry:
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %14
   %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
   %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   %28 = load i32, i32 addrspace(1)* %27, align 8
   %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
-  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %30
 
 ; <label>:30                                      ; preds = %26
   %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
   %32 = load i32, i32 addrspace(1)* %31, align 8
   %33 = add i32 %28, %32
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %34
 
 ; <label>:34                                      ; preds = %30
   %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   store i32 %33, i32 addrspace(1)* %35
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
   store i32 0, i32 addrspace(1)* %38
   %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %40
 
 ; <label>:40                                      ; preds = %37
   %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
@@ -7082,8 +8528,8 @@ entry:
 
 ; <label>:47                                      ; preds = %40
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
@@ -7098,8 +8544,8 @@ entry:
   %54 = load i32, i32* %loc0
   %55 = sext i32 %54 to i64
   %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
-  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %57
 
 ; <label>:57                                      ; preds = %52
   %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
@@ -7110,68 +8556,35 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %14
+ThrowNullRef2:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %23
+ThrowNullRef4:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %26
+ThrowNullRef6:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %30
+ThrowNullRef8:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %34
+ThrowNullRef10:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %47
+ThrowNullRef14:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %52
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-}
-
-INFO:  jitting method StringBuilder::get_Length using LLILCJit
-Successfully read StringBuilder.get_Length
-
-define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.StringBuilder addrspace(1)*
-  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
-  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
-
-; <label>:1                                       ; preds = %entry
-  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %3 = load i32, i32 addrspace(1)* %2, align 8
-  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
-
-; <label>:5                                       ; preds = %1
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = add i32 %3, %7
-  ret i32 %8
-
-ThrowNullRef:                                     ; preds = %entry
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef16:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7213,70 +8626,70 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
   %6 = load i32, i32 addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
   store i32 %6, i32 addrspace(1)* %8
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
   %13 = load i32, i32 addrspace(1)* %12, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
   store i32 %13, i32 addrspace(1)* %15
   %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
-  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %18
 
 ; <label>:18                                      ; preds = %14
   %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
   %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
   %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
   %34 = load i32, i32 addrspace(1)* %33, align 8
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
-  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
@@ -7287,39 +8700,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %28
+ThrowNullRef16:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %32
+ThrowNullRef18:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7455,13 +8868,13 @@ entry:
 ; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
@@ -7477,16 +8890,16 @@ entry:
 
 ; <label>:18                                      ; preds = %15
   %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
   store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
   %22 = load i32, i32* %loc0
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %24
 
 ; <label>:24                                      ; preds = %20
   %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
@@ -7498,13 +8911,13 @@ entry:
 ; <label>:28                                      ; preds = %15, %24
   %29 = load i32, i32* %arg1
   %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %31
   %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
@@ -7517,20 +8930,20 @@ entry:
   %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
-  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
   %46 = load i32, i32 addrspace(1)* %45, align 8
   %47 = sub i32 %40, %46
-  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
-  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i32 addrspace(1)* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %48
 
 ; <label>:48                                      ; preds = %44
   store i32 %47, i32 addrspace(1)* %39, align 8
@@ -7538,21 +8951,21 @@ entry:
 
 ; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
-  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %51
 
 ; <label>:51                                      ; preds = %49
   %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %53
 
 ; <label>:53                                      ; preds = %51
   %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
   %55 = load i32, i32 addrspace(1)* %54, align 8
   %56 = load i32, i32* %arg2
   %57 = sub i32 %55, %56
-  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %58
 
 ; <label>:58                                      ; preds = %53
   %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
@@ -7562,13 +8975,13 @@ entry:
 ; <label>:60                                      ; preds = %33, %58
   %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
   %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
-  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %63
 
 ; <label>:63                                      ; preds = %60
   %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
-  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
-  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
@@ -7578,15 +8991,15 @@ entry:
 
 ; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
-  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i32 addrspace(1)* %69, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %70
 
 ; <label>:70                                      ; preds = %68
   %71 = load i32, i32 addrspace(1)* %69, align 8
   store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
-  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
@@ -7596,8 +9009,8 @@ entry:
   store i32 %77, i32* %loc4
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
-  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %80
 
 ; <label>:80                                      ; preds = %73
   %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
@@ -7607,71 +9020,71 @@ entry:
 ; <label>:83                                      ; preds = %80
   store i32 0, i32* %loc3
   %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
-  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
-  br i1 %NullCheck26, label %88, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i32 addrspace(1)* %87, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %88
 
 ; <label>:88                                      ; preds = %85
   %89 = load i32, i32 addrspace(1)* %87, align 8
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
-  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %90
 
 ; <label>:90                                      ; preds = %88
   %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
   store i32 %89, i32 addrspace(1)* %91
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
-  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
-  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %96
 
 ; <label>:96                                      ; preds = %94
   %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
-  br i1 %NullCheck34, label %100, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %100
 
 ; <label>:100                                     ; preds = %96
   %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
-  br i1 %NullCheck36, label %102, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %102
 
 ; <label>:102                                     ; preds = %100
   %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
   %104 = load i32, i32 addrspace(1)* %103, align 8
   %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
-  br i1 %NullCheck38, label %106, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %106
 
 ; <label>:106                                     ; preds = %102
   %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
-  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
-  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %108
 
 ; <label>:108                                     ; preds = %106
   %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
   %110 = load i32, i32 addrspace(1)* %109, align 8
   %111 = add i32 %104, %110
-  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %112
 
 ; <label>:112                                     ; preds = %108
   %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
   store i32 %111, i32 addrspace(1)* %113
   %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
-  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i32 addrspace(1)* %114, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %115
 
 ; <label>:115                                     ; preds = %112
   %116 = load i32, i32 addrspace(1)* %114, align 8
@@ -7681,19 +9094,19 @@ entry:
 ; <label>:118                                     ; preds = %115
   %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
-  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %121
 
 ; <label>:121                                     ; preds = %118
   %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
-  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
-  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %123
 
 ; <label>:123                                     ; preds = %121
   %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
   %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
-  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
-  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %126
 
 ; <label>:126                                     ; preds = %123
   %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
@@ -7705,8 +9118,8 @@ entry:
 
 ; <label>:130                                     ; preds = %80, %115, %126
   %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %132
 
 ; <label>:132                                     ; preds = %130
   %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7715,8 +9128,8 @@ entry:
   %136 = load i32, i32* %loc3
   %137 = sub i32 %135, %136
   %138 = sub i32 %134, %137
-  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %139
 
 ; <label>:139                                     ; preds = %132
   %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7728,16 +9141,16 @@ entry:
 
 ; <label>:144                                     ; preds = %139
   %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
-  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %146
 
 ; <label>:146                                     ; preds = %144
   %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
   %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
   %149 = load i32, i32* %loc2
   %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
-  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %151
 
 ; <label>:151                                     ; preds = %146
   %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
@@ -7754,145 +9167,249 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %18
+ThrowNullRef4:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %31
+ThrowNullRef10:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %44
+ThrowNullRef16:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %68
+ThrowNullRef18:                                   ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %70
+ThrowNullRef20:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %73
+ThrowNullRef22:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %83
+ThrowNullRef24:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %85
+ThrowNullRef26:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %88
+ThrowNullRef28:                                   ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %90
+ThrowNullRef30:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %94
+ThrowNullRef32:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %96
+ThrowNullRef34:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %100
+ThrowNullRef36:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %102
+ThrowNullRef38:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %106
+ThrowNullRef40:                                   ; preds = %106
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %108
+ThrowNullRef42:                                   ; preds = %108
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %112
+ThrowNullRef44:                                   ; preds = %112
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %118
+ThrowNullRef46:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %121
+ThrowNullRef48:                                   ; preds = %121
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %123
+ThrowNullRef50:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %130
+ThrowNullRef52:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %132
+ThrowNullRef54:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %144
+ThrowNullRef56:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %146
+ThrowNullRef58:                                   ; preds = %146
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %60
+ThrowNullRef60:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %63
+ThrowNullRef62:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %49
+ThrowNullRef64:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %51
+ThrowNullRef66:                                   ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %53
+ThrowNullRef68:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(%"System.Char[]" addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %arg0 = alloca %"System.Char[]" addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store %"System.Char[]" addrspace(1)* %param0, %"System.Char[]" addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load i32, i32* %arg4
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %43, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %38, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg1
+  %13 = load i32, i32* %arg4
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %38, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %24 = load i32, i32* %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %35 = load i32, i32* %arg3
+  %36 = load i32, i32* %arg4
+  %37 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %37, %"System.Char[]" addrspace(1)* %34, i32 %35, i32 %36)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:38                                      ; preds = %5, %16
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Successfully read Buffer._Memmove
 
@@ -7914,7 +9431,7 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[loadElem]
+Failed to read AppDomain.SetDataHelper[storeElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -7923,8 +9440,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
@@ -7934,8 +9451,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
@@ -7947,15 +9464,15 @@ entry:
   %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
   %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
@@ -7966,15 +9483,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7992,7 +9509,79 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
-Failed to read Dictionary`2.TryGetValue[loadElemA]
+Successfully read Dictionary`2.TryGetValue
+
+define i8 @"Dictionary`2.TryGetValue"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)* addrspace(1)* %param2) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  %arg2 = alloca %System.__Canon addrspace(1)* addrspace(1)*
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  store %System.__Canon addrspace(1)* addrspace(1)* %param2, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  store i32 %2, i32* %loc0
+  %3 = load i32, i32* %loc0
+  %4 = icmp slt i32 %3, 0
+  br i1 %4, label %22, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 2
+  %10 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %9, align 8
+  %11 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = zext i32 %11 to i64
+  %BoundsCheck = icmp uge i64 %16, %15
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 3, i32 %11
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %20, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %6, %System.__Canon addrspace(1)* %21)
+  ret i8 1
+
+; <label>:22                                      ; preds = %entry
+  %23 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %23, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -8058,8 +9647,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
@@ -8091,8 +9680,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
@@ -8171,15 +9760,15 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck, label %19, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %ThrowNullRef, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
   %21 = load i32, i32 addrspace(1)* %20
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
@@ -8202,7 +9791,7 @@ ThrowNullRef:                                     ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %19
+ThrowNullRef2:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8248,8 +9837,8 @@ entry:
   %0 = alloca %System.AppDomainHandle
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %1 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %1, i32 0, i32 15
@@ -8269,8 +9858,8 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
@@ -8286,7 +9875,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -8299,8 +9888,8 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -8327,8 +9916,8 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
@@ -8352,8 +9941,8 @@ entry:
   %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
   store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
@@ -8363,8 +9952,8 @@ entry:
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
@@ -8374,8 +9963,8 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %9
   %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
@@ -8384,8 +9973,8 @@ entry:
 
 ; <label>:18                                      ; preds = %3, %16
   %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
@@ -8397,15 +9986,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %18
+ThrowNullRef6:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8418,8 +10007,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
@@ -8453,15 +10042,15 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
@@ -8473,7 +10062,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8481,7 +10070,7 @@ ThrowNullRef1:                                    ; preds = %1
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
 Failed to read Dictionary`2.System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
@@ -8506,8 +10095,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
@@ -8524,8 +10113,8 @@ entry:
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -8544,7 +10133,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8577,8 +10166,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = load i64, i64* %arg2
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = trunc i32 %3 to i8
@@ -8634,46 +10223,46 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
   %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
-  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
-  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
-  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
@@ -8684,27 +10273,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %20
+ThrowNullRef12:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8717,8 +10306,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -8756,22 +10345,22 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
   %9 = load i64, i64 addrspace(1)* %8, align 8
   %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
   %13 = load i64, i64 addrspace(1)* %12, align 8
   %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %11
   %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
@@ -8788,11 +10377,11 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8882,8 +10471,8 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
@@ -8900,8 +10489,8 @@ entry:
 ; <label>:8                                       ; preds = %1
   %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
   %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
@@ -8911,15 +10500,15 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
   %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
   %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
-  br i1 %NullCheck6, label %21, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
@@ -8946,15 +10535,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8992,15 +10581,15 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
   store i8 %3, i8 addrspace(1)* %5
   %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
@@ -9011,7 +10600,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9027,8 +10616,8 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -9041,8 +10630,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
@@ -9058,7 +10647,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9080,8 +10669,8 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
@@ -9096,8 +10685,8 @@ entry:
 ; <label>:12                                      ; preds = %6
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
@@ -9112,8 +10701,8 @@ entry:
 ; <label>:21                                      ; preds = %15
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
@@ -9128,8 +10717,8 @@ entry:
 ; <label>:30                                      ; preds = %24
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %31, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
@@ -9144,8 +10733,8 @@ entry:
 ; <label>:39                                      ; preds = %33
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
-  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %40, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %42
 
 ; <label>:42                                      ; preds = %39
   %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
@@ -9164,19 +10753,19 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %21
+ThrowNullRef4:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %30
+ThrowNullRef6:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %39
+ThrowNullRef8:                                    ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9243,8 +10832,8 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
@@ -9264,57 +10853,57 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
   store i8 0, i8 addrspace(1)* %2
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
   store i8 0, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
   store i8 0, i8 addrspace(1)* %17
   %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
   store i8 0, i8 addrspace(1)* %20
   %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
-  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
@@ -9325,31 +10914,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %19
+ThrowNullRef14:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9367,8 +10956,8 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
@@ -9380,8 +10969,8 @@ entry:
 
 ; <label>:9                                       ; preds = %4
   %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %9
   %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
@@ -9395,7 +10984,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef2:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9420,8 +11009,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
@@ -9512,8 +11101,8 @@ entry:
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
@@ -9524,8 +11113,8 @@ entry:
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = load i64, i64 addrspace(1)* %12
@@ -9537,8 +11126,8 @@ entry:
   %20 = load i64, i64* %19
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
-  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %13
   %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
@@ -9555,8 +11144,8 @@ entry:
 ; <label>:30                                      ; preds = %25
   %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %32 = load i32, i32* %arg2
-  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
-  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
@@ -9570,15 +11159,15 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %30
+ThrowNullRef2:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9622,87 +11211,87 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
   %10 = load i8, i8 addrspace(1)* %9, align 8
   %11 = zext i8 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %8
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
   store i8 %12, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
   %19 = load i8, i8 addrspace(1)* %18, align 8
   %20 = zext i8 %19 to i32
   %21 = trunc i32 %20 to i8
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
   store i8 %21, i8 addrspace(1)* %23
   %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
   %28 = load i8, i8 addrspace(1)* %27, align 8
   %29 = zext i8 %28 to i32
   %30 = trunc i32 %29 to i8
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
-  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %31
 
 ; <label>:31                                      ; preds = %26
   %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
   store i8 %30, i8 addrspace(1)* %32
   %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
-  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
-  br i1 %NullCheck14, label %40, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %40
 
 ; <label>:40                                      ; preds = %35
   %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
   store i8 %39, i8 addrspace(1)* %41
   %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
-  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %44
 
 ; <label>:44                                      ; preds = %40
   %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
   %46 = load i8, i8 addrspace(1)* %45, align 8
   %47 = zext i8 %46 to i32
   %48 = trunc i32 %47 to i8
-  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
   store i8 %48, i8 addrspace(1)* %50
   %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
-  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
@@ -9713,29 +11302,29 @@ entry:
 ; <label>:56                                      ; preds = %52
   %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
-  br i1 %NullCheck22, label %59, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
   %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
   %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
-  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
-  br i1 %NullCheck24, label %63, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
   %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
-  br i1 %NullCheck26, label %66, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
   %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
-  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
-  br i1 %NullCheck28, label %69, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %69
 
 ; <label>:69                                      ; preds = %66
   %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
@@ -9744,15 +11333,15 @@ entry:
 
 ; <label>:71                                      ; preds = %105
   %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
-  br i1 %NullCheck34, label %73, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %73
 
 ; <label>:73                                      ; preds = %71
   %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
   %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
   %76 = load i32, i32* %loc0
-  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
-  br i1 %NullCheck36, label %77, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
@@ -9766,8 +11355,8 @@ entry:
 
 ; <label>:83                                      ; preds = %77
   %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
-  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
@@ -9775,14 +11364,14 @@ entry:
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
   %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
-  br i1 %NullCheck40, label %91, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
 ; <label>:91                                      ; preds = %85
   %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
   %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
-  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck42, label %94, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %94
 
 ; <label>:94                                      ; preds = %91
   %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
@@ -9798,14 +11387,14 @@ entry:
 ; <label>:99                                      ; preds = %69, %96
   %100 = load i32, i32* %loc0
   %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
-  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %102
 
 ; <label>:102                                     ; preds = %99
   %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
   %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
-  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
-  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
@@ -9819,87 +11408,87 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %26
+ThrowNullRef10:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %31
+ThrowNullRef12:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %35
+ThrowNullRef14:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %40
+ThrowNullRef16:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %56
+ThrowNullRef22:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %59
+ThrowNullRef24:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %63
+ThrowNullRef26:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %66
+ThrowNullRef28:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %102
+ThrowNullRef32:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %71
+ThrowNullRef34:                                   ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %73
+ThrowNullRef36:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %83
+ThrowNullRef38:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %85
+ThrowNullRef40:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %91
+ThrowNullRef42:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9943,15 +11532,15 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
   %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
@@ -9961,28 +11550,28 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
   %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %12
   %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
   %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
   %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
-  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
@@ -9993,23 +11582,23 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %12
+ThrowNullRef6:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10031,15 +11620,15 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
   %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = load i64, i64 addrspace(1)* %7
@@ -10077,13 +11666,13 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[loadElem]
+Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -10111,8 +11700,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -10205,8 +11794,8 @@ entry:
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load float, float* %arg0
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -10340,8 +11929,8 @@ entry:
   store i64 %param0, i64* %arg0
   store i64 %param1, i64* %arg1
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
@@ -10349,8 +11938,8 @@ entry:
   %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
   %5 = load i16*, i16* addrspace(1)* %4, align 8
   %6 = addrspacecast i64* %arg1 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = bitcast i64 addrspace(1)* %6 to i8 addrspace(1)*
@@ -10366,7 +11955,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10400,8 +11989,8 @@ entry:
   %1 = load i32, i32* %arg1
   %2 = sext i32 %1 to i64
   %3 = inttoptr i64 %2 to i16*
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -10454,8 +12043,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, i32)*)(%System.IO.ConsoleStream addrspace(1)* %2, i32 %1)
   %3 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %4 = load i64, i64* %arg1
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
@@ -10466,8 +12055,8 @@ entry:
   %10 = icmp eq i32 %9, 3
   %11 = sext i1 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %5
   %14 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, i32 0, i32 5
@@ -10478,7 +12067,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10501,8 +12090,8 @@ entry:
   %5 = icmp eq i32 %4, 1
   %6 = sext i1 %5 to i32
   %7 = trunc i32 %6 to i8
-  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %2, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.ConsoleStream addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
@@ -10513,8 +12102,8 @@ entry:
   %13 = icmp eq i32 %12, 2
   %14 = sext i1 %13 to i32
   %15 = trunc i32 %14 to i8
-  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %10, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.ConsoleStream addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %8
   %17 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %10, i32 0, i32 4
@@ -10525,7 +12114,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10564,8 +12153,8 @@ entry:
   %arg0 = alloca i64
   store i64 %param0, i64* %arg0
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
@@ -10600,8 +12189,8 @@ entry:
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
   %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = load i64, i64 addrspace(1)* %7
@@ -10705,7 +12294,127 @@ entry:
 INFO:  jitting method Encoding::GetEncoding using LLILCJit
 Failed to read Encoding.GetEncoding[convertToHelperArgumentType]
 INFO:  jitting method EncodingProvider::GetEncodingFromProvider using LLILCJit
-Failed to read EncodingProvider.GetEncodingFromProvider[loadElem]
+Successfully read EncodingProvider.GetEncodingFromProvider
+
+define %System.Text.Encoding addrspace(1)* @EncodingProvider.GetEncodingFromProvider(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca %"System.Text.EncodingProvider[]" addrspace(1)*
+  %loc1 = alloca %System.Text.EncodingProvider addrspace(1)*
+  %loc2 = alloca %System.Text.Encoding addrspace(1)*
+  %loc3 = alloca %System.Text.Encoding addrspace(1)*
+  %loc4 = alloca %"System.Text.EncodingProvider[]" addrspace(1)*
+  %loc5 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1059)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2392
+  %2 = addrspacecast i8 addrspace(1)* %1 to %"System.Text.EncodingProvider[]" addrspace(1)**
+  %3 = load volatile %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %2
+  %4 = icmp ne %"System.Text.EncodingProvider[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %entry
+  ret %System.Text.Encoding addrspace(1)* null
+
+; <label>:6                                       ; preds = %entry
+  %7 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1059)
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i64 2392
+  %9 = addrspacecast i8 addrspace(1)* %8 to %"System.Text.EncodingProvider[]" addrspace(1)**
+  %10 = load volatile %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %9
+  store %"System.Text.EncodingProvider[]" addrspace(1)* %10, %"System.Text.EncodingProvider[]" addrspace(1)** %loc0
+  %11 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc0
+  store %"System.Text.EncodingProvider[]" addrspace(1)* %11, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  store i32 0, i32* %loc5
+  br label %43
+
+; <label>:12                                      ; preds = %46
+  %13 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  %14 = load i32, i32* %loc5
+  %NullCheck1 = icmp eq %"System.Text.EncodingProvider[]" addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %13, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = zext i32 %17 to i64
+  %19 = zext i32 %14 to i64
+  %BoundsCheck = icmp uge i64 %19, %18
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %20
+
+; <label>:20                                      ; preds = %15
+  %21 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %13, i32 0, i32 3, i32 %14
+  %22 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)* addrspace(1)* %21, align 8
+  store %System.Text.EncodingProvider addrspace(1)* %22, %System.Text.EncodingProvider addrspace(1)** %loc1
+  %23 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)** %loc1
+  %24 = load i32, i32* %arg0
+  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i64 addrspace(1)*
+  %NullCheck3 = icmp eq i64 addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
+
+; <label>:26                                      ; preds = %20
+  %27 = load i64, i64 addrspace(1)* %25
+  %28 = add i64 %27, 64
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 40
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Text.Encoding addrspace(1)* (%System.Text.EncodingProvider addrspace(1)*, i32)*
+  %35 = call %System.Text.Encoding addrspace(1)* %34(%System.Text.EncodingProvider addrspace(1)* %23, i32 %24)
+  store %System.Text.Encoding addrspace(1)* %35, %System.Text.Encoding addrspace(1)** %loc2
+  %36 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc2
+  %37 = icmp eq %System.Text.Encoding addrspace(1)* %36, null
+  br i1 %37, label %40, label %38
+
+; <label>:38                                      ; preds = %26
+  %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc2
+  store %System.Text.Encoding addrspace(1)* %39, %System.Text.Encoding addrspace(1)** %loc3
+  br label %53
+
+; <label>:40                                      ; preds = %26
+  %41 = load i32, i32* %loc5
+  %42 = add i32 %41, 1
+  store i32 %42, i32* %loc5
+  br label %43
+
+; <label>:43                                      ; preds = %6, %40
+  %44 = load i32, i32* %loc5
+  %45 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  %NullCheck = icmp eq %"System.Text.EncodingProvider[]" addrspace(1)* %45, null
+  br i1 %NullCheck, label %ThrowNullRef, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp slt i32 %44, %50
+  br i1 %51, label %12, label %52
+
+; <label>:52                                      ; preds = %46
+  ret %System.Text.Encoding addrspace(1)* null
+
+; <label>:53                                      ; preds = %38
+  %54 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc3
+  ret %System.Text.Encoding addrspace(1)* %54
+
+ThrowNullRef:                                     ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method EncodingProvider::.cctor using LLILCJit
 Successfully read EncodingProvider..cctor
 
@@ -10724,7 +12433,7 @@ Failed to read Encoding.get_InternalSyncObject[Call HasTypeArg]
 INFO:  jitting method Hashtable::.ctor using LLILCJit
 Failed to read Hashtable..ctor[Volatile store]
 INFO:  jitting method Hashtable::get_Item using LLILCJit
-Failed to read Hashtable.get_Item[loadElemA]
+Failed to read Hashtable.get_Item[loadNonPrimitiveObj]
 INFO:  jitting method Hashtable::InitHash using LLILCJit
 Successfully read Hashtable.InitHash
 
@@ -10744,8 +12453,8 @@ entry:
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -10761,15 +12470,15 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
   %15 = load i32, i32* %loc0
-  %NullCheck2 = icmp ne i32 addrspace(1)* %14, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i32 addrspace(1)* %14, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %3
   store i32 %15, i32 addrspace(1)* %14, align 8
   %17 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %18 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %NullCheck4 = icmp ne i32 addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i32 addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = load i32, i32 addrspace(1)* %18, align 8
@@ -10778,8 +12487,8 @@ entry:
   %23 = sub i32 %22, 1
   %24 = urem i32 %21, %23
   %25 = add i32 1, %24
-  %NullCheck6 = icmp ne i32 addrspace(1)* %17, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32 addrspace(1)* %17, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %19
   store i32 %25, i32 addrspace(1)* %17, align 8
@@ -10790,15 +12499,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %19
+ThrowNullRef6:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10813,8 +12522,8 @@ entry:
   store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
   store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %NullCheck = icmp ne %System.Collections.Hashtable addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Collections.Hashtable addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
@@ -10824,16 +12533,16 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Collections.Hashtable addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Collections.Hashtable addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
   %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck4 = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %9, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
   %13 = inttoptr i64 %11 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
@@ -10843,8 +12552,8 @@ entry:
 ; <label>:15                                      ; preds = %1
   %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -10862,15 +12571,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10884,8 +12593,8 @@ entry:
   store %System.Int32 addrspace(1)* %param0, %System.Int32 addrspace(1)** %this
   %0 = load %System.Int32 addrspace(1)*, %System.Int32 addrspace(1)** %this
   %1 = bitcast %System.Int32 addrspace(1)* %0 to i32 addrspace(1)*
-  %NullCheck = icmp ne i32 addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq i32 addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load i32, i32 addrspace(1)* %1, align 8
@@ -10961,8 +12670,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.UTF8Encoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
@@ -10971,15 +12680,15 @@ entry:
   %9 = load i8, i8* %arg2
   %10 = zext i8 %9 to i32
   %11 = trunc i32 %10 to i8
-  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %8, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %6
   %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %8, i32 0, i32 8
   store i8 %11, i8 addrspace(1)* %13
   %14 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %14, i32 0, i32 8
@@ -10991,8 +12700,8 @@ entry:
 ; <label>:20                                      ; preds = %15
   %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %22, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %22, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = load i64, i64 addrspace(1)* %22
@@ -11014,15 +12723,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %12
+ThrowNullRef4:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11037,8 +12746,8 @@ entry:
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
@@ -11060,16 +12769,16 @@ entry:
 ; <label>:10                                      ; preds = %1
   %11 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
   %12 = load i32, i32* %arg1
-  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %11, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.Encoding addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
   store i32 %12, i32 addrspace(1)* %14
   %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
   %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = load i64, i64 addrspace(1)* %16
@@ -11087,11 +12796,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11104,8 +12813,8 @@ entry:
   %this = alloca %System.Text.UTF8Encoding addrspace(1)*
   store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
   %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.UTF8Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
@@ -11117,16 +12826,16 @@ entry:
 ; <label>:6                                       ; preds = %1
   %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %8 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %10, %System.Text.EncoderFallback addrspace(1)* %8)
   %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %12 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
-  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %11, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %11, i32 0, i32 3
@@ -11139,8 +12848,8 @@ entry:
   %18 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %18, %System.String addrspace(1)* %17)
   %19 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %18 to %System.Text.EncoderFallback addrspace(1)*
-  %NullCheck6 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %16, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %16, i32 0, i32 2
@@ -11150,8 +12859,8 @@ entry:
   %24 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %24, %System.String addrspace(1)* %23)
   %25 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %24 to %System.Text.DecoderFallback addrspace(1)*
-  %NullCheck8 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %22, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %22, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %20
   %27 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %22, i32 0, i32 3
@@ -11162,19 +12871,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %20
+ThrowNullRef8:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11204,8 +12913,8 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load i32, i32* %arg1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -11223,8 +12932,8 @@ entry:
 ; <label>:15                                      ; preds = %8
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %17 = load i32, i32* %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 %17
@@ -11240,7 +12949,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11292,7 +13001,7 @@ entry:
 }
 
 INFO:  jitting method Hashtable::Insert using LLILCJit
-Failed to read Hashtable.Insert[loadElemA]
+Failed to read Hashtable.Insert[storeElem]
 INFO:  jitting method ConsoleEncoding::.ctor using LLILCJit
 Successfully read ConsoleEncoding..ctor
 
@@ -11307,8 +13016,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %1)
   %2 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
@@ -11344,8 +13053,8 @@ entry:
   %2 = call %System.Text.InternalEncoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalEncoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %1)
   %3 = bitcast %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2 to %System.Text.EncoderFallback addrspace(1)*
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
@@ -11355,8 +13064,8 @@ entry:
   %8 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %7)
   %9 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %8 to %System.Text.DecoderFallback addrspace(1)*
-  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %6, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.Encoding addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %4
   %11 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %6, i32 0, i32 3
@@ -11367,7 +13076,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11386,15 +13095,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* %1)
   %2 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   %6 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, i32 0, i32 1
@@ -11405,7 +13114,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11433,8 +13142,8 @@ entry:
   store %System.Text.InternalDecoderBestFitFallback addrspace(1)* %param0, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
   %0 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
@@ -11444,15 +13153,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %4)
   %5 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %6)
   %9 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, i32 0, i32 1
@@ -11463,11 +13172,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11535,8 +13244,8 @@ entry:
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
   %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = load i64, i64 addrspace(1)* %19
@@ -11600,8 +13309,8 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.ConsoleStream addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
@@ -11632,31 +13341,31 @@ entry:
   store i8 %param4, i8* %arg4
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %3, %System.IO.Stream addrspace(1)* %1)
   %4 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %4, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
   %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %4, i32 0, i32 4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %5)
   %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %6
   %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
   %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
   %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = load i64, i64 addrspace(1)* %13
@@ -11668,8 +13377,8 @@ entry:
   %21 = load i64, i64* %20
   %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %8, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %8, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %14
   %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 5
@@ -11687,24 +13396,24 @@ entry:
   %31 = load i32, i32* %arg3
   %32 = sext i32 %31 to i64
   %33 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %32)
-  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %30, null
-  br i1 %NullCheck10, label %34, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.StreamWriter addrspace(1)* %30, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %35, %"System.Char[]" addrspace(1)* %33)
   %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %37, null
-  br i1 %NullCheck12, label %38, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.StreamWriter addrspace(1)* %37, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %38
 
 ; <label>:38                                      ; preds = %34
   %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
   %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
   %41 = load i32, i32* %arg3
   %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %42, null
-  br i1 %NullCheck14, label %43, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %42, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
   %44 = load i64, i64 addrspace(1)* %42
@@ -11718,30 +13427,30 @@ entry:
   %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
   %53 = sext i32 %52 to i64
   %54 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %53)
-  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
-  br i1 %NullCheck16, label %55, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %55
 
 ; <label>:55                                      ; preds = %43
   %56 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %56, %"System.Byte[]" addrspace(1)* %54)
   %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %58 = load i32, i32* %arg3
-  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %57, null
-  br i1 %NullCheck18, label %59, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.StreamWriter addrspace(1)* %57, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %59
 
 ; <label>:59                                      ; preds = %55
   %60 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 10
   store i32 %58, i32 addrspace(1)* %60
   %61 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %61, null
-  br i1 %NullCheck20, label %62, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.IO.StreamWriter addrspace(1)* %61, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %62
 
 ; <label>:62                                      ; preds = %59
   %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
   %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
   %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
   %67 = load i64, i64 addrspace(1)* %65
@@ -11759,15 +13468,15 @@ entry:
 
 ; <label>:78                                      ; preds = %66
   %79 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %79, null
-  br i1 %NullCheck24, label %80, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.StreamWriter addrspace(1)* %79, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %80
 
 ; <label>:80                                      ; preds = %78
   %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
   %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
   %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %83, null
-  br i1 %NullCheck26, label %84, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %83, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
   %85 = load i64, i64 addrspace(1)* %83
@@ -11784,8 +13493,8 @@ entry:
 
 ; <label>:95                                      ; preds = %84
   %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.IO.StreamWriter addrspace(1)* %96, null
-  br i1 %NullCheck28, label %97, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.IO.StreamWriter addrspace(1)* %96, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %97
 
 ; <label>:97                                      ; preds = %95
   %98 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 12
@@ -11799,8 +13508,8 @@ entry:
   %103 = icmp eq i32 %102, 0
   %104 = sext i1 %103 to i32
   %105 = trunc i32 %104 to i8
-  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %100, null
-  br i1 %NullCheck30, label %106, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.IO.StreamWriter addrspace(1)* %100, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %106
 
 ; <label>:106                                     ; preds = %99
   %107 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %100, i32 0, i32 13
@@ -11811,63 +13520,63 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %6
+ThrowNullRef4:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %29
+ThrowNullRef10:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %34
+ThrowNullRef12:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %38
+ThrowNullRef14:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %43
+ThrowNullRef16:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %55
+ThrowNullRef18:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %59
+ThrowNullRef20:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %62
+ThrowNullRef22:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %78
+ThrowNullRef24:                                   ; preds = %78
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %80
+ThrowNullRef26:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %95
+ThrowNullRef28:                                   ; preds = %95
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11880,15 +13589,15 @@ entry:
   %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = load i64, i64 addrspace(1)* %4
@@ -11906,7 +13615,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11956,35 +13665,35 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
   %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderNLS addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %7 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.EncoderNLS addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Text.Encoding addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.Encoding addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Text.EncoderNLS addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.EncoderNLS addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
   %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck8 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = load i64, i64 addrspace(1)* %16
@@ -12003,19 +13712,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12041,8 +13750,8 @@ entry:
   %this = alloca %System.Text.Encoding addrspace(1)*
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
@@ -12062,15 +13771,15 @@ entry:
   %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
   store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
   %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
   store i32 0, i32 addrspace(1)* %2
   %3 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, i32 0, i32 2
@@ -12080,15 +13789,15 @@ entry:
 
 ; <label>:8                                       ; preds = %4
   %9 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
   %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
   %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = load i64, i64 addrspace(1)* %13
@@ -12109,15 +13818,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12132,16 +13841,16 @@ entry:
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = load i32, i32* %arg1
   %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
   %7 = load i64, i64 addrspace(1)* %5
@@ -12159,7 +13868,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12196,8 +13905,8 @@ entry:
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
   %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
   %16 = load i64, i64 addrspace(1)* %14
@@ -12218,8 +13927,8 @@ entry:
   %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
   %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
   %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %31, null
-  br i1 %NullCheck2, label %32, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = load i64, i64 addrspace(1)* %31
@@ -12262,7 +13971,7 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12275,14 +13984,14 @@ entry:
   %this = alloca %System.Text.EncoderReplacementFallback addrspace(1)*
   store %System.Text.EncoderReplacementFallback addrspace(1)* %param0, %System.Text.EncoderReplacementFallback addrspace(1)** %this
   %0 = load %System.Text.EncoderReplacementFallback addrspace(1)*, %System.Text.EncoderReplacementFallback addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -12293,7 +14002,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12323,8 +14032,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
@@ -12356,8 +14065,8 @@ entry:
   %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
   store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
@@ -12369,8 +14078,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Threading.Tasks.Task addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %7)
@@ -12393,7 +14102,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12412,8 +14121,8 @@ entry:
   store i8 %param1, i8* %arg1
   store i8 %param2, i8* %arg2
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
@@ -12427,8 +14136,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1, %5
   %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 9
@@ -12459,8 +14168,8 @@ entry:
 
 ; <label>:25                                      ; preds = %8, %20
   %26 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %26, null
-  br i1 %NullCheck4, label %27, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %26, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %26, i32 0, i32 12
@@ -12471,22 +14180,22 @@ entry:
 
 ; <label>:32                                      ; preds = %27
   %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %33, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.IO.StreamWriter addrspace(1)* %33, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %32
   %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 12
   store i8 1, i8 addrspace(1)* %35
   %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
-  br i1 %NullCheck8, label %37, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
   %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
   %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck10 = icmp ne i64 addrspace(1)* %40, null
-  br i1 %NullCheck10, label %41, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64 addrspace(1)* %40, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i64, i64 addrspace(1)* %40
@@ -12500,8 +14209,8 @@ entry:
   %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
   store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
   %51 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %NullCheck12 = icmp ne %"System.Byte[]" addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Byte[]" addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %41
   %53 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %51, i32 0, i32 1
@@ -12513,16 +14222,16 @@ entry:
 
 ; <label>:58                                      ; preds = %52
   %59 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %59, null
-  br i1 %NullCheck14, label %60, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.IO.StreamWriter addrspace(1)* %59, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %60
 
 ; <label>:60                                      ; preds = %58
   %61 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %59, i32 0, i32 3
   %62 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
   %64 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %NullCheck16 = icmp ne %"System.Byte[]" addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %"System.Byte[]" addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %60
   %66 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %64, i32 0, i32 1
@@ -12530,8 +14239,8 @@ entry:
   %68 = zext i32 %67 to i64
   %69 = trunc i64 %68 to i32
   %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck18, label %71, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
   %72 = load i64, i64 addrspace(1)* %70
@@ -12547,29 +14256,29 @@ entry:
 
 ; <label>:80                                      ; preds = %27, %52, %71
   %81 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %81, null
-  br i1 %NullCheck20, label %82, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.IO.StreamWriter addrspace(1)* %81, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
 
 ; <label>:82                                      ; preds = %80
   %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %81, i32 0, i32 5
   %84 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %83, align 8
   %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.IO.StreamWriter addrspace(1)* %85, null
-  br i1 %NullCheck22, label %86, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.IO.StreamWriter addrspace(1)* %85, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %86
 
 ; <label>:86                                      ; preds = %82
   %87 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 7
   %88 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %87, align 8
   %89 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %89, null
-  br i1 %NullCheck24, label %90, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.StreamWriter addrspace(1)* %89, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %90
 
 ; <label>:90                                      ; preds = %86
   %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %89, i32 0, i32 9
   %92 = load i32, i32 addrspace(1)* %91, align 8
   %93 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.IO.StreamWriter addrspace(1)* %93, null
-  br i1 %NullCheck26, label %94, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.IO.StreamWriter addrspace(1)* %93, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %93, i32 0, i32 6
@@ -12577,8 +14286,8 @@ entry:
   %97 = load i8, i8* %arg2
   %98 = zext i8 %97 to i32
   %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
-  %NullCheck28 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck28, label %100, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
   %101 = load i64, i64 addrspace(1)* %99
@@ -12593,8 +14302,8 @@ entry:
   %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
   store i32 %110, i32* %loc1
   %111 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %111, null
-  br i1 %NullCheck30, label %112, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.IO.StreamWriter addrspace(1)* %111, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %112
 
 ; <label>:112                                     ; preds = %100
   %113 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %111, i32 0, i32 9
@@ -12605,23 +14314,23 @@ entry:
 
 ; <label>:116                                     ; preds = %112
   %117 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck32 = icmp ne %System.IO.StreamWriter addrspace(1)* %117, null
-  br i1 %NullCheck32, label %118, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.IO.StreamWriter addrspace(1)* %117, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %118
 
 ; <label>:118                                     ; preds = %116
   %119 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %117, i32 0, i32 3
   %120 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %119, align 8
   %121 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.IO.StreamWriter addrspace(1)* %121, null
-  br i1 %NullCheck34, label %122, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.IO.StreamWriter addrspace(1)* %121, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %122
 
 ; <label>:122                                     ; preds = %118
   %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
   %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
   %125 = load i32, i32* %loc1
   %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
-  %NullCheck36 = icmp ne i64 addrspace(1)* %126, null
-  br i1 %NullCheck36, label %127, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64 addrspace(1)* %126, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
   %128 = load i64, i64 addrspace(1)* %126
@@ -12643,15 +14352,15 @@ entry:
 
 ; <label>:140                                     ; preds = %136
   %141 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.IO.StreamWriter addrspace(1)* %141, null
-  br i1 %NullCheck38, label %142, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.IO.StreamWriter addrspace(1)* %141, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %142
 
 ; <label>:142                                     ; preds = %140
   %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
   %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
   %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
-  %NullCheck40 = icmp ne i64 addrspace(1)* %145, null
-  br i1 %NullCheck40, label %146, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i64 addrspace(1)* %145, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
   %147 = load i64, i64 addrspace(1)* %145
@@ -12672,83 +14381,83 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %25
+ThrowNullRef4:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %32
+ThrowNullRef6:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %37
+ThrowNullRef10:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %41
+ThrowNullRef12:                                   ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %58
+ThrowNullRef14:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %60
+ThrowNullRef16:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %65
+ThrowNullRef18:                                   ; preds = %65
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %80
+ThrowNullRef20:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %82
+ThrowNullRef22:                                   ; preds = %82
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %86
+ThrowNullRef24:                                   ; preds = %86
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %90
+ThrowNullRef26:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %94
+ThrowNullRef28:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %100
+ThrowNullRef30:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %116
+ThrowNullRef32:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %118
+ThrowNullRef34:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %122
+ThrowNullRef36:                                   ; preds = %122
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %140
+ThrowNullRef38:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %142
+ThrowNullRef40:                                   ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12815,8 +14524,8 @@ entry:
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %1 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
-  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
@@ -12824,8 +14533,8 @@ entry:
   %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
   %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
   %8 = load i64, i64 addrspace(1)* %6
@@ -12841,8 +14550,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %17, %System.IFormatProvider addrspace(1)* %16)
   %18 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %19 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %18, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.SyncTextWriter addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %7
   %21 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %18, i32 0, i32 4
@@ -12853,11 +14562,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12870,8 +14579,8 @@ entry:
   %this = alloca %System.IO.TextWriter addrspace(1)*
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.TextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
@@ -12881,8 +14590,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.Threading.Thread addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Threading.Thread addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %6)
@@ -12891,8 +14600,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1
   %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.TextWriter addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.TextWriter addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %11, i32 0, i32 2
@@ -12903,11 +14612,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13104,8 +14813,8 @@ entry:
   store float %param1, float* %arg1
   store i8 0, i8* %loc1
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
@@ -13115,16 +14824,16 @@ entry:
   %5 = addrspacecast i8* %loc1 to i8 addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %4, i8 addrspace(1)* %5)
   %6 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.SyncTextWriter addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
   %10 = load float, float* %arg1
   %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
   %13 = load i64, i64 addrspace(1)* %11
@@ -13159,11 +14868,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13180,8 +14889,8 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load float, float* %arg1
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -13195,8 +14904,8 @@ entry:
   call void %11(%System.IO.TextWriter addrspace(1)* %0, float %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
   %15 = load i64, i64 addrspace(1)* %13
@@ -13214,7 +14923,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13232,8 +14941,8 @@ entry:
   %1 = addrspacecast float* %arg1 to float addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -13248,8 +14957,8 @@ entry:
   %14 = bitcast float addrspace(1)* %1 to %System.Single addrspace(1)*
   %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Single addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Single addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
   %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
   %18 = load i64, i64 addrspace(1)* %16
@@ -13267,7 +14976,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13283,8 +14992,8 @@ entry:
   store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
   %0 = load %System.Single addrspace(1)*, %System.Single addrspace(1)** %this
   %1 = bitcast %System.Single addrspace(1)* %0 to float addrspace(1)*
-  %NullCheck = icmp ne float addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq float addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load float, float addrspace(1)* %1, align 8
@@ -13309,8 +15018,8 @@ entry:
   %loc0 = alloca %System.Globalization.NumberFormatInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 3
@@ -13320,8 +15029,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
@@ -13331,24 +15040,24 @@ entry:
   store %System.Globalization.NumberFormatInfo addrspace(1)* %10, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
   %11 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %7
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
   %15 = load i8, i8 addrspace(1)* %14, align 8
   %16 = zext i8 %15 to i32
   %17 = trunc i32 %16 to i8
-  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %11, null
-  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %11, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %13
   %19 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %11, i32 0, i32 29
   store i8 %17, i8 addrspace(1)* %19
   %20 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %21 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %20, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %20, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %18
   %23 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %20, i32 0, i32 3
@@ -13357,8 +15066,8 @@ entry:
 
 ; <label>:24                                      ; preds = %1, %22
   %25 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %25, null
-  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %25, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %26
 
 ; <label>:26                                      ; preds = %24
   %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %25, i32 0, i32 3
@@ -13369,23 +15078,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %18
+ThrowNullRef8:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13410,168 +15119,168 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 18
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %8, align 8
-  %NullCheck2 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %5, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %5, i32 0, i32 4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %9)
   %12 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 19
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %15, align 8
-  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %12, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %12, i32 0, i32 5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %16)
   %19 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %20 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %20, null
-  br i1 %NullCheck8, label %21, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %20, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %20, i32 0, i32 23
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  %NullCheck10 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %19, null
-  br i1 %NullCheck10, label %24, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %19, i32 0, i32 7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %25, %System.String addrspace(1)* %23)
   %26 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %27 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %27, i32 0, i32 22
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %29, align 8
-  %NullCheck14 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %26, null
-  br i1 %NullCheck14, label %31, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %26, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %26, i32 0, i32 6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %32, %System.String addrspace(1)* %30)
   %33 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %34 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Globalization.CultureData addrspace(1)* %34, null
-  br i1 %NullCheck16, label %35, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Globalization.CultureData addrspace(1)* %34, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %34, i32 0, i32 51
   %37 = load i32, i32 addrspace(1)* %36, align 8
-  %NullCheck18 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %33, null
-  br i1 %NullCheck18, label %38, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %33, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %33, i32 0, i32 21
   store i32 %37, i32 addrspace(1)* %39
   %40 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %41 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Globalization.CultureData addrspace(1)* %41, null
-  br i1 %NullCheck20, label %42, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Globalization.CultureData addrspace(1)* %41, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %41, i32 0, i32 52
   %44 = load i32, i32 addrspace(1)* %43, align 8
-  %NullCheck22 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %40, null
-  br i1 %NullCheck22, label %45, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %40, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %40, i32 0, i32 25
   store i32 %44, i32 addrspace(1)* %46
   %47 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %48 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.Globalization.CultureData addrspace(1)* %48, null
-  br i1 %NullCheck24, label %49, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Globalization.CultureData addrspace(1)* %48, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %49
 
 ; <label>:49                                      ; preds = %45
   %50 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %48, i32 0, i32 29
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck26 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %47, null
-  br i1 %NullCheck26, label %52, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %47, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %47, i32 0, i32 10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %53, %System.String addrspace(1)* %51)
   %54 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %55 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Globalization.CultureData addrspace(1)* %55, null
-  br i1 %NullCheck28, label %56, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Globalization.CultureData addrspace(1)* %55, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %56
 
 ; <label>:56                                      ; preds = %52
   %57 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %55, i32 0, i32 35
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %57, align 8
-  %NullCheck30 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %54, null
-  br i1 %NullCheck30, label %59, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %54, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %54, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %60, %System.String addrspace(1)* %58)
   %61 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %62 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck32 = icmp ne %System.Globalization.CultureData addrspace(1)* %62, null
-  br i1 %NullCheck32, label %63, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Globalization.CultureData addrspace(1)* %62, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %62, i32 0, i32 34
   %65 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %64, align 8
-  %NullCheck34 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %61, null
-  br i1 %NullCheck34, label %66, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %61, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %61, i32 0, i32 9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %67, %System.String addrspace(1)* %65)
   %68 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %69 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck36 = icmp ne %System.Globalization.CultureData addrspace(1)* %69, null
-  br i1 %NullCheck36, label %70, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Globalization.CultureData addrspace(1)* %69, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %70
 
 ; <label>:70                                      ; preds = %66
   %71 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %69, i32 0, i32 55
   %72 = load i32, i32 addrspace(1)* %71, align 8
-  %NullCheck38 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %68, null
-  br i1 %NullCheck38, label %73, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %68, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %68, i32 0, i32 22
   store i32 %72, i32 addrspace(1)* %74
   %75 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %76 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck40 = icmp ne %System.Globalization.CultureData addrspace(1)* %76, null
-  br i1 %NullCheck40, label %77, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Globalization.CultureData addrspace(1)* %76, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %76, i32 0, i32 57
   %79 = load i32, i32 addrspace(1)* %78, align 8
-  %NullCheck42 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %75, null
-  br i1 %NullCheck42, label %80, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %75, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %80
 
 ; <label>:80                                      ; preds = %77
   %81 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %75, i32 0, i32 24
   store i32 %79, i32 addrspace(1)* %81
   %82 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %83 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck44 = icmp ne %System.Globalization.CultureData addrspace(1)* %83, null
-  br i1 %NullCheck44, label %84, label %ThrowNullRef43
+  %NullCheck43 = icmp eq %System.Globalization.CultureData addrspace(1)* %83, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %84
 
 ; <label>:84                                      ; preds = %80
   %85 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %83, i32 0, i32 56
   %86 = load i32, i32 addrspace(1)* %85, align 8
-  %NullCheck46 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %82, null
-  br i1 %NullCheck46, label %87, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %82, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %82, i32 0, i32 23
@@ -13580,8 +15289,8 @@ entry:
 
 ; <label>:89                                      ; preds = %entry
   %90 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck100 = icmp ne %System.Globalization.CultureData addrspace(1)* %90, null
-  br i1 %NullCheck100, label %91, label %ThrowNullRef99
+  %NullCheck99 = icmp eq %System.Globalization.CultureData addrspace(1)* %90, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %91
 
 ; <label>:91                                      ; preds = %89
   %92 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %90, i32 0, i32 2
@@ -13599,8 +15308,8 @@ entry:
   %102 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %103 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %104 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %103)
-  %NullCheck48 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %102, null
-  br i1 %NullCheck48, label %105, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %102, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %105
 
 ; <label>:105                                     ; preds = %101
   %106 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %102, i32 0, i32 1
@@ -13608,8 +15317,8 @@ entry:
   %107 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %108 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %109 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %108)
-  %NullCheck50 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %107, null
-  br i1 %NullCheck50, label %110, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %107, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %110
 
 ; <label>:110                                     ; preds = %105
   %111 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %107, i32 0, i32 2
@@ -13617,8 +15326,8 @@ entry:
   %112 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %113 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %114 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %113)
-  %NullCheck52 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %112, null
-  br i1 %NullCheck52, label %115, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %112, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %115
 
 ; <label>:115                                     ; preds = %110
   %116 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %112, i32 0, i32 27
@@ -13626,8 +15335,8 @@ entry:
   %117 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %118 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %119 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %118)
-  %NullCheck54 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %117, null
-  br i1 %NullCheck54, label %120, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %117, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %120
 
 ; <label>:120                                     ; preds = %115
   %121 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %117, i32 0, i32 26
@@ -13635,8 +15344,8 @@ entry:
   %122 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %123 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %124 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %123)
-  %NullCheck56 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %122, null
-  br i1 %NullCheck56, label %125, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %122, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %125
 
 ; <label>:125                                     ; preds = %120
   %126 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %122, i32 0, i32 17
@@ -13644,8 +15353,8 @@ entry:
   %127 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %128 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %129 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %128)
-  %NullCheck58 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %127, null
-  br i1 %NullCheck58, label %130, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %127, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %130
 
 ; <label>:130                                     ; preds = %125
   %131 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %127, i32 0, i32 18
@@ -13653,8 +15362,8 @@ entry:
   %132 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %133 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %134 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %133)
-  %NullCheck60 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %132, null
-  br i1 %NullCheck60, label %135, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %132, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %135
 
 ; <label>:135                                     ; preds = %130
   %136 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %132, i32 0, i32 14
@@ -13662,8 +15371,8 @@ entry:
   %137 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %138 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %139 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %138)
-  %NullCheck62 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %137, null
-  br i1 %NullCheck62, label %140, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %137, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %140
 
 ; <label>:140                                     ; preds = %135
   %141 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %137, i32 0, i32 13
@@ -13671,71 +15380,71 @@ entry:
   %142 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %143 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %144 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %143)
-  %NullCheck64 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %142, null
-  br i1 %NullCheck64, label %145, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %142, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %145
 
 ; <label>:145                                     ; preds = %140
   %146 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %142, i32 0, i32 12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %146, %System.String addrspace(1)* %144)
   %147 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %148 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck66 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %148, null
-  br i1 %NullCheck66, label %149, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %148, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %149
 
 ; <label>:149                                     ; preds = %145
   %150 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %148, i32 0, i32 21
   %151 = load i32, i32 addrspace(1)* %150, align 8
-  %NullCheck68 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %147, null
-  br i1 %NullCheck68, label %152, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %147, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %152
 
 ; <label>:152                                     ; preds = %149
   %153 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %147, i32 0, i32 28
   store i32 %151, i32 addrspace(1)* %153
   %154 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %155 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck70 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %155, null
-  br i1 %NullCheck70, label %156, label %ThrowNullRef69
+  %NullCheck69 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %155, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %156
 
 ; <label>:156                                     ; preds = %152
   %157 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %155, i32 0, i32 6
   %158 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %157, align 8
-  %NullCheck72 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %154, null
-  br i1 %NullCheck72, label %159, label %ThrowNullRef71
+  %NullCheck71 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %154, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %159
 
 ; <label>:159                                     ; preds = %156
   %160 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %154, i32 0, i32 15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %160, %System.String addrspace(1)* %158)
   %161 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %162 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck74 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %162, null
-  br i1 %NullCheck74, label %163, label %ThrowNullRef73
+  %NullCheck73 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %162, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %163
 
 ; <label>:163                                     ; preds = %159
   %164 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %162, i32 0, i32 1
   %165 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %164, align 8
-  %NullCheck76 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %161, null
-  br i1 %NullCheck76, label %166, label %ThrowNullRef75
+  %NullCheck75 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %161, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %166
 
 ; <label>:166                                     ; preds = %163
   %167 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %161, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %167, %"System.Int32[]" addrspace(1)* %165)
   %168 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %169 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck78 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %169, null
-  br i1 %NullCheck78, label %170, label %ThrowNullRef77
+  %NullCheck77 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %169, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %170
 
 ; <label>:170                                     ; preds = %166
   %171 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %169, i32 0, i32 7
   %172 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %171, align 8
-  %NullCheck80 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %168, null
-  br i1 %NullCheck80, label %173, label %ThrowNullRef79
+  %NullCheck79 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %168, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %173
 
 ; <label>:173                                     ; preds = %170
   %174 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %168, i32 0, i32 16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %174, %System.String addrspace(1)* %172)
   %175 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck82 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %175, null
-  br i1 %NullCheck82, label %176, label %ThrowNullRef81
+  %NullCheck81 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %175, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %176
 
 ; <label>:176                                     ; preds = %173
   %177 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %175, i32 0, i32 4
@@ -13745,14 +15454,14 @@ entry:
 
 ; <label>:180                                     ; preds = %176
   %181 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck84 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %181, null
-  br i1 %NullCheck84, label %182, label %ThrowNullRef83
+  %NullCheck83 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %181, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %182
 
 ; <label>:182                                     ; preds = %180
   %183 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %181, i32 0, i32 4
   %184 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %183, align 8
-  %NullCheck86 = icmp ne %System.String addrspace(1)* %184, null
-  br i1 %NullCheck86, label %185, label %ThrowNullRef85
+  %NullCheck85 = icmp eq %System.String addrspace(1)* %184, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %185
 
 ; <label>:185                                     ; preds = %182
   %186 = getelementptr inbounds %System.String, %System.String addrspace(1)* %184, i32 0, i32 1
@@ -13763,8 +15472,8 @@ entry:
 ; <label>:189                                     ; preds = %176, %185
   %190 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck98 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %190, null
-  br i1 %NullCheck98, label %192, label %ThrowNullRef97
+  %NullCheck97 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %190, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %192
 
 ; <label>:192                                     ; preds = %189
   %193 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %190, i32 0, i32 4
@@ -13773,8 +15482,8 @@ entry:
 
 ; <label>:194                                     ; preds = %185, %192
   %195 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck88 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %195, null
-  br i1 %NullCheck88, label %196, label %ThrowNullRef87
+  %NullCheck87 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %195, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %196
 
 ; <label>:196                                     ; preds = %194
   %197 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %195, i32 0, i32 9
@@ -13784,14 +15493,14 @@ entry:
 
 ; <label>:200                                     ; preds = %196
   %201 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck90 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %201, null
-  br i1 %NullCheck90, label %202, label %ThrowNullRef89
+  %NullCheck89 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %201, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %202
 
 ; <label>:202                                     ; preds = %200
   %203 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %201, i32 0, i32 9
   %204 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %203, align 8
-  %NullCheck92 = icmp ne %System.String addrspace(1)* %204, null
-  br i1 %NullCheck92, label %205, label %ThrowNullRef91
+  %NullCheck91 = icmp eq %System.String addrspace(1)* %204, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %205
 
 ; <label>:205                                     ; preds = %202
   %206 = getelementptr inbounds %System.String, %System.String addrspace(1)* %204, i32 0, i32 1
@@ -13802,14 +15511,14 @@ entry:
 ; <label>:209                                     ; preds = %196, %205
   %210 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %211 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck94 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %211, null
-  br i1 %NullCheck94, label %212, label %ThrowNullRef93
+  %NullCheck93 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %211, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %212
 
 ; <label>:212                                     ; preds = %209
   %213 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %211, i32 0, i32 6
   %214 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %213, align 8
-  %NullCheck96 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %210, null
-  br i1 %NullCheck96, label %215, label %ThrowNullRef95
+  %NullCheck95 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %210, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %215
 
 ; <label>:215                                     ; preds = %212
   %216 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %210, i32 0, i32 9
@@ -13823,203 +15532,203 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %17
+ThrowNullRef8:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %21
+ThrowNullRef10:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %24
+ThrowNullRef12:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %28
+ThrowNullRef14:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %31
+ThrowNullRef16:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %35
+ThrowNullRef18:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %38
+ThrowNullRef20:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %42
+ThrowNullRef22:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %45
+ThrowNullRef24:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %49
+ThrowNullRef26:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %52
+ThrowNullRef28:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %56
+ThrowNullRef30:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %59
+ThrowNullRef32:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %63
+ThrowNullRef34:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %66
+ThrowNullRef36:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %70
+ThrowNullRef38:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %73
+ThrowNullRef40:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %77
+ThrowNullRef42:                                   ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %80
+ThrowNullRef44:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %84
+ThrowNullRef46:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %101
+ThrowNullRef48:                                   ; preds = %101
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %105
+ThrowNullRef50:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %110
+ThrowNullRef52:                                   ; preds = %110
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %115
+ThrowNullRef54:                                   ; preds = %115
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %120
+ThrowNullRef56:                                   ; preds = %120
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %125
+ThrowNullRef58:                                   ; preds = %125
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %130
+ThrowNullRef60:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %135
+ThrowNullRef62:                                   ; preds = %135
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %140
+ThrowNullRef64:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %145
+ThrowNullRef66:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %149
+ThrowNullRef68:                                   ; preds = %149
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %152
+ThrowNullRef70:                                   ; preds = %152
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %156
+ThrowNullRef72:                                   ; preds = %156
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %159
+ThrowNullRef74:                                   ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %163
+ThrowNullRef76:                                   ; preds = %163
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %166
+ThrowNullRef78:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %170
+ThrowNullRef80:                                   ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %173
+ThrowNullRef82:                                   ; preds = %173
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %180
+ThrowNullRef84:                                   ; preds = %180
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %182
+ThrowNullRef86:                                   ; preds = %182
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %194
+ThrowNullRef88:                                   ; preds = %194
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %200
+ThrowNullRef90:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %202
+ThrowNullRef92:                                   ; preds = %202
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %209
+ThrowNullRef94:                                   ; preds = %209
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %212
+ThrowNullRef96:                                   ; preds = %212
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %189
+ThrowNullRef98:                                   ; preds = %189
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %89
+ThrowNullRef100:                                  ; preds = %89
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14047,8 +15756,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 21
@@ -14061,8 +15770,8 @@ entry:
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 16)
   %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 21
@@ -14071,8 +15780,8 @@ entry:
 
 ; <label>:12                                      ; preds = %1, %10
   %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 21
@@ -14083,11 +15792,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %12
+ThrowNullRef4:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14103,8 +15812,8 @@ entry:
   store i32 %param1, i32* %arg1
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %1 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
@@ -14171,8 +15880,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 33
@@ -14185,8 +15894,8 @@ entry:
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 24)
   %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 33
@@ -14195,8 +15904,8 @@ entry:
 
 ; <label>:12                                      ; preds = %1, %10
   %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 33
@@ -14207,11 +15916,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %12
+ThrowNullRef4:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14224,8 +15933,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 53
@@ -14237,8 +15946,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 116)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 53
@@ -14247,8 +15956,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 53
@@ -14259,11 +15968,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14292,8 +16001,8 @@ entry:
 
 ; <label>:7                                       ; preds = %entry, %4
   %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %7
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 2
@@ -14317,8 +16026,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 54
@@ -14330,8 +16039,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 117)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
@@ -14340,8 +16049,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 54
@@ -14352,11 +16061,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14369,8 +16078,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 27
@@ -14382,8 +16091,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 118)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 27
@@ -14392,8 +16101,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 27
@@ -14404,11 +16113,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14421,8 +16130,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 28
@@ -14434,8 +16143,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 119)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 28
@@ -14444,8 +16153,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 28
@@ -14456,11 +16165,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14473,8 +16182,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 26
@@ -14486,8 +16195,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 107)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 26
@@ -14496,8 +16205,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 26
@@ -14508,11 +16217,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14525,8 +16234,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 25
@@ -14538,8 +16247,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 106)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 25
@@ -14548,8 +16257,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 25
@@ -14560,11 +16269,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14577,8 +16286,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 24
@@ -14590,8 +16299,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 105)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 24
@@ -14600,8 +16309,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 24
@@ -14612,11 +16321,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14641,8 +16350,8 @@ entry:
   %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %3)
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %2
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -14653,15 +16362,15 @@ entry:
 
 ; <label>:8                                       ; preds = %62
   %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 9
   %12 = load i32, i32 addrspace(1)* %11, align 8
   %13 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.IO.StreamWriter addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %13, i32 0, i32 10
@@ -14676,15 +16385,15 @@ entry:
 
 ; <label>:20                                      ; preds = %14, %18
   %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
   %24 = load i32, i32 addrspace(1)* %23, align 8
   %25 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %25, null
-  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.StreamWriter addrspace(1)* %25, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %25, i32 0, i32 9
@@ -14705,36 +16414,36 @@ entry:
   %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %37 = load i32, i32* %loc1
   %38 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.StreamWriter addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %35
   %40 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %38, i32 0, i32 7
   %41 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %40, align 8
   %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
-  br i1 %NullCheck14, label %43, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %39
   %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 9
   %45 = load i32, i32 addrspace(1)* %44, align 8
   %46 = load i32, i32* %loc2
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %36, null
-  br i1 %NullCheck16, label %47, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %36, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %47
 
 ; <label>:47                                      ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %36, i32 %37, %"System.Char[]" addrspace(1)* %41, i32 %45, i32 %46)
   %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
   %51 = load i32, i32 addrspace(1)* %50, align 8
   %52 = load i32, i32* %loc2
   %53 = add i32 %51, %52
-  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
-  br i1 %NullCheck20, label %54, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %54
 
 ; <label>:54                                      ; preds = %49
   %55 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
@@ -14756,8 +16465,8 @@ entry:
 
 ; <label>:65                                      ; preds = %62
   %66 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %66, null
-  br i1 %NullCheck2, label %67, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %66, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %67
 
 ; <label>:67                                      ; preds = %65
   %68 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %66, i32 0, i32 11
@@ -14778,49 +16487,259 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %65
+ThrowNullRef2:                                    ; preds = %65
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %20
+ThrowNullRef8:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %22
+ThrowNullRef10:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %35
+ThrowNullRef12:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %43
+ThrowNullRef16:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %47
+ThrowNullRef18:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method String::CopyTo using LLILCJit
-Failed to read String.CopyTo[loadElemA]
+Successfully read String.CopyTo
+
+define void @String.CopyTo(%System.String addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  %loc1 = alloca i16 addrspace(1)*
+  %loc2 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %1 = icmp ne %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg4
+  %7 = icmp sge i32 %6, 0
+  br i1 %7, label %13, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  unreachable
+
+; <label>:13                                      ; preds = %5
+  %14 = load i32, i32* %arg1
+  %15 = icmp sge i32 %14, 0
+  br i1 %15, label %21, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %18)
+  %20 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %20, %System.String addrspace(1)* %17, %System.String addrspace(1)* %19)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %20) #0
+  unreachable
+
+; <label>:21                                      ; preds = %13
+  %22 = load i32, i32* %arg4
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck, label %ThrowNullRef, label %24
+
+; <label>:24                                      ; preds = %21
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load i32, i32* %arg1
+  %28 = sub i32 %26, %27
+  %29 = icmp sle i32 %22, %28
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34, %System.String addrspace(1)* %31, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %24
+  %36 = load i32, i32* %arg3
+  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %37, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
+
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
+  %40 = load i32, i32 addrspace(1)* %39
+  %41 = zext i32 %40 to i64
+  %42 = trunc i64 %41 to i32
+  %43 = load i32, i32* %arg4
+  %44 = sub i32 %42, %43
+  %45 = icmp sgt i32 %36, %44
+  br i1 %45, label %49, label %46
+
+; <label>:46                                      ; preds = %38
+  %47 = load i32, i32* %arg3
+  %48 = icmp sge i32 %47, 0
+  br i1 %48, label %54, label %49
+
+; <label>:49                                      ; preds = %38, %46
+  %50 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %52 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %51)
+  %53 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53, %System.String addrspace(1)* %50, %System.String addrspace(1)* %52)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53) #0
+  unreachable
+
+; <label>:54                                      ; preds = %46
+  %55 = load i32, i32* %arg4
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %97, label %57
+
+; <label>:57                                      ; preds = %54
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %59
+
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 2
+  %61 = bitcast [0 x i16] addrspace(1)* %60 to i16 addrspace(1)*
+  store i16 addrspace(1)* %61, i16 addrspace(1)** %loc0
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  store %"System.Char[]" addrspace(1)* %62, %"System.Char[]" addrspace(1)** %loc2
+  %63 = icmp eq %"System.Char[]" addrspace(1)* %62, null
+  br i1 %63, label %72, label %64
+
+; <label>:64                                      ; preds = %59
+  %65 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc2
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %65, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %66
+
+; <label>:66                                      ; preds = %64
+  %67 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %65, i32 0, i32 1
+  %68 = load i32, i32 addrspace(1)* %67
+  %69 = zext i32 %68 to i64
+  %70 = trunc i64 %69 to i32
+  %71 = icmp ne i32 %70, 0
+  br i1 %71, label %73, label %72
+
+; <label>:72                                      ; preds = %59, %66
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  br label %81
+
+; <label>:73                                      ; preds = %66
+  %74 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc2
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %74, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %75
+
+; <label>:75                                      ; preds = %73
+  %76 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %74, i32 0, i32 1
+  %77 = load i32, i32 addrspace(1)* %76
+  %78 = zext i32 %77 to i64
+  %BoundsCheck = icmp uge i64 0, %78
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %79
+
+; <label>:79                                      ; preds = %75
+  %80 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %74, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %80, i16 addrspace(1)** %loc1
+  br label %81
+
+; <label>:81                                      ; preds = %72, %79
+  %82 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %83 = ptrtoint i16 addrspace(1)* %82 to i64
+  %84 = load i32, i32* %arg3
+  %85 = sext i32 %84 to i64
+  %86 = mul i64 %85, 2
+  %87 = add i64 %83, %86
+  %88 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %89 = ptrtoint i16 addrspace(1)* %88 to i64
+  %90 = load i32, i32* %arg1
+  %91 = sext i32 %90 to i64
+  %92 = mul i64 %91, 2
+  %93 = add i64 %89, %92
+  %94 = load i32, i32* %arg4
+  %95 = inttoptr i64 %87 to i16*
+  %96 = inttoptr i64 %93 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %95, i16* %96, i32 %94)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  br label %97
+
+; <label>:97                                      ; preds = %54, %81
+  ret void
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
 Successfully read ConsoleEncoding.GetPreamble
 
@@ -14857,7 +16776,365 @@ entry:
 }
 
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[loadElemA]
+Successfully read EncoderNLS.GetBytes
+
+define i32 @EncoderNLS.GetBytes(%System.Text.EncoderNLS addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3, %"System.Byte[]" addrspace(1)* %param4, i32 %param5, i8 %param6) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %arg4 = alloca %"System.Byte[]" addrspace(1)*
+  %arg5 = alloca i32
+  %arg6 = alloca i8
+  %loc0 = alloca i32
+  %loc1 = alloca i16 addrspace(1)*
+  %loc2 = alloca i8 addrspace(1)*
+  %loc3 = alloca i32
+  %loc4 = alloca %"System.Char[]" addrspace(1)*
+  %loc5 = alloca %"System.Byte[]" addrspace(1)*
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  store %"System.Byte[]" addrspace(1)* %param4, %"System.Byte[]" addrspace(1)** %arg4
+  store i32 %param5, i32* %arg5
+  store i8 %param6, i8* %arg6
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %1 = icmp eq %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %17, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %7 = icmp eq %"System.Char[]" addrspace(1)* %6, null
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %12
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %12
+
+; <label>:12                                      ; preds = %8, %10
+  %13 = phi %System.String addrspace(1)* [ %9, %8 ], [ %11, %10 ]
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %14)
+  %16 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16, %System.String addrspace(1)* %13, %System.String addrspace(1)* %15)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16) #0
+  unreachable
+
+; <label>:17                                      ; preds = %2
+  %18 = load i32, i32* %arg2
+  %19 = icmp slt i32 %18, 0
+  br i1 %19, label %23, label %20
+
+; <label>:20                                      ; preds = %17
+  %21 = load i32, i32* %arg3
+  %22 = icmp sge i32 %21, 0
+  br i1 %22, label %35, label %23
+
+; <label>:23                                      ; preds = %17, %20
+  %24 = load i32, i32* %arg2
+  %25 = icmp slt i32 %24, 0
+  br i1 %25, label %28, label %26
+
+; <label>:26                                      ; preds = %23
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %30
+
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %30
+
+; <label>:30                                      ; preds = %26, %28
+  %31 = phi %System.String addrspace(1)* [ %27, %26 ], [ %29, %28 ]
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34, %System.String addrspace(1)* %31, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %20
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck, label %ThrowNullRef, label %37
+
+; <label>:37                                      ; preds = %35
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = load i32, i32* %arg2
+  %43 = sub i32 %41, %42
+  %44 = load i32, i32* %arg3
+  %45 = icmp sge i32 %43, %44
+  br i1 %45, label %51, label %46
+
+; <label>:46                                      ; preds = %37
+  %47 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %48 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %49 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %48)
+  %50 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %50, %System.String addrspace(1)* %47, %System.String addrspace(1)* %49)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %50) #0
+  unreachable
+
+; <label>:51                                      ; preds = %37
+  %52 = load i32, i32* %arg5
+  %53 = icmp slt i32 %52, 0
+  br i1 %53, label %63, label %54
+
+; <label>:54                                      ; preds = %51
+  %55 = load i32, i32* %arg5
+  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck1 = icmp eq %"System.Byte[]" addrspace(1)* %56, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %57
+
+; <label>:57                                      ; preds = %54
+  %58 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = zext i32 %59 to i64
+  %61 = trunc i64 %60 to i32
+  %62 = icmp sle i32 %55, %61
+  br i1 %62, label %68, label %63
+
+; <label>:63                                      ; preds = %51, %57
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %66 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %65)
+  %67 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %67, %System.String addrspace(1)* %64, %System.String addrspace(1)* %66)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %67) #0
+  unreachable
+
+; <label>:68                                      ; preds = %57
+  %69 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %69, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %69, i32 0, i32 1
+  %72 = load i32, i32 addrspace(1)* %71
+  %73 = zext i32 %72 to i64
+  %74 = trunc i64 %73 to i32
+  %75 = icmp ne i32 %74, 0
+  br i1 %75, label %78, label %76
+
+; <label>:76                                      ; preds = %70
+  %77 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1)
+  store %"System.Char[]" addrspace(1)* %77, %"System.Char[]" addrspace(1)** %arg1
+  br label %78
+
+; <label>:78                                      ; preds = %70, %76
+  %79 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck5 = icmp eq %"System.Byte[]" addrspace(1)* %79, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %80
+
+; <label>:80                                      ; preds = %78
+  %81 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %79, i32 0, i32 1
+  %82 = load i32, i32 addrspace(1)* %81
+  %83 = zext i32 %82 to i64
+  %84 = trunc i64 %83 to i32
+  %85 = load i32, i32* %arg5
+  %86 = sub i32 %84, %85
+  store i32 %86, i32* %loc0
+  %87 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck7 = icmp eq %"System.Byte[]" addrspace(1)* %87, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %88
+
+; <label>:88                                      ; preds = %80
+  %89 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %87, i32 0, i32 1
+  %90 = load i32, i32 addrspace(1)* %89
+  %91 = zext i32 %90 to i64
+  %92 = trunc i64 %91 to i32
+  %93 = icmp ne i32 %92, 0
+  br i1 %93, label %96, label %94
+
+; <label>:94                                      ; preds = %88
+  %95 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1)
+  store %"System.Byte[]" addrspace(1)* %95, %"System.Byte[]" addrspace(1)** %arg4
+  br label %96
+
+; <label>:96                                      ; preds = %88, %94
+  %97 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  store %"System.Char[]" addrspace(1)* %97, %"System.Char[]" addrspace(1)** %loc4
+  %98 = icmp eq %"System.Char[]" addrspace(1)* %97, null
+  br i1 %98, label %107, label %99
+
+; <label>:99                                      ; preds = %96
+  %100 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc4
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %100, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %101
+
+; <label>:101                                     ; preds = %99
+  %102 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %100, i32 0, i32 1
+  %103 = load i32, i32 addrspace(1)* %102
+  %104 = zext i32 %103 to i64
+  %105 = trunc i64 %104 to i32
+  %106 = icmp ne i32 %105, 0
+  br i1 %106, label %108, label %107
+
+; <label>:107                                     ; preds = %96, %101
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  br label %116
+
+; <label>:108                                     ; preds = %101
+  %109 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc4
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %109, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %110
+
+; <label>:110                                     ; preds = %108
+  %111 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %109, i32 0, i32 1
+  %112 = load i32, i32 addrspace(1)* %111
+  %113 = zext i32 %112 to i64
+  %BoundsCheck = icmp uge i64 0, %113
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %114
+
+; <label>:114                                     ; preds = %110
+  %115 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %109, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %115, i16 addrspace(1)** %loc1
+  br label %116
+
+; <label>:116                                     ; preds = %107, %114
+  %117 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  store %"System.Byte[]" addrspace(1)* %117, %"System.Byte[]" addrspace(1)** %loc5
+  %118 = icmp eq %"System.Byte[]" addrspace(1)* %117, null
+  br i1 %118, label %127, label %119
+
+; <label>:119                                     ; preds = %116
+  %120 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc5
+  %NullCheck13 = icmp eq %"System.Byte[]" addrspace(1)* %120, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %121
+
+; <label>:121                                     ; preds = %119
+  %122 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %120, i32 0, i32 1
+  %123 = load i32, i32 addrspace(1)* %122
+  %124 = zext i32 %123 to i64
+  %125 = trunc i64 %124 to i32
+  %126 = icmp ne i32 %125, 0
+  br i1 %126, label %128, label %127
+
+; <label>:127                                     ; preds = %116, %121
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc2
+  br label %136
+
+; <label>:128                                     ; preds = %121
+  %129 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc5
+  %NullCheck15 = icmp eq %"System.Byte[]" addrspace(1)* %129, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %130
+
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %129, i32 0, i32 1
+  %132 = load i32, i32 addrspace(1)* %131
+  %133 = zext i32 %132 to i64
+  %BoundsCheck17 = icmp uge i64 0, %133
+  br i1 %BoundsCheck17, label %ThrowIndexOutOfRange18, label %134
+
+; <label>:134                                     ; preds = %130
+  %135 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %129, i32 0, i32 3, i32 0
+  store i8 addrspace(1)* %135, i8 addrspace(1)** %loc2
+  br label %136
+
+; <label>:136                                     ; preds = %127, %134
+  %137 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %138 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %139 = ptrtoint i16 addrspace(1)* %138 to i64
+  %140 = load i32, i32* %arg2
+  %141 = sext i32 %140 to i64
+  %142 = mul i64 %141, 2
+  %143 = add i64 %139, %142
+  %144 = load i32, i32* %arg3
+  %145 = load i8 addrspace(1)*, i8 addrspace(1)** %loc2
+  %146 = ptrtoint i8 addrspace(1)* %145 to i64
+  %147 = load i32, i32* %arg5
+  %148 = sext i32 %147 to i64
+  %149 = add i64 %146, %148
+  %150 = load i32, i32* %loc0
+  %151 = load i8, i8* %arg6
+  %152 = zext i8 %151 to i32
+  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i64 addrspace(1)*
+  %NullCheck19 = icmp eq i64 addrspace(1)* %153, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %154
+
+; <label>:154                                     ; preds = %136
+  %155 = load i64, i64 addrspace(1)* %153
+  %156 = add i64 %155, 72
+  %157 = inttoptr i64 %156 to i64*
+  %158 = load i64, i64* %157
+  %159 = add i64 %158, 0
+  %160 = inttoptr i64 %159 to i64*
+  %161 = load i64, i64* %160
+  %162 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to %System.Text.Encoder addrspace(1)*
+  %163 = inttoptr i64 %143 to i16*
+  %164 = inttoptr i64 %149 to i8*
+  %165 = trunc i32 %152 to i8
+  %166 = inttoptr i64 %161 to i32 (%System.Text.Encoder addrspace(1)*, i16*, i32, i8*, i32, i8)*
+  %167 = call i32 %166(%System.Text.Encoder addrspace(1)* %162, i16* %163, i32 %144, i8* %164, i32 %150, i8 %165)
+  store i32 %167, i32* %loc3
+  br label %168
+
+; <label>:168                                     ; preds = %154
+  %169 = load i32, i32* %loc3
+  ret i32 %169
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %110
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %119
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange18:                           ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
 Successfully read EncoderNLS.GetBytes
 
@@ -14946,22 +17223,22 @@ entry:
   %40 = load i8, i8* %arg5
   %41 = zext i8 %40 to i32
   %42 = trunc i32 %41 to i8
-  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %39, null
-  br i1 %NullCheck, label %43, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderNLS addrspace(1)* %39, null
+  br i1 %NullCheck, label %ThrowNullRef, label %43
 
 ; <label>:43                                      ; preds = %38
   %44 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
   store i8 %42, i8 addrspace(1)* %44
   %45 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %45, null
-  br i1 %NullCheck2, label %46, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.EncoderNLS addrspace(1)* %45, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %46
 
 ; <label>:46                                      ; preds = %43
   %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %45, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %47
   %48 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.EncoderNLS addrspace(1)* %48, null
-  br i1 %NullCheck4, label %49, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.EncoderNLS addrspace(1)* %48, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %49
 
 ; <label>:49                                      ; preds = %46
   %50 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %48, i32 0, i32 3
@@ -14972,8 +17249,8 @@ entry:
   %55 = load i32, i32* %arg4
   %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck6, label %58, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
   %59 = load i64, i64 addrspace(1)* %57
@@ -14991,15 +17268,15 @@ ThrowNullRef:                                     ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %43
+ThrowNullRef2:                                    ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %46
+ThrowNullRef4:                                    ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %49
+ThrowNullRef6:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -15027,8 +17304,8 @@ entry:
   %4 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0 to %System.IO.ConsoleStream addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*)(%System.IO.ConsoleStream addrspace(1)* %4, %"System.Byte[]" addrspace(1)* %1, i32 %2, i32 %3)
   %5 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
@@ -15113,8 +17390,8 @@ entry:
 
 ; <label>:22                                      ; preds = %8
   %23 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %23, null
-  br i1 %NullCheck, label %24, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Byte[]" addrspace(1)* %23, null
+  br i1 %NullCheck, label %ThrowNullRef, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
@@ -15136,8 +17413,8 @@ entry:
 
 ; <label>:36                                      ; preds = %24
   %37 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %37, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.ConsoleStream addrspace(1)* %37, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %37, i32 0, i32 4
@@ -15158,13 +17435,138 @@ ThrowNullRef:                                     ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %36
+ThrowNullRef2:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
-Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
+Successfully read WindowsConsoleStream.WriteFileNative
+
+define i32 @WindowsConsoleStream.WriteFileNative(i64 %param0, %"System.Byte[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i64
+  %arg1 = alloca %"System.Byte[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i8 addrspace(1)*
+  %loc2 = alloca %"System.Byte[]" addrspace(1)*
+  %loc3 = alloca i32
+  store i64 %param0, i64* %arg0
+  store %"System.Byte[]" addrspace(1)* %param1, %"System.Byte[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Byte[]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = zext i32 %3 to i64
+  %5 = icmp ne i64 %4, 0
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %1
+  ret i32 0
+
+; <label>:7                                       ; preds = %1
+  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  store %"System.Byte[]" addrspace(1)* %8, %"System.Byte[]" addrspace(1)** %loc2
+  %9 = icmp eq %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %9, label %18, label %10
+
+; <label>:10                                      ; preds = %7
+  %11 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc2
+  %NullCheck1 = icmp eq %"System.Byte[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %11, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp ne i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %7, %12
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc1
+  br label %27
+
+; <label>:19                                      ; preds = %12
+  %20 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc2
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %20, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %BoundsCheck = icmp uge i64 0, %24
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %25
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %20, i32 0, i32 3, i32 0
+  store i8 addrspace(1)* %26, i8 addrspace(1)** %loc1
+  br label %27
+
+; <label>:27                                      ; preds = %18, %25
+  %28 = load i64, i64* %arg0
+  %29 = load i8 addrspace(1)*, i8 addrspace(1)** %loc1
+  %30 = ptrtoint i8 addrspace(1)* %29 to i64
+  %31 = load i32, i32* %arg2
+  %32 = sext i32 %31 to i64
+  %33 = add i64 %30, %32
+  %34 = load i32, i32* %arg3
+  %35 = addrspacecast i32* %loc3 to i32 addrspace(1)*
+  %36 = inttoptr i64 %33 to i8*
+  %37 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i8*, i32, i32 addrspace(1)*, i64)*)(i64 %28, i8* %36, i32 %34, i32 addrspace(1)* %35, i64 0)
+  %38 = icmp ugt i32 %37, 0
+  %39 = sext i1 %38 to i32
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc1
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %42, label %41
+
+; <label>:41                                      ; preds = %27
+  ret i32 0
+
+; <label>:42                                      ; preds = %27
+  %43 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  store i32 %43, i32* %loc0
+  %44 = load i32, i32* %loc0
+  %45 = icmp eq i32 %44, 232
+  br i1 %45, label %49, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = load i32, i32* %loc0
+  %48 = icmp ne i32 %47, 109
+  br i1 %48, label %50, label %49
+
+; <label>:49                                      ; preds = %42, %46
+  ret i32 0
+
+; <label>:50                                      ; preds = %46
+  %51 = load i32, i32* %loc0
+  ret i32 %51
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
 Successfully read WindowsConsoleStream.Flush
 
@@ -15173,8 +17575,8 @@ entry:
   %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
   store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
@@ -15209,8 +17611,8 @@ entry:
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
   %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load i64, i64 addrspace(1)* %1
@@ -15249,15 +17651,15 @@ entry:
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.TextWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
   %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %3, align 8
   %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
   %7 = load i64, i64 addrspace(1)* %5
@@ -15275,7 +17677,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -15304,8 +17706,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %4)
   store i32 0, i32* %loc0
   %5 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Char[]" addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
@@ -15317,15 +17719,15 @@ entry:
 
 ; <label>:11                                      ; preds = %69
   %12 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %12, i32 0, i32 9
   %15 = load i32, i32 addrspace(1)* %14, align 8
   %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.IO.StreamWriter addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %16, i32 0, i32 10
@@ -15340,15 +17742,15 @@ entry:
 
 ; <label>:23                                      ; preds = %17, %21
   %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %24, null
-  br i1 %NullCheck8, label %25, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %24, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 10
   %27 = load i32, i32 addrspace(1)* %26, align 8
   %28 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %28, null
-  br i1 %NullCheck10, label %29, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.StreamWriter addrspace(1)* %28, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %28, i32 0, i32 9
@@ -15370,15 +17772,15 @@ entry:
   %40 = load i32, i32* %loc0
   %41 = mul i32 %40, 2
   %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
-  br i1 %NullCheck12, label %43, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %43
 
 ; <label>:43                                      ; preds = %38
   %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 7
   %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %44, align 8
   %46 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %46, null
-  br i1 %NullCheck14, label %47, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.IO.StreamWriter addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %47
 
 ; <label>:47                                      ; preds = %43
   %48 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %46, i32 0, i32 9
@@ -15390,16 +17792,16 @@ entry:
   %54 = bitcast %"System.Char[]" addrspace(1)* %45 to %System.Array addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %53, i32 %41, %System.Array addrspace(1)* %54, i32 %50, i32 %52)
   %55 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
-  br i1 %NullCheck16, label %56, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %56
 
 ; <label>:56                                      ; preds = %47
   %57 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
   %58 = load i32, i32 addrspace(1)* %57, align 8
   %59 = load i32, i32* %loc2
   %60 = add i32 %58, %59
-  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
-  br i1 %NullCheck18, label %61, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %61
 
 ; <label>:61                                      ; preds = %56
   %62 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
@@ -15421,8 +17823,8 @@ entry:
 
 ; <label>:72                                      ; preds = %69
   %73 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %73, null
-  br i1 %NullCheck2, label %74, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %73, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %74
 
 ; <label>:74                                      ; preds = %72
   %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %73, i32 0, i32 11
@@ -15443,39 +17845,39 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %72
+ThrowNullRef2:                                    ; preds = %72
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %23
+ThrowNullRef8:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef10:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %43
+ThrowNullRef14:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %47
+ThrowNullRef16:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %56
+ThrowNullRef18:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPConvDbl2Lng.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPConvDbl2Lng.error.txt
@@ -25,8 +25,8 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
@@ -40,8 +40,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
   %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
@@ -75,7 +75,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -90,8 +90,8 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %NullCheck = icmp ne i8 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = load i8, i8 addrspace(1)* %0, align 8
@@ -125,8 +125,8 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
@@ -159,8 +159,8 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -184,8 +184,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
   store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
@@ -195,8 +195,8 @@ entry:
 ; <label>:4                                       ; preds = %1
   %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
   %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
@@ -206,8 +206,8 @@ entry:
   %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
@@ -221,14 +221,14 @@ entry:
 
 ; <label>:17                                      ; preds = %14
   %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
   %21 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
@@ -238,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -249,8 +249,8 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
@@ -261,27 +261,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %30
+ThrowNullRef10:                                   ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -301,7 +301,89 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
-Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
+Successfully read AppDomainSetup.GetUnsecureApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.GetUnsecureApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %NullCheck = icmp eq %"System.String[]" addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %BoundsCheck = icmp uge i64 0, %5
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %6
+
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 3, i32 0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
+  ret %System.String addrspace(1)* %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_Value using LLILCJit
+Successfully read AppDomainSetup.get_Value
+
+define %"System.String[]" addrspace(1)* @AppDomainSetup.get_Value(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.String[]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 18)
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.String[]" addrspace(1)* addrspace(1)*, %"System.String[]" addrspace(1)*)*)(%"System.String[]" addrspace(1)* addrspace(1)* %9, %"System.String[]" addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %11, i32 0, i32 1
+  %14 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %13, align 8
+  ret %"System.String[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -319,8 +401,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -368,16 +450,16 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
   %5 = load i32, i32 addrspace(1)* %4
   %6 = sub i32 %5, 1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -389,7 +471,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -421,8 +503,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
@@ -456,8 +538,8 @@ entry:
 ; <label>:27                                      ; preds = %19
   %28 = load i32, i32* %arg1
   %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
-  br i1 %NullCheck2, label %30, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %29, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %30
 
 ; <label>:30                                      ; preds = %27
   %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
@@ -493,8 +575,8 @@ entry:
 ; <label>:49                                      ; preds = %46
   %50 = load i32, i32* %arg2
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck4, label %52, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
@@ -517,11 +599,11 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %27
+ThrowNullRef2:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %49
+ThrowNullRef4:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -544,16 +626,16 @@ entry:
   %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %0)
   store %System.String addrspace(1)* %1, %System.String addrspace(1)** %loc0
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 2
   %5 = bitcast [0 x i16] addrspace(1)* %4 to i16 addrspace(1)*
   store i16 addrspace(1)* %5, i16 addrspace(1)** %loc1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %3
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2
@@ -580,7 +662,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -691,15 +773,15 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %NullCheck132 = icmp ne i8* %21, null
-  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+  %NullCheck131 = icmp eq i8* %21, null
+  br i1 %NullCheck131, label %ThrowNullRef132, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = load i8, i8* %21, align 8
   %24 = zext i8 %23 to i32
   %25 = trunc i32 %24 to i8
-  %NullCheck134 = icmp ne i8* %20, null
-  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+  %NullCheck133 = icmp eq i8* %20, null
+  br i1 %NullCheck133, label %ThrowNullRef134, label %26
 
 ; <label>:26                                      ; preds = %22
   store i8 %25, i8* %20, align 8
@@ -709,16 +791,16 @@ entry:
   %28 = load i8*, i8** %arg0
   %29 = load i8*, i8** %arg1
   %30 = bitcast i8* %29 to i16*
-  %NullCheck128 = icmp ne i16* %30, null
-  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+  %NullCheck127 = icmp eq i16* %30, null
+  br i1 %NullCheck127, label %ThrowNullRef128, label %31
 
 ; <label>:31                                      ; preds = %27
   %32 = load i16, i16* %30, align 8
   %33 = sext i16 %32 to i32
   %34 = bitcast i8* %28 to i16*
   %35 = trunc i32 %33 to i16
-  %NullCheck130 = icmp ne i16* %34, null
-  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+  %NullCheck129 = icmp eq i16* %34, null
+  br i1 %NullCheck129, label %ThrowNullRef130, label %36
 
 ; <label>:36                                      ; preds = %31
   store i16 %35, i16* %34, align 8
@@ -728,16 +810,16 @@ entry:
   %38 = load i8*, i8** %arg0
   %39 = load i8*, i8** %arg1
   %40 = bitcast i8* %39 to i16*
-  %NullCheck120 = icmp ne i16* %40, null
-  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+  %NullCheck119 = icmp eq i16* %40, null
+  br i1 %NullCheck119, label %ThrowNullRef120, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i16, i16* %40, align 8
   %43 = sext i16 %42 to i32
   %44 = bitcast i8* %38 to i16*
   %45 = trunc i32 %43 to i16
-  %NullCheck122 = icmp ne i16* %44, null
-  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+  %NullCheck121 = icmp eq i16* %44, null
+  br i1 %NullCheck121, label %ThrowNullRef122, label %46
 
 ; <label>:46                                      ; preds = %41
   store i16 %45, i16* %44, align 8
@@ -745,15 +827,15 @@ entry:
   %48 = getelementptr inbounds i8, i8* %47, i64 2
   %49 = load i8*, i8** %arg1
   %50 = getelementptr inbounds i8, i8* %49, i64 2
-  %NullCheck124 = icmp ne i8* %50, null
-  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+  %NullCheck123 = icmp eq i8* %50, null
+  br i1 %NullCheck123, label %ThrowNullRef124, label %51
 
 ; <label>:51                                      ; preds = %46
   %52 = load i8, i8* %50, align 8
   %53 = zext i8 %52 to i32
   %54 = trunc i32 %53 to i8
-  %NullCheck126 = icmp ne i8* %48, null
-  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+  %NullCheck125 = icmp eq i8* %48, null
+  br i1 %NullCheck125, label %ThrowNullRef126, label %55
 
 ; <label>:55                                      ; preds = %51
   store i8 %54, i8* %48, align 8
@@ -763,14 +845,14 @@ entry:
   %57 = load i8*, i8** %arg0
   %58 = load i8*, i8** %arg1
   %59 = bitcast i8* %58 to i32*
-  %NullCheck116 = icmp ne i32* %59, null
-  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+  %NullCheck115 = icmp eq i32* %59, null
+  br i1 %NullCheck115, label %ThrowNullRef116, label %60
 
 ; <label>:60                                      ; preds = %56
   %61 = load i32, i32* %59, align 8
   %62 = bitcast i8* %57 to i32*
-  %NullCheck118 = icmp ne i32* %62, null
-  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+  %NullCheck117 = icmp eq i32* %62, null
+  br i1 %NullCheck117, label %ThrowNullRef118, label %63
 
 ; <label>:63                                      ; preds = %60
   store i32 %61, i32* %62, align 8
@@ -780,14 +862,14 @@ entry:
   %65 = load i8*, i8** %arg0
   %66 = load i8*, i8** %arg1
   %67 = bitcast i8* %66 to i32*
-  %NullCheck108 = icmp ne i32* %67, null
-  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+  %NullCheck107 = icmp eq i32* %67, null
+  br i1 %NullCheck107, label %ThrowNullRef108, label %68
 
 ; <label>:68                                      ; preds = %64
   %69 = load i32, i32* %67, align 8
   %70 = bitcast i8* %65 to i32*
-  %NullCheck110 = icmp ne i32* %70, null
-  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+  %NullCheck109 = icmp eq i32* %70, null
+  br i1 %NullCheck109, label %ThrowNullRef110, label %71
 
 ; <label>:71                                      ; preds = %68
   store i32 %69, i32* %70, align 8
@@ -795,15 +877,15 @@ entry:
   %73 = getelementptr inbounds i8, i8* %72, i64 4
   %74 = load i8*, i8** %arg1
   %75 = getelementptr inbounds i8, i8* %74, i64 4
-  %NullCheck112 = icmp ne i8* %75, null
-  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+  %NullCheck111 = icmp eq i8* %75, null
+  br i1 %NullCheck111, label %ThrowNullRef112, label %76
 
 ; <label>:76                                      ; preds = %71
   %77 = load i8, i8* %75, align 8
   %78 = zext i8 %77 to i32
   %79 = trunc i32 %78 to i8
-  %NullCheck114 = icmp ne i8* %73, null
-  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+  %NullCheck113 = icmp eq i8* %73, null
+  br i1 %NullCheck113, label %ThrowNullRef114, label %80
 
 ; <label>:80                                      ; preds = %76
   store i8 %79, i8* %73, align 8
@@ -813,14 +895,14 @@ entry:
   %82 = load i8*, i8** %arg0
   %83 = load i8*, i8** %arg1
   %84 = bitcast i8* %83 to i32*
-  %NullCheck100 = icmp ne i32* %84, null
-  br i1 %NullCheck100, label %85, label %ThrowNullRef99
+  %NullCheck99 = icmp eq i32* %84, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %85
 
 ; <label>:85                                      ; preds = %81
   %86 = load i32, i32* %84, align 8
   %87 = bitcast i8* %82 to i32*
-  %NullCheck102 = icmp ne i32* %87, null
-  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+  %NullCheck101 = icmp eq i32* %87, null
+  br i1 %NullCheck101, label %ThrowNullRef102, label %88
 
 ; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
@@ -829,16 +911,16 @@ entry:
   %91 = load i8*, i8** %arg1
   %92 = getelementptr inbounds i8, i8* %91, i64 4
   %93 = bitcast i8* %92 to i16*
-  %NullCheck104 = icmp ne i16* %93, null
-  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+  %NullCheck103 = icmp eq i16* %93, null
+  br i1 %NullCheck103, label %ThrowNullRef104, label %94
 
 ; <label>:94                                      ; preds = %88
   %95 = load i16, i16* %93, align 8
   %96 = sext i16 %95 to i32
   %97 = bitcast i8* %90 to i16*
   %98 = trunc i32 %96 to i16
-  %NullCheck106 = icmp ne i16* %97, null
-  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+  %NullCheck105 = icmp eq i16* %97, null
+  br i1 %NullCheck105, label %ThrowNullRef106, label %99
 
 ; <label>:99                                      ; preds = %94
   store i16 %98, i16* %97, align 8
@@ -848,14 +930,14 @@ entry:
   %101 = load i8*, i8** %arg0
   %102 = load i8*, i8** %arg1
   %103 = bitcast i8* %102 to i32*
-  %NullCheck88 = icmp ne i32* %103, null
-  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+  %NullCheck87 = icmp eq i32* %103, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %104
 
 ; <label>:104                                     ; preds = %100
   %105 = load i32, i32* %103, align 8
   %106 = bitcast i8* %101 to i32*
-  %NullCheck90 = icmp ne i32* %106, null
-  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+  %NullCheck89 = icmp eq i32* %106, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %107
 
 ; <label>:107                                     ; preds = %104
   store i32 %105, i32* %106, align 8
@@ -864,16 +946,16 @@ entry:
   %110 = load i8*, i8** %arg1
   %111 = getelementptr inbounds i8, i8* %110, i64 4
   %112 = bitcast i8* %111 to i16*
-  %NullCheck92 = icmp ne i16* %112, null
-  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+  %NullCheck91 = icmp eq i16* %112, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %113
 
 ; <label>:113                                     ; preds = %107
   %114 = load i16, i16* %112, align 8
   %115 = sext i16 %114 to i32
   %116 = bitcast i8* %109 to i16*
   %117 = trunc i32 %115 to i16
-  %NullCheck94 = icmp ne i16* %116, null
-  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+  %NullCheck93 = icmp eq i16* %116, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %118
 
 ; <label>:118                                     ; preds = %113
   store i16 %117, i16* %116, align 8
@@ -881,15 +963,15 @@ entry:
   %120 = getelementptr inbounds i8, i8* %119, i64 6
   %121 = load i8*, i8** %arg1
   %122 = getelementptr inbounds i8, i8* %121, i64 6
-  %NullCheck96 = icmp ne i8* %122, null
-  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+  %NullCheck95 = icmp eq i8* %122, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %123
 
 ; <label>:123                                     ; preds = %118
   %124 = load i8, i8* %122, align 8
   %125 = zext i8 %124 to i32
   %126 = trunc i32 %125 to i8
-  %NullCheck98 = icmp ne i8* %120, null
-  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+  %NullCheck97 = icmp eq i8* %120, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %127
 
 ; <label>:127                                     ; preds = %123
   store i8 %126, i8* %120, align 8
@@ -899,14 +981,14 @@ entry:
   %129 = load i8*, i8** %arg0
   %130 = load i8*, i8** %arg1
   %131 = bitcast i8* %130 to i64*
-  %NullCheck84 = icmp ne i64* %131, null
-  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+  %NullCheck83 = icmp eq i64* %131, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %132
 
 ; <label>:132                                     ; preds = %128
   %133 = load i64, i64* %131, align 8
   %134 = bitcast i8* %129 to i64*
-  %NullCheck86 = icmp ne i64* %134, null
-  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+  %NullCheck85 = icmp eq i64* %134, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %135
 
 ; <label>:135                                     ; preds = %132
   store i64 %133, i64* %134, align 8
@@ -916,14 +998,14 @@ entry:
   %137 = load i8*, i8** %arg0
   %138 = load i8*, i8** %arg1
   %139 = bitcast i8* %138 to i64*
-  %NullCheck76 = icmp ne i64* %139, null
-  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+  %NullCheck75 = icmp eq i64* %139, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %140
 
 ; <label>:140                                     ; preds = %136
   %141 = load i64, i64* %139, align 8
   %142 = bitcast i8* %137 to i64*
-  %NullCheck78 = icmp ne i64* %142, null
-  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+  %NullCheck77 = icmp eq i64* %142, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %143
 
 ; <label>:143                                     ; preds = %140
   store i64 %141, i64* %142, align 8
@@ -931,15 +1013,15 @@ entry:
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %NullCheck80 = icmp ne i8* %147, null
-  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+  %NullCheck79 = icmp eq i8* %147, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %148
 
 ; <label>:148                                     ; preds = %143
   %149 = load i8, i8* %147, align 8
   %150 = zext i8 %149 to i32
   %151 = trunc i32 %150 to i8
-  %NullCheck82 = icmp ne i8* %145, null
-  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+  %NullCheck81 = icmp eq i8* %145, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %152
 
 ; <label>:152                                     ; preds = %148
   store i8 %151, i8* %145, align 8
@@ -949,14 +1031,14 @@ entry:
   %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
   %156 = bitcast i8* %155 to i64*
-  %NullCheck68 = icmp ne i64* %156, null
-  br i1 %NullCheck68, label %157, label %ThrowNullRef67
+  %NullCheck67 = icmp eq i64* %156, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %157
 
 ; <label>:157                                     ; preds = %153
   %158 = load i64, i64* %156, align 8
   %159 = bitcast i8* %154 to i64*
-  %NullCheck70 = icmp ne i64* %159, null
-  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+  %NullCheck69 = icmp eq i64* %159, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %160
 
 ; <label>:160                                     ; preds = %157
   store i64 %158, i64* %159, align 8
@@ -965,16 +1047,16 @@ entry:
   %163 = load i8*, i8** %arg1
   %164 = getelementptr inbounds i8, i8* %163, i64 8
   %165 = bitcast i8* %164 to i16*
-  %NullCheck72 = icmp ne i16* %165, null
-  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+  %NullCheck71 = icmp eq i16* %165, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %166
 
 ; <label>:166                                     ; preds = %160
   %167 = load i16, i16* %165, align 8
   %168 = sext i16 %167 to i32
   %169 = bitcast i8* %162 to i16*
   %170 = trunc i32 %168 to i16
-  %NullCheck74 = icmp ne i16* %169, null
-  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+  %NullCheck73 = icmp eq i16* %169, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %171
 
 ; <label>:171                                     ; preds = %166
   store i16 %170, i16* %169, align 8
@@ -984,14 +1066,14 @@ entry:
   %173 = load i8*, i8** %arg0
   %174 = load i8*, i8** %arg1
   %175 = bitcast i8* %174 to i64*
-  %NullCheck56 = icmp ne i64* %175, null
-  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+  %NullCheck55 = icmp eq i64* %175, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %176
 
 ; <label>:176                                     ; preds = %172
   %177 = load i64, i64* %175, align 8
   %178 = bitcast i8* %173 to i64*
-  %NullCheck58 = icmp ne i64* %178, null
-  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+  %NullCheck57 = icmp eq i64* %178, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %179
 
 ; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
@@ -1000,16 +1082,16 @@ entry:
   %182 = load i8*, i8** %arg1
   %183 = getelementptr inbounds i8, i8* %182, i64 8
   %184 = bitcast i8* %183 to i16*
-  %NullCheck60 = icmp ne i16* %184, null
-  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+  %NullCheck59 = icmp eq i16* %184, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %185
 
 ; <label>:185                                     ; preds = %179
   %186 = load i16, i16* %184, align 8
   %187 = sext i16 %186 to i32
   %188 = bitcast i8* %181 to i16*
   %189 = trunc i32 %187 to i16
-  %NullCheck62 = icmp ne i16* %188, null
-  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+  %NullCheck61 = icmp eq i16* %188, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %190
 
 ; <label>:190                                     ; preds = %185
   store i16 %189, i16* %188, align 8
@@ -1017,15 +1099,15 @@ entry:
   %192 = getelementptr inbounds i8, i8* %191, i64 10
   %193 = load i8*, i8** %arg1
   %194 = getelementptr inbounds i8, i8* %193, i64 10
-  %NullCheck64 = icmp ne i8* %194, null
-  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+  %NullCheck63 = icmp eq i8* %194, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %195
 
 ; <label>:195                                     ; preds = %190
   %196 = load i8, i8* %194, align 8
   %197 = zext i8 %196 to i32
   %198 = trunc i32 %197 to i8
-  %NullCheck66 = icmp ne i8* %192, null
-  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+  %NullCheck65 = icmp eq i8* %192, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %199
 
 ; <label>:199                                     ; preds = %195
   store i8 %198, i8* %192, align 8
@@ -1035,14 +1117,14 @@ entry:
   %201 = load i8*, i8** %arg0
   %202 = load i8*, i8** %arg1
   %203 = bitcast i8* %202 to i64*
-  %NullCheck48 = icmp ne i64* %203, null
-  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+  %NullCheck47 = icmp eq i64* %203, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %204
 
 ; <label>:204                                     ; preds = %200
   %205 = load i64, i64* %203, align 8
   %206 = bitcast i8* %201 to i64*
-  %NullCheck50 = icmp ne i64* %206, null
-  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+  %NullCheck49 = icmp eq i64* %206, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %207
 
 ; <label>:207                                     ; preds = %204
   store i64 %205, i64* %206, align 8
@@ -1051,14 +1133,14 @@ entry:
   %210 = load i8*, i8** %arg1
   %211 = getelementptr inbounds i8, i8* %210, i64 8
   %212 = bitcast i8* %211 to i32*
-  %NullCheck52 = icmp ne i32* %212, null
-  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+  %NullCheck51 = icmp eq i32* %212, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %213
 
 ; <label>:213                                     ; preds = %207
   %214 = load i32, i32* %212, align 8
   %215 = bitcast i8* %209 to i32*
-  %NullCheck54 = icmp ne i32* %215, null
-  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+  %NullCheck53 = icmp eq i32* %215, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %216
 
 ; <label>:216                                     ; preds = %213
   store i32 %214, i32* %215, align 8
@@ -1068,14 +1150,14 @@ entry:
   %218 = load i8*, i8** %arg0
   %219 = load i8*, i8** %arg1
   %220 = bitcast i8* %219 to i64*
-  %NullCheck36 = icmp ne i64* %220, null
-  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64* %220, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %221
 
 ; <label>:221                                     ; preds = %217
   %222 = load i64, i64* %220, align 8
   %223 = bitcast i8* %218 to i64*
-  %NullCheck38 = icmp ne i64* %223, null
-  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+  %NullCheck37 = icmp eq i64* %223, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %224
 
 ; <label>:224                                     ; preds = %221
   store i64 %222, i64* %223, align 8
@@ -1084,14 +1166,14 @@ entry:
   %227 = load i8*, i8** %arg1
   %228 = getelementptr inbounds i8, i8* %227, i64 8
   %229 = bitcast i8* %228 to i32*
-  %NullCheck40 = icmp ne i32* %229, null
-  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i32* %229, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %230
 
 ; <label>:230                                     ; preds = %224
   %231 = load i32, i32* %229, align 8
   %232 = bitcast i8* %226 to i32*
-  %NullCheck42 = icmp ne i32* %232, null
-  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+  %NullCheck41 = icmp eq i32* %232, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %233
 
 ; <label>:233                                     ; preds = %230
   store i32 %231, i32* %232, align 8
@@ -1099,15 +1181,15 @@ entry:
   %235 = getelementptr inbounds i8, i8* %234, i64 12
   %236 = load i8*, i8** %arg1
   %237 = getelementptr inbounds i8, i8* %236, i64 12
-  %NullCheck44 = icmp ne i8* %237, null
-  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i8* %237, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %238
 
 ; <label>:238                                     ; preds = %233
   %239 = load i8, i8* %237, align 8
   %240 = zext i8 %239 to i32
   %241 = trunc i32 %240 to i8
-  %NullCheck46 = icmp ne i8* %235, null
-  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+  %NullCheck45 = icmp eq i8* %235, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %242
 
 ; <label>:242                                     ; preds = %238
   store i8 %241, i8* %235, align 8
@@ -1117,14 +1199,14 @@ entry:
   %244 = load i8*, i8** %arg0
   %245 = load i8*, i8** %arg1
   %246 = bitcast i8* %245 to i64*
-  %NullCheck24 = icmp ne i64* %246, null
-  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64* %246, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %247
 
 ; <label>:247                                     ; preds = %243
   %248 = load i64, i64* %246, align 8
   %249 = bitcast i8* %244 to i64*
-  %NullCheck26 = icmp ne i64* %249, null
-  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64* %249, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %250
 
 ; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
@@ -1133,14 +1215,14 @@ entry:
   %253 = load i8*, i8** %arg1
   %254 = getelementptr inbounds i8, i8* %253, i64 8
   %255 = bitcast i8* %254 to i32*
-  %NullCheck28 = icmp ne i32* %255, null
-  br i1 %NullCheck28, label %256, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i32* %255, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %256
 
 ; <label>:256                                     ; preds = %250
   %257 = load i32, i32* %255, align 8
   %258 = bitcast i8* %252 to i32*
-  %NullCheck30 = icmp ne i32* %258, null
-  br i1 %NullCheck30, label %259, label %ThrowNullRef29
+  %NullCheck29 = icmp eq i32* %258, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %259
 
 ; <label>:259                                     ; preds = %256
   store i32 %257, i32* %258, align 8
@@ -1149,16 +1231,16 @@ entry:
   %262 = load i8*, i8** %arg1
   %263 = getelementptr inbounds i8, i8* %262, i64 12
   %264 = bitcast i8* %263 to i16*
-  %NullCheck32 = icmp ne i16* %264, null
-  br i1 %NullCheck32, label %265, label %ThrowNullRef31
+  %NullCheck31 = icmp eq i16* %264, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %265
 
 ; <label>:265                                     ; preds = %259
   %266 = load i16, i16* %264, align 8
   %267 = sext i16 %266 to i32
   %268 = bitcast i8* %261 to i16*
   %269 = trunc i32 %267 to i16
-  %NullCheck34 = icmp ne i16* %268, null
-  br i1 %NullCheck34, label %270, label %ThrowNullRef33
+  %NullCheck33 = icmp eq i16* %268, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %270
 
 ; <label>:270                                     ; preds = %265
   store i16 %269, i16* %268, align 8
@@ -1168,14 +1250,14 @@ entry:
   %272 = load i8*, i8** %arg0
   %273 = load i8*, i8** %arg1
   %274 = bitcast i8* %273 to i64*
-  %NullCheck8 = icmp ne i64* %274, null
-  br i1 %NullCheck8, label %275, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64* %274, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %275
 
 ; <label>:275                                     ; preds = %271
   %276 = load i64, i64* %274, align 8
   %277 = bitcast i8* %272 to i64*
-  %NullCheck10 = icmp ne i64* %277, null
-  br i1 %NullCheck10, label %278, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %277, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %278
 
 ; <label>:278                                     ; preds = %275
   store i64 %276, i64* %277, align 8
@@ -1184,14 +1266,14 @@ entry:
   %281 = load i8*, i8** %arg1
   %282 = getelementptr inbounds i8, i8* %281, i64 8
   %283 = bitcast i8* %282 to i32*
-  %NullCheck12 = icmp ne i32* %283, null
-  br i1 %NullCheck12, label %284, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i32* %283, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %284
 
 ; <label>:284                                     ; preds = %278
   %285 = load i32, i32* %283, align 8
   %286 = bitcast i8* %280 to i32*
-  %NullCheck14 = icmp ne i32* %286, null
-  br i1 %NullCheck14, label %287, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i32* %286, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %287
 
 ; <label>:287                                     ; preds = %284
   store i32 %285, i32* %286, align 8
@@ -1200,16 +1282,16 @@ entry:
   %290 = load i8*, i8** %arg1
   %291 = getelementptr inbounds i8, i8* %290, i64 12
   %292 = bitcast i8* %291 to i16*
-  %NullCheck16 = icmp ne i16* %292, null
-  br i1 %NullCheck16, label %293, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i16* %292, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %293
 
 ; <label>:293                                     ; preds = %287
   %294 = load i16, i16* %292, align 8
   %295 = sext i16 %294 to i32
   %296 = bitcast i8* %289 to i16*
   %297 = trunc i32 %295 to i16
-  %NullCheck18 = icmp ne i16* %296, null
-  br i1 %NullCheck18, label %298, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i16* %296, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %298
 
 ; <label>:298                                     ; preds = %293
   store i16 %297, i16* %296, align 8
@@ -1217,15 +1299,15 @@ entry:
   %300 = getelementptr inbounds i8, i8* %299, i64 14
   %301 = load i8*, i8** %arg1
   %302 = getelementptr inbounds i8, i8* %301, i64 14
-  %NullCheck20 = icmp ne i8* %302, null
-  br i1 %NullCheck20, label %303, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i8* %302, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %303
 
 ; <label>:303                                     ; preds = %298
   %304 = load i8, i8* %302, align 8
   %305 = zext i8 %304 to i32
   %306 = trunc i32 %305 to i8
-  %NullCheck22 = icmp ne i8* %300, null
-  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i8* %300, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %307
 
 ; <label>:307                                     ; preds = %303
   store i8 %306, i8* %300, align 8
@@ -1235,14 +1317,14 @@ entry:
   %309 = load i8*, i8** %arg0
   %310 = load i8*, i8** %arg1
   %311 = bitcast i8* %310 to i64*
-  %NullCheck = icmp ne i64* %311, null
-  br i1 %NullCheck, label %312, label %ThrowNullRef
+  %NullCheck = icmp eq i64* %311, null
+  br i1 %NullCheck, label %ThrowNullRef, label %312
 
 ; <label>:312                                     ; preds = %308
   %313 = load i64, i64* %311, align 8
   %314 = bitcast i8* %309 to i64*
-  %NullCheck2 = icmp ne i64* %314, null
-  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64* %314, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %315
 
 ; <label>:315                                     ; preds = %312
   store i64 %313, i64* %314, align 8
@@ -1251,14 +1333,14 @@ entry:
   %318 = load i8*, i8** %arg1
   %319 = getelementptr inbounds i8, i8* %318, i64 8
   %320 = bitcast i8* %319 to i64*
-  %NullCheck4 = icmp ne i64* %320, null
-  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64* %320, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %321
 
 ; <label>:321                                     ; preds = %315
   %322 = load i64, i64* %320, align 8
   %323 = bitcast i8* %317 to i64*
-  %NullCheck6 = icmp ne i64* %323, null
-  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64* %323, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %324
 
 ; <label>:324                                     ; preds = %321
   store i64 %322, i64* %323, align 8
@@ -1286,15 +1368,15 @@ entry:
 ; <label>:338                                     ; preds = %333
   %339 = load i8*, i8** %arg0
   %340 = load i8*, i8** %arg1
-  %NullCheck136 = icmp ne i8* %340, null
-  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+  %NullCheck135 = icmp eq i8* %340, null
+  br i1 %NullCheck135, label %ThrowNullRef136, label %341
 
 ; <label>:341                                     ; preds = %338
   %342 = load i8, i8* %340, align 8
   %343 = zext i8 %342 to i32
   %344 = trunc i32 %343 to i8
-  %NullCheck138 = icmp ne i8* %339, null
-  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+  %NullCheck137 = icmp eq i8* %339, null
+  br i1 %NullCheck137, label %ThrowNullRef138, label %345
 
 ; <label>:345                                     ; preds = %341
   store i8 %344, i8* %339, align 8
@@ -1317,16 +1399,16 @@ entry:
   %357 = load i8*, i8** %arg0
   %358 = load i8*, i8** %arg1
   %359 = bitcast i8* %358 to i16*
-  %NullCheck140 = icmp ne i16* %359, null
-  br i1 %NullCheck140, label %360, label %ThrowNullRef139
+  %NullCheck139 = icmp eq i16* %359, null
+  br i1 %NullCheck139, label %ThrowNullRef140, label %360
 
 ; <label>:360                                     ; preds = %356
   %361 = load i16, i16* %359, align 8
   %362 = sext i16 %361 to i32
   %363 = bitcast i8* %357 to i16*
   %364 = trunc i32 %362 to i16
-  %NullCheck142 = icmp ne i16* %363, null
-  br i1 %NullCheck142, label %365, label %ThrowNullRef141
+  %NullCheck141 = icmp eq i16* %363, null
+  br i1 %NullCheck141, label %ThrowNullRef142, label %365
 
 ; <label>:365                                     ; preds = %360
   store i16 %364, i16* %363, align 8
@@ -1352,14 +1434,14 @@ entry:
   %378 = load i8*, i8** %arg0
   %379 = load i8*, i8** %arg1
   %380 = bitcast i8* %379 to i32*
-  %NullCheck144 = icmp ne i32* %380, null
-  br i1 %NullCheck144, label %381, label %ThrowNullRef143
+  %NullCheck143 = icmp eq i32* %380, null
+  br i1 %NullCheck143, label %ThrowNullRef144, label %381
 
 ; <label>:381                                     ; preds = %377
   %382 = load i32, i32* %380, align 8
   %383 = bitcast i8* %378 to i32*
-  %NullCheck146 = icmp ne i32* %383, null
-  br i1 %NullCheck146, label %384, label %ThrowNullRef145
+  %NullCheck145 = icmp eq i32* %383, null
+  br i1 %NullCheck145, label %ThrowNullRef146, label %384
 
 ; <label>:384                                     ; preds = %381
   store i32 %382, i32* %383, align 8
@@ -1384,14 +1466,14 @@ entry:
   %395 = load i8*, i8** %arg0
   %396 = load i8*, i8** %arg1
   %397 = bitcast i8* %396 to i64*
-  %NullCheck164 = icmp ne i64* %397, null
-  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+  %NullCheck163 = icmp eq i64* %397, null
+  br i1 %NullCheck163, label %ThrowNullRef164, label %398
 
 ; <label>:398                                     ; preds = %394
   %399 = load i64, i64* %397, align 8
   %400 = bitcast i8* %395 to i64*
-  %NullCheck166 = icmp ne i64* %400, null
-  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+  %NullCheck165 = icmp eq i64* %400, null
+  br i1 %NullCheck165, label %ThrowNullRef166, label %401
 
 ; <label>:401                                     ; preds = %398
   store i64 %399, i64* %400, align 8
@@ -1400,14 +1482,14 @@ entry:
   %404 = load i8*, i8** %arg1
   %405 = getelementptr inbounds i8, i8* %404, i64 8
   %406 = bitcast i8* %405 to i64*
-  %NullCheck168 = icmp ne i64* %406, null
-  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+  %NullCheck167 = icmp eq i64* %406, null
+  br i1 %NullCheck167, label %ThrowNullRef168, label %407
 
 ; <label>:407                                     ; preds = %401
   %408 = load i64, i64* %406, align 8
   %409 = bitcast i8* %403 to i64*
-  %NullCheck170 = icmp ne i64* %409, null
-  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+  %NullCheck169 = icmp eq i64* %409, null
+  br i1 %NullCheck169, label %ThrowNullRef170, label %410
 
 ; <label>:410                                     ; preds = %407
   store i64 %408, i64* %409, align 8
@@ -1437,14 +1519,14 @@ entry:
   %425 = load i8*, i8** %arg0
   %426 = load i8*, i8** %arg1
   %427 = bitcast i8* %426 to i64*
-  %NullCheck148 = icmp ne i64* %427, null
-  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+  %NullCheck147 = icmp eq i64* %427, null
+  br i1 %NullCheck147, label %ThrowNullRef148, label %428
 
 ; <label>:428                                     ; preds = %424
   %429 = load i64, i64* %427, align 8
   %430 = bitcast i8* %425 to i64*
-  %NullCheck150 = icmp ne i64* %430, null
-  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+  %NullCheck149 = icmp eq i64* %430, null
+  br i1 %NullCheck149, label %ThrowNullRef150, label %431
 
 ; <label>:431                                     ; preds = %428
   store i64 %429, i64* %430, align 8
@@ -1466,14 +1548,14 @@ entry:
   %441 = load i8*, i8** %arg0
   %442 = load i8*, i8** %arg1
   %443 = bitcast i8* %442 to i32*
-  %NullCheck152 = icmp ne i32* %443, null
-  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+  %NullCheck151 = icmp eq i32* %443, null
+  br i1 %NullCheck151, label %ThrowNullRef152, label %444
 
 ; <label>:444                                     ; preds = %440
   %445 = load i32, i32* %443, align 8
   %446 = bitcast i8* %441 to i32*
-  %NullCheck154 = icmp ne i32* %446, null
-  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+  %NullCheck153 = icmp eq i32* %446, null
+  br i1 %NullCheck153, label %ThrowNullRef154, label %447
 
 ; <label>:447                                     ; preds = %444
   store i32 %445, i32* %446, align 8
@@ -1495,16 +1577,16 @@ entry:
   %457 = load i8*, i8** %arg0
   %458 = load i8*, i8** %arg1
   %459 = bitcast i8* %458 to i16*
-  %NullCheck156 = icmp ne i16* %459, null
-  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+  %NullCheck155 = icmp eq i16* %459, null
+  br i1 %NullCheck155, label %ThrowNullRef156, label %460
 
 ; <label>:460                                     ; preds = %456
   %461 = load i16, i16* %459, align 8
   %462 = sext i16 %461 to i32
   %463 = bitcast i8* %457 to i16*
   %464 = trunc i32 %462 to i16
-  %NullCheck158 = icmp ne i16* %463, null
-  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+  %NullCheck157 = icmp eq i16* %463, null
+  br i1 %NullCheck157, label %ThrowNullRef158, label %465
 
 ; <label>:465                                     ; preds = %460
   store i16 %464, i16* %463, align 8
@@ -1525,15 +1607,15 @@ entry:
 ; <label>:474                                     ; preds = %470
   %475 = load i8*, i8** %arg0
   %476 = load i8*, i8** %arg1
-  %NullCheck160 = icmp ne i8* %476, null
-  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+  %NullCheck159 = icmp eq i8* %476, null
+  br i1 %NullCheck159, label %ThrowNullRef160, label %477
 
 ; <label>:477                                     ; preds = %474
   %478 = load i8, i8* %476, align 8
   %479 = zext i8 %478 to i32
   %480 = trunc i32 %479 to i8
-  %NullCheck162 = icmp ne i8* %475, null
-  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+  %NullCheck161 = icmp eq i8* %475, null
+  br i1 %NullCheck161, label %ThrowNullRef162, label %481
 
 ; <label>:481                                     ; preds = %477
   store i8 %480, i8* %475, align 8
@@ -1553,343 +1635,343 @@ ThrowNullRef:                                     ; preds = %308
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %312
+ThrowNullRef2:                                    ; preds = %312
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %315
+ThrowNullRef4:                                    ; preds = %315
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %321
+ThrowNullRef6:                                    ; preds = %321
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %271
+ThrowNullRef8:                                    ; preds = %271
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %275
+ThrowNullRef10:                                   ; preds = %275
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %278
+ThrowNullRef12:                                   ; preds = %278
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %284
+ThrowNullRef14:                                   ; preds = %284
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %287
+ThrowNullRef16:                                   ; preds = %287
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %293
+ThrowNullRef18:                                   ; preds = %293
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %298
+ThrowNullRef20:                                   ; preds = %298
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %303
+ThrowNullRef22:                                   ; preds = %303
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %243
+ThrowNullRef24:                                   ; preds = %243
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %247
+ThrowNullRef26:                                   ; preds = %247
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %250
+ThrowNullRef28:                                   ; preds = %250
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %256
+ThrowNullRef30:                                   ; preds = %256
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %259
+ThrowNullRef32:                                   ; preds = %259
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %265
+ThrowNullRef34:                                   ; preds = %265
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %217
+ThrowNullRef36:                                   ; preds = %217
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %221
+ThrowNullRef38:                                   ; preds = %221
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %224
+ThrowNullRef40:                                   ; preds = %224
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %230
+ThrowNullRef42:                                   ; preds = %230
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %233
+ThrowNullRef44:                                   ; preds = %233
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %238
+ThrowNullRef46:                                   ; preds = %238
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %200
+ThrowNullRef48:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %204
+ThrowNullRef50:                                   ; preds = %204
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %207
+ThrowNullRef52:                                   ; preds = %207
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %213
+ThrowNullRef54:                                   ; preds = %213
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %172
+ThrowNullRef56:                                   ; preds = %172
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %176
+ThrowNullRef58:                                   ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %179
+ThrowNullRef60:                                   ; preds = %179
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %185
+ThrowNullRef62:                                   ; preds = %185
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %190
+ThrowNullRef64:                                   ; preds = %190
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %195
+ThrowNullRef66:                                   ; preds = %195
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %153
+ThrowNullRef68:                                   ; preds = %153
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %157
+ThrowNullRef70:                                   ; preds = %157
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %160
+ThrowNullRef72:                                   ; preds = %160
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %166
+ThrowNullRef74:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %136
+ThrowNullRef76:                                   ; preds = %136
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %140
+ThrowNullRef78:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %143
+ThrowNullRef80:                                   ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %148
+ThrowNullRef82:                                   ; preds = %148
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %128
+ThrowNullRef84:                                   ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %132
+ThrowNullRef86:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %100
+ThrowNullRef88:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %104
+ThrowNullRef90:                                   ; preds = %104
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %107
+ThrowNullRef92:                                   ; preds = %107
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %113
+ThrowNullRef94:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %118
+ThrowNullRef96:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %123
+ThrowNullRef98:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %81
+ThrowNullRef100:                                  ; preds = %81
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef101:                                  ; preds = %85
+ThrowNullRef102:                                  ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef103:                                  ; preds = %88
+ThrowNullRef104:                                  ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef105:                                  ; preds = %94
+ThrowNullRef106:                                  ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef107:                                  ; preds = %64
+ThrowNullRef108:                                  ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef109:                                  ; preds = %68
+ThrowNullRef110:                                  ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef111:                                  ; preds = %71
+ThrowNullRef112:                                  ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef113:                                  ; preds = %76
+ThrowNullRef114:                                  ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef115:                                  ; preds = %56
+ThrowNullRef116:                                  ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef117:                                  ; preds = %60
+ThrowNullRef118:                                  ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef119:                                  ; preds = %37
+ThrowNullRef120:                                  ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef121:                                  ; preds = %41
+ThrowNullRef122:                                  ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef123:                                  ; preds = %46
+ThrowNullRef124:                                  ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef125:                                  ; preds = %51
+ThrowNullRef126:                                  ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef127:                                  ; preds = %27
+ThrowNullRef128:                                  ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef129:                                  ; preds = %31
+ThrowNullRef130:                                  ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef131:                                  ; preds = %19
+ThrowNullRef132:                                  ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef133:                                  ; preds = %22
+ThrowNullRef134:                                  ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef135:                                  ; preds = %338
+ThrowNullRef136:                                  ; preds = %338
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef137:                                  ; preds = %341
+ThrowNullRef138:                                  ; preds = %341
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef139:                                  ; preds = %356
+ThrowNullRef140:                                  ; preds = %356
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef141:                                  ; preds = %360
+ThrowNullRef142:                                  ; preds = %360
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef143:                                  ; preds = %377
+ThrowNullRef144:                                  ; preds = %377
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef145:                                  ; preds = %381
+ThrowNullRef146:                                  ; preds = %381
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef147:                                  ; preds = %424
+ThrowNullRef148:                                  ; preds = %424
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef149:                                  ; preds = %428
+ThrowNullRef150:                                  ; preds = %428
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef151:                                  ; preds = %440
+ThrowNullRef152:                                  ; preds = %440
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef153:                                  ; preds = %444
+ThrowNullRef154:                                  ; preds = %444
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef155:                                  ; preds = %456
+ThrowNullRef156:                                  ; preds = %456
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef157:                                  ; preds = %460
+ThrowNullRef158:                                  ; preds = %460
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef159:                                  ; preds = %474
+ThrowNullRef160:                                  ; preds = %474
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef161:                                  ; preds = %477
+ThrowNullRef162:                                  ; preds = %477
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef163:                                  ; preds = %394
+ThrowNullRef164:                                  ; preds = %394
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef165:                                  ; preds = %398
+ThrowNullRef166:                                  ; preds = %398
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef167:                                  ; preds = %401
+ThrowNullRef168:                                  ; preds = %401
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef169:                                  ; preds = %407
+ThrowNullRef170:                                  ; preds = %407
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1939,8 +2021,8 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
-  br i1 %NullCheck, label %22, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %ThrowNullRef, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
@@ -1948,8 +2030,8 @@ entry:
   store i32 %24, i32* %loc0
   %25 = load i32, i32* %loc0
   %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %26, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %27
 
 ; <label>:27                                      ; preds = %22
   %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
@@ -1971,7 +2053,7 @@ ThrowNullRef:                                     ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1989,8 +2071,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -2022,15 +2104,15 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2048,16 +2130,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
   %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
   store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %15
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
@@ -2072,8 +2154,8 @@ entry:
   %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
   %29 = ptrtoint i16 addrspace(1)* %28 to i64
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %19
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
@@ -2089,19 +2171,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2114,8 +2196,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
@@ -2128,7 +2210,7 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[loadElem]
+Failed to read AppDomain.PrepareDataForSetup[storeElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
@@ -2202,8 +2284,8 @@ entry:
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
-  br i1 %NullCheck24, label %27, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = load i64, i64 addrspace(1)* %26
@@ -2218,8 +2300,8 @@ entry:
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
-  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
   %41 = load i64, i64 addrspace(1)* %39
@@ -2236,8 +2318,8 @@ entry:
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
-  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
   %54 = load i64, i64 addrspace(1)* %52
@@ -2252,8 +2334,8 @@ entry:
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
   %67 = load i64, i64 addrspace(1)* %65
@@ -2270,8 +2352,8 @@ entry:
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
-  br i1 %NullCheck16, label %79, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
   %80 = load i64, i64 addrspace(1)* %78
@@ -2286,8 +2368,8 @@ entry:
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
-  br i1 %NullCheck18, label %92, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
   %93 = load i64, i64 addrspace(1)* %91
@@ -2304,8 +2386,8 @@ entry:
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
-  br i1 %NullCheck12, label %105, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = load i64, i64 addrspace(1)* %104
@@ -2320,8 +2402,8 @@ entry:
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
-  br i1 %NullCheck14, label %118, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
   %119 = load i64, i64 addrspace(1)* %117
@@ -2337,8 +2419,8 @@ entry:
 
 ; <label>:128                                     ; preds = %20
   %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
-  br i1 %NullCheck4, label %130, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %129, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %130
 
 ; <label>:130                                     ; preds = %128
   %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
@@ -2346,8 +2428,8 @@ entry:
   %133 = load i16, i16 addrspace(1)* %132, align 8
   %134 = zext i16 %133 to i32
   %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
-  br i1 %NullCheck6, label %136, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %135, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %136
 
 ; <label>:136                                     ; preds = %130
   %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
@@ -2360,8 +2442,8 @@ entry:
 
 ; <label>:143                                     ; preds = %136
   %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
-  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %144, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %145
 
 ; <label>:145                                     ; preds = %143
   %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
@@ -2369,8 +2451,8 @@ entry:
   %148 = load i16, i16 addrspace(1)* %147, align 8
   %149 = zext i16 %148 to i32
   %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %150, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %151
 
 ; <label>:151                                     ; preds = %145
   %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
@@ -2388,8 +2470,8 @@ entry:
 
 ; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
-  br i1 %NullCheck, label %163, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %ThrowNullRef, label %163
 
 ; <label>:163                                     ; preds = %161
   %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
@@ -2399,8 +2481,8 @@ entry:
 
 ; <label>:167                                     ; preds = %163
   %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
-  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %168, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %169
 
 ; <label>:169                                     ; preds = %167
   %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
@@ -2432,55 +2514,55 @@ ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %167
+ThrowNullRef2:                                    ; preds = %167
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %128
+ThrowNullRef4:                                    ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %130
+ThrowNullRef6:                                    ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %143
+ThrowNullRef8:                                    ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %145
+ThrowNullRef10:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %102
+ThrowNullRef12:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %105
+ThrowNullRef14:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %76
+ThrowNullRef16:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %79
+ThrowNullRef18:                                   ; preds = %79
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %50
+ThrowNullRef20:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %53
+ThrowNullRef22:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %24
+ThrowNullRef24:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %27
+ThrowNullRef26:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2503,15 +2585,15 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2519,16 +2601,16 @@ entry:
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
   store i32 %8, i32* %loc0
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
   %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
   store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
@@ -2546,16 +2628,16 @@ entry:
 
 ; <label>:23                                      ; preds = %64
   %24 = load i16*, i16** %loc3
-  %NullCheck12 = icmp ne i16* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i16* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
   store i32 %27, i32* %loc5
   %28 = load i16*, i16** %loc4
-  %NullCheck14 = icmp ne i16* %28, null
-  br i1 %NullCheck14, label %29, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %28, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = load i16, i16* %28, align 8
@@ -2620,15 +2702,15 @@ entry:
 
 ; <label>:67                                      ; preds = %64
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
-  br i1 %NullCheck8, label %69, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %68, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %69
 
 ; <label>:69                                      ; preds = %67
   %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
   %71 = load i32, i32 addrspace(1)* %70
   %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
-  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %73
 
 ; <label>:73                                      ; preds = %69
   %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
@@ -2645,31 +2727,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %67
+ThrowNullRef8:                                    ; preds = %67
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %69
+ThrowNullRef10:                                   ; preds = %69
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2710,14 +2792,14 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
   %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
@@ -2730,14 +2812,14 @@ entry:
 
 ; <label>:11                                      ; preds = %4
   %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
   %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
@@ -2749,14 +2831,14 @@ entry:
 
 ; <label>:22                                      ; preds = %16
   %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
   %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
-  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
-  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
@@ -2804,23 +2886,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2836,7 +2918,280 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[loadElem]
+Successfully read RuntimeType.IsAssignableFrom
+
+define i8 @RuntimeType.IsAssignableFrom(%System.RuntimeType addrspace(1)* %param0, %System.Type addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.RuntimeType addrspace(1)*
+  %arg1 = alloca %System.Type addrspace(1)*
+  %loc0 = alloca %System.RuntimeType addrspace(1)*
+  %loc1 = alloca %"System.Type[]" addrspace(1)*
+  %loc2 = alloca i32
+  store %System.RuntimeType addrspace(1)* %param0, %System.RuntimeType addrspace(1)** %this
+  store %System.Type addrspace(1)* %param1, %System.Type addrspace(1)** %arg1
+  %0 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %1 = icmp ne %System.Type addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i8 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %5 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %6 = bitcast %System.Type addrspace(1)* %4 to %System.Object addrspace(1)*
+  %7 = bitcast %System.RuntimeType addrspace(1)* %5 to %System.Object addrspace(1)*
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %6, %System.Object addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %3
+  ret i8 1
+
+; <label>:12                                      ; preds = %3
+  %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 152
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 32
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
+  %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
+  %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
+  store %System.RuntimeType addrspace(1)* %25, %System.RuntimeType addrspace(1)** %loc0
+  %26 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %27 = icmp eq %System.RuntimeType addrspace(1)* %26, null
+  br i1 %27, label %34, label %28
+
+; <label>:28                                      ; preds = %15
+  %29 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %30 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)*)*)(%System.RuntimeType addrspace(1)* %29, %System.RuntimeType addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+; <label>:34                                      ; preds = %15
+  %35 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %36 = call %System.Reflection.Emit.TypeBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Reflection.Emit.TypeBuilder addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %35)
+  %37 = icmp eq %System.Reflection.Emit.TypeBuilder addrspace(1)* %36, null
+  br i1 %37, label %139, label %38
+
+; <label>:38                                      ; preds = %34
+  %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %42
+
+; <label>:42                                      ; preds = %38
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 152
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 40
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
+  %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
+  %53 = zext i8 %52 to i32
+  %54 = icmp eq i32 %53, 0
+  br i1 %54, label %56, label %55
+
+; <label>:55                                      ; preds = %42
+  ret i8 1
+
+; <label>:56                                      ; preds = %42
+  %57 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %58 = bitcast %System.RuntimeType addrspace(1)* %57 to %System.Type addrspace(1)*
+  %59 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %58)
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %64 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.Type addrspace(1)* %63, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = bitcast %System.RuntimeType addrspace(1)* %64 to %System.Type addrspace(1)*
+  %67 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %63, %System.Type addrspace(1)* %66)
+  %68 = zext i8 %67 to i32
+  %69 = trunc i32 %68 to i8
+  ret i8 %69
+
+; <label>:70                                      ; preds = %56
+  %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
+  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %73
+
+; <label>:73                                      ; preds = %70
+  %74 = load i64, i64 addrspace(1)* %72
+  %75 = add i64 %74, 128
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = add i64 %77, 0
+  %79 = inttoptr i64 %78 to i64*
+  %80 = load i64, i64* %79
+  %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
+  %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
+  %83 = call i8 %82(%System.Type addrspace(1)* %81)
+  %84 = zext i8 %83 to i32
+  %85 = icmp eq i32 %84, 0
+  br i1 %85, label %139, label %86
+
+; <label>:86                                      ; preds = %73
+  %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
+  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %89
+
+; <label>:89                                      ; preds = %86
+  %90 = load i64, i64 addrspace(1)* %88
+  %91 = add i64 %90, 128
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = add i64 %93, 24
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
+  %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
+  %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
+  store %"System.Type[]" addrspace(1)* %99, %"System.Type[]" addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %129
+
+; <label>:100                                     ; preds = %132
+  %101 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %102 = load i32, i32* %loc2
+  %NullCheck11 = icmp eq %"System.Type[]" addrspace(1)* %101, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %103
+
+; <label>:103                                     ; preds = %100
+  %104 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 1
+  %105 = load i32, i32 addrspace(1)* %104
+  %106 = zext i32 %105 to i64
+  %107 = zext i32 %102 to i64
+  %BoundsCheck = icmp uge i64 %107, %106
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %108
+
+; <label>:108                                     ; preds = %103
+  %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
+  %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
+  %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
+  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %113
+
+; <label>:113                                     ; preds = %108
+  %114 = load i64, i64 addrspace(1)* %112
+  %115 = add i64 %114, 152
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = add i64 %117, 56
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
+  %123 = zext i8 %122 to i32
+  %124 = icmp ne i32 %123, 0
+  br i1 %124, label %126, label %125
+
+; <label>:125                                     ; preds = %113
+  ret i8 0
+
+; <label>:126                                     ; preds = %113
+  %127 = load i32, i32* %loc2
+  %128 = add i32 %127, 1
+  store i32 %128, i32* %loc2
+  br label %129
+
+; <label>:129                                     ; preds = %89, %126
+  %130 = load i32, i32* %loc2
+  %131 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %NullCheck9 = icmp eq %"System.Type[]" addrspace(1)* %131, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %132
+
+; <label>:132                                     ; preds = %129
+  %133 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %131, i32 0, i32 1
+  %134 = load i32, i32 addrspace(1)* %133
+  %135 = zext i32 %134 to i64
+  %136 = trunc i64 %135 to i32
+  %137 = icmp slt i32 %130, %136
+  br i1 %137, label %100, label %138
+
+; <label>:138                                     ; preds = %132
+  ret i8 1
+
+; <label>:139                                     ; preds = %34, %73
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %129
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %103
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -2893,7 +3248,7 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElem]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -2904,8 +3259,8 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -2997,8 +3352,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
@@ -3059,8 +3414,8 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -3087,8 +3442,8 @@ entry:
 
 ; <label>:17                                      ; preds = %5, %11
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
@@ -3097,8 +3452,8 @@ entry:
 
 ; <label>:22                                      ; preds = %1, %11
   %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
@@ -3109,11 +3464,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %17
+ThrowNullRef2:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %22
+ThrowNullRef4:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3167,15 +3522,15 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
   %15 = load i32, i32 addrspace(1)* %14
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
@@ -3198,7 +3553,7 @@ ThrowNullRef:                                     ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef2:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3232,8 +3587,8 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
@@ -3312,8 +3667,8 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -3327,8 +3682,8 @@ entry:
 ; <label>:5                                       ; preds = %43
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %7 = load i32, i32* %loc1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck6, label %8, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
@@ -3366,8 +3721,8 @@ entry:
 ; <label>:32                                      ; preds = %21, %25
   %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
   %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
-  br i1 %NullCheck8, label %35, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = trunc i32 %34 to i16
@@ -3380,8 +3735,8 @@ entry:
 ; <label>:40                                      ; preds = %1, %35
   %41 = load i32, i32* %loc1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
-  br i1 %NullCheck2, label %43, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %42, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
@@ -3392,8 +3747,8 @@ entry:
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
   %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
-  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
   %51 = load i64, i64 addrspace(1)* %49
@@ -3412,19 +3767,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %40
+ThrowNullRef2:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %47
+ThrowNullRef4:                                    ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %5
+ThrowNullRef6:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %32
+ThrowNullRef8:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3467,8 +3822,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
@@ -3492,11 +3847,391 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(i16* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store i16* %param0, i16** %arg0
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load i32, i32* %arg3
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %42, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %37, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg2
+  %13 = load i32, i32* %arg3
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %37, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %24 = load i32, i32* %arg2
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load i16*, i16** %arg0
+  %35 = load i32, i32* %arg3
+  %36 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %36, i16* %34, i32 %35)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:37                                      ; preds = %5, %16
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %39)
+  %41 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41, %System.String addrspace(1)* %38, %System.String addrspace(1)* %40)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41) #0
+  unreachable
+
+; <label>:42                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
-Failed to read StringBuilder.ToString[loadElemA]
+Successfully read StringBuilder.ToString
+
+define %System.String addrspace(1)* @StringBuilder.ToString(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i16*
+  %loc3 = alloca %"System.Char[]" addrspace(1)*
+  %loc4 = alloca i32
+  %loc5 = alloca i32
+  %loc6 = alloca i16 addrspace(1)*
+  %loc7 = alloca %System.String addrspace(1)*
+  %loc8 = alloca %"System.Char[]" addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %0)
+  %2 = icmp ne i32 %1, 0
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %4
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %6)
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %7)
+  store %System.String addrspace(1)* %8, %System.String addrspace(1)** %loc0
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.Text.StringBuilder addrspace(1)* %9, %System.Text.StringBuilder addrspace(1)** %loc1
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  store %System.String addrspace(1)* %10, %System.String addrspace(1)** %loc7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc7
+  %12 = ptrtoint %System.String addrspace(1)* %11 to i64
+  %13 = icmp eq i64 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %5
+  %15 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %16 = sext i32 %15 to i64
+  %17 = add i64 %12, %16
+  br label %18
+
+; <label>:18                                      ; preds = %5, %14
+  %19 = phi i64 [ %12, %5 ], [ %17, %14 ]
+  %20 = inttoptr i64 %19 to i16*
+  store i16* %20, i16** %loc2
+  br label %21
+
+; <label>:21                                      ; preds = %98, %18
+  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %22, null
+  br i1 %NullCheck, label %ThrowNullRef, label %23
+
+; <label>:23                                      ; preds = %21
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 3
+  %25 = load i32, i32 addrspace(1)* %24, align 8
+  %26 = icmp sle i32 %25, 0
+  br i1 %26, label %96, label %27
+
+; <label>:27                                      ; preds = %23
+  %28 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %28, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %29
+
+; <label>:29                                      ; preds = %27
+  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %28, i32 0, i32 1
+  %31 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %30, align 8
+  store %"System.Char[]" addrspace(1)* %31, %"System.Char[]" addrspace(1)** %loc3
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %33
+
+; <label>:33                                      ; preds = %29
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  store i32 %35, i32* %loc4
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  %39 = load i32, i32 addrspace(1)* %38, align 8
+  store i32 %39, i32* %loc5
+  %40 = load i32, i32* %loc5
+  %41 = load i32, i32* %loc4
+  %42 = add i32 %40, %41
+  %43 = zext i32 %42 to i64
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %45
+
+; <label>:45                                      ; preds = %37
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = sext i32 %47 to i64
+  %49 = icmp sgt i64 %43, %48
+  br i1 %49, label %91, label %50
+
+; <label>:50                                      ; preds = %45
+  %51 = load i32, i32* %loc5
+  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %52, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %53
+
+; <label>:53                                      ; preds = %50
+  %54 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %52, i32 0, i32 1
+  %55 = load i32, i32 addrspace(1)* %54
+  %56 = zext i32 %55 to i64
+  %57 = trunc i64 %56 to i32
+  %58 = icmp ugt i32 %51, %57
+  br i1 %58, label %91, label %59
+
+; <label>:59                                      ; preds = %53
+  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  store %"System.Char[]" addrspace(1)* %60, %"System.Char[]" addrspace(1)** %loc8
+  %61 = icmp eq %"System.Char[]" addrspace(1)* %60, null
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %63, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %64
+
+; <label>:64                                      ; preds = %62
+  %65 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %63, i32 0, i32 1
+  %66 = load i32, i32 addrspace(1)* %65
+  %67 = zext i32 %66 to i64
+  %68 = trunc i64 %67 to i32
+  %69 = icmp ne i32 %68, 0
+  br i1 %69, label %71, label %70
+
+; <label>:70                                      ; preds = %59, %64
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:71                                      ; preds = %64
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %73
+
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %BoundsCheck = icmp uge i64 0, %76
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %77
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %78, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:79                                      ; preds = %70, %77
+  %80 = load i16*, i16** %loc2
+  %81 = load i32, i32* %loc4
+  %82 = sext i32 %81 to i64
+  %83 = mul i64 %82, 2
+  %84 = bitcast i16* %80 to i8*
+  %85 = getelementptr inbounds i8, i8* %84, i64 %83
+  %86 = load i16 addrspace(1)*, i16 addrspace(1)** %loc6
+  %87 = ptrtoint i16 addrspace(1)* %86 to i64
+  %88 = load i32, i32* %loc5
+  %89 = bitcast i8* %85 to i16*
+  %90 = inttoptr i64 %87 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %89, i16* %90, i32 %88)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %96
+
+; <label>:91                                      ; preds = %45, %53
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %94 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %93)
+  %95 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95, %System.String addrspace(1)* %92, %System.String addrspace(1)* %94)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95) #0
+  unreachable
+
+; <label>:96                                      ; preds = %23, %79
+  %97 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %97, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %98
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %97, i32 0, i32 2
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  store %System.Text.StringBuilder addrspace(1)* %100, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %102 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %102, label %21, label %103
+
+; <label>:103                                     ; preds = %98
+  store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc7
+  %104 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  ret %System.String addrspace(1)* %104
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method StringBuilder::get_Length using LLILCJit
+Successfully read StringBuilder.get_Length
+
+define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
+Successfully read RuntimeHelpers.get_OffsetToStringData
+
+define i32 @RuntimeHelpers.get_OffsetToStringData() {
+entry:
+  ret i32 12
+}
+
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
 Successfully read CultureData.CreateCultureData
 
@@ -3514,23 +4249,23 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
   store i8 %4, i8 addrspace(1)* %6
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
@@ -3549,11 +4284,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3566,50 +4301,50 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
   store i32 -1, i32 addrspace(1)* %2
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
   store i32 -1, i32 addrspace(1)* %8
   %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
   store i32 -1, i32 addrspace(1)* %14
   %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
   store i32 -1, i32 addrspace(1)* %17
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
@@ -3623,27 +4358,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3675,7 +4410,136 @@ Failed to read Dictionary`2.Insert[non-const derefAddress]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
 Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
-Failed to read HashHelpers.GetPrime[loadElem]
+Successfully read HashHelpers.GetPrime
+
+define i32 @HashHelpers.GetPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %6, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5, %System.String addrspace(1)* %4)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5) #0
+  unreachable
+
+; <label>:6                                       ; preds = %entry
+  store i32 0, i32* %loc0
+  br label %29
+
+; <label>:7                                       ; preds = %35
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 1296
+  %10 = addrspacecast i8 addrspace(1)* %9 to %"System.Int32[]" addrspace(1)**
+  %11 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %10
+  %12 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Int32[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = zext i32 %15 to i64
+  %17 = zext i32 %12 to i64
+  %BoundsCheck = icmp uge i64 %17, %16
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 3, i32 %12
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  store i32 %20, i32* %loc1
+  %21 = load i32, i32* %loc1
+  %22 = load i32, i32* %arg0
+  %23 = icmp slt i32 %21, %22
+  br i1 %23, label %26, label %24
+
+; <label>:24                                      ; preds = %18
+  %25 = load i32, i32* %loc1
+  ret i32 %25
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %loc0
+  %28 = add i32 %27, 1
+  store i32 %28, i32* %loc0
+  br label %29
+
+; <label>:29                                      ; preds = %6, %26
+  %30 = load i32, i32* %loc0
+  %31 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %32 = getelementptr inbounds i8, i8 addrspace(1)* %31, i64 1296
+  %33 = addrspacecast i8 addrspace(1)* %32 to %"System.Int32[]" addrspace(1)**
+  %34 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %33
+  %NullCheck = icmp eq %"System.Int32[]" addrspace(1)* %34, null
+  br i1 %NullCheck, label %ThrowNullRef, label %35
+
+; <label>:35                                      ; preds = %29
+  %36 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %34, i32 0, i32 1
+  %37 = load i32, i32 addrspace(1)* %36
+  %38 = zext i32 %37 to i64
+  %39 = trunc i64 %38 to i32
+  %40 = icmp slt i32 %30, %39
+  br i1 %40, label %7, label %41
+
+; <label>:41                                      ; preds = %35
+  %42 = load i32, i32* %arg0
+  %43 = or i32 %42, 1
+  store i32 %43, i32* %loc2
+  br label %59
+
+; <label>:44                                      ; preds = %59
+  %45 = load i32, i32* %loc2
+  %46 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %45)
+  %47 = zext i8 %46 to i32
+  %48 = icmp eq i32 %47, 0
+  br i1 %48, label %56, label %49
+
+; <label>:49                                      ; preds = %44
+  %50 = load i32, i32* %loc2
+  %51 = sub i32 %50, 1
+  %52 = srem i32 %51, 101
+  %53 = icmp eq i32 %52, 0
+  br i1 %53, label %56, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = load i32, i32* %loc2
+  ret i32 %55
+
+; <label>:56                                      ; preds = %44, %49
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %57, 2
+  store i32 %58, i32* %loc2
+  br label %59
+
+; <label>:59                                      ; preds = %41, %56
+  %60 = load i32, i32* %loc2
+  %61 = icmp slt i32 %60, 2147483647
+  br i1 %61, label %44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load i32, i32* %arg0
+  ret i32 %63
+
+ThrowNullRef:                                     ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
 Successfully read GenericEqualityComparer`1.GetHashCode
 
@@ -3694,14 +4558,14 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
   %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load i64, i64 addrspace(1)* %7
@@ -3720,7 +4584,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3750,8 +4614,8 @@ entry:
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
@@ -3796,8 +4660,8 @@ entry:
   %35 = bitcast i16* %34 to i8*
   %36 = getelementptr inbounds i8, i8* %35, i64 2
   %37 = bitcast i8* %36 to i16*
-  %NullCheck4 = icmp ne i16* %37, null
-  br i1 %NullCheck4, label %38, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %37, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %38
 
 ; <label>:38                                      ; preds = %27
   %39 = load i16, i16* %37, align 8
@@ -3824,8 +4688,8 @@ entry:
 
 ; <label>:54                                      ; preds = %22, %43
   %55 = load i16*, i16** %loc4
-  %NullCheck2 = icmp ne i16* %55, null
-  br i1 %NullCheck2, label %56, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i16* %55, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %56
 
 ; <label>:56                                      ; preds = %54
   %57 = load i16, i16* %55, align 8
@@ -3850,11 +4714,11 @@ ThrowNullRef:                                     ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %54
+ThrowNullRef2:                                    ; preds = %54
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %27
+ThrowNullRef4:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3871,8 +4735,8 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -3907,8 +4771,8 @@ entry:
 
 ; <label>:26                                      ; preds = %19
   %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
-  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %28
 
 ; <label>:28                                      ; preds = %26
   %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
@@ -3920,7 +4784,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3972,8 +4836,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
@@ -3984,26 +4848,26 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
-  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
@@ -4014,8 +4878,8 @@ entry:
 ; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
@@ -4024,8 +4888,8 @@ entry:
 
 ; <label>:25                                      ; preds = %1, %16, %23
   %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
-  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
@@ -4036,27 +4900,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %20
+ThrowNullRef10:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4069,8 +4933,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -4081,8 +4945,8 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
@@ -4091,8 +4955,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1, %8
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
@@ -4103,11 +4967,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4128,24 +4992,24 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   store i32 %3, i32* %loc0
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
   %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
   store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck4, label %9, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
@@ -4164,15 +5028,15 @@ entry:
 ; <label>:18                                      ; preds = %70
   %19 = load i16*, i16** %loc3
   %20 = bitcast i16* %19 to i64*
-  %NullCheck10 = icmp ne i64* %20, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %20, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = load i64, i64* %20, align 8
   %23 = load i16*, i16** %loc4
   %24 = bitcast i16* %23 to i64*
-  %NullCheck12 = icmp ne i64* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = load i64, i64* %24, align 8
@@ -4188,8 +5052,8 @@ entry:
   %31 = bitcast i16* %30 to i8*
   %32 = getelementptr inbounds i8, i8* %31, i64 8
   %33 = bitcast i8* %32 to i64*
-  %NullCheck14 = icmp ne i64* %33, null
-  br i1 %NullCheck14, label %34, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = load i64, i64* %33, align 8
@@ -4197,8 +5061,8 @@ entry:
   %37 = bitcast i16* %36 to i8*
   %38 = getelementptr inbounds i8, i8* %37, i64 8
   %39 = bitcast i8* %38 to i64*
-  %NullCheck16 = icmp ne i64* %39, null
-  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %40
 
 ; <label>:40                                      ; preds = %34
   %41 = load i64, i64* %39, align 8
@@ -4214,8 +5078,8 @@ entry:
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %NullCheck18 = icmp ne i64* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = load i64, i64* %48, align 8
@@ -4223,8 +5087,8 @@ entry:
   %52 = bitcast i16* %51 to i8*
   %53 = getelementptr inbounds i8, i8* %52, i64 16
   %54 = bitcast i8* %53 to i64*
-  %NullCheck20 = icmp ne i64* %54, null
-  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64* %54, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %55
 
 ; <label>:55                                      ; preds = %49
   %56 = load i64, i64* %54, align 8
@@ -4262,15 +5126,15 @@ entry:
 ; <label>:74                                      ; preds = %95
   %75 = load i16*, i16** %loc3
   %76 = bitcast i16* %75 to i32*
-  %NullCheck6 = icmp ne i32* %76, null
-  br i1 %NullCheck6, label %77, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32* %76, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %77
 
 ; <label>:77                                      ; preds = %74
   %78 = load i32, i32* %76, align 8
   %79 = load i16*, i16** %loc4
   %80 = bitcast i16* %79 to i32*
-  %NullCheck8 = icmp ne i32* %80, null
-  br i1 %NullCheck8, label %81, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i32* %80, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %81
 
 ; <label>:81                                      ; preds = %77
   %82 = load i32, i32* %80, align 8
@@ -4318,43 +5182,43 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %74
+ThrowNullRef6:                                    ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %77
+ThrowNullRef8:                                    ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %29
+ThrowNullRef14:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %34
+ThrowNullRef16:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4376,8 +5240,8 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load i64, i64 addrspace(1)* %4
@@ -4389,8 +5253,8 @@ entry:
   %12 = load i64, i64* %11
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %5
   %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
@@ -4399,8 +5263,8 @@ entry:
   %18 = load i8, i8* %arg2
   %19 = zext i8 %18 to i32
   %20 = trunc i32 %19 to i8
-  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %15
   %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
@@ -4411,11 +5275,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4442,8 +5306,8 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
@@ -4466,16 +5330,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
   %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = load i64, i64 addrspace(1)* %19
@@ -4500,8 +5364,8 @@ entry:
 ; <label>:35                                      ; preds = %30
   %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
@@ -4514,8 +5378,8 @@ entry:
 
 ; <label>:42                                      ; preds = %1, %38
   %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
-  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
@@ -4526,19 +5390,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %35
+ThrowNullRef2:                                    ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %42
+ThrowNullRef8:                                    ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4551,14 +5415,14 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
@@ -4570,7 +5434,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4583,8 +5447,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
@@ -4613,51 +5477,51 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
   %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
   %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
   %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
   %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
-  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
   store i64 %21, i64 addrspace(1)* %23
   %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %25 = load i64, i64* %loc0
-  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
@@ -4668,27 +5532,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %22
+ThrowNullRef12:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4701,8 +5565,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
@@ -4713,19 +5577,19 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
@@ -4734,8 +5598,8 @@ entry:
 
 ; <label>:15                                      ; preds = %1, %13
   %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
@@ -4746,19 +5610,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %15
+ThrowNullRef8:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4771,8 +5635,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -4831,8 +5695,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
@@ -4882,8 +5746,8 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
-  br i1 %NullCheck, label %17, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %ThrowNullRef, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
@@ -4894,15 +5758,15 @@ entry:
 
 ; <label>:22                                      ; preds = %17
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
-  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
   %26 = load i32, i32 addrspace(1)* %25
   %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
-  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %27, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
@@ -4925,8 +5789,8 @@ entry:
 ; <label>:40                                      ; preds = %17
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
-  br i1 %NullCheck6, label %43, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %41, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
@@ -4938,34 +5802,17 @@ ThrowNullRef:                                     ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %24
+ThrowNullRef4:                                    ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %40
+ThrowNullRef6:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
-}
-
-INFO:  jitting method Object::ReferenceEquals using LLILCJit
-Successfully read Object.ReferenceEquals
-
-define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
-entry:
-  %arg0 = alloca %System.Object addrspace(1)*
-  %arg1 = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
-  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
-  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = icmp eq %System.Object addrspace(1)* %0, %1
-  %3 = sext i1 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
 }
 
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
@@ -4978,21 +5825,21 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
   %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
-  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
@@ -5007,28 +5854,28 @@ entry:
 ; <label>:13                                      ; preds = %8, %12
   %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
   %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
   %21 = load i32, i32 addrspace(1)* %20, align 8
   %22 = add i32 %21, 1
-  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
   store i32 %22, i32 addrspace(1)* %24
   %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
@@ -5039,27 +5886,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5077,7 +5924,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::Setup using LLILCJit
-Failed to read AppDomain.Setup[loadElem]
+Failed to read AppDomain.Setup[unbox]
 INFO:  jitting method Thread::GetDomain using LLILCJit
 Successfully read Thread.GetDomain
 
@@ -5108,8 +5955,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
@@ -5122,14 +5969,14 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
   %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
@@ -5141,11 +5988,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5173,8 +6020,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -5189,7 +6036,328 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
 Failed to read KeyCollection.System.Collections.Generic.IEnumerable<TKey>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Successfully read Enumerator.MoveNext
+
+define i8 @Enumerator.MoveNext(%"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.RuntimeTypeHandle* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*
+  %"$TypeArg" = alloca %System.RuntimeTypeHandle*
+  store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
+  %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 8
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %76, label %12
+
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
+  br label %76
+
+; <label>:13                                      ; preds = %85
+  %14 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck19 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %15
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, i32 0, i32 0
+  %17 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %16, align 8
+  %NullCheck21 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, i32 0, i32 2
+  %20 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %19, align 8
+  %21 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck23 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %22
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, i32 0, i32 2
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %NullCheck25 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 3, i32 %24
+  %NullCheck27 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %32
+
+; <label>:32                                      ; preds = %30
+  %33 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, i32 0, i32 2
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = icmp slt i32 %34, 0
+  br i1 %35, label %68, label %36
+
+; <label>:36                                      ; preds = %32
+  %37 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %38 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck29 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %39
+
+; <label>:39                                      ; preds = %36
+  %40 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, i32 0, i32 0
+  %41 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %40, align 8
+  %NullCheck31 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, i32 0, i32 2
+  %44 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %43, align 8
+  %45 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck33 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, i32 0, i32 2
+  %48 = load i32, i32 addrspace(1)* %47, align 8
+  %NullCheck35 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %49
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = zext i32 %51 to i64
+  %53 = zext i32 %48 to i64
+  %BoundsCheck37 = icmp uge i64 %53, %52
+  br i1 %BoundsCheck37, label %ThrowIndexOutOfRange38, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 3, i32 %48
+  %NullCheck39 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %56
+
+; <label>:56                                      ; preds = %54
+  %57 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, i32 0, i32 0
+  %58 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck41 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %59
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %60, %System.__Canon addrspace(1)* %58)
+  %61 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck43 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  %64 = load i32, i32 addrspace(1)* %63, align 8
+  %65 = add i32 %64, 1
+  %NullCheck45 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  store i32 %65, i32 addrspace(1)* %67
+  ret i8 1
+
+; <label>:68                                      ; preds = %32
+  %69 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck47 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %73 = add i32 %72, 1
+  %NullCheck49 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %74
+
+; <label>:74                                      ; preds = %70
+  %75 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  store i32 %73, i32 addrspace(1)* %75
+  br label %76
+
+; <label>:76                                      ; preds = %8, %12, %74
+  %77 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %78
+
+; <label>:78                                      ; preds = %76
+  %79 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, i32 0, i32 2
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck7 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %82
+
+; <label>:82                                      ; preds = %78
+  %83 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, i32 0, i32 0
+  %84 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %83, align 8
+  %NullCheck9 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %85
+
+; <label>:85                                      ; preds = %82
+  %86 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, i32 0, i32 7
+  %87 = load i32, i32 addrspace(1)* %86, align 8
+  %88 = icmp ult i32 %80, %87
+  br i1 %88, label %13, label %89
+
+; <label>:89                                      ; preds = %85
+  %90 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %91 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck11 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %92
+
+; <label>:92                                      ; preds = %89
+  %93 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, i32 0, i32 0
+  %94 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck13 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %95
+
+; <label>:95                                      ; preds = %92
+  %96 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, i32 0, i32 7
+  %97 = load i32, i32 addrspace(1)* %96, align 8
+  %98 = add i32 %97, 1
+  %NullCheck15 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %99
+
+; <label>:99                                      ; preds = %95
+  %100 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, i32 0, i32 2
+  store i32 %98, i32 addrspace(1)* %100
+  %101 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck17 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %102
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %103, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %92
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef22:                                   ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef24:                                   ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef26:                                   ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef28:                                   ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef30:                                   ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef32:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef34:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef36:                                   ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange38:                           ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef40:                                   ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef42:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef44:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef46:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef48:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef50:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -5200,8 +6368,8 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -5232,9 +6400,9 @@ Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
 Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
-Failed to read String.MakeSeparatorList[loadElemA]
+Failed to read String.MakeSeparatorList[storeElem]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
-Failed to read String.InternalSplitKeepEmptyEntries[loadElem]
+Failed to read String.InternalSplitKeepEmptyEntries[storeElem]
 INFO:  jitting method Path::IsRelative using LLILCJit
 Successfully read Path.IsRelative
 
@@ -5243,8 +6411,8 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -5254,8 +6422,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
@@ -5271,8 +6439,8 @@ entry:
 
 ; <label>:17                                      ; preds = %7
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
@@ -5288,8 +6456,8 @@ entry:
 
 ; <label>:29                                      ; preds = %19
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %31
 
 ; <label>:31                                      ; preds = %29
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
@@ -5300,8 +6468,8 @@ entry:
 
 ; <label>:36                                      ; preds = %31
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
-  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %37, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
@@ -5312,8 +6480,8 @@ entry:
 
 ; <label>:43                                      ; preds = %31, %38
   %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
-  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %45
 
 ; <label>:45                                      ; preds = %43
   %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
@@ -5324,8 +6492,8 @@ entry:
 
 ; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %50
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
@@ -5336,8 +6504,8 @@ entry:
 
 ; <label>:57                                      ; preds = %1, %7, %19, %45, %52
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
-  br i1 %NullCheck14, label %59, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %59
 
 ; <label>:59                                      ; preds = %57
   %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
@@ -5347,8 +6515,8 @@ entry:
 
 ; <label>:63                                      ; preds = %59
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
@@ -5359,8 +6527,8 @@ entry:
 
 ; <label>:70                                      ; preds = %65
   %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
-  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.String addrspace(1)* %71, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %72
 
 ; <label>:72                                      ; preds = %70
   %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
@@ -5379,39 +6547,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %17
+ThrowNullRef4:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %29
+ThrowNullRef6:                                    ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %36
+ThrowNullRef8:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %43
+ThrowNullRef10:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %50
+ThrowNullRef12:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %57
+ThrowNullRef14:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %63
+ThrowNullRef16:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %70
+ThrowNullRef18:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5419,7 +6587,293 @@ ThrowNullRef17:                                   ; preds = %70
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
-Failed to read String.TrimHelper[loadElem]
+Successfully read String.TrimHelper
+
+define %System.String addrspace(1)* @String.TrimHelper(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i16
+  %loc4 = alloca i32
+  %loc5 = alloca i16
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = sub i32 %3, 1
+  store i32 %4, i32* %loc0
+  store i32 0, i32* %loc1
+  %5 = load i32, i32* %arg2
+  %6 = icmp eq i32 %5, 1
+  br i1 %6, label %62, label %7
+
+; <label>:7                                       ; preds = %1
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:8                                       ; preds = %58
+  store i32 0, i32* %loc2
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load i32, i32* %loc1
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2, i32 %10
+  %13 = load i16, i16 addrspace(1)* %12
+  %14 = zext i16 %13 to i32
+  %15 = trunc i32 %14 to i16
+  store i16 %15, i16* %loc3
+  store i32 0, i32* %loc2
+  br label %34
+
+; <label>:16                                      ; preds = %37
+  %17 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %18 = load i32, i32* %loc2
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %17, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %19
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = zext i32 %18 to i64
+  %BoundsCheck = icmp uge i64 %23, %22
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %24
+
+; <label>:24                                      ; preds = %19
+  %25 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 3, i32 %18
+  %26 = load i16, i16 addrspace(1)* %25, align 8
+  %27 = zext i16 %26 to i32
+  %28 = load i16, i16* %loc3
+  %29 = zext i16 %28 to i32
+  %30 = icmp eq i32 %27, %29
+  br i1 %30, label %43, label %31
+
+; <label>:31                                      ; preds = %24
+  %32 = load i32, i32* %loc2
+  %33 = add i32 %32, 1
+  store i32 %33, i32* %loc2
+  br label %34
+
+; <label>:34                                      ; preds = %11, %31
+  %35 = load i32, i32* %loc2
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = icmp slt i32 %35, %41
+  br i1 %42, label %16, label %43
+
+; <label>:43                                      ; preds = %24, %37
+  %44 = load i32, i32* %loc2
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %45, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp eq i32 %44, %50
+  br i1 %51, label %62, label %52
+
+; <label>:52                                      ; preds = %46
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %7, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %57, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %58
+
+; <label>:58                                      ; preds = %55
+  %59 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %60 = load i32, i32 addrspace(1)* %59
+  %61 = icmp slt i32 %56, %60
+  br i1 %61, label %8, label %62
+
+; <label>:62                                      ; preds = %1, %46, %58
+  %63 = load i32, i32* %arg2
+  %64 = icmp eq i32 %63, 0
+  br i1 %64, label %122, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %66, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %67
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %66, i32 0, i32 1
+  %69 = load i32, i32 addrspace(1)* %68
+  %70 = sub i32 %69, 1
+  store i32 %70, i32* %loc0
+  br label %118
+
+; <label>:71                                      ; preds = %118
+  store i32 0, i32* %loc4
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %73 = load i32, i32* %loc0
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %74
+
+; <label>:74                                      ; preds = %71
+  %75 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 2, i32 %73
+  %76 = load i16, i16 addrspace(1)* %75
+  %77 = zext i16 %76 to i32
+  %78 = trunc i32 %77 to i16
+  store i16 %78, i16* %loc5
+  store i32 0, i32* %loc4
+  br label %97
+
+; <label>:79                                      ; preds = %100
+  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %81 = load i32, i32* %loc4
+  %NullCheck19 = icmp eq %"System.Char[]" addrspace(1)* %80, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
+
+; <label>:82                                      ; preds = %79
+  %83 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 1
+  %84 = load i32, i32 addrspace(1)* %83
+  %85 = zext i32 %84 to i64
+  %86 = zext i32 %81 to i64
+  %BoundsCheck21 = icmp uge i64 %86, %85
+  br i1 %BoundsCheck21, label %ThrowIndexOutOfRange22, label %87
+
+; <label>:87                                      ; preds = %82
+  %88 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 3, i32 %81
+  %89 = load i16, i16 addrspace(1)* %88, align 8
+  %90 = zext i16 %89 to i32
+  %91 = load i16, i16* %loc5
+  %92 = zext i16 %91 to i32
+  %93 = icmp eq i32 %90, %92
+  br i1 %93, label %106, label %94
+
+; <label>:94                                      ; preds = %87
+  %95 = load i32, i32* %loc4
+  %96 = add i32 %95, 1
+  store i32 %96, i32* %loc4
+  br label %97
+
+; <label>:97                                      ; preds = %74, %94
+  %98 = load i32, i32* %loc4
+  %99 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck15 = icmp eq %"System.Char[]" addrspace(1)* %99, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %100
+
+; <label>:100                                     ; preds = %97
+  %101 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %99, i32 0, i32 1
+  %102 = load i32, i32 addrspace(1)* %101
+  %103 = zext i32 %102 to i64
+  %104 = trunc i64 %103 to i32
+  %105 = icmp slt i32 %98, %104
+  br i1 %105, label %79, label %106
+
+; <label>:106                                     ; preds = %87, %100
+  %107 = load i32, i32* %loc4
+  %108 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck17 = icmp eq %"System.Char[]" addrspace(1)* %108, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %109
+
+; <label>:109                                     ; preds = %106
+  %110 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %108, i32 0, i32 1
+  %111 = load i32, i32 addrspace(1)* %110
+  %112 = zext i32 %111 to i64
+  %113 = trunc i64 %112 to i32
+  %114 = icmp eq i32 %107, %113
+  br i1 %114, label %122, label %115
+
+; <label>:115                                     ; preds = %109
+  %116 = load i32, i32* %loc0
+  %117 = sub i32 %116, 1
+  store i32 %117, i32* %loc0
+  br label %118
+
+; <label>:118                                     ; preds = %67, %115
+  %119 = load i32, i32* %loc0
+  %120 = load i32, i32* %loc1
+  %121 = icmp sge i32 %119, %120
+  br i1 %121, label %71, label %122
+
+; <label>:122                                     ; preds = %62, %109, %118
+  %123 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %124 = load i32, i32* %loc1
+  %125 = load i32, i32* %loc0
+  %126 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %123, i32 %124, i32 %125)
+  ret %System.String addrspace(1)* %126
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %97
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange22:                           ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
 Successfully read String.CreateTrimmedString
 
@@ -5439,8 +6893,8 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
@@ -5535,8 +6989,8 @@ entry:
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i64 2872
   %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
   %8 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %7
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %3
   %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
@@ -5553,8 +7007,8 @@ entry:
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 2864
   %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
   %21 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %20
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
-  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %22
 
 ; <label>:22                                      ; preds = %16
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
@@ -5569,7 +7023,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %16
+ThrowNullRef2:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5586,8 +7040,8 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5613,8 +7067,8 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
@@ -5632,8 +7086,8 @@ entry:
 
 ; <label>:12                                      ; preds = %4
   %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
@@ -5644,8 +7098,8 @@ entry:
 
 ; <label>:19                                      ; preds = %14
   %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %19
   %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
@@ -5660,21 +7114,21 @@ entry:
   %31 = zext i16 %30 to i32
   %32 = bitcast i8* %29 to i16*
   %33 = trunc i32 %31 to i16
-  %NullCheck6 = icmp ne i16* %32, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i16* %32, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %21
   store i16 %33, i16* %32, align 8
   %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %36
 
 ; <label>:36                                      ; preds = %34
   %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
   %38 = load i32, i32 addrspace(1)* %37, align 8
   %39 = add i32 %38, 1
-  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %40
 
 ; <label>:40                                      ; preds = %36
   %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
@@ -5683,16 +7137,16 @@ entry:
 
 ; <label>:42                                      ; preds = %14
   %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
-  br i1 %NullCheck12, label %44, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
   %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
   %47 = load i16, i16* %arg1
   %48 = zext i16 %47 to i32
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = trunc i32 %48 to i16
@@ -5703,31 +7157,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %19
+ThrowNullRef4:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %21
+ThrowNullRef6:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %36
+ThrowNullRef10:                                   ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %42
+ThrowNullRef12:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %44
+ThrowNullRef14:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5740,8 +7194,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -5752,8 +7206,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
@@ -5762,14 +7216,14 @@ entry:
 
 ; <label>:11                                      ; preds = %1
   %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
@@ -5779,15 +7233,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5808,8 +7262,8 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5822,8 +7276,8 @@ entry:
 
 ; <label>:8                                       ; preds = %3
   %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
@@ -5842,15 +7296,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
-  br i1 %NullCheck4, label %22, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
   %24 = load i16*, i16* addrspace(1)* %23, align 8
   %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %25, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
@@ -5859,8 +7313,8 @@ entry:
   store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
@@ -5874,8 +7328,8 @@ entry:
 
 ; <label>:37                                      ; preds = %65
   %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %37
   %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
@@ -5886,16 +7340,16 @@ entry:
   %45 = bitcast i16* %41 to i8*
   %46 = getelementptr inbounds i8, i8* %45, i64 %44
   %47 = bitcast i8* %46 to i16*
-  %NullCheck14 = icmp ne i16* %47, null
-  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %47, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %48
 
 ; <label>:48                                      ; preds = %39
   %49 = load i16, i16* %47, align 8
   %50 = zext i16 %49 to i32
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %52 = load i32, i32* %loc1
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %53
 
 ; <label>:53                                      ; preds = %48
   %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
@@ -5916,8 +7370,8 @@ entry:
 ; <label>:62                                      ; preds = %36, %59
   %63 = load i32, i32* %loc1
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck10, label %65, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %65
 
 ; <label>:65                                      ; preds = %62
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
@@ -5936,15 +7390,15 @@ entry:
 
 ; <label>:74                                      ; preds = %70
   %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
-  br i1 %NullCheck18, label %76, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %76
 
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
   %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
-  br i1 %NullCheck20, label %80, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
   %81 = load i64, i64 addrspace(1)* %79
@@ -5958,8 +7412,8 @@ entry:
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
   %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
-  br i1 %NullCheck22, label %92, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.String addrspace(1)* %90, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %92
 
 ; <label>:92                                      ; preds = %80
   %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
@@ -5969,15 +7423,15 @@ entry:
 
 ; <label>:96                                      ; preds = %70
   %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
-  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %98
 
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
   %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
-  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
   %103 = load i64, i64 addrspace(1)* %101
@@ -5991,8 +7445,8 @@ entry:
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
   %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
-  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.String addrspace(1)* %112, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %114
 
 ; <label>:114                                     ; preds = %102
   %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
@@ -6004,59 +7458,59 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %20
+ThrowNullRef4:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %22
+ThrowNullRef6:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %26
+ThrowNullRef8:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %62
+ThrowNullRef10:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %48
+ThrowNullRef16:                                   ; preds = %48
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %74
+ThrowNullRef18:                                   ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %76
+ThrowNullRef20:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %80
+ThrowNullRef22:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %96
+ThrowNullRef24:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %98
+ThrowNullRef26:                                   ; preds = %98
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %102
+ThrowNullRef28:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6069,15 +7523,15 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
   %3 = load i16*, i16* addrspace(1)* %2, align 8
   %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
@@ -6087,8 +7541,8 @@ entry:
   %10 = bitcast i16* %3 to i8*
   %11 = getelementptr inbounds i8, i8* %10, i64 %9
   %12 = bitcast i8* %11 to i16*
-  %NullCheck4 = icmp ne i16* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %5
   store i16 0, i16* %12, align 8
@@ -6098,11 +7552,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6119,8 +7573,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -6131,8 +7585,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
@@ -6144,15 +7598,15 @@ entry:
 
 ; <label>:14                                      ; preds = %1
   %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
   %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
   %21 = load i64, i64 addrspace(1)* %19
@@ -6171,15 +7625,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %14
+ThrowNullRef4:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %16
+ThrowNullRef6:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6302,14 +7756,6 @@ entry:
   ret %System.String addrspace(1)* %57
 }
 
-INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
-Successfully read RuntimeHelpers.get_OffsetToStringData
-
-define i32 @RuntimeHelpers.get_OffsetToStringData() {
-entry:
-  ret i32 12
-}
-
 INFO:  jitting method String::Equals using LLILCJit
 Successfully read String.Equals
 
@@ -6381,8 +7827,8 @@ entry:
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
-  br i1 %NullCheck24, label %29, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
   %30 = load i64, i64 addrspace(1)* %28
@@ -6397,8 +7843,8 @@ entry:
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
-  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
   %43 = load i64, i64 addrspace(1)* %41
@@ -6418,8 +7864,8 @@ entry:
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
   %59 = load i64, i64 addrspace(1)* %57
@@ -6434,8 +7880,8 @@ entry:
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck22, label %71, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
   %72 = load i64, i64 addrspace(1)* %70
@@ -6455,8 +7901,8 @@ entry:
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
-  br i1 %NullCheck16, label %87, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = load i64, i64 addrspace(1)* %86
@@ -6471,8 +7917,8 @@ entry:
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck18, label %100, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
   %101 = load i64, i64 addrspace(1)* %99
@@ -6492,8 +7938,8 @@ entry:
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
-  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
   %117 = load i64, i64 addrspace(1)* %115
@@ -6508,8 +7954,8 @@ entry:
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
-  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
   %130 = load i64, i64 addrspace(1)* %128
@@ -6528,15 +7974,15 @@ entry:
 
 ; <label>:142                                     ; preds = %22
   %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
-  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %143, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %144
 
 ; <label>:144                                     ; preds = %142
   %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
   %146 = load i32, i32 addrspace(1)* %145
   %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
-  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %147, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %148
 
 ; <label>:148                                     ; preds = %144
   %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
@@ -6557,15 +8003,15 @@ entry:
 
 ; <label>:159                                     ; preds = %22
   %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
-  br i1 %NullCheck, label %161, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %ThrowNullRef, label %161
 
 ; <label>:161                                     ; preds = %159
   %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
   %163 = load i32, i32 addrspace(1)* %162
   %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
-  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %164, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %165
 
 ; <label>:165                                     ; preds = %161
   %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
@@ -6578,8 +8024,8 @@ entry:
 
 ; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
-  br i1 %NullCheck4, label %172, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %171, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %172
 
 ; <label>:172                                     ; preds = %170
   %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
@@ -6589,8 +8035,8 @@ entry:
 
 ; <label>:176                                     ; preds = %172
   %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
-  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %177, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %178
 
 ; <label>:178                                     ; preds = %176
   %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
@@ -6629,55 +8075,55 @@ ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %161
+ThrowNullRef2:                                    ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %170
+ThrowNullRef4:                                    ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %176
+ThrowNullRef6:                                    ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %142
+ThrowNullRef8:                                    ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %144
+ThrowNullRef10:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %113
+ThrowNullRef12:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %116
+ThrowNullRef14:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %84
+ThrowNullRef16:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %87
+ThrowNullRef18:                                   ; preds = %87
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %55
+ThrowNullRef20:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %58
+ThrowNullRef22:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %26
+ThrowNullRef24:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %29
+ThrowNullRef26:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,8 +8161,8 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck, label %14, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %ThrowNullRef, label %14
 
 ; <label>:14                                      ; preds = %8
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
@@ -6760,8 +8206,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
@@ -6770,14 +8216,14 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32, i32* %loc0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %10
   %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
   %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
@@ -6790,15 +8236,15 @@ entry:
 ; <label>:25                                      ; preds = %19
   %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
-  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
   %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
@@ -6807,8 +8253,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %37 = load i32, i32* %loc0
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %38, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %38
 
 ; <label>:38                                      ; preds = %32
   %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
@@ -6817,14 +8263,14 @@ entry:
 
 ; <label>:40                                      ; preds = %19
   %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %40
   %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
   %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
-  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
-  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
@@ -6832,8 +8278,8 @@ entry:
   %48 = zext i32 %47 to i64
   %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
-  br i1 %NullCheck16, label %51, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %51
 
 ; <label>:51                                      ; preds = %45
   %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
@@ -6847,15 +8293,15 @@ entry:
 ; <label>:57                                      ; preds = %51
   %58 = load i16*, i16** %arg1
   %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
-  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %60
 
 ; <label>:60                                      ; preds = %57
   %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
   %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
-  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %64
 
 ; <label>:64                                      ; preds = %60
   %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
@@ -6864,22 +8310,22 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
   %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
-  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %70
 
 ; <label>:70                                      ; preds = %64
   %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
   %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
-  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
-  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
   %75 = load i32, i32 addrspace(1)* %74
   %76 = zext i32 %75 to i64
   %77 = trunc i64 %76 to i32
-  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
-  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %78
 
 ; <label>:78                                      ; preds = %73
   %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
@@ -6901,8 +8347,8 @@ entry:
   %90 = bitcast i16* %86 to i8*
   %91 = getelementptr inbounds i8, i8* %90, i64 %89
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %93
 
 ; <label>:93                                      ; preds = %80
   %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
@@ -6912,8 +8358,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %99 = load i32, i32* %loc2
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %100
 
 ; <label>:100                                     ; preds = %93
   %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
@@ -6928,63 +8374,63 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %25
+ThrowNullRef6:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %32
+ThrowNullRef10:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %40
+ThrowNullRef12:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %45
+ThrowNullRef16:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %57
+ThrowNullRef18:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %60
+ThrowNullRef20:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %64
+ThrowNullRef22:                                   ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %70
+ThrowNullRef24:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %73
+ThrowNullRef26:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %80
+ThrowNullRef28:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %93
+ThrowNullRef30:                                   ; preds = %93
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7004,8 +8450,8 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
@@ -7033,43 +8479,43 @@ entry:
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %14
   %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
   %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   %28 = load i32, i32 addrspace(1)* %27, align 8
   %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
-  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %30
 
 ; <label>:30                                      ; preds = %26
   %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
   %32 = load i32, i32 addrspace(1)* %31, align 8
   %33 = add i32 %28, %32
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %34
 
 ; <label>:34                                      ; preds = %30
   %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   store i32 %33, i32 addrspace(1)* %35
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
   store i32 0, i32 addrspace(1)* %38
   %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %40
 
 ; <label>:40                                      ; preds = %37
   %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
@@ -7082,8 +8528,8 @@ entry:
 
 ; <label>:47                                      ; preds = %40
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
@@ -7098,8 +8544,8 @@ entry:
   %54 = load i32, i32* %loc0
   %55 = sext i32 %54 to i64
   %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
-  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %57
 
 ; <label>:57                                      ; preds = %52
   %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
@@ -7110,68 +8556,35 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %14
+ThrowNullRef2:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %23
+ThrowNullRef4:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %26
+ThrowNullRef6:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %30
+ThrowNullRef8:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %34
+ThrowNullRef10:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %47
+ThrowNullRef14:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %52
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-}
-
-INFO:  jitting method StringBuilder::get_Length using LLILCJit
-Successfully read StringBuilder.get_Length
-
-define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.StringBuilder addrspace(1)*
-  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
-  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
-
-; <label>:1                                       ; preds = %entry
-  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %3 = load i32, i32 addrspace(1)* %2, align 8
-  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
-
-; <label>:5                                       ; preds = %1
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = add i32 %3, %7
-  ret i32 %8
-
-ThrowNullRef:                                     ; preds = %entry
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef16:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7213,70 +8626,70 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
   %6 = load i32, i32 addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
   store i32 %6, i32 addrspace(1)* %8
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
   %13 = load i32, i32 addrspace(1)* %12, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
   store i32 %13, i32 addrspace(1)* %15
   %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
-  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %18
 
 ; <label>:18                                      ; preds = %14
   %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
   %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
   %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
   %34 = load i32, i32 addrspace(1)* %33, align 8
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
-  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
@@ -7287,39 +8700,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %28
+ThrowNullRef16:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %32
+ThrowNullRef18:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7455,13 +8868,13 @@ entry:
 ; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
@@ -7477,16 +8890,16 @@ entry:
 
 ; <label>:18                                      ; preds = %15
   %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
   store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
   %22 = load i32, i32* %loc0
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %24
 
 ; <label>:24                                      ; preds = %20
   %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
@@ -7498,13 +8911,13 @@ entry:
 ; <label>:28                                      ; preds = %15, %24
   %29 = load i32, i32* %arg1
   %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %31
   %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
@@ -7517,20 +8930,20 @@ entry:
   %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
-  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
   %46 = load i32, i32 addrspace(1)* %45, align 8
   %47 = sub i32 %40, %46
-  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
-  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i32 addrspace(1)* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %48
 
 ; <label>:48                                      ; preds = %44
   store i32 %47, i32 addrspace(1)* %39, align 8
@@ -7538,21 +8951,21 @@ entry:
 
 ; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
-  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %51
 
 ; <label>:51                                      ; preds = %49
   %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %53
 
 ; <label>:53                                      ; preds = %51
   %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
   %55 = load i32, i32 addrspace(1)* %54, align 8
   %56 = load i32, i32* %arg2
   %57 = sub i32 %55, %56
-  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %58
 
 ; <label>:58                                      ; preds = %53
   %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
@@ -7562,13 +8975,13 @@ entry:
 ; <label>:60                                      ; preds = %33, %58
   %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
   %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
-  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %63
 
 ; <label>:63                                      ; preds = %60
   %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
-  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
-  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
@@ -7578,15 +8991,15 @@ entry:
 
 ; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
-  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i32 addrspace(1)* %69, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %70
 
 ; <label>:70                                      ; preds = %68
   %71 = load i32, i32 addrspace(1)* %69, align 8
   store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
-  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
@@ -7596,8 +9009,8 @@ entry:
   store i32 %77, i32* %loc4
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
-  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %80
 
 ; <label>:80                                      ; preds = %73
   %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
@@ -7607,71 +9020,71 @@ entry:
 ; <label>:83                                      ; preds = %80
   store i32 0, i32* %loc3
   %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
-  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
-  br i1 %NullCheck26, label %88, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i32 addrspace(1)* %87, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %88
 
 ; <label>:88                                      ; preds = %85
   %89 = load i32, i32 addrspace(1)* %87, align 8
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
-  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %90
 
 ; <label>:90                                      ; preds = %88
   %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
   store i32 %89, i32 addrspace(1)* %91
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
-  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
-  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %96
 
 ; <label>:96                                      ; preds = %94
   %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
-  br i1 %NullCheck34, label %100, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %100
 
 ; <label>:100                                     ; preds = %96
   %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
-  br i1 %NullCheck36, label %102, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %102
 
 ; <label>:102                                     ; preds = %100
   %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
   %104 = load i32, i32 addrspace(1)* %103, align 8
   %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
-  br i1 %NullCheck38, label %106, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %106
 
 ; <label>:106                                     ; preds = %102
   %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
-  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
-  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %108
 
 ; <label>:108                                     ; preds = %106
   %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
   %110 = load i32, i32 addrspace(1)* %109, align 8
   %111 = add i32 %104, %110
-  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %112
 
 ; <label>:112                                     ; preds = %108
   %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
   store i32 %111, i32 addrspace(1)* %113
   %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
-  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i32 addrspace(1)* %114, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %115
 
 ; <label>:115                                     ; preds = %112
   %116 = load i32, i32 addrspace(1)* %114, align 8
@@ -7681,19 +9094,19 @@ entry:
 ; <label>:118                                     ; preds = %115
   %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
-  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %121
 
 ; <label>:121                                     ; preds = %118
   %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
-  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
-  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %123
 
 ; <label>:123                                     ; preds = %121
   %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
   %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
-  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
-  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %126
 
 ; <label>:126                                     ; preds = %123
   %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
@@ -7705,8 +9118,8 @@ entry:
 
 ; <label>:130                                     ; preds = %80, %115, %126
   %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %132
 
 ; <label>:132                                     ; preds = %130
   %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7715,8 +9128,8 @@ entry:
   %136 = load i32, i32* %loc3
   %137 = sub i32 %135, %136
   %138 = sub i32 %134, %137
-  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %139
 
 ; <label>:139                                     ; preds = %132
   %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7728,16 +9141,16 @@ entry:
 
 ; <label>:144                                     ; preds = %139
   %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
-  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %146
 
 ; <label>:146                                     ; preds = %144
   %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
   %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
   %149 = load i32, i32* %loc2
   %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
-  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %151
 
 ; <label>:151                                     ; preds = %146
   %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
@@ -7754,145 +9167,249 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %18
+ThrowNullRef4:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %31
+ThrowNullRef10:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %44
+ThrowNullRef16:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %68
+ThrowNullRef18:                                   ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %70
+ThrowNullRef20:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %73
+ThrowNullRef22:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %83
+ThrowNullRef24:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %85
+ThrowNullRef26:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %88
+ThrowNullRef28:                                   ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %90
+ThrowNullRef30:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %94
+ThrowNullRef32:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %96
+ThrowNullRef34:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %100
+ThrowNullRef36:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %102
+ThrowNullRef38:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %106
+ThrowNullRef40:                                   ; preds = %106
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %108
+ThrowNullRef42:                                   ; preds = %108
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %112
+ThrowNullRef44:                                   ; preds = %112
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %118
+ThrowNullRef46:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %121
+ThrowNullRef48:                                   ; preds = %121
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %123
+ThrowNullRef50:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %130
+ThrowNullRef52:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %132
+ThrowNullRef54:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %144
+ThrowNullRef56:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %146
+ThrowNullRef58:                                   ; preds = %146
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %60
+ThrowNullRef60:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %63
+ThrowNullRef62:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %49
+ThrowNullRef64:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %51
+ThrowNullRef66:                                   ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %53
+ThrowNullRef68:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(%"System.Char[]" addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %arg0 = alloca %"System.Char[]" addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store %"System.Char[]" addrspace(1)* %param0, %"System.Char[]" addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load i32, i32* %arg4
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %43, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %38, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg1
+  %13 = load i32, i32* %arg4
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %38, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %24 = load i32, i32* %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %35 = load i32, i32* %arg3
+  %36 = load i32, i32* %arg4
+  %37 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %37, %"System.Char[]" addrspace(1)* %34, i32 %35, i32 %36)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:38                                      ; preds = %5, %16
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Successfully read Buffer._Memmove
 
@@ -7914,7 +9431,7 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[loadElem]
+Failed to read AppDomain.SetDataHelper[storeElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -7923,8 +9440,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
@@ -7934,8 +9451,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
@@ -7947,15 +9464,15 @@ entry:
   %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
   %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
@@ -7966,15 +9483,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7992,7 +9509,79 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
-Failed to read Dictionary`2.TryGetValue[loadElemA]
+Successfully read Dictionary`2.TryGetValue
+
+define i8 @"Dictionary`2.TryGetValue"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)* addrspace(1)* %param2) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  %arg2 = alloca %System.__Canon addrspace(1)* addrspace(1)*
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  store %System.__Canon addrspace(1)* addrspace(1)* %param2, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  store i32 %2, i32* %loc0
+  %3 = load i32, i32* %loc0
+  %4 = icmp slt i32 %3, 0
+  br i1 %4, label %22, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 2
+  %10 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %9, align 8
+  %11 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = zext i32 %11 to i64
+  %BoundsCheck = icmp uge i64 %16, %15
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 3, i32 %11
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %20, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %6, %System.__Canon addrspace(1)* %21)
+  ret i8 1
+
+; <label>:22                                      ; preds = %entry
+  %23 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %23, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -8058,8 +9647,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
@@ -8091,8 +9680,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
@@ -8171,15 +9760,15 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck, label %19, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %ThrowNullRef, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
   %21 = load i32, i32 addrspace(1)* %20
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
@@ -8202,7 +9791,7 @@ ThrowNullRef:                                     ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %19
+ThrowNullRef2:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8248,8 +9837,8 @@ entry:
   %0 = alloca %System.AppDomainHandle
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %1 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %1, i32 0, i32 15
@@ -8269,8 +9858,8 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
@@ -8286,7 +9875,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -8299,8 +9888,8 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -8327,8 +9916,8 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
@@ -8352,8 +9941,8 @@ entry:
   %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
   store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
@@ -8363,8 +9952,8 @@ entry:
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
@@ -8374,8 +9963,8 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %9
   %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
@@ -8384,8 +9973,8 @@ entry:
 
 ; <label>:18                                      ; preds = %3, %16
   %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
@@ -8397,15 +9986,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %18
+ThrowNullRef6:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8418,8 +10007,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
@@ -8453,15 +10042,15 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
@@ -8473,7 +10062,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8481,7 +10070,7 @@ ThrowNullRef1:                                    ; preds = %1
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
 Failed to read Dictionary`2.System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
@@ -8506,8 +10095,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
@@ -8524,8 +10113,8 @@ entry:
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -8544,7 +10133,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8577,8 +10166,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = load i64, i64* %arg2
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = trunc i32 %3 to i8
@@ -8634,46 +10223,46 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
   %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
-  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
-  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
-  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
@@ -8684,27 +10273,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %20
+ThrowNullRef12:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8717,8 +10306,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -8756,22 +10345,22 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
   %9 = load i64, i64 addrspace(1)* %8, align 8
   %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
   %13 = load i64, i64 addrspace(1)* %12, align 8
   %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %11
   %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
@@ -8788,11 +10377,11 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8882,8 +10471,8 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
@@ -8900,8 +10489,8 @@ entry:
 ; <label>:8                                       ; preds = %1
   %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
   %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
@@ -8911,15 +10500,15 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
   %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
   %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
-  br i1 %NullCheck6, label %21, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
@@ -8946,15 +10535,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8992,15 +10581,15 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
   store i8 %3, i8 addrspace(1)* %5
   %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
@@ -9011,7 +10600,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9027,8 +10616,8 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -9041,8 +10630,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
@@ -9058,7 +10647,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9080,8 +10669,8 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
@@ -9096,8 +10685,8 @@ entry:
 ; <label>:12                                      ; preds = %6
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
@@ -9112,8 +10701,8 @@ entry:
 ; <label>:21                                      ; preds = %15
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
@@ -9128,8 +10717,8 @@ entry:
 ; <label>:30                                      ; preds = %24
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %31, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
@@ -9144,8 +10733,8 @@ entry:
 ; <label>:39                                      ; preds = %33
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
-  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %40, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %42
 
 ; <label>:42                                      ; preds = %39
   %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
@@ -9164,19 +10753,19 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %21
+ThrowNullRef4:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %30
+ThrowNullRef6:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %39
+ThrowNullRef8:                                    ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9243,8 +10832,8 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
@@ -9264,57 +10853,57 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
   store i8 0, i8 addrspace(1)* %2
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
   store i8 0, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
   store i8 0, i8 addrspace(1)* %17
   %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
   store i8 0, i8 addrspace(1)* %20
   %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
-  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
@@ -9325,31 +10914,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %19
+ThrowNullRef14:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9367,8 +10956,8 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
@@ -9380,8 +10969,8 @@ entry:
 
 ; <label>:9                                       ; preds = %4
   %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %9
   %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
@@ -9395,7 +10984,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef2:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9420,8 +11009,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
@@ -9512,8 +11101,8 @@ entry:
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
@@ -9524,8 +11113,8 @@ entry:
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = load i64, i64 addrspace(1)* %12
@@ -9537,8 +11126,8 @@ entry:
   %20 = load i64, i64* %19
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
-  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %13
   %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
@@ -9555,8 +11144,8 @@ entry:
 ; <label>:30                                      ; preds = %25
   %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %32 = load i32, i32* %arg2
-  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
-  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
@@ -9570,15 +11159,15 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %30
+ThrowNullRef2:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9622,87 +11211,87 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
   %10 = load i8, i8 addrspace(1)* %9, align 8
   %11 = zext i8 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %8
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
   store i8 %12, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
   %19 = load i8, i8 addrspace(1)* %18, align 8
   %20 = zext i8 %19 to i32
   %21 = trunc i32 %20 to i8
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
   store i8 %21, i8 addrspace(1)* %23
   %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
   %28 = load i8, i8 addrspace(1)* %27, align 8
   %29 = zext i8 %28 to i32
   %30 = trunc i32 %29 to i8
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
-  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %31
 
 ; <label>:31                                      ; preds = %26
   %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
   store i8 %30, i8 addrspace(1)* %32
   %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
-  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
-  br i1 %NullCheck14, label %40, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %40
 
 ; <label>:40                                      ; preds = %35
   %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
   store i8 %39, i8 addrspace(1)* %41
   %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
-  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %44
 
 ; <label>:44                                      ; preds = %40
   %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
   %46 = load i8, i8 addrspace(1)* %45, align 8
   %47 = zext i8 %46 to i32
   %48 = trunc i32 %47 to i8
-  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
   store i8 %48, i8 addrspace(1)* %50
   %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
-  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
@@ -9713,29 +11302,29 @@ entry:
 ; <label>:56                                      ; preds = %52
   %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
-  br i1 %NullCheck22, label %59, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
   %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
   %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
-  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
-  br i1 %NullCheck24, label %63, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
   %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
-  br i1 %NullCheck26, label %66, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
   %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
-  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
-  br i1 %NullCheck28, label %69, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %69
 
 ; <label>:69                                      ; preds = %66
   %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
@@ -9744,15 +11333,15 @@ entry:
 
 ; <label>:71                                      ; preds = %105
   %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
-  br i1 %NullCheck34, label %73, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %73
 
 ; <label>:73                                      ; preds = %71
   %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
   %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
   %76 = load i32, i32* %loc0
-  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
-  br i1 %NullCheck36, label %77, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
@@ -9766,8 +11355,8 @@ entry:
 
 ; <label>:83                                      ; preds = %77
   %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
-  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
@@ -9775,14 +11364,14 @@ entry:
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
   %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
-  br i1 %NullCheck40, label %91, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
 ; <label>:91                                      ; preds = %85
   %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
   %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
-  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck42, label %94, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %94
 
 ; <label>:94                                      ; preds = %91
   %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
@@ -9798,14 +11387,14 @@ entry:
 ; <label>:99                                      ; preds = %69, %96
   %100 = load i32, i32* %loc0
   %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
-  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %102
 
 ; <label>:102                                     ; preds = %99
   %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
   %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
-  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
-  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
@@ -9819,87 +11408,87 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %26
+ThrowNullRef10:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %31
+ThrowNullRef12:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %35
+ThrowNullRef14:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %40
+ThrowNullRef16:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %56
+ThrowNullRef22:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %59
+ThrowNullRef24:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %63
+ThrowNullRef26:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %66
+ThrowNullRef28:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %102
+ThrowNullRef32:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %71
+ThrowNullRef34:                                   ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %73
+ThrowNullRef36:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %83
+ThrowNullRef38:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %85
+ThrowNullRef40:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %91
+ThrowNullRef42:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9943,15 +11532,15 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
   %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
@@ -9961,28 +11550,28 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
   %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %12
   %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
   %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
   %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
-  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
@@ -9993,23 +11582,23 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %12
+ThrowNullRef6:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10031,15 +11620,15 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
   %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = load i64, i64 addrspace(1)* %7
@@ -10077,13 +11666,13 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[loadElem]
+Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -10111,8 +11700,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -10226,8 +11815,8 @@ entry:
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load i64, i64* %arg0
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -10361,8 +11950,8 @@ entry:
   store i64 %param0, i64* %arg0
   store i64 %param1, i64* %arg1
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
@@ -10370,8 +11959,8 @@ entry:
   %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
   %5 = load i16*, i16* addrspace(1)* %4, align 8
   %6 = addrspacecast i64* %arg1 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = bitcast i64 addrspace(1)* %6 to i8 addrspace(1)*
@@ -10387,7 +11976,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10421,8 +12010,8 @@ entry:
   %1 = load i32, i32* %arg1
   %2 = sext i32 %1 to i64
   %3 = inttoptr i64 %2 to i16*
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -10475,8 +12064,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, i32)*)(%System.IO.ConsoleStream addrspace(1)* %2, i32 %1)
   %3 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %4 = load i64, i64* %arg1
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
@@ -10487,8 +12076,8 @@ entry:
   %10 = icmp eq i32 %9, 3
   %11 = sext i1 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %5
   %14 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, i32 0, i32 5
@@ -10499,7 +12088,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10522,8 +12111,8 @@ entry:
   %5 = icmp eq i32 %4, 1
   %6 = sext i1 %5 to i32
   %7 = trunc i32 %6 to i8
-  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %2, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.ConsoleStream addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
@@ -10534,8 +12123,8 @@ entry:
   %13 = icmp eq i32 %12, 2
   %14 = sext i1 %13 to i32
   %15 = trunc i32 %14 to i8
-  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %10, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.ConsoleStream addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %8
   %17 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %10, i32 0, i32 4
@@ -10546,7 +12135,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10585,8 +12174,8 @@ entry:
   %arg0 = alloca i64
   store i64 %param0, i64* %arg0
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
@@ -10621,8 +12210,8 @@ entry:
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
   %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = load i64, i64 addrspace(1)* %7
@@ -10726,7 +12315,127 @@ entry:
 INFO:  jitting method Encoding::GetEncoding using LLILCJit
 Failed to read Encoding.GetEncoding[convertToHelperArgumentType]
 INFO:  jitting method EncodingProvider::GetEncodingFromProvider using LLILCJit
-Failed to read EncodingProvider.GetEncodingFromProvider[loadElem]
+Successfully read EncodingProvider.GetEncodingFromProvider
+
+define %System.Text.Encoding addrspace(1)* @EncodingProvider.GetEncodingFromProvider(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca %"System.Text.EncodingProvider[]" addrspace(1)*
+  %loc1 = alloca %System.Text.EncodingProvider addrspace(1)*
+  %loc2 = alloca %System.Text.Encoding addrspace(1)*
+  %loc3 = alloca %System.Text.Encoding addrspace(1)*
+  %loc4 = alloca %"System.Text.EncodingProvider[]" addrspace(1)*
+  %loc5 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1059)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2392
+  %2 = addrspacecast i8 addrspace(1)* %1 to %"System.Text.EncodingProvider[]" addrspace(1)**
+  %3 = load volatile %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %2
+  %4 = icmp ne %"System.Text.EncodingProvider[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %entry
+  ret %System.Text.Encoding addrspace(1)* null
+
+; <label>:6                                       ; preds = %entry
+  %7 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1059)
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i64 2392
+  %9 = addrspacecast i8 addrspace(1)* %8 to %"System.Text.EncodingProvider[]" addrspace(1)**
+  %10 = load volatile %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %9
+  store %"System.Text.EncodingProvider[]" addrspace(1)* %10, %"System.Text.EncodingProvider[]" addrspace(1)** %loc0
+  %11 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc0
+  store %"System.Text.EncodingProvider[]" addrspace(1)* %11, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  store i32 0, i32* %loc5
+  br label %43
+
+; <label>:12                                      ; preds = %46
+  %13 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  %14 = load i32, i32* %loc5
+  %NullCheck1 = icmp eq %"System.Text.EncodingProvider[]" addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %13, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = zext i32 %17 to i64
+  %19 = zext i32 %14 to i64
+  %BoundsCheck = icmp uge i64 %19, %18
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %20
+
+; <label>:20                                      ; preds = %15
+  %21 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %13, i32 0, i32 3, i32 %14
+  %22 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)* addrspace(1)* %21, align 8
+  store %System.Text.EncodingProvider addrspace(1)* %22, %System.Text.EncodingProvider addrspace(1)** %loc1
+  %23 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)** %loc1
+  %24 = load i32, i32* %arg0
+  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i64 addrspace(1)*
+  %NullCheck3 = icmp eq i64 addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
+
+; <label>:26                                      ; preds = %20
+  %27 = load i64, i64 addrspace(1)* %25
+  %28 = add i64 %27, 64
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 40
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Text.Encoding addrspace(1)* (%System.Text.EncodingProvider addrspace(1)*, i32)*
+  %35 = call %System.Text.Encoding addrspace(1)* %34(%System.Text.EncodingProvider addrspace(1)* %23, i32 %24)
+  store %System.Text.Encoding addrspace(1)* %35, %System.Text.Encoding addrspace(1)** %loc2
+  %36 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc2
+  %37 = icmp eq %System.Text.Encoding addrspace(1)* %36, null
+  br i1 %37, label %40, label %38
+
+; <label>:38                                      ; preds = %26
+  %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc2
+  store %System.Text.Encoding addrspace(1)* %39, %System.Text.Encoding addrspace(1)** %loc3
+  br label %53
+
+; <label>:40                                      ; preds = %26
+  %41 = load i32, i32* %loc5
+  %42 = add i32 %41, 1
+  store i32 %42, i32* %loc5
+  br label %43
+
+; <label>:43                                      ; preds = %6, %40
+  %44 = load i32, i32* %loc5
+  %45 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  %NullCheck = icmp eq %"System.Text.EncodingProvider[]" addrspace(1)* %45, null
+  br i1 %NullCheck, label %ThrowNullRef, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp slt i32 %44, %50
+  br i1 %51, label %12, label %52
+
+; <label>:52                                      ; preds = %46
+  ret %System.Text.Encoding addrspace(1)* null
+
+; <label>:53                                      ; preds = %38
+  %54 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc3
+  ret %System.Text.Encoding addrspace(1)* %54
+
+ThrowNullRef:                                     ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method EncodingProvider::.cctor using LLILCJit
 Successfully read EncodingProvider..cctor
 
@@ -10745,7 +12454,7 @@ Failed to read Encoding.get_InternalSyncObject[Call HasTypeArg]
 INFO:  jitting method Hashtable::.ctor using LLILCJit
 Failed to read Hashtable..ctor[Volatile store]
 INFO:  jitting method Hashtable::get_Item using LLILCJit
-Failed to read Hashtable.get_Item[loadElemA]
+Failed to read Hashtable.get_Item[loadNonPrimitiveObj]
 INFO:  jitting method Hashtable::InitHash using LLILCJit
 Successfully read Hashtable.InitHash
 
@@ -10765,8 +12474,8 @@ entry:
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -10782,15 +12491,15 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
   %15 = load i32, i32* %loc0
-  %NullCheck2 = icmp ne i32 addrspace(1)* %14, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i32 addrspace(1)* %14, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %3
   store i32 %15, i32 addrspace(1)* %14, align 8
   %17 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %18 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %NullCheck4 = icmp ne i32 addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i32 addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = load i32, i32 addrspace(1)* %18, align 8
@@ -10799,8 +12508,8 @@ entry:
   %23 = sub i32 %22, 1
   %24 = urem i32 %21, %23
   %25 = add i32 1, %24
-  %NullCheck6 = icmp ne i32 addrspace(1)* %17, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32 addrspace(1)* %17, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %19
   store i32 %25, i32 addrspace(1)* %17, align 8
@@ -10811,15 +12520,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %19
+ThrowNullRef6:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10834,8 +12543,8 @@ entry:
   store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
   store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %NullCheck = icmp ne %System.Collections.Hashtable addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Collections.Hashtable addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
@@ -10845,16 +12554,16 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Collections.Hashtable addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Collections.Hashtable addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
   %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck4 = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %9, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
   %13 = inttoptr i64 %11 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
@@ -10864,8 +12573,8 @@ entry:
 ; <label>:15                                      ; preds = %1
   %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -10883,15 +12592,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10905,8 +12614,8 @@ entry:
   store %System.Int32 addrspace(1)* %param0, %System.Int32 addrspace(1)** %this
   %0 = load %System.Int32 addrspace(1)*, %System.Int32 addrspace(1)** %this
   %1 = bitcast %System.Int32 addrspace(1)* %0 to i32 addrspace(1)*
-  %NullCheck = icmp ne i32 addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq i32 addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load i32, i32 addrspace(1)* %1, align 8
@@ -10982,8 +12691,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.UTF8Encoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
@@ -10992,15 +12701,15 @@ entry:
   %9 = load i8, i8* %arg2
   %10 = zext i8 %9 to i32
   %11 = trunc i32 %10 to i8
-  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %8, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %6
   %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %8, i32 0, i32 8
   store i8 %11, i8 addrspace(1)* %13
   %14 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %14, i32 0, i32 8
@@ -11012,8 +12721,8 @@ entry:
 ; <label>:20                                      ; preds = %15
   %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %22, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %22, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = load i64, i64 addrspace(1)* %22
@@ -11035,15 +12744,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %12
+ThrowNullRef4:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11058,8 +12767,8 @@ entry:
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
@@ -11081,16 +12790,16 @@ entry:
 ; <label>:10                                      ; preds = %1
   %11 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
   %12 = load i32, i32* %arg1
-  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %11, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.Encoding addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
   store i32 %12, i32 addrspace(1)* %14
   %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
   %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = load i64, i64 addrspace(1)* %16
@@ -11108,11 +12817,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11125,8 +12834,8 @@ entry:
   %this = alloca %System.Text.UTF8Encoding addrspace(1)*
   store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
   %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.UTF8Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
@@ -11138,16 +12847,16 @@ entry:
 ; <label>:6                                       ; preds = %1
   %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %8 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %10, %System.Text.EncoderFallback addrspace(1)* %8)
   %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %12 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
-  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %11, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %11, i32 0, i32 3
@@ -11160,8 +12869,8 @@ entry:
   %18 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %18, %System.String addrspace(1)* %17)
   %19 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %18 to %System.Text.EncoderFallback addrspace(1)*
-  %NullCheck6 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %16, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %16, i32 0, i32 2
@@ -11171,8 +12880,8 @@ entry:
   %24 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %24, %System.String addrspace(1)* %23)
   %25 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %24 to %System.Text.DecoderFallback addrspace(1)*
-  %NullCheck8 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %22, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %22, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %20
   %27 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %22, i32 0, i32 3
@@ -11183,19 +12892,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %20
+ThrowNullRef8:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11225,8 +12934,8 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load i32, i32* %arg1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -11244,8 +12953,8 @@ entry:
 ; <label>:15                                      ; preds = %8
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %17 = load i32, i32* %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 %17
@@ -11261,7 +12970,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11313,7 +13022,7 @@ entry:
 }
 
 INFO:  jitting method Hashtable::Insert using LLILCJit
-Failed to read Hashtable.Insert[loadElemA]
+Failed to read Hashtable.Insert[storeElem]
 INFO:  jitting method ConsoleEncoding::.ctor using LLILCJit
 Successfully read ConsoleEncoding..ctor
 
@@ -11328,8 +13037,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %1)
   %2 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
@@ -11365,8 +13074,8 @@ entry:
   %2 = call %System.Text.InternalEncoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalEncoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %1)
   %3 = bitcast %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2 to %System.Text.EncoderFallback addrspace(1)*
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
@@ -11376,8 +13085,8 @@ entry:
   %8 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %7)
   %9 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %8 to %System.Text.DecoderFallback addrspace(1)*
-  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %6, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.Encoding addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %4
   %11 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %6, i32 0, i32 3
@@ -11388,7 +13097,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11407,15 +13116,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* %1)
   %2 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   %6 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, i32 0, i32 1
@@ -11426,7 +13135,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11454,8 +13163,8 @@ entry:
   store %System.Text.InternalDecoderBestFitFallback addrspace(1)* %param0, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
   %0 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
@@ -11465,15 +13174,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %4)
   %5 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %6)
   %9 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, i32 0, i32 1
@@ -11484,11 +13193,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11556,8 +13265,8 @@ entry:
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
   %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = load i64, i64 addrspace(1)* %19
@@ -11621,8 +13330,8 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.ConsoleStream addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
@@ -11653,31 +13362,31 @@ entry:
   store i8 %param4, i8* %arg4
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %3, %System.IO.Stream addrspace(1)* %1)
   %4 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %4, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
   %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %4, i32 0, i32 4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %5)
   %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %6
   %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
   %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
   %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = load i64, i64 addrspace(1)* %13
@@ -11689,8 +13398,8 @@ entry:
   %21 = load i64, i64* %20
   %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %8, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %8, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %14
   %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 5
@@ -11708,24 +13417,24 @@ entry:
   %31 = load i32, i32* %arg3
   %32 = sext i32 %31 to i64
   %33 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %32)
-  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %30, null
-  br i1 %NullCheck10, label %34, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.StreamWriter addrspace(1)* %30, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %35, %"System.Char[]" addrspace(1)* %33)
   %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %37, null
-  br i1 %NullCheck12, label %38, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.StreamWriter addrspace(1)* %37, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %38
 
 ; <label>:38                                      ; preds = %34
   %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
   %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
   %41 = load i32, i32* %arg3
   %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %42, null
-  br i1 %NullCheck14, label %43, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %42, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
   %44 = load i64, i64 addrspace(1)* %42
@@ -11739,30 +13448,30 @@ entry:
   %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
   %53 = sext i32 %52 to i64
   %54 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %53)
-  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
-  br i1 %NullCheck16, label %55, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %55
 
 ; <label>:55                                      ; preds = %43
   %56 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %56, %"System.Byte[]" addrspace(1)* %54)
   %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %58 = load i32, i32* %arg3
-  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %57, null
-  br i1 %NullCheck18, label %59, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.StreamWriter addrspace(1)* %57, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %59
 
 ; <label>:59                                      ; preds = %55
   %60 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 10
   store i32 %58, i32 addrspace(1)* %60
   %61 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %61, null
-  br i1 %NullCheck20, label %62, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.IO.StreamWriter addrspace(1)* %61, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %62
 
 ; <label>:62                                      ; preds = %59
   %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
   %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
   %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
   %67 = load i64, i64 addrspace(1)* %65
@@ -11780,15 +13489,15 @@ entry:
 
 ; <label>:78                                      ; preds = %66
   %79 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %79, null
-  br i1 %NullCheck24, label %80, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.StreamWriter addrspace(1)* %79, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %80
 
 ; <label>:80                                      ; preds = %78
   %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
   %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
   %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %83, null
-  br i1 %NullCheck26, label %84, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %83, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
   %85 = load i64, i64 addrspace(1)* %83
@@ -11805,8 +13514,8 @@ entry:
 
 ; <label>:95                                      ; preds = %84
   %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.IO.StreamWriter addrspace(1)* %96, null
-  br i1 %NullCheck28, label %97, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.IO.StreamWriter addrspace(1)* %96, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %97
 
 ; <label>:97                                      ; preds = %95
   %98 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 12
@@ -11820,8 +13529,8 @@ entry:
   %103 = icmp eq i32 %102, 0
   %104 = sext i1 %103 to i32
   %105 = trunc i32 %104 to i8
-  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %100, null
-  br i1 %NullCheck30, label %106, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.IO.StreamWriter addrspace(1)* %100, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %106
 
 ; <label>:106                                     ; preds = %99
   %107 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %100, i32 0, i32 13
@@ -11832,63 +13541,63 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %6
+ThrowNullRef4:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %29
+ThrowNullRef10:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %34
+ThrowNullRef12:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %38
+ThrowNullRef14:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %43
+ThrowNullRef16:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %55
+ThrowNullRef18:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %59
+ThrowNullRef20:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %62
+ThrowNullRef22:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %78
+ThrowNullRef24:                                   ; preds = %78
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %80
+ThrowNullRef26:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %95
+ThrowNullRef28:                                   ; preds = %95
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11901,15 +13610,15 @@ entry:
   %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = load i64, i64 addrspace(1)* %4
@@ -11927,7 +13636,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11977,35 +13686,35 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
   %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderNLS addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %7 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.EncoderNLS addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Text.Encoding addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.Encoding addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Text.EncoderNLS addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.EncoderNLS addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
   %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck8 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = load i64, i64 addrspace(1)* %16
@@ -12024,19 +13733,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12062,8 +13771,8 @@ entry:
   %this = alloca %System.Text.Encoding addrspace(1)*
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
@@ -12083,15 +13792,15 @@ entry:
   %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
   store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
   %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
   store i32 0, i32 addrspace(1)* %2
   %3 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, i32 0, i32 2
@@ -12101,15 +13810,15 @@ entry:
 
 ; <label>:8                                       ; preds = %4
   %9 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
   %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
   %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = load i64, i64 addrspace(1)* %13
@@ -12130,15 +13839,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12153,16 +13862,16 @@ entry:
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = load i32, i32* %arg1
   %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
   %7 = load i64, i64 addrspace(1)* %5
@@ -12180,7 +13889,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12217,8 +13926,8 @@ entry:
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
   %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
   %16 = load i64, i64 addrspace(1)* %14
@@ -12239,8 +13948,8 @@ entry:
   %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
   %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
   %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %31, null
-  br i1 %NullCheck2, label %32, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = load i64, i64 addrspace(1)* %31
@@ -12283,7 +13992,7 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12296,14 +14005,14 @@ entry:
   %this = alloca %System.Text.EncoderReplacementFallback addrspace(1)*
   store %System.Text.EncoderReplacementFallback addrspace(1)* %param0, %System.Text.EncoderReplacementFallback addrspace(1)** %this
   %0 = load %System.Text.EncoderReplacementFallback addrspace(1)*, %System.Text.EncoderReplacementFallback addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -12314,7 +14023,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12344,8 +14053,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
@@ -12377,8 +14086,8 @@ entry:
   %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
   store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
@@ -12390,8 +14099,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Threading.Tasks.Task addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %7)
@@ -12414,7 +14123,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12433,8 +14142,8 @@ entry:
   store i8 %param1, i8* %arg1
   store i8 %param2, i8* %arg2
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
@@ -12448,8 +14157,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1, %5
   %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 9
@@ -12480,8 +14189,8 @@ entry:
 
 ; <label>:25                                      ; preds = %8, %20
   %26 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %26, null
-  br i1 %NullCheck4, label %27, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %26, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %26, i32 0, i32 12
@@ -12492,22 +14201,22 @@ entry:
 
 ; <label>:32                                      ; preds = %27
   %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %33, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.IO.StreamWriter addrspace(1)* %33, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %32
   %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 12
   store i8 1, i8 addrspace(1)* %35
   %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
-  br i1 %NullCheck8, label %37, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
   %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
   %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck10 = icmp ne i64 addrspace(1)* %40, null
-  br i1 %NullCheck10, label %41, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64 addrspace(1)* %40, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i64, i64 addrspace(1)* %40
@@ -12521,8 +14230,8 @@ entry:
   %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
   store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
   %51 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %NullCheck12 = icmp ne %"System.Byte[]" addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Byte[]" addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %41
   %53 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %51, i32 0, i32 1
@@ -12534,16 +14243,16 @@ entry:
 
 ; <label>:58                                      ; preds = %52
   %59 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %59, null
-  br i1 %NullCheck14, label %60, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.IO.StreamWriter addrspace(1)* %59, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %60
 
 ; <label>:60                                      ; preds = %58
   %61 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %59, i32 0, i32 3
   %62 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
   %64 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %NullCheck16 = icmp ne %"System.Byte[]" addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %"System.Byte[]" addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %60
   %66 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %64, i32 0, i32 1
@@ -12551,8 +14260,8 @@ entry:
   %68 = zext i32 %67 to i64
   %69 = trunc i64 %68 to i32
   %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck18, label %71, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
   %72 = load i64, i64 addrspace(1)* %70
@@ -12568,29 +14277,29 @@ entry:
 
 ; <label>:80                                      ; preds = %27, %52, %71
   %81 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %81, null
-  br i1 %NullCheck20, label %82, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.IO.StreamWriter addrspace(1)* %81, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
 
 ; <label>:82                                      ; preds = %80
   %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %81, i32 0, i32 5
   %84 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %83, align 8
   %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.IO.StreamWriter addrspace(1)* %85, null
-  br i1 %NullCheck22, label %86, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.IO.StreamWriter addrspace(1)* %85, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %86
 
 ; <label>:86                                      ; preds = %82
   %87 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 7
   %88 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %87, align 8
   %89 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %89, null
-  br i1 %NullCheck24, label %90, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.StreamWriter addrspace(1)* %89, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %90
 
 ; <label>:90                                      ; preds = %86
   %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %89, i32 0, i32 9
   %92 = load i32, i32 addrspace(1)* %91, align 8
   %93 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.IO.StreamWriter addrspace(1)* %93, null
-  br i1 %NullCheck26, label %94, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.IO.StreamWriter addrspace(1)* %93, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %93, i32 0, i32 6
@@ -12598,8 +14307,8 @@ entry:
   %97 = load i8, i8* %arg2
   %98 = zext i8 %97 to i32
   %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
-  %NullCheck28 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck28, label %100, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
   %101 = load i64, i64 addrspace(1)* %99
@@ -12614,8 +14323,8 @@ entry:
   %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
   store i32 %110, i32* %loc1
   %111 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %111, null
-  br i1 %NullCheck30, label %112, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.IO.StreamWriter addrspace(1)* %111, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %112
 
 ; <label>:112                                     ; preds = %100
   %113 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %111, i32 0, i32 9
@@ -12626,23 +14335,23 @@ entry:
 
 ; <label>:116                                     ; preds = %112
   %117 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck32 = icmp ne %System.IO.StreamWriter addrspace(1)* %117, null
-  br i1 %NullCheck32, label %118, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.IO.StreamWriter addrspace(1)* %117, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %118
 
 ; <label>:118                                     ; preds = %116
   %119 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %117, i32 0, i32 3
   %120 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %119, align 8
   %121 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.IO.StreamWriter addrspace(1)* %121, null
-  br i1 %NullCheck34, label %122, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.IO.StreamWriter addrspace(1)* %121, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %122
 
 ; <label>:122                                     ; preds = %118
   %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
   %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
   %125 = load i32, i32* %loc1
   %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
-  %NullCheck36 = icmp ne i64 addrspace(1)* %126, null
-  br i1 %NullCheck36, label %127, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64 addrspace(1)* %126, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
   %128 = load i64, i64 addrspace(1)* %126
@@ -12664,15 +14373,15 @@ entry:
 
 ; <label>:140                                     ; preds = %136
   %141 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.IO.StreamWriter addrspace(1)* %141, null
-  br i1 %NullCheck38, label %142, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.IO.StreamWriter addrspace(1)* %141, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %142
 
 ; <label>:142                                     ; preds = %140
   %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
   %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
   %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
-  %NullCheck40 = icmp ne i64 addrspace(1)* %145, null
-  br i1 %NullCheck40, label %146, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i64 addrspace(1)* %145, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
   %147 = load i64, i64 addrspace(1)* %145
@@ -12693,83 +14402,83 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %25
+ThrowNullRef4:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %32
+ThrowNullRef6:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %37
+ThrowNullRef10:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %41
+ThrowNullRef12:                                   ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %58
+ThrowNullRef14:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %60
+ThrowNullRef16:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %65
+ThrowNullRef18:                                   ; preds = %65
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %80
+ThrowNullRef20:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %82
+ThrowNullRef22:                                   ; preds = %82
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %86
+ThrowNullRef24:                                   ; preds = %86
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %90
+ThrowNullRef26:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %94
+ThrowNullRef28:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %100
+ThrowNullRef30:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %116
+ThrowNullRef32:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %118
+ThrowNullRef34:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %122
+ThrowNullRef36:                                   ; preds = %122
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %140
+ThrowNullRef38:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %142
+ThrowNullRef40:                                   ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12836,8 +14545,8 @@ entry:
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %1 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
-  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
@@ -12845,8 +14554,8 @@ entry:
   %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
   %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
   %8 = load i64, i64 addrspace(1)* %6
@@ -12862,8 +14571,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %17, %System.IFormatProvider addrspace(1)* %16)
   %18 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %19 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %18, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.SyncTextWriter addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %7
   %21 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %18, i32 0, i32 4
@@ -12874,11 +14583,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12891,8 +14600,8 @@ entry:
   %this = alloca %System.IO.TextWriter addrspace(1)*
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.TextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
@@ -12902,8 +14611,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.Threading.Thread addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Threading.Thread addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %6)
@@ -12912,8 +14621,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1
   %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.TextWriter addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.TextWriter addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %11, i32 0, i32 2
@@ -12924,11 +14633,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13125,8 +14834,8 @@ entry:
   store i64 %param1, i64* %arg1
   store i8 0, i8* %loc1
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
@@ -13136,16 +14845,16 @@ entry:
   %5 = addrspacecast i8* %loc1 to i8 addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %4, i8 addrspace(1)* %5)
   %6 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.SyncTextWriter addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
   %10 = load i64, i64* %arg1
   %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
   %13 = load i64, i64 addrspace(1)* %11
@@ -13180,11 +14889,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13201,8 +14910,8 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load i64, i64* %arg1
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -13216,8 +14925,8 @@ entry:
   call void %11(%System.IO.TextWriter addrspace(1)* %0, i64 %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
   %15 = load i64, i64 addrspace(1)* %13
@@ -13235,7 +14944,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13253,8 +14962,8 @@ entry:
   %1 = addrspacecast i64* %arg1 to i64 addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -13269,8 +14978,8 @@ entry:
   %14 = bitcast i64 addrspace(1)* %1 to %System.Int64 addrspace(1)*
   %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Int64 addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Int64 addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
   %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
   %18 = load i64, i64 addrspace(1)* %16
@@ -13288,7 +14997,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13304,8 +15013,8 @@ entry:
   store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
   %0 = load %System.Int64 addrspace(1)*, %System.Int64 addrspace(1)** %this
   %1 = bitcast %System.Int64 addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load i64, i64 addrspace(1)* %1, align 8
@@ -13330,8 +15039,8 @@ entry:
   %loc0 = alloca %System.Globalization.NumberFormatInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 3
@@ -13341,8 +15050,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
@@ -13352,24 +15061,24 @@ entry:
   store %System.Globalization.NumberFormatInfo addrspace(1)* %10, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
   %11 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %7
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
   %15 = load i8, i8 addrspace(1)* %14, align 8
   %16 = zext i8 %15 to i32
   %17 = trunc i32 %16 to i8
-  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %11, null
-  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %11, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %13
   %19 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %11, i32 0, i32 29
   store i8 %17, i8 addrspace(1)* %19
   %20 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %21 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %20, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %20, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %18
   %23 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %20, i32 0, i32 3
@@ -13378,8 +15087,8 @@ entry:
 
 ; <label>:24                                      ; preds = %1, %22
   %25 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %25, null
-  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %25, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %26
 
 ; <label>:26                                      ; preds = %24
   %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %25, i32 0, i32 3
@@ -13390,23 +15099,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %18
+ThrowNullRef8:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13431,168 +15140,168 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 18
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %8, align 8
-  %NullCheck2 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %5, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %5, i32 0, i32 4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %9)
   %12 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 19
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %15, align 8
-  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %12, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %12, i32 0, i32 5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %16)
   %19 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %20 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %20, null
-  br i1 %NullCheck8, label %21, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %20, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %20, i32 0, i32 23
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  %NullCheck10 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %19, null
-  br i1 %NullCheck10, label %24, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %19, i32 0, i32 7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %25, %System.String addrspace(1)* %23)
   %26 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %27 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %27, i32 0, i32 22
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %29, align 8
-  %NullCheck14 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %26, null
-  br i1 %NullCheck14, label %31, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %26, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %26, i32 0, i32 6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %32, %System.String addrspace(1)* %30)
   %33 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %34 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Globalization.CultureData addrspace(1)* %34, null
-  br i1 %NullCheck16, label %35, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Globalization.CultureData addrspace(1)* %34, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %34, i32 0, i32 51
   %37 = load i32, i32 addrspace(1)* %36, align 8
-  %NullCheck18 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %33, null
-  br i1 %NullCheck18, label %38, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %33, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %33, i32 0, i32 21
   store i32 %37, i32 addrspace(1)* %39
   %40 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %41 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Globalization.CultureData addrspace(1)* %41, null
-  br i1 %NullCheck20, label %42, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Globalization.CultureData addrspace(1)* %41, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %41, i32 0, i32 52
   %44 = load i32, i32 addrspace(1)* %43, align 8
-  %NullCheck22 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %40, null
-  br i1 %NullCheck22, label %45, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %40, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %40, i32 0, i32 25
   store i32 %44, i32 addrspace(1)* %46
   %47 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %48 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.Globalization.CultureData addrspace(1)* %48, null
-  br i1 %NullCheck24, label %49, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Globalization.CultureData addrspace(1)* %48, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %49
 
 ; <label>:49                                      ; preds = %45
   %50 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %48, i32 0, i32 29
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck26 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %47, null
-  br i1 %NullCheck26, label %52, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %47, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %47, i32 0, i32 10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %53, %System.String addrspace(1)* %51)
   %54 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %55 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Globalization.CultureData addrspace(1)* %55, null
-  br i1 %NullCheck28, label %56, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Globalization.CultureData addrspace(1)* %55, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %56
 
 ; <label>:56                                      ; preds = %52
   %57 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %55, i32 0, i32 35
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %57, align 8
-  %NullCheck30 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %54, null
-  br i1 %NullCheck30, label %59, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %54, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %54, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %60, %System.String addrspace(1)* %58)
   %61 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %62 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck32 = icmp ne %System.Globalization.CultureData addrspace(1)* %62, null
-  br i1 %NullCheck32, label %63, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Globalization.CultureData addrspace(1)* %62, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %62, i32 0, i32 34
   %65 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %64, align 8
-  %NullCheck34 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %61, null
-  br i1 %NullCheck34, label %66, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %61, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %61, i32 0, i32 9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %67, %System.String addrspace(1)* %65)
   %68 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %69 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck36 = icmp ne %System.Globalization.CultureData addrspace(1)* %69, null
-  br i1 %NullCheck36, label %70, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Globalization.CultureData addrspace(1)* %69, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %70
 
 ; <label>:70                                      ; preds = %66
   %71 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %69, i32 0, i32 55
   %72 = load i32, i32 addrspace(1)* %71, align 8
-  %NullCheck38 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %68, null
-  br i1 %NullCheck38, label %73, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %68, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %68, i32 0, i32 22
   store i32 %72, i32 addrspace(1)* %74
   %75 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %76 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck40 = icmp ne %System.Globalization.CultureData addrspace(1)* %76, null
-  br i1 %NullCheck40, label %77, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Globalization.CultureData addrspace(1)* %76, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %76, i32 0, i32 57
   %79 = load i32, i32 addrspace(1)* %78, align 8
-  %NullCheck42 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %75, null
-  br i1 %NullCheck42, label %80, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %75, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %80
 
 ; <label>:80                                      ; preds = %77
   %81 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %75, i32 0, i32 24
   store i32 %79, i32 addrspace(1)* %81
   %82 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %83 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck44 = icmp ne %System.Globalization.CultureData addrspace(1)* %83, null
-  br i1 %NullCheck44, label %84, label %ThrowNullRef43
+  %NullCheck43 = icmp eq %System.Globalization.CultureData addrspace(1)* %83, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %84
 
 ; <label>:84                                      ; preds = %80
   %85 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %83, i32 0, i32 56
   %86 = load i32, i32 addrspace(1)* %85, align 8
-  %NullCheck46 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %82, null
-  br i1 %NullCheck46, label %87, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %82, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %82, i32 0, i32 23
@@ -13601,8 +15310,8 @@ entry:
 
 ; <label>:89                                      ; preds = %entry
   %90 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck100 = icmp ne %System.Globalization.CultureData addrspace(1)* %90, null
-  br i1 %NullCheck100, label %91, label %ThrowNullRef99
+  %NullCheck99 = icmp eq %System.Globalization.CultureData addrspace(1)* %90, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %91
 
 ; <label>:91                                      ; preds = %89
   %92 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %90, i32 0, i32 2
@@ -13620,8 +15329,8 @@ entry:
   %102 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %103 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %104 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %103)
-  %NullCheck48 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %102, null
-  br i1 %NullCheck48, label %105, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %102, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %105
 
 ; <label>:105                                     ; preds = %101
   %106 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %102, i32 0, i32 1
@@ -13629,8 +15338,8 @@ entry:
   %107 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %108 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %109 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %108)
-  %NullCheck50 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %107, null
-  br i1 %NullCheck50, label %110, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %107, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %110
 
 ; <label>:110                                     ; preds = %105
   %111 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %107, i32 0, i32 2
@@ -13638,8 +15347,8 @@ entry:
   %112 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %113 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %114 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %113)
-  %NullCheck52 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %112, null
-  br i1 %NullCheck52, label %115, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %112, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %115
 
 ; <label>:115                                     ; preds = %110
   %116 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %112, i32 0, i32 27
@@ -13647,8 +15356,8 @@ entry:
   %117 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %118 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %119 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %118)
-  %NullCheck54 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %117, null
-  br i1 %NullCheck54, label %120, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %117, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %120
 
 ; <label>:120                                     ; preds = %115
   %121 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %117, i32 0, i32 26
@@ -13656,8 +15365,8 @@ entry:
   %122 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %123 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %124 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %123)
-  %NullCheck56 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %122, null
-  br i1 %NullCheck56, label %125, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %122, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %125
 
 ; <label>:125                                     ; preds = %120
   %126 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %122, i32 0, i32 17
@@ -13665,8 +15374,8 @@ entry:
   %127 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %128 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %129 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %128)
-  %NullCheck58 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %127, null
-  br i1 %NullCheck58, label %130, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %127, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %130
 
 ; <label>:130                                     ; preds = %125
   %131 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %127, i32 0, i32 18
@@ -13674,8 +15383,8 @@ entry:
   %132 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %133 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %134 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %133)
-  %NullCheck60 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %132, null
-  br i1 %NullCheck60, label %135, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %132, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %135
 
 ; <label>:135                                     ; preds = %130
   %136 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %132, i32 0, i32 14
@@ -13683,8 +15392,8 @@ entry:
   %137 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %138 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %139 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %138)
-  %NullCheck62 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %137, null
-  br i1 %NullCheck62, label %140, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %137, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %140
 
 ; <label>:140                                     ; preds = %135
   %141 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %137, i32 0, i32 13
@@ -13692,71 +15401,71 @@ entry:
   %142 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %143 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %144 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %143)
-  %NullCheck64 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %142, null
-  br i1 %NullCheck64, label %145, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %142, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %145
 
 ; <label>:145                                     ; preds = %140
   %146 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %142, i32 0, i32 12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %146, %System.String addrspace(1)* %144)
   %147 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %148 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck66 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %148, null
-  br i1 %NullCheck66, label %149, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %148, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %149
 
 ; <label>:149                                     ; preds = %145
   %150 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %148, i32 0, i32 21
   %151 = load i32, i32 addrspace(1)* %150, align 8
-  %NullCheck68 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %147, null
-  br i1 %NullCheck68, label %152, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %147, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %152
 
 ; <label>:152                                     ; preds = %149
   %153 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %147, i32 0, i32 28
   store i32 %151, i32 addrspace(1)* %153
   %154 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %155 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck70 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %155, null
-  br i1 %NullCheck70, label %156, label %ThrowNullRef69
+  %NullCheck69 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %155, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %156
 
 ; <label>:156                                     ; preds = %152
   %157 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %155, i32 0, i32 6
   %158 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %157, align 8
-  %NullCheck72 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %154, null
-  br i1 %NullCheck72, label %159, label %ThrowNullRef71
+  %NullCheck71 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %154, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %159
 
 ; <label>:159                                     ; preds = %156
   %160 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %154, i32 0, i32 15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %160, %System.String addrspace(1)* %158)
   %161 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %162 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck74 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %162, null
-  br i1 %NullCheck74, label %163, label %ThrowNullRef73
+  %NullCheck73 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %162, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %163
 
 ; <label>:163                                     ; preds = %159
   %164 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %162, i32 0, i32 1
   %165 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %164, align 8
-  %NullCheck76 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %161, null
-  br i1 %NullCheck76, label %166, label %ThrowNullRef75
+  %NullCheck75 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %161, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %166
 
 ; <label>:166                                     ; preds = %163
   %167 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %161, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %167, %"System.Int32[]" addrspace(1)* %165)
   %168 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %169 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck78 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %169, null
-  br i1 %NullCheck78, label %170, label %ThrowNullRef77
+  %NullCheck77 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %169, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %170
 
 ; <label>:170                                     ; preds = %166
   %171 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %169, i32 0, i32 7
   %172 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %171, align 8
-  %NullCheck80 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %168, null
-  br i1 %NullCheck80, label %173, label %ThrowNullRef79
+  %NullCheck79 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %168, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %173
 
 ; <label>:173                                     ; preds = %170
   %174 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %168, i32 0, i32 16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %174, %System.String addrspace(1)* %172)
   %175 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck82 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %175, null
-  br i1 %NullCheck82, label %176, label %ThrowNullRef81
+  %NullCheck81 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %175, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %176
 
 ; <label>:176                                     ; preds = %173
   %177 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %175, i32 0, i32 4
@@ -13766,14 +15475,14 @@ entry:
 
 ; <label>:180                                     ; preds = %176
   %181 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck84 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %181, null
-  br i1 %NullCheck84, label %182, label %ThrowNullRef83
+  %NullCheck83 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %181, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %182
 
 ; <label>:182                                     ; preds = %180
   %183 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %181, i32 0, i32 4
   %184 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %183, align 8
-  %NullCheck86 = icmp ne %System.String addrspace(1)* %184, null
-  br i1 %NullCheck86, label %185, label %ThrowNullRef85
+  %NullCheck85 = icmp eq %System.String addrspace(1)* %184, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %185
 
 ; <label>:185                                     ; preds = %182
   %186 = getelementptr inbounds %System.String, %System.String addrspace(1)* %184, i32 0, i32 1
@@ -13784,8 +15493,8 @@ entry:
 ; <label>:189                                     ; preds = %176, %185
   %190 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck98 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %190, null
-  br i1 %NullCheck98, label %192, label %ThrowNullRef97
+  %NullCheck97 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %190, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %192
 
 ; <label>:192                                     ; preds = %189
   %193 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %190, i32 0, i32 4
@@ -13794,8 +15503,8 @@ entry:
 
 ; <label>:194                                     ; preds = %185, %192
   %195 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck88 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %195, null
-  br i1 %NullCheck88, label %196, label %ThrowNullRef87
+  %NullCheck87 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %195, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %196
 
 ; <label>:196                                     ; preds = %194
   %197 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %195, i32 0, i32 9
@@ -13805,14 +15514,14 @@ entry:
 
 ; <label>:200                                     ; preds = %196
   %201 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck90 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %201, null
-  br i1 %NullCheck90, label %202, label %ThrowNullRef89
+  %NullCheck89 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %201, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %202
 
 ; <label>:202                                     ; preds = %200
   %203 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %201, i32 0, i32 9
   %204 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %203, align 8
-  %NullCheck92 = icmp ne %System.String addrspace(1)* %204, null
-  br i1 %NullCheck92, label %205, label %ThrowNullRef91
+  %NullCheck91 = icmp eq %System.String addrspace(1)* %204, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %205
 
 ; <label>:205                                     ; preds = %202
   %206 = getelementptr inbounds %System.String, %System.String addrspace(1)* %204, i32 0, i32 1
@@ -13823,14 +15532,14 @@ entry:
 ; <label>:209                                     ; preds = %196, %205
   %210 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %211 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck94 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %211, null
-  br i1 %NullCheck94, label %212, label %ThrowNullRef93
+  %NullCheck93 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %211, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %212
 
 ; <label>:212                                     ; preds = %209
   %213 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %211, i32 0, i32 6
   %214 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %213, align 8
-  %NullCheck96 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %210, null
-  br i1 %NullCheck96, label %215, label %ThrowNullRef95
+  %NullCheck95 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %210, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %215
 
 ; <label>:215                                     ; preds = %212
   %216 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %210, i32 0, i32 9
@@ -13844,203 +15553,203 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %17
+ThrowNullRef8:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %21
+ThrowNullRef10:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %24
+ThrowNullRef12:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %28
+ThrowNullRef14:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %31
+ThrowNullRef16:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %35
+ThrowNullRef18:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %38
+ThrowNullRef20:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %42
+ThrowNullRef22:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %45
+ThrowNullRef24:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %49
+ThrowNullRef26:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %52
+ThrowNullRef28:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %56
+ThrowNullRef30:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %59
+ThrowNullRef32:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %63
+ThrowNullRef34:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %66
+ThrowNullRef36:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %70
+ThrowNullRef38:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %73
+ThrowNullRef40:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %77
+ThrowNullRef42:                                   ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %80
+ThrowNullRef44:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %84
+ThrowNullRef46:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %101
+ThrowNullRef48:                                   ; preds = %101
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %105
+ThrowNullRef50:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %110
+ThrowNullRef52:                                   ; preds = %110
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %115
+ThrowNullRef54:                                   ; preds = %115
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %120
+ThrowNullRef56:                                   ; preds = %120
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %125
+ThrowNullRef58:                                   ; preds = %125
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %130
+ThrowNullRef60:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %135
+ThrowNullRef62:                                   ; preds = %135
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %140
+ThrowNullRef64:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %145
+ThrowNullRef66:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %149
+ThrowNullRef68:                                   ; preds = %149
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %152
+ThrowNullRef70:                                   ; preds = %152
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %156
+ThrowNullRef72:                                   ; preds = %156
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %159
+ThrowNullRef74:                                   ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %163
+ThrowNullRef76:                                   ; preds = %163
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %166
+ThrowNullRef78:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %170
+ThrowNullRef80:                                   ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %173
+ThrowNullRef82:                                   ; preds = %173
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %180
+ThrowNullRef84:                                   ; preds = %180
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %182
+ThrowNullRef86:                                   ; preds = %182
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %194
+ThrowNullRef88:                                   ; preds = %194
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %200
+ThrowNullRef90:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %202
+ThrowNullRef92:                                   ; preds = %202
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %209
+ThrowNullRef94:                                   ; preds = %209
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %212
+ThrowNullRef96:                                   ; preds = %212
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %189
+ThrowNullRef98:                                   ; preds = %189
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %89
+ThrowNullRef100:                                  ; preds = %89
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14068,8 +15777,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 21
@@ -14082,8 +15791,8 @@ entry:
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 16)
   %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 21
@@ -14092,8 +15801,8 @@ entry:
 
 ; <label>:12                                      ; preds = %1, %10
   %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 21
@@ -14104,11 +15813,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %12
+ThrowNullRef4:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14124,8 +15833,8 @@ entry:
   store i32 %param1, i32* %arg1
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %1 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
@@ -14192,8 +15901,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 33
@@ -14206,8 +15915,8 @@ entry:
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 24)
   %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 33
@@ -14216,8 +15925,8 @@ entry:
 
 ; <label>:12                                      ; preds = %1, %10
   %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 33
@@ -14228,11 +15937,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %12
+ThrowNullRef4:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14245,8 +15954,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 53
@@ -14258,8 +15967,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 116)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 53
@@ -14268,8 +15977,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 53
@@ -14280,11 +15989,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14313,8 +16022,8 @@ entry:
 
 ; <label>:7                                       ; preds = %entry, %4
   %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %7
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 2
@@ -14338,8 +16047,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 54
@@ -14351,8 +16060,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 117)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
@@ -14361,8 +16070,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 54
@@ -14373,11 +16082,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14390,8 +16099,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 27
@@ -14403,8 +16112,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 118)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 27
@@ -14413,8 +16122,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 27
@@ -14425,11 +16134,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14442,8 +16151,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 28
@@ -14455,8 +16164,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 119)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 28
@@ -14465,8 +16174,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 28
@@ -14477,11 +16186,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14494,8 +16203,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 26
@@ -14507,8 +16216,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 107)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 26
@@ -14517,8 +16226,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 26
@@ -14529,11 +16238,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14546,8 +16255,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 25
@@ -14559,8 +16268,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 106)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 25
@@ -14569,8 +16278,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 25
@@ -14581,11 +16290,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14598,8 +16307,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 24
@@ -14611,8 +16320,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 105)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 24
@@ -14621,8 +16330,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 24
@@ -14633,11 +16342,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14662,8 +16371,8 @@ entry:
   %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %3)
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %2
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -14674,15 +16383,15 @@ entry:
 
 ; <label>:8                                       ; preds = %62
   %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 9
   %12 = load i32, i32 addrspace(1)* %11, align 8
   %13 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.IO.StreamWriter addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %13, i32 0, i32 10
@@ -14697,15 +16406,15 @@ entry:
 
 ; <label>:20                                      ; preds = %14, %18
   %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
   %24 = load i32, i32 addrspace(1)* %23, align 8
   %25 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %25, null
-  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.StreamWriter addrspace(1)* %25, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %25, i32 0, i32 9
@@ -14726,36 +16435,36 @@ entry:
   %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %37 = load i32, i32* %loc1
   %38 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.StreamWriter addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %35
   %40 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %38, i32 0, i32 7
   %41 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %40, align 8
   %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
-  br i1 %NullCheck14, label %43, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %39
   %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 9
   %45 = load i32, i32 addrspace(1)* %44, align 8
   %46 = load i32, i32* %loc2
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %36, null
-  br i1 %NullCheck16, label %47, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %36, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %47
 
 ; <label>:47                                      ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %36, i32 %37, %"System.Char[]" addrspace(1)* %41, i32 %45, i32 %46)
   %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
   %51 = load i32, i32 addrspace(1)* %50, align 8
   %52 = load i32, i32* %loc2
   %53 = add i32 %51, %52
-  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
-  br i1 %NullCheck20, label %54, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %54
 
 ; <label>:54                                      ; preds = %49
   %55 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
@@ -14777,8 +16486,8 @@ entry:
 
 ; <label>:65                                      ; preds = %62
   %66 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %66, null
-  br i1 %NullCheck2, label %67, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %66, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %67
 
 ; <label>:67                                      ; preds = %65
   %68 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %66, i32 0, i32 11
@@ -14799,49 +16508,259 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %65
+ThrowNullRef2:                                    ; preds = %65
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %20
+ThrowNullRef8:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %22
+ThrowNullRef10:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %35
+ThrowNullRef12:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %43
+ThrowNullRef16:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %47
+ThrowNullRef18:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method String::CopyTo using LLILCJit
-Failed to read String.CopyTo[loadElemA]
+Successfully read String.CopyTo
+
+define void @String.CopyTo(%System.String addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  %loc1 = alloca i16 addrspace(1)*
+  %loc2 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %1 = icmp ne %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg4
+  %7 = icmp sge i32 %6, 0
+  br i1 %7, label %13, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  unreachable
+
+; <label>:13                                      ; preds = %5
+  %14 = load i32, i32* %arg1
+  %15 = icmp sge i32 %14, 0
+  br i1 %15, label %21, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %18)
+  %20 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %20, %System.String addrspace(1)* %17, %System.String addrspace(1)* %19)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %20) #0
+  unreachable
+
+; <label>:21                                      ; preds = %13
+  %22 = load i32, i32* %arg4
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck, label %ThrowNullRef, label %24
+
+; <label>:24                                      ; preds = %21
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load i32, i32* %arg1
+  %28 = sub i32 %26, %27
+  %29 = icmp sle i32 %22, %28
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34, %System.String addrspace(1)* %31, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %24
+  %36 = load i32, i32* %arg3
+  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %37, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
+
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
+  %40 = load i32, i32 addrspace(1)* %39
+  %41 = zext i32 %40 to i64
+  %42 = trunc i64 %41 to i32
+  %43 = load i32, i32* %arg4
+  %44 = sub i32 %42, %43
+  %45 = icmp sgt i32 %36, %44
+  br i1 %45, label %49, label %46
+
+; <label>:46                                      ; preds = %38
+  %47 = load i32, i32* %arg3
+  %48 = icmp sge i32 %47, 0
+  br i1 %48, label %54, label %49
+
+; <label>:49                                      ; preds = %38, %46
+  %50 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %52 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %51)
+  %53 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53, %System.String addrspace(1)* %50, %System.String addrspace(1)* %52)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53) #0
+  unreachable
+
+; <label>:54                                      ; preds = %46
+  %55 = load i32, i32* %arg4
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %97, label %57
+
+; <label>:57                                      ; preds = %54
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %59
+
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 2
+  %61 = bitcast [0 x i16] addrspace(1)* %60 to i16 addrspace(1)*
+  store i16 addrspace(1)* %61, i16 addrspace(1)** %loc0
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  store %"System.Char[]" addrspace(1)* %62, %"System.Char[]" addrspace(1)** %loc2
+  %63 = icmp eq %"System.Char[]" addrspace(1)* %62, null
+  br i1 %63, label %72, label %64
+
+; <label>:64                                      ; preds = %59
+  %65 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc2
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %65, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %66
+
+; <label>:66                                      ; preds = %64
+  %67 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %65, i32 0, i32 1
+  %68 = load i32, i32 addrspace(1)* %67
+  %69 = zext i32 %68 to i64
+  %70 = trunc i64 %69 to i32
+  %71 = icmp ne i32 %70, 0
+  br i1 %71, label %73, label %72
+
+; <label>:72                                      ; preds = %59, %66
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  br label %81
+
+; <label>:73                                      ; preds = %66
+  %74 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc2
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %74, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %75
+
+; <label>:75                                      ; preds = %73
+  %76 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %74, i32 0, i32 1
+  %77 = load i32, i32 addrspace(1)* %76
+  %78 = zext i32 %77 to i64
+  %BoundsCheck = icmp uge i64 0, %78
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %79
+
+; <label>:79                                      ; preds = %75
+  %80 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %74, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %80, i16 addrspace(1)** %loc1
+  br label %81
+
+; <label>:81                                      ; preds = %72, %79
+  %82 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %83 = ptrtoint i16 addrspace(1)* %82 to i64
+  %84 = load i32, i32* %arg3
+  %85 = sext i32 %84 to i64
+  %86 = mul i64 %85, 2
+  %87 = add i64 %83, %86
+  %88 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %89 = ptrtoint i16 addrspace(1)* %88 to i64
+  %90 = load i32, i32* %arg1
+  %91 = sext i32 %90 to i64
+  %92 = mul i64 %91, 2
+  %93 = add i64 %89, %92
+  %94 = load i32, i32* %arg4
+  %95 = inttoptr i64 %87 to i16*
+  %96 = inttoptr i64 %93 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %95, i16* %96, i32 %94)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  br label %97
+
+; <label>:97                                      ; preds = %54, %81
+  ret void
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
 Successfully read ConsoleEncoding.GetPreamble
 
@@ -14878,7 +16797,365 @@ entry:
 }
 
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[loadElemA]
+Successfully read EncoderNLS.GetBytes
+
+define i32 @EncoderNLS.GetBytes(%System.Text.EncoderNLS addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3, %"System.Byte[]" addrspace(1)* %param4, i32 %param5, i8 %param6) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %arg4 = alloca %"System.Byte[]" addrspace(1)*
+  %arg5 = alloca i32
+  %arg6 = alloca i8
+  %loc0 = alloca i32
+  %loc1 = alloca i16 addrspace(1)*
+  %loc2 = alloca i8 addrspace(1)*
+  %loc3 = alloca i32
+  %loc4 = alloca %"System.Char[]" addrspace(1)*
+  %loc5 = alloca %"System.Byte[]" addrspace(1)*
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  store %"System.Byte[]" addrspace(1)* %param4, %"System.Byte[]" addrspace(1)** %arg4
+  store i32 %param5, i32* %arg5
+  store i8 %param6, i8* %arg6
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %1 = icmp eq %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %17, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %7 = icmp eq %"System.Char[]" addrspace(1)* %6, null
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %12
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %12
+
+; <label>:12                                      ; preds = %8, %10
+  %13 = phi %System.String addrspace(1)* [ %9, %8 ], [ %11, %10 ]
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %14)
+  %16 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16, %System.String addrspace(1)* %13, %System.String addrspace(1)* %15)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16) #0
+  unreachable
+
+; <label>:17                                      ; preds = %2
+  %18 = load i32, i32* %arg2
+  %19 = icmp slt i32 %18, 0
+  br i1 %19, label %23, label %20
+
+; <label>:20                                      ; preds = %17
+  %21 = load i32, i32* %arg3
+  %22 = icmp sge i32 %21, 0
+  br i1 %22, label %35, label %23
+
+; <label>:23                                      ; preds = %17, %20
+  %24 = load i32, i32* %arg2
+  %25 = icmp slt i32 %24, 0
+  br i1 %25, label %28, label %26
+
+; <label>:26                                      ; preds = %23
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %30
+
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %30
+
+; <label>:30                                      ; preds = %26, %28
+  %31 = phi %System.String addrspace(1)* [ %27, %26 ], [ %29, %28 ]
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34, %System.String addrspace(1)* %31, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %20
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck, label %ThrowNullRef, label %37
+
+; <label>:37                                      ; preds = %35
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = load i32, i32* %arg2
+  %43 = sub i32 %41, %42
+  %44 = load i32, i32* %arg3
+  %45 = icmp sge i32 %43, %44
+  br i1 %45, label %51, label %46
+
+; <label>:46                                      ; preds = %37
+  %47 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %48 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %49 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %48)
+  %50 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %50, %System.String addrspace(1)* %47, %System.String addrspace(1)* %49)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %50) #0
+  unreachable
+
+; <label>:51                                      ; preds = %37
+  %52 = load i32, i32* %arg5
+  %53 = icmp slt i32 %52, 0
+  br i1 %53, label %63, label %54
+
+; <label>:54                                      ; preds = %51
+  %55 = load i32, i32* %arg5
+  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck1 = icmp eq %"System.Byte[]" addrspace(1)* %56, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %57
+
+; <label>:57                                      ; preds = %54
+  %58 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = zext i32 %59 to i64
+  %61 = trunc i64 %60 to i32
+  %62 = icmp sle i32 %55, %61
+  br i1 %62, label %68, label %63
+
+; <label>:63                                      ; preds = %51, %57
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %66 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %65)
+  %67 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %67, %System.String addrspace(1)* %64, %System.String addrspace(1)* %66)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %67) #0
+  unreachable
+
+; <label>:68                                      ; preds = %57
+  %69 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %69, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %69, i32 0, i32 1
+  %72 = load i32, i32 addrspace(1)* %71
+  %73 = zext i32 %72 to i64
+  %74 = trunc i64 %73 to i32
+  %75 = icmp ne i32 %74, 0
+  br i1 %75, label %78, label %76
+
+; <label>:76                                      ; preds = %70
+  %77 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1)
+  store %"System.Char[]" addrspace(1)* %77, %"System.Char[]" addrspace(1)** %arg1
+  br label %78
+
+; <label>:78                                      ; preds = %70, %76
+  %79 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck5 = icmp eq %"System.Byte[]" addrspace(1)* %79, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %80
+
+; <label>:80                                      ; preds = %78
+  %81 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %79, i32 0, i32 1
+  %82 = load i32, i32 addrspace(1)* %81
+  %83 = zext i32 %82 to i64
+  %84 = trunc i64 %83 to i32
+  %85 = load i32, i32* %arg5
+  %86 = sub i32 %84, %85
+  store i32 %86, i32* %loc0
+  %87 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck7 = icmp eq %"System.Byte[]" addrspace(1)* %87, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %88
+
+; <label>:88                                      ; preds = %80
+  %89 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %87, i32 0, i32 1
+  %90 = load i32, i32 addrspace(1)* %89
+  %91 = zext i32 %90 to i64
+  %92 = trunc i64 %91 to i32
+  %93 = icmp ne i32 %92, 0
+  br i1 %93, label %96, label %94
+
+; <label>:94                                      ; preds = %88
+  %95 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1)
+  store %"System.Byte[]" addrspace(1)* %95, %"System.Byte[]" addrspace(1)** %arg4
+  br label %96
+
+; <label>:96                                      ; preds = %88, %94
+  %97 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  store %"System.Char[]" addrspace(1)* %97, %"System.Char[]" addrspace(1)** %loc4
+  %98 = icmp eq %"System.Char[]" addrspace(1)* %97, null
+  br i1 %98, label %107, label %99
+
+; <label>:99                                      ; preds = %96
+  %100 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc4
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %100, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %101
+
+; <label>:101                                     ; preds = %99
+  %102 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %100, i32 0, i32 1
+  %103 = load i32, i32 addrspace(1)* %102
+  %104 = zext i32 %103 to i64
+  %105 = trunc i64 %104 to i32
+  %106 = icmp ne i32 %105, 0
+  br i1 %106, label %108, label %107
+
+; <label>:107                                     ; preds = %96, %101
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  br label %116
+
+; <label>:108                                     ; preds = %101
+  %109 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc4
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %109, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %110
+
+; <label>:110                                     ; preds = %108
+  %111 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %109, i32 0, i32 1
+  %112 = load i32, i32 addrspace(1)* %111
+  %113 = zext i32 %112 to i64
+  %BoundsCheck = icmp uge i64 0, %113
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %114
+
+; <label>:114                                     ; preds = %110
+  %115 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %109, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %115, i16 addrspace(1)** %loc1
+  br label %116
+
+; <label>:116                                     ; preds = %107, %114
+  %117 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  store %"System.Byte[]" addrspace(1)* %117, %"System.Byte[]" addrspace(1)** %loc5
+  %118 = icmp eq %"System.Byte[]" addrspace(1)* %117, null
+  br i1 %118, label %127, label %119
+
+; <label>:119                                     ; preds = %116
+  %120 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc5
+  %NullCheck13 = icmp eq %"System.Byte[]" addrspace(1)* %120, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %121
+
+; <label>:121                                     ; preds = %119
+  %122 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %120, i32 0, i32 1
+  %123 = load i32, i32 addrspace(1)* %122
+  %124 = zext i32 %123 to i64
+  %125 = trunc i64 %124 to i32
+  %126 = icmp ne i32 %125, 0
+  br i1 %126, label %128, label %127
+
+; <label>:127                                     ; preds = %116, %121
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc2
+  br label %136
+
+; <label>:128                                     ; preds = %121
+  %129 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc5
+  %NullCheck15 = icmp eq %"System.Byte[]" addrspace(1)* %129, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %130
+
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %129, i32 0, i32 1
+  %132 = load i32, i32 addrspace(1)* %131
+  %133 = zext i32 %132 to i64
+  %BoundsCheck17 = icmp uge i64 0, %133
+  br i1 %BoundsCheck17, label %ThrowIndexOutOfRange18, label %134
+
+; <label>:134                                     ; preds = %130
+  %135 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %129, i32 0, i32 3, i32 0
+  store i8 addrspace(1)* %135, i8 addrspace(1)** %loc2
+  br label %136
+
+; <label>:136                                     ; preds = %127, %134
+  %137 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %138 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %139 = ptrtoint i16 addrspace(1)* %138 to i64
+  %140 = load i32, i32* %arg2
+  %141 = sext i32 %140 to i64
+  %142 = mul i64 %141, 2
+  %143 = add i64 %139, %142
+  %144 = load i32, i32* %arg3
+  %145 = load i8 addrspace(1)*, i8 addrspace(1)** %loc2
+  %146 = ptrtoint i8 addrspace(1)* %145 to i64
+  %147 = load i32, i32* %arg5
+  %148 = sext i32 %147 to i64
+  %149 = add i64 %146, %148
+  %150 = load i32, i32* %loc0
+  %151 = load i8, i8* %arg6
+  %152 = zext i8 %151 to i32
+  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i64 addrspace(1)*
+  %NullCheck19 = icmp eq i64 addrspace(1)* %153, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %154
+
+; <label>:154                                     ; preds = %136
+  %155 = load i64, i64 addrspace(1)* %153
+  %156 = add i64 %155, 72
+  %157 = inttoptr i64 %156 to i64*
+  %158 = load i64, i64* %157
+  %159 = add i64 %158, 0
+  %160 = inttoptr i64 %159 to i64*
+  %161 = load i64, i64* %160
+  %162 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to %System.Text.Encoder addrspace(1)*
+  %163 = inttoptr i64 %143 to i16*
+  %164 = inttoptr i64 %149 to i8*
+  %165 = trunc i32 %152 to i8
+  %166 = inttoptr i64 %161 to i32 (%System.Text.Encoder addrspace(1)*, i16*, i32, i8*, i32, i8)*
+  %167 = call i32 %166(%System.Text.Encoder addrspace(1)* %162, i16* %163, i32 %144, i8* %164, i32 %150, i8 %165)
+  store i32 %167, i32* %loc3
+  br label %168
+
+; <label>:168                                     ; preds = %154
+  %169 = load i32, i32* %loc3
+  ret i32 %169
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %110
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %119
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange18:                           ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
 Successfully read EncoderNLS.GetBytes
 
@@ -14967,22 +17244,22 @@ entry:
   %40 = load i8, i8* %arg5
   %41 = zext i8 %40 to i32
   %42 = trunc i32 %41 to i8
-  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %39, null
-  br i1 %NullCheck, label %43, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderNLS addrspace(1)* %39, null
+  br i1 %NullCheck, label %ThrowNullRef, label %43
 
 ; <label>:43                                      ; preds = %38
   %44 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
   store i8 %42, i8 addrspace(1)* %44
   %45 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %45, null
-  br i1 %NullCheck2, label %46, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.EncoderNLS addrspace(1)* %45, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %46
 
 ; <label>:46                                      ; preds = %43
   %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %45, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %47
   %48 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.EncoderNLS addrspace(1)* %48, null
-  br i1 %NullCheck4, label %49, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.EncoderNLS addrspace(1)* %48, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %49
 
 ; <label>:49                                      ; preds = %46
   %50 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %48, i32 0, i32 3
@@ -14993,8 +17270,8 @@ entry:
   %55 = load i32, i32* %arg4
   %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck6, label %58, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
   %59 = load i64, i64 addrspace(1)* %57
@@ -15012,15 +17289,15 @@ ThrowNullRef:                                     ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %43
+ThrowNullRef2:                                    ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %46
+ThrowNullRef4:                                    ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %49
+ThrowNullRef6:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -15048,8 +17325,8 @@ entry:
   %4 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0 to %System.IO.ConsoleStream addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*)(%System.IO.ConsoleStream addrspace(1)* %4, %"System.Byte[]" addrspace(1)* %1, i32 %2, i32 %3)
   %5 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
@@ -15134,8 +17411,8 @@ entry:
 
 ; <label>:22                                      ; preds = %8
   %23 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %23, null
-  br i1 %NullCheck, label %24, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Byte[]" addrspace(1)* %23, null
+  br i1 %NullCheck, label %ThrowNullRef, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
@@ -15157,8 +17434,8 @@ entry:
 
 ; <label>:36                                      ; preds = %24
   %37 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %37, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.ConsoleStream addrspace(1)* %37, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %37, i32 0, i32 4
@@ -15179,13 +17456,138 @@ ThrowNullRef:                                     ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %36
+ThrowNullRef2:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
-Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
+Successfully read WindowsConsoleStream.WriteFileNative
+
+define i32 @WindowsConsoleStream.WriteFileNative(i64 %param0, %"System.Byte[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i64
+  %arg1 = alloca %"System.Byte[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i8 addrspace(1)*
+  %loc2 = alloca %"System.Byte[]" addrspace(1)*
+  %loc3 = alloca i32
+  store i64 %param0, i64* %arg0
+  store %"System.Byte[]" addrspace(1)* %param1, %"System.Byte[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Byte[]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = zext i32 %3 to i64
+  %5 = icmp ne i64 %4, 0
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %1
+  ret i32 0
+
+; <label>:7                                       ; preds = %1
+  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  store %"System.Byte[]" addrspace(1)* %8, %"System.Byte[]" addrspace(1)** %loc2
+  %9 = icmp eq %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %9, label %18, label %10
+
+; <label>:10                                      ; preds = %7
+  %11 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc2
+  %NullCheck1 = icmp eq %"System.Byte[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %11, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp ne i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %7, %12
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc1
+  br label %27
+
+; <label>:19                                      ; preds = %12
+  %20 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc2
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %20, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %BoundsCheck = icmp uge i64 0, %24
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %25
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %20, i32 0, i32 3, i32 0
+  store i8 addrspace(1)* %26, i8 addrspace(1)** %loc1
+  br label %27
+
+; <label>:27                                      ; preds = %18, %25
+  %28 = load i64, i64* %arg0
+  %29 = load i8 addrspace(1)*, i8 addrspace(1)** %loc1
+  %30 = ptrtoint i8 addrspace(1)* %29 to i64
+  %31 = load i32, i32* %arg2
+  %32 = sext i32 %31 to i64
+  %33 = add i64 %30, %32
+  %34 = load i32, i32* %arg3
+  %35 = addrspacecast i32* %loc3 to i32 addrspace(1)*
+  %36 = inttoptr i64 %33 to i8*
+  %37 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i8*, i32, i32 addrspace(1)*, i64)*)(i64 %28, i8* %36, i32 %34, i32 addrspace(1)* %35, i64 0)
+  %38 = icmp ugt i32 %37, 0
+  %39 = sext i1 %38 to i32
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc1
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %42, label %41
+
+; <label>:41                                      ; preds = %27
+  ret i32 0
+
+; <label>:42                                      ; preds = %27
+  %43 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  store i32 %43, i32* %loc0
+  %44 = load i32, i32* %loc0
+  %45 = icmp eq i32 %44, 232
+  br i1 %45, label %49, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = load i32, i32* %loc0
+  %48 = icmp ne i32 %47, 109
+  br i1 %48, label %50, label %49
+
+; <label>:49                                      ; preds = %42, %46
+  ret i32 0
+
+; <label>:50                                      ; preds = %46
+  %51 = load i32, i32* %loc0
+  ret i32 %51
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
 Successfully read WindowsConsoleStream.Flush
 
@@ -15194,8 +17596,8 @@ entry:
   %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
   store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
@@ -15230,8 +17632,8 @@ entry:
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
   %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load i64, i64 addrspace(1)* %1
@@ -15270,15 +17672,15 @@ entry:
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.TextWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
   %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %3, align 8
   %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
   %7 = load i64, i64 addrspace(1)* %5
@@ -15296,7 +17698,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -15325,8 +17727,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %4)
   store i32 0, i32* %loc0
   %5 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Char[]" addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
@@ -15338,15 +17740,15 @@ entry:
 
 ; <label>:11                                      ; preds = %69
   %12 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %12, i32 0, i32 9
   %15 = load i32, i32 addrspace(1)* %14, align 8
   %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.IO.StreamWriter addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %16, i32 0, i32 10
@@ -15361,15 +17763,15 @@ entry:
 
 ; <label>:23                                      ; preds = %17, %21
   %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %24, null
-  br i1 %NullCheck8, label %25, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %24, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 10
   %27 = load i32, i32 addrspace(1)* %26, align 8
   %28 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %28, null
-  br i1 %NullCheck10, label %29, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.StreamWriter addrspace(1)* %28, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %28, i32 0, i32 9
@@ -15391,15 +17793,15 @@ entry:
   %40 = load i32, i32* %loc0
   %41 = mul i32 %40, 2
   %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
-  br i1 %NullCheck12, label %43, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %43
 
 ; <label>:43                                      ; preds = %38
   %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 7
   %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %44, align 8
   %46 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %46, null
-  br i1 %NullCheck14, label %47, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.IO.StreamWriter addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %47
 
 ; <label>:47                                      ; preds = %43
   %48 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %46, i32 0, i32 9
@@ -15411,16 +17813,16 @@ entry:
   %54 = bitcast %"System.Char[]" addrspace(1)* %45 to %System.Array addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %53, i32 %41, %System.Array addrspace(1)* %54, i32 %50, i32 %52)
   %55 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
-  br i1 %NullCheck16, label %56, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %56
 
 ; <label>:56                                      ; preds = %47
   %57 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
   %58 = load i32, i32 addrspace(1)* %57, align 8
   %59 = load i32, i32* %loc2
   %60 = add i32 %58, %59
-  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
-  br i1 %NullCheck18, label %61, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %61
 
 ; <label>:61                                      ; preds = %56
   %62 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
@@ -15442,8 +17844,8 @@ entry:
 
 ; <label>:72                                      ; preds = %69
   %73 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %73, null
-  br i1 %NullCheck2, label %74, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %73, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %74
 
 ; <label>:74                                      ; preds = %72
   %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %73, i32 0, i32 11
@@ -15464,39 +17866,39 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %72
+ThrowNullRef2:                                    ; preds = %72
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %23
+ThrowNullRef8:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef10:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %43
+ThrowNullRef14:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %47
+ThrowNullRef16:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %56
+ThrowNullRef18:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -15523,8 +17925,8 @@ entry:
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load i64, i64* %arg0
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -15556,8 +17958,8 @@ entry:
   store i64 %param1, i64* %arg1
   store i8 0, i8* %loc1
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
@@ -15567,16 +17969,16 @@ entry:
   %5 = addrspacecast i8* %loc1 to i8 addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %4, i8 addrspace(1)* %5)
   %6 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.SyncTextWriter addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
   %10 = load i64, i64* %arg1
   %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
   %13 = load i64, i64 addrspace(1)* %11
@@ -15611,11 +18013,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -15632,8 +18034,8 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load i64, i64* %arg1
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -15647,8 +18049,8 @@ entry:
   call void %11(%System.IO.TextWriter addrspace(1)* %0, i64 %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
   %15 = load i64, i64 addrspace(1)* %13
@@ -15666,7 +18068,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -15684,8 +18086,8 @@ entry:
   %1 = addrspacecast i64* %arg1 to i64 addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -15700,8 +18102,8 @@ entry:
   %14 = bitcast i64 addrspace(1)* %1 to %System.UInt64 addrspace(1)*
   %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.UInt64 addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.UInt64 addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
   %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
   %18 = load i64, i64 addrspace(1)* %16
@@ -15719,7 +18121,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -15735,8 +18137,8 @@ entry:
   store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
   %0 = load %System.UInt64 addrspace(1)*, %System.UInt64 addrspace(1)** %this
   %1 = bitcast %System.UInt64 addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load i64, i64 addrspace(1)* %1, align 8

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPConvF2F.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPConvF2F.error.txt
@@ -25,8 +25,8 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
@@ -40,8 +40,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
   %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
@@ -75,7 +75,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -90,8 +90,8 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %NullCheck = icmp ne i8 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = load i8, i8 addrspace(1)* %0, align 8
@@ -125,8 +125,8 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
@@ -159,8 +159,8 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -184,8 +184,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
   store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
@@ -195,8 +195,8 @@ entry:
 ; <label>:4                                       ; preds = %1
   %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
   %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
@@ -206,8 +206,8 @@ entry:
   %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
@@ -221,14 +221,14 @@ entry:
 
 ; <label>:17                                      ; preds = %14
   %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
   %21 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
@@ -238,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -249,8 +249,8 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
@@ -261,27 +261,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %30
+ThrowNullRef10:                                   ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -301,7 +301,89 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
-Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
+Successfully read AppDomainSetup.GetUnsecureApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.GetUnsecureApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %NullCheck = icmp eq %"System.String[]" addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %BoundsCheck = icmp uge i64 0, %5
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %6
+
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 3, i32 0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
+  ret %System.String addrspace(1)* %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_Value using LLILCJit
+Successfully read AppDomainSetup.get_Value
+
+define %"System.String[]" addrspace(1)* @AppDomainSetup.get_Value(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.String[]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 18)
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.String[]" addrspace(1)* addrspace(1)*, %"System.String[]" addrspace(1)*)*)(%"System.String[]" addrspace(1)* addrspace(1)* %9, %"System.String[]" addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %11, i32 0, i32 1
+  %14 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %13, align 8
+  ret %"System.String[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -319,8 +401,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -368,16 +450,16 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
   %5 = load i32, i32 addrspace(1)* %4
   %6 = sub i32 %5, 1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -389,7 +471,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -421,8 +503,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
@@ -456,8 +538,8 @@ entry:
 ; <label>:27                                      ; preds = %19
   %28 = load i32, i32* %arg1
   %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
-  br i1 %NullCheck2, label %30, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %29, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %30
 
 ; <label>:30                                      ; preds = %27
   %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
@@ -493,8 +575,8 @@ entry:
 ; <label>:49                                      ; preds = %46
   %50 = load i32, i32* %arg2
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck4, label %52, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
@@ -517,11 +599,11 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %27
+ThrowNullRef2:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %49
+ThrowNullRef4:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -544,16 +626,16 @@ entry:
   %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %0)
   store %System.String addrspace(1)* %1, %System.String addrspace(1)** %loc0
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 2
   %5 = bitcast [0 x i16] addrspace(1)* %4 to i16 addrspace(1)*
   store i16 addrspace(1)* %5, i16 addrspace(1)** %loc1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %3
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2
@@ -580,7 +662,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -691,15 +773,15 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %NullCheck132 = icmp ne i8* %21, null
-  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+  %NullCheck131 = icmp eq i8* %21, null
+  br i1 %NullCheck131, label %ThrowNullRef132, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = load i8, i8* %21, align 8
   %24 = zext i8 %23 to i32
   %25 = trunc i32 %24 to i8
-  %NullCheck134 = icmp ne i8* %20, null
-  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+  %NullCheck133 = icmp eq i8* %20, null
+  br i1 %NullCheck133, label %ThrowNullRef134, label %26
 
 ; <label>:26                                      ; preds = %22
   store i8 %25, i8* %20, align 8
@@ -709,16 +791,16 @@ entry:
   %28 = load i8*, i8** %arg0
   %29 = load i8*, i8** %arg1
   %30 = bitcast i8* %29 to i16*
-  %NullCheck128 = icmp ne i16* %30, null
-  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+  %NullCheck127 = icmp eq i16* %30, null
+  br i1 %NullCheck127, label %ThrowNullRef128, label %31
 
 ; <label>:31                                      ; preds = %27
   %32 = load i16, i16* %30, align 8
   %33 = sext i16 %32 to i32
   %34 = bitcast i8* %28 to i16*
   %35 = trunc i32 %33 to i16
-  %NullCheck130 = icmp ne i16* %34, null
-  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+  %NullCheck129 = icmp eq i16* %34, null
+  br i1 %NullCheck129, label %ThrowNullRef130, label %36
 
 ; <label>:36                                      ; preds = %31
   store i16 %35, i16* %34, align 8
@@ -728,16 +810,16 @@ entry:
   %38 = load i8*, i8** %arg0
   %39 = load i8*, i8** %arg1
   %40 = bitcast i8* %39 to i16*
-  %NullCheck120 = icmp ne i16* %40, null
-  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+  %NullCheck119 = icmp eq i16* %40, null
+  br i1 %NullCheck119, label %ThrowNullRef120, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i16, i16* %40, align 8
   %43 = sext i16 %42 to i32
   %44 = bitcast i8* %38 to i16*
   %45 = trunc i32 %43 to i16
-  %NullCheck122 = icmp ne i16* %44, null
-  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+  %NullCheck121 = icmp eq i16* %44, null
+  br i1 %NullCheck121, label %ThrowNullRef122, label %46
 
 ; <label>:46                                      ; preds = %41
   store i16 %45, i16* %44, align 8
@@ -745,15 +827,15 @@ entry:
   %48 = getelementptr inbounds i8, i8* %47, i64 2
   %49 = load i8*, i8** %arg1
   %50 = getelementptr inbounds i8, i8* %49, i64 2
-  %NullCheck124 = icmp ne i8* %50, null
-  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+  %NullCheck123 = icmp eq i8* %50, null
+  br i1 %NullCheck123, label %ThrowNullRef124, label %51
 
 ; <label>:51                                      ; preds = %46
   %52 = load i8, i8* %50, align 8
   %53 = zext i8 %52 to i32
   %54 = trunc i32 %53 to i8
-  %NullCheck126 = icmp ne i8* %48, null
-  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+  %NullCheck125 = icmp eq i8* %48, null
+  br i1 %NullCheck125, label %ThrowNullRef126, label %55
 
 ; <label>:55                                      ; preds = %51
   store i8 %54, i8* %48, align 8
@@ -763,14 +845,14 @@ entry:
   %57 = load i8*, i8** %arg0
   %58 = load i8*, i8** %arg1
   %59 = bitcast i8* %58 to i32*
-  %NullCheck116 = icmp ne i32* %59, null
-  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+  %NullCheck115 = icmp eq i32* %59, null
+  br i1 %NullCheck115, label %ThrowNullRef116, label %60
 
 ; <label>:60                                      ; preds = %56
   %61 = load i32, i32* %59, align 8
   %62 = bitcast i8* %57 to i32*
-  %NullCheck118 = icmp ne i32* %62, null
-  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+  %NullCheck117 = icmp eq i32* %62, null
+  br i1 %NullCheck117, label %ThrowNullRef118, label %63
 
 ; <label>:63                                      ; preds = %60
   store i32 %61, i32* %62, align 8
@@ -780,14 +862,14 @@ entry:
   %65 = load i8*, i8** %arg0
   %66 = load i8*, i8** %arg1
   %67 = bitcast i8* %66 to i32*
-  %NullCheck108 = icmp ne i32* %67, null
-  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+  %NullCheck107 = icmp eq i32* %67, null
+  br i1 %NullCheck107, label %ThrowNullRef108, label %68
 
 ; <label>:68                                      ; preds = %64
   %69 = load i32, i32* %67, align 8
   %70 = bitcast i8* %65 to i32*
-  %NullCheck110 = icmp ne i32* %70, null
-  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+  %NullCheck109 = icmp eq i32* %70, null
+  br i1 %NullCheck109, label %ThrowNullRef110, label %71
 
 ; <label>:71                                      ; preds = %68
   store i32 %69, i32* %70, align 8
@@ -795,15 +877,15 @@ entry:
   %73 = getelementptr inbounds i8, i8* %72, i64 4
   %74 = load i8*, i8** %arg1
   %75 = getelementptr inbounds i8, i8* %74, i64 4
-  %NullCheck112 = icmp ne i8* %75, null
-  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+  %NullCheck111 = icmp eq i8* %75, null
+  br i1 %NullCheck111, label %ThrowNullRef112, label %76
 
 ; <label>:76                                      ; preds = %71
   %77 = load i8, i8* %75, align 8
   %78 = zext i8 %77 to i32
   %79 = trunc i32 %78 to i8
-  %NullCheck114 = icmp ne i8* %73, null
-  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+  %NullCheck113 = icmp eq i8* %73, null
+  br i1 %NullCheck113, label %ThrowNullRef114, label %80
 
 ; <label>:80                                      ; preds = %76
   store i8 %79, i8* %73, align 8
@@ -813,14 +895,14 @@ entry:
   %82 = load i8*, i8** %arg0
   %83 = load i8*, i8** %arg1
   %84 = bitcast i8* %83 to i32*
-  %NullCheck100 = icmp ne i32* %84, null
-  br i1 %NullCheck100, label %85, label %ThrowNullRef99
+  %NullCheck99 = icmp eq i32* %84, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %85
 
 ; <label>:85                                      ; preds = %81
   %86 = load i32, i32* %84, align 8
   %87 = bitcast i8* %82 to i32*
-  %NullCheck102 = icmp ne i32* %87, null
-  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+  %NullCheck101 = icmp eq i32* %87, null
+  br i1 %NullCheck101, label %ThrowNullRef102, label %88
 
 ; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
@@ -829,16 +911,16 @@ entry:
   %91 = load i8*, i8** %arg1
   %92 = getelementptr inbounds i8, i8* %91, i64 4
   %93 = bitcast i8* %92 to i16*
-  %NullCheck104 = icmp ne i16* %93, null
-  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+  %NullCheck103 = icmp eq i16* %93, null
+  br i1 %NullCheck103, label %ThrowNullRef104, label %94
 
 ; <label>:94                                      ; preds = %88
   %95 = load i16, i16* %93, align 8
   %96 = sext i16 %95 to i32
   %97 = bitcast i8* %90 to i16*
   %98 = trunc i32 %96 to i16
-  %NullCheck106 = icmp ne i16* %97, null
-  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+  %NullCheck105 = icmp eq i16* %97, null
+  br i1 %NullCheck105, label %ThrowNullRef106, label %99
 
 ; <label>:99                                      ; preds = %94
   store i16 %98, i16* %97, align 8
@@ -848,14 +930,14 @@ entry:
   %101 = load i8*, i8** %arg0
   %102 = load i8*, i8** %arg1
   %103 = bitcast i8* %102 to i32*
-  %NullCheck88 = icmp ne i32* %103, null
-  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+  %NullCheck87 = icmp eq i32* %103, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %104
 
 ; <label>:104                                     ; preds = %100
   %105 = load i32, i32* %103, align 8
   %106 = bitcast i8* %101 to i32*
-  %NullCheck90 = icmp ne i32* %106, null
-  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+  %NullCheck89 = icmp eq i32* %106, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %107
 
 ; <label>:107                                     ; preds = %104
   store i32 %105, i32* %106, align 8
@@ -864,16 +946,16 @@ entry:
   %110 = load i8*, i8** %arg1
   %111 = getelementptr inbounds i8, i8* %110, i64 4
   %112 = bitcast i8* %111 to i16*
-  %NullCheck92 = icmp ne i16* %112, null
-  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+  %NullCheck91 = icmp eq i16* %112, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %113
 
 ; <label>:113                                     ; preds = %107
   %114 = load i16, i16* %112, align 8
   %115 = sext i16 %114 to i32
   %116 = bitcast i8* %109 to i16*
   %117 = trunc i32 %115 to i16
-  %NullCheck94 = icmp ne i16* %116, null
-  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+  %NullCheck93 = icmp eq i16* %116, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %118
 
 ; <label>:118                                     ; preds = %113
   store i16 %117, i16* %116, align 8
@@ -881,15 +963,15 @@ entry:
   %120 = getelementptr inbounds i8, i8* %119, i64 6
   %121 = load i8*, i8** %arg1
   %122 = getelementptr inbounds i8, i8* %121, i64 6
-  %NullCheck96 = icmp ne i8* %122, null
-  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+  %NullCheck95 = icmp eq i8* %122, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %123
 
 ; <label>:123                                     ; preds = %118
   %124 = load i8, i8* %122, align 8
   %125 = zext i8 %124 to i32
   %126 = trunc i32 %125 to i8
-  %NullCheck98 = icmp ne i8* %120, null
-  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+  %NullCheck97 = icmp eq i8* %120, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %127
 
 ; <label>:127                                     ; preds = %123
   store i8 %126, i8* %120, align 8
@@ -899,14 +981,14 @@ entry:
   %129 = load i8*, i8** %arg0
   %130 = load i8*, i8** %arg1
   %131 = bitcast i8* %130 to i64*
-  %NullCheck84 = icmp ne i64* %131, null
-  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+  %NullCheck83 = icmp eq i64* %131, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %132
 
 ; <label>:132                                     ; preds = %128
   %133 = load i64, i64* %131, align 8
   %134 = bitcast i8* %129 to i64*
-  %NullCheck86 = icmp ne i64* %134, null
-  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+  %NullCheck85 = icmp eq i64* %134, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %135
 
 ; <label>:135                                     ; preds = %132
   store i64 %133, i64* %134, align 8
@@ -916,14 +998,14 @@ entry:
   %137 = load i8*, i8** %arg0
   %138 = load i8*, i8** %arg1
   %139 = bitcast i8* %138 to i64*
-  %NullCheck76 = icmp ne i64* %139, null
-  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+  %NullCheck75 = icmp eq i64* %139, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %140
 
 ; <label>:140                                     ; preds = %136
   %141 = load i64, i64* %139, align 8
   %142 = bitcast i8* %137 to i64*
-  %NullCheck78 = icmp ne i64* %142, null
-  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+  %NullCheck77 = icmp eq i64* %142, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %143
 
 ; <label>:143                                     ; preds = %140
   store i64 %141, i64* %142, align 8
@@ -931,15 +1013,15 @@ entry:
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %NullCheck80 = icmp ne i8* %147, null
-  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+  %NullCheck79 = icmp eq i8* %147, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %148
 
 ; <label>:148                                     ; preds = %143
   %149 = load i8, i8* %147, align 8
   %150 = zext i8 %149 to i32
   %151 = trunc i32 %150 to i8
-  %NullCheck82 = icmp ne i8* %145, null
-  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+  %NullCheck81 = icmp eq i8* %145, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %152
 
 ; <label>:152                                     ; preds = %148
   store i8 %151, i8* %145, align 8
@@ -949,14 +1031,14 @@ entry:
   %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
   %156 = bitcast i8* %155 to i64*
-  %NullCheck68 = icmp ne i64* %156, null
-  br i1 %NullCheck68, label %157, label %ThrowNullRef67
+  %NullCheck67 = icmp eq i64* %156, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %157
 
 ; <label>:157                                     ; preds = %153
   %158 = load i64, i64* %156, align 8
   %159 = bitcast i8* %154 to i64*
-  %NullCheck70 = icmp ne i64* %159, null
-  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+  %NullCheck69 = icmp eq i64* %159, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %160
 
 ; <label>:160                                     ; preds = %157
   store i64 %158, i64* %159, align 8
@@ -965,16 +1047,16 @@ entry:
   %163 = load i8*, i8** %arg1
   %164 = getelementptr inbounds i8, i8* %163, i64 8
   %165 = bitcast i8* %164 to i16*
-  %NullCheck72 = icmp ne i16* %165, null
-  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+  %NullCheck71 = icmp eq i16* %165, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %166
 
 ; <label>:166                                     ; preds = %160
   %167 = load i16, i16* %165, align 8
   %168 = sext i16 %167 to i32
   %169 = bitcast i8* %162 to i16*
   %170 = trunc i32 %168 to i16
-  %NullCheck74 = icmp ne i16* %169, null
-  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+  %NullCheck73 = icmp eq i16* %169, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %171
 
 ; <label>:171                                     ; preds = %166
   store i16 %170, i16* %169, align 8
@@ -984,14 +1066,14 @@ entry:
   %173 = load i8*, i8** %arg0
   %174 = load i8*, i8** %arg1
   %175 = bitcast i8* %174 to i64*
-  %NullCheck56 = icmp ne i64* %175, null
-  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+  %NullCheck55 = icmp eq i64* %175, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %176
 
 ; <label>:176                                     ; preds = %172
   %177 = load i64, i64* %175, align 8
   %178 = bitcast i8* %173 to i64*
-  %NullCheck58 = icmp ne i64* %178, null
-  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+  %NullCheck57 = icmp eq i64* %178, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %179
 
 ; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
@@ -1000,16 +1082,16 @@ entry:
   %182 = load i8*, i8** %arg1
   %183 = getelementptr inbounds i8, i8* %182, i64 8
   %184 = bitcast i8* %183 to i16*
-  %NullCheck60 = icmp ne i16* %184, null
-  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+  %NullCheck59 = icmp eq i16* %184, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %185
 
 ; <label>:185                                     ; preds = %179
   %186 = load i16, i16* %184, align 8
   %187 = sext i16 %186 to i32
   %188 = bitcast i8* %181 to i16*
   %189 = trunc i32 %187 to i16
-  %NullCheck62 = icmp ne i16* %188, null
-  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+  %NullCheck61 = icmp eq i16* %188, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %190
 
 ; <label>:190                                     ; preds = %185
   store i16 %189, i16* %188, align 8
@@ -1017,15 +1099,15 @@ entry:
   %192 = getelementptr inbounds i8, i8* %191, i64 10
   %193 = load i8*, i8** %arg1
   %194 = getelementptr inbounds i8, i8* %193, i64 10
-  %NullCheck64 = icmp ne i8* %194, null
-  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+  %NullCheck63 = icmp eq i8* %194, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %195
 
 ; <label>:195                                     ; preds = %190
   %196 = load i8, i8* %194, align 8
   %197 = zext i8 %196 to i32
   %198 = trunc i32 %197 to i8
-  %NullCheck66 = icmp ne i8* %192, null
-  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+  %NullCheck65 = icmp eq i8* %192, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %199
 
 ; <label>:199                                     ; preds = %195
   store i8 %198, i8* %192, align 8
@@ -1035,14 +1117,14 @@ entry:
   %201 = load i8*, i8** %arg0
   %202 = load i8*, i8** %arg1
   %203 = bitcast i8* %202 to i64*
-  %NullCheck48 = icmp ne i64* %203, null
-  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+  %NullCheck47 = icmp eq i64* %203, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %204
 
 ; <label>:204                                     ; preds = %200
   %205 = load i64, i64* %203, align 8
   %206 = bitcast i8* %201 to i64*
-  %NullCheck50 = icmp ne i64* %206, null
-  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+  %NullCheck49 = icmp eq i64* %206, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %207
 
 ; <label>:207                                     ; preds = %204
   store i64 %205, i64* %206, align 8
@@ -1051,14 +1133,14 @@ entry:
   %210 = load i8*, i8** %arg1
   %211 = getelementptr inbounds i8, i8* %210, i64 8
   %212 = bitcast i8* %211 to i32*
-  %NullCheck52 = icmp ne i32* %212, null
-  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+  %NullCheck51 = icmp eq i32* %212, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %213
 
 ; <label>:213                                     ; preds = %207
   %214 = load i32, i32* %212, align 8
   %215 = bitcast i8* %209 to i32*
-  %NullCheck54 = icmp ne i32* %215, null
-  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+  %NullCheck53 = icmp eq i32* %215, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %216
 
 ; <label>:216                                     ; preds = %213
   store i32 %214, i32* %215, align 8
@@ -1068,14 +1150,14 @@ entry:
   %218 = load i8*, i8** %arg0
   %219 = load i8*, i8** %arg1
   %220 = bitcast i8* %219 to i64*
-  %NullCheck36 = icmp ne i64* %220, null
-  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64* %220, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %221
 
 ; <label>:221                                     ; preds = %217
   %222 = load i64, i64* %220, align 8
   %223 = bitcast i8* %218 to i64*
-  %NullCheck38 = icmp ne i64* %223, null
-  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+  %NullCheck37 = icmp eq i64* %223, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %224
 
 ; <label>:224                                     ; preds = %221
   store i64 %222, i64* %223, align 8
@@ -1084,14 +1166,14 @@ entry:
   %227 = load i8*, i8** %arg1
   %228 = getelementptr inbounds i8, i8* %227, i64 8
   %229 = bitcast i8* %228 to i32*
-  %NullCheck40 = icmp ne i32* %229, null
-  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i32* %229, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %230
 
 ; <label>:230                                     ; preds = %224
   %231 = load i32, i32* %229, align 8
   %232 = bitcast i8* %226 to i32*
-  %NullCheck42 = icmp ne i32* %232, null
-  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+  %NullCheck41 = icmp eq i32* %232, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %233
 
 ; <label>:233                                     ; preds = %230
   store i32 %231, i32* %232, align 8
@@ -1099,15 +1181,15 @@ entry:
   %235 = getelementptr inbounds i8, i8* %234, i64 12
   %236 = load i8*, i8** %arg1
   %237 = getelementptr inbounds i8, i8* %236, i64 12
-  %NullCheck44 = icmp ne i8* %237, null
-  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i8* %237, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %238
 
 ; <label>:238                                     ; preds = %233
   %239 = load i8, i8* %237, align 8
   %240 = zext i8 %239 to i32
   %241 = trunc i32 %240 to i8
-  %NullCheck46 = icmp ne i8* %235, null
-  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+  %NullCheck45 = icmp eq i8* %235, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %242
 
 ; <label>:242                                     ; preds = %238
   store i8 %241, i8* %235, align 8
@@ -1117,14 +1199,14 @@ entry:
   %244 = load i8*, i8** %arg0
   %245 = load i8*, i8** %arg1
   %246 = bitcast i8* %245 to i64*
-  %NullCheck24 = icmp ne i64* %246, null
-  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64* %246, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %247
 
 ; <label>:247                                     ; preds = %243
   %248 = load i64, i64* %246, align 8
   %249 = bitcast i8* %244 to i64*
-  %NullCheck26 = icmp ne i64* %249, null
-  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64* %249, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %250
 
 ; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
@@ -1133,14 +1215,14 @@ entry:
   %253 = load i8*, i8** %arg1
   %254 = getelementptr inbounds i8, i8* %253, i64 8
   %255 = bitcast i8* %254 to i32*
-  %NullCheck28 = icmp ne i32* %255, null
-  br i1 %NullCheck28, label %256, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i32* %255, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %256
 
 ; <label>:256                                     ; preds = %250
   %257 = load i32, i32* %255, align 8
   %258 = bitcast i8* %252 to i32*
-  %NullCheck30 = icmp ne i32* %258, null
-  br i1 %NullCheck30, label %259, label %ThrowNullRef29
+  %NullCheck29 = icmp eq i32* %258, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %259
 
 ; <label>:259                                     ; preds = %256
   store i32 %257, i32* %258, align 8
@@ -1149,16 +1231,16 @@ entry:
   %262 = load i8*, i8** %arg1
   %263 = getelementptr inbounds i8, i8* %262, i64 12
   %264 = bitcast i8* %263 to i16*
-  %NullCheck32 = icmp ne i16* %264, null
-  br i1 %NullCheck32, label %265, label %ThrowNullRef31
+  %NullCheck31 = icmp eq i16* %264, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %265
 
 ; <label>:265                                     ; preds = %259
   %266 = load i16, i16* %264, align 8
   %267 = sext i16 %266 to i32
   %268 = bitcast i8* %261 to i16*
   %269 = trunc i32 %267 to i16
-  %NullCheck34 = icmp ne i16* %268, null
-  br i1 %NullCheck34, label %270, label %ThrowNullRef33
+  %NullCheck33 = icmp eq i16* %268, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %270
 
 ; <label>:270                                     ; preds = %265
   store i16 %269, i16* %268, align 8
@@ -1168,14 +1250,14 @@ entry:
   %272 = load i8*, i8** %arg0
   %273 = load i8*, i8** %arg1
   %274 = bitcast i8* %273 to i64*
-  %NullCheck8 = icmp ne i64* %274, null
-  br i1 %NullCheck8, label %275, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64* %274, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %275
 
 ; <label>:275                                     ; preds = %271
   %276 = load i64, i64* %274, align 8
   %277 = bitcast i8* %272 to i64*
-  %NullCheck10 = icmp ne i64* %277, null
-  br i1 %NullCheck10, label %278, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %277, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %278
 
 ; <label>:278                                     ; preds = %275
   store i64 %276, i64* %277, align 8
@@ -1184,14 +1266,14 @@ entry:
   %281 = load i8*, i8** %arg1
   %282 = getelementptr inbounds i8, i8* %281, i64 8
   %283 = bitcast i8* %282 to i32*
-  %NullCheck12 = icmp ne i32* %283, null
-  br i1 %NullCheck12, label %284, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i32* %283, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %284
 
 ; <label>:284                                     ; preds = %278
   %285 = load i32, i32* %283, align 8
   %286 = bitcast i8* %280 to i32*
-  %NullCheck14 = icmp ne i32* %286, null
-  br i1 %NullCheck14, label %287, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i32* %286, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %287
 
 ; <label>:287                                     ; preds = %284
   store i32 %285, i32* %286, align 8
@@ -1200,16 +1282,16 @@ entry:
   %290 = load i8*, i8** %arg1
   %291 = getelementptr inbounds i8, i8* %290, i64 12
   %292 = bitcast i8* %291 to i16*
-  %NullCheck16 = icmp ne i16* %292, null
-  br i1 %NullCheck16, label %293, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i16* %292, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %293
 
 ; <label>:293                                     ; preds = %287
   %294 = load i16, i16* %292, align 8
   %295 = sext i16 %294 to i32
   %296 = bitcast i8* %289 to i16*
   %297 = trunc i32 %295 to i16
-  %NullCheck18 = icmp ne i16* %296, null
-  br i1 %NullCheck18, label %298, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i16* %296, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %298
 
 ; <label>:298                                     ; preds = %293
   store i16 %297, i16* %296, align 8
@@ -1217,15 +1299,15 @@ entry:
   %300 = getelementptr inbounds i8, i8* %299, i64 14
   %301 = load i8*, i8** %arg1
   %302 = getelementptr inbounds i8, i8* %301, i64 14
-  %NullCheck20 = icmp ne i8* %302, null
-  br i1 %NullCheck20, label %303, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i8* %302, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %303
 
 ; <label>:303                                     ; preds = %298
   %304 = load i8, i8* %302, align 8
   %305 = zext i8 %304 to i32
   %306 = trunc i32 %305 to i8
-  %NullCheck22 = icmp ne i8* %300, null
-  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i8* %300, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %307
 
 ; <label>:307                                     ; preds = %303
   store i8 %306, i8* %300, align 8
@@ -1235,14 +1317,14 @@ entry:
   %309 = load i8*, i8** %arg0
   %310 = load i8*, i8** %arg1
   %311 = bitcast i8* %310 to i64*
-  %NullCheck = icmp ne i64* %311, null
-  br i1 %NullCheck, label %312, label %ThrowNullRef
+  %NullCheck = icmp eq i64* %311, null
+  br i1 %NullCheck, label %ThrowNullRef, label %312
 
 ; <label>:312                                     ; preds = %308
   %313 = load i64, i64* %311, align 8
   %314 = bitcast i8* %309 to i64*
-  %NullCheck2 = icmp ne i64* %314, null
-  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64* %314, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %315
 
 ; <label>:315                                     ; preds = %312
   store i64 %313, i64* %314, align 8
@@ -1251,14 +1333,14 @@ entry:
   %318 = load i8*, i8** %arg1
   %319 = getelementptr inbounds i8, i8* %318, i64 8
   %320 = bitcast i8* %319 to i64*
-  %NullCheck4 = icmp ne i64* %320, null
-  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64* %320, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %321
 
 ; <label>:321                                     ; preds = %315
   %322 = load i64, i64* %320, align 8
   %323 = bitcast i8* %317 to i64*
-  %NullCheck6 = icmp ne i64* %323, null
-  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64* %323, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %324
 
 ; <label>:324                                     ; preds = %321
   store i64 %322, i64* %323, align 8
@@ -1286,15 +1368,15 @@ entry:
 ; <label>:338                                     ; preds = %333
   %339 = load i8*, i8** %arg0
   %340 = load i8*, i8** %arg1
-  %NullCheck136 = icmp ne i8* %340, null
-  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+  %NullCheck135 = icmp eq i8* %340, null
+  br i1 %NullCheck135, label %ThrowNullRef136, label %341
 
 ; <label>:341                                     ; preds = %338
   %342 = load i8, i8* %340, align 8
   %343 = zext i8 %342 to i32
   %344 = trunc i32 %343 to i8
-  %NullCheck138 = icmp ne i8* %339, null
-  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+  %NullCheck137 = icmp eq i8* %339, null
+  br i1 %NullCheck137, label %ThrowNullRef138, label %345
 
 ; <label>:345                                     ; preds = %341
   store i8 %344, i8* %339, align 8
@@ -1317,16 +1399,16 @@ entry:
   %357 = load i8*, i8** %arg0
   %358 = load i8*, i8** %arg1
   %359 = bitcast i8* %358 to i16*
-  %NullCheck140 = icmp ne i16* %359, null
-  br i1 %NullCheck140, label %360, label %ThrowNullRef139
+  %NullCheck139 = icmp eq i16* %359, null
+  br i1 %NullCheck139, label %ThrowNullRef140, label %360
 
 ; <label>:360                                     ; preds = %356
   %361 = load i16, i16* %359, align 8
   %362 = sext i16 %361 to i32
   %363 = bitcast i8* %357 to i16*
   %364 = trunc i32 %362 to i16
-  %NullCheck142 = icmp ne i16* %363, null
-  br i1 %NullCheck142, label %365, label %ThrowNullRef141
+  %NullCheck141 = icmp eq i16* %363, null
+  br i1 %NullCheck141, label %ThrowNullRef142, label %365
 
 ; <label>:365                                     ; preds = %360
   store i16 %364, i16* %363, align 8
@@ -1352,14 +1434,14 @@ entry:
   %378 = load i8*, i8** %arg0
   %379 = load i8*, i8** %arg1
   %380 = bitcast i8* %379 to i32*
-  %NullCheck144 = icmp ne i32* %380, null
-  br i1 %NullCheck144, label %381, label %ThrowNullRef143
+  %NullCheck143 = icmp eq i32* %380, null
+  br i1 %NullCheck143, label %ThrowNullRef144, label %381
 
 ; <label>:381                                     ; preds = %377
   %382 = load i32, i32* %380, align 8
   %383 = bitcast i8* %378 to i32*
-  %NullCheck146 = icmp ne i32* %383, null
-  br i1 %NullCheck146, label %384, label %ThrowNullRef145
+  %NullCheck145 = icmp eq i32* %383, null
+  br i1 %NullCheck145, label %ThrowNullRef146, label %384
 
 ; <label>:384                                     ; preds = %381
   store i32 %382, i32* %383, align 8
@@ -1384,14 +1466,14 @@ entry:
   %395 = load i8*, i8** %arg0
   %396 = load i8*, i8** %arg1
   %397 = bitcast i8* %396 to i64*
-  %NullCheck164 = icmp ne i64* %397, null
-  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+  %NullCheck163 = icmp eq i64* %397, null
+  br i1 %NullCheck163, label %ThrowNullRef164, label %398
 
 ; <label>:398                                     ; preds = %394
   %399 = load i64, i64* %397, align 8
   %400 = bitcast i8* %395 to i64*
-  %NullCheck166 = icmp ne i64* %400, null
-  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+  %NullCheck165 = icmp eq i64* %400, null
+  br i1 %NullCheck165, label %ThrowNullRef166, label %401
 
 ; <label>:401                                     ; preds = %398
   store i64 %399, i64* %400, align 8
@@ -1400,14 +1482,14 @@ entry:
   %404 = load i8*, i8** %arg1
   %405 = getelementptr inbounds i8, i8* %404, i64 8
   %406 = bitcast i8* %405 to i64*
-  %NullCheck168 = icmp ne i64* %406, null
-  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+  %NullCheck167 = icmp eq i64* %406, null
+  br i1 %NullCheck167, label %ThrowNullRef168, label %407
 
 ; <label>:407                                     ; preds = %401
   %408 = load i64, i64* %406, align 8
   %409 = bitcast i8* %403 to i64*
-  %NullCheck170 = icmp ne i64* %409, null
-  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+  %NullCheck169 = icmp eq i64* %409, null
+  br i1 %NullCheck169, label %ThrowNullRef170, label %410
 
 ; <label>:410                                     ; preds = %407
   store i64 %408, i64* %409, align 8
@@ -1437,14 +1519,14 @@ entry:
   %425 = load i8*, i8** %arg0
   %426 = load i8*, i8** %arg1
   %427 = bitcast i8* %426 to i64*
-  %NullCheck148 = icmp ne i64* %427, null
-  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+  %NullCheck147 = icmp eq i64* %427, null
+  br i1 %NullCheck147, label %ThrowNullRef148, label %428
 
 ; <label>:428                                     ; preds = %424
   %429 = load i64, i64* %427, align 8
   %430 = bitcast i8* %425 to i64*
-  %NullCheck150 = icmp ne i64* %430, null
-  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+  %NullCheck149 = icmp eq i64* %430, null
+  br i1 %NullCheck149, label %ThrowNullRef150, label %431
 
 ; <label>:431                                     ; preds = %428
   store i64 %429, i64* %430, align 8
@@ -1466,14 +1548,14 @@ entry:
   %441 = load i8*, i8** %arg0
   %442 = load i8*, i8** %arg1
   %443 = bitcast i8* %442 to i32*
-  %NullCheck152 = icmp ne i32* %443, null
-  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+  %NullCheck151 = icmp eq i32* %443, null
+  br i1 %NullCheck151, label %ThrowNullRef152, label %444
 
 ; <label>:444                                     ; preds = %440
   %445 = load i32, i32* %443, align 8
   %446 = bitcast i8* %441 to i32*
-  %NullCheck154 = icmp ne i32* %446, null
-  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+  %NullCheck153 = icmp eq i32* %446, null
+  br i1 %NullCheck153, label %ThrowNullRef154, label %447
 
 ; <label>:447                                     ; preds = %444
   store i32 %445, i32* %446, align 8
@@ -1495,16 +1577,16 @@ entry:
   %457 = load i8*, i8** %arg0
   %458 = load i8*, i8** %arg1
   %459 = bitcast i8* %458 to i16*
-  %NullCheck156 = icmp ne i16* %459, null
-  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+  %NullCheck155 = icmp eq i16* %459, null
+  br i1 %NullCheck155, label %ThrowNullRef156, label %460
 
 ; <label>:460                                     ; preds = %456
   %461 = load i16, i16* %459, align 8
   %462 = sext i16 %461 to i32
   %463 = bitcast i8* %457 to i16*
   %464 = trunc i32 %462 to i16
-  %NullCheck158 = icmp ne i16* %463, null
-  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+  %NullCheck157 = icmp eq i16* %463, null
+  br i1 %NullCheck157, label %ThrowNullRef158, label %465
 
 ; <label>:465                                     ; preds = %460
   store i16 %464, i16* %463, align 8
@@ -1525,15 +1607,15 @@ entry:
 ; <label>:474                                     ; preds = %470
   %475 = load i8*, i8** %arg0
   %476 = load i8*, i8** %arg1
-  %NullCheck160 = icmp ne i8* %476, null
-  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+  %NullCheck159 = icmp eq i8* %476, null
+  br i1 %NullCheck159, label %ThrowNullRef160, label %477
 
 ; <label>:477                                     ; preds = %474
   %478 = load i8, i8* %476, align 8
   %479 = zext i8 %478 to i32
   %480 = trunc i32 %479 to i8
-  %NullCheck162 = icmp ne i8* %475, null
-  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+  %NullCheck161 = icmp eq i8* %475, null
+  br i1 %NullCheck161, label %ThrowNullRef162, label %481
 
 ; <label>:481                                     ; preds = %477
   store i8 %480, i8* %475, align 8
@@ -1553,343 +1635,343 @@ ThrowNullRef:                                     ; preds = %308
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %312
+ThrowNullRef2:                                    ; preds = %312
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %315
+ThrowNullRef4:                                    ; preds = %315
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %321
+ThrowNullRef6:                                    ; preds = %321
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %271
+ThrowNullRef8:                                    ; preds = %271
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %275
+ThrowNullRef10:                                   ; preds = %275
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %278
+ThrowNullRef12:                                   ; preds = %278
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %284
+ThrowNullRef14:                                   ; preds = %284
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %287
+ThrowNullRef16:                                   ; preds = %287
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %293
+ThrowNullRef18:                                   ; preds = %293
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %298
+ThrowNullRef20:                                   ; preds = %298
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %303
+ThrowNullRef22:                                   ; preds = %303
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %243
+ThrowNullRef24:                                   ; preds = %243
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %247
+ThrowNullRef26:                                   ; preds = %247
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %250
+ThrowNullRef28:                                   ; preds = %250
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %256
+ThrowNullRef30:                                   ; preds = %256
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %259
+ThrowNullRef32:                                   ; preds = %259
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %265
+ThrowNullRef34:                                   ; preds = %265
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %217
+ThrowNullRef36:                                   ; preds = %217
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %221
+ThrowNullRef38:                                   ; preds = %221
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %224
+ThrowNullRef40:                                   ; preds = %224
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %230
+ThrowNullRef42:                                   ; preds = %230
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %233
+ThrowNullRef44:                                   ; preds = %233
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %238
+ThrowNullRef46:                                   ; preds = %238
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %200
+ThrowNullRef48:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %204
+ThrowNullRef50:                                   ; preds = %204
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %207
+ThrowNullRef52:                                   ; preds = %207
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %213
+ThrowNullRef54:                                   ; preds = %213
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %172
+ThrowNullRef56:                                   ; preds = %172
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %176
+ThrowNullRef58:                                   ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %179
+ThrowNullRef60:                                   ; preds = %179
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %185
+ThrowNullRef62:                                   ; preds = %185
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %190
+ThrowNullRef64:                                   ; preds = %190
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %195
+ThrowNullRef66:                                   ; preds = %195
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %153
+ThrowNullRef68:                                   ; preds = %153
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %157
+ThrowNullRef70:                                   ; preds = %157
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %160
+ThrowNullRef72:                                   ; preds = %160
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %166
+ThrowNullRef74:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %136
+ThrowNullRef76:                                   ; preds = %136
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %140
+ThrowNullRef78:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %143
+ThrowNullRef80:                                   ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %148
+ThrowNullRef82:                                   ; preds = %148
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %128
+ThrowNullRef84:                                   ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %132
+ThrowNullRef86:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %100
+ThrowNullRef88:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %104
+ThrowNullRef90:                                   ; preds = %104
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %107
+ThrowNullRef92:                                   ; preds = %107
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %113
+ThrowNullRef94:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %118
+ThrowNullRef96:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %123
+ThrowNullRef98:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %81
+ThrowNullRef100:                                  ; preds = %81
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef101:                                  ; preds = %85
+ThrowNullRef102:                                  ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef103:                                  ; preds = %88
+ThrowNullRef104:                                  ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef105:                                  ; preds = %94
+ThrowNullRef106:                                  ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef107:                                  ; preds = %64
+ThrowNullRef108:                                  ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef109:                                  ; preds = %68
+ThrowNullRef110:                                  ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef111:                                  ; preds = %71
+ThrowNullRef112:                                  ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef113:                                  ; preds = %76
+ThrowNullRef114:                                  ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef115:                                  ; preds = %56
+ThrowNullRef116:                                  ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef117:                                  ; preds = %60
+ThrowNullRef118:                                  ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef119:                                  ; preds = %37
+ThrowNullRef120:                                  ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef121:                                  ; preds = %41
+ThrowNullRef122:                                  ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef123:                                  ; preds = %46
+ThrowNullRef124:                                  ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef125:                                  ; preds = %51
+ThrowNullRef126:                                  ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef127:                                  ; preds = %27
+ThrowNullRef128:                                  ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef129:                                  ; preds = %31
+ThrowNullRef130:                                  ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef131:                                  ; preds = %19
+ThrowNullRef132:                                  ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef133:                                  ; preds = %22
+ThrowNullRef134:                                  ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef135:                                  ; preds = %338
+ThrowNullRef136:                                  ; preds = %338
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef137:                                  ; preds = %341
+ThrowNullRef138:                                  ; preds = %341
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef139:                                  ; preds = %356
+ThrowNullRef140:                                  ; preds = %356
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef141:                                  ; preds = %360
+ThrowNullRef142:                                  ; preds = %360
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef143:                                  ; preds = %377
+ThrowNullRef144:                                  ; preds = %377
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef145:                                  ; preds = %381
+ThrowNullRef146:                                  ; preds = %381
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef147:                                  ; preds = %424
+ThrowNullRef148:                                  ; preds = %424
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef149:                                  ; preds = %428
+ThrowNullRef150:                                  ; preds = %428
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef151:                                  ; preds = %440
+ThrowNullRef152:                                  ; preds = %440
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef153:                                  ; preds = %444
+ThrowNullRef154:                                  ; preds = %444
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef155:                                  ; preds = %456
+ThrowNullRef156:                                  ; preds = %456
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef157:                                  ; preds = %460
+ThrowNullRef158:                                  ; preds = %460
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef159:                                  ; preds = %474
+ThrowNullRef160:                                  ; preds = %474
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef161:                                  ; preds = %477
+ThrowNullRef162:                                  ; preds = %477
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef163:                                  ; preds = %394
+ThrowNullRef164:                                  ; preds = %394
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef165:                                  ; preds = %398
+ThrowNullRef166:                                  ; preds = %398
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef167:                                  ; preds = %401
+ThrowNullRef168:                                  ; preds = %401
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef169:                                  ; preds = %407
+ThrowNullRef170:                                  ; preds = %407
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1939,8 +2021,8 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
-  br i1 %NullCheck, label %22, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %ThrowNullRef, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
@@ -1948,8 +2030,8 @@ entry:
   store i32 %24, i32* %loc0
   %25 = load i32, i32* %loc0
   %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %26, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %27
 
 ; <label>:27                                      ; preds = %22
   %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
@@ -1971,7 +2053,7 @@ ThrowNullRef:                                     ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1989,8 +2071,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -2022,15 +2104,15 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2048,16 +2130,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
   %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
   store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %15
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
@@ -2072,8 +2154,8 @@ entry:
   %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
   %29 = ptrtoint i16 addrspace(1)* %28 to i64
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %19
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
@@ -2089,19 +2171,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2114,8 +2196,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
@@ -2128,7 +2210,7 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[loadElem]
+Failed to read AppDomain.PrepareDataForSetup[storeElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
@@ -2202,8 +2284,8 @@ entry:
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
-  br i1 %NullCheck24, label %27, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = load i64, i64 addrspace(1)* %26
@@ -2218,8 +2300,8 @@ entry:
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
-  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
   %41 = load i64, i64 addrspace(1)* %39
@@ -2236,8 +2318,8 @@ entry:
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
-  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
   %54 = load i64, i64 addrspace(1)* %52
@@ -2252,8 +2334,8 @@ entry:
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
   %67 = load i64, i64 addrspace(1)* %65
@@ -2270,8 +2352,8 @@ entry:
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
-  br i1 %NullCheck16, label %79, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
   %80 = load i64, i64 addrspace(1)* %78
@@ -2286,8 +2368,8 @@ entry:
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
-  br i1 %NullCheck18, label %92, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
   %93 = load i64, i64 addrspace(1)* %91
@@ -2304,8 +2386,8 @@ entry:
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
-  br i1 %NullCheck12, label %105, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = load i64, i64 addrspace(1)* %104
@@ -2320,8 +2402,8 @@ entry:
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
-  br i1 %NullCheck14, label %118, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
   %119 = load i64, i64 addrspace(1)* %117
@@ -2337,8 +2419,8 @@ entry:
 
 ; <label>:128                                     ; preds = %20
   %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
-  br i1 %NullCheck4, label %130, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %129, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %130
 
 ; <label>:130                                     ; preds = %128
   %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
@@ -2346,8 +2428,8 @@ entry:
   %133 = load i16, i16 addrspace(1)* %132, align 8
   %134 = zext i16 %133 to i32
   %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
-  br i1 %NullCheck6, label %136, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %135, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %136
 
 ; <label>:136                                     ; preds = %130
   %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
@@ -2360,8 +2442,8 @@ entry:
 
 ; <label>:143                                     ; preds = %136
   %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
-  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %144, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %145
 
 ; <label>:145                                     ; preds = %143
   %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
@@ -2369,8 +2451,8 @@ entry:
   %148 = load i16, i16 addrspace(1)* %147, align 8
   %149 = zext i16 %148 to i32
   %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %150, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %151
 
 ; <label>:151                                     ; preds = %145
   %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
@@ -2388,8 +2470,8 @@ entry:
 
 ; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
-  br i1 %NullCheck, label %163, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %ThrowNullRef, label %163
 
 ; <label>:163                                     ; preds = %161
   %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
@@ -2399,8 +2481,8 @@ entry:
 
 ; <label>:167                                     ; preds = %163
   %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
-  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %168, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %169
 
 ; <label>:169                                     ; preds = %167
   %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
@@ -2432,55 +2514,55 @@ ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %167
+ThrowNullRef2:                                    ; preds = %167
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %128
+ThrowNullRef4:                                    ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %130
+ThrowNullRef6:                                    ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %143
+ThrowNullRef8:                                    ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %145
+ThrowNullRef10:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %102
+ThrowNullRef12:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %105
+ThrowNullRef14:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %76
+ThrowNullRef16:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %79
+ThrowNullRef18:                                   ; preds = %79
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %50
+ThrowNullRef20:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %53
+ThrowNullRef22:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %24
+ThrowNullRef24:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %27
+ThrowNullRef26:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2503,15 +2585,15 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2519,16 +2601,16 @@ entry:
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
   store i32 %8, i32* %loc0
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
   %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
   store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
@@ -2546,16 +2628,16 @@ entry:
 
 ; <label>:23                                      ; preds = %64
   %24 = load i16*, i16** %loc3
-  %NullCheck12 = icmp ne i16* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i16* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
   store i32 %27, i32* %loc5
   %28 = load i16*, i16** %loc4
-  %NullCheck14 = icmp ne i16* %28, null
-  br i1 %NullCheck14, label %29, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %28, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = load i16, i16* %28, align 8
@@ -2620,15 +2702,15 @@ entry:
 
 ; <label>:67                                      ; preds = %64
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
-  br i1 %NullCheck8, label %69, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %68, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %69
 
 ; <label>:69                                      ; preds = %67
   %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
   %71 = load i32, i32 addrspace(1)* %70
   %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
-  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %73
 
 ; <label>:73                                      ; preds = %69
   %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
@@ -2645,31 +2727,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %67
+ThrowNullRef8:                                    ; preds = %67
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %69
+ThrowNullRef10:                                   ; preds = %69
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2710,14 +2792,14 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
   %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
@@ -2730,14 +2812,14 @@ entry:
 
 ; <label>:11                                      ; preds = %4
   %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
   %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
@@ -2749,14 +2831,14 @@ entry:
 
 ; <label>:22                                      ; preds = %16
   %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
   %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
-  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
-  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
@@ -2804,23 +2886,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2836,7 +2918,280 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[loadElem]
+Successfully read RuntimeType.IsAssignableFrom
+
+define i8 @RuntimeType.IsAssignableFrom(%System.RuntimeType addrspace(1)* %param0, %System.Type addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.RuntimeType addrspace(1)*
+  %arg1 = alloca %System.Type addrspace(1)*
+  %loc0 = alloca %System.RuntimeType addrspace(1)*
+  %loc1 = alloca %"System.Type[]" addrspace(1)*
+  %loc2 = alloca i32
+  store %System.RuntimeType addrspace(1)* %param0, %System.RuntimeType addrspace(1)** %this
+  store %System.Type addrspace(1)* %param1, %System.Type addrspace(1)** %arg1
+  %0 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %1 = icmp ne %System.Type addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i8 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %5 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %6 = bitcast %System.Type addrspace(1)* %4 to %System.Object addrspace(1)*
+  %7 = bitcast %System.RuntimeType addrspace(1)* %5 to %System.Object addrspace(1)*
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %6, %System.Object addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %3
+  ret i8 1
+
+; <label>:12                                      ; preds = %3
+  %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 152
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 32
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
+  %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
+  %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
+  store %System.RuntimeType addrspace(1)* %25, %System.RuntimeType addrspace(1)** %loc0
+  %26 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %27 = icmp eq %System.RuntimeType addrspace(1)* %26, null
+  br i1 %27, label %34, label %28
+
+; <label>:28                                      ; preds = %15
+  %29 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %30 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)*)*)(%System.RuntimeType addrspace(1)* %29, %System.RuntimeType addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+; <label>:34                                      ; preds = %15
+  %35 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %36 = call %System.Reflection.Emit.TypeBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Reflection.Emit.TypeBuilder addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %35)
+  %37 = icmp eq %System.Reflection.Emit.TypeBuilder addrspace(1)* %36, null
+  br i1 %37, label %139, label %38
+
+; <label>:38                                      ; preds = %34
+  %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %42
+
+; <label>:42                                      ; preds = %38
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 152
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 40
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
+  %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
+  %53 = zext i8 %52 to i32
+  %54 = icmp eq i32 %53, 0
+  br i1 %54, label %56, label %55
+
+; <label>:55                                      ; preds = %42
+  ret i8 1
+
+; <label>:56                                      ; preds = %42
+  %57 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %58 = bitcast %System.RuntimeType addrspace(1)* %57 to %System.Type addrspace(1)*
+  %59 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %58)
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %64 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.Type addrspace(1)* %63, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = bitcast %System.RuntimeType addrspace(1)* %64 to %System.Type addrspace(1)*
+  %67 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %63, %System.Type addrspace(1)* %66)
+  %68 = zext i8 %67 to i32
+  %69 = trunc i32 %68 to i8
+  ret i8 %69
+
+; <label>:70                                      ; preds = %56
+  %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
+  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %73
+
+; <label>:73                                      ; preds = %70
+  %74 = load i64, i64 addrspace(1)* %72
+  %75 = add i64 %74, 128
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = add i64 %77, 0
+  %79 = inttoptr i64 %78 to i64*
+  %80 = load i64, i64* %79
+  %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
+  %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
+  %83 = call i8 %82(%System.Type addrspace(1)* %81)
+  %84 = zext i8 %83 to i32
+  %85 = icmp eq i32 %84, 0
+  br i1 %85, label %139, label %86
+
+; <label>:86                                      ; preds = %73
+  %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
+  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %89
+
+; <label>:89                                      ; preds = %86
+  %90 = load i64, i64 addrspace(1)* %88
+  %91 = add i64 %90, 128
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = add i64 %93, 24
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
+  %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
+  %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
+  store %"System.Type[]" addrspace(1)* %99, %"System.Type[]" addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %129
+
+; <label>:100                                     ; preds = %132
+  %101 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %102 = load i32, i32* %loc2
+  %NullCheck11 = icmp eq %"System.Type[]" addrspace(1)* %101, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %103
+
+; <label>:103                                     ; preds = %100
+  %104 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 1
+  %105 = load i32, i32 addrspace(1)* %104
+  %106 = zext i32 %105 to i64
+  %107 = zext i32 %102 to i64
+  %BoundsCheck = icmp uge i64 %107, %106
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %108
+
+; <label>:108                                     ; preds = %103
+  %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
+  %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
+  %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
+  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %113
+
+; <label>:113                                     ; preds = %108
+  %114 = load i64, i64 addrspace(1)* %112
+  %115 = add i64 %114, 152
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = add i64 %117, 56
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
+  %123 = zext i8 %122 to i32
+  %124 = icmp ne i32 %123, 0
+  br i1 %124, label %126, label %125
+
+; <label>:125                                     ; preds = %113
+  ret i8 0
+
+; <label>:126                                     ; preds = %113
+  %127 = load i32, i32* %loc2
+  %128 = add i32 %127, 1
+  store i32 %128, i32* %loc2
+  br label %129
+
+; <label>:129                                     ; preds = %89, %126
+  %130 = load i32, i32* %loc2
+  %131 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %NullCheck9 = icmp eq %"System.Type[]" addrspace(1)* %131, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %132
+
+; <label>:132                                     ; preds = %129
+  %133 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %131, i32 0, i32 1
+  %134 = load i32, i32 addrspace(1)* %133
+  %135 = zext i32 %134 to i64
+  %136 = trunc i64 %135 to i32
+  %137 = icmp slt i32 %130, %136
+  br i1 %137, label %100, label %138
+
+; <label>:138                                     ; preds = %132
+  ret i8 1
+
+; <label>:139                                     ; preds = %34, %73
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %129
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %103
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -2893,7 +3248,7 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElem]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -2904,8 +3259,8 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -2997,8 +3352,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
@@ -3059,8 +3414,8 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -3087,8 +3442,8 @@ entry:
 
 ; <label>:17                                      ; preds = %5, %11
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
@@ -3097,8 +3452,8 @@ entry:
 
 ; <label>:22                                      ; preds = %1, %11
   %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
@@ -3109,11 +3464,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %17
+ThrowNullRef2:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %22
+ThrowNullRef4:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3167,15 +3522,15 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
   %15 = load i32, i32 addrspace(1)* %14
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
@@ -3198,7 +3553,7 @@ ThrowNullRef:                                     ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef2:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3232,8 +3587,8 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
@@ -3312,8 +3667,8 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -3327,8 +3682,8 @@ entry:
 ; <label>:5                                       ; preds = %43
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %7 = load i32, i32* %loc1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck6, label %8, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
@@ -3366,8 +3721,8 @@ entry:
 ; <label>:32                                      ; preds = %21, %25
   %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
   %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
-  br i1 %NullCheck8, label %35, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = trunc i32 %34 to i16
@@ -3380,8 +3735,8 @@ entry:
 ; <label>:40                                      ; preds = %1, %35
   %41 = load i32, i32* %loc1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
-  br i1 %NullCheck2, label %43, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %42, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
@@ -3392,8 +3747,8 @@ entry:
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
   %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
-  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
   %51 = load i64, i64 addrspace(1)* %49
@@ -3412,19 +3767,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %40
+ThrowNullRef2:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %47
+ThrowNullRef4:                                    ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %5
+ThrowNullRef6:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %32
+ThrowNullRef8:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3467,8 +3822,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
@@ -3492,11 +3847,391 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(i16* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store i16* %param0, i16** %arg0
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load i32, i32* %arg3
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %42, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %37, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg2
+  %13 = load i32, i32* %arg3
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %37, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %24 = load i32, i32* %arg2
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load i16*, i16** %arg0
+  %35 = load i32, i32* %arg3
+  %36 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %36, i16* %34, i32 %35)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:37                                      ; preds = %5, %16
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %39)
+  %41 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41, %System.String addrspace(1)* %38, %System.String addrspace(1)* %40)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41) #0
+  unreachable
+
+; <label>:42                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
-Failed to read StringBuilder.ToString[loadElemA]
+Successfully read StringBuilder.ToString
+
+define %System.String addrspace(1)* @StringBuilder.ToString(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i16*
+  %loc3 = alloca %"System.Char[]" addrspace(1)*
+  %loc4 = alloca i32
+  %loc5 = alloca i32
+  %loc6 = alloca i16 addrspace(1)*
+  %loc7 = alloca %System.String addrspace(1)*
+  %loc8 = alloca %"System.Char[]" addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %0)
+  %2 = icmp ne i32 %1, 0
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %4
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %6)
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %7)
+  store %System.String addrspace(1)* %8, %System.String addrspace(1)** %loc0
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.Text.StringBuilder addrspace(1)* %9, %System.Text.StringBuilder addrspace(1)** %loc1
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  store %System.String addrspace(1)* %10, %System.String addrspace(1)** %loc7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc7
+  %12 = ptrtoint %System.String addrspace(1)* %11 to i64
+  %13 = icmp eq i64 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %5
+  %15 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %16 = sext i32 %15 to i64
+  %17 = add i64 %12, %16
+  br label %18
+
+; <label>:18                                      ; preds = %5, %14
+  %19 = phi i64 [ %12, %5 ], [ %17, %14 ]
+  %20 = inttoptr i64 %19 to i16*
+  store i16* %20, i16** %loc2
+  br label %21
+
+; <label>:21                                      ; preds = %98, %18
+  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %22, null
+  br i1 %NullCheck, label %ThrowNullRef, label %23
+
+; <label>:23                                      ; preds = %21
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 3
+  %25 = load i32, i32 addrspace(1)* %24, align 8
+  %26 = icmp sle i32 %25, 0
+  br i1 %26, label %96, label %27
+
+; <label>:27                                      ; preds = %23
+  %28 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %28, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %29
+
+; <label>:29                                      ; preds = %27
+  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %28, i32 0, i32 1
+  %31 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %30, align 8
+  store %"System.Char[]" addrspace(1)* %31, %"System.Char[]" addrspace(1)** %loc3
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %33
+
+; <label>:33                                      ; preds = %29
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  store i32 %35, i32* %loc4
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  %39 = load i32, i32 addrspace(1)* %38, align 8
+  store i32 %39, i32* %loc5
+  %40 = load i32, i32* %loc5
+  %41 = load i32, i32* %loc4
+  %42 = add i32 %40, %41
+  %43 = zext i32 %42 to i64
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %45
+
+; <label>:45                                      ; preds = %37
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = sext i32 %47 to i64
+  %49 = icmp sgt i64 %43, %48
+  br i1 %49, label %91, label %50
+
+; <label>:50                                      ; preds = %45
+  %51 = load i32, i32* %loc5
+  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %52, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %53
+
+; <label>:53                                      ; preds = %50
+  %54 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %52, i32 0, i32 1
+  %55 = load i32, i32 addrspace(1)* %54
+  %56 = zext i32 %55 to i64
+  %57 = trunc i64 %56 to i32
+  %58 = icmp ugt i32 %51, %57
+  br i1 %58, label %91, label %59
+
+; <label>:59                                      ; preds = %53
+  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  store %"System.Char[]" addrspace(1)* %60, %"System.Char[]" addrspace(1)** %loc8
+  %61 = icmp eq %"System.Char[]" addrspace(1)* %60, null
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %63, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %64
+
+; <label>:64                                      ; preds = %62
+  %65 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %63, i32 0, i32 1
+  %66 = load i32, i32 addrspace(1)* %65
+  %67 = zext i32 %66 to i64
+  %68 = trunc i64 %67 to i32
+  %69 = icmp ne i32 %68, 0
+  br i1 %69, label %71, label %70
+
+; <label>:70                                      ; preds = %59, %64
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:71                                      ; preds = %64
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %73
+
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %BoundsCheck = icmp uge i64 0, %76
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %77
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %78, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:79                                      ; preds = %70, %77
+  %80 = load i16*, i16** %loc2
+  %81 = load i32, i32* %loc4
+  %82 = sext i32 %81 to i64
+  %83 = mul i64 %82, 2
+  %84 = bitcast i16* %80 to i8*
+  %85 = getelementptr inbounds i8, i8* %84, i64 %83
+  %86 = load i16 addrspace(1)*, i16 addrspace(1)** %loc6
+  %87 = ptrtoint i16 addrspace(1)* %86 to i64
+  %88 = load i32, i32* %loc5
+  %89 = bitcast i8* %85 to i16*
+  %90 = inttoptr i64 %87 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %89, i16* %90, i32 %88)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %96
+
+; <label>:91                                      ; preds = %45, %53
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %94 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %93)
+  %95 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95, %System.String addrspace(1)* %92, %System.String addrspace(1)* %94)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95) #0
+  unreachable
+
+; <label>:96                                      ; preds = %23, %79
+  %97 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %97, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %98
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %97, i32 0, i32 2
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  store %System.Text.StringBuilder addrspace(1)* %100, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %102 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %102, label %21, label %103
+
+; <label>:103                                     ; preds = %98
+  store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc7
+  %104 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  ret %System.String addrspace(1)* %104
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method StringBuilder::get_Length using LLILCJit
+Successfully read StringBuilder.get_Length
+
+define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
+Successfully read RuntimeHelpers.get_OffsetToStringData
+
+define i32 @RuntimeHelpers.get_OffsetToStringData() {
+entry:
+  ret i32 12
+}
+
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
 Successfully read CultureData.CreateCultureData
 
@@ -3514,23 +4249,23 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
   store i8 %4, i8 addrspace(1)* %6
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
@@ -3549,11 +4284,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3566,50 +4301,50 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
   store i32 -1, i32 addrspace(1)* %2
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
   store i32 -1, i32 addrspace(1)* %8
   %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
   store i32 -1, i32 addrspace(1)* %14
   %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
   store i32 -1, i32 addrspace(1)* %17
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
@@ -3623,27 +4358,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3675,7 +4410,136 @@ Failed to read Dictionary`2.Insert[non-const derefAddress]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
 Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
-Failed to read HashHelpers.GetPrime[loadElem]
+Successfully read HashHelpers.GetPrime
+
+define i32 @HashHelpers.GetPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %6, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5, %System.String addrspace(1)* %4)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5) #0
+  unreachable
+
+; <label>:6                                       ; preds = %entry
+  store i32 0, i32* %loc0
+  br label %29
+
+; <label>:7                                       ; preds = %35
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 1296
+  %10 = addrspacecast i8 addrspace(1)* %9 to %"System.Int32[]" addrspace(1)**
+  %11 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %10
+  %12 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Int32[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = zext i32 %15 to i64
+  %17 = zext i32 %12 to i64
+  %BoundsCheck = icmp uge i64 %17, %16
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 3, i32 %12
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  store i32 %20, i32* %loc1
+  %21 = load i32, i32* %loc1
+  %22 = load i32, i32* %arg0
+  %23 = icmp slt i32 %21, %22
+  br i1 %23, label %26, label %24
+
+; <label>:24                                      ; preds = %18
+  %25 = load i32, i32* %loc1
+  ret i32 %25
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %loc0
+  %28 = add i32 %27, 1
+  store i32 %28, i32* %loc0
+  br label %29
+
+; <label>:29                                      ; preds = %6, %26
+  %30 = load i32, i32* %loc0
+  %31 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %32 = getelementptr inbounds i8, i8 addrspace(1)* %31, i64 1296
+  %33 = addrspacecast i8 addrspace(1)* %32 to %"System.Int32[]" addrspace(1)**
+  %34 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %33
+  %NullCheck = icmp eq %"System.Int32[]" addrspace(1)* %34, null
+  br i1 %NullCheck, label %ThrowNullRef, label %35
+
+; <label>:35                                      ; preds = %29
+  %36 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %34, i32 0, i32 1
+  %37 = load i32, i32 addrspace(1)* %36
+  %38 = zext i32 %37 to i64
+  %39 = trunc i64 %38 to i32
+  %40 = icmp slt i32 %30, %39
+  br i1 %40, label %7, label %41
+
+; <label>:41                                      ; preds = %35
+  %42 = load i32, i32* %arg0
+  %43 = or i32 %42, 1
+  store i32 %43, i32* %loc2
+  br label %59
+
+; <label>:44                                      ; preds = %59
+  %45 = load i32, i32* %loc2
+  %46 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %45)
+  %47 = zext i8 %46 to i32
+  %48 = icmp eq i32 %47, 0
+  br i1 %48, label %56, label %49
+
+; <label>:49                                      ; preds = %44
+  %50 = load i32, i32* %loc2
+  %51 = sub i32 %50, 1
+  %52 = srem i32 %51, 101
+  %53 = icmp eq i32 %52, 0
+  br i1 %53, label %56, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = load i32, i32* %loc2
+  ret i32 %55
+
+; <label>:56                                      ; preds = %44, %49
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %57, 2
+  store i32 %58, i32* %loc2
+  br label %59
+
+; <label>:59                                      ; preds = %41, %56
+  %60 = load i32, i32* %loc2
+  %61 = icmp slt i32 %60, 2147483647
+  br i1 %61, label %44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load i32, i32* %arg0
+  ret i32 %63
+
+ThrowNullRef:                                     ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
 Successfully read GenericEqualityComparer`1.GetHashCode
 
@@ -3694,14 +4558,14 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
   %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load i64, i64 addrspace(1)* %7
@@ -3720,7 +4584,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3750,8 +4614,8 @@ entry:
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
@@ -3796,8 +4660,8 @@ entry:
   %35 = bitcast i16* %34 to i8*
   %36 = getelementptr inbounds i8, i8* %35, i64 2
   %37 = bitcast i8* %36 to i16*
-  %NullCheck4 = icmp ne i16* %37, null
-  br i1 %NullCheck4, label %38, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %37, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %38
 
 ; <label>:38                                      ; preds = %27
   %39 = load i16, i16* %37, align 8
@@ -3824,8 +4688,8 @@ entry:
 
 ; <label>:54                                      ; preds = %22, %43
   %55 = load i16*, i16** %loc4
-  %NullCheck2 = icmp ne i16* %55, null
-  br i1 %NullCheck2, label %56, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i16* %55, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %56
 
 ; <label>:56                                      ; preds = %54
   %57 = load i16, i16* %55, align 8
@@ -3850,11 +4714,11 @@ ThrowNullRef:                                     ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %54
+ThrowNullRef2:                                    ; preds = %54
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %27
+ThrowNullRef4:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3871,8 +4735,8 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -3907,8 +4771,8 @@ entry:
 
 ; <label>:26                                      ; preds = %19
   %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
-  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %28
 
 ; <label>:28                                      ; preds = %26
   %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
@@ -3920,7 +4784,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3972,8 +4836,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
@@ -3984,26 +4848,26 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
-  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
@@ -4014,8 +4878,8 @@ entry:
 ; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
@@ -4024,8 +4888,8 @@ entry:
 
 ; <label>:25                                      ; preds = %1, %16, %23
   %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
-  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
@@ -4036,27 +4900,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %20
+ThrowNullRef10:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4069,8 +4933,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -4081,8 +4945,8 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
@@ -4091,8 +4955,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1, %8
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
@@ -4103,11 +4967,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4128,24 +4992,24 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   store i32 %3, i32* %loc0
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
   %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
   store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck4, label %9, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
@@ -4164,15 +5028,15 @@ entry:
 ; <label>:18                                      ; preds = %70
   %19 = load i16*, i16** %loc3
   %20 = bitcast i16* %19 to i64*
-  %NullCheck10 = icmp ne i64* %20, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %20, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = load i64, i64* %20, align 8
   %23 = load i16*, i16** %loc4
   %24 = bitcast i16* %23 to i64*
-  %NullCheck12 = icmp ne i64* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = load i64, i64* %24, align 8
@@ -4188,8 +5052,8 @@ entry:
   %31 = bitcast i16* %30 to i8*
   %32 = getelementptr inbounds i8, i8* %31, i64 8
   %33 = bitcast i8* %32 to i64*
-  %NullCheck14 = icmp ne i64* %33, null
-  br i1 %NullCheck14, label %34, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = load i64, i64* %33, align 8
@@ -4197,8 +5061,8 @@ entry:
   %37 = bitcast i16* %36 to i8*
   %38 = getelementptr inbounds i8, i8* %37, i64 8
   %39 = bitcast i8* %38 to i64*
-  %NullCheck16 = icmp ne i64* %39, null
-  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %40
 
 ; <label>:40                                      ; preds = %34
   %41 = load i64, i64* %39, align 8
@@ -4214,8 +5078,8 @@ entry:
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %NullCheck18 = icmp ne i64* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = load i64, i64* %48, align 8
@@ -4223,8 +5087,8 @@ entry:
   %52 = bitcast i16* %51 to i8*
   %53 = getelementptr inbounds i8, i8* %52, i64 16
   %54 = bitcast i8* %53 to i64*
-  %NullCheck20 = icmp ne i64* %54, null
-  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64* %54, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %55
 
 ; <label>:55                                      ; preds = %49
   %56 = load i64, i64* %54, align 8
@@ -4262,15 +5126,15 @@ entry:
 ; <label>:74                                      ; preds = %95
   %75 = load i16*, i16** %loc3
   %76 = bitcast i16* %75 to i32*
-  %NullCheck6 = icmp ne i32* %76, null
-  br i1 %NullCheck6, label %77, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32* %76, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %77
 
 ; <label>:77                                      ; preds = %74
   %78 = load i32, i32* %76, align 8
   %79 = load i16*, i16** %loc4
   %80 = bitcast i16* %79 to i32*
-  %NullCheck8 = icmp ne i32* %80, null
-  br i1 %NullCheck8, label %81, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i32* %80, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %81
 
 ; <label>:81                                      ; preds = %77
   %82 = load i32, i32* %80, align 8
@@ -4318,43 +5182,43 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %74
+ThrowNullRef6:                                    ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %77
+ThrowNullRef8:                                    ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %29
+ThrowNullRef14:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %34
+ThrowNullRef16:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4376,8 +5240,8 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load i64, i64 addrspace(1)* %4
@@ -4389,8 +5253,8 @@ entry:
   %12 = load i64, i64* %11
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %5
   %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
@@ -4399,8 +5263,8 @@ entry:
   %18 = load i8, i8* %arg2
   %19 = zext i8 %18 to i32
   %20 = trunc i32 %19 to i8
-  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %15
   %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
@@ -4411,11 +5275,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4442,8 +5306,8 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
@@ -4466,16 +5330,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
   %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = load i64, i64 addrspace(1)* %19
@@ -4500,8 +5364,8 @@ entry:
 ; <label>:35                                      ; preds = %30
   %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
@@ -4514,8 +5378,8 @@ entry:
 
 ; <label>:42                                      ; preds = %1, %38
   %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
-  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
@@ -4526,19 +5390,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %35
+ThrowNullRef2:                                    ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %42
+ThrowNullRef8:                                    ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4551,14 +5415,14 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
@@ -4570,7 +5434,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4583,8 +5447,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
@@ -4613,51 +5477,51 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
   %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
   %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
   %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
   %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
-  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
   store i64 %21, i64 addrspace(1)* %23
   %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %25 = load i64, i64* %loc0
-  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
@@ -4668,27 +5532,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %22
+ThrowNullRef12:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4701,8 +5565,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
@@ -4713,19 +5577,19 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
@@ -4734,8 +5598,8 @@ entry:
 
 ; <label>:15                                      ; preds = %1, %13
   %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
@@ -4746,19 +5610,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %15
+ThrowNullRef8:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4771,8 +5635,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -4831,8 +5695,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
@@ -4882,8 +5746,8 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
-  br i1 %NullCheck, label %17, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %ThrowNullRef, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
@@ -4894,15 +5758,15 @@ entry:
 
 ; <label>:22                                      ; preds = %17
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
-  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
   %26 = load i32, i32 addrspace(1)* %25
   %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
-  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %27, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
@@ -4925,8 +5789,8 @@ entry:
 ; <label>:40                                      ; preds = %17
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
-  br i1 %NullCheck6, label %43, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %41, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
@@ -4938,34 +5802,17 @@ ThrowNullRef:                                     ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %24
+ThrowNullRef4:                                    ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %40
+ThrowNullRef6:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
-}
-
-INFO:  jitting method Object::ReferenceEquals using LLILCJit
-Successfully read Object.ReferenceEquals
-
-define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
-entry:
-  %arg0 = alloca %System.Object addrspace(1)*
-  %arg1 = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
-  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
-  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = icmp eq %System.Object addrspace(1)* %0, %1
-  %3 = sext i1 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
 }
 
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
@@ -4978,21 +5825,21 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
   %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
-  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
@@ -5007,28 +5854,28 @@ entry:
 ; <label>:13                                      ; preds = %8, %12
   %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
   %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
   %21 = load i32, i32 addrspace(1)* %20, align 8
   %22 = add i32 %21, 1
-  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
   store i32 %22, i32 addrspace(1)* %24
   %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
@@ -5039,27 +5886,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5077,7 +5924,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::Setup using LLILCJit
-Failed to read AppDomain.Setup[loadElem]
+Failed to read AppDomain.Setup[unbox]
 INFO:  jitting method Thread::GetDomain using LLILCJit
 Successfully read Thread.GetDomain
 
@@ -5108,8 +5955,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
@@ -5122,14 +5969,14 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
   %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
@@ -5141,11 +5988,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5173,8 +6020,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -5189,7 +6036,328 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
 Failed to read KeyCollection.System.Collections.Generic.IEnumerable<TKey>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Successfully read Enumerator.MoveNext
+
+define i8 @Enumerator.MoveNext(%"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.RuntimeTypeHandle* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*
+  %"$TypeArg" = alloca %System.RuntimeTypeHandle*
+  store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
+  %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 8
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %76, label %12
+
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
+  br label %76
+
+; <label>:13                                      ; preds = %85
+  %14 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck19 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %15
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, i32 0, i32 0
+  %17 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %16, align 8
+  %NullCheck21 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, i32 0, i32 2
+  %20 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %19, align 8
+  %21 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck23 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %22
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, i32 0, i32 2
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %NullCheck25 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 3, i32 %24
+  %NullCheck27 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %32
+
+; <label>:32                                      ; preds = %30
+  %33 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, i32 0, i32 2
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = icmp slt i32 %34, 0
+  br i1 %35, label %68, label %36
+
+; <label>:36                                      ; preds = %32
+  %37 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %38 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck29 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %39
+
+; <label>:39                                      ; preds = %36
+  %40 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, i32 0, i32 0
+  %41 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %40, align 8
+  %NullCheck31 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, i32 0, i32 2
+  %44 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %43, align 8
+  %45 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck33 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, i32 0, i32 2
+  %48 = load i32, i32 addrspace(1)* %47, align 8
+  %NullCheck35 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %49
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = zext i32 %51 to i64
+  %53 = zext i32 %48 to i64
+  %BoundsCheck37 = icmp uge i64 %53, %52
+  br i1 %BoundsCheck37, label %ThrowIndexOutOfRange38, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 3, i32 %48
+  %NullCheck39 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %56
+
+; <label>:56                                      ; preds = %54
+  %57 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, i32 0, i32 0
+  %58 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck41 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %59
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %60, %System.__Canon addrspace(1)* %58)
+  %61 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck43 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  %64 = load i32, i32 addrspace(1)* %63, align 8
+  %65 = add i32 %64, 1
+  %NullCheck45 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  store i32 %65, i32 addrspace(1)* %67
+  ret i8 1
+
+; <label>:68                                      ; preds = %32
+  %69 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck47 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %73 = add i32 %72, 1
+  %NullCheck49 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %74
+
+; <label>:74                                      ; preds = %70
+  %75 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  store i32 %73, i32 addrspace(1)* %75
+  br label %76
+
+; <label>:76                                      ; preds = %8, %12, %74
+  %77 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %78
+
+; <label>:78                                      ; preds = %76
+  %79 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, i32 0, i32 2
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck7 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %82
+
+; <label>:82                                      ; preds = %78
+  %83 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, i32 0, i32 0
+  %84 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %83, align 8
+  %NullCheck9 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %85
+
+; <label>:85                                      ; preds = %82
+  %86 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, i32 0, i32 7
+  %87 = load i32, i32 addrspace(1)* %86, align 8
+  %88 = icmp ult i32 %80, %87
+  br i1 %88, label %13, label %89
+
+; <label>:89                                      ; preds = %85
+  %90 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %91 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck11 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %92
+
+; <label>:92                                      ; preds = %89
+  %93 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, i32 0, i32 0
+  %94 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck13 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %95
+
+; <label>:95                                      ; preds = %92
+  %96 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, i32 0, i32 7
+  %97 = load i32, i32 addrspace(1)* %96, align 8
+  %98 = add i32 %97, 1
+  %NullCheck15 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %99
+
+; <label>:99                                      ; preds = %95
+  %100 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, i32 0, i32 2
+  store i32 %98, i32 addrspace(1)* %100
+  %101 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck17 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %102
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %103, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %92
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef22:                                   ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef24:                                   ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef26:                                   ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef28:                                   ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef30:                                   ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef32:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef34:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef36:                                   ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange38:                           ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef40:                                   ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef42:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef44:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef46:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef48:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef50:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -5200,8 +6368,8 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -5232,9 +6400,9 @@ Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
 Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
-Failed to read String.MakeSeparatorList[loadElemA]
+Failed to read String.MakeSeparatorList[storeElem]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
-Failed to read String.InternalSplitKeepEmptyEntries[loadElem]
+Failed to read String.InternalSplitKeepEmptyEntries[storeElem]
 INFO:  jitting method Path::IsRelative using LLILCJit
 Successfully read Path.IsRelative
 
@@ -5243,8 +6411,8 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -5254,8 +6422,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
@@ -5271,8 +6439,8 @@ entry:
 
 ; <label>:17                                      ; preds = %7
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
@@ -5288,8 +6456,8 @@ entry:
 
 ; <label>:29                                      ; preds = %19
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %31
 
 ; <label>:31                                      ; preds = %29
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
@@ -5300,8 +6468,8 @@ entry:
 
 ; <label>:36                                      ; preds = %31
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
-  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %37, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
@@ -5312,8 +6480,8 @@ entry:
 
 ; <label>:43                                      ; preds = %31, %38
   %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
-  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %45
 
 ; <label>:45                                      ; preds = %43
   %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
@@ -5324,8 +6492,8 @@ entry:
 
 ; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %50
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
@@ -5336,8 +6504,8 @@ entry:
 
 ; <label>:57                                      ; preds = %1, %7, %19, %45, %52
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
-  br i1 %NullCheck14, label %59, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %59
 
 ; <label>:59                                      ; preds = %57
   %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
@@ -5347,8 +6515,8 @@ entry:
 
 ; <label>:63                                      ; preds = %59
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
@@ -5359,8 +6527,8 @@ entry:
 
 ; <label>:70                                      ; preds = %65
   %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
-  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.String addrspace(1)* %71, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %72
 
 ; <label>:72                                      ; preds = %70
   %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
@@ -5379,39 +6547,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %17
+ThrowNullRef4:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %29
+ThrowNullRef6:                                    ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %36
+ThrowNullRef8:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %43
+ThrowNullRef10:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %50
+ThrowNullRef12:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %57
+ThrowNullRef14:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %63
+ThrowNullRef16:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %70
+ThrowNullRef18:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5419,7 +6587,293 @@ ThrowNullRef17:                                   ; preds = %70
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
-Failed to read String.TrimHelper[loadElem]
+Successfully read String.TrimHelper
+
+define %System.String addrspace(1)* @String.TrimHelper(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i16
+  %loc4 = alloca i32
+  %loc5 = alloca i16
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = sub i32 %3, 1
+  store i32 %4, i32* %loc0
+  store i32 0, i32* %loc1
+  %5 = load i32, i32* %arg2
+  %6 = icmp eq i32 %5, 1
+  br i1 %6, label %62, label %7
+
+; <label>:7                                       ; preds = %1
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:8                                       ; preds = %58
+  store i32 0, i32* %loc2
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load i32, i32* %loc1
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2, i32 %10
+  %13 = load i16, i16 addrspace(1)* %12
+  %14 = zext i16 %13 to i32
+  %15 = trunc i32 %14 to i16
+  store i16 %15, i16* %loc3
+  store i32 0, i32* %loc2
+  br label %34
+
+; <label>:16                                      ; preds = %37
+  %17 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %18 = load i32, i32* %loc2
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %17, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %19
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = zext i32 %18 to i64
+  %BoundsCheck = icmp uge i64 %23, %22
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %24
+
+; <label>:24                                      ; preds = %19
+  %25 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 3, i32 %18
+  %26 = load i16, i16 addrspace(1)* %25, align 8
+  %27 = zext i16 %26 to i32
+  %28 = load i16, i16* %loc3
+  %29 = zext i16 %28 to i32
+  %30 = icmp eq i32 %27, %29
+  br i1 %30, label %43, label %31
+
+; <label>:31                                      ; preds = %24
+  %32 = load i32, i32* %loc2
+  %33 = add i32 %32, 1
+  store i32 %33, i32* %loc2
+  br label %34
+
+; <label>:34                                      ; preds = %11, %31
+  %35 = load i32, i32* %loc2
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = icmp slt i32 %35, %41
+  br i1 %42, label %16, label %43
+
+; <label>:43                                      ; preds = %24, %37
+  %44 = load i32, i32* %loc2
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %45, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp eq i32 %44, %50
+  br i1 %51, label %62, label %52
+
+; <label>:52                                      ; preds = %46
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %7, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %57, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %58
+
+; <label>:58                                      ; preds = %55
+  %59 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %60 = load i32, i32 addrspace(1)* %59
+  %61 = icmp slt i32 %56, %60
+  br i1 %61, label %8, label %62
+
+; <label>:62                                      ; preds = %1, %46, %58
+  %63 = load i32, i32* %arg2
+  %64 = icmp eq i32 %63, 0
+  br i1 %64, label %122, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %66, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %67
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %66, i32 0, i32 1
+  %69 = load i32, i32 addrspace(1)* %68
+  %70 = sub i32 %69, 1
+  store i32 %70, i32* %loc0
+  br label %118
+
+; <label>:71                                      ; preds = %118
+  store i32 0, i32* %loc4
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %73 = load i32, i32* %loc0
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %74
+
+; <label>:74                                      ; preds = %71
+  %75 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 2, i32 %73
+  %76 = load i16, i16 addrspace(1)* %75
+  %77 = zext i16 %76 to i32
+  %78 = trunc i32 %77 to i16
+  store i16 %78, i16* %loc5
+  store i32 0, i32* %loc4
+  br label %97
+
+; <label>:79                                      ; preds = %100
+  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %81 = load i32, i32* %loc4
+  %NullCheck19 = icmp eq %"System.Char[]" addrspace(1)* %80, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
+
+; <label>:82                                      ; preds = %79
+  %83 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 1
+  %84 = load i32, i32 addrspace(1)* %83
+  %85 = zext i32 %84 to i64
+  %86 = zext i32 %81 to i64
+  %BoundsCheck21 = icmp uge i64 %86, %85
+  br i1 %BoundsCheck21, label %ThrowIndexOutOfRange22, label %87
+
+; <label>:87                                      ; preds = %82
+  %88 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 3, i32 %81
+  %89 = load i16, i16 addrspace(1)* %88, align 8
+  %90 = zext i16 %89 to i32
+  %91 = load i16, i16* %loc5
+  %92 = zext i16 %91 to i32
+  %93 = icmp eq i32 %90, %92
+  br i1 %93, label %106, label %94
+
+; <label>:94                                      ; preds = %87
+  %95 = load i32, i32* %loc4
+  %96 = add i32 %95, 1
+  store i32 %96, i32* %loc4
+  br label %97
+
+; <label>:97                                      ; preds = %74, %94
+  %98 = load i32, i32* %loc4
+  %99 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck15 = icmp eq %"System.Char[]" addrspace(1)* %99, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %100
+
+; <label>:100                                     ; preds = %97
+  %101 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %99, i32 0, i32 1
+  %102 = load i32, i32 addrspace(1)* %101
+  %103 = zext i32 %102 to i64
+  %104 = trunc i64 %103 to i32
+  %105 = icmp slt i32 %98, %104
+  br i1 %105, label %79, label %106
+
+; <label>:106                                     ; preds = %87, %100
+  %107 = load i32, i32* %loc4
+  %108 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck17 = icmp eq %"System.Char[]" addrspace(1)* %108, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %109
+
+; <label>:109                                     ; preds = %106
+  %110 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %108, i32 0, i32 1
+  %111 = load i32, i32 addrspace(1)* %110
+  %112 = zext i32 %111 to i64
+  %113 = trunc i64 %112 to i32
+  %114 = icmp eq i32 %107, %113
+  br i1 %114, label %122, label %115
+
+; <label>:115                                     ; preds = %109
+  %116 = load i32, i32* %loc0
+  %117 = sub i32 %116, 1
+  store i32 %117, i32* %loc0
+  br label %118
+
+; <label>:118                                     ; preds = %67, %115
+  %119 = load i32, i32* %loc0
+  %120 = load i32, i32* %loc1
+  %121 = icmp sge i32 %119, %120
+  br i1 %121, label %71, label %122
+
+; <label>:122                                     ; preds = %62, %109, %118
+  %123 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %124 = load i32, i32* %loc1
+  %125 = load i32, i32* %loc0
+  %126 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %123, i32 %124, i32 %125)
+  ret %System.String addrspace(1)* %126
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %97
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange22:                           ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
 Successfully read String.CreateTrimmedString
 
@@ -5439,8 +6893,8 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
@@ -5535,8 +6989,8 @@ entry:
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i64 2872
   %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
   %8 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %7
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %3
   %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
@@ -5553,8 +7007,8 @@ entry:
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 2864
   %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
   %21 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %20
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
-  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %22
 
 ; <label>:22                                      ; preds = %16
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
@@ -5569,7 +7023,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %16
+ThrowNullRef2:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5586,8 +7040,8 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5613,8 +7067,8 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
@@ -5632,8 +7086,8 @@ entry:
 
 ; <label>:12                                      ; preds = %4
   %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
@@ -5644,8 +7098,8 @@ entry:
 
 ; <label>:19                                      ; preds = %14
   %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %19
   %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
@@ -5660,21 +7114,21 @@ entry:
   %31 = zext i16 %30 to i32
   %32 = bitcast i8* %29 to i16*
   %33 = trunc i32 %31 to i16
-  %NullCheck6 = icmp ne i16* %32, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i16* %32, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %21
   store i16 %33, i16* %32, align 8
   %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %36
 
 ; <label>:36                                      ; preds = %34
   %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
   %38 = load i32, i32 addrspace(1)* %37, align 8
   %39 = add i32 %38, 1
-  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %40
 
 ; <label>:40                                      ; preds = %36
   %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
@@ -5683,16 +7137,16 @@ entry:
 
 ; <label>:42                                      ; preds = %14
   %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
-  br i1 %NullCheck12, label %44, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
   %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
   %47 = load i16, i16* %arg1
   %48 = zext i16 %47 to i32
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = trunc i32 %48 to i16
@@ -5703,31 +7157,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %19
+ThrowNullRef4:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %21
+ThrowNullRef6:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %36
+ThrowNullRef10:                                   ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %42
+ThrowNullRef12:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %44
+ThrowNullRef14:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5740,8 +7194,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -5752,8 +7206,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
@@ -5762,14 +7216,14 @@ entry:
 
 ; <label>:11                                      ; preds = %1
   %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
@@ -5779,15 +7233,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5808,8 +7262,8 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5822,8 +7276,8 @@ entry:
 
 ; <label>:8                                       ; preds = %3
   %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
@@ -5842,15 +7296,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
-  br i1 %NullCheck4, label %22, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
   %24 = load i16*, i16* addrspace(1)* %23, align 8
   %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %25, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
@@ -5859,8 +7313,8 @@ entry:
   store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
@@ -5874,8 +7328,8 @@ entry:
 
 ; <label>:37                                      ; preds = %65
   %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %37
   %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
@@ -5886,16 +7340,16 @@ entry:
   %45 = bitcast i16* %41 to i8*
   %46 = getelementptr inbounds i8, i8* %45, i64 %44
   %47 = bitcast i8* %46 to i16*
-  %NullCheck14 = icmp ne i16* %47, null
-  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %47, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %48
 
 ; <label>:48                                      ; preds = %39
   %49 = load i16, i16* %47, align 8
   %50 = zext i16 %49 to i32
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %52 = load i32, i32* %loc1
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %53
 
 ; <label>:53                                      ; preds = %48
   %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
@@ -5916,8 +7370,8 @@ entry:
 ; <label>:62                                      ; preds = %36, %59
   %63 = load i32, i32* %loc1
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck10, label %65, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %65
 
 ; <label>:65                                      ; preds = %62
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
@@ -5936,15 +7390,15 @@ entry:
 
 ; <label>:74                                      ; preds = %70
   %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
-  br i1 %NullCheck18, label %76, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %76
 
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
   %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
-  br i1 %NullCheck20, label %80, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
   %81 = load i64, i64 addrspace(1)* %79
@@ -5958,8 +7412,8 @@ entry:
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
   %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
-  br i1 %NullCheck22, label %92, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.String addrspace(1)* %90, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %92
 
 ; <label>:92                                      ; preds = %80
   %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
@@ -5969,15 +7423,15 @@ entry:
 
 ; <label>:96                                      ; preds = %70
   %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
-  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %98
 
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
   %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
-  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
   %103 = load i64, i64 addrspace(1)* %101
@@ -5991,8 +7445,8 @@ entry:
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
   %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
-  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.String addrspace(1)* %112, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %114
 
 ; <label>:114                                     ; preds = %102
   %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
@@ -6004,59 +7458,59 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %20
+ThrowNullRef4:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %22
+ThrowNullRef6:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %26
+ThrowNullRef8:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %62
+ThrowNullRef10:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %48
+ThrowNullRef16:                                   ; preds = %48
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %74
+ThrowNullRef18:                                   ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %76
+ThrowNullRef20:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %80
+ThrowNullRef22:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %96
+ThrowNullRef24:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %98
+ThrowNullRef26:                                   ; preds = %98
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %102
+ThrowNullRef28:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6069,15 +7523,15 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
   %3 = load i16*, i16* addrspace(1)* %2, align 8
   %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
@@ -6087,8 +7541,8 @@ entry:
   %10 = bitcast i16* %3 to i8*
   %11 = getelementptr inbounds i8, i8* %10, i64 %9
   %12 = bitcast i8* %11 to i16*
-  %NullCheck4 = icmp ne i16* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %5
   store i16 0, i16* %12, align 8
@@ -6098,11 +7552,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6119,8 +7573,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -6131,8 +7585,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
@@ -6144,15 +7598,15 @@ entry:
 
 ; <label>:14                                      ; preds = %1
   %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
   %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
   %21 = load i64, i64 addrspace(1)* %19
@@ -6171,15 +7625,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %14
+ThrowNullRef4:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %16
+ThrowNullRef6:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6302,14 +7756,6 @@ entry:
   ret %System.String addrspace(1)* %57
 }
 
-INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
-Successfully read RuntimeHelpers.get_OffsetToStringData
-
-define i32 @RuntimeHelpers.get_OffsetToStringData() {
-entry:
-  ret i32 12
-}
-
 INFO:  jitting method String::Equals using LLILCJit
 Successfully read String.Equals
 
@@ -6381,8 +7827,8 @@ entry:
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
-  br i1 %NullCheck24, label %29, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
   %30 = load i64, i64 addrspace(1)* %28
@@ -6397,8 +7843,8 @@ entry:
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
-  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
   %43 = load i64, i64 addrspace(1)* %41
@@ -6418,8 +7864,8 @@ entry:
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
   %59 = load i64, i64 addrspace(1)* %57
@@ -6434,8 +7880,8 @@ entry:
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck22, label %71, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
   %72 = load i64, i64 addrspace(1)* %70
@@ -6455,8 +7901,8 @@ entry:
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
-  br i1 %NullCheck16, label %87, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = load i64, i64 addrspace(1)* %86
@@ -6471,8 +7917,8 @@ entry:
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck18, label %100, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
   %101 = load i64, i64 addrspace(1)* %99
@@ -6492,8 +7938,8 @@ entry:
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
-  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
   %117 = load i64, i64 addrspace(1)* %115
@@ -6508,8 +7954,8 @@ entry:
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
-  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
   %130 = load i64, i64 addrspace(1)* %128
@@ -6528,15 +7974,15 @@ entry:
 
 ; <label>:142                                     ; preds = %22
   %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
-  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %143, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %144
 
 ; <label>:144                                     ; preds = %142
   %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
   %146 = load i32, i32 addrspace(1)* %145
   %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
-  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %147, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %148
 
 ; <label>:148                                     ; preds = %144
   %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
@@ -6557,15 +8003,15 @@ entry:
 
 ; <label>:159                                     ; preds = %22
   %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
-  br i1 %NullCheck, label %161, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %ThrowNullRef, label %161
 
 ; <label>:161                                     ; preds = %159
   %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
   %163 = load i32, i32 addrspace(1)* %162
   %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
-  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %164, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %165
 
 ; <label>:165                                     ; preds = %161
   %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
@@ -6578,8 +8024,8 @@ entry:
 
 ; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
-  br i1 %NullCheck4, label %172, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %171, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %172
 
 ; <label>:172                                     ; preds = %170
   %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
@@ -6589,8 +8035,8 @@ entry:
 
 ; <label>:176                                     ; preds = %172
   %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
-  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %177, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %178
 
 ; <label>:178                                     ; preds = %176
   %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
@@ -6629,55 +8075,55 @@ ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %161
+ThrowNullRef2:                                    ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %170
+ThrowNullRef4:                                    ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %176
+ThrowNullRef6:                                    ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %142
+ThrowNullRef8:                                    ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %144
+ThrowNullRef10:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %113
+ThrowNullRef12:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %116
+ThrowNullRef14:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %84
+ThrowNullRef16:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %87
+ThrowNullRef18:                                   ; preds = %87
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %55
+ThrowNullRef20:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %58
+ThrowNullRef22:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %26
+ThrowNullRef24:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %29
+ThrowNullRef26:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,8 +8161,8 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck, label %14, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %ThrowNullRef, label %14
 
 ; <label>:14                                      ; preds = %8
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
@@ -6760,8 +8206,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
@@ -6770,14 +8216,14 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32, i32* %loc0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %10
   %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
   %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
@@ -6790,15 +8236,15 @@ entry:
 ; <label>:25                                      ; preds = %19
   %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
-  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
   %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
@@ -6807,8 +8253,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %37 = load i32, i32* %loc0
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %38, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %38
 
 ; <label>:38                                      ; preds = %32
   %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
@@ -6817,14 +8263,14 @@ entry:
 
 ; <label>:40                                      ; preds = %19
   %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %40
   %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
   %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
-  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
-  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
@@ -6832,8 +8278,8 @@ entry:
   %48 = zext i32 %47 to i64
   %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
-  br i1 %NullCheck16, label %51, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %51
 
 ; <label>:51                                      ; preds = %45
   %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
@@ -6847,15 +8293,15 @@ entry:
 ; <label>:57                                      ; preds = %51
   %58 = load i16*, i16** %arg1
   %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
-  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %60
 
 ; <label>:60                                      ; preds = %57
   %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
   %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
-  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %64
 
 ; <label>:64                                      ; preds = %60
   %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
@@ -6864,22 +8310,22 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
   %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
-  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %70
 
 ; <label>:70                                      ; preds = %64
   %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
   %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
-  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
-  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
   %75 = load i32, i32 addrspace(1)* %74
   %76 = zext i32 %75 to i64
   %77 = trunc i64 %76 to i32
-  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
-  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %78
 
 ; <label>:78                                      ; preds = %73
   %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
@@ -6901,8 +8347,8 @@ entry:
   %90 = bitcast i16* %86 to i8*
   %91 = getelementptr inbounds i8, i8* %90, i64 %89
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %93
 
 ; <label>:93                                      ; preds = %80
   %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
@@ -6912,8 +8358,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %99 = load i32, i32* %loc2
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %100
 
 ; <label>:100                                     ; preds = %93
   %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
@@ -6928,63 +8374,63 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %25
+ThrowNullRef6:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %32
+ThrowNullRef10:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %40
+ThrowNullRef12:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %45
+ThrowNullRef16:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %57
+ThrowNullRef18:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %60
+ThrowNullRef20:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %64
+ThrowNullRef22:                                   ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %70
+ThrowNullRef24:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %73
+ThrowNullRef26:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %80
+ThrowNullRef28:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %93
+ThrowNullRef30:                                   ; preds = %93
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7004,8 +8450,8 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
@@ -7033,43 +8479,43 @@ entry:
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %14
   %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
   %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   %28 = load i32, i32 addrspace(1)* %27, align 8
   %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
-  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %30
 
 ; <label>:30                                      ; preds = %26
   %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
   %32 = load i32, i32 addrspace(1)* %31, align 8
   %33 = add i32 %28, %32
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %34
 
 ; <label>:34                                      ; preds = %30
   %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   store i32 %33, i32 addrspace(1)* %35
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
   store i32 0, i32 addrspace(1)* %38
   %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %40
 
 ; <label>:40                                      ; preds = %37
   %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
@@ -7082,8 +8528,8 @@ entry:
 
 ; <label>:47                                      ; preds = %40
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
@@ -7098,8 +8544,8 @@ entry:
   %54 = load i32, i32* %loc0
   %55 = sext i32 %54 to i64
   %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
-  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %57
 
 ; <label>:57                                      ; preds = %52
   %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
@@ -7110,68 +8556,35 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %14
+ThrowNullRef2:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %23
+ThrowNullRef4:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %26
+ThrowNullRef6:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %30
+ThrowNullRef8:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %34
+ThrowNullRef10:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %47
+ThrowNullRef14:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %52
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-}
-
-INFO:  jitting method StringBuilder::get_Length using LLILCJit
-Successfully read StringBuilder.get_Length
-
-define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.StringBuilder addrspace(1)*
-  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
-  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
-
-; <label>:1                                       ; preds = %entry
-  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %3 = load i32, i32 addrspace(1)* %2, align 8
-  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
-
-; <label>:5                                       ; preds = %1
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = add i32 %3, %7
-  ret i32 %8
-
-ThrowNullRef:                                     ; preds = %entry
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef16:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7213,70 +8626,70 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
   %6 = load i32, i32 addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
   store i32 %6, i32 addrspace(1)* %8
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
   %13 = load i32, i32 addrspace(1)* %12, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
   store i32 %13, i32 addrspace(1)* %15
   %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
-  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %18
 
 ; <label>:18                                      ; preds = %14
   %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
   %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
   %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
   %34 = load i32, i32 addrspace(1)* %33, align 8
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
-  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
@@ -7287,39 +8700,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %28
+ThrowNullRef16:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %32
+ThrowNullRef18:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7455,13 +8868,13 @@ entry:
 ; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
@@ -7477,16 +8890,16 @@ entry:
 
 ; <label>:18                                      ; preds = %15
   %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
   store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
   %22 = load i32, i32* %loc0
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %24
 
 ; <label>:24                                      ; preds = %20
   %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
@@ -7498,13 +8911,13 @@ entry:
 ; <label>:28                                      ; preds = %15, %24
   %29 = load i32, i32* %arg1
   %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %31
   %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
@@ -7517,20 +8930,20 @@ entry:
   %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
-  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
   %46 = load i32, i32 addrspace(1)* %45, align 8
   %47 = sub i32 %40, %46
-  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
-  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i32 addrspace(1)* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %48
 
 ; <label>:48                                      ; preds = %44
   store i32 %47, i32 addrspace(1)* %39, align 8
@@ -7538,21 +8951,21 @@ entry:
 
 ; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
-  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %51
 
 ; <label>:51                                      ; preds = %49
   %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %53
 
 ; <label>:53                                      ; preds = %51
   %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
   %55 = load i32, i32 addrspace(1)* %54, align 8
   %56 = load i32, i32* %arg2
   %57 = sub i32 %55, %56
-  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %58
 
 ; <label>:58                                      ; preds = %53
   %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
@@ -7562,13 +8975,13 @@ entry:
 ; <label>:60                                      ; preds = %33, %58
   %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
   %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
-  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %63
 
 ; <label>:63                                      ; preds = %60
   %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
-  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
-  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
@@ -7578,15 +8991,15 @@ entry:
 
 ; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
-  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i32 addrspace(1)* %69, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %70
 
 ; <label>:70                                      ; preds = %68
   %71 = load i32, i32 addrspace(1)* %69, align 8
   store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
-  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
@@ -7596,8 +9009,8 @@ entry:
   store i32 %77, i32* %loc4
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
-  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %80
 
 ; <label>:80                                      ; preds = %73
   %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
@@ -7607,71 +9020,71 @@ entry:
 ; <label>:83                                      ; preds = %80
   store i32 0, i32* %loc3
   %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
-  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
-  br i1 %NullCheck26, label %88, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i32 addrspace(1)* %87, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %88
 
 ; <label>:88                                      ; preds = %85
   %89 = load i32, i32 addrspace(1)* %87, align 8
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
-  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %90
 
 ; <label>:90                                      ; preds = %88
   %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
   store i32 %89, i32 addrspace(1)* %91
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
-  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
-  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %96
 
 ; <label>:96                                      ; preds = %94
   %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
-  br i1 %NullCheck34, label %100, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %100
 
 ; <label>:100                                     ; preds = %96
   %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
-  br i1 %NullCheck36, label %102, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %102
 
 ; <label>:102                                     ; preds = %100
   %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
   %104 = load i32, i32 addrspace(1)* %103, align 8
   %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
-  br i1 %NullCheck38, label %106, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %106
 
 ; <label>:106                                     ; preds = %102
   %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
-  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
-  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %108
 
 ; <label>:108                                     ; preds = %106
   %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
   %110 = load i32, i32 addrspace(1)* %109, align 8
   %111 = add i32 %104, %110
-  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %112
 
 ; <label>:112                                     ; preds = %108
   %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
   store i32 %111, i32 addrspace(1)* %113
   %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
-  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i32 addrspace(1)* %114, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %115
 
 ; <label>:115                                     ; preds = %112
   %116 = load i32, i32 addrspace(1)* %114, align 8
@@ -7681,19 +9094,19 @@ entry:
 ; <label>:118                                     ; preds = %115
   %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
-  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %121
 
 ; <label>:121                                     ; preds = %118
   %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
-  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
-  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %123
 
 ; <label>:123                                     ; preds = %121
   %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
   %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
-  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
-  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %126
 
 ; <label>:126                                     ; preds = %123
   %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
@@ -7705,8 +9118,8 @@ entry:
 
 ; <label>:130                                     ; preds = %80, %115, %126
   %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %132
 
 ; <label>:132                                     ; preds = %130
   %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7715,8 +9128,8 @@ entry:
   %136 = load i32, i32* %loc3
   %137 = sub i32 %135, %136
   %138 = sub i32 %134, %137
-  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %139
 
 ; <label>:139                                     ; preds = %132
   %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7728,16 +9141,16 @@ entry:
 
 ; <label>:144                                     ; preds = %139
   %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
-  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %146
 
 ; <label>:146                                     ; preds = %144
   %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
   %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
   %149 = load i32, i32* %loc2
   %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
-  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %151
 
 ; <label>:151                                     ; preds = %146
   %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
@@ -7754,145 +9167,249 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %18
+ThrowNullRef4:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %31
+ThrowNullRef10:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %44
+ThrowNullRef16:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %68
+ThrowNullRef18:                                   ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %70
+ThrowNullRef20:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %73
+ThrowNullRef22:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %83
+ThrowNullRef24:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %85
+ThrowNullRef26:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %88
+ThrowNullRef28:                                   ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %90
+ThrowNullRef30:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %94
+ThrowNullRef32:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %96
+ThrowNullRef34:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %100
+ThrowNullRef36:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %102
+ThrowNullRef38:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %106
+ThrowNullRef40:                                   ; preds = %106
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %108
+ThrowNullRef42:                                   ; preds = %108
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %112
+ThrowNullRef44:                                   ; preds = %112
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %118
+ThrowNullRef46:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %121
+ThrowNullRef48:                                   ; preds = %121
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %123
+ThrowNullRef50:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %130
+ThrowNullRef52:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %132
+ThrowNullRef54:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %144
+ThrowNullRef56:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %146
+ThrowNullRef58:                                   ; preds = %146
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %60
+ThrowNullRef60:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %63
+ThrowNullRef62:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %49
+ThrowNullRef64:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %51
+ThrowNullRef66:                                   ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %53
+ThrowNullRef68:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(%"System.Char[]" addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %arg0 = alloca %"System.Char[]" addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store %"System.Char[]" addrspace(1)* %param0, %"System.Char[]" addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load i32, i32* %arg4
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %43, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %38, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg1
+  %13 = load i32, i32* %arg4
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %38, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %24 = load i32, i32* %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %35 = load i32, i32* %arg3
+  %36 = load i32, i32* %arg4
+  %37 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %37, %"System.Char[]" addrspace(1)* %34, i32 %35, i32 %36)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:38                                      ; preds = %5, %16
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Successfully read Buffer._Memmove
 
@@ -7914,7 +9431,7 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[loadElem]
+Failed to read AppDomain.SetDataHelper[storeElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -7923,8 +9440,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
@@ -7934,8 +9451,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
@@ -7947,15 +9464,15 @@ entry:
   %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
   %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
@@ -7966,15 +9483,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7992,7 +9509,79 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
-Failed to read Dictionary`2.TryGetValue[loadElemA]
+Successfully read Dictionary`2.TryGetValue
+
+define i8 @"Dictionary`2.TryGetValue"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)* addrspace(1)* %param2) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  %arg2 = alloca %System.__Canon addrspace(1)* addrspace(1)*
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  store %System.__Canon addrspace(1)* addrspace(1)* %param2, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  store i32 %2, i32* %loc0
+  %3 = load i32, i32* %loc0
+  %4 = icmp slt i32 %3, 0
+  br i1 %4, label %22, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 2
+  %10 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %9, align 8
+  %11 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = zext i32 %11 to i64
+  %BoundsCheck = icmp uge i64 %16, %15
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 3, i32 %11
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %20, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %6, %System.__Canon addrspace(1)* %21)
+  ret i8 1
+
+; <label>:22                                      ; preds = %entry
+  %23 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %23, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -8058,8 +9647,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
@@ -8091,8 +9680,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
@@ -8171,15 +9760,15 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck, label %19, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %ThrowNullRef, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
   %21 = load i32, i32 addrspace(1)* %20
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
@@ -8202,7 +9791,7 @@ ThrowNullRef:                                     ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %19
+ThrowNullRef2:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8248,8 +9837,8 @@ entry:
   %0 = alloca %System.AppDomainHandle
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %1 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %1, i32 0, i32 15
@@ -8269,8 +9858,8 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
@@ -8286,7 +9875,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -8299,8 +9888,8 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -8327,8 +9916,8 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
@@ -8352,8 +9941,8 @@ entry:
   %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
   store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
@@ -8363,8 +9952,8 @@ entry:
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
@@ -8374,8 +9963,8 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %9
   %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
@@ -8384,8 +9973,8 @@ entry:
 
 ; <label>:18                                      ; preds = %3, %16
   %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
@@ -8397,15 +9986,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %18
+ThrowNullRef6:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8418,8 +10007,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
@@ -8453,15 +10042,15 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
@@ -8473,7 +10062,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8481,7 +10070,7 @@ ThrowNullRef1:                                    ; preds = %1
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
 Failed to read Dictionary`2.System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
@@ -8506,8 +10095,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
@@ -8524,8 +10113,8 @@ entry:
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -8544,7 +10133,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8577,8 +10166,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = load i64, i64* %arg2
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = trunc i32 %3 to i8
@@ -8634,46 +10223,46 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
   %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
-  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
-  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
-  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
@@ -8684,27 +10273,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %20
+ThrowNullRef12:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8717,8 +10306,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -8756,22 +10345,22 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
   %9 = load i64, i64 addrspace(1)* %8, align 8
   %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
   %13 = load i64, i64 addrspace(1)* %12, align 8
   %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %11
   %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
@@ -8788,11 +10377,11 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8882,8 +10471,8 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
@@ -8900,8 +10489,8 @@ entry:
 ; <label>:8                                       ; preds = %1
   %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
   %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
@@ -8911,15 +10500,15 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
   %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
   %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
-  br i1 %NullCheck6, label %21, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
@@ -8946,15 +10535,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8992,15 +10581,15 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
   store i8 %3, i8 addrspace(1)* %5
   %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
@@ -9011,7 +10600,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9027,8 +10616,8 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -9041,8 +10630,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
@@ -9058,7 +10647,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9080,8 +10669,8 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
@@ -9096,8 +10685,8 @@ entry:
 ; <label>:12                                      ; preds = %6
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
@@ -9112,8 +10701,8 @@ entry:
 ; <label>:21                                      ; preds = %15
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
@@ -9128,8 +10717,8 @@ entry:
 ; <label>:30                                      ; preds = %24
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %31, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
@@ -9144,8 +10733,8 @@ entry:
 ; <label>:39                                      ; preds = %33
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
-  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %40, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %42
 
 ; <label>:42                                      ; preds = %39
   %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
@@ -9164,19 +10753,19 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %21
+ThrowNullRef4:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %30
+ThrowNullRef6:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %39
+ThrowNullRef8:                                    ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9243,8 +10832,8 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
@@ -9264,57 +10853,57 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
   store i8 0, i8 addrspace(1)* %2
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
   store i8 0, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
   store i8 0, i8 addrspace(1)* %17
   %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
   store i8 0, i8 addrspace(1)* %20
   %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
-  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
@@ -9325,31 +10914,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %19
+ThrowNullRef14:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9367,8 +10956,8 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
@@ -9380,8 +10969,8 @@ entry:
 
 ; <label>:9                                       ; preds = %4
   %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %9
   %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
@@ -9395,7 +10984,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef2:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9420,8 +11009,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
@@ -9512,8 +11101,8 @@ entry:
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
@@ -9524,8 +11113,8 @@ entry:
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = load i64, i64 addrspace(1)* %12
@@ -9537,8 +11126,8 @@ entry:
   %20 = load i64, i64* %19
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
-  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %13
   %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
@@ -9555,8 +11144,8 @@ entry:
 ; <label>:30                                      ; preds = %25
   %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %32 = load i32, i32* %arg2
-  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
-  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
@@ -9570,15 +11159,15 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %30
+ThrowNullRef2:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9622,87 +11211,87 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
   %10 = load i8, i8 addrspace(1)* %9, align 8
   %11 = zext i8 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %8
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
   store i8 %12, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
   %19 = load i8, i8 addrspace(1)* %18, align 8
   %20 = zext i8 %19 to i32
   %21 = trunc i32 %20 to i8
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
   store i8 %21, i8 addrspace(1)* %23
   %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
   %28 = load i8, i8 addrspace(1)* %27, align 8
   %29 = zext i8 %28 to i32
   %30 = trunc i32 %29 to i8
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
-  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %31
 
 ; <label>:31                                      ; preds = %26
   %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
   store i8 %30, i8 addrspace(1)* %32
   %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
-  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
-  br i1 %NullCheck14, label %40, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %40
 
 ; <label>:40                                      ; preds = %35
   %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
   store i8 %39, i8 addrspace(1)* %41
   %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
-  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %44
 
 ; <label>:44                                      ; preds = %40
   %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
   %46 = load i8, i8 addrspace(1)* %45, align 8
   %47 = zext i8 %46 to i32
   %48 = trunc i32 %47 to i8
-  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
   store i8 %48, i8 addrspace(1)* %50
   %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
-  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
@@ -9713,29 +11302,29 @@ entry:
 ; <label>:56                                      ; preds = %52
   %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
-  br i1 %NullCheck22, label %59, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
   %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
   %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
-  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
-  br i1 %NullCheck24, label %63, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
   %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
-  br i1 %NullCheck26, label %66, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
   %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
-  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
-  br i1 %NullCheck28, label %69, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %69
 
 ; <label>:69                                      ; preds = %66
   %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
@@ -9744,15 +11333,15 @@ entry:
 
 ; <label>:71                                      ; preds = %105
   %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
-  br i1 %NullCheck34, label %73, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %73
 
 ; <label>:73                                      ; preds = %71
   %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
   %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
   %76 = load i32, i32* %loc0
-  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
-  br i1 %NullCheck36, label %77, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
@@ -9766,8 +11355,8 @@ entry:
 
 ; <label>:83                                      ; preds = %77
   %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
-  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
@@ -9775,14 +11364,14 @@ entry:
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
   %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
-  br i1 %NullCheck40, label %91, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
 ; <label>:91                                      ; preds = %85
   %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
   %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
-  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck42, label %94, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %94
 
 ; <label>:94                                      ; preds = %91
   %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
@@ -9798,14 +11387,14 @@ entry:
 ; <label>:99                                      ; preds = %69, %96
   %100 = load i32, i32* %loc0
   %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
-  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %102
 
 ; <label>:102                                     ; preds = %99
   %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
   %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
-  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
-  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
@@ -9819,87 +11408,87 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %26
+ThrowNullRef10:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %31
+ThrowNullRef12:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %35
+ThrowNullRef14:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %40
+ThrowNullRef16:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %56
+ThrowNullRef22:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %59
+ThrowNullRef24:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %63
+ThrowNullRef26:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %66
+ThrowNullRef28:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %102
+ThrowNullRef32:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %71
+ThrowNullRef34:                                   ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %73
+ThrowNullRef36:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %83
+ThrowNullRef38:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %85
+ThrowNullRef40:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %91
+ThrowNullRef42:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9943,15 +11532,15 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
   %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
@@ -9961,28 +11550,28 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
   %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %12
   %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
   %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
   %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
-  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
@@ -9993,23 +11582,23 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %12
+ThrowNullRef6:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10031,15 +11620,15 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
   %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = load i64, i64 addrspace(1)* %7
@@ -10077,13 +11666,13 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[loadElem]
+Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -10111,8 +11700,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -10175,8 +11764,8 @@ entry:
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load double, double* %arg0
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -10310,8 +11899,8 @@ entry:
   store i64 %param0, i64* %arg0
   store i64 %param1, i64* %arg1
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
@@ -10319,8 +11908,8 @@ entry:
   %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
   %5 = load i16*, i16* addrspace(1)* %4, align 8
   %6 = addrspacecast i64* %arg1 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = bitcast i64 addrspace(1)* %6 to i8 addrspace(1)*
@@ -10336,7 +11925,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10370,8 +11959,8 @@ entry:
   %1 = load i32, i32* %arg1
   %2 = sext i32 %1 to i64
   %3 = inttoptr i64 %2 to i16*
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -10424,8 +12013,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, i32)*)(%System.IO.ConsoleStream addrspace(1)* %2, i32 %1)
   %3 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %4 = load i64, i64* %arg1
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
@@ -10436,8 +12025,8 @@ entry:
   %10 = icmp eq i32 %9, 3
   %11 = sext i1 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %5
   %14 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, i32 0, i32 5
@@ -10448,7 +12037,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10471,8 +12060,8 @@ entry:
   %5 = icmp eq i32 %4, 1
   %6 = sext i1 %5 to i32
   %7 = trunc i32 %6 to i8
-  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %2, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.ConsoleStream addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
@@ -10483,8 +12072,8 @@ entry:
   %13 = icmp eq i32 %12, 2
   %14 = sext i1 %13 to i32
   %15 = trunc i32 %14 to i8
-  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %10, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.ConsoleStream addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %8
   %17 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %10, i32 0, i32 4
@@ -10495,7 +12084,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10534,8 +12123,8 @@ entry:
   %arg0 = alloca i64
   store i64 %param0, i64* %arg0
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
@@ -10570,8 +12159,8 @@ entry:
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
   %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = load i64, i64 addrspace(1)* %7
@@ -10675,7 +12264,127 @@ entry:
 INFO:  jitting method Encoding::GetEncoding using LLILCJit
 Failed to read Encoding.GetEncoding[convertToHelperArgumentType]
 INFO:  jitting method EncodingProvider::GetEncodingFromProvider using LLILCJit
-Failed to read EncodingProvider.GetEncodingFromProvider[loadElem]
+Successfully read EncodingProvider.GetEncodingFromProvider
+
+define %System.Text.Encoding addrspace(1)* @EncodingProvider.GetEncodingFromProvider(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca %"System.Text.EncodingProvider[]" addrspace(1)*
+  %loc1 = alloca %System.Text.EncodingProvider addrspace(1)*
+  %loc2 = alloca %System.Text.Encoding addrspace(1)*
+  %loc3 = alloca %System.Text.Encoding addrspace(1)*
+  %loc4 = alloca %"System.Text.EncodingProvider[]" addrspace(1)*
+  %loc5 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1059)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2392
+  %2 = addrspacecast i8 addrspace(1)* %1 to %"System.Text.EncodingProvider[]" addrspace(1)**
+  %3 = load volatile %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %2
+  %4 = icmp ne %"System.Text.EncodingProvider[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %entry
+  ret %System.Text.Encoding addrspace(1)* null
+
+; <label>:6                                       ; preds = %entry
+  %7 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1059)
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i64 2392
+  %9 = addrspacecast i8 addrspace(1)* %8 to %"System.Text.EncodingProvider[]" addrspace(1)**
+  %10 = load volatile %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %9
+  store %"System.Text.EncodingProvider[]" addrspace(1)* %10, %"System.Text.EncodingProvider[]" addrspace(1)** %loc0
+  %11 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc0
+  store %"System.Text.EncodingProvider[]" addrspace(1)* %11, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  store i32 0, i32* %loc5
+  br label %43
+
+; <label>:12                                      ; preds = %46
+  %13 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  %14 = load i32, i32* %loc5
+  %NullCheck1 = icmp eq %"System.Text.EncodingProvider[]" addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %13, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = zext i32 %17 to i64
+  %19 = zext i32 %14 to i64
+  %BoundsCheck = icmp uge i64 %19, %18
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %20
+
+; <label>:20                                      ; preds = %15
+  %21 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %13, i32 0, i32 3, i32 %14
+  %22 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)* addrspace(1)* %21, align 8
+  store %System.Text.EncodingProvider addrspace(1)* %22, %System.Text.EncodingProvider addrspace(1)** %loc1
+  %23 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)** %loc1
+  %24 = load i32, i32* %arg0
+  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i64 addrspace(1)*
+  %NullCheck3 = icmp eq i64 addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
+
+; <label>:26                                      ; preds = %20
+  %27 = load i64, i64 addrspace(1)* %25
+  %28 = add i64 %27, 64
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 40
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Text.Encoding addrspace(1)* (%System.Text.EncodingProvider addrspace(1)*, i32)*
+  %35 = call %System.Text.Encoding addrspace(1)* %34(%System.Text.EncodingProvider addrspace(1)* %23, i32 %24)
+  store %System.Text.Encoding addrspace(1)* %35, %System.Text.Encoding addrspace(1)** %loc2
+  %36 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc2
+  %37 = icmp eq %System.Text.Encoding addrspace(1)* %36, null
+  br i1 %37, label %40, label %38
+
+; <label>:38                                      ; preds = %26
+  %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc2
+  store %System.Text.Encoding addrspace(1)* %39, %System.Text.Encoding addrspace(1)** %loc3
+  br label %53
+
+; <label>:40                                      ; preds = %26
+  %41 = load i32, i32* %loc5
+  %42 = add i32 %41, 1
+  store i32 %42, i32* %loc5
+  br label %43
+
+; <label>:43                                      ; preds = %6, %40
+  %44 = load i32, i32* %loc5
+  %45 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  %NullCheck = icmp eq %"System.Text.EncodingProvider[]" addrspace(1)* %45, null
+  br i1 %NullCheck, label %ThrowNullRef, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp slt i32 %44, %50
+  br i1 %51, label %12, label %52
+
+; <label>:52                                      ; preds = %46
+  ret %System.Text.Encoding addrspace(1)* null
+
+; <label>:53                                      ; preds = %38
+  %54 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc3
+  ret %System.Text.Encoding addrspace(1)* %54
+
+ThrowNullRef:                                     ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method EncodingProvider::.cctor using LLILCJit
 Successfully read EncodingProvider..cctor
 
@@ -10694,7 +12403,7 @@ Failed to read Encoding.get_InternalSyncObject[Call HasTypeArg]
 INFO:  jitting method Hashtable::.ctor using LLILCJit
 Failed to read Hashtable..ctor[Volatile store]
 INFO:  jitting method Hashtable::get_Item using LLILCJit
-Failed to read Hashtable.get_Item[loadElemA]
+Failed to read Hashtable.get_Item[loadNonPrimitiveObj]
 INFO:  jitting method Hashtable::InitHash using LLILCJit
 Successfully read Hashtable.InitHash
 
@@ -10714,8 +12423,8 @@ entry:
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -10731,15 +12440,15 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
   %15 = load i32, i32* %loc0
-  %NullCheck2 = icmp ne i32 addrspace(1)* %14, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i32 addrspace(1)* %14, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %3
   store i32 %15, i32 addrspace(1)* %14, align 8
   %17 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %18 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %NullCheck4 = icmp ne i32 addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i32 addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = load i32, i32 addrspace(1)* %18, align 8
@@ -10748,8 +12457,8 @@ entry:
   %23 = sub i32 %22, 1
   %24 = urem i32 %21, %23
   %25 = add i32 1, %24
-  %NullCheck6 = icmp ne i32 addrspace(1)* %17, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32 addrspace(1)* %17, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %19
   store i32 %25, i32 addrspace(1)* %17, align 8
@@ -10760,15 +12469,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %19
+ThrowNullRef6:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10783,8 +12492,8 @@ entry:
   store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
   store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %NullCheck = icmp ne %System.Collections.Hashtable addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Collections.Hashtable addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
@@ -10794,16 +12503,16 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Collections.Hashtable addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Collections.Hashtable addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
   %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck4 = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %9, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
   %13 = inttoptr i64 %11 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
@@ -10813,8 +12522,8 @@ entry:
 ; <label>:15                                      ; preds = %1
   %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -10832,15 +12541,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10854,8 +12563,8 @@ entry:
   store %System.Int32 addrspace(1)* %param0, %System.Int32 addrspace(1)** %this
   %0 = load %System.Int32 addrspace(1)*, %System.Int32 addrspace(1)** %this
   %1 = bitcast %System.Int32 addrspace(1)* %0 to i32 addrspace(1)*
-  %NullCheck = icmp ne i32 addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq i32 addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load i32, i32 addrspace(1)* %1, align 8
@@ -10931,8 +12640,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.UTF8Encoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
@@ -10941,15 +12650,15 @@ entry:
   %9 = load i8, i8* %arg2
   %10 = zext i8 %9 to i32
   %11 = trunc i32 %10 to i8
-  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %8, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %6
   %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %8, i32 0, i32 8
   store i8 %11, i8 addrspace(1)* %13
   %14 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %14, i32 0, i32 8
@@ -10961,8 +12670,8 @@ entry:
 ; <label>:20                                      ; preds = %15
   %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %22, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %22, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = load i64, i64 addrspace(1)* %22
@@ -10984,15 +12693,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %12
+ThrowNullRef4:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11007,8 +12716,8 @@ entry:
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
@@ -11030,16 +12739,16 @@ entry:
 ; <label>:10                                      ; preds = %1
   %11 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
   %12 = load i32, i32* %arg1
-  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %11, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.Encoding addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
   store i32 %12, i32 addrspace(1)* %14
   %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
   %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = load i64, i64 addrspace(1)* %16
@@ -11057,11 +12766,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11074,8 +12783,8 @@ entry:
   %this = alloca %System.Text.UTF8Encoding addrspace(1)*
   store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
   %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.UTF8Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
@@ -11087,16 +12796,16 @@ entry:
 ; <label>:6                                       ; preds = %1
   %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %8 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %10, %System.Text.EncoderFallback addrspace(1)* %8)
   %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %12 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
-  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %11, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %11, i32 0, i32 3
@@ -11109,8 +12818,8 @@ entry:
   %18 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %18, %System.String addrspace(1)* %17)
   %19 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %18 to %System.Text.EncoderFallback addrspace(1)*
-  %NullCheck6 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %16, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %16, i32 0, i32 2
@@ -11120,8 +12829,8 @@ entry:
   %24 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %24, %System.String addrspace(1)* %23)
   %25 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %24 to %System.Text.DecoderFallback addrspace(1)*
-  %NullCheck8 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %22, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %22, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %20
   %27 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %22, i32 0, i32 3
@@ -11132,19 +12841,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %20
+ThrowNullRef8:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11174,8 +12883,8 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load i32, i32* %arg1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -11193,8 +12902,8 @@ entry:
 ; <label>:15                                      ; preds = %8
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %17 = load i32, i32* %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 %17
@@ -11210,7 +12919,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11262,7 +12971,7 @@ entry:
 }
 
 INFO:  jitting method Hashtable::Insert using LLILCJit
-Failed to read Hashtable.Insert[loadElemA]
+Failed to read Hashtable.Insert[storeElem]
 INFO:  jitting method ConsoleEncoding::.ctor using LLILCJit
 Successfully read ConsoleEncoding..ctor
 
@@ -11277,8 +12986,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %1)
   %2 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
@@ -11314,8 +13023,8 @@ entry:
   %2 = call %System.Text.InternalEncoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalEncoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %1)
   %3 = bitcast %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2 to %System.Text.EncoderFallback addrspace(1)*
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
@@ -11325,8 +13034,8 @@ entry:
   %8 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %7)
   %9 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %8 to %System.Text.DecoderFallback addrspace(1)*
-  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %6, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.Encoding addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %4
   %11 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %6, i32 0, i32 3
@@ -11337,7 +13046,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11356,15 +13065,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* %1)
   %2 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   %6 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, i32 0, i32 1
@@ -11375,7 +13084,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11403,8 +13112,8 @@ entry:
   store %System.Text.InternalDecoderBestFitFallback addrspace(1)* %param0, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
   %0 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
@@ -11414,15 +13123,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %4)
   %5 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %6)
   %9 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, i32 0, i32 1
@@ -11433,11 +13142,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11505,8 +13214,8 @@ entry:
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
   %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = load i64, i64 addrspace(1)* %19
@@ -11570,8 +13279,8 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.ConsoleStream addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
@@ -11602,31 +13311,31 @@ entry:
   store i8 %param4, i8* %arg4
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %3, %System.IO.Stream addrspace(1)* %1)
   %4 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %4, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
   %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %4, i32 0, i32 4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %5)
   %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %6
   %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
   %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
   %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = load i64, i64 addrspace(1)* %13
@@ -11638,8 +13347,8 @@ entry:
   %21 = load i64, i64* %20
   %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %8, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %8, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %14
   %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 5
@@ -11657,24 +13366,24 @@ entry:
   %31 = load i32, i32* %arg3
   %32 = sext i32 %31 to i64
   %33 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %32)
-  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %30, null
-  br i1 %NullCheck10, label %34, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.StreamWriter addrspace(1)* %30, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %35, %"System.Char[]" addrspace(1)* %33)
   %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %37, null
-  br i1 %NullCheck12, label %38, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.StreamWriter addrspace(1)* %37, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %38
 
 ; <label>:38                                      ; preds = %34
   %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
   %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
   %41 = load i32, i32* %arg3
   %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %42, null
-  br i1 %NullCheck14, label %43, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %42, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
   %44 = load i64, i64 addrspace(1)* %42
@@ -11688,30 +13397,30 @@ entry:
   %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
   %53 = sext i32 %52 to i64
   %54 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %53)
-  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
-  br i1 %NullCheck16, label %55, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %55
 
 ; <label>:55                                      ; preds = %43
   %56 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %56, %"System.Byte[]" addrspace(1)* %54)
   %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %58 = load i32, i32* %arg3
-  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %57, null
-  br i1 %NullCheck18, label %59, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.StreamWriter addrspace(1)* %57, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %59
 
 ; <label>:59                                      ; preds = %55
   %60 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 10
   store i32 %58, i32 addrspace(1)* %60
   %61 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %61, null
-  br i1 %NullCheck20, label %62, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.IO.StreamWriter addrspace(1)* %61, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %62
 
 ; <label>:62                                      ; preds = %59
   %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
   %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
   %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
   %67 = load i64, i64 addrspace(1)* %65
@@ -11729,15 +13438,15 @@ entry:
 
 ; <label>:78                                      ; preds = %66
   %79 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %79, null
-  br i1 %NullCheck24, label %80, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.StreamWriter addrspace(1)* %79, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %80
 
 ; <label>:80                                      ; preds = %78
   %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
   %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
   %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %83, null
-  br i1 %NullCheck26, label %84, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %83, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
   %85 = load i64, i64 addrspace(1)* %83
@@ -11754,8 +13463,8 @@ entry:
 
 ; <label>:95                                      ; preds = %84
   %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.IO.StreamWriter addrspace(1)* %96, null
-  br i1 %NullCheck28, label %97, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.IO.StreamWriter addrspace(1)* %96, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %97
 
 ; <label>:97                                      ; preds = %95
   %98 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 12
@@ -11769,8 +13478,8 @@ entry:
   %103 = icmp eq i32 %102, 0
   %104 = sext i1 %103 to i32
   %105 = trunc i32 %104 to i8
-  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %100, null
-  br i1 %NullCheck30, label %106, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.IO.StreamWriter addrspace(1)* %100, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %106
 
 ; <label>:106                                     ; preds = %99
   %107 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %100, i32 0, i32 13
@@ -11781,63 +13490,63 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %6
+ThrowNullRef4:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %29
+ThrowNullRef10:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %34
+ThrowNullRef12:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %38
+ThrowNullRef14:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %43
+ThrowNullRef16:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %55
+ThrowNullRef18:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %59
+ThrowNullRef20:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %62
+ThrowNullRef22:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %78
+ThrowNullRef24:                                   ; preds = %78
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %80
+ThrowNullRef26:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %95
+ThrowNullRef28:                                   ; preds = %95
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11850,15 +13559,15 @@ entry:
   %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = load i64, i64 addrspace(1)* %4
@@ -11876,7 +13585,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11926,35 +13635,35 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
   %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderNLS addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %7 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.EncoderNLS addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Text.Encoding addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.Encoding addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Text.EncoderNLS addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.EncoderNLS addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
   %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck8 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = load i64, i64 addrspace(1)* %16
@@ -11973,19 +13682,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12011,8 +13720,8 @@ entry:
   %this = alloca %System.Text.Encoding addrspace(1)*
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
@@ -12032,15 +13741,15 @@ entry:
   %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
   store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
   %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
   store i32 0, i32 addrspace(1)* %2
   %3 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, i32 0, i32 2
@@ -12050,15 +13759,15 @@ entry:
 
 ; <label>:8                                       ; preds = %4
   %9 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
   %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
   %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = load i64, i64 addrspace(1)* %13
@@ -12079,15 +13788,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12102,16 +13811,16 @@ entry:
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = load i32, i32* %arg1
   %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
   %7 = load i64, i64 addrspace(1)* %5
@@ -12129,7 +13838,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12166,8 +13875,8 @@ entry:
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
   %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
   %16 = load i64, i64 addrspace(1)* %14
@@ -12188,8 +13897,8 @@ entry:
   %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
   %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
   %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %31, null
-  br i1 %NullCheck2, label %32, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = load i64, i64 addrspace(1)* %31
@@ -12232,7 +13941,7 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12245,14 +13954,14 @@ entry:
   %this = alloca %System.Text.EncoderReplacementFallback addrspace(1)*
   store %System.Text.EncoderReplacementFallback addrspace(1)* %param0, %System.Text.EncoderReplacementFallback addrspace(1)** %this
   %0 = load %System.Text.EncoderReplacementFallback addrspace(1)*, %System.Text.EncoderReplacementFallback addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -12263,7 +13972,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12293,8 +14002,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
@@ -12326,8 +14035,8 @@ entry:
   %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
   store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
@@ -12339,8 +14048,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Threading.Tasks.Task addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %7)
@@ -12363,7 +14072,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12382,8 +14091,8 @@ entry:
   store i8 %param1, i8* %arg1
   store i8 %param2, i8* %arg2
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
@@ -12397,8 +14106,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1, %5
   %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 9
@@ -12429,8 +14138,8 @@ entry:
 
 ; <label>:25                                      ; preds = %8, %20
   %26 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %26, null
-  br i1 %NullCheck4, label %27, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %26, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %26, i32 0, i32 12
@@ -12441,22 +14150,22 @@ entry:
 
 ; <label>:32                                      ; preds = %27
   %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %33, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.IO.StreamWriter addrspace(1)* %33, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %32
   %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 12
   store i8 1, i8 addrspace(1)* %35
   %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
-  br i1 %NullCheck8, label %37, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
   %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
   %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck10 = icmp ne i64 addrspace(1)* %40, null
-  br i1 %NullCheck10, label %41, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64 addrspace(1)* %40, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i64, i64 addrspace(1)* %40
@@ -12470,8 +14179,8 @@ entry:
   %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
   store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
   %51 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %NullCheck12 = icmp ne %"System.Byte[]" addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Byte[]" addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %41
   %53 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %51, i32 0, i32 1
@@ -12483,16 +14192,16 @@ entry:
 
 ; <label>:58                                      ; preds = %52
   %59 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %59, null
-  br i1 %NullCheck14, label %60, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.IO.StreamWriter addrspace(1)* %59, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %60
 
 ; <label>:60                                      ; preds = %58
   %61 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %59, i32 0, i32 3
   %62 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
   %64 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %NullCheck16 = icmp ne %"System.Byte[]" addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %"System.Byte[]" addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %60
   %66 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %64, i32 0, i32 1
@@ -12500,8 +14209,8 @@ entry:
   %68 = zext i32 %67 to i64
   %69 = trunc i64 %68 to i32
   %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck18, label %71, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
   %72 = load i64, i64 addrspace(1)* %70
@@ -12517,29 +14226,29 @@ entry:
 
 ; <label>:80                                      ; preds = %27, %52, %71
   %81 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %81, null
-  br i1 %NullCheck20, label %82, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.IO.StreamWriter addrspace(1)* %81, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
 
 ; <label>:82                                      ; preds = %80
   %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %81, i32 0, i32 5
   %84 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %83, align 8
   %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.IO.StreamWriter addrspace(1)* %85, null
-  br i1 %NullCheck22, label %86, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.IO.StreamWriter addrspace(1)* %85, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %86
 
 ; <label>:86                                      ; preds = %82
   %87 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 7
   %88 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %87, align 8
   %89 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %89, null
-  br i1 %NullCheck24, label %90, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.StreamWriter addrspace(1)* %89, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %90
 
 ; <label>:90                                      ; preds = %86
   %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %89, i32 0, i32 9
   %92 = load i32, i32 addrspace(1)* %91, align 8
   %93 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.IO.StreamWriter addrspace(1)* %93, null
-  br i1 %NullCheck26, label %94, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.IO.StreamWriter addrspace(1)* %93, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %93, i32 0, i32 6
@@ -12547,8 +14256,8 @@ entry:
   %97 = load i8, i8* %arg2
   %98 = zext i8 %97 to i32
   %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
-  %NullCheck28 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck28, label %100, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
   %101 = load i64, i64 addrspace(1)* %99
@@ -12563,8 +14272,8 @@ entry:
   %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
   store i32 %110, i32* %loc1
   %111 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %111, null
-  br i1 %NullCheck30, label %112, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.IO.StreamWriter addrspace(1)* %111, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %112
 
 ; <label>:112                                     ; preds = %100
   %113 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %111, i32 0, i32 9
@@ -12575,23 +14284,23 @@ entry:
 
 ; <label>:116                                     ; preds = %112
   %117 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck32 = icmp ne %System.IO.StreamWriter addrspace(1)* %117, null
-  br i1 %NullCheck32, label %118, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.IO.StreamWriter addrspace(1)* %117, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %118
 
 ; <label>:118                                     ; preds = %116
   %119 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %117, i32 0, i32 3
   %120 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %119, align 8
   %121 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.IO.StreamWriter addrspace(1)* %121, null
-  br i1 %NullCheck34, label %122, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.IO.StreamWriter addrspace(1)* %121, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %122
 
 ; <label>:122                                     ; preds = %118
   %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
   %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
   %125 = load i32, i32* %loc1
   %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
-  %NullCheck36 = icmp ne i64 addrspace(1)* %126, null
-  br i1 %NullCheck36, label %127, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64 addrspace(1)* %126, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
   %128 = load i64, i64 addrspace(1)* %126
@@ -12613,15 +14322,15 @@ entry:
 
 ; <label>:140                                     ; preds = %136
   %141 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.IO.StreamWriter addrspace(1)* %141, null
-  br i1 %NullCheck38, label %142, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.IO.StreamWriter addrspace(1)* %141, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %142
 
 ; <label>:142                                     ; preds = %140
   %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
   %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
   %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
-  %NullCheck40 = icmp ne i64 addrspace(1)* %145, null
-  br i1 %NullCheck40, label %146, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i64 addrspace(1)* %145, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
   %147 = load i64, i64 addrspace(1)* %145
@@ -12642,83 +14351,83 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %25
+ThrowNullRef4:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %32
+ThrowNullRef6:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %37
+ThrowNullRef10:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %41
+ThrowNullRef12:                                   ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %58
+ThrowNullRef14:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %60
+ThrowNullRef16:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %65
+ThrowNullRef18:                                   ; preds = %65
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %80
+ThrowNullRef20:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %82
+ThrowNullRef22:                                   ; preds = %82
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %86
+ThrowNullRef24:                                   ; preds = %86
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %90
+ThrowNullRef26:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %94
+ThrowNullRef28:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %100
+ThrowNullRef30:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %116
+ThrowNullRef32:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %118
+ThrowNullRef34:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %122
+ThrowNullRef36:                                   ; preds = %122
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %140
+ThrowNullRef38:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %142
+ThrowNullRef40:                                   ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12785,8 +14494,8 @@ entry:
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %1 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
-  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
@@ -12794,8 +14503,8 @@ entry:
   %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
   %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
   %8 = load i64, i64 addrspace(1)* %6
@@ -12811,8 +14520,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %17, %System.IFormatProvider addrspace(1)* %16)
   %18 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %19 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %18, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.SyncTextWriter addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %7
   %21 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %18, i32 0, i32 4
@@ -12823,11 +14532,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12840,8 +14549,8 @@ entry:
   %this = alloca %System.IO.TextWriter addrspace(1)*
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.TextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
@@ -12851,8 +14560,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.Threading.Thread addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Threading.Thread addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %6)
@@ -12861,8 +14570,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1
   %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.TextWriter addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.TextWriter addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %11, i32 0, i32 2
@@ -12873,11 +14582,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13074,8 +14783,8 @@ entry:
   store double %param1, double* %arg1
   store i8 0, i8* %loc1
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
@@ -13085,16 +14794,16 @@ entry:
   %5 = addrspacecast i8* %loc1 to i8 addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %4, i8 addrspace(1)* %5)
   %6 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.SyncTextWriter addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
   %10 = load double, double* %arg1
   %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
   %13 = load i64, i64 addrspace(1)* %11
@@ -13129,11 +14838,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13150,8 +14859,8 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load double, double* %arg1
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -13165,8 +14874,8 @@ entry:
   call void %11(%System.IO.TextWriter addrspace(1)* %0, double %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
   %15 = load i64, i64 addrspace(1)* %13
@@ -13184,7 +14893,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13202,8 +14911,8 @@ entry:
   %1 = addrspacecast double* %arg1 to double addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -13218,8 +14927,8 @@ entry:
   %14 = bitcast double addrspace(1)* %1 to %System.Double addrspace(1)*
   %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Double addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Double addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
   %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
   %18 = load i64, i64 addrspace(1)* %16
@@ -13237,7 +14946,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13253,8 +14962,8 @@ entry:
   store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
   %0 = load %System.Double addrspace(1)*, %System.Double addrspace(1)** %this
   %1 = bitcast %System.Double addrspace(1)* %0 to double addrspace(1)*
-  %NullCheck = icmp ne double addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq double addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load double, double addrspace(1)* %1, align 8
@@ -13279,8 +14988,8 @@ entry:
   %loc0 = alloca %System.Globalization.NumberFormatInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 3
@@ -13290,8 +14999,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
@@ -13301,24 +15010,24 @@ entry:
   store %System.Globalization.NumberFormatInfo addrspace(1)* %10, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
   %11 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %7
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
   %15 = load i8, i8 addrspace(1)* %14, align 8
   %16 = zext i8 %15 to i32
   %17 = trunc i32 %16 to i8
-  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %11, null
-  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %11, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %13
   %19 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %11, i32 0, i32 29
   store i8 %17, i8 addrspace(1)* %19
   %20 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %21 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %20, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %20, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %18
   %23 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %20, i32 0, i32 3
@@ -13327,8 +15036,8 @@ entry:
 
 ; <label>:24                                      ; preds = %1, %22
   %25 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %25, null
-  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %25, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %26
 
 ; <label>:26                                      ; preds = %24
   %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %25, i32 0, i32 3
@@ -13339,23 +15048,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %18
+ThrowNullRef8:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13380,168 +15089,168 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 18
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %8, align 8
-  %NullCheck2 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %5, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %5, i32 0, i32 4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %9)
   %12 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 19
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %15, align 8
-  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %12, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %12, i32 0, i32 5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %16)
   %19 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %20 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %20, null
-  br i1 %NullCheck8, label %21, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %20, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %20, i32 0, i32 23
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  %NullCheck10 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %19, null
-  br i1 %NullCheck10, label %24, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %19, i32 0, i32 7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %25, %System.String addrspace(1)* %23)
   %26 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %27 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %27, i32 0, i32 22
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %29, align 8
-  %NullCheck14 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %26, null
-  br i1 %NullCheck14, label %31, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %26, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %26, i32 0, i32 6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %32, %System.String addrspace(1)* %30)
   %33 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %34 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Globalization.CultureData addrspace(1)* %34, null
-  br i1 %NullCheck16, label %35, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Globalization.CultureData addrspace(1)* %34, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %34, i32 0, i32 51
   %37 = load i32, i32 addrspace(1)* %36, align 8
-  %NullCheck18 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %33, null
-  br i1 %NullCheck18, label %38, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %33, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %33, i32 0, i32 21
   store i32 %37, i32 addrspace(1)* %39
   %40 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %41 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Globalization.CultureData addrspace(1)* %41, null
-  br i1 %NullCheck20, label %42, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Globalization.CultureData addrspace(1)* %41, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %41, i32 0, i32 52
   %44 = load i32, i32 addrspace(1)* %43, align 8
-  %NullCheck22 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %40, null
-  br i1 %NullCheck22, label %45, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %40, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %40, i32 0, i32 25
   store i32 %44, i32 addrspace(1)* %46
   %47 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %48 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.Globalization.CultureData addrspace(1)* %48, null
-  br i1 %NullCheck24, label %49, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Globalization.CultureData addrspace(1)* %48, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %49
 
 ; <label>:49                                      ; preds = %45
   %50 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %48, i32 0, i32 29
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck26 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %47, null
-  br i1 %NullCheck26, label %52, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %47, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %47, i32 0, i32 10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %53, %System.String addrspace(1)* %51)
   %54 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %55 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Globalization.CultureData addrspace(1)* %55, null
-  br i1 %NullCheck28, label %56, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Globalization.CultureData addrspace(1)* %55, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %56
 
 ; <label>:56                                      ; preds = %52
   %57 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %55, i32 0, i32 35
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %57, align 8
-  %NullCheck30 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %54, null
-  br i1 %NullCheck30, label %59, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %54, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %54, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %60, %System.String addrspace(1)* %58)
   %61 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %62 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck32 = icmp ne %System.Globalization.CultureData addrspace(1)* %62, null
-  br i1 %NullCheck32, label %63, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Globalization.CultureData addrspace(1)* %62, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %62, i32 0, i32 34
   %65 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %64, align 8
-  %NullCheck34 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %61, null
-  br i1 %NullCheck34, label %66, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %61, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %61, i32 0, i32 9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %67, %System.String addrspace(1)* %65)
   %68 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %69 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck36 = icmp ne %System.Globalization.CultureData addrspace(1)* %69, null
-  br i1 %NullCheck36, label %70, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Globalization.CultureData addrspace(1)* %69, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %70
 
 ; <label>:70                                      ; preds = %66
   %71 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %69, i32 0, i32 55
   %72 = load i32, i32 addrspace(1)* %71, align 8
-  %NullCheck38 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %68, null
-  br i1 %NullCheck38, label %73, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %68, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %68, i32 0, i32 22
   store i32 %72, i32 addrspace(1)* %74
   %75 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %76 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck40 = icmp ne %System.Globalization.CultureData addrspace(1)* %76, null
-  br i1 %NullCheck40, label %77, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Globalization.CultureData addrspace(1)* %76, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %76, i32 0, i32 57
   %79 = load i32, i32 addrspace(1)* %78, align 8
-  %NullCheck42 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %75, null
-  br i1 %NullCheck42, label %80, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %75, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %80
 
 ; <label>:80                                      ; preds = %77
   %81 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %75, i32 0, i32 24
   store i32 %79, i32 addrspace(1)* %81
   %82 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %83 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck44 = icmp ne %System.Globalization.CultureData addrspace(1)* %83, null
-  br i1 %NullCheck44, label %84, label %ThrowNullRef43
+  %NullCheck43 = icmp eq %System.Globalization.CultureData addrspace(1)* %83, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %84
 
 ; <label>:84                                      ; preds = %80
   %85 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %83, i32 0, i32 56
   %86 = load i32, i32 addrspace(1)* %85, align 8
-  %NullCheck46 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %82, null
-  br i1 %NullCheck46, label %87, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %82, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %82, i32 0, i32 23
@@ -13550,8 +15259,8 @@ entry:
 
 ; <label>:89                                      ; preds = %entry
   %90 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck100 = icmp ne %System.Globalization.CultureData addrspace(1)* %90, null
-  br i1 %NullCheck100, label %91, label %ThrowNullRef99
+  %NullCheck99 = icmp eq %System.Globalization.CultureData addrspace(1)* %90, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %91
 
 ; <label>:91                                      ; preds = %89
   %92 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %90, i32 0, i32 2
@@ -13569,8 +15278,8 @@ entry:
   %102 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %103 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %104 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %103)
-  %NullCheck48 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %102, null
-  br i1 %NullCheck48, label %105, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %102, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %105
 
 ; <label>:105                                     ; preds = %101
   %106 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %102, i32 0, i32 1
@@ -13578,8 +15287,8 @@ entry:
   %107 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %108 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %109 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %108)
-  %NullCheck50 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %107, null
-  br i1 %NullCheck50, label %110, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %107, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %110
 
 ; <label>:110                                     ; preds = %105
   %111 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %107, i32 0, i32 2
@@ -13587,8 +15296,8 @@ entry:
   %112 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %113 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %114 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %113)
-  %NullCheck52 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %112, null
-  br i1 %NullCheck52, label %115, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %112, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %115
 
 ; <label>:115                                     ; preds = %110
   %116 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %112, i32 0, i32 27
@@ -13596,8 +15305,8 @@ entry:
   %117 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %118 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %119 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %118)
-  %NullCheck54 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %117, null
-  br i1 %NullCheck54, label %120, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %117, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %120
 
 ; <label>:120                                     ; preds = %115
   %121 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %117, i32 0, i32 26
@@ -13605,8 +15314,8 @@ entry:
   %122 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %123 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %124 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %123)
-  %NullCheck56 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %122, null
-  br i1 %NullCheck56, label %125, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %122, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %125
 
 ; <label>:125                                     ; preds = %120
   %126 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %122, i32 0, i32 17
@@ -13614,8 +15323,8 @@ entry:
   %127 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %128 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %129 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %128)
-  %NullCheck58 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %127, null
-  br i1 %NullCheck58, label %130, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %127, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %130
 
 ; <label>:130                                     ; preds = %125
   %131 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %127, i32 0, i32 18
@@ -13623,8 +15332,8 @@ entry:
   %132 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %133 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %134 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %133)
-  %NullCheck60 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %132, null
-  br i1 %NullCheck60, label %135, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %132, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %135
 
 ; <label>:135                                     ; preds = %130
   %136 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %132, i32 0, i32 14
@@ -13632,8 +15341,8 @@ entry:
   %137 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %138 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %139 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %138)
-  %NullCheck62 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %137, null
-  br i1 %NullCheck62, label %140, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %137, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %140
 
 ; <label>:140                                     ; preds = %135
   %141 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %137, i32 0, i32 13
@@ -13641,71 +15350,71 @@ entry:
   %142 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %143 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %144 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %143)
-  %NullCheck64 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %142, null
-  br i1 %NullCheck64, label %145, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %142, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %145
 
 ; <label>:145                                     ; preds = %140
   %146 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %142, i32 0, i32 12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %146, %System.String addrspace(1)* %144)
   %147 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %148 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck66 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %148, null
-  br i1 %NullCheck66, label %149, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %148, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %149
 
 ; <label>:149                                     ; preds = %145
   %150 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %148, i32 0, i32 21
   %151 = load i32, i32 addrspace(1)* %150, align 8
-  %NullCheck68 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %147, null
-  br i1 %NullCheck68, label %152, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %147, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %152
 
 ; <label>:152                                     ; preds = %149
   %153 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %147, i32 0, i32 28
   store i32 %151, i32 addrspace(1)* %153
   %154 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %155 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck70 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %155, null
-  br i1 %NullCheck70, label %156, label %ThrowNullRef69
+  %NullCheck69 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %155, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %156
 
 ; <label>:156                                     ; preds = %152
   %157 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %155, i32 0, i32 6
   %158 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %157, align 8
-  %NullCheck72 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %154, null
-  br i1 %NullCheck72, label %159, label %ThrowNullRef71
+  %NullCheck71 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %154, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %159
 
 ; <label>:159                                     ; preds = %156
   %160 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %154, i32 0, i32 15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %160, %System.String addrspace(1)* %158)
   %161 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %162 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck74 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %162, null
-  br i1 %NullCheck74, label %163, label %ThrowNullRef73
+  %NullCheck73 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %162, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %163
 
 ; <label>:163                                     ; preds = %159
   %164 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %162, i32 0, i32 1
   %165 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %164, align 8
-  %NullCheck76 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %161, null
-  br i1 %NullCheck76, label %166, label %ThrowNullRef75
+  %NullCheck75 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %161, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %166
 
 ; <label>:166                                     ; preds = %163
   %167 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %161, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %167, %"System.Int32[]" addrspace(1)* %165)
   %168 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %169 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck78 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %169, null
-  br i1 %NullCheck78, label %170, label %ThrowNullRef77
+  %NullCheck77 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %169, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %170
 
 ; <label>:170                                     ; preds = %166
   %171 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %169, i32 0, i32 7
   %172 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %171, align 8
-  %NullCheck80 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %168, null
-  br i1 %NullCheck80, label %173, label %ThrowNullRef79
+  %NullCheck79 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %168, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %173
 
 ; <label>:173                                     ; preds = %170
   %174 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %168, i32 0, i32 16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %174, %System.String addrspace(1)* %172)
   %175 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck82 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %175, null
-  br i1 %NullCheck82, label %176, label %ThrowNullRef81
+  %NullCheck81 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %175, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %176
 
 ; <label>:176                                     ; preds = %173
   %177 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %175, i32 0, i32 4
@@ -13715,14 +15424,14 @@ entry:
 
 ; <label>:180                                     ; preds = %176
   %181 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck84 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %181, null
-  br i1 %NullCheck84, label %182, label %ThrowNullRef83
+  %NullCheck83 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %181, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %182
 
 ; <label>:182                                     ; preds = %180
   %183 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %181, i32 0, i32 4
   %184 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %183, align 8
-  %NullCheck86 = icmp ne %System.String addrspace(1)* %184, null
-  br i1 %NullCheck86, label %185, label %ThrowNullRef85
+  %NullCheck85 = icmp eq %System.String addrspace(1)* %184, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %185
 
 ; <label>:185                                     ; preds = %182
   %186 = getelementptr inbounds %System.String, %System.String addrspace(1)* %184, i32 0, i32 1
@@ -13733,8 +15442,8 @@ entry:
 ; <label>:189                                     ; preds = %176, %185
   %190 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck98 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %190, null
-  br i1 %NullCheck98, label %192, label %ThrowNullRef97
+  %NullCheck97 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %190, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %192
 
 ; <label>:192                                     ; preds = %189
   %193 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %190, i32 0, i32 4
@@ -13743,8 +15452,8 @@ entry:
 
 ; <label>:194                                     ; preds = %185, %192
   %195 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck88 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %195, null
-  br i1 %NullCheck88, label %196, label %ThrowNullRef87
+  %NullCheck87 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %195, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %196
 
 ; <label>:196                                     ; preds = %194
   %197 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %195, i32 0, i32 9
@@ -13754,14 +15463,14 @@ entry:
 
 ; <label>:200                                     ; preds = %196
   %201 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck90 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %201, null
-  br i1 %NullCheck90, label %202, label %ThrowNullRef89
+  %NullCheck89 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %201, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %202
 
 ; <label>:202                                     ; preds = %200
   %203 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %201, i32 0, i32 9
   %204 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %203, align 8
-  %NullCheck92 = icmp ne %System.String addrspace(1)* %204, null
-  br i1 %NullCheck92, label %205, label %ThrowNullRef91
+  %NullCheck91 = icmp eq %System.String addrspace(1)* %204, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %205
 
 ; <label>:205                                     ; preds = %202
   %206 = getelementptr inbounds %System.String, %System.String addrspace(1)* %204, i32 0, i32 1
@@ -13772,14 +15481,14 @@ entry:
 ; <label>:209                                     ; preds = %196, %205
   %210 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %211 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck94 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %211, null
-  br i1 %NullCheck94, label %212, label %ThrowNullRef93
+  %NullCheck93 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %211, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %212
 
 ; <label>:212                                     ; preds = %209
   %213 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %211, i32 0, i32 6
   %214 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %213, align 8
-  %NullCheck96 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %210, null
-  br i1 %NullCheck96, label %215, label %ThrowNullRef95
+  %NullCheck95 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %210, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %215
 
 ; <label>:215                                     ; preds = %212
   %216 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %210, i32 0, i32 9
@@ -13793,203 +15502,203 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %17
+ThrowNullRef8:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %21
+ThrowNullRef10:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %24
+ThrowNullRef12:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %28
+ThrowNullRef14:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %31
+ThrowNullRef16:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %35
+ThrowNullRef18:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %38
+ThrowNullRef20:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %42
+ThrowNullRef22:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %45
+ThrowNullRef24:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %49
+ThrowNullRef26:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %52
+ThrowNullRef28:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %56
+ThrowNullRef30:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %59
+ThrowNullRef32:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %63
+ThrowNullRef34:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %66
+ThrowNullRef36:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %70
+ThrowNullRef38:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %73
+ThrowNullRef40:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %77
+ThrowNullRef42:                                   ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %80
+ThrowNullRef44:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %84
+ThrowNullRef46:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %101
+ThrowNullRef48:                                   ; preds = %101
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %105
+ThrowNullRef50:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %110
+ThrowNullRef52:                                   ; preds = %110
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %115
+ThrowNullRef54:                                   ; preds = %115
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %120
+ThrowNullRef56:                                   ; preds = %120
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %125
+ThrowNullRef58:                                   ; preds = %125
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %130
+ThrowNullRef60:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %135
+ThrowNullRef62:                                   ; preds = %135
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %140
+ThrowNullRef64:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %145
+ThrowNullRef66:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %149
+ThrowNullRef68:                                   ; preds = %149
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %152
+ThrowNullRef70:                                   ; preds = %152
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %156
+ThrowNullRef72:                                   ; preds = %156
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %159
+ThrowNullRef74:                                   ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %163
+ThrowNullRef76:                                   ; preds = %163
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %166
+ThrowNullRef78:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %170
+ThrowNullRef80:                                   ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %173
+ThrowNullRef82:                                   ; preds = %173
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %180
+ThrowNullRef84:                                   ; preds = %180
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %182
+ThrowNullRef86:                                   ; preds = %182
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %194
+ThrowNullRef88:                                   ; preds = %194
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %200
+ThrowNullRef90:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %202
+ThrowNullRef92:                                   ; preds = %202
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %209
+ThrowNullRef94:                                   ; preds = %209
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %212
+ThrowNullRef96:                                   ; preds = %212
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %189
+ThrowNullRef98:                                   ; preds = %189
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %89
+ThrowNullRef100:                                  ; preds = %89
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14017,8 +15726,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 21
@@ -14031,8 +15740,8 @@ entry:
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 16)
   %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 21
@@ -14041,8 +15750,8 @@ entry:
 
 ; <label>:12                                      ; preds = %1, %10
   %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 21
@@ -14053,11 +15762,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %12
+ThrowNullRef4:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14073,8 +15782,8 @@ entry:
   store i32 %param1, i32* %arg1
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %1 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
@@ -14141,8 +15850,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 33
@@ -14155,8 +15864,8 @@ entry:
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 24)
   %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 33
@@ -14165,8 +15874,8 @@ entry:
 
 ; <label>:12                                      ; preds = %1, %10
   %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 33
@@ -14177,11 +15886,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %12
+ThrowNullRef4:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14194,8 +15903,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 53
@@ -14207,8 +15916,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 116)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 53
@@ -14217,8 +15926,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 53
@@ -14229,11 +15938,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14262,8 +15971,8 @@ entry:
 
 ; <label>:7                                       ; preds = %entry, %4
   %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %7
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 2
@@ -14287,8 +15996,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 54
@@ -14300,8 +16009,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 117)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
@@ -14310,8 +16019,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 54
@@ -14322,11 +16031,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14339,8 +16048,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 27
@@ -14352,8 +16061,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 118)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 27
@@ -14362,8 +16071,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 27
@@ -14374,11 +16083,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14391,8 +16100,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 28
@@ -14404,8 +16113,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 119)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 28
@@ -14414,8 +16123,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 28
@@ -14426,11 +16135,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14443,8 +16152,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 26
@@ -14456,8 +16165,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 107)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 26
@@ -14466,8 +16175,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 26
@@ -14478,11 +16187,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14495,8 +16204,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 25
@@ -14508,8 +16217,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 106)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 25
@@ -14518,8 +16227,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 25
@@ -14530,11 +16239,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14547,8 +16256,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 24
@@ -14560,8 +16269,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 105)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 24
@@ -14570,8 +16279,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 24
@@ -14582,11 +16291,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14611,8 +16320,8 @@ entry:
   %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %3)
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %2
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -14623,15 +16332,15 @@ entry:
 
 ; <label>:8                                       ; preds = %62
   %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 9
   %12 = load i32, i32 addrspace(1)* %11, align 8
   %13 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.IO.StreamWriter addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %13, i32 0, i32 10
@@ -14646,15 +16355,15 @@ entry:
 
 ; <label>:20                                      ; preds = %14, %18
   %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
   %24 = load i32, i32 addrspace(1)* %23, align 8
   %25 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %25, null
-  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.StreamWriter addrspace(1)* %25, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %25, i32 0, i32 9
@@ -14675,36 +16384,36 @@ entry:
   %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %37 = load i32, i32* %loc1
   %38 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.StreamWriter addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %35
   %40 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %38, i32 0, i32 7
   %41 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %40, align 8
   %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
-  br i1 %NullCheck14, label %43, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %39
   %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 9
   %45 = load i32, i32 addrspace(1)* %44, align 8
   %46 = load i32, i32* %loc2
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %36, null
-  br i1 %NullCheck16, label %47, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %36, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %47
 
 ; <label>:47                                      ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %36, i32 %37, %"System.Char[]" addrspace(1)* %41, i32 %45, i32 %46)
   %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
   %51 = load i32, i32 addrspace(1)* %50, align 8
   %52 = load i32, i32* %loc2
   %53 = add i32 %51, %52
-  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
-  br i1 %NullCheck20, label %54, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %54
 
 ; <label>:54                                      ; preds = %49
   %55 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
@@ -14726,8 +16435,8 @@ entry:
 
 ; <label>:65                                      ; preds = %62
   %66 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %66, null
-  br i1 %NullCheck2, label %67, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %66, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %67
 
 ; <label>:67                                      ; preds = %65
   %68 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %66, i32 0, i32 11
@@ -14748,49 +16457,259 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %65
+ThrowNullRef2:                                    ; preds = %65
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %20
+ThrowNullRef8:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %22
+ThrowNullRef10:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %35
+ThrowNullRef12:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %43
+ThrowNullRef16:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %47
+ThrowNullRef18:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method String::CopyTo using LLILCJit
-Failed to read String.CopyTo[loadElemA]
+Successfully read String.CopyTo
+
+define void @String.CopyTo(%System.String addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  %loc1 = alloca i16 addrspace(1)*
+  %loc2 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %1 = icmp ne %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg4
+  %7 = icmp sge i32 %6, 0
+  br i1 %7, label %13, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  unreachable
+
+; <label>:13                                      ; preds = %5
+  %14 = load i32, i32* %arg1
+  %15 = icmp sge i32 %14, 0
+  br i1 %15, label %21, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %18)
+  %20 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %20, %System.String addrspace(1)* %17, %System.String addrspace(1)* %19)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %20) #0
+  unreachable
+
+; <label>:21                                      ; preds = %13
+  %22 = load i32, i32* %arg4
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck, label %ThrowNullRef, label %24
+
+; <label>:24                                      ; preds = %21
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load i32, i32* %arg1
+  %28 = sub i32 %26, %27
+  %29 = icmp sle i32 %22, %28
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34, %System.String addrspace(1)* %31, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %24
+  %36 = load i32, i32* %arg3
+  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %37, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
+
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
+  %40 = load i32, i32 addrspace(1)* %39
+  %41 = zext i32 %40 to i64
+  %42 = trunc i64 %41 to i32
+  %43 = load i32, i32* %arg4
+  %44 = sub i32 %42, %43
+  %45 = icmp sgt i32 %36, %44
+  br i1 %45, label %49, label %46
+
+; <label>:46                                      ; preds = %38
+  %47 = load i32, i32* %arg3
+  %48 = icmp sge i32 %47, 0
+  br i1 %48, label %54, label %49
+
+; <label>:49                                      ; preds = %38, %46
+  %50 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %52 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %51)
+  %53 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53, %System.String addrspace(1)* %50, %System.String addrspace(1)* %52)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53) #0
+  unreachable
+
+; <label>:54                                      ; preds = %46
+  %55 = load i32, i32* %arg4
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %97, label %57
+
+; <label>:57                                      ; preds = %54
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %59
+
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 2
+  %61 = bitcast [0 x i16] addrspace(1)* %60 to i16 addrspace(1)*
+  store i16 addrspace(1)* %61, i16 addrspace(1)** %loc0
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  store %"System.Char[]" addrspace(1)* %62, %"System.Char[]" addrspace(1)** %loc2
+  %63 = icmp eq %"System.Char[]" addrspace(1)* %62, null
+  br i1 %63, label %72, label %64
+
+; <label>:64                                      ; preds = %59
+  %65 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc2
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %65, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %66
+
+; <label>:66                                      ; preds = %64
+  %67 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %65, i32 0, i32 1
+  %68 = load i32, i32 addrspace(1)* %67
+  %69 = zext i32 %68 to i64
+  %70 = trunc i64 %69 to i32
+  %71 = icmp ne i32 %70, 0
+  br i1 %71, label %73, label %72
+
+; <label>:72                                      ; preds = %59, %66
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  br label %81
+
+; <label>:73                                      ; preds = %66
+  %74 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc2
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %74, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %75
+
+; <label>:75                                      ; preds = %73
+  %76 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %74, i32 0, i32 1
+  %77 = load i32, i32 addrspace(1)* %76
+  %78 = zext i32 %77 to i64
+  %BoundsCheck = icmp uge i64 0, %78
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %79
+
+; <label>:79                                      ; preds = %75
+  %80 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %74, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %80, i16 addrspace(1)** %loc1
+  br label %81
+
+; <label>:81                                      ; preds = %72, %79
+  %82 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %83 = ptrtoint i16 addrspace(1)* %82 to i64
+  %84 = load i32, i32* %arg3
+  %85 = sext i32 %84 to i64
+  %86 = mul i64 %85, 2
+  %87 = add i64 %83, %86
+  %88 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %89 = ptrtoint i16 addrspace(1)* %88 to i64
+  %90 = load i32, i32* %arg1
+  %91 = sext i32 %90 to i64
+  %92 = mul i64 %91, 2
+  %93 = add i64 %89, %92
+  %94 = load i32, i32* %arg4
+  %95 = inttoptr i64 %87 to i16*
+  %96 = inttoptr i64 %93 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %95, i16* %96, i32 %94)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  br label %97
+
+; <label>:97                                      ; preds = %54, %81
+  ret void
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
 Successfully read ConsoleEncoding.GetPreamble
 
@@ -14827,7 +16746,365 @@ entry:
 }
 
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[loadElemA]
+Successfully read EncoderNLS.GetBytes
+
+define i32 @EncoderNLS.GetBytes(%System.Text.EncoderNLS addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3, %"System.Byte[]" addrspace(1)* %param4, i32 %param5, i8 %param6) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %arg4 = alloca %"System.Byte[]" addrspace(1)*
+  %arg5 = alloca i32
+  %arg6 = alloca i8
+  %loc0 = alloca i32
+  %loc1 = alloca i16 addrspace(1)*
+  %loc2 = alloca i8 addrspace(1)*
+  %loc3 = alloca i32
+  %loc4 = alloca %"System.Char[]" addrspace(1)*
+  %loc5 = alloca %"System.Byte[]" addrspace(1)*
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  store %"System.Byte[]" addrspace(1)* %param4, %"System.Byte[]" addrspace(1)** %arg4
+  store i32 %param5, i32* %arg5
+  store i8 %param6, i8* %arg6
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %1 = icmp eq %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %17, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %7 = icmp eq %"System.Char[]" addrspace(1)* %6, null
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %12
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %12
+
+; <label>:12                                      ; preds = %8, %10
+  %13 = phi %System.String addrspace(1)* [ %9, %8 ], [ %11, %10 ]
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %14)
+  %16 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16, %System.String addrspace(1)* %13, %System.String addrspace(1)* %15)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16) #0
+  unreachable
+
+; <label>:17                                      ; preds = %2
+  %18 = load i32, i32* %arg2
+  %19 = icmp slt i32 %18, 0
+  br i1 %19, label %23, label %20
+
+; <label>:20                                      ; preds = %17
+  %21 = load i32, i32* %arg3
+  %22 = icmp sge i32 %21, 0
+  br i1 %22, label %35, label %23
+
+; <label>:23                                      ; preds = %17, %20
+  %24 = load i32, i32* %arg2
+  %25 = icmp slt i32 %24, 0
+  br i1 %25, label %28, label %26
+
+; <label>:26                                      ; preds = %23
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %30
+
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %30
+
+; <label>:30                                      ; preds = %26, %28
+  %31 = phi %System.String addrspace(1)* [ %27, %26 ], [ %29, %28 ]
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34, %System.String addrspace(1)* %31, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %20
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck, label %ThrowNullRef, label %37
+
+; <label>:37                                      ; preds = %35
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = load i32, i32* %arg2
+  %43 = sub i32 %41, %42
+  %44 = load i32, i32* %arg3
+  %45 = icmp sge i32 %43, %44
+  br i1 %45, label %51, label %46
+
+; <label>:46                                      ; preds = %37
+  %47 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %48 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %49 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %48)
+  %50 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %50, %System.String addrspace(1)* %47, %System.String addrspace(1)* %49)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %50) #0
+  unreachable
+
+; <label>:51                                      ; preds = %37
+  %52 = load i32, i32* %arg5
+  %53 = icmp slt i32 %52, 0
+  br i1 %53, label %63, label %54
+
+; <label>:54                                      ; preds = %51
+  %55 = load i32, i32* %arg5
+  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck1 = icmp eq %"System.Byte[]" addrspace(1)* %56, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %57
+
+; <label>:57                                      ; preds = %54
+  %58 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = zext i32 %59 to i64
+  %61 = trunc i64 %60 to i32
+  %62 = icmp sle i32 %55, %61
+  br i1 %62, label %68, label %63
+
+; <label>:63                                      ; preds = %51, %57
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %66 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %65)
+  %67 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %67, %System.String addrspace(1)* %64, %System.String addrspace(1)* %66)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %67) #0
+  unreachable
+
+; <label>:68                                      ; preds = %57
+  %69 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %69, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %69, i32 0, i32 1
+  %72 = load i32, i32 addrspace(1)* %71
+  %73 = zext i32 %72 to i64
+  %74 = trunc i64 %73 to i32
+  %75 = icmp ne i32 %74, 0
+  br i1 %75, label %78, label %76
+
+; <label>:76                                      ; preds = %70
+  %77 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1)
+  store %"System.Char[]" addrspace(1)* %77, %"System.Char[]" addrspace(1)** %arg1
+  br label %78
+
+; <label>:78                                      ; preds = %70, %76
+  %79 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck5 = icmp eq %"System.Byte[]" addrspace(1)* %79, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %80
+
+; <label>:80                                      ; preds = %78
+  %81 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %79, i32 0, i32 1
+  %82 = load i32, i32 addrspace(1)* %81
+  %83 = zext i32 %82 to i64
+  %84 = trunc i64 %83 to i32
+  %85 = load i32, i32* %arg5
+  %86 = sub i32 %84, %85
+  store i32 %86, i32* %loc0
+  %87 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck7 = icmp eq %"System.Byte[]" addrspace(1)* %87, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %88
+
+; <label>:88                                      ; preds = %80
+  %89 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %87, i32 0, i32 1
+  %90 = load i32, i32 addrspace(1)* %89
+  %91 = zext i32 %90 to i64
+  %92 = trunc i64 %91 to i32
+  %93 = icmp ne i32 %92, 0
+  br i1 %93, label %96, label %94
+
+; <label>:94                                      ; preds = %88
+  %95 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1)
+  store %"System.Byte[]" addrspace(1)* %95, %"System.Byte[]" addrspace(1)** %arg4
+  br label %96
+
+; <label>:96                                      ; preds = %88, %94
+  %97 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  store %"System.Char[]" addrspace(1)* %97, %"System.Char[]" addrspace(1)** %loc4
+  %98 = icmp eq %"System.Char[]" addrspace(1)* %97, null
+  br i1 %98, label %107, label %99
+
+; <label>:99                                      ; preds = %96
+  %100 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc4
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %100, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %101
+
+; <label>:101                                     ; preds = %99
+  %102 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %100, i32 0, i32 1
+  %103 = load i32, i32 addrspace(1)* %102
+  %104 = zext i32 %103 to i64
+  %105 = trunc i64 %104 to i32
+  %106 = icmp ne i32 %105, 0
+  br i1 %106, label %108, label %107
+
+; <label>:107                                     ; preds = %96, %101
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  br label %116
+
+; <label>:108                                     ; preds = %101
+  %109 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc4
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %109, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %110
+
+; <label>:110                                     ; preds = %108
+  %111 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %109, i32 0, i32 1
+  %112 = load i32, i32 addrspace(1)* %111
+  %113 = zext i32 %112 to i64
+  %BoundsCheck = icmp uge i64 0, %113
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %114
+
+; <label>:114                                     ; preds = %110
+  %115 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %109, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %115, i16 addrspace(1)** %loc1
+  br label %116
+
+; <label>:116                                     ; preds = %107, %114
+  %117 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  store %"System.Byte[]" addrspace(1)* %117, %"System.Byte[]" addrspace(1)** %loc5
+  %118 = icmp eq %"System.Byte[]" addrspace(1)* %117, null
+  br i1 %118, label %127, label %119
+
+; <label>:119                                     ; preds = %116
+  %120 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc5
+  %NullCheck13 = icmp eq %"System.Byte[]" addrspace(1)* %120, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %121
+
+; <label>:121                                     ; preds = %119
+  %122 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %120, i32 0, i32 1
+  %123 = load i32, i32 addrspace(1)* %122
+  %124 = zext i32 %123 to i64
+  %125 = trunc i64 %124 to i32
+  %126 = icmp ne i32 %125, 0
+  br i1 %126, label %128, label %127
+
+; <label>:127                                     ; preds = %116, %121
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc2
+  br label %136
+
+; <label>:128                                     ; preds = %121
+  %129 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc5
+  %NullCheck15 = icmp eq %"System.Byte[]" addrspace(1)* %129, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %130
+
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %129, i32 0, i32 1
+  %132 = load i32, i32 addrspace(1)* %131
+  %133 = zext i32 %132 to i64
+  %BoundsCheck17 = icmp uge i64 0, %133
+  br i1 %BoundsCheck17, label %ThrowIndexOutOfRange18, label %134
+
+; <label>:134                                     ; preds = %130
+  %135 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %129, i32 0, i32 3, i32 0
+  store i8 addrspace(1)* %135, i8 addrspace(1)** %loc2
+  br label %136
+
+; <label>:136                                     ; preds = %127, %134
+  %137 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %138 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %139 = ptrtoint i16 addrspace(1)* %138 to i64
+  %140 = load i32, i32* %arg2
+  %141 = sext i32 %140 to i64
+  %142 = mul i64 %141, 2
+  %143 = add i64 %139, %142
+  %144 = load i32, i32* %arg3
+  %145 = load i8 addrspace(1)*, i8 addrspace(1)** %loc2
+  %146 = ptrtoint i8 addrspace(1)* %145 to i64
+  %147 = load i32, i32* %arg5
+  %148 = sext i32 %147 to i64
+  %149 = add i64 %146, %148
+  %150 = load i32, i32* %loc0
+  %151 = load i8, i8* %arg6
+  %152 = zext i8 %151 to i32
+  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i64 addrspace(1)*
+  %NullCheck19 = icmp eq i64 addrspace(1)* %153, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %154
+
+; <label>:154                                     ; preds = %136
+  %155 = load i64, i64 addrspace(1)* %153
+  %156 = add i64 %155, 72
+  %157 = inttoptr i64 %156 to i64*
+  %158 = load i64, i64* %157
+  %159 = add i64 %158, 0
+  %160 = inttoptr i64 %159 to i64*
+  %161 = load i64, i64* %160
+  %162 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to %System.Text.Encoder addrspace(1)*
+  %163 = inttoptr i64 %143 to i16*
+  %164 = inttoptr i64 %149 to i8*
+  %165 = trunc i32 %152 to i8
+  %166 = inttoptr i64 %161 to i32 (%System.Text.Encoder addrspace(1)*, i16*, i32, i8*, i32, i8)*
+  %167 = call i32 %166(%System.Text.Encoder addrspace(1)* %162, i16* %163, i32 %144, i8* %164, i32 %150, i8 %165)
+  store i32 %167, i32* %loc3
+  br label %168
+
+; <label>:168                                     ; preds = %154
+  %169 = load i32, i32* %loc3
+  ret i32 %169
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %110
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %119
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange18:                           ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
 Successfully read EncoderNLS.GetBytes
 
@@ -14916,22 +17193,22 @@ entry:
   %40 = load i8, i8* %arg5
   %41 = zext i8 %40 to i32
   %42 = trunc i32 %41 to i8
-  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %39, null
-  br i1 %NullCheck, label %43, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderNLS addrspace(1)* %39, null
+  br i1 %NullCheck, label %ThrowNullRef, label %43
 
 ; <label>:43                                      ; preds = %38
   %44 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
   store i8 %42, i8 addrspace(1)* %44
   %45 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %45, null
-  br i1 %NullCheck2, label %46, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.EncoderNLS addrspace(1)* %45, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %46
 
 ; <label>:46                                      ; preds = %43
   %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %45, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %47
   %48 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.EncoderNLS addrspace(1)* %48, null
-  br i1 %NullCheck4, label %49, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.EncoderNLS addrspace(1)* %48, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %49
 
 ; <label>:49                                      ; preds = %46
   %50 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %48, i32 0, i32 3
@@ -14942,8 +17219,8 @@ entry:
   %55 = load i32, i32* %arg4
   %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck6, label %58, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
   %59 = load i64, i64 addrspace(1)* %57
@@ -14961,15 +17238,15 @@ ThrowNullRef:                                     ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %43
+ThrowNullRef2:                                    ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %46
+ThrowNullRef4:                                    ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %49
+ThrowNullRef6:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14997,8 +17274,8 @@ entry:
   %4 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0 to %System.IO.ConsoleStream addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*)(%System.IO.ConsoleStream addrspace(1)* %4, %"System.Byte[]" addrspace(1)* %1, i32 %2, i32 %3)
   %5 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
@@ -15083,8 +17360,8 @@ entry:
 
 ; <label>:22                                      ; preds = %8
   %23 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %23, null
-  br i1 %NullCheck, label %24, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Byte[]" addrspace(1)* %23, null
+  br i1 %NullCheck, label %ThrowNullRef, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
@@ -15106,8 +17383,8 @@ entry:
 
 ; <label>:36                                      ; preds = %24
   %37 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %37, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.ConsoleStream addrspace(1)* %37, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %37, i32 0, i32 4
@@ -15128,13 +17405,138 @@ ThrowNullRef:                                     ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %36
+ThrowNullRef2:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
-Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
+Successfully read WindowsConsoleStream.WriteFileNative
+
+define i32 @WindowsConsoleStream.WriteFileNative(i64 %param0, %"System.Byte[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i64
+  %arg1 = alloca %"System.Byte[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i8 addrspace(1)*
+  %loc2 = alloca %"System.Byte[]" addrspace(1)*
+  %loc3 = alloca i32
+  store i64 %param0, i64* %arg0
+  store %"System.Byte[]" addrspace(1)* %param1, %"System.Byte[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Byte[]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = zext i32 %3 to i64
+  %5 = icmp ne i64 %4, 0
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %1
+  ret i32 0
+
+; <label>:7                                       ; preds = %1
+  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  store %"System.Byte[]" addrspace(1)* %8, %"System.Byte[]" addrspace(1)** %loc2
+  %9 = icmp eq %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %9, label %18, label %10
+
+; <label>:10                                      ; preds = %7
+  %11 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc2
+  %NullCheck1 = icmp eq %"System.Byte[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %11, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp ne i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %7, %12
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc1
+  br label %27
+
+; <label>:19                                      ; preds = %12
+  %20 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc2
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %20, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %BoundsCheck = icmp uge i64 0, %24
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %25
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %20, i32 0, i32 3, i32 0
+  store i8 addrspace(1)* %26, i8 addrspace(1)** %loc1
+  br label %27
+
+; <label>:27                                      ; preds = %18, %25
+  %28 = load i64, i64* %arg0
+  %29 = load i8 addrspace(1)*, i8 addrspace(1)** %loc1
+  %30 = ptrtoint i8 addrspace(1)* %29 to i64
+  %31 = load i32, i32* %arg2
+  %32 = sext i32 %31 to i64
+  %33 = add i64 %30, %32
+  %34 = load i32, i32* %arg3
+  %35 = addrspacecast i32* %loc3 to i32 addrspace(1)*
+  %36 = inttoptr i64 %33 to i8*
+  %37 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i8*, i32, i32 addrspace(1)*, i64)*)(i64 %28, i8* %36, i32 %34, i32 addrspace(1)* %35, i64 0)
+  %38 = icmp ugt i32 %37, 0
+  %39 = sext i1 %38 to i32
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc1
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %42, label %41
+
+; <label>:41                                      ; preds = %27
+  ret i32 0
+
+; <label>:42                                      ; preds = %27
+  %43 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  store i32 %43, i32* %loc0
+  %44 = load i32, i32* %loc0
+  %45 = icmp eq i32 %44, 232
+  br i1 %45, label %49, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = load i32, i32* %loc0
+  %48 = icmp ne i32 %47, 109
+  br i1 %48, label %50, label %49
+
+; <label>:49                                      ; preds = %42, %46
+  ret i32 0
+
+; <label>:50                                      ; preds = %46
+  %51 = load i32, i32* %loc0
+  ret i32 %51
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
 Successfully read WindowsConsoleStream.Flush
 
@@ -15143,8 +17545,8 @@ entry:
   %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
   store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
@@ -15179,8 +17581,8 @@ entry:
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
   %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load i64, i64 addrspace(1)* %1
@@ -15219,15 +17621,15 @@ entry:
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.TextWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
   %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %3, align 8
   %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
   %7 = load i64, i64 addrspace(1)* %5
@@ -15245,7 +17647,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -15274,8 +17676,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %4)
   store i32 0, i32* %loc0
   %5 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Char[]" addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
@@ -15287,15 +17689,15 @@ entry:
 
 ; <label>:11                                      ; preds = %69
   %12 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %12, i32 0, i32 9
   %15 = load i32, i32 addrspace(1)* %14, align 8
   %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.IO.StreamWriter addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %16, i32 0, i32 10
@@ -15310,15 +17712,15 @@ entry:
 
 ; <label>:23                                      ; preds = %17, %21
   %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %24, null
-  br i1 %NullCheck8, label %25, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %24, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 10
   %27 = load i32, i32 addrspace(1)* %26, align 8
   %28 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %28, null
-  br i1 %NullCheck10, label %29, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.StreamWriter addrspace(1)* %28, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %28, i32 0, i32 9
@@ -15340,15 +17742,15 @@ entry:
   %40 = load i32, i32* %loc0
   %41 = mul i32 %40, 2
   %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
-  br i1 %NullCheck12, label %43, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %43
 
 ; <label>:43                                      ; preds = %38
   %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 7
   %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %44, align 8
   %46 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %46, null
-  br i1 %NullCheck14, label %47, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.IO.StreamWriter addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %47
 
 ; <label>:47                                      ; preds = %43
   %48 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %46, i32 0, i32 9
@@ -15360,16 +17762,16 @@ entry:
   %54 = bitcast %"System.Char[]" addrspace(1)* %45 to %System.Array addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %53, i32 %41, %System.Array addrspace(1)* %54, i32 %50, i32 %52)
   %55 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
-  br i1 %NullCheck16, label %56, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %56
 
 ; <label>:56                                      ; preds = %47
   %57 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
   %58 = load i32, i32 addrspace(1)* %57, align 8
   %59 = load i32, i32* %loc2
   %60 = add i32 %58, %59
-  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
-  br i1 %NullCheck18, label %61, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %61
 
 ; <label>:61                                      ; preds = %56
   %62 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
@@ -15391,8 +17793,8 @@ entry:
 
 ; <label>:72                                      ; preds = %69
   %73 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %73, null
-  br i1 %NullCheck2, label %74, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %73, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %74
 
 ; <label>:74                                      ; preds = %72
   %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %73, i32 0, i32 11
@@ -15413,39 +17815,39 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %72
+ThrowNullRef2:                                    ; preds = %72
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %23
+ThrowNullRef8:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef10:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %43
+ThrowNullRef14:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %47
+ThrowNullRef16:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %56
+ThrowNullRef18:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -15472,8 +17874,8 @@ entry:
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load float, float* %arg0
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -15505,8 +17907,8 @@ entry:
   store float %param1, float* %arg1
   store i8 0, i8* %loc1
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
@@ -15516,16 +17918,16 @@ entry:
   %5 = addrspacecast i8* %loc1 to i8 addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %4, i8 addrspace(1)* %5)
   %6 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.SyncTextWriter addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
   %10 = load float, float* %arg1
   %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
   %13 = load i64, i64 addrspace(1)* %11
@@ -15560,11 +17962,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -15581,8 +17983,8 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load float, float* %arg1
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -15596,8 +17998,8 @@ entry:
   call void %11(%System.IO.TextWriter addrspace(1)* %0, float %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
   %15 = load i64, i64 addrspace(1)* %13
@@ -15615,7 +18017,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -15633,8 +18035,8 @@ entry:
   %1 = addrspacecast float* %arg1 to float addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -15649,8 +18051,8 @@ entry:
   %14 = bitcast float addrspace(1)* %1 to %System.Single addrspace(1)*
   %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Single addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Single addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
   %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
   %18 = load i64, i64 addrspace(1)* %16
@@ -15668,7 +18070,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -15684,8 +18086,8 @@ entry:
   store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
   %0 = load %System.Single addrspace(1)*, %System.Single addrspace(1)** %this
   %1 = bitcast %System.Single addrspace(1)* %0 to float addrspace(1)*
-  %NullCheck = icmp ne float addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq float addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load float, float addrspace(1)* %1, align 8

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPConvF2I.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPConvF2I.error.txt
@@ -25,8 +25,8 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
@@ -40,8 +40,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
   %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
@@ -75,7 +75,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -90,8 +90,8 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %NullCheck = icmp ne i8 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = load i8, i8 addrspace(1)* %0, align 8
@@ -125,8 +125,8 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
@@ -159,8 +159,8 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -184,8 +184,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
   store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
@@ -195,8 +195,8 @@ entry:
 ; <label>:4                                       ; preds = %1
   %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
   %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
@@ -206,8 +206,8 @@ entry:
   %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
@@ -221,14 +221,14 @@ entry:
 
 ; <label>:17                                      ; preds = %14
   %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
   %21 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
@@ -238,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -249,8 +249,8 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
@@ -261,27 +261,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %30
+ThrowNullRef10:                                   ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -301,7 +301,89 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
-Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
+Successfully read AppDomainSetup.GetUnsecureApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.GetUnsecureApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %NullCheck = icmp eq %"System.String[]" addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %BoundsCheck = icmp uge i64 0, %5
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %6
+
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 3, i32 0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
+  ret %System.String addrspace(1)* %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_Value using LLILCJit
+Successfully read AppDomainSetup.get_Value
+
+define %"System.String[]" addrspace(1)* @AppDomainSetup.get_Value(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.String[]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 18)
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.String[]" addrspace(1)* addrspace(1)*, %"System.String[]" addrspace(1)*)*)(%"System.String[]" addrspace(1)* addrspace(1)* %9, %"System.String[]" addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %11, i32 0, i32 1
+  %14 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %13, align 8
+  ret %"System.String[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -319,8 +401,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -368,16 +450,16 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
   %5 = load i32, i32 addrspace(1)* %4
   %6 = sub i32 %5, 1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -389,7 +471,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -421,8 +503,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
@@ -456,8 +538,8 @@ entry:
 ; <label>:27                                      ; preds = %19
   %28 = load i32, i32* %arg1
   %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
-  br i1 %NullCheck2, label %30, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %29, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %30
 
 ; <label>:30                                      ; preds = %27
   %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
@@ -493,8 +575,8 @@ entry:
 ; <label>:49                                      ; preds = %46
   %50 = load i32, i32* %arg2
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck4, label %52, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
@@ -517,11 +599,11 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %27
+ThrowNullRef2:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %49
+ThrowNullRef4:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -544,16 +626,16 @@ entry:
   %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %0)
   store %System.String addrspace(1)* %1, %System.String addrspace(1)** %loc0
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 2
   %5 = bitcast [0 x i16] addrspace(1)* %4 to i16 addrspace(1)*
   store i16 addrspace(1)* %5, i16 addrspace(1)** %loc1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %3
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2
@@ -580,7 +662,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -691,15 +773,15 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %NullCheck132 = icmp ne i8* %21, null
-  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+  %NullCheck131 = icmp eq i8* %21, null
+  br i1 %NullCheck131, label %ThrowNullRef132, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = load i8, i8* %21, align 8
   %24 = zext i8 %23 to i32
   %25 = trunc i32 %24 to i8
-  %NullCheck134 = icmp ne i8* %20, null
-  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+  %NullCheck133 = icmp eq i8* %20, null
+  br i1 %NullCheck133, label %ThrowNullRef134, label %26
 
 ; <label>:26                                      ; preds = %22
   store i8 %25, i8* %20, align 8
@@ -709,16 +791,16 @@ entry:
   %28 = load i8*, i8** %arg0
   %29 = load i8*, i8** %arg1
   %30 = bitcast i8* %29 to i16*
-  %NullCheck128 = icmp ne i16* %30, null
-  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+  %NullCheck127 = icmp eq i16* %30, null
+  br i1 %NullCheck127, label %ThrowNullRef128, label %31
 
 ; <label>:31                                      ; preds = %27
   %32 = load i16, i16* %30, align 8
   %33 = sext i16 %32 to i32
   %34 = bitcast i8* %28 to i16*
   %35 = trunc i32 %33 to i16
-  %NullCheck130 = icmp ne i16* %34, null
-  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+  %NullCheck129 = icmp eq i16* %34, null
+  br i1 %NullCheck129, label %ThrowNullRef130, label %36
 
 ; <label>:36                                      ; preds = %31
   store i16 %35, i16* %34, align 8
@@ -728,16 +810,16 @@ entry:
   %38 = load i8*, i8** %arg0
   %39 = load i8*, i8** %arg1
   %40 = bitcast i8* %39 to i16*
-  %NullCheck120 = icmp ne i16* %40, null
-  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+  %NullCheck119 = icmp eq i16* %40, null
+  br i1 %NullCheck119, label %ThrowNullRef120, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i16, i16* %40, align 8
   %43 = sext i16 %42 to i32
   %44 = bitcast i8* %38 to i16*
   %45 = trunc i32 %43 to i16
-  %NullCheck122 = icmp ne i16* %44, null
-  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+  %NullCheck121 = icmp eq i16* %44, null
+  br i1 %NullCheck121, label %ThrowNullRef122, label %46
 
 ; <label>:46                                      ; preds = %41
   store i16 %45, i16* %44, align 8
@@ -745,15 +827,15 @@ entry:
   %48 = getelementptr inbounds i8, i8* %47, i64 2
   %49 = load i8*, i8** %arg1
   %50 = getelementptr inbounds i8, i8* %49, i64 2
-  %NullCheck124 = icmp ne i8* %50, null
-  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+  %NullCheck123 = icmp eq i8* %50, null
+  br i1 %NullCheck123, label %ThrowNullRef124, label %51
 
 ; <label>:51                                      ; preds = %46
   %52 = load i8, i8* %50, align 8
   %53 = zext i8 %52 to i32
   %54 = trunc i32 %53 to i8
-  %NullCheck126 = icmp ne i8* %48, null
-  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+  %NullCheck125 = icmp eq i8* %48, null
+  br i1 %NullCheck125, label %ThrowNullRef126, label %55
 
 ; <label>:55                                      ; preds = %51
   store i8 %54, i8* %48, align 8
@@ -763,14 +845,14 @@ entry:
   %57 = load i8*, i8** %arg0
   %58 = load i8*, i8** %arg1
   %59 = bitcast i8* %58 to i32*
-  %NullCheck116 = icmp ne i32* %59, null
-  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+  %NullCheck115 = icmp eq i32* %59, null
+  br i1 %NullCheck115, label %ThrowNullRef116, label %60
 
 ; <label>:60                                      ; preds = %56
   %61 = load i32, i32* %59, align 8
   %62 = bitcast i8* %57 to i32*
-  %NullCheck118 = icmp ne i32* %62, null
-  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+  %NullCheck117 = icmp eq i32* %62, null
+  br i1 %NullCheck117, label %ThrowNullRef118, label %63
 
 ; <label>:63                                      ; preds = %60
   store i32 %61, i32* %62, align 8
@@ -780,14 +862,14 @@ entry:
   %65 = load i8*, i8** %arg0
   %66 = load i8*, i8** %arg1
   %67 = bitcast i8* %66 to i32*
-  %NullCheck108 = icmp ne i32* %67, null
-  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+  %NullCheck107 = icmp eq i32* %67, null
+  br i1 %NullCheck107, label %ThrowNullRef108, label %68
 
 ; <label>:68                                      ; preds = %64
   %69 = load i32, i32* %67, align 8
   %70 = bitcast i8* %65 to i32*
-  %NullCheck110 = icmp ne i32* %70, null
-  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+  %NullCheck109 = icmp eq i32* %70, null
+  br i1 %NullCheck109, label %ThrowNullRef110, label %71
 
 ; <label>:71                                      ; preds = %68
   store i32 %69, i32* %70, align 8
@@ -795,15 +877,15 @@ entry:
   %73 = getelementptr inbounds i8, i8* %72, i64 4
   %74 = load i8*, i8** %arg1
   %75 = getelementptr inbounds i8, i8* %74, i64 4
-  %NullCheck112 = icmp ne i8* %75, null
-  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+  %NullCheck111 = icmp eq i8* %75, null
+  br i1 %NullCheck111, label %ThrowNullRef112, label %76
 
 ; <label>:76                                      ; preds = %71
   %77 = load i8, i8* %75, align 8
   %78 = zext i8 %77 to i32
   %79 = trunc i32 %78 to i8
-  %NullCheck114 = icmp ne i8* %73, null
-  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+  %NullCheck113 = icmp eq i8* %73, null
+  br i1 %NullCheck113, label %ThrowNullRef114, label %80
 
 ; <label>:80                                      ; preds = %76
   store i8 %79, i8* %73, align 8
@@ -813,14 +895,14 @@ entry:
   %82 = load i8*, i8** %arg0
   %83 = load i8*, i8** %arg1
   %84 = bitcast i8* %83 to i32*
-  %NullCheck100 = icmp ne i32* %84, null
-  br i1 %NullCheck100, label %85, label %ThrowNullRef99
+  %NullCheck99 = icmp eq i32* %84, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %85
 
 ; <label>:85                                      ; preds = %81
   %86 = load i32, i32* %84, align 8
   %87 = bitcast i8* %82 to i32*
-  %NullCheck102 = icmp ne i32* %87, null
-  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+  %NullCheck101 = icmp eq i32* %87, null
+  br i1 %NullCheck101, label %ThrowNullRef102, label %88
 
 ; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
@@ -829,16 +911,16 @@ entry:
   %91 = load i8*, i8** %arg1
   %92 = getelementptr inbounds i8, i8* %91, i64 4
   %93 = bitcast i8* %92 to i16*
-  %NullCheck104 = icmp ne i16* %93, null
-  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+  %NullCheck103 = icmp eq i16* %93, null
+  br i1 %NullCheck103, label %ThrowNullRef104, label %94
 
 ; <label>:94                                      ; preds = %88
   %95 = load i16, i16* %93, align 8
   %96 = sext i16 %95 to i32
   %97 = bitcast i8* %90 to i16*
   %98 = trunc i32 %96 to i16
-  %NullCheck106 = icmp ne i16* %97, null
-  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+  %NullCheck105 = icmp eq i16* %97, null
+  br i1 %NullCheck105, label %ThrowNullRef106, label %99
 
 ; <label>:99                                      ; preds = %94
   store i16 %98, i16* %97, align 8
@@ -848,14 +930,14 @@ entry:
   %101 = load i8*, i8** %arg0
   %102 = load i8*, i8** %arg1
   %103 = bitcast i8* %102 to i32*
-  %NullCheck88 = icmp ne i32* %103, null
-  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+  %NullCheck87 = icmp eq i32* %103, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %104
 
 ; <label>:104                                     ; preds = %100
   %105 = load i32, i32* %103, align 8
   %106 = bitcast i8* %101 to i32*
-  %NullCheck90 = icmp ne i32* %106, null
-  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+  %NullCheck89 = icmp eq i32* %106, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %107
 
 ; <label>:107                                     ; preds = %104
   store i32 %105, i32* %106, align 8
@@ -864,16 +946,16 @@ entry:
   %110 = load i8*, i8** %arg1
   %111 = getelementptr inbounds i8, i8* %110, i64 4
   %112 = bitcast i8* %111 to i16*
-  %NullCheck92 = icmp ne i16* %112, null
-  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+  %NullCheck91 = icmp eq i16* %112, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %113
 
 ; <label>:113                                     ; preds = %107
   %114 = load i16, i16* %112, align 8
   %115 = sext i16 %114 to i32
   %116 = bitcast i8* %109 to i16*
   %117 = trunc i32 %115 to i16
-  %NullCheck94 = icmp ne i16* %116, null
-  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+  %NullCheck93 = icmp eq i16* %116, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %118
 
 ; <label>:118                                     ; preds = %113
   store i16 %117, i16* %116, align 8
@@ -881,15 +963,15 @@ entry:
   %120 = getelementptr inbounds i8, i8* %119, i64 6
   %121 = load i8*, i8** %arg1
   %122 = getelementptr inbounds i8, i8* %121, i64 6
-  %NullCheck96 = icmp ne i8* %122, null
-  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+  %NullCheck95 = icmp eq i8* %122, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %123
 
 ; <label>:123                                     ; preds = %118
   %124 = load i8, i8* %122, align 8
   %125 = zext i8 %124 to i32
   %126 = trunc i32 %125 to i8
-  %NullCheck98 = icmp ne i8* %120, null
-  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+  %NullCheck97 = icmp eq i8* %120, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %127
 
 ; <label>:127                                     ; preds = %123
   store i8 %126, i8* %120, align 8
@@ -899,14 +981,14 @@ entry:
   %129 = load i8*, i8** %arg0
   %130 = load i8*, i8** %arg1
   %131 = bitcast i8* %130 to i64*
-  %NullCheck84 = icmp ne i64* %131, null
-  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+  %NullCheck83 = icmp eq i64* %131, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %132
 
 ; <label>:132                                     ; preds = %128
   %133 = load i64, i64* %131, align 8
   %134 = bitcast i8* %129 to i64*
-  %NullCheck86 = icmp ne i64* %134, null
-  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+  %NullCheck85 = icmp eq i64* %134, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %135
 
 ; <label>:135                                     ; preds = %132
   store i64 %133, i64* %134, align 8
@@ -916,14 +998,14 @@ entry:
   %137 = load i8*, i8** %arg0
   %138 = load i8*, i8** %arg1
   %139 = bitcast i8* %138 to i64*
-  %NullCheck76 = icmp ne i64* %139, null
-  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+  %NullCheck75 = icmp eq i64* %139, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %140
 
 ; <label>:140                                     ; preds = %136
   %141 = load i64, i64* %139, align 8
   %142 = bitcast i8* %137 to i64*
-  %NullCheck78 = icmp ne i64* %142, null
-  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+  %NullCheck77 = icmp eq i64* %142, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %143
 
 ; <label>:143                                     ; preds = %140
   store i64 %141, i64* %142, align 8
@@ -931,15 +1013,15 @@ entry:
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %NullCheck80 = icmp ne i8* %147, null
-  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+  %NullCheck79 = icmp eq i8* %147, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %148
 
 ; <label>:148                                     ; preds = %143
   %149 = load i8, i8* %147, align 8
   %150 = zext i8 %149 to i32
   %151 = trunc i32 %150 to i8
-  %NullCheck82 = icmp ne i8* %145, null
-  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+  %NullCheck81 = icmp eq i8* %145, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %152
 
 ; <label>:152                                     ; preds = %148
   store i8 %151, i8* %145, align 8
@@ -949,14 +1031,14 @@ entry:
   %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
   %156 = bitcast i8* %155 to i64*
-  %NullCheck68 = icmp ne i64* %156, null
-  br i1 %NullCheck68, label %157, label %ThrowNullRef67
+  %NullCheck67 = icmp eq i64* %156, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %157
 
 ; <label>:157                                     ; preds = %153
   %158 = load i64, i64* %156, align 8
   %159 = bitcast i8* %154 to i64*
-  %NullCheck70 = icmp ne i64* %159, null
-  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+  %NullCheck69 = icmp eq i64* %159, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %160
 
 ; <label>:160                                     ; preds = %157
   store i64 %158, i64* %159, align 8
@@ -965,16 +1047,16 @@ entry:
   %163 = load i8*, i8** %arg1
   %164 = getelementptr inbounds i8, i8* %163, i64 8
   %165 = bitcast i8* %164 to i16*
-  %NullCheck72 = icmp ne i16* %165, null
-  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+  %NullCheck71 = icmp eq i16* %165, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %166
 
 ; <label>:166                                     ; preds = %160
   %167 = load i16, i16* %165, align 8
   %168 = sext i16 %167 to i32
   %169 = bitcast i8* %162 to i16*
   %170 = trunc i32 %168 to i16
-  %NullCheck74 = icmp ne i16* %169, null
-  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+  %NullCheck73 = icmp eq i16* %169, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %171
 
 ; <label>:171                                     ; preds = %166
   store i16 %170, i16* %169, align 8
@@ -984,14 +1066,14 @@ entry:
   %173 = load i8*, i8** %arg0
   %174 = load i8*, i8** %arg1
   %175 = bitcast i8* %174 to i64*
-  %NullCheck56 = icmp ne i64* %175, null
-  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+  %NullCheck55 = icmp eq i64* %175, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %176
 
 ; <label>:176                                     ; preds = %172
   %177 = load i64, i64* %175, align 8
   %178 = bitcast i8* %173 to i64*
-  %NullCheck58 = icmp ne i64* %178, null
-  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+  %NullCheck57 = icmp eq i64* %178, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %179
 
 ; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
@@ -1000,16 +1082,16 @@ entry:
   %182 = load i8*, i8** %arg1
   %183 = getelementptr inbounds i8, i8* %182, i64 8
   %184 = bitcast i8* %183 to i16*
-  %NullCheck60 = icmp ne i16* %184, null
-  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+  %NullCheck59 = icmp eq i16* %184, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %185
 
 ; <label>:185                                     ; preds = %179
   %186 = load i16, i16* %184, align 8
   %187 = sext i16 %186 to i32
   %188 = bitcast i8* %181 to i16*
   %189 = trunc i32 %187 to i16
-  %NullCheck62 = icmp ne i16* %188, null
-  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+  %NullCheck61 = icmp eq i16* %188, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %190
 
 ; <label>:190                                     ; preds = %185
   store i16 %189, i16* %188, align 8
@@ -1017,15 +1099,15 @@ entry:
   %192 = getelementptr inbounds i8, i8* %191, i64 10
   %193 = load i8*, i8** %arg1
   %194 = getelementptr inbounds i8, i8* %193, i64 10
-  %NullCheck64 = icmp ne i8* %194, null
-  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+  %NullCheck63 = icmp eq i8* %194, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %195
 
 ; <label>:195                                     ; preds = %190
   %196 = load i8, i8* %194, align 8
   %197 = zext i8 %196 to i32
   %198 = trunc i32 %197 to i8
-  %NullCheck66 = icmp ne i8* %192, null
-  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+  %NullCheck65 = icmp eq i8* %192, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %199
 
 ; <label>:199                                     ; preds = %195
   store i8 %198, i8* %192, align 8
@@ -1035,14 +1117,14 @@ entry:
   %201 = load i8*, i8** %arg0
   %202 = load i8*, i8** %arg1
   %203 = bitcast i8* %202 to i64*
-  %NullCheck48 = icmp ne i64* %203, null
-  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+  %NullCheck47 = icmp eq i64* %203, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %204
 
 ; <label>:204                                     ; preds = %200
   %205 = load i64, i64* %203, align 8
   %206 = bitcast i8* %201 to i64*
-  %NullCheck50 = icmp ne i64* %206, null
-  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+  %NullCheck49 = icmp eq i64* %206, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %207
 
 ; <label>:207                                     ; preds = %204
   store i64 %205, i64* %206, align 8
@@ -1051,14 +1133,14 @@ entry:
   %210 = load i8*, i8** %arg1
   %211 = getelementptr inbounds i8, i8* %210, i64 8
   %212 = bitcast i8* %211 to i32*
-  %NullCheck52 = icmp ne i32* %212, null
-  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+  %NullCheck51 = icmp eq i32* %212, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %213
 
 ; <label>:213                                     ; preds = %207
   %214 = load i32, i32* %212, align 8
   %215 = bitcast i8* %209 to i32*
-  %NullCheck54 = icmp ne i32* %215, null
-  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+  %NullCheck53 = icmp eq i32* %215, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %216
 
 ; <label>:216                                     ; preds = %213
   store i32 %214, i32* %215, align 8
@@ -1068,14 +1150,14 @@ entry:
   %218 = load i8*, i8** %arg0
   %219 = load i8*, i8** %arg1
   %220 = bitcast i8* %219 to i64*
-  %NullCheck36 = icmp ne i64* %220, null
-  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64* %220, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %221
 
 ; <label>:221                                     ; preds = %217
   %222 = load i64, i64* %220, align 8
   %223 = bitcast i8* %218 to i64*
-  %NullCheck38 = icmp ne i64* %223, null
-  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+  %NullCheck37 = icmp eq i64* %223, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %224
 
 ; <label>:224                                     ; preds = %221
   store i64 %222, i64* %223, align 8
@@ -1084,14 +1166,14 @@ entry:
   %227 = load i8*, i8** %arg1
   %228 = getelementptr inbounds i8, i8* %227, i64 8
   %229 = bitcast i8* %228 to i32*
-  %NullCheck40 = icmp ne i32* %229, null
-  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i32* %229, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %230
 
 ; <label>:230                                     ; preds = %224
   %231 = load i32, i32* %229, align 8
   %232 = bitcast i8* %226 to i32*
-  %NullCheck42 = icmp ne i32* %232, null
-  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+  %NullCheck41 = icmp eq i32* %232, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %233
 
 ; <label>:233                                     ; preds = %230
   store i32 %231, i32* %232, align 8
@@ -1099,15 +1181,15 @@ entry:
   %235 = getelementptr inbounds i8, i8* %234, i64 12
   %236 = load i8*, i8** %arg1
   %237 = getelementptr inbounds i8, i8* %236, i64 12
-  %NullCheck44 = icmp ne i8* %237, null
-  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i8* %237, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %238
 
 ; <label>:238                                     ; preds = %233
   %239 = load i8, i8* %237, align 8
   %240 = zext i8 %239 to i32
   %241 = trunc i32 %240 to i8
-  %NullCheck46 = icmp ne i8* %235, null
-  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+  %NullCheck45 = icmp eq i8* %235, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %242
 
 ; <label>:242                                     ; preds = %238
   store i8 %241, i8* %235, align 8
@@ -1117,14 +1199,14 @@ entry:
   %244 = load i8*, i8** %arg0
   %245 = load i8*, i8** %arg1
   %246 = bitcast i8* %245 to i64*
-  %NullCheck24 = icmp ne i64* %246, null
-  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64* %246, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %247
 
 ; <label>:247                                     ; preds = %243
   %248 = load i64, i64* %246, align 8
   %249 = bitcast i8* %244 to i64*
-  %NullCheck26 = icmp ne i64* %249, null
-  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64* %249, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %250
 
 ; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
@@ -1133,14 +1215,14 @@ entry:
   %253 = load i8*, i8** %arg1
   %254 = getelementptr inbounds i8, i8* %253, i64 8
   %255 = bitcast i8* %254 to i32*
-  %NullCheck28 = icmp ne i32* %255, null
-  br i1 %NullCheck28, label %256, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i32* %255, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %256
 
 ; <label>:256                                     ; preds = %250
   %257 = load i32, i32* %255, align 8
   %258 = bitcast i8* %252 to i32*
-  %NullCheck30 = icmp ne i32* %258, null
-  br i1 %NullCheck30, label %259, label %ThrowNullRef29
+  %NullCheck29 = icmp eq i32* %258, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %259
 
 ; <label>:259                                     ; preds = %256
   store i32 %257, i32* %258, align 8
@@ -1149,16 +1231,16 @@ entry:
   %262 = load i8*, i8** %arg1
   %263 = getelementptr inbounds i8, i8* %262, i64 12
   %264 = bitcast i8* %263 to i16*
-  %NullCheck32 = icmp ne i16* %264, null
-  br i1 %NullCheck32, label %265, label %ThrowNullRef31
+  %NullCheck31 = icmp eq i16* %264, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %265
 
 ; <label>:265                                     ; preds = %259
   %266 = load i16, i16* %264, align 8
   %267 = sext i16 %266 to i32
   %268 = bitcast i8* %261 to i16*
   %269 = trunc i32 %267 to i16
-  %NullCheck34 = icmp ne i16* %268, null
-  br i1 %NullCheck34, label %270, label %ThrowNullRef33
+  %NullCheck33 = icmp eq i16* %268, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %270
 
 ; <label>:270                                     ; preds = %265
   store i16 %269, i16* %268, align 8
@@ -1168,14 +1250,14 @@ entry:
   %272 = load i8*, i8** %arg0
   %273 = load i8*, i8** %arg1
   %274 = bitcast i8* %273 to i64*
-  %NullCheck8 = icmp ne i64* %274, null
-  br i1 %NullCheck8, label %275, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64* %274, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %275
 
 ; <label>:275                                     ; preds = %271
   %276 = load i64, i64* %274, align 8
   %277 = bitcast i8* %272 to i64*
-  %NullCheck10 = icmp ne i64* %277, null
-  br i1 %NullCheck10, label %278, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %277, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %278
 
 ; <label>:278                                     ; preds = %275
   store i64 %276, i64* %277, align 8
@@ -1184,14 +1266,14 @@ entry:
   %281 = load i8*, i8** %arg1
   %282 = getelementptr inbounds i8, i8* %281, i64 8
   %283 = bitcast i8* %282 to i32*
-  %NullCheck12 = icmp ne i32* %283, null
-  br i1 %NullCheck12, label %284, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i32* %283, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %284
 
 ; <label>:284                                     ; preds = %278
   %285 = load i32, i32* %283, align 8
   %286 = bitcast i8* %280 to i32*
-  %NullCheck14 = icmp ne i32* %286, null
-  br i1 %NullCheck14, label %287, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i32* %286, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %287
 
 ; <label>:287                                     ; preds = %284
   store i32 %285, i32* %286, align 8
@@ -1200,16 +1282,16 @@ entry:
   %290 = load i8*, i8** %arg1
   %291 = getelementptr inbounds i8, i8* %290, i64 12
   %292 = bitcast i8* %291 to i16*
-  %NullCheck16 = icmp ne i16* %292, null
-  br i1 %NullCheck16, label %293, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i16* %292, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %293
 
 ; <label>:293                                     ; preds = %287
   %294 = load i16, i16* %292, align 8
   %295 = sext i16 %294 to i32
   %296 = bitcast i8* %289 to i16*
   %297 = trunc i32 %295 to i16
-  %NullCheck18 = icmp ne i16* %296, null
-  br i1 %NullCheck18, label %298, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i16* %296, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %298
 
 ; <label>:298                                     ; preds = %293
   store i16 %297, i16* %296, align 8
@@ -1217,15 +1299,15 @@ entry:
   %300 = getelementptr inbounds i8, i8* %299, i64 14
   %301 = load i8*, i8** %arg1
   %302 = getelementptr inbounds i8, i8* %301, i64 14
-  %NullCheck20 = icmp ne i8* %302, null
-  br i1 %NullCheck20, label %303, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i8* %302, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %303
 
 ; <label>:303                                     ; preds = %298
   %304 = load i8, i8* %302, align 8
   %305 = zext i8 %304 to i32
   %306 = trunc i32 %305 to i8
-  %NullCheck22 = icmp ne i8* %300, null
-  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i8* %300, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %307
 
 ; <label>:307                                     ; preds = %303
   store i8 %306, i8* %300, align 8
@@ -1235,14 +1317,14 @@ entry:
   %309 = load i8*, i8** %arg0
   %310 = load i8*, i8** %arg1
   %311 = bitcast i8* %310 to i64*
-  %NullCheck = icmp ne i64* %311, null
-  br i1 %NullCheck, label %312, label %ThrowNullRef
+  %NullCheck = icmp eq i64* %311, null
+  br i1 %NullCheck, label %ThrowNullRef, label %312
 
 ; <label>:312                                     ; preds = %308
   %313 = load i64, i64* %311, align 8
   %314 = bitcast i8* %309 to i64*
-  %NullCheck2 = icmp ne i64* %314, null
-  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64* %314, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %315
 
 ; <label>:315                                     ; preds = %312
   store i64 %313, i64* %314, align 8
@@ -1251,14 +1333,14 @@ entry:
   %318 = load i8*, i8** %arg1
   %319 = getelementptr inbounds i8, i8* %318, i64 8
   %320 = bitcast i8* %319 to i64*
-  %NullCheck4 = icmp ne i64* %320, null
-  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64* %320, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %321
 
 ; <label>:321                                     ; preds = %315
   %322 = load i64, i64* %320, align 8
   %323 = bitcast i8* %317 to i64*
-  %NullCheck6 = icmp ne i64* %323, null
-  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64* %323, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %324
 
 ; <label>:324                                     ; preds = %321
   store i64 %322, i64* %323, align 8
@@ -1286,15 +1368,15 @@ entry:
 ; <label>:338                                     ; preds = %333
   %339 = load i8*, i8** %arg0
   %340 = load i8*, i8** %arg1
-  %NullCheck136 = icmp ne i8* %340, null
-  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+  %NullCheck135 = icmp eq i8* %340, null
+  br i1 %NullCheck135, label %ThrowNullRef136, label %341
 
 ; <label>:341                                     ; preds = %338
   %342 = load i8, i8* %340, align 8
   %343 = zext i8 %342 to i32
   %344 = trunc i32 %343 to i8
-  %NullCheck138 = icmp ne i8* %339, null
-  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+  %NullCheck137 = icmp eq i8* %339, null
+  br i1 %NullCheck137, label %ThrowNullRef138, label %345
 
 ; <label>:345                                     ; preds = %341
   store i8 %344, i8* %339, align 8
@@ -1317,16 +1399,16 @@ entry:
   %357 = load i8*, i8** %arg0
   %358 = load i8*, i8** %arg1
   %359 = bitcast i8* %358 to i16*
-  %NullCheck140 = icmp ne i16* %359, null
-  br i1 %NullCheck140, label %360, label %ThrowNullRef139
+  %NullCheck139 = icmp eq i16* %359, null
+  br i1 %NullCheck139, label %ThrowNullRef140, label %360
 
 ; <label>:360                                     ; preds = %356
   %361 = load i16, i16* %359, align 8
   %362 = sext i16 %361 to i32
   %363 = bitcast i8* %357 to i16*
   %364 = trunc i32 %362 to i16
-  %NullCheck142 = icmp ne i16* %363, null
-  br i1 %NullCheck142, label %365, label %ThrowNullRef141
+  %NullCheck141 = icmp eq i16* %363, null
+  br i1 %NullCheck141, label %ThrowNullRef142, label %365
 
 ; <label>:365                                     ; preds = %360
   store i16 %364, i16* %363, align 8
@@ -1352,14 +1434,14 @@ entry:
   %378 = load i8*, i8** %arg0
   %379 = load i8*, i8** %arg1
   %380 = bitcast i8* %379 to i32*
-  %NullCheck144 = icmp ne i32* %380, null
-  br i1 %NullCheck144, label %381, label %ThrowNullRef143
+  %NullCheck143 = icmp eq i32* %380, null
+  br i1 %NullCheck143, label %ThrowNullRef144, label %381
 
 ; <label>:381                                     ; preds = %377
   %382 = load i32, i32* %380, align 8
   %383 = bitcast i8* %378 to i32*
-  %NullCheck146 = icmp ne i32* %383, null
-  br i1 %NullCheck146, label %384, label %ThrowNullRef145
+  %NullCheck145 = icmp eq i32* %383, null
+  br i1 %NullCheck145, label %ThrowNullRef146, label %384
 
 ; <label>:384                                     ; preds = %381
   store i32 %382, i32* %383, align 8
@@ -1384,14 +1466,14 @@ entry:
   %395 = load i8*, i8** %arg0
   %396 = load i8*, i8** %arg1
   %397 = bitcast i8* %396 to i64*
-  %NullCheck164 = icmp ne i64* %397, null
-  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+  %NullCheck163 = icmp eq i64* %397, null
+  br i1 %NullCheck163, label %ThrowNullRef164, label %398
 
 ; <label>:398                                     ; preds = %394
   %399 = load i64, i64* %397, align 8
   %400 = bitcast i8* %395 to i64*
-  %NullCheck166 = icmp ne i64* %400, null
-  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+  %NullCheck165 = icmp eq i64* %400, null
+  br i1 %NullCheck165, label %ThrowNullRef166, label %401
 
 ; <label>:401                                     ; preds = %398
   store i64 %399, i64* %400, align 8
@@ -1400,14 +1482,14 @@ entry:
   %404 = load i8*, i8** %arg1
   %405 = getelementptr inbounds i8, i8* %404, i64 8
   %406 = bitcast i8* %405 to i64*
-  %NullCheck168 = icmp ne i64* %406, null
-  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+  %NullCheck167 = icmp eq i64* %406, null
+  br i1 %NullCheck167, label %ThrowNullRef168, label %407
 
 ; <label>:407                                     ; preds = %401
   %408 = load i64, i64* %406, align 8
   %409 = bitcast i8* %403 to i64*
-  %NullCheck170 = icmp ne i64* %409, null
-  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+  %NullCheck169 = icmp eq i64* %409, null
+  br i1 %NullCheck169, label %ThrowNullRef170, label %410
 
 ; <label>:410                                     ; preds = %407
   store i64 %408, i64* %409, align 8
@@ -1437,14 +1519,14 @@ entry:
   %425 = load i8*, i8** %arg0
   %426 = load i8*, i8** %arg1
   %427 = bitcast i8* %426 to i64*
-  %NullCheck148 = icmp ne i64* %427, null
-  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+  %NullCheck147 = icmp eq i64* %427, null
+  br i1 %NullCheck147, label %ThrowNullRef148, label %428
 
 ; <label>:428                                     ; preds = %424
   %429 = load i64, i64* %427, align 8
   %430 = bitcast i8* %425 to i64*
-  %NullCheck150 = icmp ne i64* %430, null
-  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+  %NullCheck149 = icmp eq i64* %430, null
+  br i1 %NullCheck149, label %ThrowNullRef150, label %431
 
 ; <label>:431                                     ; preds = %428
   store i64 %429, i64* %430, align 8
@@ -1466,14 +1548,14 @@ entry:
   %441 = load i8*, i8** %arg0
   %442 = load i8*, i8** %arg1
   %443 = bitcast i8* %442 to i32*
-  %NullCheck152 = icmp ne i32* %443, null
-  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+  %NullCheck151 = icmp eq i32* %443, null
+  br i1 %NullCheck151, label %ThrowNullRef152, label %444
 
 ; <label>:444                                     ; preds = %440
   %445 = load i32, i32* %443, align 8
   %446 = bitcast i8* %441 to i32*
-  %NullCheck154 = icmp ne i32* %446, null
-  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+  %NullCheck153 = icmp eq i32* %446, null
+  br i1 %NullCheck153, label %ThrowNullRef154, label %447
 
 ; <label>:447                                     ; preds = %444
   store i32 %445, i32* %446, align 8
@@ -1495,16 +1577,16 @@ entry:
   %457 = load i8*, i8** %arg0
   %458 = load i8*, i8** %arg1
   %459 = bitcast i8* %458 to i16*
-  %NullCheck156 = icmp ne i16* %459, null
-  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+  %NullCheck155 = icmp eq i16* %459, null
+  br i1 %NullCheck155, label %ThrowNullRef156, label %460
 
 ; <label>:460                                     ; preds = %456
   %461 = load i16, i16* %459, align 8
   %462 = sext i16 %461 to i32
   %463 = bitcast i8* %457 to i16*
   %464 = trunc i32 %462 to i16
-  %NullCheck158 = icmp ne i16* %463, null
-  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+  %NullCheck157 = icmp eq i16* %463, null
+  br i1 %NullCheck157, label %ThrowNullRef158, label %465
 
 ; <label>:465                                     ; preds = %460
   store i16 %464, i16* %463, align 8
@@ -1525,15 +1607,15 @@ entry:
 ; <label>:474                                     ; preds = %470
   %475 = load i8*, i8** %arg0
   %476 = load i8*, i8** %arg1
-  %NullCheck160 = icmp ne i8* %476, null
-  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+  %NullCheck159 = icmp eq i8* %476, null
+  br i1 %NullCheck159, label %ThrowNullRef160, label %477
 
 ; <label>:477                                     ; preds = %474
   %478 = load i8, i8* %476, align 8
   %479 = zext i8 %478 to i32
   %480 = trunc i32 %479 to i8
-  %NullCheck162 = icmp ne i8* %475, null
-  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+  %NullCheck161 = icmp eq i8* %475, null
+  br i1 %NullCheck161, label %ThrowNullRef162, label %481
 
 ; <label>:481                                     ; preds = %477
   store i8 %480, i8* %475, align 8
@@ -1553,343 +1635,343 @@ ThrowNullRef:                                     ; preds = %308
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %312
+ThrowNullRef2:                                    ; preds = %312
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %315
+ThrowNullRef4:                                    ; preds = %315
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %321
+ThrowNullRef6:                                    ; preds = %321
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %271
+ThrowNullRef8:                                    ; preds = %271
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %275
+ThrowNullRef10:                                   ; preds = %275
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %278
+ThrowNullRef12:                                   ; preds = %278
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %284
+ThrowNullRef14:                                   ; preds = %284
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %287
+ThrowNullRef16:                                   ; preds = %287
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %293
+ThrowNullRef18:                                   ; preds = %293
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %298
+ThrowNullRef20:                                   ; preds = %298
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %303
+ThrowNullRef22:                                   ; preds = %303
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %243
+ThrowNullRef24:                                   ; preds = %243
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %247
+ThrowNullRef26:                                   ; preds = %247
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %250
+ThrowNullRef28:                                   ; preds = %250
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %256
+ThrowNullRef30:                                   ; preds = %256
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %259
+ThrowNullRef32:                                   ; preds = %259
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %265
+ThrowNullRef34:                                   ; preds = %265
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %217
+ThrowNullRef36:                                   ; preds = %217
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %221
+ThrowNullRef38:                                   ; preds = %221
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %224
+ThrowNullRef40:                                   ; preds = %224
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %230
+ThrowNullRef42:                                   ; preds = %230
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %233
+ThrowNullRef44:                                   ; preds = %233
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %238
+ThrowNullRef46:                                   ; preds = %238
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %200
+ThrowNullRef48:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %204
+ThrowNullRef50:                                   ; preds = %204
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %207
+ThrowNullRef52:                                   ; preds = %207
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %213
+ThrowNullRef54:                                   ; preds = %213
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %172
+ThrowNullRef56:                                   ; preds = %172
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %176
+ThrowNullRef58:                                   ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %179
+ThrowNullRef60:                                   ; preds = %179
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %185
+ThrowNullRef62:                                   ; preds = %185
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %190
+ThrowNullRef64:                                   ; preds = %190
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %195
+ThrowNullRef66:                                   ; preds = %195
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %153
+ThrowNullRef68:                                   ; preds = %153
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %157
+ThrowNullRef70:                                   ; preds = %157
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %160
+ThrowNullRef72:                                   ; preds = %160
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %166
+ThrowNullRef74:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %136
+ThrowNullRef76:                                   ; preds = %136
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %140
+ThrowNullRef78:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %143
+ThrowNullRef80:                                   ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %148
+ThrowNullRef82:                                   ; preds = %148
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %128
+ThrowNullRef84:                                   ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %132
+ThrowNullRef86:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %100
+ThrowNullRef88:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %104
+ThrowNullRef90:                                   ; preds = %104
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %107
+ThrowNullRef92:                                   ; preds = %107
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %113
+ThrowNullRef94:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %118
+ThrowNullRef96:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %123
+ThrowNullRef98:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %81
+ThrowNullRef100:                                  ; preds = %81
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef101:                                  ; preds = %85
+ThrowNullRef102:                                  ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef103:                                  ; preds = %88
+ThrowNullRef104:                                  ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef105:                                  ; preds = %94
+ThrowNullRef106:                                  ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef107:                                  ; preds = %64
+ThrowNullRef108:                                  ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef109:                                  ; preds = %68
+ThrowNullRef110:                                  ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef111:                                  ; preds = %71
+ThrowNullRef112:                                  ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef113:                                  ; preds = %76
+ThrowNullRef114:                                  ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef115:                                  ; preds = %56
+ThrowNullRef116:                                  ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef117:                                  ; preds = %60
+ThrowNullRef118:                                  ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef119:                                  ; preds = %37
+ThrowNullRef120:                                  ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef121:                                  ; preds = %41
+ThrowNullRef122:                                  ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef123:                                  ; preds = %46
+ThrowNullRef124:                                  ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef125:                                  ; preds = %51
+ThrowNullRef126:                                  ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef127:                                  ; preds = %27
+ThrowNullRef128:                                  ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef129:                                  ; preds = %31
+ThrowNullRef130:                                  ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef131:                                  ; preds = %19
+ThrowNullRef132:                                  ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef133:                                  ; preds = %22
+ThrowNullRef134:                                  ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef135:                                  ; preds = %338
+ThrowNullRef136:                                  ; preds = %338
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef137:                                  ; preds = %341
+ThrowNullRef138:                                  ; preds = %341
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef139:                                  ; preds = %356
+ThrowNullRef140:                                  ; preds = %356
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef141:                                  ; preds = %360
+ThrowNullRef142:                                  ; preds = %360
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef143:                                  ; preds = %377
+ThrowNullRef144:                                  ; preds = %377
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef145:                                  ; preds = %381
+ThrowNullRef146:                                  ; preds = %381
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef147:                                  ; preds = %424
+ThrowNullRef148:                                  ; preds = %424
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef149:                                  ; preds = %428
+ThrowNullRef150:                                  ; preds = %428
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef151:                                  ; preds = %440
+ThrowNullRef152:                                  ; preds = %440
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef153:                                  ; preds = %444
+ThrowNullRef154:                                  ; preds = %444
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef155:                                  ; preds = %456
+ThrowNullRef156:                                  ; preds = %456
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef157:                                  ; preds = %460
+ThrowNullRef158:                                  ; preds = %460
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef159:                                  ; preds = %474
+ThrowNullRef160:                                  ; preds = %474
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef161:                                  ; preds = %477
+ThrowNullRef162:                                  ; preds = %477
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef163:                                  ; preds = %394
+ThrowNullRef164:                                  ; preds = %394
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef165:                                  ; preds = %398
+ThrowNullRef166:                                  ; preds = %398
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef167:                                  ; preds = %401
+ThrowNullRef168:                                  ; preds = %401
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef169:                                  ; preds = %407
+ThrowNullRef170:                                  ; preds = %407
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1939,8 +2021,8 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
-  br i1 %NullCheck, label %22, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %ThrowNullRef, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
@@ -1948,8 +2030,8 @@ entry:
   store i32 %24, i32* %loc0
   %25 = load i32, i32* %loc0
   %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %26, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %27
 
 ; <label>:27                                      ; preds = %22
   %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
@@ -1971,7 +2053,7 @@ ThrowNullRef:                                     ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1989,8 +2071,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -2022,15 +2104,15 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2048,16 +2130,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
   %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
   store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %15
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
@@ -2072,8 +2154,8 @@ entry:
   %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
   %29 = ptrtoint i16 addrspace(1)* %28 to i64
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %19
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
@@ -2089,19 +2171,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2114,8 +2196,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
@@ -2128,7 +2210,7 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[loadElem]
+Failed to read AppDomain.PrepareDataForSetup[storeElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
@@ -2202,8 +2284,8 @@ entry:
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
-  br i1 %NullCheck24, label %27, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = load i64, i64 addrspace(1)* %26
@@ -2218,8 +2300,8 @@ entry:
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
-  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
   %41 = load i64, i64 addrspace(1)* %39
@@ -2236,8 +2318,8 @@ entry:
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
-  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
   %54 = load i64, i64 addrspace(1)* %52
@@ -2252,8 +2334,8 @@ entry:
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
   %67 = load i64, i64 addrspace(1)* %65
@@ -2270,8 +2352,8 @@ entry:
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
-  br i1 %NullCheck16, label %79, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
   %80 = load i64, i64 addrspace(1)* %78
@@ -2286,8 +2368,8 @@ entry:
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
-  br i1 %NullCheck18, label %92, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
   %93 = load i64, i64 addrspace(1)* %91
@@ -2304,8 +2386,8 @@ entry:
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
-  br i1 %NullCheck12, label %105, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = load i64, i64 addrspace(1)* %104
@@ -2320,8 +2402,8 @@ entry:
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
-  br i1 %NullCheck14, label %118, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
   %119 = load i64, i64 addrspace(1)* %117
@@ -2337,8 +2419,8 @@ entry:
 
 ; <label>:128                                     ; preds = %20
   %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
-  br i1 %NullCheck4, label %130, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %129, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %130
 
 ; <label>:130                                     ; preds = %128
   %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
@@ -2346,8 +2428,8 @@ entry:
   %133 = load i16, i16 addrspace(1)* %132, align 8
   %134 = zext i16 %133 to i32
   %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
-  br i1 %NullCheck6, label %136, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %135, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %136
 
 ; <label>:136                                     ; preds = %130
   %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
@@ -2360,8 +2442,8 @@ entry:
 
 ; <label>:143                                     ; preds = %136
   %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
-  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %144, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %145
 
 ; <label>:145                                     ; preds = %143
   %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
@@ -2369,8 +2451,8 @@ entry:
   %148 = load i16, i16 addrspace(1)* %147, align 8
   %149 = zext i16 %148 to i32
   %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %150, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %151
 
 ; <label>:151                                     ; preds = %145
   %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
@@ -2388,8 +2470,8 @@ entry:
 
 ; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
-  br i1 %NullCheck, label %163, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %ThrowNullRef, label %163
 
 ; <label>:163                                     ; preds = %161
   %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
@@ -2399,8 +2481,8 @@ entry:
 
 ; <label>:167                                     ; preds = %163
   %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
-  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %168, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %169
 
 ; <label>:169                                     ; preds = %167
   %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
@@ -2432,55 +2514,55 @@ ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %167
+ThrowNullRef2:                                    ; preds = %167
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %128
+ThrowNullRef4:                                    ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %130
+ThrowNullRef6:                                    ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %143
+ThrowNullRef8:                                    ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %145
+ThrowNullRef10:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %102
+ThrowNullRef12:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %105
+ThrowNullRef14:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %76
+ThrowNullRef16:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %79
+ThrowNullRef18:                                   ; preds = %79
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %50
+ThrowNullRef20:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %53
+ThrowNullRef22:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %24
+ThrowNullRef24:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %27
+ThrowNullRef26:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2503,15 +2585,15 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2519,16 +2601,16 @@ entry:
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
   store i32 %8, i32* %loc0
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
   %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
   store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
@@ -2546,16 +2628,16 @@ entry:
 
 ; <label>:23                                      ; preds = %64
   %24 = load i16*, i16** %loc3
-  %NullCheck12 = icmp ne i16* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i16* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
   store i32 %27, i32* %loc5
   %28 = load i16*, i16** %loc4
-  %NullCheck14 = icmp ne i16* %28, null
-  br i1 %NullCheck14, label %29, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %28, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = load i16, i16* %28, align 8
@@ -2620,15 +2702,15 @@ entry:
 
 ; <label>:67                                      ; preds = %64
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
-  br i1 %NullCheck8, label %69, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %68, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %69
 
 ; <label>:69                                      ; preds = %67
   %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
   %71 = load i32, i32 addrspace(1)* %70
   %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
-  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %73
 
 ; <label>:73                                      ; preds = %69
   %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
@@ -2645,31 +2727,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %67
+ThrowNullRef8:                                    ; preds = %67
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %69
+ThrowNullRef10:                                   ; preds = %69
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2710,14 +2792,14 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
   %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
@@ -2730,14 +2812,14 @@ entry:
 
 ; <label>:11                                      ; preds = %4
   %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
   %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
@@ -2749,14 +2831,14 @@ entry:
 
 ; <label>:22                                      ; preds = %16
   %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
   %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
-  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
-  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
@@ -2804,23 +2886,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2836,7 +2918,280 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[loadElem]
+Successfully read RuntimeType.IsAssignableFrom
+
+define i8 @RuntimeType.IsAssignableFrom(%System.RuntimeType addrspace(1)* %param0, %System.Type addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.RuntimeType addrspace(1)*
+  %arg1 = alloca %System.Type addrspace(1)*
+  %loc0 = alloca %System.RuntimeType addrspace(1)*
+  %loc1 = alloca %"System.Type[]" addrspace(1)*
+  %loc2 = alloca i32
+  store %System.RuntimeType addrspace(1)* %param0, %System.RuntimeType addrspace(1)** %this
+  store %System.Type addrspace(1)* %param1, %System.Type addrspace(1)** %arg1
+  %0 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %1 = icmp ne %System.Type addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i8 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %5 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %6 = bitcast %System.Type addrspace(1)* %4 to %System.Object addrspace(1)*
+  %7 = bitcast %System.RuntimeType addrspace(1)* %5 to %System.Object addrspace(1)*
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %6, %System.Object addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %3
+  ret i8 1
+
+; <label>:12                                      ; preds = %3
+  %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 152
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 32
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
+  %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
+  %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
+  store %System.RuntimeType addrspace(1)* %25, %System.RuntimeType addrspace(1)** %loc0
+  %26 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %27 = icmp eq %System.RuntimeType addrspace(1)* %26, null
+  br i1 %27, label %34, label %28
+
+; <label>:28                                      ; preds = %15
+  %29 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %30 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)*)*)(%System.RuntimeType addrspace(1)* %29, %System.RuntimeType addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+; <label>:34                                      ; preds = %15
+  %35 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %36 = call %System.Reflection.Emit.TypeBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Reflection.Emit.TypeBuilder addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %35)
+  %37 = icmp eq %System.Reflection.Emit.TypeBuilder addrspace(1)* %36, null
+  br i1 %37, label %139, label %38
+
+; <label>:38                                      ; preds = %34
+  %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %42
+
+; <label>:42                                      ; preds = %38
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 152
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 40
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
+  %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
+  %53 = zext i8 %52 to i32
+  %54 = icmp eq i32 %53, 0
+  br i1 %54, label %56, label %55
+
+; <label>:55                                      ; preds = %42
+  ret i8 1
+
+; <label>:56                                      ; preds = %42
+  %57 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %58 = bitcast %System.RuntimeType addrspace(1)* %57 to %System.Type addrspace(1)*
+  %59 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %58)
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %64 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.Type addrspace(1)* %63, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = bitcast %System.RuntimeType addrspace(1)* %64 to %System.Type addrspace(1)*
+  %67 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %63, %System.Type addrspace(1)* %66)
+  %68 = zext i8 %67 to i32
+  %69 = trunc i32 %68 to i8
+  ret i8 %69
+
+; <label>:70                                      ; preds = %56
+  %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
+  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %73
+
+; <label>:73                                      ; preds = %70
+  %74 = load i64, i64 addrspace(1)* %72
+  %75 = add i64 %74, 128
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = add i64 %77, 0
+  %79 = inttoptr i64 %78 to i64*
+  %80 = load i64, i64* %79
+  %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
+  %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
+  %83 = call i8 %82(%System.Type addrspace(1)* %81)
+  %84 = zext i8 %83 to i32
+  %85 = icmp eq i32 %84, 0
+  br i1 %85, label %139, label %86
+
+; <label>:86                                      ; preds = %73
+  %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
+  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %89
+
+; <label>:89                                      ; preds = %86
+  %90 = load i64, i64 addrspace(1)* %88
+  %91 = add i64 %90, 128
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = add i64 %93, 24
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
+  %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
+  %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
+  store %"System.Type[]" addrspace(1)* %99, %"System.Type[]" addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %129
+
+; <label>:100                                     ; preds = %132
+  %101 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %102 = load i32, i32* %loc2
+  %NullCheck11 = icmp eq %"System.Type[]" addrspace(1)* %101, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %103
+
+; <label>:103                                     ; preds = %100
+  %104 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 1
+  %105 = load i32, i32 addrspace(1)* %104
+  %106 = zext i32 %105 to i64
+  %107 = zext i32 %102 to i64
+  %BoundsCheck = icmp uge i64 %107, %106
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %108
+
+; <label>:108                                     ; preds = %103
+  %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
+  %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
+  %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
+  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %113
+
+; <label>:113                                     ; preds = %108
+  %114 = load i64, i64 addrspace(1)* %112
+  %115 = add i64 %114, 152
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = add i64 %117, 56
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
+  %123 = zext i8 %122 to i32
+  %124 = icmp ne i32 %123, 0
+  br i1 %124, label %126, label %125
+
+; <label>:125                                     ; preds = %113
+  ret i8 0
+
+; <label>:126                                     ; preds = %113
+  %127 = load i32, i32* %loc2
+  %128 = add i32 %127, 1
+  store i32 %128, i32* %loc2
+  br label %129
+
+; <label>:129                                     ; preds = %89, %126
+  %130 = load i32, i32* %loc2
+  %131 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %NullCheck9 = icmp eq %"System.Type[]" addrspace(1)* %131, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %132
+
+; <label>:132                                     ; preds = %129
+  %133 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %131, i32 0, i32 1
+  %134 = load i32, i32 addrspace(1)* %133
+  %135 = zext i32 %134 to i64
+  %136 = trunc i64 %135 to i32
+  %137 = icmp slt i32 %130, %136
+  br i1 %137, label %100, label %138
+
+; <label>:138                                     ; preds = %132
+  ret i8 1
+
+; <label>:139                                     ; preds = %34, %73
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %129
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %103
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -2893,7 +3248,7 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElem]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -2904,8 +3259,8 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -2997,8 +3352,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
@@ -3059,8 +3414,8 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -3087,8 +3442,8 @@ entry:
 
 ; <label>:17                                      ; preds = %5, %11
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
@@ -3097,8 +3452,8 @@ entry:
 
 ; <label>:22                                      ; preds = %1, %11
   %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
@@ -3109,11 +3464,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %17
+ThrowNullRef2:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %22
+ThrowNullRef4:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3167,15 +3522,15 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
   %15 = load i32, i32 addrspace(1)* %14
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
@@ -3198,7 +3553,7 @@ ThrowNullRef:                                     ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef2:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3232,8 +3587,8 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
@@ -3312,8 +3667,8 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -3327,8 +3682,8 @@ entry:
 ; <label>:5                                       ; preds = %43
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %7 = load i32, i32* %loc1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck6, label %8, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
@@ -3366,8 +3721,8 @@ entry:
 ; <label>:32                                      ; preds = %21, %25
   %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
   %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
-  br i1 %NullCheck8, label %35, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = trunc i32 %34 to i16
@@ -3380,8 +3735,8 @@ entry:
 ; <label>:40                                      ; preds = %1, %35
   %41 = load i32, i32* %loc1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
-  br i1 %NullCheck2, label %43, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %42, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
@@ -3392,8 +3747,8 @@ entry:
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
   %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
-  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
   %51 = load i64, i64 addrspace(1)* %49
@@ -3412,19 +3767,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %40
+ThrowNullRef2:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %47
+ThrowNullRef4:                                    ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %5
+ThrowNullRef6:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %32
+ThrowNullRef8:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3467,8 +3822,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
@@ -3492,11 +3847,391 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(i16* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store i16* %param0, i16** %arg0
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load i32, i32* %arg3
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %42, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %37, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg2
+  %13 = load i32, i32* %arg3
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %37, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %24 = load i32, i32* %arg2
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load i16*, i16** %arg0
+  %35 = load i32, i32* %arg3
+  %36 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %36, i16* %34, i32 %35)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:37                                      ; preds = %5, %16
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %39)
+  %41 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41, %System.String addrspace(1)* %38, %System.String addrspace(1)* %40)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41) #0
+  unreachable
+
+; <label>:42                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
-Failed to read StringBuilder.ToString[loadElemA]
+Successfully read StringBuilder.ToString
+
+define %System.String addrspace(1)* @StringBuilder.ToString(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i16*
+  %loc3 = alloca %"System.Char[]" addrspace(1)*
+  %loc4 = alloca i32
+  %loc5 = alloca i32
+  %loc6 = alloca i16 addrspace(1)*
+  %loc7 = alloca %System.String addrspace(1)*
+  %loc8 = alloca %"System.Char[]" addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %0)
+  %2 = icmp ne i32 %1, 0
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %4
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %6)
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %7)
+  store %System.String addrspace(1)* %8, %System.String addrspace(1)** %loc0
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.Text.StringBuilder addrspace(1)* %9, %System.Text.StringBuilder addrspace(1)** %loc1
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  store %System.String addrspace(1)* %10, %System.String addrspace(1)** %loc7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc7
+  %12 = ptrtoint %System.String addrspace(1)* %11 to i64
+  %13 = icmp eq i64 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %5
+  %15 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %16 = sext i32 %15 to i64
+  %17 = add i64 %12, %16
+  br label %18
+
+; <label>:18                                      ; preds = %5, %14
+  %19 = phi i64 [ %12, %5 ], [ %17, %14 ]
+  %20 = inttoptr i64 %19 to i16*
+  store i16* %20, i16** %loc2
+  br label %21
+
+; <label>:21                                      ; preds = %98, %18
+  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %22, null
+  br i1 %NullCheck, label %ThrowNullRef, label %23
+
+; <label>:23                                      ; preds = %21
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 3
+  %25 = load i32, i32 addrspace(1)* %24, align 8
+  %26 = icmp sle i32 %25, 0
+  br i1 %26, label %96, label %27
+
+; <label>:27                                      ; preds = %23
+  %28 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %28, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %29
+
+; <label>:29                                      ; preds = %27
+  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %28, i32 0, i32 1
+  %31 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %30, align 8
+  store %"System.Char[]" addrspace(1)* %31, %"System.Char[]" addrspace(1)** %loc3
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %33
+
+; <label>:33                                      ; preds = %29
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  store i32 %35, i32* %loc4
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  %39 = load i32, i32 addrspace(1)* %38, align 8
+  store i32 %39, i32* %loc5
+  %40 = load i32, i32* %loc5
+  %41 = load i32, i32* %loc4
+  %42 = add i32 %40, %41
+  %43 = zext i32 %42 to i64
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %45
+
+; <label>:45                                      ; preds = %37
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = sext i32 %47 to i64
+  %49 = icmp sgt i64 %43, %48
+  br i1 %49, label %91, label %50
+
+; <label>:50                                      ; preds = %45
+  %51 = load i32, i32* %loc5
+  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %52, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %53
+
+; <label>:53                                      ; preds = %50
+  %54 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %52, i32 0, i32 1
+  %55 = load i32, i32 addrspace(1)* %54
+  %56 = zext i32 %55 to i64
+  %57 = trunc i64 %56 to i32
+  %58 = icmp ugt i32 %51, %57
+  br i1 %58, label %91, label %59
+
+; <label>:59                                      ; preds = %53
+  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  store %"System.Char[]" addrspace(1)* %60, %"System.Char[]" addrspace(1)** %loc8
+  %61 = icmp eq %"System.Char[]" addrspace(1)* %60, null
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %63, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %64
+
+; <label>:64                                      ; preds = %62
+  %65 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %63, i32 0, i32 1
+  %66 = load i32, i32 addrspace(1)* %65
+  %67 = zext i32 %66 to i64
+  %68 = trunc i64 %67 to i32
+  %69 = icmp ne i32 %68, 0
+  br i1 %69, label %71, label %70
+
+; <label>:70                                      ; preds = %59, %64
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:71                                      ; preds = %64
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %73
+
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %BoundsCheck = icmp uge i64 0, %76
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %77
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %78, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:79                                      ; preds = %70, %77
+  %80 = load i16*, i16** %loc2
+  %81 = load i32, i32* %loc4
+  %82 = sext i32 %81 to i64
+  %83 = mul i64 %82, 2
+  %84 = bitcast i16* %80 to i8*
+  %85 = getelementptr inbounds i8, i8* %84, i64 %83
+  %86 = load i16 addrspace(1)*, i16 addrspace(1)** %loc6
+  %87 = ptrtoint i16 addrspace(1)* %86 to i64
+  %88 = load i32, i32* %loc5
+  %89 = bitcast i8* %85 to i16*
+  %90 = inttoptr i64 %87 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %89, i16* %90, i32 %88)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %96
+
+; <label>:91                                      ; preds = %45, %53
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %94 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %93)
+  %95 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95, %System.String addrspace(1)* %92, %System.String addrspace(1)* %94)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95) #0
+  unreachable
+
+; <label>:96                                      ; preds = %23, %79
+  %97 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %97, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %98
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %97, i32 0, i32 2
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  store %System.Text.StringBuilder addrspace(1)* %100, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %102 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %102, label %21, label %103
+
+; <label>:103                                     ; preds = %98
+  store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc7
+  %104 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  ret %System.String addrspace(1)* %104
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method StringBuilder::get_Length using LLILCJit
+Successfully read StringBuilder.get_Length
+
+define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
+Successfully read RuntimeHelpers.get_OffsetToStringData
+
+define i32 @RuntimeHelpers.get_OffsetToStringData() {
+entry:
+  ret i32 12
+}
+
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
 Successfully read CultureData.CreateCultureData
 
@@ -3514,23 +4249,23 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
   store i8 %4, i8 addrspace(1)* %6
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
@@ -3549,11 +4284,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3566,50 +4301,50 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
   store i32 -1, i32 addrspace(1)* %2
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
   store i32 -1, i32 addrspace(1)* %8
   %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
   store i32 -1, i32 addrspace(1)* %14
   %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
   store i32 -1, i32 addrspace(1)* %17
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
@@ -3623,27 +4358,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3675,7 +4410,136 @@ Failed to read Dictionary`2.Insert[non-const derefAddress]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
 Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
-Failed to read HashHelpers.GetPrime[loadElem]
+Successfully read HashHelpers.GetPrime
+
+define i32 @HashHelpers.GetPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %6, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5, %System.String addrspace(1)* %4)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5) #0
+  unreachable
+
+; <label>:6                                       ; preds = %entry
+  store i32 0, i32* %loc0
+  br label %29
+
+; <label>:7                                       ; preds = %35
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 1296
+  %10 = addrspacecast i8 addrspace(1)* %9 to %"System.Int32[]" addrspace(1)**
+  %11 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %10
+  %12 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Int32[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = zext i32 %15 to i64
+  %17 = zext i32 %12 to i64
+  %BoundsCheck = icmp uge i64 %17, %16
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 3, i32 %12
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  store i32 %20, i32* %loc1
+  %21 = load i32, i32* %loc1
+  %22 = load i32, i32* %arg0
+  %23 = icmp slt i32 %21, %22
+  br i1 %23, label %26, label %24
+
+; <label>:24                                      ; preds = %18
+  %25 = load i32, i32* %loc1
+  ret i32 %25
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %loc0
+  %28 = add i32 %27, 1
+  store i32 %28, i32* %loc0
+  br label %29
+
+; <label>:29                                      ; preds = %6, %26
+  %30 = load i32, i32* %loc0
+  %31 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %32 = getelementptr inbounds i8, i8 addrspace(1)* %31, i64 1296
+  %33 = addrspacecast i8 addrspace(1)* %32 to %"System.Int32[]" addrspace(1)**
+  %34 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %33
+  %NullCheck = icmp eq %"System.Int32[]" addrspace(1)* %34, null
+  br i1 %NullCheck, label %ThrowNullRef, label %35
+
+; <label>:35                                      ; preds = %29
+  %36 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %34, i32 0, i32 1
+  %37 = load i32, i32 addrspace(1)* %36
+  %38 = zext i32 %37 to i64
+  %39 = trunc i64 %38 to i32
+  %40 = icmp slt i32 %30, %39
+  br i1 %40, label %7, label %41
+
+; <label>:41                                      ; preds = %35
+  %42 = load i32, i32* %arg0
+  %43 = or i32 %42, 1
+  store i32 %43, i32* %loc2
+  br label %59
+
+; <label>:44                                      ; preds = %59
+  %45 = load i32, i32* %loc2
+  %46 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %45)
+  %47 = zext i8 %46 to i32
+  %48 = icmp eq i32 %47, 0
+  br i1 %48, label %56, label %49
+
+; <label>:49                                      ; preds = %44
+  %50 = load i32, i32* %loc2
+  %51 = sub i32 %50, 1
+  %52 = srem i32 %51, 101
+  %53 = icmp eq i32 %52, 0
+  br i1 %53, label %56, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = load i32, i32* %loc2
+  ret i32 %55
+
+; <label>:56                                      ; preds = %44, %49
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %57, 2
+  store i32 %58, i32* %loc2
+  br label %59
+
+; <label>:59                                      ; preds = %41, %56
+  %60 = load i32, i32* %loc2
+  %61 = icmp slt i32 %60, 2147483647
+  br i1 %61, label %44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load i32, i32* %arg0
+  ret i32 %63
+
+ThrowNullRef:                                     ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
 Successfully read GenericEqualityComparer`1.GetHashCode
 
@@ -3694,14 +4558,14 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
   %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load i64, i64 addrspace(1)* %7
@@ -3720,7 +4584,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3750,8 +4614,8 @@ entry:
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
@@ -3796,8 +4660,8 @@ entry:
   %35 = bitcast i16* %34 to i8*
   %36 = getelementptr inbounds i8, i8* %35, i64 2
   %37 = bitcast i8* %36 to i16*
-  %NullCheck4 = icmp ne i16* %37, null
-  br i1 %NullCheck4, label %38, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %37, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %38
 
 ; <label>:38                                      ; preds = %27
   %39 = load i16, i16* %37, align 8
@@ -3824,8 +4688,8 @@ entry:
 
 ; <label>:54                                      ; preds = %22, %43
   %55 = load i16*, i16** %loc4
-  %NullCheck2 = icmp ne i16* %55, null
-  br i1 %NullCheck2, label %56, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i16* %55, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %56
 
 ; <label>:56                                      ; preds = %54
   %57 = load i16, i16* %55, align 8
@@ -3850,11 +4714,11 @@ ThrowNullRef:                                     ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %54
+ThrowNullRef2:                                    ; preds = %54
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %27
+ThrowNullRef4:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3871,8 +4735,8 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -3907,8 +4771,8 @@ entry:
 
 ; <label>:26                                      ; preds = %19
   %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
-  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %28
 
 ; <label>:28                                      ; preds = %26
   %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
@@ -3920,7 +4784,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3972,8 +4836,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
@@ -3984,26 +4848,26 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
-  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
@@ -4014,8 +4878,8 @@ entry:
 ; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
@@ -4024,8 +4888,8 @@ entry:
 
 ; <label>:25                                      ; preds = %1, %16, %23
   %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
-  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
@@ -4036,27 +4900,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %20
+ThrowNullRef10:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4069,8 +4933,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -4081,8 +4945,8 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
@@ -4091,8 +4955,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1, %8
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
@@ -4103,11 +4967,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4128,24 +4992,24 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   store i32 %3, i32* %loc0
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
   %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
   store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck4, label %9, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
@@ -4164,15 +5028,15 @@ entry:
 ; <label>:18                                      ; preds = %70
   %19 = load i16*, i16** %loc3
   %20 = bitcast i16* %19 to i64*
-  %NullCheck10 = icmp ne i64* %20, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %20, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = load i64, i64* %20, align 8
   %23 = load i16*, i16** %loc4
   %24 = bitcast i16* %23 to i64*
-  %NullCheck12 = icmp ne i64* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = load i64, i64* %24, align 8
@@ -4188,8 +5052,8 @@ entry:
   %31 = bitcast i16* %30 to i8*
   %32 = getelementptr inbounds i8, i8* %31, i64 8
   %33 = bitcast i8* %32 to i64*
-  %NullCheck14 = icmp ne i64* %33, null
-  br i1 %NullCheck14, label %34, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = load i64, i64* %33, align 8
@@ -4197,8 +5061,8 @@ entry:
   %37 = bitcast i16* %36 to i8*
   %38 = getelementptr inbounds i8, i8* %37, i64 8
   %39 = bitcast i8* %38 to i64*
-  %NullCheck16 = icmp ne i64* %39, null
-  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %40
 
 ; <label>:40                                      ; preds = %34
   %41 = load i64, i64* %39, align 8
@@ -4214,8 +5078,8 @@ entry:
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %NullCheck18 = icmp ne i64* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = load i64, i64* %48, align 8
@@ -4223,8 +5087,8 @@ entry:
   %52 = bitcast i16* %51 to i8*
   %53 = getelementptr inbounds i8, i8* %52, i64 16
   %54 = bitcast i8* %53 to i64*
-  %NullCheck20 = icmp ne i64* %54, null
-  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64* %54, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %55
 
 ; <label>:55                                      ; preds = %49
   %56 = load i64, i64* %54, align 8
@@ -4262,15 +5126,15 @@ entry:
 ; <label>:74                                      ; preds = %95
   %75 = load i16*, i16** %loc3
   %76 = bitcast i16* %75 to i32*
-  %NullCheck6 = icmp ne i32* %76, null
-  br i1 %NullCheck6, label %77, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32* %76, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %77
 
 ; <label>:77                                      ; preds = %74
   %78 = load i32, i32* %76, align 8
   %79 = load i16*, i16** %loc4
   %80 = bitcast i16* %79 to i32*
-  %NullCheck8 = icmp ne i32* %80, null
-  br i1 %NullCheck8, label %81, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i32* %80, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %81
 
 ; <label>:81                                      ; preds = %77
   %82 = load i32, i32* %80, align 8
@@ -4318,43 +5182,43 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %74
+ThrowNullRef6:                                    ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %77
+ThrowNullRef8:                                    ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %29
+ThrowNullRef14:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %34
+ThrowNullRef16:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4376,8 +5240,8 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load i64, i64 addrspace(1)* %4
@@ -4389,8 +5253,8 @@ entry:
   %12 = load i64, i64* %11
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %5
   %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
@@ -4399,8 +5263,8 @@ entry:
   %18 = load i8, i8* %arg2
   %19 = zext i8 %18 to i32
   %20 = trunc i32 %19 to i8
-  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %15
   %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
@@ -4411,11 +5275,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4442,8 +5306,8 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
@@ -4466,16 +5330,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
   %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = load i64, i64 addrspace(1)* %19
@@ -4500,8 +5364,8 @@ entry:
 ; <label>:35                                      ; preds = %30
   %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
@@ -4514,8 +5378,8 @@ entry:
 
 ; <label>:42                                      ; preds = %1, %38
   %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
-  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
@@ -4526,19 +5390,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %35
+ThrowNullRef2:                                    ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %42
+ThrowNullRef8:                                    ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4551,14 +5415,14 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
@@ -4570,7 +5434,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4583,8 +5447,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
@@ -4613,51 +5477,51 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
   %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
   %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
   %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
   %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
-  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
   store i64 %21, i64 addrspace(1)* %23
   %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %25 = load i64, i64* %loc0
-  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
@@ -4668,27 +5532,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %22
+ThrowNullRef12:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4701,8 +5565,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
@@ -4713,19 +5577,19 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
@@ -4734,8 +5598,8 @@ entry:
 
 ; <label>:15                                      ; preds = %1, %13
   %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
@@ -4746,19 +5610,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %15
+ThrowNullRef8:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4771,8 +5635,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -4831,8 +5695,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
@@ -4882,8 +5746,8 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
-  br i1 %NullCheck, label %17, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %ThrowNullRef, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
@@ -4894,15 +5758,15 @@ entry:
 
 ; <label>:22                                      ; preds = %17
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
-  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
   %26 = load i32, i32 addrspace(1)* %25
   %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
-  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %27, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
@@ -4925,8 +5789,8 @@ entry:
 ; <label>:40                                      ; preds = %17
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
-  br i1 %NullCheck6, label %43, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %41, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
@@ -4938,34 +5802,17 @@ ThrowNullRef:                                     ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %24
+ThrowNullRef4:                                    ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %40
+ThrowNullRef6:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
-}
-
-INFO:  jitting method Object::ReferenceEquals using LLILCJit
-Successfully read Object.ReferenceEquals
-
-define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
-entry:
-  %arg0 = alloca %System.Object addrspace(1)*
-  %arg1 = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
-  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
-  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = icmp eq %System.Object addrspace(1)* %0, %1
-  %3 = sext i1 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
 }
 
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
@@ -4978,21 +5825,21 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
   %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
-  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
@@ -5007,28 +5854,28 @@ entry:
 ; <label>:13                                      ; preds = %8, %12
   %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
   %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
   %21 = load i32, i32 addrspace(1)* %20, align 8
   %22 = add i32 %21, 1
-  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
   store i32 %22, i32 addrspace(1)* %24
   %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
@@ -5039,27 +5886,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5077,7 +5924,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::Setup using LLILCJit
-Failed to read AppDomain.Setup[loadElem]
+Failed to read AppDomain.Setup[unbox]
 INFO:  jitting method Thread::GetDomain using LLILCJit
 Successfully read Thread.GetDomain
 
@@ -5108,8 +5955,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
@@ -5122,14 +5969,14 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
   %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
@@ -5141,11 +5988,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5173,8 +6020,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -5189,7 +6036,328 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
 Failed to read KeyCollection.System.Collections.Generic.IEnumerable<TKey>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Successfully read Enumerator.MoveNext
+
+define i8 @Enumerator.MoveNext(%"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.RuntimeTypeHandle* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*
+  %"$TypeArg" = alloca %System.RuntimeTypeHandle*
+  store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
+  %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 8
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %76, label %12
+
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
+  br label %76
+
+; <label>:13                                      ; preds = %85
+  %14 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck19 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %15
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, i32 0, i32 0
+  %17 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %16, align 8
+  %NullCheck21 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, i32 0, i32 2
+  %20 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %19, align 8
+  %21 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck23 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %22
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, i32 0, i32 2
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %NullCheck25 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 3, i32 %24
+  %NullCheck27 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %32
+
+; <label>:32                                      ; preds = %30
+  %33 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, i32 0, i32 2
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = icmp slt i32 %34, 0
+  br i1 %35, label %68, label %36
+
+; <label>:36                                      ; preds = %32
+  %37 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %38 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck29 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %39
+
+; <label>:39                                      ; preds = %36
+  %40 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, i32 0, i32 0
+  %41 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %40, align 8
+  %NullCheck31 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, i32 0, i32 2
+  %44 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %43, align 8
+  %45 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck33 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, i32 0, i32 2
+  %48 = load i32, i32 addrspace(1)* %47, align 8
+  %NullCheck35 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %49
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = zext i32 %51 to i64
+  %53 = zext i32 %48 to i64
+  %BoundsCheck37 = icmp uge i64 %53, %52
+  br i1 %BoundsCheck37, label %ThrowIndexOutOfRange38, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 3, i32 %48
+  %NullCheck39 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %56
+
+; <label>:56                                      ; preds = %54
+  %57 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, i32 0, i32 0
+  %58 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck41 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %59
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %60, %System.__Canon addrspace(1)* %58)
+  %61 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck43 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  %64 = load i32, i32 addrspace(1)* %63, align 8
+  %65 = add i32 %64, 1
+  %NullCheck45 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  store i32 %65, i32 addrspace(1)* %67
+  ret i8 1
+
+; <label>:68                                      ; preds = %32
+  %69 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck47 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %73 = add i32 %72, 1
+  %NullCheck49 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %74
+
+; <label>:74                                      ; preds = %70
+  %75 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  store i32 %73, i32 addrspace(1)* %75
+  br label %76
+
+; <label>:76                                      ; preds = %8, %12, %74
+  %77 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %78
+
+; <label>:78                                      ; preds = %76
+  %79 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, i32 0, i32 2
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck7 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %82
+
+; <label>:82                                      ; preds = %78
+  %83 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, i32 0, i32 0
+  %84 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %83, align 8
+  %NullCheck9 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %85
+
+; <label>:85                                      ; preds = %82
+  %86 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, i32 0, i32 7
+  %87 = load i32, i32 addrspace(1)* %86, align 8
+  %88 = icmp ult i32 %80, %87
+  br i1 %88, label %13, label %89
+
+; <label>:89                                      ; preds = %85
+  %90 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %91 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck11 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %92
+
+; <label>:92                                      ; preds = %89
+  %93 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, i32 0, i32 0
+  %94 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck13 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %95
+
+; <label>:95                                      ; preds = %92
+  %96 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, i32 0, i32 7
+  %97 = load i32, i32 addrspace(1)* %96, align 8
+  %98 = add i32 %97, 1
+  %NullCheck15 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %99
+
+; <label>:99                                      ; preds = %95
+  %100 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, i32 0, i32 2
+  store i32 %98, i32 addrspace(1)* %100
+  %101 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck17 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %102
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %103, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %92
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef22:                                   ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef24:                                   ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef26:                                   ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef28:                                   ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef30:                                   ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef32:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef34:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef36:                                   ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange38:                           ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef40:                                   ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef42:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef44:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef46:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef48:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef50:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -5200,8 +6368,8 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -5232,9 +6400,9 @@ Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
 Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
-Failed to read String.MakeSeparatorList[loadElemA]
+Failed to read String.MakeSeparatorList[storeElem]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
-Failed to read String.InternalSplitKeepEmptyEntries[loadElem]
+Failed to read String.InternalSplitKeepEmptyEntries[storeElem]
 INFO:  jitting method Path::IsRelative using LLILCJit
 Successfully read Path.IsRelative
 
@@ -5243,8 +6411,8 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -5254,8 +6422,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
@@ -5271,8 +6439,8 @@ entry:
 
 ; <label>:17                                      ; preds = %7
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
@@ -5288,8 +6456,8 @@ entry:
 
 ; <label>:29                                      ; preds = %19
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %31
 
 ; <label>:31                                      ; preds = %29
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
@@ -5300,8 +6468,8 @@ entry:
 
 ; <label>:36                                      ; preds = %31
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
-  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %37, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
@@ -5312,8 +6480,8 @@ entry:
 
 ; <label>:43                                      ; preds = %31, %38
   %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
-  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %45
 
 ; <label>:45                                      ; preds = %43
   %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
@@ -5324,8 +6492,8 @@ entry:
 
 ; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %50
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
@@ -5336,8 +6504,8 @@ entry:
 
 ; <label>:57                                      ; preds = %1, %7, %19, %45, %52
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
-  br i1 %NullCheck14, label %59, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %59
 
 ; <label>:59                                      ; preds = %57
   %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
@@ -5347,8 +6515,8 @@ entry:
 
 ; <label>:63                                      ; preds = %59
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
@@ -5359,8 +6527,8 @@ entry:
 
 ; <label>:70                                      ; preds = %65
   %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
-  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.String addrspace(1)* %71, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %72
 
 ; <label>:72                                      ; preds = %70
   %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
@@ -5379,39 +6547,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %17
+ThrowNullRef4:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %29
+ThrowNullRef6:                                    ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %36
+ThrowNullRef8:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %43
+ThrowNullRef10:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %50
+ThrowNullRef12:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %57
+ThrowNullRef14:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %63
+ThrowNullRef16:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %70
+ThrowNullRef18:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5419,7 +6587,293 @@ ThrowNullRef17:                                   ; preds = %70
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
-Failed to read String.TrimHelper[loadElem]
+Successfully read String.TrimHelper
+
+define %System.String addrspace(1)* @String.TrimHelper(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i16
+  %loc4 = alloca i32
+  %loc5 = alloca i16
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = sub i32 %3, 1
+  store i32 %4, i32* %loc0
+  store i32 0, i32* %loc1
+  %5 = load i32, i32* %arg2
+  %6 = icmp eq i32 %5, 1
+  br i1 %6, label %62, label %7
+
+; <label>:7                                       ; preds = %1
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:8                                       ; preds = %58
+  store i32 0, i32* %loc2
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load i32, i32* %loc1
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2, i32 %10
+  %13 = load i16, i16 addrspace(1)* %12
+  %14 = zext i16 %13 to i32
+  %15 = trunc i32 %14 to i16
+  store i16 %15, i16* %loc3
+  store i32 0, i32* %loc2
+  br label %34
+
+; <label>:16                                      ; preds = %37
+  %17 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %18 = load i32, i32* %loc2
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %17, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %19
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = zext i32 %18 to i64
+  %BoundsCheck = icmp uge i64 %23, %22
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %24
+
+; <label>:24                                      ; preds = %19
+  %25 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 3, i32 %18
+  %26 = load i16, i16 addrspace(1)* %25, align 8
+  %27 = zext i16 %26 to i32
+  %28 = load i16, i16* %loc3
+  %29 = zext i16 %28 to i32
+  %30 = icmp eq i32 %27, %29
+  br i1 %30, label %43, label %31
+
+; <label>:31                                      ; preds = %24
+  %32 = load i32, i32* %loc2
+  %33 = add i32 %32, 1
+  store i32 %33, i32* %loc2
+  br label %34
+
+; <label>:34                                      ; preds = %11, %31
+  %35 = load i32, i32* %loc2
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = icmp slt i32 %35, %41
+  br i1 %42, label %16, label %43
+
+; <label>:43                                      ; preds = %24, %37
+  %44 = load i32, i32* %loc2
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %45, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp eq i32 %44, %50
+  br i1 %51, label %62, label %52
+
+; <label>:52                                      ; preds = %46
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %7, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %57, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %58
+
+; <label>:58                                      ; preds = %55
+  %59 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %60 = load i32, i32 addrspace(1)* %59
+  %61 = icmp slt i32 %56, %60
+  br i1 %61, label %8, label %62
+
+; <label>:62                                      ; preds = %1, %46, %58
+  %63 = load i32, i32* %arg2
+  %64 = icmp eq i32 %63, 0
+  br i1 %64, label %122, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %66, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %67
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %66, i32 0, i32 1
+  %69 = load i32, i32 addrspace(1)* %68
+  %70 = sub i32 %69, 1
+  store i32 %70, i32* %loc0
+  br label %118
+
+; <label>:71                                      ; preds = %118
+  store i32 0, i32* %loc4
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %73 = load i32, i32* %loc0
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %74
+
+; <label>:74                                      ; preds = %71
+  %75 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 2, i32 %73
+  %76 = load i16, i16 addrspace(1)* %75
+  %77 = zext i16 %76 to i32
+  %78 = trunc i32 %77 to i16
+  store i16 %78, i16* %loc5
+  store i32 0, i32* %loc4
+  br label %97
+
+; <label>:79                                      ; preds = %100
+  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %81 = load i32, i32* %loc4
+  %NullCheck19 = icmp eq %"System.Char[]" addrspace(1)* %80, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
+
+; <label>:82                                      ; preds = %79
+  %83 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 1
+  %84 = load i32, i32 addrspace(1)* %83
+  %85 = zext i32 %84 to i64
+  %86 = zext i32 %81 to i64
+  %BoundsCheck21 = icmp uge i64 %86, %85
+  br i1 %BoundsCheck21, label %ThrowIndexOutOfRange22, label %87
+
+; <label>:87                                      ; preds = %82
+  %88 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 3, i32 %81
+  %89 = load i16, i16 addrspace(1)* %88, align 8
+  %90 = zext i16 %89 to i32
+  %91 = load i16, i16* %loc5
+  %92 = zext i16 %91 to i32
+  %93 = icmp eq i32 %90, %92
+  br i1 %93, label %106, label %94
+
+; <label>:94                                      ; preds = %87
+  %95 = load i32, i32* %loc4
+  %96 = add i32 %95, 1
+  store i32 %96, i32* %loc4
+  br label %97
+
+; <label>:97                                      ; preds = %74, %94
+  %98 = load i32, i32* %loc4
+  %99 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck15 = icmp eq %"System.Char[]" addrspace(1)* %99, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %100
+
+; <label>:100                                     ; preds = %97
+  %101 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %99, i32 0, i32 1
+  %102 = load i32, i32 addrspace(1)* %101
+  %103 = zext i32 %102 to i64
+  %104 = trunc i64 %103 to i32
+  %105 = icmp slt i32 %98, %104
+  br i1 %105, label %79, label %106
+
+; <label>:106                                     ; preds = %87, %100
+  %107 = load i32, i32* %loc4
+  %108 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck17 = icmp eq %"System.Char[]" addrspace(1)* %108, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %109
+
+; <label>:109                                     ; preds = %106
+  %110 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %108, i32 0, i32 1
+  %111 = load i32, i32 addrspace(1)* %110
+  %112 = zext i32 %111 to i64
+  %113 = trunc i64 %112 to i32
+  %114 = icmp eq i32 %107, %113
+  br i1 %114, label %122, label %115
+
+; <label>:115                                     ; preds = %109
+  %116 = load i32, i32* %loc0
+  %117 = sub i32 %116, 1
+  store i32 %117, i32* %loc0
+  br label %118
+
+; <label>:118                                     ; preds = %67, %115
+  %119 = load i32, i32* %loc0
+  %120 = load i32, i32* %loc1
+  %121 = icmp sge i32 %119, %120
+  br i1 %121, label %71, label %122
+
+; <label>:122                                     ; preds = %62, %109, %118
+  %123 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %124 = load i32, i32* %loc1
+  %125 = load i32, i32* %loc0
+  %126 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %123, i32 %124, i32 %125)
+  ret %System.String addrspace(1)* %126
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %97
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange22:                           ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
 Successfully read String.CreateTrimmedString
 
@@ -5439,8 +6893,8 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
@@ -5535,8 +6989,8 @@ entry:
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i64 2872
   %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
   %8 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %7
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %3
   %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
@@ -5553,8 +7007,8 @@ entry:
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 2864
   %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
   %21 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %20
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
-  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %22
 
 ; <label>:22                                      ; preds = %16
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
@@ -5569,7 +7023,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %16
+ThrowNullRef2:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5586,8 +7040,8 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5613,8 +7067,8 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
@@ -5632,8 +7086,8 @@ entry:
 
 ; <label>:12                                      ; preds = %4
   %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
@@ -5644,8 +7098,8 @@ entry:
 
 ; <label>:19                                      ; preds = %14
   %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %19
   %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
@@ -5660,21 +7114,21 @@ entry:
   %31 = zext i16 %30 to i32
   %32 = bitcast i8* %29 to i16*
   %33 = trunc i32 %31 to i16
-  %NullCheck6 = icmp ne i16* %32, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i16* %32, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %21
   store i16 %33, i16* %32, align 8
   %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %36
 
 ; <label>:36                                      ; preds = %34
   %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
   %38 = load i32, i32 addrspace(1)* %37, align 8
   %39 = add i32 %38, 1
-  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %40
 
 ; <label>:40                                      ; preds = %36
   %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
@@ -5683,16 +7137,16 @@ entry:
 
 ; <label>:42                                      ; preds = %14
   %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
-  br i1 %NullCheck12, label %44, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
   %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
   %47 = load i16, i16* %arg1
   %48 = zext i16 %47 to i32
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = trunc i32 %48 to i16
@@ -5703,31 +7157,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %19
+ThrowNullRef4:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %21
+ThrowNullRef6:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %36
+ThrowNullRef10:                                   ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %42
+ThrowNullRef12:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %44
+ThrowNullRef14:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5740,8 +7194,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -5752,8 +7206,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
@@ -5762,14 +7216,14 @@ entry:
 
 ; <label>:11                                      ; preds = %1
   %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
@@ -5779,15 +7233,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5808,8 +7262,8 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5822,8 +7276,8 @@ entry:
 
 ; <label>:8                                       ; preds = %3
   %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
@@ -5842,15 +7296,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
-  br i1 %NullCheck4, label %22, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
   %24 = load i16*, i16* addrspace(1)* %23, align 8
   %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %25, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
@@ -5859,8 +7313,8 @@ entry:
   store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
@@ -5874,8 +7328,8 @@ entry:
 
 ; <label>:37                                      ; preds = %65
   %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %37
   %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
@@ -5886,16 +7340,16 @@ entry:
   %45 = bitcast i16* %41 to i8*
   %46 = getelementptr inbounds i8, i8* %45, i64 %44
   %47 = bitcast i8* %46 to i16*
-  %NullCheck14 = icmp ne i16* %47, null
-  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %47, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %48
 
 ; <label>:48                                      ; preds = %39
   %49 = load i16, i16* %47, align 8
   %50 = zext i16 %49 to i32
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %52 = load i32, i32* %loc1
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %53
 
 ; <label>:53                                      ; preds = %48
   %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
@@ -5916,8 +7370,8 @@ entry:
 ; <label>:62                                      ; preds = %36, %59
   %63 = load i32, i32* %loc1
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck10, label %65, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %65
 
 ; <label>:65                                      ; preds = %62
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
@@ -5936,15 +7390,15 @@ entry:
 
 ; <label>:74                                      ; preds = %70
   %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
-  br i1 %NullCheck18, label %76, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %76
 
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
   %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
-  br i1 %NullCheck20, label %80, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
   %81 = load i64, i64 addrspace(1)* %79
@@ -5958,8 +7412,8 @@ entry:
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
   %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
-  br i1 %NullCheck22, label %92, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.String addrspace(1)* %90, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %92
 
 ; <label>:92                                      ; preds = %80
   %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
@@ -5969,15 +7423,15 @@ entry:
 
 ; <label>:96                                      ; preds = %70
   %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
-  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %98
 
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
   %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
-  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
   %103 = load i64, i64 addrspace(1)* %101
@@ -5991,8 +7445,8 @@ entry:
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
   %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
-  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.String addrspace(1)* %112, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %114
 
 ; <label>:114                                     ; preds = %102
   %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
@@ -6004,59 +7458,59 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %20
+ThrowNullRef4:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %22
+ThrowNullRef6:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %26
+ThrowNullRef8:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %62
+ThrowNullRef10:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %48
+ThrowNullRef16:                                   ; preds = %48
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %74
+ThrowNullRef18:                                   ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %76
+ThrowNullRef20:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %80
+ThrowNullRef22:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %96
+ThrowNullRef24:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %98
+ThrowNullRef26:                                   ; preds = %98
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %102
+ThrowNullRef28:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6069,15 +7523,15 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
   %3 = load i16*, i16* addrspace(1)* %2, align 8
   %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
@@ -6087,8 +7541,8 @@ entry:
   %10 = bitcast i16* %3 to i8*
   %11 = getelementptr inbounds i8, i8* %10, i64 %9
   %12 = bitcast i8* %11 to i16*
-  %NullCheck4 = icmp ne i16* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %5
   store i16 0, i16* %12, align 8
@@ -6098,11 +7552,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6119,8 +7573,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -6131,8 +7585,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
@@ -6144,15 +7598,15 @@ entry:
 
 ; <label>:14                                      ; preds = %1
   %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
   %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
   %21 = load i64, i64 addrspace(1)* %19
@@ -6171,15 +7625,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %14
+ThrowNullRef4:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %16
+ThrowNullRef6:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6302,14 +7756,6 @@ entry:
   ret %System.String addrspace(1)* %57
 }
 
-INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
-Successfully read RuntimeHelpers.get_OffsetToStringData
-
-define i32 @RuntimeHelpers.get_OffsetToStringData() {
-entry:
-  ret i32 12
-}
-
 INFO:  jitting method String::Equals using LLILCJit
 Successfully read String.Equals
 
@@ -6381,8 +7827,8 @@ entry:
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
-  br i1 %NullCheck24, label %29, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
   %30 = load i64, i64 addrspace(1)* %28
@@ -6397,8 +7843,8 @@ entry:
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
-  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
   %43 = load i64, i64 addrspace(1)* %41
@@ -6418,8 +7864,8 @@ entry:
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
   %59 = load i64, i64 addrspace(1)* %57
@@ -6434,8 +7880,8 @@ entry:
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck22, label %71, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
   %72 = load i64, i64 addrspace(1)* %70
@@ -6455,8 +7901,8 @@ entry:
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
-  br i1 %NullCheck16, label %87, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = load i64, i64 addrspace(1)* %86
@@ -6471,8 +7917,8 @@ entry:
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck18, label %100, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
   %101 = load i64, i64 addrspace(1)* %99
@@ -6492,8 +7938,8 @@ entry:
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
-  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
   %117 = load i64, i64 addrspace(1)* %115
@@ -6508,8 +7954,8 @@ entry:
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
-  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
   %130 = load i64, i64 addrspace(1)* %128
@@ -6528,15 +7974,15 @@ entry:
 
 ; <label>:142                                     ; preds = %22
   %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
-  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %143, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %144
 
 ; <label>:144                                     ; preds = %142
   %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
   %146 = load i32, i32 addrspace(1)* %145
   %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
-  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %147, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %148
 
 ; <label>:148                                     ; preds = %144
   %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
@@ -6557,15 +8003,15 @@ entry:
 
 ; <label>:159                                     ; preds = %22
   %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
-  br i1 %NullCheck, label %161, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %ThrowNullRef, label %161
 
 ; <label>:161                                     ; preds = %159
   %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
   %163 = load i32, i32 addrspace(1)* %162
   %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
-  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %164, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %165
 
 ; <label>:165                                     ; preds = %161
   %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
@@ -6578,8 +8024,8 @@ entry:
 
 ; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
-  br i1 %NullCheck4, label %172, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %171, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %172
 
 ; <label>:172                                     ; preds = %170
   %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
@@ -6589,8 +8035,8 @@ entry:
 
 ; <label>:176                                     ; preds = %172
   %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
-  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %177, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %178
 
 ; <label>:178                                     ; preds = %176
   %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
@@ -6629,55 +8075,55 @@ ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %161
+ThrowNullRef2:                                    ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %170
+ThrowNullRef4:                                    ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %176
+ThrowNullRef6:                                    ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %142
+ThrowNullRef8:                                    ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %144
+ThrowNullRef10:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %113
+ThrowNullRef12:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %116
+ThrowNullRef14:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %84
+ThrowNullRef16:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %87
+ThrowNullRef18:                                   ; preds = %87
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %55
+ThrowNullRef20:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %58
+ThrowNullRef22:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %26
+ThrowNullRef24:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %29
+ThrowNullRef26:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,8 +8161,8 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck, label %14, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %ThrowNullRef, label %14
 
 ; <label>:14                                      ; preds = %8
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
@@ -6760,8 +8206,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
@@ -6770,14 +8216,14 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32, i32* %loc0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %10
   %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
   %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
@@ -6790,15 +8236,15 @@ entry:
 ; <label>:25                                      ; preds = %19
   %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
-  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
   %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
@@ -6807,8 +8253,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %37 = load i32, i32* %loc0
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %38, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %38
 
 ; <label>:38                                      ; preds = %32
   %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
@@ -6817,14 +8263,14 @@ entry:
 
 ; <label>:40                                      ; preds = %19
   %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %40
   %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
   %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
-  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
-  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
@@ -6832,8 +8278,8 @@ entry:
   %48 = zext i32 %47 to i64
   %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
-  br i1 %NullCheck16, label %51, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %51
 
 ; <label>:51                                      ; preds = %45
   %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
@@ -6847,15 +8293,15 @@ entry:
 ; <label>:57                                      ; preds = %51
   %58 = load i16*, i16** %arg1
   %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
-  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %60
 
 ; <label>:60                                      ; preds = %57
   %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
   %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
-  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %64
 
 ; <label>:64                                      ; preds = %60
   %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
@@ -6864,22 +8310,22 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
   %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
-  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %70
 
 ; <label>:70                                      ; preds = %64
   %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
   %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
-  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
-  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
   %75 = load i32, i32 addrspace(1)* %74
   %76 = zext i32 %75 to i64
   %77 = trunc i64 %76 to i32
-  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
-  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %78
 
 ; <label>:78                                      ; preds = %73
   %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
@@ -6901,8 +8347,8 @@ entry:
   %90 = bitcast i16* %86 to i8*
   %91 = getelementptr inbounds i8, i8* %90, i64 %89
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %93
 
 ; <label>:93                                      ; preds = %80
   %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
@@ -6912,8 +8358,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %99 = load i32, i32* %loc2
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %100
 
 ; <label>:100                                     ; preds = %93
   %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
@@ -6928,63 +8374,63 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %25
+ThrowNullRef6:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %32
+ThrowNullRef10:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %40
+ThrowNullRef12:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %45
+ThrowNullRef16:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %57
+ThrowNullRef18:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %60
+ThrowNullRef20:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %64
+ThrowNullRef22:                                   ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %70
+ThrowNullRef24:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %73
+ThrowNullRef26:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %80
+ThrowNullRef28:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %93
+ThrowNullRef30:                                   ; preds = %93
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7004,8 +8450,8 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
@@ -7033,43 +8479,43 @@ entry:
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %14
   %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
   %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   %28 = load i32, i32 addrspace(1)* %27, align 8
   %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
-  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %30
 
 ; <label>:30                                      ; preds = %26
   %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
   %32 = load i32, i32 addrspace(1)* %31, align 8
   %33 = add i32 %28, %32
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %34
 
 ; <label>:34                                      ; preds = %30
   %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   store i32 %33, i32 addrspace(1)* %35
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
   store i32 0, i32 addrspace(1)* %38
   %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %40
 
 ; <label>:40                                      ; preds = %37
   %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
@@ -7082,8 +8528,8 @@ entry:
 
 ; <label>:47                                      ; preds = %40
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
@@ -7098,8 +8544,8 @@ entry:
   %54 = load i32, i32* %loc0
   %55 = sext i32 %54 to i64
   %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
-  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %57
 
 ; <label>:57                                      ; preds = %52
   %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
@@ -7110,68 +8556,35 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %14
+ThrowNullRef2:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %23
+ThrowNullRef4:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %26
+ThrowNullRef6:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %30
+ThrowNullRef8:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %34
+ThrowNullRef10:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %47
+ThrowNullRef14:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %52
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-}
-
-INFO:  jitting method StringBuilder::get_Length using LLILCJit
-Successfully read StringBuilder.get_Length
-
-define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.StringBuilder addrspace(1)*
-  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
-  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
-
-; <label>:1                                       ; preds = %entry
-  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %3 = load i32, i32 addrspace(1)* %2, align 8
-  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
-
-; <label>:5                                       ; preds = %1
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = add i32 %3, %7
-  ret i32 %8
-
-ThrowNullRef:                                     ; preds = %entry
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef16:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7213,70 +8626,70 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
   %6 = load i32, i32 addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
   store i32 %6, i32 addrspace(1)* %8
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
   %13 = load i32, i32 addrspace(1)* %12, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
   store i32 %13, i32 addrspace(1)* %15
   %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
-  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %18
 
 ; <label>:18                                      ; preds = %14
   %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
   %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
   %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
   %34 = load i32, i32 addrspace(1)* %33, align 8
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
-  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
@@ -7287,39 +8700,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %28
+ThrowNullRef16:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %32
+ThrowNullRef18:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7455,13 +8868,13 @@ entry:
 ; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
@@ -7477,16 +8890,16 @@ entry:
 
 ; <label>:18                                      ; preds = %15
   %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
   store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
   %22 = load i32, i32* %loc0
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %24
 
 ; <label>:24                                      ; preds = %20
   %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
@@ -7498,13 +8911,13 @@ entry:
 ; <label>:28                                      ; preds = %15, %24
   %29 = load i32, i32* %arg1
   %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %31
   %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
@@ -7517,20 +8930,20 @@ entry:
   %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
-  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
   %46 = load i32, i32 addrspace(1)* %45, align 8
   %47 = sub i32 %40, %46
-  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
-  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i32 addrspace(1)* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %48
 
 ; <label>:48                                      ; preds = %44
   store i32 %47, i32 addrspace(1)* %39, align 8
@@ -7538,21 +8951,21 @@ entry:
 
 ; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
-  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %51
 
 ; <label>:51                                      ; preds = %49
   %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %53
 
 ; <label>:53                                      ; preds = %51
   %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
   %55 = load i32, i32 addrspace(1)* %54, align 8
   %56 = load i32, i32* %arg2
   %57 = sub i32 %55, %56
-  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %58
 
 ; <label>:58                                      ; preds = %53
   %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
@@ -7562,13 +8975,13 @@ entry:
 ; <label>:60                                      ; preds = %33, %58
   %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
   %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
-  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %63
 
 ; <label>:63                                      ; preds = %60
   %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
-  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
-  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
@@ -7578,15 +8991,15 @@ entry:
 
 ; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
-  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i32 addrspace(1)* %69, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %70
 
 ; <label>:70                                      ; preds = %68
   %71 = load i32, i32 addrspace(1)* %69, align 8
   store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
-  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
@@ -7596,8 +9009,8 @@ entry:
   store i32 %77, i32* %loc4
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
-  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %80
 
 ; <label>:80                                      ; preds = %73
   %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
@@ -7607,71 +9020,71 @@ entry:
 ; <label>:83                                      ; preds = %80
   store i32 0, i32* %loc3
   %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
-  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
-  br i1 %NullCheck26, label %88, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i32 addrspace(1)* %87, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %88
 
 ; <label>:88                                      ; preds = %85
   %89 = load i32, i32 addrspace(1)* %87, align 8
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
-  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %90
 
 ; <label>:90                                      ; preds = %88
   %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
   store i32 %89, i32 addrspace(1)* %91
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
-  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
-  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %96
 
 ; <label>:96                                      ; preds = %94
   %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
-  br i1 %NullCheck34, label %100, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %100
 
 ; <label>:100                                     ; preds = %96
   %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
-  br i1 %NullCheck36, label %102, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %102
 
 ; <label>:102                                     ; preds = %100
   %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
   %104 = load i32, i32 addrspace(1)* %103, align 8
   %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
-  br i1 %NullCheck38, label %106, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %106
 
 ; <label>:106                                     ; preds = %102
   %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
-  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
-  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %108
 
 ; <label>:108                                     ; preds = %106
   %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
   %110 = load i32, i32 addrspace(1)* %109, align 8
   %111 = add i32 %104, %110
-  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %112
 
 ; <label>:112                                     ; preds = %108
   %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
   store i32 %111, i32 addrspace(1)* %113
   %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
-  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i32 addrspace(1)* %114, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %115
 
 ; <label>:115                                     ; preds = %112
   %116 = load i32, i32 addrspace(1)* %114, align 8
@@ -7681,19 +9094,19 @@ entry:
 ; <label>:118                                     ; preds = %115
   %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
-  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %121
 
 ; <label>:121                                     ; preds = %118
   %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
-  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
-  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %123
 
 ; <label>:123                                     ; preds = %121
   %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
   %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
-  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
-  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %126
 
 ; <label>:126                                     ; preds = %123
   %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
@@ -7705,8 +9118,8 @@ entry:
 
 ; <label>:130                                     ; preds = %80, %115, %126
   %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %132
 
 ; <label>:132                                     ; preds = %130
   %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7715,8 +9128,8 @@ entry:
   %136 = load i32, i32* %loc3
   %137 = sub i32 %135, %136
   %138 = sub i32 %134, %137
-  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %139
 
 ; <label>:139                                     ; preds = %132
   %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7728,16 +9141,16 @@ entry:
 
 ; <label>:144                                     ; preds = %139
   %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
-  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %146
 
 ; <label>:146                                     ; preds = %144
   %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
   %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
   %149 = load i32, i32* %loc2
   %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
-  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %151
 
 ; <label>:151                                     ; preds = %146
   %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
@@ -7754,145 +9167,249 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %18
+ThrowNullRef4:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %31
+ThrowNullRef10:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %44
+ThrowNullRef16:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %68
+ThrowNullRef18:                                   ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %70
+ThrowNullRef20:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %73
+ThrowNullRef22:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %83
+ThrowNullRef24:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %85
+ThrowNullRef26:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %88
+ThrowNullRef28:                                   ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %90
+ThrowNullRef30:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %94
+ThrowNullRef32:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %96
+ThrowNullRef34:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %100
+ThrowNullRef36:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %102
+ThrowNullRef38:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %106
+ThrowNullRef40:                                   ; preds = %106
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %108
+ThrowNullRef42:                                   ; preds = %108
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %112
+ThrowNullRef44:                                   ; preds = %112
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %118
+ThrowNullRef46:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %121
+ThrowNullRef48:                                   ; preds = %121
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %123
+ThrowNullRef50:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %130
+ThrowNullRef52:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %132
+ThrowNullRef54:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %144
+ThrowNullRef56:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %146
+ThrowNullRef58:                                   ; preds = %146
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %60
+ThrowNullRef60:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %63
+ThrowNullRef62:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %49
+ThrowNullRef64:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %51
+ThrowNullRef66:                                   ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %53
+ThrowNullRef68:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(%"System.Char[]" addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %arg0 = alloca %"System.Char[]" addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store %"System.Char[]" addrspace(1)* %param0, %"System.Char[]" addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load i32, i32* %arg4
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %43, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %38, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg1
+  %13 = load i32, i32* %arg4
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %38, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %24 = load i32, i32* %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %35 = load i32, i32* %arg3
+  %36 = load i32, i32* %arg4
+  %37 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %37, %"System.Char[]" addrspace(1)* %34, i32 %35, i32 %36)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:38                                      ; preds = %5, %16
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Successfully read Buffer._Memmove
 
@@ -7914,7 +9431,7 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[loadElem]
+Failed to read AppDomain.SetDataHelper[storeElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -7923,8 +9440,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
@@ -7934,8 +9451,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
@@ -7947,15 +9464,15 @@ entry:
   %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
   %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
@@ -7966,15 +9483,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7992,7 +9509,79 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
-Failed to read Dictionary`2.TryGetValue[loadElemA]
+Successfully read Dictionary`2.TryGetValue
+
+define i8 @"Dictionary`2.TryGetValue"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)* addrspace(1)* %param2) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  %arg2 = alloca %System.__Canon addrspace(1)* addrspace(1)*
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  store %System.__Canon addrspace(1)* addrspace(1)* %param2, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  store i32 %2, i32* %loc0
+  %3 = load i32, i32* %loc0
+  %4 = icmp slt i32 %3, 0
+  br i1 %4, label %22, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 2
+  %10 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %9, align 8
+  %11 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = zext i32 %11 to i64
+  %BoundsCheck = icmp uge i64 %16, %15
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 3, i32 %11
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %20, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %6, %System.__Canon addrspace(1)* %21)
+  ret i8 1
+
+; <label>:22                                      ; preds = %entry
+  %23 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %23, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -8058,8 +9647,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
@@ -8091,8 +9680,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
@@ -8171,15 +9760,15 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck, label %19, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %ThrowNullRef, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
   %21 = load i32, i32 addrspace(1)* %20
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
@@ -8202,7 +9791,7 @@ ThrowNullRef:                                     ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %19
+ThrowNullRef2:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8248,8 +9837,8 @@ entry:
   %0 = alloca %System.AppDomainHandle
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %1 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %1, i32 0, i32 15
@@ -8269,8 +9858,8 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
@@ -8286,7 +9875,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -8299,8 +9888,8 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -8327,8 +9916,8 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
@@ -8352,8 +9941,8 @@ entry:
   %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
   store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
@@ -8363,8 +9952,8 @@ entry:
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
@@ -8374,8 +9963,8 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %9
   %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
@@ -8384,8 +9973,8 @@ entry:
 
 ; <label>:18                                      ; preds = %3, %16
   %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
@@ -8397,15 +9986,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %18
+ThrowNullRef6:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8418,8 +10007,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
@@ -8453,15 +10042,15 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
@@ -8473,7 +10062,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8481,7 +10070,7 @@ ThrowNullRef1:                                    ; preds = %1
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
 Failed to read Dictionary`2.System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
@@ -8506,8 +10095,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
@@ -8524,8 +10113,8 @@ entry:
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -8544,7 +10133,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8577,8 +10166,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = load i64, i64* %arg2
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = trunc i32 %3 to i8
@@ -8634,46 +10223,46 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
   %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
-  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
-  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
-  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
@@ -8684,27 +10273,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %20
+ThrowNullRef12:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8717,8 +10306,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -8756,22 +10345,22 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
   %9 = load i64, i64 addrspace(1)* %8, align 8
   %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
   %13 = load i64, i64 addrspace(1)* %12, align 8
   %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %11
   %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
@@ -8788,11 +10377,11 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8882,8 +10471,8 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
@@ -8900,8 +10489,8 @@ entry:
 ; <label>:8                                       ; preds = %1
   %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
   %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
@@ -8911,15 +10500,15 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
   %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
   %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
-  br i1 %NullCheck6, label %21, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
@@ -8946,15 +10535,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8992,15 +10581,15 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
   store i8 %3, i8 addrspace(1)* %5
   %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
@@ -9011,7 +10600,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9027,8 +10616,8 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -9041,8 +10630,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
@@ -9058,7 +10647,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9080,8 +10669,8 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
@@ -9096,8 +10685,8 @@ entry:
 ; <label>:12                                      ; preds = %6
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
@@ -9112,8 +10701,8 @@ entry:
 ; <label>:21                                      ; preds = %15
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
@@ -9128,8 +10717,8 @@ entry:
 ; <label>:30                                      ; preds = %24
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %31, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
@@ -9144,8 +10733,8 @@ entry:
 ; <label>:39                                      ; preds = %33
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
-  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %40, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %42
 
 ; <label>:42                                      ; preds = %39
   %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
@@ -9164,19 +10753,19 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %21
+ThrowNullRef4:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %30
+ThrowNullRef6:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %39
+ThrowNullRef8:                                    ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9243,8 +10832,8 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
@@ -9264,57 +10853,57 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
   store i8 0, i8 addrspace(1)* %2
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
   store i8 0, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
   store i8 0, i8 addrspace(1)* %17
   %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
   store i8 0, i8 addrspace(1)* %20
   %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
-  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
@@ -9325,31 +10914,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %19
+ThrowNullRef14:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9367,8 +10956,8 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
@@ -9380,8 +10969,8 @@ entry:
 
 ; <label>:9                                       ; preds = %4
   %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %9
   %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
@@ -9395,7 +10984,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef2:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9420,8 +11009,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
@@ -9512,8 +11101,8 @@ entry:
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
@@ -9524,8 +11113,8 @@ entry:
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = load i64, i64 addrspace(1)* %12
@@ -9537,8 +11126,8 @@ entry:
   %20 = load i64, i64* %19
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
-  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %13
   %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
@@ -9555,8 +11144,8 @@ entry:
 ; <label>:30                                      ; preds = %25
   %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %32 = load i32, i32* %arg2
-  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
-  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
@@ -9570,15 +11159,15 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %30
+ThrowNullRef2:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9622,87 +11211,87 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
   %10 = load i8, i8 addrspace(1)* %9, align 8
   %11 = zext i8 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %8
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
   store i8 %12, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
   %19 = load i8, i8 addrspace(1)* %18, align 8
   %20 = zext i8 %19 to i32
   %21 = trunc i32 %20 to i8
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
   store i8 %21, i8 addrspace(1)* %23
   %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
   %28 = load i8, i8 addrspace(1)* %27, align 8
   %29 = zext i8 %28 to i32
   %30 = trunc i32 %29 to i8
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
-  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %31
 
 ; <label>:31                                      ; preds = %26
   %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
   store i8 %30, i8 addrspace(1)* %32
   %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
-  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
-  br i1 %NullCheck14, label %40, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %40
 
 ; <label>:40                                      ; preds = %35
   %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
   store i8 %39, i8 addrspace(1)* %41
   %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
-  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %44
 
 ; <label>:44                                      ; preds = %40
   %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
   %46 = load i8, i8 addrspace(1)* %45, align 8
   %47 = zext i8 %46 to i32
   %48 = trunc i32 %47 to i8
-  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
   store i8 %48, i8 addrspace(1)* %50
   %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
-  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
@@ -9713,29 +11302,29 @@ entry:
 ; <label>:56                                      ; preds = %52
   %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
-  br i1 %NullCheck22, label %59, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
   %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
   %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
-  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
-  br i1 %NullCheck24, label %63, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
   %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
-  br i1 %NullCheck26, label %66, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
   %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
-  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
-  br i1 %NullCheck28, label %69, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %69
 
 ; <label>:69                                      ; preds = %66
   %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
@@ -9744,15 +11333,15 @@ entry:
 
 ; <label>:71                                      ; preds = %105
   %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
-  br i1 %NullCheck34, label %73, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %73
 
 ; <label>:73                                      ; preds = %71
   %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
   %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
   %76 = load i32, i32* %loc0
-  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
-  br i1 %NullCheck36, label %77, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
@@ -9766,8 +11355,8 @@ entry:
 
 ; <label>:83                                      ; preds = %77
   %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
-  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
@@ -9775,14 +11364,14 @@ entry:
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
   %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
-  br i1 %NullCheck40, label %91, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
 ; <label>:91                                      ; preds = %85
   %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
   %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
-  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck42, label %94, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %94
 
 ; <label>:94                                      ; preds = %91
   %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
@@ -9798,14 +11387,14 @@ entry:
 ; <label>:99                                      ; preds = %69, %96
   %100 = load i32, i32* %loc0
   %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
-  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %102
 
 ; <label>:102                                     ; preds = %99
   %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
   %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
-  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
-  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
@@ -9819,87 +11408,87 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %26
+ThrowNullRef10:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %31
+ThrowNullRef12:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %35
+ThrowNullRef14:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %40
+ThrowNullRef16:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %56
+ThrowNullRef22:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %59
+ThrowNullRef24:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %63
+ThrowNullRef26:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %66
+ThrowNullRef28:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %102
+ThrowNullRef32:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %71
+ThrowNullRef34:                                   ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %73
+ThrowNullRef36:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %83
+ThrowNullRef38:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %85
+ThrowNullRef40:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %91
+ThrowNullRef42:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9943,15 +11532,15 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
   %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
@@ -9961,28 +11550,28 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
   %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %12
   %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
   %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
   %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
-  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
@@ -9993,23 +11582,23 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %12
+ThrowNullRef6:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10031,15 +11620,15 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
   %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = load i64, i64 addrspace(1)* %7
@@ -10077,13 +11666,13 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[loadElem]
+Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -10111,8 +11700,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -10230,8 +11819,8 @@ entry:
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load i32, i32* %arg0
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -10365,8 +11954,8 @@ entry:
   store i64 %param0, i64* %arg0
   store i64 %param1, i64* %arg1
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
@@ -10374,8 +11963,8 @@ entry:
   %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
   %5 = load i16*, i16* addrspace(1)* %4, align 8
   %6 = addrspacecast i64* %arg1 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = bitcast i64 addrspace(1)* %6 to i8 addrspace(1)*
@@ -10391,7 +11980,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10425,8 +12014,8 @@ entry:
   %1 = load i32, i32* %arg1
   %2 = sext i32 %1 to i64
   %3 = inttoptr i64 %2 to i16*
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -10479,8 +12068,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, i32)*)(%System.IO.ConsoleStream addrspace(1)* %2, i32 %1)
   %3 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %4 = load i64, i64* %arg1
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
@@ -10491,8 +12080,8 @@ entry:
   %10 = icmp eq i32 %9, 3
   %11 = sext i1 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %5
   %14 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, i32 0, i32 5
@@ -10503,7 +12092,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10526,8 +12115,8 @@ entry:
   %5 = icmp eq i32 %4, 1
   %6 = sext i1 %5 to i32
   %7 = trunc i32 %6 to i8
-  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %2, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.ConsoleStream addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
@@ -10538,8 +12127,8 @@ entry:
   %13 = icmp eq i32 %12, 2
   %14 = sext i1 %13 to i32
   %15 = trunc i32 %14 to i8
-  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %10, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.ConsoleStream addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %8
   %17 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %10, i32 0, i32 4
@@ -10550,7 +12139,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10589,8 +12178,8 @@ entry:
   %arg0 = alloca i64
   store i64 %param0, i64* %arg0
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
@@ -10625,8 +12214,8 @@ entry:
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
   %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = load i64, i64 addrspace(1)* %7
@@ -10730,7 +12319,127 @@ entry:
 INFO:  jitting method Encoding::GetEncoding using LLILCJit
 Failed to read Encoding.GetEncoding[convertToHelperArgumentType]
 INFO:  jitting method EncodingProvider::GetEncodingFromProvider using LLILCJit
-Failed to read EncodingProvider.GetEncodingFromProvider[loadElem]
+Successfully read EncodingProvider.GetEncodingFromProvider
+
+define %System.Text.Encoding addrspace(1)* @EncodingProvider.GetEncodingFromProvider(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca %"System.Text.EncodingProvider[]" addrspace(1)*
+  %loc1 = alloca %System.Text.EncodingProvider addrspace(1)*
+  %loc2 = alloca %System.Text.Encoding addrspace(1)*
+  %loc3 = alloca %System.Text.Encoding addrspace(1)*
+  %loc4 = alloca %"System.Text.EncodingProvider[]" addrspace(1)*
+  %loc5 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1059)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2392
+  %2 = addrspacecast i8 addrspace(1)* %1 to %"System.Text.EncodingProvider[]" addrspace(1)**
+  %3 = load volatile %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %2
+  %4 = icmp ne %"System.Text.EncodingProvider[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %entry
+  ret %System.Text.Encoding addrspace(1)* null
+
+; <label>:6                                       ; preds = %entry
+  %7 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1059)
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i64 2392
+  %9 = addrspacecast i8 addrspace(1)* %8 to %"System.Text.EncodingProvider[]" addrspace(1)**
+  %10 = load volatile %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %9
+  store %"System.Text.EncodingProvider[]" addrspace(1)* %10, %"System.Text.EncodingProvider[]" addrspace(1)** %loc0
+  %11 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc0
+  store %"System.Text.EncodingProvider[]" addrspace(1)* %11, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  store i32 0, i32* %loc5
+  br label %43
+
+; <label>:12                                      ; preds = %46
+  %13 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  %14 = load i32, i32* %loc5
+  %NullCheck1 = icmp eq %"System.Text.EncodingProvider[]" addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %13, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = zext i32 %17 to i64
+  %19 = zext i32 %14 to i64
+  %BoundsCheck = icmp uge i64 %19, %18
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %20
+
+; <label>:20                                      ; preds = %15
+  %21 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %13, i32 0, i32 3, i32 %14
+  %22 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)* addrspace(1)* %21, align 8
+  store %System.Text.EncodingProvider addrspace(1)* %22, %System.Text.EncodingProvider addrspace(1)** %loc1
+  %23 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)** %loc1
+  %24 = load i32, i32* %arg0
+  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i64 addrspace(1)*
+  %NullCheck3 = icmp eq i64 addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
+
+; <label>:26                                      ; preds = %20
+  %27 = load i64, i64 addrspace(1)* %25
+  %28 = add i64 %27, 64
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 40
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Text.Encoding addrspace(1)* (%System.Text.EncodingProvider addrspace(1)*, i32)*
+  %35 = call %System.Text.Encoding addrspace(1)* %34(%System.Text.EncodingProvider addrspace(1)* %23, i32 %24)
+  store %System.Text.Encoding addrspace(1)* %35, %System.Text.Encoding addrspace(1)** %loc2
+  %36 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc2
+  %37 = icmp eq %System.Text.Encoding addrspace(1)* %36, null
+  br i1 %37, label %40, label %38
+
+; <label>:38                                      ; preds = %26
+  %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc2
+  store %System.Text.Encoding addrspace(1)* %39, %System.Text.Encoding addrspace(1)** %loc3
+  br label %53
+
+; <label>:40                                      ; preds = %26
+  %41 = load i32, i32* %loc5
+  %42 = add i32 %41, 1
+  store i32 %42, i32* %loc5
+  br label %43
+
+; <label>:43                                      ; preds = %6, %40
+  %44 = load i32, i32* %loc5
+  %45 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  %NullCheck = icmp eq %"System.Text.EncodingProvider[]" addrspace(1)* %45, null
+  br i1 %NullCheck, label %ThrowNullRef, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp slt i32 %44, %50
+  br i1 %51, label %12, label %52
+
+; <label>:52                                      ; preds = %46
+  ret %System.Text.Encoding addrspace(1)* null
+
+; <label>:53                                      ; preds = %38
+  %54 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc3
+  ret %System.Text.Encoding addrspace(1)* %54
+
+ThrowNullRef:                                     ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method EncodingProvider::.cctor using LLILCJit
 Successfully read EncodingProvider..cctor
 
@@ -10749,7 +12458,7 @@ Failed to read Encoding.get_InternalSyncObject[Call HasTypeArg]
 INFO:  jitting method Hashtable::.ctor using LLILCJit
 Failed to read Hashtable..ctor[Volatile store]
 INFO:  jitting method Hashtable::get_Item using LLILCJit
-Failed to read Hashtable.get_Item[loadElemA]
+Failed to read Hashtable.get_Item[loadNonPrimitiveObj]
 INFO:  jitting method Hashtable::InitHash using LLILCJit
 Successfully read Hashtable.InitHash
 
@@ -10769,8 +12478,8 @@ entry:
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -10786,15 +12495,15 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
   %15 = load i32, i32* %loc0
-  %NullCheck2 = icmp ne i32 addrspace(1)* %14, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i32 addrspace(1)* %14, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %3
   store i32 %15, i32 addrspace(1)* %14, align 8
   %17 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %18 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %NullCheck4 = icmp ne i32 addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i32 addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = load i32, i32 addrspace(1)* %18, align 8
@@ -10803,8 +12512,8 @@ entry:
   %23 = sub i32 %22, 1
   %24 = urem i32 %21, %23
   %25 = add i32 1, %24
-  %NullCheck6 = icmp ne i32 addrspace(1)* %17, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32 addrspace(1)* %17, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %19
   store i32 %25, i32 addrspace(1)* %17, align 8
@@ -10815,15 +12524,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %19
+ThrowNullRef6:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10838,8 +12547,8 @@ entry:
   store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
   store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %NullCheck = icmp ne %System.Collections.Hashtable addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Collections.Hashtable addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
@@ -10849,16 +12558,16 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Collections.Hashtable addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Collections.Hashtable addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
   %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck4 = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %9, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
   %13 = inttoptr i64 %11 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
@@ -10868,8 +12577,8 @@ entry:
 ; <label>:15                                      ; preds = %1
   %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -10887,15 +12596,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10909,8 +12618,8 @@ entry:
   store %System.Int32 addrspace(1)* %param0, %System.Int32 addrspace(1)** %this
   %0 = load %System.Int32 addrspace(1)*, %System.Int32 addrspace(1)** %this
   %1 = bitcast %System.Int32 addrspace(1)* %0 to i32 addrspace(1)*
-  %NullCheck = icmp ne i32 addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq i32 addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load i32, i32 addrspace(1)* %1, align 8
@@ -10986,8 +12695,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.UTF8Encoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
@@ -10996,15 +12705,15 @@ entry:
   %9 = load i8, i8* %arg2
   %10 = zext i8 %9 to i32
   %11 = trunc i32 %10 to i8
-  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %8, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %6
   %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %8, i32 0, i32 8
   store i8 %11, i8 addrspace(1)* %13
   %14 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %14, i32 0, i32 8
@@ -11016,8 +12725,8 @@ entry:
 ; <label>:20                                      ; preds = %15
   %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %22, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %22, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = load i64, i64 addrspace(1)* %22
@@ -11039,15 +12748,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %12
+ThrowNullRef4:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11062,8 +12771,8 @@ entry:
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
@@ -11085,16 +12794,16 @@ entry:
 ; <label>:10                                      ; preds = %1
   %11 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
   %12 = load i32, i32* %arg1
-  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %11, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.Encoding addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
   store i32 %12, i32 addrspace(1)* %14
   %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
   %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = load i64, i64 addrspace(1)* %16
@@ -11112,11 +12821,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11129,8 +12838,8 @@ entry:
   %this = alloca %System.Text.UTF8Encoding addrspace(1)*
   store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
   %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.UTF8Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
@@ -11142,16 +12851,16 @@ entry:
 ; <label>:6                                       ; preds = %1
   %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %8 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %10, %System.Text.EncoderFallback addrspace(1)* %8)
   %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %12 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
-  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %11, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %11, i32 0, i32 3
@@ -11164,8 +12873,8 @@ entry:
   %18 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %18, %System.String addrspace(1)* %17)
   %19 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %18 to %System.Text.EncoderFallback addrspace(1)*
-  %NullCheck6 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %16, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %16, i32 0, i32 2
@@ -11175,8 +12884,8 @@ entry:
   %24 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %24, %System.String addrspace(1)* %23)
   %25 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %24 to %System.Text.DecoderFallback addrspace(1)*
-  %NullCheck8 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %22, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %22, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %20
   %27 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %22, i32 0, i32 3
@@ -11187,19 +12896,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %20
+ThrowNullRef8:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11229,8 +12938,8 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load i32, i32* %arg1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -11248,8 +12957,8 @@ entry:
 ; <label>:15                                      ; preds = %8
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %17 = load i32, i32* %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 %17
@@ -11265,7 +12974,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11317,7 +13026,7 @@ entry:
 }
 
 INFO:  jitting method Hashtable::Insert using LLILCJit
-Failed to read Hashtable.Insert[loadElemA]
+Failed to read Hashtable.Insert[storeElem]
 INFO:  jitting method ConsoleEncoding::.ctor using LLILCJit
 Successfully read ConsoleEncoding..ctor
 
@@ -11332,8 +13041,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %1)
   %2 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
@@ -11369,8 +13078,8 @@ entry:
   %2 = call %System.Text.InternalEncoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalEncoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %1)
   %3 = bitcast %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2 to %System.Text.EncoderFallback addrspace(1)*
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
@@ -11380,8 +13089,8 @@ entry:
   %8 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %7)
   %9 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %8 to %System.Text.DecoderFallback addrspace(1)*
-  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %6, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.Encoding addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %4
   %11 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %6, i32 0, i32 3
@@ -11392,7 +13101,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11411,15 +13120,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* %1)
   %2 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   %6 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, i32 0, i32 1
@@ -11430,7 +13139,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11458,8 +13167,8 @@ entry:
   store %System.Text.InternalDecoderBestFitFallback addrspace(1)* %param0, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
   %0 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
@@ -11469,15 +13178,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %4)
   %5 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %6)
   %9 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, i32 0, i32 1
@@ -11488,11 +13197,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11560,8 +13269,8 @@ entry:
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
   %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = load i64, i64 addrspace(1)* %19
@@ -11625,8 +13334,8 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.ConsoleStream addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
@@ -11657,31 +13366,31 @@ entry:
   store i8 %param4, i8* %arg4
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %3, %System.IO.Stream addrspace(1)* %1)
   %4 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %4, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
   %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %4, i32 0, i32 4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %5)
   %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %6
   %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
   %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
   %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = load i64, i64 addrspace(1)* %13
@@ -11693,8 +13402,8 @@ entry:
   %21 = load i64, i64* %20
   %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %8, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %8, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %14
   %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 5
@@ -11712,24 +13421,24 @@ entry:
   %31 = load i32, i32* %arg3
   %32 = sext i32 %31 to i64
   %33 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %32)
-  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %30, null
-  br i1 %NullCheck10, label %34, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.StreamWriter addrspace(1)* %30, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %35, %"System.Char[]" addrspace(1)* %33)
   %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %37, null
-  br i1 %NullCheck12, label %38, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.StreamWriter addrspace(1)* %37, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %38
 
 ; <label>:38                                      ; preds = %34
   %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
   %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
   %41 = load i32, i32* %arg3
   %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %42, null
-  br i1 %NullCheck14, label %43, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %42, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
   %44 = load i64, i64 addrspace(1)* %42
@@ -11743,30 +13452,30 @@ entry:
   %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
   %53 = sext i32 %52 to i64
   %54 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %53)
-  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
-  br i1 %NullCheck16, label %55, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %55
 
 ; <label>:55                                      ; preds = %43
   %56 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %56, %"System.Byte[]" addrspace(1)* %54)
   %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %58 = load i32, i32* %arg3
-  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %57, null
-  br i1 %NullCheck18, label %59, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.StreamWriter addrspace(1)* %57, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %59
 
 ; <label>:59                                      ; preds = %55
   %60 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 10
   store i32 %58, i32 addrspace(1)* %60
   %61 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %61, null
-  br i1 %NullCheck20, label %62, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.IO.StreamWriter addrspace(1)* %61, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %62
 
 ; <label>:62                                      ; preds = %59
   %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
   %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
   %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
   %67 = load i64, i64 addrspace(1)* %65
@@ -11784,15 +13493,15 @@ entry:
 
 ; <label>:78                                      ; preds = %66
   %79 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %79, null
-  br i1 %NullCheck24, label %80, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.StreamWriter addrspace(1)* %79, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %80
 
 ; <label>:80                                      ; preds = %78
   %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
   %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
   %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %83, null
-  br i1 %NullCheck26, label %84, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %83, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
   %85 = load i64, i64 addrspace(1)* %83
@@ -11809,8 +13518,8 @@ entry:
 
 ; <label>:95                                      ; preds = %84
   %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.IO.StreamWriter addrspace(1)* %96, null
-  br i1 %NullCheck28, label %97, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.IO.StreamWriter addrspace(1)* %96, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %97
 
 ; <label>:97                                      ; preds = %95
   %98 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 12
@@ -11824,8 +13533,8 @@ entry:
   %103 = icmp eq i32 %102, 0
   %104 = sext i1 %103 to i32
   %105 = trunc i32 %104 to i8
-  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %100, null
-  br i1 %NullCheck30, label %106, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.IO.StreamWriter addrspace(1)* %100, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %106
 
 ; <label>:106                                     ; preds = %99
   %107 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %100, i32 0, i32 13
@@ -11836,63 +13545,63 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %6
+ThrowNullRef4:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %29
+ThrowNullRef10:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %34
+ThrowNullRef12:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %38
+ThrowNullRef14:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %43
+ThrowNullRef16:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %55
+ThrowNullRef18:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %59
+ThrowNullRef20:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %62
+ThrowNullRef22:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %78
+ThrowNullRef24:                                   ; preds = %78
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %80
+ThrowNullRef26:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %95
+ThrowNullRef28:                                   ; preds = %95
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11905,15 +13614,15 @@ entry:
   %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = load i64, i64 addrspace(1)* %4
@@ -11931,7 +13640,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11981,35 +13690,35 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
   %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderNLS addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %7 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.EncoderNLS addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Text.Encoding addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.Encoding addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Text.EncoderNLS addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.EncoderNLS addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
   %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck8 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = load i64, i64 addrspace(1)* %16
@@ -12028,19 +13737,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12066,8 +13775,8 @@ entry:
   %this = alloca %System.Text.Encoding addrspace(1)*
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
@@ -12087,15 +13796,15 @@ entry:
   %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
   store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
   %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
   store i32 0, i32 addrspace(1)* %2
   %3 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, i32 0, i32 2
@@ -12105,15 +13814,15 @@ entry:
 
 ; <label>:8                                       ; preds = %4
   %9 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
   %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
   %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = load i64, i64 addrspace(1)* %13
@@ -12134,15 +13843,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12157,16 +13866,16 @@ entry:
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = load i32, i32* %arg1
   %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
   %7 = load i64, i64 addrspace(1)* %5
@@ -12184,7 +13893,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12221,8 +13930,8 @@ entry:
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
   %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
   %16 = load i64, i64 addrspace(1)* %14
@@ -12243,8 +13952,8 @@ entry:
   %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
   %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
   %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %31, null
-  br i1 %NullCheck2, label %32, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = load i64, i64 addrspace(1)* %31
@@ -12287,7 +13996,7 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12300,14 +14009,14 @@ entry:
   %this = alloca %System.Text.EncoderReplacementFallback addrspace(1)*
   store %System.Text.EncoderReplacementFallback addrspace(1)* %param0, %System.Text.EncoderReplacementFallback addrspace(1)** %this
   %0 = load %System.Text.EncoderReplacementFallback addrspace(1)*, %System.Text.EncoderReplacementFallback addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -12318,7 +14027,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12348,8 +14057,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
@@ -12381,8 +14090,8 @@ entry:
   %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
   store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
@@ -12394,8 +14103,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Threading.Tasks.Task addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %7)
@@ -12418,7 +14127,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12437,8 +14146,8 @@ entry:
   store i8 %param1, i8* %arg1
   store i8 %param2, i8* %arg2
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
@@ -12452,8 +14161,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1, %5
   %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 9
@@ -12484,8 +14193,8 @@ entry:
 
 ; <label>:25                                      ; preds = %8, %20
   %26 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %26, null
-  br i1 %NullCheck4, label %27, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %26, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %26, i32 0, i32 12
@@ -12496,22 +14205,22 @@ entry:
 
 ; <label>:32                                      ; preds = %27
   %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %33, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.IO.StreamWriter addrspace(1)* %33, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %32
   %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 12
   store i8 1, i8 addrspace(1)* %35
   %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
-  br i1 %NullCheck8, label %37, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
   %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
   %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck10 = icmp ne i64 addrspace(1)* %40, null
-  br i1 %NullCheck10, label %41, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64 addrspace(1)* %40, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i64, i64 addrspace(1)* %40
@@ -12525,8 +14234,8 @@ entry:
   %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
   store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
   %51 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %NullCheck12 = icmp ne %"System.Byte[]" addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Byte[]" addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %41
   %53 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %51, i32 0, i32 1
@@ -12538,16 +14247,16 @@ entry:
 
 ; <label>:58                                      ; preds = %52
   %59 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %59, null
-  br i1 %NullCheck14, label %60, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.IO.StreamWriter addrspace(1)* %59, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %60
 
 ; <label>:60                                      ; preds = %58
   %61 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %59, i32 0, i32 3
   %62 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
   %64 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %NullCheck16 = icmp ne %"System.Byte[]" addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %"System.Byte[]" addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %60
   %66 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %64, i32 0, i32 1
@@ -12555,8 +14264,8 @@ entry:
   %68 = zext i32 %67 to i64
   %69 = trunc i64 %68 to i32
   %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck18, label %71, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
   %72 = load i64, i64 addrspace(1)* %70
@@ -12572,29 +14281,29 @@ entry:
 
 ; <label>:80                                      ; preds = %27, %52, %71
   %81 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %81, null
-  br i1 %NullCheck20, label %82, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.IO.StreamWriter addrspace(1)* %81, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
 
 ; <label>:82                                      ; preds = %80
   %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %81, i32 0, i32 5
   %84 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %83, align 8
   %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.IO.StreamWriter addrspace(1)* %85, null
-  br i1 %NullCheck22, label %86, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.IO.StreamWriter addrspace(1)* %85, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %86
 
 ; <label>:86                                      ; preds = %82
   %87 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 7
   %88 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %87, align 8
   %89 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %89, null
-  br i1 %NullCheck24, label %90, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.StreamWriter addrspace(1)* %89, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %90
 
 ; <label>:90                                      ; preds = %86
   %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %89, i32 0, i32 9
   %92 = load i32, i32 addrspace(1)* %91, align 8
   %93 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.IO.StreamWriter addrspace(1)* %93, null
-  br i1 %NullCheck26, label %94, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.IO.StreamWriter addrspace(1)* %93, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %93, i32 0, i32 6
@@ -12602,8 +14311,8 @@ entry:
   %97 = load i8, i8* %arg2
   %98 = zext i8 %97 to i32
   %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
-  %NullCheck28 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck28, label %100, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
   %101 = load i64, i64 addrspace(1)* %99
@@ -12618,8 +14327,8 @@ entry:
   %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
   store i32 %110, i32* %loc1
   %111 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %111, null
-  br i1 %NullCheck30, label %112, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.IO.StreamWriter addrspace(1)* %111, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %112
 
 ; <label>:112                                     ; preds = %100
   %113 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %111, i32 0, i32 9
@@ -12630,23 +14339,23 @@ entry:
 
 ; <label>:116                                     ; preds = %112
   %117 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck32 = icmp ne %System.IO.StreamWriter addrspace(1)* %117, null
-  br i1 %NullCheck32, label %118, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.IO.StreamWriter addrspace(1)* %117, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %118
 
 ; <label>:118                                     ; preds = %116
   %119 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %117, i32 0, i32 3
   %120 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %119, align 8
   %121 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.IO.StreamWriter addrspace(1)* %121, null
-  br i1 %NullCheck34, label %122, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.IO.StreamWriter addrspace(1)* %121, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %122
 
 ; <label>:122                                     ; preds = %118
   %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
   %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
   %125 = load i32, i32* %loc1
   %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
-  %NullCheck36 = icmp ne i64 addrspace(1)* %126, null
-  br i1 %NullCheck36, label %127, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64 addrspace(1)* %126, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
   %128 = load i64, i64 addrspace(1)* %126
@@ -12668,15 +14377,15 @@ entry:
 
 ; <label>:140                                     ; preds = %136
   %141 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.IO.StreamWriter addrspace(1)* %141, null
-  br i1 %NullCheck38, label %142, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.IO.StreamWriter addrspace(1)* %141, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %142
 
 ; <label>:142                                     ; preds = %140
   %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
   %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
   %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
-  %NullCheck40 = icmp ne i64 addrspace(1)* %145, null
-  br i1 %NullCheck40, label %146, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i64 addrspace(1)* %145, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
   %147 = load i64, i64 addrspace(1)* %145
@@ -12697,83 +14406,83 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %25
+ThrowNullRef4:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %32
+ThrowNullRef6:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %37
+ThrowNullRef10:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %41
+ThrowNullRef12:                                   ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %58
+ThrowNullRef14:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %60
+ThrowNullRef16:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %65
+ThrowNullRef18:                                   ; preds = %65
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %80
+ThrowNullRef20:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %82
+ThrowNullRef22:                                   ; preds = %82
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %86
+ThrowNullRef24:                                   ; preds = %86
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %90
+ThrowNullRef26:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %94
+ThrowNullRef28:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %100
+ThrowNullRef30:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %116
+ThrowNullRef32:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %118
+ThrowNullRef34:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %122
+ThrowNullRef36:                                   ; preds = %122
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %140
+ThrowNullRef38:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %142
+ThrowNullRef40:                                   ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12840,8 +14549,8 @@ entry:
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %1 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
-  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
@@ -12849,8 +14558,8 @@ entry:
   %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
   %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
   %8 = load i64, i64 addrspace(1)* %6
@@ -12866,8 +14575,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %17, %System.IFormatProvider addrspace(1)* %16)
   %18 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %19 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %18, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.SyncTextWriter addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %7
   %21 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %18, i32 0, i32 4
@@ -12878,11 +14587,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12895,8 +14604,8 @@ entry:
   %this = alloca %System.IO.TextWriter addrspace(1)*
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.TextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
@@ -12906,8 +14615,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.Threading.Thread addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Threading.Thread addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %6)
@@ -12916,8 +14625,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1
   %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.TextWriter addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.TextWriter addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %11, i32 0, i32 2
@@ -12928,11 +14637,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13129,8 +14838,8 @@ entry:
   store i32 %param1, i32* %arg1
   store i8 0, i8* %loc1
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
@@ -13140,16 +14849,16 @@ entry:
   %5 = addrspacecast i8* %loc1 to i8 addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %4, i8 addrspace(1)* %5)
   %6 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.SyncTextWriter addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
   %10 = load i32, i32* %arg1
   %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
   %13 = load i64, i64 addrspace(1)* %11
@@ -13184,11 +14893,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13205,8 +14914,8 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load i32, i32* %arg1
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -13220,8 +14929,8 @@ entry:
   call void %11(%System.IO.TextWriter addrspace(1)* %0, i32 %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
   %15 = load i64, i64 addrspace(1)* %13
@@ -13239,7 +14948,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13257,8 +14966,8 @@ entry:
   %1 = addrspacecast i32* %arg1 to i32 addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -13273,8 +14982,8 @@ entry:
   %14 = bitcast i32 addrspace(1)* %1 to %System.Int32 addrspace(1)*
   %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Int32 addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Int32 addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
   %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
   %18 = load i64, i64 addrspace(1)* %16
@@ -13292,7 +15001,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13308,8 +15017,8 @@ entry:
   store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
   %0 = load %System.Int32 addrspace(1)*, %System.Int32 addrspace(1)** %this
   %1 = bitcast %System.Int32 addrspace(1)* %0 to i32 addrspace(1)*
-  %NullCheck = icmp ne i32 addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq i32 addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load i32, i32 addrspace(1)* %1, align 8
@@ -13334,8 +15043,8 @@ entry:
   %loc0 = alloca %System.Globalization.NumberFormatInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 3
@@ -13345,8 +15054,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
@@ -13356,24 +15065,24 @@ entry:
   store %System.Globalization.NumberFormatInfo addrspace(1)* %10, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
   %11 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %7
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
   %15 = load i8, i8 addrspace(1)* %14, align 8
   %16 = zext i8 %15 to i32
   %17 = trunc i32 %16 to i8
-  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %11, null
-  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %11, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %13
   %19 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %11, i32 0, i32 29
   store i8 %17, i8 addrspace(1)* %19
   %20 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %21 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %20, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %20, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %18
   %23 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %20, i32 0, i32 3
@@ -13382,8 +15091,8 @@ entry:
 
 ; <label>:24                                      ; preds = %1, %22
   %25 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %25, null
-  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %25, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %26
 
 ; <label>:26                                      ; preds = %24
   %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %25, i32 0, i32 3
@@ -13394,23 +15103,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %18
+ThrowNullRef8:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13435,168 +15144,168 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 18
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %8, align 8
-  %NullCheck2 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %5, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %5, i32 0, i32 4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %9)
   %12 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 19
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %15, align 8
-  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %12, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %12, i32 0, i32 5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %16)
   %19 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %20 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %20, null
-  br i1 %NullCheck8, label %21, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %20, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %20, i32 0, i32 23
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  %NullCheck10 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %19, null
-  br i1 %NullCheck10, label %24, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %19, i32 0, i32 7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %25, %System.String addrspace(1)* %23)
   %26 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %27 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %27, i32 0, i32 22
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %29, align 8
-  %NullCheck14 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %26, null
-  br i1 %NullCheck14, label %31, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %26, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %26, i32 0, i32 6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %32, %System.String addrspace(1)* %30)
   %33 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %34 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Globalization.CultureData addrspace(1)* %34, null
-  br i1 %NullCheck16, label %35, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Globalization.CultureData addrspace(1)* %34, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %34, i32 0, i32 51
   %37 = load i32, i32 addrspace(1)* %36, align 8
-  %NullCheck18 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %33, null
-  br i1 %NullCheck18, label %38, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %33, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %33, i32 0, i32 21
   store i32 %37, i32 addrspace(1)* %39
   %40 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %41 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Globalization.CultureData addrspace(1)* %41, null
-  br i1 %NullCheck20, label %42, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Globalization.CultureData addrspace(1)* %41, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %41, i32 0, i32 52
   %44 = load i32, i32 addrspace(1)* %43, align 8
-  %NullCheck22 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %40, null
-  br i1 %NullCheck22, label %45, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %40, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %40, i32 0, i32 25
   store i32 %44, i32 addrspace(1)* %46
   %47 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %48 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.Globalization.CultureData addrspace(1)* %48, null
-  br i1 %NullCheck24, label %49, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Globalization.CultureData addrspace(1)* %48, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %49
 
 ; <label>:49                                      ; preds = %45
   %50 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %48, i32 0, i32 29
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck26 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %47, null
-  br i1 %NullCheck26, label %52, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %47, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %47, i32 0, i32 10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %53, %System.String addrspace(1)* %51)
   %54 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %55 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Globalization.CultureData addrspace(1)* %55, null
-  br i1 %NullCheck28, label %56, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Globalization.CultureData addrspace(1)* %55, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %56
 
 ; <label>:56                                      ; preds = %52
   %57 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %55, i32 0, i32 35
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %57, align 8
-  %NullCheck30 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %54, null
-  br i1 %NullCheck30, label %59, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %54, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %54, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %60, %System.String addrspace(1)* %58)
   %61 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %62 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck32 = icmp ne %System.Globalization.CultureData addrspace(1)* %62, null
-  br i1 %NullCheck32, label %63, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Globalization.CultureData addrspace(1)* %62, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %62, i32 0, i32 34
   %65 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %64, align 8
-  %NullCheck34 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %61, null
-  br i1 %NullCheck34, label %66, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %61, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %61, i32 0, i32 9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %67, %System.String addrspace(1)* %65)
   %68 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %69 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck36 = icmp ne %System.Globalization.CultureData addrspace(1)* %69, null
-  br i1 %NullCheck36, label %70, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Globalization.CultureData addrspace(1)* %69, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %70
 
 ; <label>:70                                      ; preds = %66
   %71 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %69, i32 0, i32 55
   %72 = load i32, i32 addrspace(1)* %71, align 8
-  %NullCheck38 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %68, null
-  br i1 %NullCheck38, label %73, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %68, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %68, i32 0, i32 22
   store i32 %72, i32 addrspace(1)* %74
   %75 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %76 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck40 = icmp ne %System.Globalization.CultureData addrspace(1)* %76, null
-  br i1 %NullCheck40, label %77, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Globalization.CultureData addrspace(1)* %76, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %76, i32 0, i32 57
   %79 = load i32, i32 addrspace(1)* %78, align 8
-  %NullCheck42 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %75, null
-  br i1 %NullCheck42, label %80, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %75, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %80
 
 ; <label>:80                                      ; preds = %77
   %81 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %75, i32 0, i32 24
   store i32 %79, i32 addrspace(1)* %81
   %82 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %83 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck44 = icmp ne %System.Globalization.CultureData addrspace(1)* %83, null
-  br i1 %NullCheck44, label %84, label %ThrowNullRef43
+  %NullCheck43 = icmp eq %System.Globalization.CultureData addrspace(1)* %83, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %84
 
 ; <label>:84                                      ; preds = %80
   %85 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %83, i32 0, i32 56
   %86 = load i32, i32 addrspace(1)* %85, align 8
-  %NullCheck46 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %82, null
-  br i1 %NullCheck46, label %87, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %82, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %82, i32 0, i32 23
@@ -13605,8 +15314,8 @@ entry:
 
 ; <label>:89                                      ; preds = %entry
   %90 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck100 = icmp ne %System.Globalization.CultureData addrspace(1)* %90, null
-  br i1 %NullCheck100, label %91, label %ThrowNullRef99
+  %NullCheck99 = icmp eq %System.Globalization.CultureData addrspace(1)* %90, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %91
 
 ; <label>:91                                      ; preds = %89
   %92 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %90, i32 0, i32 2
@@ -13624,8 +15333,8 @@ entry:
   %102 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %103 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %104 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %103)
-  %NullCheck48 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %102, null
-  br i1 %NullCheck48, label %105, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %102, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %105
 
 ; <label>:105                                     ; preds = %101
   %106 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %102, i32 0, i32 1
@@ -13633,8 +15342,8 @@ entry:
   %107 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %108 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %109 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %108)
-  %NullCheck50 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %107, null
-  br i1 %NullCheck50, label %110, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %107, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %110
 
 ; <label>:110                                     ; preds = %105
   %111 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %107, i32 0, i32 2
@@ -13642,8 +15351,8 @@ entry:
   %112 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %113 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %114 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %113)
-  %NullCheck52 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %112, null
-  br i1 %NullCheck52, label %115, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %112, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %115
 
 ; <label>:115                                     ; preds = %110
   %116 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %112, i32 0, i32 27
@@ -13651,8 +15360,8 @@ entry:
   %117 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %118 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %119 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %118)
-  %NullCheck54 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %117, null
-  br i1 %NullCheck54, label %120, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %117, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %120
 
 ; <label>:120                                     ; preds = %115
   %121 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %117, i32 0, i32 26
@@ -13660,8 +15369,8 @@ entry:
   %122 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %123 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %124 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %123)
-  %NullCheck56 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %122, null
-  br i1 %NullCheck56, label %125, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %122, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %125
 
 ; <label>:125                                     ; preds = %120
   %126 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %122, i32 0, i32 17
@@ -13669,8 +15378,8 @@ entry:
   %127 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %128 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %129 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %128)
-  %NullCheck58 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %127, null
-  br i1 %NullCheck58, label %130, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %127, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %130
 
 ; <label>:130                                     ; preds = %125
   %131 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %127, i32 0, i32 18
@@ -13678,8 +15387,8 @@ entry:
   %132 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %133 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %134 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %133)
-  %NullCheck60 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %132, null
-  br i1 %NullCheck60, label %135, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %132, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %135
 
 ; <label>:135                                     ; preds = %130
   %136 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %132, i32 0, i32 14
@@ -13687,8 +15396,8 @@ entry:
   %137 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %138 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %139 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %138)
-  %NullCheck62 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %137, null
-  br i1 %NullCheck62, label %140, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %137, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %140
 
 ; <label>:140                                     ; preds = %135
   %141 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %137, i32 0, i32 13
@@ -13696,71 +15405,71 @@ entry:
   %142 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %143 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %144 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %143)
-  %NullCheck64 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %142, null
-  br i1 %NullCheck64, label %145, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %142, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %145
 
 ; <label>:145                                     ; preds = %140
   %146 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %142, i32 0, i32 12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %146, %System.String addrspace(1)* %144)
   %147 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %148 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck66 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %148, null
-  br i1 %NullCheck66, label %149, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %148, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %149
 
 ; <label>:149                                     ; preds = %145
   %150 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %148, i32 0, i32 21
   %151 = load i32, i32 addrspace(1)* %150, align 8
-  %NullCheck68 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %147, null
-  br i1 %NullCheck68, label %152, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %147, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %152
 
 ; <label>:152                                     ; preds = %149
   %153 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %147, i32 0, i32 28
   store i32 %151, i32 addrspace(1)* %153
   %154 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %155 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck70 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %155, null
-  br i1 %NullCheck70, label %156, label %ThrowNullRef69
+  %NullCheck69 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %155, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %156
 
 ; <label>:156                                     ; preds = %152
   %157 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %155, i32 0, i32 6
   %158 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %157, align 8
-  %NullCheck72 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %154, null
-  br i1 %NullCheck72, label %159, label %ThrowNullRef71
+  %NullCheck71 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %154, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %159
 
 ; <label>:159                                     ; preds = %156
   %160 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %154, i32 0, i32 15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %160, %System.String addrspace(1)* %158)
   %161 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %162 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck74 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %162, null
-  br i1 %NullCheck74, label %163, label %ThrowNullRef73
+  %NullCheck73 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %162, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %163
 
 ; <label>:163                                     ; preds = %159
   %164 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %162, i32 0, i32 1
   %165 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %164, align 8
-  %NullCheck76 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %161, null
-  br i1 %NullCheck76, label %166, label %ThrowNullRef75
+  %NullCheck75 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %161, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %166
 
 ; <label>:166                                     ; preds = %163
   %167 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %161, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %167, %"System.Int32[]" addrspace(1)* %165)
   %168 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %169 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck78 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %169, null
-  br i1 %NullCheck78, label %170, label %ThrowNullRef77
+  %NullCheck77 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %169, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %170
 
 ; <label>:170                                     ; preds = %166
   %171 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %169, i32 0, i32 7
   %172 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %171, align 8
-  %NullCheck80 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %168, null
-  br i1 %NullCheck80, label %173, label %ThrowNullRef79
+  %NullCheck79 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %168, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %173
 
 ; <label>:173                                     ; preds = %170
   %174 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %168, i32 0, i32 16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %174, %System.String addrspace(1)* %172)
   %175 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck82 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %175, null
-  br i1 %NullCheck82, label %176, label %ThrowNullRef81
+  %NullCheck81 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %175, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %176
 
 ; <label>:176                                     ; preds = %173
   %177 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %175, i32 0, i32 4
@@ -13770,14 +15479,14 @@ entry:
 
 ; <label>:180                                     ; preds = %176
   %181 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck84 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %181, null
-  br i1 %NullCheck84, label %182, label %ThrowNullRef83
+  %NullCheck83 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %181, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %182
 
 ; <label>:182                                     ; preds = %180
   %183 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %181, i32 0, i32 4
   %184 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %183, align 8
-  %NullCheck86 = icmp ne %System.String addrspace(1)* %184, null
-  br i1 %NullCheck86, label %185, label %ThrowNullRef85
+  %NullCheck85 = icmp eq %System.String addrspace(1)* %184, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %185
 
 ; <label>:185                                     ; preds = %182
   %186 = getelementptr inbounds %System.String, %System.String addrspace(1)* %184, i32 0, i32 1
@@ -13788,8 +15497,8 @@ entry:
 ; <label>:189                                     ; preds = %176, %185
   %190 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck98 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %190, null
-  br i1 %NullCheck98, label %192, label %ThrowNullRef97
+  %NullCheck97 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %190, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %192
 
 ; <label>:192                                     ; preds = %189
   %193 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %190, i32 0, i32 4
@@ -13798,8 +15507,8 @@ entry:
 
 ; <label>:194                                     ; preds = %185, %192
   %195 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck88 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %195, null
-  br i1 %NullCheck88, label %196, label %ThrowNullRef87
+  %NullCheck87 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %195, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %196
 
 ; <label>:196                                     ; preds = %194
   %197 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %195, i32 0, i32 9
@@ -13809,14 +15518,14 @@ entry:
 
 ; <label>:200                                     ; preds = %196
   %201 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck90 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %201, null
-  br i1 %NullCheck90, label %202, label %ThrowNullRef89
+  %NullCheck89 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %201, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %202
 
 ; <label>:202                                     ; preds = %200
   %203 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %201, i32 0, i32 9
   %204 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %203, align 8
-  %NullCheck92 = icmp ne %System.String addrspace(1)* %204, null
-  br i1 %NullCheck92, label %205, label %ThrowNullRef91
+  %NullCheck91 = icmp eq %System.String addrspace(1)* %204, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %205
 
 ; <label>:205                                     ; preds = %202
   %206 = getelementptr inbounds %System.String, %System.String addrspace(1)* %204, i32 0, i32 1
@@ -13827,14 +15536,14 @@ entry:
 ; <label>:209                                     ; preds = %196, %205
   %210 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %211 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck94 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %211, null
-  br i1 %NullCheck94, label %212, label %ThrowNullRef93
+  %NullCheck93 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %211, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %212
 
 ; <label>:212                                     ; preds = %209
   %213 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %211, i32 0, i32 6
   %214 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %213, align 8
-  %NullCheck96 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %210, null
-  br i1 %NullCheck96, label %215, label %ThrowNullRef95
+  %NullCheck95 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %210, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %215
 
 ; <label>:215                                     ; preds = %212
   %216 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %210, i32 0, i32 9
@@ -13848,203 +15557,203 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %17
+ThrowNullRef8:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %21
+ThrowNullRef10:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %24
+ThrowNullRef12:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %28
+ThrowNullRef14:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %31
+ThrowNullRef16:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %35
+ThrowNullRef18:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %38
+ThrowNullRef20:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %42
+ThrowNullRef22:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %45
+ThrowNullRef24:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %49
+ThrowNullRef26:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %52
+ThrowNullRef28:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %56
+ThrowNullRef30:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %59
+ThrowNullRef32:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %63
+ThrowNullRef34:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %66
+ThrowNullRef36:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %70
+ThrowNullRef38:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %73
+ThrowNullRef40:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %77
+ThrowNullRef42:                                   ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %80
+ThrowNullRef44:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %84
+ThrowNullRef46:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %101
+ThrowNullRef48:                                   ; preds = %101
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %105
+ThrowNullRef50:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %110
+ThrowNullRef52:                                   ; preds = %110
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %115
+ThrowNullRef54:                                   ; preds = %115
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %120
+ThrowNullRef56:                                   ; preds = %120
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %125
+ThrowNullRef58:                                   ; preds = %125
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %130
+ThrowNullRef60:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %135
+ThrowNullRef62:                                   ; preds = %135
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %140
+ThrowNullRef64:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %145
+ThrowNullRef66:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %149
+ThrowNullRef68:                                   ; preds = %149
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %152
+ThrowNullRef70:                                   ; preds = %152
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %156
+ThrowNullRef72:                                   ; preds = %156
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %159
+ThrowNullRef74:                                   ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %163
+ThrowNullRef76:                                   ; preds = %163
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %166
+ThrowNullRef78:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %170
+ThrowNullRef80:                                   ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %173
+ThrowNullRef82:                                   ; preds = %173
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %180
+ThrowNullRef84:                                   ; preds = %180
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %182
+ThrowNullRef86:                                   ; preds = %182
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %194
+ThrowNullRef88:                                   ; preds = %194
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %200
+ThrowNullRef90:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %202
+ThrowNullRef92:                                   ; preds = %202
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %209
+ThrowNullRef94:                                   ; preds = %209
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %212
+ThrowNullRef96:                                   ; preds = %212
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %189
+ThrowNullRef98:                                   ; preds = %189
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %89
+ThrowNullRef100:                                  ; preds = %89
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14072,8 +15781,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 21
@@ -14086,8 +15795,8 @@ entry:
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 16)
   %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 21
@@ -14096,8 +15805,8 @@ entry:
 
 ; <label>:12                                      ; preds = %1, %10
   %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 21
@@ -14108,11 +15817,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %12
+ThrowNullRef4:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14128,8 +15837,8 @@ entry:
   store i32 %param1, i32* %arg1
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %1 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
@@ -14196,8 +15905,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 33
@@ -14210,8 +15919,8 @@ entry:
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 24)
   %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 33
@@ -14220,8 +15929,8 @@ entry:
 
 ; <label>:12                                      ; preds = %1, %10
   %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 33
@@ -14232,11 +15941,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %12
+ThrowNullRef4:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14249,8 +15958,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 53
@@ -14262,8 +15971,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 116)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 53
@@ -14272,8 +15981,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 53
@@ -14284,11 +15993,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14317,8 +16026,8 @@ entry:
 
 ; <label>:7                                       ; preds = %entry, %4
   %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %7
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 2
@@ -14342,8 +16051,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 54
@@ -14355,8 +16064,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 117)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
@@ -14365,8 +16074,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 54
@@ -14377,11 +16086,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14394,8 +16103,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 27
@@ -14407,8 +16116,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 118)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 27
@@ -14417,8 +16126,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 27
@@ -14429,11 +16138,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14446,8 +16155,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 28
@@ -14459,8 +16168,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 119)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 28
@@ -14469,8 +16178,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 28
@@ -14481,11 +16190,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14498,8 +16207,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 26
@@ -14511,8 +16220,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 107)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 26
@@ -14521,8 +16230,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 26
@@ -14533,11 +16242,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14550,8 +16259,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 25
@@ -14563,8 +16272,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 106)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 25
@@ -14573,8 +16282,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 25
@@ -14585,11 +16294,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14602,8 +16311,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 24
@@ -14615,8 +16324,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 105)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 24
@@ -14625,8 +16334,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 24
@@ -14637,11 +16346,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14666,8 +16375,8 @@ entry:
   %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %3)
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %2
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -14678,15 +16387,15 @@ entry:
 
 ; <label>:8                                       ; preds = %62
   %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 9
   %12 = load i32, i32 addrspace(1)* %11, align 8
   %13 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.IO.StreamWriter addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %13, i32 0, i32 10
@@ -14701,15 +16410,15 @@ entry:
 
 ; <label>:20                                      ; preds = %14, %18
   %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
   %24 = load i32, i32 addrspace(1)* %23, align 8
   %25 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %25, null
-  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.StreamWriter addrspace(1)* %25, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %25, i32 0, i32 9
@@ -14730,36 +16439,36 @@ entry:
   %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %37 = load i32, i32* %loc1
   %38 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.StreamWriter addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %35
   %40 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %38, i32 0, i32 7
   %41 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %40, align 8
   %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
-  br i1 %NullCheck14, label %43, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %39
   %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 9
   %45 = load i32, i32 addrspace(1)* %44, align 8
   %46 = load i32, i32* %loc2
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %36, null
-  br i1 %NullCheck16, label %47, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %36, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %47
 
 ; <label>:47                                      ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %36, i32 %37, %"System.Char[]" addrspace(1)* %41, i32 %45, i32 %46)
   %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
   %51 = load i32, i32 addrspace(1)* %50, align 8
   %52 = load i32, i32* %loc2
   %53 = add i32 %51, %52
-  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
-  br i1 %NullCheck20, label %54, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %54
 
 ; <label>:54                                      ; preds = %49
   %55 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
@@ -14781,8 +16490,8 @@ entry:
 
 ; <label>:65                                      ; preds = %62
   %66 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %66, null
-  br i1 %NullCheck2, label %67, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %66, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %67
 
 ; <label>:67                                      ; preds = %65
   %68 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %66, i32 0, i32 11
@@ -14803,49 +16512,259 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %65
+ThrowNullRef2:                                    ; preds = %65
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %20
+ThrowNullRef8:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %22
+ThrowNullRef10:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %35
+ThrowNullRef12:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %43
+ThrowNullRef16:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %47
+ThrowNullRef18:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method String::CopyTo using LLILCJit
-Failed to read String.CopyTo[loadElemA]
+Successfully read String.CopyTo
+
+define void @String.CopyTo(%System.String addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  %loc1 = alloca i16 addrspace(1)*
+  %loc2 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %1 = icmp ne %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg4
+  %7 = icmp sge i32 %6, 0
+  br i1 %7, label %13, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  unreachable
+
+; <label>:13                                      ; preds = %5
+  %14 = load i32, i32* %arg1
+  %15 = icmp sge i32 %14, 0
+  br i1 %15, label %21, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %18)
+  %20 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %20, %System.String addrspace(1)* %17, %System.String addrspace(1)* %19)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %20) #0
+  unreachable
+
+; <label>:21                                      ; preds = %13
+  %22 = load i32, i32* %arg4
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck, label %ThrowNullRef, label %24
+
+; <label>:24                                      ; preds = %21
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load i32, i32* %arg1
+  %28 = sub i32 %26, %27
+  %29 = icmp sle i32 %22, %28
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34, %System.String addrspace(1)* %31, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %24
+  %36 = load i32, i32* %arg3
+  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %37, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
+
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
+  %40 = load i32, i32 addrspace(1)* %39
+  %41 = zext i32 %40 to i64
+  %42 = trunc i64 %41 to i32
+  %43 = load i32, i32* %arg4
+  %44 = sub i32 %42, %43
+  %45 = icmp sgt i32 %36, %44
+  br i1 %45, label %49, label %46
+
+; <label>:46                                      ; preds = %38
+  %47 = load i32, i32* %arg3
+  %48 = icmp sge i32 %47, 0
+  br i1 %48, label %54, label %49
+
+; <label>:49                                      ; preds = %38, %46
+  %50 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %52 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %51)
+  %53 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53, %System.String addrspace(1)* %50, %System.String addrspace(1)* %52)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53) #0
+  unreachable
+
+; <label>:54                                      ; preds = %46
+  %55 = load i32, i32* %arg4
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %97, label %57
+
+; <label>:57                                      ; preds = %54
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %59
+
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 2
+  %61 = bitcast [0 x i16] addrspace(1)* %60 to i16 addrspace(1)*
+  store i16 addrspace(1)* %61, i16 addrspace(1)** %loc0
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  store %"System.Char[]" addrspace(1)* %62, %"System.Char[]" addrspace(1)** %loc2
+  %63 = icmp eq %"System.Char[]" addrspace(1)* %62, null
+  br i1 %63, label %72, label %64
+
+; <label>:64                                      ; preds = %59
+  %65 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc2
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %65, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %66
+
+; <label>:66                                      ; preds = %64
+  %67 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %65, i32 0, i32 1
+  %68 = load i32, i32 addrspace(1)* %67
+  %69 = zext i32 %68 to i64
+  %70 = trunc i64 %69 to i32
+  %71 = icmp ne i32 %70, 0
+  br i1 %71, label %73, label %72
+
+; <label>:72                                      ; preds = %59, %66
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  br label %81
+
+; <label>:73                                      ; preds = %66
+  %74 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc2
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %74, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %75
+
+; <label>:75                                      ; preds = %73
+  %76 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %74, i32 0, i32 1
+  %77 = load i32, i32 addrspace(1)* %76
+  %78 = zext i32 %77 to i64
+  %BoundsCheck = icmp uge i64 0, %78
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %79
+
+; <label>:79                                      ; preds = %75
+  %80 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %74, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %80, i16 addrspace(1)** %loc1
+  br label %81
+
+; <label>:81                                      ; preds = %72, %79
+  %82 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %83 = ptrtoint i16 addrspace(1)* %82 to i64
+  %84 = load i32, i32* %arg3
+  %85 = sext i32 %84 to i64
+  %86 = mul i64 %85, 2
+  %87 = add i64 %83, %86
+  %88 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %89 = ptrtoint i16 addrspace(1)* %88 to i64
+  %90 = load i32, i32* %arg1
+  %91 = sext i32 %90 to i64
+  %92 = mul i64 %91, 2
+  %93 = add i64 %89, %92
+  %94 = load i32, i32* %arg4
+  %95 = inttoptr i64 %87 to i16*
+  %96 = inttoptr i64 %93 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %95, i16* %96, i32 %94)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  br label %97
+
+; <label>:97                                      ; preds = %54, %81
+  ret void
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
 Successfully read ConsoleEncoding.GetPreamble
 
@@ -14882,7 +16801,365 @@ entry:
 }
 
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[loadElemA]
+Successfully read EncoderNLS.GetBytes
+
+define i32 @EncoderNLS.GetBytes(%System.Text.EncoderNLS addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3, %"System.Byte[]" addrspace(1)* %param4, i32 %param5, i8 %param6) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %arg4 = alloca %"System.Byte[]" addrspace(1)*
+  %arg5 = alloca i32
+  %arg6 = alloca i8
+  %loc0 = alloca i32
+  %loc1 = alloca i16 addrspace(1)*
+  %loc2 = alloca i8 addrspace(1)*
+  %loc3 = alloca i32
+  %loc4 = alloca %"System.Char[]" addrspace(1)*
+  %loc5 = alloca %"System.Byte[]" addrspace(1)*
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  store %"System.Byte[]" addrspace(1)* %param4, %"System.Byte[]" addrspace(1)** %arg4
+  store i32 %param5, i32* %arg5
+  store i8 %param6, i8* %arg6
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %1 = icmp eq %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %17, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %7 = icmp eq %"System.Char[]" addrspace(1)* %6, null
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %12
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %12
+
+; <label>:12                                      ; preds = %8, %10
+  %13 = phi %System.String addrspace(1)* [ %9, %8 ], [ %11, %10 ]
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %14)
+  %16 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16, %System.String addrspace(1)* %13, %System.String addrspace(1)* %15)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16) #0
+  unreachable
+
+; <label>:17                                      ; preds = %2
+  %18 = load i32, i32* %arg2
+  %19 = icmp slt i32 %18, 0
+  br i1 %19, label %23, label %20
+
+; <label>:20                                      ; preds = %17
+  %21 = load i32, i32* %arg3
+  %22 = icmp sge i32 %21, 0
+  br i1 %22, label %35, label %23
+
+; <label>:23                                      ; preds = %17, %20
+  %24 = load i32, i32* %arg2
+  %25 = icmp slt i32 %24, 0
+  br i1 %25, label %28, label %26
+
+; <label>:26                                      ; preds = %23
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %30
+
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %30
+
+; <label>:30                                      ; preds = %26, %28
+  %31 = phi %System.String addrspace(1)* [ %27, %26 ], [ %29, %28 ]
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34, %System.String addrspace(1)* %31, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %20
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck, label %ThrowNullRef, label %37
+
+; <label>:37                                      ; preds = %35
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = load i32, i32* %arg2
+  %43 = sub i32 %41, %42
+  %44 = load i32, i32* %arg3
+  %45 = icmp sge i32 %43, %44
+  br i1 %45, label %51, label %46
+
+; <label>:46                                      ; preds = %37
+  %47 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %48 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %49 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %48)
+  %50 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %50, %System.String addrspace(1)* %47, %System.String addrspace(1)* %49)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %50) #0
+  unreachable
+
+; <label>:51                                      ; preds = %37
+  %52 = load i32, i32* %arg5
+  %53 = icmp slt i32 %52, 0
+  br i1 %53, label %63, label %54
+
+; <label>:54                                      ; preds = %51
+  %55 = load i32, i32* %arg5
+  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck1 = icmp eq %"System.Byte[]" addrspace(1)* %56, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %57
+
+; <label>:57                                      ; preds = %54
+  %58 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = zext i32 %59 to i64
+  %61 = trunc i64 %60 to i32
+  %62 = icmp sle i32 %55, %61
+  br i1 %62, label %68, label %63
+
+; <label>:63                                      ; preds = %51, %57
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %66 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %65)
+  %67 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %67, %System.String addrspace(1)* %64, %System.String addrspace(1)* %66)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %67) #0
+  unreachable
+
+; <label>:68                                      ; preds = %57
+  %69 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %69, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %69, i32 0, i32 1
+  %72 = load i32, i32 addrspace(1)* %71
+  %73 = zext i32 %72 to i64
+  %74 = trunc i64 %73 to i32
+  %75 = icmp ne i32 %74, 0
+  br i1 %75, label %78, label %76
+
+; <label>:76                                      ; preds = %70
+  %77 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1)
+  store %"System.Char[]" addrspace(1)* %77, %"System.Char[]" addrspace(1)** %arg1
+  br label %78
+
+; <label>:78                                      ; preds = %70, %76
+  %79 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck5 = icmp eq %"System.Byte[]" addrspace(1)* %79, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %80
+
+; <label>:80                                      ; preds = %78
+  %81 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %79, i32 0, i32 1
+  %82 = load i32, i32 addrspace(1)* %81
+  %83 = zext i32 %82 to i64
+  %84 = trunc i64 %83 to i32
+  %85 = load i32, i32* %arg5
+  %86 = sub i32 %84, %85
+  store i32 %86, i32* %loc0
+  %87 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck7 = icmp eq %"System.Byte[]" addrspace(1)* %87, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %88
+
+; <label>:88                                      ; preds = %80
+  %89 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %87, i32 0, i32 1
+  %90 = load i32, i32 addrspace(1)* %89
+  %91 = zext i32 %90 to i64
+  %92 = trunc i64 %91 to i32
+  %93 = icmp ne i32 %92, 0
+  br i1 %93, label %96, label %94
+
+; <label>:94                                      ; preds = %88
+  %95 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1)
+  store %"System.Byte[]" addrspace(1)* %95, %"System.Byte[]" addrspace(1)** %arg4
+  br label %96
+
+; <label>:96                                      ; preds = %88, %94
+  %97 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  store %"System.Char[]" addrspace(1)* %97, %"System.Char[]" addrspace(1)** %loc4
+  %98 = icmp eq %"System.Char[]" addrspace(1)* %97, null
+  br i1 %98, label %107, label %99
+
+; <label>:99                                      ; preds = %96
+  %100 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc4
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %100, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %101
+
+; <label>:101                                     ; preds = %99
+  %102 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %100, i32 0, i32 1
+  %103 = load i32, i32 addrspace(1)* %102
+  %104 = zext i32 %103 to i64
+  %105 = trunc i64 %104 to i32
+  %106 = icmp ne i32 %105, 0
+  br i1 %106, label %108, label %107
+
+; <label>:107                                     ; preds = %96, %101
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  br label %116
+
+; <label>:108                                     ; preds = %101
+  %109 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc4
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %109, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %110
+
+; <label>:110                                     ; preds = %108
+  %111 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %109, i32 0, i32 1
+  %112 = load i32, i32 addrspace(1)* %111
+  %113 = zext i32 %112 to i64
+  %BoundsCheck = icmp uge i64 0, %113
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %114
+
+; <label>:114                                     ; preds = %110
+  %115 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %109, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %115, i16 addrspace(1)** %loc1
+  br label %116
+
+; <label>:116                                     ; preds = %107, %114
+  %117 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  store %"System.Byte[]" addrspace(1)* %117, %"System.Byte[]" addrspace(1)** %loc5
+  %118 = icmp eq %"System.Byte[]" addrspace(1)* %117, null
+  br i1 %118, label %127, label %119
+
+; <label>:119                                     ; preds = %116
+  %120 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc5
+  %NullCheck13 = icmp eq %"System.Byte[]" addrspace(1)* %120, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %121
+
+; <label>:121                                     ; preds = %119
+  %122 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %120, i32 0, i32 1
+  %123 = load i32, i32 addrspace(1)* %122
+  %124 = zext i32 %123 to i64
+  %125 = trunc i64 %124 to i32
+  %126 = icmp ne i32 %125, 0
+  br i1 %126, label %128, label %127
+
+; <label>:127                                     ; preds = %116, %121
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc2
+  br label %136
+
+; <label>:128                                     ; preds = %121
+  %129 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc5
+  %NullCheck15 = icmp eq %"System.Byte[]" addrspace(1)* %129, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %130
+
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %129, i32 0, i32 1
+  %132 = load i32, i32 addrspace(1)* %131
+  %133 = zext i32 %132 to i64
+  %BoundsCheck17 = icmp uge i64 0, %133
+  br i1 %BoundsCheck17, label %ThrowIndexOutOfRange18, label %134
+
+; <label>:134                                     ; preds = %130
+  %135 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %129, i32 0, i32 3, i32 0
+  store i8 addrspace(1)* %135, i8 addrspace(1)** %loc2
+  br label %136
+
+; <label>:136                                     ; preds = %127, %134
+  %137 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %138 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %139 = ptrtoint i16 addrspace(1)* %138 to i64
+  %140 = load i32, i32* %arg2
+  %141 = sext i32 %140 to i64
+  %142 = mul i64 %141, 2
+  %143 = add i64 %139, %142
+  %144 = load i32, i32* %arg3
+  %145 = load i8 addrspace(1)*, i8 addrspace(1)** %loc2
+  %146 = ptrtoint i8 addrspace(1)* %145 to i64
+  %147 = load i32, i32* %arg5
+  %148 = sext i32 %147 to i64
+  %149 = add i64 %146, %148
+  %150 = load i32, i32* %loc0
+  %151 = load i8, i8* %arg6
+  %152 = zext i8 %151 to i32
+  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i64 addrspace(1)*
+  %NullCheck19 = icmp eq i64 addrspace(1)* %153, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %154
+
+; <label>:154                                     ; preds = %136
+  %155 = load i64, i64 addrspace(1)* %153
+  %156 = add i64 %155, 72
+  %157 = inttoptr i64 %156 to i64*
+  %158 = load i64, i64* %157
+  %159 = add i64 %158, 0
+  %160 = inttoptr i64 %159 to i64*
+  %161 = load i64, i64* %160
+  %162 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to %System.Text.Encoder addrspace(1)*
+  %163 = inttoptr i64 %143 to i16*
+  %164 = inttoptr i64 %149 to i8*
+  %165 = trunc i32 %152 to i8
+  %166 = inttoptr i64 %161 to i32 (%System.Text.Encoder addrspace(1)*, i16*, i32, i8*, i32, i8)*
+  %167 = call i32 %166(%System.Text.Encoder addrspace(1)* %162, i16* %163, i32 %144, i8* %164, i32 %150, i8 %165)
+  store i32 %167, i32* %loc3
+  br label %168
+
+; <label>:168                                     ; preds = %154
+  %169 = load i32, i32* %loc3
+  ret i32 %169
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %110
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %119
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange18:                           ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
 Successfully read EncoderNLS.GetBytes
 
@@ -14971,22 +17248,22 @@ entry:
   %40 = load i8, i8* %arg5
   %41 = zext i8 %40 to i32
   %42 = trunc i32 %41 to i8
-  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %39, null
-  br i1 %NullCheck, label %43, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderNLS addrspace(1)* %39, null
+  br i1 %NullCheck, label %ThrowNullRef, label %43
 
 ; <label>:43                                      ; preds = %38
   %44 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
   store i8 %42, i8 addrspace(1)* %44
   %45 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %45, null
-  br i1 %NullCheck2, label %46, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.EncoderNLS addrspace(1)* %45, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %46
 
 ; <label>:46                                      ; preds = %43
   %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %45, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %47
   %48 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.EncoderNLS addrspace(1)* %48, null
-  br i1 %NullCheck4, label %49, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.EncoderNLS addrspace(1)* %48, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %49
 
 ; <label>:49                                      ; preds = %46
   %50 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %48, i32 0, i32 3
@@ -14997,8 +17274,8 @@ entry:
   %55 = load i32, i32* %arg4
   %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck6, label %58, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
   %59 = load i64, i64 addrspace(1)* %57
@@ -15016,15 +17293,15 @@ ThrowNullRef:                                     ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %43
+ThrowNullRef2:                                    ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %46
+ThrowNullRef4:                                    ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %49
+ThrowNullRef6:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -15052,8 +17329,8 @@ entry:
   %4 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0 to %System.IO.ConsoleStream addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*)(%System.IO.ConsoleStream addrspace(1)* %4, %"System.Byte[]" addrspace(1)* %1, i32 %2, i32 %3)
   %5 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
@@ -15138,8 +17415,8 @@ entry:
 
 ; <label>:22                                      ; preds = %8
   %23 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %23, null
-  br i1 %NullCheck, label %24, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Byte[]" addrspace(1)* %23, null
+  br i1 %NullCheck, label %ThrowNullRef, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
@@ -15161,8 +17438,8 @@ entry:
 
 ; <label>:36                                      ; preds = %24
   %37 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %37, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.ConsoleStream addrspace(1)* %37, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %37, i32 0, i32 4
@@ -15183,13 +17460,138 @@ ThrowNullRef:                                     ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %36
+ThrowNullRef2:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
-Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
+Successfully read WindowsConsoleStream.WriteFileNative
+
+define i32 @WindowsConsoleStream.WriteFileNative(i64 %param0, %"System.Byte[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i64
+  %arg1 = alloca %"System.Byte[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i8 addrspace(1)*
+  %loc2 = alloca %"System.Byte[]" addrspace(1)*
+  %loc3 = alloca i32
+  store i64 %param0, i64* %arg0
+  store %"System.Byte[]" addrspace(1)* %param1, %"System.Byte[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Byte[]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = zext i32 %3 to i64
+  %5 = icmp ne i64 %4, 0
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %1
+  ret i32 0
+
+; <label>:7                                       ; preds = %1
+  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  store %"System.Byte[]" addrspace(1)* %8, %"System.Byte[]" addrspace(1)** %loc2
+  %9 = icmp eq %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %9, label %18, label %10
+
+; <label>:10                                      ; preds = %7
+  %11 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc2
+  %NullCheck1 = icmp eq %"System.Byte[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %11, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp ne i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %7, %12
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc1
+  br label %27
+
+; <label>:19                                      ; preds = %12
+  %20 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc2
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %20, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %BoundsCheck = icmp uge i64 0, %24
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %25
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %20, i32 0, i32 3, i32 0
+  store i8 addrspace(1)* %26, i8 addrspace(1)** %loc1
+  br label %27
+
+; <label>:27                                      ; preds = %18, %25
+  %28 = load i64, i64* %arg0
+  %29 = load i8 addrspace(1)*, i8 addrspace(1)** %loc1
+  %30 = ptrtoint i8 addrspace(1)* %29 to i64
+  %31 = load i32, i32* %arg2
+  %32 = sext i32 %31 to i64
+  %33 = add i64 %30, %32
+  %34 = load i32, i32* %arg3
+  %35 = addrspacecast i32* %loc3 to i32 addrspace(1)*
+  %36 = inttoptr i64 %33 to i8*
+  %37 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i8*, i32, i32 addrspace(1)*, i64)*)(i64 %28, i8* %36, i32 %34, i32 addrspace(1)* %35, i64 0)
+  %38 = icmp ugt i32 %37, 0
+  %39 = sext i1 %38 to i32
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc1
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %42, label %41
+
+; <label>:41                                      ; preds = %27
+  ret i32 0
+
+; <label>:42                                      ; preds = %27
+  %43 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  store i32 %43, i32* %loc0
+  %44 = load i32, i32* %loc0
+  %45 = icmp eq i32 %44, 232
+  br i1 %45, label %49, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = load i32, i32* %loc0
+  %48 = icmp ne i32 %47, 109
+  br i1 %48, label %50, label %49
+
+; <label>:49                                      ; preds = %42, %46
+  ret i32 0
+
+; <label>:50                                      ; preds = %46
+  %51 = load i32, i32* %loc0
+  ret i32 %51
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
 Successfully read WindowsConsoleStream.Flush
 
@@ -15198,8 +17600,8 @@ entry:
   %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
   store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
@@ -15234,8 +17636,8 @@ entry:
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
   %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load i64, i64 addrspace(1)* %1
@@ -15274,15 +17676,15 @@ entry:
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.TextWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
   %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %3, align 8
   %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
   %7 = load i64, i64 addrspace(1)* %5
@@ -15300,7 +17702,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -15329,8 +17731,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %4)
   store i32 0, i32* %loc0
   %5 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Char[]" addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
@@ -15342,15 +17744,15 @@ entry:
 
 ; <label>:11                                      ; preds = %69
   %12 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %12, i32 0, i32 9
   %15 = load i32, i32 addrspace(1)* %14, align 8
   %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.IO.StreamWriter addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %16, i32 0, i32 10
@@ -15365,15 +17767,15 @@ entry:
 
 ; <label>:23                                      ; preds = %17, %21
   %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %24, null
-  br i1 %NullCheck8, label %25, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %24, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 10
   %27 = load i32, i32 addrspace(1)* %26, align 8
   %28 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %28, null
-  br i1 %NullCheck10, label %29, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.StreamWriter addrspace(1)* %28, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %28, i32 0, i32 9
@@ -15395,15 +17797,15 @@ entry:
   %40 = load i32, i32* %loc0
   %41 = mul i32 %40, 2
   %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
-  br i1 %NullCheck12, label %43, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %43
 
 ; <label>:43                                      ; preds = %38
   %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 7
   %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %44, align 8
   %46 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %46, null
-  br i1 %NullCheck14, label %47, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.IO.StreamWriter addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %47
 
 ; <label>:47                                      ; preds = %43
   %48 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %46, i32 0, i32 9
@@ -15415,16 +17817,16 @@ entry:
   %54 = bitcast %"System.Char[]" addrspace(1)* %45 to %System.Array addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %53, i32 %41, %System.Array addrspace(1)* %54, i32 %50, i32 %52)
   %55 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
-  br i1 %NullCheck16, label %56, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %56
 
 ; <label>:56                                      ; preds = %47
   %57 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
   %58 = load i32, i32 addrspace(1)* %57, align 8
   %59 = load i32, i32* %loc2
   %60 = add i32 %58, %59
-  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
-  br i1 %NullCheck18, label %61, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %61
 
 ; <label>:61                                      ; preds = %56
   %62 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
@@ -15446,8 +17848,8 @@ entry:
 
 ; <label>:72                                      ; preds = %69
   %73 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %73, null
-  br i1 %NullCheck2, label %74, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %73, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %74
 
 ; <label>:74                                      ; preds = %72
   %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %73, i32 0, i32 11
@@ -15468,39 +17870,39 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %72
+ThrowNullRef2:                                    ; preds = %72
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %23
+ThrowNullRef8:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef10:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %43
+ThrowNullRef14:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %47
+ThrowNullRef16:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %56
+ThrowNullRef18:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPConvF2Lng.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPConvF2Lng.error.txt
@@ -25,8 +25,8 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
@@ -40,8 +40,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
   %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
@@ -75,7 +75,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -90,8 +90,8 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %NullCheck = icmp ne i8 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = load i8, i8 addrspace(1)* %0, align 8
@@ -125,8 +125,8 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
@@ -159,8 +159,8 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -184,8 +184,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
   store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
@@ -195,8 +195,8 @@ entry:
 ; <label>:4                                       ; preds = %1
   %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
   %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
@@ -206,8 +206,8 @@ entry:
   %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
@@ -221,14 +221,14 @@ entry:
 
 ; <label>:17                                      ; preds = %14
   %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
   %21 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
@@ -238,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -249,8 +249,8 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
@@ -261,27 +261,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %30
+ThrowNullRef10:                                   ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -301,7 +301,89 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
-Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
+Successfully read AppDomainSetup.GetUnsecureApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.GetUnsecureApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %NullCheck = icmp eq %"System.String[]" addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %BoundsCheck = icmp uge i64 0, %5
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %6
+
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 3, i32 0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
+  ret %System.String addrspace(1)* %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_Value using LLILCJit
+Successfully read AppDomainSetup.get_Value
+
+define %"System.String[]" addrspace(1)* @AppDomainSetup.get_Value(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.String[]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 18)
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.String[]" addrspace(1)* addrspace(1)*, %"System.String[]" addrspace(1)*)*)(%"System.String[]" addrspace(1)* addrspace(1)* %9, %"System.String[]" addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %11, i32 0, i32 1
+  %14 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %13, align 8
+  ret %"System.String[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -319,8 +401,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -368,16 +450,16 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
   %5 = load i32, i32 addrspace(1)* %4
   %6 = sub i32 %5, 1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -389,7 +471,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -421,8 +503,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
@@ -456,8 +538,8 @@ entry:
 ; <label>:27                                      ; preds = %19
   %28 = load i32, i32* %arg1
   %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
-  br i1 %NullCheck2, label %30, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %29, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %30
 
 ; <label>:30                                      ; preds = %27
   %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
@@ -493,8 +575,8 @@ entry:
 ; <label>:49                                      ; preds = %46
   %50 = load i32, i32* %arg2
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck4, label %52, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
@@ -517,11 +599,11 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %27
+ThrowNullRef2:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %49
+ThrowNullRef4:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -544,16 +626,16 @@ entry:
   %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %0)
   store %System.String addrspace(1)* %1, %System.String addrspace(1)** %loc0
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 2
   %5 = bitcast [0 x i16] addrspace(1)* %4 to i16 addrspace(1)*
   store i16 addrspace(1)* %5, i16 addrspace(1)** %loc1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %3
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2
@@ -580,7 +662,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -691,15 +773,15 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %NullCheck132 = icmp ne i8* %21, null
-  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+  %NullCheck131 = icmp eq i8* %21, null
+  br i1 %NullCheck131, label %ThrowNullRef132, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = load i8, i8* %21, align 8
   %24 = zext i8 %23 to i32
   %25 = trunc i32 %24 to i8
-  %NullCheck134 = icmp ne i8* %20, null
-  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+  %NullCheck133 = icmp eq i8* %20, null
+  br i1 %NullCheck133, label %ThrowNullRef134, label %26
 
 ; <label>:26                                      ; preds = %22
   store i8 %25, i8* %20, align 8
@@ -709,16 +791,16 @@ entry:
   %28 = load i8*, i8** %arg0
   %29 = load i8*, i8** %arg1
   %30 = bitcast i8* %29 to i16*
-  %NullCheck128 = icmp ne i16* %30, null
-  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+  %NullCheck127 = icmp eq i16* %30, null
+  br i1 %NullCheck127, label %ThrowNullRef128, label %31
 
 ; <label>:31                                      ; preds = %27
   %32 = load i16, i16* %30, align 8
   %33 = sext i16 %32 to i32
   %34 = bitcast i8* %28 to i16*
   %35 = trunc i32 %33 to i16
-  %NullCheck130 = icmp ne i16* %34, null
-  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+  %NullCheck129 = icmp eq i16* %34, null
+  br i1 %NullCheck129, label %ThrowNullRef130, label %36
 
 ; <label>:36                                      ; preds = %31
   store i16 %35, i16* %34, align 8
@@ -728,16 +810,16 @@ entry:
   %38 = load i8*, i8** %arg0
   %39 = load i8*, i8** %arg1
   %40 = bitcast i8* %39 to i16*
-  %NullCheck120 = icmp ne i16* %40, null
-  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+  %NullCheck119 = icmp eq i16* %40, null
+  br i1 %NullCheck119, label %ThrowNullRef120, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i16, i16* %40, align 8
   %43 = sext i16 %42 to i32
   %44 = bitcast i8* %38 to i16*
   %45 = trunc i32 %43 to i16
-  %NullCheck122 = icmp ne i16* %44, null
-  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+  %NullCheck121 = icmp eq i16* %44, null
+  br i1 %NullCheck121, label %ThrowNullRef122, label %46
 
 ; <label>:46                                      ; preds = %41
   store i16 %45, i16* %44, align 8
@@ -745,15 +827,15 @@ entry:
   %48 = getelementptr inbounds i8, i8* %47, i64 2
   %49 = load i8*, i8** %arg1
   %50 = getelementptr inbounds i8, i8* %49, i64 2
-  %NullCheck124 = icmp ne i8* %50, null
-  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+  %NullCheck123 = icmp eq i8* %50, null
+  br i1 %NullCheck123, label %ThrowNullRef124, label %51
 
 ; <label>:51                                      ; preds = %46
   %52 = load i8, i8* %50, align 8
   %53 = zext i8 %52 to i32
   %54 = trunc i32 %53 to i8
-  %NullCheck126 = icmp ne i8* %48, null
-  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+  %NullCheck125 = icmp eq i8* %48, null
+  br i1 %NullCheck125, label %ThrowNullRef126, label %55
 
 ; <label>:55                                      ; preds = %51
   store i8 %54, i8* %48, align 8
@@ -763,14 +845,14 @@ entry:
   %57 = load i8*, i8** %arg0
   %58 = load i8*, i8** %arg1
   %59 = bitcast i8* %58 to i32*
-  %NullCheck116 = icmp ne i32* %59, null
-  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+  %NullCheck115 = icmp eq i32* %59, null
+  br i1 %NullCheck115, label %ThrowNullRef116, label %60
 
 ; <label>:60                                      ; preds = %56
   %61 = load i32, i32* %59, align 8
   %62 = bitcast i8* %57 to i32*
-  %NullCheck118 = icmp ne i32* %62, null
-  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+  %NullCheck117 = icmp eq i32* %62, null
+  br i1 %NullCheck117, label %ThrowNullRef118, label %63
 
 ; <label>:63                                      ; preds = %60
   store i32 %61, i32* %62, align 8
@@ -780,14 +862,14 @@ entry:
   %65 = load i8*, i8** %arg0
   %66 = load i8*, i8** %arg1
   %67 = bitcast i8* %66 to i32*
-  %NullCheck108 = icmp ne i32* %67, null
-  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+  %NullCheck107 = icmp eq i32* %67, null
+  br i1 %NullCheck107, label %ThrowNullRef108, label %68
 
 ; <label>:68                                      ; preds = %64
   %69 = load i32, i32* %67, align 8
   %70 = bitcast i8* %65 to i32*
-  %NullCheck110 = icmp ne i32* %70, null
-  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+  %NullCheck109 = icmp eq i32* %70, null
+  br i1 %NullCheck109, label %ThrowNullRef110, label %71
 
 ; <label>:71                                      ; preds = %68
   store i32 %69, i32* %70, align 8
@@ -795,15 +877,15 @@ entry:
   %73 = getelementptr inbounds i8, i8* %72, i64 4
   %74 = load i8*, i8** %arg1
   %75 = getelementptr inbounds i8, i8* %74, i64 4
-  %NullCheck112 = icmp ne i8* %75, null
-  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+  %NullCheck111 = icmp eq i8* %75, null
+  br i1 %NullCheck111, label %ThrowNullRef112, label %76
 
 ; <label>:76                                      ; preds = %71
   %77 = load i8, i8* %75, align 8
   %78 = zext i8 %77 to i32
   %79 = trunc i32 %78 to i8
-  %NullCheck114 = icmp ne i8* %73, null
-  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+  %NullCheck113 = icmp eq i8* %73, null
+  br i1 %NullCheck113, label %ThrowNullRef114, label %80
 
 ; <label>:80                                      ; preds = %76
   store i8 %79, i8* %73, align 8
@@ -813,14 +895,14 @@ entry:
   %82 = load i8*, i8** %arg0
   %83 = load i8*, i8** %arg1
   %84 = bitcast i8* %83 to i32*
-  %NullCheck100 = icmp ne i32* %84, null
-  br i1 %NullCheck100, label %85, label %ThrowNullRef99
+  %NullCheck99 = icmp eq i32* %84, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %85
 
 ; <label>:85                                      ; preds = %81
   %86 = load i32, i32* %84, align 8
   %87 = bitcast i8* %82 to i32*
-  %NullCheck102 = icmp ne i32* %87, null
-  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+  %NullCheck101 = icmp eq i32* %87, null
+  br i1 %NullCheck101, label %ThrowNullRef102, label %88
 
 ; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
@@ -829,16 +911,16 @@ entry:
   %91 = load i8*, i8** %arg1
   %92 = getelementptr inbounds i8, i8* %91, i64 4
   %93 = bitcast i8* %92 to i16*
-  %NullCheck104 = icmp ne i16* %93, null
-  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+  %NullCheck103 = icmp eq i16* %93, null
+  br i1 %NullCheck103, label %ThrowNullRef104, label %94
 
 ; <label>:94                                      ; preds = %88
   %95 = load i16, i16* %93, align 8
   %96 = sext i16 %95 to i32
   %97 = bitcast i8* %90 to i16*
   %98 = trunc i32 %96 to i16
-  %NullCheck106 = icmp ne i16* %97, null
-  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+  %NullCheck105 = icmp eq i16* %97, null
+  br i1 %NullCheck105, label %ThrowNullRef106, label %99
 
 ; <label>:99                                      ; preds = %94
   store i16 %98, i16* %97, align 8
@@ -848,14 +930,14 @@ entry:
   %101 = load i8*, i8** %arg0
   %102 = load i8*, i8** %arg1
   %103 = bitcast i8* %102 to i32*
-  %NullCheck88 = icmp ne i32* %103, null
-  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+  %NullCheck87 = icmp eq i32* %103, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %104
 
 ; <label>:104                                     ; preds = %100
   %105 = load i32, i32* %103, align 8
   %106 = bitcast i8* %101 to i32*
-  %NullCheck90 = icmp ne i32* %106, null
-  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+  %NullCheck89 = icmp eq i32* %106, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %107
 
 ; <label>:107                                     ; preds = %104
   store i32 %105, i32* %106, align 8
@@ -864,16 +946,16 @@ entry:
   %110 = load i8*, i8** %arg1
   %111 = getelementptr inbounds i8, i8* %110, i64 4
   %112 = bitcast i8* %111 to i16*
-  %NullCheck92 = icmp ne i16* %112, null
-  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+  %NullCheck91 = icmp eq i16* %112, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %113
 
 ; <label>:113                                     ; preds = %107
   %114 = load i16, i16* %112, align 8
   %115 = sext i16 %114 to i32
   %116 = bitcast i8* %109 to i16*
   %117 = trunc i32 %115 to i16
-  %NullCheck94 = icmp ne i16* %116, null
-  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+  %NullCheck93 = icmp eq i16* %116, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %118
 
 ; <label>:118                                     ; preds = %113
   store i16 %117, i16* %116, align 8
@@ -881,15 +963,15 @@ entry:
   %120 = getelementptr inbounds i8, i8* %119, i64 6
   %121 = load i8*, i8** %arg1
   %122 = getelementptr inbounds i8, i8* %121, i64 6
-  %NullCheck96 = icmp ne i8* %122, null
-  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+  %NullCheck95 = icmp eq i8* %122, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %123
 
 ; <label>:123                                     ; preds = %118
   %124 = load i8, i8* %122, align 8
   %125 = zext i8 %124 to i32
   %126 = trunc i32 %125 to i8
-  %NullCheck98 = icmp ne i8* %120, null
-  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+  %NullCheck97 = icmp eq i8* %120, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %127
 
 ; <label>:127                                     ; preds = %123
   store i8 %126, i8* %120, align 8
@@ -899,14 +981,14 @@ entry:
   %129 = load i8*, i8** %arg0
   %130 = load i8*, i8** %arg1
   %131 = bitcast i8* %130 to i64*
-  %NullCheck84 = icmp ne i64* %131, null
-  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+  %NullCheck83 = icmp eq i64* %131, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %132
 
 ; <label>:132                                     ; preds = %128
   %133 = load i64, i64* %131, align 8
   %134 = bitcast i8* %129 to i64*
-  %NullCheck86 = icmp ne i64* %134, null
-  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+  %NullCheck85 = icmp eq i64* %134, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %135
 
 ; <label>:135                                     ; preds = %132
   store i64 %133, i64* %134, align 8
@@ -916,14 +998,14 @@ entry:
   %137 = load i8*, i8** %arg0
   %138 = load i8*, i8** %arg1
   %139 = bitcast i8* %138 to i64*
-  %NullCheck76 = icmp ne i64* %139, null
-  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+  %NullCheck75 = icmp eq i64* %139, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %140
 
 ; <label>:140                                     ; preds = %136
   %141 = load i64, i64* %139, align 8
   %142 = bitcast i8* %137 to i64*
-  %NullCheck78 = icmp ne i64* %142, null
-  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+  %NullCheck77 = icmp eq i64* %142, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %143
 
 ; <label>:143                                     ; preds = %140
   store i64 %141, i64* %142, align 8
@@ -931,15 +1013,15 @@ entry:
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %NullCheck80 = icmp ne i8* %147, null
-  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+  %NullCheck79 = icmp eq i8* %147, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %148
 
 ; <label>:148                                     ; preds = %143
   %149 = load i8, i8* %147, align 8
   %150 = zext i8 %149 to i32
   %151 = trunc i32 %150 to i8
-  %NullCheck82 = icmp ne i8* %145, null
-  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+  %NullCheck81 = icmp eq i8* %145, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %152
 
 ; <label>:152                                     ; preds = %148
   store i8 %151, i8* %145, align 8
@@ -949,14 +1031,14 @@ entry:
   %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
   %156 = bitcast i8* %155 to i64*
-  %NullCheck68 = icmp ne i64* %156, null
-  br i1 %NullCheck68, label %157, label %ThrowNullRef67
+  %NullCheck67 = icmp eq i64* %156, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %157
 
 ; <label>:157                                     ; preds = %153
   %158 = load i64, i64* %156, align 8
   %159 = bitcast i8* %154 to i64*
-  %NullCheck70 = icmp ne i64* %159, null
-  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+  %NullCheck69 = icmp eq i64* %159, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %160
 
 ; <label>:160                                     ; preds = %157
   store i64 %158, i64* %159, align 8
@@ -965,16 +1047,16 @@ entry:
   %163 = load i8*, i8** %arg1
   %164 = getelementptr inbounds i8, i8* %163, i64 8
   %165 = bitcast i8* %164 to i16*
-  %NullCheck72 = icmp ne i16* %165, null
-  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+  %NullCheck71 = icmp eq i16* %165, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %166
 
 ; <label>:166                                     ; preds = %160
   %167 = load i16, i16* %165, align 8
   %168 = sext i16 %167 to i32
   %169 = bitcast i8* %162 to i16*
   %170 = trunc i32 %168 to i16
-  %NullCheck74 = icmp ne i16* %169, null
-  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+  %NullCheck73 = icmp eq i16* %169, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %171
 
 ; <label>:171                                     ; preds = %166
   store i16 %170, i16* %169, align 8
@@ -984,14 +1066,14 @@ entry:
   %173 = load i8*, i8** %arg0
   %174 = load i8*, i8** %arg1
   %175 = bitcast i8* %174 to i64*
-  %NullCheck56 = icmp ne i64* %175, null
-  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+  %NullCheck55 = icmp eq i64* %175, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %176
 
 ; <label>:176                                     ; preds = %172
   %177 = load i64, i64* %175, align 8
   %178 = bitcast i8* %173 to i64*
-  %NullCheck58 = icmp ne i64* %178, null
-  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+  %NullCheck57 = icmp eq i64* %178, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %179
 
 ; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
@@ -1000,16 +1082,16 @@ entry:
   %182 = load i8*, i8** %arg1
   %183 = getelementptr inbounds i8, i8* %182, i64 8
   %184 = bitcast i8* %183 to i16*
-  %NullCheck60 = icmp ne i16* %184, null
-  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+  %NullCheck59 = icmp eq i16* %184, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %185
 
 ; <label>:185                                     ; preds = %179
   %186 = load i16, i16* %184, align 8
   %187 = sext i16 %186 to i32
   %188 = bitcast i8* %181 to i16*
   %189 = trunc i32 %187 to i16
-  %NullCheck62 = icmp ne i16* %188, null
-  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+  %NullCheck61 = icmp eq i16* %188, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %190
 
 ; <label>:190                                     ; preds = %185
   store i16 %189, i16* %188, align 8
@@ -1017,15 +1099,15 @@ entry:
   %192 = getelementptr inbounds i8, i8* %191, i64 10
   %193 = load i8*, i8** %arg1
   %194 = getelementptr inbounds i8, i8* %193, i64 10
-  %NullCheck64 = icmp ne i8* %194, null
-  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+  %NullCheck63 = icmp eq i8* %194, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %195
 
 ; <label>:195                                     ; preds = %190
   %196 = load i8, i8* %194, align 8
   %197 = zext i8 %196 to i32
   %198 = trunc i32 %197 to i8
-  %NullCheck66 = icmp ne i8* %192, null
-  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+  %NullCheck65 = icmp eq i8* %192, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %199
 
 ; <label>:199                                     ; preds = %195
   store i8 %198, i8* %192, align 8
@@ -1035,14 +1117,14 @@ entry:
   %201 = load i8*, i8** %arg0
   %202 = load i8*, i8** %arg1
   %203 = bitcast i8* %202 to i64*
-  %NullCheck48 = icmp ne i64* %203, null
-  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+  %NullCheck47 = icmp eq i64* %203, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %204
 
 ; <label>:204                                     ; preds = %200
   %205 = load i64, i64* %203, align 8
   %206 = bitcast i8* %201 to i64*
-  %NullCheck50 = icmp ne i64* %206, null
-  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+  %NullCheck49 = icmp eq i64* %206, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %207
 
 ; <label>:207                                     ; preds = %204
   store i64 %205, i64* %206, align 8
@@ -1051,14 +1133,14 @@ entry:
   %210 = load i8*, i8** %arg1
   %211 = getelementptr inbounds i8, i8* %210, i64 8
   %212 = bitcast i8* %211 to i32*
-  %NullCheck52 = icmp ne i32* %212, null
-  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+  %NullCheck51 = icmp eq i32* %212, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %213
 
 ; <label>:213                                     ; preds = %207
   %214 = load i32, i32* %212, align 8
   %215 = bitcast i8* %209 to i32*
-  %NullCheck54 = icmp ne i32* %215, null
-  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+  %NullCheck53 = icmp eq i32* %215, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %216
 
 ; <label>:216                                     ; preds = %213
   store i32 %214, i32* %215, align 8
@@ -1068,14 +1150,14 @@ entry:
   %218 = load i8*, i8** %arg0
   %219 = load i8*, i8** %arg1
   %220 = bitcast i8* %219 to i64*
-  %NullCheck36 = icmp ne i64* %220, null
-  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64* %220, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %221
 
 ; <label>:221                                     ; preds = %217
   %222 = load i64, i64* %220, align 8
   %223 = bitcast i8* %218 to i64*
-  %NullCheck38 = icmp ne i64* %223, null
-  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+  %NullCheck37 = icmp eq i64* %223, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %224
 
 ; <label>:224                                     ; preds = %221
   store i64 %222, i64* %223, align 8
@@ -1084,14 +1166,14 @@ entry:
   %227 = load i8*, i8** %arg1
   %228 = getelementptr inbounds i8, i8* %227, i64 8
   %229 = bitcast i8* %228 to i32*
-  %NullCheck40 = icmp ne i32* %229, null
-  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i32* %229, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %230
 
 ; <label>:230                                     ; preds = %224
   %231 = load i32, i32* %229, align 8
   %232 = bitcast i8* %226 to i32*
-  %NullCheck42 = icmp ne i32* %232, null
-  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+  %NullCheck41 = icmp eq i32* %232, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %233
 
 ; <label>:233                                     ; preds = %230
   store i32 %231, i32* %232, align 8
@@ -1099,15 +1181,15 @@ entry:
   %235 = getelementptr inbounds i8, i8* %234, i64 12
   %236 = load i8*, i8** %arg1
   %237 = getelementptr inbounds i8, i8* %236, i64 12
-  %NullCheck44 = icmp ne i8* %237, null
-  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i8* %237, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %238
 
 ; <label>:238                                     ; preds = %233
   %239 = load i8, i8* %237, align 8
   %240 = zext i8 %239 to i32
   %241 = trunc i32 %240 to i8
-  %NullCheck46 = icmp ne i8* %235, null
-  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+  %NullCheck45 = icmp eq i8* %235, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %242
 
 ; <label>:242                                     ; preds = %238
   store i8 %241, i8* %235, align 8
@@ -1117,14 +1199,14 @@ entry:
   %244 = load i8*, i8** %arg0
   %245 = load i8*, i8** %arg1
   %246 = bitcast i8* %245 to i64*
-  %NullCheck24 = icmp ne i64* %246, null
-  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64* %246, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %247
 
 ; <label>:247                                     ; preds = %243
   %248 = load i64, i64* %246, align 8
   %249 = bitcast i8* %244 to i64*
-  %NullCheck26 = icmp ne i64* %249, null
-  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64* %249, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %250
 
 ; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
@@ -1133,14 +1215,14 @@ entry:
   %253 = load i8*, i8** %arg1
   %254 = getelementptr inbounds i8, i8* %253, i64 8
   %255 = bitcast i8* %254 to i32*
-  %NullCheck28 = icmp ne i32* %255, null
-  br i1 %NullCheck28, label %256, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i32* %255, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %256
 
 ; <label>:256                                     ; preds = %250
   %257 = load i32, i32* %255, align 8
   %258 = bitcast i8* %252 to i32*
-  %NullCheck30 = icmp ne i32* %258, null
-  br i1 %NullCheck30, label %259, label %ThrowNullRef29
+  %NullCheck29 = icmp eq i32* %258, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %259
 
 ; <label>:259                                     ; preds = %256
   store i32 %257, i32* %258, align 8
@@ -1149,16 +1231,16 @@ entry:
   %262 = load i8*, i8** %arg1
   %263 = getelementptr inbounds i8, i8* %262, i64 12
   %264 = bitcast i8* %263 to i16*
-  %NullCheck32 = icmp ne i16* %264, null
-  br i1 %NullCheck32, label %265, label %ThrowNullRef31
+  %NullCheck31 = icmp eq i16* %264, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %265
 
 ; <label>:265                                     ; preds = %259
   %266 = load i16, i16* %264, align 8
   %267 = sext i16 %266 to i32
   %268 = bitcast i8* %261 to i16*
   %269 = trunc i32 %267 to i16
-  %NullCheck34 = icmp ne i16* %268, null
-  br i1 %NullCheck34, label %270, label %ThrowNullRef33
+  %NullCheck33 = icmp eq i16* %268, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %270
 
 ; <label>:270                                     ; preds = %265
   store i16 %269, i16* %268, align 8
@@ -1168,14 +1250,14 @@ entry:
   %272 = load i8*, i8** %arg0
   %273 = load i8*, i8** %arg1
   %274 = bitcast i8* %273 to i64*
-  %NullCheck8 = icmp ne i64* %274, null
-  br i1 %NullCheck8, label %275, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64* %274, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %275
 
 ; <label>:275                                     ; preds = %271
   %276 = load i64, i64* %274, align 8
   %277 = bitcast i8* %272 to i64*
-  %NullCheck10 = icmp ne i64* %277, null
-  br i1 %NullCheck10, label %278, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %277, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %278
 
 ; <label>:278                                     ; preds = %275
   store i64 %276, i64* %277, align 8
@@ -1184,14 +1266,14 @@ entry:
   %281 = load i8*, i8** %arg1
   %282 = getelementptr inbounds i8, i8* %281, i64 8
   %283 = bitcast i8* %282 to i32*
-  %NullCheck12 = icmp ne i32* %283, null
-  br i1 %NullCheck12, label %284, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i32* %283, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %284
 
 ; <label>:284                                     ; preds = %278
   %285 = load i32, i32* %283, align 8
   %286 = bitcast i8* %280 to i32*
-  %NullCheck14 = icmp ne i32* %286, null
-  br i1 %NullCheck14, label %287, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i32* %286, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %287
 
 ; <label>:287                                     ; preds = %284
   store i32 %285, i32* %286, align 8
@@ -1200,16 +1282,16 @@ entry:
   %290 = load i8*, i8** %arg1
   %291 = getelementptr inbounds i8, i8* %290, i64 12
   %292 = bitcast i8* %291 to i16*
-  %NullCheck16 = icmp ne i16* %292, null
-  br i1 %NullCheck16, label %293, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i16* %292, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %293
 
 ; <label>:293                                     ; preds = %287
   %294 = load i16, i16* %292, align 8
   %295 = sext i16 %294 to i32
   %296 = bitcast i8* %289 to i16*
   %297 = trunc i32 %295 to i16
-  %NullCheck18 = icmp ne i16* %296, null
-  br i1 %NullCheck18, label %298, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i16* %296, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %298
 
 ; <label>:298                                     ; preds = %293
   store i16 %297, i16* %296, align 8
@@ -1217,15 +1299,15 @@ entry:
   %300 = getelementptr inbounds i8, i8* %299, i64 14
   %301 = load i8*, i8** %arg1
   %302 = getelementptr inbounds i8, i8* %301, i64 14
-  %NullCheck20 = icmp ne i8* %302, null
-  br i1 %NullCheck20, label %303, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i8* %302, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %303
 
 ; <label>:303                                     ; preds = %298
   %304 = load i8, i8* %302, align 8
   %305 = zext i8 %304 to i32
   %306 = trunc i32 %305 to i8
-  %NullCheck22 = icmp ne i8* %300, null
-  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i8* %300, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %307
 
 ; <label>:307                                     ; preds = %303
   store i8 %306, i8* %300, align 8
@@ -1235,14 +1317,14 @@ entry:
   %309 = load i8*, i8** %arg0
   %310 = load i8*, i8** %arg1
   %311 = bitcast i8* %310 to i64*
-  %NullCheck = icmp ne i64* %311, null
-  br i1 %NullCheck, label %312, label %ThrowNullRef
+  %NullCheck = icmp eq i64* %311, null
+  br i1 %NullCheck, label %ThrowNullRef, label %312
 
 ; <label>:312                                     ; preds = %308
   %313 = load i64, i64* %311, align 8
   %314 = bitcast i8* %309 to i64*
-  %NullCheck2 = icmp ne i64* %314, null
-  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64* %314, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %315
 
 ; <label>:315                                     ; preds = %312
   store i64 %313, i64* %314, align 8
@@ -1251,14 +1333,14 @@ entry:
   %318 = load i8*, i8** %arg1
   %319 = getelementptr inbounds i8, i8* %318, i64 8
   %320 = bitcast i8* %319 to i64*
-  %NullCheck4 = icmp ne i64* %320, null
-  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64* %320, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %321
 
 ; <label>:321                                     ; preds = %315
   %322 = load i64, i64* %320, align 8
   %323 = bitcast i8* %317 to i64*
-  %NullCheck6 = icmp ne i64* %323, null
-  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64* %323, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %324
 
 ; <label>:324                                     ; preds = %321
   store i64 %322, i64* %323, align 8
@@ -1286,15 +1368,15 @@ entry:
 ; <label>:338                                     ; preds = %333
   %339 = load i8*, i8** %arg0
   %340 = load i8*, i8** %arg1
-  %NullCheck136 = icmp ne i8* %340, null
-  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+  %NullCheck135 = icmp eq i8* %340, null
+  br i1 %NullCheck135, label %ThrowNullRef136, label %341
 
 ; <label>:341                                     ; preds = %338
   %342 = load i8, i8* %340, align 8
   %343 = zext i8 %342 to i32
   %344 = trunc i32 %343 to i8
-  %NullCheck138 = icmp ne i8* %339, null
-  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+  %NullCheck137 = icmp eq i8* %339, null
+  br i1 %NullCheck137, label %ThrowNullRef138, label %345
 
 ; <label>:345                                     ; preds = %341
   store i8 %344, i8* %339, align 8
@@ -1317,16 +1399,16 @@ entry:
   %357 = load i8*, i8** %arg0
   %358 = load i8*, i8** %arg1
   %359 = bitcast i8* %358 to i16*
-  %NullCheck140 = icmp ne i16* %359, null
-  br i1 %NullCheck140, label %360, label %ThrowNullRef139
+  %NullCheck139 = icmp eq i16* %359, null
+  br i1 %NullCheck139, label %ThrowNullRef140, label %360
 
 ; <label>:360                                     ; preds = %356
   %361 = load i16, i16* %359, align 8
   %362 = sext i16 %361 to i32
   %363 = bitcast i8* %357 to i16*
   %364 = trunc i32 %362 to i16
-  %NullCheck142 = icmp ne i16* %363, null
-  br i1 %NullCheck142, label %365, label %ThrowNullRef141
+  %NullCheck141 = icmp eq i16* %363, null
+  br i1 %NullCheck141, label %ThrowNullRef142, label %365
 
 ; <label>:365                                     ; preds = %360
   store i16 %364, i16* %363, align 8
@@ -1352,14 +1434,14 @@ entry:
   %378 = load i8*, i8** %arg0
   %379 = load i8*, i8** %arg1
   %380 = bitcast i8* %379 to i32*
-  %NullCheck144 = icmp ne i32* %380, null
-  br i1 %NullCheck144, label %381, label %ThrowNullRef143
+  %NullCheck143 = icmp eq i32* %380, null
+  br i1 %NullCheck143, label %ThrowNullRef144, label %381
 
 ; <label>:381                                     ; preds = %377
   %382 = load i32, i32* %380, align 8
   %383 = bitcast i8* %378 to i32*
-  %NullCheck146 = icmp ne i32* %383, null
-  br i1 %NullCheck146, label %384, label %ThrowNullRef145
+  %NullCheck145 = icmp eq i32* %383, null
+  br i1 %NullCheck145, label %ThrowNullRef146, label %384
 
 ; <label>:384                                     ; preds = %381
   store i32 %382, i32* %383, align 8
@@ -1384,14 +1466,14 @@ entry:
   %395 = load i8*, i8** %arg0
   %396 = load i8*, i8** %arg1
   %397 = bitcast i8* %396 to i64*
-  %NullCheck164 = icmp ne i64* %397, null
-  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+  %NullCheck163 = icmp eq i64* %397, null
+  br i1 %NullCheck163, label %ThrowNullRef164, label %398
 
 ; <label>:398                                     ; preds = %394
   %399 = load i64, i64* %397, align 8
   %400 = bitcast i8* %395 to i64*
-  %NullCheck166 = icmp ne i64* %400, null
-  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+  %NullCheck165 = icmp eq i64* %400, null
+  br i1 %NullCheck165, label %ThrowNullRef166, label %401
 
 ; <label>:401                                     ; preds = %398
   store i64 %399, i64* %400, align 8
@@ -1400,14 +1482,14 @@ entry:
   %404 = load i8*, i8** %arg1
   %405 = getelementptr inbounds i8, i8* %404, i64 8
   %406 = bitcast i8* %405 to i64*
-  %NullCheck168 = icmp ne i64* %406, null
-  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+  %NullCheck167 = icmp eq i64* %406, null
+  br i1 %NullCheck167, label %ThrowNullRef168, label %407
 
 ; <label>:407                                     ; preds = %401
   %408 = load i64, i64* %406, align 8
   %409 = bitcast i8* %403 to i64*
-  %NullCheck170 = icmp ne i64* %409, null
-  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+  %NullCheck169 = icmp eq i64* %409, null
+  br i1 %NullCheck169, label %ThrowNullRef170, label %410
 
 ; <label>:410                                     ; preds = %407
   store i64 %408, i64* %409, align 8
@@ -1437,14 +1519,14 @@ entry:
   %425 = load i8*, i8** %arg0
   %426 = load i8*, i8** %arg1
   %427 = bitcast i8* %426 to i64*
-  %NullCheck148 = icmp ne i64* %427, null
-  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+  %NullCheck147 = icmp eq i64* %427, null
+  br i1 %NullCheck147, label %ThrowNullRef148, label %428
 
 ; <label>:428                                     ; preds = %424
   %429 = load i64, i64* %427, align 8
   %430 = bitcast i8* %425 to i64*
-  %NullCheck150 = icmp ne i64* %430, null
-  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+  %NullCheck149 = icmp eq i64* %430, null
+  br i1 %NullCheck149, label %ThrowNullRef150, label %431
 
 ; <label>:431                                     ; preds = %428
   store i64 %429, i64* %430, align 8
@@ -1466,14 +1548,14 @@ entry:
   %441 = load i8*, i8** %arg0
   %442 = load i8*, i8** %arg1
   %443 = bitcast i8* %442 to i32*
-  %NullCheck152 = icmp ne i32* %443, null
-  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+  %NullCheck151 = icmp eq i32* %443, null
+  br i1 %NullCheck151, label %ThrowNullRef152, label %444
 
 ; <label>:444                                     ; preds = %440
   %445 = load i32, i32* %443, align 8
   %446 = bitcast i8* %441 to i32*
-  %NullCheck154 = icmp ne i32* %446, null
-  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+  %NullCheck153 = icmp eq i32* %446, null
+  br i1 %NullCheck153, label %ThrowNullRef154, label %447
 
 ; <label>:447                                     ; preds = %444
   store i32 %445, i32* %446, align 8
@@ -1495,16 +1577,16 @@ entry:
   %457 = load i8*, i8** %arg0
   %458 = load i8*, i8** %arg1
   %459 = bitcast i8* %458 to i16*
-  %NullCheck156 = icmp ne i16* %459, null
-  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+  %NullCheck155 = icmp eq i16* %459, null
+  br i1 %NullCheck155, label %ThrowNullRef156, label %460
 
 ; <label>:460                                     ; preds = %456
   %461 = load i16, i16* %459, align 8
   %462 = sext i16 %461 to i32
   %463 = bitcast i8* %457 to i16*
   %464 = trunc i32 %462 to i16
-  %NullCheck158 = icmp ne i16* %463, null
-  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+  %NullCheck157 = icmp eq i16* %463, null
+  br i1 %NullCheck157, label %ThrowNullRef158, label %465
 
 ; <label>:465                                     ; preds = %460
   store i16 %464, i16* %463, align 8
@@ -1525,15 +1607,15 @@ entry:
 ; <label>:474                                     ; preds = %470
   %475 = load i8*, i8** %arg0
   %476 = load i8*, i8** %arg1
-  %NullCheck160 = icmp ne i8* %476, null
-  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+  %NullCheck159 = icmp eq i8* %476, null
+  br i1 %NullCheck159, label %ThrowNullRef160, label %477
 
 ; <label>:477                                     ; preds = %474
   %478 = load i8, i8* %476, align 8
   %479 = zext i8 %478 to i32
   %480 = trunc i32 %479 to i8
-  %NullCheck162 = icmp ne i8* %475, null
-  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+  %NullCheck161 = icmp eq i8* %475, null
+  br i1 %NullCheck161, label %ThrowNullRef162, label %481
 
 ; <label>:481                                     ; preds = %477
   store i8 %480, i8* %475, align 8
@@ -1553,343 +1635,343 @@ ThrowNullRef:                                     ; preds = %308
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %312
+ThrowNullRef2:                                    ; preds = %312
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %315
+ThrowNullRef4:                                    ; preds = %315
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %321
+ThrowNullRef6:                                    ; preds = %321
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %271
+ThrowNullRef8:                                    ; preds = %271
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %275
+ThrowNullRef10:                                   ; preds = %275
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %278
+ThrowNullRef12:                                   ; preds = %278
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %284
+ThrowNullRef14:                                   ; preds = %284
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %287
+ThrowNullRef16:                                   ; preds = %287
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %293
+ThrowNullRef18:                                   ; preds = %293
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %298
+ThrowNullRef20:                                   ; preds = %298
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %303
+ThrowNullRef22:                                   ; preds = %303
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %243
+ThrowNullRef24:                                   ; preds = %243
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %247
+ThrowNullRef26:                                   ; preds = %247
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %250
+ThrowNullRef28:                                   ; preds = %250
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %256
+ThrowNullRef30:                                   ; preds = %256
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %259
+ThrowNullRef32:                                   ; preds = %259
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %265
+ThrowNullRef34:                                   ; preds = %265
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %217
+ThrowNullRef36:                                   ; preds = %217
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %221
+ThrowNullRef38:                                   ; preds = %221
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %224
+ThrowNullRef40:                                   ; preds = %224
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %230
+ThrowNullRef42:                                   ; preds = %230
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %233
+ThrowNullRef44:                                   ; preds = %233
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %238
+ThrowNullRef46:                                   ; preds = %238
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %200
+ThrowNullRef48:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %204
+ThrowNullRef50:                                   ; preds = %204
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %207
+ThrowNullRef52:                                   ; preds = %207
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %213
+ThrowNullRef54:                                   ; preds = %213
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %172
+ThrowNullRef56:                                   ; preds = %172
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %176
+ThrowNullRef58:                                   ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %179
+ThrowNullRef60:                                   ; preds = %179
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %185
+ThrowNullRef62:                                   ; preds = %185
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %190
+ThrowNullRef64:                                   ; preds = %190
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %195
+ThrowNullRef66:                                   ; preds = %195
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %153
+ThrowNullRef68:                                   ; preds = %153
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %157
+ThrowNullRef70:                                   ; preds = %157
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %160
+ThrowNullRef72:                                   ; preds = %160
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %166
+ThrowNullRef74:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %136
+ThrowNullRef76:                                   ; preds = %136
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %140
+ThrowNullRef78:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %143
+ThrowNullRef80:                                   ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %148
+ThrowNullRef82:                                   ; preds = %148
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %128
+ThrowNullRef84:                                   ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %132
+ThrowNullRef86:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %100
+ThrowNullRef88:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %104
+ThrowNullRef90:                                   ; preds = %104
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %107
+ThrowNullRef92:                                   ; preds = %107
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %113
+ThrowNullRef94:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %118
+ThrowNullRef96:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %123
+ThrowNullRef98:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %81
+ThrowNullRef100:                                  ; preds = %81
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef101:                                  ; preds = %85
+ThrowNullRef102:                                  ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef103:                                  ; preds = %88
+ThrowNullRef104:                                  ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef105:                                  ; preds = %94
+ThrowNullRef106:                                  ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef107:                                  ; preds = %64
+ThrowNullRef108:                                  ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef109:                                  ; preds = %68
+ThrowNullRef110:                                  ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef111:                                  ; preds = %71
+ThrowNullRef112:                                  ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef113:                                  ; preds = %76
+ThrowNullRef114:                                  ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef115:                                  ; preds = %56
+ThrowNullRef116:                                  ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef117:                                  ; preds = %60
+ThrowNullRef118:                                  ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef119:                                  ; preds = %37
+ThrowNullRef120:                                  ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef121:                                  ; preds = %41
+ThrowNullRef122:                                  ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef123:                                  ; preds = %46
+ThrowNullRef124:                                  ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef125:                                  ; preds = %51
+ThrowNullRef126:                                  ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef127:                                  ; preds = %27
+ThrowNullRef128:                                  ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef129:                                  ; preds = %31
+ThrowNullRef130:                                  ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef131:                                  ; preds = %19
+ThrowNullRef132:                                  ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef133:                                  ; preds = %22
+ThrowNullRef134:                                  ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef135:                                  ; preds = %338
+ThrowNullRef136:                                  ; preds = %338
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef137:                                  ; preds = %341
+ThrowNullRef138:                                  ; preds = %341
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef139:                                  ; preds = %356
+ThrowNullRef140:                                  ; preds = %356
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef141:                                  ; preds = %360
+ThrowNullRef142:                                  ; preds = %360
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef143:                                  ; preds = %377
+ThrowNullRef144:                                  ; preds = %377
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef145:                                  ; preds = %381
+ThrowNullRef146:                                  ; preds = %381
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef147:                                  ; preds = %424
+ThrowNullRef148:                                  ; preds = %424
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef149:                                  ; preds = %428
+ThrowNullRef150:                                  ; preds = %428
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef151:                                  ; preds = %440
+ThrowNullRef152:                                  ; preds = %440
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef153:                                  ; preds = %444
+ThrowNullRef154:                                  ; preds = %444
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef155:                                  ; preds = %456
+ThrowNullRef156:                                  ; preds = %456
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef157:                                  ; preds = %460
+ThrowNullRef158:                                  ; preds = %460
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef159:                                  ; preds = %474
+ThrowNullRef160:                                  ; preds = %474
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef161:                                  ; preds = %477
+ThrowNullRef162:                                  ; preds = %477
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef163:                                  ; preds = %394
+ThrowNullRef164:                                  ; preds = %394
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef165:                                  ; preds = %398
+ThrowNullRef166:                                  ; preds = %398
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef167:                                  ; preds = %401
+ThrowNullRef168:                                  ; preds = %401
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef169:                                  ; preds = %407
+ThrowNullRef170:                                  ; preds = %407
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1939,8 +2021,8 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
-  br i1 %NullCheck, label %22, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %ThrowNullRef, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
@@ -1948,8 +2030,8 @@ entry:
   store i32 %24, i32* %loc0
   %25 = load i32, i32* %loc0
   %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %26, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %27
 
 ; <label>:27                                      ; preds = %22
   %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
@@ -1971,7 +2053,7 @@ ThrowNullRef:                                     ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1989,8 +2071,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -2022,15 +2104,15 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2048,16 +2130,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
   %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
   store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %15
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
@@ -2072,8 +2154,8 @@ entry:
   %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
   %29 = ptrtoint i16 addrspace(1)* %28 to i64
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %19
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
@@ -2089,19 +2171,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2114,8 +2196,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
@@ -2128,7 +2210,7 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[loadElem]
+Failed to read AppDomain.PrepareDataForSetup[storeElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
@@ -2202,8 +2284,8 @@ entry:
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
-  br i1 %NullCheck24, label %27, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = load i64, i64 addrspace(1)* %26
@@ -2218,8 +2300,8 @@ entry:
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
-  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
   %41 = load i64, i64 addrspace(1)* %39
@@ -2236,8 +2318,8 @@ entry:
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
-  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
   %54 = load i64, i64 addrspace(1)* %52
@@ -2252,8 +2334,8 @@ entry:
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
   %67 = load i64, i64 addrspace(1)* %65
@@ -2270,8 +2352,8 @@ entry:
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
-  br i1 %NullCheck16, label %79, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
   %80 = load i64, i64 addrspace(1)* %78
@@ -2286,8 +2368,8 @@ entry:
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
-  br i1 %NullCheck18, label %92, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
   %93 = load i64, i64 addrspace(1)* %91
@@ -2304,8 +2386,8 @@ entry:
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
-  br i1 %NullCheck12, label %105, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = load i64, i64 addrspace(1)* %104
@@ -2320,8 +2402,8 @@ entry:
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
-  br i1 %NullCheck14, label %118, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
   %119 = load i64, i64 addrspace(1)* %117
@@ -2337,8 +2419,8 @@ entry:
 
 ; <label>:128                                     ; preds = %20
   %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
-  br i1 %NullCheck4, label %130, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %129, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %130
 
 ; <label>:130                                     ; preds = %128
   %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
@@ -2346,8 +2428,8 @@ entry:
   %133 = load i16, i16 addrspace(1)* %132, align 8
   %134 = zext i16 %133 to i32
   %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
-  br i1 %NullCheck6, label %136, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %135, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %136
 
 ; <label>:136                                     ; preds = %130
   %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
@@ -2360,8 +2442,8 @@ entry:
 
 ; <label>:143                                     ; preds = %136
   %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
-  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %144, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %145
 
 ; <label>:145                                     ; preds = %143
   %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
@@ -2369,8 +2451,8 @@ entry:
   %148 = load i16, i16 addrspace(1)* %147, align 8
   %149 = zext i16 %148 to i32
   %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %150, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %151
 
 ; <label>:151                                     ; preds = %145
   %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
@@ -2388,8 +2470,8 @@ entry:
 
 ; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
-  br i1 %NullCheck, label %163, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %ThrowNullRef, label %163
 
 ; <label>:163                                     ; preds = %161
   %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
@@ -2399,8 +2481,8 @@ entry:
 
 ; <label>:167                                     ; preds = %163
   %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
-  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %168, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %169
 
 ; <label>:169                                     ; preds = %167
   %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
@@ -2432,55 +2514,55 @@ ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %167
+ThrowNullRef2:                                    ; preds = %167
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %128
+ThrowNullRef4:                                    ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %130
+ThrowNullRef6:                                    ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %143
+ThrowNullRef8:                                    ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %145
+ThrowNullRef10:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %102
+ThrowNullRef12:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %105
+ThrowNullRef14:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %76
+ThrowNullRef16:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %79
+ThrowNullRef18:                                   ; preds = %79
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %50
+ThrowNullRef20:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %53
+ThrowNullRef22:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %24
+ThrowNullRef24:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %27
+ThrowNullRef26:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2503,15 +2585,15 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2519,16 +2601,16 @@ entry:
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
   store i32 %8, i32* %loc0
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
   %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
   store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
@@ -2546,16 +2628,16 @@ entry:
 
 ; <label>:23                                      ; preds = %64
   %24 = load i16*, i16** %loc3
-  %NullCheck12 = icmp ne i16* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i16* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
   store i32 %27, i32* %loc5
   %28 = load i16*, i16** %loc4
-  %NullCheck14 = icmp ne i16* %28, null
-  br i1 %NullCheck14, label %29, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %28, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = load i16, i16* %28, align 8
@@ -2620,15 +2702,15 @@ entry:
 
 ; <label>:67                                      ; preds = %64
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
-  br i1 %NullCheck8, label %69, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %68, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %69
 
 ; <label>:69                                      ; preds = %67
   %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
   %71 = load i32, i32 addrspace(1)* %70
   %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
-  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %73
 
 ; <label>:73                                      ; preds = %69
   %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
@@ -2645,31 +2727,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %67
+ThrowNullRef8:                                    ; preds = %67
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %69
+ThrowNullRef10:                                   ; preds = %69
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2710,14 +2792,14 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
   %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
@@ -2730,14 +2812,14 @@ entry:
 
 ; <label>:11                                      ; preds = %4
   %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
   %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
@@ -2749,14 +2831,14 @@ entry:
 
 ; <label>:22                                      ; preds = %16
   %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
   %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
-  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
-  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
@@ -2804,23 +2886,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2836,7 +2918,280 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[loadElem]
+Successfully read RuntimeType.IsAssignableFrom
+
+define i8 @RuntimeType.IsAssignableFrom(%System.RuntimeType addrspace(1)* %param0, %System.Type addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.RuntimeType addrspace(1)*
+  %arg1 = alloca %System.Type addrspace(1)*
+  %loc0 = alloca %System.RuntimeType addrspace(1)*
+  %loc1 = alloca %"System.Type[]" addrspace(1)*
+  %loc2 = alloca i32
+  store %System.RuntimeType addrspace(1)* %param0, %System.RuntimeType addrspace(1)** %this
+  store %System.Type addrspace(1)* %param1, %System.Type addrspace(1)** %arg1
+  %0 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %1 = icmp ne %System.Type addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i8 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %5 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %6 = bitcast %System.Type addrspace(1)* %4 to %System.Object addrspace(1)*
+  %7 = bitcast %System.RuntimeType addrspace(1)* %5 to %System.Object addrspace(1)*
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %6, %System.Object addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %3
+  ret i8 1
+
+; <label>:12                                      ; preds = %3
+  %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 152
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 32
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
+  %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
+  %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
+  store %System.RuntimeType addrspace(1)* %25, %System.RuntimeType addrspace(1)** %loc0
+  %26 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %27 = icmp eq %System.RuntimeType addrspace(1)* %26, null
+  br i1 %27, label %34, label %28
+
+; <label>:28                                      ; preds = %15
+  %29 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %30 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)*)*)(%System.RuntimeType addrspace(1)* %29, %System.RuntimeType addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+; <label>:34                                      ; preds = %15
+  %35 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %36 = call %System.Reflection.Emit.TypeBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Reflection.Emit.TypeBuilder addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %35)
+  %37 = icmp eq %System.Reflection.Emit.TypeBuilder addrspace(1)* %36, null
+  br i1 %37, label %139, label %38
+
+; <label>:38                                      ; preds = %34
+  %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %42
+
+; <label>:42                                      ; preds = %38
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 152
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 40
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
+  %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
+  %53 = zext i8 %52 to i32
+  %54 = icmp eq i32 %53, 0
+  br i1 %54, label %56, label %55
+
+; <label>:55                                      ; preds = %42
+  ret i8 1
+
+; <label>:56                                      ; preds = %42
+  %57 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %58 = bitcast %System.RuntimeType addrspace(1)* %57 to %System.Type addrspace(1)*
+  %59 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %58)
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %64 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.Type addrspace(1)* %63, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = bitcast %System.RuntimeType addrspace(1)* %64 to %System.Type addrspace(1)*
+  %67 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %63, %System.Type addrspace(1)* %66)
+  %68 = zext i8 %67 to i32
+  %69 = trunc i32 %68 to i8
+  ret i8 %69
+
+; <label>:70                                      ; preds = %56
+  %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
+  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %73
+
+; <label>:73                                      ; preds = %70
+  %74 = load i64, i64 addrspace(1)* %72
+  %75 = add i64 %74, 128
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = add i64 %77, 0
+  %79 = inttoptr i64 %78 to i64*
+  %80 = load i64, i64* %79
+  %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
+  %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
+  %83 = call i8 %82(%System.Type addrspace(1)* %81)
+  %84 = zext i8 %83 to i32
+  %85 = icmp eq i32 %84, 0
+  br i1 %85, label %139, label %86
+
+; <label>:86                                      ; preds = %73
+  %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
+  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %89
+
+; <label>:89                                      ; preds = %86
+  %90 = load i64, i64 addrspace(1)* %88
+  %91 = add i64 %90, 128
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = add i64 %93, 24
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
+  %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
+  %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
+  store %"System.Type[]" addrspace(1)* %99, %"System.Type[]" addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %129
+
+; <label>:100                                     ; preds = %132
+  %101 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %102 = load i32, i32* %loc2
+  %NullCheck11 = icmp eq %"System.Type[]" addrspace(1)* %101, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %103
+
+; <label>:103                                     ; preds = %100
+  %104 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 1
+  %105 = load i32, i32 addrspace(1)* %104
+  %106 = zext i32 %105 to i64
+  %107 = zext i32 %102 to i64
+  %BoundsCheck = icmp uge i64 %107, %106
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %108
+
+; <label>:108                                     ; preds = %103
+  %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
+  %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
+  %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
+  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %113
+
+; <label>:113                                     ; preds = %108
+  %114 = load i64, i64 addrspace(1)* %112
+  %115 = add i64 %114, 152
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = add i64 %117, 56
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
+  %123 = zext i8 %122 to i32
+  %124 = icmp ne i32 %123, 0
+  br i1 %124, label %126, label %125
+
+; <label>:125                                     ; preds = %113
+  ret i8 0
+
+; <label>:126                                     ; preds = %113
+  %127 = load i32, i32* %loc2
+  %128 = add i32 %127, 1
+  store i32 %128, i32* %loc2
+  br label %129
+
+; <label>:129                                     ; preds = %89, %126
+  %130 = load i32, i32* %loc2
+  %131 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %NullCheck9 = icmp eq %"System.Type[]" addrspace(1)* %131, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %132
+
+; <label>:132                                     ; preds = %129
+  %133 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %131, i32 0, i32 1
+  %134 = load i32, i32 addrspace(1)* %133
+  %135 = zext i32 %134 to i64
+  %136 = trunc i64 %135 to i32
+  %137 = icmp slt i32 %130, %136
+  br i1 %137, label %100, label %138
+
+; <label>:138                                     ; preds = %132
+  ret i8 1
+
+; <label>:139                                     ; preds = %34, %73
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %129
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %103
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -2893,7 +3248,7 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElem]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -2904,8 +3259,8 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -2997,8 +3352,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
@@ -3059,8 +3414,8 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -3087,8 +3442,8 @@ entry:
 
 ; <label>:17                                      ; preds = %5, %11
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
@@ -3097,8 +3452,8 @@ entry:
 
 ; <label>:22                                      ; preds = %1, %11
   %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
@@ -3109,11 +3464,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %17
+ThrowNullRef2:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %22
+ThrowNullRef4:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3167,15 +3522,15 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
   %15 = load i32, i32 addrspace(1)* %14
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
@@ -3198,7 +3553,7 @@ ThrowNullRef:                                     ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef2:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3232,8 +3587,8 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
@@ -3312,8 +3667,8 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -3327,8 +3682,8 @@ entry:
 ; <label>:5                                       ; preds = %43
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %7 = load i32, i32* %loc1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck6, label %8, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
@@ -3366,8 +3721,8 @@ entry:
 ; <label>:32                                      ; preds = %21, %25
   %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
   %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
-  br i1 %NullCheck8, label %35, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = trunc i32 %34 to i16
@@ -3380,8 +3735,8 @@ entry:
 ; <label>:40                                      ; preds = %1, %35
   %41 = load i32, i32* %loc1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
-  br i1 %NullCheck2, label %43, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %42, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
@@ -3392,8 +3747,8 @@ entry:
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
   %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
-  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
   %51 = load i64, i64 addrspace(1)* %49
@@ -3412,19 +3767,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %40
+ThrowNullRef2:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %47
+ThrowNullRef4:                                    ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %5
+ThrowNullRef6:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %32
+ThrowNullRef8:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3467,8 +3822,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
@@ -3492,11 +3847,391 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(i16* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store i16* %param0, i16** %arg0
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load i32, i32* %arg3
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %42, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %37, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg2
+  %13 = load i32, i32* %arg3
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %37, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %24 = load i32, i32* %arg2
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load i16*, i16** %arg0
+  %35 = load i32, i32* %arg3
+  %36 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %36, i16* %34, i32 %35)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:37                                      ; preds = %5, %16
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %39)
+  %41 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41, %System.String addrspace(1)* %38, %System.String addrspace(1)* %40)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41) #0
+  unreachable
+
+; <label>:42                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
-Failed to read StringBuilder.ToString[loadElemA]
+Successfully read StringBuilder.ToString
+
+define %System.String addrspace(1)* @StringBuilder.ToString(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i16*
+  %loc3 = alloca %"System.Char[]" addrspace(1)*
+  %loc4 = alloca i32
+  %loc5 = alloca i32
+  %loc6 = alloca i16 addrspace(1)*
+  %loc7 = alloca %System.String addrspace(1)*
+  %loc8 = alloca %"System.Char[]" addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %0)
+  %2 = icmp ne i32 %1, 0
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %4
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %6)
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %7)
+  store %System.String addrspace(1)* %8, %System.String addrspace(1)** %loc0
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.Text.StringBuilder addrspace(1)* %9, %System.Text.StringBuilder addrspace(1)** %loc1
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  store %System.String addrspace(1)* %10, %System.String addrspace(1)** %loc7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc7
+  %12 = ptrtoint %System.String addrspace(1)* %11 to i64
+  %13 = icmp eq i64 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %5
+  %15 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %16 = sext i32 %15 to i64
+  %17 = add i64 %12, %16
+  br label %18
+
+; <label>:18                                      ; preds = %5, %14
+  %19 = phi i64 [ %12, %5 ], [ %17, %14 ]
+  %20 = inttoptr i64 %19 to i16*
+  store i16* %20, i16** %loc2
+  br label %21
+
+; <label>:21                                      ; preds = %98, %18
+  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %22, null
+  br i1 %NullCheck, label %ThrowNullRef, label %23
+
+; <label>:23                                      ; preds = %21
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 3
+  %25 = load i32, i32 addrspace(1)* %24, align 8
+  %26 = icmp sle i32 %25, 0
+  br i1 %26, label %96, label %27
+
+; <label>:27                                      ; preds = %23
+  %28 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %28, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %29
+
+; <label>:29                                      ; preds = %27
+  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %28, i32 0, i32 1
+  %31 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %30, align 8
+  store %"System.Char[]" addrspace(1)* %31, %"System.Char[]" addrspace(1)** %loc3
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %33
+
+; <label>:33                                      ; preds = %29
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  store i32 %35, i32* %loc4
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  %39 = load i32, i32 addrspace(1)* %38, align 8
+  store i32 %39, i32* %loc5
+  %40 = load i32, i32* %loc5
+  %41 = load i32, i32* %loc4
+  %42 = add i32 %40, %41
+  %43 = zext i32 %42 to i64
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %45
+
+; <label>:45                                      ; preds = %37
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = sext i32 %47 to i64
+  %49 = icmp sgt i64 %43, %48
+  br i1 %49, label %91, label %50
+
+; <label>:50                                      ; preds = %45
+  %51 = load i32, i32* %loc5
+  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %52, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %53
+
+; <label>:53                                      ; preds = %50
+  %54 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %52, i32 0, i32 1
+  %55 = load i32, i32 addrspace(1)* %54
+  %56 = zext i32 %55 to i64
+  %57 = trunc i64 %56 to i32
+  %58 = icmp ugt i32 %51, %57
+  br i1 %58, label %91, label %59
+
+; <label>:59                                      ; preds = %53
+  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  store %"System.Char[]" addrspace(1)* %60, %"System.Char[]" addrspace(1)** %loc8
+  %61 = icmp eq %"System.Char[]" addrspace(1)* %60, null
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %63, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %64
+
+; <label>:64                                      ; preds = %62
+  %65 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %63, i32 0, i32 1
+  %66 = load i32, i32 addrspace(1)* %65
+  %67 = zext i32 %66 to i64
+  %68 = trunc i64 %67 to i32
+  %69 = icmp ne i32 %68, 0
+  br i1 %69, label %71, label %70
+
+; <label>:70                                      ; preds = %59, %64
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:71                                      ; preds = %64
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %73
+
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %BoundsCheck = icmp uge i64 0, %76
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %77
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %78, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:79                                      ; preds = %70, %77
+  %80 = load i16*, i16** %loc2
+  %81 = load i32, i32* %loc4
+  %82 = sext i32 %81 to i64
+  %83 = mul i64 %82, 2
+  %84 = bitcast i16* %80 to i8*
+  %85 = getelementptr inbounds i8, i8* %84, i64 %83
+  %86 = load i16 addrspace(1)*, i16 addrspace(1)** %loc6
+  %87 = ptrtoint i16 addrspace(1)* %86 to i64
+  %88 = load i32, i32* %loc5
+  %89 = bitcast i8* %85 to i16*
+  %90 = inttoptr i64 %87 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %89, i16* %90, i32 %88)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %96
+
+; <label>:91                                      ; preds = %45, %53
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %94 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %93)
+  %95 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95, %System.String addrspace(1)* %92, %System.String addrspace(1)* %94)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95) #0
+  unreachable
+
+; <label>:96                                      ; preds = %23, %79
+  %97 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %97, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %98
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %97, i32 0, i32 2
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  store %System.Text.StringBuilder addrspace(1)* %100, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %102 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %102, label %21, label %103
+
+; <label>:103                                     ; preds = %98
+  store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc7
+  %104 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  ret %System.String addrspace(1)* %104
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method StringBuilder::get_Length using LLILCJit
+Successfully read StringBuilder.get_Length
+
+define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
+Successfully read RuntimeHelpers.get_OffsetToStringData
+
+define i32 @RuntimeHelpers.get_OffsetToStringData() {
+entry:
+  ret i32 12
+}
+
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
 Successfully read CultureData.CreateCultureData
 
@@ -3514,23 +4249,23 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
   store i8 %4, i8 addrspace(1)* %6
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
@@ -3549,11 +4284,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3566,50 +4301,50 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
   store i32 -1, i32 addrspace(1)* %2
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
   store i32 -1, i32 addrspace(1)* %8
   %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
   store i32 -1, i32 addrspace(1)* %14
   %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
   store i32 -1, i32 addrspace(1)* %17
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
@@ -3623,27 +4358,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3675,7 +4410,136 @@ Failed to read Dictionary`2.Insert[non-const derefAddress]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
 Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
-Failed to read HashHelpers.GetPrime[loadElem]
+Successfully read HashHelpers.GetPrime
+
+define i32 @HashHelpers.GetPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %6, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5, %System.String addrspace(1)* %4)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5) #0
+  unreachable
+
+; <label>:6                                       ; preds = %entry
+  store i32 0, i32* %loc0
+  br label %29
+
+; <label>:7                                       ; preds = %35
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 1296
+  %10 = addrspacecast i8 addrspace(1)* %9 to %"System.Int32[]" addrspace(1)**
+  %11 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %10
+  %12 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Int32[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = zext i32 %15 to i64
+  %17 = zext i32 %12 to i64
+  %BoundsCheck = icmp uge i64 %17, %16
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 3, i32 %12
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  store i32 %20, i32* %loc1
+  %21 = load i32, i32* %loc1
+  %22 = load i32, i32* %arg0
+  %23 = icmp slt i32 %21, %22
+  br i1 %23, label %26, label %24
+
+; <label>:24                                      ; preds = %18
+  %25 = load i32, i32* %loc1
+  ret i32 %25
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %loc0
+  %28 = add i32 %27, 1
+  store i32 %28, i32* %loc0
+  br label %29
+
+; <label>:29                                      ; preds = %6, %26
+  %30 = load i32, i32* %loc0
+  %31 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %32 = getelementptr inbounds i8, i8 addrspace(1)* %31, i64 1296
+  %33 = addrspacecast i8 addrspace(1)* %32 to %"System.Int32[]" addrspace(1)**
+  %34 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %33
+  %NullCheck = icmp eq %"System.Int32[]" addrspace(1)* %34, null
+  br i1 %NullCheck, label %ThrowNullRef, label %35
+
+; <label>:35                                      ; preds = %29
+  %36 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %34, i32 0, i32 1
+  %37 = load i32, i32 addrspace(1)* %36
+  %38 = zext i32 %37 to i64
+  %39 = trunc i64 %38 to i32
+  %40 = icmp slt i32 %30, %39
+  br i1 %40, label %7, label %41
+
+; <label>:41                                      ; preds = %35
+  %42 = load i32, i32* %arg0
+  %43 = or i32 %42, 1
+  store i32 %43, i32* %loc2
+  br label %59
+
+; <label>:44                                      ; preds = %59
+  %45 = load i32, i32* %loc2
+  %46 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %45)
+  %47 = zext i8 %46 to i32
+  %48 = icmp eq i32 %47, 0
+  br i1 %48, label %56, label %49
+
+; <label>:49                                      ; preds = %44
+  %50 = load i32, i32* %loc2
+  %51 = sub i32 %50, 1
+  %52 = srem i32 %51, 101
+  %53 = icmp eq i32 %52, 0
+  br i1 %53, label %56, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = load i32, i32* %loc2
+  ret i32 %55
+
+; <label>:56                                      ; preds = %44, %49
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %57, 2
+  store i32 %58, i32* %loc2
+  br label %59
+
+; <label>:59                                      ; preds = %41, %56
+  %60 = load i32, i32* %loc2
+  %61 = icmp slt i32 %60, 2147483647
+  br i1 %61, label %44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load i32, i32* %arg0
+  ret i32 %63
+
+ThrowNullRef:                                     ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
 Successfully read GenericEqualityComparer`1.GetHashCode
 
@@ -3694,14 +4558,14 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
   %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load i64, i64 addrspace(1)* %7
@@ -3720,7 +4584,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3750,8 +4614,8 @@ entry:
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
@@ -3796,8 +4660,8 @@ entry:
   %35 = bitcast i16* %34 to i8*
   %36 = getelementptr inbounds i8, i8* %35, i64 2
   %37 = bitcast i8* %36 to i16*
-  %NullCheck4 = icmp ne i16* %37, null
-  br i1 %NullCheck4, label %38, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %37, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %38
 
 ; <label>:38                                      ; preds = %27
   %39 = load i16, i16* %37, align 8
@@ -3824,8 +4688,8 @@ entry:
 
 ; <label>:54                                      ; preds = %22, %43
   %55 = load i16*, i16** %loc4
-  %NullCheck2 = icmp ne i16* %55, null
-  br i1 %NullCheck2, label %56, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i16* %55, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %56
 
 ; <label>:56                                      ; preds = %54
   %57 = load i16, i16* %55, align 8
@@ -3850,11 +4714,11 @@ ThrowNullRef:                                     ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %54
+ThrowNullRef2:                                    ; preds = %54
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %27
+ThrowNullRef4:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3871,8 +4735,8 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -3907,8 +4771,8 @@ entry:
 
 ; <label>:26                                      ; preds = %19
   %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
-  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %28
 
 ; <label>:28                                      ; preds = %26
   %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
@@ -3920,7 +4784,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3972,8 +4836,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
@@ -3984,26 +4848,26 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
-  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
@@ -4014,8 +4878,8 @@ entry:
 ; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
@@ -4024,8 +4888,8 @@ entry:
 
 ; <label>:25                                      ; preds = %1, %16, %23
   %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
-  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
@@ -4036,27 +4900,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %20
+ThrowNullRef10:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4069,8 +4933,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -4081,8 +4945,8 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
@@ -4091,8 +4955,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1, %8
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
@@ -4103,11 +4967,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4128,24 +4992,24 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   store i32 %3, i32* %loc0
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
   %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
   store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck4, label %9, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
@@ -4164,15 +5028,15 @@ entry:
 ; <label>:18                                      ; preds = %70
   %19 = load i16*, i16** %loc3
   %20 = bitcast i16* %19 to i64*
-  %NullCheck10 = icmp ne i64* %20, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %20, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = load i64, i64* %20, align 8
   %23 = load i16*, i16** %loc4
   %24 = bitcast i16* %23 to i64*
-  %NullCheck12 = icmp ne i64* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = load i64, i64* %24, align 8
@@ -4188,8 +5052,8 @@ entry:
   %31 = bitcast i16* %30 to i8*
   %32 = getelementptr inbounds i8, i8* %31, i64 8
   %33 = bitcast i8* %32 to i64*
-  %NullCheck14 = icmp ne i64* %33, null
-  br i1 %NullCheck14, label %34, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = load i64, i64* %33, align 8
@@ -4197,8 +5061,8 @@ entry:
   %37 = bitcast i16* %36 to i8*
   %38 = getelementptr inbounds i8, i8* %37, i64 8
   %39 = bitcast i8* %38 to i64*
-  %NullCheck16 = icmp ne i64* %39, null
-  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %40
 
 ; <label>:40                                      ; preds = %34
   %41 = load i64, i64* %39, align 8
@@ -4214,8 +5078,8 @@ entry:
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %NullCheck18 = icmp ne i64* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = load i64, i64* %48, align 8
@@ -4223,8 +5087,8 @@ entry:
   %52 = bitcast i16* %51 to i8*
   %53 = getelementptr inbounds i8, i8* %52, i64 16
   %54 = bitcast i8* %53 to i64*
-  %NullCheck20 = icmp ne i64* %54, null
-  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64* %54, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %55
 
 ; <label>:55                                      ; preds = %49
   %56 = load i64, i64* %54, align 8
@@ -4262,15 +5126,15 @@ entry:
 ; <label>:74                                      ; preds = %95
   %75 = load i16*, i16** %loc3
   %76 = bitcast i16* %75 to i32*
-  %NullCheck6 = icmp ne i32* %76, null
-  br i1 %NullCheck6, label %77, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32* %76, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %77
 
 ; <label>:77                                      ; preds = %74
   %78 = load i32, i32* %76, align 8
   %79 = load i16*, i16** %loc4
   %80 = bitcast i16* %79 to i32*
-  %NullCheck8 = icmp ne i32* %80, null
-  br i1 %NullCheck8, label %81, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i32* %80, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %81
 
 ; <label>:81                                      ; preds = %77
   %82 = load i32, i32* %80, align 8
@@ -4318,43 +5182,43 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %74
+ThrowNullRef6:                                    ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %77
+ThrowNullRef8:                                    ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %29
+ThrowNullRef14:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %34
+ThrowNullRef16:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4376,8 +5240,8 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load i64, i64 addrspace(1)* %4
@@ -4389,8 +5253,8 @@ entry:
   %12 = load i64, i64* %11
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %5
   %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
@@ -4399,8 +5263,8 @@ entry:
   %18 = load i8, i8* %arg2
   %19 = zext i8 %18 to i32
   %20 = trunc i32 %19 to i8
-  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %15
   %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
@@ -4411,11 +5275,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4442,8 +5306,8 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
@@ -4466,16 +5330,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
   %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = load i64, i64 addrspace(1)* %19
@@ -4500,8 +5364,8 @@ entry:
 ; <label>:35                                      ; preds = %30
   %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
@@ -4514,8 +5378,8 @@ entry:
 
 ; <label>:42                                      ; preds = %1, %38
   %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
-  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
@@ -4526,19 +5390,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %35
+ThrowNullRef2:                                    ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %42
+ThrowNullRef8:                                    ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4551,14 +5415,14 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
@@ -4570,7 +5434,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4583,8 +5447,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
@@ -4613,51 +5477,51 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
   %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
   %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
   %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
   %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
-  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
   store i64 %21, i64 addrspace(1)* %23
   %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %25 = load i64, i64* %loc0
-  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
@@ -4668,27 +5532,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %22
+ThrowNullRef12:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4701,8 +5565,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
@@ -4713,19 +5577,19 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
@@ -4734,8 +5598,8 @@ entry:
 
 ; <label>:15                                      ; preds = %1, %13
   %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
@@ -4746,19 +5610,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %15
+ThrowNullRef8:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4771,8 +5635,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -4831,8 +5695,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
@@ -4882,8 +5746,8 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
-  br i1 %NullCheck, label %17, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %ThrowNullRef, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
@@ -4894,15 +5758,15 @@ entry:
 
 ; <label>:22                                      ; preds = %17
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
-  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
   %26 = load i32, i32 addrspace(1)* %25
   %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
-  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %27, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
@@ -4925,8 +5789,8 @@ entry:
 ; <label>:40                                      ; preds = %17
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
-  br i1 %NullCheck6, label %43, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %41, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
@@ -4938,34 +5802,17 @@ ThrowNullRef:                                     ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %24
+ThrowNullRef4:                                    ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %40
+ThrowNullRef6:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
-}
-
-INFO:  jitting method Object::ReferenceEquals using LLILCJit
-Successfully read Object.ReferenceEquals
-
-define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
-entry:
-  %arg0 = alloca %System.Object addrspace(1)*
-  %arg1 = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
-  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
-  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = icmp eq %System.Object addrspace(1)* %0, %1
-  %3 = sext i1 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
 }
 
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
@@ -4978,21 +5825,21 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
   %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
-  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
@@ -5007,28 +5854,28 @@ entry:
 ; <label>:13                                      ; preds = %8, %12
   %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
   %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
   %21 = load i32, i32 addrspace(1)* %20, align 8
   %22 = add i32 %21, 1
-  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
   store i32 %22, i32 addrspace(1)* %24
   %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
@@ -5039,27 +5886,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5077,7 +5924,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::Setup using LLILCJit
-Failed to read AppDomain.Setup[loadElem]
+Failed to read AppDomain.Setup[unbox]
 INFO:  jitting method Thread::GetDomain using LLILCJit
 Successfully read Thread.GetDomain
 
@@ -5108,8 +5955,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
@@ -5122,14 +5969,14 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
   %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
@@ -5141,11 +5988,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5173,8 +6020,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -5189,7 +6036,328 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
 Failed to read KeyCollection.System.Collections.Generic.IEnumerable<TKey>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Successfully read Enumerator.MoveNext
+
+define i8 @Enumerator.MoveNext(%"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.RuntimeTypeHandle* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*
+  %"$TypeArg" = alloca %System.RuntimeTypeHandle*
+  store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
+  %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 8
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %76, label %12
+
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
+  br label %76
+
+; <label>:13                                      ; preds = %85
+  %14 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck19 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %15
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, i32 0, i32 0
+  %17 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %16, align 8
+  %NullCheck21 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, i32 0, i32 2
+  %20 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %19, align 8
+  %21 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck23 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %22
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, i32 0, i32 2
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %NullCheck25 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 3, i32 %24
+  %NullCheck27 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %32
+
+; <label>:32                                      ; preds = %30
+  %33 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, i32 0, i32 2
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = icmp slt i32 %34, 0
+  br i1 %35, label %68, label %36
+
+; <label>:36                                      ; preds = %32
+  %37 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %38 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck29 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %39
+
+; <label>:39                                      ; preds = %36
+  %40 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, i32 0, i32 0
+  %41 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %40, align 8
+  %NullCheck31 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, i32 0, i32 2
+  %44 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %43, align 8
+  %45 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck33 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, i32 0, i32 2
+  %48 = load i32, i32 addrspace(1)* %47, align 8
+  %NullCheck35 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %49
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = zext i32 %51 to i64
+  %53 = zext i32 %48 to i64
+  %BoundsCheck37 = icmp uge i64 %53, %52
+  br i1 %BoundsCheck37, label %ThrowIndexOutOfRange38, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 3, i32 %48
+  %NullCheck39 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %56
+
+; <label>:56                                      ; preds = %54
+  %57 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, i32 0, i32 0
+  %58 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck41 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %59
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %60, %System.__Canon addrspace(1)* %58)
+  %61 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck43 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  %64 = load i32, i32 addrspace(1)* %63, align 8
+  %65 = add i32 %64, 1
+  %NullCheck45 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  store i32 %65, i32 addrspace(1)* %67
+  ret i8 1
+
+; <label>:68                                      ; preds = %32
+  %69 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck47 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %73 = add i32 %72, 1
+  %NullCheck49 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %74
+
+; <label>:74                                      ; preds = %70
+  %75 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  store i32 %73, i32 addrspace(1)* %75
+  br label %76
+
+; <label>:76                                      ; preds = %8, %12, %74
+  %77 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %78
+
+; <label>:78                                      ; preds = %76
+  %79 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, i32 0, i32 2
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck7 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %82
+
+; <label>:82                                      ; preds = %78
+  %83 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, i32 0, i32 0
+  %84 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %83, align 8
+  %NullCheck9 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %85
+
+; <label>:85                                      ; preds = %82
+  %86 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, i32 0, i32 7
+  %87 = load i32, i32 addrspace(1)* %86, align 8
+  %88 = icmp ult i32 %80, %87
+  br i1 %88, label %13, label %89
+
+; <label>:89                                      ; preds = %85
+  %90 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %91 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck11 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %92
+
+; <label>:92                                      ; preds = %89
+  %93 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, i32 0, i32 0
+  %94 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck13 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %95
+
+; <label>:95                                      ; preds = %92
+  %96 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, i32 0, i32 7
+  %97 = load i32, i32 addrspace(1)* %96, align 8
+  %98 = add i32 %97, 1
+  %NullCheck15 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %99
+
+; <label>:99                                      ; preds = %95
+  %100 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, i32 0, i32 2
+  store i32 %98, i32 addrspace(1)* %100
+  %101 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck17 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %102
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %103, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %92
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef22:                                   ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef24:                                   ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef26:                                   ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef28:                                   ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef30:                                   ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef32:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef34:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef36:                                   ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange38:                           ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef40:                                   ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef42:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef44:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef46:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef48:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef50:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -5200,8 +6368,8 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -5232,9 +6400,9 @@ Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
 Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
-Failed to read String.MakeSeparatorList[loadElemA]
+Failed to read String.MakeSeparatorList[storeElem]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
-Failed to read String.InternalSplitKeepEmptyEntries[loadElem]
+Failed to read String.InternalSplitKeepEmptyEntries[storeElem]
 INFO:  jitting method Path::IsRelative using LLILCJit
 Successfully read Path.IsRelative
 
@@ -5243,8 +6411,8 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -5254,8 +6422,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
@@ -5271,8 +6439,8 @@ entry:
 
 ; <label>:17                                      ; preds = %7
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
@@ -5288,8 +6456,8 @@ entry:
 
 ; <label>:29                                      ; preds = %19
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %31
 
 ; <label>:31                                      ; preds = %29
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
@@ -5300,8 +6468,8 @@ entry:
 
 ; <label>:36                                      ; preds = %31
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
-  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %37, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
@@ -5312,8 +6480,8 @@ entry:
 
 ; <label>:43                                      ; preds = %31, %38
   %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
-  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %45
 
 ; <label>:45                                      ; preds = %43
   %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
@@ -5324,8 +6492,8 @@ entry:
 
 ; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %50
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
@@ -5336,8 +6504,8 @@ entry:
 
 ; <label>:57                                      ; preds = %1, %7, %19, %45, %52
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
-  br i1 %NullCheck14, label %59, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %59
 
 ; <label>:59                                      ; preds = %57
   %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
@@ -5347,8 +6515,8 @@ entry:
 
 ; <label>:63                                      ; preds = %59
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
@@ -5359,8 +6527,8 @@ entry:
 
 ; <label>:70                                      ; preds = %65
   %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
-  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.String addrspace(1)* %71, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %72
 
 ; <label>:72                                      ; preds = %70
   %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
@@ -5379,39 +6547,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %17
+ThrowNullRef4:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %29
+ThrowNullRef6:                                    ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %36
+ThrowNullRef8:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %43
+ThrowNullRef10:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %50
+ThrowNullRef12:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %57
+ThrowNullRef14:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %63
+ThrowNullRef16:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %70
+ThrowNullRef18:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5419,7 +6587,293 @@ ThrowNullRef17:                                   ; preds = %70
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
-Failed to read String.TrimHelper[loadElem]
+Successfully read String.TrimHelper
+
+define %System.String addrspace(1)* @String.TrimHelper(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i16
+  %loc4 = alloca i32
+  %loc5 = alloca i16
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = sub i32 %3, 1
+  store i32 %4, i32* %loc0
+  store i32 0, i32* %loc1
+  %5 = load i32, i32* %arg2
+  %6 = icmp eq i32 %5, 1
+  br i1 %6, label %62, label %7
+
+; <label>:7                                       ; preds = %1
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:8                                       ; preds = %58
+  store i32 0, i32* %loc2
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load i32, i32* %loc1
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2, i32 %10
+  %13 = load i16, i16 addrspace(1)* %12
+  %14 = zext i16 %13 to i32
+  %15 = trunc i32 %14 to i16
+  store i16 %15, i16* %loc3
+  store i32 0, i32* %loc2
+  br label %34
+
+; <label>:16                                      ; preds = %37
+  %17 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %18 = load i32, i32* %loc2
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %17, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %19
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = zext i32 %18 to i64
+  %BoundsCheck = icmp uge i64 %23, %22
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %24
+
+; <label>:24                                      ; preds = %19
+  %25 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 3, i32 %18
+  %26 = load i16, i16 addrspace(1)* %25, align 8
+  %27 = zext i16 %26 to i32
+  %28 = load i16, i16* %loc3
+  %29 = zext i16 %28 to i32
+  %30 = icmp eq i32 %27, %29
+  br i1 %30, label %43, label %31
+
+; <label>:31                                      ; preds = %24
+  %32 = load i32, i32* %loc2
+  %33 = add i32 %32, 1
+  store i32 %33, i32* %loc2
+  br label %34
+
+; <label>:34                                      ; preds = %11, %31
+  %35 = load i32, i32* %loc2
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = icmp slt i32 %35, %41
+  br i1 %42, label %16, label %43
+
+; <label>:43                                      ; preds = %24, %37
+  %44 = load i32, i32* %loc2
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %45, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp eq i32 %44, %50
+  br i1 %51, label %62, label %52
+
+; <label>:52                                      ; preds = %46
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %7, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %57, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %58
+
+; <label>:58                                      ; preds = %55
+  %59 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %60 = load i32, i32 addrspace(1)* %59
+  %61 = icmp slt i32 %56, %60
+  br i1 %61, label %8, label %62
+
+; <label>:62                                      ; preds = %1, %46, %58
+  %63 = load i32, i32* %arg2
+  %64 = icmp eq i32 %63, 0
+  br i1 %64, label %122, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %66, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %67
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %66, i32 0, i32 1
+  %69 = load i32, i32 addrspace(1)* %68
+  %70 = sub i32 %69, 1
+  store i32 %70, i32* %loc0
+  br label %118
+
+; <label>:71                                      ; preds = %118
+  store i32 0, i32* %loc4
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %73 = load i32, i32* %loc0
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %74
+
+; <label>:74                                      ; preds = %71
+  %75 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 2, i32 %73
+  %76 = load i16, i16 addrspace(1)* %75
+  %77 = zext i16 %76 to i32
+  %78 = trunc i32 %77 to i16
+  store i16 %78, i16* %loc5
+  store i32 0, i32* %loc4
+  br label %97
+
+; <label>:79                                      ; preds = %100
+  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %81 = load i32, i32* %loc4
+  %NullCheck19 = icmp eq %"System.Char[]" addrspace(1)* %80, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
+
+; <label>:82                                      ; preds = %79
+  %83 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 1
+  %84 = load i32, i32 addrspace(1)* %83
+  %85 = zext i32 %84 to i64
+  %86 = zext i32 %81 to i64
+  %BoundsCheck21 = icmp uge i64 %86, %85
+  br i1 %BoundsCheck21, label %ThrowIndexOutOfRange22, label %87
+
+; <label>:87                                      ; preds = %82
+  %88 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 3, i32 %81
+  %89 = load i16, i16 addrspace(1)* %88, align 8
+  %90 = zext i16 %89 to i32
+  %91 = load i16, i16* %loc5
+  %92 = zext i16 %91 to i32
+  %93 = icmp eq i32 %90, %92
+  br i1 %93, label %106, label %94
+
+; <label>:94                                      ; preds = %87
+  %95 = load i32, i32* %loc4
+  %96 = add i32 %95, 1
+  store i32 %96, i32* %loc4
+  br label %97
+
+; <label>:97                                      ; preds = %74, %94
+  %98 = load i32, i32* %loc4
+  %99 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck15 = icmp eq %"System.Char[]" addrspace(1)* %99, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %100
+
+; <label>:100                                     ; preds = %97
+  %101 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %99, i32 0, i32 1
+  %102 = load i32, i32 addrspace(1)* %101
+  %103 = zext i32 %102 to i64
+  %104 = trunc i64 %103 to i32
+  %105 = icmp slt i32 %98, %104
+  br i1 %105, label %79, label %106
+
+; <label>:106                                     ; preds = %87, %100
+  %107 = load i32, i32* %loc4
+  %108 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck17 = icmp eq %"System.Char[]" addrspace(1)* %108, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %109
+
+; <label>:109                                     ; preds = %106
+  %110 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %108, i32 0, i32 1
+  %111 = load i32, i32 addrspace(1)* %110
+  %112 = zext i32 %111 to i64
+  %113 = trunc i64 %112 to i32
+  %114 = icmp eq i32 %107, %113
+  br i1 %114, label %122, label %115
+
+; <label>:115                                     ; preds = %109
+  %116 = load i32, i32* %loc0
+  %117 = sub i32 %116, 1
+  store i32 %117, i32* %loc0
+  br label %118
+
+; <label>:118                                     ; preds = %67, %115
+  %119 = load i32, i32* %loc0
+  %120 = load i32, i32* %loc1
+  %121 = icmp sge i32 %119, %120
+  br i1 %121, label %71, label %122
+
+; <label>:122                                     ; preds = %62, %109, %118
+  %123 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %124 = load i32, i32* %loc1
+  %125 = load i32, i32* %loc0
+  %126 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %123, i32 %124, i32 %125)
+  ret %System.String addrspace(1)* %126
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %97
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange22:                           ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
 Successfully read String.CreateTrimmedString
 
@@ -5439,8 +6893,8 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
@@ -5535,8 +6989,8 @@ entry:
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i64 2872
   %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
   %8 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %7
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %3
   %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
@@ -5553,8 +7007,8 @@ entry:
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 2864
   %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
   %21 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %20
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
-  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %22
 
 ; <label>:22                                      ; preds = %16
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
@@ -5569,7 +7023,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %16
+ThrowNullRef2:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5586,8 +7040,8 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5613,8 +7067,8 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
@@ -5632,8 +7086,8 @@ entry:
 
 ; <label>:12                                      ; preds = %4
   %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
@@ -5644,8 +7098,8 @@ entry:
 
 ; <label>:19                                      ; preds = %14
   %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %19
   %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
@@ -5660,21 +7114,21 @@ entry:
   %31 = zext i16 %30 to i32
   %32 = bitcast i8* %29 to i16*
   %33 = trunc i32 %31 to i16
-  %NullCheck6 = icmp ne i16* %32, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i16* %32, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %21
   store i16 %33, i16* %32, align 8
   %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %36
 
 ; <label>:36                                      ; preds = %34
   %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
   %38 = load i32, i32 addrspace(1)* %37, align 8
   %39 = add i32 %38, 1
-  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %40
 
 ; <label>:40                                      ; preds = %36
   %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
@@ -5683,16 +7137,16 @@ entry:
 
 ; <label>:42                                      ; preds = %14
   %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
-  br i1 %NullCheck12, label %44, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
   %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
   %47 = load i16, i16* %arg1
   %48 = zext i16 %47 to i32
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = trunc i32 %48 to i16
@@ -5703,31 +7157,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %19
+ThrowNullRef4:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %21
+ThrowNullRef6:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %36
+ThrowNullRef10:                                   ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %42
+ThrowNullRef12:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %44
+ThrowNullRef14:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5740,8 +7194,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -5752,8 +7206,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
@@ -5762,14 +7216,14 @@ entry:
 
 ; <label>:11                                      ; preds = %1
   %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
@@ -5779,15 +7233,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5808,8 +7262,8 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5822,8 +7276,8 @@ entry:
 
 ; <label>:8                                       ; preds = %3
   %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
@@ -5842,15 +7296,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
-  br i1 %NullCheck4, label %22, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
   %24 = load i16*, i16* addrspace(1)* %23, align 8
   %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %25, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
@@ -5859,8 +7313,8 @@ entry:
   store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
@@ -5874,8 +7328,8 @@ entry:
 
 ; <label>:37                                      ; preds = %65
   %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %37
   %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
@@ -5886,16 +7340,16 @@ entry:
   %45 = bitcast i16* %41 to i8*
   %46 = getelementptr inbounds i8, i8* %45, i64 %44
   %47 = bitcast i8* %46 to i16*
-  %NullCheck14 = icmp ne i16* %47, null
-  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %47, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %48
 
 ; <label>:48                                      ; preds = %39
   %49 = load i16, i16* %47, align 8
   %50 = zext i16 %49 to i32
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %52 = load i32, i32* %loc1
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %53
 
 ; <label>:53                                      ; preds = %48
   %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
@@ -5916,8 +7370,8 @@ entry:
 ; <label>:62                                      ; preds = %36, %59
   %63 = load i32, i32* %loc1
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck10, label %65, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %65
 
 ; <label>:65                                      ; preds = %62
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
@@ -5936,15 +7390,15 @@ entry:
 
 ; <label>:74                                      ; preds = %70
   %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
-  br i1 %NullCheck18, label %76, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %76
 
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
   %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
-  br i1 %NullCheck20, label %80, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
   %81 = load i64, i64 addrspace(1)* %79
@@ -5958,8 +7412,8 @@ entry:
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
   %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
-  br i1 %NullCheck22, label %92, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.String addrspace(1)* %90, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %92
 
 ; <label>:92                                      ; preds = %80
   %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
@@ -5969,15 +7423,15 @@ entry:
 
 ; <label>:96                                      ; preds = %70
   %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
-  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %98
 
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
   %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
-  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
   %103 = load i64, i64 addrspace(1)* %101
@@ -5991,8 +7445,8 @@ entry:
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
   %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
-  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.String addrspace(1)* %112, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %114
 
 ; <label>:114                                     ; preds = %102
   %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
@@ -6004,59 +7458,59 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %20
+ThrowNullRef4:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %22
+ThrowNullRef6:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %26
+ThrowNullRef8:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %62
+ThrowNullRef10:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %48
+ThrowNullRef16:                                   ; preds = %48
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %74
+ThrowNullRef18:                                   ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %76
+ThrowNullRef20:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %80
+ThrowNullRef22:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %96
+ThrowNullRef24:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %98
+ThrowNullRef26:                                   ; preds = %98
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %102
+ThrowNullRef28:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6069,15 +7523,15 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
   %3 = load i16*, i16* addrspace(1)* %2, align 8
   %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
@@ -6087,8 +7541,8 @@ entry:
   %10 = bitcast i16* %3 to i8*
   %11 = getelementptr inbounds i8, i8* %10, i64 %9
   %12 = bitcast i8* %11 to i16*
-  %NullCheck4 = icmp ne i16* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %5
   store i16 0, i16* %12, align 8
@@ -6098,11 +7552,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6119,8 +7573,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -6131,8 +7585,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
@@ -6144,15 +7598,15 @@ entry:
 
 ; <label>:14                                      ; preds = %1
   %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
   %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
   %21 = load i64, i64 addrspace(1)* %19
@@ -6171,15 +7625,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %14
+ThrowNullRef4:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %16
+ThrowNullRef6:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6302,14 +7756,6 @@ entry:
   ret %System.String addrspace(1)* %57
 }
 
-INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
-Successfully read RuntimeHelpers.get_OffsetToStringData
-
-define i32 @RuntimeHelpers.get_OffsetToStringData() {
-entry:
-  ret i32 12
-}
-
 INFO:  jitting method String::Equals using LLILCJit
 Successfully read String.Equals
 
@@ -6381,8 +7827,8 @@ entry:
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
-  br i1 %NullCheck24, label %29, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
   %30 = load i64, i64 addrspace(1)* %28
@@ -6397,8 +7843,8 @@ entry:
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
-  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
   %43 = load i64, i64 addrspace(1)* %41
@@ -6418,8 +7864,8 @@ entry:
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
   %59 = load i64, i64 addrspace(1)* %57
@@ -6434,8 +7880,8 @@ entry:
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck22, label %71, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
   %72 = load i64, i64 addrspace(1)* %70
@@ -6455,8 +7901,8 @@ entry:
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
-  br i1 %NullCheck16, label %87, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = load i64, i64 addrspace(1)* %86
@@ -6471,8 +7917,8 @@ entry:
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck18, label %100, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
   %101 = load i64, i64 addrspace(1)* %99
@@ -6492,8 +7938,8 @@ entry:
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
-  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
   %117 = load i64, i64 addrspace(1)* %115
@@ -6508,8 +7954,8 @@ entry:
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
-  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
   %130 = load i64, i64 addrspace(1)* %128
@@ -6528,15 +7974,15 @@ entry:
 
 ; <label>:142                                     ; preds = %22
   %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
-  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %143, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %144
 
 ; <label>:144                                     ; preds = %142
   %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
   %146 = load i32, i32 addrspace(1)* %145
   %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
-  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %147, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %148
 
 ; <label>:148                                     ; preds = %144
   %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
@@ -6557,15 +8003,15 @@ entry:
 
 ; <label>:159                                     ; preds = %22
   %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
-  br i1 %NullCheck, label %161, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %ThrowNullRef, label %161
 
 ; <label>:161                                     ; preds = %159
   %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
   %163 = load i32, i32 addrspace(1)* %162
   %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
-  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %164, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %165
 
 ; <label>:165                                     ; preds = %161
   %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
@@ -6578,8 +8024,8 @@ entry:
 
 ; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
-  br i1 %NullCheck4, label %172, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %171, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %172
 
 ; <label>:172                                     ; preds = %170
   %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
@@ -6589,8 +8035,8 @@ entry:
 
 ; <label>:176                                     ; preds = %172
   %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
-  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %177, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %178
 
 ; <label>:178                                     ; preds = %176
   %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
@@ -6629,55 +8075,55 @@ ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %161
+ThrowNullRef2:                                    ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %170
+ThrowNullRef4:                                    ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %176
+ThrowNullRef6:                                    ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %142
+ThrowNullRef8:                                    ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %144
+ThrowNullRef10:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %113
+ThrowNullRef12:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %116
+ThrowNullRef14:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %84
+ThrowNullRef16:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %87
+ThrowNullRef18:                                   ; preds = %87
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %55
+ThrowNullRef20:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %58
+ThrowNullRef22:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %26
+ThrowNullRef24:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %29
+ThrowNullRef26:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,8 +8161,8 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck, label %14, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %ThrowNullRef, label %14
 
 ; <label>:14                                      ; preds = %8
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
@@ -6760,8 +8206,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
@@ -6770,14 +8216,14 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32, i32* %loc0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %10
   %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
   %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
@@ -6790,15 +8236,15 @@ entry:
 ; <label>:25                                      ; preds = %19
   %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
-  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
   %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
@@ -6807,8 +8253,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %37 = load i32, i32* %loc0
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %38, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %38
 
 ; <label>:38                                      ; preds = %32
   %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
@@ -6817,14 +8263,14 @@ entry:
 
 ; <label>:40                                      ; preds = %19
   %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %40
   %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
   %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
-  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
-  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
@@ -6832,8 +8278,8 @@ entry:
   %48 = zext i32 %47 to i64
   %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
-  br i1 %NullCheck16, label %51, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %51
 
 ; <label>:51                                      ; preds = %45
   %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
@@ -6847,15 +8293,15 @@ entry:
 ; <label>:57                                      ; preds = %51
   %58 = load i16*, i16** %arg1
   %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
-  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %60
 
 ; <label>:60                                      ; preds = %57
   %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
   %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
-  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %64
 
 ; <label>:64                                      ; preds = %60
   %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
@@ -6864,22 +8310,22 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
   %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
-  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %70
 
 ; <label>:70                                      ; preds = %64
   %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
   %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
-  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
-  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
   %75 = load i32, i32 addrspace(1)* %74
   %76 = zext i32 %75 to i64
   %77 = trunc i64 %76 to i32
-  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
-  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %78
 
 ; <label>:78                                      ; preds = %73
   %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
@@ -6901,8 +8347,8 @@ entry:
   %90 = bitcast i16* %86 to i8*
   %91 = getelementptr inbounds i8, i8* %90, i64 %89
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %93
 
 ; <label>:93                                      ; preds = %80
   %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
@@ -6912,8 +8358,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %99 = load i32, i32* %loc2
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %100
 
 ; <label>:100                                     ; preds = %93
   %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
@@ -6928,63 +8374,63 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %25
+ThrowNullRef6:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %32
+ThrowNullRef10:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %40
+ThrowNullRef12:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %45
+ThrowNullRef16:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %57
+ThrowNullRef18:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %60
+ThrowNullRef20:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %64
+ThrowNullRef22:                                   ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %70
+ThrowNullRef24:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %73
+ThrowNullRef26:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %80
+ThrowNullRef28:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %93
+ThrowNullRef30:                                   ; preds = %93
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7004,8 +8450,8 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
@@ -7033,43 +8479,43 @@ entry:
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %14
   %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
   %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   %28 = load i32, i32 addrspace(1)* %27, align 8
   %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
-  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %30
 
 ; <label>:30                                      ; preds = %26
   %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
   %32 = load i32, i32 addrspace(1)* %31, align 8
   %33 = add i32 %28, %32
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %34
 
 ; <label>:34                                      ; preds = %30
   %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   store i32 %33, i32 addrspace(1)* %35
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
   store i32 0, i32 addrspace(1)* %38
   %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %40
 
 ; <label>:40                                      ; preds = %37
   %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
@@ -7082,8 +8528,8 @@ entry:
 
 ; <label>:47                                      ; preds = %40
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
@@ -7098,8 +8544,8 @@ entry:
   %54 = load i32, i32* %loc0
   %55 = sext i32 %54 to i64
   %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
-  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %57
 
 ; <label>:57                                      ; preds = %52
   %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
@@ -7110,68 +8556,35 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %14
+ThrowNullRef2:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %23
+ThrowNullRef4:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %26
+ThrowNullRef6:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %30
+ThrowNullRef8:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %34
+ThrowNullRef10:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %47
+ThrowNullRef14:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %52
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-}
-
-INFO:  jitting method StringBuilder::get_Length using LLILCJit
-Successfully read StringBuilder.get_Length
-
-define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.StringBuilder addrspace(1)*
-  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
-  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
-
-; <label>:1                                       ; preds = %entry
-  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %3 = load i32, i32 addrspace(1)* %2, align 8
-  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
-
-; <label>:5                                       ; preds = %1
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = add i32 %3, %7
-  ret i32 %8
-
-ThrowNullRef:                                     ; preds = %entry
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef16:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7213,70 +8626,70 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
   %6 = load i32, i32 addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
   store i32 %6, i32 addrspace(1)* %8
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
   %13 = load i32, i32 addrspace(1)* %12, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
   store i32 %13, i32 addrspace(1)* %15
   %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
-  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %18
 
 ; <label>:18                                      ; preds = %14
   %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
   %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
   %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
   %34 = load i32, i32 addrspace(1)* %33, align 8
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
-  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
@@ -7287,39 +8700,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %28
+ThrowNullRef16:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %32
+ThrowNullRef18:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7455,13 +8868,13 @@ entry:
 ; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
@@ -7477,16 +8890,16 @@ entry:
 
 ; <label>:18                                      ; preds = %15
   %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
   store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
   %22 = load i32, i32* %loc0
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %24
 
 ; <label>:24                                      ; preds = %20
   %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
@@ -7498,13 +8911,13 @@ entry:
 ; <label>:28                                      ; preds = %15, %24
   %29 = load i32, i32* %arg1
   %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %31
   %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
@@ -7517,20 +8930,20 @@ entry:
   %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
-  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
   %46 = load i32, i32 addrspace(1)* %45, align 8
   %47 = sub i32 %40, %46
-  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
-  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i32 addrspace(1)* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %48
 
 ; <label>:48                                      ; preds = %44
   store i32 %47, i32 addrspace(1)* %39, align 8
@@ -7538,21 +8951,21 @@ entry:
 
 ; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
-  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %51
 
 ; <label>:51                                      ; preds = %49
   %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %53
 
 ; <label>:53                                      ; preds = %51
   %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
   %55 = load i32, i32 addrspace(1)* %54, align 8
   %56 = load i32, i32* %arg2
   %57 = sub i32 %55, %56
-  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %58
 
 ; <label>:58                                      ; preds = %53
   %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
@@ -7562,13 +8975,13 @@ entry:
 ; <label>:60                                      ; preds = %33, %58
   %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
   %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
-  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %63
 
 ; <label>:63                                      ; preds = %60
   %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
-  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
-  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
@@ -7578,15 +8991,15 @@ entry:
 
 ; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
-  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i32 addrspace(1)* %69, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %70
 
 ; <label>:70                                      ; preds = %68
   %71 = load i32, i32 addrspace(1)* %69, align 8
   store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
-  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
@@ -7596,8 +9009,8 @@ entry:
   store i32 %77, i32* %loc4
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
-  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %80
 
 ; <label>:80                                      ; preds = %73
   %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
@@ -7607,71 +9020,71 @@ entry:
 ; <label>:83                                      ; preds = %80
   store i32 0, i32* %loc3
   %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
-  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
-  br i1 %NullCheck26, label %88, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i32 addrspace(1)* %87, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %88
 
 ; <label>:88                                      ; preds = %85
   %89 = load i32, i32 addrspace(1)* %87, align 8
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
-  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %90
 
 ; <label>:90                                      ; preds = %88
   %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
   store i32 %89, i32 addrspace(1)* %91
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
-  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
-  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %96
 
 ; <label>:96                                      ; preds = %94
   %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
-  br i1 %NullCheck34, label %100, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %100
 
 ; <label>:100                                     ; preds = %96
   %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
-  br i1 %NullCheck36, label %102, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %102
 
 ; <label>:102                                     ; preds = %100
   %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
   %104 = load i32, i32 addrspace(1)* %103, align 8
   %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
-  br i1 %NullCheck38, label %106, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %106
 
 ; <label>:106                                     ; preds = %102
   %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
-  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
-  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %108
 
 ; <label>:108                                     ; preds = %106
   %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
   %110 = load i32, i32 addrspace(1)* %109, align 8
   %111 = add i32 %104, %110
-  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %112
 
 ; <label>:112                                     ; preds = %108
   %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
   store i32 %111, i32 addrspace(1)* %113
   %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
-  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i32 addrspace(1)* %114, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %115
 
 ; <label>:115                                     ; preds = %112
   %116 = load i32, i32 addrspace(1)* %114, align 8
@@ -7681,19 +9094,19 @@ entry:
 ; <label>:118                                     ; preds = %115
   %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
-  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %121
 
 ; <label>:121                                     ; preds = %118
   %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
-  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
-  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %123
 
 ; <label>:123                                     ; preds = %121
   %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
   %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
-  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
-  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %126
 
 ; <label>:126                                     ; preds = %123
   %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
@@ -7705,8 +9118,8 @@ entry:
 
 ; <label>:130                                     ; preds = %80, %115, %126
   %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %132
 
 ; <label>:132                                     ; preds = %130
   %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7715,8 +9128,8 @@ entry:
   %136 = load i32, i32* %loc3
   %137 = sub i32 %135, %136
   %138 = sub i32 %134, %137
-  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %139
 
 ; <label>:139                                     ; preds = %132
   %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7728,16 +9141,16 @@ entry:
 
 ; <label>:144                                     ; preds = %139
   %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
-  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %146
 
 ; <label>:146                                     ; preds = %144
   %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
   %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
   %149 = load i32, i32* %loc2
   %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
-  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %151
 
 ; <label>:151                                     ; preds = %146
   %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
@@ -7754,145 +9167,249 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %18
+ThrowNullRef4:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %31
+ThrowNullRef10:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %44
+ThrowNullRef16:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %68
+ThrowNullRef18:                                   ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %70
+ThrowNullRef20:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %73
+ThrowNullRef22:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %83
+ThrowNullRef24:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %85
+ThrowNullRef26:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %88
+ThrowNullRef28:                                   ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %90
+ThrowNullRef30:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %94
+ThrowNullRef32:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %96
+ThrowNullRef34:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %100
+ThrowNullRef36:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %102
+ThrowNullRef38:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %106
+ThrowNullRef40:                                   ; preds = %106
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %108
+ThrowNullRef42:                                   ; preds = %108
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %112
+ThrowNullRef44:                                   ; preds = %112
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %118
+ThrowNullRef46:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %121
+ThrowNullRef48:                                   ; preds = %121
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %123
+ThrowNullRef50:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %130
+ThrowNullRef52:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %132
+ThrowNullRef54:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %144
+ThrowNullRef56:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %146
+ThrowNullRef58:                                   ; preds = %146
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %60
+ThrowNullRef60:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %63
+ThrowNullRef62:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %49
+ThrowNullRef64:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %51
+ThrowNullRef66:                                   ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %53
+ThrowNullRef68:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(%"System.Char[]" addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %arg0 = alloca %"System.Char[]" addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store %"System.Char[]" addrspace(1)* %param0, %"System.Char[]" addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load i32, i32* %arg4
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %43, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %38, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg1
+  %13 = load i32, i32* %arg4
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %38, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %24 = load i32, i32* %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %35 = load i32, i32* %arg3
+  %36 = load i32, i32* %arg4
+  %37 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %37, %"System.Char[]" addrspace(1)* %34, i32 %35, i32 %36)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:38                                      ; preds = %5, %16
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Successfully read Buffer._Memmove
 
@@ -7914,7 +9431,7 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[loadElem]
+Failed to read AppDomain.SetDataHelper[storeElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -7923,8 +9440,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
@@ -7934,8 +9451,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
@@ -7947,15 +9464,15 @@ entry:
   %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
   %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
@@ -7966,15 +9483,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7992,7 +9509,79 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
-Failed to read Dictionary`2.TryGetValue[loadElemA]
+Successfully read Dictionary`2.TryGetValue
+
+define i8 @"Dictionary`2.TryGetValue"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)* addrspace(1)* %param2) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  %arg2 = alloca %System.__Canon addrspace(1)* addrspace(1)*
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  store %System.__Canon addrspace(1)* addrspace(1)* %param2, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  store i32 %2, i32* %loc0
+  %3 = load i32, i32* %loc0
+  %4 = icmp slt i32 %3, 0
+  br i1 %4, label %22, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 2
+  %10 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %9, align 8
+  %11 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = zext i32 %11 to i64
+  %BoundsCheck = icmp uge i64 %16, %15
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 3, i32 %11
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %20, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %6, %System.__Canon addrspace(1)* %21)
+  ret i8 1
+
+; <label>:22                                      ; preds = %entry
+  %23 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %23, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -8058,8 +9647,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
@@ -8091,8 +9680,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
@@ -8171,15 +9760,15 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck, label %19, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %ThrowNullRef, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
   %21 = load i32, i32 addrspace(1)* %20
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
@@ -8202,7 +9791,7 @@ ThrowNullRef:                                     ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %19
+ThrowNullRef2:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8248,8 +9837,8 @@ entry:
   %0 = alloca %System.AppDomainHandle
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %1 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %1, i32 0, i32 15
@@ -8269,8 +9858,8 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
@@ -8286,7 +9875,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -8299,8 +9888,8 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -8327,8 +9916,8 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
@@ -8352,8 +9941,8 @@ entry:
   %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
   store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
@@ -8363,8 +9952,8 @@ entry:
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
@@ -8374,8 +9963,8 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %9
   %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
@@ -8384,8 +9973,8 @@ entry:
 
 ; <label>:18                                      ; preds = %3, %16
   %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
@@ -8397,15 +9986,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %18
+ThrowNullRef6:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8418,8 +10007,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
@@ -8453,15 +10042,15 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
@@ -8473,7 +10062,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8481,7 +10070,7 @@ ThrowNullRef1:                                    ; preds = %1
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
 Failed to read Dictionary`2.System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
@@ -8506,8 +10095,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
@@ -8524,8 +10113,8 @@ entry:
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -8544,7 +10133,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8577,8 +10166,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = load i64, i64* %arg2
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = trunc i32 %3 to i8
@@ -8634,46 +10223,46 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
   %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
-  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
-  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
-  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
@@ -8684,27 +10273,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %20
+ThrowNullRef12:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8717,8 +10306,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -8756,22 +10345,22 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
   %9 = load i64, i64 addrspace(1)* %8, align 8
   %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
   %13 = load i64, i64 addrspace(1)* %12, align 8
   %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %11
   %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
@@ -8788,11 +10377,11 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8882,8 +10471,8 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
@@ -8900,8 +10489,8 @@ entry:
 ; <label>:8                                       ; preds = %1
   %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
   %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
@@ -8911,15 +10500,15 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
   %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
   %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
-  br i1 %NullCheck6, label %21, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
@@ -8946,15 +10535,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8992,15 +10581,15 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
   store i8 %3, i8 addrspace(1)* %5
   %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
@@ -9011,7 +10600,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9027,8 +10616,8 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -9041,8 +10630,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
@@ -9058,7 +10647,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9080,8 +10669,8 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
@@ -9096,8 +10685,8 @@ entry:
 ; <label>:12                                      ; preds = %6
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
@@ -9112,8 +10701,8 @@ entry:
 ; <label>:21                                      ; preds = %15
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
@@ -9128,8 +10717,8 @@ entry:
 ; <label>:30                                      ; preds = %24
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %31, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
@@ -9144,8 +10733,8 @@ entry:
 ; <label>:39                                      ; preds = %33
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
-  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %40, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %42
 
 ; <label>:42                                      ; preds = %39
   %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
@@ -9164,19 +10753,19 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %21
+ThrowNullRef4:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %30
+ThrowNullRef6:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %39
+ThrowNullRef8:                                    ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9243,8 +10832,8 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
@@ -9264,57 +10853,57 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
   store i8 0, i8 addrspace(1)* %2
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
   store i8 0, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
   store i8 0, i8 addrspace(1)* %17
   %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
   store i8 0, i8 addrspace(1)* %20
   %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
-  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
@@ -9325,31 +10914,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %19
+ThrowNullRef14:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9367,8 +10956,8 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
@@ -9380,8 +10969,8 @@ entry:
 
 ; <label>:9                                       ; preds = %4
   %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %9
   %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
@@ -9395,7 +10984,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef2:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9420,8 +11009,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
@@ -9512,8 +11101,8 @@ entry:
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
@@ -9524,8 +11113,8 @@ entry:
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = load i64, i64 addrspace(1)* %12
@@ -9537,8 +11126,8 @@ entry:
   %20 = load i64, i64* %19
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
-  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %13
   %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
@@ -9555,8 +11144,8 @@ entry:
 ; <label>:30                                      ; preds = %25
   %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %32 = load i32, i32* %arg2
-  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
-  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
@@ -9570,15 +11159,15 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %30
+ThrowNullRef2:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9622,87 +11211,87 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
   %10 = load i8, i8 addrspace(1)* %9, align 8
   %11 = zext i8 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %8
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
   store i8 %12, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
   %19 = load i8, i8 addrspace(1)* %18, align 8
   %20 = zext i8 %19 to i32
   %21 = trunc i32 %20 to i8
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
   store i8 %21, i8 addrspace(1)* %23
   %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
   %28 = load i8, i8 addrspace(1)* %27, align 8
   %29 = zext i8 %28 to i32
   %30 = trunc i32 %29 to i8
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
-  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %31
 
 ; <label>:31                                      ; preds = %26
   %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
   store i8 %30, i8 addrspace(1)* %32
   %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
-  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
-  br i1 %NullCheck14, label %40, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %40
 
 ; <label>:40                                      ; preds = %35
   %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
   store i8 %39, i8 addrspace(1)* %41
   %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
-  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %44
 
 ; <label>:44                                      ; preds = %40
   %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
   %46 = load i8, i8 addrspace(1)* %45, align 8
   %47 = zext i8 %46 to i32
   %48 = trunc i32 %47 to i8
-  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
   store i8 %48, i8 addrspace(1)* %50
   %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
-  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
@@ -9713,29 +11302,29 @@ entry:
 ; <label>:56                                      ; preds = %52
   %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
-  br i1 %NullCheck22, label %59, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
   %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
   %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
-  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
-  br i1 %NullCheck24, label %63, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
   %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
-  br i1 %NullCheck26, label %66, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
   %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
-  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
-  br i1 %NullCheck28, label %69, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %69
 
 ; <label>:69                                      ; preds = %66
   %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
@@ -9744,15 +11333,15 @@ entry:
 
 ; <label>:71                                      ; preds = %105
   %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
-  br i1 %NullCheck34, label %73, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %73
 
 ; <label>:73                                      ; preds = %71
   %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
   %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
   %76 = load i32, i32* %loc0
-  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
-  br i1 %NullCheck36, label %77, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
@@ -9766,8 +11355,8 @@ entry:
 
 ; <label>:83                                      ; preds = %77
   %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
-  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
@@ -9775,14 +11364,14 @@ entry:
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
   %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
-  br i1 %NullCheck40, label %91, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
 ; <label>:91                                      ; preds = %85
   %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
   %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
-  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck42, label %94, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %94
 
 ; <label>:94                                      ; preds = %91
   %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
@@ -9798,14 +11387,14 @@ entry:
 ; <label>:99                                      ; preds = %69, %96
   %100 = load i32, i32* %loc0
   %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
-  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %102
 
 ; <label>:102                                     ; preds = %99
   %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
   %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
-  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
-  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
@@ -9819,87 +11408,87 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %26
+ThrowNullRef10:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %31
+ThrowNullRef12:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %35
+ThrowNullRef14:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %40
+ThrowNullRef16:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %56
+ThrowNullRef22:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %59
+ThrowNullRef24:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %63
+ThrowNullRef26:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %66
+ThrowNullRef28:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %102
+ThrowNullRef32:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %71
+ThrowNullRef34:                                   ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %73
+ThrowNullRef36:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %83
+ThrowNullRef38:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %85
+ThrowNullRef40:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %91
+ThrowNullRef42:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9943,15 +11532,15 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
   %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
@@ -9961,28 +11550,28 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
   %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %12
   %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
   %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
   %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
-  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
@@ -9993,23 +11582,23 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %12
+ThrowNullRef6:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10031,15 +11620,15 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
   %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = load i64, i64 addrspace(1)* %7
@@ -10077,13 +11666,13 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[loadElem]
+Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -10111,8 +11700,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -10226,8 +11815,8 @@ entry:
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load i64, i64* %arg0
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -10361,8 +11950,8 @@ entry:
   store i64 %param0, i64* %arg0
   store i64 %param1, i64* %arg1
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
@@ -10370,8 +11959,8 @@ entry:
   %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
   %5 = load i16*, i16* addrspace(1)* %4, align 8
   %6 = addrspacecast i64* %arg1 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = bitcast i64 addrspace(1)* %6 to i8 addrspace(1)*
@@ -10387,7 +11976,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10421,8 +12010,8 @@ entry:
   %1 = load i32, i32* %arg1
   %2 = sext i32 %1 to i64
   %3 = inttoptr i64 %2 to i16*
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -10475,8 +12064,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, i32)*)(%System.IO.ConsoleStream addrspace(1)* %2, i32 %1)
   %3 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %4 = load i64, i64* %arg1
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
@@ -10487,8 +12076,8 @@ entry:
   %10 = icmp eq i32 %9, 3
   %11 = sext i1 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %5
   %14 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, i32 0, i32 5
@@ -10499,7 +12088,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10522,8 +12111,8 @@ entry:
   %5 = icmp eq i32 %4, 1
   %6 = sext i1 %5 to i32
   %7 = trunc i32 %6 to i8
-  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %2, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.ConsoleStream addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
@@ -10534,8 +12123,8 @@ entry:
   %13 = icmp eq i32 %12, 2
   %14 = sext i1 %13 to i32
   %15 = trunc i32 %14 to i8
-  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %10, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.ConsoleStream addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %8
   %17 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %10, i32 0, i32 4
@@ -10546,7 +12135,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10585,8 +12174,8 @@ entry:
   %arg0 = alloca i64
   store i64 %param0, i64* %arg0
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
@@ -10621,8 +12210,8 @@ entry:
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
   %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = load i64, i64 addrspace(1)* %7
@@ -10726,7 +12315,127 @@ entry:
 INFO:  jitting method Encoding::GetEncoding using LLILCJit
 Failed to read Encoding.GetEncoding[convertToHelperArgumentType]
 INFO:  jitting method EncodingProvider::GetEncodingFromProvider using LLILCJit
-Failed to read EncodingProvider.GetEncodingFromProvider[loadElem]
+Successfully read EncodingProvider.GetEncodingFromProvider
+
+define %System.Text.Encoding addrspace(1)* @EncodingProvider.GetEncodingFromProvider(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca %"System.Text.EncodingProvider[]" addrspace(1)*
+  %loc1 = alloca %System.Text.EncodingProvider addrspace(1)*
+  %loc2 = alloca %System.Text.Encoding addrspace(1)*
+  %loc3 = alloca %System.Text.Encoding addrspace(1)*
+  %loc4 = alloca %"System.Text.EncodingProvider[]" addrspace(1)*
+  %loc5 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1059)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2392
+  %2 = addrspacecast i8 addrspace(1)* %1 to %"System.Text.EncodingProvider[]" addrspace(1)**
+  %3 = load volatile %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %2
+  %4 = icmp ne %"System.Text.EncodingProvider[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %entry
+  ret %System.Text.Encoding addrspace(1)* null
+
+; <label>:6                                       ; preds = %entry
+  %7 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1059)
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i64 2392
+  %9 = addrspacecast i8 addrspace(1)* %8 to %"System.Text.EncodingProvider[]" addrspace(1)**
+  %10 = load volatile %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %9
+  store %"System.Text.EncodingProvider[]" addrspace(1)* %10, %"System.Text.EncodingProvider[]" addrspace(1)** %loc0
+  %11 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc0
+  store %"System.Text.EncodingProvider[]" addrspace(1)* %11, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  store i32 0, i32* %loc5
+  br label %43
+
+; <label>:12                                      ; preds = %46
+  %13 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  %14 = load i32, i32* %loc5
+  %NullCheck1 = icmp eq %"System.Text.EncodingProvider[]" addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %13, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = zext i32 %17 to i64
+  %19 = zext i32 %14 to i64
+  %BoundsCheck = icmp uge i64 %19, %18
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %20
+
+; <label>:20                                      ; preds = %15
+  %21 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %13, i32 0, i32 3, i32 %14
+  %22 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)* addrspace(1)* %21, align 8
+  store %System.Text.EncodingProvider addrspace(1)* %22, %System.Text.EncodingProvider addrspace(1)** %loc1
+  %23 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)** %loc1
+  %24 = load i32, i32* %arg0
+  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i64 addrspace(1)*
+  %NullCheck3 = icmp eq i64 addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
+
+; <label>:26                                      ; preds = %20
+  %27 = load i64, i64 addrspace(1)* %25
+  %28 = add i64 %27, 64
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 40
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Text.Encoding addrspace(1)* (%System.Text.EncodingProvider addrspace(1)*, i32)*
+  %35 = call %System.Text.Encoding addrspace(1)* %34(%System.Text.EncodingProvider addrspace(1)* %23, i32 %24)
+  store %System.Text.Encoding addrspace(1)* %35, %System.Text.Encoding addrspace(1)** %loc2
+  %36 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc2
+  %37 = icmp eq %System.Text.Encoding addrspace(1)* %36, null
+  br i1 %37, label %40, label %38
+
+; <label>:38                                      ; preds = %26
+  %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc2
+  store %System.Text.Encoding addrspace(1)* %39, %System.Text.Encoding addrspace(1)** %loc3
+  br label %53
+
+; <label>:40                                      ; preds = %26
+  %41 = load i32, i32* %loc5
+  %42 = add i32 %41, 1
+  store i32 %42, i32* %loc5
+  br label %43
+
+; <label>:43                                      ; preds = %6, %40
+  %44 = load i32, i32* %loc5
+  %45 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  %NullCheck = icmp eq %"System.Text.EncodingProvider[]" addrspace(1)* %45, null
+  br i1 %NullCheck, label %ThrowNullRef, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp slt i32 %44, %50
+  br i1 %51, label %12, label %52
+
+; <label>:52                                      ; preds = %46
+  ret %System.Text.Encoding addrspace(1)* null
+
+; <label>:53                                      ; preds = %38
+  %54 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc3
+  ret %System.Text.Encoding addrspace(1)* %54
+
+ThrowNullRef:                                     ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method EncodingProvider::.cctor using LLILCJit
 Successfully read EncodingProvider..cctor
 
@@ -10745,7 +12454,7 @@ Failed to read Encoding.get_InternalSyncObject[Call HasTypeArg]
 INFO:  jitting method Hashtable::.ctor using LLILCJit
 Failed to read Hashtable..ctor[Volatile store]
 INFO:  jitting method Hashtable::get_Item using LLILCJit
-Failed to read Hashtable.get_Item[loadElemA]
+Failed to read Hashtable.get_Item[loadNonPrimitiveObj]
 INFO:  jitting method Hashtable::InitHash using LLILCJit
 Successfully read Hashtable.InitHash
 
@@ -10765,8 +12474,8 @@ entry:
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -10782,15 +12491,15 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
   %15 = load i32, i32* %loc0
-  %NullCheck2 = icmp ne i32 addrspace(1)* %14, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i32 addrspace(1)* %14, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %3
   store i32 %15, i32 addrspace(1)* %14, align 8
   %17 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %18 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %NullCheck4 = icmp ne i32 addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i32 addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = load i32, i32 addrspace(1)* %18, align 8
@@ -10799,8 +12508,8 @@ entry:
   %23 = sub i32 %22, 1
   %24 = urem i32 %21, %23
   %25 = add i32 1, %24
-  %NullCheck6 = icmp ne i32 addrspace(1)* %17, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32 addrspace(1)* %17, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %19
   store i32 %25, i32 addrspace(1)* %17, align 8
@@ -10811,15 +12520,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %19
+ThrowNullRef6:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10834,8 +12543,8 @@ entry:
   store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
   store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %NullCheck = icmp ne %System.Collections.Hashtable addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Collections.Hashtable addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
@@ -10845,16 +12554,16 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Collections.Hashtable addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Collections.Hashtable addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
   %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck4 = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %9, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
   %13 = inttoptr i64 %11 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
@@ -10864,8 +12573,8 @@ entry:
 ; <label>:15                                      ; preds = %1
   %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -10883,15 +12592,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10905,8 +12614,8 @@ entry:
   store %System.Int32 addrspace(1)* %param0, %System.Int32 addrspace(1)** %this
   %0 = load %System.Int32 addrspace(1)*, %System.Int32 addrspace(1)** %this
   %1 = bitcast %System.Int32 addrspace(1)* %0 to i32 addrspace(1)*
-  %NullCheck = icmp ne i32 addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq i32 addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load i32, i32 addrspace(1)* %1, align 8
@@ -10982,8 +12691,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.UTF8Encoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
@@ -10992,15 +12701,15 @@ entry:
   %9 = load i8, i8* %arg2
   %10 = zext i8 %9 to i32
   %11 = trunc i32 %10 to i8
-  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %8, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %6
   %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %8, i32 0, i32 8
   store i8 %11, i8 addrspace(1)* %13
   %14 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %14, i32 0, i32 8
@@ -11012,8 +12721,8 @@ entry:
 ; <label>:20                                      ; preds = %15
   %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %22, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %22, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = load i64, i64 addrspace(1)* %22
@@ -11035,15 +12744,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %12
+ThrowNullRef4:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11058,8 +12767,8 @@ entry:
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
@@ -11081,16 +12790,16 @@ entry:
 ; <label>:10                                      ; preds = %1
   %11 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
   %12 = load i32, i32* %arg1
-  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %11, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.Encoding addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
   store i32 %12, i32 addrspace(1)* %14
   %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
   %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = load i64, i64 addrspace(1)* %16
@@ -11108,11 +12817,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11125,8 +12834,8 @@ entry:
   %this = alloca %System.Text.UTF8Encoding addrspace(1)*
   store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
   %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.UTF8Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
@@ -11138,16 +12847,16 @@ entry:
 ; <label>:6                                       ; preds = %1
   %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %8 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %10, %System.Text.EncoderFallback addrspace(1)* %8)
   %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %12 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
-  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %11, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %11, i32 0, i32 3
@@ -11160,8 +12869,8 @@ entry:
   %18 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %18, %System.String addrspace(1)* %17)
   %19 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %18 to %System.Text.EncoderFallback addrspace(1)*
-  %NullCheck6 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %16, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %16, i32 0, i32 2
@@ -11171,8 +12880,8 @@ entry:
   %24 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %24, %System.String addrspace(1)* %23)
   %25 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %24 to %System.Text.DecoderFallback addrspace(1)*
-  %NullCheck8 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %22, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %22, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %20
   %27 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %22, i32 0, i32 3
@@ -11183,19 +12892,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %20
+ThrowNullRef8:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11225,8 +12934,8 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load i32, i32* %arg1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -11244,8 +12953,8 @@ entry:
 ; <label>:15                                      ; preds = %8
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %17 = load i32, i32* %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 %17
@@ -11261,7 +12970,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11313,7 +13022,7 @@ entry:
 }
 
 INFO:  jitting method Hashtable::Insert using LLILCJit
-Failed to read Hashtable.Insert[loadElemA]
+Failed to read Hashtable.Insert[storeElem]
 INFO:  jitting method ConsoleEncoding::.ctor using LLILCJit
 Successfully read ConsoleEncoding..ctor
 
@@ -11328,8 +13037,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %1)
   %2 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
@@ -11365,8 +13074,8 @@ entry:
   %2 = call %System.Text.InternalEncoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalEncoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %1)
   %3 = bitcast %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2 to %System.Text.EncoderFallback addrspace(1)*
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
@@ -11376,8 +13085,8 @@ entry:
   %8 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %7)
   %9 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %8 to %System.Text.DecoderFallback addrspace(1)*
-  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %6, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.Encoding addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %4
   %11 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %6, i32 0, i32 3
@@ -11388,7 +13097,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11407,15 +13116,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* %1)
   %2 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   %6 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, i32 0, i32 1
@@ -11426,7 +13135,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11454,8 +13163,8 @@ entry:
   store %System.Text.InternalDecoderBestFitFallback addrspace(1)* %param0, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
   %0 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
@@ -11465,15 +13174,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %4)
   %5 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %6)
   %9 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, i32 0, i32 1
@@ -11484,11 +13193,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11556,8 +13265,8 @@ entry:
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
   %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = load i64, i64 addrspace(1)* %19
@@ -11621,8 +13330,8 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.ConsoleStream addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
@@ -11653,31 +13362,31 @@ entry:
   store i8 %param4, i8* %arg4
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %3, %System.IO.Stream addrspace(1)* %1)
   %4 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %4, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
   %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %4, i32 0, i32 4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %5)
   %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %6
   %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
   %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
   %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = load i64, i64 addrspace(1)* %13
@@ -11689,8 +13398,8 @@ entry:
   %21 = load i64, i64* %20
   %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %8, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %8, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %14
   %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 5
@@ -11708,24 +13417,24 @@ entry:
   %31 = load i32, i32* %arg3
   %32 = sext i32 %31 to i64
   %33 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %32)
-  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %30, null
-  br i1 %NullCheck10, label %34, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.StreamWriter addrspace(1)* %30, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %35, %"System.Char[]" addrspace(1)* %33)
   %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %37, null
-  br i1 %NullCheck12, label %38, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.StreamWriter addrspace(1)* %37, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %38
 
 ; <label>:38                                      ; preds = %34
   %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
   %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
   %41 = load i32, i32* %arg3
   %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %42, null
-  br i1 %NullCheck14, label %43, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %42, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
   %44 = load i64, i64 addrspace(1)* %42
@@ -11739,30 +13448,30 @@ entry:
   %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
   %53 = sext i32 %52 to i64
   %54 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %53)
-  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
-  br i1 %NullCheck16, label %55, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %55
 
 ; <label>:55                                      ; preds = %43
   %56 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %56, %"System.Byte[]" addrspace(1)* %54)
   %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %58 = load i32, i32* %arg3
-  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %57, null
-  br i1 %NullCheck18, label %59, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.StreamWriter addrspace(1)* %57, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %59
 
 ; <label>:59                                      ; preds = %55
   %60 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 10
   store i32 %58, i32 addrspace(1)* %60
   %61 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %61, null
-  br i1 %NullCheck20, label %62, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.IO.StreamWriter addrspace(1)* %61, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %62
 
 ; <label>:62                                      ; preds = %59
   %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
   %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
   %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
   %67 = load i64, i64 addrspace(1)* %65
@@ -11780,15 +13489,15 @@ entry:
 
 ; <label>:78                                      ; preds = %66
   %79 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %79, null
-  br i1 %NullCheck24, label %80, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.StreamWriter addrspace(1)* %79, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %80
 
 ; <label>:80                                      ; preds = %78
   %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
   %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
   %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %83, null
-  br i1 %NullCheck26, label %84, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %83, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
   %85 = load i64, i64 addrspace(1)* %83
@@ -11805,8 +13514,8 @@ entry:
 
 ; <label>:95                                      ; preds = %84
   %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.IO.StreamWriter addrspace(1)* %96, null
-  br i1 %NullCheck28, label %97, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.IO.StreamWriter addrspace(1)* %96, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %97
 
 ; <label>:97                                      ; preds = %95
   %98 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 12
@@ -11820,8 +13529,8 @@ entry:
   %103 = icmp eq i32 %102, 0
   %104 = sext i1 %103 to i32
   %105 = trunc i32 %104 to i8
-  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %100, null
-  br i1 %NullCheck30, label %106, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.IO.StreamWriter addrspace(1)* %100, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %106
 
 ; <label>:106                                     ; preds = %99
   %107 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %100, i32 0, i32 13
@@ -11832,63 +13541,63 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %6
+ThrowNullRef4:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %29
+ThrowNullRef10:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %34
+ThrowNullRef12:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %38
+ThrowNullRef14:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %43
+ThrowNullRef16:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %55
+ThrowNullRef18:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %59
+ThrowNullRef20:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %62
+ThrowNullRef22:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %78
+ThrowNullRef24:                                   ; preds = %78
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %80
+ThrowNullRef26:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %95
+ThrowNullRef28:                                   ; preds = %95
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11901,15 +13610,15 @@ entry:
   %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = load i64, i64 addrspace(1)* %4
@@ -11927,7 +13636,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11977,35 +13686,35 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
   %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderNLS addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %7 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.EncoderNLS addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Text.Encoding addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.Encoding addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Text.EncoderNLS addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.EncoderNLS addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
   %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck8 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = load i64, i64 addrspace(1)* %16
@@ -12024,19 +13733,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12062,8 +13771,8 @@ entry:
   %this = alloca %System.Text.Encoding addrspace(1)*
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
@@ -12083,15 +13792,15 @@ entry:
   %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
   store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
   %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
   store i32 0, i32 addrspace(1)* %2
   %3 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, i32 0, i32 2
@@ -12101,15 +13810,15 @@ entry:
 
 ; <label>:8                                       ; preds = %4
   %9 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
   %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
   %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = load i64, i64 addrspace(1)* %13
@@ -12130,15 +13839,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12153,16 +13862,16 @@ entry:
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = load i32, i32* %arg1
   %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
   %7 = load i64, i64 addrspace(1)* %5
@@ -12180,7 +13889,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12217,8 +13926,8 @@ entry:
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
   %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
   %16 = load i64, i64 addrspace(1)* %14
@@ -12239,8 +13948,8 @@ entry:
   %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
   %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
   %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %31, null
-  br i1 %NullCheck2, label %32, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = load i64, i64 addrspace(1)* %31
@@ -12283,7 +13992,7 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12296,14 +14005,14 @@ entry:
   %this = alloca %System.Text.EncoderReplacementFallback addrspace(1)*
   store %System.Text.EncoderReplacementFallback addrspace(1)* %param0, %System.Text.EncoderReplacementFallback addrspace(1)** %this
   %0 = load %System.Text.EncoderReplacementFallback addrspace(1)*, %System.Text.EncoderReplacementFallback addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -12314,7 +14023,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12344,8 +14053,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
@@ -12377,8 +14086,8 @@ entry:
   %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
   store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
@@ -12390,8 +14099,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Threading.Tasks.Task addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %7)
@@ -12414,7 +14123,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12433,8 +14142,8 @@ entry:
   store i8 %param1, i8* %arg1
   store i8 %param2, i8* %arg2
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
@@ -12448,8 +14157,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1, %5
   %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 9
@@ -12480,8 +14189,8 @@ entry:
 
 ; <label>:25                                      ; preds = %8, %20
   %26 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %26, null
-  br i1 %NullCheck4, label %27, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %26, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %26, i32 0, i32 12
@@ -12492,22 +14201,22 @@ entry:
 
 ; <label>:32                                      ; preds = %27
   %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %33, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.IO.StreamWriter addrspace(1)* %33, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %32
   %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 12
   store i8 1, i8 addrspace(1)* %35
   %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
-  br i1 %NullCheck8, label %37, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
   %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
   %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck10 = icmp ne i64 addrspace(1)* %40, null
-  br i1 %NullCheck10, label %41, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64 addrspace(1)* %40, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i64, i64 addrspace(1)* %40
@@ -12521,8 +14230,8 @@ entry:
   %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
   store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
   %51 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %NullCheck12 = icmp ne %"System.Byte[]" addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Byte[]" addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %41
   %53 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %51, i32 0, i32 1
@@ -12534,16 +14243,16 @@ entry:
 
 ; <label>:58                                      ; preds = %52
   %59 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %59, null
-  br i1 %NullCheck14, label %60, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.IO.StreamWriter addrspace(1)* %59, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %60
 
 ; <label>:60                                      ; preds = %58
   %61 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %59, i32 0, i32 3
   %62 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
   %64 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %NullCheck16 = icmp ne %"System.Byte[]" addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %"System.Byte[]" addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %60
   %66 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %64, i32 0, i32 1
@@ -12551,8 +14260,8 @@ entry:
   %68 = zext i32 %67 to i64
   %69 = trunc i64 %68 to i32
   %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck18, label %71, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
   %72 = load i64, i64 addrspace(1)* %70
@@ -12568,29 +14277,29 @@ entry:
 
 ; <label>:80                                      ; preds = %27, %52, %71
   %81 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %81, null
-  br i1 %NullCheck20, label %82, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.IO.StreamWriter addrspace(1)* %81, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
 
 ; <label>:82                                      ; preds = %80
   %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %81, i32 0, i32 5
   %84 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %83, align 8
   %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.IO.StreamWriter addrspace(1)* %85, null
-  br i1 %NullCheck22, label %86, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.IO.StreamWriter addrspace(1)* %85, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %86
 
 ; <label>:86                                      ; preds = %82
   %87 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 7
   %88 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %87, align 8
   %89 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %89, null
-  br i1 %NullCheck24, label %90, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.StreamWriter addrspace(1)* %89, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %90
 
 ; <label>:90                                      ; preds = %86
   %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %89, i32 0, i32 9
   %92 = load i32, i32 addrspace(1)* %91, align 8
   %93 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.IO.StreamWriter addrspace(1)* %93, null
-  br i1 %NullCheck26, label %94, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.IO.StreamWriter addrspace(1)* %93, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %93, i32 0, i32 6
@@ -12598,8 +14307,8 @@ entry:
   %97 = load i8, i8* %arg2
   %98 = zext i8 %97 to i32
   %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
-  %NullCheck28 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck28, label %100, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
   %101 = load i64, i64 addrspace(1)* %99
@@ -12614,8 +14323,8 @@ entry:
   %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
   store i32 %110, i32* %loc1
   %111 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %111, null
-  br i1 %NullCheck30, label %112, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.IO.StreamWriter addrspace(1)* %111, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %112
 
 ; <label>:112                                     ; preds = %100
   %113 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %111, i32 0, i32 9
@@ -12626,23 +14335,23 @@ entry:
 
 ; <label>:116                                     ; preds = %112
   %117 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck32 = icmp ne %System.IO.StreamWriter addrspace(1)* %117, null
-  br i1 %NullCheck32, label %118, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.IO.StreamWriter addrspace(1)* %117, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %118
 
 ; <label>:118                                     ; preds = %116
   %119 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %117, i32 0, i32 3
   %120 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %119, align 8
   %121 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.IO.StreamWriter addrspace(1)* %121, null
-  br i1 %NullCheck34, label %122, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.IO.StreamWriter addrspace(1)* %121, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %122
 
 ; <label>:122                                     ; preds = %118
   %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
   %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
   %125 = load i32, i32* %loc1
   %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
-  %NullCheck36 = icmp ne i64 addrspace(1)* %126, null
-  br i1 %NullCheck36, label %127, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64 addrspace(1)* %126, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
   %128 = load i64, i64 addrspace(1)* %126
@@ -12664,15 +14373,15 @@ entry:
 
 ; <label>:140                                     ; preds = %136
   %141 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.IO.StreamWriter addrspace(1)* %141, null
-  br i1 %NullCheck38, label %142, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.IO.StreamWriter addrspace(1)* %141, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %142
 
 ; <label>:142                                     ; preds = %140
   %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
   %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
   %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
-  %NullCheck40 = icmp ne i64 addrspace(1)* %145, null
-  br i1 %NullCheck40, label %146, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i64 addrspace(1)* %145, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
   %147 = load i64, i64 addrspace(1)* %145
@@ -12693,83 +14402,83 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %25
+ThrowNullRef4:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %32
+ThrowNullRef6:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %37
+ThrowNullRef10:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %41
+ThrowNullRef12:                                   ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %58
+ThrowNullRef14:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %60
+ThrowNullRef16:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %65
+ThrowNullRef18:                                   ; preds = %65
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %80
+ThrowNullRef20:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %82
+ThrowNullRef22:                                   ; preds = %82
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %86
+ThrowNullRef24:                                   ; preds = %86
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %90
+ThrowNullRef26:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %94
+ThrowNullRef28:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %100
+ThrowNullRef30:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %116
+ThrowNullRef32:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %118
+ThrowNullRef34:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %122
+ThrowNullRef36:                                   ; preds = %122
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %140
+ThrowNullRef38:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %142
+ThrowNullRef40:                                   ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12836,8 +14545,8 @@ entry:
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %1 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
-  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
@@ -12845,8 +14554,8 @@ entry:
   %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
   %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
   %8 = load i64, i64 addrspace(1)* %6
@@ -12862,8 +14571,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %17, %System.IFormatProvider addrspace(1)* %16)
   %18 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %19 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %18, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.SyncTextWriter addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %7
   %21 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %18, i32 0, i32 4
@@ -12874,11 +14583,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12891,8 +14600,8 @@ entry:
   %this = alloca %System.IO.TextWriter addrspace(1)*
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.TextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
@@ -12902,8 +14611,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.Threading.Thread addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Threading.Thread addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %6)
@@ -12912,8 +14621,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1
   %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.TextWriter addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.TextWriter addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %11, i32 0, i32 2
@@ -12924,11 +14633,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13125,8 +14834,8 @@ entry:
   store i64 %param1, i64* %arg1
   store i8 0, i8* %loc1
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
@@ -13136,16 +14845,16 @@ entry:
   %5 = addrspacecast i8* %loc1 to i8 addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %4, i8 addrspace(1)* %5)
   %6 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.SyncTextWriter addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
   %10 = load i64, i64* %arg1
   %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
   %13 = load i64, i64 addrspace(1)* %11
@@ -13180,11 +14889,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13201,8 +14910,8 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load i64, i64* %arg1
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -13216,8 +14925,8 @@ entry:
   call void %11(%System.IO.TextWriter addrspace(1)* %0, i64 %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
   %15 = load i64, i64 addrspace(1)* %13
@@ -13235,7 +14944,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13253,8 +14962,8 @@ entry:
   %1 = addrspacecast i64* %arg1 to i64 addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -13269,8 +14978,8 @@ entry:
   %14 = bitcast i64 addrspace(1)* %1 to %System.Int64 addrspace(1)*
   %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Int64 addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Int64 addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
   %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
   %18 = load i64, i64 addrspace(1)* %16
@@ -13288,7 +14997,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13304,8 +15013,8 @@ entry:
   store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
   %0 = load %System.Int64 addrspace(1)*, %System.Int64 addrspace(1)** %this
   %1 = bitcast %System.Int64 addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load i64, i64 addrspace(1)* %1, align 8
@@ -13330,8 +15039,8 @@ entry:
   %loc0 = alloca %System.Globalization.NumberFormatInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 3
@@ -13341,8 +15050,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
@@ -13352,24 +15061,24 @@ entry:
   store %System.Globalization.NumberFormatInfo addrspace(1)* %10, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
   %11 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %7
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
   %15 = load i8, i8 addrspace(1)* %14, align 8
   %16 = zext i8 %15 to i32
   %17 = trunc i32 %16 to i8
-  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %11, null
-  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %11, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %13
   %19 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %11, i32 0, i32 29
   store i8 %17, i8 addrspace(1)* %19
   %20 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %21 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %20, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %20, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %18
   %23 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %20, i32 0, i32 3
@@ -13378,8 +15087,8 @@ entry:
 
 ; <label>:24                                      ; preds = %1, %22
   %25 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %25, null
-  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %25, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %26
 
 ; <label>:26                                      ; preds = %24
   %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %25, i32 0, i32 3
@@ -13390,23 +15099,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %18
+ThrowNullRef8:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13431,168 +15140,168 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 18
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %8, align 8
-  %NullCheck2 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %5, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %5, i32 0, i32 4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %9)
   %12 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 19
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %15, align 8
-  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %12, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %12, i32 0, i32 5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %16)
   %19 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %20 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %20, null
-  br i1 %NullCheck8, label %21, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %20, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %20, i32 0, i32 23
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  %NullCheck10 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %19, null
-  br i1 %NullCheck10, label %24, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %19, i32 0, i32 7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %25, %System.String addrspace(1)* %23)
   %26 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %27 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %27, i32 0, i32 22
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %29, align 8
-  %NullCheck14 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %26, null
-  br i1 %NullCheck14, label %31, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %26, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %26, i32 0, i32 6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %32, %System.String addrspace(1)* %30)
   %33 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %34 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Globalization.CultureData addrspace(1)* %34, null
-  br i1 %NullCheck16, label %35, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Globalization.CultureData addrspace(1)* %34, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %34, i32 0, i32 51
   %37 = load i32, i32 addrspace(1)* %36, align 8
-  %NullCheck18 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %33, null
-  br i1 %NullCheck18, label %38, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %33, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %33, i32 0, i32 21
   store i32 %37, i32 addrspace(1)* %39
   %40 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %41 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Globalization.CultureData addrspace(1)* %41, null
-  br i1 %NullCheck20, label %42, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Globalization.CultureData addrspace(1)* %41, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %41, i32 0, i32 52
   %44 = load i32, i32 addrspace(1)* %43, align 8
-  %NullCheck22 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %40, null
-  br i1 %NullCheck22, label %45, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %40, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %40, i32 0, i32 25
   store i32 %44, i32 addrspace(1)* %46
   %47 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %48 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.Globalization.CultureData addrspace(1)* %48, null
-  br i1 %NullCheck24, label %49, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Globalization.CultureData addrspace(1)* %48, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %49
 
 ; <label>:49                                      ; preds = %45
   %50 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %48, i32 0, i32 29
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck26 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %47, null
-  br i1 %NullCheck26, label %52, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %47, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %47, i32 0, i32 10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %53, %System.String addrspace(1)* %51)
   %54 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %55 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Globalization.CultureData addrspace(1)* %55, null
-  br i1 %NullCheck28, label %56, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Globalization.CultureData addrspace(1)* %55, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %56
 
 ; <label>:56                                      ; preds = %52
   %57 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %55, i32 0, i32 35
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %57, align 8
-  %NullCheck30 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %54, null
-  br i1 %NullCheck30, label %59, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %54, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %54, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %60, %System.String addrspace(1)* %58)
   %61 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %62 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck32 = icmp ne %System.Globalization.CultureData addrspace(1)* %62, null
-  br i1 %NullCheck32, label %63, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Globalization.CultureData addrspace(1)* %62, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %62, i32 0, i32 34
   %65 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %64, align 8
-  %NullCheck34 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %61, null
-  br i1 %NullCheck34, label %66, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %61, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %61, i32 0, i32 9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %67, %System.String addrspace(1)* %65)
   %68 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %69 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck36 = icmp ne %System.Globalization.CultureData addrspace(1)* %69, null
-  br i1 %NullCheck36, label %70, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Globalization.CultureData addrspace(1)* %69, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %70
 
 ; <label>:70                                      ; preds = %66
   %71 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %69, i32 0, i32 55
   %72 = load i32, i32 addrspace(1)* %71, align 8
-  %NullCheck38 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %68, null
-  br i1 %NullCheck38, label %73, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %68, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %68, i32 0, i32 22
   store i32 %72, i32 addrspace(1)* %74
   %75 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %76 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck40 = icmp ne %System.Globalization.CultureData addrspace(1)* %76, null
-  br i1 %NullCheck40, label %77, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Globalization.CultureData addrspace(1)* %76, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %76, i32 0, i32 57
   %79 = load i32, i32 addrspace(1)* %78, align 8
-  %NullCheck42 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %75, null
-  br i1 %NullCheck42, label %80, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %75, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %80
 
 ; <label>:80                                      ; preds = %77
   %81 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %75, i32 0, i32 24
   store i32 %79, i32 addrspace(1)* %81
   %82 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %83 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck44 = icmp ne %System.Globalization.CultureData addrspace(1)* %83, null
-  br i1 %NullCheck44, label %84, label %ThrowNullRef43
+  %NullCheck43 = icmp eq %System.Globalization.CultureData addrspace(1)* %83, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %84
 
 ; <label>:84                                      ; preds = %80
   %85 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %83, i32 0, i32 56
   %86 = load i32, i32 addrspace(1)* %85, align 8
-  %NullCheck46 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %82, null
-  br i1 %NullCheck46, label %87, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %82, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %82, i32 0, i32 23
@@ -13601,8 +15310,8 @@ entry:
 
 ; <label>:89                                      ; preds = %entry
   %90 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck100 = icmp ne %System.Globalization.CultureData addrspace(1)* %90, null
-  br i1 %NullCheck100, label %91, label %ThrowNullRef99
+  %NullCheck99 = icmp eq %System.Globalization.CultureData addrspace(1)* %90, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %91
 
 ; <label>:91                                      ; preds = %89
   %92 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %90, i32 0, i32 2
@@ -13620,8 +15329,8 @@ entry:
   %102 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %103 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %104 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %103)
-  %NullCheck48 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %102, null
-  br i1 %NullCheck48, label %105, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %102, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %105
 
 ; <label>:105                                     ; preds = %101
   %106 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %102, i32 0, i32 1
@@ -13629,8 +15338,8 @@ entry:
   %107 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %108 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %109 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %108)
-  %NullCheck50 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %107, null
-  br i1 %NullCheck50, label %110, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %107, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %110
 
 ; <label>:110                                     ; preds = %105
   %111 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %107, i32 0, i32 2
@@ -13638,8 +15347,8 @@ entry:
   %112 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %113 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %114 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %113)
-  %NullCheck52 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %112, null
-  br i1 %NullCheck52, label %115, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %112, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %115
 
 ; <label>:115                                     ; preds = %110
   %116 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %112, i32 0, i32 27
@@ -13647,8 +15356,8 @@ entry:
   %117 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %118 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %119 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %118)
-  %NullCheck54 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %117, null
-  br i1 %NullCheck54, label %120, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %117, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %120
 
 ; <label>:120                                     ; preds = %115
   %121 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %117, i32 0, i32 26
@@ -13656,8 +15365,8 @@ entry:
   %122 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %123 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %124 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %123)
-  %NullCheck56 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %122, null
-  br i1 %NullCheck56, label %125, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %122, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %125
 
 ; <label>:125                                     ; preds = %120
   %126 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %122, i32 0, i32 17
@@ -13665,8 +15374,8 @@ entry:
   %127 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %128 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %129 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %128)
-  %NullCheck58 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %127, null
-  br i1 %NullCheck58, label %130, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %127, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %130
 
 ; <label>:130                                     ; preds = %125
   %131 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %127, i32 0, i32 18
@@ -13674,8 +15383,8 @@ entry:
   %132 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %133 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %134 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %133)
-  %NullCheck60 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %132, null
-  br i1 %NullCheck60, label %135, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %132, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %135
 
 ; <label>:135                                     ; preds = %130
   %136 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %132, i32 0, i32 14
@@ -13683,8 +15392,8 @@ entry:
   %137 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %138 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %139 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %138)
-  %NullCheck62 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %137, null
-  br i1 %NullCheck62, label %140, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %137, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %140
 
 ; <label>:140                                     ; preds = %135
   %141 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %137, i32 0, i32 13
@@ -13692,71 +15401,71 @@ entry:
   %142 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %143 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %144 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %143)
-  %NullCheck64 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %142, null
-  br i1 %NullCheck64, label %145, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %142, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %145
 
 ; <label>:145                                     ; preds = %140
   %146 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %142, i32 0, i32 12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %146, %System.String addrspace(1)* %144)
   %147 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %148 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck66 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %148, null
-  br i1 %NullCheck66, label %149, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %148, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %149
 
 ; <label>:149                                     ; preds = %145
   %150 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %148, i32 0, i32 21
   %151 = load i32, i32 addrspace(1)* %150, align 8
-  %NullCheck68 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %147, null
-  br i1 %NullCheck68, label %152, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %147, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %152
 
 ; <label>:152                                     ; preds = %149
   %153 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %147, i32 0, i32 28
   store i32 %151, i32 addrspace(1)* %153
   %154 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %155 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck70 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %155, null
-  br i1 %NullCheck70, label %156, label %ThrowNullRef69
+  %NullCheck69 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %155, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %156
 
 ; <label>:156                                     ; preds = %152
   %157 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %155, i32 0, i32 6
   %158 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %157, align 8
-  %NullCheck72 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %154, null
-  br i1 %NullCheck72, label %159, label %ThrowNullRef71
+  %NullCheck71 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %154, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %159
 
 ; <label>:159                                     ; preds = %156
   %160 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %154, i32 0, i32 15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %160, %System.String addrspace(1)* %158)
   %161 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %162 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck74 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %162, null
-  br i1 %NullCheck74, label %163, label %ThrowNullRef73
+  %NullCheck73 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %162, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %163
 
 ; <label>:163                                     ; preds = %159
   %164 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %162, i32 0, i32 1
   %165 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %164, align 8
-  %NullCheck76 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %161, null
-  br i1 %NullCheck76, label %166, label %ThrowNullRef75
+  %NullCheck75 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %161, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %166
 
 ; <label>:166                                     ; preds = %163
   %167 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %161, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %167, %"System.Int32[]" addrspace(1)* %165)
   %168 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %169 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck78 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %169, null
-  br i1 %NullCheck78, label %170, label %ThrowNullRef77
+  %NullCheck77 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %169, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %170
 
 ; <label>:170                                     ; preds = %166
   %171 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %169, i32 0, i32 7
   %172 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %171, align 8
-  %NullCheck80 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %168, null
-  br i1 %NullCheck80, label %173, label %ThrowNullRef79
+  %NullCheck79 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %168, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %173
 
 ; <label>:173                                     ; preds = %170
   %174 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %168, i32 0, i32 16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %174, %System.String addrspace(1)* %172)
   %175 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck82 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %175, null
-  br i1 %NullCheck82, label %176, label %ThrowNullRef81
+  %NullCheck81 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %175, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %176
 
 ; <label>:176                                     ; preds = %173
   %177 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %175, i32 0, i32 4
@@ -13766,14 +15475,14 @@ entry:
 
 ; <label>:180                                     ; preds = %176
   %181 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck84 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %181, null
-  br i1 %NullCheck84, label %182, label %ThrowNullRef83
+  %NullCheck83 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %181, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %182
 
 ; <label>:182                                     ; preds = %180
   %183 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %181, i32 0, i32 4
   %184 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %183, align 8
-  %NullCheck86 = icmp ne %System.String addrspace(1)* %184, null
-  br i1 %NullCheck86, label %185, label %ThrowNullRef85
+  %NullCheck85 = icmp eq %System.String addrspace(1)* %184, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %185
 
 ; <label>:185                                     ; preds = %182
   %186 = getelementptr inbounds %System.String, %System.String addrspace(1)* %184, i32 0, i32 1
@@ -13784,8 +15493,8 @@ entry:
 ; <label>:189                                     ; preds = %176, %185
   %190 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck98 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %190, null
-  br i1 %NullCheck98, label %192, label %ThrowNullRef97
+  %NullCheck97 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %190, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %192
 
 ; <label>:192                                     ; preds = %189
   %193 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %190, i32 0, i32 4
@@ -13794,8 +15503,8 @@ entry:
 
 ; <label>:194                                     ; preds = %185, %192
   %195 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck88 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %195, null
-  br i1 %NullCheck88, label %196, label %ThrowNullRef87
+  %NullCheck87 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %195, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %196
 
 ; <label>:196                                     ; preds = %194
   %197 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %195, i32 0, i32 9
@@ -13805,14 +15514,14 @@ entry:
 
 ; <label>:200                                     ; preds = %196
   %201 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck90 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %201, null
-  br i1 %NullCheck90, label %202, label %ThrowNullRef89
+  %NullCheck89 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %201, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %202
 
 ; <label>:202                                     ; preds = %200
   %203 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %201, i32 0, i32 9
   %204 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %203, align 8
-  %NullCheck92 = icmp ne %System.String addrspace(1)* %204, null
-  br i1 %NullCheck92, label %205, label %ThrowNullRef91
+  %NullCheck91 = icmp eq %System.String addrspace(1)* %204, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %205
 
 ; <label>:205                                     ; preds = %202
   %206 = getelementptr inbounds %System.String, %System.String addrspace(1)* %204, i32 0, i32 1
@@ -13823,14 +15532,14 @@ entry:
 ; <label>:209                                     ; preds = %196, %205
   %210 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %211 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck94 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %211, null
-  br i1 %NullCheck94, label %212, label %ThrowNullRef93
+  %NullCheck93 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %211, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %212
 
 ; <label>:212                                     ; preds = %209
   %213 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %211, i32 0, i32 6
   %214 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %213, align 8
-  %NullCheck96 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %210, null
-  br i1 %NullCheck96, label %215, label %ThrowNullRef95
+  %NullCheck95 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %210, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %215
 
 ; <label>:215                                     ; preds = %212
   %216 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %210, i32 0, i32 9
@@ -13844,203 +15553,203 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %17
+ThrowNullRef8:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %21
+ThrowNullRef10:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %24
+ThrowNullRef12:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %28
+ThrowNullRef14:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %31
+ThrowNullRef16:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %35
+ThrowNullRef18:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %38
+ThrowNullRef20:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %42
+ThrowNullRef22:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %45
+ThrowNullRef24:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %49
+ThrowNullRef26:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %52
+ThrowNullRef28:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %56
+ThrowNullRef30:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %59
+ThrowNullRef32:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %63
+ThrowNullRef34:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %66
+ThrowNullRef36:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %70
+ThrowNullRef38:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %73
+ThrowNullRef40:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %77
+ThrowNullRef42:                                   ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %80
+ThrowNullRef44:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %84
+ThrowNullRef46:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %101
+ThrowNullRef48:                                   ; preds = %101
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %105
+ThrowNullRef50:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %110
+ThrowNullRef52:                                   ; preds = %110
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %115
+ThrowNullRef54:                                   ; preds = %115
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %120
+ThrowNullRef56:                                   ; preds = %120
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %125
+ThrowNullRef58:                                   ; preds = %125
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %130
+ThrowNullRef60:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %135
+ThrowNullRef62:                                   ; preds = %135
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %140
+ThrowNullRef64:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %145
+ThrowNullRef66:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %149
+ThrowNullRef68:                                   ; preds = %149
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %152
+ThrowNullRef70:                                   ; preds = %152
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %156
+ThrowNullRef72:                                   ; preds = %156
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %159
+ThrowNullRef74:                                   ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %163
+ThrowNullRef76:                                   ; preds = %163
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %166
+ThrowNullRef78:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %170
+ThrowNullRef80:                                   ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %173
+ThrowNullRef82:                                   ; preds = %173
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %180
+ThrowNullRef84:                                   ; preds = %180
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %182
+ThrowNullRef86:                                   ; preds = %182
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %194
+ThrowNullRef88:                                   ; preds = %194
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %200
+ThrowNullRef90:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %202
+ThrowNullRef92:                                   ; preds = %202
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %209
+ThrowNullRef94:                                   ; preds = %209
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %212
+ThrowNullRef96:                                   ; preds = %212
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %189
+ThrowNullRef98:                                   ; preds = %189
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %89
+ThrowNullRef100:                                  ; preds = %89
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14068,8 +15777,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 21
@@ -14082,8 +15791,8 @@ entry:
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 16)
   %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 21
@@ -14092,8 +15801,8 @@ entry:
 
 ; <label>:12                                      ; preds = %1, %10
   %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 21
@@ -14104,11 +15813,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %12
+ThrowNullRef4:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14124,8 +15833,8 @@ entry:
   store i32 %param1, i32* %arg1
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %1 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
@@ -14192,8 +15901,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 33
@@ -14206,8 +15915,8 @@ entry:
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 24)
   %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 33
@@ -14216,8 +15925,8 @@ entry:
 
 ; <label>:12                                      ; preds = %1, %10
   %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 33
@@ -14228,11 +15937,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %12
+ThrowNullRef4:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14245,8 +15954,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 53
@@ -14258,8 +15967,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 116)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 53
@@ -14268,8 +15977,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 53
@@ -14280,11 +15989,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14313,8 +16022,8 @@ entry:
 
 ; <label>:7                                       ; preds = %entry, %4
   %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %7
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 2
@@ -14338,8 +16047,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 54
@@ -14351,8 +16060,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 117)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
@@ -14361,8 +16070,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 54
@@ -14373,11 +16082,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14390,8 +16099,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 27
@@ -14403,8 +16112,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 118)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 27
@@ -14413,8 +16122,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 27
@@ -14425,11 +16134,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14442,8 +16151,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 28
@@ -14455,8 +16164,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 119)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 28
@@ -14465,8 +16174,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 28
@@ -14477,11 +16186,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14494,8 +16203,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 26
@@ -14507,8 +16216,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 107)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 26
@@ -14517,8 +16226,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 26
@@ -14529,11 +16238,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14546,8 +16255,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 25
@@ -14559,8 +16268,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 106)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 25
@@ -14569,8 +16278,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 25
@@ -14581,11 +16290,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14598,8 +16307,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 24
@@ -14611,8 +16320,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 105)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 24
@@ -14621,8 +16330,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 24
@@ -14633,11 +16342,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14662,8 +16371,8 @@ entry:
   %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %3)
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %2
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -14674,15 +16383,15 @@ entry:
 
 ; <label>:8                                       ; preds = %62
   %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 9
   %12 = load i32, i32 addrspace(1)* %11, align 8
   %13 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.IO.StreamWriter addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %13, i32 0, i32 10
@@ -14697,15 +16406,15 @@ entry:
 
 ; <label>:20                                      ; preds = %14, %18
   %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
   %24 = load i32, i32 addrspace(1)* %23, align 8
   %25 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %25, null
-  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.StreamWriter addrspace(1)* %25, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %25, i32 0, i32 9
@@ -14726,36 +16435,36 @@ entry:
   %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %37 = load i32, i32* %loc1
   %38 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.StreamWriter addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %35
   %40 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %38, i32 0, i32 7
   %41 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %40, align 8
   %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
-  br i1 %NullCheck14, label %43, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %39
   %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 9
   %45 = load i32, i32 addrspace(1)* %44, align 8
   %46 = load i32, i32* %loc2
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %36, null
-  br i1 %NullCheck16, label %47, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %36, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %47
 
 ; <label>:47                                      ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %36, i32 %37, %"System.Char[]" addrspace(1)* %41, i32 %45, i32 %46)
   %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
   %51 = load i32, i32 addrspace(1)* %50, align 8
   %52 = load i32, i32* %loc2
   %53 = add i32 %51, %52
-  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
-  br i1 %NullCheck20, label %54, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %54
 
 ; <label>:54                                      ; preds = %49
   %55 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
@@ -14777,8 +16486,8 @@ entry:
 
 ; <label>:65                                      ; preds = %62
   %66 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %66, null
-  br i1 %NullCheck2, label %67, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %66, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %67
 
 ; <label>:67                                      ; preds = %65
   %68 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %66, i32 0, i32 11
@@ -14799,49 +16508,259 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %65
+ThrowNullRef2:                                    ; preds = %65
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %20
+ThrowNullRef8:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %22
+ThrowNullRef10:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %35
+ThrowNullRef12:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %43
+ThrowNullRef16:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %47
+ThrowNullRef18:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method String::CopyTo using LLILCJit
-Failed to read String.CopyTo[loadElemA]
+Successfully read String.CopyTo
+
+define void @String.CopyTo(%System.String addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  %loc1 = alloca i16 addrspace(1)*
+  %loc2 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %1 = icmp ne %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg4
+  %7 = icmp sge i32 %6, 0
+  br i1 %7, label %13, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  unreachable
+
+; <label>:13                                      ; preds = %5
+  %14 = load i32, i32* %arg1
+  %15 = icmp sge i32 %14, 0
+  br i1 %15, label %21, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %18)
+  %20 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %20, %System.String addrspace(1)* %17, %System.String addrspace(1)* %19)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %20) #0
+  unreachable
+
+; <label>:21                                      ; preds = %13
+  %22 = load i32, i32* %arg4
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck, label %ThrowNullRef, label %24
+
+; <label>:24                                      ; preds = %21
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load i32, i32* %arg1
+  %28 = sub i32 %26, %27
+  %29 = icmp sle i32 %22, %28
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34, %System.String addrspace(1)* %31, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %24
+  %36 = load i32, i32* %arg3
+  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %37, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
+
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
+  %40 = load i32, i32 addrspace(1)* %39
+  %41 = zext i32 %40 to i64
+  %42 = trunc i64 %41 to i32
+  %43 = load i32, i32* %arg4
+  %44 = sub i32 %42, %43
+  %45 = icmp sgt i32 %36, %44
+  br i1 %45, label %49, label %46
+
+; <label>:46                                      ; preds = %38
+  %47 = load i32, i32* %arg3
+  %48 = icmp sge i32 %47, 0
+  br i1 %48, label %54, label %49
+
+; <label>:49                                      ; preds = %38, %46
+  %50 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %52 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %51)
+  %53 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53, %System.String addrspace(1)* %50, %System.String addrspace(1)* %52)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53) #0
+  unreachable
+
+; <label>:54                                      ; preds = %46
+  %55 = load i32, i32* %arg4
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %97, label %57
+
+; <label>:57                                      ; preds = %54
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %59
+
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 2
+  %61 = bitcast [0 x i16] addrspace(1)* %60 to i16 addrspace(1)*
+  store i16 addrspace(1)* %61, i16 addrspace(1)** %loc0
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  store %"System.Char[]" addrspace(1)* %62, %"System.Char[]" addrspace(1)** %loc2
+  %63 = icmp eq %"System.Char[]" addrspace(1)* %62, null
+  br i1 %63, label %72, label %64
+
+; <label>:64                                      ; preds = %59
+  %65 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc2
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %65, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %66
+
+; <label>:66                                      ; preds = %64
+  %67 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %65, i32 0, i32 1
+  %68 = load i32, i32 addrspace(1)* %67
+  %69 = zext i32 %68 to i64
+  %70 = trunc i64 %69 to i32
+  %71 = icmp ne i32 %70, 0
+  br i1 %71, label %73, label %72
+
+; <label>:72                                      ; preds = %59, %66
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  br label %81
+
+; <label>:73                                      ; preds = %66
+  %74 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc2
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %74, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %75
+
+; <label>:75                                      ; preds = %73
+  %76 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %74, i32 0, i32 1
+  %77 = load i32, i32 addrspace(1)* %76
+  %78 = zext i32 %77 to i64
+  %BoundsCheck = icmp uge i64 0, %78
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %79
+
+; <label>:79                                      ; preds = %75
+  %80 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %74, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %80, i16 addrspace(1)** %loc1
+  br label %81
+
+; <label>:81                                      ; preds = %72, %79
+  %82 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %83 = ptrtoint i16 addrspace(1)* %82 to i64
+  %84 = load i32, i32* %arg3
+  %85 = sext i32 %84 to i64
+  %86 = mul i64 %85, 2
+  %87 = add i64 %83, %86
+  %88 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %89 = ptrtoint i16 addrspace(1)* %88 to i64
+  %90 = load i32, i32* %arg1
+  %91 = sext i32 %90 to i64
+  %92 = mul i64 %91, 2
+  %93 = add i64 %89, %92
+  %94 = load i32, i32* %arg4
+  %95 = inttoptr i64 %87 to i16*
+  %96 = inttoptr i64 %93 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %95, i16* %96, i32 %94)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  br label %97
+
+; <label>:97                                      ; preds = %54, %81
+  ret void
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
 Successfully read ConsoleEncoding.GetPreamble
 
@@ -14878,7 +16797,365 @@ entry:
 }
 
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[loadElemA]
+Successfully read EncoderNLS.GetBytes
+
+define i32 @EncoderNLS.GetBytes(%System.Text.EncoderNLS addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3, %"System.Byte[]" addrspace(1)* %param4, i32 %param5, i8 %param6) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %arg4 = alloca %"System.Byte[]" addrspace(1)*
+  %arg5 = alloca i32
+  %arg6 = alloca i8
+  %loc0 = alloca i32
+  %loc1 = alloca i16 addrspace(1)*
+  %loc2 = alloca i8 addrspace(1)*
+  %loc3 = alloca i32
+  %loc4 = alloca %"System.Char[]" addrspace(1)*
+  %loc5 = alloca %"System.Byte[]" addrspace(1)*
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  store %"System.Byte[]" addrspace(1)* %param4, %"System.Byte[]" addrspace(1)** %arg4
+  store i32 %param5, i32* %arg5
+  store i8 %param6, i8* %arg6
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %1 = icmp eq %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %17, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %7 = icmp eq %"System.Char[]" addrspace(1)* %6, null
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %12
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %12
+
+; <label>:12                                      ; preds = %8, %10
+  %13 = phi %System.String addrspace(1)* [ %9, %8 ], [ %11, %10 ]
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %14)
+  %16 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16, %System.String addrspace(1)* %13, %System.String addrspace(1)* %15)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16) #0
+  unreachable
+
+; <label>:17                                      ; preds = %2
+  %18 = load i32, i32* %arg2
+  %19 = icmp slt i32 %18, 0
+  br i1 %19, label %23, label %20
+
+; <label>:20                                      ; preds = %17
+  %21 = load i32, i32* %arg3
+  %22 = icmp sge i32 %21, 0
+  br i1 %22, label %35, label %23
+
+; <label>:23                                      ; preds = %17, %20
+  %24 = load i32, i32* %arg2
+  %25 = icmp slt i32 %24, 0
+  br i1 %25, label %28, label %26
+
+; <label>:26                                      ; preds = %23
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %30
+
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %30
+
+; <label>:30                                      ; preds = %26, %28
+  %31 = phi %System.String addrspace(1)* [ %27, %26 ], [ %29, %28 ]
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34, %System.String addrspace(1)* %31, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %20
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck, label %ThrowNullRef, label %37
+
+; <label>:37                                      ; preds = %35
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = load i32, i32* %arg2
+  %43 = sub i32 %41, %42
+  %44 = load i32, i32* %arg3
+  %45 = icmp sge i32 %43, %44
+  br i1 %45, label %51, label %46
+
+; <label>:46                                      ; preds = %37
+  %47 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %48 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %49 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %48)
+  %50 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %50, %System.String addrspace(1)* %47, %System.String addrspace(1)* %49)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %50) #0
+  unreachable
+
+; <label>:51                                      ; preds = %37
+  %52 = load i32, i32* %arg5
+  %53 = icmp slt i32 %52, 0
+  br i1 %53, label %63, label %54
+
+; <label>:54                                      ; preds = %51
+  %55 = load i32, i32* %arg5
+  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck1 = icmp eq %"System.Byte[]" addrspace(1)* %56, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %57
+
+; <label>:57                                      ; preds = %54
+  %58 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = zext i32 %59 to i64
+  %61 = trunc i64 %60 to i32
+  %62 = icmp sle i32 %55, %61
+  br i1 %62, label %68, label %63
+
+; <label>:63                                      ; preds = %51, %57
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %66 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %65)
+  %67 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %67, %System.String addrspace(1)* %64, %System.String addrspace(1)* %66)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %67) #0
+  unreachable
+
+; <label>:68                                      ; preds = %57
+  %69 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %69, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %69, i32 0, i32 1
+  %72 = load i32, i32 addrspace(1)* %71
+  %73 = zext i32 %72 to i64
+  %74 = trunc i64 %73 to i32
+  %75 = icmp ne i32 %74, 0
+  br i1 %75, label %78, label %76
+
+; <label>:76                                      ; preds = %70
+  %77 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1)
+  store %"System.Char[]" addrspace(1)* %77, %"System.Char[]" addrspace(1)** %arg1
+  br label %78
+
+; <label>:78                                      ; preds = %70, %76
+  %79 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck5 = icmp eq %"System.Byte[]" addrspace(1)* %79, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %80
+
+; <label>:80                                      ; preds = %78
+  %81 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %79, i32 0, i32 1
+  %82 = load i32, i32 addrspace(1)* %81
+  %83 = zext i32 %82 to i64
+  %84 = trunc i64 %83 to i32
+  %85 = load i32, i32* %arg5
+  %86 = sub i32 %84, %85
+  store i32 %86, i32* %loc0
+  %87 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck7 = icmp eq %"System.Byte[]" addrspace(1)* %87, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %88
+
+; <label>:88                                      ; preds = %80
+  %89 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %87, i32 0, i32 1
+  %90 = load i32, i32 addrspace(1)* %89
+  %91 = zext i32 %90 to i64
+  %92 = trunc i64 %91 to i32
+  %93 = icmp ne i32 %92, 0
+  br i1 %93, label %96, label %94
+
+; <label>:94                                      ; preds = %88
+  %95 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1)
+  store %"System.Byte[]" addrspace(1)* %95, %"System.Byte[]" addrspace(1)** %arg4
+  br label %96
+
+; <label>:96                                      ; preds = %88, %94
+  %97 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  store %"System.Char[]" addrspace(1)* %97, %"System.Char[]" addrspace(1)** %loc4
+  %98 = icmp eq %"System.Char[]" addrspace(1)* %97, null
+  br i1 %98, label %107, label %99
+
+; <label>:99                                      ; preds = %96
+  %100 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc4
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %100, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %101
+
+; <label>:101                                     ; preds = %99
+  %102 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %100, i32 0, i32 1
+  %103 = load i32, i32 addrspace(1)* %102
+  %104 = zext i32 %103 to i64
+  %105 = trunc i64 %104 to i32
+  %106 = icmp ne i32 %105, 0
+  br i1 %106, label %108, label %107
+
+; <label>:107                                     ; preds = %96, %101
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  br label %116
+
+; <label>:108                                     ; preds = %101
+  %109 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc4
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %109, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %110
+
+; <label>:110                                     ; preds = %108
+  %111 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %109, i32 0, i32 1
+  %112 = load i32, i32 addrspace(1)* %111
+  %113 = zext i32 %112 to i64
+  %BoundsCheck = icmp uge i64 0, %113
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %114
+
+; <label>:114                                     ; preds = %110
+  %115 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %109, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %115, i16 addrspace(1)** %loc1
+  br label %116
+
+; <label>:116                                     ; preds = %107, %114
+  %117 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  store %"System.Byte[]" addrspace(1)* %117, %"System.Byte[]" addrspace(1)** %loc5
+  %118 = icmp eq %"System.Byte[]" addrspace(1)* %117, null
+  br i1 %118, label %127, label %119
+
+; <label>:119                                     ; preds = %116
+  %120 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc5
+  %NullCheck13 = icmp eq %"System.Byte[]" addrspace(1)* %120, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %121
+
+; <label>:121                                     ; preds = %119
+  %122 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %120, i32 0, i32 1
+  %123 = load i32, i32 addrspace(1)* %122
+  %124 = zext i32 %123 to i64
+  %125 = trunc i64 %124 to i32
+  %126 = icmp ne i32 %125, 0
+  br i1 %126, label %128, label %127
+
+; <label>:127                                     ; preds = %116, %121
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc2
+  br label %136
+
+; <label>:128                                     ; preds = %121
+  %129 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc5
+  %NullCheck15 = icmp eq %"System.Byte[]" addrspace(1)* %129, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %130
+
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %129, i32 0, i32 1
+  %132 = load i32, i32 addrspace(1)* %131
+  %133 = zext i32 %132 to i64
+  %BoundsCheck17 = icmp uge i64 0, %133
+  br i1 %BoundsCheck17, label %ThrowIndexOutOfRange18, label %134
+
+; <label>:134                                     ; preds = %130
+  %135 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %129, i32 0, i32 3, i32 0
+  store i8 addrspace(1)* %135, i8 addrspace(1)** %loc2
+  br label %136
+
+; <label>:136                                     ; preds = %127, %134
+  %137 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %138 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %139 = ptrtoint i16 addrspace(1)* %138 to i64
+  %140 = load i32, i32* %arg2
+  %141 = sext i32 %140 to i64
+  %142 = mul i64 %141, 2
+  %143 = add i64 %139, %142
+  %144 = load i32, i32* %arg3
+  %145 = load i8 addrspace(1)*, i8 addrspace(1)** %loc2
+  %146 = ptrtoint i8 addrspace(1)* %145 to i64
+  %147 = load i32, i32* %arg5
+  %148 = sext i32 %147 to i64
+  %149 = add i64 %146, %148
+  %150 = load i32, i32* %loc0
+  %151 = load i8, i8* %arg6
+  %152 = zext i8 %151 to i32
+  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i64 addrspace(1)*
+  %NullCheck19 = icmp eq i64 addrspace(1)* %153, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %154
+
+; <label>:154                                     ; preds = %136
+  %155 = load i64, i64 addrspace(1)* %153
+  %156 = add i64 %155, 72
+  %157 = inttoptr i64 %156 to i64*
+  %158 = load i64, i64* %157
+  %159 = add i64 %158, 0
+  %160 = inttoptr i64 %159 to i64*
+  %161 = load i64, i64* %160
+  %162 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to %System.Text.Encoder addrspace(1)*
+  %163 = inttoptr i64 %143 to i16*
+  %164 = inttoptr i64 %149 to i8*
+  %165 = trunc i32 %152 to i8
+  %166 = inttoptr i64 %161 to i32 (%System.Text.Encoder addrspace(1)*, i16*, i32, i8*, i32, i8)*
+  %167 = call i32 %166(%System.Text.Encoder addrspace(1)* %162, i16* %163, i32 %144, i8* %164, i32 %150, i8 %165)
+  store i32 %167, i32* %loc3
+  br label %168
+
+; <label>:168                                     ; preds = %154
+  %169 = load i32, i32* %loc3
+  ret i32 %169
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %110
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %119
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange18:                           ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
 Successfully read EncoderNLS.GetBytes
 
@@ -14967,22 +17244,22 @@ entry:
   %40 = load i8, i8* %arg5
   %41 = zext i8 %40 to i32
   %42 = trunc i32 %41 to i8
-  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %39, null
-  br i1 %NullCheck, label %43, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderNLS addrspace(1)* %39, null
+  br i1 %NullCheck, label %ThrowNullRef, label %43
 
 ; <label>:43                                      ; preds = %38
   %44 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
   store i8 %42, i8 addrspace(1)* %44
   %45 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %45, null
-  br i1 %NullCheck2, label %46, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.EncoderNLS addrspace(1)* %45, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %46
 
 ; <label>:46                                      ; preds = %43
   %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %45, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %47
   %48 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.EncoderNLS addrspace(1)* %48, null
-  br i1 %NullCheck4, label %49, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.EncoderNLS addrspace(1)* %48, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %49
 
 ; <label>:49                                      ; preds = %46
   %50 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %48, i32 0, i32 3
@@ -14993,8 +17270,8 @@ entry:
   %55 = load i32, i32* %arg4
   %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck6, label %58, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
   %59 = load i64, i64 addrspace(1)* %57
@@ -15012,15 +17289,15 @@ ThrowNullRef:                                     ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %43
+ThrowNullRef2:                                    ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %46
+ThrowNullRef4:                                    ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %49
+ThrowNullRef6:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -15048,8 +17325,8 @@ entry:
   %4 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0 to %System.IO.ConsoleStream addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*)(%System.IO.ConsoleStream addrspace(1)* %4, %"System.Byte[]" addrspace(1)* %1, i32 %2, i32 %3)
   %5 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
@@ -15134,8 +17411,8 @@ entry:
 
 ; <label>:22                                      ; preds = %8
   %23 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %23, null
-  br i1 %NullCheck, label %24, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Byte[]" addrspace(1)* %23, null
+  br i1 %NullCheck, label %ThrowNullRef, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
@@ -15157,8 +17434,8 @@ entry:
 
 ; <label>:36                                      ; preds = %24
   %37 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %37, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.ConsoleStream addrspace(1)* %37, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %37, i32 0, i32 4
@@ -15179,13 +17456,138 @@ ThrowNullRef:                                     ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %36
+ThrowNullRef2:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
-Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
+Successfully read WindowsConsoleStream.WriteFileNative
+
+define i32 @WindowsConsoleStream.WriteFileNative(i64 %param0, %"System.Byte[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i64
+  %arg1 = alloca %"System.Byte[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i8 addrspace(1)*
+  %loc2 = alloca %"System.Byte[]" addrspace(1)*
+  %loc3 = alloca i32
+  store i64 %param0, i64* %arg0
+  store %"System.Byte[]" addrspace(1)* %param1, %"System.Byte[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Byte[]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = zext i32 %3 to i64
+  %5 = icmp ne i64 %4, 0
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %1
+  ret i32 0
+
+; <label>:7                                       ; preds = %1
+  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  store %"System.Byte[]" addrspace(1)* %8, %"System.Byte[]" addrspace(1)** %loc2
+  %9 = icmp eq %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %9, label %18, label %10
+
+; <label>:10                                      ; preds = %7
+  %11 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc2
+  %NullCheck1 = icmp eq %"System.Byte[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %11, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp ne i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %7, %12
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc1
+  br label %27
+
+; <label>:19                                      ; preds = %12
+  %20 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc2
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %20, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %BoundsCheck = icmp uge i64 0, %24
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %25
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %20, i32 0, i32 3, i32 0
+  store i8 addrspace(1)* %26, i8 addrspace(1)** %loc1
+  br label %27
+
+; <label>:27                                      ; preds = %18, %25
+  %28 = load i64, i64* %arg0
+  %29 = load i8 addrspace(1)*, i8 addrspace(1)** %loc1
+  %30 = ptrtoint i8 addrspace(1)* %29 to i64
+  %31 = load i32, i32* %arg2
+  %32 = sext i32 %31 to i64
+  %33 = add i64 %30, %32
+  %34 = load i32, i32* %arg3
+  %35 = addrspacecast i32* %loc3 to i32 addrspace(1)*
+  %36 = inttoptr i64 %33 to i8*
+  %37 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i8*, i32, i32 addrspace(1)*, i64)*)(i64 %28, i8* %36, i32 %34, i32 addrspace(1)* %35, i64 0)
+  %38 = icmp ugt i32 %37, 0
+  %39 = sext i1 %38 to i32
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc1
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %42, label %41
+
+; <label>:41                                      ; preds = %27
+  ret i32 0
+
+; <label>:42                                      ; preds = %27
+  %43 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  store i32 %43, i32* %loc0
+  %44 = load i32, i32* %loc0
+  %45 = icmp eq i32 %44, 232
+  br i1 %45, label %49, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = load i32, i32* %loc0
+  %48 = icmp ne i32 %47, 109
+  br i1 %48, label %50, label %49
+
+; <label>:49                                      ; preds = %42, %46
+  ret i32 0
+
+; <label>:50                                      ; preds = %46
+  %51 = load i32, i32* %loc0
+  ret i32 %51
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
 Successfully read WindowsConsoleStream.Flush
 
@@ -15194,8 +17596,8 @@ entry:
   %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
   store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
@@ -15230,8 +17632,8 @@ entry:
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
   %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load i64, i64 addrspace(1)* %1
@@ -15270,15 +17672,15 @@ entry:
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.TextWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
   %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %3, align 8
   %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
   %7 = load i64, i64 addrspace(1)* %5
@@ -15296,7 +17698,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -15325,8 +17727,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %4)
   store i32 0, i32* %loc0
   %5 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Char[]" addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
@@ -15338,15 +17740,15 @@ entry:
 
 ; <label>:11                                      ; preds = %69
   %12 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %12, i32 0, i32 9
   %15 = load i32, i32 addrspace(1)* %14, align 8
   %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.IO.StreamWriter addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %16, i32 0, i32 10
@@ -15361,15 +17763,15 @@ entry:
 
 ; <label>:23                                      ; preds = %17, %21
   %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %24, null
-  br i1 %NullCheck8, label %25, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %24, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 10
   %27 = load i32, i32 addrspace(1)* %26, align 8
   %28 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %28, null
-  br i1 %NullCheck10, label %29, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.StreamWriter addrspace(1)* %28, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %28, i32 0, i32 9
@@ -15391,15 +17793,15 @@ entry:
   %40 = load i32, i32* %loc0
   %41 = mul i32 %40, 2
   %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
-  br i1 %NullCheck12, label %43, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %43
 
 ; <label>:43                                      ; preds = %38
   %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 7
   %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %44, align 8
   %46 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %46, null
-  br i1 %NullCheck14, label %47, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.IO.StreamWriter addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %47
 
 ; <label>:47                                      ; preds = %43
   %48 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %46, i32 0, i32 9
@@ -15411,16 +17813,16 @@ entry:
   %54 = bitcast %"System.Char[]" addrspace(1)* %45 to %System.Array addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %53, i32 %41, %System.Array addrspace(1)* %54, i32 %50, i32 %52)
   %55 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
-  br i1 %NullCheck16, label %56, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %56
 
 ; <label>:56                                      ; preds = %47
   %57 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
   %58 = load i32, i32 addrspace(1)* %57, align 8
   %59 = load i32, i32* %loc2
   %60 = add i32 %58, %59
-  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
-  br i1 %NullCheck18, label %61, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %61
 
 ; <label>:61                                      ; preds = %56
   %62 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
@@ -15442,8 +17844,8 @@ entry:
 
 ; <label>:72                                      ; preds = %69
   %73 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %73, null
-  br i1 %NullCheck2, label %74, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %73, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %74
 
 ; <label>:74                                      ; preds = %72
   %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %73, i32 0, i32 11
@@ -15464,39 +17866,39 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %72
+ThrowNullRef2:                                    ; preds = %72
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %23
+ThrowNullRef8:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef10:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %43
+ThrowNullRef14:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %47
+ThrowNullRef16:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %56
+ThrowNullRef18:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -15523,8 +17925,8 @@ entry:
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load i64, i64* %arg0
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -15556,8 +17958,8 @@ entry:
   store i64 %param1, i64* %arg1
   store i8 0, i8* %loc1
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
@@ -15567,16 +17969,16 @@ entry:
   %5 = addrspacecast i8* %loc1 to i8 addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %4, i8 addrspace(1)* %5)
   %6 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.SyncTextWriter addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
   %10 = load i64, i64* %arg1
   %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
   %13 = load i64, i64 addrspace(1)* %11
@@ -15611,11 +18013,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -15632,8 +18034,8 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load i64, i64* %arg1
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -15647,8 +18049,8 @@ entry:
   call void %11(%System.IO.TextWriter addrspace(1)* %0, i64 %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
   %15 = load i64, i64 addrspace(1)* %13
@@ -15666,7 +18068,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -15684,8 +18086,8 @@ entry:
   %1 = addrspacecast i64* %arg1 to i64 addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -15700,8 +18102,8 @@ entry:
   %14 = bitcast i64 addrspace(1)* %1 to %System.UInt64 addrspace(1)*
   %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.UInt64 addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.UInt64 addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
   %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
   %18 = load i64, i64 addrspace(1)* %16
@@ -15719,7 +18121,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -15735,8 +18137,8 @@ entry:
   store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
   %0 = load %System.UInt64 addrspace(1)*, %System.UInt64 addrspace(1)** %this
   %1 = bitcast %System.UInt64 addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load i64, i64 addrspace(1)* %1, align 8

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPConvI2F.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPConvI2F.error.txt
@@ -25,8 +25,8 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
@@ -40,8 +40,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
   %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
@@ -75,7 +75,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -90,8 +90,8 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %NullCheck = icmp ne i8 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = load i8, i8 addrspace(1)* %0, align 8
@@ -125,8 +125,8 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
@@ -159,8 +159,8 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -184,8 +184,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
   store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
@@ -195,8 +195,8 @@ entry:
 ; <label>:4                                       ; preds = %1
   %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
   %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
@@ -206,8 +206,8 @@ entry:
   %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
@@ -221,14 +221,14 @@ entry:
 
 ; <label>:17                                      ; preds = %14
   %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
   %21 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
@@ -238,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -249,8 +249,8 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
@@ -261,27 +261,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %30
+ThrowNullRef10:                                   ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -301,7 +301,89 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
-Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
+Successfully read AppDomainSetup.GetUnsecureApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.GetUnsecureApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %NullCheck = icmp eq %"System.String[]" addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %BoundsCheck = icmp uge i64 0, %5
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %6
+
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 3, i32 0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
+  ret %System.String addrspace(1)* %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_Value using LLILCJit
+Successfully read AppDomainSetup.get_Value
+
+define %"System.String[]" addrspace(1)* @AppDomainSetup.get_Value(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.String[]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 18)
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.String[]" addrspace(1)* addrspace(1)*, %"System.String[]" addrspace(1)*)*)(%"System.String[]" addrspace(1)* addrspace(1)* %9, %"System.String[]" addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %11, i32 0, i32 1
+  %14 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %13, align 8
+  ret %"System.String[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -319,8 +401,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -368,16 +450,16 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
   %5 = load i32, i32 addrspace(1)* %4
   %6 = sub i32 %5, 1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -389,7 +471,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -421,8 +503,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
@@ -456,8 +538,8 @@ entry:
 ; <label>:27                                      ; preds = %19
   %28 = load i32, i32* %arg1
   %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
-  br i1 %NullCheck2, label %30, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %29, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %30
 
 ; <label>:30                                      ; preds = %27
   %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
@@ -493,8 +575,8 @@ entry:
 ; <label>:49                                      ; preds = %46
   %50 = load i32, i32* %arg2
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck4, label %52, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
@@ -517,11 +599,11 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %27
+ThrowNullRef2:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %49
+ThrowNullRef4:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -544,16 +626,16 @@ entry:
   %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %0)
   store %System.String addrspace(1)* %1, %System.String addrspace(1)** %loc0
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 2
   %5 = bitcast [0 x i16] addrspace(1)* %4 to i16 addrspace(1)*
   store i16 addrspace(1)* %5, i16 addrspace(1)** %loc1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %3
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2
@@ -580,7 +662,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -691,15 +773,15 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %NullCheck132 = icmp ne i8* %21, null
-  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+  %NullCheck131 = icmp eq i8* %21, null
+  br i1 %NullCheck131, label %ThrowNullRef132, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = load i8, i8* %21, align 8
   %24 = zext i8 %23 to i32
   %25 = trunc i32 %24 to i8
-  %NullCheck134 = icmp ne i8* %20, null
-  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+  %NullCheck133 = icmp eq i8* %20, null
+  br i1 %NullCheck133, label %ThrowNullRef134, label %26
 
 ; <label>:26                                      ; preds = %22
   store i8 %25, i8* %20, align 8
@@ -709,16 +791,16 @@ entry:
   %28 = load i8*, i8** %arg0
   %29 = load i8*, i8** %arg1
   %30 = bitcast i8* %29 to i16*
-  %NullCheck128 = icmp ne i16* %30, null
-  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+  %NullCheck127 = icmp eq i16* %30, null
+  br i1 %NullCheck127, label %ThrowNullRef128, label %31
 
 ; <label>:31                                      ; preds = %27
   %32 = load i16, i16* %30, align 8
   %33 = sext i16 %32 to i32
   %34 = bitcast i8* %28 to i16*
   %35 = trunc i32 %33 to i16
-  %NullCheck130 = icmp ne i16* %34, null
-  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+  %NullCheck129 = icmp eq i16* %34, null
+  br i1 %NullCheck129, label %ThrowNullRef130, label %36
 
 ; <label>:36                                      ; preds = %31
   store i16 %35, i16* %34, align 8
@@ -728,16 +810,16 @@ entry:
   %38 = load i8*, i8** %arg0
   %39 = load i8*, i8** %arg1
   %40 = bitcast i8* %39 to i16*
-  %NullCheck120 = icmp ne i16* %40, null
-  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+  %NullCheck119 = icmp eq i16* %40, null
+  br i1 %NullCheck119, label %ThrowNullRef120, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i16, i16* %40, align 8
   %43 = sext i16 %42 to i32
   %44 = bitcast i8* %38 to i16*
   %45 = trunc i32 %43 to i16
-  %NullCheck122 = icmp ne i16* %44, null
-  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+  %NullCheck121 = icmp eq i16* %44, null
+  br i1 %NullCheck121, label %ThrowNullRef122, label %46
 
 ; <label>:46                                      ; preds = %41
   store i16 %45, i16* %44, align 8
@@ -745,15 +827,15 @@ entry:
   %48 = getelementptr inbounds i8, i8* %47, i64 2
   %49 = load i8*, i8** %arg1
   %50 = getelementptr inbounds i8, i8* %49, i64 2
-  %NullCheck124 = icmp ne i8* %50, null
-  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+  %NullCheck123 = icmp eq i8* %50, null
+  br i1 %NullCheck123, label %ThrowNullRef124, label %51
 
 ; <label>:51                                      ; preds = %46
   %52 = load i8, i8* %50, align 8
   %53 = zext i8 %52 to i32
   %54 = trunc i32 %53 to i8
-  %NullCheck126 = icmp ne i8* %48, null
-  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+  %NullCheck125 = icmp eq i8* %48, null
+  br i1 %NullCheck125, label %ThrowNullRef126, label %55
 
 ; <label>:55                                      ; preds = %51
   store i8 %54, i8* %48, align 8
@@ -763,14 +845,14 @@ entry:
   %57 = load i8*, i8** %arg0
   %58 = load i8*, i8** %arg1
   %59 = bitcast i8* %58 to i32*
-  %NullCheck116 = icmp ne i32* %59, null
-  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+  %NullCheck115 = icmp eq i32* %59, null
+  br i1 %NullCheck115, label %ThrowNullRef116, label %60
 
 ; <label>:60                                      ; preds = %56
   %61 = load i32, i32* %59, align 8
   %62 = bitcast i8* %57 to i32*
-  %NullCheck118 = icmp ne i32* %62, null
-  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+  %NullCheck117 = icmp eq i32* %62, null
+  br i1 %NullCheck117, label %ThrowNullRef118, label %63
 
 ; <label>:63                                      ; preds = %60
   store i32 %61, i32* %62, align 8
@@ -780,14 +862,14 @@ entry:
   %65 = load i8*, i8** %arg0
   %66 = load i8*, i8** %arg1
   %67 = bitcast i8* %66 to i32*
-  %NullCheck108 = icmp ne i32* %67, null
-  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+  %NullCheck107 = icmp eq i32* %67, null
+  br i1 %NullCheck107, label %ThrowNullRef108, label %68
 
 ; <label>:68                                      ; preds = %64
   %69 = load i32, i32* %67, align 8
   %70 = bitcast i8* %65 to i32*
-  %NullCheck110 = icmp ne i32* %70, null
-  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+  %NullCheck109 = icmp eq i32* %70, null
+  br i1 %NullCheck109, label %ThrowNullRef110, label %71
 
 ; <label>:71                                      ; preds = %68
   store i32 %69, i32* %70, align 8
@@ -795,15 +877,15 @@ entry:
   %73 = getelementptr inbounds i8, i8* %72, i64 4
   %74 = load i8*, i8** %arg1
   %75 = getelementptr inbounds i8, i8* %74, i64 4
-  %NullCheck112 = icmp ne i8* %75, null
-  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+  %NullCheck111 = icmp eq i8* %75, null
+  br i1 %NullCheck111, label %ThrowNullRef112, label %76
 
 ; <label>:76                                      ; preds = %71
   %77 = load i8, i8* %75, align 8
   %78 = zext i8 %77 to i32
   %79 = trunc i32 %78 to i8
-  %NullCheck114 = icmp ne i8* %73, null
-  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+  %NullCheck113 = icmp eq i8* %73, null
+  br i1 %NullCheck113, label %ThrowNullRef114, label %80
 
 ; <label>:80                                      ; preds = %76
   store i8 %79, i8* %73, align 8
@@ -813,14 +895,14 @@ entry:
   %82 = load i8*, i8** %arg0
   %83 = load i8*, i8** %arg1
   %84 = bitcast i8* %83 to i32*
-  %NullCheck100 = icmp ne i32* %84, null
-  br i1 %NullCheck100, label %85, label %ThrowNullRef99
+  %NullCheck99 = icmp eq i32* %84, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %85
 
 ; <label>:85                                      ; preds = %81
   %86 = load i32, i32* %84, align 8
   %87 = bitcast i8* %82 to i32*
-  %NullCheck102 = icmp ne i32* %87, null
-  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+  %NullCheck101 = icmp eq i32* %87, null
+  br i1 %NullCheck101, label %ThrowNullRef102, label %88
 
 ; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
@@ -829,16 +911,16 @@ entry:
   %91 = load i8*, i8** %arg1
   %92 = getelementptr inbounds i8, i8* %91, i64 4
   %93 = bitcast i8* %92 to i16*
-  %NullCheck104 = icmp ne i16* %93, null
-  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+  %NullCheck103 = icmp eq i16* %93, null
+  br i1 %NullCheck103, label %ThrowNullRef104, label %94
 
 ; <label>:94                                      ; preds = %88
   %95 = load i16, i16* %93, align 8
   %96 = sext i16 %95 to i32
   %97 = bitcast i8* %90 to i16*
   %98 = trunc i32 %96 to i16
-  %NullCheck106 = icmp ne i16* %97, null
-  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+  %NullCheck105 = icmp eq i16* %97, null
+  br i1 %NullCheck105, label %ThrowNullRef106, label %99
 
 ; <label>:99                                      ; preds = %94
   store i16 %98, i16* %97, align 8
@@ -848,14 +930,14 @@ entry:
   %101 = load i8*, i8** %arg0
   %102 = load i8*, i8** %arg1
   %103 = bitcast i8* %102 to i32*
-  %NullCheck88 = icmp ne i32* %103, null
-  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+  %NullCheck87 = icmp eq i32* %103, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %104
 
 ; <label>:104                                     ; preds = %100
   %105 = load i32, i32* %103, align 8
   %106 = bitcast i8* %101 to i32*
-  %NullCheck90 = icmp ne i32* %106, null
-  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+  %NullCheck89 = icmp eq i32* %106, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %107
 
 ; <label>:107                                     ; preds = %104
   store i32 %105, i32* %106, align 8
@@ -864,16 +946,16 @@ entry:
   %110 = load i8*, i8** %arg1
   %111 = getelementptr inbounds i8, i8* %110, i64 4
   %112 = bitcast i8* %111 to i16*
-  %NullCheck92 = icmp ne i16* %112, null
-  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+  %NullCheck91 = icmp eq i16* %112, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %113
 
 ; <label>:113                                     ; preds = %107
   %114 = load i16, i16* %112, align 8
   %115 = sext i16 %114 to i32
   %116 = bitcast i8* %109 to i16*
   %117 = trunc i32 %115 to i16
-  %NullCheck94 = icmp ne i16* %116, null
-  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+  %NullCheck93 = icmp eq i16* %116, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %118
 
 ; <label>:118                                     ; preds = %113
   store i16 %117, i16* %116, align 8
@@ -881,15 +963,15 @@ entry:
   %120 = getelementptr inbounds i8, i8* %119, i64 6
   %121 = load i8*, i8** %arg1
   %122 = getelementptr inbounds i8, i8* %121, i64 6
-  %NullCheck96 = icmp ne i8* %122, null
-  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+  %NullCheck95 = icmp eq i8* %122, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %123
 
 ; <label>:123                                     ; preds = %118
   %124 = load i8, i8* %122, align 8
   %125 = zext i8 %124 to i32
   %126 = trunc i32 %125 to i8
-  %NullCheck98 = icmp ne i8* %120, null
-  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+  %NullCheck97 = icmp eq i8* %120, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %127
 
 ; <label>:127                                     ; preds = %123
   store i8 %126, i8* %120, align 8
@@ -899,14 +981,14 @@ entry:
   %129 = load i8*, i8** %arg0
   %130 = load i8*, i8** %arg1
   %131 = bitcast i8* %130 to i64*
-  %NullCheck84 = icmp ne i64* %131, null
-  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+  %NullCheck83 = icmp eq i64* %131, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %132
 
 ; <label>:132                                     ; preds = %128
   %133 = load i64, i64* %131, align 8
   %134 = bitcast i8* %129 to i64*
-  %NullCheck86 = icmp ne i64* %134, null
-  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+  %NullCheck85 = icmp eq i64* %134, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %135
 
 ; <label>:135                                     ; preds = %132
   store i64 %133, i64* %134, align 8
@@ -916,14 +998,14 @@ entry:
   %137 = load i8*, i8** %arg0
   %138 = load i8*, i8** %arg1
   %139 = bitcast i8* %138 to i64*
-  %NullCheck76 = icmp ne i64* %139, null
-  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+  %NullCheck75 = icmp eq i64* %139, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %140
 
 ; <label>:140                                     ; preds = %136
   %141 = load i64, i64* %139, align 8
   %142 = bitcast i8* %137 to i64*
-  %NullCheck78 = icmp ne i64* %142, null
-  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+  %NullCheck77 = icmp eq i64* %142, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %143
 
 ; <label>:143                                     ; preds = %140
   store i64 %141, i64* %142, align 8
@@ -931,15 +1013,15 @@ entry:
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %NullCheck80 = icmp ne i8* %147, null
-  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+  %NullCheck79 = icmp eq i8* %147, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %148
 
 ; <label>:148                                     ; preds = %143
   %149 = load i8, i8* %147, align 8
   %150 = zext i8 %149 to i32
   %151 = trunc i32 %150 to i8
-  %NullCheck82 = icmp ne i8* %145, null
-  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+  %NullCheck81 = icmp eq i8* %145, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %152
 
 ; <label>:152                                     ; preds = %148
   store i8 %151, i8* %145, align 8
@@ -949,14 +1031,14 @@ entry:
   %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
   %156 = bitcast i8* %155 to i64*
-  %NullCheck68 = icmp ne i64* %156, null
-  br i1 %NullCheck68, label %157, label %ThrowNullRef67
+  %NullCheck67 = icmp eq i64* %156, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %157
 
 ; <label>:157                                     ; preds = %153
   %158 = load i64, i64* %156, align 8
   %159 = bitcast i8* %154 to i64*
-  %NullCheck70 = icmp ne i64* %159, null
-  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+  %NullCheck69 = icmp eq i64* %159, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %160
 
 ; <label>:160                                     ; preds = %157
   store i64 %158, i64* %159, align 8
@@ -965,16 +1047,16 @@ entry:
   %163 = load i8*, i8** %arg1
   %164 = getelementptr inbounds i8, i8* %163, i64 8
   %165 = bitcast i8* %164 to i16*
-  %NullCheck72 = icmp ne i16* %165, null
-  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+  %NullCheck71 = icmp eq i16* %165, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %166
 
 ; <label>:166                                     ; preds = %160
   %167 = load i16, i16* %165, align 8
   %168 = sext i16 %167 to i32
   %169 = bitcast i8* %162 to i16*
   %170 = trunc i32 %168 to i16
-  %NullCheck74 = icmp ne i16* %169, null
-  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+  %NullCheck73 = icmp eq i16* %169, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %171
 
 ; <label>:171                                     ; preds = %166
   store i16 %170, i16* %169, align 8
@@ -984,14 +1066,14 @@ entry:
   %173 = load i8*, i8** %arg0
   %174 = load i8*, i8** %arg1
   %175 = bitcast i8* %174 to i64*
-  %NullCheck56 = icmp ne i64* %175, null
-  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+  %NullCheck55 = icmp eq i64* %175, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %176
 
 ; <label>:176                                     ; preds = %172
   %177 = load i64, i64* %175, align 8
   %178 = bitcast i8* %173 to i64*
-  %NullCheck58 = icmp ne i64* %178, null
-  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+  %NullCheck57 = icmp eq i64* %178, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %179
 
 ; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
@@ -1000,16 +1082,16 @@ entry:
   %182 = load i8*, i8** %arg1
   %183 = getelementptr inbounds i8, i8* %182, i64 8
   %184 = bitcast i8* %183 to i16*
-  %NullCheck60 = icmp ne i16* %184, null
-  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+  %NullCheck59 = icmp eq i16* %184, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %185
 
 ; <label>:185                                     ; preds = %179
   %186 = load i16, i16* %184, align 8
   %187 = sext i16 %186 to i32
   %188 = bitcast i8* %181 to i16*
   %189 = trunc i32 %187 to i16
-  %NullCheck62 = icmp ne i16* %188, null
-  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+  %NullCheck61 = icmp eq i16* %188, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %190
 
 ; <label>:190                                     ; preds = %185
   store i16 %189, i16* %188, align 8
@@ -1017,15 +1099,15 @@ entry:
   %192 = getelementptr inbounds i8, i8* %191, i64 10
   %193 = load i8*, i8** %arg1
   %194 = getelementptr inbounds i8, i8* %193, i64 10
-  %NullCheck64 = icmp ne i8* %194, null
-  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+  %NullCheck63 = icmp eq i8* %194, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %195
 
 ; <label>:195                                     ; preds = %190
   %196 = load i8, i8* %194, align 8
   %197 = zext i8 %196 to i32
   %198 = trunc i32 %197 to i8
-  %NullCheck66 = icmp ne i8* %192, null
-  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+  %NullCheck65 = icmp eq i8* %192, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %199
 
 ; <label>:199                                     ; preds = %195
   store i8 %198, i8* %192, align 8
@@ -1035,14 +1117,14 @@ entry:
   %201 = load i8*, i8** %arg0
   %202 = load i8*, i8** %arg1
   %203 = bitcast i8* %202 to i64*
-  %NullCheck48 = icmp ne i64* %203, null
-  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+  %NullCheck47 = icmp eq i64* %203, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %204
 
 ; <label>:204                                     ; preds = %200
   %205 = load i64, i64* %203, align 8
   %206 = bitcast i8* %201 to i64*
-  %NullCheck50 = icmp ne i64* %206, null
-  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+  %NullCheck49 = icmp eq i64* %206, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %207
 
 ; <label>:207                                     ; preds = %204
   store i64 %205, i64* %206, align 8
@@ -1051,14 +1133,14 @@ entry:
   %210 = load i8*, i8** %arg1
   %211 = getelementptr inbounds i8, i8* %210, i64 8
   %212 = bitcast i8* %211 to i32*
-  %NullCheck52 = icmp ne i32* %212, null
-  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+  %NullCheck51 = icmp eq i32* %212, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %213
 
 ; <label>:213                                     ; preds = %207
   %214 = load i32, i32* %212, align 8
   %215 = bitcast i8* %209 to i32*
-  %NullCheck54 = icmp ne i32* %215, null
-  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+  %NullCheck53 = icmp eq i32* %215, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %216
 
 ; <label>:216                                     ; preds = %213
   store i32 %214, i32* %215, align 8
@@ -1068,14 +1150,14 @@ entry:
   %218 = load i8*, i8** %arg0
   %219 = load i8*, i8** %arg1
   %220 = bitcast i8* %219 to i64*
-  %NullCheck36 = icmp ne i64* %220, null
-  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64* %220, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %221
 
 ; <label>:221                                     ; preds = %217
   %222 = load i64, i64* %220, align 8
   %223 = bitcast i8* %218 to i64*
-  %NullCheck38 = icmp ne i64* %223, null
-  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+  %NullCheck37 = icmp eq i64* %223, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %224
 
 ; <label>:224                                     ; preds = %221
   store i64 %222, i64* %223, align 8
@@ -1084,14 +1166,14 @@ entry:
   %227 = load i8*, i8** %arg1
   %228 = getelementptr inbounds i8, i8* %227, i64 8
   %229 = bitcast i8* %228 to i32*
-  %NullCheck40 = icmp ne i32* %229, null
-  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i32* %229, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %230
 
 ; <label>:230                                     ; preds = %224
   %231 = load i32, i32* %229, align 8
   %232 = bitcast i8* %226 to i32*
-  %NullCheck42 = icmp ne i32* %232, null
-  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+  %NullCheck41 = icmp eq i32* %232, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %233
 
 ; <label>:233                                     ; preds = %230
   store i32 %231, i32* %232, align 8
@@ -1099,15 +1181,15 @@ entry:
   %235 = getelementptr inbounds i8, i8* %234, i64 12
   %236 = load i8*, i8** %arg1
   %237 = getelementptr inbounds i8, i8* %236, i64 12
-  %NullCheck44 = icmp ne i8* %237, null
-  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i8* %237, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %238
 
 ; <label>:238                                     ; preds = %233
   %239 = load i8, i8* %237, align 8
   %240 = zext i8 %239 to i32
   %241 = trunc i32 %240 to i8
-  %NullCheck46 = icmp ne i8* %235, null
-  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+  %NullCheck45 = icmp eq i8* %235, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %242
 
 ; <label>:242                                     ; preds = %238
   store i8 %241, i8* %235, align 8
@@ -1117,14 +1199,14 @@ entry:
   %244 = load i8*, i8** %arg0
   %245 = load i8*, i8** %arg1
   %246 = bitcast i8* %245 to i64*
-  %NullCheck24 = icmp ne i64* %246, null
-  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64* %246, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %247
 
 ; <label>:247                                     ; preds = %243
   %248 = load i64, i64* %246, align 8
   %249 = bitcast i8* %244 to i64*
-  %NullCheck26 = icmp ne i64* %249, null
-  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64* %249, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %250
 
 ; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
@@ -1133,14 +1215,14 @@ entry:
   %253 = load i8*, i8** %arg1
   %254 = getelementptr inbounds i8, i8* %253, i64 8
   %255 = bitcast i8* %254 to i32*
-  %NullCheck28 = icmp ne i32* %255, null
-  br i1 %NullCheck28, label %256, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i32* %255, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %256
 
 ; <label>:256                                     ; preds = %250
   %257 = load i32, i32* %255, align 8
   %258 = bitcast i8* %252 to i32*
-  %NullCheck30 = icmp ne i32* %258, null
-  br i1 %NullCheck30, label %259, label %ThrowNullRef29
+  %NullCheck29 = icmp eq i32* %258, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %259
 
 ; <label>:259                                     ; preds = %256
   store i32 %257, i32* %258, align 8
@@ -1149,16 +1231,16 @@ entry:
   %262 = load i8*, i8** %arg1
   %263 = getelementptr inbounds i8, i8* %262, i64 12
   %264 = bitcast i8* %263 to i16*
-  %NullCheck32 = icmp ne i16* %264, null
-  br i1 %NullCheck32, label %265, label %ThrowNullRef31
+  %NullCheck31 = icmp eq i16* %264, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %265
 
 ; <label>:265                                     ; preds = %259
   %266 = load i16, i16* %264, align 8
   %267 = sext i16 %266 to i32
   %268 = bitcast i8* %261 to i16*
   %269 = trunc i32 %267 to i16
-  %NullCheck34 = icmp ne i16* %268, null
-  br i1 %NullCheck34, label %270, label %ThrowNullRef33
+  %NullCheck33 = icmp eq i16* %268, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %270
 
 ; <label>:270                                     ; preds = %265
   store i16 %269, i16* %268, align 8
@@ -1168,14 +1250,14 @@ entry:
   %272 = load i8*, i8** %arg0
   %273 = load i8*, i8** %arg1
   %274 = bitcast i8* %273 to i64*
-  %NullCheck8 = icmp ne i64* %274, null
-  br i1 %NullCheck8, label %275, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64* %274, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %275
 
 ; <label>:275                                     ; preds = %271
   %276 = load i64, i64* %274, align 8
   %277 = bitcast i8* %272 to i64*
-  %NullCheck10 = icmp ne i64* %277, null
-  br i1 %NullCheck10, label %278, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %277, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %278
 
 ; <label>:278                                     ; preds = %275
   store i64 %276, i64* %277, align 8
@@ -1184,14 +1266,14 @@ entry:
   %281 = load i8*, i8** %arg1
   %282 = getelementptr inbounds i8, i8* %281, i64 8
   %283 = bitcast i8* %282 to i32*
-  %NullCheck12 = icmp ne i32* %283, null
-  br i1 %NullCheck12, label %284, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i32* %283, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %284
 
 ; <label>:284                                     ; preds = %278
   %285 = load i32, i32* %283, align 8
   %286 = bitcast i8* %280 to i32*
-  %NullCheck14 = icmp ne i32* %286, null
-  br i1 %NullCheck14, label %287, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i32* %286, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %287
 
 ; <label>:287                                     ; preds = %284
   store i32 %285, i32* %286, align 8
@@ -1200,16 +1282,16 @@ entry:
   %290 = load i8*, i8** %arg1
   %291 = getelementptr inbounds i8, i8* %290, i64 12
   %292 = bitcast i8* %291 to i16*
-  %NullCheck16 = icmp ne i16* %292, null
-  br i1 %NullCheck16, label %293, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i16* %292, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %293
 
 ; <label>:293                                     ; preds = %287
   %294 = load i16, i16* %292, align 8
   %295 = sext i16 %294 to i32
   %296 = bitcast i8* %289 to i16*
   %297 = trunc i32 %295 to i16
-  %NullCheck18 = icmp ne i16* %296, null
-  br i1 %NullCheck18, label %298, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i16* %296, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %298
 
 ; <label>:298                                     ; preds = %293
   store i16 %297, i16* %296, align 8
@@ -1217,15 +1299,15 @@ entry:
   %300 = getelementptr inbounds i8, i8* %299, i64 14
   %301 = load i8*, i8** %arg1
   %302 = getelementptr inbounds i8, i8* %301, i64 14
-  %NullCheck20 = icmp ne i8* %302, null
-  br i1 %NullCheck20, label %303, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i8* %302, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %303
 
 ; <label>:303                                     ; preds = %298
   %304 = load i8, i8* %302, align 8
   %305 = zext i8 %304 to i32
   %306 = trunc i32 %305 to i8
-  %NullCheck22 = icmp ne i8* %300, null
-  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i8* %300, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %307
 
 ; <label>:307                                     ; preds = %303
   store i8 %306, i8* %300, align 8
@@ -1235,14 +1317,14 @@ entry:
   %309 = load i8*, i8** %arg0
   %310 = load i8*, i8** %arg1
   %311 = bitcast i8* %310 to i64*
-  %NullCheck = icmp ne i64* %311, null
-  br i1 %NullCheck, label %312, label %ThrowNullRef
+  %NullCheck = icmp eq i64* %311, null
+  br i1 %NullCheck, label %ThrowNullRef, label %312
 
 ; <label>:312                                     ; preds = %308
   %313 = load i64, i64* %311, align 8
   %314 = bitcast i8* %309 to i64*
-  %NullCheck2 = icmp ne i64* %314, null
-  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64* %314, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %315
 
 ; <label>:315                                     ; preds = %312
   store i64 %313, i64* %314, align 8
@@ -1251,14 +1333,14 @@ entry:
   %318 = load i8*, i8** %arg1
   %319 = getelementptr inbounds i8, i8* %318, i64 8
   %320 = bitcast i8* %319 to i64*
-  %NullCheck4 = icmp ne i64* %320, null
-  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64* %320, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %321
 
 ; <label>:321                                     ; preds = %315
   %322 = load i64, i64* %320, align 8
   %323 = bitcast i8* %317 to i64*
-  %NullCheck6 = icmp ne i64* %323, null
-  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64* %323, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %324
 
 ; <label>:324                                     ; preds = %321
   store i64 %322, i64* %323, align 8
@@ -1286,15 +1368,15 @@ entry:
 ; <label>:338                                     ; preds = %333
   %339 = load i8*, i8** %arg0
   %340 = load i8*, i8** %arg1
-  %NullCheck136 = icmp ne i8* %340, null
-  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+  %NullCheck135 = icmp eq i8* %340, null
+  br i1 %NullCheck135, label %ThrowNullRef136, label %341
 
 ; <label>:341                                     ; preds = %338
   %342 = load i8, i8* %340, align 8
   %343 = zext i8 %342 to i32
   %344 = trunc i32 %343 to i8
-  %NullCheck138 = icmp ne i8* %339, null
-  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+  %NullCheck137 = icmp eq i8* %339, null
+  br i1 %NullCheck137, label %ThrowNullRef138, label %345
 
 ; <label>:345                                     ; preds = %341
   store i8 %344, i8* %339, align 8
@@ -1317,16 +1399,16 @@ entry:
   %357 = load i8*, i8** %arg0
   %358 = load i8*, i8** %arg1
   %359 = bitcast i8* %358 to i16*
-  %NullCheck140 = icmp ne i16* %359, null
-  br i1 %NullCheck140, label %360, label %ThrowNullRef139
+  %NullCheck139 = icmp eq i16* %359, null
+  br i1 %NullCheck139, label %ThrowNullRef140, label %360
 
 ; <label>:360                                     ; preds = %356
   %361 = load i16, i16* %359, align 8
   %362 = sext i16 %361 to i32
   %363 = bitcast i8* %357 to i16*
   %364 = trunc i32 %362 to i16
-  %NullCheck142 = icmp ne i16* %363, null
-  br i1 %NullCheck142, label %365, label %ThrowNullRef141
+  %NullCheck141 = icmp eq i16* %363, null
+  br i1 %NullCheck141, label %ThrowNullRef142, label %365
 
 ; <label>:365                                     ; preds = %360
   store i16 %364, i16* %363, align 8
@@ -1352,14 +1434,14 @@ entry:
   %378 = load i8*, i8** %arg0
   %379 = load i8*, i8** %arg1
   %380 = bitcast i8* %379 to i32*
-  %NullCheck144 = icmp ne i32* %380, null
-  br i1 %NullCheck144, label %381, label %ThrowNullRef143
+  %NullCheck143 = icmp eq i32* %380, null
+  br i1 %NullCheck143, label %ThrowNullRef144, label %381
 
 ; <label>:381                                     ; preds = %377
   %382 = load i32, i32* %380, align 8
   %383 = bitcast i8* %378 to i32*
-  %NullCheck146 = icmp ne i32* %383, null
-  br i1 %NullCheck146, label %384, label %ThrowNullRef145
+  %NullCheck145 = icmp eq i32* %383, null
+  br i1 %NullCheck145, label %ThrowNullRef146, label %384
 
 ; <label>:384                                     ; preds = %381
   store i32 %382, i32* %383, align 8
@@ -1384,14 +1466,14 @@ entry:
   %395 = load i8*, i8** %arg0
   %396 = load i8*, i8** %arg1
   %397 = bitcast i8* %396 to i64*
-  %NullCheck164 = icmp ne i64* %397, null
-  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+  %NullCheck163 = icmp eq i64* %397, null
+  br i1 %NullCheck163, label %ThrowNullRef164, label %398
 
 ; <label>:398                                     ; preds = %394
   %399 = load i64, i64* %397, align 8
   %400 = bitcast i8* %395 to i64*
-  %NullCheck166 = icmp ne i64* %400, null
-  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+  %NullCheck165 = icmp eq i64* %400, null
+  br i1 %NullCheck165, label %ThrowNullRef166, label %401
 
 ; <label>:401                                     ; preds = %398
   store i64 %399, i64* %400, align 8
@@ -1400,14 +1482,14 @@ entry:
   %404 = load i8*, i8** %arg1
   %405 = getelementptr inbounds i8, i8* %404, i64 8
   %406 = bitcast i8* %405 to i64*
-  %NullCheck168 = icmp ne i64* %406, null
-  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+  %NullCheck167 = icmp eq i64* %406, null
+  br i1 %NullCheck167, label %ThrowNullRef168, label %407
 
 ; <label>:407                                     ; preds = %401
   %408 = load i64, i64* %406, align 8
   %409 = bitcast i8* %403 to i64*
-  %NullCheck170 = icmp ne i64* %409, null
-  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+  %NullCheck169 = icmp eq i64* %409, null
+  br i1 %NullCheck169, label %ThrowNullRef170, label %410
 
 ; <label>:410                                     ; preds = %407
   store i64 %408, i64* %409, align 8
@@ -1437,14 +1519,14 @@ entry:
   %425 = load i8*, i8** %arg0
   %426 = load i8*, i8** %arg1
   %427 = bitcast i8* %426 to i64*
-  %NullCheck148 = icmp ne i64* %427, null
-  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+  %NullCheck147 = icmp eq i64* %427, null
+  br i1 %NullCheck147, label %ThrowNullRef148, label %428
 
 ; <label>:428                                     ; preds = %424
   %429 = load i64, i64* %427, align 8
   %430 = bitcast i8* %425 to i64*
-  %NullCheck150 = icmp ne i64* %430, null
-  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+  %NullCheck149 = icmp eq i64* %430, null
+  br i1 %NullCheck149, label %ThrowNullRef150, label %431
 
 ; <label>:431                                     ; preds = %428
   store i64 %429, i64* %430, align 8
@@ -1466,14 +1548,14 @@ entry:
   %441 = load i8*, i8** %arg0
   %442 = load i8*, i8** %arg1
   %443 = bitcast i8* %442 to i32*
-  %NullCheck152 = icmp ne i32* %443, null
-  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+  %NullCheck151 = icmp eq i32* %443, null
+  br i1 %NullCheck151, label %ThrowNullRef152, label %444
 
 ; <label>:444                                     ; preds = %440
   %445 = load i32, i32* %443, align 8
   %446 = bitcast i8* %441 to i32*
-  %NullCheck154 = icmp ne i32* %446, null
-  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+  %NullCheck153 = icmp eq i32* %446, null
+  br i1 %NullCheck153, label %ThrowNullRef154, label %447
 
 ; <label>:447                                     ; preds = %444
   store i32 %445, i32* %446, align 8
@@ -1495,16 +1577,16 @@ entry:
   %457 = load i8*, i8** %arg0
   %458 = load i8*, i8** %arg1
   %459 = bitcast i8* %458 to i16*
-  %NullCheck156 = icmp ne i16* %459, null
-  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+  %NullCheck155 = icmp eq i16* %459, null
+  br i1 %NullCheck155, label %ThrowNullRef156, label %460
 
 ; <label>:460                                     ; preds = %456
   %461 = load i16, i16* %459, align 8
   %462 = sext i16 %461 to i32
   %463 = bitcast i8* %457 to i16*
   %464 = trunc i32 %462 to i16
-  %NullCheck158 = icmp ne i16* %463, null
-  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+  %NullCheck157 = icmp eq i16* %463, null
+  br i1 %NullCheck157, label %ThrowNullRef158, label %465
 
 ; <label>:465                                     ; preds = %460
   store i16 %464, i16* %463, align 8
@@ -1525,15 +1607,15 @@ entry:
 ; <label>:474                                     ; preds = %470
   %475 = load i8*, i8** %arg0
   %476 = load i8*, i8** %arg1
-  %NullCheck160 = icmp ne i8* %476, null
-  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+  %NullCheck159 = icmp eq i8* %476, null
+  br i1 %NullCheck159, label %ThrowNullRef160, label %477
 
 ; <label>:477                                     ; preds = %474
   %478 = load i8, i8* %476, align 8
   %479 = zext i8 %478 to i32
   %480 = trunc i32 %479 to i8
-  %NullCheck162 = icmp ne i8* %475, null
-  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+  %NullCheck161 = icmp eq i8* %475, null
+  br i1 %NullCheck161, label %ThrowNullRef162, label %481
 
 ; <label>:481                                     ; preds = %477
   store i8 %480, i8* %475, align 8
@@ -1553,343 +1635,343 @@ ThrowNullRef:                                     ; preds = %308
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %312
+ThrowNullRef2:                                    ; preds = %312
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %315
+ThrowNullRef4:                                    ; preds = %315
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %321
+ThrowNullRef6:                                    ; preds = %321
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %271
+ThrowNullRef8:                                    ; preds = %271
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %275
+ThrowNullRef10:                                   ; preds = %275
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %278
+ThrowNullRef12:                                   ; preds = %278
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %284
+ThrowNullRef14:                                   ; preds = %284
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %287
+ThrowNullRef16:                                   ; preds = %287
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %293
+ThrowNullRef18:                                   ; preds = %293
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %298
+ThrowNullRef20:                                   ; preds = %298
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %303
+ThrowNullRef22:                                   ; preds = %303
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %243
+ThrowNullRef24:                                   ; preds = %243
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %247
+ThrowNullRef26:                                   ; preds = %247
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %250
+ThrowNullRef28:                                   ; preds = %250
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %256
+ThrowNullRef30:                                   ; preds = %256
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %259
+ThrowNullRef32:                                   ; preds = %259
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %265
+ThrowNullRef34:                                   ; preds = %265
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %217
+ThrowNullRef36:                                   ; preds = %217
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %221
+ThrowNullRef38:                                   ; preds = %221
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %224
+ThrowNullRef40:                                   ; preds = %224
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %230
+ThrowNullRef42:                                   ; preds = %230
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %233
+ThrowNullRef44:                                   ; preds = %233
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %238
+ThrowNullRef46:                                   ; preds = %238
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %200
+ThrowNullRef48:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %204
+ThrowNullRef50:                                   ; preds = %204
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %207
+ThrowNullRef52:                                   ; preds = %207
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %213
+ThrowNullRef54:                                   ; preds = %213
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %172
+ThrowNullRef56:                                   ; preds = %172
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %176
+ThrowNullRef58:                                   ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %179
+ThrowNullRef60:                                   ; preds = %179
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %185
+ThrowNullRef62:                                   ; preds = %185
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %190
+ThrowNullRef64:                                   ; preds = %190
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %195
+ThrowNullRef66:                                   ; preds = %195
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %153
+ThrowNullRef68:                                   ; preds = %153
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %157
+ThrowNullRef70:                                   ; preds = %157
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %160
+ThrowNullRef72:                                   ; preds = %160
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %166
+ThrowNullRef74:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %136
+ThrowNullRef76:                                   ; preds = %136
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %140
+ThrowNullRef78:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %143
+ThrowNullRef80:                                   ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %148
+ThrowNullRef82:                                   ; preds = %148
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %128
+ThrowNullRef84:                                   ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %132
+ThrowNullRef86:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %100
+ThrowNullRef88:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %104
+ThrowNullRef90:                                   ; preds = %104
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %107
+ThrowNullRef92:                                   ; preds = %107
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %113
+ThrowNullRef94:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %118
+ThrowNullRef96:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %123
+ThrowNullRef98:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %81
+ThrowNullRef100:                                  ; preds = %81
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef101:                                  ; preds = %85
+ThrowNullRef102:                                  ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef103:                                  ; preds = %88
+ThrowNullRef104:                                  ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef105:                                  ; preds = %94
+ThrowNullRef106:                                  ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef107:                                  ; preds = %64
+ThrowNullRef108:                                  ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef109:                                  ; preds = %68
+ThrowNullRef110:                                  ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef111:                                  ; preds = %71
+ThrowNullRef112:                                  ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef113:                                  ; preds = %76
+ThrowNullRef114:                                  ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef115:                                  ; preds = %56
+ThrowNullRef116:                                  ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef117:                                  ; preds = %60
+ThrowNullRef118:                                  ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef119:                                  ; preds = %37
+ThrowNullRef120:                                  ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef121:                                  ; preds = %41
+ThrowNullRef122:                                  ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef123:                                  ; preds = %46
+ThrowNullRef124:                                  ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef125:                                  ; preds = %51
+ThrowNullRef126:                                  ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef127:                                  ; preds = %27
+ThrowNullRef128:                                  ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef129:                                  ; preds = %31
+ThrowNullRef130:                                  ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef131:                                  ; preds = %19
+ThrowNullRef132:                                  ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef133:                                  ; preds = %22
+ThrowNullRef134:                                  ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef135:                                  ; preds = %338
+ThrowNullRef136:                                  ; preds = %338
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef137:                                  ; preds = %341
+ThrowNullRef138:                                  ; preds = %341
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef139:                                  ; preds = %356
+ThrowNullRef140:                                  ; preds = %356
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef141:                                  ; preds = %360
+ThrowNullRef142:                                  ; preds = %360
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef143:                                  ; preds = %377
+ThrowNullRef144:                                  ; preds = %377
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef145:                                  ; preds = %381
+ThrowNullRef146:                                  ; preds = %381
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef147:                                  ; preds = %424
+ThrowNullRef148:                                  ; preds = %424
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef149:                                  ; preds = %428
+ThrowNullRef150:                                  ; preds = %428
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef151:                                  ; preds = %440
+ThrowNullRef152:                                  ; preds = %440
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef153:                                  ; preds = %444
+ThrowNullRef154:                                  ; preds = %444
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef155:                                  ; preds = %456
+ThrowNullRef156:                                  ; preds = %456
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef157:                                  ; preds = %460
+ThrowNullRef158:                                  ; preds = %460
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef159:                                  ; preds = %474
+ThrowNullRef160:                                  ; preds = %474
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef161:                                  ; preds = %477
+ThrowNullRef162:                                  ; preds = %477
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef163:                                  ; preds = %394
+ThrowNullRef164:                                  ; preds = %394
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef165:                                  ; preds = %398
+ThrowNullRef166:                                  ; preds = %398
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef167:                                  ; preds = %401
+ThrowNullRef168:                                  ; preds = %401
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef169:                                  ; preds = %407
+ThrowNullRef170:                                  ; preds = %407
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1939,8 +2021,8 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
-  br i1 %NullCheck, label %22, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %ThrowNullRef, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
@@ -1948,8 +2030,8 @@ entry:
   store i32 %24, i32* %loc0
   %25 = load i32, i32* %loc0
   %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %26, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %27
 
 ; <label>:27                                      ; preds = %22
   %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
@@ -1971,7 +2053,7 @@ ThrowNullRef:                                     ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1989,8 +2071,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -2022,15 +2104,15 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2048,16 +2130,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
   %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
   store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %15
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
@@ -2072,8 +2154,8 @@ entry:
   %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
   %29 = ptrtoint i16 addrspace(1)* %28 to i64
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %19
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
@@ -2089,19 +2171,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2114,8 +2196,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
@@ -2128,7 +2210,7 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[loadElem]
+Failed to read AppDomain.PrepareDataForSetup[storeElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
@@ -2202,8 +2284,8 @@ entry:
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
-  br i1 %NullCheck24, label %27, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = load i64, i64 addrspace(1)* %26
@@ -2218,8 +2300,8 @@ entry:
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
-  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
   %41 = load i64, i64 addrspace(1)* %39
@@ -2236,8 +2318,8 @@ entry:
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
-  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
   %54 = load i64, i64 addrspace(1)* %52
@@ -2252,8 +2334,8 @@ entry:
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
   %67 = load i64, i64 addrspace(1)* %65
@@ -2270,8 +2352,8 @@ entry:
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
-  br i1 %NullCheck16, label %79, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
   %80 = load i64, i64 addrspace(1)* %78
@@ -2286,8 +2368,8 @@ entry:
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
-  br i1 %NullCheck18, label %92, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
   %93 = load i64, i64 addrspace(1)* %91
@@ -2304,8 +2386,8 @@ entry:
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
-  br i1 %NullCheck12, label %105, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = load i64, i64 addrspace(1)* %104
@@ -2320,8 +2402,8 @@ entry:
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
-  br i1 %NullCheck14, label %118, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
   %119 = load i64, i64 addrspace(1)* %117
@@ -2337,8 +2419,8 @@ entry:
 
 ; <label>:128                                     ; preds = %20
   %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
-  br i1 %NullCheck4, label %130, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %129, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %130
 
 ; <label>:130                                     ; preds = %128
   %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
@@ -2346,8 +2428,8 @@ entry:
   %133 = load i16, i16 addrspace(1)* %132, align 8
   %134 = zext i16 %133 to i32
   %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
-  br i1 %NullCheck6, label %136, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %135, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %136
 
 ; <label>:136                                     ; preds = %130
   %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
@@ -2360,8 +2442,8 @@ entry:
 
 ; <label>:143                                     ; preds = %136
   %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
-  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %144, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %145
 
 ; <label>:145                                     ; preds = %143
   %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
@@ -2369,8 +2451,8 @@ entry:
   %148 = load i16, i16 addrspace(1)* %147, align 8
   %149 = zext i16 %148 to i32
   %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %150, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %151
 
 ; <label>:151                                     ; preds = %145
   %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
@@ -2388,8 +2470,8 @@ entry:
 
 ; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
-  br i1 %NullCheck, label %163, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %ThrowNullRef, label %163
 
 ; <label>:163                                     ; preds = %161
   %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
@@ -2399,8 +2481,8 @@ entry:
 
 ; <label>:167                                     ; preds = %163
   %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
-  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %168, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %169
 
 ; <label>:169                                     ; preds = %167
   %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
@@ -2432,55 +2514,55 @@ ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %167
+ThrowNullRef2:                                    ; preds = %167
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %128
+ThrowNullRef4:                                    ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %130
+ThrowNullRef6:                                    ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %143
+ThrowNullRef8:                                    ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %145
+ThrowNullRef10:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %102
+ThrowNullRef12:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %105
+ThrowNullRef14:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %76
+ThrowNullRef16:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %79
+ThrowNullRef18:                                   ; preds = %79
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %50
+ThrowNullRef20:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %53
+ThrowNullRef22:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %24
+ThrowNullRef24:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %27
+ThrowNullRef26:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2503,15 +2585,15 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2519,16 +2601,16 @@ entry:
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
   store i32 %8, i32* %loc0
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
   %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
   store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
@@ -2546,16 +2628,16 @@ entry:
 
 ; <label>:23                                      ; preds = %64
   %24 = load i16*, i16** %loc3
-  %NullCheck12 = icmp ne i16* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i16* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
   store i32 %27, i32* %loc5
   %28 = load i16*, i16** %loc4
-  %NullCheck14 = icmp ne i16* %28, null
-  br i1 %NullCheck14, label %29, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %28, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = load i16, i16* %28, align 8
@@ -2620,15 +2702,15 @@ entry:
 
 ; <label>:67                                      ; preds = %64
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
-  br i1 %NullCheck8, label %69, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %68, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %69
 
 ; <label>:69                                      ; preds = %67
   %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
   %71 = load i32, i32 addrspace(1)* %70
   %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
-  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %73
 
 ; <label>:73                                      ; preds = %69
   %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
@@ -2645,31 +2727,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %67
+ThrowNullRef8:                                    ; preds = %67
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %69
+ThrowNullRef10:                                   ; preds = %69
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2710,14 +2792,14 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
   %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
@@ -2730,14 +2812,14 @@ entry:
 
 ; <label>:11                                      ; preds = %4
   %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
   %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
@@ -2749,14 +2831,14 @@ entry:
 
 ; <label>:22                                      ; preds = %16
   %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
   %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
-  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
-  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
@@ -2804,23 +2886,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2836,7 +2918,280 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[loadElem]
+Successfully read RuntimeType.IsAssignableFrom
+
+define i8 @RuntimeType.IsAssignableFrom(%System.RuntimeType addrspace(1)* %param0, %System.Type addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.RuntimeType addrspace(1)*
+  %arg1 = alloca %System.Type addrspace(1)*
+  %loc0 = alloca %System.RuntimeType addrspace(1)*
+  %loc1 = alloca %"System.Type[]" addrspace(1)*
+  %loc2 = alloca i32
+  store %System.RuntimeType addrspace(1)* %param0, %System.RuntimeType addrspace(1)** %this
+  store %System.Type addrspace(1)* %param1, %System.Type addrspace(1)** %arg1
+  %0 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %1 = icmp ne %System.Type addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i8 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %5 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %6 = bitcast %System.Type addrspace(1)* %4 to %System.Object addrspace(1)*
+  %7 = bitcast %System.RuntimeType addrspace(1)* %5 to %System.Object addrspace(1)*
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %6, %System.Object addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %3
+  ret i8 1
+
+; <label>:12                                      ; preds = %3
+  %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 152
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 32
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
+  %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
+  %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
+  store %System.RuntimeType addrspace(1)* %25, %System.RuntimeType addrspace(1)** %loc0
+  %26 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %27 = icmp eq %System.RuntimeType addrspace(1)* %26, null
+  br i1 %27, label %34, label %28
+
+; <label>:28                                      ; preds = %15
+  %29 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %30 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)*)*)(%System.RuntimeType addrspace(1)* %29, %System.RuntimeType addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+; <label>:34                                      ; preds = %15
+  %35 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %36 = call %System.Reflection.Emit.TypeBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Reflection.Emit.TypeBuilder addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %35)
+  %37 = icmp eq %System.Reflection.Emit.TypeBuilder addrspace(1)* %36, null
+  br i1 %37, label %139, label %38
+
+; <label>:38                                      ; preds = %34
+  %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %42
+
+; <label>:42                                      ; preds = %38
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 152
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 40
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
+  %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
+  %53 = zext i8 %52 to i32
+  %54 = icmp eq i32 %53, 0
+  br i1 %54, label %56, label %55
+
+; <label>:55                                      ; preds = %42
+  ret i8 1
+
+; <label>:56                                      ; preds = %42
+  %57 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %58 = bitcast %System.RuntimeType addrspace(1)* %57 to %System.Type addrspace(1)*
+  %59 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %58)
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %64 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.Type addrspace(1)* %63, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = bitcast %System.RuntimeType addrspace(1)* %64 to %System.Type addrspace(1)*
+  %67 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %63, %System.Type addrspace(1)* %66)
+  %68 = zext i8 %67 to i32
+  %69 = trunc i32 %68 to i8
+  ret i8 %69
+
+; <label>:70                                      ; preds = %56
+  %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
+  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %73
+
+; <label>:73                                      ; preds = %70
+  %74 = load i64, i64 addrspace(1)* %72
+  %75 = add i64 %74, 128
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = add i64 %77, 0
+  %79 = inttoptr i64 %78 to i64*
+  %80 = load i64, i64* %79
+  %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
+  %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
+  %83 = call i8 %82(%System.Type addrspace(1)* %81)
+  %84 = zext i8 %83 to i32
+  %85 = icmp eq i32 %84, 0
+  br i1 %85, label %139, label %86
+
+; <label>:86                                      ; preds = %73
+  %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
+  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %89
+
+; <label>:89                                      ; preds = %86
+  %90 = load i64, i64 addrspace(1)* %88
+  %91 = add i64 %90, 128
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = add i64 %93, 24
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
+  %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
+  %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
+  store %"System.Type[]" addrspace(1)* %99, %"System.Type[]" addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %129
+
+; <label>:100                                     ; preds = %132
+  %101 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %102 = load i32, i32* %loc2
+  %NullCheck11 = icmp eq %"System.Type[]" addrspace(1)* %101, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %103
+
+; <label>:103                                     ; preds = %100
+  %104 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 1
+  %105 = load i32, i32 addrspace(1)* %104
+  %106 = zext i32 %105 to i64
+  %107 = zext i32 %102 to i64
+  %BoundsCheck = icmp uge i64 %107, %106
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %108
+
+; <label>:108                                     ; preds = %103
+  %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
+  %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
+  %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
+  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %113
+
+; <label>:113                                     ; preds = %108
+  %114 = load i64, i64 addrspace(1)* %112
+  %115 = add i64 %114, 152
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = add i64 %117, 56
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
+  %123 = zext i8 %122 to i32
+  %124 = icmp ne i32 %123, 0
+  br i1 %124, label %126, label %125
+
+; <label>:125                                     ; preds = %113
+  ret i8 0
+
+; <label>:126                                     ; preds = %113
+  %127 = load i32, i32* %loc2
+  %128 = add i32 %127, 1
+  store i32 %128, i32* %loc2
+  br label %129
+
+; <label>:129                                     ; preds = %89, %126
+  %130 = load i32, i32* %loc2
+  %131 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %NullCheck9 = icmp eq %"System.Type[]" addrspace(1)* %131, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %132
+
+; <label>:132                                     ; preds = %129
+  %133 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %131, i32 0, i32 1
+  %134 = load i32, i32 addrspace(1)* %133
+  %135 = zext i32 %134 to i64
+  %136 = trunc i64 %135 to i32
+  %137 = icmp slt i32 %130, %136
+  br i1 %137, label %100, label %138
+
+; <label>:138                                     ; preds = %132
+  ret i8 1
+
+; <label>:139                                     ; preds = %34, %73
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %129
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %103
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -2893,7 +3248,7 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElem]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -2904,8 +3259,8 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -2997,8 +3352,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
@@ -3059,8 +3414,8 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -3087,8 +3442,8 @@ entry:
 
 ; <label>:17                                      ; preds = %5, %11
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
@@ -3097,8 +3452,8 @@ entry:
 
 ; <label>:22                                      ; preds = %1, %11
   %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
@@ -3109,11 +3464,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %17
+ThrowNullRef2:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %22
+ThrowNullRef4:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3167,15 +3522,15 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
   %15 = load i32, i32 addrspace(1)* %14
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
@@ -3198,7 +3553,7 @@ ThrowNullRef:                                     ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef2:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3232,8 +3587,8 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
@@ -3312,8 +3667,8 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -3327,8 +3682,8 @@ entry:
 ; <label>:5                                       ; preds = %43
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %7 = load i32, i32* %loc1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck6, label %8, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
@@ -3366,8 +3721,8 @@ entry:
 ; <label>:32                                      ; preds = %21, %25
   %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
   %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
-  br i1 %NullCheck8, label %35, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = trunc i32 %34 to i16
@@ -3380,8 +3735,8 @@ entry:
 ; <label>:40                                      ; preds = %1, %35
   %41 = load i32, i32* %loc1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
-  br i1 %NullCheck2, label %43, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %42, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
@@ -3392,8 +3747,8 @@ entry:
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
   %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
-  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
   %51 = load i64, i64 addrspace(1)* %49
@@ -3412,19 +3767,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %40
+ThrowNullRef2:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %47
+ThrowNullRef4:                                    ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %5
+ThrowNullRef6:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %32
+ThrowNullRef8:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3467,8 +3822,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
@@ -3492,11 +3847,391 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(i16* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store i16* %param0, i16** %arg0
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load i32, i32* %arg3
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %42, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %37, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg2
+  %13 = load i32, i32* %arg3
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %37, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %24 = load i32, i32* %arg2
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load i16*, i16** %arg0
+  %35 = load i32, i32* %arg3
+  %36 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %36, i16* %34, i32 %35)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:37                                      ; preds = %5, %16
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %39)
+  %41 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41, %System.String addrspace(1)* %38, %System.String addrspace(1)* %40)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41) #0
+  unreachable
+
+; <label>:42                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
-Failed to read StringBuilder.ToString[loadElemA]
+Successfully read StringBuilder.ToString
+
+define %System.String addrspace(1)* @StringBuilder.ToString(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i16*
+  %loc3 = alloca %"System.Char[]" addrspace(1)*
+  %loc4 = alloca i32
+  %loc5 = alloca i32
+  %loc6 = alloca i16 addrspace(1)*
+  %loc7 = alloca %System.String addrspace(1)*
+  %loc8 = alloca %"System.Char[]" addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %0)
+  %2 = icmp ne i32 %1, 0
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %4
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %6)
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %7)
+  store %System.String addrspace(1)* %8, %System.String addrspace(1)** %loc0
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.Text.StringBuilder addrspace(1)* %9, %System.Text.StringBuilder addrspace(1)** %loc1
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  store %System.String addrspace(1)* %10, %System.String addrspace(1)** %loc7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc7
+  %12 = ptrtoint %System.String addrspace(1)* %11 to i64
+  %13 = icmp eq i64 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %5
+  %15 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %16 = sext i32 %15 to i64
+  %17 = add i64 %12, %16
+  br label %18
+
+; <label>:18                                      ; preds = %5, %14
+  %19 = phi i64 [ %12, %5 ], [ %17, %14 ]
+  %20 = inttoptr i64 %19 to i16*
+  store i16* %20, i16** %loc2
+  br label %21
+
+; <label>:21                                      ; preds = %98, %18
+  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %22, null
+  br i1 %NullCheck, label %ThrowNullRef, label %23
+
+; <label>:23                                      ; preds = %21
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 3
+  %25 = load i32, i32 addrspace(1)* %24, align 8
+  %26 = icmp sle i32 %25, 0
+  br i1 %26, label %96, label %27
+
+; <label>:27                                      ; preds = %23
+  %28 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %28, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %29
+
+; <label>:29                                      ; preds = %27
+  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %28, i32 0, i32 1
+  %31 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %30, align 8
+  store %"System.Char[]" addrspace(1)* %31, %"System.Char[]" addrspace(1)** %loc3
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %33
+
+; <label>:33                                      ; preds = %29
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  store i32 %35, i32* %loc4
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  %39 = load i32, i32 addrspace(1)* %38, align 8
+  store i32 %39, i32* %loc5
+  %40 = load i32, i32* %loc5
+  %41 = load i32, i32* %loc4
+  %42 = add i32 %40, %41
+  %43 = zext i32 %42 to i64
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %45
+
+; <label>:45                                      ; preds = %37
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = sext i32 %47 to i64
+  %49 = icmp sgt i64 %43, %48
+  br i1 %49, label %91, label %50
+
+; <label>:50                                      ; preds = %45
+  %51 = load i32, i32* %loc5
+  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %52, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %53
+
+; <label>:53                                      ; preds = %50
+  %54 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %52, i32 0, i32 1
+  %55 = load i32, i32 addrspace(1)* %54
+  %56 = zext i32 %55 to i64
+  %57 = trunc i64 %56 to i32
+  %58 = icmp ugt i32 %51, %57
+  br i1 %58, label %91, label %59
+
+; <label>:59                                      ; preds = %53
+  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  store %"System.Char[]" addrspace(1)* %60, %"System.Char[]" addrspace(1)** %loc8
+  %61 = icmp eq %"System.Char[]" addrspace(1)* %60, null
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %63, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %64
+
+; <label>:64                                      ; preds = %62
+  %65 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %63, i32 0, i32 1
+  %66 = load i32, i32 addrspace(1)* %65
+  %67 = zext i32 %66 to i64
+  %68 = trunc i64 %67 to i32
+  %69 = icmp ne i32 %68, 0
+  br i1 %69, label %71, label %70
+
+; <label>:70                                      ; preds = %59, %64
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:71                                      ; preds = %64
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %73
+
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %BoundsCheck = icmp uge i64 0, %76
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %77
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %78, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:79                                      ; preds = %70, %77
+  %80 = load i16*, i16** %loc2
+  %81 = load i32, i32* %loc4
+  %82 = sext i32 %81 to i64
+  %83 = mul i64 %82, 2
+  %84 = bitcast i16* %80 to i8*
+  %85 = getelementptr inbounds i8, i8* %84, i64 %83
+  %86 = load i16 addrspace(1)*, i16 addrspace(1)** %loc6
+  %87 = ptrtoint i16 addrspace(1)* %86 to i64
+  %88 = load i32, i32* %loc5
+  %89 = bitcast i8* %85 to i16*
+  %90 = inttoptr i64 %87 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %89, i16* %90, i32 %88)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %96
+
+; <label>:91                                      ; preds = %45, %53
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %94 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %93)
+  %95 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95, %System.String addrspace(1)* %92, %System.String addrspace(1)* %94)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95) #0
+  unreachable
+
+; <label>:96                                      ; preds = %23, %79
+  %97 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %97, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %98
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %97, i32 0, i32 2
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  store %System.Text.StringBuilder addrspace(1)* %100, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %102 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %102, label %21, label %103
+
+; <label>:103                                     ; preds = %98
+  store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc7
+  %104 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  ret %System.String addrspace(1)* %104
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method StringBuilder::get_Length using LLILCJit
+Successfully read StringBuilder.get_Length
+
+define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
+Successfully read RuntimeHelpers.get_OffsetToStringData
+
+define i32 @RuntimeHelpers.get_OffsetToStringData() {
+entry:
+  ret i32 12
+}
+
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
 Successfully read CultureData.CreateCultureData
 
@@ -3514,23 +4249,23 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
   store i8 %4, i8 addrspace(1)* %6
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
@@ -3549,11 +4284,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3566,50 +4301,50 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
   store i32 -1, i32 addrspace(1)* %2
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
   store i32 -1, i32 addrspace(1)* %8
   %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
   store i32 -1, i32 addrspace(1)* %14
   %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
   store i32 -1, i32 addrspace(1)* %17
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
@@ -3623,27 +4358,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3675,7 +4410,136 @@ Failed to read Dictionary`2.Insert[non-const derefAddress]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
 Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
-Failed to read HashHelpers.GetPrime[loadElem]
+Successfully read HashHelpers.GetPrime
+
+define i32 @HashHelpers.GetPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %6, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5, %System.String addrspace(1)* %4)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5) #0
+  unreachable
+
+; <label>:6                                       ; preds = %entry
+  store i32 0, i32* %loc0
+  br label %29
+
+; <label>:7                                       ; preds = %35
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 1296
+  %10 = addrspacecast i8 addrspace(1)* %9 to %"System.Int32[]" addrspace(1)**
+  %11 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %10
+  %12 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Int32[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = zext i32 %15 to i64
+  %17 = zext i32 %12 to i64
+  %BoundsCheck = icmp uge i64 %17, %16
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 3, i32 %12
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  store i32 %20, i32* %loc1
+  %21 = load i32, i32* %loc1
+  %22 = load i32, i32* %arg0
+  %23 = icmp slt i32 %21, %22
+  br i1 %23, label %26, label %24
+
+; <label>:24                                      ; preds = %18
+  %25 = load i32, i32* %loc1
+  ret i32 %25
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %loc0
+  %28 = add i32 %27, 1
+  store i32 %28, i32* %loc0
+  br label %29
+
+; <label>:29                                      ; preds = %6, %26
+  %30 = load i32, i32* %loc0
+  %31 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %32 = getelementptr inbounds i8, i8 addrspace(1)* %31, i64 1296
+  %33 = addrspacecast i8 addrspace(1)* %32 to %"System.Int32[]" addrspace(1)**
+  %34 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %33
+  %NullCheck = icmp eq %"System.Int32[]" addrspace(1)* %34, null
+  br i1 %NullCheck, label %ThrowNullRef, label %35
+
+; <label>:35                                      ; preds = %29
+  %36 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %34, i32 0, i32 1
+  %37 = load i32, i32 addrspace(1)* %36
+  %38 = zext i32 %37 to i64
+  %39 = trunc i64 %38 to i32
+  %40 = icmp slt i32 %30, %39
+  br i1 %40, label %7, label %41
+
+; <label>:41                                      ; preds = %35
+  %42 = load i32, i32* %arg0
+  %43 = or i32 %42, 1
+  store i32 %43, i32* %loc2
+  br label %59
+
+; <label>:44                                      ; preds = %59
+  %45 = load i32, i32* %loc2
+  %46 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %45)
+  %47 = zext i8 %46 to i32
+  %48 = icmp eq i32 %47, 0
+  br i1 %48, label %56, label %49
+
+; <label>:49                                      ; preds = %44
+  %50 = load i32, i32* %loc2
+  %51 = sub i32 %50, 1
+  %52 = srem i32 %51, 101
+  %53 = icmp eq i32 %52, 0
+  br i1 %53, label %56, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = load i32, i32* %loc2
+  ret i32 %55
+
+; <label>:56                                      ; preds = %44, %49
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %57, 2
+  store i32 %58, i32* %loc2
+  br label %59
+
+; <label>:59                                      ; preds = %41, %56
+  %60 = load i32, i32* %loc2
+  %61 = icmp slt i32 %60, 2147483647
+  br i1 %61, label %44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load i32, i32* %arg0
+  ret i32 %63
+
+ThrowNullRef:                                     ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
 Successfully read GenericEqualityComparer`1.GetHashCode
 
@@ -3694,14 +4558,14 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
   %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load i64, i64 addrspace(1)* %7
@@ -3720,7 +4584,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3750,8 +4614,8 @@ entry:
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
@@ -3796,8 +4660,8 @@ entry:
   %35 = bitcast i16* %34 to i8*
   %36 = getelementptr inbounds i8, i8* %35, i64 2
   %37 = bitcast i8* %36 to i16*
-  %NullCheck4 = icmp ne i16* %37, null
-  br i1 %NullCheck4, label %38, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %37, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %38
 
 ; <label>:38                                      ; preds = %27
   %39 = load i16, i16* %37, align 8
@@ -3824,8 +4688,8 @@ entry:
 
 ; <label>:54                                      ; preds = %22, %43
   %55 = load i16*, i16** %loc4
-  %NullCheck2 = icmp ne i16* %55, null
-  br i1 %NullCheck2, label %56, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i16* %55, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %56
 
 ; <label>:56                                      ; preds = %54
   %57 = load i16, i16* %55, align 8
@@ -3850,11 +4714,11 @@ ThrowNullRef:                                     ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %54
+ThrowNullRef2:                                    ; preds = %54
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %27
+ThrowNullRef4:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3871,8 +4735,8 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -3907,8 +4771,8 @@ entry:
 
 ; <label>:26                                      ; preds = %19
   %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
-  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %28
 
 ; <label>:28                                      ; preds = %26
   %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
@@ -3920,7 +4784,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3972,8 +4836,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
@@ -3984,26 +4848,26 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
-  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
@@ -4014,8 +4878,8 @@ entry:
 ; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
@@ -4024,8 +4888,8 @@ entry:
 
 ; <label>:25                                      ; preds = %1, %16, %23
   %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
-  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
@@ -4036,27 +4900,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %20
+ThrowNullRef10:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4069,8 +4933,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -4081,8 +4945,8 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
@@ -4091,8 +4955,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1, %8
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
@@ -4103,11 +4967,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4128,24 +4992,24 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   store i32 %3, i32* %loc0
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
   %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
   store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck4, label %9, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
@@ -4164,15 +5028,15 @@ entry:
 ; <label>:18                                      ; preds = %70
   %19 = load i16*, i16** %loc3
   %20 = bitcast i16* %19 to i64*
-  %NullCheck10 = icmp ne i64* %20, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %20, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = load i64, i64* %20, align 8
   %23 = load i16*, i16** %loc4
   %24 = bitcast i16* %23 to i64*
-  %NullCheck12 = icmp ne i64* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = load i64, i64* %24, align 8
@@ -4188,8 +5052,8 @@ entry:
   %31 = bitcast i16* %30 to i8*
   %32 = getelementptr inbounds i8, i8* %31, i64 8
   %33 = bitcast i8* %32 to i64*
-  %NullCheck14 = icmp ne i64* %33, null
-  br i1 %NullCheck14, label %34, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = load i64, i64* %33, align 8
@@ -4197,8 +5061,8 @@ entry:
   %37 = bitcast i16* %36 to i8*
   %38 = getelementptr inbounds i8, i8* %37, i64 8
   %39 = bitcast i8* %38 to i64*
-  %NullCheck16 = icmp ne i64* %39, null
-  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %40
 
 ; <label>:40                                      ; preds = %34
   %41 = load i64, i64* %39, align 8
@@ -4214,8 +5078,8 @@ entry:
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %NullCheck18 = icmp ne i64* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = load i64, i64* %48, align 8
@@ -4223,8 +5087,8 @@ entry:
   %52 = bitcast i16* %51 to i8*
   %53 = getelementptr inbounds i8, i8* %52, i64 16
   %54 = bitcast i8* %53 to i64*
-  %NullCheck20 = icmp ne i64* %54, null
-  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64* %54, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %55
 
 ; <label>:55                                      ; preds = %49
   %56 = load i64, i64* %54, align 8
@@ -4262,15 +5126,15 @@ entry:
 ; <label>:74                                      ; preds = %95
   %75 = load i16*, i16** %loc3
   %76 = bitcast i16* %75 to i32*
-  %NullCheck6 = icmp ne i32* %76, null
-  br i1 %NullCheck6, label %77, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32* %76, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %77
 
 ; <label>:77                                      ; preds = %74
   %78 = load i32, i32* %76, align 8
   %79 = load i16*, i16** %loc4
   %80 = bitcast i16* %79 to i32*
-  %NullCheck8 = icmp ne i32* %80, null
-  br i1 %NullCheck8, label %81, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i32* %80, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %81
 
 ; <label>:81                                      ; preds = %77
   %82 = load i32, i32* %80, align 8
@@ -4318,43 +5182,43 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %74
+ThrowNullRef6:                                    ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %77
+ThrowNullRef8:                                    ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %29
+ThrowNullRef14:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %34
+ThrowNullRef16:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4376,8 +5240,8 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load i64, i64 addrspace(1)* %4
@@ -4389,8 +5253,8 @@ entry:
   %12 = load i64, i64* %11
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %5
   %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
@@ -4399,8 +5263,8 @@ entry:
   %18 = load i8, i8* %arg2
   %19 = zext i8 %18 to i32
   %20 = trunc i32 %19 to i8
-  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %15
   %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
@@ -4411,11 +5275,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4442,8 +5306,8 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
@@ -4466,16 +5330,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
   %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = load i64, i64 addrspace(1)* %19
@@ -4500,8 +5364,8 @@ entry:
 ; <label>:35                                      ; preds = %30
   %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
@@ -4514,8 +5378,8 @@ entry:
 
 ; <label>:42                                      ; preds = %1, %38
   %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
-  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
@@ -4526,19 +5390,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %35
+ThrowNullRef2:                                    ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %42
+ThrowNullRef8:                                    ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4551,14 +5415,14 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
@@ -4570,7 +5434,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4583,8 +5447,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
@@ -4613,51 +5477,51 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
   %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
   %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
   %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
   %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
-  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
   store i64 %21, i64 addrspace(1)* %23
   %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %25 = load i64, i64* %loc0
-  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
@@ -4668,27 +5532,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %22
+ThrowNullRef12:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4701,8 +5565,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
@@ -4713,19 +5577,19 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
@@ -4734,8 +5598,8 @@ entry:
 
 ; <label>:15                                      ; preds = %1, %13
   %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
@@ -4746,19 +5610,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %15
+ThrowNullRef8:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4771,8 +5635,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -4831,8 +5695,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
@@ -4882,8 +5746,8 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
-  br i1 %NullCheck, label %17, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %ThrowNullRef, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
@@ -4894,15 +5758,15 @@ entry:
 
 ; <label>:22                                      ; preds = %17
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
-  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
   %26 = load i32, i32 addrspace(1)* %25
   %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
-  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %27, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
@@ -4925,8 +5789,8 @@ entry:
 ; <label>:40                                      ; preds = %17
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
-  br i1 %NullCheck6, label %43, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %41, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
@@ -4938,34 +5802,17 @@ ThrowNullRef:                                     ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %24
+ThrowNullRef4:                                    ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %40
+ThrowNullRef6:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
-}
-
-INFO:  jitting method Object::ReferenceEquals using LLILCJit
-Successfully read Object.ReferenceEquals
-
-define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
-entry:
-  %arg0 = alloca %System.Object addrspace(1)*
-  %arg1 = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
-  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
-  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = icmp eq %System.Object addrspace(1)* %0, %1
-  %3 = sext i1 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
 }
 
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
@@ -4978,21 +5825,21 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
   %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
-  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
@@ -5007,28 +5854,28 @@ entry:
 ; <label>:13                                      ; preds = %8, %12
   %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
   %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
   %21 = load i32, i32 addrspace(1)* %20, align 8
   %22 = add i32 %21, 1
-  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
   store i32 %22, i32 addrspace(1)* %24
   %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
@@ -5039,27 +5886,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5077,7 +5924,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::Setup using LLILCJit
-Failed to read AppDomain.Setup[loadElem]
+Failed to read AppDomain.Setup[unbox]
 INFO:  jitting method Thread::GetDomain using LLILCJit
 Successfully read Thread.GetDomain
 
@@ -5108,8 +5955,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
@@ -5122,14 +5969,14 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
   %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
@@ -5141,11 +5988,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5173,8 +6020,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -5189,7 +6036,328 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
 Failed to read KeyCollection.System.Collections.Generic.IEnumerable<TKey>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Successfully read Enumerator.MoveNext
+
+define i8 @Enumerator.MoveNext(%"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.RuntimeTypeHandle* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*
+  %"$TypeArg" = alloca %System.RuntimeTypeHandle*
+  store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
+  %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 8
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %76, label %12
+
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
+  br label %76
+
+; <label>:13                                      ; preds = %85
+  %14 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck19 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %15
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, i32 0, i32 0
+  %17 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %16, align 8
+  %NullCheck21 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, i32 0, i32 2
+  %20 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %19, align 8
+  %21 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck23 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %22
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, i32 0, i32 2
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %NullCheck25 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 3, i32 %24
+  %NullCheck27 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %32
+
+; <label>:32                                      ; preds = %30
+  %33 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, i32 0, i32 2
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = icmp slt i32 %34, 0
+  br i1 %35, label %68, label %36
+
+; <label>:36                                      ; preds = %32
+  %37 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %38 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck29 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %39
+
+; <label>:39                                      ; preds = %36
+  %40 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, i32 0, i32 0
+  %41 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %40, align 8
+  %NullCheck31 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, i32 0, i32 2
+  %44 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %43, align 8
+  %45 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck33 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, i32 0, i32 2
+  %48 = load i32, i32 addrspace(1)* %47, align 8
+  %NullCheck35 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %49
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = zext i32 %51 to i64
+  %53 = zext i32 %48 to i64
+  %BoundsCheck37 = icmp uge i64 %53, %52
+  br i1 %BoundsCheck37, label %ThrowIndexOutOfRange38, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 3, i32 %48
+  %NullCheck39 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %56
+
+; <label>:56                                      ; preds = %54
+  %57 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, i32 0, i32 0
+  %58 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck41 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %59
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %60, %System.__Canon addrspace(1)* %58)
+  %61 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck43 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  %64 = load i32, i32 addrspace(1)* %63, align 8
+  %65 = add i32 %64, 1
+  %NullCheck45 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  store i32 %65, i32 addrspace(1)* %67
+  ret i8 1
+
+; <label>:68                                      ; preds = %32
+  %69 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck47 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %73 = add i32 %72, 1
+  %NullCheck49 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %74
+
+; <label>:74                                      ; preds = %70
+  %75 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  store i32 %73, i32 addrspace(1)* %75
+  br label %76
+
+; <label>:76                                      ; preds = %8, %12, %74
+  %77 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %78
+
+; <label>:78                                      ; preds = %76
+  %79 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, i32 0, i32 2
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck7 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %82
+
+; <label>:82                                      ; preds = %78
+  %83 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, i32 0, i32 0
+  %84 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %83, align 8
+  %NullCheck9 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %85
+
+; <label>:85                                      ; preds = %82
+  %86 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, i32 0, i32 7
+  %87 = load i32, i32 addrspace(1)* %86, align 8
+  %88 = icmp ult i32 %80, %87
+  br i1 %88, label %13, label %89
+
+; <label>:89                                      ; preds = %85
+  %90 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %91 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck11 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %92
+
+; <label>:92                                      ; preds = %89
+  %93 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, i32 0, i32 0
+  %94 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck13 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %95
+
+; <label>:95                                      ; preds = %92
+  %96 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, i32 0, i32 7
+  %97 = load i32, i32 addrspace(1)* %96, align 8
+  %98 = add i32 %97, 1
+  %NullCheck15 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %99
+
+; <label>:99                                      ; preds = %95
+  %100 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, i32 0, i32 2
+  store i32 %98, i32 addrspace(1)* %100
+  %101 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck17 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %102
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %103, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %92
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef22:                                   ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef24:                                   ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef26:                                   ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef28:                                   ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef30:                                   ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef32:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef34:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef36:                                   ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange38:                           ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef40:                                   ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef42:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef44:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef46:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef48:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef50:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -5200,8 +6368,8 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -5232,9 +6400,9 @@ Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
 Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
-Failed to read String.MakeSeparatorList[loadElemA]
+Failed to read String.MakeSeparatorList[storeElem]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
-Failed to read String.InternalSplitKeepEmptyEntries[loadElem]
+Failed to read String.InternalSplitKeepEmptyEntries[storeElem]
 INFO:  jitting method Path::IsRelative using LLILCJit
 Successfully read Path.IsRelative
 
@@ -5243,8 +6411,8 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -5254,8 +6422,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
@@ -5271,8 +6439,8 @@ entry:
 
 ; <label>:17                                      ; preds = %7
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
@@ -5288,8 +6456,8 @@ entry:
 
 ; <label>:29                                      ; preds = %19
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %31
 
 ; <label>:31                                      ; preds = %29
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
@@ -5300,8 +6468,8 @@ entry:
 
 ; <label>:36                                      ; preds = %31
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
-  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %37, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
@@ -5312,8 +6480,8 @@ entry:
 
 ; <label>:43                                      ; preds = %31, %38
   %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
-  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %45
 
 ; <label>:45                                      ; preds = %43
   %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
@@ -5324,8 +6492,8 @@ entry:
 
 ; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %50
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
@@ -5336,8 +6504,8 @@ entry:
 
 ; <label>:57                                      ; preds = %1, %7, %19, %45, %52
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
-  br i1 %NullCheck14, label %59, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %59
 
 ; <label>:59                                      ; preds = %57
   %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
@@ -5347,8 +6515,8 @@ entry:
 
 ; <label>:63                                      ; preds = %59
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
@@ -5359,8 +6527,8 @@ entry:
 
 ; <label>:70                                      ; preds = %65
   %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
-  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.String addrspace(1)* %71, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %72
 
 ; <label>:72                                      ; preds = %70
   %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
@@ -5379,39 +6547,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %17
+ThrowNullRef4:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %29
+ThrowNullRef6:                                    ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %36
+ThrowNullRef8:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %43
+ThrowNullRef10:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %50
+ThrowNullRef12:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %57
+ThrowNullRef14:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %63
+ThrowNullRef16:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %70
+ThrowNullRef18:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5419,7 +6587,293 @@ ThrowNullRef17:                                   ; preds = %70
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
-Failed to read String.TrimHelper[loadElem]
+Successfully read String.TrimHelper
+
+define %System.String addrspace(1)* @String.TrimHelper(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i16
+  %loc4 = alloca i32
+  %loc5 = alloca i16
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = sub i32 %3, 1
+  store i32 %4, i32* %loc0
+  store i32 0, i32* %loc1
+  %5 = load i32, i32* %arg2
+  %6 = icmp eq i32 %5, 1
+  br i1 %6, label %62, label %7
+
+; <label>:7                                       ; preds = %1
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:8                                       ; preds = %58
+  store i32 0, i32* %loc2
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load i32, i32* %loc1
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2, i32 %10
+  %13 = load i16, i16 addrspace(1)* %12
+  %14 = zext i16 %13 to i32
+  %15 = trunc i32 %14 to i16
+  store i16 %15, i16* %loc3
+  store i32 0, i32* %loc2
+  br label %34
+
+; <label>:16                                      ; preds = %37
+  %17 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %18 = load i32, i32* %loc2
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %17, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %19
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = zext i32 %18 to i64
+  %BoundsCheck = icmp uge i64 %23, %22
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %24
+
+; <label>:24                                      ; preds = %19
+  %25 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 3, i32 %18
+  %26 = load i16, i16 addrspace(1)* %25, align 8
+  %27 = zext i16 %26 to i32
+  %28 = load i16, i16* %loc3
+  %29 = zext i16 %28 to i32
+  %30 = icmp eq i32 %27, %29
+  br i1 %30, label %43, label %31
+
+; <label>:31                                      ; preds = %24
+  %32 = load i32, i32* %loc2
+  %33 = add i32 %32, 1
+  store i32 %33, i32* %loc2
+  br label %34
+
+; <label>:34                                      ; preds = %11, %31
+  %35 = load i32, i32* %loc2
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = icmp slt i32 %35, %41
+  br i1 %42, label %16, label %43
+
+; <label>:43                                      ; preds = %24, %37
+  %44 = load i32, i32* %loc2
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %45, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp eq i32 %44, %50
+  br i1 %51, label %62, label %52
+
+; <label>:52                                      ; preds = %46
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %7, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %57, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %58
+
+; <label>:58                                      ; preds = %55
+  %59 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %60 = load i32, i32 addrspace(1)* %59
+  %61 = icmp slt i32 %56, %60
+  br i1 %61, label %8, label %62
+
+; <label>:62                                      ; preds = %1, %46, %58
+  %63 = load i32, i32* %arg2
+  %64 = icmp eq i32 %63, 0
+  br i1 %64, label %122, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %66, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %67
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %66, i32 0, i32 1
+  %69 = load i32, i32 addrspace(1)* %68
+  %70 = sub i32 %69, 1
+  store i32 %70, i32* %loc0
+  br label %118
+
+; <label>:71                                      ; preds = %118
+  store i32 0, i32* %loc4
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %73 = load i32, i32* %loc0
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %74
+
+; <label>:74                                      ; preds = %71
+  %75 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 2, i32 %73
+  %76 = load i16, i16 addrspace(1)* %75
+  %77 = zext i16 %76 to i32
+  %78 = trunc i32 %77 to i16
+  store i16 %78, i16* %loc5
+  store i32 0, i32* %loc4
+  br label %97
+
+; <label>:79                                      ; preds = %100
+  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %81 = load i32, i32* %loc4
+  %NullCheck19 = icmp eq %"System.Char[]" addrspace(1)* %80, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
+
+; <label>:82                                      ; preds = %79
+  %83 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 1
+  %84 = load i32, i32 addrspace(1)* %83
+  %85 = zext i32 %84 to i64
+  %86 = zext i32 %81 to i64
+  %BoundsCheck21 = icmp uge i64 %86, %85
+  br i1 %BoundsCheck21, label %ThrowIndexOutOfRange22, label %87
+
+; <label>:87                                      ; preds = %82
+  %88 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 3, i32 %81
+  %89 = load i16, i16 addrspace(1)* %88, align 8
+  %90 = zext i16 %89 to i32
+  %91 = load i16, i16* %loc5
+  %92 = zext i16 %91 to i32
+  %93 = icmp eq i32 %90, %92
+  br i1 %93, label %106, label %94
+
+; <label>:94                                      ; preds = %87
+  %95 = load i32, i32* %loc4
+  %96 = add i32 %95, 1
+  store i32 %96, i32* %loc4
+  br label %97
+
+; <label>:97                                      ; preds = %74, %94
+  %98 = load i32, i32* %loc4
+  %99 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck15 = icmp eq %"System.Char[]" addrspace(1)* %99, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %100
+
+; <label>:100                                     ; preds = %97
+  %101 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %99, i32 0, i32 1
+  %102 = load i32, i32 addrspace(1)* %101
+  %103 = zext i32 %102 to i64
+  %104 = trunc i64 %103 to i32
+  %105 = icmp slt i32 %98, %104
+  br i1 %105, label %79, label %106
+
+; <label>:106                                     ; preds = %87, %100
+  %107 = load i32, i32* %loc4
+  %108 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck17 = icmp eq %"System.Char[]" addrspace(1)* %108, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %109
+
+; <label>:109                                     ; preds = %106
+  %110 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %108, i32 0, i32 1
+  %111 = load i32, i32 addrspace(1)* %110
+  %112 = zext i32 %111 to i64
+  %113 = trunc i64 %112 to i32
+  %114 = icmp eq i32 %107, %113
+  br i1 %114, label %122, label %115
+
+; <label>:115                                     ; preds = %109
+  %116 = load i32, i32* %loc0
+  %117 = sub i32 %116, 1
+  store i32 %117, i32* %loc0
+  br label %118
+
+; <label>:118                                     ; preds = %67, %115
+  %119 = load i32, i32* %loc0
+  %120 = load i32, i32* %loc1
+  %121 = icmp sge i32 %119, %120
+  br i1 %121, label %71, label %122
+
+; <label>:122                                     ; preds = %62, %109, %118
+  %123 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %124 = load i32, i32* %loc1
+  %125 = load i32, i32* %loc0
+  %126 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %123, i32 %124, i32 %125)
+  ret %System.String addrspace(1)* %126
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %97
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange22:                           ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
 Successfully read String.CreateTrimmedString
 
@@ -5439,8 +6893,8 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
@@ -5535,8 +6989,8 @@ entry:
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i64 2872
   %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
   %8 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %7
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %3
   %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
@@ -5553,8 +7007,8 @@ entry:
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 2864
   %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
   %21 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %20
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
-  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %22
 
 ; <label>:22                                      ; preds = %16
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
@@ -5569,7 +7023,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %16
+ThrowNullRef2:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5586,8 +7040,8 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5613,8 +7067,8 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
@@ -5632,8 +7086,8 @@ entry:
 
 ; <label>:12                                      ; preds = %4
   %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
@@ -5644,8 +7098,8 @@ entry:
 
 ; <label>:19                                      ; preds = %14
   %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %19
   %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
@@ -5660,21 +7114,21 @@ entry:
   %31 = zext i16 %30 to i32
   %32 = bitcast i8* %29 to i16*
   %33 = trunc i32 %31 to i16
-  %NullCheck6 = icmp ne i16* %32, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i16* %32, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %21
   store i16 %33, i16* %32, align 8
   %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %36
 
 ; <label>:36                                      ; preds = %34
   %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
   %38 = load i32, i32 addrspace(1)* %37, align 8
   %39 = add i32 %38, 1
-  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %40
 
 ; <label>:40                                      ; preds = %36
   %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
@@ -5683,16 +7137,16 @@ entry:
 
 ; <label>:42                                      ; preds = %14
   %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
-  br i1 %NullCheck12, label %44, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
   %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
   %47 = load i16, i16* %arg1
   %48 = zext i16 %47 to i32
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = trunc i32 %48 to i16
@@ -5703,31 +7157,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %19
+ThrowNullRef4:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %21
+ThrowNullRef6:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %36
+ThrowNullRef10:                                   ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %42
+ThrowNullRef12:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %44
+ThrowNullRef14:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5740,8 +7194,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -5752,8 +7206,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
@@ -5762,14 +7216,14 @@ entry:
 
 ; <label>:11                                      ; preds = %1
   %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
@@ -5779,15 +7233,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5808,8 +7262,8 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5822,8 +7276,8 @@ entry:
 
 ; <label>:8                                       ; preds = %3
   %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
@@ -5842,15 +7296,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
-  br i1 %NullCheck4, label %22, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
   %24 = load i16*, i16* addrspace(1)* %23, align 8
   %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %25, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
@@ -5859,8 +7313,8 @@ entry:
   store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
@@ -5874,8 +7328,8 @@ entry:
 
 ; <label>:37                                      ; preds = %65
   %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %37
   %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
@@ -5886,16 +7340,16 @@ entry:
   %45 = bitcast i16* %41 to i8*
   %46 = getelementptr inbounds i8, i8* %45, i64 %44
   %47 = bitcast i8* %46 to i16*
-  %NullCheck14 = icmp ne i16* %47, null
-  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %47, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %48
 
 ; <label>:48                                      ; preds = %39
   %49 = load i16, i16* %47, align 8
   %50 = zext i16 %49 to i32
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %52 = load i32, i32* %loc1
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %53
 
 ; <label>:53                                      ; preds = %48
   %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
@@ -5916,8 +7370,8 @@ entry:
 ; <label>:62                                      ; preds = %36, %59
   %63 = load i32, i32* %loc1
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck10, label %65, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %65
 
 ; <label>:65                                      ; preds = %62
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
@@ -5936,15 +7390,15 @@ entry:
 
 ; <label>:74                                      ; preds = %70
   %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
-  br i1 %NullCheck18, label %76, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %76
 
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
   %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
-  br i1 %NullCheck20, label %80, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
   %81 = load i64, i64 addrspace(1)* %79
@@ -5958,8 +7412,8 @@ entry:
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
   %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
-  br i1 %NullCheck22, label %92, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.String addrspace(1)* %90, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %92
 
 ; <label>:92                                      ; preds = %80
   %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
@@ -5969,15 +7423,15 @@ entry:
 
 ; <label>:96                                      ; preds = %70
   %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
-  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %98
 
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
   %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
-  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
   %103 = load i64, i64 addrspace(1)* %101
@@ -5991,8 +7445,8 @@ entry:
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
   %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
-  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.String addrspace(1)* %112, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %114
 
 ; <label>:114                                     ; preds = %102
   %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
@@ -6004,59 +7458,59 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %20
+ThrowNullRef4:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %22
+ThrowNullRef6:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %26
+ThrowNullRef8:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %62
+ThrowNullRef10:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %48
+ThrowNullRef16:                                   ; preds = %48
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %74
+ThrowNullRef18:                                   ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %76
+ThrowNullRef20:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %80
+ThrowNullRef22:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %96
+ThrowNullRef24:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %98
+ThrowNullRef26:                                   ; preds = %98
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %102
+ThrowNullRef28:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6069,15 +7523,15 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
   %3 = load i16*, i16* addrspace(1)* %2, align 8
   %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
@@ -6087,8 +7541,8 @@ entry:
   %10 = bitcast i16* %3 to i8*
   %11 = getelementptr inbounds i8, i8* %10, i64 %9
   %12 = bitcast i8* %11 to i16*
-  %NullCheck4 = icmp ne i16* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %5
   store i16 0, i16* %12, align 8
@@ -6098,11 +7552,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6119,8 +7573,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -6131,8 +7585,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
@@ -6144,15 +7598,15 @@ entry:
 
 ; <label>:14                                      ; preds = %1
   %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
   %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
   %21 = load i64, i64 addrspace(1)* %19
@@ -6171,15 +7625,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %14
+ThrowNullRef4:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %16
+ThrowNullRef6:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6302,14 +7756,6 @@ entry:
   ret %System.String addrspace(1)* %57
 }
 
-INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
-Successfully read RuntimeHelpers.get_OffsetToStringData
-
-define i32 @RuntimeHelpers.get_OffsetToStringData() {
-entry:
-  ret i32 12
-}
-
 INFO:  jitting method String::Equals using LLILCJit
 Successfully read String.Equals
 
@@ -6381,8 +7827,8 @@ entry:
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
-  br i1 %NullCheck24, label %29, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
   %30 = load i64, i64 addrspace(1)* %28
@@ -6397,8 +7843,8 @@ entry:
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
-  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
   %43 = load i64, i64 addrspace(1)* %41
@@ -6418,8 +7864,8 @@ entry:
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
   %59 = load i64, i64 addrspace(1)* %57
@@ -6434,8 +7880,8 @@ entry:
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck22, label %71, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
   %72 = load i64, i64 addrspace(1)* %70
@@ -6455,8 +7901,8 @@ entry:
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
-  br i1 %NullCheck16, label %87, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = load i64, i64 addrspace(1)* %86
@@ -6471,8 +7917,8 @@ entry:
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck18, label %100, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
   %101 = load i64, i64 addrspace(1)* %99
@@ -6492,8 +7938,8 @@ entry:
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
-  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
   %117 = load i64, i64 addrspace(1)* %115
@@ -6508,8 +7954,8 @@ entry:
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
-  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
   %130 = load i64, i64 addrspace(1)* %128
@@ -6528,15 +7974,15 @@ entry:
 
 ; <label>:142                                     ; preds = %22
   %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
-  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %143, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %144
 
 ; <label>:144                                     ; preds = %142
   %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
   %146 = load i32, i32 addrspace(1)* %145
   %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
-  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %147, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %148
 
 ; <label>:148                                     ; preds = %144
   %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
@@ -6557,15 +8003,15 @@ entry:
 
 ; <label>:159                                     ; preds = %22
   %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
-  br i1 %NullCheck, label %161, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %ThrowNullRef, label %161
 
 ; <label>:161                                     ; preds = %159
   %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
   %163 = load i32, i32 addrspace(1)* %162
   %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
-  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %164, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %165
 
 ; <label>:165                                     ; preds = %161
   %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
@@ -6578,8 +8024,8 @@ entry:
 
 ; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
-  br i1 %NullCheck4, label %172, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %171, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %172
 
 ; <label>:172                                     ; preds = %170
   %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
@@ -6589,8 +8035,8 @@ entry:
 
 ; <label>:176                                     ; preds = %172
   %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
-  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %177, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %178
 
 ; <label>:178                                     ; preds = %176
   %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
@@ -6629,55 +8075,55 @@ ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %161
+ThrowNullRef2:                                    ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %170
+ThrowNullRef4:                                    ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %176
+ThrowNullRef6:                                    ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %142
+ThrowNullRef8:                                    ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %144
+ThrowNullRef10:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %113
+ThrowNullRef12:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %116
+ThrowNullRef14:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %84
+ThrowNullRef16:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %87
+ThrowNullRef18:                                   ; preds = %87
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %55
+ThrowNullRef20:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %58
+ThrowNullRef22:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %26
+ThrowNullRef24:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %29
+ThrowNullRef26:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,8 +8161,8 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck, label %14, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %ThrowNullRef, label %14
 
 ; <label>:14                                      ; preds = %8
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
@@ -6760,8 +8206,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
@@ -6770,14 +8216,14 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32, i32* %loc0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %10
   %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
   %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
@@ -6790,15 +8236,15 @@ entry:
 ; <label>:25                                      ; preds = %19
   %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
-  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
   %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
@@ -6807,8 +8253,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %37 = load i32, i32* %loc0
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %38, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %38
 
 ; <label>:38                                      ; preds = %32
   %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
@@ -6817,14 +8263,14 @@ entry:
 
 ; <label>:40                                      ; preds = %19
   %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %40
   %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
   %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
-  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
-  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
@@ -6832,8 +8278,8 @@ entry:
   %48 = zext i32 %47 to i64
   %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
-  br i1 %NullCheck16, label %51, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %51
 
 ; <label>:51                                      ; preds = %45
   %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
@@ -6847,15 +8293,15 @@ entry:
 ; <label>:57                                      ; preds = %51
   %58 = load i16*, i16** %arg1
   %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
-  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %60
 
 ; <label>:60                                      ; preds = %57
   %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
   %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
-  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %64
 
 ; <label>:64                                      ; preds = %60
   %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
@@ -6864,22 +8310,22 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
   %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
-  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %70
 
 ; <label>:70                                      ; preds = %64
   %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
   %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
-  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
-  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
   %75 = load i32, i32 addrspace(1)* %74
   %76 = zext i32 %75 to i64
   %77 = trunc i64 %76 to i32
-  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
-  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %78
 
 ; <label>:78                                      ; preds = %73
   %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
@@ -6901,8 +8347,8 @@ entry:
   %90 = bitcast i16* %86 to i8*
   %91 = getelementptr inbounds i8, i8* %90, i64 %89
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %93
 
 ; <label>:93                                      ; preds = %80
   %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
@@ -6912,8 +8358,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %99 = load i32, i32* %loc2
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %100
 
 ; <label>:100                                     ; preds = %93
   %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
@@ -6928,63 +8374,63 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %25
+ThrowNullRef6:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %32
+ThrowNullRef10:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %40
+ThrowNullRef12:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %45
+ThrowNullRef16:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %57
+ThrowNullRef18:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %60
+ThrowNullRef20:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %64
+ThrowNullRef22:                                   ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %70
+ThrowNullRef24:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %73
+ThrowNullRef26:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %80
+ThrowNullRef28:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %93
+ThrowNullRef30:                                   ; preds = %93
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7004,8 +8450,8 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
@@ -7033,43 +8479,43 @@ entry:
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %14
   %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
   %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   %28 = load i32, i32 addrspace(1)* %27, align 8
   %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
-  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %30
 
 ; <label>:30                                      ; preds = %26
   %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
   %32 = load i32, i32 addrspace(1)* %31, align 8
   %33 = add i32 %28, %32
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %34
 
 ; <label>:34                                      ; preds = %30
   %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   store i32 %33, i32 addrspace(1)* %35
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
   store i32 0, i32 addrspace(1)* %38
   %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %40
 
 ; <label>:40                                      ; preds = %37
   %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
@@ -7082,8 +8528,8 @@ entry:
 
 ; <label>:47                                      ; preds = %40
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
@@ -7098,8 +8544,8 @@ entry:
   %54 = load i32, i32* %loc0
   %55 = sext i32 %54 to i64
   %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
-  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %57
 
 ; <label>:57                                      ; preds = %52
   %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
@@ -7110,68 +8556,35 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %14
+ThrowNullRef2:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %23
+ThrowNullRef4:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %26
+ThrowNullRef6:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %30
+ThrowNullRef8:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %34
+ThrowNullRef10:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %47
+ThrowNullRef14:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %52
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-}
-
-INFO:  jitting method StringBuilder::get_Length using LLILCJit
-Successfully read StringBuilder.get_Length
-
-define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.StringBuilder addrspace(1)*
-  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
-  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
-
-; <label>:1                                       ; preds = %entry
-  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %3 = load i32, i32 addrspace(1)* %2, align 8
-  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
-
-; <label>:5                                       ; preds = %1
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = add i32 %3, %7
-  ret i32 %8
-
-ThrowNullRef:                                     ; preds = %entry
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef16:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7213,70 +8626,70 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
   %6 = load i32, i32 addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
   store i32 %6, i32 addrspace(1)* %8
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
   %13 = load i32, i32 addrspace(1)* %12, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
   store i32 %13, i32 addrspace(1)* %15
   %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
-  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %18
 
 ; <label>:18                                      ; preds = %14
   %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
   %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
   %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
   %34 = load i32, i32 addrspace(1)* %33, align 8
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
-  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
@@ -7287,39 +8700,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %28
+ThrowNullRef16:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %32
+ThrowNullRef18:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7455,13 +8868,13 @@ entry:
 ; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
@@ -7477,16 +8890,16 @@ entry:
 
 ; <label>:18                                      ; preds = %15
   %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
   store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
   %22 = load i32, i32* %loc0
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %24
 
 ; <label>:24                                      ; preds = %20
   %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
@@ -7498,13 +8911,13 @@ entry:
 ; <label>:28                                      ; preds = %15, %24
   %29 = load i32, i32* %arg1
   %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %31
   %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
@@ -7517,20 +8930,20 @@ entry:
   %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
-  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
   %46 = load i32, i32 addrspace(1)* %45, align 8
   %47 = sub i32 %40, %46
-  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
-  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i32 addrspace(1)* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %48
 
 ; <label>:48                                      ; preds = %44
   store i32 %47, i32 addrspace(1)* %39, align 8
@@ -7538,21 +8951,21 @@ entry:
 
 ; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
-  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %51
 
 ; <label>:51                                      ; preds = %49
   %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %53
 
 ; <label>:53                                      ; preds = %51
   %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
   %55 = load i32, i32 addrspace(1)* %54, align 8
   %56 = load i32, i32* %arg2
   %57 = sub i32 %55, %56
-  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %58
 
 ; <label>:58                                      ; preds = %53
   %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
@@ -7562,13 +8975,13 @@ entry:
 ; <label>:60                                      ; preds = %33, %58
   %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
   %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
-  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %63
 
 ; <label>:63                                      ; preds = %60
   %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
-  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
-  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
@@ -7578,15 +8991,15 @@ entry:
 
 ; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
-  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i32 addrspace(1)* %69, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %70
 
 ; <label>:70                                      ; preds = %68
   %71 = load i32, i32 addrspace(1)* %69, align 8
   store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
-  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
@@ -7596,8 +9009,8 @@ entry:
   store i32 %77, i32* %loc4
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
-  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %80
 
 ; <label>:80                                      ; preds = %73
   %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
@@ -7607,71 +9020,71 @@ entry:
 ; <label>:83                                      ; preds = %80
   store i32 0, i32* %loc3
   %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
-  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
-  br i1 %NullCheck26, label %88, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i32 addrspace(1)* %87, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %88
 
 ; <label>:88                                      ; preds = %85
   %89 = load i32, i32 addrspace(1)* %87, align 8
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
-  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %90
 
 ; <label>:90                                      ; preds = %88
   %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
   store i32 %89, i32 addrspace(1)* %91
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
-  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
-  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %96
 
 ; <label>:96                                      ; preds = %94
   %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
-  br i1 %NullCheck34, label %100, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %100
 
 ; <label>:100                                     ; preds = %96
   %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
-  br i1 %NullCheck36, label %102, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %102
 
 ; <label>:102                                     ; preds = %100
   %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
   %104 = load i32, i32 addrspace(1)* %103, align 8
   %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
-  br i1 %NullCheck38, label %106, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %106
 
 ; <label>:106                                     ; preds = %102
   %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
-  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
-  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %108
 
 ; <label>:108                                     ; preds = %106
   %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
   %110 = load i32, i32 addrspace(1)* %109, align 8
   %111 = add i32 %104, %110
-  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %112
 
 ; <label>:112                                     ; preds = %108
   %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
   store i32 %111, i32 addrspace(1)* %113
   %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
-  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i32 addrspace(1)* %114, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %115
 
 ; <label>:115                                     ; preds = %112
   %116 = load i32, i32 addrspace(1)* %114, align 8
@@ -7681,19 +9094,19 @@ entry:
 ; <label>:118                                     ; preds = %115
   %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
-  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %121
 
 ; <label>:121                                     ; preds = %118
   %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
-  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
-  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %123
 
 ; <label>:123                                     ; preds = %121
   %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
   %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
-  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
-  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %126
 
 ; <label>:126                                     ; preds = %123
   %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
@@ -7705,8 +9118,8 @@ entry:
 
 ; <label>:130                                     ; preds = %80, %115, %126
   %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %132
 
 ; <label>:132                                     ; preds = %130
   %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7715,8 +9128,8 @@ entry:
   %136 = load i32, i32* %loc3
   %137 = sub i32 %135, %136
   %138 = sub i32 %134, %137
-  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %139
 
 ; <label>:139                                     ; preds = %132
   %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7728,16 +9141,16 @@ entry:
 
 ; <label>:144                                     ; preds = %139
   %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
-  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %146
 
 ; <label>:146                                     ; preds = %144
   %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
   %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
   %149 = load i32, i32* %loc2
   %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
-  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %151
 
 ; <label>:151                                     ; preds = %146
   %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
@@ -7754,145 +9167,249 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %18
+ThrowNullRef4:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %31
+ThrowNullRef10:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %44
+ThrowNullRef16:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %68
+ThrowNullRef18:                                   ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %70
+ThrowNullRef20:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %73
+ThrowNullRef22:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %83
+ThrowNullRef24:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %85
+ThrowNullRef26:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %88
+ThrowNullRef28:                                   ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %90
+ThrowNullRef30:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %94
+ThrowNullRef32:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %96
+ThrowNullRef34:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %100
+ThrowNullRef36:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %102
+ThrowNullRef38:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %106
+ThrowNullRef40:                                   ; preds = %106
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %108
+ThrowNullRef42:                                   ; preds = %108
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %112
+ThrowNullRef44:                                   ; preds = %112
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %118
+ThrowNullRef46:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %121
+ThrowNullRef48:                                   ; preds = %121
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %123
+ThrowNullRef50:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %130
+ThrowNullRef52:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %132
+ThrowNullRef54:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %144
+ThrowNullRef56:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %146
+ThrowNullRef58:                                   ; preds = %146
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %60
+ThrowNullRef60:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %63
+ThrowNullRef62:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %49
+ThrowNullRef64:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %51
+ThrowNullRef66:                                   ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %53
+ThrowNullRef68:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(%"System.Char[]" addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %arg0 = alloca %"System.Char[]" addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store %"System.Char[]" addrspace(1)* %param0, %"System.Char[]" addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load i32, i32* %arg4
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %43, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %38, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg1
+  %13 = load i32, i32* %arg4
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %38, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %24 = load i32, i32* %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %35 = load i32, i32* %arg3
+  %36 = load i32, i32* %arg4
+  %37 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %37, %"System.Char[]" addrspace(1)* %34, i32 %35, i32 %36)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:38                                      ; preds = %5, %16
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Successfully read Buffer._Memmove
 
@@ -7914,7 +9431,7 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[loadElem]
+Failed to read AppDomain.SetDataHelper[storeElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -7923,8 +9440,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
@@ -7934,8 +9451,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
@@ -7947,15 +9464,15 @@ entry:
   %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
   %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
@@ -7966,15 +9483,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7992,7 +9509,79 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
-Failed to read Dictionary`2.TryGetValue[loadElemA]
+Successfully read Dictionary`2.TryGetValue
+
+define i8 @"Dictionary`2.TryGetValue"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)* addrspace(1)* %param2) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  %arg2 = alloca %System.__Canon addrspace(1)* addrspace(1)*
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  store %System.__Canon addrspace(1)* addrspace(1)* %param2, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  store i32 %2, i32* %loc0
+  %3 = load i32, i32* %loc0
+  %4 = icmp slt i32 %3, 0
+  br i1 %4, label %22, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 2
+  %10 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %9, align 8
+  %11 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = zext i32 %11 to i64
+  %BoundsCheck = icmp uge i64 %16, %15
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 3, i32 %11
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %20, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %6, %System.__Canon addrspace(1)* %21)
+  ret i8 1
+
+; <label>:22                                      ; preds = %entry
+  %23 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %23, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -8058,8 +9647,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
@@ -8091,8 +9680,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
@@ -8171,15 +9760,15 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck, label %19, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %ThrowNullRef, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
   %21 = load i32, i32 addrspace(1)* %20
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
@@ -8202,7 +9791,7 @@ ThrowNullRef:                                     ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %19
+ThrowNullRef2:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8248,8 +9837,8 @@ entry:
   %0 = alloca %System.AppDomainHandle
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %1 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %1, i32 0, i32 15
@@ -8269,8 +9858,8 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
@@ -8286,7 +9875,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -8299,8 +9888,8 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -8327,8 +9916,8 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
@@ -8352,8 +9941,8 @@ entry:
   %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
   store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
@@ -8363,8 +9952,8 @@ entry:
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
@@ -8374,8 +9963,8 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %9
   %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
@@ -8384,8 +9973,8 @@ entry:
 
 ; <label>:18                                      ; preds = %3, %16
   %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
@@ -8397,15 +9986,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %18
+ThrowNullRef6:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8418,8 +10007,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
@@ -8453,15 +10042,15 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
@@ -8473,7 +10062,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8481,7 +10070,7 @@ ThrowNullRef1:                                    ; preds = %1
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
 Failed to read Dictionary`2.System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
@@ -8506,8 +10095,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
@@ -8524,8 +10113,8 @@ entry:
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -8544,7 +10133,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8577,8 +10166,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = load i64, i64* %arg2
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = trunc i32 %3 to i8
@@ -8634,46 +10223,46 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
   %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
-  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
-  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
-  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
@@ -8684,27 +10273,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %20
+ThrowNullRef12:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8717,8 +10306,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -8756,22 +10345,22 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
   %9 = load i64, i64 addrspace(1)* %8, align 8
   %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
   %13 = load i64, i64 addrspace(1)* %12, align 8
   %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %11
   %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
@@ -8788,11 +10377,11 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8882,8 +10471,8 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
@@ -8900,8 +10489,8 @@ entry:
 ; <label>:8                                       ; preds = %1
   %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
   %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
@@ -8911,15 +10500,15 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
   %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
   %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
-  br i1 %NullCheck6, label %21, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
@@ -8946,15 +10535,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8992,15 +10581,15 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
   store i8 %3, i8 addrspace(1)* %5
   %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
@@ -9011,7 +10600,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9027,8 +10616,8 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -9041,8 +10630,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
@@ -9058,7 +10647,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9080,8 +10669,8 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
@@ -9096,8 +10685,8 @@ entry:
 ; <label>:12                                      ; preds = %6
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
@@ -9112,8 +10701,8 @@ entry:
 ; <label>:21                                      ; preds = %15
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
@@ -9128,8 +10717,8 @@ entry:
 ; <label>:30                                      ; preds = %24
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %31, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
@@ -9144,8 +10733,8 @@ entry:
 ; <label>:39                                      ; preds = %33
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
-  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %40, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %42
 
 ; <label>:42                                      ; preds = %39
   %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
@@ -9164,19 +10753,19 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %21
+ThrowNullRef4:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %30
+ThrowNullRef6:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %39
+ThrowNullRef8:                                    ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9243,8 +10832,8 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
@@ -9264,57 +10853,57 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
   store i8 0, i8 addrspace(1)* %2
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
   store i8 0, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
   store i8 0, i8 addrspace(1)* %17
   %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
   store i8 0, i8 addrspace(1)* %20
   %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
-  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
@@ -9325,31 +10914,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %19
+ThrowNullRef14:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9367,8 +10956,8 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
@@ -9380,8 +10969,8 @@ entry:
 
 ; <label>:9                                       ; preds = %4
   %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %9
   %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
@@ -9395,7 +10984,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef2:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9420,8 +11009,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
@@ -9512,8 +11101,8 @@ entry:
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
@@ -9524,8 +11113,8 @@ entry:
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = load i64, i64 addrspace(1)* %12
@@ -9537,8 +11126,8 @@ entry:
   %20 = load i64, i64* %19
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
-  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %13
   %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
@@ -9555,8 +11144,8 @@ entry:
 ; <label>:30                                      ; preds = %25
   %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %32 = load i32, i32* %arg2
-  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
-  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
@@ -9570,15 +11159,15 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %30
+ThrowNullRef2:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9622,87 +11211,87 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
   %10 = load i8, i8 addrspace(1)* %9, align 8
   %11 = zext i8 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %8
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
   store i8 %12, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
   %19 = load i8, i8 addrspace(1)* %18, align 8
   %20 = zext i8 %19 to i32
   %21 = trunc i32 %20 to i8
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
   store i8 %21, i8 addrspace(1)* %23
   %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
   %28 = load i8, i8 addrspace(1)* %27, align 8
   %29 = zext i8 %28 to i32
   %30 = trunc i32 %29 to i8
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
-  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %31
 
 ; <label>:31                                      ; preds = %26
   %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
   store i8 %30, i8 addrspace(1)* %32
   %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
-  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
-  br i1 %NullCheck14, label %40, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %40
 
 ; <label>:40                                      ; preds = %35
   %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
   store i8 %39, i8 addrspace(1)* %41
   %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
-  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %44
 
 ; <label>:44                                      ; preds = %40
   %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
   %46 = load i8, i8 addrspace(1)* %45, align 8
   %47 = zext i8 %46 to i32
   %48 = trunc i32 %47 to i8
-  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
   store i8 %48, i8 addrspace(1)* %50
   %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
-  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
@@ -9713,29 +11302,29 @@ entry:
 ; <label>:56                                      ; preds = %52
   %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
-  br i1 %NullCheck22, label %59, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
   %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
   %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
-  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
-  br i1 %NullCheck24, label %63, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
   %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
-  br i1 %NullCheck26, label %66, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
   %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
-  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
-  br i1 %NullCheck28, label %69, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %69
 
 ; <label>:69                                      ; preds = %66
   %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
@@ -9744,15 +11333,15 @@ entry:
 
 ; <label>:71                                      ; preds = %105
   %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
-  br i1 %NullCheck34, label %73, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %73
 
 ; <label>:73                                      ; preds = %71
   %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
   %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
   %76 = load i32, i32* %loc0
-  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
-  br i1 %NullCheck36, label %77, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
@@ -9766,8 +11355,8 @@ entry:
 
 ; <label>:83                                      ; preds = %77
   %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
-  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
@@ -9775,14 +11364,14 @@ entry:
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
   %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
-  br i1 %NullCheck40, label %91, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
 ; <label>:91                                      ; preds = %85
   %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
   %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
-  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck42, label %94, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %94
 
 ; <label>:94                                      ; preds = %91
   %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
@@ -9798,14 +11387,14 @@ entry:
 ; <label>:99                                      ; preds = %69, %96
   %100 = load i32, i32* %loc0
   %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
-  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %102
 
 ; <label>:102                                     ; preds = %99
   %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
   %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
-  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
-  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
@@ -9819,87 +11408,87 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %26
+ThrowNullRef10:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %31
+ThrowNullRef12:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %35
+ThrowNullRef14:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %40
+ThrowNullRef16:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %56
+ThrowNullRef22:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %59
+ThrowNullRef24:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %63
+ThrowNullRef26:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %66
+ThrowNullRef28:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %102
+ThrowNullRef32:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %71
+ThrowNullRef34:                                   ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %73
+ThrowNullRef36:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %83
+ThrowNullRef38:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %85
+ThrowNullRef40:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %91
+ThrowNullRef42:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9943,15 +11532,15 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
   %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
@@ -9961,28 +11550,28 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
   %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %12
   %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
   %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
   %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
-  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
@@ -9993,23 +11582,23 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %12
+ThrowNullRef6:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10031,15 +11620,15 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
   %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = load i64, i64 addrspace(1)* %7
@@ -10077,13 +11666,13 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[loadElem]
+Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -10111,8 +11700,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -10175,8 +11764,8 @@ entry:
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load float, float* %arg0
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -10310,8 +11899,8 @@ entry:
   store i64 %param0, i64* %arg0
   store i64 %param1, i64* %arg1
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
@@ -10319,8 +11908,8 @@ entry:
   %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
   %5 = load i16*, i16* addrspace(1)* %4, align 8
   %6 = addrspacecast i64* %arg1 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = bitcast i64 addrspace(1)* %6 to i8 addrspace(1)*
@@ -10336,7 +11925,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10370,8 +11959,8 @@ entry:
   %1 = load i32, i32* %arg1
   %2 = sext i32 %1 to i64
   %3 = inttoptr i64 %2 to i16*
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -10424,8 +12013,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, i32)*)(%System.IO.ConsoleStream addrspace(1)* %2, i32 %1)
   %3 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %4 = load i64, i64* %arg1
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
@@ -10436,8 +12025,8 @@ entry:
   %10 = icmp eq i32 %9, 3
   %11 = sext i1 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %5
   %14 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, i32 0, i32 5
@@ -10448,7 +12037,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10471,8 +12060,8 @@ entry:
   %5 = icmp eq i32 %4, 1
   %6 = sext i1 %5 to i32
   %7 = trunc i32 %6 to i8
-  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %2, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.ConsoleStream addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
@@ -10483,8 +12072,8 @@ entry:
   %13 = icmp eq i32 %12, 2
   %14 = sext i1 %13 to i32
   %15 = trunc i32 %14 to i8
-  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %10, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.ConsoleStream addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %8
   %17 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %10, i32 0, i32 4
@@ -10495,7 +12084,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10534,8 +12123,8 @@ entry:
   %arg0 = alloca i64
   store i64 %param0, i64* %arg0
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
@@ -10570,8 +12159,8 @@ entry:
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
   %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = load i64, i64 addrspace(1)* %7
@@ -10675,7 +12264,127 @@ entry:
 INFO:  jitting method Encoding::GetEncoding using LLILCJit
 Failed to read Encoding.GetEncoding[convertToHelperArgumentType]
 INFO:  jitting method EncodingProvider::GetEncodingFromProvider using LLILCJit
-Failed to read EncodingProvider.GetEncodingFromProvider[loadElem]
+Successfully read EncodingProvider.GetEncodingFromProvider
+
+define %System.Text.Encoding addrspace(1)* @EncodingProvider.GetEncodingFromProvider(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca %"System.Text.EncodingProvider[]" addrspace(1)*
+  %loc1 = alloca %System.Text.EncodingProvider addrspace(1)*
+  %loc2 = alloca %System.Text.Encoding addrspace(1)*
+  %loc3 = alloca %System.Text.Encoding addrspace(1)*
+  %loc4 = alloca %"System.Text.EncodingProvider[]" addrspace(1)*
+  %loc5 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1059)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2392
+  %2 = addrspacecast i8 addrspace(1)* %1 to %"System.Text.EncodingProvider[]" addrspace(1)**
+  %3 = load volatile %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %2
+  %4 = icmp ne %"System.Text.EncodingProvider[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %entry
+  ret %System.Text.Encoding addrspace(1)* null
+
+; <label>:6                                       ; preds = %entry
+  %7 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1059)
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i64 2392
+  %9 = addrspacecast i8 addrspace(1)* %8 to %"System.Text.EncodingProvider[]" addrspace(1)**
+  %10 = load volatile %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %9
+  store %"System.Text.EncodingProvider[]" addrspace(1)* %10, %"System.Text.EncodingProvider[]" addrspace(1)** %loc0
+  %11 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc0
+  store %"System.Text.EncodingProvider[]" addrspace(1)* %11, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  store i32 0, i32* %loc5
+  br label %43
+
+; <label>:12                                      ; preds = %46
+  %13 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  %14 = load i32, i32* %loc5
+  %NullCheck1 = icmp eq %"System.Text.EncodingProvider[]" addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %13, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = zext i32 %17 to i64
+  %19 = zext i32 %14 to i64
+  %BoundsCheck = icmp uge i64 %19, %18
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %20
+
+; <label>:20                                      ; preds = %15
+  %21 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %13, i32 0, i32 3, i32 %14
+  %22 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)* addrspace(1)* %21, align 8
+  store %System.Text.EncodingProvider addrspace(1)* %22, %System.Text.EncodingProvider addrspace(1)** %loc1
+  %23 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)** %loc1
+  %24 = load i32, i32* %arg0
+  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i64 addrspace(1)*
+  %NullCheck3 = icmp eq i64 addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
+
+; <label>:26                                      ; preds = %20
+  %27 = load i64, i64 addrspace(1)* %25
+  %28 = add i64 %27, 64
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 40
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Text.Encoding addrspace(1)* (%System.Text.EncodingProvider addrspace(1)*, i32)*
+  %35 = call %System.Text.Encoding addrspace(1)* %34(%System.Text.EncodingProvider addrspace(1)* %23, i32 %24)
+  store %System.Text.Encoding addrspace(1)* %35, %System.Text.Encoding addrspace(1)** %loc2
+  %36 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc2
+  %37 = icmp eq %System.Text.Encoding addrspace(1)* %36, null
+  br i1 %37, label %40, label %38
+
+; <label>:38                                      ; preds = %26
+  %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc2
+  store %System.Text.Encoding addrspace(1)* %39, %System.Text.Encoding addrspace(1)** %loc3
+  br label %53
+
+; <label>:40                                      ; preds = %26
+  %41 = load i32, i32* %loc5
+  %42 = add i32 %41, 1
+  store i32 %42, i32* %loc5
+  br label %43
+
+; <label>:43                                      ; preds = %6, %40
+  %44 = load i32, i32* %loc5
+  %45 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  %NullCheck = icmp eq %"System.Text.EncodingProvider[]" addrspace(1)* %45, null
+  br i1 %NullCheck, label %ThrowNullRef, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp slt i32 %44, %50
+  br i1 %51, label %12, label %52
+
+; <label>:52                                      ; preds = %46
+  ret %System.Text.Encoding addrspace(1)* null
+
+; <label>:53                                      ; preds = %38
+  %54 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc3
+  ret %System.Text.Encoding addrspace(1)* %54
+
+ThrowNullRef:                                     ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method EncodingProvider::.cctor using LLILCJit
 Successfully read EncodingProvider..cctor
 
@@ -10694,7 +12403,7 @@ Failed to read Encoding.get_InternalSyncObject[Call HasTypeArg]
 INFO:  jitting method Hashtable::.ctor using LLILCJit
 Failed to read Hashtable..ctor[Volatile store]
 INFO:  jitting method Hashtable::get_Item using LLILCJit
-Failed to read Hashtable.get_Item[loadElemA]
+Failed to read Hashtable.get_Item[loadNonPrimitiveObj]
 INFO:  jitting method Hashtable::InitHash using LLILCJit
 Successfully read Hashtable.InitHash
 
@@ -10714,8 +12423,8 @@ entry:
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -10731,15 +12440,15 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
   %15 = load i32, i32* %loc0
-  %NullCheck2 = icmp ne i32 addrspace(1)* %14, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i32 addrspace(1)* %14, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %3
   store i32 %15, i32 addrspace(1)* %14, align 8
   %17 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %18 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %NullCheck4 = icmp ne i32 addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i32 addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = load i32, i32 addrspace(1)* %18, align 8
@@ -10748,8 +12457,8 @@ entry:
   %23 = sub i32 %22, 1
   %24 = urem i32 %21, %23
   %25 = add i32 1, %24
-  %NullCheck6 = icmp ne i32 addrspace(1)* %17, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32 addrspace(1)* %17, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %19
   store i32 %25, i32 addrspace(1)* %17, align 8
@@ -10760,15 +12469,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %19
+ThrowNullRef6:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10783,8 +12492,8 @@ entry:
   store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
   store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %NullCheck = icmp ne %System.Collections.Hashtable addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Collections.Hashtable addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
@@ -10794,16 +12503,16 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Collections.Hashtable addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Collections.Hashtable addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
   %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck4 = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %9, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
   %13 = inttoptr i64 %11 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
@@ -10813,8 +12522,8 @@ entry:
 ; <label>:15                                      ; preds = %1
   %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -10832,15 +12541,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10854,8 +12563,8 @@ entry:
   store %System.Int32 addrspace(1)* %param0, %System.Int32 addrspace(1)** %this
   %0 = load %System.Int32 addrspace(1)*, %System.Int32 addrspace(1)** %this
   %1 = bitcast %System.Int32 addrspace(1)* %0 to i32 addrspace(1)*
-  %NullCheck = icmp ne i32 addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq i32 addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load i32, i32 addrspace(1)* %1, align 8
@@ -10931,8 +12640,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.UTF8Encoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
@@ -10941,15 +12650,15 @@ entry:
   %9 = load i8, i8* %arg2
   %10 = zext i8 %9 to i32
   %11 = trunc i32 %10 to i8
-  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %8, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %6
   %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %8, i32 0, i32 8
   store i8 %11, i8 addrspace(1)* %13
   %14 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %14, i32 0, i32 8
@@ -10961,8 +12670,8 @@ entry:
 ; <label>:20                                      ; preds = %15
   %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %22, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %22, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = load i64, i64 addrspace(1)* %22
@@ -10984,15 +12693,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %12
+ThrowNullRef4:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11007,8 +12716,8 @@ entry:
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
@@ -11030,16 +12739,16 @@ entry:
 ; <label>:10                                      ; preds = %1
   %11 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
   %12 = load i32, i32* %arg1
-  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %11, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.Encoding addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
   store i32 %12, i32 addrspace(1)* %14
   %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
   %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = load i64, i64 addrspace(1)* %16
@@ -11057,11 +12766,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11074,8 +12783,8 @@ entry:
   %this = alloca %System.Text.UTF8Encoding addrspace(1)*
   store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
   %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.UTF8Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
@@ -11087,16 +12796,16 @@ entry:
 ; <label>:6                                       ; preds = %1
   %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %8 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %10, %System.Text.EncoderFallback addrspace(1)* %8)
   %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %12 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
-  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %11, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %11, i32 0, i32 3
@@ -11109,8 +12818,8 @@ entry:
   %18 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %18, %System.String addrspace(1)* %17)
   %19 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %18 to %System.Text.EncoderFallback addrspace(1)*
-  %NullCheck6 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %16, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %16, i32 0, i32 2
@@ -11120,8 +12829,8 @@ entry:
   %24 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %24, %System.String addrspace(1)* %23)
   %25 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %24 to %System.Text.DecoderFallback addrspace(1)*
-  %NullCheck8 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %22, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %22, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %20
   %27 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %22, i32 0, i32 3
@@ -11132,19 +12841,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %20
+ThrowNullRef8:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11174,8 +12883,8 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load i32, i32* %arg1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -11193,8 +12902,8 @@ entry:
 ; <label>:15                                      ; preds = %8
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %17 = load i32, i32* %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 %17
@@ -11210,7 +12919,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11262,7 +12971,7 @@ entry:
 }
 
 INFO:  jitting method Hashtable::Insert using LLILCJit
-Failed to read Hashtable.Insert[loadElemA]
+Failed to read Hashtable.Insert[storeElem]
 INFO:  jitting method ConsoleEncoding::.ctor using LLILCJit
 Successfully read ConsoleEncoding..ctor
 
@@ -11277,8 +12986,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %1)
   %2 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
@@ -11314,8 +13023,8 @@ entry:
   %2 = call %System.Text.InternalEncoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalEncoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %1)
   %3 = bitcast %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2 to %System.Text.EncoderFallback addrspace(1)*
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
@@ -11325,8 +13034,8 @@ entry:
   %8 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %7)
   %9 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %8 to %System.Text.DecoderFallback addrspace(1)*
-  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %6, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.Encoding addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %4
   %11 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %6, i32 0, i32 3
@@ -11337,7 +13046,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11356,15 +13065,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* %1)
   %2 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   %6 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, i32 0, i32 1
@@ -11375,7 +13084,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11403,8 +13112,8 @@ entry:
   store %System.Text.InternalDecoderBestFitFallback addrspace(1)* %param0, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
   %0 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
@@ -11414,15 +13123,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %4)
   %5 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %6)
   %9 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, i32 0, i32 1
@@ -11433,11 +13142,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11505,8 +13214,8 @@ entry:
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
   %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = load i64, i64 addrspace(1)* %19
@@ -11570,8 +13279,8 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.ConsoleStream addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
@@ -11602,31 +13311,31 @@ entry:
   store i8 %param4, i8* %arg4
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %3, %System.IO.Stream addrspace(1)* %1)
   %4 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %4, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
   %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %4, i32 0, i32 4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %5)
   %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %6
   %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
   %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
   %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = load i64, i64 addrspace(1)* %13
@@ -11638,8 +13347,8 @@ entry:
   %21 = load i64, i64* %20
   %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %8, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %8, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %14
   %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 5
@@ -11657,24 +13366,24 @@ entry:
   %31 = load i32, i32* %arg3
   %32 = sext i32 %31 to i64
   %33 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %32)
-  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %30, null
-  br i1 %NullCheck10, label %34, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.StreamWriter addrspace(1)* %30, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %35, %"System.Char[]" addrspace(1)* %33)
   %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %37, null
-  br i1 %NullCheck12, label %38, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.StreamWriter addrspace(1)* %37, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %38
 
 ; <label>:38                                      ; preds = %34
   %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
   %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
   %41 = load i32, i32* %arg3
   %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %42, null
-  br i1 %NullCheck14, label %43, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %42, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
   %44 = load i64, i64 addrspace(1)* %42
@@ -11688,30 +13397,30 @@ entry:
   %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
   %53 = sext i32 %52 to i64
   %54 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %53)
-  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
-  br i1 %NullCheck16, label %55, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %55
 
 ; <label>:55                                      ; preds = %43
   %56 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %56, %"System.Byte[]" addrspace(1)* %54)
   %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %58 = load i32, i32* %arg3
-  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %57, null
-  br i1 %NullCheck18, label %59, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.StreamWriter addrspace(1)* %57, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %59
 
 ; <label>:59                                      ; preds = %55
   %60 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 10
   store i32 %58, i32 addrspace(1)* %60
   %61 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %61, null
-  br i1 %NullCheck20, label %62, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.IO.StreamWriter addrspace(1)* %61, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %62
 
 ; <label>:62                                      ; preds = %59
   %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
   %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
   %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
   %67 = load i64, i64 addrspace(1)* %65
@@ -11729,15 +13438,15 @@ entry:
 
 ; <label>:78                                      ; preds = %66
   %79 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %79, null
-  br i1 %NullCheck24, label %80, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.StreamWriter addrspace(1)* %79, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %80
 
 ; <label>:80                                      ; preds = %78
   %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
   %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
   %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %83, null
-  br i1 %NullCheck26, label %84, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %83, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
   %85 = load i64, i64 addrspace(1)* %83
@@ -11754,8 +13463,8 @@ entry:
 
 ; <label>:95                                      ; preds = %84
   %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.IO.StreamWriter addrspace(1)* %96, null
-  br i1 %NullCheck28, label %97, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.IO.StreamWriter addrspace(1)* %96, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %97
 
 ; <label>:97                                      ; preds = %95
   %98 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 12
@@ -11769,8 +13478,8 @@ entry:
   %103 = icmp eq i32 %102, 0
   %104 = sext i1 %103 to i32
   %105 = trunc i32 %104 to i8
-  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %100, null
-  br i1 %NullCheck30, label %106, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.IO.StreamWriter addrspace(1)* %100, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %106
 
 ; <label>:106                                     ; preds = %99
   %107 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %100, i32 0, i32 13
@@ -11781,63 +13490,63 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %6
+ThrowNullRef4:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %29
+ThrowNullRef10:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %34
+ThrowNullRef12:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %38
+ThrowNullRef14:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %43
+ThrowNullRef16:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %55
+ThrowNullRef18:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %59
+ThrowNullRef20:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %62
+ThrowNullRef22:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %78
+ThrowNullRef24:                                   ; preds = %78
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %80
+ThrowNullRef26:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %95
+ThrowNullRef28:                                   ; preds = %95
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11850,15 +13559,15 @@ entry:
   %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = load i64, i64 addrspace(1)* %4
@@ -11876,7 +13585,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11926,35 +13635,35 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
   %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderNLS addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %7 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.EncoderNLS addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Text.Encoding addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.Encoding addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Text.EncoderNLS addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.EncoderNLS addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
   %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck8 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = load i64, i64 addrspace(1)* %16
@@ -11973,19 +13682,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12011,8 +13720,8 @@ entry:
   %this = alloca %System.Text.Encoding addrspace(1)*
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
@@ -12032,15 +13741,15 @@ entry:
   %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
   store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
   %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
   store i32 0, i32 addrspace(1)* %2
   %3 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, i32 0, i32 2
@@ -12050,15 +13759,15 @@ entry:
 
 ; <label>:8                                       ; preds = %4
   %9 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
   %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
   %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = load i64, i64 addrspace(1)* %13
@@ -12079,15 +13788,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12102,16 +13811,16 @@ entry:
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = load i32, i32* %arg1
   %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
   %7 = load i64, i64 addrspace(1)* %5
@@ -12129,7 +13838,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12166,8 +13875,8 @@ entry:
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
   %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
   %16 = load i64, i64 addrspace(1)* %14
@@ -12188,8 +13897,8 @@ entry:
   %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
   %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
   %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %31, null
-  br i1 %NullCheck2, label %32, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = load i64, i64 addrspace(1)* %31
@@ -12232,7 +13941,7 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12245,14 +13954,14 @@ entry:
   %this = alloca %System.Text.EncoderReplacementFallback addrspace(1)*
   store %System.Text.EncoderReplacementFallback addrspace(1)* %param0, %System.Text.EncoderReplacementFallback addrspace(1)** %this
   %0 = load %System.Text.EncoderReplacementFallback addrspace(1)*, %System.Text.EncoderReplacementFallback addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -12263,7 +13972,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12293,8 +14002,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
@@ -12326,8 +14035,8 @@ entry:
   %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
   store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
@@ -12339,8 +14048,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Threading.Tasks.Task addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %7)
@@ -12363,7 +14072,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12382,8 +14091,8 @@ entry:
   store i8 %param1, i8* %arg1
   store i8 %param2, i8* %arg2
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
@@ -12397,8 +14106,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1, %5
   %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 9
@@ -12429,8 +14138,8 @@ entry:
 
 ; <label>:25                                      ; preds = %8, %20
   %26 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %26, null
-  br i1 %NullCheck4, label %27, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %26, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %26, i32 0, i32 12
@@ -12441,22 +14150,22 @@ entry:
 
 ; <label>:32                                      ; preds = %27
   %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %33, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.IO.StreamWriter addrspace(1)* %33, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %32
   %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 12
   store i8 1, i8 addrspace(1)* %35
   %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
-  br i1 %NullCheck8, label %37, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
   %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
   %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck10 = icmp ne i64 addrspace(1)* %40, null
-  br i1 %NullCheck10, label %41, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64 addrspace(1)* %40, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i64, i64 addrspace(1)* %40
@@ -12470,8 +14179,8 @@ entry:
   %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
   store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
   %51 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %NullCheck12 = icmp ne %"System.Byte[]" addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Byte[]" addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %41
   %53 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %51, i32 0, i32 1
@@ -12483,16 +14192,16 @@ entry:
 
 ; <label>:58                                      ; preds = %52
   %59 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %59, null
-  br i1 %NullCheck14, label %60, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.IO.StreamWriter addrspace(1)* %59, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %60
 
 ; <label>:60                                      ; preds = %58
   %61 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %59, i32 0, i32 3
   %62 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
   %64 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %NullCheck16 = icmp ne %"System.Byte[]" addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %"System.Byte[]" addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %60
   %66 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %64, i32 0, i32 1
@@ -12500,8 +14209,8 @@ entry:
   %68 = zext i32 %67 to i64
   %69 = trunc i64 %68 to i32
   %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck18, label %71, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
   %72 = load i64, i64 addrspace(1)* %70
@@ -12517,29 +14226,29 @@ entry:
 
 ; <label>:80                                      ; preds = %27, %52, %71
   %81 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %81, null
-  br i1 %NullCheck20, label %82, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.IO.StreamWriter addrspace(1)* %81, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
 
 ; <label>:82                                      ; preds = %80
   %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %81, i32 0, i32 5
   %84 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %83, align 8
   %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.IO.StreamWriter addrspace(1)* %85, null
-  br i1 %NullCheck22, label %86, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.IO.StreamWriter addrspace(1)* %85, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %86
 
 ; <label>:86                                      ; preds = %82
   %87 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 7
   %88 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %87, align 8
   %89 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %89, null
-  br i1 %NullCheck24, label %90, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.StreamWriter addrspace(1)* %89, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %90
 
 ; <label>:90                                      ; preds = %86
   %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %89, i32 0, i32 9
   %92 = load i32, i32 addrspace(1)* %91, align 8
   %93 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.IO.StreamWriter addrspace(1)* %93, null
-  br i1 %NullCheck26, label %94, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.IO.StreamWriter addrspace(1)* %93, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %93, i32 0, i32 6
@@ -12547,8 +14256,8 @@ entry:
   %97 = load i8, i8* %arg2
   %98 = zext i8 %97 to i32
   %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
-  %NullCheck28 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck28, label %100, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
   %101 = load i64, i64 addrspace(1)* %99
@@ -12563,8 +14272,8 @@ entry:
   %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
   store i32 %110, i32* %loc1
   %111 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %111, null
-  br i1 %NullCheck30, label %112, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.IO.StreamWriter addrspace(1)* %111, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %112
 
 ; <label>:112                                     ; preds = %100
   %113 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %111, i32 0, i32 9
@@ -12575,23 +14284,23 @@ entry:
 
 ; <label>:116                                     ; preds = %112
   %117 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck32 = icmp ne %System.IO.StreamWriter addrspace(1)* %117, null
-  br i1 %NullCheck32, label %118, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.IO.StreamWriter addrspace(1)* %117, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %118
 
 ; <label>:118                                     ; preds = %116
   %119 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %117, i32 0, i32 3
   %120 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %119, align 8
   %121 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.IO.StreamWriter addrspace(1)* %121, null
-  br i1 %NullCheck34, label %122, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.IO.StreamWriter addrspace(1)* %121, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %122
 
 ; <label>:122                                     ; preds = %118
   %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
   %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
   %125 = load i32, i32* %loc1
   %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
-  %NullCheck36 = icmp ne i64 addrspace(1)* %126, null
-  br i1 %NullCheck36, label %127, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64 addrspace(1)* %126, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
   %128 = load i64, i64 addrspace(1)* %126
@@ -12613,15 +14322,15 @@ entry:
 
 ; <label>:140                                     ; preds = %136
   %141 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.IO.StreamWriter addrspace(1)* %141, null
-  br i1 %NullCheck38, label %142, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.IO.StreamWriter addrspace(1)* %141, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %142
 
 ; <label>:142                                     ; preds = %140
   %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
   %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
   %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
-  %NullCheck40 = icmp ne i64 addrspace(1)* %145, null
-  br i1 %NullCheck40, label %146, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i64 addrspace(1)* %145, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
   %147 = load i64, i64 addrspace(1)* %145
@@ -12642,83 +14351,83 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %25
+ThrowNullRef4:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %32
+ThrowNullRef6:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %37
+ThrowNullRef10:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %41
+ThrowNullRef12:                                   ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %58
+ThrowNullRef14:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %60
+ThrowNullRef16:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %65
+ThrowNullRef18:                                   ; preds = %65
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %80
+ThrowNullRef20:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %82
+ThrowNullRef22:                                   ; preds = %82
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %86
+ThrowNullRef24:                                   ; preds = %86
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %90
+ThrowNullRef26:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %94
+ThrowNullRef28:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %100
+ThrowNullRef30:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %116
+ThrowNullRef32:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %118
+ThrowNullRef34:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %122
+ThrowNullRef36:                                   ; preds = %122
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %140
+ThrowNullRef38:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %142
+ThrowNullRef40:                                   ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12785,8 +14494,8 @@ entry:
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %1 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
-  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
@@ -12794,8 +14503,8 @@ entry:
   %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
   %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
   %8 = load i64, i64 addrspace(1)* %6
@@ -12811,8 +14520,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %17, %System.IFormatProvider addrspace(1)* %16)
   %18 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %19 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %18, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.SyncTextWriter addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %7
   %21 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %18, i32 0, i32 4
@@ -12823,11 +14532,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12840,8 +14549,8 @@ entry:
   %this = alloca %System.IO.TextWriter addrspace(1)*
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.TextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
@@ -12851,8 +14560,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.Threading.Thread addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Threading.Thread addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %6)
@@ -12861,8 +14570,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1
   %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.TextWriter addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.TextWriter addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %11, i32 0, i32 2
@@ -12873,11 +14582,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13074,8 +14783,8 @@ entry:
   store float %param1, float* %arg1
   store i8 0, i8* %loc1
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
@@ -13085,16 +14794,16 @@ entry:
   %5 = addrspacecast i8* %loc1 to i8 addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %4, i8 addrspace(1)* %5)
   %6 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.SyncTextWriter addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
   %10 = load float, float* %arg1
   %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
   %13 = load i64, i64 addrspace(1)* %11
@@ -13129,11 +14838,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13150,8 +14859,8 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load float, float* %arg1
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -13165,8 +14874,8 @@ entry:
   call void %11(%System.IO.TextWriter addrspace(1)* %0, float %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
   %15 = load i64, i64 addrspace(1)* %13
@@ -13184,7 +14893,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13202,8 +14911,8 @@ entry:
   %1 = addrspacecast float* %arg1 to float addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -13218,8 +14927,8 @@ entry:
   %14 = bitcast float addrspace(1)* %1 to %System.Single addrspace(1)*
   %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Single addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Single addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
   %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
   %18 = load i64, i64 addrspace(1)* %16
@@ -13237,7 +14946,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13253,8 +14962,8 @@ entry:
   store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
   %0 = load %System.Single addrspace(1)*, %System.Single addrspace(1)** %this
   %1 = bitcast %System.Single addrspace(1)* %0 to float addrspace(1)*
-  %NullCheck = icmp ne float addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq float addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load float, float addrspace(1)* %1, align 8
@@ -13279,8 +14988,8 @@ entry:
   %loc0 = alloca %System.Globalization.NumberFormatInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 3
@@ -13290,8 +14999,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
@@ -13301,24 +15010,24 @@ entry:
   store %System.Globalization.NumberFormatInfo addrspace(1)* %10, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
   %11 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %7
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
   %15 = load i8, i8 addrspace(1)* %14, align 8
   %16 = zext i8 %15 to i32
   %17 = trunc i32 %16 to i8
-  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %11, null
-  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %11, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %13
   %19 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %11, i32 0, i32 29
   store i8 %17, i8 addrspace(1)* %19
   %20 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %21 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %20, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %20, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %18
   %23 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %20, i32 0, i32 3
@@ -13327,8 +15036,8 @@ entry:
 
 ; <label>:24                                      ; preds = %1, %22
   %25 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %25, null
-  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %25, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %26
 
 ; <label>:26                                      ; preds = %24
   %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %25, i32 0, i32 3
@@ -13339,23 +15048,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %18
+ThrowNullRef8:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13380,168 +15089,168 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 18
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %8, align 8
-  %NullCheck2 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %5, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %5, i32 0, i32 4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %9)
   %12 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 19
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %15, align 8
-  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %12, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %12, i32 0, i32 5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %16)
   %19 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %20 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %20, null
-  br i1 %NullCheck8, label %21, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %20, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %20, i32 0, i32 23
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  %NullCheck10 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %19, null
-  br i1 %NullCheck10, label %24, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %19, i32 0, i32 7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %25, %System.String addrspace(1)* %23)
   %26 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %27 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %27, i32 0, i32 22
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %29, align 8
-  %NullCheck14 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %26, null
-  br i1 %NullCheck14, label %31, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %26, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %26, i32 0, i32 6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %32, %System.String addrspace(1)* %30)
   %33 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %34 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Globalization.CultureData addrspace(1)* %34, null
-  br i1 %NullCheck16, label %35, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Globalization.CultureData addrspace(1)* %34, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %34, i32 0, i32 51
   %37 = load i32, i32 addrspace(1)* %36, align 8
-  %NullCheck18 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %33, null
-  br i1 %NullCheck18, label %38, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %33, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %33, i32 0, i32 21
   store i32 %37, i32 addrspace(1)* %39
   %40 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %41 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Globalization.CultureData addrspace(1)* %41, null
-  br i1 %NullCheck20, label %42, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Globalization.CultureData addrspace(1)* %41, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %41, i32 0, i32 52
   %44 = load i32, i32 addrspace(1)* %43, align 8
-  %NullCheck22 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %40, null
-  br i1 %NullCheck22, label %45, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %40, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %40, i32 0, i32 25
   store i32 %44, i32 addrspace(1)* %46
   %47 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %48 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.Globalization.CultureData addrspace(1)* %48, null
-  br i1 %NullCheck24, label %49, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Globalization.CultureData addrspace(1)* %48, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %49
 
 ; <label>:49                                      ; preds = %45
   %50 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %48, i32 0, i32 29
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck26 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %47, null
-  br i1 %NullCheck26, label %52, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %47, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %47, i32 0, i32 10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %53, %System.String addrspace(1)* %51)
   %54 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %55 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Globalization.CultureData addrspace(1)* %55, null
-  br i1 %NullCheck28, label %56, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Globalization.CultureData addrspace(1)* %55, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %56
 
 ; <label>:56                                      ; preds = %52
   %57 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %55, i32 0, i32 35
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %57, align 8
-  %NullCheck30 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %54, null
-  br i1 %NullCheck30, label %59, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %54, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %54, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %60, %System.String addrspace(1)* %58)
   %61 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %62 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck32 = icmp ne %System.Globalization.CultureData addrspace(1)* %62, null
-  br i1 %NullCheck32, label %63, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Globalization.CultureData addrspace(1)* %62, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %62, i32 0, i32 34
   %65 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %64, align 8
-  %NullCheck34 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %61, null
-  br i1 %NullCheck34, label %66, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %61, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %61, i32 0, i32 9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %67, %System.String addrspace(1)* %65)
   %68 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %69 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck36 = icmp ne %System.Globalization.CultureData addrspace(1)* %69, null
-  br i1 %NullCheck36, label %70, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Globalization.CultureData addrspace(1)* %69, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %70
 
 ; <label>:70                                      ; preds = %66
   %71 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %69, i32 0, i32 55
   %72 = load i32, i32 addrspace(1)* %71, align 8
-  %NullCheck38 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %68, null
-  br i1 %NullCheck38, label %73, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %68, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %68, i32 0, i32 22
   store i32 %72, i32 addrspace(1)* %74
   %75 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %76 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck40 = icmp ne %System.Globalization.CultureData addrspace(1)* %76, null
-  br i1 %NullCheck40, label %77, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Globalization.CultureData addrspace(1)* %76, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %76, i32 0, i32 57
   %79 = load i32, i32 addrspace(1)* %78, align 8
-  %NullCheck42 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %75, null
-  br i1 %NullCheck42, label %80, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %75, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %80
 
 ; <label>:80                                      ; preds = %77
   %81 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %75, i32 0, i32 24
   store i32 %79, i32 addrspace(1)* %81
   %82 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %83 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck44 = icmp ne %System.Globalization.CultureData addrspace(1)* %83, null
-  br i1 %NullCheck44, label %84, label %ThrowNullRef43
+  %NullCheck43 = icmp eq %System.Globalization.CultureData addrspace(1)* %83, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %84
 
 ; <label>:84                                      ; preds = %80
   %85 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %83, i32 0, i32 56
   %86 = load i32, i32 addrspace(1)* %85, align 8
-  %NullCheck46 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %82, null
-  br i1 %NullCheck46, label %87, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %82, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %82, i32 0, i32 23
@@ -13550,8 +15259,8 @@ entry:
 
 ; <label>:89                                      ; preds = %entry
   %90 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck100 = icmp ne %System.Globalization.CultureData addrspace(1)* %90, null
-  br i1 %NullCheck100, label %91, label %ThrowNullRef99
+  %NullCheck99 = icmp eq %System.Globalization.CultureData addrspace(1)* %90, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %91
 
 ; <label>:91                                      ; preds = %89
   %92 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %90, i32 0, i32 2
@@ -13569,8 +15278,8 @@ entry:
   %102 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %103 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %104 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %103)
-  %NullCheck48 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %102, null
-  br i1 %NullCheck48, label %105, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %102, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %105
 
 ; <label>:105                                     ; preds = %101
   %106 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %102, i32 0, i32 1
@@ -13578,8 +15287,8 @@ entry:
   %107 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %108 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %109 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %108)
-  %NullCheck50 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %107, null
-  br i1 %NullCheck50, label %110, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %107, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %110
 
 ; <label>:110                                     ; preds = %105
   %111 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %107, i32 0, i32 2
@@ -13587,8 +15296,8 @@ entry:
   %112 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %113 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %114 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %113)
-  %NullCheck52 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %112, null
-  br i1 %NullCheck52, label %115, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %112, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %115
 
 ; <label>:115                                     ; preds = %110
   %116 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %112, i32 0, i32 27
@@ -13596,8 +15305,8 @@ entry:
   %117 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %118 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %119 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %118)
-  %NullCheck54 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %117, null
-  br i1 %NullCheck54, label %120, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %117, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %120
 
 ; <label>:120                                     ; preds = %115
   %121 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %117, i32 0, i32 26
@@ -13605,8 +15314,8 @@ entry:
   %122 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %123 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %124 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %123)
-  %NullCheck56 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %122, null
-  br i1 %NullCheck56, label %125, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %122, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %125
 
 ; <label>:125                                     ; preds = %120
   %126 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %122, i32 0, i32 17
@@ -13614,8 +15323,8 @@ entry:
   %127 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %128 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %129 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %128)
-  %NullCheck58 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %127, null
-  br i1 %NullCheck58, label %130, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %127, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %130
 
 ; <label>:130                                     ; preds = %125
   %131 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %127, i32 0, i32 18
@@ -13623,8 +15332,8 @@ entry:
   %132 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %133 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %134 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %133)
-  %NullCheck60 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %132, null
-  br i1 %NullCheck60, label %135, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %132, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %135
 
 ; <label>:135                                     ; preds = %130
   %136 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %132, i32 0, i32 14
@@ -13632,8 +15341,8 @@ entry:
   %137 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %138 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %139 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %138)
-  %NullCheck62 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %137, null
-  br i1 %NullCheck62, label %140, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %137, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %140
 
 ; <label>:140                                     ; preds = %135
   %141 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %137, i32 0, i32 13
@@ -13641,71 +15350,71 @@ entry:
   %142 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %143 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %144 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %143)
-  %NullCheck64 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %142, null
-  br i1 %NullCheck64, label %145, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %142, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %145
 
 ; <label>:145                                     ; preds = %140
   %146 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %142, i32 0, i32 12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %146, %System.String addrspace(1)* %144)
   %147 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %148 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck66 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %148, null
-  br i1 %NullCheck66, label %149, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %148, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %149
 
 ; <label>:149                                     ; preds = %145
   %150 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %148, i32 0, i32 21
   %151 = load i32, i32 addrspace(1)* %150, align 8
-  %NullCheck68 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %147, null
-  br i1 %NullCheck68, label %152, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %147, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %152
 
 ; <label>:152                                     ; preds = %149
   %153 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %147, i32 0, i32 28
   store i32 %151, i32 addrspace(1)* %153
   %154 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %155 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck70 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %155, null
-  br i1 %NullCheck70, label %156, label %ThrowNullRef69
+  %NullCheck69 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %155, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %156
 
 ; <label>:156                                     ; preds = %152
   %157 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %155, i32 0, i32 6
   %158 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %157, align 8
-  %NullCheck72 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %154, null
-  br i1 %NullCheck72, label %159, label %ThrowNullRef71
+  %NullCheck71 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %154, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %159
 
 ; <label>:159                                     ; preds = %156
   %160 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %154, i32 0, i32 15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %160, %System.String addrspace(1)* %158)
   %161 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %162 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck74 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %162, null
-  br i1 %NullCheck74, label %163, label %ThrowNullRef73
+  %NullCheck73 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %162, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %163
 
 ; <label>:163                                     ; preds = %159
   %164 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %162, i32 0, i32 1
   %165 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %164, align 8
-  %NullCheck76 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %161, null
-  br i1 %NullCheck76, label %166, label %ThrowNullRef75
+  %NullCheck75 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %161, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %166
 
 ; <label>:166                                     ; preds = %163
   %167 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %161, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %167, %"System.Int32[]" addrspace(1)* %165)
   %168 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %169 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck78 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %169, null
-  br i1 %NullCheck78, label %170, label %ThrowNullRef77
+  %NullCheck77 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %169, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %170
 
 ; <label>:170                                     ; preds = %166
   %171 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %169, i32 0, i32 7
   %172 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %171, align 8
-  %NullCheck80 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %168, null
-  br i1 %NullCheck80, label %173, label %ThrowNullRef79
+  %NullCheck79 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %168, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %173
 
 ; <label>:173                                     ; preds = %170
   %174 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %168, i32 0, i32 16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %174, %System.String addrspace(1)* %172)
   %175 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck82 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %175, null
-  br i1 %NullCheck82, label %176, label %ThrowNullRef81
+  %NullCheck81 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %175, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %176
 
 ; <label>:176                                     ; preds = %173
   %177 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %175, i32 0, i32 4
@@ -13715,14 +15424,14 @@ entry:
 
 ; <label>:180                                     ; preds = %176
   %181 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck84 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %181, null
-  br i1 %NullCheck84, label %182, label %ThrowNullRef83
+  %NullCheck83 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %181, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %182
 
 ; <label>:182                                     ; preds = %180
   %183 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %181, i32 0, i32 4
   %184 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %183, align 8
-  %NullCheck86 = icmp ne %System.String addrspace(1)* %184, null
-  br i1 %NullCheck86, label %185, label %ThrowNullRef85
+  %NullCheck85 = icmp eq %System.String addrspace(1)* %184, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %185
 
 ; <label>:185                                     ; preds = %182
   %186 = getelementptr inbounds %System.String, %System.String addrspace(1)* %184, i32 0, i32 1
@@ -13733,8 +15442,8 @@ entry:
 ; <label>:189                                     ; preds = %176, %185
   %190 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck98 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %190, null
-  br i1 %NullCheck98, label %192, label %ThrowNullRef97
+  %NullCheck97 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %190, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %192
 
 ; <label>:192                                     ; preds = %189
   %193 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %190, i32 0, i32 4
@@ -13743,8 +15452,8 @@ entry:
 
 ; <label>:194                                     ; preds = %185, %192
   %195 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck88 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %195, null
-  br i1 %NullCheck88, label %196, label %ThrowNullRef87
+  %NullCheck87 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %195, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %196
 
 ; <label>:196                                     ; preds = %194
   %197 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %195, i32 0, i32 9
@@ -13754,14 +15463,14 @@ entry:
 
 ; <label>:200                                     ; preds = %196
   %201 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck90 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %201, null
-  br i1 %NullCheck90, label %202, label %ThrowNullRef89
+  %NullCheck89 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %201, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %202
 
 ; <label>:202                                     ; preds = %200
   %203 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %201, i32 0, i32 9
   %204 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %203, align 8
-  %NullCheck92 = icmp ne %System.String addrspace(1)* %204, null
-  br i1 %NullCheck92, label %205, label %ThrowNullRef91
+  %NullCheck91 = icmp eq %System.String addrspace(1)* %204, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %205
 
 ; <label>:205                                     ; preds = %202
   %206 = getelementptr inbounds %System.String, %System.String addrspace(1)* %204, i32 0, i32 1
@@ -13772,14 +15481,14 @@ entry:
 ; <label>:209                                     ; preds = %196, %205
   %210 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %211 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck94 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %211, null
-  br i1 %NullCheck94, label %212, label %ThrowNullRef93
+  %NullCheck93 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %211, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %212
 
 ; <label>:212                                     ; preds = %209
   %213 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %211, i32 0, i32 6
   %214 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %213, align 8
-  %NullCheck96 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %210, null
-  br i1 %NullCheck96, label %215, label %ThrowNullRef95
+  %NullCheck95 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %210, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %215
 
 ; <label>:215                                     ; preds = %212
   %216 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %210, i32 0, i32 9
@@ -13793,203 +15502,203 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %17
+ThrowNullRef8:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %21
+ThrowNullRef10:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %24
+ThrowNullRef12:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %28
+ThrowNullRef14:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %31
+ThrowNullRef16:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %35
+ThrowNullRef18:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %38
+ThrowNullRef20:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %42
+ThrowNullRef22:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %45
+ThrowNullRef24:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %49
+ThrowNullRef26:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %52
+ThrowNullRef28:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %56
+ThrowNullRef30:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %59
+ThrowNullRef32:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %63
+ThrowNullRef34:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %66
+ThrowNullRef36:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %70
+ThrowNullRef38:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %73
+ThrowNullRef40:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %77
+ThrowNullRef42:                                   ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %80
+ThrowNullRef44:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %84
+ThrowNullRef46:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %101
+ThrowNullRef48:                                   ; preds = %101
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %105
+ThrowNullRef50:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %110
+ThrowNullRef52:                                   ; preds = %110
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %115
+ThrowNullRef54:                                   ; preds = %115
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %120
+ThrowNullRef56:                                   ; preds = %120
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %125
+ThrowNullRef58:                                   ; preds = %125
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %130
+ThrowNullRef60:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %135
+ThrowNullRef62:                                   ; preds = %135
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %140
+ThrowNullRef64:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %145
+ThrowNullRef66:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %149
+ThrowNullRef68:                                   ; preds = %149
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %152
+ThrowNullRef70:                                   ; preds = %152
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %156
+ThrowNullRef72:                                   ; preds = %156
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %159
+ThrowNullRef74:                                   ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %163
+ThrowNullRef76:                                   ; preds = %163
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %166
+ThrowNullRef78:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %170
+ThrowNullRef80:                                   ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %173
+ThrowNullRef82:                                   ; preds = %173
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %180
+ThrowNullRef84:                                   ; preds = %180
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %182
+ThrowNullRef86:                                   ; preds = %182
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %194
+ThrowNullRef88:                                   ; preds = %194
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %200
+ThrowNullRef90:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %202
+ThrowNullRef92:                                   ; preds = %202
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %209
+ThrowNullRef94:                                   ; preds = %209
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %212
+ThrowNullRef96:                                   ; preds = %212
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %189
+ThrowNullRef98:                                   ; preds = %189
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %89
+ThrowNullRef100:                                  ; preds = %89
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14017,8 +15726,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 21
@@ -14031,8 +15740,8 @@ entry:
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 16)
   %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 21
@@ -14041,8 +15750,8 @@ entry:
 
 ; <label>:12                                      ; preds = %1, %10
   %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 21
@@ -14053,11 +15762,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %12
+ThrowNullRef4:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14073,8 +15782,8 @@ entry:
   store i32 %param1, i32* %arg1
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %1 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
@@ -14141,8 +15850,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 33
@@ -14155,8 +15864,8 @@ entry:
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 24)
   %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 33
@@ -14165,8 +15874,8 @@ entry:
 
 ; <label>:12                                      ; preds = %1, %10
   %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 33
@@ -14177,11 +15886,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %12
+ThrowNullRef4:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14194,8 +15903,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 53
@@ -14207,8 +15916,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 116)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 53
@@ -14217,8 +15926,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 53
@@ -14229,11 +15938,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14262,8 +15971,8 @@ entry:
 
 ; <label>:7                                       ; preds = %entry, %4
   %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %7
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 2
@@ -14287,8 +15996,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 54
@@ -14300,8 +16009,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 117)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
@@ -14310,8 +16019,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 54
@@ -14322,11 +16031,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14339,8 +16048,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 27
@@ -14352,8 +16061,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 118)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 27
@@ -14362,8 +16071,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 27
@@ -14374,11 +16083,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14391,8 +16100,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 28
@@ -14404,8 +16113,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 119)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 28
@@ -14414,8 +16123,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 28
@@ -14426,11 +16135,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14443,8 +16152,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 26
@@ -14456,8 +16165,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 107)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 26
@@ -14466,8 +16175,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 26
@@ -14478,11 +16187,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14495,8 +16204,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 25
@@ -14508,8 +16217,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 106)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 25
@@ -14518,8 +16227,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 25
@@ -14530,11 +16239,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14547,8 +16256,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 24
@@ -14560,8 +16269,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 105)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 24
@@ -14570,8 +16279,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 24
@@ -14582,11 +16291,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14611,8 +16320,8 @@ entry:
   %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %3)
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %2
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -14623,15 +16332,15 @@ entry:
 
 ; <label>:8                                       ; preds = %62
   %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 9
   %12 = load i32, i32 addrspace(1)* %11, align 8
   %13 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.IO.StreamWriter addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %13, i32 0, i32 10
@@ -14646,15 +16355,15 @@ entry:
 
 ; <label>:20                                      ; preds = %14, %18
   %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
   %24 = load i32, i32 addrspace(1)* %23, align 8
   %25 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %25, null
-  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.StreamWriter addrspace(1)* %25, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %25, i32 0, i32 9
@@ -14675,36 +16384,36 @@ entry:
   %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %37 = load i32, i32* %loc1
   %38 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.StreamWriter addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %35
   %40 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %38, i32 0, i32 7
   %41 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %40, align 8
   %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
-  br i1 %NullCheck14, label %43, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %39
   %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 9
   %45 = load i32, i32 addrspace(1)* %44, align 8
   %46 = load i32, i32* %loc2
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %36, null
-  br i1 %NullCheck16, label %47, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %36, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %47
 
 ; <label>:47                                      ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %36, i32 %37, %"System.Char[]" addrspace(1)* %41, i32 %45, i32 %46)
   %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
   %51 = load i32, i32 addrspace(1)* %50, align 8
   %52 = load i32, i32* %loc2
   %53 = add i32 %51, %52
-  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
-  br i1 %NullCheck20, label %54, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %54
 
 ; <label>:54                                      ; preds = %49
   %55 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
@@ -14726,8 +16435,8 @@ entry:
 
 ; <label>:65                                      ; preds = %62
   %66 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %66, null
-  br i1 %NullCheck2, label %67, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %66, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %67
 
 ; <label>:67                                      ; preds = %65
   %68 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %66, i32 0, i32 11
@@ -14748,49 +16457,259 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %65
+ThrowNullRef2:                                    ; preds = %65
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %20
+ThrowNullRef8:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %22
+ThrowNullRef10:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %35
+ThrowNullRef12:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %43
+ThrowNullRef16:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %47
+ThrowNullRef18:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method String::CopyTo using LLILCJit
-Failed to read String.CopyTo[loadElemA]
+Successfully read String.CopyTo
+
+define void @String.CopyTo(%System.String addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  %loc1 = alloca i16 addrspace(1)*
+  %loc2 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %1 = icmp ne %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg4
+  %7 = icmp sge i32 %6, 0
+  br i1 %7, label %13, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  unreachable
+
+; <label>:13                                      ; preds = %5
+  %14 = load i32, i32* %arg1
+  %15 = icmp sge i32 %14, 0
+  br i1 %15, label %21, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %18)
+  %20 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %20, %System.String addrspace(1)* %17, %System.String addrspace(1)* %19)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %20) #0
+  unreachable
+
+; <label>:21                                      ; preds = %13
+  %22 = load i32, i32* %arg4
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck, label %ThrowNullRef, label %24
+
+; <label>:24                                      ; preds = %21
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load i32, i32* %arg1
+  %28 = sub i32 %26, %27
+  %29 = icmp sle i32 %22, %28
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34, %System.String addrspace(1)* %31, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %24
+  %36 = load i32, i32* %arg3
+  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %37, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
+
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
+  %40 = load i32, i32 addrspace(1)* %39
+  %41 = zext i32 %40 to i64
+  %42 = trunc i64 %41 to i32
+  %43 = load i32, i32* %arg4
+  %44 = sub i32 %42, %43
+  %45 = icmp sgt i32 %36, %44
+  br i1 %45, label %49, label %46
+
+; <label>:46                                      ; preds = %38
+  %47 = load i32, i32* %arg3
+  %48 = icmp sge i32 %47, 0
+  br i1 %48, label %54, label %49
+
+; <label>:49                                      ; preds = %38, %46
+  %50 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %52 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %51)
+  %53 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53, %System.String addrspace(1)* %50, %System.String addrspace(1)* %52)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53) #0
+  unreachable
+
+; <label>:54                                      ; preds = %46
+  %55 = load i32, i32* %arg4
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %97, label %57
+
+; <label>:57                                      ; preds = %54
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %59
+
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 2
+  %61 = bitcast [0 x i16] addrspace(1)* %60 to i16 addrspace(1)*
+  store i16 addrspace(1)* %61, i16 addrspace(1)** %loc0
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  store %"System.Char[]" addrspace(1)* %62, %"System.Char[]" addrspace(1)** %loc2
+  %63 = icmp eq %"System.Char[]" addrspace(1)* %62, null
+  br i1 %63, label %72, label %64
+
+; <label>:64                                      ; preds = %59
+  %65 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc2
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %65, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %66
+
+; <label>:66                                      ; preds = %64
+  %67 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %65, i32 0, i32 1
+  %68 = load i32, i32 addrspace(1)* %67
+  %69 = zext i32 %68 to i64
+  %70 = trunc i64 %69 to i32
+  %71 = icmp ne i32 %70, 0
+  br i1 %71, label %73, label %72
+
+; <label>:72                                      ; preds = %59, %66
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  br label %81
+
+; <label>:73                                      ; preds = %66
+  %74 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc2
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %74, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %75
+
+; <label>:75                                      ; preds = %73
+  %76 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %74, i32 0, i32 1
+  %77 = load i32, i32 addrspace(1)* %76
+  %78 = zext i32 %77 to i64
+  %BoundsCheck = icmp uge i64 0, %78
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %79
+
+; <label>:79                                      ; preds = %75
+  %80 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %74, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %80, i16 addrspace(1)** %loc1
+  br label %81
+
+; <label>:81                                      ; preds = %72, %79
+  %82 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %83 = ptrtoint i16 addrspace(1)* %82 to i64
+  %84 = load i32, i32* %arg3
+  %85 = sext i32 %84 to i64
+  %86 = mul i64 %85, 2
+  %87 = add i64 %83, %86
+  %88 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %89 = ptrtoint i16 addrspace(1)* %88 to i64
+  %90 = load i32, i32* %arg1
+  %91 = sext i32 %90 to i64
+  %92 = mul i64 %91, 2
+  %93 = add i64 %89, %92
+  %94 = load i32, i32* %arg4
+  %95 = inttoptr i64 %87 to i16*
+  %96 = inttoptr i64 %93 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %95, i16* %96, i32 %94)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  br label %97
+
+; <label>:97                                      ; preds = %54, %81
+  ret void
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
 Successfully read ConsoleEncoding.GetPreamble
 
@@ -14827,7 +16746,365 @@ entry:
 }
 
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[loadElemA]
+Successfully read EncoderNLS.GetBytes
+
+define i32 @EncoderNLS.GetBytes(%System.Text.EncoderNLS addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3, %"System.Byte[]" addrspace(1)* %param4, i32 %param5, i8 %param6) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %arg4 = alloca %"System.Byte[]" addrspace(1)*
+  %arg5 = alloca i32
+  %arg6 = alloca i8
+  %loc0 = alloca i32
+  %loc1 = alloca i16 addrspace(1)*
+  %loc2 = alloca i8 addrspace(1)*
+  %loc3 = alloca i32
+  %loc4 = alloca %"System.Char[]" addrspace(1)*
+  %loc5 = alloca %"System.Byte[]" addrspace(1)*
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  store %"System.Byte[]" addrspace(1)* %param4, %"System.Byte[]" addrspace(1)** %arg4
+  store i32 %param5, i32* %arg5
+  store i8 %param6, i8* %arg6
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %1 = icmp eq %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %17, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %7 = icmp eq %"System.Char[]" addrspace(1)* %6, null
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %12
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %12
+
+; <label>:12                                      ; preds = %8, %10
+  %13 = phi %System.String addrspace(1)* [ %9, %8 ], [ %11, %10 ]
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %14)
+  %16 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16, %System.String addrspace(1)* %13, %System.String addrspace(1)* %15)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16) #0
+  unreachable
+
+; <label>:17                                      ; preds = %2
+  %18 = load i32, i32* %arg2
+  %19 = icmp slt i32 %18, 0
+  br i1 %19, label %23, label %20
+
+; <label>:20                                      ; preds = %17
+  %21 = load i32, i32* %arg3
+  %22 = icmp sge i32 %21, 0
+  br i1 %22, label %35, label %23
+
+; <label>:23                                      ; preds = %17, %20
+  %24 = load i32, i32* %arg2
+  %25 = icmp slt i32 %24, 0
+  br i1 %25, label %28, label %26
+
+; <label>:26                                      ; preds = %23
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %30
+
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %30
+
+; <label>:30                                      ; preds = %26, %28
+  %31 = phi %System.String addrspace(1)* [ %27, %26 ], [ %29, %28 ]
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34, %System.String addrspace(1)* %31, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %20
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck, label %ThrowNullRef, label %37
+
+; <label>:37                                      ; preds = %35
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = load i32, i32* %arg2
+  %43 = sub i32 %41, %42
+  %44 = load i32, i32* %arg3
+  %45 = icmp sge i32 %43, %44
+  br i1 %45, label %51, label %46
+
+; <label>:46                                      ; preds = %37
+  %47 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %48 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %49 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %48)
+  %50 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %50, %System.String addrspace(1)* %47, %System.String addrspace(1)* %49)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %50) #0
+  unreachable
+
+; <label>:51                                      ; preds = %37
+  %52 = load i32, i32* %arg5
+  %53 = icmp slt i32 %52, 0
+  br i1 %53, label %63, label %54
+
+; <label>:54                                      ; preds = %51
+  %55 = load i32, i32* %arg5
+  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck1 = icmp eq %"System.Byte[]" addrspace(1)* %56, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %57
+
+; <label>:57                                      ; preds = %54
+  %58 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = zext i32 %59 to i64
+  %61 = trunc i64 %60 to i32
+  %62 = icmp sle i32 %55, %61
+  br i1 %62, label %68, label %63
+
+; <label>:63                                      ; preds = %51, %57
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %66 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %65)
+  %67 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %67, %System.String addrspace(1)* %64, %System.String addrspace(1)* %66)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %67) #0
+  unreachable
+
+; <label>:68                                      ; preds = %57
+  %69 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %69, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %69, i32 0, i32 1
+  %72 = load i32, i32 addrspace(1)* %71
+  %73 = zext i32 %72 to i64
+  %74 = trunc i64 %73 to i32
+  %75 = icmp ne i32 %74, 0
+  br i1 %75, label %78, label %76
+
+; <label>:76                                      ; preds = %70
+  %77 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1)
+  store %"System.Char[]" addrspace(1)* %77, %"System.Char[]" addrspace(1)** %arg1
+  br label %78
+
+; <label>:78                                      ; preds = %70, %76
+  %79 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck5 = icmp eq %"System.Byte[]" addrspace(1)* %79, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %80
+
+; <label>:80                                      ; preds = %78
+  %81 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %79, i32 0, i32 1
+  %82 = load i32, i32 addrspace(1)* %81
+  %83 = zext i32 %82 to i64
+  %84 = trunc i64 %83 to i32
+  %85 = load i32, i32* %arg5
+  %86 = sub i32 %84, %85
+  store i32 %86, i32* %loc0
+  %87 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck7 = icmp eq %"System.Byte[]" addrspace(1)* %87, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %88
+
+; <label>:88                                      ; preds = %80
+  %89 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %87, i32 0, i32 1
+  %90 = load i32, i32 addrspace(1)* %89
+  %91 = zext i32 %90 to i64
+  %92 = trunc i64 %91 to i32
+  %93 = icmp ne i32 %92, 0
+  br i1 %93, label %96, label %94
+
+; <label>:94                                      ; preds = %88
+  %95 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1)
+  store %"System.Byte[]" addrspace(1)* %95, %"System.Byte[]" addrspace(1)** %arg4
+  br label %96
+
+; <label>:96                                      ; preds = %88, %94
+  %97 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  store %"System.Char[]" addrspace(1)* %97, %"System.Char[]" addrspace(1)** %loc4
+  %98 = icmp eq %"System.Char[]" addrspace(1)* %97, null
+  br i1 %98, label %107, label %99
+
+; <label>:99                                      ; preds = %96
+  %100 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc4
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %100, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %101
+
+; <label>:101                                     ; preds = %99
+  %102 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %100, i32 0, i32 1
+  %103 = load i32, i32 addrspace(1)* %102
+  %104 = zext i32 %103 to i64
+  %105 = trunc i64 %104 to i32
+  %106 = icmp ne i32 %105, 0
+  br i1 %106, label %108, label %107
+
+; <label>:107                                     ; preds = %96, %101
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  br label %116
+
+; <label>:108                                     ; preds = %101
+  %109 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc4
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %109, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %110
+
+; <label>:110                                     ; preds = %108
+  %111 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %109, i32 0, i32 1
+  %112 = load i32, i32 addrspace(1)* %111
+  %113 = zext i32 %112 to i64
+  %BoundsCheck = icmp uge i64 0, %113
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %114
+
+; <label>:114                                     ; preds = %110
+  %115 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %109, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %115, i16 addrspace(1)** %loc1
+  br label %116
+
+; <label>:116                                     ; preds = %107, %114
+  %117 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  store %"System.Byte[]" addrspace(1)* %117, %"System.Byte[]" addrspace(1)** %loc5
+  %118 = icmp eq %"System.Byte[]" addrspace(1)* %117, null
+  br i1 %118, label %127, label %119
+
+; <label>:119                                     ; preds = %116
+  %120 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc5
+  %NullCheck13 = icmp eq %"System.Byte[]" addrspace(1)* %120, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %121
+
+; <label>:121                                     ; preds = %119
+  %122 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %120, i32 0, i32 1
+  %123 = load i32, i32 addrspace(1)* %122
+  %124 = zext i32 %123 to i64
+  %125 = trunc i64 %124 to i32
+  %126 = icmp ne i32 %125, 0
+  br i1 %126, label %128, label %127
+
+; <label>:127                                     ; preds = %116, %121
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc2
+  br label %136
+
+; <label>:128                                     ; preds = %121
+  %129 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc5
+  %NullCheck15 = icmp eq %"System.Byte[]" addrspace(1)* %129, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %130
+
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %129, i32 0, i32 1
+  %132 = load i32, i32 addrspace(1)* %131
+  %133 = zext i32 %132 to i64
+  %BoundsCheck17 = icmp uge i64 0, %133
+  br i1 %BoundsCheck17, label %ThrowIndexOutOfRange18, label %134
+
+; <label>:134                                     ; preds = %130
+  %135 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %129, i32 0, i32 3, i32 0
+  store i8 addrspace(1)* %135, i8 addrspace(1)** %loc2
+  br label %136
+
+; <label>:136                                     ; preds = %127, %134
+  %137 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %138 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %139 = ptrtoint i16 addrspace(1)* %138 to i64
+  %140 = load i32, i32* %arg2
+  %141 = sext i32 %140 to i64
+  %142 = mul i64 %141, 2
+  %143 = add i64 %139, %142
+  %144 = load i32, i32* %arg3
+  %145 = load i8 addrspace(1)*, i8 addrspace(1)** %loc2
+  %146 = ptrtoint i8 addrspace(1)* %145 to i64
+  %147 = load i32, i32* %arg5
+  %148 = sext i32 %147 to i64
+  %149 = add i64 %146, %148
+  %150 = load i32, i32* %loc0
+  %151 = load i8, i8* %arg6
+  %152 = zext i8 %151 to i32
+  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i64 addrspace(1)*
+  %NullCheck19 = icmp eq i64 addrspace(1)* %153, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %154
+
+; <label>:154                                     ; preds = %136
+  %155 = load i64, i64 addrspace(1)* %153
+  %156 = add i64 %155, 72
+  %157 = inttoptr i64 %156 to i64*
+  %158 = load i64, i64* %157
+  %159 = add i64 %158, 0
+  %160 = inttoptr i64 %159 to i64*
+  %161 = load i64, i64* %160
+  %162 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to %System.Text.Encoder addrspace(1)*
+  %163 = inttoptr i64 %143 to i16*
+  %164 = inttoptr i64 %149 to i8*
+  %165 = trunc i32 %152 to i8
+  %166 = inttoptr i64 %161 to i32 (%System.Text.Encoder addrspace(1)*, i16*, i32, i8*, i32, i8)*
+  %167 = call i32 %166(%System.Text.Encoder addrspace(1)* %162, i16* %163, i32 %144, i8* %164, i32 %150, i8 %165)
+  store i32 %167, i32* %loc3
+  br label %168
+
+; <label>:168                                     ; preds = %154
+  %169 = load i32, i32* %loc3
+  ret i32 %169
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %110
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %119
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange18:                           ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
 Successfully read EncoderNLS.GetBytes
 
@@ -14916,22 +17193,22 @@ entry:
   %40 = load i8, i8* %arg5
   %41 = zext i8 %40 to i32
   %42 = trunc i32 %41 to i8
-  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %39, null
-  br i1 %NullCheck, label %43, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderNLS addrspace(1)* %39, null
+  br i1 %NullCheck, label %ThrowNullRef, label %43
 
 ; <label>:43                                      ; preds = %38
   %44 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
   store i8 %42, i8 addrspace(1)* %44
   %45 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %45, null
-  br i1 %NullCheck2, label %46, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.EncoderNLS addrspace(1)* %45, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %46
 
 ; <label>:46                                      ; preds = %43
   %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %45, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %47
   %48 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.EncoderNLS addrspace(1)* %48, null
-  br i1 %NullCheck4, label %49, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.EncoderNLS addrspace(1)* %48, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %49
 
 ; <label>:49                                      ; preds = %46
   %50 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %48, i32 0, i32 3
@@ -14942,8 +17219,8 @@ entry:
   %55 = load i32, i32* %arg4
   %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck6, label %58, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
   %59 = load i64, i64 addrspace(1)* %57
@@ -14961,15 +17238,15 @@ ThrowNullRef:                                     ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %43
+ThrowNullRef2:                                    ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %46
+ThrowNullRef4:                                    ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %49
+ThrowNullRef6:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14997,8 +17274,8 @@ entry:
   %4 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0 to %System.IO.ConsoleStream addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*)(%System.IO.ConsoleStream addrspace(1)* %4, %"System.Byte[]" addrspace(1)* %1, i32 %2, i32 %3)
   %5 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
@@ -15083,8 +17360,8 @@ entry:
 
 ; <label>:22                                      ; preds = %8
   %23 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %23, null
-  br i1 %NullCheck, label %24, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Byte[]" addrspace(1)* %23, null
+  br i1 %NullCheck, label %ThrowNullRef, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
@@ -15106,8 +17383,8 @@ entry:
 
 ; <label>:36                                      ; preds = %24
   %37 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %37, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.ConsoleStream addrspace(1)* %37, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %37, i32 0, i32 4
@@ -15128,13 +17405,138 @@ ThrowNullRef:                                     ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %36
+ThrowNullRef2:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
-Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
+Successfully read WindowsConsoleStream.WriteFileNative
+
+define i32 @WindowsConsoleStream.WriteFileNative(i64 %param0, %"System.Byte[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i64
+  %arg1 = alloca %"System.Byte[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i8 addrspace(1)*
+  %loc2 = alloca %"System.Byte[]" addrspace(1)*
+  %loc3 = alloca i32
+  store i64 %param0, i64* %arg0
+  store %"System.Byte[]" addrspace(1)* %param1, %"System.Byte[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Byte[]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = zext i32 %3 to i64
+  %5 = icmp ne i64 %4, 0
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %1
+  ret i32 0
+
+; <label>:7                                       ; preds = %1
+  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  store %"System.Byte[]" addrspace(1)* %8, %"System.Byte[]" addrspace(1)** %loc2
+  %9 = icmp eq %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %9, label %18, label %10
+
+; <label>:10                                      ; preds = %7
+  %11 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc2
+  %NullCheck1 = icmp eq %"System.Byte[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %11, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp ne i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %7, %12
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc1
+  br label %27
+
+; <label>:19                                      ; preds = %12
+  %20 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc2
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %20, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %BoundsCheck = icmp uge i64 0, %24
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %25
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %20, i32 0, i32 3, i32 0
+  store i8 addrspace(1)* %26, i8 addrspace(1)** %loc1
+  br label %27
+
+; <label>:27                                      ; preds = %18, %25
+  %28 = load i64, i64* %arg0
+  %29 = load i8 addrspace(1)*, i8 addrspace(1)** %loc1
+  %30 = ptrtoint i8 addrspace(1)* %29 to i64
+  %31 = load i32, i32* %arg2
+  %32 = sext i32 %31 to i64
+  %33 = add i64 %30, %32
+  %34 = load i32, i32* %arg3
+  %35 = addrspacecast i32* %loc3 to i32 addrspace(1)*
+  %36 = inttoptr i64 %33 to i8*
+  %37 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i8*, i32, i32 addrspace(1)*, i64)*)(i64 %28, i8* %36, i32 %34, i32 addrspace(1)* %35, i64 0)
+  %38 = icmp ugt i32 %37, 0
+  %39 = sext i1 %38 to i32
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc1
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %42, label %41
+
+; <label>:41                                      ; preds = %27
+  ret i32 0
+
+; <label>:42                                      ; preds = %27
+  %43 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  store i32 %43, i32* %loc0
+  %44 = load i32, i32* %loc0
+  %45 = icmp eq i32 %44, 232
+  br i1 %45, label %49, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = load i32, i32* %loc0
+  %48 = icmp ne i32 %47, 109
+  br i1 %48, label %50, label %49
+
+; <label>:49                                      ; preds = %42, %46
+  ret i32 0
+
+; <label>:50                                      ; preds = %46
+  %51 = load i32, i32* %loc0
+  ret i32 %51
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
 Successfully read WindowsConsoleStream.Flush
 
@@ -15143,8 +17545,8 @@ entry:
   %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
   store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
@@ -15179,8 +17581,8 @@ entry:
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
   %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load i64, i64 addrspace(1)* %1
@@ -15219,15 +17621,15 @@ entry:
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.TextWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
   %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %3, align 8
   %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
   %7 = load i64, i64 addrspace(1)* %5
@@ -15245,7 +17647,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -15274,8 +17676,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %4)
   store i32 0, i32* %loc0
   %5 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Char[]" addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
@@ -15287,15 +17689,15 @@ entry:
 
 ; <label>:11                                      ; preds = %69
   %12 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %12, i32 0, i32 9
   %15 = load i32, i32 addrspace(1)* %14, align 8
   %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.IO.StreamWriter addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %16, i32 0, i32 10
@@ -15310,15 +17712,15 @@ entry:
 
 ; <label>:23                                      ; preds = %17, %21
   %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %24, null
-  br i1 %NullCheck8, label %25, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %24, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 10
   %27 = load i32, i32 addrspace(1)* %26, align 8
   %28 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %28, null
-  br i1 %NullCheck10, label %29, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.StreamWriter addrspace(1)* %28, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %28, i32 0, i32 9
@@ -15340,15 +17742,15 @@ entry:
   %40 = load i32, i32* %loc0
   %41 = mul i32 %40, 2
   %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
-  br i1 %NullCheck12, label %43, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %43
 
 ; <label>:43                                      ; preds = %38
   %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 7
   %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %44, align 8
   %46 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %46, null
-  br i1 %NullCheck14, label %47, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.IO.StreamWriter addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %47
 
 ; <label>:47                                      ; preds = %43
   %48 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %46, i32 0, i32 9
@@ -15360,16 +17762,16 @@ entry:
   %54 = bitcast %"System.Char[]" addrspace(1)* %45 to %System.Array addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %53, i32 %41, %System.Array addrspace(1)* %54, i32 %50, i32 %52)
   %55 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
-  br i1 %NullCheck16, label %56, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %56
 
 ; <label>:56                                      ; preds = %47
   %57 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
   %58 = load i32, i32 addrspace(1)* %57, align 8
   %59 = load i32, i32* %loc2
   %60 = add i32 %58, %59
-  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
-  br i1 %NullCheck18, label %61, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %61
 
 ; <label>:61                                      ; preds = %56
   %62 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
@@ -15391,8 +17793,8 @@ entry:
 
 ; <label>:72                                      ; preds = %69
   %73 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %73, null
-  br i1 %NullCheck2, label %74, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %73, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %74
 
 ; <label>:74                                      ; preds = %72
   %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %73, i32 0, i32 11
@@ -15413,39 +17815,39 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %72
+ThrowNullRef2:                                    ; preds = %72
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %23
+ThrowNullRef8:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef10:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %43
+ThrowNullRef14:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %47
+ThrowNullRef16:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %56
+ThrowNullRef18:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -15472,8 +17874,8 @@ entry:
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load double, double* %arg0
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -15505,8 +17907,8 @@ entry:
   store double %param1, double* %arg1
   store i8 0, i8* %loc1
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
@@ -15516,16 +17918,16 @@ entry:
   %5 = addrspacecast i8* %loc1 to i8 addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %4, i8 addrspace(1)* %5)
   %6 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.SyncTextWriter addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
   %10 = load double, double* %arg1
   %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
   %13 = load i64, i64 addrspace(1)* %11
@@ -15560,11 +17962,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -15581,8 +17983,8 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load double, double* %arg1
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -15596,8 +17998,8 @@ entry:
   call void %11(%System.IO.TextWriter addrspace(1)* %0, double %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
   %15 = load i64, i64 addrspace(1)* %13
@@ -15615,7 +18017,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -15633,8 +18035,8 @@ entry:
   %1 = addrspacecast double* %arg1 to double addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -15649,8 +18051,8 @@ entry:
   %14 = bitcast double addrspace(1)* %1 to %System.Double addrspace(1)*
   %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Double addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Double addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
   %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
   %18 = load i64, i64 addrspace(1)* %16
@@ -15668,7 +18070,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -15684,8 +18086,8 @@ entry:
   store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
   %0 = load %System.Double addrspace(1)*, %System.Double addrspace(1)** %this
   %1 = bitcast %System.Double addrspace(1)* %0 to double addrspace(1)*
-  %NullCheck = icmp ne double addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq double addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load double, double addrspace(1)* %1, align 8

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPDist.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPDist.error.txt
@@ -25,8 +25,8 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
@@ -40,8 +40,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
   %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
@@ -75,7 +75,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -90,8 +90,8 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %NullCheck = icmp ne i8 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = load i8, i8 addrspace(1)* %0, align 8
@@ -125,8 +125,8 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
@@ -159,8 +159,8 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -184,8 +184,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
   store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
@@ -195,8 +195,8 @@ entry:
 ; <label>:4                                       ; preds = %1
   %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
   %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
@@ -206,8 +206,8 @@ entry:
   %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
@@ -221,14 +221,14 @@ entry:
 
 ; <label>:17                                      ; preds = %14
   %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
   %21 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
@@ -238,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -249,8 +249,8 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
@@ -261,27 +261,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %30
+ThrowNullRef10:                                   ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -301,7 +301,89 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
-Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
+Successfully read AppDomainSetup.GetUnsecureApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.GetUnsecureApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %NullCheck = icmp eq %"System.String[]" addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %BoundsCheck = icmp uge i64 0, %5
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %6
+
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 3, i32 0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
+  ret %System.String addrspace(1)* %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_Value using LLILCJit
+Successfully read AppDomainSetup.get_Value
+
+define %"System.String[]" addrspace(1)* @AppDomainSetup.get_Value(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.String[]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 18)
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.String[]" addrspace(1)* addrspace(1)*, %"System.String[]" addrspace(1)*)*)(%"System.String[]" addrspace(1)* addrspace(1)* %9, %"System.String[]" addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %11, i32 0, i32 1
+  %14 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %13, align 8
+  ret %"System.String[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -319,8 +401,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -368,16 +450,16 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
   %5 = load i32, i32 addrspace(1)* %4
   %6 = sub i32 %5, 1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -389,7 +471,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -421,8 +503,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
@@ -456,8 +538,8 @@ entry:
 ; <label>:27                                      ; preds = %19
   %28 = load i32, i32* %arg1
   %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
-  br i1 %NullCheck2, label %30, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %29, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %30
 
 ; <label>:30                                      ; preds = %27
   %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
@@ -493,8 +575,8 @@ entry:
 ; <label>:49                                      ; preds = %46
   %50 = load i32, i32* %arg2
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck4, label %52, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
@@ -517,11 +599,11 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %27
+ThrowNullRef2:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %49
+ThrowNullRef4:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -544,16 +626,16 @@ entry:
   %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %0)
   store %System.String addrspace(1)* %1, %System.String addrspace(1)** %loc0
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 2
   %5 = bitcast [0 x i16] addrspace(1)* %4 to i16 addrspace(1)*
   store i16 addrspace(1)* %5, i16 addrspace(1)** %loc1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %3
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2
@@ -580,7 +662,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -691,15 +773,15 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %NullCheck132 = icmp ne i8* %21, null
-  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+  %NullCheck131 = icmp eq i8* %21, null
+  br i1 %NullCheck131, label %ThrowNullRef132, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = load i8, i8* %21, align 8
   %24 = zext i8 %23 to i32
   %25 = trunc i32 %24 to i8
-  %NullCheck134 = icmp ne i8* %20, null
-  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+  %NullCheck133 = icmp eq i8* %20, null
+  br i1 %NullCheck133, label %ThrowNullRef134, label %26
 
 ; <label>:26                                      ; preds = %22
   store i8 %25, i8* %20, align 8
@@ -709,16 +791,16 @@ entry:
   %28 = load i8*, i8** %arg0
   %29 = load i8*, i8** %arg1
   %30 = bitcast i8* %29 to i16*
-  %NullCheck128 = icmp ne i16* %30, null
-  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+  %NullCheck127 = icmp eq i16* %30, null
+  br i1 %NullCheck127, label %ThrowNullRef128, label %31
 
 ; <label>:31                                      ; preds = %27
   %32 = load i16, i16* %30, align 8
   %33 = sext i16 %32 to i32
   %34 = bitcast i8* %28 to i16*
   %35 = trunc i32 %33 to i16
-  %NullCheck130 = icmp ne i16* %34, null
-  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+  %NullCheck129 = icmp eq i16* %34, null
+  br i1 %NullCheck129, label %ThrowNullRef130, label %36
 
 ; <label>:36                                      ; preds = %31
   store i16 %35, i16* %34, align 8
@@ -728,16 +810,16 @@ entry:
   %38 = load i8*, i8** %arg0
   %39 = load i8*, i8** %arg1
   %40 = bitcast i8* %39 to i16*
-  %NullCheck120 = icmp ne i16* %40, null
-  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+  %NullCheck119 = icmp eq i16* %40, null
+  br i1 %NullCheck119, label %ThrowNullRef120, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i16, i16* %40, align 8
   %43 = sext i16 %42 to i32
   %44 = bitcast i8* %38 to i16*
   %45 = trunc i32 %43 to i16
-  %NullCheck122 = icmp ne i16* %44, null
-  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+  %NullCheck121 = icmp eq i16* %44, null
+  br i1 %NullCheck121, label %ThrowNullRef122, label %46
 
 ; <label>:46                                      ; preds = %41
   store i16 %45, i16* %44, align 8
@@ -745,15 +827,15 @@ entry:
   %48 = getelementptr inbounds i8, i8* %47, i64 2
   %49 = load i8*, i8** %arg1
   %50 = getelementptr inbounds i8, i8* %49, i64 2
-  %NullCheck124 = icmp ne i8* %50, null
-  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+  %NullCheck123 = icmp eq i8* %50, null
+  br i1 %NullCheck123, label %ThrowNullRef124, label %51
 
 ; <label>:51                                      ; preds = %46
   %52 = load i8, i8* %50, align 8
   %53 = zext i8 %52 to i32
   %54 = trunc i32 %53 to i8
-  %NullCheck126 = icmp ne i8* %48, null
-  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+  %NullCheck125 = icmp eq i8* %48, null
+  br i1 %NullCheck125, label %ThrowNullRef126, label %55
 
 ; <label>:55                                      ; preds = %51
   store i8 %54, i8* %48, align 8
@@ -763,14 +845,14 @@ entry:
   %57 = load i8*, i8** %arg0
   %58 = load i8*, i8** %arg1
   %59 = bitcast i8* %58 to i32*
-  %NullCheck116 = icmp ne i32* %59, null
-  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+  %NullCheck115 = icmp eq i32* %59, null
+  br i1 %NullCheck115, label %ThrowNullRef116, label %60
 
 ; <label>:60                                      ; preds = %56
   %61 = load i32, i32* %59, align 8
   %62 = bitcast i8* %57 to i32*
-  %NullCheck118 = icmp ne i32* %62, null
-  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+  %NullCheck117 = icmp eq i32* %62, null
+  br i1 %NullCheck117, label %ThrowNullRef118, label %63
 
 ; <label>:63                                      ; preds = %60
   store i32 %61, i32* %62, align 8
@@ -780,14 +862,14 @@ entry:
   %65 = load i8*, i8** %arg0
   %66 = load i8*, i8** %arg1
   %67 = bitcast i8* %66 to i32*
-  %NullCheck108 = icmp ne i32* %67, null
-  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+  %NullCheck107 = icmp eq i32* %67, null
+  br i1 %NullCheck107, label %ThrowNullRef108, label %68
 
 ; <label>:68                                      ; preds = %64
   %69 = load i32, i32* %67, align 8
   %70 = bitcast i8* %65 to i32*
-  %NullCheck110 = icmp ne i32* %70, null
-  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+  %NullCheck109 = icmp eq i32* %70, null
+  br i1 %NullCheck109, label %ThrowNullRef110, label %71
 
 ; <label>:71                                      ; preds = %68
   store i32 %69, i32* %70, align 8
@@ -795,15 +877,15 @@ entry:
   %73 = getelementptr inbounds i8, i8* %72, i64 4
   %74 = load i8*, i8** %arg1
   %75 = getelementptr inbounds i8, i8* %74, i64 4
-  %NullCheck112 = icmp ne i8* %75, null
-  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+  %NullCheck111 = icmp eq i8* %75, null
+  br i1 %NullCheck111, label %ThrowNullRef112, label %76
 
 ; <label>:76                                      ; preds = %71
   %77 = load i8, i8* %75, align 8
   %78 = zext i8 %77 to i32
   %79 = trunc i32 %78 to i8
-  %NullCheck114 = icmp ne i8* %73, null
-  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+  %NullCheck113 = icmp eq i8* %73, null
+  br i1 %NullCheck113, label %ThrowNullRef114, label %80
 
 ; <label>:80                                      ; preds = %76
   store i8 %79, i8* %73, align 8
@@ -813,14 +895,14 @@ entry:
   %82 = load i8*, i8** %arg0
   %83 = load i8*, i8** %arg1
   %84 = bitcast i8* %83 to i32*
-  %NullCheck100 = icmp ne i32* %84, null
-  br i1 %NullCheck100, label %85, label %ThrowNullRef99
+  %NullCheck99 = icmp eq i32* %84, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %85
 
 ; <label>:85                                      ; preds = %81
   %86 = load i32, i32* %84, align 8
   %87 = bitcast i8* %82 to i32*
-  %NullCheck102 = icmp ne i32* %87, null
-  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+  %NullCheck101 = icmp eq i32* %87, null
+  br i1 %NullCheck101, label %ThrowNullRef102, label %88
 
 ; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
@@ -829,16 +911,16 @@ entry:
   %91 = load i8*, i8** %arg1
   %92 = getelementptr inbounds i8, i8* %91, i64 4
   %93 = bitcast i8* %92 to i16*
-  %NullCheck104 = icmp ne i16* %93, null
-  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+  %NullCheck103 = icmp eq i16* %93, null
+  br i1 %NullCheck103, label %ThrowNullRef104, label %94
 
 ; <label>:94                                      ; preds = %88
   %95 = load i16, i16* %93, align 8
   %96 = sext i16 %95 to i32
   %97 = bitcast i8* %90 to i16*
   %98 = trunc i32 %96 to i16
-  %NullCheck106 = icmp ne i16* %97, null
-  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+  %NullCheck105 = icmp eq i16* %97, null
+  br i1 %NullCheck105, label %ThrowNullRef106, label %99
 
 ; <label>:99                                      ; preds = %94
   store i16 %98, i16* %97, align 8
@@ -848,14 +930,14 @@ entry:
   %101 = load i8*, i8** %arg0
   %102 = load i8*, i8** %arg1
   %103 = bitcast i8* %102 to i32*
-  %NullCheck88 = icmp ne i32* %103, null
-  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+  %NullCheck87 = icmp eq i32* %103, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %104
 
 ; <label>:104                                     ; preds = %100
   %105 = load i32, i32* %103, align 8
   %106 = bitcast i8* %101 to i32*
-  %NullCheck90 = icmp ne i32* %106, null
-  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+  %NullCheck89 = icmp eq i32* %106, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %107
 
 ; <label>:107                                     ; preds = %104
   store i32 %105, i32* %106, align 8
@@ -864,16 +946,16 @@ entry:
   %110 = load i8*, i8** %arg1
   %111 = getelementptr inbounds i8, i8* %110, i64 4
   %112 = bitcast i8* %111 to i16*
-  %NullCheck92 = icmp ne i16* %112, null
-  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+  %NullCheck91 = icmp eq i16* %112, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %113
 
 ; <label>:113                                     ; preds = %107
   %114 = load i16, i16* %112, align 8
   %115 = sext i16 %114 to i32
   %116 = bitcast i8* %109 to i16*
   %117 = trunc i32 %115 to i16
-  %NullCheck94 = icmp ne i16* %116, null
-  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+  %NullCheck93 = icmp eq i16* %116, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %118
 
 ; <label>:118                                     ; preds = %113
   store i16 %117, i16* %116, align 8
@@ -881,15 +963,15 @@ entry:
   %120 = getelementptr inbounds i8, i8* %119, i64 6
   %121 = load i8*, i8** %arg1
   %122 = getelementptr inbounds i8, i8* %121, i64 6
-  %NullCheck96 = icmp ne i8* %122, null
-  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+  %NullCheck95 = icmp eq i8* %122, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %123
 
 ; <label>:123                                     ; preds = %118
   %124 = load i8, i8* %122, align 8
   %125 = zext i8 %124 to i32
   %126 = trunc i32 %125 to i8
-  %NullCheck98 = icmp ne i8* %120, null
-  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+  %NullCheck97 = icmp eq i8* %120, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %127
 
 ; <label>:127                                     ; preds = %123
   store i8 %126, i8* %120, align 8
@@ -899,14 +981,14 @@ entry:
   %129 = load i8*, i8** %arg0
   %130 = load i8*, i8** %arg1
   %131 = bitcast i8* %130 to i64*
-  %NullCheck84 = icmp ne i64* %131, null
-  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+  %NullCheck83 = icmp eq i64* %131, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %132
 
 ; <label>:132                                     ; preds = %128
   %133 = load i64, i64* %131, align 8
   %134 = bitcast i8* %129 to i64*
-  %NullCheck86 = icmp ne i64* %134, null
-  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+  %NullCheck85 = icmp eq i64* %134, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %135
 
 ; <label>:135                                     ; preds = %132
   store i64 %133, i64* %134, align 8
@@ -916,14 +998,14 @@ entry:
   %137 = load i8*, i8** %arg0
   %138 = load i8*, i8** %arg1
   %139 = bitcast i8* %138 to i64*
-  %NullCheck76 = icmp ne i64* %139, null
-  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+  %NullCheck75 = icmp eq i64* %139, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %140
 
 ; <label>:140                                     ; preds = %136
   %141 = load i64, i64* %139, align 8
   %142 = bitcast i8* %137 to i64*
-  %NullCheck78 = icmp ne i64* %142, null
-  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+  %NullCheck77 = icmp eq i64* %142, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %143
 
 ; <label>:143                                     ; preds = %140
   store i64 %141, i64* %142, align 8
@@ -931,15 +1013,15 @@ entry:
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %NullCheck80 = icmp ne i8* %147, null
-  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+  %NullCheck79 = icmp eq i8* %147, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %148
 
 ; <label>:148                                     ; preds = %143
   %149 = load i8, i8* %147, align 8
   %150 = zext i8 %149 to i32
   %151 = trunc i32 %150 to i8
-  %NullCheck82 = icmp ne i8* %145, null
-  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+  %NullCheck81 = icmp eq i8* %145, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %152
 
 ; <label>:152                                     ; preds = %148
   store i8 %151, i8* %145, align 8
@@ -949,14 +1031,14 @@ entry:
   %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
   %156 = bitcast i8* %155 to i64*
-  %NullCheck68 = icmp ne i64* %156, null
-  br i1 %NullCheck68, label %157, label %ThrowNullRef67
+  %NullCheck67 = icmp eq i64* %156, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %157
 
 ; <label>:157                                     ; preds = %153
   %158 = load i64, i64* %156, align 8
   %159 = bitcast i8* %154 to i64*
-  %NullCheck70 = icmp ne i64* %159, null
-  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+  %NullCheck69 = icmp eq i64* %159, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %160
 
 ; <label>:160                                     ; preds = %157
   store i64 %158, i64* %159, align 8
@@ -965,16 +1047,16 @@ entry:
   %163 = load i8*, i8** %arg1
   %164 = getelementptr inbounds i8, i8* %163, i64 8
   %165 = bitcast i8* %164 to i16*
-  %NullCheck72 = icmp ne i16* %165, null
-  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+  %NullCheck71 = icmp eq i16* %165, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %166
 
 ; <label>:166                                     ; preds = %160
   %167 = load i16, i16* %165, align 8
   %168 = sext i16 %167 to i32
   %169 = bitcast i8* %162 to i16*
   %170 = trunc i32 %168 to i16
-  %NullCheck74 = icmp ne i16* %169, null
-  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+  %NullCheck73 = icmp eq i16* %169, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %171
 
 ; <label>:171                                     ; preds = %166
   store i16 %170, i16* %169, align 8
@@ -984,14 +1066,14 @@ entry:
   %173 = load i8*, i8** %arg0
   %174 = load i8*, i8** %arg1
   %175 = bitcast i8* %174 to i64*
-  %NullCheck56 = icmp ne i64* %175, null
-  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+  %NullCheck55 = icmp eq i64* %175, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %176
 
 ; <label>:176                                     ; preds = %172
   %177 = load i64, i64* %175, align 8
   %178 = bitcast i8* %173 to i64*
-  %NullCheck58 = icmp ne i64* %178, null
-  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+  %NullCheck57 = icmp eq i64* %178, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %179
 
 ; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
@@ -1000,16 +1082,16 @@ entry:
   %182 = load i8*, i8** %arg1
   %183 = getelementptr inbounds i8, i8* %182, i64 8
   %184 = bitcast i8* %183 to i16*
-  %NullCheck60 = icmp ne i16* %184, null
-  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+  %NullCheck59 = icmp eq i16* %184, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %185
 
 ; <label>:185                                     ; preds = %179
   %186 = load i16, i16* %184, align 8
   %187 = sext i16 %186 to i32
   %188 = bitcast i8* %181 to i16*
   %189 = trunc i32 %187 to i16
-  %NullCheck62 = icmp ne i16* %188, null
-  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+  %NullCheck61 = icmp eq i16* %188, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %190
 
 ; <label>:190                                     ; preds = %185
   store i16 %189, i16* %188, align 8
@@ -1017,15 +1099,15 @@ entry:
   %192 = getelementptr inbounds i8, i8* %191, i64 10
   %193 = load i8*, i8** %arg1
   %194 = getelementptr inbounds i8, i8* %193, i64 10
-  %NullCheck64 = icmp ne i8* %194, null
-  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+  %NullCheck63 = icmp eq i8* %194, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %195
 
 ; <label>:195                                     ; preds = %190
   %196 = load i8, i8* %194, align 8
   %197 = zext i8 %196 to i32
   %198 = trunc i32 %197 to i8
-  %NullCheck66 = icmp ne i8* %192, null
-  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+  %NullCheck65 = icmp eq i8* %192, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %199
 
 ; <label>:199                                     ; preds = %195
   store i8 %198, i8* %192, align 8
@@ -1035,14 +1117,14 @@ entry:
   %201 = load i8*, i8** %arg0
   %202 = load i8*, i8** %arg1
   %203 = bitcast i8* %202 to i64*
-  %NullCheck48 = icmp ne i64* %203, null
-  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+  %NullCheck47 = icmp eq i64* %203, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %204
 
 ; <label>:204                                     ; preds = %200
   %205 = load i64, i64* %203, align 8
   %206 = bitcast i8* %201 to i64*
-  %NullCheck50 = icmp ne i64* %206, null
-  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+  %NullCheck49 = icmp eq i64* %206, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %207
 
 ; <label>:207                                     ; preds = %204
   store i64 %205, i64* %206, align 8
@@ -1051,14 +1133,14 @@ entry:
   %210 = load i8*, i8** %arg1
   %211 = getelementptr inbounds i8, i8* %210, i64 8
   %212 = bitcast i8* %211 to i32*
-  %NullCheck52 = icmp ne i32* %212, null
-  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+  %NullCheck51 = icmp eq i32* %212, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %213
 
 ; <label>:213                                     ; preds = %207
   %214 = load i32, i32* %212, align 8
   %215 = bitcast i8* %209 to i32*
-  %NullCheck54 = icmp ne i32* %215, null
-  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+  %NullCheck53 = icmp eq i32* %215, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %216
 
 ; <label>:216                                     ; preds = %213
   store i32 %214, i32* %215, align 8
@@ -1068,14 +1150,14 @@ entry:
   %218 = load i8*, i8** %arg0
   %219 = load i8*, i8** %arg1
   %220 = bitcast i8* %219 to i64*
-  %NullCheck36 = icmp ne i64* %220, null
-  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64* %220, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %221
 
 ; <label>:221                                     ; preds = %217
   %222 = load i64, i64* %220, align 8
   %223 = bitcast i8* %218 to i64*
-  %NullCheck38 = icmp ne i64* %223, null
-  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+  %NullCheck37 = icmp eq i64* %223, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %224
 
 ; <label>:224                                     ; preds = %221
   store i64 %222, i64* %223, align 8
@@ -1084,14 +1166,14 @@ entry:
   %227 = load i8*, i8** %arg1
   %228 = getelementptr inbounds i8, i8* %227, i64 8
   %229 = bitcast i8* %228 to i32*
-  %NullCheck40 = icmp ne i32* %229, null
-  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i32* %229, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %230
 
 ; <label>:230                                     ; preds = %224
   %231 = load i32, i32* %229, align 8
   %232 = bitcast i8* %226 to i32*
-  %NullCheck42 = icmp ne i32* %232, null
-  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+  %NullCheck41 = icmp eq i32* %232, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %233
 
 ; <label>:233                                     ; preds = %230
   store i32 %231, i32* %232, align 8
@@ -1099,15 +1181,15 @@ entry:
   %235 = getelementptr inbounds i8, i8* %234, i64 12
   %236 = load i8*, i8** %arg1
   %237 = getelementptr inbounds i8, i8* %236, i64 12
-  %NullCheck44 = icmp ne i8* %237, null
-  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i8* %237, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %238
 
 ; <label>:238                                     ; preds = %233
   %239 = load i8, i8* %237, align 8
   %240 = zext i8 %239 to i32
   %241 = trunc i32 %240 to i8
-  %NullCheck46 = icmp ne i8* %235, null
-  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+  %NullCheck45 = icmp eq i8* %235, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %242
 
 ; <label>:242                                     ; preds = %238
   store i8 %241, i8* %235, align 8
@@ -1117,14 +1199,14 @@ entry:
   %244 = load i8*, i8** %arg0
   %245 = load i8*, i8** %arg1
   %246 = bitcast i8* %245 to i64*
-  %NullCheck24 = icmp ne i64* %246, null
-  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64* %246, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %247
 
 ; <label>:247                                     ; preds = %243
   %248 = load i64, i64* %246, align 8
   %249 = bitcast i8* %244 to i64*
-  %NullCheck26 = icmp ne i64* %249, null
-  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64* %249, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %250
 
 ; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
@@ -1133,14 +1215,14 @@ entry:
   %253 = load i8*, i8** %arg1
   %254 = getelementptr inbounds i8, i8* %253, i64 8
   %255 = bitcast i8* %254 to i32*
-  %NullCheck28 = icmp ne i32* %255, null
-  br i1 %NullCheck28, label %256, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i32* %255, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %256
 
 ; <label>:256                                     ; preds = %250
   %257 = load i32, i32* %255, align 8
   %258 = bitcast i8* %252 to i32*
-  %NullCheck30 = icmp ne i32* %258, null
-  br i1 %NullCheck30, label %259, label %ThrowNullRef29
+  %NullCheck29 = icmp eq i32* %258, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %259
 
 ; <label>:259                                     ; preds = %256
   store i32 %257, i32* %258, align 8
@@ -1149,16 +1231,16 @@ entry:
   %262 = load i8*, i8** %arg1
   %263 = getelementptr inbounds i8, i8* %262, i64 12
   %264 = bitcast i8* %263 to i16*
-  %NullCheck32 = icmp ne i16* %264, null
-  br i1 %NullCheck32, label %265, label %ThrowNullRef31
+  %NullCheck31 = icmp eq i16* %264, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %265
 
 ; <label>:265                                     ; preds = %259
   %266 = load i16, i16* %264, align 8
   %267 = sext i16 %266 to i32
   %268 = bitcast i8* %261 to i16*
   %269 = trunc i32 %267 to i16
-  %NullCheck34 = icmp ne i16* %268, null
-  br i1 %NullCheck34, label %270, label %ThrowNullRef33
+  %NullCheck33 = icmp eq i16* %268, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %270
 
 ; <label>:270                                     ; preds = %265
   store i16 %269, i16* %268, align 8
@@ -1168,14 +1250,14 @@ entry:
   %272 = load i8*, i8** %arg0
   %273 = load i8*, i8** %arg1
   %274 = bitcast i8* %273 to i64*
-  %NullCheck8 = icmp ne i64* %274, null
-  br i1 %NullCheck8, label %275, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64* %274, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %275
 
 ; <label>:275                                     ; preds = %271
   %276 = load i64, i64* %274, align 8
   %277 = bitcast i8* %272 to i64*
-  %NullCheck10 = icmp ne i64* %277, null
-  br i1 %NullCheck10, label %278, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %277, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %278
 
 ; <label>:278                                     ; preds = %275
   store i64 %276, i64* %277, align 8
@@ -1184,14 +1266,14 @@ entry:
   %281 = load i8*, i8** %arg1
   %282 = getelementptr inbounds i8, i8* %281, i64 8
   %283 = bitcast i8* %282 to i32*
-  %NullCheck12 = icmp ne i32* %283, null
-  br i1 %NullCheck12, label %284, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i32* %283, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %284
 
 ; <label>:284                                     ; preds = %278
   %285 = load i32, i32* %283, align 8
   %286 = bitcast i8* %280 to i32*
-  %NullCheck14 = icmp ne i32* %286, null
-  br i1 %NullCheck14, label %287, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i32* %286, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %287
 
 ; <label>:287                                     ; preds = %284
   store i32 %285, i32* %286, align 8
@@ -1200,16 +1282,16 @@ entry:
   %290 = load i8*, i8** %arg1
   %291 = getelementptr inbounds i8, i8* %290, i64 12
   %292 = bitcast i8* %291 to i16*
-  %NullCheck16 = icmp ne i16* %292, null
-  br i1 %NullCheck16, label %293, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i16* %292, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %293
 
 ; <label>:293                                     ; preds = %287
   %294 = load i16, i16* %292, align 8
   %295 = sext i16 %294 to i32
   %296 = bitcast i8* %289 to i16*
   %297 = trunc i32 %295 to i16
-  %NullCheck18 = icmp ne i16* %296, null
-  br i1 %NullCheck18, label %298, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i16* %296, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %298
 
 ; <label>:298                                     ; preds = %293
   store i16 %297, i16* %296, align 8
@@ -1217,15 +1299,15 @@ entry:
   %300 = getelementptr inbounds i8, i8* %299, i64 14
   %301 = load i8*, i8** %arg1
   %302 = getelementptr inbounds i8, i8* %301, i64 14
-  %NullCheck20 = icmp ne i8* %302, null
-  br i1 %NullCheck20, label %303, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i8* %302, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %303
 
 ; <label>:303                                     ; preds = %298
   %304 = load i8, i8* %302, align 8
   %305 = zext i8 %304 to i32
   %306 = trunc i32 %305 to i8
-  %NullCheck22 = icmp ne i8* %300, null
-  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i8* %300, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %307
 
 ; <label>:307                                     ; preds = %303
   store i8 %306, i8* %300, align 8
@@ -1235,14 +1317,14 @@ entry:
   %309 = load i8*, i8** %arg0
   %310 = load i8*, i8** %arg1
   %311 = bitcast i8* %310 to i64*
-  %NullCheck = icmp ne i64* %311, null
-  br i1 %NullCheck, label %312, label %ThrowNullRef
+  %NullCheck = icmp eq i64* %311, null
+  br i1 %NullCheck, label %ThrowNullRef, label %312
 
 ; <label>:312                                     ; preds = %308
   %313 = load i64, i64* %311, align 8
   %314 = bitcast i8* %309 to i64*
-  %NullCheck2 = icmp ne i64* %314, null
-  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64* %314, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %315
 
 ; <label>:315                                     ; preds = %312
   store i64 %313, i64* %314, align 8
@@ -1251,14 +1333,14 @@ entry:
   %318 = load i8*, i8** %arg1
   %319 = getelementptr inbounds i8, i8* %318, i64 8
   %320 = bitcast i8* %319 to i64*
-  %NullCheck4 = icmp ne i64* %320, null
-  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64* %320, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %321
 
 ; <label>:321                                     ; preds = %315
   %322 = load i64, i64* %320, align 8
   %323 = bitcast i8* %317 to i64*
-  %NullCheck6 = icmp ne i64* %323, null
-  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64* %323, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %324
 
 ; <label>:324                                     ; preds = %321
   store i64 %322, i64* %323, align 8
@@ -1286,15 +1368,15 @@ entry:
 ; <label>:338                                     ; preds = %333
   %339 = load i8*, i8** %arg0
   %340 = load i8*, i8** %arg1
-  %NullCheck136 = icmp ne i8* %340, null
-  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+  %NullCheck135 = icmp eq i8* %340, null
+  br i1 %NullCheck135, label %ThrowNullRef136, label %341
 
 ; <label>:341                                     ; preds = %338
   %342 = load i8, i8* %340, align 8
   %343 = zext i8 %342 to i32
   %344 = trunc i32 %343 to i8
-  %NullCheck138 = icmp ne i8* %339, null
-  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+  %NullCheck137 = icmp eq i8* %339, null
+  br i1 %NullCheck137, label %ThrowNullRef138, label %345
 
 ; <label>:345                                     ; preds = %341
   store i8 %344, i8* %339, align 8
@@ -1317,16 +1399,16 @@ entry:
   %357 = load i8*, i8** %arg0
   %358 = load i8*, i8** %arg1
   %359 = bitcast i8* %358 to i16*
-  %NullCheck140 = icmp ne i16* %359, null
-  br i1 %NullCheck140, label %360, label %ThrowNullRef139
+  %NullCheck139 = icmp eq i16* %359, null
+  br i1 %NullCheck139, label %ThrowNullRef140, label %360
 
 ; <label>:360                                     ; preds = %356
   %361 = load i16, i16* %359, align 8
   %362 = sext i16 %361 to i32
   %363 = bitcast i8* %357 to i16*
   %364 = trunc i32 %362 to i16
-  %NullCheck142 = icmp ne i16* %363, null
-  br i1 %NullCheck142, label %365, label %ThrowNullRef141
+  %NullCheck141 = icmp eq i16* %363, null
+  br i1 %NullCheck141, label %ThrowNullRef142, label %365
 
 ; <label>:365                                     ; preds = %360
   store i16 %364, i16* %363, align 8
@@ -1352,14 +1434,14 @@ entry:
   %378 = load i8*, i8** %arg0
   %379 = load i8*, i8** %arg1
   %380 = bitcast i8* %379 to i32*
-  %NullCheck144 = icmp ne i32* %380, null
-  br i1 %NullCheck144, label %381, label %ThrowNullRef143
+  %NullCheck143 = icmp eq i32* %380, null
+  br i1 %NullCheck143, label %ThrowNullRef144, label %381
 
 ; <label>:381                                     ; preds = %377
   %382 = load i32, i32* %380, align 8
   %383 = bitcast i8* %378 to i32*
-  %NullCheck146 = icmp ne i32* %383, null
-  br i1 %NullCheck146, label %384, label %ThrowNullRef145
+  %NullCheck145 = icmp eq i32* %383, null
+  br i1 %NullCheck145, label %ThrowNullRef146, label %384
 
 ; <label>:384                                     ; preds = %381
   store i32 %382, i32* %383, align 8
@@ -1384,14 +1466,14 @@ entry:
   %395 = load i8*, i8** %arg0
   %396 = load i8*, i8** %arg1
   %397 = bitcast i8* %396 to i64*
-  %NullCheck164 = icmp ne i64* %397, null
-  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+  %NullCheck163 = icmp eq i64* %397, null
+  br i1 %NullCheck163, label %ThrowNullRef164, label %398
 
 ; <label>:398                                     ; preds = %394
   %399 = load i64, i64* %397, align 8
   %400 = bitcast i8* %395 to i64*
-  %NullCheck166 = icmp ne i64* %400, null
-  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+  %NullCheck165 = icmp eq i64* %400, null
+  br i1 %NullCheck165, label %ThrowNullRef166, label %401
 
 ; <label>:401                                     ; preds = %398
   store i64 %399, i64* %400, align 8
@@ -1400,14 +1482,14 @@ entry:
   %404 = load i8*, i8** %arg1
   %405 = getelementptr inbounds i8, i8* %404, i64 8
   %406 = bitcast i8* %405 to i64*
-  %NullCheck168 = icmp ne i64* %406, null
-  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+  %NullCheck167 = icmp eq i64* %406, null
+  br i1 %NullCheck167, label %ThrowNullRef168, label %407
 
 ; <label>:407                                     ; preds = %401
   %408 = load i64, i64* %406, align 8
   %409 = bitcast i8* %403 to i64*
-  %NullCheck170 = icmp ne i64* %409, null
-  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+  %NullCheck169 = icmp eq i64* %409, null
+  br i1 %NullCheck169, label %ThrowNullRef170, label %410
 
 ; <label>:410                                     ; preds = %407
   store i64 %408, i64* %409, align 8
@@ -1437,14 +1519,14 @@ entry:
   %425 = load i8*, i8** %arg0
   %426 = load i8*, i8** %arg1
   %427 = bitcast i8* %426 to i64*
-  %NullCheck148 = icmp ne i64* %427, null
-  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+  %NullCheck147 = icmp eq i64* %427, null
+  br i1 %NullCheck147, label %ThrowNullRef148, label %428
 
 ; <label>:428                                     ; preds = %424
   %429 = load i64, i64* %427, align 8
   %430 = bitcast i8* %425 to i64*
-  %NullCheck150 = icmp ne i64* %430, null
-  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+  %NullCheck149 = icmp eq i64* %430, null
+  br i1 %NullCheck149, label %ThrowNullRef150, label %431
 
 ; <label>:431                                     ; preds = %428
   store i64 %429, i64* %430, align 8
@@ -1466,14 +1548,14 @@ entry:
   %441 = load i8*, i8** %arg0
   %442 = load i8*, i8** %arg1
   %443 = bitcast i8* %442 to i32*
-  %NullCheck152 = icmp ne i32* %443, null
-  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+  %NullCheck151 = icmp eq i32* %443, null
+  br i1 %NullCheck151, label %ThrowNullRef152, label %444
 
 ; <label>:444                                     ; preds = %440
   %445 = load i32, i32* %443, align 8
   %446 = bitcast i8* %441 to i32*
-  %NullCheck154 = icmp ne i32* %446, null
-  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+  %NullCheck153 = icmp eq i32* %446, null
+  br i1 %NullCheck153, label %ThrowNullRef154, label %447
 
 ; <label>:447                                     ; preds = %444
   store i32 %445, i32* %446, align 8
@@ -1495,16 +1577,16 @@ entry:
   %457 = load i8*, i8** %arg0
   %458 = load i8*, i8** %arg1
   %459 = bitcast i8* %458 to i16*
-  %NullCheck156 = icmp ne i16* %459, null
-  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+  %NullCheck155 = icmp eq i16* %459, null
+  br i1 %NullCheck155, label %ThrowNullRef156, label %460
 
 ; <label>:460                                     ; preds = %456
   %461 = load i16, i16* %459, align 8
   %462 = sext i16 %461 to i32
   %463 = bitcast i8* %457 to i16*
   %464 = trunc i32 %462 to i16
-  %NullCheck158 = icmp ne i16* %463, null
-  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+  %NullCheck157 = icmp eq i16* %463, null
+  br i1 %NullCheck157, label %ThrowNullRef158, label %465
 
 ; <label>:465                                     ; preds = %460
   store i16 %464, i16* %463, align 8
@@ -1525,15 +1607,15 @@ entry:
 ; <label>:474                                     ; preds = %470
   %475 = load i8*, i8** %arg0
   %476 = load i8*, i8** %arg1
-  %NullCheck160 = icmp ne i8* %476, null
-  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+  %NullCheck159 = icmp eq i8* %476, null
+  br i1 %NullCheck159, label %ThrowNullRef160, label %477
 
 ; <label>:477                                     ; preds = %474
   %478 = load i8, i8* %476, align 8
   %479 = zext i8 %478 to i32
   %480 = trunc i32 %479 to i8
-  %NullCheck162 = icmp ne i8* %475, null
-  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+  %NullCheck161 = icmp eq i8* %475, null
+  br i1 %NullCheck161, label %ThrowNullRef162, label %481
 
 ; <label>:481                                     ; preds = %477
   store i8 %480, i8* %475, align 8
@@ -1553,343 +1635,343 @@ ThrowNullRef:                                     ; preds = %308
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %312
+ThrowNullRef2:                                    ; preds = %312
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %315
+ThrowNullRef4:                                    ; preds = %315
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %321
+ThrowNullRef6:                                    ; preds = %321
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %271
+ThrowNullRef8:                                    ; preds = %271
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %275
+ThrowNullRef10:                                   ; preds = %275
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %278
+ThrowNullRef12:                                   ; preds = %278
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %284
+ThrowNullRef14:                                   ; preds = %284
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %287
+ThrowNullRef16:                                   ; preds = %287
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %293
+ThrowNullRef18:                                   ; preds = %293
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %298
+ThrowNullRef20:                                   ; preds = %298
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %303
+ThrowNullRef22:                                   ; preds = %303
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %243
+ThrowNullRef24:                                   ; preds = %243
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %247
+ThrowNullRef26:                                   ; preds = %247
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %250
+ThrowNullRef28:                                   ; preds = %250
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %256
+ThrowNullRef30:                                   ; preds = %256
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %259
+ThrowNullRef32:                                   ; preds = %259
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %265
+ThrowNullRef34:                                   ; preds = %265
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %217
+ThrowNullRef36:                                   ; preds = %217
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %221
+ThrowNullRef38:                                   ; preds = %221
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %224
+ThrowNullRef40:                                   ; preds = %224
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %230
+ThrowNullRef42:                                   ; preds = %230
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %233
+ThrowNullRef44:                                   ; preds = %233
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %238
+ThrowNullRef46:                                   ; preds = %238
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %200
+ThrowNullRef48:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %204
+ThrowNullRef50:                                   ; preds = %204
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %207
+ThrowNullRef52:                                   ; preds = %207
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %213
+ThrowNullRef54:                                   ; preds = %213
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %172
+ThrowNullRef56:                                   ; preds = %172
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %176
+ThrowNullRef58:                                   ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %179
+ThrowNullRef60:                                   ; preds = %179
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %185
+ThrowNullRef62:                                   ; preds = %185
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %190
+ThrowNullRef64:                                   ; preds = %190
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %195
+ThrowNullRef66:                                   ; preds = %195
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %153
+ThrowNullRef68:                                   ; preds = %153
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %157
+ThrowNullRef70:                                   ; preds = %157
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %160
+ThrowNullRef72:                                   ; preds = %160
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %166
+ThrowNullRef74:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %136
+ThrowNullRef76:                                   ; preds = %136
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %140
+ThrowNullRef78:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %143
+ThrowNullRef80:                                   ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %148
+ThrowNullRef82:                                   ; preds = %148
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %128
+ThrowNullRef84:                                   ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %132
+ThrowNullRef86:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %100
+ThrowNullRef88:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %104
+ThrowNullRef90:                                   ; preds = %104
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %107
+ThrowNullRef92:                                   ; preds = %107
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %113
+ThrowNullRef94:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %118
+ThrowNullRef96:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %123
+ThrowNullRef98:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %81
+ThrowNullRef100:                                  ; preds = %81
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef101:                                  ; preds = %85
+ThrowNullRef102:                                  ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef103:                                  ; preds = %88
+ThrowNullRef104:                                  ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef105:                                  ; preds = %94
+ThrowNullRef106:                                  ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef107:                                  ; preds = %64
+ThrowNullRef108:                                  ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef109:                                  ; preds = %68
+ThrowNullRef110:                                  ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef111:                                  ; preds = %71
+ThrowNullRef112:                                  ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef113:                                  ; preds = %76
+ThrowNullRef114:                                  ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef115:                                  ; preds = %56
+ThrowNullRef116:                                  ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef117:                                  ; preds = %60
+ThrowNullRef118:                                  ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef119:                                  ; preds = %37
+ThrowNullRef120:                                  ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef121:                                  ; preds = %41
+ThrowNullRef122:                                  ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef123:                                  ; preds = %46
+ThrowNullRef124:                                  ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef125:                                  ; preds = %51
+ThrowNullRef126:                                  ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef127:                                  ; preds = %27
+ThrowNullRef128:                                  ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef129:                                  ; preds = %31
+ThrowNullRef130:                                  ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef131:                                  ; preds = %19
+ThrowNullRef132:                                  ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef133:                                  ; preds = %22
+ThrowNullRef134:                                  ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef135:                                  ; preds = %338
+ThrowNullRef136:                                  ; preds = %338
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef137:                                  ; preds = %341
+ThrowNullRef138:                                  ; preds = %341
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef139:                                  ; preds = %356
+ThrowNullRef140:                                  ; preds = %356
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef141:                                  ; preds = %360
+ThrowNullRef142:                                  ; preds = %360
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef143:                                  ; preds = %377
+ThrowNullRef144:                                  ; preds = %377
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef145:                                  ; preds = %381
+ThrowNullRef146:                                  ; preds = %381
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef147:                                  ; preds = %424
+ThrowNullRef148:                                  ; preds = %424
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef149:                                  ; preds = %428
+ThrowNullRef150:                                  ; preds = %428
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef151:                                  ; preds = %440
+ThrowNullRef152:                                  ; preds = %440
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef153:                                  ; preds = %444
+ThrowNullRef154:                                  ; preds = %444
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef155:                                  ; preds = %456
+ThrowNullRef156:                                  ; preds = %456
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef157:                                  ; preds = %460
+ThrowNullRef158:                                  ; preds = %460
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef159:                                  ; preds = %474
+ThrowNullRef160:                                  ; preds = %474
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef161:                                  ; preds = %477
+ThrowNullRef162:                                  ; preds = %477
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef163:                                  ; preds = %394
+ThrowNullRef164:                                  ; preds = %394
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef165:                                  ; preds = %398
+ThrowNullRef166:                                  ; preds = %398
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef167:                                  ; preds = %401
+ThrowNullRef168:                                  ; preds = %401
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef169:                                  ; preds = %407
+ThrowNullRef170:                                  ; preds = %407
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1939,8 +2021,8 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
-  br i1 %NullCheck, label %22, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %ThrowNullRef, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
@@ -1948,8 +2030,8 @@ entry:
   store i32 %24, i32* %loc0
   %25 = load i32, i32* %loc0
   %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %26, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %27
 
 ; <label>:27                                      ; preds = %22
   %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
@@ -1971,7 +2053,7 @@ ThrowNullRef:                                     ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1989,8 +2071,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -2022,15 +2104,15 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2048,16 +2130,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
   %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
   store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %15
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
@@ -2072,8 +2154,8 @@ entry:
   %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
   %29 = ptrtoint i16 addrspace(1)* %28 to i64
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %19
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
@@ -2089,19 +2171,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2114,8 +2196,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
@@ -2128,7 +2210,7 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[loadElem]
+Failed to read AppDomain.PrepareDataForSetup[storeElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
@@ -2202,8 +2284,8 @@ entry:
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
-  br i1 %NullCheck24, label %27, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = load i64, i64 addrspace(1)* %26
@@ -2218,8 +2300,8 @@ entry:
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
-  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
   %41 = load i64, i64 addrspace(1)* %39
@@ -2236,8 +2318,8 @@ entry:
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
-  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
   %54 = load i64, i64 addrspace(1)* %52
@@ -2252,8 +2334,8 @@ entry:
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
   %67 = load i64, i64 addrspace(1)* %65
@@ -2270,8 +2352,8 @@ entry:
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
-  br i1 %NullCheck16, label %79, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
   %80 = load i64, i64 addrspace(1)* %78
@@ -2286,8 +2368,8 @@ entry:
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
-  br i1 %NullCheck18, label %92, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
   %93 = load i64, i64 addrspace(1)* %91
@@ -2304,8 +2386,8 @@ entry:
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
-  br i1 %NullCheck12, label %105, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = load i64, i64 addrspace(1)* %104
@@ -2320,8 +2402,8 @@ entry:
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
-  br i1 %NullCheck14, label %118, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
   %119 = load i64, i64 addrspace(1)* %117
@@ -2337,8 +2419,8 @@ entry:
 
 ; <label>:128                                     ; preds = %20
   %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
-  br i1 %NullCheck4, label %130, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %129, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %130
 
 ; <label>:130                                     ; preds = %128
   %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
@@ -2346,8 +2428,8 @@ entry:
   %133 = load i16, i16 addrspace(1)* %132, align 8
   %134 = zext i16 %133 to i32
   %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
-  br i1 %NullCheck6, label %136, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %135, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %136
 
 ; <label>:136                                     ; preds = %130
   %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
@@ -2360,8 +2442,8 @@ entry:
 
 ; <label>:143                                     ; preds = %136
   %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
-  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %144, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %145
 
 ; <label>:145                                     ; preds = %143
   %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
@@ -2369,8 +2451,8 @@ entry:
   %148 = load i16, i16 addrspace(1)* %147, align 8
   %149 = zext i16 %148 to i32
   %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %150, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %151
 
 ; <label>:151                                     ; preds = %145
   %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
@@ -2388,8 +2470,8 @@ entry:
 
 ; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
-  br i1 %NullCheck, label %163, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %ThrowNullRef, label %163
 
 ; <label>:163                                     ; preds = %161
   %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
@@ -2399,8 +2481,8 @@ entry:
 
 ; <label>:167                                     ; preds = %163
   %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
-  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %168, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %169
 
 ; <label>:169                                     ; preds = %167
   %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
@@ -2432,55 +2514,55 @@ ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %167
+ThrowNullRef2:                                    ; preds = %167
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %128
+ThrowNullRef4:                                    ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %130
+ThrowNullRef6:                                    ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %143
+ThrowNullRef8:                                    ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %145
+ThrowNullRef10:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %102
+ThrowNullRef12:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %105
+ThrowNullRef14:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %76
+ThrowNullRef16:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %79
+ThrowNullRef18:                                   ; preds = %79
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %50
+ThrowNullRef20:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %53
+ThrowNullRef22:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %24
+ThrowNullRef24:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %27
+ThrowNullRef26:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2503,15 +2585,15 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2519,16 +2601,16 @@ entry:
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
   store i32 %8, i32* %loc0
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
   %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
   store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
@@ -2546,16 +2628,16 @@ entry:
 
 ; <label>:23                                      ; preds = %64
   %24 = load i16*, i16** %loc3
-  %NullCheck12 = icmp ne i16* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i16* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
   store i32 %27, i32* %loc5
   %28 = load i16*, i16** %loc4
-  %NullCheck14 = icmp ne i16* %28, null
-  br i1 %NullCheck14, label %29, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %28, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = load i16, i16* %28, align 8
@@ -2620,15 +2702,15 @@ entry:
 
 ; <label>:67                                      ; preds = %64
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
-  br i1 %NullCheck8, label %69, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %68, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %69
 
 ; <label>:69                                      ; preds = %67
   %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
   %71 = load i32, i32 addrspace(1)* %70
   %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
-  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %73
 
 ; <label>:73                                      ; preds = %69
   %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
@@ -2645,31 +2727,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %67
+ThrowNullRef8:                                    ; preds = %67
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %69
+ThrowNullRef10:                                   ; preds = %69
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2710,14 +2792,14 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
   %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
@@ -2730,14 +2812,14 @@ entry:
 
 ; <label>:11                                      ; preds = %4
   %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
   %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
@@ -2749,14 +2831,14 @@ entry:
 
 ; <label>:22                                      ; preds = %16
   %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
   %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
-  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
-  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
@@ -2804,23 +2886,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2836,7 +2918,280 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[loadElem]
+Successfully read RuntimeType.IsAssignableFrom
+
+define i8 @RuntimeType.IsAssignableFrom(%System.RuntimeType addrspace(1)* %param0, %System.Type addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.RuntimeType addrspace(1)*
+  %arg1 = alloca %System.Type addrspace(1)*
+  %loc0 = alloca %System.RuntimeType addrspace(1)*
+  %loc1 = alloca %"System.Type[]" addrspace(1)*
+  %loc2 = alloca i32
+  store %System.RuntimeType addrspace(1)* %param0, %System.RuntimeType addrspace(1)** %this
+  store %System.Type addrspace(1)* %param1, %System.Type addrspace(1)** %arg1
+  %0 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %1 = icmp ne %System.Type addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i8 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %5 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %6 = bitcast %System.Type addrspace(1)* %4 to %System.Object addrspace(1)*
+  %7 = bitcast %System.RuntimeType addrspace(1)* %5 to %System.Object addrspace(1)*
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %6, %System.Object addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %3
+  ret i8 1
+
+; <label>:12                                      ; preds = %3
+  %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 152
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 32
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
+  %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
+  %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
+  store %System.RuntimeType addrspace(1)* %25, %System.RuntimeType addrspace(1)** %loc0
+  %26 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %27 = icmp eq %System.RuntimeType addrspace(1)* %26, null
+  br i1 %27, label %34, label %28
+
+; <label>:28                                      ; preds = %15
+  %29 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %30 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)*)*)(%System.RuntimeType addrspace(1)* %29, %System.RuntimeType addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+; <label>:34                                      ; preds = %15
+  %35 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %36 = call %System.Reflection.Emit.TypeBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Reflection.Emit.TypeBuilder addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %35)
+  %37 = icmp eq %System.Reflection.Emit.TypeBuilder addrspace(1)* %36, null
+  br i1 %37, label %139, label %38
+
+; <label>:38                                      ; preds = %34
+  %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %42
+
+; <label>:42                                      ; preds = %38
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 152
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 40
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
+  %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
+  %53 = zext i8 %52 to i32
+  %54 = icmp eq i32 %53, 0
+  br i1 %54, label %56, label %55
+
+; <label>:55                                      ; preds = %42
+  ret i8 1
+
+; <label>:56                                      ; preds = %42
+  %57 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %58 = bitcast %System.RuntimeType addrspace(1)* %57 to %System.Type addrspace(1)*
+  %59 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %58)
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %64 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.Type addrspace(1)* %63, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = bitcast %System.RuntimeType addrspace(1)* %64 to %System.Type addrspace(1)*
+  %67 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %63, %System.Type addrspace(1)* %66)
+  %68 = zext i8 %67 to i32
+  %69 = trunc i32 %68 to i8
+  ret i8 %69
+
+; <label>:70                                      ; preds = %56
+  %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
+  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %73
+
+; <label>:73                                      ; preds = %70
+  %74 = load i64, i64 addrspace(1)* %72
+  %75 = add i64 %74, 128
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = add i64 %77, 0
+  %79 = inttoptr i64 %78 to i64*
+  %80 = load i64, i64* %79
+  %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
+  %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
+  %83 = call i8 %82(%System.Type addrspace(1)* %81)
+  %84 = zext i8 %83 to i32
+  %85 = icmp eq i32 %84, 0
+  br i1 %85, label %139, label %86
+
+; <label>:86                                      ; preds = %73
+  %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
+  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %89
+
+; <label>:89                                      ; preds = %86
+  %90 = load i64, i64 addrspace(1)* %88
+  %91 = add i64 %90, 128
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = add i64 %93, 24
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
+  %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
+  %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
+  store %"System.Type[]" addrspace(1)* %99, %"System.Type[]" addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %129
+
+; <label>:100                                     ; preds = %132
+  %101 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %102 = load i32, i32* %loc2
+  %NullCheck11 = icmp eq %"System.Type[]" addrspace(1)* %101, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %103
+
+; <label>:103                                     ; preds = %100
+  %104 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 1
+  %105 = load i32, i32 addrspace(1)* %104
+  %106 = zext i32 %105 to i64
+  %107 = zext i32 %102 to i64
+  %BoundsCheck = icmp uge i64 %107, %106
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %108
+
+; <label>:108                                     ; preds = %103
+  %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
+  %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
+  %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
+  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %113
+
+; <label>:113                                     ; preds = %108
+  %114 = load i64, i64 addrspace(1)* %112
+  %115 = add i64 %114, 152
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = add i64 %117, 56
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
+  %123 = zext i8 %122 to i32
+  %124 = icmp ne i32 %123, 0
+  br i1 %124, label %126, label %125
+
+; <label>:125                                     ; preds = %113
+  ret i8 0
+
+; <label>:126                                     ; preds = %113
+  %127 = load i32, i32* %loc2
+  %128 = add i32 %127, 1
+  store i32 %128, i32* %loc2
+  br label %129
+
+; <label>:129                                     ; preds = %89, %126
+  %130 = load i32, i32* %loc2
+  %131 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %NullCheck9 = icmp eq %"System.Type[]" addrspace(1)* %131, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %132
+
+; <label>:132                                     ; preds = %129
+  %133 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %131, i32 0, i32 1
+  %134 = load i32, i32 addrspace(1)* %133
+  %135 = zext i32 %134 to i64
+  %136 = trunc i64 %135 to i32
+  %137 = icmp slt i32 %130, %136
+  br i1 %137, label %100, label %138
+
+; <label>:138                                     ; preds = %132
+  ret i8 1
+
+; <label>:139                                     ; preds = %34, %73
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %129
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %103
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -2893,7 +3248,7 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElem]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -2904,8 +3259,8 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -2997,8 +3352,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
@@ -3059,8 +3414,8 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -3087,8 +3442,8 @@ entry:
 
 ; <label>:17                                      ; preds = %5, %11
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
@@ -3097,8 +3452,8 @@ entry:
 
 ; <label>:22                                      ; preds = %1, %11
   %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
@@ -3109,11 +3464,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %17
+ThrowNullRef2:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %22
+ThrowNullRef4:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3167,15 +3522,15 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
   %15 = load i32, i32 addrspace(1)* %14
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
@@ -3198,7 +3553,7 @@ ThrowNullRef:                                     ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef2:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3232,8 +3587,8 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
@@ -3312,8 +3667,8 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -3327,8 +3682,8 @@ entry:
 ; <label>:5                                       ; preds = %43
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %7 = load i32, i32* %loc1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck6, label %8, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
@@ -3366,8 +3721,8 @@ entry:
 ; <label>:32                                      ; preds = %21, %25
   %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
   %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
-  br i1 %NullCheck8, label %35, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = trunc i32 %34 to i16
@@ -3380,8 +3735,8 @@ entry:
 ; <label>:40                                      ; preds = %1, %35
   %41 = load i32, i32* %loc1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
-  br i1 %NullCheck2, label %43, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %42, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
@@ -3392,8 +3747,8 @@ entry:
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
   %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
-  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
   %51 = load i64, i64 addrspace(1)* %49
@@ -3412,19 +3767,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %40
+ThrowNullRef2:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %47
+ThrowNullRef4:                                    ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %5
+ThrowNullRef6:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %32
+ThrowNullRef8:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3467,8 +3822,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
@@ -3492,11 +3847,391 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(i16* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store i16* %param0, i16** %arg0
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load i32, i32* %arg3
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %42, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %37, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg2
+  %13 = load i32, i32* %arg3
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %37, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %24 = load i32, i32* %arg2
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load i16*, i16** %arg0
+  %35 = load i32, i32* %arg3
+  %36 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %36, i16* %34, i32 %35)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:37                                      ; preds = %5, %16
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %39)
+  %41 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41, %System.String addrspace(1)* %38, %System.String addrspace(1)* %40)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41) #0
+  unreachable
+
+; <label>:42                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
-Failed to read StringBuilder.ToString[loadElemA]
+Successfully read StringBuilder.ToString
+
+define %System.String addrspace(1)* @StringBuilder.ToString(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i16*
+  %loc3 = alloca %"System.Char[]" addrspace(1)*
+  %loc4 = alloca i32
+  %loc5 = alloca i32
+  %loc6 = alloca i16 addrspace(1)*
+  %loc7 = alloca %System.String addrspace(1)*
+  %loc8 = alloca %"System.Char[]" addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %0)
+  %2 = icmp ne i32 %1, 0
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %4
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %6)
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %7)
+  store %System.String addrspace(1)* %8, %System.String addrspace(1)** %loc0
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.Text.StringBuilder addrspace(1)* %9, %System.Text.StringBuilder addrspace(1)** %loc1
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  store %System.String addrspace(1)* %10, %System.String addrspace(1)** %loc7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc7
+  %12 = ptrtoint %System.String addrspace(1)* %11 to i64
+  %13 = icmp eq i64 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %5
+  %15 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %16 = sext i32 %15 to i64
+  %17 = add i64 %12, %16
+  br label %18
+
+; <label>:18                                      ; preds = %5, %14
+  %19 = phi i64 [ %12, %5 ], [ %17, %14 ]
+  %20 = inttoptr i64 %19 to i16*
+  store i16* %20, i16** %loc2
+  br label %21
+
+; <label>:21                                      ; preds = %98, %18
+  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %22, null
+  br i1 %NullCheck, label %ThrowNullRef, label %23
+
+; <label>:23                                      ; preds = %21
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 3
+  %25 = load i32, i32 addrspace(1)* %24, align 8
+  %26 = icmp sle i32 %25, 0
+  br i1 %26, label %96, label %27
+
+; <label>:27                                      ; preds = %23
+  %28 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %28, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %29
+
+; <label>:29                                      ; preds = %27
+  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %28, i32 0, i32 1
+  %31 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %30, align 8
+  store %"System.Char[]" addrspace(1)* %31, %"System.Char[]" addrspace(1)** %loc3
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %33
+
+; <label>:33                                      ; preds = %29
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  store i32 %35, i32* %loc4
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  %39 = load i32, i32 addrspace(1)* %38, align 8
+  store i32 %39, i32* %loc5
+  %40 = load i32, i32* %loc5
+  %41 = load i32, i32* %loc4
+  %42 = add i32 %40, %41
+  %43 = zext i32 %42 to i64
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %45
+
+; <label>:45                                      ; preds = %37
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = sext i32 %47 to i64
+  %49 = icmp sgt i64 %43, %48
+  br i1 %49, label %91, label %50
+
+; <label>:50                                      ; preds = %45
+  %51 = load i32, i32* %loc5
+  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %52, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %53
+
+; <label>:53                                      ; preds = %50
+  %54 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %52, i32 0, i32 1
+  %55 = load i32, i32 addrspace(1)* %54
+  %56 = zext i32 %55 to i64
+  %57 = trunc i64 %56 to i32
+  %58 = icmp ugt i32 %51, %57
+  br i1 %58, label %91, label %59
+
+; <label>:59                                      ; preds = %53
+  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  store %"System.Char[]" addrspace(1)* %60, %"System.Char[]" addrspace(1)** %loc8
+  %61 = icmp eq %"System.Char[]" addrspace(1)* %60, null
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %63, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %64
+
+; <label>:64                                      ; preds = %62
+  %65 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %63, i32 0, i32 1
+  %66 = load i32, i32 addrspace(1)* %65
+  %67 = zext i32 %66 to i64
+  %68 = trunc i64 %67 to i32
+  %69 = icmp ne i32 %68, 0
+  br i1 %69, label %71, label %70
+
+; <label>:70                                      ; preds = %59, %64
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:71                                      ; preds = %64
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %73
+
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %BoundsCheck = icmp uge i64 0, %76
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %77
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %78, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:79                                      ; preds = %70, %77
+  %80 = load i16*, i16** %loc2
+  %81 = load i32, i32* %loc4
+  %82 = sext i32 %81 to i64
+  %83 = mul i64 %82, 2
+  %84 = bitcast i16* %80 to i8*
+  %85 = getelementptr inbounds i8, i8* %84, i64 %83
+  %86 = load i16 addrspace(1)*, i16 addrspace(1)** %loc6
+  %87 = ptrtoint i16 addrspace(1)* %86 to i64
+  %88 = load i32, i32* %loc5
+  %89 = bitcast i8* %85 to i16*
+  %90 = inttoptr i64 %87 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %89, i16* %90, i32 %88)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %96
+
+; <label>:91                                      ; preds = %45, %53
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %94 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %93)
+  %95 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95, %System.String addrspace(1)* %92, %System.String addrspace(1)* %94)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95) #0
+  unreachable
+
+; <label>:96                                      ; preds = %23, %79
+  %97 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %97, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %98
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %97, i32 0, i32 2
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  store %System.Text.StringBuilder addrspace(1)* %100, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %102 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %102, label %21, label %103
+
+; <label>:103                                     ; preds = %98
+  store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc7
+  %104 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  ret %System.String addrspace(1)* %104
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method StringBuilder::get_Length using LLILCJit
+Successfully read StringBuilder.get_Length
+
+define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
+Successfully read RuntimeHelpers.get_OffsetToStringData
+
+define i32 @RuntimeHelpers.get_OffsetToStringData() {
+entry:
+  ret i32 12
+}
+
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
 Successfully read CultureData.CreateCultureData
 
@@ -3514,23 +4249,23 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
   store i8 %4, i8 addrspace(1)* %6
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
@@ -3549,11 +4284,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3566,50 +4301,50 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
   store i32 -1, i32 addrspace(1)* %2
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
   store i32 -1, i32 addrspace(1)* %8
   %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
   store i32 -1, i32 addrspace(1)* %14
   %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
   store i32 -1, i32 addrspace(1)* %17
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
@@ -3623,27 +4358,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3675,7 +4410,136 @@ Failed to read Dictionary`2.Insert[non-const derefAddress]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
 Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
-Failed to read HashHelpers.GetPrime[loadElem]
+Successfully read HashHelpers.GetPrime
+
+define i32 @HashHelpers.GetPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %6, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5, %System.String addrspace(1)* %4)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5) #0
+  unreachable
+
+; <label>:6                                       ; preds = %entry
+  store i32 0, i32* %loc0
+  br label %29
+
+; <label>:7                                       ; preds = %35
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 1296
+  %10 = addrspacecast i8 addrspace(1)* %9 to %"System.Int32[]" addrspace(1)**
+  %11 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %10
+  %12 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Int32[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = zext i32 %15 to i64
+  %17 = zext i32 %12 to i64
+  %BoundsCheck = icmp uge i64 %17, %16
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 3, i32 %12
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  store i32 %20, i32* %loc1
+  %21 = load i32, i32* %loc1
+  %22 = load i32, i32* %arg0
+  %23 = icmp slt i32 %21, %22
+  br i1 %23, label %26, label %24
+
+; <label>:24                                      ; preds = %18
+  %25 = load i32, i32* %loc1
+  ret i32 %25
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %loc0
+  %28 = add i32 %27, 1
+  store i32 %28, i32* %loc0
+  br label %29
+
+; <label>:29                                      ; preds = %6, %26
+  %30 = load i32, i32* %loc0
+  %31 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %32 = getelementptr inbounds i8, i8 addrspace(1)* %31, i64 1296
+  %33 = addrspacecast i8 addrspace(1)* %32 to %"System.Int32[]" addrspace(1)**
+  %34 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %33
+  %NullCheck = icmp eq %"System.Int32[]" addrspace(1)* %34, null
+  br i1 %NullCheck, label %ThrowNullRef, label %35
+
+; <label>:35                                      ; preds = %29
+  %36 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %34, i32 0, i32 1
+  %37 = load i32, i32 addrspace(1)* %36
+  %38 = zext i32 %37 to i64
+  %39 = trunc i64 %38 to i32
+  %40 = icmp slt i32 %30, %39
+  br i1 %40, label %7, label %41
+
+; <label>:41                                      ; preds = %35
+  %42 = load i32, i32* %arg0
+  %43 = or i32 %42, 1
+  store i32 %43, i32* %loc2
+  br label %59
+
+; <label>:44                                      ; preds = %59
+  %45 = load i32, i32* %loc2
+  %46 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %45)
+  %47 = zext i8 %46 to i32
+  %48 = icmp eq i32 %47, 0
+  br i1 %48, label %56, label %49
+
+; <label>:49                                      ; preds = %44
+  %50 = load i32, i32* %loc2
+  %51 = sub i32 %50, 1
+  %52 = srem i32 %51, 101
+  %53 = icmp eq i32 %52, 0
+  br i1 %53, label %56, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = load i32, i32* %loc2
+  ret i32 %55
+
+; <label>:56                                      ; preds = %44, %49
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %57, 2
+  store i32 %58, i32* %loc2
+  br label %59
+
+; <label>:59                                      ; preds = %41, %56
+  %60 = load i32, i32* %loc2
+  %61 = icmp slt i32 %60, 2147483647
+  br i1 %61, label %44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load i32, i32* %arg0
+  ret i32 %63
+
+ThrowNullRef:                                     ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
 Successfully read GenericEqualityComparer`1.GetHashCode
 
@@ -3694,14 +4558,14 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
   %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load i64, i64 addrspace(1)* %7
@@ -3720,7 +4584,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3750,8 +4614,8 @@ entry:
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
@@ -3796,8 +4660,8 @@ entry:
   %35 = bitcast i16* %34 to i8*
   %36 = getelementptr inbounds i8, i8* %35, i64 2
   %37 = bitcast i8* %36 to i16*
-  %NullCheck4 = icmp ne i16* %37, null
-  br i1 %NullCheck4, label %38, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %37, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %38
 
 ; <label>:38                                      ; preds = %27
   %39 = load i16, i16* %37, align 8
@@ -3824,8 +4688,8 @@ entry:
 
 ; <label>:54                                      ; preds = %22, %43
   %55 = load i16*, i16** %loc4
-  %NullCheck2 = icmp ne i16* %55, null
-  br i1 %NullCheck2, label %56, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i16* %55, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %56
 
 ; <label>:56                                      ; preds = %54
   %57 = load i16, i16* %55, align 8
@@ -3850,11 +4714,11 @@ ThrowNullRef:                                     ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %54
+ThrowNullRef2:                                    ; preds = %54
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %27
+ThrowNullRef4:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3871,8 +4735,8 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -3907,8 +4771,8 @@ entry:
 
 ; <label>:26                                      ; preds = %19
   %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
-  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %28
 
 ; <label>:28                                      ; preds = %26
   %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
@@ -3920,7 +4784,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3972,8 +4836,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
@@ -3984,26 +4848,26 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
-  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
@@ -4014,8 +4878,8 @@ entry:
 ; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
@@ -4024,8 +4888,8 @@ entry:
 
 ; <label>:25                                      ; preds = %1, %16, %23
   %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
-  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
@@ -4036,27 +4900,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %20
+ThrowNullRef10:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4069,8 +4933,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -4081,8 +4945,8 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
@@ -4091,8 +4955,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1, %8
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
@@ -4103,11 +4967,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4128,24 +4992,24 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   store i32 %3, i32* %loc0
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
   %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
   store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck4, label %9, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
@@ -4164,15 +5028,15 @@ entry:
 ; <label>:18                                      ; preds = %70
   %19 = load i16*, i16** %loc3
   %20 = bitcast i16* %19 to i64*
-  %NullCheck10 = icmp ne i64* %20, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %20, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = load i64, i64* %20, align 8
   %23 = load i16*, i16** %loc4
   %24 = bitcast i16* %23 to i64*
-  %NullCheck12 = icmp ne i64* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = load i64, i64* %24, align 8
@@ -4188,8 +5052,8 @@ entry:
   %31 = bitcast i16* %30 to i8*
   %32 = getelementptr inbounds i8, i8* %31, i64 8
   %33 = bitcast i8* %32 to i64*
-  %NullCheck14 = icmp ne i64* %33, null
-  br i1 %NullCheck14, label %34, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = load i64, i64* %33, align 8
@@ -4197,8 +5061,8 @@ entry:
   %37 = bitcast i16* %36 to i8*
   %38 = getelementptr inbounds i8, i8* %37, i64 8
   %39 = bitcast i8* %38 to i64*
-  %NullCheck16 = icmp ne i64* %39, null
-  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %40
 
 ; <label>:40                                      ; preds = %34
   %41 = load i64, i64* %39, align 8
@@ -4214,8 +5078,8 @@ entry:
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %NullCheck18 = icmp ne i64* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = load i64, i64* %48, align 8
@@ -4223,8 +5087,8 @@ entry:
   %52 = bitcast i16* %51 to i8*
   %53 = getelementptr inbounds i8, i8* %52, i64 16
   %54 = bitcast i8* %53 to i64*
-  %NullCheck20 = icmp ne i64* %54, null
-  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64* %54, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %55
 
 ; <label>:55                                      ; preds = %49
   %56 = load i64, i64* %54, align 8
@@ -4262,15 +5126,15 @@ entry:
 ; <label>:74                                      ; preds = %95
   %75 = load i16*, i16** %loc3
   %76 = bitcast i16* %75 to i32*
-  %NullCheck6 = icmp ne i32* %76, null
-  br i1 %NullCheck6, label %77, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32* %76, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %77
 
 ; <label>:77                                      ; preds = %74
   %78 = load i32, i32* %76, align 8
   %79 = load i16*, i16** %loc4
   %80 = bitcast i16* %79 to i32*
-  %NullCheck8 = icmp ne i32* %80, null
-  br i1 %NullCheck8, label %81, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i32* %80, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %81
 
 ; <label>:81                                      ; preds = %77
   %82 = load i32, i32* %80, align 8
@@ -4318,43 +5182,43 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %74
+ThrowNullRef6:                                    ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %77
+ThrowNullRef8:                                    ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %29
+ThrowNullRef14:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %34
+ThrowNullRef16:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4376,8 +5240,8 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load i64, i64 addrspace(1)* %4
@@ -4389,8 +5253,8 @@ entry:
   %12 = load i64, i64* %11
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %5
   %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
@@ -4399,8 +5263,8 @@ entry:
   %18 = load i8, i8* %arg2
   %19 = zext i8 %18 to i32
   %20 = trunc i32 %19 to i8
-  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %15
   %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
@@ -4411,11 +5275,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4442,8 +5306,8 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
@@ -4466,16 +5330,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
   %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = load i64, i64 addrspace(1)* %19
@@ -4500,8 +5364,8 @@ entry:
 ; <label>:35                                      ; preds = %30
   %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
@@ -4514,8 +5378,8 @@ entry:
 
 ; <label>:42                                      ; preds = %1, %38
   %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
-  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
@@ -4526,19 +5390,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %35
+ThrowNullRef2:                                    ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %42
+ThrowNullRef8:                                    ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4551,14 +5415,14 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
@@ -4570,7 +5434,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4583,8 +5447,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
@@ -4613,51 +5477,51 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
   %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
   %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
   %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
   %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
-  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
   store i64 %21, i64 addrspace(1)* %23
   %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %25 = load i64, i64* %loc0
-  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
@@ -4668,27 +5532,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %22
+ThrowNullRef12:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4701,8 +5565,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
@@ -4713,19 +5577,19 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
@@ -4734,8 +5598,8 @@ entry:
 
 ; <label>:15                                      ; preds = %1, %13
   %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
@@ -4746,19 +5610,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %15
+ThrowNullRef8:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4771,8 +5635,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -4831,8 +5695,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
@@ -4882,8 +5746,8 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
-  br i1 %NullCheck, label %17, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %ThrowNullRef, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
@@ -4894,15 +5758,15 @@ entry:
 
 ; <label>:22                                      ; preds = %17
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
-  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
   %26 = load i32, i32 addrspace(1)* %25
   %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
-  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %27, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
@@ -4925,8 +5789,8 @@ entry:
 ; <label>:40                                      ; preds = %17
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
-  br i1 %NullCheck6, label %43, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %41, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
@@ -4938,34 +5802,17 @@ ThrowNullRef:                                     ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %24
+ThrowNullRef4:                                    ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %40
+ThrowNullRef6:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
-}
-
-INFO:  jitting method Object::ReferenceEquals using LLILCJit
-Successfully read Object.ReferenceEquals
-
-define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
-entry:
-  %arg0 = alloca %System.Object addrspace(1)*
-  %arg1 = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
-  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
-  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = icmp eq %System.Object addrspace(1)* %0, %1
-  %3 = sext i1 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
 }
 
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
@@ -4978,21 +5825,21 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
   %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
-  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
@@ -5007,28 +5854,28 @@ entry:
 ; <label>:13                                      ; preds = %8, %12
   %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
   %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
   %21 = load i32, i32 addrspace(1)* %20, align 8
   %22 = add i32 %21, 1
-  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
   store i32 %22, i32 addrspace(1)* %24
   %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
@@ -5039,27 +5886,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5077,7 +5924,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::Setup using LLILCJit
-Failed to read AppDomain.Setup[loadElem]
+Failed to read AppDomain.Setup[unbox]
 INFO:  jitting method Thread::GetDomain using LLILCJit
 Successfully read Thread.GetDomain
 
@@ -5108,8 +5955,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
@@ -5122,14 +5969,14 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
   %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
@@ -5141,11 +5988,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5173,8 +6020,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -5189,7 +6036,328 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
 Failed to read KeyCollection.System.Collections.Generic.IEnumerable<TKey>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Successfully read Enumerator.MoveNext
+
+define i8 @Enumerator.MoveNext(%"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.RuntimeTypeHandle* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*
+  %"$TypeArg" = alloca %System.RuntimeTypeHandle*
+  store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
+  %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 8
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %76, label %12
+
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
+  br label %76
+
+; <label>:13                                      ; preds = %85
+  %14 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck19 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %15
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, i32 0, i32 0
+  %17 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %16, align 8
+  %NullCheck21 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, i32 0, i32 2
+  %20 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %19, align 8
+  %21 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck23 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %22
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, i32 0, i32 2
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %NullCheck25 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 3, i32 %24
+  %NullCheck27 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %32
+
+; <label>:32                                      ; preds = %30
+  %33 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, i32 0, i32 2
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = icmp slt i32 %34, 0
+  br i1 %35, label %68, label %36
+
+; <label>:36                                      ; preds = %32
+  %37 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %38 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck29 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %39
+
+; <label>:39                                      ; preds = %36
+  %40 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, i32 0, i32 0
+  %41 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %40, align 8
+  %NullCheck31 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, i32 0, i32 2
+  %44 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %43, align 8
+  %45 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck33 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, i32 0, i32 2
+  %48 = load i32, i32 addrspace(1)* %47, align 8
+  %NullCheck35 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %49
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = zext i32 %51 to i64
+  %53 = zext i32 %48 to i64
+  %BoundsCheck37 = icmp uge i64 %53, %52
+  br i1 %BoundsCheck37, label %ThrowIndexOutOfRange38, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 3, i32 %48
+  %NullCheck39 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %56
+
+; <label>:56                                      ; preds = %54
+  %57 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, i32 0, i32 0
+  %58 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck41 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %59
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %60, %System.__Canon addrspace(1)* %58)
+  %61 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck43 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  %64 = load i32, i32 addrspace(1)* %63, align 8
+  %65 = add i32 %64, 1
+  %NullCheck45 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  store i32 %65, i32 addrspace(1)* %67
+  ret i8 1
+
+; <label>:68                                      ; preds = %32
+  %69 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck47 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %73 = add i32 %72, 1
+  %NullCheck49 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %74
+
+; <label>:74                                      ; preds = %70
+  %75 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  store i32 %73, i32 addrspace(1)* %75
+  br label %76
+
+; <label>:76                                      ; preds = %8, %12, %74
+  %77 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %78
+
+; <label>:78                                      ; preds = %76
+  %79 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, i32 0, i32 2
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck7 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %82
+
+; <label>:82                                      ; preds = %78
+  %83 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, i32 0, i32 0
+  %84 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %83, align 8
+  %NullCheck9 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %85
+
+; <label>:85                                      ; preds = %82
+  %86 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, i32 0, i32 7
+  %87 = load i32, i32 addrspace(1)* %86, align 8
+  %88 = icmp ult i32 %80, %87
+  br i1 %88, label %13, label %89
+
+; <label>:89                                      ; preds = %85
+  %90 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %91 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck11 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %92
+
+; <label>:92                                      ; preds = %89
+  %93 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, i32 0, i32 0
+  %94 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck13 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %95
+
+; <label>:95                                      ; preds = %92
+  %96 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, i32 0, i32 7
+  %97 = load i32, i32 addrspace(1)* %96, align 8
+  %98 = add i32 %97, 1
+  %NullCheck15 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %99
+
+; <label>:99                                      ; preds = %95
+  %100 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, i32 0, i32 2
+  store i32 %98, i32 addrspace(1)* %100
+  %101 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck17 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %102
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %103, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %92
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef22:                                   ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef24:                                   ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef26:                                   ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef28:                                   ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef30:                                   ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef32:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef34:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef36:                                   ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange38:                           ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef40:                                   ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef42:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef44:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef46:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef48:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef50:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -5200,8 +6368,8 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -5232,9 +6400,9 @@ Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
 Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
-Failed to read String.MakeSeparatorList[loadElemA]
+Failed to read String.MakeSeparatorList[storeElem]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
-Failed to read String.InternalSplitKeepEmptyEntries[loadElem]
+Failed to read String.InternalSplitKeepEmptyEntries[storeElem]
 INFO:  jitting method Path::IsRelative using LLILCJit
 Successfully read Path.IsRelative
 
@@ -5243,8 +6411,8 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -5254,8 +6422,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
@@ -5271,8 +6439,8 @@ entry:
 
 ; <label>:17                                      ; preds = %7
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
@@ -5288,8 +6456,8 @@ entry:
 
 ; <label>:29                                      ; preds = %19
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %31
 
 ; <label>:31                                      ; preds = %29
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
@@ -5300,8 +6468,8 @@ entry:
 
 ; <label>:36                                      ; preds = %31
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
-  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %37, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
@@ -5312,8 +6480,8 @@ entry:
 
 ; <label>:43                                      ; preds = %31, %38
   %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
-  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %45
 
 ; <label>:45                                      ; preds = %43
   %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
@@ -5324,8 +6492,8 @@ entry:
 
 ; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %50
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
@@ -5336,8 +6504,8 @@ entry:
 
 ; <label>:57                                      ; preds = %1, %7, %19, %45, %52
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
-  br i1 %NullCheck14, label %59, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %59
 
 ; <label>:59                                      ; preds = %57
   %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
@@ -5347,8 +6515,8 @@ entry:
 
 ; <label>:63                                      ; preds = %59
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
@@ -5359,8 +6527,8 @@ entry:
 
 ; <label>:70                                      ; preds = %65
   %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
-  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.String addrspace(1)* %71, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %72
 
 ; <label>:72                                      ; preds = %70
   %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
@@ -5379,39 +6547,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %17
+ThrowNullRef4:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %29
+ThrowNullRef6:                                    ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %36
+ThrowNullRef8:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %43
+ThrowNullRef10:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %50
+ThrowNullRef12:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %57
+ThrowNullRef14:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %63
+ThrowNullRef16:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %70
+ThrowNullRef18:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5419,7 +6587,293 @@ ThrowNullRef17:                                   ; preds = %70
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
-Failed to read String.TrimHelper[loadElem]
+Successfully read String.TrimHelper
+
+define %System.String addrspace(1)* @String.TrimHelper(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i16
+  %loc4 = alloca i32
+  %loc5 = alloca i16
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = sub i32 %3, 1
+  store i32 %4, i32* %loc0
+  store i32 0, i32* %loc1
+  %5 = load i32, i32* %arg2
+  %6 = icmp eq i32 %5, 1
+  br i1 %6, label %62, label %7
+
+; <label>:7                                       ; preds = %1
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:8                                       ; preds = %58
+  store i32 0, i32* %loc2
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load i32, i32* %loc1
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2, i32 %10
+  %13 = load i16, i16 addrspace(1)* %12
+  %14 = zext i16 %13 to i32
+  %15 = trunc i32 %14 to i16
+  store i16 %15, i16* %loc3
+  store i32 0, i32* %loc2
+  br label %34
+
+; <label>:16                                      ; preds = %37
+  %17 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %18 = load i32, i32* %loc2
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %17, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %19
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = zext i32 %18 to i64
+  %BoundsCheck = icmp uge i64 %23, %22
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %24
+
+; <label>:24                                      ; preds = %19
+  %25 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 3, i32 %18
+  %26 = load i16, i16 addrspace(1)* %25, align 8
+  %27 = zext i16 %26 to i32
+  %28 = load i16, i16* %loc3
+  %29 = zext i16 %28 to i32
+  %30 = icmp eq i32 %27, %29
+  br i1 %30, label %43, label %31
+
+; <label>:31                                      ; preds = %24
+  %32 = load i32, i32* %loc2
+  %33 = add i32 %32, 1
+  store i32 %33, i32* %loc2
+  br label %34
+
+; <label>:34                                      ; preds = %11, %31
+  %35 = load i32, i32* %loc2
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = icmp slt i32 %35, %41
+  br i1 %42, label %16, label %43
+
+; <label>:43                                      ; preds = %24, %37
+  %44 = load i32, i32* %loc2
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %45, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp eq i32 %44, %50
+  br i1 %51, label %62, label %52
+
+; <label>:52                                      ; preds = %46
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %7, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %57, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %58
+
+; <label>:58                                      ; preds = %55
+  %59 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %60 = load i32, i32 addrspace(1)* %59
+  %61 = icmp slt i32 %56, %60
+  br i1 %61, label %8, label %62
+
+; <label>:62                                      ; preds = %1, %46, %58
+  %63 = load i32, i32* %arg2
+  %64 = icmp eq i32 %63, 0
+  br i1 %64, label %122, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %66, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %67
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %66, i32 0, i32 1
+  %69 = load i32, i32 addrspace(1)* %68
+  %70 = sub i32 %69, 1
+  store i32 %70, i32* %loc0
+  br label %118
+
+; <label>:71                                      ; preds = %118
+  store i32 0, i32* %loc4
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %73 = load i32, i32* %loc0
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %74
+
+; <label>:74                                      ; preds = %71
+  %75 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 2, i32 %73
+  %76 = load i16, i16 addrspace(1)* %75
+  %77 = zext i16 %76 to i32
+  %78 = trunc i32 %77 to i16
+  store i16 %78, i16* %loc5
+  store i32 0, i32* %loc4
+  br label %97
+
+; <label>:79                                      ; preds = %100
+  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %81 = load i32, i32* %loc4
+  %NullCheck19 = icmp eq %"System.Char[]" addrspace(1)* %80, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
+
+; <label>:82                                      ; preds = %79
+  %83 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 1
+  %84 = load i32, i32 addrspace(1)* %83
+  %85 = zext i32 %84 to i64
+  %86 = zext i32 %81 to i64
+  %BoundsCheck21 = icmp uge i64 %86, %85
+  br i1 %BoundsCheck21, label %ThrowIndexOutOfRange22, label %87
+
+; <label>:87                                      ; preds = %82
+  %88 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 3, i32 %81
+  %89 = load i16, i16 addrspace(1)* %88, align 8
+  %90 = zext i16 %89 to i32
+  %91 = load i16, i16* %loc5
+  %92 = zext i16 %91 to i32
+  %93 = icmp eq i32 %90, %92
+  br i1 %93, label %106, label %94
+
+; <label>:94                                      ; preds = %87
+  %95 = load i32, i32* %loc4
+  %96 = add i32 %95, 1
+  store i32 %96, i32* %loc4
+  br label %97
+
+; <label>:97                                      ; preds = %74, %94
+  %98 = load i32, i32* %loc4
+  %99 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck15 = icmp eq %"System.Char[]" addrspace(1)* %99, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %100
+
+; <label>:100                                     ; preds = %97
+  %101 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %99, i32 0, i32 1
+  %102 = load i32, i32 addrspace(1)* %101
+  %103 = zext i32 %102 to i64
+  %104 = trunc i64 %103 to i32
+  %105 = icmp slt i32 %98, %104
+  br i1 %105, label %79, label %106
+
+; <label>:106                                     ; preds = %87, %100
+  %107 = load i32, i32* %loc4
+  %108 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck17 = icmp eq %"System.Char[]" addrspace(1)* %108, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %109
+
+; <label>:109                                     ; preds = %106
+  %110 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %108, i32 0, i32 1
+  %111 = load i32, i32 addrspace(1)* %110
+  %112 = zext i32 %111 to i64
+  %113 = trunc i64 %112 to i32
+  %114 = icmp eq i32 %107, %113
+  br i1 %114, label %122, label %115
+
+; <label>:115                                     ; preds = %109
+  %116 = load i32, i32* %loc0
+  %117 = sub i32 %116, 1
+  store i32 %117, i32* %loc0
+  br label %118
+
+; <label>:118                                     ; preds = %67, %115
+  %119 = load i32, i32* %loc0
+  %120 = load i32, i32* %loc1
+  %121 = icmp sge i32 %119, %120
+  br i1 %121, label %71, label %122
+
+; <label>:122                                     ; preds = %62, %109, %118
+  %123 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %124 = load i32, i32* %loc1
+  %125 = load i32, i32* %loc0
+  %126 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %123, i32 %124, i32 %125)
+  ret %System.String addrspace(1)* %126
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %97
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange22:                           ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
 Successfully read String.CreateTrimmedString
 
@@ -5439,8 +6893,8 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
@@ -5535,8 +6989,8 @@ entry:
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i64 2872
   %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
   %8 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %7
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %3
   %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
@@ -5553,8 +7007,8 @@ entry:
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 2864
   %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
   %21 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %20
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
-  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %22
 
 ; <label>:22                                      ; preds = %16
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
@@ -5569,7 +7023,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %16
+ThrowNullRef2:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5586,8 +7040,8 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5613,8 +7067,8 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
@@ -5632,8 +7086,8 @@ entry:
 
 ; <label>:12                                      ; preds = %4
   %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
@@ -5644,8 +7098,8 @@ entry:
 
 ; <label>:19                                      ; preds = %14
   %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %19
   %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
@@ -5660,21 +7114,21 @@ entry:
   %31 = zext i16 %30 to i32
   %32 = bitcast i8* %29 to i16*
   %33 = trunc i32 %31 to i16
-  %NullCheck6 = icmp ne i16* %32, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i16* %32, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %21
   store i16 %33, i16* %32, align 8
   %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %36
 
 ; <label>:36                                      ; preds = %34
   %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
   %38 = load i32, i32 addrspace(1)* %37, align 8
   %39 = add i32 %38, 1
-  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %40
 
 ; <label>:40                                      ; preds = %36
   %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
@@ -5683,16 +7137,16 @@ entry:
 
 ; <label>:42                                      ; preds = %14
   %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
-  br i1 %NullCheck12, label %44, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
   %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
   %47 = load i16, i16* %arg1
   %48 = zext i16 %47 to i32
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = trunc i32 %48 to i16
@@ -5703,31 +7157,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %19
+ThrowNullRef4:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %21
+ThrowNullRef6:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %36
+ThrowNullRef10:                                   ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %42
+ThrowNullRef12:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %44
+ThrowNullRef14:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5740,8 +7194,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -5752,8 +7206,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
@@ -5762,14 +7216,14 @@ entry:
 
 ; <label>:11                                      ; preds = %1
   %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
@@ -5779,15 +7233,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5808,8 +7262,8 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5822,8 +7276,8 @@ entry:
 
 ; <label>:8                                       ; preds = %3
   %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
@@ -5842,15 +7296,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
-  br i1 %NullCheck4, label %22, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
   %24 = load i16*, i16* addrspace(1)* %23, align 8
   %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %25, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
@@ -5859,8 +7313,8 @@ entry:
   store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
@@ -5874,8 +7328,8 @@ entry:
 
 ; <label>:37                                      ; preds = %65
   %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %37
   %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
@@ -5886,16 +7340,16 @@ entry:
   %45 = bitcast i16* %41 to i8*
   %46 = getelementptr inbounds i8, i8* %45, i64 %44
   %47 = bitcast i8* %46 to i16*
-  %NullCheck14 = icmp ne i16* %47, null
-  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %47, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %48
 
 ; <label>:48                                      ; preds = %39
   %49 = load i16, i16* %47, align 8
   %50 = zext i16 %49 to i32
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %52 = load i32, i32* %loc1
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %53
 
 ; <label>:53                                      ; preds = %48
   %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
@@ -5916,8 +7370,8 @@ entry:
 ; <label>:62                                      ; preds = %36, %59
   %63 = load i32, i32* %loc1
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck10, label %65, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %65
 
 ; <label>:65                                      ; preds = %62
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
@@ -5936,15 +7390,15 @@ entry:
 
 ; <label>:74                                      ; preds = %70
   %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
-  br i1 %NullCheck18, label %76, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %76
 
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
   %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
-  br i1 %NullCheck20, label %80, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
   %81 = load i64, i64 addrspace(1)* %79
@@ -5958,8 +7412,8 @@ entry:
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
   %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
-  br i1 %NullCheck22, label %92, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.String addrspace(1)* %90, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %92
 
 ; <label>:92                                      ; preds = %80
   %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
@@ -5969,15 +7423,15 @@ entry:
 
 ; <label>:96                                      ; preds = %70
   %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
-  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %98
 
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
   %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
-  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
   %103 = load i64, i64 addrspace(1)* %101
@@ -5991,8 +7445,8 @@ entry:
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
   %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
-  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.String addrspace(1)* %112, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %114
 
 ; <label>:114                                     ; preds = %102
   %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
@@ -6004,59 +7458,59 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %20
+ThrowNullRef4:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %22
+ThrowNullRef6:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %26
+ThrowNullRef8:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %62
+ThrowNullRef10:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %48
+ThrowNullRef16:                                   ; preds = %48
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %74
+ThrowNullRef18:                                   ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %76
+ThrowNullRef20:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %80
+ThrowNullRef22:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %96
+ThrowNullRef24:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %98
+ThrowNullRef26:                                   ; preds = %98
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %102
+ThrowNullRef28:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6069,15 +7523,15 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
   %3 = load i16*, i16* addrspace(1)* %2, align 8
   %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
@@ -6087,8 +7541,8 @@ entry:
   %10 = bitcast i16* %3 to i8*
   %11 = getelementptr inbounds i8, i8* %10, i64 %9
   %12 = bitcast i8* %11 to i16*
-  %NullCheck4 = icmp ne i16* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %5
   store i16 0, i16* %12, align 8
@@ -6098,11 +7552,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6119,8 +7573,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -6131,8 +7585,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
@@ -6144,15 +7598,15 @@ entry:
 
 ; <label>:14                                      ; preds = %1
   %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
   %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
   %21 = load i64, i64 addrspace(1)* %19
@@ -6171,15 +7625,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %14
+ThrowNullRef4:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %16
+ThrowNullRef6:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6302,14 +7756,6 @@ entry:
   ret %System.String addrspace(1)* %57
 }
 
-INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
-Successfully read RuntimeHelpers.get_OffsetToStringData
-
-define i32 @RuntimeHelpers.get_OffsetToStringData() {
-entry:
-  ret i32 12
-}
-
 INFO:  jitting method String::Equals using LLILCJit
 Successfully read String.Equals
 
@@ -6381,8 +7827,8 @@ entry:
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
-  br i1 %NullCheck24, label %29, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
   %30 = load i64, i64 addrspace(1)* %28
@@ -6397,8 +7843,8 @@ entry:
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
-  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
   %43 = load i64, i64 addrspace(1)* %41
@@ -6418,8 +7864,8 @@ entry:
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
   %59 = load i64, i64 addrspace(1)* %57
@@ -6434,8 +7880,8 @@ entry:
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck22, label %71, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
   %72 = load i64, i64 addrspace(1)* %70
@@ -6455,8 +7901,8 @@ entry:
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
-  br i1 %NullCheck16, label %87, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = load i64, i64 addrspace(1)* %86
@@ -6471,8 +7917,8 @@ entry:
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck18, label %100, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
   %101 = load i64, i64 addrspace(1)* %99
@@ -6492,8 +7938,8 @@ entry:
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
-  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
   %117 = load i64, i64 addrspace(1)* %115
@@ -6508,8 +7954,8 @@ entry:
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
-  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
   %130 = load i64, i64 addrspace(1)* %128
@@ -6528,15 +7974,15 @@ entry:
 
 ; <label>:142                                     ; preds = %22
   %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
-  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %143, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %144
 
 ; <label>:144                                     ; preds = %142
   %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
   %146 = load i32, i32 addrspace(1)* %145
   %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
-  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %147, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %148
 
 ; <label>:148                                     ; preds = %144
   %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
@@ -6557,15 +8003,15 @@ entry:
 
 ; <label>:159                                     ; preds = %22
   %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
-  br i1 %NullCheck, label %161, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %ThrowNullRef, label %161
 
 ; <label>:161                                     ; preds = %159
   %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
   %163 = load i32, i32 addrspace(1)* %162
   %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
-  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %164, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %165
 
 ; <label>:165                                     ; preds = %161
   %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
@@ -6578,8 +8024,8 @@ entry:
 
 ; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
-  br i1 %NullCheck4, label %172, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %171, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %172
 
 ; <label>:172                                     ; preds = %170
   %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
@@ -6589,8 +8035,8 @@ entry:
 
 ; <label>:176                                     ; preds = %172
   %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
-  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %177, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %178
 
 ; <label>:178                                     ; preds = %176
   %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
@@ -6629,55 +8075,55 @@ ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %161
+ThrowNullRef2:                                    ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %170
+ThrowNullRef4:                                    ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %176
+ThrowNullRef6:                                    ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %142
+ThrowNullRef8:                                    ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %144
+ThrowNullRef10:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %113
+ThrowNullRef12:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %116
+ThrowNullRef14:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %84
+ThrowNullRef16:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %87
+ThrowNullRef18:                                   ; preds = %87
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %55
+ThrowNullRef20:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %58
+ThrowNullRef22:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %26
+ThrowNullRef24:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %29
+ThrowNullRef26:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,8 +8161,8 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck, label %14, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %ThrowNullRef, label %14
 
 ; <label>:14                                      ; preds = %8
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
@@ -6760,8 +8206,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
@@ -6770,14 +8216,14 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32, i32* %loc0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %10
   %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
   %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
@@ -6790,15 +8236,15 @@ entry:
 ; <label>:25                                      ; preds = %19
   %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
-  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
   %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
@@ -6807,8 +8253,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %37 = load i32, i32* %loc0
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %38, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %38
 
 ; <label>:38                                      ; preds = %32
   %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
@@ -6817,14 +8263,14 @@ entry:
 
 ; <label>:40                                      ; preds = %19
   %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %40
   %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
   %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
-  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
-  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
@@ -6832,8 +8278,8 @@ entry:
   %48 = zext i32 %47 to i64
   %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
-  br i1 %NullCheck16, label %51, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %51
 
 ; <label>:51                                      ; preds = %45
   %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
@@ -6847,15 +8293,15 @@ entry:
 ; <label>:57                                      ; preds = %51
   %58 = load i16*, i16** %arg1
   %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
-  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %60
 
 ; <label>:60                                      ; preds = %57
   %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
   %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
-  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %64
 
 ; <label>:64                                      ; preds = %60
   %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
@@ -6864,22 +8310,22 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
   %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
-  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %70
 
 ; <label>:70                                      ; preds = %64
   %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
   %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
-  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
-  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
   %75 = load i32, i32 addrspace(1)* %74
   %76 = zext i32 %75 to i64
   %77 = trunc i64 %76 to i32
-  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
-  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %78
 
 ; <label>:78                                      ; preds = %73
   %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
@@ -6901,8 +8347,8 @@ entry:
   %90 = bitcast i16* %86 to i8*
   %91 = getelementptr inbounds i8, i8* %90, i64 %89
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %93
 
 ; <label>:93                                      ; preds = %80
   %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
@@ -6912,8 +8358,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %99 = load i32, i32* %loc2
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %100
 
 ; <label>:100                                     ; preds = %93
   %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
@@ -6928,63 +8374,63 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %25
+ThrowNullRef6:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %32
+ThrowNullRef10:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %40
+ThrowNullRef12:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %45
+ThrowNullRef16:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %57
+ThrowNullRef18:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %60
+ThrowNullRef20:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %64
+ThrowNullRef22:                                   ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %70
+ThrowNullRef24:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %73
+ThrowNullRef26:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %80
+ThrowNullRef28:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %93
+ThrowNullRef30:                                   ; preds = %93
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7004,8 +8450,8 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
@@ -7033,43 +8479,43 @@ entry:
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %14
   %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
   %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   %28 = load i32, i32 addrspace(1)* %27, align 8
   %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
-  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %30
 
 ; <label>:30                                      ; preds = %26
   %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
   %32 = load i32, i32 addrspace(1)* %31, align 8
   %33 = add i32 %28, %32
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %34
 
 ; <label>:34                                      ; preds = %30
   %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   store i32 %33, i32 addrspace(1)* %35
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
   store i32 0, i32 addrspace(1)* %38
   %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %40
 
 ; <label>:40                                      ; preds = %37
   %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
@@ -7082,8 +8528,8 @@ entry:
 
 ; <label>:47                                      ; preds = %40
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
@@ -7098,8 +8544,8 @@ entry:
   %54 = load i32, i32* %loc0
   %55 = sext i32 %54 to i64
   %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
-  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %57
 
 ; <label>:57                                      ; preds = %52
   %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
@@ -7110,68 +8556,35 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %14
+ThrowNullRef2:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %23
+ThrowNullRef4:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %26
+ThrowNullRef6:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %30
+ThrowNullRef8:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %34
+ThrowNullRef10:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %47
+ThrowNullRef14:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %52
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-}
-
-INFO:  jitting method StringBuilder::get_Length using LLILCJit
-Successfully read StringBuilder.get_Length
-
-define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.StringBuilder addrspace(1)*
-  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
-  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
-
-; <label>:1                                       ; preds = %entry
-  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %3 = load i32, i32 addrspace(1)* %2, align 8
-  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
-
-; <label>:5                                       ; preds = %1
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = add i32 %3, %7
-  ret i32 %8
-
-ThrowNullRef:                                     ; preds = %entry
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef16:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7213,70 +8626,70 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
   %6 = load i32, i32 addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
   store i32 %6, i32 addrspace(1)* %8
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
   %13 = load i32, i32 addrspace(1)* %12, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
   store i32 %13, i32 addrspace(1)* %15
   %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
-  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %18
 
 ; <label>:18                                      ; preds = %14
   %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
   %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
   %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
   %34 = load i32, i32 addrspace(1)* %33, align 8
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
-  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
@@ -7287,39 +8700,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %28
+ThrowNullRef16:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %32
+ThrowNullRef18:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7455,13 +8868,13 @@ entry:
 ; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
@@ -7477,16 +8890,16 @@ entry:
 
 ; <label>:18                                      ; preds = %15
   %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
   store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
   %22 = load i32, i32* %loc0
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %24
 
 ; <label>:24                                      ; preds = %20
   %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
@@ -7498,13 +8911,13 @@ entry:
 ; <label>:28                                      ; preds = %15, %24
   %29 = load i32, i32* %arg1
   %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %31
   %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
@@ -7517,20 +8930,20 @@ entry:
   %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
-  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
   %46 = load i32, i32 addrspace(1)* %45, align 8
   %47 = sub i32 %40, %46
-  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
-  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i32 addrspace(1)* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %48
 
 ; <label>:48                                      ; preds = %44
   store i32 %47, i32 addrspace(1)* %39, align 8
@@ -7538,21 +8951,21 @@ entry:
 
 ; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
-  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %51
 
 ; <label>:51                                      ; preds = %49
   %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %53
 
 ; <label>:53                                      ; preds = %51
   %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
   %55 = load i32, i32 addrspace(1)* %54, align 8
   %56 = load i32, i32* %arg2
   %57 = sub i32 %55, %56
-  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %58
 
 ; <label>:58                                      ; preds = %53
   %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
@@ -7562,13 +8975,13 @@ entry:
 ; <label>:60                                      ; preds = %33, %58
   %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
   %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
-  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %63
 
 ; <label>:63                                      ; preds = %60
   %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
-  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
-  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
@@ -7578,15 +8991,15 @@ entry:
 
 ; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
-  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i32 addrspace(1)* %69, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %70
 
 ; <label>:70                                      ; preds = %68
   %71 = load i32, i32 addrspace(1)* %69, align 8
   store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
-  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
@@ -7596,8 +9009,8 @@ entry:
   store i32 %77, i32* %loc4
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
-  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %80
 
 ; <label>:80                                      ; preds = %73
   %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
@@ -7607,71 +9020,71 @@ entry:
 ; <label>:83                                      ; preds = %80
   store i32 0, i32* %loc3
   %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
-  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
-  br i1 %NullCheck26, label %88, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i32 addrspace(1)* %87, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %88
 
 ; <label>:88                                      ; preds = %85
   %89 = load i32, i32 addrspace(1)* %87, align 8
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
-  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %90
 
 ; <label>:90                                      ; preds = %88
   %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
   store i32 %89, i32 addrspace(1)* %91
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
-  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
-  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %96
 
 ; <label>:96                                      ; preds = %94
   %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
-  br i1 %NullCheck34, label %100, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %100
 
 ; <label>:100                                     ; preds = %96
   %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
-  br i1 %NullCheck36, label %102, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %102
 
 ; <label>:102                                     ; preds = %100
   %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
   %104 = load i32, i32 addrspace(1)* %103, align 8
   %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
-  br i1 %NullCheck38, label %106, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %106
 
 ; <label>:106                                     ; preds = %102
   %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
-  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
-  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %108
 
 ; <label>:108                                     ; preds = %106
   %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
   %110 = load i32, i32 addrspace(1)* %109, align 8
   %111 = add i32 %104, %110
-  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %112
 
 ; <label>:112                                     ; preds = %108
   %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
   store i32 %111, i32 addrspace(1)* %113
   %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
-  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i32 addrspace(1)* %114, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %115
 
 ; <label>:115                                     ; preds = %112
   %116 = load i32, i32 addrspace(1)* %114, align 8
@@ -7681,19 +9094,19 @@ entry:
 ; <label>:118                                     ; preds = %115
   %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
-  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %121
 
 ; <label>:121                                     ; preds = %118
   %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
-  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
-  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %123
 
 ; <label>:123                                     ; preds = %121
   %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
   %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
-  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
-  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %126
 
 ; <label>:126                                     ; preds = %123
   %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
@@ -7705,8 +9118,8 @@ entry:
 
 ; <label>:130                                     ; preds = %80, %115, %126
   %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %132
 
 ; <label>:132                                     ; preds = %130
   %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7715,8 +9128,8 @@ entry:
   %136 = load i32, i32* %loc3
   %137 = sub i32 %135, %136
   %138 = sub i32 %134, %137
-  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %139
 
 ; <label>:139                                     ; preds = %132
   %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7728,16 +9141,16 @@ entry:
 
 ; <label>:144                                     ; preds = %139
   %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
-  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %146
 
 ; <label>:146                                     ; preds = %144
   %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
   %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
   %149 = load i32, i32* %loc2
   %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
-  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %151
 
 ; <label>:151                                     ; preds = %146
   %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
@@ -7754,145 +9167,249 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %18
+ThrowNullRef4:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %31
+ThrowNullRef10:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %44
+ThrowNullRef16:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %68
+ThrowNullRef18:                                   ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %70
+ThrowNullRef20:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %73
+ThrowNullRef22:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %83
+ThrowNullRef24:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %85
+ThrowNullRef26:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %88
+ThrowNullRef28:                                   ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %90
+ThrowNullRef30:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %94
+ThrowNullRef32:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %96
+ThrowNullRef34:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %100
+ThrowNullRef36:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %102
+ThrowNullRef38:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %106
+ThrowNullRef40:                                   ; preds = %106
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %108
+ThrowNullRef42:                                   ; preds = %108
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %112
+ThrowNullRef44:                                   ; preds = %112
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %118
+ThrowNullRef46:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %121
+ThrowNullRef48:                                   ; preds = %121
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %123
+ThrowNullRef50:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %130
+ThrowNullRef52:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %132
+ThrowNullRef54:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %144
+ThrowNullRef56:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %146
+ThrowNullRef58:                                   ; preds = %146
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %60
+ThrowNullRef60:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %63
+ThrowNullRef62:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %49
+ThrowNullRef64:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %51
+ThrowNullRef66:                                   ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %53
+ThrowNullRef68:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(%"System.Char[]" addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %arg0 = alloca %"System.Char[]" addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store %"System.Char[]" addrspace(1)* %param0, %"System.Char[]" addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load i32, i32* %arg4
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %43, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %38, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg1
+  %13 = load i32, i32* %arg4
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %38, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %24 = load i32, i32* %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %35 = load i32, i32* %arg3
+  %36 = load i32, i32* %arg4
+  %37 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %37, %"System.Char[]" addrspace(1)* %34, i32 %35, i32 %36)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:38                                      ; preds = %5, %16
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Successfully read Buffer._Memmove
 
@@ -7914,7 +9431,7 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[loadElem]
+Failed to read AppDomain.SetDataHelper[storeElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -7923,8 +9440,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
@@ -7934,8 +9451,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
@@ -7947,15 +9464,15 @@ entry:
   %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
   %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
@@ -7966,15 +9483,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7992,7 +9509,79 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
-Failed to read Dictionary`2.TryGetValue[loadElemA]
+Successfully read Dictionary`2.TryGetValue
+
+define i8 @"Dictionary`2.TryGetValue"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)* addrspace(1)* %param2) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  %arg2 = alloca %System.__Canon addrspace(1)* addrspace(1)*
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  store %System.__Canon addrspace(1)* addrspace(1)* %param2, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  store i32 %2, i32* %loc0
+  %3 = load i32, i32* %loc0
+  %4 = icmp slt i32 %3, 0
+  br i1 %4, label %22, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 2
+  %10 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %9, align 8
+  %11 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = zext i32 %11 to i64
+  %BoundsCheck = icmp uge i64 %16, %15
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 3, i32 %11
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %20, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %6, %System.__Canon addrspace(1)* %21)
+  ret i8 1
+
+; <label>:22                                      ; preds = %entry
+  %23 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %23, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -8058,8 +9647,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
@@ -8091,8 +9680,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
@@ -8171,15 +9760,15 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck, label %19, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %ThrowNullRef, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
   %21 = load i32, i32 addrspace(1)* %20
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
@@ -8202,7 +9791,7 @@ ThrowNullRef:                                     ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %19
+ThrowNullRef2:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8248,8 +9837,8 @@ entry:
   %0 = alloca %System.AppDomainHandle
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %1 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %1, i32 0, i32 15
@@ -8269,8 +9858,8 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
@@ -8286,7 +9875,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -8299,8 +9888,8 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -8327,8 +9916,8 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
@@ -8352,8 +9941,8 @@ entry:
   %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
   store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
@@ -8363,8 +9952,8 @@ entry:
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
@@ -8374,8 +9963,8 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %9
   %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
@@ -8384,8 +9973,8 @@ entry:
 
 ; <label>:18                                      ; preds = %3, %16
   %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
@@ -8397,15 +9986,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %18
+ThrowNullRef6:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8418,8 +10007,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
@@ -8453,15 +10042,15 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
@@ -8473,7 +10062,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8481,7 +10070,7 @@ ThrowNullRef1:                                    ; preds = %1
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
 Failed to read Dictionary`2.System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
@@ -8506,8 +10095,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
@@ -8524,8 +10113,8 @@ entry:
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -8544,7 +10133,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8577,8 +10166,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = load i64, i64* %arg2
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = trunc i32 %3 to i8
@@ -8634,46 +10223,46 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
   %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
-  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
-  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
-  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
@@ -8684,27 +10273,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %20
+ThrowNullRef12:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8717,8 +10306,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -8756,22 +10345,22 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
   %9 = load i64, i64 addrspace(1)* %8, align 8
   %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
   %13 = load i64, i64 addrspace(1)* %12, align 8
   %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %11
   %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
@@ -8788,11 +10377,11 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8882,8 +10471,8 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
@@ -8900,8 +10489,8 @@ entry:
 ; <label>:8                                       ; preds = %1
   %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
   %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
@@ -8911,15 +10500,15 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
   %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
   %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
-  br i1 %NullCheck6, label %21, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
@@ -8946,15 +10535,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8992,15 +10581,15 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
   store i8 %3, i8 addrspace(1)* %5
   %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
@@ -9011,7 +10600,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9027,8 +10616,8 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -9041,8 +10630,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
@@ -9058,7 +10647,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9080,8 +10669,8 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
@@ -9096,8 +10685,8 @@ entry:
 ; <label>:12                                      ; preds = %6
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
@@ -9112,8 +10701,8 @@ entry:
 ; <label>:21                                      ; preds = %15
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
@@ -9128,8 +10717,8 @@ entry:
 ; <label>:30                                      ; preds = %24
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %31, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
@@ -9144,8 +10733,8 @@ entry:
 ; <label>:39                                      ; preds = %33
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
-  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %40, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %42
 
 ; <label>:42                                      ; preds = %39
   %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
@@ -9164,19 +10753,19 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %21
+ThrowNullRef4:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %30
+ThrowNullRef6:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %39
+ThrowNullRef8:                                    ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9243,8 +10832,8 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
@@ -9264,57 +10853,57 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
   store i8 0, i8 addrspace(1)* %2
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
   store i8 0, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
   store i8 0, i8 addrspace(1)* %17
   %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
   store i8 0, i8 addrspace(1)* %20
   %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
-  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
@@ -9325,31 +10914,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %19
+ThrowNullRef14:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9367,8 +10956,8 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
@@ -9380,8 +10969,8 @@ entry:
 
 ; <label>:9                                       ; preds = %4
   %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %9
   %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
@@ -9395,7 +10984,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef2:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9420,8 +11009,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
@@ -9512,8 +11101,8 @@ entry:
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
@@ -9524,8 +11113,8 @@ entry:
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = load i64, i64 addrspace(1)* %12
@@ -9537,8 +11126,8 @@ entry:
   %20 = load i64, i64* %19
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
-  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %13
   %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
@@ -9555,8 +11144,8 @@ entry:
 ; <label>:30                                      ; preds = %25
   %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %32 = load i32, i32* %arg2
-  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
-  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
@@ -9570,15 +11159,15 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %30
+ThrowNullRef2:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9622,87 +11211,87 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
   %10 = load i8, i8 addrspace(1)* %9, align 8
   %11 = zext i8 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %8
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
   store i8 %12, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
   %19 = load i8, i8 addrspace(1)* %18, align 8
   %20 = zext i8 %19 to i32
   %21 = trunc i32 %20 to i8
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
   store i8 %21, i8 addrspace(1)* %23
   %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
   %28 = load i8, i8 addrspace(1)* %27, align 8
   %29 = zext i8 %28 to i32
   %30 = trunc i32 %29 to i8
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
-  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %31
 
 ; <label>:31                                      ; preds = %26
   %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
   store i8 %30, i8 addrspace(1)* %32
   %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
-  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
-  br i1 %NullCheck14, label %40, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %40
 
 ; <label>:40                                      ; preds = %35
   %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
   store i8 %39, i8 addrspace(1)* %41
   %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
-  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %44
 
 ; <label>:44                                      ; preds = %40
   %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
   %46 = load i8, i8 addrspace(1)* %45, align 8
   %47 = zext i8 %46 to i32
   %48 = trunc i32 %47 to i8
-  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
   store i8 %48, i8 addrspace(1)* %50
   %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
-  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
@@ -9713,29 +11302,29 @@ entry:
 ; <label>:56                                      ; preds = %52
   %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
-  br i1 %NullCheck22, label %59, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
   %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
   %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
-  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
-  br i1 %NullCheck24, label %63, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
   %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
-  br i1 %NullCheck26, label %66, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
   %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
-  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
-  br i1 %NullCheck28, label %69, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %69
 
 ; <label>:69                                      ; preds = %66
   %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
@@ -9744,15 +11333,15 @@ entry:
 
 ; <label>:71                                      ; preds = %105
   %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
-  br i1 %NullCheck34, label %73, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %73
 
 ; <label>:73                                      ; preds = %71
   %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
   %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
   %76 = load i32, i32* %loc0
-  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
-  br i1 %NullCheck36, label %77, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
@@ -9766,8 +11355,8 @@ entry:
 
 ; <label>:83                                      ; preds = %77
   %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
-  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
@@ -9775,14 +11364,14 @@ entry:
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
   %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
-  br i1 %NullCheck40, label %91, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
 ; <label>:91                                      ; preds = %85
   %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
   %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
-  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck42, label %94, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %94
 
 ; <label>:94                                      ; preds = %91
   %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
@@ -9798,14 +11387,14 @@ entry:
 ; <label>:99                                      ; preds = %69, %96
   %100 = load i32, i32* %loc0
   %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
-  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %102
 
 ; <label>:102                                     ; preds = %99
   %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
   %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
-  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
-  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
@@ -9819,87 +11408,87 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %26
+ThrowNullRef10:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %31
+ThrowNullRef12:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %35
+ThrowNullRef14:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %40
+ThrowNullRef16:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %56
+ThrowNullRef22:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %59
+ThrowNullRef24:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %63
+ThrowNullRef26:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %66
+ThrowNullRef28:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %102
+ThrowNullRef32:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %71
+ThrowNullRef34:                                   ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %73
+ThrowNullRef36:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %83
+ThrowNullRef38:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %85
+ThrowNullRef40:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %91
+ThrowNullRef42:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9943,15 +11532,15 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
   %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
@@ -9961,28 +11550,28 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
   %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %12
   %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
   %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
   %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
-  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
@@ -9993,23 +11582,23 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %12
+ThrowNullRef6:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10031,15 +11620,15 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
   %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = load i64, i64 addrspace(1)* %7
@@ -10077,13 +11666,13 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[loadElem]
+Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -10111,8 +11700,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -10165,8 +11754,8 @@ entry:
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load float, float* %arg0
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -10300,8 +11889,8 @@ entry:
   store i64 %param0, i64* %arg0
   store i64 %param1, i64* %arg1
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
@@ -10309,8 +11898,8 @@ entry:
   %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
   %5 = load i16*, i16* addrspace(1)* %4, align 8
   %6 = addrspacecast i64* %arg1 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = bitcast i64 addrspace(1)* %6 to i8 addrspace(1)*
@@ -10326,7 +11915,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10360,8 +11949,8 @@ entry:
   %1 = load i32, i32* %arg1
   %2 = sext i32 %1 to i64
   %3 = inttoptr i64 %2 to i16*
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -10414,8 +12003,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, i32)*)(%System.IO.ConsoleStream addrspace(1)* %2, i32 %1)
   %3 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %4 = load i64, i64* %arg1
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
@@ -10426,8 +12015,8 @@ entry:
   %10 = icmp eq i32 %9, 3
   %11 = sext i1 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %5
   %14 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, i32 0, i32 5
@@ -10438,7 +12027,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10461,8 +12050,8 @@ entry:
   %5 = icmp eq i32 %4, 1
   %6 = sext i1 %5 to i32
   %7 = trunc i32 %6 to i8
-  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %2, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.ConsoleStream addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
@@ -10473,8 +12062,8 @@ entry:
   %13 = icmp eq i32 %12, 2
   %14 = sext i1 %13 to i32
   %15 = trunc i32 %14 to i8
-  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %10, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.ConsoleStream addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %8
   %17 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %10, i32 0, i32 4
@@ -10485,7 +12074,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10524,8 +12113,8 @@ entry:
   %arg0 = alloca i64
   store i64 %param0, i64* %arg0
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
@@ -10560,8 +12149,8 @@ entry:
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
   %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = load i64, i64 addrspace(1)* %7
@@ -10665,7 +12254,127 @@ entry:
 INFO:  jitting method Encoding::GetEncoding using LLILCJit
 Failed to read Encoding.GetEncoding[convertToHelperArgumentType]
 INFO:  jitting method EncodingProvider::GetEncodingFromProvider using LLILCJit
-Failed to read EncodingProvider.GetEncodingFromProvider[loadElem]
+Successfully read EncodingProvider.GetEncodingFromProvider
+
+define %System.Text.Encoding addrspace(1)* @EncodingProvider.GetEncodingFromProvider(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca %"System.Text.EncodingProvider[]" addrspace(1)*
+  %loc1 = alloca %System.Text.EncodingProvider addrspace(1)*
+  %loc2 = alloca %System.Text.Encoding addrspace(1)*
+  %loc3 = alloca %System.Text.Encoding addrspace(1)*
+  %loc4 = alloca %"System.Text.EncodingProvider[]" addrspace(1)*
+  %loc5 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1059)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2392
+  %2 = addrspacecast i8 addrspace(1)* %1 to %"System.Text.EncodingProvider[]" addrspace(1)**
+  %3 = load volatile %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %2
+  %4 = icmp ne %"System.Text.EncodingProvider[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %entry
+  ret %System.Text.Encoding addrspace(1)* null
+
+; <label>:6                                       ; preds = %entry
+  %7 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1059)
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i64 2392
+  %9 = addrspacecast i8 addrspace(1)* %8 to %"System.Text.EncodingProvider[]" addrspace(1)**
+  %10 = load volatile %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %9
+  store %"System.Text.EncodingProvider[]" addrspace(1)* %10, %"System.Text.EncodingProvider[]" addrspace(1)** %loc0
+  %11 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc0
+  store %"System.Text.EncodingProvider[]" addrspace(1)* %11, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  store i32 0, i32* %loc5
+  br label %43
+
+; <label>:12                                      ; preds = %46
+  %13 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  %14 = load i32, i32* %loc5
+  %NullCheck1 = icmp eq %"System.Text.EncodingProvider[]" addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %13, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = zext i32 %17 to i64
+  %19 = zext i32 %14 to i64
+  %BoundsCheck = icmp uge i64 %19, %18
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %20
+
+; <label>:20                                      ; preds = %15
+  %21 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %13, i32 0, i32 3, i32 %14
+  %22 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)* addrspace(1)* %21, align 8
+  store %System.Text.EncodingProvider addrspace(1)* %22, %System.Text.EncodingProvider addrspace(1)** %loc1
+  %23 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)** %loc1
+  %24 = load i32, i32* %arg0
+  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i64 addrspace(1)*
+  %NullCheck3 = icmp eq i64 addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
+
+; <label>:26                                      ; preds = %20
+  %27 = load i64, i64 addrspace(1)* %25
+  %28 = add i64 %27, 64
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 40
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Text.Encoding addrspace(1)* (%System.Text.EncodingProvider addrspace(1)*, i32)*
+  %35 = call %System.Text.Encoding addrspace(1)* %34(%System.Text.EncodingProvider addrspace(1)* %23, i32 %24)
+  store %System.Text.Encoding addrspace(1)* %35, %System.Text.Encoding addrspace(1)** %loc2
+  %36 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc2
+  %37 = icmp eq %System.Text.Encoding addrspace(1)* %36, null
+  br i1 %37, label %40, label %38
+
+; <label>:38                                      ; preds = %26
+  %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc2
+  store %System.Text.Encoding addrspace(1)* %39, %System.Text.Encoding addrspace(1)** %loc3
+  br label %53
+
+; <label>:40                                      ; preds = %26
+  %41 = load i32, i32* %loc5
+  %42 = add i32 %41, 1
+  store i32 %42, i32* %loc5
+  br label %43
+
+; <label>:43                                      ; preds = %6, %40
+  %44 = load i32, i32* %loc5
+  %45 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  %NullCheck = icmp eq %"System.Text.EncodingProvider[]" addrspace(1)* %45, null
+  br i1 %NullCheck, label %ThrowNullRef, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp slt i32 %44, %50
+  br i1 %51, label %12, label %52
+
+; <label>:52                                      ; preds = %46
+  ret %System.Text.Encoding addrspace(1)* null
+
+; <label>:53                                      ; preds = %38
+  %54 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc3
+  ret %System.Text.Encoding addrspace(1)* %54
+
+ThrowNullRef:                                     ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method EncodingProvider::.cctor using LLILCJit
 Successfully read EncodingProvider..cctor
 
@@ -10684,7 +12393,7 @@ Failed to read Encoding.get_InternalSyncObject[Call HasTypeArg]
 INFO:  jitting method Hashtable::.ctor using LLILCJit
 Failed to read Hashtable..ctor[Volatile store]
 INFO:  jitting method Hashtable::get_Item using LLILCJit
-Failed to read Hashtable.get_Item[loadElemA]
+Failed to read Hashtable.get_Item[loadNonPrimitiveObj]
 INFO:  jitting method Hashtable::InitHash using LLILCJit
 Successfully read Hashtable.InitHash
 
@@ -10704,8 +12413,8 @@ entry:
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -10721,15 +12430,15 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
   %15 = load i32, i32* %loc0
-  %NullCheck2 = icmp ne i32 addrspace(1)* %14, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i32 addrspace(1)* %14, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %3
   store i32 %15, i32 addrspace(1)* %14, align 8
   %17 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %18 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %NullCheck4 = icmp ne i32 addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i32 addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = load i32, i32 addrspace(1)* %18, align 8
@@ -10738,8 +12447,8 @@ entry:
   %23 = sub i32 %22, 1
   %24 = urem i32 %21, %23
   %25 = add i32 1, %24
-  %NullCheck6 = icmp ne i32 addrspace(1)* %17, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32 addrspace(1)* %17, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %19
   store i32 %25, i32 addrspace(1)* %17, align 8
@@ -10750,15 +12459,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %19
+ThrowNullRef6:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10773,8 +12482,8 @@ entry:
   store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
   store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %NullCheck = icmp ne %System.Collections.Hashtable addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Collections.Hashtable addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
@@ -10784,16 +12493,16 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Collections.Hashtable addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Collections.Hashtable addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
   %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck4 = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %9, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
   %13 = inttoptr i64 %11 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
@@ -10803,8 +12512,8 @@ entry:
 ; <label>:15                                      ; preds = %1
   %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -10822,15 +12531,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10844,8 +12553,8 @@ entry:
   store %System.Int32 addrspace(1)* %param0, %System.Int32 addrspace(1)** %this
   %0 = load %System.Int32 addrspace(1)*, %System.Int32 addrspace(1)** %this
   %1 = bitcast %System.Int32 addrspace(1)* %0 to i32 addrspace(1)*
-  %NullCheck = icmp ne i32 addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq i32 addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load i32, i32 addrspace(1)* %1, align 8
@@ -10921,8 +12630,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.UTF8Encoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
@@ -10931,15 +12640,15 @@ entry:
   %9 = load i8, i8* %arg2
   %10 = zext i8 %9 to i32
   %11 = trunc i32 %10 to i8
-  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %8, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %6
   %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %8, i32 0, i32 8
   store i8 %11, i8 addrspace(1)* %13
   %14 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %14, i32 0, i32 8
@@ -10951,8 +12660,8 @@ entry:
 ; <label>:20                                      ; preds = %15
   %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %22, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %22, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = load i64, i64 addrspace(1)* %22
@@ -10974,15 +12683,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %12
+ThrowNullRef4:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10997,8 +12706,8 @@ entry:
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
@@ -11020,16 +12729,16 @@ entry:
 ; <label>:10                                      ; preds = %1
   %11 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
   %12 = load i32, i32* %arg1
-  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %11, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.Encoding addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
   store i32 %12, i32 addrspace(1)* %14
   %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
   %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = load i64, i64 addrspace(1)* %16
@@ -11047,11 +12756,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11064,8 +12773,8 @@ entry:
   %this = alloca %System.Text.UTF8Encoding addrspace(1)*
   store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
   %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.UTF8Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
@@ -11077,16 +12786,16 @@ entry:
 ; <label>:6                                       ; preds = %1
   %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %8 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %10, %System.Text.EncoderFallback addrspace(1)* %8)
   %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %12 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
-  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %11, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %11, i32 0, i32 3
@@ -11099,8 +12808,8 @@ entry:
   %18 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %18, %System.String addrspace(1)* %17)
   %19 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %18 to %System.Text.EncoderFallback addrspace(1)*
-  %NullCheck6 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %16, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %16, i32 0, i32 2
@@ -11110,8 +12819,8 @@ entry:
   %24 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %24, %System.String addrspace(1)* %23)
   %25 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %24 to %System.Text.DecoderFallback addrspace(1)*
-  %NullCheck8 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %22, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %22, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %20
   %27 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %22, i32 0, i32 3
@@ -11122,19 +12831,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %20
+ThrowNullRef8:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11164,8 +12873,8 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load i32, i32* %arg1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -11183,8 +12892,8 @@ entry:
 ; <label>:15                                      ; preds = %8
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %17 = load i32, i32* %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 %17
@@ -11200,7 +12909,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11252,7 +12961,7 @@ entry:
 }
 
 INFO:  jitting method Hashtable::Insert using LLILCJit
-Failed to read Hashtable.Insert[loadElemA]
+Failed to read Hashtable.Insert[storeElem]
 INFO:  jitting method ConsoleEncoding::.ctor using LLILCJit
 Successfully read ConsoleEncoding..ctor
 
@@ -11267,8 +12976,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %1)
   %2 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
@@ -11304,8 +13013,8 @@ entry:
   %2 = call %System.Text.InternalEncoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalEncoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %1)
   %3 = bitcast %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2 to %System.Text.EncoderFallback addrspace(1)*
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
@@ -11315,8 +13024,8 @@ entry:
   %8 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %7)
   %9 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %8 to %System.Text.DecoderFallback addrspace(1)*
-  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %6, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.Encoding addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %4
   %11 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %6, i32 0, i32 3
@@ -11327,7 +13036,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11346,15 +13055,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* %1)
   %2 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   %6 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, i32 0, i32 1
@@ -11365,7 +13074,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11393,8 +13102,8 @@ entry:
   store %System.Text.InternalDecoderBestFitFallback addrspace(1)* %param0, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
   %0 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
@@ -11404,15 +13113,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %4)
   %5 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %6)
   %9 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, i32 0, i32 1
@@ -11423,11 +13132,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11495,8 +13204,8 @@ entry:
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
   %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = load i64, i64 addrspace(1)* %19
@@ -11560,8 +13269,8 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.ConsoleStream addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
@@ -11592,31 +13301,31 @@ entry:
   store i8 %param4, i8* %arg4
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %3, %System.IO.Stream addrspace(1)* %1)
   %4 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %4, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
   %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %4, i32 0, i32 4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %5)
   %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %6
   %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
   %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
   %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = load i64, i64 addrspace(1)* %13
@@ -11628,8 +13337,8 @@ entry:
   %21 = load i64, i64* %20
   %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %8, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %8, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %14
   %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 5
@@ -11647,24 +13356,24 @@ entry:
   %31 = load i32, i32* %arg3
   %32 = sext i32 %31 to i64
   %33 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %32)
-  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %30, null
-  br i1 %NullCheck10, label %34, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.StreamWriter addrspace(1)* %30, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %35, %"System.Char[]" addrspace(1)* %33)
   %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %37, null
-  br i1 %NullCheck12, label %38, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.StreamWriter addrspace(1)* %37, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %38
 
 ; <label>:38                                      ; preds = %34
   %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
   %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
   %41 = load i32, i32* %arg3
   %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %42, null
-  br i1 %NullCheck14, label %43, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %42, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
   %44 = load i64, i64 addrspace(1)* %42
@@ -11678,30 +13387,30 @@ entry:
   %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
   %53 = sext i32 %52 to i64
   %54 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %53)
-  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
-  br i1 %NullCheck16, label %55, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %55
 
 ; <label>:55                                      ; preds = %43
   %56 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %56, %"System.Byte[]" addrspace(1)* %54)
   %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %58 = load i32, i32* %arg3
-  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %57, null
-  br i1 %NullCheck18, label %59, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.StreamWriter addrspace(1)* %57, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %59
 
 ; <label>:59                                      ; preds = %55
   %60 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 10
   store i32 %58, i32 addrspace(1)* %60
   %61 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %61, null
-  br i1 %NullCheck20, label %62, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.IO.StreamWriter addrspace(1)* %61, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %62
 
 ; <label>:62                                      ; preds = %59
   %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
   %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
   %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
   %67 = load i64, i64 addrspace(1)* %65
@@ -11719,15 +13428,15 @@ entry:
 
 ; <label>:78                                      ; preds = %66
   %79 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %79, null
-  br i1 %NullCheck24, label %80, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.StreamWriter addrspace(1)* %79, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %80
 
 ; <label>:80                                      ; preds = %78
   %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
   %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
   %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %83, null
-  br i1 %NullCheck26, label %84, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %83, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
   %85 = load i64, i64 addrspace(1)* %83
@@ -11744,8 +13453,8 @@ entry:
 
 ; <label>:95                                      ; preds = %84
   %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.IO.StreamWriter addrspace(1)* %96, null
-  br i1 %NullCheck28, label %97, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.IO.StreamWriter addrspace(1)* %96, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %97
 
 ; <label>:97                                      ; preds = %95
   %98 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 12
@@ -11759,8 +13468,8 @@ entry:
   %103 = icmp eq i32 %102, 0
   %104 = sext i1 %103 to i32
   %105 = trunc i32 %104 to i8
-  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %100, null
-  br i1 %NullCheck30, label %106, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.IO.StreamWriter addrspace(1)* %100, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %106
 
 ; <label>:106                                     ; preds = %99
   %107 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %100, i32 0, i32 13
@@ -11771,63 +13480,63 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %6
+ThrowNullRef4:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %29
+ThrowNullRef10:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %34
+ThrowNullRef12:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %38
+ThrowNullRef14:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %43
+ThrowNullRef16:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %55
+ThrowNullRef18:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %59
+ThrowNullRef20:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %62
+ThrowNullRef22:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %78
+ThrowNullRef24:                                   ; preds = %78
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %80
+ThrowNullRef26:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %95
+ThrowNullRef28:                                   ; preds = %95
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11840,15 +13549,15 @@ entry:
   %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = load i64, i64 addrspace(1)* %4
@@ -11866,7 +13575,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11916,35 +13625,35 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
   %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderNLS addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %7 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.EncoderNLS addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Text.Encoding addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.Encoding addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Text.EncoderNLS addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.EncoderNLS addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
   %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck8 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = load i64, i64 addrspace(1)* %16
@@ -11963,19 +13672,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12001,8 +13710,8 @@ entry:
   %this = alloca %System.Text.Encoding addrspace(1)*
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
@@ -12022,15 +13731,15 @@ entry:
   %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
   store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
   %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
   store i32 0, i32 addrspace(1)* %2
   %3 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, i32 0, i32 2
@@ -12040,15 +13749,15 @@ entry:
 
 ; <label>:8                                       ; preds = %4
   %9 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
   %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
   %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = load i64, i64 addrspace(1)* %13
@@ -12069,15 +13778,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12092,16 +13801,16 @@ entry:
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = load i32, i32* %arg1
   %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
   %7 = load i64, i64 addrspace(1)* %5
@@ -12119,7 +13828,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12156,8 +13865,8 @@ entry:
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
   %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
   %16 = load i64, i64 addrspace(1)* %14
@@ -12178,8 +13887,8 @@ entry:
   %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
   %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
   %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %31, null
-  br i1 %NullCheck2, label %32, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = load i64, i64 addrspace(1)* %31
@@ -12222,7 +13931,7 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12235,14 +13944,14 @@ entry:
   %this = alloca %System.Text.EncoderReplacementFallback addrspace(1)*
   store %System.Text.EncoderReplacementFallback addrspace(1)* %param0, %System.Text.EncoderReplacementFallback addrspace(1)** %this
   %0 = load %System.Text.EncoderReplacementFallback addrspace(1)*, %System.Text.EncoderReplacementFallback addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -12253,7 +13962,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12283,8 +13992,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
@@ -12316,8 +14025,8 @@ entry:
   %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
   store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
@@ -12329,8 +14038,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Threading.Tasks.Task addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %7)
@@ -12353,7 +14062,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12372,8 +14081,8 @@ entry:
   store i8 %param1, i8* %arg1
   store i8 %param2, i8* %arg2
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
@@ -12387,8 +14096,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1, %5
   %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 9
@@ -12419,8 +14128,8 @@ entry:
 
 ; <label>:25                                      ; preds = %8, %20
   %26 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %26, null
-  br i1 %NullCheck4, label %27, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %26, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %26, i32 0, i32 12
@@ -12431,22 +14140,22 @@ entry:
 
 ; <label>:32                                      ; preds = %27
   %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %33, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.IO.StreamWriter addrspace(1)* %33, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %32
   %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 12
   store i8 1, i8 addrspace(1)* %35
   %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
-  br i1 %NullCheck8, label %37, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
   %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
   %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck10 = icmp ne i64 addrspace(1)* %40, null
-  br i1 %NullCheck10, label %41, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64 addrspace(1)* %40, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i64, i64 addrspace(1)* %40
@@ -12460,8 +14169,8 @@ entry:
   %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
   store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
   %51 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %NullCheck12 = icmp ne %"System.Byte[]" addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Byte[]" addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %41
   %53 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %51, i32 0, i32 1
@@ -12473,16 +14182,16 @@ entry:
 
 ; <label>:58                                      ; preds = %52
   %59 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %59, null
-  br i1 %NullCheck14, label %60, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.IO.StreamWriter addrspace(1)* %59, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %60
 
 ; <label>:60                                      ; preds = %58
   %61 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %59, i32 0, i32 3
   %62 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
   %64 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %NullCheck16 = icmp ne %"System.Byte[]" addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %"System.Byte[]" addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %60
   %66 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %64, i32 0, i32 1
@@ -12490,8 +14199,8 @@ entry:
   %68 = zext i32 %67 to i64
   %69 = trunc i64 %68 to i32
   %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck18, label %71, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
   %72 = load i64, i64 addrspace(1)* %70
@@ -12507,29 +14216,29 @@ entry:
 
 ; <label>:80                                      ; preds = %27, %52, %71
   %81 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %81, null
-  br i1 %NullCheck20, label %82, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.IO.StreamWriter addrspace(1)* %81, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
 
 ; <label>:82                                      ; preds = %80
   %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %81, i32 0, i32 5
   %84 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %83, align 8
   %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.IO.StreamWriter addrspace(1)* %85, null
-  br i1 %NullCheck22, label %86, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.IO.StreamWriter addrspace(1)* %85, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %86
 
 ; <label>:86                                      ; preds = %82
   %87 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 7
   %88 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %87, align 8
   %89 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %89, null
-  br i1 %NullCheck24, label %90, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.StreamWriter addrspace(1)* %89, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %90
 
 ; <label>:90                                      ; preds = %86
   %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %89, i32 0, i32 9
   %92 = load i32, i32 addrspace(1)* %91, align 8
   %93 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.IO.StreamWriter addrspace(1)* %93, null
-  br i1 %NullCheck26, label %94, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.IO.StreamWriter addrspace(1)* %93, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %93, i32 0, i32 6
@@ -12537,8 +14246,8 @@ entry:
   %97 = load i8, i8* %arg2
   %98 = zext i8 %97 to i32
   %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
-  %NullCheck28 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck28, label %100, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
   %101 = load i64, i64 addrspace(1)* %99
@@ -12553,8 +14262,8 @@ entry:
   %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
   store i32 %110, i32* %loc1
   %111 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %111, null
-  br i1 %NullCheck30, label %112, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.IO.StreamWriter addrspace(1)* %111, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %112
 
 ; <label>:112                                     ; preds = %100
   %113 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %111, i32 0, i32 9
@@ -12565,23 +14274,23 @@ entry:
 
 ; <label>:116                                     ; preds = %112
   %117 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck32 = icmp ne %System.IO.StreamWriter addrspace(1)* %117, null
-  br i1 %NullCheck32, label %118, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.IO.StreamWriter addrspace(1)* %117, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %118
 
 ; <label>:118                                     ; preds = %116
   %119 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %117, i32 0, i32 3
   %120 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %119, align 8
   %121 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.IO.StreamWriter addrspace(1)* %121, null
-  br i1 %NullCheck34, label %122, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.IO.StreamWriter addrspace(1)* %121, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %122
 
 ; <label>:122                                     ; preds = %118
   %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
   %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
   %125 = load i32, i32* %loc1
   %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
-  %NullCheck36 = icmp ne i64 addrspace(1)* %126, null
-  br i1 %NullCheck36, label %127, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64 addrspace(1)* %126, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
   %128 = load i64, i64 addrspace(1)* %126
@@ -12603,15 +14312,15 @@ entry:
 
 ; <label>:140                                     ; preds = %136
   %141 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.IO.StreamWriter addrspace(1)* %141, null
-  br i1 %NullCheck38, label %142, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.IO.StreamWriter addrspace(1)* %141, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %142
 
 ; <label>:142                                     ; preds = %140
   %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
   %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
   %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
-  %NullCheck40 = icmp ne i64 addrspace(1)* %145, null
-  br i1 %NullCheck40, label %146, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i64 addrspace(1)* %145, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
   %147 = load i64, i64 addrspace(1)* %145
@@ -12632,83 +14341,83 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %25
+ThrowNullRef4:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %32
+ThrowNullRef6:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %37
+ThrowNullRef10:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %41
+ThrowNullRef12:                                   ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %58
+ThrowNullRef14:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %60
+ThrowNullRef16:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %65
+ThrowNullRef18:                                   ; preds = %65
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %80
+ThrowNullRef20:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %82
+ThrowNullRef22:                                   ; preds = %82
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %86
+ThrowNullRef24:                                   ; preds = %86
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %90
+ThrowNullRef26:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %94
+ThrowNullRef28:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %100
+ThrowNullRef30:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %116
+ThrowNullRef32:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %118
+ThrowNullRef34:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %122
+ThrowNullRef36:                                   ; preds = %122
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %140
+ThrowNullRef38:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %142
+ThrowNullRef40:                                   ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12775,8 +14484,8 @@ entry:
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %1 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
-  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
@@ -12784,8 +14493,8 @@ entry:
   %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
   %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
   %8 = load i64, i64 addrspace(1)* %6
@@ -12801,8 +14510,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %17, %System.IFormatProvider addrspace(1)* %16)
   %18 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %19 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %18, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.SyncTextWriter addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %7
   %21 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %18, i32 0, i32 4
@@ -12813,11 +14522,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12830,8 +14539,8 @@ entry:
   %this = alloca %System.IO.TextWriter addrspace(1)*
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.TextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
@@ -12841,8 +14550,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.Threading.Thread addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Threading.Thread addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %6)
@@ -12851,8 +14560,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1
   %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.TextWriter addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.TextWriter addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %11, i32 0, i32 2
@@ -12863,11 +14572,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13064,8 +14773,8 @@ entry:
   store float %param1, float* %arg1
   store i8 0, i8* %loc1
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
@@ -13075,16 +14784,16 @@ entry:
   %5 = addrspacecast i8* %loc1 to i8 addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %4, i8 addrspace(1)* %5)
   %6 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.SyncTextWriter addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
   %10 = load float, float* %arg1
   %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
   %13 = load i64, i64 addrspace(1)* %11
@@ -13119,11 +14828,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13140,8 +14849,8 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load float, float* %arg1
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -13155,8 +14864,8 @@ entry:
   call void %11(%System.IO.TextWriter addrspace(1)* %0, float %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
   %15 = load i64, i64 addrspace(1)* %13
@@ -13174,7 +14883,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13192,8 +14901,8 @@ entry:
   %1 = addrspacecast float* %arg1 to float addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -13208,8 +14917,8 @@ entry:
   %14 = bitcast float addrspace(1)* %1 to %System.Single addrspace(1)*
   %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Single addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Single addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
   %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
   %18 = load i64, i64 addrspace(1)* %16
@@ -13227,7 +14936,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13243,8 +14952,8 @@ entry:
   store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
   %0 = load %System.Single addrspace(1)*, %System.Single addrspace(1)** %this
   %1 = bitcast %System.Single addrspace(1)* %0 to float addrspace(1)*
-  %NullCheck = icmp ne float addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq float addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load float, float addrspace(1)* %1, align 8
@@ -13269,8 +14978,8 @@ entry:
   %loc0 = alloca %System.Globalization.NumberFormatInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 3
@@ -13280,8 +14989,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
@@ -13291,24 +15000,24 @@ entry:
   store %System.Globalization.NumberFormatInfo addrspace(1)* %10, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
   %11 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %7
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
   %15 = load i8, i8 addrspace(1)* %14, align 8
   %16 = zext i8 %15 to i32
   %17 = trunc i32 %16 to i8
-  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %11, null
-  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %11, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %13
   %19 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %11, i32 0, i32 29
   store i8 %17, i8 addrspace(1)* %19
   %20 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %21 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %20, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %20, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %18
   %23 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %20, i32 0, i32 3
@@ -13317,8 +15026,8 @@ entry:
 
 ; <label>:24                                      ; preds = %1, %22
   %25 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %25, null
-  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %25, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %26
 
 ; <label>:26                                      ; preds = %24
   %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %25, i32 0, i32 3
@@ -13329,23 +15038,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %18
+ThrowNullRef8:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13370,168 +15079,168 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 18
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %8, align 8
-  %NullCheck2 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %5, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %5, i32 0, i32 4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %9)
   %12 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 19
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %15, align 8
-  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %12, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %12, i32 0, i32 5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %16)
   %19 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %20 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %20, null
-  br i1 %NullCheck8, label %21, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %20, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %20, i32 0, i32 23
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  %NullCheck10 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %19, null
-  br i1 %NullCheck10, label %24, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %19, i32 0, i32 7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %25, %System.String addrspace(1)* %23)
   %26 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %27 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %27, i32 0, i32 22
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %29, align 8
-  %NullCheck14 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %26, null
-  br i1 %NullCheck14, label %31, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %26, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %26, i32 0, i32 6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %32, %System.String addrspace(1)* %30)
   %33 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %34 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Globalization.CultureData addrspace(1)* %34, null
-  br i1 %NullCheck16, label %35, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Globalization.CultureData addrspace(1)* %34, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %34, i32 0, i32 51
   %37 = load i32, i32 addrspace(1)* %36, align 8
-  %NullCheck18 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %33, null
-  br i1 %NullCheck18, label %38, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %33, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %33, i32 0, i32 21
   store i32 %37, i32 addrspace(1)* %39
   %40 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %41 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Globalization.CultureData addrspace(1)* %41, null
-  br i1 %NullCheck20, label %42, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Globalization.CultureData addrspace(1)* %41, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %41, i32 0, i32 52
   %44 = load i32, i32 addrspace(1)* %43, align 8
-  %NullCheck22 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %40, null
-  br i1 %NullCheck22, label %45, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %40, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %40, i32 0, i32 25
   store i32 %44, i32 addrspace(1)* %46
   %47 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %48 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.Globalization.CultureData addrspace(1)* %48, null
-  br i1 %NullCheck24, label %49, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Globalization.CultureData addrspace(1)* %48, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %49
 
 ; <label>:49                                      ; preds = %45
   %50 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %48, i32 0, i32 29
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck26 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %47, null
-  br i1 %NullCheck26, label %52, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %47, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %47, i32 0, i32 10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %53, %System.String addrspace(1)* %51)
   %54 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %55 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Globalization.CultureData addrspace(1)* %55, null
-  br i1 %NullCheck28, label %56, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Globalization.CultureData addrspace(1)* %55, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %56
 
 ; <label>:56                                      ; preds = %52
   %57 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %55, i32 0, i32 35
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %57, align 8
-  %NullCheck30 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %54, null
-  br i1 %NullCheck30, label %59, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %54, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %54, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %60, %System.String addrspace(1)* %58)
   %61 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %62 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck32 = icmp ne %System.Globalization.CultureData addrspace(1)* %62, null
-  br i1 %NullCheck32, label %63, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Globalization.CultureData addrspace(1)* %62, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %62, i32 0, i32 34
   %65 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %64, align 8
-  %NullCheck34 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %61, null
-  br i1 %NullCheck34, label %66, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %61, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %61, i32 0, i32 9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %67, %System.String addrspace(1)* %65)
   %68 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %69 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck36 = icmp ne %System.Globalization.CultureData addrspace(1)* %69, null
-  br i1 %NullCheck36, label %70, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Globalization.CultureData addrspace(1)* %69, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %70
 
 ; <label>:70                                      ; preds = %66
   %71 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %69, i32 0, i32 55
   %72 = load i32, i32 addrspace(1)* %71, align 8
-  %NullCheck38 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %68, null
-  br i1 %NullCheck38, label %73, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %68, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %68, i32 0, i32 22
   store i32 %72, i32 addrspace(1)* %74
   %75 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %76 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck40 = icmp ne %System.Globalization.CultureData addrspace(1)* %76, null
-  br i1 %NullCheck40, label %77, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Globalization.CultureData addrspace(1)* %76, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %76, i32 0, i32 57
   %79 = load i32, i32 addrspace(1)* %78, align 8
-  %NullCheck42 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %75, null
-  br i1 %NullCheck42, label %80, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %75, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %80
 
 ; <label>:80                                      ; preds = %77
   %81 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %75, i32 0, i32 24
   store i32 %79, i32 addrspace(1)* %81
   %82 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %83 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck44 = icmp ne %System.Globalization.CultureData addrspace(1)* %83, null
-  br i1 %NullCheck44, label %84, label %ThrowNullRef43
+  %NullCheck43 = icmp eq %System.Globalization.CultureData addrspace(1)* %83, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %84
 
 ; <label>:84                                      ; preds = %80
   %85 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %83, i32 0, i32 56
   %86 = load i32, i32 addrspace(1)* %85, align 8
-  %NullCheck46 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %82, null
-  br i1 %NullCheck46, label %87, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %82, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %82, i32 0, i32 23
@@ -13540,8 +15249,8 @@ entry:
 
 ; <label>:89                                      ; preds = %entry
   %90 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck100 = icmp ne %System.Globalization.CultureData addrspace(1)* %90, null
-  br i1 %NullCheck100, label %91, label %ThrowNullRef99
+  %NullCheck99 = icmp eq %System.Globalization.CultureData addrspace(1)* %90, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %91
 
 ; <label>:91                                      ; preds = %89
   %92 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %90, i32 0, i32 2
@@ -13559,8 +15268,8 @@ entry:
   %102 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %103 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %104 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %103)
-  %NullCheck48 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %102, null
-  br i1 %NullCheck48, label %105, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %102, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %105
 
 ; <label>:105                                     ; preds = %101
   %106 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %102, i32 0, i32 1
@@ -13568,8 +15277,8 @@ entry:
   %107 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %108 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %109 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %108)
-  %NullCheck50 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %107, null
-  br i1 %NullCheck50, label %110, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %107, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %110
 
 ; <label>:110                                     ; preds = %105
   %111 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %107, i32 0, i32 2
@@ -13577,8 +15286,8 @@ entry:
   %112 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %113 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %114 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %113)
-  %NullCheck52 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %112, null
-  br i1 %NullCheck52, label %115, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %112, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %115
 
 ; <label>:115                                     ; preds = %110
   %116 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %112, i32 0, i32 27
@@ -13586,8 +15295,8 @@ entry:
   %117 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %118 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %119 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %118)
-  %NullCheck54 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %117, null
-  br i1 %NullCheck54, label %120, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %117, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %120
 
 ; <label>:120                                     ; preds = %115
   %121 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %117, i32 0, i32 26
@@ -13595,8 +15304,8 @@ entry:
   %122 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %123 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %124 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %123)
-  %NullCheck56 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %122, null
-  br i1 %NullCheck56, label %125, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %122, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %125
 
 ; <label>:125                                     ; preds = %120
   %126 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %122, i32 0, i32 17
@@ -13604,8 +15313,8 @@ entry:
   %127 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %128 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %129 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %128)
-  %NullCheck58 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %127, null
-  br i1 %NullCheck58, label %130, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %127, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %130
 
 ; <label>:130                                     ; preds = %125
   %131 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %127, i32 0, i32 18
@@ -13613,8 +15322,8 @@ entry:
   %132 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %133 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %134 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %133)
-  %NullCheck60 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %132, null
-  br i1 %NullCheck60, label %135, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %132, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %135
 
 ; <label>:135                                     ; preds = %130
   %136 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %132, i32 0, i32 14
@@ -13622,8 +15331,8 @@ entry:
   %137 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %138 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %139 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %138)
-  %NullCheck62 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %137, null
-  br i1 %NullCheck62, label %140, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %137, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %140
 
 ; <label>:140                                     ; preds = %135
   %141 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %137, i32 0, i32 13
@@ -13631,71 +15340,71 @@ entry:
   %142 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %143 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %144 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %143)
-  %NullCheck64 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %142, null
-  br i1 %NullCheck64, label %145, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %142, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %145
 
 ; <label>:145                                     ; preds = %140
   %146 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %142, i32 0, i32 12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %146, %System.String addrspace(1)* %144)
   %147 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %148 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck66 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %148, null
-  br i1 %NullCheck66, label %149, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %148, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %149
 
 ; <label>:149                                     ; preds = %145
   %150 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %148, i32 0, i32 21
   %151 = load i32, i32 addrspace(1)* %150, align 8
-  %NullCheck68 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %147, null
-  br i1 %NullCheck68, label %152, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %147, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %152
 
 ; <label>:152                                     ; preds = %149
   %153 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %147, i32 0, i32 28
   store i32 %151, i32 addrspace(1)* %153
   %154 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %155 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck70 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %155, null
-  br i1 %NullCheck70, label %156, label %ThrowNullRef69
+  %NullCheck69 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %155, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %156
 
 ; <label>:156                                     ; preds = %152
   %157 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %155, i32 0, i32 6
   %158 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %157, align 8
-  %NullCheck72 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %154, null
-  br i1 %NullCheck72, label %159, label %ThrowNullRef71
+  %NullCheck71 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %154, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %159
 
 ; <label>:159                                     ; preds = %156
   %160 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %154, i32 0, i32 15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %160, %System.String addrspace(1)* %158)
   %161 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %162 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck74 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %162, null
-  br i1 %NullCheck74, label %163, label %ThrowNullRef73
+  %NullCheck73 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %162, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %163
 
 ; <label>:163                                     ; preds = %159
   %164 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %162, i32 0, i32 1
   %165 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %164, align 8
-  %NullCheck76 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %161, null
-  br i1 %NullCheck76, label %166, label %ThrowNullRef75
+  %NullCheck75 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %161, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %166
 
 ; <label>:166                                     ; preds = %163
   %167 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %161, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %167, %"System.Int32[]" addrspace(1)* %165)
   %168 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %169 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck78 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %169, null
-  br i1 %NullCheck78, label %170, label %ThrowNullRef77
+  %NullCheck77 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %169, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %170
 
 ; <label>:170                                     ; preds = %166
   %171 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %169, i32 0, i32 7
   %172 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %171, align 8
-  %NullCheck80 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %168, null
-  br i1 %NullCheck80, label %173, label %ThrowNullRef79
+  %NullCheck79 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %168, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %173
 
 ; <label>:173                                     ; preds = %170
   %174 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %168, i32 0, i32 16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %174, %System.String addrspace(1)* %172)
   %175 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck82 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %175, null
-  br i1 %NullCheck82, label %176, label %ThrowNullRef81
+  %NullCheck81 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %175, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %176
 
 ; <label>:176                                     ; preds = %173
   %177 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %175, i32 0, i32 4
@@ -13705,14 +15414,14 @@ entry:
 
 ; <label>:180                                     ; preds = %176
   %181 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck84 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %181, null
-  br i1 %NullCheck84, label %182, label %ThrowNullRef83
+  %NullCheck83 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %181, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %182
 
 ; <label>:182                                     ; preds = %180
   %183 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %181, i32 0, i32 4
   %184 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %183, align 8
-  %NullCheck86 = icmp ne %System.String addrspace(1)* %184, null
-  br i1 %NullCheck86, label %185, label %ThrowNullRef85
+  %NullCheck85 = icmp eq %System.String addrspace(1)* %184, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %185
 
 ; <label>:185                                     ; preds = %182
   %186 = getelementptr inbounds %System.String, %System.String addrspace(1)* %184, i32 0, i32 1
@@ -13723,8 +15432,8 @@ entry:
 ; <label>:189                                     ; preds = %176, %185
   %190 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck98 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %190, null
-  br i1 %NullCheck98, label %192, label %ThrowNullRef97
+  %NullCheck97 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %190, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %192
 
 ; <label>:192                                     ; preds = %189
   %193 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %190, i32 0, i32 4
@@ -13733,8 +15442,8 @@ entry:
 
 ; <label>:194                                     ; preds = %185, %192
   %195 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck88 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %195, null
-  br i1 %NullCheck88, label %196, label %ThrowNullRef87
+  %NullCheck87 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %195, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %196
 
 ; <label>:196                                     ; preds = %194
   %197 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %195, i32 0, i32 9
@@ -13744,14 +15453,14 @@ entry:
 
 ; <label>:200                                     ; preds = %196
   %201 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck90 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %201, null
-  br i1 %NullCheck90, label %202, label %ThrowNullRef89
+  %NullCheck89 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %201, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %202
 
 ; <label>:202                                     ; preds = %200
   %203 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %201, i32 0, i32 9
   %204 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %203, align 8
-  %NullCheck92 = icmp ne %System.String addrspace(1)* %204, null
-  br i1 %NullCheck92, label %205, label %ThrowNullRef91
+  %NullCheck91 = icmp eq %System.String addrspace(1)* %204, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %205
 
 ; <label>:205                                     ; preds = %202
   %206 = getelementptr inbounds %System.String, %System.String addrspace(1)* %204, i32 0, i32 1
@@ -13762,14 +15471,14 @@ entry:
 ; <label>:209                                     ; preds = %196, %205
   %210 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %211 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck94 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %211, null
-  br i1 %NullCheck94, label %212, label %ThrowNullRef93
+  %NullCheck93 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %211, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %212
 
 ; <label>:212                                     ; preds = %209
   %213 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %211, i32 0, i32 6
   %214 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %213, align 8
-  %NullCheck96 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %210, null
-  br i1 %NullCheck96, label %215, label %ThrowNullRef95
+  %NullCheck95 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %210, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %215
 
 ; <label>:215                                     ; preds = %212
   %216 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %210, i32 0, i32 9
@@ -13783,203 +15492,203 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %17
+ThrowNullRef8:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %21
+ThrowNullRef10:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %24
+ThrowNullRef12:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %28
+ThrowNullRef14:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %31
+ThrowNullRef16:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %35
+ThrowNullRef18:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %38
+ThrowNullRef20:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %42
+ThrowNullRef22:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %45
+ThrowNullRef24:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %49
+ThrowNullRef26:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %52
+ThrowNullRef28:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %56
+ThrowNullRef30:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %59
+ThrowNullRef32:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %63
+ThrowNullRef34:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %66
+ThrowNullRef36:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %70
+ThrowNullRef38:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %73
+ThrowNullRef40:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %77
+ThrowNullRef42:                                   ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %80
+ThrowNullRef44:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %84
+ThrowNullRef46:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %101
+ThrowNullRef48:                                   ; preds = %101
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %105
+ThrowNullRef50:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %110
+ThrowNullRef52:                                   ; preds = %110
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %115
+ThrowNullRef54:                                   ; preds = %115
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %120
+ThrowNullRef56:                                   ; preds = %120
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %125
+ThrowNullRef58:                                   ; preds = %125
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %130
+ThrowNullRef60:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %135
+ThrowNullRef62:                                   ; preds = %135
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %140
+ThrowNullRef64:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %145
+ThrowNullRef66:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %149
+ThrowNullRef68:                                   ; preds = %149
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %152
+ThrowNullRef70:                                   ; preds = %152
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %156
+ThrowNullRef72:                                   ; preds = %156
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %159
+ThrowNullRef74:                                   ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %163
+ThrowNullRef76:                                   ; preds = %163
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %166
+ThrowNullRef78:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %170
+ThrowNullRef80:                                   ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %173
+ThrowNullRef82:                                   ; preds = %173
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %180
+ThrowNullRef84:                                   ; preds = %180
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %182
+ThrowNullRef86:                                   ; preds = %182
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %194
+ThrowNullRef88:                                   ; preds = %194
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %200
+ThrowNullRef90:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %202
+ThrowNullRef92:                                   ; preds = %202
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %209
+ThrowNullRef94:                                   ; preds = %209
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %212
+ThrowNullRef96:                                   ; preds = %212
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %189
+ThrowNullRef98:                                   ; preds = %189
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %89
+ThrowNullRef100:                                  ; preds = %89
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14007,8 +15716,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 21
@@ -14021,8 +15730,8 @@ entry:
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 16)
   %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 21
@@ -14031,8 +15740,8 @@ entry:
 
 ; <label>:12                                      ; preds = %1, %10
   %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 21
@@ -14043,11 +15752,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %12
+ThrowNullRef4:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14063,8 +15772,8 @@ entry:
   store i32 %param1, i32* %arg1
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %1 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
@@ -14131,8 +15840,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 33
@@ -14145,8 +15854,8 @@ entry:
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 24)
   %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 33
@@ -14155,8 +15864,8 @@ entry:
 
 ; <label>:12                                      ; preds = %1, %10
   %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 33
@@ -14167,11 +15876,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %12
+ThrowNullRef4:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14184,8 +15893,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 53
@@ -14197,8 +15906,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 116)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 53
@@ -14207,8 +15916,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 53
@@ -14219,11 +15928,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14252,8 +15961,8 @@ entry:
 
 ; <label>:7                                       ; preds = %entry, %4
   %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %7
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 2
@@ -14277,8 +15986,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 54
@@ -14290,8 +15999,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 117)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
@@ -14300,8 +16009,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 54
@@ -14312,11 +16021,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14329,8 +16038,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 27
@@ -14342,8 +16051,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 118)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 27
@@ -14352,8 +16061,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 27
@@ -14364,11 +16073,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14381,8 +16090,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 28
@@ -14394,8 +16103,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 119)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 28
@@ -14404,8 +16113,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 28
@@ -14416,11 +16125,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14433,8 +16142,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 26
@@ -14446,8 +16155,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 107)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 26
@@ -14456,8 +16165,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 26
@@ -14468,11 +16177,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14485,8 +16194,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 25
@@ -14498,8 +16207,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 106)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 25
@@ -14508,8 +16217,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 25
@@ -14520,11 +16229,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14537,8 +16246,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 24
@@ -14550,8 +16259,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 105)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 24
@@ -14560,8 +16269,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 24
@@ -14572,11 +16281,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14601,8 +16310,8 @@ entry:
   %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %3)
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %2
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -14613,15 +16322,15 @@ entry:
 
 ; <label>:8                                       ; preds = %62
   %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 9
   %12 = load i32, i32 addrspace(1)* %11, align 8
   %13 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.IO.StreamWriter addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %13, i32 0, i32 10
@@ -14636,15 +16345,15 @@ entry:
 
 ; <label>:20                                      ; preds = %14, %18
   %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
   %24 = load i32, i32 addrspace(1)* %23, align 8
   %25 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %25, null
-  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.StreamWriter addrspace(1)* %25, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %25, i32 0, i32 9
@@ -14665,36 +16374,36 @@ entry:
   %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %37 = load i32, i32* %loc1
   %38 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.StreamWriter addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %35
   %40 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %38, i32 0, i32 7
   %41 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %40, align 8
   %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
-  br i1 %NullCheck14, label %43, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %39
   %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 9
   %45 = load i32, i32 addrspace(1)* %44, align 8
   %46 = load i32, i32* %loc2
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %36, null
-  br i1 %NullCheck16, label %47, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %36, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %47
 
 ; <label>:47                                      ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %36, i32 %37, %"System.Char[]" addrspace(1)* %41, i32 %45, i32 %46)
   %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
   %51 = load i32, i32 addrspace(1)* %50, align 8
   %52 = load i32, i32* %loc2
   %53 = add i32 %51, %52
-  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
-  br i1 %NullCheck20, label %54, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %54
 
 ; <label>:54                                      ; preds = %49
   %55 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
@@ -14716,8 +16425,8 @@ entry:
 
 ; <label>:65                                      ; preds = %62
   %66 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %66, null
-  br i1 %NullCheck2, label %67, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %66, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %67
 
 ; <label>:67                                      ; preds = %65
   %68 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %66, i32 0, i32 11
@@ -14738,49 +16447,259 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %65
+ThrowNullRef2:                                    ; preds = %65
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %20
+ThrowNullRef8:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %22
+ThrowNullRef10:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %35
+ThrowNullRef12:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %43
+ThrowNullRef16:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %47
+ThrowNullRef18:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method String::CopyTo using LLILCJit
-Failed to read String.CopyTo[loadElemA]
+Successfully read String.CopyTo
+
+define void @String.CopyTo(%System.String addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  %loc1 = alloca i16 addrspace(1)*
+  %loc2 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %1 = icmp ne %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg4
+  %7 = icmp sge i32 %6, 0
+  br i1 %7, label %13, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  unreachable
+
+; <label>:13                                      ; preds = %5
+  %14 = load i32, i32* %arg1
+  %15 = icmp sge i32 %14, 0
+  br i1 %15, label %21, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %18)
+  %20 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %20, %System.String addrspace(1)* %17, %System.String addrspace(1)* %19)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %20) #0
+  unreachable
+
+; <label>:21                                      ; preds = %13
+  %22 = load i32, i32* %arg4
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck, label %ThrowNullRef, label %24
+
+; <label>:24                                      ; preds = %21
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load i32, i32* %arg1
+  %28 = sub i32 %26, %27
+  %29 = icmp sle i32 %22, %28
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34, %System.String addrspace(1)* %31, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %24
+  %36 = load i32, i32* %arg3
+  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %37, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
+
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
+  %40 = load i32, i32 addrspace(1)* %39
+  %41 = zext i32 %40 to i64
+  %42 = trunc i64 %41 to i32
+  %43 = load i32, i32* %arg4
+  %44 = sub i32 %42, %43
+  %45 = icmp sgt i32 %36, %44
+  br i1 %45, label %49, label %46
+
+; <label>:46                                      ; preds = %38
+  %47 = load i32, i32* %arg3
+  %48 = icmp sge i32 %47, 0
+  br i1 %48, label %54, label %49
+
+; <label>:49                                      ; preds = %38, %46
+  %50 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %52 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %51)
+  %53 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53, %System.String addrspace(1)* %50, %System.String addrspace(1)* %52)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53) #0
+  unreachable
+
+; <label>:54                                      ; preds = %46
+  %55 = load i32, i32* %arg4
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %97, label %57
+
+; <label>:57                                      ; preds = %54
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %59
+
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 2
+  %61 = bitcast [0 x i16] addrspace(1)* %60 to i16 addrspace(1)*
+  store i16 addrspace(1)* %61, i16 addrspace(1)** %loc0
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  store %"System.Char[]" addrspace(1)* %62, %"System.Char[]" addrspace(1)** %loc2
+  %63 = icmp eq %"System.Char[]" addrspace(1)* %62, null
+  br i1 %63, label %72, label %64
+
+; <label>:64                                      ; preds = %59
+  %65 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc2
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %65, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %66
+
+; <label>:66                                      ; preds = %64
+  %67 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %65, i32 0, i32 1
+  %68 = load i32, i32 addrspace(1)* %67
+  %69 = zext i32 %68 to i64
+  %70 = trunc i64 %69 to i32
+  %71 = icmp ne i32 %70, 0
+  br i1 %71, label %73, label %72
+
+; <label>:72                                      ; preds = %59, %66
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  br label %81
+
+; <label>:73                                      ; preds = %66
+  %74 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc2
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %74, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %75
+
+; <label>:75                                      ; preds = %73
+  %76 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %74, i32 0, i32 1
+  %77 = load i32, i32 addrspace(1)* %76
+  %78 = zext i32 %77 to i64
+  %BoundsCheck = icmp uge i64 0, %78
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %79
+
+; <label>:79                                      ; preds = %75
+  %80 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %74, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %80, i16 addrspace(1)** %loc1
+  br label %81
+
+; <label>:81                                      ; preds = %72, %79
+  %82 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %83 = ptrtoint i16 addrspace(1)* %82 to i64
+  %84 = load i32, i32* %arg3
+  %85 = sext i32 %84 to i64
+  %86 = mul i64 %85, 2
+  %87 = add i64 %83, %86
+  %88 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %89 = ptrtoint i16 addrspace(1)* %88 to i64
+  %90 = load i32, i32* %arg1
+  %91 = sext i32 %90 to i64
+  %92 = mul i64 %91, 2
+  %93 = add i64 %89, %92
+  %94 = load i32, i32* %arg4
+  %95 = inttoptr i64 %87 to i16*
+  %96 = inttoptr i64 %93 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %95, i16* %96, i32 %94)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  br label %97
+
+; <label>:97                                      ; preds = %54, %81
+  ret void
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
 Successfully read ConsoleEncoding.GetPreamble
 
@@ -14817,7 +16736,365 @@ entry:
 }
 
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[loadElemA]
+Successfully read EncoderNLS.GetBytes
+
+define i32 @EncoderNLS.GetBytes(%System.Text.EncoderNLS addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3, %"System.Byte[]" addrspace(1)* %param4, i32 %param5, i8 %param6) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %arg4 = alloca %"System.Byte[]" addrspace(1)*
+  %arg5 = alloca i32
+  %arg6 = alloca i8
+  %loc0 = alloca i32
+  %loc1 = alloca i16 addrspace(1)*
+  %loc2 = alloca i8 addrspace(1)*
+  %loc3 = alloca i32
+  %loc4 = alloca %"System.Char[]" addrspace(1)*
+  %loc5 = alloca %"System.Byte[]" addrspace(1)*
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  store %"System.Byte[]" addrspace(1)* %param4, %"System.Byte[]" addrspace(1)** %arg4
+  store i32 %param5, i32* %arg5
+  store i8 %param6, i8* %arg6
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %1 = icmp eq %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %17, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %7 = icmp eq %"System.Char[]" addrspace(1)* %6, null
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %12
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %12
+
+; <label>:12                                      ; preds = %8, %10
+  %13 = phi %System.String addrspace(1)* [ %9, %8 ], [ %11, %10 ]
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %14)
+  %16 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16, %System.String addrspace(1)* %13, %System.String addrspace(1)* %15)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16) #0
+  unreachable
+
+; <label>:17                                      ; preds = %2
+  %18 = load i32, i32* %arg2
+  %19 = icmp slt i32 %18, 0
+  br i1 %19, label %23, label %20
+
+; <label>:20                                      ; preds = %17
+  %21 = load i32, i32* %arg3
+  %22 = icmp sge i32 %21, 0
+  br i1 %22, label %35, label %23
+
+; <label>:23                                      ; preds = %17, %20
+  %24 = load i32, i32* %arg2
+  %25 = icmp slt i32 %24, 0
+  br i1 %25, label %28, label %26
+
+; <label>:26                                      ; preds = %23
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %30
+
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %30
+
+; <label>:30                                      ; preds = %26, %28
+  %31 = phi %System.String addrspace(1)* [ %27, %26 ], [ %29, %28 ]
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34, %System.String addrspace(1)* %31, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %20
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck, label %ThrowNullRef, label %37
+
+; <label>:37                                      ; preds = %35
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = load i32, i32* %arg2
+  %43 = sub i32 %41, %42
+  %44 = load i32, i32* %arg3
+  %45 = icmp sge i32 %43, %44
+  br i1 %45, label %51, label %46
+
+; <label>:46                                      ; preds = %37
+  %47 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %48 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %49 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %48)
+  %50 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %50, %System.String addrspace(1)* %47, %System.String addrspace(1)* %49)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %50) #0
+  unreachable
+
+; <label>:51                                      ; preds = %37
+  %52 = load i32, i32* %arg5
+  %53 = icmp slt i32 %52, 0
+  br i1 %53, label %63, label %54
+
+; <label>:54                                      ; preds = %51
+  %55 = load i32, i32* %arg5
+  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck1 = icmp eq %"System.Byte[]" addrspace(1)* %56, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %57
+
+; <label>:57                                      ; preds = %54
+  %58 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = zext i32 %59 to i64
+  %61 = trunc i64 %60 to i32
+  %62 = icmp sle i32 %55, %61
+  br i1 %62, label %68, label %63
+
+; <label>:63                                      ; preds = %51, %57
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %66 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %65)
+  %67 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %67, %System.String addrspace(1)* %64, %System.String addrspace(1)* %66)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %67) #0
+  unreachable
+
+; <label>:68                                      ; preds = %57
+  %69 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %69, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %69, i32 0, i32 1
+  %72 = load i32, i32 addrspace(1)* %71
+  %73 = zext i32 %72 to i64
+  %74 = trunc i64 %73 to i32
+  %75 = icmp ne i32 %74, 0
+  br i1 %75, label %78, label %76
+
+; <label>:76                                      ; preds = %70
+  %77 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1)
+  store %"System.Char[]" addrspace(1)* %77, %"System.Char[]" addrspace(1)** %arg1
+  br label %78
+
+; <label>:78                                      ; preds = %70, %76
+  %79 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck5 = icmp eq %"System.Byte[]" addrspace(1)* %79, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %80
+
+; <label>:80                                      ; preds = %78
+  %81 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %79, i32 0, i32 1
+  %82 = load i32, i32 addrspace(1)* %81
+  %83 = zext i32 %82 to i64
+  %84 = trunc i64 %83 to i32
+  %85 = load i32, i32* %arg5
+  %86 = sub i32 %84, %85
+  store i32 %86, i32* %loc0
+  %87 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck7 = icmp eq %"System.Byte[]" addrspace(1)* %87, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %88
+
+; <label>:88                                      ; preds = %80
+  %89 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %87, i32 0, i32 1
+  %90 = load i32, i32 addrspace(1)* %89
+  %91 = zext i32 %90 to i64
+  %92 = trunc i64 %91 to i32
+  %93 = icmp ne i32 %92, 0
+  br i1 %93, label %96, label %94
+
+; <label>:94                                      ; preds = %88
+  %95 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1)
+  store %"System.Byte[]" addrspace(1)* %95, %"System.Byte[]" addrspace(1)** %arg4
+  br label %96
+
+; <label>:96                                      ; preds = %88, %94
+  %97 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  store %"System.Char[]" addrspace(1)* %97, %"System.Char[]" addrspace(1)** %loc4
+  %98 = icmp eq %"System.Char[]" addrspace(1)* %97, null
+  br i1 %98, label %107, label %99
+
+; <label>:99                                      ; preds = %96
+  %100 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc4
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %100, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %101
+
+; <label>:101                                     ; preds = %99
+  %102 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %100, i32 0, i32 1
+  %103 = load i32, i32 addrspace(1)* %102
+  %104 = zext i32 %103 to i64
+  %105 = trunc i64 %104 to i32
+  %106 = icmp ne i32 %105, 0
+  br i1 %106, label %108, label %107
+
+; <label>:107                                     ; preds = %96, %101
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  br label %116
+
+; <label>:108                                     ; preds = %101
+  %109 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc4
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %109, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %110
+
+; <label>:110                                     ; preds = %108
+  %111 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %109, i32 0, i32 1
+  %112 = load i32, i32 addrspace(1)* %111
+  %113 = zext i32 %112 to i64
+  %BoundsCheck = icmp uge i64 0, %113
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %114
+
+; <label>:114                                     ; preds = %110
+  %115 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %109, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %115, i16 addrspace(1)** %loc1
+  br label %116
+
+; <label>:116                                     ; preds = %107, %114
+  %117 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  store %"System.Byte[]" addrspace(1)* %117, %"System.Byte[]" addrspace(1)** %loc5
+  %118 = icmp eq %"System.Byte[]" addrspace(1)* %117, null
+  br i1 %118, label %127, label %119
+
+; <label>:119                                     ; preds = %116
+  %120 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc5
+  %NullCheck13 = icmp eq %"System.Byte[]" addrspace(1)* %120, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %121
+
+; <label>:121                                     ; preds = %119
+  %122 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %120, i32 0, i32 1
+  %123 = load i32, i32 addrspace(1)* %122
+  %124 = zext i32 %123 to i64
+  %125 = trunc i64 %124 to i32
+  %126 = icmp ne i32 %125, 0
+  br i1 %126, label %128, label %127
+
+; <label>:127                                     ; preds = %116, %121
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc2
+  br label %136
+
+; <label>:128                                     ; preds = %121
+  %129 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc5
+  %NullCheck15 = icmp eq %"System.Byte[]" addrspace(1)* %129, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %130
+
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %129, i32 0, i32 1
+  %132 = load i32, i32 addrspace(1)* %131
+  %133 = zext i32 %132 to i64
+  %BoundsCheck17 = icmp uge i64 0, %133
+  br i1 %BoundsCheck17, label %ThrowIndexOutOfRange18, label %134
+
+; <label>:134                                     ; preds = %130
+  %135 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %129, i32 0, i32 3, i32 0
+  store i8 addrspace(1)* %135, i8 addrspace(1)** %loc2
+  br label %136
+
+; <label>:136                                     ; preds = %127, %134
+  %137 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %138 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %139 = ptrtoint i16 addrspace(1)* %138 to i64
+  %140 = load i32, i32* %arg2
+  %141 = sext i32 %140 to i64
+  %142 = mul i64 %141, 2
+  %143 = add i64 %139, %142
+  %144 = load i32, i32* %arg3
+  %145 = load i8 addrspace(1)*, i8 addrspace(1)** %loc2
+  %146 = ptrtoint i8 addrspace(1)* %145 to i64
+  %147 = load i32, i32* %arg5
+  %148 = sext i32 %147 to i64
+  %149 = add i64 %146, %148
+  %150 = load i32, i32* %loc0
+  %151 = load i8, i8* %arg6
+  %152 = zext i8 %151 to i32
+  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i64 addrspace(1)*
+  %NullCheck19 = icmp eq i64 addrspace(1)* %153, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %154
+
+; <label>:154                                     ; preds = %136
+  %155 = load i64, i64 addrspace(1)* %153
+  %156 = add i64 %155, 72
+  %157 = inttoptr i64 %156 to i64*
+  %158 = load i64, i64* %157
+  %159 = add i64 %158, 0
+  %160 = inttoptr i64 %159 to i64*
+  %161 = load i64, i64* %160
+  %162 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to %System.Text.Encoder addrspace(1)*
+  %163 = inttoptr i64 %143 to i16*
+  %164 = inttoptr i64 %149 to i8*
+  %165 = trunc i32 %152 to i8
+  %166 = inttoptr i64 %161 to i32 (%System.Text.Encoder addrspace(1)*, i16*, i32, i8*, i32, i8)*
+  %167 = call i32 %166(%System.Text.Encoder addrspace(1)* %162, i16* %163, i32 %144, i8* %164, i32 %150, i8 %165)
+  store i32 %167, i32* %loc3
+  br label %168
+
+; <label>:168                                     ; preds = %154
+  %169 = load i32, i32* %loc3
+  ret i32 %169
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %110
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %119
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange18:                           ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
 Successfully read EncoderNLS.GetBytes
 
@@ -14906,22 +17183,22 @@ entry:
   %40 = load i8, i8* %arg5
   %41 = zext i8 %40 to i32
   %42 = trunc i32 %41 to i8
-  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %39, null
-  br i1 %NullCheck, label %43, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderNLS addrspace(1)* %39, null
+  br i1 %NullCheck, label %ThrowNullRef, label %43
 
 ; <label>:43                                      ; preds = %38
   %44 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
   store i8 %42, i8 addrspace(1)* %44
   %45 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %45, null
-  br i1 %NullCheck2, label %46, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.EncoderNLS addrspace(1)* %45, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %46
 
 ; <label>:46                                      ; preds = %43
   %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %45, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %47
   %48 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.EncoderNLS addrspace(1)* %48, null
-  br i1 %NullCheck4, label %49, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.EncoderNLS addrspace(1)* %48, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %49
 
 ; <label>:49                                      ; preds = %46
   %50 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %48, i32 0, i32 3
@@ -14932,8 +17209,8 @@ entry:
   %55 = load i32, i32* %arg4
   %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck6, label %58, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
   %59 = load i64, i64 addrspace(1)* %57
@@ -14951,15 +17228,15 @@ ThrowNullRef:                                     ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %43
+ThrowNullRef2:                                    ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %46
+ThrowNullRef4:                                    ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %49
+ThrowNullRef6:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14987,8 +17264,8 @@ entry:
   %4 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0 to %System.IO.ConsoleStream addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*)(%System.IO.ConsoleStream addrspace(1)* %4, %"System.Byte[]" addrspace(1)* %1, i32 %2, i32 %3)
   %5 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
@@ -15073,8 +17350,8 @@ entry:
 
 ; <label>:22                                      ; preds = %8
   %23 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %23, null
-  br i1 %NullCheck, label %24, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Byte[]" addrspace(1)* %23, null
+  br i1 %NullCheck, label %ThrowNullRef, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
@@ -15096,8 +17373,8 @@ entry:
 
 ; <label>:36                                      ; preds = %24
   %37 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %37, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.ConsoleStream addrspace(1)* %37, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %37, i32 0, i32 4
@@ -15118,13 +17395,138 @@ ThrowNullRef:                                     ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %36
+ThrowNullRef2:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
-Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
+Successfully read WindowsConsoleStream.WriteFileNative
+
+define i32 @WindowsConsoleStream.WriteFileNative(i64 %param0, %"System.Byte[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i64
+  %arg1 = alloca %"System.Byte[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i8 addrspace(1)*
+  %loc2 = alloca %"System.Byte[]" addrspace(1)*
+  %loc3 = alloca i32
+  store i64 %param0, i64* %arg0
+  store %"System.Byte[]" addrspace(1)* %param1, %"System.Byte[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Byte[]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = zext i32 %3 to i64
+  %5 = icmp ne i64 %4, 0
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %1
+  ret i32 0
+
+; <label>:7                                       ; preds = %1
+  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  store %"System.Byte[]" addrspace(1)* %8, %"System.Byte[]" addrspace(1)** %loc2
+  %9 = icmp eq %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %9, label %18, label %10
+
+; <label>:10                                      ; preds = %7
+  %11 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc2
+  %NullCheck1 = icmp eq %"System.Byte[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %11, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp ne i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %7, %12
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc1
+  br label %27
+
+; <label>:19                                      ; preds = %12
+  %20 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc2
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %20, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %BoundsCheck = icmp uge i64 0, %24
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %25
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %20, i32 0, i32 3, i32 0
+  store i8 addrspace(1)* %26, i8 addrspace(1)** %loc1
+  br label %27
+
+; <label>:27                                      ; preds = %18, %25
+  %28 = load i64, i64* %arg0
+  %29 = load i8 addrspace(1)*, i8 addrspace(1)** %loc1
+  %30 = ptrtoint i8 addrspace(1)* %29 to i64
+  %31 = load i32, i32* %arg2
+  %32 = sext i32 %31 to i64
+  %33 = add i64 %30, %32
+  %34 = load i32, i32* %arg3
+  %35 = addrspacecast i32* %loc3 to i32 addrspace(1)*
+  %36 = inttoptr i64 %33 to i8*
+  %37 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i8*, i32, i32 addrspace(1)*, i64)*)(i64 %28, i8* %36, i32 %34, i32 addrspace(1)* %35, i64 0)
+  %38 = icmp ugt i32 %37, 0
+  %39 = sext i1 %38 to i32
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc1
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %42, label %41
+
+; <label>:41                                      ; preds = %27
+  ret i32 0
+
+; <label>:42                                      ; preds = %27
+  %43 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  store i32 %43, i32* %loc0
+  %44 = load i32, i32* %loc0
+  %45 = icmp eq i32 %44, 232
+  br i1 %45, label %49, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = load i32, i32* %loc0
+  %48 = icmp ne i32 %47, 109
+  br i1 %48, label %50, label %49
+
+; <label>:49                                      ; preds = %42, %46
+  ret i32 0
+
+; <label>:50                                      ; preds = %46
+  %51 = load i32, i32* %loc0
+  ret i32 %51
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
 Successfully read WindowsConsoleStream.Flush
 
@@ -15133,8 +17535,8 @@ entry:
   %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
   store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
@@ -15169,8 +17571,8 @@ entry:
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
   %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load i64, i64 addrspace(1)* %1
@@ -15209,15 +17611,15 @@ entry:
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.TextWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
   %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %3, align 8
   %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
   %7 = load i64, i64 addrspace(1)* %5
@@ -15235,7 +17637,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -15264,8 +17666,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %4)
   store i32 0, i32* %loc0
   %5 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Char[]" addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
@@ -15277,15 +17679,15 @@ entry:
 
 ; <label>:11                                      ; preds = %69
   %12 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %12, i32 0, i32 9
   %15 = load i32, i32 addrspace(1)* %14, align 8
   %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.IO.StreamWriter addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %16, i32 0, i32 10
@@ -15300,15 +17702,15 @@ entry:
 
 ; <label>:23                                      ; preds = %17, %21
   %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %24, null
-  br i1 %NullCheck8, label %25, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %24, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 10
   %27 = load i32, i32 addrspace(1)* %26, align 8
   %28 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %28, null
-  br i1 %NullCheck10, label %29, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.StreamWriter addrspace(1)* %28, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %28, i32 0, i32 9
@@ -15330,15 +17732,15 @@ entry:
   %40 = load i32, i32* %loc0
   %41 = mul i32 %40, 2
   %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
-  br i1 %NullCheck12, label %43, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %43
 
 ; <label>:43                                      ; preds = %38
   %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 7
   %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %44, align 8
   %46 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %46, null
-  br i1 %NullCheck14, label %47, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.IO.StreamWriter addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %47
 
 ; <label>:47                                      ; preds = %43
   %48 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %46, i32 0, i32 9
@@ -15350,16 +17752,16 @@ entry:
   %54 = bitcast %"System.Char[]" addrspace(1)* %45 to %System.Array addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %53, i32 %41, %System.Array addrspace(1)* %54, i32 %50, i32 %52)
   %55 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
-  br i1 %NullCheck16, label %56, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %56
 
 ; <label>:56                                      ; preds = %47
   %57 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
   %58 = load i32, i32 addrspace(1)* %57, align 8
   %59 = load i32, i32* %loc2
   %60 = add i32 %58, %59
-  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
-  br i1 %NullCheck18, label %61, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %61
 
 ; <label>:61                                      ; preds = %56
   %62 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
@@ -15381,8 +17783,8 @@ entry:
 
 ; <label>:72                                      ; preds = %69
   %73 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %73, null
-  br i1 %NullCheck2, label %74, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %73, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %74
 
 ; <label>:74                                      ; preds = %72
   %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %73, i32 0, i32 11
@@ -15403,39 +17805,39 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %72
+ThrowNullRef2:                                    ; preds = %72
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %23
+ThrowNullRef8:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef10:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %43
+ThrowNullRef14:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %47
+ThrowNullRef16:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %56
+ThrowNullRef18:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPDiv.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPDiv.error.txt
@@ -25,8 +25,8 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
@@ -40,8 +40,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
   %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
@@ -75,7 +75,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -90,8 +90,8 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %NullCheck = icmp ne i8 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = load i8, i8 addrspace(1)* %0, align 8
@@ -125,8 +125,8 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
@@ -159,8 +159,8 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -184,8 +184,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
   store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
@@ -195,8 +195,8 @@ entry:
 ; <label>:4                                       ; preds = %1
   %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
   %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
@@ -206,8 +206,8 @@ entry:
   %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
@@ -221,14 +221,14 @@ entry:
 
 ; <label>:17                                      ; preds = %14
   %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
   %21 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
@@ -238,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -249,8 +249,8 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
@@ -261,27 +261,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %30
+ThrowNullRef10:                                   ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -301,7 +301,89 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
-Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
+Successfully read AppDomainSetup.GetUnsecureApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.GetUnsecureApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %NullCheck = icmp eq %"System.String[]" addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %BoundsCheck = icmp uge i64 0, %5
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %6
+
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 3, i32 0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
+  ret %System.String addrspace(1)* %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_Value using LLILCJit
+Successfully read AppDomainSetup.get_Value
+
+define %"System.String[]" addrspace(1)* @AppDomainSetup.get_Value(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.String[]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 18)
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.String[]" addrspace(1)* addrspace(1)*, %"System.String[]" addrspace(1)*)*)(%"System.String[]" addrspace(1)* addrspace(1)* %9, %"System.String[]" addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %11, i32 0, i32 1
+  %14 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %13, align 8
+  ret %"System.String[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -319,8 +401,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -368,16 +450,16 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
   %5 = load i32, i32 addrspace(1)* %4
   %6 = sub i32 %5, 1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -389,7 +471,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -421,8 +503,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
@@ -456,8 +538,8 @@ entry:
 ; <label>:27                                      ; preds = %19
   %28 = load i32, i32* %arg1
   %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
-  br i1 %NullCheck2, label %30, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %29, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %30
 
 ; <label>:30                                      ; preds = %27
   %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
@@ -493,8 +575,8 @@ entry:
 ; <label>:49                                      ; preds = %46
   %50 = load i32, i32* %arg2
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck4, label %52, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
@@ -517,11 +599,11 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %27
+ThrowNullRef2:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %49
+ThrowNullRef4:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -544,16 +626,16 @@ entry:
   %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %0)
   store %System.String addrspace(1)* %1, %System.String addrspace(1)** %loc0
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 2
   %5 = bitcast [0 x i16] addrspace(1)* %4 to i16 addrspace(1)*
   store i16 addrspace(1)* %5, i16 addrspace(1)** %loc1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %3
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2
@@ -580,7 +662,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -691,15 +773,15 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %NullCheck132 = icmp ne i8* %21, null
-  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+  %NullCheck131 = icmp eq i8* %21, null
+  br i1 %NullCheck131, label %ThrowNullRef132, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = load i8, i8* %21, align 8
   %24 = zext i8 %23 to i32
   %25 = trunc i32 %24 to i8
-  %NullCheck134 = icmp ne i8* %20, null
-  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+  %NullCheck133 = icmp eq i8* %20, null
+  br i1 %NullCheck133, label %ThrowNullRef134, label %26
 
 ; <label>:26                                      ; preds = %22
   store i8 %25, i8* %20, align 8
@@ -709,16 +791,16 @@ entry:
   %28 = load i8*, i8** %arg0
   %29 = load i8*, i8** %arg1
   %30 = bitcast i8* %29 to i16*
-  %NullCheck128 = icmp ne i16* %30, null
-  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+  %NullCheck127 = icmp eq i16* %30, null
+  br i1 %NullCheck127, label %ThrowNullRef128, label %31
 
 ; <label>:31                                      ; preds = %27
   %32 = load i16, i16* %30, align 8
   %33 = sext i16 %32 to i32
   %34 = bitcast i8* %28 to i16*
   %35 = trunc i32 %33 to i16
-  %NullCheck130 = icmp ne i16* %34, null
-  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+  %NullCheck129 = icmp eq i16* %34, null
+  br i1 %NullCheck129, label %ThrowNullRef130, label %36
 
 ; <label>:36                                      ; preds = %31
   store i16 %35, i16* %34, align 8
@@ -728,16 +810,16 @@ entry:
   %38 = load i8*, i8** %arg0
   %39 = load i8*, i8** %arg1
   %40 = bitcast i8* %39 to i16*
-  %NullCheck120 = icmp ne i16* %40, null
-  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+  %NullCheck119 = icmp eq i16* %40, null
+  br i1 %NullCheck119, label %ThrowNullRef120, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i16, i16* %40, align 8
   %43 = sext i16 %42 to i32
   %44 = bitcast i8* %38 to i16*
   %45 = trunc i32 %43 to i16
-  %NullCheck122 = icmp ne i16* %44, null
-  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+  %NullCheck121 = icmp eq i16* %44, null
+  br i1 %NullCheck121, label %ThrowNullRef122, label %46
 
 ; <label>:46                                      ; preds = %41
   store i16 %45, i16* %44, align 8
@@ -745,15 +827,15 @@ entry:
   %48 = getelementptr inbounds i8, i8* %47, i64 2
   %49 = load i8*, i8** %arg1
   %50 = getelementptr inbounds i8, i8* %49, i64 2
-  %NullCheck124 = icmp ne i8* %50, null
-  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+  %NullCheck123 = icmp eq i8* %50, null
+  br i1 %NullCheck123, label %ThrowNullRef124, label %51
 
 ; <label>:51                                      ; preds = %46
   %52 = load i8, i8* %50, align 8
   %53 = zext i8 %52 to i32
   %54 = trunc i32 %53 to i8
-  %NullCheck126 = icmp ne i8* %48, null
-  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+  %NullCheck125 = icmp eq i8* %48, null
+  br i1 %NullCheck125, label %ThrowNullRef126, label %55
 
 ; <label>:55                                      ; preds = %51
   store i8 %54, i8* %48, align 8
@@ -763,14 +845,14 @@ entry:
   %57 = load i8*, i8** %arg0
   %58 = load i8*, i8** %arg1
   %59 = bitcast i8* %58 to i32*
-  %NullCheck116 = icmp ne i32* %59, null
-  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+  %NullCheck115 = icmp eq i32* %59, null
+  br i1 %NullCheck115, label %ThrowNullRef116, label %60
 
 ; <label>:60                                      ; preds = %56
   %61 = load i32, i32* %59, align 8
   %62 = bitcast i8* %57 to i32*
-  %NullCheck118 = icmp ne i32* %62, null
-  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+  %NullCheck117 = icmp eq i32* %62, null
+  br i1 %NullCheck117, label %ThrowNullRef118, label %63
 
 ; <label>:63                                      ; preds = %60
   store i32 %61, i32* %62, align 8
@@ -780,14 +862,14 @@ entry:
   %65 = load i8*, i8** %arg0
   %66 = load i8*, i8** %arg1
   %67 = bitcast i8* %66 to i32*
-  %NullCheck108 = icmp ne i32* %67, null
-  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+  %NullCheck107 = icmp eq i32* %67, null
+  br i1 %NullCheck107, label %ThrowNullRef108, label %68
 
 ; <label>:68                                      ; preds = %64
   %69 = load i32, i32* %67, align 8
   %70 = bitcast i8* %65 to i32*
-  %NullCheck110 = icmp ne i32* %70, null
-  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+  %NullCheck109 = icmp eq i32* %70, null
+  br i1 %NullCheck109, label %ThrowNullRef110, label %71
 
 ; <label>:71                                      ; preds = %68
   store i32 %69, i32* %70, align 8
@@ -795,15 +877,15 @@ entry:
   %73 = getelementptr inbounds i8, i8* %72, i64 4
   %74 = load i8*, i8** %arg1
   %75 = getelementptr inbounds i8, i8* %74, i64 4
-  %NullCheck112 = icmp ne i8* %75, null
-  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+  %NullCheck111 = icmp eq i8* %75, null
+  br i1 %NullCheck111, label %ThrowNullRef112, label %76
 
 ; <label>:76                                      ; preds = %71
   %77 = load i8, i8* %75, align 8
   %78 = zext i8 %77 to i32
   %79 = trunc i32 %78 to i8
-  %NullCheck114 = icmp ne i8* %73, null
-  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+  %NullCheck113 = icmp eq i8* %73, null
+  br i1 %NullCheck113, label %ThrowNullRef114, label %80
 
 ; <label>:80                                      ; preds = %76
   store i8 %79, i8* %73, align 8
@@ -813,14 +895,14 @@ entry:
   %82 = load i8*, i8** %arg0
   %83 = load i8*, i8** %arg1
   %84 = bitcast i8* %83 to i32*
-  %NullCheck100 = icmp ne i32* %84, null
-  br i1 %NullCheck100, label %85, label %ThrowNullRef99
+  %NullCheck99 = icmp eq i32* %84, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %85
 
 ; <label>:85                                      ; preds = %81
   %86 = load i32, i32* %84, align 8
   %87 = bitcast i8* %82 to i32*
-  %NullCheck102 = icmp ne i32* %87, null
-  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+  %NullCheck101 = icmp eq i32* %87, null
+  br i1 %NullCheck101, label %ThrowNullRef102, label %88
 
 ; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
@@ -829,16 +911,16 @@ entry:
   %91 = load i8*, i8** %arg1
   %92 = getelementptr inbounds i8, i8* %91, i64 4
   %93 = bitcast i8* %92 to i16*
-  %NullCheck104 = icmp ne i16* %93, null
-  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+  %NullCheck103 = icmp eq i16* %93, null
+  br i1 %NullCheck103, label %ThrowNullRef104, label %94
 
 ; <label>:94                                      ; preds = %88
   %95 = load i16, i16* %93, align 8
   %96 = sext i16 %95 to i32
   %97 = bitcast i8* %90 to i16*
   %98 = trunc i32 %96 to i16
-  %NullCheck106 = icmp ne i16* %97, null
-  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+  %NullCheck105 = icmp eq i16* %97, null
+  br i1 %NullCheck105, label %ThrowNullRef106, label %99
 
 ; <label>:99                                      ; preds = %94
   store i16 %98, i16* %97, align 8
@@ -848,14 +930,14 @@ entry:
   %101 = load i8*, i8** %arg0
   %102 = load i8*, i8** %arg1
   %103 = bitcast i8* %102 to i32*
-  %NullCheck88 = icmp ne i32* %103, null
-  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+  %NullCheck87 = icmp eq i32* %103, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %104
 
 ; <label>:104                                     ; preds = %100
   %105 = load i32, i32* %103, align 8
   %106 = bitcast i8* %101 to i32*
-  %NullCheck90 = icmp ne i32* %106, null
-  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+  %NullCheck89 = icmp eq i32* %106, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %107
 
 ; <label>:107                                     ; preds = %104
   store i32 %105, i32* %106, align 8
@@ -864,16 +946,16 @@ entry:
   %110 = load i8*, i8** %arg1
   %111 = getelementptr inbounds i8, i8* %110, i64 4
   %112 = bitcast i8* %111 to i16*
-  %NullCheck92 = icmp ne i16* %112, null
-  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+  %NullCheck91 = icmp eq i16* %112, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %113
 
 ; <label>:113                                     ; preds = %107
   %114 = load i16, i16* %112, align 8
   %115 = sext i16 %114 to i32
   %116 = bitcast i8* %109 to i16*
   %117 = trunc i32 %115 to i16
-  %NullCheck94 = icmp ne i16* %116, null
-  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+  %NullCheck93 = icmp eq i16* %116, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %118
 
 ; <label>:118                                     ; preds = %113
   store i16 %117, i16* %116, align 8
@@ -881,15 +963,15 @@ entry:
   %120 = getelementptr inbounds i8, i8* %119, i64 6
   %121 = load i8*, i8** %arg1
   %122 = getelementptr inbounds i8, i8* %121, i64 6
-  %NullCheck96 = icmp ne i8* %122, null
-  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+  %NullCheck95 = icmp eq i8* %122, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %123
 
 ; <label>:123                                     ; preds = %118
   %124 = load i8, i8* %122, align 8
   %125 = zext i8 %124 to i32
   %126 = trunc i32 %125 to i8
-  %NullCheck98 = icmp ne i8* %120, null
-  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+  %NullCheck97 = icmp eq i8* %120, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %127
 
 ; <label>:127                                     ; preds = %123
   store i8 %126, i8* %120, align 8
@@ -899,14 +981,14 @@ entry:
   %129 = load i8*, i8** %arg0
   %130 = load i8*, i8** %arg1
   %131 = bitcast i8* %130 to i64*
-  %NullCheck84 = icmp ne i64* %131, null
-  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+  %NullCheck83 = icmp eq i64* %131, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %132
 
 ; <label>:132                                     ; preds = %128
   %133 = load i64, i64* %131, align 8
   %134 = bitcast i8* %129 to i64*
-  %NullCheck86 = icmp ne i64* %134, null
-  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+  %NullCheck85 = icmp eq i64* %134, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %135
 
 ; <label>:135                                     ; preds = %132
   store i64 %133, i64* %134, align 8
@@ -916,14 +998,14 @@ entry:
   %137 = load i8*, i8** %arg0
   %138 = load i8*, i8** %arg1
   %139 = bitcast i8* %138 to i64*
-  %NullCheck76 = icmp ne i64* %139, null
-  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+  %NullCheck75 = icmp eq i64* %139, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %140
 
 ; <label>:140                                     ; preds = %136
   %141 = load i64, i64* %139, align 8
   %142 = bitcast i8* %137 to i64*
-  %NullCheck78 = icmp ne i64* %142, null
-  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+  %NullCheck77 = icmp eq i64* %142, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %143
 
 ; <label>:143                                     ; preds = %140
   store i64 %141, i64* %142, align 8
@@ -931,15 +1013,15 @@ entry:
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %NullCheck80 = icmp ne i8* %147, null
-  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+  %NullCheck79 = icmp eq i8* %147, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %148
 
 ; <label>:148                                     ; preds = %143
   %149 = load i8, i8* %147, align 8
   %150 = zext i8 %149 to i32
   %151 = trunc i32 %150 to i8
-  %NullCheck82 = icmp ne i8* %145, null
-  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+  %NullCheck81 = icmp eq i8* %145, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %152
 
 ; <label>:152                                     ; preds = %148
   store i8 %151, i8* %145, align 8
@@ -949,14 +1031,14 @@ entry:
   %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
   %156 = bitcast i8* %155 to i64*
-  %NullCheck68 = icmp ne i64* %156, null
-  br i1 %NullCheck68, label %157, label %ThrowNullRef67
+  %NullCheck67 = icmp eq i64* %156, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %157
 
 ; <label>:157                                     ; preds = %153
   %158 = load i64, i64* %156, align 8
   %159 = bitcast i8* %154 to i64*
-  %NullCheck70 = icmp ne i64* %159, null
-  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+  %NullCheck69 = icmp eq i64* %159, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %160
 
 ; <label>:160                                     ; preds = %157
   store i64 %158, i64* %159, align 8
@@ -965,16 +1047,16 @@ entry:
   %163 = load i8*, i8** %arg1
   %164 = getelementptr inbounds i8, i8* %163, i64 8
   %165 = bitcast i8* %164 to i16*
-  %NullCheck72 = icmp ne i16* %165, null
-  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+  %NullCheck71 = icmp eq i16* %165, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %166
 
 ; <label>:166                                     ; preds = %160
   %167 = load i16, i16* %165, align 8
   %168 = sext i16 %167 to i32
   %169 = bitcast i8* %162 to i16*
   %170 = trunc i32 %168 to i16
-  %NullCheck74 = icmp ne i16* %169, null
-  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+  %NullCheck73 = icmp eq i16* %169, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %171
 
 ; <label>:171                                     ; preds = %166
   store i16 %170, i16* %169, align 8
@@ -984,14 +1066,14 @@ entry:
   %173 = load i8*, i8** %arg0
   %174 = load i8*, i8** %arg1
   %175 = bitcast i8* %174 to i64*
-  %NullCheck56 = icmp ne i64* %175, null
-  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+  %NullCheck55 = icmp eq i64* %175, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %176
 
 ; <label>:176                                     ; preds = %172
   %177 = load i64, i64* %175, align 8
   %178 = bitcast i8* %173 to i64*
-  %NullCheck58 = icmp ne i64* %178, null
-  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+  %NullCheck57 = icmp eq i64* %178, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %179
 
 ; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
@@ -1000,16 +1082,16 @@ entry:
   %182 = load i8*, i8** %arg1
   %183 = getelementptr inbounds i8, i8* %182, i64 8
   %184 = bitcast i8* %183 to i16*
-  %NullCheck60 = icmp ne i16* %184, null
-  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+  %NullCheck59 = icmp eq i16* %184, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %185
 
 ; <label>:185                                     ; preds = %179
   %186 = load i16, i16* %184, align 8
   %187 = sext i16 %186 to i32
   %188 = bitcast i8* %181 to i16*
   %189 = trunc i32 %187 to i16
-  %NullCheck62 = icmp ne i16* %188, null
-  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+  %NullCheck61 = icmp eq i16* %188, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %190
 
 ; <label>:190                                     ; preds = %185
   store i16 %189, i16* %188, align 8
@@ -1017,15 +1099,15 @@ entry:
   %192 = getelementptr inbounds i8, i8* %191, i64 10
   %193 = load i8*, i8** %arg1
   %194 = getelementptr inbounds i8, i8* %193, i64 10
-  %NullCheck64 = icmp ne i8* %194, null
-  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+  %NullCheck63 = icmp eq i8* %194, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %195
 
 ; <label>:195                                     ; preds = %190
   %196 = load i8, i8* %194, align 8
   %197 = zext i8 %196 to i32
   %198 = trunc i32 %197 to i8
-  %NullCheck66 = icmp ne i8* %192, null
-  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+  %NullCheck65 = icmp eq i8* %192, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %199
 
 ; <label>:199                                     ; preds = %195
   store i8 %198, i8* %192, align 8
@@ -1035,14 +1117,14 @@ entry:
   %201 = load i8*, i8** %arg0
   %202 = load i8*, i8** %arg1
   %203 = bitcast i8* %202 to i64*
-  %NullCheck48 = icmp ne i64* %203, null
-  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+  %NullCheck47 = icmp eq i64* %203, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %204
 
 ; <label>:204                                     ; preds = %200
   %205 = load i64, i64* %203, align 8
   %206 = bitcast i8* %201 to i64*
-  %NullCheck50 = icmp ne i64* %206, null
-  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+  %NullCheck49 = icmp eq i64* %206, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %207
 
 ; <label>:207                                     ; preds = %204
   store i64 %205, i64* %206, align 8
@@ -1051,14 +1133,14 @@ entry:
   %210 = load i8*, i8** %arg1
   %211 = getelementptr inbounds i8, i8* %210, i64 8
   %212 = bitcast i8* %211 to i32*
-  %NullCheck52 = icmp ne i32* %212, null
-  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+  %NullCheck51 = icmp eq i32* %212, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %213
 
 ; <label>:213                                     ; preds = %207
   %214 = load i32, i32* %212, align 8
   %215 = bitcast i8* %209 to i32*
-  %NullCheck54 = icmp ne i32* %215, null
-  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+  %NullCheck53 = icmp eq i32* %215, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %216
 
 ; <label>:216                                     ; preds = %213
   store i32 %214, i32* %215, align 8
@@ -1068,14 +1150,14 @@ entry:
   %218 = load i8*, i8** %arg0
   %219 = load i8*, i8** %arg1
   %220 = bitcast i8* %219 to i64*
-  %NullCheck36 = icmp ne i64* %220, null
-  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64* %220, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %221
 
 ; <label>:221                                     ; preds = %217
   %222 = load i64, i64* %220, align 8
   %223 = bitcast i8* %218 to i64*
-  %NullCheck38 = icmp ne i64* %223, null
-  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+  %NullCheck37 = icmp eq i64* %223, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %224
 
 ; <label>:224                                     ; preds = %221
   store i64 %222, i64* %223, align 8
@@ -1084,14 +1166,14 @@ entry:
   %227 = load i8*, i8** %arg1
   %228 = getelementptr inbounds i8, i8* %227, i64 8
   %229 = bitcast i8* %228 to i32*
-  %NullCheck40 = icmp ne i32* %229, null
-  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i32* %229, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %230
 
 ; <label>:230                                     ; preds = %224
   %231 = load i32, i32* %229, align 8
   %232 = bitcast i8* %226 to i32*
-  %NullCheck42 = icmp ne i32* %232, null
-  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+  %NullCheck41 = icmp eq i32* %232, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %233
 
 ; <label>:233                                     ; preds = %230
   store i32 %231, i32* %232, align 8
@@ -1099,15 +1181,15 @@ entry:
   %235 = getelementptr inbounds i8, i8* %234, i64 12
   %236 = load i8*, i8** %arg1
   %237 = getelementptr inbounds i8, i8* %236, i64 12
-  %NullCheck44 = icmp ne i8* %237, null
-  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i8* %237, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %238
 
 ; <label>:238                                     ; preds = %233
   %239 = load i8, i8* %237, align 8
   %240 = zext i8 %239 to i32
   %241 = trunc i32 %240 to i8
-  %NullCheck46 = icmp ne i8* %235, null
-  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+  %NullCheck45 = icmp eq i8* %235, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %242
 
 ; <label>:242                                     ; preds = %238
   store i8 %241, i8* %235, align 8
@@ -1117,14 +1199,14 @@ entry:
   %244 = load i8*, i8** %arg0
   %245 = load i8*, i8** %arg1
   %246 = bitcast i8* %245 to i64*
-  %NullCheck24 = icmp ne i64* %246, null
-  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64* %246, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %247
 
 ; <label>:247                                     ; preds = %243
   %248 = load i64, i64* %246, align 8
   %249 = bitcast i8* %244 to i64*
-  %NullCheck26 = icmp ne i64* %249, null
-  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64* %249, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %250
 
 ; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
@@ -1133,14 +1215,14 @@ entry:
   %253 = load i8*, i8** %arg1
   %254 = getelementptr inbounds i8, i8* %253, i64 8
   %255 = bitcast i8* %254 to i32*
-  %NullCheck28 = icmp ne i32* %255, null
-  br i1 %NullCheck28, label %256, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i32* %255, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %256
 
 ; <label>:256                                     ; preds = %250
   %257 = load i32, i32* %255, align 8
   %258 = bitcast i8* %252 to i32*
-  %NullCheck30 = icmp ne i32* %258, null
-  br i1 %NullCheck30, label %259, label %ThrowNullRef29
+  %NullCheck29 = icmp eq i32* %258, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %259
 
 ; <label>:259                                     ; preds = %256
   store i32 %257, i32* %258, align 8
@@ -1149,16 +1231,16 @@ entry:
   %262 = load i8*, i8** %arg1
   %263 = getelementptr inbounds i8, i8* %262, i64 12
   %264 = bitcast i8* %263 to i16*
-  %NullCheck32 = icmp ne i16* %264, null
-  br i1 %NullCheck32, label %265, label %ThrowNullRef31
+  %NullCheck31 = icmp eq i16* %264, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %265
 
 ; <label>:265                                     ; preds = %259
   %266 = load i16, i16* %264, align 8
   %267 = sext i16 %266 to i32
   %268 = bitcast i8* %261 to i16*
   %269 = trunc i32 %267 to i16
-  %NullCheck34 = icmp ne i16* %268, null
-  br i1 %NullCheck34, label %270, label %ThrowNullRef33
+  %NullCheck33 = icmp eq i16* %268, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %270
 
 ; <label>:270                                     ; preds = %265
   store i16 %269, i16* %268, align 8
@@ -1168,14 +1250,14 @@ entry:
   %272 = load i8*, i8** %arg0
   %273 = load i8*, i8** %arg1
   %274 = bitcast i8* %273 to i64*
-  %NullCheck8 = icmp ne i64* %274, null
-  br i1 %NullCheck8, label %275, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64* %274, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %275
 
 ; <label>:275                                     ; preds = %271
   %276 = load i64, i64* %274, align 8
   %277 = bitcast i8* %272 to i64*
-  %NullCheck10 = icmp ne i64* %277, null
-  br i1 %NullCheck10, label %278, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %277, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %278
 
 ; <label>:278                                     ; preds = %275
   store i64 %276, i64* %277, align 8
@@ -1184,14 +1266,14 @@ entry:
   %281 = load i8*, i8** %arg1
   %282 = getelementptr inbounds i8, i8* %281, i64 8
   %283 = bitcast i8* %282 to i32*
-  %NullCheck12 = icmp ne i32* %283, null
-  br i1 %NullCheck12, label %284, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i32* %283, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %284
 
 ; <label>:284                                     ; preds = %278
   %285 = load i32, i32* %283, align 8
   %286 = bitcast i8* %280 to i32*
-  %NullCheck14 = icmp ne i32* %286, null
-  br i1 %NullCheck14, label %287, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i32* %286, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %287
 
 ; <label>:287                                     ; preds = %284
   store i32 %285, i32* %286, align 8
@@ -1200,16 +1282,16 @@ entry:
   %290 = load i8*, i8** %arg1
   %291 = getelementptr inbounds i8, i8* %290, i64 12
   %292 = bitcast i8* %291 to i16*
-  %NullCheck16 = icmp ne i16* %292, null
-  br i1 %NullCheck16, label %293, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i16* %292, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %293
 
 ; <label>:293                                     ; preds = %287
   %294 = load i16, i16* %292, align 8
   %295 = sext i16 %294 to i32
   %296 = bitcast i8* %289 to i16*
   %297 = trunc i32 %295 to i16
-  %NullCheck18 = icmp ne i16* %296, null
-  br i1 %NullCheck18, label %298, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i16* %296, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %298
 
 ; <label>:298                                     ; preds = %293
   store i16 %297, i16* %296, align 8
@@ -1217,15 +1299,15 @@ entry:
   %300 = getelementptr inbounds i8, i8* %299, i64 14
   %301 = load i8*, i8** %arg1
   %302 = getelementptr inbounds i8, i8* %301, i64 14
-  %NullCheck20 = icmp ne i8* %302, null
-  br i1 %NullCheck20, label %303, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i8* %302, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %303
 
 ; <label>:303                                     ; preds = %298
   %304 = load i8, i8* %302, align 8
   %305 = zext i8 %304 to i32
   %306 = trunc i32 %305 to i8
-  %NullCheck22 = icmp ne i8* %300, null
-  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i8* %300, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %307
 
 ; <label>:307                                     ; preds = %303
   store i8 %306, i8* %300, align 8
@@ -1235,14 +1317,14 @@ entry:
   %309 = load i8*, i8** %arg0
   %310 = load i8*, i8** %arg1
   %311 = bitcast i8* %310 to i64*
-  %NullCheck = icmp ne i64* %311, null
-  br i1 %NullCheck, label %312, label %ThrowNullRef
+  %NullCheck = icmp eq i64* %311, null
+  br i1 %NullCheck, label %ThrowNullRef, label %312
 
 ; <label>:312                                     ; preds = %308
   %313 = load i64, i64* %311, align 8
   %314 = bitcast i8* %309 to i64*
-  %NullCheck2 = icmp ne i64* %314, null
-  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64* %314, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %315
 
 ; <label>:315                                     ; preds = %312
   store i64 %313, i64* %314, align 8
@@ -1251,14 +1333,14 @@ entry:
   %318 = load i8*, i8** %arg1
   %319 = getelementptr inbounds i8, i8* %318, i64 8
   %320 = bitcast i8* %319 to i64*
-  %NullCheck4 = icmp ne i64* %320, null
-  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64* %320, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %321
 
 ; <label>:321                                     ; preds = %315
   %322 = load i64, i64* %320, align 8
   %323 = bitcast i8* %317 to i64*
-  %NullCheck6 = icmp ne i64* %323, null
-  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64* %323, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %324
 
 ; <label>:324                                     ; preds = %321
   store i64 %322, i64* %323, align 8
@@ -1286,15 +1368,15 @@ entry:
 ; <label>:338                                     ; preds = %333
   %339 = load i8*, i8** %arg0
   %340 = load i8*, i8** %arg1
-  %NullCheck136 = icmp ne i8* %340, null
-  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+  %NullCheck135 = icmp eq i8* %340, null
+  br i1 %NullCheck135, label %ThrowNullRef136, label %341
 
 ; <label>:341                                     ; preds = %338
   %342 = load i8, i8* %340, align 8
   %343 = zext i8 %342 to i32
   %344 = trunc i32 %343 to i8
-  %NullCheck138 = icmp ne i8* %339, null
-  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+  %NullCheck137 = icmp eq i8* %339, null
+  br i1 %NullCheck137, label %ThrowNullRef138, label %345
 
 ; <label>:345                                     ; preds = %341
   store i8 %344, i8* %339, align 8
@@ -1317,16 +1399,16 @@ entry:
   %357 = load i8*, i8** %arg0
   %358 = load i8*, i8** %arg1
   %359 = bitcast i8* %358 to i16*
-  %NullCheck140 = icmp ne i16* %359, null
-  br i1 %NullCheck140, label %360, label %ThrowNullRef139
+  %NullCheck139 = icmp eq i16* %359, null
+  br i1 %NullCheck139, label %ThrowNullRef140, label %360
 
 ; <label>:360                                     ; preds = %356
   %361 = load i16, i16* %359, align 8
   %362 = sext i16 %361 to i32
   %363 = bitcast i8* %357 to i16*
   %364 = trunc i32 %362 to i16
-  %NullCheck142 = icmp ne i16* %363, null
-  br i1 %NullCheck142, label %365, label %ThrowNullRef141
+  %NullCheck141 = icmp eq i16* %363, null
+  br i1 %NullCheck141, label %ThrowNullRef142, label %365
 
 ; <label>:365                                     ; preds = %360
   store i16 %364, i16* %363, align 8
@@ -1352,14 +1434,14 @@ entry:
   %378 = load i8*, i8** %arg0
   %379 = load i8*, i8** %arg1
   %380 = bitcast i8* %379 to i32*
-  %NullCheck144 = icmp ne i32* %380, null
-  br i1 %NullCheck144, label %381, label %ThrowNullRef143
+  %NullCheck143 = icmp eq i32* %380, null
+  br i1 %NullCheck143, label %ThrowNullRef144, label %381
 
 ; <label>:381                                     ; preds = %377
   %382 = load i32, i32* %380, align 8
   %383 = bitcast i8* %378 to i32*
-  %NullCheck146 = icmp ne i32* %383, null
-  br i1 %NullCheck146, label %384, label %ThrowNullRef145
+  %NullCheck145 = icmp eq i32* %383, null
+  br i1 %NullCheck145, label %ThrowNullRef146, label %384
 
 ; <label>:384                                     ; preds = %381
   store i32 %382, i32* %383, align 8
@@ -1384,14 +1466,14 @@ entry:
   %395 = load i8*, i8** %arg0
   %396 = load i8*, i8** %arg1
   %397 = bitcast i8* %396 to i64*
-  %NullCheck164 = icmp ne i64* %397, null
-  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+  %NullCheck163 = icmp eq i64* %397, null
+  br i1 %NullCheck163, label %ThrowNullRef164, label %398
 
 ; <label>:398                                     ; preds = %394
   %399 = load i64, i64* %397, align 8
   %400 = bitcast i8* %395 to i64*
-  %NullCheck166 = icmp ne i64* %400, null
-  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+  %NullCheck165 = icmp eq i64* %400, null
+  br i1 %NullCheck165, label %ThrowNullRef166, label %401
 
 ; <label>:401                                     ; preds = %398
   store i64 %399, i64* %400, align 8
@@ -1400,14 +1482,14 @@ entry:
   %404 = load i8*, i8** %arg1
   %405 = getelementptr inbounds i8, i8* %404, i64 8
   %406 = bitcast i8* %405 to i64*
-  %NullCheck168 = icmp ne i64* %406, null
-  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+  %NullCheck167 = icmp eq i64* %406, null
+  br i1 %NullCheck167, label %ThrowNullRef168, label %407
 
 ; <label>:407                                     ; preds = %401
   %408 = load i64, i64* %406, align 8
   %409 = bitcast i8* %403 to i64*
-  %NullCheck170 = icmp ne i64* %409, null
-  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+  %NullCheck169 = icmp eq i64* %409, null
+  br i1 %NullCheck169, label %ThrowNullRef170, label %410
 
 ; <label>:410                                     ; preds = %407
   store i64 %408, i64* %409, align 8
@@ -1437,14 +1519,14 @@ entry:
   %425 = load i8*, i8** %arg0
   %426 = load i8*, i8** %arg1
   %427 = bitcast i8* %426 to i64*
-  %NullCheck148 = icmp ne i64* %427, null
-  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+  %NullCheck147 = icmp eq i64* %427, null
+  br i1 %NullCheck147, label %ThrowNullRef148, label %428
 
 ; <label>:428                                     ; preds = %424
   %429 = load i64, i64* %427, align 8
   %430 = bitcast i8* %425 to i64*
-  %NullCheck150 = icmp ne i64* %430, null
-  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+  %NullCheck149 = icmp eq i64* %430, null
+  br i1 %NullCheck149, label %ThrowNullRef150, label %431
 
 ; <label>:431                                     ; preds = %428
   store i64 %429, i64* %430, align 8
@@ -1466,14 +1548,14 @@ entry:
   %441 = load i8*, i8** %arg0
   %442 = load i8*, i8** %arg1
   %443 = bitcast i8* %442 to i32*
-  %NullCheck152 = icmp ne i32* %443, null
-  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+  %NullCheck151 = icmp eq i32* %443, null
+  br i1 %NullCheck151, label %ThrowNullRef152, label %444
 
 ; <label>:444                                     ; preds = %440
   %445 = load i32, i32* %443, align 8
   %446 = bitcast i8* %441 to i32*
-  %NullCheck154 = icmp ne i32* %446, null
-  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+  %NullCheck153 = icmp eq i32* %446, null
+  br i1 %NullCheck153, label %ThrowNullRef154, label %447
 
 ; <label>:447                                     ; preds = %444
   store i32 %445, i32* %446, align 8
@@ -1495,16 +1577,16 @@ entry:
   %457 = load i8*, i8** %arg0
   %458 = load i8*, i8** %arg1
   %459 = bitcast i8* %458 to i16*
-  %NullCheck156 = icmp ne i16* %459, null
-  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+  %NullCheck155 = icmp eq i16* %459, null
+  br i1 %NullCheck155, label %ThrowNullRef156, label %460
 
 ; <label>:460                                     ; preds = %456
   %461 = load i16, i16* %459, align 8
   %462 = sext i16 %461 to i32
   %463 = bitcast i8* %457 to i16*
   %464 = trunc i32 %462 to i16
-  %NullCheck158 = icmp ne i16* %463, null
-  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+  %NullCheck157 = icmp eq i16* %463, null
+  br i1 %NullCheck157, label %ThrowNullRef158, label %465
 
 ; <label>:465                                     ; preds = %460
   store i16 %464, i16* %463, align 8
@@ -1525,15 +1607,15 @@ entry:
 ; <label>:474                                     ; preds = %470
   %475 = load i8*, i8** %arg0
   %476 = load i8*, i8** %arg1
-  %NullCheck160 = icmp ne i8* %476, null
-  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+  %NullCheck159 = icmp eq i8* %476, null
+  br i1 %NullCheck159, label %ThrowNullRef160, label %477
 
 ; <label>:477                                     ; preds = %474
   %478 = load i8, i8* %476, align 8
   %479 = zext i8 %478 to i32
   %480 = trunc i32 %479 to i8
-  %NullCheck162 = icmp ne i8* %475, null
-  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+  %NullCheck161 = icmp eq i8* %475, null
+  br i1 %NullCheck161, label %ThrowNullRef162, label %481
 
 ; <label>:481                                     ; preds = %477
   store i8 %480, i8* %475, align 8
@@ -1553,343 +1635,343 @@ ThrowNullRef:                                     ; preds = %308
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %312
+ThrowNullRef2:                                    ; preds = %312
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %315
+ThrowNullRef4:                                    ; preds = %315
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %321
+ThrowNullRef6:                                    ; preds = %321
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %271
+ThrowNullRef8:                                    ; preds = %271
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %275
+ThrowNullRef10:                                   ; preds = %275
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %278
+ThrowNullRef12:                                   ; preds = %278
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %284
+ThrowNullRef14:                                   ; preds = %284
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %287
+ThrowNullRef16:                                   ; preds = %287
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %293
+ThrowNullRef18:                                   ; preds = %293
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %298
+ThrowNullRef20:                                   ; preds = %298
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %303
+ThrowNullRef22:                                   ; preds = %303
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %243
+ThrowNullRef24:                                   ; preds = %243
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %247
+ThrowNullRef26:                                   ; preds = %247
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %250
+ThrowNullRef28:                                   ; preds = %250
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %256
+ThrowNullRef30:                                   ; preds = %256
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %259
+ThrowNullRef32:                                   ; preds = %259
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %265
+ThrowNullRef34:                                   ; preds = %265
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %217
+ThrowNullRef36:                                   ; preds = %217
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %221
+ThrowNullRef38:                                   ; preds = %221
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %224
+ThrowNullRef40:                                   ; preds = %224
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %230
+ThrowNullRef42:                                   ; preds = %230
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %233
+ThrowNullRef44:                                   ; preds = %233
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %238
+ThrowNullRef46:                                   ; preds = %238
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %200
+ThrowNullRef48:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %204
+ThrowNullRef50:                                   ; preds = %204
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %207
+ThrowNullRef52:                                   ; preds = %207
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %213
+ThrowNullRef54:                                   ; preds = %213
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %172
+ThrowNullRef56:                                   ; preds = %172
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %176
+ThrowNullRef58:                                   ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %179
+ThrowNullRef60:                                   ; preds = %179
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %185
+ThrowNullRef62:                                   ; preds = %185
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %190
+ThrowNullRef64:                                   ; preds = %190
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %195
+ThrowNullRef66:                                   ; preds = %195
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %153
+ThrowNullRef68:                                   ; preds = %153
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %157
+ThrowNullRef70:                                   ; preds = %157
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %160
+ThrowNullRef72:                                   ; preds = %160
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %166
+ThrowNullRef74:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %136
+ThrowNullRef76:                                   ; preds = %136
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %140
+ThrowNullRef78:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %143
+ThrowNullRef80:                                   ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %148
+ThrowNullRef82:                                   ; preds = %148
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %128
+ThrowNullRef84:                                   ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %132
+ThrowNullRef86:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %100
+ThrowNullRef88:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %104
+ThrowNullRef90:                                   ; preds = %104
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %107
+ThrowNullRef92:                                   ; preds = %107
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %113
+ThrowNullRef94:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %118
+ThrowNullRef96:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %123
+ThrowNullRef98:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %81
+ThrowNullRef100:                                  ; preds = %81
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef101:                                  ; preds = %85
+ThrowNullRef102:                                  ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef103:                                  ; preds = %88
+ThrowNullRef104:                                  ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef105:                                  ; preds = %94
+ThrowNullRef106:                                  ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef107:                                  ; preds = %64
+ThrowNullRef108:                                  ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef109:                                  ; preds = %68
+ThrowNullRef110:                                  ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef111:                                  ; preds = %71
+ThrowNullRef112:                                  ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef113:                                  ; preds = %76
+ThrowNullRef114:                                  ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef115:                                  ; preds = %56
+ThrowNullRef116:                                  ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef117:                                  ; preds = %60
+ThrowNullRef118:                                  ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef119:                                  ; preds = %37
+ThrowNullRef120:                                  ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef121:                                  ; preds = %41
+ThrowNullRef122:                                  ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef123:                                  ; preds = %46
+ThrowNullRef124:                                  ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef125:                                  ; preds = %51
+ThrowNullRef126:                                  ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef127:                                  ; preds = %27
+ThrowNullRef128:                                  ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef129:                                  ; preds = %31
+ThrowNullRef130:                                  ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef131:                                  ; preds = %19
+ThrowNullRef132:                                  ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef133:                                  ; preds = %22
+ThrowNullRef134:                                  ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef135:                                  ; preds = %338
+ThrowNullRef136:                                  ; preds = %338
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef137:                                  ; preds = %341
+ThrowNullRef138:                                  ; preds = %341
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef139:                                  ; preds = %356
+ThrowNullRef140:                                  ; preds = %356
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef141:                                  ; preds = %360
+ThrowNullRef142:                                  ; preds = %360
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef143:                                  ; preds = %377
+ThrowNullRef144:                                  ; preds = %377
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef145:                                  ; preds = %381
+ThrowNullRef146:                                  ; preds = %381
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef147:                                  ; preds = %424
+ThrowNullRef148:                                  ; preds = %424
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef149:                                  ; preds = %428
+ThrowNullRef150:                                  ; preds = %428
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef151:                                  ; preds = %440
+ThrowNullRef152:                                  ; preds = %440
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef153:                                  ; preds = %444
+ThrowNullRef154:                                  ; preds = %444
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef155:                                  ; preds = %456
+ThrowNullRef156:                                  ; preds = %456
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef157:                                  ; preds = %460
+ThrowNullRef158:                                  ; preds = %460
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef159:                                  ; preds = %474
+ThrowNullRef160:                                  ; preds = %474
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef161:                                  ; preds = %477
+ThrowNullRef162:                                  ; preds = %477
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef163:                                  ; preds = %394
+ThrowNullRef164:                                  ; preds = %394
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef165:                                  ; preds = %398
+ThrowNullRef166:                                  ; preds = %398
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef167:                                  ; preds = %401
+ThrowNullRef168:                                  ; preds = %401
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef169:                                  ; preds = %407
+ThrowNullRef170:                                  ; preds = %407
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1939,8 +2021,8 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
-  br i1 %NullCheck, label %22, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %ThrowNullRef, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
@@ -1948,8 +2030,8 @@ entry:
   store i32 %24, i32* %loc0
   %25 = load i32, i32* %loc0
   %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %26, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %27
 
 ; <label>:27                                      ; preds = %22
   %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
@@ -1971,7 +2053,7 @@ ThrowNullRef:                                     ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1989,8 +2071,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -2022,15 +2104,15 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2048,16 +2130,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
   %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
   store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %15
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
@@ -2072,8 +2154,8 @@ entry:
   %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
   %29 = ptrtoint i16 addrspace(1)* %28 to i64
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %19
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
@@ -2089,19 +2171,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2114,8 +2196,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
@@ -2128,7 +2210,7 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[loadElem]
+Failed to read AppDomain.PrepareDataForSetup[storeElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
@@ -2202,8 +2284,8 @@ entry:
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
-  br i1 %NullCheck24, label %27, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = load i64, i64 addrspace(1)* %26
@@ -2218,8 +2300,8 @@ entry:
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
-  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
   %41 = load i64, i64 addrspace(1)* %39
@@ -2236,8 +2318,8 @@ entry:
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
-  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
   %54 = load i64, i64 addrspace(1)* %52
@@ -2252,8 +2334,8 @@ entry:
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
   %67 = load i64, i64 addrspace(1)* %65
@@ -2270,8 +2352,8 @@ entry:
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
-  br i1 %NullCheck16, label %79, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
   %80 = load i64, i64 addrspace(1)* %78
@@ -2286,8 +2368,8 @@ entry:
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
-  br i1 %NullCheck18, label %92, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
   %93 = load i64, i64 addrspace(1)* %91
@@ -2304,8 +2386,8 @@ entry:
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
-  br i1 %NullCheck12, label %105, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = load i64, i64 addrspace(1)* %104
@@ -2320,8 +2402,8 @@ entry:
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
-  br i1 %NullCheck14, label %118, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
   %119 = load i64, i64 addrspace(1)* %117
@@ -2337,8 +2419,8 @@ entry:
 
 ; <label>:128                                     ; preds = %20
   %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
-  br i1 %NullCheck4, label %130, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %129, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %130
 
 ; <label>:130                                     ; preds = %128
   %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
@@ -2346,8 +2428,8 @@ entry:
   %133 = load i16, i16 addrspace(1)* %132, align 8
   %134 = zext i16 %133 to i32
   %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
-  br i1 %NullCheck6, label %136, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %135, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %136
 
 ; <label>:136                                     ; preds = %130
   %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
@@ -2360,8 +2442,8 @@ entry:
 
 ; <label>:143                                     ; preds = %136
   %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
-  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %144, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %145
 
 ; <label>:145                                     ; preds = %143
   %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
@@ -2369,8 +2451,8 @@ entry:
   %148 = load i16, i16 addrspace(1)* %147, align 8
   %149 = zext i16 %148 to i32
   %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %150, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %151
 
 ; <label>:151                                     ; preds = %145
   %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
@@ -2388,8 +2470,8 @@ entry:
 
 ; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
-  br i1 %NullCheck, label %163, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %ThrowNullRef, label %163
 
 ; <label>:163                                     ; preds = %161
   %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
@@ -2399,8 +2481,8 @@ entry:
 
 ; <label>:167                                     ; preds = %163
   %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
-  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %168, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %169
 
 ; <label>:169                                     ; preds = %167
   %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
@@ -2432,55 +2514,55 @@ ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %167
+ThrowNullRef2:                                    ; preds = %167
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %128
+ThrowNullRef4:                                    ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %130
+ThrowNullRef6:                                    ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %143
+ThrowNullRef8:                                    ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %145
+ThrowNullRef10:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %102
+ThrowNullRef12:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %105
+ThrowNullRef14:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %76
+ThrowNullRef16:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %79
+ThrowNullRef18:                                   ; preds = %79
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %50
+ThrowNullRef20:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %53
+ThrowNullRef22:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %24
+ThrowNullRef24:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %27
+ThrowNullRef26:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2503,15 +2585,15 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2519,16 +2601,16 @@ entry:
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
   store i32 %8, i32* %loc0
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
   %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
   store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
@@ -2546,16 +2628,16 @@ entry:
 
 ; <label>:23                                      ; preds = %64
   %24 = load i16*, i16** %loc3
-  %NullCheck12 = icmp ne i16* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i16* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
   store i32 %27, i32* %loc5
   %28 = load i16*, i16** %loc4
-  %NullCheck14 = icmp ne i16* %28, null
-  br i1 %NullCheck14, label %29, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %28, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = load i16, i16* %28, align 8
@@ -2620,15 +2702,15 @@ entry:
 
 ; <label>:67                                      ; preds = %64
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
-  br i1 %NullCheck8, label %69, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %68, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %69
 
 ; <label>:69                                      ; preds = %67
   %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
   %71 = load i32, i32 addrspace(1)* %70
   %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
-  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %73
 
 ; <label>:73                                      ; preds = %69
   %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
@@ -2645,31 +2727,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %67
+ThrowNullRef8:                                    ; preds = %67
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %69
+ThrowNullRef10:                                   ; preds = %69
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2710,14 +2792,14 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
   %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
@@ -2730,14 +2812,14 @@ entry:
 
 ; <label>:11                                      ; preds = %4
   %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
   %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
@@ -2749,14 +2831,14 @@ entry:
 
 ; <label>:22                                      ; preds = %16
   %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
   %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
-  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
-  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
@@ -2804,23 +2886,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2836,7 +2918,280 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[loadElem]
+Successfully read RuntimeType.IsAssignableFrom
+
+define i8 @RuntimeType.IsAssignableFrom(%System.RuntimeType addrspace(1)* %param0, %System.Type addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.RuntimeType addrspace(1)*
+  %arg1 = alloca %System.Type addrspace(1)*
+  %loc0 = alloca %System.RuntimeType addrspace(1)*
+  %loc1 = alloca %"System.Type[]" addrspace(1)*
+  %loc2 = alloca i32
+  store %System.RuntimeType addrspace(1)* %param0, %System.RuntimeType addrspace(1)** %this
+  store %System.Type addrspace(1)* %param1, %System.Type addrspace(1)** %arg1
+  %0 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %1 = icmp ne %System.Type addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i8 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %5 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %6 = bitcast %System.Type addrspace(1)* %4 to %System.Object addrspace(1)*
+  %7 = bitcast %System.RuntimeType addrspace(1)* %5 to %System.Object addrspace(1)*
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %6, %System.Object addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %3
+  ret i8 1
+
+; <label>:12                                      ; preds = %3
+  %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 152
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 32
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
+  %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
+  %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
+  store %System.RuntimeType addrspace(1)* %25, %System.RuntimeType addrspace(1)** %loc0
+  %26 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %27 = icmp eq %System.RuntimeType addrspace(1)* %26, null
+  br i1 %27, label %34, label %28
+
+; <label>:28                                      ; preds = %15
+  %29 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %30 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)*)*)(%System.RuntimeType addrspace(1)* %29, %System.RuntimeType addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+; <label>:34                                      ; preds = %15
+  %35 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %36 = call %System.Reflection.Emit.TypeBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Reflection.Emit.TypeBuilder addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %35)
+  %37 = icmp eq %System.Reflection.Emit.TypeBuilder addrspace(1)* %36, null
+  br i1 %37, label %139, label %38
+
+; <label>:38                                      ; preds = %34
+  %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %42
+
+; <label>:42                                      ; preds = %38
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 152
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 40
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
+  %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
+  %53 = zext i8 %52 to i32
+  %54 = icmp eq i32 %53, 0
+  br i1 %54, label %56, label %55
+
+; <label>:55                                      ; preds = %42
+  ret i8 1
+
+; <label>:56                                      ; preds = %42
+  %57 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %58 = bitcast %System.RuntimeType addrspace(1)* %57 to %System.Type addrspace(1)*
+  %59 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %58)
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %64 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.Type addrspace(1)* %63, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = bitcast %System.RuntimeType addrspace(1)* %64 to %System.Type addrspace(1)*
+  %67 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %63, %System.Type addrspace(1)* %66)
+  %68 = zext i8 %67 to i32
+  %69 = trunc i32 %68 to i8
+  ret i8 %69
+
+; <label>:70                                      ; preds = %56
+  %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
+  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %73
+
+; <label>:73                                      ; preds = %70
+  %74 = load i64, i64 addrspace(1)* %72
+  %75 = add i64 %74, 128
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = add i64 %77, 0
+  %79 = inttoptr i64 %78 to i64*
+  %80 = load i64, i64* %79
+  %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
+  %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
+  %83 = call i8 %82(%System.Type addrspace(1)* %81)
+  %84 = zext i8 %83 to i32
+  %85 = icmp eq i32 %84, 0
+  br i1 %85, label %139, label %86
+
+; <label>:86                                      ; preds = %73
+  %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
+  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %89
+
+; <label>:89                                      ; preds = %86
+  %90 = load i64, i64 addrspace(1)* %88
+  %91 = add i64 %90, 128
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = add i64 %93, 24
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
+  %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
+  %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
+  store %"System.Type[]" addrspace(1)* %99, %"System.Type[]" addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %129
+
+; <label>:100                                     ; preds = %132
+  %101 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %102 = load i32, i32* %loc2
+  %NullCheck11 = icmp eq %"System.Type[]" addrspace(1)* %101, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %103
+
+; <label>:103                                     ; preds = %100
+  %104 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 1
+  %105 = load i32, i32 addrspace(1)* %104
+  %106 = zext i32 %105 to i64
+  %107 = zext i32 %102 to i64
+  %BoundsCheck = icmp uge i64 %107, %106
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %108
+
+; <label>:108                                     ; preds = %103
+  %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
+  %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
+  %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
+  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %113
+
+; <label>:113                                     ; preds = %108
+  %114 = load i64, i64 addrspace(1)* %112
+  %115 = add i64 %114, 152
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = add i64 %117, 56
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
+  %123 = zext i8 %122 to i32
+  %124 = icmp ne i32 %123, 0
+  br i1 %124, label %126, label %125
+
+; <label>:125                                     ; preds = %113
+  ret i8 0
+
+; <label>:126                                     ; preds = %113
+  %127 = load i32, i32* %loc2
+  %128 = add i32 %127, 1
+  store i32 %128, i32* %loc2
+  br label %129
+
+; <label>:129                                     ; preds = %89, %126
+  %130 = load i32, i32* %loc2
+  %131 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %NullCheck9 = icmp eq %"System.Type[]" addrspace(1)* %131, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %132
+
+; <label>:132                                     ; preds = %129
+  %133 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %131, i32 0, i32 1
+  %134 = load i32, i32 addrspace(1)* %133
+  %135 = zext i32 %134 to i64
+  %136 = trunc i64 %135 to i32
+  %137 = icmp slt i32 %130, %136
+  br i1 %137, label %100, label %138
+
+; <label>:138                                     ; preds = %132
+  ret i8 1
+
+; <label>:139                                     ; preds = %34, %73
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %129
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %103
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -2893,7 +3248,7 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElem]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -2904,8 +3259,8 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -2997,8 +3352,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
@@ -3059,8 +3414,8 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -3087,8 +3442,8 @@ entry:
 
 ; <label>:17                                      ; preds = %5, %11
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
@@ -3097,8 +3452,8 @@ entry:
 
 ; <label>:22                                      ; preds = %1, %11
   %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
@@ -3109,11 +3464,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %17
+ThrowNullRef2:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %22
+ThrowNullRef4:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3167,15 +3522,15 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
   %15 = load i32, i32 addrspace(1)* %14
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
@@ -3198,7 +3553,7 @@ ThrowNullRef:                                     ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef2:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3232,8 +3587,8 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
@@ -3312,8 +3667,8 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -3327,8 +3682,8 @@ entry:
 ; <label>:5                                       ; preds = %43
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %7 = load i32, i32* %loc1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck6, label %8, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
@@ -3366,8 +3721,8 @@ entry:
 ; <label>:32                                      ; preds = %21, %25
   %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
   %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
-  br i1 %NullCheck8, label %35, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = trunc i32 %34 to i16
@@ -3380,8 +3735,8 @@ entry:
 ; <label>:40                                      ; preds = %1, %35
   %41 = load i32, i32* %loc1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
-  br i1 %NullCheck2, label %43, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %42, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
@@ -3392,8 +3747,8 @@ entry:
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
   %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
-  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
   %51 = load i64, i64 addrspace(1)* %49
@@ -3412,19 +3767,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %40
+ThrowNullRef2:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %47
+ThrowNullRef4:                                    ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %5
+ThrowNullRef6:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %32
+ThrowNullRef8:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3467,8 +3822,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
@@ -3492,11 +3847,391 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(i16* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store i16* %param0, i16** %arg0
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load i32, i32* %arg3
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %42, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %37, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg2
+  %13 = load i32, i32* %arg3
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %37, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %24 = load i32, i32* %arg2
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load i16*, i16** %arg0
+  %35 = load i32, i32* %arg3
+  %36 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %36, i16* %34, i32 %35)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:37                                      ; preds = %5, %16
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %39)
+  %41 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41, %System.String addrspace(1)* %38, %System.String addrspace(1)* %40)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41) #0
+  unreachable
+
+; <label>:42                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
-Failed to read StringBuilder.ToString[loadElemA]
+Successfully read StringBuilder.ToString
+
+define %System.String addrspace(1)* @StringBuilder.ToString(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i16*
+  %loc3 = alloca %"System.Char[]" addrspace(1)*
+  %loc4 = alloca i32
+  %loc5 = alloca i32
+  %loc6 = alloca i16 addrspace(1)*
+  %loc7 = alloca %System.String addrspace(1)*
+  %loc8 = alloca %"System.Char[]" addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %0)
+  %2 = icmp ne i32 %1, 0
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %4
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %6)
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %7)
+  store %System.String addrspace(1)* %8, %System.String addrspace(1)** %loc0
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.Text.StringBuilder addrspace(1)* %9, %System.Text.StringBuilder addrspace(1)** %loc1
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  store %System.String addrspace(1)* %10, %System.String addrspace(1)** %loc7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc7
+  %12 = ptrtoint %System.String addrspace(1)* %11 to i64
+  %13 = icmp eq i64 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %5
+  %15 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %16 = sext i32 %15 to i64
+  %17 = add i64 %12, %16
+  br label %18
+
+; <label>:18                                      ; preds = %5, %14
+  %19 = phi i64 [ %12, %5 ], [ %17, %14 ]
+  %20 = inttoptr i64 %19 to i16*
+  store i16* %20, i16** %loc2
+  br label %21
+
+; <label>:21                                      ; preds = %98, %18
+  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %22, null
+  br i1 %NullCheck, label %ThrowNullRef, label %23
+
+; <label>:23                                      ; preds = %21
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 3
+  %25 = load i32, i32 addrspace(1)* %24, align 8
+  %26 = icmp sle i32 %25, 0
+  br i1 %26, label %96, label %27
+
+; <label>:27                                      ; preds = %23
+  %28 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %28, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %29
+
+; <label>:29                                      ; preds = %27
+  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %28, i32 0, i32 1
+  %31 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %30, align 8
+  store %"System.Char[]" addrspace(1)* %31, %"System.Char[]" addrspace(1)** %loc3
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %33
+
+; <label>:33                                      ; preds = %29
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  store i32 %35, i32* %loc4
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  %39 = load i32, i32 addrspace(1)* %38, align 8
+  store i32 %39, i32* %loc5
+  %40 = load i32, i32* %loc5
+  %41 = load i32, i32* %loc4
+  %42 = add i32 %40, %41
+  %43 = zext i32 %42 to i64
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %45
+
+; <label>:45                                      ; preds = %37
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = sext i32 %47 to i64
+  %49 = icmp sgt i64 %43, %48
+  br i1 %49, label %91, label %50
+
+; <label>:50                                      ; preds = %45
+  %51 = load i32, i32* %loc5
+  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %52, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %53
+
+; <label>:53                                      ; preds = %50
+  %54 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %52, i32 0, i32 1
+  %55 = load i32, i32 addrspace(1)* %54
+  %56 = zext i32 %55 to i64
+  %57 = trunc i64 %56 to i32
+  %58 = icmp ugt i32 %51, %57
+  br i1 %58, label %91, label %59
+
+; <label>:59                                      ; preds = %53
+  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  store %"System.Char[]" addrspace(1)* %60, %"System.Char[]" addrspace(1)** %loc8
+  %61 = icmp eq %"System.Char[]" addrspace(1)* %60, null
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %63, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %64
+
+; <label>:64                                      ; preds = %62
+  %65 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %63, i32 0, i32 1
+  %66 = load i32, i32 addrspace(1)* %65
+  %67 = zext i32 %66 to i64
+  %68 = trunc i64 %67 to i32
+  %69 = icmp ne i32 %68, 0
+  br i1 %69, label %71, label %70
+
+; <label>:70                                      ; preds = %59, %64
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:71                                      ; preds = %64
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %73
+
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %BoundsCheck = icmp uge i64 0, %76
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %77
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %78, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:79                                      ; preds = %70, %77
+  %80 = load i16*, i16** %loc2
+  %81 = load i32, i32* %loc4
+  %82 = sext i32 %81 to i64
+  %83 = mul i64 %82, 2
+  %84 = bitcast i16* %80 to i8*
+  %85 = getelementptr inbounds i8, i8* %84, i64 %83
+  %86 = load i16 addrspace(1)*, i16 addrspace(1)** %loc6
+  %87 = ptrtoint i16 addrspace(1)* %86 to i64
+  %88 = load i32, i32* %loc5
+  %89 = bitcast i8* %85 to i16*
+  %90 = inttoptr i64 %87 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %89, i16* %90, i32 %88)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %96
+
+; <label>:91                                      ; preds = %45, %53
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %94 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %93)
+  %95 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95, %System.String addrspace(1)* %92, %System.String addrspace(1)* %94)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95) #0
+  unreachable
+
+; <label>:96                                      ; preds = %23, %79
+  %97 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %97, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %98
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %97, i32 0, i32 2
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  store %System.Text.StringBuilder addrspace(1)* %100, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %102 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %102, label %21, label %103
+
+; <label>:103                                     ; preds = %98
+  store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc7
+  %104 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  ret %System.String addrspace(1)* %104
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method StringBuilder::get_Length using LLILCJit
+Successfully read StringBuilder.get_Length
+
+define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
+Successfully read RuntimeHelpers.get_OffsetToStringData
+
+define i32 @RuntimeHelpers.get_OffsetToStringData() {
+entry:
+  ret i32 12
+}
+
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
 Successfully read CultureData.CreateCultureData
 
@@ -3514,23 +4249,23 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
   store i8 %4, i8 addrspace(1)* %6
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
@@ -3549,11 +4284,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3566,50 +4301,50 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
   store i32 -1, i32 addrspace(1)* %2
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
   store i32 -1, i32 addrspace(1)* %8
   %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
   store i32 -1, i32 addrspace(1)* %14
   %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
   store i32 -1, i32 addrspace(1)* %17
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
@@ -3623,27 +4358,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3675,7 +4410,136 @@ Failed to read Dictionary`2.Insert[non-const derefAddress]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
 Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
-Failed to read HashHelpers.GetPrime[loadElem]
+Successfully read HashHelpers.GetPrime
+
+define i32 @HashHelpers.GetPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %6, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5, %System.String addrspace(1)* %4)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5) #0
+  unreachable
+
+; <label>:6                                       ; preds = %entry
+  store i32 0, i32* %loc0
+  br label %29
+
+; <label>:7                                       ; preds = %35
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 1296
+  %10 = addrspacecast i8 addrspace(1)* %9 to %"System.Int32[]" addrspace(1)**
+  %11 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %10
+  %12 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Int32[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = zext i32 %15 to i64
+  %17 = zext i32 %12 to i64
+  %BoundsCheck = icmp uge i64 %17, %16
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 3, i32 %12
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  store i32 %20, i32* %loc1
+  %21 = load i32, i32* %loc1
+  %22 = load i32, i32* %arg0
+  %23 = icmp slt i32 %21, %22
+  br i1 %23, label %26, label %24
+
+; <label>:24                                      ; preds = %18
+  %25 = load i32, i32* %loc1
+  ret i32 %25
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %loc0
+  %28 = add i32 %27, 1
+  store i32 %28, i32* %loc0
+  br label %29
+
+; <label>:29                                      ; preds = %6, %26
+  %30 = load i32, i32* %loc0
+  %31 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %32 = getelementptr inbounds i8, i8 addrspace(1)* %31, i64 1296
+  %33 = addrspacecast i8 addrspace(1)* %32 to %"System.Int32[]" addrspace(1)**
+  %34 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %33
+  %NullCheck = icmp eq %"System.Int32[]" addrspace(1)* %34, null
+  br i1 %NullCheck, label %ThrowNullRef, label %35
+
+; <label>:35                                      ; preds = %29
+  %36 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %34, i32 0, i32 1
+  %37 = load i32, i32 addrspace(1)* %36
+  %38 = zext i32 %37 to i64
+  %39 = trunc i64 %38 to i32
+  %40 = icmp slt i32 %30, %39
+  br i1 %40, label %7, label %41
+
+; <label>:41                                      ; preds = %35
+  %42 = load i32, i32* %arg0
+  %43 = or i32 %42, 1
+  store i32 %43, i32* %loc2
+  br label %59
+
+; <label>:44                                      ; preds = %59
+  %45 = load i32, i32* %loc2
+  %46 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %45)
+  %47 = zext i8 %46 to i32
+  %48 = icmp eq i32 %47, 0
+  br i1 %48, label %56, label %49
+
+; <label>:49                                      ; preds = %44
+  %50 = load i32, i32* %loc2
+  %51 = sub i32 %50, 1
+  %52 = srem i32 %51, 101
+  %53 = icmp eq i32 %52, 0
+  br i1 %53, label %56, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = load i32, i32* %loc2
+  ret i32 %55
+
+; <label>:56                                      ; preds = %44, %49
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %57, 2
+  store i32 %58, i32* %loc2
+  br label %59
+
+; <label>:59                                      ; preds = %41, %56
+  %60 = load i32, i32* %loc2
+  %61 = icmp slt i32 %60, 2147483647
+  br i1 %61, label %44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load i32, i32* %arg0
+  ret i32 %63
+
+ThrowNullRef:                                     ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
 Successfully read GenericEqualityComparer`1.GetHashCode
 
@@ -3694,14 +4558,14 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
   %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load i64, i64 addrspace(1)* %7
@@ -3720,7 +4584,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3750,8 +4614,8 @@ entry:
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
@@ -3796,8 +4660,8 @@ entry:
   %35 = bitcast i16* %34 to i8*
   %36 = getelementptr inbounds i8, i8* %35, i64 2
   %37 = bitcast i8* %36 to i16*
-  %NullCheck4 = icmp ne i16* %37, null
-  br i1 %NullCheck4, label %38, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %37, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %38
 
 ; <label>:38                                      ; preds = %27
   %39 = load i16, i16* %37, align 8
@@ -3824,8 +4688,8 @@ entry:
 
 ; <label>:54                                      ; preds = %22, %43
   %55 = load i16*, i16** %loc4
-  %NullCheck2 = icmp ne i16* %55, null
-  br i1 %NullCheck2, label %56, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i16* %55, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %56
 
 ; <label>:56                                      ; preds = %54
   %57 = load i16, i16* %55, align 8
@@ -3850,11 +4714,11 @@ ThrowNullRef:                                     ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %54
+ThrowNullRef2:                                    ; preds = %54
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %27
+ThrowNullRef4:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3871,8 +4735,8 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -3907,8 +4771,8 @@ entry:
 
 ; <label>:26                                      ; preds = %19
   %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
-  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %28
 
 ; <label>:28                                      ; preds = %26
   %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
@@ -3920,7 +4784,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3972,8 +4836,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
@@ -3984,26 +4848,26 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
-  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
@@ -4014,8 +4878,8 @@ entry:
 ; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
@@ -4024,8 +4888,8 @@ entry:
 
 ; <label>:25                                      ; preds = %1, %16, %23
   %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
-  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
@@ -4036,27 +4900,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %20
+ThrowNullRef10:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4069,8 +4933,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -4081,8 +4945,8 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
@@ -4091,8 +4955,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1, %8
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
@@ -4103,11 +4967,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4128,24 +4992,24 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   store i32 %3, i32* %loc0
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
   %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
   store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck4, label %9, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
@@ -4164,15 +5028,15 @@ entry:
 ; <label>:18                                      ; preds = %70
   %19 = load i16*, i16** %loc3
   %20 = bitcast i16* %19 to i64*
-  %NullCheck10 = icmp ne i64* %20, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %20, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = load i64, i64* %20, align 8
   %23 = load i16*, i16** %loc4
   %24 = bitcast i16* %23 to i64*
-  %NullCheck12 = icmp ne i64* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = load i64, i64* %24, align 8
@@ -4188,8 +5052,8 @@ entry:
   %31 = bitcast i16* %30 to i8*
   %32 = getelementptr inbounds i8, i8* %31, i64 8
   %33 = bitcast i8* %32 to i64*
-  %NullCheck14 = icmp ne i64* %33, null
-  br i1 %NullCheck14, label %34, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = load i64, i64* %33, align 8
@@ -4197,8 +5061,8 @@ entry:
   %37 = bitcast i16* %36 to i8*
   %38 = getelementptr inbounds i8, i8* %37, i64 8
   %39 = bitcast i8* %38 to i64*
-  %NullCheck16 = icmp ne i64* %39, null
-  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %40
 
 ; <label>:40                                      ; preds = %34
   %41 = load i64, i64* %39, align 8
@@ -4214,8 +5078,8 @@ entry:
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %NullCheck18 = icmp ne i64* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = load i64, i64* %48, align 8
@@ -4223,8 +5087,8 @@ entry:
   %52 = bitcast i16* %51 to i8*
   %53 = getelementptr inbounds i8, i8* %52, i64 16
   %54 = bitcast i8* %53 to i64*
-  %NullCheck20 = icmp ne i64* %54, null
-  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64* %54, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %55
 
 ; <label>:55                                      ; preds = %49
   %56 = load i64, i64* %54, align 8
@@ -4262,15 +5126,15 @@ entry:
 ; <label>:74                                      ; preds = %95
   %75 = load i16*, i16** %loc3
   %76 = bitcast i16* %75 to i32*
-  %NullCheck6 = icmp ne i32* %76, null
-  br i1 %NullCheck6, label %77, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32* %76, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %77
 
 ; <label>:77                                      ; preds = %74
   %78 = load i32, i32* %76, align 8
   %79 = load i16*, i16** %loc4
   %80 = bitcast i16* %79 to i32*
-  %NullCheck8 = icmp ne i32* %80, null
-  br i1 %NullCheck8, label %81, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i32* %80, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %81
 
 ; <label>:81                                      ; preds = %77
   %82 = load i32, i32* %80, align 8
@@ -4318,43 +5182,43 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %74
+ThrowNullRef6:                                    ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %77
+ThrowNullRef8:                                    ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %29
+ThrowNullRef14:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %34
+ThrowNullRef16:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4376,8 +5240,8 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load i64, i64 addrspace(1)* %4
@@ -4389,8 +5253,8 @@ entry:
   %12 = load i64, i64* %11
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %5
   %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
@@ -4399,8 +5263,8 @@ entry:
   %18 = load i8, i8* %arg2
   %19 = zext i8 %18 to i32
   %20 = trunc i32 %19 to i8
-  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %15
   %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
@@ -4411,11 +5275,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4442,8 +5306,8 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
@@ -4466,16 +5330,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
   %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = load i64, i64 addrspace(1)* %19
@@ -4500,8 +5364,8 @@ entry:
 ; <label>:35                                      ; preds = %30
   %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
@@ -4514,8 +5378,8 @@ entry:
 
 ; <label>:42                                      ; preds = %1, %38
   %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
-  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
@@ -4526,19 +5390,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %35
+ThrowNullRef2:                                    ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %42
+ThrowNullRef8:                                    ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4551,14 +5415,14 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
@@ -4570,7 +5434,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4583,8 +5447,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
@@ -4613,51 +5477,51 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
   %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
   %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
   %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
   %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
-  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
   store i64 %21, i64 addrspace(1)* %23
   %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %25 = load i64, i64* %loc0
-  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
@@ -4668,27 +5532,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %22
+ThrowNullRef12:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4701,8 +5565,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
@@ -4713,19 +5577,19 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
@@ -4734,8 +5598,8 @@ entry:
 
 ; <label>:15                                      ; preds = %1, %13
   %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
@@ -4746,19 +5610,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %15
+ThrowNullRef8:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4771,8 +5635,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -4831,8 +5695,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
@@ -4882,8 +5746,8 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
-  br i1 %NullCheck, label %17, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %ThrowNullRef, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
@@ -4894,15 +5758,15 @@ entry:
 
 ; <label>:22                                      ; preds = %17
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
-  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
   %26 = load i32, i32 addrspace(1)* %25
   %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
-  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %27, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
@@ -4925,8 +5789,8 @@ entry:
 ; <label>:40                                      ; preds = %17
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
-  br i1 %NullCheck6, label %43, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %41, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
@@ -4938,34 +5802,17 @@ ThrowNullRef:                                     ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %24
+ThrowNullRef4:                                    ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %40
+ThrowNullRef6:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
-}
-
-INFO:  jitting method Object::ReferenceEquals using LLILCJit
-Successfully read Object.ReferenceEquals
-
-define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
-entry:
-  %arg0 = alloca %System.Object addrspace(1)*
-  %arg1 = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
-  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
-  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = icmp eq %System.Object addrspace(1)* %0, %1
-  %3 = sext i1 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
 }
 
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
@@ -4978,21 +5825,21 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
   %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
-  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
@@ -5007,28 +5854,28 @@ entry:
 ; <label>:13                                      ; preds = %8, %12
   %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
   %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
   %21 = load i32, i32 addrspace(1)* %20, align 8
   %22 = add i32 %21, 1
-  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
   store i32 %22, i32 addrspace(1)* %24
   %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
@@ -5039,27 +5886,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5077,7 +5924,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::Setup using LLILCJit
-Failed to read AppDomain.Setup[loadElem]
+Failed to read AppDomain.Setup[unbox]
 INFO:  jitting method Thread::GetDomain using LLILCJit
 Successfully read Thread.GetDomain
 
@@ -5108,8 +5955,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
@@ -5122,14 +5969,14 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
   %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
@@ -5141,11 +5988,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5173,8 +6020,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -5189,7 +6036,328 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
 Failed to read KeyCollection.System.Collections.Generic.IEnumerable<TKey>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Successfully read Enumerator.MoveNext
+
+define i8 @Enumerator.MoveNext(%"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.RuntimeTypeHandle* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*
+  %"$TypeArg" = alloca %System.RuntimeTypeHandle*
+  store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
+  %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 8
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %76, label %12
+
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
+  br label %76
+
+; <label>:13                                      ; preds = %85
+  %14 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck19 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %15
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, i32 0, i32 0
+  %17 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %16, align 8
+  %NullCheck21 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, i32 0, i32 2
+  %20 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %19, align 8
+  %21 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck23 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %22
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, i32 0, i32 2
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %NullCheck25 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 3, i32 %24
+  %NullCheck27 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %32
+
+; <label>:32                                      ; preds = %30
+  %33 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, i32 0, i32 2
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = icmp slt i32 %34, 0
+  br i1 %35, label %68, label %36
+
+; <label>:36                                      ; preds = %32
+  %37 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %38 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck29 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %39
+
+; <label>:39                                      ; preds = %36
+  %40 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, i32 0, i32 0
+  %41 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %40, align 8
+  %NullCheck31 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, i32 0, i32 2
+  %44 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %43, align 8
+  %45 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck33 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, i32 0, i32 2
+  %48 = load i32, i32 addrspace(1)* %47, align 8
+  %NullCheck35 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %49
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = zext i32 %51 to i64
+  %53 = zext i32 %48 to i64
+  %BoundsCheck37 = icmp uge i64 %53, %52
+  br i1 %BoundsCheck37, label %ThrowIndexOutOfRange38, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 3, i32 %48
+  %NullCheck39 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %56
+
+; <label>:56                                      ; preds = %54
+  %57 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, i32 0, i32 0
+  %58 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck41 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %59
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %60, %System.__Canon addrspace(1)* %58)
+  %61 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck43 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  %64 = load i32, i32 addrspace(1)* %63, align 8
+  %65 = add i32 %64, 1
+  %NullCheck45 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  store i32 %65, i32 addrspace(1)* %67
+  ret i8 1
+
+; <label>:68                                      ; preds = %32
+  %69 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck47 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %73 = add i32 %72, 1
+  %NullCheck49 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %74
+
+; <label>:74                                      ; preds = %70
+  %75 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  store i32 %73, i32 addrspace(1)* %75
+  br label %76
+
+; <label>:76                                      ; preds = %8, %12, %74
+  %77 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %78
+
+; <label>:78                                      ; preds = %76
+  %79 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, i32 0, i32 2
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck7 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %82
+
+; <label>:82                                      ; preds = %78
+  %83 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, i32 0, i32 0
+  %84 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %83, align 8
+  %NullCheck9 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %85
+
+; <label>:85                                      ; preds = %82
+  %86 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, i32 0, i32 7
+  %87 = load i32, i32 addrspace(1)* %86, align 8
+  %88 = icmp ult i32 %80, %87
+  br i1 %88, label %13, label %89
+
+; <label>:89                                      ; preds = %85
+  %90 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %91 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck11 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %92
+
+; <label>:92                                      ; preds = %89
+  %93 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, i32 0, i32 0
+  %94 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck13 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %95
+
+; <label>:95                                      ; preds = %92
+  %96 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, i32 0, i32 7
+  %97 = load i32, i32 addrspace(1)* %96, align 8
+  %98 = add i32 %97, 1
+  %NullCheck15 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %99
+
+; <label>:99                                      ; preds = %95
+  %100 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, i32 0, i32 2
+  store i32 %98, i32 addrspace(1)* %100
+  %101 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck17 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %102
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %103, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %92
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef22:                                   ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef24:                                   ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef26:                                   ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef28:                                   ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef30:                                   ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef32:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef34:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef36:                                   ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange38:                           ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef40:                                   ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef42:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef44:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef46:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef48:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef50:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -5200,8 +6368,8 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -5232,9 +6400,9 @@ Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
 Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
-Failed to read String.MakeSeparatorList[loadElemA]
+Failed to read String.MakeSeparatorList[storeElem]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
-Failed to read String.InternalSplitKeepEmptyEntries[loadElem]
+Failed to read String.InternalSplitKeepEmptyEntries[storeElem]
 INFO:  jitting method Path::IsRelative using LLILCJit
 Successfully read Path.IsRelative
 
@@ -5243,8 +6411,8 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -5254,8 +6422,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
@@ -5271,8 +6439,8 @@ entry:
 
 ; <label>:17                                      ; preds = %7
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
@@ -5288,8 +6456,8 @@ entry:
 
 ; <label>:29                                      ; preds = %19
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %31
 
 ; <label>:31                                      ; preds = %29
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
@@ -5300,8 +6468,8 @@ entry:
 
 ; <label>:36                                      ; preds = %31
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
-  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %37, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
@@ -5312,8 +6480,8 @@ entry:
 
 ; <label>:43                                      ; preds = %31, %38
   %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
-  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %45
 
 ; <label>:45                                      ; preds = %43
   %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
@@ -5324,8 +6492,8 @@ entry:
 
 ; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %50
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
@@ -5336,8 +6504,8 @@ entry:
 
 ; <label>:57                                      ; preds = %1, %7, %19, %45, %52
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
-  br i1 %NullCheck14, label %59, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %59
 
 ; <label>:59                                      ; preds = %57
   %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
@@ -5347,8 +6515,8 @@ entry:
 
 ; <label>:63                                      ; preds = %59
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
@@ -5359,8 +6527,8 @@ entry:
 
 ; <label>:70                                      ; preds = %65
   %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
-  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.String addrspace(1)* %71, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %72
 
 ; <label>:72                                      ; preds = %70
   %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
@@ -5379,39 +6547,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %17
+ThrowNullRef4:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %29
+ThrowNullRef6:                                    ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %36
+ThrowNullRef8:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %43
+ThrowNullRef10:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %50
+ThrowNullRef12:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %57
+ThrowNullRef14:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %63
+ThrowNullRef16:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %70
+ThrowNullRef18:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5419,7 +6587,293 @@ ThrowNullRef17:                                   ; preds = %70
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
-Failed to read String.TrimHelper[loadElem]
+Successfully read String.TrimHelper
+
+define %System.String addrspace(1)* @String.TrimHelper(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i16
+  %loc4 = alloca i32
+  %loc5 = alloca i16
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = sub i32 %3, 1
+  store i32 %4, i32* %loc0
+  store i32 0, i32* %loc1
+  %5 = load i32, i32* %arg2
+  %6 = icmp eq i32 %5, 1
+  br i1 %6, label %62, label %7
+
+; <label>:7                                       ; preds = %1
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:8                                       ; preds = %58
+  store i32 0, i32* %loc2
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load i32, i32* %loc1
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2, i32 %10
+  %13 = load i16, i16 addrspace(1)* %12
+  %14 = zext i16 %13 to i32
+  %15 = trunc i32 %14 to i16
+  store i16 %15, i16* %loc3
+  store i32 0, i32* %loc2
+  br label %34
+
+; <label>:16                                      ; preds = %37
+  %17 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %18 = load i32, i32* %loc2
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %17, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %19
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = zext i32 %18 to i64
+  %BoundsCheck = icmp uge i64 %23, %22
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %24
+
+; <label>:24                                      ; preds = %19
+  %25 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 3, i32 %18
+  %26 = load i16, i16 addrspace(1)* %25, align 8
+  %27 = zext i16 %26 to i32
+  %28 = load i16, i16* %loc3
+  %29 = zext i16 %28 to i32
+  %30 = icmp eq i32 %27, %29
+  br i1 %30, label %43, label %31
+
+; <label>:31                                      ; preds = %24
+  %32 = load i32, i32* %loc2
+  %33 = add i32 %32, 1
+  store i32 %33, i32* %loc2
+  br label %34
+
+; <label>:34                                      ; preds = %11, %31
+  %35 = load i32, i32* %loc2
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = icmp slt i32 %35, %41
+  br i1 %42, label %16, label %43
+
+; <label>:43                                      ; preds = %24, %37
+  %44 = load i32, i32* %loc2
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %45, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp eq i32 %44, %50
+  br i1 %51, label %62, label %52
+
+; <label>:52                                      ; preds = %46
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %7, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %57, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %58
+
+; <label>:58                                      ; preds = %55
+  %59 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %60 = load i32, i32 addrspace(1)* %59
+  %61 = icmp slt i32 %56, %60
+  br i1 %61, label %8, label %62
+
+; <label>:62                                      ; preds = %1, %46, %58
+  %63 = load i32, i32* %arg2
+  %64 = icmp eq i32 %63, 0
+  br i1 %64, label %122, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %66, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %67
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %66, i32 0, i32 1
+  %69 = load i32, i32 addrspace(1)* %68
+  %70 = sub i32 %69, 1
+  store i32 %70, i32* %loc0
+  br label %118
+
+; <label>:71                                      ; preds = %118
+  store i32 0, i32* %loc4
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %73 = load i32, i32* %loc0
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %74
+
+; <label>:74                                      ; preds = %71
+  %75 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 2, i32 %73
+  %76 = load i16, i16 addrspace(1)* %75
+  %77 = zext i16 %76 to i32
+  %78 = trunc i32 %77 to i16
+  store i16 %78, i16* %loc5
+  store i32 0, i32* %loc4
+  br label %97
+
+; <label>:79                                      ; preds = %100
+  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %81 = load i32, i32* %loc4
+  %NullCheck19 = icmp eq %"System.Char[]" addrspace(1)* %80, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
+
+; <label>:82                                      ; preds = %79
+  %83 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 1
+  %84 = load i32, i32 addrspace(1)* %83
+  %85 = zext i32 %84 to i64
+  %86 = zext i32 %81 to i64
+  %BoundsCheck21 = icmp uge i64 %86, %85
+  br i1 %BoundsCheck21, label %ThrowIndexOutOfRange22, label %87
+
+; <label>:87                                      ; preds = %82
+  %88 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 3, i32 %81
+  %89 = load i16, i16 addrspace(1)* %88, align 8
+  %90 = zext i16 %89 to i32
+  %91 = load i16, i16* %loc5
+  %92 = zext i16 %91 to i32
+  %93 = icmp eq i32 %90, %92
+  br i1 %93, label %106, label %94
+
+; <label>:94                                      ; preds = %87
+  %95 = load i32, i32* %loc4
+  %96 = add i32 %95, 1
+  store i32 %96, i32* %loc4
+  br label %97
+
+; <label>:97                                      ; preds = %74, %94
+  %98 = load i32, i32* %loc4
+  %99 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck15 = icmp eq %"System.Char[]" addrspace(1)* %99, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %100
+
+; <label>:100                                     ; preds = %97
+  %101 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %99, i32 0, i32 1
+  %102 = load i32, i32 addrspace(1)* %101
+  %103 = zext i32 %102 to i64
+  %104 = trunc i64 %103 to i32
+  %105 = icmp slt i32 %98, %104
+  br i1 %105, label %79, label %106
+
+; <label>:106                                     ; preds = %87, %100
+  %107 = load i32, i32* %loc4
+  %108 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck17 = icmp eq %"System.Char[]" addrspace(1)* %108, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %109
+
+; <label>:109                                     ; preds = %106
+  %110 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %108, i32 0, i32 1
+  %111 = load i32, i32 addrspace(1)* %110
+  %112 = zext i32 %111 to i64
+  %113 = trunc i64 %112 to i32
+  %114 = icmp eq i32 %107, %113
+  br i1 %114, label %122, label %115
+
+; <label>:115                                     ; preds = %109
+  %116 = load i32, i32* %loc0
+  %117 = sub i32 %116, 1
+  store i32 %117, i32* %loc0
+  br label %118
+
+; <label>:118                                     ; preds = %67, %115
+  %119 = load i32, i32* %loc0
+  %120 = load i32, i32* %loc1
+  %121 = icmp sge i32 %119, %120
+  br i1 %121, label %71, label %122
+
+; <label>:122                                     ; preds = %62, %109, %118
+  %123 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %124 = load i32, i32* %loc1
+  %125 = load i32, i32* %loc0
+  %126 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %123, i32 %124, i32 %125)
+  ret %System.String addrspace(1)* %126
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %97
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange22:                           ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
 Successfully read String.CreateTrimmedString
 
@@ -5439,8 +6893,8 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
@@ -5535,8 +6989,8 @@ entry:
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i64 2872
   %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
   %8 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %7
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %3
   %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
@@ -5553,8 +7007,8 @@ entry:
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 2864
   %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
   %21 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %20
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
-  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %22
 
 ; <label>:22                                      ; preds = %16
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
@@ -5569,7 +7023,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %16
+ThrowNullRef2:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5586,8 +7040,8 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5613,8 +7067,8 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
@@ -5632,8 +7086,8 @@ entry:
 
 ; <label>:12                                      ; preds = %4
   %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
@@ -5644,8 +7098,8 @@ entry:
 
 ; <label>:19                                      ; preds = %14
   %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %19
   %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
@@ -5660,21 +7114,21 @@ entry:
   %31 = zext i16 %30 to i32
   %32 = bitcast i8* %29 to i16*
   %33 = trunc i32 %31 to i16
-  %NullCheck6 = icmp ne i16* %32, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i16* %32, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %21
   store i16 %33, i16* %32, align 8
   %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %36
 
 ; <label>:36                                      ; preds = %34
   %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
   %38 = load i32, i32 addrspace(1)* %37, align 8
   %39 = add i32 %38, 1
-  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %40
 
 ; <label>:40                                      ; preds = %36
   %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
@@ -5683,16 +7137,16 @@ entry:
 
 ; <label>:42                                      ; preds = %14
   %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
-  br i1 %NullCheck12, label %44, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
   %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
   %47 = load i16, i16* %arg1
   %48 = zext i16 %47 to i32
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = trunc i32 %48 to i16
@@ -5703,31 +7157,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %19
+ThrowNullRef4:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %21
+ThrowNullRef6:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %36
+ThrowNullRef10:                                   ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %42
+ThrowNullRef12:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %44
+ThrowNullRef14:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5740,8 +7194,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -5752,8 +7206,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
@@ -5762,14 +7216,14 @@ entry:
 
 ; <label>:11                                      ; preds = %1
   %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
@@ -5779,15 +7233,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5808,8 +7262,8 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5822,8 +7276,8 @@ entry:
 
 ; <label>:8                                       ; preds = %3
   %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
@@ -5842,15 +7296,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
-  br i1 %NullCheck4, label %22, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
   %24 = load i16*, i16* addrspace(1)* %23, align 8
   %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %25, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
@@ -5859,8 +7313,8 @@ entry:
   store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
@@ -5874,8 +7328,8 @@ entry:
 
 ; <label>:37                                      ; preds = %65
   %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %37
   %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
@@ -5886,16 +7340,16 @@ entry:
   %45 = bitcast i16* %41 to i8*
   %46 = getelementptr inbounds i8, i8* %45, i64 %44
   %47 = bitcast i8* %46 to i16*
-  %NullCheck14 = icmp ne i16* %47, null
-  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %47, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %48
 
 ; <label>:48                                      ; preds = %39
   %49 = load i16, i16* %47, align 8
   %50 = zext i16 %49 to i32
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %52 = load i32, i32* %loc1
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %53
 
 ; <label>:53                                      ; preds = %48
   %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
@@ -5916,8 +7370,8 @@ entry:
 ; <label>:62                                      ; preds = %36, %59
   %63 = load i32, i32* %loc1
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck10, label %65, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %65
 
 ; <label>:65                                      ; preds = %62
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
@@ -5936,15 +7390,15 @@ entry:
 
 ; <label>:74                                      ; preds = %70
   %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
-  br i1 %NullCheck18, label %76, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %76
 
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
   %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
-  br i1 %NullCheck20, label %80, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
   %81 = load i64, i64 addrspace(1)* %79
@@ -5958,8 +7412,8 @@ entry:
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
   %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
-  br i1 %NullCheck22, label %92, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.String addrspace(1)* %90, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %92
 
 ; <label>:92                                      ; preds = %80
   %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
@@ -5969,15 +7423,15 @@ entry:
 
 ; <label>:96                                      ; preds = %70
   %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
-  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %98
 
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
   %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
-  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
   %103 = load i64, i64 addrspace(1)* %101
@@ -5991,8 +7445,8 @@ entry:
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
   %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
-  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.String addrspace(1)* %112, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %114
 
 ; <label>:114                                     ; preds = %102
   %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
@@ -6004,59 +7458,59 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %20
+ThrowNullRef4:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %22
+ThrowNullRef6:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %26
+ThrowNullRef8:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %62
+ThrowNullRef10:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %48
+ThrowNullRef16:                                   ; preds = %48
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %74
+ThrowNullRef18:                                   ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %76
+ThrowNullRef20:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %80
+ThrowNullRef22:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %96
+ThrowNullRef24:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %98
+ThrowNullRef26:                                   ; preds = %98
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %102
+ThrowNullRef28:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6069,15 +7523,15 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
   %3 = load i16*, i16* addrspace(1)* %2, align 8
   %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
@@ -6087,8 +7541,8 @@ entry:
   %10 = bitcast i16* %3 to i8*
   %11 = getelementptr inbounds i8, i8* %10, i64 %9
   %12 = bitcast i8* %11 to i16*
-  %NullCheck4 = icmp ne i16* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %5
   store i16 0, i16* %12, align 8
@@ -6098,11 +7552,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6119,8 +7573,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -6131,8 +7585,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
@@ -6144,15 +7598,15 @@ entry:
 
 ; <label>:14                                      ; preds = %1
   %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
   %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
   %21 = load i64, i64 addrspace(1)* %19
@@ -6171,15 +7625,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %14
+ThrowNullRef4:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %16
+ThrowNullRef6:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6302,14 +7756,6 @@ entry:
   ret %System.String addrspace(1)* %57
 }
 
-INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
-Successfully read RuntimeHelpers.get_OffsetToStringData
-
-define i32 @RuntimeHelpers.get_OffsetToStringData() {
-entry:
-  ret i32 12
-}
-
 INFO:  jitting method String::Equals using LLILCJit
 Successfully read String.Equals
 
@@ -6381,8 +7827,8 @@ entry:
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
-  br i1 %NullCheck24, label %29, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
   %30 = load i64, i64 addrspace(1)* %28
@@ -6397,8 +7843,8 @@ entry:
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
-  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
   %43 = load i64, i64 addrspace(1)* %41
@@ -6418,8 +7864,8 @@ entry:
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
   %59 = load i64, i64 addrspace(1)* %57
@@ -6434,8 +7880,8 @@ entry:
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck22, label %71, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
   %72 = load i64, i64 addrspace(1)* %70
@@ -6455,8 +7901,8 @@ entry:
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
-  br i1 %NullCheck16, label %87, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = load i64, i64 addrspace(1)* %86
@@ -6471,8 +7917,8 @@ entry:
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck18, label %100, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
   %101 = load i64, i64 addrspace(1)* %99
@@ -6492,8 +7938,8 @@ entry:
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
-  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
   %117 = load i64, i64 addrspace(1)* %115
@@ -6508,8 +7954,8 @@ entry:
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
-  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
   %130 = load i64, i64 addrspace(1)* %128
@@ -6528,15 +7974,15 @@ entry:
 
 ; <label>:142                                     ; preds = %22
   %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
-  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %143, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %144
 
 ; <label>:144                                     ; preds = %142
   %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
   %146 = load i32, i32 addrspace(1)* %145
   %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
-  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %147, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %148
 
 ; <label>:148                                     ; preds = %144
   %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
@@ -6557,15 +8003,15 @@ entry:
 
 ; <label>:159                                     ; preds = %22
   %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
-  br i1 %NullCheck, label %161, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %ThrowNullRef, label %161
 
 ; <label>:161                                     ; preds = %159
   %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
   %163 = load i32, i32 addrspace(1)* %162
   %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
-  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %164, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %165
 
 ; <label>:165                                     ; preds = %161
   %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
@@ -6578,8 +8024,8 @@ entry:
 
 ; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
-  br i1 %NullCheck4, label %172, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %171, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %172
 
 ; <label>:172                                     ; preds = %170
   %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
@@ -6589,8 +8035,8 @@ entry:
 
 ; <label>:176                                     ; preds = %172
   %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
-  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %177, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %178
 
 ; <label>:178                                     ; preds = %176
   %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
@@ -6629,55 +8075,55 @@ ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %161
+ThrowNullRef2:                                    ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %170
+ThrowNullRef4:                                    ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %176
+ThrowNullRef6:                                    ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %142
+ThrowNullRef8:                                    ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %144
+ThrowNullRef10:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %113
+ThrowNullRef12:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %116
+ThrowNullRef14:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %84
+ThrowNullRef16:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %87
+ThrowNullRef18:                                   ; preds = %87
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %55
+ThrowNullRef20:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %58
+ThrowNullRef22:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %26
+ThrowNullRef24:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %29
+ThrowNullRef26:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,8 +8161,8 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck, label %14, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %ThrowNullRef, label %14
 
 ; <label>:14                                      ; preds = %8
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
@@ -6760,8 +8206,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
@@ -6770,14 +8216,14 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32, i32* %loc0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %10
   %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
   %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
@@ -6790,15 +8236,15 @@ entry:
 ; <label>:25                                      ; preds = %19
   %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
-  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
   %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
@@ -6807,8 +8253,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %37 = load i32, i32* %loc0
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %38, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %38
 
 ; <label>:38                                      ; preds = %32
   %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
@@ -6817,14 +8263,14 @@ entry:
 
 ; <label>:40                                      ; preds = %19
   %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %40
   %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
   %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
-  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
-  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
@@ -6832,8 +8278,8 @@ entry:
   %48 = zext i32 %47 to i64
   %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
-  br i1 %NullCheck16, label %51, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %51
 
 ; <label>:51                                      ; preds = %45
   %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
@@ -6847,15 +8293,15 @@ entry:
 ; <label>:57                                      ; preds = %51
   %58 = load i16*, i16** %arg1
   %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
-  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %60
 
 ; <label>:60                                      ; preds = %57
   %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
   %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
-  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %64
 
 ; <label>:64                                      ; preds = %60
   %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
@@ -6864,22 +8310,22 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
   %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
-  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %70
 
 ; <label>:70                                      ; preds = %64
   %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
   %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
-  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
-  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
   %75 = load i32, i32 addrspace(1)* %74
   %76 = zext i32 %75 to i64
   %77 = trunc i64 %76 to i32
-  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
-  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %78
 
 ; <label>:78                                      ; preds = %73
   %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
@@ -6901,8 +8347,8 @@ entry:
   %90 = bitcast i16* %86 to i8*
   %91 = getelementptr inbounds i8, i8* %90, i64 %89
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %93
 
 ; <label>:93                                      ; preds = %80
   %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
@@ -6912,8 +8358,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %99 = load i32, i32* %loc2
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %100
 
 ; <label>:100                                     ; preds = %93
   %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
@@ -6928,63 +8374,63 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %25
+ThrowNullRef6:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %32
+ThrowNullRef10:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %40
+ThrowNullRef12:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %45
+ThrowNullRef16:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %57
+ThrowNullRef18:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %60
+ThrowNullRef20:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %64
+ThrowNullRef22:                                   ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %70
+ThrowNullRef24:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %73
+ThrowNullRef26:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %80
+ThrowNullRef28:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %93
+ThrowNullRef30:                                   ; preds = %93
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7004,8 +8450,8 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
@@ -7033,43 +8479,43 @@ entry:
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %14
   %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
   %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   %28 = load i32, i32 addrspace(1)* %27, align 8
   %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
-  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %30
 
 ; <label>:30                                      ; preds = %26
   %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
   %32 = load i32, i32 addrspace(1)* %31, align 8
   %33 = add i32 %28, %32
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %34
 
 ; <label>:34                                      ; preds = %30
   %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   store i32 %33, i32 addrspace(1)* %35
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
   store i32 0, i32 addrspace(1)* %38
   %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %40
 
 ; <label>:40                                      ; preds = %37
   %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
@@ -7082,8 +8528,8 @@ entry:
 
 ; <label>:47                                      ; preds = %40
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
@@ -7098,8 +8544,8 @@ entry:
   %54 = load i32, i32* %loc0
   %55 = sext i32 %54 to i64
   %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
-  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %57
 
 ; <label>:57                                      ; preds = %52
   %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
@@ -7110,68 +8556,35 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %14
+ThrowNullRef2:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %23
+ThrowNullRef4:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %26
+ThrowNullRef6:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %30
+ThrowNullRef8:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %34
+ThrowNullRef10:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %47
+ThrowNullRef14:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %52
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-}
-
-INFO:  jitting method StringBuilder::get_Length using LLILCJit
-Successfully read StringBuilder.get_Length
-
-define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.StringBuilder addrspace(1)*
-  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
-  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
-
-; <label>:1                                       ; preds = %entry
-  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %3 = load i32, i32 addrspace(1)* %2, align 8
-  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
-
-; <label>:5                                       ; preds = %1
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = add i32 %3, %7
-  ret i32 %8
-
-ThrowNullRef:                                     ; preds = %entry
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef16:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7213,70 +8626,70 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
   %6 = load i32, i32 addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
   store i32 %6, i32 addrspace(1)* %8
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
   %13 = load i32, i32 addrspace(1)* %12, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
   store i32 %13, i32 addrspace(1)* %15
   %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
-  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %18
 
 ; <label>:18                                      ; preds = %14
   %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
   %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
   %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
   %34 = load i32, i32 addrspace(1)* %33, align 8
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
-  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
@@ -7287,39 +8700,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %28
+ThrowNullRef16:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %32
+ThrowNullRef18:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7455,13 +8868,13 @@ entry:
 ; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
@@ -7477,16 +8890,16 @@ entry:
 
 ; <label>:18                                      ; preds = %15
   %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
   store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
   %22 = load i32, i32* %loc0
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %24
 
 ; <label>:24                                      ; preds = %20
   %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
@@ -7498,13 +8911,13 @@ entry:
 ; <label>:28                                      ; preds = %15, %24
   %29 = load i32, i32* %arg1
   %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %31
   %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
@@ -7517,20 +8930,20 @@ entry:
   %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
-  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
   %46 = load i32, i32 addrspace(1)* %45, align 8
   %47 = sub i32 %40, %46
-  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
-  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i32 addrspace(1)* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %48
 
 ; <label>:48                                      ; preds = %44
   store i32 %47, i32 addrspace(1)* %39, align 8
@@ -7538,21 +8951,21 @@ entry:
 
 ; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
-  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %51
 
 ; <label>:51                                      ; preds = %49
   %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %53
 
 ; <label>:53                                      ; preds = %51
   %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
   %55 = load i32, i32 addrspace(1)* %54, align 8
   %56 = load i32, i32* %arg2
   %57 = sub i32 %55, %56
-  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %58
 
 ; <label>:58                                      ; preds = %53
   %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
@@ -7562,13 +8975,13 @@ entry:
 ; <label>:60                                      ; preds = %33, %58
   %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
   %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
-  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %63
 
 ; <label>:63                                      ; preds = %60
   %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
-  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
-  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
@@ -7578,15 +8991,15 @@ entry:
 
 ; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
-  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i32 addrspace(1)* %69, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %70
 
 ; <label>:70                                      ; preds = %68
   %71 = load i32, i32 addrspace(1)* %69, align 8
   store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
-  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
@@ -7596,8 +9009,8 @@ entry:
   store i32 %77, i32* %loc4
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
-  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %80
 
 ; <label>:80                                      ; preds = %73
   %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
@@ -7607,71 +9020,71 @@ entry:
 ; <label>:83                                      ; preds = %80
   store i32 0, i32* %loc3
   %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
-  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
-  br i1 %NullCheck26, label %88, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i32 addrspace(1)* %87, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %88
 
 ; <label>:88                                      ; preds = %85
   %89 = load i32, i32 addrspace(1)* %87, align 8
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
-  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %90
 
 ; <label>:90                                      ; preds = %88
   %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
   store i32 %89, i32 addrspace(1)* %91
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
-  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
-  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %96
 
 ; <label>:96                                      ; preds = %94
   %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
-  br i1 %NullCheck34, label %100, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %100
 
 ; <label>:100                                     ; preds = %96
   %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
-  br i1 %NullCheck36, label %102, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %102
 
 ; <label>:102                                     ; preds = %100
   %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
   %104 = load i32, i32 addrspace(1)* %103, align 8
   %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
-  br i1 %NullCheck38, label %106, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %106
 
 ; <label>:106                                     ; preds = %102
   %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
-  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
-  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %108
 
 ; <label>:108                                     ; preds = %106
   %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
   %110 = load i32, i32 addrspace(1)* %109, align 8
   %111 = add i32 %104, %110
-  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %112
 
 ; <label>:112                                     ; preds = %108
   %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
   store i32 %111, i32 addrspace(1)* %113
   %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
-  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i32 addrspace(1)* %114, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %115
 
 ; <label>:115                                     ; preds = %112
   %116 = load i32, i32 addrspace(1)* %114, align 8
@@ -7681,19 +9094,19 @@ entry:
 ; <label>:118                                     ; preds = %115
   %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
-  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %121
 
 ; <label>:121                                     ; preds = %118
   %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
-  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
-  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %123
 
 ; <label>:123                                     ; preds = %121
   %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
   %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
-  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
-  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %126
 
 ; <label>:126                                     ; preds = %123
   %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
@@ -7705,8 +9118,8 @@ entry:
 
 ; <label>:130                                     ; preds = %80, %115, %126
   %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %132
 
 ; <label>:132                                     ; preds = %130
   %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7715,8 +9128,8 @@ entry:
   %136 = load i32, i32* %loc3
   %137 = sub i32 %135, %136
   %138 = sub i32 %134, %137
-  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %139
 
 ; <label>:139                                     ; preds = %132
   %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7728,16 +9141,16 @@ entry:
 
 ; <label>:144                                     ; preds = %139
   %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
-  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %146
 
 ; <label>:146                                     ; preds = %144
   %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
   %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
   %149 = load i32, i32* %loc2
   %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
-  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %151
 
 ; <label>:151                                     ; preds = %146
   %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
@@ -7754,145 +9167,249 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %18
+ThrowNullRef4:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %31
+ThrowNullRef10:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %44
+ThrowNullRef16:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %68
+ThrowNullRef18:                                   ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %70
+ThrowNullRef20:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %73
+ThrowNullRef22:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %83
+ThrowNullRef24:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %85
+ThrowNullRef26:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %88
+ThrowNullRef28:                                   ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %90
+ThrowNullRef30:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %94
+ThrowNullRef32:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %96
+ThrowNullRef34:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %100
+ThrowNullRef36:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %102
+ThrowNullRef38:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %106
+ThrowNullRef40:                                   ; preds = %106
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %108
+ThrowNullRef42:                                   ; preds = %108
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %112
+ThrowNullRef44:                                   ; preds = %112
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %118
+ThrowNullRef46:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %121
+ThrowNullRef48:                                   ; preds = %121
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %123
+ThrowNullRef50:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %130
+ThrowNullRef52:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %132
+ThrowNullRef54:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %144
+ThrowNullRef56:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %146
+ThrowNullRef58:                                   ; preds = %146
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %60
+ThrowNullRef60:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %63
+ThrowNullRef62:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %49
+ThrowNullRef64:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %51
+ThrowNullRef66:                                   ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %53
+ThrowNullRef68:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(%"System.Char[]" addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %arg0 = alloca %"System.Char[]" addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store %"System.Char[]" addrspace(1)* %param0, %"System.Char[]" addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load i32, i32* %arg4
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %43, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %38, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg1
+  %13 = load i32, i32* %arg4
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %38, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %24 = load i32, i32* %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %35 = load i32, i32* %arg3
+  %36 = load i32, i32* %arg4
+  %37 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %37, %"System.Char[]" addrspace(1)* %34, i32 %35, i32 %36)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:38                                      ; preds = %5, %16
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Successfully read Buffer._Memmove
 
@@ -7914,7 +9431,7 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[loadElem]
+Failed to read AppDomain.SetDataHelper[storeElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -7923,8 +9440,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
@@ -7934,8 +9451,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
@@ -7947,15 +9464,15 @@ entry:
   %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
   %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
@@ -7966,15 +9483,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7992,7 +9509,79 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
-Failed to read Dictionary`2.TryGetValue[loadElemA]
+Successfully read Dictionary`2.TryGetValue
+
+define i8 @"Dictionary`2.TryGetValue"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)* addrspace(1)* %param2) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  %arg2 = alloca %System.__Canon addrspace(1)* addrspace(1)*
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  store %System.__Canon addrspace(1)* addrspace(1)* %param2, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  store i32 %2, i32* %loc0
+  %3 = load i32, i32* %loc0
+  %4 = icmp slt i32 %3, 0
+  br i1 %4, label %22, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 2
+  %10 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %9, align 8
+  %11 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = zext i32 %11 to i64
+  %BoundsCheck = icmp uge i64 %16, %15
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 3, i32 %11
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %20, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %6, %System.__Canon addrspace(1)* %21)
+  ret i8 1
+
+; <label>:22                                      ; preds = %entry
+  %23 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %23, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -8058,8 +9647,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
@@ -8091,8 +9680,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
@@ -8171,15 +9760,15 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck, label %19, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %ThrowNullRef, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
   %21 = load i32, i32 addrspace(1)* %20
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
@@ -8202,7 +9791,7 @@ ThrowNullRef:                                     ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %19
+ThrowNullRef2:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8248,8 +9837,8 @@ entry:
   %0 = alloca %System.AppDomainHandle
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %1 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %1, i32 0, i32 15
@@ -8269,8 +9858,8 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
@@ -8286,7 +9875,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -8299,8 +9888,8 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -8327,8 +9916,8 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
@@ -8352,8 +9941,8 @@ entry:
   %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
   store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
@@ -8363,8 +9952,8 @@ entry:
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
@@ -8374,8 +9963,8 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %9
   %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
@@ -8384,8 +9973,8 @@ entry:
 
 ; <label>:18                                      ; preds = %3, %16
   %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
@@ -8397,15 +9986,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %18
+ThrowNullRef6:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8418,8 +10007,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
@@ -8453,15 +10042,15 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
@@ -8473,7 +10062,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8481,7 +10070,7 @@ ThrowNullRef1:                                    ; preds = %1
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
 Failed to read Dictionary`2.System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
@@ -8506,8 +10095,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
@@ -8524,8 +10113,8 @@ entry:
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -8544,7 +10133,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8577,8 +10166,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = load i64, i64* %arg2
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = trunc i32 %3 to i8
@@ -8634,46 +10223,46 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
   %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
-  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
-  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
-  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
@@ -8684,27 +10273,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %20
+ThrowNullRef12:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8717,8 +10306,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -8756,22 +10345,22 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
   %9 = load i64, i64 addrspace(1)* %8, align 8
   %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
   %13 = load i64, i64 addrspace(1)* %12, align 8
   %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %11
   %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
@@ -8788,11 +10377,11 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8882,8 +10471,8 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
@@ -8900,8 +10489,8 @@ entry:
 ; <label>:8                                       ; preds = %1
   %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
   %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
@@ -8911,15 +10500,15 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
   %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
   %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
-  br i1 %NullCheck6, label %21, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
@@ -8946,15 +10535,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8992,15 +10581,15 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
   store i8 %3, i8 addrspace(1)* %5
   %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
@@ -9011,7 +10600,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9027,8 +10616,8 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -9041,8 +10630,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
@@ -9058,7 +10647,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9080,8 +10669,8 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
@@ -9096,8 +10685,8 @@ entry:
 ; <label>:12                                      ; preds = %6
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
@@ -9112,8 +10701,8 @@ entry:
 ; <label>:21                                      ; preds = %15
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
@@ -9128,8 +10717,8 @@ entry:
 ; <label>:30                                      ; preds = %24
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %31, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
@@ -9144,8 +10733,8 @@ entry:
 ; <label>:39                                      ; preds = %33
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
-  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %40, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %42
 
 ; <label>:42                                      ; preds = %39
   %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
@@ -9164,19 +10753,19 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %21
+ThrowNullRef4:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %30
+ThrowNullRef6:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %39
+ThrowNullRef8:                                    ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9243,8 +10832,8 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
@@ -9264,57 +10853,57 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
   store i8 0, i8 addrspace(1)* %2
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
   store i8 0, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
   store i8 0, i8 addrspace(1)* %17
   %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
   store i8 0, i8 addrspace(1)* %20
   %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
-  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
@@ -9325,31 +10914,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %19
+ThrowNullRef14:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9367,8 +10956,8 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
@@ -9380,8 +10969,8 @@ entry:
 
 ; <label>:9                                       ; preds = %4
   %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %9
   %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
@@ -9395,7 +10984,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef2:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9420,8 +11009,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
@@ -9512,8 +11101,8 @@ entry:
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
@@ -9524,8 +11113,8 @@ entry:
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = load i64, i64 addrspace(1)* %12
@@ -9537,8 +11126,8 @@ entry:
   %20 = load i64, i64* %19
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
-  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %13
   %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
@@ -9555,8 +11144,8 @@ entry:
 ; <label>:30                                      ; preds = %25
   %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %32 = load i32, i32* %arg2
-  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
-  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
@@ -9570,15 +11159,15 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %30
+ThrowNullRef2:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9622,87 +11211,87 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
   %10 = load i8, i8 addrspace(1)* %9, align 8
   %11 = zext i8 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %8
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
   store i8 %12, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
   %19 = load i8, i8 addrspace(1)* %18, align 8
   %20 = zext i8 %19 to i32
   %21 = trunc i32 %20 to i8
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
   store i8 %21, i8 addrspace(1)* %23
   %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
   %28 = load i8, i8 addrspace(1)* %27, align 8
   %29 = zext i8 %28 to i32
   %30 = trunc i32 %29 to i8
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
-  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %31
 
 ; <label>:31                                      ; preds = %26
   %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
   store i8 %30, i8 addrspace(1)* %32
   %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
-  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
-  br i1 %NullCheck14, label %40, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %40
 
 ; <label>:40                                      ; preds = %35
   %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
   store i8 %39, i8 addrspace(1)* %41
   %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
-  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %44
 
 ; <label>:44                                      ; preds = %40
   %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
   %46 = load i8, i8 addrspace(1)* %45, align 8
   %47 = zext i8 %46 to i32
   %48 = trunc i32 %47 to i8
-  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
   store i8 %48, i8 addrspace(1)* %50
   %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
-  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
@@ -9713,29 +11302,29 @@ entry:
 ; <label>:56                                      ; preds = %52
   %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
-  br i1 %NullCheck22, label %59, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
   %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
   %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
-  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
-  br i1 %NullCheck24, label %63, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
   %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
-  br i1 %NullCheck26, label %66, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
   %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
-  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
-  br i1 %NullCheck28, label %69, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %69
 
 ; <label>:69                                      ; preds = %66
   %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
@@ -9744,15 +11333,15 @@ entry:
 
 ; <label>:71                                      ; preds = %105
   %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
-  br i1 %NullCheck34, label %73, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %73
 
 ; <label>:73                                      ; preds = %71
   %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
   %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
   %76 = load i32, i32* %loc0
-  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
-  br i1 %NullCheck36, label %77, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
@@ -9766,8 +11355,8 @@ entry:
 
 ; <label>:83                                      ; preds = %77
   %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
-  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
@@ -9775,14 +11364,14 @@ entry:
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
   %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
-  br i1 %NullCheck40, label %91, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
 ; <label>:91                                      ; preds = %85
   %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
   %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
-  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck42, label %94, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %94
 
 ; <label>:94                                      ; preds = %91
   %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
@@ -9798,14 +11387,14 @@ entry:
 ; <label>:99                                      ; preds = %69, %96
   %100 = load i32, i32* %loc0
   %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
-  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %102
 
 ; <label>:102                                     ; preds = %99
   %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
   %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
-  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
-  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
@@ -9819,87 +11408,87 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %26
+ThrowNullRef10:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %31
+ThrowNullRef12:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %35
+ThrowNullRef14:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %40
+ThrowNullRef16:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %56
+ThrowNullRef22:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %59
+ThrowNullRef24:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %63
+ThrowNullRef26:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %66
+ThrowNullRef28:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %102
+ThrowNullRef32:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %71
+ThrowNullRef34:                                   ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %73
+ThrowNullRef36:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %83
+ThrowNullRef38:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %85
+ThrowNullRef40:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %91
+ThrowNullRef42:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9943,15 +11532,15 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
   %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
@@ -9961,28 +11550,28 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
   %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %12
   %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
   %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
   %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
-  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
@@ -9993,23 +11582,23 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %12
+ThrowNullRef6:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10031,15 +11620,15 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
   %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = load i64, i64 addrspace(1)* %7
@@ -10077,13 +11666,13 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[loadElem]
+Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -10111,8 +11700,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -10178,8 +11767,8 @@ entry:
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load float, float* %arg0
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -10313,8 +11902,8 @@ entry:
   store i64 %param0, i64* %arg0
   store i64 %param1, i64* %arg1
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
@@ -10322,8 +11911,8 @@ entry:
   %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
   %5 = load i16*, i16* addrspace(1)* %4, align 8
   %6 = addrspacecast i64* %arg1 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = bitcast i64 addrspace(1)* %6 to i8 addrspace(1)*
@@ -10339,7 +11928,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10373,8 +11962,8 @@ entry:
   %1 = load i32, i32* %arg1
   %2 = sext i32 %1 to i64
   %3 = inttoptr i64 %2 to i16*
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -10427,8 +12016,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, i32)*)(%System.IO.ConsoleStream addrspace(1)* %2, i32 %1)
   %3 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %4 = load i64, i64* %arg1
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
@@ -10439,8 +12028,8 @@ entry:
   %10 = icmp eq i32 %9, 3
   %11 = sext i1 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %5
   %14 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, i32 0, i32 5
@@ -10451,7 +12040,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10474,8 +12063,8 @@ entry:
   %5 = icmp eq i32 %4, 1
   %6 = sext i1 %5 to i32
   %7 = trunc i32 %6 to i8
-  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %2, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.ConsoleStream addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
@@ -10486,8 +12075,8 @@ entry:
   %13 = icmp eq i32 %12, 2
   %14 = sext i1 %13 to i32
   %15 = trunc i32 %14 to i8
-  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %10, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.ConsoleStream addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %8
   %17 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %10, i32 0, i32 4
@@ -10498,7 +12087,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10537,8 +12126,8 @@ entry:
   %arg0 = alloca i64
   store i64 %param0, i64* %arg0
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
@@ -10573,8 +12162,8 @@ entry:
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
   %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = load i64, i64 addrspace(1)* %7
@@ -10678,7 +12267,127 @@ entry:
 INFO:  jitting method Encoding::GetEncoding using LLILCJit
 Failed to read Encoding.GetEncoding[convertToHelperArgumentType]
 INFO:  jitting method EncodingProvider::GetEncodingFromProvider using LLILCJit
-Failed to read EncodingProvider.GetEncodingFromProvider[loadElem]
+Successfully read EncodingProvider.GetEncodingFromProvider
+
+define %System.Text.Encoding addrspace(1)* @EncodingProvider.GetEncodingFromProvider(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca %"System.Text.EncodingProvider[]" addrspace(1)*
+  %loc1 = alloca %System.Text.EncodingProvider addrspace(1)*
+  %loc2 = alloca %System.Text.Encoding addrspace(1)*
+  %loc3 = alloca %System.Text.Encoding addrspace(1)*
+  %loc4 = alloca %"System.Text.EncodingProvider[]" addrspace(1)*
+  %loc5 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1059)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2392
+  %2 = addrspacecast i8 addrspace(1)* %1 to %"System.Text.EncodingProvider[]" addrspace(1)**
+  %3 = load volatile %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %2
+  %4 = icmp ne %"System.Text.EncodingProvider[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %entry
+  ret %System.Text.Encoding addrspace(1)* null
+
+; <label>:6                                       ; preds = %entry
+  %7 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1059)
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i64 2392
+  %9 = addrspacecast i8 addrspace(1)* %8 to %"System.Text.EncodingProvider[]" addrspace(1)**
+  %10 = load volatile %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %9
+  store %"System.Text.EncodingProvider[]" addrspace(1)* %10, %"System.Text.EncodingProvider[]" addrspace(1)** %loc0
+  %11 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc0
+  store %"System.Text.EncodingProvider[]" addrspace(1)* %11, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  store i32 0, i32* %loc5
+  br label %43
+
+; <label>:12                                      ; preds = %46
+  %13 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  %14 = load i32, i32* %loc5
+  %NullCheck1 = icmp eq %"System.Text.EncodingProvider[]" addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %13, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = zext i32 %17 to i64
+  %19 = zext i32 %14 to i64
+  %BoundsCheck = icmp uge i64 %19, %18
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %20
+
+; <label>:20                                      ; preds = %15
+  %21 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %13, i32 0, i32 3, i32 %14
+  %22 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)* addrspace(1)* %21, align 8
+  store %System.Text.EncodingProvider addrspace(1)* %22, %System.Text.EncodingProvider addrspace(1)** %loc1
+  %23 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)** %loc1
+  %24 = load i32, i32* %arg0
+  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i64 addrspace(1)*
+  %NullCheck3 = icmp eq i64 addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
+
+; <label>:26                                      ; preds = %20
+  %27 = load i64, i64 addrspace(1)* %25
+  %28 = add i64 %27, 64
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 40
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Text.Encoding addrspace(1)* (%System.Text.EncodingProvider addrspace(1)*, i32)*
+  %35 = call %System.Text.Encoding addrspace(1)* %34(%System.Text.EncodingProvider addrspace(1)* %23, i32 %24)
+  store %System.Text.Encoding addrspace(1)* %35, %System.Text.Encoding addrspace(1)** %loc2
+  %36 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc2
+  %37 = icmp eq %System.Text.Encoding addrspace(1)* %36, null
+  br i1 %37, label %40, label %38
+
+; <label>:38                                      ; preds = %26
+  %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc2
+  store %System.Text.Encoding addrspace(1)* %39, %System.Text.Encoding addrspace(1)** %loc3
+  br label %53
+
+; <label>:40                                      ; preds = %26
+  %41 = load i32, i32* %loc5
+  %42 = add i32 %41, 1
+  store i32 %42, i32* %loc5
+  br label %43
+
+; <label>:43                                      ; preds = %6, %40
+  %44 = load i32, i32* %loc5
+  %45 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  %NullCheck = icmp eq %"System.Text.EncodingProvider[]" addrspace(1)* %45, null
+  br i1 %NullCheck, label %ThrowNullRef, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp slt i32 %44, %50
+  br i1 %51, label %12, label %52
+
+; <label>:52                                      ; preds = %46
+  ret %System.Text.Encoding addrspace(1)* null
+
+; <label>:53                                      ; preds = %38
+  %54 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc3
+  ret %System.Text.Encoding addrspace(1)* %54
+
+ThrowNullRef:                                     ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method EncodingProvider::.cctor using LLILCJit
 Successfully read EncodingProvider..cctor
 
@@ -10697,7 +12406,7 @@ Failed to read Encoding.get_InternalSyncObject[Call HasTypeArg]
 INFO:  jitting method Hashtable::.ctor using LLILCJit
 Failed to read Hashtable..ctor[Volatile store]
 INFO:  jitting method Hashtable::get_Item using LLILCJit
-Failed to read Hashtable.get_Item[loadElemA]
+Failed to read Hashtable.get_Item[loadNonPrimitiveObj]
 INFO:  jitting method Hashtable::InitHash using LLILCJit
 Successfully read Hashtable.InitHash
 
@@ -10717,8 +12426,8 @@ entry:
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -10734,15 +12443,15 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
   %15 = load i32, i32* %loc0
-  %NullCheck2 = icmp ne i32 addrspace(1)* %14, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i32 addrspace(1)* %14, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %3
   store i32 %15, i32 addrspace(1)* %14, align 8
   %17 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %18 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %NullCheck4 = icmp ne i32 addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i32 addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = load i32, i32 addrspace(1)* %18, align 8
@@ -10751,8 +12460,8 @@ entry:
   %23 = sub i32 %22, 1
   %24 = urem i32 %21, %23
   %25 = add i32 1, %24
-  %NullCheck6 = icmp ne i32 addrspace(1)* %17, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32 addrspace(1)* %17, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %19
   store i32 %25, i32 addrspace(1)* %17, align 8
@@ -10763,15 +12472,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %19
+ThrowNullRef6:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10786,8 +12495,8 @@ entry:
   store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
   store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %NullCheck = icmp ne %System.Collections.Hashtable addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Collections.Hashtable addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
@@ -10797,16 +12506,16 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Collections.Hashtable addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Collections.Hashtable addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
   %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck4 = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %9, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
   %13 = inttoptr i64 %11 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
@@ -10816,8 +12525,8 @@ entry:
 ; <label>:15                                      ; preds = %1
   %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -10835,15 +12544,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10857,8 +12566,8 @@ entry:
   store %System.Int32 addrspace(1)* %param0, %System.Int32 addrspace(1)** %this
   %0 = load %System.Int32 addrspace(1)*, %System.Int32 addrspace(1)** %this
   %1 = bitcast %System.Int32 addrspace(1)* %0 to i32 addrspace(1)*
-  %NullCheck = icmp ne i32 addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq i32 addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load i32, i32 addrspace(1)* %1, align 8
@@ -10934,8 +12643,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.UTF8Encoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
@@ -10944,15 +12653,15 @@ entry:
   %9 = load i8, i8* %arg2
   %10 = zext i8 %9 to i32
   %11 = trunc i32 %10 to i8
-  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %8, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %6
   %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %8, i32 0, i32 8
   store i8 %11, i8 addrspace(1)* %13
   %14 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %14, i32 0, i32 8
@@ -10964,8 +12673,8 @@ entry:
 ; <label>:20                                      ; preds = %15
   %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %22, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %22, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = load i64, i64 addrspace(1)* %22
@@ -10987,15 +12696,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %12
+ThrowNullRef4:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11010,8 +12719,8 @@ entry:
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
@@ -11033,16 +12742,16 @@ entry:
 ; <label>:10                                      ; preds = %1
   %11 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
   %12 = load i32, i32* %arg1
-  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %11, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.Encoding addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
   store i32 %12, i32 addrspace(1)* %14
   %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
   %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = load i64, i64 addrspace(1)* %16
@@ -11060,11 +12769,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11077,8 +12786,8 @@ entry:
   %this = alloca %System.Text.UTF8Encoding addrspace(1)*
   store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
   %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.UTF8Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
@@ -11090,16 +12799,16 @@ entry:
 ; <label>:6                                       ; preds = %1
   %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %8 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %10, %System.Text.EncoderFallback addrspace(1)* %8)
   %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %12 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
-  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %11, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %11, i32 0, i32 3
@@ -11112,8 +12821,8 @@ entry:
   %18 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %18, %System.String addrspace(1)* %17)
   %19 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %18 to %System.Text.EncoderFallback addrspace(1)*
-  %NullCheck6 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %16, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %16, i32 0, i32 2
@@ -11123,8 +12832,8 @@ entry:
   %24 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %24, %System.String addrspace(1)* %23)
   %25 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %24 to %System.Text.DecoderFallback addrspace(1)*
-  %NullCheck8 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %22, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %22, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %20
   %27 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %22, i32 0, i32 3
@@ -11135,19 +12844,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %20
+ThrowNullRef8:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11177,8 +12886,8 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load i32, i32* %arg1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -11196,8 +12905,8 @@ entry:
 ; <label>:15                                      ; preds = %8
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %17 = load i32, i32* %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 %17
@@ -11213,7 +12922,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11265,7 +12974,7 @@ entry:
 }
 
 INFO:  jitting method Hashtable::Insert using LLILCJit
-Failed to read Hashtable.Insert[loadElemA]
+Failed to read Hashtable.Insert[storeElem]
 INFO:  jitting method ConsoleEncoding::.ctor using LLILCJit
 Successfully read ConsoleEncoding..ctor
 
@@ -11280,8 +12989,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %1)
   %2 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
@@ -11317,8 +13026,8 @@ entry:
   %2 = call %System.Text.InternalEncoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalEncoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %1)
   %3 = bitcast %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2 to %System.Text.EncoderFallback addrspace(1)*
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
@@ -11328,8 +13037,8 @@ entry:
   %8 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %7)
   %9 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %8 to %System.Text.DecoderFallback addrspace(1)*
-  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %6, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.Encoding addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %4
   %11 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %6, i32 0, i32 3
@@ -11340,7 +13049,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11359,15 +13068,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* %1)
   %2 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   %6 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, i32 0, i32 1
@@ -11378,7 +13087,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11406,8 +13115,8 @@ entry:
   store %System.Text.InternalDecoderBestFitFallback addrspace(1)* %param0, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
   %0 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
@@ -11417,15 +13126,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %4)
   %5 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %6)
   %9 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, i32 0, i32 1
@@ -11436,11 +13145,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11508,8 +13217,8 @@ entry:
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
   %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = load i64, i64 addrspace(1)* %19
@@ -11573,8 +13282,8 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.ConsoleStream addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
@@ -11605,31 +13314,31 @@ entry:
   store i8 %param4, i8* %arg4
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %3, %System.IO.Stream addrspace(1)* %1)
   %4 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %4, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
   %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %4, i32 0, i32 4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %5)
   %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %6
   %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
   %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
   %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = load i64, i64 addrspace(1)* %13
@@ -11641,8 +13350,8 @@ entry:
   %21 = load i64, i64* %20
   %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %8, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %8, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %14
   %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 5
@@ -11660,24 +13369,24 @@ entry:
   %31 = load i32, i32* %arg3
   %32 = sext i32 %31 to i64
   %33 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %32)
-  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %30, null
-  br i1 %NullCheck10, label %34, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.StreamWriter addrspace(1)* %30, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %35, %"System.Char[]" addrspace(1)* %33)
   %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %37, null
-  br i1 %NullCheck12, label %38, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.StreamWriter addrspace(1)* %37, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %38
 
 ; <label>:38                                      ; preds = %34
   %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
   %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
   %41 = load i32, i32* %arg3
   %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %42, null
-  br i1 %NullCheck14, label %43, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %42, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
   %44 = load i64, i64 addrspace(1)* %42
@@ -11691,30 +13400,30 @@ entry:
   %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
   %53 = sext i32 %52 to i64
   %54 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %53)
-  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
-  br i1 %NullCheck16, label %55, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %55
 
 ; <label>:55                                      ; preds = %43
   %56 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %56, %"System.Byte[]" addrspace(1)* %54)
   %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %58 = load i32, i32* %arg3
-  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %57, null
-  br i1 %NullCheck18, label %59, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.StreamWriter addrspace(1)* %57, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %59
 
 ; <label>:59                                      ; preds = %55
   %60 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 10
   store i32 %58, i32 addrspace(1)* %60
   %61 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %61, null
-  br i1 %NullCheck20, label %62, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.IO.StreamWriter addrspace(1)* %61, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %62
 
 ; <label>:62                                      ; preds = %59
   %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
   %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
   %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
   %67 = load i64, i64 addrspace(1)* %65
@@ -11732,15 +13441,15 @@ entry:
 
 ; <label>:78                                      ; preds = %66
   %79 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %79, null
-  br i1 %NullCheck24, label %80, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.StreamWriter addrspace(1)* %79, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %80
 
 ; <label>:80                                      ; preds = %78
   %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
   %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
   %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %83, null
-  br i1 %NullCheck26, label %84, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %83, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
   %85 = load i64, i64 addrspace(1)* %83
@@ -11757,8 +13466,8 @@ entry:
 
 ; <label>:95                                      ; preds = %84
   %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.IO.StreamWriter addrspace(1)* %96, null
-  br i1 %NullCheck28, label %97, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.IO.StreamWriter addrspace(1)* %96, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %97
 
 ; <label>:97                                      ; preds = %95
   %98 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 12
@@ -11772,8 +13481,8 @@ entry:
   %103 = icmp eq i32 %102, 0
   %104 = sext i1 %103 to i32
   %105 = trunc i32 %104 to i8
-  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %100, null
-  br i1 %NullCheck30, label %106, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.IO.StreamWriter addrspace(1)* %100, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %106
 
 ; <label>:106                                     ; preds = %99
   %107 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %100, i32 0, i32 13
@@ -11784,63 +13493,63 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %6
+ThrowNullRef4:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %29
+ThrowNullRef10:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %34
+ThrowNullRef12:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %38
+ThrowNullRef14:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %43
+ThrowNullRef16:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %55
+ThrowNullRef18:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %59
+ThrowNullRef20:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %62
+ThrowNullRef22:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %78
+ThrowNullRef24:                                   ; preds = %78
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %80
+ThrowNullRef26:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %95
+ThrowNullRef28:                                   ; preds = %95
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11853,15 +13562,15 @@ entry:
   %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = load i64, i64 addrspace(1)* %4
@@ -11879,7 +13588,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11929,35 +13638,35 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
   %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderNLS addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %7 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.EncoderNLS addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Text.Encoding addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.Encoding addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Text.EncoderNLS addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.EncoderNLS addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
   %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck8 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = load i64, i64 addrspace(1)* %16
@@ -11976,19 +13685,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12014,8 +13723,8 @@ entry:
   %this = alloca %System.Text.Encoding addrspace(1)*
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
@@ -12035,15 +13744,15 @@ entry:
   %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
   store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
   %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
   store i32 0, i32 addrspace(1)* %2
   %3 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, i32 0, i32 2
@@ -12053,15 +13762,15 @@ entry:
 
 ; <label>:8                                       ; preds = %4
   %9 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
   %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
   %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = load i64, i64 addrspace(1)* %13
@@ -12082,15 +13791,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12105,16 +13814,16 @@ entry:
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = load i32, i32* %arg1
   %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
   %7 = load i64, i64 addrspace(1)* %5
@@ -12132,7 +13841,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12169,8 +13878,8 @@ entry:
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
   %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
   %16 = load i64, i64 addrspace(1)* %14
@@ -12191,8 +13900,8 @@ entry:
   %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
   %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
   %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %31, null
-  br i1 %NullCheck2, label %32, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = load i64, i64 addrspace(1)* %31
@@ -12235,7 +13944,7 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12248,14 +13957,14 @@ entry:
   %this = alloca %System.Text.EncoderReplacementFallback addrspace(1)*
   store %System.Text.EncoderReplacementFallback addrspace(1)* %param0, %System.Text.EncoderReplacementFallback addrspace(1)** %this
   %0 = load %System.Text.EncoderReplacementFallback addrspace(1)*, %System.Text.EncoderReplacementFallback addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -12266,7 +13975,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12296,8 +14005,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
@@ -12329,8 +14038,8 @@ entry:
   %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
   store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
@@ -12342,8 +14051,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Threading.Tasks.Task addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %7)
@@ -12366,7 +14075,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12385,8 +14094,8 @@ entry:
   store i8 %param1, i8* %arg1
   store i8 %param2, i8* %arg2
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
@@ -12400,8 +14109,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1, %5
   %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 9
@@ -12432,8 +14141,8 @@ entry:
 
 ; <label>:25                                      ; preds = %8, %20
   %26 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %26, null
-  br i1 %NullCheck4, label %27, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %26, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %26, i32 0, i32 12
@@ -12444,22 +14153,22 @@ entry:
 
 ; <label>:32                                      ; preds = %27
   %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %33, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.IO.StreamWriter addrspace(1)* %33, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %32
   %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 12
   store i8 1, i8 addrspace(1)* %35
   %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
-  br i1 %NullCheck8, label %37, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
   %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
   %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck10 = icmp ne i64 addrspace(1)* %40, null
-  br i1 %NullCheck10, label %41, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64 addrspace(1)* %40, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i64, i64 addrspace(1)* %40
@@ -12473,8 +14182,8 @@ entry:
   %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
   store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
   %51 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %NullCheck12 = icmp ne %"System.Byte[]" addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Byte[]" addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %41
   %53 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %51, i32 0, i32 1
@@ -12486,16 +14195,16 @@ entry:
 
 ; <label>:58                                      ; preds = %52
   %59 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %59, null
-  br i1 %NullCheck14, label %60, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.IO.StreamWriter addrspace(1)* %59, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %60
 
 ; <label>:60                                      ; preds = %58
   %61 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %59, i32 0, i32 3
   %62 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
   %64 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %NullCheck16 = icmp ne %"System.Byte[]" addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %"System.Byte[]" addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %60
   %66 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %64, i32 0, i32 1
@@ -12503,8 +14212,8 @@ entry:
   %68 = zext i32 %67 to i64
   %69 = trunc i64 %68 to i32
   %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck18, label %71, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
   %72 = load i64, i64 addrspace(1)* %70
@@ -12520,29 +14229,29 @@ entry:
 
 ; <label>:80                                      ; preds = %27, %52, %71
   %81 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %81, null
-  br i1 %NullCheck20, label %82, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.IO.StreamWriter addrspace(1)* %81, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
 
 ; <label>:82                                      ; preds = %80
   %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %81, i32 0, i32 5
   %84 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %83, align 8
   %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.IO.StreamWriter addrspace(1)* %85, null
-  br i1 %NullCheck22, label %86, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.IO.StreamWriter addrspace(1)* %85, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %86
 
 ; <label>:86                                      ; preds = %82
   %87 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 7
   %88 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %87, align 8
   %89 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %89, null
-  br i1 %NullCheck24, label %90, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.StreamWriter addrspace(1)* %89, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %90
 
 ; <label>:90                                      ; preds = %86
   %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %89, i32 0, i32 9
   %92 = load i32, i32 addrspace(1)* %91, align 8
   %93 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.IO.StreamWriter addrspace(1)* %93, null
-  br i1 %NullCheck26, label %94, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.IO.StreamWriter addrspace(1)* %93, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %93, i32 0, i32 6
@@ -12550,8 +14259,8 @@ entry:
   %97 = load i8, i8* %arg2
   %98 = zext i8 %97 to i32
   %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
-  %NullCheck28 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck28, label %100, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
   %101 = load i64, i64 addrspace(1)* %99
@@ -12566,8 +14275,8 @@ entry:
   %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
   store i32 %110, i32* %loc1
   %111 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %111, null
-  br i1 %NullCheck30, label %112, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.IO.StreamWriter addrspace(1)* %111, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %112
 
 ; <label>:112                                     ; preds = %100
   %113 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %111, i32 0, i32 9
@@ -12578,23 +14287,23 @@ entry:
 
 ; <label>:116                                     ; preds = %112
   %117 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck32 = icmp ne %System.IO.StreamWriter addrspace(1)* %117, null
-  br i1 %NullCheck32, label %118, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.IO.StreamWriter addrspace(1)* %117, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %118
 
 ; <label>:118                                     ; preds = %116
   %119 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %117, i32 0, i32 3
   %120 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %119, align 8
   %121 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.IO.StreamWriter addrspace(1)* %121, null
-  br i1 %NullCheck34, label %122, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.IO.StreamWriter addrspace(1)* %121, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %122
 
 ; <label>:122                                     ; preds = %118
   %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
   %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
   %125 = load i32, i32* %loc1
   %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
-  %NullCheck36 = icmp ne i64 addrspace(1)* %126, null
-  br i1 %NullCheck36, label %127, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64 addrspace(1)* %126, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
   %128 = load i64, i64 addrspace(1)* %126
@@ -12616,15 +14325,15 @@ entry:
 
 ; <label>:140                                     ; preds = %136
   %141 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.IO.StreamWriter addrspace(1)* %141, null
-  br i1 %NullCheck38, label %142, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.IO.StreamWriter addrspace(1)* %141, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %142
 
 ; <label>:142                                     ; preds = %140
   %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
   %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
   %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
-  %NullCheck40 = icmp ne i64 addrspace(1)* %145, null
-  br i1 %NullCheck40, label %146, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i64 addrspace(1)* %145, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
   %147 = load i64, i64 addrspace(1)* %145
@@ -12645,83 +14354,83 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %25
+ThrowNullRef4:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %32
+ThrowNullRef6:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %37
+ThrowNullRef10:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %41
+ThrowNullRef12:                                   ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %58
+ThrowNullRef14:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %60
+ThrowNullRef16:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %65
+ThrowNullRef18:                                   ; preds = %65
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %80
+ThrowNullRef20:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %82
+ThrowNullRef22:                                   ; preds = %82
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %86
+ThrowNullRef24:                                   ; preds = %86
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %90
+ThrowNullRef26:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %94
+ThrowNullRef28:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %100
+ThrowNullRef30:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %116
+ThrowNullRef32:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %118
+ThrowNullRef34:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %122
+ThrowNullRef36:                                   ; preds = %122
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %140
+ThrowNullRef38:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %142
+ThrowNullRef40:                                   ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12788,8 +14497,8 @@ entry:
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %1 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
-  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
@@ -12797,8 +14506,8 @@ entry:
   %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
   %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
   %8 = load i64, i64 addrspace(1)* %6
@@ -12814,8 +14523,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %17, %System.IFormatProvider addrspace(1)* %16)
   %18 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %19 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %18, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.SyncTextWriter addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %7
   %21 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %18, i32 0, i32 4
@@ -12826,11 +14535,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12843,8 +14552,8 @@ entry:
   %this = alloca %System.IO.TextWriter addrspace(1)*
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.TextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
@@ -12854,8 +14563,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.Threading.Thread addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Threading.Thread addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %6)
@@ -12864,8 +14573,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1
   %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.TextWriter addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.TextWriter addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %11, i32 0, i32 2
@@ -12876,11 +14585,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13077,8 +14786,8 @@ entry:
   store float %param1, float* %arg1
   store i8 0, i8* %loc1
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
@@ -13088,16 +14797,16 @@ entry:
   %5 = addrspacecast i8* %loc1 to i8 addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %4, i8 addrspace(1)* %5)
   %6 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.SyncTextWriter addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
   %10 = load float, float* %arg1
   %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
   %13 = load i64, i64 addrspace(1)* %11
@@ -13132,11 +14841,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13153,8 +14862,8 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load float, float* %arg1
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -13168,8 +14877,8 @@ entry:
   call void %11(%System.IO.TextWriter addrspace(1)* %0, float %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
   %15 = load i64, i64 addrspace(1)* %13
@@ -13187,7 +14896,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13205,8 +14914,8 @@ entry:
   %1 = addrspacecast float* %arg1 to float addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -13221,8 +14930,8 @@ entry:
   %14 = bitcast float addrspace(1)* %1 to %System.Single addrspace(1)*
   %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Single addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Single addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
   %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
   %18 = load i64, i64 addrspace(1)* %16
@@ -13240,7 +14949,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13256,8 +14965,8 @@ entry:
   store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
   %0 = load %System.Single addrspace(1)*, %System.Single addrspace(1)** %this
   %1 = bitcast %System.Single addrspace(1)* %0 to float addrspace(1)*
-  %NullCheck = icmp ne float addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq float addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load float, float addrspace(1)* %1, align 8
@@ -13282,8 +14991,8 @@ entry:
   %loc0 = alloca %System.Globalization.NumberFormatInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 3
@@ -13293,8 +15002,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
@@ -13304,24 +15013,24 @@ entry:
   store %System.Globalization.NumberFormatInfo addrspace(1)* %10, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
   %11 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %7
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
   %15 = load i8, i8 addrspace(1)* %14, align 8
   %16 = zext i8 %15 to i32
   %17 = trunc i32 %16 to i8
-  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %11, null
-  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %11, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %13
   %19 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %11, i32 0, i32 29
   store i8 %17, i8 addrspace(1)* %19
   %20 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %21 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %20, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %20, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %18
   %23 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %20, i32 0, i32 3
@@ -13330,8 +15039,8 @@ entry:
 
 ; <label>:24                                      ; preds = %1, %22
   %25 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %25, null
-  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %25, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %26
 
 ; <label>:26                                      ; preds = %24
   %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %25, i32 0, i32 3
@@ -13342,23 +15051,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %18
+ThrowNullRef8:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13383,168 +15092,168 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 18
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %8, align 8
-  %NullCheck2 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %5, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %5, i32 0, i32 4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %9)
   %12 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 19
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %15, align 8
-  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %12, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %12, i32 0, i32 5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %16)
   %19 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %20 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %20, null
-  br i1 %NullCheck8, label %21, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %20, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %20, i32 0, i32 23
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  %NullCheck10 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %19, null
-  br i1 %NullCheck10, label %24, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %19, i32 0, i32 7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %25, %System.String addrspace(1)* %23)
   %26 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %27 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %27, i32 0, i32 22
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %29, align 8
-  %NullCheck14 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %26, null
-  br i1 %NullCheck14, label %31, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %26, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %26, i32 0, i32 6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %32, %System.String addrspace(1)* %30)
   %33 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %34 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Globalization.CultureData addrspace(1)* %34, null
-  br i1 %NullCheck16, label %35, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Globalization.CultureData addrspace(1)* %34, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %34, i32 0, i32 51
   %37 = load i32, i32 addrspace(1)* %36, align 8
-  %NullCheck18 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %33, null
-  br i1 %NullCheck18, label %38, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %33, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %33, i32 0, i32 21
   store i32 %37, i32 addrspace(1)* %39
   %40 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %41 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Globalization.CultureData addrspace(1)* %41, null
-  br i1 %NullCheck20, label %42, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Globalization.CultureData addrspace(1)* %41, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %41, i32 0, i32 52
   %44 = load i32, i32 addrspace(1)* %43, align 8
-  %NullCheck22 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %40, null
-  br i1 %NullCheck22, label %45, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %40, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %40, i32 0, i32 25
   store i32 %44, i32 addrspace(1)* %46
   %47 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %48 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.Globalization.CultureData addrspace(1)* %48, null
-  br i1 %NullCheck24, label %49, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Globalization.CultureData addrspace(1)* %48, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %49
 
 ; <label>:49                                      ; preds = %45
   %50 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %48, i32 0, i32 29
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck26 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %47, null
-  br i1 %NullCheck26, label %52, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %47, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %47, i32 0, i32 10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %53, %System.String addrspace(1)* %51)
   %54 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %55 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Globalization.CultureData addrspace(1)* %55, null
-  br i1 %NullCheck28, label %56, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Globalization.CultureData addrspace(1)* %55, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %56
 
 ; <label>:56                                      ; preds = %52
   %57 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %55, i32 0, i32 35
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %57, align 8
-  %NullCheck30 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %54, null
-  br i1 %NullCheck30, label %59, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %54, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %54, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %60, %System.String addrspace(1)* %58)
   %61 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %62 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck32 = icmp ne %System.Globalization.CultureData addrspace(1)* %62, null
-  br i1 %NullCheck32, label %63, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Globalization.CultureData addrspace(1)* %62, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %62, i32 0, i32 34
   %65 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %64, align 8
-  %NullCheck34 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %61, null
-  br i1 %NullCheck34, label %66, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %61, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %61, i32 0, i32 9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %67, %System.String addrspace(1)* %65)
   %68 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %69 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck36 = icmp ne %System.Globalization.CultureData addrspace(1)* %69, null
-  br i1 %NullCheck36, label %70, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Globalization.CultureData addrspace(1)* %69, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %70
 
 ; <label>:70                                      ; preds = %66
   %71 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %69, i32 0, i32 55
   %72 = load i32, i32 addrspace(1)* %71, align 8
-  %NullCheck38 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %68, null
-  br i1 %NullCheck38, label %73, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %68, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %68, i32 0, i32 22
   store i32 %72, i32 addrspace(1)* %74
   %75 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %76 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck40 = icmp ne %System.Globalization.CultureData addrspace(1)* %76, null
-  br i1 %NullCheck40, label %77, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Globalization.CultureData addrspace(1)* %76, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %76, i32 0, i32 57
   %79 = load i32, i32 addrspace(1)* %78, align 8
-  %NullCheck42 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %75, null
-  br i1 %NullCheck42, label %80, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %75, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %80
 
 ; <label>:80                                      ; preds = %77
   %81 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %75, i32 0, i32 24
   store i32 %79, i32 addrspace(1)* %81
   %82 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %83 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck44 = icmp ne %System.Globalization.CultureData addrspace(1)* %83, null
-  br i1 %NullCheck44, label %84, label %ThrowNullRef43
+  %NullCheck43 = icmp eq %System.Globalization.CultureData addrspace(1)* %83, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %84
 
 ; <label>:84                                      ; preds = %80
   %85 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %83, i32 0, i32 56
   %86 = load i32, i32 addrspace(1)* %85, align 8
-  %NullCheck46 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %82, null
-  br i1 %NullCheck46, label %87, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %82, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %82, i32 0, i32 23
@@ -13553,8 +15262,8 @@ entry:
 
 ; <label>:89                                      ; preds = %entry
   %90 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck100 = icmp ne %System.Globalization.CultureData addrspace(1)* %90, null
-  br i1 %NullCheck100, label %91, label %ThrowNullRef99
+  %NullCheck99 = icmp eq %System.Globalization.CultureData addrspace(1)* %90, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %91
 
 ; <label>:91                                      ; preds = %89
   %92 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %90, i32 0, i32 2
@@ -13572,8 +15281,8 @@ entry:
   %102 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %103 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %104 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %103)
-  %NullCheck48 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %102, null
-  br i1 %NullCheck48, label %105, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %102, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %105
 
 ; <label>:105                                     ; preds = %101
   %106 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %102, i32 0, i32 1
@@ -13581,8 +15290,8 @@ entry:
   %107 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %108 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %109 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %108)
-  %NullCheck50 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %107, null
-  br i1 %NullCheck50, label %110, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %107, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %110
 
 ; <label>:110                                     ; preds = %105
   %111 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %107, i32 0, i32 2
@@ -13590,8 +15299,8 @@ entry:
   %112 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %113 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %114 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %113)
-  %NullCheck52 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %112, null
-  br i1 %NullCheck52, label %115, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %112, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %115
 
 ; <label>:115                                     ; preds = %110
   %116 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %112, i32 0, i32 27
@@ -13599,8 +15308,8 @@ entry:
   %117 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %118 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %119 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %118)
-  %NullCheck54 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %117, null
-  br i1 %NullCheck54, label %120, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %117, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %120
 
 ; <label>:120                                     ; preds = %115
   %121 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %117, i32 0, i32 26
@@ -13608,8 +15317,8 @@ entry:
   %122 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %123 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %124 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %123)
-  %NullCheck56 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %122, null
-  br i1 %NullCheck56, label %125, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %122, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %125
 
 ; <label>:125                                     ; preds = %120
   %126 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %122, i32 0, i32 17
@@ -13617,8 +15326,8 @@ entry:
   %127 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %128 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %129 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %128)
-  %NullCheck58 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %127, null
-  br i1 %NullCheck58, label %130, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %127, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %130
 
 ; <label>:130                                     ; preds = %125
   %131 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %127, i32 0, i32 18
@@ -13626,8 +15335,8 @@ entry:
   %132 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %133 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %134 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %133)
-  %NullCheck60 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %132, null
-  br i1 %NullCheck60, label %135, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %132, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %135
 
 ; <label>:135                                     ; preds = %130
   %136 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %132, i32 0, i32 14
@@ -13635,8 +15344,8 @@ entry:
   %137 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %138 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %139 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %138)
-  %NullCheck62 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %137, null
-  br i1 %NullCheck62, label %140, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %137, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %140
 
 ; <label>:140                                     ; preds = %135
   %141 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %137, i32 0, i32 13
@@ -13644,71 +15353,71 @@ entry:
   %142 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %143 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %144 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %143)
-  %NullCheck64 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %142, null
-  br i1 %NullCheck64, label %145, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %142, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %145
 
 ; <label>:145                                     ; preds = %140
   %146 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %142, i32 0, i32 12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %146, %System.String addrspace(1)* %144)
   %147 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %148 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck66 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %148, null
-  br i1 %NullCheck66, label %149, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %148, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %149
 
 ; <label>:149                                     ; preds = %145
   %150 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %148, i32 0, i32 21
   %151 = load i32, i32 addrspace(1)* %150, align 8
-  %NullCheck68 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %147, null
-  br i1 %NullCheck68, label %152, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %147, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %152
 
 ; <label>:152                                     ; preds = %149
   %153 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %147, i32 0, i32 28
   store i32 %151, i32 addrspace(1)* %153
   %154 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %155 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck70 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %155, null
-  br i1 %NullCheck70, label %156, label %ThrowNullRef69
+  %NullCheck69 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %155, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %156
 
 ; <label>:156                                     ; preds = %152
   %157 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %155, i32 0, i32 6
   %158 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %157, align 8
-  %NullCheck72 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %154, null
-  br i1 %NullCheck72, label %159, label %ThrowNullRef71
+  %NullCheck71 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %154, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %159
 
 ; <label>:159                                     ; preds = %156
   %160 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %154, i32 0, i32 15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %160, %System.String addrspace(1)* %158)
   %161 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %162 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck74 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %162, null
-  br i1 %NullCheck74, label %163, label %ThrowNullRef73
+  %NullCheck73 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %162, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %163
 
 ; <label>:163                                     ; preds = %159
   %164 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %162, i32 0, i32 1
   %165 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %164, align 8
-  %NullCheck76 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %161, null
-  br i1 %NullCheck76, label %166, label %ThrowNullRef75
+  %NullCheck75 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %161, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %166
 
 ; <label>:166                                     ; preds = %163
   %167 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %161, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %167, %"System.Int32[]" addrspace(1)* %165)
   %168 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %169 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck78 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %169, null
-  br i1 %NullCheck78, label %170, label %ThrowNullRef77
+  %NullCheck77 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %169, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %170
 
 ; <label>:170                                     ; preds = %166
   %171 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %169, i32 0, i32 7
   %172 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %171, align 8
-  %NullCheck80 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %168, null
-  br i1 %NullCheck80, label %173, label %ThrowNullRef79
+  %NullCheck79 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %168, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %173
 
 ; <label>:173                                     ; preds = %170
   %174 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %168, i32 0, i32 16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %174, %System.String addrspace(1)* %172)
   %175 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck82 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %175, null
-  br i1 %NullCheck82, label %176, label %ThrowNullRef81
+  %NullCheck81 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %175, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %176
 
 ; <label>:176                                     ; preds = %173
   %177 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %175, i32 0, i32 4
@@ -13718,14 +15427,14 @@ entry:
 
 ; <label>:180                                     ; preds = %176
   %181 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck84 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %181, null
-  br i1 %NullCheck84, label %182, label %ThrowNullRef83
+  %NullCheck83 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %181, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %182
 
 ; <label>:182                                     ; preds = %180
   %183 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %181, i32 0, i32 4
   %184 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %183, align 8
-  %NullCheck86 = icmp ne %System.String addrspace(1)* %184, null
-  br i1 %NullCheck86, label %185, label %ThrowNullRef85
+  %NullCheck85 = icmp eq %System.String addrspace(1)* %184, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %185
 
 ; <label>:185                                     ; preds = %182
   %186 = getelementptr inbounds %System.String, %System.String addrspace(1)* %184, i32 0, i32 1
@@ -13736,8 +15445,8 @@ entry:
 ; <label>:189                                     ; preds = %176, %185
   %190 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck98 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %190, null
-  br i1 %NullCheck98, label %192, label %ThrowNullRef97
+  %NullCheck97 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %190, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %192
 
 ; <label>:192                                     ; preds = %189
   %193 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %190, i32 0, i32 4
@@ -13746,8 +15455,8 @@ entry:
 
 ; <label>:194                                     ; preds = %185, %192
   %195 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck88 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %195, null
-  br i1 %NullCheck88, label %196, label %ThrowNullRef87
+  %NullCheck87 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %195, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %196
 
 ; <label>:196                                     ; preds = %194
   %197 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %195, i32 0, i32 9
@@ -13757,14 +15466,14 @@ entry:
 
 ; <label>:200                                     ; preds = %196
   %201 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck90 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %201, null
-  br i1 %NullCheck90, label %202, label %ThrowNullRef89
+  %NullCheck89 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %201, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %202
 
 ; <label>:202                                     ; preds = %200
   %203 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %201, i32 0, i32 9
   %204 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %203, align 8
-  %NullCheck92 = icmp ne %System.String addrspace(1)* %204, null
-  br i1 %NullCheck92, label %205, label %ThrowNullRef91
+  %NullCheck91 = icmp eq %System.String addrspace(1)* %204, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %205
 
 ; <label>:205                                     ; preds = %202
   %206 = getelementptr inbounds %System.String, %System.String addrspace(1)* %204, i32 0, i32 1
@@ -13775,14 +15484,14 @@ entry:
 ; <label>:209                                     ; preds = %196, %205
   %210 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %211 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck94 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %211, null
-  br i1 %NullCheck94, label %212, label %ThrowNullRef93
+  %NullCheck93 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %211, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %212
 
 ; <label>:212                                     ; preds = %209
   %213 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %211, i32 0, i32 6
   %214 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %213, align 8
-  %NullCheck96 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %210, null
-  br i1 %NullCheck96, label %215, label %ThrowNullRef95
+  %NullCheck95 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %210, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %215
 
 ; <label>:215                                     ; preds = %212
   %216 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %210, i32 0, i32 9
@@ -13796,203 +15505,203 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %17
+ThrowNullRef8:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %21
+ThrowNullRef10:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %24
+ThrowNullRef12:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %28
+ThrowNullRef14:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %31
+ThrowNullRef16:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %35
+ThrowNullRef18:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %38
+ThrowNullRef20:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %42
+ThrowNullRef22:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %45
+ThrowNullRef24:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %49
+ThrowNullRef26:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %52
+ThrowNullRef28:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %56
+ThrowNullRef30:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %59
+ThrowNullRef32:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %63
+ThrowNullRef34:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %66
+ThrowNullRef36:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %70
+ThrowNullRef38:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %73
+ThrowNullRef40:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %77
+ThrowNullRef42:                                   ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %80
+ThrowNullRef44:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %84
+ThrowNullRef46:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %101
+ThrowNullRef48:                                   ; preds = %101
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %105
+ThrowNullRef50:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %110
+ThrowNullRef52:                                   ; preds = %110
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %115
+ThrowNullRef54:                                   ; preds = %115
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %120
+ThrowNullRef56:                                   ; preds = %120
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %125
+ThrowNullRef58:                                   ; preds = %125
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %130
+ThrowNullRef60:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %135
+ThrowNullRef62:                                   ; preds = %135
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %140
+ThrowNullRef64:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %145
+ThrowNullRef66:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %149
+ThrowNullRef68:                                   ; preds = %149
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %152
+ThrowNullRef70:                                   ; preds = %152
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %156
+ThrowNullRef72:                                   ; preds = %156
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %159
+ThrowNullRef74:                                   ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %163
+ThrowNullRef76:                                   ; preds = %163
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %166
+ThrowNullRef78:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %170
+ThrowNullRef80:                                   ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %173
+ThrowNullRef82:                                   ; preds = %173
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %180
+ThrowNullRef84:                                   ; preds = %180
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %182
+ThrowNullRef86:                                   ; preds = %182
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %194
+ThrowNullRef88:                                   ; preds = %194
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %200
+ThrowNullRef90:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %202
+ThrowNullRef92:                                   ; preds = %202
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %209
+ThrowNullRef94:                                   ; preds = %209
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %212
+ThrowNullRef96:                                   ; preds = %212
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %189
+ThrowNullRef98:                                   ; preds = %189
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %89
+ThrowNullRef100:                                  ; preds = %89
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14020,8 +15729,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 21
@@ -14034,8 +15743,8 @@ entry:
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 16)
   %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 21
@@ -14044,8 +15753,8 @@ entry:
 
 ; <label>:12                                      ; preds = %1, %10
   %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 21
@@ -14056,11 +15765,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %12
+ThrowNullRef4:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14076,8 +15785,8 @@ entry:
   store i32 %param1, i32* %arg1
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %1 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
@@ -14144,8 +15853,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 33
@@ -14158,8 +15867,8 @@ entry:
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 24)
   %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 33
@@ -14168,8 +15877,8 @@ entry:
 
 ; <label>:12                                      ; preds = %1, %10
   %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 33
@@ -14180,11 +15889,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %12
+ThrowNullRef4:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14197,8 +15906,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 53
@@ -14210,8 +15919,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 116)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 53
@@ -14220,8 +15929,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 53
@@ -14232,11 +15941,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14265,8 +15974,8 @@ entry:
 
 ; <label>:7                                       ; preds = %entry, %4
   %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %7
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 2
@@ -14290,8 +15999,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 54
@@ -14303,8 +16012,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 117)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
@@ -14313,8 +16022,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 54
@@ -14325,11 +16034,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14342,8 +16051,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 27
@@ -14355,8 +16064,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 118)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 27
@@ -14365,8 +16074,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 27
@@ -14377,11 +16086,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14394,8 +16103,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 28
@@ -14407,8 +16116,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 119)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 28
@@ -14417,8 +16126,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 28
@@ -14429,11 +16138,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14446,8 +16155,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 26
@@ -14459,8 +16168,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 107)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 26
@@ -14469,8 +16178,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 26
@@ -14481,11 +16190,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14498,8 +16207,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 25
@@ -14511,8 +16220,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 106)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 25
@@ -14521,8 +16230,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 25
@@ -14533,11 +16242,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14550,8 +16259,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 24
@@ -14563,8 +16272,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 105)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 24
@@ -14573,8 +16282,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 24
@@ -14585,11 +16294,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14614,8 +16323,8 @@ entry:
   %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %3)
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %2
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -14626,15 +16335,15 @@ entry:
 
 ; <label>:8                                       ; preds = %62
   %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 9
   %12 = load i32, i32 addrspace(1)* %11, align 8
   %13 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.IO.StreamWriter addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %13, i32 0, i32 10
@@ -14649,15 +16358,15 @@ entry:
 
 ; <label>:20                                      ; preds = %14, %18
   %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
   %24 = load i32, i32 addrspace(1)* %23, align 8
   %25 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %25, null
-  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.StreamWriter addrspace(1)* %25, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %25, i32 0, i32 9
@@ -14678,36 +16387,36 @@ entry:
   %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %37 = load i32, i32* %loc1
   %38 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.StreamWriter addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %35
   %40 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %38, i32 0, i32 7
   %41 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %40, align 8
   %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
-  br i1 %NullCheck14, label %43, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %39
   %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 9
   %45 = load i32, i32 addrspace(1)* %44, align 8
   %46 = load i32, i32* %loc2
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %36, null
-  br i1 %NullCheck16, label %47, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %36, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %47
 
 ; <label>:47                                      ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %36, i32 %37, %"System.Char[]" addrspace(1)* %41, i32 %45, i32 %46)
   %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
   %51 = load i32, i32 addrspace(1)* %50, align 8
   %52 = load i32, i32* %loc2
   %53 = add i32 %51, %52
-  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
-  br i1 %NullCheck20, label %54, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %54
 
 ; <label>:54                                      ; preds = %49
   %55 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
@@ -14729,8 +16438,8 @@ entry:
 
 ; <label>:65                                      ; preds = %62
   %66 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %66, null
-  br i1 %NullCheck2, label %67, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %66, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %67
 
 ; <label>:67                                      ; preds = %65
   %68 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %66, i32 0, i32 11
@@ -14751,49 +16460,259 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %65
+ThrowNullRef2:                                    ; preds = %65
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %20
+ThrowNullRef8:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %22
+ThrowNullRef10:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %35
+ThrowNullRef12:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %43
+ThrowNullRef16:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %47
+ThrowNullRef18:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method String::CopyTo using LLILCJit
-Failed to read String.CopyTo[loadElemA]
+Successfully read String.CopyTo
+
+define void @String.CopyTo(%System.String addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  %loc1 = alloca i16 addrspace(1)*
+  %loc2 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %1 = icmp ne %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg4
+  %7 = icmp sge i32 %6, 0
+  br i1 %7, label %13, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  unreachable
+
+; <label>:13                                      ; preds = %5
+  %14 = load i32, i32* %arg1
+  %15 = icmp sge i32 %14, 0
+  br i1 %15, label %21, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %18)
+  %20 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %20, %System.String addrspace(1)* %17, %System.String addrspace(1)* %19)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %20) #0
+  unreachable
+
+; <label>:21                                      ; preds = %13
+  %22 = load i32, i32* %arg4
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck, label %ThrowNullRef, label %24
+
+; <label>:24                                      ; preds = %21
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load i32, i32* %arg1
+  %28 = sub i32 %26, %27
+  %29 = icmp sle i32 %22, %28
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34, %System.String addrspace(1)* %31, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %24
+  %36 = load i32, i32* %arg3
+  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %37, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
+
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
+  %40 = load i32, i32 addrspace(1)* %39
+  %41 = zext i32 %40 to i64
+  %42 = trunc i64 %41 to i32
+  %43 = load i32, i32* %arg4
+  %44 = sub i32 %42, %43
+  %45 = icmp sgt i32 %36, %44
+  br i1 %45, label %49, label %46
+
+; <label>:46                                      ; preds = %38
+  %47 = load i32, i32* %arg3
+  %48 = icmp sge i32 %47, 0
+  br i1 %48, label %54, label %49
+
+; <label>:49                                      ; preds = %38, %46
+  %50 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %52 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %51)
+  %53 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53, %System.String addrspace(1)* %50, %System.String addrspace(1)* %52)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53) #0
+  unreachable
+
+; <label>:54                                      ; preds = %46
+  %55 = load i32, i32* %arg4
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %97, label %57
+
+; <label>:57                                      ; preds = %54
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %59
+
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 2
+  %61 = bitcast [0 x i16] addrspace(1)* %60 to i16 addrspace(1)*
+  store i16 addrspace(1)* %61, i16 addrspace(1)** %loc0
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  store %"System.Char[]" addrspace(1)* %62, %"System.Char[]" addrspace(1)** %loc2
+  %63 = icmp eq %"System.Char[]" addrspace(1)* %62, null
+  br i1 %63, label %72, label %64
+
+; <label>:64                                      ; preds = %59
+  %65 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc2
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %65, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %66
+
+; <label>:66                                      ; preds = %64
+  %67 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %65, i32 0, i32 1
+  %68 = load i32, i32 addrspace(1)* %67
+  %69 = zext i32 %68 to i64
+  %70 = trunc i64 %69 to i32
+  %71 = icmp ne i32 %70, 0
+  br i1 %71, label %73, label %72
+
+; <label>:72                                      ; preds = %59, %66
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  br label %81
+
+; <label>:73                                      ; preds = %66
+  %74 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc2
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %74, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %75
+
+; <label>:75                                      ; preds = %73
+  %76 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %74, i32 0, i32 1
+  %77 = load i32, i32 addrspace(1)* %76
+  %78 = zext i32 %77 to i64
+  %BoundsCheck = icmp uge i64 0, %78
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %79
+
+; <label>:79                                      ; preds = %75
+  %80 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %74, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %80, i16 addrspace(1)** %loc1
+  br label %81
+
+; <label>:81                                      ; preds = %72, %79
+  %82 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %83 = ptrtoint i16 addrspace(1)* %82 to i64
+  %84 = load i32, i32* %arg3
+  %85 = sext i32 %84 to i64
+  %86 = mul i64 %85, 2
+  %87 = add i64 %83, %86
+  %88 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %89 = ptrtoint i16 addrspace(1)* %88 to i64
+  %90 = load i32, i32* %arg1
+  %91 = sext i32 %90 to i64
+  %92 = mul i64 %91, 2
+  %93 = add i64 %89, %92
+  %94 = load i32, i32* %arg4
+  %95 = inttoptr i64 %87 to i16*
+  %96 = inttoptr i64 %93 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %95, i16* %96, i32 %94)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  br label %97
+
+; <label>:97                                      ; preds = %54, %81
+  ret void
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
 Successfully read ConsoleEncoding.GetPreamble
 
@@ -14830,7 +16749,365 @@ entry:
 }
 
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[loadElemA]
+Successfully read EncoderNLS.GetBytes
+
+define i32 @EncoderNLS.GetBytes(%System.Text.EncoderNLS addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3, %"System.Byte[]" addrspace(1)* %param4, i32 %param5, i8 %param6) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %arg4 = alloca %"System.Byte[]" addrspace(1)*
+  %arg5 = alloca i32
+  %arg6 = alloca i8
+  %loc0 = alloca i32
+  %loc1 = alloca i16 addrspace(1)*
+  %loc2 = alloca i8 addrspace(1)*
+  %loc3 = alloca i32
+  %loc4 = alloca %"System.Char[]" addrspace(1)*
+  %loc5 = alloca %"System.Byte[]" addrspace(1)*
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  store %"System.Byte[]" addrspace(1)* %param4, %"System.Byte[]" addrspace(1)** %arg4
+  store i32 %param5, i32* %arg5
+  store i8 %param6, i8* %arg6
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %1 = icmp eq %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %17, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %7 = icmp eq %"System.Char[]" addrspace(1)* %6, null
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %12
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %12
+
+; <label>:12                                      ; preds = %8, %10
+  %13 = phi %System.String addrspace(1)* [ %9, %8 ], [ %11, %10 ]
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %14)
+  %16 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16, %System.String addrspace(1)* %13, %System.String addrspace(1)* %15)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16) #0
+  unreachable
+
+; <label>:17                                      ; preds = %2
+  %18 = load i32, i32* %arg2
+  %19 = icmp slt i32 %18, 0
+  br i1 %19, label %23, label %20
+
+; <label>:20                                      ; preds = %17
+  %21 = load i32, i32* %arg3
+  %22 = icmp sge i32 %21, 0
+  br i1 %22, label %35, label %23
+
+; <label>:23                                      ; preds = %17, %20
+  %24 = load i32, i32* %arg2
+  %25 = icmp slt i32 %24, 0
+  br i1 %25, label %28, label %26
+
+; <label>:26                                      ; preds = %23
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %30
+
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %30
+
+; <label>:30                                      ; preds = %26, %28
+  %31 = phi %System.String addrspace(1)* [ %27, %26 ], [ %29, %28 ]
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34, %System.String addrspace(1)* %31, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %20
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck, label %ThrowNullRef, label %37
+
+; <label>:37                                      ; preds = %35
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = load i32, i32* %arg2
+  %43 = sub i32 %41, %42
+  %44 = load i32, i32* %arg3
+  %45 = icmp sge i32 %43, %44
+  br i1 %45, label %51, label %46
+
+; <label>:46                                      ; preds = %37
+  %47 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %48 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %49 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %48)
+  %50 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %50, %System.String addrspace(1)* %47, %System.String addrspace(1)* %49)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %50) #0
+  unreachable
+
+; <label>:51                                      ; preds = %37
+  %52 = load i32, i32* %arg5
+  %53 = icmp slt i32 %52, 0
+  br i1 %53, label %63, label %54
+
+; <label>:54                                      ; preds = %51
+  %55 = load i32, i32* %arg5
+  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck1 = icmp eq %"System.Byte[]" addrspace(1)* %56, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %57
+
+; <label>:57                                      ; preds = %54
+  %58 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = zext i32 %59 to i64
+  %61 = trunc i64 %60 to i32
+  %62 = icmp sle i32 %55, %61
+  br i1 %62, label %68, label %63
+
+; <label>:63                                      ; preds = %51, %57
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %66 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %65)
+  %67 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %67, %System.String addrspace(1)* %64, %System.String addrspace(1)* %66)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %67) #0
+  unreachable
+
+; <label>:68                                      ; preds = %57
+  %69 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %69, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %69, i32 0, i32 1
+  %72 = load i32, i32 addrspace(1)* %71
+  %73 = zext i32 %72 to i64
+  %74 = trunc i64 %73 to i32
+  %75 = icmp ne i32 %74, 0
+  br i1 %75, label %78, label %76
+
+; <label>:76                                      ; preds = %70
+  %77 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1)
+  store %"System.Char[]" addrspace(1)* %77, %"System.Char[]" addrspace(1)** %arg1
+  br label %78
+
+; <label>:78                                      ; preds = %70, %76
+  %79 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck5 = icmp eq %"System.Byte[]" addrspace(1)* %79, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %80
+
+; <label>:80                                      ; preds = %78
+  %81 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %79, i32 0, i32 1
+  %82 = load i32, i32 addrspace(1)* %81
+  %83 = zext i32 %82 to i64
+  %84 = trunc i64 %83 to i32
+  %85 = load i32, i32* %arg5
+  %86 = sub i32 %84, %85
+  store i32 %86, i32* %loc0
+  %87 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck7 = icmp eq %"System.Byte[]" addrspace(1)* %87, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %88
+
+; <label>:88                                      ; preds = %80
+  %89 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %87, i32 0, i32 1
+  %90 = load i32, i32 addrspace(1)* %89
+  %91 = zext i32 %90 to i64
+  %92 = trunc i64 %91 to i32
+  %93 = icmp ne i32 %92, 0
+  br i1 %93, label %96, label %94
+
+; <label>:94                                      ; preds = %88
+  %95 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1)
+  store %"System.Byte[]" addrspace(1)* %95, %"System.Byte[]" addrspace(1)** %arg4
+  br label %96
+
+; <label>:96                                      ; preds = %88, %94
+  %97 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  store %"System.Char[]" addrspace(1)* %97, %"System.Char[]" addrspace(1)** %loc4
+  %98 = icmp eq %"System.Char[]" addrspace(1)* %97, null
+  br i1 %98, label %107, label %99
+
+; <label>:99                                      ; preds = %96
+  %100 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc4
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %100, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %101
+
+; <label>:101                                     ; preds = %99
+  %102 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %100, i32 0, i32 1
+  %103 = load i32, i32 addrspace(1)* %102
+  %104 = zext i32 %103 to i64
+  %105 = trunc i64 %104 to i32
+  %106 = icmp ne i32 %105, 0
+  br i1 %106, label %108, label %107
+
+; <label>:107                                     ; preds = %96, %101
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  br label %116
+
+; <label>:108                                     ; preds = %101
+  %109 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc4
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %109, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %110
+
+; <label>:110                                     ; preds = %108
+  %111 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %109, i32 0, i32 1
+  %112 = load i32, i32 addrspace(1)* %111
+  %113 = zext i32 %112 to i64
+  %BoundsCheck = icmp uge i64 0, %113
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %114
+
+; <label>:114                                     ; preds = %110
+  %115 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %109, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %115, i16 addrspace(1)** %loc1
+  br label %116
+
+; <label>:116                                     ; preds = %107, %114
+  %117 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  store %"System.Byte[]" addrspace(1)* %117, %"System.Byte[]" addrspace(1)** %loc5
+  %118 = icmp eq %"System.Byte[]" addrspace(1)* %117, null
+  br i1 %118, label %127, label %119
+
+; <label>:119                                     ; preds = %116
+  %120 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc5
+  %NullCheck13 = icmp eq %"System.Byte[]" addrspace(1)* %120, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %121
+
+; <label>:121                                     ; preds = %119
+  %122 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %120, i32 0, i32 1
+  %123 = load i32, i32 addrspace(1)* %122
+  %124 = zext i32 %123 to i64
+  %125 = trunc i64 %124 to i32
+  %126 = icmp ne i32 %125, 0
+  br i1 %126, label %128, label %127
+
+; <label>:127                                     ; preds = %116, %121
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc2
+  br label %136
+
+; <label>:128                                     ; preds = %121
+  %129 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc5
+  %NullCheck15 = icmp eq %"System.Byte[]" addrspace(1)* %129, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %130
+
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %129, i32 0, i32 1
+  %132 = load i32, i32 addrspace(1)* %131
+  %133 = zext i32 %132 to i64
+  %BoundsCheck17 = icmp uge i64 0, %133
+  br i1 %BoundsCheck17, label %ThrowIndexOutOfRange18, label %134
+
+; <label>:134                                     ; preds = %130
+  %135 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %129, i32 0, i32 3, i32 0
+  store i8 addrspace(1)* %135, i8 addrspace(1)** %loc2
+  br label %136
+
+; <label>:136                                     ; preds = %127, %134
+  %137 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %138 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %139 = ptrtoint i16 addrspace(1)* %138 to i64
+  %140 = load i32, i32* %arg2
+  %141 = sext i32 %140 to i64
+  %142 = mul i64 %141, 2
+  %143 = add i64 %139, %142
+  %144 = load i32, i32* %arg3
+  %145 = load i8 addrspace(1)*, i8 addrspace(1)** %loc2
+  %146 = ptrtoint i8 addrspace(1)* %145 to i64
+  %147 = load i32, i32* %arg5
+  %148 = sext i32 %147 to i64
+  %149 = add i64 %146, %148
+  %150 = load i32, i32* %loc0
+  %151 = load i8, i8* %arg6
+  %152 = zext i8 %151 to i32
+  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i64 addrspace(1)*
+  %NullCheck19 = icmp eq i64 addrspace(1)* %153, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %154
+
+; <label>:154                                     ; preds = %136
+  %155 = load i64, i64 addrspace(1)* %153
+  %156 = add i64 %155, 72
+  %157 = inttoptr i64 %156 to i64*
+  %158 = load i64, i64* %157
+  %159 = add i64 %158, 0
+  %160 = inttoptr i64 %159 to i64*
+  %161 = load i64, i64* %160
+  %162 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to %System.Text.Encoder addrspace(1)*
+  %163 = inttoptr i64 %143 to i16*
+  %164 = inttoptr i64 %149 to i8*
+  %165 = trunc i32 %152 to i8
+  %166 = inttoptr i64 %161 to i32 (%System.Text.Encoder addrspace(1)*, i16*, i32, i8*, i32, i8)*
+  %167 = call i32 %166(%System.Text.Encoder addrspace(1)* %162, i16* %163, i32 %144, i8* %164, i32 %150, i8 %165)
+  store i32 %167, i32* %loc3
+  br label %168
+
+; <label>:168                                     ; preds = %154
+  %169 = load i32, i32* %loc3
+  ret i32 %169
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %110
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %119
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange18:                           ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
 Successfully read EncoderNLS.GetBytes
 
@@ -14919,22 +17196,22 @@ entry:
   %40 = load i8, i8* %arg5
   %41 = zext i8 %40 to i32
   %42 = trunc i32 %41 to i8
-  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %39, null
-  br i1 %NullCheck, label %43, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderNLS addrspace(1)* %39, null
+  br i1 %NullCheck, label %ThrowNullRef, label %43
 
 ; <label>:43                                      ; preds = %38
   %44 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
   store i8 %42, i8 addrspace(1)* %44
   %45 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %45, null
-  br i1 %NullCheck2, label %46, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.EncoderNLS addrspace(1)* %45, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %46
 
 ; <label>:46                                      ; preds = %43
   %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %45, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %47
   %48 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.EncoderNLS addrspace(1)* %48, null
-  br i1 %NullCheck4, label %49, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.EncoderNLS addrspace(1)* %48, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %49
 
 ; <label>:49                                      ; preds = %46
   %50 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %48, i32 0, i32 3
@@ -14945,8 +17222,8 @@ entry:
   %55 = load i32, i32* %arg4
   %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck6, label %58, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
   %59 = load i64, i64 addrspace(1)* %57
@@ -14964,15 +17241,15 @@ ThrowNullRef:                                     ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %43
+ThrowNullRef2:                                    ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %46
+ThrowNullRef4:                                    ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %49
+ThrowNullRef6:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -15000,8 +17277,8 @@ entry:
   %4 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0 to %System.IO.ConsoleStream addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*)(%System.IO.ConsoleStream addrspace(1)* %4, %"System.Byte[]" addrspace(1)* %1, i32 %2, i32 %3)
   %5 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
@@ -15086,8 +17363,8 @@ entry:
 
 ; <label>:22                                      ; preds = %8
   %23 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %23, null
-  br i1 %NullCheck, label %24, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Byte[]" addrspace(1)* %23, null
+  br i1 %NullCheck, label %ThrowNullRef, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
@@ -15109,8 +17386,8 @@ entry:
 
 ; <label>:36                                      ; preds = %24
   %37 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %37, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.ConsoleStream addrspace(1)* %37, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %37, i32 0, i32 4
@@ -15131,13 +17408,138 @@ ThrowNullRef:                                     ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %36
+ThrowNullRef2:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
-Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
+Successfully read WindowsConsoleStream.WriteFileNative
+
+define i32 @WindowsConsoleStream.WriteFileNative(i64 %param0, %"System.Byte[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i64
+  %arg1 = alloca %"System.Byte[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i8 addrspace(1)*
+  %loc2 = alloca %"System.Byte[]" addrspace(1)*
+  %loc3 = alloca i32
+  store i64 %param0, i64* %arg0
+  store %"System.Byte[]" addrspace(1)* %param1, %"System.Byte[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Byte[]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = zext i32 %3 to i64
+  %5 = icmp ne i64 %4, 0
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %1
+  ret i32 0
+
+; <label>:7                                       ; preds = %1
+  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  store %"System.Byte[]" addrspace(1)* %8, %"System.Byte[]" addrspace(1)** %loc2
+  %9 = icmp eq %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %9, label %18, label %10
+
+; <label>:10                                      ; preds = %7
+  %11 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc2
+  %NullCheck1 = icmp eq %"System.Byte[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %11, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp ne i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %7, %12
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc1
+  br label %27
+
+; <label>:19                                      ; preds = %12
+  %20 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc2
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %20, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %BoundsCheck = icmp uge i64 0, %24
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %25
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %20, i32 0, i32 3, i32 0
+  store i8 addrspace(1)* %26, i8 addrspace(1)** %loc1
+  br label %27
+
+; <label>:27                                      ; preds = %18, %25
+  %28 = load i64, i64* %arg0
+  %29 = load i8 addrspace(1)*, i8 addrspace(1)** %loc1
+  %30 = ptrtoint i8 addrspace(1)* %29 to i64
+  %31 = load i32, i32* %arg2
+  %32 = sext i32 %31 to i64
+  %33 = add i64 %30, %32
+  %34 = load i32, i32* %arg3
+  %35 = addrspacecast i32* %loc3 to i32 addrspace(1)*
+  %36 = inttoptr i64 %33 to i8*
+  %37 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i8*, i32, i32 addrspace(1)*, i64)*)(i64 %28, i8* %36, i32 %34, i32 addrspace(1)* %35, i64 0)
+  %38 = icmp ugt i32 %37, 0
+  %39 = sext i1 %38 to i32
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc1
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %42, label %41
+
+; <label>:41                                      ; preds = %27
+  ret i32 0
+
+; <label>:42                                      ; preds = %27
+  %43 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  store i32 %43, i32* %loc0
+  %44 = load i32, i32* %loc0
+  %45 = icmp eq i32 %44, 232
+  br i1 %45, label %49, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = load i32, i32* %loc0
+  %48 = icmp ne i32 %47, 109
+  br i1 %48, label %50, label %49
+
+; <label>:49                                      ; preds = %42, %46
+  ret i32 0
+
+; <label>:50                                      ; preds = %46
+  %51 = load i32, i32* %loc0
+  ret i32 %51
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
 Successfully read WindowsConsoleStream.Flush
 
@@ -15146,8 +17548,8 @@ entry:
   %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
   store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
@@ -15182,8 +17584,8 @@ entry:
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
   %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load i64, i64 addrspace(1)* %1
@@ -15222,15 +17624,15 @@ entry:
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.TextWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
   %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %3, align 8
   %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
   %7 = load i64, i64 addrspace(1)* %5
@@ -15248,7 +17650,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -15277,8 +17679,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %4)
   store i32 0, i32* %loc0
   %5 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Char[]" addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
@@ -15290,15 +17692,15 @@ entry:
 
 ; <label>:11                                      ; preds = %69
   %12 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %12, i32 0, i32 9
   %15 = load i32, i32 addrspace(1)* %14, align 8
   %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.IO.StreamWriter addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %16, i32 0, i32 10
@@ -15313,15 +17715,15 @@ entry:
 
 ; <label>:23                                      ; preds = %17, %21
   %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %24, null
-  br i1 %NullCheck8, label %25, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %24, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 10
   %27 = load i32, i32 addrspace(1)* %26, align 8
   %28 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %28, null
-  br i1 %NullCheck10, label %29, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.StreamWriter addrspace(1)* %28, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %28, i32 0, i32 9
@@ -15343,15 +17745,15 @@ entry:
   %40 = load i32, i32* %loc0
   %41 = mul i32 %40, 2
   %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
-  br i1 %NullCheck12, label %43, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %43
 
 ; <label>:43                                      ; preds = %38
   %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 7
   %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %44, align 8
   %46 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %46, null
-  br i1 %NullCheck14, label %47, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.IO.StreamWriter addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %47
 
 ; <label>:47                                      ; preds = %43
   %48 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %46, i32 0, i32 9
@@ -15363,16 +17765,16 @@ entry:
   %54 = bitcast %"System.Char[]" addrspace(1)* %45 to %System.Array addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %53, i32 %41, %System.Array addrspace(1)* %54, i32 %50, i32 %52)
   %55 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
-  br i1 %NullCheck16, label %56, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %56
 
 ; <label>:56                                      ; preds = %47
   %57 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
   %58 = load i32, i32 addrspace(1)* %57, align 8
   %59 = load i32, i32* %loc2
   %60 = add i32 %58, %59
-  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
-  br i1 %NullCheck18, label %61, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %61
 
 ; <label>:61                                      ; preds = %56
   %62 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
@@ -15394,8 +17796,8 @@ entry:
 
 ; <label>:72                                      ; preds = %69
   %73 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %73, null
-  br i1 %NullCheck2, label %74, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %73, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %74
 
 ; <label>:74                                      ; preds = %72
   %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %73, i32 0, i32 11
@@ -15416,39 +17818,39 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %72
+ThrowNullRef2:                                    ; preds = %72
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %23
+ThrowNullRef8:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef10:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %43
+ThrowNullRef14:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %47
+ThrowNullRef16:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %56
+ThrowNullRef18:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPDivConst.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPDivConst.error.txt
@@ -25,8 +25,8 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
@@ -40,8 +40,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
   %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
@@ -75,7 +75,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -90,8 +90,8 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %NullCheck = icmp ne i8 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = load i8, i8 addrspace(1)* %0, align 8
@@ -125,8 +125,8 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
@@ -159,8 +159,8 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -184,8 +184,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
   store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
@@ -195,8 +195,8 @@ entry:
 ; <label>:4                                       ; preds = %1
   %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
   %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
@@ -206,8 +206,8 @@ entry:
   %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
@@ -221,14 +221,14 @@ entry:
 
 ; <label>:17                                      ; preds = %14
   %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
   %21 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
@@ -238,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -249,8 +249,8 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
@@ -261,27 +261,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %30
+ThrowNullRef10:                                   ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -301,7 +301,89 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
-Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
+Successfully read AppDomainSetup.GetUnsecureApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.GetUnsecureApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %NullCheck = icmp eq %"System.String[]" addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %BoundsCheck = icmp uge i64 0, %5
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %6
+
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 3, i32 0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
+  ret %System.String addrspace(1)* %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_Value using LLILCJit
+Successfully read AppDomainSetup.get_Value
+
+define %"System.String[]" addrspace(1)* @AppDomainSetup.get_Value(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.String[]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 18)
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.String[]" addrspace(1)* addrspace(1)*, %"System.String[]" addrspace(1)*)*)(%"System.String[]" addrspace(1)* addrspace(1)* %9, %"System.String[]" addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %11, i32 0, i32 1
+  %14 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %13, align 8
+  ret %"System.String[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -319,8 +401,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -368,16 +450,16 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
   %5 = load i32, i32 addrspace(1)* %4
   %6 = sub i32 %5, 1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -389,7 +471,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -421,8 +503,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
@@ -456,8 +538,8 @@ entry:
 ; <label>:27                                      ; preds = %19
   %28 = load i32, i32* %arg1
   %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
-  br i1 %NullCheck2, label %30, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %29, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %30
 
 ; <label>:30                                      ; preds = %27
   %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
@@ -493,8 +575,8 @@ entry:
 ; <label>:49                                      ; preds = %46
   %50 = load i32, i32* %arg2
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck4, label %52, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
@@ -517,11 +599,11 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %27
+ThrowNullRef2:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %49
+ThrowNullRef4:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -544,16 +626,16 @@ entry:
   %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %0)
   store %System.String addrspace(1)* %1, %System.String addrspace(1)** %loc0
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 2
   %5 = bitcast [0 x i16] addrspace(1)* %4 to i16 addrspace(1)*
   store i16 addrspace(1)* %5, i16 addrspace(1)** %loc1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %3
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2
@@ -580,7 +662,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -691,15 +773,15 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %NullCheck132 = icmp ne i8* %21, null
-  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+  %NullCheck131 = icmp eq i8* %21, null
+  br i1 %NullCheck131, label %ThrowNullRef132, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = load i8, i8* %21, align 8
   %24 = zext i8 %23 to i32
   %25 = trunc i32 %24 to i8
-  %NullCheck134 = icmp ne i8* %20, null
-  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+  %NullCheck133 = icmp eq i8* %20, null
+  br i1 %NullCheck133, label %ThrowNullRef134, label %26
 
 ; <label>:26                                      ; preds = %22
   store i8 %25, i8* %20, align 8
@@ -709,16 +791,16 @@ entry:
   %28 = load i8*, i8** %arg0
   %29 = load i8*, i8** %arg1
   %30 = bitcast i8* %29 to i16*
-  %NullCheck128 = icmp ne i16* %30, null
-  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+  %NullCheck127 = icmp eq i16* %30, null
+  br i1 %NullCheck127, label %ThrowNullRef128, label %31
 
 ; <label>:31                                      ; preds = %27
   %32 = load i16, i16* %30, align 8
   %33 = sext i16 %32 to i32
   %34 = bitcast i8* %28 to i16*
   %35 = trunc i32 %33 to i16
-  %NullCheck130 = icmp ne i16* %34, null
-  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+  %NullCheck129 = icmp eq i16* %34, null
+  br i1 %NullCheck129, label %ThrowNullRef130, label %36
 
 ; <label>:36                                      ; preds = %31
   store i16 %35, i16* %34, align 8
@@ -728,16 +810,16 @@ entry:
   %38 = load i8*, i8** %arg0
   %39 = load i8*, i8** %arg1
   %40 = bitcast i8* %39 to i16*
-  %NullCheck120 = icmp ne i16* %40, null
-  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+  %NullCheck119 = icmp eq i16* %40, null
+  br i1 %NullCheck119, label %ThrowNullRef120, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i16, i16* %40, align 8
   %43 = sext i16 %42 to i32
   %44 = bitcast i8* %38 to i16*
   %45 = trunc i32 %43 to i16
-  %NullCheck122 = icmp ne i16* %44, null
-  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+  %NullCheck121 = icmp eq i16* %44, null
+  br i1 %NullCheck121, label %ThrowNullRef122, label %46
 
 ; <label>:46                                      ; preds = %41
   store i16 %45, i16* %44, align 8
@@ -745,15 +827,15 @@ entry:
   %48 = getelementptr inbounds i8, i8* %47, i64 2
   %49 = load i8*, i8** %arg1
   %50 = getelementptr inbounds i8, i8* %49, i64 2
-  %NullCheck124 = icmp ne i8* %50, null
-  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+  %NullCheck123 = icmp eq i8* %50, null
+  br i1 %NullCheck123, label %ThrowNullRef124, label %51
 
 ; <label>:51                                      ; preds = %46
   %52 = load i8, i8* %50, align 8
   %53 = zext i8 %52 to i32
   %54 = trunc i32 %53 to i8
-  %NullCheck126 = icmp ne i8* %48, null
-  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+  %NullCheck125 = icmp eq i8* %48, null
+  br i1 %NullCheck125, label %ThrowNullRef126, label %55
 
 ; <label>:55                                      ; preds = %51
   store i8 %54, i8* %48, align 8
@@ -763,14 +845,14 @@ entry:
   %57 = load i8*, i8** %arg0
   %58 = load i8*, i8** %arg1
   %59 = bitcast i8* %58 to i32*
-  %NullCheck116 = icmp ne i32* %59, null
-  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+  %NullCheck115 = icmp eq i32* %59, null
+  br i1 %NullCheck115, label %ThrowNullRef116, label %60
 
 ; <label>:60                                      ; preds = %56
   %61 = load i32, i32* %59, align 8
   %62 = bitcast i8* %57 to i32*
-  %NullCheck118 = icmp ne i32* %62, null
-  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+  %NullCheck117 = icmp eq i32* %62, null
+  br i1 %NullCheck117, label %ThrowNullRef118, label %63
 
 ; <label>:63                                      ; preds = %60
   store i32 %61, i32* %62, align 8
@@ -780,14 +862,14 @@ entry:
   %65 = load i8*, i8** %arg0
   %66 = load i8*, i8** %arg1
   %67 = bitcast i8* %66 to i32*
-  %NullCheck108 = icmp ne i32* %67, null
-  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+  %NullCheck107 = icmp eq i32* %67, null
+  br i1 %NullCheck107, label %ThrowNullRef108, label %68
 
 ; <label>:68                                      ; preds = %64
   %69 = load i32, i32* %67, align 8
   %70 = bitcast i8* %65 to i32*
-  %NullCheck110 = icmp ne i32* %70, null
-  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+  %NullCheck109 = icmp eq i32* %70, null
+  br i1 %NullCheck109, label %ThrowNullRef110, label %71
 
 ; <label>:71                                      ; preds = %68
   store i32 %69, i32* %70, align 8
@@ -795,15 +877,15 @@ entry:
   %73 = getelementptr inbounds i8, i8* %72, i64 4
   %74 = load i8*, i8** %arg1
   %75 = getelementptr inbounds i8, i8* %74, i64 4
-  %NullCheck112 = icmp ne i8* %75, null
-  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+  %NullCheck111 = icmp eq i8* %75, null
+  br i1 %NullCheck111, label %ThrowNullRef112, label %76
 
 ; <label>:76                                      ; preds = %71
   %77 = load i8, i8* %75, align 8
   %78 = zext i8 %77 to i32
   %79 = trunc i32 %78 to i8
-  %NullCheck114 = icmp ne i8* %73, null
-  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+  %NullCheck113 = icmp eq i8* %73, null
+  br i1 %NullCheck113, label %ThrowNullRef114, label %80
 
 ; <label>:80                                      ; preds = %76
   store i8 %79, i8* %73, align 8
@@ -813,14 +895,14 @@ entry:
   %82 = load i8*, i8** %arg0
   %83 = load i8*, i8** %arg1
   %84 = bitcast i8* %83 to i32*
-  %NullCheck100 = icmp ne i32* %84, null
-  br i1 %NullCheck100, label %85, label %ThrowNullRef99
+  %NullCheck99 = icmp eq i32* %84, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %85
 
 ; <label>:85                                      ; preds = %81
   %86 = load i32, i32* %84, align 8
   %87 = bitcast i8* %82 to i32*
-  %NullCheck102 = icmp ne i32* %87, null
-  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+  %NullCheck101 = icmp eq i32* %87, null
+  br i1 %NullCheck101, label %ThrowNullRef102, label %88
 
 ; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
@@ -829,16 +911,16 @@ entry:
   %91 = load i8*, i8** %arg1
   %92 = getelementptr inbounds i8, i8* %91, i64 4
   %93 = bitcast i8* %92 to i16*
-  %NullCheck104 = icmp ne i16* %93, null
-  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+  %NullCheck103 = icmp eq i16* %93, null
+  br i1 %NullCheck103, label %ThrowNullRef104, label %94
 
 ; <label>:94                                      ; preds = %88
   %95 = load i16, i16* %93, align 8
   %96 = sext i16 %95 to i32
   %97 = bitcast i8* %90 to i16*
   %98 = trunc i32 %96 to i16
-  %NullCheck106 = icmp ne i16* %97, null
-  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+  %NullCheck105 = icmp eq i16* %97, null
+  br i1 %NullCheck105, label %ThrowNullRef106, label %99
 
 ; <label>:99                                      ; preds = %94
   store i16 %98, i16* %97, align 8
@@ -848,14 +930,14 @@ entry:
   %101 = load i8*, i8** %arg0
   %102 = load i8*, i8** %arg1
   %103 = bitcast i8* %102 to i32*
-  %NullCheck88 = icmp ne i32* %103, null
-  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+  %NullCheck87 = icmp eq i32* %103, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %104
 
 ; <label>:104                                     ; preds = %100
   %105 = load i32, i32* %103, align 8
   %106 = bitcast i8* %101 to i32*
-  %NullCheck90 = icmp ne i32* %106, null
-  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+  %NullCheck89 = icmp eq i32* %106, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %107
 
 ; <label>:107                                     ; preds = %104
   store i32 %105, i32* %106, align 8
@@ -864,16 +946,16 @@ entry:
   %110 = load i8*, i8** %arg1
   %111 = getelementptr inbounds i8, i8* %110, i64 4
   %112 = bitcast i8* %111 to i16*
-  %NullCheck92 = icmp ne i16* %112, null
-  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+  %NullCheck91 = icmp eq i16* %112, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %113
 
 ; <label>:113                                     ; preds = %107
   %114 = load i16, i16* %112, align 8
   %115 = sext i16 %114 to i32
   %116 = bitcast i8* %109 to i16*
   %117 = trunc i32 %115 to i16
-  %NullCheck94 = icmp ne i16* %116, null
-  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+  %NullCheck93 = icmp eq i16* %116, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %118
 
 ; <label>:118                                     ; preds = %113
   store i16 %117, i16* %116, align 8
@@ -881,15 +963,15 @@ entry:
   %120 = getelementptr inbounds i8, i8* %119, i64 6
   %121 = load i8*, i8** %arg1
   %122 = getelementptr inbounds i8, i8* %121, i64 6
-  %NullCheck96 = icmp ne i8* %122, null
-  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+  %NullCheck95 = icmp eq i8* %122, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %123
 
 ; <label>:123                                     ; preds = %118
   %124 = load i8, i8* %122, align 8
   %125 = zext i8 %124 to i32
   %126 = trunc i32 %125 to i8
-  %NullCheck98 = icmp ne i8* %120, null
-  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+  %NullCheck97 = icmp eq i8* %120, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %127
 
 ; <label>:127                                     ; preds = %123
   store i8 %126, i8* %120, align 8
@@ -899,14 +981,14 @@ entry:
   %129 = load i8*, i8** %arg0
   %130 = load i8*, i8** %arg1
   %131 = bitcast i8* %130 to i64*
-  %NullCheck84 = icmp ne i64* %131, null
-  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+  %NullCheck83 = icmp eq i64* %131, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %132
 
 ; <label>:132                                     ; preds = %128
   %133 = load i64, i64* %131, align 8
   %134 = bitcast i8* %129 to i64*
-  %NullCheck86 = icmp ne i64* %134, null
-  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+  %NullCheck85 = icmp eq i64* %134, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %135
 
 ; <label>:135                                     ; preds = %132
   store i64 %133, i64* %134, align 8
@@ -916,14 +998,14 @@ entry:
   %137 = load i8*, i8** %arg0
   %138 = load i8*, i8** %arg1
   %139 = bitcast i8* %138 to i64*
-  %NullCheck76 = icmp ne i64* %139, null
-  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+  %NullCheck75 = icmp eq i64* %139, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %140
 
 ; <label>:140                                     ; preds = %136
   %141 = load i64, i64* %139, align 8
   %142 = bitcast i8* %137 to i64*
-  %NullCheck78 = icmp ne i64* %142, null
-  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+  %NullCheck77 = icmp eq i64* %142, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %143
 
 ; <label>:143                                     ; preds = %140
   store i64 %141, i64* %142, align 8
@@ -931,15 +1013,15 @@ entry:
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %NullCheck80 = icmp ne i8* %147, null
-  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+  %NullCheck79 = icmp eq i8* %147, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %148
 
 ; <label>:148                                     ; preds = %143
   %149 = load i8, i8* %147, align 8
   %150 = zext i8 %149 to i32
   %151 = trunc i32 %150 to i8
-  %NullCheck82 = icmp ne i8* %145, null
-  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+  %NullCheck81 = icmp eq i8* %145, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %152
 
 ; <label>:152                                     ; preds = %148
   store i8 %151, i8* %145, align 8
@@ -949,14 +1031,14 @@ entry:
   %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
   %156 = bitcast i8* %155 to i64*
-  %NullCheck68 = icmp ne i64* %156, null
-  br i1 %NullCheck68, label %157, label %ThrowNullRef67
+  %NullCheck67 = icmp eq i64* %156, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %157
 
 ; <label>:157                                     ; preds = %153
   %158 = load i64, i64* %156, align 8
   %159 = bitcast i8* %154 to i64*
-  %NullCheck70 = icmp ne i64* %159, null
-  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+  %NullCheck69 = icmp eq i64* %159, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %160
 
 ; <label>:160                                     ; preds = %157
   store i64 %158, i64* %159, align 8
@@ -965,16 +1047,16 @@ entry:
   %163 = load i8*, i8** %arg1
   %164 = getelementptr inbounds i8, i8* %163, i64 8
   %165 = bitcast i8* %164 to i16*
-  %NullCheck72 = icmp ne i16* %165, null
-  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+  %NullCheck71 = icmp eq i16* %165, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %166
 
 ; <label>:166                                     ; preds = %160
   %167 = load i16, i16* %165, align 8
   %168 = sext i16 %167 to i32
   %169 = bitcast i8* %162 to i16*
   %170 = trunc i32 %168 to i16
-  %NullCheck74 = icmp ne i16* %169, null
-  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+  %NullCheck73 = icmp eq i16* %169, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %171
 
 ; <label>:171                                     ; preds = %166
   store i16 %170, i16* %169, align 8
@@ -984,14 +1066,14 @@ entry:
   %173 = load i8*, i8** %arg0
   %174 = load i8*, i8** %arg1
   %175 = bitcast i8* %174 to i64*
-  %NullCheck56 = icmp ne i64* %175, null
-  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+  %NullCheck55 = icmp eq i64* %175, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %176
 
 ; <label>:176                                     ; preds = %172
   %177 = load i64, i64* %175, align 8
   %178 = bitcast i8* %173 to i64*
-  %NullCheck58 = icmp ne i64* %178, null
-  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+  %NullCheck57 = icmp eq i64* %178, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %179
 
 ; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
@@ -1000,16 +1082,16 @@ entry:
   %182 = load i8*, i8** %arg1
   %183 = getelementptr inbounds i8, i8* %182, i64 8
   %184 = bitcast i8* %183 to i16*
-  %NullCheck60 = icmp ne i16* %184, null
-  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+  %NullCheck59 = icmp eq i16* %184, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %185
 
 ; <label>:185                                     ; preds = %179
   %186 = load i16, i16* %184, align 8
   %187 = sext i16 %186 to i32
   %188 = bitcast i8* %181 to i16*
   %189 = trunc i32 %187 to i16
-  %NullCheck62 = icmp ne i16* %188, null
-  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+  %NullCheck61 = icmp eq i16* %188, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %190
 
 ; <label>:190                                     ; preds = %185
   store i16 %189, i16* %188, align 8
@@ -1017,15 +1099,15 @@ entry:
   %192 = getelementptr inbounds i8, i8* %191, i64 10
   %193 = load i8*, i8** %arg1
   %194 = getelementptr inbounds i8, i8* %193, i64 10
-  %NullCheck64 = icmp ne i8* %194, null
-  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+  %NullCheck63 = icmp eq i8* %194, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %195
 
 ; <label>:195                                     ; preds = %190
   %196 = load i8, i8* %194, align 8
   %197 = zext i8 %196 to i32
   %198 = trunc i32 %197 to i8
-  %NullCheck66 = icmp ne i8* %192, null
-  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+  %NullCheck65 = icmp eq i8* %192, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %199
 
 ; <label>:199                                     ; preds = %195
   store i8 %198, i8* %192, align 8
@@ -1035,14 +1117,14 @@ entry:
   %201 = load i8*, i8** %arg0
   %202 = load i8*, i8** %arg1
   %203 = bitcast i8* %202 to i64*
-  %NullCheck48 = icmp ne i64* %203, null
-  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+  %NullCheck47 = icmp eq i64* %203, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %204
 
 ; <label>:204                                     ; preds = %200
   %205 = load i64, i64* %203, align 8
   %206 = bitcast i8* %201 to i64*
-  %NullCheck50 = icmp ne i64* %206, null
-  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+  %NullCheck49 = icmp eq i64* %206, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %207
 
 ; <label>:207                                     ; preds = %204
   store i64 %205, i64* %206, align 8
@@ -1051,14 +1133,14 @@ entry:
   %210 = load i8*, i8** %arg1
   %211 = getelementptr inbounds i8, i8* %210, i64 8
   %212 = bitcast i8* %211 to i32*
-  %NullCheck52 = icmp ne i32* %212, null
-  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+  %NullCheck51 = icmp eq i32* %212, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %213
 
 ; <label>:213                                     ; preds = %207
   %214 = load i32, i32* %212, align 8
   %215 = bitcast i8* %209 to i32*
-  %NullCheck54 = icmp ne i32* %215, null
-  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+  %NullCheck53 = icmp eq i32* %215, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %216
 
 ; <label>:216                                     ; preds = %213
   store i32 %214, i32* %215, align 8
@@ -1068,14 +1150,14 @@ entry:
   %218 = load i8*, i8** %arg0
   %219 = load i8*, i8** %arg1
   %220 = bitcast i8* %219 to i64*
-  %NullCheck36 = icmp ne i64* %220, null
-  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64* %220, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %221
 
 ; <label>:221                                     ; preds = %217
   %222 = load i64, i64* %220, align 8
   %223 = bitcast i8* %218 to i64*
-  %NullCheck38 = icmp ne i64* %223, null
-  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+  %NullCheck37 = icmp eq i64* %223, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %224
 
 ; <label>:224                                     ; preds = %221
   store i64 %222, i64* %223, align 8
@@ -1084,14 +1166,14 @@ entry:
   %227 = load i8*, i8** %arg1
   %228 = getelementptr inbounds i8, i8* %227, i64 8
   %229 = bitcast i8* %228 to i32*
-  %NullCheck40 = icmp ne i32* %229, null
-  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i32* %229, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %230
 
 ; <label>:230                                     ; preds = %224
   %231 = load i32, i32* %229, align 8
   %232 = bitcast i8* %226 to i32*
-  %NullCheck42 = icmp ne i32* %232, null
-  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+  %NullCheck41 = icmp eq i32* %232, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %233
 
 ; <label>:233                                     ; preds = %230
   store i32 %231, i32* %232, align 8
@@ -1099,15 +1181,15 @@ entry:
   %235 = getelementptr inbounds i8, i8* %234, i64 12
   %236 = load i8*, i8** %arg1
   %237 = getelementptr inbounds i8, i8* %236, i64 12
-  %NullCheck44 = icmp ne i8* %237, null
-  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i8* %237, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %238
 
 ; <label>:238                                     ; preds = %233
   %239 = load i8, i8* %237, align 8
   %240 = zext i8 %239 to i32
   %241 = trunc i32 %240 to i8
-  %NullCheck46 = icmp ne i8* %235, null
-  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+  %NullCheck45 = icmp eq i8* %235, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %242
 
 ; <label>:242                                     ; preds = %238
   store i8 %241, i8* %235, align 8
@@ -1117,14 +1199,14 @@ entry:
   %244 = load i8*, i8** %arg0
   %245 = load i8*, i8** %arg1
   %246 = bitcast i8* %245 to i64*
-  %NullCheck24 = icmp ne i64* %246, null
-  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64* %246, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %247
 
 ; <label>:247                                     ; preds = %243
   %248 = load i64, i64* %246, align 8
   %249 = bitcast i8* %244 to i64*
-  %NullCheck26 = icmp ne i64* %249, null
-  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64* %249, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %250
 
 ; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
@@ -1133,14 +1215,14 @@ entry:
   %253 = load i8*, i8** %arg1
   %254 = getelementptr inbounds i8, i8* %253, i64 8
   %255 = bitcast i8* %254 to i32*
-  %NullCheck28 = icmp ne i32* %255, null
-  br i1 %NullCheck28, label %256, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i32* %255, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %256
 
 ; <label>:256                                     ; preds = %250
   %257 = load i32, i32* %255, align 8
   %258 = bitcast i8* %252 to i32*
-  %NullCheck30 = icmp ne i32* %258, null
-  br i1 %NullCheck30, label %259, label %ThrowNullRef29
+  %NullCheck29 = icmp eq i32* %258, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %259
 
 ; <label>:259                                     ; preds = %256
   store i32 %257, i32* %258, align 8
@@ -1149,16 +1231,16 @@ entry:
   %262 = load i8*, i8** %arg1
   %263 = getelementptr inbounds i8, i8* %262, i64 12
   %264 = bitcast i8* %263 to i16*
-  %NullCheck32 = icmp ne i16* %264, null
-  br i1 %NullCheck32, label %265, label %ThrowNullRef31
+  %NullCheck31 = icmp eq i16* %264, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %265
 
 ; <label>:265                                     ; preds = %259
   %266 = load i16, i16* %264, align 8
   %267 = sext i16 %266 to i32
   %268 = bitcast i8* %261 to i16*
   %269 = trunc i32 %267 to i16
-  %NullCheck34 = icmp ne i16* %268, null
-  br i1 %NullCheck34, label %270, label %ThrowNullRef33
+  %NullCheck33 = icmp eq i16* %268, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %270
 
 ; <label>:270                                     ; preds = %265
   store i16 %269, i16* %268, align 8
@@ -1168,14 +1250,14 @@ entry:
   %272 = load i8*, i8** %arg0
   %273 = load i8*, i8** %arg1
   %274 = bitcast i8* %273 to i64*
-  %NullCheck8 = icmp ne i64* %274, null
-  br i1 %NullCheck8, label %275, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64* %274, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %275
 
 ; <label>:275                                     ; preds = %271
   %276 = load i64, i64* %274, align 8
   %277 = bitcast i8* %272 to i64*
-  %NullCheck10 = icmp ne i64* %277, null
-  br i1 %NullCheck10, label %278, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %277, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %278
 
 ; <label>:278                                     ; preds = %275
   store i64 %276, i64* %277, align 8
@@ -1184,14 +1266,14 @@ entry:
   %281 = load i8*, i8** %arg1
   %282 = getelementptr inbounds i8, i8* %281, i64 8
   %283 = bitcast i8* %282 to i32*
-  %NullCheck12 = icmp ne i32* %283, null
-  br i1 %NullCheck12, label %284, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i32* %283, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %284
 
 ; <label>:284                                     ; preds = %278
   %285 = load i32, i32* %283, align 8
   %286 = bitcast i8* %280 to i32*
-  %NullCheck14 = icmp ne i32* %286, null
-  br i1 %NullCheck14, label %287, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i32* %286, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %287
 
 ; <label>:287                                     ; preds = %284
   store i32 %285, i32* %286, align 8
@@ -1200,16 +1282,16 @@ entry:
   %290 = load i8*, i8** %arg1
   %291 = getelementptr inbounds i8, i8* %290, i64 12
   %292 = bitcast i8* %291 to i16*
-  %NullCheck16 = icmp ne i16* %292, null
-  br i1 %NullCheck16, label %293, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i16* %292, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %293
 
 ; <label>:293                                     ; preds = %287
   %294 = load i16, i16* %292, align 8
   %295 = sext i16 %294 to i32
   %296 = bitcast i8* %289 to i16*
   %297 = trunc i32 %295 to i16
-  %NullCheck18 = icmp ne i16* %296, null
-  br i1 %NullCheck18, label %298, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i16* %296, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %298
 
 ; <label>:298                                     ; preds = %293
   store i16 %297, i16* %296, align 8
@@ -1217,15 +1299,15 @@ entry:
   %300 = getelementptr inbounds i8, i8* %299, i64 14
   %301 = load i8*, i8** %arg1
   %302 = getelementptr inbounds i8, i8* %301, i64 14
-  %NullCheck20 = icmp ne i8* %302, null
-  br i1 %NullCheck20, label %303, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i8* %302, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %303
 
 ; <label>:303                                     ; preds = %298
   %304 = load i8, i8* %302, align 8
   %305 = zext i8 %304 to i32
   %306 = trunc i32 %305 to i8
-  %NullCheck22 = icmp ne i8* %300, null
-  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i8* %300, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %307
 
 ; <label>:307                                     ; preds = %303
   store i8 %306, i8* %300, align 8
@@ -1235,14 +1317,14 @@ entry:
   %309 = load i8*, i8** %arg0
   %310 = load i8*, i8** %arg1
   %311 = bitcast i8* %310 to i64*
-  %NullCheck = icmp ne i64* %311, null
-  br i1 %NullCheck, label %312, label %ThrowNullRef
+  %NullCheck = icmp eq i64* %311, null
+  br i1 %NullCheck, label %ThrowNullRef, label %312
 
 ; <label>:312                                     ; preds = %308
   %313 = load i64, i64* %311, align 8
   %314 = bitcast i8* %309 to i64*
-  %NullCheck2 = icmp ne i64* %314, null
-  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64* %314, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %315
 
 ; <label>:315                                     ; preds = %312
   store i64 %313, i64* %314, align 8
@@ -1251,14 +1333,14 @@ entry:
   %318 = load i8*, i8** %arg1
   %319 = getelementptr inbounds i8, i8* %318, i64 8
   %320 = bitcast i8* %319 to i64*
-  %NullCheck4 = icmp ne i64* %320, null
-  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64* %320, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %321
 
 ; <label>:321                                     ; preds = %315
   %322 = load i64, i64* %320, align 8
   %323 = bitcast i8* %317 to i64*
-  %NullCheck6 = icmp ne i64* %323, null
-  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64* %323, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %324
 
 ; <label>:324                                     ; preds = %321
   store i64 %322, i64* %323, align 8
@@ -1286,15 +1368,15 @@ entry:
 ; <label>:338                                     ; preds = %333
   %339 = load i8*, i8** %arg0
   %340 = load i8*, i8** %arg1
-  %NullCheck136 = icmp ne i8* %340, null
-  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+  %NullCheck135 = icmp eq i8* %340, null
+  br i1 %NullCheck135, label %ThrowNullRef136, label %341
 
 ; <label>:341                                     ; preds = %338
   %342 = load i8, i8* %340, align 8
   %343 = zext i8 %342 to i32
   %344 = trunc i32 %343 to i8
-  %NullCheck138 = icmp ne i8* %339, null
-  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+  %NullCheck137 = icmp eq i8* %339, null
+  br i1 %NullCheck137, label %ThrowNullRef138, label %345
 
 ; <label>:345                                     ; preds = %341
   store i8 %344, i8* %339, align 8
@@ -1317,16 +1399,16 @@ entry:
   %357 = load i8*, i8** %arg0
   %358 = load i8*, i8** %arg1
   %359 = bitcast i8* %358 to i16*
-  %NullCheck140 = icmp ne i16* %359, null
-  br i1 %NullCheck140, label %360, label %ThrowNullRef139
+  %NullCheck139 = icmp eq i16* %359, null
+  br i1 %NullCheck139, label %ThrowNullRef140, label %360
 
 ; <label>:360                                     ; preds = %356
   %361 = load i16, i16* %359, align 8
   %362 = sext i16 %361 to i32
   %363 = bitcast i8* %357 to i16*
   %364 = trunc i32 %362 to i16
-  %NullCheck142 = icmp ne i16* %363, null
-  br i1 %NullCheck142, label %365, label %ThrowNullRef141
+  %NullCheck141 = icmp eq i16* %363, null
+  br i1 %NullCheck141, label %ThrowNullRef142, label %365
 
 ; <label>:365                                     ; preds = %360
   store i16 %364, i16* %363, align 8
@@ -1352,14 +1434,14 @@ entry:
   %378 = load i8*, i8** %arg0
   %379 = load i8*, i8** %arg1
   %380 = bitcast i8* %379 to i32*
-  %NullCheck144 = icmp ne i32* %380, null
-  br i1 %NullCheck144, label %381, label %ThrowNullRef143
+  %NullCheck143 = icmp eq i32* %380, null
+  br i1 %NullCheck143, label %ThrowNullRef144, label %381
 
 ; <label>:381                                     ; preds = %377
   %382 = load i32, i32* %380, align 8
   %383 = bitcast i8* %378 to i32*
-  %NullCheck146 = icmp ne i32* %383, null
-  br i1 %NullCheck146, label %384, label %ThrowNullRef145
+  %NullCheck145 = icmp eq i32* %383, null
+  br i1 %NullCheck145, label %ThrowNullRef146, label %384
 
 ; <label>:384                                     ; preds = %381
   store i32 %382, i32* %383, align 8
@@ -1384,14 +1466,14 @@ entry:
   %395 = load i8*, i8** %arg0
   %396 = load i8*, i8** %arg1
   %397 = bitcast i8* %396 to i64*
-  %NullCheck164 = icmp ne i64* %397, null
-  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+  %NullCheck163 = icmp eq i64* %397, null
+  br i1 %NullCheck163, label %ThrowNullRef164, label %398
 
 ; <label>:398                                     ; preds = %394
   %399 = load i64, i64* %397, align 8
   %400 = bitcast i8* %395 to i64*
-  %NullCheck166 = icmp ne i64* %400, null
-  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+  %NullCheck165 = icmp eq i64* %400, null
+  br i1 %NullCheck165, label %ThrowNullRef166, label %401
 
 ; <label>:401                                     ; preds = %398
   store i64 %399, i64* %400, align 8
@@ -1400,14 +1482,14 @@ entry:
   %404 = load i8*, i8** %arg1
   %405 = getelementptr inbounds i8, i8* %404, i64 8
   %406 = bitcast i8* %405 to i64*
-  %NullCheck168 = icmp ne i64* %406, null
-  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+  %NullCheck167 = icmp eq i64* %406, null
+  br i1 %NullCheck167, label %ThrowNullRef168, label %407
 
 ; <label>:407                                     ; preds = %401
   %408 = load i64, i64* %406, align 8
   %409 = bitcast i8* %403 to i64*
-  %NullCheck170 = icmp ne i64* %409, null
-  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+  %NullCheck169 = icmp eq i64* %409, null
+  br i1 %NullCheck169, label %ThrowNullRef170, label %410
 
 ; <label>:410                                     ; preds = %407
   store i64 %408, i64* %409, align 8
@@ -1437,14 +1519,14 @@ entry:
   %425 = load i8*, i8** %arg0
   %426 = load i8*, i8** %arg1
   %427 = bitcast i8* %426 to i64*
-  %NullCheck148 = icmp ne i64* %427, null
-  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+  %NullCheck147 = icmp eq i64* %427, null
+  br i1 %NullCheck147, label %ThrowNullRef148, label %428
 
 ; <label>:428                                     ; preds = %424
   %429 = load i64, i64* %427, align 8
   %430 = bitcast i8* %425 to i64*
-  %NullCheck150 = icmp ne i64* %430, null
-  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+  %NullCheck149 = icmp eq i64* %430, null
+  br i1 %NullCheck149, label %ThrowNullRef150, label %431
 
 ; <label>:431                                     ; preds = %428
   store i64 %429, i64* %430, align 8
@@ -1466,14 +1548,14 @@ entry:
   %441 = load i8*, i8** %arg0
   %442 = load i8*, i8** %arg1
   %443 = bitcast i8* %442 to i32*
-  %NullCheck152 = icmp ne i32* %443, null
-  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+  %NullCheck151 = icmp eq i32* %443, null
+  br i1 %NullCheck151, label %ThrowNullRef152, label %444
 
 ; <label>:444                                     ; preds = %440
   %445 = load i32, i32* %443, align 8
   %446 = bitcast i8* %441 to i32*
-  %NullCheck154 = icmp ne i32* %446, null
-  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+  %NullCheck153 = icmp eq i32* %446, null
+  br i1 %NullCheck153, label %ThrowNullRef154, label %447
 
 ; <label>:447                                     ; preds = %444
   store i32 %445, i32* %446, align 8
@@ -1495,16 +1577,16 @@ entry:
   %457 = load i8*, i8** %arg0
   %458 = load i8*, i8** %arg1
   %459 = bitcast i8* %458 to i16*
-  %NullCheck156 = icmp ne i16* %459, null
-  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+  %NullCheck155 = icmp eq i16* %459, null
+  br i1 %NullCheck155, label %ThrowNullRef156, label %460
 
 ; <label>:460                                     ; preds = %456
   %461 = load i16, i16* %459, align 8
   %462 = sext i16 %461 to i32
   %463 = bitcast i8* %457 to i16*
   %464 = trunc i32 %462 to i16
-  %NullCheck158 = icmp ne i16* %463, null
-  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+  %NullCheck157 = icmp eq i16* %463, null
+  br i1 %NullCheck157, label %ThrowNullRef158, label %465
 
 ; <label>:465                                     ; preds = %460
   store i16 %464, i16* %463, align 8
@@ -1525,15 +1607,15 @@ entry:
 ; <label>:474                                     ; preds = %470
   %475 = load i8*, i8** %arg0
   %476 = load i8*, i8** %arg1
-  %NullCheck160 = icmp ne i8* %476, null
-  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+  %NullCheck159 = icmp eq i8* %476, null
+  br i1 %NullCheck159, label %ThrowNullRef160, label %477
 
 ; <label>:477                                     ; preds = %474
   %478 = load i8, i8* %476, align 8
   %479 = zext i8 %478 to i32
   %480 = trunc i32 %479 to i8
-  %NullCheck162 = icmp ne i8* %475, null
-  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+  %NullCheck161 = icmp eq i8* %475, null
+  br i1 %NullCheck161, label %ThrowNullRef162, label %481
 
 ; <label>:481                                     ; preds = %477
   store i8 %480, i8* %475, align 8
@@ -1553,343 +1635,343 @@ ThrowNullRef:                                     ; preds = %308
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %312
+ThrowNullRef2:                                    ; preds = %312
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %315
+ThrowNullRef4:                                    ; preds = %315
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %321
+ThrowNullRef6:                                    ; preds = %321
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %271
+ThrowNullRef8:                                    ; preds = %271
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %275
+ThrowNullRef10:                                   ; preds = %275
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %278
+ThrowNullRef12:                                   ; preds = %278
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %284
+ThrowNullRef14:                                   ; preds = %284
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %287
+ThrowNullRef16:                                   ; preds = %287
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %293
+ThrowNullRef18:                                   ; preds = %293
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %298
+ThrowNullRef20:                                   ; preds = %298
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %303
+ThrowNullRef22:                                   ; preds = %303
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %243
+ThrowNullRef24:                                   ; preds = %243
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %247
+ThrowNullRef26:                                   ; preds = %247
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %250
+ThrowNullRef28:                                   ; preds = %250
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %256
+ThrowNullRef30:                                   ; preds = %256
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %259
+ThrowNullRef32:                                   ; preds = %259
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %265
+ThrowNullRef34:                                   ; preds = %265
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %217
+ThrowNullRef36:                                   ; preds = %217
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %221
+ThrowNullRef38:                                   ; preds = %221
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %224
+ThrowNullRef40:                                   ; preds = %224
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %230
+ThrowNullRef42:                                   ; preds = %230
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %233
+ThrowNullRef44:                                   ; preds = %233
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %238
+ThrowNullRef46:                                   ; preds = %238
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %200
+ThrowNullRef48:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %204
+ThrowNullRef50:                                   ; preds = %204
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %207
+ThrowNullRef52:                                   ; preds = %207
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %213
+ThrowNullRef54:                                   ; preds = %213
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %172
+ThrowNullRef56:                                   ; preds = %172
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %176
+ThrowNullRef58:                                   ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %179
+ThrowNullRef60:                                   ; preds = %179
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %185
+ThrowNullRef62:                                   ; preds = %185
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %190
+ThrowNullRef64:                                   ; preds = %190
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %195
+ThrowNullRef66:                                   ; preds = %195
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %153
+ThrowNullRef68:                                   ; preds = %153
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %157
+ThrowNullRef70:                                   ; preds = %157
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %160
+ThrowNullRef72:                                   ; preds = %160
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %166
+ThrowNullRef74:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %136
+ThrowNullRef76:                                   ; preds = %136
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %140
+ThrowNullRef78:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %143
+ThrowNullRef80:                                   ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %148
+ThrowNullRef82:                                   ; preds = %148
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %128
+ThrowNullRef84:                                   ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %132
+ThrowNullRef86:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %100
+ThrowNullRef88:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %104
+ThrowNullRef90:                                   ; preds = %104
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %107
+ThrowNullRef92:                                   ; preds = %107
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %113
+ThrowNullRef94:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %118
+ThrowNullRef96:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %123
+ThrowNullRef98:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %81
+ThrowNullRef100:                                  ; preds = %81
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef101:                                  ; preds = %85
+ThrowNullRef102:                                  ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef103:                                  ; preds = %88
+ThrowNullRef104:                                  ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef105:                                  ; preds = %94
+ThrowNullRef106:                                  ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef107:                                  ; preds = %64
+ThrowNullRef108:                                  ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef109:                                  ; preds = %68
+ThrowNullRef110:                                  ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef111:                                  ; preds = %71
+ThrowNullRef112:                                  ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef113:                                  ; preds = %76
+ThrowNullRef114:                                  ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef115:                                  ; preds = %56
+ThrowNullRef116:                                  ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef117:                                  ; preds = %60
+ThrowNullRef118:                                  ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef119:                                  ; preds = %37
+ThrowNullRef120:                                  ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef121:                                  ; preds = %41
+ThrowNullRef122:                                  ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef123:                                  ; preds = %46
+ThrowNullRef124:                                  ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef125:                                  ; preds = %51
+ThrowNullRef126:                                  ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef127:                                  ; preds = %27
+ThrowNullRef128:                                  ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef129:                                  ; preds = %31
+ThrowNullRef130:                                  ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef131:                                  ; preds = %19
+ThrowNullRef132:                                  ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef133:                                  ; preds = %22
+ThrowNullRef134:                                  ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef135:                                  ; preds = %338
+ThrowNullRef136:                                  ; preds = %338
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef137:                                  ; preds = %341
+ThrowNullRef138:                                  ; preds = %341
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef139:                                  ; preds = %356
+ThrowNullRef140:                                  ; preds = %356
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef141:                                  ; preds = %360
+ThrowNullRef142:                                  ; preds = %360
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef143:                                  ; preds = %377
+ThrowNullRef144:                                  ; preds = %377
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef145:                                  ; preds = %381
+ThrowNullRef146:                                  ; preds = %381
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef147:                                  ; preds = %424
+ThrowNullRef148:                                  ; preds = %424
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef149:                                  ; preds = %428
+ThrowNullRef150:                                  ; preds = %428
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef151:                                  ; preds = %440
+ThrowNullRef152:                                  ; preds = %440
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef153:                                  ; preds = %444
+ThrowNullRef154:                                  ; preds = %444
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef155:                                  ; preds = %456
+ThrowNullRef156:                                  ; preds = %456
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef157:                                  ; preds = %460
+ThrowNullRef158:                                  ; preds = %460
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef159:                                  ; preds = %474
+ThrowNullRef160:                                  ; preds = %474
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef161:                                  ; preds = %477
+ThrowNullRef162:                                  ; preds = %477
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef163:                                  ; preds = %394
+ThrowNullRef164:                                  ; preds = %394
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef165:                                  ; preds = %398
+ThrowNullRef166:                                  ; preds = %398
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef167:                                  ; preds = %401
+ThrowNullRef168:                                  ; preds = %401
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef169:                                  ; preds = %407
+ThrowNullRef170:                                  ; preds = %407
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1939,8 +2021,8 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
-  br i1 %NullCheck, label %22, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %ThrowNullRef, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
@@ -1948,8 +2030,8 @@ entry:
   store i32 %24, i32* %loc0
   %25 = load i32, i32* %loc0
   %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %26, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %27
 
 ; <label>:27                                      ; preds = %22
   %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
@@ -1971,7 +2053,7 @@ ThrowNullRef:                                     ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1989,8 +2071,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -2022,15 +2104,15 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2048,16 +2130,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
   %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
   store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %15
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
@@ -2072,8 +2154,8 @@ entry:
   %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
   %29 = ptrtoint i16 addrspace(1)* %28 to i64
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %19
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
@@ -2089,19 +2171,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2114,8 +2196,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
@@ -2128,7 +2210,7 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[loadElem]
+Failed to read AppDomain.PrepareDataForSetup[storeElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
@@ -2202,8 +2284,8 @@ entry:
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
-  br i1 %NullCheck24, label %27, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = load i64, i64 addrspace(1)* %26
@@ -2218,8 +2300,8 @@ entry:
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
-  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
   %41 = load i64, i64 addrspace(1)* %39
@@ -2236,8 +2318,8 @@ entry:
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
-  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
   %54 = load i64, i64 addrspace(1)* %52
@@ -2252,8 +2334,8 @@ entry:
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
   %67 = load i64, i64 addrspace(1)* %65
@@ -2270,8 +2352,8 @@ entry:
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
-  br i1 %NullCheck16, label %79, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
   %80 = load i64, i64 addrspace(1)* %78
@@ -2286,8 +2368,8 @@ entry:
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
-  br i1 %NullCheck18, label %92, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
   %93 = load i64, i64 addrspace(1)* %91
@@ -2304,8 +2386,8 @@ entry:
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
-  br i1 %NullCheck12, label %105, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = load i64, i64 addrspace(1)* %104
@@ -2320,8 +2402,8 @@ entry:
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
-  br i1 %NullCheck14, label %118, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
   %119 = load i64, i64 addrspace(1)* %117
@@ -2337,8 +2419,8 @@ entry:
 
 ; <label>:128                                     ; preds = %20
   %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
-  br i1 %NullCheck4, label %130, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %129, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %130
 
 ; <label>:130                                     ; preds = %128
   %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
@@ -2346,8 +2428,8 @@ entry:
   %133 = load i16, i16 addrspace(1)* %132, align 8
   %134 = zext i16 %133 to i32
   %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
-  br i1 %NullCheck6, label %136, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %135, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %136
 
 ; <label>:136                                     ; preds = %130
   %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
@@ -2360,8 +2442,8 @@ entry:
 
 ; <label>:143                                     ; preds = %136
   %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
-  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %144, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %145
 
 ; <label>:145                                     ; preds = %143
   %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
@@ -2369,8 +2451,8 @@ entry:
   %148 = load i16, i16 addrspace(1)* %147, align 8
   %149 = zext i16 %148 to i32
   %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %150, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %151
 
 ; <label>:151                                     ; preds = %145
   %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
@@ -2388,8 +2470,8 @@ entry:
 
 ; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
-  br i1 %NullCheck, label %163, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %ThrowNullRef, label %163
 
 ; <label>:163                                     ; preds = %161
   %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
@@ -2399,8 +2481,8 @@ entry:
 
 ; <label>:167                                     ; preds = %163
   %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
-  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %168, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %169
 
 ; <label>:169                                     ; preds = %167
   %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
@@ -2432,55 +2514,55 @@ ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %167
+ThrowNullRef2:                                    ; preds = %167
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %128
+ThrowNullRef4:                                    ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %130
+ThrowNullRef6:                                    ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %143
+ThrowNullRef8:                                    ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %145
+ThrowNullRef10:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %102
+ThrowNullRef12:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %105
+ThrowNullRef14:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %76
+ThrowNullRef16:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %79
+ThrowNullRef18:                                   ; preds = %79
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %50
+ThrowNullRef20:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %53
+ThrowNullRef22:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %24
+ThrowNullRef24:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %27
+ThrowNullRef26:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2503,15 +2585,15 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2519,16 +2601,16 @@ entry:
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
   store i32 %8, i32* %loc0
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
   %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
   store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
@@ -2546,16 +2628,16 @@ entry:
 
 ; <label>:23                                      ; preds = %64
   %24 = load i16*, i16** %loc3
-  %NullCheck12 = icmp ne i16* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i16* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
   store i32 %27, i32* %loc5
   %28 = load i16*, i16** %loc4
-  %NullCheck14 = icmp ne i16* %28, null
-  br i1 %NullCheck14, label %29, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %28, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = load i16, i16* %28, align 8
@@ -2620,15 +2702,15 @@ entry:
 
 ; <label>:67                                      ; preds = %64
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
-  br i1 %NullCheck8, label %69, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %68, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %69
 
 ; <label>:69                                      ; preds = %67
   %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
   %71 = load i32, i32 addrspace(1)* %70
   %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
-  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %73
 
 ; <label>:73                                      ; preds = %69
   %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
@@ -2645,31 +2727,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %67
+ThrowNullRef8:                                    ; preds = %67
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %69
+ThrowNullRef10:                                   ; preds = %69
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2710,14 +2792,14 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
   %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
@@ -2730,14 +2812,14 @@ entry:
 
 ; <label>:11                                      ; preds = %4
   %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
   %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
@@ -2749,14 +2831,14 @@ entry:
 
 ; <label>:22                                      ; preds = %16
   %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
   %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
-  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
-  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
@@ -2804,23 +2886,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2836,7 +2918,280 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[loadElem]
+Successfully read RuntimeType.IsAssignableFrom
+
+define i8 @RuntimeType.IsAssignableFrom(%System.RuntimeType addrspace(1)* %param0, %System.Type addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.RuntimeType addrspace(1)*
+  %arg1 = alloca %System.Type addrspace(1)*
+  %loc0 = alloca %System.RuntimeType addrspace(1)*
+  %loc1 = alloca %"System.Type[]" addrspace(1)*
+  %loc2 = alloca i32
+  store %System.RuntimeType addrspace(1)* %param0, %System.RuntimeType addrspace(1)** %this
+  store %System.Type addrspace(1)* %param1, %System.Type addrspace(1)** %arg1
+  %0 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %1 = icmp ne %System.Type addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i8 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %5 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %6 = bitcast %System.Type addrspace(1)* %4 to %System.Object addrspace(1)*
+  %7 = bitcast %System.RuntimeType addrspace(1)* %5 to %System.Object addrspace(1)*
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %6, %System.Object addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %3
+  ret i8 1
+
+; <label>:12                                      ; preds = %3
+  %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 152
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 32
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
+  %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
+  %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
+  store %System.RuntimeType addrspace(1)* %25, %System.RuntimeType addrspace(1)** %loc0
+  %26 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %27 = icmp eq %System.RuntimeType addrspace(1)* %26, null
+  br i1 %27, label %34, label %28
+
+; <label>:28                                      ; preds = %15
+  %29 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %30 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)*)*)(%System.RuntimeType addrspace(1)* %29, %System.RuntimeType addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+; <label>:34                                      ; preds = %15
+  %35 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %36 = call %System.Reflection.Emit.TypeBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Reflection.Emit.TypeBuilder addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %35)
+  %37 = icmp eq %System.Reflection.Emit.TypeBuilder addrspace(1)* %36, null
+  br i1 %37, label %139, label %38
+
+; <label>:38                                      ; preds = %34
+  %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %42
+
+; <label>:42                                      ; preds = %38
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 152
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 40
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
+  %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
+  %53 = zext i8 %52 to i32
+  %54 = icmp eq i32 %53, 0
+  br i1 %54, label %56, label %55
+
+; <label>:55                                      ; preds = %42
+  ret i8 1
+
+; <label>:56                                      ; preds = %42
+  %57 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %58 = bitcast %System.RuntimeType addrspace(1)* %57 to %System.Type addrspace(1)*
+  %59 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %58)
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %64 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.Type addrspace(1)* %63, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = bitcast %System.RuntimeType addrspace(1)* %64 to %System.Type addrspace(1)*
+  %67 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %63, %System.Type addrspace(1)* %66)
+  %68 = zext i8 %67 to i32
+  %69 = trunc i32 %68 to i8
+  ret i8 %69
+
+; <label>:70                                      ; preds = %56
+  %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
+  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %73
+
+; <label>:73                                      ; preds = %70
+  %74 = load i64, i64 addrspace(1)* %72
+  %75 = add i64 %74, 128
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = add i64 %77, 0
+  %79 = inttoptr i64 %78 to i64*
+  %80 = load i64, i64* %79
+  %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
+  %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
+  %83 = call i8 %82(%System.Type addrspace(1)* %81)
+  %84 = zext i8 %83 to i32
+  %85 = icmp eq i32 %84, 0
+  br i1 %85, label %139, label %86
+
+; <label>:86                                      ; preds = %73
+  %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
+  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %89
+
+; <label>:89                                      ; preds = %86
+  %90 = load i64, i64 addrspace(1)* %88
+  %91 = add i64 %90, 128
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = add i64 %93, 24
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
+  %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
+  %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
+  store %"System.Type[]" addrspace(1)* %99, %"System.Type[]" addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %129
+
+; <label>:100                                     ; preds = %132
+  %101 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %102 = load i32, i32* %loc2
+  %NullCheck11 = icmp eq %"System.Type[]" addrspace(1)* %101, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %103
+
+; <label>:103                                     ; preds = %100
+  %104 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 1
+  %105 = load i32, i32 addrspace(1)* %104
+  %106 = zext i32 %105 to i64
+  %107 = zext i32 %102 to i64
+  %BoundsCheck = icmp uge i64 %107, %106
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %108
+
+; <label>:108                                     ; preds = %103
+  %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
+  %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
+  %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
+  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %113
+
+; <label>:113                                     ; preds = %108
+  %114 = load i64, i64 addrspace(1)* %112
+  %115 = add i64 %114, 152
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = add i64 %117, 56
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
+  %123 = zext i8 %122 to i32
+  %124 = icmp ne i32 %123, 0
+  br i1 %124, label %126, label %125
+
+; <label>:125                                     ; preds = %113
+  ret i8 0
+
+; <label>:126                                     ; preds = %113
+  %127 = load i32, i32* %loc2
+  %128 = add i32 %127, 1
+  store i32 %128, i32* %loc2
+  br label %129
+
+; <label>:129                                     ; preds = %89, %126
+  %130 = load i32, i32* %loc2
+  %131 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %NullCheck9 = icmp eq %"System.Type[]" addrspace(1)* %131, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %132
+
+; <label>:132                                     ; preds = %129
+  %133 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %131, i32 0, i32 1
+  %134 = load i32, i32 addrspace(1)* %133
+  %135 = zext i32 %134 to i64
+  %136 = trunc i64 %135 to i32
+  %137 = icmp slt i32 %130, %136
+  br i1 %137, label %100, label %138
+
+; <label>:138                                     ; preds = %132
+  ret i8 1
+
+; <label>:139                                     ; preds = %34, %73
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %129
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %103
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -2893,7 +3248,7 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElem]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -2904,8 +3259,8 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -2997,8 +3352,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
@@ -3059,8 +3414,8 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -3087,8 +3442,8 @@ entry:
 
 ; <label>:17                                      ; preds = %5, %11
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
@@ -3097,8 +3452,8 @@ entry:
 
 ; <label>:22                                      ; preds = %1, %11
   %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
@@ -3109,11 +3464,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %17
+ThrowNullRef2:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %22
+ThrowNullRef4:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3167,15 +3522,15 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
   %15 = load i32, i32 addrspace(1)* %14
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
@@ -3198,7 +3553,7 @@ ThrowNullRef:                                     ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef2:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3232,8 +3587,8 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
@@ -3312,8 +3667,8 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -3327,8 +3682,8 @@ entry:
 ; <label>:5                                       ; preds = %43
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %7 = load i32, i32* %loc1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck6, label %8, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
@@ -3366,8 +3721,8 @@ entry:
 ; <label>:32                                      ; preds = %21, %25
   %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
   %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
-  br i1 %NullCheck8, label %35, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = trunc i32 %34 to i16
@@ -3380,8 +3735,8 @@ entry:
 ; <label>:40                                      ; preds = %1, %35
   %41 = load i32, i32* %loc1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
-  br i1 %NullCheck2, label %43, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %42, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
@@ -3392,8 +3747,8 @@ entry:
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
   %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
-  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
   %51 = load i64, i64 addrspace(1)* %49
@@ -3412,19 +3767,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %40
+ThrowNullRef2:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %47
+ThrowNullRef4:                                    ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %5
+ThrowNullRef6:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %32
+ThrowNullRef8:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3467,8 +3822,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
@@ -3492,11 +3847,391 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(i16* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store i16* %param0, i16** %arg0
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load i32, i32* %arg3
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %42, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %37, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg2
+  %13 = load i32, i32* %arg3
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %37, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %24 = load i32, i32* %arg2
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load i16*, i16** %arg0
+  %35 = load i32, i32* %arg3
+  %36 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %36, i16* %34, i32 %35)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:37                                      ; preds = %5, %16
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %39)
+  %41 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41, %System.String addrspace(1)* %38, %System.String addrspace(1)* %40)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41) #0
+  unreachable
+
+; <label>:42                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
-Failed to read StringBuilder.ToString[loadElemA]
+Successfully read StringBuilder.ToString
+
+define %System.String addrspace(1)* @StringBuilder.ToString(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i16*
+  %loc3 = alloca %"System.Char[]" addrspace(1)*
+  %loc4 = alloca i32
+  %loc5 = alloca i32
+  %loc6 = alloca i16 addrspace(1)*
+  %loc7 = alloca %System.String addrspace(1)*
+  %loc8 = alloca %"System.Char[]" addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %0)
+  %2 = icmp ne i32 %1, 0
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %4
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %6)
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %7)
+  store %System.String addrspace(1)* %8, %System.String addrspace(1)** %loc0
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.Text.StringBuilder addrspace(1)* %9, %System.Text.StringBuilder addrspace(1)** %loc1
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  store %System.String addrspace(1)* %10, %System.String addrspace(1)** %loc7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc7
+  %12 = ptrtoint %System.String addrspace(1)* %11 to i64
+  %13 = icmp eq i64 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %5
+  %15 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %16 = sext i32 %15 to i64
+  %17 = add i64 %12, %16
+  br label %18
+
+; <label>:18                                      ; preds = %5, %14
+  %19 = phi i64 [ %12, %5 ], [ %17, %14 ]
+  %20 = inttoptr i64 %19 to i16*
+  store i16* %20, i16** %loc2
+  br label %21
+
+; <label>:21                                      ; preds = %98, %18
+  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %22, null
+  br i1 %NullCheck, label %ThrowNullRef, label %23
+
+; <label>:23                                      ; preds = %21
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 3
+  %25 = load i32, i32 addrspace(1)* %24, align 8
+  %26 = icmp sle i32 %25, 0
+  br i1 %26, label %96, label %27
+
+; <label>:27                                      ; preds = %23
+  %28 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %28, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %29
+
+; <label>:29                                      ; preds = %27
+  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %28, i32 0, i32 1
+  %31 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %30, align 8
+  store %"System.Char[]" addrspace(1)* %31, %"System.Char[]" addrspace(1)** %loc3
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %33
+
+; <label>:33                                      ; preds = %29
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  store i32 %35, i32* %loc4
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  %39 = load i32, i32 addrspace(1)* %38, align 8
+  store i32 %39, i32* %loc5
+  %40 = load i32, i32* %loc5
+  %41 = load i32, i32* %loc4
+  %42 = add i32 %40, %41
+  %43 = zext i32 %42 to i64
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %45
+
+; <label>:45                                      ; preds = %37
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = sext i32 %47 to i64
+  %49 = icmp sgt i64 %43, %48
+  br i1 %49, label %91, label %50
+
+; <label>:50                                      ; preds = %45
+  %51 = load i32, i32* %loc5
+  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %52, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %53
+
+; <label>:53                                      ; preds = %50
+  %54 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %52, i32 0, i32 1
+  %55 = load i32, i32 addrspace(1)* %54
+  %56 = zext i32 %55 to i64
+  %57 = trunc i64 %56 to i32
+  %58 = icmp ugt i32 %51, %57
+  br i1 %58, label %91, label %59
+
+; <label>:59                                      ; preds = %53
+  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  store %"System.Char[]" addrspace(1)* %60, %"System.Char[]" addrspace(1)** %loc8
+  %61 = icmp eq %"System.Char[]" addrspace(1)* %60, null
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %63, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %64
+
+; <label>:64                                      ; preds = %62
+  %65 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %63, i32 0, i32 1
+  %66 = load i32, i32 addrspace(1)* %65
+  %67 = zext i32 %66 to i64
+  %68 = trunc i64 %67 to i32
+  %69 = icmp ne i32 %68, 0
+  br i1 %69, label %71, label %70
+
+; <label>:70                                      ; preds = %59, %64
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:71                                      ; preds = %64
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %73
+
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %BoundsCheck = icmp uge i64 0, %76
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %77
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %78, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:79                                      ; preds = %70, %77
+  %80 = load i16*, i16** %loc2
+  %81 = load i32, i32* %loc4
+  %82 = sext i32 %81 to i64
+  %83 = mul i64 %82, 2
+  %84 = bitcast i16* %80 to i8*
+  %85 = getelementptr inbounds i8, i8* %84, i64 %83
+  %86 = load i16 addrspace(1)*, i16 addrspace(1)** %loc6
+  %87 = ptrtoint i16 addrspace(1)* %86 to i64
+  %88 = load i32, i32* %loc5
+  %89 = bitcast i8* %85 to i16*
+  %90 = inttoptr i64 %87 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %89, i16* %90, i32 %88)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %96
+
+; <label>:91                                      ; preds = %45, %53
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %94 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %93)
+  %95 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95, %System.String addrspace(1)* %92, %System.String addrspace(1)* %94)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95) #0
+  unreachable
+
+; <label>:96                                      ; preds = %23, %79
+  %97 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %97, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %98
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %97, i32 0, i32 2
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  store %System.Text.StringBuilder addrspace(1)* %100, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %102 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %102, label %21, label %103
+
+; <label>:103                                     ; preds = %98
+  store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc7
+  %104 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  ret %System.String addrspace(1)* %104
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method StringBuilder::get_Length using LLILCJit
+Successfully read StringBuilder.get_Length
+
+define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
+Successfully read RuntimeHelpers.get_OffsetToStringData
+
+define i32 @RuntimeHelpers.get_OffsetToStringData() {
+entry:
+  ret i32 12
+}
+
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
 Successfully read CultureData.CreateCultureData
 
@@ -3514,23 +4249,23 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
   store i8 %4, i8 addrspace(1)* %6
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
@@ -3549,11 +4284,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3566,50 +4301,50 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
   store i32 -1, i32 addrspace(1)* %2
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
   store i32 -1, i32 addrspace(1)* %8
   %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
   store i32 -1, i32 addrspace(1)* %14
   %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
   store i32 -1, i32 addrspace(1)* %17
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
@@ -3623,27 +4358,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3675,7 +4410,136 @@ Failed to read Dictionary`2.Insert[non-const derefAddress]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
 Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
-Failed to read HashHelpers.GetPrime[loadElem]
+Successfully read HashHelpers.GetPrime
+
+define i32 @HashHelpers.GetPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %6, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5, %System.String addrspace(1)* %4)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5) #0
+  unreachable
+
+; <label>:6                                       ; preds = %entry
+  store i32 0, i32* %loc0
+  br label %29
+
+; <label>:7                                       ; preds = %35
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 1296
+  %10 = addrspacecast i8 addrspace(1)* %9 to %"System.Int32[]" addrspace(1)**
+  %11 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %10
+  %12 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Int32[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = zext i32 %15 to i64
+  %17 = zext i32 %12 to i64
+  %BoundsCheck = icmp uge i64 %17, %16
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 3, i32 %12
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  store i32 %20, i32* %loc1
+  %21 = load i32, i32* %loc1
+  %22 = load i32, i32* %arg0
+  %23 = icmp slt i32 %21, %22
+  br i1 %23, label %26, label %24
+
+; <label>:24                                      ; preds = %18
+  %25 = load i32, i32* %loc1
+  ret i32 %25
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %loc0
+  %28 = add i32 %27, 1
+  store i32 %28, i32* %loc0
+  br label %29
+
+; <label>:29                                      ; preds = %6, %26
+  %30 = load i32, i32* %loc0
+  %31 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %32 = getelementptr inbounds i8, i8 addrspace(1)* %31, i64 1296
+  %33 = addrspacecast i8 addrspace(1)* %32 to %"System.Int32[]" addrspace(1)**
+  %34 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %33
+  %NullCheck = icmp eq %"System.Int32[]" addrspace(1)* %34, null
+  br i1 %NullCheck, label %ThrowNullRef, label %35
+
+; <label>:35                                      ; preds = %29
+  %36 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %34, i32 0, i32 1
+  %37 = load i32, i32 addrspace(1)* %36
+  %38 = zext i32 %37 to i64
+  %39 = trunc i64 %38 to i32
+  %40 = icmp slt i32 %30, %39
+  br i1 %40, label %7, label %41
+
+; <label>:41                                      ; preds = %35
+  %42 = load i32, i32* %arg0
+  %43 = or i32 %42, 1
+  store i32 %43, i32* %loc2
+  br label %59
+
+; <label>:44                                      ; preds = %59
+  %45 = load i32, i32* %loc2
+  %46 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %45)
+  %47 = zext i8 %46 to i32
+  %48 = icmp eq i32 %47, 0
+  br i1 %48, label %56, label %49
+
+; <label>:49                                      ; preds = %44
+  %50 = load i32, i32* %loc2
+  %51 = sub i32 %50, 1
+  %52 = srem i32 %51, 101
+  %53 = icmp eq i32 %52, 0
+  br i1 %53, label %56, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = load i32, i32* %loc2
+  ret i32 %55
+
+; <label>:56                                      ; preds = %44, %49
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %57, 2
+  store i32 %58, i32* %loc2
+  br label %59
+
+; <label>:59                                      ; preds = %41, %56
+  %60 = load i32, i32* %loc2
+  %61 = icmp slt i32 %60, 2147483647
+  br i1 %61, label %44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load i32, i32* %arg0
+  ret i32 %63
+
+ThrowNullRef:                                     ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
 Successfully read GenericEqualityComparer`1.GetHashCode
 
@@ -3694,14 +4558,14 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
   %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load i64, i64 addrspace(1)* %7
@@ -3720,7 +4584,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3750,8 +4614,8 @@ entry:
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
@@ -3796,8 +4660,8 @@ entry:
   %35 = bitcast i16* %34 to i8*
   %36 = getelementptr inbounds i8, i8* %35, i64 2
   %37 = bitcast i8* %36 to i16*
-  %NullCheck4 = icmp ne i16* %37, null
-  br i1 %NullCheck4, label %38, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %37, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %38
 
 ; <label>:38                                      ; preds = %27
   %39 = load i16, i16* %37, align 8
@@ -3824,8 +4688,8 @@ entry:
 
 ; <label>:54                                      ; preds = %22, %43
   %55 = load i16*, i16** %loc4
-  %NullCheck2 = icmp ne i16* %55, null
-  br i1 %NullCheck2, label %56, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i16* %55, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %56
 
 ; <label>:56                                      ; preds = %54
   %57 = load i16, i16* %55, align 8
@@ -3850,11 +4714,11 @@ ThrowNullRef:                                     ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %54
+ThrowNullRef2:                                    ; preds = %54
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %27
+ThrowNullRef4:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3871,8 +4735,8 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -3907,8 +4771,8 @@ entry:
 
 ; <label>:26                                      ; preds = %19
   %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
-  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %28
 
 ; <label>:28                                      ; preds = %26
   %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
@@ -3920,7 +4784,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3972,8 +4836,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
@@ -3984,26 +4848,26 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
-  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
@@ -4014,8 +4878,8 @@ entry:
 ; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
@@ -4024,8 +4888,8 @@ entry:
 
 ; <label>:25                                      ; preds = %1, %16, %23
   %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
-  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
@@ -4036,27 +4900,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %20
+ThrowNullRef10:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4069,8 +4933,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -4081,8 +4945,8 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
@@ -4091,8 +4955,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1, %8
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
@@ -4103,11 +4967,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4128,24 +4992,24 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   store i32 %3, i32* %loc0
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
   %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
   store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck4, label %9, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
@@ -4164,15 +5028,15 @@ entry:
 ; <label>:18                                      ; preds = %70
   %19 = load i16*, i16** %loc3
   %20 = bitcast i16* %19 to i64*
-  %NullCheck10 = icmp ne i64* %20, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %20, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = load i64, i64* %20, align 8
   %23 = load i16*, i16** %loc4
   %24 = bitcast i16* %23 to i64*
-  %NullCheck12 = icmp ne i64* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = load i64, i64* %24, align 8
@@ -4188,8 +5052,8 @@ entry:
   %31 = bitcast i16* %30 to i8*
   %32 = getelementptr inbounds i8, i8* %31, i64 8
   %33 = bitcast i8* %32 to i64*
-  %NullCheck14 = icmp ne i64* %33, null
-  br i1 %NullCheck14, label %34, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = load i64, i64* %33, align 8
@@ -4197,8 +5061,8 @@ entry:
   %37 = bitcast i16* %36 to i8*
   %38 = getelementptr inbounds i8, i8* %37, i64 8
   %39 = bitcast i8* %38 to i64*
-  %NullCheck16 = icmp ne i64* %39, null
-  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %40
 
 ; <label>:40                                      ; preds = %34
   %41 = load i64, i64* %39, align 8
@@ -4214,8 +5078,8 @@ entry:
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %NullCheck18 = icmp ne i64* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = load i64, i64* %48, align 8
@@ -4223,8 +5087,8 @@ entry:
   %52 = bitcast i16* %51 to i8*
   %53 = getelementptr inbounds i8, i8* %52, i64 16
   %54 = bitcast i8* %53 to i64*
-  %NullCheck20 = icmp ne i64* %54, null
-  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64* %54, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %55
 
 ; <label>:55                                      ; preds = %49
   %56 = load i64, i64* %54, align 8
@@ -4262,15 +5126,15 @@ entry:
 ; <label>:74                                      ; preds = %95
   %75 = load i16*, i16** %loc3
   %76 = bitcast i16* %75 to i32*
-  %NullCheck6 = icmp ne i32* %76, null
-  br i1 %NullCheck6, label %77, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32* %76, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %77
 
 ; <label>:77                                      ; preds = %74
   %78 = load i32, i32* %76, align 8
   %79 = load i16*, i16** %loc4
   %80 = bitcast i16* %79 to i32*
-  %NullCheck8 = icmp ne i32* %80, null
-  br i1 %NullCheck8, label %81, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i32* %80, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %81
 
 ; <label>:81                                      ; preds = %77
   %82 = load i32, i32* %80, align 8
@@ -4318,43 +5182,43 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %74
+ThrowNullRef6:                                    ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %77
+ThrowNullRef8:                                    ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %29
+ThrowNullRef14:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %34
+ThrowNullRef16:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4376,8 +5240,8 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load i64, i64 addrspace(1)* %4
@@ -4389,8 +5253,8 @@ entry:
   %12 = load i64, i64* %11
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %5
   %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
@@ -4399,8 +5263,8 @@ entry:
   %18 = load i8, i8* %arg2
   %19 = zext i8 %18 to i32
   %20 = trunc i32 %19 to i8
-  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %15
   %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
@@ -4411,11 +5275,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4442,8 +5306,8 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
@@ -4466,16 +5330,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
   %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = load i64, i64 addrspace(1)* %19
@@ -4500,8 +5364,8 @@ entry:
 ; <label>:35                                      ; preds = %30
   %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
@@ -4514,8 +5378,8 @@ entry:
 
 ; <label>:42                                      ; preds = %1, %38
   %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
-  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
@@ -4526,19 +5390,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %35
+ThrowNullRef2:                                    ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %42
+ThrowNullRef8:                                    ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4551,14 +5415,14 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
@@ -4570,7 +5434,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4583,8 +5447,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
@@ -4613,51 +5477,51 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
   %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
   %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
   %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
   %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
-  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
   store i64 %21, i64 addrspace(1)* %23
   %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %25 = load i64, i64* %loc0
-  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
@@ -4668,27 +5532,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %22
+ThrowNullRef12:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4701,8 +5565,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
@@ -4713,19 +5577,19 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
@@ -4734,8 +5598,8 @@ entry:
 
 ; <label>:15                                      ; preds = %1, %13
   %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
@@ -4746,19 +5610,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %15
+ThrowNullRef8:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4771,8 +5635,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -4831,8 +5695,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
@@ -4882,8 +5746,8 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
-  br i1 %NullCheck, label %17, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %ThrowNullRef, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
@@ -4894,15 +5758,15 @@ entry:
 
 ; <label>:22                                      ; preds = %17
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
-  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
   %26 = load i32, i32 addrspace(1)* %25
   %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
-  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %27, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
@@ -4925,8 +5789,8 @@ entry:
 ; <label>:40                                      ; preds = %17
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
-  br i1 %NullCheck6, label %43, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %41, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
@@ -4938,34 +5802,17 @@ ThrowNullRef:                                     ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %24
+ThrowNullRef4:                                    ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %40
+ThrowNullRef6:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
-}
-
-INFO:  jitting method Object::ReferenceEquals using LLILCJit
-Successfully read Object.ReferenceEquals
-
-define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
-entry:
-  %arg0 = alloca %System.Object addrspace(1)*
-  %arg1 = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
-  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
-  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = icmp eq %System.Object addrspace(1)* %0, %1
-  %3 = sext i1 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
 }
 
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
@@ -4978,21 +5825,21 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
   %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
-  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
@@ -5007,28 +5854,28 @@ entry:
 ; <label>:13                                      ; preds = %8, %12
   %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
   %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
   %21 = load i32, i32 addrspace(1)* %20, align 8
   %22 = add i32 %21, 1
-  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
   store i32 %22, i32 addrspace(1)* %24
   %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
@@ -5039,27 +5886,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5077,7 +5924,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::Setup using LLILCJit
-Failed to read AppDomain.Setup[loadElem]
+Failed to read AppDomain.Setup[unbox]
 INFO:  jitting method Thread::GetDomain using LLILCJit
 Successfully read Thread.GetDomain
 
@@ -5108,8 +5955,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
@@ -5122,14 +5969,14 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
   %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
@@ -5141,11 +5988,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5173,8 +6020,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -5189,7 +6036,328 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
 Failed to read KeyCollection.System.Collections.Generic.IEnumerable<TKey>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Successfully read Enumerator.MoveNext
+
+define i8 @Enumerator.MoveNext(%"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.RuntimeTypeHandle* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*
+  %"$TypeArg" = alloca %System.RuntimeTypeHandle*
+  store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
+  %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 8
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %76, label %12
+
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
+  br label %76
+
+; <label>:13                                      ; preds = %85
+  %14 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck19 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %15
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, i32 0, i32 0
+  %17 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %16, align 8
+  %NullCheck21 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, i32 0, i32 2
+  %20 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %19, align 8
+  %21 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck23 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %22
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, i32 0, i32 2
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %NullCheck25 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 3, i32 %24
+  %NullCheck27 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %32
+
+; <label>:32                                      ; preds = %30
+  %33 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, i32 0, i32 2
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = icmp slt i32 %34, 0
+  br i1 %35, label %68, label %36
+
+; <label>:36                                      ; preds = %32
+  %37 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %38 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck29 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %39
+
+; <label>:39                                      ; preds = %36
+  %40 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, i32 0, i32 0
+  %41 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %40, align 8
+  %NullCheck31 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, i32 0, i32 2
+  %44 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %43, align 8
+  %45 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck33 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, i32 0, i32 2
+  %48 = load i32, i32 addrspace(1)* %47, align 8
+  %NullCheck35 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %49
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = zext i32 %51 to i64
+  %53 = zext i32 %48 to i64
+  %BoundsCheck37 = icmp uge i64 %53, %52
+  br i1 %BoundsCheck37, label %ThrowIndexOutOfRange38, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 3, i32 %48
+  %NullCheck39 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %56
+
+; <label>:56                                      ; preds = %54
+  %57 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, i32 0, i32 0
+  %58 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck41 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %59
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %60, %System.__Canon addrspace(1)* %58)
+  %61 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck43 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  %64 = load i32, i32 addrspace(1)* %63, align 8
+  %65 = add i32 %64, 1
+  %NullCheck45 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  store i32 %65, i32 addrspace(1)* %67
+  ret i8 1
+
+; <label>:68                                      ; preds = %32
+  %69 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck47 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %73 = add i32 %72, 1
+  %NullCheck49 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %74
+
+; <label>:74                                      ; preds = %70
+  %75 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  store i32 %73, i32 addrspace(1)* %75
+  br label %76
+
+; <label>:76                                      ; preds = %8, %12, %74
+  %77 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %78
+
+; <label>:78                                      ; preds = %76
+  %79 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, i32 0, i32 2
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck7 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %82
+
+; <label>:82                                      ; preds = %78
+  %83 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, i32 0, i32 0
+  %84 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %83, align 8
+  %NullCheck9 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %85
+
+; <label>:85                                      ; preds = %82
+  %86 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, i32 0, i32 7
+  %87 = load i32, i32 addrspace(1)* %86, align 8
+  %88 = icmp ult i32 %80, %87
+  br i1 %88, label %13, label %89
+
+; <label>:89                                      ; preds = %85
+  %90 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %91 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck11 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %92
+
+; <label>:92                                      ; preds = %89
+  %93 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, i32 0, i32 0
+  %94 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck13 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %95
+
+; <label>:95                                      ; preds = %92
+  %96 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, i32 0, i32 7
+  %97 = load i32, i32 addrspace(1)* %96, align 8
+  %98 = add i32 %97, 1
+  %NullCheck15 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %99
+
+; <label>:99                                      ; preds = %95
+  %100 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, i32 0, i32 2
+  store i32 %98, i32 addrspace(1)* %100
+  %101 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck17 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %102
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %103, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %92
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef22:                                   ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef24:                                   ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef26:                                   ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef28:                                   ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef30:                                   ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef32:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef34:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef36:                                   ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange38:                           ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef40:                                   ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef42:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef44:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef46:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef48:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef50:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -5200,8 +6368,8 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -5232,9 +6400,9 @@ Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
 Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
-Failed to read String.MakeSeparatorList[loadElemA]
+Failed to read String.MakeSeparatorList[storeElem]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
-Failed to read String.InternalSplitKeepEmptyEntries[loadElem]
+Failed to read String.InternalSplitKeepEmptyEntries[storeElem]
 INFO:  jitting method Path::IsRelative using LLILCJit
 Successfully read Path.IsRelative
 
@@ -5243,8 +6411,8 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -5254,8 +6422,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
@@ -5271,8 +6439,8 @@ entry:
 
 ; <label>:17                                      ; preds = %7
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
@@ -5288,8 +6456,8 @@ entry:
 
 ; <label>:29                                      ; preds = %19
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %31
 
 ; <label>:31                                      ; preds = %29
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
@@ -5300,8 +6468,8 @@ entry:
 
 ; <label>:36                                      ; preds = %31
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
-  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %37, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
@@ -5312,8 +6480,8 @@ entry:
 
 ; <label>:43                                      ; preds = %31, %38
   %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
-  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %45
 
 ; <label>:45                                      ; preds = %43
   %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
@@ -5324,8 +6492,8 @@ entry:
 
 ; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %50
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
@@ -5336,8 +6504,8 @@ entry:
 
 ; <label>:57                                      ; preds = %1, %7, %19, %45, %52
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
-  br i1 %NullCheck14, label %59, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %59
 
 ; <label>:59                                      ; preds = %57
   %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
@@ -5347,8 +6515,8 @@ entry:
 
 ; <label>:63                                      ; preds = %59
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
@@ -5359,8 +6527,8 @@ entry:
 
 ; <label>:70                                      ; preds = %65
   %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
-  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.String addrspace(1)* %71, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %72
 
 ; <label>:72                                      ; preds = %70
   %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
@@ -5379,39 +6547,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %17
+ThrowNullRef4:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %29
+ThrowNullRef6:                                    ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %36
+ThrowNullRef8:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %43
+ThrowNullRef10:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %50
+ThrowNullRef12:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %57
+ThrowNullRef14:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %63
+ThrowNullRef16:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %70
+ThrowNullRef18:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5419,7 +6587,293 @@ ThrowNullRef17:                                   ; preds = %70
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
-Failed to read String.TrimHelper[loadElem]
+Successfully read String.TrimHelper
+
+define %System.String addrspace(1)* @String.TrimHelper(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i16
+  %loc4 = alloca i32
+  %loc5 = alloca i16
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = sub i32 %3, 1
+  store i32 %4, i32* %loc0
+  store i32 0, i32* %loc1
+  %5 = load i32, i32* %arg2
+  %6 = icmp eq i32 %5, 1
+  br i1 %6, label %62, label %7
+
+; <label>:7                                       ; preds = %1
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:8                                       ; preds = %58
+  store i32 0, i32* %loc2
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load i32, i32* %loc1
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2, i32 %10
+  %13 = load i16, i16 addrspace(1)* %12
+  %14 = zext i16 %13 to i32
+  %15 = trunc i32 %14 to i16
+  store i16 %15, i16* %loc3
+  store i32 0, i32* %loc2
+  br label %34
+
+; <label>:16                                      ; preds = %37
+  %17 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %18 = load i32, i32* %loc2
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %17, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %19
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = zext i32 %18 to i64
+  %BoundsCheck = icmp uge i64 %23, %22
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %24
+
+; <label>:24                                      ; preds = %19
+  %25 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 3, i32 %18
+  %26 = load i16, i16 addrspace(1)* %25, align 8
+  %27 = zext i16 %26 to i32
+  %28 = load i16, i16* %loc3
+  %29 = zext i16 %28 to i32
+  %30 = icmp eq i32 %27, %29
+  br i1 %30, label %43, label %31
+
+; <label>:31                                      ; preds = %24
+  %32 = load i32, i32* %loc2
+  %33 = add i32 %32, 1
+  store i32 %33, i32* %loc2
+  br label %34
+
+; <label>:34                                      ; preds = %11, %31
+  %35 = load i32, i32* %loc2
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = icmp slt i32 %35, %41
+  br i1 %42, label %16, label %43
+
+; <label>:43                                      ; preds = %24, %37
+  %44 = load i32, i32* %loc2
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %45, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp eq i32 %44, %50
+  br i1 %51, label %62, label %52
+
+; <label>:52                                      ; preds = %46
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %7, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %57, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %58
+
+; <label>:58                                      ; preds = %55
+  %59 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %60 = load i32, i32 addrspace(1)* %59
+  %61 = icmp slt i32 %56, %60
+  br i1 %61, label %8, label %62
+
+; <label>:62                                      ; preds = %1, %46, %58
+  %63 = load i32, i32* %arg2
+  %64 = icmp eq i32 %63, 0
+  br i1 %64, label %122, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %66, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %67
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %66, i32 0, i32 1
+  %69 = load i32, i32 addrspace(1)* %68
+  %70 = sub i32 %69, 1
+  store i32 %70, i32* %loc0
+  br label %118
+
+; <label>:71                                      ; preds = %118
+  store i32 0, i32* %loc4
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %73 = load i32, i32* %loc0
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %74
+
+; <label>:74                                      ; preds = %71
+  %75 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 2, i32 %73
+  %76 = load i16, i16 addrspace(1)* %75
+  %77 = zext i16 %76 to i32
+  %78 = trunc i32 %77 to i16
+  store i16 %78, i16* %loc5
+  store i32 0, i32* %loc4
+  br label %97
+
+; <label>:79                                      ; preds = %100
+  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %81 = load i32, i32* %loc4
+  %NullCheck19 = icmp eq %"System.Char[]" addrspace(1)* %80, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
+
+; <label>:82                                      ; preds = %79
+  %83 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 1
+  %84 = load i32, i32 addrspace(1)* %83
+  %85 = zext i32 %84 to i64
+  %86 = zext i32 %81 to i64
+  %BoundsCheck21 = icmp uge i64 %86, %85
+  br i1 %BoundsCheck21, label %ThrowIndexOutOfRange22, label %87
+
+; <label>:87                                      ; preds = %82
+  %88 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 3, i32 %81
+  %89 = load i16, i16 addrspace(1)* %88, align 8
+  %90 = zext i16 %89 to i32
+  %91 = load i16, i16* %loc5
+  %92 = zext i16 %91 to i32
+  %93 = icmp eq i32 %90, %92
+  br i1 %93, label %106, label %94
+
+; <label>:94                                      ; preds = %87
+  %95 = load i32, i32* %loc4
+  %96 = add i32 %95, 1
+  store i32 %96, i32* %loc4
+  br label %97
+
+; <label>:97                                      ; preds = %74, %94
+  %98 = load i32, i32* %loc4
+  %99 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck15 = icmp eq %"System.Char[]" addrspace(1)* %99, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %100
+
+; <label>:100                                     ; preds = %97
+  %101 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %99, i32 0, i32 1
+  %102 = load i32, i32 addrspace(1)* %101
+  %103 = zext i32 %102 to i64
+  %104 = trunc i64 %103 to i32
+  %105 = icmp slt i32 %98, %104
+  br i1 %105, label %79, label %106
+
+; <label>:106                                     ; preds = %87, %100
+  %107 = load i32, i32* %loc4
+  %108 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck17 = icmp eq %"System.Char[]" addrspace(1)* %108, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %109
+
+; <label>:109                                     ; preds = %106
+  %110 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %108, i32 0, i32 1
+  %111 = load i32, i32 addrspace(1)* %110
+  %112 = zext i32 %111 to i64
+  %113 = trunc i64 %112 to i32
+  %114 = icmp eq i32 %107, %113
+  br i1 %114, label %122, label %115
+
+; <label>:115                                     ; preds = %109
+  %116 = load i32, i32* %loc0
+  %117 = sub i32 %116, 1
+  store i32 %117, i32* %loc0
+  br label %118
+
+; <label>:118                                     ; preds = %67, %115
+  %119 = load i32, i32* %loc0
+  %120 = load i32, i32* %loc1
+  %121 = icmp sge i32 %119, %120
+  br i1 %121, label %71, label %122
+
+; <label>:122                                     ; preds = %62, %109, %118
+  %123 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %124 = load i32, i32* %loc1
+  %125 = load i32, i32* %loc0
+  %126 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %123, i32 %124, i32 %125)
+  ret %System.String addrspace(1)* %126
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %97
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange22:                           ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
 Successfully read String.CreateTrimmedString
 
@@ -5439,8 +6893,8 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
@@ -5535,8 +6989,8 @@ entry:
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i64 2872
   %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
   %8 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %7
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %3
   %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
@@ -5553,8 +7007,8 @@ entry:
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 2864
   %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
   %21 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %20
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
-  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %22
 
 ; <label>:22                                      ; preds = %16
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
@@ -5569,7 +7023,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %16
+ThrowNullRef2:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5586,8 +7040,8 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5613,8 +7067,8 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
@@ -5632,8 +7086,8 @@ entry:
 
 ; <label>:12                                      ; preds = %4
   %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
@@ -5644,8 +7098,8 @@ entry:
 
 ; <label>:19                                      ; preds = %14
   %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %19
   %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
@@ -5660,21 +7114,21 @@ entry:
   %31 = zext i16 %30 to i32
   %32 = bitcast i8* %29 to i16*
   %33 = trunc i32 %31 to i16
-  %NullCheck6 = icmp ne i16* %32, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i16* %32, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %21
   store i16 %33, i16* %32, align 8
   %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %36
 
 ; <label>:36                                      ; preds = %34
   %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
   %38 = load i32, i32 addrspace(1)* %37, align 8
   %39 = add i32 %38, 1
-  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %40
 
 ; <label>:40                                      ; preds = %36
   %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
@@ -5683,16 +7137,16 @@ entry:
 
 ; <label>:42                                      ; preds = %14
   %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
-  br i1 %NullCheck12, label %44, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
   %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
   %47 = load i16, i16* %arg1
   %48 = zext i16 %47 to i32
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = trunc i32 %48 to i16
@@ -5703,31 +7157,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %19
+ThrowNullRef4:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %21
+ThrowNullRef6:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %36
+ThrowNullRef10:                                   ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %42
+ThrowNullRef12:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %44
+ThrowNullRef14:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5740,8 +7194,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -5752,8 +7206,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
@@ -5762,14 +7216,14 @@ entry:
 
 ; <label>:11                                      ; preds = %1
   %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
@@ -5779,15 +7233,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5808,8 +7262,8 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5822,8 +7276,8 @@ entry:
 
 ; <label>:8                                       ; preds = %3
   %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
@@ -5842,15 +7296,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
-  br i1 %NullCheck4, label %22, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
   %24 = load i16*, i16* addrspace(1)* %23, align 8
   %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %25, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
@@ -5859,8 +7313,8 @@ entry:
   store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
@@ -5874,8 +7328,8 @@ entry:
 
 ; <label>:37                                      ; preds = %65
   %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %37
   %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
@@ -5886,16 +7340,16 @@ entry:
   %45 = bitcast i16* %41 to i8*
   %46 = getelementptr inbounds i8, i8* %45, i64 %44
   %47 = bitcast i8* %46 to i16*
-  %NullCheck14 = icmp ne i16* %47, null
-  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %47, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %48
 
 ; <label>:48                                      ; preds = %39
   %49 = load i16, i16* %47, align 8
   %50 = zext i16 %49 to i32
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %52 = load i32, i32* %loc1
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %53
 
 ; <label>:53                                      ; preds = %48
   %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
@@ -5916,8 +7370,8 @@ entry:
 ; <label>:62                                      ; preds = %36, %59
   %63 = load i32, i32* %loc1
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck10, label %65, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %65
 
 ; <label>:65                                      ; preds = %62
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
@@ -5936,15 +7390,15 @@ entry:
 
 ; <label>:74                                      ; preds = %70
   %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
-  br i1 %NullCheck18, label %76, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %76
 
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
   %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
-  br i1 %NullCheck20, label %80, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
   %81 = load i64, i64 addrspace(1)* %79
@@ -5958,8 +7412,8 @@ entry:
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
   %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
-  br i1 %NullCheck22, label %92, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.String addrspace(1)* %90, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %92
 
 ; <label>:92                                      ; preds = %80
   %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
@@ -5969,15 +7423,15 @@ entry:
 
 ; <label>:96                                      ; preds = %70
   %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
-  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %98
 
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
   %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
-  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
   %103 = load i64, i64 addrspace(1)* %101
@@ -5991,8 +7445,8 @@ entry:
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
   %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
-  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.String addrspace(1)* %112, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %114
 
 ; <label>:114                                     ; preds = %102
   %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
@@ -6004,59 +7458,59 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %20
+ThrowNullRef4:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %22
+ThrowNullRef6:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %26
+ThrowNullRef8:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %62
+ThrowNullRef10:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %48
+ThrowNullRef16:                                   ; preds = %48
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %74
+ThrowNullRef18:                                   ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %76
+ThrowNullRef20:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %80
+ThrowNullRef22:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %96
+ThrowNullRef24:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %98
+ThrowNullRef26:                                   ; preds = %98
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %102
+ThrowNullRef28:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6069,15 +7523,15 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
   %3 = load i16*, i16* addrspace(1)* %2, align 8
   %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
@@ -6087,8 +7541,8 @@ entry:
   %10 = bitcast i16* %3 to i8*
   %11 = getelementptr inbounds i8, i8* %10, i64 %9
   %12 = bitcast i8* %11 to i16*
-  %NullCheck4 = icmp ne i16* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %5
   store i16 0, i16* %12, align 8
@@ -6098,11 +7552,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6119,8 +7573,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -6131,8 +7585,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
@@ -6144,15 +7598,15 @@ entry:
 
 ; <label>:14                                      ; preds = %1
   %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
   %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
   %21 = load i64, i64 addrspace(1)* %19
@@ -6171,15 +7625,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %14
+ThrowNullRef4:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %16
+ThrowNullRef6:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6302,14 +7756,6 @@ entry:
   ret %System.String addrspace(1)* %57
 }
 
-INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
-Successfully read RuntimeHelpers.get_OffsetToStringData
-
-define i32 @RuntimeHelpers.get_OffsetToStringData() {
-entry:
-  ret i32 12
-}
-
 INFO:  jitting method String::Equals using LLILCJit
 Successfully read String.Equals
 
@@ -6381,8 +7827,8 @@ entry:
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
-  br i1 %NullCheck24, label %29, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
   %30 = load i64, i64 addrspace(1)* %28
@@ -6397,8 +7843,8 @@ entry:
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
-  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
   %43 = load i64, i64 addrspace(1)* %41
@@ -6418,8 +7864,8 @@ entry:
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
   %59 = load i64, i64 addrspace(1)* %57
@@ -6434,8 +7880,8 @@ entry:
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck22, label %71, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
   %72 = load i64, i64 addrspace(1)* %70
@@ -6455,8 +7901,8 @@ entry:
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
-  br i1 %NullCheck16, label %87, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = load i64, i64 addrspace(1)* %86
@@ -6471,8 +7917,8 @@ entry:
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck18, label %100, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
   %101 = load i64, i64 addrspace(1)* %99
@@ -6492,8 +7938,8 @@ entry:
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
-  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
   %117 = load i64, i64 addrspace(1)* %115
@@ -6508,8 +7954,8 @@ entry:
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
-  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
   %130 = load i64, i64 addrspace(1)* %128
@@ -6528,15 +7974,15 @@ entry:
 
 ; <label>:142                                     ; preds = %22
   %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
-  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %143, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %144
 
 ; <label>:144                                     ; preds = %142
   %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
   %146 = load i32, i32 addrspace(1)* %145
   %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
-  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %147, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %148
 
 ; <label>:148                                     ; preds = %144
   %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
@@ -6557,15 +8003,15 @@ entry:
 
 ; <label>:159                                     ; preds = %22
   %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
-  br i1 %NullCheck, label %161, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %ThrowNullRef, label %161
 
 ; <label>:161                                     ; preds = %159
   %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
   %163 = load i32, i32 addrspace(1)* %162
   %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
-  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %164, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %165
 
 ; <label>:165                                     ; preds = %161
   %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
@@ -6578,8 +8024,8 @@ entry:
 
 ; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
-  br i1 %NullCheck4, label %172, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %171, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %172
 
 ; <label>:172                                     ; preds = %170
   %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
@@ -6589,8 +8035,8 @@ entry:
 
 ; <label>:176                                     ; preds = %172
   %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
-  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %177, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %178
 
 ; <label>:178                                     ; preds = %176
   %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
@@ -6629,55 +8075,55 @@ ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %161
+ThrowNullRef2:                                    ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %170
+ThrowNullRef4:                                    ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %176
+ThrowNullRef6:                                    ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %142
+ThrowNullRef8:                                    ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %144
+ThrowNullRef10:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %113
+ThrowNullRef12:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %116
+ThrowNullRef14:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %84
+ThrowNullRef16:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %87
+ThrowNullRef18:                                   ; preds = %87
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %55
+ThrowNullRef20:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %58
+ThrowNullRef22:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %26
+ThrowNullRef24:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %29
+ThrowNullRef26:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,8 +8161,8 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck, label %14, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %ThrowNullRef, label %14
 
 ; <label>:14                                      ; preds = %8
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
@@ -6760,8 +8206,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
@@ -6770,14 +8216,14 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32, i32* %loc0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %10
   %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
   %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
@@ -6790,15 +8236,15 @@ entry:
 ; <label>:25                                      ; preds = %19
   %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
-  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
   %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
@@ -6807,8 +8253,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %37 = load i32, i32* %loc0
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %38, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %38
 
 ; <label>:38                                      ; preds = %32
   %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
@@ -6817,14 +8263,14 @@ entry:
 
 ; <label>:40                                      ; preds = %19
   %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %40
   %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
   %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
-  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
-  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
@@ -6832,8 +8278,8 @@ entry:
   %48 = zext i32 %47 to i64
   %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
-  br i1 %NullCheck16, label %51, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %51
 
 ; <label>:51                                      ; preds = %45
   %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
@@ -6847,15 +8293,15 @@ entry:
 ; <label>:57                                      ; preds = %51
   %58 = load i16*, i16** %arg1
   %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
-  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %60
 
 ; <label>:60                                      ; preds = %57
   %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
   %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
-  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %64
 
 ; <label>:64                                      ; preds = %60
   %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
@@ -6864,22 +8310,22 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
   %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
-  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %70
 
 ; <label>:70                                      ; preds = %64
   %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
   %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
-  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
-  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
   %75 = load i32, i32 addrspace(1)* %74
   %76 = zext i32 %75 to i64
   %77 = trunc i64 %76 to i32
-  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
-  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %78
 
 ; <label>:78                                      ; preds = %73
   %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
@@ -6901,8 +8347,8 @@ entry:
   %90 = bitcast i16* %86 to i8*
   %91 = getelementptr inbounds i8, i8* %90, i64 %89
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %93
 
 ; <label>:93                                      ; preds = %80
   %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
@@ -6912,8 +8358,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %99 = load i32, i32* %loc2
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %100
 
 ; <label>:100                                     ; preds = %93
   %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
@@ -6928,63 +8374,63 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %25
+ThrowNullRef6:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %32
+ThrowNullRef10:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %40
+ThrowNullRef12:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %45
+ThrowNullRef16:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %57
+ThrowNullRef18:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %60
+ThrowNullRef20:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %64
+ThrowNullRef22:                                   ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %70
+ThrowNullRef24:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %73
+ThrowNullRef26:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %80
+ThrowNullRef28:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %93
+ThrowNullRef30:                                   ; preds = %93
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7004,8 +8450,8 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
@@ -7033,43 +8479,43 @@ entry:
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %14
   %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
   %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   %28 = load i32, i32 addrspace(1)* %27, align 8
   %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
-  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %30
 
 ; <label>:30                                      ; preds = %26
   %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
   %32 = load i32, i32 addrspace(1)* %31, align 8
   %33 = add i32 %28, %32
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %34
 
 ; <label>:34                                      ; preds = %30
   %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   store i32 %33, i32 addrspace(1)* %35
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
   store i32 0, i32 addrspace(1)* %38
   %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %40
 
 ; <label>:40                                      ; preds = %37
   %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
@@ -7082,8 +8528,8 @@ entry:
 
 ; <label>:47                                      ; preds = %40
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
@@ -7098,8 +8544,8 @@ entry:
   %54 = load i32, i32* %loc0
   %55 = sext i32 %54 to i64
   %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
-  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %57
 
 ; <label>:57                                      ; preds = %52
   %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
@@ -7110,68 +8556,35 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %14
+ThrowNullRef2:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %23
+ThrowNullRef4:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %26
+ThrowNullRef6:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %30
+ThrowNullRef8:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %34
+ThrowNullRef10:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %47
+ThrowNullRef14:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %52
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-}
-
-INFO:  jitting method StringBuilder::get_Length using LLILCJit
-Successfully read StringBuilder.get_Length
-
-define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.StringBuilder addrspace(1)*
-  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
-  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
-
-; <label>:1                                       ; preds = %entry
-  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %3 = load i32, i32 addrspace(1)* %2, align 8
-  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
-
-; <label>:5                                       ; preds = %1
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = add i32 %3, %7
-  ret i32 %8
-
-ThrowNullRef:                                     ; preds = %entry
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef16:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7213,70 +8626,70 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
   %6 = load i32, i32 addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
   store i32 %6, i32 addrspace(1)* %8
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
   %13 = load i32, i32 addrspace(1)* %12, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
   store i32 %13, i32 addrspace(1)* %15
   %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
-  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %18
 
 ; <label>:18                                      ; preds = %14
   %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
   %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
   %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
   %34 = load i32, i32 addrspace(1)* %33, align 8
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
-  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
@@ -7287,39 +8700,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %28
+ThrowNullRef16:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %32
+ThrowNullRef18:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7455,13 +8868,13 @@ entry:
 ; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
@@ -7477,16 +8890,16 @@ entry:
 
 ; <label>:18                                      ; preds = %15
   %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
   store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
   %22 = load i32, i32* %loc0
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %24
 
 ; <label>:24                                      ; preds = %20
   %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
@@ -7498,13 +8911,13 @@ entry:
 ; <label>:28                                      ; preds = %15, %24
   %29 = load i32, i32* %arg1
   %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %31
   %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
@@ -7517,20 +8930,20 @@ entry:
   %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
-  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
   %46 = load i32, i32 addrspace(1)* %45, align 8
   %47 = sub i32 %40, %46
-  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
-  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i32 addrspace(1)* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %48
 
 ; <label>:48                                      ; preds = %44
   store i32 %47, i32 addrspace(1)* %39, align 8
@@ -7538,21 +8951,21 @@ entry:
 
 ; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
-  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %51
 
 ; <label>:51                                      ; preds = %49
   %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %53
 
 ; <label>:53                                      ; preds = %51
   %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
   %55 = load i32, i32 addrspace(1)* %54, align 8
   %56 = load i32, i32* %arg2
   %57 = sub i32 %55, %56
-  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %58
 
 ; <label>:58                                      ; preds = %53
   %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
@@ -7562,13 +8975,13 @@ entry:
 ; <label>:60                                      ; preds = %33, %58
   %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
   %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
-  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %63
 
 ; <label>:63                                      ; preds = %60
   %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
-  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
-  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
@@ -7578,15 +8991,15 @@ entry:
 
 ; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
-  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i32 addrspace(1)* %69, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %70
 
 ; <label>:70                                      ; preds = %68
   %71 = load i32, i32 addrspace(1)* %69, align 8
   store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
-  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
@@ -7596,8 +9009,8 @@ entry:
   store i32 %77, i32* %loc4
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
-  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %80
 
 ; <label>:80                                      ; preds = %73
   %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
@@ -7607,71 +9020,71 @@ entry:
 ; <label>:83                                      ; preds = %80
   store i32 0, i32* %loc3
   %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
-  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
-  br i1 %NullCheck26, label %88, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i32 addrspace(1)* %87, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %88
 
 ; <label>:88                                      ; preds = %85
   %89 = load i32, i32 addrspace(1)* %87, align 8
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
-  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %90
 
 ; <label>:90                                      ; preds = %88
   %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
   store i32 %89, i32 addrspace(1)* %91
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
-  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
-  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %96
 
 ; <label>:96                                      ; preds = %94
   %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
-  br i1 %NullCheck34, label %100, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %100
 
 ; <label>:100                                     ; preds = %96
   %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
-  br i1 %NullCheck36, label %102, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %102
 
 ; <label>:102                                     ; preds = %100
   %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
   %104 = load i32, i32 addrspace(1)* %103, align 8
   %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
-  br i1 %NullCheck38, label %106, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %106
 
 ; <label>:106                                     ; preds = %102
   %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
-  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
-  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %108
 
 ; <label>:108                                     ; preds = %106
   %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
   %110 = load i32, i32 addrspace(1)* %109, align 8
   %111 = add i32 %104, %110
-  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %112
 
 ; <label>:112                                     ; preds = %108
   %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
   store i32 %111, i32 addrspace(1)* %113
   %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
-  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i32 addrspace(1)* %114, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %115
 
 ; <label>:115                                     ; preds = %112
   %116 = load i32, i32 addrspace(1)* %114, align 8
@@ -7681,19 +9094,19 @@ entry:
 ; <label>:118                                     ; preds = %115
   %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
-  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %121
 
 ; <label>:121                                     ; preds = %118
   %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
-  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
-  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %123
 
 ; <label>:123                                     ; preds = %121
   %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
   %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
-  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
-  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %126
 
 ; <label>:126                                     ; preds = %123
   %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
@@ -7705,8 +9118,8 @@ entry:
 
 ; <label>:130                                     ; preds = %80, %115, %126
   %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %132
 
 ; <label>:132                                     ; preds = %130
   %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7715,8 +9128,8 @@ entry:
   %136 = load i32, i32* %loc3
   %137 = sub i32 %135, %136
   %138 = sub i32 %134, %137
-  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %139
 
 ; <label>:139                                     ; preds = %132
   %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7728,16 +9141,16 @@ entry:
 
 ; <label>:144                                     ; preds = %139
   %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
-  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %146
 
 ; <label>:146                                     ; preds = %144
   %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
   %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
   %149 = load i32, i32* %loc2
   %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
-  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %151
 
 ; <label>:151                                     ; preds = %146
   %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
@@ -7754,145 +9167,249 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %18
+ThrowNullRef4:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %31
+ThrowNullRef10:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %44
+ThrowNullRef16:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %68
+ThrowNullRef18:                                   ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %70
+ThrowNullRef20:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %73
+ThrowNullRef22:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %83
+ThrowNullRef24:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %85
+ThrowNullRef26:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %88
+ThrowNullRef28:                                   ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %90
+ThrowNullRef30:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %94
+ThrowNullRef32:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %96
+ThrowNullRef34:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %100
+ThrowNullRef36:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %102
+ThrowNullRef38:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %106
+ThrowNullRef40:                                   ; preds = %106
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %108
+ThrowNullRef42:                                   ; preds = %108
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %112
+ThrowNullRef44:                                   ; preds = %112
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %118
+ThrowNullRef46:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %121
+ThrowNullRef48:                                   ; preds = %121
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %123
+ThrowNullRef50:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %130
+ThrowNullRef52:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %132
+ThrowNullRef54:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %144
+ThrowNullRef56:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %146
+ThrowNullRef58:                                   ; preds = %146
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %60
+ThrowNullRef60:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %63
+ThrowNullRef62:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %49
+ThrowNullRef64:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %51
+ThrowNullRef66:                                   ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %53
+ThrowNullRef68:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(%"System.Char[]" addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %arg0 = alloca %"System.Char[]" addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store %"System.Char[]" addrspace(1)* %param0, %"System.Char[]" addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load i32, i32* %arg4
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %43, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %38, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg1
+  %13 = load i32, i32* %arg4
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %38, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %24 = load i32, i32* %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %35 = load i32, i32* %arg3
+  %36 = load i32, i32* %arg4
+  %37 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %37, %"System.Char[]" addrspace(1)* %34, i32 %35, i32 %36)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:38                                      ; preds = %5, %16
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Successfully read Buffer._Memmove
 
@@ -7914,7 +9431,7 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[loadElem]
+Failed to read AppDomain.SetDataHelper[storeElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -7923,8 +9440,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
@@ -7934,8 +9451,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
@@ -7947,15 +9464,15 @@ entry:
   %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
   %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
@@ -7966,15 +9483,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7992,7 +9509,79 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
-Failed to read Dictionary`2.TryGetValue[loadElemA]
+Successfully read Dictionary`2.TryGetValue
+
+define i8 @"Dictionary`2.TryGetValue"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)* addrspace(1)* %param2) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  %arg2 = alloca %System.__Canon addrspace(1)* addrspace(1)*
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  store %System.__Canon addrspace(1)* addrspace(1)* %param2, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  store i32 %2, i32* %loc0
+  %3 = load i32, i32* %loc0
+  %4 = icmp slt i32 %3, 0
+  br i1 %4, label %22, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 2
+  %10 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %9, align 8
+  %11 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = zext i32 %11 to i64
+  %BoundsCheck = icmp uge i64 %16, %15
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 3, i32 %11
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %20, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %6, %System.__Canon addrspace(1)* %21)
+  ret i8 1
+
+; <label>:22                                      ; preds = %entry
+  %23 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %23, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -8058,8 +9647,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
@@ -8091,8 +9680,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
@@ -8171,15 +9760,15 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck, label %19, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %ThrowNullRef, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
   %21 = load i32, i32 addrspace(1)* %20
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
@@ -8202,7 +9791,7 @@ ThrowNullRef:                                     ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %19
+ThrowNullRef2:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8248,8 +9837,8 @@ entry:
   %0 = alloca %System.AppDomainHandle
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %1 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %1, i32 0, i32 15
@@ -8269,8 +9858,8 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
@@ -8286,7 +9875,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -8299,8 +9888,8 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -8327,8 +9916,8 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
@@ -8352,8 +9941,8 @@ entry:
   %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
   store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
@@ -8363,8 +9952,8 @@ entry:
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
@@ -8374,8 +9963,8 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %9
   %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
@@ -8384,8 +9973,8 @@ entry:
 
 ; <label>:18                                      ; preds = %3, %16
   %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
@@ -8397,15 +9986,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %18
+ThrowNullRef6:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8418,8 +10007,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
@@ -8453,15 +10042,15 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
@@ -8473,7 +10062,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8481,7 +10070,7 @@ ThrowNullRef1:                                    ; preds = %1
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
 Failed to read Dictionary`2.System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
@@ -8506,8 +10095,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
@@ -8524,8 +10113,8 @@ entry:
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -8544,7 +10133,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8577,8 +10166,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = load i64, i64* %arg2
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = trunc i32 %3 to i8
@@ -8634,46 +10223,46 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
   %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
-  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
-  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
-  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
@@ -8684,27 +10273,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %20
+ThrowNullRef12:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8717,8 +10306,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -8756,22 +10345,22 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
   %9 = load i64, i64 addrspace(1)* %8, align 8
   %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
   %13 = load i64, i64 addrspace(1)* %12, align 8
   %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %11
   %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
@@ -8788,11 +10377,11 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8882,8 +10471,8 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
@@ -8900,8 +10489,8 @@ entry:
 ; <label>:8                                       ; preds = %1
   %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
   %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
@@ -8911,15 +10500,15 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
   %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
   %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
-  br i1 %NullCheck6, label %21, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
@@ -8946,15 +10535,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8992,15 +10581,15 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
   store i8 %3, i8 addrspace(1)* %5
   %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
@@ -9011,7 +10600,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9027,8 +10616,8 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -9041,8 +10630,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
@@ -9058,7 +10647,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9080,8 +10669,8 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
@@ -9096,8 +10685,8 @@ entry:
 ; <label>:12                                      ; preds = %6
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
@@ -9112,8 +10701,8 @@ entry:
 ; <label>:21                                      ; preds = %15
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
@@ -9128,8 +10717,8 @@ entry:
 ; <label>:30                                      ; preds = %24
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %31, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
@@ -9144,8 +10733,8 @@ entry:
 ; <label>:39                                      ; preds = %33
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
-  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %40, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %42
 
 ; <label>:42                                      ; preds = %39
   %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
@@ -9164,19 +10753,19 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %21
+ThrowNullRef4:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %30
+ThrowNullRef6:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %39
+ThrowNullRef8:                                    ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9243,8 +10832,8 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
@@ -9264,57 +10853,57 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
   store i8 0, i8 addrspace(1)* %2
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
   store i8 0, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
   store i8 0, i8 addrspace(1)* %17
   %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
   store i8 0, i8 addrspace(1)* %20
   %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
-  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
@@ -9325,31 +10914,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %19
+ThrowNullRef14:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9367,8 +10956,8 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
@@ -9380,8 +10969,8 @@ entry:
 
 ; <label>:9                                       ; preds = %4
   %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %9
   %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
@@ -9395,7 +10984,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef2:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9420,8 +11009,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
@@ -9512,8 +11101,8 @@ entry:
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
@@ -9524,8 +11113,8 @@ entry:
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = load i64, i64 addrspace(1)* %12
@@ -9537,8 +11126,8 @@ entry:
   %20 = load i64, i64* %19
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
-  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %13
   %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
@@ -9555,8 +11144,8 @@ entry:
 ; <label>:30                                      ; preds = %25
   %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %32 = load i32, i32* %arg2
-  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
-  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
@@ -9570,15 +11159,15 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %30
+ThrowNullRef2:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9622,87 +11211,87 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
   %10 = load i8, i8 addrspace(1)* %9, align 8
   %11 = zext i8 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %8
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
   store i8 %12, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
   %19 = load i8, i8 addrspace(1)* %18, align 8
   %20 = zext i8 %19 to i32
   %21 = trunc i32 %20 to i8
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
   store i8 %21, i8 addrspace(1)* %23
   %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
   %28 = load i8, i8 addrspace(1)* %27, align 8
   %29 = zext i8 %28 to i32
   %30 = trunc i32 %29 to i8
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
-  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %31
 
 ; <label>:31                                      ; preds = %26
   %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
   store i8 %30, i8 addrspace(1)* %32
   %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
-  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
-  br i1 %NullCheck14, label %40, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %40
 
 ; <label>:40                                      ; preds = %35
   %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
   store i8 %39, i8 addrspace(1)* %41
   %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
-  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %44
 
 ; <label>:44                                      ; preds = %40
   %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
   %46 = load i8, i8 addrspace(1)* %45, align 8
   %47 = zext i8 %46 to i32
   %48 = trunc i32 %47 to i8
-  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
   store i8 %48, i8 addrspace(1)* %50
   %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
-  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
@@ -9713,29 +11302,29 @@ entry:
 ; <label>:56                                      ; preds = %52
   %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
-  br i1 %NullCheck22, label %59, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
   %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
   %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
-  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
-  br i1 %NullCheck24, label %63, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
   %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
-  br i1 %NullCheck26, label %66, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
   %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
-  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
-  br i1 %NullCheck28, label %69, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %69
 
 ; <label>:69                                      ; preds = %66
   %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
@@ -9744,15 +11333,15 @@ entry:
 
 ; <label>:71                                      ; preds = %105
   %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
-  br i1 %NullCheck34, label %73, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %73
 
 ; <label>:73                                      ; preds = %71
   %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
   %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
   %76 = load i32, i32* %loc0
-  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
-  br i1 %NullCheck36, label %77, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
@@ -9766,8 +11355,8 @@ entry:
 
 ; <label>:83                                      ; preds = %77
   %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
-  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
@@ -9775,14 +11364,14 @@ entry:
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
   %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
-  br i1 %NullCheck40, label %91, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
 ; <label>:91                                      ; preds = %85
   %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
   %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
-  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck42, label %94, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %94
 
 ; <label>:94                                      ; preds = %91
   %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
@@ -9798,14 +11387,14 @@ entry:
 ; <label>:99                                      ; preds = %69, %96
   %100 = load i32, i32* %loc0
   %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
-  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %102
 
 ; <label>:102                                     ; preds = %99
   %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
   %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
-  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
-  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
@@ -9819,87 +11408,87 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %26
+ThrowNullRef10:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %31
+ThrowNullRef12:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %35
+ThrowNullRef14:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %40
+ThrowNullRef16:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %56
+ThrowNullRef22:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %59
+ThrowNullRef24:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %63
+ThrowNullRef26:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %66
+ThrowNullRef28:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %102
+ThrowNullRef32:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %71
+ThrowNullRef34:                                   ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %73
+ThrowNullRef36:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %83
+ThrowNullRef38:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %85
+ThrowNullRef40:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %91
+ThrowNullRef42:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9943,15 +11532,15 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
   %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
@@ -9961,28 +11550,28 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
   %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %12
   %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
   %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
   %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
-  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
@@ -9993,23 +11582,23 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %12
+ThrowNullRef6:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10031,15 +11620,15 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
   %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = load i64, i64 addrspace(1)* %7
@@ -10077,13 +11666,13 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[loadElem]
+Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -10111,8 +11700,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -10175,8 +11764,8 @@ entry:
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load float, float* %arg0
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -10310,8 +11899,8 @@ entry:
   store i64 %param0, i64* %arg0
   store i64 %param1, i64* %arg1
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
@@ -10319,8 +11908,8 @@ entry:
   %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
   %5 = load i16*, i16* addrspace(1)* %4, align 8
   %6 = addrspacecast i64* %arg1 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = bitcast i64 addrspace(1)* %6 to i8 addrspace(1)*
@@ -10336,7 +11925,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10370,8 +11959,8 @@ entry:
   %1 = load i32, i32* %arg1
   %2 = sext i32 %1 to i64
   %3 = inttoptr i64 %2 to i16*
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -10424,8 +12013,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, i32)*)(%System.IO.ConsoleStream addrspace(1)* %2, i32 %1)
   %3 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %4 = load i64, i64* %arg1
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
@@ -10436,8 +12025,8 @@ entry:
   %10 = icmp eq i32 %9, 3
   %11 = sext i1 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %5
   %14 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, i32 0, i32 5
@@ -10448,7 +12037,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10471,8 +12060,8 @@ entry:
   %5 = icmp eq i32 %4, 1
   %6 = sext i1 %5 to i32
   %7 = trunc i32 %6 to i8
-  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %2, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.ConsoleStream addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
@@ -10483,8 +12072,8 @@ entry:
   %13 = icmp eq i32 %12, 2
   %14 = sext i1 %13 to i32
   %15 = trunc i32 %14 to i8
-  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %10, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.ConsoleStream addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %8
   %17 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %10, i32 0, i32 4
@@ -10495,7 +12084,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10534,8 +12123,8 @@ entry:
   %arg0 = alloca i64
   store i64 %param0, i64* %arg0
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
@@ -10570,8 +12159,8 @@ entry:
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
   %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = load i64, i64 addrspace(1)* %7
@@ -10675,7 +12264,127 @@ entry:
 INFO:  jitting method Encoding::GetEncoding using LLILCJit
 Failed to read Encoding.GetEncoding[convertToHelperArgumentType]
 INFO:  jitting method EncodingProvider::GetEncodingFromProvider using LLILCJit
-Failed to read EncodingProvider.GetEncodingFromProvider[loadElem]
+Successfully read EncodingProvider.GetEncodingFromProvider
+
+define %System.Text.Encoding addrspace(1)* @EncodingProvider.GetEncodingFromProvider(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca %"System.Text.EncodingProvider[]" addrspace(1)*
+  %loc1 = alloca %System.Text.EncodingProvider addrspace(1)*
+  %loc2 = alloca %System.Text.Encoding addrspace(1)*
+  %loc3 = alloca %System.Text.Encoding addrspace(1)*
+  %loc4 = alloca %"System.Text.EncodingProvider[]" addrspace(1)*
+  %loc5 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1059)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2392
+  %2 = addrspacecast i8 addrspace(1)* %1 to %"System.Text.EncodingProvider[]" addrspace(1)**
+  %3 = load volatile %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %2
+  %4 = icmp ne %"System.Text.EncodingProvider[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %entry
+  ret %System.Text.Encoding addrspace(1)* null
+
+; <label>:6                                       ; preds = %entry
+  %7 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1059)
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i64 2392
+  %9 = addrspacecast i8 addrspace(1)* %8 to %"System.Text.EncodingProvider[]" addrspace(1)**
+  %10 = load volatile %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %9
+  store %"System.Text.EncodingProvider[]" addrspace(1)* %10, %"System.Text.EncodingProvider[]" addrspace(1)** %loc0
+  %11 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc0
+  store %"System.Text.EncodingProvider[]" addrspace(1)* %11, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  store i32 0, i32* %loc5
+  br label %43
+
+; <label>:12                                      ; preds = %46
+  %13 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  %14 = load i32, i32* %loc5
+  %NullCheck1 = icmp eq %"System.Text.EncodingProvider[]" addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %13, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = zext i32 %17 to i64
+  %19 = zext i32 %14 to i64
+  %BoundsCheck = icmp uge i64 %19, %18
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %20
+
+; <label>:20                                      ; preds = %15
+  %21 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %13, i32 0, i32 3, i32 %14
+  %22 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)* addrspace(1)* %21, align 8
+  store %System.Text.EncodingProvider addrspace(1)* %22, %System.Text.EncodingProvider addrspace(1)** %loc1
+  %23 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)** %loc1
+  %24 = load i32, i32* %arg0
+  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i64 addrspace(1)*
+  %NullCheck3 = icmp eq i64 addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
+
+; <label>:26                                      ; preds = %20
+  %27 = load i64, i64 addrspace(1)* %25
+  %28 = add i64 %27, 64
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 40
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Text.Encoding addrspace(1)* (%System.Text.EncodingProvider addrspace(1)*, i32)*
+  %35 = call %System.Text.Encoding addrspace(1)* %34(%System.Text.EncodingProvider addrspace(1)* %23, i32 %24)
+  store %System.Text.Encoding addrspace(1)* %35, %System.Text.Encoding addrspace(1)** %loc2
+  %36 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc2
+  %37 = icmp eq %System.Text.Encoding addrspace(1)* %36, null
+  br i1 %37, label %40, label %38
+
+; <label>:38                                      ; preds = %26
+  %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc2
+  store %System.Text.Encoding addrspace(1)* %39, %System.Text.Encoding addrspace(1)** %loc3
+  br label %53
+
+; <label>:40                                      ; preds = %26
+  %41 = load i32, i32* %loc5
+  %42 = add i32 %41, 1
+  store i32 %42, i32* %loc5
+  br label %43
+
+; <label>:43                                      ; preds = %6, %40
+  %44 = load i32, i32* %loc5
+  %45 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  %NullCheck = icmp eq %"System.Text.EncodingProvider[]" addrspace(1)* %45, null
+  br i1 %NullCheck, label %ThrowNullRef, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp slt i32 %44, %50
+  br i1 %51, label %12, label %52
+
+; <label>:52                                      ; preds = %46
+  ret %System.Text.Encoding addrspace(1)* null
+
+; <label>:53                                      ; preds = %38
+  %54 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc3
+  ret %System.Text.Encoding addrspace(1)* %54
+
+ThrowNullRef:                                     ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method EncodingProvider::.cctor using LLILCJit
 Successfully read EncodingProvider..cctor
 
@@ -10694,7 +12403,7 @@ Failed to read Encoding.get_InternalSyncObject[Call HasTypeArg]
 INFO:  jitting method Hashtable::.ctor using LLILCJit
 Failed to read Hashtable..ctor[Volatile store]
 INFO:  jitting method Hashtable::get_Item using LLILCJit
-Failed to read Hashtable.get_Item[loadElemA]
+Failed to read Hashtable.get_Item[loadNonPrimitiveObj]
 INFO:  jitting method Hashtable::InitHash using LLILCJit
 Successfully read Hashtable.InitHash
 
@@ -10714,8 +12423,8 @@ entry:
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -10731,15 +12440,15 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
   %15 = load i32, i32* %loc0
-  %NullCheck2 = icmp ne i32 addrspace(1)* %14, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i32 addrspace(1)* %14, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %3
   store i32 %15, i32 addrspace(1)* %14, align 8
   %17 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %18 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %NullCheck4 = icmp ne i32 addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i32 addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = load i32, i32 addrspace(1)* %18, align 8
@@ -10748,8 +12457,8 @@ entry:
   %23 = sub i32 %22, 1
   %24 = urem i32 %21, %23
   %25 = add i32 1, %24
-  %NullCheck6 = icmp ne i32 addrspace(1)* %17, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32 addrspace(1)* %17, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %19
   store i32 %25, i32 addrspace(1)* %17, align 8
@@ -10760,15 +12469,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %19
+ThrowNullRef6:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10783,8 +12492,8 @@ entry:
   store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
   store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %NullCheck = icmp ne %System.Collections.Hashtable addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Collections.Hashtable addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
@@ -10794,16 +12503,16 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Collections.Hashtable addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Collections.Hashtable addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
   %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck4 = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %9, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
   %13 = inttoptr i64 %11 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
@@ -10813,8 +12522,8 @@ entry:
 ; <label>:15                                      ; preds = %1
   %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -10832,15 +12541,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10854,8 +12563,8 @@ entry:
   store %System.Int32 addrspace(1)* %param0, %System.Int32 addrspace(1)** %this
   %0 = load %System.Int32 addrspace(1)*, %System.Int32 addrspace(1)** %this
   %1 = bitcast %System.Int32 addrspace(1)* %0 to i32 addrspace(1)*
-  %NullCheck = icmp ne i32 addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq i32 addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load i32, i32 addrspace(1)* %1, align 8
@@ -10931,8 +12640,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.UTF8Encoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
@@ -10941,15 +12650,15 @@ entry:
   %9 = load i8, i8* %arg2
   %10 = zext i8 %9 to i32
   %11 = trunc i32 %10 to i8
-  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %8, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %6
   %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %8, i32 0, i32 8
   store i8 %11, i8 addrspace(1)* %13
   %14 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %14, i32 0, i32 8
@@ -10961,8 +12670,8 @@ entry:
 ; <label>:20                                      ; preds = %15
   %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %22, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %22, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = load i64, i64 addrspace(1)* %22
@@ -10984,15 +12693,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %12
+ThrowNullRef4:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11007,8 +12716,8 @@ entry:
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
@@ -11030,16 +12739,16 @@ entry:
 ; <label>:10                                      ; preds = %1
   %11 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
   %12 = load i32, i32* %arg1
-  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %11, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.Encoding addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
   store i32 %12, i32 addrspace(1)* %14
   %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
   %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = load i64, i64 addrspace(1)* %16
@@ -11057,11 +12766,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11074,8 +12783,8 @@ entry:
   %this = alloca %System.Text.UTF8Encoding addrspace(1)*
   store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
   %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.UTF8Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
@@ -11087,16 +12796,16 @@ entry:
 ; <label>:6                                       ; preds = %1
   %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %8 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %10, %System.Text.EncoderFallback addrspace(1)* %8)
   %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %12 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
-  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %11, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %11, i32 0, i32 3
@@ -11109,8 +12818,8 @@ entry:
   %18 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %18, %System.String addrspace(1)* %17)
   %19 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %18 to %System.Text.EncoderFallback addrspace(1)*
-  %NullCheck6 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %16, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %16, i32 0, i32 2
@@ -11120,8 +12829,8 @@ entry:
   %24 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %24, %System.String addrspace(1)* %23)
   %25 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %24 to %System.Text.DecoderFallback addrspace(1)*
-  %NullCheck8 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %22, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %22, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %20
   %27 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %22, i32 0, i32 3
@@ -11132,19 +12841,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %20
+ThrowNullRef8:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11174,8 +12883,8 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load i32, i32* %arg1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -11193,8 +12902,8 @@ entry:
 ; <label>:15                                      ; preds = %8
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %17 = load i32, i32* %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 %17
@@ -11210,7 +12919,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11262,7 +12971,7 @@ entry:
 }
 
 INFO:  jitting method Hashtable::Insert using LLILCJit
-Failed to read Hashtable.Insert[loadElemA]
+Failed to read Hashtable.Insert[storeElem]
 INFO:  jitting method ConsoleEncoding::.ctor using LLILCJit
 Successfully read ConsoleEncoding..ctor
 
@@ -11277,8 +12986,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %1)
   %2 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
@@ -11314,8 +13023,8 @@ entry:
   %2 = call %System.Text.InternalEncoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalEncoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %1)
   %3 = bitcast %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2 to %System.Text.EncoderFallback addrspace(1)*
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
@@ -11325,8 +13034,8 @@ entry:
   %8 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %7)
   %9 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %8 to %System.Text.DecoderFallback addrspace(1)*
-  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %6, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.Encoding addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %4
   %11 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %6, i32 0, i32 3
@@ -11337,7 +13046,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11356,15 +13065,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* %1)
   %2 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   %6 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, i32 0, i32 1
@@ -11375,7 +13084,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11403,8 +13112,8 @@ entry:
   store %System.Text.InternalDecoderBestFitFallback addrspace(1)* %param0, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
   %0 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
@@ -11414,15 +13123,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %4)
   %5 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %6)
   %9 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, i32 0, i32 1
@@ -11433,11 +13142,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11505,8 +13214,8 @@ entry:
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
   %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = load i64, i64 addrspace(1)* %19
@@ -11570,8 +13279,8 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.ConsoleStream addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
@@ -11602,31 +13311,31 @@ entry:
   store i8 %param4, i8* %arg4
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %3, %System.IO.Stream addrspace(1)* %1)
   %4 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %4, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
   %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %4, i32 0, i32 4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %5)
   %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %6
   %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
   %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
   %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = load i64, i64 addrspace(1)* %13
@@ -11638,8 +13347,8 @@ entry:
   %21 = load i64, i64* %20
   %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %8, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %8, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %14
   %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 5
@@ -11657,24 +13366,24 @@ entry:
   %31 = load i32, i32* %arg3
   %32 = sext i32 %31 to i64
   %33 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %32)
-  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %30, null
-  br i1 %NullCheck10, label %34, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.StreamWriter addrspace(1)* %30, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %35, %"System.Char[]" addrspace(1)* %33)
   %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %37, null
-  br i1 %NullCheck12, label %38, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.StreamWriter addrspace(1)* %37, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %38
 
 ; <label>:38                                      ; preds = %34
   %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
   %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
   %41 = load i32, i32* %arg3
   %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %42, null
-  br i1 %NullCheck14, label %43, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %42, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
   %44 = load i64, i64 addrspace(1)* %42
@@ -11688,30 +13397,30 @@ entry:
   %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
   %53 = sext i32 %52 to i64
   %54 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %53)
-  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
-  br i1 %NullCheck16, label %55, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %55
 
 ; <label>:55                                      ; preds = %43
   %56 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %56, %"System.Byte[]" addrspace(1)* %54)
   %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %58 = load i32, i32* %arg3
-  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %57, null
-  br i1 %NullCheck18, label %59, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.StreamWriter addrspace(1)* %57, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %59
 
 ; <label>:59                                      ; preds = %55
   %60 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 10
   store i32 %58, i32 addrspace(1)* %60
   %61 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %61, null
-  br i1 %NullCheck20, label %62, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.IO.StreamWriter addrspace(1)* %61, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %62
 
 ; <label>:62                                      ; preds = %59
   %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
   %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
   %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
   %67 = load i64, i64 addrspace(1)* %65
@@ -11729,15 +13438,15 @@ entry:
 
 ; <label>:78                                      ; preds = %66
   %79 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %79, null
-  br i1 %NullCheck24, label %80, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.StreamWriter addrspace(1)* %79, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %80
 
 ; <label>:80                                      ; preds = %78
   %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
   %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
   %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %83, null
-  br i1 %NullCheck26, label %84, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %83, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
   %85 = load i64, i64 addrspace(1)* %83
@@ -11754,8 +13463,8 @@ entry:
 
 ; <label>:95                                      ; preds = %84
   %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.IO.StreamWriter addrspace(1)* %96, null
-  br i1 %NullCheck28, label %97, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.IO.StreamWriter addrspace(1)* %96, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %97
 
 ; <label>:97                                      ; preds = %95
   %98 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 12
@@ -11769,8 +13478,8 @@ entry:
   %103 = icmp eq i32 %102, 0
   %104 = sext i1 %103 to i32
   %105 = trunc i32 %104 to i8
-  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %100, null
-  br i1 %NullCheck30, label %106, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.IO.StreamWriter addrspace(1)* %100, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %106
 
 ; <label>:106                                     ; preds = %99
   %107 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %100, i32 0, i32 13
@@ -11781,63 +13490,63 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %6
+ThrowNullRef4:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %29
+ThrowNullRef10:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %34
+ThrowNullRef12:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %38
+ThrowNullRef14:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %43
+ThrowNullRef16:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %55
+ThrowNullRef18:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %59
+ThrowNullRef20:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %62
+ThrowNullRef22:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %78
+ThrowNullRef24:                                   ; preds = %78
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %80
+ThrowNullRef26:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %95
+ThrowNullRef28:                                   ; preds = %95
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11850,15 +13559,15 @@ entry:
   %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = load i64, i64 addrspace(1)* %4
@@ -11876,7 +13585,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11926,35 +13635,35 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
   %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderNLS addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %7 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.EncoderNLS addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Text.Encoding addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.Encoding addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Text.EncoderNLS addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.EncoderNLS addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
   %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck8 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = load i64, i64 addrspace(1)* %16
@@ -11973,19 +13682,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12011,8 +13720,8 @@ entry:
   %this = alloca %System.Text.Encoding addrspace(1)*
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
@@ -12032,15 +13741,15 @@ entry:
   %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
   store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
   %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
   store i32 0, i32 addrspace(1)* %2
   %3 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, i32 0, i32 2
@@ -12050,15 +13759,15 @@ entry:
 
 ; <label>:8                                       ; preds = %4
   %9 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
   %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
   %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = load i64, i64 addrspace(1)* %13
@@ -12079,15 +13788,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12102,16 +13811,16 @@ entry:
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = load i32, i32* %arg1
   %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
   %7 = load i64, i64 addrspace(1)* %5
@@ -12129,7 +13838,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12166,8 +13875,8 @@ entry:
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
   %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
   %16 = load i64, i64 addrspace(1)* %14
@@ -12188,8 +13897,8 @@ entry:
   %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
   %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
   %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %31, null
-  br i1 %NullCheck2, label %32, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = load i64, i64 addrspace(1)* %31
@@ -12232,7 +13941,7 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12245,14 +13954,14 @@ entry:
   %this = alloca %System.Text.EncoderReplacementFallback addrspace(1)*
   store %System.Text.EncoderReplacementFallback addrspace(1)* %param0, %System.Text.EncoderReplacementFallback addrspace(1)** %this
   %0 = load %System.Text.EncoderReplacementFallback addrspace(1)*, %System.Text.EncoderReplacementFallback addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -12263,7 +13972,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12293,8 +14002,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
@@ -12326,8 +14035,8 @@ entry:
   %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
   store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
@@ -12339,8 +14048,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Threading.Tasks.Task addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %7)
@@ -12363,7 +14072,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12382,8 +14091,8 @@ entry:
   store i8 %param1, i8* %arg1
   store i8 %param2, i8* %arg2
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
@@ -12397,8 +14106,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1, %5
   %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 9
@@ -12429,8 +14138,8 @@ entry:
 
 ; <label>:25                                      ; preds = %8, %20
   %26 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %26, null
-  br i1 %NullCheck4, label %27, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %26, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %26, i32 0, i32 12
@@ -12441,22 +14150,22 @@ entry:
 
 ; <label>:32                                      ; preds = %27
   %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %33, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.IO.StreamWriter addrspace(1)* %33, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %32
   %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 12
   store i8 1, i8 addrspace(1)* %35
   %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
-  br i1 %NullCheck8, label %37, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
   %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
   %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck10 = icmp ne i64 addrspace(1)* %40, null
-  br i1 %NullCheck10, label %41, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64 addrspace(1)* %40, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i64, i64 addrspace(1)* %40
@@ -12470,8 +14179,8 @@ entry:
   %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
   store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
   %51 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %NullCheck12 = icmp ne %"System.Byte[]" addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Byte[]" addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %41
   %53 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %51, i32 0, i32 1
@@ -12483,16 +14192,16 @@ entry:
 
 ; <label>:58                                      ; preds = %52
   %59 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %59, null
-  br i1 %NullCheck14, label %60, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.IO.StreamWriter addrspace(1)* %59, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %60
 
 ; <label>:60                                      ; preds = %58
   %61 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %59, i32 0, i32 3
   %62 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
   %64 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %NullCheck16 = icmp ne %"System.Byte[]" addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %"System.Byte[]" addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %60
   %66 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %64, i32 0, i32 1
@@ -12500,8 +14209,8 @@ entry:
   %68 = zext i32 %67 to i64
   %69 = trunc i64 %68 to i32
   %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck18, label %71, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
   %72 = load i64, i64 addrspace(1)* %70
@@ -12517,29 +14226,29 @@ entry:
 
 ; <label>:80                                      ; preds = %27, %52, %71
   %81 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %81, null
-  br i1 %NullCheck20, label %82, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.IO.StreamWriter addrspace(1)* %81, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
 
 ; <label>:82                                      ; preds = %80
   %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %81, i32 0, i32 5
   %84 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %83, align 8
   %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.IO.StreamWriter addrspace(1)* %85, null
-  br i1 %NullCheck22, label %86, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.IO.StreamWriter addrspace(1)* %85, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %86
 
 ; <label>:86                                      ; preds = %82
   %87 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 7
   %88 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %87, align 8
   %89 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %89, null
-  br i1 %NullCheck24, label %90, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.StreamWriter addrspace(1)* %89, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %90
 
 ; <label>:90                                      ; preds = %86
   %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %89, i32 0, i32 9
   %92 = load i32, i32 addrspace(1)* %91, align 8
   %93 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.IO.StreamWriter addrspace(1)* %93, null
-  br i1 %NullCheck26, label %94, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.IO.StreamWriter addrspace(1)* %93, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %93, i32 0, i32 6
@@ -12547,8 +14256,8 @@ entry:
   %97 = load i8, i8* %arg2
   %98 = zext i8 %97 to i32
   %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
-  %NullCheck28 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck28, label %100, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
   %101 = load i64, i64 addrspace(1)* %99
@@ -12563,8 +14272,8 @@ entry:
   %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
   store i32 %110, i32* %loc1
   %111 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %111, null
-  br i1 %NullCheck30, label %112, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.IO.StreamWriter addrspace(1)* %111, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %112
 
 ; <label>:112                                     ; preds = %100
   %113 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %111, i32 0, i32 9
@@ -12575,23 +14284,23 @@ entry:
 
 ; <label>:116                                     ; preds = %112
   %117 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck32 = icmp ne %System.IO.StreamWriter addrspace(1)* %117, null
-  br i1 %NullCheck32, label %118, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.IO.StreamWriter addrspace(1)* %117, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %118
 
 ; <label>:118                                     ; preds = %116
   %119 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %117, i32 0, i32 3
   %120 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %119, align 8
   %121 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.IO.StreamWriter addrspace(1)* %121, null
-  br i1 %NullCheck34, label %122, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.IO.StreamWriter addrspace(1)* %121, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %122
 
 ; <label>:122                                     ; preds = %118
   %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
   %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
   %125 = load i32, i32* %loc1
   %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
-  %NullCheck36 = icmp ne i64 addrspace(1)* %126, null
-  br i1 %NullCheck36, label %127, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64 addrspace(1)* %126, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
   %128 = load i64, i64 addrspace(1)* %126
@@ -12613,15 +14322,15 @@ entry:
 
 ; <label>:140                                     ; preds = %136
   %141 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.IO.StreamWriter addrspace(1)* %141, null
-  br i1 %NullCheck38, label %142, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.IO.StreamWriter addrspace(1)* %141, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %142
 
 ; <label>:142                                     ; preds = %140
   %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
   %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
   %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
-  %NullCheck40 = icmp ne i64 addrspace(1)* %145, null
-  br i1 %NullCheck40, label %146, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i64 addrspace(1)* %145, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
   %147 = load i64, i64 addrspace(1)* %145
@@ -12642,83 +14351,83 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %25
+ThrowNullRef4:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %32
+ThrowNullRef6:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %37
+ThrowNullRef10:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %41
+ThrowNullRef12:                                   ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %58
+ThrowNullRef14:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %60
+ThrowNullRef16:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %65
+ThrowNullRef18:                                   ; preds = %65
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %80
+ThrowNullRef20:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %82
+ThrowNullRef22:                                   ; preds = %82
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %86
+ThrowNullRef24:                                   ; preds = %86
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %90
+ThrowNullRef26:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %94
+ThrowNullRef28:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %100
+ThrowNullRef30:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %116
+ThrowNullRef32:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %118
+ThrowNullRef34:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %122
+ThrowNullRef36:                                   ; preds = %122
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %140
+ThrowNullRef38:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %142
+ThrowNullRef40:                                   ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12785,8 +14494,8 @@ entry:
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %1 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
-  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
@@ -12794,8 +14503,8 @@ entry:
   %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
   %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
   %8 = load i64, i64 addrspace(1)* %6
@@ -12811,8 +14520,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %17, %System.IFormatProvider addrspace(1)* %16)
   %18 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %19 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %18, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.SyncTextWriter addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %7
   %21 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %18, i32 0, i32 4
@@ -12823,11 +14532,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12840,8 +14549,8 @@ entry:
   %this = alloca %System.IO.TextWriter addrspace(1)*
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.TextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
@@ -12851,8 +14560,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.Threading.Thread addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Threading.Thread addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %6)
@@ -12861,8 +14570,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1
   %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.TextWriter addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.TextWriter addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %11, i32 0, i32 2
@@ -12873,11 +14582,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13074,8 +14783,8 @@ entry:
   store float %param1, float* %arg1
   store i8 0, i8* %loc1
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
@@ -13085,16 +14794,16 @@ entry:
   %5 = addrspacecast i8* %loc1 to i8 addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %4, i8 addrspace(1)* %5)
   %6 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.SyncTextWriter addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
   %10 = load float, float* %arg1
   %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
   %13 = load i64, i64 addrspace(1)* %11
@@ -13129,11 +14838,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13150,8 +14859,8 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load float, float* %arg1
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -13165,8 +14874,8 @@ entry:
   call void %11(%System.IO.TextWriter addrspace(1)* %0, float %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
   %15 = load i64, i64 addrspace(1)* %13
@@ -13184,7 +14893,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13202,8 +14911,8 @@ entry:
   %1 = addrspacecast float* %arg1 to float addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -13218,8 +14927,8 @@ entry:
   %14 = bitcast float addrspace(1)* %1 to %System.Single addrspace(1)*
   %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Single addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Single addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
   %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
   %18 = load i64, i64 addrspace(1)* %16
@@ -13237,7 +14946,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13253,8 +14962,8 @@ entry:
   store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
   %0 = load %System.Single addrspace(1)*, %System.Single addrspace(1)** %this
   %1 = bitcast %System.Single addrspace(1)* %0 to float addrspace(1)*
-  %NullCheck = icmp ne float addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq float addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load float, float addrspace(1)* %1, align 8
@@ -13279,8 +14988,8 @@ entry:
   %loc0 = alloca %System.Globalization.NumberFormatInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 3
@@ -13290,8 +14999,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
@@ -13301,24 +15010,24 @@ entry:
   store %System.Globalization.NumberFormatInfo addrspace(1)* %10, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
   %11 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %7
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
   %15 = load i8, i8 addrspace(1)* %14, align 8
   %16 = zext i8 %15 to i32
   %17 = trunc i32 %16 to i8
-  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %11, null
-  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %11, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %13
   %19 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %11, i32 0, i32 29
   store i8 %17, i8 addrspace(1)* %19
   %20 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %21 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %20, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %20, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %18
   %23 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %20, i32 0, i32 3
@@ -13327,8 +15036,8 @@ entry:
 
 ; <label>:24                                      ; preds = %1, %22
   %25 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %25, null
-  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %25, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %26
 
 ; <label>:26                                      ; preds = %24
   %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %25, i32 0, i32 3
@@ -13339,23 +15048,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %18
+ThrowNullRef8:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13380,168 +15089,168 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 18
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %8, align 8
-  %NullCheck2 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %5, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %5, i32 0, i32 4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %9)
   %12 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 19
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %15, align 8
-  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %12, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %12, i32 0, i32 5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %16)
   %19 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %20 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %20, null
-  br i1 %NullCheck8, label %21, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %20, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %20, i32 0, i32 23
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  %NullCheck10 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %19, null
-  br i1 %NullCheck10, label %24, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %19, i32 0, i32 7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %25, %System.String addrspace(1)* %23)
   %26 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %27 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %27, i32 0, i32 22
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %29, align 8
-  %NullCheck14 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %26, null
-  br i1 %NullCheck14, label %31, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %26, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %26, i32 0, i32 6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %32, %System.String addrspace(1)* %30)
   %33 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %34 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Globalization.CultureData addrspace(1)* %34, null
-  br i1 %NullCheck16, label %35, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Globalization.CultureData addrspace(1)* %34, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %34, i32 0, i32 51
   %37 = load i32, i32 addrspace(1)* %36, align 8
-  %NullCheck18 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %33, null
-  br i1 %NullCheck18, label %38, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %33, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %33, i32 0, i32 21
   store i32 %37, i32 addrspace(1)* %39
   %40 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %41 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Globalization.CultureData addrspace(1)* %41, null
-  br i1 %NullCheck20, label %42, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Globalization.CultureData addrspace(1)* %41, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %41, i32 0, i32 52
   %44 = load i32, i32 addrspace(1)* %43, align 8
-  %NullCheck22 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %40, null
-  br i1 %NullCheck22, label %45, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %40, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %40, i32 0, i32 25
   store i32 %44, i32 addrspace(1)* %46
   %47 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %48 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.Globalization.CultureData addrspace(1)* %48, null
-  br i1 %NullCheck24, label %49, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Globalization.CultureData addrspace(1)* %48, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %49
 
 ; <label>:49                                      ; preds = %45
   %50 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %48, i32 0, i32 29
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck26 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %47, null
-  br i1 %NullCheck26, label %52, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %47, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %47, i32 0, i32 10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %53, %System.String addrspace(1)* %51)
   %54 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %55 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Globalization.CultureData addrspace(1)* %55, null
-  br i1 %NullCheck28, label %56, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Globalization.CultureData addrspace(1)* %55, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %56
 
 ; <label>:56                                      ; preds = %52
   %57 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %55, i32 0, i32 35
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %57, align 8
-  %NullCheck30 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %54, null
-  br i1 %NullCheck30, label %59, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %54, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %54, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %60, %System.String addrspace(1)* %58)
   %61 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %62 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck32 = icmp ne %System.Globalization.CultureData addrspace(1)* %62, null
-  br i1 %NullCheck32, label %63, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Globalization.CultureData addrspace(1)* %62, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %62, i32 0, i32 34
   %65 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %64, align 8
-  %NullCheck34 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %61, null
-  br i1 %NullCheck34, label %66, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %61, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %61, i32 0, i32 9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %67, %System.String addrspace(1)* %65)
   %68 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %69 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck36 = icmp ne %System.Globalization.CultureData addrspace(1)* %69, null
-  br i1 %NullCheck36, label %70, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Globalization.CultureData addrspace(1)* %69, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %70
 
 ; <label>:70                                      ; preds = %66
   %71 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %69, i32 0, i32 55
   %72 = load i32, i32 addrspace(1)* %71, align 8
-  %NullCheck38 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %68, null
-  br i1 %NullCheck38, label %73, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %68, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %68, i32 0, i32 22
   store i32 %72, i32 addrspace(1)* %74
   %75 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %76 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck40 = icmp ne %System.Globalization.CultureData addrspace(1)* %76, null
-  br i1 %NullCheck40, label %77, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Globalization.CultureData addrspace(1)* %76, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %76, i32 0, i32 57
   %79 = load i32, i32 addrspace(1)* %78, align 8
-  %NullCheck42 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %75, null
-  br i1 %NullCheck42, label %80, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %75, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %80
 
 ; <label>:80                                      ; preds = %77
   %81 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %75, i32 0, i32 24
   store i32 %79, i32 addrspace(1)* %81
   %82 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %83 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck44 = icmp ne %System.Globalization.CultureData addrspace(1)* %83, null
-  br i1 %NullCheck44, label %84, label %ThrowNullRef43
+  %NullCheck43 = icmp eq %System.Globalization.CultureData addrspace(1)* %83, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %84
 
 ; <label>:84                                      ; preds = %80
   %85 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %83, i32 0, i32 56
   %86 = load i32, i32 addrspace(1)* %85, align 8
-  %NullCheck46 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %82, null
-  br i1 %NullCheck46, label %87, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %82, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %82, i32 0, i32 23
@@ -13550,8 +15259,8 @@ entry:
 
 ; <label>:89                                      ; preds = %entry
   %90 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck100 = icmp ne %System.Globalization.CultureData addrspace(1)* %90, null
-  br i1 %NullCheck100, label %91, label %ThrowNullRef99
+  %NullCheck99 = icmp eq %System.Globalization.CultureData addrspace(1)* %90, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %91
 
 ; <label>:91                                      ; preds = %89
   %92 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %90, i32 0, i32 2
@@ -13569,8 +15278,8 @@ entry:
   %102 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %103 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %104 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %103)
-  %NullCheck48 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %102, null
-  br i1 %NullCheck48, label %105, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %102, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %105
 
 ; <label>:105                                     ; preds = %101
   %106 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %102, i32 0, i32 1
@@ -13578,8 +15287,8 @@ entry:
   %107 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %108 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %109 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %108)
-  %NullCheck50 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %107, null
-  br i1 %NullCheck50, label %110, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %107, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %110
 
 ; <label>:110                                     ; preds = %105
   %111 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %107, i32 0, i32 2
@@ -13587,8 +15296,8 @@ entry:
   %112 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %113 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %114 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %113)
-  %NullCheck52 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %112, null
-  br i1 %NullCheck52, label %115, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %112, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %115
 
 ; <label>:115                                     ; preds = %110
   %116 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %112, i32 0, i32 27
@@ -13596,8 +15305,8 @@ entry:
   %117 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %118 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %119 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %118)
-  %NullCheck54 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %117, null
-  br i1 %NullCheck54, label %120, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %117, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %120
 
 ; <label>:120                                     ; preds = %115
   %121 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %117, i32 0, i32 26
@@ -13605,8 +15314,8 @@ entry:
   %122 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %123 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %124 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %123)
-  %NullCheck56 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %122, null
-  br i1 %NullCheck56, label %125, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %122, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %125
 
 ; <label>:125                                     ; preds = %120
   %126 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %122, i32 0, i32 17
@@ -13614,8 +15323,8 @@ entry:
   %127 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %128 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %129 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %128)
-  %NullCheck58 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %127, null
-  br i1 %NullCheck58, label %130, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %127, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %130
 
 ; <label>:130                                     ; preds = %125
   %131 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %127, i32 0, i32 18
@@ -13623,8 +15332,8 @@ entry:
   %132 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %133 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %134 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %133)
-  %NullCheck60 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %132, null
-  br i1 %NullCheck60, label %135, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %132, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %135
 
 ; <label>:135                                     ; preds = %130
   %136 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %132, i32 0, i32 14
@@ -13632,8 +15341,8 @@ entry:
   %137 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %138 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %139 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %138)
-  %NullCheck62 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %137, null
-  br i1 %NullCheck62, label %140, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %137, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %140
 
 ; <label>:140                                     ; preds = %135
   %141 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %137, i32 0, i32 13
@@ -13641,71 +15350,71 @@ entry:
   %142 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %143 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %144 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %143)
-  %NullCheck64 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %142, null
-  br i1 %NullCheck64, label %145, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %142, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %145
 
 ; <label>:145                                     ; preds = %140
   %146 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %142, i32 0, i32 12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %146, %System.String addrspace(1)* %144)
   %147 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %148 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck66 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %148, null
-  br i1 %NullCheck66, label %149, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %148, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %149
 
 ; <label>:149                                     ; preds = %145
   %150 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %148, i32 0, i32 21
   %151 = load i32, i32 addrspace(1)* %150, align 8
-  %NullCheck68 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %147, null
-  br i1 %NullCheck68, label %152, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %147, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %152
 
 ; <label>:152                                     ; preds = %149
   %153 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %147, i32 0, i32 28
   store i32 %151, i32 addrspace(1)* %153
   %154 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %155 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck70 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %155, null
-  br i1 %NullCheck70, label %156, label %ThrowNullRef69
+  %NullCheck69 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %155, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %156
 
 ; <label>:156                                     ; preds = %152
   %157 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %155, i32 0, i32 6
   %158 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %157, align 8
-  %NullCheck72 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %154, null
-  br i1 %NullCheck72, label %159, label %ThrowNullRef71
+  %NullCheck71 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %154, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %159
 
 ; <label>:159                                     ; preds = %156
   %160 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %154, i32 0, i32 15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %160, %System.String addrspace(1)* %158)
   %161 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %162 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck74 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %162, null
-  br i1 %NullCheck74, label %163, label %ThrowNullRef73
+  %NullCheck73 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %162, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %163
 
 ; <label>:163                                     ; preds = %159
   %164 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %162, i32 0, i32 1
   %165 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %164, align 8
-  %NullCheck76 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %161, null
-  br i1 %NullCheck76, label %166, label %ThrowNullRef75
+  %NullCheck75 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %161, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %166
 
 ; <label>:166                                     ; preds = %163
   %167 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %161, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %167, %"System.Int32[]" addrspace(1)* %165)
   %168 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %169 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck78 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %169, null
-  br i1 %NullCheck78, label %170, label %ThrowNullRef77
+  %NullCheck77 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %169, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %170
 
 ; <label>:170                                     ; preds = %166
   %171 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %169, i32 0, i32 7
   %172 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %171, align 8
-  %NullCheck80 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %168, null
-  br i1 %NullCheck80, label %173, label %ThrowNullRef79
+  %NullCheck79 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %168, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %173
 
 ; <label>:173                                     ; preds = %170
   %174 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %168, i32 0, i32 16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %174, %System.String addrspace(1)* %172)
   %175 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck82 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %175, null
-  br i1 %NullCheck82, label %176, label %ThrowNullRef81
+  %NullCheck81 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %175, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %176
 
 ; <label>:176                                     ; preds = %173
   %177 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %175, i32 0, i32 4
@@ -13715,14 +15424,14 @@ entry:
 
 ; <label>:180                                     ; preds = %176
   %181 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck84 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %181, null
-  br i1 %NullCheck84, label %182, label %ThrowNullRef83
+  %NullCheck83 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %181, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %182
 
 ; <label>:182                                     ; preds = %180
   %183 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %181, i32 0, i32 4
   %184 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %183, align 8
-  %NullCheck86 = icmp ne %System.String addrspace(1)* %184, null
-  br i1 %NullCheck86, label %185, label %ThrowNullRef85
+  %NullCheck85 = icmp eq %System.String addrspace(1)* %184, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %185
 
 ; <label>:185                                     ; preds = %182
   %186 = getelementptr inbounds %System.String, %System.String addrspace(1)* %184, i32 0, i32 1
@@ -13733,8 +15442,8 @@ entry:
 ; <label>:189                                     ; preds = %176, %185
   %190 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck98 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %190, null
-  br i1 %NullCheck98, label %192, label %ThrowNullRef97
+  %NullCheck97 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %190, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %192
 
 ; <label>:192                                     ; preds = %189
   %193 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %190, i32 0, i32 4
@@ -13743,8 +15452,8 @@ entry:
 
 ; <label>:194                                     ; preds = %185, %192
   %195 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck88 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %195, null
-  br i1 %NullCheck88, label %196, label %ThrowNullRef87
+  %NullCheck87 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %195, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %196
 
 ; <label>:196                                     ; preds = %194
   %197 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %195, i32 0, i32 9
@@ -13754,14 +15463,14 @@ entry:
 
 ; <label>:200                                     ; preds = %196
   %201 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck90 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %201, null
-  br i1 %NullCheck90, label %202, label %ThrowNullRef89
+  %NullCheck89 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %201, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %202
 
 ; <label>:202                                     ; preds = %200
   %203 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %201, i32 0, i32 9
   %204 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %203, align 8
-  %NullCheck92 = icmp ne %System.String addrspace(1)* %204, null
-  br i1 %NullCheck92, label %205, label %ThrowNullRef91
+  %NullCheck91 = icmp eq %System.String addrspace(1)* %204, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %205
 
 ; <label>:205                                     ; preds = %202
   %206 = getelementptr inbounds %System.String, %System.String addrspace(1)* %204, i32 0, i32 1
@@ -13772,14 +15481,14 @@ entry:
 ; <label>:209                                     ; preds = %196, %205
   %210 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %211 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck94 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %211, null
-  br i1 %NullCheck94, label %212, label %ThrowNullRef93
+  %NullCheck93 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %211, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %212
 
 ; <label>:212                                     ; preds = %209
   %213 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %211, i32 0, i32 6
   %214 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %213, align 8
-  %NullCheck96 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %210, null
-  br i1 %NullCheck96, label %215, label %ThrowNullRef95
+  %NullCheck95 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %210, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %215
 
 ; <label>:215                                     ; preds = %212
   %216 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %210, i32 0, i32 9
@@ -13793,203 +15502,203 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %17
+ThrowNullRef8:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %21
+ThrowNullRef10:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %24
+ThrowNullRef12:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %28
+ThrowNullRef14:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %31
+ThrowNullRef16:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %35
+ThrowNullRef18:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %38
+ThrowNullRef20:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %42
+ThrowNullRef22:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %45
+ThrowNullRef24:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %49
+ThrowNullRef26:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %52
+ThrowNullRef28:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %56
+ThrowNullRef30:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %59
+ThrowNullRef32:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %63
+ThrowNullRef34:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %66
+ThrowNullRef36:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %70
+ThrowNullRef38:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %73
+ThrowNullRef40:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %77
+ThrowNullRef42:                                   ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %80
+ThrowNullRef44:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %84
+ThrowNullRef46:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %101
+ThrowNullRef48:                                   ; preds = %101
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %105
+ThrowNullRef50:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %110
+ThrowNullRef52:                                   ; preds = %110
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %115
+ThrowNullRef54:                                   ; preds = %115
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %120
+ThrowNullRef56:                                   ; preds = %120
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %125
+ThrowNullRef58:                                   ; preds = %125
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %130
+ThrowNullRef60:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %135
+ThrowNullRef62:                                   ; preds = %135
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %140
+ThrowNullRef64:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %145
+ThrowNullRef66:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %149
+ThrowNullRef68:                                   ; preds = %149
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %152
+ThrowNullRef70:                                   ; preds = %152
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %156
+ThrowNullRef72:                                   ; preds = %156
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %159
+ThrowNullRef74:                                   ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %163
+ThrowNullRef76:                                   ; preds = %163
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %166
+ThrowNullRef78:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %170
+ThrowNullRef80:                                   ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %173
+ThrowNullRef82:                                   ; preds = %173
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %180
+ThrowNullRef84:                                   ; preds = %180
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %182
+ThrowNullRef86:                                   ; preds = %182
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %194
+ThrowNullRef88:                                   ; preds = %194
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %200
+ThrowNullRef90:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %202
+ThrowNullRef92:                                   ; preds = %202
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %209
+ThrowNullRef94:                                   ; preds = %209
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %212
+ThrowNullRef96:                                   ; preds = %212
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %189
+ThrowNullRef98:                                   ; preds = %189
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %89
+ThrowNullRef100:                                  ; preds = %89
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14017,8 +15726,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 21
@@ -14031,8 +15740,8 @@ entry:
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 16)
   %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 21
@@ -14041,8 +15750,8 @@ entry:
 
 ; <label>:12                                      ; preds = %1, %10
   %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 21
@@ -14053,11 +15762,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %12
+ThrowNullRef4:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14073,8 +15782,8 @@ entry:
   store i32 %param1, i32* %arg1
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %1 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
@@ -14141,8 +15850,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 33
@@ -14155,8 +15864,8 @@ entry:
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 24)
   %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 33
@@ -14165,8 +15874,8 @@ entry:
 
 ; <label>:12                                      ; preds = %1, %10
   %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 33
@@ -14177,11 +15886,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %12
+ThrowNullRef4:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14194,8 +15903,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 53
@@ -14207,8 +15916,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 116)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 53
@@ -14217,8 +15926,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 53
@@ -14229,11 +15938,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14262,8 +15971,8 @@ entry:
 
 ; <label>:7                                       ; preds = %entry, %4
   %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %7
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 2
@@ -14287,8 +15996,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 54
@@ -14300,8 +16009,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 117)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
@@ -14310,8 +16019,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 54
@@ -14322,11 +16031,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14339,8 +16048,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 27
@@ -14352,8 +16061,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 118)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 27
@@ -14362,8 +16071,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 27
@@ -14374,11 +16083,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14391,8 +16100,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 28
@@ -14404,8 +16113,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 119)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 28
@@ -14414,8 +16123,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 28
@@ -14426,11 +16135,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14443,8 +16152,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 26
@@ -14456,8 +16165,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 107)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 26
@@ -14466,8 +16175,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 26
@@ -14478,11 +16187,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14495,8 +16204,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 25
@@ -14508,8 +16217,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 106)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 25
@@ -14518,8 +16227,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 25
@@ -14530,11 +16239,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14547,8 +16256,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 24
@@ -14560,8 +16269,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 105)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 24
@@ -14570,8 +16279,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 24
@@ -14582,11 +16291,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14611,8 +16320,8 @@ entry:
   %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %3)
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %2
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -14623,15 +16332,15 @@ entry:
 
 ; <label>:8                                       ; preds = %62
   %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 9
   %12 = load i32, i32 addrspace(1)* %11, align 8
   %13 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.IO.StreamWriter addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %13, i32 0, i32 10
@@ -14646,15 +16355,15 @@ entry:
 
 ; <label>:20                                      ; preds = %14, %18
   %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
   %24 = load i32, i32 addrspace(1)* %23, align 8
   %25 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %25, null
-  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.StreamWriter addrspace(1)* %25, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %25, i32 0, i32 9
@@ -14675,36 +16384,36 @@ entry:
   %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %37 = load i32, i32* %loc1
   %38 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.StreamWriter addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %35
   %40 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %38, i32 0, i32 7
   %41 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %40, align 8
   %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
-  br i1 %NullCheck14, label %43, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %39
   %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 9
   %45 = load i32, i32 addrspace(1)* %44, align 8
   %46 = load i32, i32* %loc2
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %36, null
-  br i1 %NullCheck16, label %47, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %36, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %47
 
 ; <label>:47                                      ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %36, i32 %37, %"System.Char[]" addrspace(1)* %41, i32 %45, i32 %46)
   %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
   %51 = load i32, i32 addrspace(1)* %50, align 8
   %52 = load i32, i32* %loc2
   %53 = add i32 %51, %52
-  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
-  br i1 %NullCheck20, label %54, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %54
 
 ; <label>:54                                      ; preds = %49
   %55 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
@@ -14726,8 +16435,8 @@ entry:
 
 ; <label>:65                                      ; preds = %62
   %66 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %66, null
-  br i1 %NullCheck2, label %67, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %66, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %67
 
 ; <label>:67                                      ; preds = %65
   %68 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %66, i32 0, i32 11
@@ -14748,49 +16457,259 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %65
+ThrowNullRef2:                                    ; preds = %65
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %20
+ThrowNullRef8:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %22
+ThrowNullRef10:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %35
+ThrowNullRef12:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %43
+ThrowNullRef16:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %47
+ThrowNullRef18:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method String::CopyTo using LLILCJit
-Failed to read String.CopyTo[loadElemA]
+Successfully read String.CopyTo
+
+define void @String.CopyTo(%System.String addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  %loc1 = alloca i16 addrspace(1)*
+  %loc2 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %1 = icmp ne %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg4
+  %7 = icmp sge i32 %6, 0
+  br i1 %7, label %13, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  unreachable
+
+; <label>:13                                      ; preds = %5
+  %14 = load i32, i32* %arg1
+  %15 = icmp sge i32 %14, 0
+  br i1 %15, label %21, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %18)
+  %20 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %20, %System.String addrspace(1)* %17, %System.String addrspace(1)* %19)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %20) #0
+  unreachable
+
+; <label>:21                                      ; preds = %13
+  %22 = load i32, i32* %arg4
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck, label %ThrowNullRef, label %24
+
+; <label>:24                                      ; preds = %21
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load i32, i32* %arg1
+  %28 = sub i32 %26, %27
+  %29 = icmp sle i32 %22, %28
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34, %System.String addrspace(1)* %31, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %24
+  %36 = load i32, i32* %arg3
+  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %37, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
+
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
+  %40 = load i32, i32 addrspace(1)* %39
+  %41 = zext i32 %40 to i64
+  %42 = trunc i64 %41 to i32
+  %43 = load i32, i32* %arg4
+  %44 = sub i32 %42, %43
+  %45 = icmp sgt i32 %36, %44
+  br i1 %45, label %49, label %46
+
+; <label>:46                                      ; preds = %38
+  %47 = load i32, i32* %arg3
+  %48 = icmp sge i32 %47, 0
+  br i1 %48, label %54, label %49
+
+; <label>:49                                      ; preds = %38, %46
+  %50 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %52 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %51)
+  %53 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53, %System.String addrspace(1)* %50, %System.String addrspace(1)* %52)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53) #0
+  unreachable
+
+; <label>:54                                      ; preds = %46
+  %55 = load i32, i32* %arg4
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %97, label %57
+
+; <label>:57                                      ; preds = %54
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %59
+
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 2
+  %61 = bitcast [0 x i16] addrspace(1)* %60 to i16 addrspace(1)*
+  store i16 addrspace(1)* %61, i16 addrspace(1)** %loc0
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  store %"System.Char[]" addrspace(1)* %62, %"System.Char[]" addrspace(1)** %loc2
+  %63 = icmp eq %"System.Char[]" addrspace(1)* %62, null
+  br i1 %63, label %72, label %64
+
+; <label>:64                                      ; preds = %59
+  %65 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc2
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %65, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %66
+
+; <label>:66                                      ; preds = %64
+  %67 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %65, i32 0, i32 1
+  %68 = load i32, i32 addrspace(1)* %67
+  %69 = zext i32 %68 to i64
+  %70 = trunc i64 %69 to i32
+  %71 = icmp ne i32 %70, 0
+  br i1 %71, label %73, label %72
+
+; <label>:72                                      ; preds = %59, %66
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  br label %81
+
+; <label>:73                                      ; preds = %66
+  %74 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc2
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %74, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %75
+
+; <label>:75                                      ; preds = %73
+  %76 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %74, i32 0, i32 1
+  %77 = load i32, i32 addrspace(1)* %76
+  %78 = zext i32 %77 to i64
+  %BoundsCheck = icmp uge i64 0, %78
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %79
+
+; <label>:79                                      ; preds = %75
+  %80 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %74, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %80, i16 addrspace(1)** %loc1
+  br label %81
+
+; <label>:81                                      ; preds = %72, %79
+  %82 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %83 = ptrtoint i16 addrspace(1)* %82 to i64
+  %84 = load i32, i32* %arg3
+  %85 = sext i32 %84 to i64
+  %86 = mul i64 %85, 2
+  %87 = add i64 %83, %86
+  %88 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %89 = ptrtoint i16 addrspace(1)* %88 to i64
+  %90 = load i32, i32* %arg1
+  %91 = sext i32 %90 to i64
+  %92 = mul i64 %91, 2
+  %93 = add i64 %89, %92
+  %94 = load i32, i32* %arg4
+  %95 = inttoptr i64 %87 to i16*
+  %96 = inttoptr i64 %93 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %95, i16* %96, i32 %94)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  br label %97
+
+; <label>:97                                      ; preds = %54, %81
+  ret void
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
 Successfully read ConsoleEncoding.GetPreamble
 
@@ -14827,7 +16746,365 @@ entry:
 }
 
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[loadElemA]
+Successfully read EncoderNLS.GetBytes
+
+define i32 @EncoderNLS.GetBytes(%System.Text.EncoderNLS addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3, %"System.Byte[]" addrspace(1)* %param4, i32 %param5, i8 %param6) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %arg4 = alloca %"System.Byte[]" addrspace(1)*
+  %arg5 = alloca i32
+  %arg6 = alloca i8
+  %loc0 = alloca i32
+  %loc1 = alloca i16 addrspace(1)*
+  %loc2 = alloca i8 addrspace(1)*
+  %loc3 = alloca i32
+  %loc4 = alloca %"System.Char[]" addrspace(1)*
+  %loc5 = alloca %"System.Byte[]" addrspace(1)*
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  store %"System.Byte[]" addrspace(1)* %param4, %"System.Byte[]" addrspace(1)** %arg4
+  store i32 %param5, i32* %arg5
+  store i8 %param6, i8* %arg6
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %1 = icmp eq %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %17, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %7 = icmp eq %"System.Char[]" addrspace(1)* %6, null
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %12
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %12
+
+; <label>:12                                      ; preds = %8, %10
+  %13 = phi %System.String addrspace(1)* [ %9, %8 ], [ %11, %10 ]
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %14)
+  %16 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16, %System.String addrspace(1)* %13, %System.String addrspace(1)* %15)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16) #0
+  unreachable
+
+; <label>:17                                      ; preds = %2
+  %18 = load i32, i32* %arg2
+  %19 = icmp slt i32 %18, 0
+  br i1 %19, label %23, label %20
+
+; <label>:20                                      ; preds = %17
+  %21 = load i32, i32* %arg3
+  %22 = icmp sge i32 %21, 0
+  br i1 %22, label %35, label %23
+
+; <label>:23                                      ; preds = %17, %20
+  %24 = load i32, i32* %arg2
+  %25 = icmp slt i32 %24, 0
+  br i1 %25, label %28, label %26
+
+; <label>:26                                      ; preds = %23
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %30
+
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %30
+
+; <label>:30                                      ; preds = %26, %28
+  %31 = phi %System.String addrspace(1)* [ %27, %26 ], [ %29, %28 ]
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34, %System.String addrspace(1)* %31, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %20
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck, label %ThrowNullRef, label %37
+
+; <label>:37                                      ; preds = %35
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = load i32, i32* %arg2
+  %43 = sub i32 %41, %42
+  %44 = load i32, i32* %arg3
+  %45 = icmp sge i32 %43, %44
+  br i1 %45, label %51, label %46
+
+; <label>:46                                      ; preds = %37
+  %47 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %48 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %49 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %48)
+  %50 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %50, %System.String addrspace(1)* %47, %System.String addrspace(1)* %49)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %50) #0
+  unreachable
+
+; <label>:51                                      ; preds = %37
+  %52 = load i32, i32* %arg5
+  %53 = icmp slt i32 %52, 0
+  br i1 %53, label %63, label %54
+
+; <label>:54                                      ; preds = %51
+  %55 = load i32, i32* %arg5
+  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck1 = icmp eq %"System.Byte[]" addrspace(1)* %56, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %57
+
+; <label>:57                                      ; preds = %54
+  %58 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = zext i32 %59 to i64
+  %61 = trunc i64 %60 to i32
+  %62 = icmp sle i32 %55, %61
+  br i1 %62, label %68, label %63
+
+; <label>:63                                      ; preds = %51, %57
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %66 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %65)
+  %67 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %67, %System.String addrspace(1)* %64, %System.String addrspace(1)* %66)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %67) #0
+  unreachable
+
+; <label>:68                                      ; preds = %57
+  %69 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %69, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %69, i32 0, i32 1
+  %72 = load i32, i32 addrspace(1)* %71
+  %73 = zext i32 %72 to i64
+  %74 = trunc i64 %73 to i32
+  %75 = icmp ne i32 %74, 0
+  br i1 %75, label %78, label %76
+
+; <label>:76                                      ; preds = %70
+  %77 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1)
+  store %"System.Char[]" addrspace(1)* %77, %"System.Char[]" addrspace(1)** %arg1
+  br label %78
+
+; <label>:78                                      ; preds = %70, %76
+  %79 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck5 = icmp eq %"System.Byte[]" addrspace(1)* %79, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %80
+
+; <label>:80                                      ; preds = %78
+  %81 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %79, i32 0, i32 1
+  %82 = load i32, i32 addrspace(1)* %81
+  %83 = zext i32 %82 to i64
+  %84 = trunc i64 %83 to i32
+  %85 = load i32, i32* %arg5
+  %86 = sub i32 %84, %85
+  store i32 %86, i32* %loc0
+  %87 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck7 = icmp eq %"System.Byte[]" addrspace(1)* %87, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %88
+
+; <label>:88                                      ; preds = %80
+  %89 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %87, i32 0, i32 1
+  %90 = load i32, i32 addrspace(1)* %89
+  %91 = zext i32 %90 to i64
+  %92 = trunc i64 %91 to i32
+  %93 = icmp ne i32 %92, 0
+  br i1 %93, label %96, label %94
+
+; <label>:94                                      ; preds = %88
+  %95 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1)
+  store %"System.Byte[]" addrspace(1)* %95, %"System.Byte[]" addrspace(1)** %arg4
+  br label %96
+
+; <label>:96                                      ; preds = %88, %94
+  %97 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  store %"System.Char[]" addrspace(1)* %97, %"System.Char[]" addrspace(1)** %loc4
+  %98 = icmp eq %"System.Char[]" addrspace(1)* %97, null
+  br i1 %98, label %107, label %99
+
+; <label>:99                                      ; preds = %96
+  %100 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc4
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %100, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %101
+
+; <label>:101                                     ; preds = %99
+  %102 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %100, i32 0, i32 1
+  %103 = load i32, i32 addrspace(1)* %102
+  %104 = zext i32 %103 to i64
+  %105 = trunc i64 %104 to i32
+  %106 = icmp ne i32 %105, 0
+  br i1 %106, label %108, label %107
+
+; <label>:107                                     ; preds = %96, %101
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  br label %116
+
+; <label>:108                                     ; preds = %101
+  %109 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc4
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %109, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %110
+
+; <label>:110                                     ; preds = %108
+  %111 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %109, i32 0, i32 1
+  %112 = load i32, i32 addrspace(1)* %111
+  %113 = zext i32 %112 to i64
+  %BoundsCheck = icmp uge i64 0, %113
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %114
+
+; <label>:114                                     ; preds = %110
+  %115 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %109, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %115, i16 addrspace(1)** %loc1
+  br label %116
+
+; <label>:116                                     ; preds = %107, %114
+  %117 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  store %"System.Byte[]" addrspace(1)* %117, %"System.Byte[]" addrspace(1)** %loc5
+  %118 = icmp eq %"System.Byte[]" addrspace(1)* %117, null
+  br i1 %118, label %127, label %119
+
+; <label>:119                                     ; preds = %116
+  %120 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc5
+  %NullCheck13 = icmp eq %"System.Byte[]" addrspace(1)* %120, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %121
+
+; <label>:121                                     ; preds = %119
+  %122 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %120, i32 0, i32 1
+  %123 = load i32, i32 addrspace(1)* %122
+  %124 = zext i32 %123 to i64
+  %125 = trunc i64 %124 to i32
+  %126 = icmp ne i32 %125, 0
+  br i1 %126, label %128, label %127
+
+; <label>:127                                     ; preds = %116, %121
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc2
+  br label %136
+
+; <label>:128                                     ; preds = %121
+  %129 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc5
+  %NullCheck15 = icmp eq %"System.Byte[]" addrspace(1)* %129, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %130
+
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %129, i32 0, i32 1
+  %132 = load i32, i32 addrspace(1)* %131
+  %133 = zext i32 %132 to i64
+  %BoundsCheck17 = icmp uge i64 0, %133
+  br i1 %BoundsCheck17, label %ThrowIndexOutOfRange18, label %134
+
+; <label>:134                                     ; preds = %130
+  %135 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %129, i32 0, i32 3, i32 0
+  store i8 addrspace(1)* %135, i8 addrspace(1)** %loc2
+  br label %136
+
+; <label>:136                                     ; preds = %127, %134
+  %137 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %138 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %139 = ptrtoint i16 addrspace(1)* %138 to i64
+  %140 = load i32, i32* %arg2
+  %141 = sext i32 %140 to i64
+  %142 = mul i64 %141, 2
+  %143 = add i64 %139, %142
+  %144 = load i32, i32* %arg3
+  %145 = load i8 addrspace(1)*, i8 addrspace(1)** %loc2
+  %146 = ptrtoint i8 addrspace(1)* %145 to i64
+  %147 = load i32, i32* %arg5
+  %148 = sext i32 %147 to i64
+  %149 = add i64 %146, %148
+  %150 = load i32, i32* %loc0
+  %151 = load i8, i8* %arg6
+  %152 = zext i8 %151 to i32
+  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i64 addrspace(1)*
+  %NullCheck19 = icmp eq i64 addrspace(1)* %153, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %154
+
+; <label>:154                                     ; preds = %136
+  %155 = load i64, i64 addrspace(1)* %153
+  %156 = add i64 %155, 72
+  %157 = inttoptr i64 %156 to i64*
+  %158 = load i64, i64* %157
+  %159 = add i64 %158, 0
+  %160 = inttoptr i64 %159 to i64*
+  %161 = load i64, i64* %160
+  %162 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to %System.Text.Encoder addrspace(1)*
+  %163 = inttoptr i64 %143 to i16*
+  %164 = inttoptr i64 %149 to i8*
+  %165 = trunc i32 %152 to i8
+  %166 = inttoptr i64 %161 to i32 (%System.Text.Encoder addrspace(1)*, i16*, i32, i8*, i32, i8)*
+  %167 = call i32 %166(%System.Text.Encoder addrspace(1)* %162, i16* %163, i32 %144, i8* %164, i32 %150, i8 %165)
+  store i32 %167, i32* %loc3
+  br label %168
+
+; <label>:168                                     ; preds = %154
+  %169 = load i32, i32* %loc3
+  ret i32 %169
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %110
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %119
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange18:                           ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
 Successfully read EncoderNLS.GetBytes
 
@@ -14916,22 +17193,22 @@ entry:
   %40 = load i8, i8* %arg5
   %41 = zext i8 %40 to i32
   %42 = trunc i32 %41 to i8
-  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %39, null
-  br i1 %NullCheck, label %43, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderNLS addrspace(1)* %39, null
+  br i1 %NullCheck, label %ThrowNullRef, label %43
 
 ; <label>:43                                      ; preds = %38
   %44 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
   store i8 %42, i8 addrspace(1)* %44
   %45 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %45, null
-  br i1 %NullCheck2, label %46, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.EncoderNLS addrspace(1)* %45, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %46
 
 ; <label>:46                                      ; preds = %43
   %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %45, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %47
   %48 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.EncoderNLS addrspace(1)* %48, null
-  br i1 %NullCheck4, label %49, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.EncoderNLS addrspace(1)* %48, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %49
 
 ; <label>:49                                      ; preds = %46
   %50 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %48, i32 0, i32 3
@@ -14942,8 +17219,8 @@ entry:
   %55 = load i32, i32* %arg4
   %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck6, label %58, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
   %59 = load i64, i64 addrspace(1)* %57
@@ -14961,15 +17238,15 @@ ThrowNullRef:                                     ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %43
+ThrowNullRef2:                                    ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %46
+ThrowNullRef4:                                    ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %49
+ThrowNullRef6:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14997,8 +17274,8 @@ entry:
   %4 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0 to %System.IO.ConsoleStream addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*)(%System.IO.ConsoleStream addrspace(1)* %4, %"System.Byte[]" addrspace(1)* %1, i32 %2, i32 %3)
   %5 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
@@ -15083,8 +17360,8 @@ entry:
 
 ; <label>:22                                      ; preds = %8
   %23 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %23, null
-  br i1 %NullCheck, label %24, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Byte[]" addrspace(1)* %23, null
+  br i1 %NullCheck, label %ThrowNullRef, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
@@ -15106,8 +17383,8 @@ entry:
 
 ; <label>:36                                      ; preds = %24
   %37 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %37, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.ConsoleStream addrspace(1)* %37, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %37, i32 0, i32 4
@@ -15128,13 +17405,138 @@ ThrowNullRef:                                     ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %36
+ThrowNullRef2:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
-Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
+Successfully read WindowsConsoleStream.WriteFileNative
+
+define i32 @WindowsConsoleStream.WriteFileNative(i64 %param0, %"System.Byte[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i64
+  %arg1 = alloca %"System.Byte[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i8 addrspace(1)*
+  %loc2 = alloca %"System.Byte[]" addrspace(1)*
+  %loc3 = alloca i32
+  store i64 %param0, i64* %arg0
+  store %"System.Byte[]" addrspace(1)* %param1, %"System.Byte[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Byte[]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = zext i32 %3 to i64
+  %5 = icmp ne i64 %4, 0
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %1
+  ret i32 0
+
+; <label>:7                                       ; preds = %1
+  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  store %"System.Byte[]" addrspace(1)* %8, %"System.Byte[]" addrspace(1)** %loc2
+  %9 = icmp eq %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %9, label %18, label %10
+
+; <label>:10                                      ; preds = %7
+  %11 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc2
+  %NullCheck1 = icmp eq %"System.Byte[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %11, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp ne i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %7, %12
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc1
+  br label %27
+
+; <label>:19                                      ; preds = %12
+  %20 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc2
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %20, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %BoundsCheck = icmp uge i64 0, %24
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %25
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %20, i32 0, i32 3, i32 0
+  store i8 addrspace(1)* %26, i8 addrspace(1)** %loc1
+  br label %27
+
+; <label>:27                                      ; preds = %18, %25
+  %28 = load i64, i64* %arg0
+  %29 = load i8 addrspace(1)*, i8 addrspace(1)** %loc1
+  %30 = ptrtoint i8 addrspace(1)* %29 to i64
+  %31 = load i32, i32* %arg2
+  %32 = sext i32 %31 to i64
+  %33 = add i64 %30, %32
+  %34 = load i32, i32* %arg3
+  %35 = addrspacecast i32* %loc3 to i32 addrspace(1)*
+  %36 = inttoptr i64 %33 to i8*
+  %37 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i8*, i32, i32 addrspace(1)*, i64)*)(i64 %28, i8* %36, i32 %34, i32 addrspace(1)* %35, i64 0)
+  %38 = icmp ugt i32 %37, 0
+  %39 = sext i1 %38 to i32
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc1
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %42, label %41
+
+; <label>:41                                      ; preds = %27
+  ret i32 0
+
+; <label>:42                                      ; preds = %27
+  %43 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  store i32 %43, i32* %loc0
+  %44 = load i32, i32* %loc0
+  %45 = icmp eq i32 %44, 232
+  br i1 %45, label %49, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = load i32, i32* %loc0
+  %48 = icmp ne i32 %47, 109
+  br i1 %48, label %50, label %49
+
+; <label>:49                                      ; preds = %42, %46
+  ret i32 0
+
+; <label>:50                                      ; preds = %46
+  %51 = load i32, i32* %loc0
+  ret i32 %51
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
 Successfully read WindowsConsoleStream.Flush
 
@@ -15143,8 +17545,8 @@ entry:
   %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
   store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
@@ -15179,8 +17581,8 @@ entry:
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
   %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load i64, i64 addrspace(1)* %1
@@ -15219,15 +17621,15 @@ entry:
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.TextWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
   %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %3, align 8
   %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
   %7 = load i64, i64 addrspace(1)* %5
@@ -15245,7 +17647,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -15274,8 +17676,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %4)
   store i32 0, i32* %loc0
   %5 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Char[]" addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
@@ -15287,15 +17689,15 @@ entry:
 
 ; <label>:11                                      ; preds = %69
   %12 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %12, i32 0, i32 9
   %15 = load i32, i32 addrspace(1)* %14, align 8
   %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.IO.StreamWriter addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %16, i32 0, i32 10
@@ -15310,15 +17712,15 @@ entry:
 
 ; <label>:23                                      ; preds = %17, %21
   %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %24, null
-  br i1 %NullCheck8, label %25, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %24, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 10
   %27 = load i32, i32 addrspace(1)* %26, align 8
   %28 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %28, null
-  br i1 %NullCheck10, label %29, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.StreamWriter addrspace(1)* %28, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %28, i32 0, i32 9
@@ -15340,15 +17742,15 @@ entry:
   %40 = load i32, i32* %loc0
   %41 = mul i32 %40, 2
   %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
-  br i1 %NullCheck12, label %43, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %43
 
 ; <label>:43                                      ; preds = %38
   %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 7
   %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %44, align 8
   %46 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %46, null
-  br i1 %NullCheck14, label %47, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.IO.StreamWriter addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %47
 
 ; <label>:47                                      ; preds = %43
   %48 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %46, i32 0, i32 9
@@ -15360,16 +17762,16 @@ entry:
   %54 = bitcast %"System.Char[]" addrspace(1)* %45 to %System.Array addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %53, i32 %41, %System.Array addrspace(1)* %54, i32 %50, i32 %52)
   %55 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
-  br i1 %NullCheck16, label %56, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %56
 
 ; <label>:56                                      ; preds = %47
   %57 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
   %58 = load i32, i32 addrspace(1)* %57, align 8
   %59 = load i32, i32* %loc2
   %60 = add i32 %58, %59
-  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
-  br i1 %NullCheck18, label %61, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %61
 
 ; <label>:61                                      ; preds = %56
   %62 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
@@ -15391,8 +17793,8 @@ entry:
 
 ; <label>:72                                      ; preds = %69
   %73 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %73, null
-  br i1 %NullCheck2, label %74, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %73, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %74
 
 ; <label>:74                                      ; preds = %72
   %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %73, i32 0, i32 11
@@ -15413,39 +17815,39 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %72
+ThrowNullRef2:                                    ; preds = %72
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %23
+ThrowNullRef8:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef10:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %43
+ThrowNullRef14:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %47
+ThrowNullRef16:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %56
+ThrowNullRef18:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPError.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPError.error.txt
@@ -25,8 +25,8 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
@@ -40,8 +40,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
   %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
@@ -75,7 +75,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -90,8 +90,8 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %NullCheck = icmp ne i8 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = load i8, i8 addrspace(1)* %0, align 8
@@ -125,8 +125,8 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
@@ -159,8 +159,8 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -184,8 +184,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
   store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
@@ -195,8 +195,8 @@ entry:
 ; <label>:4                                       ; preds = %1
   %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
   %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
@@ -206,8 +206,8 @@ entry:
   %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
@@ -221,14 +221,14 @@ entry:
 
 ; <label>:17                                      ; preds = %14
   %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
   %21 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
@@ -238,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -249,8 +249,8 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
@@ -261,27 +261,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %30
+ThrowNullRef10:                                   ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -301,7 +301,89 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
-Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
+Successfully read AppDomainSetup.GetUnsecureApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.GetUnsecureApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %NullCheck = icmp eq %"System.String[]" addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %BoundsCheck = icmp uge i64 0, %5
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %6
+
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 3, i32 0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
+  ret %System.String addrspace(1)* %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_Value using LLILCJit
+Successfully read AppDomainSetup.get_Value
+
+define %"System.String[]" addrspace(1)* @AppDomainSetup.get_Value(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.String[]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 18)
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.String[]" addrspace(1)* addrspace(1)*, %"System.String[]" addrspace(1)*)*)(%"System.String[]" addrspace(1)* addrspace(1)* %9, %"System.String[]" addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %11, i32 0, i32 1
+  %14 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %13, align 8
+  ret %"System.String[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -319,8 +401,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -368,16 +450,16 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
   %5 = load i32, i32 addrspace(1)* %4
   %6 = sub i32 %5, 1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -389,7 +471,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -421,8 +503,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
@@ -456,8 +538,8 @@ entry:
 ; <label>:27                                      ; preds = %19
   %28 = load i32, i32* %arg1
   %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
-  br i1 %NullCheck2, label %30, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %29, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %30
 
 ; <label>:30                                      ; preds = %27
   %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
@@ -493,8 +575,8 @@ entry:
 ; <label>:49                                      ; preds = %46
   %50 = load i32, i32* %arg2
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck4, label %52, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
@@ -517,11 +599,11 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %27
+ThrowNullRef2:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %49
+ThrowNullRef4:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -544,16 +626,16 @@ entry:
   %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %0)
   store %System.String addrspace(1)* %1, %System.String addrspace(1)** %loc0
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 2
   %5 = bitcast [0 x i16] addrspace(1)* %4 to i16 addrspace(1)*
   store i16 addrspace(1)* %5, i16 addrspace(1)** %loc1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %3
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2
@@ -580,7 +662,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -691,15 +773,15 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %NullCheck132 = icmp ne i8* %21, null
-  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+  %NullCheck131 = icmp eq i8* %21, null
+  br i1 %NullCheck131, label %ThrowNullRef132, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = load i8, i8* %21, align 8
   %24 = zext i8 %23 to i32
   %25 = trunc i32 %24 to i8
-  %NullCheck134 = icmp ne i8* %20, null
-  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+  %NullCheck133 = icmp eq i8* %20, null
+  br i1 %NullCheck133, label %ThrowNullRef134, label %26
 
 ; <label>:26                                      ; preds = %22
   store i8 %25, i8* %20, align 8
@@ -709,16 +791,16 @@ entry:
   %28 = load i8*, i8** %arg0
   %29 = load i8*, i8** %arg1
   %30 = bitcast i8* %29 to i16*
-  %NullCheck128 = icmp ne i16* %30, null
-  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+  %NullCheck127 = icmp eq i16* %30, null
+  br i1 %NullCheck127, label %ThrowNullRef128, label %31
 
 ; <label>:31                                      ; preds = %27
   %32 = load i16, i16* %30, align 8
   %33 = sext i16 %32 to i32
   %34 = bitcast i8* %28 to i16*
   %35 = trunc i32 %33 to i16
-  %NullCheck130 = icmp ne i16* %34, null
-  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+  %NullCheck129 = icmp eq i16* %34, null
+  br i1 %NullCheck129, label %ThrowNullRef130, label %36
 
 ; <label>:36                                      ; preds = %31
   store i16 %35, i16* %34, align 8
@@ -728,16 +810,16 @@ entry:
   %38 = load i8*, i8** %arg0
   %39 = load i8*, i8** %arg1
   %40 = bitcast i8* %39 to i16*
-  %NullCheck120 = icmp ne i16* %40, null
-  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+  %NullCheck119 = icmp eq i16* %40, null
+  br i1 %NullCheck119, label %ThrowNullRef120, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i16, i16* %40, align 8
   %43 = sext i16 %42 to i32
   %44 = bitcast i8* %38 to i16*
   %45 = trunc i32 %43 to i16
-  %NullCheck122 = icmp ne i16* %44, null
-  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+  %NullCheck121 = icmp eq i16* %44, null
+  br i1 %NullCheck121, label %ThrowNullRef122, label %46
 
 ; <label>:46                                      ; preds = %41
   store i16 %45, i16* %44, align 8
@@ -745,15 +827,15 @@ entry:
   %48 = getelementptr inbounds i8, i8* %47, i64 2
   %49 = load i8*, i8** %arg1
   %50 = getelementptr inbounds i8, i8* %49, i64 2
-  %NullCheck124 = icmp ne i8* %50, null
-  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+  %NullCheck123 = icmp eq i8* %50, null
+  br i1 %NullCheck123, label %ThrowNullRef124, label %51
 
 ; <label>:51                                      ; preds = %46
   %52 = load i8, i8* %50, align 8
   %53 = zext i8 %52 to i32
   %54 = trunc i32 %53 to i8
-  %NullCheck126 = icmp ne i8* %48, null
-  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+  %NullCheck125 = icmp eq i8* %48, null
+  br i1 %NullCheck125, label %ThrowNullRef126, label %55
 
 ; <label>:55                                      ; preds = %51
   store i8 %54, i8* %48, align 8
@@ -763,14 +845,14 @@ entry:
   %57 = load i8*, i8** %arg0
   %58 = load i8*, i8** %arg1
   %59 = bitcast i8* %58 to i32*
-  %NullCheck116 = icmp ne i32* %59, null
-  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+  %NullCheck115 = icmp eq i32* %59, null
+  br i1 %NullCheck115, label %ThrowNullRef116, label %60
 
 ; <label>:60                                      ; preds = %56
   %61 = load i32, i32* %59, align 8
   %62 = bitcast i8* %57 to i32*
-  %NullCheck118 = icmp ne i32* %62, null
-  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+  %NullCheck117 = icmp eq i32* %62, null
+  br i1 %NullCheck117, label %ThrowNullRef118, label %63
 
 ; <label>:63                                      ; preds = %60
   store i32 %61, i32* %62, align 8
@@ -780,14 +862,14 @@ entry:
   %65 = load i8*, i8** %arg0
   %66 = load i8*, i8** %arg1
   %67 = bitcast i8* %66 to i32*
-  %NullCheck108 = icmp ne i32* %67, null
-  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+  %NullCheck107 = icmp eq i32* %67, null
+  br i1 %NullCheck107, label %ThrowNullRef108, label %68
 
 ; <label>:68                                      ; preds = %64
   %69 = load i32, i32* %67, align 8
   %70 = bitcast i8* %65 to i32*
-  %NullCheck110 = icmp ne i32* %70, null
-  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+  %NullCheck109 = icmp eq i32* %70, null
+  br i1 %NullCheck109, label %ThrowNullRef110, label %71
 
 ; <label>:71                                      ; preds = %68
   store i32 %69, i32* %70, align 8
@@ -795,15 +877,15 @@ entry:
   %73 = getelementptr inbounds i8, i8* %72, i64 4
   %74 = load i8*, i8** %arg1
   %75 = getelementptr inbounds i8, i8* %74, i64 4
-  %NullCheck112 = icmp ne i8* %75, null
-  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+  %NullCheck111 = icmp eq i8* %75, null
+  br i1 %NullCheck111, label %ThrowNullRef112, label %76
 
 ; <label>:76                                      ; preds = %71
   %77 = load i8, i8* %75, align 8
   %78 = zext i8 %77 to i32
   %79 = trunc i32 %78 to i8
-  %NullCheck114 = icmp ne i8* %73, null
-  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+  %NullCheck113 = icmp eq i8* %73, null
+  br i1 %NullCheck113, label %ThrowNullRef114, label %80
 
 ; <label>:80                                      ; preds = %76
   store i8 %79, i8* %73, align 8
@@ -813,14 +895,14 @@ entry:
   %82 = load i8*, i8** %arg0
   %83 = load i8*, i8** %arg1
   %84 = bitcast i8* %83 to i32*
-  %NullCheck100 = icmp ne i32* %84, null
-  br i1 %NullCheck100, label %85, label %ThrowNullRef99
+  %NullCheck99 = icmp eq i32* %84, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %85
 
 ; <label>:85                                      ; preds = %81
   %86 = load i32, i32* %84, align 8
   %87 = bitcast i8* %82 to i32*
-  %NullCheck102 = icmp ne i32* %87, null
-  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+  %NullCheck101 = icmp eq i32* %87, null
+  br i1 %NullCheck101, label %ThrowNullRef102, label %88
 
 ; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
@@ -829,16 +911,16 @@ entry:
   %91 = load i8*, i8** %arg1
   %92 = getelementptr inbounds i8, i8* %91, i64 4
   %93 = bitcast i8* %92 to i16*
-  %NullCheck104 = icmp ne i16* %93, null
-  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+  %NullCheck103 = icmp eq i16* %93, null
+  br i1 %NullCheck103, label %ThrowNullRef104, label %94
 
 ; <label>:94                                      ; preds = %88
   %95 = load i16, i16* %93, align 8
   %96 = sext i16 %95 to i32
   %97 = bitcast i8* %90 to i16*
   %98 = trunc i32 %96 to i16
-  %NullCheck106 = icmp ne i16* %97, null
-  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+  %NullCheck105 = icmp eq i16* %97, null
+  br i1 %NullCheck105, label %ThrowNullRef106, label %99
 
 ; <label>:99                                      ; preds = %94
   store i16 %98, i16* %97, align 8
@@ -848,14 +930,14 @@ entry:
   %101 = load i8*, i8** %arg0
   %102 = load i8*, i8** %arg1
   %103 = bitcast i8* %102 to i32*
-  %NullCheck88 = icmp ne i32* %103, null
-  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+  %NullCheck87 = icmp eq i32* %103, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %104
 
 ; <label>:104                                     ; preds = %100
   %105 = load i32, i32* %103, align 8
   %106 = bitcast i8* %101 to i32*
-  %NullCheck90 = icmp ne i32* %106, null
-  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+  %NullCheck89 = icmp eq i32* %106, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %107
 
 ; <label>:107                                     ; preds = %104
   store i32 %105, i32* %106, align 8
@@ -864,16 +946,16 @@ entry:
   %110 = load i8*, i8** %arg1
   %111 = getelementptr inbounds i8, i8* %110, i64 4
   %112 = bitcast i8* %111 to i16*
-  %NullCheck92 = icmp ne i16* %112, null
-  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+  %NullCheck91 = icmp eq i16* %112, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %113
 
 ; <label>:113                                     ; preds = %107
   %114 = load i16, i16* %112, align 8
   %115 = sext i16 %114 to i32
   %116 = bitcast i8* %109 to i16*
   %117 = trunc i32 %115 to i16
-  %NullCheck94 = icmp ne i16* %116, null
-  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+  %NullCheck93 = icmp eq i16* %116, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %118
 
 ; <label>:118                                     ; preds = %113
   store i16 %117, i16* %116, align 8
@@ -881,15 +963,15 @@ entry:
   %120 = getelementptr inbounds i8, i8* %119, i64 6
   %121 = load i8*, i8** %arg1
   %122 = getelementptr inbounds i8, i8* %121, i64 6
-  %NullCheck96 = icmp ne i8* %122, null
-  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+  %NullCheck95 = icmp eq i8* %122, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %123
 
 ; <label>:123                                     ; preds = %118
   %124 = load i8, i8* %122, align 8
   %125 = zext i8 %124 to i32
   %126 = trunc i32 %125 to i8
-  %NullCheck98 = icmp ne i8* %120, null
-  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+  %NullCheck97 = icmp eq i8* %120, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %127
 
 ; <label>:127                                     ; preds = %123
   store i8 %126, i8* %120, align 8
@@ -899,14 +981,14 @@ entry:
   %129 = load i8*, i8** %arg0
   %130 = load i8*, i8** %arg1
   %131 = bitcast i8* %130 to i64*
-  %NullCheck84 = icmp ne i64* %131, null
-  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+  %NullCheck83 = icmp eq i64* %131, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %132
 
 ; <label>:132                                     ; preds = %128
   %133 = load i64, i64* %131, align 8
   %134 = bitcast i8* %129 to i64*
-  %NullCheck86 = icmp ne i64* %134, null
-  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+  %NullCheck85 = icmp eq i64* %134, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %135
 
 ; <label>:135                                     ; preds = %132
   store i64 %133, i64* %134, align 8
@@ -916,14 +998,14 @@ entry:
   %137 = load i8*, i8** %arg0
   %138 = load i8*, i8** %arg1
   %139 = bitcast i8* %138 to i64*
-  %NullCheck76 = icmp ne i64* %139, null
-  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+  %NullCheck75 = icmp eq i64* %139, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %140
 
 ; <label>:140                                     ; preds = %136
   %141 = load i64, i64* %139, align 8
   %142 = bitcast i8* %137 to i64*
-  %NullCheck78 = icmp ne i64* %142, null
-  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+  %NullCheck77 = icmp eq i64* %142, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %143
 
 ; <label>:143                                     ; preds = %140
   store i64 %141, i64* %142, align 8
@@ -931,15 +1013,15 @@ entry:
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %NullCheck80 = icmp ne i8* %147, null
-  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+  %NullCheck79 = icmp eq i8* %147, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %148
 
 ; <label>:148                                     ; preds = %143
   %149 = load i8, i8* %147, align 8
   %150 = zext i8 %149 to i32
   %151 = trunc i32 %150 to i8
-  %NullCheck82 = icmp ne i8* %145, null
-  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+  %NullCheck81 = icmp eq i8* %145, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %152
 
 ; <label>:152                                     ; preds = %148
   store i8 %151, i8* %145, align 8
@@ -949,14 +1031,14 @@ entry:
   %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
   %156 = bitcast i8* %155 to i64*
-  %NullCheck68 = icmp ne i64* %156, null
-  br i1 %NullCheck68, label %157, label %ThrowNullRef67
+  %NullCheck67 = icmp eq i64* %156, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %157
 
 ; <label>:157                                     ; preds = %153
   %158 = load i64, i64* %156, align 8
   %159 = bitcast i8* %154 to i64*
-  %NullCheck70 = icmp ne i64* %159, null
-  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+  %NullCheck69 = icmp eq i64* %159, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %160
 
 ; <label>:160                                     ; preds = %157
   store i64 %158, i64* %159, align 8
@@ -965,16 +1047,16 @@ entry:
   %163 = load i8*, i8** %arg1
   %164 = getelementptr inbounds i8, i8* %163, i64 8
   %165 = bitcast i8* %164 to i16*
-  %NullCheck72 = icmp ne i16* %165, null
-  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+  %NullCheck71 = icmp eq i16* %165, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %166
 
 ; <label>:166                                     ; preds = %160
   %167 = load i16, i16* %165, align 8
   %168 = sext i16 %167 to i32
   %169 = bitcast i8* %162 to i16*
   %170 = trunc i32 %168 to i16
-  %NullCheck74 = icmp ne i16* %169, null
-  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+  %NullCheck73 = icmp eq i16* %169, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %171
 
 ; <label>:171                                     ; preds = %166
   store i16 %170, i16* %169, align 8
@@ -984,14 +1066,14 @@ entry:
   %173 = load i8*, i8** %arg0
   %174 = load i8*, i8** %arg1
   %175 = bitcast i8* %174 to i64*
-  %NullCheck56 = icmp ne i64* %175, null
-  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+  %NullCheck55 = icmp eq i64* %175, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %176
 
 ; <label>:176                                     ; preds = %172
   %177 = load i64, i64* %175, align 8
   %178 = bitcast i8* %173 to i64*
-  %NullCheck58 = icmp ne i64* %178, null
-  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+  %NullCheck57 = icmp eq i64* %178, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %179
 
 ; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
@@ -1000,16 +1082,16 @@ entry:
   %182 = load i8*, i8** %arg1
   %183 = getelementptr inbounds i8, i8* %182, i64 8
   %184 = bitcast i8* %183 to i16*
-  %NullCheck60 = icmp ne i16* %184, null
-  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+  %NullCheck59 = icmp eq i16* %184, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %185
 
 ; <label>:185                                     ; preds = %179
   %186 = load i16, i16* %184, align 8
   %187 = sext i16 %186 to i32
   %188 = bitcast i8* %181 to i16*
   %189 = trunc i32 %187 to i16
-  %NullCheck62 = icmp ne i16* %188, null
-  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+  %NullCheck61 = icmp eq i16* %188, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %190
 
 ; <label>:190                                     ; preds = %185
   store i16 %189, i16* %188, align 8
@@ -1017,15 +1099,15 @@ entry:
   %192 = getelementptr inbounds i8, i8* %191, i64 10
   %193 = load i8*, i8** %arg1
   %194 = getelementptr inbounds i8, i8* %193, i64 10
-  %NullCheck64 = icmp ne i8* %194, null
-  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+  %NullCheck63 = icmp eq i8* %194, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %195
 
 ; <label>:195                                     ; preds = %190
   %196 = load i8, i8* %194, align 8
   %197 = zext i8 %196 to i32
   %198 = trunc i32 %197 to i8
-  %NullCheck66 = icmp ne i8* %192, null
-  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+  %NullCheck65 = icmp eq i8* %192, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %199
 
 ; <label>:199                                     ; preds = %195
   store i8 %198, i8* %192, align 8
@@ -1035,14 +1117,14 @@ entry:
   %201 = load i8*, i8** %arg0
   %202 = load i8*, i8** %arg1
   %203 = bitcast i8* %202 to i64*
-  %NullCheck48 = icmp ne i64* %203, null
-  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+  %NullCheck47 = icmp eq i64* %203, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %204
 
 ; <label>:204                                     ; preds = %200
   %205 = load i64, i64* %203, align 8
   %206 = bitcast i8* %201 to i64*
-  %NullCheck50 = icmp ne i64* %206, null
-  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+  %NullCheck49 = icmp eq i64* %206, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %207
 
 ; <label>:207                                     ; preds = %204
   store i64 %205, i64* %206, align 8
@@ -1051,14 +1133,14 @@ entry:
   %210 = load i8*, i8** %arg1
   %211 = getelementptr inbounds i8, i8* %210, i64 8
   %212 = bitcast i8* %211 to i32*
-  %NullCheck52 = icmp ne i32* %212, null
-  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+  %NullCheck51 = icmp eq i32* %212, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %213
 
 ; <label>:213                                     ; preds = %207
   %214 = load i32, i32* %212, align 8
   %215 = bitcast i8* %209 to i32*
-  %NullCheck54 = icmp ne i32* %215, null
-  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+  %NullCheck53 = icmp eq i32* %215, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %216
 
 ; <label>:216                                     ; preds = %213
   store i32 %214, i32* %215, align 8
@@ -1068,14 +1150,14 @@ entry:
   %218 = load i8*, i8** %arg0
   %219 = load i8*, i8** %arg1
   %220 = bitcast i8* %219 to i64*
-  %NullCheck36 = icmp ne i64* %220, null
-  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64* %220, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %221
 
 ; <label>:221                                     ; preds = %217
   %222 = load i64, i64* %220, align 8
   %223 = bitcast i8* %218 to i64*
-  %NullCheck38 = icmp ne i64* %223, null
-  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+  %NullCheck37 = icmp eq i64* %223, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %224
 
 ; <label>:224                                     ; preds = %221
   store i64 %222, i64* %223, align 8
@@ -1084,14 +1166,14 @@ entry:
   %227 = load i8*, i8** %arg1
   %228 = getelementptr inbounds i8, i8* %227, i64 8
   %229 = bitcast i8* %228 to i32*
-  %NullCheck40 = icmp ne i32* %229, null
-  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i32* %229, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %230
 
 ; <label>:230                                     ; preds = %224
   %231 = load i32, i32* %229, align 8
   %232 = bitcast i8* %226 to i32*
-  %NullCheck42 = icmp ne i32* %232, null
-  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+  %NullCheck41 = icmp eq i32* %232, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %233
 
 ; <label>:233                                     ; preds = %230
   store i32 %231, i32* %232, align 8
@@ -1099,15 +1181,15 @@ entry:
   %235 = getelementptr inbounds i8, i8* %234, i64 12
   %236 = load i8*, i8** %arg1
   %237 = getelementptr inbounds i8, i8* %236, i64 12
-  %NullCheck44 = icmp ne i8* %237, null
-  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i8* %237, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %238
 
 ; <label>:238                                     ; preds = %233
   %239 = load i8, i8* %237, align 8
   %240 = zext i8 %239 to i32
   %241 = trunc i32 %240 to i8
-  %NullCheck46 = icmp ne i8* %235, null
-  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+  %NullCheck45 = icmp eq i8* %235, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %242
 
 ; <label>:242                                     ; preds = %238
   store i8 %241, i8* %235, align 8
@@ -1117,14 +1199,14 @@ entry:
   %244 = load i8*, i8** %arg0
   %245 = load i8*, i8** %arg1
   %246 = bitcast i8* %245 to i64*
-  %NullCheck24 = icmp ne i64* %246, null
-  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64* %246, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %247
 
 ; <label>:247                                     ; preds = %243
   %248 = load i64, i64* %246, align 8
   %249 = bitcast i8* %244 to i64*
-  %NullCheck26 = icmp ne i64* %249, null
-  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64* %249, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %250
 
 ; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
@@ -1133,14 +1215,14 @@ entry:
   %253 = load i8*, i8** %arg1
   %254 = getelementptr inbounds i8, i8* %253, i64 8
   %255 = bitcast i8* %254 to i32*
-  %NullCheck28 = icmp ne i32* %255, null
-  br i1 %NullCheck28, label %256, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i32* %255, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %256
 
 ; <label>:256                                     ; preds = %250
   %257 = load i32, i32* %255, align 8
   %258 = bitcast i8* %252 to i32*
-  %NullCheck30 = icmp ne i32* %258, null
-  br i1 %NullCheck30, label %259, label %ThrowNullRef29
+  %NullCheck29 = icmp eq i32* %258, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %259
 
 ; <label>:259                                     ; preds = %256
   store i32 %257, i32* %258, align 8
@@ -1149,16 +1231,16 @@ entry:
   %262 = load i8*, i8** %arg1
   %263 = getelementptr inbounds i8, i8* %262, i64 12
   %264 = bitcast i8* %263 to i16*
-  %NullCheck32 = icmp ne i16* %264, null
-  br i1 %NullCheck32, label %265, label %ThrowNullRef31
+  %NullCheck31 = icmp eq i16* %264, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %265
 
 ; <label>:265                                     ; preds = %259
   %266 = load i16, i16* %264, align 8
   %267 = sext i16 %266 to i32
   %268 = bitcast i8* %261 to i16*
   %269 = trunc i32 %267 to i16
-  %NullCheck34 = icmp ne i16* %268, null
-  br i1 %NullCheck34, label %270, label %ThrowNullRef33
+  %NullCheck33 = icmp eq i16* %268, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %270
 
 ; <label>:270                                     ; preds = %265
   store i16 %269, i16* %268, align 8
@@ -1168,14 +1250,14 @@ entry:
   %272 = load i8*, i8** %arg0
   %273 = load i8*, i8** %arg1
   %274 = bitcast i8* %273 to i64*
-  %NullCheck8 = icmp ne i64* %274, null
-  br i1 %NullCheck8, label %275, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64* %274, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %275
 
 ; <label>:275                                     ; preds = %271
   %276 = load i64, i64* %274, align 8
   %277 = bitcast i8* %272 to i64*
-  %NullCheck10 = icmp ne i64* %277, null
-  br i1 %NullCheck10, label %278, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %277, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %278
 
 ; <label>:278                                     ; preds = %275
   store i64 %276, i64* %277, align 8
@@ -1184,14 +1266,14 @@ entry:
   %281 = load i8*, i8** %arg1
   %282 = getelementptr inbounds i8, i8* %281, i64 8
   %283 = bitcast i8* %282 to i32*
-  %NullCheck12 = icmp ne i32* %283, null
-  br i1 %NullCheck12, label %284, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i32* %283, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %284
 
 ; <label>:284                                     ; preds = %278
   %285 = load i32, i32* %283, align 8
   %286 = bitcast i8* %280 to i32*
-  %NullCheck14 = icmp ne i32* %286, null
-  br i1 %NullCheck14, label %287, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i32* %286, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %287
 
 ; <label>:287                                     ; preds = %284
   store i32 %285, i32* %286, align 8
@@ -1200,16 +1282,16 @@ entry:
   %290 = load i8*, i8** %arg1
   %291 = getelementptr inbounds i8, i8* %290, i64 12
   %292 = bitcast i8* %291 to i16*
-  %NullCheck16 = icmp ne i16* %292, null
-  br i1 %NullCheck16, label %293, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i16* %292, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %293
 
 ; <label>:293                                     ; preds = %287
   %294 = load i16, i16* %292, align 8
   %295 = sext i16 %294 to i32
   %296 = bitcast i8* %289 to i16*
   %297 = trunc i32 %295 to i16
-  %NullCheck18 = icmp ne i16* %296, null
-  br i1 %NullCheck18, label %298, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i16* %296, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %298
 
 ; <label>:298                                     ; preds = %293
   store i16 %297, i16* %296, align 8
@@ -1217,15 +1299,15 @@ entry:
   %300 = getelementptr inbounds i8, i8* %299, i64 14
   %301 = load i8*, i8** %arg1
   %302 = getelementptr inbounds i8, i8* %301, i64 14
-  %NullCheck20 = icmp ne i8* %302, null
-  br i1 %NullCheck20, label %303, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i8* %302, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %303
 
 ; <label>:303                                     ; preds = %298
   %304 = load i8, i8* %302, align 8
   %305 = zext i8 %304 to i32
   %306 = trunc i32 %305 to i8
-  %NullCheck22 = icmp ne i8* %300, null
-  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i8* %300, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %307
 
 ; <label>:307                                     ; preds = %303
   store i8 %306, i8* %300, align 8
@@ -1235,14 +1317,14 @@ entry:
   %309 = load i8*, i8** %arg0
   %310 = load i8*, i8** %arg1
   %311 = bitcast i8* %310 to i64*
-  %NullCheck = icmp ne i64* %311, null
-  br i1 %NullCheck, label %312, label %ThrowNullRef
+  %NullCheck = icmp eq i64* %311, null
+  br i1 %NullCheck, label %ThrowNullRef, label %312
 
 ; <label>:312                                     ; preds = %308
   %313 = load i64, i64* %311, align 8
   %314 = bitcast i8* %309 to i64*
-  %NullCheck2 = icmp ne i64* %314, null
-  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64* %314, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %315
 
 ; <label>:315                                     ; preds = %312
   store i64 %313, i64* %314, align 8
@@ -1251,14 +1333,14 @@ entry:
   %318 = load i8*, i8** %arg1
   %319 = getelementptr inbounds i8, i8* %318, i64 8
   %320 = bitcast i8* %319 to i64*
-  %NullCheck4 = icmp ne i64* %320, null
-  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64* %320, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %321
 
 ; <label>:321                                     ; preds = %315
   %322 = load i64, i64* %320, align 8
   %323 = bitcast i8* %317 to i64*
-  %NullCheck6 = icmp ne i64* %323, null
-  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64* %323, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %324
 
 ; <label>:324                                     ; preds = %321
   store i64 %322, i64* %323, align 8
@@ -1286,15 +1368,15 @@ entry:
 ; <label>:338                                     ; preds = %333
   %339 = load i8*, i8** %arg0
   %340 = load i8*, i8** %arg1
-  %NullCheck136 = icmp ne i8* %340, null
-  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+  %NullCheck135 = icmp eq i8* %340, null
+  br i1 %NullCheck135, label %ThrowNullRef136, label %341
 
 ; <label>:341                                     ; preds = %338
   %342 = load i8, i8* %340, align 8
   %343 = zext i8 %342 to i32
   %344 = trunc i32 %343 to i8
-  %NullCheck138 = icmp ne i8* %339, null
-  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+  %NullCheck137 = icmp eq i8* %339, null
+  br i1 %NullCheck137, label %ThrowNullRef138, label %345
 
 ; <label>:345                                     ; preds = %341
   store i8 %344, i8* %339, align 8
@@ -1317,16 +1399,16 @@ entry:
   %357 = load i8*, i8** %arg0
   %358 = load i8*, i8** %arg1
   %359 = bitcast i8* %358 to i16*
-  %NullCheck140 = icmp ne i16* %359, null
-  br i1 %NullCheck140, label %360, label %ThrowNullRef139
+  %NullCheck139 = icmp eq i16* %359, null
+  br i1 %NullCheck139, label %ThrowNullRef140, label %360
 
 ; <label>:360                                     ; preds = %356
   %361 = load i16, i16* %359, align 8
   %362 = sext i16 %361 to i32
   %363 = bitcast i8* %357 to i16*
   %364 = trunc i32 %362 to i16
-  %NullCheck142 = icmp ne i16* %363, null
-  br i1 %NullCheck142, label %365, label %ThrowNullRef141
+  %NullCheck141 = icmp eq i16* %363, null
+  br i1 %NullCheck141, label %ThrowNullRef142, label %365
 
 ; <label>:365                                     ; preds = %360
   store i16 %364, i16* %363, align 8
@@ -1352,14 +1434,14 @@ entry:
   %378 = load i8*, i8** %arg0
   %379 = load i8*, i8** %arg1
   %380 = bitcast i8* %379 to i32*
-  %NullCheck144 = icmp ne i32* %380, null
-  br i1 %NullCheck144, label %381, label %ThrowNullRef143
+  %NullCheck143 = icmp eq i32* %380, null
+  br i1 %NullCheck143, label %ThrowNullRef144, label %381
 
 ; <label>:381                                     ; preds = %377
   %382 = load i32, i32* %380, align 8
   %383 = bitcast i8* %378 to i32*
-  %NullCheck146 = icmp ne i32* %383, null
-  br i1 %NullCheck146, label %384, label %ThrowNullRef145
+  %NullCheck145 = icmp eq i32* %383, null
+  br i1 %NullCheck145, label %ThrowNullRef146, label %384
 
 ; <label>:384                                     ; preds = %381
   store i32 %382, i32* %383, align 8
@@ -1384,14 +1466,14 @@ entry:
   %395 = load i8*, i8** %arg0
   %396 = load i8*, i8** %arg1
   %397 = bitcast i8* %396 to i64*
-  %NullCheck164 = icmp ne i64* %397, null
-  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+  %NullCheck163 = icmp eq i64* %397, null
+  br i1 %NullCheck163, label %ThrowNullRef164, label %398
 
 ; <label>:398                                     ; preds = %394
   %399 = load i64, i64* %397, align 8
   %400 = bitcast i8* %395 to i64*
-  %NullCheck166 = icmp ne i64* %400, null
-  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+  %NullCheck165 = icmp eq i64* %400, null
+  br i1 %NullCheck165, label %ThrowNullRef166, label %401
 
 ; <label>:401                                     ; preds = %398
   store i64 %399, i64* %400, align 8
@@ -1400,14 +1482,14 @@ entry:
   %404 = load i8*, i8** %arg1
   %405 = getelementptr inbounds i8, i8* %404, i64 8
   %406 = bitcast i8* %405 to i64*
-  %NullCheck168 = icmp ne i64* %406, null
-  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+  %NullCheck167 = icmp eq i64* %406, null
+  br i1 %NullCheck167, label %ThrowNullRef168, label %407
 
 ; <label>:407                                     ; preds = %401
   %408 = load i64, i64* %406, align 8
   %409 = bitcast i8* %403 to i64*
-  %NullCheck170 = icmp ne i64* %409, null
-  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+  %NullCheck169 = icmp eq i64* %409, null
+  br i1 %NullCheck169, label %ThrowNullRef170, label %410
 
 ; <label>:410                                     ; preds = %407
   store i64 %408, i64* %409, align 8
@@ -1437,14 +1519,14 @@ entry:
   %425 = load i8*, i8** %arg0
   %426 = load i8*, i8** %arg1
   %427 = bitcast i8* %426 to i64*
-  %NullCheck148 = icmp ne i64* %427, null
-  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+  %NullCheck147 = icmp eq i64* %427, null
+  br i1 %NullCheck147, label %ThrowNullRef148, label %428
 
 ; <label>:428                                     ; preds = %424
   %429 = load i64, i64* %427, align 8
   %430 = bitcast i8* %425 to i64*
-  %NullCheck150 = icmp ne i64* %430, null
-  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+  %NullCheck149 = icmp eq i64* %430, null
+  br i1 %NullCheck149, label %ThrowNullRef150, label %431
 
 ; <label>:431                                     ; preds = %428
   store i64 %429, i64* %430, align 8
@@ -1466,14 +1548,14 @@ entry:
   %441 = load i8*, i8** %arg0
   %442 = load i8*, i8** %arg1
   %443 = bitcast i8* %442 to i32*
-  %NullCheck152 = icmp ne i32* %443, null
-  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+  %NullCheck151 = icmp eq i32* %443, null
+  br i1 %NullCheck151, label %ThrowNullRef152, label %444
 
 ; <label>:444                                     ; preds = %440
   %445 = load i32, i32* %443, align 8
   %446 = bitcast i8* %441 to i32*
-  %NullCheck154 = icmp ne i32* %446, null
-  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+  %NullCheck153 = icmp eq i32* %446, null
+  br i1 %NullCheck153, label %ThrowNullRef154, label %447
 
 ; <label>:447                                     ; preds = %444
   store i32 %445, i32* %446, align 8
@@ -1495,16 +1577,16 @@ entry:
   %457 = load i8*, i8** %arg0
   %458 = load i8*, i8** %arg1
   %459 = bitcast i8* %458 to i16*
-  %NullCheck156 = icmp ne i16* %459, null
-  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+  %NullCheck155 = icmp eq i16* %459, null
+  br i1 %NullCheck155, label %ThrowNullRef156, label %460
 
 ; <label>:460                                     ; preds = %456
   %461 = load i16, i16* %459, align 8
   %462 = sext i16 %461 to i32
   %463 = bitcast i8* %457 to i16*
   %464 = trunc i32 %462 to i16
-  %NullCheck158 = icmp ne i16* %463, null
-  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+  %NullCheck157 = icmp eq i16* %463, null
+  br i1 %NullCheck157, label %ThrowNullRef158, label %465
 
 ; <label>:465                                     ; preds = %460
   store i16 %464, i16* %463, align 8
@@ -1525,15 +1607,15 @@ entry:
 ; <label>:474                                     ; preds = %470
   %475 = load i8*, i8** %arg0
   %476 = load i8*, i8** %arg1
-  %NullCheck160 = icmp ne i8* %476, null
-  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+  %NullCheck159 = icmp eq i8* %476, null
+  br i1 %NullCheck159, label %ThrowNullRef160, label %477
 
 ; <label>:477                                     ; preds = %474
   %478 = load i8, i8* %476, align 8
   %479 = zext i8 %478 to i32
   %480 = trunc i32 %479 to i8
-  %NullCheck162 = icmp ne i8* %475, null
-  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+  %NullCheck161 = icmp eq i8* %475, null
+  br i1 %NullCheck161, label %ThrowNullRef162, label %481
 
 ; <label>:481                                     ; preds = %477
   store i8 %480, i8* %475, align 8
@@ -1553,343 +1635,343 @@ ThrowNullRef:                                     ; preds = %308
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %312
+ThrowNullRef2:                                    ; preds = %312
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %315
+ThrowNullRef4:                                    ; preds = %315
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %321
+ThrowNullRef6:                                    ; preds = %321
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %271
+ThrowNullRef8:                                    ; preds = %271
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %275
+ThrowNullRef10:                                   ; preds = %275
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %278
+ThrowNullRef12:                                   ; preds = %278
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %284
+ThrowNullRef14:                                   ; preds = %284
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %287
+ThrowNullRef16:                                   ; preds = %287
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %293
+ThrowNullRef18:                                   ; preds = %293
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %298
+ThrowNullRef20:                                   ; preds = %298
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %303
+ThrowNullRef22:                                   ; preds = %303
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %243
+ThrowNullRef24:                                   ; preds = %243
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %247
+ThrowNullRef26:                                   ; preds = %247
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %250
+ThrowNullRef28:                                   ; preds = %250
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %256
+ThrowNullRef30:                                   ; preds = %256
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %259
+ThrowNullRef32:                                   ; preds = %259
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %265
+ThrowNullRef34:                                   ; preds = %265
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %217
+ThrowNullRef36:                                   ; preds = %217
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %221
+ThrowNullRef38:                                   ; preds = %221
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %224
+ThrowNullRef40:                                   ; preds = %224
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %230
+ThrowNullRef42:                                   ; preds = %230
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %233
+ThrowNullRef44:                                   ; preds = %233
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %238
+ThrowNullRef46:                                   ; preds = %238
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %200
+ThrowNullRef48:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %204
+ThrowNullRef50:                                   ; preds = %204
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %207
+ThrowNullRef52:                                   ; preds = %207
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %213
+ThrowNullRef54:                                   ; preds = %213
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %172
+ThrowNullRef56:                                   ; preds = %172
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %176
+ThrowNullRef58:                                   ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %179
+ThrowNullRef60:                                   ; preds = %179
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %185
+ThrowNullRef62:                                   ; preds = %185
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %190
+ThrowNullRef64:                                   ; preds = %190
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %195
+ThrowNullRef66:                                   ; preds = %195
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %153
+ThrowNullRef68:                                   ; preds = %153
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %157
+ThrowNullRef70:                                   ; preds = %157
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %160
+ThrowNullRef72:                                   ; preds = %160
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %166
+ThrowNullRef74:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %136
+ThrowNullRef76:                                   ; preds = %136
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %140
+ThrowNullRef78:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %143
+ThrowNullRef80:                                   ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %148
+ThrowNullRef82:                                   ; preds = %148
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %128
+ThrowNullRef84:                                   ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %132
+ThrowNullRef86:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %100
+ThrowNullRef88:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %104
+ThrowNullRef90:                                   ; preds = %104
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %107
+ThrowNullRef92:                                   ; preds = %107
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %113
+ThrowNullRef94:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %118
+ThrowNullRef96:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %123
+ThrowNullRef98:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %81
+ThrowNullRef100:                                  ; preds = %81
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef101:                                  ; preds = %85
+ThrowNullRef102:                                  ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef103:                                  ; preds = %88
+ThrowNullRef104:                                  ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef105:                                  ; preds = %94
+ThrowNullRef106:                                  ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef107:                                  ; preds = %64
+ThrowNullRef108:                                  ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef109:                                  ; preds = %68
+ThrowNullRef110:                                  ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef111:                                  ; preds = %71
+ThrowNullRef112:                                  ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef113:                                  ; preds = %76
+ThrowNullRef114:                                  ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef115:                                  ; preds = %56
+ThrowNullRef116:                                  ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef117:                                  ; preds = %60
+ThrowNullRef118:                                  ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef119:                                  ; preds = %37
+ThrowNullRef120:                                  ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef121:                                  ; preds = %41
+ThrowNullRef122:                                  ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef123:                                  ; preds = %46
+ThrowNullRef124:                                  ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef125:                                  ; preds = %51
+ThrowNullRef126:                                  ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef127:                                  ; preds = %27
+ThrowNullRef128:                                  ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef129:                                  ; preds = %31
+ThrowNullRef130:                                  ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef131:                                  ; preds = %19
+ThrowNullRef132:                                  ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef133:                                  ; preds = %22
+ThrowNullRef134:                                  ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef135:                                  ; preds = %338
+ThrowNullRef136:                                  ; preds = %338
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef137:                                  ; preds = %341
+ThrowNullRef138:                                  ; preds = %341
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef139:                                  ; preds = %356
+ThrowNullRef140:                                  ; preds = %356
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef141:                                  ; preds = %360
+ThrowNullRef142:                                  ; preds = %360
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef143:                                  ; preds = %377
+ThrowNullRef144:                                  ; preds = %377
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef145:                                  ; preds = %381
+ThrowNullRef146:                                  ; preds = %381
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef147:                                  ; preds = %424
+ThrowNullRef148:                                  ; preds = %424
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef149:                                  ; preds = %428
+ThrowNullRef150:                                  ; preds = %428
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef151:                                  ; preds = %440
+ThrowNullRef152:                                  ; preds = %440
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef153:                                  ; preds = %444
+ThrowNullRef154:                                  ; preds = %444
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef155:                                  ; preds = %456
+ThrowNullRef156:                                  ; preds = %456
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef157:                                  ; preds = %460
+ThrowNullRef158:                                  ; preds = %460
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef159:                                  ; preds = %474
+ThrowNullRef160:                                  ; preds = %474
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef161:                                  ; preds = %477
+ThrowNullRef162:                                  ; preds = %477
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef163:                                  ; preds = %394
+ThrowNullRef164:                                  ; preds = %394
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef165:                                  ; preds = %398
+ThrowNullRef166:                                  ; preds = %398
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef167:                                  ; preds = %401
+ThrowNullRef168:                                  ; preds = %401
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef169:                                  ; preds = %407
+ThrowNullRef170:                                  ; preds = %407
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1939,8 +2021,8 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
-  br i1 %NullCheck, label %22, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %ThrowNullRef, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
@@ -1948,8 +2030,8 @@ entry:
   store i32 %24, i32* %loc0
   %25 = load i32, i32* %loc0
   %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %26, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %27
 
 ; <label>:27                                      ; preds = %22
   %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
@@ -1971,7 +2053,7 @@ ThrowNullRef:                                     ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1989,8 +2071,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -2022,15 +2104,15 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2048,16 +2130,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
   %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
   store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %15
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
@@ -2072,8 +2154,8 @@ entry:
   %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
   %29 = ptrtoint i16 addrspace(1)* %28 to i64
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %19
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
@@ -2089,19 +2171,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2114,8 +2196,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
@@ -2128,7 +2210,7 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[loadElem]
+Failed to read AppDomain.PrepareDataForSetup[storeElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
@@ -2202,8 +2284,8 @@ entry:
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
-  br i1 %NullCheck24, label %27, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = load i64, i64 addrspace(1)* %26
@@ -2218,8 +2300,8 @@ entry:
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
-  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
   %41 = load i64, i64 addrspace(1)* %39
@@ -2236,8 +2318,8 @@ entry:
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
-  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
   %54 = load i64, i64 addrspace(1)* %52
@@ -2252,8 +2334,8 @@ entry:
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
   %67 = load i64, i64 addrspace(1)* %65
@@ -2270,8 +2352,8 @@ entry:
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
-  br i1 %NullCheck16, label %79, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
   %80 = load i64, i64 addrspace(1)* %78
@@ -2286,8 +2368,8 @@ entry:
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
-  br i1 %NullCheck18, label %92, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
   %93 = load i64, i64 addrspace(1)* %91
@@ -2304,8 +2386,8 @@ entry:
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
-  br i1 %NullCheck12, label %105, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = load i64, i64 addrspace(1)* %104
@@ -2320,8 +2402,8 @@ entry:
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
-  br i1 %NullCheck14, label %118, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
   %119 = load i64, i64 addrspace(1)* %117
@@ -2337,8 +2419,8 @@ entry:
 
 ; <label>:128                                     ; preds = %20
   %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
-  br i1 %NullCheck4, label %130, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %129, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %130
 
 ; <label>:130                                     ; preds = %128
   %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
@@ -2346,8 +2428,8 @@ entry:
   %133 = load i16, i16 addrspace(1)* %132, align 8
   %134 = zext i16 %133 to i32
   %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
-  br i1 %NullCheck6, label %136, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %135, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %136
 
 ; <label>:136                                     ; preds = %130
   %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
@@ -2360,8 +2442,8 @@ entry:
 
 ; <label>:143                                     ; preds = %136
   %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
-  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %144, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %145
 
 ; <label>:145                                     ; preds = %143
   %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
@@ -2369,8 +2451,8 @@ entry:
   %148 = load i16, i16 addrspace(1)* %147, align 8
   %149 = zext i16 %148 to i32
   %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %150, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %151
 
 ; <label>:151                                     ; preds = %145
   %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
@@ -2388,8 +2470,8 @@ entry:
 
 ; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
-  br i1 %NullCheck, label %163, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %ThrowNullRef, label %163
 
 ; <label>:163                                     ; preds = %161
   %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
@@ -2399,8 +2481,8 @@ entry:
 
 ; <label>:167                                     ; preds = %163
   %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
-  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %168, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %169
 
 ; <label>:169                                     ; preds = %167
   %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
@@ -2432,55 +2514,55 @@ ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %167
+ThrowNullRef2:                                    ; preds = %167
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %128
+ThrowNullRef4:                                    ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %130
+ThrowNullRef6:                                    ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %143
+ThrowNullRef8:                                    ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %145
+ThrowNullRef10:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %102
+ThrowNullRef12:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %105
+ThrowNullRef14:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %76
+ThrowNullRef16:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %79
+ThrowNullRef18:                                   ; preds = %79
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %50
+ThrowNullRef20:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %53
+ThrowNullRef22:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %24
+ThrowNullRef24:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %27
+ThrowNullRef26:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2503,15 +2585,15 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2519,16 +2601,16 @@ entry:
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
   store i32 %8, i32* %loc0
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
   %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
   store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
@@ -2546,16 +2628,16 @@ entry:
 
 ; <label>:23                                      ; preds = %64
   %24 = load i16*, i16** %loc3
-  %NullCheck12 = icmp ne i16* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i16* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
   store i32 %27, i32* %loc5
   %28 = load i16*, i16** %loc4
-  %NullCheck14 = icmp ne i16* %28, null
-  br i1 %NullCheck14, label %29, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %28, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = load i16, i16* %28, align 8
@@ -2620,15 +2702,15 @@ entry:
 
 ; <label>:67                                      ; preds = %64
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
-  br i1 %NullCheck8, label %69, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %68, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %69
 
 ; <label>:69                                      ; preds = %67
   %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
   %71 = load i32, i32 addrspace(1)* %70
   %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
-  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %73
 
 ; <label>:73                                      ; preds = %69
   %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
@@ -2645,31 +2727,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %67
+ThrowNullRef8:                                    ; preds = %67
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %69
+ThrowNullRef10:                                   ; preds = %69
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2710,14 +2792,14 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
   %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
@@ -2730,14 +2812,14 @@ entry:
 
 ; <label>:11                                      ; preds = %4
   %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
   %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
@@ -2749,14 +2831,14 @@ entry:
 
 ; <label>:22                                      ; preds = %16
   %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
   %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
-  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
-  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
@@ -2804,23 +2886,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2836,7 +2918,280 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[loadElem]
+Successfully read RuntimeType.IsAssignableFrom
+
+define i8 @RuntimeType.IsAssignableFrom(%System.RuntimeType addrspace(1)* %param0, %System.Type addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.RuntimeType addrspace(1)*
+  %arg1 = alloca %System.Type addrspace(1)*
+  %loc0 = alloca %System.RuntimeType addrspace(1)*
+  %loc1 = alloca %"System.Type[]" addrspace(1)*
+  %loc2 = alloca i32
+  store %System.RuntimeType addrspace(1)* %param0, %System.RuntimeType addrspace(1)** %this
+  store %System.Type addrspace(1)* %param1, %System.Type addrspace(1)** %arg1
+  %0 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %1 = icmp ne %System.Type addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i8 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %5 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %6 = bitcast %System.Type addrspace(1)* %4 to %System.Object addrspace(1)*
+  %7 = bitcast %System.RuntimeType addrspace(1)* %5 to %System.Object addrspace(1)*
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %6, %System.Object addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %3
+  ret i8 1
+
+; <label>:12                                      ; preds = %3
+  %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 152
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 32
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
+  %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
+  %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
+  store %System.RuntimeType addrspace(1)* %25, %System.RuntimeType addrspace(1)** %loc0
+  %26 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %27 = icmp eq %System.RuntimeType addrspace(1)* %26, null
+  br i1 %27, label %34, label %28
+
+; <label>:28                                      ; preds = %15
+  %29 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %30 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)*)*)(%System.RuntimeType addrspace(1)* %29, %System.RuntimeType addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+; <label>:34                                      ; preds = %15
+  %35 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %36 = call %System.Reflection.Emit.TypeBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Reflection.Emit.TypeBuilder addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %35)
+  %37 = icmp eq %System.Reflection.Emit.TypeBuilder addrspace(1)* %36, null
+  br i1 %37, label %139, label %38
+
+; <label>:38                                      ; preds = %34
+  %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %42
+
+; <label>:42                                      ; preds = %38
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 152
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 40
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
+  %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
+  %53 = zext i8 %52 to i32
+  %54 = icmp eq i32 %53, 0
+  br i1 %54, label %56, label %55
+
+; <label>:55                                      ; preds = %42
+  ret i8 1
+
+; <label>:56                                      ; preds = %42
+  %57 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %58 = bitcast %System.RuntimeType addrspace(1)* %57 to %System.Type addrspace(1)*
+  %59 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %58)
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %64 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.Type addrspace(1)* %63, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = bitcast %System.RuntimeType addrspace(1)* %64 to %System.Type addrspace(1)*
+  %67 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %63, %System.Type addrspace(1)* %66)
+  %68 = zext i8 %67 to i32
+  %69 = trunc i32 %68 to i8
+  ret i8 %69
+
+; <label>:70                                      ; preds = %56
+  %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
+  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %73
+
+; <label>:73                                      ; preds = %70
+  %74 = load i64, i64 addrspace(1)* %72
+  %75 = add i64 %74, 128
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = add i64 %77, 0
+  %79 = inttoptr i64 %78 to i64*
+  %80 = load i64, i64* %79
+  %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
+  %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
+  %83 = call i8 %82(%System.Type addrspace(1)* %81)
+  %84 = zext i8 %83 to i32
+  %85 = icmp eq i32 %84, 0
+  br i1 %85, label %139, label %86
+
+; <label>:86                                      ; preds = %73
+  %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
+  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %89
+
+; <label>:89                                      ; preds = %86
+  %90 = load i64, i64 addrspace(1)* %88
+  %91 = add i64 %90, 128
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = add i64 %93, 24
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
+  %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
+  %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
+  store %"System.Type[]" addrspace(1)* %99, %"System.Type[]" addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %129
+
+; <label>:100                                     ; preds = %132
+  %101 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %102 = load i32, i32* %loc2
+  %NullCheck11 = icmp eq %"System.Type[]" addrspace(1)* %101, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %103
+
+; <label>:103                                     ; preds = %100
+  %104 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 1
+  %105 = load i32, i32 addrspace(1)* %104
+  %106 = zext i32 %105 to i64
+  %107 = zext i32 %102 to i64
+  %BoundsCheck = icmp uge i64 %107, %106
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %108
+
+; <label>:108                                     ; preds = %103
+  %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
+  %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
+  %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
+  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %113
+
+; <label>:113                                     ; preds = %108
+  %114 = load i64, i64 addrspace(1)* %112
+  %115 = add i64 %114, 152
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = add i64 %117, 56
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
+  %123 = zext i8 %122 to i32
+  %124 = icmp ne i32 %123, 0
+  br i1 %124, label %126, label %125
+
+; <label>:125                                     ; preds = %113
+  ret i8 0
+
+; <label>:126                                     ; preds = %113
+  %127 = load i32, i32* %loc2
+  %128 = add i32 %127, 1
+  store i32 %128, i32* %loc2
+  br label %129
+
+; <label>:129                                     ; preds = %89, %126
+  %130 = load i32, i32* %loc2
+  %131 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %NullCheck9 = icmp eq %"System.Type[]" addrspace(1)* %131, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %132
+
+; <label>:132                                     ; preds = %129
+  %133 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %131, i32 0, i32 1
+  %134 = load i32, i32 addrspace(1)* %133
+  %135 = zext i32 %134 to i64
+  %136 = trunc i64 %135 to i32
+  %137 = icmp slt i32 %130, %136
+  br i1 %137, label %100, label %138
+
+; <label>:138                                     ; preds = %132
+  ret i8 1
+
+; <label>:139                                     ; preds = %34, %73
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %129
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %103
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -2893,7 +3248,7 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElem]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -2904,8 +3259,8 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -2997,8 +3352,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
@@ -3059,8 +3414,8 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -3087,8 +3442,8 @@ entry:
 
 ; <label>:17                                      ; preds = %5, %11
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
@@ -3097,8 +3452,8 @@ entry:
 
 ; <label>:22                                      ; preds = %1, %11
   %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
@@ -3109,11 +3464,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %17
+ThrowNullRef2:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %22
+ThrowNullRef4:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3167,15 +3522,15 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
   %15 = load i32, i32 addrspace(1)* %14
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
@@ -3198,7 +3553,7 @@ ThrowNullRef:                                     ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef2:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3232,8 +3587,8 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
@@ -3312,8 +3667,8 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -3327,8 +3682,8 @@ entry:
 ; <label>:5                                       ; preds = %43
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %7 = load i32, i32* %loc1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck6, label %8, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
@@ -3366,8 +3721,8 @@ entry:
 ; <label>:32                                      ; preds = %21, %25
   %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
   %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
-  br i1 %NullCheck8, label %35, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = trunc i32 %34 to i16
@@ -3380,8 +3735,8 @@ entry:
 ; <label>:40                                      ; preds = %1, %35
   %41 = load i32, i32* %loc1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
-  br i1 %NullCheck2, label %43, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %42, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
@@ -3392,8 +3747,8 @@ entry:
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
   %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
-  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
   %51 = load i64, i64 addrspace(1)* %49
@@ -3412,19 +3767,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %40
+ThrowNullRef2:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %47
+ThrowNullRef4:                                    ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %5
+ThrowNullRef6:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %32
+ThrowNullRef8:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3467,8 +3822,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
@@ -3492,11 +3847,391 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(i16* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store i16* %param0, i16** %arg0
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load i32, i32* %arg3
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %42, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %37, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg2
+  %13 = load i32, i32* %arg3
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %37, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %24 = load i32, i32* %arg2
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load i16*, i16** %arg0
+  %35 = load i32, i32* %arg3
+  %36 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %36, i16* %34, i32 %35)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:37                                      ; preds = %5, %16
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %39)
+  %41 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41, %System.String addrspace(1)* %38, %System.String addrspace(1)* %40)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41) #0
+  unreachable
+
+; <label>:42                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
-Failed to read StringBuilder.ToString[loadElemA]
+Successfully read StringBuilder.ToString
+
+define %System.String addrspace(1)* @StringBuilder.ToString(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i16*
+  %loc3 = alloca %"System.Char[]" addrspace(1)*
+  %loc4 = alloca i32
+  %loc5 = alloca i32
+  %loc6 = alloca i16 addrspace(1)*
+  %loc7 = alloca %System.String addrspace(1)*
+  %loc8 = alloca %"System.Char[]" addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %0)
+  %2 = icmp ne i32 %1, 0
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %4
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %6)
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %7)
+  store %System.String addrspace(1)* %8, %System.String addrspace(1)** %loc0
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.Text.StringBuilder addrspace(1)* %9, %System.Text.StringBuilder addrspace(1)** %loc1
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  store %System.String addrspace(1)* %10, %System.String addrspace(1)** %loc7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc7
+  %12 = ptrtoint %System.String addrspace(1)* %11 to i64
+  %13 = icmp eq i64 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %5
+  %15 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %16 = sext i32 %15 to i64
+  %17 = add i64 %12, %16
+  br label %18
+
+; <label>:18                                      ; preds = %5, %14
+  %19 = phi i64 [ %12, %5 ], [ %17, %14 ]
+  %20 = inttoptr i64 %19 to i16*
+  store i16* %20, i16** %loc2
+  br label %21
+
+; <label>:21                                      ; preds = %98, %18
+  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %22, null
+  br i1 %NullCheck, label %ThrowNullRef, label %23
+
+; <label>:23                                      ; preds = %21
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 3
+  %25 = load i32, i32 addrspace(1)* %24, align 8
+  %26 = icmp sle i32 %25, 0
+  br i1 %26, label %96, label %27
+
+; <label>:27                                      ; preds = %23
+  %28 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %28, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %29
+
+; <label>:29                                      ; preds = %27
+  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %28, i32 0, i32 1
+  %31 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %30, align 8
+  store %"System.Char[]" addrspace(1)* %31, %"System.Char[]" addrspace(1)** %loc3
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %33
+
+; <label>:33                                      ; preds = %29
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  store i32 %35, i32* %loc4
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  %39 = load i32, i32 addrspace(1)* %38, align 8
+  store i32 %39, i32* %loc5
+  %40 = load i32, i32* %loc5
+  %41 = load i32, i32* %loc4
+  %42 = add i32 %40, %41
+  %43 = zext i32 %42 to i64
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %45
+
+; <label>:45                                      ; preds = %37
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = sext i32 %47 to i64
+  %49 = icmp sgt i64 %43, %48
+  br i1 %49, label %91, label %50
+
+; <label>:50                                      ; preds = %45
+  %51 = load i32, i32* %loc5
+  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %52, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %53
+
+; <label>:53                                      ; preds = %50
+  %54 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %52, i32 0, i32 1
+  %55 = load i32, i32 addrspace(1)* %54
+  %56 = zext i32 %55 to i64
+  %57 = trunc i64 %56 to i32
+  %58 = icmp ugt i32 %51, %57
+  br i1 %58, label %91, label %59
+
+; <label>:59                                      ; preds = %53
+  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  store %"System.Char[]" addrspace(1)* %60, %"System.Char[]" addrspace(1)** %loc8
+  %61 = icmp eq %"System.Char[]" addrspace(1)* %60, null
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %63, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %64
+
+; <label>:64                                      ; preds = %62
+  %65 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %63, i32 0, i32 1
+  %66 = load i32, i32 addrspace(1)* %65
+  %67 = zext i32 %66 to i64
+  %68 = trunc i64 %67 to i32
+  %69 = icmp ne i32 %68, 0
+  br i1 %69, label %71, label %70
+
+; <label>:70                                      ; preds = %59, %64
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:71                                      ; preds = %64
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %73
+
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %BoundsCheck = icmp uge i64 0, %76
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %77
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %78, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:79                                      ; preds = %70, %77
+  %80 = load i16*, i16** %loc2
+  %81 = load i32, i32* %loc4
+  %82 = sext i32 %81 to i64
+  %83 = mul i64 %82, 2
+  %84 = bitcast i16* %80 to i8*
+  %85 = getelementptr inbounds i8, i8* %84, i64 %83
+  %86 = load i16 addrspace(1)*, i16 addrspace(1)** %loc6
+  %87 = ptrtoint i16 addrspace(1)* %86 to i64
+  %88 = load i32, i32* %loc5
+  %89 = bitcast i8* %85 to i16*
+  %90 = inttoptr i64 %87 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %89, i16* %90, i32 %88)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %96
+
+; <label>:91                                      ; preds = %45, %53
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %94 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %93)
+  %95 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95, %System.String addrspace(1)* %92, %System.String addrspace(1)* %94)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95) #0
+  unreachable
+
+; <label>:96                                      ; preds = %23, %79
+  %97 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %97, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %98
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %97, i32 0, i32 2
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  store %System.Text.StringBuilder addrspace(1)* %100, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %102 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %102, label %21, label %103
+
+; <label>:103                                     ; preds = %98
+  store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc7
+  %104 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  ret %System.String addrspace(1)* %104
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method StringBuilder::get_Length using LLILCJit
+Successfully read StringBuilder.get_Length
+
+define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
+Successfully read RuntimeHelpers.get_OffsetToStringData
+
+define i32 @RuntimeHelpers.get_OffsetToStringData() {
+entry:
+  ret i32 12
+}
+
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
 Successfully read CultureData.CreateCultureData
 
@@ -3514,23 +4249,23 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
   store i8 %4, i8 addrspace(1)* %6
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
@@ -3549,11 +4284,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3566,50 +4301,50 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
   store i32 -1, i32 addrspace(1)* %2
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
   store i32 -1, i32 addrspace(1)* %8
   %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
   store i32 -1, i32 addrspace(1)* %14
   %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
   store i32 -1, i32 addrspace(1)* %17
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
@@ -3623,27 +4358,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3675,7 +4410,136 @@ Failed to read Dictionary`2.Insert[non-const derefAddress]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
 Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
-Failed to read HashHelpers.GetPrime[loadElem]
+Successfully read HashHelpers.GetPrime
+
+define i32 @HashHelpers.GetPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %6, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5, %System.String addrspace(1)* %4)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5) #0
+  unreachable
+
+; <label>:6                                       ; preds = %entry
+  store i32 0, i32* %loc0
+  br label %29
+
+; <label>:7                                       ; preds = %35
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 1296
+  %10 = addrspacecast i8 addrspace(1)* %9 to %"System.Int32[]" addrspace(1)**
+  %11 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %10
+  %12 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Int32[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = zext i32 %15 to i64
+  %17 = zext i32 %12 to i64
+  %BoundsCheck = icmp uge i64 %17, %16
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 3, i32 %12
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  store i32 %20, i32* %loc1
+  %21 = load i32, i32* %loc1
+  %22 = load i32, i32* %arg0
+  %23 = icmp slt i32 %21, %22
+  br i1 %23, label %26, label %24
+
+; <label>:24                                      ; preds = %18
+  %25 = load i32, i32* %loc1
+  ret i32 %25
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %loc0
+  %28 = add i32 %27, 1
+  store i32 %28, i32* %loc0
+  br label %29
+
+; <label>:29                                      ; preds = %6, %26
+  %30 = load i32, i32* %loc0
+  %31 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %32 = getelementptr inbounds i8, i8 addrspace(1)* %31, i64 1296
+  %33 = addrspacecast i8 addrspace(1)* %32 to %"System.Int32[]" addrspace(1)**
+  %34 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %33
+  %NullCheck = icmp eq %"System.Int32[]" addrspace(1)* %34, null
+  br i1 %NullCheck, label %ThrowNullRef, label %35
+
+; <label>:35                                      ; preds = %29
+  %36 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %34, i32 0, i32 1
+  %37 = load i32, i32 addrspace(1)* %36
+  %38 = zext i32 %37 to i64
+  %39 = trunc i64 %38 to i32
+  %40 = icmp slt i32 %30, %39
+  br i1 %40, label %7, label %41
+
+; <label>:41                                      ; preds = %35
+  %42 = load i32, i32* %arg0
+  %43 = or i32 %42, 1
+  store i32 %43, i32* %loc2
+  br label %59
+
+; <label>:44                                      ; preds = %59
+  %45 = load i32, i32* %loc2
+  %46 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %45)
+  %47 = zext i8 %46 to i32
+  %48 = icmp eq i32 %47, 0
+  br i1 %48, label %56, label %49
+
+; <label>:49                                      ; preds = %44
+  %50 = load i32, i32* %loc2
+  %51 = sub i32 %50, 1
+  %52 = srem i32 %51, 101
+  %53 = icmp eq i32 %52, 0
+  br i1 %53, label %56, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = load i32, i32* %loc2
+  ret i32 %55
+
+; <label>:56                                      ; preds = %44, %49
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %57, 2
+  store i32 %58, i32* %loc2
+  br label %59
+
+; <label>:59                                      ; preds = %41, %56
+  %60 = load i32, i32* %loc2
+  %61 = icmp slt i32 %60, 2147483647
+  br i1 %61, label %44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load i32, i32* %arg0
+  ret i32 %63
+
+ThrowNullRef:                                     ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
 Successfully read GenericEqualityComparer`1.GetHashCode
 
@@ -3694,14 +4558,14 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
   %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load i64, i64 addrspace(1)* %7
@@ -3720,7 +4584,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3750,8 +4614,8 @@ entry:
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
@@ -3796,8 +4660,8 @@ entry:
   %35 = bitcast i16* %34 to i8*
   %36 = getelementptr inbounds i8, i8* %35, i64 2
   %37 = bitcast i8* %36 to i16*
-  %NullCheck4 = icmp ne i16* %37, null
-  br i1 %NullCheck4, label %38, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %37, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %38
 
 ; <label>:38                                      ; preds = %27
   %39 = load i16, i16* %37, align 8
@@ -3824,8 +4688,8 @@ entry:
 
 ; <label>:54                                      ; preds = %22, %43
   %55 = load i16*, i16** %loc4
-  %NullCheck2 = icmp ne i16* %55, null
-  br i1 %NullCheck2, label %56, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i16* %55, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %56
 
 ; <label>:56                                      ; preds = %54
   %57 = load i16, i16* %55, align 8
@@ -3850,11 +4714,11 @@ ThrowNullRef:                                     ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %54
+ThrowNullRef2:                                    ; preds = %54
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %27
+ThrowNullRef4:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3871,8 +4735,8 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -3907,8 +4771,8 @@ entry:
 
 ; <label>:26                                      ; preds = %19
   %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
-  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %28
 
 ; <label>:28                                      ; preds = %26
   %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
@@ -3920,7 +4784,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3972,8 +4836,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
@@ -3984,26 +4848,26 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
-  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
@@ -4014,8 +4878,8 @@ entry:
 ; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
@@ -4024,8 +4888,8 @@ entry:
 
 ; <label>:25                                      ; preds = %1, %16, %23
   %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
-  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
@@ -4036,27 +4900,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %20
+ThrowNullRef10:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4069,8 +4933,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -4081,8 +4945,8 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
@@ -4091,8 +4955,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1, %8
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
@@ -4103,11 +4967,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4128,24 +4992,24 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   store i32 %3, i32* %loc0
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
   %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
   store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck4, label %9, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
@@ -4164,15 +5028,15 @@ entry:
 ; <label>:18                                      ; preds = %70
   %19 = load i16*, i16** %loc3
   %20 = bitcast i16* %19 to i64*
-  %NullCheck10 = icmp ne i64* %20, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %20, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = load i64, i64* %20, align 8
   %23 = load i16*, i16** %loc4
   %24 = bitcast i16* %23 to i64*
-  %NullCheck12 = icmp ne i64* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = load i64, i64* %24, align 8
@@ -4188,8 +5052,8 @@ entry:
   %31 = bitcast i16* %30 to i8*
   %32 = getelementptr inbounds i8, i8* %31, i64 8
   %33 = bitcast i8* %32 to i64*
-  %NullCheck14 = icmp ne i64* %33, null
-  br i1 %NullCheck14, label %34, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = load i64, i64* %33, align 8
@@ -4197,8 +5061,8 @@ entry:
   %37 = bitcast i16* %36 to i8*
   %38 = getelementptr inbounds i8, i8* %37, i64 8
   %39 = bitcast i8* %38 to i64*
-  %NullCheck16 = icmp ne i64* %39, null
-  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %40
 
 ; <label>:40                                      ; preds = %34
   %41 = load i64, i64* %39, align 8
@@ -4214,8 +5078,8 @@ entry:
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %NullCheck18 = icmp ne i64* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = load i64, i64* %48, align 8
@@ -4223,8 +5087,8 @@ entry:
   %52 = bitcast i16* %51 to i8*
   %53 = getelementptr inbounds i8, i8* %52, i64 16
   %54 = bitcast i8* %53 to i64*
-  %NullCheck20 = icmp ne i64* %54, null
-  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64* %54, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %55
 
 ; <label>:55                                      ; preds = %49
   %56 = load i64, i64* %54, align 8
@@ -4262,15 +5126,15 @@ entry:
 ; <label>:74                                      ; preds = %95
   %75 = load i16*, i16** %loc3
   %76 = bitcast i16* %75 to i32*
-  %NullCheck6 = icmp ne i32* %76, null
-  br i1 %NullCheck6, label %77, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32* %76, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %77
 
 ; <label>:77                                      ; preds = %74
   %78 = load i32, i32* %76, align 8
   %79 = load i16*, i16** %loc4
   %80 = bitcast i16* %79 to i32*
-  %NullCheck8 = icmp ne i32* %80, null
-  br i1 %NullCheck8, label %81, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i32* %80, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %81
 
 ; <label>:81                                      ; preds = %77
   %82 = load i32, i32* %80, align 8
@@ -4318,43 +5182,43 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %74
+ThrowNullRef6:                                    ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %77
+ThrowNullRef8:                                    ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %29
+ThrowNullRef14:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %34
+ThrowNullRef16:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4376,8 +5240,8 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load i64, i64 addrspace(1)* %4
@@ -4389,8 +5253,8 @@ entry:
   %12 = load i64, i64* %11
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %5
   %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
@@ -4399,8 +5263,8 @@ entry:
   %18 = load i8, i8* %arg2
   %19 = zext i8 %18 to i32
   %20 = trunc i32 %19 to i8
-  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %15
   %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
@@ -4411,11 +5275,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4442,8 +5306,8 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
@@ -4466,16 +5330,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
   %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = load i64, i64 addrspace(1)* %19
@@ -4500,8 +5364,8 @@ entry:
 ; <label>:35                                      ; preds = %30
   %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
@@ -4514,8 +5378,8 @@ entry:
 
 ; <label>:42                                      ; preds = %1, %38
   %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
-  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
@@ -4526,19 +5390,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %35
+ThrowNullRef2:                                    ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %42
+ThrowNullRef8:                                    ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4551,14 +5415,14 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
@@ -4570,7 +5434,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4583,8 +5447,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
@@ -4613,51 +5477,51 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
   %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
   %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
   %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
   %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
-  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
   store i64 %21, i64 addrspace(1)* %23
   %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %25 = load i64, i64* %loc0
-  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
@@ -4668,27 +5532,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %22
+ThrowNullRef12:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4701,8 +5565,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
@@ -4713,19 +5577,19 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
@@ -4734,8 +5598,8 @@ entry:
 
 ; <label>:15                                      ; preds = %1, %13
   %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
@@ -4746,19 +5610,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %15
+ThrowNullRef8:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4771,8 +5635,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -4831,8 +5695,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
@@ -4882,8 +5746,8 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
-  br i1 %NullCheck, label %17, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %ThrowNullRef, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
@@ -4894,15 +5758,15 @@ entry:
 
 ; <label>:22                                      ; preds = %17
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
-  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
   %26 = load i32, i32 addrspace(1)* %25
   %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
-  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %27, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
@@ -4925,8 +5789,8 @@ entry:
 ; <label>:40                                      ; preds = %17
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
-  br i1 %NullCheck6, label %43, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %41, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
@@ -4938,34 +5802,17 @@ ThrowNullRef:                                     ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %24
+ThrowNullRef4:                                    ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %40
+ThrowNullRef6:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
-}
-
-INFO:  jitting method Object::ReferenceEquals using LLILCJit
-Successfully read Object.ReferenceEquals
-
-define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
-entry:
-  %arg0 = alloca %System.Object addrspace(1)*
-  %arg1 = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
-  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
-  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = icmp eq %System.Object addrspace(1)* %0, %1
-  %3 = sext i1 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
 }
 
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
@@ -4978,21 +5825,21 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
   %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
-  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
@@ -5007,28 +5854,28 @@ entry:
 ; <label>:13                                      ; preds = %8, %12
   %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
   %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
   %21 = load i32, i32 addrspace(1)* %20, align 8
   %22 = add i32 %21, 1
-  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
   store i32 %22, i32 addrspace(1)* %24
   %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
@@ -5039,27 +5886,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5077,7 +5924,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::Setup using LLILCJit
-Failed to read AppDomain.Setup[loadElem]
+Failed to read AppDomain.Setup[unbox]
 INFO:  jitting method Thread::GetDomain using LLILCJit
 Successfully read Thread.GetDomain
 
@@ -5108,8 +5955,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
@@ -5122,14 +5969,14 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
   %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
@@ -5141,11 +5988,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5173,8 +6020,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -5189,7 +6036,328 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
 Failed to read KeyCollection.System.Collections.Generic.IEnumerable<TKey>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Successfully read Enumerator.MoveNext
+
+define i8 @Enumerator.MoveNext(%"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.RuntimeTypeHandle* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*
+  %"$TypeArg" = alloca %System.RuntimeTypeHandle*
+  store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
+  %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 8
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %76, label %12
+
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
+  br label %76
+
+; <label>:13                                      ; preds = %85
+  %14 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck19 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %15
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, i32 0, i32 0
+  %17 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %16, align 8
+  %NullCheck21 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, i32 0, i32 2
+  %20 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %19, align 8
+  %21 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck23 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %22
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, i32 0, i32 2
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %NullCheck25 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 3, i32 %24
+  %NullCheck27 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %32
+
+; <label>:32                                      ; preds = %30
+  %33 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, i32 0, i32 2
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = icmp slt i32 %34, 0
+  br i1 %35, label %68, label %36
+
+; <label>:36                                      ; preds = %32
+  %37 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %38 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck29 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %39
+
+; <label>:39                                      ; preds = %36
+  %40 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, i32 0, i32 0
+  %41 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %40, align 8
+  %NullCheck31 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, i32 0, i32 2
+  %44 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %43, align 8
+  %45 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck33 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, i32 0, i32 2
+  %48 = load i32, i32 addrspace(1)* %47, align 8
+  %NullCheck35 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %49
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = zext i32 %51 to i64
+  %53 = zext i32 %48 to i64
+  %BoundsCheck37 = icmp uge i64 %53, %52
+  br i1 %BoundsCheck37, label %ThrowIndexOutOfRange38, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 3, i32 %48
+  %NullCheck39 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %56
+
+; <label>:56                                      ; preds = %54
+  %57 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, i32 0, i32 0
+  %58 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck41 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %59
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %60, %System.__Canon addrspace(1)* %58)
+  %61 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck43 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  %64 = load i32, i32 addrspace(1)* %63, align 8
+  %65 = add i32 %64, 1
+  %NullCheck45 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  store i32 %65, i32 addrspace(1)* %67
+  ret i8 1
+
+; <label>:68                                      ; preds = %32
+  %69 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck47 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %73 = add i32 %72, 1
+  %NullCheck49 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %74
+
+; <label>:74                                      ; preds = %70
+  %75 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  store i32 %73, i32 addrspace(1)* %75
+  br label %76
+
+; <label>:76                                      ; preds = %8, %12, %74
+  %77 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %78
+
+; <label>:78                                      ; preds = %76
+  %79 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, i32 0, i32 2
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck7 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %82
+
+; <label>:82                                      ; preds = %78
+  %83 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, i32 0, i32 0
+  %84 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %83, align 8
+  %NullCheck9 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %85
+
+; <label>:85                                      ; preds = %82
+  %86 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, i32 0, i32 7
+  %87 = load i32, i32 addrspace(1)* %86, align 8
+  %88 = icmp ult i32 %80, %87
+  br i1 %88, label %13, label %89
+
+; <label>:89                                      ; preds = %85
+  %90 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %91 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck11 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %92
+
+; <label>:92                                      ; preds = %89
+  %93 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, i32 0, i32 0
+  %94 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck13 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %95
+
+; <label>:95                                      ; preds = %92
+  %96 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, i32 0, i32 7
+  %97 = load i32, i32 addrspace(1)* %96, align 8
+  %98 = add i32 %97, 1
+  %NullCheck15 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %99
+
+; <label>:99                                      ; preds = %95
+  %100 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, i32 0, i32 2
+  store i32 %98, i32 addrspace(1)* %100
+  %101 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck17 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %102
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %103, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %92
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef22:                                   ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef24:                                   ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef26:                                   ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef28:                                   ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef30:                                   ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef32:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef34:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef36:                                   ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange38:                           ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef40:                                   ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef42:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef44:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef46:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef48:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef50:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -5200,8 +6368,8 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -5232,9 +6400,9 @@ Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
 Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
-Failed to read String.MakeSeparatorList[loadElemA]
+Failed to read String.MakeSeparatorList[storeElem]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
-Failed to read String.InternalSplitKeepEmptyEntries[loadElem]
+Failed to read String.InternalSplitKeepEmptyEntries[storeElem]
 INFO:  jitting method Path::IsRelative using LLILCJit
 Successfully read Path.IsRelative
 
@@ -5243,8 +6411,8 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -5254,8 +6422,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
@@ -5271,8 +6439,8 @@ entry:
 
 ; <label>:17                                      ; preds = %7
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
@@ -5288,8 +6456,8 @@ entry:
 
 ; <label>:29                                      ; preds = %19
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %31
 
 ; <label>:31                                      ; preds = %29
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
@@ -5300,8 +6468,8 @@ entry:
 
 ; <label>:36                                      ; preds = %31
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
-  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %37, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
@@ -5312,8 +6480,8 @@ entry:
 
 ; <label>:43                                      ; preds = %31, %38
   %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
-  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %45
 
 ; <label>:45                                      ; preds = %43
   %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
@@ -5324,8 +6492,8 @@ entry:
 
 ; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %50
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
@@ -5336,8 +6504,8 @@ entry:
 
 ; <label>:57                                      ; preds = %1, %7, %19, %45, %52
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
-  br i1 %NullCheck14, label %59, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %59
 
 ; <label>:59                                      ; preds = %57
   %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
@@ -5347,8 +6515,8 @@ entry:
 
 ; <label>:63                                      ; preds = %59
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
@@ -5359,8 +6527,8 @@ entry:
 
 ; <label>:70                                      ; preds = %65
   %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
-  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.String addrspace(1)* %71, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %72
 
 ; <label>:72                                      ; preds = %70
   %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
@@ -5379,39 +6547,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %17
+ThrowNullRef4:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %29
+ThrowNullRef6:                                    ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %36
+ThrowNullRef8:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %43
+ThrowNullRef10:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %50
+ThrowNullRef12:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %57
+ThrowNullRef14:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %63
+ThrowNullRef16:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %70
+ThrowNullRef18:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5419,7 +6587,293 @@ ThrowNullRef17:                                   ; preds = %70
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
-Failed to read String.TrimHelper[loadElem]
+Successfully read String.TrimHelper
+
+define %System.String addrspace(1)* @String.TrimHelper(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i16
+  %loc4 = alloca i32
+  %loc5 = alloca i16
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = sub i32 %3, 1
+  store i32 %4, i32* %loc0
+  store i32 0, i32* %loc1
+  %5 = load i32, i32* %arg2
+  %6 = icmp eq i32 %5, 1
+  br i1 %6, label %62, label %7
+
+; <label>:7                                       ; preds = %1
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:8                                       ; preds = %58
+  store i32 0, i32* %loc2
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load i32, i32* %loc1
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2, i32 %10
+  %13 = load i16, i16 addrspace(1)* %12
+  %14 = zext i16 %13 to i32
+  %15 = trunc i32 %14 to i16
+  store i16 %15, i16* %loc3
+  store i32 0, i32* %loc2
+  br label %34
+
+; <label>:16                                      ; preds = %37
+  %17 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %18 = load i32, i32* %loc2
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %17, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %19
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = zext i32 %18 to i64
+  %BoundsCheck = icmp uge i64 %23, %22
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %24
+
+; <label>:24                                      ; preds = %19
+  %25 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 3, i32 %18
+  %26 = load i16, i16 addrspace(1)* %25, align 8
+  %27 = zext i16 %26 to i32
+  %28 = load i16, i16* %loc3
+  %29 = zext i16 %28 to i32
+  %30 = icmp eq i32 %27, %29
+  br i1 %30, label %43, label %31
+
+; <label>:31                                      ; preds = %24
+  %32 = load i32, i32* %loc2
+  %33 = add i32 %32, 1
+  store i32 %33, i32* %loc2
+  br label %34
+
+; <label>:34                                      ; preds = %11, %31
+  %35 = load i32, i32* %loc2
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = icmp slt i32 %35, %41
+  br i1 %42, label %16, label %43
+
+; <label>:43                                      ; preds = %24, %37
+  %44 = load i32, i32* %loc2
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %45, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp eq i32 %44, %50
+  br i1 %51, label %62, label %52
+
+; <label>:52                                      ; preds = %46
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %7, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %57, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %58
+
+; <label>:58                                      ; preds = %55
+  %59 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %60 = load i32, i32 addrspace(1)* %59
+  %61 = icmp slt i32 %56, %60
+  br i1 %61, label %8, label %62
+
+; <label>:62                                      ; preds = %1, %46, %58
+  %63 = load i32, i32* %arg2
+  %64 = icmp eq i32 %63, 0
+  br i1 %64, label %122, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %66, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %67
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %66, i32 0, i32 1
+  %69 = load i32, i32 addrspace(1)* %68
+  %70 = sub i32 %69, 1
+  store i32 %70, i32* %loc0
+  br label %118
+
+; <label>:71                                      ; preds = %118
+  store i32 0, i32* %loc4
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %73 = load i32, i32* %loc0
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %74
+
+; <label>:74                                      ; preds = %71
+  %75 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 2, i32 %73
+  %76 = load i16, i16 addrspace(1)* %75
+  %77 = zext i16 %76 to i32
+  %78 = trunc i32 %77 to i16
+  store i16 %78, i16* %loc5
+  store i32 0, i32* %loc4
+  br label %97
+
+; <label>:79                                      ; preds = %100
+  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %81 = load i32, i32* %loc4
+  %NullCheck19 = icmp eq %"System.Char[]" addrspace(1)* %80, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
+
+; <label>:82                                      ; preds = %79
+  %83 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 1
+  %84 = load i32, i32 addrspace(1)* %83
+  %85 = zext i32 %84 to i64
+  %86 = zext i32 %81 to i64
+  %BoundsCheck21 = icmp uge i64 %86, %85
+  br i1 %BoundsCheck21, label %ThrowIndexOutOfRange22, label %87
+
+; <label>:87                                      ; preds = %82
+  %88 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 3, i32 %81
+  %89 = load i16, i16 addrspace(1)* %88, align 8
+  %90 = zext i16 %89 to i32
+  %91 = load i16, i16* %loc5
+  %92 = zext i16 %91 to i32
+  %93 = icmp eq i32 %90, %92
+  br i1 %93, label %106, label %94
+
+; <label>:94                                      ; preds = %87
+  %95 = load i32, i32* %loc4
+  %96 = add i32 %95, 1
+  store i32 %96, i32* %loc4
+  br label %97
+
+; <label>:97                                      ; preds = %74, %94
+  %98 = load i32, i32* %loc4
+  %99 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck15 = icmp eq %"System.Char[]" addrspace(1)* %99, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %100
+
+; <label>:100                                     ; preds = %97
+  %101 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %99, i32 0, i32 1
+  %102 = load i32, i32 addrspace(1)* %101
+  %103 = zext i32 %102 to i64
+  %104 = trunc i64 %103 to i32
+  %105 = icmp slt i32 %98, %104
+  br i1 %105, label %79, label %106
+
+; <label>:106                                     ; preds = %87, %100
+  %107 = load i32, i32* %loc4
+  %108 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck17 = icmp eq %"System.Char[]" addrspace(1)* %108, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %109
+
+; <label>:109                                     ; preds = %106
+  %110 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %108, i32 0, i32 1
+  %111 = load i32, i32 addrspace(1)* %110
+  %112 = zext i32 %111 to i64
+  %113 = trunc i64 %112 to i32
+  %114 = icmp eq i32 %107, %113
+  br i1 %114, label %122, label %115
+
+; <label>:115                                     ; preds = %109
+  %116 = load i32, i32* %loc0
+  %117 = sub i32 %116, 1
+  store i32 %117, i32* %loc0
+  br label %118
+
+; <label>:118                                     ; preds = %67, %115
+  %119 = load i32, i32* %loc0
+  %120 = load i32, i32* %loc1
+  %121 = icmp sge i32 %119, %120
+  br i1 %121, label %71, label %122
+
+; <label>:122                                     ; preds = %62, %109, %118
+  %123 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %124 = load i32, i32* %loc1
+  %125 = load i32, i32* %loc0
+  %126 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %123, i32 %124, i32 %125)
+  ret %System.String addrspace(1)* %126
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %97
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange22:                           ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
 Successfully read String.CreateTrimmedString
 
@@ -5439,8 +6893,8 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
@@ -5535,8 +6989,8 @@ entry:
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i64 2872
   %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
   %8 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %7
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %3
   %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
@@ -5553,8 +7007,8 @@ entry:
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 2864
   %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
   %21 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %20
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
-  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %22
 
 ; <label>:22                                      ; preds = %16
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
@@ -5569,7 +7023,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %16
+ThrowNullRef2:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5586,8 +7040,8 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5613,8 +7067,8 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
@@ -5632,8 +7086,8 @@ entry:
 
 ; <label>:12                                      ; preds = %4
   %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
@@ -5644,8 +7098,8 @@ entry:
 
 ; <label>:19                                      ; preds = %14
   %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %19
   %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
@@ -5660,21 +7114,21 @@ entry:
   %31 = zext i16 %30 to i32
   %32 = bitcast i8* %29 to i16*
   %33 = trunc i32 %31 to i16
-  %NullCheck6 = icmp ne i16* %32, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i16* %32, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %21
   store i16 %33, i16* %32, align 8
   %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %36
 
 ; <label>:36                                      ; preds = %34
   %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
   %38 = load i32, i32 addrspace(1)* %37, align 8
   %39 = add i32 %38, 1
-  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %40
 
 ; <label>:40                                      ; preds = %36
   %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
@@ -5683,16 +7137,16 @@ entry:
 
 ; <label>:42                                      ; preds = %14
   %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
-  br i1 %NullCheck12, label %44, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
   %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
   %47 = load i16, i16* %arg1
   %48 = zext i16 %47 to i32
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = trunc i32 %48 to i16
@@ -5703,31 +7157,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %19
+ThrowNullRef4:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %21
+ThrowNullRef6:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %36
+ThrowNullRef10:                                   ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %42
+ThrowNullRef12:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %44
+ThrowNullRef14:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5740,8 +7194,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -5752,8 +7206,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
@@ -5762,14 +7216,14 @@ entry:
 
 ; <label>:11                                      ; preds = %1
   %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
@@ -5779,15 +7233,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5808,8 +7262,8 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5822,8 +7276,8 @@ entry:
 
 ; <label>:8                                       ; preds = %3
   %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
@@ -5842,15 +7296,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
-  br i1 %NullCheck4, label %22, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
   %24 = load i16*, i16* addrspace(1)* %23, align 8
   %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %25, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
@@ -5859,8 +7313,8 @@ entry:
   store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
@@ -5874,8 +7328,8 @@ entry:
 
 ; <label>:37                                      ; preds = %65
   %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %37
   %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
@@ -5886,16 +7340,16 @@ entry:
   %45 = bitcast i16* %41 to i8*
   %46 = getelementptr inbounds i8, i8* %45, i64 %44
   %47 = bitcast i8* %46 to i16*
-  %NullCheck14 = icmp ne i16* %47, null
-  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %47, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %48
 
 ; <label>:48                                      ; preds = %39
   %49 = load i16, i16* %47, align 8
   %50 = zext i16 %49 to i32
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %52 = load i32, i32* %loc1
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %53
 
 ; <label>:53                                      ; preds = %48
   %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
@@ -5916,8 +7370,8 @@ entry:
 ; <label>:62                                      ; preds = %36, %59
   %63 = load i32, i32* %loc1
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck10, label %65, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %65
 
 ; <label>:65                                      ; preds = %62
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
@@ -5936,15 +7390,15 @@ entry:
 
 ; <label>:74                                      ; preds = %70
   %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
-  br i1 %NullCheck18, label %76, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %76
 
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
   %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
-  br i1 %NullCheck20, label %80, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
   %81 = load i64, i64 addrspace(1)* %79
@@ -5958,8 +7412,8 @@ entry:
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
   %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
-  br i1 %NullCheck22, label %92, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.String addrspace(1)* %90, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %92
 
 ; <label>:92                                      ; preds = %80
   %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
@@ -5969,15 +7423,15 @@ entry:
 
 ; <label>:96                                      ; preds = %70
   %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
-  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %98
 
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
   %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
-  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
   %103 = load i64, i64 addrspace(1)* %101
@@ -5991,8 +7445,8 @@ entry:
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
   %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
-  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.String addrspace(1)* %112, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %114
 
 ; <label>:114                                     ; preds = %102
   %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
@@ -6004,59 +7458,59 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %20
+ThrowNullRef4:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %22
+ThrowNullRef6:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %26
+ThrowNullRef8:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %62
+ThrowNullRef10:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %48
+ThrowNullRef16:                                   ; preds = %48
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %74
+ThrowNullRef18:                                   ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %76
+ThrowNullRef20:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %80
+ThrowNullRef22:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %96
+ThrowNullRef24:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %98
+ThrowNullRef26:                                   ; preds = %98
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %102
+ThrowNullRef28:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6069,15 +7523,15 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
   %3 = load i16*, i16* addrspace(1)* %2, align 8
   %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
@@ -6087,8 +7541,8 @@ entry:
   %10 = bitcast i16* %3 to i8*
   %11 = getelementptr inbounds i8, i8* %10, i64 %9
   %12 = bitcast i8* %11 to i16*
-  %NullCheck4 = icmp ne i16* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %5
   store i16 0, i16* %12, align 8
@@ -6098,11 +7552,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6119,8 +7573,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -6131,8 +7585,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
@@ -6144,15 +7598,15 @@ entry:
 
 ; <label>:14                                      ; preds = %1
   %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
   %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
   %21 = load i64, i64 addrspace(1)* %19
@@ -6171,15 +7625,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %14
+ThrowNullRef4:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %16
+ThrowNullRef6:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6302,14 +7756,6 @@ entry:
   ret %System.String addrspace(1)* %57
 }
 
-INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
-Successfully read RuntimeHelpers.get_OffsetToStringData
-
-define i32 @RuntimeHelpers.get_OffsetToStringData() {
-entry:
-  ret i32 12
-}
-
 INFO:  jitting method String::Equals using LLILCJit
 Successfully read String.Equals
 
@@ -6381,8 +7827,8 @@ entry:
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
-  br i1 %NullCheck24, label %29, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
   %30 = load i64, i64 addrspace(1)* %28
@@ -6397,8 +7843,8 @@ entry:
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
-  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
   %43 = load i64, i64 addrspace(1)* %41
@@ -6418,8 +7864,8 @@ entry:
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
   %59 = load i64, i64 addrspace(1)* %57
@@ -6434,8 +7880,8 @@ entry:
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck22, label %71, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
   %72 = load i64, i64 addrspace(1)* %70
@@ -6455,8 +7901,8 @@ entry:
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
-  br i1 %NullCheck16, label %87, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = load i64, i64 addrspace(1)* %86
@@ -6471,8 +7917,8 @@ entry:
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck18, label %100, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
   %101 = load i64, i64 addrspace(1)* %99
@@ -6492,8 +7938,8 @@ entry:
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
-  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
   %117 = load i64, i64 addrspace(1)* %115
@@ -6508,8 +7954,8 @@ entry:
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
-  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
   %130 = load i64, i64 addrspace(1)* %128
@@ -6528,15 +7974,15 @@ entry:
 
 ; <label>:142                                     ; preds = %22
   %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
-  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %143, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %144
 
 ; <label>:144                                     ; preds = %142
   %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
   %146 = load i32, i32 addrspace(1)* %145
   %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
-  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %147, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %148
 
 ; <label>:148                                     ; preds = %144
   %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
@@ -6557,15 +8003,15 @@ entry:
 
 ; <label>:159                                     ; preds = %22
   %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
-  br i1 %NullCheck, label %161, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %ThrowNullRef, label %161
 
 ; <label>:161                                     ; preds = %159
   %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
   %163 = load i32, i32 addrspace(1)* %162
   %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
-  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %164, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %165
 
 ; <label>:165                                     ; preds = %161
   %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
@@ -6578,8 +8024,8 @@ entry:
 
 ; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
-  br i1 %NullCheck4, label %172, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %171, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %172
 
 ; <label>:172                                     ; preds = %170
   %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
@@ -6589,8 +8035,8 @@ entry:
 
 ; <label>:176                                     ; preds = %172
   %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
-  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %177, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %178
 
 ; <label>:178                                     ; preds = %176
   %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
@@ -6629,55 +8075,55 @@ ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %161
+ThrowNullRef2:                                    ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %170
+ThrowNullRef4:                                    ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %176
+ThrowNullRef6:                                    ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %142
+ThrowNullRef8:                                    ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %144
+ThrowNullRef10:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %113
+ThrowNullRef12:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %116
+ThrowNullRef14:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %84
+ThrowNullRef16:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %87
+ThrowNullRef18:                                   ; preds = %87
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %55
+ThrowNullRef20:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %58
+ThrowNullRef22:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %26
+ThrowNullRef24:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %29
+ThrowNullRef26:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,8 +8161,8 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck, label %14, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %ThrowNullRef, label %14
 
 ; <label>:14                                      ; preds = %8
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
@@ -6760,8 +8206,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
@@ -6770,14 +8216,14 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32, i32* %loc0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %10
   %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
   %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
@@ -6790,15 +8236,15 @@ entry:
 ; <label>:25                                      ; preds = %19
   %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
-  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
   %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
@@ -6807,8 +8253,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %37 = load i32, i32* %loc0
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %38, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %38
 
 ; <label>:38                                      ; preds = %32
   %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
@@ -6817,14 +8263,14 @@ entry:
 
 ; <label>:40                                      ; preds = %19
   %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %40
   %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
   %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
-  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
-  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
@@ -6832,8 +8278,8 @@ entry:
   %48 = zext i32 %47 to i64
   %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
-  br i1 %NullCheck16, label %51, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %51
 
 ; <label>:51                                      ; preds = %45
   %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
@@ -6847,15 +8293,15 @@ entry:
 ; <label>:57                                      ; preds = %51
   %58 = load i16*, i16** %arg1
   %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
-  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %60
 
 ; <label>:60                                      ; preds = %57
   %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
   %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
-  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %64
 
 ; <label>:64                                      ; preds = %60
   %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
@@ -6864,22 +8310,22 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
   %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
-  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %70
 
 ; <label>:70                                      ; preds = %64
   %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
   %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
-  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
-  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
   %75 = load i32, i32 addrspace(1)* %74
   %76 = zext i32 %75 to i64
   %77 = trunc i64 %76 to i32
-  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
-  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %78
 
 ; <label>:78                                      ; preds = %73
   %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
@@ -6901,8 +8347,8 @@ entry:
   %90 = bitcast i16* %86 to i8*
   %91 = getelementptr inbounds i8, i8* %90, i64 %89
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %93
 
 ; <label>:93                                      ; preds = %80
   %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
@@ -6912,8 +8358,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %99 = load i32, i32* %loc2
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %100
 
 ; <label>:100                                     ; preds = %93
   %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
@@ -6928,63 +8374,63 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %25
+ThrowNullRef6:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %32
+ThrowNullRef10:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %40
+ThrowNullRef12:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %45
+ThrowNullRef16:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %57
+ThrowNullRef18:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %60
+ThrowNullRef20:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %64
+ThrowNullRef22:                                   ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %70
+ThrowNullRef24:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %73
+ThrowNullRef26:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %80
+ThrowNullRef28:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %93
+ThrowNullRef30:                                   ; preds = %93
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7004,8 +8450,8 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
@@ -7033,43 +8479,43 @@ entry:
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %14
   %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
   %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   %28 = load i32, i32 addrspace(1)* %27, align 8
   %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
-  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %30
 
 ; <label>:30                                      ; preds = %26
   %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
   %32 = load i32, i32 addrspace(1)* %31, align 8
   %33 = add i32 %28, %32
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %34
 
 ; <label>:34                                      ; preds = %30
   %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   store i32 %33, i32 addrspace(1)* %35
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
   store i32 0, i32 addrspace(1)* %38
   %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %40
 
 ; <label>:40                                      ; preds = %37
   %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
@@ -7082,8 +8528,8 @@ entry:
 
 ; <label>:47                                      ; preds = %40
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
@@ -7098,8 +8544,8 @@ entry:
   %54 = load i32, i32* %loc0
   %55 = sext i32 %54 to i64
   %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
-  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %57
 
 ; <label>:57                                      ; preds = %52
   %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
@@ -7110,68 +8556,35 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %14
+ThrowNullRef2:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %23
+ThrowNullRef4:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %26
+ThrowNullRef6:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %30
+ThrowNullRef8:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %34
+ThrowNullRef10:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %47
+ThrowNullRef14:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %52
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-}
-
-INFO:  jitting method StringBuilder::get_Length using LLILCJit
-Successfully read StringBuilder.get_Length
-
-define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.StringBuilder addrspace(1)*
-  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
-  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
-
-; <label>:1                                       ; preds = %entry
-  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %3 = load i32, i32 addrspace(1)* %2, align 8
-  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
-
-; <label>:5                                       ; preds = %1
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = add i32 %3, %7
-  ret i32 %8
-
-ThrowNullRef:                                     ; preds = %entry
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef16:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7213,70 +8626,70 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
   %6 = load i32, i32 addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
   store i32 %6, i32 addrspace(1)* %8
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
   %13 = load i32, i32 addrspace(1)* %12, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
   store i32 %13, i32 addrspace(1)* %15
   %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
-  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %18
 
 ; <label>:18                                      ; preds = %14
   %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
   %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
   %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
   %34 = load i32, i32 addrspace(1)* %33, align 8
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
-  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
@@ -7287,39 +8700,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %28
+ThrowNullRef16:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %32
+ThrowNullRef18:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7455,13 +8868,13 @@ entry:
 ; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
@@ -7477,16 +8890,16 @@ entry:
 
 ; <label>:18                                      ; preds = %15
   %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
   store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
   %22 = load i32, i32* %loc0
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %24
 
 ; <label>:24                                      ; preds = %20
   %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
@@ -7498,13 +8911,13 @@ entry:
 ; <label>:28                                      ; preds = %15, %24
   %29 = load i32, i32* %arg1
   %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %31
   %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
@@ -7517,20 +8930,20 @@ entry:
   %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
-  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
   %46 = load i32, i32 addrspace(1)* %45, align 8
   %47 = sub i32 %40, %46
-  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
-  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i32 addrspace(1)* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %48
 
 ; <label>:48                                      ; preds = %44
   store i32 %47, i32 addrspace(1)* %39, align 8
@@ -7538,21 +8951,21 @@ entry:
 
 ; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
-  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %51
 
 ; <label>:51                                      ; preds = %49
   %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %53
 
 ; <label>:53                                      ; preds = %51
   %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
   %55 = load i32, i32 addrspace(1)* %54, align 8
   %56 = load i32, i32* %arg2
   %57 = sub i32 %55, %56
-  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %58
 
 ; <label>:58                                      ; preds = %53
   %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
@@ -7562,13 +8975,13 @@ entry:
 ; <label>:60                                      ; preds = %33, %58
   %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
   %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
-  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %63
 
 ; <label>:63                                      ; preds = %60
   %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
-  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
-  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
@@ -7578,15 +8991,15 @@ entry:
 
 ; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
-  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i32 addrspace(1)* %69, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %70
 
 ; <label>:70                                      ; preds = %68
   %71 = load i32, i32 addrspace(1)* %69, align 8
   store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
-  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
@@ -7596,8 +9009,8 @@ entry:
   store i32 %77, i32* %loc4
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
-  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %80
 
 ; <label>:80                                      ; preds = %73
   %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
@@ -7607,71 +9020,71 @@ entry:
 ; <label>:83                                      ; preds = %80
   store i32 0, i32* %loc3
   %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
-  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
-  br i1 %NullCheck26, label %88, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i32 addrspace(1)* %87, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %88
 
 ; <label>:88                                      ; preds = %85
   %89 = load i32, i32 addrspace(1)* %87, align 8
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
-  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %90
 
 ; <label>:90                                      ; preds = %88
   %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
   store i32 %89, i32 addrspace(1)* %91
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
-  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
-  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %96
 
 ; <label>:96                                      ; preds = %94
   %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
-  br i1 %NullCheck34, label %100, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %100
 
 ; <label>:100                                     ; preds = %96
   %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
-  br i1 %NullCheck36, label %102, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %102
 
 ; <label>:102                                     ; preds = %100
   %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
   %104 = load i32, i32 addrspace(1)* %103, align 8
   %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
-  br i1 %NullCheck38, label %106, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %106
 
 ; <label>:106                                     ; preds = %102
   %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
-  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
-  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %108
 
 ; <label>:108                                     ; preds = %106
   %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
   %110 = load i32, i32 addrspace(1)* %109, align 8
   %111 = add i32 %104, %110
-  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %112
 
 ; <label>:112                                     ; preds = %108
   %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
   store i32 %111, i32 addrspace(1)* %113
   %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
-  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i32 addrspace(1)* %114, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %115
 
 ; <label>:115                                     ; preds = %112
   %116 = load i32, i32 addrspace(1)* %114, align 8
@@ -7681,19 +9094,19 @@ entry:
 ; <label>:118                                     ; preds = %115
   %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
-  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %121
 
 ; <label>:121                                     ; preds = %118
   %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
-  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
-  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %123
 
 ; <label>:123                                     ; preds = %121
   %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
   %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
-  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
-  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %126
 
 ; <label>:126                                     ; preds = %123
   %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
@@ -7705,8 +9118,8 @@ entry:
 
 ; <label>:130                                     ; preds = %80, %115, %126
   %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %132
 
 ; <label>:132                                     ; preds = %130
   %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7715,8 +9128,8 @@ entry:
   %136 = load i32, i32* %loc3
   %137 = sub i32 %135, %136
   %138 = sub i32 %134, %137
-  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %139
 
 ; <label>:139                                     ; preds = %132
   %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7728,16 +9141,16 @@ entry:
 
 ; <label>:144                                     ; preds = %139
   %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
-  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %146
 
 ; <label>:146                                     ; preds = %144
   %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
   %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
   %149 = load i32, i32* %loc2
   %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
-  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %151
 
 ; <label>:151                                     ; preds = %146
   %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
@@ -7754,145 +9167,249 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %18
+ThrowNullRef4:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %31
+ThrowNullRef10:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %44
+ThrowNullRef16:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %68
+ThrowNullRef18:                                   ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %70
+ThrowNullRef20:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %73
+ThrowNullRef22:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %83
+ThrowNullRef24:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %85
+ThrowNullRef26:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %88
+ThrowNullRef28:                                   ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %90
+ThrowNullRef30:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %94
+ThrowNullRef32:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %96
+ThrowNullRef34:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %100
+ThrowNullRef36:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %102
+ThrowNullRef38:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %106
+ThrowNullRef40:                                   ; preds = %106
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %108
+ThrowNullRef42:                                   ; preds = %108
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %112
+ThrowNullRef44:                                   ; preds = %112
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %118
+ThrowNullRef46:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %121
+ThrowNullRef48:                                   ; preds = %121
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %123
+ThrowNullRef50:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %130
+ThrowNullRef52:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %132
+ThrowNullRef54:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %144
+ThrowNullRef56:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %146
+ThrowNullRef58:                                   ; preds = %146
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %60
+ThrowNullRef60:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %63
+ThrowNullRef62:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %49
+ThrowNullRef64:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %51
+ThrowNullRef66:                                   ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %53
+ThrowNullRef68:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(%"System.Char[]" addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %arg0 = alloca %"System.Char[]" addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store %"System.Char[]" addrspace(1)* %param0, %"System.Char[]" addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load i32, i32* %arg4
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %43, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %38, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg1
+  %13 = load i32, i32* %arg4
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %38, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %24 = load i32, i32* %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %35 = load i32, i32* %arg3
+  %36 = load i32, i32* %arg4
+  %37 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %37, %"System.Char[]" addrspace(1)* %34, i32 %35, i32 %36)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:38                                      ; preds = %5, %16
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Successfully read Buffer._Memmove
 
@@ -7914,7 +9431,7 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[loadElem]
+Failed to read AppDomain.SetDataHelper[storeElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -7923,8 +9440,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
@@ -7934,8 +9451,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
@@ -7947,15 +9464,15 @@ entry:
   %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
   %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
@@ -7966,15 +9483,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7992,7 +9509,79 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
-Failed to read Dictionary`2.TryGetValue[loadElemA]
+Successfully read Dictionary`2.TryGetValue
+
+define i8 @"Dictionary`2.TryGetValue"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)* addrspace(1)* %param2) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  %arg2 = alloca %System.__Canon addrspace(1)* addrspace(1)*
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  store %System.__Canon addrspace(1)* addrspace(1)* %param2, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  store i32 %2, i32* %loc0
+  %3 = load i32, i32* %loc0
+  %4 = icmp slt i32 %3, 0
+  br i1 %4, label %22, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 2
+  %10 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %9, align 8
+  %11 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = zext i32 %11 to i64
+  %BoundsCheck = icmp uge i64 %16, %15
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 3, i32 %11
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %20, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %6, %System.__Canon addrspace(1)* %21)
+  ret i8 1
+
+; <label>:22                                      ; preds = %entry
+  %23 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %23, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -8058,8 +9647,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
@@ -8091,8 +9680,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
@@ -8171,15 +9760,15 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck, label %19, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %ThrowNullRef, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
   %21 = load i32, i32 addrspace(1)* %20
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
@@ -8202,7 +9791,7 @@ ThrowNullRef:                                     ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %19
+ThrowNullRef2:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8248,8 +9837,8 @@ entry:
   %0 = alloca %System.AppDomainHandle
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %1 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %1, i32 0, i32 15
@@ -8269,8 +9858,8 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
@@ -8286,7 +9875,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -8299,8 +9888,8 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -8327,8 +9916,8 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
@@ -8352,8 +9941,8 @@ entry:
   %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
   store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
@@ -8363,8 +9952,8 @@ entry:
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
@@ -8374,8 +9963,8 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %9
   %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
@@ -8384,8 +9973,8 @@ entry:
 
 ; <label>:18                                      ; preds = %3, %16
   %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
@@ -8397,15 +9986,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %18
+ThrowNullRef6:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8418,8 +10007,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
@@ -8453,15 +10042,15 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
@@ -8473,7 +10062,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8481,7 +10070,7 @@ ThrowNullRef1:                                    ; preds = %1
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
 Failed to read Dictionary`2.System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
@@ -8506,8 +10095,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
@@ -8524,8 +10113,8 @@ entry:
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -8544,7 +10133,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8577,8 +10166,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = load i64, i64* %arg2
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = trunc i32 %3 to i8
@@ -8634,46 +10223,46 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
   %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
-  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
-  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
-  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
@@ -8684,27 +10273,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %20
+ThrowNullRef12:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8717,8 +10306,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -8756,22 +10345,22 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
   %9 = load i64, i64 addrspace(1)* %8, align 8
   %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
   %13 = load i64, i64 addrspace(1)* %12, align 8
   %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %11
   %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
@@ -8788,11 +10377,11 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8882,8 +10471,8 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
@@ -8900,8 +10489,8 @@ entry:
 ; <label>:8                                       ; preds = %1
   %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
   %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
@@ -8911,15 +10500,15 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
   %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
   %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
-  br i1 %NullCheck6, label %21, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
@@ -8946,15 +10535,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8992,15 +10581,15 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
   store i8 %3, i8 addrspace(1)* %5
   %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
@@ -9011,7 +10600,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9027,8 +10616,8 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -9041,8 +10630,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
@@ -9058,7 +10647,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9080,8 +10669,8 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
@@ -9096,8 +10685,8 @@ entry:
 ; <label>:12                                      ; preds = %6
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
@@ -9112,8 +10701,8 @@ entry:
 ; <label>:21                                      ; preds = %15
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
@@ -9128,8 +10717,8 @@ entry:
 ; <label>:30                                      ; preds = %24
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %31, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
@@ -9144,8 +10733,8 @@ entry:
 ; <label>:39                                      ; preds = %33
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
-  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %40, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %42
 
 ; <label>:42                                      ; preds = %39
   %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
@@ -9164,19 +10753,19 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %21
+ThrowNullRef4:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %30
+ThrowNullRef6:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %39
+ThrowNullRef8:                                    ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9243,8 +10832,8 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
@@ -9264,57 +10853,57 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
   store i8 0, i8 addrspace(1)* %2
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
   store i8 0, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
   store i8 0, i8 addrspace(1)* %17
   %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
   store i8 0, i8 addrspace(1)* %20
   %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
-  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
@@ -9325,31 +10914,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %19
+ThrowNullRef14:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9367,8 +10956,8 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
@@ -9380,8 +10969,8 @@ entry:
 
 ; <label>:9                                       ; preds = %4
   %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %9
   %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
@@ -9395,7 +10984,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef2:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9420,8 +11009,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
@@ -9512,8 +11101,8 @@ entry:
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
@@ -9524,8 +11113,8 @@ entry:
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = load i64, i64 addrspace(1)* %12
@@ -9537,8 +11126,8 @@ entry:
   %20 = load i64, i64* %19
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
-  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %13
   %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
@@ -9555,8 +11144,8 @@ entry:
 ; <label>:30                                      ; preds = %25
   %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %32 = load i32, i32* %arg2
-  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
-  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
@@ -9570,15 +11159,15 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %30
+ThrowNullRef2:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9622,87 +11211,87 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
   %10 = load i8, i8 addrspace(1)* %9, align 8
   %11 = zext i8 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %8
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
   store i8 %12, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
   %19 = load i8, i8 addrspace(1)* %18, align 8
   %20 = zext i8 %19 to i32
   %21 = trunc i32 %20 to i8
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
   store i8 %21, i8 addrspace(1)* %23
   %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
   %28 = load i8, i8 addrspace(1)* %27, align 8
   %29 = zext i8 %28 to i32
   %30 = trunc i32 %29 to i8
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
-  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %31
 
 ; <label>:31                                      ; preds = %26
   %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
   store i8 %30, i8 addrspace(1)* %32
   %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
-  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
-  br i1 %NullCheck14, label %40, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %40
 
 ; <label>:40                                      ; preds = %35
   %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
   store i8 %39, i8 addrspace(1)* %41
   %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
-  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %44
 
 ; <label>:44                                      ; preds = %40
   %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
   %46 = load i8, i8 addrspace(1)* %45, align 8
   %47 = zext i8 %46 to i32
   %48 = trunc i32 %47 to i8
-  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
   store i8 %48, i8 addrspace(1)* %50
   %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
-  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
@@ -9713,29 +11302,29 @@ entry:
 ; <label>:56                                      ; preds = %52
   %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
-  br i1 %NullCheck22, label %59, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
   %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
   %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
-  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
-  br i1 %NullCheck24, label %63, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
   %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
-  br i1 %NullCheck26, label %66, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
   %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
-  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
-  br i1 %NullCheck28, label %69, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %69
 
 ; <label>:69                                      ; preds = %66
   %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
@@ -9744,15 +11333,15 @@ entry:
 
 ; <label>:71                                      ; preds = %105
   %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
-  br i1 %NullCheck34, label %73, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %73
 
 ; <label>:73                                      ; preds = %71
   %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
   %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
   %76 = load i32, i32* %loc0
-  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
-  br i1 %NullCheck36, label %77, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
@@ -9766,8 +11355,8 @@ entry:
 
 ; <label>:83                                      ; preds = %77
   %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
-  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
@@ -9775,14 +11364,14 @@ entry:
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
   %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
-  br i1 %NullCheck40, label %91, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
 ; <label>:91                                      ; preds = %85
   %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
   %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
-  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck42, label %94, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %94
 
 ; <label>:94                                      ; preds = %91
   %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
@@ -9798,14 +11387,14 @@ entry:
 ; <label>:99                                      ; preds = %69, %96
   %100 = load i32, i32* %loc0
   %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
-  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %102
 
 ; <label>:102                                     ; preds = %99
   %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
   %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
-  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
-  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
@@ -9819,87 +11408,87 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %26
+ThrowNullRef10:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %31
+ThrowNullRef12:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %35
+ThrowNullRef14:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %40
+ThrowNullRef16:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %56
+ThrowNullRef22:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %59
+ThrowNullRef24:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %63
+ThrowNullRef26:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %66
+ThrowNullRef28:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %102
+ThrowNullRef32:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %71
+ThrowNullRef34:                                   ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %73
+ThrowNullRef36:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %83
+ThrowNullRef38:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %85
+ThrowNullRef40:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %91
+ThrowNullRef42:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9943,15 +11532,15 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
   %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
@@ -9961,28 +11550,28 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
   %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %12
   %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
   %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
   %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
-  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
@@ -9993,23 +11582,23 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %12
+ThrowNullRef6:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10031,15 +11620,15 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
   %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = load i64, i64 addrspace(1)* %7
@@ -10077,13 +11666,13 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[loadElem]
+Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -10111,8 +11700,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -10182,8 +11771,8 @@ entry:
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load float, float* %arg0
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -10317,8 +11906,8 @@ entry:
   store i64 %param0, i64* %arg0
   store i64 %param1, i64* %arg1
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
@@ -10326,8 +11915,8 @@ entry:
   %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
   %5 = load i16*, i16* addrspace(1)* %4, align 8
   %6 = addrspacecast i64* %arg1 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = bitcast i64 addrspace(1)* %6 to i8 addrspace(1)*
@@ -10343,7 +11932,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10377,8 +11966,8 @@ entry:
   %1 = load i32, i32* %arg1
   %2 = sext i32 %1 to i64
   %3 = inttoptr i64 %2 to i16*
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -10431,8 +12020,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, i32)*)(%System.IO.ConsoleStream addrspace(1)* %2, i32 %1)
   %3 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %4 = load i64, i64* %arg1
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
@@ -10443,8 +12032,8 @@ entry:
   %10 = icmp eq i32 %9, 3
   %11 = sext i1 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %5
   %14 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, i32 0, i32 5
@@ -10455,7 +12044,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10478,8 +12067,8 @@ entry:
   %5 = icmp eq i32 %4, 1
   %6 = sext i1 %5 to i32
   %7 = trunc i32 %6 to i8
-  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %2, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.ConsoleStream addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
@@ -10490,8 +12079,8 @@ entry:
   %13 = icmp eq i32 %12, 2
   %14 = sext i1 %13 to i32
   %15 = trunc i32 %14 to i8
-  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %10, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.ConsoleStream addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %8
   %17 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %10, i32 0, i32 4
@@ -10502,7 +12091,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10541,8 +12130,8 @@ entry:
   %arg0 = alloca i64
   store i64 %param0, i64* %arg0
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
@@ -10577,8 +12166,8 @@ entry:
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
   %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = load i64, i64 addrspace(1)* %7
@@ -10682,7 +12271,127 @@ entry:
 INFO:  jitting method Encoding::GetEncoding using LLILCJit
 Failed to read Encoding.GetEncoding[convertToHelperArgumentType]
 INFO:  jitting method EncodingProvider::GetEncodingFromProvider using LLILCJit
-Failed to read EncodingProvider.GetEncodingFromProvider[loadElem]
+Successfully read EncodingProvider.GetEncodingFromProvider
+
+define %System.Text.Encoding addrspace(1)* @EncodingProvider.GetEncodingFromProvider(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca %"System.Text.EncodingProvider[]" addrspace(1)*
+  %loc1 = alloca %System.Text.EncodingProvider addrspace(1)*
+  %loc2 = alloca %System.Text.Encoding addrspace(1)*
+  %loc3 = alloca %System.Text.Encoding addrspace(1)*
+  %loc4 = alloca %"System.Text.EncodingProvider[]" addrspace(1)*
+  %loc5 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1059)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2392
+  %2 = addrspacecast i8 addrspace(1)* %1 to %"System.Text.EncodingProvider[]" addrspace(1)**
+  %3 = load volatile %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %2
+  %4 = icmp ne %"System.Text.EncodingProvider[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %entry
+  ret %System.Text.Encoding addrspace(1)* null
+
+; <label>:6                                       ; preds = %entry
+  %7 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1059)
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i64 2392
+  %9 = addrspacecast i8 addrspace(1)* %8 to %"System.Text.EncodingProvider[]" addrspace(1)**
+  %10 = load volatile %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %9
+  store %"System.Text.EncodingProvider[]" addrspace(1)* %10, %"System.Text.EncodingProvider[]" addrspace(1)** %loc0
+  %11 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc0
+  store %"System.Text.EncodingProvider[]" addrspace(1)* %11, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  store i32 0, i32* %loc5
+  br label %43
+
+; <label>:12                                      ; preds = %46
+  %13 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  %14 = load i32, i32* %loc5
+  %NullCheck1 = icmp eq %"System.Text.EncodingProvider[]" addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %13, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = zext i32 %17 to i64
+  %19 = zext i32 %14 to i64
+  %BoundsCheck = icmp uge i64 %19, %18
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %20
+
+; <label>:20                                      ; preds = %15
+  %21 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %13, i32 0, i32 3, i32 %14
+  %22 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)* addrspace(1)* %21, align 8
+  store %System.Text.EncodingProvider addrspace(1)* %22, %System.Text.EncodingProvider addrspace(1)** %loc1
+  %23 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)** %loc1
+  %24 = load i32, i32* %arg0
+  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i64 addrspace(1)*
+  %NullCheck3 = icmp eq i64 addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
+
+; <label>:26                                      ; preds = %20
+  %27 = load i64, i64 addrspace(1)* %25
+  %28 = add i64 %27, 64
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 40
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Text.Encoding addrspace(1)* (%System.Text.EncodingProvider addrspace(1)*, i32)*
+  %35 = call %System.Text.Encoding addrspace(1)* %34(%System.Text.EncodingProvider addrspace(1)* %23, i32 %24)
+  store %System.Text.Encoding addrspace(1)* %35, %System.Text.Encoding addrspace(1)** %loc2
+  %36 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc2
+  %37 = icmp eq %System.Text.Encoding addrspace(1)* %36, null
+  br i1 %37, label %40, label %38
+
+; <label>:38                                      ; preds = %26
+  %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc2
+  store %System.Text.Encoding addrspace(1)* %39, %System.Text.Encoding addrspace(1)** %loc3
+  br label %53
+
+; <label>:40                                      ; preds = %26
+  %41 = load i32, i32* %loc5
+  %42 = add i32 %41, 1
+  store i32 %42, i32* %loc5
+  br label %43
+
+; <label>:43                                      ; preds = %6, %40
+  %44 = load i32, i32* %loc5
+  %45 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  %NullCheck = icmp eq %"System.Text.EncodingProvider[]" addrspace(1)* %45, null
+  br i1 %NullCheck, label %ThrowNullRef, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp slt i32 %44, %50
+  br i1 %51, label %12, label %52
+
+; <label>:52                                      ; preds = %46
+  ret %System.Text.Encoding addrspace(1)* null
+
+; <label>:53                                      ; preds = %38
+  %54 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc3
+  ret %System.Text.Encoding addrspace(1)* %54
+
+ThrowNullRef:                                     ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method EncodingProvider::.cctor using LLILCJit
 Successfully read EncodingProvider..cctor
 
@@ -10701,7 +12410,7 @@ Failed to read Encoding.get_InternalSyncObject[Call HasTypeArg]
 INFO:  jitting method Hashtable::.ctor using LLILCJit
 Failed to read Hashtable..ctor[Volatile store]
 INFO:  jitting method Hashtable::get_Item using LLILCJit
-Failed to read Hashtable.get_Item[loadElemA]
+Failed to read Hashtable.get_Item[loadNonPrimitiveObj]
 INFO:  jitting method Hashtable::InitHash using LLILCJit
 Successfully read Hashtable.InitHash
 
@@ -10721,8 +12430,8 @@ entry:
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -10738,15 +12447,15 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
   %15 = load i32, i32* %loc0
-  %NullCheck2 = icmp ne i32 addrspace(1)* %14, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i32 addrspace(1)* %14, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %3
   store i32 %15, i32 addrspace(1)* %14, align 8
   %17 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %18 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %NullCheck4 = icmp ne i32 addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i32 addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = load i32, i32 addrspace(1)* %18, align 8
@@ -10755,8 +12464,8 @@ entry:
   %23 = sub i32 %22, 1
   %24 = urem i32 %21, %23
   %25 = add i32 1, %24
-  %NullCheck6 = icmp ne i32 addrspace(1)* %17, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32 addrspace(1)* %17, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %19
   store i32 %25, i32 addrspace(1)* %17, align 8
@@ -10767,15 +12476,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %19
+ThrowNullRef6:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10790,8 +12499,8 @@ entry:
   store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
   store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %NullCheck = icmp ne %System.Collections.Hashtable addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Collections.Hashtable addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
@@ -10801,16 +12510,16 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Collections.Hashtable addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Collections.Hashtable addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
   %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck4 = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %9, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
   %13 = inttoptr i64 %11 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
@@ -10820,8 +12529,8 @@ entry:
 ; <label>:15                                      ; preds = %1
   %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -10839,15 +12548,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10861,8 +12570,8 @@ entry:
   store %System.Int32 addrspace(1)* %param0, %System.Int32 addrspace(1)** %this
   %0 = load %System.Int32 addrspace(1)*, %System.Int32 addrspace(1)** %this
   %1 = bitcast %System.Int32 addrspace(1)* %0 to i32 addrspace(1)*
-  %NullCheck = icmp ne i32 addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq i32 addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load i32, i32 addrspace(1)* %1, align 8
@@ -10938,8 +12647,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.UTF8Encoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
@@ -10948,15 +12657,15 @@ entry:
   %9 = load i8, i8* %arg2
   %10 = zext i8 %9 to i32
   %11 = trunc i32 %10 to i8
-  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %8, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %6
   %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %8, i32 0, i32 8
   store i8 %11, i8 addrspace(1)* %13
   %14 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %14, i32 0, i32 8
@@ -10968,8 +12677,8 @@ entry:
 ; <label>:20                                      ; preds = %15
   %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %22, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %22, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = load i64, i64 addrspace(1)* %22
@@ -10991,15 +12700,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %12
+ThrowNullRef4:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11014,8 +12723,8 @@ entry:
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
@@ -11037,16 +12746,16 @@ entry:
 ; <label>:10                                      ; preds = %1
   %11 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
   %12 = load i32, i32* %arg1
-  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %11, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.Encoding addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
   store i32 %12, i32 addrspace(1)* %14
   %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
   %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = load i64, i64 addrspace(1)* %16
@@ -11064,11 +12773,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11081,8 +12790,8 @@ entry:
   %this = alloca %System.Text.UTF8Encoding addrspace(1)*
   store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
   %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.UTF8Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
@@ -11094,16 +12803,16 @@ entry:
 ; <label>:6                                       ; preds = %1
   %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %8 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %10, %System.Text.EncoderFallback addrspace(1)* %8)
   %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %12 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
-  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %11, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %11, i32 0, i32 3
@@ -11116,8 +12825,8 @@ entry:
   %18 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %18, %System.String addrspace(1)* %17)
   %19 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %18 to %System.Text.EncoderFallback addrspace(1)*
-  %NullCheck6 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %16, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %16, i32 0, i32 2
@@ -11127,8 +12836,8 @@ entry:
   %24 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %24, %System.String addrspace(1)* %23)
   %25 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %24 to %System.Text.DecoderFallback addrspace(1)*
-  %NullCheck8 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %22, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %22, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %20
   %27 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %22, i32 0, i32 3
@@ -11139,19 +12848,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %20
+ThrowNullRef8:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11181,8 +12890,8 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load i32, i32* %arg1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -11200,8 +12909,8 @@ entry:
 ; <label>:15                                      ; preds = %8
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %17 = load i32, i32* %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 %17
@@ -11217,7 +12926,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11269,7 +12978,7 @@ entry:
 }
 
 INFO:  jitting method Hashtable::Insert using LLILCJit
-Failed to read Hashtable.Insert[loadElemA]
+Failed to read Hashtable.Insert[storeElem]
 INFO:  jitting method ConsoleEncoding::.ctor using LLILCJit
 Successfully read ConsoleEncoding..ctor
 
@@ -11284,8 +12993,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %1)
   %2 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
@@ -11321,8 +13030,8 @@ entry:
   %2 = call %System.Text.InternalEncoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalEncoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %1)
   %3 = bitcast %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2 to %System.Text.EncoderFallback addrspace(1)*
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
@@ -11332,8 +13041,8 @@ entry:
   %8 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %7)
   %9 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %8 to %System.Text.DecoderFallback addrspace(1)*
-  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %6, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.Encoding addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %4
   %11 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %6, i32 0, i32 3
@@ -11344,7 +13053,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11363,15 +13072,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* %1)
   %2 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   %6 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, i32 0, i32 1
@@ -11382,7 +13091,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11410,8 +13119,8 @@ entry:
   store %System.Text.InternalDecoderBestFitFallback addrspace(1)* %param0, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
   %0 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
@@ -11421,15 +13130,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %4)
   %5 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %6)
   %9 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, i32 0, i32 1
@@ -11440,11 +13149,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11512,8 +13221,8 @@ entry:
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
   %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = load i64, i64 addrspace(1)* %19
@@ -11577,8 +13286,8 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.ConsoleStream addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
@@ -11609,31 +13318,31 @@ entry:
   store i8 %param4, i8* %arg4
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %3, %System.IO.Stream addrspace(1)* %1)
   %4 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %4, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
   %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %4, i32 0, i32 4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %5)
   %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %6
   %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
   %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
   %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = load i64, i64 addrspace(1)* %13
@@ -11645,8 +13354,8 @@ entry:
   %21 = load i64, i64* %20
   %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %8, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %8, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %14
   %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 5
@@ -11664,24 +13373,24 @@ entry:
   %31 = load i32, i32* %arg3
   %32 = sext i32 %31 to i64
   %33 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %32)
-  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %30, null
-  br i1 %NullCheck10, label %34, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.StreamWriter addrspace(1)* %30, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %35, %"System.Char[]" addrspace(1)* %33)
   %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %37, null
-  br i1 %NullCheck12, label %38, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.StreamWriter addrspace(1)* %37, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %38
 
 ; <label>:38                                      ; preds = %34
   %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
   %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
   %41 = load i32, i32* %arg3
   %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %42, null
-  br i1 %NullCheck14, label %43, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %42, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
   %44 = load i64, i64 addrspace(1)* %42
@@ -11695,30 +13404,30 @@ entry:
   %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
   %53 = sext i32 %52 to i64
   %54 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %53)
-  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
-  br i1 %NullCheck16, label %55, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %55
 
 ; <label>:55                                      ; preds = %43
   %56 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %56, %"System.Byte[]" addrspace(1)* %54)
   %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %58 = load i32, i32* %arg3
-  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %57, null
-  br i1 %NullCheck18, label %59, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.StreamWriter addrspace(1)* %57, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %59
 
 ; <label>:59                                      ; preds = %55
   %60 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 10
   store i32 %58, i32 addrspace(1)* %60
   %61 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %61, null
-  br i1 %NullCheck20, label %62, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.IO.StreamWriter addrspace(1)* %61, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %62
 
 ; <label>:62                                      ; preds = %59
   %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
   %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
   %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
   %67 = load i64, i64 addrspace(1)* %65
@@ -11736,15 +13445,15 @@ entry:
 
 ; <label>:78                                      ; preds = %66
   %79 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %79, null
-  br i1 %NullCheck24, label %80, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.StreamWriter addrspace(1)* %79, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %80
 
 ; <label>:80                                      ; preds = %78
   %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
   %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
   %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %83, null
-  br i1 %NullCheck26, label %84, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %83, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
   %85 = load i64, i64 addrspace(1)* %83
@@ -11761,8 +13470,8 @@ entry:
 
 ; <label>:95                                      ; preds = %84
   %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.IO.StreamWriter addrspace(1)* %96, null
-  br i1 %NullCheck28, label %97, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.IO.StreamWriter addrspace(1)* %96, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %97
 
 ; <label>:97                                      ; preds = %95
   %98 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 12
@@ -11776,8 +13485,8 @@ entry:
   %103 = icmp eq i32 %102, 0
   %104 = sext i1 %103 to i32
   %105 = trunc i32 %104 to i8
-  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %100, null
-  br i1 %NullCheck30, label %106, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.IO.StreamWriter addrspace(1)* %100, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %106
 
 ; <label>:106                                     ; preds = %99
   %107 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %100, i32 0, i32 13
@@ -11788,63 +13497,63 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %6
+ThrowNullRef4:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %29
+ThrowNullRef10:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %34
+ThrowNullRef12:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %38
+ThrowNullRef14:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %43
+ThrowNullRef16:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %55
+ThrowNullRef18:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %59
+ThrowNullRef20:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %62
+ThrowNullRef22:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %78
+ThrowNullRef24:                                   ; preds = %78
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %80
+ThrowNullRef26:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %95
+ThrowNullRef28:                                   ; preds = %95
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11857,15 +13566,15 @@ entry:
   %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = load i64, i64 addrspace(1)* %4
@@ -11883,7 +13592,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11933,35 +13642,35 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
   %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderNLS addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %7 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.EncoderNLS addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Text.Encoding addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.Encoding addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Text.EncoderNLS addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.EncoderNLS addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
   %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck8 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = load i64, i64 addrspace(1)* %16
@@ -11980,19 +13689,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12018,8 +13727,8 @@ entry:
   %this = alloca %System.Text.Encoding addrspace(1)*
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
@@ -12039,15 +13748,15 @@ entry:
   %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
   store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
   %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
   store i32 0, i32 addrspace(1)* %2
   %3 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, i32 0, i32 2
@@ -12057,15 +13766,15 @@ entry:
 
 ; <label>:8                                       ; preds = %4
   %9 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
   %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
   %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = load i64, i64 addrspace(1)* %13
@@ -12086,15 +13795,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12109,16 +13818,16 @@ entry:
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = load i32, i32* %arg1
   %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
   %7 = load i64, i64 addrspace(1)* %5
@@ -12136,7 +13845,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12173,8 +13882,8 @@ entry:
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
   %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
   %16 = load i64, i64 addrspace(1)* %14
@@ -12195,8 +13904,8 @@ entry:
   %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
   %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
   %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %31, null
-  br i1 %NullCheck2, label %32, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = load i64, i64 addrspace(1)* %31
@@ -12239,7 +13948,7 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12252,14 +13961,14 @@ entry:
   %this = alloca %System.Text.EncoderReplacementFallback addrspace(1)*
   store %System.Text.EncoderReplacementFallback addrspace(1)* %param0, %System.Text.EncoderReplacementFallback addrspace(1)** %this
   %0 = load %System.Text.EncoderReplacementFallback addrspace(1)*, %System.Text.EncoderReplacementFallback addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -12270,7 +13979,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12300,8 +14009,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
@@ -12333,8 +14042,8 @@ entry:
   %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
   store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
@@ -12346,8 +14055,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Threading.Tasks.Task addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %7)
@@ -12370,7 +14079,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12389,8 +14098,8 @@ entry:
   store i8 %param1, i8* %arg1
   store i8 %param2, i8* %arg2
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
@@ -12404,8 +14113,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1, %5
   %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 9
@@ -12436,8 +14145,8 @@ entry:
 
 ; <label>:25                                      ; preds = %8, %20
   %26 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %26, null
-  br i1 %NullCheck4, label %27, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %26, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %26, i32 0, i32 12
@@ -12448,22 +14157,22 @@ entry:
 
 ; <label>:32                                      ; preds = %27
   %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %33, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.IO.StreamWriter addrspace(1)* %33, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %32
   %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 12
   store i8 1, i8 addrspace(1)* %35
   %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
-  br i1 %NullCheck8, label %37, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
   %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
   %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck10 = icmp ne i64 addrspace(1)* %40, null
-  br i1 %NullCheck10, label %41, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64 addrspace(1)* %40, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i64, i64 addrspace(1)* %40
@@ -12477,8 +14186,8 @@ entry:
   %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
   store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
   %51 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %NullCheck12 = icmp ne %"System.Byte[]" addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Byte[]" addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %41
   %53 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %51, i32 0, i32 1
@@ -12490,16 +14199,16 @@ entry:
 
 ; <label>:58                                      ; preds = %52
   %59 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %59, null
-  br i1 %NullCheck14, label %60, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.IO.StreamWriter addrspace(1)* %59, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %60
 
 ; <label>:60                                      ; preds = %58
   %61 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %59, i32 0, i32 3
   %62 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
   %64 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %NullCheck16 = icmp ne %"System.Byte[]" addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %"System.Byte[]" addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %60
   %66 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %64, i32 0, i32 1
@@ -12507,8 +14216,8 @@ entry:
   %68 = zext i32 %67 to i64
   %69 = trunc i64 %68 to i32
   %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck18, label %71, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
   %72 = load i64, i64 addrspace(1)* %70
@@ -12524,29 +14233,29 @@ entry:
 
 ; <label>:80                                      ; preds = %27, %52, %71
   %81 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %81, null
-  br i1 %NullCheck20, label %82, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.IO.StreamWriter addrspace(1)* %81, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
 
 ; <label>:82                                      ; preds = %80
   %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %81, i32 0, i32 5
   %84 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %83, align 8
   %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.IO.StreamWriter addrspace(1)* %85, null
-  br i1 %NullCheck22, label %86, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.IO.StreamWriter addrspace(1)* %85, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %86
 
 ; <label>:86                                      ; preds = %82
   %87 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 7
   %88 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %87, align 8
   %89 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %89, null
-  br i1 %NullCheck24, label %90, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.StreamWriter addrspace(1)* %89, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %90
 
 ; <label>:90                                      ; preds = %86
   %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %89, i32 0, i32 9
   %92 = load i32, i32 addrspace(1)* %91, align 8
   %93 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.IO.StreamWriter addrspace(1)* %93, null
-  br i1 %NullCheck26, label %94, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.IO.StreamWriter addrspace(1)* %93, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %93, i32 0, i32 6
@@ -12554,8 +14263,8 @@ entry:
   %97 = load i8, i8* %arg2
   %98 = zext i8 %97 to i32
   %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
-  %NullCheck28 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck28, label %100, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
   %101 = load i64, i64 addrspace(1)* %99
@@ -12570,8 +14279,8 @@ entry:
   %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
   store i32 %110, i32* %loc1
   %111 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %111, null
-  br i1 %NullCheck30, label %112, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.IO.StreamWriter addrspace(1)* %111, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %112
 
 ; <label>:112                                     ; preds = %100
   %113 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %111, i32 0, i32 9
@@ -12582,23 +14291,23 @@ entry:
 
 ; <label>:116                                     ; preds = %112
   %117 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck32 = icmp ne %System.IO.StreamWriter addrspace(1)* %117, null
-  br i1 %NullCheck32, label %118, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.IO.StreamWriter addrspace(1)* %117, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %118
 
 ; <label>:118                                     ; preds = %116
   %119 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %117, i32 0, i32 3
   %120 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %119, align 8
   %121 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.IO.StreamWriter addrspace(1)* %121, null
-  br i1 %NullCheck34, label %122, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.IO.StreamWriter addrspace(1)* %121, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %122
 
 ; <label>:122                                     ; preds = %118
   %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
   %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
   %125 = load i32, i32* %loc1
   %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
-  %NullCheck36 = icmp ne i64 addrspace(1)* %126, null
-  br i1 %NullCheck36, label %127, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64 addrspace(1)* %126, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
   %128 = load i64, i64 addrspace(1)* %126
@@ -12620,15 +14329,15 @@ entry:
 
 ; <label>:140                                     ; preds = %136
   %141 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.IO.StreamWriter addrspace(1)* %141, null
-  br i1 %NullCheck38, label %142, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.IO.StreamWriter addrspace(1)* %141, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %142
 
 ; <label>:142                                     ; preds = %140
   %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
   %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
   %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
-  %NullCheck40 = icmp ne i64 addrspace(1)* %145, null
-  br i1 %NullCheck40, label %146, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i64 addrspace(1)* %145, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
   %147 = load i64, i64 addrspace(1)* %145
@@ -12649,83 +14358,83 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %25
+ThrowNullRef4:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %32
+ThrowNullRef6:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %37
+ThrowNullRef10:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %41
+ThrowNullRef12:                                   ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %58
+ThrowNullRef14:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %60
+ThrowNullRef16:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %65
+ThrowNullRef18:                                   ; preds = %65
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %80
+ThrowNullRef20:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %82
+ThrowNullRef22:                                   ; preds = %82
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %86
+ThrowNullRef24:                                   ; preds = %86
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %90
+ThrowNullRef26:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %94
+ThrowNullRef28:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %100
+ThrowNullRef30:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %116
+ThrowNullRef32:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %118
+ThrowNullRef34:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %122
+ThrowNullRef36:                                   ; preds = %122
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %140
+ThrowNullRef38:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %142
+ThrowNullRef40:                                   ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12792,8 +14501,8 @@ entry:
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %1 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
-  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
@@ -12801,8 +14510,8 @@ entry:
   %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
   %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
   %8 = load i64, i64 addrspace(1)* %6
@@ -12818,8 +14527,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %17, %System.IFormatProvider addrspace(1)* %16)
   %18 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %19 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %18, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.SyncTextWriter addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %7
   %21 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %18, i32 0, i32 4
@@ -12830,11 +14539,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12847,8 +14556,8 @@ entry:
   %this = alloca %System.IO.TextWriter addrspace(1)*
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.TextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
@@ -12858,8 +14567,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.Threading.Thread addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Threading.Thread addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %6)
@@ -12868,8 +14577,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1
   %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.TextWriter addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.TextWriter addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %11, i32 0, i32 2
@@ -12880,11 +14589,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13081,8 +14790,8 @@ entry:
   store float %param1, float* %arg1
   store i8 0, i8* %loc1
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
@@ -13092,16 +14801,16 @@ entry:
   %5 = addrspacecast i8* %loc1 to i8 addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %4, i8 addrspace(1)* %5)
   %6 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.SyncTextWriter addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
   %10 = load float, float* %arg1
   %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
   %13 = load i64, i64 addrspace(1)* %11
@@ -13136,11 +14845,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13157,8 +14866,8 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load float, float* %arg1
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -13172,8 +14881,8 @@ entry:
   call void %11(%System.IO.TextWriter addrspace(1)* %0, float %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
   %15 = load i64, i64 addrspace(1)* %13
@@ -13191,7 +14900,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13209,8 +14918,8 @@ entry:
   %1 = addrspacecast float* %arg1 to float addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -13225,8 +14934,8 @@ entry:
   %14 = bitcast float addrspace(1)* %1 to %System.Single addrspace(1)*
   %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Single addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Single addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
   %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
   %18 = load i64, i64 addrspace(1)* %16
@@ -13244,7 +14953,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13260,8 +14969,8 @@ entry:
   store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
   %0 = load %System.Single addrspace(1)*, %System.Single addrspace(1)** %this
   %1 = bitcast %System.Single addrspace(1)* %0 to float addrspace(1)*
-  %NullCheck = icmp ne float addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq float addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load float, float addrspace(1)* %1, align 8
@@ -13286,8 +14995,8 @@ entry:
   %loc0 = alloca %System.Globalization.NumberFormatInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 3
@@ -13297,8 +15006,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
@@ -13308,24 +15017,24 @@ entry:
   store %System.Globalization.NumberFormatInfo addrspace(1)* %10, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
   %11 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %7
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
   %15 = load i8, i8 addrspace(1)* %14, align 8
   %16 = zext i8 %15 to i32
   %17 = trunc i32 %16 to i8
-  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %11, null
-  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %11, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %13
   %19 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %11, i32 0, i32 29
   store i8 %17, i8 addrspace(1)* %19
   %20 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %21 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %20, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %20, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %18
   %23 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %20, i32 0, i32 3
@@ -13334,8 +15043,8 @@ entry:
 
 ; <label>:24                                      ; preds = %1, %22
   %25 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %25, null
-  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %25, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %26
 
 ; <label>:26                                      ; preds = %24
   %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %25, i32 0, i32 3
@@ -13346,23 +15055,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %18
+ThrowNullRef8:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13387,168 +15096,168 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 18
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %8, align 8
-  %NullCheck2 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %5, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %5, i32 0, i32 4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %9)
   %12 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 19
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %15, align 8
-  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %12, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %12, i32 0, i32 5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %16)
   %19 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %20 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %20, null
-  br i1 %NullCheck8, label %21, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %20, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %20, i32 0, i32 23
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  %NullCheck10 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %19, null
-  br i1 %NullCheck10, label %24, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %19, i32 0, i32 7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %25, %System.String addrspace(1)* %23)
   %26 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %27 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %27, i32 0, i32 22
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %29, align 8
-  %NullCheck14 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %26, null
-  br i1 %NullCheck14, label %31, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %26, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %26, i32 0, i32 6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %32, %System.String addrspace(1)* %30)
   %33 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %34 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Globalization.CultureData addrspace(1)* %34, null
-  br i1 %NullCheck16, label %35, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Globalization.CultureData addrspace(1)* %34, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %34, i32 0, i32 51
   %37 = load i32, i32 addrspace(1)* %36, align 8
-  %NullCheck18 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %33, null
-  br i1 %NullCheck18, label %38, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %33, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %33, i32 0, i32 21
   store i32 %37, i32 addrspace(1)* %39
   %40 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %41 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Globalization.CultureData addrspace(1)* %41, null
-  br i1 %NullCheck20, label %42, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Globalization.CultureData addrspace(1)* %41, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %41, i32 0, i32 52
   %44 = load i32, i32 addrspace(1)* %43, align 8
-  %NullCheck22 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %40, null
-  br i1 %NullCheck22, label %45, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %40, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %40, i32 0, i32 25
   store i32 %44, i32 addrspace(1)* %46
   %47 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %48 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.Globalization.CultureData addrspace(1)* %48, null
-  br i1 %NullCheck24, label %49, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Globalization.CultureData addrspace(1)* %48, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %49
 
 ; <label>:49                                      ; preds = %45
   %50 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %48, i32 0, i32 29
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck26 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %47, null
-  br i1 %NullCheck26, label %52, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %47, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %47, i32 0, i32 10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %53, %System.String addrspace(1)* %51)
   %54 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %55 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Globalization.CultureData addrspace(1)* %55, null
-  br i1 %NullCheck28, label %56, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Globalization.CultureData addrspace(1)* %55, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %56
 
 ; <label>:56                                      ; preds = %52
   %57 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %55, i32 0, i32 35
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %57, align 8
-  %NullCheck30 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %54, null
-  br i1 %NullCheck30, label %59, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %54, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %54, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %60, %System.String addrspace(1)* %58)
   %61 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %62 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck32 = icmp ne %System.Globalization.CultureData addrspace(1)* %62, null
-  br i1 %NullCheck32, label %63, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Globalization.CultureData addrspace(1)* %62, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %62, i32 0, i32 34
   %65 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %64, align 8
-  %NullCheck34 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %61, null
-  br i1 %NullCheck34, label %66, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %61, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %61, i32 0, i32 9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %67, %System.String addrspace(1)* %65)
   %68 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %69 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck36 = icmp ne %System.Globalization.CultureData addrspace(1)* %69, null
-  br i1 %NullCheck36, label %70, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Globalization.CultureData addrspace(1)* %69, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %70
 
 ; <label>:70                                      ; preds = %66
   %71 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %69, i32 0, i32 55
   %72 = load i32, i32 addrspace(1)* %71, align 8
-  %NullCheck38 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %68, null
-  br i1 %NullCheck38, label %73, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %68, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %68, i32 0, i32 22
   store i32 %72, i32 addrspace(1)* %74
   %75 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %76 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck40 = icmp ne %System.Globalization.CultureData addrspace(1)* %76, null
-  br i1 %NullCheck40, label %77, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Globalization.CultureData addrspace(1)* %76, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %76, i32 0, i32 57
   %79 = load i32, i32 addrspace(1)* %78, align 8
-  %NullCheck42 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %75, null
-  br i1 %NullCheck42, label %80, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %75, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %80
 
 ; <label>:80                                      ; preds = %77
   %81 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %75, i32 0, i32 24
   store i32 %79, i32 addrspace(1)* %81
   %82 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %83 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck44 = icmp ne %System.Globalization.CultureData addrspace(1)* %83, null
-  br i1 %NullCheck44, label %84, label %ThrowNullRef43
+  %NullCheck43 = icmp eq %System.Globalization.CultureData addrspace(1)* %83, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %84
 
 ; <label>:84                                      ; preds = %80
   %85 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %83, i32 0, i32 56
   %86 = load i32, i32 addrspace(1)* %85, align 8
-  %NullCheck46 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %82, null
-  br i1 %NullCheck46, label %87, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %82, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %82, i32 0, i32 23
@@ -13557,8 +15266,8 @@ entry:
 
 ; <label>:89                                      ; preds = %entry
   %90 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck100 = icmp ne %System.Globalization.CultureData addrspace(1)* %90, null
-  br i1 %NullCheck100, label %91, label %ThrowNullRef99
+  %NullCheck99 = icmp eq %System.Globalization.CultureData addrspace(1)* %90, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %91
 
 ; <label>:91                                      ; preds = %89
   %92 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %90, i32 0, i32 2
@@ -13576,8 +15285,8 @@ entry:
   %102 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %103 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %104 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %103)
-  %NullCheck48 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %102, null
-  br i1 %NullCheck48, label %105, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %102, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %105
 
 ; <label>:105                                     ; preds = %101
   %106 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %102, i32 0, i32 1
@@ -13585,8 +15294,8 @@ entry:
   %107 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %108 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %109 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %108)
-  %NullCheck50 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %107, null
-  br i1 %NullCheck50, label %110, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %107, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %110
 
 ; <label>:110                                     ; preds = %105
   %111 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %107, i32 0, i32 2
@@ -13594,8 +15303,8 @@ entry:
   %112 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %113 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %114 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %113)
-  %NullCheck52 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %112, null
-  br i1 %NullCheck52, label %115, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %112, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %115
 
 ; <label>:115                                     ; preds = %110
   %116 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %112, i32 0, i32 27
@@ -13603,8 +15312,8 @@ entry:
   %117 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %118 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %119 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %118)
-  %NullCheck54 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %117, null
-  br i1 %NullCheck54, label %120, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %117, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %120
 
 ; <label>:120                                     ; preds = %115
   %121 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %117, i32 0, i32 26
@@ -13612,8 +15321,8 @@ entry:
   %122 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %123 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %124 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %123)
-  %NullCheck56 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %122, null
-  br i1 %NullCheck56, label %125, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %122, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %125
 
 ; <label>:125                                     ; preds = %120
   %126 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %122, i32 0, i32 17
@@ -13621,8 +15330,8 @@ entry:
   %127 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %128 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %129 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %128)
-  %NullCheck58 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %127, null
-  br i1 %NullCheck58, label %130, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %127, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %130
 
 ; <label>:130                                     ; preds = %125
   %131 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %127, i32 0, i32 18
@@ -13630,8 +15339,8 @@ entry:
   %132 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %133 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %134 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %133)
-  %NullCheck60 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %132, null
-  br i1 %NullCheck60, label %135, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %132, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %135
 
 ; <label>:135                                     ; preds = %130
   %136 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %132, i32 0, i32 14
@@ -13639,8 +15348,8 @@ entry:
   %137 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %138 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %139 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %138)
-  %NullCheck62 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %137, null
-  br i1 %NullCheck62, label %140, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %137, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %140
 
 ; <label>:140                                     ; preds = %135
   %141 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %137, i32 0, i32 13
@@ -13648,71 +15357,71 @@ entry:
   %142 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %143 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %144 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %143)
-  %NullCheck64 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %142, null
-  br i1 %NullCheck64, label %145, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %142, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %145
 
 ; <label>:145                                     ; preds = %140
   %146 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %142, i32 0, i32 12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %146, %System.String addrspace(1)* %144)
   %147 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %148 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck66 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %148, null
-  br i1 %NullCheck66, label %149, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %148, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %149
 
 ; <label>:149                                     ; preds = %145
   %150 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %148, i32 0, i32 21
   %151 = load i32, i32 addrspace(1)* %150, align 8
-  %NullCheck68 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %147, null
-  br i1 %NullCheck68, label %152, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %147, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %152
 
 ; <label>:152                                     ; preds = %149
   %153 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %147, i32 0, i32 28
   store i32 %151, i32 addrspace(1)* %153
   %154 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %155 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck70 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %155, null
-  br i1 %NullCheck70, label %156, label %ThrowNullRef69
+  %NullCheck69 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %155, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %156
 
 ; <label>:156                                     ; preds = %152
   %157 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %155, i32 0, i32 6
   %158 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %157, align 8
-  %NullCheck72 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %154, null
-  br i1 %NullCheck72, label %159, label %ThrowNullRef71
+  %NullCheck71 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %154, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %159
 
 ; <label>:159                                     ; preds = %156
   %160 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %154, i32 0, i32 15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %160, %System.String addrspace(1)* %158)
   %161 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %162 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck74 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %162, null
-  br i1 %NullCheck74, label %163, label %ThrowNullRef73
+  %NullCheck73 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %162, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %163
 
 ; <label>:163                                     ; preds = %159
   %164 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %162, i32 0, i32 1
   %165 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %164, align 8
-  %NullCheck76 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %161, null
-  br i1 %NullCheck76, label %166, label %ThrowNullRef75
+  %NullCheck75 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %161, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %166
 
 ; <label>:166                                     ; preds = %163
   %167 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %161, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %167, %"System.Int32[]" addrspace(1)* %165)
   %168 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %169 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck78 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %169, null
-  br i1 %NullCheck78, label %170, label %ThrowNullRef77
+  %NullCheck77 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %169, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %170
 
 ; <label>:170                                     ; preds = %166
   %171 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %169, i32 0, i32 7
   %172 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %171, align 8
-  %NullCheck80 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %168, null
-  br i1 %NullCheck80, label %173, label %ThrowNullRef79
+  %NullCheck79 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %168, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %173
 
 ; <label>:173                                     ; preds = %170
   %174 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %168, i32 0, i32 16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %174, %System.String addrspace(1)* %172)
   %175 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck82 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %175, null
-  br i1 %NullCheck82, label %176, label %ThrowNullRef81
+  %NullCheck81 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %175, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %176
 
 ; <label>:176                                     ; preds = %173
   %177 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %175, i32 0, i32 4
@@ -13722,14 +15431,14 @@ entry:
 
 ; <label>:180                                     ; preds = %176
   %181 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck84 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %181, null
-  br i1 %NullCheck84, label %182, label %ThrowNullRef83
+  %NullCheck83 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %181, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %182
 
 ; <label>:182                                     ; preds = %180
   %183 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %181, i32 0, i32 4
   %184 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %183, align 8
-  %NullCheck86 = icmp ne %System.String addrspace(1)* %184, null
-  br i1 %NullCheck86, label %185, label %ThrowNullRef85
+  %NullCheck85 = icmp eq %System.String addrspace(1)* %184, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %185
 
 ; <label>:185                                     ; preds = %182
   %186 = getelementptr inbounds %System.String, %System.String addrspace(1)* %184, i32 0, i32 1
@@ -13740,8 +15449,8 @@ entry:
 ; <label>:189                                     ; preds = %176, %185
   %190 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck98 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %190, null
-  br i1 %NullCheck98, label %192, label %ThrowNullRef97
+  %NullCheck97 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %190, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %192
 
 ; <label>:192                                     ; preds = %189
   %193 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %190, i32 0, i32 4
@@ -13750,8 +15459,8 @@ entry:
 
 ; <label>:194                                     ; preds = %185, %192
   %195 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck88 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %195, null
-  br i1 %NullCheck88, label %196, label %ThrowNullRef87
+  %NullCheck87 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %195, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %196
 
 ; <label>:196                                     ; preds = %194
   %197 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %195, i32 0, i32 9
@@ -13761,14 +15470,14 @@ entry:
 
 ; <label>:200                                     ; preds = %196
   %201 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck90 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %201, null
-  br i1 %NullCheck90, label %202, label %ThrowNullRef89
+  %NullCheck89 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %201, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %202
 
 ; <label>:202                                     ; preds = %200
   %203 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %201, i32 0, i32 9
   %204 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %203, align 8
-  %NullCheck92 = icmp ne %System.String addrspace(1)* %204, null
-  br i1 %NullCheck92, label %205, label %ThrowNullRef91
+  %NullCheck91 = icmp eq %System.String addrspace(1)* %204, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %205
 
 ; <label>:205                                     ; preds = %202
   %206 = getelementptr inbounds %System.String, %System.String addrspace(1)* %204, i32 0, i32 1
@@ -13779,14 +15488,14 @@ entry:
 ; <label>:209                                     ; preds = %196, %205
   %210 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %211 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck94 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %211, null
-  br i1 %NullCheck94, label %212, label %ThrowNullRef93
+  %NullCheck93 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %211, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %212
 
 ; <label>:212                                     ; preds = %209
   %213 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %211, i32 0, i32 6
   %214 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %213, align 8
-  %NullCheck96 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %210, null
-  br i1 %NullCheck96, label %215, label %ThrowNullRef95
+  %NullCheck95 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %210, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %215
 
 ; <label>:215                                     ; preds = %212
   %216 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %210, i32 0, i32 9
@@ -13800,203 +15509,203 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %17
+ThrowNullRef8:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %21
+ThrowNullRef10:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %24
+ThrowNullRef12:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %28
+ThrowNullRef14:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %31
+ThrowNullRef16:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %35
+ThrowNullRef18:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %38
+ThrowNullRef20:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %42
+ThrowNullRef22:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %45
+ThrowNullRef24:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %49
+ThrowNullRef26:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %52
+ThrowNullRef28:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %56
+ThrowNullRef30:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %59
+ThrowNullRef32:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %63
+ThrowNullRef34:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %66
+ThrowNullRef36:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %70
+ThrowNullRef38:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %73
+ThrowNullRef40:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %77
+ThrowNullRef42:                                   ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %80
+ThrowNullRef44:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %84
+ThrowNullRef46:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %101
+ThrowNullRef48:                                   ; preds = %101
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %105
+ThrowNullRef50:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %110
+ThrowNullRef52:                                   ; preds = %110
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %115
+ThrowNullRef54:                                   ; preds = %115
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %120
+ThrowNullRef56:                                   ; preds = %120
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %125
+ThrowNullRef58:                                   ; preds = %125
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %130
+ThrowNullRef60:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %135
+ThrowNullRef62:                                   ; preds = %135
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %140
+ThrowNullRef64:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %145
+ThrowNullRef66:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %149
+ThrowNullRef68:                                   ; preds = %149
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %152
+ThrowNullRef70:                                   ; preds = %152
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %156
+ThrowNullRef72:                                   ; preds = %156
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %159
+ThrowNullRef74:                                   ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %163
+ThrowNullRef76:                                   ; preds = %163
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %166
+ThrowNullRef78:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %170
+ThrowNullRef80:                                   ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %173
+ThrowNullRef82:                                   ; preds = %173
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %180
+ThrowNullRef84:                                   ; preds = %180
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %182
+ThrowNullRef86:                                   ; preds = %182
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %194
+ThrowNullRef88:                                   ; preds = %194
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %200
+ThrowNullRef90:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %202
+ThrowNullRef92:                                   ; preds = %202
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %209
+ThrowNullRef94:                                   ; preds = %209
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %212
+ThrowNullRef96:                                   ; preds = %212
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %189
+ThrowNullRef98:                                   ; preds = %189
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %89
+ThrowNullRef100:                                  ; preds = %89
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14024,8 +15733,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 21
@@ -14038,8 +15747,8 @@ entry:
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 16)
   %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 21
@@ -14048,8 +15757,8 @@ entry:
 
 ; <label>:12                                      ; preds = %1, %10
   %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 21
@@ -14060,11 +15769,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %12
+ThrowNullRef4:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14080,8 +15789,8 @@ entry:
   store i32 %param1, i32* %arg1
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %1 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
@@ -14148,8 +15857,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 33
@@ -14162,8 +15871,8 @@ entry:
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 24)
   %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 33
@@ -14172,8 +15881,8 @@ entry:
 
 ; <label>:12                                      ; preds = %1, %10
   %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 33
@@ -14184,11 +15893,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %12
+ThrowNullRef4:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14201,8 +15910,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 53
@@ -14214,8 +15923,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 116)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 53
@@ -14224,8 +15933,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 53
@@ -14236,11 +15945,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14269,8 +15978,8 @@ entry:
 
 ; <label>:7                                       ; preds = %entry, %4
   %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %7
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 2
@@ -14294,8 +16003,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 54
@@ -14307,8 +16016,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 117)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
@@ -14317,8 +16026,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 54
@@ -14329,11 +16038,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14346,8 +16055,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 27
@@ -14359,8 +16068,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 118)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 27
@@ -14369,8 +16078,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 27
@@ -14381,11 +16090,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14398,8 +16107,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 28
@@ -14411,8 +16120,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 119)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 28
@@ -14421,8 +16130,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 28
@@ -14433,11 +16142,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14450,8 +16159,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 26
@@ -14463,8 +16172,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 107)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 26
@@ -14473,8 +16182,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 26
@@ -14485,11 +16194,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14502,8 +16211,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 25
@@ -14515,8 +16224,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 106)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 25
@@ -14525,8 +16234,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 25
@@ -14537,11 +16246,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14554,8 +16263,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 24
@@ -14567,8 +16276,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 105)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 24
@@ -14577,8 +16286,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 24
@@ -14589,11 +16298,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14618,8 +16327,8 @@ entry:
   %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %3)
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %2
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -14630,15 +16339,15 @@ entry:
 
 ; <label>:8                                       ; preds = %62
   %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 9
   %12 = load i32, i32 addrspace(1)* %11, align 8
   %13 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.IO.StreamWriter addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %13, i32 0, i32 10
@@ -14653,15 +16362,15 @@ entry:
 
 ; <label>:20                                      ; preds = %14, %18
   %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
   %24 = load i32, i32 addrspace(1)* %23, align 8
   %25 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %25, null
-  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.StreamWriter addrspace(1)* %25, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %25, i32 0, i32 9
@@ -14682,36 +16391,36 @@ entry:
   %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %37 = load i32, i32* %loc1
   %38 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.StreamWriter addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %35
   %40 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %38, i32 0, i32 7
   %41 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %40, align 8
   %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
-  br i1 %NullCheck14, label %43, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %39
   %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 9
   %45 = load i32, i32 addrspace(1)* %44, align 8
   %46 = load i32, i32* %loc2
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %36, null
-  br i1 %NullCheck16, label %47, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %36, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %47
 
 ; <label>:47                                      ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %36, i32 %37, %"System.Char[]" addrspace(1)* %41, i32 %45, i32 %46)
   %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
   %51 = load i32, i32 addrspace(1)* %50, align 8
   %52 = load i32, i32* %loc2
   %53 = add i32 %51, %52
-  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
-  br i1 %NullCheck20, label %54, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %54
 
 ; <label>:54                                      ; preds = %49
   %55 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
@@ -14733,8 +16442,8 @@ entry:
 
 ; <label>:65                                      ; preds = %62
   %66 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %66, null
-  br i1 %NullCheck2, label %67, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %66, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %67
 
 ; <label>:67                                      ; preds = %65
   %68 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %66, i32 0, i32 11
@@ -14755,49 +16464,259 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %65
+ThrowNullRef2:                                    ; preds = %65
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %20
+ThrowNullRef8:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %22
+ThrowNullRef10:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %35
+ThrowNullRef12:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %43
+ThrowNullRef16:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %47
+ThrowNullRef18:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method String::CopyTo using LLILCJit
-Failed to read String.CopyTo[loadElemA]
+Successfully read String.CopyTo
+
+define void @String.CopyTo(%System.String addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  %loc1 = alloca i16 addrspace(1)*
+  %loc2 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %1 = icmp ne %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg4
+  %7 = icmp sge i32 %6, 0
+  br i1 %7, label %13, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  unreachable
+
+; <label>:13                                      ; preds = %5
+  %14 = load i32, i32* %arg1
+  %15 = icmp sge i32 %14, 0
+  br i1 %15, label %21, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %18)
+  %20 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %20, %System.String addrspace(1)* %17, %System.String addrspace(1)* %19)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %20) #0
+  unreachable
+
+; <label>:21                                      ; preds = %13
+  %22 = load i32, i32* %arg4
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck, label %ThrowNullRef, label %24
+
+; <label>:24                                      ; preds = %21
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load i32, i32* %arg1
+  %28 = sub i32 %26, %27
+  %29 = icmp sle i32 %22, %28
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34, %System.String addrspace(1)* %31, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %24
+  %36 = load i32, i32* %arg3
+  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %37, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
+
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
+  %40 = load i32, i32 addrspace(1)* %39
+  %41 = zext i32 %40 to i64
+  %42 = trunc i64 %41 to i32
+  %43 = load i32, i32* %arg4
+  %44 = sub i32 %42, %43
+  %45 = icmp sgt i32 %36, %44
+  br i1 %45, label %49, label %46
+
+; <label>:46                                      ; preds = %38
+  %47 = load i32, i32* %arg3
+  %48 = icmp sge i32 %47, 0
+  br i1 %48, label %54, label %49
+
+; <label>:49                                      ; preds = %38, %46
+  %50 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %52 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %51)
+  %53 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53, %System.String addrspace(1)* %50, %System.String addrspace(1)* %52)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53) #0
+  unreachable
+
+; <label>:54                                      ; preds = %46
+  %55 = load i32, i32* %arg4
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %97, label %57
+
+; <label>:57                                      ; preds = %54
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %59
+
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 2
+  %61 = bitcast [0 x i16] addrspace(1)* %60 to i16 addrspace(1)*
+  store i16 addrspace(1)* %61, i16 addrspace(1)** %loc0
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  store %"System.Char[]" addrspace(1)* %62, %"System.Char[]" addrspace(1)** %loc2
+  %63 = icmp eq %"System.Char[]" addrspace(1)* %62, null
+  br i1 %63, label %72, label %64
+
+; <label>:64                                      ; preds = %59
+  %65 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc2
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %65, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %66
+
+; <label>:66                                      ; preds = %64
+  %67 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %65, i32 0, i32 1
+  %68 = load i32, i32 addrspace(1)* %67
+  %69 = zext i32 %68 to i64
+  %70 = trunc i64 %69 to i32
+  %71 = icmp ne i32 %70, 0
+  br i1 %71, label %73, label %72
+
+; <label>:72                                      ; preds = %59, %66
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  br label %81
+
+; <label>:73                                      ; preds = %66
+  %74 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc2
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %74, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %75
+
+; <label>:75                                      ; preds = %73
+  %76 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %74, i32 0, i32 1
+  %77 = load i32, i32 addrspace(1)* %76
+  %78 = zext i32 %77 to i64
+  %BoundsCheck = icmp uge i64 0, %78
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %79
+
+; <label>:79                                      ; preds = %75
+  %80 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %74, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %80, i16 addrspace(1)** %loc1
+  br label %81
+
+; <label>:81                                      ; preds = %72, %79
+  %82 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %83 = ptrtoint i16 addrspace(1)* %82 to i64
+  %84 = load i32, i32* %arg3
+  %85 = sext i32 %84 to i64
+  %86 = mul i64 %85, 2
+  %87 = add i64 %83, %86
+  %88 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %89 = ptrtoint i16 addrspace(1)* %88 to i64
+  %90 = load i32, i32* %arg1
+  %91 = sext i32 %90 to i64
+  %92 = mul i64 %91, 2
+  %93 = add i64 %89, %92
+  %94 = load i32, i32* %arg4
+  %95 = inttoptr i64 %87 to i16*
+  %96 = inttoptr i64 %93 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %95, i16* %96, i32 %94)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  br label %97
+
+; <label>:97                                      ; preds = %54, %81
+  ret void
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
 Successfully read ConsoleEncoding.GetPreamble
 
@@ -14834,7 +16753,365 @@ entry:
 }
 
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[loadElemA]
+Successfully read EncoderNLS.GetBytes
+
+define i32 @EncoderNLS.GetBytes(%System.Text.EncoderNLS addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3, %"System.Byte[]" addrspace(1)* %param4, i32 %param5, i8 %param6) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %arg4 = alloca %"System.Byte[]" addrspace(1)*
+  %arg5 = alloca i32
+  %arg6 = alloca i8
+  %loc0 = alloca i32
+  %loc1 = alloca i16 addrspace(1)*
+  %loc2 = alloca i8 addrspace(1)*
+  %loc3 = alloca i32
+  %loc4 = alloca %"System.Char[]" addrspace(1)*
+  %loc5 = alloca %"System.Byte[]" addrspace(1)*
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  store %"System.Byte[]" addrspace(1)* %param4, %"System.Byte[]" addrspace(1)** %arg4
+  store i32 %param5, i32* %arg5
+  store i8 %param6, i8* %arg6
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %1 = icmp eq %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %17, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %7 = icmp eq %"System.Char[]" addrspace(1)* %6, null
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %12
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %12
+
+; <label>:12                                      ; preds = %8, %10
+  %13 = phi %System.String addrspace(1)* [ %9, %8 ], [ %11, %10 ]
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %14)
+  %16 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16, %System.String addrspace(1)* %13, %System.String addrspace(1)* %15)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16) #0
+  unreachable
+
+; <label>:17                                      ; preds = %2
+  %18 = load i32, i32* %arg2
+  %19 = icmp slt i32 %18, 0
+  br i1 %19, label %23, label %20
+
+; <label>:20                                      ; preds = %17
+  %21 = load i32, i32* %arg3
+  %22 = icmp sge i32 %21, 0
+  br i1 %22, label %35, label %23
+
+; <label>:23                                      ; preds = %17, %20
+  %24 = load i32, i32* %arg2
+  %25 = icmp slt i32 %24, 0
+  br i1 %25, label %28, label %26
+
+; <label>:26                                      ; preds = %23
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %30
+
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %30
+
+; <label>:30                                      ; preds = %26, %28
+  %31 = phi %System.String addrspace(1)* [ %27, %26 ], [ %29, %28 ]
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34, %System.String addrspace(1)* %31, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %20
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck, label %ThrowNullRef, label %37
+
+; <label>:37                                      ; preds = %35
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = load i32, i32* %arg2
+  %43 = sub i32 %41, %42
+  %44 = load i32, i32* %arg3
+  %45 = icmp sge i32 %43, %44
+  br i1 %45, label %51, label %46
+
+; <label>:46                                      ; preds = %37
+  %47 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %48 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %49 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %48)
+  %50 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %50, %System.String addrspace(1)* %47, %System.String addrspace(1)* %49)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %50) #0
+  unreachable
+
+; <label>:51                                      ; preds = %37
+  %52 = load i32, i32* %arg5
+  %53 = icmp slt i32 %52, 0
+  br i1 %53, label %63, label %54
+
+; <label>:54                                      ; preds = %51
+  %55 = load i32, i32* %arg5
+  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck1 = icmp eq %"System.Byte[]" addrspace(1)* %56, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %57
+
+; <label>:57                                      ; preds = %54
+  %58 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = zext i32 %59 to i64
+  %61 = trunc i64 %60 to i32
+  %62 = icmp sle i32 %55, %61
+  br i1 %62, label %68, label %63
+
+; <label>:63                                      ; preds = %51, %57
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %66 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %65)
+  %67 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %67, %System.String addrspace(1)* %64, %System.String addrspace(1)* %66)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %67) #0
+  unreachable
+
+; <label>:68                                      ; preds = %57
+  %69 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %69, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %69, i32 0, i32 1
+  %72 = load i32, i32 addrspace(1)* %71
+  %73 = zext i32 %72 to i64
+  %74 = trunc i64 %73 to i32
+  %75 = icmp ne i32 %74, 0
+  br i1 %75, label %78, label %76
+
+; <label>:76                                      ; preds = %70
+  %77 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1)
+  store %"System.Char[]" addrspace(1)* %77, %"System.Char[]" addrspace(1)** %arg1
+  br label %78
+
+; <label>:78                                      ; preds = %70, %76
+  %79 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck5 = icmp eq %"System.Byte[]" addrspace(1)* %79, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %80
+
+; <label>:80                                      ; preds = %78
+  %81 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %79, i32 0, i32 1
+  %82 = load i32, i32 addrspace(1)* %81
+  %83 = zext i32 %82 to i64
+  %84 = trunc i64 %83 to i32
+  %85 = load i32, i32* %arg5
+  %86 = sub i32 %84, %85
+  store i32 %86, i32* %loc0
+  %87 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck7 = icmp eq %"System.Byte[]" addrspace(1)* %87, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %88
+
+; <label>:88                                      ; preds = %80
+  %89 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %87, i32 0, i32 1
+  %90 = load i32, i32 addrspace(1)* %89
+  %91 = zext i32 %90 to i64
+  %92 = trunc i64 %91 to i32
+  %93 = icmp ne i32 %92, 0
+  br i1 %93, label %96, label %94
+
+; <label>:94                                      ; preds = %88
+  %95 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1)
+  store %"System.Byte[]" addrspace(1)* %95, %"System.Byte[]" addrspace(1)** %arg4
+  br label %96
+
+; <label>:96                                      ; preds = %88, %94
+  %97 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  store %"System.Char[]" addrspace(1)* %97, %"System.Char[]" addrspace(1)** %loc4
+  %98 = icmp eq %"System.Char[]" addrspace(1)* %97, null
+  br i1 %98, label %107, label %99
+
+; <label>:99                                      ; preds = %96
+  %100 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc4
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %100, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %101
+
+; <label>:101                                     ; preds = %99
+  %102 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %100, i32 0, i32 1
+  %103 = load i32, i32 addrspace(1)* %102
+  %104 = zext i32 %103 to i64
+  %105 = trunc i64 %104 to i32
+  %106 = icmp ne i32 %105, 0
+  br i1 %106, label %108, label %107
+
+; <label>:107                                     ; preds = %96, %101
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  br label %116
+
+; <label>:108                                     ; preds = %101
+  %109 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc4
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %109, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %110
+
+; <label>:110                                     ; preds = %108
+  %111 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %109, i32 0, i32 1
+  %112 = load i32, i32 addrspace(1)* %111
+  %113 = zext i32 %112 to i64
+  %BoundsCheck = icmp uge i64 0, %113
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %114
+
+; <label>:114                                     ; preds = %110
+  %115 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %109, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %115, i16 addrspace(1)** %loc1
+  br label %116
+
+; <label>:116                                     ; preds = %107, %114
+  %117 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  store %"System.Byte[]" addrspace(1)* %117, %"System.Byte[]" addrspace(1)** %loc5
+  %118 = icmp eq %"System.Byte[]" addrspace(1)* %117, null
+  br i1 %118, label %127, label %119
+
+; <label>:119                                     ; preds = %116
+  %120 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc5
+  %NullCheck13 = icmp eq %"System.Byte[]" addrspace(1)* %120, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %121
+
+; <label>:121                                     ; preds = %119
+  %122 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %120, i32 0, i32 1
+  %123 = load i32, i32 addrspace(1)* %122
+  %124 = zext i32 %123 to i64
+  %125 = trunc i64 %124 to i32
+  %126 = icmp ne i32 %125, 0
+  br i1 %126, label %128, label %127
+
+; <label>:127                                     ; preds = %116, %121
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc2
+  br label %136
+
+; <label>:128                                     ; preds = %121
+  %129 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc5
+  %NullCheck15 = icmp eq %"System.Byte[]" addrspace(1)* %129, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %130
+
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %129, i32 0, i32 1
+  %132 = load i32, i32 addrspace(1)* %131
+  %133 = zext i32 %132 to i64
+  %BoundsCheck17 = icmp uge i64 0, %133
+  br i1 %BoundsCheck17, label %ThrowIndexOutOfRange18, label %134
+
+; <label>:134                                     ; preds = %130
+  %135 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %129, i32 0, i32 3, i32 0
+  store i8 addrspace(1)* %135, i8 addrspace(1)** %loc2
+  br label %136
+
+; <label>:136                                     ; preds = %127, %134
+  %137 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %138 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %139 = ptrtoint i16 addrspace(1)* %138 to i64
+  %140 = load i32, i32* %arg2
+  %141 = sext i32 %140 to i64
+  %142 = mul i64 %141, 2
+  %143 = add i64 %139, %142
+  %144 = load i32, i32* %arg3
+  %145 = load i8 addrspace(1)*, i8 addrspace(1)** %loc2
+  %146 = ptrtoint i8 addrspace(1)* %145 to i64
+  %147 = load i32, i32* %arg5
+  %148 = sext i32 %147 to i64
+  %149 = add i64 %146, %148
+  %150 = load i32, i32* %loc0
+  %151 = load i8, i8* %arg6
+  %152 = zext i8 %151 to i32
+  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i64 addrspace(1)*
+  %NullCheck19 = icmp eq i64 addrspace(1)* %153, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %154
+
+; <label>:154                                     ; preds = %136
+  %155 = load i64, i64 addrspace(1)* %153
+  %156 = add i64 %155, 72
+  %157 = inttoptr i64 %156 to i64*
+  %158 = load i64, i64* %157
+  %159 = add i64 %158, 0
+  %160 = inttoptr i64 %159 to i64*
+  %161 = load i64, i64* %160
+  %162 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to %System.Text.Encoder addrspace(1)*
+  %163 = inttoptr i64 %143 to i16*
+  %164 = inttoptr i64 %149 to i8*
+  %165 = trunc i32 %152 to i8
+  %166 = inttoptr i64 %161 to i32 (%System.Text.Encoder addrspace(1)*, i16*, i32, i8*, i32, i8)*
+  %167 = call i32 %166(%System.Text.Encoder addrspace(1)* %162, i16* %163, i32 %144, i8* %164, i32 %150, i8 %165)
+  store i32 %167, i32* %loc3
+  br label %168
+
+; <label>:168                                     ; preds = %154
+  %169 = load i32, i32* %loc3
+  ret i32 %169
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %110
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %119
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange18:                           ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
 Successfully read EncoderNLS.GetBytes
 
@@ -14923,22 +17200,22 @@ entry:
   %40 = load i8, i8* %arg5
   %41 = zext i8 %40 to i32
   %42 = trunc i32 %41 to i8
-  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %39, null
-  br i1 %NullCheck, label %43, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderNLS addrspace(1)* %39, null
+  br i1 %NullCheck, label %ThrowNullRef, label %43
 
 ; <label>:43                                      ; preds = %38
   %44 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
   store i8 %42, i8 addrspace(1)* %44
   %45 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %45, null
-  br i1 %NullCheck2, label %46, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.EncoderNLS addrspace(1)* %45, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %46
 
 ; <label>:46                                      ; preds = %43
   %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %45, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %47
   %48 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.EncoderNLS addrspace(1)* %48, null
-  br i1 %NullCheck4, label %49, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.EncoderNLS addrspace(1)* %48, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %49
 
 ; <label>:49                                      ; preds = %46
   %50 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %48, i32 0, i32 3
@@ -14949,8 +17226,8 @@ entry:
   %55 = load i32, i32* %arg4
   %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck6, label %58, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
   %59 = load i64, i64 addrspace(1)* %57
@@ -14968,15 +17245,15 @@ ThrowNullRef:                                     ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %43
+ThrowNullRef2:                                    ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %46
+ThrowNullRef4:                                    ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %49
+ThrowNullRef6:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -15004,8 +17281,8 @@ entry:
   %4 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0 to %System.IO.ConsoleStream addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*)(%System.IO.ConsoleStream addrspace(1)* %4, %"System.Byte[]" addrspace(1)* %1, i32 %2, i32 %3)
   %5 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
@@ -15090,8 +17367,8 @@ entry:
 
 ; <label>:22                                      ; preds = %8
   %23 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %23, null
-  br i1 %NullCheck, label %24, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Byte[]" addrspace(1)* %23, null
+  br i1 %NullCheck, label %ThrowNullRef, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
@@ -15113,8 +17390,8 @@ entry:
 
 ; <label>:36                                      ; preds = %24
   %37 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %37, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.ConsoleStream addrspace(1)* %37, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %37, i32 0, i32 4
@@ -15135,13 +17412,138 @@ ThrowNullRef:                                     ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %36
+ThrowNullRef2:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
-Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
+Successfully read WindowsConsoleStream.WriteFileNative
+
+define i32 @WindowsConsoleStream.WriteFileNative(i64 %param0, %"System.Byte[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i64
+  %arg1 = alloca %"System.Byte[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i8 addrspace(1)*
+  %loc2 = alloca %"System.Byte[]" addrspace(1)*
+  %loc3 = alloca i32
+  store i64 %param0, i64* %arg0
+  store %"System.Byte[]" addrspace(1)* %param1, %"System.Byte[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Byte[]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = zext i32 %3 to i64
+  %5 = icmp ne i64 %4, 0
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %1
+  ret i32 0
+
+; <label>:7                                       ; preds = %1
+  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  store %"System.Byte[]" addrspace(1)* %8, %"System.Byte[]" addrspace(1)** %loc2
+  %9 = icmp eq %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %9, label %18, label %10
+
+; <label>:10                                      ; preds = %7
+  %11 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc2
+  %NullCheck1 = icmp eq %"System.Byte[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %11, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp ne i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %7, %12
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc1
+  br label %27
+
+; <label>:19                                      ; preds = %12
+  %20 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc2
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %20, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %BoundsCheck = icmp uge i64 0, %24
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %25
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %20, i32 0, i32 3, i32 0
+  store i8 addrspace(1)* %26, i8 addrspace(1)** %loc1
+  br label %27
+
+; <label>:27                                      ; preds = %18, %25
+  %28 = load i64, i64* %arg0
+  %29 = load i8 addrspace(1)*, i8 addrspace(1)** %loc1
+  %30 = ptrtoint i8 addrspace(1)* %29 to i64
+  %31 = load i32, i32* %arg2
+  %32 = sext i32 %31 to i64
+  %33 = add i64 %30, %32
+  %34 = load i32, i32* %arg3
+  %35 = addrspacecast i32* %loc3 to i32 addrspace(1)*
+  %36 = inttoptr i64 %33 to i8*
+  %37 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i8*, i32, i32 addrspace(1)*, i64)*)(i64 %28, i8* %36, i32 %34, i32 addrspace(1)* %35, i64 0)
+  %38 = icmp ugt i32 %37, 0
+  %39 = sext i1 %38 to i32
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc1
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %42, label %41
+
+; <label>:41                                      ; preds = %27
+  ret i32 0
+
+; <label>:42                                      ; preds = %27
+  %43 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  store i32 %43, i32* %loc0
+  %44 = load i32, i32* %loc0
+  %45 = icmp eq i32 %44, 232
+  br i1 %45, label %49, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = load i32, i32* %loc0
+  %48 = icmp ne i32 %47, 109
+  br i1 %48, label %50, label %49
+
+; <label>:49                                      ; preds = %42, %46
+  ret i32 0
+
+; <label>:50                                      ; preds = %46
+  %51 = load i32, i32* %loc0
+  ret i32 %51
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
 Successfully read WindowsConsoleStream.Flush
 
@@ -15150,8 +17552,8 @@ entry:
   %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
   store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
@@ -15186,8 +17588,8 @@ entry:
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
   %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load i64, i64 addrspace(1)* %1
@@ -15226,15 +17628,15 @@ entry:
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.TextWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
   %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %3, align 8
   %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
   %7 = load i64, i64 addrspace(1)* %5
@@ -15252,7 +17654,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -15281,8 +17683,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %4)
   store i32 0, i32* %loc0
   %5 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Char[]" addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
@@ -15294,15 +17696,15 @@ entry:
 
 ; <label>:11                                      ; preds = %69
   %12 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %12, i32 0, i32 9
   %15 = load i32, i32 addrspace(1)* %14, align 8
   %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.IO.StreamWriter addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %16, i32 0, i32 10
@@ -15317,15 +17719,15 @@ entry:
 
 ; <label>:23                                      ; preds = %17, %21
   %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %24, null
-  br i1 %NullCheck8, label %25, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %24, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 10
   %27 = load i32, i32 addrspace(1)* %26, align 8
   %28 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %28, null
-  br i1 %NullCheck10, label %29, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.StreamWriter addrspace(1)* %28, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %28, i32 0, i32 9
@@ -15347,15 +17749,15 @@ entry:
   %40 = load i32, i32* %loc0
   %41 = mul i32 %40, 2
   %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
-  br i1 %NullCheck12, label %43, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %43
 
 ; <label>:43                                      ; preds = %38
   %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 7
   %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %44, align 8
   %46 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %46, null
-  br i1 %NullCheck14, label %47, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.IO.StreamWriter addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %47
 
 ; <label>:47                                      ; preds = %43
   %48 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %46, i32 0, i32 9
@@ -15367,16 +17769,16 @@ entry:
   %54 = bitcast %"System.Char[]" addrspace(1)* %45 to %System.Array addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %53, i32 %41, %System.Array addrspace(1)* %54, i32 %50, i32 %52)
   %55 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
-  br i1 %NullCheck16, label %56, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %56
 
 ; <label>:56                                      ; preds = %47
   %57 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
   %58 = load i32, i32 addrspace(1)* %57, align 8
   %59 = load i32, i32* %loc2
   %60 = add i32 %58, %59
-  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
-  br i1 %NullCheck18, label %61, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %61
 
 ; <label>:61                                      ; preds = %56
   %62 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
@@ -15398,8 +17800,8 @@ entry:
 
 ; <label>:72                                      ; preds = %69
   %73 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %73, null
-  br i1 %NullCheck2, label %74, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %73, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %74
 
 ; <label>:74                                      ; preds = %72
   %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %73, i32 0, i32 11
@@ -15420,39 +17822,39 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %72
+ThrowNullRef2:                                    ; preds = %72
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %23
+ThrowNullRef8:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef10:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %43
+ThrowNullRef14:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %47
+ThrowNullRef16:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %56
+ThrowNullRef18:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPFillArray.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPFillArray.error.txt
@@ -25,8 +25,8 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
@@ -40,8 +40,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
   %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
@@ -75,7 +75,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -90,8 +90,8 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %NullCheck = icmp ne i8 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = load i8, i8 addrspace(1)* %0, align 8
@@ -125,8 +125,8 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
@@ -159,8 +159,8 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -184,8 +184,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
   store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
@@ -195,8 +195,8 @@ entry:
 ; <label>:4                                       ; preds = %1
   %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
   %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
@@ -206,8 +206,8 @@ entry:
   %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
@@ -221,14 +221,14 @@ entry:
 
 ; <label>:17                                      ; preds = %14
   %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
   %21 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
@@ -238,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -249,8 +249,8 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
@@ -261,27 +261,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %30
+ThrowNullRef10:                                   ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -301,7 +301,89 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
-Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
+Successfully read AppDomainSetup.GetUnsecureApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.GetUnsecureApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %NullCheck = icmp eq %"System.String[]" addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %BoundsCheck = icmp uge i64 0, %5
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %6
+
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 3, i32 0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
+  ret %System.String addrspace(1)* %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_Value using LLILCJit
+Successfully read AppDomainSetup.get_Value
+
+define %"System.String[]" addrspace(1)* @AppDomainSetup.get_Value(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.String[]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 18)
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.String[]" addrspace(1)* addrspace(1)*, %"System.String[]" addrspace(1)*)*)(%"System.String[]" addrspace(1)* addrspace(1)* %9, %"System.String[]" addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %11, i32 0, i32 1
+  %14 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %13, align 8
+  ret %"System.String[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -319,8 +401,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -368,16 +450,16 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
   %5 = load i32, i32 addrspace(1)* %4
   %6 = sub i32 %5, 1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -389,7 +471,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -421,8 +503,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
@@ -456,8 +538,8 @@ entry:
 ; <label>:27                                      ; preds = %19
   %28 = load i32, i32* %arg1
   %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
-  br i1 %NullCheck2, label %30, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %29, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %30
 
 ; <label>:30                                      ; preds = %27
   %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
@@ -493,8 +575,8 @@ entry:
 ; <label>:49                                      ; preds = %46
   %50 = load i32, i32* %arg2
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck4, label %52, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
@@ -517,11 +599,11 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %27
+ThrowNullRef2:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %49
+ThrowNullRef4:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -544,16 +626,16 @@ entry:
   %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %0)
   store %System.String addrspace(1)* %1, %System.String addrspace(1)** %loc0
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 2
   %5 = bitcast [0 x i16] addrspace(1)* %4 to i16 addrspace(1)*
   store i16 addrspace(1)* %5, i16 addrspace(1)** %loc1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %3
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2
@@ -580,7 +662,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -691,15 +773,15 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %NullCheck132 = icmp ne i8* %21, null
-  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+  %NullCheck131 = icmp eq i8* %21, null
+  br i1 %NullCheck131, label %ThrowNullRef132, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = load i8, i8* %21, align 8
   %24 = zext i8 %23 to i32
   %25 = trunc i32 %24 to i8
-  %NullCheck134 = icmp ne i8* %20, null
-  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+  %NullCheck133 = icmp eq i8* %20, null
+  br i1 %NullCheck133, label %ThrowNullRef134, label %26
 
 ; <label>:26                                      ; preds = %22
   store i8 %25, i8* %20, align 8
@@ -709,16 +791,16 @@ entry:
   %28 = load i8*, i8** %arg0
   %29 = load i8*, i8** %arg1
   %30 = bitcast i8* %29 to i16*
-  %NullCheck128 = icmp ne i16* %30, null
-  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+  %NullCheck127 = icmp eq i16* %30, null
+  br i1 %NullCheck127, label %ThrowNullRef128, label %31
 
 ; <label>:31                                      ; preds = %27
   %32 = load i16, i16* %30, align 8
   %33 = sext i16 %32 to i32
   %34 = bitcast i8* %28 to i16*
   %35 = trunc i32 %33 to i16
-  %NullCheck130 = icmp ne i16* %34, null
-  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+  %NullCheck129 = icmp eq i16* %34, null
+  br i1 %NullCheck129, label %ThrowNullRef130, label %36
 
 ; <label>:36                                      ; preds = %31
   store i16 %35, i16* %34, align 8
@@ -728,16 +810,16 @@ entry:
   %38 = load i8*, i8** %arg0
   %39 = load i8*, i8** %arg1
   %40 = bitcast i8* %39 to i16*
-  %NullCheck120 = icmp ne i16* %40, null
-  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+  %NullCheck119 = icmp eq i16* %40, null
+  br i1 %NullCheck119, label %ThrowNullRef120, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i16, i16* %40, align 8
   %43 = sext i16 %42 to i32
   %44 = bitcast i8* %38 to i16*
   %45 = trunc i32 %43 to i16
-  %NullCheck122 = icmp ne i16* %44, null
-  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+  %NullCheck121 = icmp eq i16* %44, null
+  br i1 %NullCheck121, label %ThrowNullRef122, label %46
 
 ; <label>:46                                      ; preds = %41
   store i16 %45, i16* %44, align 8
@@ -745,15 +827,15 @@ entry:
   %48 = getelementptr inbounds i8, i8* %47, i64 2
   %49 = load i8*, i8** %arg1
   %50 = getelementptr inbounds i8, i8* %49, i64 2
-  %NullCheck124 = icmp ne i8* %50, null
-  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+  %NullCheck123 = icmp eq i8* %50, null
+  br i1 %NullCheck123, label %ThrowNullRef124, label %51
 
 ; <label>:51                                      ; preds = %46
   %52 = load i8, i8* %50, align 8
   %53 = zext i8 %52 to i32
   %54 = trunc i32 %53 to i8
-  %NullCheck126 = icmp ne i8* %48, null
-  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+  %NullCheck125 = icmp eq i8* %48, null
+  br i1 %NullCheck125, label %ThrowNullRef126, label %55
 
 ; <label>:55                                      ; preds = %51
   store i8 %54, i8* %48, align 8
@@ -763,14 +845,14 @@ entry:
   %57 = load i8*, i8** %arg0
   %58 = load i8*, i8** %arg1
   %59 = bitcast i8* %58 to i32*
-  %NullCheck116 = icmp ne i32* %59, null
-  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+  %NullCheck115 = icmp eq i32* %59, null
+  br i1 %NullCheck115, label %ThrowNullRef116, label %60
 
 ; <label>:60                                      ; preds = %56
   %61 = load i32, i32* %59, align 8
   %62 = bitcast i8* %57 to i32*
-  %NullCheck118 = icmp ne i32* %62, null
-  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+  %NullCheck117 = icmp eq i32* %62, null
+  br i1 %NullCheck117, label %ThrowNullRef118, label %63
 
 ; <label>:63                                      ; preds = %60
   store i32 %61, i32* %62, align 8
@@ -780,14 +862,14 @@ entry:
   %65 = load i8*, i8** %arg0
   %66 = load i8*, i8** %arg1
   %67 = bitcast i8* %66 to i32*
-  %NullCheck108 = icmp ne i32* %67, null
-  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+  %NullCheck107 = icmp eq i32* %67, null
+  br i1 %NullCheck107, label %ThrowNullRef108, label %68
 
 ; <label>:68                                      ; preds = %64
   %69 = load i32, i32* %67, align 8
   %70 = bitcast i8* %65 to i32*
-  %NullCheck110 = icmp ne i32* %70, null
-  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+  %NullCheck109 = icmp eq i32* %70, null
+  br i1 %NullCheck109, label %ThrowNullRef110, label %71
 
 ; <label>:71                                      ; preds = %68
   store i32 %69, i32* %70, align 8
@@ -795,15 +877,15 @@ entry:
   %73 = getelementptr inbounds i8, i8* %72, i64 4
   %74 = load i8*, i8** %arg1
   %75 = getelementptr inbounds i8, i8* %74, i64 4
-  %NullCheck112 = icmp ne i8* %75, null
-  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+  %NullCheck111 = icmp eq i8* %75, null
+  br i1 %NullCheck111, label %ThrowNullRef112, label %76
 
 ; <label>:76                                      ; preds = %71
   %77 = load i8, i8* %75, align 8
   %78 = zext i8 %77 to i32
   %79 = trunc i32 %78 to i8
-  %NullCheck114 = icmp ne i8* %73, null
-  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+  %NullCheck113 = icmp eq i8* %73, null
+  br i1 %NullCheck113, label %ThrowNullRef114, label %80
 
 ; <label>:80                                      ; preds = %76
   store i8 %79, i8* %73, align 8
@@ -813,14 +895,14 @@ entry:
   %82 = load i8*, i8** %arg0
   %83 = load i8*, i8** %arg1
   %84 = bitcast i8* %83 to i32*
-  %NullCheck100 = icmp ne i32* %84, null
-  br i1 %NullCheck100, label %85, label %ThrowNullRef99
+  %NullCheck99 = icmp eq i32* %84, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %85
 
 ; <label>:85                                      ; preds = %81
   %86 = load i32, i32* %84, align 8
   %87 = bitcast i8* %82 to i32*
-  %NullCheck102 = icmp ne i32* %87, null
-  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+  %NullCheck101 = icmp eq i32* %87, null
+  br i1 %NullCheck101, label %ThrowNullRef102, label %88
 
 ; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
@@ -829,16 +911,16 @@ entry:
   %91 = load i8*, i8** %arg1
   %92 = getelementptr inbounds i8, i8* %91, i64 4
   %93 = bitcast i8* %92 to i16*
-  %NullCheck104 = icmp ne i16* %93, null
-  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+  %NullCheck103 = icmp eq i16* %93, null
+  br i1 %NullCheck103, label %ThrowNullRef104, label %94
 
 ; <label>:94                                      ; preds = %88
   %95 = load i16, i16* %93, align 8
   %96 = sext i16 %95 to i32
   %97 = bitcast i8* %90 to i16*
   %98 = trunc i32 %96 to i16
-  %NullCheck106 = icmp ne i16* %97, null
-  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+  %NullCheck105 = icmp eq i16* %97, null
+  br i1 %NullCheck105, label %ThrowNullRef106, label %99
 
 ; <label>:99                                      ; preds = %94
   store i16 %98, i16* %97, align 8
@@ -848,14 +930,14 @@ entry:
   %101 = load i8*, i8** %arg0
   %102 = load i8*, i8** %arg1
   %103 = bitcast i8* %102 to i32*
-  %NullCheck88 = icmp ne i32* %103, null
-  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+  %NullCheck87 = icmp eq i32* %103, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %104
 
 ; <label>:104                                     ; preds = %100
   %105 = load i32, i32* %103, align 8
   %106 = bitcast i8* %101 to i32*
-  %NullCheck90 = icmp ne i32* %106, null
-  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+  %NullCheck89 = icmp eq i32* %106, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %107
 
 ; <label>:107                                     ; preds = %104
   store i32 %105, i32* %106, align 8
@@ -864,16 +946,16 @@ entry:
   %110 = load i8*, i8** %arg1
   %111 = getelementptr inbounds i8, i8* %110, i64 4
   %112 = bitcast i8* %111 to i16*
-  %NullCheck92 = icmp ne i16* %112, null
-  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+  %NullCheck91 = icmp eq i16* %112, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %113
 
 ; <label>:113                                     ; preds = %107
   %114 = load i16, i16* %112, align 8
   %115 = sext i16 %114 to i32
   %116 = bitcast i8* %109 to i16*
   %117 = trunc i32 %115 to i16
-  %NullCheck94 = icmp ne i16* %116, null
-  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+  %NullCheck93 = icmp eq i16* %116, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %118
 
 ; <label>:118                                     ; preds = %113
   store i16 %117, i16* %116, align 8
@@ -881,15 +963,15 @@ entry:
   %120 = getelementptr inbounds i8, i8* %119, i64 6
   %121 = load i8*, i8** %arg1
   %122 = getelementptr inbounds i8, i8* %121, i64 6
-  %NullCheck96 = icmp ne i8* %122, null
-  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+  %NullCheck95 = icmp eq i8* %122, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %123
 
 ; <label>:123                                     ; preds = %118
   %124 = load i8, i8* %122, align 8
   %125 = zext i8 %124 to i32
   %126 = trunc i32 %125 to i8
-  %NullCheck98 = icmp ne i8* %120, null
-  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+  %NullCheck97 = icmp eq i8* %120, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %127
 
 ; <label>:127                                     ; preds = %123
   store i8 %126, i8* %120, align 8
@@ -899,14 +981,14 @@ entry:
   %129 = load i8*, i8** %arg0
   %130 = load i8*, i8** %arg1
   %131 = bitcast i8* %130 to i64*
-  %NullCheck84 = icmp ne i64* %131, null
-  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+  %NullCheck83 = icmp eq i64* %131, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %132
 
 ; <label>:132                                     ; preds = %128
   %133 = load i64, i64* %131, align 8
   %134 = bitcast i8* %129 to i64*
-  %NullCheck86 = icmp ne i64* %134, null
-  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+  %NullCheck85 = icmp eq i64* %134, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %135
 
 ; <label>:135                                     ; preds = %132
   store i64 %133, i64* %134, align 8
@@ -916,14 +998,14 @@ entry:
   %137 = load i8*, i8** %arg0
   %138 = load i8*, i8** %arg1
   %139 = bitcast i8* %138 to i64*
-  %NullCheck76 = icmp ne i64* %139, null
-  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+  %NullCheck75 = icmp eq i64* %139, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %140
 
 ; <label>:140                                     ; preds = %136
   %141 = load i64, i64* %139, align 8
   %142 = bitcast i8* %137 to i64*
-  %NullCheck78 = icmp ne i64* %142, null
-  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+  %NullCheck77 = icmp eq i64* %142, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %143
 
 ; <label>:143                                     ; preds = %140
   store i64 %141, i64* %142, align 8
@@ -931,15 +1013,15 @@ entry:
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %NullCheck80 = icmp ne i8* %147, null
-  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+  %NullCheck79 = icmp eq i8* %147, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %148
 
 ; <label>:148                                     ; preds = %143
   %149 = load i8, i8* %147, align 8
   %150 = zext i8 %149 to i32
   %151 = trunc i32 %150 to i8
-  %NullCheck82 = icmp ne i8* %145, null
-  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+  %NullCheck81 = icmp eq i8* %145, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %152
 
 ; <label>:152                                     ; preds = %148
   store i8 %151, i8* %145, align 8
@@ -949,14 +1031,14 @@ entry:
   %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
   %156 = bitcast i8* %155 to i64*
-  %NullCheck68 = icmp ne i64* %156, null
-  br i1 %NullCheck68, label %157, label %ThrowNullRef67
+  %NullCheck67 = icmp eq i64* %156, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %157
 
 ; <label>:157                                     ; preds = %153
   %158 = load i64, i64* %156, align 8
   %159 = bitcast i8* %154 to i64*
-  %NullCheck70 = icmp ne i64* %159, null
-  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+  %NullCheck69 = icmp eq i64* %159, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %160
 
 ; <label>:160                                     ; preds = %157
   store i64 %158, i64* %159, align 8
@@ -965,16 +1047,16 @@ entry:
   %163 = load i8*, i8** %arg1
   %164 = getelementptr inbounds i8, i8* %163, i64 8
   %165 = bitcast i8* %164 to i16*
-  %NullCheck72 = icmp ne i16* %165, null
-  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+  %NullCheck71 = icmp eq i16* %165, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %166
 
 ; <label>:166                                     ; preds = %160
   %167 = load i16, i16* %165, align 8
   %168 = sext i16 %167 to i32
   %169 = bitcast i8* %162 to i16*
   %170 = trunc i32 %168 to i16
-  %NullCheck74 = icmp ne i16* %169, null
-  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+  %NullCheck73 = icmp eq i16* %169, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %171
 
 ; <label>:171                                     ; preds = %166
   store i16 %170, i16* %169, align 8
@@ -984,14 +1066,14 @@ entry:
   %173 = load i8*, i8** %arg0
   %174 = load i8*, i8** %arg1
   %175 = bitcast i8* %174 to i64*
-  %NullCheck56 = icmp ne i64* %175, null
-  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+  %NullCheck55 = icmp eq i64* %175, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %176
 
 ; <label>:176                                     ; preds = %172
   %177 = load i64, i64* %175, align 8
   %178 = bitcast i8* %173 to i64*
-  %NullCheck58 = icmp ne i64* %178, null
-  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+  %NullCheck57 = icmp eq i64* %178, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %179
 
 ; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
@@ -1000,16 +1082,16 @@ entry:
   %182 = load i8*, i8** %arg1
   %183 = getelementptr inbounds i8, i8* %182, i64 8
   %184 = bitcast i8* %183 to i16*
-  %NullCheck60 = icmp ne i16* %184, null
-  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+  %NullCheck59 = icmp eq i16* %184, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %185
 
 ; <label>:185                                     ; preds = %179
   %186 = load i16, i16* %184, align 8
   %187 = sext i16 %186 to i32
   %188 = bitcast i8* %181 to i16*
   %189 = trunc i32 %187 to i16
-  %NullCheck62 = icmp ne i16* %188, null
-  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+  %NullCheck61 = icmp eq i16* %188, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %190
 
 ; <label>:190                                     ; preds = %185
   store i16 %189, i16* %188, align 8
@@ -1017,15 +1099,15 @@ entry:
   %192 = getelementptr inbounds i8, i8* %191, i64 10
   %193 = load i8*, i8** %arg1
   %194 = getelementptr inbounds i8, i8* %193, i64 10
-  %NullCheck64 = icmp ne i8* %194, null
-  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+  %NullCheck63 = icmp eq i8* %194, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %195
 
 ; <label>:195                                     ; preds = %190
   %196 = load i8, i8* %194, align 8
   %197 = zext i8 %196 to i32
   %198 = trunc i32 %197 to i8
-  %NullCheck66 = icmp ne i8* %192, null
-  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+  %NullCheck65 = icmp eq i8* %192, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %199
 
 ; <label>:199                                     ; preds = %195
   store i8 %198, i8* %192, align 8
@@ -1035,14 +1117,14 @@ entry:
   %201 = load i8*, i8** %arg0
   %202 = load i8*, i8** %arg1
   %203 = bitcast i8* %202 to i64*
-  %NullCheck48 = icmp ne i64* %203, null
-  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+  %NullCheck47 = icmp eq i64* %203, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %204
 
 ; <label>:204                                     ; preds = %200
   %205 = load i64, i64* %203, align 8
   %206 = bitcast i8* %201 to i64*
-  %NullCheck50 = icmp ne i64* %206, null
-  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+  %NullCheck49 = icmp eq i64* %206, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %207
 
 ; <label>:207                                     ; preds = %204
   store i64 %205, i64* %206, align 8
@@ -1051,14 +1133,14 @@ entry:
   %210 = load i8*, i8** %arg1
   %211 = getelementptr inbounds i8, i8* %210, i64 8
   %212 = bitcast i8* %211 to i32*
-  %NullCheck52 = icmp ne i32* %212, null
-  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+  %NullCheck51 = icmp eq i32* %212, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %213
 
 ; <label>:213                                     ; preds = %207
   %214 = load i32, i32* %212, align 8
   %215 = bitcast i8* %209 to i32*
-  %NullCheck54 = icmp ne i32* %215, null
-  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+  %NullCheck53 = icmp eq i32* %215, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %216
 
 ; <label>:216                                     ; preds = %213
   store i32 %214, i32* %215, align 8
@@ -1068,14 +1150,14 @@ entry:
   %218 = load i8*, i8** %arg0
   %219 = load i8*, i8** %arg1
   %220 = bitcast i8* %219 to i64*
-  %NullCheck36 = icmp ne i64* %220, null
-  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64* %220, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %221
 
 ; <label>:221                                     ; preds = %217
   %222 = load i64, i64* %220, align 8
   %223 = bitcast i8* %218 to i64*
-  %NullCheck38 = icmp ne i64* %223, null
-  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+  %NullCheck37 = icmp eq i64* %223, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %224
 
 ; <label>:224                                     ; preds = %221
   store i64 %222, i64* %223, align 8
@@ -1084,14 +1166,14 @@ entry:
   %227 = load i8*, i8** %arg1
   %228 = getelementptr inbounds i8, i8* %227, i64 8
   %229 = bitcast i8* %228 to i32*
-  %NullCheck40 = icmp ne i32* %229, null
-  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i32* %229, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %230
 
 ; <label>:230                                     ; preds = %224
   %231 = load i32, i32* %229, align 8
   %232 = bitcast i8* %226 to i32*
-  %NullCheck42 = icmp ne i32* %232, null
-  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+  %NullCheck41 = icmp eq i32* %232, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %233
 
 ; <label>:233                                     ; preds = %230
   store i32 %231, i32* %232, align 8
@@ -1099,15 +1181,15 @@ entry:
   %235 = getelementptr inbounds i8, i8* %234, i64 12
   %236 = load i8*, i8** %arg1
   %237 = getelementptr inbounds i8, i8* %236, i64 12
-  %NullCheck44 = icmp ne i8* %237, null
-  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i8* %237, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %238
 
 ; <label>:238                                     ; preds = %233
   %239 = load i8, i8* %237, align 8
   %240 = zext i8 %239 to i32
   %241 = trunc i32 %240 to i8
-  %NullCheck46 = icmp ne i8* %235, null
-  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+  %NullCheck45 = icmp eq i8* %235, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %242
 
 ; <label>:242                                     ; preds = %238
   store i8 %241, i8* %235, align 8
@@ -1117,14 +1199,14 @@ entry:
   %244 = load i8*, i8** %arg0
   %245 = load i8*, i8** %arg1
   %246 = bitcast i8* %245 to i64*
-  %NullCheck24 = icmp ne i64* %246, null
-  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64* %246, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %247
 
 ; <label>:247                                     ; preds = %243
   %248 = load i64, i64* %246, align 8
   %249 = bitcast i8* %244 to i64*
-  %NullCheck26 = icmp ne i64* %249, null
-  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64* %249, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %250
 
 ; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
@@ -1133,14 +1215,14 @@ entry:
   %253 = load i8*, i8** %arg1
   %254 = getelementptr inbounds i8, i8* %253, i64 8
   %255 = bitcast i8* %254 to i32*
-  %NullCheck28 = icmp ne i32* %255, null
-  br i1 %NullCheck28, label %256, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i32* %255, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %256
 
 ; <label>:256                                     ; preds = %250
   %257 = load i32, i32* %255, align 8
   %258 = bitcast i8* %252 to i32*
-  %NullCheck30 = icmp ne i32* %258, null
-  br i1 %NullCheck30, label %259, label %ThrowNullRef29
+  %NullCheck29 = icmp eq i32* %258, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %259
 
 ; <label>:259                                     ; preds = %256
   store i32 %257, i32* %258, align 8
@@ -1149,16 +1231,16 @@ entry:
   %262 = load i8*, i8** %arg1
   %263 = getelementptr inbounds i8, i8* %262, i64 12
   %264 = bitcast i8* %263 to i16*
-  %NullCheck32 = icmp ne i16* %264, null
-  br i1 %NullCheck32, label %265, label %ThrowNullRef31
+  %NullCheck31 = icmp eq i16* %264, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %265
 
 ; <label>:265                                     ; preds = %259
   %266 = load i16, i16* %264, align 8
   %267 = sext i16 %266 to i32
   %268 = bitcast i8* %261 to i16*
   %269 = trunc i32 %267 to i16
-  %NullCheck34 = icmp ne i16* %268, null
-  br i1 %NullCheck34, label %270, label %ThrowNullRef33
+  %NullCheck33 = icmp eq i16* %268, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %270
 
 ; <label>:270                                     ; preds = %265
   store i16 %269, i16* %268, align 8
@@ -1168,14 +1250,14 @@ entry:
   %272 = load i8*, i8** %arg0
   %273 = load i8*, i8** %arg1
   %274 = bitcast i8* %273 to i64*
-  %NullCheck8 = icmp ne i64* %274, null
-  br i1 %NullCheck8, label %275, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64* %274, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %275
 
 ; <label>:275                                     ; preds = %271
   %276 = load i64, i64* %274, align 8
   %277 = bitcast i8* %272 to i64*
-  %NullCheck10 = icmp ne i64* %277, null
-  br i1 %NullCheck10, label %278, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %277, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %278
 
 ; <label>:278                                     ; preds = %275
   store i64 %276, i64* %277, align 8
@@ -1184,14 +1266,14 @@ entry:
   %281 = load i8*, i8** %arg1
   %282 = getelementptr inbounds i8, i8* %281, i64 8
   %283 = bitcast i8* %282 to i32*
-  %NullCheck12 = icmp ne i32* %283, null
-  br i1 %NullCheck12, label %284, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i32* %283, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %284
 
 ; <label>:284                                     ; preds = %278
   %285 = load i32, i32* %283, align 8
   %286 = bitcast i8* %280 to i32*
-  %NullCheck14 = icmp ne i32* %286, null
-  br i1 %NullCheck14, label %287, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i32* %286, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %287
 
 ; <label>:287                                     ; preds = %284
   store i32 %285, i32* %286, align 8
@@ -1200,16 +1282,16 @@ entry:
   %290 = load i8*, i8** %arg1
   %291 = getelementptr inbounds i8, i8* %290, i64 12
   %292 = bitcast i8* %291 to i16*
-  %NullCheck16 = icmp ne i16* %292, null
-  br i1 %NullCheck16, label %293, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i16* %292, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %293
 
 ; <label>:293                                     ; preds = %287
   %294 = load i16, i16* %292, align 8
   %295 = sext i16 %294 to i32
   %296 = bitcast i8* %289 to i16*
   %297 = trunc i32 %295 to i16
-  %NullCheck18 = icmp ne i16* %296, null
-  br i1 %NullCheck18, label %298, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i16* %296, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %298
 
 ; <label>:298                                     ; preds = %293
   store i16 %297, i16* %296, align 8
@@ -1217,15 +1299,15 @@ entry:
   %300 = getelementptr inbounds i8, i8* %299, i64 14
   %301 = load i8*, i8** %arg1
   %302 = getelementptr inbounds i8, i8* %301, i64 14
-  %NullCheck20 = icmp ne i8* %302, null
-  br i1 %NullCheck20, label %303, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i8* %302, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %303
 
 ; <label>:303                                     ; preds = %298
   %304 = load i8, i8* %302, align 8
   %305 = zext i8 %304 to i32
   %306 = trunc i32 %305 to i8
-  %NullCheck22 = icmp ne i8* %300, null
-  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i8* %300, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %307
 
 ; <label>:307                                     ; preds = %303
   store i8 %306, i8* %300, align 8
@@ -1235,14 +1317,14 @@ entry:
   %309 = load i8*, i8** %arg0
   %310 = load i8*, i8** %arg1
   %311 = bitcast i8* %310 to i64*
-  %NullCheck = icmp ne i64* %311, null
-  br i1 %NullCheck, label %312, label %ThrowNullRef
+  %NullCheck = icmp eq i64* %311, null
+  br i1 %NullCheck, label %ThrowNullRef, label %312
 
 ; <label>:312                                     ; preds = %308
   %313 = load i64, i64* %311, align 8
   %314 = bitcast i8* %309 to i64*
-  %NullCheck2 = icmp ne i64* %314, null
-  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64* %314, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %315
 
 ; <label>:315                                     ; preds = %312
   store i64 %313, i64* %314, align 8
@@ -1251,14 +1333,14 @@ entry:
   %318 = load i8*, i8** %arg1
   %319 = getelementptr inbounds i8, i8* %318, i64 8
   %320 = bitcast i8* %319 to i64*
-  %NullCheck4 = icmp ne i64* %320, null
-  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64* %320, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %321
 
 ; <label>:321                                     ; preds = %315
   %322 = load i64, i64* %320, align 8
   %323 = bitcast i8* %317 to i64*
-  %NullCheck6 = icmp ne i64* %323, null
-  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64* %323, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %324
 
 ; <label>:324                                     ; preds = %321
   store i64 %322, i64* %323, align 8
@@ -1286,15 +1368,15 @@ entry:
 ; <label>:338                                     ; preds = %333
   %339 = load i8*, i8** %arg0
   %340 = load i8*, i8** %arg1
-  %NullCheck136 = icmp ne i8* %340, null
-  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+  %NullCheck135 = icmp eq i8* %340, null
+  br i1 %NullCheck135, label %ThrowNullRef136, label %341
 
 ; <label>:341                                     ; preds = %338
   %342 = load i8, i8* %340, align 8
   %343 = zext i8 %342 to i32
   %344 = trunc i32 %343 to i8
-  %NullCheck138 = icmp ne i8* %339, null
-  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+  %NullCheck137 = icmp eq i8* %339, null
+  br i1 %NullCheck137, label %ThrowNullRef138, label %345
 
 ; <label>:345                                     ; preds = %341
   store i8 %344, i8* %339, align 8
@@ -1317,16 +1399,16 @@ entry:
   %357 = load i8*, i8** %arg0
   %358 = load i8*, i8** %arg1
   %359 = bitcast i8* %358 to i16*
-  %NullCheck140 = icmp ne i16* %359, null
-  br i1 %NullCheck140, label %360, label %ThrowNullRef139
+  %NullCheck139 = icmp eq i16* %359, null
+  br i1 %NullCheck139, label %ThrowNullRef140, label %360
 
 ; <label>:360                                     ; preds = %356
   %361 = load i16, i16* %359, align 8
   %362 = sext i16 %361 to i32
   %363 = bitcast i8* %357 to i16*
   %364 = trunc i32 %362 to i16
-  %NullCheck142 = icmp ne i16* %363, null
-  br i1 %NullCheck142, label %365, label %ThrowNullRef141
+  %NullCheck141 = icmp eq i16* %363, null
+  br i1 %NullCheck141, label %ThrowNullRef142, label %365
 
 ; <label>:365                                     ; preds = %360
   store i16 %364, i16* %363, align 8
@@ -1352,14 +1434,14 @@ entry:
   %378 = load i8*, i8** %arg0
   %379 = load i8*, i8** %arg1
   %380 = bitcast i8* %379 to i32*
-  %NullCheck144 = icmp ne i32* %380, null
-  br i1 %NullCheck144, label %381, label %ThrowNullRef143
+  %NullCheck143 = icmp eq i32* %380, null
+  br i1 %NullCheck143, label %ThrowNullRef144, label %381
 
 ; <label>:381                                     ; preds = %377
   %382 = load i32, i32* %380, align 8
   %383 = bitcast i8* %378 to i32*
-  %NullCheck146 = icmp ne i32* %383, null
-  br i1 %NullCheck146, label %384, label %ThrowNullRef145
+  %NullCheck145 = icmp eq i32* %383, null
+  br i1 %NullCheck145, label %ThrowNullRef146, label %384
 
 ; <label>:384                                     ; preds = %381
   store i32 %382, i32* %383, align 8
@@ -1384,14 +1466,14 @@ entry:
   %395 = load i8*, i8** %arg0
   %396 = load i8*, i8** %arg1
   %397 = bitcast i8* %396 to i64*
-  %NullCheck164 = icmp ne i64* %397, null
-  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+  %NullCheck163 = icmp eq i64* %397, null
+  br i1 %NullCheck163, label %ThrowNullRef164, label %398
 
 ; <label>:398                                     ; preds = %394
   %399 = load i64, i64* %397, align 8
   %400 = bitcast i8* %395 to i64*
-  %NullCheck166 = icmp ne i64* %400, null
-  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+  %NullCheck165 = icmp eq i64* %400, null
+  br i1 %NullCheck165, label %ThrowNullRef166, label %401
 
 ; <label>:401                                     ; preds = %398
   store i64 %399, i64* %400, align 8
@@ -1400,14 +1482,14 @@ entry:
   %404 = load i8*, i8** %arg1
   %405 = getelementptr inbounds i8, i8* %404, i64 8
   %406 = bitcast i8* %405 to i64*
-  %NullCheck168 = icmp ne i64* %406, null
-  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+  %NullCheck167 = icmp eq i64* %406, null
+  br i1 %NullCheck167, label %ThrowNullRef168, label %407
 
 ; <label>:407                                     ; preds = %401
   %408 = load i64, i64* %406, align 8
   %409 = bitcast i8* %403 to i64*
-  %NullCheck170 = icmp ne i64* %409, null
-  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+  %NullCheck169 = icmp eq i64* %409, null
+  br i1 %NullCheck169, label %ThrowNullRef170, label %410
 
 ; <label>:410                                     ; preds = %407
   store i64 %408, i64* %409, align 8
@@ -1437,14 +1519,14 @@ entry:
   %425 = load i8*, i8** %arg0
   %426 = load i8*, i8** %arg1
   %427 = bitcast i8* %426 to i64*
-  %NullCheck148 = icmp ne i64* %427, null
-  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+  %NullCheck147 = icmp eq i64* %427, null
+  br i1 %NullCheck147, label %ThrowNullRef148, label %428
 
 ; <label>:428                                     ; preds = %424
   %429 = load i64, i64* %427, align 8
   %430 = bitcast i8* %425 to i64*
-  %NullCheck150 = icmp ne i64* %430, null
-  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+  %NullCheck149 = icmp eq i64* %430, null
+  br i1 %NullCheck149, label %ThrowNullRef150, label %431
 
 ; <label>:431                                     ; preds = %428
   store i64 %429, i64* %430, align 8
@@ -1466,14 +1548,14 @@ entry:
   %441 = load i8*, i8** %arg0
   %442 = load i8*, i8** %arg1
   %443 = bitcast i8* %442 to i32*
-  %NullCheck152 = icmp ne i32* %443, null
-  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+  %NullCheck151 = icmp eq i32* %443, null
+  br i1 %NullCheck151, label %ThrowNullRef152, label %444
 
 ; <label>:444                                     ; preds = %440
   %445 = load i32, i32* %443, align 8
   %446 = bitcast i8* %441 to i32*
-  %NullCheck154 = icmp ne i32* %446, null
-  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+  %NullCheck153 = icmp eq i32* %446, null
+  br i1 %NullCheck153, label %ThrowNullRef154, label %447
 
 ; <label>:447                                     ; preds = %444
   store i32 %445, i32* %446, align 8
@@ -1495,16 +1577,16 @@ entry:
   %457 = load i8*, i8** %arg0
   %458 = load i8*, i8** %arg1
   %459 = bitcast i8* %458 to i16*
-  %NullCheck156 = icmp ne i16* %459, null
-  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+  %NullCheck155 = icmp eq i16* %459, null
+  br i1 %NullCheck155, label %ThrowNullRef156, label %460
 
 ; <label>:460                                     ; preds = %456
   %461 = load i16, i16* %459, align 8
   %462 = sext i16 %461 to i32
   %463 = bitcast i8* %457 to i16*
   %464 = trunc i32 %462 to i16
-  %NullCheck158 = icmp ne i16* %463, null
-  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+  %NullCheck157 = icmp eq i16* %463, null
+  br i1 %NullCheck157, label %ThrowNullRef158, label %465
 
 ; <label>:465                                     ; preds = %460
   store i16 %464, i16* %463, align 8
@@ -1525,15 +1607,15 @@ entry:
 ; <label>:474                                     ; preds = %470
   %475 = load i8*, i8** %arg0
   %476 = load i8*, i8** %arg1
-  %NullCheck160 = icmp ne i8* %476, null
-  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+  %NullCheck159 = icmp eq i8* %476, null
+  br i1 %NullCheck159, label %ThrowNullRef160, label %477
 
 ; <label>:477                                     ; preds = %474
   %478 = load i8, i8* %476, align 8
   %479 = zext i8 %478 to i32
   %480 = trunc i32 %479 to i8
-  %NullCheck162 = icmp ne i8* %475, null
-  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+  %NullCheck161 = icmp eq i8* %475, null
+  br i1 %NullCheck161, label %ThrowNullRef162, label %481
 
 ; <label>:481                                     ; preds = %477
   store i8 %480, i8* %475, align 8
@@ -1553,343 +1635,343 @@ ThrowNullRef:                                     ; preds = %308
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %312
+ThrowNullRef2:                                    ; preds = %312
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %315
+ThrowNullRef4:                                    ; preds = %315
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %321
+ThrowNullRef6:                                    ; preds = %321
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %271
+ThrowNullRef8:                                    ; preds = %271
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %275
+ThrowNullRef10:                                   ; preds = %275
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %278
+ThrowNullRef12:                                   ; preds = %278
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %284
+ThrowNullRef14:                                   ; preds = %284
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %287
+ThrowNullRef16:                                   ; preds = %287
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %293
+ThrowNullRef18:                                   ; preds = %293
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %298
+ThrowNullRef20:                                   ; preds = %298
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %303
+ThrowNullRef22:                                   ; preds = %303
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %243
+ThrowNullRef24:                                   ; preds = %243
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %247
+ThrowNullRef26:                                   ; preds = %247
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %250
+ThrowNullRef28:                                   ; preds = %250
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %256
+ThrowNullRef30:                                   ; preds = %256
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %259
+ThrowNullRef32:                                   ; preds = %259
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %265
+ThrowNullRef34:                                   ; preds = %265
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %217
+ThrowNullRef36:                                   ; preds = %217
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %221
+ThrowNullRef38:                                   ; preds = %221
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %224
+ThrowNullRef40:                                   ; preds = %224
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %230
+ThrowNullRef42:                                   ; preds = %230
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %233
+ThrowNullRef44:                                   ; preds = %233
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %238
+ThrowNullRef46:                                   ; preds = %238
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %200
+ThrowNullRef48:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %204
+ThrowNullRef50:                                   ; preds = %204
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %207
+ThrowNullRef52:                                   ; preds = %207
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %213
+ThrowNullRef54:                                   ; preds = %213
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %172
+ThrowNullRef56:                                   ; preds = %172
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %176
+ThrowNullRef58:                                   ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %179
+ThrowNullRef60:                                   ; preds = %179
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %185
+ThrowNullRef62:                                   ; preds = %185
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %190
+ThrowNullRef64:                                   ; preds = %190
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %195
+ThrowNullRef66:                                   ; preds = %195
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %153
+ThrowNullRef68:                                   ; preds = %153
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %157
+ThrowNullRef70:                                   ; preds = %157
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %160
+ThrowNullRef72:                                   ; preds = %160
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %166
+ThrowNullRef74:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %136
+ThrowNullRef76:                                   ; preds = %136
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %140
+ThrowNullRef78:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %143
+ThrowNullRef80:                                   ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %148
+ThrowNullRef82:                                   ; preds = %148
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %128
+ThrowNullRef84:                                   ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %132
+ThrowNullRef86:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %100
+ThrowNullRef88:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %104
+ThrowNullRef90:                                   ; preds = %104
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %107
+ThrowNullRef92:                                   ; preds = %107
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %113
+ThrowNullRef94:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %118
+ThrowNullRef96:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %123
+ThrowNullRef98:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %81
+ThrowNullRef100:                                  ; preds = %81
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef101:                                  ; preds = %85
+ThrowNullRef102:                                  ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef103:                                  ; preds = %88
+ThrowNullRef104:                                  ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef105:                                  ; preds = %94
+ThrowNullRef106:                                  ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef107:                                  ; preds = %64
+ThrowNullRef108:                                  ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef109:                                  ; preds = %68
+ThrowNullRef110:                                  ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef111:                                  ; preds = %71
+ThrowNullRef112:                                  ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef113:                                  ; preds = %76
+ThrowNullRef114:                                  ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef115:                                  ; preds = %56
+ThrowNullRef116:                                  ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef117:                                  ; preds = %60
+ThrowNullRef118:                                  ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef119:                                  ; preds = %37
+ThrowNullRef120:                                  ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef121:                                  ; preds = %41
+ThrowNullRef122:                                  ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef123:                                  ; preds = %46
+ThrowNullRef124:                                  ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef125:                                  ; preds = %51
+ThrowNullRef126:                                  ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef127:                                  ; preds = %27
+ThrowNullRef128:                                  ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef129:                                  ; preds = %31
+ThrowNullRef130:                                  ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef131:                                  ; preds = %19
+ThrowNullRef132:                                  ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef133:                                  ; preds = %22
+ThrowNullRef134:                                  ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef135:                                  ; preds = %338
+ThrowNullRef136:                                  ; preds = %338
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef137:                                  ; preds = %341
+ThrowNullRef138:                                  ; preds = %341
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef139:                                  ; preds = %356
+ThrowNullRef140:                                  ; preds = %356
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef141:                                  ; preds = %360
+ThrowNullRef142:                                  ; preds = %360
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef143:                                  ; preds = %377
+ThrowNullRef144:                                  ; preds = %377
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef145:                                  ; preds = %381
+ThrowNullRef146:                                  ; preds = %381
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef147:                                  ; preds = %424
+ThrowNullRef148:                                  ; preds = %424
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef149:                                  ; preds = %428
+ThrowNullRef150:                                  ; preds = %428
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef151:                                  ; preds = %440
+ThrowNullRef152:                                  ; preds = %440
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef153:                                  ; preds = %444
+ThrowNullRef154:                                  ; preds = %444
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef155:                                  ; preds = %456
+ThrowNullRef156:                                  ; preds = %456
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef157:                                  ; preds = %460
+ThrowNullRef158:                                  ; preds = %460
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef159:                                  ; preds = %474
+ThrowNullRef160:                                  ; preds = %474
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef161:                                  ; preds = %477
+ThrowNullRef162:                                  ; preds = %477
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef163:                                  ; preds = %394
+ThrowNullRef164:                                  ; preds = %394
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef165:                                  ; preds = %398
+ThrowNullRef166:                                  ; preds = %398
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef167:                                  ; preds = %401
+ThrowNullRef168:                                  ; preds = %401
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef169:                                  ; preds = %407
+ThrowNullRef170:                                  ; preds = %407
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1939,8 +2021,8 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
-  br i1 %NullCheck, label %22, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %ThrowNullRef, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
@@ -1948,8 +2030,8 @@ entry:
   store i32 %24, i32* %loc0
   %25 = load i32, i32* %loc0
   %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %26, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %27
 
 ; <label>:27                                      ; preds = %22
   %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
@@ -1971,7 +2053,7 @@ ThrowNullRef:                                     ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1989,8 +2071,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -2022,15 +2104,15 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2048,16 +2130,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
   %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
   store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %15
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
@@ -2072,8 +2154,8 @@ entry:
   %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
   %29 = ptrtoint i16 addrspace(1)* %28 to i64
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %19
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
@@ -2089,19 +2171,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2114,8 +2196,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
@@ -2128,7 +2210,7 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[loadElem]
+Failed to read AppDomain.PrepareDataForSetup[storeElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
@@ -2202,8 +2284,8 @@ entry:
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
-  br i1 %NullCheck24, label %27, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = load i64, i64 addrspace(1)* %26
@@ -2218,8 +2300,8 @@ entry:
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
-  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
   %41 = load i64, i64 addrspace(1)* %39
@@ -2236,8 +2318,8 @@ entry:
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
-  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
   %54 = load i64, i64 addrspace(1)* %52
@@ -2252,8 +2334,8 @@ entry:
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
   %67 = load i64, i64 addrspace(1)* %65
@@ -2270,8 +2352,8 @@ entry:
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
-  br i1 %NullCheck16, label %79, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
   %80 = load i64, i64 addrspace(1)* %78
@@ -2286,8 +2368,8 @@ entry:
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
-  br i1 %NullCheck18, label %92, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
   %93 = load i64, i64 addrspace(1)* %91
@@ -2304,8 +2386,8 @@ entry:
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
-  br i1 %NullCheck12, label %105, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = load i64, i64 addrspace(1)* %104
@@ -2320,8 +2402,8 @@ entry:
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
-  br i1 %NullCheck14, label %118, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
   %119 = load i64, i64 addrspace(1)* %117
@@ -2337,8 +2419,8 @@ entry:
 
 ; <label>:128                                     ; preds = %20
   %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
-  br i1 %NullCheck4, label %130, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %129, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %130
 
 ; <label>:130                                     ; preds = %128
   %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
@@ -2346,8 +2428,8 @@ entry:
   %133 = load i16, i16 addrspace(1)* %132, align 8
   %134 = zext i16 %133 to i32
   %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
-  br i1 %NullCheck6, label %136, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %135, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %136
 
 ; <label>:136                                     ; preds = %130
   %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
@@ -2360,8 +2442,8 @@ entry:
 
 ; <label>:143                                     ; preds = %136
   %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
-  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %144, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %145
 
 ; <label>:145                                     ; preds = %143
   %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
@@ -2369,8 +2451,8 @@ entry:
   %148 = load i16, i16 addrspace(1)* %147, align 8
   %149 = zext i16 %148 to i32
   %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %150, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %151
 
 ; <label>:151                                     ; preds = %145
   %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
@@ -2388,8 +2470,8 @@ entry:
 
 ; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
-  br i1 %NullCheck, label %163, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %ThrowNullRef, label %163
 
 ; <label>:163                                     ; preds = %161
   %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
@@ -2399,8 +2481,8 @@ entry:
 
 ; <label>:167                                     ; preds = %163
   %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
-  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %168, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %169
 
 ; <label>:169                                     ; preds = %167
   %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
@@ -2432,55 +2514,55 @@ ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %167
+ThrowNullRef2:                                    ; preds = %167
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %128
+ThrowNullRef4:                                    ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %130
+ThrowNullRef6:                                    ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %143
+ThrowNullRef8:                                    ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %145
+ThrowNullRef10:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %102
+ThrowNullRef12:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %105
+ThrowNullRef14:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %76
+ThrowNullRef16:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %79
+ThrowNullRef18:                                   ; preds = %79
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %50
+ThrowNullRef20:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %53
+ThrowNullRef22:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %24
+ThrowNullRef24:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %27
+ThrowNullRef26:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2503,15 +2585,15 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2519,16 +2601,16 @@ entry:
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
   store i32 %8, i32* %loc0
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
   %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
   store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
@@ -2546,16 +2628,16 @@ entry:
 
 ; <label>:23                                      ; preds = %64
   %24 = load i16*, i16** %loc3
-  %NullCheck12 = icmp ne i16* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i16* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
   store i32 %27, i32* %loc5
   %28 = load i16*, i16** %loc4
-  %NullCheck14 = icmp ne i16* %28, null
-  br i1 %NullCheck14, label %29, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %28, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = load i16, i16* %28, align 8
@@ -2620,15 +2702,15 @@ entry:
 
 ; <label>:67                                      ; preds = %64
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
-  br i1 %NullCheck8, label %69, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %68, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %69
 
 ; <label>:69                                      ; preds = %67
   %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
   %71 = load i32, i32 addrspace(1)* %70
   %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
-  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %73
 
 ; <label>:73                                      ; preds = %69
   %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
@@ -2645,31 +2727,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %67
+ThrowNullRef8:                                    ; preds = %67
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %69
+ThrowNullRef10:                                   ; preds = %69
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2710,14 +2792,14 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
   %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
@@ -2730,14 +2812,14 @@ entry:
 
 ; <label>:11                                      ; preds = %4
   %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
   %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
@@ -2749,14 +2831,14 @@ entry:
 
 ; <label>:22                                      ; preds = %16
   %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
   %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
-  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
-  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
@@ -2804,23 +2886,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2836,7 +2918,280 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[loadElem]
+Successfully read RuntimeType.IsAssignableFrom
+
+define i8 @RuntimeType.IsAssignableFrom(%System.RuntimeType addrspace(1)* %param0, %System.Type addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.RuntimeType addrspace(1)*
+  %arg1 = alloca %System.Type addrspace(1)*
+  %loc0 = alloca %System.RuntimeType addrspace(1)*
+  %loc1 = alloca %"System.Type[]" addrspace(1)*
+  %loc2 = alloca i32
+  store %System.RuntimeType addrspace(1)* %param0, %System.RuntimeType addrspace(1)** %this
+  store %System.Type addrspace(1)* %param1, %System.Type addrspace(1)** %arg1
+  %0 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %1 = icmp ne %System.Type addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i8 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %5 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %6 = bitcast %System.Type addrspace(1)* %4 to %System.Object addrspace(1)*
+  %7 = bitcast %System.RuntimeType addrspace(1)* %5 to %System.Object addrspace(1)*
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %6, %System.Object addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %3
+  ret i8 1
+
+; <label>:12                                      ; preds = %3
+  %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 152
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 32
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
+  %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
+  %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
+  store %System.RuntimeType addrspace(1)* %25, %System.RuntimeType addrspace(1)** %loc0
+  %26 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %27 = icmp eq %System.RuntimeType addrspace(1)* %26, null
+  br i1 %27, label %34, label %28
+
+; <label>:28                                      ; preds = %15
+  %29 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %30 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)*)*)(%System.RuntimeType addrspace(1)* %29, %System.RuntimeType addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+; <label>:34                                      ; preds = %15
+  %35 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %36 = call %System.Reflection.Emit.TypeBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Reflection.Emit.TypeBuilder addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %35)
+  %37 = icmp eq %System.Reflection.Emit.TypeBuilder addrspace(1)* %36, null
+  br i1 %37, label %139, label %38
+
+; <label>:38                                      ; preds = %34
+  %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %42
+
+; <label>:42                                      ; preds = %38
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 152
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 40
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
+  %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
+  %53 = zext i8 %52 to i32
+  %54 = icmp eq i32 %53, 0
+  br i1 %54, label %56, label %55
+
+; <label>:55                                      ; preds = %42
+  ret i8 1
+
+; <label>:56                                      ; preds = %42
+  %57 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %58 = bitcast %System.RuntimeType addrspace(1)* %57 to %System.Type addrspace(1)*
+  %59 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %58)
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %64 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.Type addrspace(1)* %63, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = bitcast %System.RuntimeType addrspace(1)* %64 to %System.Type addrspace(1)*
+  %67 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %63, %System.Type addrspace(1)* %66)
+  %68 = zext i8 %67 to i32
+  %69 = trunc i32 %68 to i8
+  ret i8 %69
+
+; <label>:70                                      ; preds = %56
+  %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
+  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %73
+
+; <label>:73                                      ; preds = %70
+  %74 = load i64, i64 addrspace(1)* %72
+  %75 = add i64 %74, 128
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = add i64 %77, 0
+  %79 = inttoptr i64 %78 to i64*
+  %80 = load i64, i64* %79
+  %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
+  %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
+  %83 = call i8 %82(%System.Type addrspace(1)* %81)
+  %84 = zext i8 %83 to i32
+  %85 = icmp eq i32 %84, 0
+  br i1 %85, label %139, label %86
+
+; <label>:86                                      ; preds = %73
+  %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
+  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %89
+
+; <label>:89                                      ; preds = %86
+  %90 = load i64, i64 addrspace(1)* %88
+  %91 = add i64 %90, 128
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = add i64 %93, 24
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
+  %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
+  %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
+  store %"System.Type[]" addrspace(1)* %99, %"System.Type[]" addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %129
+
+; <label>:100                                     ; preds = %132
+  %101 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %102 = load i32, i32* %loc2
+  %NullCheck11 = icmp eq %"System.Type[]" addrspace(1)* %101, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %103
+
+; <label>:103                                     ; preds = %100
+  %104 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 1
+  %105 = load i32, i32 addrspace(1)* %104
+  %106 = zext i32 %105 to i64
+  %107 = zext i32 %102 to i64
+  %BoundsCheck = icmp uge i64 %107, %106
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %108
+
+; <label>:108                                     ; preds = %103
+  %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
+  %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
+  %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
+  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %113
+
+; <label>:113                                     ; preds = %108
+  %114 = load i64, i64 addrspace(1)* %112
+  %115 = add i64 %114, 152
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = add i64 %117, 56
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
+  %123 = zext i8 %122 to i32
+  %124 = icmp ne i32 %123, 0
+  br i1 %124, label %126, label %125
+
+; <label>:125                                     ; preds = %113
+  ret i8 0
+
+; <label>:126                                     ; preds = %113
+  %127 = load i32, i32* %loc2
+  %128 = add i32 %127, 1
+  store i32 %128, i32* %loc2
+  br label %129
+
+; <label>:129                                     ; preds = %89, %126
+  %130 = load i32, i32* %loc2
+  %131 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %NullCheck9 = icmp eq %"System.Type[]" addrspace(1)* %131, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %132
+
+; <label>:132                                     ; preds = %129
+  %133 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %131, i32 0, i32 1
+  %134 = load i32, i32 addrspace(1)* %133
+  %135 = zext i32 %134 to i64
+  %136 = trunc i64 %135 to i32
+  %137 = icmp slt i32 %130, %136
+  br i1 %137, label %100, label %138
+
+; <label>:138                                     ; preds = %132
+  ret i8 1
+
+; <label>:139                                     ; preds = %34, %73
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %129
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %103
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -2893,7 +3248,7 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElem]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -2904,8 +3259,8 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -2997,8 +3352,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
@@ -3059,8 +3414,8 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -3087,8 +3442,8 @@ entry:
 
 ; <label>:17                                      ; preds = %5, %11
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
@@ -3097,8 +3452,8 @@ entry:
 
 ; <label>:22                                      ; preds = %1, %11
   %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
@@ -3109,11 +3464,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %17
+ThrowNullRef2:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %22
+ThrowNullRef4:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3167,15 +3522,15 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
   %15 = load i32, i32 addrspace(1)* %14
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
@@ -3198,7 +3553,7 @@ ThrowNullRef:                                     ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef2:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3232,8 +3587,8 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
@@ -3312,8 +3667,8 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -3327,8 +3682,8 @@ entry:
 ; <label>:5                                       ; preds = %43
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %7 = load i32, i32* %loc1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck6, label %8, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
@@ -3366,8 +3721,8 @@ entry:
 ; <label>:32                                      ; preds = %21, %25
   %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
   %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
-  br i1 %NullCheck8, label %35, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = trunc i32 %34 to i16
@@ -3380,8 +3735,8 @@ entry:
 ; <label>:40                                      ; preds = %1, %35
   %41 = load i32, i32* %loc1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
-  br i1 %NullCheck2, label %43, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %42, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
@@ -3392,8 +3747,8 @@ entry:
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
   %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
-  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
   %51 = load i64, i64 addrspace(1)* %49
@@ -3412,19 +3767,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %40
+ThrowNullRef2:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %47
+ThrowNullRef4:                                    ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %5
+ThrowNullRef6:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %32
+ThrowNullRef8:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3467,8 +3822,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
@@ -3492,11 +3847,391 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(i16* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store i16* %param0, i16** %arg0
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load i32, i32* %arg3
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %42, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %37, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg2
+  %13 = load i32, i32* %arg3
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %37, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %24 = load i32, i32* %arg2
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load i16*, i16** %arg0
+  %35 = load i32, i32* %arg3
+  %36 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %36, i16* %34, i32 %35)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:37                                      ; preds = %5, %16
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %39)
+  %41 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41, %System.String addrspace(1)* %38, %System.String addrspace(1)* %40)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41) #0
+  unreachable
+
+; <label>:42                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
-Failed to read StringBuilder.ToString[loadElemA]
+Successfully read StringBuilder.ToString
+
+define %System.String addrspace(1)* @StringBuilder.ToString(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i16*
+  %loc3 = alloca %"System.Char[]" addrspace(1)*
+  %loc4 = alloca i32
+  %loc5 = alloca i32
+  %loc6 = alloca i16 addrspace(1)*
+  %loc7 = alloca %System.String addrspace(1)*
+  %loc8 = alloca %"System.Char[]" addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %0)
+  %2 = icmp ne i32 %1, 0
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %4
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %6)
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %7)
+  store %System.String addrspace(1)* %8, %System.String addrspace(1)** %loc0
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.Text.StringBuilder addrspace(1)* %9, %System.Text.StringBuilder addrspace(1)** %loc1
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  store %System.String addrspace(1)* %10, %System.String addrspace(1)** %loc7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc7
+  %12 = ptrtoint %System.String addrspace(1)* %11 to i64
+  %13 = icmp eq i64 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %5
+  %15 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %16 = sext i32 %15 to i64
+  %17 = add i64 %12, %16
+  br label %18
+
+; <label>:18                                      ; preds = %5, %14
+  %19 = phi i64 [ %12, %5 ], [ %17, %14 ]
+  %20 = inttoptr i64 %19 to i16*
+  store i16* %20, i16** %loc2
+  br label %21
+
+; <label>:21                                      ; preds = %98, %18
+  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %22, null
+  br i1 %NullCheck, label %ThrowNullRef, label %23
+
+; <label>:23                                      ; preds = %21
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 3
+  %25 = load i32, i32 addrspace(1)* %24, align 8
+  %26 = icmp sle i32 %25, 0
+  br i1 %26, label %96, label %27
+
+; <label>:27                                      ; preds = %23
+  %28 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %28, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %29
+
+; <label>:29                                      ; preds = %27
+  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %28, i32 0, i32 1
+  %31 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %30, align 8
+  store %"System.Char[]" addrspace(1)* %31, %"System.Char[]" addrspace(1)** %loc3
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %33
+
+; <label>:33                                      ; preds = %29
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  store i32 %35, i32* %loc4
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  %39 = load i32, i32 addrspace(1)* %38, align 8
+  store i32 %39, i32* %loc5
+  %40 = load i32, i32* %loc5
+  %41 = load i32, i32* %loc4
+  %42 = add i32 %40, %41
+  %43 = zext i32 %42 to i64
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %45
+
+; <label>:45                                      ; preds = %37
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = sext i32 %47 to i64
+  %49 = icmp sgt i64 %43, %48
+  br i1 %49, label %91, label %50
+
+; <label>:50                                      ; preds = %45
+  %51 = load i32, i32* %loc5
+  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %52, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %53
+
+; <label>:53                                      ; preds = %50
+  %54 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %52, i32 0, i32 1
+  %55 = load i32, i32 addrspace(1)* %54
+  %56 = zext i32 %55 to i64
+  %57 = trunc i64 %56 to i32
+  %58 = icmp ugt i32 %51, %57
+  br i1 %58, label %91, label %59
+
+; <label>:59                                      ; preds = %53
+  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  store %"System.Char[]" addrspace(1)* %60, %"System.Char[]" addrspace(1)** %loc8
+  %61 = icmp eq %"System.Char[]" addrspace(1)* %60, null
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %63, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %64
+
+; <label>:64                                      ; preds = %62
+  %65 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %63, i32 0, i32 1
+  %66 = load i32, i32 addrspace(1)* %65
+  %67 = zext i32 %66 to i64
+  %68 = trunc i64 %67 to i32
+  %69 = icmp ne i32 %68, 0
+  br i1 %69, label %71, label %70
+
+; <label>:70                                      ; preds = %59, %64
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:71                                      ; preds = %64
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %73
+
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %BoundsCheck = icmp uge i64 0, %76
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %77
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %78, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:79                                      ; preds = %70, %77
+  %80 = load i16*, i16** %loc2
+  %81 = load i32, i32* %loc4
+  %82 = sext i32 %81 to i64
+  %83 = mul i64 %82, 2
+  %84 = bitcast i16* %80 to i8*
+  %85 = getelementptr inbounds i8, i8* %84, i64 %83
+  %86 = load i16 addrspace(1)*, i16 addrspace(1)** %loc6
+  %87 = ptrtoint i16 addrspace(1)* %86 to i64
+  %88 = load i32, i32* %loc5
+  %89 = bitcast i8* %85 to i16*
+  %90 = inttoptr i64 %87 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %89, i16* %90, i32 %88)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %96
+
+; <label>:91                                      ; preds = %45, %53
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %94 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %93)
+  %95 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95, %System.String addrspace(1)* %92, %System.String addrspace(1)* %94)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95) #0
+  unreachable
+
+; <label>:96                                      ; preds = %23, %79
+  %97 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %97, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %98
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %97, i32 0, i32 2
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  store %System.Text.StringBuilder addrspace(1)* %100, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %102 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %102, label %21, label %103
+
+; <label>:103                                     ; preds = %98
+  store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc7
+  %104 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  ret %System.String addrspace(1)* %104
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method StringBuilder::get_Length using LLILCJit
+Successfully read StringBuilder.get_Length
+
+define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
+Successfully read RuntimeHelpers.get_OffsetToStringData
+
+define i32 @RuntimeHelpers.get_OffsetToStringData() {
+entry:
+  ret i32 12
+}
+
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
 Successfully read CultureData.CreateCultureData
 
@@ -3514,23 +4249,23 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
   store i8 %4, i8 addrspace(1)* %6
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
@@ -3549,11 +4284,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3566,50 +4301,50 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
   store i32 -1, i32 addrspace(1)* %2
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
   store i32 -1, i32 addrspace(1)* %8
   %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
   store i32 -1, i32 addrspace(1)* %14
   %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
   store i32 -1, i32 addrspace(1)* %17
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
@@ -3623,27 +4358,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3675,7 +4410,136 @@ Failed to read Dictionary`2.Insert[non-const derefAddress]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
 Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
-Failed to read HashHelpers.GetPrime[loadElem]
+Successfully read HashHelpers.GetPrime
+
+define i32 @HashHelpers.GetPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %6, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5, %System.String addrspace(1)* %4)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5) #0
+  unreachable
+
+; <label>:6                                       ; preds = %entry
+  store i32 0, i32* %loc0
+  br label %29
+
+; <label>:7                                       ; preds = %35
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 1296
+  %10 = addrspacecast i8 addrspace(1)* %9 to %"System.Int32[]" addrspace(1)**
+  %11 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %10
+  %12 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Int32[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = zext i32 %15 to i64
+  %17 = zext i32 %12 to i64
+  %BoundsCheck = icmp uge i64 %17, %16
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 3, i32 %12
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  store i32 %20, i32* %loc1
+  %21 = load i32, i32* %loc1
+  %22 = load i32, i32* %arg0
+  %23 = icmp slt i32 %21, %22
+  br i1 %23, label %26, label %24
+
+; <label>:24                                      ; preds = %18
+  %25 = load i32, i32* %loc1
+  ret i32 %25
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %loc0
+  %28 = add i32 %27, 1
+  store i32 %28, i32* %loc0
+  br label %29
+
+; <label>:29                                      ; preds = %6, %26
+  %30 = load i32, i32* %loc0
+  %31 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %32 = getelementptr inbounds i8, i8 addrspace(1)* %31, i64 1296
+  %33 = addrspacecast i8 addrspace(1)* %32 to %"System.Int32[]" addrspace(1)**
+  %34 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %33
+  %NullCheck = icmp eq %"System.Int32[]" addrspace(1)* %34, null
+  br i1 %NullCheck, label %ThrowNullRef, label %35
+
+; <label>:35                                      ; preds = %29
+  %36 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %34, i32 0, i32 1
+  %37 = load i32, i32 addrspace(1)* %36
+  %38 = zext i32 %37 to i64
+  %39 = trunc i64 %38 to i32
+  %40 = icmp slt i32 %30, %39
+  br i1 %40, label %7, label %41
+
+; <label>:41                                      ; preds = %35
+  %42 = load i32, i32* %arg0
+  %43 = or i32 %42, 1
+  store i32 %43, i32* %loc2
+  br label %59
+
+; <label>:44                                      ; preds = %59
+  %45 = load i32, i32* %loc2
+  %46 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %45)
+  %47 = zext i8 %46 to i32
+  %48 = icmp eq i32 %47, 0
+  br i1 %48, label %56, label %49
+
+; <label>:49                                      ; preds = %44
+  %50 = load i32, i32* %loc2
+  %51 = sub i32 %50, 1
+  %52 = srem i32 %51, 101
+  %53 = icmp eq i32 %52, 0
+  br i1 %53, label %56, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = load i32, i32* %loc2
+  ret i32 %55
+
+; <label>:56                                      ; preds = %44, %49
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %57, 2
+  store i32 %58, i32* %loc2
+  br label %59
+
+; <label>:59                                      ; preds = %41, %56
+  %60 = load i32, i32* %loc2
+  %61 = icmp slt i32 %60, 2147483647
+  br i1 %61, label %44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load i32, i32* %arg0
+  ret i32 %63
+
+ThrowNullRef:                                     ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
 Successfully read GenericEqualityComparer`1.GetHashCode
 
@@ -3694,14 +4558,14 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
   %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load i64, i64 addrspace(1)* %7
@@ -3720,7 +4584,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3750,8 +4614,8 @@ entry:
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
@@ -3796,8 +4660,8 @@ entry:
   %35 = bitcast i16* %34 to i8*
   %36 = getelementptr inbounds i8, i8* %35, i64 2
   %37 = bitcast i8* %36 to i16*
-  %NullCheck4 = icmp ne i16* %37, null
-  br i1 %NullCheck4, label %38, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %37, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %38
 
 ; <label>:38                                      ; preds = %27
   %39 = load i16, i16* %37, align 8
@@ -3824,8 +4688,8 @@ entry:
 
 ; <label>:54                                      ; preds = %22, %43
   %55 = load i16*, i16** %loc4
-  %NullCheck2 = icmp ne i16* %55, null
-  br i1 %NullCheck2, label %56, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i16* %55, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %56
 
 ; <label>:56                                      ; preds = %54
   %57 = load i16, i16* %55, align 8
@@ -3850,11 +4714,11 @@ ThrowNullRef:                                     ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %54
+ThrowNullRef2:                                    ; preds = %54
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %27
+ThrowNullRef4:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3871,8 +4735,8 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -3907,8 +4771,8 @@ entry:
 
 ; <label>:26                                      ; preds = %19
   %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
-  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %28
 
 ; <label>:28                                      ; preds = %26
   %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
@@ -3920,7 +4784,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3972,8 +4836,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
@@ -3984,26 +4848,26 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
-  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
@@ -4014,8 +4878,8 @@ entry:
 ; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
@@ -4024,8 +4888,8 @@ entry:
 
 ; <label>:25                                      ; preds = %1, %16, %23
   %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
-  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
@@ -4036,27 +4900,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %20
+ThrowNullRef10:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4069,8 +4933,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -4081,8 +4945,8 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
@@ -4091,8 +4955,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1, %8
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
@@ -4103,11 +4967,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4128,24 +4992,24 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   store i32 %3, i32* %loc0
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
   %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
   store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck4, label %9, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
@@ -4164,15 +5028,15 @@ entry:
 ; <label>:18                                      ; preds = %70
   %19 = load i16*, i16** %loc3
   %20 = bitcast i16* %19 to i64*
-  %NullCheck10 = icmp ne i64* %20, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %20, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = load i64, i64* %20, align 8
   %23 = load i16*, i16** %loc4
   %24 = bitcast i16* %23 to i64*
-  %NullCheck12 = icmp ne i64* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = load i64, i64* %24, align 8
@@ -4188,8 +5052,8 @@ entry:
   %31 = bitcast i16* %30 to i8*
   %32 = getelementptr inbounds i8, i8* %31, i64 8
   %33 = bitcast i8* %32 to i64*
-  %NullCheck14 = icmp ne i64* %33, null
-  br i1 %NullCheck14, label %34, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = load i64, i64* %33, align 8
@@ -4197,8 +5061,8 @@ entry:
   %37 = bitcast i16* %36 to i8*
   %38 = getelementptr inbounds i8, i8* %37, i64 8
   %39 = bitcast i8* %38 to i64*
-  %NullCheck16 = icmp ne i64* %39, null
-  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %40
 
 ; <label>:40                                      ; preds = %34
   %41 = load i64, i64* %39, align 8
@@ -4214,8 +5078,8 @@ entry:
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %NullCheck18 = icmp ne i64* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = load i64, i64* %48, align 8
@@ -4223,8 +5087,8 @@ entry:
   %52 = bitcast i16* %51 to i8*
   %53 = getelementptr inbounds i8, i8* %52, i64 16
   %54 = bitcast i8* %53 to i64*
-  %NullCheck20 = icmp ne i64* %54, null
-  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64* %54, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %55
 
 ; <label>:55                                      ; preds = %49
   %56 = load i64, i64* %54, align 8
@@ -4262,15 +5126,15 @@ entry:
 ; <label>:74                                      ; preds = %95
   %75 = load i16*, i16** %loc3
   %76 = bitcast i16* %75 to i32*
-  %NullCheck6 = icmp ne i32* %76, null
-  br i1 %NullCheck6, label %77, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32* %76, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %77
 
 ; <label>:77                                      ; preds = %74
   %78 = load i32, i32* %76, align 8
   %79 = load i16*, i16** %loc4
   %80 = bitcast i16* %79 to i32*
-  %NullCheck8 = icmp ne i32* %80, null
-  br i1 %NullCheck8, label %81, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i32* %80, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %81
 
 ; <label>:81                                      ; preds = %77
   %82 = load i32, i32* %80, align 8
@@ -4318,43 +5182,43 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %74
+ThrowNullRef6:                                    ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %77
+ThrowNullRef8:                                    ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %29
+ThrowNullRef14:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %34
+ThrowNullRef16:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4376,8 +5240,8 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load i64, i64 addrspace(1)* %4
@@ -4389,8 +5253,8 @@ entry:
   %12 = load i64, i64* %11
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %5
   %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
@@ -4399,8 +5263,8 @@ entry:
   %18 = load i8, i8* %arg2
   %19 = zext i8 %18 to i32
   %20 = trunc i32 %19 to i8
-  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %15
   %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
@@ -4411,11 +5275,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4442,8 +5306,8 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
@@ -4466,16 +5330,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
   %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = load i64, i64 addrspace(1)* %19
@@ -4500,8 +5364,8 @@ entry:
 ; <label>:35                                      ; preds = %30
   %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
@@ -4514,8 +5378,8 @@ entry:
 
 ; <label>:42                                      ; preds = %1, %38
   %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
-  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
@@ -4526,19 +5390,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %35
+ThrowNullRef2:                                    ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %42
+ThrowNullRef8:                                    ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4551,14 +5415,14 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
@@ -4570,7 +5434,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4583,8 +5447,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
@@ -4613,51 +5477,51 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
   %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
   %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
   %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
   %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
-  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
   store i64 %21, i64 addrspace(1)* %23
   %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %25 = load i64, i64* %loc0
-  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
@@ -4668,27 +5532,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %22
+ThrowNullRef12:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4701,8 +5565,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
@@ -4713,19 +5577,19 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
@@ -4734,8 +5598,8 @@ entry:
 
 ; <label>:15                                      ; preds = %1, %13
   %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
@@ -4746,19 +5610,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %15
+ThrowNullRef8:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4771,8 +5635,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -4831,8 +5695,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
@@ -4882,8 +5746,8 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
-  br i1 %NullCheck, label %17, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %ThrowNullRef, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
@@ -4894,15 +5758,15 @@ entry:
 
 ; <label>:22                                      ; preds = %17
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
-  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
   %26 = load i32, i32 addrspace(1)* %25
   %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
-  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %27, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
@@ -4925,8 +5789,8 @@ entry:
 ; <label>:40                                      ; preds = %17
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
-  br i1 %NullCheck6, label %43, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %41, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
@@ -4938,34 +5802,17 @@ ThrowNullRef:                                     ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %24
+ThrowNullRef4:                                    ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %40
+ThrowNullRef6:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
-}
-
-INFO:  jitting method Object::ReferenceEquals using LLILCJit
-Successfully read Object.ReferenceEquals
-
-define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
-entry:
-  %arg0 = alloca %System.Object addrspace(1)*
-  %arg1 = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
-  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
-  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = icmp eq %System.Object addrspace(1)* %0, %1
-  %3 = sext i1 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
 }
 
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
@@ -4978,21 +5825,21 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
   %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
-  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
@@ -5007,28 +5854,28 @@ entry:
 ; <label>:13                                      ; preds = %8, %12
   %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
   %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
   %21 = load i32, i32 addrspace(1)* %20, align 8
   %22 = add i32 %21, 1
-  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
   store i32 %22, i32 addrspace(1)* %24
   %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
@@ -5039,27 +5886,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5077,7 +5924,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::Setup using LLILCJit
-Failed to read AppDomain.Setup[loadElem]
+Failed to read AppDomain.Setup[unbox]
 INFO:  jitting method Thread::GetDomain using LLILCJit
 Successfully read Thread.GetDomain
 
@@ -5108,8 +5955,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
@@ -5122,14 +5969,14 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
   %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
@@ -5141,11 +5988,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5173,8 +6020,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -5189,7 +6036,328 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
 Failed to read KeyCollection.System.Collections.Generic.IEnumerable<TKey>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Successfully read Enumerator.MoveNext
+
+define i8 @Enumerator.MoveNext(%"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.RuntimeTypeHandle* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*
+  %"$TypeArg" = alloca %System.RuntimeTypeHandle*
+  store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
+  %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 8
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %76, label %12
+
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
+  br label %76
+
+; <label>:13                                      ; preds = %85
+  %14 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck19 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %15
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, i32 0, i32 0
+  %17 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %16, align 8
+  %NullCheck21 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, i32 0, i32 2
+  %20 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %19, align 8
+  %21 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck23 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %22
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, i32 0, i32 2
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %NullCheck25 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 3, i32 %24
+  %NullCheck27 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %32
+
+; <label>:32                                      ; preds = %30
+  %33 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, i32 0, i32 2
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = icmp slt i32 %34, 0
+  br i1 %35, label %68, label %36
+
+; <label>:36                                      ; preds = %32
+  %37 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %38 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck29 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %39
+
+; <label>:39                                      ; preds = %36
+  %40 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, i32 0, i32 0
+  %41 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %40, align 8
+  %NullCheck31 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, i32 0, i32 2
+  %44 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %43, align 8
+  %45 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck33 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, i32 0, i32 2
+  %48 = load i32, i32 addrspace(1)* %47, align 8
+  %NullCheck35 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %49
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = zext i32 %51 to i64
+  %53 = zext i32 %48 to i64
+  %BoundsCheck37 = icmp uge i64 %53, %52
+  br i1 %BoundsCheck37, label %ThrowIndexOutOfRange38, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 3, i32 %48
+  %NullCheck39 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %56
+
+; <label>:56                                      ; preds = %54
+  %57 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, i32 0, i32 0
+  %58 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck41 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %59
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %60, %System.__Canon addrspace(1)* %58)
+  %61 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck43 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  %64 = load i32, i32 addrspace(1)* %63, align 8
+  %65 = add i32 %64, 1
+  %NullCheck45 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  store i32 %65, i32 addrspace(1)* %67
+  ret i8 1
+
+; <label>:68                                      ; preds = %32
+  %69 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck47 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %73 = add i32 %72, 1
+  %NullCheck49 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %74
+
+; <label>:74                                      ; preds = %70
+  %75 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  store i32 %73, i32 addrspace(1)* %75
+  br label %76
+
+; <label>:76                                      ; preds = %8, %12, %74
+  %77 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %78
+
+; <label>:78                                      ; preds = %76
+  %79 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, i32 0, i32 2
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck7 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %82
+
+; <label>:82                                      ; preds = %78
+  %83 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, i32 0, i32 0
+  %84 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %83, align 8
+  %NullCheck9 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %85
+
+; <label>:85                                      ; preds = %82
+  %86 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, i32 0, i32 7
+  %87 = load i32, i32 addrspace(1)* %86, align 8
+  %88 = icmp ult i32 %80, %87
+  br i1 %88, label %13, label %89
+
+; <label>:89                                      ; preds = %85
+  %90 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %91 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck11 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %92
+
+; <label>:92                                      ; preds = %89
+  %93 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, i32 0, i32 0
+  %94 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck13 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %95
+
+; <label>:95                                      ; preds = %92
+  %96 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, i32 0, i32 7
+  %97 = load i32, i32 addrspace(1)* %96, align 8
+  %98 = add i32 %97, 1
+  %NullCheck15 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %99
+
+; <label>:99                                      ; preds = %95
+  %100 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, i32 0, i32 2
+  store i32 %98, i32 addrspace(1)* %100
+  %101 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck17 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %102
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %103, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %92
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef22:                                   ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef24:                                   ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef26:                                   ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef28:                                   ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef30:                                   ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef32:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef34:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef36:                                   ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange38:                           ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef40:                                   ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef42:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef44:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef46:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef48:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef50:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -5200,8 +6368,8 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -5232,9 +6400,9 @@ Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
 Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
-Failed to read String.MakeSeparatorList[loadElemA]
+Failed to read String.MakeSeparatorList[storeElem]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
-Failed to read String.InternalSplitKeepEmptyEntries[loadElem]
+Failed to read String.InternalSplitKeepEmptyEntries[storeElem]
 INFO:  jitting method Path::IsRelative using LLILCJit
 Successfully read Path.IsRelative
 
@@ -5243,8 +6411,8 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -5254,8 +6422,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
@@ -5271,8 +6439,8 @@ entry:
 
 ; <label>:17                                      ; preds = %7
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
@@ -5288,8 +6456,8 @@ entry:
 
 ; <label>:29                                      ; preds = %19
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %31
 
 ; <label>:31                                      ; preds = %29
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
@@ -5300,8 +6468,8 @@ entry:
 
 ; <label>:36                                      ; preds = %31
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
-  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %37, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
@@ -5312,8 +6480,8 @@ entry:
 
 ; <label>:43                                      ; preds = %31, %38
   %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
-  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %45
 
 ; <label>:45                                      ; preds = %43
   %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
@@ -5324,8 +6492,8 @@ entry:
 
 ; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %50
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
@@ -5336,8 +6504,8 @@ entry:
 
 ; <label>:57                                      ; preds = %1, %7, %19, %45, %52
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
-  br i1 %NullCheck14, label %59, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %59
 
 ; <label>:59                                      ; preds = %57
   %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
@@ -5347,8 +6515,8 @@ entry:
 
 ; <label>:63                                      ; preds = %59
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
@@ -5359,8 +6527,8 @@ entry:
 
 ; <label>:70                                      ; preds = %65
   %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
-  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.String addrspace(1)* %71, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %72
 
 ; <label>:72                                      ; preds = %70
   %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
@@ -5379,39 +6547,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %17
+ThrowNullRef4:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %29
+ThrowNullRef6:                                    ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %36
+ThrowNullRef8:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %43
+ThrowNullRef10:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %50
+ThrowNullRef12:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %57
+ThrowNullRef14:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %63
+ThrowNullRef16:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %70
+ThrowNullRef18:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5419,7 +6587,293 @@ ThrowNullRef17:                                   ; preds = %70
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
-Failed to read String.TrimHelper[loadElem]
+Successfully read String.TrimHelper
+
+define %System.String addrspace(1)* @String.TrimHelper(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i16
+  %loc4 = alloca i32
+  %loc5 = alloca i16
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = sub i32 %3, 1
+  store i32 %4, i32* %loc0
+  store i32 0, i32* %loc1
+  %5 = load i32, i32* %arg2
+  %6 = icmp eq i32 %5, 1
+  br i1 %6, label %62, label %7
+
+; <label>:7                                       ; preds = %1
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:8                                       ; preds = %58
+  store i32 0, i32* %loc2
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load i32, i32* %loc1
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2, i32 %10
+  %13 = load i16, i16 addrspace(1)* %12
+  %14 = zext i16 %13 to i32
+  %15 = trunc i32 %14 to i16
+  store i16 %15, i16* %loc3
+  store i32 0, i32* %loc2
+  br label %34
+
+; <label>:16                                      ; preds = %37
+  %17 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %18 = load i32, i32* %loc2
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %17, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %19
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = zext i32 %18 to i64
+  %BoundsCheck = icmp uge i64 %23, %22
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %24
+
+; <label>:24                                      ; preds = %19
+  %25 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 3, i32 %18
+  %26 = load i16, i16 addrspace(1)* %25, align 8
+  %27 = zext i16 %26 to i32
+  %28 = load i16, i16* %loc3
+  %29 = zext i16 %28 to i32
+  %30 = icmp eq i32 %27, %29
+  br i1 %30, label %43, label %31
+
+; <label>:31                                      ; preds = %24
+  %32 = load i32, i32* %loc2
+  %33 = add i32 %32, 1
+  store i32 %33, i32* %loc2
+  br label %34
+
+; <label>:34                                      ; preds = %11, %31
+  %35 = load i32, i32* %loc2
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = icmp slt i32 %35, %41
+  br i1 %42, label %16, label %43
+
+; <label>:43                                      ; preds = %24, %37
+  %44 = load i32, i32* %loc2
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %45, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp eq i32 %44, %50
+  br i1 %51, label %62, label %52
+
+; <label>:52                                      ; preds = %46
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %7, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %57, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %58
+
+; <label>:58                                      ; preds = %55
+  %59 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %60 = load i32, i32 addrspace(1)* %59
+  %61 = icmp slt i32 %56, %60
+  br i1 %61, label %8, label %62
+
+; <label>:62                                      ; preds = %1, %46, %58
+  %63 = load i32, i32* %arg2
+  %64 = icmp eq i32 %63, 0
+  br i1 %64, label %122, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %66, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %67
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %66, i32 0, i32 1
+  %69 = load i32, i32 addrspace(1)* %68
+  %70 = sub i32 %69, 1
+  store i32 %70, i32* %loc0
+  br label %118
+
+; <label>:71                                      ; preds = %118
+  store i32 0, i32* %loc4
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %73 = load i32, i32* %loc0
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %74
+
+; <label>:74                                      ; preds = %71
+  %75 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 2, i32 %73
+  %76 = load i16, i16 addrspace(1)* %75
+  %77 = zext i16 %76 to i32
+  %78 = trunc i32 %77 to i16
+  store i16 %78, i16* %loc5
+  store i32 0, i32* %loc4
+  br label %97
+
+; <label>:79                                      ; preds = %100
+  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %81 = load i32, i32* %loc4
+  %NullCheck19 = icmp eq %"System.Char[]" addrspace(1)* %80, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
+
+; <label>:82                                      ; preds = %79
+  %83 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 1
+  %84 = load i32, i32 addrspace(1)* %83
+  %85 = zext i32 %84 to i64
+  %86 = zext i32 %81 to i64
+  %BoundsCheck21 = icmp uge i64 %86, %85
+  br i1 %BoundsCheck21, label %ThrowIndexOutOfRange22, label %87
+
+; <label>:87                                      ; preds = %82
+  %88 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 3, i32 %81
+  %89 = load i16, i16 addrspace(1)* %88, align 8
+  %90 = zext i16 %89 to i32
+  %91 = load i16, i16* %loc5
+  %92 = zext i16 %91 to i32
+  %93 = icmp eq i32 %90, %92
+  br i1 %93, label %106, label %94
+
+; <label>:94                                      ; preds = %87
+  %95 = load i32, i32* %loc4
+  %96 = add i32 %95, 1
+  store i32 %96, i32* %loc4
+  br label %97
+
+; <label>:97                                      ; preds = %74, %94
+  %98 = load i32, i32* %loc4
+  %99 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck15 = icmp eq %"System.Char[]" addrspace(1)* %99, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %100
+
+; <label>:100                                     ; preds = %97
+  %101 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %99, i32 0, i32 1
+  %102 = load i32, i32 addrspace(1)* %101
+  %103 = zext i32 %102 to i64
+  %104 = trunc i64 %103 to i32
+  %105 = icmp slt i32 %98, %104
+  br i1 %105, label %79, label %106
+
+; <label>:106                                     ; preds = %87, %100
+  %107 = load i32, i32* %loc4
+  %108 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck17 = icmp eq %"System.Char[]" addrspace(1)* %108, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %109
+
+; <label>:109                                     ; preds = %106
+  %110 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %108, i32 0, i32 1
+  %111 = load i32, i32 addrspace(1)* %110
+  %112 = zext i32 %111 to i64
+  %113 = trunc i64 %112 to i32
+  %114 = icmp eq i32 %107, %113
+  br i1 %114, label %122, label %115
+
+; <label>:115                                     ; preds = %109
+  %116 = load i32, i32* %loc0
+  %117 = sub i32 %116, 1
+  store i32 %117, i32* %loc0
+  br label %118
+
+; <label>:118                                     ; preds = %67, %115
+  %119 = load i32, i32* %loc0
+  %120 = load i32, i32* %loc1
+  %121 = icmp sge i32 %119, %120
+  br i1 %121, label %71, label %122
+
+; <label>:122                                     ; preds = %62, %109, %118
+  %123 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %124 = load i32, i32* %loc1
+  %125 = load i32, i32* %loc0
+  %126 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %123, i32 %124, i32 %125)
+  ret %System.String addrspace(1)* %126
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %97
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange22:                           ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
 Successfully read String.CreateTrimmedString
 
@@ -5439,8 +6893,8 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
@@ -5535,8 +6989,8 @@ entry:
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i64 2872
   %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
   %8 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %7
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %3
   %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
@@ -5553,8 +7007,8 @@ entry:
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 2864
   %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
   %21 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %20
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
-  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %22
 
 ; <label>:22                                      ; preds = %16
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
@@ -5569,7 +7023,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %16
+ThrowNullRef2:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5586,8 +7040,8 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5613,8 +7067,8 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
@@ -5632,8 +7086,8 @@ entry:
 
 ; <label>:12                                      ; preds = %4
   %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
@@ -5644,8 +7098,8 @@ entry:
 
 ; <label>:19                                      ; preds = %14
   %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %19
   %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
@@ -5660,21 +7114,21 @@ entry:
   %31 = zext i16 %30 to i32
   %32 = bitcast i8* %29 to i16*
   %33 = trunc i32 %31 to i16
-  %NullCheck6 = icmp ne i16* %32, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i16* %32, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %21
   store i16 %33, i16* %32, align 8
   %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %36
 
 ; <label>:36                                      ; preds = %34
   %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
   %38 = load i32, i32 addrspace(1)* %37, align 8
   %39 = add i32 %38, 1
-  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %40
 
 ; <label>:40                                      ; preds = %36
   %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
@@ -5683,16 +7137,16 @@ entry:
 
 ; <label>:42                                      ; preds = %14
   %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
-  br i1 %NullCheck12, label %44, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
   %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
   %47 = load i16, i16* %arg1
   %48 = zext i16 %47 to i32
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = trunc i32 %48 to i16
@@ -5703,31 +7157,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %19
+ThrowNullRef4:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %21
+ThrowNullRef6:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %36
+ThrowNullRef10:                                   ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %42
+ThrowNullRef12:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %44
+ThrowNullRef14:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5740,8 +7194,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -5752,8 +7206,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
@@ -5762,14 +7216,14 @@ entry:
 
 ; <label>:11                                      ; preds = %1
   %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
@@ -5779,15 +7233,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5808,8 +7262,8 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5822,8 +7276,8 @@ entry:
 
 ; <label>:8                                       ; preds = %3
   %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
@@ -5842,15 +7296,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
-  br i1 %NullCheck4, label %22, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
   %24 = load i16*, i16* addrspace(1)* %23, align 8
   %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %25, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
@@ -5859,8 +7313,8 @@ entry:
   store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
@@ -5874,8 +7328,8 @@ entry:
 
 ; <label>:37                                      ; preds = %65
   %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %37
   %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
@@ -5886,16 +7340,16 @@ entry:
   %45 = bitcast i16* %41 to i8*
   %46 = getelementptr inbounds i8, i8* %45, i64 %44
   %47 = bitcast i8* %46 to i16*
-  %NullCheck14 = icmp ne i16* %47, null
-  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %47, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %48
 
 ; <label>:48                                      ; preds = %39
   %49 = load i16, i16* %47, align 8
   %50 = zext i16 %49 to i32
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %52 = load i32, i32* %loc1
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %53
 
 ; <label>:53                                      ; preds = %48
   %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
@@ -5916,8 +7370,8 @@ entry:
 ; <label>:62                                      ; preds = %36, %59
   %63 = load i32, i32* %loc1
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck10, label %65, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %65
 
 ; <label>:65                                      ; preds = %62
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
@@ -5936,15 +7390,15 @@ entry:
 
 ; <label>:74                                      ; preds = %70
   %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
-  br i1 %NullCheck18, label %76, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %76
 
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
   %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
-  br i1 %NullCheck20, label %80, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
   %81 = load i64, i64 addrspace(1)* %79
@@ -5958,8 +7412,8 @@ entry:
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
   %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
-  br i1 %NullCheck22, label %92, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.String addrspace(1)* %90, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %92
 
 ; <label>:92                                      ; preds = %80
   %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
@@ -5969,15 +7423,15 @@ entry:
 
 ; <label>:96                                      ; preds = %70
   %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
-  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %98
 
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
   %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
-  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
   %103 = load i64, i64 addrspace(1)* %101
@@ -5991,8 +7445,8 @@ entry:
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
   %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
-  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.String addrspace(1)* %112, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %114
 
 ; <label>:114                                     ; preds = %102
   %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
@@ -6004,59 +7458,59 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %20
+ThrowNullRef4:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %22
+ThrowNullRef6:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %26
+ThrowNullRef8:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %62
+ThrowNullRef10:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %48
+ThrowNullRef16:                                   ; preds = %48
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %74
+ThrowNullRef18:                                   ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %76
+ThrowNullRef20:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %80
+ThrowNullRef22:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %96
+ThrowNullRef24:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %98
+ThrowNullRef26:                                   ; preds = %98
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %102
+ThrowNullRef28:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6069,15 +7523,15 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
   %3 = load i16*, i16* addrspace(1)* %2, align 8
   %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
@@ -6087,8 +7541,8 @@ entry:
   %10 = bitcast i16* %3 to i8*
   %11 = getelementptr inbounds i8, i8* %10, i64 %9
   %12 = bitcast i8* %11 to i16*
-  %NullCheck4 = icmp ne i16* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %5
   store i16 0, i16* %12, align 8
@@ -6098,11 +7552,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6119,8 +7573,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -6131,8 +7585,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
@@ -6144,15 +7598,15 @@ entry:
 
 ; <label>:14                                      ; preds = %1
   %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
   %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
   %21 = load i64, i64 addrspace(1)* %19
@@ -6171,15 +7625,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %14
+ThrowNullRef4:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %16
+ThrowNullRef6:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6302,14 +7756,6 @@ entry:
   ret %System.String addrspace(1)* %57
 }
 
-INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
-Successfully read RuntimeHelpers.get_OffsetToStringData
-
-define i32 @RuntimeHelpers.get_OffsetToStringData() {
-entry:
-  ret i32 12
-}
-
 INFO:  jitting method String::Equals using LLILCJit
 Successfully read String.Equals
 
@@ -6381,8 +7827,8 @@ entry:
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
-  br i1 %NullCheck24, label %29, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
   %30 = load i64, i64 addrspace(1)* %28
@@ -6397,8 +7843,8 @@ entry:
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
-  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
   %43 = load i64, i64 addrspace(1)* %41
@@ -6418,8 +7864,8 @@ entry:
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
   %59 = load i64, i64 addrspace(1)* %57
@@ -6434,8 +7880,8 @@ entry:
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck22, label %71, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
   %72 = load i64, i64 addrspace(1)* %70
@@ -6455,8 +7901,8 @@ entry:
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
-  br i1 %NullCheck16, label %87, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = load i64, i64 addrspace(1)* %86
@@ -6471,8 +7917,8 @@ entry:
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck18, label %100, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
   %101 = load i64, i64 addrspace(1)* %99
@@ -6492,8 +7938,8 @@ entry:
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
-  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
   %117 = load i64, i64 addrspace(1)* %115
@@ -6508,8 +7954,8 @@ entry:
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
-  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
   %130 = load i64, i64 addrspace(1)* %128
@@ -6528,15 +7974,15 @@ entry:
 
 ; <label>:142                                     ; preds = %22
   %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
-  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %143, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %144
 
 ; <label>:144                                     ; preds = %142
   %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
   %146 = load i32, i32 addrspace(1)* %145
   %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
-  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %147, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %148
 
 ; <label>:148                                     ; preds = %144
   %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
@@ -6557,15 +8003,15 @@ entry:
 
 ; <label>:159                                     ; preds = %22
   %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
-  br i1 %NullCheck, label %161, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %ThrowNullRef, label %161
 
 ; <label>:161                                     ; preds = %159
   %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
   %163 = load i32, i32 addrspace(1)* %162
   %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
-  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %164, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %165
 
 ; <label>:165                                     ; preds = %161
   %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
@@ -6578,8 +8024,8 @@ entry:
 
 ; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
-  br i1 %NullCheck4, label %172, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %171, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %172
 
 ; <label>:172                                     ; preds = %170
   %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
@@ -6589,8 +8035,8 @@ entry:
 
 ; <label>:176                                     ; preds = %172
   %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
-  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %177, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %178
 
 ; <label>:178                                     ; preds = %176
   %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
@@ -6629,55 +8075,55 @@ ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %161
+ThrowNullRef2:                                    ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %170
+ThrowNullRef4:                                    ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %176
+ThrowNullRef6:                                    ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %142
+ThrowNullRef8:                                    ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %144
+ThrowNullRef10:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %113
+ThrowNullRef12:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %116
+ThrowNullRef14:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %84
+ThrowNullRef16:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %87
+ThrowNullRef18:                                   ; preds = %87
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %55
+ThrowNullRef20:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %58
+ThrowNullRef22:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %26
+ThrowNullRef24:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %29
+ThrowNullRef26:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,8 +8161,8 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck, label %14, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %ThrowNullRef, label %14
 
 ; <label>:14                                      ; preds = %8
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
@@ -6760,8 +8206,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
@@ -6770,14 +8216,14 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32, i32* %loc0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %10
   %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
   %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
@@ -6790,15 +8236,15 @@ entry:
 ; <label>:25                                      ; preds = %19
   %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
-  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
   %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
@@ -6807,8 +8253,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %37 = load i32, i32* %loc0
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %38, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %38
 
 ; <label>:38                                      ; preds = %32
   %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
@@ -6817,14 +8263,14 @@ entry:
 
 ; <label>:40                                      ; preds = %19
   %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %40
   %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
   %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
-  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
-  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
@@ -6832,8 +8278,8 @@ entry:
   %48 = zext i32 %47 to i64
   %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
-  br i1 %NullCheck16, label %51, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %51
 
 ; <label>:51                                      ; preds = %45
   %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
@@ -6847,15 +8293,15 @@ entry:
 ; <label>:57                                      ; preds = %51
   %58 = load i16*, i16** %arg1
   %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
-  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %60
 
 ; <label>:60                                      ; preds = %57
   %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
   %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
-  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %64
 
 ; <label>:64                                      ; preds = %60
   %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
@@ -6864,22 +8310,22 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
   %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
-  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %70
 
 ; <label>:70                                      ; preds = %64
   %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
   %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
-  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
-  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
   %75 = load i32, i32 addrspace(1)* %74
   %76 = zext i32 %75 to i64
   %77 = trunc i64 %76 to i32
-  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
-  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %78
 
 ; <label>:78                                      ; preds = %73
   %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
@@ -6901,8 +8347,8 @@ entry:
   %90 = bitcast i16* %86 to i8*
   %91 = getelementptr inbounds i8, i8* %90, i64 %89
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %93
 
 ; <label>:93                                      ; preds = %80
   %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
@@ -6912,8 +8358,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %99 = load i32, i32* %loc2
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %100
 
 ; <label>:100                                     ; preds = %93
   %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
@@ -6928,63 +8374,63 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %25
+ThrowNullRef6:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %32
+ThrowNullRef10:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %40
+ThrowNullRef12:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %45
+ThrowNullRef16:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %57
+ThrowNullRef18:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %60
+ThrowNullRef20:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %64
+ThrowNullRef22:                                   ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %70
+ThrowNullRef24:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %73
+ThrowNullRef26:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %80
+ThrowNullRef28:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %93
+ThrowNullRef30:                                   ; preds = %93
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7004,8 +8450,8 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
@@ -7033,43 +8479,43 @@ entry:
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %14
   %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
   %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   %28 = load i32, i32 addrspace(1)* %27, align 8
   %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
-  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %30
 
 ; <label>:30                                      ; preds = %26
   %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
   %32 = load i32, i32 addrspace(1)* %31, align 8
   %33 = add i32 %28, %32
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %34
 
 ; <label>:34                                      ; preds = %30
   %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   store i32 %33, i32 addrspace(1)* %35
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
   store i32 0, i32 addrspace(1)* %38
   %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %40
 
 ; <label>:40                                      ; preds = %37
   %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
@@ -7082,8 +8528,8 @@ entry:
 
 ; <label>:47                                      ; preds = %40
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
@@ -7098,8 +8544,8 @@ entry:
   %54 = load i32, i32* %loc0
   %55 = sext i32 %54 to i64
   %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
-  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %57
 
 ; <label>:57                                      ; preds = %52
   %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
@@ -7110,68 +8556,35 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %14
+ThrowNullRef2:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %23
+ThrowNullRef4:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %26
+ThrowNullRef6:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %30
+ThrowNullRef8:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %34
+ThrowNullRef10:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %47
+ThrowNullRef14:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %52
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-}
-
-INFO:  jitting method StringBuilder::get_Length using LLILCJit
-Successfully read StringBuilder.get_Length
-
-define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.StringBuilder addrspace(1)*
-  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
-  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
-
-; <label>:1                                       ; preds = %entry
-  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %3 = load i32, i32 addrspace(1)* %2, align 8
-  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
-
-; <label>:5                                       ; preds = %1
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = add i32 %3, %7
-  ret i32 %8
-
-ThrowNullRef:                                     ; preds = %entry
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef16:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7213,70 +8626,70 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
   %6 = load i32, i32 addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
   store i32 %6, i32 addrspace(1)* %8
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
   %13 = load i32, i32 addrspace(1)* %12, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
   store i32 %13, i32 addrspace(1)* %15
   %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
-  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %18
 
 ; <label>:18                                      ; preds = %14
   %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
   %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
   %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
   %34 = load i32, i32 addrspace(1)* %33, align 8
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
-  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
@@ -7287,39 +8700,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %28
+ThrowNullRef16:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %32
+ThrowNullRef18:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7455,13 +8868,13 @@ entry:
 ; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
@@ -7477,16 +8890,16 @@ entry:
 
 ; <label>:18                                      ; preds = %15
   %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
   store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
   %22 = load i32, i32* %loc0
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %24
 
 ; <label>:24                                      ; preds = %20
   %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
@@ -7498,13 +8911,13 @@ entry:
 ; <label>:28                                      ; preds = %15, %24
   %29 = load i32, i32* %arg1
   %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %31
   %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
@@ -7517,20 +8930,20 @@ entry:
   %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
-  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
   %46 = load i32, i32 addrspace(1)* %45, align 8
   %47 = sub i32 %40, %46
-  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
-  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i32 addrspace(1)* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %48
 
 ; <label>:48                                      ; preds = %44
   store i32 %47, i32 addrspace(1)* %39, align 8
@@ -7538,21 +8951,21 @@ entry:
 
 ; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
-  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %51
 
 ; <label>:51                                      ; preds = %49
   %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %53
 
 ; <label>:53                                      ; preds = %51
   %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
   %55 = load i32, i32 addrspace(1)* %54, align 8
   %56 = load i32, i32* %arg2
   %57 = sub i32 %55, %56
-  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %58
 
 ; <label>:58                                      ; preds = %53
   %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
@@ -7562,13 +8975,13 @@ entry:
 ; <label>:60                                      ; preds = %33, %58
   %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
   %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
-  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %63
 
 ; <label>:63                                      ; preds = %60
   %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
-  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
-  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
@@ -7578,15 +8991,15 @@ entry:
 
 ; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
-  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i32 addrspace(1)* %69, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %70
 
 ; <label>:70                                      ; preds = %68
   %71 = load i32, i32 addrspace(1)* %69, align 8
   store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
-  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
@@ -7596,8 +9009,8 @@ entry:
   store i32 %77, i32* %loc4
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
-  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %80
 
 ; <label>:80                                      ; preds = %73
   %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
@@ -7607,71 +9020,71 @@ entry:
 ; <label>:83                                      ; preds = %80
   store i32 0, i32* %loc3
   %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
-  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
-  br i1 %NullCheck26, label %88, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i32 addrspace(1)* %87, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %88
 
 ; <label>:88                                      ; preds = %85
   %89 = load i32, i32 addrspace(1)* %87, align 8
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
-  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %90
 
 ; <label>:90                                      ; preds = %88
   %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
   store i32 %89, i32 addrspace(1)* %91
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
-  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
-  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %96
 
 ; <label>:96                                      ; preds = %94
   %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
-  br i1 %NullCheck34, label %100, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %100
 
 ; <label>:100                                     ; preds = %96
   %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
-  br i1 %NullCheck36, label %102, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %102
 
 ; <label>:102                                     ; preds = %100
   %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
   %104 = load i32, i32 addrspace(1)* %103, align 8
   %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
-  br i1 %NullCheck38, label %106, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %106
 
 ; <label>:106                                     ; preds = %102
   %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
-  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
-  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %108
 
 ; <label>:108                                     ; preds = %106
   %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
   %110 = load i32, i32 addrspace(1)* %109, align 8
   %111 = add i32 %104, %110
-  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %112
 
 ; <label>:112                                     ; preds = %108
   %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
   store i32 %111, i32 addrspace(1)* %113
   %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
-  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i32 addrspace(1)* %114, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %115
 
 ; <label>:115                                     ; preds = %112
   %116 = load i32, i32 addrspace(1)* %114, align 8
@@ -7681,19 +9094,19 @@ entry:
 ; <label>:118                                     ; preds = %115
   %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
-  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %121
 
 ; <label>:121                                     ; preds = %118
   %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
-  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
-  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %123
 
 ; <label>:123                                     ; preds = %121
   %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
   %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
-  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
-  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %126
 
 ; <label>:126                                     ; preds = %123
   %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
@@ -7705,8 +9118,8 @@ entry:
 
 ; <label>:130                                     ; preds = %80, %115, %126
   %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %132
 
 ; <label>:132                                     ; preds = %130
   %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7715,8 +9128,8 @@ entry:
   %136 = load i32, i32* %loc3
   %137 = sub i32 %135, %136
   %138 = sub i32 %134, %137
-  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %139
 
 ; <label>:139                                     ; preds = %132
   %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7728,16 +9141,16 @@ entry:
 
 ; <label>:144                                     ; preds = %139
   %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
-  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %146
 
 ; <label>:146                                     ; preds = %144
   %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
   %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
   %149 = load i32, i32* %loc2
   %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
-  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %151
 
 ; <label>:151                                     ; preds = %146
   %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
@@ -7754,145 +9167,249 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %18
+ThrowNullRef4:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %31
+ThrowNullRef10:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %44
+ThrowNullRef16:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %68
+ThrowNullRef18:                                   ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %70
+ThrowNullRef20:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %73
+ThrowNullRef22:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %83
+ThrowNullRef24:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %85
+ThrowNullRef26:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %88
+ThrowNullRef28:                                   ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %90
+ThrowNullRef30:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %94
+ThrowNullRef32:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %96
+ThrowNullRef34:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %100
+ThrowNullRef36:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %102
+ThrowNullRef38:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %106
+ThrowNullRef40:                                   ; preds = %106
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %108
+ThrowNullRef42:                                   ; preds = %108
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %112
+ThrowNullRef44:                                   ; preds = %112
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %118
+ThrowNullRef46:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %121
+ThrowNullRef48:                                   ; preds = %121
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %123
+ThrowNullRef50:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %130
+ThrowNullRef52:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %132
+ThrowNullRef54:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %144
+ThrowNullRef56:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %146
+ThrowNullRef58:                                   ; preds = %146
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %60
+ThrowNullRef60:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %63
+ThrowNullRef62:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %49
+ThrowNullRef64:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %51
+ThrowNullRef66:                                   ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %53
+ThrowNullRef68:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(%"System.Char[]" addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %arg0 = alloca %"System.Char[]" addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store %"System.Char[]" addrspace(1)* %param0, %"System.Char[]" addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load i32, i32* %arg4
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %43, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %38, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg1
+  %13 = load i32, i32* %arg4
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %38, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %24 = load i32, i32* %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %35 = load i32, i32* %arg3
+  %36 = load i32, i32* %arg4
+  %37 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %37, %"System.Char[]" addrspace(1)* %34, i32 %35, i32 %36)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:38                                      ; preds = %5, %16
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Successfully read Buffer._Memmove
 
@@ -7914,7 +9431,7 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[loadElem]
+Failed to read AppDomain.SetDataHelper[storeElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -7923,8 +9440,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
@@ -7934,8 +9451,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
@@ -7947,15 +9464,15 @@ entry:
   %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
   %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
@@ -7966,15 +9483,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7992,7 +9509,79 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
-Failed to read Dictionary`2.TryGetValue[loadElemA]
+Successfully read Dictionary`2.TryGetValue
+
+define i8 @"Dictionary`2.TryGetValue"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)* addrspace(1)* %param2) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  %arg2 = alloca %System.__Canon addrspace(1)* addrspace(1)*
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  store %System.__Canon addrspace(1)* addrspace(1)* %param2, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  store i32 %2, i32* %loc0
+  %3 = load i32, i32* %loc0
+  %4 = icmp slt i32 %3, 0
+  br i1 %4, label %22, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 2
+  %10 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %9, align 8
+  %11 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = zext i32 %11 to i64
+  %BoundsCheck = icmp uge i64 %16, %15
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 3, i32 %11
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %20, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %6, %System.__Canon addrspace(1)* %21)
+  ret i8 1
+
+; <label>:22                                      ; preds = %entry
+  %23 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %23, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -8058,8 +9647,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
@@ -8091,8 +9680,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
@@ -8171,15 +9760,15 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck, label %19, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %ThrowNullRef, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
   %21 = load i32, i32 addrspace(1)* %20
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
@@ -8202,7 +9791,7 @@ ThrowNullRef:                                     ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %19
+ThrowNullRef2:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8248,8 +9837,8 @@ entry:
   %0 = alloca %System.AppDomainHandle
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %1 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %1, i32 0, i32 15
@@ -8269,8 +9858,8 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
@@ -8286,7 +9875,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -8299,8 +9888,8 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -8327,8 +9916,8 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
@@ -8352,8 +9941,8 @@ entry:
   %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
   store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
@@ -8363,8 +9952,8 @@ entry:
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
@@ -8374,8 +9963,8 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %9
   %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
@@ -8384,8 +9973,8 @@ entry:
 
 ; <label>:18                                      ; preds = %3, %16
   %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
@@ -8397,15 +9986,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %18
+ThrowNullRef6:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8418,8 +10007,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
@@ -8453,15 +10042,15 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
@@ -8473,7 +10062,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8481,7 +10070,7 @@ ThrowNullRef1:                                    ; preds = %1
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
 Failed to read Dictionary`2.System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
@@ -8506,8 +10095,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
@@ -8524,8 +10113,8 @@ entry:
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -8544,7 +10133,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8577,8 +10166,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = load i64, i64* %arg2
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = trunc i32 %3 to i8
@@ -8634,46 +10223,46 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
   %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
-  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
-  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
-  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
@@ -8684,27 +10273,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %20
+ThrowNullRef12:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8717,8 +10306,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -8756,22 +10345,22 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
   %9 = load i64, i64 addrspace(1)* %8, align 8
   %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
   %13 = load i64, i64 addrspace(1)* %12, align 8
   %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %11
   %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
@@ -8788,11 +10377,11 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8882,8 +10471,8 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
@@ -8900,8 +10489,8 @@ entry:
 ; <label>:8                                       ; preds = %1
   %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
   %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
@@ -8911,15 +10500,15 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
   %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
   %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
-  br i1 %NullCheck6, label %21, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
@@ -8946,15 +10535,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8992,15 +10581,15 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
   store i8 %3, i8 addrspace(1)* %5
   %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
@@ -9011,7 +10600,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9027,8 +10616,8 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -9041,8 +10630,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
@@ -9058,7 +10647,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9080,8 +10669,8 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
@@ -9096,8 +10685,8 @@ entry:
 ; <label>:12                                      ; preds = %6
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
@@ -9112,8 +10701,8 @@ entry:
 ; <label>:21                                      ; preds = %15
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
@@ -9128,8 +10717,8 @@ entry:
 ; <label>:30                                      ; preds = %24
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %31, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
@@ -9144,8 +10733,8 @@ entry:
 ; <label>:39                                      ; preds = %33
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
-  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %40, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %42
 
 ; <label>:42                                      ; preds = %39
   %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
@@ -9164,19 +10753,19 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %21
+ThrowNullRef4:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %30
+ThrowNullRef6:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %39
+ThrowNullRef8:                                    ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9243,8 +10832,8 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
@@ -9264,57 +10853,57 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
   store i8 0, i8 addrspace(1)* %2
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
   store i8 0, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
   store i8 0, i8 addrspace(1)* %17
   %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
   store i8 0, i8 addrspace(1)* %20
   %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
-  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
@@ -9325,31 +10914,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %19
+ThrowNullRef14:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9367,8 +10956,8 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
@@ -9380,8 +10969,8 @@ entry:
 
 ; <label>:9                                       ; preds = %4
   %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %9
   %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
@@ -9395,7 +10984,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef2:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9420,8 +11009,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
@@ -9512,8 +11101,8 @@ entry:
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
@@ -9524,8 +11113,8 @@ entry:
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = load i64, i64 addrspace(1)* %12
@@ -9537,8 +11126,8 @@ entry:
   %20 = load i64, i64* %19
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
-  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %13
   %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
@@ -9555,8 +11144,8 @@ entry:
 ; <label>:30                                      ; preds = %25
   %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %32 = load i32, i32* %arg2
-  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
-  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
@@ -9570,15 +11159,15 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %30
+ThrowNullRef2:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9622,87 +11211,87 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
   %10 = load i8, i8 addrspace(1)* %9, align 8
   %11 = zext i8 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %8
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
   store i8 %12, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
   %19 = load i8, i8 addrspace(1)* %18, align 8
   %20 = zext i8 %19 to i32
   %21 = trunc i32 %20 to i8
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
   store i8 %21, i8 addrspace(1)* %23
   %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
   %28 = load i8, i8 addrspace(1)* %27, align 8
   %29 = zext i8 %28 to i32
   %30 = trunc i32 %29 to i8
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
-  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %31
 
 ; <label>:31                                      ; preds = %26
   %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
   store i8 %30, i8 addrspace(1)* %32
   %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
-  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
-  br i1 %NullCheck14, label %40, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %40
 
 ; <label>:40                                      ; preds = %35
   %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
   store i8 %39, i8 addrspace(1)* %41
   %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
-  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %44
 
 ; <label>:44                                      ; preds = %40
   %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
   %46 = load i8, i8 addrspace(1)* %45, align 8
   %47 = zext i8 %46 to i32
   %48 = trunc i32 %47 to i8
-  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
   store i8 %48, i8 addrspace(1)* %50
   %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
-  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
@@ -9713,29 +11302,29 @@ entry:
 ; <label>:56                                      ; preds = %52
   %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
-  br i1 %NullCheck22, label %59, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
   %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
   %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
-  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
-  br i1 %NullCheck24, label %63, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
   %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
-  br i1 %NullCheck26, label %66, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
   %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
-  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
-  br i1 %NullCheck28, label %69, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %69
 
 ; <label>:69                                      ; preds = %66
   %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
@@ -9744,15 +11333,15 @@ entry:
 
 ; <label>:71                                      ; preds = %105
   %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
-  br i1 %NullCheck34, label %73, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %73
 
 ; <label>:73                                      ; preds = %71
   %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
   %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
   %76 = load i32, i32* %loc0
-  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
-  br i1 %NullCheck36, label %77, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
@@ -9766,8 +11355,8 @@ entry:
 
 ; <label>:83                                      ; preds = %77
   %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
-  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
@@ -9775,14 +11364,14 @@ entry:
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
   %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
-  br i1 %NullCheck40, label %91, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
 ; <label>:91                                      ; preds = %85
   %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
   %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
-  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck42, label %94, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %94
 
 ; <label>:94                                      ; preds = %91
   %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
@@ -9798,14 +11387,14 @@ entry:
 ; <label>:99                                      ; preds = %69, %96
   %100 = load i32, i32* %loc0
   %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
-  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %102
 
 ; <label>:102                                     ; preds = %99
   %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
   %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
-  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
-  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
@@ -9819,87 +11408,87 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %26
+ThrowNullRef10:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %31
+ThrowNullRef12:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %35
+ThrowNullRef14:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %40
+ThrowNullRef16:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %56
+ThrowNullRef22:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %59
+ThrowNullRef24:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %63
+ThrowNullRef26:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %66
+ThrowNullRef28:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %102
+ThrowNullRef32:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %71
+ThrowNullRef34:                                   ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %73
+ThrowNullRef36:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %83
+ThrowNullRef38:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %85
+ThrowNullRef40:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %91
+ThrowNullRef42:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9943,15 +11532,15 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
   %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
@@ -9961,28 +11550,28 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
   %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %12
   %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
   %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
   %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
-  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
@@ -9993,23 +11582,23 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %12
+ThrowNullRef6:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10031,15 +11620,15 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
   %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = load i64, i64 addrspace(1)* %7
@@ -10077,13 +11666,13 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[loadElem]
+Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -10111,8 +11700,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -10156,7 +11745,89 @@ Failed to read BringUpTest.Main[abs]
 INFO:  jitting method BringUpTest::FPFillArray using LLILCJit
 Failed to read BringUpTest.FPFillArray[storeElem]
 INFO:  jitting method BringUpTest::FPArray using LLILCJit
-Failed to read BringUpTest.FPArray[loadElem]
+Successfully read BringUpTest.FPArray
+
+define float @BringUpTest.FPArray(%"System.Single[]" addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %"System.Single[]" addrspace(1)*
+  %loc0 = alloca float
+  %loc1 = alloca i32
+  store %"System.Single[]" addrspace(1)* %param0, %"System.Single[]" addrspace(1)** %arg0
+  store float 0.000000e+00, float* %loc0
+  store i32 0, i32* %loc1
+  br label %15
+
+; <label>:0                                       ; preds = %18
+  %1 = load float, float* %loc0
+  %2 = load %"System.Single[]" addrspace(1)*, %"System.Single[]" addrspace(1)** %arg0
+  %3 = load i32, i32* %loc1
+  %NullCheck3 = icmp eq %"System.Single[]" addrspace(1)* %2, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %4
+
+; <label>:4                                       ; preds = %0
+  %5 = getelementptr inbounds %"System.Single[]", %"System.Single[]" addrspace(1)* %2, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = zext i32 %6 to i64
+  %8 = zext i32 %3 to i64
+  %BoundsCheck = icmp uge i64 %8, %7
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %9
+
+; <label>:9                                       ; preds = %4
+  %10 = getelementptr inbounds %"System.Single[]", %"System.Single[]" addrspace(1)* %2, i32 0, i32 3, i32 %3
+  %11 = load float, float addrspace(1)* %10, align 8
+  %12 = fadd float %1, %11
+  store float %12, float* %loc0
+  %13 = load i32, i32* %loc1
+  %14 = add i32 %13, 1
+  store i32 %14, i32* %loc1
+  br label %15
+
+; <label>:15                                      ; preds = %entry, %9
+  %16 = load i32, i32* %loc1
+  %17 = load %"System.Single[]" addrspace(1)*, %"System.Single[]" addrspace(1)** %arg0
+  %NullCheck = icmp eq %"System.Single[]" addrspace(1)* %17, null
+  br i1 %NullCheck, label %ThrowNullRef, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %"System.Single[]", %"System.Single[]" addrspace(1)* %17, i32 0, i32 1
+  %20 = load i32, i32 addrspace(1)* %19
+  %21 = zext i32 %20 to i64
+  %22 = trunc i64 %21 to i32
+  %23 = icmp slt i32 %16, %22
+  br i1 %23, label %0, label %24
+
+; <label>:24                                      ; preds = %18
+  %25 = load float, float* %loc0
+  %26 = load %"System.Single[]" addrspace(1)*, %"System.Single[]" addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %"System.Single[]" addrspace(1)* %26, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %27
+
+; <label>:27                                      ; preds = %24
+  %28 = getelementptr inbounds %"System.Single[]", %"System.Single[]" addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = zext i32 %29 to i64
+  %31 = trunc i64 %30 to i32
+  %32 = sitofp i32 %31 to float
+  %33 = fdiv float %25, %32
+  ret float %33
+
+ThrowNullRef:                                     ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Console::WriteLine using LLILCJit
 Successfully read Console.WriteLine
 
@@ -10167,8 +11838,8 @@ entry:
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load float, float* %arg0
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -10302,8 +11973,8 @@ entry:
   store i64 %param0, i64* %arg0
   store i64 %param1, i64* %arg1
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
@@ -10311,8 +11982,8 @@ entry:
   %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
   %5 = load i16*, i16* addrspace(1)* %4, align 8
   %6 = addrspacecast i64* %arg1 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = bitcast i64 addrspace(1)* %6 to i8 addrspace(1)*
@@ -10328,7 +11999,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10362,8 +12033,8 @@ entry:
   %1 = load i32, i32* %arg1
   %2 = sext i32 %1 to i64
   %3 = inttoptr i64 %2 to i16*
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -10416,8 +12087,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, i32)*)(%System.IO.ConsoleStream addrspace(1)* %2, i32 %1)
   %3 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %4 = load i64, i64* %arg1
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
@@ -10428,8 +12099,8 @@ entry:
   %10 = icmp eq i32 %9, 3
   %11 = sext i1 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %5
   %14 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, i32 0, i32 5
@@ -10440,7 +12111,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10463,8 +12134,8 @@ entry:
   %5 = icmp eq i32 %4, 1
   %6 = sext i1 %5 to i32
   %7 = trunc i32 %6 to i8
-  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %2, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.ConsoleStream addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
@@ -10475,8 +12146,8 @@ entry:
   %13 = icmp eq i32 %12, 2
   %14 = sext i1 %13 to i32
   %15 = trunc i32 %14 to i8
-  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %10, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.ConsoleStream addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %8
   %17 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %10, i32 0, i32 4
@@ -10487,7 +12158,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10526,8 +12197,8 @@ entry:
   %arg0 = alloca i64
   store i64 %param0, i64* %arg0
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
@@ -10562,8 +12233,8 @@ entry:
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
   %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = load i64, i64 addrspace(1)* %7
@@ -10667,7 +12338,127 @@ entry:
 INFO:  jitting method Encoding::GetEncoding using LLILCJit
 Failed to read Encoding.GetEncoding[convertToHelperArgumentType]
 INFO:  jitting method EncodingProvider::GetEncodingFromProvider using LLILCJit
-Failed to read EncodingProvider.GetEncodingFromProvider[loadElem]
+Successfully read EncodingProvider.GetEncodingFromProvider
+
+define %System.Text.Encoding addrspace(1)* @EncodingProvider.GetEncodingFromProvider(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca %"System.Text.EncodingProvider[]" addrspace(1)*
+  %loc1 = alloca %System.Text.EncodingProvider addrspace(1)*
+  %loc2 = alloca %System.Text.Encoding addrspace(1)*
+  %loc3 = alloca %System.Text.Encoding addrspace(1)*
+  %loc4 = alloca %"System.Text.EncodingProvider[]" addrspace(1)*
+  %loc5 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1059)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2392
+  %2 = addrspacecast i8 addrspace(1)* %1 to %"System.Text.EncodingProvider[]" addrspace(1)**
+  %3 = load volatile %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %2
+  %4 = icmp ne %"System.Text.EncodingProvider[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %entry
+  ret %System.Text.Encoding addrspace(1)* null
+
+; <label>:6                                       ; preds = %entry
+  %7 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1059)
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i64 2392
+  %9 = addrspacecast i8 addrspace(1)* %8 to %"System.Text.EncodingProvider[]" addrspace(1)**
+  %10 = load volatile %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %9
+  store %"System.Text.EncodingProvider[]" addrspace(1)* %10, %"System.Text.EncodingProvider[]" addrspace(1)** %loc0
+  %11 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc0
+  store %"System.Text.EncodingProvider[]" addrspace(1)* %11, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  store i32 0, i32* %loc5
+  br label %43
+
+; <label>:12                                      ; preds = %46
+  %13 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  %14 = load i32, i32* %loc5
+  %NullCheck1 = icmp eq %"System.Text.EncodingProvider[]" addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %13, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = zext i32 %17 to i64
+  %19 = zext i32 %14 to i64
+  %BoundsCheck = icmp uge i64 %19, %18
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %20
+
+; <label>:20                                      ; preds = %15
+  %21 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %13, i32 0, i32 3, i32 %14
+  %22 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)* addrspace(1)* %21, align 8
+  store %System.Text.EncodingProvider addrspace(1)* %22, %System.Text.EncodingProvider addrspace(1)** %loc1
+  %23 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)** %loc1
+  %24 = load i32, i32* %arg0
+  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i64 addrspace(1)*
+  %NullCheck3 = icmp eq i64 addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
+
+; <label>:26                                      ; preds = %20
+  %27 = load i64, i64 addrspace(1)* %25
+  %28 = add i64 %27, 64
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 40
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Text.Encoding addrspace(1)* (%System.Text.EncodingProvider addrspace(1)*, i32)*
+  %35 = call %System.Text.Encoding addrspace(1)* %34(%System.Text.EncodingProvider addrspace(1)* %23, i32 %24)
+  store %System.Text.Encoding addrspace(1)* %35, %System.Text.Encoding addrspace(1)** %loc2
+  %36 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc2
+  %37 = icmp eq %System.Text.Encoding addrspace(1)* %36, null
+  br i1 %37, label %40, label %38
+
+; <label>:38                                      ; preds = %26
+  %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc2
+  store %System.Text.Encoding addrspace(1)* %39, %System.Text.Encoding addrspace(1)** %loc3
+  br label %53
+
+; <label>:40                                      ; preds = %26
+  %41 = load i32, i32* %loc5
+  %42 = add i32 %41, 1
+  store i32 %42, i32* %loc5
+  br label %43
+
+; <label>:43                                      ; preds = %6, %40
+  %44 = load i32, i32* %loc5
+  %45 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  %NullCheck = icmp eq %"System.Text.EncodingProvider[]" addrspace(1)* %45, null
+  br i1 %NullCheck, label %ThrowNullRef, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp slt i32 %44, %50
+  br i1 %51, label %12, label %52
+
+; <label>:52                                      ; preds = %46
+  ret %System.Text.Encoding addrspace(1)* null
+
+; <label>:53                                      ; preds = %38
+  %54 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc3
+  ret %System.Text.Encoding addrspace(1)* %54
+
+ThrowNullRef:                                     ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method EncodingProvider::.cctor using LLILCJit
 Successfully read EncodingProvider..cctor
 
@@ -10686,7 +12477,7 @@ Failed to read Encoding.get_InternalSyncObject[Call HasTypeArg]
 INFO:  jitting method Hashtable::.ctor using LLILCJit
 Failed to read Hashtable..ctor[Volatile store]
 INFO:  jitting method Hashtable::get_Item using LLILCJit
-Failed to read Hashtable.get_Item[loadElemA]
+Failed to read Hashtable.get_Item[loadNonPrimitiveObj]
 INFO:  jitting method Hashtable::InitHash using LLILCJit
 Successfully read Hashtable.InitHash
 
@@ -10706,8 +12497,8 @@ entry:
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -10723,15 +12514,15 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
   %15 = load i32, i32* %loc0
-  %NullCheck2 = icmp ne i32 addrspace(1)* %14, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i32 addrspace(1)* %14, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %3
   store i32 %15, i32 addrspace(1)* %14, align 8
   %17 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %18 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %NullCheck4 = icmp ne i32 addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i32 addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = load i32, i32 addrspace(1)* %18, align 8
@@ -10740,8 +12531,8 @@ entry:
   %23 = sub i32 %22, 1
   %24 = urem i32 %21, %23
   %25 = add i32 1, %24
-  %NullCheck6 = icmp ne i32 addrspace(1)* %17, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32 addrspace(1)* %17, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %19
   store i32 %25, i32 addrspace(1)* %17, align 8
@@ -10752,15 +12543,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %19
+ThrowNullRef6:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10775,8 +12566,8 @@ entry:
   store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
   store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %NullCheck = icmp ne %System.Collections.Hashtable addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Collections.Hashtable addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
@@ -10786,16 +12577,16 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Collections.Hashtable addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Collections.Hashtable addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
   %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck4 = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %9, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
   %13 = inttoptr i64 %11 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
@@ -10805,8 +12596,8 @@ entry:
 ; <label>:15                                      ; preds = %1
   %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -10824,15 +12615,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10846,8 +12637,8 @@ entry:
   store %System.Int32 addrspace(1)* %param0, %System.Int32 addrspace(1)** %this
   %0 = load %System.Int32 addrspace(1)*, %System.Int32 addrspace(1)** %this
   %1 = bitcast %System.Int32 addrspace(1)* %0 to i32 addrspace(1)*
-  %NullCheck = icmp ne i32 addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq i32 addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load i32, i32 addrspace(1)* %1, align 8
@@ -10923,8 +12714,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.UTF8Encoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
@@ -10933,15 +12724,15 @@ entry:
   %9 = load i8, i8* %arg2
   %10 = zext i8 %9 to i32
   %11 = trunc i32 %10 to i8
-  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %8, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %6
   %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %8, i32 0, i32 8
   store i8 %11, i8 addrspace(1)* %13
   %14 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %14, i32 0, i32 8
@@ -10953,8 +12744,8 @@ entry:
 ; <label>:20                                      ; preds = %15
   %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %22, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %22, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = load i64, i64 addrspace(1)* %22
@@ -10976,15 +12767,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %12
+ThrowNullRef4:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10999,8 +12790,8 @@ entry:
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
@@ -11022,16 +12813,16 @@ entry:
 ; <label>:10                                      ; preds = %1
   %11 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
   %12 = load i32, i32* %arg1
-  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %11, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.Encoding addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
   store i32 %12, i32 addrspace(1)* %14
   %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
   %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = load i64, i64 addrspace(1)* %16
@@ -11049,11 +12840,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11066,8 +12857,8 @@ entry:
   %this = alloca %System.Text.UTF8Encoding addrspace(1)*
   store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
   %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.UTF8Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
@@ -11079,16 +12870,16 @@ entry:
 ; <label>:6                                       ; preds = %1
   %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %8 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %10, %System.Text.EncoderFallback addrspace(1)* %8)
   %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %12 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
-  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %11, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %11, i32 0, i32 3
@@ -11101,8 +12892,8 @@ entry:
   %18 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %18, %System.String addrspace(1)* %17)
   %19 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %18 to %System.Text.EncoderFallback addrspace(1)*
-  %NullCheck6 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %16, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %16, i32 0, i32 2
@@ -11112,8 +12903,8 @@ entry:
   %24 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %24, %System.String addrspace(1)* %23)
   %25 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %24 to %System.Text.DecoderFallback addrspace(1)*
-  %NullCheck8 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %22, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %22, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %20
   %27 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %22, i32 0, i32 3
@@ -11124,19 +12915,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %20
+ThrowNullRef8:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11166,8 +12957,8 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load i32, i32* %arg1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -11185,8 +12976,8 @@ entry:
 ; <label>:15                                      ; preds = %8
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %17 = load i32, i32* %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 %17
@@ -11202,7 +12993,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11254,7 +13045,7 @@ entry:
 }
 
 INFO:  jitting method Hashtable::Insert using LLILCJit
-Failed to read Hashtable.Insert[loadElemA]
+Failed to read Hashtable.Insert[storeElem]
 INFO:  jitting method ConsoleEncoding::.ctor using LLILCJit
 Successfully read ConsoleEncoding..ctor
 
@@ -11269,8 +13060,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %1)
   %2 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
@@ -11306,8 +13097,8 @@ entry:
   %2 = call %System.Text.InternalEncoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalEncoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %1)
   %3 = bitcast %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2 to %System.Text.EncoderFallback addrspace(1)*
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
@@ -11317,8 +13108,8 @@ entry:
   %8 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %7)
   %9 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %8 to %System.Text.DecoderFallback addrspace(1)*
-  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %6, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.Encoding addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %4
   %11 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %6, i32 0, i32 3
@@ -11329,7 +13120,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11348,15 +13139,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* %1)
   %2 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   %6 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, i32 0, i32 1
@@ -11367,7 +13158,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11395,8 +13186,8 @@ entry:
   store %System.Text.InternalDecoderBestFitFallback addrspace(1)* %param0, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
   %0 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
@@ -11406,15 +13197,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %4)
   %5 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %6)
   %9 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, i32 0, i32 1
@@ -11425,11 +13216,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11497,8 +13288,8 @@ entry:
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
   %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = load i64, i64 addrspace(1)* %19
@@ -11562,8 +13353,8 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.ConsoleStream addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
@@ -11594,31 +13385,31 @@ entry:
   store i8 %param4, i8* %arg4
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %3, %System.IO.Stream addrspace(1)* %1)
   %4 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %4, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
   %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %4, i32 0, i32 4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %5)
   %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %6
   %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
   %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
   %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = load i64, i64 addrspace(1)* %13
@@ -11630,8 +13421,8 @@ entry:
   %21 = load i64, i64* %20
   %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %8, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %8, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %14
   %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 5
@@ -11649,24 +13440,24 @@ entry:
   %31 = load i32, i32* %arg3
   %32 = sext i32 %31 to i64
   %33 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %32)
-  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %30, null
-  br i1 %NullCheck10, label %34, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.StreamWriter addrspace(1)* %30, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %35, %"System.Char[]" addrspace(1)* %33)
   %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %37, null
-  br i1 %NullCheck12, label %38, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.StreamWriter addrspace(1)* %37, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %38
 
 ; <label>:38                                      ; preds = %34
   %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
   %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
   %41 = load i32, i32* %arg3
   %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %42, null
-  br i1 %NullCheck14, label %43, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %42, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
   %44 = load i64, i64 addrspace(1)* %42
@@ -11680,30 +13471,30 @@ entry:
   %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
   %53 = sext i32 %52 to i64
   %54 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %53)
-  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
-  br i1 %NullCheck16, label %55, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %55
 
 ; <label>:55                                      ; preds = %43
   %56 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %56, %"System.Byte[]" addrspace(1)* %54)
   %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %58 = load i32, i32* %arg3
-  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %57, null
-  br i1 %NullCheck18, label %59, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.StreamWriter addrspace(1)* %57, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %59
 
 ; <label>:59                                      ; preds = %55
   %60 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 10
   store i32 %58, i32 addrspace(1)* %60
   %61 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %61, null
-  br i1 %NullCheck20, label %62, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.IO.StreamWriter addrspace(1)* %61, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %62
 
 ; <label>:62                                      ; preds = %59
   %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
   %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
   %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
   %67 = load i64, i64 addrspace(1)* %65
@@ -11721,15 +13512,15 @@ entry:
 
 ; <label>:78                                      ; preds = %66
   %79 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %79, null
-  br i1 %NullCheck24, label %80, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.StreamWriter addrspace(1)* %79, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %80
 
 ; <label>:80                                      ; preds = %78
   %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
   %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
   %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %83, null
-  br i1 %NullCheck26, label %84, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %83, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
   %85 = load i64, i64 addrspace(1)* %83
@@ -11746,8 +13537,8 @@ entry:
 
 ; <label>:95                                      ; preds = %84
   %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.IO.StreamWriter addrspace(1)* %96, null
-  br i1 %NullCheck28, label %97, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.IO.StreamWriter addrspace(1)* %96, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %97
 
 ; <label>:97                                      ; preds = %95
   %98 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 12
@@ -11761,8 +13552,8 @@ entry:
   %103 = icmp eq i32 %102, 0
   %104 = sext i1 %103 to i32
   %105 = trunc i32 %104 to i8
-  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %100, null
-  br i1 %NullCheck30, label %106, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.IO.StreamWriter addrspace(1)* %100, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %106
 
 ; <label>:106                                     ; preds = %99
   %107 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %100, i32 0, i32 13
@@ -11773,63 +13564,63 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %6
+ThrowNullRef4:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %29
+ThrowNullRef10:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %34
+ThrowNullRef12:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %38
+ThrowNullRef14:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %43
+ThrowNullRef16:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %55
+ThrowNullRef18:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %59
+ThrowNullRef20:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %62
+ThrowNullRef22:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %78
+ThrowNullRef24:                                   ; preds = %78
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %80
+ThrowNullRef26:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %95
+ThrowNullRef28:                                   ; preds = %95
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11842,15 +13633,15 @@ entry:
   %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = load i64, i64 addrspace(1)* %4
@@ -11868,7 +13659,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11918,35 +13709,35 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
   %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderNLS addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %7 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.EncoderNLS addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Text.Encoding addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.Encoding addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Text.EncoderNLS addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.EncoderNLS addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
   %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck8 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = load i64, i64 addrspace(1)* %16
@@ -11965,19 +13756,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12003,8 +13794,8 @@ entry:
   %this = alloca %System.Text.Encoding addrspace(1)*
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
@@ -12024,15 +13815,15 @@ entry:
   %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
   store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
   %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
   store i32 0, i32 addrspace(1)* %2
   %3 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, i32 0, i32 2
@@ -12042,15 +13833,15 @@ entry:
 
 ; <label>:8                                       ; preds = %4
   %9 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
   %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
   %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = load i64, i64 addrspace(1)* %13
@@ -12071,15 +13862,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12094,16 +13885,16 @@ entry:
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = load i32, i32* %arg1
   %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
   %7 = load i64, i64 addrspace(1)* %5
@@ -12121,7 +13912,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12158,8 +13949,8 @@ entry:
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
   %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
   %16 = load i64, i64 addrspace(1)* %14
@@ -12180,8 +13971,8 @@ entry:
   %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
   %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
   %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %31, null
-  br i1 %NullCheck2, label %32, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = load i64, i64 addrspace(1)* %31
@@ -12224,7 +14015,7 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12237,14 +14028,14 @@ entry:
   %this = alloca %System.Text.EncoderReplacementFallback addrspace(1)*
   store %System.Text.EncoderReplacementFallback addrspace(1)* %param0, %System.Text.EncoderReplacementFallback addrspace(1)** %this
   %0 = load %System.Text.EncoderReplacementFallback addrspace(1)*, %System.Text.EncoderReplacementFallback addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -12255,7 +14046,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12285,8 +14076,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
@@ -12318,8 +14109,8 @@ entry:
   %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
   store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
@@ -12331,8 +14122,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Threading.Tasks.Task addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %7)
@@ -12355,7 +14146,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12374,8 +14165,8 @@ entry:
   store i8 %param1, i8* %arg1
   store i8 %param2, i8* %arg2
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
@@ -12389,8 +14180,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1, %5
   %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 9
@@ -12421,8 +14212,8 @@ entry:
 
 ; <label>:25                                      ; preds = %8, %20
   %26 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %26, null
-  br i1 %NullCheck4, label %27, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %26, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %26, i32 0, i32 12
@@ -12433,22 +14224,22 @@ entry:
 
 ; <label>:32                                      ; preds = %27
   %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %33, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.IO.StreamWriter addrspace(1)* %33, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %32
   %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 12
   store i8 1, i8 addrspace(1)* %35
   %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
-  br i1 %NullCheck8, label %37, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
   %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
   %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck10 = icmp ne i64 addrspace(1)* %40, null
-  br i1 %NullCheck10, label %41, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64 addrspace(1)* %40, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i64, i64 addrspace(1)* %40
@@ -12462,8 +14253,8 @@ entry:
   %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
   store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
   %51 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %NullCheck12 = icmp ne %"System.Byte[]" addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Byte[]" addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %41
   %53 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %51, i32 0, i32 1
@@ -12475,16 +14266,16 @@ entry:
 
 ; <label>:58                                      ; preds = %52
   %59 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %59, null
-  br i1 %NullCheck14, label %60, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.IO.StreamWriter addrspace(1)* %59, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %60
 
 ; <label>:60                                      ; preds = %58
   %61 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %59, i32 0, i32 3
   %62 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
   %64 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %NullCheck16 = icmp ne %"System.Byte[]" addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %"System.Byte[]" addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %60
   %66 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %64, i32 0, i32 1
@@ -12492,8 +14283,8 @@ entry:
   %68 = zext i32 %67 to i64
   %69 = trunc i64 %68 to i32
   %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck18, label %71, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
   %72 = load i64, i64 addrspace(1)* %70
@@ -12509,29 +14300,29 @@ entry:
 
 ; <label>:80                                      ; preds = %27, %52, %71
   %81 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %81, null
-  br i1 %NullCheck20, label %82, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.IO.StreamWriter addrspace(1)* %81, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
 
 ; <label>:82                                      ; preds = %80
   %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %81, i32 0, i32 5
   %84 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %83, align 8
   %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.IO.StreamWriter addrspace(1)* %85, null
-  br i1 %NullCheck22, label %86, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.IO.StreamWriter addrspace(1)* %85, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %86
 
 ; <label>:86                                      ; preds = %82
   %87 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 7
   %88 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %87, align 8
   %89 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %89, null
-  br i1 %NullCheck24, label %90, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.StreamWriter addrspace(1)* %89, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %90
 
 ; <label>:90                                      ; preds = %86
   %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %89, i32 0, i32 9
   %92 = load i32, i32 addrspace(1)* %91, align 8
   %93 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.IO.StreamWriter addrspace(1)* %93, null
-  br i1 %NullCheck26, label %94, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.IO.StreamWriter addrspace(1)* %93, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %93, i32 0, i32 6
@@ -12539,8 +14330,8 @@ entry:
   %97 = load i8, i8* %arg2
   %98 = zext i8 %97 to i32
   %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
-  %NullCheck28 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck28, label %100, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
   %101 = load i64, i64 addrspace(1)* %99
@@ -12555,8 +14346,8 @@ entry:
   %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
   store i32 %110, i32* %loc1
   %111 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %111, null
-  br i1 %NullCheck30, label %112, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.IO.StreamWriter addrspace(1)* %111, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %112
 
 ; <label>:112                                     ; preds = %100
   %113 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %111, i32 0, i32 9
@@ -12567,23 +14358,23 @@ entry:
 
 ; <label>:116                                     ; preds = %112
   %117 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck32 = icmp ne %System.IO.StreamWriter addrspace(1)* %117, null
-  br i1 %NullCheck32, label %118, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.IO.StreamWriter addrspace(1)* %117, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %118
 
 ; <label>:118                                     ; preds = %116
   %119 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %117, i32 0, i32 3
   %120 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %119, align 8
   %121 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.IO.StreamWriter addrspace(1)* %121, null
-  br i1 %NullCheck34, label %122, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.IO.StreamWriter addrspace(1)* %121, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %122
 
 ; <label>:122                                     ; preds = %118
   %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
   %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
   %125 = load i32, i32* %loc1
   %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
-  %NullCheck36 = icmp ne i64 addrspace(1)* %126, null
-  br i1 %NullCheck36, label %127, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64 addrspace(1)* %126, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
   %128 = load i64, i64 addrspace(1)* %126
@@ -12605,15 +14396,15 @@ entry:
 
 ; <label>:140                                     ; preds = %136
   %141 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.IO.StreamWriter addrspace(1)* %141, null
-  br i1 %NullCheck38, label %142, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.IO.StreamWriter addrspace(1)* %141, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %142
 
 ; <label>:142                                     ; preds = %140
   %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
   %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
   %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
-  %NullCheck40 = icmp ne i64 addrspace(1)* %145, null
-  br i1 %NullCheck40, label %146, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i64 addrspace(1)* %145, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
   %147 = load i64, i64 addrspace(1)* %145
@@ -12634,83 +14425,83 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %25
+ThrowNullRef4:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %32
+ThrowNullRef6:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %37
+ThrowNullRef10:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %41
+ThrowNullRef12:                                   ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %58
+ThrowNullRef14:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %60
+ThrowNullRef16:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %65
+ThrowNullRef18:                                   ; preds = %65
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %80
+ThrowNullRef20:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %82
+ThrowNullRef22:                                   ; preds = %82
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %86
+ThrowNullRef24:                                   ; preds = %86
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %90
+ThrowNullRef26:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %94
+ThrowNullRef28:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %100
+ThrowNullRef30:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %116
+ThrowNullRef32:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %118
+ThrowNullRef34:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %122
+ThrowNullRef36:                                   ; preds = %122
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %140
+ThrowNullRef38:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %142
+ThrowNullRef40:                                   ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12777,8 +14568,8 @@ entry:
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %1 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
-  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
@@ -12786,8 +14577,8 @@ entry:
   %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
   %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
   %8 = load i64, i64 addrspace(1)* %6
@@ -12803,8 +14594,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %17, %System.IFormatProvider addrspace(1)* %16)
   %18 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %19 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %18, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.SyncTextWriter addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %7
   %21 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %18, i32 0, i32 4
@@ -12815,11 +14606,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12832,8 +14623,8 @@ entry:
   %this = alloca %System.IO.TextWriter addrspace(1)*
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.TextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
@@ -12843,8 +14634,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.Threading.Thread addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Threading.Thread addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %6)
@@ -12853,8 +14644,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1
   %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.TextWriter addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.TextWriter addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %11, i32 0, i32 2
@@ -12865,11 +14656,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13066,8 +14857,8 @@ entry:
   store float %param1, float* %arg1
   store i8 0, i8* %loc1
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
@@ -13077,16 +14868,16 @@ entry:
   %5 = addrspacecast i8* %loc1 to i8 addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %4, i8 addrspace(1)* %5)
   %6 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.SyncTextWriter addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
   %10 = load float, float* %arg1
   %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
   %13 = load i64, i64 addrspace(1)* %11
@@ -13121,11 +14912,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13142,8 +14933,8 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load float, float* %arg1
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -13157,8 +14948,8 @@ entry:
   call void %11(%System.IO.TextWriter addrspace(1)* %0, float %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
   %15 = load i64, i64 addrspace(1)* %13
@@ -13176,7 +14967,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13194,8 +14985,8 @@ entry:
   %1 = addrspacecast float* %arg1 to float addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -13210,8 +15001,8 @@ entry:
   %14 = bitcast float addrspace(1)* %1 to %System.Single addrspace(1)*
   %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Single addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Single addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
   %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
   %18 = load i64, i64 addrspace(1)* %16
@@ -13229,7 +15020,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13245,8 +15036,8 @@ entry:
   store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
   %0 = load %System.Single addrspace(1)*, %System.Single addrspace(1)** %this
   %1 = bitcast %System.Single addrspace(1)* %0 to float addrspace(1)*
-  %NullCheck = icmp ne float addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq float addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load float, float addrspace(1)* %1, align 8
@@ -13271,8 +15062,8 @@ entry:
   %loc0 = alloca %System.Globalization.NumberFormatInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 3
@@ -13282,8 +15073,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
@@ -13293,24 +15084,24 @@ entry:
   store %System.Globalization.NumberFormatInfo addrspace(1)* %10, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
   %11 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %7
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
   %15 = load i8, i8 addrspace(1)* %14, align 8
   %16 = zext i8 %15 to i32
   %17 = trunc i32 %16 to i8
-  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %11, null
-  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %11, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %13
   %19 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %11, i32 0, i32 29
   store i8 %17, i8 addrspace(1)* %19
   %20 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %21 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %20, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %20, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %18
   %23 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %20, i32 0, i32 3
@@ -13319,8 +15110,8 @@ entry:
 
 ; <label>:24                                      ; preds = %1, %22
   %25 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %25, null
-  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %25, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %26
 
 ; <label>:26                                      ; preds = %24
   %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %25, i32 0, i32 3
@@ -13331,23 +15122,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %18
+ThrowNullRef8:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13372,168 +15163,168 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 18
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %8, align 8
-  %NullCheck2 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %5, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %5, i32 0, i32 4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %9)
   %12 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 19
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %15, align 8
-  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %12, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %12, i32 0, i32 5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %16)
   %19 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %20 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %20, null
-  br i1 %NullCheck8, label %21, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %20, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %20, i32 0, i32 23
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  %NullCheck10 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %19, null
-  br i1 %NullCheck10, label %24, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %19, i32 0, i32 7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %25, %System.String addrspace(1)* %23)
   %26 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %27 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %27, i32 0, i32 22
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %29, align 8
-  %NullCheck14 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %26, null
-  br i1 %NullCheck14, label %31, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %26, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %26, i32 0, i32 6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %32, %System.String addrspace(1)* %30)
   %33 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %34 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Globalization.CultureData addrspace(1)* %34, null
-  br i1 %NullCheck16, label %35, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Globalization.CultureData addrspace(1)* %34, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %34, i32 0, i32 51
   %37 = load i32, i32 addrspace(1)* %36, align 8
-  %NullCheck18 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %33, null
-  br i1 %NullCheck18, label %38, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %33, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %33, i32 0, i32 21
   store i32 %37, i32 addrspace(1)* %39
   %40 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %41 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Globalization.CultureData addrspace(1)* %41, null
-  br i1 %NullCheck20, label %42, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Globalization.CultureData addrspace(1)* %41, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %41, i32 0, i32 52
   %44 = load i32, i32 addrspace(1)* %43, align 8
-  %NullCheck22 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %40, null
-  br i1 %NullCheck22, label %45, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %40, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %40, i32 0, i32 25
   store i32 %44, i32 addrspace(1)* %46
   %47 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %48 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.Globalization.CultureData addrspace(1)* %48, null
-  br i1 %NullCheck24, label %49, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Globalization.CultureData addrspace(1)* %48, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %49
 
 ; <label>:49                                      ; preds = %45
   %50 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %48, i32 0, i32 29
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck26 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %47, null
-  br i1 %NullCheck26, label %52, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %47, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %47, i32 0, i32 10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %53, %System.String addrspace(1)* %51)
   %54 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %55 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Globalization.CultureData addrspace(1)* %55, null
-  br i1 %NullCheck28, label %56, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Globalization.CultureData addrspace(1)* %55, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %56
 
 ; <label>:56                                      ; preds = %52
   %57 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %55, i32 0, i32 35
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %57, align 8
-  %NullCheck30 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %54, null
-  br i1 %NullCheck30, label %59, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %54, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %54, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %60, %System.String addrspace(1)* %58)
   %61 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %62 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck32 = icmp ne %System.Globalization.CultureData addrspace(1)* %62, null
-  br i1 %NullCheck32, label %63, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Globalization.CultureData addrspace(1)* %62, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %62, i32 0, i32 34
   %65 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %64, align 8
-  %NullCheck34 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %61, null
-  br i1 %NullCheck34, label %66, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %61, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %61, i32 0, i32 9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %67, %System.String addrspace(1)* %65)
   %68 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %69 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck36 = icmp ne %System.Globalization.CultureData addrspace(1)* %69, null
-  br i1 %NullCheck36, label %70, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Globalization.CultureData addrspace(1)* %69, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %70
 
 ; <label>:70                                      ; preds = %66
   %71 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %69, i32 0, i32 55
   %72 = load i32, i32 addrspace(1)* %71, align 8
-  %NullCheck38 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %68, null
-  br i1 %NullCheck38, label %73, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %68, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %68, i32 0, i32 22
   store i32 %72, i32 addrspace(1)* %74
   %75 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %76 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck40 = icmp ne %System.Globalization.CultureData addrspace(1)* %76, null
-  br i1 %NullCheck40, label %77, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Globalization.CultureData addrspace(1)* %76, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %76, i32 0, i32 57
   %79 = load i32, i32 addrspace(1)* %78, align 8
-  %NullCheck42 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %75, null
-  br i1 %NullCheck42, label %80, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %75, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %80
 
 ; <label>:80                                      ; preds = %77
   %81 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %75, i32 0, i32 24
   store i32 %79, i32 addrspace(1)* %81
   %82 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %83 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck44 = icmp ne %System.Globalization.CultureData addrspace(1)* %83, null
-  br i1 %NullCheck44, label %84, label %ThrowNullRef43
+  %NullCheck43 = icmp eq %System.Globalization.CultureData addrspace(1)* %83, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %84
 
 ; <label>:84                                      ; preds = %80
   %85 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %83, i32 0, i32 56
   %86 = load i32, i32 addrspace(1)* %85, align 8
-  %NullCheck46 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %82, null
-  br i1 %NullCheck46, label %87, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %82, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %82, i32 0, i32 23
@@ -13542,8 +15333,8 @@ entry:
 
 ; <label>:89                                      ; preds = %entry
   %90 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck100 = icmp ne %System.Globalization.CultureData addrspace(1)* %90, null
-  br i1 %NullCheck100, label %91, label %ThrowNullRef99
+  %NullCheck99 = icmp eq %System.Globalization.CultureData addrspace(1)* %90, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %91
 
 ; <label>:91                                      ; preds = %89
   %92 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %90, i32 0, i32 2
@@ -13561,8 +15352,8 @@ entry:
   %102 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %103 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %104 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %103)
-  %NullCheck48 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %102, null
-  br i1 %NullCheck48, label %105, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %102, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %105
 
 ; <label>:105                                     ; preds = %101
   %106 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %102, i32 0, i32 1
@@ -13570,8 +15361,8 @@ entry:
   %107 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %108 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %109 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %108)
-  %NullCheck50 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %107, null
-  br i1 %NullCheck50, label %110, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %107, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %110
 
 ; <label>:110                                     ; preds = %105
   %111 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %107, i32 0, i32 2
@@ -13579,8 +15370,8 @@ entry:
   %112 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %113 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %114 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %113)
-  %NullCheck52 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %112, null
-  br i1 %NullCheck52, label %115, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %112, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %115
 
 ; <label>:115                                     ; preds = %110
   %116 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %112, i32 0, i32 27
@@ -13588,8 +15379,8 @@ entry:
   %117 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %118 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %119 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %118)
-  %NullCheck54 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %117, null
-  br i1 %NullCheck54, label %120, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %117, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %120
 
 ; <label>:120                                     ; preds = %115
   %121 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %117, i32 0, i32 26
@@ -13597,8 +15388,8 @@ entry:
   %122 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %123 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %124 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %123)
-  %NullCheck56 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %122, null
-  br i1 %NullCheck56, label %125, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %122, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %125
 
 ; <label>:125                                     ; preds = %120
   %126 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %122, i32 0, i32 17
@@ -13606,8 +15397,8 @@ entry:
   %127 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %128 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %129 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %128)
-  %NullCheck58 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %127, null
-  br i1 %NullCheck58, label %130, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %127, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %130
 
 ; <label>:130                                     ; preds = %125
   %131 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %127, i32 0, i32 18
@@ -13615,8 +15406,8 @@ entry:
   %132 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %133 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %134 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %133)
-  %NullCheck60 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %132, null
-  br i1 %NullCheck60, label %135, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %132, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %135
 
 ; <label>:135                                     ; preds = %130
   %136 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %132, i32 0, i32 14
@@ -13624,8 +15415,8 @@ entry:
   %137 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %138 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %139 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %138)
-  %NullCheck62 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %137, null
-  br i1 %NullCheck62, label %140, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %137, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %140
 
 ; <label>:140                                     ; preds = %135
   %141 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %137, i32 0, i32 13
@@ -13633,71 +15424,71 @@ entry:
   %142 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %143 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %144 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %143)
-  %NullCheck64 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %142, null
-  br i1 %NullCheck64, label %145, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %142, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %145
 
 ; <label>:145                                     ; preds = %140
   %146 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %142, i32 0, i32 12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %146, %System.String addrspace(1)* %144)
   %147 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %148 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck66 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %148, null
-  br i1 %NullCheck66, label %149, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %148, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %149
 
 ; <label>:149                                     ; preds = %145
   %150 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %148, i32 0, i32 21
   %151 = load i32, i32 addrspace(1)* %150, align 8
-  %NullCheck68 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %147, null
-  br i1 %NullCheck68, label %152, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %147, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %152
 
 ; <label>:152                                     ; preds = %149
   %153 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %147, i32 0, i32 28
   store i32 %151, i32 addrspace(1)* %153
   %154 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %155 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck70 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %155, null
-  br i1 %NullCheck70, label %156, label %ThrowNullRef69
+  %NullCheck69 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %155, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %156
 
 ; <label>:156                                     ; preds = %152
   %157 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %155, i32 0, i32 6
   %158 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %157, align 8
-  %NullCheck72 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %154, null
-  br i1 %NullCheck72, label %159, label %ThrowNullRef71
+  %NullCheck71 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %154, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %159
 
 ; <label>:159                                     ; preds = %156
   %160 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %154, i32 0, i32 15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %160, %System.String addrspace(1)* %158)
   %161 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %162 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck74 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %162, null
-  br i1 %NullCheck74, label %163, label %ThrowNullRef73
+  %NullCheck73 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %162, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %163
 
 ; <label>:163                                     ; preds = %159
   %164 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %162, i32 0, i32 1
   %165 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %164, align 8
-  %NullCheck76 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %161, null
-  br i1 %NullCheck76, label %166, label %ThrowNullRef75
+  %NullCheck75 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %161, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %166
 
 ; <label>:166                                     ; preds = %163
   %167 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %161, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %167, %"System.Int32[]" addrspace(1)* %165)
   %168 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %169 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck78 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %169, null
-  br i1 %NullCheck78, label %170, label %ThrowNullRef77
+  %NullCheck77 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %169, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %170
 
 ; <label>:170                                     ; preds = %166
   %171 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %169, i32 0, i32 7
   %172 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %171, align 8
-  %NullCheck80 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %168, null
-  br i1 %NullCheck80, label %173, label %ThrowNullRef79
+  %NullCheck79 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %168, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %173
 
 ; <label>:173                                     ; preds = %170
   %174 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %168, i32 0, i32 16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %174, %System.String addrspace(1)* %172)
   %175 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck82 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %175, null
-  br i1 %NullCheck82, label %176, label %ThrowNullRef81
+  %NullCheck81 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %175, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %176
 
 ; <label>:176                                     ; preds = %173
   %177 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %175, i32 0, i32 4
@@ -13707,14 +15498,14 @@ entry:
 
 ; <label>:180                                     ; preds = %176
   %181 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck84 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %181, null
-  br i1 %NullCheck84, label %182, label %ThrowNullRef83
+  %NullCheck83 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %181, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %182
 
 ; <label>:182                                     ; preds = %180
   %183 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %181, i32 0, i32 4
   %184 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %183, align 8
-  %NullCheck86 = icmp ne %System.String addrspace(1)* %184, null
-  br i1 %NullCheck86, label %185, label %ThrowNullRef85
+  %NullCheck85 = icmp eq %System.String addrspace(1)* %184, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %185
 
 ; <label>:185                                     ; preds = %182
   %186 = getelementptr inbounds %System.String, %System.String addrspace(1)* %184, i32 0, i32 1
@@ -13725,8 +15516,8 @@ entry:
 ; <label>:189                                     ; preds = %176, %185
   %190 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck98 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %190, null
-  br i1 %NullCheck98, label %192, label %ThrowNullRef97
+  %NullCheck97 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %190, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %192
 
 ; <label>:192                                     ; preds = %189
   %193 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %190, i32 0, i32 4
@@ -13735,8 +15526,8 @@ entry:
 
 ; <label>:194                                     ; preds = %185, %192
   %195 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck88 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %195, null
-  br i1 %NullCheck88, label %196, label %ThrowNullRef87
+  %NullCheck87 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %195, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %196
 
 ; <label>:196                                     ; preds = %194
   %197 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %195, i32 0, i32 9
@@ -13746,14 +15537,14 @@ entry:
 
 ; <label>:200                                     ; preds = %196
   %201 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck90 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %201, null
-  br i1 %NullCheck90, label %202, label %ThrowNullRef89
+  %NullCheck89 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %201, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %202
 
 ; <label>:202                                     ; preds = %200
   %203 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %201, i32 0, i32 9
   %204 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %203, align 8
-  %NullCheck92 = icmp ne %System.String addrspace(1)* %204, null
-  br i1 %NullCheck92, label %205, label %ThrowNullRef91
+  %NullCheck91 = icmp eq %System.String addrspace(1)* %204, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %205
 
 ; <label>:205                                     ; preds = %202
   %206 = getelementptr inbounds %System.String, %System.String addrspace(1)* %204, i32 0, i32 1
@@ -13764,14 +15555,14 @@ entry:
 ; <label>:209                                     ; preds = %196, %205
   %210 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %211 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck94 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %211, null
-  br i1 %NullCheck94, label %212, label %ThrowNullRef93
+  %NullCheck93 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %211, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %212
 
 ; <label>:212                                     ; preds = %209
   %213 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %211, i32 0, i32 6
   %214 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %213, align 8
-  %NullCheck96 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %210, null
-  br i1 %NullCheck96, label %215, label %ThrowNullRef95
+  %NullCheck95 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %210, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %215
 
 ; <label>:215                                     ; preds = %212
   %216 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %210, i32 0, i32 9
@@ -13785,203 +15576,203 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %17
+ThrowNullRef8:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %21
+ThrowNullRef10:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %24
+ThrowNullRef12:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %28
+ThrowNullRef14:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %31
+ThrowNullRef16:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %35
+ThrowNullRef18:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %38
+ThrowNullRef20:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %42
+ThrowNullRef22:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %45
+ThrowNullRef24:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %49
+ThrowNullRef26:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %52
+ThrowNullRef28:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %56
+ThrowNullRef30:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %59
+ThrowNullRef32:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %63
+ThrowNullRef34:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %66
+ThrowNullRef36:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %70
+ThrowNullRef38:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %73
+ThrowNullRef40:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %77
+ThrowNullRef42:                                   ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %80
+ThrowNullRef44:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %84
+ThrowNullRef46:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %101
+ThrowNullRef48:                                   ; preds = %101
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %105
+ThrowNullRef50:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %110
+ThrowNullRef52:                                   ; preds = %110
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %115
+ThrowNullRef54:                                   ; preds = %115
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %120
+ThrowNullRef56:                                   ; preds = %120
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %125
+ThrowNullRef58:                                   ; preds = %125
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %130
+ThrowNullRef60:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %135
+ThrowNullRef62:                                   ; preds = %135
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %140
+ThrowNullRef64:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %145
+ThrowNullRef66:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %149
+ThrowNullRef68:                                   ; preds = %149
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %152
+ThrowNullRef70:                                   ; preds = %152
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %156
+ThrowNullRef72:                                   ; preds = %156
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %159
+ThrowNullRef74:                                   ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %163
+ThrowNullRef76:                                   ; preds = %163
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %166
+ThrowNullRef78:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %170
+ThrowNullRef80:                                   ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %173
+ThrowNullRef82:                                   ; preds = %173
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %180
+ThrowNullRef84:                                   ; preds = %180
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %182
+ThrowNullRef86:                                   ; preds = %182
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %194
+ThrowNullRef88:                                   ; preds = %194
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %200
+ThrowNullRef90:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %202
+ThrowNullRef92:                                   ; preds = %202
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %209
+ThrowNullRef94:                                   ; preds = %209
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %212
+ThrowNullRef96:                                   ; preds = %212
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %189
+ThrowNullRef98:                                   ; preds = %189
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %89
+ThrowNullRef100:                                  ; preds = %89
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14009,8 +15800,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 21
@@ -14023,8 +15814,8 @@ entry:
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 16)
   %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 21
@@ -14033,8 +15824,8 @@ entry:
 
 ; <label>:12                                      ; preds = %1, %10
   %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 21
@@ -14045,11 +15836,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %12
+ThrowNullRef4:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14065,8 +15856,8 @@ entry:
   store i32 %param1, i32* %arg1
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %1 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
@@ -14133,8 +15924,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 33
@@ -14147,8 +15938,8 @@ entry:
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 24)
   %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 33
@@ -14157,8 +15948,8 @@ entry:
 
 ; <label>:12                                      ; preds = %1, %10
   %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 33
@@ -14169,11 +15960,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %12
+ThrowNullRef4:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14186,8 +15977,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 53
@@ -14199,8 +15990,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 116)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 53
@@ -14209,8 +16000,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 53
@@ -14221,11 +16012,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14254,8 +16045,8 @@ entry:
 
 ; <label>:7                                       ; preds = %entry, %4
   %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %7
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 2
@@ -14279,8 +16070,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 54
@@ -14292,8 +16083,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 117)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
@@ -14302,8 +16093,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 54
@@ -14314,11 +16105,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14331,8 +16122,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 27
@@ -14344,8 +16135,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 118)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 27
@@ -14354,8 +16145,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 27
@@ -14366,11 +16157,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14383,8 +16174,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 28
@@ -14396,8 +16187,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 119)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 28
@@ -14406,8 +16197,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 28
@@ -14418,11 +16209,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14435,8 +16226,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 26
@@ -14448,8 +16239,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 107)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 26
@@ -14458,8 +16249,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 26
@@ -14470,11 +16261,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14487,8 +16278,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 25
@@ -14500,8 +16291,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 106)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 25
@@ -14510,8 +16301,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 25
@@ -14522,11 +16313,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14539,8 +16330,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 24
@@ -14552,8 +16343,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 105)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 24
@@ -14562,8 +16353,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 24
@@ -14574,11 +16365,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14603,8 +16394,8 @@ entry:
   %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %3)
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %2
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -14615,15 +16406,15 @@ entry:
 
 ; <label>:8                                       ; preds = %62
   %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 9
   %12 = load i32, i32 addrspace(1)* %11, align 8
   %13 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.IO.StreamWriter addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %13, i32 0, i32 10
@@ -14638,15 +16429,15 @@ entry:
 
 ; <label>:20                                      ; preds = %14, %18
   %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
   %24 = load i32, i32 addrspace(1)* %23, align 8
   %25 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %25, null
-  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.StreamWriter addrspace(1)* %25, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %25, i32 0, i32 9
@@ -14667,36 +16458,36 @@ entry:
   %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %37 = load i32, i32* %loc1
   %38 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.StreamWriter addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %35
   %40 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %38, i32 0, i32 7
   %41 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %40, align 8
   %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
-  br i1 %NullCheck14, label %43, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %39
   %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 9
   %45 = load i32, i32 addrspace(1)* %44, align 8
   %46 = load i32, i32* %loc2
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %36, null
-  br i1 %NullCheck16, label %47, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %36, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %47
 
 ; <label>:47                                      ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %36, i32 %37, %"System.Char[]" addrspace(1)* %41, i32 %45, i32 %46)
   %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
   %51 = load i32, i32 addrspace(1)* %50, align 8
   %52 = load i32, i32* %loc2
   %53 = add i32 %51, %52
-  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
-  br i1 %NullCheck20, label %54, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %54
 
 ; <label>:54                                      ; preds = %49
   %55 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
@@ -14718,8 +16509,8 @@ entry:
 
 ; <label>:65                                      ; preds = %62
   %66 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %66, null
-  br i1 %NullCheck2, label %67, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %66, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %67
 
 ; <label>:67                                      ; preds = %65
   %68 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %66, i32 0, i32 11
@@ -14740,49 +16531,259 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %65
+ThrowNullRef2:                                    ; preds = %65
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %20
+ThrowNullRef8:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %22
+ThrowNullRef10:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %35
+ThrowNullRef12:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %43
+ThrowNullRef16:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %47
+ThrowNullRef18:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method String::CopyTo using LLILCJit
-Failed to read String.CopyTo[loadElemA]
+Successfully read String.CopyTo
+
+define void @String.CopyTo(%System.String addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  %loc1 = alloca i16 addrspace(1)*
+  %loc2 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %1 = icmp ne %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg4
+  %7 = icmp sge i32 %6, 0
+  br i1 %7, label %13, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  unreachable
+
+; <label>:13                                      ; preds = %5
+  %14 = load i32, i32* %arg1
+  %15 = icmp sge i32 %14, 0
+  br i1 %15, label %21, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %18)
+  %20 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %20, %System.String addrspace(1)* %17, %System.String addrspace(1)* %19)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %20) #0
+  unreachable
+
+; <label>:21                                      ; preds = %13
+  %22 = load i32, i32* %arg4
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck, label %ThrowNullRef, label %24
+
+; <label>:24                                      ; preds = %21
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load i32, i32* %arg1
+  %28 = sub i32 %26, %27
+  %29 = icmp sle i32 %22, %28
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34, %System.String addrspace(1)* %31, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %24
+  %36 = load i32, i32* %arg3
+  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %37, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
+
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
+  %40 = load i32, i32 addrspace(1)* %39
+  %41 = zext i32 %40 to i64
+  %42 = trunc i64 %41 to i32
+  %43 = load i32, i32* %arg4
+  %44 = sub i32 %42, %43
+  %45 = icmp sgt i32 %36, %44
+  br i1 %45, label %49, label %46
+
+; <label>:46                                      ; preds = %38
+  %47 = load i32, i32* %arg3
+  %48 = icmp sge i32 %47, 0
+  br i1 %48, label %54, label %49
+
+; <label>:49                                      ; preds = %38, %46
+  %50 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %52 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %51)
+  %53 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53, %System.String addrspace(1)* %50, %System.String addrspace(1)* %52)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53) #0
+  unreachable
+
+; <label>:54                                      ; preds = %46
+  %55 = load i32, i32* %arg4
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %97, label %57
+
+; <label>:57                                      ; preds = %54
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %59
+
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 2
+  %61 = bitcast [0 x i16] addrspace(1)* %60 to i16 addrspace(1)*
+  store i16 addrspace(1)* %61, i16 addrspace(1)** %loc0
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  store %"System.Char[]" addrspace(1)* %62, %"System.Char[]" addrspace(1)** %loc2
+  %63 = icmp eq %"System.Char[]" addrspace(1)* %62, null
+  br i1 %63, label %72, label %64
+
+; <label>:64                                      ; preds = %59
+  %65 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc2
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %65, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %66
+
+; <label>:66                                      ; preds = %64
+  %67 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %65, i32 0, i32 1
+  %68 = load i32, i32 addrspace(1)* %67
+  %69 = zext i32 %68 to i64
+  %70 = trunc i64 %69 to i32
+  %71 = icmp ne i32 %70, 0
+  br i1 %71, label %73, label %72
+
+; <label>:72                                      ; preds = %59, %66
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  br label %81
+
+; <label>:73                                      ; preds = %66
+  %74 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc2
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %74, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %75
+
+; <label>:75                                      ; preds = %73
+  %76 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %74, i32 0, i32 1
+  %77 = load i32, i32 addrspace(1)* %76
+  %78 = zext i32 %77 to i64
+  %BoundsCheck = icmp uge i64 0, %78
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %79
+
+; <label>:79                                      ; preds = %75
+  %80 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %74, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %80, i16 addrspace(1)** %loc1
+  br label %81
+
+; <label>:81                                      ; preds = %72, %79
+  %82 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %83 = ptrtoint i16 addrspace(1)* %82 to i64
+  %84 = load i32, i32* %arg3
+  %85 = sext i32 %84 to i64
+  %86 = mul i64 %85, 2
+  %87 = add i64 %83, %86
+  %88 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %89 = ptrtoint i16 addrspace(1)* %88 to i64
+  %90 = load i32, i32* %arg1
+  %91 = sext i32 %90 to i64
+  %92 = mul i64 %91, 2
+  %93 = add i64 %89, %92
+  %94 = load i32, i32* %arg4
+  %95 = inttoptr i64 %87 to i16*
+  %96 = inttoptr i64 %93 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %95, i16* %96, i32 %94)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  br label %97
+
+; <label>:97                                      ; preds = %54, %81
+  ret void
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
 Successfully read ConsoleEncoding.GetPreamble
 
@@ -14819,7 +16820,365 @@ entry:
 }
 
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[loadElemA]
+Successfully read EncoderNLS.GetBytes
+
+define i32 @EncoderNLS.GetBytes(%System.Text.EncoderNLS addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3, %"System.Byte[]" addrspace(1)* %param4, i32 %param5, i8 %param6) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %arg4 = alloca %"System.Byte[]" addrspace(1)*
+  %arg5 = alloca i32
+  %arg6 = alloca i8
+  %loc0 = alloca i32
+  %loc1 = alloca i16 addrspace(1)*
+  %loc2 = alloca i8 addrspace(1)*
+  %loc3 = alloca i32
+  %loc4 = alloca %"System.Char[]" addrspace(1)*
+  %loc5 = alloca %"System.Byte[]" addrspace(1)*
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  store %"System.Byte[]" addrspace(1)* %param4, %"System.Byte[]" addrspace(1)** %arg4
+  store i32 %param5, i32* %arg5
+  store i8 %param6, i8* %arg6
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %1 = icmp eq %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %17, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %7 = icmp eq %"System.Char[]" addrspace(1)* %6, null
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %12
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %12
+
+; <label>:12                                      ; preds = %8, %10
+  %13 = phi %System.String addrspace(1)* [ %9, %8 ], [ %11, %10 ]
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %14)
+  %16 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16, %System.String addrspace(1)* %13, %System.String addrspace(1)* %15)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16) #0
+  unreachable
+
+; <label>:17                                      ; preds = %2
+  %18 = load i32, i32* %arg2
+  %19 = icmp slt i32 %18, 0
+  br i1 %19, label %23, label %20
+
+; <label>:20                                      ; preds = %17
+  %21 = load i32, i32* %arg3
+  %22 = icmp sge i32 %21, 0
+  br i1 %22, label %35, label %23
+
+; <label>:23                                      ; preds = %17, %20
+  %24 = load i32, i32* %arg2
+  %25 = icmp slt i32 %24, 0
+  br i1 %25, label %28, label %26
+
+; <label>:26                                      ; preds = %23
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %30
+
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %30
+
+; <label>:30                                      ; preds = %26, %28
+  %31 = phi %System.String addrspace(1)* [ %27, %26 ], [ %29, %28 ]
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34, %System.String addrspace(1)* %31, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %20
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck, label %ThrowNullRef, label %37
+
+; <label>:37                                      ; preds = %35
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = load i32, i32* %arg2
+  %43 = sub i32 %41, %42
+  %44 = load i32, i32* %arg3
+  %45 = icmp sge i32 %43, %44
+  br i1 %45, label %51, label %46
+
+; <label>:46                                      ; preds = %37
+  %47 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %48 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %49 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %48)
+  %50 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %50, %System.String addrspace(1)* %47, %System.String addrspace(1)* %49)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %50) #0
+  unreachable
+
+; <label>:51                                      ; preds = %37
+  %52 = load i32, i32* %arg5
+  %53 = icmp slt i32 %52, 0
+  br i1 %53, label %63, label %54
+
+; <label>:54                                      ; preds = %51
+  %55 = load i32, i32* %arg5
+  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck1 = icmp eq %"System.Byte[]" addrspace(1)* %56, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %57
+
+; <label>:57                                      ; preds = %54
+  %58 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = zext i32 %59 to i64
+  %61 = trunc i64 %60 to i32
+  %62 = icmp sle i32 %55, %61
+  br i1 %62, label %68, label %63
+
+; <label>:63                                      ; preds = %51, %57
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %66 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %65)
+  %67 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %67, %System.String addrspace(1)* %64, %System.String addrspace(1)* %66)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %67) #0
+  unreachable
+
+; <label>:68                                      ; preds = %57
+  %69 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %69, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %69, i32 0, i32 1
+  %72 = load i32, i32 addrspace(1)* %71
+  %73 = zext i32 %72 to i64
+  %74 = trunc i64 %73 to i32
+  %75 = icmp ne i32 %74, 0
+  br i1 %75, label %78, label %76
+
+; <label>:76                                      ; preds = %70
+  %77 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1)
+  store %"System.Char[]" addrspace(1)* %77, %"System.Char[]" addrspace(1)** %arg1
+  br label %78
+
+; <label>:78                                      ; preds = %70, %76
+  %79 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck5 = icmp eq %"System.Byte[]" addrspace(1)* %79, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %80
+
+; <label>:80                                      ; preds = %78
+  %81 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %79, i32 0, i32 1
+  %82 = load i32, i32 addrspace(1)* %81
+  %83 = zext i32 %82 to i64
+  %84 = trunc i64 %83 to i32
+  %85 = load i32, i32* %arg5
+  %86 = sub i32 %84, %85
+  store i32 %86, i32* %loc0
+  %87 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck7 = icmp eq %"System.Byte[]" addrspace(1)* %87, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %88
+
+; <label>:88                                      ; preds = %80
+  %89 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %87, i32 0, i32 1
+  %90 = load i32, i32 addrspace(1)* %89
+  %91 = zext i32 %90 to i64
+  %92 = trunc i64 %91 to i32
+  %93 = icmp ne i32 %92, 0
+  br i1 %93, label %96, label %94
+
+; <label>:94                                      ; preds = %88
+  %95 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1)
+  store %"System.Byte[]" addrspace(1)* %95, %"System.Byte[]" addrspace(1)** %arg4
+  br label %96
+
+; <label>:96                                      ; preds = %88, %94
+  %97 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  store %"System.Char[]" addrspace(1)* %97, %"System.Char[]" addrspace(1)** %loc4
+  %98 = icmp eq %"System.Char[]" addrspace(1)* %97, null
+  br i1 %98, label %107, label %99
+
+; <label>:99                                      ; preds = %96
+  %100 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc4
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %100, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %101
+
+; <label>:101                                     ; preds = %99
+  %102 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %100, i32 0, i32 1
+  %103 = load i32, i32 addrspace(1)* %102
+  %104 = zext i32 %103 to i64
+  %105 = trunc i64 %104 to i32
+  %106 = icmp ne i32 %105, 0
+  br i1 %106, label %108, label %107
+
+; <label>:107                                     ; preds = %96, %101
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  br label %116
+
+; <label>:108                                     ; preds = %101
+  %109 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc4
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %109, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %110
+
+; <label>:110                                     ; preds = %108
+  %111 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %109, i32 0, i32 1
+  %112 = load i32, i32 addrspace(1)* %111
+  %113 = zext i32 %112 to i64
+  %BoundsCheck = icmp uge i64 0, %113
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %114
+
+; <label>:114                                     ; preds = %110
+  %115 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %109, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %115, i16 addrspace(1)** %loc1
+  br label %116
+
+; <label>:116                                     ; preds = %107, %114
+  %117 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  store %"System.Byte[]" addrspace(1)* %117, %"System.Byte[]" addrspace(1)** %loc5
+  %118 = icmp eq %"System.Byte[]" addrspace(1)* %117, null
+  br i1 %118, label %127, label %119
+
+; <label>:119                                     ; preds = %116
+  %120 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc5
+  %NullCheck13 = icmp eq %"System.Byte[]" addrspace(1)* %120, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %121
+
+; <label>:121                                     ; preds = %119
+  %122 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %120, i32 0, i32 1
+  %123 = load i32, i32 addrspace(1)* %122
+  %124 = zext i32 %123 to i64
+  %125 = trunc i64 %124 to i32
+  %126 = icmp ne i32 %125, 0
+  br i1 %126, label %128, label %127
+
+; <label>:127                                     ; preds = %116, %121
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc2
+  br label %136
+
+; <label>:128                                     ; preds = %121
+  %129 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc5
+  %NullCheck15 = icmp eq %"System.Byte[]" addrspace(1)* %129, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %130
+
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %129, i32 0, i32 1
+  %132 = load i32, i32 addrspace(1)* %131
+  %133 = zext i32 %132 to i64
+  %BoundsCheck17 = icmp uge i64 0, %133
+  br i1 %BoundsCheck17, label %ThrowIndexOutOfRange18, label %134
+
+; <label>:134                                     ; preds = %130
+  %135 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %129, i32 0, i32 3, i32 0
+  store i8 addrspace(1)* %135, i8 addrspace(1)** %loc2
+  br label %136
+
+; <label>:136                                     ; preds = %127, %134
+  %137 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %138 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %139 = ptrtoint i16 addrspace(1)* %138 to i64
+  %140 = load i32, i32* %arg2
+  %141 = sext i32 %140 to i64
+  %142 = mul i64 %141, 2
+  %143 = add i64 %139, %142
+  %144 = load i32, i32* %arg3
+  %145 = load i8 addrspace(1)*, i8 addrspace(1)** %loc2
+  %146 = ptrtoint i8 addrspace(1)* %145 to i64
+  %147 = load i32, i32* %arg5
+  %148 = sext i32 %147 to i64
+  %149 = add i64 %146, %148
+  %150 = load i32, i32* %loc0
+  %151 = load i8, i8* %arg6
+  %152 = zext i8 %151 to i32
+  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i64 addrspace(1)*
+  %NullCheck19 = icmp eq i64 addrspace(1)* %153, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %154
+
+; <label>:154                                     ; preds = %136
+  %155 = load i64, i64 addrspace(1)* %153
+  %156 = add i64 %155, 72
+  %157 = inttoptr i64 %156 to i64*
+  %158 = load i64, i64* %157
+  %159 = add i64 %158, 0
+  %160 = inttoptr i64 %159 to i64*
+  %161 = load i64, i64* %160
+  %162 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to %System.Text.Encoder addrspace(1)*
+  %163 = inttoptr i64 %143 to i16*
+  %164 = inttoptr i64 %149 to i8*
+  %165 = trunc i32 %152 to i8
+  %166 = inttoptr i64 %161 to i32 (%System.Text.Encoder addrspace(1)*, i16*, i32, i8*, i32, i8)*
+  %167 = call i32 %166(%System.Text.Encoder addrspace(1)* %162, i16* %163, i32 %144, i8* %164, i32 %150, i8 %165)
+  store i32 %167, i32* %loc3
+  br label %168
+
+; <label>:168                                     ; preds = %154
+  %169 = load i32, i32* %loc3
+  ret i32 %169
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %110
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %119
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange18:                           ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
 Successfully read EncoderNLS.GetBytes
 
@@ -14908,22 +17267,22 @@ entry:
   %40 = load i8, i8* %arg5
   %41 = zext i8 %40 to i32
   %42 = trunc i32 %41 to i8
-  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %39, null
-  br i1 %NullCheck, label %43, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderNLS addrspace(1)* %39, null
+  br i1 %NullCheck, label %ThrowNullRef, label %43
 
 ; <label>:43                                      ; preds = %38
   %44 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
   store i8 %42, i8 addrspace(1)* %44
   %45 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %45, null
-  br i1 %NullCheck2, label %46, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.EncoderNLS addrspace(1)* %45, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %46
 
 ; <label>:46                                      ; preds = %43
   %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %45, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %47
   %48 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.EncoderNLS addrspace(1)* %48, null
-  br i1 %NullCheck4, label %49, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.EncoderNLS addrspace(1)* %48, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %49
 
 ; <label>:49                                      ; preds = %46
   %50 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %48, i32 0, i32 3
@@ -14934,8 +17293,8 @@ entry:
   %55 = load i32, i32* %arg4
   %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck6, label %58, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
   %59 = load i64, i64 addrspace(1)* %57
@@ -14953,15 +17312,15 @@ ThrowNullRef:                                     ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %43
+ThrowNullRef2:                                    ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %46
+ThrowNullRef4:                                    ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %49
+ThrowNullRef6:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14989,8 +17348,8 @@ entry:
   %4 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0 to %System.IO.ConsoleStream addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*)(%System.IO.ConsoleStream addrspace(1)* %4, %"System.Byte[]" addrspace(1)* %1, i32 %2, i32 %3)
   %5 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
@@ -15075,8 +17434,8 @@ entry:
 
 ; <label>:22                                      ; preds = %8
   %23 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %23, null
-  br i1 %NullCheck, label %24, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Byte[]" addrspace(1)* %23, null
+  br i1 %NullCheck, label %ThrowNullRef, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
@@ -15098,8 +17457,8 @@ entry:
 
 ; <label>:36                                      ; preds = %24
   %37 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %37, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.ConsoleStream addrspace(1)* %37, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %37, i32 0, i32 4
@@ -15120,13 +17479,138 @@ ThrowNullRef:                                     ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %36
+ThrowNullRef2:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
-Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
+Successfully read WindowsConsoleStream.WriteFileNative
+
+define i32 @WindowsConsoleStream.WriteFileNative(i64 %param0, %"System.Byte[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i64
+  %arg1 = alloca %"System.Byte[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i8 addrspace(1)*
+  %loc2 = alloca %"System.Byte[]" addrspace(1)*
+  %loc3 = alloca i32
+  store i64 %param0, i64* %arg0
+  store %"System.Byte[]" addrspace(1)* %param1, %"System.Byte[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Byte[]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = zext i32 %3 to i64
+  %5 = icmp ne i64 %4, 0
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %1
+  ret i32 0
+
+; <label>:7                                       ; preds = %1
+  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  store %"System.Byte[]" addrspace(1)* %8, %"System.Byte[]" addrspace(1)** %loc2
+  %9 = icmp eq %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %9, label %18, label %10
+
+; <label>:10                                      ; preds = %7
+  %11 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc2
+  %NullCheck1 = icmp eq %"System.Byte[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %11, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp ne i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %7, %12
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc1
+  br label %27
+
+; <label>:19                                      ; preds = %12
+  %20 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc2
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %20, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %BoundsCheck = icmp uge i64 0, %24
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %25
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %20, i32 0, i32 3, i32 0
+  store i8 addrspace(1)* %26, i8 addrspace(1)** %loc1
+  br label %27
+
+; <label>:27                                      ; preds = %18, %25
+  %28 = load i64, i64* %arg0
+  %29 = load i8 addrspace(1)*, i8 addrspace(1)** %loc1
+  %30 = ptrtoint i8 addrspace(1)* %29 to i64
+  %31 = load i32, i32* %arg2
+  %32 = sext i32 %31 to i64
+  %33 = add i64 %30, %32
+  %34 = load i32, i32* %arg3
+  %35 = addrspacecast i32* %loc3 to i32 addrspace(1)*
+  %36 = inttoptr i64 %33 to i8*
+  %37 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i8*, i32, i32 addrspace(1)*, i64)*)(i64 %28, i8* %36, i32 %34, i32 addrspace(1)* %35, i64 0)
+  %38 = icmp ugt i32 %37, 0
+  %39 = sext i1 %38 to i32
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc1
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %42, label %41
+
+; <label>:41                                      ; preds = %27
+  ret i32 0
+
+; <label>:42                                      ; preds = %27
+  %43 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  store i32 %43, i32* %loc0
+  %44 = load i32, i32* %loc0
+  %45 = icmp eq i32 %44, 232
+  br i1 %45, label %49, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = load i32, i32* %loc0
+  %48 = icmp ne i32 %47, 109
+  br i1 %48, label %50, label %49
+
+; <label>:49                                      ; preds = %42, %46
+  ret i32 0
+
+; <label>:50                                      ; preds = %46
+  %51 = load i32, i32* %loc0
+  ret i32 %51
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
 Successfully read WindowsConsoleStream.Flush
 
@@ -15135,8 +17619,8 @@ entry:
   %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
   store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
@@ -15171,8 +17655,8 @@ entry:
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
   %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load i64, i64 addrspace(1)* %1
@@ -15211,15 +17695,15 @@ entry:
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.TextWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
   %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %3, align 8
   %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
   %7 = load i64, i64 addrspace(1)* %5
@@ -15237,7 +17721,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -15266,8 +17750,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %4)
   store i32 0, i32* %loc0
   %5 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Char[]" addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
@@ -15279,15 +17763,15 @@ entry:
 
 ; <label>:11                                      ; preds = %69
   %12 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %12, i32 0, i32 9
   %15 = load i32, i32 addrspace(1)* %14, align 8
   %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.IO.StreamWriter addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %16, i32 0, i32 10
@@ -15302,15 +17786,15 @@ entry:
 
 ; <label>:23                                      ; preds = %17, %21
   %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %24, null
-  br i1 %NullCheck8, label %25, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %24, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 10
   %27 = load i32, i32 addrspace(1)* %26, align 8
   %28 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %28, null
-  br i1 %NullCheck10, label %29, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.StreamWriter addrspace(1)* %28, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %28, i32 0, i32 9
@@ -15332,15 +17816,15 @@ entry:
   %40 = load i32, i32* %loc0
   %41 = mul i32 %40, 2
   %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
-  br i1 %NullCheck12, label %43, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %43
 
 ; <label>:43                                      ; preds = %38
   %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 7
   %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %44, align 8
   %46 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %46, null
-  br i1 %NullCheck14, label %47, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.IO.StreamWriter addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %47
 
 ; <label>:47                                      ; preds = %43
   %48 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %46, i32 0, i32 9
@@ -15352,16 +17836,16 @@ entry:
   %54 = bitcast %"System.Char[]" addrspace(1)* %45 to %System.Array addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %53, i32 %41, %System.Array addrspace(1)* %54, i32 %50, i32 %52)
   %55 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
-  br i1 %NullCheck16, label %56, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %56
 
 ; <label>:56                                      ; preds = %47
   %57 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
   %58 = load i32, i32 addrspace(1)* %57, align 8
   %59 = load i32, i32* %loc2
   %60 = add i32 %58, %59
-  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
-  br i1 %NullCheck18, label %61, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %61
 
 ; <label>:61                                      ; preds = %56
   %62 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
@@ -15383,8 +17867,8 @@ entry:
 
 ; <label>:72                                      ; preds = %69
   %73 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %73, null
-  br i1 %NullCheck2, label %74, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %73, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %74
 
 ; <label>:74                                      ; preds = %72
   %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %73, i32 0, i32 11
@@ -15405,39 +17889,39 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %72
+ThrowNullRef2:                                    ; preds = %72
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %23
+ThrowNullRef8:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef10:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %43
+ThrowNullRef14:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %47
+ThrowNullRef16:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %56
+ThrowNullRef18:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPMath.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPMath.error.txt
@@ -25,8 +25,8 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
@@ -40,8 +40,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
   %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
@@ -75,7 +75,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -90,8 +90,8 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %NullCheck = icmp ne i8 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = load i8, i8 addrspace(1)* %0, align 8
@@ -125,8 +125,8 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
@@ -159,8 +159,8 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -184,8 +184,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
   store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
@@ -195,8 +195,8 @@ entry:
 ; <label>:4                                       ; preds = %1
   %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
   %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
@@ -206,8 +206,8 @@ entry:
   %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
@@ -221,14 +221,14 @@ entry:
 
 ; <label>:17                                      ; preds = %14
   %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
   %21 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
@@ -238,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -249,8 +249,8 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
@@ -261,27 +261,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %30
+ThrowNullRef10:                                   ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -301,7 +301,89 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
-Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
+Successfully read AppDomainSetup.GetUnsecureApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.GetUnsecureApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %NullCheck = icmp eq %"System.String[]" addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %BoundsCheck = icmp uge i64 0, %5
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %6
+
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 3, i32 0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
+  ret %System.String addrspace(1)* %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_Value using LLILCJit
+Successfully read AppDomainSetup.get_Value
+
+define %"System.String[]" addrspace(1)* @AppDomainSetup.get_Value(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.String[]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 18)
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.String[]" addrspace(1)* addrspace(1)*, %"System.String[]" addrspace(1)*)*)(%"System.String[]" addrspace(1)* addrspace(1)* %9, %"System.String[]" addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %11, i32 0, i32 1
+  %14 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %13, align 8
+  ret %"System.String[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -319,8 +401,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -368,16 +450,16 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
   %5 = load i32, i32 addrspace(1)* %4
   %6 = sub i32 %5, 1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -389,7 +471,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -421,8 +503,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
@@ -456,8 +538,8 @@ entry:
 ; <label>:27                                      ; preds = %19
   %28 = load i32, i32* %arg1
   %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
-  br i1 %NullCheck2, label %30, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %29, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %30
 
 ; <label>:30                                      ; preds = %27
   %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
@@ -493,8 +575,8 @@ entry:
 ; <label>:49                                      ; preds = %46
   %50 = load i32, i32* %arg2
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck4, label %52, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
@@ -517,11 +599,11 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %27
+ThrowNullRef2:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %49
+ThrowNullRef4:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -544,16 +626,16 @@ entry:
   %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %0)
   store %System.String addrspace(1)* %1, %System.String addrspace(1)** %loc0
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 2
   %5 = bitcast [0 x i16] addrspace(1)* %4 to i16 addrspace(1)*
   store i16 addrspace(1)* %5, i16 addrspace(1)** %loc1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %3
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2
@@ -580,7 +662,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -691,15 +773,15 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %NullCheck132 = icmp ne i8* %21, null
-  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+  %NullCheck131 = icmp eq i8* %21, null
+  br i1 %NullCheck131, label %ThrowNullRef132, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = load i8, i8* %21, align 8
   %24 = zext i8 %23 to i32
   %25 = trunc i32 %24 to i8
-  %NullCheck134 = icmp ne i8* %20, null
-  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+  %NullCheck133 = icmp eq i8* %20, null
+  br i1 %NullCheck133, label %ThrowNullRef134, label %26
 
 ; <label>:26                                      ; preds = %22
   store i8 %25, i8* %20, align 8
@@ -709,16 +791,16 @@ entry:
   %28 = load i8*, i8** %arg0
   %29 = load i8*, i8** %arg1
   %30 = bitcast i8* %29 to i16*
-  %NullCheck128 = icmp ne i16* %30, null
-  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+  %NullCheck127 = icmp eq i16* %30, null
+  br i1 %NullCheck127, label %ThrowNullRef128, label %31
 
 ; <label>:31                                      ; preds = %27
   %32 = load i16, i16* %30, align 8
   %33 = sext i16 %32 to i32
   %34 = bitcast i8* %28 to i16*
   %35 = trunc i32 %33 to i16
-  %NullCheck130 = icmp ne i16* %34, null
-  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+  %NullCheck129 = icmp eq i16* %34, null
+  br i1 %NullCheck129, label %ThrowNullRef130, label %36
 
 ; <label>:36                                      ; preds = %31
   store i16 %35, i16* %34, align 8
@@ -728,16 +810,16 @@ entry:
   %38 = load i8*, i8** %arg0
   %39 = load i8*, i8** %arg1
   %40 = bitcast i8* %39 to i16*
-  %NullCheck120 = icmp ne i16* %40, null
-  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+  %NullCheck119 = icmp eq i16* %40, null
+  br i1 %NullCheck119, label %ThrowNullRef120, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i16, i16* %40, align 8
   %43 = sext i16 %42 to i32
   %44 = bitcast i8* %38 to i16*
   %45 = trunc i32 %43 to i16
-  %NullCheck122 = icmp ne i16* %44, null
-  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+  %NullCheck121 = icmp eq i16* %44, null
+  br i1 %NullCheck121, label %ThrowNullRef122, label %46
 
 ; <label>:46                                      ; preds = %41
   store i16 %45, i16* %44, align 8
@@ -745,15 +827,15 @@ entry:
   %48 = getelementptr inbounds i8, i8* %47, i64 2
   %49 = load i8*, i8** %arg1
   %50 = getelementptr inbounds i8, i8* %49, i64 2
-  %NullCheck124 = icmp ne i8* %50, null
-  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+  %NullCheck123 = icmp eq i8* %50, null
+  br i1 %NullCheck123, label %ThrowNullRef124, label %51
 
 ; <label>:51                                      ; preds = %46
   %52 = load i8, i8* %50, align 8
   %53 = zext i8 %52 to i32
   %54 = trunc i32 %53 to i8
-  %NullCheck126 = icmp ne i8* %48, null
-  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+  %NullCheck125 = icmp eq i8* %48, null
+  br i1 %NullCheck125, label %ThrowNullRef126, label %55
 
 ; <label>:55                                      ; preds = %51
   store i8 %54, i8* %48, align 8
@@ -763,14 +845,14 @@ entry:
   %57 = load i8*, i8** %arg0
   %58 = load i8*, i8** %arg1
   %59 = bitcast i8* %58 to i32*
-  %NullCheck116 = icmp ne i32* %59, null
-  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+  %NullCheck115 = icmp eq i32* %59, null
+  br i1 %NullCheck115, label %ThrowNullRef116, label %60
 
 ; <label>:60                                      ; preds = %56
   %61 = load i32, i32* %59, align 8
   %62 = bitcast i8* %57 to i32*
-  %NullCheck118 = icmp ne i32* %62, null
-  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+  %NullCheck117 = icmp eq i32* %62, null
+  br i1 %NullCheck117, label %ThrowNullRef118, label %63
 
 ; <label>:63                                      ; preds = %60
   store i32 %61, i32* %62, align 8
@@ -780,14 +862,14 @@ entry:
   %65 = load i8*, i8** %arg0
   %66 = load i8*, i8** %arg1
   %67 = bitcast i8* %66 to i32*
-  %NullCheck108 = icmp ne i32* %67, null
-  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+  %NullCheck107 = icmp eq i32* %67, null
+  br i1 %NullCheck107, label %ThrowNullRef108, label %68
 
 ; <label>:68                                      ; preds = %64
   %69 = load i32, i32* %67, align 8
   %70 = bitcast i8* %65 to i32*
-  %NullCheck110 = icmp ne i32* %70, null
-  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+  %NullCheck109 = icmp eq i32* %70, null
+  br i1 %NullCheck109, label %ThrowNullRef110, label %71
 
 ; <label>:71                                      ; preds = %68
   store i32 %69, i32* %70, align 8
@@ -795,15 +877,15 @@ entry:
   %73 = getelementptr inbounds i8, i8* %72, i64 4
   %74 = load i8*, i8** %arg1
   %75 = getelementptr inbounds i8, i8* %74, i64 4
-  %NullCheck112 = icmp ne i8* %75, null
-  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+  %NullCheck111 = icmp eq i8* %75, null
+  br i1 %NullCheck111, label %ThrowNullRef112, label %76
 
 ; <label>:76                                      ; preds = %71
   %77 = load i8, i8* %75, align 8
   %78 = zext i8 %77 to i32
   %79 = trunc i32 %78 to i8
-  %NullCheck114 = icmp ne i8* %73, null
-  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+  %NullCheck113 = icmp eq i8* %73, null
+  br i1 %NullCheck113, label %ThrowNullRef114, label %80
 
 ; <label>:80                                      ; preds = %76
   store i8 %79, i8* %73, align 8
@@ -813,14 +895,14 @@ entry:
   %82 = load i8*, i8** %arg0
   %83 = load i8*, i8** %arg1
   %84 = bitcast i8* %83 to i32*
-  %NullCheck100 = icmp ne i32* %84, null
-  br i1 %NullCheck100, label %85, label %ThrowNullRef99
+  %NullCheck99 = icmp eq i32* %84, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %85
 
 ; <label>:85                                      ; preds = %81
   %86 = load i32, i32* %84, align 8
   %87 = bitcast i8* %82 to i32*
-  %NullCheck102 = icmp ne i32* %87, null
-  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+  %NullCheck101 = icmp eq i32* %87, null
+  br i1 %NullCheck101, label %ThrowNullRef102, label %88
 
 ; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
@@ -829,16 +911,16 @@ entry:
   %91 = load i8*, i8** %arg1
   %92 = getelementptr inbounds i8, i8* %91, i64 4
   %93 = bitcast i8* %92 to i16*
-  %NullCheck104 = icmp ne i16* %93, null
-  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+  %NullCheck103 = icmp eq i16* %93, null
+  br i1 %NullCheck103, label %ThrowNullRef104, label %94
 
 ; <label>:94                                      ; preds = %88
   %95 = load i16, i16* %93, align 8
   %96 = sext i16 %95 to i32
   %97 = bitcast i8* %90 to i16*
   %98 = trunc i32 %96 to i16
-  %NullCheck106 = icmp ne i16* %97, null
-  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+  %NullCheck105 = icmp eq i16* %97, null
+  br i1 %NullCheck105, label %ThrowNullRef106, label %99
 
 ; <label>:99                                      ; preds = %94
   store i16 %98, i16* %97, align 8
@@ -848,14 +930,14 @@ entry:
   %101 = load i8*, i8** %arg0
   %102 = load i8*, i8** %arg1
   %103 = bitcast i8* %102 to i32*
-  %NullCheck88 = icmp ne i32* %103, null
-  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+  %NullCheck87 = icmp eq i32* %103, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %104
 
 ; <label>:104                                     ; preds = %100
   %105 = load i32, i32* %103, align 8
   %106 = bitcast i8* %101 to i32*
-  %NullCheck90 = icmp ne i32* %106, null
-  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+  %NullCheck89 = icmp eq i32* %106, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %107
 
 ; <label>:107                                     ; preds = %104
   store i32 %105, i32* %106, align 8
@@ -864,16 +946,16 @@ entry:
   %110 = load i8*, i8** %arg1
   %111 = getelementptr inbounds i8, i8* %110, i64 4
   %112 = bitcast i8* %111 to i16*
-  %NullCheck92 = icmp ne i16* %112, null
-  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+  %NullCheck91 = icmp eq i16* %112, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %113
 
 ; <label>:113                                     ; preds = %107
   %114 = load i16, i16* %112, align 8
   %115 = sext i16 %114 to i32
   %116 = bitcast i8* %109 to i16*
   %117 = trunc i32 %115 to i16
-  %NullCheck94 = icmp ne i16* %116, null
-  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+  %NullCheck93 = icmp eq i16* %116, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %118
 
 ; <label>:118                                     ; preds = %113
   store i16 %117, i16* %116, align 8
@@ -881,15 +963,15 @@ entry:
   %120 = getelementptr inbounds i8, i8* %119, i64 6
   %121 = load i8*, i8** %arg1
   %122 = getelementptr inbounds i8, i8* %121, i64 6
-  %NullCheck96 = icmp ne i8* %122, null
-  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+  %NullCheck95 = icmp eq i8* %122, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %123
 
 ; <label>:123                                     ; preds = %118
   %124 = load i8, i8* %122, align 8
   %125 = zext i8 %124 to i32
   %126 = trunc i32 %125 to i8
-  %NullCheck98 = icmp ne i8* %120, null
-  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+  %NullCheck97 = icmp eq i8* %120, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %127
 
 ; <label>:127                                     ; preds = %123
   store i8 %126, i8* %120, align 8
@@ -899,14 +981,14 @@ entry:
   %129 = load i8*, i8** %arg0
   %130 = load i8*, i8** %arg1
   %131 = bitcast i8* %130 to i64*
-  %NullCheck84 = icmp ne i64* %131, null
-  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+  %NullCheck83 = icmp eq i64* %131, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %132
 
 ; <label>:132                                     ; preds = %128
   %133 = load i64, i64* %131, align 8
   %134 = bitcast i8* %129 to i64*
-  %NullCheck86 = icmp ne i64* %134, null
-  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+  %NullCheck85 = icmp eq i64* %134, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %135
 
 ; <label>:135                                     ; preds = %132
   store i64 %133, i64* %134, align 8
@@ -916,14 +998,14 @@ entry:
   %137 = load i8*, i8** %arg0
   %138 = load i8*, i8** %arg1
   %139 = bitcast i8* %138 to i64*
-  %NullCheck76 = icmp ne i64* %139, null
-  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+  %NullCheck75 = icmp eq i64* %139, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %140
 
 ; <label>:140                                     ; preds = %136
   %141 = load i64, i64* %139, align 8
   %142 = bitcast i8* %137 to i64*
-  %NullCheck78 = icmp ne i64* %142, null
-  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+  %NullCheck77 = icmp eq i64* %142, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %143
 
 ; <label>:143                                     ; preds = %140
   store i64 %141, i64* %142, align 8
@@ -931,15 +1013,15 @@ entry:
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %NullCheck80 = icmp ne i8* %147, null
-  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+  %NullCheck79 = icmp eq i8* %147, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %148
 
 ; <label>:148                                     ; preds = %143
   %149 = load i8, i8* %147, align 8
   %150 = zext i8 %149 to i32
   %151 = trunc i32 %150 to i8
-  %NullCheck82 = icmp ne i8* %145, null
-  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+  %NullCheck81 = icmp eq i8* %145, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %152
 
 ; <label>:152                                     ; preds = %148
   store i8 %151, i8* %145, align 8
@@ -949,14 +1031,14 @@ entry:
   %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
   %156 = bitcast i8* %155 to i64*
-  %NullCheck68 = icmp ne i64* %156, null
-  br i1 %NullCheck68, label %157, label %ThrowNullRef67
+  %NullCheck67 = icmp eq i64* %156, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %157
 
 ; <label>:157                                     ; preds = %153
   %158 = load i64, i64* %156, align 8
   %159 = bitcast i8* %154 to i64*
-  %NullCheck70 = icmp ne i64* %159, null
-  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+  %NullCheck69 = icmp eq i64* %159, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %160
 
 ; <label>:160                                     ; preds = %157
   store i64 %158, i64* %159, align 8
@@ -965,16 +1047,16 @@ entry:
   %163 = load i8*, i8** %arg1
   %164 = getelementptr inbounds i8, i8* %163, i64 8
   %165 = bitcast i8* %164 to i16*
-  %NullCheck72 = icmp ne i16* %165, null
-  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+  %NullCheck71 = icmp eq i16* %165, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %166
 
 ; <label>:166                                     ; preds = %160
   %167 = load i16, i16* %165, align 8
   %168 = sext i16 %167 to i32
   %169 = bitcast i8* %162 to i16*
   %170 = trunc i32 %168 to i16
-  %NullCheck74 = icmp ne i16* %169, null
-  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+  %NullCheck73 = icmp eq i16* %169, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %171
 
 ; <label>:171                                     ; preds = %166
   store i16 %170, i16* %169, align 8
@@ -984,14 +1066,14 @@ entry:
   %173 = load i8*, i8** %arg0
   %174 = load i8*, i8** %arg1
   %175 = bitcast i8* %174 to i64*
-  %NullCheck56 = icmp ne i64* %175, null
-  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+  %NullCheck55 = icmp eq i64* %175, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %176
 
 ; <label>:176                                     ; preds = %172
   %177 = load i64, i64* %175, align 8
   %178 = bitcast i8* %173 to i64*
-  %NullCheck58 = icmp ne i64* %178, null
-  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+  %NullCheck57 = icmp eq i64* %178, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %179
 
 ; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
@@ -1000,16 +1082,16 @@ entry:
   %182 = load i8*, i8** %arg1
   %183 = getelementptr inbounds i8, i8* %182, i64 8
   %184 = bitcast i8* %183 to i16*
-  %NullCheck60 = icmp ne i16* %184, null
-  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+  %NullCheck59 = icmp eq i16* %184, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %185
 
 ; <label>:185                                     ; preds = %179
   %186 = load i16, i16* %184, align 8
   %187 = sext i16 %186 to i32
   %188 = bitcast i8* %181 to i16*
   %189 = trunc i32 %187 to i16
-  %NullCheck62 = icmp ne i16* %188, null
-  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+  %NullCheck61 = icmp eq i16* %188, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %190
 
 ; <label>:190                                     ; preds = %185
   store i16 %189, i16* %188, align 8
@@ -1017,15 +1099,15 @@ entry:
   %192 = getelementptr inbounds i8, i8* %191, i64 10
   %193 = load i8*, i8** %arg1
   %194 = getelementptr inbounds i8, i8* %193, i64 10
-  %NullCheck64 = icmp ne i8* %194, null
-  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+  %NullCheck63 = icmp eq i8* %194, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %195
 
 ; <label>:195                                     ; preds = %190
   %196 = load i8, i8* %194, align 8
   %197 = zext i8 %196 to i32
   %198 = trunc i32 %197 to i8
-  %NullCheck66 = icmp ne i8* %192, null
-  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+  %NullCheck65 = icmp eq i8* %192, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %199
 
 ; <label>:199                                     ; preds = %195
   store i8 %198, i8* %192, align 8
@@ -1035,14 +1117,14 @@ entry:
   %201 = load i8*, i8** %arg0
   %202 = load i8*, i8** %arg1
   %203 = bitcast i8* %202 to i64*
-  %NullCheck48 = icmp ne i64* %203, null
-  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+  %NullCheck47 = icmp eq i64* %203, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %204
 
 ; <label>:204                                     ; preds = %200
   %205 = load i64, i64* %203, align 8
   %206 = bitcast i8* %201 to i64*
-  %NullCheck50 = icmp ne i64* %206, null
-  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+  %NullCheck49 = icmp eq i64* %206, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %207
 
 ; <label>:207                                     ; preds = %204
   store i64 %205, i64* %206, align 8
@@ -1051,14 +1133,14 @@ entry:
   %210 = load i8*, i8** %arg1
   %211 = getelementptr inbounds i8, i8* %210, i64 8
   %212 = bitcast i8* %211 to i32*
-  %NullCheck52 = icmp ne i32* %212, null
-  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+  %NullCheck51 = icmp eq i32* %212, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %213
 
 ; <label>:213                                     ; preds = %207
   %214 = load i32, i32* %212, align 8
   %215 = bitcast i8* %209 to i32*
-  %NullCheck54 = icmp ne i32* %215, null
-  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+  %NullCheck53 = icmp eq i32* %215, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %216
 
 ; <label>:216                                     ; preds = %213
   store i32 %214, i32* %215, align 8
@@ -1068,14 +1150,14 @@ entry:
   %218 = load i8*, i8** %arg0
   %219 = load i8*, i8** %arg1
   %220 = bitcast i8* %219 to i64*
-  %NullCheck36 = icmp ne i64* %220, null
-  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64* %220, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %221
 
 ; <label>:221                                     ; preds = %217
   %222 = load i64, i64* %220, align 8
   %223 = bitcast i8* %218 to i64*
-  %NullCheck38 = icmp ne i64* %223, null
-  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+  %NullCheck37 = icmp eq i64* %223, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %224
 
 ; <label>:224                                     ; preds = %221
   store i64 %222, i64* %223, align 8
@@ -1084,14 +1166,14 @@ entry:
   %227 = load i8*, i8** %arg1
   %228 = getelementptr inbounds i8, i8* %227, i64 8
   %229 = bitcast i8* %228 to i32*
-  %NullCheck40 = icmp ne i32* %229, null
-  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i32* %229, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %230
 
 ; <label>:230                                     ; preds = %224
   %231 = load i32, i32* %229, align 8
   %232 = bitcast i8* %226 to i32*
-  %NullCheck42 = icmp ne i32* %232, null
-  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+  %NullCheck41 = icmp eq i32* %232, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %233
 
 ; <label>:233                                     ; preds = %230
   store i32 %231, i32* %232, align 8
@@ -1099,15 +1181,15 @@ entry:
   %235 = getelementptr inbounds i8, i8* %234, i64 12
   %236 = load i8*, i8** %arg1
   %237 = getelementptr inbounds i8, i8* %236, i64 12
-  %NullCheck44 = icmp ne i8* %237, null
-  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i8* %237, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %238
 
 ; <label>:238                                     ; preds = %233
   %239 = load i8, i8* %237, align 8
   %240 = zext i8 %239 to i32
   %241 = trunc i32 %240 to i8
-  %NullCheck46 = icmp ne i8* %235, null
-  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+  %NullCheck45 = icmp eq i8* %235, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %242
 
 ; <label>:242                                     ; preds = %238
   store i8 %241, i8* %235, align 8
@@ -1117,14 +1199,14 @@ entry:
   %244 = load i8*, i8** %arg0
   %245 = load i8*, i8** %arg1
   %246 = bitcast i8* %245 to i64*
-  %NullCheck24 = icmp ne i64* %246, null
-  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64* %246, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %247
 
 ; <label>:247                                     ; preds = %243
   %248 = load i64, i64* %246, align 8
   %249 = bitcast i8* %244 to i64*
-  %NullCheck26 = icmp ne i64* %249, null
-  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64* %249, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %250
 
 ; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
@@ -1133,14 +1215,14 @@ entry:
   %253 = load i8*, i8** %arg1
   %254 = getelementptr inbounds i8, i8* %253, i64 8
   %255 = bitcast i8* %254 to i32*
-  %NullCheck28 = icmp ne i32* %255, null
-  br i1 %NullCheck28, label %256, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i32* %255, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %256
 
 ; <label>:256                                     ; preds = %250
   %257 = load i32, i32* %255, align 8
   %258 = bitcast i8* %252 to i32*
-  %NullCheck30 = icmp ne i32* %258, null
-  br i1 %NullCheck30, label %259, label %ThrowNullRef29
+  %NullCheck29 = icmp eq i32* %258, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %259
 
 ; <label>:259                                     ; preds = %256
   store i32 %257, i32* %258, align 8
@@ -1149,16 +1231,16 @@ entry:
   %262 = load i8*, i8** %arg1
   %263 = getelementptr inbounds i8, i8* %262, i64 12
   %264 = bitcast i8* %263 to i16*
-  %NullCheck32 = icmp ne i16* %264, null
-  br i1 %NullCheck32, label %265, label %ThrowNullRef31
+  %NullCheck31 = icmp eq i16* %264, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %265
 
 ; <label>:265                                     ; preds = %259
   %266 = load i16, i16* %264, align 8
   %267 = sext i16 %266 to i32
   %268 = bitcast i8* %261 to i16*
   %269 = trunc i32 %267 to i16
-  %NullCheck34 = icmp ne i16* %268, null
-  br i1 %NullCheck34, label %270, label %ThrowNullRef33
+  %NullCheck33 = icmp eq i16* %268, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %270
 
 ; <label>:270                                     ; preds = %265
   store i16 %269, i16* %268, align 8
@@ -1168,14 +1250,14 @@ entry:
   %272 = load i8*, i8** %arg0
   %273 = load i8*, i8** %arg1
   %274 = bitcast i8* %273 to i64*
-  %NullCheck8 = icmp ne i64* %274, null
-  br i1 %NullCheck8, label %275, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64* %274, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %275
 
 ; <label>:275                                     ; preds = %271
   %276 = load i64, i64* %274, align 8
   %277 = bitcast i8* %272 to i64*
-  %NullCheck10 = icmp ne i64* %277, null
-  br i1 %NullCheck10, label %278, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %277, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %278
 
 ; <label>:278                                     ; preds = %275
   store i64 %276, i64* %277, align 8
@@ -1184,14 +1266,14 @@ entry:
   %281 = load i8*, i8** %arg1
   %282 = getelementptr inbounds i8, i8* %281, i64 8
   %283 = bitcast i8* %282 to i32*
-  %NullCheck12 = icmp ne i32* %283, null
-  br i1 %NullCheck12, label %284, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i32* %283, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %284
 
 ; <label>:284                                     ; preds = %278
   %285 = load i32, i32* %283, align 8
   %286 = bitcast i8* %280 to i32*
-  %NullCheck14 = icmp ne i32* %286, null
-  br i1 %NullCheck14, label %287, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i32* %286, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %287
 
 ; <label>:287                                     ; preds = %284
   store i32 %285, i32* %286, align 8
@@ -1200,16 +1282,16 @@ entry:
   %290 = load i8*, i8** %arg1
   %291 = getelementptr inbounds i8, i8* %290, i64 12
   %292 = bitcast i8* %291 to i16*
-  %NullCheck16 = icmp ne i16* %292, null
-  br i1 %NullCheck16, label %293, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i16* %292, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %293
 
 ; <label>:293                                     ; preds = %287
   %294 = load i16, i16* %292, align 8
   %295 = sext i16 %294 to i32
   %296 = bitcast i8* %289 to i16*
   %297 = trunc i32 %295 to i16
-  %NullCheck18 = icmp ne i16* %296, null
-  br i1 %NullCheck18, label %298, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i16* %296, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %298
 
 ; <label>:298                                     ; preds = %293
   store i16 %297, i16* %296, align 8
@@ -1217,15 +1299,15 @@ entry:
   %300 = getelementptr inbounds i8, i8* %299, i64 14
   %301 = load i8*, i8** %arg1
   %302 = getelementptr inbounds i8, i8* %301, i64 14
-  %NullCheck20 = icmp ne i8* %302, null
-  br i1 %NullCheck20, label %303, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i8* %302, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %303
 
 ; <label>:303                                     ; preds = %298
   %304 = load i8, i8* %302, align 8
   %305 = zext i8 %304 to i32
   %306 = trunc i32 %305 to i8
-  %NullCheck22 = icmp ne i8* %300, null
-  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i8* %300, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %307
 
 ; <label>:307                                     ; preds = %303
   store i8 %306, i8* %300, align 8
@@ -1235,14 +1317,14 @@ entry:
   %309 = load i8*, i8** %arg0
   %310 = load i8*, i8** %arg1
   %311 = bitcast i8* %310 to i64*
-  %NullCheck = icmp ne i64* %311, null
-  br i1 %NullCheck, label %312, label %ThrowNullRef
+  %NullCheck = icmp eq i64* %311, null
+  br i1 %NullCheck, label %ThrowNullRef, label %312
 
 ; <label>:312                                     ; preds = %308
   %313 = load i64, i64* %311, align 8
   %314 = bitcast i8* %309 to i64*
-  %NullCheck2 = icmp ne i64* %314, null
-  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64* %314, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %315
 
 ; <label>:315                                     ; preds = %312
   store i64 %313, i64* %314, align 8
@@ -1251,14 +1333,14 @@ entry:
   %318 = load i8*, i8** %arg1
   %319 = getelementptr inbounds i8, i8* %318, i64 8
   %320 = bitcast i8* %319 to i64*
-  %NullCheck4 = icmp ne i64* %320, null
-  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64* %320, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %321
 
 ; <label>:321                                     ; preds = %315
   %322 = load i64, i64* %320, align 8
   %323 = bitcast i8* %317 to i64*
-  %NullCheck6 = icmp ne i64* %323, null
-  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64* %323, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %324
 
 ; <label>:324                                     ; preds = %321
   store i64 %322, i64* %323, align 8
@@ -1286,15 +1368,15 @@ entry:
 ; <label>:338                                     ; preds = %333
   %339 = load i8*, i8** %arg0
   %340 = load i8*, i8** %arg1
-  %NullCheck136 = icmp ne i8* %340, null
-  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+  %NullCheck135 = icmp eq i8* %340, null
+  br i1 %NullCheck135, label %ThrowNullRef136, label %341
 
 ; <label>:341                                     ; preds = %338
   %342 = load i8, i8* %340, align 8
   %343 = zext i8 %342 to i32
   %344 = trunc i32 %343 to i8
-  %NullCheck138 = icmp ne i8* %339, null
-  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+  %NullCheck137 = icmp eq i8* %339, null
+  br i1 %NullCheck137, label %ThrowNullRef138, label %345
 
 ; <label>:345                                     ; preds = %341
   store i8 %344, i8* %339, align 8
@@ -1317,16 +1399,16 @@ entry:
   %357 = load i8*, i8** %arg0
   %358 = load i8*, i8** %arg1
   %359 = bitcast i8* %358 to i16*
-  %NullCheck140 = icmp ne i16* %359, null
-  br i1 %NullCheck140, label %360, label %ThrowNullRef139
+  %NullCheck139 = icmp eq i16* %359, null
+  br i1 %NullCheck139, label %ThrowNullRef140, label %360
 
 ; <label>:360                                     ; preds = %356
   %361 = load i16, i16* %359, align 8
   %362 = sext i16 %361 to i32
   %363 = bitcast i8* %357 to i16*
   %364 = trunc i32 %362 to i16
-  %NullCheck142 = icmp ne i16* %363, null
-  br i1 %NullCheck142, label %365, label %ThrowNullRef141
+  %NullCheck141 = icmp eq i16* %363, null
+  br i1 %NullCheck141, label %ThrowNullRef142, label %365
 
 ; <label>:365                                     ; preds = %360
   store i16 %364, i16* %363, align 8
@@ -1352,14 +1434,14 @@ entry:
   %378 = load i8*, i8** %arg0
   %379 = load i8*, i8** %arg1
   %380 = bitcast i8* %379 to i32*
-  %NullCheck144 = icmp ne i32* %380, null
-  br i1 %NullCheck144, label %381, label %ThrowNullRef143
+  %NullCheck143 = icmp eq i32* %380, null
+  br i1 %NullCheck143, label %ThrowNullRef144, label %381
 
 ; <label>:381                                     ; preds = %377
   %382 = load i32, i32* %380, align 8
   %383 = bitcast i8* %378 to i32*
-  %NullCheck146 = icmp ne i32* %383, null
-  br i1 %NullCheck146, label %384, label %ThrowNullRef145
+  %NullCheck145 = icmp eq i32* %383, null
+  br i1 %NullCheck145, label %ThrowNullRef146, label %384
 
 ; <label>:384                                     ; preds = %381
   store i32 %382, i32* %383, align 8
@@ -1384,14 +1466,14 @@ entry:
   %395 = load i8*, i8** %arg0
   %396 = load i8*, i8** %arg1
   %397 = bitcast i8* %396 to i64*
-  %NullCheck164 = icmp ne i64* %397, null
-  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+  %NullCheck163 = icmp eq i64* %397, null
+  br i1 %NullCheck163, label %ThrowNullRef164, label %398
 
 ; <label>:398                                     ; preds = %394
   %399 = load i64, i64* %397, align 8
   %400 = bitcast i8* %395 to i64*
-  %NullCheck166 = icmp ne i64* %400, null
-  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+  %NullCheck165 = icmp eq i64* %400, null
+  br i1 %NullCheck165, label %ThrowNullRef166, label %401
 
 ; <label>:401                                     ; preds = %398
   store i64 %399, i64* %400, align 8
@@ -1400,14 +1482,14 @@ entry:
   %404 = load i8*, i8** %arg1
   %405 = getelementptr inbounds i8, i8* %404, i64 8
   %406 = bitcast i8* %405 to i64*
-  %NullCheck168 = icmp ne i64* %406, null
-  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+  %NullCheck167 = icmp eq i64* %406, null
+  br i1 %NullCheck167, label %ThrowNullRef168, label %407
 
 ; <label>:407                                     ; preds = %401
   %408 = load i64, i64* %406, align 8
   %409 = bitcast i8* %403 to i64*
-  %NullCheck170 = icmp ne i64* %409, null
-  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+  %NullCheck169 = icmp eq i64* %409, null
+  br i1 %NullCheck169, label %ThrowNullRef170, label %410
 
 ; <label>:410                                     ; preds = %407
   store i64 %408, i64* %409, align 8
@@ -1437,14 +1519,14 @@ entry:
   %425 = load i8*, i8** %arg0
   %426 = load i8*, i8** %arg1
   %427 = bitcast i8* %426 to i64*
-  %NullCheck148 = icmp ne i64* %427, null
-  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+  %NullCheck147 = icmp eq i64* %427, null
+  br i1 %NullCheck147, label %ThrowNullRef148, label %428
 
 ; <label>:428                                     ; preds = %424
   %429 = load i64, i64* %427, align 8
   %430 = bitcast i8* %425 to i64*
-  %NullCheck150 = icmp ne i64* %430, null
-  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+  %NullCheck149 = icmp eq i64* %430, null
+  br i1 %NullCheck149, label %ThrowNullRef150, label %431
 
 ; <label>:431                                     ; preds = %428
   store i64 %429, i64* %430, align 8
@@ -1466,14 +1548,14 @@ entry:
   %441 = load i8*, i8** %arg0
   %442 = load i8*, i8** %arg1
   %443 = bitcast i8* %442 to i32*
-  %NullCheck152 = icmp ne i32* %443, null
-  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+  %NullCheck151 = icmp eq i32* %443, null
+  br i1 %NullCheck151, label %ThrowNullRef152, label %444
 
 ; <label>:444                                     ; preds = %440
   %445 = load i32, i32* %443, align 8
   %446 = bitcast i8* %441 to i32*
-  %NullCheck154 = icmp ne i32* %446, null
-  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+  %NullCheck153 = icmp eq i32* %446, null
+  br i1 %NullCheck153, label %ThrowNullRef154, label %447
 
 ; <label>:447                                     ; preds = %444
   store i32 %445, i32* %446, align 8
@@ -1495,16 +1577,16 @@ entry:
   %457 = load i8*, i8** %arg0
   %458 = load i8*, i8** %arg1
   %459 = bitcast i8* %458 to i16*
-  %NullCheck156 = icmp ne i16* %459, null
-  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+  %NullCheck155 = icmp eq i16* %459, null
+  br i1 %NullCheck155, label %ThrowNullRef156, label %460
 
 ; <label>:460                                     ; preds = %456
   %461 = load i16, i16* %459, align 8
   %462 = sext i16 %461 to i32
   %463 = bitcast i8* %457 to i16*
   %464 = trunc i32 %462 to i16
-  %NullCheck158 = icmp ne i16* %463, null
-  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+  %NullCheck157 = icmp eq i16* %463, null
+  br i1 %NullCheck157, label %ThrowNullRef158, label %465
 
 ; <label>:465                                     ; preds = %460
   store i16 %464, i16* %463, align 8
@@ -1525,15 +1607,15 @@ entry:
 ; <label>:474                                     ; preds = %470
   %475 = load i8*, i8** %arg0
   %476 = load i8*, i8** %arg1
-  %NullCheck160 = icmp ne i8* %476, null
-  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+  %NullCheck159 = icmp eq i8* %476, null
+  br i1 %NullCheck159, label %ThrowNullRef160, label %477
 
 ; <label>:477                                     ; preds = %474
   %478 = load i8, i8* %476, align 8
   %479 = zext i8 %478 to i32
   %480 = trunc i32 %479 to i8
-  %NullCheck162 = icmp ne i8* %475, null
-  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+  %NullCheck161 = icmp eq i8* %475, null
+  br i1 %NullCheck161, label %ThrowNullRef162, label %481
 
 ; <label>:481                                     ; preds = %477
   store i8 %480, i8* %475, align 8
@@ -1553,343 +1635,343 @@ ThrowNullRef:                                     ; preds = %308
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %312
+ThrowNullRef2:                                    ; preds = %312
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %315
+ThrowNullRef4:                                    ; preds = %315
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %321
+ThrowNullRef6:                                    ; preds = %321
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %271
+ThrowNullRef8:                                    ; preds = %271
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %275
+ThrowNullRef10:                                   ; preds = %275
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %278
+ThrowNullRef12:                                   ; preds = %278
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %284
+ThrowNullRef14:                                   ; preds = %284
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %287
+ThrowNullRef16:                                   ; preds = %287
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %293
+ThrowNullRef18:                                   ; preds = %293
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %298
+ThrowNullRef20:                                   ; preds = %298
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %303
+ThrowNullRef22:                                   ; preds = %303
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %243
+ThrowNullRef24:                                   ; preds = %243
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %247
+ThrowNullRef26:                                   ; preds = %247
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %250
+ThrowNullRef28:                                   ; preds = %250
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %256
+ThrowNullRef30:                                   ; preds = %256
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %259
+ThrowNullRef32:                                   ; preds = %259
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %265
+ThrowNullRef34:                                   ; preds = %265
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %217
+ThrowNullRef36:                                   ; preds = %217
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %221
+ThrowNullRef38:                                   ; preds = %221
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %224
+ThrowNullRef40:                                   ; preds = %224
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %230
+ThrowNullRef42:                                   ; preds = %230
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %233
+ThrowNullRef44:                                   ; preds = %233
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %238
+ThrowNullRef46:                                   ; preds = %238
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %200
+ThrowNullRef48:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %204
+ThrowNullRef50:                                   ; preds = %204
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %207
+ThrowNullRef52:                                   ; preds = %207
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %213
+ThrowNullRef54:                                   ; preds = %213
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %172
+ThrowNullRef56:                                   ; preds = %172
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %176
+ThrowNullRef58:                                   ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %179
+ThrowNullRef60:                                   ; preds = %179
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %185
+ThrowNullRef62:                                   ; preds = %185
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %190
+ThrowNullRef64:                                   ; preds = %190
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %195
+ThrowNullRef66:                                   ; preds = %195
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %153
+ThrowNullRef68:                                   ; preds = %153
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %157
+ThrowNullRef70:                                   ; preds = %157
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %160
+ThrowNullRef72:                                   ; preds = %160
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %166
+ThrowNullRef74:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %136
+ThrowNullRef76:                                   ; preds = %136
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %140
+ThrowNullRef78:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %143
+ThrowNullRef80:                                   ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %148
+ThrowNullRef82:                                   ; preds = %148
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %128
+ThrowNullRef84:                                   ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %132
+ThrowNullRef86:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %100
+ThrowNullRef88:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %104
+ThrowNullRef90:                                   ; preds = %104
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %107
+ThrowNullRef92:                                   ; preds = %107
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %113
+ThrowNullRef94:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %118
+ThrowNullRef96:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %123
+ThrowNullRef98:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %81
+ThrowNullRef100:                                  ; preds = %81
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef101:                                  ; preds = %85
+ThrowNullRef102:                                  ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef103:                                  ; preds = %88
+ThrowNullRef104:                                  ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef105:                                  ; preds = %94
+ThrowNullRef106:                                  ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef107:                                  ; preds = %64
+ThrowNullRef108:                                  ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef109:                                  ; preds = %68
+ThrowNullRef110:                                  ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef111:                                  ; preds = %71
+ThrowNullRef112:                                  ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef113:                                  ; preds = %76
+ThrowNullRef114:                                  ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef115:                                  ; preds = %56
+ThrowNullRef116:                                  ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef117:                                  ; preds = %60
+ThrowNullRef118:                                  ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef119:                                  ; preds = %37
+ThrowNullRef120:                                  ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef121:                                  ; preds = %41
+ThrowNullRef122:                                  ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef123:                                  ; preds = %46
+ThrowNullRef124:                                  ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef125:                                  ; preds = %51
+ThrowNullRef126:                                  ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef127:                                  ; preds = %27
+ThrowNullRef128:                                  ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef129:                                  ; preds = %31
+ThrowNullRef130:                                  ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef131:                                  ; preds = %19
+ThrowNullRef132:                                  ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef133:                                  ; preds = %22
+ThrowNullRef134:                                  ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef135:                                  ; preds = %338
+ThrowNullRef136:                                  ; preds = %338
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef137:                                  ; preds = %341
+ThrowNullRef138:                                  ; preds = %341
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef139:                                  ; preds = %356
+ThrowNullRef140:                                  ; preds = %356
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef141:                                  ; preds = %360
+ThrowNullRef142:                                  ; preds = %360
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef143:                                  ; preds = %377
+ThrowNullRef144:                                  ; preds = %377
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef145:                                  ; preds = %381
+ThrowNullRef146:                                  ; preds = %381
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef147:                                  ; preds = %424
+ThrowNullRef148:                                  ; preds = %424
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef149:                                  ; preds = %428
+ThrowNullRef150:                                  ; preds = %428
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef151:                                  ; preds = %440
+ThrowNullRef152:                                  ; preds = %440
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef153:                                  ; preds = %444
+ThrowNullRef154:                                  ; preds = %444
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef155:                                  ; preds = %456
+ThrowNullRef156:                                  ; preds = %456
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef157:                                  ; preds = %460
+ThrowNullRef158:                                  ; preds = %460
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef159:                                  ; preds = %474
+ThrowNullRef160:                                  ; preds = %474
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef161:                                  ; preds = %477
+ThrowNullRef162:                                  ; preds = %477
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef163:                                  ; preds = %394
+ThrowNullRef164:                                  ; preds = %394
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef165:                                  ; preds = %398
+ThrowNullRef166:                                  ; preds = %398
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef167:                                  ; preds = %401
+ThrowNullRef168:                                  ; preds = %401
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef169:                                  ; preds = %407
+ThrowNullRef170:                                  ; preds = %407
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1939,8 +2021,8 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
-  br i1 %NullCheck, label %22, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %ThrowNullRef, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
@@ -1948,8 +2030,8 @@ entry:
   store i32 %24, i32* %loc0
   %25 = load i32, i32* %loc0
   %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %26, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %27
 
 ; <label>:27                                      ; preds = %22
   %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
@@ -1971,7 +2053,7 @@ ThrowNullRef:                                     ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1989,8 +2071,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -2022,15 +2104,15 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2048,16 +2130,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
   %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
   store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %15
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
@@ -2072,8 +2154,8 @@ entry:
   %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
   %29 = ptrtoint i16 addrspace(1)* %28 to i64
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %19
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
@@ -2089,19 +2171,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2114,8 +2196,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
@@ -2128,7 +2210,7 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[loadElem]
+Failed to read AppDomain.PrepareDataForSetup[storeElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
@@ -2202,8 +2284,8 @@ entry:
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
-  br i1 %NullCheck24, label %27, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = load i64, i64 addrspace(1)* %26
@@ -2218,8 +2300,8 @@ entry:
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
-  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
   %41 = load i64, i64 addrspace(1)* %39
@@ -2236,8 +2318,8 @@ entry:
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
-  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
   %54 = load i64, i64 addrspace(1)* %52
@@ -2252,8 +2334,8 @@ entry:
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
   %67 = load i64, i64 addrspace(1)* %65
@@ -2270,8 +2352,8 @@ entry:
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
-  br i1 %NullCheck16, label %79, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
   %80 = load i64, i64 addrspace(1)* %78
@@ -2286,8 +2368,8 @@ entry:
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
-  br i1 %NullCheck18, label %92, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
   %93 = load i64, i64 addrspace(1)* %91
@@ -2304,8 +2386,8 @@ entry:
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
-  br i1 %NullCheck12, label %105, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = load i64, i64 addrspace(1)* %104
@@ -2320,8 +2402,8 @@ entry:
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
-  br i1 %NullCheck14, label %118, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
   %119 = load i64, i64 addrspace(1)* %117
@@ -2337,8 +2419,8 @@ entry:
 
 ; <label>:128                                     ; preds = %20
   %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
-  br i1 %NullCheck4, label %130, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %129, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %130
 
 ; <label>:130                                     ; preds = %128
   %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
@@ -2346,8 +2428,8 @@ entry:
   %133 = load i16, i16 addrspace(1)* %132, align 8
   %134 = zext i16 %133 to i32
   %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
-  br i1 %NullCheck6, label %136, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %135, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %136
 
 ; <label>:136                                     ; preds = %130
   %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
@@ -2360,8 +2442,8 @@ entry:
 
 ; <label>:143                                     ; preds = %136
   %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
-  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %144, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %145
 
 ; <label>:145                                     ; preds = %143
   %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
@@ -2369,8 +2451,8 @@ entry:
   %148 = load i16, i16 addrspace(1)* %147, align 8
   %149 = zext i16 %148 to i32
   %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %150, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %151
 
 ; <label>:151                                     ; preds = %145
   %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
@@ -2388,8 +2470,8 @@ entry:
 
 ; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
-  br i1 %NullCheck, label %163, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %ThrowNullRef, label %163
 
 ; <label>:163                                     ; preds = %161
   %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
@@ -2399,8 +2481,8 @@ entry:
 
 ; <label>:167                                     ; preds = %163
   %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
-  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %168, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %169
 
 ; <label>:169                                     ; preds = %167
   %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
@@ -2432,55 +2514,55 @@ ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %167
+ThrowNullRef2:                                    ; preds = %167
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %128
+ThrowNullRef4:                                    ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %130
+ThrowNullRef6:                                    ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %143
+ThrowNullRef8:                                    ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %145
+ThrowNullRef10:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %102
+ThrowNullRef12:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %105
+ThrowNullRef14:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %76
+ThrowNullRef16:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %79
+ThrowNullRef18:                                   ; preds = %79
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %50
+ThrowNullRef20:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %53
+ThrowNullRef22:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %24
+ThrowNullRef24:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %27
+ThrowNullRef26:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2503,15 +2585,15 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2519,16 +2601,16 @@ entry:
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
   store i32 %8, i32* %loc0
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
   %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
   store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
@@ -2546,16 +2628,16 @@ entry:
 
 ; <label>:23                                      ; preds = %64
   %24 = load i16*, i16** %loc3
-  %NullCheck12 = icmp ne i16* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i16* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
   store i32 %27, i32* %loc5
   %28 = load i16*, i16** %loc4
-  %NullCheck14 = icmp ne i16* %28, null
-  br i1 %NullCheck14, label %29, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %28, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = load i16, i16* %28, align 8
@@ -2620,15 +2702,15 @@ entry:
 
 ; <label>:67                                      ; preds = %64
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
-  br i1 %NullCheck8, label %69, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %68, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %69
 
 ; <label>:69                                      ; preds = %67
   %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
   %71 = load i32, i32 addrspace(1)* %70
   %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
-  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %73
 
 ; <label>:73                                      ; preds = %69
   %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
@@ -2645,31 +2727,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %67
+ThrowNullRef8:                                    ; preds = %67
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %69
+ThrowNullRef10:                                   ; preds = %69
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2710,14 +2792,14 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
   %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
@@ -2730,14 +2812,14 @@ entry:
 
 ; <label>:11                                      ; preds = %4
   %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
   %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
@@ -2749,14 +2831,14 @@ entry:
 
 ; <label>:22                                      ; preds = %16
   %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
   %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
-  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
-  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
@@ -2804,23 +2886,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2836,7 +2918,280 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[loadElem]
+Successfully read RuntimeType.IsAssignableFrom
+
+define i8 @RuntimeType.IsAssignableFrom(%System.RuntimeType addrspace(1)* %param0, %System.Type addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.RuntimeType addrspace(1)*
+  %arg1 = alloca %System.Type addrspace(1)*
+  %loc0 = alloca %System.RuntimeType addrspace(1)*
+  %loc1 = alloca %"System.Type[]" addrspace(1)*
+  %loc2 = alloca i32
+  store %System.RuntimeType addrspace(1)* %param0, %System.RuntimeType addrspace(1)** %this
+  store %System.Type addrspace(1)* %param1, %System.Type addrspace(1)** %arg1
+  %0 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %1 = icmp ne %System.Type addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i8 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %5 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %6 = bitcast %System.Type addrspace(1)* %4 to %System.Object addrspace(1)*
+  %7 = bitcast %System.RuntimeType addrspace(1)* %5 to %System.Object addrspace(1)*
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %6, %System.Object addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %3
+  ret i8 1
+
+; <label>:12                                      ; preds = %3
+  %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 152
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 32
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
+  %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
+  %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
+  store %System.RuntimeType addrspace(1)* %25, %System.RuntimeType addrspace(1)** %loc0
+  %26 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %27 = icmp eq %System.RuntimeType addrspace(1)* %26, null
+  br i1 %27, label %34, label %28
+
+; <label>:28                                      ; preds = %15
+  %29 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %30 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)*)*)(%System.RuntimeType addrspace(1)* %29, %System.RuntimeType addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+; <label>:34                                      ; preds = %15
+  %35 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %36 = call %System.Reflection.Emit.TypeBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Reflection.Emit.TypeBuilder addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %35)
+  %37 = icmp eq %System.Reflection.Emit.TypeBuilder addrspace(1)* %36, null
+  br i1 %37, label %139, label %38
+
+; <label>:38                                      ; preds = %34
+  %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %42
+
+; <label>:42                                      ; preds = %38
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 152
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 40
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
+  %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
+  %53 = zext i8 %52 to i32
+  %54 = icmp eq i32 %53, 0
+  br i1 %54, label %56, label %55
+
+; <label>:55                                      ; preds = %42
+  ret i8 1
+
+; <label>:56                                      ; preds = %42
+  %57 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %58 = bitcast %System.RuntimeType addrspace(1)* %57 to %System.Type addrspace(1)*
+  %59 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %58)
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %64 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.Type addrspace(1)* %63, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = bitcast %System.RuntimeType addrspace(1)* %64 to %System.Type addrspace(1)*
+  %67 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %63, %System.Type addrspace(1)* %66)
+  %68 = zext i8 %67 to i32
+  %69 = trunc i32 %68 to i8
+  ret i8 %69
+
+; <label>:70                                      ; preds = %56
+  %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
+  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %73
+
+; <label>:73                                      ; preds = %70
+  %74 = load i64, i64 addrspace(1)* %72
+  %75 = add i64 %74, 128
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = add i64 %77, 0
+  %79 = inttoptr i64 %78 to i64*
+  %80 = load i64, i64* %79
+  %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
+  %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
+  %83 = call i8 %82(%System.Type addrspace(1)* %81)
+  %84 = zext i8 %83 to i32
+  %85 = icmp eq i32 %84, 0
+  br i1 %85, label %139, label %86
+
+; <label>:86                                      ; preds = %73
+  %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
+  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %89
+
+; <label>:89                                      ; preds = %86
+  %90 = load i64, i64 addrspace(1)* %88
+  %91 = add i64 %90, 128
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = add i64 %93, 24
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
+  %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
+  %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
+  store %"System.Type[]" addrspace(1)* %99, %"System.Type[]" addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %129
+
+; <label>:100                                     ; preds = %132
+  %101 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %102 = load i32, i32* %loc2
+  %NullCheck11 = icmp eq %"System.Type[]" addrspace(1)* %101, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %103
+
+; <label>:103                                     ; preds = %100
+  %104 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 1
+  %105 = load i32, i32 addrspace(1)* %104
+  %106 = zext i32 %105 to i64
+  %107 = zext i32 %102 to i64
+  %BoundsCheck = icmp uge i64 %107, %106
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %108
+
+; <label>:108                                     ; preds = %103
+  %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
+  %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
+  %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
+  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %113
+
+; <label>:113                                     ; preds = %108
+  %114 = load i64, i64 addrspace(1)* %112
+  %115 = add i64 %114, 152
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = add i64 %117, 56
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
+  %123 = zext i8 %122 to i32
+  %124 = icmp ne i32 %123, 0
+  br i1 %124, label %126, label %125
+
+; <label>:125                                     ; preds = %113
+  ret i8 0
+
+; <label>:126                                     ; preds = %113
+  %127 = load i32, i32* %loc2
+  %128 = add i32 %127, 1
+  store i32 %128, i32* %loc2
+  br label %129
+
+; <label>:129                                     ; preds = %89, %126
+  %130 = load i32, i32* %loc2
+  %131 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %NullCheck9 = icmp eq %"System.Type[]" addrspace(1)* %131, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %132
+
+; <label>:132                                     ; preds = %129
+  %133 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %131, i32 0, i32 1
+  %134 = load i32, i32 addrspace(1)* %133
+  %135 = zext i32 %134 to i64
+  %136 = trunc i64 %135 to i32
+  %137 = icmp slt i32 %130, %136
+  br i1 %137, label %100, label %138
+
+; <label>:138                                     ; preds = %132
+  ret i8 1
+
+; <label>:139                                     ; preds = %34, %73
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %129
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %103
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -2893,7 +3248,7 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElem]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -2904,8 +3259,8 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -2997,8 +3352,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
@@ -3059,8 +3414,8 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -3087,8 +3442,8 @@ entry:
 
 ; <label>:17                                      ; preds = %5, %11
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
@@ -3097,8 +3452,8 @@ entry:
 
 ; <label>:22                                      ; preds = %1, %11
   %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
@@ -3109,11 +3464,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %17
+ThrowNullRef2:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %22
+ThrowNullRef4:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3167,15 +3522,15 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
   %15 = load i32, i32 addrspace(1)* %14
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
@@ -3198,7 +3553,7 @@ ThrowNullRef:                                     ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef2:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3232,8 +3587,8 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
@@ -3312,8 +3667,8 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -3327,8 +3682,8 @@ entry:
 ; <label>:5                                       ; preds = %43
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %7 = load i32, i32* %loc1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck6, label %8, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
@@ -3366,8 +3721,8 @@ entry:
 ; <label>:32                                      ; preds = %21, %25
   %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
   %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
-  br i1 %NullCheck8, label %35, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = trunc i32 %34 to i16
@@ -3380,8 +3735,8 @@ entry:
 ; <label>:40                                      ; preds = %1, %35
   %41 = load i32, i32* %loc1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
-  br i1 %NullCheck2, label %43, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %42, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
@@ -3392,8 +3747,8 @@ entry:
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
   %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
-  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
   %51 = load i64, i64 addrspace(1)* %49
@@ -3412,19 +3767,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %40
+ThrowNullRef2:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %47
+ThrowNullRef4:                                    ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %5
+ThrowNullRef6:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %32
+ThrowNullRef8:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3467,8 +3822,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
@@ -3492,11 +3847,391 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(i16* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store i16* %param0, i16** %arg0
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load i32, i32* %arg3
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %42, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %37, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg2
+  %13 = load i32, i32* %arg3
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %37, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %24 = load i32, i32* %arg2
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load i16*, i16** %arg0
+  %35 = load i32, i32* %arg3
+  %36 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %36, i16* %34, i32 %35)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:37                                      ; preds = %5, %16
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %39)
+  %41 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41, %System.String addrspace(1)* %38, %System.String addrspace(1)* %40)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41) #0
+  unreachable
+
+; <label>:42                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
-Failed to read StringBuilder.ToString[loadElemA]
+Successfully read StringBuilder.ToString
+
+define %System.String addrspace(1)* @StringBuilder.ToString(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i16*
+  %loc3 = alloca %"System.Char[]" addrspace(1)*
+  %loc4 = alloca i32
+  %loc5 = alloca i32
+  %loc6 = alloca i16 addrspace(1)*
+  %loc7 = alloca %System.String addrspace(1)*
+  %loc8 = alloca %"System.Char[]" addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %0)
+  %2 = icmp ne i32 %1, 0
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %4
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %6)
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %7)
+  store %System.String addrspace(1)* %8, %System.String addrspace(1)** %loc0
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.Text.StringBuilder addrspace(1)* %9, %System.Text.StringBuilder addrspace(1)** %loc1
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  store %System.String addrspace(1)* %10, %System.String addrspace(1)** %loc7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc7
+  %12 = ptrtoint %System.String addrspace(1)* %11 to i64
+  %13 = icmp eq i64 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %5
+  %15 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %16 = sext i32 %15 to i64
+  %17 = add i64 %12, %16
+  br label %18
+
+; <label>:18                                      ; preds = %5, %14
+  %19 = phi i64 [ %12, %5 ], [ %17, %14 ]
+  %20 = inttoptr i64 %19 to i16*
+  store i16* %20, i16** %loc2
+  br label %21
+
+; <label>:21                                      ; preds = %98, %18
+  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %22, null
+  br i1 %NullCheck, label %ThrowNullRef, label %23
+
+; <label>:23                                      ; preds = %21
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 3
+  %25 = load i32, i32 addrspace(1)* %24, align 8
+  %26 = icmp sle i32 %25, 0
+  br i1 %26, label %96, label %27
+
+; <label>:27                                      ; preds = %23
+  %28 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %28, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %29
+
+; <label>:29                                      ; preds = %27
+  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %28, i32 0, i32 1
+  %31 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %30, align 8
+  store %"System.Char[]" addrspace(1)* %31, %"System.Char[]" addrspace(1)** %loc3
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %33
+
+; <label>:33                                      ; preds = %29
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  store i32 %35, i32* %loc4
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  %39 = load i32, i32 addrspace(1)* %38, align 8
+  store i32 %39, i32* %loc5
+  %40 = load i32, i32* %loc5
+  %41 = load i32, i32* %loc4
+  %42 = add i32 %40, %41
+  %43 = zext i32 %42 to i64
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %45
+
+; <label>:45                                      ; preds = %37
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = sext i32 %47 to i64
+  %49 = icmp sgt i64 %43, %48
+  br i1 %49, label %91, label %50
+
+; <label>:50                                      ; preds = %45
+  %51 = load i32, i32* %loc5
+  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %52, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %53
+
+; <label>:53                                      ; preds = %50
+  %54 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %52, i32 0, i32 1
+  %55 = load i32, i32 addrspace(1)* %54
+  %56 = zext i32 %55 to i64
+  %57 = trunc i64 %56 to i32
+  %58 = icmp ugt i32 %51, %57
+  br i1 %58, label %91, label %59
+
+; <label>:59                                      ; preds = %53
+  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  store %"System.Char[]" addrspace(1)* %60, %"System.Char[]" addrspace(1)** %loc8
+  %61 = icmp eq %"System.Char[]" addrspace(1)* %60, null
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %63, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %64
+
+; <label>:64                                      ; preds = %62
+  %65 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %63, i32 0, i32 1
+  %66 = load i32, i32 addrspace(1)* %65
+  %67 = zext i32 %66 to i64
+  %68 = trunc i64 %67 to i32
+  %69 = icmp ne i32 %68, 0
+  br i1 %69, label %71, label %70
+
+; <label>:70                                      ; preds = %59, %64
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:71                                      ; preds = %64
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %73
+
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %BoundsCheck = icmp uge i64 0, %76
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %77
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %78, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:79                                      ; preds = %70, %77
+  %80 = load i16*, i16** %loc2
+  %81 = load i32, i32* %loc4
+  %82 = sext i32 %81 to i64
+  %83 = mul i64 %82, 2
+  %84 = bitcast i16* %80 to i8*
+  %85 = getelementptr inbounds i8, i8* %84, i64 %83
+  %86 = load i16 addrspace(1)*, i16 addrspace(1)** %loc6
+  %87 = ptrtoint i16 addrspace(1)* %86 to i64
+  %88 = load i32, i32* %loc5
+  %89 = bitcast i8* %85 to i16*
+  %90 = inttoptr i64 %87 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %89, i16* %90, i32 %88)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %96
+
+; <label>:91                                      ; preds = %45, %53
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %94 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %93)
+  %95 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95, %System.String addrspace(1)* %92, %System.String addrspace(1)* %94)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95) #0
+  unreachable
+
+; <label>:96                                      ; preds = %23, %79
+  %97 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %97, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %98
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %97, i32 0, i32 2
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  store %System.Text.StringBuilder addrspace(1)* %100, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %102 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %102, label %21, label %103
+
+; <label>:103                                     ; preds = %98
+  store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc7
+  %104 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  ret %System.String addrspace(1)* %104
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method StringBuilder::get_Length using LLILCJit
+Successfully read StringBuilder.get_Length
+
+define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
+Successfully read RuntimeHelpers.get_OffsetToStringData
+
+define i32 @RuntimeHelpers.get_OffsetToStringData() {
+entry:
+  ret i32 12
+}
+
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
 Successfully read CultureData.CreateCultureData
 
@@ -3514,23 +4249,23 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
   store i8 %4, i8 addrspace(1)* %6
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
@@ -3549,11 +4284,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3566,50 +4301,50 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
   store i32 -1, i32 addrspace(1)* %2
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
   store i32 -1, i32 addrspace(1)* %8
   %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
   store i32 -1, i32 addrspace(1)* %14
   %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
   store i32 -1, i32 addrspace(1)* %17
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
@@ -3623,27 +4358,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3675,7 +4410,136 @@ Failed to read Dictionary`2.Insert[non-const derefAddress]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
 Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
-Failed to read HashHelpers.GetPrime[loadElem]
+Successfully read HashHelpers.GetPrime
+
+define i32 @HashHelpers.GetPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %6, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5, %System.String addrspace(1)* %4)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5) #0
+  unreachable
+
+; <label>:6                                       ; preds = %entry
+  store i32 0, i32* %loc0
+  br label %29
+
+; <label>:7                                       ; preds = %35
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 1296
+  %10 = addrspacecast i8 addrspace(1)* %9 to %"System.Int32[]" addrspace(1)**
+  %11 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %10
+  %12 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Int32[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = zext i32 %15 to i64
+  %17 = zext i32 %12 to i64
+  %BoundsCheck = icmp uge i64 %17, %16
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 3, i32 %12
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  store i32 %20, i32* %loc1
+  %21 = load i32, i32* %loc1
+  %22 = load i32, i32* %arg0
+  %23 = icmp slt i32 %21, %22
+  br i1 %23, label %26, label %24
+
+; <label>:24                                      ; preds = %18
+  %25 = load i32, i32* %loc1
+  ret i32 %25
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %loc0
+  %28 = add i32 %27, 1
+  store i32 %28, i32* %loc0
+  br label %29
+
+; <label>:29                                      ; preds = %6, %26
+  %30 = load i32, i32* %loc0
+  %31 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %32 = getelementptr inbounds i8, i8 addrspace(1)* %31, i64 1296
+  %33 = addrspacecast i8 addrspace(1)* %32 to %"System.Int32[]" addrspace(1)**
+  %34 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %33
+  %NullCheck = icmp eq %"System.Int32[]" addrspace(1)* %34, null
+  br i1 %NullCheck, label %ThrowNullRef, label %35
+
+; <label>:35                                      ; preds = %29
+  %36 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %34, i32 0, i32 1
+  %37 = load i32, i32 addrspace(1)* %36
+  %38 = zext i32 %37 to i64
+  %39 = trunc i64 %38 to i32
+  %40 = icmp slt i32 %30, %39
+  br i1 %40, label %7, label %41
+
+; <label>:41                                      ; preds = %35
+  %42 = load i32, i32* %arg0
+  %43 = or i32 %42, 1
+  store i32 %43, i32* %loc2
+  br label %59
+
+; <label>:44                                      ; preds = %59
+  %45 = load i32, i32* %loc2
+  %46 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %45)
+  %47 = zext i8 %46 to i32
+  %48 = icmp eq i32 %47, 0
+  br i1 %48, label %56, label %49
+
+; <label>:49                                      ; preds = %44
+  %50 = load i32, i32* %loc2
+  %51 = sub i32 %50, 1
+  %52 = srem i32 %51, 101
+  %53 = icmp eq i32 %52, 0
+  br i1 %53, label %56, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = load i32, i32* %loc2
+  ret i32 %55
+
+; <label>:56                                      ; preds = %44, %49
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %57, 2
+  store i32 %58, i32* %loc2
+  br label %59
+
+; <label>:59                                      ; preds = %41, %56
+  %60 = load i32, i32* %loc2
+  %61 = icmp slt i32 %60, 2147483647
+  br i1 %61, label %44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load i32, i32* %arg0
+  ret i32 %63
+
+ThrowNullRef:                                     ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
 Successfully read GenericEqualityComparer`1.GetHashCode
 
@@ -3694,14 +4558,14 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
   %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load i64, i64 addrspace(1)* %7
@@ -3720,7 +4584,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3750,8 +4614,8 @@ entry:
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
@@ -3796,8 +4660,8 @@ entry:
   %35 = bitcast i16* %34 to i8*
   %36 = getelementptr inbounds i8, i8* %35, i64 2
   %37 = bitcast i8* %36 to i16*
-  %NullCheck4 = icmp ne i16* %37, null
-  br i1 %NullCheck4, label %38, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %37, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %38
 
 ; <label>:38                                      ; preds = %27
   %39 = load i16, i16* %37, align 8
@@ -3824,8 +4688,8 @@ entry:
 
 ; <label>:54                                      ; preds = %22, %43
   %55 = load i16*, i16** %loc4
-  %NullCheck2 = icmp ne i16* %55, null
-  br i1 %NullCheck2, label %56, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i16* %55, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %56
 
 ; <label>:56                                      ; preds = %54
   %57 = load i16, i16* %55, align 8
@@ -3850,11 +4714,11 @@ ThrowNullRef:                                     ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %54
+ThrowNullRef2:                                    ; preds = %54
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %27
+ThrowNullRef4:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3871,8 +4735,8 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -3907,8 +4771,8 @@ entry:
 
 ; <label>:26                                      ; preds = %19
   %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
-  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %28
 
 ; <label>:28                                      ; preds = %26
   %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
@@ -3920,7 +4784,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3972,8 +4836,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
@@ -3984,26 +4848,26 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
-  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
@@ -4014,8 +4878,8 @@ entry:
 ; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
@@ -4024,8 +4888,8 @@ entry:
 
 ; <label>:25                                      ; preds = %1, %16, %23
   %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
-  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
@@ -4036,27 +4900,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %20
+ThrowNullRef10:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4069,8 +4933,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -4081,8 +4945,8 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
@@ -4091,8 +4955,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1, %8
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
@@ -4103,11 +4967,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4128,24 +4992,24 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   store i32 %3, i32* %loc0
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
   %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
   store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck4, label %9, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
@@ -4164,15 +5028,15 @@ entry:
 ; <label>:18                                      ; preds = %70
   %19 = load i16*, i16** %loc3
   %20 = bitcast i16* %19 to i64*
-  %NullCheck10 = icmp ne i64* %20, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %20, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = load i64, i64* %20, align 8
   %23 = load i16*, i16** %loc4
   %24 = bitcast i16* %23 to i64*
-  %NullCheck12 = icmp ne i64* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = load i64, i64* %24, align 8
@@ -4188,8 +5052,8 @@ entry:
   %31 = bitcast i16* %30 to i8*
   %32 = getelementptr inbounds i8, i8* %31, i64 8
   %33 = bitcast i8* %32 to i64*
-  %NullCheck14 = icmp ne i64* %33, null
-  br i1 %NullCheck14, label %34, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = load i64, i64* %33, align 8
@@ -4197,8 +5061,8 @@ entry:
   %37 = bitcast i16* %36 to i8*
   %38 = getelementptr inbounds i8, i8* %37, i64 8
   %39 = bitcast i8* %38 to i64*
-  %NullCheck16 = icmp ne i64* %39, null
-  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %40
 
 ; <label>:40                                      ; preds = %34
   %41 = load i64, i64* %39, align 8
@@ -4214,8 +5078,8 @@ entry:
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %NullCheck18 = icmp ne i64* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = load i64, i64* %48, align 8
@@ -4223,8 +5087,8 @@ entry:
   %52 = bitcast i16* %51 to i8*
   %53 = getelementptr inbounds i8, i8* %52, i64 16
   %54 = bitcast i8* %53 to i64*
-  %NullCheck20 = icmp ne i64* %54, null
-  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64* %54, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %55
 
 ; <label>:55                                      ; preds = %49
   %56 = load i64, i64* %54, align 8
@@ -4262,15 +5126,15 @@ entry:
 ; <label>:74                                      ; preds = %95
   %75 = load i16*, i16** %loc3
   %76 = bitcast i16* %75 to i32*
-  %NullCheck6 = icmp ne i32* %76, null
-  br i1 %NullCheck6, label %77, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32* %76, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %77
 
 ; <label>:77                                      ; preds = %74
   %78 = load i32, i32* %76, align 8
   %79 = load i16*, i16** %loc4
   %80 = bitcast i16* %79 to i32*
-  %NullCheck8 = icmp ne i32* %80, null
-  br i1 %NullCheck8, label %81, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i32* %80, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %81
 
 ; <label>:81                                      ; preds = %77
   %82 = load i32, i32* %80, align 8
@@ -4318,43 +5182,43 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %74
+ThrowNullRef6:                                    ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %77
+ThrowNullRef8:                                    ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %29
+ThrowNullRef14:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %34
+ThrowNullRef16:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4376,8 +5240,8 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load i64, i64 addrspace(1)* %4
@@ -4389,8 +5253,8 @@ entry:
   %12 = load i64, i64* %11
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %5
   %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
@@ -4399,8 +5263,8 @@ entry:
   %18 = load i8, i8* %arg2
   %19 = zext i8 %18 to i32
   %20 = trunc i32 %19 to i8
-  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %15
   %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
@@ -4411,11 +5275,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4442,8 +5306,8 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
@@ -4466,16 +5330,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
   %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = load i64, i64 addrspace(1)* %19
@@ -4500,8 +5364,8 @@ entry:
 ; <label>:35                                      ; preds = %30
   %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
@@ -4514,8 +5378,8 @@ entry:
 
 ; <label>:42                                      ; preds = %1, %38
   %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
-  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
@@ -4526,19 +5390,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %35
+ThrowNullRef2:                                    ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %42
+ThrowNullRef8:                                    ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4551,14 +5415,14 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
@@ -4570,7 +5434,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4583,8 +5447,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
@@ -4613,51 +5477,51 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
   %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
   %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
   %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
   %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
-  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
   store i64 %21, i64 addrspace(1)* %23
   %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %25 = load i64, i64* %loc0
-  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
@@ -4668,27 +5532,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %22
+ThrowNullRef12:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4701,8 +5565,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
@@ -4713,19 +5577,19 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
@@ -4734,8 +5598,8 @@ entry:
 
 ; <label>:15                                      ; preds = %1, %13
   %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
@@ -4746,19 +5610,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %15
+ThrowNullRef8:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4771,8 +5635,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -4831,8 +5695,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
@@ -4882,8 +5746,8 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
-  br i1 %NullCheck, label %17, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %ThrowNullRef, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
@@ -4894,15 +5758,15 @@ entry:
 
 ; <label>:22                                      ; preds = %17
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
-  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
   %26 = load i32, i32 addrspace(1)* %25
   %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
-  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %27, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
@@ -4925,8 +5789,8 @@ entry:
 ; <label>:40                                      ; preds = %17
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
-  br i1 %NullCheck6, label %43, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %41, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
@@ -4938,34 +5802,17 @@ ThrowNullRef:                                     ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %24
+ThrowNullRef4:                                    ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %40
+ThrowNullRef6:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
-}
-
-INFO:  jitting method Object::ReferenceEquals using LLILCJit
-Successfully read Object.ReferenceEquals
-
-define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
-entry:
-  %arg0 = alloca %System.Object addrspace(1)*
-  %arg1 = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
-  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
-  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = icmp eq %System.Object addrspace(1)* %0, %1
-  %3 = sext i1 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
 }
 
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
@@ -4978,21 +5825,21 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
   %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
-  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
@@ -5007,28 +5854,28 @@ entry:
 ; <label>:13                                      ; preds = %8, %12
   %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
   %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
   %21 = load i32, i32 addrspace(1)* %20, align 8
   %22 = add i32 %21, 1
-  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
   store i32 %22, i32 addrspace(1)* %24
   %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
@@ -5039,27 +5886,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5077,7 +5924,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::Setup using LLILCJit
-Failed to read AppDomain.Setup[loadElem]
+Failed to read AppDomain.Setup[unbox]
 INFO:  jitting method Thread::GetDomain using LLILCJit
 Successfully read Thread.GetDomain
 
@@ -5108,8 +5955,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
@@ -5122,14 +5969,14 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
   %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
@@ -5141,11 +5988,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5173,8 +6020,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -5189,7 +6036,328 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
 Failed to read KeyCollection.System.Collections.Generic.IEnumerable<TKey>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Successfully read Enumerator.MoveNext
+
+define i8 @Enumerator.MoveNext(%"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.RuntimeTypeHandle* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*
+  %"$TypeArg" = alloca %System.RuntimeTypeHandle*
+  store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
+  %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 8
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %76, label %12
+
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
+  br label %76
+
+; <label>:13                                      ; preds = %85
+  %14 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck19 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %15
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, i32 0, i32 0
+  %17 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %16, align 8
+  %NullCheck21 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, i32 0, i32 2
+  %20 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %19, align 8
+  %21 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck23 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %22
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, i32 0, i32 2
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %NullCheck25 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 3, i32 %24
+  %NullCheck27 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %32
+
+; <label>:32                                      ; preds = %30
+  %33 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, i32 0, i32 2
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = icmp slt i32 %34, 0
+  br i1 %35, label %68, label %36
+
+; <label>:36                                      ; preds = %32
+  %37 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %38 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck29 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %39
+
+; <label>:39                                      ; preds = %36
+  %40 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, i32 0, i32 0
+  %41 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %40, align 8
+  %NullCheck31 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, i32 0, i32 2
+  %44 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %43, align 8
+  %45 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck33 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, i32 0, i32 2
+  %48 = load i32, i32 addrspace(1)* %47, align 8
+  %NullCheck35 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %49
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = zext i32 %51 to i64
+  %53 = zext i32 %48 to i64
+  %BoundsCheck37 = icmp uge i64 %53, %52
+  br i1 %BoundsCheck37, label %ThrowIndexOutOfRange38, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 3, i32 %48
+  %NullCheck39 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %56
+
+; <label>:56                                      ; preds = %54
+  %57 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, i32 0, i32 0
+  %58 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck41 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %59
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %60, %System.__Canon addrspace(1)* %58)
+  %61 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck43 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  %64 = load i32, i32 addrspace(1)* %63, align 8
+  %65 = add i32 %64, 1
+  %NullCheck45 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  store i32 %65, i32 addrspace(1)* %67
+  ret i8 1
+
+; <label>:68                                      ; preds = %32
+  %69 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck47 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %73 = add i32 %72, 1
+  %NullCheck49 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %74
+
+; <label>:74                                      ; preds = %70
+  %75 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  store i32 %73, i32 addrspace(1)* %75
+  br label %76
+
+; <label>:76                                      ; preds = %8, %12, %74
+  %77 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %78
+
+; <label>:78                                      ; preds = %76
+  %79 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, i32 0, i32 2
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck7 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %82
+
+; <label>:82                                      ; preds = %78
+  %83 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, i32 0, i32 0
+  %84 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %83, align 8
+  %NullCheck9 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %85
+
+; <label>:85                                      ; preds = %82
+  %86 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, i32 0, i32 7
+  %87 = load i32, i32 addrspace(1)* %86, align 8
+  %88 = icmp ult i32 %80, %87
+  br i1 %88, label %13, label %89
+
+; <label>:89                                      ; preds = %85
+  %90 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %91 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck11 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %92
+
+; <label>:92                                      ; preds = %89
+  %93 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, i32 0, i32 0
+  %94 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck13 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %95
+
+; <label>:95                                      ; preds = %92
+  %96 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, i32 0, i32 7
+  %97 = load i32, i32 addrspace(1)* %96, align 8
+  %98 = add i32 %97, 1
+  %NullCheck15 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %99
+
+; <label>:99                                      ; preds = %95
+  %100 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, i32 0, i32 2
+  store i32 %98, i32 addrspace(1)* %100
+  %101 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck17 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %102
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %103, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %92
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef22:                                   ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef24:                                   ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef26:                                   ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef28:                                   ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef30:                                   ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef32:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef34:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef36:                                   ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange38:                           ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef40:                                   ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef42:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef44:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef46:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef48:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef50:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -5200,8 +6368,8 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -5232,9 +6400,9 @@ Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
 Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
-Failed to read String.MakeSeparatorList[loadElemA]
+Failed to read String.MakeSeparatorList[storeElem]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
-Failed to read String.InternalSplitKeepEmptyEntries[loadElem]
+Failed to read String.InternalSplitKeepEmptyEntries[storeElem]
 INFO:  jitting method Path::IsRelative using LLILCJit
 Successfully read Path.IsRelative
 
@@ -5243,8 +6411,8 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -5254,8 +6422,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
@@ -5271,8 +6439,8 @@ entry:
 
 ; <label>:17                                      ; preds = %7
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
@@ -5288,8 +6456,8 @@ entry:
 
 ; <label>:29                                      ; preds = %19
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %31
 
 ; <label>:31                                      ; preds = %29
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
@@ -5300,8 +6468,8 @@ entry:
 
 ; <label>:36                                      ; preds = %31
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
-  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %37, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
@@ -5312,8 +6480,8 @@ entry:
 
 ; <label>:43                                      ; preds = %31, %38
   %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
-  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %45
 
 ; <label>:45                                      ; preds = %43
   %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
@@ -5324,8 +6492,8 @@ entry:
 
 ; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %50
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
@@ -5336,8 +6504,8 @@ entry:
 
 ; <label>:57                                      ; preds = %1, %7, %19, %45, %52
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
-  br i1 %NullCheck14, label %59, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %59
 
 ; <label>:59                                      ; preds = %57
   %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
@@ -5347,8 +6515,8 @@ entry:
 
 ; <label>:63                                      ; preds = %59
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
@@ -5359,8 +6527,8 @@ entry:
 
 ; <label>:70                                      ; preds = %65
   %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
-  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.String addrspace(1)* %71, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %72
 
 ; <label>:72                                      ; preds = %70
   %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
@@ -5379,39 +6547,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %17
+ThrowNullRef4:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %29
+ThrowNullRef6:                                    ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %36
+ThrowNullRef8:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %43
+ThrowNullRef10:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %50
+ThrowNullRef12:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %57
+ThrowNullRef14:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %63
+ThrowNullRef16:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %70
+ThrowNullRef18:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5419,7 +6587,293 @@ ThrowNullRef17:                                   ; preds = %70
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
-Failed to read String.TrimHelper[loadElem]
+Successfully read String.TrimHelper
+
+define %System.String addrspace(1)* @String.TrimHelper(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i16
+  %loc4 = alloca i32
+  %loc5 = alloca i16
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = sub i32 %3, 1
+  store i32 %4, i32* %loc0
+  store i32 0, i32* %loc1
+  %5 = load i32, i32* %arg2
+  %6 = icmp eq i32 %5, 1
+  br i1 %6, label %62, label %7
+
+; <label>:7                                       ; preds = %1
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:8                                       ; preds = %58
+  store i32 0, i32* %loc2
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load i32, i32* %loc1
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2, i32 %10
+  %13 = load i16, i16 addrspace(1)* %12
+  %14 = zext i16 %13 to i32
+  %15 = trunc i32 %14 to i16
+  store i16 %15, i16* %loc3
+  store i32 0, i32* %loc2
+  br label %34
+
+; <label>:16                                      ; preds = %37
+  %17 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %18 = load i32, i32* %loc2
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %17, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %19
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = zext i32 %18 to i64
+  %BoundsCheck = icmp uge i64 %23, %22
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %24
+
+; <label>:24                                      ; preds = %19
+  %25 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 3, i32 %18
+  %26 = load i16, i16 addrspace(1)* %25, align 8
+  %27 = zext i16 %26 to i32
+  %28 = load i16, i16* %loc3
+  %29 = zext i16 %28 to i32
+  %30 = icmp eq i32 %27, %29
+  br i1 %30, label %43, label %31
+
+; <label>:31                                      ; preds = %24
+  %32 = load i32, i32* %loc2
+  %33 = add i32 %32, 1
+  store i32 %33, i32* %loc2
+  br label %34
+
+; <label>:34                                      ; preds = %11, %31
+  %35 = load i32, i32* %loc2
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = icmp slt i32 %35, %41
+  br i1 %42, label %16, label %43
+
+; <label>:43                                      ; preds = %24, %37
+  %44 = load i32, i32* %loc2
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %45, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp eq i32 %44, %50
+  br i1 %51, label %62, label %52
+
+; <label>:52                                      ; preds = %46
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %7, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %57, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %58
+
+; <label>:58                                      ; preds = %55
+  %59 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %60 = load i32, i32 addrspace(1)* %59
+  %61 = icmp slt i32 %56, %60
+  br i1 %61, label %8, label %62
+
+; <label>:62                                      ; preds = %1, %46, %58
+  %63 = load i32, i32* %arg2
+  %64 = icmp eq i32 %63, 0
+  br i1 %64, label %122, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %66, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %67
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %66, i32 0, i32 1
+  %69 = load i32, i32 addrspace(1)* %68
+  %70 = sub i32 %69, 1
+  store i32 %70, i32* %loc0
+  br label %118
+
+; <label>:71                                      ; preds = %118
+  store i32 0, i32* %loc4
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %73 = load i32, i32* %loc0
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %74
+
+; <label>:74                                      ; preds = %71
+  %75 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 2, i32 %73
+  %76 = load i16, i16 addrspace(1)* %75
+  %77 = zext i16 %76 to i32
+  %78 = trunc i32 %77 to i16
+  store i16 %78, i16* %loc5
+  store i32 0, i32* %loc4
+  br label %97
+
+; <label>:79                                      ; preds = %100
+  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %81 = load i32, i32* %loc4
+  %NullCheck19 = icmp eq %"System.Char[]" addrspace(1)* %80, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
+
+; <label>:82                                      ; preds = %79
+  %83 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 1
+  %84 = load i32, i32 addrspace(1)* %83
+  %85 = zext i32 %84 to i64
+  %86 = zext i32 %81 to i64
+  %BoundsCheck21 = icmp uge i64 %86, %85
+  br i1 %BoundsCheck21, label %ThrowIndexOutOfRange22, label %87
+
+; <label>:87                                      ; preds = %82
+  %88 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 3, i32 %81
+  %89 = load i16, i16 addrspace(1)* %88, align 8
+  %90 = zext i16 %89 to i32
+  %91 = load i16, i16* %loc5
+  %92 = zext i16 %91 to i32
+  %93 = icmp eq i32 %90, %92
+  br i1 %93, label %106, label %94
+
+; <label>:94                                      ; preds = %87
+  %95 = load i32, i32* %loc4
+  %96 = add i32 %95, 1
+  store i32 %96, i32* %loc4
+  br label %97
+
+; <label>:97                                      ; preds = %74, %94
+  %98 = load i32, i32* %loc4
+  %99 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck15 = icmp eq %"System.Char[]" addrspace(1)* %99, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %100
+
+; <label>:100                                     ; preds = %97
+  %101 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %99, i32 0, i32 1
+  %102 = load i32, i32 addrspace(1)* %101
+  %103 = zext i32 %102 to i64
+  %104 = trunc i64 %103 to i32
+  %105 = icmp slt i32 %98, %104
+  br i1 %105, label %79, label %106
+
+; <label>:106                                     ; preds = %87, %100
+  %107 = load i32, i32* %loc4
+  %108 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck17 = icmp eq %"System.Char[]" addrspace(1)* %108, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %109
+
+; <label>:109                                     ; preds = %106
+  %110 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %108, i32 0, i32 1
+  %111 = load i32, i32 addrspace(1)* %110
+  %112 = zext i32 %111 to i64
+  %113 = trunc i64 %112 to i32
+  %114 = icmp eq i32 %107, %113
+  br i1 %114, label %122, label %115
+
+; <label>:115                                     ; preds = %109
+  %116 = load i32, i32* %loc0
+  %117 = sub i32 %116, 1
+  store i32 %117, i32* %loc0
+  br label %118
+
+; <label>:118                                     ; preds = %67, %115
+  %119 = load i32, i32* %loc0
+  %120 = load i32, i32* %loc1
+  %121 = icmp sge i32 %119, %120
+  br i1 %121, label %71, label %122
+
+; <label>:122                                     ; preds = %62, %109, %118
+  %123 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %124 = load i32, i32* %loc1
+  %125 = load i32, i32* %loc0
+  %126 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %123, i32 %124, i32 %125)
+  ret %System.String addrspace(1)* %126
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %97
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange22:                           ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
 Successfully read String.CreateTrimmedString
 
@@ -5439,8 +6893,8 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
@@ -5535,8 +6989,8 @@ entry:
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i64 2872
   %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
   %8 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %7
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %3
   %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
@@ -5553,8 +7007,8 @@ entry:
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 2864
   %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
   %21 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %20
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
-  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %22
 
 ; <label>:22                                      ; preds = %16
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
@@ -5569,7 +7023,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %16
+ThrowNullRef2:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5586,8 +7040,8 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5613,8 +7067,8 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
@@ -5632,8 +7086,8 @@ entry:
 
 ; <label>:12                                      ; preds = %4
   %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
@@ -5644,8 +7098,8 @@ entry:
 
 ; <label>:19                                      ; preds = %14
   %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %19
   %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
@@ -5660,21 +7114,21 @@ entry:
   %31 = zext i16 %30 to i32
   %32 = bitcast i8* %29 to i16*
   %33 = trunc i32 %31 to i16
-  %NullCheck6 = icmp ne i16* %32, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i16* %32, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %21
   store i16 %33, i16* %32, align 8
   %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %36
 
 ; <label>:36                                      ; preds = %34
   %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
   %38 = load i32, i32 addrspace(1)* %37, align 8
   %39 = add i32 %38, 1
-  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %40
 
 ; <label>:40                                      ; preds = %36
   %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
@@ -5683,16 +7137,16 @@ entry:
 
 ; <label>:42                                      ; preds = %14
   %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
-  br i1 %NullCheck12, label %44, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
   %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
   %47 = load i16, i16* %arg1
   %48 = zext i16 %47 to i32
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = trunc i32 %48 to i16
@@ -5703,31 +7157,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %19
+ThrowNullRef4:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %21
+ThrowNullRef6:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %36
+ThrowNullRef10:                                   ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %42
+ThrowNullRef12:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %44
+ThrowNullRef14:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5740,8 +7194,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -5752,8 +7206,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
@@ -5762,14 +7216,14 @@ entry:
 
 ; <label>:11                                      ; preds = %1
   %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
@@ -5779,15 +7233,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5808,8 +7262,8 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5822,8 +7276,8 @@ entry:
 
 ; <label>:8                                       ; preds = %3
   %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
@@ -5842,15 +7296,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
-  br i1 %NullCheck4, label %22, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
   %24 = load i16*, i16* addrspace(1)* %23, align 8
   %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %25, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
@@ -5859,8 +7313,8 @@ entry:
   store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
@@ -5874,8 +7328,8 @@ entry:
 
 ; <label>:37                                      ; preds = %65
   %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %37
   %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
@@ -5886,16 +7340,16 @@ entry:
   %45 = bitcast i16* %41 to i8*
   %46 = getelementptr inbounds i8, i8* %45, i64 %44
   %47 = bitcast i8* %46 to i16*
-  %NullCheck14 = icmp ne i16* %47, null
-  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %47, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %48
 
 ; <label>:48                                      ; preds = %39
   %49 = load i16, i16* %47, align 8
   %50 = zext i16 %49 to i32
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %52 = load i32, i32* %loc1
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %53
 
 ; <label>:53                                      ; preds = %48
   %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
@@ -5916,8 +7370,8 @@ entry:
 ; <label>:62                                      ; preds = %36, %59
   %63 = load i32, i32* %loc1
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck10, label %65, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %65
 
 ; <label>:65                                      ; preds = %62
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
@@ -5936,15 +7390,15 @@ entry:
 
 ; <label>:74                                      ; preds = %70
   %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
-  br i1 %NullCheck18, label %76, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %76
 
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
   %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
-  br i1 %NullCheck20, label %80, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
   %81 = load i64, i64 addrspace(1)* %79
@@ -5958,8 +7412,8 @@ entry:
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
   %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
-  br i1 %NullCheck22, label %92, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.String addrspace(1)* %90, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %92
 
 ; <label>:92                                      ; preds = %80
   %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
@@ -5969,15 +7423,15 @@ entry:
 
 ; <label>:96                                      ; preds = %70
   %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
-  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %98
 
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
   %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
-  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
   %103 = load i64, i64 addrspace(1)* %101
@@ -5991,8 +7445,8 @@ entry:
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
   %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
-  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.String addrspace(1)* %112, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %114
 
 ; <label>:114                                     ; preds = %102
   %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
@@ -6004,59 +7458,59 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %20
+ThrowNullRef4:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %22
+ThrowNullRef6:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %26
+ThrowNullRef8:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %62
+ThrowNullRef10:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %48
+ThrowNullRef16:                                   ; preds = %48
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %74
+ThrowNullRef18:                                   ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %76
+ThrowNullRef20:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %80
+ThrowNullRef22:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %96
+ThrowNullRef24:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %98
+ThrowNullRef26:                                   ; preds = %98
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %102
+ThrowNullRef28:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6069,15 +7523,15 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
   %3 = load i16*, i16* addrspace(1)* %2, align 8
   %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
@@ -6087,8 +7541,8 @@ entry:
   %10 = bitcast i16* %3 to i8*
   %11 = getelementptr inbounds i8, i8* %10, i64 %9
   %12 = bitcast i8* %11 to i16*
-  %NullCheck4 = icmp ne i16* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %5
   store i16 0, i16* %12, align 8
@@ -6098,11 +7552,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6119,8 +7573,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -6131,8 +7585,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
@@ -6144,15 +7598,15 @@ entry:
 
 ; <label>:14                                      ; preds = %1
   %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
   %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
   %21 = load i64, i64 addrspace(1)* %19
@@ -6171,15 +7625,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %14
+ThrowNullRef4:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %16
+ThrowNullRef6:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6302,14 +7756,6 @@ entry:
   ret %System.String addrspace(1)* %57
 }
 
-INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
-Successfully read RuntimeHelpers.get_OffsetToStringData
-
-define i32 @RuntimeHelpers.get_OffsetToStringData() {
-entry:
-  ret i32 12
-}
-
 INFO:  jitting method String::Equals using LLILCJit
 Successfully read String.Equals
 
@@ -6381,8 +7827,8 @@ entry:
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
-  br i1 %NullCheck24, label %29, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
   %30 = load i64, i64 addrspace(1)* %28
@@ -6397,8 +7843,8 @@ entry:
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
-  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
   %43 = load i64, i64 addrspace(1)* %41
@@ -6418,8 +7864,8 @@ entry:
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
   %59 = load i64, i64 addrspace(1)* %57
@@ -6434,8 +7880,8 @@ entry:
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck22, label %71, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
   %72 = load i64, i64 addrspace(1)* %70
@@ -6455,8 +7901,8 @@ entry:
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
-  br i1 %NullCheck16, label %87, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = load i64, i64 addrspace(1)* %86
@@ -6471,8 +7917,8 @@ entry:
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck18, label %100, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
   %101 = load i64, i64 addrspace(1)* %99
@@ -6492,8 +7938,8 @@ entry:
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
-  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
   %117 = load i64, i64 addrspace(1)* %115
@@ -6508,8 +7954,8 @@ entry:
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
-  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
   %130 = load i64, i64 addrspace(1)* %128
@@ -6528,15 +7974,15 @@ entry:
 
 ; <label>:142                                     ; preds = %22
   %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
-  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %143, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %144
 
 ; <label>:144                                     ; preds = %142
   %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
   %146 = load i32, i32 addrspace(1)* %145
   %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
-  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %147, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %148
 
 ; <label>:148                                     ; preds = %144
   %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
@@ -6557,15 +8003,15 @@ entry:
 
 ; <label>:159                                     ; preds = %22
   %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
-  br i1 %NullCheck, label %161, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %ThrowNullRef, label %161
 
 ; <label>:161                                     ; preds = %159
   %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
   %163 = load i32, i32 addrspace(1)* %162
   %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
-  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %164, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %165
 
 ; <label>:165                                     ; preds = %161
   %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
@@ -6578,8 +8024,8 @@ entry:
 
 ; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
-  br i1 %NullCheck4, label %172, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %171, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %172
 
 ; <label>:172                                     ; preds = %170
   %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
@@ -6589,8 +8035,8 @@ entry:
 
 ; <label>:176                                     ; preds = %172
   %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
-  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %177, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %178
 
 ; <label>:178                                     ; preds = %176
   %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
@@ -6629,55 +8075,55 @@ ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %161
+ThrowNullRef2:                                    ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %170
+ThrowNullRef4:                                    ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %176
+ThrowNullRef6:                                    ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %142
+ThrowNullRef8:                                    ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %144
+ThrowNullRef10:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %113
+ThrowNullRef12:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %116
+ThrowNullRef14:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %84
+ThrowNullRef16:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %87
+ThrowNullRef18:                                   ; preds = %87
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %55
+ThrowNullRef20:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %58
+ThrowNullRef22:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %26
+ThrowNullRef24:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %29
+ThrowNullRef26:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,8 +8161,8 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck, label %14, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %ThrowNullRef, label %14
 
 ; <label>:14                                      ; preds = %8
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
@@ -6760,8 +8206,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
@@ -6770,14 +8216,14 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32, i32* %loc0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %10
   %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
   %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
@@ -6790,15 +8236,15 @@ entry:
 ; <label>:25                                      ; preds = %19
   %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
-  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
   %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
@@ -6807,8 +8253,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %37 = load i32, i32* %loc0
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %38, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %38
 
 ; <label>:38                                      ; preds = %32
   %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
@@ -6817,14 +8263,14 @@ entry:
 
 ; <label>:40                                      ; preds = %19
   %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %40
   %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
   %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
-  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
-  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
@@ -6832,8 +8278,8 @@ entry:
   %48 = zext i32 %47 to i64
   %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
-  br i1 %NullCheck16, label %51, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %51
 
 ; <label>:51                                      ; preds = %45
   %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
@@ -6847,15 +8293,15 @@ entry:
 ; <label>:57                                      ; preds = %51
   %58 = load i16*, i16** %arg1
   %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
-  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %60
 
 ; <label>:60                                      ; preds = %57
   %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
   %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
-  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %64
 
 ; <label>:64                                      ; preds = %60
   %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
@@ -6864,22 +8310,22 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
   %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
-  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %70
 
 ; <label>:70                                      ; preds = %64
   %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
   %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
-  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
-  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
   %75 = load i32, i32 addrspace(1)* %74
   %76 = zext i32 %75 to i64
   %77 = trunc i64 %76 to i32
-  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
-  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %78
 
 ; <label>:78                                      ; preds = %73
   %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
@@ -6901,8 +8347,8 @@ entry:
   %90 = bitcast i16* %86 to i8*
   %91 = getelementptr inbounds i8, i8* %90, i64 %89
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %93
 
 ; <label>:93                                      ; preds = %80
   %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
@@ -6912,8 +8358,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %99 = load i32, i32* %loc2
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %100
 
 ; <label>:100                                     ; preds = %93
   %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
@@ -6928,63 +8374,63 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %25
+ThrowNullRef6:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %32
+ThrowNullRef10:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %40
+ThrowNullRef12:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %45
+ThrowNullRef16:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %57
+ThrowNullRef18:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %60
+ThrowNullRef20:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %64
+ThrowNullRef22:                                   ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %70
+ThrowNullRef24:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %73
+ThrowNullRef26:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %80
+ThrowNullRef28:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %93
+ThrowNullRef30:                                   ; preds = %93
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7004,8 +8450,8 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
@@ -7033,43 +8479,43 @@ entry:
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %14
   %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
   %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   %28 = load i32, i32 addrspace(1)* %27, align 8
   %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
-  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %30
 
 ; <label>:30                                      ; preds = %26
   %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
   %32 = load i32, i32 addrspace(1)* %31, align 8
   %33 = add i32 %28, %32
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %34
 
 ; <label>:34                                      ; preds = %30
   %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   store i32 %33, i32 addrspace(1)* %35
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
   store i32 0, i32 addrspace(1)* %38
   %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %40
 
 ; <label>:40                                      ; preds = %37
   %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
@@ -7082,8 +8528,8 @@ entry:
 
 ; <label>:47                                      ; preds = %40
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
@@ -7098,8 +8544,8 @@ entry:
   %54 = load i32, i32* %loc0
   %55 = sext i32 %54 to i64
   %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
-  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %57
 
 ; <label>:57                                      ; preds = %52
   %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
@@ -7110,68 +8556,35 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %14
+ThrowNullRef2:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %23
+ThrowNullRef4:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %26
+ThrowNullRef6:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %30
+ThrowNullRef8:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %34
+ThrowNullRef10:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %47
+ThrowNullRef14:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %52
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-}
-
-INFO:  jitting method StringBuilder::get_Length using LLILCJit
-Successfully read StringBuilder.get_Length
-
-define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.StringBuilder addrspace(1)*
-  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
-  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
-
-; <label>:1                                       ; preds = %entry
-  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %3 = load i32, i32 addrspace(1)* %2, align 8
-  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
-
-; <label>:5                                       ; preds = %1
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = add i32 %3, %7
-  ret i32 %8
-
-ThrowNullRef:                                     ; preds = %entry
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef16:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7213,70 +8626,70 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
   %6 = load i32, i32 addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
   store i32 %6, i32 addrspace(1)* %8
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
   %13 = load i32, i32 addrspace(1)* %12, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
   store i32 %13, i32 addrspace(1)* %15
   %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
-  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %18
 
 ; <label>:18                                      ; preds = %14
   %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
   %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
   %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
   %34 = load i32, i32 addrspace(1)* %33, align 8
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
-  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
@@ -7287,39 +8700,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %28
+ThrowNullRef16:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %32
+ThrowNullRef18:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7455,13 +8868,13 @@ entry:
 ; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
@@ -7477,16 +8890,16 @@ entry:
 
 ; <label>:18                                      ; preds = %15
   %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
   store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
   %22 = load i32, i32* %loc0
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %24
 
 ; <label>:24                                      ; preds = %20
   %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
@@ -7498,13 +8911,13 @@ entry:
 ; <label>:28                                      ; preds = %15, %24
   %29 = load i32, i32* %arg1
   %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %31
   %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
@@ -7517,20 +8930,20 @@ entry:
   %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
-  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
   %46 = load i32, i32 addrspace(1)* %45, align 8
   %47 = sub i32 %40, %46
-  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
-  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i32 addrspace(1)* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %48
 
 ; <label>:48                                      ; preds = %44
   store i32 %47, i32 addrspace(1)* %39, align 8
@@ -7538,21 +8951,21 @@ entry:
 
 ; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
-  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %51
 
 ; <label>:51                                      ; preds = %49
   %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %53
 
 ; <label>:53                                      ; preds = %51
   %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
   %55 = load i32, i32 addrspace(1)* %54, align 8
   %56 = load i32, i32* %arg2
   %57 = sub i32 %55, %56
-  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %58
 
 ; <label>:58                                      ; preds = %53
   %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
@@ -7562,13 +8975,13 @@ entry:
 ; <label>:60                                      ; preds = %33, %58
   %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
   %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
-  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %63
 
 ; <label>:63                                      ; preds = %60
   %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
-  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
-  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
@@ -7578,15 +8991,15 @@ entry:
 
 ; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
-  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i32 addrspace(1)* %69, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %70
 
 ; <label>:70                                      ; preds = %68
   %71 = load i32, i32 addrspace(1)* %69, align 8
   store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
-  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
@@ -7596,8 +9009,8 @@ entry:
   store i32 %77, i32* %loc4
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
-  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %80
 
 ; <label>:80                                      ; preds = %73
   %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
@@ -7607,71 +9020,71 @@ entry:
 ; <label>:83                                      ; preds = %80
   store i32 0, i32* %loc3
   %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
-  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
-  br i1 %NullCheck26, label %88, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i32 addrspace(1)* %87, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %88
 
 ; <label>:88                                      ; preds = %85
   %89 = load i32, i32 addrspace(1)* %87, align 8
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
-  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %90
 
 ; <label>:90                                      ; preds = %88
   %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
   store i32 %89, i32 addrspace(1)* %91
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
-  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
-  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %96
 
 ; <label>:96                                      ; preds = %94
   %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
-  br i1 %NullCheck34, label %100, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %100
 
 ; <label>:100                                     ; preds = %96
   %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
-  br i1 %NullCheck36, label %102, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %102
 
 ; <label>:102                                     ; preds = %100
   %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
   %104 = load i32, i32 addrspace(1)* %103, align 8
   %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
-  br i1 %NullCheck38, label %106, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %106
 
 ; <label>:106                                     ; preds = %102
   %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
-  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
-  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %108
 
 ; <label>:108                                     ; preds = %106
   %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
   %110 = load i32, i32 addrspace(1)* %109, align 8
   %111 = add i32 %104, %110
-  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %112
 
 ; <label>:112                                     ; preds = %108
   %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
   store i32 %111, i32 addrspace(1)* %113
   %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
-  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i32 addrspace(1)* %114, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %115
 
 ; <label>:115                                     ; preds = %112
   %116 = load i32, i32 addrspace(1)* %114, align 8
@@ -7681,19 +9094,19 @@ entry:
 ; <label>:118                                     ; preds = %115
   %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
-  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %121
 
 ; <label>:121                                     ; preds = %118
   %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
-  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
-  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %123
 
 ; <label>:123                                     ; preds = %121
   %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
   %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
-  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
-  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %126
 
 ; <label>:126                                     ; preds = %123
   %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
@@ -7705,8 +9118,8 @@ entry:
 
 ; <label>:130                                     ; preds = %80, %115, %126
   %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %132
 
 ; <label>:132                                     ; preds = %130
   %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7715,8 +9128,8 @@ entry:
   %136 = load i32, i32* %loc3
   %137 = sub i32 %135, %136
   %138 = sub i32 %134, %137
-  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %139
 
 ; <label>:139                                     ; preds = %132
   %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7728,16 +9141,16 @@ entry:
 
 ; <label>:144                                     ; preds = %139
   %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
-  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %146
 
 ; <label>:146                                     ; preds = %144
   %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
   %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
   %149 = load i32, i32* %loc2
   %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
-  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %151
 
 ; <label>:151                                     ; preds = %146
   %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
@@ -7754,145 +9167,249 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %18
+ThrowNullRef4:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %31
+ThrowNullRef10:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %44
+ThrowNullRef16:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %68
+ThrowNullRef18:                                   ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %70
+ThrowNullRef20:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %73
+ThrowNullRef22:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %83
+ThrowNullRef24:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %85
+ThrowNullRef26:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %88
+ThrowNullRef28:                                   ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %90
+ThrowNullRef30:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %94
+ThrowNullRef32:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %96
+ThrowNullRef34:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %100
+ThrowNullRef36:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %102
+ThrowNullRef38:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %106
+ThrowNullRef40:                                   ; preds = %106
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %108
+ThrowNullRef42:                                   ; preds = %108
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %112
+ThrowNullRef44:                                   ; preds = %112
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %118
+ThrowNullRef46:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %121
+ThrowNullRef48:                                   ; preds = %121
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %123
+ThrowNullRef50:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %130
+ThrowNullRef52:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %132
+ThrowNullRef54:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %144
+ThrowNullRef56:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %146
+ThrowNullRef58:                                   ; preds = %146
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %60
+ThrowNullRef60:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %63
+ThrowNullRef62:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %49
+ThrowNullRef64:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %51
+ThrowNullRef66:                                   ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %53
+ThrowNullRef68:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(%"System.Char[]" addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %arg0 = alloca %"System.Char[]" addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store %"System.Char[]" addrspace(1)* %param0, %"System.Char[]" addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load i32, i32* %arg4
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %43, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %38, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg1
+  %13 = load i32, i32* %arg4
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %38, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %24 = load i32, i32* %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %35 = load i32, i32* %arg3
+  %36 = load i32, i32* %arg4
+  %37 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %37, %"System.Char[]" addrspace(1)* %34, i32 %35, i32 %36)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:38                                      ; preds = %5, %16
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Successfully read Buffer._Memmove
 
@@ -7914,7 +9431,7 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[loadElem]
+Failed to read AppDomain.SetDataHelper[storeElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -7923,8 +9440,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
@@ -7934,8 +9451,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
@@ -7947,15 +9464,15 @@ entry:
   %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
   %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
@@ -7966,15 +9483,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7992,7 +9509,79 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
-Failed to read Dictionary`2.TryGetValue[loadElemA]
+Successfully read Dictionary`2.TryGetValue
+
+define i8 @"Dictionary`2.TryGetValue"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)* addrspace(1)* %param2) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  %arg2 = alloca %System.__Canon addrspace(1)* addrspace(1)*
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  store %System.__Canon addrspace(1)* addrspace(1)* %param2, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  store i32 %2, i32* %loc0
+  %3 = load i32, i32* %loc0
+  %4 = icmp slt i32 %3, 0
+  br i1 %4, label %22, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 2
+  %10 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %9, align 8
+  %11 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = zext i32 %11 to i64
+  %BoundsCheck = icmp uge i64 %16, %15
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 3, i32 %11
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %20, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %6, %System.__Canon addrspace(1)* %21)
+  ret i8 1
+
+; <label>:22                                      ; preds = %entry
+  %23 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %23, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -8058,8 +9647,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
@@ -8091,8 +9680,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
@@ -8171,15 +9760,15 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck, label %19, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %ThrowNullRef, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
   %21 = load i32, i32 addrspace(1)* %20
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
@@ -8202,7 +9791,7 @@ ThrowNullRef:                                     ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %19
+ThrowNullRef2:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8248,8 +9837,8 @@ entry:
   %0 = alloca %System.AppDomainHandle
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %1 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %1, i32 0, i32 15
@@ -8269,8 +9858,8 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
@@ -8286,7 +9875,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -8299,8 +9888,8 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -8327,8 +9916,8 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
@@ -8352,8 +9941,8 @@ entry:
   %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
   store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
@@ -8363,8 +9952,8 @@ entry:
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
@@ -8374,8 +9963,8 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %9
   %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
@@ -8384,8 +9973,8 @@ entry:
 
 ; <label>:18                                      ; preds = %3, %16
   %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
@@ -8397,15 +9986,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %18
+ThrowNullRef6:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8418,8 +10007,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
@@ -8453,15 +10042,15 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
@@ -8473,7 +10062,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8481,7 +10070,7 @@ ThrowNullRef1:                                    ; preds = %1
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
 Failed to read Dictionary`2.System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
@@ -8506,8 +10095,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
@@ -8524,8 +10113,8 @@ entry:
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -8544,7 +10133,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8577,8 +10166,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = load i64, i64* %arg2
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = trunc i32 %3 to i8
@@ -8634,46 +10223,46 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
   %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
-  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
-  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
-  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
@@ -8684,27 +10273,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %20
+ThrowNullRef12:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8717,8 +10306,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -8756,22 +10345,22 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
   %9 = load i64, i64 addrspace(1)* %8, align 8
   %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
   %13 = load i64, i64 addrspace(1)* %12, align 8
   %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %11
   %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
@@ -8788,11 +10377,11 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8882,8 +10471,8 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
@@ -8900,8 +10489,8 @@ entry:
 ; <label>:8                                       ; preds = %1
   %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
   %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
@@ -8911,15 +10500,15 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
   %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
   %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
-  br i1 %NullCheck6, label %21, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
@@ -8946,15 +10535,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8992,15 +10581,15 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
   store i8 %3, i8 addrspace(1)* %5
   %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
@@ -9011,7 +10600,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9027,8 +10616,8 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -9041,8 +10630,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
@@ -9058,7 +10647,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9080,8 +10669,8 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
@@ -9096,8 +10685,8 @@ entry:
 ; <label>:12                                      ; preds = %6
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
@@ -9112,8 +10701,8 @@ entry:
 ; <label>:21                                      ; preds = %15
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
@@ -9128,8 +10717,8 @@ entry:
 ; <label>:30                                      ; preds = %24
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %31, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
@@ -9144,8 +10733,8 @@ entry:
 ; <label>:39                                      ; preds = %33
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
-  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %40, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %42
 
 ; <label>:42                                      ; preds = %39
   %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
@@ -9164,19 +10753,19 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %21
+ThrowNullRef4:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %30
+ThrowNullRef6:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %39
+ThrowNullRef8:                                    ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9243,8 +10832,8 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
@@ -9264,57 +10853,57 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
   store i8 0, i8 addrspace(1)* %2
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
   store i8 0, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
   store i8 0, i8 addrspace(1)* %17
   %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
   store i8 0, i8 addrspace(1)* %20
   %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
-  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
@@ -9325,31 +10914,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %19
+ThrowNullRef14:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9367,8 +10956,8 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
@@ -9380,8 +10969,8 @@ entry:
 
 ; <label>:9                                       ; preds = %4
   %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %9
   %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
@@ -9395,7 +10984,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef2:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9420,8 +11009,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
@@ -9512,8 +11101,8 @@ entry:
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
@@ -9524,8 +11113,8 @@ entry:
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = load i64, i64 addrspace(1)* %12
@@ -9537,8 +11126,8 @@ entry:
   %20 = load i64, i64* %19
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
-  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %13
   %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
@@ -9555,8 +11144,8 @@ entry:
 ; <label>:30                                      ; preds = %25
   %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %32 = load i32, i32* %arg2
-  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
-  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
@@ -9570,15 +11159,15 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %30
+ThrowNullRef2:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9622,87 +11211,87 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
   %10 = load i8, i8 addrspace(1)* %9, align 8
   %11 = zext i8 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %8
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
   store i8 %12, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
   %19 = load i8, i8 addrspace(1)* %18, align 8
   %20 = zext i8 %19 to i32
   %21 = trunc i32 %20 to i8
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
   store i8 %21, i8 addrspace(1)* %23
   %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
   %28 = load i8, i8 addrspace(1)* %27, align 8
   %29 = zext i8 %28 to i32
   %30 = trunc i32 %29 to i8
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
-  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %31
 
 ; <label>:31                                      ; preds = %26
   %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
   store i8 %30, i8 addrspace(1)* %32
   %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
-  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
-  br i1 %NullCheck14, label %40, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %40
 
 ; <label>:40                                      ; preds = %35
   %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
   store i8 %39, i8 addrspace(1)* %41
   %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
-  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %44
 
 ; <label>:44                                      ; preds = %40
   %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
   %46 = load i8, i8 addrspace(1)* %45, align 8
   %47 = zext i8 %46 to i32
   %48 = trunc i32 %47 to i8
-  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
   store i8 %48, i8 addrspace(1)* %50
   %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
-  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
@@ -9713,29 +11302,29 @@ entry:
 ; <label>:56                                      ; preds = %52
   %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
-  br i1 %NullCheck22, label %59, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
   %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
   %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
-  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
-  br i1 %NullCheck24, label %63, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
   %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
-  br i1 %NullCheck26, label %66, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
   %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
-  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
-  br i1 %NullCheck28, label %69, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %69
 
 ; <label>:69                                      ; preds = %66
   %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
@@ -9744,15 +11333,15 @@ entry:
 
 ; <label>:71                                      ; preds = %105
   %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
-  br i1 %NullCheck34, label %73, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %73
 
 ; <label>:73                                      ; preds = %71
   %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
   %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
   %76 = load i32, i32* %loc0
-  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
-  br i1 %NullCheck36, label %77, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
@@ -9766,8 +11355,8 @@ entry:
 
 ; <label>:83                                      ; preds = %77
   %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
-  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
@@ -9775,14 +11364,14 @@ entry:
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
   %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
-  br i1 %NullCheck40, label %91, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
 ; <label>:91                                      ; preds = %85
   %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
   %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
-  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck42, label %94, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %94
 
 ; <label>:94                                      ; preds = %91
   %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
@@ -9798,14 +11387,14 @@ entry:
 ; <label>:99                                      ; preds = %69, %96
   %100 = load i32, i32* %loc0
   %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
-  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %102
 
 ; <label>:102                                     ; preds = %99
   %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
   %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
-  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
-  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
@@ -9819,87 +11408,87 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %26
+ThrowNullRef10:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %31
+ThrowNullRef12:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %35
+ThrowNullRef14:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %40
+ThrowNullRef16:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %56
+ThrowNullRef22:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %59
+ThrowNullRef24:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %63
+ThrowNullRef26:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %66
+ThrowNullRef28:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %102
+ThrowNullRef32:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %71
+ThrowNullRef34:                                   ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %73
+ThrowNullRef36:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %83
+ThrowNullRef38:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %85
+ThrowNullRef40:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %91
+ThrowNullRef42:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9943,15 +11532,15 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
   %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
@@ -9961,28 +11550,28 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
   %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %12
   %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
   %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
   %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
-  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
@@ -9993,23 +11582,23 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %12
+ThrowNullRef6:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10031,15 +11620,15 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
   %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = load i64, i64 addrspace(1)* %7
@@ -10077,13 +11666,13 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[loadElem]
+Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -10111,8 +11700,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -10167,8 +11756,8 @@ entry:
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load double, double* %arg0
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -10302,8 +11891,8 @@ entry:
   store i64 %param0, i64* %arg0
   store i64 %param1, i64* %arg1
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
@@ -10311,8 +11900,8 @@ entry:
   %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
   %5 = load i16*, i16* addrspace(1)* %4, align 8
   %6 = addrspacecast i64* %arg1 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = bitcast i64 addrspace(1)* %6 to i8 addrspace(1)*
@@ -10328,7 +11917,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10362,8 +11951,8 @@ entry:
   %1 = load i32, i32* %arg1
   %2 = sext i32 %1 to i64
   %3 = inttoptr i64 %2 to i16*
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -10416,8 +12005,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, i32)*)(%System.IO.ConsoleStream addrspace(1)* %2, i32 %1)
   %3 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %4 = load i64, i64* %arg1
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
@@ -10428,8 +12017,8 @@ entry:
   %10 = icmp eq i32 %9, 3
   %11 = sext i1 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %5
   %14 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, i32 0, i32 5
@@ -10440,7 +12029,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10463,8 +12052,8 @@ entry:
   %5 = icmp eq i32 %4, 1
   %6 = sext i1 %5 to i32
   %7 = trunc i32 %6 to i8
-  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %2, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.ConsoleStream addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
@@ -10475,8 +12064,8 @@ entry:
   %13 = icmp eq i32 %12, 2
   %14 = sext i1 %13 to i32
   %15 = trunc i32 %14 to i8
-  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %10, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.ConsoleStream addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %8
   %17 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %10, i32 0, i32 4
@@ -10487,7 +12076,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10526,8 +12115,8 @@ entry:
   %arg0 = alloca i64
   store i64 %param0, i64* %arg0
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
@@ -10562,8 +12151,8 @@ entry:
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
   %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = load i64, i64 addrspace(1)* %7
@@ -10667,7 +12256,127 @@ entry:
 INFO:  jitting method Encoding::GetEncoding using LLILCJit
 Failed to read Encoding.GetEncoding[convertToHelperArgumentType]
 INFO:  jitting method EncodingProvider::GetEncodingFromProvider using LLILCJit
-Failed to read EncodingProvider.GetEncodingFromProvider[loadElem]
+Successfully read EncodingProvider.GetEncodingFromProvider
+
+define %System.Text.Encoding addrspace(1)* @EncodingProvider.GetEncodingFromProvider(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca %"System.Text.EncodingProvider[]" addrspace(1)*
+  %loc1 = alloca %System.Text.EncodingProvider addrspace(1)*
+  %loc2 = alloca %System.Text.Encoding addrspace(1)*
+  %loc3 = alloca %System.Text.Encoding addrspace(1)*
+  %loc4 = alloca %"System.Text.EncodingProvider[]" addrspace(1)*
+  %loc5 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1059)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2392
+  %2 = addrspacecast i8 addrspace(1)* %1 to %"System.Text.EncodingProvider[]" addrspace(1)**
+  %3 = load volatile %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %2
+  %4 = icmp ne %"System.Text.EncodingProvider[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %entry
+  ret %System.Text.Encoding addrspace(1)* null
+
+; <label>:6                                       ; preds = %entry
+  %7 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1059)
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i64 2392
+  %9 = addrspacecast i8 addrspace(1)* %8 to %"System.Text.EncodingProvider[]" addrspace(1)**
+  %10 = load volatile %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %9
+  store %"System.Text.EncodingProvider[]" addrspace(1)* %10, %"System.Text.EncodingProvider[]" addrspace(1)** %loc0
+  %11 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc0
+  store %"System.Text.EncodingProvider[]" addrspace(1)* %11, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  store i32 0, i32* %loc5
+  br label %43
+
+; <label>:12                                      ; preds = %46
+  %13 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  %14 = load i32, i32* %loc5
+  %NullCheck1 = icmp eq %"System.Text.EncodingProvider[]" addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %13, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = zext i32 %17 to i64
+  %19 = zext i32 %14 to i64
+  %BoundsCheck = icmp uge i64 %19, %18
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %20
+
+; <label>:20                                      ; preds = %15
+  %21 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %13, i32 0, i32 3, i32 %14
+  %22 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)* addrspace(1)* %21, align 8
+  store %System.Text.EncodingProvider addrspace(1)* %22, %System.Text.EncodingProvider addrspace(1)** %loc1
+  %23 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)** %loc1
+  %24 = load i32, i32* %arg0
+  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i64 addrspace(1)*
+  %NullCheck3 = icmp eq i64 addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
+
+; <label>:26                                      ; preds = %20
+  %27 = load i64, i64 addrspace(1)* %25
+  %28 = add i64 %27, 64
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 40
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Text.Encoding addrspace(1)* (%System.Text.EncodingProvider addrspace(1)*, i32)*
+  %35 = call %System.Text.Encoding addrspace(1)* %34(%System.Text.EncodingProvider addrspace(1)* %23, i32 %24)
+  store %System.Text.Encoding addrspace(1)* %35, %System.Text.Encoding addrspace(1)** %loc2
+  %36 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc2
+  %37 = icmp eq %System.Text.Encoding addrspace(1)* %36, null
+  br i1 %37, label %40, label %38
+
+; <label>:38                                      ; preds = %26
+  %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc2
+  store %System.Text.Encoding addrspace(1)* %39, %System.Text.Encoding addrspace(1)** %loc3
+  br label %53
+
+; <label>:40                                      ; preds = %26
+  %41 = load i32, i32* %loc5
+  %42 = add i32 %41, 1
+  store i32 %42, i32* %loc5
+  br label %43
+
+; <label>:43                                      ; preds = %6, %40
+  %44 = load i32, i32* %loc5
+  %45 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  %NullCheck = icmp eq %"System.Text.EncodingProvider[]" addrspace(1)* %45, null
+  br i1 %NullCheck, label %ThrowNullRef, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp slt i32 %44, %50
+  br i1 %51, label %12, label %52
+
+; <label>:52                                      ; preds = %46
+  ret %System.Text.Encoding addrspace(1)* null
+
+; <label>:53                                      ; preds = %38
+  %54 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc3
+  ret %System.Text.Encoding addrspace(1)* %54
+
+ThrowNullRef:                                     ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method EncodingProvider::.cctor using LLILCJit
 Successfully read EncodingProvider..cctor
 
@@ -10686,7 +12395,7 @@ Failed to read Encoding.get_InternalSyncObject[Call HasTypeArg]
 INFO:  jitting method Hashtable::.ctor using LLILCJit
 Failed to read Hashtable..ctor[Volatile store]
 INFO:  jitting method Hashtable::get_Item using LLILCJit
-Failed to read Hashtable.get_Item[loadElemA]
+Failed to read Hashtable.get_Item[loadNonPrimitiveObj]
 INFO:  jitting method Hashtable::InitHash using LLILCJit
 Successfully read Hashtable.InitHash
 
@@ -10706,8 +12415,8 @@ entry:
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -10723,15 +12432,15 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
   %15 = load i32, i32* %loc0
-  %NullCheck2 = icmp ne i32 addrspace(1)* %14, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i32 addrspace(1)* %14, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %3
   store i32 %15, i32 addrspace(1)* %14, align 8
   %17 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %18 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %NullCheck4 = icmp ne i32 addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i32 addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = load i32, i32 addrspace(1)* %18, align 8
@@ -10740,8 +12449,8 @@ entry:
   %23 = sub i32 %22, 1
   %24 = urem i32 %21, %23
   %25 = add i32 1, %24
-  %NullCheck6 = icmp ne i32 addrspace(1)* %17, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32 addrspace(1)* %17, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %19
   store i32 %25, i32 addrspace(1)* %17, align 8
@@ -10752,15 +12461,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %19
+ThrowNullRef6:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10775,8 +12484,8 @@ entry:
   store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
   store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %NullCheck = icmp ne %System.Collections.Hashtable addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Collections.Hashtable addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
@@ -10786,16 +12495,16 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Collections.Hashtable addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Collections.Hashtable addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
   %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck4 = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %9, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
   %13 = inttoptr i64 %11 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
@@ -10805,8 +12514,8 @@ entry:
 ; <label>:15                                      ; preds = %1
   %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -10824,15 +12533,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10846,8 +12555,8 @@ entry:
   store %System.Int32 addrspace(1)* %param0, %System.Int32 addrspace(1)** %this
   %0 = load %System.Int32 addrspace(1)*, %System.Int32 addrspace(1)** %this
   %1 = bitcast %System.Int32 addrspace(1)* %0 to i32 addrspace(1)*
-  %NullCheck = icmp ne i32 addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq i32 addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load i32, i32 addrspace(1)* %1, align 8
@@ -10923,8 +12632,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.UTF8Encoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
@@ -10933,15 +12642,15 @@ entry:
   %9 = load i8, i8* %arg2
   %10 = zext i8 %9 to i32
   %11 = trunc i32 %10 to i8
-  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %8, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %6
   %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %8, i32 0, i32 8
   store i8 %11, i8 addrspace(1)* %13
   %14 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %14, i32 0, i32 8
@@ -10953,8 +12662,8 @@ entry:
 ; <label>:20                                      ; preds = %15
   %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %22, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %22, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = load i64, i64 addrspace(1)* %22
@@ -10976,15 +12685,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %12
+ThrowNullRef4:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10999,8 +12708,8 @@ entry:
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
@@ -11022,16 +12731,16 @@ entry:
 ; <label>:10                                      ; preds = %1
   %11 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
   %12 = load i32, i32* %arg1
-  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %11, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.Encoding addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
   store i32 %12, i32 addrspace(1)* %14
   %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
   %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = load i64, i64 addrspace(1)* %16
@@ -11049,11 +12758,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11066,8 +12775,8 @@ entry:
   %this = alloca %System.Text.UTF8Encoding addrspace(1)*
   store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
   %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.UTF8Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
@@ -11079,16 +12788,16 @@ entry:
 ; <label>:6                                       ; preds = %1
   %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %8 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %10, %System.Text.EncoderFallback addrspace(1)* %8)
   %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %12 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
-  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %11, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %11, i32 0, i32 3
@@ -11101,8 +12810,8 @@ entry:
   %18 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %18, %System.String addrspace(1)* %17)
   %19 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %18 to %System.Text.EncoderFallback addrspace(1)*
-  %NullCheck6 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %16, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %16, i32 0, i32 2
@@ -11112,8 +12821,8 @@ entry:
   %24 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %24, %System.String addrspace(1)* %23)
   %25 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %24 to %System.Text.DecoderFallback addrspace(1)*
-  %NullCheck8 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %22, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %22, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %20
   %27 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %22, i32 0, i32 3
@@ -11124,19 +12833,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %20
+ThrowNullRef8:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11166,8 +12875,8 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load i32, i32* %arg1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -11185,8 +12894,8 @@ entry:
 ; <label>:15                                      ; preds = %8
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %17 = load i32, i32* %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 %17
@@ -11202,7 +12911,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11254,7 +12963,7 @@ entry:
 }
 
 INFO:  jitting method Hashtable::Insert using LLILCJit
-Failed to read Hashtable.Insert[loadElemA]
+Failed to read Hashtable.Insert[storeElem]
 INFO:  jitting method ConsoleEncoding::.ctor using LLILCJit
 Successfully read ConsoleEncoding..ctor
 
@@ -11269,8 +12978,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %1)
   %2 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
@@ -11306,8 +13015,8 @@ entry:
   %2 = call %System.Text.InternalEncoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalEncoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %1)
   %3 = bitcast %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2 to %System.Text.EncoderFallback addrspace(1)*
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
@@ -11317,8 +13026,8 @@ entry:
   %8 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %7)
   %9 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %8 to %System.Text.DecoderFallback addrspace(1)*
-  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %6, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.Encoding addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %4
   %11 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %6, i32 0, i32 3
@@ -11329,7 +13038,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11348,15 +13057,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* %1)
   %2 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   %6 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, i32 0, i32 1
@@ -11367,7 +13076,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11395,8 +13104,8 @@ entry:
   store %System.Text.InternalDecoderBestFitFallback addrspace(1)* %param0, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
   %0 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
@@ -11406,15 +13115,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %4)
   %5 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %6)
   %9 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, i32 0, i32 1
@@ -11425,11 +13134,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11497,8 +13206,8 @@ entry:
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
   %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = load i64, i64 addrspace(1)* %19
@@ -11562,8 +13271,8 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.ConsoleStream addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
@@ -11594,31 +13303,31 @@ entry:
   store i8 %param4, i8* %arg4
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %3, %System.IO.Stream addrspace(1)* %1)
   %4 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %4, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
   %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %4, i32 0, i32 4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %5)
   %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %6
   %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
   %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
   %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = load i64, i64 addrspace(1)* %13
@@ -11630,8 +13339,8 @@ entry:
   %21 = load i64, i64* %20
   %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %8, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %8, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %14
   %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 5
@@ -11649,24 +13358,24 @@ entry:
   %31 = load i32, i32* %arg3
   %32 = sext i32 %31 to i64
   %33 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %32)
-  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %30, null
-  br i1 %NullCheck10, label %34, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.StreamWriter addrspace(1)* %30, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %35, %"System.Char[]" addrspace(1)* %33)
   %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %37, null
-  br i1 %NullCheck12, label %38, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.StreamWriter addrspace(1)* %37, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %38
 
 ; <label>:38                                      ; preds = %34
   %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
   %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
   %41 = load i32, i32* %arg3
   %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %42, null
-  br i1 %NullCheck14, label %43, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %42, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
   %44 = load i64, i64 addrspace(1)* %42
@@ -11680,30 +13389,30 @@ entry:
   %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
   %53 = sext i32 %52 to i64
   %54 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %53)
-  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
-  br i1 %NullCheck16, label %55, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %55
 
 ; <label>:55                                      ; preds = %43
   %56 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %56, %"System.Byte[]" addrspace(1)* %54)
   %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %58 = load i32, i32* %arg3
-  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %57, null
-  br i1 %NullCheck18, label %59, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.StreamWriter addrspace(1)* %57, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %59
 
 ; <label>:59                                      ; preds = %55
   %60 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 10
   store i32 %58, i32 addrspace(1)* %60
   %61 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %61, null
-  br i1 %NullCheck20, label %62, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.IO.StreamWriter addrspace(1)* %61, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %62
 
 ; <label>:62                                      ; preds = %59
   %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
   %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
   %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
   %67 = load i64, i64 addrspace(1)* %65
@@ -11721,15 +13430,15 @@ entry:
 
 ; <label>:78                                      ; preds = %66
   %79 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %79, null
-  br i1 %NullCheck24, label %80, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.StreamWriter addrspace(1)* %79, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %80
 
 ; <label>:80                                      ; preds = %78
   %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
   %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
   %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %83, null
-  br i1 %NullCheck26, label %84, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %83, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
   %85 = load i64, i64 addrspace(1)* %83
@@ -11746,8 +13455,8 @@ entry:
 
 ; <label>:95                                      ; preds = %84
   %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.IO.StreamWriter addrspace(1)* %96, null
-  br i1 %NullCheck28, label %97, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.IO.StreamWriter addrspace(1)* %96, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %97
 
 ; <label>:97                                      ; preds = %95
   %98 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 12
@@ -11761,8 +13470,8 @@ entry:
   %103 = icmp eq i32 %102, 0
   %104 = sext i1 %103 to i32
   %105 = trunc i32 %104 to i8
-  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %100, null
-  br i1 %NullCheck30, label %106, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.IO.StreamWriter addrspace(1)* %100, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %106
 
 ; <label>:106                                     ; preds = %99
   %107 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %100, i32 0, i32 13
@@ -11773,63 +13482,63 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %6
+ThrowNullRef4:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %29
+ThrowNullRef10:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %34
+ThrowNullRef12:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %38
+ThrowNullRef14:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %43
+ThrowNullRef16:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %55
+ThrowNullRef18:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %59
+ThrowNullRef20:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %62
+ThrowNullRef22:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %78
+ThrowNullRef24:                                   ; preds = %78
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %80
+ThrowNullRef26:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %95
+ThrowNullRef28:                                   ; preds = %95
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11842,15 +13551,15 @@ entry:
   %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = load i64, i64 addrspace(1)* %4
@@ -11868,7 +13577,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11918,35 +13627,35 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
   %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderNLS addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %7 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.EncoderNLS addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Text.Encoding addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.Encoding addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Text.EncoderNLS addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.EncoderNLS addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
   %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck8 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = load i64, i64 addrspace(1)* %16
@@ -11965,19 +13674,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12003,8 +13712,8 @@ entry:
   %this = alloca %System.Text.Encoding addrspace(1)*
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
@@ -12024,15 +13733,15 @@ entry:
   %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
   store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
   %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
   store i32 0, i32 addrspace(1)* %2
   %3 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, i32 0, i32 2
@@ -12042,15 +13751,15 @@ entry:
 
 ; <label>:8                                       ; preds = %4
   %9 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
   %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
   %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = load i64, i64 addrspace(1)* %13
@@ -12071,15 +13780,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12094,16 +13803,16 @@ entry:
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = load i32, i32* %arg1
   %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
   %7 = load i64, i64 addrspace(1)* %5
@@ -12121,7 +13830,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12158,8 +13867,8 @@ entry:
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
   %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
   %16 = load i64, i64 addrspace(1)* %14
@@ -12180,8 +13889,8 @@ entry:
   %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
   %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
   %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %31, null
-  br i1 %NullCheck2, label %32, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = load i64, i64 addrspace(1)* %31
@@ -12224,7 +13933,7 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12237,14 +13946,14 @@ entry:
   %this = alloca %System.Text.EncoderReplacementFallback addrspace(1)*
   store %System.Text.EncoderReplacementFallback addrspace(1)* %param0, %System.Text.EncoderReplacementFallback addrspace(1)** %this
   %0 = load %System.Text.EncoderReplacementFallback addrspace(1)*, %System.Text.EncoderReplacementFallback addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -12255,7 +13964,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12285,8 +13994,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
@@ -12318,8 +14027,8 @@ entry:
   %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
   store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
@@ -12331,8 +14040,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Threading.Tasks.Task addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %7)
@@ -12355,7 +14064,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12374,8 +14083,8 @@ entry:
   store i8 %param1, i8* %arg1
   store i8 %param2, i8* %arg2
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
@@ -12389,8 +14098,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1, %5
   %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 9
@@ -12421,8 +14130,8 @@ entry:
 
 ; <label>:25                                      ; preds = %8, %20
   %26 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %26, null
-  br i1 %NullCheck4, label %27, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %26, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %26, i32 0, i32 12
@@ -12433,22 +14142,22 @@ entry:
 
 ; <label>:32                                      ; preds = %27
   %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %33, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.IO.StreamWriter addrspace(1)* %33, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %32
   %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 12
   store i8 1, i8 addrspace(1)* %35
   %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
-  br i1 %NullCheck8, label %37, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
   %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
   %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck10 = icmp ne i64 addrspace(1)* %40, null
-  br i1 %NullCheck10, label %41, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64 addrspace(1)* %40, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i64, i64 addrspace(1)* %40
@@ -12462,8 +14171,8 @@ entry:
   %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
   store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
   %51 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %NullCheck12 = icmp ne %"System.Byte[]" addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Byte[]" addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %41
   %53 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %51, i32 0, i32 1
@@ -12475,16 +14184,16 @@ entry:
 
 ; <label>:58                                      ; preds = %52
   %59 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %59, null
-  br i1 %NullCheck14, label %60, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.IO.StreamWriter addrspace(1)* %59, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %60
 
 ; <label>:60                                      ; preds = %58
   %61 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %59, i32 0, i32 3
   %62 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
   %64 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %NullCheck16 = icmp ne %"System.Byte[]" addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %"System.Byte[]" addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %60
   %66 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %64, i32 0, i32 1
@@ -12492,8 +14201,8 @@ entry:
   %68 = zext i32 %67 to i64
   %69 = trunc i64 %68 to i32
   %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck18, label %71, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
   %72 = load i64, i64 addrspace(1)* %70
@@ -12509,29 +14218,29 @@ entry:
 
 ; <label>:80                                      ; preds = %27, %52, %71
   %81 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %81, null
-  br i1 %NullCheck20, label %82, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.IO.StreamWriter addrspace(1)* %81, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
 
 ; <label>:82                                      ; preds = %80
   %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %81, i32 0, i32 5
   %84 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %83, align 8
   %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.IO.StreamWriter addrspace(1)* %85, null
-  br i1 %NullCheck22, label %86, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.IO.StreamWriter addrspace(1)* %85, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %86
 
 ; <label>:86                                      ; preds = %82
   %87 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 7
   %88 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %87, align 8
   %89 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %89, null
-  br i1 %NullCheck24, label %90, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.StreamWriter addrspace(1)* %89, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %90
 
 ; <label>:90                                      ; preds = %86
   %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %89, i32 0, i32 9
   %92 = load i32, i32 addrspace(1)* %91, align 8
   %93 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.IO.StreamWriter addrspace(1)* %93, null
-  br i1 %NullCheck26, label %94, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.IO.StreamWriter addrspace(1)* %93, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %93, i32 0, i32 6
@@ -12539,8 +14248,8 @@ entry:
   %97 = load i8, i8* %arg2
   %98 = zext i8 %97 to i32
   %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
-  %NullCheck28 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck28, label %100, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
   %101 = load i64, i64 addrspace(1)* %99
@@ -12555,8 +14264,8 @@ entry:
   %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
   store i32 %110, i32* %loc1
   %111 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %111, null
-  br i1 %NullCheck30, label %112, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.IO.StreamWriter addrspace(1)* %111, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %112
 
 ; <label>:112                                     ; preds = %100
   %113 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %111, i32 0, i32 9
@@ -12567,23 +14276,23 @@ entry:
 
 ; <label>:116                                     ; preds = %112
   %117 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck32 = icmp ne %System.IO.StreamWriter addrspace(1)* %117, null
-  br i1 %NullCheck32, label %118, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.IO.StreamWriter addrspace(1)* %117, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %118
 
 ; <label>:118                                     ; preds = %116
   %119 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %117, i32 0, i32 3
   %120 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %119, align 8
   %121 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.IO.StreamWriter addrspace(1)* %121, null
-  br i1 %NullCheck34, label %122, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.IO.StreamWriter addrspace(1)* %121, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %122
 
 ; <label>:122                                     ; preds = %118
   %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
   %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
   %125 = load i32, i32* %loc1
   %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
-  %NullCheck36 = icmp ne i64 addrspace(1)* %126, null
-  br i1 %NullCheck36, label %127, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64 addrspace(1)* %126, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
   %128 = load i64, i64 addrspace(1)* %126
@@ -12605,15 +14314,15 @@ entry:
 
 ; <label>:140                                     ; preds = %136
   %141 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.IO.StreamWriter addrspace(1)* %141, null
-  br i1 %NullCheck38, label %142, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.IO.StreamWriter addrspace(1)* %141, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %142
 
 ; <label>:142                                     ; preds = %140
   %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
   %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
   %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
-  %NullCheck40 = icmp ne i64 addrspace(1)* %145, null
-  br i1 %NullCheck40, label %146, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i64 addrspace(1)* %145, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
   %147 = load i64, i64 addrspace(1)* %145
@@ -12634,83 +14343,83 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %25
+ThrowNullRef4:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %32
+ThrowNullRef6:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %37
+ThrowNullRef10:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %41
+ThrowNullRef12:                                   ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %58
+ThrowNullRef14:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %60
+ThrowNullRef16:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %65
+ThrowNullRef18:                                   ; preds = %65
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %80
+ThrowNullRef20:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %82
+ThrowNullRef22:                                   ; preds = %82
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %86
+ThrowNullRef24:                                   ; preds = %86
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %90
+ThrowNullRef26:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %94
+ThrowNullRef28:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %100
+ThrowNullRef30:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %116
+ThrowNullRef32:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %118
+ThrowNullRef34:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %122
+ThrowNullRef36:                                   ; preds = %122
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %140
+ThrowNullRef38:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %142
+ThrowNullRef40:                                   ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12777,8 +14486,8 @@ entry:
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %1 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
-  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
@@ -12786,8 +14495,8 @@ entry:
   %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
   %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
   %8 = load i64, i64 addrspace(1)* %6
@@ -12803,8 +14512,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %17, %System.IFormatProvider addrspace(1)* %16)
   %18 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %19 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %18, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.SyncTextWriter addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %7
   %21 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %18, i32 0, i32 4
@@ -12815,11 +14524,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12832,8 +14541,8 @@ entry:
   %this = alloca %System.IO.TextWriter addrspace(1)*
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.TextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
@@ -12843,8 +14552,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.Threading.Thread addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Threading.Thread addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %6)
@@ -12853,8 +14562,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1
   %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.TextWriter addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.TextWriter addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %11, i32 0, i32 2
@@ -12865,11 +14574,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13066,8 +14775,8 @@ entry:
   store double %param1, double* %arg1
   store i8 0, i8* %loc1
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
@@ -13077,16 +14786,16 @@ entry:
   %5 = addrspacecast i8* %loc1 to i8 addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %4, i8 addrspace(1)* %5)
   %6 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.SyncTextWriter addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
   %10 = load double, double* %arg1
   %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
   %13 = load i64, i64 addrspace(1)* %11
@@ -13121,11 +14830,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13142,8 +14851,8 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load double, double* %arg1
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -13157,8 +14866,8 @@ entry:
   call void %11(%System.IO.TextWriter addrspace(1)* %0, double %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
   %15 = load i64, i64 addrspace(1)* %13
@@ -13176,7 +14885,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13194,8 +14903,8 @@ entry:
   %1 = addrspacecast double* %arg1 to double addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -13210,8 +14919,8 @@ entry:
   %14 = bitcast double addrspace(1)* %1 to %System.Double addrspace(1)*
   %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Double addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Double addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
   %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
   %18 = load i64, i64 addrspace(1)* %16
@@ -13229,7 +14938,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13245,8 +14954,8 @@ entry:
   store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
   %0 = load %System.Double addrspace(1)*, %System.Double addrspace(1)** %this
   %1 = bitcast %System.Double addrspace(1)* %0 to double addrspace(1)*
-  %NullCheck = icmp ne double addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq double addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load double, double addrspace(1)* %1, align 8
@@ -13271,8 +14980,8 @@ entry:
   %loc0 = alloca %System.Globalization.NumberFormatInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 3
@@ -13282,8 +14991,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
@@ -13293,24 +15002,24 @@ entry:
   store %System.Globalization.NumberFormatInfo addrspace(1)* %10, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
   %11 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %7
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
   %15 = load i8, i8 addrspace(1)* %14, align 8
   %16 = zext i8 %15 to i32
   %17 = trunc i32 %16 to i8
-  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %11, null
-  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %11, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %13
   %19 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %11, i32 0, i32 29
   store i8 %17, i8 addrspace(1)* %19
   %20 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %21 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %20, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %20, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %18
   %23 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %20, i32 0, i32 3
@@ -13319,8 +15028,8 @@ entry:
 
 ; <label>:24                                      ; preds = %1, %22
   %25 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %25, null
-  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %25, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %26
 
 ; <label>:26                                      ; preds = %24
   %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %25, i32 0, i32 3
@@ -13331,23 +15040,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %18
+ThrowNullRef8:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13372,168 +15081,168 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 18
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %8, align 8
-  %NullCheck2 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %5, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %5, i32 0, i32 4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %9)
   %12 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 19
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %15, align 8
-  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %12, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %12, i32 0, i32 5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %16)
   %19 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %20 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %20, null
-  br i1 %NullCheck8, label %21, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %20, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %20, i32 0, i32 23
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  %NullCheck10 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %19, null
-  br i1 %NullCheck10, label %24, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %19, i32 0, i32 7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %25, %System.String addrspace(1)* %23)
   %26 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %27 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %27, i32 0, i32 22
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %29, align 8
-  %NullCheck14 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %26, null
-  br i1 %NullCheck14, label %31, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %26, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %26, i32 0, i32 6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %32, %System.String addrspace(1)* %30)
   %33 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %34 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Globalization.CultureData addrspace(1)* %34, null
-  br i1 %NullCheck16, label %35, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Globalization.CultureData addrspace(1)* %34, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %34, i32 0, i32 51
   %37 = load i32, i32 addrspace(1)* %36, align 8
-  %NullCheck18 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %33, null
-  br i1 %NullCheck18, label %38, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %33, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %33, i32 0, i32 21
   store i32 %37, i32 addrspace(1)* %39
   %40 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %41 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Globalization.CultureData addrspace(1)* %41, null
-  br i1 %NullCheck20, label %42, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Globalization.CultureData addrspace(1)* %41, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %41, i32 0, i32 52
   %44 = load i32, i32 addrspace(1)* %43, align 8
-  %NullCheck22 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %40, null
-  br i1 %NullCheck22, label %45, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %40, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %40, i32 0, i32 25
   store i32 %44, i32 addrspace(1)* %46
   %47 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %48 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.Globalization.CultureData addrspace(1)* %48, null
-  br i1 %NullCheck24, label %49, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Globalization.CultureData addrspace(1)* %48, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %49
 
 ; <label>:49                                      ; preds = %45
   %50 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %48, i32 0, i32 29
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck26 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %47, null
-  br i1 %NullCheck26, label %52, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %47, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %47, i32 0, i32 10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %53, %System.String addrspace(1)* %51)
   %54 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %55 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Globalization.CultureData addrspace(1)* %55, null
-  br i1 %NullCheck28, label %56, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Globalization.CultureData addrspace(1)* %55, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %56
 
 ; <label>:56                                      ; preds = %52
   %57 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %55, i32 0, i32 35
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %57, align 8
-  %NullCheck30 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %54, null
-  br i1 %NullCheck30, label %59, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %54, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %54, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %60, %System.String addrspace(1)* %58)
   %61 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %62 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck32 = icmp ne %System.Globalization.CultureData addrspace(1)* %62, null
-  br i1 %NullCheck32, label %63, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Globalization.CultureData addrspace(1)* %62, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %62, i32 0, i32 34
   %65 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %64, align 8
-  %NullCheck34 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %61, null
-  br i1 %NullCheck34, label %66, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %61, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %61, i32 0, i32 9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %67, %System.String addrspace(1)* %65)
   %68 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %69 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck36 = icmp ne %System.Globalization.CultureData addrspace(1)* %69, null
-  br i1 %NullCheck36, label %70, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Globalization.CultureData addrspace(1)* %69, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %70
 
 ; <label>:70                                      ; preds = %66
   %71 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %69, i32 0, i32 55
   %72 = load i32, i32 addrspace(1)* %71, align 8
-  %NullCheck38 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %68, null
-  br i1 %NullCheck38, label %73, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %68, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %68, i32 0, i32 22
   store i32 %72, i32 addrspace(1)* %74
   %75 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %76 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck40 = icmp ne %System.Globalization.CultureData addrspace(1)* %76, null
-  br i1 %NullCheck40, label %77, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Globalization.CultureData addrspace(1)* %76, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %76, i32 0, i32 57
   %79 = load i32, i32 addrspace(1)* %78, align 8
-  %NullCheck42 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %75, null
-  br i1 %NullCheck42, label %80, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %75, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %80
 
 ; <label>:80                                      ; preds = %77
   %81 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %75, i32 0, i32 24
   store i32 %79, i32 addrspace(1)* %81
   %82 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %83 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck44 = icmp ne %System.Globalization.CultureData addrspace(1)* %83, null
-  br i1 %NullCheck44, label %84, label %ThrowNullRef43
+  %NullCheck43 = icmp eq %System.Globalization.CultureData addrspace(1)* %83, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %84
 
 ; <label>:84                                      ; preds = %80
   %85 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %83, i32 0, i32 56
   %86 = load i32, i32 addrspace(1)* %85, align 8
-  %NullCheck46 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %82, null
-  br i1 %NullCheck46, label %87, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %82, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %82, i32 0, i32 23
@@ -13542,8 +15251,8 @@ entry:
 
 ; <label>:89                                      ; preds = %entry
   %90 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck100 = icmp ne %System.Globalization.CultureData addrspace(1)* %90, null
-  br i1 %NullCheck100, label %91, label %ThrowNullRef99
+  %NullCheck99 = icmp eq %System.Globalization.CultureData addrspace(1)* %90, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %91
 
 ; <label>:91                                      ; preds = %89
   %92 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %90, i32 0, i32 2
@@ -13561,8 +15270,8 @@ entry:
   %102 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %103 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %104 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %103)
-  %NullCheck48 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %102, null
-  br i1 %NullCheck48, label %105, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %102, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %105
 
 ; <label>:105                                     ; preds = %101
   %106 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %102, i32 0, i32 1
@@ -13570,8 +15279,8 @@ entry:
   %107 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %108 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %109 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %108)
-  %NullCheck50 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %107, null
-  br i1 %NullCheck50, label %110, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %107, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %110
 
 ; <label>:110                                     ; preds = %105
   %111 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %107, i32 0, i32 2
@@ -13579,8 +15288,8 @@ entry:
   %112 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %113 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %114 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %113)
-  %NullCheck52 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %112, null
-  br i1 %NullCheck52, label %115, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %112, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %115
 
 ; <label>:115                                     ; preds = %110
   %116 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %112, i32 0, i32 27
@@ -13588,8 +15297,8 @@ entry:
   %117 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %118 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %119 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %118)
-  %NullCheck54 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %117, null
-  br i1 %NullCheck54, label %120, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %117, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %120
 
 ; <label>:120                                     ; preds = %115
   %121 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %117, i32 0, i32 26
@@ -13597,8 +15306,8 @@ entry:
   %122 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %123 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %124 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %123)
-  %NullCheck56 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %122, null
-  br i1 %NullCheck56, label %125, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %122, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %125
 
 ; <label>:125                                     ; preds = %120
   %126 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %122, i32 0, i32 17
@@ -13606,8 +15315,8 @@ entry:
   %127 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %128 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %129 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %128)
-  %NullCheck58 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %127, null
-  br i1 %NullCheck58, label %130, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %127, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %130
 
 ; <label>:130                                     ; preds = %125
   %131 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %127, i32 0, i32 18
@@ -13615,8 +15324,8 @@ entry:
   %132 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %133 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %134 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %133)
-  %NullCheck60 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %132, null
-  br i1 %NullCheck60, label %135, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %132, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %135
 
 ; <label>:135                                     ; preds = %130
   %136 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %132, i32 0, i32 14
@@ -13624,8 +15333,8 @@ entry:
   %137 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %138 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %139 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %138)
-  %NullCheck62 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %137, null
-  br i1 %NullCheck62, label %140, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %137, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %140
 
 ; <label>:140                                     ; preds = %135
   %141 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %137, i32 0, i32 13
@@ -13633,71 +15342,71 @@ entry:
   %142 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %143 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %144 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %143)
-  %NullCheck64 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %142, null
-  br i1 %NullCheck64, label %145, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %142, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %145
 
 ; <label>:145                                     ; preds = %140
   %146 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %142, i32 0, i32 12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %146, %System.String addrspace(1)* %144)
   %147 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %148 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck66 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %148, null
-  br i1 %NullCheck66, label %149, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %148, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %149
 
 ; <label>:149                                     ; preds = %145
   %150 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %148, i32 0, i32 21
   %151 = load i32, i32 addrspace(1)* %150, align 8
-  %NullCheck68 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %147, null
-  br i1 %NullCheck68, label %152, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %147, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %152
 
 ; <label>:152                                     ; preds = %149
   %153 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %147, i32 0, i32 28
   store i32 %151, i32 addrspace(1)* %153
   %154 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %155 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck70 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %155, null
-  br i1 %NullCheck70, label %156, label %ThrowNullRef69
+  %NullCheck69 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %155, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %156
 
 ; <label>:156                                     ; preds = %152
   %157 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %155, i32 0, i32 6
   %158 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %157, align 8
-  %NullCheck72 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %154, null
-  br i1 %NullCheck72, label %159, label %ThrowNullRef71
+  %NullCheck71 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %154, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %159
 
 ; <label>:159                                     ; preds = %156
   %160 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %154, i32 0, i32 15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %160, %System.String addrspace(1)* %158)
   %161 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %162 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck74 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %162, null
-  br i1 %NullCheck74, label %163, label %ThrowNullRef73
+  %NullCheck73 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %162, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %163
 
 ; <label>:163                                     ; preds = %159
   %164 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %162, i32 0, i32 1
   %165 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %164, align 8
-  %NullCheck76 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %161, null
-  br i1 %NullCheck76, label %166, label %ThrowNullRef75
+  %NullCheck75 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %161, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %166
 
 ; <label>:166                                     ; preds = %163
   %167 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %161, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %167, %"System.Int32[]" addrspace(1)* %165)
   %168 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %169 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck78 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %169, null
-  br i1 %NullCheck78, label %170, label %ThrowNullRef77
+  %NullCheck77 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %169, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %170
 
 ; <label>:170                                     ; preds = %166
   %171 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %169, i32 0, i32 7
   %172 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %171, align 8
-  %NullCheck80 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %168, null
-  br i1 %NullCheck80, label %173, label %ThrowNullRef79
+  %NullCheck79 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %168, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %173
 
 ; <label>:173                                     ; preds = %170
   %174 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %168, i32 0, i32 16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %174, %System.String addrspace(1)* %172)
   %175 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck82 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %175, null
-  br i1 %NullCheck82, label %176, label %ThrowNullRef81
+  %NullCheck81 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %175, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %176
 
 ; <label>:176                                     ; preds = %173
   %177 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %175, i32 0, i32 4
@@ -13707,14 +15416,14 @@ entry:
 
 ; <label>:180                                     ; preds = %176
   %181 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck84 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %181, null
-  br i1 %NullCheck84, label %182, label %ThrowNullRef83
+  %NullCheck83 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %181, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %182
 
 ; <label>:182                                     ; preds = %180
   %183 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %181, i32 0, i32 4
   %184 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %183, align 8
-  %NullCheck86 = icmp ne %System.String addrspace(1)* %184, null
-  br i1 %NullCheck86, label %185, label %ThrowNullRef85
+  %NullCheck85 = icmp eq %System.String addrspace(1)* %184, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %185
 
 ; <label>:185                                     ; preds = %182
   %186 = getelementptr inbounds %System.String, %System.String addrspace(1)* %184, i32 0, i32 1
@@ -13725,8 +15434,8 @@ entry:
 ; <label>:189                                     ; preds = %176, %185
   %190 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck98 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %190, null
-  br i1 %NullCheck98, label %192, label %ThrowNullRef97
+  %NullCheck97 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %190, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %192
 
 ; <label>:192                                     ; preds = %189
   %193 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %190, i32 0, i32 4
@@ -13735,8 +15444,8 @@ entry:
 
 ; <label>:194                                     ; preds = %185, %192
   %195 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck88 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %195, null
-  br i1 %NullCheck88, label %196, label %ThrowNullRef87
+  %NullCheck87 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %195, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %196
 
 ; <label>:196                                     ; preds = %194
   %197 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %195, i32 0, i32 9
@@ -13746,14 +15455,14 @@ entry:
 
 ; <label>:200                                     ; preds = %196
   %201 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck90 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %201, null
-  br i1 %NullCheck90, label %202, label %ThrowNullRef89
+  %NullCheck89 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %201, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %202
 
 ; <label>:202                                     ; preds = %200
   %203 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %201, i32 0, i32 9
   %204 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %203, align 8
-  %NullCheck92 = icmp ne %System.String addrspace(1)* %204, null
-  br i1 %NullCheck92, label %205, label %ThrowNullRef91
+  %NullCheck91 = icmp eq %System.String addrspace(1)* %204, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %205
 
 ; <label>:205                                     ; preds = %202
   %206 = getelementptr inbounds %System.String, %System.String addrspace(1)* %204, i32 0, i32 1
@@ -13764,14 +15473,14 @@ entry:
 ; <label>:209                                     ; preds = %196, %205
   %210 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %211 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck94 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %211, null
-  br i1 %NullCheck94, label %212, label %ThrowNullRef93
+  %NullCheck93 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %211, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %212
 
 ; <label>:212                                     ; preds = %209
   %213 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %211, i32 0, i32 6
   %214 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %213, align 8
-  %NullCheck96 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %210, null
-  br i1 %NullCheck96, label %215, label %ThrowNullRef95
+  %NullCheck95 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %210, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %215
 
 ; <label>:215                                     ; preds = %212
   %216 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %210, i32 0, i32 9
@@ -13785,203 +15494,203 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %17
+ThrowNullRef8:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %21
+ThrowNullRef10:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %24
+ThrowNullRef12:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %28
+ThrowNullRef14:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %31
+ThrowNullRef16:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %35
+ThrowNullRef18:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %38
+ThrowNullRef20:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %42
+ThrowNullRef22:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %45
+ThrowNullRef24:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %49
+ThrowNullRef26:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %52
+ThrowNullRef28:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %56
+ThrowNullRef30:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %59
+ThrowNullRef32:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %63
+ThrowNullRef34:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %66
+ThrowNullRef36:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %70
+ThrowNullRef38:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %73
+ThrowNullRef40:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %77
+ThrowNullRef42:                                   ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %80
+ThrowNullRef44:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %84
+ThrowNullRef46:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %101
+ThrowNullRef48:                                   ; preds = %101
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %105
+ThrowNullRef50:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %110
+ThrowNullRef52:                                   ; preds = %110
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %115
+ThrowNullRef54:                                   ; preds = %115
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %120
+ThrowNullRef56:                                   ; preds = %120
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %125
+ThrowNullRef58:                                   ; preds = %125
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %130
+ThrowNullRef60:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %135
+ThrowNullRef62:                                   ; preds = %135
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %140
+ThrowNullRef64:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %145
+ThrowNullRef66:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %149
+ThrowNullRef68:                                   ; preds = %149
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %152
+ThrowNullRef70:                                   ; preds = %152
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %156
+ThrowNullRef72:                                   ; preds = %156
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %159
+ThrowNullRef74:                                   ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %163
+ThrowNullRef76:                                   ; preds = %163
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %166
+ThrowNullRef78:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %170
+ThrowNullRef80:                                   ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %173
+ThrowNullRef82:                                   ; preds = %173
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %180
+ThrowNullRef84:                                   ; preds = %180
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %182
+ThrowNullRef86:                                   ; preds = %182
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %194
+ThrowNullRef88:                                   ; preds = %194
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %200
+ThrowNullRef90:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %202
+ThrowNullRef92:                                   ; preds = %202
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %209
+ThrowNullRef94:                                   ; preds = %209
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %212
+ThrowNullRef96:                                   ; preds = %212
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %189
+ThrowNullRef98:                                   ; preds = %189
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %89
+ThrowNullRef100:                                  ; preds = %89
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14009,8 +15718,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 21
@@ -14023,8 +15732,8 @@ entry:
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 16)
   %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 21
@@ -14033,8 +15742,8 @@ entry:
 
 ; <label>:12                                      ; preds = %1, %10
   %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 21
@@ -14045,11 +15754,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %12
+ThrowNullRef4:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14065,8 +15774,8 @@ entry:
   store i32 %param1, i32* %arg1
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %1 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
@@ -14133,8 +15842,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 33
@@ -14147,8 +15856,8 @@ entry:
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 24)
   %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 33
@@ -14157,8 +15866,8 @@ entry:
 
 ; <label>:12                                      ; preds = %1, %10
   %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 33
@@ -14169,11 +15878,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %12
+ThrowNullRef4:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14186,8 +15895,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 53
@@ -14199,8 +15908,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 116)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 53
@@ -14209,8 +15918,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 53
@@ -14221,11 +15930,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14254,8 +15963,8 @@ entry:
 
 ; <label>:7                                       ; preds = %entry, %4
   %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %7
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 2
@@ -14279,8 +15988,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 54
@@ -14292,8 +16001,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 117)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
@@ -14302,8 +16011,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 54
@@ -14314,11 +16023,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14331,8 +16040,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 27
@@ -14344,8 +16053,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 118)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 27
@@ -14354,8 +16063,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 27
@@ -14366,11 +16075,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14383,8 +16092,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 28
@@ -14396,8 +16105,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 119)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 28
@@ -14406,8 +16115,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 28
@@ -14418,11 +16127,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14435,8 +16144,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 26
@@ -14448,8 +16157,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 107)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 26
@@ -14458,8 +16167,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 26
@@ -14470,11 +16179,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14487,8 +16196,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 25
@@ -14500,8 +16209,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 106)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 25
@@ -14510,8 +16219,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 25
@@ -14522,11 +16231,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14539,8 +16248,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 24
@@ -14552,8 +16261,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 105)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 24
@@ -14562,8 +16271,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 24
@@ -14574,11 +16283,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14603,8 +16312,8 @@ entry:
   %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %3)
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %2
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -14615,15 +16324,15 @@ entry:
 
 ; <label>:8                                       ; preds = %62
   %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 9
   %12 = load i32, i32 addrspace(1)* %11, align 8
   %13 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.IO.StreamWriter addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %13, i32 0, i32 10
@@ -14638,15 +16347,15 @@ entry:
 
 ; <label>:20                                      ; preds = %14, %18
   %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
   %24 = load i32, i32 addrspace(1)* %23, align 8
   %25 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %25, null
-  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.StreamWriter addrspace(1)* %25, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %25, i32 0, i32 9
@@ -14667,36 +16376,36 @@ entry:
   %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %37 = load i32, i32* %loc1
   %38 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.StreamWriter addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %35
   %40 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %38, i32 0, i32 7
   %41 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %40, align 8
   %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
-  br i1 %NullCheck14, label %43, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %39
   %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 9
   %45 = load i32, i32 addrspace(1)* %44, align 8
   %46 = load i32, i32* %loc2
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %36, null
-  br i1 %NullCheck16, label %47, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %36, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %47
 
 ; <label>:47                                      ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %36, i32 %37, %"System.Char[]" addrspace(1)* %41, i32 %45, i32 %46)
   %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
   %51 = load i32, i32 addrspace(1)* %50, align 8
   %52 = load i32, i32* %loc2
   %53 = add i32 %51, %52
-  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
-  br i1 %NullCheck20, label %54, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %54
 
 ; <label>:54                                      ; preds = %49
   %55 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
@@ -14718,8 +16427,8 @@ entry:
 
 ; <label>:65                                      ; preds = %62
   %66 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %66, null
-  br i1 %NullCheck2, label %67, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %66, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %67
 
 ; <label>:67                                      ; preds = %65
   %68 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %66, i32 0, i32 11
@@ -14740,49 +16449,259 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %65
+ThrowNullRef2:                                    ; preds = %65
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %20
+ThrowNullRef8:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %22
+ThrowNullRef10:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %35
+ThrowNullRef12:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %43
+ThrowNullRef16:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %47
+ThrowNullRef18:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method String::CopyTo using LLILCJit
-Failed to read String.CopyTo[loadElemA]
+Successfully read String.CopyTo
+
+define void @String.CopyTo(%System.String addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  %loc1 = alloca i16 addrspace(1)*
+  %loc2 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %1 = icmp ne %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg4
+  %7 = icmp sge i32 %6, 0
+  br i1 %7, label %13, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  unreachable
+
+; <label>:13                                      ; preds = %5
+  %14 = load i32, i32* %arg1
+  %15 = icmp sge i32 %14, 0
+  br i1 %15, label %21, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %18)
+  %20 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %20, %System.String addrspace(1)* %17, %System.String addrspace(1)* %19)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %20) #0
+  unreachable
+
+; <label>:21                                      ; preds = %13
+  %22 = load i32, i32* %arg4
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck, label %ThrowNullRef, label %24
+
+; <label>:24                                      ; preds = %21
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load i32, i32* %arg1
+  %28 = sub i32 %26, %27
+  %29 = icmp sle i32 %22, %28
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34, %System.String addrspace(1)* %31, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %24
+  %36 = load i32, i32* %arg3
+  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %37, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
+
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
+  %40 = load i32, i32 addrspace(1)* %39
+  %41 = zext i32 %40 to i64
+  %42 = trunc i64 %41 to i32
+  %43 = load i32, i32* %arg4
+  %44 = sub i32 %42, %43
+  %45 = icmp sgt i32 %36, %44
+  br i1 %45, label %49, label %46
+
+; <label>:46                                      ; preds = %38
+  %47 = load i32, i32* %arg3
+  %48 = icmp sge i32 %47, 0
+  br i1 %48, label %54, label %49
+
+; <label>:49                                      ; preds = %38, %46
+  %50 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %52 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %51)
+  %53 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53, %System.String addrspace(1)* %50, %System.String addrspace(1)* %52)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53) #0
+  unreachable
+
+; <label>:54                                      ; preds = %46
+  %55 = load i32, i32* %arg4
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %97, label %57
+
+; <label>:57                                      ; preds = %54
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %59
+
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 2
+  %61 = bitcast [0 x i16] addrspace(1)* %60 to i16 addrspace(1)*
+  store i16 addrspace(1)* %61, i16 addrspace(1)** %loc0
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  store %"System.Char[]" addrspace(1)* %62, %"System.Char[]" addrspace(1)** %loc2
+  %63 = icmp eq %"System.Char[]" addrspace(1)* %62, null
+  br i1 %63, label %72, label %64
+
+; <label>:64                                      ; preds = %59
+  %65 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc2
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %65, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %66
+
+; <label>:66                                      ; preds = %64
+  %67 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %65, i32 0, i32 1
+  %68 = load i32, i32 addrspace(1)* %67
+  %69 = zext i32 %68 to i64
+  %70 = trunc i64 %69 to i32
+  %71 = icmp ne i32 %70, 0
+  br i1 %71, label %73, label %72
+
+; <label>:72                                      ; preds = %59, %66
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  br label %81
+
+; <label>:73                                      ; preds = %66
+  %74 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc2
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %74, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %75
+
+; <label>:75                                      ; preds = %73
+  %76 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %74, i32 0, i32 1
+  %77 = load i32, i32 addrspace(1)* %76
+  %78 = zext i32 %77 to i64
+  %BoundsCheck = icmp uge i64 0, %78
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %79
+
+; <label>:79                                      ; preds = %75
+  %80 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %74, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %80, i16 addrspace(1)** %loc1
+  br label %81
+
+; <label>:81                                      ; preds = %72, %79
+  %82 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %83 = ptrtoint i16 addrspace(1)* %82 to i64
+  %84 = load i32, i32* %arg3
+  %85 = sext i32 %84 to i64
+  %86 = mul i64 %85, 2
+  %87 = add i64 %83, %86
+  %88 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %89 = ptrtoint i16 addrspace(1)* %88 to i64
+  %90 = load i32, i32* %arg1
+  %91 = sext i32 %90 to i64
+  %92 = mul i64 %91, 2
+  %93 = add i64 %89, %92
+  %94 = load i32, i32* %arg4
+  %95 = inttoptr i64 %87 to i16*
+  %96 = inttoptr i64 %93 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %95, i16* %96, i32 %94)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  br label %97
+
+; <label>:97                                      ; preds = %54, %81
+  ret void
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
 Successfully read ConsoleEncoding.GetPreamble
 
@@ -14819,7 +16738,365 @@ entry:
 }
 
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[loadElemA]
+Successfully read EncoderNLS.GetBytes
+
+define i32 @EncoderNLS.GetBytes(%System.Text.EncoderNLS addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3, %"System.Byte[]" addrspace(1)* %param4, i32 %param5, i8 %param6) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %arg4 = alloca %"System.Byte[]" addrspace(1)*
+  %arg5 = alloca i32
+  %arg6 = alloca i8
+  %loc0 = alloca i32
+  %loc1 = alloca i16 addrspace(1)*
+  %loc2 = alloca i8 addrspace(1)*
+  %loc3 = alloca i32
+  %loc4 = alloca %"System.Char[]" addrspace(1)*
+  %loc5 = alloca %"System.Byte[]" addrspace(1)*
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  store %"System.Byte[]" addrspace(1)* %param4, %"System.Byte[]" addrspace(1)** %arg4
+  store i32 %param5, i32* %arg5
+  store i8 %param6, i8* %arg6
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %1 = icmp eq %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %17, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %7 = icmp eq %"System.Char[]" addrspace(1)* %6, null
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %12
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %12
+
+; <label>:12                                      ; preds = %8, %10
+  %13 = phi %System.String addrspace(1)* [ %9, %8 ], [ %11, %10 ]
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %14)
+  %16 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16, %System.String addrspace(1)* %13, %System.String addrspace(1)* %15)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16) #0
+  unreachable
+
+; <label>:17                                      ; preds = %2
+  %18 = load i32, i32* %arg2
+  %19 = icmp slt i32 %18, 0
+  br i1 %19, label %23, label %20
+
+; <label>:20                                      ; preds = %17
+  %21 = load i32, i32* %arg3
+  %22 = icmp sge i32 %21, 0
+  br i1 %22, label %35, label %23
+
+; <label>:23                                      ; preds = %17, %20
+  %24 = load i32, i32* %arg2
+  %25 = icmp slt i32 %24, 0
+  br i1 %25, label %28, label %26
+
+; <label>:26                                      ; preds = %23
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %30
+
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %30
+
+; <label>:30                                      ; preds = %26, %28
+  %31 = phi %System.String addrspace(1)* [ %27, %26 ], [ %29, %28 ]
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34, %System.String addrspace(1)* %31, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %20
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck, label %ThrowNullRef, label %37
+
+; <label>:37                                      ; preds = %35
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = load i32, i32* %arg2
+  %43 = sub i32 %41, %42
+  %44 = load i32, i32* %arg3
+  %45 = icmp sge i32 %43, %44
+  br i1 %45, label %51, label %46
+
+; <label>:46                                      ; preds = %37
+  %47 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %48 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %49 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %48)
+  %50 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %50, %System.String addrspace(1)* %47, %System.String addrspace(1)* %49)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %50) #0
+  unreachable
+
+; <label>:51                                      ; preds = %37
+  %52 = load i32, i32* %arg5
+  %53 = icmp slt i32 %52, 0
+  br i1 %53, label %63, label %54
+
+; <label>:54                                      ; preds = %51
+  %55 = load i32, i32* %arg5
+  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck1 = icmp eq %"System.Byte[]" addrspace(1)* %56, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %57
+
+; <label>:57                                      ; preds = %54
+  %58 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = zext i32 %59 to i64
+  %61 = trunc i64 %60 to i32
+  %62 = icmp sle i32 %55, %61
+  br i1 %62, label %68, label %63
+
+; <label>:63                                      ; preds = %51, %57
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %66 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %65)
+  %67 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %67, %System.String addrspace(1)* %64, %System.String addrspace(1)* %66)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %67) #0
+  unreachable
+
+; <label>:68                                      ; preds = %57
+  %69 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %69, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %69, i32 0, i32 1
+  %72 = load i32, i32 addrspace(1)* %71
+  %73 = zext i32 %72 to i64
+  %74 = trunc i64 %73 to i32
+  %75 = icmp ne i32 %74, 0
+  br i1 %75, label %78, label %76
+
+; <label>:76                                      ; preds = %70
+  %77 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1)
+  store %"System.Char[]" addrspace(1)* %77, %"System.Char[]" addrspace(1)** %arg1
+  br label %78
+
+; <label>:78                                      ; preds = %70, %76
+  %79 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck5 = icmp eq %"System.Byte[]" addrspace(1)* %79, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %80
+
+; <label>:80                                      ; preds = %78
+  %81 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %79, i32 0, i32 1
+  %82 = load i32, i32 addrspace(1)* %81
+  %83 = zext i32 %82 to i64
+  %84 = trunc i64 %83 to i32
+  %85 = load i32, i32* %arg5
+  %86 = sub i32 %84, %85
+  store i32 %86, i32* %loc0
+  %87 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck7 = icmp eq %"System.Byte[]" addrspace(1)* %87, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %88
+
+; <label>:88                                      ; preds = %80
+  %89 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %87, i32 0, i32 1
+  %90 = load i32, i32 addrspace(1)* %89
+  %91 = zext i32 %90 to i64
+  %92 = trunc i64 %91 to i32
+  %93 = icmp ne i32 %92, 0
+  br i1 %93, label %96, label %94
+
+; <label>:94                                      ; preds = %88
+  %95 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1)
+  store %"System.Byte[]" addrspace(1)* %95, %"System.Byte[]" addrspace(1)** %arg4
+  br label %96
+
+; <label>:96                                      ; preds = %88, %94
+  %97 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  store %"System.Char[]" addrspace(1)* %97, %"System.Char[]" addrspace(1)** %loc4
+  %98 = icmp eq %"System.Char[]" addrspace(1)* %97, null
+  br i1 %98, label %107, label %99
+
+; <label>:99                                      ; preds = %96
+  %100 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc4
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %100, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %101
+
+; <label>:101                                     ; preds = %99
+  %102 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %100, i32 0, i32 1
+  %103 = load i32, i32 addrspace(1)* %102
+  %104 = zext i32 %103 to i64
+  %105 = trunc i64 %104 to i32
+  %106 = icmp ne i32 %105, 0
+  br i1 %106, label %108, label %107
+
+; <label>:107                                     ; preds = %96, %101
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  br label %116
+
+; <label>:108                                     ; preds = %101
+  %109 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc4
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %109, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %110
+
+; <label>:110                                     ; preds = %108
+  %111 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %109, i32 0, i32 1
+  %112 = load i32, i32 addrspace(1)* %111
+  %113 = zext i32 %112 to i64
+  %BoundsCheck = icmp uge i64 0, %113
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %114
+
+; <label>:114                                     ; preds = %110
+  %115 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %109, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %115, i16 addrspace(1)** %loc1
+  br label %116
+
+; <label>:116                                     ; preds = %107, %114
+  %117 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  store %"System.Byte[]" addrspace(1)* %117, %"System.Byte[]" addrspace(1)** %loc5
+  %118 = icmp eq %"System.Byte[]" addrspace(1)* %117, null
+  br i1 %118, label %127, label %119
+
+; <label>:119                                     ; preds = %116
+  %120 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc5
+  %NullCheck13 = icmp eq %"System.Byte[]" addrspace(1)* %120, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %121
+
+; <label>:121                                     ; preds = %119
+  %122 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %120, i32 0, i32 1
+  %123 = load i32, i32 addrspace(1)* %122
+  %124 = zext i32 %123 to i64
+  %125 = trunc i64 %124 to i32
+  %126 = icmp ne i32 %125, 0
+  br i1 %126, label %128, label %127
+
+; <label>:127                                     ; preds = %116, %121
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc2
+  br label %136
+
+; <label>:128                                     ; preds = %121
+  %129 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc5
+  %NullCheck15 = icmp eq %"System.Byte[]" addrspace(1)* %129, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %130
+
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %129, i32 0, i32 1
+  %132 = load i32, i32 addrspace(1)* %131
+  %133 = zext i32 %132 to i64
+  %BoundsCheck17 = icmp uge i64 0, %133
+  br i1 %BoundsCheck17, label %ThrowIndexOutOfRange18, label %134
+
+; <label>:134                                     ; preds = %130
+  %135 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %129, i32 0, i32 3, i32 0
+  store i8 addrspace(1)* %135, i8 addrspace(1)** %loc2
+  br label %136
+
+; <label>:136                                     ; preds = %127, %134
+  %137 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %138 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %139 = ptrtoint i16 addrspace(1)* %138 to i64
+  %140 = load i32, i32* %arg2
+  %141 = sext i32 %140 to i64
+  %142 = mul i64 %141, 2
+  %143 = add i64 %139, %142
+  %144 = load i32, i32* %arg3
+  %145 = load i8 addrspace(1)*, i8 addrspace(1)** %loc2
+  %146 = ptrtoint i8 addrspace(1)* %145 to i64
+  %147 = load i32, i32* %arg5
+  %148 = sext i32 %147 to i64
+  %149 = add i64 %146, %148
+  %150 = load i32, i32* %loc0
+  %151 = load i8, i8* %arg6
+  %152 = zext i8 %151 to i32
+  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i64 addrspace(1)*
+  %NullCheck19 = icmp eq i64 addrspace(1)* %153, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %154
+
+; <label>:154                                     ; preds = %136
+  %155 = load i64, i64 addrspace(1)* %153
+  %156 = add i64 %155, 72
+  %157 = inttoptr i64 %156 to i64*
+  %158 = load i64, i64* %157
+  %159 = add i64 %158, 0
+  %160 = inttoptr i64 %159 to i64*
+  %161 = load i64, i64* %160
+  %162 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to %System.Text.Encoder addrspace(1)*
+  %163 = inttoptr i64 %143 to i16*
+  %164 = inttoptr i64 %149 to i8*
+  %165 = trunc i32 %152 to i8
+  %166 = inttoptr i64 %161 to i32 (%System.Text.Encoder addrspace(1)*, i16*, i32, i8*, i32, i8)*
+  %167 = call i32 %166(%System.Text.Encoder addrspace(1)* %162, i16* %163, i32 %144, i8* %164, i32 %150, i8 %165)
+  store i32 %167, i32* %loc3
+  br label %168
+
+; <label>:168                                     ; preds = %154
+  %169 = load i32, i32* %loc3
+  ret i32 %169
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %110
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %119
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange18:                           ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
 Successfully read EncoderNLS.GetBytes
 
@@ -14908,22 +17185,22 @@ entry:
   %40 = load i8, i8* %arg5
   %41 = zext i8 %40 to i32
   %42 = trunc i32 %41 to i8
-  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %39, null
-  br i1 %NullCheck, label %43, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderNLS addrspace(1)* %39, null
+  br i1 %NullCheck, label %ThrowNullRef, label %43
 
 ; <label>:43                                      ; preds = %38
   %44 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
   store i8 %42, i8 addrspace(1)* %44
   %45 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %45, null
-  br i1 %NullCheck2, label %46, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.EncoderNLS addrspace(1)* %45, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %46
 
 ; <label>:46                                      ; preds = %43
   %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %45, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %47
   %48 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.EncoderNLS addrspace(1)* %48, null
-  br i1 %NullCheck4, label %49, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.EncoderNLS addrspace(1)* %48, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %49
 
 ; <label>:49                                      ; preds = %46
   %50 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %48, i32 0, i32 3
@@ -14934,8 +17211,8 @@ entry:
   %55 = load i32, i32* %arg4
   %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck6, label %58, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
   %59 = load i64, i64 addrspace(1)* %57
@@ -14953,15 +17230,15 @@ ThrowNullRef:                                     ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %43
+ThrowNullRef2:                                    ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %46
+ThrowNullRef4:                                    ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %49
+ThrowNullRef6:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14989,8 +17266,8 @@ entry:
   %4 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0 to %System.IO.ConsoleStream addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*)(%System.IO.ConsoleStream addrspace(1)* %4, %"System.Byte[]" addrspace(1)* %1, i32 %2, i32 %3)
   %5 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
@@ -15075,8 +17352,8 @@ entry:
 
 ; <label>:22                                      ; preds = %8
   %23 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %23, null
-  br i1 %NullCheck, label %24, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Byte[]" addrspace(1)* %23, null
+  br i1 %NullCheck, label %ThrowNullRef, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
@@ -15098,8 +17375,8 @@ entry:
 
 ; <label>:36                                      ; preds = %24
   %37 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %37, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.ConsoleStream addrspace(1)* %37, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %37, i32 0, i32 4
@@ -15120,13 +17397,138 @@ ThrowNullRef:                                     ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %36
+ThrowNullRef2:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
-Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
+Successfully read WindowsConsoleStream.WriteFileNative
+
+define i32 @WindowsConsoleStream.WriteFileNative(i64 %param0, %"System.Byte[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i64
+  %arg1 = alloca %"System.Byte[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i8 addrspace(1)*
+  %loc2 = alloca %"System.Byte[]" addrspace(1)*
+  %loc3 = alloca i32
+  store i64 %param0, i64* %arg0
+  store %"System.Byte[]" addrspace(1)* %param1, %"System.Byte[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Byte[]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = zext i32 %3 to i64
+  %5 = icmp ne i64 %4, 0
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %1
+  ret i32 0
+
+; <label>:7                                       ; preds = %1
+  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  store %"System.Byte[]" addrspace(1)* %8, %"System.Byte[]" addrspace(1)** %loc2
+  %9 = icmp eq %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %9, label %18, label %10
+
+; <label>:10                                      ; preds = %7
+  %11 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc2
+  %NullCheck1 = icmp eq %"System.Byte[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %11, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp ne i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %7, %12
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc1
+  br label %27
+
+; <label>:19                                      ; preds = %12
+  %20 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc2
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %20, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %BoundsCheck = icmp uge i64 0, %24
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %25
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %20, i32 0, i32 3, i32 0
+  store i8 addrspace(1)* %26, i8 addrspace(1)** %loc1
+  br label %27
+
+; <label>:27                                      ; preds = %18, %25
+  %28 = load i64, i64* %arg0
+  %29 = load i8 addrspace(1)*, i8 addrspace(1)** %loc1
+  %30 = ptrtoint i8 addrspace(1)* %29 to i64
+  %31 = load i32, i32* %arg2
+  %32 = sext i32 %31 to i64
+  %33 = add i64 %30, %32
+  %34 = load i32, i32* %arg3
+  %35 = addrspacecast i32* %loc3 to i32 addrspace(1)*
+  %36 = inttoptr i64 %33 to i8*
+  %37 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i8*, i32, i32 addrspace(1)*, i64)*)(i64 %28, i8* %36, i32 %34, i32 addrspace(1)* %35, i64 0)
+  %38 = icmp ugt i32 %37, 0
+  %39 = sext i1 %38 to i32
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc1
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %42, label %41
+
+; <label>:41                                      ; preds = %27
+  ret i32 0
+
+; <label>:42                                      ; preds = %27
+  %43 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  store i32 %43, i32* %loc0
+  %44 = load i32, i32* %loc0
+  %45 = icmp eq i32 %44, 232
+  br i1 %45, label %49, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = load i32, i32* %loc0
+  %48 = icmp ne i32 %47, 109
+  br i1 %48, label %50, label %49
+
+; <label>:49                                      ; preds = %42, %46
+  ret i32 0
+
+; <label>:50                                      ; preds = %46
+  %51 = load i32, i32* %loc0
+  ret i32 %51
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
 Successfully read WindowsConsoleStream.Flush
 
@@ -15135,8 +17537,8 @@ entry:
   %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
   store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
@@ -15171,8 +17573,8 @@ entry:
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
   %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load i64, i64 addrspace(1)* %1
@@ -15211,15 +17613,15 @@ entry:
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.TextWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
   %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %3, align 8
   %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
   %7 = load i64, i64 addrspace(1)* %5
@@ -15237,7 +17639,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -15266,8 +17668,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %4)
   store i32 0, i32* %loc0
   %5 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Char[]" addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
@@ -15279,15 +17681,15 @@ entry:
 
 ; <label>:11                                      ; preds = %69
   %12 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %12, i32 0, i32 9
   %15 = load i32, i32 addrspace(1)* %14, align 8
   %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.IO.StreamWriter addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %16, i32 0, i32 10
@@ -15302,15 +17704,15 @@ entry:
 
 ; <label>:23                                      ; preds = %17, %21
   %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %24, null
-  br i1 %NullCheck8, label %25, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %24, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 10
   %27 = load i32, i32 addrspace(1)* %26, align 8
   %28 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %28, null
-  br i1 %NullCheck10, label %29, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.StreamWriter addrspace(1)* %28, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %28, i32 0, i32 9
@@ -15332,15 +17734,15 @@ entry:
   %40 = load i32, i32* %loc0
   %41 = mul i32 %40, 2
   %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
-  br i1 %NullCheck12, label %43, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %43
 
 ; <label>:43                                      ; preds = %38
   %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 7
   %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %44, align 8
   %46 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %46, null
-  br i1 %NullCheck14, label %47, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.IO.StreamWriter addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %47
 
 ; <label>:47                                      ; preds = %43
   %48 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %46, i32 0, i32 9
@@ -15352,16 +17754,16 @@ entry:
   %54 = bitcast %"System.Char[]" addrspace(1)* %45 to %System.Array addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %53, i32 %41, %System.Array addrspace(1)* %54, i32 %50, i32 %52)
   %55 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
-  br i1 %NullCheck16, label %56, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %56
 
 ; <label>:56                                      ; preds = %47
   %57 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
   %58 = load i32, i32 addrspace(1)* %57, align 8
   %59 = load i32, i32* %loc2
   %60 = add i32 %58, %59
-  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
-  br i1 %NullCheck18, label %61, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %61
 
 ; <label>:61                                      ; preds = %56
   %62 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
@@ -15383,8 +17785,8 @@ entry:
 
 ; <label>:72                                      ; preds = %69
   %73 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %73, null
-  br i1 %NullCheck2, label %74, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %73, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %74
 
 ; <label>:74                                      ; preds = %72
   %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %73, i32 0, i32 11
@@ -15405,39 +17807,39 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %72
+ThrowNullRef2:                                    ; preds = %72
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %23
+ThrowNullRef8:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef10:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %43
+ThrowNullRef14:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %47
+ThrowNullRef16:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %56
+ThrowNullRef18:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPMul.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPMul.error.txt
@@ -25,8 +25,8 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
@@ -40,8 +40,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
   %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
@@ -75,7 +75,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -90,8 +90,8 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %NullCheck = icmp ne i8 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = load i8, i8 addrspace(1)* %0, align 8
@@ -125,8 +125,8 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
@@ -159,8 +159,8 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -184,8 +184,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
   store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
@@ -195,8 +195,8 @@ entry:
 ; <label>:4                                       ; preds = %1
   %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
   %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
@@ -206,8 +206,8 @@ entry:
   %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
@@ -221,14 +221,14 @@ entry:
 
 ; <label>:17                                      ; preds = %14
   %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
   %21 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
@@ -238,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -249,8 +249,8 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
@@ -261,27 +261,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %30
+ThrowNullRef10:                                   ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -301,7 +301,89 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
-Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
+Successfully read AppDomainSetup.GetUnsecureApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.GetUnsecureApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %NullCheck = icmp eq %"System.String[]" addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %BoundsCheck = icmp uge i64 0, %5
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %6
+
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 3, i32 0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
+  ret %System.String addrspace(1)* %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_Value using LLILCJit
+Successfully read AppDomainSetup.get_Value
+
+define %"System.String[]" addrspace(1)* @AppDomainSetup.get_Value(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.String[]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 18)
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.String[]" addrspace(1)* addrspace(1)*, %"System.String[]" addrspace(1)*)*)(%"System.String[]" addrspace(1)* addrspace(1)* %9, %"System.String[]" addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %11, i32 0, i32 1
+  %14 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %13, align 8
+  ret %"System.String[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -319,8 +401,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -368,16 +450,16 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
   %5 = load i32, i32 addrspace(1)* %4
   %6 = sub i32 %5, 1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -389,7 +471,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -421,8 +503,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
@@ -456,8 +538,8 @@ entry:
 ; <label>:27                                      ; preds = %19
   %28 = load i32, i32* %arg1
   %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
-  br i1 %NullCheck2, label %30, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %29, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %30
 
 ; <label>:30                                      ; preds = %27
   %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
@@ -493,8 +575,8 @@ entry:
 ; <label>:49                                      ; preds = %46
   %50 = load i32, i32* %arg2
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck4, label %52, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
@@ -517,11 +599,11 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %27
+ThrowNullRef2:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %49
+ThrowNullRef4:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -544,16 +626,16 @@ entry:
   %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %0)
   store %System.String addrspace(1)* %1, %System.String addrspace(1)** %loc0
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 2
   %5 = bitcast [0 x i16] addrspace(1)* %4 to i16 addrspace(1)*
   store i16 addrspace(1)* %5, i16 addrspace(1)** %loc1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %3
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2
@@ -580,7 +662,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -691,15 +773,15 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %NullCheck132 = icmp ne i8* %21, null
-  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+  %NullCheck131 = icmp eq i8* %21, null
+  br i1 %NullCheck131, label %ThrowNullRef132, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = load i8, i8* %21, align 8
   %24 = zext i8 %23 to i32
   %25 = trunc i32 %24 to i8
-  %NullCheck134 = icmp ne i8* %20, null
-  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+  %NullCheck133 = icmp eq i8* %20, null
+  br i1 %NullCheck133, label %ThrowNullRef134, label %26
 
 ; <label>:26                                      ; preds = %22
   store i8 %25, i8* %20, align 8
@@ -709,16 +791,16 @@ entry:
   %28 = load i8*, i8** %arg0
   %29 = load i8*, i8** %arg1
   %30 = bitcast i8* %29 to i16*
-  %NullCheck128 = icmp ne i16* %30, null
-  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+  %NullCheck127 = icmp eq i16* %30, null
+  br i1 %NullCheck127, label %ThrowNullRef128, label %31
 
 ; <label>:31                                      ; preds = %27
   %32 = load i16, i16* %30, align 8
   %33 = sext i16 %32 to i32
   %34 = bitcast i8* %28 to i16*
   %35 = trunc i32 %33 to i16
-  %NullCheck130 = icmp ne i16* %34, null
-  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+  %NullCheck129 = icmp eq i16* %34, null
+  br i1 %NullCheck129, label %ThrowNullRef130, label %36
 
 ; <label>:36                                      ; preds = %31
   store i16 %35, i16* %34, align 8
@@ -728,16 +810,16 @@ entry:
   %38 = load i8*, i8** %arg0
   %39 = load i8*, i8** %arg1
   %40 = bitcast i8* %39 to i16*
-  %NullCheck120 = icmp ne i16* %40, null
-  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+  %NullCheck119 = icmp eq i16* %40, null
+  br i1 %NullCheck119, label %ThrowNullRef120, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i16, i16* %40, align 8
   %43 = sext i16 %42 to i32
   %44 = bitcast i8* %38 to i16*
   %45 = trunc i32 %43 to i16
-  %NullCheck122 = icmp ne i16* %44, null
-  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+  %NullCheck121 = icmp eq i16* %44, null
+  br i1 %NullCheck121, label %ThrowNullRef122, label %46
 
 ; <label>:46                                      ; preds = %41
   store i16 %45, i16* %44, align 8
@@ -745,15 +827,15 @@ entry:
   %48 = getelementptr inbounds i8, i8* %47, i64 2
   %49 = load i8*, i8** %arg1
   %50 = getelementptr inbounds i8, i8* %49, i64 2
-  %NullCheck124 = icmp ne i8* %50, null
-  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+  %NullCheck123 = icmp eq i8* %50, null
+  br i1 %NullCheck123, label %ThrowNullRef124, label %51
 
 ; <label>:51                                      ; preds = %46
   %52 = load i8, i8* %50, align 8
   %53 = zext i8 %52 to i32
   %54 = trunc i32 %53 to i8
-  %NullCheck126 = icmp ne i8* %48, null
-  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+  %NullCheck125 = icmp eq i8* %48, null
+  br i1 %NullCheck125, label %ThrowNullRef126, label %55
 
 ; <label>:55                                      ; preds = %51
   store i8 %54, i8* %48, align 8
@@ -763,14 +845,14 @@ entry:
   %57 = load i8*, i8** %arg0
   %58 = load i8*, i8** %arg1
   %59 = bitcast i8* %58 to i32*
-  %NullCheck116 = icmp ne i32* %59, null
-  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+  %NullCheck115 = icmp eq i32* %59, null
+  br i1 %NullCheck115, label %ThrowNullRef116, label %60
 
 ; <label>:60                                      ; preds = %56
   %61 = load i32, i32* %59, align 8
   %62 = bitcast i8* %57 to i32*
-  %NullCheck118 = icmp ne i32* %62, null
-  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+  %NullCheck117 = icmp eq i32* %62, null
+  br i1 %NullCheck117, label %ThrowNullRef118, label %63
 
 ; <label>:63                                      ; preds = %60
   store i32 %61, i32* %62, align 8
@@ -780,14 +862,14 @@ entry:
   %65 = load i8*, i8** %arg0
   %66 = load i8*, i8** %arg1
   %67 = bitcast i8* %66 to i32*
-  %NullCheck108 = icmp ne i32* %67, null
-  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+  %NullCheck107 = icmp eq i32* %67, null
+  br i1 %NullCheck107, label %ThrowNullRef108, label %68
 
 ; <label>:68                                      ; preds = %64
   %69 = load i32, i32* %67, align 8
   %70 = bitcast i8* %65 to i32*
-  %NullCheck110 = icmp ne i32* %70, null
-  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+  %NullCheck109 = icmp eq i32* %70, null
+  br i1 %NullCheck109, label %ThrowNullRef110, label %71
 
 ; <label>:71                                      ; preds = %68
   store i32 %69, i32* %70, align 8
@@ -795,15 +877,15 @@ entry:
   %73 = getelementptr inbounds i8, i8* %72, i64 4
   %74 = load i8*, i8** %arg1
   %75 = getelementptr inbounds i8, i8* %74, i64 4
-  %NullCheck112 = icmp ne i8* %75, null
-  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+  %NullCheck111 = icmp eq i8* %75, null
+  br i1 %NullCheck111, label %ThrowNullRef112, label %76
 
 ; <label>:76                                      ; preds = %71
   %77 = load i8, i8* %75, align 8
   %78 = zext i8 %77 to i32
   %79 = trunc i32 %78 to i8
-  %NullCheck114 = icmp ne i8* %73, null
-  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+  %NullCheck113 = icmp eq i8* %73, null
+  br i1 %NullCheck113, label %ThrowNullRef114, label %80
 
 ; <label>:80                                      ; preds = %76
   store i8 %79, i8* %73, align 8
@@ -813,14 +895,14 @@ entry:
   %82 = load i8*, i8** %arg0
   %83 = load i8*, i8** %arg1
   %84 = bitcast i8* %83 to i32*
-  %NullCheck100 = icmp ne i32* %84, null
-  br i1 %NullCheck100, label %85, label %ThrowNullRef99
+  %NullCheck99 = icmp eq i32* %84, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %85
 
 ; <label>:85                                      ; preds = %81
   %86 = load i32, i32* %84, align 8
   %87 = bitcast i8* %82 to i32*
-  %NullCheck102 = icmp ne i32* %87, null
-  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+  %NullCheck101 = icmp eq i32* %87, null
+  br i1 %NullCheck101, label %ThrowNullRef102, label %88
 
 ; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
@@ -829,16 +911,16 @@ entry:
   %91 = load i8*, i8** %arg1
   %92 = getelementptr inbounds i8, i8* %91, i64 4
   %93 = bitcast i8* %92 to i16*
-  %NullCheck104 = icmp ne i16* %93, null
-  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+  %NullCheck103 = icmp eq i16* %93, null
+  br i1 %NullCheck103, label %ThrowNullRef104, label %94
 
 ; <label>:94                                      ; preds = %88
   %95 = load i16, i16* %93, align 8
   %96 = sext i16 %95 to i32
   %97 = bitcast i8* %90 to i16*
   %98 = trunc i32 %96 to i16
-  %NullCheck106 = icmp ne i16* %97, null
-  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+  %NullCheck105 = icmp eq i16* %97, null
+  br i1 %NullCheck105, label %ThrowNullRef106, label %99
 
 ; <label>:99                                      ; preds = %94
   store i16 %98, i16* %97, align 8
@@ -848,14 +930,14 @@ entry:
   %101 = load i8*, i8** %arg0
   %102 = load i8*, i8** %arg1
   %103 = bitcast i8* %102 to i32*
-  %NullCheck88 = icmp ne i32* %103, null
-  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+  %NullCheck87 = icmp eq i32* %103, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %104
 
 ; <label>:104                                     ; preds = %100
   %105 = load i32, i32* %103, align 8
   %106 = bitcast i8* %101 to i32*
-  %NullCheck90 = icmp ne i32* %106, null
-  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+  %NullCheck89 = icmp eq i32* %106, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %107
 
 ; <label>:107                                     ; preds = %104
   store i32 %105, i32* %106, align 8
@@ -864,16 +946,16 @@ entry:
   %110 = load i8*, i8** %arg1
   %111 = getelementptr inbounds i8, i8* %110, i64 4
   %112 = bitcast i8* %111 to i16*
-  %NullCheck92 = icmp ne i16* %112, null
-  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+  %NullCheck91 = icmp eq i16* %112, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %113
 
 ; <label>:113                                     ; preds = %107
   %114 = load i16, i16* %112, align 8
   %115 = sext i16 %114 to i32
   %116 = bitcast i8* %109 to i16*
   %117 = trunc i32 %115 to i16
-  %NullCheck94 = icmp ne i16* %116, null
-  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+  %NullCheck93 = icmp eq i16* %116, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %118
 
 ; <label>:118                                     ; preds = %113
   store i16 %117, i16* %116, align 8
@@ -881,15 +963,15 @@ entry:
   %120 = getelementptr inbounds i8, i8* %119, i64 6
   %121 = load i8*, i8** %arg1
   %122 = getelementptr inbounds i8, i8* %121, i64 6
-  %NullCheck96 = icmp ne i8* %122, null
-  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+  %NullCheck95 = icmp eq i8* %122, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %123
 
 ; <label>:123                                     ; preds = %118
   %124 = load i8, i8* %122, align 8
   %125 = zext i8 %124 to i32
   %126 = trunc i32 %125 to i8
-  %NullCheck98 = icmp ne i8* %120, null
-  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+  %NullCheck97 = icmp eq i8* %120, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %127
 
 ; <label>:127                                     ; preds = %123
   store i8 %126, i8* %120, align 8
@@ -899,14 +981,14 @@ entry:
   %129 = load i8*, i8** %arg0
   %130 = load i8*, i8** %arg1
   %131 = bitcast i8* %130 to i64*
-  %NullCheck84 = icmp ne i64* %131, null
-  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+  %NullCheck83 = icmp eq i64* %131, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %132
 
 ; <label>:132                                     ; preds = %128
   %133 = load i64, i64* %131, align 8
   %134 = bitcast i8* %129 to i64*
-  %NullCheck86 = icmp ne i64* %134, null
-  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+  %NullCheck85 = icmp eq i64* %134, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %135
 
 ; <label>:135                                     ; preds = %132
   store i64 %133, i64* %134, align 8
@@ -916,14 +998,14 @@ entry:
   %137 = load i8*, i8** %arg0
   %138 = load i8*, i8** %arg1
   %139 = bitcast i8* %138 to i64*
-  %NullCheck76 = icmp ne i64* %139, null
-  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+  %NullCheck75 = icmp eq i64* %139, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %140
 
 ; <label>:140                                     ; preds = %136
   %141 = load i64, i64* %139, align 8
   %142 = bitcast i8* %137 to i64*
-  %NullCheck78 = icmp ne i64* %142, null
-  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+  %NullCheck77 = icmp eq i64* %142, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %143
 
 ; <label>:143                                     ; preds = %140
   store i64 %141, i64* %142, align 8
@@ -931,15 +1013,15 @@ entry:
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %NullCheck80 = icmp ne i8* %147, null
-  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+  %NullCheck79 = icmp eq i8* %147, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %148
 
 ; <label>:148                                     ; preds = %143
   %149 = load i8, i8* %147, align 8
   %150 = zext i8 %149 to i32
   %151 = trunc i32 %150 to i8
-  %NullCheck82 = icmp ne i8* %145, null
-  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+  %NullCheck81 = icmp eq i8* %145, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %152
 
 ; <label>:152                                     ; preds = %148
   store i8 %151, i8* %145, align 8
@@ -949,14 +1031,14 @@ entry:
   %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
   %156 = bitcast i8* %155 to i64*
-  %NullCheck68 = icmp ne i64* %156, null
-  br i1 %NullCheck68, label %157, label %ThrowNullRef67
+  %NullCheck67 = icmp eq i64* %156, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %157
 
 ; <label>:157                                     ; preds = %153
   %158 = load i64, i64* %156, align 8
   %159 = bitcast i8* %154 to i64*
-  %NullCheck70 = icmp ne i64* %159, null
-  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+  %NullCheck69 = icmp eq i64* %159, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %160
 
 ; <label>:160                                     ; preds = %157
   store i64 %158, i64* %159, align 8
@@ -965,16 +1047,16 @@ entry:
   %163 = load i8*, i8** %arg1
   %164 = getelementptr inbounds i8, i8* %163, i64 8
   %165 = bitcast i8* %164 to i16*
-  %NullCheck72 = icmp ne i16* %165, null
-  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+  %NullCheck71 = icmp eq i16* %165, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %166
 
 ; <label>:166                                     ; preds = %160
   %167 = load i16, i16* %165, align 8
   %168 = sext i16 %167 to i32
   %169 = bitcast i8* %162 to i16*
   %170 = trunc i32 %168 to i16
-  %NullCheck74 = icmp ne i16* %169, null
-  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+  %NullCheck73 = icmp eq i16* %169, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %171
 
 ; <label>:171                                     ; preds = %166
   store i16 %170, i16* %169, align 8
@@ -984,14 +1066,14 @@ entry:
   %173 = load i8*, i8** %arg0
   %174 = load i8*, i8** %arg1
   %175 = bitcast i8* %174 to i64*
-  %NullCheck56 = icmp ne i64* %175, null
-  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+  %NullCheck55 = icmp eq i64* %175, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %176
 
 ; <label>:176                                     ; preds = %172
   %177 = load i64, i64* %175, align 8
   %178 = bitcast i8* %173 to i64*
-  %NullCheck58 = icmp ne i64* %178, null
-  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+  %NullCheck57 = icmp eq i64* %178, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %179
 
 ; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
@@ -1000,16 +1082,16 @@ entry:
   %182 = load i8*, i8** %arg1
   %183 = getelementptr inbounds i8, i8* %182, i64 8
   %184 = bitcast i8* %183 to i16*
-  %NullCheck60 = icmp ne i16* %184, null
-  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+  %NullCheck59 = icmp eq i16* %184, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %185
 
 ; <label>:185                                     ; preds = %179
   %186 = load i16, i16* %184, align 8
   %187 = sext i16 %186 to i32
   %188 = bitcast i8* %181 to i16*
   %189 = trunc i32 %187 to i16
-  %NullCheck62 = icmp ne i16* %188, null
-  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+  %NullCheck61 = icmp eq i16* %188, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %190
 
 ; <label>:190                                     ; preds = %185
   store i16 %189, i16* %188, align 8
@@ -1017,15 +1099,15 @@ entry:
   %192 = getelementptr inbounds i8, i8* %191, i64 10
   %193 = load i8*, i8** %arg1
   %194 = getelementptr inbounds i8, i8* %193, i64 10
-  %NullCheck64 = icmp ne i8* %194, null
-  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+  %NullCheck63 = icmp eq i8* %194, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %195
 
 ; <label>:195                                     ; preds = %190
   %196 = load i8, i8* %194, align 8
   %197 = zext i8 %196 to i32
   %198 = trunc i32 %197 to i8
-  %NullCheck66 = icmp ne i8* %192, null
-  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+  %NullCheck65 = icmp eq i8* %192, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %199
 
 ; <label>:199                                     ; preds = %195
   store i8 %198, i8* %192, align 8
@@ -1035,14 +1117,14 @@ entry:
   %201 = load i8*, i8** %arg0
   %202 = load i8*, i8** %arg1
   %203 = bitcast i8* %202 to i64*
-  %NullCheck48 = icmp ne i64* %203, null
-  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+  %NullCheck47 = icmp eq i64* %203, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %204
 
 ; <label>:204                                     ; preds = %200
   %205 = load i64, i64* %203, align 8
   %206 = bitcast i8* %201 to i64*
-  %NullCheck50 = icmp ne i64* %206, null
-  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+  %NullCheck49 = icmp eq i64* %206, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %207
 
 ; <label>:207                                     ; preds = %204
   store i64 %205, i64* %206, align 8
@@ -1051,14 +1133,14 @@ entry:
   %210 = load i8*, i8** %arg1
   %211 = getelementptr inbounds i8, i8* %210, i64 8
   %212 = bitcast i8* %211 to i32*
-  %NullCheck52 = icmp ne i32* %212, null
-  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+  %NullCheck51 = icmp eq i32* %212, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %213
 
 ; <label>:213                                     ; preds = %207
   %214 = load i32, i32* %212, align 8
   %215 = bitcast i8* %209 to i32*
-  %NullCheck54 = icmp ne i32* %215, null
-  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+  %NullCheck53 = icmp eq i32* %215, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %216
 
 ; <label>:216                                     ; preds = %213
   store i32 %214, i32* %215, align 8
@@ -1068,14 +1150,14 @@ entry:
   %218 = load i8*, i8** %arg0
   %219 = load i8*, i8** %arg1
   %220 = bitcast i8* %219 to i64*
-  %NullCheck36 = icmp ne i64* %220, null
-  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64* %220, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %221
 
 ; <label>:221                                     ; preds = %217
   %222 = load i64, i64* %220, align 8
   %223 = bitcast i8* %218 to i64*
-  %NullCheck38 = icmp ne i64* %223, null
-  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+  %NullCheck37 = icmp eq i64* %223, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %224
 
 ; <label>:224                                     ; preds = %221
   store i64 %222, i64* %223, align 8
@@ -1084,14 +1166,14 @@ entry:
   %227 = load i8*, i8** %arg1
   %228 = getelementptr inbounds i8, i8* %227, i64 8
   %229 = bitcast i8* %228 to i32*
-  %NullCheck40 = icmp ne i32* %229, null
-  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i32* %229, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %230
 
 ; <label>:230                                     ; preds = %224
   %231 = load i32, i32* %229, align 8
   %232 = bitcast i8* %226 to i32*
-  %NullCheck42 = icmp ne i32* %232, null
-  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+  %NullCheck41 = icmp eq i32* %232, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %233
 
 ; <label>:233                                     ; preds = %230
   store i32 %231, i32* %232, align 8
@@ -1099,15 +1181,15 @@ entry:
   %235 = getelementptr inbounds i8, i8* %234, i64 12
   %236 = load i8*, i8** %arg1
   %237 = getelementptr inbounds i8, i8* %236, i64 12
-  %NullCheck44 = icmp ne i8* %237, null
-  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i8* %237, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %238
 
 ; <label>:238                                     ; preds = %233
   %239 = load i8, i8* %237, align 8
   %240 = zext i8 %239 to i32
   %241 = trunc i32 %240 to i8
-  %NullCheck46 = icmp ne i8* %235, null
-  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+  %NullCheck45 = icmp eq i8* %235, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %242
 
 ; <label>:242                                     ; preds = %238
   store i8 %241, i8* %235, align 8
@@ -1117,14 +1199,14 @@ entry:
   %244 = load i8*, i8** %arg0
   %245 = load i8*, i8** %arg1
   %246 = bitcast i8* %245 to i64*
-  %NullCheck24 = icmp ne i64* %246, null
-  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64* %246, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %247
 
 ; <label>:247                                     ; preds = %243
   %248 = load i64, i64* %246, align 8
   %249 = bitcast i8* %244 to i64*
-  %NullCheck26 = icmp ne i64* %249, null
-  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64* %249, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %250
 
 ; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
@@ -1133,14 +1215,14 @@ entry:
   %253 = load i8*, i8** %arg1
   %254 = getelementptr inbounds i8, i8* %253, i64 8
   %255 = bitcast i8* %254 to i32*
-  %NullCheck28 = icmp ne i32* %255, null
-  br i1 %NullCheck28, label %256, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i32* %255, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %256
 
 ; <label>:256                                     ; preds = %250
   %257 = load i32, i32* %255, align 8
   %258 = bitcast i8* %252 to i32*
-  %NullCheck30 = icmp ne i32* %258, null
-  br i1 %NullCheck30, label %259, label %ThrowNullRef29
+  %NullCheck29 = icmp eq i32* %258, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %259
 
 ; <label>:259                                     ; preds = %256
   store i32 %257, i32* %258, align 8
@@ -1149,16 +1231,16 @@ entry:
   %262 = load i8*, i8** %arg1
   %263 = getelementptr inbounds i8, i8* %262, i64 12
   %264 = bitcast i8* %263 to i16*
-  %NullCheck32 = icmp ne i16* %264, null
-  br i1 %NullCheck32, label %265, label %ThrowNullRef31
+  %NullCheck31 = icmp eq i16* %264, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %265
 
 ; <label>:265                                     ; preds = %259
   %266 = load i16, i16* %264, align 8
   %267 = sext i16 %266 to i32
   %268 = bitcast i8* %261 to i16*
   %269 = trunc i32 %267 to i16
-  %NullCheck34 = icmp ne i16* %268, null
-  br i1 %NullCheck34, label %270, label %ThrowNullRef33
+  %NullCheck33 = icmp eq i16* %268, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %270
 
 ; <label>:270                                     ; preds = %265
   store i16 %269, i16* %268, align 8
@@ -1168,14 +1250,14 @@ entry:
   %272 = load i8*, i8** %arg0
   %273 = load i8*, i8** %arg1
   %274 = bitcast i8* %273 to i64*
-  %NullCheck8 = icmp ne i64* %274, null
-  br i1 %NullCheck8, label %275, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64* %274, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %275
 
 ; <label>:275                                     ; preds = %271
   %276 = load i64, i64* %274, align 8
   %277 = bitcast i8* %272 to i64*
-  %NullCheck10 = icmp ne i64* %277, null
-  br i1 %NullCheck10, label %278, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %277, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %278
 
 ; <label>:278                                     ; preds = %275
   store i64 %276, i64* %277, align 8
@@ -1184,14 +1266,14 @@ entry:
   %281 = load i8*, i8** %arg1
   %282 = getelementptr inbounds i8, i8* %281, i64 8
   %283 = bitcast i8* %282 to i32*
-  %NullCheck12 = icmp ne i32* %283, null
-  br i1 %NullCheck12, label %284, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i32* %283, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %284
 
 ; <label>:284                                     ; preds = %278
   %285 = load i32, i32* %283, align 8
   %286 = bitcast i8* %280 to i32*
-  %NullCheck14 = icmp ne i32* %286, null
-  br i1 %NullCheck14, label %287, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i32* %286, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %287
 
 ; <label>:287                                     ; preds = %284
   store i32 %285, i32* %286, align 8
@@ -1200,16 +1282,16 @@ entry:
   %290 = load i8*, i8** %arg1
   %291 = getelementptr inbounds i8, i8* %290, i64 12
   %292 = bitcast i8* %291 to i16*
-  %NullCheck16 = icmp ne i16* %292, null
-  br i1 %NullCheck16, label %293, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i16* %292, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %293
 
 ; <label>:293                                     ; preds = %287
   %294 = load i16, i16* %292, align 8
   %295 = sext i16 %294 to i32
   %296 = bitcast i8* %289 to i16*
   %297 = trunc i32 %295 to i16
-  %NullCheck18 = icmp ne i16* %296, null
-  br i1 %NullCheck18, label %298, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i16* %296, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %298
 
 ; <label>:298                                     ; preds = %293
   store i16 %297, i16* %296, align 8
@@ -1217,15 +1299,15 @@ entry:
   %300 = getelementptr inbounds i8, i8* %299, i64 14
   %301 = load i8*, i8** %arg1
   %302 = getelementptr inbounds i8, i8* %301, i64 14
-  %NullCheck20 = icmp ne i8* %302, null
-  br i1 %NullCheck20, label %303, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i8* %302, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %303
 
 ; <label>:303                                     ; preds = %298
   %304 = load i8, i8* %302, align 8
   %305 = zext i8 %304 to i32
   %306 = trunc i32 %305 to i8
-  %NullCheck22 = icmp ne i8* %300, null
-  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i8* %300, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %307
 
 ; <label>:307                                     ; preds = %303
   store i8 %306, i8* %300, align 8
@@ -1235,14 +1317,14 @@ entry:
   %309 = load i8*, i8** %arg0
   %310 = load i8*, i8** %arg1
   %311 = bitcast i8* %310 to i64*
-  %NullCheck = icmp ne i64* %311, null
-  br i1 %NullCheck, label %312, label %ThrowNullRef
+  %NullCheck = icmp eq i64* %311, null
+  br i1 %NullCheck, label %ThrowNullRef, label %312
 
 ; <label>:312                                     ; preds = %308
   %313 = load i64, i64* %311, align 8
   %314 = bitcast i8* %309 to i64*
-  %NullCheck2 = icmp ne i64* %314, null
-  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64* %314, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %315
 
 ; <label>:315                                     ; preds = %312
   store i64 %313, i64* %314, align 8
@@ -1251,14 +1333,14 @@ entry:
   %318 = load i8*, i8** %arg1
   %319 = getelementptr inbounds i8, i8* %318, i64 8
   %320 = bitcast i8* %319 to i64*
-  %NullCheck4 = icmp ne i64* %320, null
-  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64* %320, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %321
 
 ; <label>:321                                     ; preds = %315
   %322 = load i64, i64* %320, align 8
   %323 = bitcast i8* %317 to i64*
-  %NullCheck6 = icmp ne i64* %323, null
-  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64* %323, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %324
 
 ; <label>:324                                     ; preds = %321
   store i64 %322, i64* %323, align 8
@@ -1286,15 +1368,15 @@ entry:
 ; <label>:338                                     ; preds = %333
   %339 = load i8*, i8** %arg0
   %340 = load i8*, i8** %arg1
-  %NullCheck136 = icmp ne i8* %340, null
-  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+  %NullCheck135 = icmp eq i8* %340, null
+  br i1 %NullCheck135, label %ThrowNullRef136, label %341
 
 ; <label>:341                                     ; preds = %338
   %342 = load i8, i8* %340, align 8
   %343 = zext i8 %342 to i32
   %344 = trunc i32 %343 to i8
-  %NullCheck138 = icmp ne i8* %339, null
-  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+  %NullCheck137 = icmp eq i8* %339, null
+  br i1 %NullCheck137, label %ThrowNullRef138, label %345
 
 ; <label>:345                                     ; preds = %341
   store i8 %344, i8* %339, align 8
@@ -1317,16 +1399,16 @@ entry:
   %357 = load i8*, i8** %arg0
   %358 = load i8*, i8** %arg1
   %359 = bitcast i8* %358 to i16*
-  %NullCheck140 = icmp ne i16* %359, null
-  br i1 %NullCheck140, label %360, label %ThrowNullRef139
+  %NullCheck139 = icmp eq i16* %359, null
+  br i1 %NullCheck139, label %ThrowNullRef140, label %360
 
 ; <label>:360                                     ; preds = %356
   %361 = load i16, i16* %359, align 8
   %362 = sext i16 %361 to i32
   %363 = bitcast i8* %357 to i16*
   %364 = trunc i32 %362 to i16
-  %NullCheck142 = icmp ne i16* %363, null
-  br i1 %NullCheck142, label %365, label %ThrowNullRef141
+  %NullCheck141 = icmp eq i16* %363, null
+  br i1 %NullCheck141, label %ThrowNullRef142, label %365
 
 ; <label>:365                                     ; preds = %360
   store i16 %364, i16* %363, align 8
@@ -1352,14 +1434,14 @@ entry:
   %378 = load i8*, i8** %arg0
   %379 = load i8*, i8** %arg1
   %380 = bitcast i8* %379 to i32*
-  %NullCheck144 = icmp ne i32* %380, null
-  br i1 %NullCheck144, label %381, label %ThrowNullRef143
+  %NullCheck143 = icmp eq i32* %380, null
+  br i1 %NullCheck143, label %ThrowNullRef144, label %381
 
 ; <label>:381                                     ; preds = %377
   %382 = load i32, i32* %380, align 8
   %383 = bitcast i8* %378 to i32*
-  %NullCheck146 = icmp ne i32* %383, null
-  br i1 %NullCheck146, label %384, label %ThrowNullRef145
+  %NullCheck145 = icmp eq i32* %383, null
+  br i1 %NullCheck145, label %ThrowNullRef146, label %384
 
 ; <label>:384                                     ; preds = %381
   store i32 %382, i32* %383, align 8
@@ -1384,14 +1466,14 @@ entry:
   %395 = load i8*, i8** %arg0
   %396 = load i8*, i8** %arg1
   %397 = bitcast i8* %396 to i64*
-  %NullCheck164 = icmp ne i64* %397, null
-  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+  %NullCheck163 = icmp eq i64* %397, null
+  br i1 %NullCheck163, label %ThrowNullRef164, label %398
 
 ; <label>:398                                     ; preds = %394
   %399 = load i64, i64* %397, align 8
   %400 = bitcast i8* %395 to i64*
-  %NullCheck166 = icmp ne i64* %400, null
-  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+  %NullCheck165 = icmp eq i64* %400, null
+  br i1 %NullCheck165, label %ThrowNullRef166, label %401
 
 ; <label>:401                                     ; preds = %398
   store i64 %399, i64* %400, align 8
@@ -1400,14 +1482,14 @@ entry:
   %404 = load i8*, i8** %arg1
   %405 = getelementptr inbounds i8, i8* %404, i64 8
   %406 = bitcast i8* %405 to i64*
-  %NullCheck168 = icmp ne i64* %406, null
-  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+  %NullCheck167 = icmp eq i64* %406, null
+  br i1 %NullCheck167, label %ThrowNullRef168, label %407
 
 ; <label>:407                                     ; preds = %401
   %408 = load i64, i64* %406, align 8
   %409 = bitcast i8* %403 to i64*
-  %NullCheck170 = icmp ne i64* %409, null
-  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+  %NullCheck169 = icmp eq i64* %409, null
+  br i1 %NullCheck169, label %ThrowNullRef170, label %410
 
 ; <label>:410                                     ; preds = %407
   store i64 %408, i64* %409, align 8
@@ -1437,14 +1519,14 @@ entry:
   %425 = load i8*, i8** %arg0
   %426 = load i8*, i8** %arg1
   %427 = bitcast i8* %426 to i64*
-  %NullCheck148 = icmp ne i64* %427, null
-  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+  %NullCheck147 = icmp eq i64* %427, null
+  br i1 %NullCheck147, label %ThrowNullRef148, label %428
 
 ; <label>:428                                     ; preds = %424
   %429 = load i64, i64* %427, align 8
   %430 = bitcast i8* %425 to i64*
-  %NullCheck150 = icmp ne i64* %430, null
-  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+  %NullCheck149 = icmp eq i64* %430, null
+  br i1 %NullCheck149, label %ThrowNullRef150, label %431
 
 ; <label>:431                                     ; preds = %428
   store i64 %429, i64* %430, align 8
@@ -1466,14 +1548,14 @@ entry:
   %441 = load i8*, i8** %arg0
   %442 = load i8*, i8** %arg1
   %443 = bitcast i8* %442 to i32*
-  %NullCheck152 = icmp ne i32* %443, null
-  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+  %NullCheck151 = icmp eq i32* %443, null
+  br i1 %NullCheck151, label %ThrowNullRef152, label %444
 
 ; <label>:444                                     ; preds = %440
   %445 = load i32, i32* %443, align 8
   %446 = bitcast i8* %441 to i32*
-  %NullCheck154 = icmp ne i32* %446, null
-  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+  %NullCheck153 = icmp eq i32* %446, null
+  br i1 %NullCheck153, label %ThrowNullRef154, label %447
 
 ; <label>:447                                     ; preds = %444
   store i32 %445, i32* %446, align 8
@@ -1495,16 +1577,16 @@ entry:
   %457 = load i8*, i8** %arg0
   %458 = load i8*, i8** %arg1
   %459 = bitcast i8* %458 to i16*
-  %NullCheck156 = icmp ne i16* %459, null
-  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+  %NullCheck155 = icmp eq i16* %459, null
+  br i1 %NullCheck155, label %ThrowNullRef156, label %460
 
 ; <label>:460                                     ; preds = %456
   %461 = load i16, i16* %459, align 8
   %462 = sext i16 %461 to i32
   %463 = bitcast i8* %457 to i16*
   %464 = trunc i32 %462 to i16
-  %NullCheck158 = icmp ne i16* %463, null
-  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+  %NullCheck157 = icmp eq i16* %463, null
+  br i1 %NullCheck157, label %ThrowNullRef158, label %465
 
 ; <label>:465                                     ; preds = %460
   store i16 %464, i16* %463, align 8
@@ -1525,15 +1607,15 @@ entry:
 ; <label>:474                                     ; preds = %470
   %475 = load i8*, i8** %arg0
   %476 = load i8*, i8** %arg1
-  %NullCheck160 = icmp ne i8* %476, null
-  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+  %NullCheck159 = icmp eq i8* %476, null
+  br i1 %NullCheck159, label %ThrowNullRef160, label %477
 
 ; <label>:477                                     ; preds = %474
   %478 = load i8, i8* %476, align 8
   %479 = zext i8 %478 to i32
   %480 = trunc i32 %479 to i8
-  %NullCheck162 = icmp ne i8* %475, null
-  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+  %NullCheck161 = icmp eq i8* %475, null
+  br i1 %NullCheck161, label %ThrowNullRef162, label %481
 
 ; <label>:481                                     ; preds = %477
   store i8 %480, i8* %475, align 8
@@ -1553,343 +1635,343 @@ ThrowNullRef:                                     ; preds = %308
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %312
+ThrowNullRef2:                                    ; preds = %312
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %315
+ThrowNullRef4:                                    ; preds = %315
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %321
+ThrowNullRef6:                                    ; preds = %321
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %271
+ThrowNullRef8:                                    ; preds = %271
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %275
+ThrowNullRef10:                                   ; preds = %275
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %278
+ThrowNullRef12:                                   ; preds = %278
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %284
+ThrowNullRef14:                                   ; preds = %284
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %287
+ThrowNullRef16:                                   ; preds = %287
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %293
+ThrowNullRef18:                                   ; preds = %293
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %298
+ThrowNullRef20:                                   ; preds = %298
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %303
+ThrowNullRef22:                                   ; preds = %303
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %243
+ThrowNullRef24:                                   ; preds = %243
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %247
+ThrowNullRef26:                                   ; preds = %247
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %250
+ThrowNullRef28:                                   ; preds = %250
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %256
+ThrowNullRef30:                                   ; preds = %256
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %259
+ThrowNullRef32:                                   ; preds = %259
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %265
+ThrowNullRef34:                                   ; preds = %265
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %217
+ThrowNullRef36:                                   ; preds = %217
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %221
+ThrowNullRef38:                                   ; preds = %221
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %224
+ThrowNullRef40:                                   ; preds = %224
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %230
+ThrowNullRef42:                                   ; preds = %230
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %233
+ThrowNullRef44:                                   ; preds = %233
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %238
+ThrowNullRef46:                                   ; preds = %238
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %200
+ThrowNullRef48:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %204
+ThrowNullRef50:                                   ; preds = %204
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %207
+ThrowNullRef52:                                   ; preds = %207
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %213
+ThrowNullRef54:                                   ; preds = %213
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %172
+ThrowNullRef56:                                   ; preds = %172
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %176
+ThrowNullRef58:                                   ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %179
+ThrowNullRef60:                                   ; preds = %179
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %185
+ThrowNullRef62:                                   ; preds = %185
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %190
+ThrowNullRef64:                                   ; preds = %190
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %195
+ThrowNullRef66:                                   ; preds = %195
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %153
+ThrowNullRef68:                                   ; preds = %153
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %157
+ThrowNullRef70:                                   ; preds = %157
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %160
+ThrowNullRef72:                                   ; preds = %160
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %166
+ThrowNullRef74:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %136
+ThrowNullRef76:                                   ; preds = %136
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %140
+ThrowNullRef78:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %143
+ThrowNullRef80:                                   ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %148
+ThrowNullRef82:                                   ; preds = %148
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %128
+ThrowNullRef84:                                   ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %132
+ThrowNullRef86:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %100
+ThrowNullRef88:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %104
+ThrowNullRef90:                                   ; preds = %104
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %107
+ThrowNullRef92:                                   ; preds = %107
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %113
+ThrowNullRef94:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %118
+ThrowNullRef96:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %123
+ThrowNullRef98:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %81
+ThrowNullRef100:                                  ; preds = %81
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef101:                                  ; preds = %85
+ThrowNullRef102:                                  ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef103:                                  ; preds = %88
+ThrowNullRef104:                                  ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef105:                                  ; preds = %94
+ThrowNullRef106:                                  ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef107:                                  ; preds = %64
+ThrowNullRef108:                                  ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef109:                                  ; preds = %68
+ThrowNullRef110:                                  ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef111:                                  ; preds = %71
+ThrowNullRef112:                                  ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef113:                                  ; preds = %76
+ThrowNullRef114:                                  ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef115:                                  ; preds = %56
+ThrowNullRef116:                                  ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef117:                                  ; preds = %60
+ThrowNullRef118:                                  ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef119:                                  ; preds = %37
+ThrowNullRef120:                                  ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef121:                                  ; preds = %41
+ThrowNullRef122:                                  ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef123:                                  ; preds = %46
+ThrowNullRef124:                                  ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef125:                                  ; preds = %51
+ThrowNullRef126:                                  ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef127:                                  ; preds = %27
+ThrowNullRef128:                                  ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef129:                                  ; preds = %31
+ThrowNullRef130:                                  ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef131:                                  ; preds = %19
+ThrowNullRef132:                                  ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef133:                                  ; preds = %22
+ThrowNullRef134:                                  ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef135:                                  ; preds = %338
+ThrowNullRef136:                                  ; preds = %338
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef137:                                  ; preds = %341
+ThrowNullRef138:                                  ; preds = %341
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef139:                                  ; preds = %356
+ThrowNullRef140:                                  ; preds = %356
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef141:                                  ; preds = %360
+ThrowNullRef142:                                  ; preds = %360
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef143:                                  ; preds = %377
+ThrowNullRef144:                                  ; preds = %377
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef145:                                  ; preds = %381
+ThrowNullRef146:                                  ; preds = %381
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef147:                                  ; preds = %424
+ThrowNullRef148:                                  ; preds = %424
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef149:                                  ; preds = %428
+ThrowNullRef150:                                  ; preds = %428
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef151:                                  ; preds = %440
+ThrowNullRef152:                                  ; preds = %440
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef153:                                  ; preds = %444
+ThrowNullRef154:                                  ; preds = %444
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef155:                                  ; preds = %456
+ThrowNullRef156:                                  ; preds = %456
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef157:                                  ; preds = %460
+ThrowNullRef158:                                  ; preds = %460
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef159:                                  ; preds = %474
+ThrowNullRef160:                                  ; preds = %474
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef161:                                  ; preds = %477
+ThrowNullRef162:                                  ; preds = %477
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef163:                                  ; preds = %394
+ThrowNullRef164:                                  ; preds = %394
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef165:                                  ; preds = %398
+ThrowNullRef166:                                  ; preds = %398
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef167:                                  ; preds = %401
+ThrowNullRef168:                                  ; preds = %401
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef169:                                  ; preds = %407
+ThrowNullRef170:                                  ; preds = %407
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1939,8 +2021,8 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
-  br i1 %NullCheck, label %22, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %ThrowNullRef, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
@@ -1948,8 +2030,8 @@ entry:
   store i32 %24, i32* %loc0
   %25 = load i32, i32* %loc0
   %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %26, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %27
 
 ; <label>:27                                      ; preds = %22
   %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
@@ -1971,7 +2053,7 @@ ThrowNullRef:                                     ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1989,8 +2071,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -2022,15 +2104,15 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2048,16 +2130,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
   %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
   store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %15
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
@@ -2072,8 +2154,8 @@ entry:
   %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
   %29 = ptrtoint i16 addrspace(1)* %28 to i64
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %19
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
@@ -2089,19 +2171,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2114,8 +2196,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
@@ -2128,7 +2210,7 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[loadElem]
+Failed to read AppDomain.PrepareDataForSetup[storeElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
@@ -2202,8 +2284,8 @@ entry:
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
-  br i1 %NullCheck24, label %27, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = load i64, i64 addrspace(1)* %26
@@ -2218,8 +2300,8 @@ entry:
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
-  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
   %41 = load i64, i64 addrspace(1)* %39
@@ -2236,8 +2318,8 @@ entry:
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
-  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
   %54 = load i64, i64 addrspace(1)* %52
@@ -2252,8 +2334,8 @@ entry:
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
   %67 = load i64, i64 addrspace(1)* %65
@@ -2270,8 +2352,8 @@ entry:
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
-  br i1 %NullCheck16, label %79, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
   %80 = load i64, i64 addrspace(1)* %78
@@ -2286,8 +2368,8 @@ entry:
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
-  br i1 %NullCheck18, label %92, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
   %93 = load i64, i64 addrspace(1)* %91
@@ -2304,8 +2386,8 @@ entry:
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
-  br i1 %NullCheck12, label %105, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = load i64, i64 addrspace(1)* %104
@@ -2320,8 +2402,8 @@ entry:
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
-  br i1 %NullCheck14, label %118, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
   %119 = load i64, i64 addrspace(1)* %117
@@ -2337,8 +2419,8 @@ entry:
 
 ; <label>:128                                     ; preds = %20
   %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
-  br i1 %NullCheck4, label %130, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %129, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %130
 
 ; <label>:130                                     ; preds = %128
   %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
@@ -2346,8 +2428,8 @@ entry:
   %133 = load i16, i16 addrspace(1)* %132, align 8
   %134 = zext i16 %133 to i32
   %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
-  br i1 %NullCheck6, label %136, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %135, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %136
 
 ; <label>:136                                     ; preds = %130
   %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
@@ -2360,8 +2442,8 @@ entry:
 
 ; <label>:143                                     ; preds = %136
   %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
-  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %144, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %145
 
 ; <label>:145                                     ; preds = %143
   %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
@@ -2369,8 +2451,8 @@ entry:
   %148 = load i16, i16 addrspace(1)* %147, align 8
   %149 = zext i16 %148 to i32
   %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %150, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %151
 
 ; <label>:151                                     ; preds = %145
   %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
@@ -2388,8 +2470,8 @@ entry:
 
 ; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
-  br i1 %NullCheck, label %163, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %ThrowNullRef, label %163
 
 ; <label>:163                                     ; preds = %161
   %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
@@ -2399,8 +2481,8 @@ entry:
 
 ; <label>:167                                     ; preds = %163
   %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
-  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %168, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %169
 
 ; <label>:169                                     ; preds = %167
   %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
@@ -2432,55 +2514,55 @@ ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %167
+ThrowNullRef2:                                    ; preds = %167
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %128
+ThrowNullRef4:                                    ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %130
+ThrowNullRef6:                                    ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %143
+ThrowNullRef8:                                    ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %145
+ThrowNullRef10:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %102
+ThrowNullRef12:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %105
+ThrowNullRef14:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %76
+ThrowNullRef16:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %79
+ThrowNullRef18:                                   ; preds = %79
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %50
+ThrowNullRef20:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %53
+ThrowNullRef22:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %24
+ThrowNullRef24:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %27
+ThrowNullRef26:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2503,15 +2585,15 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2519,16 +2601,16 @@ entry:
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
   store i32 %8, i32* %loc0
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
   %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
   store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
@@ -2546,16 +2628,16 @@ entry:
 
 ; <label>:23                                      ; preds = %64
   %24 = load i16*, i16** %loc3
-  %NullCheck12 = icmp ne i16* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i16* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
   store i32 %27, i32* %loc5
   %28 = load i16*, i16** %loc4
-  %NullCheck14 = icmp ne i16* %28, null
-  br i1 %NullCheck14, label %29, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %28, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = load i16, i16* %28, align 8
@@ -2620,15 +2702,15 @@ entry:
 
 ; <label>:67                                      ; preds = %64
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
-  br i1 %NullCheck8, label %69, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %68, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %69
 
 ; <label>:69                                      ; preds = %67
   %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
   %71 = load i32, i32 addrspace(1)* %70
   %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
-  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %73
 
 ; <label>:73                                      ; preds = %69
   %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
@@ -2645,31 +2727,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %67
+ThrowNullRef8:                                    ; preds = %67
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %69
+ThrowNullRef10:                                   ; preds = %69
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2710,14 +2792,14 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
   %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
@@ -2730,14 +2812,14 @@ entry:
 
 ; <label>:11                                      ; preds = %4
   %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
   %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
@@ -2749,14 +2831,14 @@ entry:
 
 ; <label>:22                                      ; preds = %16
   %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
   %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
-  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
-  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
@@ -2804,23 +2886,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2836,7 +2918,280 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[loadElem]
+Successfully read RuntimeType.IsAssignableFrom
+
+define i8 @RuntimeType.IsAssignableFrom(%System.RuntimeType addrspace(1)* %param0, %System.Type addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.RuntimeType addrspace(1)*
+  %arg1 = alloca %System.Type addrspace(1)*
+  %loc0 = alloca %System.RuntimeType addrspace(1)*
+  %loc1 = alloca %"System.Type[]" addrspace(1)*
+  %loc2 = alloca i32
+  store %System.RuntimeType addrspace(1)* %param0, %System.RuntimeType addrspace(1)** %this
+  store %System.Type addrspace(1)* %param1, %System.Type addrspace(1)** %arg1
+  %0 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %1 = icmp ne %System.Type addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i8 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %5 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %6 = bitcast %System.Type addrspace(1)* %4 to %System.Object addrspace(1)*
+  %7 = bitcast %System.RuntimeType addrspace(1)* %5 to %System.Object addrspace(1)*
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %6, %System.Object addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %3
+  ret i8 1
+
+; <label>:12                                      ; preds = %3
+  %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 152
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 32
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
+  %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
+  %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
+  store %System.RuntimeType addrspace(1)* %25, %System.RuntimeType addrspace(1)** %loc0
+  %26 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %27 = icmp eq %System.RuntimeType addrspace(1)* %26, null
+  br i1 %27, label %34, label %28
+
+; <label>:28                                      ; preds = %15
+  %29 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %30 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)*)*)(%System.RuntimeType addrspace(1)* %29, %System.RuntimeType addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+; <label>:34                                      ; preds = %15
+  %35 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %36 = call %System.Reflection.Emit.TypeBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Reflection.Emit.TypeBuilder addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %35)
+  %37 = icmp eq %System.Reflection.Emit.TypeBuilder addrspace(1)* %36, null
+  br i1 %37, label %139, label %38
+
+; <label>:38                                      ; preds = %34
+  %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %42
+
+; <label>:42                                      ; preds = %38
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 152
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 40
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
+  %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
+  %53 = zext i8 %52 to i32
+  %54 = icmp eq i32 %53, 0
+  br i1 %54, label %56, label %55
+
+; <label>:55                                      ; preds = %42
+  ret i8 1
+
+; <label>:56                                      ; preds = %42
+  %57 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %58 = bitcast %System.RuntimeType addrspace(1)* %57 to %System.Type addrspace(1)*
+  %59 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %58)
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %64 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.Type addrspace(1)* %63, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = bitcast %System.RuntimeType addrspace(1)* %64 to %System.Type addrspace(1)*
+  %67 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %63, %System.Type addrspace(1)* %66)
+  %68 = zext i8 %67 to i32
+  %69 = trunc i32 %68 to i8
+  ret i8 %69
+
+; <label>:70                                      ; preds = %56
+  %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
+  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %73
+
+; <label>:73                                      ; preds = %70
+  %74 = load i64, i64 addrspace(1)* %72
+  %75 = add i64 %74, 128
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = add i64 %77, 0
+  %79 = inttoptr i64 %78 to i64*
+  %80 = load i64, i64* %79
+  %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
+  %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
+  %83 = call i8 %82(%System.Type addrspace(1)* %81)
+  %84 = zext i8 %83 to i32
+  %85 = icmp eq i32 %84, 0
+  br i1 %85, label %139, label %86
+
+; <label>:86                                      ; preds = %73
+  %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
+  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %89
+
+; <label>:89                                      ; preds = %86
+  %90 = load i64, i64 addrspace(1)* %88
+  %91 = add i64 %90, 128
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = add i64 %93, 24
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
+  %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
+  %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
+  store %"System.Type[]" addrspace(1)* %99, %"System.Type[]" addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %129
+
+; <label>:100                                     ; preds = %132
+  %101 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %102 = load i32, i32* %loc2
+  %NullCheck11 = icmp eq %"System.Type[]" addrspace(1)* %101, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %103
+
+; <label>:103                                     ; preds = %100
+  %104 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 1
+  %105 = load i32, i32 addrspace(1)* %104
+  %106 = zext i32 %105 to i64
+  %107 = zext i32 %102 to i64
+  %BoundsCheck = icmp uge i64 %107, %106
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %108
+
+; <label>:108                                     ; preds = %103
+  %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
+  %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
+  %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
+  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %113
+
+; <label>:113                                     ; preds = %108
+  %114 = load i64, i64 addrspace(1)* %112
+  %115 = add i64 %114, 152
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = add i64 %117, 56
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
+  %123 = zext i8 %122 to i32
+  %124 = icmp ne i32 %123, 0
+  br i1 %124, label %126, label %125
+
+; <label>:125                                     ; preds = %113
+  ret i8 0
+
+; <label>:126                                     ; preds = %113
+  %127 = load i32, i32* %loc2
+  %128 = add i32 %127, 1
+  store i32 %128, i32* %loc2
+  br label %129
+
+; <label>:129                                     ; preds = %89, %126
+  %130 = load i32, i32* %loc2
+  %131 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %NullCheck9 = icmp eq %"System.Type[]" addrspace(1)* %131, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %132
+
+; <label>:132                                     ; preds = %129
+  %133 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %131, i32 0, i32 1
+  %134 = load i32, i32 addrspace(1)* %133
+  %135 = zext i32 %134 to i64
+  %136 = trunc i64 %135 to i32
+  %137 = icmp slt i32 %130, %136
+  br i1 %137, label %100, label %138
+
+; <label>:138                                     ; preds = %132
+  ret i8 1
+
+; <label>:139                                     ; preds = %34, %73
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %129
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %103
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -2893,7 +3248,7 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElem]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -2904,8 +3259,8 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -2997,8 +3352,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
@@ -3059,8 +3414,8 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -3087,8 +3442,8 @@ entry:
 
 ; <label>:17                                      ; preds = %5, %11
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
@@ -3097,8 +3452,8 @@ entry:
 
 ; <label>:22                                      ; preds = %1, %11
   %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
@@ -3109,11 +3464,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %17
+ThrowNullRef2:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %22
+ThrowNullRef4:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3167,15 +3522,15 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
   %15 = load i32, i32 addrspace(1)* %14
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
@@ -3198,7 +3553,7 @@ ThrowNullRef:                                     ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef2:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3232,8 +3587,8 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
@@ -3312,8 +3667,8 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -3327,8 +3682,8 @@ entry:
 ; <label>:5                                       ; preds = %43
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %7 = load i32, i32* %loc1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck6, label %8, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
@@ -3366,8 +3721,8 @@ entry:
 ; <label>:32                                      ; preds = %21, %25
   %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
   %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
-  br i1 %NullCheck8, label %35, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = trunc i32 %34 to i16
@@ -3380,8 +3735,8 @@ entry:
 ; <label>:40                                      ; preds = %1, %35
   %41 = load i32, i32* %loc1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
-  br i1 %NullCheck2, label %43, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %42, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
@@ -3392,8 +3747,8 @@ entry:
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
   %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
-  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
   %51 = load i64, i64 addrspace(1)* %49
@@ -3412,19 +3767,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %40
+ThrowNullRef2:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %47
+ThrowNullRef4:                                    ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %5
+ThrowNullRef6:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %32
+ThrowNullRef8:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3467,8 +3822,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
@@ -3492,11 +3847,391 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(i16* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store i16* %param0, i16** %arg0
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load i32, i32* %arg3
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %42, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %37, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg2
+  %13 = load i32, i32* %arg3
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %37, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %24 = load i32, i32* %arg2
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load i16*, i16** %arg0
+  %35 = load i32, i32* %arg3
+  %36 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %36, i16* %34, i32 %35)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:37                                      ; preds = %5, %16
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %39)
+  %41 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41, %System.String addrspace(1)* %38, %System.String addrspace(1)* %40)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41) #0
+  unreachable
+
+; <label>:42                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
-Failed to read StringBuilder.ToString[loadElemA]
+Successfully read StringBuilder.ToString
+
+define %System.String addrspace(1)* @StringBuilder.ToString(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i16*
+  %loc3 = alloca %"System.Char[]" addrspace(1)*
+  %loc4 = alloca i32
+  %loc5 = alloca i32
+  %loc6 = alloca i16 addrspace(1)*
+  %loc7 = alloca %System.String addrspace(1)*
+  %loc8 = alloca %"System.Char[]" addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %0)
+  %2 = icmp ne i32 %1, 0
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %4
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %6)
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %7)
+  store %System.String addrspace(1)* %8, %System.String addrspace(1)** %loc0
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.Text.StringBuilder addrspace(1)* %9, %System.Text.StringBuilder addrspace(1)** %loc1
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  store %System.String addrspace(1)* %10, %System.String addrspace(1)** %loc7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc7
+  %12 = ptrtoint %System.String addrspace(1)* %11 to i64
+  %13 = icmp eq i64 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %5
+  %15 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %16 = sext i32 %15 to i64
+  %17 = add i64 %12, %16
+  br label %18
+
+; <label>:18                                      ; preds = %5, %14
+  %19 = phi i64 [ %12, %5 ], [ %17, %14 ]
+  %20 = inttoptr i64 %19 to i16*
+  store i16* %20, i16** %loc2
+  br label %21
+
+; <label>:21                                      ; preds = %98, %18
+  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %22, null
+  br i1 %NullCheck, label %ThrowNullRef, label %23
+
+; <label>:23                                      ; preds = %21
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 3
+  %25 = load i32, i32 addrspace(1)* %24, align 8
+  %26 = icmp sle i32 %25, 0
+  br i1 %26, label %96, label %27
+
+; <label>:27                                      ; preds = %23
+  %28 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %28, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %29
+
+; <label>:29                                      ; preds = %27
+  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %28, i32 0, i32 1
+  %31 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %30, align 8
+  store %"System.Char[]" addrspace(1)* %31, %"System.Char[]" addrspace(1)** %loc3
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %33
+
+; <label>:33                                      ; preds = %29
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  store i32 %35, i32* %loc4
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  %39 = load i32, i32 addrspace(1)* %38, align 8
+  store i32 %39, i32* %loc5
+  %40 = load i32, i32* %loc5
+  %41 = load i32, i32* %loc4
+  %42 = add i32 %40, %41
+  %43 = zext i32 %42 to i64
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %45
+
+; <label>:45                                      ; preds = %37
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = sext i32 %47 to i64
+  %49 = icmp sgt i64 %43, %48
+  br i1 %49, label %91, label %50
+
+; <label>:50                                      ; preds = %45
+  %51 = load i32, i32* %loc5
+  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %52, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %53
+
+; <label>:53                                      ; preds = %50
+  %54 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %52, i32 0, i32 1
+  %55 = load i32, i32 addrspace(1)* %54
+  %56 = zext i32 %55 to i64
+  %57 = trunc i64 %56 to i32
+  %58 = icmp ugt i32 %51, %57
+  br i1 %58, label %91, label %59
+
+; <label>:59                                      ; preds = %53
+  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  store %"System.Char[]" addrspace(1)* %60, %"System.Char[]" addrspace(1)** %loc8
+  %61 = icmp eq %"System.Char[]" addrspace(1)* %60, null
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %63, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %64
+
+; <label>:64                                      ; preds = %62
+  %65 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %63, i32 0, i32 1
+  %66 = load i32, i32 addrspace(1)* %65
+  %67 = zext i32 %66 to i64
+  %68 = trunc i64 %67 to i32
+  %69 = icmp ne i32 %68, 0
+  br i1 %69, label %71, label %70
+
+; <label>:70                                      ; preds = %59, %64
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:71                                      ; preds = %64
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %73
+
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %BoundsCheck = icmp uge i64 0, %76
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %77
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %78, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:79                                      ; preds = %70, %77
+  %80 = load i16*, i16** %loc2
+  %81 = load i32, i32* %loc4
+  %82 = sext i32 %81 to i64
+  %83 = mul i64 %82, 2
+  %84 = bitcast i16* %80 to i8*
+  %85 = getelementptr inbounds i8, i8* %84, i64 %83
+  %86 = load i16 addrspace(1)*, i16 addrspace(1)** %loc6
+  %87 = ptrtoint i16 addrspace(1)* %86 to i64
+  %88 = load i32, i32* %loc5
+  %89 = bitcast i8* %85 to i16*
+  %90 = inttoptr i64 %87 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %89, i16* %90, i32 %88)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %96
+
+; <label>:91                                      ; preds = %45, %53
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %94 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %93)
+  %95 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95, %System.String addrspace(1)* %92, %System.String addrspace(1)* %94)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95) #0
+  unreachable
+
+; <label>:96                                      ; preds = %23, %79
+  %97 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %97, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %98
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %97, i32 0, i32 2
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  store %System.Text.StringBuilder addrspace(1)* %100, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %102 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %102, label %21, label %103
+
+; <label>:103                                     ; preds = %98
+  store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc7
+  %104 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  ret %System.String addrspace(1)* %104
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method StringBuilder::get_Length using LLILCJit
+Successfully read StringBuilder.get_Length
+
+define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
+Successfully read RuntimeHelpers.get_OffsetToStringData
+
+define i32 @RuntimeHelpers.get_OffsetToStringData() {
+entry:
+  ret i32 12
+}
+
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
 Successfully read CultureData.CreateCultureData
 
@@ -3514,23 +4249,23 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
   store i8 %4, i8 addrspace(1)* %6
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
@@ -3549,11 +4284,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3566,50 +4301,50 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
   store i32 -1, i32 addrspace(1)* %2
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
   store i32 -1, i32 addrspace(1)* %8
   %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
   store i32 -1, i32 addrspace(1)* %14
   %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
   store i32 -1, i32 addrspace(1)* %17
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
@@ -3623,27 +4358,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3675,7 +4410,136 @@ Failed to read Dictionary`2.Insert[non-const derefAddress]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
 Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
-Failed to read HashHelpers.GetPrime[loadElem]
+Successfully read HashHelpers.GetPrime
+
+define i32 @HashHelpers.GetPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %6, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5, %System.String addrspace(1)* %4)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5) #0
+  unreachable
+
+; <label>:6                                       ; preds = %entry
+  store i32 0, i32* %loc0
+  br label %29
+
+; <label>:7                                       ; preds = %35
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 1296
+  %10 = addrspacecast i8 addrspace(1)* %9 to %"System.Int32[]" addrspace(1)**
+  %11 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %10
+  %12 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Int32[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = zext i32 %15 to i64
+  %17 = zext i32 %12 to i64
+  %BoundsCheck = icmp uge i64 %17, %16
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 3, i32 %12
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  store i32 %20, i32* %loc1
+  %21 = load i32, i32* %loc1
+  %22 = load i32, i32* %arg0
+  %23 = icmp slt i32 %21, %22
+  br i1 %23, label %26, label %24
+
+; <label>:24                                      ; preds = %18
+  %25 = load i32, i32* %loc1
+  ret i32 %25
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %loc0
+  %28 = add i32 %27, 1
+  store i32 %28, i32* %loc0
+  br label %29
+
+; <label>:29                                      ; preds = %6, %26
+  %30 = load i32, i32* %loc0
+  %31 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %32 = getelementptr inbounds i8, i8 addrspace(1)* %31, i64 1296
+  %33 = addrspacecast i8 addrspace(1)* %32 to %"System.Int32[]" addrspace(1)**
+  %34 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %33
+  %NullCheck = icmp eq %"System.Int32[]" addrspace(1)* %34, null
+  br i1 %NullCheck, label %ThrowNullRef, label %35
+
+; <label>:35                                      ; preds = %29
+  %36 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %34, i32 0, i32 1
+  %37 = load i32, i32 addrspace(1)* %36
+  %38 = zext i32 %37 to i64
+  %39 = trunc i64 %38 to i32
+  %40 = icmp slt i32 %30, %39
+  br i1 %40, label %7, label %41
+
+; <label>:41                                      ; preds = %35
+  %42 = load i32, i32* %arg0
+  %43 = or i32 %42, 1
+  store i32 %43, i32* %loc2
+  br label %59
+
+; <label>:44                                      ; preds = %59
+  %45 = load i32, i32* %loc2
+  %46 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %45)
+  %47 = zext i8 %46 to i32
+  %48 = icmp eq i32 %47, 0
+  br i1 %48, label %56, label %49
+
+; <label>:49                                      ; preds = %44
+  %50 = load i32, i32* %loc2
+  %51 = sub i32 %50, 1
+  %52 = srem i32 %51, 101
+  %53 = icmp eq i32 %52, 0
+  br i1 %53, label %56, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = load i32, i32* %loc2
+  ret i32 %55
+
+; <label>:56                                      ; preds = %44, %49
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %57, 2
+  store i32 %58, i32* %loc2
+  br label %59
+
+; <label>:59                                      ; preds = %41, %56
+  %60 = load i32, i32* %loc2
+  %61 = icmp slt i32 %60, 2147483647
+  br i1 %61, label %44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load i32, i32* %arg0
+  ret i32 %63
+
+ThrowNullRef:                                     ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
 Successfully read GenericEqualityComparer`1.GetHashCode
 
@@ -3694,14 +4558,14 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
   %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load i64, i64 addrspace(1)* %7
@@ -3720,7 +4584,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3750,8 +4614,8 @@ entry:
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
@@ -3796,8 +4660,8 @@ entry:
   %35 = bitcast i16* %34 to i8*
   %36 = getelementptr inbounds i8, i8* %35, i64 2
   %37 = bitcast i8* %36 to i16*
-  %NullCheck4 = icmp ne i16* %37, null
-  br i1 %NullCheck4, label %38, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %37, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %38
 
 ; <label>:38                                      ; preds = %27
   %39 = load i16, i16* %37, align 8
@@ -3824,8 +4688,8 @@ entry:
 
 ; <label>:54                                      ; preds = %22, %43
   %55 = load i16*, i16** %loc4
-  %NullCheck2 = icmp ne i16* %55, null
-  br i1 %NullCheck2, label %56, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i16* %55, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %56
 
 ; <label>:56                                      ; preds = %54
   %57 = load i16, i16* %55, align 8
@@ -3850,11 +4714,11 @@ ThrowNullRef:                                     ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %54
+ThrowNullRef2:                                    ; preds = %54
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %27
+ThrowNullRef4:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3871,8 +4735,8 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -3907,8 +4771,8 @@ entry:
 
 ; <label>:26                                      ; preds = %19
   %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
-  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %28
 
 ; <label>:28                                      ; preds = %26
   %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
@@ -3920,7 +4784,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3972,8 +4836,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
@@ -3984,26 +4848,26 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
-  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
@@ -4014,8 +4878,8 @@ entry:
 ; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
@@ -4024,8 +4888,8 @@ entry:
 
 ; <label>:25                                      ; preds = %1, %16, %23
   %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
-  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
@@ -4036,27 +4900,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %20
+ThrowNullRef10:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4069,8 +4933,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -4081,8 +4945,8 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
@@ -4091,8 +4955,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1, %8
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
@@ -4103,11 +4967,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4128,24 +4992,24 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   store i32 %3, i32* %loc0
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
   %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
   store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck4, label %9, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
@@ -4164,15 +5028,15 @@ entry:
 ; <label>:18                                      ; preds = %70
   %19 = load i16*, i16** %loc3
   %20 = bitcast i16* %19 to i64*
-  %NullCheck10 = icmp ne i64* %20, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %20, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = load i64, i64* %20, align 8
   %23 = load i16*, i16** %loc4
   %24 = bitcast i16* %23 to i64*
-  %NullCheck12 = icmp ne i64* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = load i64, i64* %24, align 8
@@ -4188,8 +5052,8 @@ entry:
   %31 = bitcast i16* %30 to i8*
   %32 = getelementptr inbounds i8, i8* %31, i64 8
   %33 = bitcast i8* %32 to i64*
-  %NullCheck14 = icmp ne i64* %33, null
-  br i1 %NullCheck14, label %34, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = load i64, i64* %33, align 8
@@ -4197,8 +5061,8 @@ entry:
   %37 = bitcast i16* %36 to i8*
   %38 = getelementptr inbounds i8, i8* %37, i64 8
   %39 = bitcast i8* %38 to i64*
-  %NullCheck16 = icmp ne i64* %39, null
-  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %40
 
 ; <label>:40                                      ; preds = %34
   %41 = load i64, i64* %39, align 8
@@ -4214,8 +5078,8 @@ entry:
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %NullCheck18 = icmp ne i64* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = load i64, i64* %48, align 8
@@ -4223,8 +5087,8 @@ entry:
   %52 = bitcast i16* %51 to i8*
   %53 = getelementptr inbounds i8, i8* %52, i64 16
   %54 = bitcast i8* %53 to i64*
-  %NullCheck20 = icmp ne i64* %54, null
-  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64* %54, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %55
 
 ; <label>:55                                      ; preds = %49
   %56 = load i64, i64* %54, align 8
@@ -4262,15 +5126,15 @@ entry:
 ; <label>:74                                      ; preds = %95
   %75 = load i16*, i16** %loc3
   %76 = bitcast i16* %75 to i32*
-  %NullCheck6 = icmp ne i32* %76, null
-  br i1 %NullCheck6, label %77, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32* %76, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %77
 
 ; <label>:77                                      ; preds = %74
   %78 = load i32, i32* %76, align 8
   %79 = load i16*, i16** %loc4
   %80 = bitcast i16* %79 to i32*
-  %NullCheck8 = icmp ne i32* %80, null
-  br i1 %NullCheck8, label %81, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i32* %80, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %81
 
 ; <label>:81                                      ; preds = %77
   %82 = load i32, i32* %80, align 8
@@ -4318,43 +5182,43 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %74
+ThrowNullRef6:                                    ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %77
+ThrowNullRef8:                                    ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %29
+ThrowNullRef14:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %34
+ThrowNullRef16:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4376,8 +5240,8 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load i64, i64 addrspace(1)* %4
@@ -4389,8 +5253,8 @@ entry:
   %12 = load i64, i64* %11
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %5
   %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
@@ -4399,8 +5263,8 @@ entry:
   %18 = load i8, i8* %arg2
   %19 = zext i8 %18 to i32
   %20 = trunc i32 %19 to i8
-  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %15
   %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
@@ -4411,11 +5275,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4442,8 +5306,8 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
@@ -4466,16 +5330,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
   %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = load i64, i64 addrspace(1)* %19
@@ -4500,8 +5364,8 @@ entry:
 ; <label>:35                                      ; preds = %30
   %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
@@ -4514,8 +5378,8 @@ entry:
 
 ; <label>:42                                      ; preds = %1, %38
   %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
-  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
@@ -4526,19 +5390,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %35
+ThrowNullRef2:                                    ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %42
+ThrowNullRef8:                                    ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4551,14 +5415,14 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
@@ -4570,7 +5434,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4583,8 +5447,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
@@ -4613,51 +5477,51 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
   %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
   %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
   %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
   %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
-  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
   store i64 %21, i64 addrspace(1)* %23
   %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %25 = load i64, i64* %loc0
-  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
@@ -4668,27 +5532,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %22
+ThrowNullRef12:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4701,8 +5565,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
@@ -4713,19 +5577,19 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
@@ -4734,8 +5598,8 @@ entry:
 
 ; <label>:15                                      ; preds = %1, %13
   %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
@@ -4746,19 +5610,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %15
+ThrowNullRef8:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4771,8 +5635,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -4831,8 +5695,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
@@ -4882,8 +5746,8 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
-  br i1 %NullCheck, label %17, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %ThrowNullRef, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
@@ -4894,15 +5758,15 @@ entry:
 
 ; <label>:22                                      ; preds = %17
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
-  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
   %26 = load i32, i32 addrspace(1)* %25
   %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
-  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %27, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
@@ -4925,8 +5789,8 @@ entry:
 ; <label>:40                                      ; preds = %17
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
-  br i1 %NullCheck6, label %43, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %41, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
@@ -4938,34 +5802,17 @@ ThrowNullRef:                                     ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %24
+ThrowNullRef4:                                    ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %40
+ThrowNullRef6:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
-}
-
-INFO:  jitting method Object::ReferenceEquals using LLILCJit
-Successfully read Object.ReferenceEquals
-
-define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
-entry:
-  %arg0 = alloca %System.Object addrspace(1)*
-  %arg1 = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
-  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
-  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = icmp eq %System.Object addrspace(1)* %0, %1
-  %3 = sext i1 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
 }
 
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
@@ -4978,21 +5825,21 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
   %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
-  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
@@ -5007,28 +5854,28 @@ entry:
 ; <label>:13                                      ; preds = %8, %12
   %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
   %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
   %21 = load i32, i32 addrspace(1)* %20, align 8
   %22 = add i32 %21, 1
-  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
   store i32 %22, i32 addrspace(1)* %24
   %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
@@ -5039,27 +5886,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5077,7 +5924,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::Setup using LLILCJit
-Failed to read AppDomain.Setup[loadElem]
+Failed to read AppDomain.Setup[unbox]
 INFO:  jitting method Thread::GetDomain using LLILCJit
 Successfully read Thread.GetDomain
 
@@ -5108,8 +5955,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
@@ -5122,14 +5969,14 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
   %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
@@ -5141,11 +5988,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5173,8 +6020,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -5189,7 +6036,328 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
 Failed to read KeyCollection.System.Collections.Generic.IEnumerable<TKey>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Successfully read Enumerator.MoveNext
+
+define i8 @Enumerator.MoveNext(%"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.RuntimeTypeHandle* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*
+  %"$TypeArg" = alloca %System.RuntimeTypeHandle*
+  store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
+  %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 8
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %76, label %12
+
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
+  br label %76
+
+; <label>:13                                      ; preds = %85
+  %14 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck19 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %15
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, i32 0, i32 0
+  %17 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %16, align 8
+  %NullCheck21 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, i32 0, i32 2
+  %20 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %19, align 8
+  %21 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck23 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %22
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, i32 0, i32 2
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %NullCheck25 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 3, i32 %24
+  %NullCheck27 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %32
+
+; <label>:32                                      ; preds = %30
+  %33 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, i32 0, i32 2
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = icmp slt i32 %34, 0
+  br i1 %35, label %68, label %36
+
+; <label>:36                                      ; preds = %32
+  %37 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %38 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck29 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %39
+
+; <label>:39                                      ; preds = %36
+  %40 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, i32 0, i32 0
+  %41 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %40, align 8
+  %NullCheck31 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, i32 0, i32 2
+  %44 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %43, align 8
+  %45 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck33 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, i32 0, i32 2
+  %48 = load i32, i32 addrspace(1)* %47, align 8
+  %NullCheck35 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %49
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = zext i32 %51 to i64
+  %53 = zext i32 %48 to i64
+  %BoundsCheck37 = icmp uge i64 %53, %52
+  br i1 %BoundsCheck37, label %ThrowIndexOutOfRange38, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 3, i32 %48
+  %NullCheck39 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %56
+
+; <label>:56                                      ; preds = %54
+  %57 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, i32 0, i32 0
+  %58 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck41 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %59
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %60, %System.__Canon addrspace(1)* %58)
+  %61 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck43 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  %64 = load i32, i32 addrspace(1)* %63, align 8
+  %65 = add i32 %64, 1
+  %NullCheck45 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  store i32 %65, i32 addrspace(1)* %67
+  ret i8 1
+
+; <label>:68                                      ; preds = %32
+  %69 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck47 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %73 = add i32 %72, 1
+  %NullCheck49 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %74
+
+; <label>:74                                      ; preds = %70
+  %75 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  store i32 %73, i32 addrspace(1)* %75
+  br label %76
+
+; <label>:76                                      ; preds = %8, %12, %74
+  %77 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %78
+
+; <label>:78                                      ; preds = %76
+  %79 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, i32 0, i32 2
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck7 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %82
+
+; <label>:82                                      ; preds = %78
+  %83 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, i32 0, i32 0
+  %84 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %83, align 8
+  %NullCheck9 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %85
+
+; <label>:85                                      ; preds = %82
+  %86 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, i32 0, i32 7
+  %87 = load i32, i32 addrspace(1)* %86, align 8
+  %88 = icmp ult i32 %80, %87
+  br i1 %88, label %13, label %89
+
+; <label>:89                                      ; preds = %85
+  %90 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %91 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck11 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %92
+
+; <label>:92                                      ; preds = %89
+  %93 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, i32 0, i32 0
+  %94 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck13 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %95
+
+; <label>:95                                      ; preds = %92
+  %96 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, i32 0, i32 7
+  %97 = load i32, i32 addrspace(1)* %96, align 8
+  %98 = add i32 %97, 1
+  %NullCheck15 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %99
+
+; <label>:99                                      ; preds = %95
+  %100 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, i32 0, i32 2
+  store i32 %98, i32 addrspace(1)* %100
+  %101 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck17 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %102
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %103, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %92
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef22:                                   ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef24:                                   ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef26:                                   ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef28:                                   ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef30:                                   ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef32:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef34:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef36:                                   ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange38:                           ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef40:                                   ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef42:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef44:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef46:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef48:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef50:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -5200,8 +6368,8 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -5232,9 +6400,9 @@ Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
 Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
-Failed to read String.MakeSeparatorList[loadElemA]
+Failed to read String.MakeSeparatorList[storeElem]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
-Failed to read String.InternalSplitKeepEmptyEntries[loadElem]
+Failed to read String.InternalSplitKeepEmptyEntries[storeElem]
 INFO:  jitting method Path::IsRelative using LLILCJit
 Successfully read Path.IsRelative
 
@@ -5243,8 +6411,8 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -5254,8 +6422,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
@@ -5271,8 +6439,8 @@ entry:
 
 ; <label>:17                                      ; preds = %7
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
@@ -5288,8 +6456,8 @@ entry:
 
 ; <label>:29                                      ; preds = %19
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %31
 
 ; <label>:31                                      ; preds = %29
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
@@ -5300,8 +6468,8 @@ entry:
 
 ; <label>:36                                      ; preds = %31
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
-  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %37, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
@@ -5312,8 +6480,8 @@ entry:
 
 ; <label>:43                                      ; preds = %31, %38
   %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
-  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %45
 
 ; <label>:45                                      ; preds = %43
   %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
@@ -5324,8 +6492,8 @@ entry:
 
 ; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %50
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
@@ -5336,8 +6504,8 @@ entry:
 
 ; <label>:57                                      ; preds = %1, %7, %19, %45, %52
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
-  br i1 %NullCheck14, label %59, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %59
 
 ; <label>:59                                      ; preds = %57
   %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
@@ -5347,8 +6515,8 @@ entry:
 
 ; <label>:63                                      ; preds = %59
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
@@ -5359,8 +6527,8 @@ entry:
 
 ; <label>:70                                      ; preds = %65
   %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
-  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.String addrspace(1)* %71, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %72
 
 ; <label>:72                                      ; preds = %70
   %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
@@ -5379,39 +6547,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %17
+ThrowNullRef4:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %29
+ThrowNullRef6:                                    ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %36
+ThrowNullRef8:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %43
+ThrowNullRef10:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %50
+ThrowNullRef12:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %57
+ThrowNullRef14:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %63
+ThrowNullRef16:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %70
+ThrowNullRef18:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5419,7 +6587,293 @@ ThrowNullRef17:                                   ; preds = %70
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
-Failed to read String.TrimHelper[loadElem]
+Successfully read String.TrimHelper
+
+define %System.String addrspace(1)* @String.TrimHelper(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i16
+  %loc4 = alloca i32
+  %loc5 = alloca i16
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = sub i32 %3, 1
+  store i32 %4, i32* %loc0
+  store i32 0, i32* %loc1
+  %5 = load i32, i32* %arg2
+  %6 = icmp eq i32 %5, 1
+  br i1 %6, label %62, label %7
+
+; <label>:7                                       ; preds = %1
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:8                                       ; preds = %58
+  store i32 0, i32* %loc2
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load i32, i32* %loc1
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2, i32 %10
+  %13 = load i16, i16 addrspace(1)* %12
+  %14 = zext i16 %13 to i32
+  %15 = trunc i32 %14 to i16
+  store i16 %15, i16* %loc3
+  store i32 0, i32* %loc2
+  br label %34
+
+; <label>:16                                      ; preds = %37
+  %17 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %18 = load i32, i32* %loc2
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %17, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %19
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = zext i32 %18 to i64
+  %BoundsCheck = icmp uge i64 %23, %22
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %24
+
+; <label>:24                                      ; preds = %19
+  %25 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 3, i32 %18
+  %26 = load i16, i16 addrspace(1)* %25, align 8
+  %27 = zext i16 %26 to i32
+  %28 = load i16, i16* %loc3
+  %29 = zext i16 %28 to i32
+  %30 = icmp eq i32 %27, %29
+  br i1 %30, label %43, label %31
+
+; <label>:31                                      ; preds = %24
+  %32 = load i32, i32* %loc2
+  %33 = add i32 %32, 1
+  store i32 %33, i32* %loc2
+  br label %34
+
+; <label>:34                                      ; preds = %11, %31
+  %35 = load i32, i32* %loc2
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = icmp slt i32 %35, %41
+  br i1 %42, label %16, label %43
+
+; <label>:43                                      ; preds = %24, %37
+  %44 = load i32, i32* %loc2
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %45, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp eq i32 %44, %50
+  br i1 %51, label %62, label %52
+
+; <label>:52                                      ; preds = %46
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %7, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %57, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %58
+
+; <label>:58                                      ; preds = %55
+  %59 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %60 = load i32, i32 addrspace(1)* %59
+  %61 = icmp slt i32 %56, %60
+  br i1 %61, label %8, label %62
+
+; <label>:62                                      ; preds = %1, %46, %58
+  %63 = load i32, i32* %arg2
+  %64 = icmp eq i32 %63, 0
+  br i1 %64, label %122, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %66, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %67
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %66, i32 0, i32 1
+  %69 = load i32, i32 addrspace(1)* %68
+  %70 = sub i32 %69, 1
+  store i32 %70, i32* %loc0
+  br label %118
+
+; <label>:71                                      ; preds = %118
+  store i32 0, i32* %loc4
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %73 = load i32, i32* %loc0
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %74
+
+; <label>:74                                      ; preds = %71
+  %75 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 2, i32 %73
+  %76 = load i16, i16 addrspace(1)* %75
+  %77 = zext i16 %76 to i32
+  %78 = trunc i32 %77 to i16
+  store i16 %78, i16* %loc5
+  store i32 0, i32* %loc4
+  br label %97
+
+; <label>:79                                      ; preds = %100
+  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %81 = load i32, i32* %loc4
+  %NullCheck19 = icmp eq %"System.Char[]" addrspace(1)* %80, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
+
+; <label>:82                                      ; preds = %79
+  %83 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 1
+  %84 = load i32, i32 addrspace(1)* %83
+  %85 = zext i32 %84 to i64
+  %86 = zext i32 %81 to i64
+  %BoundsCheck21 = icmp uge i64 %86, %85
+  br i1 %BoundsCheck21, label %ThrowIndexOutOfRange22, label %87
+
+; <label>:87                                      ; preds = %82
+  %88 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 3, i32 %81
+  %89 = load i16, i16 addrspace(1)* %88, align 8
+  %90 = zext i16 %89 to i32
+  %91 = load i16, i16* %loc5
+  %92 = zext i16 %91 to i32
+  %93 = icmp eq i32 %90, %92
+  br i1 %93, label %106, label %94
+
+; <label>:94                                      ; preds = %87
+  %95 = load i32, i32* %loc4
+  %96 = add i32 %95, 1
+  store i32 %96, i32* %loc4
+  br label %97
+
+; <label>:97                                      ; preds = %74, %94
+  %98 = load i32, i32* %loc4
+  %99 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck15 = icmp eq %"System.Char[]" addrspace(1)* %99, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %100
+
+; <label>:100                                     ; preds = %97
+  %101 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %99, i32 0, i32 1
+  %102 = load i32, i32 addrspace(1)* %101
+  %103 = zext i32 %102 to i64
+  %104 = trunc i64 %103 to i32
+  %105 = icmp slt i32 %98, %104
+  br i1 %105, label %79, label %106
+
+; <label>:106                                     ; preds = %87, %100
+  %107 = load i32, i32* %loc4
+  %108 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck17 = icmp eq %"System.Char[]" addrspace(1)* %108, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %109
+
+; <label>:109                                     ; preds = %106
+  %110 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %108, i32 0, i32 1
+  %111 = load i32, i32 addrspace(1)* %110
+  %112 = zext i32 %111 to i64
+  %113 = trunc i64 %112 to i32
+  %114 = icmp eq i32 %107, %113
+  br i1 %114, label %122, label %115
+
+; <label>:115                                     ; preds = %109
+  %116 = load i32, i32* %loc0
+  %117 = sub i32 %116, 1
+  store i32 %117, i32* %loc0
+  br label %118
+
+; <label>:118                                     ; preds = %67, %115
+  %119 = load i32, i32* %loc0
+  %120 = load i32, i32* %loc1
+  %121 = icmp sge i32 %119, %120
+  br i1 %121, label %71, label %122
+
+; <label>:122                                     ; preds = %62, %109, %118
+  %123 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %124 = load i32, i32* %loc1
+  %125 = load i32, i32* %loc0
+  %126 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %123, i32 %124, i32 %125)
+  ret %System.String addrspace(1)* %126
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %97
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange22:                           ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
 Successfully read String.CreateTrimmedString
 
@@ -5439,8 +6893,8 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
@@ -5535,8 +6989,8 @@ entry:
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i64 2872
   %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
   %8 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %7
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %3
   %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
@@ -5553,8 +7007,8 @@ entry:
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 2864
   %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
   %21 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %20
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
-  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %22
 
 ; <label>:22                                      ; preds = %16
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
@@ -5569,7 +7023,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %16
+ThrowNullRef2:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5586,8 +7040,8 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5613,8 +7067,8 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
@@ -5632,8 +7086,8 @@ entry:
 
 ; <label>:12                                      ; preds = %4
   %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
@@ -5644,8 +7098,8 @@ entry:
 
 ; <label>:19                                      ; preds = %14
   %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %19
   %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
@@ -5660,21 +7114,21 @@ entry:
   %31 = zext i16 %30 to i32
   %32 = bitcast i8* %29 to i16*
   %33 = trunc i32 %31 to i16
-  %NullCheck6 = icmp ne i16* %32, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i16* %32, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %21
   store i16 %33, i16* %32, align 8
   %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %36
 
 ; <label>:36                                      ; preds = %34
   %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
   %38 = load i32, i32 addrspace(1)* %37, align 8
   %39 = add i32 %38, 1
-  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %40
 
 ; <label>:40                                      ; preds = %36
   %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
@@ -5683,16 +7137,16 @@ entry:
 
 ; <label>:42                                      ; preds = %14
   %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
-  br i1 %NullCheck12, label %44, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
   %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
   %47 = load i16, i16* %arg1
   %48 = zext i16 %47 to i32
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = trunc i32 %48 to i16
@@ -5703,31 +7157,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %19
+ThrowNullRef4:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %21
+ThrowNullRef6:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %36
+ThrowNullRef10:                                   ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %42
+ThrowNullRef12:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %44
+ThrowNullRef14:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5740,8 +7194,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -5752,8 +7206,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
@@ -5762,14 +7216,14 @@ entry:
 
 ; <label>:11                                      ; preds = %1
   %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
@@ -5779,15 +7233,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5808,8 +7262,8 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5822,8 +7276,8 @@ entry:
 
 ; <label>:8                                       ; preds = %3
   %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
@@ -5842,15 +7296,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
-  br i1 %NullCheck4, label %22, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
   %24 = load i16*, i16* addrspace(1)* %23, align 8
   %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %25, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
@@ -5859,8 +7313,8 @@ entry:
   store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
@@ -5874,8 +7328,8 @@ entry:
 
 ; <label>:37                                      ; preds = %65
   %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %37
   %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
@@ -5886,16 +7340,16 @@ entry:
   %45 = bitcast i16* %41 to i8*
   %46 = getelementptr inbounds i8, i8* %45, i64 %44
   %47 = bitcast i8* %46 to i16*
-  %NullCheck14 = icmp ne i16* %47, null
-  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %47, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %48
 
 ; <label>:48                                      ; preds = %39
   %49 = load i16, i16* %47, align 8
   %50 = zext i16 %49 to i32
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %52 = load i32, i32* %loc1
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %53
 
 ; <label>:53                                      ; preds = %48
   %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
@@ -5916,8 +7370,8 @@ entry:
 ; <label>:62                                      ; preds = %36, %59
   %63 = load i32, i32* %loc1
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck10, label %65, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %65
 
 ; <label>:65                                      ; preds = %62
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
@@ -5936,15 +7390,15 @@ entry:
 
 ; <label>:74                                      ; preds = %70
   %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
-  br i1 %NullCheck18, label %76, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %76
 
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
   %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
-  br i1 %NullCheck20, label %80, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
   %81 = load i64, i64 addrspace(1)* %79
@@ -5958,8 +7412,8 @@ entry:
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
   %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
-  br i1 %NullCheck22, label %92, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.String addrspace(1)* %90, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %92
 
 ; <label>:92                                      ; preds = %80
   %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
@@ -5969,15 +7423,15 @@ entry:
 
 ; <label>:96                                      ; preds = %70
   %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
-  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %98
 
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
   %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
-  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
   %103 = load i64, i64 addrspace(1)* %101
@@ -5991,8 +7445,8 @@ entry:
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
   %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
-  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.String addrspace(1)* %112, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %114
 
 ; <label>:114                                     ; preds = %102
   %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
@@ -6004,59 +7458,59 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %20
+ThrowNullRef4:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %22
+ThrowNullRef6:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %26
+ThrowNullRef8:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %62
+ThrowNullRef10:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %48
+ThrowNullRef16:                                   ; preds = %48
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %74
+ThrowNullRef18:                                   ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %76
+ThrowNullRef20:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %80
+ThrowNullRef22:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %96
+ThrowNullRef24:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %98
+ThrowNullRef26:                                   ; preds = %98
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %102
+ThrowNullRef28:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6069,15 +7523,15 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
   %3 = load i16*, i16* addrspace(1)* %2, align 8
   %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
@@ -6087,8 +7541,8 @@ entry:
   %10 = bitcast i16* %3 to i8*
   %11 = getelementptr inbounds i8, i8* %10, i64 %9
   %12 = bitcast i8* %11 to i16*
-  %NullCheck4 = icmp ne i16* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %5
   store i16 0, i16* %12, align 8
@@ -6098,11 +7552,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6119,8 +7573,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -6131,8 +7585,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
@@ -6144,15 +7598,15 @@ entry:
 
 ; <label>:14                                      ; preds = %1
   %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
   %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
   %21 = load i64, i64 addrspace(1)* %19
@@ -6171,15 +7625,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %14
+ThrowNullRef4:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %16
+ThrowNullRef6:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6302,14 +7756,6 @@ entry:
   ret %System.String addrspace(1)* %57
 }
 
-INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
-Successfully read RuntimeHelpers.get_OffsetToStringData
-
-define i32 @RuntimeHelpers.get_OffsetToStringData() {
-entry:
-  ret i32 12
-}
-
 INFO:  jitting method String::Equals using LLILCJit
 Successfully read String.Equals
 
@@ -6381,8 +7827,8 @@ entry:
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
-  br i1 %NullCheck24, label %29, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
   %30 = load i64, i64 addrspace(1)* %28
@@ -6397,8 +7843,8 @@ entry:
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
-  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
   %43 = load i64, i64 addrspace(1)* %41
@@ -6418,8 +7864,8 @@ entry:
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
   %59 = load i64, i64 addrspace(1)* %57
@@ -6434,8 +7880,8 @@ entry:
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck22, label %71, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
   %72 = load i64, i64 addrspace(1)* %70
@@ -6455,8 +7901,8 @@ entry:
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
-  br i1 %NullCheck16, label %87, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = load i64, i64 addrspace(1)* %86
@@ -6471,8 +7917,8 @@ entry:
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck18, label %100, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
   %101 = load i64, i64 addrspace(1)* %99
@@ -6492,8 +7938,8 @@ entry:
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
-  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
   %117 = load i64, i64 addrspace(1)* %115
@@ -6508,8 +7954,8 @@ entry:
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
-  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
   %130 = load i64, i64 addrspace(1)* %128
@@ -6528,15 +7974,15 @@ entry:
 
 ; <label>:142                                     ; preds = %22
   %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
-  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %143, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %144
 
 ; <label>:144                                     ; preds = %142
   %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
   %146 = load i32, i32 addrspace(1)* %145
   %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
-  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %147, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %148
 
 ; <label>:148                                     ; preds = %144
   %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
@@ -6557,15 +8003,15 @@ entry:
 
 ; <label>:159                                     ; preds = %22
   %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
-  br i1 %NullCheck, label %161, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %ThrowNullRef, label %161
 
 ; <label>:161                                     ; preds = %159
   %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
   %163 = load i32, i32 addrspace(1)* %162
   %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
-  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %164, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %165
 
 ; <label>:165                                     ; preds = %161
   %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
@@ -6578,8 +8024,8 @@ entry:
 
 ; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
-  br i1 %NullCheck4, label %172, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %171, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %172
 
 ; <label>:172                                     ; preds = %170
   %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
@@ -6589,8 +8035,8 @@ entry:
 
 ; <label>:176                                     ; preds = %172
   %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
-  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %177, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %178
 
 ; <label>:178                                     ; preds = %176
   %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
@@ -6629,55 +8075,55 @@ ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %161
+ThrowNullRef2:                                    ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %170
+ThrowNullRef4:                                    ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %176
+ThrowNullRef6:                                    ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %142
+ThrowNullRef8:                                    ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %144
+ThrowNullRef10:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %113
+ThrowNullRef12:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %116
+ThrowNullRef14:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %84
+ThrowNullRef16:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %87
+ThrowNullRef18:                                   ; preds = %87
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %55
+ThrowNullRef20:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %58
+ThrowNullRef22:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %26
+ThrowNullRef24:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %29
+ThrowNullRef26:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,8 +8161,8 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck, label %14, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %ThrowNullRef, label %14
 
 ; <label>:14                                      ; preds = %8
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
@@ -6760,8 +8206,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
@@ -6770,14 +8216,14 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32, i32* %loc0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %10
   %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
   %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
@@ -6790,15 +8236,15 @@ entry:
 ; <label>:25                                      ; preds = %19
   %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
-  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
   %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
@@ -6807,8 +8253,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %37 = load i32, i32* %loc0
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %38, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %38
 
 ; <label>:38                                      ; preds = %32
   %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
@@ -6817,14 +8263,14 @@ entry:
 
 ; <label>:40                                      ; preds = %19
   %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %40
   %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
   %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
-  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
-  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
@@ -6832,8 +8278,8 @@ entry:
   %48 = zext i32 %47 to i64
   %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
-  br i1 %NullCheck16, label %51, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %51
 
 ; <label>:51                                      ; preds = %45
   %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
@@ -6847,15 +8293,15 @@ entry:
 ; <label>:57                                      ; preds = %51
   %58 = load i16*, i16** %arg1
   %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
-  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %60
 
 ; <label>:60                                      ; preds = %57
   %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
   %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
-  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %64
 
 ; <label>:64                                      ; preds = %60
   %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
@@ -6864,22 +8310,22 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
   %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
-  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %70
 
 ; <label>:70                                      ; preds = %64
   %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
   %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
-  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
-  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
   %75 = load i32, i32 addrspace(1)* %74
   %76 = zext i32 %75 to i64
   %77 = trunc i64 %76 to i32
-  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
-  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %78
 
 ; <label>:78                                      ; preds = %73
   %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
@@ -6901,8 +8347,8 @@ entry:
   %90 = bitcast i16* %86 to i8*
   %91 = getelementptr inbounds i8, i8* %90, i64 %89
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %93
 
 ; <label>:93                                      ; preds = %80
   %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
@@ -6912,8 +8358,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %99 = load i32, i32* %loc2
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %100
 
 ; <label>:100                                     ; preds = %93
   %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
@@ -6928,63 +8374,63 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %25
+ThrowNullRef6:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %32
+ThrowNullRef10:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %40
+ThrowNullRef12:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %45
+ThrowNullRef16:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %57
+ThrowNullRef18:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %60
+ThrowNullRef20:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %64
+ThrowNullRef22:                                   ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %70
+ThrowNullRef24:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %73
+ThrowNullRef26:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %80
+ThrowNullRef28:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %93
+ThrowNullRef30:                                   ; preds = %93
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7004,8 +8450,8 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
@@ -7033,43 +8479,43 @@ entry:
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %14
   %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
   %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   %28 = load i32, i32 addrspace(1)* %27, align 8
   %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
-  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %30
 
 ; <label>:30                                      ; preds = %26
   %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
   %32 = load i32, i32 addrspace(1)* %31, align 8
   %33 = add i32 %28, %32
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %34
 
 ; <label>:34                                      ; preds = %30
   %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   store i32 %33, i32 addrspace(1)* %35
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
   store i32 0, i32 addrspace(1)* %38
   %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %40
 
 ; <label>:40                                      ; preds = %37
   %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
@@ -7082,8 +8528,8 @@ entry:
 
 ; <label>:47                                      ; preds = %40
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
@@ -7098,8 +8544,8 @@ entry:
   %54 = load i32, i32* %loc0
   %55 = sext i32 %54 to i64
   %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
-  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %57
 
 ; <label>:57                                      ; preds = %52
   %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
@@ -7110,68 +8556,35 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %14
+ThrowNullRef2:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %23
+ThrowNullRef4:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %26
+ThrowNullRef6:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %30
+ThrowNullRef8:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %34
+ThrowNullRef10:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %47
+ThrowNullRef14:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %52
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-}
-
-INFO:  jitting method StringBuilder::get_Length using LLILCJit
-Successfully read StringBuilder.get_Length
-
-define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.StringBuilder addrspace(1)*
-  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
-  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
-
-; <label>:1                                       ; preds = %entry
-  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %3 = load i32, i32 addrspace(1)* %2, align 8
-  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
-
-; <label>:5                                       ; preds = %1
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = add i32 %3, %7
-  ret i32 %8
-
-ThrowNullRef:                                     ; preds = %entry
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef16:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7213,70 +8626,70 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
   %6 = load i32, i32 addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
   store i32 %6, i32 addrspace(1)* %8
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
   %13 = load i32, i32 addrspace(1)* %12, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
   store i32 %13, i32 addrspace(1)* %15
   %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
-  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %18
 
 ; <label>:18                                      ; preds = %14
   %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
   %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
   %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
   %34 = load i32, i32 addrspace(1)* %33, align 8
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
-  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
@@ -7287,39 +8700,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %28
+ThrowNullRef16:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %32
+ThrowNullRef18:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7455,13 +8868,13 @@ entry:
 ; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
@@ -7477,16 +8890,16 @@ entry:
 
 ; <label>:18                                      ; preds = %15
   %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
   store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
   %22 = load i32, i32* %loc0
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %24
 
 ; <label>:24                                      ; preds = %20
   %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
@@ -7498,13 +8911,13 @@ entry:
 ; <label>:28                                      ; preds = %15, %24
   %29 = load i32, i32* %arg1
   %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %31
   %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
@@ -7517,20 +8930,20 @@ entry:
   %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
-  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
   %46 = load i32, i32 addrspace(1)* %45, align 8
   %47 = sub i32 %40, %46
-  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
-  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i32 addrspace(1)* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %48
 
 ; <label>:48                                      ; preds = %44
   store i32 %47, i32 addrspace(1)* %39, align 8
@@ -7538,21 +8951,21 @@ entry:
 
 ; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
-  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %51
 
 ; <label>:51                                      ; preds = %49
   %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %53
 
 ; <label>:53                                      ; preds = %51
   %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
   %55 = load i32, i32 addrspace(1)* %54, align 8
   %56 = load i32, i32* %arg2
   %57 = sub i32 %55, %56
-  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %58
 
 ; <label>:58                                      ; preds = %53
   %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
@@ -7562,13 +8975,13 @@ entry:
 ; <label>:60                                      ; preds = %33, %58
   %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
   %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
-  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %63
 
 ; <label>:63                                      ; preds = %60
   %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
-  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
-  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
@@ -7578,15 +8991,15 @@ entry:
 
 ; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
-  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i32 addrspace(1)* %69, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %70
 
 ; <label>:70                                      ; preds = %68
   %71 = load i32, i32 addrspace(1)* %69, align 8
   store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
-  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
@@ -7596,8 +9009,8 @@ entry:
   store i32 %77, i32* %loc4
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
-  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %80
 
 ; <label>:80                                      ; preds = %73
   %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
@@ -7607,71 +9020,71 @@ entry:
 ; <label>:83                                      ; preds = %80
   store i32 0, i32* %loc3
   %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
-  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
-  br i1 %NullCheck26, label %88, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i32 addrspace(1)* %87, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %88
 
 ; <label>:88                                      ; preds = %85
   %89 = load i32, i32 addrspace(1)* %87, align 8
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
-  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %90
 
 ; <label>:90                                      ; preds = %88
   %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
   store i32 %89, i32 addrspace(1)* %91
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
-  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
-  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %96
 
 ; <label>:96                                      ; preds = %94
   %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
-  br i1 %NullCheck34, label %100, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %100
 
 ; <label>:100                                     ; preds = %96
   %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
-  br i1 %NullCheck36, label %102, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %102
 
 ; <label>:102                                     ; preds = %100
   %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
   %104 = load i32, i32 addrspace(1)* %103, align 8
   %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
-  br i1 %NullCheck38, label %106, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %106
 
 ; <label>:106                                     ; preds = %102
   %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
-  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
-  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %108
 
 ; <label>:108                                     ; preds = %106
   %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
   %110 = load i32, i32 addrspace(1)* %109, align 8
   %111 = add i32 %104, %110
-  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %112
 
 ; <label>:112                                     ; preds = %108
   %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
   store i32 %111, i32 addrspace(1)* %113
   %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
-  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i32 addrspace(1)* %114, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %115
 
 ; <label>:115                                     ; preds = %112
   %116 = load i32, i32 addrspace(1)* %114, align 8
@@ -7681,19 +9094,19 @@ entry:
 ; <label>:118                                     ; preds = %115
   %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
-  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %121
 
 ; <label>:121                                     ; preds = %118
   %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
-  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
-  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %123
 
 ; <label>:123                                     ; preds = %121
   %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
   %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
-  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
-  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %126
 
 ; <label>:126                                     ; preds = %123
   %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
@@ -7705,8 +9118,8 @@ entry:
 
 ; <label>:130                                     ; preds = %80, %115, %126
   %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %132
 
 ; <label>:132                                     ; preds = %130
   %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7715,8 +9128,8 @@ entry:
   %136 = load i32, i32* %loc3
   %137 = sub i32 %135, %136
   %138 = sub i32 %134, %137
-  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %139
 
 ; <label>:139                                     ; preds = %132
   %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7728,16 +9141,16 @@ entry:
 
 ; <label>:144                                     ; preds = %139
   %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
-  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %146
 
 ; <label>:146                                     ; preds = %144
   %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
   %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
   %149 = load i32, i32* %loc2
   %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
-  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %151
 
 ; <label>:151                                     ; preds = %146
   %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
@@ -7754,145 +9167,249 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %18
+ThrowNullRef4:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %31
+ThrowNullRef10:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %44
+ThrowNullRef16:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %68
+ThrowNullRef18:                                   ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %70
+ThrowNullRef20:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %73
+ThrowNullRef22:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %83
+ThrowNullRef24:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %85
+ThrowNullRef26:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %88
+ThrowNullRef28:                                   ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %90
+ThrowNullRef30:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %94
+ThrowNullRef32:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %96
+ThrowNullRef34:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %100
+ThrowNullRef36:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %102
+ThrowNullRef38:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %106
+ThrowNullRef40:                                   ; preds = %106
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %108
+ThrowNullRef42:                                   ; preds = %108
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %112
+ThrowNullRef44:                                   ; preds = %112
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %118
+ThrowNullRef46:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %121
+ThrowNullRef48:                                   ; preds = %121
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %123
+ThrowNullRef50:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %130
+ThrowNullRef52:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %132
+ThrowNullRef54:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %144
+ThrowNullRef56:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %146
+ThrowNullRef58:                                   ; preds = %146
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %60
+ThrowNullRef60:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %63
+ThrowNullRef62:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %49
+ThrowNullRef64:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %51
+ThrowNullRef66:                                   ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %53
+ThrowNullRef68:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(%"System.Char[]" addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %arg0 = alloca %"System.Char[]" addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store %"System.Char[]" addrspace(1)* %param0, %"System.Char[]" addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load i32, i32* %arg4
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %43, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %38, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg1
+  %13 = load i32, i32* %arg4
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %38, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %24 = load i32, i32* %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %35 = load i32, i32* %arg3
+  %36 = load i32, i32* %arg4
+  %37 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %37, %"System.Char[]" addrspace(1)* %34, i32 %35, i32 %36)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:38                                      ; preds = %5, %16
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Successfully read Buffer._Memmove
 
@@ -7914,7 +9431,7 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[loadElem]
+Failed to read AppDomain.SetDataHelper[storeElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -7923,8 +9440,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
@@ -7934,8 +9451,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
@@ -7947,15 +9464,15 @@ entry:
   %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
   %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
@@ -7966,15 +9483,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7992,7 +9509,79 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
-Failed to read Dictionary`2.TryGetValue[loadElemA]
+Successfully read Dictionary`2.TryGetValue
+
+define i8 @"Dictionary`2.TryGetValue"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)* addrspace(1)* %param2) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  %arg2 = alloca %System.__Canon addrspace(1)* addrspace(1)*
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  store %System.__Canon addrspace(1)* addrspace(1)* %param2, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  store i32 %2, i32* %loc0
+  %3 = load i32, i32* %loc0
+  %4 = icmp slt i32 %3, 0
+  br i1 %4, label %22, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 2
+  %10 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %9, align 8
+  %11 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = zext i32 %11 to i64
+  %BoundsCheck = icmp uge i64 %16, %15
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 3, i32 %11
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %20, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %6, %System.__Canon addrspace(1)* %21)
+  ret i8 1
+
+; <label>:22                                      ; preds = %entry
+  %23 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %23, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -8058,8 +9647,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
@@ -8091,8 +9680,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
@@ -8171,15 +9760,15 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck, label %19, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %ThrowNullRef, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
   %21 = load i32, i32 addrspace(1)* %20
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
@@ -8202,7 +9791,7 @@ ThrowNullRef:                                     ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %19
+ThrowNullRef2:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8248,8 +9837,8 @@ entry:
   %0 = alloca %System.AppDomainHandle
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %1 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %1, i32 0, i32 15
@@ -8269,8 +9858,8 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
@@ -8286,7 +9875,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -8299,8 +9888,8 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -8327,8 +9916,8 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
@@ -8352,8 +9941,8 @@ entry:
   %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
   store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
@@ -8363,8 +9952,8 @@ entry:
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
@@ -8374,8 +9963,8 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %9
   %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
@@ -8384,8 +9973,8 @@ entry:
 
 ; <label>:18                                      ; preds = %3, %16
   %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
@@ -8397,15 +9986,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %18
+ThrowNullRef6:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8418,8 +10007,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
@@ -8453,15 +10042,15 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
@@ -8473,7 +10062,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8481,7 +10070,7 @@ ThrowNullRef1:                                    ; preds = %1
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
 Failed to read Dictionary`2.System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
@@ -8506,8 +10095,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
@@ -8524,8 +10113,8 @@ entry:
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -8544,7 +10133,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8577,8 +10166,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = load i64, i64* %arg2
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = trunc i32 %3 to i8
@@ -8634,46 +10223,46 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
   %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
-  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
-  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
-  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
@@ -8684,27 +10273,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %20
+ThrowNullRef12:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8717,8 +10306,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -8756,22 +10345,22 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
   %9 = load i64, i64 addrspace(1)* %8, align 8
   %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
   %13 = load i64, i64 addrspace(1)* %12, align 8
   %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %11
   %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
@@ -8788,11 +10377,11 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8882,8 +10471,8 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
@@ -8900,8 +10489,8 @@ entry:
 ; <label>:8                                       ; preds = %1
   %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
   %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
@@ -8911,15 +10500,15 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
   %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
   %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
-  br i1 %NullCheck6, label %21, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
@@ -8946,15 +10535,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8992,15 +10581,15 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
   store i8 %3, i8 addrspace(1)* %5
   %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
@@ -9011,7 +10600,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9027,8 +10616,8 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -9041,8 +10630,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
@@ -9058,7 +10647,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9080,8 +10669,8 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
@@ -9096,8 +10685,8 @@ entry:
 ; <label>:12                                      ; preds = %6
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
@@ -9112,8 +10701,8 @@ entry:
 ; <label>:21                                      ; preds = %15
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
@@ -9128,8 +10717,8 @@ entry:
 ; <label>:30                                      ; preds = %24
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %31, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
@@ -9144,8 +10733,8 @@ entry:
 ; <label>:39                                      ; preds = %33
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
-  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %40, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %42
 
 ; <label>:42                                      ; preds = %39
   %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
@@ -9164,19 +10753,19 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %21
+ThrowNullRef4:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %30
+ThrowNullRef6:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %39
+ThrowNullRef8:                                    ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9243,8 +10832,8 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
@@ -9264,57 +10853,57 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
   store i8 0, i8 addrspace(1)* %2
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
   store i8 0, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
   store i8 0, i8 addrspace(1)* %17
   %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
   store i8 0, i8 addrspace(1)* %20
   %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
-  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
@@ -9325,31 +10914,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %19
+ThrowNullRef14:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9367,8 +10956,8 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
@@ -9380,8 +10969,8 @@ entry:
 
 ; <label>:9                                       ; preds = %4
   %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %9
   %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
@@ -9395,7 +10984,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef2:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9420,8 +11009,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
@@ -9512,8 +11101,8 @@ entry:
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
@@ -9524,8 +11113,8 @@ entry:
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = load i64, i64 addrspace(1)* %12
@@ -9537,8 +11126,8 @@ entry:
   %20 = load i64, i64* %19
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
-  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %13
   %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
@@ -9555,8 +11144,8 @@ entry:
 ; <label>:30                                      ; preds = %25
   %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %32 = load i32, i32* %arg2
-  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
-  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
@@ -9570,15 +11159,15 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %30
+ThrowNullRef2:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9622,87 +11211,87 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
   %10 = load i8, i8 addrspace(1)* %9, align 8
   %11 = zext i8 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %8
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
   store i8 %12, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
   %19 = load i8, i8 addrspace(1)* %18, align 8
   %20 = zext i8 %19 to i32
   %21 = trunc i32 %20 to i8
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
   store i8 %21, i8 addrspace(1)* %23
   %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
   %28 = load i8, i8 addrspace(1)* %27, align 8
   %29 = zext i8 %28 to i32
   %30 = trunc i32 %29 to i8
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
-  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %31
 
 ; <label>:31                                      ; preds = %26
   %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
   store i8 %30, i8 addrspace(1)* %32
   %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
-  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
-  br i1 %NullCheck14, label %40, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %40
 
 ; <label>:40                                      ; preds = %35
   %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
   store i8 %39, i8 addrspace(1)* %41
   %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
-  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %44
 
 ; <label>:44                                      ; preds = %40
   %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
   %46 = load i8, i8 addrspace(1)* %45, align 8
   %47 = zext i8 %46 to i32
   %48 = trunc i32 %47 to i8
-  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
   store i8 %48, i8 addrspace(1)* %50
   %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
-  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
@@ -9713,29 +11302,29 @@ entry:
 ; <label>:56                                      ; preds = %52
   %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
-  br i1 %NullCheck22, label %59, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
   %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
   %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
-  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
-  br i1 %NullCheck24, label %63, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
   %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
-  br i1 %NullCheck26, label %66, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
   %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
-  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
-  br i1 %NullCheck28, label %69, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %69
 
 ; <label>:69                                      ; preds = %66
   %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
@@ -9744,15 +11333,15 @@ entry:
 
 ; <label>:71                                      ; preds = %105
   %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
-  br i1 %NullCheck34, label %73, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %73
 
 ; <label>:73                                      ; preds = %71
   %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
   %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
   %76 = load i32, i32* %loc0
-  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
-  br i1 %NullCheck36, label %77, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
@@ -9766,8 +11355,8 @@ entry:
 
 ; <label>:83                                      ; preds = %77
   %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
-  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
@@ -9775,14 +11364,14 @@ entry:
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
   %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
-  br i1 %NullCheck40, label %91, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
 ; <label>:91                                      ; preds = %85
   %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
   %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
-  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck42, label %94, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %94
 
 ; <label>:94                                      ; preds = %91
   %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
@@ -9798,14 +11387,14 @@ entry:
 ; <label>:99                                      ; preds = %69, %96
   %100 = load i32, i32* %loc0
   %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
-  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %102
 
 ; <label>:102                                     ; preds = %99
   %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
   %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
-  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
-  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
@@ -9819,87 +11408,87 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %26
+ThrowNullRef10:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %31
+ThrowNullRef12:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %35
+ThrowNullRef14:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %40
+ThrowNullRef16:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %56
+ThrowNullRef22:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %59
+ThrowNullRef24:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %63
+ThrowNullRef26:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %66
+ThrowNullRef28:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %102
+ThrowNullRef32:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %71
+ThrowNullRef34:                                   ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %73
+ThrowNullRef36:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %83
+ThrowNullRef38:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %85
+ThrowNullRef40:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %91
+ThrowNullRef42:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9943,15 +11532,15 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
   %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
@@ -9961,28 +11550,28 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
   %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %12
   %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
   %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
   %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
-  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
@@ -9993,23 +11582,23 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %12
+ThrowNullRef6:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10031,15 +11620,15 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
   %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = load i64, i64 addrspace(1)* %7
@@ -10077,13 +11666,13 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[loadElem]
+Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -10111,8 +11700,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -10178,8 +11767,8 @@ entry:
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load float, float* %arg0
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -10313,8 +11902,8 @@ entry:
   store i64 %param0, i64* %arg0
   store i64 %param1, i64* %arg1
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
@@ -10322,8 +11911,8 @@ entry:
   %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
   %5 = load i16*, i16* addrspace(1)* %4, align 8
   %6 = addrspacecast i64* %arg1 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = bitcast i64 addrspace(1)* %6 to i8 addrspace(1)*
@@ -10339,7 +11928,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10373,8 +11962,8 @@ entry:
   %1 = load i32, i32* %arg1
   %2 = sext i32 %1 to i64
   %3 = inttoptr i64 %2 to i16*
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -10427,8 +12016,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, i32)*)(%System.IO.ConsoleStream addrspace(1)* %2, i32 %1)
   %3 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %4 = load i64, i64* %arg1
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
@@ -10439,8 +12028,8 @@ entry:
   %10 = icmp eq i32 %9, 3
   %11 = sext i1 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %5
   %14 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, i32 0, i32 5
@@ -10451,7 +12040,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10474,8 +12063,8 @@ entry:
   %5 = icmp eq i32 %4, 1
   %6 = sext i1 %5 to i32
   %7 = trunc i32 %6 to i8
-  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %2, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.ConsoleStream addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
@@ -10486,8 +12075,8 @@ entry:
   %13 = icmp eq i32 %12, 2
   %14 = sext i1 %13 to i32
   %15 = trunc i32 %14 to i8
-  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %10, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.ConsoleStream addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %8
   %17 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %10, i32 0, i32 4
@@ -10498,7 +12087,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10537,8 +12126,8 @@ entry:
   %arg0 = alloca i64
   store i64 %param0, i64* %arg0
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
@@ -10573,8 +12162,8 @@ entry:
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
   %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = load i64, i64 addrspace(1)* %7
@@ -10678,7 +12267,127 @@ entry:
 INFO:  jitting method Encoding::GetEncoding using LLILCJit
 Failed to read Encoding.GetEncoding[convertToHelperArgumentType]
 INFO:  jitting method EncodingProvider::GetEncodingFromProvider using LLILCJit
-Failed to read EncodingProvider.GetEncodingFromProvider[loadElem]
+Successfully read EncodingProvider.GetEncodingFromProvider
+
+define %System.Text.Encoding addrspace(1)* @EncodingProvider.GetEncodingFromProvider(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca %"System.Text.EncodingProvider[]" addrspace(1)*
+  %loc1 = alloca %System.Text.EncodingProvider addrspace(1)*
+  %loc2 = alloca %System.Text.Encoding addrspace(1)*
+  %loc3 = alloca %System.Text.Encoding addrspace(1)*
+  %loc4 = alloca %"System.Text.EncodingProvider[]" addrspace(1)*
+  %loc5 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1059)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2392
+  %2 = addrspacecast i8 addrspace(1)* %1 to %"System.Text.EncodingProvider[]" addrspace(1)**
+  %3 = load volatile %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %2
+  %4 = icmp ne %"System.Text.EncodingProvider[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %entry
+  ret %System.Text.Encoding addrspace(1)* null
+
+; <label>:6                                       ; preds = %entry
+  %7 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1059)
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i64 2392
+  %9 = addrspacecast i8 addrspace(1)* %8 to %"System.Text.EncodingProvider[]" addrspace(1)**
+  %10 = load volatile %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %9
+  store %"System.Text.EncodingProvider[]" addrspace(1)* %10, %"System.Text.EncodingProvider[]" addrspace(1)** %loc0
+  %11 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc0
+  store %"System.Text.EncodingProvider[]" addrspace(1)* %11, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  store i32 0, i32* %loc5
+  br label %43
+
+; <label>:12                                      ; preds = %46
+  %13 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  %14 = load i32, i32* %loc5
+  %NullCheck1 = icmp eq %"System.Text.EncodingProvider[]" addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %13, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = zext i32 %17 to i64
+  %19 = zext i32 %14 to i64
+  %BoundsCheck = icmp uge i64 %19, %18
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %20
+
+; <label>:20                                      ; preds = %15
+  %21 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %13, i32 0, i32 3, i32 %14
+  %22 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)* addrspace(1)* %21, align 8
+  store %System.Text.EncodingProvider addrspace(1)* %22, %System.Text.EncodingProvider addrspace(1)** %loc1
+  %23 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)** %loc1
+  %24 = load i32, i32* %arg0
+  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i64 addrspace(1)*
+  %NullCheck3 = icmp eq i64 addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
+
+; <label>:26                                      ; preds = %20
+  %27 = load i64, i64 addrspace(1)* %25
+  %28 = add i64 %27, 64
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 40
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Text.Encoding addrspace(1)* (%System.Text.EncodingProvider addrspace(1)*, i32)*
+  %35 = call %System.Text.Encoding addrspace(1)* %34(%System.Text.EncodingProvider addrspace(1)* %23, i32 %24)
+  store %System.Text.Encoding addrspace(1)* %35, %System.Text.Encoding addrspace(1)** %loc2
+  %36 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc2
+  %37 = icmp eq %System.Text.Encoding addrspace(1)* %36, null
+  br i1 %37, label %40, label %38
+
+; <label>:38                                      ; preds = %26
+  %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc2
+  store %System.Text.Encoding addrspace(1)* %39, %System.Text.Encoding addrspace(1)** %loc3
+  br label %53
+
+; <label>:40                                      ; preds = %26
+  %41 = load i32, i32* %loc5
+  %42 = add i32 %41, 1
+  store i32 %42, i32* %loc5
+  br label %43
+
+; <label>:43                                      ; preds = %6, %40
+  %44 = load i32, i32* %loc5
+  %45 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  %NullCheck = icmp eq %"System.Text.EncodingProvider[]" addrspace(1)* %45, null
+  br i1 %NullCheck, label %ThrowNullRef, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp slt i32 %44, %50
+  br i1 %51, label %12, label %52
+
+; <label>:52                                      ; preds = %46
+  ret %System.Text.Encoding addrspace(1)* null
+
+; <label>:53                                      ; preds = %38
+  %54 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc3
+  ret %System.Text.Encoding addrspace(1)* %54
+
+ThrowNullRef:                                     ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method EncodingProvider::.cctor using LLILCJit
 Successfully read EncodingProvider..cctor
 
@@ -10697,7 +12406,7 @@ Failed to read Encoding.get_InternalSyncObject[Call HasTypeArg]
 INFO:  jitting method Hashtable::.ctor using LLILCJit
 Failed to read Hashtable..ctor[Volatile store]
 INFO:  jitting method Hashtable::get_Item using LLILCJit
-Failed to read Hashtable.get_Item[loadElemA]
+Failed to read Hashtable.get_Item[loadNonPrimitiveObj]
 INFO:  jitting method Hashtable::InitHash using LLILCJit
 Successfully read Hashtable.InitHash
 
@@ -10717,8 +12426,8 @@ entry:
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -10734,15 +12443,15 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
   %15 = load i32, i32* %loc0
-  %NullCheck2 = icmp ne i32 addrspace(1)* %14, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i32 addrspace(1)* %14, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %3
   store i32 %15, i32 addrspace(1)* %14, align 8
   %17 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %18 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %NullCheck4 = icmp ne i32 addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i32 addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = load i32, i32 addrspace(1)* %18, align 8
@@ -10751,8 +12460,8 @@ entry:
   %23 = sub i32 %22, 1
   %24 = urem i32 %21, %23
   %25 = add i32 1, %24
-  %NullCheck6 = icmp ne i32 addrspace(1)* %17, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32 addrspace(1)* %17, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %19
   store i32 %25, i32 addrspace(1)* %17, align 8
@@ -10763,15 +12472,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %19
+ThrowNullRef6:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10786,8 +12495,8 @@ entry:
   store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
   store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %NullCheck = icmp ne %System.Collections.Hashtable addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Collections.Hashtable addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
@@ -10797,16 +12506,16 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Collections.Hashtable addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Collections.Hashtable addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
   %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck4 = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %9, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
   %13 = inttoptr i64 %11 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
@@ -10816,8 +12525,8 @@ entry:
 ; <label>:15                                      ; preds = %1
   %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -10835,15 +12544,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10857,8 +12566,8 @@ entry:
   store %System.Int32 addrspace(1)* %param0, %System.Int32 addrspace(1)** %this
   %0 = load %System.Int32 addrspace(1)*, %System.Int32 addrspace(1)** %this
   %1 = bitcast %System.Int32 addrspace(1)* %0 to i32 addrspace(1)*
-  %NullCheck = icmp ne i32 addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq i32 addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load i32, i32 addrspace(1)* %1, align 8
@@ -10934,8 +12643,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.UTF8Encoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
@@ -10944,15 +12653,15 @@ entry:
   %9 = load i8, i8* %arg2
   %10 = zext i8 %9 to i32
   %11 = trunc i32 %10 to i8
-  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %8, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %6
   %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %8, i32 0, i32 8
   store i8 %11, i8 addrspace(1)* %13
   %14 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %14, i32 0, i32 8
@@ -10964,8 +12673,8 @@ entry:
 ; <label>:20                                      ; preds = %15
   %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %22, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %22, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = load i64, i64 addrspace(1)* %22
@@ -10987,15 +12696,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %12
+ThrowNullRef4:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11010,8 +12719,8 @@ entry:
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
@@ -11033,16 +12742,16 @@ entry:
 ; <label>:10                                      ; preds = %1
   %11 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
   %12 = load i32, i32* %arg1
-  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %11, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.Encoding addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
   store i32 %12, i32 addrspace(1)* %14
   %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
   %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = load i64, i64 addrspace(1)* %16
@@ -11060,11 +12769,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11077,8 +12786,8 @@ entry:
   %this = alloca %System.Text.UTF8Encoding addrspace(1)*
   store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
   %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.UTF8Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
@@ -11090,16 +12799,16 @@ entry:
 ; <label>:6                                       ; preds = %1
   %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %8 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %10, %System.Text.EncoderFallback addrspace(1)* %8)
   %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %12 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
-  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %11, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %11, i32 0, i32 3
@@ -11112,8 +12821,8 @@ entry:
   %18 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %18, %System.String addrspace(1)* %17)
   %19 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %18 to %System.Text.EncoderFallback addrspace(1)*
-  %NullCheck6 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %16, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %16, i32 0, i32 2
@@ -11123,8 +12832,8 @@ entry:
   %24 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %24, %System.String addrspace(1)* %23)
   %25 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %24 to %System.Text.DecoderFallback addrspace(1)*
-  %NullCheck8 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %22, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %22, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %20
   %27 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %22, i32 0, i32 3
@@ -11135,19 +12844,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %20
+ThrowNullRef8:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11177,8 +12886,8 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load i32, i32* %arg1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -11196,8 +12905,8 @@ entry:
 ; <label>:15                                      ; preds = %8
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %17 = load i32, i32* %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 %17
@@ -11213,7 +12922,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11265,7 +12974,7 @@ entry:
 }
 
 INFO:  jitting method Hashtable::Insert using LLILCJit
-Failed to read Hashtable.Insert[loadElemA]
+Failed to read Hashtable.Insert[storeElem]
 INFO:  jitting method ConsoleEncoding::.ctor using LLILCJit
 Successfully read ConsoleEncoding..ctor
 
@@ -11280,8 +12989,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %1)
   %2 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
@@ -11317,8 +13026,8 @@ entry:
   %2 = call %System.Text.InternalEncoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalEncoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %1)
   %3 = bitcast %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2 to %System.Text.EncoderFallback addrspace(1)*
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
@@ -11328,8 +13037,8 @@ entry:
   %8 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %7)
   %9 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %8 to %System.Text.DecoderFallback addrspace(1)*
-  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %6, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.Encoding addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %4
   %11 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %6, i32 0, i32 3
@@ -11340,7 +13049,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11359,15 +13068,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* %1)
   %2 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   %6 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, i32 0, i32 1
@@ -11378,7 +13087,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11406,8 +13115,8 @@ entry:
   store %System.Text.InternalDecoderBestFitFallback addrspace(1)* %param0, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
   %0 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
@@ -11417,15 +13126,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %4)
   %5 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %6)
   %9 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, i32 0, i32 1
@@ -11436,11 +13145,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11508,8 +13217,8 @@ entry:
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
   %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = load i64, i64 addrspace(1)* %19
@@ -11573,8 +13282,8 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.ConsoleStream addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
@@ -11605,31 +13314,31 @@ entry:
   store i8 %param4, i8* %arg4
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %3, %System.IO.Stream addrspace(1)* %1)
   %4 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %4, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
   %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %4, i32 0, i32 4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %5)
   %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %6
   %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
   %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
   %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = load i64, i64 addrspace(1)* %13
@@ -11641,8 +13350,8 @@ entry:
   %21 = load i64, i64* %20
   %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %8, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %8, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %14
   %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 5
@@ -11660,24 +13369,24 @@ entry:
   %31 = load i32, i32* %arg3
   %32 = sext i32 %31 to i64
   %33 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %32)
-  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %30, null
-  br i1 %NullCheck10, label %34, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.StreamWriter addrspace(1)* %30, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %35, %"System.Char[]" addrspace(1)* %33)
   %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %37, null
-  br i1 %NullCheck12, label %38, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.StreamWriter addrspace(1)* %37, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %38
 
 ; <label>:38                                      ; preds = %34
   %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
   %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
   %41 = load i32, i32* %arg3
   %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %42, null
-  br i1 %NullCheck14, label %43, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %42, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
   %44 = load i64, i64 addrspace(1)* %42
@@ -11691,30 +13400,30 @@ entry:
   %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
   %53 = sext i32 %52 to i64
   %54 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %53)
-  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
-  br i1 %NullCheck16, label %55, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %55
 
 ; <label>:55                                      ; preds = %43
   %56 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %56, %"System.Byte[]" addrspace(1)* %54)
   %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %58 = load i32, i32* %arg3
-  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %57, null
-  br i1 %NullCheck18, label %59, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.StreamWriter addrspace(1)* %57, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %59
 
 ; <label>:59                                      ; preds = %55
   %60 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 10
   store i32 %58, i32 addrspace(1)* %60
   %61 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %61, null
-  br i1 %NullCheck20, label %62, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.IO.StreamWriter addrspace(1)* %61, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %62
 
 ; <label>:62                                      ; preds = %59
   %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
   %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
   %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
   %67 = load i64, i64 addrspace(1)* %65
@@ -11732,15 +13441,15 @@ entry:
 
 ; <label>:78                                      ; preds = %66
   %79 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %79, null
-  br i1 %NullCheck24, label %80, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.StreamWriter addrspace(1)* %79, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %80
 
 ; <label>:80                                      ; preds = %78
   %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
   %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
   %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %83, null
-  br i1 %NullCheck26, label %84, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %83, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
   %85 = load i64, i64 addrspace(1)* %83
@@ -11757,8 +13466,8 @@ entry:
 
 ; <label>:95                                      ; preds = %84
   %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.IO.StreamWriter addrspace(1)* %96, null
-  br i1 %NullCheck28, label %97, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.IO.StreamWriter addrspace(1)* %96, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %97
 
 ; <label>:97                                      ; preds = %95
   %98 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 12
@@ -11772,8 +13481,8 @@ entry:
   %103 = icmp eq i32 %102, 0
   %104 = sext i1 %103 to i32
   %105 = trunc i32 %104 to i8
-  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %100, null
-  br i1 %NullCheck30, label %106, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.IO.StreamWriter addrspace(1)* %100, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %106
 
 ; <label>:106                                     ; preds = %99
   %107 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %100, i32 0, i32 13
@@ -11784,63 +13493,63 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %6
+ThrowNullRef4:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %29
+ThrowNullRef10:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %34
+ThrowNullRef12:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %38
+ThrowNullRef14:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %43
+ThrowNullRef16:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %55
+ThrowNullRef18:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %59
+ThrowNullRef20:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %62
+ThrowNullRef22:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %78
+ThrowNullRef24:                                   ; preds = %78
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %80
+ThrowNullRef26:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %95
+ThrowNullRef28:                                   ; preds = %95
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11853,15 +13562,15 @@ entry:
   %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = load i64, i64 addrspace(1)* %4
@@ -11879,7 +13588,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11929,35 +13638,35 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
   %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderNLS addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %7 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.EncoderNLS addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Text.Encoding addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.Encoding addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Text.EncoderNLS addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.EncoderNLS addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
   %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck8 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = load i64, i64 addrspace(1)* %16
@@ -11976,19 +13685,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12014,8 +13723,8 @@ entry:
   %this = alloca %System.Text.Encoding addrspace(1)*
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
@@ -12035,15 +13744,15 @@ entry:
   %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
   store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
   %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
   store i32 0, i32 addrspace(1)* %2
   %3 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, i32 0, i32 2
@@ -12053,15 +13762,15 @@ entry:
 
 ; <label>:8                                       ; preds = %4
   %9 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
   %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
   %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = load i64, i64 addrspace(1)* %13
@@ -12082,15 +13791,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12105,16 +13814,16 @@ entry:
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = load i32, i32* %arg1
   %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
   %7 = load i64, i64 addrspace(1)* %5
@@ -12132,7 +13841,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12169,8 +13878,8 @@ entry:
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
   %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
   %16 = load i64, i64 addrspace(1)* %14
@@ -12191,8 +13900,8 @@ entry:
   %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
   %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
   %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %31, null
-  br i1 %NullCheck2, label %32, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = load i64, i64 addrspace(1)* %31
@@ -12235,7 +13944,7 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12248,14 +13957,14 @@ entry:
   %this = alloca %System.Text.EncoderReplacementFallback addrspace(1)*
   store %System.Text.EncoderReplacementFallback addrspace(1)* %param0, %System.Text.EncoderReplacementFallback addrspace(1)** %this
   %0 = load %System.Text.EncoderReplacementFallback addrspace(1)*, %System.Text.EncoderReplacementFallback addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -12266,7 +13975,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12296,8 +14005,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
@@ -12329,8 +14038,8 @@ entry:
   %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
   store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
@@ -12342,8 +14051,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Threading.Tasks.Task addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %7)
@@ -12366,7 +14075,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12385,8 +14094,8 @@ entry:
   store i8 %param1, i8* %arg1
   store i8 %param2, i8* %arg2
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
@@ -12400,8 +14109,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1, %5
   %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 9
@@ -12432,8 +14141,8 @@ entry:
 
 ; <label>:25                                      ; preds = %8, %20
   %26 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %26, null
-  br i1 %NullCheck4, label %27, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %26, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %26, i32 0, i32 12
@@ -12444,22 +14153,22 @@ entry:
 
 ; <label>:32                                      ; preds = %27
   %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %33, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.IO.StreamWriter addrspace(1)* %33, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %32
   %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 12
   store i8 1, i8 addrspace(1)* %35
   %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
-  br i1 %NullCheck8, label %37, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
   %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
   %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck10 = icmp ne i64 addrspace(1)* %40, null
-  br i1 %NullCheck10, label %41, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64 addrspace(1)* %40, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i64, i64 addrspace(1)* %40
@@ -12473,8 +14182,8 @@ entry:
   %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
   store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
   %51 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %NullCheck12 = icmp ne %"System.Byte[]" addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Byte[]" addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %41
   %53 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %51, i32 0, i32 1
@@ -12486,16 +14195,16 @@ entry:
 
 ; <label>:58                                      ; preds = %52
   %59 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %59, null
-  br i1 %NullCheck14, label %60, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.IO.StreamWriter addrspace(1)* %59, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %60
 
 ; <label>:60                                      ; preds = %58
   %61 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %59, i32 0, i32 3
   %62 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
   %64 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %NullCheck16 = icmp ne %"System.Byte[]" addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %"System.Byte[]" addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %60
   %66 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %64, i32 0, i32 1
@@ -12503,8 +14212,8 @@ entry:
   %68 = zext i32 %67 to i64
   %69 = trunc i64 %68 to i32
   %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck18, label %71, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
   %72 = load i64, i64 addrspace(1)* %70
@@ -12520,29 +14229,29 @@ entry:
 
 ; <label>:80                                      ; preds = %27, %52, %71
   %81 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %81, null
-  br i1 %NullCheck20, label %82, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.IO.StreamWriter addrspace(1)* %81, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
 
 ; <label>:82                                      ; preds = %80
   %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %81, i32 0, i32 5
   %84 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %83, align 8
   %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.IO.StreamWriter addrspace(1)* %85, null
-  br i1 %NullCheck22, label %86, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.IO.StreamWriter addrspace(1)* %85, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %86
 
 ; <label>:86                                      ; preds = %82
   %87 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 7
   %88 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %87, align 8
   %89 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %89, null
-  br i1 %NullCheck24, label %90, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.StreamWriter addrspace(1)* %89, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %90
 
 ; <label>:90                                      ; preds = %86
   %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %89, i32 0, i32 9
   %92 = load i32, i32 addrspace(1)* %91, align 8
   %93 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.IO.StreamWriter addrspace(1)* %93, null
-  br i1 %NullCheck26, label %94, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.IO.StreamWriter addrspace(1)* %93, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %93, i32 0, i32 6
@@ -12550,8 +14259,8 @@ entry:
   %97 = load i8, i8* %arg2
   %98 = zext i8 %97 to i32
   %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
-  %NullCheck28 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck28, label %100, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
   %101 = load i64, i64 addrspace(1)* %99
@@ -12566,8 +14275,8 @@ entry:
   %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
   store i32 %110, i32* %loc1
   %111 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %111, null
-  br i1 %NullCheck30, label %112, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.IO.StreamWriter addrspace(1)* %111, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %112
 
 ; <label>:112                                     ; preds = %100
   %113 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %111, i32 0, i32 9
@@ -12578,23 +14287,23 @@ entry:
 
 ; <label>:116                                     ; preds = %112
   %117 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck32 = icmp ne %System.IO.StreamWriter addrspace(1)* %117, null
-  br i1 %NullCheck32, label %118, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.IO.StreamWriter addrspace(1)* %117, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %118
 
 ; <label>:118                                     ; preds = %116
   %119 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %117, i32 0, i32 3
   %120 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %119, align 8
   %121 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.IO.StreamWriter addrspace(1)* %121, null
-  br i1 %NullCheck34, label %122, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.IO.StreamWriter addrspace(1)* %121, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %122
 
 ; <label>:122                                     ; preds = %118
   %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
   %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
   %125 = load i32, i32* %loc1
   %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
-  %NullCheck36 = icmp ne i64 addrspace(1)* %126, null
-  br i1 %NullCheck36, label %127, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64 addrspace(1)* %126, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
   %128 = load i64, i64 addrspace(1)* %126
@@ -12616,15 +14325,15 @@ entry:
 
 ; <label>:140                                     ; preds = %136
   %141 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.IO.StreamWriter addrspace(1)* %141, null
-  br i1 %NullCheck38, label %142, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.IO.StreamWriter addrspace(1)* %141, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %142
 
 ; <label>:142                                     ; preds = %140
   %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
   %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
   %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
-  %NullCheck40 = icmp ne i64 addrspace(1)* %145, null
-  br i1 %NullCheck40, label %146, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i64 addrspace(1)* %145, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
   %147 = load i64, i64 addrspace(1)* %145
@@ -12645,83 +14354,83 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %25
+ThrowNullRef4:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %32
+ThrowNullRef6:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %37
+ThrowNullRef10:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %41
+ThrowNullRef12:                                   ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %58
+ThrowNullRef14:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %60
+ThrowNullRef16:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %65
+ThrowNullRef18:                                   ; preds = %65
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %80
+ThrowNullRef20:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %82
+ThrowNullRef22:                                   ; preds = %82
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %86
+ThrowNullRef24:                                   ; preds = %86
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %90
+ThrowNullRef26:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %94
+ThrowNullRef28:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %100
+ThrowNullRef30:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %116
+ThrowNullRef32:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %118
+ThrowNullRef34:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %122
+ThrowNullRef36:                                   ; preds = %122
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %140
+ThrowNullRef38:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %142
+ThrowNullRef40:                                   ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12788,8 +14497,8 @@ entry:
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %1 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
-  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
@@ -12797,8 +14506,8 @@ entry:
   %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
   %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
   %8 = load i64, i64 addrspace(1)* %6
@@ -12814,8 +14523,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %17, %System.IFormatProvider addrspace(1)* %16)
   %18 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %19 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %18, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.SyncTextWriter addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %7
   %21 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %18, i32 0, i32 4
@@ -12826,11 +14535,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12843,8 +14552,8 @@ entry:
   %this = alloca %System.IO.TextWriter addrspace(1)*
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.TextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
@@ -12854,8 +14563,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.Threading.Thread addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Threading.Thread addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %6)
@@ -12864,8 +14573,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1
   %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.TextWriter addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.TextWriter addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %11, i32 0, i32 2
@@ -12876,11 +14585,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13077,8 +14786,8 @@ entry:
   store float %param1, float* %arg1
   store i8 0, i8* %loc1
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
@@ -13088,16 +14797,16 @@ entry:
   %5 = addrspacecast i8* %loc1 to i8 addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %4, i8 addrspace(1)* %5)
   %6 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.SyncTextWriter addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
   %10 = load float, float* %arg1
   %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
   %13 = load i64, i64 addrspace(1)* %11
@@ -13132,11 +14841,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13153,8 +14862,8 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load float, float* %arg1
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -13168,8 +14877,8 @@ entry:
   call void %11(%System.IO.TextWriter addrspace(1)* %0, float %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
   %15 = load i64, i64 addrspace(1)* %13
@@ -13187,7 +14896,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13205,8 +14914,8 @@ entry:
   %1 = addrspacecast float* %arg1 to float addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -13221,8 +14930,8 @@ entry:
   %14 = bitcast float addrspace(1)* %1 to %System.Single addrspace(1)*
   %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Single addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Single addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
   %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
   %18 = load i64, i64 addrspace(1)* %16
@@ -13240,7 +14949,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13256,8 +14965,8 @@ entry:
   store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
   %0 = load %System.Single addrspace(1)*, %System.Single addrspace(1)** %this
   %1 = bitcast %System.Single addrspace(1)* %0 to float addrspace(1)*
-  %NullCheck = icmp ne float addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq float addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load float, float addrspace(1)* %1, align 8
@@ -13282,8 +14991,8 @@ entry:
   %loc0 = alloca %System.Globalization.NumberFormatInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 3
@@ -13293,8 +15002,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
@@ -13304,24 +15013,24 @@ entry:
   store %System.Globalization.NumberFormatInfo addrspace(1)* %10, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
   %11 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %7
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
   %15 = load i8, i8 addrspace(1)* %14, align 8
   %16 = zext i8 %15 to i32
   %17 = trunc i32 %16 to i8
-  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %11, null
-  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %11, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %13
   %19 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %11, i32 0, i32 29
   store i8 %17, i8 addrspace(1)* %19
   %20 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %21 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %20, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %20, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %18
   %23 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %20, i32 0, i32 3
@@ -13330,8 +15039,8 @@ entry:
 
 ; <label>:24                                      ; preds = %1, %22
   %25 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %25, null
-  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %25, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %26
 
 ; <label>:26                                      ; preds = %24
   %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %25, i32 0, i32 3
@@ -13342,23 +15051,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %18
+ThrowNullRef8:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13383,168 +15092,168 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 18
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %8, align 8
-  %NullCheck2 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %5, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %5, i32 0, i32 4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %9)
   %12 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 19
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %15, align 8
-  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %12, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %12, i32 0, i32 5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %16)
   %19 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %20 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %20, null
-  br i1 %NullCheck8, label %21, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %20, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %20, i32 0, i32 23
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  %NullCheck10 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %19, null
-  br i1 %NullCheck10, label %24, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %19, i32 0, i32 7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %25, %System.String addrspace(1)* %23)
   %26 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %27 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %27, i32 0, i32 22
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %29, align 8
-  %NullCheck14 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %26, null
-  br i1 %NullCheck14, label %31, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %26, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %26, i32 0, i32 6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %32, %System.String addrspace(1)* %30)
   %33 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %34 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Globalization.CultureData addrspace(1)* %34, null
-  br i1 %NullCheck16, label %35, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Globalization.CultureData addrspace(1)* %34, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %34, i32 0, i32 51
   %37 = load i32, i32 addrspace(1)* %36, align 8
-  %NullCheck18 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %33, null
-  br i1 %NullCheck18, label %38, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %33, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %33, i32 0, i32 21
   store i32 %37, i32 addrspace(1)* %39
   %40 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %41 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Globalization.CultureData addrspace(1)* %41, null
-  br i1 %NullCheck20, label %42, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Globalization.CultureData addrspace(1)* %41, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %41, i32 0, i32 52
   %44 = load i32, i32 addrspace(1)* %43, align 8
-  %NullCheck22 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %40, null
-  br i1 %NullCheck22, label %45, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %40, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %40, i32 0, i32 25
   store i32 %44, i32 addrspace(1)* %46
   %47 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %48 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.Globalization.CultureData addrspace(1)* %48, null
-  br i1 %NullCheck24, label %49, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Globalization.CultureData addrspace(1)* %48, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %49
 
 ; <label>:49                                      ; preds = %45
   %50 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %48, i32 0, i32 29
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck26 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %47, null
-  br i1 %NullCheck26, label %52, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %47, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %47, i32 0, i32 10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %53, %System.String addrspace(1)* %51)
   %54 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %55 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Globalization.CultureData addrspace(1)* %55, null
-  br i1 %NullCheck28, label %56, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Globalization.CultureData addrspace(1)* %55, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %56
 
 ; <label>:56                                      ; preds = %52
   %57 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %55, i32 0, i32 35
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %57, align 8
-  %NullCheck30 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %54, null
-  br i1 %NullCheck30, label %59, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %54, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %54, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %60, %System.String addrspace(1)* %58)
   %61 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %62 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck32 = icmp ne %System.Globalization.CultureData addrspace(1)* %62, null
-  br i1 %NullCheck32, label %63, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Globalization.CultureData addrspace(1)* %62, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %62, i32 0, i32 34
   %65 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %64, align 8
-  %NullCheck34 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %61, null
-  br i1 %NullCheck34, label %66, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %61, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %61, i32 0, i32 9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %67, %System.String addrspace(1)* %65)
   %68 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %69 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck36 = icmp ne %System.Globalization.CultureData addrspace(1)* %69, null
-  br i1 %NullCheck36, label %70, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Globalization.CultureData addrspace(1)* %69, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %70
 
 ; <label>:70                                      ; preds = %66
   %71 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %69, i32 0, i32 55
   %72 = load i32, i32 addrspace(1)* %71, align 8
-  %NullCheck38 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %68, null
-  br i1 %NullCheck38, label %73, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %68, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %68, i32 0, i32 22
   store i32 %72, i32 addrspace(1)* %74
   %75 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %76 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck40 = icmp ne %System.Globalization.CultureData addrspace(1)* %76, null
-  br i1 %NullCheck40, label %77, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Globalization.CultureData addrspace(1)* %76, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %76, i32 0, i32 57
   %79 = load i32, i32 addrspace(1)* %78, align 8
-  %NullCheck42 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %75, null
-  br i1 %NullCheck42, label %80, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %75, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %80
 
 ; <label>:80                                      ; preds = %77
   %81 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %75, i32 0, i32 24
   store i32 %79, i32 addrspace(1)* %81
   %82 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %83 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck44 = icmp ne %System.Globalization.CultureData addrspace(1)* %83, null
-  br i1 %NullCheck44, label %84, label %ThrowNullRef43
+  %NullCheck43 = icmp eq %System.Globalization.CultureData addrspace(1)* %83, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %84
 
 ; <label>:84                                      ; preds = %80
   %85 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %83, i32 0, i32 56
   %86 = load i32, i32 addrspace(1)* %85, align 8
-  %NullCheck46 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %82, null
-  br i1 %NullCheck46, label %87, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %82, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %82, i32 0, i32 23
@@ -13553,8 +15262,8 @@ entry:
 
 ; <label>:89                                      ; preds = %entry
   %90 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck100 = icmp ne %System.Globalization.CultureData addrspace(1)* %90, null
-  br i1 %NullCheck100, label %91, label %ThrowNullRef99
+  %NullCheck99 = icmp eq %System.Globalization.CultureData addrspace(1)* %90, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %91
 
 ; <label>:91                                      ; preds = %89
   %92 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %90, i32 0, i32 2
@@ -13572,8 +15281,8 @@ entry:
   %102 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %103 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %104 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %103)
-  %NullCheck48 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %102, null
-  br i1 %NullCheck48, label %105, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %102, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %105
 
 ; <label>:105                                     ; preds = %101
   %106 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %102, i32 0, i32 1
@@ -13581,8 +15290,8 @@ entry:
   %107 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %108 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %109 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %108)
-  %NullCheck50 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %107, null
-  br i1 %NullCheck50, label %110, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %107, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %110
 
 ; <label>:110                                     ; preds = %105
   %111 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %107, i32 0, i32 2
@@ -13590,8 +15299,8 @@ entry:
   %112 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %113 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %114 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %113)
-  %NullCheck52 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %112, null
-  br i1 %NullCheck52, label %115, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %112, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %115
 
 ; <label>:115                                     ; preds = %110
   %116 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %112, i32 0, i32 27
@@ -13599,8 +15308,8 @@ entry:
   %117 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %118 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %119 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %118)
-  %NullCheck54 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %117, null
-  br i1 %NullCheck54, label %120, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %117, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %120
 
 ; <label>:120                                     ; preds = %115
   %121 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %117, i32 0, i32 26
@@ -13608,8 +15317,8 @@ entry:
   %122 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %123 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %124 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %123)
-  %NullCheck56 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %122, null
-  br i1 %NullCheck56, label %125, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %122, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %125
 
 ; <label>:125                                     ; preds = %120
   %126 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %122, i32 0, i32 17
@@ -13617,8 +15326,8 @@ entry:
   %127 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %128 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %129 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %128)
-  %NullCheck58 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %127, null
-  br i1 %NullCheck58, label %130, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %127, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %130
 
 ; <label>:130                                     ; preds = %125
   %131 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %127, i32 0, i32 18
@@ -13626,8 +15335,8 @@ entry:
   %132 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %133 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %134 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %133)
-  %NullCheck60 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %132, null
-  br i1 %NullCheck60, label %135, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %132, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %135
 
 ; <label>:135                                     ; preds = %130
   %136 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %132, i32 0, i32 14
@@ -13635,8 +15344,8 @@ entry:
   %137 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %138 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %139 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %138)
-  %NullCheck62 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %137, null
-  br i1 %NullCheck62, label %140, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %137, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %140
 
 ; <label>:140                                     ; preds = %135
   %141 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %137, i32 0, i32 13
@@ -13644,71 +15353,71 @@ entry:
   %142 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %143 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %144 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %143)
-  %NullCheck64 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %142, null
-  br i1 %NullCheck64, label %145, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %142, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %145
 
 ; <label>:145                                     ; preds = %140
   %146 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %142, i32 0, i32 12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %146, %System.String addrspace(1)* %144)
   %147 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %148 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck66 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %148, null
-  br i1 %NullCheck66, label %149, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %148, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %149
 
 ; <label>:149                                     ; preds = %145
   %150 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %148, i32 0, i32 21
   %151 = load i32, i32 addrspace(1)* %150, align 8
-  %NullCheck68 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %147, null
-  br i1 %NullCheck68, label %152, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %147, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %152
 
 ; <label>:152                                     ; preds = %149
   %153 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %147, i32 0, i32 28
   store i32 %151, i32 addrspace(1)* %153
   %154 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %155 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck70 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %155, null
-  br i1 %NullCheck70, label %156, label %ThrowNullRef69
+  %NullCheck69 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %155, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %156
 
 ; <label>:156                                     ; preds = %152
   %157 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %155, i32 0, i32 6
   %158 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %157, align 8
-  %NullCheck72 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %154, null
-  br i1 %NullCheck72, label %159, label %ThrowNullRef71
+  %NullCheck71 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %154, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %159
 
 ; <label>:159                                     ; preds = %156
   %160 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %154, i32 0, i32 15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %160, %System.String addrspace(1)* %158)
   %161 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %162 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck74 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %162, null
-  br i1 %NullCheck74, label %163, label %ThrowNullRef73
+  %NullCheck73 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %162, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %163
 
 ; <label>:163                                     ; preds = %159
   %164 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %162, i32 0, i32 1
   %165 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %164, align 8
-  %NullCheck76 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %161, null
-  br i1 %NullCheck76, label %166, label %ThrowNullRef75
+  %NullCheck75 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %161, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %166
 
 ; <label>:166                                     ; preds = %163
   %167 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %161, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %167, %"System.Int32[]" addrspace(1)* %165)
   %168 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %169 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck78 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %169, null
-  br i1 %NullCheck78, label %170, label %ThrowNullRef77
+  %NullCheck77 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %169, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %170
 
 ; <label>:170                                     ; preds = %166
   %171 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %169, i32 0, i32 7
   %172 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %171, align 8
-  %NullCheck80 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %168, null
-  br i1 %NullCheck80, label %173, label %ThrowNullRef79
+  %NullCheck79 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %168, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %173
 
 ; <label>:173                                     ; preds = %170
   %174 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %168, i32 0, i32 16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %174, %System.String addrspace(1)* %172)
   %175 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck82 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %175, null
-  br i1 %NullCheck82, label %176, label %ThrowNullRef81
+  %NullCheck81 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %175, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %176
 
 ; <label>:176                                     ; preds = %173
   %177 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %175, i32 0, i32 4
@@ -13718,14 +15427,14 @@ entry:
 
 ; <label>:180                                     ; preds = %176
   %181 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck84 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %181, null
-  br i1 %NullCheck84, label %182, label %ThrowNullRef83
+  %NullCheck83 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %181, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %182
 
 ; <label>:182                                     ; preds = %180
   %183 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %181, i32 0, i32 4
   %184 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %183, align 8
-  %NullCheck86 = icmp ne %System.String addrspace(1)* %184, null
-  br i1 %NullCheck86, label %185, label %ThrowNullRef85
+  %NullCheck85 = icmp eq %System.String addrspace(1)* %184, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %185
 
 ; <label>:185                                     ; preds = %182
   %186 = getelementptr inbounds %System.String, %System.String addrspace(1)* %184, i32 0, i32 1
@@ -13736,8 +15445,8 @@ entry:
 ; <label>:189                                     ; preds = %176, %185
   %190 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck98 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %190, null
-  br i1 %NullCheck98, label %192, label %ThrowNullRef97
+  %NullCheck97 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %190, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %192
 
 ; <label>:192                                     ; preds = %189
   %193 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %190, i32 0, i32 4
@@ -13746,8 +15455,8 @@ entry:
 
 ; <label>:194                                     ; preds = %185, %192
   %195 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck88 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %195, null
-  br i1 %NullCheck88, label %196, label %ThrowNullRef87
+  %NullCheck87 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %195, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %196
 
 ; <label>:196                                     ; preds = %194
   %197 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %195, i32 0, i32 9
@@ -13757,14 +15466,14 @@ entry:
 
 ; <label>:200                                     ; preds = %196
   %201 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck90 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %201, null
-  br i1 %NullCheck90, label %202, label %ThrowNullRef89
+  %NullCheck89 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %201, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %202
 
 ; <label>:202                                     ; preds = %200
   %203 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %201, i32 0, i32 9
   %204 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %203, align 8
-  %NullCheck92 = icmp ne %System.String addrspace(1)* %204, null
-  br i1 %NullCheck92, label %205, label %ThrowNullRef91
+  %NullCheck91 = icmp eq %System.String addrspace(1)* %204, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %205
 
 ; <label>:205                                     ; preds = %202
   %206 = getelementptr inbounds %System.String, %System.String addrspace(1)* %204, i32 0, i32 1
@@ -13775,14 +15484,14 @@ entry:
 ; <label>:209                                     ; preds = %196, %205
   %210 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %211 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck94 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %211, null
-  br i1 %NullCheck94, label %212, label %ThrowNullRef93
+  %NullCheck93 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %211, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %212
 
 ; <label>:212                                     ; preds = %209
   %213 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %211, i32 0, i32 6
   %214 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %213, align 8
-  %NullCheck96 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %210, null
-  br i1 %NullCheck96, label %215, label %ThrowNullRef95
+  %NullCheck95 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %210, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %215
 
 ; <label>:215                                     ; preds = %212
   %216 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %210, i32 0, i32 9
@@ -13796,203 +15505,203 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %17
+ThrowNullRef8:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %21
+ThrowNullRef10:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %24
+ThrowNullRef12:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %28
+ThrowNullRef14:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %31
+ThrowNullRef16:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %35
+ThrowNullRef18:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %38
+ThrowNullRef20:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %42
+ThrowNullRef22:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %45
+ThrowNullRef24:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %49
+ThrowNullRef26:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %52
+ThrowNullRef28:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %56
+ThrowNullRef30:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %59
+ThrowNullRef32:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %63
+ThrowNullRef34:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %66
+ThrowNullRef36:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %70
+ThrowNullRef38:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %73
+ThrowNullRef40:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %77
+ThrowNullRef42:                                   ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %80
+ThrowNullRef44:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %84
+ThrowNullRef46:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %101
+ThrowNullRef48:                                   ; preds = %101
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %105
+ThrowNullRef50:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %110
+ThrowNullRef52:                                   ; preds = %110
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %115
+ThrowNullRef54:                                   ; preds = %115
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %120
+ThrowNullRef56:                                   ; preds = %120
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %125
+ThrowNullRef58:                                   ; preds = %125
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %130
+ThrowNullRef60:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %135
+ThrowNullRef62:                                   ; preds = %135
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %140
+ThrowNullRef64:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %145
+ThrowNullRef66:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %149
+ThrowNullRef68:                                   ; preds = %149
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %152
+ThrowNullRef70:                                   ; preds = %152
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %156
+ThrowNullRef72:                                   ; preds = %156
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %159
+ThrowNullRef74:                                   ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %163
+ThrowNullRef76:                                   ; preds = %163
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %166
+ThrowNullRef78:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %170
+ThrowNullRef80:                                   ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %173
+ThrowNullRef82:                                   ; preds = %173
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %180
+ThrowNullRef84:                                   ; preds = %180
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %182
+ThrowNullRef86:                                   ; preds = %182
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %194
+ThrowNullRef88:                                   ; preds = %194
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %200
+ThrowNullRef90:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %202
+ThrowNullRef92:                                   ; preds = %202
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %209
+ThrowNullRef94:                                   ; preds = %209
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %212
+ThrowNullRef96:                                   ; preds = %212
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %189
+ThrowNullRef98:                                   ; preds = %189
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %89
+ThrowNullRef100:                                  ; preds = %89
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14020,8 +15729,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 21
@@ -14034,8 +15743,8 @@ entry:
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 16)
   %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 21
@@ -14044,8 +15753,8 @@ entry:
 
 ; <label>:12                                      ; preds = %1, %10
   %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 21
@@ -14056,11 +15765,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %12
+ThrowNullRef4:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14076,8 +15785,8 @@ entry:
   store i32 %param1, i32* %arg1
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %1 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
@@ -14144,8 +15853,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 33
@@ -14158,8 +15867,8 @@ entry:
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 24)
   %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 33
@@ -14168,8 +15877,8 @@ entry:
 
 ; <label>:12                                      ; preds = %1, %10
   %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 33
@@ -14180,11 +15889,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %12
+ThrowNullRef4:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14197,8 +15906,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 53
@@ -14210,8 +15919,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 116)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 53
@@ -14220,8 +15929,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 53
@@ -14232,11 +15941,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14265,8 +15974,8 @@ entry:
 
 ; <label>:7                                       ; preds = %entry, %4
   %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %7
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 2
@@ -14290,8 +15999,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 54
@@ -14303,8 +16012,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 117)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
@@ -14313,8 +16022,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 54
@@ -14325,11 +16034,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14342,8 +16051,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 27
@@ -14355,8 +16064,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 118)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 27
@@ -14365,8 +16074,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 27
@@ -14377,11 +16086,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14394,8 +16103,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 28
@@ -14407,8 +16116,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 119)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 28
@@ -14417,8 +16126,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 28
@@ -14429,11 +16138,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14446,8 +16155,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 26
@@ -14459,8 +16168,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 107)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 26
@@ -14469,8 +16178,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 26
@@ -14481,11 +16190,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14498,8 +16207,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 25
@@ -14511,8 +16220,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 106)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 25
@@ -14521,8 +16230,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 25
@@ -14533,11 +16242,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14550,8 +16259,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 24
@@ -14563,8 +16272,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 105)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 24
@@ -14573,8 +16282,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 24
@@ -14585,11 +16294,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14614,8 +16323,8 @@ entry:
   %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %3)
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %2
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -14626,15 +16335,15 @@ entry:
 
 ; <label>:8                                       ; preds = %62
   %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 9
   %12 = load i32, i32 addrspace(1)* %11, align 8
   %13 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.IO.StreamWriter addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %13, i32 0, i32 10
@@ -14649,15 +16358,15 @@ entry:
 
 ; <label>:20                                      ; preds = %14, %18
   %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
   %24 = load i32, i32 addrspace(1)* %23, align 8
   %25 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %25, null
-  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.StreamWriter addrspace(1)* %25, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %25, i32 0, i32 9
@@ -14678,36 +16387,36 @@ entry:
   %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %37 = load i32, i32* %loc1
   %38 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.StreamWriter addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %35
   %40 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %38, i32 0, i32 7
   %41 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %40, align 8
   %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
-  br i1 %NullCheck14, label %43, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %39
   %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 9
   %45 = load i32, i32 addrspace(1)* %44, align 8
   %46 = load i32, i32* %loc2
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %36, null
-  br i1 %NullCheck16, label %47, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %36, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %47
 
 ; <label>:47                                      ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %36, i32 %37, %"System.Char[]" addrspace(1)* %41, i32 %45, i32 %46)
   %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
   %51 = load i32, i32 addrspace(1)* %50, align 8
   %52 = load i32, i32* %loc2
   %53 = add i32 %51, %52
-  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
-  br i1 %NullCheck20, label %54, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %54
 
 ; <label>:54                                      ; preds = %49
   %55 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
@@ -14729,8 +16438,8 @@ entry:
 
 ; <label>:65                                      ; preds = %62
   %66 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %66, null
-  br i1 %NullCheck2, label %67, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %66, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %67
 
 ; <label>:67                                      ; preds = %65
   %68 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %66, i32 0, i32 11
@@ -14751,49 +16460,259 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %65
+ThrowNullRef2:                                    ; preds = %65
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %20
+ThrowNullRef8:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %22
+ThrowNullRef10:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %35
+ThrowNullRef12:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %43
+ThrowNullRef16:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %47
+ThrowNullRef18:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method String::CopyTo using LLILCJit
-Failed to read String.CopyTo[loadElemA]
+Successfully read String.CopyTo
+
+define void @String.CopyTo(%System.String addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  %loc1 = alloca i16 addrspace(1)*
+  %loc2 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %1 = icmp ne %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg4
+  %7 = icmp sge i32 %6, 0
+  br i1 %7, label %13, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  unreachable
+
+; <label>:13                                      ; preds = %5
+  %14 = load i32, i32* %arg1
+  %15 = icmp sge i32 %14, 0
+  br i1 %15, label %21, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %18)
+  %20 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %20, %System.String addrspace(1)* %17, %System.String addrspace(1)* %19)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %20) #0
+  unreachable
+
+; <label>:21                                      ; preds = %13
+  %22 = load i32, i32* %arg4
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck, label %ThrowNullRef, label %24
+
+; <label>:24                                      ; preds = %21
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load i32, i32* %arg1
+  %28 = sub i32 %26, %27
+  %29 = icmp sle i32 %22, %28
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34, %System.String addrspace(1)* %31, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %24
+  %36 = load i32, i32* %arg3
+  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %37, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
+
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
+  %40 = load i32, i32 addrspace(1)* %39
+  %41 = zext i32 %40 to i64
+  %42 = trunc i64 %41 to i32
+  %43 = load i32, i32* %arg4
+  %44 = sub i32 %42, %43
+  %45 = icmp sgt i32 %36, %44
+  br i1 %45, label %49, label %46
+
+; <label>:46                                      ; preds = %38
+  %47 = load i32, i32* %arg3
+  %48 = icmp sge i32 %47, 0
+  br i1 %48, label %54, label %49
+
+; <label>:49                                      ; preds = %38, %46
+  %50 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %52 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %51)
+  %53 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53, %System.String addrspace(1)* %50, %System.String addrspace(1)* %52)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53) #0
+  unreachable
+
+; <label>:54                                      ; preds = %46
+  %55 = load i32, i32* %arg4
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %97, label %57
+
+; <label>:57                                      ; preds = %54
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %59
+
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 2
+  %61 = bitcast [0 x i16] addrspace(1)* %60 to i16 addrspace(1)*
+  store i16 addrspace(1)* %61, i16 addrspace(1)** %loc0
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  store %"System.Char[]" addrspace(1)* %62, %"System.Char[]" addrspace(1)** %loc2
+  %63 = icmp eq %"System.Char[]" addrspace(1)* %62, null
+  br i1 %63, label %72, label %64
+
+; <label>:64                                      ; preds = %59
+  %65 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc2
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %65, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %66
+
+; <label>:66                                      ; preds = %64
+  %67 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %65, i32 0, i32 1
+  %68 = load i32, i32 addrspace(1)* %67
+  %69 = zext i32 %68 to i64
+  %70 = trunc i64 %69 to i32
+  %71 = icmp ne i32 %70, 0
+  br i1 %71, label %73, label %72
+
+; <label>:72                                      ; preds = %59, %66
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  br label %81
+
+; <label>:73                                      ; preds = %66
+  %74 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc2
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %74, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %75
+
+; <label>:75                                      ; preds = %73
+  %76 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %74, i32 0, i32 1
+  %77 = load i32, i32 addrspace(1)* %76
+  %78 = zext i32 %77 to i64
+  %BoundsCheck = icmp uge i64 0, %78
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %79
+
+; <label>:79                                      ; preds = %75
+  %80 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %74, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %80, i16 addrspace(1)** %loc1
+  br label %81
+
+; <label>:81                                      ; preds = %72, %79
+  %82 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %83 = ptrtoint i16 addrspace(1)* %82 to i64
+  %84 = load i32, i32* %arg3
+  %85 = sext i32 %84 to i64
+  %86 = mul i64 %85, 2
+  %87 = add i64 %83, %86
+  %88 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %89 = ptrtoint i16 addrspace(1)* %88 to i64
+  %90 = load i32, i32* %arg1
+  %91 = sext i32 %90 to i64
+  %92 = mul i64 %91, 2
+  %93 = add i64 %89, %92
+  %94 = load i32, i32* %arg4
+  %95 = inttoptr i64 %87 to i16*
+  %96 = inttoptr i64 %93 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %95, i16* %96, i32 %94)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  br label %97
+
+; <label>:97                                      ; preds = %54, %81
+  ret void
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
 Successfully read ConsoleEncoding.GetPreamble
 
@@ -14830,7 +16749,365 @@ entry:
 }
 
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[loadElemA]
+Successfully read EncoderNLS.GetBytes
+
+define i32 @EncoderNLS.GetBytes(%System.Text.EncoderNLS addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3, %"System.Byte[]" addrspace(1)* %param4, i32 %param5, i8 %param6) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %arg4 = alloca %"System.Byte[]" addrspace(1)*
+  %arg5 = alloca i32
+  %arg6 = alloca i8
+  %loc0 = alloca i32
+  %loc1 = alloca i16 addrspace(1)*
+  %loc2 = alloca i8 addrspace(1)*
+  %loc3 = alloca i32
+  %loc4 = alloca %"System.Char[]" addrspace(1)*
+  %loc5 = alloca %"System.Byte[]" addrspace(1)*
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  store %"System.Byte[]" addrspace(1)* %param4, %"System.Byte[]" addrspace(1)** %arg4
+  store i32 %param5, i32* %arg5
+  store i8 %param6, i8* %arg6
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %1 = icmp eq %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %17, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %7 = icmp eq %"System.Char[]" addrspace(1)* %6, null
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %12
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %12
+
+; <label>:12                                      ; preds = %8, %10
+  %13 = phi %System.String addrspace(1)* [ %9, %8 ], [ %11, %10 ]
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %14)
+  %16 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16, %System.String addrspace(1)* %13, %System.String addrspace(1)* %15)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16) #0
+  unreachable
+
+; <label>:17                                      ; preds = %2
+  %18 = load i32, i32* %arg2
+  %19 = icmp slt i32 %18, 0
+  br i1 %19, label %23, label %20
+
+; <label>:20                                      ; preds = %17
+  %21 = load i32, i32* %arg3
+  %22 = icmp sge i32 %21, 0
+  br i1 %22, label %35, label %23
+
+; <label>:23                                      ; preds = %17, %20
+  %24 = load i32, i32* %arg2
+  %25 = icmp slt i32 %24, 0
+  br i1 %25, label %28, label %26
+
+; <label>:26                                      ; preds = %23
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %30
+
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %30
+
+; <label>:30                                      ; preds = %26, %28
+  %31 = phi %System.String addrspace(1)* [ %27, %26 ], [ %29, %28 ]
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34, %System.String addrspace(1)* %31, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %20
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck, label %ThrowNullRef, label %37
+
+; <label>:37                                      ; preds = %35
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = load i32, i32* %arg2
+  %43 = sub i32 %41, %42
+  %44 = load i32, i32* %arg3
+  %45 = icmp sge i32 %43, %44
+  br i1 %45, label %51, label %46
+
+; <label>:46                                      ; preds = %37
+  %47 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %48 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %49 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %48)
+  %50 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %50, %System.String addrspace(1)* %47, %System.String addrspace(1)* %49)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %50) #0
+  unreachable
+
+; <label>:51                                      ; preds = %37
+  %52 = load i32, i32* %arg5
+  %53 = icmp slt i32 %52, 0
+  br i1 %53, label %63, label %54
+
+; <label>:54                                      ; preds = %51
+  %55 = load i32, i32* %arg5
+  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck1 = icmp eq %"System.Byte[]" addrspace(1)* %56, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %57
+
+; <label>:57                                      ; preds = %54
+  %58 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = zext i32 %59 to i64
+  %61 = trunc i64 %60 to i32
+  %62 = icmp sle i32 %55, %61
+  br i1 %62, label %68, label %63
+
+; <label>:63                                      ; preds = %51, %57
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %66 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %65)
+  %67 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %67, %System.String addrspace(1)* %64, %System.String addrspace(1)* %66)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %67) #0
+  unreachable
+
+; <label>:68                                      ; preds = %57
+  %69 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %69, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %69, i32 0, i32 1
+  %72 = load i32, i32 addrspace(1)* %71
+  %73 = zext i32 %72 to i64
+  %74 = trunc i64 %73 to i32
+  %75 = icmp ne i32 %74, 0
+  br i1 %75, label %78, label %76
+
+; <label>:76                                      ; preds = %70
+  %77 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1)
+  store %"System.Char[]" addrspace(1)* %77, %"System.Char[]" addrspace(1)** %arg1
+  br label %78
+
+; <label>:78                                      ; preds = %70, %76
+  %79 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck5 = icmp eq %"System.Byte[]" addrspace(1)* %79, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %80
+
+; <label>:80                                      ; preds = %78
+  %81 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %79, i32 0, i32 1
+  %82 = load i32, i32 addrspace(1)* %81
+  %83 = zext i32 %82 to i64
+  %84 = trunc i64 %83 to i32
+  %85 = load i32, i32* %arg5
+  %86 = sub i32 %84, %85
+  store i32 %86, i32* %loc0
+  %87 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck7 = icmp eq %"System.Byte[]" addrspace(1)* %87, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %88
+
+; <label>:88                                      ; preds = %80
+  %89 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %87, i32 0, i32 1
+  %90 = load i32, i32 addrspace(1)* %89
+  %91 = zext i32 %90 to i64
+  %92 = trunc i64 %91 to i32
+  %93 = icmp ne i32 %92, 0
+  br i1 %93, label %96, label %94
+
+; <label>:94                                      ; preds = %88
+  %95 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1)
+  store %"System.Byte[]" addrspace(1)* %95, %"System.Byte[]" addrspace(1)** %arg4
+  br label %96
+
+; <label>:96                                      ; preds = %88, %94
+  %97 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  store %"System.Char[]" addrspace(1)* %97, %"System.Char[]" addrspace(1)** %loc4
+  %98 = icmp eq %"System.Char[]" addrspace(1)* %97, null
+  br i1 %98, label %107, label %99
+
+; <label>:99                                      ; preds = %96
+  %100 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc4
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %100, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %101
+
+; <label>:101                                     ; preds = %99
+  %102 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %100, i32 0, i32 1
+  %103 = load i32, i32 addrspace(1)* %102
+  %104 = zext i32 %103 to i64
+  %105 = trunc i64 %104 to i32
+  %106 = icmp ne i32 %105, 0
+  br i1 %106, label %108, label %107
+
+; <label>:107                                     ; preds = %96, %101
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  br label %116
+
+; <label>:108                                     ; preds = %101
+  %109 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc4
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %109, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %110
+
+; <label>:110                                     ; preds = %108
+  %111 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %109, i32 0, i32 1
+  %112 = load i32, i32 addrspace(1)* %111
+  %113 = zext i32 %112 to i64
+  %BoundsCheck = icmp uge i64 0, %113
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %114
+
+; <label>:114                                     ; preds = %110
+  %115 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %109, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %115, i16 addrspace(1)** %loc1
+  br label %116
+
+; <label>:116                                     ; preds = %107, %114
+  %117 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  store %"System.Byte[]" addrspace(1)* %117, %"System.Byte[]" addrspace(1)** %loc5
+  %118 = icmp eq %"System.Byte[]" addrspace(1)* %117, null
+  br i1 %118, label %127, label %119
+
+; <label>:119                                     ; preds = %116
+  %120 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc5
+  %NullCheck13 = icmp eq %"System.Byte[]" addrspace(1)* %120, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %121
+
+; <label>:121                                     ; preds = %119
+  %122 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %120, i32 0, i32 1
+  %123 = load i32, i32 addrspace(1)* %122
+  %124 = zext i32 %123 to i64
+  %125 = trunc i64 %124 to i32
+  %126 = icmp ne i32 %125, 0
+  br i1 %126, label %128, label %127
+
+; <label>:127                                     ; preds = %116, %121
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc2
+  br label %136
+
+; <label>:128                                     ; preds = %121
+  %129 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc5
+  %NullCheck15 = icmp eq %"System.Byte[]" addrspace(1)* %129, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %130
+
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %129, i32 0, i32 1
+  %132 = load i32, i32 addrspace(1)* %131
+  %133 = zext i32 %132 to i64
+  %BoundsCheck17 = icmp uge i64 0, %133
+  br i1 %BoundsCheck17, label %ThrowIndexOutOfRange18, label %134
+
+; <label>:134                                     ; preds = %130
+  %135 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %129, i32 0, i32 3, i32 0
+  store i8 addrspace(1)* %135, i8 addrspace(1)** %loc2
+  br label %136
+
+; <label>:136                                     ; preds = %127, %134
+  %137 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %138 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %139 = ptrtoint i16 addrspace(1)* %138 to i64
+  %140 = load i32, i32* %arg2
+  %141 = sext i32 %140 to i64
+  %142 = mul i64 %141, 2
+  %143 = add i64 %139, %142
+  %144 = load i32, i32* %arg3
+  %145 = load i8 addrspace(1)*, i8 addrspace(1)** %loc2
+  %146 = ptrtoint i8 addrspace(1)* %145 to i64
+  %147 = load i32, i32* %arg5
+  %148 = sext i32 %147 to i64
+  %149 = add i64 %146, %148
+  %150 = load i32, i32* %loc0
+  %151 = load i8, i8* %arg6
+  %152 = zext i8 %151 to i32
+  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i64 addrspace(1)*
+  %NullCheck19 = icmp eq i64 addrspace(1)* %153, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %154
+
+; <label>:154                                     ; preds = %136
+  %155 = load i64, i64 addrspace(1)* %153
+  %156 = add i64 %155, 72
+  %157 = inttoptr i64 %156 to i64*
+  %158 = load i64, i64* %157
+  %159 = add i64 %158, 0
+  %160 = inttoptr i64 %159 to i64*
+  %161 = load i64, i64* %160
+  %162 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to %System.Text.Encoder addrspace(1)*
+  %163 = inttoptr i64 %143 to i16*
+  %164 = inttoptr i64 %149 to i8*
+  %165 = trunc i32 %152 to i8
+  %166 = inttoptr i64 %161 to i32 (%System.Text.Encoder addrspace(1)*, i16*, i32, i8*, i32, i8)*
+  %167 = call i32 %166(%System.Text.Encoder addrspace(1)* %162, i16* %163, i32 %144, i8* %164, i32 %150, i8 %165)
+  store i32 %167, i32* %loc3
+  br label %168
+
+; <label>:168                                     ; preds = %154
+  %169 = load i32, i32* %loc3
+  ret i32 %169
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %110
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %119
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange18:                           ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
 Successfully read EncoderNLS.GetBytes
 
@@ -14919,22 +17196,22 @@ entry:
   %40 = load i8, i8* %arg5
   %41 = zext i8 %40 to i32
   %42 = trunc i32 %41 to i8
-  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %39, null
-  br i1 %NullCheck, label %43, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderNLS addrspace(1)* %39, null
+  br i1 %NullCheck, label %ThrowNullRef, label %43
 
 ; <label>:43                                      ; preds = %38
   %44 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
   store i8 %42, i8 addrspace(1)* %44
   %45 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %45, null
-  br i1 %NullCheck2, label %46, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.EncoderNLS addrspace(1)* %45, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %46
 
 ; <label>:46                                      ; preds = %43
   %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %45, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %47
   %48 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.EncoderNLS addrspace(1)* %48, null
-  br i1 %NullCheck4, label %49, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.EncoderNLS addrspace(1)* %48, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %49
 
 ; <label>:49                                      ; preds = %46
   %50 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %48, i32 0, i32 3
@@ -14945,8 +17222,8 @@ entry:
   %55 = load i32, i32* %arg4
   %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck6, label %58, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
   %59 = load i64, i64 addrspace(1)* %57
@@ -14964,15 +17241,15 @@ ThrowNullRef:                                     ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %43
+ThrowNullRef2:                                    ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %46
+ThrowNullRef4:                                    ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %49
+ThrowNullRef6:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -15000,8 +17277,8 @@ entry:
   %4 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0 to %System.IO.ConsoleStream addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*)(%System.IO.ConsoleStream addrspace(1)* %4, %"System.Byte[]" addrspace(1)* %1, i32 %2, i32 %3)
   %5 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
@@ -15086,8 +17363,8 @@ entry:
 
 ; <label>:22                                      ; preds = %8
   %23 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %23, null
-  br i1 %NullCheck, label %24, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Byte[]" addrspace(1)* %23, null
+  br i1 %NullCheck, label %ThrowNullRef, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
@@ -15109,8 +17386,8 @@ entry:
 
 ; <label>:36                                      ; preds = %24
   %37 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %37, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.ConsoleStream addrspace(1)* %37, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %37, i32 0, i32 4
@@ -15131,13 +17408,138 @@ ThrowNullRef:                                     ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %36
+ThrowNullRef2:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
-Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
+Successfully read WindowsConsoleStream.WriteFileNative
+
+define i32 @WindowsConsoleStream.WriteFileNative(i64 %param0, %"System.Byte[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i64
+  %arg1 = alloca %"System.Byte[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i8 addrspace(1)*
+  %loc2 = alloca %"System.Byte[]" addrspace(1)*
+  %loc3 = alloca i32
+  store i64 %param0, i64* %arg0
+  store %"System.Byte[]" addrspace(1)* %param1, %"System.Byte[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Byte[]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = zext i32 %3 to i64
+  %5 = icmp ne i64 %4, 0
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %1
+  ret i32 0
+
+; <label>:7                                       ; preds = %1
+  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  store %"System.Byte[]" addrspace(1)* %8, %"System.Byte[]" addrspace(1)** %loc2
+  %9 = icmp eq %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %9, label %18, label %10
+
+; <label>:10                                      ; preds = %7
+  %11 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc2
+  %NullCheck1 = icmp eq %"System.Byte[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %11, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp ne i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %7, %12
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc1
+  br label %27
+
+; <label>:19                                      ; preds = %12
+  %20 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc2
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %20, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %BoundsCheck = icmp uge i64 0, %24
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %25
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %20, i32 0, i32 3, i32 0
+  store i8 addrspace(1)* %26, i8 addrspace(1)** %loc1
+  br label %27
+
+; <label>:27                                      ; preds = %18, %25
+  %28 = load i64, i64* %arg0
+  %29 = load i8 addrspace(1)*, i8 addrspace(1)** %loc1
+  %30 = ptrtoint i8 addrspace(1)* %29 to i64
+  %31 = load i32, i32* %arg2
+  %32 = sext i32 %31 to i64
+  %33 = add i64 %30, %32
+  %34 = load i32, i32* %arg3
+  %35 = addrspacecast i32* %loc3 to i32 addrspace(1)*
+  %36 = inttoptr i64 %33 to i8*
+  %37 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i8*, i32, i32 addrspace(1)*, i64)*)(i64 %28, i8* %36, i32 %34, i32 addrspace(1)* %35, i64 0)
+  %38 = icmp ugt i32 %37, 0
+  %39 = sext i1 %38 to i32
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc1
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %42, label %41
+
+; <label>:41                                      ; preds = %27
+  ret i32 0
+
+; <label>:42                                      ; preds = %27
+  %43 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  store i32 %43, i32* %loc0
+  %44 = load i32, i32* %loc0
+  %45 = icmp eq i32 %44, 232
+  br i1 %45, label %49, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = load i32, i32* %loc0
+  %48 = icmp ne i32 %47, 109
+  br i1 %48, label %50, label %49
+
+; <label>:49                                      ; preds = %42, %46
+  ret i32 0
+
+; <label>:50                                      ; preds = %46
+  %51 = load i32, i32* %loc0
+  ret i32 %51
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
 Successfully read WindowsConsoleStream.Flush
 
@@ -15146,8 +17548,8 @@ entry:
   %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
   store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
@@ -15182,8 +17584,8 @@ entry:
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
   %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load i64, i64 addrspace(1)* %1
@@ -15222,15 +17624,15 @@ entry:
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.TextWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
   %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %3, align 8
   %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
   %7 = load i64, i64 addrspace(1)* %5
@@ -15248,7 +17650,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -15277,8 +17679,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %4)
   store i32 0, i32* %loc0
   %5 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Char[]" addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
@@ -15290,15 +17692,15 @@ entry:
 
 ; <label>:11                                      ; preds = %69
   %12 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %12, i32 0, i32 9
   %15 = load i32, i32 addrspace(1)* %14, align 8
   %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.IO.StreamWriter addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %16, i32 0, i32 10
@@ -15313,15 +17715,15 @@ entry:
 
 ; <label>:23                                      ; preds = %17, %21
   %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %24, null
-  br i1 %NullCheck8, label %25, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %24, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 10
   %27 = load i32, i32 addrspace(1)* %26, align 8
   %28 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %28, null
-  br i1 %NullCheck10, label %29, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.StreamWriter addrspace(1)* %28, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %28, i32 0, i32 9
@@ -15343,15 +17745,15 @@ entry:
   %40 = load i32, i32* %loc0
   %41 = mul i32 %40, 2
   %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
-  br i1 %NullCheck12, label %43, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %43
 
 ; <label>:43                                      ; preds = %38
   %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 7
   %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %44, align 8
   %46 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %46, null
-  br i1 %NullCheck14, label %47, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.IO.StreamWriter addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %47
 
 ; <label>:47                                      ; preds = %43
   %48 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %46, i32 0, i32 9
@@ -15363,16 +17765,16 @@ entry:
   %54 = bitcast %"System.Char[]" addrspace(1)* %45 to %System.Array addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %53, i32 %41, %System.Array addrspace(1)* %54, i32 %50, i32 %52)
   %55 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
-  br i1 %NullCheck16, label %56, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %56
 
 ; <label>:56                                      ; preds = %47
   %57 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
   %58 = load i32, i32 addrspace(1)* %57, align 8
   %59 = load i32, i32* %loc2
   %60 = add i32 %58, %59
-  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
-  br i1 %NullCheck18, label %61, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %61
 
 ; <label>:61                                      ; preds = %56
   %62 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
@@ -15394,8 +17796,8 @@ entry:
 
 ; <label>:72                                      ; preds = %69
   %73 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %73, null
-  br i1 %NullCheck2, label %74, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %73, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %74
 
 ; <label>:74                                      ; preds = %72
   %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %73, i32 0, i32 11
@@ -15416,39 +17818,39 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %72
+ThrowNullRef2:                                    ; preds = %72
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %23
+ThrowNullRef8:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef10:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %43
+ThrowNullRef14:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %47
+ThrowNullRef16:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %56
+ThrowNullRef18:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPMulConst.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPMulConst.error.txt
@@ -25,8 +25,8 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
@@ -40,8 +40,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
   %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
@@ -75,7 +75,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -90,8 +90,8 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %NullCheck = icmp ne i8 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = load i8, i8 addrspace(1)* %0, align 8
@@ -125,8 +125,8 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
@@ -159,8 +159,8 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -184,8 +184,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
   store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
@@ -195,8 +195,8 @@ entry:
 ; <label>:4                                       ; preds = %1
   %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
   %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
@@ -206,8 +206,8 @@ entry:
   %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
@@ -221,14 +221,14 @@ entry:
 
 ; <label>:17                                      ; preds = %14
   %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
   %21 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
@@ -238,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -249,8 +249,8 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
@@ -261,27 +261,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %30
+ThrowNullRef10:                                   ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -301,7 +301,89 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
-Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
+Successfully read AppDomainSetup.GetUnsecureApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.GetUnsecureApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %NullCheck = icmp eq %"System.String[]" addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %BoundsCheck = icmp uge i64 0, %5
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %6
+
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 3, i32 0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
+  ret %System.String addrspace(1)* %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_Value using LLILCJit
+Successfully read AppDomainSetup.get_Value
+
+define %"System.String[]" addrspace(1)* @AppDomainSetup.get_Value(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.String[]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 18)
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.String[]" addrspace(1)* addrspace(1)*, %"System.String[]" addrspace(1)*)*)(%"System.String[]" addrspace(1)* addrspace(1)* %9, %"System.String[]" addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %11, i32 0, i32 1
+  %14 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %13, align 8
+  ret %"System.String[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -319,8 +401,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -368,16 +450,16 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
   %5 = load i32, i32 addrspace(1)* %4
   %6 = sub i32 %5, 1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -389,7 +471,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -421,8 +503,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
@@ -456,8 +538,8 @@ entry:
 ; <label>:27                                      ; preds = %19
   %28 = load i32, i32* %arg1
   %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
-  br i1 %NullCheck2, label %30, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %29, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %30
 
 ; <label>:30                                      ; preds = %27
   %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
@@ -493,8 +575,8 @@ entry:
 ; <label>:49                                      ; preds = %46
   %50 = load i32, i32* %arg2
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck4, label %52, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
@@ -517,11 +599,11 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %27
+ThrowNullRef2:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %49
+ThrowNullRef4:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -544,16 +626,16 @@ entry:
   %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %0)
   store %System.String addrspace(1)* %1, %System.String addrspace(1)** %loc0
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 2
   %5 = bitcast [0 x i16] addrspace(1)* %4 to i16 addrspace(1)*
   store i16 addrspace(1)* %5, i16 addrspace(1)** %loc1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %3
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2
@@ -580,7 +662,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -691,15 +773,15 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %NullCheck132 = icmp ne i8* %21, null
-  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+  %NullCheck131 = icmp eq i8* %21, null
+  br i1 %NullCheck131, label %ThrowNullRef132, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = load i8, i8* %21, align 8
   %24 = zext i8 %23 to i32
   %25 = trunc i32 %24 to i8
-  %NullCheck134 = icmp ne i8* %20, null
-  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+  %NullCheck133 = icmp eq i8* %20, null
+  br i1 %NullCheck133, label %ThrowNullRef134, label %26
 
 ; <label>:26                                      ; preds = %22
   store i8 %25, i8* %20, align 8
@@ -709,16 +791,16 @@ entry:
   %28 = load i8*, i8** %arg0
   %29 = load i8*, i8** %arg1
   %30 = bitcast i8* %29 to i16*
-  %NullCheck128 = icmp ne i16* %30, null
-  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+  %NullCheck127 = icmp eq i16* %30, null
+  br i1 %NullCheck127, label %ThrowNullRef128, label %31
 
 ; <label>:31                                      ; preds = %27
   %32 = load i16, i16* %30, align 8
   %33 = sext i16 %32 to i32
   %34 = bitcast i8* %28 to i16*
   %35 = trunc i32 %33 to i16
-  %NullCheck130 = icmp ne i16* %34, null
-  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+  %NullCheck129 = icmp eq i16* %34, null
+  br i1 %NullCheck129, label %ThrowNullRef130, label %36
 
 ; <label>:36                                      ; preds = %31
   store i16 %35, i16* %34, align 8
@@ -728,16 +810,16 @@ entry:
   %38 = load i8*, i8** %arg0
   %39 = load i8*, i8** %arg1
   %40 = bitcast i8* %39 to i16*
-  %NullCheck120 = icmp ne i16* %40, null
-  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+  %NullCheck119 = icmp eq i16* %40, null
+  br i1 %NullCheck119, label %ThrowNullRef120, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i16, i16* %40, align 8
   %43 = sext i16 %42 to i32
   %44 = bitcast i8* %38 to i16*
   %45 = trunc i32 %43 to i16
-  %NullCheck122 = icmp ne i16* %44, null
-  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+  %NullCheck121 = icmp eq i16* %44, null
+  br i1 %NullCheck121, label %ThrowNullRef122, label %46
 
 ; <label>:46                                      ; preds = %41
   store i16 %45, i16* %44, align 8
@@ -745,15 +827,15 @@ entry:
   %48 = getelementptr inbounds i8, i8* %47, i64 2
   %49 = load i8*, i8** %arg1
   %50 = getelementptr inbounds i8, i8* %49, i64 2
-  %NullCheck124 = icmp ne i8* %50, null
-  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+  %NullCheck123 = icmp eq i8* %50, null
+  br i1 %NullCheck123, label %ThrowNullRef124, label %51
 
 ; <label>:51                                      ; preds = %46
   %52 = load i8, i8* %50, align 8
   %53 = zext i8 %52 to i32
   %54 = trunc i32 %53 to i8
-  %NullCheck126 = icmp ne i8* %48, null
-  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+  %NullCheck125 = icmp eq i8* %48, null
+  br i1 %NullCheck125, label %ThrowNullRef126, label %55
 
 ; <label>:55                                      ; preds = %51
   store i8 %54, i8* %48, align 8
@@ -763,14 +845,14 @@ entry:
   %57 = load i8*, i8** %arg0
   %58 = load i8*, i8** %arg1
   %59 = bitcast i8* %58 to i32*
-  %NullCheck116 = icmp ne i32* %59, null
-  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+  %NullCheck115 = icmp eq i32* %59, null
+  br i1 %NullCheck115, label %ThrowNullRef116, label %60
 
 ; <label>:60                                      ; preds = %56
   %61 = load i32, i32* %59, align 8
   %62 = bitcast i8* %57 to i32*
-  %NullCheck118 = icmp ne i32* %62, null
-  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+  %NullCheck117 = icmp eq i32* %62, null
+  br i1 %NullCheck117, label %ThrowNullRef118, label %63
 
 ; <label>:63                                      ; preds = %60
   store i32 %61, i32* %62, align 8
@@ -780,14 +862,14 @@ entry:
   %65 = load i8*, i8** %arg0
   %66 = load i8*, i8** %arg1
   %67 = bitcast i8* %66 to i32*
-  %NullCheck108 = icmp ne i32* %67, null
-  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+  %NullCheck107 = icmp eq i32* %67, null
+  br i1 %NullCheck107, label %ThrowNullRef108, label %68
 
 ; <label>:68                                      ; preds = %64
   %69 = load i32, i32* %67, align 8
   %70 = bitcast i8* %65 to i32*
-  %NullCheck110 = icmp ne i32* %70, null
-  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+  %NullCheck109 = icmp eq i32* %70, null
+  br i1 %NullCheck109, label %ThrowNullRef110, label %71
 
 ; <label>:71                                      ; preds = %68
   store i32 %69, i32* %70, align 8
@@ -795,15 +877,15 @@ entry:
   %73 = getelementptr inbounds i8, i8* %72, i64 4
   %74 = load i8*, i8** %arg1
   %75 = getelementptr inbounds i8, i8* %74, i64 4
-  %NullCheck112 = icmp ne i8* %75, null
-  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+  %NullCheck111 = icmp eq i8* %75, null
+  br i1 %NullCheck111, label %ThrowNullRef112, label %76
 
 ; <label>:76                                      ; preds = %71
   %77 = load i8, i8* %75, align 8
   %78 = zext i8 %77 to i32
   %79 = trunc i32 %78 to i8
-  %NullCheck114 = icmp ne i8* %73, null
-  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+  %NullCheck113 = icmp eq i8* %73, null
+  br i1 %NullCheck113, label %ThrowNullRef114, label %80
 
 ; <label>:80                                      ; preds = %76
   store i8 %79, i8* %73, align 8
@@ -813,14 +895,14 @@ entry:
   %82 = load i8*, i8** %arg0
   %83 = load i8*, i8** %arg1
   %84 = bitcast i8* %83 to i32*
-  %NullCheck100 = icmp ne i32* %84, null
-  br i1 %NullCheck100, label %85, label %ThrowNullRef99
+  %NullCheck99 = icmp eq i32* %84, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %85
 
 ; <label>:85                                      ; preds = %81
   %86 = load i32, i32* %84, align 8
   %87 = bitcast i8* %82 to i32*
-  %NullCheck102 = icmp ne i32* %87, null
-  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+  %NullCheck101 = icmp eq i32* %87, null
+  br i1 %NullCheck101, label %ThrowNullRef102, label %88
 
 ; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
@@ -829,16 +911,16 @@ entry:
   %91 = load i8*, i8** %arg1
   %92 = getelementptr inbounds i8, i8* %91, i64 4
   %93 = bitcast i8* %92 to i16*
-  %NullCheck104 = icmp ne i16* %93, null
-  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+  %NullCheck103 = icmp eq i16* %93, null
+  br i1 %NullCheck103, label %ThrowNullRef104, label %94
 
 ; <label>:94                                      ; preds = %88
   %95 = load i16, i16* %93, align 8
   %96 = sext i16 %95 to i32
   %97 = bitcast i8* %90 to i16*
   %98 = trunc i32 %96 to i16
-  %NullCheck106 = icmp ne i16* %97, null
-  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+  %NullCheck105 = icmp eq i16* %97, null
+  br i1 %NullCheck105, label %ThrowNullRef106, label %99
 
 ; <label>:99                                      ; preds = %94
   store i16 %98, i16* %97, align 8
@@ -848,14 +930,14 @@ entry:
   %101 = load i8*, i8** %arg0
   %102 = load i8*, i8** %arg1
   %103 = bitcast i8* %102 to i32*
-  %NullCheck88 = icmp ne i32* %103, null
-  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+  %NullCheck87 = icmp eq i32* %103, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %104
 
 ; <label>:104                                     ; preds = %100
   %105 = load i32, i32* %103, align 8
   %106 = bitcast i8* %101 to i32*
-  %NullCheck90 = icmp ne i32* %106, null
-  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+  %NullCheck89 = icmp eq i32* %106, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %107
 
 ; <label>:107                                     ; preds = %104
   store i32 %105, i32* %106, align 8
@@ -864,16 +946,16 @@ entry:
   %110 = load i8*, i8** %arg1
   %111 = getelementptr inbounds i8, i8* %110, i64 4
   %112 = bitcast i8* %111 to i16*
-  %NullCheck92 = icmp ne i16* %112, null
-  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+  %NullCheck91 = icmp eq i16* %112, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %113
 
 ; <label>:113                                     ; preds = %107
   %114 = load i16, i16* %112, align 8
   %115 = sext i16 %114 to i32
   %116 = bitcast i8* %109 to i16*
   %117 = trunc i32 %115 to i16
-  %NullCheck94 = icmp ne i16* %116, null
-  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+  %NullCheck93 = icmp eq i16* %116, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %118
 
 ; <label>:118                                     ; preds = %113
   store i16 %117, i16* %116, align 8
@@ -881,15 +963,15 @@ entry:
   %120 = getelementptr inbounds i8, i8* %119, i64 6
   %121 = load i8*, i8** %arg1
   %122 = getelementptr inbounds i8, i8* %121, i64 6
-  %NullCheck96 = icmp ne i8* %122, null
-  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+  %NullCheck95 = icmp eq i8* %122, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %123
 
 ; <label>:123                                     ; preds = %118
   %124 = load i8, i8* %122, align 8
   %125 = zext i8 %124 to i32
   %126 = trunc i32 %125 to i8
-  %NullCheck98 = icmp ne i8* %120, null
-  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+  %NullCheck97 = icmp eq i8* %120, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %127
 
 ; <label>:127                                     ; preds = %123
   store i8 %126, i8* %120, align 8
@@ -899,14 +981,14 @@ entry:
   %129 = load i8*, i8** %arg0
   %130 = load i8*, i8** %arg1
   %131 = bitcast i8* %130 to i64*
-  %NullCheck84 = icmp ne i64* %131, null
-  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+  %NullCheck83 = icmp eq i64* %131, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %132
 
 ; <label>:132                                     ; preds = %128
   %133 = load i64, i64* %131, align 8
   %134 = bitcast i8* %129 to i64*
-  %NullCheck86 = icmp ne i64* %134, null
-  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+  %NullCheck85 = icmp eq i64* %134, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %135
 
 ; <label>:135                                     ; preds = %132
   store i64 %133, i64* %134, align 8
@@ -916,14 +998,14 @@ entry:
   %137 = load i8*, i8** %arg0
   %138 = load i8*, i8** %arg1
   %139 = bitcast i8* %138 to i64*
-  %NullCheck76 = icmp ne i64* %139, null
-  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+  %NullCheck75 = icmp eq i64* %139, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %140
 
 ; <label>:140                                     ; preds = %136
   %141 = load i64, i64* %139, align 8
   %142 = bitcast i8* %137 to i64*
-  %NullCheck78 = icmp ne i64* %142, null
-  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+  %NullCheck77 = icmp eq i64* %142, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %143
 
 ; <label>:143                                     ; preds = %140
   store i64 %141, i64* %142, align 8
@@ -931,15 +1013,15 @@ entry:
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %NullCheck80 = icmp ne i8* %147, null
-  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+  %NullCheck79 = icmp eq i8* %147, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %148
 
 ; <label>:148                                     ; preds = %143
   %149 = load i8, i8* %147, align 8
   %150 = zext i8 %149 to i32
   %151 = trunc i32 %150 to i8
-  %NullCheck82 = icmp ne i8* %145, null
-  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+  %NullCheck81 = icmp eq i8* %145, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %152
 
 ; <label>:152                                     ; preds = %148
   store i8 %151, i8* %145, align 8
@@ -949,14 +1031,14 @@ entry:
   %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
   %156 = bitcast i8* %155 to i64*
-  %NullCheck68 = icmp ne i64* %156, null
-  br i1 %NullCheck68, label %157, label %ThrowNullRef67
+  %NullCheck67 = icmp eq i64* %156, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %157
 
 ; <label>:157                                     ; preds = %153
   %158 = load i64, i64* %156, align 8
   %159 = bitcast i8* %154 to i64*
-  %NullCheck70 = icmp ne i64* %159, null
-  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+  %NullCheck69 = icmp eq i64* %159, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %160
 
 ; <label>:160                                     ; preds = %157
   store i64 %158, i64* %159, align 8
@@ -965,16 +1047,16 @@ entry:
   %163 = load i8*, i8** %arg1
   %164 = getelementptr inbounds i8, i8* %163, i64 8
   %165 = bitcast i8* %164 to i16*
-  %NullCheck72 = icmp ne i16* %165, null
-  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+  %NullCheck71 = icmp eq i16* %165, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %166
 
 ; <label>:166                                     ; preds = %160
   %167 = load i16, i16* %165, align 8
   %168 = sext i16 %167 to i32
   %169 = bitcast i8* %162 to i16*
   %170 = trunc i32 %168 to i16
-  %NullCheck74 = icmp ne i16* %169, null
-  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+  %NullCheck73 = icmp eq i16* %169, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %171
 
 ; <label>:171                                     ; preds = %166
   store i16 %170, i16* %169, align 8
@@ -984,14 +1066,14 @@ entry:
   %173 = load i8*, i8** %arg0
   %174 = load i8*, i8** %arg1
   %175 = bitcast i8* %174 to i64*
-  %NullCheck56 = icmp ne i64* %175, null
-  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+  %NullCheck55 = icmp eq i64* %175, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %176
 
 ; <label>:176                                     ; preds = %172
   %177 = load i64, i64* %175, align 8
   %178 = bitcast i8* %173 to i64*
-  %NullCheck58 = icmp ne i64* %178, null
-  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+  %NullCheck57 = icmp eq i64* %178, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %179
 
 ; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
@@ -1000,16 +1082,16 @@ entry:
   %182 = load i8*, i8** %arg1
   %183 = getelementptr inbounds i8, i8* %182, i64 8
   %184 = bitcast i8* %183 to i16*
-  %NullCheck60 = icmp ne i16* %184, null
-  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+  %NullCheck59 = icmp eq i16* %184, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %185
 
 ; <label>:185                                     ; preds = %179
   %186 = load i16, i16* %184, align 8
   %187 = sext i16 %186 to i32
   %188 = bitcast i8* %181 to i16*
   %189 = trunc i32 %187 to i16
-  %NullCheck62 = icmp ne i16* %188, null
-  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+  %NullCheck61 = icmp eq i16* %188, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %190
 
 ; <label>:190                                     ; preds = %185
   store i16 %189, i16* %188, align 8
@@ -1017,15 +1099,15 @@ entry:
   %192 = getelementptr inbounds i8, i8* %191, i64 10
   %193 = load i8*, i8** %arg1
   %194 = getelementptr inbounds i8, i8* %193, i64 10
-  %NullCheck64 = icmp ne i8* %194, null
-  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+  %NullCheck63 = icmp eq i8* %194, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %195
 
 ; <label>:195                                     ; preds = %190
   %196 = load i8, i8* %194, align 8
   %197 = zext i8 %196 to i32
   %198 = trunc i32 %197 to i8
-  %NullCheck66 = icmp ne i8* %192, null
-  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+  %NullCheck65 = icmp eq i8* %192, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %199
 
 ; <label>:199                                     ; preds = %195
   store i8 %198, i8* %192, align 8
@@ -1035,14 +1117,14 @@ entry:
   %201 = load i8*, i8** %arg0
   %202 = load i8*, i8** %arg1
   %203 = bitcast i8* %202 to i64*
-  %NullCheck48 = icmp ne i64* %203, null
-  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+  %NullCheck47 = icmp eq i64* %203, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %204
 
 ; <label>:204                                     ; preds = %200
   %205 = load i64, i64* %203, align 8
   %206 = bitcast i8* %201 to i64*
-  %NullCheck50 = icmp ne i64* %206, null
-  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+  %NullCheck49 = icmp eq i64* %206, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %207
 
 ; <label>:207                                     ; preds = %204
   store i64 %205, i64* %206, align 8
@@ -1051,14 +1133,14 @@ entry:
   %210 = load i8*, i8** %arg1
   %211 = getelementptr inbounds i8, i8* %210, i64 8
   %212 = bitcast i8* %211 to i32*
-  %NullCheck52 = icmp ne i32* %212, null
-  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+  %NullCheck51 = icmp eq i32* %212, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %213
 
 ; <label>:213                                     ; preds = %207
   %214 = load i32, i32* %212, align 8
   %215 = bitcast i8* %209 to i32*
-  %NullCheck54 = icmp ne i32* %215, null
-  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+  %NullCheck53 = icmp eq i32* %215, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %216
 
 ; <label>:216                                     ; preds = %213
   store i32 %214, i32* %215, align 8
@@ -1068,14 +1150,14 @@ entry:
   %218 = load i8*, i8** %arg0
   %219 = load i8*, i8** %arg1
   %220 = bitcast i8* %219 to i64*
-  %NullCheck36 = icmp ne i64* %220, null
-  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64* %220, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %221
 
 ; <label>:221                                     ; preds = %217
   %222 = load i64, i64* %220, align 8
   %223 = bitcast i8* %218 to i64*
-  %NullCheck38 = icmp ne i64* %223, null
-  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+  %NullCheck37 = icmp eq i64* %223, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %224
 
 ; <label>:224                                     ; preds = %221
   store i64 %222, i64* %223, align 8
@@ -1084,14 +1166,14 @@ entry:
   %227 = load i8*, i8** %arg1
   %228 = getelementptr inbounds i8, i8* %227, i64 8
   %229 = bitcast i8* %228 to i32*
-  %NullCheck40 = icmp ne i32* %229, null
-  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i32* %229, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %230
 
 ; <label>:230                                     ; preds = %224
   %231 = load i32, i32* %229, align 8
   %232 = bitcast i8* %226 to i32*
-  %NullCheck42 = icmp ne i32* %232, null
-  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+  %NullCheck41 = icmp eq i32* %232, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %233
 
 ; <label>:233                                     ; preds = %230
   store i32 %231, i32* %232, align 8
@@ -1099,15 +1181,15 @@ entry:
   %235 = getelementptr inbounds i8, i8* %234, i64 12
   %236 = load i8*, i8** %arg1
   %237 = getelementptr inbounds i8, i8* %236, i64 12
-  %NullCheck44 = icmp ne i8* %237, null
-  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i8* %237, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %238
 
 ; <label>:238                                     ; preds = %233
   %239 = load i8, i8* %237, align 8
   %240 = zext i8 %239 to i32
   %241 = trunc i32 %240 to i8
-  %NullCheck46 = icmp ne i8* %235, null
-  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+  %NullCheck45 = icmp eq i8* %235, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %242
 
 ; <label>:242                                     ; preds = %238
   store i8 %241, i8* %235, align 8
@@ -1117,14 +1199,14 @@ entry:
   %244 = load i8*, i8** %arg0
   %245 = load i8*, i8** %arg1
   %246 = bitcast i8* %245 to i64*
-  %NullCheck24 = icmp ne i64* %246, null
-  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64* %246, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %247
 
 ; <label>:247                                     ; preds = %243
   %248 = load i64, i64* %246, align 8
   %249 = bitcast i8* %244 to i64*
-  %NullCheck26 = icmp ne i64* %249, null
-  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64* %249, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %250
 
 ; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
@@ -1133,14 +1215,14 @@ entry:
   %253 = load i8*, i8** %arg1
   %254 = getelementptr inbounds i8, i8* %253, i64 8
   %255 = bitcast i8* %254 to i32*
-  %NullCheck28 = icmp ne i32* %255, null
-  br i1 %NullCheck28, label %256, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i32* %255, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %256
 
 ; <label>:256                                     ; preds = %250
   %257 = load i32, i32* %255, align 8
   %258 = bitcast i8* %252 to i32*
-  %NullCheck30 = icmp ne i32* %258, null
-  br i1 %NullCheck30, label %259, label %ThrowNullRef29
+  %NullCheck29 = icmp eq i32* %258, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %259
 
 ; <label>:259                                     ; preds = %256
   store i32 %257, i32* %258, align 8
@@ -1149,16 +1231,16 @@ entry:
   %262 = load i8*, i8** %arg1
   %263 = getelementptr inbounds i8, i8* %262, i64 12
   %264 = bitcast i8* %263 to i16*
-  %NullCheck32 = icmp ne i16* %264, null
-  br i1 %NullCheck32, label %265, label %ThrowNullRef31
+  %NullCheck31 = icmp eq i16* %264, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %265
 
 ; <label>:265                                     ; preds = %259
   %266 = load i16, i16* %264, align 8
   %267 = sext i16 %266 to i32
   %268 = bitcast i8* %261 to i16*
   %269 = trunc i32 %267 to i16
-  %NullCheck34 = icmp ne i16* %268, null
-  br i1 %NullCheck34, label %270, label %ThrowNullRef33
+  %NullCheck33 = icmp eq i16* %268, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %270
 
 ; <label>:270                                     ; preds = %265
   store i16 %269, i16* %268, align 8
@@ -1168,14 +1250,14 @@ entry:
   %272 = load i8*, i8** %arg0
   %273 = load i8*, i8** %arg1
   %274 = bitcast i8* %273 to i64*
-  %NullCheck8 = icmp ne i64* %274, null
-  br i1 %NullCheck8, label %275, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64* %274, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %275
 
 ; <label>:275                                     ; preds = %271
   %276 = load i64, i64* %274, align 8
   %277 = bitcast i8* %272 to i64*
-  %NullCheck10 = icmp ne i64* %277, null
-  br i1 %NullCheck10, label %278, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %277, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %278
 
 ; <label>:278                                     ; preds = %275
   store i64 %276, i64* %277, align 8
@@ -1184,14 +1266,14 @@ entry:
   %281 = load i8*, i8** %arg1
   %282 = getelementptr inbounds i8, i8* %281, i64 8
   %283 = bitcast i8* %282 to i32*
-  %NullCheck12 = icmp ne i32* %283, null
-  br i1 %NullCheck12, label %284, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i32* %283, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %284
 
 ; <label>:284                                     ; preds = %278
   %285 = load i32, i32* %283, align 8
   %286 = bitcast i8* %280 to i32*
-  %NullCheck14 = icmp ne i32* %286, null
-  br i1 %NullCheck14, label %287, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i32* %286, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %287
 
 ; <label>:287                                     ; preds = %284
   store i32 %285, i32* %286, align 8
@@ -1200,16 +1282,16 @@ entry:
   %290 = load i8*, i8** %arg1
   %291 = getelementptr inbounds i8, i8* %290, i64 12
   %292 = bitcast i8* %291 to i16*
-  %NullCheck16 = icmp ne i16* %292, null
-  br i1 %NullCheck16, label %293, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i16* %292, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %293
 
 ; <label>:293                                     ; preds = %287
   %294 = load i16, i16* %292, align 8
   %295 = sext i16 %294 to i32
   %296 = bitcast i8* %289 to i16*
   %297 = trunc i32 %295 to i16
-  %NullCheck18 = icmp ne i16* %296, null
-  br i1 %NullCheck18, label %298, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i16* %296, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %298
 
 ; <label>:298                                     ; preds = %293
   store i16 %297, i16* %296, align 8
@@ -1217,15 +1299,15 @@ entry:
   %300 = getelementptr inbounds i8, i8* %299, i64 14
   %301 = load i8*, i8** %arg1
   %302 = getelementptr inbounds i8, i8* %301, i64 14
-  %NullCheck20 = icmp ne i8* %302, null
-  br i1 %NullCheck20, label %303, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i8* %302, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %303
 
 ; <label>:303                                     ; preds = %298
   %304 = load i8, i8* %302, align 8
   %305 = zext i8 %304 to i32
   %306 = trunc i32 %305 to i8
-  %NullCheck22 = icmp ne i8* %300, null
-  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i8* %300, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %307
 
 ; <label>:307                                     ; preds = %303
   store i8 %306, i8* %300, align 8
@@ -1235,14 +1317,14 @@ entry:
   %309 = load i8*, i8** %arg0
   %310 = load i8*, i8** %arg1
   %311 = bitcast i8* %310 to i64*
-  %NullCheck = icmp ne i64* %311, null
-  br i1 %NullCheck, label %312, label %ThrowNullRef
+  %NullCheck = icmp eq i64* %311, null
+  br i1 %NullCheck, label %ThrowNullRef, label %312
 
 ; <label>:312                                     ; preds = %308
   %313 = load i64, i64* %311, align 8
   %314 = bitcast i8* %309 to i64*
-  %NullCheck2 = icmp ne i64* %314, null
-  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64* %314, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %315
 
 ; <label>:315                                     ; preds = %312
   store i64 %313, i64* %314, align 8
@@ -1251,14 +1333,14 @@ entry:
   %318 = load i8*, i8** %arg1
   %319 = getelementptr inbounds i8, i8* %318, i64 8
   %320 = bitcast i8* %319 to i64*
-  %NullCheck4 = icmp ne i64* %320, null
-  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64* %320, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %321
 
 ; <label>:321                                     ; preds = %315
   %322 = load i64, i64* %320, align 8
   %323 = bitcast i8* %317 to i64*
-  %NullCheck6 = icmp ne i64* %323, null
-  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64* %323, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %324
 
 ; <label>:324                                     ; preds = %321
   store i64 %322, i64* %323, align 8
@@ -1286,15 +1368,15 @@ entry:
 ; <label>:338                                     ; preds = %333
   %339 = load i8*, i8** %arg0
   %340 = load i8*, i8** %arg1
-  %NullCheck136 = icmp ne i8* %340, null
-  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+  %NullCheck135 = icmp eq i8* %340, null
+  br i1 %NullCheck135, label %ThrowNullRef136, label %341
 
 ; <label>:341                                     ; preds = %338
   %342 = load i8, i8* %340, align 8
   %343 = zext i8 %342 to i32
   %344 = trunc i32 %343 to i8
-  %NullCheck138 = icmp ne i8* %339, null
-  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+  %NullCheck137 = icmp eq i8* %339, null
+  br i1 %NullCheck137, label %ThrowNullRef138, label %345
 
 ; <label>:345                                     ; preds = %341
   store i8 %344, i8* %339, align 8
@@ -1317,16 +1399,16 @@ entry:
   %357 = load i8*, i8** %arg0
   %358 = load i8*, i8** %arg1
   %359 = bitcast i8* %358 to i16*
-  %NullCheck140 = icmp ne i16* %359, null
-  br i1 %NullCheck140, label %360, label %ThrowNullRef139
+  %NullCheck139 = icmp eq i16* %359, null
+  br i1 %NullCheck139, label %ThrowNullRef140, label %360
 
 ; <label>:360                                     ; preds = %356
   %361 = load i16, i16* %359, align 8
   %362 = sext i16 %361 to i32
   %363 = bitcast i8* %357 to i16*
   %364 = trunc i32 %362 to i16
-  %NullCheck142 = icmp ne i16* %363, null
-  br i1 %NullCheck142, label %365, label %ThrowNullRef141
+  %NullCheck141 = icmp eq i16* %363, null
+  br i1 %NullCheck141, label %ThrowNullRef142, label %365
 
 ; <label>:365                                     ; preds = %360
   store i16 %364, i16* %363, align 8
@@ -1352,14 +1434,14 @@ entry:
   %378 = load i8*, i8** %arg0
   %379 = load i8*, i8** %arg1
   %380 = bitcast i8* %379 to i32*
-  %NullCheck144 = icmp ne i32* %380, null
-  br i1 %NullCheck144, label %381, label %ThrowNullRef143
+  %NullCheck143 = icmp eq i32* %380, null
+  br i1 %NullCheck143, label %ThrowNullRef144, label %381
 
 ; <label>:381                                     ; preds = %377
   %382 = load i32, i32* %380, align 8
   %383 = bitcast i8* %378 to i32*
-  %NullCheck146 = icmp ne i32* %383, null
-  br i1 %NullCheck146, label %384, label %ThrowNullRef145
+  %NullCheck145 = icmp eq i32* %383, null
+  br i1 %NullCheck145, label %ThrowNullRef146, label %384
 
 ; <label>:384                                     ; preds = %381
   store i32 %382, i32* %383, align 8
@@ -1384,14 +1466,14 @@ entry:
   %395 = load i8*, i8** %arg0
   %396 = load i8*, i8** %arg1
   %397 = bitcast i8* %396 to i64*
-  %NullCheck164 = icmp ne i64* %397, null
-  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+  %NullCheck163 = icmp eq i64* %397, null
+  br i1 %NullCheck163, label %ThrowNullRef164, label %398
 
 ; <label>:398                                     ; preds = %394
   %399 = load i64, i64* %397, align 8
   %400 = bitcast i8* %395 to i64*
-  %NullCheck166 = icmp ne i64* %400, null
-  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+  %NullCheck165 = icmp eq i64* %400, null
+  br i1 %NullCheck165, label %ThrowNullRef166, label %401
 
 ; <label>:401                                     ; preds = %398
   store i64 %399, i64* %400, align 8
@@ -1400,14 +1482,14 @@ entry:
   %404 = load i8*, i8** %arg1
   %405 = getelementptr inbounds i8, i8* %404, i64 8
   %406 = bitcast i8* %405 to i64*
-  %NullCheck168 = icmp ne i64* %406, null
-  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+  %NullCheck167 = icmp eq i64* %406, null
+  br i1 %NullCheck167, label %ThrowNullRef168, label %407
 
 ; <label>:407                                     ; preds = %401
   %408 = load i64, i64* %406, align 8
   %409 = bitcast i8* %403 to i64*
-  %NullCheck170 = icmp ne i64* %409, null
-  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+  %NullCheck169 = icmp eq i64* %409, null
+  br i1 %NullCheck169, label %ThrowNullRef170, label %410
 
 ; <label>:410                                     ; preds = %407
   store i64 %408, i64* %409, align 8
@@ -1437,14 +1519,14 @@ entry:
   %425 = load i8*, i8** %arg0
   %426 = load i8*, i8** %arg1
   %427 = bitcast i8* %426 to i64*
-  %NullCheck148 = icmp ne i64* %427, null
-  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+  %NullCheck147 = icmp eq i64* %427, null
+  br i1 %NullCheck147, label %ThrowNullRef148, label %428
 
 ; <label>:428                                     ; preds = %424
   %429 = load i64, i64* %427, align 8
   %430 = bitcast i8* %425 to i64*
-  %NullCheck150 = icmp ne i64* %430, null
-  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+  %NullCheck149 = icmp eq i64* %430, null
+  br i1 %NullCheck149, label %ThrowNullRef150, label %431
 
 ; <label>:431                                     ; preds = %428
   store i64 %429, i64* %430, align 8
@@ -1466,14 +1548,14 @@ entry:
   %441 = load i8*, i8** %arg0
   %442 = load i8*, i8** %arg1
   %443 = bitcast i8* %442 to i32*
-  %NullCheck152 = icmp ne i32* %443, null
-  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+  %NullCheck151 = icmp eq i32* %443, null
+  br i1 %NullCheck151, label %ThrowNullRef152, label %444
 
 ; <label>:444                                     ; preds = %440
   %445 = load i32, i32* %443, align 8
   %446 = bitcast i8* %441 to i32*
-  %NullCheck154 = icmp ne i32* %446, null
-  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+  %NullCheck153 = icmp eq i32* %446, null
+  br i1 %NullCheck153, label %ThrowNullRef154, label %447
 
 ; <label>:447                                     ; preds = %444
   store i32 %445, i32* %446, align 8
@@ -1495,16 +1577,16 @@ entry:
   %457 = load i8*, i8** %arg0
   %458 = load i8*, i8** %arg1
   %459 = bitcast i8* %458 to i16*
-  %NullCheck156 = icmp ne i16* %459, null
-  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+  %NullCheck155 = icmp eq i16* %459, null
+  br i1 %NullCheck155, label %ThrowNullRef156, label %460
 
 ; <label>:460                                     ; preds = %456
   %461 = load i16, i16* %459, align 8
   %462 = sext i16 %461 to i32
   %463 = bitcast i8* %457 to i16*
   %464 = trunc i32 %462 to i16
-  %NullCheck158 = icmp ne i16* %463, null
-  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+  %NullCheck157 = icmp eq i16* %463, null
+  br i1 %NullCheck157, label %ThrowNullRef158, label %465
 
 ; <label>:465                                     ; preds = %460
   store i16 %464, i16* %463, align 8
@@ -1525,15 +1607,15 @@ entry:
 ; <label>:474                                     ; preds = %470
   %475 = load i8*, i8** %arg0
   %476 = load i8*, i8** %arg1
-  %NullCheck160 = icmp ne i8* %476, null
-  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+  %NullCheck159 = icmp eq i8* %476, null
+  br i1 %NullCheck159, label %ThrowNullRef160, label %477
 
 ; <label>:477                                     ; preds = %474
   %478 = load i8, i8* %476, align 8
   %479 = zext i8 %478 to i32
   %480 = trunc i32 %479 to i8
-  %NullCheck162 = icmp ne i8* %475, null
-  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+  %NullCheck161 = icmp eq i8* %475, null
+  br i1 %NullCheck161, label %ThrowNullRef162, label %481
 
 ; <label>:481                                     ; preds = %477
   store i8 %480, i8* %475, align 8
@@ -1553,343 +1635,343 @@ ThrowNullRef:                                     ; preds = %308
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %312
+ThrowNullRef2:                                    ; preds = %312
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %315
+ThrowNullRef4:                                    ; preds = %315
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %321
+ThrowNullRef6:                                    ; preds = %321
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %271
+ThrowNullRef8:                                    ; preds = %271
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %275
+ThrowNullRef10:                                   ; preds = %275
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %278
+ThrowNullRef12:                                   ; preds = %278
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %284
+ThrowNullRef14:                                   ; preds = %284
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %287
+ThrowNullRef16:                                   ; preds = %287
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %293
+ThrowNullRef18:                                   ; preds = %293
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %298
+ThrowNullRef20:                                   ; preds = %298
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %303
+ThrowNullRef22:                                   ; preds = %303
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %243
+ThrowNullRef24:                                   ; preds = %243
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %247
+ThrowNullRef26:                                   ; preds = %247
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %250
+ThrowNullRef28:                                   ; preds = %250
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %256
+ThrowNullRef30:                                   ; preds = %256
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %259
+ThrowNullRef32:                                   ; preds = %259
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %265
+ThrowNullRef34:                                   ; preds = %265
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %217
+ThrowNullRef36:                                   ; preds = %217
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %221
+ThrowNullRef38:                                   ; preds = %221
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %224
+ThrowNullRef40:                                   ; preds = %224
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %230
+ThrowNullRef42:                                   ; preds = %230
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %233
+ThrowNullRef44:                                   ; preds = %233
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %238
+ThrowNullRef46:                                   ; preds = %238
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %200
+ThrowNullRef48:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %204
+ThrowNullRef50:                                   ; preds = %204
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %207
+ThrowNullRef52:                                   ; preds = %207
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %213
+ThrowNullRef54:                                   ; preds = %213
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %172
+ThrowNullRef56:                                   ; preds = %172
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %176
+ThrowNullRef58:                                   ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %179
+ThrowNullRef60:                                   ; preds = %179
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %185
+ThrowNullRef62:                                   ; preds = %185
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %190
+ThrowNullRef64:                                   ; preds = %190
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %195
+ThrowNullRef66:                                   ; preds = %195
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %153
+ThrowNullRef68:                                   ; preds = %153
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %157
+ThrowNullRef70:                                   ; preds = %157
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %160
+ThrowNullRef72:                                   ; preds = %160
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %166
+ThrowNullRef74:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %136
+ThrowNullRef76:                                   ; preds = %136
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %140
+ThrowNullRef78:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %143
+ThrowNullRef80:                                   ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %148
+ThrowNullRef82:                                   ; preds = %148
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %128
+ThrowNullRef84:                                   ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %132
+ThrowNullRef86:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %100
+ThrowNullRef88:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %104
+ThrowNullRef90:                                   ; preds = %104
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %107
+ThrowNullRef92:                                   ; preds = %107
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %113
+ThrowNullRef94:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %118
+ThrowNullRef96:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %123
+ThrowNullRef98:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %81
+ThrowNullRef100:                                  ; preds = %81
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef101:                                  ; preds = %85
+ThrowNullRef102:                                  ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef103:                                  ; preds = %88
+ThrowNullRef104:                                  ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef105:                                  ; preds = %94
+ThrowNullRef106:                                  ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef107:                                  ; preds = %64
+ThrowNullRef108:                                  ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef109:                                  ; preds = %68
+ThrowNullRef110:                                  ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef111:                                  ; preds = %71
+ThrowNullRef112:                                  ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef113:                                  ; preds = %76
+ThrowNullRef114:                                  ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef115:                                  ; preds = %56
+ThrowNullRef116:                                  ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef117:                                  ; preds = %60
+ThrowNullRef118:                                  ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef119:                                  ; preds = %37
+ThrowNullRef120:                                  ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef121:                                  ; preds = %41
+ThrowNullRef122:                                  ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef123:                                  ; preds = %46
+ThrowNullRef124:                                  ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef125:                                  ; preds = %51
+ThrowNullRef126:                                  ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef127:                                  ; preds = %27
+ThrowNullRef128:                                  ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef129:                                  ; preds = %31
+ThrowNullRef130:                                  ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef131:                                  ; preds = %19
+ThrowNullRef132:                                  ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef133:                                  ; preds = %22
+ThrowNullRef134:                                  ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef135:                                  ; preds = %338
+ThrowNullRef136:                                  ; preds = %338
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef137:                                  ; preds = %341
+ThrowNullRef138:                                  ; preds = %341
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef139:                                  ; preds = %356
+ThrowNullRef140:                                  ; preds = %356
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef141:                                  ; preds = %360
+ThrowNullRef142:                                  ; preds = %360
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef143:                                  ; preds = %377
+ThrowNullRef144:                                  ; preds = %377
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef145:                                  ; preds = %381
+ThrowNullRef146:                                  ; preds = %381
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef147:                                  ; preds = %424
+ThrowNullRef148:                                  ; preds = %424
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef149:                                  ; preds = %428
+ThrowNullRef150:                                  ; preds = %428
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef151:                                  ; preds = %440
+ThrowNullRef152:                                  ; preds = %440
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef153:                                  ; preds = %444
+ThrowNullRef154:                                  ; preds = %444
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef155:                                  ; preds = %456
+ThrowNullRef156:                                  ; preds = %456
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef157:                                  ; preds = %460
+ThrowNullRef158:                                  ; preds = %460
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef159:                                  ; preds = %474
+ThrowNullRef160:                                  ; preds = %474
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef161:                                  ; preds = %477
+ThrowNullRef162:                                  ; preds = %477
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef163:                                  ; preds = %394
+ThrowNullRef164:                                  ; preds = %394
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef165:                                  ; preds = %398
+ThrowNullRef166:                                  ; preds = %398
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef167:                                  ; preds = %401
+ThrowNullRef168:                                  ; preds = %401
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef169:                                  ; preds = %407
+ThrowNullRef170:                                  ; preds = %407
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1939,8 +2021,8 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
-  br i1 %NullCheck, label %22, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %ThrowNullRef, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
@@ -1948,8 +2030,8 @@ entry:
   store i32 %24, i32* %loc0
   %25 = load i32, i32* %loc0
   %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %26, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %27
 
 ; <label>:27                                      ; preds = %22
   %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
@@ -1971,7 +2053,7 @@ ThrowNullRef:                                     ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1989,8 +2071,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -2022,15 +2104,15 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2048,16 +2130,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
   %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
   store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %15
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
@@ -2072,8 +2154,8 @@ entry:
   %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
   %29 = ptrtoint i16 addrspace(1)* %28 to i64
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %19
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
@@ -2089,19 +2171,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2114,8 +2196,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
@@ -2128,7 +2210,7 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[loadElem]
+Failed to read AppDomain.PrepareDataForSetup[storeElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
@@ -2202,8 +2284,8 @@ entry:
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
-  br i1 %NullCheck24, label %27, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = load i64, i64 addrspace(1)* %26
@@ -2218,8 +2300,8 @@ entry:
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
-  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
   %41 = load i64, i64 addrspace(1)* %39
@@ -2236,8 +2318,8 @@ entry:
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
-  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
   %54 = load i64, i64 addrspace(1)* %52
@@ -2252,8 +2334,8 @@ entry:
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
   %67 = load i64, i64 addrspace(1)* %65
@@ -2270,8 +2352,8 @@ entry:
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
-  br i1 %NullCheck16, label %79, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
   %80 = load i64, i64 addrspace(1)* %78
@@ -2286,8 +2368,8 @@ entry:
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
-  br i1 %NullCheck18, label %92, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
   %93 = load i64, i64 addrspace(1)* %91
@@ -2304,8 +2386,8 @@ entry:
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
-  br i1 %NullCheck12, label %105, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = load i64, i64 addrspace(1)* %104
@@ -2320,8 +2402,8 @@ entry:
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
-  br i1 %NullCheck14, label %118, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
   %119 = load i64, i64 addrspace(1)* %117
@@ -2337,8 +2419,8 @@ entry:
 
 ; <label>:128                                     ; preds = %20
   %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
-  br i1 %NullCheck4, label %130, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %129, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %130
 
 ; <label>:130                                     ; preds = %128
   %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
@@ -2346,8 +2428,8 @@ entry:
   %133 = load i16, i16 addrspace(1)* %132, align 8
   %134 = zext i16 %133 to i32
   %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
-  br i1 %NullCheck6, label %136, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %135, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %136
 
 ; <label>:136                                     ; preds = %130
   %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
@@ -2360,8 +2442,8 @@ entry:
 
 ; <label>:143                                     ; preds = %136
   %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
-  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %144, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %145
 
 ; <label>:145                                     ; preds = %143
   %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
@@ -2369,8 +2451,8 @@ entry:
   %148 = load i16, i16 addrspace(1)* %147, align 8
   %149 = zext i16 %148 to i32
   %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %150, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %151
 
 ; <label>:151                                     ; preds = %145
   %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
@@ -2388,8 +2470,8 @@ entry:
 
 ; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
-  br i1 %NullCheck, label %163, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %ThrowNullRef, label %163
 
 ; <label>:163                                     ; preds = %161
   %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
@@ -2399,8 +2481,8 @@ entry:
 
 ; <label>:167                                     ; preds = %163
   %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
-  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %168, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %169
 
 ; <label>:169                                     ; preds = %167
   %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
@@ -2432,55 +2514,55 @@ ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %167
+ThrowNullRef2:                                    ; preds = %167
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %128
+ThrowNullRef4:                                    ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %130
+ThrowNullRef6:                                    ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %143
+ThrowNullRef8:                                    ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %145
+ThrowNullRef10:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %102
+ThrowNullRef12:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %105
+ThrowNullRef14:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %76
+ThrowNullRef16:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %79
+ThrowNullRef18:                                   ; preds = %79
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %50
+ThrowNullRef20:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %53
+ThrowNullRef22:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %24
+ThrowNullRef24:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %27
+ThrowNullRef26:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2503,15 +2585,15 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2519,16 +2601,16 @@ entry:
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
   store i32 %8, i32* %loc0
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
   %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
   store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
@@ -2546,16 +2628,16 @@ entry:
 
 ; <label>:23                                      ; preds = %64
   %24 = load i16*, i16** %loc3
-  %NullCheck12 = icmp ne i16* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i16* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
   store i32 %27, i32* %loc5
   %28 = load i16*, i16** %loc4
-  %NullCheck14 = icmp ne i16* %28, null
-  br i1 %NullCheck14, label %29, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %28, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = load i16, i16* %28, align 8
@@ -2620,15 +2702,15 @@ entry:
 
 ; <label>:67                                      ; preds = %64
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
-  br i1 %NullCheck8, label %69, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %68, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %69
 
 ; <label>:69                                      ; preds = %67
   %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
   %71 = load i32, i32 addrspace(1)* %70
   %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
-  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %73
 
 ; <label>:73                                      ; preds = %69
   %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
@@ -2645,31 +2727,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %67
+ThrowNullRef8:                                    ; preds = %67
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %69
+ThrowNullRef10:                                   ; preds = %69
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2710,14 +2792,14 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
   %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
@@ -2730,14 +2812,14 @@ entry:
 
 ; <label>:11                                      ; preds = %4
   %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
   %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
@@ -2749,14 +2831,14 @@ entry:
 
 ; <label>:22                                      ; preds = %16
   %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
   %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
-  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
-  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
@@ -2804,23 +2886,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2836,7 +2918,280 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[loadElem]
+Successfully read RuntimeType.IsAssignableFrom
+
+define i8 @RuntimeType.IsAssignableFrom(%System.RuntimeType addrspace(1)* %param0, %System.Type addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.RuntimeType addrspace(1)*
+  %arg1 = alloca %System.Type addrspace(1)*
+  %loc0 = alloca %System.RuntimeType addrspace(1)*
+  %loc1 = alloca %"System.Type[]" addrspace(1)*
+  %loc2 = alloca i32
+  store %System.RuntimeType addrspace(1)* %param0, %System.RuntimeType addrspace(1)** %this
+  store %System.Type addrspace(1)* %param1, %System.Type addrspace(1)** %arg1
+  %0 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %1 = icmp ne %System.Type addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i8 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %5 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %6 = bitcast %System.Type addrspace(1)* %4 to %System.Object addrspace(1)*
+  %7 = bitcast %System.RuntimeType addrspace(1)* %5 to %System.Object addrspace(1)*
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %6, %System.Object addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %3
+  ret i8 1
+
+; <label>:12                                      ; preds = %3
+  %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 152
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 32
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
+  %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
+  %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
+  store %System.RuntimeType addrspace(1)* %25, %System.RuntimeType addrspace(1)** %loc0
+  %26 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %27 = icmp eq %System.RuntimeType addrspace(1)* %26, null
+  br i1 %27, label %34, label %28
+
+; <label>:28                                      ; preds = %15
+  %29 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %30 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)*)*)(%System.RuntimeType addrspace(1)* %29, %System.RuntimeType addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+; <label>:34                                      ; preds = %15
+  %35 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %36 = call %System.Reflection.Emit.TypeBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Reflection.Emit.TypeBuilder addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %35)
+  %37 = icmp eq %System.Reflection.Emit.TypeBuilder addrspace(1)* %36, null
+  br i1 %37, label %139, label %38
+
+; <label>:38                                      ; preds = %34
+  %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %42
+
+; <label>:42                                      ; preds = %38
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 152
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 40
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
+  %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
+  %53 = zext i8 %52 to i32
+  %54 = icmp eq i32 %53, 0
+  br i1 %54, label %56, label %55
+
+; <label>:55                                      ; preds = %42
+  ret i8 1
+
+; <label>:56                                      ; preds = %42
+  %57 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %58 = bitcast %System.RuntimeType addrspace(1)* %57 to %System.Type addrspace(1)*
+  %59 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %58)
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %64 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.Type addrspace(1)* %63, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = bitcast %System.RuntimeType addrspace(1)* %64 to %System.Type addrspace(1)*
+  %67 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %63, %System.Type addrspace(1)* %66)
+  %68 = zext i8 %67 to i32
+  %69 = trunc i32 %68 to i8
+  ret i8 %69
+
+; <label>:70                                      ; preds = %56
+  %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
+  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %73
+
+; <label>:73                                      ; preds = %70
+  %74 = load i64, i64 addrspace(1)* %72
+  %75 = add i64 %74, 128
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = add i64 %77, 0
+  %79 = inttoptr i64 %78 to i64*
+  %80 = load i64, i64* %79
+  %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
+  %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
+  %83 = call i8 %82(%System.Type addrspace(1)* %81)
+  %84 = zext i8 %83 to i32
+  %85 = icmp eq i32 %84, 0
+  br i1 %85, label %139, label %86
+
+; <label>:86                                      ; preds = %73
+  %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
+  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %89
+
+; <label>:89                                      ; preds = %86
+  %90 = load i64, i64 addrspace(1)* %88
+  %91 = add i64 %90, 128
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = add i64 %93, 24
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
+  %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
+  %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
+  store %"System.Type[]" addrspace(1)* %99, %"System.Type[]" addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %129
+
+; <label>:100                                     ; preds = %132
+  %101 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %102 = load i32, i32* %loc2
+  %NullCheck11 = icmp eq %"System.Type[]" addrspace(1)* %101, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %103
+
+; <label>:103                                     ; preds = %100
+  %104 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 1
+  %105 = load i32, i32 addrspace(1)* %104
+  %106 = zext i32 %105 to i64
+  %107 = zext i32 %102 to i64
+  %BoundsCheck = icmp uge i64 %107, %106
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %108
+
+; <label>:108                                     ; preds = %103
+  %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
+  %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
+  %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
+  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %113
+
+; <label>:113                                     ; preds = %108
+  %114 = load i64, i64 addrspace(1)* %112
+  %115 = add i64 %114, 152
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = add i64 %117, 56
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
+  %123 = zext i8 %122 to i32
+  %124 = icmp ne i32 %123, 0
+  br i1 %124, label %126, label %125
+
+; <label>:125                                     ; preds = %113
+  ret i8 0
+
+; <label>:126                                     ; preds = %113
+  %127 = load i32, i32* %loc2
+  %128 = add i32 %127, 1
+  store i32 %128, i32* %loc2
+  br label %129
+
+; <label>:129                                     ; preds = %89, %126
+  %130 = load i32, i32* %loc2
+  %131 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %NullCheck9 = icmp eq %"System.Type[]" addrspace(1)* %131, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %132
+
+; <label>:132                                     ; preds = %129
+  %133 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %131, i32 0, i32 1
+  %134 = load i32, i32 addrspace(1)* %133
+  %135 = zext i32 %134 to i64
+  %136 = trunc i64 %135 to i32
+  %137 = icmp slt i32 %130, %136
+  br i1 %137, label %100, label %138
+
+; <label>:138                                     ; preds = %132
+  ret i8 1
+
+; <label>:139                                     ; preds = %34, %73
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %129
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %103
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -2893,7 +3248,7 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElem]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -2904,8 +3259,8 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -2997,8 +3352,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
@@ -3059,8 +3414,8 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -3087,8 +3442,8 @@ entry:
 
 ; <label>:17                                      ; preds = %5, %11
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
@@ -3097,8 +3452,8 @@ entry:
 
 ; <label>:22                                      ; preds = %1, %11
   %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
@@ -3109,11 +3464,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %17
+ThrowNullRef2:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %22
+ThrowNullRef4:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3167,15 +3522,15 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
   %15 = load i32, i32 addrspace(1)* %14
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
@@ -3198,7 +3553,7 @@ ThrowNullRef:                                     ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef2:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3232,8 +3587,8 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
@@ -3312,8 +3667,8 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -3327,8 +3682,8 @@ entry:
 ; <label>:5                                       ; preds = %43
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %7 = load i32, i32* %loc1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck6, label %8, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
@@ -3366,8 +3721,8 @@ entry:
 ; <label>:32                                      ; preds = %21, %25
   %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
   %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
-  br i1 %NullCheck8, label %35, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = trunc i32 %34 to i16
@@ -3380,8 +3735,8 @@ entry:
 ; <label>:40                                      ; preds = %1, %35
   %41 = load i32, i32* %loc1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
-  br i1 %NullCheck2, label %43, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %42, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
@@ -3392,8 +3747,8 @@ entry:
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
   %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
-  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
   %51 = load i64, i64 addrspace(1)* %49
@@ -3412,19 +3767,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %40
+ThrowNullRef2:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %47
+ThrowNullRef4:                                    ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %5
+ThrowNullRef6:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %32
+ThrowNullRef8:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3467,8 +3822,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
@@ -3492,11 +3847,391 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(i16* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store i16* %param0, i16** %arg0
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load i32, i32* %arg3
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %42, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %37, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg2
+  %13 = load i32, i32* %arg3
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %37, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %24 = load i32, i32* %arg2
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load i16*, i16** %arg0
+  %35 = load i32, i32* %arg3
+  %36 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %36, i16* %34, i32 %35)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:37                                      ; preds = %5, %16
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %39)
+  %41 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41, %System.String addrspace(1)* %38, %System.String addrspace(1)* %40)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41) #0
+  unreachable
+
+; <label>:42                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
-Failed to read StringBuilder.ToString[loadElemA]
+Successfully read StringBuilder.ToString
+
+define %System.String addrspace(1)* @StringBuilder.ToString(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i16*
+  %loc3 = alloca %"System.Char[]" addrspace(1)*
+  %loc4 = alloca i32
+  %loc5 = alloca i32
+  %loc6 = alloca i16 addrspace(1)*
+  %loc7 = alloca %System.String addrspace(1)*
+  %loc8 = alloca %"System.Char[]" addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %0)
+  %2 = icmp ne i32 %1, 0
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %4
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %6)
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %7)
+  store %System.String addrspace(1)* %8, %System.String addrspace(1)** %loc0
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.Text.StringBuilder addrspace(1)* %9, %System.Text.StringBuilder addrspace(1)** %loc1
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  store %System.String addrspace(1)* %10, %System.String addrspace(1)** %loc7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc7
+  %12 = ptrtoint %System.String addrspace(1)* %11 to i64
+  %13 = icmp eq i64 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %5
+  %15 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %16 = sext i32 %15 to i64
+  %17 = add i64 %12, %16
+  br label %18
+
+; <label>:18                                      ; preds = %5, %14
+  %19 = phi i64 [ %12, %5 ], [ %17, %14 ]
+  %20 = inttoptr i64 %19 to i16*
+  store i16* %20, i16** %loc2
+  br label %21
+
+; <label>:21                                      ; preds = %98, %18
+  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %22, null
+  br i1 %NullCheck, label %ThrowNullRef, label %23
+
+; <label>:23                                      ; preds = %21
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 3
+  %25 = load i32, i32 addrspace(1)* %24, align 8
+  %26 = icmp sle i32 %25, 0
+  br i1 %26, label %96, label %27
+
+; <label>:27                                      ; preds = %23
+  %28 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %28, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %29
+
+; <label>:29                                      ; preds = %27
+  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %28, i32 0, i32 1
+  %31 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %30, align 8
+  store %"System.Char[]" addrspace(1)* %31, %"System.Char[]" addrspace(1)** %loc3
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %33
+
+; <label>:33                                      ; preds = %29
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  store i32 %35, i32* %loc4
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  %39 = load i32, i32 addrspace(1)* %38, align 8
+  store i32 %39, i32* %loc5
+  %40 = load i32, i32* %loc5
+  %41 = load i32, i32* %loc4
+  %42 = add i32 %40, %41
+  %43 = zext i32 %42 to i64
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %45
+
+; <label>:45                                      ; preds = %37
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = sext i32 %47 to i64
+  %49 = icmp sgt i64 %43, %48
+  br i1 %49, label %91, label %50
+
+; <label>:50                                      ; preds = %45
+  %51 = load i32, i32* %loc5
+  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %52, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %53
+
+; <label>:53                                      ; preds = %50
+  %54 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %52, i32 0, i32 1
+  %55 = load i32, i32 addrspace(1)* %54
+  %56 = zext i32 %55 to i64
+  %57 = trunc i64 %56 to i32
+  %58 = icmp ugt i32 %51, %57
+  br i1 %58, label %91, label %59
+
+; <label>:59                                      ; preds = %53
+  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  store %"System.Char[]" addrspace(1)* %60, %"System.Char[]" addrspace(1)** %loc8
+  %61 = icmp eq %"System.Char[]" addrspace(1)* %60, null
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %63, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %64
+
+; <label>:64                                      ; preds = %62
+  %65 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %63, i32 0, i32 1
+  %66 = load i32, i32 addrspace(1)* %65
+  %67 = zext i32 %66 to i64
+  %68 = trunc i64 %67 to i32
+  %69 = icmp ne i32 %68, 0
+  br i1 %69, label %71, label %70
+
+; <label>:70                                      ; preds = %59, %64
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:71                                      ; preds = %64
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %73
+
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %BoundsCheck = icmp uge i64 0, %76
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %77
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %78, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:79                                      ; preds = %70, %77
+  %80 = load i16*, i16** %loc2
+  %81 = load i32, i32* %loc4
+  %82 = sext i32 %81 to i64
+  %83 = mul i64 %82, 2
+  %84 = bitcast i16* %80 to i8*
+  %85 = getelementptr inbounds i8, i8* %84, i64 %83
+  %86 = load i16 addrspace(1)*, i16 addrspace(1)** %loc6
+  %87 = ptrtoint i16 addrspace(1)* %86 to i64
+  %88 = load i32, i32* %loc5
+  %89 = bitcast i8* %85 to i16*
+  %90 = inttoptr i64 %87 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %89, i16* %90, i32 %88)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %96
+
+; <label>:91                                      ; preds = %45, %53
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %94 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %93)
+  %95 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95, %System.String addrspace(1)* %92, %System.String addrspace(1)* %94)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95) #0
+  unreachable
+
+; <label>:96                                      ; preds = %23, %79
+  %97 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %97, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %98
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %97, i32 0, i32 2
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  store %System.Text.StringBuilder addrspace(1)* %100, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %102 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %102, label %21, label %103
+
+; <label>:103                                     ; preds = %98
+  store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc7
+  %104 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  ret %System.String addrspace(1)* %104
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method StringBuilder::get_Length using LLILCJit
+Successfully read StringBuilder.get_Length
+
+define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
+Successfully read RuntimeHelpers.get_OffsetToStringData
+
+define i32 @RuntimeHelpers.get_OffsetToStringData() {
+entry:
+  ret i32 12
+}
+
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
 Successfully read CultureData.CreateCultureData
 
@@ -3514,23 +4249,23 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
   store i8 %4, i8 addrspace(1)* %6
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
@@ -3549,11 +4284,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3566,50 +4301,50 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
   store i32 -1, i32 addrspace(1)* %2
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
   store i32 -1, i32 addrspace(1)* %8
   %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
   store i32 -1, i32 addrspace(1)* %14
   %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
   store i32 -1, i32 addrspace(1)* %17
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
@@ -3623,27 +4358,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3675,7 +4410,136 @@ Failed to read Dictionary`2.Insert[non-const derefAddress]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
 Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
-Failed to read HashHelpers.GetPrime[loadElem]
+Successfully read HashHelpers.GetPrime
+
+define i32 @HashHelpers.GetPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %6, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5, %System.String addrspace(1)* %4)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5) #0
+  unreachable
+
+; <label>:6                                       ; preds = %entry
+  store i32 0, i32* %loc0
+  br label %29
+
+; <label>:7                                       ; preds = %35
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 1296
+  %10 = addrspacecast i8 addrspace(1)* %9 to %"System.Int32[]" addrspace(1)**
+  %11 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %10
+  %12 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Int32[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = zext i32 %15 to i64
+  %17 = zext i32 %12 to i64
+  %BoundsCheck = icmp uge i64 %17, %16
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 3, i32 %12
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  store i32 %20, i32* %loc1
+  %21 = load i32, i32* %loc1
+  %22 = load i32, i32* %arg0
+  %23 = icmp slt i32 %21, %22
+  br i1 %23, label %26, label %24
+
+; <label>:24                                      ; preds = %18
+  %25 = load i32, i32* %loc1
+  ret i32 %25
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %loc0
+  %28 = add i32 %27, 1
+  store i32 %28, i32* %loc0
+  br label %29
+
+; <label>:29                                      ; preds = %6, %26
+  %30 = load i32, i32* %loc0
+  %31 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %32 = getelementptr inbounds i8, i8 addrspace(1)* %31, i64 1296
+  %33 = addrspacecast i8 addrspace(1)* %32 to %"System.Int32[]" addrspace(1)**
+  %34 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %33
+  %NullCheck = icmp eq %"System.Int32[]" addrspace(1)* %34, null
+  br i1 %NullCheck, label %ThrowNullRef, label %35
+
+; <label>:35                                      ; preds = %29
+  %36 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %34, i32 0, i32 1
+  %37 = load i32, i32 addrspace(1)* %36
+  %38 = zext i32 %37 to i64
+  %39 = trunc i64 %38 to i32
+  %40 = icmp slt i32 %30, %39
+  br i1 %40, label %7, label %41
+
+; <label>:41                                      ; preds = %35
+  %42 = load i32, i32* %arg0
+  %43 = or i32 %42, 1
+  store i32 %43, i32* %loc2
+  br label %59
+
+; <label>:44                                      ; preds = %59
+  %45 = load i32, i32* %loc2
+  %46 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %45)
+  %47 = zext i8 %46 to i32
+  %48 = icmp eq i32 %47, 0
+  br i1 %48, label %56, label %49
+
+; <label>:49                                      ; preds = %44
+  %50 = load i32, i32* %loc2
+  %51 = sub i32 %50, 1
+  %52 = srem i32 %51, 101
+  %53 = icmp eq i32 %52, 0
+  br i1 %53, label %56, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = load i32, i32* %loc2
+  ret i32 %55
+
+; <label>:56                                      ; preds = %44, %49
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %57, 2
+  store i32 %58, i32* %loc2
+  br label %59
+
+; <label>:59                                      ; preds = %41, %56
+  %60 = load i32, i32* %loc2
+  %61 = icmp slt i32 %60, 2147483647
+  br i1 %61, label %44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load i32, i32* %arg0
+  ret i32 %63
+
+ThrowNullRef:                                     ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
 Successfully read GenericEqualityComparer`1.GetHashCode
 
@@ -3694,14 +4558,14 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
   %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load i64, i64 addrspace(1)* %7
@@ -3720,7 +4584,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3750,8 +4614,8 @@ entry:
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
@@ -3796,8 +4660,8 @@ entry:
   %35 = bitcast i16* %34 to i8*
   %36 = getelementptr inbounds i8, i8* %35, i64 2
   %37 = bitcast i8* %36 to i16*
-  %NullCheck4 = icmp ne i16* %37, null
-  br i1 %NullCheck4, label %38, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %37, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %38
 
 ; <label>:38                                      ; preds = %27
   %39 = load i16, i16* %37, align 8
@@ -3824,8 +4688,8 @@ entry:
 
 ; <label>:54                                      ; preds = %22, %43
   %55 = load i16*, i16** %loc4
-  %NullCheck2 = icmp ne i16* %55, null
-  br i1 %NullCheck2, label %56, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i16* %55, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %56
 
 ; <label>:56                                      ; preds = %54
   %57 = load i16, i16* %55, align 8
@@ -3850,11 +4714,11 @@ ThrowNullRef:                                     ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %54
+ThrowNullRef2:                                    ; preds = %54
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %27
+ThrowNullRef4:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3871,8 +4735,8 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -3907,8 +4771,8 @@ entry:
 
 ; <label>:26                                      ; preds = %19
   %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
-  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %28
 
 ; <label>:28                                      ; preds = %26
   %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
@@ -3920,7 +4784,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3972,8 +4836,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
@@ -3984,26 +4848,26 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
-  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
@@ -4014,8 +4878,8 @@ entry:
 ; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
@@ -4024,8 +4888,8 @@ entry:
 
 ; <label>:25                                      ; preds = %1, %16, %23
   %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
-  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
@@ -4036,27 +4900,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %20
+ThrowNullRef10:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4069,8 +4933,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -4081,8 +4945,8 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
@@ -4091,8 +4955,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1, %8
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
@@ -4103,11 +4967,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4128,24 +4992,24 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   store i32 %3, i32* %loc0
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
   %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
   store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck4, label %9, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
@@ -4164,15 +5028,15 @@ entry:
 ; <label>:18                                      ; preds = %70
   %19 = load i16*, i16** %loc3
   %20 = bitcast i16* %19 to i64*
-  %NullCheck10 = icmp ne i64* %20, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %20, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = load i64, i64* %20, align 8
   %23 = load i16*, i16** %loc4
   %24 = bitcast i16* %23 to i64*
-  %NullCheck12 = icmp ne i64* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = load i64, i64* %24, align 8
@@ -4188,8 +5052,8 @@ entry:
   %31 = bitcast i16* %30 to i8*
   %32 = getelementptr inbounds i8, i8* %31, i64 8
   %33 = bitcast i8* %32 to i64*
-  %NullCheck14 = icmp ne i64* %33, null
-  br i1 %NullCheck14, label %34, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = load i64, i64* %33, align 8
@@ -4197,8 +5061,8 @@ entry:
   %37 = bitcast i16* %36 to i8*
   %38 = getelementptr inbounds i8, i8* %37, i64 8
   %39 = bitcast i8* %38 to i64*
-  %NullCheck16 = icmp ne i64* %39, null
-  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %40
 
 ; <label>:40                                      ; preds = %34
   %41 = load i64, i64* %39, align 8
@@ -4214,8 +5078,8 @@ entry:
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %NullCheck18 = icmp ne i64* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = load i64, i64* %48, align 8
@@ -4223,8 +5087,8 @@ entry:
   %52 = bitcast i16* %51 to i8*
   %53 = getelementptr inbounds i8, i8* %52, i64 16
   %54 = bitcast i8* %53 to i64*
-  %NullCheck20 = icmp ne i64* %54, null
-  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64* %54, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %55
 
 ; <label>:55                                      ; preds = %49
   %56 = load i64, i64* %54, align 8
@@ -4262,15 +5126,15 @@ entry:
 ; <label>:74                                      ; preds = %95
   %75 = load i16*, i16** %loc3
   %76 = bitcast i16* %75 to i32*
-  %NullCheck6 = icmp ne i32* %76, null
-  br i1 %NullCheck6, label %77, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32* %76, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %77
 
 ; <label>:77                                      ; preds = %74
   %78 = load i32, i32* %76, align 8
   %79 = load i16*, i16** %loc4
   %80 = bitcast i16* %79 to i32*
-  %NullCheck8 = icmp ne i32* %80, null
-  br i1 %NullCheck8, label %81, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i32* %80, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %81
 
 ; <label>:81                                      ; preds = %77
   %82 = load i32, i32* %80, align 8
@@ -4318,43 +5182,43 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %74
+ThrowNullRef6:                                    ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %77
+ThrowNullRef8:                                    ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %29
+ThrowNullRef14:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %34
+ThrowNullRef16:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4376,8 +5240,8 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load i64, i64 addrspace(1)* %4
@@ -4389,8 +5253,8 @@ entry:
   %12 = load i64, i64* %11
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %5
   %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
@@ -4399,8 +5263,8 @@ entry:
   %18 = load i8, i8* %arg2
   %19 = zext i8 %18 to i32
   %20 = trunc i32 %19 to i8
-  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %15
   %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
@@ -4411,11 +5275,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4442,8 +5306,8 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
@@ -4466,16 +5330,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
   %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = load i64, i64 addrspace(1)* %19
@@ -4500,8 +5364,8 @@ entry:
 ; <label>:35                                      ; preds = %30
   %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
@@ -4514,8 +5378,8 @@ entry:
 
 ; <label>:42                                      ; preds = %1, %38
   %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
-  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
@@ -4526,19 +5390,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %35
+ThrowNullRef2:                                    ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %42
+ThrowNullRef8:                                    ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4551,14 +5415,14 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
@@ -4570,7 +5434,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4583,8 +5447,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
@@ -4613,51 +5477,51 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
   %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
   %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
   %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
   %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
-  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
   store i64 %21, i64 addrspace(1)* %23
   %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %25 = load i64, i64* %loc0
-  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
@@ -4668,27 +5532,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %22
+ThrowNullRef12:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4701,8 +5565,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
@@ -4713,19 +5577,19 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
@@ -4734,8 +5598,8 @@ entry:
 
 ; <label>:15                                      ; preds = %1, %13
   %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
@@ -4746,19 +5610,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %15
+ThrowNullRef8:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4771,8 +5635,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -4831,8 +5695,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
@@ -4882,8 +5746,8 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
-  br i1 %NullCheck, label %17, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %ThrowNullRef, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
@@ -4894,15 +5758,15 @@ entry:
 
 ; <label>:22                                      ; preds = %17
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
-  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
   %26 = load i32, i32 addrspace(1)* %25
   %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
-  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %27, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
@@ -4925,8 +5789,8 @@ entry:
 ; <label>:40                                      ; preds = %17
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
-  br i1 %NullCheck6, label %43, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %41, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
@@ -4938,34 +5802,17 @@ ThrowNullRef:                                     ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %24
+ThrowNullRef4:                                    ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %40
+ThrowNullRef6:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
-}
-
-INFO:  jitting method Object::ReferenceEquals using LLILCJit
-Successfully read Object.ReferenceEquals
-
-define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
-entry:
-  %arg0 = alloca %System.Object addrspace(1)*
-  %arg1 = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
-  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
-  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = icmp eq %System.Object addrspace(1)* %0, %1
-  %3 = sext i1 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
 }
 
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
@@ -4978,21 +5825,21 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
   %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
-  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
@@ -5007,28 +5854,28 @@ entry:
 ; <label>:13                                      ; preds = %8, %12
   %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
   %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
   %21 = load i32, i32 addrspace(1)* %20, align 8
   %22 = add i32 %21, 1
-  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
   store i32 %22, i32 addrspace(1)* %24
   %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
@@ -5039,27 +5886,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5077,7 +5924,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::Setup using LLILCJit
-Failed to read AppDomain.Setup[loadElem]
+Failed to read AppDomain.Setup[unbox]
 INFO:  jitting method Thread::GetDomain using LLILCJit
 Successfully read Thread.GetDomain
 
@@ -5108,8 +5955,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
@@ -5122,14 +5969,14 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
   %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
@@ -5141,11 +5988,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5173,8 +6020,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -5189,7 +6036,328 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
 Failed to read KeyCollection.System.Collections.Generic.IEnumerable<TKey>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Successfully read Enumerator.MoveNext
+
+define i8 @Enumerator.MoveNext(%"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.RuntimeTypeHandle* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*
+  %"$TypeArg" = alloca %System.RuntimeTypeHandle*
+  store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
+  %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 8
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %76, label %12
+
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
+  br label %76
+
+; <label>:13                                      ; preds = %85
+  %14 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck19 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %15
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, i32 0, i32 0
+  %17 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %16, align 8
+  %NullCheck21 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, i32 0, i32 2
+  %20 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %19, align 8
+  %21 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck23 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %22
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, i32 0, i32 2
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %NullCheck25 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 3, i32 %24
+  %NullCheck27 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %32
+
+; <label>:32                                      ; preds = %30
+  %33 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, i32 0, i32 2
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = icmp slt i32 %34, 0
+  br i1 %35, label %68, label %36
+
+; <label>:36                                      ; preds = %32
+  %37 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %38 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck29 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %39
+
+; <label>:39                                      ; preds = %36
+  %40 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, i32 0, i32 0
+  %41 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %40, align 8
+  %NullCheck31 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, i32 0, i32 2
+  %44 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %43, align 8
+  %45 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck33 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, i32 0, i32 2
+  %48 = load i32, i32 addrspace(1)* %47, align 8
+  %NullCheck35 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %49
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = zext i32 %51 to i64
+  %53 = zext i32 %48 to i64
+  %BoundsCheck37 = icmp uge i64 %53, %52
+  br i1 %BoundsCheck37, label %ThrowIndexOutOfRange38, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 3, i32 %48
+  %NullCheck39 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %56
+
+; <label>:56                                      ; preds = %54
+  %57 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, i32 0, i32 0
+  %58 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck41 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %59
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %60, %System.__Canon addrspace(1)* %58)
+  %61 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck43 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  %64 = load i32, i32 addrspace(1)* %63, align 8
+  %65 = add i32 %64, 1
+  %NullCheck45 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  store i32 %65, i32 addrspace(1)* %67
+  ret i8 1
+
+; <label>:68                                      ; preds = %32
+  %69 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck47 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %73 = add i32 %72, 1
+  %NullCheck49 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %74
+
+; <label>:74                                      ; preds = %70
+  %75 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  store i32 %73, i32 addrspace(1)* %75
+  br label %76
+
+; <label>:76                                      ; preds = %8, %12, %74
+  %77 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %78
+
+; <label>:78                                      ; preds = %76
+  %79 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, i32 0, i32 2
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck7 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %82
+
+; <label>:82                                      ; preds = %78
+  %83 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, i32 0, i32 0
+  %84 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %83, align 8
+  %NullCheck9 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %85
+
+; <label>:85                                      ; preds = %82
+  %86 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, i32 0, i32 7
+  %87 = load i32, i32 addrspace(1)* %86, align 8
+  %88 = icmp ult i32 %80, %87
+  br i1 %88, label %13, label %89
+
+; <label>:89                                      ; preds = %85
+  %90 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %91 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck11 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %92
+
+; <label>:92                                      ; preds = %89
+  %93 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, i32 0, i32 0
+  %94 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck13 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %95
+
+; <label>:95                                      ; preds = %92
+  %96 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, i32 0, i32 7
+  %97 = load i32, i32 addrspace(1)* %96, align 8
+  %98 = add i32 %97, 1
+  %NullCheck15 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %99
+
+; <label>:99                                      ; preds = %95
+  %100 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, i32 0, i32 2
+  store i32 %98, i32 addrspace(1)* %100
+  %101 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck17 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %102
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %103, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %92
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef22:                                   ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef24:                                   ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef26:                                   ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef28:                                   ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef30:                                   ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef32:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef34:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef36:                                   ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange38:                           ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef40:                                   ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef42:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef44:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef46:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef48:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef50:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -5200,8 +6368,8 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -5232,9 +6400,9 @@ Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
 Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
-Failed to read String.MakeSeparatorList[loadElemA]
+Failed to read String.MakeSeparatorList[storeElem]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
-Failed to read String.InternalSplitKeepEmptyEntries[loadElem]
+Failed to read String.InternalSplitKeepEmptyEntries[storeElem]
 INFO:  jitting method Path::IsRelative using LLILCJit
 Successfully read Path.IsRelative
 
@@ -5243,8 +6411,8 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -5254,8 +6422,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
@@ -5271,8 +6439,8 @@ entry:
 
 ; <label>:17                                      ; preds = %7
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
@@ -5288,8 +6456,8 @@ entry:
 
 ; <label>:29                                      ; preds = %19
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %31
 
 ; <label>:31                                      ; preds = %29
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
@@ -5300,8 +6468,8 @@ entry:
 
 ; <label>:36                                      ; preds = %31
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
-  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %37, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
@@ -5312,8 +6480,8 @@ entry:
 
 ; <label>:43                                      ; preds = %31, %38
   %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
-  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %45
 
 ; <label>:45                                      ; preds = %43
   %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
@@ -5324,8 +6492,8 @@ entry:
 
 ; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %50
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
@@ -5336,8 +6504,8 @@ entry:
 
 ; <label>:57                                      ; preds = %1, %7, %19, %45, %52
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
-  br i1 %NullCheck14, label %59, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %59
 
 ; <label>:59                                      ; preds = %57
   %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
@@ -5347,8 +6515,8 @@ entry:
 
 ; <label>:63                                      ; preds = %59
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
@@ -5359,8 +6527,8 @@ entry:
 
 ; <label>:70                                      ; preds = %65
   %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
-  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.String addrspace(1)* %71, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %72
 
 ; <label>:72                                      ; preds = %70
   %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
@@ -5379,39 +6547,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %17
+ThrowNullRef4:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %29
+ThrowNullRef6:                                    ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %36
+ThrowNullRef8:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %43
+ThrowNullRef10:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %50
+ThrowNullRef12:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %57
+ThrowNullRef14:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %63
+ThrowNullRef16:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %70
+ThrowNullRef18:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5419,7 +6587,293 @@ ThrowNullRef17:                                   ; preds = %70
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
-Failed to read String.TrimHelper[loadElem]
+Successfully read String.TrimHelper
+
+define %System.String addrspace(1)* @String.TrimHelper(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i16
+  %loc4 = alloca i32
+  %loc5 = alloca i16
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = sub i32 %3, 1
+  store i32 %4, i32* %loc0
+  store i32 0, i32* %loc1
+  %5 = load i32, i32* %arg2
+  %6 = icmp eq i32 %5, 1
+  br i1 %6, label %62, label %7
+
+; <label>:7                                       ; preds = %1
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:8                                       ; preds = %58
+  store i32 0, i32* %loc2
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load i32, i32* %loc1
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2, i32 %10
+  %13 = load i16, i16 addrspace(1)* %12
+  %14 = zext i16 %13 to i32
+  %15 = trunc i32 %14 to i16
+  store i16 %15, i16* %loc3
+  store i32 0, i32* %loc2
+  br label %34
+
+; <label>:16                                      ; preds = %37
+  %17 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %18 = load i32, i32* %loc2
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %17, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %19
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = zext i32 %18 to i64
+  %BoundsCheck = icmp uge i64 %23, %22
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %24
+
+; <label>:24                                      ; preds = %19
+  %25 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 3, i32 %18
+  %26 = load i16, i16 addrspace(1)* %25, align 8
+  %27 = zext i16 %26 to i32
+  %28 = load i16, i16* %loc3
+  %29 = zext i16 %28 to i32
+  %30 = icmp eq i32 %27, %29
+  br i1 %30, label %43, label %31
+
+; <label>:31                                      ; preds = %24
+  %32 = load i32, i32* %loc2
+  %33 = add i32 %32, 1
+  store i32 %33, i32* %loc2
+  br label %34
+
+; <label>:34                                      ; preds = %11, %31
+  %35 = load i32, i32* %loc2
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = icmp slt i32 %35, %41
+  br i1 %42, label %16, label %43
+
+; <label>:43                                      ; preds = %24, %37
+  %44 = load i32, i32* %loc2
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %45, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp eq i32 %44, %50
+  br i1 %51, label %62, label %52
+
+; <label>:52                                      ; preds = %46
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %7, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %57, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %58
+
+; <label>:58                                      ; preds = %55
+  %59 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %60 = load i32, i32 addrspace(1)* %59
+  %61 = icmp slt i32 %56, %60
+  br i1 %61, label %8, label %62
+
+; <label>:62                                      ; preds = %1, %46, %58
+  %63 = load i32, i32* %arg2
+  %64 = icmp eq i32 %63, 0
+  br i1 %64, label %122, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %66, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %67
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %66, i32 0, i32 1
+  %69 = load i32, i32 addrspace(1)* %68
+  %70 = sub i32 %69, 1
+  store i32 %70, i32* %loc0
+  br label %118
+
+; <label>:71                                      ; preds = %118
+  store i32 0, i32* %loc4
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %73 = load i32, i32* %loc0
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %74
+
+; <label>:74                                      ; preds = %71
+  %75 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 2, i32 %73
+  %76 = load i16, i16 addrspace(1)* %75
+  %77 = zext i16 %76 to i32
+  %78 = trunc i32 %77 to i16
+  store i16 %78, i16* %loc5
+  store i32 0, i32* %loc4
+  br label %97
+
+; <label>:79                                      ; preds = %100
+  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %81 = load i32, i32* %loc4
+  %NullCheck19 = icmp eq %"System.Char[]" addrspace(1)* %80, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
+
+; <label>:82                                      ; preds = %79
+  %83 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 1
+  %84 = load i32, i32 addrspace(1)* %83
+  %85 = zext i32 %84 to i64
+  %86 = zext i32 %81 to i64
+  %BoundsCheck21 = icmp uge i64 %86, %85
+  br i1 %BoundsCheck21, label %ThrowIndexOutOfRange22, label %87
+
+; <label>:87                                      ; preds = %82
+  %88 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 3, i32 %81
+  %89 = load i16, i16 addrspace(1)* %88, align 8
+  %90 = zext i16 %89 to i32
+  %91 = load i16, i16* %loc5
+  %92 = zext i16 %91 to i32
+  %93 = icmp eq i32 %90, %92
+  br i1 %93, label %106, label %94
+
+; <label>:94                                      ; preds = %87
+  %95 = load i32, i32* %loc4
+  %96 = add i32 %95, 1
+  store i32 %96, i32* %loc4
+  br label %97
+
+; <label>:97                                      ; preds = %74, %94
+  %98 = load i32, i32* %loc4
+  %99 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck15 = icmp eq %"System.Char[]" addrspace(1)* %99, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %100
+
+; <label>:100                                     ; preds = %97
+  %101 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %99, i32 0, i32 1
+  %102 = load i32, i32 addrspace(1)* %101
+  %103 = zext i32 %102 to i64
+  %104 = trunc i64 %103 to i32
+  %105 = icmp slt i32 %98, %104
+  br i1 %105, label %79, label %106
+
+; <label>:106                                     ; preds = %87, %100
+  %107 = load i32, i32* %loc4
+  %108 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck17 = icmp eq %"System.Char[]" addrspace(1)* %108, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %109
+
+; <label>:109                                     ; preds = %106
+  %110 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %108, i32 0, i32 1
+  %111 = load i32, i32 addrspace(1)* %110
+  %112 = zext i32 %111 to i64
+  %113 = trunc i64 %112 to i32
+  %114 = icmp eq i32 %107, %113
+  br i1 %114, label %122, label %115
+
+; <label>:115                                     ; preds = %109
+  %116 = load i32, i32* %loc0
+  %117 = sub i32 %116, 1
+  store i32 %117, i32* %loc0
+  br label %118
+
+; <label>:118                                     ; preds = %67, %115
+  %119 = load i32, i32* %loc0
+  %120 = load i32, i32* %loc1
+  %121 = icmp sge i32 %119, %120
+  br i1 %121, label %71, label %122
+
+; <label>:122                                     ; preds = %62, %109, %118
+  %123 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %124 = load i32, i32* %loc1
+  %125 = load i32, i32* %loc0
+  %126 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %123, i32 %124, i32 %125)
+  ret %System.String addrspace(1)* %126
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %97
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange22:                           ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
 Successfully read String.CreateTrimmedString
 
@@ -5439,8 +6893,8 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
@@ -5535,8 +6989,8 @@ entry:
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i64 2872
   %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
   %8 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %7
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %3
   %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
@@ -5553,8 +7007,8 @@ entry:
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 2864
   %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
   %21 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %20
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
-  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %22
 
 ; <label>:22                                      ; preds = %16
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
@@ -5569,7 +7023,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %16
+ThrowNullRef2:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5586,8 +7040,8 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5613,8 +7067,8 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
@@ -5632,8 +7086,8 @@ entry:
 
 ; <label>:12                                      ; preds = %4
   %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
@@ -5644,8 +7098,8 @@ entry:
 
 ; <label>:19                                      ; preds = %14
   %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %19
   %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
@@ -5660,21 +7114,21 @@ entry:
   %31 = zext i16 %30 to i32
   %32 = bitcast i8* %29 to i16*
   %33 = trunc i32 %31 to i16
-  %NullCheck6 = icmp ne i16* %32, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i16* %32, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %21
   store i16 %33, i16* %32, align 8
   %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %36
 
 ; <label>:36                                      ; preds = %34
   %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
   %38 = load i32, i32 addrspace(1)* %37, align 8
   %39 = add i32 %38, 1
-  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %40
 
 ; <label>:40                                      ; preds = %36
   %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
@@ -5683,16 +7137,16 @@ entry:
 
 ; <label>:42                                      ; preds = %14
   %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
-  br i1 %NullCheck12, label %44, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
   %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
   %47 = load i16, i16* %arg1
   %48 = zext i16 %47 to i32
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = trunc i32 %48 to i16
@@ -5703,31 +7157,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %19
+ThrowNullRef4:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %21
+ThrowNullRef6:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %36
+ThrowNullRef10:                                   ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %42
+ThrowNullRef12:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %44
+ThrowNullRef14:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5740,8 +7194,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -5752,8 +7206,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
@@ -5762,14 +7216,14 @@ entry:
 
 ; <label>:11                                      ; preds = %1
   %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
@@ -5779,15 +7233,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5808,8 +7262,8 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5822,8 +7276,8 @@ entry:
 
 ; <label>:8                                       ; preds = %3
   %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
@@ -5842,15 +7296,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
-  br i1 %NullCheck4, label %22, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
   %24 = load i16*, i16* addrspace(1)* %23, align 8
   %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %25, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
@@ -5859,8 +7313,8 @@ entry:
   store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
@@ -5874,8 +7328,8 @@ entry:
 
 ; <label>:37                                      ; preds = %65
   %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %37
   %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
@@ -5886,16 +7340,16 @@ entry:
   %45 = bitcast i16* %41 to i8*
   %46 = getelementptr inbounds i8, i8* %45, i64 %44
   %47 = bitcast i8* %46 to i16*
-  %NullCheck14 = icmp ne i16* %47, null
-  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %47, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %48
 
 ; <label>:48                                      ; preds = %39
   %49 = load i16, i16* %47, align 8
   %50 = zext i16 %49 to i32
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %52 = load i32, i32* %loc1
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %53
 
 ; <label>:53                                      ; preds = %48
   %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
@@ -5916,8 +7370,8 @@ entry:
 ; <label>:62                                      ; preds = %36, %59
   %63 = load i32, i32* %loc1
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck10, label %65, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %65
 
 ; <label>:65                                      ; preds = %62
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
@@ -5936,15 +7390,15 @@ entry:
 
 ; <label>:74                                      ; preds = %70
   %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
-  br i1 %NullCheck18, label %76, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %76
 
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
   %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
-  br i1 %NullCheck20, label %80, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
   %81 = load i64, i64 addrspace(1)* %79
@@ -5958,8 +7412,8 @@ entry:
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
   %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
-  br i1 %NullCheck22, label %92, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.String addrspace(1)* %90, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %92
 
 ; <label>:92                                      ; preds = %80
   %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
@@ -5969,15 +7423,15 @@ entry:
 
 ; <label>:96                                      ; preds = %70
   %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
-  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %98
 
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
   %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
-  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
   %103 = load i64, i64 addrspace(1)* %101
@@ -5991,8 +7445,8 @@ entry:
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
   %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
-  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.String addrspace(1)* %112, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %114
 
 ; <label>:114                                     ; preds = %102
   %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
@@ -6004,59 +7458,59 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %20
+ThrowNullRef4:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %22
+ThrowNullRef6:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %26
+ThrowNullRef8:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %62
+ThrowNullRef10:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %48
+ThrowNullRef16:                                   ; preds = %48
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %74
+ThrowNullRef18:                                   ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %76
+ThrowNullRef20:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %80
+ThrowNullRef22:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %96
+ThrowNullRef24:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %98
+ThrowNullRef26:                                   ; preds = %98
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %102
+ThrowNullRef28:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6069,15 +7523,15 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
   %3 = load i16*, i16* addrspace(1)* %2, align 8
   %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
@@ -6087,8 +7541,8 @@ entry:
   %10 = bitcast i16* %3 to i8*
   %11 = getelementptr inbounds i8, i8* %10, i64 %9
   %12 = bitcast i8* %11 to i16*
-  %NullCheck4 = icmp ne i16* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %5
   store i16 0, i16* %12, align 8
@@ -6098,11 +7552,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6119,8 +7573,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -6131,8 +7585,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
@@ -6144,15 +7598,15 @@ entry:
 
 ; <label>:14                                      ; preds = %1
   %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
   %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
   %21 = load i64, i64 addrspace(1)* %19
@@ -6171,15 +7625,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %14
+ThrowNullRef4:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %16
+ThrowNullRef6:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6302,14 +7756,6 @@ entry:
   ret %System.String addrspace(1)* %57
 }
 
-INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
-Successfully read RuntimeHelpers.get_OffsetToStringData
-
-define i32 @RuntimeHelpers.get_OffsetToStringData() {
-entry:
-  ret i32 12
-}
-
 INFO:  jitting method String::Equals using LLILCJit
 Successfully read String.Equals
 
@@ -6381,8 +7827,8 @@ entry:
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
-  br i1 %NullCheck24, label %29, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
   %30 = load i64, i64 addrspace(1)* %28
@@ -6397,8 +7843,8 @@ entry:
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
-  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
   %43 = load i64, i64 addrspace(1)* %41
@@ -6418,8 +7864,8 @@ entry:
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
   %59 = load i64, i64 addrspace(1)* %57
@@ -6434,8 +7880,8 @@ entry:
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck22, label %71, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
   %72 = load i64, i64 addrspace(1)* %70
@@ -6455,8 +7901,8 @@ entry:
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
-  br i1 %NullCheck16, label %87, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = load i64, i64 addrspace(1)* %86
@@ -6471,8 +7917,8 @@ entry:
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck18, label %100, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
   %101 = load i64, i64 addrspace(1)* %99
@@ -6492,8 +7938,8 @@ entry:
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
-  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
   %117 = load i64, i64 addrspace(1)* %115
@@ -6508,8 +7954,8 @@ entry:
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
-  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
   %130 = load i64, i64 addrspace(1)* %128
@@ -6528,15 +7974,15 @@ entry:
 
 ; <label>:142                                     ; preds = %22
   %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
-  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %143, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %144
 
 ; <label>:144                                     ; preds = %142
   %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
   %146 = load i32, i32 addrspace(1)* %145
   %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
-  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %147, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %148
 
 ; <label>:148                                     ; preds = %144
   %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
@@ -6557,15 +8003,15 @@ entry:
 
 ; <label>:159                                     ; preds = %22
   %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
-  br i1 %NullCheck, label %161, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %ThrowNullRef, label %161
 
 ; <label>:161                                     ; preds = %159
   %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
   %163 = load i32, i32 addrspace(1)* %162
   %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
-  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %164, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %165
 
 ; <label>:165                                     ; preds = %161
   %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
@@ -6578,8 +8024,8 @@ entry:
 
 ; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
-  br i1 %NullCheck4, label %172, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %171, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %172
 
 ; <label>:172                                     ; preds = %170
   %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
@@ -6589,8 +8035,8 @@ entry:
 
 ; <label>:176                                     ; preds = %172
   %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
-  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %177, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %178
 
 ; <label>:178                                     ; preds = %176
   %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
@@ -6629,55 +8075,55 @@ ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %161
+ThrowNullRef2:                                    ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %170
+ThrowNullRef4:                                    ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %176
+ThrowNullRef6:                                    ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %142
+ThrowNullRef8:                                    ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %144
+ThrowNullRef10:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %113
+ThrowNullRef12:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %116
+ThrowNullRef14:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %84
+ThrowNullRef16:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %87
+ThrowNullRef18:                                   ; preds = %87
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %55
+ThrowNullRef20:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %58
+ThrowNullRef22:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %26
+ThrowNullRef24:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %29
+ThrowNullRef26:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,8 +8161,8 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck, label %14, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %ThrowNullRef, label %14
 
 ; <label>:14                                      ; preds = %8
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
@@ -6760,8 +8206,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
@@ -6770,14 +8216,14 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32, i32* %loc0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %10
   %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
   %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
@@ -6790,15 +8236,15 @@ entry:
 ; <label>:25                                      ; preds = %19
   %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
-  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
   %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
@@ -6807,8 +8253,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %37 = load i32, i32* %loc0
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %38, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %38
 
 ; <label>:38                                      ; preds = %32
   %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
@@ -6817,14 +8263,14 @@ entry:
 
 ; <label>:40                                      ; preds = %19
   %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %40
   %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
   %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
-  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
-  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
@@ -6832,8 +8278,8 @@ entry:
   %48 = zext i32 %47 to i64
   %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
-  br i1 %NullCheck16, label %51, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %51
 
 ; <label>:51                                      ; preds = %45
   %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
@@ -6847,15 +8293,15 @@ entry:
 ; <label>:57                                      ; preds = %51
   %58 = load i16*, i16** %arg1
   %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
-  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %60
 
 ; <label>:60                                      ; preds = %57
   %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
   %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
-  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %64
 
 ; <label>:64                                      ; preds = %60
   %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
@@ -6864,22 +8310,22 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
   %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
-  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %70
 
 ; <label>:70                                      ; preds = %64
   %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
   %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
-  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
-  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
   %75 = load i32, i32 addrspace(1)* %74
   %76 = zext i32 %75 to i64
   %77 = trunc i64 %76 to i32
-  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
-  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %78
 
 ; <label>:78                                      ; preds = %73
   %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
@@ -6901,8 +8347,8 @@ entry:
   %90 = bitcast i16* %86 to i8*
   %91 = getelementptr inbounds i8, i8* %90, i64 %89
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %93
 
 ; <label>:93                                      ; preds = %80
   %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
@@ -6912,8 +8358,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %99 = load i32, i32* %loc2
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %100
 
 ; <label>:100                                     ; preds = %93
   %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
@@ -6928,63 +8374,63 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %25
+ThrowNullRef6:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %32
+ThrowNullRef10:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %40
+ThrowNullRef12:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %45
+ThrowNullRef16:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %57
+ThrowNullRef18:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %60
+ThrowNullRef20:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %64
+ThrowNullRef22:                                   ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %70
+ThrowNullRef24:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %73
+ThrowNullRef26:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %80
+ThrowNullRef28:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %93
+ThrowNullRef30:                                   ; preds = %93
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7004,8 +8450,8 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
@@ -7033,43 +8479,43 @@ entry:
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %14
   %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
   %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   %28 = load i32, i32 addrspace(1)* %27, align 8
   %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
-  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %30
 
 ; <label>:30                                      ; preds = %26
   %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
   %32 = load i32, i32 addrspace(1)* %31, align 8
   %33 = add i32 %28, %32
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %34
 
 ; <label>:34                                      ; preds = %30
   %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   store i32 %33, i32 addrspace(1)* %35
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
   store i32 0, i32 addrspace(1)* %38
   %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %40
 
 ; <label>:40                                      ; preds = %37
   %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
@@ -7082,8 +8528,8 @@ entry:
 
 ; <label>:47                                      ; preds = %40
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
@@ -7098,8 +8544,8 @@ entry:
   %54 = load i32, i32* %loc0
   %55 = sext i32 %54 to i64
   %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
-  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %57
 
 ; <label>:57                                      ; preds = %52
   %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
@@ -7110,68 +8556,35 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %14
+ThrowNullRef2:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %23
+ThrowNullRef4:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %26
+ThrowNullRef6:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %30
+ThrowNullRef8:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %34
+ThrowNullRef10:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %47
+ThrowNullRef14:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %52
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-}
-
-INFO:  jitting method StringBuilder::get_Length using LLILCJit
-Successfully read StringBuilder.get_Length
-
-define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.StringBuilder addrspace(1)*
-  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
-  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
-
-; <label>:1                                       ; preds = %entry
-  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %3 = load i32, i32 addrspace(1)* %2, align 8
-  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
-
-; <label>:5                                       ; preds = %1
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = add i32 %3, %7
-  ret i32 %8
-
-ThrowNullRef:                                     ; preds = %entry
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef16:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7213,70 +8626,70 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
   %6 = load i32, i32 addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
   store i32 %6, i32 addrspace(1)* %8
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
   %13 = load i32, i32 addrspace(1)* %12, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
   store i32 %13, i32 addrspace(1)* %15
   %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
-  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %18
 
 ; <label>:18                                      ; preds = %14
   %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
   %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
   %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
   %34 = load i32, i32 addrspace(1)* %33, align 8
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
-  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
@@ -7287,39 +8700,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %28
+ThrowNullRef16:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %32
+ThrowNullRef18:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7455,13 +8868,13 @@ entry:
 ; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
@@ -7477,16 +8890,16 @@ entry:
 
 ; <label>:18                                      ; preds = %15
   %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
   store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
   %22 = load i32, i32* %loc0
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %24
 
 ; <label>:24                                      ; preds = %20
   %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
@@ -7498,13 +8911,13 @@ entry:
 ; <label>:28                                      ; preds = %15, %24
   %29 = load i32, i32* %arg1
   %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %31
   %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
@@ -7517,20 +8930,20 @@ entry:
   %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
-  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
   %46 = load i32, i32 addrspace(1)* %45, align 8
   %47 = sub i32 %40, %46
-  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
-  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i32 addrspace(1)* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %48
 
 ; <label>:48                                      ; preds = %44
   store i32 %47, i32 addrspace(1)* %39, align 8
@@ -7538,21 +8951,21 @@ entry:
 
 ; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
-  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %51
 
 ; <label>:51                                      ; preds = %49
   %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %53
 
 ; <label>:53                                      ; preds = %51
   %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
   %55 = load i32, i32 addrspace(1)* %54, align 8
   %56 = load i32, i32* %arg2
   %57 = sub i32 %55, %56
-  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %58
 
 ; <label>:58                                      ; preds = %53
   %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
@@ -7562,13 +8975,13 @@ entry:
 ; <label>:60                                      ; preds = %33, %58
   %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
   %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
-  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %63
 
 ; <label>:63                                      ; preds = %60
   %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
-  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
-  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
@@ -7578,15 +8991,15 @@ entry:
 
 ; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
-  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i32 addrspace(1)* %69, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %70
 
 ; <label>:70                                      ; preds = %68
   %71 = load i32, i32 addrspace(1)* %69, align 8
   store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
-  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
@@ -7596,8 +9009,8 @@ entry:
   store i32 %77, i32* %loc4
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
-  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %80
 
 ; <label>:80                                      ; preds = %73
   %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
@@ -7607,71 +9020,71 @@ entry:
 ; <label>:83                                      ; preds = %80
   store i32 0, i32* %loc3
   %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
-  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
-  br i1 %NullCheck26, label %88, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i32 addrspace(1)* %87, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %88
 
 ; <label>:88                                      ; preds = %85
   %89 = load i32, i32 addrspace(1)* %87, align 8
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
-  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %90
 
 ; <label>:90                                      ; preds = %88
   %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
   store i32 %89, i32 addrspace(1)* %91
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
-  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
-  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %96
 
 ; <label>:96                                      ; preds = %94
   %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
-  br i1 %NullCheck34, label %100, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %100
 
 ; <label>:100                                     ; preds = %96
   %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
-  br i1 %NullCheck36, label %102, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %102
 
 ; <label>:102                                     ; preds = %100
   %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
   %104 = load i32, i32 addrspace(1)* %103, align 8
   %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
-  br i1 %NullCheck38, label %106, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %106
 
 ; <label>:106                                     ; preds = %102
   %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
-  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
-  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %108
 
 ; <label>:108                                     ; preds = %106
   %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
   %110 = load i32, i32 addrspace(1)* %109, align 8
   %111 = add i32 %104, %110
-  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %112
 
 ; <label>:112                                     ; preds = %108
   %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
   store i32 %111, i32 addrspace(1)* %113
   %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
-  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i32 addrspace(1)* %114, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %115
 
 ; <label>:115                                     ; preds = %112
   %116 = load i32, i32 addrspace(1)* %114, align 8
@@ -7681,19 +9094,19 @@ entry:
 ; <label>:118                                     ; preds = %115
   %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
-  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %121
 
 ; <label>:121                                     ; preds = %118
   %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
-  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
-  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %123
 
 ; <label>:123                                     ; preds = %121
   %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
   %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
-  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
-  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %126
 
 ; <label>:126                                     ; preds = %123
   %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
@@ -7705,8 +9118,8 @@ entry:
 
 ; <label>:130                                     ; preds = %80, %115, %126
   %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %132
 
 ; <label>:132                                     ; preds = %130
   %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7715,8 +9128,8 @@ entry:
   %136 = load i32, i32* %loc3
   %137 = sub i32 %135, %136
   %138 = sub i32 %134, %137
-  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %139
 
 ; <label>:139                                     ; preds = %132
   %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7728,16 +9141,16 @@ entry:
 
 ; <label>:144                                     ; preds = %139
   %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
-  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %146
 
 ; <label>:146                                     ; preds = %144
   %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
   %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
   %149 = load i32, i32* %loc2
   %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
-  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %151
 
 ; <label>:151                                     ; preds = %146
   %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
@@ -7754,145 +9167,249 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %18
+ThrowNullRef4:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %31
+ThrowNullRef10:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %44
+ThrowNullRef16:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %68
+ThrowNullRef18:                                   ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %70
+ThrowNullRef20:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %73
+ThrowNullRef22:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %83
+ThrowNullRef24:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %85
+ThrowNullRef26:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %88
+ThrowNullRef28:                                   ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %90
+ThrowNullRef30:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %94
+ThrowNullRef32:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %96
+ThrowNullRef34:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %100
+ThrowNullRef36:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %102
+ThrowNullRef38:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %106
+ThrowNullRef40:                                   ; preds = %106
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %108
+ThrowNullRef42:                                   ; preds = %108
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %112
+ThrowNullRef44:                                   ; preds = %112
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %118
+ThrowNullRef46:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %121
+ThrowNullRef48:                                   ; preds = %121
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %123
+ThrowNullRef50:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %130
+ThrowNullRef52:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %132
+ThrowNullRef54:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %144
+ThrowNullRef56:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %146
+ThrowNullRef58:                                   ; preds = %146
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %60
+ThrowNullRef60:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %63
+ThrowNullRef62:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %49
+ThrowNullRef64:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %51
+ThrowNullRef66:                                   ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %53
+ThrowNullRef68:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(%"System.Char[]" addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %arg0 = alloca %"System.Char[]" addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store %"System.Char[]" addrspace(1)* %param0, %"System.Char[]" addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load i32, i32* %arg4
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %43, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %38, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg1
+  %13 = load i32, i32* %arg4
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %38, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %24 = load i32, i32* %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %35 = load i32, i32* %arg3
+  %36 = load i32, i32* %arg4
+  %37 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %37, %"System.Char[]" addrspace(1)* %34, i32 %35, i32 %36)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:38                                      ; preds = %5, %16
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Successfully read Buffer._Memmove
 
@@ -7914,7 +9431,7 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[loadElem]
+Failed to read AppDomain.SetDataHelper[storeElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -7923,8 +9440,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
@@ -7934,8 +9451,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
@@ -7947,15 +9464,15 @@ entry:
   %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
   %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
@@ -7966,15 +9483,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7992,7 +9509,79 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
-Failed to read Dictionary`2.TryGetValue[loadElemA]
+Successfully read Dictionary`2.TryGetValue
+
+define i8 @"Dictionary`2.TryGetValue"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)* addrspace(1)* %param2) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  %arg2 = alloca %System.__Canon addrspace(1)* addrspace(1)*
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  store %System.__Canon addrspace(1)* addrspace(1)* %param2, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  store i32 %2, i32* %loc0
+  %3 = load i32, i32* %loc0
+  %4 = icmp slt i32 %3, 0
+  br i1 %4, label %22, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 2
+  %10 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %9, align 8
+  %11 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = zext i32 %11 to i64
+  %BoundsCheck = icmp uge i64 %16, %15
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 3, i32 %11
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %20, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %6, %System.__Canon addrspace(1)* %21)
+  ret i8 1
+
+; <label>:22                                      ; preds = %entry
+  %23 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %23, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -8058,8 +9647,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
@@ -8091,8 +9680,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
@@ -8171,15 +9760,15 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck, label %19, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %ThrowNullRef, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
   %21 = load i32, i32 addrspace(1)* %20
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
@@ -8202,7 +9791,7 @@ ThrowNullRef:                                     ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %19
+ThrowNullRef2:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8248,8 +9837,8 @@ entry:
   %0 = alloca %System.AppDomainHandle
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %1 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %1, i32 0, i32 15
@@ -8269,8 +9858,8 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
@@ -8286,7 +9875,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -8299,8 +9888,8 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -8327,8 +9916,8 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
@@ -8352,8 +9941,8 @@ entry:
   %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
   store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
@@ -8363,8 +9952,8 @@ entry:
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
@@ -8374,8 +9963,8 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %9
   %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
@@ -8384,8 +9973,8 @@ entry:
 
 ; <label>:18                                      ; preds = %3, %16
   %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
@@ -8397,15 +9986,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %18
+ThrowNullRef6:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8418,8 +10007,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
@@ -8453,15 +10042,15 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
@@ -8473,7 +10062,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8481,7 +10070,7 @@ ThrowNullRef1:                                    ; preds = %1
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
 Failed to read Dictionary`2.System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
@@ -8506,8 +10095,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
@@ -8524,8 +10113,8 @@ entry:
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -8544,7 +10133,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8577,8 +10166,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = load i64, i64* %arg2
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = trunc i32 %3 to i8
@@ -8634,46 +10223,46 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
   %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
-  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
-  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
-  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
@@ -8684,27 +10273,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %20
+ThrowNullRef12:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8717,8 +10306,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -8756,22 +10345,22 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
   %9 = load i64, i64 addrspace(1)* %8, align 8
   %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
   %13 = load i64, i64 addrspace(1)* %12, align 8
   %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %11
   %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
@@ -8788,11 +10377,11 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8882,8 +10471,8 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
@@ -8900,8 +10489,8 @@ entry:
 ; <label>:8                                       ; preds = %1
   %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
   %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
@@ -8911,15 +10500,15 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
   %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
   %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
-  br i1 %NullCheck6, label %21, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
@@ -8946,15 +10535,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8992,15 +10581,15 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
   store i8 %3, i8 addrspace(1)* %5
   %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
@@ -9011,7 +10600,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9027,8 +10616,8 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -9041,8 +10630,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
@@ -9058,7 +10647,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9080,8 +10669,8 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
@@ -9096,8 +10685,8 @@ entry:
 ; <label>:12                                      ; preds = %6
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
@@ -9112,8 +10701,8 @@ entry:
 ; <label>:21                                      ; preds = %15
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
@@ -9128,8 +10717,8 @@ entry:
 ; <label>:30                                      ; preds = %24
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %31, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
@@ -9144,8 +10733,8 @@ entry:
 ; <label>:39                                      ; preds = %33
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
-  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %40, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %42
 
 ; <label>:42                                      ; preds = %39
   %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
@@ -9164,19 +10753,19 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %21
+ThrowNullRef4:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %30
+ThrowNullRef6:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %39
+ThrowNullRef8:                                    ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9243,8 +10832,8 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
@@ -9264,57 +10853,57 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
   store i8 0, i8 addrspace(1)* %2
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
   store i8 0, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
   store i8 0, i8 addrspace(1)* %17
   %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
   store i8 0, i8 addrspace(1)* %20
   %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
-  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
@@ -9325,31 +10914,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %19
+ThrowNullRef14:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9367,8 +10956,8 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
@@ -9380,8 +10969,8 @@ entry:
 
 ; <label>:9                                       ; preds = %4
   %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %9
   %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
@@ -9395,7 +10984,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef2:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9420,8 +11009,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
@@ -9512,8 +11101,8 @@ entry:
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
@@ -9524,8 +11113,8 @@ entry:
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = load i64, i64 addrspace(1)* %12
@@ -9537,8 +11126,8 @@ entry:
   %20 = load i64, i64* %19
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
-  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %13
   %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
@@ -9555,8 +11144,8 @@ entry:
 ; <label>:30                                      ; preds = %25
   %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %32 = load i32, i32* %arg2
-  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
-  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
@@ -9570,15 +11159,15 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %30
+ThrowNullRef2:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9622,87 +11211,87 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
   %10 = load i8, i8 addrspace(1)* %9, align 8
   %11 = zext i8 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %8
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
   store i8 %12, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
   %19 = load i8, i8 addrspace(1)* %18, align 8
   %20 = zext i8 %19 to i32
   %21 = trunc i32 %20 to i8
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
   store i8 %21, i8 addrspace(1)* %23
   %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
   %28 = load i8, i8 addrspace(1)* %27, align 8
   %29 = zext i8 %28 to i32
   %30 = trunc i32 %29 to i8
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
-  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %31
 
 ; <label>:31                                      ; preds = %26
   %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
   store i8 %30, i8 addrspace(1)* %32
   %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
-  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
-  br i1 %NullCheck14, label %40, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %40
 
 ; <label>:40                                      ; preds = %35
   %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
   store i8 %39, i8 addrspace(1)* %41
   %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
-  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %44
 
 ; <label>:44                                      ; preds = %40
   %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
   %46 = load i8, i8 addrspace(1)* %45, align 8
   %47 = zext i8 %46 to i32
   %48 = trunc i32 %47 to i8
-  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
   store i8 %48, i8 addrspace(1)* %50
   %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
-  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
@@ -9713,29 +11302,29 @@ entry:
 ; <label>:56                                      ; preds = %52
   %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
-  br i1 %NullCheck22, label %59, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
   %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
   %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
-  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
-  br i1 %NullCheck24, label %63, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
   %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
-  br i1 %NullCheck26, label %66, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
   %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
-  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
-  br i1 %NullCheck28, label %69, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %69
 
 ; <label>:69                                      ; preds = %66
   %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
@@ -9744,15 +11333,15 @@ entry:
 
 ; <label>:71                                      ; preds = %105
   %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
-  br i1 %NullCheck34, label %73, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %73
 
 ; <label>:73                                      ; preds = %71
   %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
   %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
   %76 = load i32, i32* %loc0
-  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
-  br i1 %NullCheck36, label %77, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
@@ -9766,8 +11355,8 @@ entry:
 
 ; <label>:83                                      ; preds = %77
   %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
-  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
@@ -9775,14 +11364,14 @@ entry:
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
   %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
-  br i1 %NullCheck40, label %91, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
 ; <label>:91                                      ; preds = %85
   %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
   %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
-  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck42, label %94, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %94
 
 ; <label>:94                                      ; preds = %91
   %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
@@ -9798,14 +11387,14 @@ entry:
 ; <label>:99                                      ; preds = %69, %96
   %100 = load i32, i32* %loc0
   %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
-  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %102
 
 ; <label>:102                                     ; preds = %99
   %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
   %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
-  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
-  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
@@ -9819,87 +11408,87 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %26
+ThrowNullRef10:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %31
+ThrowNullRef12:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %35
+ThrowNullRef14:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %40
+ThrowNullRef16:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %56
+ThrowNullRef22:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %59
+ThrowNullRef24:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %63
+ThrowNullRef26:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %66
+ThrowNullRef28:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %102
+ThrowNullRef32:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %71
+ThrowNullRef34:                                   ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %73
+ThrowNullRef36:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %83
+ThrowNullRef38:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %85
+ThrowNullRef40:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %91
+ThrowNullRef42:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9943,15 +11532,15 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
   %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
@@ -9961,28 +11550,28 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
   %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %12
   %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
   %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
   %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
-  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
@@ -9993,23 +11582,23 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %12
+ThrowNullRef6:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10031,15 +11620,15 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
   %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = load i64, i64 addrspace(1)* %7
@@ -10077,13 +11666,13 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[loadElem]
+Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -10111,8 +11700,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -10177,8 +11766,8 @@ entry:
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load float, float* %arg0
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -10312,8 +11901,8 @@ entry:
   store i64 %param0, i64* %arg0
   store i64 %param1, i64* %arg1
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
@@ -10321,8 +11910,8 @@ entry:
   %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
   %5 = load i16*, i16* addrspace(1)* %4, align 8
   %6 = addrspacecast i64* %arg1 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = bitcast i64 addrspace(1)* %6 to i8 addrspace(1)*
@@ -10338,7 +11927,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10372,8 +11961,8 @@ entry:
   %1 = load i32, i32* %arg1
   %2 = sext i32 %1 to i64
   %3 = inttoptr i64 %2 to i16*
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -10426,8 +12015,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, i32)*)(%System.IO.ConsoleStream addrspace(1)* %2, i32 %1)
   %3 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %4 = load i64, i64* %arg1
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
@@ -10438,8 +12027,8 @@ entry:
   %10 = icmp eq i32 %9, 3
   %11 = sext i1 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %5
   %14 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, i32 0, i32 5
@@ -10450,7 +12039,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10473,8 +12062,8 @@ entry:
   %5 = icmp eq i32 %4, 1
   %6 = sext i1 %5 to i32
   %7 = trunc i32 %6 to i8
-  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %2, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.ConsoleStream addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
@@ -10485,8 +12074,8 @@ entry:
   %13 = icmp eq i32 %12, 2
   %14 = sext i1 %13 to i32
   %15 = trunc i32 %14 to i8
-  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %10, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.ConsoleStream addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %8
   %17 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %10, i32 0, i32 4
@@ -10497,7 +12086,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10536,8 +12125,8 @@ entry:
   %arg0 = alloca i64
   store i64 %param0, i64* %arg0
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
@@ -10572,8 +12161,8 @@ entry:
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
   %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = load i64, i64 addrspace(1)* %7
@@ -10677,7 +12266,127 @@ entry:
 INFO:  jitting method Encoding::GetEncoding using LLILCJit
 Failed to read Encoding.GetEncoding[convertToHelperArgumentType]
 INFO:  jitting method EncodingProvider::GetEncodingFromProvider using LLILCJit
-Failed to read EncodingProvider.GetEncodingFromProvider[loadElem]
+Successfully read EncodingProvider.GetEncodingFromProvider
+
+define %System.Text.Encoding addrspace(1)* @EncodingProvider.GetEncodingFromProvider(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca %"System.Text.EncodingProvider[]" addrspace(1)*
+  %loc1 = alloca %System.Text.EncodingProvider addrspace(1)*
+  %loc2 = alloca %System.Text.Encoding addrspace(1)*
+  %loc3 = alloca %System.Text.Encoding addrspace(1)*
+  %loc4 = alloca %"System.Text.EncodingProvider[]" addrspace(1)*
+  %loc5 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1059)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2392
+  %2 = addrspacecast i8 addrspace(1)* %1 to %"System.Text.EncodingProvider[]" addrspace(1)**
+  %3 = load volatile %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %2
+  %4 = icmp ne %"System.Text.EncodingProvider[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %entry
+  ret %System.Text.Encoding addrspace(1)* null
+
+; <label>:6                                       ; preds = %entry
+  %7 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1059)
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i64 2392
+  %9 = addrspacecast i8 addrspace(1)* %8 to %"System.Text.EncodingProvider[]" addrspace(1)**
+  %10 = load volatile %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %9
+  store %"System.Text.EncodingProvider[]" addrspace(1)* %10, %"System.Text.EncodingProvider[]" addrspace(1)** %loc0
+  %11 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc0
+  store %"System.Text.EncodingProvider[]" addrspace(1)* %11, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  store i32 0, i32* %loc5
+  br label %43
+
+; <label>:12                                      ; preds = %46
+  %13 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  %14 = load i32, i32* %loc5
+  %NullCheck1 = icmp eq %"System.Text.EncodingProvider[]" addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %13, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = zext i32 %17 to i64
+  %19 = zext i32 %14 to i64
+  %BoundsCheck = icmp uge i64 %19, %18
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %20
+
+; <label>:20                                      ; preds = %15
+  %21 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %13, i32 0, i32 3, i32 %14
+  %22 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)* addrspace(1)* %21, align 8
+  store %System.Text.EncodingProvider addrspace(1)* %22, %System.Text.EncodingProvider addrspace(1)** %loc1
+  %23 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)** %loc1
+  %24 = load i32, i32* %arg0
+  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i64 addrspace(1)*
+  %NullCheck3 = icmp eq i64 addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
+
+; <label>:26                                      ; preds = %20
+  %27 = load i64, i64 addrspace(1)* %25
+  %28 = add i64 %27, 64
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 40
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Text.Encoding addrspace(1)* (%System.Text.EncodingProvider addrspace(1)*, i32)*
+  %35 = call %System.Text.Encoding addrspace(1)* %34(%System.Text.EncodingProvider addrspace(1)* %23, i32 %24)
+  store %System.Text.Encoding addrspace(1)* %35, %System.Text.Encoding addrspace(1)** %loc2
+  %36 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc2
+  %37 = icmp eq %System.Text.Encoding addrspace(1)* %36, null
+  br i1 %37, label %40, label %38
+
+; <label>:38                                      ; preds = %26
+  %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc2
+  store %System.Text.Encoding addrspace(1)* %39, %System.Text.Encoding addrspace(1)** %loc3
+  br label %53
+
+; <label>:40                                      ; preds = %26
+  %41 = load i32, i32* %loc5
+  %42 = add i32 %41, 1
+  store i32 %42, i32* %loc5
+  br label %43
+
+; <label>:43                                      ; preds = %6, %40
+  %44 = load i32, i32* %loc5
+  %45 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  %NullCheck = icmp eq %"System.Text.EncodingProvider[]" addrspace(1)* %45, null
+  br i1 %NullCheck, label %ThrowNullRef, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp slt i32 %44, %50
+  br i1 %51, label %12, label %52
+
+; <label>:52                                      ; preds = %46
+  ret %System.Text.Encoding addrspace(1)* null
+
+; <label>:53                                      ; preds = %38
+  %54 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc3
+  ret %System.Text.Encoding addrspace(1)* %54
+
+ThrowNullRef:                                     ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method EncodingProvider::.cctor using LLILCJit
 Successfully read EncodingProvider..cctor
 
@@ -10696,7 +12405,7 @@ Failed to read Encoding.get_InternalSyncObject[Call HasTypeArg]
 INFO:  jitting method Hashtable::.ctor using LLILCJit
 Failed to read Hashtable..ctor[Volatile store]
 INFO:  jitting method Hashtable::get_Item using LLILCJit
-Failed to read Hashtable.get_Item[loadElemA]
+Failed to read Hashtable.get_Item[loadNonPrimitiveObj]
 INFO:  jitting method Hashtable::InitHash using LLILCJit
 Successfully read Hashtable.InitHash
 
@@ -10716,8 +12425,8 @@ entry:
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -10733,15 +12442,15 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
   %15 = load i32, i32* %loc0
-  %NullCheck2 = icmp ne i32 addrspace(1)* %14, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i32 addrspace(1)* %14, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %3
   store i32 %15, i32 addrspace(1)* %14, align 8
   %17 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %18 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %NullCheck4 = icmp ne i32 addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i32 addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = load i32, i32 addrspace(1)* %18, align 8
@@ -10750,8 +12459,8 @@ entry:
   %23 = sub i32 %22, 1
   %24 = urem i32 %21, %23
   %25 = add i32 1, %24
-  %NullCheck6 = icmp ne i32 addrspace(1)* %17, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32 addrspace(1)* %17, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %19
   store i32 %25, i32 addrspace(1)* %17, align 8
@@ -10762,15 +12471,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %19
+ThrowNullRef6:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10785,8 +12494,8 @@ entry:
   store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
   store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %NullCheck = icmp ne %System.Collections.Hashtable addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Collections.Hashtable addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
@@ -10796,16 +12505,16 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Collections.Hashtable addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Collections.Hashtable addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
   %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck4 = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %9, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
   %13 = inttoptr i64 %11 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
@@ -10815,8 +12524,8 @@ entry:
 ; <label>:15                                      ; preds = %1
   %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -10834,15 +12543,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10856,8 +12565,8 @@ entry:
   store %System.Int32 addrspace(1)* %param0, %System.Int32 addrspace(1)** %this
   %0 = load %System.Int32 addrspace(1)*, %System.Int32 addrspace(1)** %this
   %1 = bitcast %System.Int32 addrspace(1)* %0 to i32 addrspace(1)*
-  %NullCheck = icmp ne i32 addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq i32 addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load i32, i32 addrspace(1)* %1, align 8
@@ -10933,8 +12642,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.UTF8Encoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
@@ -10943,15 +12652,15 @@ entry:
   %9 = load i8, i8* %arg2
   %10 = zext i8 %9 to i32
   %11 = trunc i32 %10 to i8
-  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %8, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %6
   %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %8, i32 0, i32 8
   store i8 %11, i8 addrspace(1)* %13
   %14 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %14, i32 0, i32 8
@@ -10963,8 +12672,8 @@ entry:
 ; <label>:20                                      ; preds = %15
   %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %22, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %22, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = load i64, i64 addrspace(1)* %22
@@ -10986,15 +12695,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %12
+ThrowNullRef4:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11009,8 +12718,8 @@ entry:
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
@@ -11032,16 +12741,16 @@ entry:
 ; <label>:10                                      ; preds = %1
   %11 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
   %12 = load i32, i32* %arg1
-  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %11, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.Encoding addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
   store i32 %12, i32 addrspace(1)* %14
   %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
   %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = load i64, i64 addrspace(1)* %16
@@ -11059,11 +12768,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11076,8 +12785,8 @@ entry:
   %this = alloca %System.Text.UTF8Encoding addrspace(1)*
   store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
   %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.UTF8Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
@@ -11089,16 +12798,16 @@ entry:
 ; <label>:6                                       ; preds = %1
   %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %8 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %10, %System.Text.EncoderFallback addrspace(1)* %8)
   %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %12 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
-  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %11, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %11, i32 0, i32 3
@@ -11111,8 +12820,8 @@ entry:
   %18 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %18, %System.String addrspace(1)* %17)
   %19 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %18 to %System.Text.EncoderFallback addrspace(1)*
-  %NullCheck6 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %16, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %16, i32 0, i32 2
@@ -11122,8 +12831,8 @@ entry:
   %24 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %24, %System.String addrspace(1)* %23)
   %25 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %24 to %System.Text.DecoderFallback addrspace(1)*
-  %NullCheck8 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %22, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %22, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %20
   %27 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %22, i32 0, i32 3
@@ -11134,19 +12843,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %20
+ThrowNullRef8:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11176,8 +12885,8 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load i32, i32* %arg1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -11195,8 +12904,8 @@ entry:
 ; <label>:15                                      ; preds = %8
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %17 = load i32, i32* %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 %17
@@ -11212,7 +12921,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11264,7 +12973,7 @@ entry:
 }
 
 INFO:  jitting method Hashtable::Insert using LLILCJit
-Failed to read Hashtable.Insert[loadElemA]
+Failed to read Hashtable.Insert[storeElem]
 INFO:  jitting method ConsoleEncoding::.ctor using LLILCJit
 Successfully read ConsoleEncoding..ctor
 
@@ -11279,8 +12988,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %1)
   %2 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
@@ -11316,8 +13025,8 @@ entry:
   %2 = call %System.Text.InternalEncoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalEncoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %1)
   %3 = bitcast %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2 to %System.Text.EncoderFallback addrspace(1)*
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
@@ -11327,8 +13036,8 @@ entry:
   %8 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %7)
   %9 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %8 to %System.Text.DecoderFallback addrspace(1)*
-  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %6, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.Encoding addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %4
   %11 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %6, i32 0, i32 3
@@ -11339,7 +13048,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11358,15 +13067,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* %1)
   %2 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   %6 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, i32 0, i32 1
@@ -11377,7 +13086,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11405,8 +13114,8 @@ entry:
   store %System.Text.InternalDecoderBestFitFallback addrspace(1)* %param0, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
   %0 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
@@ -11416,15 +13125,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %4)
   %5 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %6)
   %9 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, i32 0, i32 1
@@ -11435,11 +13144,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11507,8 +13216,8 @@ entry:
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
   %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = load i64, i64 addrspace(1)* %19
@@ -11572,8 +13281,8 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.ConsoleStream addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
@@ -11604,31 +13313,31 @@ entry:
   store i8 %param4, i8* %arg4
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %3, %System.IO.Stream addrspace(1)* %1)
   %4 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %4, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
   %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %4, i32 0, i32 4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %5)
   %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %6
   %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
   %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
   %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = load i64, i64 addrspace(1)* %13
@@ -11640,8 +13349,8 @@ entry:
   %21 = load i64, i64* %20
   %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %8, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %8, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %14
   %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 5
@@ -11659,24 +13368,24 @@ entry:
   %31 = load i32, i32* %arg3
   %32 = sext i32 %31 to i64
   %33 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %32)
-  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %30, null
-  br i1 %NullCheck10, label %34, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.StreamWriter addrspace(1)* %30, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %35, %"System.Char[]" addrspace(1)* %33)
   %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %37, null
-  br i1 %NullCheck12, label %38, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.StreamWriter addrspace(1)* %37, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %38
 
 ; <label>:38                                      ; preds = %34
   %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
   %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
   %41 = load i32, i32* %arg3
   %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %42, null
-  br i1 %NullCheck14, label %43, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %42, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
   %44 = load i64, i64 addrspace(1)* %42
@@ -11690,30 +13399,30 @@ entry:
   %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
   %53 = sext i32 %52 to i64
   %54 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %53)
-  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
-  br i1 %NullCheck16, label %55, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %55
 
 ; <label>:55                                      ; preds = %43
   %56 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %56, %"System.Byte[]" addrspace(1)* %54)
   %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %58 = load i32, i32* %arg3
-  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %57, null
-  br i1 %NullCheck18, label %59, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.StreamWriter addrspace(1)* %57, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %59
 
 ; <label>:59                                      ; preds = %55
   %60 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 10
   store i32 %58, i32 addrspace(1)* %60
   %61 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %61, null
-  br i1 %NullCheck20, label %62, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.IO.StreamWriter addrspace(1)* %61, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %62
 
 ; <label>:62                                      ; preds = %59
   %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
   %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
   %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
   %67 = load i64, i64 addrspace(1)* %65
@@ -11731,15 +13440,15 @@ entry:
 
 ; <label>:78                                      ; preds = %66
   %79 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %79, null
-  br i1 %NullCheck24, label %80, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.StreamWriter addrspace(1)* %79, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %80
 
 ; <label>:80                                      ; preds = %78
   %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
   %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
   %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %83, null
-  br i1 %NullCheck26, label %84, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %83, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
   %85 = load i64, i64 addrspace(1)* %83
@@ -11756,8 +13465,8 @@ entry:
 
 ; <label>:95                                      ; preds = %84
   %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.IO.StreamWriter addrspace(1)* %96, null
-  br i1 %NullCheck28, label %97, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.IO.StreamWriter addrspace(1)* %96, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %97
 
 ; <label>:97                                      ; preds = %95
   %98 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 12
@@ -11771,8 +13480,8 @@ entry:
   %103 = icmp eq i32 %102, 0
   %104 = sext i1 %103 to i32
   %105 = trunc i32 %104 to i8
-  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %100, null
-  br i1 %NullCheck30, label %106, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.IO.StreamWriter addrspace(1)* %100, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %106
 
 ; <label>:106                                     ; preds = %99
   %107 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %100, i32 0, i32 13
@@ -11783,63 +13492,63 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %6
+ThrowNullRef4:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %29
+ThrowNullRef10:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %34
+ThrowNullRef12:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %38
+ThrowNullRef14:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %43
+ThrowNullRef16:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %55
+ThrowNullRef18:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %59
+ThrowNullRef20:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %62
+ThrowNullRef22:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %78
+ThrowNullRef24:                                   ; preds = %78
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %80
+ThrowNullRef26:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %95
+ThrowNullRef28:                                   ; preds = %95
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11852,15 +13561,15 @@ entry:
   %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = load i64, i64 addrspace(1)* %4
@@ -11878,7 +13587,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11928,35 +13637,35 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
   %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderNLS addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %7 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.EncoderNLS addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Text.Encoding addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.Encoding addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Text.EncoderNLS addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.EncoderNLS addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
   %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck8 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = load i64, i64 addrspace(1)* %16
@@ -11975,19 +13684,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12013,8 +13722,8 @@ entry:
   %this = alloca %System.Text.Encoding addrspace(1)*
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
@@ -12034,15 +13743,15 @@ entry:
   %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
   store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
   %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
   store i32 0, i32 addrspace(1)* %2
   %3 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, i32 0, i32 2
@@ -12052,15 +13761,15 @@ entry:
 
 ; <label>:8                                       ; preds = %4
   %9 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
   %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
   %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = load i64, i64 addrspace(1)* %13
@@ -12081,15 +13790,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12104,16 +13813,16 @@ entry:
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = load i32, i32* %arg1
   %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
   %7 = load i64, i64 addrspace(1)* %5
@@ -12131,7 +13840,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12168,8 +13877,8 @@ entry:
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
   %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
   %16 = load i64, i64 addrspace(1)* %14
@@ -12190,8 +13899,8 @@ entry:
   %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
   %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
   %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %31, null
-  br i1 %NullCheck2, label %32, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = load i64, i64 addrspace(1)* %31
@@ -12234,7 +13943,7 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12247,14 +13956,14 @@ entry:
   %this = alloca %System.Text.EncoderReplacementFallback addrspace(1)*
   store %System.Text.EncoderReplacementFallback addrspace(1)* %param0, %System.Text.EncoderReplacementFallback addrspace(1)** %this
   %0 = load %System.Text.EncoderReplacementFallback addrspace(1)*, %System.Text.EncoderReplacementFallback addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -12265,7 +13974,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12295,8 +14004,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
@@ -12328,8 +14037,8 @@ entry:
   %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
   store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
@@ -12341,8 +14050,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Threading.Tasks.Task addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %7)
@@ -12365,7 +14074,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12384,8 +14093,8 @@ entry:
   store i8 %param1, i8* %arg1
   store i8 %param2, i8* %arg2
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
@@ -12399,8 +14108,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1, %5
   %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 9
@@ -12431,8 +14140,8 @@ entry:
 
 ; <label>:25                                      ; preds = %8, %20
   %26 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %26, null
-  br i1 %NullCheck4, label %27, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %26, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %26, i32 0, i32 12
@@ -12443,22 +14152,22 @@ entry:
 
 ; <label>:32                                      ; preds = %27
   %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %33, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.IO.StreamWriter addrspace(1)* %33, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %32
   %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 12
   store i8 1, i8 addrspace(1)* %35
   %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
-  br i1 %NullCheck8, label %37, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
   %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
   %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck10 = icmp ne i64 addrspace(1)* %40, null
-  br i1 %NullCheck10, label %41, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64 addrspace(1)* %40, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i64, i64 addrspace(1)* %40
@@ -12472,8 +14181,8 @@ entry:
   %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
   store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
   %51 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %NullCheck12 = icmp ne %"System.Byte[]" addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Byte[]" addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %41
   %53 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %51, i32 0, i32 1
@@ -12485,16 +14194,16 @@ entry:
 
 ; <label>:58                                      ; preds = %52
   %59 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %59, null
-  br i1 %NullCheck14, label %60, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.IO.StreamWriter addrspace(1)* %59, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %60
 
 ; <label>:60                                      ; preds = %58
   %61 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %59, i32 0, i32 3
   %62 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
   %64 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %NullCheck16 = icmp ne %"System.Byte[]" addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %"System.Byte[]" addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %60
   %66 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %64, i32 0, i32 1
@@ -12502,8 +14211,8 @@ entry:
   %68 = zext i32 %67 to i64
   %69 = trunc i64 %68 to i32
   %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck18, label %71, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
   %72 = load i64, i64 addrspace(1)* %70
@@ -12519,29 +14228,29 @@ entry:
 
 ; <label>:80                                      ; preds = %27, %52, %71
   %81 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %81, null
-  br i1 %NullCheck20, label %82, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.IO.StreamWriter addrspace(1)* %81, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
 
 ; <label>:82                                      ; preds = %80
   %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %81, i32 0, i32 5
   %84 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %83, align 8
   %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.IO.StreamWriter addrspace(1)* %85, null
-  br i1 %NullCheck22, label %86, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.IO.StreamWriter addrspace(1)* %85, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %86
 
 ; <label>:86                                      ; preds = %82
   %87 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 7
   %88 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %87, align 8
   %89 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %89, null
-  br i1 %NullCheck24, label %90, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.StreamWriter addrspace(1)* %89, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %90
 
 ; <label>:90                                      ; preds = %86
   %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %89, i32 0, i32 9
   %92 = load i32, i32 addrspace(1)* %91, align 8
   %93 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.IO.StreamWriter addrspace(1)* %93, null
-  br i1 %NullCheck26, label %94, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.IO.StreamWriter addrspace(1)* %93, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %93, i32 0, i32 6
@@ -12549,8 +14258,8 @@ entry:
   %97 = load i8, i8* %arg2
   %98 = zext i8 %97 to i32
   %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
-  %NullCheck28 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck28, label %100, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
   %101 = load i64, i64 addrspace(1)* %99
@@ -12565,8 +14274,8 @@ entry:
   %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
   store i32 %110, i32* %loc1
   %111 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %111, null
-  br i1 %NullCheck30, label %112, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.IO.StreamWriter addrspace(1)* %111, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %112
 
 ; <label>:112                                     ; preds = %100
   %113 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %111, i32 0, i32 9
@@ -12577,23 +14286,23 @@ entry:
 
 ; <label>:116                                     ; preds = %112
   %117 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck32 = icmp ne %System.IO.StreamWriter addrspace(1)* %117, null
-  br i1 %NullCheck32, label %118, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.IO.StreamWriter addrspace(1)* %117, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %118
 
 ; <label>:118                                     ; preds = %116
   %119 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %117, i32 0, i32 3
   %120 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %119, align 8
   %121 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.IO.StreamWriter addrspace(1)* %121, null
-  br i1 %NullCheck34, label %122, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.IO.StreamWriter addrspace(1)* %121, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %122
 
 ; <label>:122                                     ; preds = %118
   %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
   %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
   %125 = load i32, i32* %loc1
   %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
-  %NullCheck36 = icmp ne i64 addrspace(1)* %126, null
-  br i1 %NullCheck36, label %127, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64 addrspace(1)* %126, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
   %128 = load i64, i64 addrspace(1)* %126
@@ -12615,15 +14324,15 @@ entry:
 
 ; <label>:140                                     ; preds = %136
   %141 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.IO.StreamWriter addrspace(1)* %141, null
-  br i1 %NullCheck38, label %142, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.IO.StreamWriter addrspace(1)* %141, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %142
 
 ; <label>:142                                     ; preds = %140
   %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
   %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
   %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
-  %NullCheck40 = icmp ne i64 addrspace(1)* %145, null
-  br i1 %NullCheck40, label %146, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i64 addrspace(1)* %145, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
   %147 = load i64, i64 addrspace(1)* %145
@@ -12644,83 +14353,83 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %25
+ThrowNullRef4:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %32
+ThrowNullRef6:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %37
+ThrowNullRef10:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %41
+ThrowNullRef12:                                   ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %58
+ThrowNullRef14:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %60
+ThrowNullRef16:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %65
+ThrowNullRef18:                                   ; preds = %65
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %80
+ThrowNullRef20:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %82
+ThrowNullRef22:                                   ; preds = %82
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %86
+ThrowNullRef24:                                   ; preds = %86
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %90
+ThrowNullRef26:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %94
+ThrowNullRef28:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %100
+ThrowNullRef30:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %116
+ThrowNullRef32:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %118
+ThrowNullRef34:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %122
+ThrowNullRef36:                                   ; preds = %122
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %140
+ThrowNullRef38:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %142
+ThrowNullRef40:                                   ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12787,8 +14496,8 @@ entry:
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %1 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
-  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
@@ -12796,8 +14505,8 @@ entry:
   %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
   %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
   %8 = load i64, i64 addrspace(1)* %6
@@ -12813,8 +14522,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %17, %System.IFormatProvider addrspace(1)* %16)
   %18 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %19 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %18, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.SyncTextWriter addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %7
   %21 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %18, i32 0, i32 4
@@ -12825,11 +14534,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12842,8 +14551,8 @@ entry:
   %this = alloca %System.IO.TextWriter addrspace(1)*
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.TextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
@@ -12853,8 +14562,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.Threading.Thread addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Threading.Thread addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %6)
@@ -12863,8 +14572,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1
   %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.TextWriter addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.TextWriter addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %11, i32 0, i32 2
@@ -12875,11 +14584,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13076,8 +14785,8 @@ entry:
   store float %param1, float* %arg1
   store i8 0, i8* %loc1
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
@@ -13087,16 +14796,16 @@ entry:
   %5 = addrspacecast i8* %loc1 to i8 addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %4, i8 addrspace(1)* %5)
   %6 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.SyncTextWriter addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
   %10 = load float, float* %arg1
   %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
   %13 = load i64, i64 addrspace(1)* %11
@@ -13131,11 +14840,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13152,8 +14861,8 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load float, float* %arg1
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -13167,8 +14876,8 @@ entry:
   call void %11(%System.IO.TextWriter addrspace(1)* %0, float %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
   %15 = load i64, i64 addrspace(1)* %13
@@ -13186,7 +14895,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13204,8 +14913,8 @@ entry:
   %1 = addrspacecast float* %arg1 to float addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -13220,8 +14929,8 @@ entry:
   %14 = bitcast float addrspace(1)* %1 to %System.Single addrspace(1)*
   %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Single addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Single addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
   %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
   %18 = load i64, i64 addrspace(1)* %16
@@ -13239,7 +14948,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13255,8 +14964,8 @@ entry:
   store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
   %0 = load %System.Single addrspace(1)*, %System.Single addrspace(1)** %this
   %1 = bitcast %System.Single addrspace(1)* %0 to float addrspace(1)*
-  %NullCheck = icmp ne float addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq float addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load float, float addrspace(1)* %1, align 8
@@ -13281,8 +14990,8 @@ entry:
   %loc0 = alloca %System.Globalization.NumberFormatInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 3
@@ -13292,8 +15001,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
@@ -13303,24 +15012,24 @@ entry:
   store %System.Globalization.NumberFormatInfo addrspace(1)* %10, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
   %11 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %7
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
   %15 = load i8, i8 addrspace(1)* %14, align 8
   %16 = zext i8 %15 to i32
   %17 = trunc i32 %16 to i8
-  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %11, null
-  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %11, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %13
   %19 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %11, i32 0, i32 29
   store i8 %17, i8 addrspace(1)* %19
   %20 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %21 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %20, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %20, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %18
   %23 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %20, i32 0, i32 3
@@ -13329,8 +15038,8 @@ entry:
 
 ; <label>:24                                      ; preds = %1, %22
   %25 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %25, null
-  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %25, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %26
 
 ; <label>:26                                      ; preds = %24
   %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %25, i32 0, i32 3
@@ -13341,23 +15050,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %18
+ThrowNullRef8:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13382,168 +15091,168 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 18
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %8, align 8
-  %NullCheck2 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %5, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %5, i32 0, i32 4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %9)
   %12 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 19
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %15, align 8
-  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %12, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %12, i32 0, i32 5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %16)
   %19 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %20 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %20, null
-  br i1 %NullCheck8, label %21, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %20, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %20, i32 0, i32 23
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  %NullCheck10 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %19, null
-  br i1 %NullCheck10, label %24, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %19, i32 0, i32 7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %25, %System.String addrspace(1)* %23)
   %26 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %27 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %27, i32 0, i32 22
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %29, align 8
-  %NullCheck14 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %26, null
-  br i1 %NullCheck14, label %31, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %26, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %26, i32 0, i32 6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %32, %System.String addrspace(1)* %30)
   %33 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %34 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Globalization.CultureData addrspace(1)* %34, null
-  br i1 %NullCheck16, label %35, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Globalization.CultureData addrspace(1)* %34, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %34, i32 0, i32 51
   %37 = load i32, i32 addrspace(1)* %36, align 8
-  %NullCheck18 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %33, null
-  br i1 %NullCheck18, label %38, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %33, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %33, i32 0, i32 21
   store i32 %37, i32 addrspace(1)* %39
   %40 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %41 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Globalization.CultureData addrspace(1)* %41, null
-  br i1 %NullCheck20, label %42, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Globalization.CultureData addrspace(1)* %41, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %41, i32 0, i32 52
   %44 = load i32, i32 addrspace(1)* %43, align 8
-  %NullCheck22 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %40, null
-  br i1 %NullCheck22, label %45, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %40, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %40, i32 0, i32 25
   store i32 %44, i32 addrspace(1)* %46
   %47 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %48 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.Globalization.CultureData addrspace(1)* %48, null
-  br i1 %NullCheck24, label %49, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Globalization.CultureData addrspace(1)* %48, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %49
 
 ; <label>:49                                      ; preds = %45
   %50 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %48, i32 0, i32 29
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck26 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %47, null
-  br i1 %NullCheck26, label %52, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %47, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %47, i32 0, i32 10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %53, %System.String addrspace(1)* %51)
   %54 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %55 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Globalization.CultureData addrspace(1)* %55, null
-  br i1 %NullCheck28, label %56, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Globalization.CultureData addrspace(1)* %55, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %56
 
 ; <label>:56                                      ; preds = %52
   %57 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %55, i32 0, i32 35
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %57, align 8
-  %NullCheck30 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %54, null
-  br i1 %NullCheck30, label %59, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %54, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %54, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %60, %System.String addrspace(1)* %58)
   %61 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %62 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck32 = icmp ne %System.Globalization.CultureData addrspace(1)* %62, null
-  br i1 %NullCheck32, label %63, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Globalization.CultureData addrspace(1)* %62, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %62, i32 0, i32 34
   %65 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %64, align 8
-  %NullCheck34 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %61, null
-  br i1 %NullCheck34, label %66, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %61, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %61, i32 0, i32 9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %67, %System.String addrspace(1)* %65)
   %68 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %69 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck36 = icmp ne %System.Globalization.CultureData addrspace(1)* %69, null
-  br i1 %NullCheck36, label %70, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Globalization.CultureData addrspace(1)* %69, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %70
 
 ; <label>:70                                      ; preds = %66
   %71 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %69, i32 0, i32 55
   %72 = load i32, i32 addrspace(1)* %71, align 8
-  %NullCheck38 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %68, null
-  br i1 %NullCheck38, label %73, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %68, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %68, i32 0, i32 22
   store i32 %72, i32 addrspace(1)* %74
   %75 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %76 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck40 = icmp ne %System.Globalization.CultureData addrspace(1)* %76, null
-  br i1 %NullCheck40, label %77, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Globalization.CultureData addrspace(1)* %76, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %76, i32 0, i32 57
   %79 = load i32, i32 addrspace(1)* %78, align 8
-  %NullCheck42 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %75, null
-  br i1 %NullCheck42, label %80, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %75, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %80
 
 ; <label>:80                                      ; preds = %77
   %81 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %75, i32 0, i32 24
   store i32 %79, i32 addrspace(1)* %81
   %82 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %83 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck44 = icmp ne %System.Globalization.CultureData addrspace(1)* %83, null
-  br i1 %NullCheck44, label %84, label %ThrowNullRef43
+  %NullCheck43 = icmp eq %System.Globalization.CultureData addrspace(1)* %83, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %84
 
 ; <label>:84                                      ; preds = %80
   %85 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %83, i32 0, i32 56
   %86 = load i32, i32 addrspace(1)* %85, align 8
-  %NullCheck46 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %82, null
-  br i1 %NullCheck46, label %87, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %82, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %82, i32 0, i32 23
@@ -13552,8 +15261,8 @@ entry:
 
 ; <label>:89                                      ; preds = %entry
   %90 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck100 = icmp ne %System.Globalization.CultureData addrspace(1)* %90, null
-  br i1 %NullCheck100, label %91, label %ThrowNullRef99
+  %NullCheck99 = icmp eq %System.Globalization.CultureData addrspace(1)* %90, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %91
 
 ; <label>:91                                      ; preds = %89
   %92 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %90, i32 0, i32 2
@@ -13571,8 +15280,8 @@ entry:
   %102 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %103 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %104 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %103)
-  %NullCheck48 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %102, null
-  br i1 %NullCheck48, label %105, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %102, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %105
 
 ; <label>:105                                     ; preds = %101
   %106 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %102, i32 0, i32 1
@@ -13580,8 +15289,8 @@ entry:
   %107 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %108 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %109 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %108)
-  %NullCheck50 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %107, null
-  br i1 %NullCheck50, label %110, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %107, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %110
 
 ; <label>:110                                     ; preds = %105
   %111 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %107, i32 0, i32 2
@@ -13589,8 +15298,8 @@ entry:
   %112 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %113 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %114 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %113)
-  %NullCheck52 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %112, null
-  br i1 %NullCheck52, label %115, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %112, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %115
 
 ; <label>:115                                     ; preds = %110
   %116 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %112, i32 0, i32 27
@@ -13598,8 +15307,8 @@ entry:
   %117 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %118 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %119 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %118)
-  %NullCheck54 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %117, null
-  br i1 %NullCheck54, label %120, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %117, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %120
 
 ; <label>:120                                     ; preds = %115
   %121 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %117, i32 0, i32 26
@@ -13607,8 +15316,8 @@ entry:
   %122 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %123 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %124 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %123)
-  %NullCheck56 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %122, null
-  br i1 %NullCheck56, label %125, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %122, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %125
 
 ; <label>:125                                     ; preds = %120
   %126 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %122, i32 0, i32 17
@@ -13616,8 +15325,8 @@ entry:
   %127 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %128 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %129 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %128)
-  %NullCheck58 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %127, null
-  br i1 %NullCheck58, label %130, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %127, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %130
 
 ; <label>:130                                     ; preds = %125
   %131 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %127, i32 0, i32 18
@@ -13625,8 +15334,8 @@ entry:
   %132 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %133 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %134 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %133)
-  %NullCheck60 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %132, null
-  br i1 %NullCheck60, label %135, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %132, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %135
 
 ; <label>:135                                     ; preds = %130
   %136 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %132, i32 0, i32 14
@@ -13634,8 +15343,8 @@ entry:
   %137 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %138 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %139 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %138)
-  %NullCheck62 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %137, null
-  br i1 %NullCheck62, label %140, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %137, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %140
 
 ; <label>:140                                     ; preds = %135
   %141 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %137, i32 0, i32 13
@@ -13643,71 +15352,71 @@ entry:
   %142 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %143 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %144 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %143)
-  %NullCheck64 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %142, null
-  br i1 %NullCheck64, label %145, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %142, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %145
 
 ; <label>:145                                     ; preds = %140
   %146 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %142, i32 0, i32 12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %146, %System.String addrspace(1)* %144)
   %147 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %148 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck66 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %148, null
-  br i1 %NullCheck66, label %149, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %148, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %149
 
 ; <label>:149                                     ; preds = %145
   %150 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %148, i32 0, i32 21
   %151 = load i32, i32 addrspace(1)* %150, align 8
-  %NullCheck68 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %147, null
-  br i1 %NullCheck68, label %152, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %147, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %152
 
 ; <label>:152                                     ; preds = %149
   %153 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %147, i32 0, i32 28
   store i32 %151, i32 addrspace(1)* %153
   %154 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %155 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck70 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %155, null
-  br i1 %NullCheck70, label %156, label %ThrowNullRef69
+  %NullCheck69 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %155, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %156
 
 ; <label>:156                                     ; preds = %152
   %157 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %155, i32 0, i32 6
   %158 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %157, align 8
-  %NullCheck72 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %154, null
-  br i1 %NullCheck72, label %159, label %ThrowNullRef71
+  %NullCheck71 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %154, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %159
 
 ; <label>:159                                     ; preds = %156
   %160 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %154, i32 0, i32 15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %160, %System.String addrspace(1)* %158)
   %161 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %162 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck74 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %162, null
-  br i1 %NullCheck74, label %163, label %ThrowNullRef73
+  %NullCheck73 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %162, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %163
 
 ; <label>:163                                     ; preds = %159
   %164 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %162, i32 0, i32 1
   %165 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %164, align 8
-  %NullCheck76 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %161, null
-  br i1 %NullCheck76, label %166, label %ThrowNullRef75
+  %NullCheck75 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %161, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %166
 
 ; <label>:166                                     ; preds = %163
   %167 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %161, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %167, %"System.Int32[]" addrspace(1)* %165)
   %168 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %169 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck78 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %169, null
-  br i1 %NullCheck78, label %170, label %ThrowNullRef77
+  %NullCheck77 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %169, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %170
 
 ; <label>:170                                     ; preds = %166
   %171 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %169, i32 0, i32 7
   %172 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %171, align 8
-  %NullCheck80 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %168, null
-  br i1 %NullCheck80, label %173, label %ThrowNullRef79
+  %NullCheck79 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %168, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %173
 
 ; <label>:173                                     ; preds = %170
   %174 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %168, i32 0, i32 16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %174, %System.String addrspace(1)* %172)
   %175 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck82 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %175, null
-  br i1 %NullCheck82, label %176, label %ThrowNullRef81
+  %NullCheck81 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %175, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %176
 
 ; <label>:176                                     ; preds = %173
   %177 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %175, i32 0, i32 4
@@ -13717,14 +15426,14 @@ entry:
 
 ; <label>:180                                     ; preds = %176
   %181 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck84 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %181, null
-  br i1 %NullCheck84, label %182, label %ThrowNullRef83
+  %NullCheck83 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %181, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %182
 
 ; <label>:182                                     ; preds = %180
   %183 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %181, i32 0, i32 4
   %184 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %183, align 8
-  %NullCheck86 = icmp ne %System.String addrspace(1)* %184, null
-  br i1 %NullCheck86, label %185, label %ThrowNullRef85
+  %NullCheck85 = icmp eq %System.String addrspace(1)* %184, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %185
 
 ; <label>:185                                     ; preds = %182
   %186 = getelementptr inbounds %System.String, %System.String addrspace(1)* %184, i32 0, i32 1
@@ -13735,8 +15444,8 @@ entry:
 ; <label>:189                                     ; preds = %176, %185
   %190 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck98 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %190, null
-  br i1 %NullCheck98, label %192, label %ThrowNullRef97
+  %NullCheck97 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %190, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %192
 
 ; <label>:192                                     ; preds = %189
   %193 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %190, i32 0, i32 4
@@ -13745,8 +15454,8 @@ entry:
 
 ; <label>:194                                     ; preds = %185, %192
   %195 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck88 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %195, null
-  br i1 %NullCheck88, label %196, label %ThrowNullRef87
+  %NullCheck87 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %195, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %196
 
 ; <label>:196                                     ; preds = %194
   %197 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %195, i32 0, i32 9
@@ -13756,14 +15465,14 @@ entry:
 
 ; <label>:200                                     ; preds = %196
   %201 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck90 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %201, null
-  br i1 %NullCheck90, label %202, label %ThrowNullRef89
+  %NullCheck89 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %201, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %202
 
 ; <label>:202                                     ; preds = %200
   %203 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %201, i32 0, i32 9
   %204 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %203, align 8
-  %NullCheck92 = icmp ne %System.String addrspace(1)* %204, null
-  br i1 %NullCheck92, label %205, label %ThrowNullRef91
+  %NullCheck91 = icmp eq %System.String addrspace(1)* %204, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %205
 
 ; <label>:205                                     ; preds = %202
   %206 = getelementptr inbounds %System.String, %System.String addrspace(1)* %204, i32 0, i32 1
@@ -13774,14 +15483,14 @@ entry:
 ; <label>:209                                     ; preds = %196, %205
   %210 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %211 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck94 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %211, null
-  br i1 %NullCheck94, label %212, label %ThrowNullRef93
+  %NullCheck93 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %211, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %212
 
 ; <label>:212                                     ; preds = %209
   %213 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %211, i32 0, i32 6
   %214 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %213, align 8
-  %NullCheck96 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %210, null
-  br i1 %NullCheck96, label %215, label %ThrowNullRef95
+  %NullCheck95 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %210, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %215
 
 ; <label>:215                                     ; preds = %212
   %216 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %210, i32 0, i32 9
@@ -13795,203 +15504,203 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %17
+ThrowNullRef8:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %21
+ThrowNullRef10:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %24
+ThrowNullRef12:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %28
+ThrowNullRef14:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %31
+ThrowNullRef16:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %35
+ThrowNullRef18:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %38
+ThrowNullRef20:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %42
+ThrowNullRef22:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %45
+ThrowNullRef24:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %49
+ThrowNullRef26:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %52
+ThrowNullRef28:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %56
+ThrowNullRef30:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %59
+ThrowNullRef32:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %63
+ThrowNullRef34:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %66
+ThrowNullRef36:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %70
+ThrowNullRef38:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %73
+ThrowNullRef40:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %77
+ThrowNullRef42:                                   ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %80
+ThrowNullRef44:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %84
+ThrowNullRef46:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %101
+ThrowNullRef48:                                   ; preds = %101
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %105
+ThrowNullRef50:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %110
+ThrowNullRef52:                                   ; preds = %110
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %115
+ThrowNullRef54:                                   ; preds = %115
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %120
+ThrowNullRef56:                                   ; preds = %120
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %125
+ThrowNullRef58:                                   ; preds = %125
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %130
+ThrowNullRef60:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %135
+ThrowNullRef62:                                   ; preds = %135
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %140
+ThrowNullRef64:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %145
+ThrowNullRef66:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %149
+ThrowNullRef68:                                   ; preds = %149
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %152
+ThrowNullRef70:                                   ; preds = %152
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %156
+ThrowNullRef72:                                   ; preds = %156
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %159
+ThrowNullRef74:                                   ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %163
+ThrowNullRef76:                                   ; preds = %163
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %166
+ThrowNullRef78:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %170
+ThrowNullRef80:                                   ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %173
+ThrowNullRef82:                                   ; preds = %173
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %180
+ThrowNullRef84:                                   ; preds = %180
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %182
+ThrowNullRef86:                                   ; preds = %182
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %194
+ThrowNullRef88:                                   ; preds = %194
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %200
+ThrowNullRef90:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %202
+ThrowNullRef92:                                   ; preds = %202
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %209
+ThrowNullRef94:                                   ; preds = %209
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %212
+ThrowNullRef96:                                   ; preds = %212
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %189
+ThrowNullRef98:                                   ; preds = %189
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %89
+ThrowNullRef100:                                  ; preds = %89
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14019,8 +15728,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 21
@@ -14033,8 +15742,8 @@ entry:
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 16)
   %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 21
@@ -14043,8 +15752,8 @@ entry:
 
 ; <label>:12                                      ; preds = %1, %10
   %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 21
@@ -14055,11 +15764,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %12
+ThrowNullRef4:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14075,8 +15784,8 @@ entry:
   store i32 %param1, i32* %arg1
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %1 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
@@ -14143,8 +15852,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 33
@@ -14157,8 +15866,8 @@ entry:
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 24)
   %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 33
@@ -14167,8 +15876,8 @@ entry:
 
 ; <label>:12                                      ; preds = %1, %10
   %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 33
@@ -14179,11 +15888,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %12
+ThrowNullRef4:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14196,8 +15905,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 53
@@ -14209,8 +15918,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 116)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 53
@@ -14219,8 +15928,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 53
@@ -14231,11 +15940,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14264,8 +15973,8 @@ entry:
 
 ; <label>:7                                       ; preds = %entry, %4
   %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %7
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 2
@@ -14289,8 +15998,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 54
@@ -14302,8 +16011,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 117)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
@@ -14312,8 +16021,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 54
@@ -14324,11 +16033,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14341,8 +16050,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 27
@@ -14354,8 +16063,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 118)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 27
@@ -14364,8 +16073,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 27
@@ -14376,11 +16085,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14393,8 +16102,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 28
@@ -14406,8 +16115,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 119)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 28
@@ -14416,8 +16125,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 28
@@ -14428,11 +16137,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14445,8 +16154,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 26
@@ -14458,8 +16167,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 107)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 26
@@ -14468,8 +16177,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 26
@@ -14480,11 +16189,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14497,8 +16206,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 25
@@ -14510,8 +16219,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 106)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 25
@@ -14520,8 +16229,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 25
@@ -14532,11 +16241,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14549,8 +16258,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 24
@@ -14562,8 +16271,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 105)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 24
@@ -14572,8 +16281,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 24
@@ -14584,11 +16293,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14613,8 +16322,8 @@ entry:
   %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %3)
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %2
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -14625,15 +16334,15 @@ entry:
 
 ; <label>:8                                       ; preds = %62
   %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 9
   %12 = load i32, i32 addrspace(1)* %11, align 8
   %13 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.IO.StreamWriter addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %13, i32 0, i32 10
@@ -14648,15 +16357,15 @@ entry:
 
 ; <label>:20                                      ; preds = %14, %18
   %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
   %24 = load i32, i32 addrspace(1)* %23, align 8
   %25 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %25, null
-  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.StreamWriter addrspace(1)* %25, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %25, i32 0, i32 9
@@ -14677,36 +16386,36 @@ entry:
   %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %37 = load i32, i32* %loc1
   %38 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.StreamWriter addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %35
   %40 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %38, i32 0, i32 7
   %41 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %40, align 8
   %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
-  br i1 %NullCheck14, label %43, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %39
   %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 9
   %45 = load i32, i32 addrspace(1)* %44, align 8
   %46 = load i32, i32* %loc2
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %36, null
-  br i1 %NullCheck16, label %47, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %36, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %47
 
 ; <label>:47                                      ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %36, i32 %37, %"System.Char[]" addrspace(1)* %41, i32 %45, i32 %46)
   %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
   %51 = load i32, i32 addrspace(1)* %50, align 8
   %52 = load i32, i32* %loc2
   %53 = add i32 %51, %52
-  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
-  br i1 %NullCheck20, label %54, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %54
 
 ; <label>:54                                      ; preds = %49
   %55 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
@@ -14728,8 +16437,8 @@ entry:
 
 ; <label>:65                                      ; preds = %62
   %66 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %66, null
-  br i1 %NullCheck2, label %67, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %66, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %67
 
 ; <label>:67                                      ; preds = %65
   %68 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %66, i32 0, i32 11
@@ -14750,49 +16459,259 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %65
+ThrowNullRef2:                                    ; preds = %65
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %20
+ThrowNullRef8:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %22
+ThrowNullRef10:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %35
+ThrowNullRef12:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %43
+ThrowNullRef16:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %47
+ThrowNullRef18:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method String::CopyTo using LLILCJit
-Failed to read String.CopyTo[loadElemA]
+Successfully read String.CopyTo
+
+define void @String.CopyTo(%System.String addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  %loc1 = alloca i16 addrspace(1)*
+  %loc2 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %1 = icmp ne %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg4
+  %7 = icmp sge i32 %6, 0
+  br i1 %7, label %13, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  unreachable
+
+; <label>:13                                      ; preds = %5
+  %14 = load i32, i32* %arg1
+  %15 = icmp sge i32 %14, 0
+  br i1 %15, label %21, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %18)
+  %20 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %20, %System.String addrspace(1)* %17, %System.String addrspace(1)* %19)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %20) #0
+  unreachable
+
+; <label>:21                                      ; preds = %13
+  %22 = load i32, i32* %arg4
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck, label %ThrowNullRef, label %24
+
+; <label>:24                                      ; preds = %21
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load i32, i32* %arg1
+  %28 = sub i32 %26, %27
+  %29 = icmp sle i32 %22, %28
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34, %System.String addrspace(1)* %31, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %24
+  %36 = load i32, i32* %arg3
+  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %37, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
+
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
+  %40 = load i32, i32 addrspace(1)* %39
+  %41 = zext i32 %40 to i64
+  %42 = trunc i64 %41 to i32
+  %43 = load i32, i32* %arg4
+  %44 = sub i32 %42, %43
+  %45 = icmp sgt i32 %36, %44
+  br i1 %45, label %49, label %46
+
+; <label>:46                                      ; preds = %38
+  %47 = load i32, i32* %arg3
+  %48 = icmp sge i32 %47, 0
+  br i1 %48, label %54, label %49
+
+; <label>:49                                      ; preds = %38, %46
+  %50 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %52 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %51)
+  %53 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53, %System.String addrspace(1)* %50, %System.String addrspace(1)* %52)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53) #0
+  unreachable
+
+; <label>:54                                      ; preds = %46
+  %55 = load i32, i32* %arg4
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %97, label %57
+
+; <label>:57                                      ; preds = %54
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %59
+
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 2
+  %61 = bitcast [0 x i16] addrspace(1)* %60 to i16 addrspace(1)*
+  store i16 addrspace(1)* %61, i16 addrspace(1)** %loc0
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  store %"System.Char[]" addrspace(1)* %62, %"System.Char[]" addrspace(1)** %loc2
+  %63 = icmp eq %"System.Char[]" addrspace(1)* %62, null
+  br i1 %63, label %72, label %64
+
+; <label>:64                                      ; preds = %59
+  %65 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc2
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %65, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %66
+
+; <label>:66                                      ; preds = %64
+  %67 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %65, i32 0, i32 1
+  %68 = load i32, i32 addrspace(1)* %67
+  %69 = zext i32 %68 to i64
+  %70 = trunc i64 %69 to i32
+  %71 = icmp ne i32 %70, 0
+  br i1 %71, label %73, label %72
+
+; <label>:72                                      ; preds = %59, %66
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  br label %81
+
+; <label>:73                                      ; preds = %66
+  %74 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc2
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %74, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %75
+
+; <label>:75                                      ; preds = %73
+  %76 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %74, i32 0, i32 1
+  %77 = load i32, i32 addrspace(1)* %76
+  %78 = zext i32 %77 to i64
+  %BoundsCheck = icmp uge i64 0, %78
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %79
+
+; <label>:79                                      ; preds = %75
+  %80 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %74, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %80, i16 addrspace(1)** %loc1
+  br label %81
+
+; <label>:81                                      ; preds = %72, %79
+  %82 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %83 = ptrtoint i16 addrspace(1)* %82 to i64
+  %84 = load i32, i32* %arg3
+  %85 = sext i32 %84 to i64
+  %86 = mul i64 %85, 2
+  %87 = add i64 %83, %86
+  %88 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %89 = ptrtoint i16 addrspace(1)* %88 to i64
+  %90 = load i32, i32* %arg1
+  %91 = sext i32 %90 to i64
+  %92 = mul i64 %91, 2
+  %93 = add i64 %89, %92
+  %94 = load i32, i32* %arg4
+  %95 = inttoptr i64 %87 to i16*
+  %96 = inttoptr i64 %93 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %95, i16* %96, i32 %94)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  br label %97
+
+; <label>:97                                      ; preds = %54, %81
+  ret void
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
 Successfully read ConsoleEncoding.GetPreamble
 
@@ -14829,7 +16748,365 @@ entry:
 }
 
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[loadElemA]
+Successfully read EncoderNLS.GetBytes
+
+define i32 @EncoderNLS.GetBytes(%System.Text.EncoderNLS addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3, %"System.Byte[]" addrspace(1)* %param4, i32 %param5, i8 %param6) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %arg4 = alloca %"System.Byte[]" addrspace(1)*
+  %arg5 = alloca i32
+  %arg6 = alloca i8
+  %loc0 = alloca i32
+  %loc1 = alloca i16 addrspace(1)*
+  %loc2 = alloca i8 addrspace(1)*
+  %loc3 = alloca i32
+  %loc4 = alloca %"System.Char[]" addrspace(1)*
+  %loc5 = alloca %"System.Byte[]" addrspace(1)*
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  store %"System.Byte[]" addrspace(1)* %param4, %"System.Byte[]" addrspace(1)** %arg4
+  store i32 %param5, i32* %arg5
+  store i8 %param6, i8* %arg6
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %1 = icmp eq %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %17, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %7 = icmp eq %"System.Char[]" addrspace(1)* %6, null
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %12
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %12
+
+; <label>:12                                      ; preds = %8, %10
+  %13 = phi %System.String addrspace(1)* [ %9, %8 ], [ %11, %10 ]
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %14)
+  %16 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16, %System.String addrspace(1)* %13, %System.String addrspace(1)* %15)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16) #0
+  unreachable
+
+; <label>:17                                      ; preds = %2
+  %18 = load i32, i32* %arg2
+  %19 = icmp slt i32 %18, 0
+  br i1 %19, label %23, label %20
+
+; <label>:20                                      ; preds = %17
+  %21 = load i32, i32* %arg3
+  %22 = icmp sge i32 %21, 0
+  br i1 %22, label %35, label %23
+
+; <label>:23                                      ; preds = %17, %20
+  %24 = load i32, i32* %arg2
+  %25 = icmp slt i32 %24, 0
+  br i1 %25, label %28, label %26
+
+; <label>:26                                      ; preds = %23
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %30
+
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %30
+
+; <label>:30                                      ; preds = %26, %28
+  %31 = phi %System.String addrspace(1)* [ %27, %26 ], [ %29, %28 ]
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34, %System.String addrspace(1)* %31, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %20
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck, label %ThrowNullRef, label %37
+
+; <label>:37                                      ; preds = %35
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = load i32, i32* %arg2
+  %43 = sub i32 %41, %42
+  %44 = load i32, i32* %arg3
+  %45 = icmp sge i32 %43, %44
+  br i1 %45, label %51, label %46
+
+; <label>:46                                      ; preds = %37
+  %47 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %48 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %49 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %48)
+  %50 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %50, %System.String addrspace(1)* %47, %System.String addrspace(1)* %49)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %50) #0
+  unreachable
+
+; <label>:51                                      ; preds = %37
+  %52 = load i32, i32* %arg5
+  %53 = icmp slt i32 %52, 0
+  br i1 %53, label %63, label %54
+
+; <label>:54                                      ; preds = %51
+  %55 = load i32, i32* %arg5
+  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck1 = icmp eq %"System.Byte[]" addrspace(1)* %56, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %57
+
+; <label>:57                                      ; preds = %54
+  %58 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = zext i32 %59 to i64
+  %61 = trunc i64 %60 to i32
+  %62 = icmp sle i32 %55, %61
+  br i1 %62, label %68, label %63
+
+; <label>:63                                      ; preds = %51, %57
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %66 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %65)
+  %67 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %67, %System.String addrspace(1)* %64, %System.String addrspace(1)* %66)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %67) #0
+  unreachable
+
+; <label>:68                                      ; preds = %57
+  %69 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %69, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %69, i32 0, i32 1
+  %72 = load i32, i32 addrspace(1)* %71
+  %73 = zext i32 %72 to i64
+  %74 = trunc i64 %73 to i32
+  %75 = icmp ne i32 %74, 0
+  br i1 %75, label %78, label %76
+
+; <label>:76                                      ; preds = %70
+  %77 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1)
+  store %"System.Char[]" addrspace(1)* %77, %"System.Char[]" addrspace(1)** %arg1
+  br label %78
+
+; <label>:78                                      ; preds = %70, %76
+  %79 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck5 = icmp eq %"System.Byte[]" addrspace(1)* %79, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %80
+
+; <label>:80                                      ; preds = %78
+  %81 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %79, i32 0, i32 1
+  %82 = load i32, i32 addrspace(1)* %81
+  %83 = zext i32 %82 to i64
+  %84 = trunc i64 %83 to i32
+  %85 = load i32, i32* %arg5
+  %86 = sub i32 %84, %85
+  store i32 %86, i32* %loc0
+  %87 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck7 = icmp eq %"System.Byte[]" addrspace(1)* %87, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %88
+
+; <label>:88                                      ; preds = %80
+  %89 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %87, i32 0, i32 1
+  %90 = load i32, i32 addrspace(1)* %89
+  %91 = zext i32 %90 to i64
+  %92 = trunc i64 %91 to i32
+  %93 = icmp ne i32 %92, 0
+  br i1 %93, label %96, label %94
+
+; <label>:94                                      ; preds = %88
+  %95 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1)
+  store %"System.Byte[]" addrspace(1)* %95, %"System.Byte[]" addrspace(1)** %arg4
+  br label %96
+
+; <label>:96                                      ; preds = %88, %94
+  %97 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  store %"System.Char[]" addrspace(1)* %97, %"System.Char[]" addrspace(1)** %loc4
+  %98 = icmp eq %"System.Char[]" addrspace(1)* %97, null
+  br i1 %98, label %107, label %99
+
+; <label>:99                                      ; preds = %96
+  %100 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc4
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %100, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %101
+
+; <label>:101                                     ; preds = %99
+  %102 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %100, i32 0, i32 1
+  %103 = load i32, i32 addrspace(1)* %102
+  %104 = zext i32 %103 to i64
+  %105 = trunc i64 %104 to i32
+  %106 = icmp ne i32 %105, 0
+  br i1 %106, label %108, label %107
+
+; <label>:107                                     ; preds = %96, %101
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  br label %116
+
+; <label>:108                                     ; preds = %101
+  %109 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc4
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %109, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %110
+
+; <label>:110                                     ; preds = %108
+  %111 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %109, i32 0, i32 1
+  %112 = load i32, i32 addrspace(1)* %111
+  %113 = zext i32 %112 to i64
+  %BoundsCheck = icmp uge i64 0, %113
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %114
+
+; <label>:114                                     ; preds = %110
+  %115 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %109, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %115, i16 addrspace(1)** %loc1
+  br label %116
+
+; <label>:116                                     ; preds = %107, %114
+  %117 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  store %"System.Byte[]" addrspace(1)* %117, %"System.Byte[]" addrspace(1)** %loc5
+  %118 = icmp eq %"System.Byte[]" addrspace(1)* %117, null
+  br i1 %118, label %127, label %119
+
+; <label>:119                                     ; preds = %116
+  %120 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc5
+  %NullCheck13 = icmp eq %"System.Byte[]" addrspace(1)* %120, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %121
+
+; <label>:121                                     ; preds = %119
+  %122 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %120, i32 0, i32 1
+  %123 = load i32, i32 addrspace(1)* %122
+  %124 = zext i32 %123 to i64
+  %125 = trunc i64 %124 to i32
+  %126 = icmp ne i32 %125, 0
+  br i1 %126, label %128, label %127
+
+; <label>:127                                     ; preds = %116, %121
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc2
+  br label %136
+
+; <label>:128                                     ; preds = %121
+  %129 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc5
+  %NullCheck15 = icmp eq %"System.Byte[]" addrspace(1)* %129, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %130
+
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %129, i32 0, i32 1
+  %132 = load i32, i32 addrspace(1)* %131
+  %133 = zext i32 %132 to i64
+  %BoundsCheck17 = icmp uge i64 0, %133
+  br i1 %BoundsCheck17, label %ThrowIndexOutOfRange18, label %134
+
+; <label>:134                                     ; preds = %130
+  %135 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %129, i32 0, i32 3, i32 0
+  store i8 addrspace(1)* %135, i8 addrspace(1)** %loc2
+  br label %136
+
+; <label>:136                                     ; preds = %127, %134
+  %137 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %138 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %139 = ptrtoint i16 addrspace(1)* %138 to i64
+  %140 = load i32, i32* %arg2
+  %141 = sext i32 %140 to i64
+  %142 = mul i64 %141, 2
+  %143 = add i64 %139, %142
+  %144 = load i32, i32* %arg3
+  %145 = load i8 addrspace(1)*, i8 addrspace(1)** %loc2
+  %146 = ptrtoint i8 addrspace(1)* %145 to i64
+  %147 = load i32, i32* %arg5
+  %148 = sext i32 %147 to i64
+  %149 = add i64 %146, %148
+  %150 = load i32, i32* %loc0
+  %151 = load i8, i8* %arg6
+  %152 = zext i8 %151 to i32
+  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i64 addrspace(1)*
+  %NullCheck19 = icmp eq i64 addrspace(1)* %153, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %154
+
+; <label>:154                                     ; preds = %136
+  %155 = load i64, i64 addrspace(1)* %153
+  %156 = add i64 %155, 72
+  %157 = inttoptr i64 %156 to i64*
+  %158 = load i64, i64* %157
+  %159 = add i64 %158, 0
+  %160 = inttoptr i64 %159 to i64*
+  %161 = load i64, i64* %160
+  %162 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to %System.Text.Encoder addrspace(1)*
+  %163 = inttoptr i64 %143 to i16*
+  %164 = inttoptr i64 %149 to i8*
+  %165 = trunc i32 %152 to i8
+  %166 = inttoptr i64 %161 to i32 (%System.Text.Encoder addrspace(1)*, i16*, i32, i8*, i32, i8)*
+  %167 = call i32 %166(%System.Text.Encoder addrspace(1)* %162, i16* %163, i32 %144, i8* %164, i32 %150, i8 %165)
+  store i32 %167, i32* %loc3
+  br label %168
+
+; <label>:168                                     ; preds = %154
+  %169 = load i32, i32* %loc3
+  ret i32 %169
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %110
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %119
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange18:                           ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
 Successfully read EncoderNLS.GetBytes
 
@@ -14918,22 +17195,22 @@ entry:
   %40 = load i8, i8* %arg5
   %41 = zext i8 %40 to i32
   %42 = trunc i32 %41 to i8
-  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %39, null
-  br i1 %NullCheck, label %43, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderNLS addrspace(1)* %39, null
+  br i1 %NullCheck, label %ThrowNullRef, label %43
 
 ; <label>:43                                      ; preds = %38
   %44 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
   store i8 %42, i8 addrspace(1)* %44
   %45 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %45, null
-  br i1 %NullCheck2, label %46, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.EncoderNLS addrspace(1)* %45, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %46
 
 ; <label>:46                                      ; preds = %43
   %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %45, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %47
   %48 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.EncoderNLS addrspace(1)* %48, null
-  br i1 %NullCheck4, label %49, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.EncoderNLS addrspace(1)* %48, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %49
 
 ; <label>:49                                      ; preds = %46
   %50 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %48, i32 0, i32 3
@@ -14944,8 +17221,8 @@ entry:
   %55 = load i32, i32* %arg4
   %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck6, label %58, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
   %59 = load i64, i64 addrspace(1)* %57
@@ -14963,15 +17240,15 @@ ThrowNullRef:                                     ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %43
+ThrowNullRef2:                                    ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %46
+ThrowNullRef4:                                    ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %49
+ThrowNullRef6:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14999,8 +17276,8 @@ entry:
   %4 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0 to %System.IO.ConsoleStream addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*)(%System.IO.ConsoleStream addrspace(1)* %4, %"System.Byte[]" addrspace(1)* %1, i32 %2, i32 %3)
   %5 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
@@ -15085,8 +17362,8 @@ entry:
 
 ; <label>:22                                      ; preds = %8
   %23 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %23, null
-  br i1 %NullCheck, label %24, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Byte[]" addrspace(1)* %23, null
+  br i1 %NullCheck, label %ThrowNullRef, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
@@ -15108,8 +17385,8 @@ entry:
 
 ; <label>:36                                      ; preds = %24
   %37 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %37, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.ConsoleStream addrspace(1)* %37, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %37, i32 0, i32 4
@@ -15130,13 +17407,138 @@ ThrowNullRef:                                     ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %36
+ThrowNullRef2:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
-Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
+Successfully read WindowsConsoleStream.WriteFileNative
+
+define i32 @WindowsConsoleStream.WriteFileNative(i64 %param0, %"System.Byte[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i64
+  %arg1 = alloca %"System.Byte[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i8 addrspace(1)*
+  %loc2 = alloca %"System.Byte[]" addrspace(1)*
+  %loc3 = alloca i32
+  store i64 %param0, i64* %arg0
+  store %"System.Byte[]" addrspace(1)* %param1, %"System.Byte[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Byte[]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = zext i32 %3 to i64
+  %5 = icmp ne i64 %4, 0
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %1
+  ret i32 0
+
+; <label>:7                                       ; preds = %1
+  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  store %"System.Byte[]" addrspace(1)* %8, %"System.Byte[]" addrspace(1)** %loc2
+  %9 = icmp eq %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %9, label %18, label %10
+
+; <label>:10                                      ; preds = %7
+  %11 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc2
+  %NullCheck1 = icmp eq %"System.Byte[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %11, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp ne i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %7, %12
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc1
+  br label %27
+
+; <label>:19                                      ; preds = %12
+  %20 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc2
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %20, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %BoundsCheck = icmp uge i64 0, %24
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %25
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %20, i32 0, i32 3, i32 0
+  store i8 addrspace(1)* %26, i8 addrspace(1)** %loc1
+  br label %27
+
+; <label>:27                                      ; preds = %18, %25
+  %28 = load i64, i64* %arg0
+  %29 = load i8 addrspace(1)*, i8 addrspace(1)** %loc1
+  %30 = ptrtoint i8 addrspace(1)* %29 to i64
+  %31 = load i32, i32* %arg2
+  %32 = sext i32 %31 to i64
+  %33 = add i64 %30, %32
+  %34 = load i32, i32* %arg3
+  %35 = addrspacecast i32* %loc3 to i32 addrspace(1)*
+  %36 = inttoptr i64 %33 to i8*
+  %37 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i8*, i32, i32 addrspace(1)*, i64)*)(i64 %28, i8* %36, i32 %34, i32 addrspace(1)* %35, i64 0)
+  %38 = icmp ugt i32 %37, 0
+  %39 = sext i1 %38 to i32
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc1
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %42, label %41
+
+; <label>:41                                      ; preds = %27
+  ret i32 0
+
+; <label>:42                                      ; preds = %27
+  %43 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  store i32 %43, i32* %loc0
+  %44 = load i32, i32* %loc0
+  %45 = icmp eq i32 %44, 232
+  br i1 %45, label %49, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = load i32, i32* %loc0
+  %48 = icmp ne i32 %47, 109
+  br i1 %48, label %50, label %49
+
+; <label>:49                                      ; preds = %42, %46
+  ret i32 0
+
+; <label>:50                                      ; preds = %46
+  %51 = load i32, i32* %loc0
+  ret i32 %51
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
 Successfully read WindowsConsoleStream.Flush
 
@@ -15145,8 +17547,8 @@ entry:
   %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
   store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
@@ -15181,8 +17583,8 @@ entry:
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
   %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load i64, i64 addrspace(1)* %1
@@ -15221,15 +17623,15 @@ entry:
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.TextWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
   %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %3, align 8
   %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
   %7 = load i64, i64 addrspace(1)* %5
@@ -15247,7 +17649,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -15276,8 +17678,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %4)
   store i32 0, i32* %loc0
   %5 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Char[]" addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
@@ -15289,15 +17691,15 @@ entry:
 
 ; <label>:11                                      ; preds = %69
   %12 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %12, i32 0, i32 9
   %15 = load i32, i32 addrspace(1)* %14, align 8
   %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.IO.StreamWriter addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %16, i32 0, i32 10
@@ -15312,15 +17714,15 @@ entry:
 
 ; <label>:23                                      ; preds = %17, %21
   %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %24, null
-  br i1 %NullCheck8, label %25, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %24, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 10
   %27 = load i32, i32 addrspace(1)* %26, align 8
   %28 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %28, null
-  br i1 %NullCheck10, label %29, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.StreamWriter addrspace(1)* %28, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %28, i32 0, i32 9
@@ -15342,15 +17744,15 @@ entry:
   %40 = load i32, i32* %loc0
   %41 = mul i32 %40, 2
   %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
-  br i1 %NullCheck12, label %43, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %43
 
 ; <label>:43                                      ; preds = %38
   %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 7
   %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %44, align 8
   %46 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %46, null
-  br i1 %NullCheck14, label %47, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.IO.StreamWriter addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %47
 
 ; <label>:47                                      ; preds = %43
   %48 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %46, i32 0, i32 9
@@ -15362,16 +17764,16 @@ entry:
   %54 = bitcast %"System.Char[]" addrspace(1)* %45 to %System.Array addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %53, i32 %41, %System.Array addrspace(1)* %54, i32 %50, i32 %52)
   %55 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
-  br i1 %NullCheck16, label %56, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %56
 
 ; <label>:56                                      ; preds = %47
   %57 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
   %58 = load i32, i32 addrspace(1)* %57, align 8
   %59 = load i32, i32* %loc2
   %60 = add i32 %58, %59
-  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
-  br i1 %NullCheck18, label %61, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %61
 
 ; <label>:61                                      ; preds = %56
   %62 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
@@ -15393,8 +17795,8 @@ entry:
 
 ; <label>:72                                      ; preds = %69
   %73 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %73, null
-  br i1 %NullCheck2, label %74, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %73, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %74
 
 ; <label>:74                                      ; preds = %72
   %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %73, i32 0, i32 11
@@ -15415,39 +17817,39 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %72
+ThrowNullRef2:                                    ; preds = %72
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %23
+ThrowNullRef8:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef10:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %43
+ThrowNullRef14:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %47
+ThrowNullRef16:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %56
+ThrowNullRef18:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPNeg.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPNeg.error.txt
@@ -25,8 +25,8 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
@@ -40,8 +40,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
   %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
@@ -75,7 +75,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -90,8 +90,8 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %NullCheck = icmp ne i8 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = load i8, i8 addrspace(1)* %0, align 8
@@ -125,8 +125,8 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
@@ -159,8 +159,8 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -184,8 +184,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
   store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
@@ -195,8 +195,8 @@ entry:
 ; <label>:4                                       ; preds = %1
   %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
   %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
@@ -206,8 +206,8 @@ entry:
   %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
@@ -221,14 +221,14 @@ entry:
 
 ; <label>:17                                      ; preds = %14
   %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
   %21 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
@@ -238,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -249,8 +249,8 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
@@ -261,27 +261,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %30
+ThrowNullRef10:                                   ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -301,7 +301,89 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
-Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
+Successfully read AppDomainSetup.GetUnsecureApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.GetUnsecureApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %NullCheck = icmp eq %"System.String[]" addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %BoundsCheck = icmp uge i64 0, %5
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %6
+
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 3, i32 0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
+  ret %System.String addrspace(1)* %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_Value using LLILCJit
+Successfully read AppDomainSetup.get_Value
+
+define %"System.String[]" addrspace(1)* @AppDomainSetup.get_Value(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.String[]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 18)
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.String[]" addrspace(1)* addrspace(1)*, %"System.String[]" addrspace(1)*)*)(%"System.String[]" addrspace(1)* addrspace(1)* %9, %"System.String[]" addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %11, i32 0, i32 1
+  %14 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %13, align 8
+  ret %"System.String[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -319,8 +401,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -368,16 +450,16 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
   %5 = load i32, i32 addrspace(1)* %4
   %6 = sub i32 %5, 1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -389,7 +471,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -421,8 +503,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
@@ -456,8 +538,8 @@ entry:
 ; <label>:27                                      ; preds = %19
   %28 = load i32, i32* %arg1
   %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
-  br i1 %NullCheck2, label %30, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %29, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %30
 
 ; <label>:30                                      ; preds = %27
   %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
@@ -493,8 +575,8 @@ entry:
 ; <label>:49                                      ; preds = %46
   %50 = load i32, i32* %arg2
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck4, label %52, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
@@ -517,11 +599,11 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %27
+ThrowNullRef2:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %49
+ThrowNullRef4:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -544,16 +626,16 @@ entry:
   %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %0)
   store %System.String addrspace(1)* %1, %System.String addrspace(1)** %loc0
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 2
   %5 = bitcast [0 x i16] addrspace(1)* %4 to i16 addrspace(1)*
   store i16 addrspace(1)* %5, i16 addrspace(1)** %loc1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %3
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2
@@ -580,7 +662,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -691,15 +773,15 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %NullCheck132 = icmp ne i8* %21, null
-  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+  %NullCheck131 = icmp eq i8* %21, null
+  br i1 %NullCheck131, label %ThrowNullRef132, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = load i8, i8* %21, align 8
   %24 = zext i8 %23 to i32
   %25 = trunc i32 %24 to i8
-  %NullCheck134 = icmp ne i8* %20, null
-  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+  %NullCheck133 = icmp eq i8* %20, null
+  br i1 %NullCheck133, label %ThrowNullRef134, label %26
 
 ; <label>:26                                      ; preds = %22
   store i8 %25, i8* %20, align 8
@@ -709,16 +791,16 @@ entry:
   %28 = load i8*, i8** %arg0
   %29 = load i8*, i8** %arg1
   %30 = bitcast i8* %29 to i16*
-  %NullCheck128 = icmp ne i16* %30, null
-  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+  %NullCheck127 = icmp eq i16* %30, null
+  br i1 %NullCheck127, label %ThrowNullRef128, label %31
 
 ; <label>:31                                      ; preds = %27
   %32 = load i16, i16* %30, align 8
   %33 = sext i16 %32 to i32
   %34 = bitcast i8* %28 to i16*
   %35 = trunc i32 %33 to i16
-  %NullCheck130 = icmp ne i16* %34, null
-  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+  %NullCheck129 = icmp eq i16* %34, null
+  br i1 %NullCheck129, label %ThrowNullRef130, label %36
 
 ; <label>:36                                      ; preds = %31
   store i16 %35, i16* %34, align 8
@@ -728,16 +810,16 @@ entry:
   %38 = load i8*, i8** %arg0
   %39 = load i8*, i8** %arg1
   %40 = bitcast i8* %39 to i16*
-  %NullCheck120 = icmp ne i16* %40, null
-  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+  %NullCheck119 = icmp eq i16* %40, null
+  br i1 %NullCheck119, label %ThrowNullRef120, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i16, i16* %40, align 8
   %43 = sext i16 %42 to i32
   %44 = bitcast i8* %38 to i16*
   %45 = trunc i32 %43 to i16
-  %NullCheck122 = icmp ne i16* %44, null
-  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+  %NullCheck121 = icmp eq i16* %44, null
+  br i1 %NullCheck121, label %ThrowNullRef122, label %46
 
 ; <label>:46                                      ; preds = %41
   store i16 %45, i16* %44, align 8
@@ -745,15 +827,15 @@ entry:
   %48 = getelementptr inbounds i8, i8* %47, i64 2
   %49 = load i8*, i8** %arg1
   %50 = getelementptr inbounds i8, i8* %49, i64 2
-  %NullCheck124 = icmp ne i8* %50, null
-  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+  %NullCheck123 = icmp eq i8* %50, null
+  br i1 %NullCheck123, label %ThrowNullRef124, label %51
 
 ; <label>:51                                      ; preds = %46
   %52 = load i8, i8* %50, align 8
   %53 = zext i8 %52 to i32
   %54 = trunc i32 %53 to i8
-  %NullCheck126 = icmp ne i8* %48, null
-  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+  %NullCheck125 = icmp eq i8* %48, null
+  br i1 %NullCheck125, label %ThrowNullRef126, label %55
 
 ; <label>:55                                      ; preds = %51
   store i8 %54, i8* %48, align 8
@@ -763,14 +845,14 @@ entry:
   %57 = load i8*, i8** %arg0
   %58 = load i8*, i8** %arg1
   %59 = bitcast i8* %58 to i32*
-  %NullCheck116 = icmp ne i32* %59, null
-  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+  %NullCheck115 = icmp eq i32* %59, null
+  br i1 %NullCheck115, label %ThrowNullRef116, label %60
 
 ; <label>:60                                      ; preds = %56
   %61 = load i32, i32* %59, align 8
   %62 = bitcast i8* %57 to i32*
-  %NullCheck118 = icmp ne i32* %62, null
-  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+  %NullCheck117 = icmp eq i32* %62, null
+  br i1 %NullCheck117, label %ThrowNullRef118, label %63
 
 ; <label>:63                                      ; preds = %60
   store i32 %61, i32* %62, align 8
@@ -780,14 +862,14 @@ entry:
   %65 = load i8*, i8** %arg0
   %66 = load i8*, i8** %arg1
   %67 = bitcast i8* %66 to i32*
-  %NullCheck108 = icmp ne i32* %67, null
-  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+  %NullCheck107 = icmp eq i32* %67, null
+  br i1 %NullCheck107, label %ThrowNullRef108, label %68
 
 ; <label>:68                                      ; preds = %64
   %69 = load i32, i32* %67, align 8
   %70 = bitcast i8* %65 to i32*
-  %NullCheck110 = icmp ne i32* %70, null
-  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+  %NullCheck109 = icmp eq i32* %70, null
+  br i1 %NullCheck109, label %ThrowNullRef110, label %71
 
 ; <label>:71                                      ; preds = %68
   store i32 %69, i32* %70, align 8
@@ -795,15 +877,15 @@ entry:
   %73 = getelementptr inbounds i8, i8* %72, i64 4
   %74 = load i8*, i8** %arg1
   %75 = getelementptr inbounds i8, i8* %74, i64 4
-  %NullCheck112 = icmp ne i8* %75, null
-  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+  %NullCheck111 = icmp eq i8* %75, null
+  br i1 %NullCheck111, label %ThrowNullRef112, label %76
 
 ; <label>:76                                      ; preds = %71
   %77 = load i8, i8* %75, align 8
   %78 = zext i8 %77 to i32
   %79 = trunc i32 %78 to i8
-  %NullCheck114 = icmp ne i8* %73, null
-  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+  %NullCheck113 = icmp eq i8* %73, null
+  br i1 %NullCheck113, label %ThrowNullRef114, label %80
 
 ; <label>:80                                      ; preds = %76
   store i8 %79, i8* %73, align 8
@@ -813,14 +895,14 @@ entry:
   %82 = load i8*, i8** %arg0
   %83 = load i8*, i8** %arg1
   %84 = bitcast i8* %83 to i32*
-  %NullCheck100 = icmp ne i32* %84, null
-  br i1 %NullCheck100, label %85, label %ThrowNullRef99
+  %NullCheck99 = icmp eq i32* %84, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %85
 
 ; <label>:85                                      ; preds = %81
   %86 = load i32, i32* %84, align 8
   %87 = bitcast i8* %82 to i32*
-  %NullCheck102 = icmp ne i32* %87, null
-  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+  %NullCheck101 = icmp eq i32* %87, null
+  br i1 %NullCheck101, label %ThrowNullRef102, label %88
 
 ; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
@@ -829,16 +911,16 @@ entry:
   %91 = load i8*, i8** %arg1
   %92 = getelementptr inbounds i8, i8* %91, i64 4
   %93 = bitcast i8* %92 to i16*
-  %NullCheck104 = icmp ne i16* %93, null
-  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+  %NullCheck103 = icmp eq i16* %93, null
+  br i1 %NullCheck103, label %ThrowNullRef104, label %94
 
 ; <label>:94                                      ; preds = %88
   %95 = load i16, i16* %93, align 8
   %96 = sext i16 %95 to i32
   %97 = bitcast i8* %90 to i16*
   %98 = trunc i32 %96 to i16
-  %NullCheck106 = icmp ne i16* %97, null
-  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+  %NullCheck105 = icmp eq i16* %97, null
+  br i1 %NullCheck105, label %ThrowNullRef106, label %99
 
 ; <label>:99                                      ; preds = %94
   store i16 %98, i16* %97, align 8
@@ -848,14 +930,14 @@ entry:
   %101 = load i8*, i8** %arg0
   %102 = load i8*, i8** %arg1
   %103 = bitcast i8* %102 to i32*
-  %NullCheck88 = icmp ne i32* %103, null
-  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+  %NullCheck87 = icmp eq i32* %103, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %104
 
 ; <label>:104                                     ; preds = %100
   %105 = load i32, i32* %103, align 8
   %106 = bitcast i8* %101 to i32*
-  %NullCheck90 = icmp ne i32* %106, null
-  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+  %NullCheck89 = icmp eq i32* %106, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %107
 
 ; <label>:107                                     ; preds = %104
   store i32 %105, i32* %106, align 8
@@ -864,16 +946,16 @@ entry:
   %110 = load i8*, i8** %arg1
   %111 = getelementptr inbounds i8, i8* %110, i64 4
   %112 = bitcast i8* %111 to i16*
-  %NullCheck92 = icmp ne i16* %112, null
-  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+  %NullCheck91 = icmp eq i16* %112, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %113
 
 ; <label>:113                                     ; preds = %107
   %114 = load i16, i16* %112, align 8
   %115 = sext i16 %114 to i32
   %116 = bitcast i8* %109 to i16*
   %117 = trunc i32 %115 to i16
-  %NullCheck94 = icmp ne i16* %116, null
-  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+  %NullCheck93 = icmp eq i16* %116, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %118
 
 ; <label>:118                                     ; preds = %113
   store i16 %117, i16* %116, align 8
@@ -881,15 +963,15 @@ entry:
   %120 = getelementptr inbounds i8, i8* %119, i64 6
   %121 = load i8*, i8** %arg1
   %122 = getelementptr inbounds i8, i8* %121, i64 6
-  %NullCheck96 = icmp ne i8* %122, null
-  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+  %NullCheck95 = icmp eq i8* %122, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %123
 
 ; <label>:123                                     ; preds = %118
   %124 = load i8, i8* %122, align 8
   %125 = zext i8 %124 to i32
   %126 = trunc i32 %125 to i8
-  %NullCheck98 = icmp ne i8* %120, null
-  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+  %NullCheck97 = icmp eq i8* %120, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %127
 
 ; <label>:127                                     ; preds = %123
   store i8 %126, i8* %120, align 8
@@ -899,14 +981,14 @@ entry:
   %129 = load i8*, i8** %arg0
   %130 = load i8*, i8** %arg1
   %131 = bitcast i8* %130 to i64*
-  %NullCheck84 = icmp ne i64* %131, null
-  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+  %NullCheck83 = icmp eq i64* %131, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %132
 
 ; <label>:132                                     ; preds = %128
   %133 = load i64, i64* %131, align 8
   %134 = bitcast i8* %129 to i64*
-  %NullCheck86 = icmp ne i64* %134, null
-  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+  %NullCheck85 = icmp eq i64* %134, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %135
 
 ; <label>:135                                     ; preds = %132
   store i64 %133, i64* %134, align 8
@@ -916,14 +998,14 @@ entry:
   %137 = load i8*, i8** %arg0
   %138 = load i8*, i8** %arg1
   %139 = bitcast i8* %138 to i64*
-  %NullCheck76 = icmp ne i64* %139, null
-  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+  %NullCheck75 = icmp eq i64* %139, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %140
 
 ; <label>:140                                     ; preds = %136
   %141 = load i64, i64* %139, align 8
   %142 = bitcast i8* %137 to i64*
-  %NullCheck78 = icmp ne i64* %142, null
-  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+  %NullCheck77 = icmp eq i64* %142, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %143
 
 ; <label>:143                                     ; preds = %140
   store i64 %141, i64* %142, align 8
@@ -931,15 +1013,15 @@ entry:
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %NullCheck80 = icmp ne i8* %147, null
-  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+  %NullCheck79 = icmp eq i8* %147, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %148
 
 ; <label>:148                                     ; preds = %143
   %149 = load i8, i8* %147, align 8
   %150 = zext i8 %149 to i32
   %151 = trunc i32 %150 to i8
-  %NullCheck82 = icmp ne i8* %145, null
-  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+  %NullCheck81 = icmp eq i8* %145, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %152
 
 ; <label>:152                                     ; preds = %148
   store i8 %151, i8* %145, align 8
@@ -949,14 +1031,14 @@ entry:
   %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
   %156 = bitcast i8* %155 to i64*
-  %NullCheck68 = icmp ne i64* %156, null
-  br i1 %NullCheck68, label %157, label %ThrowNullRef67
+  %NullCheck67 = icmp eq i64* %156, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %157
 
 ; <label>:157                                     ; preds = %153
   %158 = load i64, i64* %156, align 8
   %159 = bitcast i8* %154 to i64*
-  %NullCheck70 = icmp ne i64* %159, null
-  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+  %NullCheck69 = icmp eq i64* %159, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %160
 
 ; <label>:160                                     ; preds = %157
   store i64 %158, i64* %159, align 8
@@ -965,16 +1047,16 @@ entry:
   %163 = load i8*, i8** %arg1
   %164 = getelementptr inbounds i8, i8* %163, i64 8
   %165 = bitcast i8* %164 to i16*
-  %NullCheck72 = icmp ne i16* %165, null
-  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+  %NullCheck71 = icmp eq i16* %165, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %166
 
 ; <label>:166                                     ; preds = %160
   %167 = load i16, i16* %165, align 8
   %168 = sext i16 %167 to i32
   %169 = bitcast i8* %162 to i16*
   %170 = trunc i32 %168 to i16
-  %NullCheck74 = icmp ne i16* %169, null
-  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+  %NullCheck73 = icmp eq i16* %169, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %171
 
 ; <label>:171                                     ; preds = %166
   store i16 %170, i16* %169, align 8
@@ -984,14 +1066,14 @@ entry:
   %173 = load i8*, i8** %arg0
   %174 = load i8*, i8** %arg1
   %175 = bitcast i8* %174 to i64*
-  %NullCheck56 = icmp ne i64* %175, null
-  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+  %NullCheck55 = icmp eq i64* %175, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %176
 
 ; <label>:176                                     ; preds = %172
   %177 = load i64, i64* %175, align 8
   %178 = bitcast i8* %173 to i64*
-  %NullCheck58 = icmp ne i64* %178, null
-  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+  %NullCheck57 = icmp eq i64* %178, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %179
 
 ; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
@@ -1000,16 +1082,16 @@ entry:
   %182 = load i8*, i8** %arg1
   %183 = getelementptr inbounds i8, i8* %182, i64 8
   %184 = bitcast i8* %183 to i16*
-  %NullCheck60 = icmp ne i16* %184, null
-  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+  %NullCheck59 = icmp eq i16* %184, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %185
 
 ; <label>:185                                     ; preds = %179
   %186 = load i16, i16* %184, align 8
   %187 = sext i16 %186 to i32
   %188 = bitcast i8* %181 to i16*
   %189 = trunc i32 %187 to i16
-  %NullCheck62 = icmp ne i16* %188, null
-  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+  %NullCheck61 = icmp eq i16* %188, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %190
 
 ; <label>:190                                     ; preds = %185
   store i16 %189, i16* %188, align 8
@@ -1017,15 +1099,15 @@ entry:
   %192 = getelementptr inbounds i8, i8* %191, i64 10
   %193 = load i8*, i8** %arg1
   %194 = getelementptr inbounds i8, i8* %193, i64 10
-  %NullCheck64 = icmp ne i8* %194, null
-  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+  %NullCheck63 = icmp eq i8* %194, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %195
 
 ; <label>:195                                     ; preds = %190
   %196 = load i8, i8* %194, align 8
   %197 = zext i8 %196 to i32
   %198 = trunc i32 %197 to i8
-  %NullCheck66 = icmp ne i8* %192, null
-  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+  %NullCheck65 = icmp eq i8* %192, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %199
 
 ; <label>:199                                     ; preds = %195
   store i8 %198, i8* %192, align 8
@@ -1035,14 +1117,14 @@ entry:
   %201 = load i8*, i8** %arg0
   %202 = load i8*, i8** %arg1
   %203 = bitcast i8* %202 to i64*
-  %NullCheck48 = icmp ne i64* %203, null
-  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+  %NullCheck47 = icmp eq i64* %203, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %204
 
 ; <label>:204                                     ; preds = %200
   %205 = load i64, i64* %203, align 8
   %206 = bitcast i8* %201 to i64*
-  %NullCheck50 = icmp ne i64* %206, null
-  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+  %NullCheck49 = icmp eq i64* %206, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %207
 
 ; <label>:207                                     ; preds = %204
   store i64 %205, i64* %206, align 8
@@ -1051,14 +1133,14 @@ entry:
   %210 = load i8*, i8** %arg1
   %211 = getelementptr inbounds i8, i8* %210, i64 8
   %212 = bitcast i8* %211 to i32*
-  %NullCheck52 = icmp ne i32* %212, null
-  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+  %NullCheck51 = icmp eq i32* %212, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %213
 
 ; <label>:213                                     ; preds = %207
   %214 = load i32, i32* %212, align 8
   %215 = bitcast i8* %209 to i32*
-  %NullCheck54 = icmp ne i32* %215, null
-  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+  %NullCheck53 = icmp eq i32* %215, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %216
 
 ; <label>:216                                     ; preds = %213
   store i32 %214, i32* %215, align 8
@@ -1068,14 +1150,14 @@ entry:
   %218 = load i8*, i8** %arg0
   %219 = load i8*, i8** %arg1
   %220 = bitcast i8* %219 to i64*
-  %NullCheck36 = icmp ne i64* %220, null
-  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64* %220, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %221
 
 ; <label>:221                                     ; preds = %217
   %222 = load i64, i64* %220, align 8
   %223 = bitcast i8* %218 to i64*
-  %NullCheck38 = icmp ne i64* %223, null
-  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+  %NullCheck37 = icmp eq i64* %223, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %224
 
 ; <label>:224                                     ; preds = %221
   store i64 %222, i64* %223, align 8
@@ -1084,14 +1166,14 @@ entry:
   %227 = load i8*, i8** %arg1
   %228 = getelementptr inbounds i8, i8* %227, i64 8
   %229 = bitcast i8* %228 to i32*
-  %NullCheck40 = icmp ne i32* %229, null
-  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i32* %229, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %230
 
 ; <label>:230                                     ; preds = %224
   %231 = load i32, i32* %229, align 8
   %232 = bitcast i8* %226 to i32*
-  %NullCheck42 = icmp ne i32* %232, null
-  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+  %NullCheck41 = icmp eq i32* %232, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %233
 
 ; <label>:233                                     ; preds = %230
   store i32 %231, i32* %232, align 8
@@ -1099,15 +1181,15 @@ entry:
   %235 = getelementptr inbounds i8, i8* %234, i64 12
   %236 = load i8*, i8** %arg1
   %237 = getelementptr inbounds i8, i8* %236, i64 12
-  %NullCheck44 = icmp ne i8* %237, null
-  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i8* %237, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %238
 
 ; <label>:238                                     ; preds = %233
   %239 = load i8, i8* %237, align 8
   %240 = zext i8 %239 to i32
   %241 = trunc i32 %240 to i8
-  %NullCheck46 = icmp ne i8* %235, null
-  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+  %NullCheck45 = icmp eq i8* %235, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %242
 
 ; <label>:242                                     ; preds = %238
   store i8 %241, i8* %235, align 8
@@ -1117,14 +1199,14 @@ entry:
   %244 = load i8*, i8** %arg0
   %245 = load i8*, i8** %arg1
   %246 = bitcast i8* %245 to i64*
-  %NullCheck24 = icmp ne i64* %246, null
-  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64* %246, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %247
 
 ; <label>:247                                     ; preds = %243
   %248 = load i64, i64* %246, align 8
   %249 = bitcast i8* %244 to i64*
-  %NullCheck26 = icmp ne i64* %249, null
-  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64* %249, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %250
 
 ; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
@@ -1133,14 +1215,14 @@ entry:
   %253 = load i8*, i8** %arg1
   %254 = getelementptr inbounds i8, i8* %253, i64 8
   %255 = bitcast i8* %254 to i32*
-  %NullCheck28 = icmp ne i32* %255, null
-  br i1 %NullCheck28, label %256, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i32* %255, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %256
 
 ; <label>:256                                     ; preds = %250
   %257 = load i32, i32* %255, align 8
   %258 = bitcast i8* %252 to i32*
-  %NullCheck30 = icmp ne i32* %258, null
-  br i1 %NullCheck30, label %259, label %ThrowNullRef29
+  %NullCheck29 = icmp eq i32* %258, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %259
 
 ; <label>:259                                     ; preds = %256
   store i32 %257, i32* %258, align 8
@@ -1149,16 +1231,16 @@ entry:
   %262 = load i8*, i8** %arg1
   %263 = getelementptr inbounds i8, i8* %262, i64 12
   %264 = bitcast i8* %263 to i16*
-  %NullCheck32 = icmp ne i16* %264, null
-  br i1 %NullCheck32, label %265, label %ThrowNullRef31
+  %NullCheck31 = icmp eq i16* %264, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %265
 
 ; <label>:265                                     ; preds = %259
   %266 = load i16, i16* %264, align 8
   %267 = sext i16 %266 to i32
   %268 = bitcast i8* %261 to i16*
   %269 = trunc i32 %267 to i16
-  %NullCheck34 = icmp ne i16* %268, null
-  br i1 %NullCheck34, label %270, label %ThrowNullRef33
+  %NullCheck33 = icmp eq i16* %268, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %270
 
 ; <label>:270                                     ; preds = %265
   store i16 %269, i16* %268, align 8
@@ -1168,14 +1250,14 @@ entry:
   %272 = load i8*, i8** %arg0
   %273 = load i8*, i8** %arg1
   %274 = bitcast i8* %273 to i64*
-  %NullCheck8 = icmp ne i64* %274, null
-  br i1 %NullCheck8, label %275, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64* %274, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %275
 
 ; <label>:275                                     ; preds = %271
   %276 = load i64, i64* %274, align 8
   %277 = bitcast i8* %272 to i64*
-  %NullCheck10 = icmp ne i64* %277, null
-  br i1 %NullCheck10, label %278, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %277, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %278
 
 ; <label>:278                                     ; preds = %275
   store i64 %276, i64* %277, align 8
@@ -1184,14 +1266,14 @@ entry:
   %281 = load i8*, i8** %arg1
   %282 = getelementptr inbounds i8, i8* %281, i64 8
   %283 = bitcast i8* %282 to i32*
-  %NullCheck12 = icmp ne i32* %283, null
-  br i1 %NullCheck12, label %284, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i32* %283, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %284
 
 ; <label>:284                                     ; preds = %278
   %285 = load i32, i32* %283, align 8
   %286 = bitcast i8* %280 to i32*
-  %NullCheck14 = icmp ne i32* %286, null
-  br i1 %NullCheck14, label %287, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i32* %286, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %287
 
 ; <label>:287                                     ; preds = %284
   store i32 %285, i32* %286, align 8
@@ -1200,16 +1282,16 @@ entry:
   %290 = load i8*, i8** %arg1
   %291 = getelementptr inbounds i8, i8* %290, i64 12
   %292 = bitcast i8* %291 to i16*
-  %NullCheck16 = icmp ne i16* %292, null
-  br i1 %NullCheck16, label %293, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i16* %292, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %293
 
 ; <label>:293                                     ; preds = %287
   %294 = load i16, i16* %292, align 8
   %295 = sext i16 %294 to i32
   %296 = bitcast i8* %289 to i16*
   %297 = trunc i32 %295 to i16
-  %NullCheck18 = icmp ne i16* %296, null
-  br i1 %NullCheck18, label %298, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i16* %296, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %298
 
 ; <label>:298                                     ; preds = %293
   store i16 %297, i16* %296, align 8
@@ -1217,15 +1299,15 @@ entry:
   %300 = getelementptr inbounds i8, i8* %299, i64 14
   %301 = load i8*, i8** %arg1
   %302 = getelementptr inbounds i8, i8* %301, i64 14
-  %NullCheck20 = icmp ne i8* %302, null
-  br i1 %NullCheck20, label %303, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i8* %302, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %303
 
 ; <label>:303                                     ; preds = %298
   %304 = load i8, i8* %302, align 8
   %305 = zext i8 %304 to i32
   %306 = trunc i32 %305 to i8
-  %NullCheck22 = icmp ne i8* %300, null
-  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i8* %300, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %307
 
 ; <label>:307                                     ; preds = %303
   store i8 %306, i8* %300, align 8
@@ -1235,14 +1317,14 @@ entry:
   %309 = load i8*, i8** %arg0
   %310 = load i8*, i8** %arg1
   %311 = bitcast i8* %310 to i64*
-  %NullCheck = icmp ne i64* %311, null
-  br i1 %NullCheck, label %312, label %ThrowNullRef
+  %NullCheck = icmp eq i64* %311, null
+  br i1 %NullCheck, label %ThrowNullRef, label %312
 
 ; <label>:312                                     ; preds = %308
   %313 = load i64, i64* %311, align 8
   %314 = bitcast i8* %309 to i64*
-  %NullCheck2 = icmp ne i64* %314, null
-  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64* %314, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %315
 
 ; <label>:315                                     ; preds = %312
   store i64 %313, i64* %314, align 8
@@ -1251,14 +1333,14 @@ entry:
   %318 = load i8*, i8** %arg1
   %319 = getelementptr inbounds i8, i8* %318, i64 8
   %320 = bitcast i8* %319 to i64*
-  %NullCheck4 = icmp ne i64* %320, null
-  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64* %320, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %321
 
 ; <label>:321                                     ; preds = %315
   %322 = load i64, i64* %320, align 8
   %323 = bitcast i8* %317 to i64*
-  %NullCheck6 = icmp ne i64* %323, null
-  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64* %323, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %324
 
 ; <label>:324                                     ; preds = %321
   store i64 %322, i64* %323, align 8
@@ -1286,15 +1368,15 @@ entry:
 ; <label>:338                                     ; preds = %333
   %339 = load i8*, i8** %arg0
   %340 = load i8*, i8** %arg1
-  %NullCheck136 = icmp ne i8* %340, null
-  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+  %NullCheck135 = icmp eq i8* %340, null
+  br i1 %NullCheck135, label %ThrowNullRef136, label %341
 
 ; <label>:341                                     ; preds = %338
   %342 = load i8, i8* %340, align 8
   %343 = zext i8 %342 to i32
   %344 = trunc i32 %343 to i8
-  %NullCheck138 = icmp ne i8* %339, null
-  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+  %NullCheck137 = icmp eq i8* %339, null
+  br i1 %NullCheck137, label %ThrowNullRef138, label %345
 
 ; <label>:345                                     ; preds = %341
   store i8 %344, i8* %339, align 8
@@ -1317,16 +1399,16 @@ entry:
   %357 = load i8*, i8** %arg0
   %358 = load i8*, i8** %arg1
   %359 = bitcast i8* %358 to i16*
-  %NullCheck140 = icmp ne i16* %359, null
-  br i1 %NullCheck140, label %360, label %ThrowNullRef139
+  %NullCheck139 = icmp eq i16* %359, null
+  br i1 %NullCheck139, label %ThrowNullRef140, label %360
 
 ; <label>:360                                     ; preds = %356
   %361 = load i16, i16* %359, align 8
   %362 = sext i16 %361 to i32
   %363 = bitcast i8* %357 to i16*
   %364 = trunc i32 %362 to i16
-  %NullCheck142 = icmp ne i16* %363, null
-  br i1 %NullCheck142, label %365, label %ThrowNullRef141
+  %NullCheck141 = icmp eq i16* %363, null
+  br i1 %NullCheck141, label %ThrowNullRef142, label %365
 
 ; <label>:365                                     ; preds = %360
   store i16 %364, i16* %363, align 8
@@ -1352,14 +1434,14 @@ entry:
   %378 = load i8*, i8** %arg0
   %379 = load i8*, i8** %arg1
   %380 = bitcast i8* %379 to i32*
-  %NullCheck144 = icmp ne i32* %380, null
-  br i1 %NullCheck144, label %381, label %ThrowNullRef143
+  %NullCheck143 = icmp eq i32* %380, null
+  br i1 %NullCheck143, label %ThrowNullRef144, label %381
 
 ; <label>:381                                     ; preds = %377
   %382 = load i32, i32* %380, align 8
   %383 = bitcast i8* %378 to i32*
-  %NullCheck146 = icmp ne i32* %383, null
-  br i1 %NullCheck146, label %384, label %ThrowNullRef145
+  %NullCheck145 = icmp eq i32* %383, null
+  br i1 %NullCheck145, label %ThrowNullRef146, label %384
 
 ; <label>:384                                     ; preds = %381
   store i32 %382, i32* %383, align 8
@@ -1384,14 +1466,14 @@ entry:
   %395 = load i8*, i8** %arg0
   %396 = load i8*, i8** %arg1
   %397 = bitcast i8* %396 to i64*
-  %NullCheck164 = icmp ne i64* %397, null
-  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+  %NullCheck163 = icmp eq i64* %397, null
+  br i1 %NullCheck163, label %ThrowNullRef164, label %398
 
 ; <label>:398                                     ; preds = %394
   %399 = load i64, i64* %397, align 8
   %400 = bitcast i8* %395 to i64*
-  %NullCheck166 = icmp ne i64* %400, null
-  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+  %NullCheck165 = icmp eq i64* %400, null
+  br i1 %NullCheck165, label %ThrowNullRef166, label %401
 
 ; <label>:401                                     ; preds = %398
   store i64 %399, i64* %400, align 8
@@ -1400,14 +1482,14 @@ entry:
   %404 = load i8*, i8** %arg1
   %405 = getelementptr inbounds i8, i8* %404, i64 8
   %406 = bitcast i8* %405 to i64*
-  %NullCheck168 = icmp ne i64* %406, null
-  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+  %NullCheck167 = icmp eq i64* %406, null
+  br i1 %NullCheck167, label %ThrowNullRef168, label %407
 
 ; <label>:407                                     ; preds = %401
   %408 = load i64, i64* %406, align 8
   %409 = bitcast i8* %403 to i64*
-  %NullCheck170 = icmp ne i64* %409, null
-  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+  %NullCheck169 = icmp eq i64* %409, null
+  br i1 %NullCheck169, label %ThrowNullRef170, label %410
 
 ; <label>:410                                     ; preds = %407
   store i64 %408, i64* %409, align 8
@@ -1437,14 +1519,14 @@ entry:
   %425 = load i8*, i8** %arg0
   %426 = load i8*, i8** %arg1
   %427 = bitcast i8* %426 to i64*
-  %NullCheck148 = icmp ne i64* %427, null
-  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+  %NullCheck147 = icmp eq i64* %427, null
+  br i1 %NullCheck147, label %ThrowNullRef148, label %428
 
 ; <label>:428                                     ; preds = %424
   %429 = load i64, i64* %427, align 8
   %430 = bitcast i8* %425 to i64*
-  %NullCheck150 = icmp ne i64* %430, null
-  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+  %NullCheck149 = icmp eq i64* %430, null
+  br i1 %NullCheck149, label %ThrowNullRef150, label %431
 
 ; <label>:431                                     ; preds = %428
   store i64 %429, i64* %430, align 8
@@ -1466,14 +1548,14 @@ entry:
   %441 = load i8*, i8** %arg0
   %442 = load i8*, i8** %arg1
   %443 = bitcast i8* %442 to i32*
-  %NullCheck152 = icmp ne i32* %443, null
-  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+  %NullCheck151 = icmp eq i32* %443, null
+  br i1 %NullCheck151, label %ThrowNullRef152, label %444
 
 ; <label>:444                                     ; preds = %440
   %445 = load i32, i32* %443, align 8
   %446 = bitcast i8* %441 to i32*
-  %NullCheck154 = icmp ne i32* %446, null
-  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+  %NullCheck153 = icmp eq i32* %446, null
+  br i1 %NullCheck153, label %ThrowNullRef154, label %447
 
 ; <label>:447                                     ; preds = %444
   store i32 %445, i32* %446, align 8
@@ -1495,16 +1577,16 @@ entry:
   %457 = load i8*, i8** %arg0
   %458 = load i8*, i8** %arg1
   %459 = bitcast i8* %458 to i16*
-  %NullCheck156 = icmp ne i16* %459, null
-  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+  %NullCheck155 = icmp eq i16* %459, null
+  br i1 %NullCheck155, label %ThrowNullRef156, label %460
 
 ; <label>:460                                     ; preds = %456
   %461 = load i16, i16* %459, align 8
   %462 = sext i16 %461 to i32
   %463 = bitcast i8* %457 to i16*
   %464 = trunc i32 %462 to i16
-  %NullCheck158 = icmp ne i16* %463, null
-  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+  %NullCheck157 = icmp eq i16* %463, null
+  br i1 %NullCheck157, label %ThrowNullRef158, label %465
 
 ; <label>:465                                     ; preds = %460
   store i16 %464, i16* %463, align 8
@@ -1525,15 +1607,15 @@ entry:
 ; <label>:474                                     ; preds = %470
   %475 = load i8*, i8** %arg0
   %476 = load i8*, i8** %arg1
-  %NullCheck160 = icmp ne i8* %476, null
-  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+  %NullCheck159 = icmp eq i8* %476, null
+  br i1 %NullCheck159, label %ThrowNullRef160, label %477
 
 ; <label>:477                                     ; preds = %474
   %478 = load i8, i8* %476, align 8
   %479 = zext i8 %478 to i32
   %480 = trunc i32 %479 to i8
-  %NullCheck162 = icmp ne i8* %475, null
-  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+  %NullCheck161 = icmp eq i8* %475, null
+  br i1 %NullCheck161, label %ThrowNullRef162, label %481
 
 ; <label>:481                                     ; preds = %477
   store i8 %480, i8* %475, align 8
@@ -1553,343 +1635,343 @@ ThrowNullRef:                                     ; preds = %308
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %312
+ThrowNullRef2:                                    ; preds = %312
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %315
+ThrowNullRef4:                                    ; preds = %315
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %321
+ThrowNullRef6:                                    ; preds = %321
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %271
+ThrowNullRef8:                                    ; preds = %271
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %275
+ThrowNullRef10:                                   ; preds = %275
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %278
+ThrowNullRef12:                                   ; preds = %278
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %284
+ThrowNullRef14:                                   ; preds = %284
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %287
+ThrowNullRef16:                                   ; preds = %287
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %293
+ThrowNullRef18:                                   ; preds = %293
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %298
+ThrowNullRef20:                                   ; preds = %298
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %303
+ThrowNullRef22:                                   ; preds = %303
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %243
+ThrowNullRef24:                                   ; preds = %243
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %247
+ThrowNullRef26:                                   ; preds = %247
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %250
+ThrowNullRef28:                                   ; preds = %250
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %256
+ThrowNullRef30:                                   ; preds = %256
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %259
+ThrowNullRef32:                                   ; preds = %259
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %265
+ThrowNullRef34:                                   ; preds = %265
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %217
+ThrowNullRef36:                                   ; preds = %217
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %221
+ThrowNullRef38:                                   ; preds = %221
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %224
+ThrowNullRef40:                                   ; preds = %224
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %230
+ThrowNullRef42:                                   ; preds = %230
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %233
+ThrowNullRef44:                                   ; preds = %233
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %238
+ThrowNullRef46:                                   ; preds = %238
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %200
+ThrowNullRef48:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %204
+ThrowNullRef50:                                   ; preds = %204
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %207
+ThrowNullRef52:                                   ; preds = %207
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %213
+ThrowNullRef54:                                   ; preds = %213
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %172
+ThrowNullRef56:                                   ; preds = %172
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %176
+ThrowNullRef58:                                   ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %179
+ThrowNullRef60:                                   ; preds = %179
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %185
+ThrowNullRef62:                                   ; preds = %185
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %190
+ThrowNullRef64:                                   ; preds = %190
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %195
+ThrowNullRef66:                                   ; preds = %195
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %153
+ThrowNullRef68:                                   ; preds = %153
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %157
+ThrowNullRef70:                                   ; preds = %157
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %160
+ThrowNullRef72:                                   ; preds = %160
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %166
+ThrowNullRef74:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %136
+ThrowNullRef76:                                   ; preds = %136
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %140
+ThrowNullRef78:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %143
+ThrowNullRef80:                                   ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %148
+ThrowNullRef82:                                   ; preds = %148
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %128
+ThrowNullRef84:                                   ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %132
+ThrowNullRef86:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %100
+ThrowNullRef88:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %104
+ThrowNullRef90:                                   ; preds = %104
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %107
+ThrowNullRef92:                                   ; preds = %107
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %113
+ThrowNullRef94:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %118
+ThrowNullRef96:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %123
+ThrowNullRef98:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %81
+ThrowNullRef100:                                  ; preds = %81
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef101:                                  ; preds = %85
+ThrowNullRef102:                                  ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef103:                                  ; preds = %88
+ThrowNullRef104:                                  ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef105:                                  ; preds = %94
+ThrowNullRef106:                                  ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef107:                                  ; preds = %64
+ThrowNullRef108:                                  ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef109:                                  ; preds = %68
+ThrowNullRef110:                                  ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef111:                                  ; preds = %71
+ThrowNullRef112:                                  ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef113:                                  ; preds = %76
+ThrowNullRef114:                                  ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef115:                                  ; preds = %56
+ThrowNullRef116:                                  ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef117:                                  ; preds = %60
+ThrowNullRef118:                                  ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef119:                                  ; preds = %37
+ThrowNullRef120:                                  ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef121:                                  ; preds = %41
+ThrowNullRef122:                                  ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef123:                                  ; preds = %46
+ThrowNullRef124:                                  ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef125:                                  ; preds = %51
+ThrowNullRef126:                                  ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef127:                                  ; preds = %27
+ThrowNullRef128:                                  ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef129:                                  ; preds = %31
+ThrowNullRef130:                                  ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef131:                                  ; preds = %19
+ThrowNullRef132:                                  ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef133:                                  ; preds = %22
+ThrowNullRef134:                                  ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef135:                                  ; preds = %338
+ThrowNullRef136:                                  ; preds = %338
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef137:                                  ; preds = %341
+ThrowNullRef138:                                  ; preds = %341
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef139:                                  ; preds = %356
+ThrowNullRef140:                                  ; preds = %356
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef141:                                  ; preds = %360
+ThrowNullRef142:                                  ; preds = %360
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef143:                                  ; preds = %377
+ThrowNullRef144:                                  ; preds = %377
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef145:                                  ; preds = %381
+ThrowNullRef146:                                  ; preds = %381
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef147:                                  ; preds = %424
+ThrowNullRef148:                                  ; preds = %424
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef149:                                  ; preds = %428
+ThrowNullRef150:                                  ; preds = %428
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef151:                                  ; preds = %440
+ThrowNullRef152:                                  ; preds = %440
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef153:                                  ; preds = %444
+ThrowNullRef154:                                  ; preds = %444
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef155:                                  ; preds = %456
+ThrowNullRef156:                                  ; preds = %456
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef157:                                  ; preds = %460
+ThrowNullRef158:                                  ; preds = %460
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef159:                                  ; preds = %474
+ThrowNullRef160:                                  ; preds = %474
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef161:                                  ; preds = %477
+ThrowNullRef162:                                  ; preds = %477
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef163:                                  ; preds = %394
+ThrowNullRef164:                                  ; preds = %394
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef165:                                  ; preds = %398
+ThrowNullRef166:                                  ; preds = %398
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef167:                                  ; preds = %401
+ThrowNullRef168:                                  ; preds = %401
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef169:                                  ; preds = %407
+ThrowNullRef170:                                  ; preds = %407
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1939,8 +2021,8 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
-  br i1 %NullCheck, label %22, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %ThrowNullRef, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
@@ -1948,8 +2030,8 @@ entry:
   store i32 %24, i32* %loc0
   %25 = load i32, i32* %loc0
   %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %26, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %27
 
 ; <label>:27                                      ; preds = %22
   %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
@@ -1971,7 +2053,7 @@ ThrowNullRef:                                     ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1989,8 +2071,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -2022,15 +2104,15 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2048,16 +2130,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
   %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
   store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %15
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
@@ -2072,8 +2154,8 @@ entry:
   %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
   %29 = ptrtoint i16 addrspace(1)* %28 to i64
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %19
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
@@ -2089,19 +2171,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2114,8 +2196,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
@@ -2128,7 +2210,7 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[loadElem]
+Failed to read AppDomain.PrepareDataForSetup[storeElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
@@ -2202,8 +2284,8 @@ entry:
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
-  br i1 %NullCheck24, label %27, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = load i64, i64 addrspace(1)* %26
@@ -2218,8 +2300,8 @@ entry:
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
-  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
   %41 = load i64, i64 addrspace(1)* %39
@@ -2236,8 +2318,8 @@ entry:
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
-  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
   %54 = load i64, i64 addrspace(1)* %52
@@ -2252,8 +2334,8 @@ entry:
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
   %67 = load i64, i64 addrspace(1)* %65
@@ -2270,8 +2352,8 @@ entry:
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
-  br i1 %NullCheck16, label %79, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
   %80 = load i64, i64 addrspace(1)* %78
@@ -2286,8 +2368,8 @@ entry:
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
-  br i1 %NullCheck18, label %92, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
   %93 = load i64, i64 addrspace(1)* %91
@@ -2304,8 +2386,8 @@ entry:
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
-  br i1 %NullCheck12, label %105, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = load i64, i64 addrspace(1)* %104
@@ -2320,8 +2402,8 @@ entry:
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
-  br i1 %NullCheck14, label %118, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
   %119 = load i64, i64 addrspace(1)* %117
@@ -2337,8 +2419,8 @@ entry:
 
 ; <label>:128                                     ; preds = %20
   %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
-  br i1 %NullCheck4, label %130, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %129, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %130
 
 ; <label>:130                                     ; preds = %128
   %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
@@ -2346,8 +2428,8 @@ entry:
   %133 = load i16, i16 addrspace(1)* %132, align 8
   %134 = zext i16 %133 to i32
   %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
-  br i1 %NullCheck6, label %136, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %135, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %136
 
 ; <label>:136                                     ; preds = %130
   %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
@@ -2360,8 +2442,8 @@ entry:
 
 ; <label>:143                                     ; preds = %136
   %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
-  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %144, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %145
 
 ; <label>:145                                     ; preds = %143
   %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
@@ -2369,8 +2451,8 @@ entry:
   %148 = load i16, i16 addrspace(1)* %147, align 8
   %149 = zext i16 %148 to i32
   %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %150, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %151
 
 ; <label>:151                                     ; preds = %145
   %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
@@ -2388,8 +2470,8 @@ entry:
 
 ; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
-  br i1 %NullCheck, label %163, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %ThrowNullRef, label %163
 
 ; <label>:163                                     ; preds = %161
   %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
@@ -2399,8 +2481,8 @@ entry:
 
 ; <label>:167                                     ; preds = %163
   %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
-  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %168, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %169
 
 ; <label>:169                                     ; preds = %167
   %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
@@ -2432,55 +2514,55 @@ ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %167
+ThrowNullRef2:                                    ; preds = %167
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %128
+ThrowNullRef4:                                    ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %130
+ThrowNullRef6:                                    ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %143
+ThrowNullRef8:                                    ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %145
+ThrowNullRef10:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %102
+ThrowNullRef12:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %105
+ThrowNullRef14:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %76
+ThrowNullRef16:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %79
+ThrowNullRef18:                                   ; preds = %79
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %50
+ThrowNullRef20:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %53
+ThrowNullRef22:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %24
+ThrowNullRef24:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %27
+ThrowNullRef26:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2503,15 +2585,15 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2519,16 +2601,16 @@ entry:
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
   store i32 %8, i32* %loc0
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
   %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
   store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
@@ -2546,16 +2628,16 @@ entry:
 
 ; <label>:23                                      ; preds = %64
   %24 = load i16*, i16** %loc3
-  %NullCheck12 = icmp ne i16* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i16* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
   store i32 %27, i32* %loc5
   %28 = load i16*, i16** %loc4
-  %NullCheck14 = icmp ne i16* %28, null
-  br i1 %NullCheck14, label %29, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %28, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = load i16, i16* %28, align 8
@@ -2620,15 +2702,15 @@ entry:
 
 ; <label>:67                                      ; preds = %64
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
-  br i1 %NullCheck8, label %69, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %68, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %69
 
 ; <label>:69                                      ; preds = %67
   %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
   %71 = load i32, i32 addrspace(1)* %70
   %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
-  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %73
 
 ; <label>:73                                      ; preds = %69
   %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
@@ -2645,31 +2727,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %67
+ThrowNullRef8:                                    ; preds = %67
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %69
+ThrowNullRef10:                                   ; preds = %69
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2710,14 +2792,14 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
   %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
@@ -2730,14 +2812,14 @@ entry:
 
 ; <label>:11                                      ; preds = %4
   %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
   %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
@@ -2749,14 +2831,14 @@ entry:
 
 ; <label>:22                                      ; preds = %16
   %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
   %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
-  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
-  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
@@ -2804,23 +2886,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2836,7 +2918,280 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[loadElem]
+Successfully read RuntimeType.IsAssignableFrom
+
+define i8 @RuntimeType.IsAssignableFrom(%System.RuntimeType addrspace(1)* %param0, %System.Type addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.RuntimeType addrspace(1)*
+  %arg1 = alloca %System.Type addrspace(1)*
+  %loc0 = alloca %System.RuntimeType addrspace(1)*
+  %loc1 = alloca %"System.Type[]" addrspace(1)*
+  %loc2 = alloca i32
+  store %System.RuntimeType addrspace(1)* %param0, %System.RuntimeType addrspace(1)** %this
+  store %System.Type addrspace(1)* %param1, %System.Type addrspace(1)** %arg1
+  %0 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %1 = icmp ne %System.Type addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i8 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %5 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %6 = bitcast %System.Type addrspace(1)* %4 to %System.Object addrspace(1)*
+  %7 = bitcast %System.RuntimeType addrspace(1)* %5 to %System.Object addrspace(1)*
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %6, %System.Object addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %3
+  ret i8 1
+
+; <label>:12                                      ; preds = %3
+  %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 152
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 32
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
+  %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
+  %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
+  store %System.RuntimeType addrspace(1)* %25, %System.RuntimeType addrspace(1)** %loc0
+  %26 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %27 = icmp eq %System.RuntimeType addrspace(1)* %26, null
+  br i1 %27, label %34, label %28
+
+; <label>:28                                      ; preds = %15
+  %29 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %30 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)*)*)(%System.RuntimeType addrspace(1)* %29, %System.RuntimeType addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+; <label>:34                                      ; preds = %15
+  %35 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %36 = call %System.Reflection.Emit.TypeBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Reflection.Emit.TypeBuilder addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %35)
+  %37 = icmp eq %System.Reflection.Emit.TypeBuilder addrspace(1)* %36, null
+  br i1 %37, label %139, label %38
+
+; <label>:38                                      ; preds = %34
+  %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %42
+
+; <label>:42                                      ; preds = %38
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 152
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 40
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
+  %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
+  %53 = zext i8 %52 to i32
+  %54 = icmp eq i32 %53, 0
+  br i1 %54, label %56, label %55
+
+; <label>:55                                      ; preds = %42
+  ret i8 1
+
+; <label>:56                                      ; preds = %42
+  %57 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %58 = bitcast %System.RuntimeType addrspace(1)* %57 to %System.Type addrspace(1)*
+  %59 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %58)
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %64 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.Type addrspace(1)* %63, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = bitcast %System.RuntimeType addrspace(1)* %64 to %System.Type addrspace(1)*
+  %67 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %63, %System.Type addrspace(1)* %66)
+  %68 = zext i8 %67 to i32
+  %69 = trunc i32 %68 to i8
+  ret i8 %69
+
+; <label>:70                                      ; preds = %56
+  %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
+  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %73
+
+; <label>:73                                      ; preds = %70
+  %74 = load i64, i64 addrspace(1)* %72
+  %75 = add i64 %74, 128
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = add i64 %77, 0
+  %79 = inttoptr i64 %78 to i64*
+  %80 = load i64, i64* %79
+  %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
+  %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
+  %83 = call i8 %82(%System.Type addrspace(1)* %81)
+  %84 = zext i8 %83 to i32
+  %85 = icmp eq i32 %84, 0
+  br i1 %85, label %139, label %86
+
+; <label>:86                                      ; preds = %73
+  %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
+  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %89
+
+; <label>:89                                      ; preds = %86
+  %90 = load i64, i64 addrspace(1)* %88
+  %91 = add i64 %90, 128
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = add i64 %93, 24
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
+  %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
+  %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
+  store %"System.Type[]" addrspace(1)* %99, %"System.Type[]" addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %129
+
+; <label>:100                                     ; preds = %132
+  %101 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %102 = load i32, i32* %loc2
+  %NullCheck11 = icmp eq %"System.Type[]" addrspace(1)* %101, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %103
+
+; <label>:103                                     ; preds = %100
+  %104 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 1
+  %105 = load i32, i32 addrspace(1)* %104
+  %106 = zext i32 %105 to i64
+  %107 = zext i32 %102 to i64
+  %BoundsCheck = icmp uge i64 %107, %106
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %108
+
+; <label>:108                                     ; preds = %103
+  %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
+  %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
+  %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
+  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %113
+
+; <label>:113                                     ; preds = %108
+  %114 = load i64, i64 addrspace(1)* %112
+  %115 = add i64 %114, 152
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = add i64 %117, 56
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
+  %123 = zext i8 %122 to i32
+  %124 = icmp ne i32 %123, 0
+  br i1 %124, label %126, label %125
+
+; <label>:125                                     ; preds = %113
+  ret i8 0
+
+; <label>:126                                     ; preds = %113
+  %127 = load i32, i32* %loc2
+  %128 = add i32 %127, 1
+  store i32 %128, i32* %loc2
+  br label %129
+
+; <label>:129                                     ; preds = %89, %126
+  %130 = load i32, i32* %loc2
+  %131 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %NullCheck9 = icmp eq %"System.Type[]" addrspace(1)* %131, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %132
+
+; <label>:132                                     ; preds = %129
+  %133 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %131, i32 0, i32 1
+  %134 = load i32, i32 addrspace(1)* %133
+  %135 = zext i32 %134 to i64
+  %136 = trunc i64 %135 to i32
+  %137 = icmp slt i32 %130, %136
+  br i1 %137, label %100, label %138
+
+; <label>:138                                     ; preds = %132
+  ret i8 1
+
+; <label>:139                                     ; preds = %34, %73
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %129
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %103
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -2893,7 +3248,7 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElem]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -2904,8 +3259,8 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -2997,8 +3352,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
@@ -3059,8 +3414,8 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -3087,8 +3442,8 @@ entry:
 
 ; <label>:17                                      ; preds = %5, %11
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
@@ -3097,8 +3452,8 @@ entry:
 
 ; <label>:22                                      ; preds = %1, %11
   %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
@@ -3109,11 +3464,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %17
+ThrowNullRef2:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %22
+ThrowNullRef4:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3167,15 +3522,15 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
   %15 = load i32, i32 addrspace(1)* %14
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
@@ -3198,7 +3553,7 @@ ThrowNullRef:                                     ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef2:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3232,8 +3587,8 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
@@ -3312,8 +3667,8 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -3327,8 +3682,8 @@ entry:
 ; <label>:5                                       ; preds = %43
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %7 = load i32, i32* %loc1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck6, label %8, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
@@ -3366,8 +3721,8 @@ entry:
 ; <label>:32                                      ; preds = %21, %25
   %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
   %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
-  br i1 %NullCheck8, label %35, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = trunc i32 %34 to i16
@@ -3380,8 +3735,8 @@ entry:
 ; <label>:40                                      ; preds = %1, %35
   %41 = load i32, i32* %loc1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
-  br i1 %NullCheck2, label %43, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %42, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
@@ -3392,8 +3747,8 @@ entry:
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
   %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
-  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
   %51 = load i64, i64 addrspace(1)* %49
@@ -3412,19 +3767,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %40
+ThrowNullRef2:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %47
+ThrowNullRef4:                                    ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %5
+ThrowNullRef6:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %32
+ThrowNullRef8:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3467,8 +3822,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
@@ -3492,11 +3847,391 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(i16* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store i16* %param0, i16** %arg0
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load i32, i32* %arg3
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %42, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %37, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg2
+  %13 = load i32, i32* %arg3
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %37, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %24 = load i32, i32* %arg2
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load i16*, i16** %arg0
+  %35 = load i32, i32* %arg3
+  %36 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %36, i16* %34, i32 %35)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:37                                      ; preds = %5, %16
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %39)
+  %41 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41, %System.String addrspace(1)* %38, %System.String addrspace(1)* %40)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41) #0
+  unreachable
+
+; <label>:42                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
-Failed to read StringBuilder.ToString[loadElemA]
+Successfully read StringBuilder.ToString
+
+define %System.String addrspace(1)* @StringBuilder.ToString(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i16*
+  %loc3 = alloca %"System.Char[]" addrspace(1)*
+  %loc4 = alloca i32
+  %loc5 = alloca i32
+  %loc6 = alloca i16 addrspace(1)*
+  %loc7 = alloca %System.String addrspace(1)*
+  %loc8 = alloca %"System.Char[]" addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %0)
+  %2 = icmp ne i32 %1, 0
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %4
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %6)
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %7)
+  store %System.String addrspace(1)* %8, %System.String addrspace(1)** %loc0
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.Text.StringBuilder addrspace(1)* %9, %System.Text.StringBuilder addrspace(1)** %loc1
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  store %System.String addrspace(1)* %10, %System.String addrspace(1)** %loc7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc7
+  %12 = ptrtoint %System.String addrspace(1)* %11 to i64
+  %13 = icmp eq i64 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %5
+  %15 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %16 = sext i32 %15 to i64
+  %17 = add i64 %12, %16
+  br label %18
+
+; <label>:18                                      ; preds = %5, %14
+  %19 = phi i64 [ %12, %5 ], [ %17, %14 ]
+  %20 = inttoptr i64 %19 to i16*
+  store i16* %20, i16** %loc2
+  br label %21
+
+; <label>:21                                      ; preds = %98, %18
+  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %22, null
+  br i1 %NullCheck, label %ThrowNullRef, label %23
+
+; <label>:23                                      ; preds = %21
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 3
+  %25 = load i32, i32 addrspace(1)* %24, align 8
+  %26 = icmp sle i32 %25, 0
+  br i1 %26, label %96, label %27
+
+; <label>:27                                      ; preds = %23
+  %28 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %28, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %29
+
+; <label>:29                                      ; preds = %27
+  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %28, i32 0, i32 1
+  %31 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %30, align 8
+  store %"System.Char[]" addrspace(1)* %31, %"System.Char[]" addrspace(1)** %loc3
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %33
+
+; <label>:33                                      ; preds = %29
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  store i32 %35, i32* %loc4
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  %39 = load i32, i32 addrspace(1)* %38, align 8
+  store i32 %39, i32* %loc5
+  %40 = load i32, i32* %loc5
+  %41 = load i32, i32* %loc4
+  %42 = add i32 %40, %41
+  %43 = zext i32 %42 to i64
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %45
+
+; <label>:45                                      ; preds = %37
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = sext i32 %47 to i64
+  %49 = icmp sgt i64 %43, %48
+  br i1 %49, label %91, label %50
+
+; <label>:50                                      ; preds = %45
+  %51 = load i32, i32* %loc5
+  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %52, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %53
+
+; <label>:53                                      ; preds = %50
+  %54 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %52, i32 0, i32 1
+  %55 = load i32, i32 addrspace(1)* %54
+  %56 = zext i32 %55 to i64
+  %57 = trunc i64 %56 to i32
+  %58 = icmp ugt i32 %51, %57
+  br i1 %58, label %91, label %59
+
+; <label>:59                                      ; preds = %53
+  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  store %"System.Char[]" addrspace(1)* %60, %"System.Char[]" addrspace(1)** %loc8
+  %61 = icmp eq %"System.Char[]" addrspace(1)* %60, null
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %63, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %64
+
+; <label>:64                                      ; preds = %62
+  %65 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %63, i32 0, i32 1
+  %66 = load i32, i32 addrspace(1)* %65
+  %67 = zext i32 %66 to i64
+  %68 = trunc i64 %67 to i32
+  %69 = icmp ne i32 %68, 0
+  br i1 %69, label %71, label %70
+
+; <label>:70                                      ; preds = %59, %64
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:71                                      ; preds = %64
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %73
+
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %BoundsCheck = icmp uge i64 0, %76
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %77
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %78, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:79                                      ; preds = %70, %77
+  %80 = load i16*, i16** %loc2
+  %81 = load i32, i32* %loc4
+  %82 = sext i32 %81 to i64
+  %83 = mul i64 %82, 2
+  %84 = bitcast i16* %80 to i8*
+  %85 = getelementptr inbounds i8, i8* %84, i64 %83
+  %86 = load i16 addrspace(1)*, i16 addrspace(1)** %loc6
+  %87 = ptrtoint i16 addrspace(1)* %86 to i64
+  %88 = load i32, i32* %loc5
+  %89 = bitcast i8* %85 to i16*
+  %90 = inttoptr i64 %87 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %89, i16* %90, i32 %88)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %96
+
+; <label>:91                                      ; preds = %45, %53
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %94 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %93)
+  %95 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95, %System.String addrspace(1)* %92, %System.String addrspace(1)* %94)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95) #0
+  unreachable
+
+; <label>:96                                      ; preds = %23, %79
+  %97 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %97, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %98
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %97, i32 0, i32 2
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  store %System.Text.StringBuilder addrspace(1)* %100, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %102 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %102, label %21, label %103
+
+; <label>:103                                     ; preds = %98
+  store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc7
+  %104 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  ret %System.String addrspace(1)* %104
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method StringBuilder::get_Length using LLILCJit
+Successfully read StringBuilder.get_Length
+
+define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
+Successfully read RuntimeHelpers.get_OffsetToStringData
+
+define i32 @RuntimeHelpers.get_OffsetToStringData() {
+entry:
+  ret i32 12
+}
+
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
 Successfully read CultureData.CreateCultureData
 
@@ -3514,23 +4249,23 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
   store i8 %4, i8 addrspace(1)* %6
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
@@ -3549,11 +4284,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3566,50 +4301,50 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
   store i32 -1, i32 addrspace(1)* %2
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
   store i32 -1, i32 addrspace(1)* %8
   %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
   store i32 -1, i32 addrspace(1)* %14
   %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
   store i32 -1, i32 addrspace(1)* %17
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
@@ -3623,27 +4358,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3675,7 +4410,136 @@ Failed to read Dictionary`2.Insert[non-const derefAddress]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
 Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
-Failed to read HashHelpers.GetPrime[loadElem]
+Successfully read HashHelpers.GetPrime
+
+define i32 @HashHelpers.GetPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %6, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5, %System.String addrspace(1)* %4)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5) #0
+  unreachable
+
+; <label>:6                                       ; preds = %entry
+  store i32 0, i32* %loc0
+  br label %29
+
+; <label>:7                                       ; preds = %35
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 1296
+  %10 = addrspacecast i8 addrspace(1)* %9 to %"System.Int32[]" addrspace(1)**
+  %11 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %10
+  %12 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Int32[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = zext i32 %15 to i64
+  %17 = zext i32 %12 to i64
+  %BoundsCheck = icmp uge i64 %17, %16
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 3, i32 %12
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  store i32 %20, i32* %loc1
+  %21 = load i32, i32* %loc1
+  %22 = load i32, i32* %arg0
+  %23 = icmp slt i32 %21, %22
+  br i1 %23, label %26, label %24
+
+; <label>:24                                      ; preds = %18
+  %25 = load i32, i32* %loc1
+  ret i32 %25
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %loc0
+  %28 = add i32 %27, 1
+  store i32 %28, i32* %loc0
+  br label %29
+
+; <label>:29                                      ; preds = %6, %26
+  %30 = load i32, i32* %loc0
+  %31 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %32 = getelementptr inbounds i8, i8 addrspace(1)* %31, i64 1296
+  %33 = addrspacecast i8 addrspace(1)* %32 to %"System.Int32[]" addrspace(1)**
+  %34 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %33
+  %NullCheck = icmp eq %"System.Int32[]" addrspace(1)* %34, null
+  br i1 %NullCheck, label %ThrowNullRef, label %35
+
+; <label>:35                                      ; preds = %29
+  %36 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %34, i32 0, i32 1
+  %37 = load i32, i32 addrspace(1)* %36
+  %38 = zext i32 %37 to i64
+  %39 = trunc i64 %38 to i32
+  %40 = icmp slt i32 %30, %39
+  br i1 %40, label %7, label %41
+
+; <label>:41                                      ; preds = %35
+  %42 = load i32, i32* %arg0
+  %43 = or i32 %42, 1
+  store i32 %43, i32* %loc2
+  br label %59
+
+; <label>:44                                      ; preds = %59
+  %45 = load i32, i32* %loc2
+  %46 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %45)
+  %47 = zext i8 %46 to i32
+  %48 = icmp eq i32 %47, 0
+  br i1 %48, label %56, label %49
+
+; <label>:49                                      ; preds = %44
+  %50 = load i32, i32* %loc2
+  %51 = sub i32 %50, 1
+  %52 = srem i32 %51, 101
+  %53 = icmp eq i32 %52, 0
+  br i1 %53, label %56, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = load i32, i32* %loc2
+  ret i32 %55
+
+; <label>:56                                      ; preds = %44, %49
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %57, 2
+  store i32 %58, i32* %loc2
+  br label %59
+
+; <label>:59                                      ; preds = %41, %56
+  %60 = load i32, i32* %loc2
+  %61 = icmp slt i32 %60, 2147483647
+  br i1 %61, label %44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load i32, i32* %arg0
+  ret i32 %63
+
+ThrowNullRef:                                     ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
 Successfully read GenericEqualityComparer`1.GetHashCode
 
@@ -3694,14 +4558,14 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
   %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load i64, i64 addrspace(1)* %7
@@ -3720,7 +4584,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3750,8 +4614,8 @@ entry:
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
@@ -3796,8 +4660,8 @@ entry:
   %35 = bitcast i16* %34 to i8*
   %36 = getelementptr inbounds i8, i8* %35, i64 2
   %37 = bitcast i8* %36 to i16*
-  %NullCheck4 = icmp ne i16* %37, null
-  br i1 %NullCheck4, label %38, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %37, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %38
 
 ; <label>:38                                      ; preds = %27
   %39 = load i16, i16* %37, align 8
@@ -3824,8 +4688,8 @@ entry:
 
 ; <label>:54                                      ; preds = %22, %43
   %55 = load i16*, i16** %loc4
-  %NullCheck2 = icmp ne i16* %55, null
-  br i1 %NullCheck2, label %56, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i16* %55, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %56
 
 ; <label>:56                                      ; preds = %54
   %57 = load i16, i16* %55, align 8
@@ -3850,11 +4714,11 @@ ThrowNullRef:                                     ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %54
+ThrowNullRef2:                                    ; preds = %54
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %27
+ThrowNullRef4:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3871,8 +4735,8 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -3907,8 +4771,8 @@ entry:
 
 ; <label>:26                                      ; preds = %19
   %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
-  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %28
 
 ; <label>:28                                      ; preds = %26
   %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
@@ -3920,7 +4784,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3972,8 +4836,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
@@ -3984,26 +4848,26 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
-  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
@@ -4014,8 +4878,8 @@ entry:
 ; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
@@ -4024,8 +4888,8 @@ entry:
 
 ; <label>:25                                      ; preds = %1, %16, %23
   %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
-  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
@@ -4036,27 +4900,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %20
+ThrowNullRef10:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4069,8 +4933,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -4081,8 +4945,8 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
@@ -4091,8 +4955,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1, %8
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
@@ -4103,11 +4967,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4128,24 +4992,24 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   store i32 %3, i32* %loc0
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
   %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
   store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck4, label %9, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
@@ -4164,15 +5028,15 @@ entry:
 ; <label>:18                                      ; preds = %70
   %19 = load i16*, i16** %loc3
   %20 = bitcast i16* %19 to i64*
-  %NullCheck10 = icmp ne i64* %20, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %20, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = load i64, i64* %20, align 8
   %23 = load i16*, i16** %loc4
   %24 = bitcast i16* %23 to i64*
-  %NullCheck12 = icmp ne i64* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = load i64, i64* %24, align 8
@@ -4188,8 +5052,8 @@ entry:
   %31 = bitcast i16* %30 to i8*
   %32 = getelementptr inbounds i8, i8* %31, i64 8
   %33 = bitcast i8* %32 to i64*
-  %NullCheck14 = icmp ne i64* %33, null
-  br i1 %NullCheck14, label %34, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = load i64, i64* %33, align 8
@@ -4197,8 +5061,8 @@ entry:
   %37 = bitcast i16* %36 to i8*
   %38 = getelementptr inbounds i8, i8* %37, i64 8
   %39 = bitcast i8* %38 to i64*
-  %NullCheck16 = icmp ne i64* %39, null
-  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %40
 
 ; <label>:40                                      ; preds = %34
   %41 = load i64, i64* %39, align 8
@@ -4214,8 +5078,8 @@ entry:
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %NullCheck18 = icmp ne i64* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = load i64, i64* %48, align 8
@@ -4223,8 +5087,8 @@ entry:
   %52 = bitcast i16* %51 to i8*
   %53 = getelementptr inbounds i8, i8* %52, i64 16
   %54 = bitcast i8* %53 to i64*
-  %NullCheck20 = icmp ne i64* %54, null
-  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64* %54, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %55
 
 ; <label>:55                                      ; preds = %49
   %56 = load i64, i64* %54, align 8
@@ -4262,15 +5126,15 @@ entry:
 ; <label>:74                                      ; preds = %95
   %75 = load i16*, i16** %loc3
   %76 = bitcast i16* %75 to i32*
-  %NullCheck6 = icmp ne i32* %76, null
-  br i1 %NullCheck6, label %77, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32* %76, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %77
 
 ; <label>:77                                      ; preds = %74
   %78 = load i32, i32* %76, align 8
   %79 = load i16*, i16** %loc4
   %80 = bitcast i16* %79 to i32*
-  %NullCheck8 = icmp ne i32* %80, null
-  br i1 %NullCheck8, label %81, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i32* %80, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %81
 
 ; <label>:81                                      ; preds = %77
   %82 = load i32, i32* %80, align 8
@@ -4318,43 +5182,43 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %74
+ThrowNullRef6:                                    ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %77
+ThrowNullRef8:                                    ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %29
+ThrowNullRef14:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %34
+ThrowNullRef16:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4376,8 +5240,8 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load i64, i64 addrspace(1)* %4
@@ -4389,8 +5253,8 @@ entry:
   %12 = load i64, i64* %11
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %5
   %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
@@ -4399,8 +5263,8 @@ entry:
   %18 = load i8, i8* %arg2
   %19 = zext i8 %18 to i32
   %20 = trunc i32 %19 to i8
-  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %15
   %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
@@ -4411,11 +5275,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4442,8 +5306,8 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
@@ -4466,16 +5330,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
   %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = load i64, i64 addrspace(1)* %19
@@ -4500,8 +5364,8 @@ entry:
 ; <label>:35                                      ; preds = %30
   %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
@@ -4514,8 +5378,8 @@ entry:
 
 ; <label>:42                                      ; preds = %1, %38
   %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
-  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
@@ -4526,19 +5390,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %35
+ThrowNullRef2:                                    ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %42
+ThrowNullRef8:                                    ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4551,14 +5415,14 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
@@ -4570,7 +5434,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4583,8 +5447,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
@@ -4613,51 +5477,51 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
   %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
   %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
   %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
   %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
-  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
   store i64 %21, i64 addrspace(1)* %23
   %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %25 = load i64, i64* %loc0
-  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
@@ -4668,27 +5532,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %22
+ThrowNullRef12:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4701,8 +5565,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
@@ -4713,19 +5577,19 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
@@ -4734,8 +5598,8 @@ entry:
 
 ; <label>:15                                      ; preds = %1, %13
   %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
@@ -4746,19 +5610,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %15
+ThrowNullRef8:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4771,8 +5635,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -4831,8 +5695,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
@@ -4882,8 +5746,8 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
-  br i1 %NullCheck, label %17, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %ThrowNullRef, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
@@ -4894,15 +5758,15 @@ entry:
 
 ; <label>:22                                      ; preds = %17
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
-  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
   %26 = load i32, i32 addrspace(1)* %25
   %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
-  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %27, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
@@ -4925,8 +5789,8 @@ entry:
 ; <label>:40                                      ; preds = %17
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
-  br i1 %NullCheck6, label %43, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %41, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
@@ -4938,34 +5802,17 @@ ThrowNullRef:                                     ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %24
+ThrowNullRef4:                                    ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %40
+ThrowNullRef6:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
-}
-
-INFO:  jitting method Object::ReferenceEquals using LLILCJit
-Successfully read Object.ReferenceEquals
-
-define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
-entry:
-  %arg0 = alloca %System.Object addrspace(1)*
-  %arg1 = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
-  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
-  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = icmp eq %System.Object addrspace(1)* %0, %1
-  %3 = sext i1 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
 }
 
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
@@ -4978,21 +5825,21 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
   %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
-  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
@@ -5007,28 +5854,28 @@ entry:
 ; <label>:13                                      ; preds = %8, %12
   %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
   %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
   %21 = load i32, i32 addrspace(1)* %20, align 8
   %22 = add i32 %21, 1
-  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
   store i32 %22, i32 addrspace(1)* %24
   %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
@@ -5039,27 +5886,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5077,7 +5924,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::Setup using LLILCJit
-Failed to read AppDomain.Setup[loadElem]
+Failed to read AppDomain.Setup[unbox]
 INFO:  jitting method Thread::GetDomain using LLILCJit
 Successfully read Thread.GetDomain
 
@@ -5108,8 +5955,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
@@ -5122,14 +5969,14 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
   %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
@@ -5141,11 +5988,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5173,8 +6020,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -5189,7 +6036,328 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
 Failed to read KeyCollection.System.Collections.Generic.IEnumerable<TKey>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Successfully read Enumerator.MoveNext
+
+define i8 @Enumerator.MoveNext(%"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.RuntimeTypeHandle* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*
+  %"$TypeArg" = alloca %System.RuntimeTypeHandle*
+  store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
+  %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 8
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %76, label %12
+
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
+  br label %76
+
+; <label>:13                                      ; preds = %85
+  %14 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck19 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %15
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, i32 0, i32 0
+  %17 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %16, align 8
+  %NullCheck21 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, i32 0, i32 2
+  %20 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %19, align 8
+  %21 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck23 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %22
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, i32 0, i32 2
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %NullCheck25 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 3, i32 %24
+  %NullCheck27 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %32
+
+; <label>:32                                      ; preds = %30
+  %33 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, i32 0, i32 2
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = icmp slt i32 %34, 0
+  br i1 %35, label %68, label %36
+
+; <label>:36                                      ; preds = %32
+  %37 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %38 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck29 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %39
+
+; <label>:39                                      ; preds = %36
+  %40 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, i32 0, i32 0
+  %41 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %40, align 8
+  %NullCheck31 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, i32 0, i32 2
+  %44 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %43, align 8
+  %45 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck33 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, i32 0, i32 2
+  %48 = load i32, i32 addrspace(1)* %47, align 8
+  %NullCheck35 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %49
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = zext i32 %51 to i64
+  %53 = zext i32 %48 to i64
+  %BoundsCheck37 = icmp uge i64 %53, %52
+  br i1 %BoundsCheck37, label %ThrowIndexOutOfRange38, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 3, i32 %48
+  %NullCheck39 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %56
+
+; <label>:56                                      ; preds = %54
+  %57 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, i32 0, i32 0
+  %58 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck41 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %59
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %60, %System.__Canon addrspace(1)* %58)
+  %61 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck43 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  %64 = load i32, i32 addrspace(1)* %63, align 8
+  %65 = add i32 %64, 1
+  %NullCheck45 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  store i32 %65, i32 addrspace(1)* %67
+  ret i8 1
+
+; <label>:68                                      ; preds = %32
+  %69 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck47 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %73 = add i32 %72, 1
+  %NullCheck49 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %74
+
+; <label>:74                                      ; preds = %70
+  %75 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  store i32 %73, i32 addrspace(1)* %75
+  br label %76
+
+; <label>:76                                      ; preds = %8, %12, %74
+  %77 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %78
+
+; <label>:78                                      ; preds = %76
+  %79 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, i32 0, i32 2
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck7 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %82
+
+; <label>:82                                      ; preds = %78
+  %83 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, i32 0, i32 0
+  %84 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %83, align 8
+  %NullCheck9 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %85
+
+; <label>:85                                      ; preds = %82
+  %86 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, i32 0, i32 7
+  %87 = load i32, i32 addrspace(1)* %86, align 8
+  %88 = icmp ult i32 %80, %87
+  br i1 %88, label %13, label %89
+
+; <label>:89                                      ; preds = %85
+  %90 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %91 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck11 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %92
+
+; <label>:92                                      ; preds = %89
+  %93 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, i32 0, i32 0
+  %94 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck13 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %95
+
+; <label>:95                                      ; preds = %92
+  %96 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, i32 0, i32 7
+  %97 = load i32, i32 addrspace(1)* %96, align 8
+  %98 = add i32 %97, 1
+  %NullCheck15 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %99
+
+; <label>:99                                      ; preds = %95
+  %100 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, i32 0, i32 2
+  store i32 %98, i32 addrspace(1)* %100
+  %101 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck17 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %102
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %103, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %92
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef22:                                   ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef24:                                   ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef26:                                   ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef28:                                   ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef30:                                   ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef32:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef34:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef36:                                   ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange38:                           ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef40:                                   ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef42:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef44:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef46:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef48:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef50:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -5200,8 +6368,8 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -5232,9 +6400,9 @@ Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
 Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
-Failed to read String.MakeSeparatorList[loadElemA]
+Failed to read String.MakeSeparatorList[storeElem]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
-Failed to read String.InternalSplitKeepEmptyEntries[loadElem]
+Failed to read String.InternalSplitKeepEmptyEntries[storeElem]
 INFO:  jitting method Path::IsRelative using LLILCJit
 Successfully read Path.IsRelative
 
@@ -5243,8 +6411,8 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -5254,8 +6422,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
@@ -5271,8 +6439,8 @@ entry:
 
 ; <label>:17                                      ; preds = %7
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
@@ -5288,8 +6456,8 @@ entry:
 
 ; <label>:29                                      ; preds = %19
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %31
 
 ; <label>:31                                      ; preds = %29
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
@@ -5300,8 +6468,8 @@ entry:
 
 ; <label>:36                                      ; preds = %31
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
-  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %37, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
@@ -5312,8 +6480,8 @@ entry:
 
 ; <label>:43                                      ; preds = %31, %38
   %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
-  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %45
 
 ; <label>:45                                      ; preds = %43
   %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
@@ -5324,8 +6492,8 @@ entry:
 
 ; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %50
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
@@ -5336,8 +6504,8 @@ entry:
 
 ; <label>:57                                      ; preds = %1, %7, %19, %45, %52
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
-  br i1 %NullCheck14, label %59, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %59
 
 ; <label>:59                                      ; preds = %57
   %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
@@ -5347,8 +6515,8 @@ entry:
 
 ; <label>:63                                      ; preds = %59
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
@@ -5359,8 +6527,8 @@ entry:
 
 ; <label>:70                                      ; preds = %65
   %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
-  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.String addrspace(1)* %71, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %72
 
 ; <label>:72                                      ; preds = %70
   %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
@@ -5379,39 +6547,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %17
+ThrowNullRef4:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %29
+ThrowNullRef6:                                    ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %36
+ThrowNullRef8:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %43
+ThrowNullRef10:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %50
+ThrowNullRef12:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %57
+ThrowNullRef14:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %63
+ThrowNullRef16:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %70
+ThrowNullRef18:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5419,7 +6587,293 @@ ThrowNullRef17:                                   ; preds = %70
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
-Failed to read String.TrimHelper[loadElem]
+Successfully read String.TrimHelper
+
+define %System.String addrspace(1)* @String.TrimHelper(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i16
+  %loc4 = alloca i32
+  %loc5 = alloca i16
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = sub i32 %3, 1
+  store i32 %4, i32* %loc0
+  store i32 0, i32* %loc1
+  %5 = load i32, i32* %arg2
+  %6 = icmp eq i32 %5, 1
+  br i1 %6, label %62, label %7
+
+; <label>:7                                       ; preds = %1
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:8                                       ; preds = %58
+  store i32 0, i32* %loc2
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load i32, i32* %loc1
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2, i32 %10
+  %13 = load i16, i16 addrspace(1)* %12
+  %14 = zext i16 %13 to i32
+  %15 = trunc i32 %14 to i16
+  store i16 %15, i16* %loc3
+  store i32 0, i32* %loc2
+  br label %34
+
+; <label>:16                                      ; preds = %37
+  %17 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %18 = load i32, i32* %loc2
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %17, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %19
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = zext i32 %18 to i64
+  %BoundsCheck = icmp uge i64 %23, %22
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %24
+
+; <label>:24                                      ; preds = %19
+  %25 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 3, i32 %18
+  %26 = load i16, i16 addrspace(1)* %25, align 8
+  %27 = zext i16 %26 to i32
+  %28 = load i16, i16* %loc3
+  %29 = zext i16 %28 to i32
+  %30 = icmp eq i32 %27, %29
+  br i1 %30, label %43, label %31
+
+; <label>:31                                      ; preds = %24
+  %32 = load i32, i32* %loc2
+  %33 = add i32 %32, 1
+  store i32 %33, i32* %loc2
+  br label %34
+
+; <label>:34                                      ; preds = %11, %31
+  %35 = load i32, i32* %loc2
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = icmp slt i32 %35, %41
+  br i1 %42, label %16, label %43
+
+; <label>:43                                      ; preds = %24, %37
+  %44 = load i32, i32* %loc2
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %45, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp eq i32 %44, %50
+  br i1 %51, label %62, label %52
+
+; <label>:52                                      ; preds = %46
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %7, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %57, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %58
+
+; <label>:58                                      ; preds = %55
+  %59 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %60 = load i32, i32 addrspace(1)* %59
+  %61 = icmp slt i32 %56, %60
+  br i1 %61, label %8, label %62
+
+; <label>:62                                      ; preds = %1, %46, %58
+  %63 = load i32, i32* %arg2
+  %64 = icmp eq i32 %63, 0
+  br i1 %64, label %122, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %66, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %67
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %66, i32 0, i32 1
+  %69 = load i32, i32 addrspace(1)* %68
+  %70 = sub i32 %69, 1
+  store i32 %70, i32* %loc0
+  br label %118
+
+; <label>:71                                      ; preds = %118
+  store i32 0, i32* %loc4
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %73 = load i32, i32* %loc0
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %74
+
+; <label>:74                                      ; preds = %71
+  %75 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 2, i32 %73
+  %76 = load i16, i16 addrspace(1)* %75
+  %77 = zext i16 %76 to i32
+  %78 = trunc i32 %77 to i16
+  store i16 %78, i16* %loc5
+  store i32 0, i32* %loc4
+  br label %97
+
+; <label>:79                                      ; preds = %100
+  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %81 = load i32, i32* %loc4
+  %NullCheck19 = icmp eq %"System.Char[]" addrspace(1)* %80, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
+
+; <label>:82                                      ; preds = %79
+  %83 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 1
+  %84 = load i32, i32 addrspace(1)* %83
+  %85 = zext i32 %84 to i64
+  %86 = zext i32 %81 to i64
+  %BoundsCheck21 = icmp uge i64 %86, %85
+  br i1 %BoundsCheck21, label %ThrowIndexOutOfRange22, label %87
+
+; <label>:87                                      ; preds = %82
+  %88 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 3, i32 %81
+  %89 = load i16, i16 addrspace(1)* %88, align 8
+  %90 = zext i16 %89 to i32
+  %91 = load i16, i16* %loc5
+  %92 = zext i16 %91 to i32
+  %93 = icmp eq i32 %90, %92
+  br i1 %93, label %106, label %94
+
+; <label>:94                                      ; preds = %87
+  %95 = load i32, i32* %loc4
+  %96 = add i32 %95, 1
+  store i32 %96, i32* %loc4
+  br label %97
+
+; <label>:97                                      ; preds = %74, %94
+  %98 = load i32, i32* %loc4
+  %99 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck15 = icmp eq %"System.Char[]" addrspace(1)* %99, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %100
+
+; <label>:100                                     ; preds = %97
+  %101 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %99, i32 0, i32 1
+  %102 = load i32, i32 addrspace(1)* %101
+  %103 = zext i32 %102 to i64
+  %104 = trunc i64 %103 to i32
+  %105 = icmp slt i32 %98, %104
+  br i1 %105, label %79, label %106
+
+; <label>:106                                     ; preds = %87, %100
+  %107 = load i32, i32* %loc4
+  %108 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck17 = icmp eq %"System.Char[]" addrspace(1)* %108, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %109
+
+; <label>:109                                     ; preds = %106
+  %110 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %108, i32 0, i32 1
+  %111 = load i32, i32 addrspace(1)* %110
+  %112 = zext i32 %111 to i64
+  %113 = trunc i64 %112 to i32
+  %114 = icmp eq i32 %107, %113
+  br i1 %114, label %122, label %115
+
+; <label>:115                                     ; preds = %109
+  %116 = load i32, i32* %loc0
+  %117 = sub i32 %116, 1
+  store i32 %117, i32* %loc0
+  br label %118
+
+; <label>:118                                     ; preds = %67, %115
+  %119 = load i32, i32* %loc0
+  %120 = load i32, i32* %loc1
+  %121 = icmp sge i32 %119, %120
+  br i1 %121, label %71, label %122
+
+; <label>:122                                     ; preds = %62, %109, %118
+  %123 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %124 = load i32, i32* %loc1
+  %125 = load i32, i32* %loc0
+  %126 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %123, i32 %124, i32 %125)
+  ret %System.String addrspace(1)* %126
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %97
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange22:                           ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
 Successfully read String.CreateTrimmedString
 
@@ -5439,8 +6893,8 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
@@ -5535,8 +6989,8 @@ entry:
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i64 2872
   %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
   %8 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %7
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %3
   %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
@@ -5553,8 +7007,8 @@ entry:
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 2864
   %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
   %21 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %20
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
-  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %22
 
 ; <label>:22                                      ; preds = %16
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
@@ -5569,7 +7023,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %16
+ThrowNullRef2:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5586,8 +7040,8 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5613,8 +7067,8 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
@@ -5632,8 +7086,8 @@ entry:
 
 ; <label>:12                                      ; preds = %4
   %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
@@ -5644,8 +7098,8 @@ entry:
 
 ; <label>:19                                      ; preds = %14
   %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %19
   %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
@@ -5660,21 +7114,21 @@ entry:
   %31 = zext i16 %30 to i32
   %32 = bitcast i8* %29 to i16*
   %33 = trunc i32 %31 to i16
-  %NullCheck6 = icmp ne i16* %32, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i16* %32, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %21
   store i16 %33, i16* %32, align 8
   %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %36
 
 ; <label>:36                                      ; preds = %34
   %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
   %38 = load i32, i32 addrspace(1)* %37, align 8
   %39 = add i32 %38, 1
-  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %40
 
 ; <label>:40                                      ; preds = %36
   %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
@@ -5683,16 +7137,16 @@ entry:
 
 ; <label>:42                                      ; preds = %14
   %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
-  br i1 %NullCheck12, label %44, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
   %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
   %47 = load i16, i16* %arg1
   %48 = zext i16 %47 to i32
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = trunc i32 %48 to i16
@@ -5703,31 +7157,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %19
+ThrowNullRef4:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %21
+ThrowNullRef6:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %36
+ThrowNullRef10:                                   ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %42
+ThrowNullRef12:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %44
+ThrowNullRef14:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5740,8 +7194,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -5752,8 +7206,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
@@ -5762,14 +7216,14 @@ entry:
 
 ; <label>:11                                      ; preds = %1
   %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
@@ -5779,15 +7233,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5808,8 +7262,8 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5822,8 +7276,8 @@ entry:
 
 ; <label>:8                                       ; preds = %3
   %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
@@ -5842,15 +7296,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
-  br i1 %NullCheck4, label %22, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
   %24 = load i16*, i16* addrspace(1)* %23, align 8
   %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %25, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
@@ -5859,8 +7313,8 @@ entry:
   store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
@@ -5874,8 +7328,8 @@ entry:
 
 ; <label>:37                                      ; preds = %65
   %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %37
   %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
@@ -5886,16 +7340,16 @@ entry:
   %45 = bitcast i16* %41 to i8*
   %46 = getelementptr inbounds i8, i8* %45, i64 %44
   %47 = bitcast i8* %46 to i16*
-  %NullCheck14 = icmp ne i16* %47, null
-  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %47, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %48
 
 ; <label>:48                                      ; preds = %39
   %49 = load i16, i16* %47, align 8
   %50 = zext i16 %49 to i32
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %52 = load i32, i32* %loc1
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %53
 
 ; <label>:53                                      ; preds = %48
   %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
@@ -5916,8 +7370,8 @@ entry:
 ; <label>:62                                      ; preds = %36, %59
   %63 = load i32, i32* %loc1
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck10, label %65, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %65
 
 ; <label>:65                                      ; preds = %62
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
@@ -5936,15 +7390,15 @@ entry:
 
 ; <label>:74                                      ; preds = %70
   %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
-  br i1 %NullCheck18, label %76, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %76
 
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
   %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
-  br i1 %NullCheck20, label %80, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
   %81 = load i64, i64 addrspace(1)* %79
@@ -5958,8 +7412,8 @@ entry:
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
   %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
-  br i1 %NullCheck22, label %92, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.String addrspace(1)* %90, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %92
 
 ; <label>:92                                      ; preds = %80
   %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
@@ -5969,15 +7423,15 @@ entry:
 
 ; <label>:96                                      ; preds = %70
   %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
-  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %98
 
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
   %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
-  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
   %103 = load i64, i64 addrspace(1)* %101
@@ -5991,8 +7445,8 @@ entry:
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
   %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
-  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.String addrspace(1)* %112, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %114
 
 ; <label>:114                                     ; preds = %102
   %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
@@ -6004,59 +7458,59 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %20
+ThrowNullRef4:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %22
+ThrowNullRef6:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %26
+ThrowNullRef8:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %62
+ThrowNullRef10:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %48
+ThrowNullRef16:                                   ; preds = %48
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %74
+ThrowNullRef18:                                   ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %76
+ThrowNullRef20:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %80
+ThrowNullRef22:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %96
+ThrowNullRef24:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %98
+ThrowNullRef26:                                   ; preds = %98
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %102
+ThrowNullRef28:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6069,15 +7523,15 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
   %3 = load i16*, i16* addrspace(1)* %2, align 8
   %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
@@ -6087,8 +7541,8 @@ entry:
   %10 = bitcast i16* %3 to i8*
   %11 = getelementptr inbounds i8, i8* %10, i64 %9
   %12 = bitcast i8* %11 to i16*
-  %NullCheck4 = icmp ne i16* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %5
   store i16 0, i16* %12, align 8
@@ -6098,11 +7552,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6119,8 +7573,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -6131,8 +7585,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
@@ -6144,15 +7598,15 @@ entry:
 
 ; <label>:14                                      ; preds = %1
   %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
   %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
   %21 = load i64, i64 addrspace(1)* %19
@@ -6171,15 +7625,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %14
+ThrowNullRef4:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %16
+ThrowNullRef6:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6302,14 +7756,6 @@ entry:
   ret %System.String addrspace(1)* %57
 }
 
-INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
-Successfully read RuntimeHelpers.get_OffsetToStringData
-
-define i32 @RuntimeHelpers.get_OffsetToStringData() {
-entry:
-  ret i32 12
-}
-
 INFO:  jitting method String::Equals using LLILCJit
 Successfully read String.Equals
 
@@ -6381,8 +7827,8 @@ entry:
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
-  br i1 %NullCheck24, label %29, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
   %30 = load i64, i64 addrspace(1)* %28
@@ -6397,8 +7843,8 @@ entry:
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
-  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
   %43 = load i64, i64 addrspace(1)* %41
@@ -6418,8 +7864,8 @@ entry:
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
   %59 = load i64, i64 addrspace(1)* %57
@@ -6434,8 +7880,8 @@ entry:
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck22, label %71, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
   %72 = load i64, i64 addrspace(1)* %70
@@ -6455,8 +7901,8 @@ entry:
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
-  br i1 %NullCheck16, label %87, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = load i64, i64 addrspace(1)* %86
@@ -6471,8 +7917,8 @@ entry:
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck18, label %100, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
   %101 = load i64, i64 addrspace(1)* %99
@@ -6492,8 +7938,8 @@ entry:
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
-  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
   %117 = load i64, i64 addrspace(1)* %115
@@ -6508,8 +7954,8 @@ entry:
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
-  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
   %130 = load i64, i64 addrspace(1)* %128
@@ -6528,15 +7974,15 @@ entry:
 
 ; <label>:142                                     ; preds = %22
   %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
-  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %143, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %144
 
 ; <label>:144                                     ; preds = %142
   %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
   %146 = load i32, i32 addrspace(1)* %145
   %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
-  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %147, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %148
 
 ; <label>:148                                     ; preds = %144
   %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
@@ -6557,15 +8003,15 @@ entry:
 
 ; <label>:159                                     ; preds = %22
   %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
-  br i1 %NullCheck, label %161, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %ThrowNullRef, label %161
 
 ; <label>:161                                     ; preds = %159
   %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
   %163 = load i32, i32 addrspace(1)* %162
   %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
-  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %164, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %165
 
 ; <label>:165                                     ; preds = %161
   %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
@@ -6578,8 +8024,8 @@ entry:
 
 ; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
-  br i1 %NullCheck4, label %172, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %171, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %172
 
 ; <label>:172                                     ; preds = %170
   %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
@@ -6589,8 +8035,8 @@ entry:
 
 ; <label>:176                                     ; preds = %172
   %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
-  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %177, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %178
 
 ; <label>:178                                     ; preds = %176
   %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
@@ -6629,55 +8075,55 @@ ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %161
+ThrowNullRef2:                                    ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %170
+ThrowNullRef4:                                    ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %176
+ThrowNullRef6:                                    ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %142
+ThrowNullRef8:                                    ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %144
+ThrowNullRef10:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %113
+ThrowNullRef12:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %116
+ThrowNullRef14:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %84
+ThrowNullRef16:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %87
+ThrowNullRef18:                                   ; preds = %87
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %55
+ThrowNullRef20:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %58
+ThrowNullRef22:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %26
+ThrowNullRef24:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %29
+ThrowNullRef26:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,8 +8161,8 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck, label %14, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %ThrowNullRef, label %14
 
 ; <label>:14                                      ; preds = %8
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
@@ -6760,8 +8206,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
@@ -6770,14 +8216,14 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32, i32* %loc0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %10
   %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
   %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
@@ -6790,15 +8236,15 @@ entry:
 ; <label>:25                                      ; preds = %19
   %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
-  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
   %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
@@ -6807,8 +8253,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %37 = load i32, i32* %loc0
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %38, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %38
 
 ; <label>:38                                      ; preds = %32
   %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
@@ -6817,14 +8263,14 @@ entry:
 
 ; <label>:40                                      ; preds = %19
   %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %40
   %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
   %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
-  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
-  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
@@ -6832,8 +8278,8 @@ entry:
   %48 = zext i32 %47 to i64
   %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
-  br i1 %NullCheck16, label %51, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %51
 
 ; <label>:51                                      ; preds = %45
   %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
@@ -6847,15 +8293,15 @@ entry:
 ; <label>:57                                      ; preds = %51
   %58 = load i16*, i16** %arg1
   %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
-  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %60
 
 ; <label>:60                                      ; preds = %57
   %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
   %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
-  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %64
 
 ; <label>:64                                      ; preds = %60
   %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
@@ -6864,22 +8310,22 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
   %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
-  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %70
 
 ; <label>:70                                      ; preds = %64
   %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
   %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
-  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
-  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
   %75 = load i32, i32 addrspace(1)* %74
   %76 = zext i32 %75 to i64
   %77 = trunc i64 %76 to i32
-  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
-  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %78
 
 ; <label>:78                                      ; preds = %73
   %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
@@ -6901,8 +8347,8 @@ entry:
   %90 = bitcast i16* %86 to i8*
   %91 = getelementptr inbounds i8, i8* %90, i64 %89
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %93
 
 ; <label>:93                                      ; preds = %80
   %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
@@ -6912,8 +8358,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %99 = load i32, i32* %loc2
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %100
 
 ; <label>:100                                     ; preds = %93
   %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
@@ -6928,63 +8374,63 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %25
+ThrowNullRef6:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %32
+ThrowNullRef10:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %40
+ThrowNullRef12:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %45
+ThrowNullRef16:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %57
+ThrowNullRef18:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %60
+ThrowNullRef20:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %64
+ThrowNullRef22:                                   ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %70
+ThrowNullRef24:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %73
+ThrowNullRef26:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %80
+ThrowNullRef28:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %93
+ThrowNullRef30:                                   ; preds = %93
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7004,8 +8450,8 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
@@ -7033,43 +8479,43 @@ entry:
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %14
   %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
   %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   %28 = load i32, i32 addrspace(1)* %27, align 8
   %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
-  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %30
 
 ; <label>:30                                      ; preds = %26
   %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
   %32 = load i32, i32 addrspace(1)* %31, align 8
   %33 = add i32 %28, %32
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %34
 
 ; <label>:34                                      ; preds = %30
   %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   store i32 %33, i32 addrspace(1)* %35
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
   store i32 0, i32 addrspace(1)* %38
   %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %40
 
 ; <label>:40                                      ; preds = %37
   %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
@@ -7082,8 +8528,8 @@ entry:
 
 ; <label>:47                                      ; preds = %40
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
@@ -7098,8 +8544,8 @@ entry:
   %54 = load i32, i32* %loc0
   %55 = sext i32 %54 to i64
   %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
-  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %57
 
 ; <label>:57                                      ; preds = %52
   %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
@@ -7110,68 +8556,35 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %14
+ThrowNullRef2:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %23
+ThrowNullRef4:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %26
+ThrowNullRef6:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %30
+ThrowNullRef8:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %34
+ThrowNullRef10:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %47
+ThrowNullRef14:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %52
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-}
-
-INFO:  jitting method StringBuilder::get_Length using LLILCJit
-Successfully read StringBuilder.get_Length
-
-define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.StringBuilder addrspace(1)*
-  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
-  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
-
-; <label>:1                                       ; preds = %entry
-  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %3 = load i32, i32 addrspace(1)* %2, align 8
-  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
-
-; <label>:5                                       ; preds = %1
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = add i32 %3, %7
-  ret i32 %8
-
-ThrowNullRef:                                     ; preds = %entry
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef16:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7213,70 +8626,70 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
   %6 = load i32, i32 addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
   store i32 %6, i32 addrspace(1)* %8
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
   %13 = load i32, i32 addrspace(1)* %12, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
   store i32 %13, i32 addrspace(1)* %15
   %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
-  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %18
 
 ; <label>:18                                      ; preds = %14
   %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
   %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
   %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
   %34 = load i32, i32 addrspace(1)* %33, align 8
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
-  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
@@ -7287,39 +8700,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %28
+ThrowNullRef16:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %32
+ThrowNullRef18:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7455,13 +8868,13 @@ entry:
 ; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
@@ -7477,16 +8890,16 @@ entry:
 
 ; <label>:18                                      ; preds = %15
   %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
   store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
   %22 = load i32, i32* %loc0
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %24
 
 ; <label>:24                                      ; preds = %20
   %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
@@ -7498,13 +8911,13 @@ entry:
 ; <label>:28                                      ; preds = %15, %24
   %29 = load i32, i32* %arg1
   %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %31
   %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
@@ -7517,20 +8930,20 @@ entry:
   %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
-  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
   %46 = load i32, i32 addrspace(1)* %45, align 8
   %47 = sub i32 %40, %46
-  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
-  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i32 addrspace(1)* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %48
 
 ; <label>:48                                      ; preds = %44
   store i32 %47, i32 addrspace(1)* %39, align 8
@@ -7538,21 +8951,21 @@ entry:
 
 ; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
-  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %51
 
 ; <label>:51                                      ; preds = %49
   %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %53
 
 ; <label>:53                                      ; preds = %51
   %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
   %55 = load i32, i32 addrspace(1)* %54, align 8
   %56 = load i32, i32* %arg2
   %57 = sub i32 %55, %56
-  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %58
 
 ; <label>:58                                      ; preds = %53
   %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
@@ -7562,13 +8975,13 @@ entry:
 ; <label>:60                                      ; preds = %33, %58
   %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
   %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
-  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %63
 
 ; <label>:63                                      ; preds = %60
   %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
-  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
-  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
@@ -7578,15 +8991,15 @@ entry:
 
 ; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
-  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i32 addrspace(1)* %69, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %70
 
 ; <label>:70                                      ; preds = %68
   %71 = load i32, i32 addrspace(1)* %69, align 8
   store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
-  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
@@ -7596,8 +9009,8 @@ entry:
   store i32 %77, i32* %loc4
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
-  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %80
 
 ; <label>:80                                      ; preds = %73
   %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
@@ -7607,71 +9020,71 @@ entry:
 ; <label>:83                                      ; preds = %80
   store i32 0, i32* %loc3
   %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
-  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
-  br i1 %NullCheck26, label %88, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i32 addrspace(1)* %87, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %88
 
 ; <label>:88                                      ; preds = %85
   %89 = load i32, i32 addrspace(1)* %87, align 8
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
-  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %90
 
 ; <label>:90                                      ; preds = %88
   %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
   store i32 %89, i32 addrspace(1)* %91
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
-  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
-  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %96
 
 ; <label>:96                                      ; preds = %94
   %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
-  br i1 %NullCheck34, label %100, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %100
 
 ; <label>:100                                     ; preds = %96
   %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
-  br i1 %NullCheck36, label %102, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %102
 
 ; <label>:102                                     ; preds = %100
   %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
   %104 = load i32, i32 addrspace(1)* %103, align 8
   %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
-  br i1 %NullCheck38, label %106, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %106
 
 ; <label>:106                                     ; preds = %102
   %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
-  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
-  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %108
 
 ; <label>:108                                     ; preds = %106
   %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
   %110 = load i32, i32 addrspace(1)* %109, align 8
   %111 = add i32 %104, %110
-  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %112
 
 ; <label>:112                                     ; preds = %108
   %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
   store i32 %111, i32 addrspace(1)* %113
   %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
-  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i32 addrspace(1)* %114, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %115
 
 ; <label>:115                                     ; preds = %112
   %116 = load i32, i32 addrspace(1)* %114, align 8
@@ -7681,19 +9094,19 @@ entry:
 ; <label>:118                                     ; preds = %115
   %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
-  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %121
 
 ; <label>:121                                     ; preds = %118
   %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
-  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
-  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %123
 
 ; <label>:123                                     ; preds = %121
   %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
   %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
-  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
-  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %126
 
 ; <label>:126                                     ; preds = %123
   %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
@@ -7705,8 +9118,8 @@ entry:
 
 ; <label>:130                                     ; preds = %80, %115, %126
   %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %132
 
 ; <label>:132                                     ; preds = %130
   %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7715,8 +9128,8 @@ entry:
   %136 = load i32, i32* %loc3
   %137 = sub i32 %135, %136
   %138 = sub i32 %134, %137
-  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %139
 
 ; <label>:139                                     ; preds = %132
   %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7728,16 +9141,16 @@ entry:
 
 ; <label>:144                                     ; preds = %139
   %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
-  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %146
 
 ; <label>:146                                     ; preds = %144
   %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
   %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
   %149 = load i32, i32* %loc2
   %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
-  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %151
 
 ; <label>:151                                     ; preds = %146
   %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
@@ -7754,145 +9167,249 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %18
+ThrowNullRef4:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %31
+ThrowNullRef10:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %44
+ThrowNullRef16:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %68
+ThrowNullRef18:                                   ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %70
+ThrowNullRef20:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %73
+ThrowNullRef22:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %83
+ThrowNullRef24:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %85
+ThrowNullRef26:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %88
+ThrowNullRef28:                                   ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %90
+ThrowNullRef30:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %94
+ThrowNullRef32:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %96
+ThrowNullRef34:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %100
+ThrowNullRef36:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %102
+ThrowNullRef38:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %106
+ThrowNullRef40:                                   ; preds = %106
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %108
+ThrowNullRef42:                                   ; preds = %108
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %112
+ThrowNullRef44:                                   ; preds = %112
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %118
+ThrowNullRef46:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %121
+ThrowNullRef48:                                   ; preds = %121
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %123
+ThrowNullRef50:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %130
+ThrowNullRef52:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %132
+ThrowNullRef54:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %144
+ThrowNullRef56:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %146
+ThrowNullRef58:                                   ; preds = %146
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %60
+ThrowNullRef60:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %63
+ThrowNullRef62:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %49
+ThrowNullRef64:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %51
+ThrowNullRef66:                                   ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %53
+ThrowNullRef68:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(%"System.Char[]" addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %arg0 = alloca %"System.Char[]" addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store %"System.Char[]" addrspace(1)* %param0, %"System.Char[]" addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load i32, i32* %arg4
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %43, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %38, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg1
+  %13 = load i32, i32* %arg4
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %38, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %24 = load i32, i32* %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %35 = load i32, i32* %arg3
+  %36 = load i32, i32* %arg4
+  %37 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %37, %"System.Char[]" addrspace(1)* %34, i32 %35, i32 %36)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:38                                      ; preds = %5, %16
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Successfully read Buffer._Memmove
 
@@ -7914,7 +9431,7 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[loadElem]
+Failed to read AppDomain.SetDataHelper[storeElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -7923,8 +9440,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
@@ -7934,8 +9451,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
@@ -7947,15 +9464,15 @@ entry:
   %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
   %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
@@ -7966,15 +9483,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7992,7 +9509,79 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
-Failed to read Dictionary`2.TryGetValue[loadElemA]
+Successfully read Dictionary`2.TryGetValue
+
+define i8 @"Dictionary`2.TryGetValue"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)* addrspace(1)* %param2) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  %arg2 = alloca %System.__Canon addrspace(1)* addrspace(1)*
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  store %System.__Canon addrspace(1)* addrspace(1)* %param2, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  store i32 %2, i32* %loc0
+  %3 = load i32, i32* %loc0
+  %4 = icmp slt i32 %3, 0
+  br i1 %4, label %22, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 2
+  %10 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %9, align 8
+  %11 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = zext i32 %11 to i64
+  %BoundsCheck = icmp uge i64 %16, %15
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 3, i32 %11
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %20, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %6, %System.__Canon addrspace(1)* %21)
+  ret i8 1
+
+; <label>:22                                      ; preds = %entry
+  %23 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %23, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -8058,8 +9647,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
@@ -8091,8 +9680,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
@@ -8171,15 +9760,15 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck, label %19, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %ThrowNullRef, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
   %21 = load i32, i32 addrspace(1)* %20
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
@@ -8202,7 +9791,7 @@ ThrowNullRef:                                     ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %19
+ThrowNullRef2:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8248,8 +9837,8 @@ entry:
   %0 = alloca %System.AppDomainHandle
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %1 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %1, i32 0, i32 15
@@ -8269,8 +9858,8 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
@@ -8286,7 +9875,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -8299,8 +9888,8 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -8327,8 +9916,8 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
@@ -8352,8 +9941,8 @@ entry:
   %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
   store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
@@ -8363,8 +9952,8 @@ entry:
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
@@ -8374,8 +9963,8 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %9
   %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
@@ -8384,8 +9973,8 @@ entry:
 
 ; <label>:18                                      ; preds = %3, %16
   %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
@@ -8397,15 +9986,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %18
+ThrowNullRef6:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8418,8 +10007,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
@@ -8453,15 +10042,15 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
@@ -8473,7 +10062,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8481,7 +10070,7 @@ ThrowNullRef1:                                    ; preds = %1
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
 Failed to read Dictionary`2.System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
@@ -8506,8 +10095,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
@@ -8524,8 +10113,8 @@ entry:
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -8544,7 +10133,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8577,8 +10166,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = load i64, i64* %arg2
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = trunc i32 %3 to i8
@@ -8634,46 +10223,46 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
   %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
-  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
-  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
-  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
@@ -8684,27 +10273,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %20
+ThrowNullRef12:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8717,8 +10306,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -8756,22 +10345,22 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
   %9 = load i64, i64 addrspace(1)* %8, align 8
   %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
   %13 = load i64, i64 addrspace(1)* %12, align 8
   %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %11
   %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
@@ -8788,11 +10377,11 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8882,8 +10471,8 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
@@ -8900,8 +10489,8 @@ entry:
 ; <label>:8                                       ; preds = %1
   %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
   %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
@@ -8911,15 +10500,15 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
   %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
   %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
-  br i1 %NullCheck6, label %21, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
@@ -8946,15 +10535,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8992,15 +10581,15 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
   store i8 %3, i8 addrspace(1)* %5
   %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
@@ -9011,7 +10600,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9027,8 +10616,8 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -9041,8 +10630,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
@@ -9058,7 +10647,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9080,8 +10669,8 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
@@ -9096,8 +10685,8 @@ entry:
 ; <label>:12                                      ; preds = %6
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
@@ -9112,8 +10701,8 @@ entry:
 ; <label>:21                                      ; preds = %15
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
@@ -9128,8 +10717,8 @@ entry:
 ; <label>:30                                      ; preds = %24
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %31, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
@@ -9144,8 +10733,8 @@ entry:
 ; <label>:39                                      ; preds = %33
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
-  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %40, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %42
 
 ; <label>:42                                      ; preds = %39
   %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
@@ -9164,19 +10753,19 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %21
+ThrowNullRef4:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %30
+ThrowNullRef6:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %39
+ThrowNullRef8:                                    ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9243,8 +10832,8 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
@@ -9264,57 +10853,57 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
   store i8 0, i8 addrspace(1)* %2
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
   store i8 0, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
   store i8 0, i8 addrspace(1)* %17
   %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
   store i8 0, i8 addrspace(1)* %20
   %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
-  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
@@ -9325,31 +10914,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %19
+ThrowNullRef14:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9367,8 +10956,8 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
@@ -9380,8 +10969,8 @@ entry:
 
 ; <label>:9                                       ; preds = %4
   %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %9
   %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
@@ -9395,7 +10984,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef2:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9420,8 +11009,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
@@ -9512,8 +11101,8 @@ entry:
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
@@ -9524,8 +11113,8 @@ entry:
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = load i64, i64 addrspace(1)* %12
@@ -9537,8 +11126,8 @@ entry:
   %20 = load i64, i64* %19
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
-  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %13
   %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
@@ -9555,8 +11144,8 @@ entry:
 ; <label>:30                                      ; preds = %25
   %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %32 = load i32, i32* %arg2
-  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
-  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
@@ -9570,15 +11159,15 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %30
+ThrowNullRef2:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9622,87 +11211,87 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
   %10 = load i8, i8 addrspace(1)* %9, align 8
   %11 = zext i8 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %8
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
   store i8 %12, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
   %19 = load i8, i8 addrspace(1)* %18, align 8
   %20 = zext i8 %19 to i32
   %21 = trunc i32 %20 to i8
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
   store i8 %21, i8 addrspace(1)* %23
   %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
   %28 = load i8, i8 addrspace(1)* %27, align 8
   %29 = zext i8 %28 to i32
   %30 = trunc i32 %29 to i8
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
-  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %31
 
 ; <label>:31                                      ; preds = %26
   %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
   store i8 %30, i8 addrspace(1)* %32
   %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
-  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
-  br i1 %NullCheck14, label %40, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %40
 
 ; <label>:40                                      ; preds = %35
   %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
   store i8 %39, i8 addrspace(1)* %41
   %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
-  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %44
 
 ; <label>:44                                      ; preds = %40
   %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
   %46 = load i8, i8 addrspace(1)* %45, align 8
   %47 = zext i8 %46 to i32
   %48 = trunc i32 %47 to i8
-  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
   store i8 %48, i8 addrspace(1)* %50
   %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
-  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
@@ -9713,29 +11302,29 @@ entry:
 ; <label>:56                                      ; preds = %52
   %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
-  br i1 %NullCheck22, label %59, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
   %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
   %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
-  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
-  br i1 %NullCheck24, label %63, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
   %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
-  br i1 %NullCheck26, label %66, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
   %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
-  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
-  br i1 %NullCheck28, label %69, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %69
 
 ; <label>:69                                      ; preds = %66
   %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
@@ -9744,15 +11333,15 @@ entry:
 
 ; <label>:71                                      ; preds = %105
   %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
-  br i1 %NullCheck34, label %73, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %73
 
 ; <label>:73                                      ; preds = %71
   %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
   %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
   %76 = load i32, i32* %loc0
-  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
-  br i1 %NullCheck36, label %77, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
@@ -9766,8 +11355,8 @@ entry:
 
 ; <label>:83                                      ; preds = %77
   %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
-  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
@@ -9775,14 +11364,14 @@ entry:
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
   %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
-  br i1 %NullCheck40, label %91, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
 ; <label>:91                                      ; preds = %85
   %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
   %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
-  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck42, label %94, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %94
 
 ; <label>:94                                      ; preds = %91
   %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
@@ -9798,14 +11387,14 @@ entry:
 ; <label>:99                                      ; preds = %69, %96
   %100 = load i32, i32* %loc0
   %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
-  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %102
 
 ; <label>:102                                     ; preds = %99
   %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
   %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
-  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
-  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
@@ -9819,87 +11408,87 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %26
+ThrowNullRef10:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %31
+ThrowNullRef12:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %35
+ThrowNullRef14:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %40
+ThrowNullRef16:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %56
+ThrowNullRef22:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %59
+ThrowNullRef24:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %63
+ThrowNullRef26:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %66
+ThrowNullRef28:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %102
+ThrowNullRef32:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %71
+ThrowNullRef34:                                   ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %73
+ThrowNullRef36:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %83
+ThrowNullRef38:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %85
+ThrowNullRef40:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %91
+ThrowNullRef42:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9943,15 +11532,15 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
   %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
@@ -9961,28 +11550,28 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
   %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %12
   %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
   %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
   %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
-  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
@@ -9993,23 +11582,23 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %12
+ThrowNullRef6:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10031,15 +11620,15 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
   %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = load i64, i64 addrspace(1)* %7
@@ -10077,13 +11666,13 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[loadElem]
+Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -10111,8 +11700,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -10175,8 +11764,8 @@ entry:
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load float, float* %arg0
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -10310,8 +11899,8 @@ entry:
   store i64 %param0, i64* %arg0
   store i64 %param1, i64* %arg1
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
@@ -10319,8 +11908,8 @@ entry:
   %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
   %5 = load i16*, i16* addrspace(1)* %4, align 8
   %6 = addrspacecast i64* %arg1 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = bitcast i64 addrspace(1)* %6 to i8 addrspace(1)*
@@ -10336,7 +11925,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10370,8 +11959,8 @@ entry:
   %1 = load i32, i32* %arg1
   %2 = sext i32 %1 to i64
   %3 = inttoptr i64 %2 to i16*
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -10424,8 +12013,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, i32)*)(%System.IO.ConsoleStream addrspace(1)* %2, i32 %1)
   %3 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %4 = load i64, i64* %arg1
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
@@ -10436,8 +12025,8 @@ entry:
   %10 = icmp eq i32 %9, 3
   %11 = sext i1 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %5
   %14 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, i32 0, i32 5
@@ -10448,7 +12037,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10471,8 +12060,8 @@ entry:
   %5 = icmp eq i32 %4, 1
   %6 = sext i1 %5 to i32
   %7 = trunc i32 %6 to i8
-  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %2, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.ConsoleStream addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
@@ -10483,8 +12072,8 @@ entry:
   %13 = icmp eq i32 %12, 2
   %14 = sext i1 %13 to i32
   %15 = trunc i32 %14 to i8
-  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %10, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.ConsoleStream addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %8
   %17 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %10, i32 0, i32 4
@@ -10495,7 +12084,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10534,8 +12123,8 @@ entry:
   %arg0 = alloca i64
   store i64 %param0, i64* %arg0
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
@@ -10570,8 +12159,8 @@ entry:
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
   %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = load i64, i64 addrspace(1)* %7
@@ -10675,7 +12264,127 @@ entry:
 INFO:  jitting method Encoding::GetEncoding using LLILCJit
 Failed to read Encoding.GetEncoding[convertToHelperArgumentType]
 INFO:  jitting method EncodingProvider::GetEncodingFromProvider using LLILCJit
-Failed to read EncodingProvider.GetEncodingFromProvider[loadElem]
+Successfully read EncodingProvider.GetEncodingFromProvider
+
+define %System.Text.Encoding addrspace(1)* @EncodingProvider.GetEncodingFromProvider(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca %"System.Text.EncodingProvider[]" addrspace(1)*
+  %loc1 = alloca %System.Text.EncodingProvider addrspace(1)*
+  %loc2 = alloca %System.Text.Encoding addrspace(1)*
+  %loc3 = alloca %System.Text.Encoding addrspace(1)*
+  %loc4 = alloca %"System.Text.EncodingProvider[]" addrspace(1)*
+  %loc5 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1059)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2392
+  %2 = addrspacecast i8 addrspace(1)* %1 to %"System.Text.EncodingProvider[]" addrspace(1)**
+  %3 = load volatile %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %2
+  %4 = icmp ne %"System.Text.EncodingProvider[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %entry
+  ret %System.Text.Encoding addrspace(1)* null
+
+; <label>:6                                       ; preds = %entry
+  %7 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1059)
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i64 2392
+  %9 = addrspacecast i8 addrspace(1)* %8 to %"System.Text.EncodingProvider[]" addrspace(1)**
+  %10 = load volatile %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %9
+  store %"System.Text.EncodingProvider[]" addrspace(1)* %10, %"System.Text.EncodingProvider[]" addrspace(1)** %loc0
+  %11 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc0
+  store %"System.Text.EncodingProvider[]" addrspace(1)* %11, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  store i32 0, i32* %loc5
+  br label %43
+
+; <label>:12                                      ; preds = %46
+  %13 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  %14 = load i32, i32* %loc5
+  %NullCheck1 = icmp eq %"System.Text.EncodingProvider[]" addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %13, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = zext i32 %17 to i64
+  %19 = zext i32 %14 to i64
+  %BoundsCheck = icmp uge i64 %19, %18
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %20
+
+; <label>:20                                      ; preds = %15
+  %21 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %13, i32 0, i32 3, i32 %14
+  %22 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)* addrspace(1)* %21, align 8
+  store %System.Text.EncodingProvider addrspace(1)* %22, %System.Text.EncodingProvider addrspace(1)** %loc1
+  %23 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)** %loc1
+  %24 = load i32, i32* %arg0
+  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i64 addrspace(1)*
+  %NullCheck3 = icmp eq i64 addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
+
+; <label>:26                                      ; preds = %20
+  %27 = load i64, i64 addrspace(1)* %25
+  %28 = add i64 %27, 64
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 40
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Text.Encoding addrspace(1)* (%System.Text.EncodingProvider addrspace(1)*, i32)*
+  %35 = call %System.Text.Encoding addrspace(1)* %34(%System.Text.EncodingProvider addrspace(1)* %23, i32 %24)
+  store %System.Text.Encoding addrspace(1)* %35, %System.Text.Encoding addrspace(1)** %loc2
+  %36 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc2
+  %37 = icmp eq %System.Text.Encoding addrspace(1)* %36, null
+  br i1 %37, label %40, label %38
+
+; <label>:38                                      ; preds = %26
+  %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc2
+  store %System.Text.Encoding addrspace(1)* %39, %System.Text.Encoding addrspace(1)** %loc3
+  br label %53
+
+; <label>:40                                      ; preds = %26
+  %41 = load i32, i32* %loc5
+  %42 = add i32 %41, 1
+  store i32 %42, i32* %loc5
+  br label %43
+
+; <label>:43                                      ; preds = %6, %40
+  %44 = load i32, i32* %loc5
+  %45 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  %NullCheck = icmp eq %"System.Text.EncodingProvider[]" addrspace(1)* %45, null
+  br i1 %NullCheck, label %ThrowNullRef, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp slt i32 %44, %50
+  br i1 %51, label %12, label %52
+
+; <label>:52                                      ; preds = %46
+  ret %System.Text.Encoding addrspace(1)* null
+
+; <label>:53                                      ; preds = %38
+  %54 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc3
+  ret %System.Text.Encoding addrspace(1)* %54
+
+ThrowNullRef:                                     ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method EncodingProvider::.cctor using LLILCJit
 Successfully read EncodingProvider..cctor
 
@@ -10694,7 +12403,7 @@ Failed to read Encoding.get_InternalSyncObject[Call HasTypeArg]
 INFO:  jitting method Hashtable::.ctor using LLILCJit
 Failed to read Hashtable..ctor[Volatile store]
 INFO:  jitting method Hashtable::get_Item using LLILCJit
-Failed to read Hashtable.get_Item[loadElemA]
+Failed to read Hashtable.get_Item[loadNonPrimitiveObj]
 INFO:  jitting method Hashtable::InitHash using LLILCJit
 Successfully read Hashtable.InitHash
 
@@ -10714,8 +12423,8 @@ entry:
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -10731,15 +12440,15 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
   %15 = load i32, i32* %loc0
-  %NullCheck2 = icmp ne i32 addrspace(1)* %14, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i32 addrspace(1)* %14, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %3
   store i32 %15, i32 addrspace(1)* %14, align 8
   %17 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %18 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %NullCheck4 = icmp ne i32 addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i32 addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = load i32, i32 addrspace(1)* %18, align 8
@@ -10748,8 +12457,8 @@ entry:
   %23 = sub i32 %22, 1
   %24 = urem i32 %21, %23
   %25 = add i32 1, %24
-  %NullCheck6 = icmp ne i32 addrspace(1)* %17, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32 addrspace(1)* %17, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %19
   store i32 %25, i32 addrspace(1)* %17, align 8
@@ -10760,15 +12469,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %19
+ThrowNullRef6:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10783,8 +12492,8 @@ entry:
   store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
   store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %NullCheck = icmp ne %System.Collections.Hashtable addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Collections.Hashtable addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
@@ -10794,16 +12503,16 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Collections.Hashtable addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Collections.Hashtable addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
   %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck4 = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %9, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
   %13 = inttoptr i64 %11 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
@@ -10813,8 +12522,8 @@ entry:
 ; <label>:15                                      ; preds = %1
   %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -10832,15 +12541,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10854,8 +12563,8 @@ entry:
   store %System.Int32 addrspace(1)* %param0, %System.Int32 addrspace(1)** %this
   %0 = load %System.Int32 addrspace(1)*, %System.Int32 addrspace(1)** %this
   %1 = bitcast %System.Int32 addrspace(1)* %0 to i32 addrspace(1)*
-  %NullCheck = icmp ne i32 addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq i32 addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load i32, i32 addrspace(1)* %1, align 8
@@ -10931,8 +12640,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.UTF8Encoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
@@ -10941,15 +12650,15 @@ entry:
   %9 = load i8, i8* %arg2
   %10 = zext i8 %9 to i32
   %11 = trunc i32 %10 to i8
-  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %8, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %6
   %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %8, i32 0, i32 8
   store i8 %11, i8 addrspace(1)* %13
   %14 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %14, i32 0, i32 8
@@ -10961,8 +12670,8 @@ entry:
 ; <label>:20                                      ; preds = %15
   %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %22, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %22, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = load i64, i64 addrspace(1)* %22
@@ -10984,15 +12693,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %12
+ThrowNullRef4:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11007,8 +12716,8 @@ entry:
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
@@ -11030,16 +12739,16 @@ entry:
 ; <label>:10                                      ; preds = %1
   %11 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
   %12 = load i32, i32* %arg1
-  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %11, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.Encoding addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
   store i32 %12, i32 addrspace(1)* %14
   %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
   %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = load i64, i64 addrspace(1)* %16
@@ -11057,11 +12766,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11074,8 +12783,8 @@ entry:
   %this = alloca %System.Text.UTF8Encoding addrspace(1)*
   store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
   %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.UTF8Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
@@ -11087,16 +12796,16 @@ entry:
 ; <label>:6                                       ; preds = %1
   %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %8 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %10, %System.Text.EncoderFallback addrspace(1)* %8)
   %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %12 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
-  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %11, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %11, i32 0, i32 3
@@ -11109,8 +12818,8 @@ entry:
   %18 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %18, %System.String addrspace(1)* %17)
   %19 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %18 to %System.Text.EncoderFallback addrspace(1)*
-  %NullCheck6 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %16, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %16, i32 0, i32 2
@@ -11120,8 +12829,8 @@ entry:
   %24 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %24, %System.String addrspace(1)* %23)
   %25 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %24 to %System.Text.DecoderFallback addrspace(1)*
-  %NullCheck8 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %22, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %22, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %20
   %27 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %22, i32 0, i32 3
@@ -11132,19 +12841,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %20
+ThrowNullRef8:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11174,8 +12883,8 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load i32, i32* %arg1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -11193,8 +12902,8 @@ entry:
 ; <label>:15                                      ; preds = %8
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %17 = load i32, i32* %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 %17
@@ -11210,7 +12919,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11262,7 +12971,7 @@ entry:
 }
 
 INFO:  jitting method Hashtable::Insert using LLILCJit
-Failed to read Hashtable.Insert[loadElemA]
+Failed to read Hashtable.Insert[storeElem]
 INFO:  jitting method ConsoleEncoding::.ctor using LLILCJit
 Successfully read ConsoleEncoding..ctor
 
@@ -11277,8 +12986,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %1)
   %2 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
@@ -11314,8 +13023,8 @@ entry:
   %2 = call %System.Text.InternalEncoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalEncoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %1)
   %3 = bitcast %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2 to %System.Text.EncoderFallback addrspace(1)*
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
@@ -11325,8 +13034,8 @@ entry:
   %8 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %7)
   %9 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %8 to %System.Text.DecoderFallback addrspace(1)*
-  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %6, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.Encoding addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %4
   %11 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %6, i32 0, i32 3
@@ -11337,7 +13046,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11356,15 +13065,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* %1)
   %2 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   %6 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, i32 0, i32 1
@@ -11375,7 +13084,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11403,8 +13112,8 @@ entry:
   store %System.Text.InternalDecoderBestFitFallback addrspace(1)* %param0, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
   %0 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
@@ -11414,15 +13123,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %4)
   %5 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %6)
   %9 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, i32 0, i32 1
@@ -11433,11 +13142,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11505,8 +13214,8 @@ entry:
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
   %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = load i64, i64 addrspace(1)* %19
@@ -11570,8 +13279,8 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.ConsoleStream addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
@@ -11602,31 +13311,31 @@ entry:
   store i8 %param4, i8* %arg4
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %3, %System.IO.Stream addrspace(1)* %1)
   %4 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %4, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
   %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %4, i32 0, i32 4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %5)
   %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %6
   %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
   %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
   %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = load i64, i64 addrspace(1)* %13
@@ -11638,8 +13347,8 @@ entry:
   %21 = load i64, i64* %20
   %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %8, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %8, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %14
   %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 5
@@ -11657,24 +13366,24 @@ entry:
   %31 = load i32, i32* %arg3
   %32 = sext i32 %31 to i64
   %33 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %32)
-  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %30, null
-  br i1 %NullCheck10, label %34, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.StreamWriter addrspace(1)* %30, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %35, %"System.Char[]" addrspace(1)* %33)
   %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %37, null
-  br i1 %NullCheck12, label %38, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.StreamWriter addrspace(1)* %37, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %38
 
 ; <label>:38                                      ; preds = %34
   %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
   %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
   %41 = load i32, i32* %arg3
   %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %42, null
-  br i1 %NullCheck14, label %43, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %42, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
   %44 = load i64, i64 addrspace(1)* %42
@@ -11688,30 +13397,30 @@ entry:
   %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
   %53 = sext i32 %52 to i64
   %54 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %53)
-  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
-  br i1 %NullCheck16, label %55, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %55
 
 ; <label>:55                                      ; preds = %43
   %56 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %56, %"System.Byte[]" addrspace(1)* %54)
   %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %58 = load i32, i32* %arg3
-  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %57, null
-  br i1 %NullCheck18, label %59, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.StreamWriter addrspace(1)* %57, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %59
 
 ; <label>:59                                      ; preds = %55
   %60 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 10
   store i32 %58, i32 addrspace(1)* %60
   %61 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %61, null
-  br i1 %NullCheck20, label %62, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.IO.StreamWriter addrspace(1)* %61, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %62
 
 ; <label>:62                                      ; preds = %59
   %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
   %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
   %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
   %67 = load i64, i64 addrspace(1)* %65
@@ -11729,15 +13438,15 @@ entry:
 
 ; <label>:78                                      ; preds = %66
   %79 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %79, null
-  br i1 %NullCheck24, label %80, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.StreamWriter addrspace(1)* %79, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %80
 
 ; <label>:80                                      ; preds = %78
   %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
   %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
   %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %83, null
-  br i1 %NullCheck26, label %84, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %83, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
   %85 = load i64, i64 addrspace(1)* %83
@@ -11754,8 +13463,8 @@ entry:
 
 ; <label>:95                                      ; preds = %84
   %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.IO.StreamWriter addrspace(1)* %96, null
-  br i1 %NullCheck28, label %97, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.IO.StreamWriter addrspace(1)* %96, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %97
 
 ; <label>:97                                      ; preds = %95
   %98 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 12
@@ -11769,8 +13478,8 @@ entry:
   %103 = icmp eq i32 %102, 0
   %104 = sext i1 %103 to i32
   %105 = trunc i32 %104 to i8
-  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %100, null
-  br i1 %NullCheck30, label %106, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.IO.StreamWriter addrspace(1)* %100, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %106
 
 ; <label>:106                                     ; preds = %99
   %107 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %100, i32 0, i32 13
@@ -11781,63 +13490,63 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %6
+ThrowNullRef4:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %29
+ThrowNullRef10:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %34
+ThrowNullRef12:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %38
+ThrowNullRef14:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %43
+ThrowNullRef16:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %55
+ThrowNullRef18:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %59
+ThrowNullRef20:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %62
+ThrowNullRef22:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %78
+ThrowNullRef24:                                   ; preds = %78
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %80
+ThrowNullRef26:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %95
+ThrowNullRef28:                                   ; preds = %95
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11850,15 +13559,15 @@ entry:
   %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = load i64, i64 addrspace(1)* %4
@@ -11876,7 +13585,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11926,35 +13635,35 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
   %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderNLS addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %7 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.EncoderNLS addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Text.Encoding addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.Encoding addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Text.EncoderNLS addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.EncoderNLS addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
   %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck8 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = load i64, i64 addrspace(1)* %16
@@ -11973,19 +13682,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12011,8 +13720,8 @@ entry:
   %this = alloca %System.Text.Encoding addrspace(1)*
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
@@ -12032,15 +13741,15 @@ entry:
   %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
   store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
   %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
   store i32 0, i32 addrspace(1)* %2
   %3 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, i32 0, i32 2
@@ -12050,15 +13759,15 @@ entry:
 
 ; <label>:8                                       ; preds = %4
   %9 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
   %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
   %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = load i64, i64 addrspace(1)* %13
@@ -12079,15 +13788,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12102,16 +13811,16 @@ entry:
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = load i32, i32* %arg1
   %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
   %7 = load i64, i64 addrspace(1)* %5
@@ -12129,7 +13838,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12166,8 +13875,8 @@ entry:
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
   %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
   %16 = load i64, i64 addrspace(1)* %14
@@ -12188,8 +13897,8 @@ entry:
   %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
   %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
   %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %31, null
-  br i1 %NullCheck2, label %32, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = load i64, i64 addrspace(1)* %31
@@ -12232,7 +13941,7 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12245,14 +13954,14 @@ entry:
   %this = alloca %System.Text.EncoderReplacementFallback addrspace(1)*
   store %System.Text.EncoderReplacementFallback addrspace(1)* %param0, %System.Text.EncoderReplacementFallback addrspace(1)** %this
   %0 = load %System.Text.EncoderReplacementFallback addrspace(1)*, %System.Text.EncoderReplacementFallback addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -12263,7 +13972,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12293,8 +14002,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
@@ -12326,8 +14035,8 @@ entry:
   %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
   store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
@@ -12339,8 +14048,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Threading.Tasks.Task addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %7)
@@ -12363,7 +14072,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12382,8 +14091,8 @@ entry:
   store i8 %param1, i8* %arg1
   store i8 %param2, i8* %arg2
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
@@ -12397,8 +14106,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1, %5
   %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 9
@@ -12429,8 +14138,8 @@ entry:
 
 ; <label>:25                                      ; preds = %8, %20
   %26 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %26, null
-  br i1 %NullCheck4, label %27, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %26, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %26, i32 0, i32 12
@@ -12441,22 +14150,22 @@ entry:
 
 ; <label>:32                                      ; preds = %27
   %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %33, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.IO.StreamWriter addrspace(1)* %33, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %32
   %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 12
   store i8 1, i8 addrspace(1)* %35
   %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
-  br i1 %NullCheck8, label %37, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
   %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
   %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck10 = icmp ne i64 addrspace(1)* %40, null
-  br i1 %NullCheck10, label %41, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64 addrspace(1)* %40, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i64, i64 addrspace(1)* %40
@@ -12470,8 +14179,8 @@ entry:
   %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
   store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
   %51 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %NullCheck12 = icmp ne %"System.Byte[]" addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Byte[]" addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %41
   %53 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %51, i32 0, i32 1
@@ -12483,16 +14192,16 @@ entry:
 
 ; <label>:58                                      ; preds = %52
   %59 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %59, null
-  br i1 %NullCheck14, label %60, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.IO.StreamWriter addrspace(1)* %59, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %60
 
 ; <label>:60                                      ; preds = %58
   %61 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %59, i32 0, i32 3
   %62 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
   %64 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %NullCheck16 = icmp ne %"System.Byte[]" addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %"System.Byte[]" addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %60
   %66 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %64, i32 0, i32 1
@@ -12500,8 +14209,8 @@ entry:
   %68 = zext i32 %67 to i64
   %69 = trunc i64 %68 to i32
   %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck18, label %71, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
   %72 = load i64, i64 addrspace(1)* %70
@@ -12517,29 +14226,29 @@ entry:
 
 ; <label>:80                                      ; preds = %27, %52, %71
   %81 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %81, null
-  br i1 %NullCheck20, label %82, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.IO.StreamWriter addrspace(1)* %81, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
 
 ; <label>:82                                      ; preds = %80
   %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %81, i32 0, i32 5
   %84 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %83, align 8
   %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.IO.StreamWriter addrspace(1)* %85, null
-  br i1 %NullCheck22, label %86, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.IO.StreamWriter addrspace(1)* %85, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %86
 
 ; <label>:86                                      ; preds = %82
   %87 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 7
   %88 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %87, align 8
   %89 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %89, null
-  br i1 %NullCheck24, label %90, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.StreamWriter addrspace(1)* %89, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %90
 
 ; <label>:90                                      ; preds = %86
   %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %89, i32 0, i32 9
   %92 = load i32, i32 addrspace(1)* %91, align 8
   %93 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.IO.StreamWriter addrspace(1)* %93, null
-  br i1 %NullCheck26, label %94, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.IO.StreamWriter addrspace(1)* %93, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %93, i32 0, i32 6
@@ -12547,8 +14256,8 @@ entry:
   %97 = load i8, i8* %arg2
   %98 = zext i8 %97 to i32
   %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
-  %NullCheck28 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck28, label %100, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
   %101 = load i64, i64 addrspace(1)* %99
@@ -12563,8 +14272,8 @@ entry:
   %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
   store i32 %110, i32* %loc1
   %111 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %111, null
-  br i1 %NullCheck30, label %112, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.IO.StreamWriter addrspace(1)* %111, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %112
 
 ; <label>:112                                     ; preds = %100
   %113 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %111, i32 0, i32 9
@@ -12575,23 +14284,23 @@ entry:
 
 ; <label>:116                                     ; preds = %112
   %117 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck32 = icmp ne %System.IO.StreamWriter addrspace(1)* %117, null
-  br i1 %NullCheck32, label %118, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.IO.StreamWriter addrspace(1)* %117, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %118
 
 ; <label>:118                                     ; preds = %116
   %119 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %117, i32 0, i32 3
   %120 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %119, align 8
   %121 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.IO.StreamWriter addrspace(1)* %121, null
-  br i1 %NullCheck34, label %122, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.IO.StreamWriter addrspace(1)* %121, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %122
 
 ; <label>:122                                     ; preds = %118
   %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
   %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
   %125 = load i32, i32* %loc1
   %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
-  %NullCheck36 = icmp ne i64 addrspace(1)* %126, null
-  br i1 %NullCheck36, label %127, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64 addrspace(1)* %126, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
   %128 = load i64, i64 addrspace(1)* %126
@@ -12613,15 +14322,15 @@ entry:
 
 ; <label>:140                                     ; preds = %136
   %141 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.IO.StreamWriter addrspace(1)* %141, null
-  br i1 %NullCheck38, label %142, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.IO.StreamWriter addrspace(1)* %141, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %142
 
 ; <label>:142                                     ; preds = %140
   %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
   %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
   %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
-  %NullCheck40 = icmp ne i64 addrspace(1)* %145, null
-  br i1 %NullCheck40, label %146, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i64 addrspace(1)* %145, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
   %147 = load i64, i64 addrspace(1)* %145
@@ -12642,83 +14351,83 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %25
+ThrowNullRef4:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %32
+ThrowNullRef6:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %37
+ThrowNullRef10:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %41
+ThrowNullRef12:                                   ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %58
+ThrowNullRef14:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %60
+ThrowNullRef16:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %65
+ThrowNullRef18:                                   ; preds = %65
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %80
+ThrowNullRef20:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %82
+ThrowNullRef22:                                   ; preds = %82
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %86
+ThrowNullRef24:                                   ; preds = %86
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %90
+ThrowNullRef26:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %94
+ThrowNullRef28:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %100
+ThrowNullRef30:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %116
+ThrowNullRef32:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %118
+ThrowNullRef34:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %122
+ThrowNullRef36:                                   ; preds = %122
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %140
+ThrowNullRef38:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %142
+ThrowNullRef40:                                   ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12785,8 +14494,8 @@ entry:
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %1 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
-  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
@@ -12794,8 +14503,8 @@ entry:
   %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
   %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
   %8 = load i64, i64 addrspace(1)* %6
@@ -12811,8 +14520,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %17, %System.IFormatProvider addrspace(1)* %16)
   %18 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %19 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %18, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.SyncTextWriter addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %7
   %21 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %18, i32 0, i32 4
@@ -12823,11 +14532,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12840,8 +14549,8 @@ entry:
   %this = alloca %System.IO.TextWriter addrspace(1)*
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.TextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
@@ -12851,8 +14560,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.Threading.Thread addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Threading.Thread addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %6)
@@ -12861,8 +14570,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1
   %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.TextWriter addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.TextWriter addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %11, i32 0, i32 2
@@ -12873,11 +14582,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13074,8 +14783,8 @@ entry:
   store float %param1, float* %arg1
   store i8 0, i8* %loc1
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
@@ -13085,16 +14794,16 @@ entry:
   %5 = addrspacecast i8* %loc1 to i8 addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %4, i8 addrspace(1)* %5)
   %6 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.SyncTextWriter addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
   %10 = load float, float* %arg1
   %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
   %13 = load i64, i64 addrspace(1)* %11
@@ -13129,11 +14838,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13150,8 +14859,8 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load float, float* %arg1
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -13165,8 +14874,8 @@ entry:
   call void %11(%System.IO.TextWriter addrspace(1)* %0, float %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
   %15 = load i64, i64 addrspace(1)* %13
@@ -13184,7 +14893,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13202,8 +14911,8 @@ entry:
   %1 = addrspacecast float* %arg1 to float addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -13218,8 +14927,8 @@ entry:
   %14 = bitcast float addrspace(1)* %1 to %System.Single addrspace(1)*
   %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Single addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Single addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
   %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
   %18 = load i64, i64 addrspace(1)* %16
@@ -13237,7 +14946,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13253,8 +14962,8 @@ entry:
   store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
   %0 = load %System.Single addrspace(1)*, %System.Single addrspace(1)** %this
   %1 = bitcast %System.Single addrspace(1)* %0 to float addrspace(1)*
-  %NullCheck = icmp ne float addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq float addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load float, float addrspace(1)* %1, align 8
@@ -13279,8 +14988,8 @@ entry:
   %loc0 = alloca %System.Globalization.NumberFormatInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 3
@@ -13290,8 +14999,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
@@ -13301,24 +15010,24 @@ entry:
   store %System.Globalization.NumberFormatInfo addrspace(1)* %10, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
   %11 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %7
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
   %15 = load i8, i8 addrspace(1)* %14, align 8
   %16 = zext i8 %15 to i32
   %17 = trunc i32 %16 to i8
-  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %11, null
-  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %11, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %13
   %19 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %11, i32 0, i32 29
   store i8 %17, i8 addrspace(1)* %19
   %20 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %21 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %20, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %20, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %18
   %23 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %20, i32 0, i32 3
@@ -13327,8 +15036,8 @@ entry:
 
 ; <label>:24                                      ; preds = %1, %22
   %25 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %25, null
-  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %25, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %26
 
 ; <label>:26                                      ; preds = %24
   %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %25, i32 0, i32 3
@@ -13339,23 +15048,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %18
+ThrowNullRef8:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13380,168 +15089,168 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 18
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %8, align 8
-  %NullCheck2 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %5, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %5, i32 0, i32 4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %9)
   %12 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 19
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %15, align 8
-  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %12, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %12, i32 0, i32 5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %16)
   %19 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %20 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %20, null
-  br i1 %NullCheck8, label %21, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %20, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %20, i32 0, i32 23
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  %NullCheck10 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %19, null
-  br i1 %NullCheck10, label %24, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %19, i32 0, i32 7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %25, %System.String addrspace(1)* %23)
   %26 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %27 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %27, i32 0, i32 22
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %29, align 8
-  %NullCheck14 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %26, null
-  br i1 %NullCheck14, label %31, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %26, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %26, i32 0, i32 6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %32, %System.String addrspace(1)* %30)
   %33 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %34 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Globalization.CultureData addrspace(1)* %34, null
-  br i1 %NullCheck16, label %35, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Globalization.CultureData addrspace(1)* %34, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %34, i32 0, i32 51
   %37 = load i32, i32 addrspace(1)* %36, align 8
-  %NullCheck18 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %33, null
-  br i1 %NullCheck18, label %38, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %33, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %33, i32 0, i32 21
   store i32 %37, i32 addrspace(1)* %39
   %40 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %41 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Globalization.CultureData addrspace(1)* %41, null
-  br i1 %NullCheck20, label %42, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Globalization.CultureData addrspace(1)* %41, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %41, i32 0, i32 52
   %44 = load i32, i32 addrspace(1)* %43, align 8
-  %NullCheck22 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %40, null
-  br i1 %NullCheck22, label %45, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %40, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %40, i32 0, i32 25
   store i32 %44, i32 addrspace(1)* %46
   %47 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %48 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.Globalization.CultureData addrspace(1)* %48, null
-  br i1 %NullCheck24, label %49, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Globalization.CultureData addrspace(1)* %48, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %49
 
 ; <label>:49                                      ; preds = %45
   %50 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %48, i32 0, i32 29
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck26 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %47, null
-  br i1 %NullCheck26, label %52, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %47, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %47, i32 0, i32 10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %53, %System.String addrspace(1)* %51)
   %54 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %55 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Globalization.CultureData addrspace(1)* %55, null
-  br i1 %NullCheck28, label %56, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Globalization.CultureData addrspace(1)* %55, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %56
 
 ; <label>:56                                      ; preds = %52
   %57 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %55, i32 0, i32 35
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %57, align 8
-  %NullCheck30 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %54, null
-  br i1 %NullCheck30, label %59, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %54, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %54, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %60, %System.String addrspace(1)* %58)
   %61 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %62 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck32 = icmp ne %System.Globalization.CultureData addrspace(1)* %62, null
-  br i1 %NullCheck32, label %63, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Globalization.CultureData addrspace(1)* %62, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %62, i32 0, i32 34
   %65 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %64, align 8
-  %NullCheck34 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %61, null
-  br i1 %NullCheck34, label %66, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %61, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %61, i32 0, i32 9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %67, %System.String addrspace(1)* %65)
   %68 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %69 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck36 = icmp ne %System.Globalization.CultureData addrspace(1)* %69, null
-  br i1 %NullCheck36, label %70, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Globalization.CultureData addrspace(1)* %69, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %70
 
 ; <label>:70                                      ; preds = %66
   %71 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %69, i32 0, i32 55
   %72 = load i32, i32 addrspace(1)* %71, align 8
-  %NullCheck38 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %68, null
-  br i1 %NullCheck38, label %73, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %68, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %68, i32 0, i32 22
   store i32 %72, i32 addrspace(1)* %74
   %75 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %76 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck40 = icmp ne %System.Globalization.CultureData addrspace(1)* %76, null
-  br i1 %NullCheck40, label %77, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Globalization.CultureData addrspace(1)* %76, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %76, i32 0, i32 57
   %79 = load i32, i32 addrspace(1)* %78, align 8
-  %NullCheck42 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %75, null
-  br i1 %NullCheck42, label %80, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %75, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %80
 
 ; <label>:80                                      ; preds = %77
   %81 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %75, i32 0, i32 24
   store i32 %79, i32 addrspace(1)* %81
   %82 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %83 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck44 = icmp ne %System.Globalization.CultureData addrspace(1)* %83, null
-  br i1 %NullCheck44, label %84, label %ThrowNullRef43
+  %NullCheck43 = icmp eq %System.Globalization.CultureData addrspace(1)* %83, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %84
 
 ; <label>:84                                      ; preds = %80
   %85 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %83, i32 0, i32 56
   %86 = load i32, i32 addrspace(1)* %85, align 8
-  %NullCheck46 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %82, null
-  br i1 %NullCheck46, label %87, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %82, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %82, i32 0, i32 23
@@ -13550,8 +15259,8 @@ entry:
 
 ; <label>:89                                      ; preds = %entry
   %90 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck100 = icmp ne %System.Globalization.CultureData addrspace(1)* %90, null
-  br i1 %NullCheck100, label %91, label %ThrowNullRef99
+  %NullCheck99 = icmp eq %System.Globalization.CultureData addrspace(1)* %90, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %91
 
 ; <label>:91                                      ; preds = %89
   %92 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %90, i32 0, i32 2
@@ -13569,8 +15278,8 @@ entry:
   %102 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %103 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %104 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %103)
-  %NullCheck48 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %102, null
-  br i1 %NullCheck48, label %105, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %102, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %105
 
 ; <label>:105                                     ; preds = %101
   %106 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %102, i32 0, i32 1
@@ -13578,8 +15287,8 @@ entry:
   %107 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %108 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %109 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %108)
-  %NullCheck50 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %107, null
-  br i1 %NullCheck50, label %110, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %107, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %110
 
 ; <label>:110                                     ; preds = %105
   %111 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %107, i32 0, i32 2
@@ -13587,8 +15296,8 @@ entry:
   %112 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %113 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %114 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %113)
-  %NullCheck52 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %112, null
-  br i1 %NullCheck52, label %115, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %112, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %115
 
 ; <label>:115                                     ; preds = %110
   %116 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %112, i32 0, i32 27
@@ -13596,8 +15305,8 @@ entry:
   %117 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %118 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %119 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %118)
-  %NullCheck54 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %117, null
-  br i1 %NullCheck54, label %120, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %117, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %120
 
 ; <label>:120                                     ; preds = %115
   %121 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %117, i32 0, i32 26
@@ -13605,8 +15314,8 @@ entry:
   %122 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %123 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %124 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %123)
-  %NullCheck56 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %122, null
-  br i1 %NullCheck56, label %125, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %122, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %125
 
 ; <label>:125                                     ; preds = %120
   %126 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %122, i32 0, i32 17
@@ -13614,8 +15323,8 @@ entry:
   %127 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %128 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %129 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %128)
-  %NullCheck58 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %127, null
-  br i1 %NullCheck58, label %130, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %127, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %130
 
 ; <label>:130                                     ; preds = %125
   %131 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %127, i32 0, i32 18
@@ -13623,8 +15332,8 @@ entry:
   %132 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %133 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %134 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %133)
-  %NullCheck60 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %132, null
-  br i1 %NullCheck60, label %135, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %132, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %135
 
 ; <label>:135                                     ; preds = %130
   %136 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %132, i32 0, i32 14
@@ -13632,8 +15341,8 @@ entry:
   %137 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %138 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %139 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %138)
-  %NullCheck62 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %137, null
-  br i1 %NullCheck62, label %140, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %137, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %140
 
 ; <label>:140                                     ; preds = %135
   %141 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %137, i32 0, i32 13
@@ -13641,71 +15350,71 @@ entry:
   %142 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %143 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %144 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %143)
-  %NullCheck64 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %142, null
-  br i1 %NullCheck64, label %145, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %142, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %145
 
 ; <label>:145                                     ; preds = %140
   %146 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %142, i32 0, i32 12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %146, %System.String addrspace(1)* %144)
   %147 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %148 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck66 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %148, null
-  br i1 %NullCheck66, label %149, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %148, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %149
 
 ; <label>:149                                     ; preds = %145
   %150 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %148, i32 0, i32 21
   %151 = load i32, i32 addrspace(1)* %150, align 8
-  %NullCheck68 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %147, null
-  br i1 %NullCheck68, label %152, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %147, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %152
 
 ; <label>:152                                     ; preds = %149
   %153 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %147, i32 0, i32 28
   store i32 %151, i32 addrspace(1)* %153
   %154 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %155 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck70 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %155, null
-  br i1 %NullCheck70, label %156, label %ThrowNullRef69
+  %NullCheck69 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %155, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %156
 
 ; <label>:156                                     ; preds = %152
   %157 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %155, i32 0, i32 6
   %158 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %157, align 8
-  %NullCheck72 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %154, null
-  br i1 %NullCheck72, label %159, label %ThrowNullRef71
+  %NullCheck71 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %154, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %159
 
 ; <label>:159                                     ; preds = %156
   %160 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %154, i32 0, i32 15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %160, %System.String addrspace(1)* %158)
   %161 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %162 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck74 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %162, null
-  br i1 %NullCheck74, label %163, label %ThrowNullRef73
+  %NullCheck73 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %162, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %163
 
 ; <label>:163                                     ; preds = %159
   %164 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %162, i32 0, i32 1
   %165 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %164, align 8
-  %NullCheck76 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %161, null
-  br i1 %NullCheck76, label %166, label %ThrowNullRef75
+  %NullCheck75 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %161, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %166
 
 ; <label>:166                                     ; preds = %163
   %167 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %161, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %167, %"System.Int32[]" addrspace(1)* %165)
   %168 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %169 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck78 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %169, null
-  br i1 %NullCheck78, label %170, label %ThrowNullRef77
+  %NullCheck77 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %169, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %170
 
 ; <label>:170                                     ; preds = %166
   %171 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %169, i32 0, i32 7
   %172 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %171, align 8
-  %NullCheck80 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %168, null
-  br i1 %NullCheck80, label %173, label %ThrowNullRef79
+  %NullCheck79 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %168, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %173
 
 ; <label>:173                                     ; preds = %170
   %174 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %168, i32 0, i32 16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %174, %System.String addrspace(1)* %172)
   %175 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck82 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %175, null
-  br i1 %NullCheck82, label %176, label %ThrowNullRef81
+  %NullCheck81 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %175, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %176
 
 ; <label>:176                                     ; preds = %173
   %177 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %175, i32 0, i32 4
@@ -13715,14 +15424,14 @@ entry:
 
 ; <label>:180                                     ; preds = %176
   %181 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck84 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %181, null
-  br i1 %NullCheck84, label %182, label %ThrowNullRef83
+  %NullCheck83 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %181, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %182
 
 ; <label>:182                                     ; preds = %180
   %183 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %181, i32 0, i32 4
   %184 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %183, align 8
-  %NullCheck86 = icmp ne %System.String addrspace(1)* %184, null
-  br i1 %NullCheck86, label %185, label %ThrowNullRef85
+  %NullCheck85 = icmp eq %System.String addrspace(1)* %184, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %185
 
 ; <label>:185                                     ; preds = %182
   %186 = getelementptr inbounds %System.String, %System.String addrspace(1)* %184, i32 0, i32 1
@@ -13733,8 +15442,8 @@ entry:
 ; <label>:189                                     ; preds = %176, %185
   %190 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck98 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %190, null
-  br i1 %NullCheck98, label %192, label %ThrowNullRef97
+  %NullCheck97 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %190, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %192
 
 ; <label>:192                                     ; preds = %189
   %193 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %190, i32 0, i32 4
@@ -13743,8 +15452,8 @@ entry:
 
 ; <label>:194                                     ; preds = %185, %192
   %195 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck88 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %195, null
-  br i1 %NullCheck88, label %196, label %ThrowNullRef87
+  %NullCheck87 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %195, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %196
 
 ; <label>:196                                     ; preds = %194
   %197 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %195, i32 0, i32 9
@@ -13754,14 +15463,14 @@ entry:
 
 ; <label>:200                                     ; preds = %196
   %201 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck90 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %201, null
-  br i1 %NullCheck90, label %202, label %ThrowNullRef89
+  %NullCheck89 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %201, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %202
 
 ; <label>:202                                     ; preds = %200
   %203 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %201, i32 0, i32 9
   %204 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %203, align 8
-  %NullCheck92 = icmp ne %System.String addrspace(1)* %204, null
-  br i1 %NullCheck92, label %205, label %ThrowNullRef91
+  %NullCheck91 = icmp eq %System.String addrspace(1)* %204, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %205
 
 ; <label>:205                                     ; preds = %202
   %206 = getelementptr inbounds %System.String, %System.String addrspace(1)* %204, i32 0, i32 1
@@ -13772,14 +15481,14 @@ entry:
 ; <label>:209                                     ; preds = %196, %205
   %210 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %211 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck94 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %211, null
-  br i1 %NullCheck94, label %212, label %ThrowNullRef93
+  %NullCheck93 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %211, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %212
 
 ; <label>:212                                     ; preds = %209
   %213 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %211, i32 0, i32 6
   %214 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %213, align 8
-  %NullCheck96 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %210, null
-  br i1 %NullCheck96, label %215, label %ThrowNullRef95
+  %NullCheck95 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %210, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %215
 
 ; <label>:215                                     ; preds = %212
   %216 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %210, i32 0, i32 9
@@ -13793,203 +15502,203 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %17
+ThrowNullRef8:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %21
+ThrowNullRef10:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %24
+ThrowNullRef12:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %28
+ThrowNullRef14:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %31
+ThrowNullRef16:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %35
+ThrowNullRef18:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %38
+ThrowNullRef20:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %42
+ThrowNullRef22:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %45
+ThrowNullRef24:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %49
+ThrowNullRef26:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %52
+ThrowNullRef28:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %56
+ThrowNullRef30:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %59
+ThrowNullRef32:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %63
+ThrowNullRef34:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %66
+ThrowNullRef36:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %70
+ThrowNullRef38:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %73
+ThrowNullRef40:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %77
+ThrowNullRef42:                                   ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %80
+ThrowNullRef44:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %84
+ThrowNullRef46:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %101
+ThrowNullRef48:                                   ; preds = %101
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %105
+ThrowNullRef50:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %110
+ThrowNullRef52:                                   ; preds = %110
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %115
+ThrowNullRef54:                                   ; preds = %115
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %120
+ThrowNullRef56:                                   ; preds = %120
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %125
+ThrowNullRef58:                                   ; preds = %125
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %130
+ThrowNullRef60:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %135
+ThrowNullRef62:                                   ; preds = %135
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %140
+ThrowNullRef64:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %145
+ThrowNullRef66:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %149
+ThrowNullRef68:                                   ; preds = %149
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %152
+ThrowNullRef70:                                   ; preds = %152
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %156
+ThrowNullRef72:                                   ; preds = %156
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %159
+ThrowNullRef74:                                   ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %163
+ThrowNullRef76:                                   ; preds = %163
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %166
+ThrowNullRef78:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %170
+ThrowNullRef80:                                   ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %173
+ThrowNullRef82:                                   ; preds = %173
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %180
+ThrowNullRef84:                                   ; preds = %180
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %182
+ThrowNullRef86:                                   ; preds = %182
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %194
+ThrowNullRef88:                                   ; preds = %194
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %200
+ThrowNullRef90:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %202
+ThrowNullRef92:                                   ; preds = %202
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %209
+ThrowNullRef94:                                   ; preds = %209
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %212
+ThrowNullRef96:                                   ; preds = %212
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %189
+ThrowNullRef98:                                   ; preds = %189
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %89
+ThrowNullRef100:                                  ; preds = %89
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14017,8 +15726,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 21
@@ -14031,8 +15740,8 @@ entry:
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 16)
   %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 21
@@ -14041,8 +15750,8 @@ entry:
 
 ; <label>:12                                      ; preds = %1, %10
   %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 21
@@ -14053,11 +15762,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %12
+ThrowNullRef4:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14073,8 +15782,8 @@ entry:
   store i32 %param1, i32* %arg1
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %1 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
@@ -14141,8 +15850,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 33
@@ -14155,8 +15864,8 @@ entry:
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 24)
   %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 33
@@ -14165,8 +15874,8 @@ entry:
 
 ; <label>:12                                      ; preds = %1, %10
   %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 33
@@ -14177,11 +15886,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %12
+ThrowNullRef4:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14194,8 +15903,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 53
@@ -14207,8 +15916,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 116)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 53
@@ -14217,8 +15926,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 53
@@ -14229,11 +15938,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14262,8 +15971,8 @@ entry:
 
 ; <label>:7                                       ; preds = %entry, %4
   %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %7
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 2
@@ -14287,8 +15996,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 54
@@ -14300,8 +16009,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 117)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
@@ -14310,8 +16019,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 54
@@ -14322,11 +16031,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14339,8 +16048,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 27
@@ -14352,8 +16061,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 118)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 27
@@ -14362,8 +16071,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 27
@@ -14374,11 +16083,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14391,8 +16100,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 28
@@ -14404,8 +16113,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 119)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 28
@@ -14414,8 +16123,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 28
@@ -14426,11 +16135,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14443,8 +16152,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 26
@@ -14456,8 +16165,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 107)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 26
@@ -14466,8 +16175,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 26
@@ -14478,11 +16187,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14495,8 +16204,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 25
@@ -14508,8 +16217,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 106)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 25
@@ -14518,8 +16227,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 25
@@ -14530,11 +16239,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14547,8 +16256,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 24
@@ -14560,8 +16269,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 105)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 24
@@ -14570,8 +16279,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 24
@@ -14582,11 +16291,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14611,8 +16320,8 @@ entry:
   %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %3)
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %2
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -14623,15 +16332,15 @@ entry:
 
 ; <label>:8                                       ; preds = %62
   %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 9
   %12 = load i32, i32 addrspace(1)* %11, align 8
   %13 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.IO.StreamWriter addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %13, i32 0, i32 10
@@ -14646,15 +16355,15 @@ entry:
 
 ; <label>:20                                      ; preds = %14, %18
   %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
   %24 = load i32, i32 addrspace(1)* %23, align 8
   %25 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %25, null
-  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.StreamWriter addrspace(1)* %25, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %25, i32 0, i32 9
@@ -14675,36 +16384,36 @@ entry:
   %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %37 = load i32, i32* %loc1
   %38 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.StreamWriter addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %35
   %40 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %38, i32 0, i32 7
   %41 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %40, align 8
   %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
-  br i1 %NullCheck14, label %43, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %39
   %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 9
   %45 = load i32, i32 addrspace(1)* %44, align 8
   %46 = load i32, i32* %loc2
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %36, null
-  br i1 %NullCheck16, label %47, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %36, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %47
 
 ; <label>:47                                      ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %36, i32 %37, %"System.Char[]" addrspace(1)* %41, i32 %45, i32 %46)
   %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
   %51 = load i32, i32 addrspace(1)* %50, align 8
   %52 = load i32, i32* %loc2
   %53 = add i32 %51, %52
-  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
-  br i1 %NullCheck20, label %54, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %54
 
 ; <label>:54                                      ; preds = %49
   %55 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
@@ -14726,8 +16435,8 @@ entry:
 
 ; <label>:65                                      ; preds = %62
   %66 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %66, null
-  br i1 %NullCheck2, label %67, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %66, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %67
 
 ; <label>:67                                      ; preds = %65
   %68 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %66, i32 0, i32 11
@@ -14748,49 +16457,259 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %65
+ThrowNullRef2:                                    ; preds = %65
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %20
+ThrowNullRef8:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %22
+ThrowNullRef10:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %35
+ThrowNullRef12:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %43
+ThrowNullRef16:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %47
+ThrowNullRef18:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method String::CopyTo using LLILCJit
-Failed to read String.CopyTo[loadElemA]
+Successfully read String.CopyTo
+
+define void @String.CopyTo(%System.String addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  %loc1 = alloca i16 addrspace(1)*
+  %loc2 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %1 = icmp ne %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg4
+  %7 = icmp sge i32 %6, 0
+  br i1 %7, label %13, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  unreachable
+
+; <label>:13                                      ; preds = %5
+  %14 = load i32, i32* %arg1
+  %15 = icmp sge i32 %14, 0
+  br i1 %15, label %21, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %18)
+  %20 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %20, %System.String addrspace(1)* %17, %System.String addrspace(1)* %19)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %20) #0
+  unreachable
+
+; <label>:21                                      ; preds = %13
+  %22 = load i32, i32* %arg4
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck, label %ThrowNullRef, label %24
+
+; <label>:24                                      ; preds = %21
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load i32, i32* %arg1
+  %28 = sub i32 %26, %27
+  %29 = icmp sle i32 %22, %28
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34, %System.String addrspace(1)* %31, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %24
+  %36 = load i32, i32* %arg3
+  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %37, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
+
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
+  %40 = load i32, i32 addrspace(1)* %39
+  %41 = zext i32 %40 to i64
+  %42 = trunc i64 %41 to i32
+  %43 = load i32, i32* %arg4
+  %44 = sub i32 %42, %43
+  %45 = icmp sgt i32 %36, %44
+  br i1 %45, label %49, label %46
+
+; <label>:46                                      ; preds = %38
+  %47 = load i32, i32* %arg3
+  %48 = icmp sge i32 %47, 0
+  br i1 %48, label %54, label %49
+
+; <label>:49                                      ; preds = %38, %46
+  %50 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %52 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %51)
+  %53 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53, %System.String addrspace(1)* %50, %System.String addrspace(1)* %52)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53) #0
+  unreachable
+
+; <label>:54                                      ; preds = %46
+  %55 = load i32, i32* %arg4
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %97, label %57
+
+; <label>:57                                      ; preds = %54
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %59
+
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 2
+  %61 = bitcast [0 x i16] addrspace(1)* %60 to i16 addrspace(1)*
+  store i16 addrspace(1)* %61, i16 addrspace(1)** %loc0
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  store %"System.Char[]" addrspace(1)* %62, %"System.Char[]" addrspace(1)** %loc2
+  %63 = icmp eq %"System.Char[]" addrspace(1)* %62, null
+  br i1 %63, label %72, label %64
+
+; <label>:64                                      ; preds = %59
+  %65 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc2
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %65, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %66
+
+; <label>:66                                      ; preds = %64
+  %67 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %65, i32 0, i32 1
+  %68 = load i32, i32 addrspace(1)* %67
+  %69 = zext i32 %68 to i64
+  %70 = trunc i64 %69 to i32
+  %71 = icmp ne i32 %70, 0
+  br i1 %71, label %73, label %72
+
+; <label>:72                                      ; preds = %59, %66
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  br label %81
+
+; <label>:73                                      ; preds = %66
+  %74 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc2
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %74, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %75
+
+; <label>:75                                      ; preds = %73
+  %76 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %74, i32 0, i32 1
+  %77 = load i32, i32 addrspace(1)* %76
+  %78 = zext i32 %77 to i64
+  %BoundsCheck = icmp uge i64 0, %78
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %79
+
+; <label>:79                                      ; preds = %75
+  %80 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %74, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %80, i16 addrspace(1)** %loc1
+  br label %81
+
+; <label>:81                                      ; preds = %72, %79
+  %82 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %83 = ptrtoint i16 addrspace(1)* %82 to i64
+  %84 = load i32, i32* %arg3
+  %85 = sext i32 %84 to i64
+  %86 = mul i64 %85, 2
+  %87 = add i64 %83, %86
+  %88 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %89 = ptrtoint i16 addrspace(1)* %88 to i64
+  %90 = load i32, i32* %arg1
+  %91 = sext i32 %90 to i64
+  %92 = mul i64 %91, 2
+  %93 = add i64 %89, %92
+  %94 = load i32, i32* %arg4
+  %95 = inttoptr i64 %87 to i16*
+  %96 = inttoptr i64 %93 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %95, i16* %96, i32 %94)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  br label %97
+
+; <label>:97                                      ; preds = %54, %81
+  ret void
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
 Successfully read ConsoleEncoding.GetPreamble
 
@@ -14827,7 +16746,365 @@ entry:
 }
 
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[loadElemA]
+Successfully read EncoderNLS.GetBytes
+
+define i32 @EncoderNLS.GetBytes(%System.Text.EncoderNLS addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3, %"System.Byte[]" addrspace(1)* %param4, i32 %param5, i8 %param6) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %arg4 = alloca %"System.Byte[]" addrspace(1)*
+  %arg5 = alloca i32
+  %arg6 = alloca i8
+  %loc0 = alloca i32
+  %loc1 = alloca i16 addrspace(1)*
+  %loc2 = alloca i8 addrspace(1)*
+  %loc3 = alloca i32
+  %loc4 = alloca %"System.Char[]" addrspace(1)*
+  %loc5 = alloca %"System.Byte[]" addrspace(1)*
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  store %"System.Byte[]" addrspace(1)* %param4, %"System.Byte[]" addrspace(1)** %arg4
+  store i32 %param5, i32* %arg5
+  store i8 %param6, i8* %arg6
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %1 = icmp eq %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %17, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %7 = icmp eq %"System.Char[]" addrspace(1)* %6, null
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %12
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %12
+
+; <label>:12                                      ; preds = %8, %10
+  %13 = phi %System.String addrspace(1)* [ %9, %8 ], [ %11, %10 ]
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %14)
+  %16 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16, %System.String addrspace(1)* %13, %System.String addrspace(1)* %15)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16) #0
+  unreachable
+
+; <label>:17                                      ; preds = %2
+  %18 = load i32, i32* %arg2
+  %19 = icmp slt i32 %18, 0
+  br i1 %19, label %23, label %20
+
+; <label>:20                                      ; preds = %17
+  %21 = load i32, i32* %arg3
+  %22 = icmp sge i32 %21, 0
+  br i1 %22, label %35, label %23
+
+; <label>:23                                      ; preds = %17, %20
+  %24 = load i32, i32* %arg2
+  %25 = icmp slt i32 %24, 0
+  br i1 %25, label %28, label %26
+
+; <label>:26                                      ; preds = %23
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %30
+
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %30
+
+; <label>:30                                      ; preds = %26, %28
+  %31 = phi %System.String addrspace(1)* [ %27, %26 ], [ %29, %28 ]
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34, %System.String addrspace(1)* %31, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %20
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck, label %ThrowNullRef, label %37
+
+; <label>:37                                      ; preds = %35
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = load i32, i32* %arg2
+  %43 = sub i32 %41, %42
+  %44 = load i32, i32* %arg3
+  %45 = icmp sge i32 %43, %44
+  br i1 %45, label %51, label %46
+
+; <label>:46                                      ; preds = %37
+  %47 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %48 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %49 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %48)
+  %50 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %50, %System.String addrspace(1)* %47, %System.String addrspace(1)* %49)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %50) #0
+  unreachable
+
+; <label>:51                                      ; preds = %37
+  %52 = load i32, i32* %arg5
+  %53 = icmp slt i32 %52, 0
+  br i1 %53, label %63, label %54
+
+; <label>:54                                      ; preds = %51
+  %55 = load i32, i32* %arg5
+  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck1 = icmp eq %"System.Byte[]" addrspace(1)* %56, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %57
+
+; <label>:57                                      ; preds = %54
+  %58 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = zext i32 %59 to i64
+  %61 = trunc i64 %60 to i32
+  %62 = icmp sle i32 %55, %61
+  br i1 %62, label %68, label %63
+
+; <label>:63                                      ; preds = %51, %57
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %66 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %65)
+  %67 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %67, %System.String addrspace(1)* %64, %System.String addrspace(1)* %66)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %67) #0
+  unreachable
+
+; <label>:68                                      ; preds = %57
+  %69 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %69, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %69, i32 0, i32 1
+  %72 = load i32, i32 addrspace(1)* %71
+  %73 = zext i32 %72 to i64
+  %74 = trunc i64 %73 to i32
+  %75 = icmp ne i32 %74, 0
+  br i1 %75, label %78, label %76
+
+; <label>:76                                      ; preds = %70
+  %77 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1)
+  store %"System.Char[]" addrspace(1)* %77, %"System.Char[]" addrspace(1)** %arg1
+  br label %78
+
+; <label>:78                                      ; preds = %70, %76
+  %79 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck5 = icmp eq %"System.Byte[]" addrspace(1)* %79, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %80
+
+; <label>:80                                      ; preds = %78
+  %81 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %79, i32 0, i32 1
+  %82 = load i32, i32 addrspace(1)* %81
+  %83 = zext i32 %82 to i64
+  %84 = trunc i64 %83 to i32
+  %85 = load i32, i32* %arg5
+  %86 = sub i32 %84, %85
+  store i32 %86, i32* %loc0
+  %87 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck7 = icmp eq %"System.Byte[]" addrspace(1)* %87, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %88
+
+; <label>:88                                      ; preds = %80
+  %89 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %87, i32 0, i32 1
+  %90 = load i32, i32 addrspace(1)* %89
+  %91 = zext i32 %90 to i64
+  %92 = trunc i64 %91 to i32
+  %93 = icmp ne i32 %92, 0
+  br i1 %93, label %96, label %94
+
+; <label>:94                                      ; preds = %88
+  %95 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1)
+  store %"System.Byte[]" addrspace(1)* %95, %"System.Byte[]" addrspace(1)** %arg4
+  br label %96
+
+; <label>:96                                      ; preds = %88, %94
+  %97 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  store %"System.Char[]" addrspace(1)* %97, %"System.Char[]" addrspace(1)** %loc4
+  %98 = icmp eq %"System.Char[]" addrspace(1)* %97, null
+  br i1 %98, label %107, label %99
+
+; <label>:99                                      ; preds = %96
+  %100 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc4
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %100, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %101
+
+; <label>:101                                     ; preds = %99
+  %102 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %100, i32 0, i32 1
+  %103 = load i32, i32 addrspace(1)* %102
+  %104 = zext i32 %103 to i64
+  %105 = trunc i64 %104 to i32
+  %106 = icmp ne i32 %105, 0
+  br i1 %106, label %108, label %107
+
+; <label>:107                                     ; preds = %96, %101
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  br label %116
+
+; <label>:108                                     ; preds = %101
+  %109 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc4
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %109, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %110
+
+; <label>:110                                     ; preds = %108
+  %111 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %109, i32 0, i32 1
+  %112 = load i32, i32 addrspace(1)* %111
+  %113 = zext i32 %112 to i64
+  %BoundsCheck = icmp uge i64 0, %113
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %114
+
+; <label>:114                                     ; preds = %110
+  %115 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %109, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %115, i16 addrspace(1)** %loc1
+  br label %116
+
+; <label>:116                                     ; preds = %107, %114
+  %117 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  store %"System.Byte[]" addrspace(1)* %117, %"System.Byte[]" addrspace(1)** %loc5
+  %118 = icmp eq %"System.Byte[]" addrspace(1)* %117, null
+  br i1 %118, label %127, label %119
+
+; <label>:119                                     ; preds = %116
+  %120 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc5
+  %NullCheck13 = icmp eq %"System.Byte[]" addrspace(1)* %120, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %121
+
+; <label>:121                                     ; preds = %119
+  %122 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %120, i32 0, i32 1
+  %123 = load i32, i32 addrspace(1)* %122
+  %124 = zext i32 %123 to i64
+  %125 = trunc i64 %124 to i32
+  %126 = icmp ne i32 %125, 0
+  br i1 %126, label %128, label %127
+
+; <label>:127                                     ; preds = %116, %121
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc2
+  br label %136
+
+; <label>:128                                     ; preds = %121
+  %129 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc5
+  %NullCheck15 = icmp eq %"System.Byte[]" addrspace(1)* %129, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %130
+
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %129, i32 0, i32 1
+  %132 = load i32, i32 addrspace(1)* %131
+  %133 = zext i32 %132 to i64
+  %BoundsCheck17 = icmp uge i64 0, %133
+  br i1 %BoundsCheck17, label %ThrowIndexOutOfRange18, label %134
+
+; <label>:134                                     ; preds = %130
+  %135 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %129, i32 0, i32 3, i32 0
+  store i8 addrspace(1)* %135, i8 addrspace(1)** %loc2
+  br label %136
+
+; <label>:136                                     ; preds = %127, %134
+  %137 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %138 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %139 = ptrtoint i16 addrspace(1)* %138 to i64
+  %140 = load i32, i32* %arg2
+  %141 = sext i32 %140 to i64
+  %142 = mul i64 %141, 2
+  %143 = add i64 %139, %142
+  %144 = load i32, i32* %arg3
+  %145 = load i8 addrspace(1)*, i8 addrspace(1)** %loc2
+  %146 = ptrtoint i8 addrspace(1)* %145 to i64
+  %147 = load i32, i32* %arg5
+  %148 = sext i32 %147 to i64
+  %149 = add i64 %146, %148
+  %150 = load i32, i32* %loc0
+  %151 = load i8, i8* %arg6
+  %152 = zext i8 %151 to i32
+  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i64 addrspace(1)*
+  %NullCheck19 = icmp eq i64 addrspace(1)* %153, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %154
+
+; <label>:154                                     ; preds = %136
+  %155 = load i64, i64 addrspace(1)* %153
+  %156 = add i64 %155, 72
+  %157 = inttoptr i64 %156 to i64*
+  %158 = load i64, i64* %157
+  %159 = add i64 %158, 0
+  %160 = inttoptr i64 %159 to i64*
+  %161 = load i64, i64* %160
+  %162 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to %System.Text.Encoder addrspace(1)*
+  %163 = inttoptr i64 %143 to i16*
+  %164 = inttoptr i64 %149 to i8*
+  %165 = trunc i32 %152 to i8
+  %166 = inttoptr i64 %161 to i32 (%System.Text.Encoder addrspace(1)*, i16*, i32, i8*, i32, i8)*
+  %167 = call i32 %166(%System.Text.Encoder addrspace(1)* %162, i16* %163, i32 %144, i8* %164, i32 %150, i8 %165)
+  store i32 %167, i32* %loc3
+  br label %168
+
+; <label>:168                                     ; preds = %154
+  %169 = load i32, i32* %loc3
+  ret i32 %169
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %110
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %119
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange18:                           ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
 Successfully read EncoderNLS.GetBytes
 
@@ -14916,22 +17193,22 @@ entry:
   %40 = load i8, i8* %arg5
   %41 = zext i8 %40 to i32
   %42 = trunc i32 %41 to i8
-  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %39, null
-  br i1 %NullCheck, label %43, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderNLS addrspace(1)* %39, null
+  br i1 %NullCheck, label %ThrowNullRef, label %43
 
 ; <label>:43                                      ; preds = %38
   %44 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
   store i8 %42, i8 addrspace(1)* %44
   %45 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %45, null
-  br i1 %NullCheck2, label %46, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.EncoderNLS addrspace(1)* %45, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %46
 
 ; <label>:46                                      ; preds = %43
   %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %45, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %47
   %48 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.EncoderNLS addrspace(1)* %48, null
-  br i1 %NullCheck4, label %49, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.EncoderNLS addrspace(1)* %48, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %49
 
 ; <label>:49                                      ; preds = %46
   %50 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %48, i32 0, i32 3
@@ -14942,8 +17219,8 @@ entry:
   %55 = load i32, i32* %arg4
   %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck6, label %58, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
   %59 = load i64, i64 addrspace(1)* %57
@@ -14961,15 +17238,15 @@ ThrowNullRef:                                     ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %43
+ThrowNullRef2:                                    ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %46
+ThrowNullRef4:                                    ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %49
+ThrowNullRef6:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14997,8 +17274,8 @@ entry:
   %4 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0 to %System.IO.ConsoleStream addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*)(%System.IO.ConsoleStream addrspace(1)* %4, %"System.Byte[]" addrspace(1)* %1, i32 %2, i32 %3)
   %5 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
@@ -15083,8 +17360,8 @@ entry:
 
 ; <label>:22                                      ; preds = %8
   %23 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %23, null
-  br i1 %NullCheck, label %24, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Byte[]" addrspace(1)* %23, null
+  br i1 %NullCheck, label %ThrowNullRef, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
@@ -15106,8 +17383,8 @@ entry:
 
 ; <label>:36                                      ; preds = %24
   %37 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %37, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.ConsoleStream addrspace(1)* %37, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %37, i32 0, i32 4
@@ -15128,13 +17405,138 @@ ThrowNullRef:                                     ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %36
+ThrowNullRef2:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
-Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
+Successfully read WindowsConsoleStream.WriteFileNative
+
+define i32 @WindowsConsoleStream.WriteFileNative(i64 %param0, %"System.Byte[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i64
+  %arg1 = alloca %"System.Byte[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i8 addrspace(1)*
+  %loc2 = alloca %"System.Byte[]" addrspace(1)*
+  %loc3 = alloca i32
+  store i64 %param0, i64* %arg0
+  store %"System.Byte[]" addrspace(1)* %param1, %"System.Byte[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Byte[]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = zext i32 %3 to i64
+  %5 = icmp ne i64 %4, 0
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %1
+  ret i32 0
+
+; <label>:7                                       ; preds = %1
+  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  store %"System.Byte[]" addrspace(1)* %8, %"System.Byte[]" addrspace(1)** %loc2
+  %9 = icmp eq %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %9, label %18, label %10
+
+; <label>:10                                      ; preds = %7
+  %11 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc2
+  %NullCheck1 = icmp eq %"System.Byte[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %11, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp ne i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %7, %12
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc1
+  br label %27
+
+; <label>:19                                      ; preds = %12
+  %20 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc2
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %20, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %BoundsCheck = icmp uge i64 0, %24
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %25
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %20, i32 0, i32 3, i32 0
+  store i8 addrspace(1)* %26, i8 addrspace(1)** %loc1
+  br label %27
+
+; <label>:27                                      ; preds = %18, %25
+  %28 = load i64, i64* %arg0
+  %29 = load i8 addrspace(1)*, i8 addrspace(1)** %loc1
+  %30 = ptrtoint i8 addrspace(1)* %29 to i64
+  %31 = load i32, i32* %arg2
+  %32 = sext i32 %31 to i64
+  %33 = add i64 %30, %32
+  %34 = load i32, i32* %arg3
+  %35 = addrspacecast i32* %loc3 to i32 addrspace(1)*
+  %36 = inttoptr i64 %33 to i8*
+  %37 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i8*, i32, i32 addrspace(1)*, i64)*)(i64 %28, i8* %36, i32 %34, i32 addrspace(1)* %35, i64 0)
+  %38 = icmp ugt i32 %37, 0
+  %39 = sext i1 %38 to i32
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc1
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %42, label %41
+
+; <label>:41                                      ; preds = %27
+  ret i32 0
+
+; <label>:42                                      ; preds = %27
+  %43 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  store i32 %43, i32* %loc0
+  %44 = load i32, i32* %loc0
+  %45 = icmp eq i32 %44, 232
+  br i1 %45, label %49, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = load i32, i32* %loc0
+  %48 = icmp ne i32 %47, 109
+  br i1 %48, label %50, label %49
+
+; <label>:49                                      ; preds = %42, %46
+  ret i32 0
+
+; <label>:50                                      ; preds = %46
+  %51 = load i32, i32* %loc0
+  ret i32 %51
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
 Successfully read WindowsConsoleStream.Flush
 
@@ -15143,8 +17545,8 @@ entry:
   %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
   store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
@@ -15179,8 +17581,8 @@ entry:
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
   %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load i64, i64 addrspace(1)* %1
@@ -15219,15 +17621,15 @@ entry:
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.TextWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
   %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %3, align 8
   %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
   %7 = load i64, i64 addrspace(1)* %5
@@ -15245,7 +17647,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -15274,8 +17676,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %4)
   store i32 0, i32* %loc0
   %5 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Char[]" addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
@@ -15287,15 +17689,15 @@ entry:
 
 ; <label>:11                                      ; preds = %69
   %12 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %12, i32 0, i32 9
   %15 = load i32, i32 addrspace(1)* %14, align 8
   %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.IO.StreamWriter addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %16, i32 0, i32 10
@@ -15310,15 +17712,15 @@ entry:
 
 ; <label>:23                                      ; preds = %17, %21
   %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %24, null
-  br i1 %NullCheck8, label %25, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %24, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 10
   %27 = load i32, i32 addrspace(1)* %26, align 8
   %28 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %28, null
-  br i1 %NullCheck10, label %29, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.StreamWriter addrspace(1)* %28, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %28, i32 0, i32 9
@@ -15340,15 +17742,15 @@ entry:
   %40 = load i32, i32* %loc0
   %41 = mul i32 %40, 2
   %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
-  br i1 %NullCheck12, label %43, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %43
 
 ; <label>:43                                      ; preds = %38
   %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 7
   %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %44, align 8
   %46 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %46, null
-  br i1 %NullCheck14, label %47, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.IO.StreamWriter addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %47
 
 ; <label>:47                                      ; preds = %43
   %48 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %46, i32 0, i32 9
@@ -15360,16 +17762,16 @@ entry:
   %54 = bitcast %"System.Char[]" addrspace(1)* %45 to %System.Array addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %53, i32 %41, %System.Array addrspace(1)* %54, i32 %50, i32 %52)
   %55 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
-  br i1 %NullCheck16, label %56, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %56
 
 ; <label>:56                                      ; preds = %47
   %57 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
   %58 = load i32, i32 addrspace(1)* %57, align 8
   %59 = load i32, i32* %loc2
   %60 = add i32 %58, %59
-  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
-  br i1 %NullCheck18, label %61, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %61
 
 ; <label>:61                                      ; preds = %56
   %62 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
@@ -15391,8 +17793,8 @@ entry:
 
 ; <label>:72                                      ; preds = %69
   %73 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %73, null
-  br i1 %NullCheck2, label %74, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %73, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %74
 
 ; <label>:74                                      ; preds = %72
   %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %73, i32 0, i32 11
@@ -15413,39 +17815,39 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %72
+ThrowNullRef2:                                    ; preds = %72
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %23
+ThrowNullRef8:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef10:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %43
+ThrowNullRef14:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %47
+ThrowNullRef16:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %56
+ThrowNullRef18:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPRem.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPRem.error.txt
@@ -25,8 +25,8 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
@@ -40,8 +40,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
   %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
@@ -75,7 +75,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -90,8 +90,8 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %NullCheck = icmp ne i8 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = load i8, i8 addrspace(1)* %0, align 8
@@ -125,8 +125,8 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
@@ -159,8 +159,8 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -184,8 +184,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
   store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
@@ -195,8 +195,8 @@ entry:
 ; <label>:4                                       ; preds = %1
   %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
   %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
@@ -206,8 +206,8 @@ entry:
   %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
@@ -221,14 +221,14 @@ entry:
 
 ; <label>:17                                      ; preds = %14
   %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
   %21 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
@@ -238,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -249,8 +249,8 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
@@ -261,27 +261,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %30
+ThrowNullRef10:                                   ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -301,7 +301,89 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
-Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
+Successfully read AppDomainSetup.GetUnsecureApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.GetUnsecureApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %NullCheck = icmp eq %"System.String[]" addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %BoundsCheck = icmp uge i64 0, %5
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %6
+
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 3, i32 0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
+  ret %System.String addrspace(1)* %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_Value using LLILCJit
+Successfully read AppDomainSetup.get_Value
+
+define %"System.String[]" addrspace(1)* @AppDomainSetup.get_Value(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.String[]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 18)
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.String[]" addrspace(1)* addrspace(1)*, %"System.String[]" addrspace(1)*)*)(%"System.String[]" addrspace(1)* addrspace(1)* %9, %"System.String[]" addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %11, i32 0, i32 1
+  %14 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %13, align 8
+  ret %"System.String[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -319,8 +401,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -368,16 +450,16 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
   %5 = load i32, i32 addrspace(1)* %4
   %6 = sub i32 %5, 1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -389,7 +471,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -421,8 +503,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
@@ -456,8 +538,8 @@ entry:
 ; <label>:27                                      ; preds = %19
   %28 = load i32, i32* %arg1
   %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
-  br i1 %NullCheck2, label %30, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %29, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %30
 
 ; <label>:30                                      ; preds = %27
   %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
@@ -493,8 +575,8 @@ entry:
 ; <label>:49                                      ; preds = %46
   %50 = load i32, i32* %arg2
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck4, label %52, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
@@ -517,11 +599,11 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %27
+ThrowNullRef2:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %49
+ThrowNullRef4:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -544,16 +626,16 @@ entry:
   %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %0)
   store %System.String addrspace(1)* %1, %System.String addrspace(1)** %loc0
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 2
   %5 = bitcast [0 x i16] addrspace(1)* %4 to i16 addrspace(1)*
   store i16 addrspace(1)* %5, i16 addrspace(1)** %loc1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %3
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2
@@ -580,7 +662,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -691,15 +773,15 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %NullCheck132 = icmp ne i8* %21, null
-  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+  %NullCheck131 = icmp eq i8* %21, null
+  br i1 %NullCheck131, label %ThrowNullRef132, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = load i8, i8* %21, align 8
   %24 = zext i8 %23 to i32
   %25 = trunc i32 %24 to i8
-  %NullCheck134 = icmp ne i8* %20, null
-  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+  %NullCheck133 = icmp eq i8* %20, null
+  br i1 %NullCheck133, label %ThrowNullRef134, label %26
 
 ; <label>:26                                      ; preds = %22
   store i8 %25, i8* %20, align 8
@@ -709,16 +791,16 @@ entry:
   %28 = load i8*, i8** %arg0
   %29 = load i8*, i8** %arg1
   %30 = bitcast i8* %29 to i16*
-  %NullCheck128 = icmp ne i16* %30, null
-  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+  %NullCheck127 = icmp eq i16* %30, null
+  br i1 %NullCheck127, label %ThrowNullRef128, label %31
 
 ; <label>:31                                      ; preds = %27
   %32 = load i16, i16* %30, align 8
   %33 = sext i16 %32 to i32
   %34 = bitcast i8* %28 to i16*
   %35 = trunc i32 %33 to i16
-  %NullCheck130 = icmp ne i16* %34, null
-  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+  %NullCheck129 = icmp eq i16* %34, null
+  br i1 %NullCheck129, label %ThrowNullRef130, label %36
 
 ; <label>:36                                      ; preds = %31
   store i16 %35, i16* %34, align 8
@@ -728,16 +810,16 @@ entry:
   %38 = load i8*, i8** %arg0
   %39 = load i8*, i8** %arg1
   %40 = bitcast i8* %39 to i16*
-  %NullCheck120 = icmp ne i16* %40, null
-  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+  %NullCheck119 = icmp eq i16* %40, null
+  br i1 %NullCheck119, label %ThrowNullRef120, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i16, i16* %40, align 8
   %43 = sext i16 %42 to i32
   %44 = bitcast i8* %38 to i16*
   %45 = trunc i32 %43 to i16
-  %NullCheck122 = icmp ne i16* %44, null
-  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+  %NullCheck121 = icmp eq i16* %44, null
+  br i1 %NullCheck121, label %ThrowNullRef122, label %46
 
 ; <label>:46                                      ; preds = %41
   store i16 %45, i16* %44, align 8
@@ -745,15 +827,15 @@ entry:
   %48 = getelementptr inbounds i8, i8* %47, i64 2
   %49 = load i8*, i8** %arg1
   %50 = getelementptr inbounds i8, i8* %49, i64 2
-  %NullCheck124 = icmp ne i8* %50, null
-  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+  %NullCheck123 = icmp eq i8* %50, null
+  br i1 %NullCheck123, label %ThrowNullRef124, label %51
 
 ; <label>:51                                      ; preds = %46
   %52 = load i8, i8* %50, align 8
   %53 = zext i8 %52 to i32
   %54 = trunc i32 %53 to i8
-  %NullCheck126 = icmp ne i8* %48, null
-  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+  %NullCheck125 = icmp eq i8* %48, null
+  br i1 %NullCheck125, label %ThrowNullRef126, label %55
 
 ; <label>:55                                      ; preds = %51
   store i8 %54, i8* %48, align 8
@@ -763,14 +845,14 @@ entry:
   %57 = load i8*, i8** %arg0
   %58 = load i8*, i8** %arg1
   %59 = bitcast i8* %58 to i32*
-  %NullCheck116 = icmp ne i32* %59, null
-  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+  %NullCheck115 = icmp eq i32* %59, null
+  br i1 %NullCheck115, label %ThrowNullRef116, label %60
 
 ; <label>:60                                      ; preds = %56
   %61 = load i32, i32* %59, align 8
   %62 = bitcast i8* %57 to i32*
-  %NullCheck118 = icmp ne i32* %62, null
-  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+  %NullCheck117 = icmp eq i32* %62, null
+  br i1 %NullCheck117, label %ThrowNullRef118, label %63
 
 ; <label>:63                                      ; preds = %60
   store i32 %61, i32* %62, align 8
@@ -780,14 +862,14 @@ entry:
   %65 = load i8*, i8** %arg0
   %66 = load i8*, i8** %arg1
   %67 = bitcast i8* %66 to i32*
-  %NullCheck108 = icmp ne i32* %67, null
-  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+  %NullCheck107 = icmp eq i32* %67, null
+  br i1 %NullCheck107, label %ThrowNullRef108, label %68
 
 ; <label>:68                                      ; preds = %64
   %69 = load i32, i32* %67, align 8
   %70 = bitcast i8* %65 to i32*
-  %NullCheck110 = icmp ne i32* %70, null
-  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+  %NullCheck109 = icmp eq i32* %70, null
+  br i1 %NullCheck109, label %ThrowNullRef110, label %71
 
 ; <label>:71                                      ; preds = %68
   store i32 %69, i32* %70, align 8
@@ -795,15 +877,15 @@ entry:
   %73 = getelementptr inbounds i8, i8* %72, i64 4
   %74 = load i8*, i8** %arg1
   %75 = getelementptr inbounds i8, i8* %74, i64 4
-  %NullCheck112 = icmp ne i8* %75, null
-  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+  %NullCheck111 = icmp eq i8* %75, null
+  br i1 %NullCheck111, label %ThrowNullRef112, label %76
 
 ; <label>:76                                      ; preds = %71
   %77 = load i8, i8* %75, align 8
   %78 = zext i8 %77 to i32
   %79 = trunc i32 %78 to i8
-  %NullCheck114 = icmp ne i8* %73, null
-  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+  %NullCheck113 = icmp eq i8* %73, null
+  br i1 %NullCheck113, label %ThrowNullRef114, label %80
 
 ; <label>:80                                      ; preds = %76
   store i8 %79, i8* %73, align 8
@@ -813,14 +895,14 @@ entry:
   %82 = load i8*, i8** %arg0
   %83 = load i8*, i8** %arg1
   %84 = bitcast i8* %83 to i32*
-  %NullCheck100 = icmp ne i32* %84, null
-  br i1 %NullCheck100, label %85, label %ThrowNullRef99
+  %NullCheck99 = icmp eq i32* %84, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %85
 
 ; <label>:85                                      ; preds = %81
   %86 = load i32, i32* %84, align 8
   %87 = bitcast i8* %82 to i32*
-  %NullCheck102 = icmp ne i32* %87, null
-  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+  %NullCheck101 = icmp eq i32* %87, null
+  br i1 %NullCheck101, label %ThrowNullRef102, label %88
 
 ; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
@@ -829,16 +911,16 @@ entry:
   %91 = load i8*, i8** %arg1
   %92 = getelementptr inbounds i8, i8* %91, i64 4
   %93 = bitcast i8* %92 to i16*
-  %NullCheck104 = icmp ne i16* %93, null
-  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+  %NullCheck103 = icmp eq i16* %93, null
+  br i1 %NullCheck103, label %ThrowNullRef104, label %94
 
 ; <label>:94                                      ; preds = %88
   %95 = load i16, i16* %93, align 8
   %96 = sext i16 %95 to i32
   %97 = bitcast i8* %90 to i16*
   %98 = trunc i32 %96 to i16
-  %NullCheck106 = icmp ne i16* %97, null
-  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+  %NullCheck105 = icmp eq i16* %97, null
+  br i1 %NullCheck105, label %ThrowNullRef106, label %99
 
 ; <label>:99                                      ; preds = %94
   store i16 %98, i16* %97, align 8
@@ -848,14 +930,14 @@ entry:
   %101 = load i8*, i8** %arg0
   %102 = load i8*, i8** %arg1
   %103 = bitcast i8* %102 to i32*
-  %NullCheck88 = icmp ne i32* %103, null
-  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+  %NullCheck87 = icmp eq i32* %103, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %104
 
 ; <label>:104                                     ; preds = %100
   %105 = load i32, i32* %103, align 8
   %106 = bitcast i8* %101 to i32*
-  %NullCheck90 = icmp ne i32* %106, null
-  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+  %NullCheck89 = icmp eq i32* %106, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %107
 
 ; <label>:107                                     ; preds = %104
   store i32 %105, i32* %106, align 8
@@ -864,16 +946,16 @@ entry:
   %110 = load i8*, i8** %arg1
   %111 = getelementptr inbounds i8, i8* %110, i64 4
   %112 = bitcast i8* %111 to i16*
-  %NullCheck92 = icmp ne i16* %112, null
-  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+  %NullCheck91 = icmp eq i16* %112, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %113
 
 ; <label>:113                                     ; preds = %107
   %114 = load i16, i16* %112, align 8
   %115 = sext i16 %114 to i32
   %116 = bitcast i8* %109 to i16*
   %117 = trunc i32 %115 to i16
-  %NullCheck94 = icmp ne i16* %116, null
-  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+  %NullCheck93 = icmp eq i16* %116, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %118
 
 ; <label>:118                                     ; preds = %113
   store i16 %117, i16* %116, align 8
@@ -881,15 +963,15 @@ entry:
   %120 = getelementptr inbounds i8, i8* %119, i64 6
   %121 = load i8*, i8** %arg1
   %122 = getelementptr inbounds i8, i8* %121, i64 6
-  %NullCheck96 = icmp ne i8* %122, null
-  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+  %NullCheck95 = icmp eq i8* %122, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %123
 
 ; <label>:123                                     ; preds = %118
   %124 = load i8, i8* %122, align 8
   %125 = zext i8 %124 to i32
   %126 = trunc i32 %125 to i8
-  %NullCheck98 = icmp ne i8* %120, null
-  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+  %NullCheck97 = icmp eq i8* %120, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %127
 
 ; <label>:127                                     ; preds = %123
   store i8 %126, i8* %120, align 8
@@ -899,14 +981,14 @@ entry:
   %129 = load i8*, i8** %arg0
   %130 = load i8*, i8** %arg1
   %131 = bitcast i8* %130 to i64*
-  %NullCheck84 = icmp ne i64* %131, null
-  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+  %NullCheck83 = icmp eq i64* %131, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %132
 
 ; <label>:132                                     ; preds = %128
   %133 = load i64, i64* %131, align 8
   %134 = bitcast i8* %129 to i64*
-  %NullCheck86 = icmp ne i64* %134, null
-  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+  %NullCheck85 = icmp eq i64* %134, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %135
 
 ; <label>:135                                     ; preds = %132
   store i64 %133, i64* %134, align 8
@@ -916,14 +998,14 @@ entry:
   %137 = load i8*, i8** %arg0
   %138 = load i8*, i8** %arg1
   %139 = bitcast i8* %138 to i64*
-  %NullCheck76 = icmp ne i64* %139, null
-  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+  %NullCheck75 = icmp eq i64* %139, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %140
 
 ; <label>:140                                     ; preds = %136
   %141 = load i64, i64* %139, align 8
   %142 = bitcast i8* %137 to i64*
-  %NullCheck78 = icmp ne i64* %142, null
-  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+  %NullCheck77 = icmp eq i64* %142, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %143
 
 ; <label>:143                                     ; preds = %140
   store i64 %141, i64* %142, align 8
@@ -931,15 +1013,15 @@ entry:
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %NullCheck80 = icmp ne i8* %147, null
-  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+  %NullCheck79 = icmp eq i8* %147, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %148
 
 ; <label>:148                                     ; preds = %143
   %149 = load i8, i8* %147, align 8
   %150 = zext i8 %149 to i32
   %151 = trunc i32 %150 to i8
-  %NullCheck82 = icmp ne i8* %145, null
-  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+  %NullCheck81 = icmp eq i8* %145, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %152
 
 ; <label>:152                                     ; preds = %148
   store i8 %151, i8* %145, align 8
@@ -949,14 +1031,14 @@ entry:
   %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
   %156 = bitcast i8* %155 to i64*
-  %NullCheck68 = icmp ne i64* %156, null
-  br i1 %NullCheck68, label %157, label %ThrowNullRef67
+  %NullCheck67 = icmp eq i64* %156, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %157
 
 ; <label>:157                                     ; preds = %153
   %158 = load i64, i64* %156, align 8
   %159 = bitcast i8* %154 to i64*
-  %NullCheck70 = icmp ne i64* %159, null
-  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+  %NullCheck69 = icmp eq i64* %159, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %160
 
 ; <label>:160                                     ; preds = %157
   store i64 %158, i64* %159, align 8
@@ -965,16 +1047,16 @@ entry:
   %163 = load i8*, i8** %arg1
   %164 = getelementptr inbounds i8, i8* %163, i64 8
   %165 = bitcast i8* %164 to i16*
-  %NullCheck72 = icmp ne i16* %165, null
-  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+  %NullCheck71 = icmp eq i16* %165, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %166
 
 ; <label>:166                                     ; preds = %160
   %167 = load i16, i16* %165, align 8
   %168 = sext i16 %167 to i32
   %169 = bitcast i8* %162 to i16*
   %170 = trunc i32 %168 to i16
-  %NullCheck74 = icmp ne i16* %169, null
-  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+  %NullCheck73 = icmp eq i16* %169, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %171
 
 ; <label>:171                                     ; preds = %166
   store i16 %170, i16* %169, align 8
@@ -984,14 +1066,14 @@ entry:
   %173 = load i8*, i8** %arg0
   %174 = load i8*, i8** %arg1
   %175 = bitcast i8* %174 to i64*
-  %NullCheck56 = icmp ne i64* %175, null
-  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+  %NullCheck55 = icmp eq i64* %175, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %176
 
 ; <label>:176                                     ; preds = %172
   %177 = load i64, i64* %175, align 8
   %178 = bitcast i8* %173 to i64*
-  %NullCheck58 = icmp ne i64* %178, null
-  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+  %NullCheck57 = icmp eq i64* %178, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %179
 
 ; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
@@ -1000,16 +1082,16 @@ entry:
   %182 = load i8*, i8** %arg1
   %183 = getelementptr inbounds i8, i8* %182, i64 8
   %184 = bitcast i8* %183 to i16*
-  %NullCheck60 = icmp ne i16* %184, null
-  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+  %NullCheck59 = icmp eq i16* %184, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %185
 
 ; <label>:185                                     ; preds = %179
   %186 = load i16, i16* %184, align 8
   %187 = sext i16 %186 to i32
   %188 = bitcast i8* %181 to i16*
   %189 = trunc i32 %187 to i16
-  %NullCheck62 = icmp ne i16* %188, null
-  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+  %NullCheck61 = icmp eq i16* %188, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %190
 
 ; <label>:190                                     ; preds = %185
   store i16 %189, i16* %188, align 8
@@ -1017,15 +1099,15 @@ entry:
   %192 = getelementptr inbounds i8, i8* %191, i64 10
   %193 = load i8*, i8** %arg1
   %194 = getelementptr inbounds i8, i8* %193, i64 10
-  %NullCheck64 = icmp ne i8* %194, null
-  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+  %NullCheck63 = icmp eq i8* %194, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %195
 
 ; <label>:195                                     ; preds = %190
   %196 = load i8, i8* %194, align 8
   %197 = zext i8 %196 to i32
   %198 = trunc i32 %197 to i8
-  %NullCheck66 = icmp ne i8* %192, null
-  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+  %NullCheck65 = icmp eq i8* %192, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %199
 
 ; <label>:199                                     ; preds = %195
   store i8 %198, i8* %192, align 8
@@ -1035,14 +1117,14 @@ entry:
   %201 = load i8*, i8** %arg0
   %202 = load i8*, i8** %arg1
   %203 = bitcast i8* %202 to i64*
-  %NullCheck48 = icmp ne i64* %203, null
-  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+  %NullCheck47 = icmp eq i64* %203, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %204
 
 ; <label>:204                                     ; preds = %200
   %205 = load i64, i64* %203, align 8
   %206 = bitcast i8* %201 to i64*
-  %NullCheck50 = icmp ne i64* %206, null
-  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+  %NullCheck49 = icmp eq i64* %206, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %207
 
 ; <label>:207                                     ; preds = %204
   store i64 %205, i64* %206, align 8
@@ -1051,14 +1133,14 @@ entry:
   %210 = load i8*, i8** %arg1
   %211 = getelementptr inbounds i8, i8* %210, i64 8
   %212 = bitcast i8* %211 to i32*
-  %NullCheck52 = icmp ne i32* %212, null
-  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+  %NullCheck51 = icmp eq i32* %212, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %213
 
 ; <label>:213                                     ; preds = %207
   %214 = load i32, i32* %212, align 8
   %215 = bitcast i8* %209 to i32*
-  %NullCheck54 = icmp ne i32* %215, null
-  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+  %NullCheck53 = icmp eq i32* %215, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %216
 
 ; <label>:216                                     ; preds = %213
   store i32 %214, i32* %215, align 8
@@ -1068,14 +1150,14 @@ entry:
   %218 = load i8*, i8** %arg0
   %219 = load i8*, i8** %arg1
   %220 = bitcast i8* %219 to i64*
-  %NullCheck36 = icmp ne i64* %220, null
-  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64* %220, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %221
 
 ; <label>:221                                     ; preds = %217
   %222 = load i64, i64* %220, align 8
   %223 = bitcast i8* %218 to i64*
-  %NullCheck38 = icmp ne i64* %223, null
-  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+  %NullCheck37 = icmp eq i64* %223, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %224
 
 ; <label>:224                                     ; preds = %221
   store i64 %222, i64* %223, align 8
@@ -1084,14 +1166,14 @@ entry:
   %227 = load i8*, i8** %arg1
   %228 = getelementptr inbounds i8, i8* %227, i64 8
   %229 = bitcast i8* %228 to i32*
-  %NullCheck40 = icmp ne i32* %229, null
-  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i32* %229, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %230
 
 ; <label>:230                                     ; preds = %224
   %231 = load i32, i32* %229, align 8
   %232 = bitcast i8* %226 to i32*
-  %NullCheck42 = icmp ne i32* %232, null
-  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+  %NullCheck41 = icmp eq i32* %232, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %233
 
 ; <label>:233                                     ; preds = %230
   store i32 %231, i32* %232, align 8
@@ -1099,15 +1181,15 @@ entry:
   %235 = getelementptr inbounds i8, i8* %234, i64 12
   %236 = load i8*, i8** %arg1
   %237 = getelementptr inbounds i8, i8* %236, i64 12
-  %NullCheck44 = icmp ne i8* %237, null
-  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i8* %237, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %238
 
 ; <label>:238                                     ; preds = %233
   %239 = load i8, i8* %237, align 8
   %240 = zext i8 %239 to i32
   %241 = trunc i32 %240 to i8
-  %NullCheck46 = icmp ne i8* %235, null
-  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+  %NullCheck45 = icmp eq i8* %235, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %242
 
 ; <label>:242                                     ; preds = %238
   store i8 %241, i8* %235, align 8
@@ -1117,14 +1199,14 @@ entry:
   %244 = load i8*, i8** %arg0
   %245 = load i8*, i8** %arg1
   %246 = bitcast i8* %245 to i64*
-  %NullCheck24 = icmp ne i64* %246, null
-  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64* %246, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %247
 
 ; <label>:247                                     ; preds = %243
   %248 = load i64, i64* %246, align 8
   %249 = bitcast i8* %244 to i64*
-  %NullCheck26 = icmp ne i64* %249, null
-  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64* %249, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %250
 
 ; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
@@ -1133,14 +1215,14 @@ entry:
   %253 = load i8*, i8** %arg1
   %254 = getelementptr inbounds i8, i8* %253, i64 8
   %255 = bitcast i8* %254 to i32*
-  %NullCheck28 = icmp ne i32* %255, null
-  br i1 %NullCheck28, label %256, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i32* %255, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %256
 
 ; <label>:256                                     ; preds = %250
   %257 = load i32, i32* %255, align 8
   %258 = bitcast i8* %252 to i32*
-  %NullCheck30 = icmp ne i32* %258, null
-  br i1 %NullCheck30, label %259, label %ThrowNullRef29
+  %NullCheck29 = icmp eq i32* %258, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %259
 
 ; <label>:259                                     ; preds = %256
   store i32 %257, i32* %258, align 8
@@ -1149,16 +1231,16 @@ entry:
   %262 = load i8*, i8** %arg1
   %263 = getelementptr inbounds i8, i8* %262, i64 12
   %264 = bitcast i8* %263 to i16*
-  %NullCheck32 = icmp ne i16* %264, null
-  br i1 %NullCheck32, label %265, label %ThrowNullRef31
+  %NullCheck31 = icmp eq i16* %264, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %265
 
 ; <label>:265                                     ; preds = %259
   %266 = load i16, i16* %264, align 8
   %267 = sext i16 %266 to i32
   %268 = bitcast i8* %261 to i16*
   %269 = trunc i32 %267 to i16
-  %NullCheck34 = icmp ne i16* %268, null
-  br i1 %NullCheck34, label %270, label %ThrowNullRef33
+  %NullCheck33 = icmp eq i16* %268, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %270
 
 ; <label>:270                                     ; preds = %265
   store i16 %269, i16* %268, align 8
@@ -1168,14 +1250,14 @@ entry:
   %272 = load i8*, i8** %arg0
   %273 = load i8*, i8** %arg1
   %274 = bitcast i8* %273 to i64*
-  %NullCheck8 = icmp ne i64* %274, null
-  br i1 %NullCheck8, label %275, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64* %274, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %275
 
 ; <label>:275                                     ; preds = %271
   %276 = load i64, i64* %274, align 8
   %277 = bitcast i8* %272 to i64*
-  %NullCheck10 = icmp ne i64* %277, null
-  br i1 %NullCheck10, label %278, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %277, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %278
 
 ; <label>:278                                     ; preds = %275
   store i64 %276, i64* %277, align 8
@@ -1184,14 +1266,14 @@ entry:
   %281 = load i8*, i8** %arg1
   %282 = getelementptr inbounds i8, i8* %281, i64 8
   %283 = bitcast i8* %282 to i32*
-  %NullCheck12 = icmp ne i32* %283, null
-  br i1 %NullCheck12, label %284, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i32* %283, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %284
 
 ; <label>:284                                     ; preds = %278
   %285 = load i32, i32* %283, align 8
   %286 = bitcast i8* %280 to i32*
-  %NullCheck14 = icmp ne i32* %286, null
-  br i1 %NullCheck14, label %287, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i32* %286, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %287
 
 ; <label>:287                                     ; preds = %284
   store i32 %285, i32* %286, align 8
@@ -1200,16 +1282,16 @@ entry:
   %290 = load i8*, i8** %arg1
   %291 = getelementptr inbounds i8, i8* %290, i64 12
   %292 = bitcast i8* %291 to i16*
-  %NullCheck16 = icmp ne i16* %292, null
-  br i1 %NullCheck16, label %293, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i16* %292, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %293
 
 ; <label>:293                                     ; preds = %287
   %294 = load i16, i16* %292, align 8
   %295 = sext i16 %294 to i32
   %296 = bitcast i8* %289 to i16*
   %297 = trunc i32 %295 to i16
-  %NullCheck18 = icmp ne i16* %296, null
-  br i1 %NullCheck18, label %298, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i16* %296, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %298
 
 ; <label>:298                                     ; preds = %293
   store i16 %297, i16* %296, align 8
@@ -1217,15 +1299,15 @@ entry:
   %300 = getelementptr inbounds i8, i8* %299, i64 14
   %301 = load i8*, i8** %arg1
   %302 = getelementptr inbounds i8, i8* %301, i64 14
-  %NullCheck20 = icmp ne i8* %302, null
-  br i1 %NullCheck20, label %303, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i8* %302, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %303
 
 ; <label>:303                                     ; preds = %298
   %304 = load i8, i8* %302, align 8
   %305 = zext i8 %304 to i32
   %306 = trunc i32 %305 to i8
-  %NullCheck22 = icmp ne i8* %300, null
-  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i8* %300, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %307
 
 ; <label>:307                                     ; preds = %303
   store i8 %306, i8* %300, align 8
@@ -1235,14 +1317,14 @@ entry:
   %309 = load i8*, i8** %arg0
   %310 = load i8*, i8** %arg1
   %311 = bitcast i8* %310 to i64*
-  %NullCheck = icmp ne i64* %311, null
-  br i1 %NullCheck, label %312, label %ThrowNullRef
+  %NullCheck = icmp eq i64* %311, null
+  br i1 %NullCheck, label %ThrowNullRef, label %312
 
 ; <label>:312                                     ; preds = %308
   %313 = load i64, i64* %311, align 8
   %314 = bitcast i8* %309 to i64*
-  %NullCheck2 = icmp ne i64* %314, null
-  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64* %314, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %315
 
 ; <label>:315                                     ; preds = %312
   store i64 %313, i64* %314, align 8
@@ -1251,14 +1333,14 @@ entry:
   %318 = load i8*, i8** %arg1
   %319 = getelementptr inbounds i8, i8* %318, i64 8
   %320 = bitcast i8* %319 to i64*
-  %NullCheck4 = icmp ne i64* %320, null
-  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64* %320, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %321
 
 ; <label>:321                                     ; preds = %315
   %322 = load i64, i64* %320, align 8
   %323 = bitcast i8* %317 to i64*
-  %NullCheck6 = icmp ne i64* %323, null
-  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64* %323, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %324
 
 ; <label>:324                                     ; preds = %321
   store i64 %322, i64* %323, align 8
@@ -1286,15 +1368,15 @@ entry:
 ; <label>:338                                     ; preds = %333
   %339 = load i8*, i8** %arg0
   %340 = load i8*, i8** %arg1
-  %NullCheck136 = icmp ne i8* %340, null
-  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+  %NullCheck135 = icmp eq i8* %340, null
+  br i1 %NullCheck135, label %ThrowNullRef136, label %341
 
 ; <label>:341                                     ; preds = %338
   %342 = load i8, i8* %340, align 8
   %343 = zext i8 %342 to i32
   %344 = trunc i32 %343 to i8
-  %NullCheck138 = icmp ne i8* %339, null
-  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+  %NullCheck137 = icmp eq i8* %339, null
+  br i1 %NullCheck137, label %ThrowNullRef138, label %345
 
 ; <label>:345                                     ; preds = %341
   store i8 %344, i8* %339, align 8
@@ -1317,16 +1399,16 @@ entry:
   %357 = load i8*, i8** %arg0
   %358 = load i8*, i8** %arg1
   %359 = bitcast i8* %358 to i16*
-  %NullCheck140 = icmp ne i16* %359, null
-  br i1 %NullCheck140, label %360, label %ThrowNullRef139
+  %NullCheck139 = icmp eq i16* %359, null
+  br i1 %NullCheck139, label %ThrowNullRef140, label %360
 
 ; <label>:360                                     ; preds = %356
   %361 = load i16, i16* %359, align 8
   %362 = sext i16 %361 to i32
   %363 = bitcast i8* %357 to i16*
   %364 = trunc i32 %362 to i16
-  %NullCheck142 = icmp ne i16* %363, null
-  br i1 %NullCheck142, label %365, label %ThrowNullRef141
+  %NullCheck141 = icmp eq i16* %363, null
+  br i1 %NullCheck141, label %ThrowNullRef142, label %365
 
 ; <label>:365                                     ; preds = %360
   store i16 %364, i16* %363, align 8
@@ -1352,14 +1434,14 @@ entry:
   %378 = load i8*, i8** %arg0
   %379 = load i8*, i8** %arg1
   %380 = bitcast i8* %379 to i32*
-  %NullCheck144 = icmp ne i32* %380, null
-  br i1 %NullCheck144, label %381, label %ThrowNullRef143
+  %NullCheck143 = icmp eq i32* %380, null
+  br i1 %NullCheck143, label %ThrowNullRef144, label %381
 
 ; <label>:381                                     ; preds = %377
   %382 = load i32, i32* %380, align 8
   %383 = bitcast i8* %378 to i32*
-  %NullCheck146 = icmp ne i32* %383, null
-  br i1 %NullCheck146, label %384, label %ThrowNullRef145
+  %NullCheck145 = icmp eq i32* %383, null
+  br i1 %NullCheck145, label %ThrowNullRef146, label %384
 
 ; <label>:384                                     ; preds = %381
   store i32 %382, i32* %383, align 8
@@ -1384,14 +1466,14 @@ entry:
   %395 = load i8*, i8** %arg0
   %396 = load i8*, i8** %arg1
   %397 = bitcast i8* %396 to i64*
-  %NullCheck164 = icmp ne i64* %397, null
-  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+  %NullCheck163 = icmp eq i64* %397, null
+  br i1 %NullCheck163, label %ThrowNullRef164, label %398
 
 ; <label>:398                                     ; preds = %394
   %399 = load i64, i64* %397, align 8
   %400 = bitcast i8* %395 to i64*
-  %NullCheck166 = icmp ne i64* %400, null
-  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+  %NullCheck165 = icmp eq i64* %400, null
+  br i1 %NullCheck165, label %ThrowNullRef166, label %401
 
 ; <label>:401                                     ; preds = %398
   store i64 %399, i64* %400, align 8
@@ -1400,14 +1482,14 @@ entry:
   %404 = load i8*, i8** %arg1
   %405 = getelementptr inbounds i8, i8* %404, i64 8
   %406 = bitcast i8* %405 to i64*
-  %NullCheck168 = icmp ne i64* %406, null
-  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+  %NullCheck167 = icmp eq i64* %406, null
+  br i1 %NullCheck167, label %ThrowNullRef168, label %407
 
 ; <label>:407                                     ; preds = %401
   %408 = load i64, i64* %406, align 8
   %409 = bitcast i8* %403 to i64*
-  %NullCheck170 = icmp ne i64* %409, null
-  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+  %NullCheck169 = icmp eq i64* %409, null
+  br i1 %NullCheck169, label %ThrowNullRef170, label %410
 
 ; <label>:410                                     ; preds = %407
   store i64 %408, i64* %409, align 8
@@ -1437,14 +1519,14 @@ entry:
   %425 = load i8*, i8** %arg0
   %426 = load i8*, i8** %arg1
   %427 = bitcast i8* %426 to i64*
-  %NullCheck148 = icmp ne i64* %427, null
-  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+  %NullCheck147 = icmp eq i64* %427, null
+  br i1 %NullCheck147, label %ThrowNullRef148, label %428
 
 ; <label>:428                                     ; preds = %424
   %429 = load i64, i64* %427, align 8
   %430 = bitcast i8* %425 to i64*
-  %NullCheck150 = icmp ne i64* %430, null
-  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+  %NullCheck149 = icmp eq i64* %430, null
+  br i1 %NullCheck149, label %ThrowNullRef150, label %431
 
 ; <label>:431                                     ; preds = %428
   store i64 %429, i64* %430, align 8
@@ -1466,14 +1548,14 @@ entry:
   %441 = load i8*, i8** %arg0
   %442 = load i8*, i8** %arg1
   %443 = bitcast i8* %442 to i32*
-  %NullCheck152 = icmp ne i32* %443, null
-  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+  %NullCheck151 = icmp eq i32* %443, null
+  br i1 %NullCheck151, label %ThrowNullRef152, label %444
 
 ; <label>:444                                     ; preds = %440
   %445 = load i32, i32* %443, align 8
   %446 = bitcast i8* %441 to i32*
-  %NullCheck154 = icmp ne i32* %446, null
-  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+  %NullCheck153 = icmp eq i32* %446, null
+  br i1 %NullCheck153, label %ThrowNullRef154, label %447
 
 ; <label>:447                                     ; preds = %444
   store i32 %445, i32* %446, align 8
@@ -1495,16 +1577,16 @@ entry:
   %457 = load i8*, i8** %arg0
   %458 = load i8*, i8** %arg1
   %459 = bitcast i8* %458 to i16*
-  %NullCheck156 = icmp ne i16* %459, null
-  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+  %NullCheck155 = icmp eq i16* %459, null
+  br i1 %NullCheck155, label %ThrowNullRef156, label %460
 
 ; <label>:460                                     ; preds = %456
   %461 = load i16, i16* %459, align 8
   %462 = sext i16 %461 to i32
   %463 = bitcast i8* %457 to i16*
   %464 = trunc i32 %462 to i16
-  %NullCheck158 = icmp ne i16* %463, null
-  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+  %NullCheck157 = icmp eq i16* %463, null
+  br i1 %NullCheck157, label %ThrowNullRef158, label %465
 
 ; <label>:465                                     ; preds = %460
   store i16 %464, i16* %463, align 8
@@ -1525,15 +1607,15 @@ entry:
 ; <label>:474                                     ; preds = %470
   %475 = load i8*, i8** %arg0
   %476 = load i8*, i8** %arg1
-  %NullCheck160 = icmp ne i8* %476, null
-  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+  %NullCheck159 = icmp eq i8* %476, null
+  br i1 %NullCheck159, label %ThrowNullRef160, label %477
 
 ; <label>:477                                     ; preds = %474
   %478 = load i8, i8* %476, align 8
   %479 = zext i8 %478 to i32
   %480 = trunc i32 %479 to i8
-  %NullCheck162 = icmp ne i8* %475, null
-  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+  %NullCheck161 = icmp eq i8* %475, null
+  br i1 %NullCheck161, label %ThrowNullRef162, label %481
 
 ; <label>:481                                     ; preds = %477
   store i8 %480, i8* %475, align 8
@@ -1553,343 +1635,343 @@ ThrowNullRef:                                     ; preds = %308
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %312
+ThrowNullRef2:                                    ; preds = %312
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %315
+ThrowNullRef4:                                    ; preds = %315
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %321
+ThrowNullRef6:                                    ; preds = %321
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %271
+ThrowNullRef8:                                    ; preds = %271
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %275
+ThrowNullRef10:                                   ; preds = %275
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %278
+ThrowNullRef12:                                   ; preds = %278
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %284
+ThrowNullRef14:                                   ; preds = %284
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %287
+ThrowNullRef16:                                   ; preds = %287
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %293
+ThrowNullRef18:                                   ; preds = %293
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %298
+ThrowNullRef20:                                   ; preds = %298
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %303
+ThrowNullRef22:                                   ; preds = %303
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %243
+ThrowNullRef24:                                   ; preds = %243
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %247
+ThrowNullRef26:                                   ; preds = %247
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %250
+ThrowNullRef28:                                   ; preds = %250
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %256
+ThrowNullRef30:                                   ; preds = %256
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %259
+ThrowNullRef32:                                   ; preds = %259
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %265
+ThrowNullRef34:                                   ; preds = %265
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %217
+ThrowNullRef36:                                   ; preds = %217
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %221
+ThrowNullRef38:                                   ; preds = %221
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %224
+ThrowNullRef40:                                   ; preds = %224
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %230
+ThrowNullRef42:                                   ; preds = %230
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %233
+ThrowNullRef44:                                   ; preds = %233
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %238
+ThrowNullRef46:                                   ; preds = %238
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %200
+ThrowNullRef48:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %204
+ThrowNullRef50:                                   ; preds = %204
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %207
+ThrowNullRef52:                                   ; preds = %207
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %213
+ThrowNullRef54:                                   ; preds = %213
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %172
+ThrowNullRef56:                                   ; preds = %172
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %176
+ThrowNullRef58:                                   ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %179
+ThrowNullRef60:                                   ; preds = %179
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %185
+ThrowNullRef62:                                   ; preds = %185
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %190
+ThrowNullRef64:                                   ; preds = %190
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %195
+ThrowNullRef66:                                   ; preds = %195
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %153
+ThrowNullRef68:                                   ; preds = %153
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %157
+ThrowNullRef70:                                   ; preds = %157
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %160
+ThrowNullRef72:                                   ; preds = %160
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %166
+ThrowNullRef74:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %136
+ThrowNullRef76:                                   ; preds = %136
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %140
+ThrowNullRef78:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %143
+ThrowNullRef80:                                   ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %148
+ThrowNullRef82:                                   ; preds = %148
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %128
+ThrowNullRef84:                                   ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %132
+ThrowNullRef86:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %100
+ThrowNullRef88:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %104
+ThrowNullRef90:                                   ; preds = %104
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %107
+ThrowNullRef92:                                   ; preds = %107
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %113
+ThrowNullRef94:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %118
+ThrowNullRef96:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %123
+ThrowNullRef98:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %81
+ThrowNullRef100:                                  ; preds = %81
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef101:                                  ; preds = %85
+ThrowNullRef102:                                  ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef103:                                  ; preds = %88
+ThrowNullRef104:                                  ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef105:                                  ; preds = %94
+ThrowNullRef106:                                  ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef107:                                  ; preds = %64
+ThrowNullRef108:                                  ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef109:                                  ; preds = %68
+ThrowNullRef110:                                  ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef111:                                  ; preds = %71
+ThrowNullRef112:                                  ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef113:                                  ; preds = %76
+ThrowNullRef114:                                  ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef115:                                  ; preds = %56
+ThrowNullRef116:                                  ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef117:                                  ; preds = %60
+ThrowNullRef118:                                  ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef119:                                  ; preds = %37
+ThrowNullRef120:                                  ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef121:                                  ; preds = %41
+ThrowNullRef122:                                  ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef123:                                  ; preds = %46
+ThrowNullRef124:                                  ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef125:                                  ; preds = %51
+ThrowNullRef126:                                  ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef127:                                  ; preds = %27
+ThrowNullRef128:                                  ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef129:                                  ; preds = %31
+ThrowNullRef130:                                  ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef131:                                  ; preds = %19
+ThrowNullRef132:                                  ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef133:                                  ; preds = %22
+ThrowNullRef134:                                  ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef135:                                  ; preds = %338
+ThrowNullRef136:                                  ; preds = %338
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef137:                                  ; preds = %341
+ThrowNullRef138:                                  ; preds = %341
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef139:                                  ; preds = %356
+ThrowNullRef140:                                  ; preds = %356
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef141:                                  ; preds = %360
+ThrowNullRef142:                                  ; preds = %360
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef143:                                  ; preds = %377
+ThrowNullRef144:                                  ; preds = %377
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef145:                                  ; preds = %381
+ThrowNullRef146:                                  ; preds = %381
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef147:                                  ; preds = %424
+ThrowNullRef148:                                  ; preds = %424
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef149:                                  ; preds = %428
+ThrowNullRef150:                                  ; preds = %428
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef151:                                  ; preds = %440
+ThrowNullRef152:                                  ; preds = %440
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef153:                                  ; preds = %444
+ThrowNullRef154:                                  ; preds = %444
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef155:                                  ; preds = %456
+ThrowNullRef156:                                  ; preds = %456
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef157:                                  ; preds = %460
+ThrowNullRef158:                                  ; preds = %460
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef159:                                  ; preds = %474
+ThrowNullRef160:                                  ; preds = %474
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef161:                                  ; preds = %477
+ThrowNullRef162:                                  ; preds = %477
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef163:                                  ; preds = %394
+ThrowNullRef164:                                  ; preds = %394
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef165:                                  ; preds = %398
+ThrowNullRef166:                                  ; preds = %398
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef167:                                  ; preds = %401
+ThrowNullRef168:                                  ; preds = %401
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef169:                                  ; preds = %407
+ThrowNullRef170:                                  ; preds = %407
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1939,8 +2021,8 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
-  br i1 %NullCheck, label %22, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %ThrowNullRef, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
@@ -1948,8 +2030,8 @@ entry:
   store i32 %24, i32* %loc0
   %25 = load i32, i32* %loc0
   %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %26, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %27
 
 ; <label>:27                                      ; preds = %22
   %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
@@ -1971,7 +2053,7 @@ ThrowNullRef:                                     ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1989,8 +2071,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -2022,15 +2104,15 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2048,16 +2130,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
   %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
   store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %15
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
@@ -2072,8 +2154,8 @@ entry:
   %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
   %29 = ptrtoint i16 addrspace(1)* %28 to i64
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %19
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
@@ -2089,19 +2171,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2114,8 +2196,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
@@ -2128,7 +2210,7 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[loadElem]
+Failed to read AppDomain.PrepareDataForSetup[storeElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
@@ -2202,8 +2284,8 @@ entry:
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
-  br i1 %NullCheck24, label %27, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = load i64, i64 addrspace(1)* %26
@@ -2218,8 +2300,8 @@ entry:
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
-  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
   %41 = load i64, i64 addrspace(1)* %39
@@ -2236,8 +2318,8 @@ entry:
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
-  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
   %54 = load i64, i64 addrspace(1)* %52
@@ -2252,8 +2334,8 @@ entry:
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
   %67 = load i64, i64 addrspace(1)* %65
@@ -2270,8 +2352,8 @@ entry:
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
-  br i1 %NullCheck16, label %79, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
   %80 = load i64, i64 addrspace(1)* %78
@@ -2286,8 +2368,8 @@ entry:
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
-  br i1 %NullCheck18, label %92, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
   %93 = load i64, i64 addrspace(1)* %91
@@ -2304,8 +2386,8 @@ entry:
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
-  br i1 %NullCheck12, label %105, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = load i64, i64 addrspace(1)* %104
@@ -2320,8 +2402,8 @@ entry:
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
-  br i1 %NullCheck14, label %118, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
   %119 = load i64, i64 addrspace(1)* %117
@@ -2337,8 +2419,8 @@ entry:
 
 ; <label>:128                                     ; preds = %20
   %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
-  br i1 %NullCheck4, label %130, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %129, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %130
 
 ; <label>:130                                     ; preds = %128
   %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
@@ -2346,8 +2428,8 @@ entry:
   %133 = load i16, i16 addrspace(1)* %132, align 8
   %134 = zext i16 %133 to i32
   %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
-  br i1 %NullCheck6, label %136, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %135, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %136
 
 ; <label>:136                                     ; preds = %130
   %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
@@ -2360,8 +2442,8 @@ entry:
 
 ; <label>:143                                     ; preds = %136
   %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
-  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %144, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %145
 
 ; <label>:145                                     ; preds = %143
   %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
@@ -2369,8 +2451,8 @@ entry:
   %148 = load i16, i16 addrspace(1)* %147, align 8
   %149 = zext i16 %148 to i32
   %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %150, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %151
 
 ; <label>:151                                     ; preds = %145
   %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
@@ -2388,8 +2470,8 @@ entry:
 
 ; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
-  br i1 %NullCheck, label %163, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %ThrowNullRef, label %163
 
 ; <label>:163                                     ; preds = %161
   %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
@@ -2399,8 +2481,8 @@ entry:
 
 ; <label>:167                                     ; preds = %163
   %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
-  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %168, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %169
 
 ; <label>:169                                     ; preds = %167
   %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
@@ -2432,55 +2514,55 @@ ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %167
+ThrowNullRef2:                                    ; preds = %167
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %128
+ThrowNullRef4:                                    ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %130
+ThrowNullRef6:                                    ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %143
+ThrowNullRef8:                                    ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %145
+ThrowNullRef10:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %102
+ThrowNullRef12:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %105
+ThrowNullRef14:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %76
+ThrowNullRef16:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %79
+ThrowNullRef18:                                   ; preds = %79
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %50
+ThrowNullRef20:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %53
+ThrowNullRef22:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %24
+ThrowNullRef24:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %27
+ThrowNullRef26:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2503,15 +2585,15 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2519,16 +2601,16 @@ entry:
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
   store i32 %8, i32* %loc0
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
   %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
   store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
@@ -2546,16 +2628,16 @@ entry:
 
 ; <label>:23                                      ; preds = %64
   %24 = load i16*, i16** %loc3
-  %NullCheck12 = icmp ne i16* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i16* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
   store i32 %27, i32* %loc5
   %28 = load i16*, i16** %loc4
-  %NullCheck14 = icmp ne i16* %28, null
-  br i1 %NullCheck14, label %29, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %28, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = load i16, i16* %28, align 8
@@ -2620,15 +2702,15 @@ entry:
 
 ; <label>:67                                      ; preds = %64
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
-  br i1 %NullCheck8, label %69, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %68, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %69
 
 ; <label>:69                                      ; preds = %67
   %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
   %71 = load i32, i32 addrspace(1)* %70
   %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
-  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %73
 
 ; <label>:73                                      ; preds = %69
   %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
@@ -2645,31 +2727,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %67
+ThrowNullRef8:                                    ; preds = %67
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %69
+ThrowNullRef10:                                   ; preds = %69
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2710,14 +2792,14 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
   %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
@@ -2730,14 +2812,14 @@ entry:
 
 ; <label>:11                                      ; preds = %4
   %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
   %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
@@ -2749,14 +2831,14 @@ entry:
 
 ; <label>:22                                      ; preds = %16
   %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
   %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
-  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
-  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
@@ -2804,23 +2886,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2836,7 +2918,280 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[loadElem]
+Successfully read RuntimeType.IsAssignableFrom
+
+define i8 @RuntimeType.IsAssignableFrom(%System.RuntimeType addrspace(1)* %param0, %System.Type addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.RuntimeType addrspace(1)*
+  %arg1 = alloca %System.Type addrspace(1)*
+  %loc0 = alloca %System.RuntimeType addrspace(1)*
+  %loc1 = alloca %"System.Type[]" addrspace(1)*
+  %loc2 = alloca i32
+  store %System.RuntimeType addrspace(1)* %param0, %System.RuntimeType addrspace(1)** %this
+  store %System.Type addrspace(1)* %param1, %System.Type addrspace(1)** %arg1
+  %0 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %1 = icmp ne %System.Type addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i8 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %5 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %6 = bitcast %System.Type addrspace(1)* %4 to %System.Object addrspace(1)*
+  %7 = bitcast %System.RuntimeType addrspace(1)* %5 to %System.Object addrspace(1)*
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %6, %System.Object addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %3
+  ret i8 1
+
+; <label>:12                                      ; preds = %3
+  %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 152
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 32
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
+  %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
+  %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
+  store %System.RuntimeType addrspace(1)* %25, %System.RuntimeType addrspace(1)** %loc0
+  %26 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %27 = icmp eq %System.RuntimeType addrspace(1)* %26, null
+  br i1 %27, label %34, label %28
+
+; <label>:28                                      ; preds = %15
+  %29 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %30 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)*)*)(%System.RuntimeType addrspace(1)* %29, %System.RuntimeType addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+; <label>:34                                      ; preds = %15
+  %35 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %36 = call %System.Reflection.Emit.TypeBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Reflection.Emit.TypeBuilder addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %35)
+  %37 = icmp eq %System.Reflection.Emit.TypeBuilder addrspace(1)* %36, null
+  br i1 %37, label %139, label %38
+
+; <label>:38                                      ; preds = %34
+  %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %42
+
+; <label>:42                                      ; preds = %38
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 152
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 40
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
+  %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
+  %53 = zext i8 %52 to i32
+  %54 = icmp eq i32 %53, 0
+  br i1 %54, label %56, label %55
+
+; <label>:55                                      ; preds = %42
+  ret i8 1
+
+; <label>:56                                      ; preds = %42
+  %57 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %58 = bitcast %System.RuntimeType addrspace(1)* %57 to %System.Type addrspace(1)*
+  %59 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %58)
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %64 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.Type addrspace(1)* %63, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = bitcast %System.RuntimeType addrspace(1)* %64 to %System.Type addrspace(1)*
+  %67 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %63, %System.Type addrspace(1)* %66)
+  %68 = zext i8 %67 to i32
+  %69 = trunc i32 %68 to i8
+  ret i8 %69
+
+; <label>:70                                      ; preds = %56
+  %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
+  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %73
+
+; <label>:73                                      ; preds = %70
+  %74 = load i64, i64 addrspace(1)* %72
+  %75 = add i64 %74, 128
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = add i64 %77, 0
+  %79 = inttoptr i64 %78 to i64*
+  %80 = load i64, i64* %79
+  %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
+  %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
+  %83 = call i8 %82(%System.Type addrspace(1)* %81)
+  %84 = zext i8 %83 to i32
+  %85 = icmp eq i32 %84, 0
+  br i1 %85, label %139, label %86
+
+; <label>:86                                      ; preds = %73
+  %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
+  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %89
+
+; <label>:89                                      ; preds = %86
+  %90 = load i64, i64 addrspace(1)* %88
+  %91 = add i64 %90, 128
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = add i64 %93, 24
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
+  %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
+  %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
+  store %"System.Type[]" addrspace(1)* %99, %"System.Type[]" addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %129
+
+; <label>:100                                     ; preds = %132
+  %101 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %102 = load i32, i32* %loc2
+  %NullCheck11 = icmp eq %"System.Type[]" addrspace(1)* %101, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %103
+
+; <label>:103                                     ; preds = %100
+  %104 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 1
+  %105 = load i32, i32 addrspace(1)* %104
+  %106 = zext i32 %105 to i64
+  %107 = zext i32 %102 to i64
+  %BoundsCheck = icmp uge i64 %107, %106
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %108
+
+; <label>:108                                     ; preds = %103
+  %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
+  %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
+  %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
+  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %113
+
+; <label>:113                                     ; preds = %108
+  %114 = load i64, i64 addrspace(1)* %112
+  %115 = add i64 %114, 152
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = add i64 %117, 56
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
+  %123 = zext i8 %122 to i32
+  %124 = icmp ne i32 %123, 0
+  br i1 %124, label %126, label %125
+
+; <label>:125                                     ; preds = %113
+  ret i8 0
+
+; <label>:126                                     ; preds = %113
+  %127 = load i32, i32* %loc2
+  %128 = add i32 %127, 1
+  store i32 %128, i32* %loc2
+  br label %129
+
+; <label>:129                                     ; preds = %89, %126
+  %130 = load i32, i32* %loc2
+  %131 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %NullCheck9 = icmp eq %"System.Type[]" addrspace(1)* %131, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %132
+
+; <label>:132                                     ; preds = %129
+  %133 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %131, i32 0, i32 1
+  %134 = load i32, i32 addrspace(1)* %133
+  %135 = zext i32 %134 to i64
+  %136 = trunc i64 %135 to i32
+  %137 = icmp slt i32 %130, %136
+  br i1 %137, label %100, label %138
+
+; <label>:138                                     ; preds = %132
+  ret i8 1
+
+; <label>:139                                     ; preds = %34, %73
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %129
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %103
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -2893,7 +3248,7 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElem]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -2904,8 +3259,8 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -2997,8 +3352,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
@@ -3059,8 +3414,8 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -3087,8 +3442,8 @@ entry:
 
 ; <label>:17                                      ; preds = %5, %11
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
@@ -3097,8 +3452,8 @@ entry:
 
 ; <label>:22                                      ; preds = %1, %11
   %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
@@ -3109,11 +3464,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %17
+ThrowNullRef2:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %22
+ThrowNullRef4:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3167,15 +3522,15 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
   %15 = load i32, i32 addrspace(1)* %14
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
@@ -3198,7 +3553,7 @@ ThrowNullRef:                                     ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef2:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3232,8 +3587,8 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
@@ -3312,8 +3667,8 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -3327,8 +3682,8 @@ entry:
 ; <label>:5                                       ; preds = %43
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %7 = load i32, i32* %loc1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck6, label %8, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
@@ -3366,8 +3721,8 @@ entry:
 ; <label>:32                                      ; preds = %21, %25
   %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
   %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
-  br i1 %NullCheck8, label %35, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = trunc i32 %34 to i16
@@ -3380,8 +3735,8 @@ entry:
 ; <label>:40                                      ; preds = %1, %35
   %41 = load i32, i32* %loc1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
-  br i1 %NullCheck2, label %43, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %42, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
@@ -3392,8 +3747,8 @@ entry:
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
   %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
-  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
   %51 = load i64, i64 addrspace(1)* %49
@@ -3412,19 +3767,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %40
+ThrowNullRef2:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %47
+ThrowNullRef4:                                    ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %5
+ThrowNullRef6:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %32
+ThrowNullRef8:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3467,8 +3822,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
@@ -3492,11 +3847,391 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(i16* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store i16* %param0, i16** %arg0
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load i32, i32* %arg3
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %42, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %37, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg2
+  %13 = load i32, i32* %arg3
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %37, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %24 = load i32, i32* %arg2
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load i16*, i16** %arg0
+  %35 = load i32, i32* %arg3
+  %36 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %36, i16* %34, i32 %35)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:37                                      ; preds = %5, %16
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %39)
+  %41 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41, %System.String addrspace(1)* %38, %System.String addrspace(1)* %40)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41) #0
+  unreachable
+
+; <label>:42                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
-Failed to read StringBuilder.ToString[loadElemA]
+Successfully read StringBuilder.ToString
+
+define %System.String addrspace(1)* @StringBuilder.ToString(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i16*
+  %loc3 = alloca %"System.Char[]" addrspace(1)*
+  %loc4 = alloca i32
+  %loc5 = alloca i32
+  %loc6 = alloca i16 addrspace(1)*
+  %loc7 = alloca %System.String addrspace(1)*
+  %loc8 = alloca %"System.Char[]" addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %0)
+  %2 = icmp ne i32 %1, 0
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %4
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %6)
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %7)
+  store %System.String addrspace(1)* %8, %System.String addrspace(1)** %loc0
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.Text.StringBuilder addrspace(1)* %9, %System.Text.StringBuilder addrspace(1)** %loc1
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  store %System.String addrspace(1)* %10, %System.String addrspace(1)** %loc7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc7
+  %12 = ptrtoint %System.String addrspace(1)* %11 to i64
+  %13 = icmp eq i64 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %5
+  %15 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %16 = sext i32 %15 to i64
+  %17 = add i64 %12, %16
+  br label %18
+
+; <label>:18                                      ; preds = %5, %14
+  %19 = phi i64 [ %12, %5 ], [ %17, %14 ]
+  %20 = inttoptr i64 %19 to i16*
+  store i16* %20, i16** %loc2
+  br label %21
+
+; <label>:21                                      ; preds = %98, %18
+  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %22, null
+  br i1 %NullCheck, label %ThrowNullRef, label %23
+
+; <label>:23                                      ; preds = %21
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 3
+  %25 = load i32, i32 addrspace(1)* %24, align 8
+  %26 = icmp sle i32 %25, 0
+  br i1 %26, label %96, label %27
+
+; <label>:27                                      ; preds = %23
+  %28 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %28, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %29
+
+; <label>:29                                      ; preds = %27
+  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %28, i32 0, i32 1
+  %31 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %30, align 8
+  store %"System.Char[]" addrspace(1)* %31, %"System.Char[]" addrspace(1)** %loc3
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %33
+
+; <label>:33                                      ; preds = %29
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  store i32 %35, i32* %loc4
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  %39 = load i32, i32 addrspace(1)* %38, align 8
+  store i32 %39, i32* %loc5
+  %40 = load i32, i32* %loc5
+  %41 = load i32, i32* %loc4
+  %42 = add i32 %40, %41
+  %43 = zext i32 %42 to i64
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %45
+
+; <label>:45                                      ; preds = %37
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = sext i32 %47 to i64
+  %49 = icmp sgt i64 %43, %48
+  br i1 %49, label %91, label %50
+
+; <label>:50                                      ; preds = %45
+  %51 = load i32, i32* %loc5
+  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %52, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %53
+
+; <label>:53                                      ; preds = %50
+  %54 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %52, i32 0, i32 1
+  %55 = load i32, i32 addrspace(1)* %54
+  %56 = zext i32 %55 to i64
+  %57 = trunc i64 %56 to i32
+  %58 = icmp ugt i32 %51, %57
+  br i1 %58, label %91, label %59
+
+; <label>:59                                      ; preds = %53
+  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  store %"System.Char[]" addrspace(1)* %60, %"System.Char[]" addrspace(1)** %loc8
+  %61 = icmp eq %"System.Char[]" addrspace(1)* %60, null
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %63, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %64
+
+; <label>:64                                      ; preds = %62
+  %65 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %63, i32 0, i32 1
+  %66 = load i32, i32 addrspace(1)* %65
+  %67 = zext i32 %66 to i64
+  %68 = trunc i64 %67 to i32
+  %69 = icmp ne i32 %68, 0
+  br i1 %69, label %71, label %70
+
+; <label>:70                                      ; preds = %59, %64
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:71                                      ; preds = %64
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %73
+
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %BoundsCheck = icmp uge i64 0, %76
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %77
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %78, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:79                                      ; preds = %70, %77
+  %80 = load i16*, i16** %loc2
+  %81 = load i32, i32* %loc4
+  %82 = sext i32 %81 to i64
+  %83 = mul i64 %82, 2
+  %84 = bitcast i16* %80 to i8*
+  %85 = getelementptr inbounds i8, i8* %84, i64 %83
+  %86 = load i16 addrspace(1)*, i16 addrspace(1)** %loc6
+  %87 = ptrtoint i16 addrspace(1)* %86 to i64
+  %88 = load i32, i32* %loc5
+  %89 = bitcast i8* %85 to i16*
+  %90 = inttoptr i64 %87 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %89, i16* %90, i32 %88)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %96
+
+; <label>:91                                      ; preds = %45, %53
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %94 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %93)
+  %95 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95, %System.String addrspace(1)* %92, %System.String addrspace(1)* %94)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95) #0
+  unreachable
+
+; <label>:96                                      ; preds = %23, %79
+  %97 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %97, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %98
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %97, i32 0, i32 2
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  store %System.Text.StringBuilder addrspace(1)* %100, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %102 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %102, label %21, label %103
+
+; <label>:103                                     ; preds = %98
+  store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc7
+  %104 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  ret %System.String addrspace(1)* %104
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method StringBuilder::get_Length using LLILCJit
+Successfully read StringBuilder.get_Length
+
+define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
+Successfully read RuntimeHelpers.get_OffsetToStringData
+
+define i32 @RuntimeHelpers.get_OffsetToStringData() {
+entry:
+  ret i32 12
+}
+
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
 Successfully read CultureData.CreateCultureData
 
@@ -3514,23 +4249,23 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
   store i8 %4, i8 addrspace(1)* %6
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
@@ -3549,11 +4284,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3566,50 +4301,50 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
   store i32 -1, i32 addrspace(1)* %2
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
   store i32 -1, i32 addrspace(1)* %8
   %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
   store i32 -1, i32 addrspace(1)* %14
   %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
   store i32 -1, i32 addrspace(1)* %17
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
@@ -3623,27 +4358,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3675,7 +4410,136 @@ Failed to read Dictionary`2.Insert[non-const derefAddress]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
 Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
-Failed to read HashHelpers.GetPrime[loadElem]
+Successfully read HashHelpers.GetPrime
+
+define i32 @HashHelpers.GetPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %6, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5, %System.String addrspace(1)* %4)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5) #0
+  unreachable
+
+; <label>:6                                       ; preds = %entry
+  store i32 0, i32* %loc0
+  br label %29
+
+; <label>:7                                       ; preds = %35
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 1296
+  %10 = addrspacecast i8 addrspace(1)* %9 to %"System.Int32[]" addrspace(1)**
+  %11 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %10
+  %12 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Int32[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = zext i32 %15 to i64
+  %17 = zext i32 %12 to i64
+  %BoundsCheck = icmp uge i64 %17, %16
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 3, i32 %12
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  store i32 %20, i32* %loc1
+  %21 = load i32, i32* %loc1
+  %22 = load i32, i32* %arg0
+  %23 = icmp slt i32 %21, %22
+  br i1 %23, label %26, label %24
+
+; <label>:24                                      ; preds = %18
+  %25 = load i32, i32* %loc1
+  ret i32 %25
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %loc0
+  %28 = add i32 %27, 1
+  store i32 %28, i32* %loc0
+  br label %29
+
+; <label>:29                                      ; preds = %6, %26
+  %30 = load i32, i32* %loc0
+  %31 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %32 = getelementptr inbounds i8, i8 addrspace(1)* %31, i64 1296
+  %33 = addrspacecast i8 addrspace(1)* %32 to %"System.Int32[]" addrspace(1)**
+  %34 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %33
+  %NullCheck = icmp eq %"System.Int32[]" addrspace(1)* %34, null
+  br i1 %NullCheck, label %ThrowNullRef, label %35
+
+; <label>:35                                      ; preds = %29
+  %36 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %34, i32 0, i32 1
+  %37 = load i32, i32 addrspace(1)* %36
+  %38 = zext i32 %37 to i64
+  %39 = trunc i64 %38 to i32
+  %40 = icmp slt i32 %30, %39
+  br i1 %40, label %7, label %41
+
+; <label>:41                                      ; preds = %35
+  %42 = load i32, i32* %arg0
+  %43 = or i32 %42, 1
+  store i32 %43, i32* %loc2
+  br label %59
+
+; <label>:44                                      ; preds = %59
+  %45 = load i32, i32* %loc2
+  %46 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %45)
+  %47 = zext i8 %46 to i32
+  %48 = icmp eq i32 %47, 0
+  br i1 %48, label %56, label %49
+
+; <label>:49                                      ; preds = %44
+  %50 = load i32, i32* %loc2
+  %51 = sub i32 %50, 1
+  %52 = srem i32 %51, 101
+  %53 = icmp eq i32 %52, 0
+  br i1 %53, label %56, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = load i32, i32* %loc2
+  ret i32 %55
+
+; <label>:56                                      ; preds = %44, %49
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %57, 2
+  store i32 %58, i32* %loc2
+  br label %59
+
+; <label>:59                                      ; preds = %41, %56
+  %60 = load i32, i32* %loc2
+  %61 = icmp slt i32 %60, 2147483647
+  br i1 %61, label %44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load i32, i32* %arg0
+  ret i32 %63
+
+ThrowNullRef:                                     ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
 Successfully read GenericEqualityComparer`1.GetHashCode
 
@@ -3694,14 +4558,14 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
   %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load i64, i64 addrspace(1)* %7
@@ -3720,7 +4584,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3750,8 +4614,8 @@ entry:
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
@@ -3796,8 +4660,8 @@ entry:
   %35 = bitcast i16* %34 to i8*
   %36 = getelementptr inbounds i8, i8* %35, i64 2
   %37 = bitcast i8* %36 to i16*
-  %NullCheck4 = icmp ne i16* %37, null
-  br i1 %NullCheck4, label %38, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %37, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %38
 
 ; <label>:38                                      ; preds = %27
   %39 = load i16, i16* %37, align 8
@@ -3824,8 +4688,8 @@ entry:
 
 ; <label>:54                                      ; preds = %22, %43
   %55 = load i16*, i16** %loc4
-  %NullCheck2 = icmp ne i16* %55, null
-  br i1 %NullCheck2, label %56, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i16* %55, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %56
 
 ; <label>:56                                      ; preds = %54
   %57 = load i16, i16* %55, align 8
@@ -3850,11 +4714,11 @@ ThrowNullRef:                                     ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %54
+ThrowNullRef2:                                    ; preds = %54
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %27
+ThrowNullRef4:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3871,8 +4735,8 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -3907,8 +4771,8 @@ entry:
 
 ; <label>:26                                      ; preds = %19
   %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
-  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %28
 
 ; <label>:28                                      ; preds = %26
   %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
@@ -3920,7 +4784,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3972,8 +4836,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
@@ -3984,26 +4848,26 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
-  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
@@ -4014,8 +4878,8 @@ entry:
 ; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
@@ -4024,8 +4888,8 @@ entry:
 
 ; <label>:25                                      ; preds = %1, %16, %23
   %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
-  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
@@ -4036,27 +4900,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %20
+ThrowNullRef10:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4069,8 +4933,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -4081,8 +4945,8 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
@@ -4091,8 +4955,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1, %8
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
@@ -4103,11 +4967,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4128,24 +4992,24 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   store i32 %3, i32* %loc0
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
   %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
   store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck4, label %9, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
@@ -4164,15 +5028,15 @@ entry:
 ; <label>:18                                      ; preds = %70
   %19 = load i16*, i16** %loc3
   %20 = bitcast i16* %19 to i64*
-  %NullCheck10 = icmp ne i64* %20, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %20, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = load i64, i64* %20, align 8
   %23 = load i16*, i16** %loc4
   %24 = bitcast i16* %23 to i64*
-  %NullCheck12 = icmp ne i64* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = load i64, i64* %24, align 8
@@ -4188,8 +5052,8 @@ entry:
   %31 = bitcast i16* %30 to i8*
   %32 = getelementptr inbounds i8, i8* %31, i64 8
   %33 = bitcast i8* %32 to i64*
-  %NullCheck14 = icmp ne i64* %33, null
-  br i1 %NullCheck14, label %34, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = load i64, i64* %33, align 8
@@ -4197,8 +5061,8 @@ entry:
   %37 = bitcast i16* %36 to i8*
   %38 = getelementptr inbounds i8, i8* %37, i64 8
   %39 = bitcast i8* %38 to i64*
-  %NullCheck16 = icmp ne i64* %39, null
-  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %40
 
 ; <label>:40                                      ; preds = %34
   %41 = load i64, i64* %39, align 8
@@ -4214,8 +5078,8 @@ entry:
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %NullCheck18 = icmp ne i64* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = load i64, i64* %48, align 8
@@ -4223,8 +5087,8 @@ entry:
   %52 = bitcast i16* %51 to i8*
   %53 = getelementptr inbounds i8, i8* %52, i64 16
   %54 = bitcast i8* %53 to i64*
-  %NullCheck20 = icmp ne i64* %54, null
-  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64* %54, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %55
 
 ; <label>:55                                      ; preds = %49
   %56 = load i64, i64* %54, align 8
@@ -4262,15 +5126,15 @@ entry:
 ; <label>:74                                      ; preds = %95
   %75 = load i16*, i16** %loc3
   %76 = bitcast i16* %75 to i32*
-  %NullCheck6 = icmp ne i32* %76, null
-  br i1 %NullCheck6, label %77, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32* %76, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %77
 
 ; <label>:77                                      ; preds = %74
   %78 = load i32, i32* %76, align 8
   %79 = load i16*, i16** %loc4
   %80 = bitcast i16* %79 to i32*
-  %NullCheck8 = icmp ne i32* %80, null
-  br i1 %NullCheck8, label %81, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i32* %80, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %81
 
 ; <label>:81                                      ; preds = %77
   %82 = load i32, i32* %80, align 8
@@ -4318,43 +5182,43 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %74
+ThrowNullRef6:                                    ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %77
+ThrowNullRef8:                                    ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %29
+ThrowNullRef14:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %34
+ThrowNullRef16:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4376,8 +5240,8 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load i64, i64 addrspace(1)* %4
@@ -4389,8 +5253,8 @@ entry:
   %12 = load i64, i64* %11
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %5
   %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
@@ -4399,8 +5263,8 @@ entry:
   %18 = load i8, i8* %arg2
   %19 = zext i8 %18 to i32
   %20 = trunc i32 %19 to i8
-  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %15
   %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
@@ -4411,11 +5275,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4442,8 +5306,8 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
@@ -4466,16 +5330,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
   %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = load i64, i64 addrspace(1)* %19
@@ -4500,8 +5364,8 @@ entry:
 ; <label>:35                                      ; preds = %30
   %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
@@ -4514,8 +5378,8 @@ entry:
 
 ; <label>:42                                      ; preds = %1, %38
   %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
-  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
@@ -4526,19 +5390,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %35
+ThrowNullRef2:                                    ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %42
+ThrowNullRef8:                                    ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4551,14 +5415,14 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
@@ -4570,7 +5434,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4583,8 +5447,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
@@ -4613,51 +5477,51 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
   %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
   %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
   %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
   %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
-  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
   store i64 %21, i64 addrspace(1)* %23
   %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %25 = load i64, i64* %loc0
-  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
@@ -4668,27 +5532,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %22
+ThrowNullRef12:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4701,8 +5565,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
@@ -4713,19 +5577,19 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
@@ -4734,8 +5598,8 @@ entry:
 
 ; <label>:15                                      ; preds = %1, %13
   %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
@@ -4746,19 +5610,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %15
+ThrowNullRef8:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4771,8 +5635,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -4831,8 +5695,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
@@ -4882,8 +5746,8 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
-  br i1 %NullCheck, label %17, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %ThrowNullRef, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
@@ -4894,15 +5758,15 @@ entry:
 
 ; <label>:22                                      ; preds = %17
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
-  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
   %26 = load i32, i32 addrspace(1)* %25
   %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
-  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %27, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
@@ -4925,8 +5789,8 @@ entry:
 ; <label>:40                                      ; preds = %17
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
-  br i1 %NullCheck6, label %43, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %41, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
@@ -4938,34 +5802,17 @@ ThrowNullRef:                                     ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %24
+ThrowNullRef4:                                    ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %40
+ThrowNullRef6:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
-}
-
-INFO:  jitting method Object::ReferenceEquals using LLILCJit
-Successfully read Object.ReferenceEquals
-
-define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
-entry:
-  %arg0 = alloca %System.Object addrspace(1)*
-  %arg1 = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
-  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
-  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = icmp eq %System.Object addrspace(1)* %0, %1
-  %3 = sext i1 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
 }
 
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
@@ -4978,21 +5825,21 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
   %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
-  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
@@ -5007,28 +5854,28 @@ entry:
 ; <label>:13                                      ; preds = %8, %12
   %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
   %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
   %21 = load i32, i32 addrspace(1)* %20, align 8
   %22 = add i32 %21, 1
-  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
   store i32 %22, i32 addrspace(1)* %24
   %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
@@ -5039,27 +5886,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5077,7 +5924,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::Setup using LLILCJit
-Failed to read AppDomain.Setup[loadElem]
+Failed to read AppDomain.Setup[unbox]
 INFO:  jitting method Thread::GetDomain using LLILCJit
 Successfully read Thread.GetDomain
 
@@ -5108,8 +5955,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
@@ -5122,14 +5969,14 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
   %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
@@ -5141,11 +5988,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5173,8 +6020,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -5189,7 +6036,328 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
 Failed to read KeyCollection.System.Collections.Generic.IEnumerable<TKey>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Successfully read Enumerator.MoveNext
+
+define i8 @Enumerator.MoveNext(%"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.RuntimeTypeHandle* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*
+  %"$TypeArg" = alloca %System.RuntimeTypeHandle*
+  store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
+  %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 8
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %76, label %12
+
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
+  br label %76
+
+; <label>:13                                      ; preds = %85
+  %14 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck19 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %15
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, i32 0, i32 0
+  %17 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %16, align 8
+  %NullCheck21 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, i32 0, i32 2
+  %20 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %19, align 8
+  %21 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck23 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %22
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, i32 0, i32 2
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %NullCheck25 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 3, i32 %24
+  %NullCheck27 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %32
+
+; <label>:32                                      ; preds = %30
+  %33 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, i32 0, i32 2
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = icmp slt i32 %34, 0
+  br i1 %35, label %68, label %36
+
+; <label>:36                                      ; preds = %32
+  %37 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %38 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck29 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %39
+
+; <label>:39                                      ; preds = %36
+  %40 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, i32 0, i32 0
+  %41 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %40, align 8
+  %NullCheck31 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, i32 0, i32 2
+  %44 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %43, align 8
+  %45 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck33 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, i32 0, i32 2
+  %48 = load i32, i32 addrspace(1)* %47, align 8
+  %NullCheck35 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %49
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = zext i32 %51 to i64
+  %53 = zext i32 %48 to i64
+  %BoundsCheck37 = icmp uge i64 %53, %52
+  br i1 %BoundsCheck37, label %ThrowIndexOutOfRange38, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 3, i32 %48
+  %NullCheck39 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %56
+
+; <label>:56                                      ; preds = %54
+  %57 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, i32 0, i32 0
+  %58 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck41 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %59
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %60, %System.__Canon addrspace(1)* %58)
+  %61 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck43 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  %64 = load i32, i32 addrspace(1)* %63, align 8
+  %65 = add i32 %64, 1
+  %NullCheck45 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  store i32 %65, i32 addrspace(1)* %67
+  ret i8 1
+
+; <label>:68                                      ; preds = %32
+  %69 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck47 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %73 = add i32 %72, 1
+  %NullCheck49 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %74
+
+; <label>:74                                      ; preds = %70
+  %75 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  store i32 %73, i32 addrspace(1)* %75
+  br label %76
+
+; <label>:76                                      ; preds = %8, %12, %74
+  %77 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %78
+
+; <label>:78                                      ; preds = %76
+  %79 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, i32 0, i32 2
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck7 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %82
+
+; <label>:82                                      ; preds = %78
+  %83 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, i32 0, i32 0
+  %84 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %83, align 8
+  %NullCheck9 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %85
+
+; <label>:85                                      ; preds = %82
+  %86 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, i32 0, i32 7
+  %87 = load i32, i32 addrspace(1)* %86, align 8
+  %88 = icmp ult i32 %80, %87
+  br i1 %88, label %13, label %89
+
+; <label>:89                                      ; preds = %85
+  %90 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %91 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck11 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %92
+
+; <label>:92                                      ; preds = %89
+  %93 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, i32 0, i32 0
+  %94 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck13 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %95
+
+; <label>:95                                      ; preds = %92
+  %96 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, i32 0, i32 7
+  %97 = load i32, i32 addrspace(1)* %96, align 8
+  %98 = add i32 %97, 1
+  %NullCheck15 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %99
+
+; <label>:99                                      ; preds = %95
+  %100 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, i32 0, i32 2
+  store i32 %98, i32 addrspace(1)* %100
+  %101 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck17 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %102
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %103, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %92
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef22:                                   ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef24:                                   ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef26:                                   ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef28:                                   ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef30:                                   ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef32:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef34:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef36:                                   ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange38:                           ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef40:                                   ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef42:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef44:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef46:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef48:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef50:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -5200,8 +6368,8 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -5232,9 +6400,9 @@ Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
 Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
-Failed to read String.MakeSeparatorList[loadElemA]
+Failed to read String.MakeSeparatorList[storeElem]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
-Failed to read String.InternalSplitKeepEmptyEntries[loadElem]
+Failed to read String.InternalSplitKeepEmptyEntries[storeElem]
 INFO:  jitting method Path::IsRelative using LLILCJit
 Successfully read Path.IsRelative
 
@@ -5243,8 +6411,8 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -5254,8 +6422,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
@@ -5271,8 +6439,8 @@ entry:
 
 ; <label>:17                                      ; preds = %7
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
@@ -5288,8 +6456,8 @@ entry:
 
 ; <label>:29                                      ; preds = %19
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %31
 
 ; <label>:31                                      ; preds = %29
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
@@ -5300,8 +6468,8 @@ entry:
 
 ; <label>:36                                      ; preds = %31
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
-  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %37, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
@@ -5312,8 +6480,8 @@ entry:
 
 ; <label>:43                                      ; preds = %31, %38
   %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
-  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %45
 
 ; <label>:45                                      ; preds = %43
   %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
@@ -5324,8 +6492,8 @@ entry:
 
 ; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %50
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
@@ -5336,8 +6504,8 @@ entry:
 
 ; <label>:57                                      ; preds = %1, %7, %19, %45, %52
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
-  br i1 %NullCheck14, label %59, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %59
 
 ; <label>:59                                      ; preds = %57
   %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
@@ -5347,8 +6515,8 @@ entry:
 
 ; <label>:63                                      ; preds = %59
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
@@ -5359,8 +6527,8 @@ entry:
 
 ; <label>:70                                      ; preds = %65
   %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
-  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.String addrspace(1)* %71, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %72
 
 ; <label>:72                                      ; preds = %70
   %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
@@ -5379,39 +6547,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %17
+ThrowNullRef4:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %29
+ThrowNullRef6:                                    ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %36
+ThrowNullRef8:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %43
+ThrowNullRef10:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %50
+ThrowNullRef12:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %57
+ThrowNullRef14:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %63
+ThrowNullRef16:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %70
+ThrowNullRef18:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5419,7 +6587,293 @@ ThrowNullRef17:                                   ; preds = %70
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
-Failed to read String.TrimHelper[loadElem]
+Successfully read String.TrimHelper
+
+define %System.String addrspace(1)* @String.TrimHelper(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i16
+  %loc4 = alloca i32
+  %loc5 = alloca i16
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = sub i32 %3, 1
+  store i32 %4, i32* %loc0
+  store i32 0, i32* %loc1
+  %5 = load i32, i32* %arg2
+  %6 = icmp eq i32 %5, 1
+  br i1 %6, label %62, label %7
+
+; <label>:7                                       ; preds = %1
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:8                                       ; preds = %58
+  store i32 0, i32* %loc2
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load i32, i32* %loc1
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2, i32 %10
+  %13 = load i16, i16 addrspace(1)* %12
+  %14 = zext i16 %13 to i32
+  %15 = trunc i32 %14 to i16
+  store i16 %15, i16* %loc3
+  store i32 0, i32* %loc2
+  br label %34
+
+; <label>:16                                      ; preds = %37
+  %17 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %18 = load i32, i32* %loc2
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %17, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %19
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = zext i32 %18 to i64
+  %BoundsCheck = icmp uge i64 %23, %22
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %24
+
+; <label>:24                                      ; preds = %19
+  %25 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 3, i32 %18
+  %26 = load i16, i16 addrspace(1)* %25, align 8
+  %27 = zext i16 %26 to i32
+  %28 = load i16, i16* %loc3
+  %29 = zext i16 %28 to i32
+  %30 = icmp eq i32 %27, %29
+  br i1 %30, label %43, label %31
+
+; <label>:31                                      ; preds = %24
+  %32 = load i32, i32* %loc2
+  %33 = add i32 %32, 1
+  store i32 %33, i32* %loc2
+  br label %34
+
+; <label>:34                                      ; preds = %11, %31
+  %35 = load i32, i32* %loc2
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = icmp slt i32 %35, %41
+  br i1 %42, label %16, label %43
+
+; <label>:43                                      ; preds = %24, %37
+  %44 = load i32, i32* %loc2
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %45, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp eq i32 %44, %50
+  br i1 %51, label %62, label %52
+
+; <label>:52                                      ; preds = %46
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %7, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %57, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %58
+
+; <label>:58                                      ; preds = %55
+  %59 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %60 = load i32, i32 addrspace(1)* %59
+  %61 = icmp slt i32 %56, %60
+  br i1 %61, label %8, label %62
+
+; <label>:62                                      ; preds = %1, %46, %58
+  %63 = load i32, i32* %arg2
+  %64 = icmp eq i32 %63, 0
+  br i1 %64, label %122, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %66, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %67
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %66, i32 0, i32 1
+  %69 = load i32, i32 addrspace(1)* %68
+  %70 = sub i32 %69, 1
+  store i32 %70, i32* %loc0
+  br label %118
+
+; <label>:71                                      ; preds = %118
+  store i32 0, i32* %loc4
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %73 = load i32, i32* %loc0
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %74
+
+; <label>:74                                      ; preds = %71
+  %75 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 2, i32 %73
+  %76 = load i16, i16 addrspace(1)* %75
+  %77 = zext i16 %76 to i32
+  %78 = trunc i32 %77 to i16
+  store i16 %78, i16* %loc5
+  store i32 0, i32* %loc4
+  br label %97
+
+; <label>:79                                      ; preds = %100
+  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %81 = load i32, i32* %loc4
+  %NullCheck19 = icmp eq %"System.Char[]" addrspace(1)* %80, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
+
+; <label>:82                                      ; preds = %79
+  %83 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 1
+  %84 = load i32, i32 addrspace(1)* %83
+  %85 = zext i32 %84 to i64
+  %86 = zext i32 %81 to i64
+  %BoundsCheck21 = icmp uge i64 %86, %85
+  br i1 %BoundsCheck21, label %ThrowIndexOutOfRange22, label %87
+
+; <label>:87                                      ; preds = %82
+  %88 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 3, i32 %81
+  %89 = load i16, i16 addrspace(1)* %88, align 8
+  %90 = zext i16 %89 to i32
+  %91 = load i16, i16* %loc5
+  %92 = zext i16 %91 to i32
+  %93 = icmp eq i32 %90, %92
+  br i1 %93, label %106, label %94
+
+; <label>:94                                      ; preds = %87
+  %95 = load i32, i32* %loc4
+  %96 = add i32 %95, 1
+  store i32 %96, i32* %loc4
+  br label %97
+
+; <label>:97                                      ; preds = %74, %94
+  %98 = load i32, i32* %loc4
+  %99 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck15 = icmp eq %"System.Char[]" addrspace(1)* %99, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %100
+
+; <label>:100                                     ; preds = %97
+  %101 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %99, i32 0, i32 1
+  %102 = load i32, i32 addrspace(1)* %101
+  %103 = zext i32 %102 to i64
+  %104 = trunc i64 %103 to i32
+  %105 = icmp slt i32 %98, %104
+  br i1 %105, label %79, label %106
+
+; <label>:106                                     ; preds = %87, %100
+  %107 = load i32, i32* %loc4
+  %108 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck17 = icmp eq %"System.Char[]" addrspace(1)* %108, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %109
+
+; <label>:109                                     ; preds = %106
+  %110 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %108, i32 0, i32 1
+  %111 = load i32, i32 addrspace(1)* %110
+  %112 = zext i32 %111 to i64
+  %113 = trunc i64 %112 to i32
+  %114 = icmp eq i32 %107, %113
+  br i1 %114, label %122, label %115
+
+; <label>:115                                     ; preds = %109
+  %116 = load i32, i32* %loc0
+  %117 = sub i32 %116, 1
+  store i32 %117, i32* %loc0
+  br label %118
+
+; <label>:118                                     ; preds = %67, %115
+  %119 = load i32, i32* %loc0
+  %120 = load i32, i32* %loc1
+  %121 = icmp sge i32 %119, %120
+  br i1 %121, label %71, label %122
+
+; <label>:122                                     ; preds = %62, %109, %118
+  %123 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %124 = load i32, i32* %loc1
+  %125 = load i32, i32* %loc0
+  %126 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %123, i32 %124, i32 %125)
+  ret %System.String addrspace(1)* %126
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %97
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange22:                           ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
 Successfully read String.CreateTrimmedString
 
@@ -5439,8 +6893,8 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
@@ -5535,8 +6989,8 @@ entry:
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i64 2872
   %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
   %8 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %7
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %3
   %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
@@ -5553,8 +7007,8 @@ entry:
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 2864
   %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
   %21 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %20
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
-  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %22
 
 ; <label>:22                                      ; preds = %16
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
@@ -5569,7 +7023,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %16
+ThrowNullRef2:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5586,8 +7040,8 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5613,8 +7067,8 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
@@ -5632,8 +7086,8 @@ entry:
 
 ; <label>:12                                      ; preds = %4
   %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
@@ -5644,8 +7098,8 @@ entry:
 
 ; <label>:19                                      ; preds = %14
   %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %19
   %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
@@ -5660,21 +7114,21 @@ entry:
   %31 = zext i16 %30 to i32
   %32 = bitcast i8* %29 to i16*
   %33 = trunc i32 %31 to i16
-  %NullCheck6 = icmp ne i16* %32, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i16* %32, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %21
   store i16 %33, i16* %32, align 8
   %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %36
 
 ; <label>:36                                      ; preds = %34
   %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
   %38 = load i32, i32 addrspace(1)* %37, align 8
   %39 = add i32 %38, 1
-  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %40
 
 ; <label>:40                                      ; preds = %36
   %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
@@ -5683,16 +7137,16 @@ entry:
 
 ; <label>:42                                      ; preds = %14
   %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
-  br i1 %NullCheck12, label %44, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
   %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
   %47 = load i16, i16* %arg1
   %48 = zext i16 %47 to i32
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = trunc i32 %48 to i16
@@ -5703,31 +7157,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %19
+ThrowNullRef4:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %21
+ThrowNullRef6:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %36
+ThrowNullRef10:                                   ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %42
+ThrowNullRef12:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %44
+ThrowNullRef14:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5740,8 +7194,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -5752,8 +7206,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
@@ -5762,14 +7216,14 @@ entry:
 
 ; <label>:11                                      ; preds = %1
   %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
@@ -5779,15 +7233,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5808,8 +7262,8 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5822,8 +7276,8 @@ entry:
 
 ; <label>:8                                       ; preds = %3
   %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
@@ -5842,15 +7296,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
-  br i1 %NullCheck4, label %22, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
   %24 = load i16*, i16* addrspace(1)* %23, align 8
   %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %25, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
@@ -5859,8 +7313,8 @@ entry:
   store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
@@ -5874,8 +7328,8 @@ entry:
 
 ; <label>:37                                      ; preds = %65
   %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %37
   %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
@@ -5886,16 +7340,16 @@ entry:
   %45 = bitcast i16* %41 to i8*
   %46 = getelementptr inbounds i8, i8* %45, i64 %44
   %47 = bitcast i8* %46 to i16*
-  %NullCheck14 = icmp ne i16* %47, null
-  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %47, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %48
 
 ; <label>:48                                      ; preds = %39
   %49 = load i16, i16* %47, align 8
   %50 = zext i16 %49 to i32
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %52 = load i32, i32* %loc1
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %53
 
 ; <label>:53                                      ; preds = %48
   %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
@@ -5916,8 +7370,8 @@ entry:
 ; <label>:62                                      ; preds = %36, %59
   %63 = load i32, i32* %loc1
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck10, label %65, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %65
 
 ; <label>:65                                      ; preds = %62
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
@@ -5936,15 +7390,15 @@ entry:
 
 ; <label>:74                                      ; preds = %70
   %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
-  br i1 %NullCheck18, label %76, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %76
 
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
   %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
-  br i1 %NullCheck20, label %80, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
   %81 = load i64, i64 addrspace(1)* %79
@@ -5958,8 +7412,8 @@ entry:
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
   %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
-  br i1 %NullCheck22, label %92, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.String addrspace(1)* %90, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %92
 
 ; <label>:92                                      ; preds = %80
   %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
@@ -5969,15 +7423,15 @@ entry:
 
 ; <label>:96                                      ; preds = %70
   %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
-  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %98
 
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
   %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
-  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
   %103 = load i64, i64 addrspace(1)* %101
@@ -5991,8 +7445,8 @@ entry:
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
   %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
-  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.String addrspace(1)* %112, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %114
 
 ; <label>:114                                     ; preds = %102
   %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
@@ -6004,59 +7458,59 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %20
+ThrowNullRef4:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %22
+ThrowNullRef6:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %26
+ThrowNullRef8:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %62
+ThrowNullRef10:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %48
+ThrowNullRef16:                                   ; preds = %48
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %74
+ThrowNullRef18:                                   ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %76
+ThrowNullRef20:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %80
+ThrowNullRef22:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %96
+ThrowNullRef24:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %98
+ThrowNullRef26:                                   ; preds = %98
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %102
+ThrowNullRef28:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6069,15 +7523,15 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
   %3 = load i16*, i16* addrspace(1)* %2, align 8
   %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
@@ -6087,8 +7541,8 @@ entry:
   %10 = bitcast i16* %3 to i8*
   %11 = getelementptr inbounds i8, i8* %10, i64 %9
   %12 = bitcast i8* %11 to i16*
-  %NullCheck4 = icmp ne i16* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %5
   store i16 0, i16* %12, align 8
@@ -6098,11 +7552,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6119,8 +7573,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -6131,8 +7585,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
@@ -6144,15 +7598,15 @@ entry:
 
 ; <label>:14                                      ; preds = %1
   %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
   %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
   %21 = load i64, i64 addrspace(1)* %19
@@ -6171,15 +7625,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %14
+ThrowNullRef4:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %16
+ThrowNullRef6:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6302,14 +7756,6 @@ entry:
   ret %System.String addrspace(1)* %57
 }
 
-INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
-Successfully read RuntimeHelpers.get_OffsetToStringData
-
-define i32 @RuntimeHelpers.get_OffsetToStringData() {
-entry:
-  ret i32 12
-}
-
 INFO:  jitting method String::Equals using LLILCJit
 Successfully read String.Equals
 
@@ -6381,8 +7827,8 @@ entry:
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
-  br i1 %NullCheck24, label %29, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
   %30 = load i64, i64 addrspace(1)* %28
@@ -6397,8 +7843,8 @@ entry:
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
-  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
   %43 = load i64, i64 addrspace(1)* %41
@@ -6418,8 +7864,8 @@ entry:
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
   %59 = load i64, i64 addrspace(1)* %57
@@ -6434,8 +7880,8 @@ entry:
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck22, label %71, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
   %72 = load i64, i64 addrspace(1)* %70
@@ -6455,8 +7901,8 @@ entry:
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
-  br i1 %NullCheck16, label %87, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = load i64, i64 addrspace(1)* %86
@@ -6471,8 +7917,8 @@ entry:
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck18, label %100, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
   %101 = load i64, i64 addrspace(1)* %99
@@ -6492,8 +7938,8 @@ entry:
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
-  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
   %117 = load i64, i64 addrspace(1)* %115
@@ -6508,8 +7954,8 @@ entry:
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
-  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
   %130 = load i64, i64 addrspace(1)* %128
@@ -6528,15 +7974,15 @@ entry:
 
 ; <label>:142                                     ; preds = %22
   %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
-  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %143, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %144
 
 ; <label>:144                                     ; preds = %142
   %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
   %146 = load i32, i32 addrspace(1)* %145
   %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
-  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %147, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %148
 
 ; <label>:148                                     ; preds = %144
   %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
@@ -6557,15 +8003,15 @@ entry:
 
 ; <label>:159                                     ; preds = %22
   %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
-  br i1 %NullCheck, label %161, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %ThrowNullRef, label %161
 
 ; <label>:161                                     ; preds = %159
   %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
   %163 = load i32, i32 addrspace(1)* %162
   %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
-  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %164, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %165
 
 ; <label>:165                                     ; preds = %161
   %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
@@ -6578,8 +8024,8 @@ entry:
 
 ; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
-  br i1 %NullCheck4, label %172, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %171, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %172
 
 ; <label>:172                                     ; preds = %170
   %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
@@ -6589,8 +8035,8 @@ entry:
 
 ; <label>:176                                     ; preds = %172
   %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
-  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %177, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %178
 
 ; <label>:178                                     ; preds = %176
   %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
@@ -6629,55 +8075,55 @@ ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %161
+ThrowNullRef2:                                    ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %170
+ThrowNullRef4:                                    ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %176
+ThrowNullRef6:                                    ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %142
+ThrowNullRef8:                                    ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %144
+ThrowNullRef10:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %113
+ThrowNullRef12:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %116
+ThrowNullRef14:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %84
+ThrowNullRef16:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %87
+ThrowNullRef18:                                   ; preds = %87
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %55
+ThrowNullRef20:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %58
+ThrowNullRef22:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %26
+ThrowNullRef24:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %29
+ThrowNullRef26:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,8 +8161,8 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck, label %14, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %ThrowNullRef, label %14
 
 ; <label>:14                                      ; preds = %8
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
@@ -6760,8 +8206,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
@@ -6770,14 +8216,14 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32, i32* %loc0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %10
   %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
   %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
@@ -6790,15 +8236,15 @@ entry:
 ; <label>:25                                      ; preds = %19
   %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
-  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
   %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
@@ -6807,8 +8253,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %37 = load i32, i32* %loc0
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %38, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %38
 
 ; <label>:38                                      ; preds = %32
   %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
@@ -6817,14 +8263,14 @@ entry:
 
 ; <label>:40                                      ; preds = %19
   %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %40
   %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
   %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
-  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
-  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
@@ -6832,8 +8278,8 @@ entry:
   %48 = zext i32 %47 to i64
   %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
-  br i1 %NullCheck16, label %51, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %51
 
 ; <label>:51                                      ; preds = %45
   %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
@@ -6847,15 +8293,15 @@ entry:
 ; <label>:57                                      ; preds = %51
   %58 = load i16*, i16** %arg1
   %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
-  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %60
 
 ; <label>:60                                      ; preds = %57
   %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
   %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
-  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %64
 
 ; <label>:64                                      ; preds = %60
   %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
@@ -6864,22 +8310,22 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
   %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
-  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %70
 
 ; <label>:70                                      ; preds = %64
   %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
   %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
-  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
-  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
   %75 = load i32, i32 addrspace(1)* %74
   %76 = zext i32 %75 to i64
   %77 = trunc i64 %76 to i32
-  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
-  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %78
 
 ; <label>:78                                      ; preds = %73
   %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
@@ -6901,8 +8347,8 @@ entry:
   %90 = bitcast i16* %86 to i8*
   %91 = getelementptr inbounds i8, i8* %90, i64 %89
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %93
 
 ; <label>:93                                      ; preds = %80
   %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
@@ -6912,8 +8358,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %99 = load i32, i32* %loc2
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %100
 
 ; <label>:100                                     ; preds = %93
   %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
@@ -6928,63 +8374,63 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %25
+ThrowNullRef6:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %32
+ThrowNullRef10:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %40
+ThrowNullRef12:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %45
+ThrowNullRef16:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %57
+ThrowNullRef18:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %60
+ThrowNullRef20:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %64
+ThrowNullRef22:                                   ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %70
+ThrowNullRef24:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %73
+ThrowNullRef26:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %80
+ThrowNullRef28:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %93
+ThrowNullRef30:                                   ; preds = %93
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7004,8 +8450,8 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
@@ -7033,43 +8479,43 @@ entry:
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %14
   %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
   %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   %28 = load i32, i32 addrspace(1)* %27, align 8
   %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
-  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %30
 
 ; <label>:30                                      ; preds = %26
   %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
   %32 = load i32, i32 addrspace(1)* %31, align 8
   %33 = add i32 %28, %32
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %34
 
 ; <label>:34                                      ; preds = %30
   %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   store i32 %33, i32 addrspace(1)* %35
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
   store i32 0, i32 addrspace(1)* %38
   %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %40
 
 ; <label>:40                                      ; preds = %37
   %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
@@ -7082,8 +8528,8 @@ entry:
 
 ; <label>:47                                      ; preds = %40
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
@@ -7098,8 +8544,8 @@ entry:
   %54 = load i32, i32* %loc0
   %55 = sext i32 %54 to i64
   %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
-  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %57
 
 ; <label>:57                                      ; preds = %52
   %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
@@ -7110,68 +8556,35 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %14
+ThrowNullRef2:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %23
+ThrowNullRef4:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %26
+ThrowNullRef6:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %30
+ThrowNullRef8:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %34
+ThrowNullRef10:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %47
+ThrowNullRef14:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %52
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-}
-
-INFO:  jitting method StringBuilder::get_Length using LLILCJit
-Successfully read StringBuilder.get_Length
-
-define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.StringBuilder addrspace(1)*
-  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
-  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
-
-; <label>:1                                       ; preds = %entry
-  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %3 = load i32, i32 addrspace(1)* %2, align 8
-  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
-
-; <label>:5                                       ; preds = %1
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = add i32 %3, %7
-  ret i32 %8
-
-ThrowNullRef:                                     ; preds = %entry
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef16:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7213,70 +8626,70 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
   %6 = load i32, i32 addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
   store i32 %6, i32 addrspace(1)* %8
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
   %13 = load i32, i32 addrspace(1)* %12, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
   store i32 %13, i32 addrspace(1)* %15
   %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
-  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %18
 
 ; <label>:18                                      ; preds = %14
   %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
   %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
   %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
   %34 = load i32, i32 addrspace(1)* %33, align 8
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
-  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
@@ -7287,39 +8700,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %28
+ThrowNullRef16:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %32
+ThrowNullRef18:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7455,13 +8868,13 @@ entry:
 ; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
@@ -7477,16 +8890,16 @@ entry:
 
 ; <label>:18                                      ; preds = %15
   %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
   store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
   %22 = load i32, i32* %loc0
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %24
 
 ; <label>:24                                      ; preds = %20
   %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
@@ -7498,13 +8911,13 @@ entry:
 ; <label>:28                                      ; preds = %15, %24
   %29 = load i32, i32* %arg1
   %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %31
   %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
@@ -7517,20 +8930,20 @@ entry:
   %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
-  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
   %46 = load i32, i32 addrspace(1)* %45, align 8
   %47 = sub i32 %40, %46
-  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
-  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i32 addrspace(1)* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %48
 
 ; <label>:48                                      ; preds = %44
   store i32 %47, i32 addrspace(1)* %39, align 8
@@ -7538,21 +8951,21 @@ entry:
 
 ; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
-  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %51
 
 ; <label>:51                                      ; preds = %49
   %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %53
 
 ; <label>:53                                      ; preds = %51
   %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
   %55 = load i32, i32 addrspace(1)* %54, align 8
   %56 = load i32, i32* %arg2
   %57 = sub i32 %55, %56
-  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %58
 
 ; <label>:58                                      ; preds = %53
   %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
@@ -7562,13 +8975,13 @@ entry:
 ; <label>:60                                      ; preds = %33, %58
   %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
   %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
-  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %63
 
 ; <label>:63                                      ; preds = %60
   %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
-  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
-  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
@@ -7578,15 +8991,15 @@ entry:
 
 ; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
-  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i32 addrspace(1)* %69, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %70
 
 ; <label>:70                                      ; preds = %68
   %71 = load i32, i32 addrspace(1)* %69, align 8
   store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
-  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
@@ -7596,8 +9009,8 @@ entry:
   store i32 %77, i32* %loc4
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
-  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %80
 
 ; <label>:80                                      ; preds = %73
   %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
@@ -7607,71 +9020,71 @@ entry:
 ; <label>:83                                      ; preds = %80
   store i32 0, i32* %loc3
   %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
-  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
-  br i1 %NullCheck26, label %88, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i32 addrspace(1)* %87, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %88
 
 ; <label>:88                                      ; preds = %85
   %89 = load i32, i32 addrspace(1)* %87, align 8
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
-  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %90
 
 ; <label>:90                                      ; preds = %88
   %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
   store i32 %89, i32 addrspace(1)* %91
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
-  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
-  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %96
 
 ; <label>:96                                      ; preds = %94
   %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
-  br i1 %NullCheck34, label %100, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %100
 
 ; <label>:100                                     ; preds = %96
   %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
-  br i1 %NullCheck36, label %102, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %102
 
 ; <label>:102                                     ; preds = %100
   %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
   %104 = load i32, i32 addrspace(1)* %103, align 8
   %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
-  br i1 %NullCheck38, label %106, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %106
 
 ; <label>:106                                     ; preds = %102
   %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
-  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
-  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %108
 
 ; <label>:108                                     ; preds = %106
   %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
   %110 = load i32, i32 addrspace(1)* %109, align 8
   %111 = add i32 %104, %110
-  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %112
 
 ; <label>:112                                     ; preds = %108
   %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
   store i32 %111, i32 addrspace(1)* %113
   %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
-  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i32 addrspace(1)* %114, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %115
 
 ; <label>:115                                     ; preds = %112
   %116 = load i32, i32 addrspace(1)* %114, align 8
@@ -7681,19 +9094,19 @@ entry:
 ; <label>:118                                     ; preds = %115
   %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
-  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %121
 
 ; <label>:121                                     ; preds = %118
   %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
-  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
-  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %123
 
 ; <label>:123                                     ; preds = %121
   %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
   %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
-  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
-  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %126
 
 ; <label>:126                                     ; preds = %123
   %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
@@ -7705,8 +9118,8 @@ entry:
 
 ; <label>:130                                     ; preds = %80, %115, %126
   %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %132
 
 ; <label>:132                                     ; preds = %130
   %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7715,8 +9128,8 @@ entry:
   %136 = load i32, i32* %loc3
   %137 = sub i32 %135, %136
   %138 = sub i32 %134, %137
-  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %139
 
 ; <label>:139                                     ; preds = %132
   %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7728,16 +9141,16 @@ entry:
 
 ; <label>:144                                     ; preds = %139
   %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
-  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %146
 
 ; <label>:146                                     ; preds = %144
   %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
   %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
   %149 = load i32, i32* %loc2
   %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
-  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %151
 
 ; <label>:151                                     ; preds = %146
   %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
@@ -7754,145 +9167,249 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %18
+ThrowNullRef4:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %31
+ThrowNullRef10:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %44
+ThrowNullRef16:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %68
+ThrowNullRef18:                                   ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %70
+ThrowNullRef20:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %73
+ThrowNullRef22:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %83
+ThrowNullRef24:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %85
+ThrowNullRef26:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %88
+ThrowNullRef28:                                   ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %90
+ThrowNullRef30:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %94
+ThrowNullRef32:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %96
+ThrowNullRef34:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %100
+ThrowNullRef36:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %102
+ThrowNullRef38:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %106
+ThrowNullRef40:                                   ; preds = %106
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %108
+ThrowNullRef42:                                   ; preds = %108
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %112
+ThrowNullRef44:                                   ; preds = %112
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %118
+ThrowNullRef46:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %121
+ThrowNullRef48:                                   ; preds = %121
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %123
+ThrowNullRef50:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %130
+ThrowNullRef52:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %132
+ThrowNullRef54:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %144
+ThrowNullRef56:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %146
+ThrowNullRef58:                                   ; preds = %146
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %60
+ThrowNullRef60:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %63
+ThrowNullRef62:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %49
+ThrowNullRef64:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %51
+ThrowNullRef66:                                   ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %53
+ThrowNullRef68:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(%"System.Char[]" addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %arg0 = alloca %"System.Char[]" addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store %"System.Char[]" addrspace(1)* %param0, %"System.Char[]" addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load i32, i32* %arg4
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %43, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %38, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg1
+  %13 = load i32, i32* %arg4
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %38, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %24 = load i32, i32* %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %35 = load i32, i32* %arg3
+  %36 = load i32, i32* %arg4
+  %37 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %37, %"System.Char[]" addrspace(1)* %34, i32 %35, i32 %36)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:38                                      ; preds = %5, %16
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Successfully read Buffer._Memmove
 
@@ -7914,7 +9431,7 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[loadElem]
+Failed to read AppDomain.SetDataHelper[storeElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -7923,8 +9440,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
@@ -7934,8 +9451,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
@@ -7947,15 +9464,15 @@ entry:
   %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
   %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
@@ -7966,15 +9483,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7992,7 +9509,79 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
-Failed to read Dictionary`2.TryGetValue[loadElemA]
+Successfully read Dictionary`2.TryGetValue
+
+define i8 @"Dictionary`2.TryGetValue"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)* addrspace(1)* %param2) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  %arg2 = alloca %System.__Canon addrspace(1)* addrspace(1)*
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  store %System.__Canon addrspace(1)* addrspace(1)* %param2, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  store i32 %2, i32* %loc0
+  %3 = load i32, i32* %loc0
+  %4 = icmp slt i32 %3, 0
+  br i1 %4, label %22, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 2
+  %10 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %9, align 8
+  %11 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = zext i32 %11 to i64
+  %BoundsCheck = icmp uge i64 %16, %15
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 3, i32 %11
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %20, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %6, %System.__Canon addrspace(1)* %21)
+  ret i8 1
+
+; <label>:22                                      ; preds = %entry
+  %23 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %23, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -8058,8 +9647,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
@@ -8091,8 +9680,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
@@ -8171,15 +9760,15 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck, label %19, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %ThrowNullRef, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
   %21 = load i32, i32 addrspace(1)* %20
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
@@ -8202,7 +9791,7 @@ ThrowNullRef:                                     ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %19
+ThrowNullRef2:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8248,8 +9837,8 @@ entry:
   %0 = alloca %System.AppDomainHandle
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %1 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %1, i32 0, i32 15
@@ -8269,8 +9858,8 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
@@ -8286,7 +9875,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -8299,8 +9888,8 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -8327,8 +9916,8 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
@@ -8352,8 +9941,8 @@ entry:
   %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
   store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
@@ -8363,8 +9952,8 @@ entry:
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
@@ -8374,8 +9963,8 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %9
   %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
@@ -8384,8 +9973,8 @@ entry:
 
 ; <label>:18                                      ; preds = %3, %16
   %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
@@ -8397,15 +9986,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %18
+ThrowNullRef6:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8418,8 +10007,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
@@ -8453,15 +10042,15 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
@@ -8473,7 +10062,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8481,7 +10070,7 @@ ThrowNullRef1:                                    ; preds = %1
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
 Failed to read Dictionary`2.System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
@@ -8506,8 +10095,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
@@ -8524,8 +10113,8 @@ entry:
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -8544,7 +10133,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8577,8 +10166,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = load i64, i64* %arg2
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = trunc i32 %3 to i8
@@ -8634,46 +10223,46 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
   %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
-  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
-  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
-  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
@@ -8684,27 +10273,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %20
+ThrowNullRef12:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8717,8 +10306,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -8756,22 +10345,22 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
   %9 = load i64, i64 addrspace(1)* %8, align 8
   %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
   %13 = load i64, i64 addrspace(1)* %12, align 8
   %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %11
   %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
@@ -8788,11 +10377,11 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8882,8 +10471,8 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
@@ -8900,8 +10489,8 @@ entry:
 ; <label>:8                                       ; preds = %1
   %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
   %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
@@ -8911,15 +10500,15 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
   %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
   %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
-  br i1 %NullCheck6, label %21, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
@@ -8946,15 +10535,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8992,15 +10581,15 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
   store i8 %3, i8 addrspace(1)* %5
   %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
@@ -9011,7 +10600,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9027,8 +10616,8 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -9041,8 +10630,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
@@ -9058,7 +10647,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9080,8 +10669,8 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
@@ -9096,8 +10685,8 @@ entry:
 ; <label>:12                                      ; preds = %6
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
@@ -9112,8 +10701,8 @@ entry:
 ; <label>:21                                      ; preds = %15
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
@@ -9128,8 +10717,8 @@ entry:
 ; <label>:30                                      ; preds = %24
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %31, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
@@ -9144,8 +10733,8 @@ entry:
 ; <label>:39                                      ; preds = %33
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
-  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %40, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %42
 
 ; <label>:42                                      ; preds = %39
   %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
@@ -9164,19 +10753,19 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %21
+ThrowNullRef4:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %30
+ThrowNullRef6:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %39
+ThrowNullRef8:                                    ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9243,8 +10832,8 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
@@ -9264,57 +10853,57 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
   store i8 0, i8 addrspace(1)* %2
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
   store i8 0, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
   store i8 0, i8 addrspace(1)* %17
   %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
   store i8 0, i8 addrspace(1)* %20
   %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
-  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
@@ -9325,31 +10914,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %19
+ThrowNullRef14:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9367,8 +10956,8 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
@@ -9380,8 +10969,8 @@ entry:
 
 ; <label>:9                                       ; preds = %4
   %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %9
   %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
@@ -9395,7 +10984,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef2:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9420,8 +11009,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
@@ -9512,8 +11101,8 @@ entry:
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
@@ -9524,8 +11113,8 @@ entry:
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = load i64, i64 addrspace(1)* %12
@@ -9537,8 +11126,8 @@ entry:
   %20 = load i64, i64* %19
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
-  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %13
   %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
@@ -9555,8 +11144,8 @@ entry:
 ; <label>:30                                      ; preds = %25
   %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %32 = load i32, i32* %arg2
-  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
-  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
@@ -9570,15 +11159,15 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %30
+ThrowNullRef2:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9622,87 +11211,87 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
   %10 = load i8, i8 addrspace(1)* %9, align 8
   %11 = zext i8 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %8
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
   store i8 %12, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
   %19 = load i8, i8 addrspace(1)* %18, align 8
   %20 = zext i8 %19 to i32
   %21 = trunc i32 %20 to i8
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
   store i8 %21, i8 addrspace(1)* %23
   %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
   %28 = load i8, i8 addrspace(1)* %27, align 8
   %29 = zext i8 %28 to i32
   %30 = trunc i32 %29 to i8
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
-  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %31
 
 ; <label>:31                                      ; preds = %26
   %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
   store i8 %30, i8 addrspace(1)* %32
   %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
-  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
-  br i1 %NullCheck14, label %40, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %40
 
 ; <label>:40                                      ; preds = %35
   %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
   store i8 %39, i8 addrspace(1)* %41
   %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
-  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %44
 
 ; <label>:44                                      ; preds = %40
   %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
   %46 = load i8, i8 addrspace(1)* %45, align 8
   %47 = zext i8 %46 to i32
   %48 = trunc i32 %47 to i8
-  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
   store i8 %48, i8 addrspace(1)* %50
   %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
-  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
@@ -9713,29 +11302,29 @@ entry:
 ; <label>:56                                      ; preds = %52
   %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
-  br i1 %NullCheck22, label %59, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
   %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
   %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
-  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
-  br i1 %NullCheck24, label %63, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
   %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
-  br i1 %NullCheck26, label %66, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
   %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
-  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
-  br i1 %NullCheck28, label %69, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %69
 
 ; <label>:69                                      ; preds = %66
   %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
@@ -9744,15 +11333,15 @@ entry:
 
 ; <label>:71                                      ; preds = %105
   %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
-  br i1 %NullCheck34, label %73, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %73
 
 ; <label>:73                                      ; preds = %71
   %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
   %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
   %76 = load i32, i32* %loc0
-  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
-  br i1 %NullCheck36, label %77, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
@@ -9766,8 +11355,8 @@ entry:
 
 ; <label>:83                                      ; preds = %77
   %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
-  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
@@ -9775,14 +11364,14 @@ entry:
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
   %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
-  br i1 %NullCheck40, label %91, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
 ; <label>:91                                      ; preds = %85
   %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
   %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
-  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck42, label %94, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %94
 
 ; <label>:94                                      ; preds = %91
   %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
@@ -9798,14 +11387,14 @@ entry:
 ; <label>:99                                      ; preds = %69, %96
   %100 = load i32, i32* %loc0
   %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
-  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %102
 
 ; <label>:102                                     ; preds = %99
   %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
   %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
-  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
-  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
@@ -9819,87 +11408,87 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %26
+ThrowNullRef10:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %31
+ThrowNullRef12:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %35
+ThrowNullRef14:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %40
+ThrowNullRef16:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %56
+ThrowNullRef22:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %59
+ThrowNullRef24:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %63
+ThrowNullRef26:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %66
+ThrowNullRef28:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %102
+ThrowNullRef32:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %71
+ThrowNullRef34:                                   ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %73
+ThrowNullRef36:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %83
+ThrowNullRef38:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %85
+ThrowNullRef40:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %91
+ThrowNullRef42:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9943,15 +11532,15 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
   %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
@@ -9961,28 +11550,28 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
   %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %12
   %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
   %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
   %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
-  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
@@ -9993,23 +11582,23 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %12
+ThrowNullRef6:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10031,15 +11620,15 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
   %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = load i64, i64 addrspace(1)* %7
@@ -10077,13 +11666,13 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[loadElem]
+Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -10111,8 +11700,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -10178,8 +11767,8 @@ entry:
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load float, float* %arg0
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -10313,8 +11902,8 @@ entry:
   store i64 %param0, i64* %arg0
   store i64 %param1, i64* %arg1
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
@@ -10322,8 +11911,8 @@ entry:
   %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
   %5 = load i16*, i16* addrspace(1)* %4, align 8
   %6 = addrspacecast i64* %arg1 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = bitcast i64 addrspace(1)* %6 to i8 addrspace(1)*
@@ -10339,7 +11928,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10373,8 +11962,8 @@ entry:
   %1 = load i32, i32* %arg1
   %2 = sext i32 %1 to i64
   %3 = inttoptr i64 %2 to i16*
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -10427,8 +12016,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, i32)*)(%System.IO.ConsoleStream addrspace(1)* %2, i32 %1)
   %3 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %4 = load i64, i64* %arg1
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
@@ -10439,8 +12028,8 @@ entry:
   %10 = icmp eq i32 %9, 3
   %11 = sext i1 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %5
   %14 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, i32 0, i32 5
@@ -10451,7 +12040,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10474,8 +12063,8 @@ entry:
   %5 = icmp eq i32 %4, 1
   %6 = sext i1 %5 to i32
   %7 = trunc i32 %6 to i8
-  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %2, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.ConsoleStream addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
@@ -10486,8 +12075,8 @@ entry:
   %13 = icmp eq i32 %12, 2
   %14 = sext i1 %13 to i32
   %15 = trunc i32 %14 to i8
-  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %10, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.ConsoleStream addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %8
   %17 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %10, i32 0, i32 4
@@ -10498,7 +12087,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10537,8 +12126,8 @@ entry:
   %arg0 = alloca i64
   store i64 %param0, i64* %arg0
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
@@ -10573,8 +12162,8 @@ entry:
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
   %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = load i64, i64 addrspace(1)* %7
@@ -10678,7 +12267,127 @@ entry:
 INFO:  jitting method Encoding::GetEncoding using LLILCJit
 Failed to read Encoding.GetEncoding[convertToHelperArgumentType]
 INFO:  jitting method EncodingProvider::GetEncodingFromProvider using LLILCJit
-Failed to read EncodingProvider.GetEncodingFromProvider[loadElem]
+Successfully read EncodingProvider.GetEncodingFromProvider
+
+define %System.Text.Encoding addrspace(1)* @EncodingProvider.GetEncodingFromProvider(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca %"System.Text.EncodingProvider[]" addrspace(1)*
+  %loc1 = alloca %System.Text.EncodingProvider addrspace(1)*
+  %loc2 = alloca %System.Text.Encoding addrspace(1)*
+  %loc3 = alloca %System.Text.Encoding addrspace(1)*
+  %loc4 = alloca %"System.Text.EncodingProvider[]" addrspace(1)*
+  %loc5 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1059)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2392
+  %2 = addrspacecast i8 addrspace(1)* %1 to %"System.Text.EncodingProvider[]" addrspace(1)**
+  %3 = load volatile %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %2
+  %4 = icmp ne %"System.Text.EncodingProvider[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %entry
+  ret %System.Text.Encoding addrspace(1)* null
+
+; <label>:6                                       ; preds = %entry
+  %7 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1059)
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i64 2392
+  %9 = addrspacecast i8 addrspace(1)* %8 to %"System.Text.EncodingProvider[]" addrspace(1)**
+  %10 = load volatile %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %9
+  store %"System.Text.EncodingProvider[]" addrspace(1)* %10, %"System.Text.EncodingProvider[]" addrspace(1)** %loc0
+  %11 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc0
+  store %"System.Text.EncodingProvider[]" addrspace(1)* %11, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  store i32 0, i32* %loc5
+  br label %43
+
+; <label>:12                                      ; preds = %46
+  %13 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  %14 = load i32, i32* %loc5
+  %NullCheck1 = icmp eq %"System.Text.EncodingProvider[]" addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %13, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = zext i32 %17 to i64
+  %19 = zext i32 %14 to i64
+  %BoundsCheck = icmp uge i64 %19, %18
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %20
+
+; <label>:20                                      ; preds = %15
+  %21 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %13, i32 0, i32 3, i32 %14
+  %22 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)* addrspace(1)* %21, align 8
+  store %System.Text.EncodingProvider addrspace(1)* %22, %System.Text.EncodingProvider addrspace(1)** %loc1
+  %23 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)** %loc1
+  %24 = load i32, i32* %arg0
+  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i64 addrspace(1)*
+  %NullCheck3 = icmp eq i64 addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
+
+; <label>:26                                      ; preds = %20
+  %27 = load i64, i64 addrspace(1)* %25
+  %28 = add i64 %27, 64
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 40
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Text.Encoding addrspace(1)* (%System.Text.EncodingProvider addrspace(1)*, i32)*
+  %35 = call %System.Text.Encoding addrspace(1)* %34(%System.Text.EncodingProvider addrspace(1)* %23, i32 %24)
+  store %System.Text.Encoding addrspace(1)* %35, %System.Text.Encoding addrspace(1)** %loc2
+  %36 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc2
+  %37 = icmp eq %System.Text.Encoding addrspace(1)* %36, null
+  br i1 %37, label %40, label %38
+
+; <label>:38                                      ; preds = %26
+  %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc2
+  store %System.Text.Encoding addrspace(1)* %39, %System.Text.Encoding addrspace(1)** %loc3
+  br label %53
+
+; <label>:40                                      ; preds = %26
+  %41 = load i32, i32* %loc5
+  %42 = add i32 %41, 1
+  store i32 %42, i32* %loc5
+  br label %43
+
+; <label>:43                                      ; preds = %6, %40
+  %44 = load i32, i32* %loc5
+  %45 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  %NullCheck = icmp eq %"System.Text.EncodingProvider[]" addrspace(1)* %45, null
+  br i1 %NullCheck, label %ThrowNullRef, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp slt i32 %44, %50
+  br i1 %51, label %12, label %52
+
+; <label>:52                                      ; preds = %46
+  ret %System.Text.Encoding addrspace(1)* null
+
+; <label>:53                                      ; preds = %38
+  %54 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc3
+  ret %System.Text.Encoding addrspace(1)* %54
+
+ThrowNullRef:                                     ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method EncodingProvider::.cctor using LLILCJit
 Successfully read EncodingProvider..cctor
 
@@ -10697,7 +12406,7 @@ Failed to read Encoding.get_InternalSyncObject[Call HasTypeArg]
 INFO:  jitting method Hashtable::.ctor using LLILCJit
 Failed to read Hashtable..ctor[Volatile store]
 INFO:  jitting method Hashtable::get_Item using LLILCJit
-Failed to read Hashtable.get_Item[loadElemA]
+Failed to read Hashtable.get_Item[loadNonPrimitiveObj]
 INFO:  jitting method Hashtable::InitHash using LLILCJit
 Successfully read Hashtable.InitHash
 
@@ -10717,8 +12426,8 @@ entry:
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -10734,15 +12443,15 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
   %15 = load i32, i32* %loc0
-  %NullCheck2 = icmp ne i32 addrspace(1)* %14, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i32 addrspace(1)* %14, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %3
   store i32 %15, i32 addrspace(1)* %14, align 8
   %17 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %18 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %NullCheck4 = icmp ne i32 addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i32 addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = load i32, i32 addrspace(1)* %18, align 8
@@ -10751,8 +12460,8 @@ entry:
   %23 = sub i32 %22, 1
   %24 = urem i32 %21, %23
   %25 = add i32 1, %24
-  %NullCheck6 = icmp ne i32 addrspace(1)* %17, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32 addrspace(1)* %17, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %19
   store i32 %25, i32 addrspace(1)* %17, align 8
@@ -10763,15 +12472,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %19
+ThrowNullRef6:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10786,8 +12495,8 @@ entry:
   store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
   store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %NullCheck = icmp ne %System.Collections.Hashtable addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Collections.Hashtable addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
@@ -10797,16 +12506,16 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Collections.Hashtable addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Collections.Hashtable addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
   %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck4 = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %9, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
   %13 = inttoptr i64 %11 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
@@ -10816,8 +12525,8 @@ entry:
 ; <label>:15                                      ; preds = %1
   %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -10835,15 +12544,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10857,8 +12566,8 @@ entry:
   store %System.Int32 addrspace(1)* %param0, %System.Int32 addrspace(1)** %this
   %0 = load %System.Int32 addrspace(1)*, %System.Int32 addrspace(1)** %this
   %1 = bitcast %System.Int32 addrspace(1)* %0 to i32 addrspace(1)*
-  %NullCheck = icmp ne i32 addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq i32 addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load i32, i32 addrspace(1)* %1, align 8
@@ -10934,8 +12643,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.UTF8Encoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
@@ -10944,15 +12653,15 @@ entry:
   %9 = load i8, i8* %arg2
   %10 = zext i8 %9 to i32
   %11 = trunc i32 %10 to i8
-  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %8, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %6
   %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %8, i32 0, i32 8
   store i8 %11, i8 addrspace(1)* %13
   %14 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %14, i32 0, i32 8
@@ -10964,8 +12673,8 @@ entry:
 ; <label>:20                                      ; preds = %15
   %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %22, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %22, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = load i64, i64 addrspace(1)* %22
@@ -10987,15 +12696,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %12
+ThrowNullRef4:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11010,8 +12719,8 @@ entry:
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
@@ -11033,16 +12742,16 @@ entry:
 ; <label>:10                                      ; preds = %1
   %11 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
   %12 = load i32, i32* %arg1
-  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %11, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.Encoding addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
   store i32 %12, i32 addrspace(1)* %14
   %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
   %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = load i64, i64 addrspace(1)* %16
@@ -11060,11 +12769,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11077,8 +12786,8 @@ entry:
   %this = alloca %System.Text.UTF8Encoding addrspace(1)*
   store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
   %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.UTF8Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
@@ -11090,16 +12799,16 @@ entry:
 ; <label>:6                                       ; preds = %1
   %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %8 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %10, %System.Text.EncoderFallback addrspace(1)* %8)
   %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %12 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
-  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %11, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %11, i32 0, i32 3
@@ -11112,8 +12821,8 @@ entry:
   %18 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %18, %System.String addrspace(1)* %17)
   %19 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %18 to %System.Text.EncoderFallback addrspace(1)*
-  %NullCheck6 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %16, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %16, i32 0, i32 2
@@ -11123,8 +12832,8 @@ entry:
   %24 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %24, %System.String addrspace(1)* %23)
   %25 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %24 to %System.Text.DecoderFallback addrspace(1)*
-  %NullCheck8 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %22, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %22, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %20
   %27 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %22, i32 0, i32 3
@@ -11135,19 +12844,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %20
+ThrowNullRef8:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11177,8 +12886,8 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load i32, i32* %arg1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -11196,8 +12905,8 @@ entry:
 ; <label>:15                                      ; preds = %8
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %17 = load i32, i32* %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 %17
@@ -11213,7 +12922,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11265,7 +12974,7 @@ entry:
 }
 
 INFO:  jitting method Hashtable::Insert using LLILCJit
-Failed to read Hashtable.Insert[loadElemA]
+Failed to read Hashtable.Insert[storeElem]
 INFO:  jitting method ConsoleEncoding::.ctor using LLILCJit
 Successfully read ConsoleEncoding..ctor
 
@@ -11280,8 +12989,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %1)
   %2 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
@@ -11317,8 +13026,8 @@ entry:
   %2 = call %System.Text.InternalEncoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalEncoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %1)
   %3 = bitcast %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2 to %System.Text.EncoderFallback addrspace(1)*
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
@@ -11328,8 +13037,8 @@ entry:
   %8 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %7)
   %9 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %8 to %System.Text.DecoderFallback addrspace(1)*
-  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %6, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.Encoding addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %4
   %11 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %6, i32 0, i32 3
@@ -11340,7 +13049,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11359,15 +13068,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* %1)
   %2 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   %6 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, i32 0, i32 1
@@ -11378,7 +13087,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11406,8 +13115,8 @@ entry:
   store %System.Text.InternalDecoderBestFitFallback addrspace(1)* %param0, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
   %0 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
@@ -11417,15 +13126,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %4)
   %5 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %6)
   %9 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, i32 0, i32 1
@@ -11436,11 +13145,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11508,8 +13217,8 @@ entry:
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
   %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = load i64, i64 addrspace(1)* %19
@@ -11573,8 +13282,8 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.ConsoleStream addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
@@ -11605,31 +13314,31 @@ entry:
   store i8 %param4, i8* %arg4
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %3, %System.IO.Stream addrspace(1)* %1)
   %4 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %4, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
   %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %4, i32 0, i32 4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %5)
   %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %6
   %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
   %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
   %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = load i64, i64 addrspace(1)* %13
@@ -11641,8 +13350,8 @@ entry:
   %21 = load i64, i64* %20
   %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %8, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %8, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %14
   %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 5
@@ -11660,24 +13369,24 @@ entry:
   %31 = load i32, i32* %arg3
   %32 = sext i32 %31 to i64
   %33 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %32)
-  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %30, null
-  br i1 %NullCheck10, label %34, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.StreamWriter addrspace(1)* %30, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %35, %"System.Char[]" addrspace(1)* %33)
   %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %37, null
-  br i1 %NullCheck12, label %38, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.StreamWriter addrspace(1)* %37, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %38
 
 ; <label>:38                                      ; preds = %34
   %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
   %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
   %41 = load i32, i32* %arg3
   %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %42, null
-  br i1 %NullCheck14, label %43, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %42, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
   %44 = load i64, i64 addrspace(1)* %42
@@ -11691,30 +13400,30 @@ entry:
   %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
   %53 = sext i32 %52 to i64
   %54 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %53)
-  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
-  br i1 %NullCheck16, label %55, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %55
 
 ; <label>:55                                      ; preds = %43
   %56 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %56, %"System.Byte[]" addrspace(1)* %54)
   %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %58 = load i32, i32* %arg3
-  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %57, null
-  br i1 %NullCheck18, label %59, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.StreamWriter addrspace(1)* %57, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %59
 
 ; <label>:59                                      ; preds = %55
   %60 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 10
   store i32 %58, i32 addrspace(1)* %60
   %61 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %61, null
-  br i1 %NullCheck20, label %62, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.IO.StreamWriter addrspace(1)* %61, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %62
 
 ; <label>:62                                      ; preds = %59
   %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
   %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
   %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
   %67 = load i64, i64 addrspace(1)* %65
@@ -11732,15 +13441,15 @@ entry:
 
 ; <label>:78                                      ; preds = %66
   %79 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %79, null
-  br i1 %NullCheck24, label %80, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.StreamWriter addrspace(1)* %79, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %80
 
 ; <label>:80                                      ; preds = %78
   %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
   %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
   %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %83, null
-  br i1 %NullCheck26, label %84, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %83, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
   %85 = load i64, i64 addrspace(1)* %83
@@ -11757,8 +13466,8 @@ entry:
 
 ; <label>:95                                      ; preds = %84
   %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.IO.StreamWriter addrspace(1)* %96, null
-  br i1 %NullCheck28, label %97, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.IO.StreamWriter addrspace(1)* %96, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %97
 
 ; <label>:97                                      ; preds = %95
   %98 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 12
@@ -11772,8 +13481,8 @@ entry:
   %103 = icmp eq i32 %102, 0
   %104 = sext i1 %103 to i32
   %105 = trunc i32 %104 to i8
-  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %100, null
-  br i1 %NullCheck30, label %106, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.IO.StreamWriter addrspace(1)* %100, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %106
 
 ; <label>:106                                     ; preds = %99
   %107 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %100, i32 0, i32 13
@@ -11784,63 +13493,63 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %6
+ThrowNullRef4:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %29
+ThrowNullRef10:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %34
+ThrowNullRef12:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %38
+ThrowNullRef14:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %43
+ThrowNullRef16:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %55
+ThrowNullRef18:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %59
+ThrowNullRef20:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %62
+ThrowNullRef22:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %78
+ThrowNullRef24:                                   ; preds = %78
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %80
+ThrowNullRef26:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %95
+ThrowNullRef28:                                   ; preds = %95
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11853,15 +13562,15 @@ entry:
   %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = load i64, i64 addrspace(1)* %4
@@ -11879,7 +13588,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11929,35 +13638,35 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
   %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderNLS addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %7 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.EncoderNLS addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Text.Encoding addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.Encoding addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Text.EncoderNLS addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.EncoderNLS addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
   %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck8 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = load i64, i64 addrspace(1)* %16
@@ -11976,19 +13685,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12014,8 +13723,8 @@ entry:
   %this = alloca %System.Text.Encoding addrspace(1)*
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
@@ -12035,15 +13744,15 @@ entry:
   %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
   store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
   %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
   store i32 0, i32 addrspace(1)* %2
   %3 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, i32 0, i32 2
@@ -12053,15 +13762,15 @@ entry:
 
 ; <label>:8                                       ; preds = %4
   %9 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
   %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
   %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = load i64, i64 addrspace(1)* %13
@@ -12082,15 +13791,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12105,16 +13814,16 @@ entry:
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = load i32, i32* %arg1
   %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
   %7 = load i64, i64 addrspace(1)* %5
@@ -12132,7 +13841,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12169,8 +13878,8 @@ entry:
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
   %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
   %16 = load i64, i64 addrspace(1)* %14
@@ -12191,8 +13900,8 @@ entry:
   %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
   %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
   %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %31, null
-  br i1 %NullCheck2, label %32, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = load i64, i64 addrspace(1)* %31
@@ -12235,7 +13944,7 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12248,14 +13957,14 @@ entry:
   %this = alloca %System.Text.EncoderReplacementFallback addrspace(1)*
   store %System.Text.EncoderReplacementFallback addrspace(1)* %param0, %System.Text.EncoderReplacementFallback addrspace(1)** %this
   %0 = load %System.Text.EncoderReplacementFallback addrspace(1)*, %System.Text.EncoderReplacementFallback addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -12266,7 +13975,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12296,8 +14005,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
@@ -12329,8 +14038,8 @@ entry:
   %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
   store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
@@ -12342,8 +14051,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Threading.Tasks.Task addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %7)
@@ -12366,7 +14075,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12385,8 +14094,8 @@ entry:
   store i8 %param1, i8* %arg1
   store i8 %param2, i8* %arg2
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
@@ -12400,8 +14109,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1, %5
   %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 9
@@ -12432,8 +14141,8 @@ entry:
 
 ; <label>:25                                      ; preds = %8, %20
   %26 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %26, null
-  br i1 %NullCheck4, label %27, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %26, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %26, i32 0, i32 12
@@ -12444,22 +14153,22 @@ entry:
 
 ; <label>:32                                      ; preds = %27
   %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %33, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.IO.StreamWriter addrspace(1)* %33, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %32
   %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 12
   store i8 1, i8 addrspace(1)* %35
   %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
-  br i1 %NullCheck8, label %37, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
   %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
   %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck10 = icmp ne i64 addrspace(1)* %40, null
-  br i1 %NullCheck10, label %41, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64 addrspace(1)* %40, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i64, i64 addrspace(1)* %40
@@ -12473,8 +14182,8 @@ entry:
   %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
   store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
   %51 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %NullCheck12 = icmp ne %"System.Byte[]" addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Byte[]" addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %41
   %53 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %51, i32 0, i32 1
@@ -12486,16 +14195,16 @@ entry:
 
 ; <label>:58                                      ; preds = %52
   %59 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %59, null
-  br i1 %NullCheck14, label %60, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.IO.StreamWriter addrspace(1)* %59, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %60
 
 ; <label>:60                                      ; preds = %58
   %61 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %59, i32 0, i32 3
   %62 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
   %64 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %NullCheck16 = icmp ne %"System.Byte[]" addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %"System.Byte[]" addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %60
   %66 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %64, i32 0, i32 1
@@ -12503,8 +14212,8 @@ entry:
   %68 = zext i32 %67 to i64
   %69 = trunc i64 %68 to i32
   %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck18, label %71, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
   %72 = load i64, i64 addrspace(1)* %70
@@ -12520,29 +14229,29 @@ entry:
 
 ; <label>:80                                      ; preds = %27, %52, %71
   %81 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %81, null
-  br i1 %NullCheck20, label %82, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.IO.StreamWriter addrspace(1)* %81, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
 
 ; <label>:82                                      ; preds = %80
   %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %81, i32 0, i32 5
   %84 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %83, align 8
   %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.IO.StreamWriter addrspace(1)* %85, null
-  br i1 %NullCheck22, label %86, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.IO.StreamWriter addrspace(1)* %85, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %86
 
 ; <label>:86                                      ; preds = %82
   %87 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 7
   %88 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %87, align 8
   %89 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %89, null
-  br i1 %NullCheck24, label %90, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.StreamWriter addrspace(1)* %89, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %90
 
 ; <label>:90                                      ; preds = %86
   %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %89, i32 0, i32 9
   %92 = load i32, i32 addrspace(1)* %91, align 8
   %93 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.IO.StreamWriter addrspace(1)* %93, null
-  br i1 %NullCheck26, label %94, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.IO.StreamWriter addrspace(1)* %93, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %93, i32 0, i32 6
@@ -12550,8 +14259,8 @@ entry:
   %97 = load i8, i8* %arg2
   %98 = zext i8 %97 to i32
   %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
-  %NullCheck28 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck28, label %100, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
   %101 = load i64, i64 addrspace(1)* %99
@@ -12566,8 +14275,8 @@ entry:
   %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
   store i32 %110, i32* %loc1
   %111 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %111, null
-  br i1 %NullCheck30, label %112, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.IO.StreamWriter addrspace(1)* %111, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %112
 
 ; <label>:112                                     ; preds = %100
   %113 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %111, i32 0, i32 9
@@ -12578,23 +14287,23 @@ entry:
 
 ; <label>:116                                     ; preds = %112
   %117 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck32 = icmp ne %System.IO.StreamWriter addrspace(1)* %117, null
-  br i1 %NullCheck32, label %118, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.IO.StreamWriter addrspace(1)* %117, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %118
 
 ; <label>:118                                     ; preds = %116
   %119 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %117, i32 0, i32 3
   %120 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %119, align 8
   %121 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.IO.StreamWriter addrspace(1)* %121, null
-  br i1 %NullCheck34, label %122, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.IO.StreamWriter addrspace(1)* %121, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %122
 
 ; <label>:122                                     ; preds = %118
   %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
   %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
   %125 = load i32, i32* %loc1
   %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
-  %NullCheck36 = icmp ne i64 addrspace(1)* %126, null
-  br i1 %NullCheck36, label %127, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64 addrspace(1)* %126, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
   %128 = load i64, i64 addrspace(1)* %126
@@ -12616,15 +14325,15 @@ entry:
 
 ; <label>:140                                     ; preds = %136
   %141 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.IO.StreamWriter addrspace(1)* %141, null
-  br i1 %NullCheck38, label %142, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.IO.StreamWriter addrspace(1)* %141, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %142
 
 ; <label>:142                                     ; preds = %140
   %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
   %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
   %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
-  %NullCheck40 = icmp ne i64 addrspace(1)* %145, null
-  br i1 %NullCheck40, label %146, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i64 addrspace(1)* %145, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
   %147 = load i64, i64 addrspace(1)* %145
@@ -12645,83 +14354,83 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %25
+ThrowNullRef4:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %32
+ThrowNullRef6:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %37
+ThrowNullRef10:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %41
+ThrowNullRef12:                                   ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %58
+ThrowNullRef14:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %60
+ThrowNullRef16:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %65
+ThrowNullRef18:                                   ; preds = %65
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %80
+ThrowNullRef20:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %82
+ThrowNullRef22:                                   ; preds = %82
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %86
+ThrowNullRef24:                                   ; preds = %86
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %90
+ThrowNullRef26:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %94
+ThrowNullRef28:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %100
+ThrowNullRef30:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %116
+ThrowNullRef32:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %118
+ThrowNullRef34:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %122
+ThrowNullRef36:                                   ; preds = %122
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %140
+ThrowNullRef38:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %142
+ThrowNullRef40:                                   ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12788,8 +14497,8 @@ entry:
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %1 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
-  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
@@ -12797,8 +14506,8 @@ entry:
   %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
   %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
   %8 = load i64, i64 addrspace(1)* %6
@@ -12814,8 +14523,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %17, %System.IFormatProvider addrspace(1)* %16)
   %18 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %19 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %18, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.SyncTextWriter addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %7
   %21 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %18, i32 0, i32 4
@@ -12826,11 +14535,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12843,8 +14552,8 @@ entry:
   %this = alloca %System.IO.TextWriter addrspace(1)*
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.TextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
@@ -12854,8 +14563,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.Threading.Thread addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Threading.Thread addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %6)
@@ -12864,8 +14573,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1
   %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.TextWriter addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.TextWriter addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %11, i32 0, i32 2
@@ -12876,11 +14585,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13077,8 +14786,8 @@ entry:
   store float %param1, float* %arg1
   store i8 0, i8* %loc1
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
@@ -13088,16 +14797,16 @@ entry:
   %5 = addrspacecast i8* %loc1 to i8 addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %4, i8 addrspace(1)* %5)
   %6 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.SyncTextWriter addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
   %10 = load float, float* %arg1
   %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
   %13 = load i64, i64 addrspace(1)* %11
@@ -13132,11 +14841,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13153,8 +14862,8 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load float, float* %arg1
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -13168,8 +14877,8 @@ entry:
   call void %11(%System.IO.TextWriter addrspace(1)* %0, float %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
   %15 = load i64, i64 addrspace(1)* %13
@@ -13187,7 +14896,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13205,8 +14914,8 @@ entry:
   %1 = addrspacecast float* %arg1 to float addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -13221,8 +14930,8 @@ entry:
   %14 = bitcast float addrspace(1)* %1 to %System.Single addrspace(1)*
   %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Single addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Single addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
   %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
   %18 = load i64, i64 addrspace(1)* %16
@@ -13240,7 +14949,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13256,8 +14965,8 @@ entry:
   store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
   %0 = load %System.Single addrspace(1)*, %System.Single addrspace(1)** %this
   %1 = bitcast %System.Single addrspace(1)* %0 to float addrspace(1)*
-  %NullCheck = icmp ne float addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq float addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load float, float addrspace(1)* %1, align 8
@@ -13282,8 +14991,8 @@ entry:
   %loc0 = alloca %System.Globalization.NumberFormatInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 3
@@ -13293,8 +15002,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
@@ -13304,24 +15013,24 @@ entry:
   store %System.Globalization.NumberFormatInfo addrspace(1)* %10, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
   %11 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %7
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
   %15 = load i8, i8 addrspace(1)* %14, align 8
   %16 = zext i8 %15 to i32
   %17 = trunc i32 %16 to i8
-  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %11, null
-  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %11, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %13
   %19 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %11, i32 0, i32 29
   store i8 %17, i8 addrspace(1)* %19
   %20 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %21 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %20, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %20, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %18
   %23 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %20, i32 0, i32 3
@@ -13330,8 +15039,8 @@ entry:
 
 ; <label>:24                                      ; preds = %1, %22
   %25 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %25, null
-  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %25, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %26
 
 ; <label>:26                                      ; preds = %24
   %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %25, i32 0, i32 3
@@ -13342,23 +15051,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %18
+ThrowNullRef8:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13383,168 +15092,168 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 18
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %8, align 8
-  %NullCheck2 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %5, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %5, i32 0, i32 4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %9)
   %12 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 19
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %15, align 8
-  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %12, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %12, i32 0, i32 5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %16)
   %19 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %20 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %20, null
-  br i1 %NullCheck8, label %21, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %20, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %20, i32 0, i32 23
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  %NullCheck10 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %19, null
-  br i1 %NullCheck10, label %24, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %19, i32 0, i32 7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %25, %System.String addrspace(1)* %23)
   %26 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %27 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %27, i32 0, i32 22
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %29, align 8
-  %NullCheck14 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %26, null
-  br i1 %NullCheck14, label %31, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %26, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %26, i32 0, i32 6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %32, %System.String addrspace(1)* %30)
   %33 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %34 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Globalization.CultureData addrspace(1)* %34, null
-  br i1 %NullCheck16, label %35, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Globalization.CultureData addrspace(1)* %34, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %34, i32 0, i32 51
   %37 = load i32, i32 addrspace(1)* %36, align 8
-  %NullCheck18 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %33, null
-  br i1 %NullCheck18, label %38, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %33, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %33, i32 0, i32 21
   store i32 %37, i32 addrspace(1)* %39
   %40 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %41 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Globalization.CultureData addrspace(1)* %41, null
-  br i1 %NullCheck20, label %42, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Globalization.CultureData addrspace(1)* %41, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %41, i32 0, i32 52
   %44 = load i32, i32 addrspace(1)* %43, align 8
-  %NullCheck22 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %40, null
-  br i1 %NullCheck22, label %45, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %40, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %40, i32 0, i32 25
   store i32 %44, i32 addrspace(1)* %46
   %47 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %48 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.Globalization.CultureData addrspace(1)* %48, null
-  br i1 %NullCheck24, label %49, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Globalization.CultureData addrspace(1)* %48, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %49
 
 ; <label>:49                                      ; preds = %45
   %50 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %48, i32 0, i32 29
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck26 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %47, null
-  br i1 %NullCheck26, label %52, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %47, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %47, i32 0, i32 10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %53, %System.String addrspace(1)* %51)
   %54 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %55 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Globalization.CultureData addrspace(1)* %55, null
-  br i1 %NullCheck28, label %56, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Globalization.CultureData addrspace(1)* %55, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %56
 
 ; <label>:56                                      ; preds = %52
   %57 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %55, i32 0, i32 35
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %57, align 8
-  %NullCheck30 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %54, null
-  br i1 %NullCheck30, label %59, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %54, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %54, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %60, %System.String addrspace(1)* %58)
   %61 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %62 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck32 = icmp ne %System.Globalization.CultureData addrspace(1)* %62, null
-  br i1 %NullCheck32, label %63, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Globalization.CultureData addrspace(1)* %62, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %62, i32 0, i32 34
   %65 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %64, align 8
-  %NullCheck34 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %61, null
-  br i1 %NullCheck34, label %66, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %61, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %61, i32 0, i32 9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %67, %System.String addrspace(1)* %65)
   %68 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %69 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck36 = icmp ne %System.Globalization.CultureData addrspace(1)* %69, null
-  br i1 %NullCheck36, label %70, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Globalization.CultureData addrspace(1)* %69, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %70
 
 ; <label>:70                                      ; preds = %66
   %71 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %69, i32 0, i32 55
   %72 = load i32, i32 addrspace(1)* %71, align 8
-  %NullCheck38 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %68, null
-  br i1 %NullCheck38, label %73, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %68, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %68, i32 0, i32 22
   store i32 %72, i32 addrspace(1)* %74
   %75 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %76 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck40 = icmp ne %System.Globalization.CultureData addrspace(1)* %76, null
-  br i1 %NullCheck40, label %77, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Globalization.CultureData addrspace(1)* %76, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %76, i32 0, i32 57
   %79 = load i32, i32 addrspace(1)* %78, align 8
-  %NullCheck42 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %75, null
-  br i1 %NullCheck42, label %80, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %75, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %80
 
 ; <label>:80                                      ; preds = %77
   %81 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %75, i32 0, i32 24
   store i32 %79, i32 addrspace(1)* %81
   %82 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %83 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck44 = icmp ne %System.Globalization.CultureData addrspace(1)* %83, null
-  br i1 %NullCheck44, label %84, label %ThrowNullRef43
+  %NullCheck43 = icmp eq %System.Globalization.CultureData addrspace(1)* %83, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %84
 
 ; <label>:84                                      ; preds = %80
   %85 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %83, i32 0, i32 56
   %86 = load i32, i32 addrspace(1)* %85, align 8
-  %NullCheck46 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %82, null
-  br i1 %NullCheck46, label %87, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %82, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %82, i32 0, i32 23
@@ -13553,8 +15262,8 @@ entry:
 
 ; <label>:89                                      ; preds = %entry
   %90 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck100 = icmp ne %System.Globalization.CultureData addrspace(1)* %90, null
-  br i1 %NullCheck100, label %91, label %ThrowNullRef99
+  %NullCheck99 = icmp eq %System.Globalization.CultureData addrspace(1)* %90, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %91
 
 ; <label>:91                                      ; preds = %89
   %92 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %90, i32 0, i32 2
@@ -13572,8 +15281,8 @@ entry:
   %102 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %103 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %104 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %103)
-  %NullCheck48 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %102, null
-  br i1 %NullCheck48, label %105, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %102, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %105
 
 ; <label>:105                                     ; preds = %101
   %106 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %102, i32 0, i32 1
@@ -13581,8 +15290,8 @@ entry:
   %107 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %108 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %109 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %108)
-  %NullCheck50 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %107, null
-  br i1 %NullCheck50, label %110, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %107, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %110
 
 ; <label>:110                                     ; preds = %105
   %111 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %107, i32 0, i32 2
@@ -13590,8 +15299,8 @@ entry:
   %112 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %113 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %114 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %113)
-  %NullCheck52 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %112, null
-  br i1 %NullCheck52, label %115, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %112, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %115
 
 ; <label>:115                                     ; preds = %110
   %116 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %112, i32 0, i32 27
@@ -13599,8 +15308,8 @@ entry:
   %117 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %118 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %119 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %118)
-  %NullCheck54 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %117, null
-  br i1 %NullCheck54, label %120, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %117, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %120
 
 ; <label>:120                                     ; preds = %115
   %121 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %117, i32 0, i32 26
@@ -13608,8 +15317,8 @@ entry:
   %122 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %123 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %124 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %123)
-  %NullCheck56 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %122, null
-  br i1 %NullCheck56, label %125, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %122, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %125
 
 ; <label>:125                                     ; preds = %120
   %126 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %122, i32 0, i32 17
@@ -13617,8 +15326,8 @@ entry:
   %127 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %128 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %129 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %128)
-  %NullCheck58 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %127, null
-  br i1 %NullCheck58, label %130, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %127, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %130
 
 ; <label>:130                                     ; preds = %125
   %131 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %127, i32 0, i32 18
@@ -13626,8 +15335,8 @@ entry:
   %132 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %133 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %134 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %133)
-  %NullCheck60 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %132, null
-  br i1 %NullCheck60, label %135, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %132, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %135
 
 ; <label>:135                                     ; preds = %130
   %136 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %132, i32 0, i32 14
@@ -13635,8 +15344,8 @@ entry:
   %137 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %138 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %139 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %138)
-  %NullCheck62 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %137, null
-  br i1 %NullCheck62, label %140, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %137, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %140
 
 ; <label>:140                                     ; preds = %135
   %141 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %137, i32 0, i32 13
@@ -13644,71 +15353,71 @@ entry:
   %142 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %143 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %144 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %143)
-  %NullCheck64 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %142, null
-  br i1 %NullCheck64, label %145, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %142, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %145
 
 ; <label>:145                                     ; preds = %140
   %146 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %142, i32 0, i32 12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %146, %System.String addrspace(1)* %144)
   %147 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %148 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck66 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %148, null
-  br i1 %NullCheck66, label %149, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %148, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %149
 
 ; <label>:149                                     ; preds = %145
   %150 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %148, i32 0, i32 21
   %151 = load i32, i32 addrspace(1)* %150, align 8
-  %NullCheck68 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %147, null
-  br i1 %NullCheck68, label %152, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %147, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %152
 
 ; <label>:152                                     ; preds = %149
   %153 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %147, i32 0, i32 28
   store i32 %151, i32 addrspace(1)* %153
   %154 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %155 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck70 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %155, null
-  br i1 %NullCheck70, label %156, label %ThrowNullRef69
+  %NullCheck69 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %155, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %156
 
 ; <label>:156                                     ; preds = %152
   %157 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %155, i32 0, i32 6
   %158 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %157, align 8
-  %NullCheck72 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %154, null
-  br i1 %NullCheck72, label %159, label %ThrowNullRef71
+  %NullCheck71 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %154, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %159
 
 ; <label>:159                                     ; preds = %156
   %160 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %154, i32 0, i32 15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %160, %System.String addrspace(1)* %158)
   %161 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %162 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck74 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %162, null
-  br i1 %NullCheck74, label %163, label %ThrowNullRef73
+  %NullCheck73 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %162, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %163
 
 ; <label>:163                                     ; preds = %159
   %164 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %162, i32 0, i32 1
   %165 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %164, align 8
-  %NullCheck76 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %161, null
-  br i1 %NullCheck76, label %166, label %ThrowNullRef75
+  %NullCheck75 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %161, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %166
 
 ; <label>:166                                     ; preds = %163
   %167 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %161, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %167, %"System.Int32[]" addrspace(1)* %165)
   %168 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %169 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck78 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %169, null
-  br i1 %NullCheck78, label %170, label %ThrowNullRef77
+  %NullCheck77 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %169, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %170
 
 ; <label>:170                                     ; preds = %166
   %171 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %169, i32 0, i32 7
   %172 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %171, align 8
-  %NullCheck80 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %168, null
-  br i1 %NullCheck80, label %173, label %ThrowNullRef79
+  %NullCheck79 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %168, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %173
 
 ; <label>:173                                     ; preds = %170
   %174 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %168, i32 0, i32 16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %174, %System.String addrspace(1)* %172)
   %175 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck82 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %175, null
-  br i1 %NullCheck82, label %176, label %ThrowNullRef81
+  %NullCheck81 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %175, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %176
 
 ; <label>:176                                     ; preds = %173
   %177 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %175, i32 0, i32 4
@@ -13718,14 +15427,14 @@ entry:
 
 ; <label>:180                                     ; preds = %176
   %181 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck84 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %181, null
-  br i1 %NullCheck84, label %182, label %ThrowNullRef83
+  %NullCheck83 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %181, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %182
 
 ; <label>:182                                     ; preds = %180
   %183 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %181, i32 0, i32 4
   %184 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %183, align 8
-  %NullCheck86 = icmp ne %System.String addrspace(1)* %184, null
-  br i1 %NullCheck86, label %185, label %ThrowNullRef85
+  %NullCheck85 = icmp eq %System.String addrspace(1)* %184, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %185
 
 ; <label>:185                                     ; preds = %182
   %186 = getelementptr inbounds %System.String, %System.String addrspace(1)* %184, i32 0, i32 1
@@ -13736,8 +15445,8 @@ entry:
 ; <label>:189                                     ; preds = %176, %185
   %190 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck98 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %190, null
-  br i1 %NullCheck98, label %192, label %ThrowNullRef97
+  %NullCheck97 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %190, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %192
 
 ; <label>:192                                     ; preds = %189
   %193 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %190, i32 0, i32 4
@@ -13746,8 +15455,8 @@ entry:
 
 ; <label>:194                                     ; preds = %185, %192
   %195 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck88 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %195, null
-  br i1 %NullCheck88, label %196, label %ThrowNullRef87
+  %NullCheck87 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %195, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %196
 
 ; <label>:196                                     ; preds = %194
   %197 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %195, i32 0, i32 9
@@ -13757,14 +15466,14 @@ entry:
 
 ; <label>:200                                     ; preds = %196
   %201 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck90 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %201, null
-  br i1 %NullCheck90, label %202, label %ThrowNullRef89
+  %NullCheck89 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %201, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %202
 
 ; <label>:202                                     ; preds = %200
   %203 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %201, i32 0, i32 9
   %204 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %203, align 8
-  %NullCheck92 = icmp ne %System.String addrspace(1)* %204, null
-  br i1 %NullCheck92, label %205, label %ThrowNullRef91
+  %NullCheck91 = icmp eq %System.String addrspace(1)* %204, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %205
 
 ; <label>:205                                     ; preds = %202
   %206 = getelementptr inbounds %System.String, %System.String addrspace(1)* %204, i32 0, i32 1
@@ -13775,14 +15484,14 @@ entry:
 ; <label>:209                                     ; preds = %196, %205
   %210 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %211 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck94 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %211, null
-  br i1 %NullCheck94, label %212, label %ThrowNullRef93
+  %NullCheck93 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %211, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %212
 
 ; <label>:212                                     ; preds = %209
   %213 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %211, i32 0, i32 6
   %214 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %213, align 8
-  %NullCheck96 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %210, null
-  br i1 %NullCheck96, label %215, label %ThrowNullRef95
+  %NullCheck95 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %210, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %215
 
 ; <label>:215                                     ; preds = %212
   %216 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %210, i32 0, i32 9
@@ -13796,203 +15505,203 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %17
+ThrowNullRef8:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %21
+ThrowNullRef10:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %24
+ThrowNullRef12:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %28
+ThrowNullRef14:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %31
+ThrowNullRef16:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %35
+ThrowNullRef18:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %38
+ThrowNullRef20:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %42
+ThrowNullRef22:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %45
+ThrowNullRef24:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %49
+ThrowNullRef26:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %52
+ThrowNullRef28:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %56
+ThrowNullRef30:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %59
+ThrowNullRef32:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %63
+ThrowNullRef34:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %66
+ThrowNullRef36:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %70
+ThrowNullRef38:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %73
+ThrowNullRef40:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %77
+ThrowNullRef42:                                   ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %80
+ThrowNullRef44:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %84
+ThrowNullRef46:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %101
+ThrowNullRef48:                                   ; preds = %101
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %105
+ThrowNullRef50:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %110
+ThrowNullRef52:                                   ; preds = %110
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %115
+ThrowNullRef54:                                   ; preds = %115
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %120
+ThrowNullRef56:                                   ; preds = %120
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %125
+ThrowNullRef58:                                   ; preds = %125
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %130
+ThrowNullRef60:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %135
+ThrowNullRef62:                                   ; preds = %135
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %140
+ThrowNullRef64:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %145
+ThrowNullRef66:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %149
+ThrowNullRef68:                                   ; preds = %149
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %152
+ThrowNullRef70:                                   ; preds = %152
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %156
+ThrowNullRef72:                                   ; preds = %156
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %159
+ThrowNullRef74:                                   ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %163
+ThrowNullRef76:                                   ; preds = %163
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %166
+ThrowNullRef78:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %170
+ThrowNullRef80:                                   ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %173
+ThrowNullRef82:                                   ; preds = %173
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %180
+ThrowNullRef84:                                   ; preds = %180
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %182
+ThrowNullRef86:                                   ; preds = %182
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %194
+ThrowNullRef88:                                   ; preds = %194
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %200
+ThrowNullRef90:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %202
+ThrowNullRef92:                                   ; preds = %202
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %209
+ThrowNullRef94:                                   ; preds = %209
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %212
+ThrowNullRef96:                                   ; preds = %212
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %189
+ThrowNullRef98:                                   ; preds = %189
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %89
+ThrowNullRef100:                                  ; preds = %89
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14020,8 +15729,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 21
@@ -14034,8 +15743,8 @@ entry:
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 16)
   %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 21
@@ -14044,8 +15753,8 @@ entry:
 
 ; <label>:12                                      ; preds = %1, %10
   %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 21
@@ -14056,11 +15765,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %12
+ThrowNullRef4:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14076,8 +15785,8 @@ entry:
   store i32 %param1, i32* %arg1
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %1 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
@@ -14144,8 +15853,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 33
@@ -14158,8 +15867,8 @@ entry:
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 24)
   %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 33
@@ -14168,8 +15877,8 @@ entry:
 
 ; <label>:12                                      ; preds = %1, %10
   %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 33
@@ -14180,11 +15889,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %12
+ThrowNullRef4:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14197,8 +15906,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 53
@@ -14210,8 +15919,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 116)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 53
@@ -14220,8 +15929,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 53
@@ -14232,11 +15941,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14265,8 +15974,8 @@ entry:
 
 ; <label>:7                                       ; preds = %entry, %4
   %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %7
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 2
@@ -14290,8 +15999,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 54
@@ -14303,8 +16012,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 117)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
@@ -14313,8 +16022,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 54
@@ -14325,11 +16034,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14342,8 +16051,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 27
@@ -14355,8 +16064,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 118)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 27
@@ -14365,8 +16074,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 27
@@ -14377,11 +16086,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14394,8 +16103,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 28
@@ -14407,8 +16116,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 119)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 28
@@ -14417,8 +16126,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 28
@@ -14429,11 +16138,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14446,8 +16155,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 26
@@ -14459,8 +16168,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 107)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 26
@@ -14469,8 +16178,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 26
@@ -14481,11 +16190,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14498,8 +16207,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 25
@@ -14511,8 +16220,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 106)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 25
@@ -14521,8 +16230,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 25
@@ -14533,11 +16242,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14550,8 +16259,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 24
@@ -14563,8 +16272,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 105)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 24
@@ -14573,8 +16282,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 24
@@ -14585,11 +16294,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14614,8 +16323,8 @@ entry:
   %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %3)
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %2
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -14626,15 +16335,15 @@ entry:
 
 ; <label>:8                                       ; preds = %62
   %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 9
   %12 = load i32, i32 addrspace(1)* %11, align 8
   %13 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.IO.StreamWriter addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %13, i32 0, i32 10
@@ -14649,15 +16358,15 @@ entry:
 
 ; <label>:20                                      ; preds = %14, %18
   %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
   %24 = load i32, i32 addrspace(1)* %23, align 8
   %25 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %25, null
-  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.StreamWriter addrspace(1)* %25, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %25, i32 0, i32 9
@@ -14678,36 +16387,36 @@ entry:
   %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %37 = load i32, i32* %loc1
   %38 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.StreamWriter addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %35
   %40 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %38, i32 0, i32 7
   %41 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %40, align 8
   %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
-  br i1 %NullCheck14, label %43, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %39
   %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 9
   %45 = load i32, i32 addrspace(1)* %44, align 8
   %46 = load i32, i32* %loc2
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %36, null
-  br i1 %NullCheck16, label %47, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %36, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %47
 
 ; <label>:47                                      ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %36, i32 %37, %"System.Char[]" addrspace(1)* %41, i32 %45, i32 %46)
   %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
   %51 = load i32, i32 addrspace(1)* %50, align 8
   %52 = load i32, i32* %loc2
   %53 = add i32 %51, %52
-  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
-  br i1 %NullCheck20, label %54, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %54
 
 ; <label>:54                                      ; preds = %49
   %55 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
@@ -14729,8 +16438,8 @@ entry:
 
 ; <label>:65                                      ; preds = %62
   %66 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %66, null
-  br i1 %NullCheck2, label %67, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %66, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %67
 
 ; <label>:67                                      ; preds = %65
   %68 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %66, i32 0, i32 11
@@ -14751,49 +16460,259 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %65
+ThrowNullRef2:                                    ; preds = %65
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %20
+ThrowNullRef8:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %22
+ThrowNullRef10:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %35
+ThrowNullRef12:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %43
+ThrowNullRef16:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %47
+ThrowNullRef18:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method String::CopyTo using LLILCJit
-Failed to read String.CopyTo[loadElemA]
+Successfully read String.CopyTo
+
+define void @String.CopyTo(%System.String addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  %loc1 = alloca i16 addrspace(1)*
+  %loc2 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %1 = icmp ne %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg4
+  %7 = icmp sge i32 %6, 0
+  br i1 %7, label %13, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  unreachable
+
+; <label>:13                                      ; preds = %5
+  %14 = load i32, i32* %arg1
+  %15 = icmp sge i32 %14, 0
+  br i1 %15, label %21, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %18)
+  %20 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %20, %System.String addrspace(1)* %17, %System.String addrspace(1)* %19)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %20) #0
+  unreachable
+
+; <label>:21                                      ; preds = %13
+  %22 = load i32, i32* %arg4
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck, label %ThrowNullRef, label %24
+
+; <label>:24                                      ; preds = %21
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load i32, i32* %arg1
+  %28 = sub i32 %26, %27
+  %29 = icmp sle i32 %22, %28
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34, %System.String addrspace(1)* %31, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %24
+  %36 = load i32, i32* %arg3
+  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %37, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
+
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
+  %40 = load i32, i32 addrspace(1)* %39
+  %41 = zext i32 %40 to i64
+  %42 = trunc i64 %41 to i32
+  %43 = load i32, i32* %arg4
+  %44 = sub i32 %42, %43
+  %45 = icmp sgt i32 %36, %44
+  br i1 %45, label %49, label %46
+
+; <label>:46                                      ; preds = %38
+  %47 = load i32, i32* %arg3
+  %48 = icmp sge i32 %47, 0
+  br i1 %48, label %54, label %49
+
+; <label>:49                                      ; preds = %38, %46
+  %50 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %52 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %51)
+  %53 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53, %System.String addrspace(1)* %50, %System.String addrspace(1)* %52)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53) #0
+  unreachable
+
+; <label>:54                                      ; preds = %46
+  %55 = load i32, i32* %arg4
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %97, label %57
+
+; <label>:57                                      ; preds = %54
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %59
+
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 2
+  %61 = bitcast [0 x i16] addrspace(1)* %60 to i16 addrspace(1)*
+  store i16 addrspace(1)* %61, i16 addrspace(1)** %loc0
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  store %"System.Char[]" addrspace(1)* %62, %"System.Char[]" addrspace(1)** %loc2
+  %63 = icmp eq %"System.Char[]" addrspace(1)* %62, null
+  br i1 %63, label %72, label %64
+
+; <label>:64                                      ; preds = %59
+  %65 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc2
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %65, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %66
+
+; <label>:66                                      ; preds = %64
+  %67 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %65, i32 0, i32 1
+  %68 = load i32, i32 addrspace(1)* %67
+  %69 = zext i32 %68 to i64
+  %70 = trunc i64 %69 to i32
+  %71 = icmp ne i32 %70, 0
+  br i1 %71, label %73, label %72
+
+; <label>:72                                      ; preds = %59, %66
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  br label %81
+
+; <label>:73                                      ; preds = %66
+  %74 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc2
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %74, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %75
+
+; <label>:75                                      ; preds = %73
+  %76 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %74, i32 0, i32 1
+  %77 = load i32, i32 addrspace(1)* %76
+  %78 = zext i32 %77 to i64
+  %BoundsCheck = icmp uge i64 0, %78
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %79
+
+; <label>:79                                      ; preds = %75
+  %80 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %74, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %80, i16 addrspace(1)** %loc1
+  br label %81
+
+; <label>:81                                      ; preds = %72, %79
+  %82 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %83 = ptrtoint i16 addrspace(1)* %82 to i64
+  %84 = load i32, i32* %arg3
+  %85 = sext i32 %84 to i64
+  %86 = mul i64 %85, 2
+  %87 = add i64 %83, %86
+  %88 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %89 = ptrtoint i16 addrspace(1)* %88 to i64
+  %90 = load i32, i32* %arg1
+  %91 = sext i32 %90 to i64
+  %92 = mul i64 %91, 2
+  %93 = add i64 %89, %92
+  %94 = load i32, i32* %arg4
+  %95 = inttoptr i64 %87 to i16*
+  %96 = inttoptr i64 %93 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %95, i16* %96, i32 %94)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  br label %97
+
+; <label>:97                                      ; preds = %54, %81
+  ret void
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
 Successfully read ConsoleEncoding.GetPreamble
 
@@ -14830,7 +16749,365 @@ entry:
 }
 
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[loadElemA]
+Successfully read EncoderNLS.GetBytes
+
+define i32 @EncoderNLS.GetBytes(%System.Text.EncoderNLS addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3, %"System.Byte[]" addrspace(1)* %param4, i32 %param5, i8 %param6) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %arg4 = alloca %"System.Byte[]" addrspace(1)*
+  %arg5 = alloca i32
+  %arg6 = alloca i8
+  %loc0 = alloca i32
+  %loc1 = alloca i16 addrspace(1)*
+  %loc2 = alloca i8 addrspace(1)*
+  %loc3 = alloca i32
+  %loc4 = alloca %"System.Char[]" addrspace(1)*
+  %loc5 = alloca %"System.Byte[]" addrspace(1)*
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  store %"System.Byte[]" addrspace(1)* %param4, %"System.Byte[]" addrspace(1)** %arg4
+  store i32 %param5, i32* %arg5
+  store i8 %param6, i8* %arg6
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %1 = icmp eq %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %17, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %7 = icmp eq %"System.Char[]" addrspace(1)* %6, null
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %12
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %12
+
+; <label>:12                                      ; preds = %8, %10
+  %13 = phi %System.String addrspace(1)* [ %9, %8 ], [ %11, %10 ]
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %14)
+  %16 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16, %System.String addrspace(1)* %13, %System.String addrspace(1)* %15)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16) #0
+  unreachable
+
+; <label>:17                                      ; preds = %2
+  %18 = load i32, i32* %arg2
+  %19 = icmp slt i32 %18, 0
+  br i1 %19, label %23, label %20
+
+; <label>:20                                      ; preds = %17
+  %21 = load i32, i32* %arg3
+  %22 = icmp sge i32 %21, 0
+  br i1 %22, label %35, label %23
+
+; <label>:23                                      ; preds = %17, %20
+  %24 = load i32, i32* %arg2
+  %25 = icmp slt i32 %24, 0
+  br i1 %25, label %28, label %26
+
+; <label>:26                                      ; preds = %23
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %30
+
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %30
+
+; <label>:30                                      ; preds = %26, %28
+  %31 = phi %System.String addrspace(1)* [ %27, %26 ], [ %29, %28 ]
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34, %System.String addrspace(1)* %31, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %20
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck, label %ThrowNullRef, label %37
+
+; <label>:37                                      ; preds = %35
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = load i32, i32* %arg2
+  %43 = sub i32 %41, %42
+  %44 = load i32, i32* %arg3
+  %45 = icmp sge i32 %43, %44
+  br i1 %45, label %51, label %46
+
+; <label>:46                                      ; preds = %37
+  %47 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %48 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %49 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %48)
+  %50 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %50, %System.String addrspace(1)* %47, %System.String addrspace(1)* %49)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %50) #0
+  unreachable
+
+; <label>:51                                      ; preds = %37
+  %52 = load i32, i32* %arg5
+  %53 = icmp slt i32 %52, 0
+  br i1 %53, label %63, label %54
+
+; <label>:54                                      ; preds = %51
+  %55 = load i32, i32* %arg5
+  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck1 = icmp eq %"System.Byte[]" addrspace(1)* %56, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %57
+
+; <label>:57                                      ; preds = %54
+  %58 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = zext i32 %59 to i64
+  %61 = trunc i64 %60 to i32
+  %62 = icmp sle i32 %55, %61
+  br i1 %62, label %68, label %63
+
+; <label>:63                                      ; preds = %51, %57
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %66 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %65)
+  %67 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %67, %System.String addrspace(1)* %64, %System.String addrspace(1)* %66)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %67) #0
+  unreachable
+
+; <label>:68                                      ; preds = %57
+  %69 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %69, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %69, i32 0, i32 1
+  %72 = load i32, i32 addrspace(1)* %71
+  %73 = zext i32 %72 to i64
+  %74 = trunc i64 %73 to i32
+  %75 = icmp ne i32 %74, 0
+  br i1 %75, label %78, label %76
+
+; <label>:76                                      ; preds = %70
+  %77 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1)
+  store %"System.Char[]" addrspace(1)* %77, %"System.Char[]" addrspace(1)** %arg1
+  br label %78
+
+; <label>:78                                      ; preds = %70, %76
+  %79 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck5 = icmp eq %"System.Byte[]" addrspace(1)* %79, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %80
+
+; <label>:80                                      ; preds = %78
+  %81 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %79, i32 0, i32 1
+  %82 = load i32, i32 addrspace(1)* %81
+  %83 = zext i32 %82 to i64
+  %84 = trunc i64 %83 to i32
+  %85 = load i32, i32* %arg5
+  %86 = sub i32 %84, %85
+  store i32 %86, i32* %loc0
+  %87 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck7 = icmp eq %"System.Byte[]" addrspace(1)* %87, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %88
+
+; <label>:88                                      ; preds = %80
+  %89 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %87, i32 0, i32 1
+  %90 = load i32, i32 addrspace(1)* %89
+  %91 = zext i32 %90 to i64
+  %92 = trunc i64 %91 to i32
+  %93 = icmp ne i32 %92, 0
+  br i1 %93, label %96, label %94
+
+; <label>:94                                      ; preds = %88
+  %95 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1)
+  store %"System.Byte[]" addrspace(1)* %95, %"System.Byte[]" addrspace(1)** %arg4
+  br label %96
+
+; <label>:96                                      ; preds = %88, %94
+  %97 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  store %"System.Char[]" addrspace(1)* %97, %"System.Char[]" addrspace(1)** %loc4
+  %98 = icmp eq %"System.Char[]" addrspace(1)* %97, null
+  br i1 %98, label %107, label %99
+
+; <label>:99                                      ; preds = %96
+  %100 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc4
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %100, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %101
+
+; <label>:101                                     ; preds = %99
+  %102 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %100, i32 0, i32 1
+  %103 = load i32, i32 addrspace(1)* %102
+  %104 = zext i32 %103 to i64
+  %105 = trunc i64 %104 to i32
+  %106 = icmp ne i32 %105, 0
+  br i1 %106, label %108, label %107
+
+; <label>:107                                     ; preds = %96, %101
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  br label %116
+
+; <label>:108                                     ; preds = %101
+  %109 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc4
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %109, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %110
+
+; <label>:110                                     ; preds = %108
+  %111 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %109, i32 0, i32 1
+  %112 = load i32, i32 addrspace(1)* %111
+  %113 = zext i32 %112 to i64
+  %BoundsCheck = icmp uge i64 0, %113
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %114
+
+; <label>:114                                     ; preds = %110
+  %115 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %109, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %115, i16 addrspace(1)** %loc1
+  br label %116
+
+; <label>:116                                     ; preds = %107, %114
+  %117 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  store %"System.Byte[]" addrspace(1)* %117, %"System.Byte[]" addrspace(1)** %loc5
+  %118 = icmp eq %"System.Byte[]" addrspace(1)* %117, null
+  br i1 %118, label %127, label %119
+
+; <label>:119                                     ; preds = %116
+  %120 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc5
+  %NullCheck13 = icmp eq %"System.Byte[]" addrspace(1)* %120, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %121
+
+; <label>:121                                     ; preds = %119
+  %122 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %120, i32 0, i32 1
+  %123 = load i32, i32 addrspace(1)* %122
+  %124 = zext i32 %123 to i64
+  %125 = trunc i64 %124 to i32
+  %126 = icmp ne i32 %125, 0
+  br i1 %126, label %128, label %127
+
+; <label>:127                                     ; preds = %116, %121
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc2
+  br label %136
+
+; <label>:128                                     ; preds = %121
+  %129 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc5
+  %NullCheck15 = icmp eq %"System.Byte[]" addrspace(1)* %129, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %130
+
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %129, i32 0, i32 1
+  %132 = load i32, i32 addrspace(1)* %131
+  %133 = zext i32 %132 to i64
+  %BoundsCheck17 = icmp uge i64 0, %133
+  br i1 %BoundsCheck17, label %ThrowIndexOutOfRange18, label %134
+
+; <label>:134                                     ; preds = %130
+  %135 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %129, i32 0, i32 3, i32 0
+  store i8 addrspace(1)* %135, i8 addrspace(1)** %loc2
+  br label %136
+
+; <label>:136                                     ; preds = %127, %134
+  %137 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %138 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %139 = ptrtoint i16 addrspace(1)* %138 to i64
+  %140 = load i32, i32* %arg2
+  %141 = sext i32 %140 to i64
+  %142 = mul i64 %141, 2
+  %143 = add i64 %139, %142
+  %144 = load i32, i32* %arg3
+  %145 = load i8 addrspace(1)*, i8 addrspace(1)** %loc2
+  %146 = ptrtoint i8 addrspace(1)* %145 to i64
+  %147 = load i32, i32* %arg5
+  %148 = sext i32 %147 to i64
+  %149 = add i64 %146, %148
+  %150 = load i32, i32* %loc0
+  %151 = load i8, i8* %arg6
+  %152 = zext i8 %151 to i32
+  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i64 addrspace(1)*
+  %NullCheck19 = icmp eq i64 addrspace(1)* %153, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %154
+
+; <label>:154                                     ; preds = %136
+  %155 = load i64, i64 addrspace(1)* %153
+  %156 = add i64 %155, 72
+  %157 = inttoptr i64 %156 to i64*
+  %158 = load i64, i64* %157
+  %159 = add i64 %158, 0
+  %160 = inttoptr i64 %159 to i64*
+  %161 = load i64, i64* %160
+  %162 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to %System.Text.Encoder addrspace(1)*
+  %163 = inttoptr i64 %143 to i16*
+  %164 = inttoptr i64 %149 to i8*
+  %165 = trunc i32 %152 to i8
+  %166 = inttoptr i64 %161 to i32 (%System.Text.Encoder addrspace(1)*, i16*, i32, i8*, i32, i8)*
+  %167 = call i32 %166(%System.Text.Encoder addrspace(1)* %162, i16* %163, i32 %144, i8* %164, i32 %150, i8 %165)
+  store i32 %167, i32* %loc3
+  br label %168
+
+; <label>:168                                     ; preds = %154
+  %169 = load i32, i32* %loc3
+  ret i32 %169
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %110
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %119
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange18:                           ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
 Successfully read EncoderNLS.GetBytes
 
@@ -14919,22 +17196,22 @@ entry:
   %40 = load i8, i8* %arg5
   %41 = zext i8 %40 to i32
   %42 = trunc i32 %41 to i8
-  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %39, null
-  br i1 %NullCheck, label %43, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderNLS addrspace(1)* %39, null
+  br i1 %NullCheck, label %ThrowNullRef, label %43
 
 ; <label>:43                                      ; preds = %38
   %44 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
   store i8 %42, i8 addrspace(1)* %44
   %45 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %45, null
-  br i1 %NullCheck2, label %46, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.EncoderNLS addrspace(1)* %45, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %46
 
 ; <label>:46                                      ; preds = %43
   %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %45, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %47
   %48 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.EncoderNLS addrspace(1)* %48, null
-  br i1 %NullCheck4, label %49, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.EncoderNLS addrspace(1)* %48, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %49
 
 ; <label>:49                                      ; preds = %46
   %50 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %48, i32 0, i32 3
@@ -14945,8 +17222,8 @@ entry:
   %55 = load i32, i32* %arg4
   %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck6, label %58, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
   %59 = load i64, i64 addrspace(1)* %57
@@ -14964,15 +17241,15 @@ ThrowNullRef:                                     ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %43
+ThrowNullRef2:                                    ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %46
+ThrowNullRef4:                                    ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %49
+ThrowNullRef6:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -15000,8 +17277,8 @@ entry:
   %4 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0 to %System.IO.ConsoleStream addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*)(%System.IO.ConsoleStream addrspace(1)* %4, %"System.Byte[]" addrspace(1)* %1, i32 %2, i32 %3)
   %5 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
@@ -15086,8 +17363,8 @@ entry:
 
 ; <label>:22                                      ; preds = %8
   %23 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %23, null
-  br i1 %NullCheck, label %24, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Byte[]" addrspace(1)* %23, null
+  br i1 %NullCheck, label %ThrowNullRef, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
@@ -15109,8 +17386,8 @@ entry:
 
 ; <label>:36                                      ; preds = %24
   %37 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %37, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.ConsoleStream addrspace(1)* %37, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %37, i32 0, i32 4
@@ -15131,13 +17408,138 @@ ThrowNullRef:                                     ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %36
+ThrowNullRef2:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
-Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
+Successfully read WindowsConsoleStream.WriteFileNative
+
+define i32 @WindowsConsoleStream.WriteFileNative(i64 %param0, %"System.Byte[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i64
+  %arg1 = alloca %"System.Byte[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i8 addrspace(1)*
+  %loc2 = alloca %"System.Byte[]" addrspace(1)*
+  %loc3 = alloca i32
+  store i64 %param0, i64* %arg0
+  store %"System.Byte[]" addrspace(1)* %param1, %"System.Byte[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Byte[]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = zext i32 %3 to i64
+  %5 = icmp ne i64 %4, 0
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %1
+  ret i32 0
+
+; <label>:7                                       ; preds = %1
+  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  store %"System.Byte[]" addrspace(1)* %8, %"System.Byte[]" addrspace(1)** %loc2
+  %9 = icmp eq %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %9, label %18, label %10
+
+; <label>:10                                      ; preds = %7
+  %11 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc2
+  %NullCheck1 = icmp eq %"System.Byte[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %11, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp ne i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %7, %12
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc1
+  br label %27
+
+; <label>:19                                      ; preds = %12
+  %20 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc2
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %20, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %BoundsCheck = icmp uge i64 0, %24
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %25
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %20, i32 0, i32 3, i32 0
+  store i8 addrspace(1)* %26, i8 addrspace(1)** %loc1
+  br label %27
+
+; <label>:27                                      ; preds = %18, %25
+  %28 = load i64, i64* %arg0
+  %29 = load i8 addrspace(1)*, i8 addrspace(1)** %loc1
+  %30 = ptrtoint i8 addrspace(1)* %29 to i64
+  %31 = load i32, i32* %arg2
+  %32 = sext i32 %31 to i64
+  %33 = add i64 %30, %32
+  %34 = load i32, i32* %arg3
+  %35 = addrspacecast i32* %loc3 to i32 addrspace(1)*
+  %36 = inttoptr i64 %33 to i8*
+  %37 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i8*, i32, i32 addrspace(1)*, i64)*)(i64 %28, i8* %36, i32 %34, i32 addrspace(1)* %35, i64 0)
+  %38 = icmp ugt i32 %37, 0
+  %39 = sext i1 %38 to i32
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc1
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %42, label %41
+
+; <label>:41                                      ; preds = %27
+  ret i32 0
+
+; <label>:42                                      ; preds = %27
+  %43 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  store i32 %43, i32* %loc0
+  %44 = load i32, i32* %loc0
+  %45 = icmp eq i32 %44, 232
+  br i1 %45, label %49, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = load i32, i32* %loc0
+  %48 = icmp ne i32 %47, 109
+  br i1 %48, label %50, label %49
+
+; <label>:49                                      ; preds = %42, %46
+  ret i32 0
+
+; <label>:50                                      ; preds = %46
+  %51 = load i32, i32* %loc0
+  ret i32 %51
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
 Successfully read WindowsConsoleStream.Flush
 
@@ -15146,8 +17548,8 @@ entry:
   %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
   store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
@@ -15182,8 +17584,8 @@ entry:
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
   %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load i64, i64 addrspace(1)* %1
@@ -15222,15 +17624,15 @@ entry:
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.TextWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
   %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %3, align 8
   %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
   %7 = load i64, i64 addrspace(1)* %5
@@ -15248,7 +17650,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -15277,8 +17679,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %4)
   store i32 0, i32* %loc0
   %5 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Char[]" addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
@@ -15290,15 +17692,15 @@ entry:
 
 ; <label>:11                                      ; preds = %69
   %12 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %12, i32 0, i32 9
   %15 = load i32, i32 addrspace(1)* %14, align 8
   %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.IO.StreamWriter addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %16, i32 0, i32 10
@@ -15313,15 +17715,15 @@ entry:
 
 ; <label>:23                                      ; preds = %17, %21
   %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %24, null
-  br i1 %NullCheck8, label %25, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %24, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 10
   %27 = load i32, i32 addrspace(1)* %26, align 8
   %28 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %28, null
-  br i1 %NullCheck10, label %29, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.StreamWriter addrspace(1)* %28, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %28, i32 0, i32 9
@@ -15343,15 +17745,15 @@ entry:
   %40 = load i32, i32* %loc0
   %41 = mul i32 %40, 2
   %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
-  br i1 %NullCheck12, label %43, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %43
 
 ; <label>:43                                      ; preds = %38
   %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 7
   %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %44, align 8
   %46 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %46, null
-  br i1 %NullCheck14, label %47, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.IO.StreamWriter addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %47
 
 ; <label>:47                                      ; preds = %43
   %48 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %46, i32 0, i32 9
@@ -15363,16 +17765,16 @@ entry:
   %54 = bitcast %"System.Char[]" addrspace(1)* %45 to %System.Array addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %53, i32 %41, %System.Array addrspace(1)* %54, i32 %50, i32 %52)
   %55 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
-  br i1 %NullCheck16, label %56, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %56
 
 ; <label>:56                                      ; preds = %47
   %57 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
   %58 = load i32, i32 addrspace(1)* %57, align 8
   %59 = load i32, i32* %loc2
   %60 = add i32 %58, %59
-  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
-  br i1 %NullCheck18, label %61, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %61
 
 ; <label>:61                                      ; preds = %56
   %62 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
@@ -15394,8 +17796,8 @@ entry:
 
 ; <label>:72                                      ; preds = %69
   %73 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %73, null
-  br i1 %NullCheck2, label %74, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %73, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %74
 
 ; <label>:74                                      ; preds = %72
   %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %73, i32 0, i32 11
@@ -15416,39 +17818,39 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %72
+ThrowNullRef2:                                    ; preds = %72
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %23
+ThrowNullRef8:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef10:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %43
+ThrowNullRef14:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %47
+ThrowNullRef16:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %56
+ThrowNullRef18:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPRoots.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPRoots.error.txt
@@ -25,8 +25,8 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
@@ -40,8 +40,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
   %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
@@ -75,7 +75,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -90,8 +90,8 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %NullCheck = icmp ne i8 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = load i8, i8 addrspace(1)* %0, align 8
@@ -125,8 +125,8 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
@@ -159,8 +159,8 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -184,8 +184,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
   store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
@@ -195,8 +195,8 @@ entry:
 ; <label>:4                                       ; preds = %1
   %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
   %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
@@ -206,8 +206,8 @@ entry:
   %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
@@ -221,14 +221,14 @@ entry:
 
 ; <label>:17                                      ; preds = %14
   %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
   %21 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
@@ -238,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -249,8 +249,8 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
@@ -261,27 +261,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %30
+ThrowNullRef10:                                   ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -301,7 +301,89 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
-Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
+Successfully read AppDomainSetup.GetUnsecureApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.GetUnsecureApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %NullCheck = icmp eq %"System.String[]" addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %BoundsCheck = icmp uge i64 0, %5
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %6
+
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 3, i32 0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
+  ret %System.String addrspace(1)* %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_Value using LLILCJit
+Successfully read AppDomainSetup.get_Value
+
+define %"System.String[]" addrspace(1)* @AppDomainSetup.get_Value(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.String[]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 18)
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.String[]" addrspace(1)* addrspace(1)*, %"System.String[]" addrspace(1)*)*)(%"System.String[]" addrspace(1)* addrspace(1)* %9, %"System.String[]" addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %11, i32 0, i32 1
+  %14 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %13, align 8
+  ret %"System.String[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -319,8 +401,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -368,16 +450,16 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
   %5 = load i32, i32 addrspace(1)* %4
   %6 = sub i32 %5, 1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -389,7 +471,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -421,8 +503,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
@@ -456,8 +538,8 @@ entry:
 ; <label>:27                                      ; preds = %19
   %28 = load i32, i32* %arg1
   %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
-  br i1 %NullCheck2, label %30, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %29, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %30
 
 ; <label>:30                                      ; preds = %27
   %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
@@ -493,8 +575,8 @@ entry:
 ; <label>:49                                      ; preds = %46
   %50 = load i32, i32* %arg2
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck4, label %52, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
@@ -517,11 +599,11 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %27
+ThrowNullRef2:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %49
+ThrowNullRef4:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -544,16 +626,16 @@ entry:
   %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %0)
   store %System.String addrspace(1)* %1, %System.String addrspace(1)** %loc0
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 2
   %5 = bitcast [0 x i16] addrspace(1)* %4 to i16 addrspace(1)*
   store i16 addrspace(1)* %5, i16 addrspace(1)** %loc1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %3
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2
@@ -580,7 +662,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -691,15 +773,15 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %NullCheck132 = icmp ne i8* %21, null
-  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+  %NullCheck131 = icmp eq i8* %21, null
+  br i1 %NullCheck131, label %ThrowNullRef132, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = load i8, i8* %21, align 8
   %24 = zext i8 %23 to i32
   %25 = trunc i32 %24 to i8
-  %NullCheck134 = icmp ne i8* %20, null
-  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+  %NullCheck133 = icmp eq i8* %20, null
+  br i1 %NullCheck133, label %ThrowNullRef134, label %26
 
 ; <label>:26                                      ; preds = %22
   store i8 %25, i8* %20, align 8
@@ -709,16 +791,16 @@ entry:
   %28 = load i8*, i8** %arg0
   %29 = load i8*, i8** %arg1
   %30 = bitcast i8* %29 to i16*
-  %NullCheck128 = icmp ne i16* %30, null
-  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+  %NullCheck127 = icmp eq i16* %30, null
+  br i1 %NullCheck127, label %ThrowNullRef128, label %31
 
 ; <label>:31                                      ; preds = %27
   %32 = load i16, i16* %30, align 8
   %33 = sext i16 %32 to i32
   %34 = bitcast i8* %28 to i16*
   %35 = trunc i32 %33 to i16
-  %NullCheck130 = icmp ne i16* %34, null
-  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+  %NullCheck129 = icmp eq i16* %34, null
+  br i1 %NullCheck129, label %ThrowNullRef130, label %36
 
 ; <label>:36                                      ; preds = %31
   store i16 %35, i16* %34, align 8
@@ -728,16 +810,16 @@ entry:
   %38 = load i8*, i8** %arg0
   %39 = load i8*, i8** %arg1
   %40 = bitcast i8* %39 to i16*
-  %NullCheck120 = icmp ne i16* %40, null
-  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+  %NullCheck119 = icmp eq i16* %40, null
+  br i1 %NullCheck119, label %ThrowNullRef120, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i16, i16* %40, align 8
   %43 = sext i16 %42 to i32
   %44 = bitcast i8* %38 to i16*
   %45 = trunc i32 %43 to i16
-  %NullCheck122 = icmp ne i16* %44, null
-  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+  %NullCheck121 = icmp eq i16* %44, null
+  br i1 %NullCheck121, label %ThrowNullRef122, label %46
 
 ; <label>:46                                      ; preds = %41
   store i16 %45, i16* %44, align 8
@@ -745,15 +827,15 @@ entry:
   %48 = getelementptr inbounds i8, i8* %47, i64 2
   %49 = load i8*, i8** %arg1
   %50 = getelementptr inbounds i8, i8* %49, i64 2
-  %NullCheck124 = icmp ne i8* %50, null
-  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+  %NullCheck123 = icmp eq i8* %50, null
+  br i1 %NullCheck123, label %ThrowNullRef124, label %51
 
 ; <label>:51                                      ; preds = %46
   %52 = load i8, i8* %50, align 8
   %53 = zext i8 %52 to i32
   %54 = trunc i32 %53 to i8
-  %NullCheck126 = icmp ne i8* %48, null
-  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+  %NullCheck125 = icmp eq i8* %48, null
+  br i1 %NullCheck125, label %ThrowNullRef126, label %55
 
 ; <label>:55                                      ; preds = %51
   store i8 %54, i8* %48, align 8
@@ -763,14 +845,14 @@ entry:
   %57 = load i8*, i8** %arg0
   %58 = load i8*, i8** %arg1
   %59 = bitcast i8* %58 to i32*
-  %NullCheck116 = icmp ne i32* %59, null
-  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+  %NullCheck115 = icmp eq i32* %59, null
+  br i1 %NullCheck115, label %ThrowNullRef116, label %60
 
 ; <label>:60                                      ; preds = %56
   %61 = load i32, i32* %59, align 8
   %62 = bitcast i8* %57 to i32*
-  %NullCheck118 = icmp ne i32* %62, null
-  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+  %NullCheck117 = icmp eq i32* %62, null
+  br i1 %NullCheck117, label %ThrowNullRef118, label %63
 
 ; <label>:63                                      ; preds = %60
   store i32 %61, i32* %62, align 8
@@ -780,14 +862,14 @@ entry:
   %65 = load i8*, i8** %arg0
   %66 = load i8*, i8** %arg1
   %67 = bitcast i8* %66 to i32*
-  %NullCheck108 = icmp ne i32* %67, null
-  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+  %NullCheck107 = icmp eq i32* %67, null
+  br i1 %NullCheck107, label %ThrowNullRef108, label %68
 
 ; <label>:68                                      ; preds = %64
   %69 = load i32, i32* %67, align 8
   %70 = bitcast i8* %65 to i32*
-  %NullCheck110 = icmp ne i32* %70, null
-  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+  %NullCheck109 = icmp eq i32* %70, null
+  br i1 %NullCheck109, label %ThrowNullRef110, label %71
 
 ; <label>:71                                      ; preds = %68
   store i32 %69, i32* %70, align 8
@@ -795,15 +877,15 @@ entry:
   %73 = getelementptr inbounds i8, i8* %72, i64 4
   %74 = load i8*, i8** %arg1
   %75 = getelementptr inbounds i8, i8* %74, i64 4
-  %NullCheck112 = icmp ne i8* %75, null
-  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+  %NullCheck111 = icmp eq i8* %75, null
+  br i1 %NullCheck111, label %ThrowNullRef112, label %76
 
 ; <label>:76                                      ; preds = %71
   %77 = load i8, i8* %75, align 8
   %78 = zext i8 %77 to i32
   %79 = trunc i32 %78 to i8
-  %NullCheck114 = icmp ne i8* %73, null
-  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+  %NullCheck113 = icmp eq i8* %73, null
+  br i1 %NullCheck113, label %ThrowNullRef114, label %80
 
 ; <label>:80                                      ; preds = %76
   store i8 %79, i8* %73, align 8
@@ -813,14 +895,14 @@ entry:
   %82 = load i8*, i8** %arg0
   %83 = load i8*, i8** %arg1
   %84 = bitcast i8* %83 to i32*
-  %NullCheck100 = icmp ne i32* %84, null
-  br i1 %NullCheck100, label %85, label %ThrowNullRef99
+  %NullCheck99 = icmp eq i32* %84, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %85
 
 ; <label>:85                                      ; preds = %81
   %86 = load i32, i32* %84, align 8
   %87 = bitcast i8* %82 to i32*
-  %NullCheck102 = icmp ne i32* %87, null
-  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+  %NullCheck101 = icmp eq i32* %87, null
+  br i1 %NullCheck101, label %ThrowNullRef102, label %88
 
 ; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
@@ -829,16 +911,16 @@ entry:
   %91 = load i8*, i8** %arg1
   %92 = getelementptr inbounds i8, i8* %91, i64 4
   %93 = bitcast i8* %92 to i16*
-  %NullCheck104 = icmp ne i16* %93, null
-  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+  %NullCheck103 = icmp eq i16* %93, null
+  br i1 %NullCheck103, label %ThrowNullRef104, label %94
 
 ; <label>:94                                      ; preds = %88
   %95 = load i16, i16* %93, align 8
   %96 = sext i16 %95 to i32
   %97 = bitcast i8* %90 to i16*
   %98 = trunc i32 %96 to i16
-  %NullCheck106 = icmp ne i16* %97, null
-  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+  %NullCheck105 = icmp eq i16* %97, null
+  br i1 %NullCheck105, label %ThrowNullRef106, label %99
 
 ; <label>:99                                      ; preds = %94
   store i16 %98, i16* %97, align 8
@@ -848,14 +930,14 @@ entry:
   %101 = load i8*, i8** %arg0
   %102 = load i8*, i8** %arg1
   %103 = bitcast i8* %102 to i32*
-  %NullCheck88 = icmp ne i32* %103, null
-  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+  %NullCheck87 = icmp eq i32* %103, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %104
 
 ; <label>:104                                     ; preds = %100
   %105 = load i32, i32* %103, align 8
   %106 = bitcast i8* %101 to i32*
-  %NullCheck90 = icmp ne i32* %106, null
-  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+  %NullCheck89 = icmp eq i32* %106, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %107
 
 ; <label>:107                                     ; preds = %104
   store i32 %105, i32* %106, align 8
@@ -864,16 +946,16 @@ entry:
   %110 = load i8*, i8** %arg1
   %111 = getelementptr inbounds i8, i8* %110, i64 4
   %112 = bitcast i8* %111 to i16*
-  %NullCheck92 = icmp ne i16* %112, null
-  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+  %NullCheck91 = icmp eq i16* %112, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %113
 
 ; <label>:113                                     ; preds = %107
   %114 = load i16, i16* %112, align 8
   %115 = sext i16 %114 to i32
   %116 = bitcast i8* %109 to i16*
   %117 = trunc i32 %115 to i16
-  %NullCheck94 = icmp ne i16* %116, null
-  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+  %NullCheck93 = icmp eq i16* %116, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %118
 
 ; <label>:118                                     ; preds = %113
   store i16 %117, i16* %116, align 8
@@ -881,15 +963,15 @@ entry:
   %120 = getelementptr inbounds i8, i8* %119, i64 6
   %121 = load i8*, i8** %arg1
   %122 = getelementptr inbounds i8, i8* %121, i64 6
-  %NullCheck96 = icmp ne i8* %122, null
-  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+  %NullCheck95 = icmp eq i8* %122, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %123
 
 ; <label>:123                                     ; preds = %118
   %124 = load i8, i8* %122, align 8
   %125 = zext i8 %124 to i32
   %126 = trunc i32 %125 to i8
-  %NullCheck98 = icmp ne i8* %120, null
-  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+  %NullCheck97 = icmp eq i8* %120, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %127
 
 ; <label>:127                                     ; preds = %123
   store i8 %126, i8* %120, align 8
@@ -899,14 +981,14 @@ entry:
   %129 = load i8*, i8** %arg0
   %130 = load i8*, i8** %arg1
   %131 = bitcast i8* %130 to i64*
-  %NullCheck84 = icmp ne i64* %131, null
-  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+  %NullCheck83 = icmp eq i64* %131, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %132
 
 ; <label>:132                                     ; preds = %128
   %133 = load i64, i64* %131, align 8
   %134 = bitcast i8* %129 to i64*
-  %NullCheck86 = icmp ne i64* %134, null
-  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+  %NullCheck85 = icmp eq i64* %134, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %135
 
 ; <label>:135                                     ; preds = %132
   store i64 %133, i64* %134, align 8
@@ -916,14 +998,14 @@ entry:
   %137 = load i8*, i8** %arg0
   %138 = load i8*, i8** %arg1
   %139 = bitcast i8* %138 to i64*
-  %NullCheck76 = icmp ne i64* %139, null
-  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+  %NullCheck75 = icmp eq i64* %139, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %140
 
 ; <label>:140                                     ; preds = %136
   %141 = load i64, i64* %139, align 8
   %142 = bitcast i8* %137 to i64*
-  %NullCheck78 = icmp ne i64* %142, null
-  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+  %NullCheck77 = icmp eq i64* %142, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %143
 
 ; <label>:143                                     ; preds = %140
   store i64 %141, i64* %142, align 8
@@ -931,15 +1013,15 @@ entry:
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %NullCheck80 = icmp ne i8* %147, null
-  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+  %NullCheck79 = icmp eq i8* %147, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %148
 
 ; <label>:148                                     ; preds = %143
   %149 = load i8, i8* %147, align 8
   %150 = zext i8 %149 to i32
   %151 = trunc i32 %150 to i8
-  %NullCheck82 = icmp ne i8* %145, null
-  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+  %NullCheck81 = icmp eq i8* %145, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %152
 
 ; <label>:152                                     ; preds = %148
   store i8 %151, i8* %145, align 8
@@ -949,14 +1031,14 @@ entry:
   %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
   %156 = bitcast i8* %155 to i64*
-  %NullCheck68 = icmp ne i64* %156, null
-  br i1 %NullCheck68, label %157, label %ThrowNullRef67
+  %NullCheck67 = icmp eq i64* %156, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %157
 
 ; <label>:157                                     ; preds = %153
   %158 = load i64, i64* %156, align 8
   %159 = bitcast i8* %154 to i64*
-  %NullCheck70 = icmp ne i64* %159, null
-  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+  %NullCheck69 = icmp eq i64* %159, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %160
 
 ; <label>:160                                     ; preds = %157
   store i64 %158, i64* %159, align 8
@@ -965,16 +1047,16 @@ entry:
   %163 = load i8*, i8** %arg1
   %164 = getelementptr inbounds i8, i8* %163, i64 8
   %165 = bitcast i8* %164 to i16*
-  %NullCheck72 = icmp ne i16* %165, null
-  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+  %NullCheck71 = icmp eq i16* %165, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %166
 
 ; <label>:166                                     ; preds = %160
   %167 = load i16, i16* %165, align 8
   %168 = sext i16 %167 to i32
   %169 = bitcast i8* %162 to i16*
   %170 = trunc i32 %168 to i16
-  %NullCheck74 = icmp ne i16* %169, null
-  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+  %NullCheck73 = icmp eq i16* %169, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %171
 
 ; <label>:171                                     ; preds = %166
   store i16 %170, i16* %169, align 8
@@ -984,14 +1066,14 @@ entry:
   %173 = load i8*, i8** %arg0
   %174 = load i8*, i8** %arg1
   %175 = bitcast i8* %174 to i64*
-  %NullCheck56 = icmp ne i64* %175, null
-  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+  %NullCheck55 = icmp eq i64* %175, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %176
 
 ; <label>:176                                     ; preds = %172
   %177 = load i64, i64* %175, align 8
   %178 = bitcast i8* %173 to i64*
-  %NullCheck58 = icmp ne i64* %178, null
-  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+  %NullCheck57 = icmp eq i64* %178, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %179
 
 ; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
@@ -1000,16 +1082,16 @@ entry:
   %182 = load i8*, i8** %arg1
   %183 = getelementptr inbounds i8, i8* %182, i64 8
   %184 = bitcast i8* %183 to i16*
-  %NullCheck60 = icmp ne i16* %184, null
-  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+  %NullCheck59 = icmp eq i16* %184, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %185
 
 ; <label>:185                                     ; preds = %179
   %186 = load i16, i16* %184, align 8
   %187 = sext i16 %186 to i32
   %188 = bitcast i8* %181 to i16*
   %189 = trunc i32 %187 to i16
-  %NullCheck62 = icmp ne i16* %188, null
-  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+  %NullCheck61 = icmp eq i16* %188, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %190
 
 ; <label>:190                                     ; preds = %185
   store i16 %189, i16* %188, align 8
@@ -1017,15 +1099,15 @@ entry:
   %192 = getelementptr inbounds i8, i8* %191, i64 10
   %193 = load i8*, i8** %arg1
   %194 = getelementptr inbounds i8, i8* %193, i64 10
-  %NullCheck64 = icmp ne i8* %194, null
-  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+  %NullCheck63 = icmp eq i8* %194, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %195
 
 ; <label>:195                                     ; preds = %190
   %196 = load i8, i8* %194, align 8
   %197 = zext i8 %196 to i32
   %198 = trunc i32 %197 to i8
-  %NullCheck66 = icmp ne i8* %192, null
-  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+  %NullCheck65 = icmp eq i8* %192, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %199
 
 ; <label>:199                                     ; preds = %195
   store i8 %198, i8* %192, align 8
@@ -1035,14 +1117,14 @@ entry:
   %201 = load i8*, i8** %arg0
   %202 = load i8*, i8** %arg1
   %203 = bitcast i8* %202 to i64*
-  %NullCheck48 = icmp ne i64* %203, null
-  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+  %NullCheck47 = icmp eq i64* %203, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %204
 
 ; <label>:204                                     ; preds = %200
   %205 = load i64, i64* %203, align 8
   %206 = bitcast i8* %201 to i64*
-  %NullCheck50 = icmp ne i64* %206, null
-  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+  %NullCheck49 = icmp eq i64* %206, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %207
 
 ; <label>:207                                     ; preds = %204
   store i64 %205, i64* %206, align 8
@@ -1051,14 +1133,14 @@ entry:
   %210 = load i8*, i8** %arg1
   %211 = getelementptr inbounds i8, i8* %210, i64 8
   %212 = bitcast i8* %211 to i32*
-  %NullCheck52 = icmp ne i32* %212, null
-  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+  %NullCheck51 = icmp eq i32* %212, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %213
 
 ; <label>:213                                     ; preds = %207
   %214 = load i32, i32* %212, align 8
   %215 = bitcast i8* %209 to i32*
-  %NullCheck54 = icmp ne i32* %215, null
-  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+  %NullCheck53 = icmp eq i32* %215, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %216
 
 ; <label>:216                                     ; preds = %213
   store i32 %214, i32* %215, align 8
@@ -1068,14 +1150,14 @@ entry:
   %218 = load i8*, i8** %arg0
   %219 = load i8*, i8** %arg1
   %220 = bitcast i8* %219 to i64*
-  %NullCheck36 = icmp ne i64* %220, null
-  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64* %220, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %221
 
 ; <label>:221                                     ; preds = %217
   %222 = load i64, i64* %220, align 8
   %223 = bitcast i8* %218 to i64*
-  %NullCheck38 = icmp ne i64* %223, null
-  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+  %NullCheck37 = icmp eq i64* %223, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %224
 
 ; <label>:224                                     ; preds = %221
   store i64 %222, i64* %223, align 8
@@ -1084,14 +1166,14 @@ entry:
   %227 = load i8*, i8** %arg1
   %228 = getelementptr inbounds i8, i8* %227, i64 8
   %229 = bitcast i8* %228 to i32*
-  %NullCheck40 = icmp ne i32* %229, null
-  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i32* %229, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %230
 
 ; <label>:230                                     ; preds = %224
   %231 = load i32, i32* %229, align 8
   %232 = bitcast i8* %226 to i32*
-  %NullCheck42 = icmp ne i32* %232, null
-  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+  %NullCheck41 = icmp eq i32* %232, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %233
 
 ; <label>:233                                     ; preds = %230
   store i32 %231, i32* %232, align 8
@@ -1099,15 +1181,15 @@ entry:
   %235 = getelementptr inbounds i8, i8* %234, i64 12
   %236 = load i8*, i8** %arg1
   %237 = getelementptr inbounds i8, i8* %236, i64 12
-  %NullCheck44 = icmp ne i8* %237, null
-  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i8* %237, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %238
 
 ; <label>:238                                     ; preds = %233
   %239 = load i8, i8* %237, align 8
   %240 = zext i8 %239 to i32
   %241 = trunc i32 %240 to i8
-  %NullCheck46 = icmp ne i8* %235, null
-  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+  %NullCheck45 = icmp eq i8* %235, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %242
 
 ; <label>:242                                     ; preds = %238
   store i8 %241, i8* %235, align 8
@@ -1117,14 +1199,14 @@ entry:
   %244 = load i8*, i8** %arg0
   %245 = load i8*, i8** %arg1
   %246 = bitcast i8* %245 to i64*
-  %NullCheck24 = icmp ne i64* %246, null
-  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64* %246, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %247
 
 ; <label>:247                                     ; preds = %243
   %248 = load i64, i64* %246, align 8
   %249 = bitcast i8* %244 to i64*
-  %NullCheck26 = icmp ne i64* %249, null
-  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64* %249, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %250
 
 ; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
@@ -1133,14 +1215,14 @@ entry:
   %253 = load i8*, i8** %arg1
   %254 = getelementptr inbounds i8, i8* %253, i64 8
   %255 = bitcast i8* %254 to i32*
-  %NullCheck28 = icmp ne i32* %255, null
-  br i1 %NullCheck28, label %256, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i32* %255, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %256
 
 ; <label>:256                                     ; preds = %250
   %257 = load i32, i32* %255, align 8
   %258 = bitcast i8* %252 to i32*
-  %NullCheck30 = icmp ne i32* %258, null
-  br i1 %NullCheck30, label %259, label %ThrowNullRef29
+  %NullCheck29 = icmp eq i32* %258, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %259
 
 ; <label>:259                                     ; preds = %256
   store i32 %257, i32* %258, align 8
@@ -1149,16 +1231,16 @@ entry:
   %262 = load i8*, i8** %arg1
   %263 = getelementptr inbounds i8, i8* %262, i64 12
   %264 = bitcast i8* %263 to i16*
-  %NullCheck32 = icmp ne i16* %264, null
-  br i1 %NullCheck32, label %265, label %ThrowNullRef31
+  %NullCheck31 = icmp eq i16* %264, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %265
 
 ; <label>:265                                     ; preds = %259
   %266 = load i16, i16* %264, align 8
   %267 = sext i16 %266 to i32
   %268 = bitcast i8* %261 to i16*
   %269 = trunc i32 %267 to i16
-  %NullCheck34 = icmp ne i16* %268, null
-  br i1 %NullCheck34, label %270, label %ThrowNullRef33
+  %NullCheck33 = icmp eq i16* %268, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %270
 
 ; <label>:270                                     ; preds = %265
   store i16 %269, i16* %268, align 8
@@ -1168,14 +1250,14 @@ entry:
   %272 = load i8*, i8** %arg0
   %273 = load i8*, i8** %arg1
   %274 = bitcast i8* %273 to i64*
-  %NullCheck8 = icmp ne i64* %274, null
-  br i1 %NullCheck8, label %275, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64* %274, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %275
 
 ; <label>:275                                     ; preds = %271
   %276 = load i64, i64* %274, align 8
   %277 = bitcast i8* %272 to i64*
-  %NullCheck10 = icmp ne i64* %277, null
-  br i1 %NullCheck10, label %278, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %277, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %278
 
 ; <label>:278                                     ; preds = %275
   store i64 %276, i64* %277, align 8
@@ -1184,14 +1266,14 @@ entry:
   %281 = load i8*, i8** %arg1
   %282 = getelementptr inbounds i8, i8* %281, i64 8
   %283 = bitcast i8* %282 to i32*
-  %NullCheck12 = icmp ne i32* %283, null
-  br i1 %NullCheck12, label %284, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i32* %283, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %284
 
 ; <label>:284                                     ; preds = %278
   %285 = load i32, i32* %283, align 8
   %286 = bitcast i8* %280 to i32*
-  %NullCheck14 = icmp ne i32* %286, null
-  br i1 %NullCheck14, label %287, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i32* %286, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %287
 
 ; <label>:287                                     ; preds = %284
   store i32 %285, i32* %286, align 8
@@ -1200,16 +1282,16 @@ entry:
   %290 = load i8*, i8** %arg1
   %291 = getelementptr inbounds i8, i8* %290, i64 12
   %292 = bitcast i8* %291 to i16*
-  %NullCheck16 = icmp ne i16* %292, null
-  br i1 %NullCheck16, label %293, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i16* %292, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %293
 
 ; <label>:293                                     ; preds = %287
   %294 = load i16, i16* %292, align 8
   %295 = sext i16 %294 to i32
   %296 = bitcast i8* %289 to i16*
   %297 = trunc i32 %295 to i16
-  %NullCheck18 = icmp ne i16* %296, null
-  br i1 %NullCheck18, label %298, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i16* %296, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %298
 
 ; <label>:298                                     ; preds = %293
   store i16 %297, i16* %296, align 8
@@ -1217,15 +1299,15 @@ entry:
   %300 = getelementptr inbounds i8, i8* %299, i64 14
   %301 = load i8*, i8** %arg1
   %302 = getelementptr inbounds i8, i8* %301, i64 14
-  %NullCheck20 = icmp ne i8* %302, null
-  br i1 %NullCheck20, label %303, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i8* %302, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %303
 
 ; <label>:303                                     ; preds = %298
   %304 = load i8, i8* %302, align 8
   %305 = zext i8 %304 to i32
   %306 = trunc i32 %305 to i8
-  %NullCheck22 = icmp ne i8* %300, null
-  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i8* %300, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %307
 
 ; <label>:307                                     ; preds = %303
   store i8 %306, i8* %300, align 8
@@ -1235,14 +1317,14 @@ entry:
   %309 = load i8*, i8** %arg0
   %310 = load i8*, i8** %arg1
   %311 = bitcast i8* %310 to i64*
-  %NullCheck = icmp ne i64* %311, null
-  br i1 %NullCheck, label %312, label %ThrowNullRef
+  %NullCheck = icmp eq i64* %311, null
+  br i1 %NullCheck, label %ThrowNullRef, label %312
 
 ; <label>:312                                     ; preds = %308
   %313 = load i64, i64* %311, align 8
   %314 = bitcast i8* %309 to i64*
-  %NullCheck2 = icmp ne i64* %314, null
-  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64* %314, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %315
 
 ; <label>:315                                     ; preds = %312
   store i64 %313, i64* %314, align 8
@@ -1251,14 +1333,14 @@ entry:
   %318 = load i8*, i8** %arg1
   %319 = getelementptr inbounds i8, i8* %318, i64 8
   %320 = bitcast i8* %319 to i64*
-  %NullCheck4 = icmp ne i64* %320, null
-  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64* %320, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %321
 
 ; <label>:321                                     ; preds = %315
   %322 = load i64, i64* %320, align 8
   %323 = bitcast i8* %317 to i64*
-  %NullCheck6 = icmp ne i64* %323, null
-  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64* %323, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %324
 
 ; <label>:324                                     ; preds = %321
   store i64 %322, i64* %323, align 8
@@ -1286,15 +1368,15 @@ entry:
 ; <label>:338                                     ; preds = %333
   %339 = load i8*, i8** %arg0
   %340 = load i8*, i8** %arg1
-  %NullCheck136 = icmp ne i8* %340, null
-  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+  %NullCheck135 = icmp eq i8* %340, null
+  br i1 %NullCheck135, label %ThrowNullRef136, label %341
 
 ; <label>:341                                     ; preds = %338
   %342 = load i8, i8* %340, align 8
   %343 = zext i8 %342 to i32
   %344 = trunc i32 %343 to i8
-  %NullCheck138 = icmp ne i8* %339, null
-  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+  %NullCheck137 = icmp eq i8* %339, null
+  br i1 %NullCheck137, label %ThrowNullRef138, label %345
 
 ; <label>:345                                     ; preds = %341
   store i8 %344, i8* %339, align 8
@@ -1317,16 +1399,16 @@ entry:
   %357 = load i8*, i8** %arg0
   %358 = load i8*, i8** %arg1
   %359 = bitcast i8* %358 to i16*
-  %NullCheck140 = icmp ne i16* %359, null
-  br i1 %NullCheck140, label %360, label %ThrowNullRef139
+  %NullCheck139 = icmp eq i16* %359, null
+  br i1 %NullCheck139, label %ThrowNullRef140, label %360
 
 ; <label>:360                                     ; preds = %356
   %361 = load i16, i16* %359, align 8
   %362 = sext i16 %361 to i32
   %363 = bitcast i8* %357 to i16*
   %364 = trunc i32 %362 to i16
-  %NullCheck142 = icmp ne i16* %363, null
-  br i1 %NullCheck142, label %365, label %ThrowNullRef141
+  %NullCheck141 = icmp eq i16* %363, null
+  br i1 %NullCheck141, label %ThrowNullRef142, label %365
 
 ; <label>:365                                     ; preds = %360
   store i16 %364, i16* %363, align 8
@@ -1352,14 +1434,14 @@ entry:
   %378 = load i8*, i8** %arg0
   %379 = load i8*, i8** %arg1
   %380 = bitcast i8* %379 to i32*
-  %NullCheck144 = icmp ne i32* %380, null
-  br i1 %NullCheck144, label %381, label %ThrowNullRef143
+  %NullCheck143 = icmp eq i32* %380, null
+  br i1 %NullCheck143, label %ThrowNullRef144, label %381
 
 ; <label>:381                                     ; preds = %377
   %382 = load i32, i32* %380, align 8
   %383 = bitcast i8* %378 to i32*
-  %NullCheck146 = icmp ne i32* %383, null
-  br i1 %NullCheck146, label %384, label %ThrowNullRef145
+  %NullCheck145 = icmp eq i32* %383, null
+  br i1 %NullCheck145, label %ThrowNullRef146, label %384
 
 ; <label>:384                                     ; preds = %381
   store i32 %382, i32* %383, align 8
@@ -1384,14 +1466,14 @@ entry:
   %395 = load i8*, i8** %arg0
   %396 = load i8*, i8** %arg1
   %397 = bitcast i8* %396 to i64*
-  %NullCheck164 = icmp ne i64* %397, null
-  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+  %NullCheck163 = icmp eq i64* %397, null
+  br i1 %NullCheck163, label %ThrowNullRef164, label %398
 
 ; <label>:398                                     ; preds = %394
   %399 = load i64, i64* %397, align 8
   %400 = bitcast i8* %395 to i64*
-  %NullCheck166 = icmp ne i64* %400, null
-  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+  %NullCheck165 = icmp eq i64* %400, null
+  br i1 %NullCheck165, label %ThrowNullRef166, label %401
 
 ; <label>:401                                     ; preds = %398
   store i64 %399, i64* %400, align 8
@@ -1400,14 +1482,14 @@ entry:
   %404 = load i8*, i8** %arg1
   %405 = getelementptr inbounds i8, i8* %404, i64 8
   %406 = bitcast i8* %405 to i64*
-  %NullCheck168 = icmp ne i64* %406, null
-  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+  %NullCheck167 = icmp eq i64* %406, null
+  br i1 %NullCheck167, label %ThrowNullRef168, label %407
 
 ; <label>:407                                     ; preds = %401
   %408 = load i64, i64* %406, align 8
   %409 = bitcast i8* %403 to i64*
-  %NullCheck170 = icmp ne i64* %409, null
-  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+  %NullCheck169 = icmp eq i64* %409, null
+  br i1 %NullCheck169, label %ThrowNullRef170, label %410
 
 ; <label>:410                                     ; preds = %407
   store i64 %408, i64* %409, align 8
@@ -1437,14 +1519,14 @@ entry:
   %425 = load i8*, i8** %arg0
   %426 = load i8*, i8** %arg1
   %427 = bitcast i8* %426 to i64*
-  %NullCheck148 = icmp ne i64* %427, null
-  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+  %NullCheck147 = icmp eq i64* %427, null
+  br i1 %NullCheck147, label %ThrowNullRef148, label %428
 
 ; <label>:428                                     ; preds = %424
   %429 = load i64, i64* %427, align 8
   %430 = bitcast i8* %425 to i64*
-  %NullCheck150 = icmp ne i64* %430, null
-  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+  %NullCheck149 = icmp eq i64* %430, null
+  br i1 %NullCheck149, label %ThrowNullRef150, label %431
 
 ; <label>:431                                     ; preds = %428
   store i64 %429, i64* %430, align 8
@@ -1466,14 +1548,14 @@ entry:
   %441 = load i8*, i8** %arg0
   %442 = load i8*, i8** %arg1
   %443 = bitcast i8* %442 to i32*
-  %NullCheck152 = icmp ne i32* %443, null
-  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+  %NullCheck151 = icmp eq i32* %443, null
+  br i1 %NullCheck151, label %ThrowNullRef152, label %444
 
 ; <label>:444                                     ; preds = %440
   %445 = load i32, i32* %443, align 8
   %446 = bitcast i8* %441 to i32*
-  %NullCheck154 = icmp ne i32* %446, null
-  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+  %NullCheck153 = icmp eq i32* %446, null
+  br i1 %NullCheck153, label %ThrowNullRef154, label %447
 
 ; <label>:447                                     ; preds = %444
   store i32 %445, i32* %446, align 8
@@ -1495,16 +1577,16 @@ entry:
   %457 = load i8*, i8** %arg0
   %458 = load i8*, i8** %arg1
   %459 = bitcast i8* %458 to i16*
-  %NullCheck156 = icmp ne i16* %459, null
-  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+  %NullCheck155 = icmp eq i16* %459, null
+  br i1 %NullCheck155, label %ThrowNullRef156, label %460
 
 ; <label>:460                                     ; preds = %456
   %461 = load i16, i16* %459, align 8
   %462 = sext i16 %461 to i32
   %463 = bitcast i8* %457 to i16*
   %464 = trunc i32 %462 to i16
-  %NullCheck158 = icmp ne i16* %463, null
-  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+  %NullCheck157 = icmp eq i16* %463, null
+  br i1 %NullCheck157, label %ThrowNullRef158, label %465
 
 ; <label>:465                                     ; preds = %460
   store i16 %464, i16* %463, align 8
@@ -1525,15 +1607,15 @@ entry:
 ; <label>:474                                     ; preds = %470
   %475 = load i8*, i8** %arg0
   %476 = load i8*, i8** %arg1
-  %NullCheck160 = icmp ne i8* %476, null
-  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+  %NullCheck159 = icmp eq i8* %476, null
+  br i1 %NullCheck159, label %ThrowNullRef160, label %477
 
 ; <label>:477                                     ; preds = %474
   %478 = load i8, i8* %476, align 8
   %479 = zext i8 %478 to i32
   %480 = trunc i32 %479 to i8
-  %NullCheck162 = icmp ne i8* %475, null
-  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+  %NullCheck161 = icmp eq i8* %475, null
+  br i1 %NullCheck161, label %ThrowNullRef162, label %481
 
 ; <label>:481                                     ; preds = %477
   store i8 %480, i8* %475, align 8
@@ -1553,343 +1635,343 @@ ThrowNullRef:                                     ; preds = %308
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %312
+ThrowNullRef2:                                    ; preds = %312
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %315
+ThrowNullRef4:                                    ; preds = %315
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %321
+ThrowNullRef6:                                    ; preds = %321
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %271
+ThrowNullRef8:                                    ; preds = %271
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %275
+ThrowNullRef10:                                   ; preds = %275
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %278
+ThrowNullRef12:                                   ; preds = %278
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %284
+ThrowNullRef14:                                   ; preds = %284
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %287
+ThrowNullRef16:                                   ; preds = %287
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %293
+ThrowNullRef18:                                   ; preds = %293
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %298
+ThrowNullRef20:                                   ; preds = %298
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %303
+ThrowNullRef22:                                   ; preds = %303
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %243
+ThrowNullRef24:                                   ; preds = %243
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %247
+ThrowNullRef26:                                   ; preds = %247
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %250
+ThrowNullRef28:                                   ; preds = %250
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %256
+ThrowNullRef30:                                   ; preds = %256
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %259
+ThrowNullRef32:                                   ; preds = %259
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %265
+ThrowNullRef34:                                   ; preds = %265
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %217
+ThrowNullRef36:                                   ; preds = %217
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %221
+ThrowNullRef38:                                   ; preds = %221
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %224
+ThrowNullRef40:                                   ; preds = %224
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %230
+ThrowNullRef42:                                   ; preds = %230
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %233
+ThrowNullRef44:                                   ; preds = %233
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %238
+ThrowNullRef46:                                   ; preds = %238
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %200
+ThrowNullRef48:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %204
+ThrowNullRef50:                                   ; preds = %204
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %207
+ThrowNullRef52:                                   ; preds = %207
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %213
+ThrowNullRef54:                                   ; preds = %213
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %172
+ThrowNullRef56:                                   ; preds = %172
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %176
+ThrowNullRef58:                                   ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %179
+ThrowNullRef60:                                   ; preds = %179
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %185
+ThrowNullRef62:                                   ; preds = %185
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %190
+ThrowNullRef64:                                   ; preds = %190
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %195
+ThrowNullRef66:                                   ; preds = %195
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %153
+ThrowNullRef68:                                   ; preds = %153
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %157
+ThrowNullRef70:                                   ; preds = %157
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %160
+ThrowNullRef72:                                   ; preds = %160
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %166
+ThrowNullRef74:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %136
+ThrowNullRef76:                                   ; preds = %136
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %140
+ThrowNullRef78:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %143
+ThrowNullRef80:                                   ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %148
+ThrowNullRef82:                                   ; preds = %148
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %128
+ThrowNullRef84:                                   ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %132
+ThrowNullRef86:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %100
+ThrowNullRef88:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %104
+ThrowNullRef90:                                   ; preds = %104
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %107
+ThrowNullRef92:                                   ; preds = %107
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %113
+ThrowNullRef94:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %118
+ThrowNullRef96:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %123
+ThrowNullRef98:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %81
+ThrowNullRef100:                                  ; preds = %81
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef101:                                  ; preds = %85
+ThrowNullRef102:                                  ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef103:                                  ; preds = %88
+ThrowNullRef104:                                  ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef105:                                  ; preds = %94
+ThrowNullRef106:                                  ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef107:                                  ; preds = %64
+ThrowNullRef108:                                  ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef109:                                  ; preds = %68
+ThrowNullRef110:                                  ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef111:                                  ; preds = %71
+ThrowNullRef112:                                  ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef113:                                  ; preds = %76
+ThrowNullRef114:                                  ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef115:                                  ; preds = %56
+ThrowNullRef116:                                  ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef117:                                  ; preds = %60
+ThrowNullRef118:                                  ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef119:                                  ; preds = %37
+ThrowNullRef120:                                  ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef121:                                  ; preds = %41
+ThrowNullRef122:                                  ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef123:                                  ; preds = %46
+ThrowNullRef124:                                  ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef125:                                  ; preds = %51
+ThrowNullRef126:                                  ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef127:                                  ; preds = %27
+ThrowNullRef128:                                  ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef129:                                  ; preds = %31
+ThrowNullRef130:                                  ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef131:                                  ; preds = %19
+ThrowNullRef132:                                  ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef133:                                  ; preds = %22
+ThrowNullRef134:                                  ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef135:                                  ; preds = %338
+ThrowNullRef136:                                  ; preds = %338
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef137:                                  ; preds = %341
+ThrowNullRef138:                                  ; preds = %341
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef139:                                  ; preds = %356
+ThrowNullRef140:                                  ; preds = %356
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef141:                                  ; preds = %360
+ThrowNullRef142:                                  ; preds = %360
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef143:                                  ; preds = %377
+ThrowNullRef144:                                  ; preds = %377
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef145:                                  ; preds = %381
+ThrowNullRef146:                                  ; preds = %381
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef147:                                  ; preds = %424
+ThrowNullRef148:                                  ; preds = %424
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef149:                                  ; preds = %428
+ThrowNullRef150:                                  ; preds = %428
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef151:                                  ; preds = %440
+ThrowNullRef152:                                  ; preds = %440
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef153:                                  ; preds = %444
+ThrowNullRef154:                                  ; preds = %444
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef155:                                  ; preds = %456
+ThrowNullRef156:                                  ; preds = %456
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef157:                                  ; preds = %460
+ThrowNullRef158:                                  ; preds = %460
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef159:                                  ; preds = %474
+ThrowNullRef160:                                  ; preds = %474
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef161:                                  ; preds = %477
+ThrowNullRef162:                                  ; preds = %477
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef163:                                  ; preds = %394
+ThrowNullRef164:                                  ; preds = %394
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef165:                                  ; preds = %398
+ThrowNullRef166:                                  ; preds = %398
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef167:                                  ; preds = %401
+ThrowNullRef168:                                  ; preds = %401
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef169:                                  ; preds = %407
+ThrowNullRef170:                                  ; preds = %407
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1939,8 +2021,8 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
-  br i1 %NullCheck, label %22, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %ThrowNullRef, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
@@ -1948,8 +2030,8 @@ entry:
   store i32 %24, i32* %loc0
   %25 = load i32, i32* %loc0
   %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %26, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %27
 
 ; <label>:27                                      ; preds = %22
   %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
@@ -1971,7 +2053,7 @@ ThrowNullRef:                                     ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1989,8 +2071,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -2022,15 +2104,15 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2048,16 +2130,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
   %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
   store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %15
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
@@ -2072,8 +2154,8 @@ entry:
   %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
   %29 = ptrtoint i16 addrspace(1)* %28 to i64
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %19
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
@@ -2089,19 +2171,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2114,8 +2196,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
@@ -2128,7 +2210,7 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[loadElem]
+Failed to read AppDomain.PrepareDataForSetup[storeElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
@@ -2202,8 +2284,8 @@ entry:
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
-  br i1 %NullCheck24, label %27, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = load i64, i64 addrspace(1)* %26
@@ -2218,8 +2300,8 @@ entry:
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
-  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
   %41 = load i64, i64 addrspace(1)* %39
@@ -2236,8 +2318,8 @@ entry:
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
-  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
   %54 = load i64, i64 addrspace(1)* %52
@@ -2252,8 +2334,8 @@ entry:
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
   %67 = load i64, i64 addrspace(1)* %65
@@ -2270,8 +2352,8 @@ entry:
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
-  br i1 %NullCheck16, label %79, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
   %80 = load i64, i64 addrspace(1)* %78
@@ -2286,8 +2368,8 @@ entry:
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
-  br i1 %NullCheck18, label %92, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
   %93 = load i64, i64 addrspace(1)* %91
@@ -2304,8 +2386,8 @@ entry:
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
-  br i1 %NullCheck12, label %105, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = load i64, i64 addrspace(1)* %104
@@ -2320,8 +2402,8 @@ entry:
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
-  br i1 %NullCheck14, label %118, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
   %119 = load i64, i64 addrspace(1)* %117
@@ -2337,8 +2419,8 @@ entry:
 
 ; <label>:128                                     ; preds = %20
   %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
-  br i1 %NullCheck4, label %130, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %129, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %130
 
 ; <label>:130                                     ; preds = %128
   %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
@@ -2346,8 +2428,8 @@ entry:
   %133 = load i16, i16 addrspace(1)* %132, align 8
   %134 = zext i16 %133 to i32
   %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
-  br i1 %NullCheck6, label %136, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %135, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %136
 
 ; <label>:136                                     ; preds = %130
   %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
@@ -2360,8 +2442,8 @@ entry:
 
 ; <label>:143                                     ; preds = %136
   %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
-  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %144, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %145
 
 ; <label>:145                                     ; preds = %143
   %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
@@ -2369,8 +2451,8 @@ entry:
   %148 = load i16, i16 addrspace(1)* %147, align 8
   %149 = zext i16 %148 to i32
   %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %150, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %151
 
 ; <label>:151                                     ; preds = %145
   %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
@@ -2388,8 +2470,8 @@ entry:
 
 ; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
-  br i1 %NullCheck, label %163, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %ThrowNullRef, label %163
 
 ; <label>:163                                     ; preds = %161
   %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
@@ -2399,8 +2481,8 @@ entry:
 
 ; <label>:167                                     ; preds = %163
   %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
-  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %168, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %169
 
 ; <label>:169                                     ; preds = %167
   %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
@@ -2432,55 +2514,55 @@ ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %167
+ThrowNullRef2:                                    ; preds = %167
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %128
+ThrowNullRef4:                                    ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %130
+ThrowNullRef6:                                    ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %143
+ThrowNullRef8:                                    ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %145
+ThrowNullRef10:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %102
+ThrowNullRef12:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %105
+ThrowNullRef14:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %76
+ThrowNullRef16:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %79
+ThrowNullRef18:                                   ; preds = %79
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %50
+ThrowNullRef20:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %53
+ThrowNullRef22:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %24
+ThrowNullRef24:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %27
+ThrowNullRef26:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2503,15 +2585,15 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2519,16 +2601,16 @@ entry:
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
   store i32 %8, i32* %loc0
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
   %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
   store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
@@ -2546,16 +2628,16 @@ entry:
 
 ; <label>:23                                      ; preds = %64
   %24 = load i16*, i16** %loc3
-  %NullCheck12 = icmp ne i16* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i16* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
   store i32 %27, i32* %loc5
   %28 = load i16*, i16** %loc4
-  %NullCheck14 = icmp ne i16* %28, null
-  br i1 %NullCheck14, label %29, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %28, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = load i16, i16* %28, align 8
@@ -2620,15 +2702,15 @@ entry:
 
 ; <label>:67                                      ; preds = %64
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
-  br i1 %NullCheck8, label %69, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %68, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %69
 
 ; <label>:69                                      ; preds = %67
   %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
   %71 = load i32, i32 addrspace(1)* %70
   %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
-  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %73
 
 ; <label>:73                                      ; preds = %69
   %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
@@ -2645,31 +2727,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %67
+ThrowNullRef8:                                    ; preds = %67
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %69
+ThrowNullRef10:                                   ; preds = %69
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2710,14 +2792,14 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
   %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
@@ -2730,14 +2812,14 @@ entry:
 
 ; <label>:11                                      ; preds = %4
   %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
   %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
@@ -2749,14 +2831,14 @@ entry:
 
 ; <label>:22                                      ; preds = %16
   %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
   %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
-  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
-  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
@@ -2804,23 +2886,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2836,7 +2918,280 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[loadElem]
+Successfully read RuntimeType.IsAssignableFrom
+
+define i8 @RuntimeType.IsAssignableFrom(%System.RuntimeType addrspace(1)* %param0, %System.Type addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.RuntimeType addrspace(1)*
+  %arg1 = alloca %System.Type addrspace(1)*
+  %loc0 = alloca %System.RuntimeType addrspace(1)*
+  %loc1 = alloca %"System.Type[]" addrspace(1)*
+  %loc2 = alloca i32
+  store %System.RuntimeType addrspace(1)* %param0, %System.RuntimeType addrspace(1)** %this
+  store %System.Type addrspace(1)* %param1, %System.Type addrspace(1)** %arg1
+  %0 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %1 = icmp ne %System.Type addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i8 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %5 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %6 = bitcast %System.Type addrspace(1)* %4 to %System.Object addrspace(1)*
+  %7 = bitcast %System.RuntimeType addrspace(1)* %5 to %System.Object addrspace(1)*
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %6, %System.Object addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %3
+  ret i8 1
+
+; <label>:12                                      ; preds = %3
+  %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 152
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 32
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
+  %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
+  %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
+  store %System.RuntimeType addrspace(1)* %25, %System.RuntimeType addrspace(1)** %loc0
+  %26 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %27 = icmp eq %System.RuntimeType addrspace(1)* %26, null
+  br i1 %27, label %34, label %28
+
+; <label>:28                                      ; preds = %15
+  %29 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %30 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)*)*)(%System.RuntimeType addrspace(1)* %29, %System.RuntimeType addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+; <label>:34                                      ; preds = %15
+  %35 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %36 = call %System.Reflection.Emit.TypeBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Reflection.Emit.TypeBuilder addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %35)
+  %37 = icmp eq %System.Reflection.Emit.TypeBuilder addrspace(1)* %36, null
+  br i1 %37, label %139, label %38
+
+; <label>:38                                      ; preds = %34
+  %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %42
+
+; <label>:42                                      ; preds = %38
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 152
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 40
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
+  %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
+  %53 = zext i8 %52 to i32
+  %54 = icmp eq i32 %53, 0
+  br i1 %54, label %56, label %55
+
+; <label>:55                                      ; preds = %42
+  ret i8 1
+
+; <label>:56                                      ; preds = %42
+  %57 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %58 = bitcast %System.RuntimeType addrspace(1)* %57 to %System.Type addrspace(1)*
+  %59 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %58)
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %64 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.Type addrspace(1)* %63, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = bitcast %System.RuntimeType addrspace(1)* %64 to %System.Type addrspace(1)*
+  %67 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %63, %System.Type addrspace(1)* %66)
+  %68 = zext i8 %67 to i32
+  %69 = trunc i32 %68 to i8
+  ret i8 %69
+
+; <label>:70                                      ; preds = %56
+  %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
+  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %73
+
+; <label>:73                                      ; preds = %70
+  %74 = load i64, i64 addrspace(1)* %72
+  %75 = add i64 %74, 128
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = add i64 %77, 0
+  %79 = inttoptr i64 %78 to i64*
+  %80 = load i64, i64* %79
+  %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
+  %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
+  %83 = call i8 %82(%System.Type addrspace(1)* %81)
+  %84 = zext i8 %83 to i32
+  %85 = icmp eq i32 %84, 0
+  br i1 %85, label %139, label %86
+
+; <label>:86                                      ; preds = %73
+  %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
+  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %89
+
+; <label>:89                                      ; preds = %86
+  %90 = load i64, i64 addrspace(1)* %88
+  %91 = add i64 %90, 128
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = add i64 %93, 24
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
+  %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
+  %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
+  store %"System.Type[]" addrspace(1)* %99, %"System.Type[]" addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %129
+
+; <label>:100                                     ; preds = %132
+  %101 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %102 = load i32, i32* %loc2
+  %NullCheck11 = icmp eq %"System.Type[]" addrspace(1)* %101, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %103
+
+; <label>:103                                     ; preds = %100
+  %104 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 1
+  %105 = load i32, i32 addrspace(1)* %104
+  %106 = zext i32 %105 to i64
+  %107 = zext i32 %102 to i64
+  %BoundsCheck = icmp uge i64 %107, %106
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %108
+
+; <label>:108                                     ; preds = %103
+  %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
+  %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
+  %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
+  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %113
+
+; <label>:113                                     ; preds = %108
+  %114 = load i64, i64 addrspace(1)* %112
+  %115 = add i64 %114, 152
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = add i64 %117, 56
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
+  %123 = zext i8 %122 to i32
+  %124 = icmp ne i32 %123, 0
+  br i1 %124, label %126, label %125
+
+; <label>:125                                     ; preds = %113
+  ret i8 0
+
+; <label>:126                                     ; preds = %113
+  %127 = load i32, i32* %loc2
+  %128 = add i32 %127, 1
+  store i32 %128, i32* %loc2
+  br label %129
+
+; <label>:129                                     ; preds = %89, %126
+  %130 = load i32, i32* %loc2
+  %131 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %NullCheck9 = icmp eq %"System.Type[]" addrspace(1)* %131, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %132
+
+; <label>:132                                     ; preds = %129
+  %133 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %131, i32 0, i32 1
+  %134 = load i32, i32 addrspace(1)* %133
+  %135 = zext i32 %134 to i64
+  %136 = trunc i64 %135 to i32
+  %137 = icmp slt i32 %130, %136
+  br i1 %137, label %100, label %138
+
+; <label>:138                                     ; preds = %132
+  ret i8 1
+
+; <label>:139                                     ; preds = %34, %73
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %129
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %103
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -2893,7 +3248,7 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElem]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -2904,8 +3259,8 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -2997,8 +3352,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
@@ -3059,8 +3414,8 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -3087,8 +3442,8 @@ entry:
 
 ; <label>:17                                      ; preds = %5, %11
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
@@ -3097,8 +3452,8 @@ entry:
 
 ; <label>:22                                      ; preds = %1, %11
   %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
@@ -3109,11 +3464,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %17
+ThrowNullRef2:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %22
+ThrowNullRef4:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3167,15 +3522,15 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
   %15 = load i32, i32 addrspace(1)* %14
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
@@ -3198,7 +3553,7 @@ ThrowNullRef:                                     ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef2:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3232,8 +3587,8 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
@@ -3312,8 +3667,8 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -3327,8 +3682,8 @@ entry:
 ; <label>:5                                       ; preds = %43
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %7 = load i32, i32* %loc1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck6, label %8, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
@@ -3366,8 +3721,8 @@ entry:
 ; <label>:32                                      ; preds = %21, %25
   %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
   %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
-  br i1 %NullCheck8, label %35, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = trunc i32 %34 to i16
@@ -3380,8 +3735,8 @@ entry:
 ; <label>:40                                      ; preds = %1, %35
   %41 = load i32, i32* %loc1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
-  br i1 %NullCheck2, label %43, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %42, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
@@ -3392,8 +3747,8 @@ entry:
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
   %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
-  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
   %51 = load i64, i64 addrspace(1)* %49
@@ -3412,19 +3767,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %40
+ThrowNullRef2:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %47
+ThrowNullRef4:                                    ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %5
+ThrowNullRef6:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %32
+ThrowNullRef8:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3467,8 +3822,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
@@ -3492,11 +3847,391 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(i16* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store i16* %param0, i16** %arg0
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load i32, i32* %arg3
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %42, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %37, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg2
+  %13 = load i32, i32* %arg3
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %37, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %24 = load i32, i32* %arg2
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load i16*, i16** %arg0
+  %35 = load i32, i32* %arg3
+  %36 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %36, i16* %34, i32 %35)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:37                                      ; preds = %5, %16
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %39)
+  %41 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41, %System.String addrspace(1)* %38, %System.String addrspace(1)* %40)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41) #0
+  unreachable
+
+; <label>:42                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
-Failed to read StringBuilder.ToString[loadElemA]
+Successfully read StringBuilder.ToString
+
+define %System.String addrspace(1)* @StringBuilder.ToString(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i16*
+  %loc3 = alloca %"System.Char[]" addrspace(1)*
+  %loc4 = alloca i32
+  %loc5 = alloca i32
+  %loc6 = alloca i16 addrspace(1)*
+  %loc7 = alloca %System.String addrspace(1)*
+  %loc8 = alloca %"System.Char[]" addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %0)
+  %2 = icmp ne i32 %1, 0
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %4
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %6)
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %7)
+  store %System.String addrspace(1)* %8, %System.String addrspace(1)** %loc0
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.Text.StringBuilder addrspace(1)* %9, %System.Text.StringBuilder addrspace(1)** %loc1
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  store %System.String addrspace(1)* %10, %System.String addrspace(1)** %loc7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc7
+  %12 = ptrtoint %System.String addrspace(1)* %11 to i64
+  %13 = icmp eq i64 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %5
+  %15 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %16 = sext i32 %15 to i64
+  %17 = add i64 %12, %16
+  br label %18
+
+; <label>:18                                      ; preds = %5, %14
+  %19 = phi i64 [ %12, %5 ], [ %17, %14 ]
+  %20 = inttoptr i64 %19 to i16*
+  store i16* %20, i16** %loc2
+  br label %21
+
+; <label>:21                                      ; preds = %98, %18
+  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %22, null
+  br i1 %NullCheck, label %ThrowNullRef, label %23
+
+; <label>:23                                      ; preds = %21
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 3
+  %25 = load i32, i32 addrspace(1)* %24, align 8
+  %26 = icmp sle i32 %25, 0
+  br i1 %26, label %96, label %27
+
+; <label>:27                                      ; preds = %23
+  %28 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %28, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %29
+
+; <label>:29                                      ; preds = %27
+  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %28, i32 0, i32 1
+  %31 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %30, align 8
+  store %"System.Char[]" addrspace(1)* %31, %"System.Char[]" addrspace(1)** %loc3
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %33
+
+; <label>:33                                      ; preds = %29
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  store i32 %35, i32* %loc4
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  %39 = load i32, i32 addrspace(1)* %38, align 8
+  store i32 %39, i32* %loc5
+  %40 = load i32, i32* %loc5
+  %41 = load i32, i32* %loc4
+  %42 = add i32 %40, %41
+  %43 = zext i32 %42 to i64
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %45
+
+; <label>:45                                      ; preds = %37
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = sext i32 %47 to i64
+  %49 = icmp sgt i64 %43, %48
+  br i1 %49, label %91, label %50
+
+; <label>:50                                      ; preds = %45
+  %51 = load i32, i32* %loc5
+  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %52, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %53
+
+; <label>:53                                      ; preds = %50
+  %54 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %52, i32 0, i32 1
+  %55 = load i32, i32 addrspace(1)* %54
+  %56 = zext i32 %55 to i64
+  %57 = trunc i64 %56 to i32
+  %58 = icmp ugt i32 %51, %57
+  br i1 %58, label %91, label %59
+
+; <label>:59                                      ; preds = %53
+  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  store %"System.Char[]" addrspace(1)* %60, %"System.Char[]" addrspace(1)** %loc8
+  %61 = icmp eq %"System.Char[]" addrspace(1)* %60, null
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %63, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %64
+
+; <label>:64                                      ; preds = %62
+  %65 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %63, i32 0, i32 1
+  %66 = load i32, i32 addrspace(1)* %65
+  %67 = zext i32 %66 to i64
+  %68 = trunc i64 %67 to i32
+  %69 = icmp ne i32 %68, 0
+  br i1 %69, label %71, label %70
+
+; <label>:70                                      ; preds = %59, %64
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:71                                      ; preds = %64
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %73
+
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %BoundsCheck = icmp uge i64 0, %76
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %77
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %78, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:79                                      ; preds = %70, %77
+  %80 = load i16*, i16** %loc2
+  %81 = load i32, i32* %loc4
+  %82 = sext i32 %81 to i64
+  %83 = mul i64 %82, 2
+  %84 = bitcast i16* %80 to i8*
+  %85 = getelementptr inbounds i8, i8* %84, i64 %83
+  %86 = load i16 addrspace(1)*, i16 addrspace(1)** %loc6
+  %87 = ptrtoint i16 addrspace(1)* %86 to i64
+  %88 = load i32, i32* %loc5
+  %89 = bitcast i8* %85 to i16*
+  %90 = inttoptr i64 %87 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %89, i16* %90, i32 %88)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %96
+
+; <label>:91                                      ; preds = %45, %53
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %94 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %93)
+  %95 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95, %System.String addrspace(1)* %92, %System.String addrspace(1)* %94)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95) #0
+  unreachable
+
+; <label>:96                                      ; preds = %23, %79
+  %97 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %97, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %98
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %97, i32 0, i32 2
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  store %System.Text.StringBuilder addrspace(1)* %100, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %102 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %102, label %21, label %103
+
+; <label>:103                                     ; preds = %98
+  store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc7
+  %104 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  ret %System.String addrspace(1)* %104
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method StringBuilder::get_Length using LLILCJit
+Successfully read StringBuilder.get_Length
+
+define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
+Successfully read RuntimeHelpers.get_OffsetToStringData
+
+define i32 @RuntimeHelpers.get_OffsetToStringData() {
+entry:
+  ret i32 12
+}
+
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
 Successfully read CultureData.CreateCultureData
 
@@ -3514,23 +4249,23 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
   store i8 %4, i8 addrspace(1)* %6
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
@@ -3549,11 +4284,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3566,50 +4301,50 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
   store i32 -1, i32 addrspace(1)* %2
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
   store i32 -1, i32 addrspace(1)* %8
   %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
   store i32 -1, i32 addrspace(1)* %14
   %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
   store i32 -1, i32 addrspace(1)* %17
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
@@ -3623,27 +4358,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3675,7 +4410,136 @@ Failed to read Dictionary`2.Insert[non-const derefAddress]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
 Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
-Failed to read HashHelpers.GetPrime[loadElem]
+Successfully read HashHelpers.GetPrime
+
+define i32 @HashHelpers.GetPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %6, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5, %System.String addrspace(1)* %4)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5) #0
+  unreachable
+
+; <label>:6                                       ; preds = %entry
+  store i32 0, i32* %loc0
+  br label %29
+
+; <label>:7                                       ; preds = %35
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 1296
+  %10 = addrspacecast i8 addrspace(1)* %9 to %"System.Int32[]" addrspace(1)**
+  %11 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %10
+  %12 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Int32[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = zext i32 %15 to i64
+  %17 = zext i32 %12 to i64
+  %BoundsCheck = icmp uge i64 %17, %16
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 3, i32 %12
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  store i32 %20, i32* %loc1
+  %21 = load i32, i32* %loc1
+  %22 = load i32, i32* %arg0
+  %23 = icmp slt i32 %21, %22
+  br i1 %23, label %26, label %24
+
+; <label>:24                                      ; preds = %18
+  %25 = load i32, i32* %loc1
+  ret i32 %25
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %loc0
+  %28 = add i32 %27, 1
+  store i32 %28, i32* %loc0
+  br label %29
+
+; <label>:29                                      ; preds = %6, %26
+  %30 = load i32, i32* %loc0
+  %31 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %32 = getelementptr inbounds i8, i8 addrspace(1)* %31, i64 1296
+  %33 = addrspacecast i8 addrspace(1)* %32 to %"System.Int32[]" addrspace(1)**
+  %34 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %33
+  %NullCheck = icmp eq %"System.Int32[]" addrspace(1)* %34, null
+  br i1 %NullCheck, label %ThrowNullRef, label %35
+
+; <label>:35                                      ; preds = %29
+  %36 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %34, i32 0, i32 1
+  %37 = load i32, i32 addrspace(1)* %36
+  %38 = zext i32 %37 to i64
+  %39 = trunc i64 %38 to i32
+  %40 = icmp slt i32 %30, %39
+  br i1 %40, label %7, label %41
+
+; <label>:41                                      ; preds = %35
+  %42 = load i32, i32* %arg0
+  %43 = or i32 %42, 1
+  store i32 %43, i32* %loc2
+  br label %59
+
+; <label>:44                                      ; preds = %59
+  %45 = load i32, i32* %loc2
+  %46 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %45)
+  %47 = zext i8 %46 to i32
+  %48 = icmp eq i32 %47, 0
+  br i1 %48, label %56, label %49
+
+; <label>:49                                      ; preds = %44
+  %50 = load i32, i32* %loc2
+  %51 = sub i32 %50, 1
+  %52 = srem i32 %51, 101
+  %53 = icmp eq i32 %52, 0
+  br i1 %53, label %56, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = load i32, i32* %loc2
+  ret i32 %55
+
+; <label>:56                                      ; preds = %44, %49
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %57, 2
+  store i32 %58, i32* %loc2
+  br label %59
+
+; <label>:59                                      ; preds = %41, %56
+  %60 = load i32, i32* %loc2
+  %61 = icmp slt i32 %60, 2147483647
+  br i1 %61, label %44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load i32, i32* %arg0
+  ret i32 %63
+
+ThrowNullRef:                                     ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
 Successfully read GenericEqualityComparer`1.GetHashCode
 
@@ -3694,14 +4558,14 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
   %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load i64, i64 addrspace(1)* %7
@@ -3720,7 +4584,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3750,8 +4614,8 @@ entry:
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
@@ -3796,8 +4660,8 @@ entry:
   %35 = bitcast i16* %34 to i8*
   %36 = getelementptr inbounds i8, i8* %35, i64 2
   %37 = bitcast i8* %36 to i16*
-  %NullCheck4 = icmp ne i16* %37, null
-  br i1 %NullCheck4, label %38, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %37, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %38
 
 ; <label>:38                                      ; preds = %27
   %39 = load i16, i16* %37, align 8
@@ -3824,8 +4688,8 @@ entry:
 
 ; <label>:54                                      ; preds = %22, %43
   %55 = load i16*, i16** %loc4
-  %NullCheck2 = icmp ne i16* %55, null
-  br i1 %NullCheck2, label %56, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i16* %55, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %56
 
 ; <label>:56                                      ; preds = %54
   %57 = load i16, i16* %55, align 8
@@ -3850,11 +4714,11 @@ ThrowNullRef:                                     ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %54
+ThrowNullRef2:                                    ; preds = %54
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %27
+ThrowNullRef4:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3871,8 +4735,8 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -3907,8 +4771,8 @@ entry:
 
 ; <label>:26                                      ; preds = %19
   %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
-  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %28
 
 ; <label>:28                                      ; preds = %26
   %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
@@ -3920,7 +4784,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3972,8 +4836,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
@@ -3984,26 +4848,26 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
-  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
@@ -4014,8 +4878,8 @@ entry:
 ; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
@@ -4024,8 +4888,8 @@ entry:
 
 ; <label>:25                                      ; preds = %1, %16, %23
   %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
-  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
@@ -4036,27 +4900,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %20
+ThrowNullRef10:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4069,8 +4933,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -4081,8 +4945,8 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
@@ -4091,8 +4955,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1, %8
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
@@ -4103,11 +4967,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4128,24 +4992,24 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   store i32 %3, i32* %loc0
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
   %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
   store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck4, label %9, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
@@ -4164,15 +5028,15 @@ entry:
 ; <label>:18                                      ; preds = %70
   %19 = load i16*, i16** %loc3
   %20 = bitcast i16* %19 to i64*
-  %NullCheck10 = icmp ne i64* %20, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %20, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = load i64, i64* %20, align 8
   %23 = load i16*, i16** %loc4
   %24 = bitcast i16* %23 to i64*
-  %NullCheck12 = icmp ne i64* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = load i64, i64* %24, align 8
@@ -4188,8 +5052,8 @@ entry:
   %31 = bitcast i16* %30 to i8*
   %32 = getelementptr inbounds i8, i8* %31, i64 8
   %33 = bitcast i8* %32 to i64*
-  %NullCheck14 = icmp ne i64* %33, null
-  br i1 %NullCheck14, label %34, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = load i64, i64* %33, align 8
@@ -4197,8 +5061,8 @@ entry:
   %37 = bitcast i16* %36 to i8*
   %38 = getelementptr inbounds i8, i8* %37, i64 8
   %39 = bitcast i8* %38 to i64*
-  %NullCheck16 = icmp ne i64* %39, null
-  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %40
 
 ; <label>:40                                      ; preds = %34
   %41 = load i64, i64* %39, align 8
@@ -4214,8 +5078,8 @@ entry:
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %NullCheck18 = icmp ne i64* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = load i64, i64* %48, align 8
@@ -4223,8 +5087,8 @@ entry:
   %52 = bitcast i16* %51 to i8*
   %53 = getelementptr inbounds i8, i8* %52, i64 16
   %54 = bitcast i8* %53 to i64*
-  %NullCheck20 = icmp ne i64* %54, null
-  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64* %54, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %55
 
 ; <label>:55                                      ; preds = %49
   %56 = load i64, i64* %54, align 8
@@ -4262,15 +5126,15 @@ entry:
 ; <label>:74                                      ; preds = %95
   %75 = load i16*, i16** %loc3
   %76 = bitcast i16* %75 to i32*
-  %NullCheck6 = icmp ne i32* %76, null
-  br i1 %NullCheck6, label %77, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32* %76, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %77
 
 ; <label>:77                                      ; preds = %74
   %78 = load i32, i32* %76, align 8
   %79 = load i16*, i16** %loc4
   %80 = bitcast i16* %79 to i32*
-  %NullCheck8 = icmp ne i32* %80, null
-  br i1 %NullCheck8, label %81, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i32* %80, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %81
 
 ; <label>:81                                      ; preds = %77
   %82 = load i32, i32* %80, align 8
@@ -4318,43 +5182,43 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %74
+ThrowNullRef6:                                    ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %77
+ThrowNullRef8:                                    ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %29
+ThrowNullRef14:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %34
+ThrowNullRef16:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4376,8 +5240,8 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load i64, i64 addrspace(1)* %4
@@ -4389,8 +5253,8 @@ entry:
   %12 = load i64, i64* %11
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %5
   %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
@@ -4399,8 +5263,8 @@ entry:
   %18 = load i8, i8* %arg2
   %19 = zext i8 %18 to i32
   %20 = trunc i32 %19 to i8
-  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %15
   %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
@@ -4411,11 +5275,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4442,8 +5306,8 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
@@ -4466,16 +5330,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
   %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = load i64, i64 addrspace(1)* %19
@@ -4500,8 +5364,8 @@ entry:
 ; <label>:35                                      ; preds = %30
   %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
@@ -4514,8 +5378,8 @@ entry:
 
 ; <label>:42                                      ; preds = %1, %38
   %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
-  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
@@ -4526,19 +5390,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %35
+ThrowNullRef2:                                    ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %42
+ThrowNullRef8:                                    ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4551,14 +5415,14 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
@@ -4570,7 +5434,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4583,8 +5447,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
@@ -4613,51 +5477,51 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
   %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
   %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
   %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
   %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
-  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
   store i64 %21, i64 addrspace(1)* %23
   %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %25 = load i64, i64* %loc0
-  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
@@ -4668,27 +5532,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %22
+ThrowNullRef12:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4701,8 +5565,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
@@ -4713,19 +5577,19 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
@@ -4734,8 +5598,8 @@ entry:
 
 ; <label>:15                                      ; preds = %1, %13
   %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
@@ -4746,19 +5610,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %15
+ThrowNullRef8:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4771,8 +5635,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -4831,8 +5695,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
@@ -4882,8 +5746,8 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
-  br i1 %NullCheck, label %17, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %ThrowNullRef, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
@@ -4894,15 +5758,15 @@ entry:
 
 ; <label>:22                                      ; preds = %17
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
-  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
   %26 = load i32, i32 addrspace(1)* %25
   %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
-  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %27, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
@@ -4925,8 +5789,8 @@ entry:
 ; <label>:40                                      ; preds = %17
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
-  br i1 %NullCheck6, label %43, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %41, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
@@ -4938,34 +5802,17 @@ ThrowNullRef:                                     ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %24
+ThrowNullRef4:                                    ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %40
+ThrowNullRef6:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
-}
-
-INFO:  jitting method Object::ReferenceEquals using LLILCJit
-Successfully read Object.ReferenceEquals
-
-define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
-entry:
-  %arg0 = alloca %System.Object addrspace(1)*
-  %arg1 = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
-  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
-  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = icmp eq %System.Object addrspace(1)* %0, %1
-  %3 = sext i1 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
 }
 
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
@@ -4978,21 +5825,21 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
   %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
-  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
@@ -5007,28 +5854,28 @@ entry:
 ; <label>:13                                      ; preds = %8, %12
   %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
   %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
   %21 = load i32, i32 addrspace(1)* %20, align 8
   %22 = add i32 %21, 1
-  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
   store i32 %22, i32 addrspace(1)* %24
   %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
@@ -5039,27 +5886,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5077,7 +5924,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::Setup using LLILCJit
-Failed to read AppDomain.Setup[loadElem]
+Failed to read AppDomain.Setup[unbox]
 INFO:  jitting method Thread::GetDomain using LLILCJit
 Successfully read Thread.GetDomain
 
@@ -5108,8 +5955,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
@@ -5122,14 +5969,14 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
   %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
@@ -5141,11 +5988,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5173,8 +6020,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -5189,7 +6036,328 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
 Failed to read KeyCollection.System.Collections.Generic.IEnumerable<TKey>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Successfully read Enumerator.MoveNext
+
+define i8 @Enumerator.MoveNext(%"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.RuntimeTypeHandle* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*
+  %"$TypeArg" = alloca %System.RuntimeTypeHandle*
+  store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
+  %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 8
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %76, label %12
+
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
+  br label %76
+
+; <label>:13                                      ; preds = %85
+  %14 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck19 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %15
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, i32 0, i32 0
+  %17 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %16, align 8
+  %NullCheck21 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, i32 0, i32 2
+  %20 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %19, align 8
+  %21 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck23 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %22
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, i32 0, i32 2
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %NullCheck25 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 3, i32 %24
+  %NullCheck27 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %32
+
+; <label>:32                                      ; preds = %30
+  %33 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, i32 0, i32 2
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = icmp slt i32 %34, 0
+  br i1 %35, label %68, label %36
+
+; <label>:36                                      ; preds = %32
+  %37 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %38 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck29 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %39
+
+; <label>:39                                      ; preds = %36
+  %40 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, i32 0, i32 0
+  %41 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %40, align 8
+  %NullCheck31 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, i32 0, i32 2
+  %44 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %43, align 8
+  %45 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck33 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, i32 0, i32 2
+  %48 = load i32, i32 addrspace(1)* %47, align 8
+  %NullCheck35 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %49
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = zext i32 %51 to i64
+  %53 = zext i32 %48 to i64
+  %BoundsCheck37 = icmp uge i64 %53, %52
+  br i1 %BoundsCheck37, label %ThrowIndexOutOfRange38, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 3, i32 %48
+  %NullCheck39 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %56
+
+; <label>:56                                      ; preds = %54
+  %57 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, i32 0, i32 0
+  %58 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck41 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %59
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %60, %System.__Canon addrspace(1)* %58)
+  %61 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck43 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  %64 = load i32, i32 addrspace(1)* %63, align 8
+  %65 = add i32 %64, 1
+  %NullCheck45 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  store i32 %65, i32 addrspace(1)* %67
+  ret i8 1
+
+; <label>:68                                      ; preds = %32
+  %69 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck47 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %73 = add i32 %72, 1
+  %NullCheck49 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %74
+
+; <label>:74                                      ; preds = %70
+  %75 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  store i32 %73, i32 addrspace(1)* %75
+  br label %76
+
+; <label>:76                                      ; preds = %8, %12, %74
+  %77 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %78
+
+; <label>:78                                      ; preds = %76
+  %79 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, i32 0, i32 2
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck7 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %82
+
+; <label>:82                                      ; preds = %78
+  %83 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, i32 0, i32 0
+  %84 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %83, align 8
+  %NullCheck9 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %85
+
+; <label>:85                                      ; preds = %82
+  %86 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, i32 0, i32 7
+  %87 = load i32, i32 addrspace(1)* %86, align 8
+  %88 = icmp ult i32 %80, %87
+  br i1 %88, label %13, label %89
+
+; <label>:89                                      ; preds = %85
+  %90 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %91 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck11 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %92
+
+; <label>:92                                      ; preds = %89
+  %93 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, i32 0, i32 0
+  %94 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck13 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %95
+
+; <label>:95                                      ; preds = %92
+  %96 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, i32 0, i32 7
+  %97 = load i32, i32 addrspace(1)* %96, align 8
+  %98 = add i32 %97, 1
+  %NullCheck15 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %99
+
+; <label>:99                                      ; preds = %95
+  %100 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, i32 0, i32 2
+  store i32 %98, i32 addrspace(1)* %100
+  %101 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck17 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %102
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %103, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %92
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef22:                                   ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef24:                                   ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef26:                                   ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef28:                                   ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef30:                                   ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef32:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef34:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef36:                                   ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange38:                           ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef40:                                   ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef42:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef44:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef46:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef48:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef50:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -5200,8 +6368,8 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -5232,9 +6400,9 @@ Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
 Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
-Failed to read String.MakeSeparatorList[loadElemA]
+Failed to read String.MakeSeparatorList[storeElem]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
-Failed to read String.InternalSplitKeepEmptyEntries[loadElem]
+Failed to read String.InternalSplitKeepEmptyEntries[storeElem]
 INFO:  jitting method Path::IsRelative using LLILCJit
 Successfully read Path.IsRelative
 
@@ -5243,8 +6411,8 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -5254,8 +6422,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
@@ -5271,8 +6439,8 @@ entry:
 
 ; <label>:17                                      ; preds = %7
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
@@ -5288,8 +6456,8 @@ entry:
 
 ; <label>:29                                      ; preds = %19
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %31
 
 ; <label>:31                                      ; preds = %29
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
@@ -5300,8 +6468,8 @@ entry:
 
 ; <label>:36                                      ; preds = %31
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
-  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %37, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
@@ -5312,8 +6480,8 @@ entry:
 
 ; <label>:43                                      ; preds = %31, %38
   %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
-  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %45
 
 ; <label>:45                                      ; preds = %43
   %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
@@ -5324,8 +6492,8 @@ entry:
 
 ; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %50
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
@@ -5336,8 +6504,8 @@ entry:
 
 ; <label>:57                                      ; preds = %1, %7, %19, %45, %52
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
-  br i1 %NullCheck14, label %59, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %59
 
 ; <label>:59                                      ; preds = %57
   %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
@@ -5347,8 +6515,8 @@ entry:
 
 ; <label>:63                                      ; preds = %59
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
@@ -5359,8 +6527,8 @@ entry:
 
 ; <label>:70                                      ; preds = %65
   %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
-  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.String addrspace(1)* %71, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %72
 
 ; <label>:72                                      ; preds = %70
   %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
@@ -5379,39 +6547,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %17
+ThrowNullRef4:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %29
+ThrowNullRef6:                                    ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %36
+ThrowNullRef8:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %43
+ThrowNullRef10:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %50
+ThrowNullRef12:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %57
+ThrowNullRef14:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %63
+ThrowNullRef16:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %70
+ThrowNullRef18:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5419,7 +6587,293 @@ ThrowNullRef17:                                   ; preds = %70
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
-Failed to read String.TrimHelper[loadElem]
+Successfully read String.TrimHelper
+
+define %System.String addrspace(1)* @String.TrimHelper(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i16
+  %loc4 = alloca i32
+  %loc5 = alloca i16
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = sub i32 %3, 1
+  store i32 %4, i32* %loc0
+  store i32 0, i32* %loc1
+  %5 = load i32, i32* %arg2
+  %6 = icmp eq i32 %5, 1
+  br i1 %6, label %62, label %7
+
+; <label>:7                                       ; preds = %1
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:8                                       ; preds = %58
+  store i32 0, i32* %loc2
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load i32, i32* %loc1
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2, i32 %10
+  %13 = load i16, i16 addrspace(1)* %12
+  %14 = zext i16 %13 to i32
+  %15 = trunc i32 %14 to i16
+  store i16 %15, i16* %loc3
+  store i32 0, i32* %loc2
+  br label %34
+
+; <label>:16                                      ; preds = %37
+  %17 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %18 = load i32, i32* %loc2
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %17, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %19
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = zext i32 %18 to i64
+  %BoundsCheck = icmp uge i64 %23, %22
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %24
+
+; <label>:24                                      ; preds = %19
+  %25 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 3, i32 %18
+  %26 = load i16, i16 addrspace(1)* %25, align 8
+  %27 = zext i16 %26 to i32
+  %28 = load i16, i16* %loc3
+  %29 = zext i16 %28 to i32
+  %30 = icmp eq i32 %27, %29
+  br i1 %30, label %43, label %31
+
+; <label>:31                                      ; preds = %24
+  %32 = load i32, i32* %loc2
+  %33 = add i32 %32, 1
+  store i32 %33, i32* %loc2
+  br label %34
+
+; <label>:34                                      ; preds = %11, %31
+  %35 = load i32, i32* %loc2
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = icmp slt i32 %35, %41
+  br i1 %42, label %16, label %43
+
+; <label>:43                                      ; preds = %24, %37
+  %44 = load i32, i32* %loc2
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %45, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp eq i32 %44, %50
+  br i1 %51, label %62, label %52
+
+; <label>:52                                      ; preds = %46
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %7, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %57, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %58
+
+; <label>:58                                      ; preds = %55
+  %59 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %60 = load i32, i32 addrspace(1)* %59
+  %61 = icmp slt i32 %56, %60
+  br i1 %61, label %8, label %62
+
+; <label>:62                                      ; preds = %1, %46, %58
+  %63 = load i32, i32* %arg2
+  %64 = icmp eq i32 %63, 0
+  br i1 %64, label %122, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %66, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %67
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %66, i32 0, i32 1
+  %69 = load i32, i32 addrspace(1)* %68
+  %70 = sub i32 %69, 1
+  store i32 %70, i32* %loc0
+  br label %118
+
+; <label>:71                                      ; preds = %118
+  store i32 0, i32* %loc4
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %73 = load i32, i32* %loc0
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %74
+
+; <label>:74                                      ; preds = %71
+  %75 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 2, i32 %73
+  %76 = load i16, i16 addrspace(1)* %75
+  %77 = zext i16 %76 to i32
+  %78 = trunc i32 %77 to i16
+  store i16 %78, i16* %loc5
+  store i32 0, i32* %loc4
+  br label %97
+
+; <label>:79                                      ; preds = %100
+  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %81 = load i32, i32* %loc4
+  %NullCheck19 = icmp eq %"System.Char[]" addrspace(1)* %80, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
+
+; <label>:82                                      ; preds = %79
+  %83 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 1
+  %84 = load i32, i32 addrspace(1)* %83
+  %85 = zext i32 %84 to i64
+  %86 = zext i32 %81 to i64
+  %BoundsCheck21 = icmp uge i64 %86, %85
+  br i1 %BoundsCheck21, label %ThrowIndexOutOfRange22, label %87
+
+; <label>:87                                      ; preds = %82
+  %88 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 3, i32 %81
+  %89 = load i16, i16 addrspace(1)* %88, align 8
+  %90 = zext i16 %89 to i32
+  %91 = load i16, i16* %loc5
+  %92 = zext i16 %91 to i32
+  %93 = icmp eq i32 %90, %92
+  br i1 %93, label %106, label %94
+
+; <label>:94                                      ; preds = %87
+  %95 = load i32, i32* %loc4
+  %96 = add i32 %95, 1
+  store i32 %96, i32* %loc4
+  br label %97
+
+; <label>:97                                      ; preds = %74, %94
+  %98 = load i32, i32* %loc4
+  %99 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck15 = icmp eq %"System.Char[]" addrspace(1)* %99, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %100
+
+; <label>:100                                     ; preds = %97
+  %101 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %99, i32 0, i32 1
+  %102 = load i32, i32 addrspace(1)* %101
+  %103 = zext i32 %102 to i64
+  %104 = trunc i64 %103 to i32
+  %105 = icmp slt i32 %98, %104
+  br i1 %105, label %79, label %106
+
+; <label>:106                                     ; preds = %87, %100
+  %107 = load i32, i32* %loc4
+  %108 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck17 = icmp eq %"System.Char[]" addrspace(1)* %108, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %109
+
+; <label>:109                                     ; preds = %106
+  %110 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %108, i32 0, i32 1
+  %111 = load i32, i32 addrspace(1)* %110
+  %112 = zext i32 %111 to i64
+  %113 = trunc i64 %112 to i32
+  %114 = icmp eq i32 %107, %113
+  br i1 %114, label %122, label %115
+
+; <label>:115                                     ; preds = %109
+  %116 = load i32, i32* %loc0
+  %117 = sub i32 %116, 1
+  store i32 %117, i32* %loc0
+  br label %118
+
+; <label>:118                                     ; preds = %67, %115
+  %119 = load i32, i32* %loc0
+  %120 = load i32, i32* %loc1
+  %121 = icmp sge i32 %119, %120
+  br i1 %121, label %71, label %122
+
+; <label>:122                                     ; preds = %62, %109, %118
+  %123 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %124 = load i32, i32* %loc1
+  %125 = load i32, i32* %loc0
+  %126 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %123, i32 %124, i32 %125)
+  ret %System.String addrspace(1)* %126
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %97
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange22:                           ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
 Successfully read String.CreateTrimmedString
 
@@ -5439,8 +6893,8 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
@@ -5535,8 +6989,8 @@ entry:
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i64 2872
   %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
   %8 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %7
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %3
   %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
@@ -5553,8 +7007,8 @@ entry:
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 2864
   %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
   %21 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %20
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
-  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %22
 
 ; <label>:22                                      ; preds = %16
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
@@ -5569,7 +7023,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %16
+ThrowNullRef2:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5586,8 +7040,8 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5613,8 +7067,8 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
@@ -5632,8 +7086,8 @@ entry:
 
 ; <label>:12                                      ; preds = %4
   %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
@@ -5644,8 +7098,8 @@ entry:
 
 ; <label>:19                                      ; preds = %14
   %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %19
   %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
@@ -5660,21 +7114,21 @@ entry:
   %31 = zext i16 %30 to i32
   %32 = bitcast i8* %29 to i16*
   %33 = trunc i32 %31 to i16
-  %NullCheck6 = icmp ne i16* %32, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i16* %32, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %21
   store i16 %33, i16* %32, align 8
   %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %36
 
 ; <label>:36                                      ; preds = %34
   %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
   %38 = load i32, i32 addrspace(1)* %37, align 8
   %39 = add i32 %38, 1
-  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %40
 
 ; <label>:40                                      ; preds = %36
   %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
@@ -5683,16 +7137,16 @@ entry:
 
 ; <label>:42                                      ; preds = %14
   %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
-  br i1 %NullCheck12, label %44, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
   %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
   %47 = load i16, i16* %arg1
   %48 = zext i16 %47 to i32
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = trunc i32 %48 to i16
@@ -5703,31 +7157,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %19
+ThrowNullRef4:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %21
+ThrowNullRef6:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %36
+ThrowNullRef10:                                   ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %42
+ThrowNullRef12:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %44
+ThrowNullRef14:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5740,8 +7194,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -5752,8 +7206,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
@@ -5762,14 +7216,14 @@ entry:
 
 ; <label>:11                                      ; preds = %1
   %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
@@ -5779,15 +7233,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5808,8 +7262,8 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5822,8 +7276,8 @@ entry:
 
 ; <label>:8                                       ; preds = %3
   %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
@@ -5842,15 +7296,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
-  br i1 %NullCheck4, label %22, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
   %24 = load i16*, i16* addrspace(1)* %23, align 8
   %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %25, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
@@ -5859,8 +7313,8 @@ entry:
   store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
@@ -5874,8 +7328,8 @@ entry:
 
 ; <label>:37                                      ; preds = %65
   %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %37
   %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
@@ -5886,16 +7340,16 @@ entry:
   %45 = bitcast i16* %41 to i8*
   %46 = getelementptr inbounds i8, i8* %45, i64 %44
   %47 = bitcast i8* %46 to i16*
-  %NullCheck14 = icmp ne i16* %47, null
-  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %47, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %48
 
 ; <label>:48                                      ; preds = %39
   %49 = load i16, i16* %47, align 8
   %50 = zext i16 %49 to i32
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %52 = load i32, i32* %loc1
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %53
 
 ; <label>:53                                      ; preds = %48
   %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
@@ -5916,8 +7370,8 @@ entry:
 ; <label>:62                                      ; preds = %36, %59
   %63 = load i32, i32* %loc1
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck10, label %65, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %65
 
 ; <label>:65                                      ; preds = %62
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
@@ -5936,15 +7390,15 @@ entry:
 
 ; <label>:74                                      ; preds = %70
   %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
-  br i1 %NullCheck18, label %76, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %76
 
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
   %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
-  br i1 %NullCheck20, label %80, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
   %81 = load i64, i64 addrspace(1)* %79
@@ -5958,8 +7412,8 @@ entry:
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
   %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
-  br i1 %NullCheck22, label %92, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.String addrspace(1)* %90, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %92
 
 ; <label>:92                                      ; preds = %80
   %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
@@ -5969,15 +7423,15 @@ entry:
 
 ; <label>:96                                      ; preds = %70
   %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
-  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %98
 
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
   %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
-  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
   %103 = load i64, i64 addrspace(1)* %101
@@ -5991,8 +7445,8 @@ entry:
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
   %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
-  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.String addrspace(1)* %112, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %114
 
 ; <label>:114                                     ; preds = %102
   %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
@@ -6004,59 +7458,59 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %20
+ThrowNullRef4:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %22
+ThrowNullRef6:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %26
+ThrowNullRef8:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %62
+ThrowNullRef10:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %48
+ThrowNullRef16:                                   ; preds = %48
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %74
+ThrowNullRef18:                                   ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %76
+ThrowNullRef20:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %80
+ThrowNullRef22:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %96
+ThrowNullRef24:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %98
+ThrowNullRef26:                                   ; preds = %98
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %102
+ThrowNullRef28:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6069,15 +7523,15 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
   %3 = load i16*, i16* addrspace(1)* %2, align 8
   %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
@@ -6087,8 +7541,8 @@ entry:
   %10 = bitcast i16* %3 to i8*
   %11 = getelementptr inbounds i8, i8* %10, i64 %9
   %12 = bitcast i8* %11 to i16*
-  %NullCheck4 = icmp ne i16* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %5
   store i16 0, i16* %12, align 8
@@ -6098,11 +7552,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6119,8 +7573,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -6131,8 +7585,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
@@ -6144,15 +7598,15 @@ entry:
 
 ; <label>:14                                      ; preds = %1
   %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
   %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
   %21 = load i64, i64 addrspace(1)* %19
@@ -6171,15 +7625,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %14
+ThrowNullRef4:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %16
+ThrowNullRef6:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6302,14 +7756,6 @@ entry:
   ret %System.String addrspace(1)* %57
 }
 
-INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
-Successfully read RuntimeHelpers.get_OffsetToStringData
-
-define i32 @RuntimeHelpers.get_OffsetToStringData() {
-entry:
-  ret i32 12
-}
-
 INFO:  jitting method String::Equals using LLILCJit
 Successfully read String.Equals
 
@@ -6381,8 +7827,8 @@ entry:
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
-  br i1 %NullCheck24, label %29, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
   %30 = load i64, i64 addrspace(1)* %28
@@ -6397,8 +7843,8 @@ entry:
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
-  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
   %43 = load i64, i64 addrspace(1)* %41
@@ -6418,8 +7864,8 @@ entry:
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
   %59 = load i64, i64 addrspace(1)* %57
@@ -6434,8 +7880,8 @@ entry:
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck22, label %71, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
   %72 = load i64, i64 addrspace(1)* %70
@@ -6455,8 +7901,8 @@ entry:
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
-  br i1 %NullCheck16, label %87, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = load i64, i64 addrspace(1)* %86
@@ -6471,8 +7917,8 @@ entry:
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck18, label %100, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
   %101 = load i64, i64 addrspace(1)* %99
@@ -6492,8 +7938,8 @@ entry:
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
-  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
   %117 = load i64, i64 addrspace(1)* %115
@@ -6508,8 +7954,8 @@ entry:
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
-  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
   %130 = load i64, i64 addrspace(1)* %128
@@ -6528,15 +7974,15 @@ entry:
 
 ; <label>:142                                     ; preds = %22
   %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
-  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %143, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %144
 
 ; <label>:144                                     ; preds = %142
   %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
   %146 = load i32, i32 addrspace(1)* %145
   %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
-  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %147, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %148
 
 ; <label>:148                                     ; preds = %144
   %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
@@ -6557,15 +8003,15 @@ entry:
 
 ; <label>:159                                     ; preds = %22
   %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
-  br i1 %NullCheck, label %161, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %ThrowNullRef, label %161
 
 ; <label>:161                                     ; preds = %159
   %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
   %163 = load i32, i32 addrspace(1)* %162
   %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
-  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %164, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %165
 
 ; <label>:165                                     ; preds = %161
   %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
@@ -6578,8 +8024,8 @@ entry:
 
 ; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
-  br i1 %NullCheck4, label %172, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %171, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %172
 
 ; <label>:172                                     ; preds = %170
   %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
@@ -6589,8 +8035,8 @@ entry:
 
 ; <label>:176                                     ; preds = %172
   %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
-  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %177, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %178
 
 ; <label>:178                                     ; preds = %176
   %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
@@ -6629,55 +8075,55 @@ ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %161
+ThrowNullRef2:                                    ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %170
+ThrowNullRef4:                                    ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %176
+ThrowNullRef6:                                    ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %142
+ThrowNullRef8:                                    ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %144
+ThrowNullRef10:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %113
+ThrowNullRef12:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %116
+ThrowNullRef14:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %84
+ThrowNullRef16:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %87
+ThrowNullRef18:                                   ; preds = %87
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %55
+ThrowNullRef20:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %58
+ThrowNullRef22:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %26
+ThrowNullRef24:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %29
+ThrowNullRef26:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,8 +8161,8 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck, label %14, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %ThrowNullRef, label %14
 
 ; <label>:14                                      ; preds = %8
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
@@ -6760,8 +8206,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
@@ -6770,14 +8216,14 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32, i32* %loc0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %10
   %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
   %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
@@ -6790,15 +8236,15 @@ entry:
 ; <label>:25                                      ; preds = %19
   %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
-  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
   %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
@@ -6807,8 +8253,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %37 = load i32, i32* %loc0
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %38, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %38
 
 ; <label>:38                                      ; preds = %32
   %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
@@ -6817,14 +8263,14 @@ entry:
 
 ; <label>:40                                      ; preds = %19
   %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %40
   %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
   %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
-  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
-  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
@@ -6832,8 +8278,8 @@ entry:
   %48 = zext i32 %47 to i64
   %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
-  br i1 %NullCheck16, label %51, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %51
 
 ; <label>:51                                      ; preds = %45
   %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
@@ -6847,15 +8293,15 @@ entry:
 ; <label>:57                                      ; preds = %51
   %58 = load i16*, i16** %arg1
   %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
-  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %60
 
 ; <label>:60                                      ; preds = %57
   %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
   %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
-  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %64
 
 ; <label>:64                                      ; preds = %60
   %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
@@ -6864,22 +8310,22 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
   %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
-  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %70
 
 ; <label>:70                                      ; preds = %64
   %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
   %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
-  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
-  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
   %75 = load i32, i32 addrspace(1)* %74
   %76 = zext i32 %75 to i64
   %77 = trunc i64 %76 to i32
-  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
-  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %78
 
 ; <label>:78                                      ; preds = %73
   %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
@@ -6901,8 +8347,8 @@ entry:
   %90 = bitcast i16* %86 to i8*
   %91 = getelementptr inbounds i8, i8* %90, i64 %89
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %93
 
 ; <label>:93                                      ; preds = %80
   %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
@@ -6912,8 +8358,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %99 = load i32, i32* %loc2
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %100
 
 ; <label>:100                                     ; preds = %93
   %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
@@ -6928,63 +8374,63 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %25
+ThrowNullRef6:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %32
+ThrowNullRef10:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %40
+ThrowNullRef12:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %45
+ThrowNullRef16:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %57
+ThrowNullRef18:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %60
+ThrowNullRef20:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %64
+ThrowNullRef22:                                   ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %70
+ThrowNullRef24:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %73
+ThrowNullRef26:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %80
+ThrowNullRef28:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %93
+ThrowNullRef30:                                   ; preds = %93
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7004,8 +8450,8 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
@@ -7033,43 +8479,43 @@ entry:
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %14
   %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
   %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   %28 = load i32, i32 addrspace(1)* %27, align 8
   %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
-  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %30
 
 ; <label>:30                                      ; preds = %26
   %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
   %32 = load i32, i32 addrspace(1)* %31, align 8
   %33 = add i32 %28, %32
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %34
 
 ; <label>:34                                      ; preds = %30
   %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   store i32 %33, i32 addrspace(1)* %35
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
   store i32 0, i32 addrspace(1)* %38
   %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %40
 
 ; <label>:40                                      ; preds = %37
   %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
@@ -7082,8 +8528,8 @@ entry:
 
 ; <label>:47                                      ; preds = %40
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
@@ -7098,8 +8544,8 @@ entry:
   %54 = load i32, i32* %loc0
   %55 = sext i32 %54 to i64
   %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
-  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %57
 
 ; <label>:57                                      ; preds = %52
   %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
@@ -7110,68 +8556,35 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %14
+ThrowNullRef2:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %23
+ThrowNullRef4:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %26
+ThrowNullRef6:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %30
+ThrowNullRef8:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %34
+ThrowNullRef10:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %47
+ThrowNullRef14:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %52
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-}
-
-INFO:  jitting method StringBuilder::get_Length using LLILCJit
-Successfully read StringBuilder.get_Length
-
-define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.StringBuilder addrspace(1)*
-  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
-  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
-
-; <label>:1                                       ; preds = %entry
-  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %3 = load i32, i32 addrspace(1)* %2, align 8
-  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
-
-; <label>:5                                       ; preds = %1
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = add i32 %3, %7
-  ret i32 %8
-
-ThrowNullRef:                                     ; preds = %entry
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef16:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7213,70 +8626,70 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
   %6 = load i32, i32 addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
   store i32 %6, i32 addrspace(1)* %8
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
   %13 = load i32, i32 addrspace(1)* %12, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
   store i32 %13, i32 addrspace(1)* %15
   %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
-  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %18
 
 ; <label>:18                                      ; preds = %14
   %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
   %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
   %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
   %34 = load i32, i32 addrspace(1)* %33, align 8
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
-  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
@@ -7287,39 +8700,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %28
+ThrowNullRef16:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %32
+ThrowNullRef18:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7455,13 +8868,13 @@ entry:
 ; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
@@ -7477,16 +8890,16 @@ entry:
 
 ; <label>:18                                      ; preds = %15
   %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
   store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
   %22 = load i32, i32* %loc0
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %24
 
 ; <label>:24                                      ; preds = %20
   %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
@@ -7498,13 +8911,13 @@ entry:
 ; <label>:28                                      ; preds = %15, %24
   %29 = load i32, i32* %arg1
   %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %31
   %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
@@ -7517,20 +8930,20 @@ entry:
   %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
-  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
   %46 = load i32, i32 addrspace(1)* %45, align 8
   %47 = sub i32 %40, %46
-  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
-  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i32 addrspace(1)* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %48
 
 ; <label>:48                                      ; preds = %44
   store i32 %47, i32 addrspace(1)* %39, align 8
@@ -7538,21 +8951,21 @@ entry:
 
 ; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
-  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %51
 
 ; <label>:51                                      ; preds = %49
   %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %53
 
 ; <label>:53                                      ; preds = %51
   %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
   %55 = load i32, i32 addrspace(1)* %54, align 8
   %56 = load i32, i32* %arg2
   %57 = sub i32 %55, %56
-  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %58
 
 ; <label>:58                                      ; preds = %53
   %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
@@ -7562,13 +8975,13 @@ entry:
 ; <label>:60                                      ; preds = %33, %58
   %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
   %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
-  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %63
 
 ; <label>:63                                      ; preds = %60
   %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
-  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
-  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
@@ -7578,15 +8991,15 @@ entry:
 
 ; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
-  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i32 addrspace(1)* %69, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %70
 
 ; <label>:70                                      ; preds = %68
   %71 = load i32, i32 addrspace(1)* %69, align 8
   store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
-  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
@@ -7596,8 +9009,8 @@ entry:
   store i32 %77, i32* %loc4
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
-  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %80
 
 ; <label>:80                                      ; preds = %73
   %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
@@ -7607,71 +9020,71 @@ entry:
 ; <label>:83                                      ; preds = %80
   store i32 0, i32* %loc3
   %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
-  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
-  br i1 %NullCheck26, label %88, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i32 addrspace(1)* %87, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %88
 
 ; <label>:88                                      ; preds = %85
   %89 = load i32, i32 addrspace(1)* %87, align 8
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
-  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %90
 
 ; <label>:90                                      ; preds = %88
   %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
   store i32 %89, i32 addrspace(1)* %91
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
-  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
-  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %96
 
 ; <label>:96                                      ; preds = %94
   %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
-  br i1 %NullCheck34, label %100, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %100
 
 ; <label>:100                                     ; preds = %96
   %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
-  br i1 %NullCheck36, label %102, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %102
 
 ; <label>:102                                     ; preds = %100
   %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
   %104 = load i32, i32 addrspace(1)* %103, align 8
   %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
-  br i1 %NullCheck38, label %106, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %106
 
 ; <label>:106                                     ; preds = %102
   %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
-  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
-  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %108
 
 ; <label>:108                                     ; preds = %106
   %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
   %110 = load i32, i32 addrspace(1)* %109, align 8
   %111 = add i32 %104, %110
-  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %112
 
 ; <label>:112                                     ; preds = %108
   %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
   store i32 %111, i32 addrspace(1)* %113
   %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
-  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i32 addrspace(1)* %114, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %115
 
 ; <label>:115                                     ; preds = %112
   %116 = load i32, i32 addrspace(1)* %114, align 8
@@ -7681,19 +9094,19 @@ entry:
 ; <label>:118                                     ; preds = %115
   %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
-  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %121
 
 ; <label>:121                                     ; preds = %118
   %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
-  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
-  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %123
 
 ; <label>:123                                     ; preds = %121
   %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
   %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
-  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
-  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %126
 
 ; <label>:126                                     ; preds = %123
   %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
@@ -7705,8 +9118,8 @@ entry:
 
 ; <label>:130                                     ; preds = %80, %115, %126
   %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %132
 
 ; <label>:132                                     ; preds = %130
   %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7715,8 +9128,8 @@ entry:
   %136 = load i32, i32* %loc3
   %137 = sub i32 %135, %136
   %138 = sub i32 %134, %137
-  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %139
 
 ; <label>:139                                     ; preds = %132
   %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7728,16 +9141,16 @@ entry:
 
 ; <label>:144                                     ; preds = %139
   %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
-  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %146
 
 ; <label>:146                                     ; preds = %144
   %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
   %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
   %149 = load i32, i32* %loc2
   %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
-  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %151
 
 ; <label>:151                                     ; preds = %146
   %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
@@ -7754,145 +9167,249 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %18
+ThrowNullRef4:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %31
+ThrowNullRef10:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %44
+ThrowNullRef16:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %68
+ThrowNullRef18:                                   ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %70
+ThrowNullRef20:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %73
+ThrowNullRef22:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %83
+ThrowNullRef24:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %85
+ThrowNullRef26:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %88
+ThrowNullRef28:                                   ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %90
+ThrowNullRef30:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %94
+ThrowNullRef32:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %96
+ThrowNullRef34:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %100
+ThrowNullRef36:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %102
+ThrowNullRef38:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %106
+ThrowNullRef40:                                   ; preds = %106
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %108
+ThrowNullRef42:                                   ; preds = %108
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %112
+ThrowNullRef44:                                   ; preds = %112
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %118
+ThrowNullRef46:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %121
+ThrowNullRef48:                                   ; preds = %121
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %123
+ThrowNullRef50:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %130
+ThrowNullRef52:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %132
+ThrowNullRef54:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %144
+ThrowNullRef56:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %146
+ThrowNullRef58:                                   ; preds = %146
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %60
+ThrowNullRef60:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %63
+ThrowNullRef62:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %49
+ThrowNullRef64:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %51
+ThrowNullRef66:                                   ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %53
+ThrowNullRef68:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(%"System.Char[]" addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %arg0 = alloca %"System.Char[]" addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store %"System.Char[]" addrspace(1)* %param0, %"System.Char[]" addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load i32, i32* %arg4
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %43, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %38, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg1
+  %13 = load i32, i32* %arg4
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %38, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %24 = load i32, i32* %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %35 = load i32, i32* %arg3
+  %36 = load i32, i32* %arg4
+  %37 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %37, %"System.Char[]" addrspace(1)* %34, i32 %35, i32 %36)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:38                                      ; preds = %5, %16
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Successfully read Buffer._Memmove
 
@@ -7914,7 +9431,7 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[loadElem]
+Failed to read AppDomain.SetDataHelper[storeElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -7923,8 +9440,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
@@ -7934,8 +9451,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
@@ -7947,15 +9464,15 @@ entry:
   %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
   %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
@@ -7966,15 +9483,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7992,7 +9509,79 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
-Failed to read Dictionary`2.TryGetValue[loadElemA]
+Successfully read Dictionary`2.TryGetValue
+
+define i8 @"Dictionary`2.TryGetValue"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)* addrspace(1)* %param2) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  %arg2 = alloca %System.__Canon addrspace(1)* addrspace(1)*
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  store %System.__Canon addrspace(1)* addrspace(1)* %param2, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  store i32 %2, i32* %loc0
+  %3 = load i32, i32* %loc0
+  %4 = icmp slt i32 %3, 0
+  br i1 %4, label %22, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 2
+  %10 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %9, align 8
+  %11 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = zext i32 %11 to i64
+  %BoundsCheck = icmp uge i64 %16, %15
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 3, i32 %11
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %20, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %6, %System.__Canon addrspace(1)* %21)
+  ret i8 1
+
+; <label>:22                                      ; preds = %entry
+  %23 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %23, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -8058,8 +9647,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
@@ -8091,8 +9680,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
@@ -8171,15 +9760,15 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck, label %19, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %ThrowNullRef, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
   %21 = load i32, i32 addrspace(1)* %20
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
@@ -8202,7 +9791,7 @@ ThrowNullRef:                                     ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %19
+ThrowNullRef2:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8248,8 +9837,8 @@ entry:
   %0 = alloca %System.AppDomainHandle
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %1 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %1, i32 0, i32 15
@@ -8269,8 +9858,8 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
@@ -8286,7 +9875,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -8299,8 +9888,8 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -8327,8 +9916,8 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
@@ -8352,8 +9941,8 @@ entry:
   %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
   store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
@@ -8363,8 +9952,8 @@ entry:
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
@@ -8374,8 +9963,8 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %9
   %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
@@ -8384,8 +9973,8 @@ entry:
 
 ; <label>:18                                      ; preds = %3, %16
   %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
@@ -8397,15 +9986,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %18
+ThrowNullRef6:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8418,8 +10007,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
@@ -8453,15 +10042,15 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
@@ -8473,7 +10062,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8481,7 +10070,7 @@ ThrowNullRef1:                                    ; preds = %1
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
 Failed to read Dictionary`2.System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
@@ -8506,8 +10095,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
@@ -8524,8 +10113,8 @@ entry:
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -8544,7 +10133,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8577,8 +10166,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = load i64, i64* %arg2
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = trunc i32 %3 to i8
@@ -8634,46 +10223,46 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
   %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
-  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
-  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
-  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
@@ -8684,27 +10273,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %20
+ThrowNullRef12:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8717,8 +10306,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -8756,22 +10345,22 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
   %9 = load i64, i64 addrspace(1)* %8, align 8
   %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
   %13 = load i64, i64 addrspace(1)* %12, align 8
   %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %11
   %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
@@ -8788,11 +10377,11 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8882,8 +10471,8 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
@@ -8900,8 +10489,8 @@ entry:
 ; <label>:8                                       ; preds = %1
   %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
   %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
@@ -8911,15 +10500,15 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
   %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
   %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
-  br i1 %NullCheck6, label %21, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
@@ -8946,15 +10535,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8992,15 +10581,15 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
   store i8 %3, i8 addrspace(1)* %5
   %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
@@ -9011,7 +10600,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9027,8 +10616,8 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -9041,8 +10630,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
@@ -9058,7 +10647,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9080,8 +10669,8 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
@@ -9096,8 +10685,8 @@ entry:
 ; <label>:12                                      ; preds = %6
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
@@ -9112,8 +10701,8 @@ entry:
 ; <label>:21                                      ; preds = %15
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
@@ -9128,8 +10717,8 @@ entry:
 ; <label>:30                                      ; preds = %24
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %31, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
@@ -9144,8 +10733,8 @@ entry:
 ; <label>:39                                      ; preds = %33
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
-  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %40, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %42
 
 ; <label>:42                                      ; preds = %39
   %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
@@ -9164,19 +10753,19 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %21
+ThrowNullRef4:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %30
+ThrowNullRef6:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %39
+ThrowNullRef8:                                    ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9243,8 +10832,8 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
@@ -9264,57 +10853,57 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
   store i8 0, i8 addrspace(1)* %2
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
   store i8 0, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
   store i8 0, i8 addrspace(1)* %17
   %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
   store i8 0, i8 addrspace(1)* %20
   %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
-  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
@@ -9325,31 +10914,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %19
+ThrowNullRef14:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9367,8 +10956,8 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
@@ -9380,8 +10969,8 @@ entry:
 
 ; <label>:9                                       ; preds = %4
   %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %9
   %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
@@ -9395,7 +10984,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef2:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9420,8 +11009,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
@@ -9512,8 +11101,8 @@ entry:
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
@@ -9524,8 +11113,8 @@ entry:
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = load i64, i64 addrspace(1)* %12
@@ -9537,8 +11126,8 @@ entry:
   %20 = load i64, i64* %19
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
-  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %13
   %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
@@ -9555,8 +11144,8 @@ entry:
 ; <label>:30                                      ; preds = %25
   %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %32 = load i32, i32* %arg2
-  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
-  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
@@ -9570,15 +11159,15 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %30
+ThrowNullRef2:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9622,87 +11211,87 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
   %10 = load i8, i8 addrspace(1)* %9, align 8
   %11 = zext i8 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %8
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
   store i8 %12, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
   %19 = load i8, i8 addrspace(1)* %18, align 8
   %20 = zext i8 %19 to i32
   %21 = trunc i32 %20 to i8
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
   store i8 %21, i8 addrspace(1)* %23
   %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
   %28 = load i8, i8 addrspace(1)* %27, align 8
   %29 = zext i8 %28 to i32
   %30 = trunc i32 %29 to i8
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
-  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %31
 
 ; <label>:31                                      ; preds = %26
   %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
   store i8 %30, i8 addrspace(1)* %32
   %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
-  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
-  br i1 %NullCheck14, label %40, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %40
 
 ; <label>:40                                      ; preds = %35
   %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
   store i8 %39, i8 addrspace(1)* %41
   %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
-  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %44
 
 ; <label>:44                                      ; preds = %40
   %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
   %46 = load i8, i8 addrspace(1)* %45, align 8
   %47 = zext i8 %46 to i32
   %48 = trunc i32 %47 to i8
-  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
   store i8 %48, i8 addrspace(1)* %50
   %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
-  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
@@ -9713,29 +11302,29 @@ entry:
 ; <label>:56                                      ; preds = %52
   %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
-  br i1 %NullCheck22, label %59, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
   %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
   %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
-  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
-  br i1 %NullCheck24, label %63, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
   %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
-  br i1 %NullCheck26, label %66, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
   %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
-  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
-  br i1 %NullCheck28, label %69, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %69
 
 ; <label>:69                                      ; preds = %66
   %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
@@ -9744,15 +11333,15 @@ entry:
 
 ; <label>:71                                      ; preds = %105
   %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
-  br i1 %NullCheck34, label %73, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %73
 
 ; <label>:73                                      ; preds = %71
   %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
   %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
   %76 = load i32, i32* %loc0
-  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
-  br i1 %NullCheck36, label %77, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
@@ -9766,8 +11355,8 @@ entry:
 
 ; <label>:83                                      ; preds = %77
   %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
-  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
@@ -9775,14 +11364,14 @@ entry:
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
   %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
-  br i1 %NullCheck40, label %91, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
 ; <label>:91                                      ; preds = %85
   %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
   %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
-  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck42, label %94, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %94
 
 ; <label>:94                                      ; preds = %91
   %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
@@ -9798,14 +11387,14 @@ entry:
 ; <label>:99                                      ; preds = %69, %96
   %100 = load i32, i32* %loc0
   %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
-  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %102
 
 ; <label>:102                                     ; preds = %99
   %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
   %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
-  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
-  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
@@ -9819,87 +11408,87 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %26
+ThrowNullRef10:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %31
+ThrowNullRef12:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %35
+ThrowNullRef14:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %40
+ThrowNullRef16:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %56
+ThrowNullRef22:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %59
+ThrowNullRef24:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %63
+ThrowNullRef26:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %66
+ThrowNullRef28:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %102
+ThrowNullRef32:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %71
+ThrowNullRef34:                                   ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %73
+ThrowNullRef36:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %83
+ThrowNullRef38:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %85
+ThrowNullRef40:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %91
+ThrowNullRef42:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9943,15 +11532,15 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
   %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
@@ -9961,28 +11550,28 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
   %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %12
   %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
   %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
   %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
-  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
@@ -9993,23 +11582,23 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %12
+ThrowNullRef6:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10031,15 +11620,15 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
   %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = load i64, i64 addrspace(1)* %7
@@ -10077,13 +11666,13 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[loadElem]
+Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -10111,8 +11700,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -10165,8 +11754,8 @@ entry:
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load float, float* %arg0
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -10300,8 +11889,8 @@ entry:
   store i64 %param0, i64* %arg0
   store i64 %param1, i64* %arg1
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
@@ -10309,8 +11898,8 @@ entry:
   %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
   %5 = load i16*, i16* addrspace(1)* %4, align 8
   %6 = addrspacecast i64* %arg1 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = bitcast i64 addrspace(1)* %6 to i8 addrspace(1)*
@@ -10326,7 +11915,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10360,8 +11949,8 @@ entry:
   %1 = load i32, i32* %arg1
   %2 = sext i32 %1 to i64
   %3 = inttoptr i64 %2 to i16*
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -10414,8 +12003,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, i32)*)(%System.IO.ConsoleStream addrspace(1)* %2, i32 %1)
   %3 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %4 = load i64, i64* %arg1
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
@@ -10426,8 +12015,8 @@ entry:
   %10 = icmp eq i32 %9, 3
   %11 = sext i1 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %5
   %14 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, i32 0, i32 5
@@ -10438,7 +12027,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10461,8 +12050,8 @@ entry:
   %5 = icmp eq i32 %4, 1
   %6 = sext i1 %5 to i32
   %7 = trunc i32 %6 to i8
-  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %2, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.ConsoleStream addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
@@ -10473,8 +12062,8 @@ entry:
   %13 = icmp eq i32 %12, 2
   %14 = sext i1 %13 to i32
   %15 = trunc i32 %14 to i8
-  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %10, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.ConsoleStream addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %8
   %17 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %10, i32 0, i32 4
@@ -10485,7 +12074,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10524,8 +12113,8 @@ entry:
   %arg0 = alloca i64
   store i64 %param0, i64* %arg0
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
@@ -10560,8 +12149,8 @@ entry:
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
   %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = load i64, i64 addrspace(1)* %7
@@ -10665,7 +12254,127 @@ entry:
 INFO:  jitting method Encoding::GetEncoding using LLILCJit
 Failed to read Encoding.GetEncoding[convertToHelperArgumentType]
 INFO:  jitting method EncodingProvider::GetEncodingFromProvider using LLILCJit
-Failed to read EncodingProvider.GetEncodingFromProvider[loadElem]
+Successfully read EncodingProvider.GetEncodingFromProvider
+
+define %System.Text.Encoding addrspace(1)* @EncodingProvider.GetEncodingFromProvider(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca %"System.Text.EncodingProvider[]" addrspace(1)*
+  %loc1 = alloca %System.Text.EncodingProvider addrspace(1)*
+  %loc2 = alloca %System.Text.Encoding addrspace(1)*
+  %loc3 = alloca %System.Text.Encoding addrspace(1)*
+  %loc4 = alloca %"System.Text.EncodingProvider[]" addrspace(1)*
+  %loc5 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1059)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2392
+  %2 = addrspacecast i8 addrspace(1)* %1 to %"System.Text.EncodingProvider[]" addrspace(1)**
+  %3 = load volatile %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %2
+  %4 = icmp ne %"System.Text.EncodingProvider[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %entry
+  ret %System.Text.Encoding addrspace(1)* null
+
+; <label>:6                                       ; preds = %entry
+  %7 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1059)
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i64 2392
+  %9 = addrspacecast i8 addrspace(1)* %8 to %"System.Text.EncodingProvider[]" addrspace(1)**
+  %10 = load volatile %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %9
+  store %"System.Text.EncodingProvider[]" addrspace(1)* %10, %"System.Text.EncodingProvider[]" addrspace(1)** %loc0
+  %11 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc0
+  store %"System.Text.EncodingProvider[]" addrspace(1)* %11, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  store i32 0, i32* %loc5
+  br label %43
+
+; <label>:12                                      ; preds = %46
+  %13 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  %14 = load i32, i32* %loc5
+  %NullCheck1 = icmp eq %"System.Text.EncodingProvider[]" addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %13, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = zext i32 %17 to i64
+  %19 = zext i32 %14 to i64
+  %BoundsCheck = icmp uge i64 %19, %18
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %20
+
+; <label>:20                                      ; preds = %15
+  %21 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %13, i32 0, i32 3, i32 %14
+  %22 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)* addrspace(1)* %21, align 8
+  store %System.Text.EncodingProvider addrspace(1)* %22, %System.Text.EncodingProvider addrspace(1)** %loc1
+  %23 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)** %loc1
+  %24 = load i32, i32* %arg0
+  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i64 addrspace(1)*
+  %NullCheck3 = icmp eq i64 addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
+
+; <label>:26                                      ; preds = %20
+  %27 = load i64, i64 addrspace(1)* %25
+  %28 = add i64 %27, 64
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 40
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Text.Encoding addrspace(1)* (%System.Text.EncodingProvider addrspace(1)*, i32)*
+  %35 = call %System.Text.Encoding addrspace(1)* %34(%System.Text.EncodingProvider addrspace(1)* %23, i32 %24)
+  store %System.Text.Encoding addrspace(1)* %35, %System.Text.Encoding addrspace(1)** %loc2
+  %36 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc2
+  %37 = icmp eq %System.Text.Encoding addrspace(1)* %36, null
+  br i1 %37, label %40, label %38
+
+; <label>:38                                      ; preds = %26
+  %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc2
+  store %System.Text.Encoding addrspace(1)* %39, %System.Text.Encoding addrspace(1)** %loc3
+  br label %53
+
+; <label>:40                                      ; preds = %26
+  %41 = load i32, i32* %loc5
+  %42 = add i32 %41, 1
+  store i32 %42, i32* %loc5
+  br label %43
+
+; <label>:43                                      ; preds = %6, %40
+  %44 = load i32, i32* %loc5
+  %45 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  %NullCheck = icmp eq %"System.Text.EncodingProvider[]" addrspace(1)* %45, null
+  br i1 %NullCheck, label %ThrowNullRef, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp slt i32 %44, %50
+  br i1 %51, label %12, label %52
+
+; <label>:52                                      ; preds = %46
+  ret %System.Text.Encoding addrspace(1)* null
+
+; <label>:53                                      ; preds = %38
+  %54 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc3
+  ret %System.Text.Encoding addrspace(1)* %54
+
+ThrowNullRef:                                     ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method EncodingProvider::.cctor using LLILCJit
 Successfully read EncodingProvider..cctor
 
@@ -10684,7 +12393,7 @@ Failed to read Encoding.get_InternalSyncObject[Call HasTypeArg]
 INFO:  jitting method Hashtable::.ctor using LLILCJit
 Failed to read Hashtable..ctor[Volatile store]
 INFO:  jitting method Hashtable::get_Item using LLILCJit
-Failed to read Hashtable.get_Item[loadElemA]
+Failed to read Hashtable.get_Item[loadNonPrimitiveObj]
 INFO:  jitting method Hashtable::InitHash using LLILCJit
 Successfully read Hashtable.InitHash
 
@@ -10704,8 +12413,8 @@ entry:
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -10721,15 +12430,15 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
   %15 = load i32, i32* %loc0
-  %NullCheck2 = icmp ne i32 addrspace(1)* %14, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i32 addrspace(1)* %14, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %3
   store i32 %15, i32 addrspace(1)* %14, align 8
   %17 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %18 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %NullCheck4 = icmp ne i32 addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i32 addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = load i32, i32 addrspace(1)* %18, align 8
@@ -10738,8 +12447,8 @@ entry:
   %23 = sub i32 %22, 1
   %24 = urem i32 %21, %23
   %25 = add i32 1, %24
-  %NullCheck6 = icmp ne i32 addrspace(1)* %17, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32 addrspace(1)* %17, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %19
   store i32 %25, i32 addrspace(1)* %17, align 8
@@ -10750,15 +12459,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %19
+ThrowNullRef6:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10773,8 +12482,8 @@ entry:
   store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
   store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %NullCheck = icmp ne %System.Collections.Hashtable addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Collections.Hashtable addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
@@ -10784,16 +12493,16 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Collections.Hashtable addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Collections.Hashtable addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
   %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck4 = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %9, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
   %13 = inttoptr i64 %11 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
@@ -10803,8 +12512,8 @@ entry:
 ; <label>:15                                      ; preds = %1
   %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -10822,15 +12531,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10844,8 +12553,8 @@ entry:
   store %System.Int32 addrspace(1)* %param0, %System.Int32 addrspace(1)** %this
   %0 = load %System.Int32 addrspace(1)*, %System.Int32 addrspace(1)** %this
   %1 = bitcast %System.Int32 addrspace(1)* %0 to i32 addrspace(1)*
-  %NullCheck = icmp ne i32 addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq i32 addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load i32, i32 addrspace(1)* %1, align 8
@@ -10921,8 +12630,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.UTF8Encoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
@@ -10931,15 +12640,15 @@ entry:
   %9 = load i8, i8* %arg2
   %10 = zext i8 %9 to i32
   %11 = trunc i32 %10 to i8
-  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %8, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %6
   %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %8, i32 0, i32 8
   store i8 %11, i8 addrspace(1)* %13
   %14 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %14, i32 0, i32 8
@@ -10951,8 +12660,8 @@ entry:
 ; <label>:20                                      ; preds = %15
   %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %22, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %22, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = load i64, i64 addrspace(1)* %22
@@ -10974,15 +12683,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %12
+ThrowNullRef4:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10997,8 +12706,8 @@ entry:
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
@@ -11020,16 +12729,16 @@ entry:
 ; <label>:10                                      ; preds = %1
   %11 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
   %12 = load i32, i32* %arg1
-  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %11, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.Encoding addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
   store i32 %12, i32 addrspace(1)* %14
   %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
   %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = load i64, i64 addrspace(1)* %16
@@ -11047,11 +12756,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11064,8 +12773,8 @@ entry:
   %this = alloca %System.Text.UTF8Encoding addrspace(1)*
   store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
   %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.UTF8Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
@@ -11077,16 +12786,16 @@ entry:
 ; <label>:6                                       ; preds = %1
   %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %8 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %10, %System.Text.EncoderFallback addrspace(1)* %8)
   %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %12 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
-  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %11, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %11, i32 0, i32 3
@@ -11099,8 +12808,8 @@ entry:
   %18 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %18, %System.String addrspace(1)* %17)
   %19 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %18 to %System.Text.EncoderFallback addrspace(1)*
-  %NullCheck6 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %16, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %16, i32 0, i32 2
@@ -11110,8 +12819,8 @@ entry:
   %24 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %24, %System.String addrspace(1)* %23)
   %25 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %24 to %System.Text.DecoderFallback addrspace(1)*
-  %NullCheck8 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %22, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %22, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %20
   %27 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %22, i32 0, i32 3
@@ -11122,19 +12831,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %20
+ThrowNullRef8:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11164,8 +12873,8 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load i32, i32* %arg1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -11183,8 +12892,8 @@ entry:
 ; <label>:15                                      ; preds = %8
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %17 = load i32, i32* %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 %17
@@ -11200,7 +12909,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11252,7 +12961,7 @@ entry:
 }
 
 INFO:  jitting method Hashtable::Insert using LLILCJit
-Failed to read Hashtable.Insert[loadElemA]
+Failed to read Hashtable.Insert[storeElem]
 INFO:  jitting method ConsoleEncoding::.ctor using LLILCJit
 Successfully read ConsoleEncoding..ctor
 
@@ -11267,8 +12976,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %1)
   %2 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
@@ -11304,8 +13013,8 @@ entry:
   %2 = call %System.Text.InternalEncoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalEncoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %1)
   %3 = bitcast %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2 to %System.Text.EncoderFallback addrspace(1)*
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
@@ -11315,8 +13024,8 @@ entry:
   %8 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %7)
   %9 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %8 to %System.Text.DecoderFallback addrspace(1)*
-  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %6, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.Encoding addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %4
   %11 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %6, i32 0, i32 3
@@ -11327,7 +13036,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11346,15 +13055,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* %1)
   %2 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   %6 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, i32 0, i32 1
@@ -11365,7 +13074,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11393,8 +13102,8 @@ entry:
   store %System.Text.InternalDecoderBestFitFallback addrspace(1)* %param0, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
   %0 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
@@ -11404,15 +13113,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %4)
   %5 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %6)
   %9 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, i32 0, i32 1
@@ -11423,11 +13132,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11495,8 +13204,8 @@ entry:
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
   %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = load i64, i64 addrspace(1)* %19
@@ -11560,8 +13269,8 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.ConsoleStream addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
@@ -11592,31 +13301,31 @@ entry:
   store i8 %param4, i8* %arg4
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %3, %System.IO.Stream addrspace(1)* %1)
   %4 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %4, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
   %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %4, i32 0, i32 4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %5)
   %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %6
   %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
   %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
   %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = load i64, i64 addrspace(1)* %13
@@ -11628,8 +13337,8 @@ entry:
   %21 = load i64, i64* %20
   %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %8, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %8, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %14
   %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 5
@@ -11647,24 +13356,24 @@ entry:
   %31 = load i32, i32* %arg3
   %32 = sext i32 %31 to i64
   %33 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %32)
-  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %30, null
-  br i1 %NullCheck10, label %34, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.StreamWriter addrspace(1)* %30, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %35, %"System.Char[]" addrspace(1)* %33)
   %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %37, null
-  br i1 %NullCheck12, label %38, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.StreamWriter addrspace(1)* %37, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %38
 
 ; <label>:38                                      ; preds = %34
   %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
   %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
   %41 = load i32, i32* %arg3
   %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %42, null
-  br i1 %NullCheck14, label %43, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %42, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
   %44 = load i64, i64 addrspace(1)* %42
@@ -11678,30 +13387,30 @@ entry:
   %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
   %53 = sext i32 %52 to i64
   %54 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %53)
-  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
-  br i1 %NullCheck16, label %55, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %55
 
 ; <label>:55                                      ; preds = %43
   %56 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %56, %"System.Byte[]" addrspace(1)* %54)
   %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %58 = load i32, i32* %arg3
-  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %57, null
-  br i1 %NullCheck18, label %59, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.StreamWriter addrspace(1)* %57, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %59
 
 ; <label>:59                                      ; preds = %55
   %60 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 10
   store i32 %58, i32 addrspace(1)* %60
   %61 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %61, null
-  br i1 %NullCheck20, label %62, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.IO.StreamWriter addrspace(1)* %61, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %62
 
 ; <label>:62                                      ; preds = %59
   %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
   %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
   %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
   %67 = load i64, i64 addrspace(1)* %65
@@ -11719,15 +13428,15 @@ entry:
 
 ; <label>:78                                      ; preds = %66
   %79 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %79, null
-  br i1 %NullCheck24, label %80, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.StreamWriter addrspace(1)* %79, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %80
 
 ; <label>:80                                      ; preds = %78
   %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
   %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
   %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %83, null
-  br i1 %NullCheck26, label %84, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %83, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
   %85 = load i64, i64 addrspace(1)* %83
@@ -11744,8 +13453,8 @@ entry:
 
 ; <label>:95                                      ; preds = %84
   %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.IO.StreamWriter addrspace(1)* %96, null
-  br i1 %NullCheck28, label %97, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.IO.StreamWriter addrspace(1)* %96, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %97
 
 ; <label>:97                                      ; preds = %95
   %98 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 12
@@ -11759,8 +13468,8 @@ entry:
   %103 = icmp eq i32 %102, 0
   %104 = sext i1 %103 to i32
   %105 = trunc i32 %104 to i8
-  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %100, null
-  br i1 %NullCheck30, label %106, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.IO.StreamWriter addrspace(1)* %100, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %106
 
 ; <label>:106                                     ; preds = %99
   %107 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %100, i32 0, i32 13
@@ -11771,63 +13480,63 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %6
+ThrowNullRef4:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %29
+ThrowNullRef10:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %34
+ThrowNullRef12:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %38
+ThrowNullRef14:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %43
+ThrowNullRef16:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %55
+ThrowNullRef18:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %59
+ThrowNullRef20:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %62
+ThrowNullRef22:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %78
+ThrowNullRef24:                                   ; preds = %78
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %80
+ThrowNullRef26:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %95
+ThrowNullRef28:                                   ; preds = %95
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11840,15 +13549,15 @@ entry:
   %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = load i64, i64 addrspace(1)* %4
@@ -11866,7 +13575,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11916,35 +13625,35 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
   %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderNLS addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %7 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.EncoderNLS addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Text.Encoding addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.Encoding addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Text.EncoderNLS addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.EncoderNLS addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
   %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck8 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = load i64, i64 addrspace(1)* %16
@@ -11963,19 +13672,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12001,8 +13710,8 @@ entry:
   %this = alloca %System.Text.Encoding addrspace(1)*
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
@@ -12022,15 +13731,15 @@ entry:
   %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
   store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
   %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
   store i32 0, i32 addrspace(1)* %2
   %3 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, i32 0, i32 2
@@ -12040,15 +13749,15 @@ entry:
 
 ; <label>:8                                       ; preds = %4
   %9 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
   %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
   %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = load i64, i64 addrspace(1)* %13
@@ -12069,15 +13778,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12092,16 +13801,16 @@ entry:
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = load i32, i32* %arg1
   %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
   %7 = load i64, i64 addrspace(1)* %5
@@ -12119,7 +13828,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12156,8 +13865,8 @@ entry:
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
   %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
   %16 = load i64, i64 addrspace(1)* %14
@@ -12178,8 +13887,8 @@ entry:
   %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
   %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
   %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %31, null
-  br i1 %NullCheck2, label %32, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = load i64, i64 addrspace(1)* %31
@@ -12222,7 +13931,7 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12235,14 +13944,14 @@ entry:
   %this = alloca %System.Text.EncoderReplacementFallback addrspace(1)*
   store %System.Text.EncoderReplacementFallback addrspace(1)* %param0, %System.Text.EncoderReplacementFallback addrspace(1)** %this
   %0 = load %System.Text.EncoderReplacementFallback addrspace(1)*, %System.Text.EncoderReplacementFallback addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -12253,7 +13962,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12283,8 +13992,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
@@ -12316,8 +14025,8 @@ entry:
   %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
   store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
@@ -12329,8 +14038,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Threading.Tasks.Task addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %7)
@@ -12353,7 +14062,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12372,8 +14081,8 @@ entry:
   store i8 %param1, i8* %arg1
   store i8 %param2, i8* %arg2
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
@@ -12387,8 +14096,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1, %5
   %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 9
@@ -12419,8 +14128,8 @@ entry:
 
 ; <label>:25                                      ; preds = %8, %20
   %26 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %26, null
-  br i1 %NullCheck4, label %27, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %26, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %26, i32 0, i32 12
@@ -12431,22 +14140,22 @@ entry:
 
 ; <label>:32                                      ; preds = %27
   %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %33, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.IO.StreamWriter addrspace(1)* %33, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %32
   %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 12
   store i8 1, i8 addrspace(1)* %35
   %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
-  br i1 %NullCheck8, label %37, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
   %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
   %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck10 = icmp ne i64 addrspace(1)* %40, null
-  br i1 %NullCheck10, label %41, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64 addrspace(1)* %40, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i64, i64 addrspace(1)* %40
@@ -12460,8 +14169,8 @@ entry:
   %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
   store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
   %51 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %NullCheck12 = icmp ne %"System.Byte[]" addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Byte[]" addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %41
   %53 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %51, i32 0, i32 1
@@ -12473,16 +14182,16 @@ entry:
 
 ; <label>:58                                      ; preds = %52
   %59 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %59, null
-  br i1 %NullCheck14, label %60, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.IO.StreamWriter addrspace(1)* %59, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %60
 
 ; <label>:60                                      ; preds = %58
   %61 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %59, i32 0, i32 3
   %62 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
   %64 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %NullCheck16 = icmp ne %"System.Byte[]" addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %"System.Byte[]" addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %60
   %66 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %64, i32 0, i32 1
@@ -12490,8 +14199,8 @@ entry:
   %68 = zext i32 %67 to i64
   %69 = trunc i64 %68 to i32
   %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck18, label %71, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
   %72 = load i64, i64 addrspace(1)* %70
@@ -12507,29 +14216,29 @@ entry:
 
 ; <label>:80                                      ; preds = %27, %52, %71
   %81 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %81, null
-  br i1 %NullCheck20, label %82, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.IO.StreamWriter addrspace(1)* %81, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
 
 ; <label>:82                                      ; preds = %80
   %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %81, i32 0, i32 5
   %84 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %83, align 8
   %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.IO.StreamWriter addrspace(1)* %85, null
-  br i1 %NullCheck22, label %86, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.IO.StreamWriter addrspace(1)* %85, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %86
 
 ; <label>:86                                      ; preds = %82
   %87 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 7
   %88 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %87, align 8
   %89 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %89, null
-  br i1 %NullCheck24, label %90, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.StreamWriter addrspace(1)* %89, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %90
 
 ; <label>:90                                      ; preds = %86
   %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %89, i32 0, i32 9
   %92 = load i32, i32 addrspace(1)* %91, align 8
   %93 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.IO.StreamWriter addrspace(1)* %93, null
-  br i1 %NullCheck26, label %94, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.IO.StreamWriter addrspace(1)* %93, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %93, i32 0, i32 6
@@ -12537,8 +14246,8 @@ entry:
   %97 = load i8, i8* %arg2
   %98 = zext i8 %97 to i32
   %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
-  %NullCheck28 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck28, label %100, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
   %101 = load i64, i64 addrspace(1)* %99
@@ -12553,8 +14262,8 @@ entry:
   %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
   store i32 %110, i32* %loc1
   %111 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %111, null
-  br i1 %NullCheck30, label %112, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.IO.StreamWriter addrspace(1)* %111, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %112
 
 ; <label>:112                                     ; preds = %100
   %113 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %111, i32 0, i32 9
@@ -12565,23 +14274,23 @@ entry:
 
 ; <label>:116                                     ; preds = %112
   %117 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck32 = icmp ne %System.IO.StreamWriter addrspace(1)* %117, null
-  br i1 %NullCheck32, label %118, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.IO.StreamWriter addrspace(1)* %117, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %118
 
 ; <label>:118                                     ; preds = %116
   %119 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %117, i32 0, i32 3
   %120 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %119, align 8
   %121 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.IO.StreamWriter addrspace(1)* %121, null
-  br i1 %NullCheck34, label %122, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.IO.StreamWriter addrspace(1)* %121, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %122
 
 ; <label>:122                                     ; preds = %118
   %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
   %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
   %125 = load i32, i32* %loc1
   %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
-  %NullCheck36 = icmp ne i64 addrspace(1)* %126, null
-  br i1 %NullCheck36, label %127, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64 addrspace(1)* %126, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
   %128 = load i64, i64 addrspace(1)* %126
@@ -12603,15 +14312,15 @@ entry:
 
 ; <label>:140                                     ; preds = %136
   %141 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.IO.StreamWriter addrspace(1)* %141, null
-  br i1 %NullCheck38, label %142, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.IO.StreamWriter addrspace(1)* %141, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %142
 
 ; <label>:142                                     ; preds = %140
   %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
   %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
   %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
-  %NullCheck40 = icmp ne i64 addrspace(1)* %145, null
-  br i1 %NullCheck40, label %146, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i64 addrspace(1)* %145, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
   %147 = load i64, i64 addrspace(1)* %145
@@ -12632,83 +14341,83 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %25
+ThrowNullRef4:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %32
+ThrowNullRef6:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %37
+ThrowNullRef10:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %41
+ThrowNullRef12:                                   ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %58
+ThrowNullRef14:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %60
+ThrowNullRef16:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %65
+ThrowNullRef18:                                   ; preds = %65
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %80
+ThrowNullRef20:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %82
+ThrowNullRef22:                                   ; preds = %82
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %86
+ThrowNullRef24:                                   ; preds = %86
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %90
+ThrowNullRef26:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %94
+ThrowNullRef28:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %100
+ThrowNullRef30:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %116
+ThrowNullRef32:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %118
+ThrowNullRef34:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %122
+ThrowNullRef36:                                   ; preds = %122
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %140
+ThrowNullRef38:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %142
+ThrowNullRef40:                                   ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12775,8 +14484,8 @@ entry:
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %1 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
-  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
@@ -12784,8 +14493,8 @@ entry:
   %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
   %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
   %8 = load i64, i64 addrspace(1)* %6
@@ -12801,8 +14510,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %17, %System.IFormatProvider addrspace(1)* %16)
   %18 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %19 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %18, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.SyncTextWriter addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %7
   %21 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %18, i32 0, i32 4
@@ -12813,11 +14522,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12830,8 +14539,8 @@ entry:
   %this = alloca %System.IO.TextWriter addrspace(1)*
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.TextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
@@ -12841,8 +14550,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.Threading.Thread addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Threading.Thread addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %6)
@@ -12851,8 +14560,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1
   %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.TextWriter addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.TextWriter addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %11, i32 0, i32 2
@@ -12863,11 +14572,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13064,8 +14773,8 @@ entry:
   store float %param1, float* %arg1
   store i8 0, i8* %loc1
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
@@ -13075,16 +14784,16 @@ entry:
   %5 = addrspacecast i8* %loc1 to i8 addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %4, i8 addrspace(1)* %5)
   %6 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.SyncTextWriter addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
   %10 = load float, float* %arg1
   %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
   %13 = load i64, i64 addrspace(1)* %11
@@ -13119,11 +14828,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13140,8 +14849,8 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load float, float* %arg1
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -13155,8 +14864,8 @@ entry:
   call void %11(%System.IO.TextWriter addrspace(1)* %0, float %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
   %15 = load i64, i64 addrspace(1)* %13
@@ -13174,7 +14883,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13192,8 +14901,8 @@ entry:
   %1 = addrspacecast float* %arg1 to float addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -13208,8 +14917,8 @@ entry:
   %14 = bitcast float addrspace(1)* %1 to %System.Single addrspace(1)*
   %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Single addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Single addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
   %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
   %18 = load i64, i64 addrspace(1)* %16
@@ -13227,7 +14936,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13243,8 +14952,8 @@ entry:
   store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
   %0 = load %System.Single addrspace(1)*, %System.Single addrspace(1)** %this
   %1 = bitcast %System.Single addrspace(1)* %0 to float addrspace(1)*
-  %NullCheck = icmp ne float addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq float addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load float, float addrspace(1)* %1, align 8
@@ -13269,8 +14978,8 @@ entry:
   %loc0 = alloca %System.Globalization.NumberFormatInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 3
@@ -13280,8 +14989,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
@@ -13291,24 +15000,24 @@ entry:
   store %System.Globalization.NumberFormatInfo addrspace(1)* %10, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
   %11 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %7
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
   %15 = load i8, i8 addrspace(1)* %14, align 8
   %16 = zext i8 %15 to i32
   %17 = trunc i32 %16 to i8
-  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %11, null
-  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %11, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %13
   %19 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %11, i32 0, i32 29
   store i8 %17, i8 addrspace(1)* %19
   %20 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %21 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %20, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %20, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %18
   %23 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %20, i32 0, i32 3
@@ -13317,8 +15026,8 @@ entry:
 
 ; <label>:24                                      ; preds = %1, %22
   %25 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %25, null
-  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %25, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %26
 
 ; <label>:26                                      ; preds = %24
   %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %25, i32 0, i32 3
@@ -13329,23 +15038,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %18
+ThrowNullRef8:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13370,168 +15079,168 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 18
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %8, align 8
-  %NullCheck2 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %5, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %5, i32 0, i32 4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %9)
   %12 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 19
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %15, align 8
-  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %12, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %12, i32 0, i32 5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %16)
   %19 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %20 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %20, null
-  br i1 %NullCheck8, label %21, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %20, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %20, i32 0, i32 23
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  %NullCheck10 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %19, null
-  br i1 %NullCheck10, label %24, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %19, i32 0, i32 7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %25, %System.String addrspace(1)* %23)
   %26 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %27 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %27, i32 0, i32 22
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %29, align 8
-  %NullCheck14 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %26, null
-  br i1 %NullCheck14, label %31, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %26, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %26, i32 0, i32 6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %32, %System.String addrspace(1)* %30)
   %33 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %34 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Globalization.CultureData addrspace(1)* %34, null
-  br i1 %NullCheck16, label %35, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Globalization.CultureData addrspace(1)* %34, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %34, i32 0, i32 51
   %37 = load i32, i32 addrspace(1)* %36, align 8
-  %NullCheck18 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %33, null
-  br i1 %NullCheck18, label %38, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %33, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %33, i32 0, i32 21
   store i32 %37, i32 addrspace(1)* %39
   %40 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %41 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Globalization.CultureData addrspace(1)* %41, null
-  br i1 %NullCheck20, label %42, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Globalization.CultureData addrspace(1)* %41, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %41, i32 0, i32 52
   %44 = load i32, i32 addrspace(1)* %43, align 8
-  %NullCheck22 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %40, null
-  br i1 %NullCheck22, label %45, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %40, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %40, i32 0, i32 25
   store i32 %44, i32 addrspace(1)* %46
   %47 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %48 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.Globalization.CultureData addrspace(1)* %48, null
-  br i1 %NullCheck24, label %49, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Globalization.CultureData addrspace(1)* %48, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %49
 
 ; <label>:49                                      ; preds = %45
   %50 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %48, i32 0, i32 29
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck26 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %47, null
-  br i1 %NullCheck26, label %52, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %47, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %47, i32 0, i32 10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %53, %System.String addrspace(1)* %51)
   %54 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %55 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Globalization.CultureData addrspace(1)* %55, null
-  br i1 %NullCheck28, label %56, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Globalization.CultureData addrspace(1)* %55, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %56
 
 ; <label>:56                                      ; preds = %52
   %57 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %55, i32 0, i32 35
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %57, align 8
-  %NullCheck30 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %54, null
-  br i1 %NullCheck30, label %59, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %54, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %54, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %60, %System.String addrspace(1)* %58)
   %61 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %62 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck32 = icmp ne %System.Globalization.CultureData addrspace(1)* %62, null
-  br i1 %NullCheck32, label %63, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Globalization.CultureData addrspace(1)* %62, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %62, i32 0, i32 34
   %65 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %64, align 8
-  %NullCheck34 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %61, null
-  br i1 %NullCheck34, label %66, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %61, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %61, i32 0, i32 9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %67, %System.String addrspace(1)* %65)
   %68 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %69 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck36 = icmp ne %System.Globalization.CultureData addrspace(1)* %69, null
-  br i1 %NullCheck36, label %70, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Globalization.CultureData addrspace(1)* %69, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %70
 
 ; <label>:70                                      ; preds = %66
   %71 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %69, i32 0, i32 55
   %72 = load i32, i32 addrspace(1)* %71, align 8
-  %NullCheck38 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %68, null
-  br i1 %NullCheck38, label %73, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %68, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %68, i32 0, i32 22
   store i32 %72, i32 addrspace(1)* %74
   %75 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %76 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck40 = icmp ne %System.Globalization.CultureData addrspace(1)* %76, null
-  br i1 %NullCheck40, label %77, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Globalization.CultureData addrspace(1)* %76, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %76, i32 0, i32 57
   %79 = load i32, i32 addrspace(1)* %78, align 8
-  %NullCheck42 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %75, null
-  br i1 %NullCheck42, label %80, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %75, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %80
 
 ; <label>:80                                      ; preds = %77
   %81 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %75, i32 0, i32 24
   store i32 %79, i32 addrspace(1)* %81
   %82 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %83 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck44 = icmp ne %System.Globalization.CultureData addrspace(1)* %83, null
-  br i1 %NullCheck44, label %84, label %ThrowNullRef43
+  %NullCheck43 = icmp eq %System.Globalization.CultureData addrspace(1)* %83, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %84
 
 ; <label>:84                                      ; preds = %80
   %85 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %83, i32 0, i32 56
   %86 = load i32, i32 addrspace(1)* %85, align 8
-  %NullCheck46 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %82, null
-  br i1 %NullCheck46, label %87, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %82, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %82, i32 0, i32 23
@@ -13540,8 +15249,8 @@ entry:
 
 ; <label>:89                                      ; preds = %entry
   %90 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck100 = icmp ne %System.Globalization.CultureData addrspace(1)* %90, null
-  br i1 %NullCheck100, label %91, label %ThrowNullRef99
+  %NullCheck99 = icmp eq %System.Globalization.CultureData addrspace(1)* %90, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %91
 
 ; <label>:91                                      ; preds = %89
   %92 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %90, i32 0, i32 2
@@ -13559,8 +15268,8 @@ entry:
   %102 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %103 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %104 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %103)
-  %NullCheck48 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %102, null
-  br i1 %NullCheck48, label %105, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %102, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %105
 
 ; <label>:105                                     ; preds = %101
   %106 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %102, i32 0, i32 1
@@ -13568,8 +15277,8 @@ entry:
   %107 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %108 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %109 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %108)
-  %NullCheck50 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %107, null
-  br i1 %NullCheck50, label %110, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %107, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %110
 
 ; <label>:110                                     ; preds = %105
   %111 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %107, i32 0, i32 2
@@ -13577,8 +15286,8 @@ entry:
   %112 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %113 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %114 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %113)
-  %NullCheck52 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %112, null
-  br i1 %NullCheck52, label %115, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %112, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %115
 
 ; <label>:115                                     ; preds = %110
   %116 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %112, i32 0, i32 27
@@ -13586,8 +15295,8 @@ entry:
   %117 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %118 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %119 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %118)
-  %NullCheck54 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %117, null
-  br i1 %NullCheck54, label %120, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %117, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %120
 
 ; <label>:120                                     ; preds = %115
   %121 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %117, i32 0, i32 26
@@ -13595,8 +15304,8 @@ entry:
   %122 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %123 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %124 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %123)
-  %NullCheck56 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %122, null
-  br i1 %NullCheck56, label %125, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %122, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %125
 
 ; <label>:125                                     ; preds = %120
   %126 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %122, i32 0, i32 17
@@ -13604,8 +15313,8 @@ entry:
   %127 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %128 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %129 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %128)
-  %NullCheck58 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %127, null
-  br i1 %NullCheck58, label %130, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %127, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %130
 
 ; <label>:130                                     ; preds = %125
   %131 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %127, i32 0, i32 18
@@ -13613,8 +15322,8 @@ entry:
   %132 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %133 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %134 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %133)
-  %NullCheck60 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %132, null
-  br i1 %NullCheck60, label %135, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %132, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %135
 
 ; <label>:135                                     ; preds = %130
   %136 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %132, i32 0, i32 14
@@ -13622,8 +15331,8 @@ entry:
   %137 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %138 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %139 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %138)
-  %NullCheck62 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %137, null
-  br i1 %NullCheck62, label %140, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %137, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %140
 
 ; <label>:140                                     ; preds = %135
   %141 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %137, i32 0, i32 13
@@ -13631,71 +15340,71 @@ entry:
   %142 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %143 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %144 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %143)
-  %NullCheck64 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %142, null
-  br i1 %NullCheck64, label %145, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %142, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %145
 
 ; <label>:145                                     ; preds = %140
   %146 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %142, i32 0, i32 12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %146, %System.String addrspace(1)* %144)
   %147 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %148 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck66 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %148, null
-  br i1 %NullCheck66, label %149, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %148, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %149
 
 ; <label>:149                                     ; preds = %145
   %150 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %148, i32 0, i32 21
   %151 = load i32, i32 addrspace(1)* %150, align 8
-  %NullCheck68 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %147, null
-  br i1 %NullCheck68, label %152, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %147, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %152
 
 ; <label>:152                                     ; preds = %149
   %153 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %147, i32 0, i32 28
   store i32 %151, i32 addrspace(1)* %153
   %154 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %155 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck70 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %155, null
-  br i1 %NullCheck70, label %156, label %ThrowNullRef69
+  %NullCheck69 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %155, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %156
 
 ; <label>:156                                     ; preds = %152
   %157 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %155, i32 0, i32 6
   %158 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %157, align 8
-  %NullCheck72 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %154, null
-  br i1 %NullCheck72, label %159, label %ThrowNullRef71
+  %NullCheck71 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %154, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %159
 
 ; <label>:159                                     ; preds = %156
   %160 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %154, i32 0, i32 15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %160, %System.String addrspace(1)* %158)
   %161 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %162 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck74 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %162, null
-  br i1 %NullCheck74, label %163, label %ThrowNullRef73
+  %NullCheck73 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %162, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %163
 
 ; <label>:163                                     ; preds = %159
   %164 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %162, i32 0, i32 1
   %165 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %164, align 8
-  %NullCheck76 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %161, null
-  br i1 %NullCheck76, label %166, label %ThrowNullRef75
+  %NullCheck75 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %161, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %166
 
 ; <label>:166                                     ; preds = %163
   %167 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %161, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %167, %"System.Int32[]" addrspace(1)* %165)
   %168 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %169 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck78 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %169, null
-  br i1 %NullCheck78, label %170, label %ThrowNullRef77
+  %NullCheck77 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %169, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %170
 
 ; <label>:170                                     ; preds = %166
   %171 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %169, i32 0, i32 7
   %172 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %171, align 8
-  %NullCheck80 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %168, null
-  br i1 %NullCheck80, label %173, label %ThrowNullRef79
+  %NullCheck79 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %168, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %173
 
 ; <label>:173                                     ; preds = %170
   %174 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %168, i32 0, i32 16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %174, %System.String addrspace(1)* %172)
   %175 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck82 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %175, null
-  br i1 %NullCheck82, label %176, label %ThrowNullRef81
+  %NullCheck81 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %175, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %176
 
 ; <label>:176                                     ; preds = %173
   %177 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %175, i32 0, i32 4
@@ -13705,14 +15414,14 @@ entry:
 
 ; <label>:180                                     ; preds = %176
   %181 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck84 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %181, null
-  br i1 %NullCheck84, label %182, label %ThrowNullRef83
+  %NullCheck83 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %181, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %182
 
 ; <label>:182                                     ; preds = %180
   %183 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %181, i32 0, i32 4
   %184 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %183, align 8
-  %NullCheck86 = icmp ne %System.String addrspace(1)* %184, null
-  br i1 %NullCheck86, label %185, label %ThrowNullRef85
+  %NullCheck85 = icmp eq %System.String addrspace(1)* %184, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %185
 
 ; <label>:185                                     ; preds = %182
   %186 = getelementptr inbounds %System.String, %System.String addrspace(1)* %184, i32 0, i32 1
@@ -13723,8 +15432,8 @@ entry:
 ; <label>:189                                     ; preds = %176, %185
   %190 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck98 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %190, null
-  br i1 %NullCheck98, label %192, label %ThrowNullRef97
+  %NullCheck97 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %190, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %192
 
 ; <label>:192                                     ; preds = %189
   %193 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %190, i32 0, i32 4
@@ -13733,8 +15442,8 @@ entry:
 
 ; <label>:194                                     ; preds = %185, %192
   %195 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck88 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %195, null
-  br i1 %NullCheck88, label %196, label %ThrowNullRef87
+  %NullCheck87 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %195, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %196
 
 ; <label>:196                                     ; preds = %194
   %197 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %195, i32 0, i32 9
@@ -13744,14 +15453,14 @@ entry:
 
 ; <label>:200                                     ; preds = %196
   %201 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck90 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %201, null
-  br i1 %NullCheck90, label %202, label %ThrowNullRef89
+  %NullCheck89 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %201, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %202
 
 ; <label>:202                                     ; preds = %200
   %203 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %201, i32 0, i32 9
   %204 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %203, align 8
-  %NullCheck92 = icmp ne %System.String addrspace(1)* %204, null
-  br i1 %NullCheck92, label %205, label %ThrowNullRef91
+  %NullCheck91 = icmp eq %System.String addrspace(1)* %204, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %205
 
 ; <label>:205                                     ; preds = %202
   %206 = getelementptr inbounds %System.String, %System.String addrspace(1)* %204, i32 0, i32 1
@@ -13762,14 +15471,14 @@ entry:
 ; <label>:209                                     ; preds = %196, %205
   %210 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %211 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck94 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %211, null
-  br i1 %NullCheck94, label %212, label %ThrowNullRef93
+  %NullCheck93 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %211, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %212
 
 ; <label>:212                                     ; preds = %209
   %213 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %211, i32 0, i32 6
   %214 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %213, align 8
-  %NullCheck96 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %210, null
-  br i1 %NullCheck96, label %215, label %ThrowNullRef95
+  %NullCheck95 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %210, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %215
 
 ; <label>:215                                     ; preds = %212
   %216 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %210, i32 0, i32 9
@@ -13783,203 +15492,203 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %17
+ThrowNullRef8:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %21
+ThrowNullRef10:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %24
+ThrowNullRef12:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %28
+ThrowNullRef14:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %31
+ThrowNullRef16:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %35
+ThrowNullRef18:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %38
+ThrowNullRef20:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %42
+ThrowNullRef22:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %45
+ThrowNullRef24:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %49
+ThrowNullRef26:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %52
+ThrowNullRef28:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %56
+ThrowNullRef30:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %59
+ThrowNullRef32:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %63
+ThrowNullRef34:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %66
+ThrowNullRef36:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %70
+ThrowNullRef38:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %73
+ThrowNullRef40:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %77
+ThrowNullRef42:                                   ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %80
+ThrowNullRef44:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %84
+ThrowNullRef46:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %101
+ThrowNullRef48:                                   ; preds = %101
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %105
+ThrowNullRef50:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %110
+ThrowNullRef52:                                   ; preds = %110
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %115
+ThrowNullRef54:                                   ; preds = %115
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %120
+ThrowNullRef56:                                   ; preds = %120
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %125
+ThrowNullRef58:                                   ; preds = %125
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %130
+ThrowNullRef60:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %135
+ThrowNullRef62:                                   ; preds = %135
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %140
+ThrowNullRef64:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %145
+ThrowNullRef66:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %149
+ThrowNullRef68:                                   ; preds = %149
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %152
+ThrowNullRef70:                                   ; preds = %152
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %156
+ThrowNullRef72:                                   ; preds = %156
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %159
+ThrowNullRef74:                                   ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %163
+ThrowNullRef76:                                   ; preds = %163
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %166
+ThrowNullRef78:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %170
+ThrowNullRef80:                                   ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %173
+ThrowNullRef82:                                   ; preds = %173
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %180
+ThrowNullRef84:                                   ; preds = %180
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %182
+ThrowNullRef86:                                   ; preds = %182
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %194
+ThrowNullRef88:                                   ; preds = %194
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %200
+ThrowNullRef90:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %202
+ThrowNullRef92:                                   ; preds = %202
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %209
+ThrowNullRef94:                                   ; preds = %209
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %212
+ThrowNullRef96:                                   ; preds = %212
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %189
+ThrowNullRef98:                                   ; preds = %189
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %89
+ThrowNullRef100:                                  ; preds = %89
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14007,8 +15716,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 21
@@ -14021,8 +15730,8 @@ entry:
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 16)
   %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 21
@@ -14031,8 +15740,8 @@ entry:
 
 ; <label>:12                                      ; preds = %1, %10
   %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 21
@@ -14043,11 +15752,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %12
+ThrowNullRef4:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14063,8 +15772,8 @@ entry:
   store i32 %param1, i32* %arg1
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %1 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
@@ -14131,8 +15840,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 33
@@ -14145,8 +15854,8 @@ entry:
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 24)
   %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 33
@@ -14155,8 +15864,8 @@ entry:
 
 ; <label>:12                                      ; preds = %1, %10
   %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 33
@@ -14167,11 +15876,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %12
+ThrowNullRef4:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14184,8 +15893,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 53
@@ -14197,8 +15906,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 116)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 53
@@ -14207,8 +15916,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 53
@@ -14219,11 +15928,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14252,8 +15961,8 @@ entry:
 
 ; <label>:7                                       ; preds = %entry, %4
   %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %7
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 2
@@ -14277,8 +15986,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 54
@@ -14290,8 +15999,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 117)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
@@ -14300,8 +16009,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 54
@@ -14312,11 +16021,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14329,8 +16038,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 27
@@ -14342,8 +16051,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 118)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 27
@@ -14352,8 +16061,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 27
@@ -14364,11 +16073,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14381,8 +16090,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 28
@@ -14394,8 +16103,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 119)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 28
@@ -14404,8 +16113,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 28
@@ -14416,11 +16125,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14433,8 +16142,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 26
@@ -14446,8 +16155,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 107)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 26
@@ -14456,8 +16165,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 26
@@ -14468,11 +16177,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14485,8 +16194,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 25
@@ -14498,8 +16207,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 106)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 25
@@ -14508,8 +16217,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 25
@@ -14520,11 +16229,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14537,8 +16246,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 24
@@ -14550,8 +16259,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 105)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 24
@@ -14560,8 +16269,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 24
@@ -14572,11 +16281,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14601,8 +16310,8 @@ entry:
   %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %3)
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %2
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -14613,15 +16322,15 @@ entry:
 
 ; <label>:8                                       ; preds = %62
   %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 9
   %12 = load i32, i32 addrspace(1)* %11, align 8
   %13 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.IO.StreamWriter addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %13, i32 0, i32 10
@@ -14636,15 +16345,15 @@ entry:
 
 ; <label>:20                                      ; preds = %14, %18
   %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
   %24 = load i32, i32 addrspace(1)* %23, align 8
   %25 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %25, null
-  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.StreamWriter addrspace(1)* %25, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %25, i32 0, i32 9
@@ -14665,36 +16374,36 @@ entry:
   %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %37 = load i32, i32* %loc1
   %38 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.StreamWriter addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %35
   %40 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %38, i32 0, i32 7
   %41 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %40, align 8
   %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
-  br i1 %NullCheck14, label %43, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %39
   %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 9
   %45 = load i32, i32 addrspace(1)* %44, align 8
   %46 = load i32, i32* %loc2
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %36, null
-  br i1 %NullCheck16, label %47, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %36, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %47
 
 ; <label>:47                                      ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %36, i32 %37, %"System.Char[]" addrspace(1)* %41, i32 %45, i32 %46)
   %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
   %51 = load i32, i32 addrspace(1)* %50, align 8
   %52 = load i32, i32* %loc2
   %53 = add i32 %51, %52
-  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
-  br i1 %NullCheck20, label %54, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %54
 
 ; <label>:54                                      ; preds = %49
   %55 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
@@ -14716,8 +16425,8 @@ entry:
 
 ; <label>:65                                      ; preds = %62
   %66 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %66, null
-  br i1 %NullCheck2, label %67, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %66, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %67
 
 ; <label>:67                                      ; preds = %65
   %68 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %66, i32 0, i32 11
@@ -14738,49 +16447,259 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %65
+ThrowNullRef2:                                    ; preds = %65
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %20
+ThrowNullRef8:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %22
+ThrowNullRef10:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %35
+ThrowNullRef12:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %43
+ThrowNullRef16:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %47
+ThrowNullRef18:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method String::CopyTo using LLILCJit
-Failed to read String.CopyTo[loadElemA]
+Successfully read String.CopyTo
+
+define void @String.CopyTo(%System.String addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  %loc1 = alloca i16 addrspace(1)*
+  %loc2 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %1 = icmp ne %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg4
+  %7 = icmp sge i32 %6, 0
+  br i1 %7, label %13, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  unreachable
+
+; <label>:13                                      ; preds = %5
+  %14 = load i32, i32* %arg1
+  %15 = icmp sge i32 %14, 0
+  br i1 %15, label %21, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %18)
+  %20 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %20, %System.String addrspace(1)* %17, %System.String addrspace(1)* %19)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %20) #0
+  unreachable
+
+; <label>:21                                      ; preds = %13
+  %22 = load i32, i32* %arg4
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck, label %ThrowNullRef, label %24
+
+; <label>:24                                      ; preds = %21
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load i32, i32* %arg1
+  %28 = sub i32 %26, %27
+  %29 = icmp sle i32 %22, %28
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34, %System.String addrspace(1)* %31, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %24
+  %36 = load i32, i32* %arg3
+  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %37, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
+
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
+  %40 = load i32, i32 addrspace(1)* %39
+  %41 = zext i32 %40 to i64
+  %42 = trunc i64 %41 to i32
+  %43 = load i32, i32* %arg4
+  %44 = sub i32 %42, %43
+  %45 = icmp sgt i32 %36, %44
+  br i1 %45, label %49, label %46
+
+; <label>:46                                      ; preds = %38
+  %47 = load i32, i32* %arg3
+  %48 = icmp sge i32 %47, 0
+  br i1 %48, label %54, label %49
+
+; <label>:49                                      ; preds = %38, %46
+  %50 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %52 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %51)
+  %53 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53, %System.String addrspace(1)* %50, %System.String addrspace(1)* %52)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53) #0
+  unreachable
+
+; <label>:54                                      ; preds = %46
+  %55 = load i32, i32* %arg4
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %97, label %57
+
+; <label>:57                                      ; preds = %54
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %59
+
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 2
+  %61 = bitcast [0 x i16] addrspace(1)* %60 to i16 addrspace(1)*
+  store i16 addrspace(1)* %61, i16 addrspace(1)** %loc0
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  store %"System.Char[]" addrspace(1)* %62, %"System.Char[]" addrspace(1)** %loc2
+  %63 = icmp eq %"System.Char[]" addrspace(1)* %62, null
+  br i1 %63, label %72, label %64
+
+; <label>:64                                      ; preds = %59
+  %65 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc2
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %65, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %66
+
+; <label>:66                                      ; preds = %64
+  %67 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %65, i32 0, i32 1
+  %68 = load i32, i32 addrspace(1)* %67
+  %69 = zext i32 %68 to i64
+  %70 = trunc i64 %69 to i32
+  %71 = icmp ne i32 %70, 0
+  br i1 %71, label %73, label %72
+
+; <label>:72                                      ; preds = %59, %66
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  br label %81
+
+; <label>:73                                      ; preds = %66
+  %74 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc2
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %74, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %75
+
+; <label>:75                                      ; preds = %73
+  %76 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %74, i32 0, i32 1
+  %77 = load i32, i32 addrspace(1)* %76
+  %78 = zext i32 %77 to i64
+  %BoundsCheck = icmp uge i64 0, %78
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %79
+
+; <label>:79                                      ; preds = %75
+  %80 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %74, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %80, i16 addrspace(1)** %loc1
+  br label %81
+
+; <label>:81                                      ; preds = %72, %79
+  %82 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %83 = ptrtoint i16 addrspace(1)* %82 to i64
+  %84 = load i32, i32* %arg3
+  %85 = sext i32 %84 to i64
+  %86 = mul i64 %85, 2
+  %87 = add i64 %83, %86
+  %88 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %89 = ptrtoint i16 addrspace(1)* %88 to i64
+  %90 = load i32, i32* %arg1
+  %91 = sext i32 %90 to i64
+  %92 = mul i64 %91, 2
+  %93 = add i64 %89, %92
+  %94 = load i32, i32* %arg4
+  %95 = inttoptr i64 %87 to i16*
+  %96 = inttoptr i64 %93 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %95, i16* %96, i32 %94)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  br label %97
+
+; <label>:97                                      ; preds = %54, %81
+  ret void
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
 Successfully read ConsoleEncoding.GetPreamble
 
@@ -14817,7 +16736,365 @@ entry:
 }
 
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[loadElemA]
+Successfully read EncoderNLS.GetBytes
+
+define i32 @EncoderNLS.GetBytes(%System.Text.EncoderNLS addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3, %"System.Byte[]" addrspace(1)* %param4, i32 %param5, i8 %param6) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %arg4 = alloca %"System.Byte[]" addrspace(1)*
+  %arg5 = alloca i32
+  %arg6 = alloca i8
+  %loc0 = alloca i32
+  %loc1 = alloca i16 addrspace(1)*
+  %loc2 = alloca i8 addrspace(1)*
+  %loc3 = alloca i32
+  %loc4 = alloca %"System.Char[]" addrspace(1)*
+  %loc5 = alloca %"System.Byte[]" addrspace(1)*
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  store %"System.Byte[]" addrspace(1)* %param4, %"System.Byte[]" addrspace(1)** %arg4
+  store i32 %param5, i32* %arg5
+  store i8 %param6, i8* %arg6
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %1 = icmp eq %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %17, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %7 = icmp eq %"System.Char[]" addrspace(1)* %6, null
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %12
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %12
+
+; <label>:12                                      ; preds = %8, %10
+  %13 = phi %System.String addrspace(1)* [ %9, %8 ], [ %11, %10 ]
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %14)
+  %16 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16, %System.String addrspace(1)* %13, %System.String addrspace(1)* %15)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16) #0
+  unreachable
+
+; <label>:17                                      ; preds = %2
+  %18 = load i32, i32* %arg2
+  %19 = icmp slt i32 %18, 0
+  br i1 %19, label %23, label %20
+
+; <label>:20                                      ; preds = %17
+  %21 = load i32, i32* %arg3
+  %22 = icmp sge i32 %21, 0
+  br i1 %22, label %35, label %23
+
+; <label>:23                                      ; preds = %17, %20
+  %24 = load i32, i32* %arg2
+  %25 = icmp slt i32 %24, 0
+  br i1 %25, label %28, label %26
+
+; <label>:26                                      ; preds = %23
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %30
+
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %30
+
+; <label>:30                                      ; preds = %26, %28
+  %31 = phi %System.String addrspace(1)* [ %27, %26 ], [ %29, %28 ]
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34, %System.String addrspace(1)* %31, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %20
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck, label %ThrowNullRef, label %37
+
+; <label>:37                                      ; preds = %35
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = load i32, i32* %arg2
+  %43 = sub i32 %41, %42
+  %44 = load i32, i32* %arg3
+  %45 = icmp sge i32 %43, %44
+  br i1 %45, label %51, label %46
+
+; <label>:46                                      ; preds = %37
+  %47 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %48 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %49 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %48)
+  %50 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %50, %System.String addrspace(1)* %47, %System.String addrspace(1)* %49)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %50) #0
+  unreachable
+
+; <label>:51                                      ; preds = %37
+  %52 = load i32, i32* %arg5
+  %53 = icmp slt i32 %52, 0
+  br i1 %53, label %63, label %54
+
+; <label>:54                                      ; preds = %51
+  %55 = load i32, i32* %arg5
+  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck1 = icmp eq %"System.Byte[]" addrspace(1)* %56, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %57
+
+; <label>:57                                      ; preds = %54
+  %58 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = zext i32 %59 to i64
+  %61 = trunc i64 %60 to i32
+  %62 = icmp sle i32 %55, %61
+  br i1 %62, label %68, label %63
+
+; <label>:63                                      ; preds = %51, %57
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %66 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %65)
+  %67 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %67, %System.String addrspace(1)* %64, %System.String addrspace(1)* %66)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %67) #0
+  unreachable
+
+; <label>:68                                      ; preds = %57
+  %69 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %69, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %69, i32 0, i32 1
+  %72 = load i32, i32 addrspace(1)* %71
+  %73 = zext i32 %72 to i64
+  %74 = trunc i64 %73 to i32
+  %75 = icmp ne i32 %74, 0
+  br i1 %75, label %78, label %76
+
+; <label>:76                                      ; preds = %70
+  %77 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1)
+  store %"System.Char[]" addrspace(1)* %77, %"System.Char[]" addrspace(1)** %arg1
+  br label %78
+
+; <label>:78                                      ; preds = %70, %76
+  %79 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck5 = icmp eq %"System.Byte[]" addrspace(1)* %79, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %80
+
+; <label>:80                                      ; preds = %78
+  %81 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %79, i32 0, i32 1
+  %82 = load i32, i32 addrspace(1)* %81
+  %83 = zext i32 %82 to i64
+  %84 = trunc i64 %83 to i32
+  %85 = load i32, i32* %arg5
+  %86 = sub i32 %84, %85
+  store i32 %86, i32* %loc0
+  %87 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck7 = icmp eq %"System.Byte[]" addrspace(1)* %87, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %88
+
+; <label>:88                                      ; preds = %80
+  %89 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %87, i32 0, i32 1
+  %90 = load i32, i32 addrspace(1)* %89
+  %91 = zext i32 %90 to i64
+  %92 = trunc i64 %91 to i32
+  %93 = icmp ne i32 %92, 0
+  br i1 %93, label %96, label %94
+
+; <label>:94                                      ; preds = %88
+  %95 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1)
+  store %"System.Byte[]" addrspace(1)* %95, %"System.Byte[]" addrspace(1)** %arg4
+  br label %96
+
+; <label>:96                                      ; preds = %88, %94
+  %97 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  store %"System.Char[]" addrspace(1)* %97, %"System.Char[]" addrspace(1)** %loc4
+  %98 = icmp eq %"System.Char[]" addrspace(1)* %97, null
+  br i1 %98, label %107, label %99
+
+; <label>:99                                      ; preds = %96
+  %100 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc4
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %100, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %101
+
+; <label>:101                                     ; preds = %99
+  %102 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %100, i32 0, i32 1
+  %103 = load i32, i32 addrspace(1)* %102
+  %104 = zext i32 %103 to i64
+  %105 = trunc i64 %104 to i32
+  %106 = icmp ne i32 %105, 0
+  br i1 %106, label %108, label %107
+
+; <label>:107                                     ; preds = %96, %101
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  br label %116
+
+; <label>:108                                     ; preds = %101
+  %109 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc4
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %109, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %110
+
+; <label>:110                                     ; preds = %108
+  %111 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %109, i32 0, i32 1
+  %112 = load i32, i32 addrspace(1)* %111
+  %113 = zext i32 %112 to i64
+  %BoundsCheck = icmp uge i64 0, %113
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %114
+
+; <label>:114                                     ; preds = %110
+  %115 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %109, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %115, i16 addrspace(1)** %loc1
+  br label %116
+
+; <label>:116                                     ; preds = %107, %114
+  %117 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  store %"System.Byte[]" addrspace(1)* %117, %"System.Byte[]" addrspace(1)** %loc5
+  %118 = icmp eq %"System.Byte[]" addrspace(1)* %117, null
+  br i1 %118, label %127, label %119
+
+; <label>:119                                     ; preds = %116
+  %120 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc5
+  %NullCheck13 = icmp eq %"System.Byte[]" addrspace(1)* %120, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %121
+
+; <label>:121                                     ; preds = %119
+  %122 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %120, i32 0, i32 1
+  %123 = load i32, i32 addrspace(1)* %122
+  %124 = zext i32 %123 to i64
+  %125 = trunc i64 %124 to i32
+  %126 = icmp ne i32 %125, 0
+  br i1 %126, label %128, label %127
+
+; <label>:127                                     ; preds = %116, %121
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc2
+  br label %136
+
+; <label>:128                                     ; preds = %121
+  %129 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc5
+  %NullCheck15 = icmp eq %"System.Byte[]" addrspace(1)* %129, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %130
+
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %129, i32 0, i32 1
+  %132 = load i32, i32 addrspace(1)* %131
+  %133 = zext i32 %132 to i64
+  %BoundsCheck17 = icmp uge i64 0, %133
+  br i1 %BoundsCheck17, label %ThrowIndexOutOfRange18, label %134
+
+; <label>:134                                     ; preds = %130
+  %135 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %129, i32 0, i32 3, i32 0
+  store i8 addrspace(1)* %135, i8 addrspace(1)** %loc2
+  br label %136
+
+; <label>:136                                     ; preds = %127, %134
+  %137 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %138 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %139 = ptrtoint i16 addrspace(1)* %138 to i64
+  %140 = load i32, i32* %arg2
+  %141 = sext i32 %140 to i64
+  %142 = mul i64 %141, 2
+  %143 = add i64 %139, %142
+  %144 = load i32, i32* %arg3
+  %145 = load i8 addrspace(1)*, i8 addrspace(1)** %loc2
+  %146 = ptrtoint i8 addrspace(1)* %145 to i64
+  %147 = load i32, i32* %arg5
+  %148 = sext i32 %147 to i64
+  %149 = add i64 %146, %148
+  %150 = load i32, i32* %loc0
+  %151 = load i8, i8* %arg6
+  %152 = zext i8 %151 to i32
+  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i64 addrspace(1)*
+  %NullCheck19 = icmp eq i64 addrspace(1)* %153, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %154
+
+; <label>:154                                     ; preds = %136
+  %155 = load i64, i64 addrspace(1)* %153
+  %156 = add i64 %155, 72
+  %157 = inttoptr i64 %156 to i64*
+  %158 = load i64, i64* %157
+  %159 = add i64 %158, 0
+  %160 = inttoptr i64 %159 to i64*
+  %161 = load i64, i64* %160
+  %162 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to %System.Text.Encoder addrspace(1)*
+  %163 = inttoptr i64 %143 to i16*
+  %164 = inttoptr i64 %149 to i8*
+  %165 = trunc i32 %152 to i8
+  %166 = inttoptr i64 %161 to i32 (%System.Text.Encoder addrspace(1)*, i16*, i32, i8*, i32, i8)*
+  %167 = call i32 %166(%System.Text.Encoder addrspace(1)* %162, i16* %163, i32 %144, i8* %164, i32 %150, i8 %165)
+  store i32 %167, i32* %loc3
+  br label %168
+
+; <label>:168                                     ; preds = %154
+  %169 = load i32, i32* %loc3
+  ret i32 %169
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %110
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %119
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange18:                           ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
 Successfully read EncoderNLS.GetBytes
 
@@ -14906,22 +17183,22 @@ entry:
   %40 = load i8, i8* %arg5
   %41 = zext i8 %40 to i32
   %42 = trunc i32 %41 to i8
-  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %39, null
-  br i1 %NullCheck, label %43, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderNLS addrspace(1)* %39, null
+  br i1 %NullCheck, label %ThrowNullRef, label %43
 
 ; <label>:43                                      ; preds = %38
   %44 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
   store i8 %42, i8 addrspace(1)* %44
   %45 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %45, null
-  br i1 %NullCheck2, label %46, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.EncoderNLS addrspace(1)* %45, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %46
 
 ; <label>:46                                      ; preds = %43
   %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %45, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %47
   %48 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.EncoderNLS addrspace(1)* %48, null
-  br i1 %NullCheck4, label %49, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.EncoderNLS addrspace(1)* %48, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %49
 
 ; <label>:49                                      ; preds = %46
   %50 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %48, i32 0, i32 3
@@ -14932,8 +17209,8 @@ entry:
   %55 = load i32, i32* %arg4
   %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck6, label %58, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
   %59 = load i64, i64 addrspace(1)* %57
@@ -14951,15 +17228,15 @@ ThrowNullRef:                                     ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %43
+ThrowNullRef2:                                    ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %46
+ThrowNullRef4:                                    ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %49
+ThrowNullRef6:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14987,8 +17264,8 @@ entry:
   %4 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0 to %System.IO.ConsoleStream addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*)(%System.IO.ConsoleStream addrspace(1)* %4, %"System.Byte[]" addrspace(1)* %1, i32 %2, i32 %3)
   %5 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
@@ -15073,8 +17350,8 @@ entry:
 
 ; <label>:22                                      ; preds = %8
   %23 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %23, null
-  br i1 %NullCheck, label %24, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Byte[]" addrspace(1)* %23, null
+  br i1 %NullCheck, label %ThrowNullRef, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
@@ -15096,8 +17373,8 @@ entry:
 
 ; <label>:36                                      ; preds = %24
   %37 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %37, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.ConsoleStream addrspace(1)* %37, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %37, i32 0, i32 4
@@ -15118,13 +17395,138 @@ ThrowNullRef:                                     ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %36
+ThrowNullRef2:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
-Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
+Successfully read WindowsConsoleStream.WriteFileNative
+
+define i32 @WindowsConsoleStream.WriteFileNative(i64 %param0, %"System.Byte[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i64
+  %arg1 = alloca %"System.Byte[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i8 addrspace(1)*
+  %loc2 = alloca %"System.Byte[]" addrspace(1)*
+  %loc3 = alloca i32
+  store i64 %param0, i64* %arg0
+  store %"System.Byte[]" addrspace(1)* %param1, %"System.Byte[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Byte[]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = zext i32 %3 to i64
+  %5 = icmp ne i64 %4, 0
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %1
+  ret i32 0
+
+; <label>:7                                       ; preds = %1
+  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  store %"System.Byte[]" addrspace(1)* %8, %"System.Byte[]" addrspace(1)** %loc2
+  %9 = icmp eq %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %9, label %18, label %10
+
+; <label>:10                                      ; preds = %7
+  %11 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc2
+  %NullCheck1 = icmp eq %"System.Byte[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %11, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp ne i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %7, %12
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc1
+  br label %27
+
+; <label>:19                                      ; preds = %12
+  %20 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc2
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %20, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %BoundsCheck = icmp uge i64 0, %24
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %25
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %20, i32 0, i32 3, i32 0
+  store i8 addrspace(1)* %26, i8 addrspace(1)** %loc1
+  br label %27
+
+; <label>:27                                      ; preds = %18, %25
+  %28 = load i64, i64* %arg0
+  %29 = load i8 addrspace(1)*, i8 addrspace(1)** %loc1
+  %30 = ptrtoint i8 addrspace(1)* %29 to i64
+  %31 = load i32, i32* %arg2
+  %32 = sext i32 %31 to i64
+  %33 = add i64 %30, %32
+  %34 = load i32, i32* %arg3
+  %35 = addrspacecast i32* %loc3 to i32 addrspace(1)*
+  %36 = inttoptr i64 %33 to i8*
+  %37 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i8*, i32, i32 addrspace(1)*, i64)*)(i64 %28, i8* %36, i32 %34, i32 addrspace(1)* %35, i64 0)
+  %38 = icmp ugt i32 %37, 0
+  %39 = sext i1 %38 to i32
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc1
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %42, label %41
+
+; <label>:41                                      ; preds = %27
+  ret i32 0
+
+; <label>:42                                      ; preds = %27
+  %43 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  store i32 %43, i32* %loc0
+  %44 = load i32, i32* %loc0
+  %45 = icmp eq i32 %44, 232
+  br i1 %45, label %49, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = load i32, i32* %loc0
+  %48 = icmp ne i32 %47, 109
+  br i1 %48, label %50, label %49
+
+; <label>:49                                      ; preds = %42, %46
+  ret i32 0
+
+; <label>:50                                      ; preds = %46
+  %51 = load i32, i32* %loc0
+  ret i32 %51
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
 Successfully read WindowsConsoleStream.Flush
 
@@ -15133,8 +17535,8 @@ entry:
   %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
   store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
@@ -15169,8 +17571,8 @@ entry:
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
   %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load i64, i64 addrspace(1)* %1
@@ -15209,15 +17611,15 @@ entry:
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.TextWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
   %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %3, align 8
   %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
   %7 = load i64, i64 addrspace(1)* %5
@@ -15235,7 +17637,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -15264,8 +17666,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %4)
   store i32 0, i32* %loc0
   %5 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Char[]" addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
@@ -15277,15 +17679,15 @@ entry:
 
 ; <label>:11                                      ; preds = %69
   %12 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %12, i32 0, i32 9
   %15 = load i32, i32 addrspace(1)* %14, align 8
   %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.IO.StreamWriter addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %16, i32 0, i32 10
@@ -15300,15 +17702,15 @@ entry:
 
 ; <label>:23                                      ; preds = %17, %21
   %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %24, null
-  br i1 %NullCheck8, label %25, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %24, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 10
   %27 = load i32, i32 addrspace(1)* %26, align 8
   %28 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %28, null
-  br i1 %NullCheck10, label %29, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.StreamWriter addrspace(1)* %28, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %28, i32 0, i32 9
@@ -15330,15 +17732,15 @@ entry:
   %40 = load i32, i32* %loc0
   %41 = mul i32 %40, 2
   %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
-  br i1 %NullCheck12, label %43, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %43
 
 ; <label>:43                                      ; preds = %38
   %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 7
   %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %44, align 8
   %46 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %46, null
-  br i1 %NullCheck14, label %47, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.IO.StreamWriter addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %47
 
 ; <label>:47                                      ; preds = %43
   %48 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %46, i32 0, i32 9
@@ -15350,16 +17752,16 @@ entry:
   %54 = bitcast %"System.Char[]" addrspace(1)* %45 to %System.Array addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %53, i32 %41, %System.Array addrspace(1)* %54, i32 %50, i32 %52)
   %55 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
-  br i1 %NullCheck16, label %56, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %56
 
 ; <label>:56                                      ; preds = %47
   %57 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
   %58 = load i32, i32 addrspace(1)* %57, align 8
   %59 = load i32, i32* %loc2
   %60 = add i32 %58, %59
-  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
-  br i1 %NullCheck18, label %61, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %61
 
 ; <label>:61                                      ; preds = %56
   %62 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
@@ -15381,8 +17783,8 @@ entry:
 
 ; <label>:72                                      ; preds = %69
   %73 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %73, null
-  br i1 %NullCheck2, label %74, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %73, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %74
 
 ; <label>:74                                      ; preds = %72
   %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %73, i32 0, i32 11
@@ -15403,39 +17805,39 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %72
+ThrowNullRef2:                                    ; preds = %72
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %23
+ThrowNullRef8:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef10:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %43
+ThrowNullRef14:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %47
+ThrowNullRef16:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %56
+ThrowNullRef18:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -15486,8 +17888,8 @@ entry:
 ; <label>:17                                      ; preds = %11, %14
   %18 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
   %19 = bitcast %System.Object addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = load i64, i64 addrspace(1)* %19
@@ -15501,8 +17903,8 @@ entry:
   %29 = call %System.String addrspace(1)* %28(%System.Object addrspace(1)* %18)
   %30 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %31 = bitcast %System.Object addrspace(1)* %30 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %31, null
-  br i1 %NullCheck2, label %32, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %20
   %33 = load i64, i64 addrspace(1)* %31
@@ -15516,8 +17918,8 @@ entry:
   %41 = call %System.String addrspace(1)* %40(%System.Object addrspace(1)* %30)
   %42 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg2
   %43 = bitcast %System.Object addrspace(1)* %42 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %43, null
-  br i1 %NullCheck4, label %44, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %43, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %44
 
 ; <label>:44                                      ; preds = %32
   %45 = load i64, i64 addrspace(1)* %43
@@ -15536,11 +17938,11 @@ ThrowNullRef:                                     ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %20
+ThrowNullRef2:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %32
+ThrowNullRef4:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -15554,8 +17956,8 @@ entry:
   store %System.Single addrspace(1)* %param0, %System.Single addrspace(1)** %this
   %0 = load %System.Single addrspace(1)*, %System.Single addrspace(1)** %this
   %1 = bitcast %System.Single addrspace(1)* %0 to float addrspace(1)*
-  %NullCheck = icmp ne float addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq float addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load float, float addrspace(1)* %1, align 8
@@ -15644,23 +18046,23 @@ entry:
 
 ; <label>:25                                      ; preds = %20, %23
   %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck, label %27, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %26, null
+  br i1 %NullCheck, label %ThrowNullRef, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
   %29 = load i32, i32 addrspace(1)* %28
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck2, label %31, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %31
 
 ; <label>:31                                      ; preds = %27
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
   %33 = load i32, i32 addrspace(1)* %32
   %34 = add i32 %29, %33
   %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %35, null
-  br i1 %NullCheck4, label %36, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %35, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %36
 
 ; <label>:36                                      ; preds = %31
   %37 = getelementptr inbounds %System.String, %System.String addrspace(1)* %35, i32 0, i32 1
@@ -15675,8 +18077,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %42, i32 0, %System.String addrspace(1)* %43)
   %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
   %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %45, null
-  br i1 %NullCheck6, label %46, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %45, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %46
 
 ; <label>:46                                      ; preds = %36
   %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 1
@@ -15685,15 +18087,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %44, i32 %48, %System.String addrspace(1)* %49)
   %50 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck8, label %52, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %52
 
 ; <label>:52                                      ; preds = %46
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
   %54 = load i32, i32 addrspace(1)* %53
   %55 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %55, null
-  br i1 %NullCheck10, label %56, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %55, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %56
 
 ; <label>:56                                      ; preds = %52
   %57 = getelementptr inbounds %System.String, %System.String addrspace(1)* %55, i32 0, i32 1
@@ -15708,23 +18110,23 @@ ThrowNullRef:                                     ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %27
+ThrowNullRef2:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %31
+ThrowNullRef4:                                    ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %36
+ThrowNullRef6:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %46
+ThrowNullRef8:                                    ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %52
+ThrowNullRef10:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -15739,8 +18141,8 @@ entry:
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -15772,8 +18174,8 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   store i8 0, i8* %loc1
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
@@ -15783,16 +18185,16 @@ entry:
   %5 = addrspacecast i8* %loc1 to i8 addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %4, i8 addrspace(1)* %5)
   %6 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.SyncTextWriter addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
   %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
   %13 = load i64, i64 addrspace(1)* %11
@@ -15827,17 +18229,17 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
-Failed to read TextWriter.WriteLine[loadElem]
+Failed to read TextWriter.WriteLine[storeElem]
 INFO:  jitting method StreamWriter::Write using LLILCJit
 Successfully read StreamWriter.Write
 
@@ -15895,8 +18297,8 @@ entry:
 
 ; <label>:23                                      ; preds = %15
   %24 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Char[]" addrspace(1)* %24, null
-  br i1 %NullCheck, label %25, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %24, null
+  br i1 %NullCheck, label %ThrowNullRef, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %24, i32 0, i32 1
@@ -15924,15 +18326,15 @@ entry:
 
 ; <label>:40                                      ; preds = %98
   %41 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %41, null
-  br i1 %NullCheck4, label %42, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %41, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %42
 
 ; <label>:42                                      ; preds = %40
   %43 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
   %44 = load i32, i32 addrspace(1)* %43, align 8
   %45 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %45, null
-  br i1 %NullCheck6, label %46, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.IO.StreamWriter addrspace(1)* %45, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %46
 
 ; <label>:46                                      ; preds = %42
   %47 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %45, i32 0, i32 10
@@ -15947,15 +18349,15 @@ entry:
 
 ; <label>:52                                      ; preds = %46, %50
   %53 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %53, null
-  br i1 %NullCheck8, label %54, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %53, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %54
 
 ; <label>:54                                      ; preds = %52
   %55 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %53, i32 0, i32 10
   %56 = load i32, i32 addrspace(1)* %55, align 8
   %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %57, null
-  br i1 %NullCheck10, label %58, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.StreamWriter addrspace(1)* %57, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %58
 
 ; <label>:58                                      ; preds = %54
   %59 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 9
@@ -15977,15 +18379,15 @@ entry:
   %69 = load i32, i32* %arg2
   %70 = mul i32 %69, 2
   %71 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %71, null
-  br i1 %NullCheck12, label %72, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.StreamWriter addrspace(1)* %71, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %72
 
 ; <label>:72                                      ; preds = %67
   %73 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %71, i32 0, i32 7
   %74 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %73, align 8
   %75 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %75, null
-  br i1 %NullCheck14, label %76, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.IO.StreamWriter addrspace(1)* %75, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %76
 
 ; <label>:76                                      ; preds = %72
   %77 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %75, i32 0, i32 9
@@ -15997,16 +18399,16 @@ entry:
   %83 = bitcast %"System.Char[]" addrspace(1)* %74 to %System.Array addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %82, i32 %70, %System.Array addrspace(1)* %83, i32 %79, i32 %81)
   %84 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %84, null
-  br i1 %NullCheck16, label %85, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.IO.StreamWriter addrspace(1)* %84, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %85
 
 ; <label>:85                                      ; preds = %76
   %86 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %84, i32 0, i32 9
   %87 = load i32, i32 addrspace(1)* %86, align 8
   %88 = load i32, i32* %loc0
   %89 = add i32 %87, %88
-  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %84, null
-  br i1 %NullCheck18, label %90, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.StreamWriter addrspace(1)* %84, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %90
 
 ; <label>:90                                      ; preds = %85
   %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %84, i32 0, i32 9
@@ -16028,8 +18430,8 @@ entry:
 
 ; <label>:101                                     ; preds = %98
   %102 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %102, null
-  br i1 %NullCheck2, label %103, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %102, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %103
 
 ; <label>:103                                     ; preds = %101
   %104 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %102, i32 0, i32 11
@@ -16050,39 +18452,39 @@ ThrowNullRef:                                     ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %101
+ThrowNullRef2:                                    ; preds = %101
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %40
+ThrowNullRef4:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %42
+ThrowNullRef6:                                    ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %52
+ThrowNullRef8:                                    ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %54
+ThrowNullRef10:                                   ; preds = %54
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %67
+ThrowNullRef12:                                   ; preds = %67
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %72
+ThrowNullRef14:                                   ; preds = %72
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %76
+ThrowNullRef16:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %85
+ThrowNullRef18:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPSmall.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPSmall.error.txt
@@ -25,8 +25,8 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
@@ -40,8 +40,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
   %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
@@ -75,7 +75,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -90,8 +90,8 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %NullCheck = icmp ne i8 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = load i8, i8 addrspace(1)* %0, align 8
@@ -125,8 +125,8 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
@@ -159,8 +159,8 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -184,8 +184,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
   store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
@@ -195,8 +195,8 @@ entry:
 ; <label>:4                                       ; preds = %1
   %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
   %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
@@ -206,8 +206,8 @@ entry:
   %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
@@ -221,14 +221,14 @@ entry:
 
 ; <label>:17                                      ; preds = %14
   %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
   %21 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
@@ -238,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -249,8 +249,8 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
@@ -261,27 +261,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %30
+ThrowNullRef10:                                   ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -301,7 +301,89 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
-Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
+Successfully read AppDomainSetup.GetUnsecureApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.GetUnsecureApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %NullCheck = icmp eq %"System.String[]" addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %BoundsCheck = icmp uge i64 0, %5
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %6
+
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 3, i32 0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
+  ret %System.String addrspace(1)* %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_Value using LLILCJit
+Successfully read AppDomainSetup.get_Value
+
+define %"System.String[]" addrspace(1)* @AppDomainSetup.get_Value(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.String[]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 18)
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.String[]" addrspace(1)* addrspace(1)*, %"System.String[]" addrspace(1)*)*)(%"System.String[]" addrspace(1)* addrspace(1)* %9, %"System.String[]" addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %11, i32 0, i32 1
+  %14 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %13, align 8
+  ret %"System.String[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -319,8 +401,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -368,16 +450,16 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
   %5 = load i32, i32 addrspace(1)* %4
   %6 = sub i32 %5, 1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -389,7 +471,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -421,8 +503,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
@@ -456,8 +538,8 @@ entry:
 ; <label>:27                                      ; preds = %19
   %28 = load i32, i32* %arg1
   %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
-  br i1 %NullCheck2, label %30, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %29, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %30
 
 ; <label>:30                                      ; preds = %27
   %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
@@ -493,8 +575,8 @@ entry:
 ; <label>:49                                      ; preds = %46
   %50 = load i32, i32* %arg2
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck4, label %52, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
@@ -517,11 +599,11 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %27
+ThrowNullRef2:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %49
+ThrowNullRef4:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -544,16 +626,16 @@ entry:
   %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %0)
   store %System.String addrspace(1)* %1, %System.String addrspace(1)** %loc0
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 2
   %5 = bitcast [0 x i16] addrspace(1)* %4 to i16 addrspace(1)*
   store i16 addrspace(1)* %5, i16 addrspace(1)** %loc1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %3
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2
@@ -580,7 +662,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -691,15 +773,15 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %NullCheck132 = icmp ne i8* %21, null
-  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+  %NullCheck131 = icmp eq i8* %21, null
+  br i1 %NullCheck131, label %ThrowNullRef132, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = load i8, i8* %21, align 8
   %24 = zext i8 %23 to i32
   %25 = trunc i32 %24 to i8
-  %NullCheck134 = icmp ne i8* %20, null
-  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+  %NullCheck133 = icmp eq i8* %20, null
+  br i1 %NullCheck133, label %ThrowNullRef134, label %26
 
 ; <label>:26                                      ; preds = %22
   store i8 %25, i8* %20, align 8
@@ -709,16 +791,16 @@ entry:
   %28 = load i8*, i8** %arg0
   %29 = load i8*, i8** %arg1
   %30 = bitcast i8* %29 to i16*
-  %NullCheck128 = icmp ne i16* %30, null
-  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+  %NullCheck127 = icmp eq i16* %30, null
+  br i1 %NullCheck127, label %ThrowNullRef128, label %31
 
 ; <label>:31                                      ; preds = %27
   %32 = load i16, i16* %30, align 8
   %33 = sext i16 %32 to i32
   %34 = bitcast i8* %28 to i16*
   %35 = trunc i32 %33 to i16
-  %NullCheck130 = icmp ne i16* %34, null
-  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+  %NullCheck129 = icmp eq i16* %34, null
+  br i1 %NullCheck129, label %ThrowNullRef130, label %36
 
 ; <label>:36                                      ; preds = %31
   store i16 %35, i16* %34, align 8
@@ -728,16 +810,16 @@ entry:
   %38 = load i8*, i8** %arg0
   %39 = load i8*, i8** %arg1
   %40 = bitcast i8* %39 to i16*
-  %NullCheck120 = icmp ne i16* %40, null
-  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+  %NullCheck119 = icmp eq i16* %40, null
+  br i1 %NullCheck119, label %ThrowNullRef120, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i16, i16* %40, align 8
   %43 = sext i16 %42 to i32
   %44 = bitcast i8* %38 to i16*
   %45 = trunc i32 %43 to i16
-  %NullCheck122 = icmp ne i16* %44, null
-  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+  %NullCheck121 = icmp eq i16* %44, null
+  br i1 %NullCheck121, label %ThrowNullRef122, label %46
 
 ; <label>:46                                      ; preds = %41
   store i16 %45, i16* %44, align 8
@@ -745,15 +827,15 @@ entry:
   %48 = getelementptr inbounds i8, i8* %47, i64 2
   %49 = load i8*, i8** %arg1
   %50 = getelementptr inbounds i8, i8* %49, i64 2
-  %NullCheck124 = icmp ne i8* %50, null
-  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+  %NullCheck123 = icmp eq i8* %50, null
+  br i1 %NullCheck123, label %ThrowNullRef124, label %51
 
 ; <label>:51                                      ; preds = %46
   %52 = load i8, i8* %50, align 8
   %53 = zext i8 %52 to i32
   %54 = trunc i32 %53 to i8
-  %NullCheck126 = icmp ne i8* %48, null
-  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+  %NullCheck125 = icmp eq i8* %48, null
+  br i1 %NullCheck125, label %ThrowNullRef126, label %55
 
 ; <label>:55                                      ; preds = %51
   store i8 %54, i8* %48, align 8
@@ -763,14 +845,14 @@ entry:
   %57 = load i8*, i8** %arg0
   %58 = load i8*, i8** %arg1
   %59 = bitcast i8* %58 to i32*
-  %NullCheck116 = icmp ne i32* %59, null
-  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+  %NullCheck115 = icmp eq i32* %59, null
+  br i1 %NullCheck115, label %ThrowNullRef116, label %60
 
 ; <label>:60                                      ; preds = %56
   %61 = load i32, i32* %59, align 8
   %62 = bitcast i8* %57 to i32*
-  %NullCheck118 = icmp ne i32* %62, null
-  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+  %NullCheck117 = icmp eq i32* %62, null
+  br i1 %NullCheck117, label %ThrowNullRef118, label %63
 
 ; <label>:63                                      ; preds = %60
   store i32 %61, i32* %62, align 8
@@ -780,14 +862,14 @@ entry:
   %65 = load i8*, i8** %arg0
   %66 = load i8*, i8** %arg1
   %67 = bitcast i8* %66 to i32*
-  %NullCheck108 = icmp ne i32* %67, null
-  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+  %NullCheck107 = icmp eq i32* %67, null
+  br i1 %NullCheck107, label %ThrowNullRef108, label %68
 
 ; <label>:68                                      ; preds = %64
   %69 = load i32, i32* %67, align 8
   %70 = bitcast i8* %65 to i32*
-  %NullCheck110 = icmp ne i32* %70, null
-  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+  %NullCheck109 = icmp eq i32* %70, null
+  br i1 %NullCheck109, label %ThrowNullRef110, label %71
 
 ; <label>:71                                      ; preds = %68
   store i32 %69, i32* %70, align 8
@@ -795,15 +877,15 @@ entry:
   %73 = getelementptr inbounds i8, i8* %72, i64 4
   %74 = load i8*, i8** %arg1
   %75 = getelementptr inbounds i8, i8* %74, i64 4
-  %NullCheck112 = icmp ne i8* %75, null
-  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+  %NullCheck111 = icmp eq i8* %75, null
+  br i1 %NullCheck111, label %ThrowNullRef112, label %76
 
 ; <label>:76                                      ; preds = %71
   %77 = load i8, i8* %75, align 8
   %78 = zext i8 %77 to i32
   %79 = trunc i32 %78 to i8
-  %NullCheck114 = icmp ne i8* %73, null
-  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+  %NullCheck113 = icmp eq i8* %73, null
+  br i1 %NullCheck113, label %ThrowNullRef114, label %80
 
 ; <label>:80                                      ; preds = %76
   store i8 %79, i8* %73, align 8
@@ -813,14 +895,14 @@ entry:
   %82 = load i8*, i8** %arg0
   %83 = load i8*, i8** %arg1
   %84 = bitcast i8* %83 to i32*
-  %NullCheck100 = icmp ne i32* %84, null
-  br i1 %NullCheck100, label %85, label %ThrowNullRef99
+  %NullCheck99 = icmp eq i32* %84, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %85
 
 ; <label>:85                                      ; preds = %81
   %86 = load i32, i32* %84, align 8
   %87 = bitcast i8* %82 to i32*
-  %NullCheck102 = icmp ne i32* %87, null
-  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+  %NullCheck101 = icmp eq i32* %87, null
+  br i1 %NullCheck101, label %ThrowNullRef102, label %88
 
 ; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
@@ -829,16 +911,16 @@ entry:
   %91 = load i8*, i8** %arg1
   %92 = getelementptr inbounds i8, i8* %91, i64 4
   %93 = bitcast i8* %92 to i16*
-  %NullCheck104 = icmp ne i16* %93, null
-  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+  %NullCheck103 = icmp eq i16* %93, null
+  br i1 %NullCheck103, label %ThrowNullRef104, label %94
 
 ; <label>:94                                      ; preds = %88
   %95 = load i16, i16* %93, align 8
   %96 = sext i16 %95 to i32
   %97 = bitcast i8* %90 to i16*
   %98 = trunc i32 %96 to i16
-  %NullCheck106 = icmp ne i16* %97, null
-  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+  %NullCheck105 = icmp eq i16* %97, null
+  br i1 %NullCheck105, label %ThrowNullRef106, label %99
 
 ; <label>:99                                      ; preds = %94
   store i16 %98, i16* %97, align 8
@@ -848,14 +930,14 @@ entry:
   %101 = load i8*, i8** %arg0
   %102 = load i8*, i8** %arg1
   %103 = bitcast i8* %102 to i32*
-  %NullCheck88 = icmp ne i32* %103, null
-  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+  %NullCheck87 = icmp eq i32* %103, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %104
 
 ; <label>:104                                     ; preds = %100
   %105 = load i32, i32* %103, align 8
   %106 = bitcast i8* %101 to i32*
-  %NullCheck90 = icmp ne i32* %106, null
-  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+  %NullCheck89 = icmp eq i32* %106, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %107
 
 ; <label>:107                                     ; preds = %104
   store i32 %105, i32* %106, align 8
@@ -864,16 +946,16 @@ entry:
   %110 = load i8*, i8** %arg1
   %111 = getelementptr inbounds i8, i8* %110, i64 4
   %112 = bitcast i8* %111 to i16*
-  %NullCheck92 = icmp ne i16* %112, null
-  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+  %NullCheck91 = icmp eq i16* %112, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %113
 
 ; <label>:113                                     ; preds = %107
   %114 = load i16, i16* %112, align 8
   %115 = sext i16 %114 to i32
   %116 = bitcast i8* %109 to i16*
   %117 = trunc i32 %115 to i16
-  %NullCheck94 = icmp ne i16* %116, null
-  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+  %NullCheck93 = icmp eq i16* %116, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %118
 
 ; <label>:118                                     ; preds = %113
   store i16 %117, i16* %116, align 8
@@ -881,15 +963,15 @@ entry:
   %120 = getelementptr inbounds i8, i8* %119, i64 6
   %121 = load i8*, i8** %arg1
   %122 = getelementptr inbounds i8, i8* %121, i64 6
-  %NullCheck96 = icmp ne i8* %122, null
-  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+  %NullCheck95 = icmp eq i8* %122, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %123
 
 ; <label>:123                                     ; preds = %118
   %124 = load i8, i8* %122, align 8
   %125 = zext i8 %124 to i32
   %126 = trunc i32 %125 to i8
-  %NullCheck98 = icmp ne i8* %120, null
-  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+  %NullCheck97 = icmp eq i8* %120, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %127
 
 ; <label>:127                                     ; preds = %123
   store i8 %126, i8* %120, align 8
@@ -899,14 +981,14 @@ entry:
   %129 = load i8*, i8** %arg0
   %130 = load i8*, i8** %arg1
   %131 = bitcast i8* %130 to i64*
-  %NullCheck84 = icmp ne i64* %131, null
-  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+  %NullCheck83 = icmp eq i64* %131, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %132
 
 ; <label>:132                                     ; preds = %128
   %133 = load i64, i64* %131, align 8
   %134 = bitcast i8* %129 to i64*
-  %NullCheck86 = icmp ne i64* %134, null
-  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+  %NullCheck85 = icmp eq i64* %134, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %135
 
 ; <label>:135                                     ; preds = %132
   store i64 %133, i64* %134, align 8
@@ -916,14 +998,14 @@ entry:
   %137 = load i8*, i8** %arg0
   %138 = load i8*, i8** %arg1
   %139 = bitcast i8* %138 to i64*
-  %NullCheck76 = icmp ne i64* %139, null
-  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+  %NullCheck75 = icmp eq i64* %139, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %140
 
 ; <label>:140                                     ; preds = %136
   %141 = load i64, i64* %139, align 8
   %142 = bitcast i8* %137 to i64*
-  %NullCheck78 = icmp ne i64* %142, null
-  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+  %NullCheck77 = icmp eq i64* %142, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %143
 
 ; <label>:143                                     ; preds = %140
   store i64 %141, i64* %142, align 8
@@ -931,15 +1013,15 @@ entry:
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %NullCheck80 = icmp ne i8* %147, null
-  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+  %NullCheck79 = icmp eq i8* %147, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %148
 
 ; <label>:148                                     ; preds = %143
   %149 = load i8, i8* %147, align 8
   %150 = zext i8 %149 to i32
   %151 = trunc i32 %150 to i8
-  %NullCheck82 = icmp ne i8* %145, null
-  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+  %NullCheck81 = icmp eq i8* %145, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %152
 
 ; <label>:152                                     ; preds = %148
   store i8 %151, i8* %145, align 8
@@ -949,14 +1031,14 @@ entry:
   %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
   %156 = bitcast i8* %155 to i64*
-  %NullCheck68 = icmp ne i64* %156, null
-  br i1 %NullCheck68, label %157, label %ThrowNullRef67
+  %NullCheck67 = icmp eq i64* %156, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %157
 
 ; <label>:157                                     ; preds = %153
   %158 = load i64, i64* %156, align 8
   %159 = bitcast i8* %154 to i64*
-  %NullCheck70 = icmp ne i64* %159, null
-  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+  %NullCheck69 = icmp eq i64* %159, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %160
 
 ; <label>:160                                     ; preds = %157
   store i64 %158, i64* %159, align 8
@@ -965,16 +1047,16 @@ entry:
   %163 = load i8*, i8** %arg1
   %164 = getelementptr inbounds i8, i8* %163, i64 8
   %165 = bitcast i8* %164 to i16*
-  %NullCheck72 = icmp ne i16* %165, null
-  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+  %NullCheck71 = icmp eq i16* %165, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %166
 
 ; <label>:166                                     ; preds = %160
   %167 = load i16, i16* %165, align 8
   %168 = sext i16 %167 to i32
   %169 = bitcast i8* %162 to i16*
   %170 = trunc i32 %168 to i16
-  %NullCheck74 = icmp ne i16* %169, null
-  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+  %NullCheck73 = icmp eq i16* %169, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %171
 
 ; <label>:171                                     ; preds = %166
   store i16 %170, i16* %169, align 8
@@ -984,14 +1066,14 @@ entry:
   %173 = load i8*, i8** %arg0
   %174 = load i8*, i8** %arg1
   %175 = bitcast i8* %174 to i64*
-  %NullCheck56 = icmp ne i64* %175, null
-  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+  %NullCheck55 = icmp eq i64* %175, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %176
 
 ; <label>:176                                     ; preds = %172
   %177 = load i64, i64* %175, align 8
   %178 = bitcast i8* %173 to i64*
-  %NullCheck58 = icmp ne i64* %178, null
-  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+  %NullCheck57 = icmp eq i64* %178, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %179
 
 ; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
@@ -1000,16 +1082,16 @@ entry:
   %182 = load i8*, i8** %arg1
   %183 = getelementptr inbounds i8, i8* %182, i64 8
   %184 = bitcast i8* %183 to i16*
-  %NullCheck60 = icmp ne i16* %184, null
-  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+  %NullCheck59 = icmp eq i16* %184, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %185
 
 ; <label>:185                                     ; preds = %179
   %186 = load i16, i16* %184, align 8
   %187 = sext i16 %186 to i32
   %188 = bitcast i8* %181 to i16*
   %189 = trunc i32 %187 to i16
-  %NullCheck62 = icmp ne i16* %188, null
-  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+  %NullCheck61 = icmp eq i16* %188, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %190
 
 ; <label>:190                                     ; preds = %185
   store i16 %189, i16* %188, align 8
@@ -1017,15 +1099,15 @@ entry:
   %192 = getelementptr inbounds i8, i8* %191, i64 10
   %193 = load i8*, i8** %arg1
   %194 = getelementptr inbounds i8, i8* %193, i64 10
-  %NullCheck64 = icmp ne i8* %194, null
-  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+  %NullCheck63 = icmp eq i8* %194, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %195
 
 ; <label>:195                                     ; preds = %190
   %196 = load i8, i8* %194, align 8
   %197 = zext i8 %196 to i32
   %198 = trunc i32 %197 to i8
-  %NullCheck66 = icmp ne i8* %192, null
-  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+  %NullCheck65 = icmp eq i8* %192, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %199
 
 ; <label>:199                                     ; preds = %195
   store i8 %198, i8* %192, align 8
@@ -1035,14 +1117,14 @@ entry:
   %201 = load i8*, i8** %arg0
   %202 = load i8*, i8** %arg1
   %203 = bitcast i8* %202 to i64*
-  %NullCheck48 = icmp ne i64* %203, null
-  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+  %NullCheck47 = icmp eq i64* %203, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %204
 
 ; <label>:204                                     ; preds = %200
   %205 = load i64, i64* %203, align 8
   %206 = bitcast i8* %201 to i64*
-  %NullCheck50 = icmp ne i64* %206, null
-  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+  %NullCheck49 = icmp eq i64* %206, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %207
 
 ; <label>:207                                     ; preds = %204
   store i64 %205, i64* %206, align 8
@@ -1051,14 +1133,14 @@ entry:
   %210 = load i8*, i8** %arg1
   %211 = getelementptr inbounds i8, i8* %210, i64 8
   %212 = bitcast i8* %211 to i32*
-  %NullCheck52 = icmp ne i32* %212, null
-  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+  %NullCheck51 = icmp eq i32* %212, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %213
 
 ; <label>:213                                     ; preds = %207
   %214 = load i32, i32* %212, align 8
   %215 = bitcast i8* %209 to i32*
-  %NullCheck54 = icmp ne i32* %215, null
-  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+  %NullCheck53 = icmp eq i32* %215, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %216
 
 ; <label>:216                                     ; preds = %213
   store i32 %214, i32* %215, align 8
@@ -1068,14 +1150,14 @@ entry:
   %218 = load i8*, i8** %arg0
   %219 = load i8*, i8** %arg1
   %220 = bitcast i8* %219 to i64*
-  %NullCheck36 = icmp ne i64* %220, null
-  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64* %220, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %221
 
 ; <label>:221                                     ; preds = %217
   %222 = load i64, i64* %220, align 8
   %223 = bitcast i8* %218 to i64*
-  %NullCheck38 = icmp ne i64* %223, null
-  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+  %NullCheck37 = icmp eq i64* %223, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %224
 
 ; <label>:224                                     ; preds = %221
   store i64 %222, i64* %223, align 8
@@ -1084,14 +1166,14 @@ entry:
   %227 = load i8*, i8** %arg1
   %228 = getelementptr inbounds i8, i8* %227, i64 8
   %229 = bitcast i8* %228 to i32*
-  %NullCheck40 = icmp ne i32* %229, null
-  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i32* %229, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %230
 
 ; <label>:230                                     ; preds = %224
   %231 = load i32, i32* %229, align 8
   %232 = bitcast i8* %226 to i32*
-  %NullCheck42 = icmp ne i32* %232, null
-  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+  %NullCheck41 = icmp eq i32* %232, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %233
 
 ; <label>:233                                     ; preds = %230
   store i32 %231, i32* %232, align 8
@@ -1099,15 +1181,15 @@ entry:
   %235 = getelementptr inbounds i8, i8* %234, i64 12
   %236 = load i8*, i8** %arg1
   %237 = getelementptr inbounds i8, i8* %236, i64 12
-  %NullCheck44 = icmp ne i8* %237, null
-  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i8* %237, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %238
 
 ; <label>:238                                     ; preds = %233
   %239 = load i8, i8* %237, align 8
   %240 = zext i8 %239 to i32
   %241 = trunc i32 %240 to i8
-  %NullCheck46 = icmp ne i8* %235, null
-  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+  %NullCheck45 = icmp eq i8* %235, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %242
 
 ; <label>:242                                     ; preds = %238
   store i8 %241, i8* %235, align 8
@@ -1117,14 +1199,14 @@ entry:
   %244 = load i8*, i8** %arg0
   %245 = load i8*, i8** %arg1
   %246 = bitcast i8* %245 to i64*
-  %NullCheck24 = icmp ne i64* %246, null
-  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64* %246, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %247
 
 ; <label>:247                                     ; preds = %243
   %248 = load i64, i64* %246, align 8
   %249 = bitcast i8* %244 to i64*
-  %NullCheck26 = icmp ne i64* %249, null
-  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64* %249, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %250
 
 ; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
@@ -1133,14 +1215,14 @@ entry:
   %253 = load i8*, i8** %arg1
   %254 = getelementptr inbounds i8, i8* %253, i64 8
   %255 = bitcast i8* %254 to i32*
-  %NullCheck28 = icmp ne i32* %255, null
-  br i1 %NullCheck28, label %256, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i32* %255, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %256
 
 ; <label>:256                                     ; preds = %250
   %257 = load i32, i32* %255, align 8
   %258 = bitcast i8* %252 to i32*
-  %NullCheck30 = icmp ne i32* %258, null
-  br i1 %NullCheck30, label %259, label %ThrowNullRef29
+  %NullCheck29 = icmp eq i32* %258, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %259
 
 ; <label>:259                                     ; preds = %256
   store i32 %257, i32* %258, align 8
@@ -1149,16 +1231,16 @@ entry:
   %262 = load i8*, i8** %arg1
   %263 = getelementptr inbounds i8, i8* %262, i64 12
   %264 = bitcast i8* %263 to i16*
-  %NullCheck32 = icmp ne i16* %264, null
-  br i1 %NullCheck32, label %265, label %ThrowNullRef31
+  %NullCheck31 = icmp eq i16* %264, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %265
 
 ; <label>:265                                     ; preds = %259
   %266 = load i16, i16* %264, align 8
   %267 = sext i16 %266 to i32
   %268 = bitcast i8* %261 to i16*
   %269 = trunc i32 %267 to i16
-  %NullCheck34 = icmp ne i16* %268, null
-  br i1 %NullCheck34, label %270, label %ThrowNullRef33
+  %NullCheck33 = icmp eq i16* %268, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %270
 
 ; <label>:270                                     ; preds = %265
   store i16 %269, i16* %268, align 8
@@ -1168,14 +1250,14 @@ entry:
   %272 = load i8*, i8** %arg0
   %273 = load i8*, i8** %arg1
   %274 = bitcast i8* %273 to i64*
-  %NullCheck8 = icmp ne i64* %274, null
-  br i1 %NullCheck8, label %275, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64* %274, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %275
 
 ; <label>:275                                     ; preds = %271
   %276 = load i64, i64* %274, align 8
   %277 = bitcast i8* %272 to i64*
-  %NullCheck10 = icmp ne i64* %277, null
-  br i1 %NullCheck10, label %278, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %277, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %278
 
 ; <label>:278                                     ; preds = %275
   store i64 %276, i64* %277, align 8
@@ -1184,14 +1266,14 @@ entry:
   %281 = load i8*, i8** %arg1
   %282 = getelementptr inbounds i8, i8* %281, i64 8
   %283 = bitcast i8* %282 to i32*
-  %NullCheck12 = icmp ne i32* %283, null
-  br i1 %NullCheck12, label %284, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i32* %283, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %284
 
 ; <label>:284                                     ; preds = %278
   %285 = load i32, i32* %283, align 8
   %286 = bitcast i8* %280 to i32*
-  %NullCheck14 = icmp ne i32* %286, null
-  br i1 %NullCheck14, label %287, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i32* %286, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %287
 
 ; <label>:287                                     ; preds = %284
   store i32 %285, i32* %286, align 8
@@ -1200,16 +1282,16 @@ entry:
   %290 = load i8*, i8** %arg1
   %291 = getelementptr inbounds i8, i8* %290, i64 12
   %292 = bitcast i8* %291 to i16*
-  %NullCheck16 = icmp ne i16* %292, null
-  br i1 %NullCheck16, label %293, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i16* %292, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %293
 
 ; <label>:293                                     ; preds = %287
   %294 = load i16, i16* %292, align 8
   %295 = sext i16 %294 to i32
   %296 = bitcast i8* %289 to i16*
   %297 = trunc i32 %295 to i16
-  %NullCheck18 = icmp ne i16* %296, null
-  br i1 %NullCheck18, label %298, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i16* %296, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %298
 
 ; <label>:298                                     ; preds = %293
   store i16 %297, i16* %296, align 8
@@ -1217,15 +1299,15 @@ entry:
   %300 = getelementptr inbounds i8, i8* %299, i64 14
   %301 = load i8*, i8** %arg1
   %302 = getelementptr inbounds i8, i8* %301, i64 14
-  %NullCheck20 = icmp ne i8* %302, null
-  br i1 %NullCheck20, label %303, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i8* %302, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %303
 
 ; <label>:303                                     ; preds = %298
   %304 = load i8, i8* %302, align 8
   %305 = zext i8 %304 to i32
   %306 = trunc i32 %305 to i8
-  %NullCheck22 = icmp ne i8* %300, null
-  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i8* %300, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %307
 
 ; <label>:307                                     ; preds = %303
   store i8 %306, i8* %300, align 8
@@ -1235,14 +1317,14 @@ entry:
   %309 = load i8*, i8** %arg0
   %310 = load i8*, i8** %arg1
   %311 = bitcast i8* %310 to i64*
-  %NullCheck = icmp ne i64* %311, null
-  br i1 %NullCheck, label %312, label %ThrowNullRef
+  %NullCheck = icmp eq i64* %311, null
+  br i1 %NullCheck, label %ThrowNullRef, label %312
 
 ; <label>:312                                     ; preds = %308
   %313 = load i64, i64* %311, align 8
   %314 = bitcast i8* %309 to i64*
-  %NullCheck2 = icmp ne i64* %314, null
-  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64* %314, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %315
 
 ; <label>:315                                     ; preds = %312
   store i64 %313, i64* %314, align 8
@@ -1251,14 +1333,14 @@ entry:
   %318 = load i8*, i8** %arg1
   %319 = getelementptr inbounds i8, i8* %318, i64 8
   %320 = bitcast i8* %319 to i64*
-  %NullCheck4 = icmp ne i64* %320, null
-  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64* %320, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %321
 
 ; <label>:321                                     ; preds = %315
   %322 = load i64, i64* %320, align 8
   %323 = bitcast i8* %317 to i64*
-  %NullCheck6 = icmp ne i64* %323, null
-  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64* %323, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %324
 
 ; <label>:324                                     ; preds = %321
   store i64 %322, i64* %323, align 8
@@ -1286,15 +1368,15 @@ entry:
 ; <label>:338                                     ; preds = %333
   %339 = load i8*, i8** %arg0
   %340 = load i8*, i8** %arg1
-  %NullCheck136 = icmp ne i8* %340, null
-  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+  %NullCheck135 = icmp eq i8* %340, null
+  br i1 %NullCheck135, label %ThrowNullRef136, label %341
 
 ; <label>:341                                     ; preds = %338
   %342 = load i8, i8* %340, align 8
   %343 = zext i8 %342 to i32
   %344 = trunc i32 %343 to i8
-  %NullCheck138 = icmp ne i8* %339, null
-  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+  %NullCheck137 = icmp eq i8* %339, null
+  br i1 %NullCheck137, label %ThrowNullRef138, label %345
 
 ; <label>:345                                     ; preds = %341
   store i8 %344, i8* %339, align 8
@@ -1317,16 +1399,16 @@ entry:
   %357 = load i8*, i8** %arg0
   %358 = load i8*, i8** %arg1
   %359 = bitcast i8* %358 to i16*
-  %NullCheck140 = icmp ne i16* %359, null
-  br i1 %NullCheck140, label %360, label %ThrowNullRef139
+  %NullCheck139 = icmp eq i16* %359, null
+  br i1 %NullCheck139, label %ThrowNullRef140, label %360
 
 ; <label>:360                                     ; preds = %356
   %361 = load i16, i16* %359, align 8
   %362 = sext i16 %361 to i32
   %363 = bitcast i8* %357 to i16*
   %364 = trunc i32 %362 to i16
-  %NullCheck142 = icmp ne i16* %363, null
-  br i1 %NullCheck142, label %365, label %ThrowNullRef141
+  %NullCheck141 = icmp eq i16* %363, null
+  br i1 %NullCheck141, label %ThrowNullRef142, label %365
 
 ; <label>:365                                     ; preds = %360
   store i16 %364, i16* %363, align 8
@@ -1352,14 +1434,14 @@ entry:
   %378 = load i8*, i8** %arg0
   %379 = load i8*, i8** %arg1
   %380 = bitcast i8* %379 to i32*
-  %NullCheck144 = icmp ne i32* %380, null
-  br i1 %NullCheck144, label %381, label %ThrowNullRef143
+  %NullCheck143 = icmp eq i32* %380, null
+  br i1 %NullCheck143, label %ThrowNullRef144, label %381
 
 ; <label>:381                                     ; preds = %377
   %382 = load i32, i32* %380, align 8
   %383 = bitcast i8* %378 to i32*
-  %NullCheck146 = icmp ne i32* %383, null
-  br i1 %NullCheck146, label %384, label %ThrowNullRef145
+  %NullCheck145 = icmp eq i32* %383, null
+  br i1 %NullCheck145, label %ThrowNullRef146, label %384
 
 ; <label>:384                                     ; preds = %381
   store i32 %382, i32* %383, align 8
@@ -1384,14 +1466,14 @@ entry:
   %395 = load i8*, i8** %arg0
   %396 = load i8*, i8** %arg1
   %397 = bitcast i8* %396 to i64*
-  %NullCheck164 = icmp ne i64* %397, null
-  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+  %NullCheck163 = icmp eq i64* %397, null
+  br i1 %NullCheck163, label %ThrowNullRef164, label %398
 
 ; <label>:398                                     ; preds = %394
   %399 = load i64, i64* %397, align 8
   %400 = bitcast i8* %395 to i64*
-  %NullCheck166 = icmp ne i64* %400, null
-  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+  %NullCheck165 = icmp eq i64* %400, null
+  br i1 %NullCheck165, label %ThrowNullRef166, label %401
 
 ; <label>:401                                     ; preds = %398
   store i64 %399, i64* %400, align 8
@@ -1400,14 +1482,14 @@ entry:
   %404 = load i8*, i8** %arg1
   %405 = getelementptr inbounds i8, i8* %404, i64 8
   %406 = bitcast i8* %405 to i64*
-  %NullCheck168 = icmp ne i64* %406, null
-  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+  %NullCheck167 = icmp eq i64* %406, null
+  br i1 %NullCheck167, label %ThrowNullRef168, label %407
 
 ; <label>:407                                     ; preds = %401
   %408 = load i64, i64* %406, align 8
   %409 = bitcast i8* %403 to i64*
-  %NullCheck170 = icmp ne i64* %409, null
-  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+  %NullCheck169 = icmp eq i64* %409, null
+  br i1 %NullCheck169, label %ThrowNullRef170, label %410
 
 ; <label>:410                                     ; preds = %407
   store i64 %408, i64* %409, align 8
@@ -1437,14 +1519,14 @@ entry:
   %425 = load i8*, i8** %arg0
   %426 = load i8*, i8** %arg1
   %427 = bitcast i8* %426 to i64*
-  %NullCheck148 = icmp ne i64* %427, null
-  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+  %NullCheck147 = icmp eq i64* %427, null
+  br i1 %NullCheck147, label %ThrowNullRef148, label %428
 
 ; <label>:428                                     ; preds = %424
   %429 = load i64, i64* %427, align 8
   %430 = bitcast i8* %425 to i64*
-  %NullCheck150 = icmp ne i64* %430, null
-  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+  %NullCheck149 = icmp eq i64* %430, null
+  br i1 %NullCheck149, label %ThrowNullRef150, label %431
 
 ; <label>:431                                     ; preds = %428
   store i64 %429, i64* %430, align 8
@@ -1466,14 +1548,14 @@ entry:
   %441 = load i8*, i8** %arg0
   %442 = load i8*, i8** %arg1
   %443 = bitcast i8* %442 to i32*
-  %NullCheck152 = icmp ne i32* %443, null
-  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+  %NullCheck151 = icmp eq i32* %443, null
+  br i1 %NullCheck151, label %ThrowNullRef152, label %444
 
 ; <label>:444                                     ; preds = %440
   %445 = load i32, i32* %443, align 8
   %446 = bitcast i8* %441 to i32*
-  %NullCheck154 = icmp ne i32* %446, null
-  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+  %NullCheck153 = icmp eq i32* %446, null
+  br i1 %NullCheck153, label %ThrowNullRef154, label %447
 
 ; <label>:447                                     ; preds = %444
   store i32 %445, i32* %446, align 8
@@ -1495,16 +1577,16 @@ entry:
   %457 = load i8*, i8** %arg0
   %458 = load i8*, i8** %arg1
   %459 = bitcast i8* %458 to i16*
-  %NullCheck156 = icmp ne i16* %459, null
-  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+  %NullCheck155 = icmp eq i16* %459, null
+  br i1 %NullCheck155, label %ThrowNullRef156, label %460
 
 ; <label>:460                                     ; preds = %456
   %461 = load i16, i16* %459, align 8
   %462 = sext i16 %461 to i32
   %463 = bitcast i8* %457 to i16*
   %464 = trunc i32 %462 to i16
-  %NullCheck158 = icmp ne i16* %463, null
-  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+  %NullCheck157 = icmp eq i16* %463, null
+  br i1 %NullCheck157, label %ThrowNullRef158, label %465
 
 ; <label>:465                                     ; preds = %460
   store i16 %464, i16* %463, align 8
@@ -1525,15 +1607,15 @@ entry:
 ; <label>:474                                     ; preds = %470
   %475 = load i8*, i8** %arg0
   %476 = load i8*, i8** %arg1
-  %NullCheck160 = icmp ne i8* %476, null
-  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+  %NullCheck159 = icmp eq i8* %476, null
+  br i1 %NullCheck159, label %ThrowNullRef160, label %477
 
 ; <label>:477                                     ; preds = %474
   %478 = load i8, i8* %476, align 8
   %479 = zext i8 %478 to i32
   %480 = trunc i32 %479 to i8
-  %NullCheck162 = icmp ne i8* %475, null
-  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+  %NullCheck161 = icmp eq i8* %475, null
+  br i1 %NullCheck161, label %ThrowNullRef162, label %481
 
 ; <label>:481                                     ; preds = %477
   store i8 %480, i8* %475, align 8
@@ -1553,343 +1635,343 @@ ThrowNullRef:                                     ; preds = %308
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %312
+ThrowNullRef2:                                    ; preds = %312
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %315
+ThrowNullRef4:                                    ; preds = %315
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %321
+ThrowNullRef6:                                    ; preds = %321
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %271
+ThrowNullRef8:                                    ; preds = %271
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %275
+ThrowNullRef10:                                   ; preds = %275
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %278
+ThrowNullRef12:                                   ; preds = %278
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %284
+ThrowNullRef14:                                   ; preds = %284
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %287
+ThrowNullRef16:                                   ; preds = %287
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %293
+ThrowNullRef18:                                   ; preds = %293
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %298
+ThrowNullRef20:                                   ; preds = %298
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %303
+ThrowNullRef22:                                   ; preds = %303
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %243
+ThrowNullRef24:                                   ; preds = %243
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %247
+ThrowNullRef26:                                   ; preds = %247
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %250
+ThrowNullRef28:                                   ; preds = %250
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %256
+ThrowNullRef30:                                   ; preds = %256
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %259
+ThrowNullRef32:                                   ; preds = %259
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %265
+ThrowNullRef34:                                   ; preds = %265
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %217
+ThrowNullRef36:                                   ; preds = %217
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %221
+ThrowNullRef38:                                   ; preds = %221
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %224
+ThrowNullRef40:                                   ; preds = %224
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %230
+ThrowNullRef42:                                   ; preds = %230
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %233
+ThrowNullRef44:                                   ; preds = %233
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %238
+ThrowNullRef46:                                   ; preds = %238
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %200
+ThrowNullRef48:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %204
+ThrowNullRef50:                                   ; preds = %204
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %207
+ThrowNullRef52:                                   ; preds = %207
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %213
+ThrowNullRef54:                                   ; preds = %213
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %172
+ThrowNullRef56:                                   ; preds = %172
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %176
+ThrowNullRef58:                                   ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %179
+ThrowNullRef60:                                   ; preds = %179
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %185
+ThrowNullRef62:                                   ; preds = %185
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %190
+ThrowNullRef64:                                   ; preds = %190
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %195
+ThrowNullRef66:                                   ; preds = %195
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %153
+ThrowNullRef68:                                   ; preds = %153
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %157
+ThrowNullRef70:                                   ; preds = %157
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %160
+ThrowNullRef72:                                   ; preds = %160
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %166
+ThrowNullRef74:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %136
+ThrowNullRef76:                                   ; preds = %136
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %140
+ThrowNullRef78:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %143
+ThrowNullRef80:                                   ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %148
+ThrowNullRef82:                                   ; preds = %148
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %128
+ThrowNullRef84:                                   ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %132
+ThrowNullRef86:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %100
+ThrowNullRef88:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %104
+ThrowNullRef90:                                   ; preds = %104
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %107
+ThrowNullRef92:                                   ; preds = %107
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %113
+ThrowNullRef94:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %118
+ThrowNullRef96:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %123
+ThrowNullRef98:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %81
+ThrowNullRef100:                                  ; preds = %81
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef101:                                  ; preds = %85
+ThrowNullRef102:                                  ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef103:                                  ; preds = %88
+ThrowNullRef104:                                  ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef105:                                  ; preds = %94
+ThrowNullRef106:                                  ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef107:                                  ; preds = %64
+ThrowNullRef108:                                  ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef109:                                  ; preds = %68
+ThrowNullRef110:                                  ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef111:                                  ; preds = %71
+ThrowNullRef112:                                  ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef113:                                  ; preds = %76
+ThrowNullRef114:                                  ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef115:                                  ; preds = %56
+ThrowNullRef116:                                  ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef117:                                  ; preds = %60
+ThrowNullRef118:                                  ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef119:                                  ; preds = %37
+ThrowNullRef120:                                  ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef121:                                  ; preds = %41
+ThrowNullRef122:                                  ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef123:                                  ; preds = %46
+ThrowNullRef124:                                  ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef125:                                  ; preds = %51
+ThrowNullRef126:                                  ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef127:                                  ; preds = %27
+ThrowNullRef128:                                  ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef129:                                  ; preds = %31
+ThrowNullRef130:                                  ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef131:                                  ; preds = %19
+ThrowNullRef132:                                  ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef133:                                  ; preds = %22
+ThrowNullRef134:                                  ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef135:                                  ; preds = %338
+ThrowNullRef136:                                  ; preds = %338
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef137:                                  ; preds = %341
+ThrowNullRef138:                                  ; preds = %341
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef139:                                  ; preds = %356
+ThrowNullRef140:                                  ; preds = %356
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef141:                                  ; preds = %360
+ThrowNullRef142:                                  ; preds = %360
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef143:                                  ; preds = %377
+ThrowNullRef144:                                  ; preds = %377
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef145:                                  ; preds = %381
+ThrowNullRef146:                                  ; preds = %381
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef147:                                  ; preds = %424
+ThrowNullRef148:                                  ; preds = %424
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef149:                                  ; preds = %428
+ThrowNullRef150:                                  ; preds = %428
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef151:                                  ; preds = %440
+ThrowNullRef152:                                  ; preds = %440
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef153:                                  ; preds = %444
+ThrowNullRef154:                                  ; preds = %444
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef155:                                  ; preds = %456
+ThrowNullRef156:                                  ; preds = %456
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef157:                                  ; preds = %460
+ThrowNullRef158:                                  ; preds = %460
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef159:                                  ; preds = %474
+ThrowNullRef160:                                  ; preds = %474
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef161:                                  ; preds = %477
+ThrowNullRef162:                                  ; preds = %477
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef163:                                  ; preds = %394
+ThrowNullRef164:                                  ; preds = %394
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef165:                                  ; preds = %398
+ThrowNullRef166:                                  ; preds = %398
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef167:                                  ; preds = %401
+ThrowNullRef168:                                  ; preds = %401
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef169:                                  ; preds = %407
+ThrowNullRef170:                                  ; preds = %407
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1939,8 +2021,8 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
-  br i1 %NullCheck, label %22, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %ThrowNullRef, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
@@ -1948,8 +2030,8 @@ entry:
   store i32 %24, i32* %loc0
   %25 = load i32, i32* %loc0
   %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %26, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %27
 
 ; <label>:27                                      ; preds = %22
   %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
@@ -1971,7 +2053,7 @@ ThrowNullRef:                                     ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1989,8 +2071,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -2022,15 +2104,15 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2048,16 +2130,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
   %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
   store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %15
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
@@ -2072,8 +2154,8 @@ entry:
   %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
   %29 = ptrtoint i16 addrspace(1)* %28 to i64
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %19
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
@@ -2089,19 +2171,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2114,8 +2196,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
@@ -2128,7 +2210,7 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[loadElem]
+Failed to read AppDomain.PrepareDataForSetup[storeElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
@@ -2202,8 +2284,8 @@ entry:
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
-  br i1 %NullCheck24, label %27, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = load i64, i64 addrspace(1)* %26
@@ -2218,8 +2300,8 @@ entry:
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
-  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
   %41 = load i64, i64 addrspace(1)* %39
@@ -2236,8 +2318,8 @@ entry:
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
-  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
   %54 = load i64, i64 addrspace(1)* %52
@@ -2252,8 +2334,8 @@ entry:
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
   %67 = load i64, i64 addrspace(1)* %65
@@ -2270,8 +2352,8 @@ entry:
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
-  br i1 %NullCheck16, label %79, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
   %80 = load i64, i64 addrspace(1)* %78
@@ -2286,8 +2368,8 @@ entry:
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
-  br i1 %NullCheck18, label %92, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
   %93 = load i64, i64 addrspace(1)* %91
@@ -2304,8 +2386,8 @@ entry:
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
-  br i1 %NullCheck12, label %105, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = load i64, i64 addrspace(1)* %104
@@ -2320,8 +2402,8 @@ entry:
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
-  br i1 %NullCheck14, label %118, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
   %119 = load i64, i64 addrspace(1)* %117
@@ -2337,8 +2419,8 @@ entry:
 
 ; <label>:128                                     ; preds = %20
   %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
-  br i1 %NullCheck4, label %130, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %129, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %130
 
 ; <label>:130                                     ; preds = %128
   %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
@@ -2346,8 +2428,8 @@ entry:
   %133 = load i16, i16 addrspace(1)* %132, align 8
   %134 = zext i16 %133 to i32
   %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
-  br i1 %NullCheck6, label %136, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %135, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %136
 
 ; <label>:136                                     ; preds = %130
   %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
@@ -2360,8 +2442,8 @@ entry:
 
 ; <label>:143                                     ; preds = %136
   %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
-  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %144, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %145
 
 ; <label>:145                                     ; preds = %143
   %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
@@ -2369,8 +2451,8 @@ entry:
   %148 = load i16, i16 addrspace(1)* %147, align 8
   %149 = zext i16 %148 to i32
   %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %150, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %151
 
 ; <label>:151                                     ; preds = %145
   %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
@@ -2388,8 +2470,8 @@ entry:
 
 ; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
-  br i1 %NullCheck, label %163, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %ThrowNullRef, label %163
 
 ; <label>:163                                     ; preds = %161
   %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
@@ -2399,8 +2481,8 @@ entry:
 
 ; <label>:167                                     ; preds = %163
   %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
-  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %168, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %169
 
 ; <label>:169                                     ; preds = %167
   %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
@@ -2432,55 +2514,55 @@ ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %167
+ThrowNullRef2:                                    ; preds = %167
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %128
+ThrowNullRef4:                                    ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %130
+ThrowNullRef6:                                    ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %143
+ThrowNullRef8:                                    ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %145
+ThrowNullRef10:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %102
+ThrowNullRef12:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %105
+ThrowNullRef14:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %76
+ThrowNullRef16:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %79
+ThrowNullRef18:                                   ; preds = %79
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %50
+ThrowNullRef20:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %53
+ThrowNullRef22:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %24
+ThrowNullRef24:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %27
+ThrowNullRef26:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2503,15 +2585,15 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2519,16 +2601,16 @@ entry:
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
   store i32 %8, i32* %loc0
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
   %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
   store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
@@ -2546,16 +2628,16 @@ entry:
 
 ; <label>:23                                      ; preds = %64
   %24 = load i16*, i16** %loc3
-  %NullCheck12 = icmp ne i16* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i16* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
   store i32 %27, i32* %loc5
   %28 = load i16*, i16** %loc4
-  %NullCheck14 = icmp ne i16* %28, null
-  br i1 %NullCheck14, label %29, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %28, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = load i16, i16* %28, align 8
@@ -2620,15 +2702,15 @@ entry:
 
 ; <label>:67                                      ; preds = %64
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
-  br i1 %NullCheck8, label %69, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %68, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %69
 
 ; <label>:69                                      ; preds = %67
   %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
   %71 = load i32, i32 addrspace(1)* %70
   %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
-  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %73
 
 ; <label>:73                                      ; preds = %69
   %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
@@ -2645,31 +2727,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %67
+ThrowNullRef8:                                    ; preds = %67
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %69
+ThrowNullRef10:                                   ; preds = %69
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2710,14 +2792,14 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
   %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
@@ -2730,14 +2812,14 @@ entry:
 
 ; <label>:11                                      ; preds = %4
   %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
   %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
@@ -2749,14 +2831,14 @@ entry:
 
 ; <label>:22                                      ; preds = %16
   %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
   %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
-  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
-  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
@@ -2804,23 +2886,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2836,7 +2918,280 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[loadElem]
+Successfully read RuntimeType.IsAssignableFrom
+
+define i8 @RuntimeType.IsAssignableFrom(%System.RuntimeType addrspace(1)* %param0, %System.Type addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.RuntimeType addrspace(1)*
+  %arg1 = alloca %System.Type addrspace(1)*
+  %loc0 = alloca %System.RuntimeType addrspace(1)*
+  %loc1 = alloca %"System.Type[]" addrspace(1)*
+  %loc2 = alloca i32
+  store %System.RuntimeType addrspace(1)* %param0, %System.RuntimeType addrspace(1)** %this
+  store %System.Type addrspace(1)* %param1, %System.Type addrspace(1)** %arg1
+  %0 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %1 = icmp ne %System.Type addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i8 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %5 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %6 = bitcast %System.Type addrspace(1)* %4 to %System.Object addrspace(1)*
+  %7 = bitcast %System.RuntimeType addrspace(1)* %5 to %System.Object addrspace(1)*
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %6, %System.Object addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %3
+  ret i8 1
+
+; <label>:12                                      ; preds = %3
+  %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 152
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 32
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
+  %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
+  %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
+  store %System.RuntimeType addrspace(1)* %25, %System.RuntimeType addrspace(1)** %loc0
+  %26 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %27 = icmp eq %System.RuntimeType addrspace(1)* %26, null
+  br i1 %27, label %34, label %28
+
+; <label>:28                                      ; preds = %15
+  %29 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %30 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)*)*)(%System.RuntimeType addrspace(1)* %29, %System.RuntimeType addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+; <label>:34                                      ; preds = %15
+  %35 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %36 = call %System.Reflection.Emit.TypeBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Reflection.Emit.TypeBuilder addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %35)
+  %37 = icmp eq %System.Reflection.Emit.TypeBuilder addrspace(1)* %36, null
+  br i1 %37, label %139, label %38
+
+; <label>:38                                      ; preds = %34
+  %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %42
+
+; <label>:42                                      ; preds = %38
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 152
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 40
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
+  %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
+  %53 = zext i8 %52 to i32
+  %54 = icmp eq i32 %53, 0
+  br i1 %54, label %56, label %55
+
+; <label>:55                                      ; preds = %42
+  ret i8 1
+
+; <label>:56                                      ; preds = %42
+  %57 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %58 = bitcast %System.RuntimeType addrspace(1)* %57 to %System.Type addrspace(1)*
+  %59 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %58)
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %64 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.Type addrspace(1)* %63, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = bitcast %System.RuntimeType addrspace(1)* %64 to %System.Type addrspace(1)*
+  %67 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %63, %System.Type addrspace(1)* %66)
+  %68 = zext i8 %67 to i32
+  %69 = trunc i32 %68 to i8
+  ret i8 %69
+
+; <label>:70                                      ; preds = %56
+  %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
+  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %73
+
+; <label>:73                                      ; preds = %70
+  %74 = load i64, i64 addrspace(1)* %72
+  %75 = add i64 %74, 128
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = add i64 %77, 0
+  %79 = inttoptr i64 %78 to i64*
+  %80 = load i64, i64* %79
+  %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
+  %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
+  %83 = call i8 %82(%System.Type addrspace(1)* %81)
+  %84 = zext i8 %83 to i32
+  %85 = icmp eq i32 %84, 0
+  br i1 %85, label %139, label %86
+
+; <label>:86                                      ; preds = %73
+  %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
+  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %89
+
+; <label>:89                                      ; preds = %86
+  %90 = load i64, i64 addrspace(1)* %88
+  %91 = add i64 %90, 128
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = add i64 %93, 24
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
+  %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
+  %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
+  store %"System.Type[]" addrspace(1)* %99, %"System.Type[]" addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %129
+
+; <label>:100                                     ; preds = %132
+  %101 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %102 = load i32, i32* %loc2
+  %NullCheck11 = icmp eq %"System.Type[]" addrspace(1)* %101, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %103
+
+; <label>:103                                     ; preds = %100
+  %104 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 1
+  %105 = load i32, i32 addrspace(1)* %104
+  %106 = zext i32 %105 to i64
+  %107 = zext i32 %102 to i64
+  %BoundsCheck = icmp uge i64 %107, %106
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %108
+
+; <label>:108                                     ; preds = %103
+  %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
+  %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
+  %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
+  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %113
+
+; <label>:113                                     ; preds = %108
+  %114 = load i64, i64 addrspace(1)* %112
+  %115 = add i64 %114, 152
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = add i64 %117, 56
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
+  %123 = zext i8 %122 to i32
+  %124 = icmp ne i32 %123, 0
+  br i1 %124, label %126, label %125
+
+; <label>:125                                     ; preds = %113
+  ret i8 0
+
+; <label>:126                                     ; preds = %113
+  %127 = load i32, i32* %loc2
+  %128 = add i32 %127, 1
+  store i32 %128, i32* %loc2
+  br label %129
+
+; <label>:129                                     ; preds = %89, %126
+  %130 = load i32, i32* %loc2
+  %131 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %NullCheck9 = icmp eq %"System.Type[]" addrspace(1)* %131, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %132
+
+; <label>:132                                     ; preds = %129
+  %133 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %131, i32 0, i32 1
+  %134 = load i32, i32 addrspace(1)* %133
+  %135 = zext i32 %134 to i64
+  %136 = trunc i64 %135 to i32
+  %137 = icmp slt i32 %130, %136
+  br i1 %137, label %100, label %138
+
+; <label>:138                                     ; preds = %132
+  ret i8 1
+
+; <label>:139                                     ; preds = %34, %73
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %129
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %103
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -2893,7 +3248,7 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElem]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -2904,8 +3259,8 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -2997,8 +3352,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
@@ -3059,8 +3414,8 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -3087,8 +3442,8 @@ entry:
 
 ; <label>:17                                      ; preds = %5, %11
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
@@ -3097,8 +3452,8 @@ entry:
 
 ; <label>:22                                      ; preds = %1, %11
   %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
@@ -3109,11 +3464,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %17
+ThrowNullRef2:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %22
+ThrowNullRef4:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3167,15 +3522,15 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
   %15 = load i32, i32 addrspace(1)* %14
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
@@ -3198,7 +3553,7 @@ ThrowNullRef:                                     ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef2:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3232,8 +3587,8 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
@@ -3312,8 +3667,8 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -3327,8 +3682,8 @@ entry:
 ; <label>:5                                       ; preds = %43
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %7 = load i32, i32* %loc1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck6, label %8, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
@@ -3366,8 +3721,8 @@ entry:
 ; <label>:32                                      ; preds = %21, %25
   %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
   %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
-  br i1 %NullCheck8, label %35, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = trunc i32 %34 to i16
@@ -3380,8 +3735,8 @@ entry:
 ; <label>:40                                      ; preds = %1, %35
   %41 = load i32, i32* %loc1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
-  br i1 %NullCheck2, label %43, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %42, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
@@ -3392,8 +3747,8 @@ entry:
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
   %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
-  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
   %51 = load i64, i64 addrspace(1)* %49
@@ -3412,19 +3767,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %40
+ThrowNullRef2:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %47
+ThrowNullRef4:                                    ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %5
+ThrowNullRef6:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %32
+ThrowNullRef8:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3467,8 +3822,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
@@ -3492,11 +3847,391 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(i16* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store i16* %param0, i16** %arg0
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load i32, i32* %arg3
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %42, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %37, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg2
+  %13 = load i32, i32* %arg3
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %37, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %24 = load i32, i32* %arg2
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load i16*, i16** %arg0
+  %35 = load i32, i32* %arg3
+  %36 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %36, i16* %34, i32 %35)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:37                                      ; preds = %5, %16
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %39)
+  %41 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41, %System.String addrspace(1)* %38, %System.String addrspace(1)* %40)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41) #0
+  unreachable
+
+; <label>:42                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
-Failed to read StringBuilder.ToString[loadElemA]
+Successfully read StringBuilder.ToString
+
+define %System.String addrspace(1)* @StringBuilder.ToString(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i16*
+  %loc3 = alloca %"System.Char[]" addrspace(1)*
+  %loc4 = alloca i32
+  %loc5 = alloca i32
+  %loc6 = alloca i16 addrspace(1)*
+  %loc7 = alloca %System.String addrspace(1)*
+  %loc8 = alloca %"System.Char[]" addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %0)
+  %2 = icmp ne i32 %1, 0
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %4
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %6)
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %7)
+  store %System.String addrspace(1)* %8, %System.String addrspace(1)** %loc0
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.Text.StringBuilder addrspace(1)* %9, %System.Text.StringBuilder addrspace(1)** %loc1
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  store %System.String addrspace(1)* %10, %System.String addrspace(1)** %loc7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc7
+  %12 = ptrtoint %System.String addrspace(1)* %11 to i64
+  %13 = icmp eq i64 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %5
+  %15 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %16 = sext i32 %15 to i64
+  %17 = add i64 %12, %16
+  br label %18
+
+; <label>:18                                      ; preds = %5, %14
+  %19 = phi i64 [ %12, %5 ], [ %17, %14 ]
+  %20 = inttoptr i64 %19 to i16*
+  store i16* %20, i16** %loc2
+  br label %21
+
+; <label>:21                                      ; preds = %98, %18
+  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %22, null
+  br i1 %NullCheck, label %ThrowNullRef, label %23
+
+; <label>:23                                      ; preds = %21
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 3
+  %25 = load i32, i32 addrspace(1)* %24, align 8
+  %26 = icmp sle i32 %25, 0
+  br i1 %26, label %96, label %27
+
+; <label>:27                                      ; preds = %23
+  %28 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %28, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %29
+
+; <label>:29                                      ; preds = %27
+  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %28, i32 0, i32 1
+  %31 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %30, align 8
+  store %"System.Char[]" addrspace(1)* %31, %"System.Char[]" addrspace(1)** %loc3
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %33
+
+; <label>:33                                      ; preds = %29
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  store i32 %35, i32* %loc4
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  %39 = load i32, i32 addrspace(1)* %38, align 8
+  store i32 %39, i32* %loc5
+  %40 = load i32, i32* %loc5
+  %41 = load i32, i32* %loc4
+  %42 = add i32 %40, %41
+  %43 = zext i32 %42 to i64
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %45
+
+; <label>:45                                      ; preds = %37
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = sext i32 %47 to i64
+  %49 = icmp sgt i64 %43, %48
+  br i1 %49, label %91, label %50
+
+; <label>:50                                      ; preds = %45
+  %51 = load i32, i32* %loc5
+  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %52, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %53
+
+; <label>:53                                      ; preds = %50
+  %54 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %52, i32 0, i32 1
+  %55 = load i32, i32 addrspace(1)* %54
+  %56 = zext i32 %55 to i64
+  %57 = trunc i64 %56 to i32
+  %58 = icmp ugt i32 %51, %57
+  br i1 %58, label %91, label %59
+
+; <label>:59                                      ; preds = %53
+  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  store %"System.Char[]" addrspace(1)* %60, %"System.Char[]" addrspace(1)** %loc8
+  %61 = icmp eq %"System.Char[]" addrspace(1)* %60, null
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %63, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %64
+
+; <label>:64                                      ; preds = %62
+  %65 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %63, i32 0, i32 1
+  %66 = load i32, i32 addrspace(1)* %65
+  %67 = zext i32 %66 to i64
+  %68 = trunc i64 %67 to i32
+  %69 = icmp ne i32 %68, 0
+  br i1 %69, label %71, label %70
+
+; <label>:70                                      ; preds = %59, %64
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:71                                      ; preds = %64
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %73
+
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %BoundsCheck = icmp uge i64 0, %76
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %77
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %78, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:79                                      ; preds = %70, %77
+  %80 = load i16*, i16** %loc2
+  %81 = load i32, i32* %loc4
+  %82 = sext i32 %81 to i64
+  %83 = mul i64 %82, 2
+  %84 = bitcast i16* %80 to i8*
+  %85 = getelementptr inbounds i8, i8* %84, i64 %83
+  %86 = load i16 addrspace(1)*, i16 addrspace(1)** %loc6
+  %87 = ptrtoint i16 addrspace(1)* %86 to i64
+  %88 = load i32, i32* %loc5
+  %89 = bitcast i8* %85 to i16*
+  %90 = inttoptr i64 %87 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %89, i16* %90, i32 %88)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %96
+
+; <label>:91                                      ; preds = %45, %53
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %94 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %93)
+  %95 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95, %System.String addrspace(1)* %92, %System.String addrspace(1)* %94)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95) #0
+  unreachable
+
+; <label>:96                                      ; preds = %23, %79
+  %97 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %97, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %98
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %97, i32 0, i32 2
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  store %System.Text.StringBuilder addrspace(1)* %100, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %102 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %102, label %21, label %103
+
+; <label>:103                                     ; preds = %98
+  store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc7
+  %104 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  ret %System.String addrspace(1)* %104
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method StringBuilder::get_Length using LLILCJit
+Successfully read StringBuilder.get_Length
+
+define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
+Successfully read RuntimeHelpers.get_OffsetToStringData
+
+define i32 @RuntimeHelpers.get_OffsetToStringData() {
+entry:
+  ret i32 12
+}
+
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
 Successfully read CultureData.CreateCultureData
 
@@ -3514,23 +4249,23 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
   store i8 %4, i8 addrspace(1)* %6
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
@@ -3549,11 +4284,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3566,50 +4301,50 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
   store i32 -1, i32 addrspace(1)* %2
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
   store i32 -1, i32 addrspace(1)* %8
   %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
   store i32 -1, i32 addrspace(1)* %14
   %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
   store i32 -1, i32 addrspace(1)* %17
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
@@ -3623,27 +4358,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3675,7 +4410,136 @@ Failed to read Dictionary`2.Insert[non-const derefAddress]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
 Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
-Failed to read HashHelpers.GetPrime[loadElem]
+Successfully read HashHelpers.GetPrime
+
+define i32 @HashHelpers.GetPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %6, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5, %System.String addrspace(1)* %4)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5) #0
+  unreachable
+
+; <label>:6                                       ; preds = %entry
+  store i32 0, i32* %loc0
+  br label %29
+
+; <label>:7                                       ; preds = %35
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 1296
+  %10 = addrspacecast i8 addrspace(1)* %9 to %"System.Int32[]" addrspace(1)**
+  %11 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %10
+  %12 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Int32[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = zext i32 %15 to i64
+  %17 = zext i32 %12 to i64
+  %BoundsCheck = icmp uge i64 %17, %16
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 3, i32 %12
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  store i32 %20, i32* %loc1
+  %21 = load i32, i32* %loc1
+  %22 = load i32, i32* %arg0
+  %23 = icmp slt i32 %21, %22
+  br i1 %23, label %26, label %24
+
+; <label>:24                                      ; preds = %18
+  %25 = load i32, i32* %loc1
+  ret i32 %25
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %loc0
+  %28 = add i32 %27, 1
+  store i32 %28, i32* %loc0
+  br label %29
+
+; <label>:29                                      ; preds = %6, %26
+  %30 = load i32, i32* %loc0
+  %31 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %32 = getelementptr inbounds i8, i8 addrspace(1)* %31, i64 1296
+  %33 = addrspacecast i8 addrspace(1)* %32 to %"System.Int32[]" addrspace(1)**
+  %34 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %33
+  %NullCheck = icmp eq %"System.Int32[]" addrspace(1)* %34, null
+  br i1 %NullCheck, label %ThrowNullRef, label %35
+
+; <label>:35                                      ; preds = %29
+  %36 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %34, i32 0, i32 1
+  %37 = load i32, i32 addrspace(1)* %36
+  %38 = zext i32 %37 to i64
+  %39 = trunc i64 %38 to i32
+  %40 = icmp slt i32 %30, %39
+  br i1 %40, label %7, label %41
+
+; <label>:41                                      ; preds = %35
+  %42 = load i32, i32* %arg0
+  %43 = or i32 %42, 1
+  store i32 %43, i32* %loc2
+  br label %59
+
+; <label>:44                                      ; preds = %59
+  %45 = load i32, i32* %loc2
+  %46 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %45)
+  %47 = zext i8 %46 to i32
+  %48 = icmp eq i32 %47, 0
+  br i1 %48, label %56, label %49
+
+; <label>:49                                      ; preds = %44
+  %50 = load i32, i32* %loc2
+  %51 = sub i32 %50, 1
+  %52 = srem i32 %51, 101
+  %53 = icmp eq i32 %52, 0
+  br i1 %53, label %56, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = load i32, i32* %loc2
+  ret i32 %55
+
+; <label>:56                                      ; preds = %44, %49
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %57, 2
+  store i32 %58, i32* %loc2
+  br label %59
+
+; <label>:59                                      ; preds = %41, %56
+  %60 = load i32, i32* %loc2
+  %61 = icmp slt i32 %60, 2147483647
+  br i1 %61, label %44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load i32, i32* %arg0
+  ret i32 %63
+
+ThrowNullRef:                                     ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
 Successfully read GenericEqualityComparer`1.GetHashCode
 
@@ -3694,14 +4558,14 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
   %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load i64, i64 addrspace(1)* %7
@@ -3720,7 +4584,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3750,8 +4614,8 @@ entry:
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
@@ -3796,8 +4660,8 @@ entry:
   %35 = bitcast i16* %34 to i8*
   %36 = getelementptr inbounds i8, i8* %35, i64 2
   %37 = bitcast i8* %36 to i16*
-  %NullCheck4 = icmp ne i16* %37, null
-  br i1 %NullCheck4, label %38, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %37, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %38
 
 ; <label>:38                                      ; preds = %27
   %39 = load i16, i16* %37, align 8
@@ -3824,8 +4688,8 @@ entry:
 
 ; <label>:54                                      ; preds = %22, %43
   %55 = load i16*, i16** %loc4
-  %NullCheck2 = icmp ne i16* %55, null
-  br i1 %NullCheck2, label %56, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i16* %55, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %56
 
 ; <label>:56                                      ; preds = %54
   %57 = load i16, i16* %55, align 8
@@ -3850,11 +4714,11 @@ ThrowNullRef:                                     ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %54
+ThrowNullRef2:                                    ; preds = %54
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %27
+ThrowNullRef4:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3871,8 +4735,8 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -3907,8 +4771,8 @@ entry:
 
 ; <label>:26                                      ; preds = %19
   %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
-  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %28
 
 ; <label>:28                                      ; preds = %26
   %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
@@ -3920,7 +4784,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3972,8 +4836,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
@@ -3984,26 +4848,26 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
-  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
@@ -4014,8 +4878,8 @@ entry:
 ; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
@@ -4024,8 +4888,8 @@ entry:
 
 ; <label>:25                                      ; preds = %1, %16, %23
   %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
-  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
@@ -4036,27 +4900,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %20
+ThrowNullRef10:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4069,8 +4933,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -4081,8 +4945,8 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
@@ -4091,8 +4955,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1, %8
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
@@ -4103,11 +4967,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4128,24 +4992,24 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   store i32 %3, i32* %loc0
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
   %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
   store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck4, label %9, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
@@ -4164,15 +5028,15 @@ entry:
 ; <label>:18                                      ; preds = %70
   %19 = load i16*, i16** %loc3
   %20 = bitcast i16* %19 to i64*
-  %NullCheck10 = icmp ne i64* %20, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %20, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = load i64, i64* %20, align 8
   %23 = load i16*, i16** %loc4
   %24 = bitcast i16* %23 to i64*
-  %NullCheck12 = icmp ne i64* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = load i64, i64* %24, align 8
@@ -4188,8 +5052,8 @@ entry:
   %31 = bitcast i16* %30 to i8*
   %32 = getelementptr inbounds i8, i8* %31, i64 8
   %33 = bitcast i8* %32 to i64*
-  %NullCheck14 = icmp ne i64* %33, null
-  br i1 %NullCheck14, label %34, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = load i64, i64* %33, align 8
@@ -4197,8 +5061,8 @@ entry:
   %37 = bitcast i16* %36 to i8*
   %38 = getelementptr inbounds i8, i8* %37, i64 8
   %39 = bitcast i8* %38 to i64*
-  %NullCheck16 = icmp ne i64* %39, null
-  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %40
 
 ; <label>:40                                      ; preds = %34
   %41 = load i64, i64* %39, align 8
@@ -4214,8 +5078,8 @@ entry:
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %NullCheck18 = icmp ne i64* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = load i64, i64* %48, align 8
@@ -4223,8 +5087,8 @@ entry:
   %52 = bitcast i16* %51 to i8*
   %53 = getelementptr inbounds i8, i8* %52, i64 16
   %54 = bitcast i8* %53 to i64*
-  %NullCheck20 = icmp ne i64* %54, null
-  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64* %54, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %55
 
 ; <label>:55                                      ; preds = %49
   %56 = load i64, i64* %54, align 8
@@ -4262,15 +5126,15 @@ entry:
 ; <label>:74                                      ; preds = %95
   %75 = load i16*, i16** %loc3
   %76 = bitcast i16* %75 to i32*
-  %NullCheck6 = icmp ne i32* %76, null
-  br i1 %NullCheck6, label %77, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32* %76, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %77
 
 ; <label>:77                                      ; preds = %74
   %78 = load i32, i32* %76, align 8
   %79 = load i16*, i16** %loc4
   %80 = bitcast i16* %79 to i32*
-  %NullCheck8 = icmp ne i32* %80, null
-  br i1 %NullCheck8, label %81, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i32* %80, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %81
 
 ; <label>:81                                      ; preds = %77
   %82 = load i32, i32* %80, align 8
@@ -4318,43 +5182,43 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %74
+ThrowNullRef6:                                    ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %77
+ThrowNullRef8:                                    ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %29
+ThrowNullRef14:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %34
+ThrowNullRef16:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4376,8 +5240,8 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load i64, i64 addrspace(1)* %4
@@ -4389,8 +5253,8 @@ entry:
   %12 = load i64, i64* %11
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %5
   %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
@@ -4399,8 +5263,8 @@ entry:
   %18 = load i8, i8* %arg2
   %19 = zext i8 %18 to i32
   %20 = trunc i32 %19 to i8
-  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %15
   %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
@@ -4411,11 +5275,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4442,8 +5306,8 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
@@ -4466,16 +5330,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
   %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = load i64, i64 addrspace(1)* %19
@@ -4500,8 +5364,8 @@ entry:
 ; <label>:35                                      ; preds = %30
   %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
@@ -4514,8 +5378,8 @@ entry:
 
 ; <label>:42                                      ; preds = %1, %38
   %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
-  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
@@ -4526,19 +5390,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %35
+ThrowNullRef2:                                    ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %42
+ThrowNullRef8:                                    ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4551,14 +5415,14 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
@@ -4570,7 +5434,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4583,8 +5447,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
@@ -4613,51 +5477,51 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
   %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
   %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
   %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
   %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
-  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
   store i64 %21, i64 addrspace(1)* %23
   %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %25 = load i64, i64* %loc0
-  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
@@ -4668,27 +5532,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %22
+ThrowNullRef12:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4701,8 +5565,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
@@ -4713,19 +5577,19 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
@@ -4734,8 +5598,8 @@ entry:
 
 ; <label>:15                                      ; preds = %1, %13
   %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
@@ -4746,19 +5610,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %15
+ThrowNullRef8:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4771,8 +5635,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -4831,8 +5695,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
@@ -4882,8 +5746,8 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
-  br i1 %NullCheck, label %17, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %ThrowNullRef, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
@@ -4894,15 +5758,15 @@ entry:
 
 ; <label>:22                                      ; preds = %17
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
-  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
   %26 = load i32, i32 addrspace(1)* %25
   %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
-  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %27, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
@@ -4925,8 +5789,8 @@ entry:
 ; <label>:40                                      ; preds = %17
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
-  br i1 %NullCheck6, label %43, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %41, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
@@ -4938,34 +5802,17 @@ ThrowNullRef:                                     ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %24
+ThrowNullRef4:                                    ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %40
+ThrowNullRef6:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
-}
-
-INFO:  jitting method Object::ReferenceEquals using LLILCJit
-Successfully read Object.ReferenceEquals
-
-define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
-entry:
-  %arg0 = alloca %System.Object addrspace(1)*
-  %arg1 = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
-  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
-  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = icmp eq %System.Object addrspace(1)* %0, %1
-  %3 = sext i1 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
 }
 
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
@@ -4978,21 +5825,21 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
   %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
-  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
@@ -5007,28 +5854,28 @@ entry:
 ; <label>:13                                      ; preds = %8, %12
   %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
   %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
   %21 = load i32, i32 addrspace(1)* %20, align 8
   %22 = add i32 %21, 1
-  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
   store i32 %22, i32 addrspace(1)* %24
   %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
@@ -5039,27 +5886,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5077,7 +5924,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::Setup using LLILCJit
-Failed to read AppDomain.Setup[loadElem]
+Failed to read AppDomain.Setup[unbox]
 INFO:  jitting method Thread::GetDomain using LLILCJit
 Successfully read Thread.GetDomain
 
@@ -5108,8 +5955,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
@@ -5122,14 +5969,14 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
   %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
@@ -5141,11 +5988,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5173,8 +6020,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -5189,7 +6036,328 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
 Failed to read KeyCollection.System.Collections.Generic.IEnumerable<TKey>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Successfully read Enumerator.MoveNext
+
+define i8 @Enumerator.MoveNext(%"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.RuntimeTypeHandle* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*
+  %"$TypeArg" = alloca %System.RuntimeTypeHandle*
+  store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
+  %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 8
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %76, label %12
+
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
+  br label %76
+
+; <label>:13                                      ; preds = %85
+  %14 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck19 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %15
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, i32 0, i32 0
+  %17 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %16, align 8
+  %NullCheck21 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, i32 0, i32 2
+  %20 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %19, align 8
+  %21 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck23 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %22
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, i32 0, i32 2
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %NullCheck25 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 3, i32 %24
+  %NullCheck27 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %32
+
+; <label>:32                                      ; preds = %30
+  %33 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, i32 0, i32 2
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = icmp slt i32 %34, 0
+  br i1 %35, label %68, label %36
+
+; <label>:36                                      ; preds = %32
+  %37 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %38 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck29 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %39
+
+; <label>:39                                      ; preds = %36
+  %40 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, i32 0, i32 0
+  %41 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %40, align 8
+  %NullCheck31 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, i32 0, i32 2
+  %44 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %43, align 8
+  %45 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck33 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, i32 0, i32 2
+  %48 = load i32, i32 addrspace(1)* %47, align 8
+  %NullCheck35 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %49
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = zext i32 %51 to i64
+  %53 = zext i32 %48 to i64
+  %BoundsCheck37 = icmp uge i64 %53, %52
+  br i1 %BoundsCheck37, label %ThrowIndexOutOfRange38, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 3, i32 %48
+  %NullCheck39 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %56
+
+; <label>:56                                      ; preds = %54
+  %57 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, i32 0, i32 0
+  %58 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck41 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %59
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %60, %System.__Canon addrspace(1)* %58)
+  %61 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck43 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  %64 = load i32, i32 addrspace(1)* %63, align 8
+  %65 = add i32 %64, 1
+  %NullCheck45 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  store i32 %65, i32 addrspace(1)* %67
+  ret i8 1
+
+; <label>:68                                      ; preds = %32
+  %69 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck47 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %73 = add i32 %72, 1
+  %NullCheck49 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %74
+
+; <label>:74                                      ; preds = %70
+  %75 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  store i32 %73, i32 addrspace(1)* %75
+  br label %76
+
+; <label>:76                                      ; preds = %8, %12, %74
+  %77 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %78
+
+; <label>:78                                      ; preds = %76
+  %79 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, i32 0, i32 2
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck7 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %82
+
+; <label>:82                                      ; preds = %78
+  %83 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, i32 0, i32 0
+  %84 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %83, align 8
+  %NullCheck9 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %85
+
+; <label>:85                                      ; preds = %82
+  %86 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, i32 0, i32 7
+  %87 = load i32, i32 addrspace(1)* %86, align 8
+  %88 = icmp ult i32 %80, %87
+  br i1 %88, label %13, label %89
+
+; <label>:89                                      ; preds = %85
+  %90 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %91 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck11 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %92
+
+; <label>:92                                      ; preds = %89
+  %93 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, i32 0, i32 0
+  %94 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck13 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %95
+
+; <label>:95                                      ; preds = %92
+  %96 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, i32 0, i32 7
+  %97 = load i32, i32 addrspace(1)* %96, align 8
+  %98 = add i32 %97, 1
+  %NullCheck15 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %99
+
+; <label>:99                                      ; preds = %95
+  %100 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, i32 0, i32 2
+  store i32 %98, i32 addrspace(1)* %100
+  %101 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck17 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %102
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %103, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %92
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef22:                                   ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef24:                                   ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef26:                                   ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef28:                                   ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef30:                                   ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef32:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef34:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef36:                                   ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange38:                           ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef40:                                   ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef42:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef44:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef46:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef48:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef50:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -5200,8 +6368,8 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -5232,9 +6400,9 @@ Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
 Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
-Failed to read String.MakeSeparatorList[loadElemA]
+Failed to read String.MakeSeparatorList[storeElem]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
-Failed to read String.InternalSplitKeepEmptyEntries[loadElem]
+Failed to read String.InternalSplitKeepEmptyEntries[storeElem]
 INFO:  jitting method Path::IsRelative using LLILCJit
 Successfully read Path.IsRelative
 
@@ -5243,8 +6411,8 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -5254,8 +6422,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
@@ -5271,8 +6439,8 @@ entry:
 
 ; <label>:17                                      ; preds = %7
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
@@ -5288,8 +6456,8 @@ entry:
 
 ; <label>:29                                      ; preds = %19
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %31
 
 ; <label>:31                                      ; preds = %29
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
@@ -5300,8 +6468,8 @@ entry:
 
 ; <label>:36                                      ; preds = %31
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
-  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %37, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
@@ -5312,8 +6480,8 @@ entry:
 
 ; <label>:43                                      ; preds = %31, %38
   %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
-  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %45
 
 ; <label>:45                                      ; preds = %43
   %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
@@ -5324,8 +6492,8 @@ entry:
 
 ; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %50
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
@@ -5336,8 +6504,8 @@ entry:
 
 ; <label>:57                                      ; preds = %1, %7, %19, %45, %52
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
-  br i1 %NullCheck14, label %59, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %59
 
 ; <label>:59                                      ; preds = %57
   %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
@@ -5347,8 +6515,8 @@ entry:
 
 ; <label>:63                                      ; preds = %59
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
@@ -5359,8 +6527,8 @@ entry:
 
 ; <label>:70                                      ; preds = %65
   %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
-  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.String addrspace(1)* %71, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %72
 
 ; <label>:72                                      ; preds = %70
   %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
@@ -5379,39 +6547,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %17
+ThrowNullRef4:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %29
+ThrowNullRef6:                                    ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %36
+ThrowNullRef8:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %43
+ThrowNullRef10:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %50
+ThrowNullRef12:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %57
+ThrowNullRef14:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %63
+ThrowNullRef16:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %70
+ThrowNullRef18:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5419,7 +6587,293 @@ ThrowNullRef17:                                   ; preds = %70
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
-Failed to read String.TrimHelper[loadElem]
+Successfully read String.TrimHelper
+
+define %System.String addrspace(1)* @String.TrimHelper(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i16
+  %loc4 = alloca i32
+  %loc5 = alloca i16
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = sub i32 %3, 1
+  store i32 %4, i32* %loc0
+  store i32 0, i32* %loc1
+  %5 = load i32, i32* %arg2
+  %6 = icmp eq i32 %5, 1
+  br i1 %6, label %62, label %7
+
+; <label>:7                                       ; preds = %1
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:8                                       ; preds = %58
+  store i32 0, i32* %loc2
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load i32, i32* %loc1
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2, i32 %10
+  %13 = load i16, i16 addrspace(1)* %12
+  %14 = zext i16 %13 to i32
+  %15 = trunc i32 %14 to i16
+  store i16 %15, i16* %loc3
+  store i32 0, i32* %loc2
+  br label %34
+
+; <label>:16                                      ; preds = %37
+  %17 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %18 = load i32, i32* %loc2
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %17, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %19
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = zext i32 %18 to i64
+  %BoundsCheck = icmp uge i64 %23, %22
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %24
+
+; <label>:24                                      ; preds = %19
+  %25 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 3, i32 %18
+  %26 = load i16, i16 addrspace(1)* %25, align 8
+  %27 = zext i16 %26 to i32
+  %28 = load i16, i16* %loc3
+  %29 = zext i16 %28 to i32
+  %30 = icmp eq i32 %27, %29
+  br i1 %30, label %43, label %31
+
+; <label>:31                                      ; preds = %24
+  %32 = load i32, i32* %loc2
+  %33 = add i32 %32, 1
+  store i32 %33, i32* %loc2
+  br label %34
+
+; <label>:34                                      ; preds = %11, %31
+  %35 = load i32, i32* %loc2
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = icmp slt i32 %35, %41
+  br i1 %42, label %16, label %43
+
+; <label>:43                                      ; preds = %24, %37
+  %44 = load i32, i32* %loc2
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %45, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp eq i32 %44, %50
+  br i1 %51, label %62, label %52
+
+; <label>:52                                      ; preds = %46
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %7, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %57, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %58
+
+; <label>:58                                      ; preds = %55
+  %59 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %60 = load i32, i32 addrspace(1)* %59
+  %61 = icmp slt i32 %56, %60
+  br i1 %61, label %8, label %62
+
+; <label>:62                                      ; preds = %1, %46, %58
+  %63 = load i32, i32* %arg2
+  %64 = icmp eq i32 %63, 0
+  br i1 %64, label %122, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %66, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %67
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %66, i32 0, i32 1
+  %69 = load i32, i32 addrspace(1)* %68
+  %70 = sub i32 %69, 1
+  store i32 %70, i32* %loc0
+  br label %118
+
+; <label>:71                                      ; preds = %118
+  store i32 0, i32* %loc4
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %73 = load i32, i32* %loc0
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %74
+
+; <label>:74                                      ; preds = %71
+  %75 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 2, i32 %73
+  %76 = load i16, i16 addrspace(1)* %75
+  %77 = zext i16 %76 to i32
+  %78 = trunc i32 %77 to i16
+  store i16 %78, i16* %loc5
+  store i32 0, i32* %loc4
+  br label %97
+
+; <label>:79                                      ; preds = %100
+  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %81 = load i32, i32* %loc4
+  %NullCheck19 = icmp eq %"System.Char[]" addrspace(1)* %80, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
+
+; <label>:82                                      ; preds = %79
+  %83 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 1
+  %84 = load i32, i32 addrspace(1)* %83
+  %85 = zext i32 %84 to i64
+  %86 = zext i32 %81 to i64
+  %BoundsCheck21 = icmp uge i64 %86, %85
+  br i1 %BoundsCheck21, label %ThrowIndexOutOfRange22, label %87
+
+; <label>:87                                      ; preds = %82
+  %88 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 3, i32 %81
+  %89 = load i16, i16 addrspace(1)* %88, align 8
+  %90 = zext i16 %89 to i32
+  %91 = load i16, i16* %loc5
+  %92 = zext i16 %91 to i32
+  %93 = icmp eq i32 %90, %92
+  br i1 %93, label %106, label %94
+
+; <label>:94                                      ; preds = %87
+  %95 = load i32, i32* %loc4
+  %96 = add i32 %95, 1
+  store i32 %96, i32* %loc4
+  br label %97
+
+; <label>:97                                      ; preds = %74, %94
+  %98 = load i32, i32* %loc4
+  %99 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck15 = icmp eq %"System.Char[]" addrspace(1)* %99, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %100
+
+; <label>:100                                     ; preds = %97
+  %101 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %99, i32 0, i32 1
+  %102 = load i32, i32 addrspace(1)* %101
+  %103 = zext i32 %102 to i64
+  %104 = trunc i64 %103 to i32
+  %105 = icmp slt i32 %98, %104
+  br i1 %105, label %79, label %106
+
+; <label>:106                                     ; preds = %87, %100
+  %107 = load i32, i32* %loc4
+  %108 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck17 = icmp eq %"System.Char[]" addrspace(1)* %108, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %109
+
+; <label>:109                                     ; preds = %106
+  %110 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %108, i32 0, i32 1
+  %111 = load i32, i32 addrspace(1)* %110
+  %112 = zext i32 %111 to i64
+  %113 = trunc i64 %112 to i32
+  %114 = icmp eq i32 %107, %113
+  br i1 %114, label %122, label %115
+
+; <label>:115                                     ; preds = %109
+  %116 = load i32, i32* %loc0
+  %117 = sub i32 %116, 1
+  store i32 %117, i32* %loc0
+  br label %118
+
+; <label>:118                                     ; preds = %67, %115
+  %119 = load i32, i32* %loc0
+  %120 = load i32, i32* %loc1
+  %121 = icmp sge i32 %119, %120
+  br i1 %121, label %71, label %122
+
+; <label>:122                                     ; preds = %62, %109, %118
+  %123 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %124 = load i32, i32* %loc1
+  %125 = load i32, i32* %loc0
+  %126 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %123, i32 %124, i32 %125)
+  ret %System.String addrspace(1)* %126
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %97
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange22:                           ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
 Successfully read String.CreateTrimmedString
 
@@ -5439,8 +6893,8 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
@@ -5535,8 +6989,8 @@ entry:
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i64 2872
   %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
   %8 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %7
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %3
   %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
@@ -5553,8 +7007,8 @@ entry:
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 2864
   %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
   %21 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %20
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
-  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %22
 
 ; <label>:22                                      ; preds = %16
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
@@ -5569,7 +7023,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %16
+ThrowNullRef2:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5586,8 +7040,8 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5613,8 +7067,8 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
@@ -5632,8 +7086,8 @@ entry:
 
 ; <label>:12                                      ; preds = %4
   %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
@@ -5644,8 +7098,8 @@ entry:
 
 ; <label>:19                                      ; preds = %14
   %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %19
   %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
@@ -5660,21 +7114,21 @@ entry:
   %31 = zext i16 %30 to i32
   %32 = bitcast i8* %29 to i16*
   %33 = trunc i32 %31 to i16
-  %NullCheck6 = icmp ne i16* %32, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i16* %32, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %21
   store i16 %33, i16* %32, align 8
   %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %36
 
 ; <label>:36                                      ; preds = %34
   %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
   %38 = load i32, i32 addrspace(1)* %37, align 8
   %39 = add i32 %38, 1
-  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %40
 
 ; <label>:40                                      ; preds = %36
   %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
@@ -5683,16 +7137,16 @@ entry:
 
 ; <label>:42                                      ; preds = %14
   %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
-  br i1 %NullCheck12, label %44, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
   %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
   %47 = load i16, i16* %arg1
   %48 = zext i16 %47 to i32
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = trunc i32 %48 to i16
@@ -5703,31 +7157,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %19
+ThrowNullRef4:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %21
+ThrowNullRef6:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %36
+ThrowNullRef10:                                   ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %42
+ThrowNullRef12:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %44
+ThrowNullRef14:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5740,8 +7194,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -5752,8 +7206,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
@@ -5762,14 +7216,14 @@ entry:
 
 ; <label>:11                                      ; preds = %1
   %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
@@ -5779,15 +7233,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5808,8 +7262,8 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5822,8 +7276,8 @@ entry:
 
 ; <label>:8                                       ; preds = %3
   %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
@@ -5842,15 +7296,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
-  br i1 %NullCheck4, label %22, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
   %24 = load i16*, i16* addrspace(1)* %23, align 8
   %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %25, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
@@ -5859,8 +7313,8 @@ entry:
   store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
@@ -5874,8 +7328,8 @@ entry:
 
 ; <label>:37                                      ; preds = %65
   %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %37
   %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
@@ -5886,16 +7340,16 @@ entry:
   %45 = bitcast i16* %41 to i8*
   %46 = getelementptr inbounds i8, i8* %45, i64 %44
   %47 = bitcast i8* %46 to i16*
-  %NullCheck14 = icmp ne i16* %47, null
-  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %47, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %48
 
 ; <label>:48                                      ; preds = %39
   %49 = load i16, i16* %47, align 8
   %50 = zext i16 %49 to i32
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %52 = load i32, i32* %loc1
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %53
 
 ; <label>:53                                      ; preds = %48
   %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
@@ -5916,8 +7370,8 @@ entry:
 ; <label>:62                                      ; preds = %36, %59
   %63 = load i32, i32* %loc1
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck10, label %65, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %65
 
 ; <label>:65                                      ; preds = %62
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
@@ -5936,15 +7390,15 @@ entry:
 
 ; <label>:74                                      ; preds = %70
   %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
-  br i1 %NullCheck18, label %76, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %76
 
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
   %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
-  br i1 %NullCheck20, label %80, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
   %81 = load i64, i64 addrspace(1)* %79
@@ -5958,8 +7412,8 @@ entry:
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
   %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
-  br i1 %NullCheck22, label %92, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.String addrspace(1)* %90, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %92
 
 ; <label>:92                                      ; preds = %80
   %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
@@ -5969,15 +7423,15 @@ entry:
 
 ; <label>:96                                      ; preds = %70
   %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
-  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %98
 
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
   %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
-  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
   %103 = load i64, i64 addrspace(1)* %101
@@ -5991,8 +7445,8 @@ entry:
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
   %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
-  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.String addrspace(1)* %112, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %114
 
 ; <label>:114                                     ; preds = %102
   %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
@@ -6004,59 +7458,59 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %20
+ThrowNullRef4:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %22
+ThrowNullRef6:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %26
+ThrowNullRef8:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %62
+ThrowNullRef10:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %48
+ThrowNullRef16:                                   ; preds = %48
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %74
+ThrowNullRef18:                                   ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %76
+ThrowNullRef20:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %80
+ThrowNullRef22:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %96
+ThrowNullRef24:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %98
+ThrowNullRef26:                                   ; preds = %98
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %102
+ThrowNullRef28:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6069,15 +7523,15 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
   %3 = load i16*, i16* addrspace(1)* %2, align 8
   %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
@@ -6087,8 +7541,8 @@ entry:
   %10 = bitcast i16* %3 to i8*
   %11 = getelementptr inbounds i8, i8* %10, i64 %9
   %12 = bitcast i8* %11 to i16*
-  %NullCheck4 = icmp ne i16* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %5
   store i16 0, i16* %12, align 8
@@ -6098,11 +7552,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6119,8 +7573,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -6131,8 +7585,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
@@ -6144,15 +7598,15 @@ entry:
 
 ; <label>:14                                      ; preds = %1
   %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
   %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
   %21 = load i64, i64 addrspace(1)* %19
@@ -6171,15 +7625,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %14
+ThrowNullRef4:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %16
+ThrowNullRef6:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6302,14 +7756,6 @@ entry:
   ret %System.String addrspace(1)* %57
 }
 
-INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
-Successfully read RuntimeHelpers.get_OffsetToStringData
-
-define i32 @RuntimeHelpers.get_OffsetToStringData() {
-entry:
-  ret i32 12
-}
-
 INFO:  jitting method String::Equals using LLILCJit
 Successfully read String.Equals
 
@@ -6381,8 +7827,8 @@ entry:
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
-  br i1 %NullCheck24, label %29, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
   %30 = load i64, i64 addrspace(1)* %28
@@ -6397,8 +7843,8 @@ entry:
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
-  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
   %43 = load i64, i64 addrspace(1)* %41
@@ -6418,8 +7864,8 @@ entry:
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
   %59 = load i64, i64 addrspace(1)* %57
@@ -6434,8 +7880,8 @@ entry:
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck22, label %71, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
   %72 = load i64, i64 addrspace(1)* %70
@@ -6455,8 +7901,8 @@ entry:
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
-  br i1 %NullCheck16, label %87, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = load i64, i64 addrspace(1)* %86
@@ -6471,8 +7917,8 @@ entry:
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck18, label %100, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
   %101 = load i64, i64 addrspace(1)* %99
@@ -6492,8 +7938,8 @@ entry:
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
-  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
   %117 = load i64, i64 addrspace(1)* %115
@@ -6508,8 +7954,8 @@ entry:
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
-  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
   %130 = load i64, i64 addrspace(1)* %128
@@ -6528,15 +7974,15 @@ entry:
 
 ; <label>:142                                     ; preds = %22
   %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
-  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %143, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %144
 
 ; <label>:144                                     ; preds = %142
   %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
   %146 = load i32, i32 addrspace(1)* %145
   %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
-  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %147, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %148
 
 ; <label>:148                                     ; preds = %144
   %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
@@ -6557,15 +8003,15 @@ entry:
 
 ; <label>:159                                     ; preds = %22
   %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
-  br i1 %NullCheck, label %161, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %ThrowNullRef, label %161
 
 ; <label>:161                                     ; preds = %159
   %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
   %163 = load i32, i32 addrspace(1)* %162
   %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
-  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %164, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %165
 
 ; <label>:165                                     ; preds = %161
   %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
@@ -6578,8 +8024,8 @@ entry:
 
 ; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
-  br i1 %NullCheck4, label %172, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %171, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %172
 
 ; <label>:172                                     ; preds = %170
   %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
@@ -6589,8 +8035,8 @@ entry:
 
 ; <label>:176                                     ; preds = %172
   %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
-  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %177, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %178
 
 ; <label>:178                                     ; preds = %176
   %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
@@ -6629,55 +8075,55 @@ ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %161
+ThrowNullRef2:                                    ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %170
+ThrowNullRef4:                                    ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %176
+ThrowNullRef6:                                    ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %142
+ThrowNullRef8:                                    ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %144
+ThrowNullRef10:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %113
+ThrowNullRef12:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %116
+ThrowNullRef14:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %84
+ThrowNullRef16:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %87
+ThrowNullRef18:                                   ; preds = %87
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %55
+ThrowNullRef20:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %58
+ThrowNullRef22:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %26
+ThrowNullRef24:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %29
+ThrowNullRef26:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,8 +8161,8 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck, label %14, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %ThrowNullRef, label %14
 
 ; <label>:14                                      ; preds = %8
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
@@ -6760,8 +8206,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
@@ -6770,14 +8216,14 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32, i32* %loc0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %10
   %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
   %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
@@ -6790,15 +8236,15 @@ entry:
 ; <label>:25                                      ; preds = %19
   %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
-  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
   %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
@@ -6807,8 +8253,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %37 = load i32, i32* %loc0
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %38, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %38
 
 ; <label>:38                                      ; preds = %32
   %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
@@ -6817,14 +8263,14 @@ entry:
 
 ; <label>:40                                      ; preds = %19
   %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %40
   %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
   %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
-  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
-  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
@@ -6832,8 +8278,8 @@ entry:
   %48 = zext i32 %47 to i64
   %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
-  br i1 %NullCheck16, label %51, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %51
 
 ; <label>:51                                      ; preds = %45
   %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
@@ -6847,15 +8293,15 @@ entry:
 ; <label>:57                                      ; preds = %51
   %58 = load i16*, i16** %arg1
   %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
-  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %60
 
 ; <label>:60                                      ; preds = %57
   %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
   %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
-  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %64
 
 ; <label>:64                                      ; preds = %60
   %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
@@ -6864,22 +8310,22 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
   %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
-  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %70
 
 ; <label>:70                                      ; preds = %64
   %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
   %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
-  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
-  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
   %75 = load i32, i32 addrspace(1)* %74
   %76 = zext i32 %75 to i64
   %77 = trunc i64 %76 to i32
-  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
-  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %78
 
 ; <label>:78                                      ; preds = %73
   %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
@@ -6901,8 +8347,8 @@ entry:
   %90 = bitcast i16* %86 to i8*
   %91 = getelementptr inbounds i8, i8* %90, i64 %89
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %93
 
 ; <label>:93                                      ; preds = %80
   %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
@@ -6912,8 +8358,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %99 = load i32, i32* %loc2
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %100
 
 ; <label>:100                                     ; preds = %93
   %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
@@ -6928,63 +8374,63 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %25
+ThrowNullRef6:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %32
+ThrowNullRef10:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %40
+ThrowNullRef12:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %45
+ThrowNullRef16:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %57
+ThrowNullRef18:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %60
+ThrowNullRef20:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %64
+ThrowNullRef22:                                   ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %70
+ThrowNullRef24:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %73
+ThrowNullRef26:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %80
+ThrowNullRef28:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %93
+ThrowNullRef30:                                   ; preds = %93
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7004,8 +8450,8 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
@@ -7033,43 +8479,43 @@ entry:
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %14
   %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
   %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   %28 = load i32, i32 addrspace(1)* %27, align 8
   %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
-  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %30
 
 ; <label>:30                                      ; preds = %26
   %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
   %32 = load i32, i32 addrspace(1)* %31, align 8
   %33 = add i32 %28, %32
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %34
 
 ; <label>:34                                      ; preds = %30
   %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   store i32 %33, i32 addrspace(1)* %35
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
   store i32 0, i32 addrspace(1)* %38
   %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %40
 
 ; <label>:40                                      ; preds = %37
   %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
@@ -7082,8 +8528,8 @@ entry:
 
 ; <label>:47                                      ; preds = %40
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
@@ -7098,8 +8544,8 @@ entry:
   %54 = load i32, i32* %loc0
   %55 = sext i32 %54 to i64
   %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
-  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %57
 
 ; <label>:57                                      ; preds = %52
   %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
@@ -7110,68 +8556,35 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %14
+ThrowNullRef2:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %23
+ThrowNullRef4:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %26
+ThrowNullRef6:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %30
+ThrowNullRef8:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %34
+ThrowNullRef10:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %47
+ThrowNullRef14:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %52
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-}
-
-INFO:  jitting method StringBuilder::get_Length using LLILCJit
-Successfully read StringBuilder.get_Length
-
-define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.StringBuilder addrspace(1)*
-  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
-  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
-
-; <label>:1                                       ; preds = %entry
-  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %3 = load i32, i32 addrspace(1)* %2, align 8
-  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
-
-; <label>:5                                       ; preds = %1
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = add i32 %3, %7
-  ret i32 %8
-
-ThrowNullRef:                                     ; preds = %entry
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef16:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7213,70 +8626,70 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
   %6 = load i32, i32 addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
   store i32 %6, i32 addrspace(1)* %8
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
   %13 = load i32, i32 addrspace(1)* %12, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
   store i32 %13, i32 addrspace(1)* %15
   %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
-  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %18
 
 ; <label>:18                                      ; preds = %14
   %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
   %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
   %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
   %34 = load i32, i32 addrspace(1)* %33, align 8
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
-  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
@@ -7287,39 +8700,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %28
+ThrowNullRef16:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %32
+ThrowNullRef18:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7455,13 +8868,13 @@ entry:
 ; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
@@ -7477,16 +8890,16 @@ entry:
 
 ; <label>:18                                      ; preds = %15
   %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
   store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
   %22 = load i32, i32* %loc0
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %24
 
 ; <label>:24                                      ; preds = %20
   %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
@@ -7498,13 +8911,13 @@ entry:
 ; <label>:28                                      ; preds = %15, %24
   %29 = load i32, i32* %arg1
   %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %31
   %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
@@ -7517,20 +8930,20 @@ entry:
   %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
-  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
   %46 = load i32, i32 addrspace(1)* %45, align 8
   %47 = sub i32 %40, %46
-  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
-  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i32 addrspace(1)* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %48
 
 ; <label>:48                                      ; preds = %44
   store i32 %47, i32 addrspace(1)* %39, align 8
@@ -7538,21 +8951,21 @@ entry:
 
 ; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
-  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %51
 
 ; <label>:51                                      ; preds = %49
   %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %53
 
 ; <label>:53                                      ; preds = %51
   %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
   %55 = load i32, i32 addrspace(1)* %54, align 8
   %56 = load i32, i32* %arg2
   %57 = sub i32 %55, %56
-  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %58
 
 ; <label>:58                                      ; preds = %53
   %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
@@ -7562,13 +8975,13 @@ entry:
 ; <label>:60                                      ; preds = %33, %58
   %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
   %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
-  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %63
 
 ; <label>:63                                      ; preds = %60
   %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
-  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
-  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
@@ -7578,15 +8991,15 @@ entry:
 
 ; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
-  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i32 addrspace(1)* %69, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %70
 
 ; <label>:70                                      ; preds = %68
   %71 = load i32, i32 addrspace(1)* %69, align 8
   store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
-  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
@@ -7596,8 +9009,8 @@ entry:
   store i32 %77, i32* %loc4
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
-  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %80
 
 ; <label>:80                                      ; preds = %73
   %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
@@ -7607,71 +9020,71 @@ entry:
 ; <label>:83                                      ; preds = %80
   store i32 0, i32* %loc3
   %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
-  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
-  br i1 %NullCheck26, label %88, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i32 addrspace(1)* %87, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %88
 
 ; <label>:88                                      ; preds = %85
   %89 = load i32, i32 addrspace(1)* %87, align 8
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
-  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %90
 
 ; <label>:90                                      ; preds = %88
   %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
   store i32 %89, i32 addrspace(1)* %91
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
-  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
-  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %96
 
 ; <label>:96                                      ; preds = %94
   %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
-  br i1 %NullCheck34, label %100, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %100
 
 ; <label>:100                                     ; preds = %96
   %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
-  br i1 %NullCheck36, label %102, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %102
 
 ; <label>:102                                     ; preds = %100
   %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
   %104 = load i32, i32 addrspace(1)* %103, align 8
   %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
-  br i1 %NullCheck38, label %106, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %106
 
 ; <label>:106                                     ; preds = %102
   %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
-  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
-  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %108
 
 ; <label>:108                                     ; preds = %106
   %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
   %110 = load i32, i32 addrspace(1)* %109, align 8
   %111 = add i32 %104, %110
-  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %112
 
 ; <label>:112                                     ; preds = %108
   %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
   store i32 %111, i32 addrspace(1)* %113
   %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
-  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i32 addrspace(1)* %114, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %115
 
 ; <label>:115                                     ; preds = %112
   %116 = load i32, i32 addrspace(1)* %114, align 8
@@ -7681,19 +9094,19 @@ entry:
 ; <label>:118                                     ; preds = %115
   %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
-  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %121
 
 ; <label>:121                                     ; preds = %118
   %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
-  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
-  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %123
 
 ; <label>:123                                     ; preds = %121
   %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
   %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
-  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
-  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %126
 
 ; <label>:126                                     ; preds = %123
   %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
@@ -7705,8 +9118,8 @@ entry:
 
 ; <label>:130                                     ; preds = %80, %115, %126
   %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %132
 
 ; <label>:132                                     ; preds = %130
   %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7715,8 +9128,8 @@ entry:
   %136 = load i32, i32* %loc3
   %137 = sub i32 %135, %136
   %138 = sub i32 %134, %137
-  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %139
 
 ; <label>:139                                     ; preds = %132
   %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7728,16 +9141,16 @@ entry:
 
 ; <label>:144                                     ; preds = %139
   %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
-  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %146
 
 ; <label>:146                                     ; preds = %144
   %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
   %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
   %149 = load i32, i32* %loc2
   %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
-  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %151
 
 ; <label>:151                                     ; preds = %146
   %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
@@ -7754,145 +9167,249 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %18
+ThrowNullRef4:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %31
+ThrowNullRef10:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %44
+ThrowNullRef16:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %68
+ThrowNullRef18:                                   ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %70
+ThrowNullRef20:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %73
+ThrowNullRef22:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %83
+ThrowNullRef24:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %85
+ThrowNullRef26:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %88
+ThrowNullRef28:                                   ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %90
+ThrowNullRef30:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %94
+ThrowNullRef32:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %96
+ThrowNullRef34:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %100
+ThrowNullRef36:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %102
+ThrowNullRef38:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %106
+ThrowNullRef40:                                   ; preds = %106
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %108
+ThrowNullRef42:                                   ; preds = %108
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %112
+ThrowNullRef44:                                   ; preds = %112
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %118
+ThrowNullRef46:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %121
+ThrowNullRef48:                                   ; preds = %121
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %123
+ThrowNullRef50:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %130
+ThrowNullRef52:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %132
+ThrowNullRef54:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %144
+ThrowNullRef56:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %146
+ThrowNullRef58:                                   ; preds = %146
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %60
+ThrowNullRef60:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %63
+ThrowNullRef62:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %49
+ThrowNullRef64:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %51
+ThrowNullRef66:                                   ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %53
+ThrowNullRef68:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(%"System.Char[]" addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %arg0 = alloca %"System.Char[]" addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store %"System.Char[]" addrspace(1)* %param0, %"System.Char[]" addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load i32, i32* %arg4
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %43, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %38, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg1
+  %13 = load i32, i32* %arg4
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %38, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %24 = load i32, i32* %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %35 = load i32, i32* %arg3
+  %36 = load i32, i32* %arg4
+  %37 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %37, %"System.Char[]" addrspace(1)* %34, i32 %35, i32 %36)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:38                                      ; preds = %5, %16
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Successfully read Buffer._Memmove
 
@@ -7914,7 +9431,7 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[loadElem]
+Failed to read AppDomain.SetDataHelper[storeElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -7923,8 +9440,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
@@ -7934,8 +9451,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
@@ -7947,15 +9464,15 @@ entry:
   %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
   %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
@@ -7966,15 +9483,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7992,7 +9509,79 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
-Failed to read Dictionary`2.TryGetValue[loadElemA]
+Successfully read Dictionary`2.TryGetValue
+
+define i8 @"Dictionary`2.TryGetValue"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)* addrspace(1)* %param2) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  %arg2 = alloca %System.__Canon addrspace(1)* addrspace(1)*
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  store %System.__Canon addrspace(1)* addrspace(1)* %param2, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  store i32 %2, i32* %loc0
+  %3 = load i32, i32* %loc0
+  %4 = icmp slt i32 %3, 0
+  br i1 %4, label %22, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 2
+  %10 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %9, align 8
+  %11 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = zext i32 %11 to i64
+  %BoundsCheck = icmp uge i64 %16, %15
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 3, i32 %11
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %20, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %6, %System.__Canon addrspace(1)* %21)
+  ret i8 1
+
+; <label>:22                                      ; preds = %entry
+  %23 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %23, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -8058,8 +9647,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
@@ -8091,8 +9680,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
@@ -8171,15 +9760,15 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck, label %19, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %ThrowNullRef, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
   %21 = load i32, i32 addrspace(1)* %20
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
@@ -8202,7 +9791,7 @@ ThrowNullRef:                                     ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %19
+ThrowNullRef2:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8248,8 +9837,8 @@ entry:
   %0 = alloca %System.AppDomainHandle
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %1 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %1, i32 0, i32 15
@@ -8269,8 +9858,8 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
@@ -8286,7 +9875,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -8299,8 +9888,8 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -8327,8 +9916,8 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
@@ -8352,8 +9941,8 @@ entry:
   %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
   store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
@@ -8363,8 +9952,8 @@ entry:
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
@@ -8374,8 +9963,8 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %9
   %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
@@ -8384,8 +9973,8 @@ entry:
 
 ; <label>:18                                      ; preds = %3, %16
   %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
@@ -8397,15 +9986,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %18
+ThrowNullRef6:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8418,8 +10007,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
@@ -8453,15 +10042,15 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
@@ -8473,7 +10062,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8481,7 +10070,7 @@ ThrowNullRef1:                                    ; preds = %1
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
 Failed to read Dictionary`2.System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
@@ -8506,8 +10095,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
@@ -8524,8 +10113,8 @@ entry:
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -8544,7 +10133,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8577,8 +10166,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = load i64, i64* %arg2
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = trunc i32 %3 to i8
@@ -8634,46 +10223,46 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
   %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
-  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
-  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
-  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
@@ -8684,27 +10273,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %20
+ThrowNullRef12:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8717,8 +10306,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -8756,22 +10345,22 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
   %9 = load i64, i64 addrspace(1)* %8, align 8
   %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
   %13 = load i64, i64 addrspace(1)* %12, align 8
   %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %11
   %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
@@ -8788,11 +10377,11 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8882,8 +10471,8 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
@@ -8900,8 +10489,8 @@ entry:
 ; <label>:8                                       ; preds = %1
   %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
   %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
@@ -8911,15 +10500,15 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
   %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
   %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
-  br i1 %NullCheck6, label %21, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
@@ -8946,15 +10535,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8992,15 +10581,15 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
   store i8 %3, i8 addrspace(1)* %5
   %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
@@ -9011,7 +10600,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9027,8 +10616,8 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -9041,8 +10630,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
@@ -9058,7 +10647,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9080,8 +10669,8 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
@@ -9096,8 +10685,8 @@ entry:
 ; <label>:12                                      ; preds = %6
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
@@ -9112,8 +10701,8 @@ entry:
 ; <label>:21                                      ; preds = %15
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
@@ -9128,8 +10717,8 @@ entry:
 ; <label>:30                                      ; preds = %24
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %31, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
@@ -9144,8 +10733,8 @@ entry:
 ; <label>:39                                      ; preds = %33
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
-  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %40, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %42
 
 ; <label>:42                                      ; preds = %39
   %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
@@ -9164,19 +10753,19 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %21
+ThrowNullRef4:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %30
+ThrowNullRef6:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %39
+ThrowNullRef8:                                    ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9243,8 +10832,8 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
@@ -9264,57 +10853,57 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
   store i8 0, i8 addrspace(1)* %2
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
   store i8 0, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
   store i8 0, i8 addrspace(1)* %17
   %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
   store i8 0, i8 addrspace(1)* %20
   %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
-  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
@@ -9325,31 +10914,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %19
+ThrowNullRef14:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9367,8 +10956,8 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
@@ -9380,8 +10969,8 @@ entry:
 
 ; <label>:9                                       ; preds = %4
   %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %9
   %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
@@ -9395,7 +10984,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef2:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9420,8 +11009,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
@@ -9512,8 +11101,8 @@ entry:
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
@@ -9524,8 +11113,8 @@ entry:
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = load i64, i64 addrspace(1)* %12
@@ -9537,8 +11126,8 @@ entry:
   %20 = load i64, i64* %19
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
-  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %13
   %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
@@ -9555,8 +11144,8 @@ entry:
 ; <label>:30                                      ; preds = %25
   %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %32 = load i32, i32* %arg2
-  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
-  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
@@ -9570,15 +11159,15 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %30
+ThrowNullRef2:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9622,87 +11211,87 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
   %10 = load i8, i8 addrspace(1)* %9, align 8
   %11 = zext i8 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %8
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
   store i8 %12, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
   %19 = load i8, i8 addrspace(1)* %18, align 8
   %20 = zext i8 %19 to i32
   %21 = trunc i32 %20 to i8
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
   store i8 %21, i8 addrspace(1)* %23
   %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
   %28 = load i8, i8 addrspace(1)* %27, align 8
   %29 = zext i8 %28 to i32
   %30 = trunc i32 %29 to i8
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
-  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %31
 
 ; <label>:31                                      ; preds = %26
   %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
   store i8 %30, i8 addrspace(1)* %32
   %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
-  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
-  br i1 %NullCheck14, label %40, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %40
 
 ; <label>:40                                      ; preds = %35
   %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
   store i8 %39, i8 addrspace(1)* %41
   %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
-  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %44
 
 ; <label>:44                                      ; preds = %40
   %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
   %46 = load i8, i8 addrspace(1)* %45, align 8
   %47 = zext i8 %46 to i32
   %48 = trunc i32 %47 to i8
-  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
   store i8 %48, i8 addrspace(1)* %50
   %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
-  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
@@ -9713,29 +11302,29 @@ entry:
 ; <label>:56                                      ; preds = %52
   %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
-  br i1 %NullCheck22, label %59, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
   %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
   %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
-  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
-  br i1 %NullCheck24, label %63, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
   %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
-  br i1 %NullCheck26, label %66, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
   %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
-  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
-  br i1 %NullCheck28, label %69, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %69
 
 ; <label>:69                                      ; preds = %66
   %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
@@ -9744,15 +11333,15 @@ entry:
 
 ; <label>:71                                      ; preds = %105
   %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
-  br i1 %NullCheck34, label %73, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %73
 
 ; <label>:73                                      ; preds = %71
   %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
   %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
   %76 = load i32, i32* %loc0
-  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
-  br i1 %NullCheck36, label %77, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
@@ -9766,8 +11355,8 @@ entry:
 
 ; <label>:83                                      ; preds = %77
   %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
-  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
@@ -9775,14 +11364,14 @@ entry:
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
   %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
-  br i1 %NullCheck40, label %91, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
 ; <label>:91                                      ; preds = %85
   %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
   %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
-  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck42, label %94, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %94
 
 ; <label>:94                                      ; preds = %91
   %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
@@ -9798,14 +11387,14 @@ entry:
 ; <label>:99                                      ; preds = %69, %96
   %100 = load i32, i32* %loc0
   %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
-  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %102
 
 ; <label>:102                                     ; preds = %99
   %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
   %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
-  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
-  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
@@ -9819,87 +11408,87 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %26
+ThrowNullRef10:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %31
+ThrowNullRef12:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %35
+ThrowNullRef14:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %40
+ThrowNullRef16:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %56
+ThrowNullRef22:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %59
+ThrowNullRef24:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %63
+ThrowNullRef26:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %66
+ThrowNullRef28:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %102
+ThrowNullRef32:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %71
+ThrowNullRef34:                                   ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %73
+ThrowNullRef36:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %83
+ThrowNullRef38:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %85
+ThrowNullRef40:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %91
+ThrowNullRef42:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9943,15 +11532,15 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
   %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
@@ -9961,28 +11550,28 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
   %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %12
   %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
   %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
   %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
-  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
@@ -9993,23 +11582,23 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %12
+ThrowNullRef6:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10031,15 +11620,15 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
   %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = load i64, i64 addrspace(1)* %7
@@ -10077,13 +11666,13 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[loadElem]
+Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -10111,8 +11700,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -10193,8 +11782,8 @@ entry:
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load float, float* %arg0
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -10328,8 +11917,8 @@ entry:
   store i64 %param0, i64* %arg0
   store i64 %param1, i64* %arg1
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
@@ -10337,8 +11926,8 @@ entry:
   %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
   %5 = load i16*, i16* addrspace(1)* %4, align 8
   %6 = addrspacecast i64* %arg1 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = bitcast i64 addrspace(1)* %6 to i8 addrspace(1)*
@@ -10354,7 +11943,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10388,8 +11977,8 @@ entry:
   %1 = load i32, i32* %arg1
   %2 = sext i32 %1 to i64
   %3 = inttoptr i64 %2 to i16*
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -10442,8 +12031,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, i32)*)(%System.IO.ConsoleStream addrspace(1)* %2, i32 %1)
   %3 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %4 = load i64, i64* %arg1
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
@@ -10454,8 +12043,8 @@ entry:
   %10 = icmp eq i32 %9, 3
   %11 = sext i1 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %5
   %14 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, i32 0, i32 5
@@ -10466,7 +12055,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10489,8 +12078,8 @@ entry:
   %5 = icmp eq i32 %4, 1
   %6 = sext i1 %5 to i32
   %7 = trunc i32 %6 to i8
-  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %2, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.ConsoleStream addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
@@ -10501,8 +12090,8 @@ entry:
   %13 = icmp eq i32 %12, 2
   %14 = sext i1 %13 to i32
   %15 = trunc i32 %14 to i8
-  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %10, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.ConsoleStream addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %8
   %17 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %10, i32 0, i32 4
@@ -10513,7 +12102,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10552,8 +12141,8 @@ entry:
   %arg0 = alloca i64
   store i64 %param0, i64* %arg0
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
@@ -10588,8 +12177,8 @@ entry:
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
   %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = load i64, i64 addrspace(1)* %7
@@ -10693,7 +12282,127 @@ entry:
 INFO:  jitting method Encoding::GetEncoding using LLILCJit
 Failed to read Encoding.GetEncoding[convertToHelperArgumentType]
 INFO:  jitting method EncodingProvider::GetEncodingFromProvider using LLILCJit
-Failed to read EncodingProvider.GetEncodingFromProvider[loadElem]
+Successfully read EncodingProvider.GetEncodingFromProvider
+
+define %System.Text.Encoding addrspace(1)* @EncodingProvider.GetEncodingFromProvider(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca %"System.Text.EncodingProvider[]" addrspace(1)*
+  %loc1 = alloca %System.Text.EncodingProvider addrspace(1)*
+  %loc2 = alloca %System.Text.Encoding addrspace(1)*
+  %loc3 = alloca %System.Text.Encoding addrspace(1)*
+  %loc4 = alloca %"System.Text.EncodingProvider[]" addrspace(1)*
+  %loc5 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1059)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2392
+  %2 = addrspacecast i8 addrspace(1)* %1 to %"System.Text.EncodingProvider[]" addrspace(1)**
+  %3 = load volatile %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %2
+  %4 = icmp ne %"System.Text.EncodingProvider[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %entry
+  ret %System.Text.Encoding addrspace(1)* null
+
+; <label>:6                                       ; preds = %entry
+  %7 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1059)
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i64 2392
+  %9 = addrspacecast i8 addrspace(1)* %8 to %"System.Text.EncodingProvider[]" addrspace(1)**
+  %10 = load volatile %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %9
+  store %"System.Text.EncodingProvider[]" addrspace(1)* %10, %"System.Text.EncodingProvider[]" addrspace(1)** %loc0
+  %11 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc0
+  store %"System.Text.EncodingProvider[]" addrspace(1)* %11, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  store i32 0, i32* %loc5
+  br label %43
+
+; <label>:12                                      ; preds = %46
+  %13 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  %14 = load i32, i32* %loc5
+  %NullCheck1 = icmp eq %"System.Text.EncodingProvider[]" addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %13, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = zext i32 %17 to i64
+  %19 = zext i32 %14 to i64
+  %BoundsCheck = icmp uge i64 %19, %18
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %20
+
+; <label>:20                                      ; preds = %15
+  %21 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %13, i32 0, i32 3, i32 %14
+  %22 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)* addrspace(1)* %21, align 8
+  store %System.Text.EncodingProvider addrspace(1)* %22, %System.Text.EncodingProvider addrspace(1)** %loc1
+  %23 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)** %loc1
+  %24 = load i32, i32* %arg0
+  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i64 addrspace(1)*
+  %NullCheck3 = icmp eq i64 addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
+
+; <label>:26                                      ; preds = %20
+  %27 = load i64, i64 addrspace(1)* %25
+  %28 = add i64 %27, 64
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 40
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Text.Encoding addrspace(1)* (%System.Text.EncodingProvider addrspace(1)*, i32)*
+  %35 = call %System.Text.Encoding addrspace(1)* %34(%System.Text.EncodingProvider addrspace(1)* %23, i32 %24)
+  store %System.Text.Encoding addrspace(1)* %35, %System.Text.Encoding addrspace(1)** %loc2
+  %36 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc2
+  %37 = icmp eq %System.Text.Encoding addrspace(1)* %36, null
+  br i1 %37, label %40, label %38
+
+; <label>:38                                      ; preds = %26
+  %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc2
+  store %System.Text.Encoding addrspace(1)* %39, %System.Text.Encoding addrspace(1)** %loc3
+  br label %53
+
+; <label>:40                                      ; preds = %26
+  %41 = load i32, i32* %loc5
+  %42 = add i32 %41, 1
+  store i32 %42, i32* %loc5
+  br label %43
+
+; <label>:43                                      ; preds = %6, %40
+  %44 = load i32, i32* %loc5
+  %45 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  %NullCheck = icmp eq %"System.Text.EncodingProvider[]" addrspace(1)* %45, null
+  br i1 %NullCheck, label %ThrowNullRef, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp slt i32 %44, %50
+  br i1 %51, label %12, label %52
+
+; <label>:52                                      ; preds = %46
+  ret %System.Text.Encoding addrspace(1)* null
+
+; <label>:53                                      ; preds = %38
+  %54 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc3
+  ret %System.Text.Encoding addrspace(1)* %54
+
+ThrowNullRef:                                     ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method EncodingProvider::.cctor using LLILCJit
 Successfully read EncodingProvider..cctor
 
@@ -10712,7 +12421,7 @@ Failed to read Encoding.get_InternalSyncObject[Call HasTypeArg]
 INFO:  jitting method Hashtable::.ctor using LLILCJit
 Failed to read Hashtable..ctor[Volatile store]
 INFO:  jitting method Hashtable::get_Item using LLILCJit
-Failed to read Hashtable.get_Item[loadElemA]
+Failed to read Hashtable.get_Item[loadNonPrimitiveObj]
 INFO:  jitting method Hashtable::InitHash using LLILCJit
 Successfully read Hashtable.InitHash
 
@@ -10732,8 +12441,8 @@ entry:
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -10749,15 +12458,15 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
   %15 = load i32, i32* %loc0
-  %NullCheck2 = icmp ne i32 addrspace(1)* %14, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i32 addrspace(1)* %14, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %3
   store i32 %15, i32 addrspace(1)* %14, align 8
   %17 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %18 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %NullCheck4 = icmp ne i32 addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i32 addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = load i32, i32 addrspace(1)* %18, align 8
@@ -10766,8 +12475,8 @@ entry:
   %23 = sub i32 %22, 1
   %24 = urem i32 %21, %23
   %25 = add i32 1, %24
-  %NullCheck6 = icmp ne i32 addrspace(1)* %17, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32 addrspace(1)* %17, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %19
   store i32 %25, i32 addrspace(1)* %17, align 8
@@ -10778,15 +12487,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %19
+ThrowNullRef6:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10801,8 +12510,8 @@ entry:
   store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
   store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %NullCheck = icmp ne %System.Collections.Hashtable addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Collections.Hashtable addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
@@ -10812,16 +12521,16 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Collections.Hashtable addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Collections.Hashtable addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
   %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck4 = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %9, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
   %13 = inttoptr i64 %11 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
@@ -10831,8 +12540,8 @@ entry:
 ; <label>:15                                      ; preds = %1
   %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -10850,15 +12559,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10872,8 +12581,8 @@ entry:
   store %System.Int32 addrspace(1)* %param0, %System.Int32 addrspace(1)** %this
   %0 = load %System.Int32 addrspace(1)*, %System.Int32 addrspace(1)** %this
   %1 = bitcast %System.Int32 addrspace(1)* %0 to i32 addrspace(1)*
-  %NullCheck = icmp ne i32 addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq i32 addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load i32, i32 addrspace(1)* %1, align 8
@@ -10949,8 +12658,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.UTF8Encoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
@@ -10959,15 +12668,15 @@ entry:
   %9 = load i8, i8* %arg2
   %10 = zext i8 %9 to i32
   %11 = trunc i32 %10 to i8
-  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %8, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %6
   %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %8, i32 0, i32 8
   store i8 %11, i8 addrspace(1)* %13
   %14 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %14, i32 0, i32 8
@@ -10979,8 +12688,8 @@ entry:
 ; <label>:20                                      ; preds = %15
   %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %22, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %22, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = load i64, i64 addrspace(1)* %22
@@ -11002,15 +12711,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %12
+ThrowNullRef4:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11025,8 +12734,8 @@ entry:
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
@@ -11048,16 +12757,16 @@ entry:
 ; <label>:10                                      ; preds = %1
   %11 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
   %12 = load i32, i32* %arg1
-  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %11, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.Encoding addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
   store i32 %12, i32 addrspace(1)* %14
   %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
   %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = load i64, i64 addrspace(1)* %16
@@ -11075,11 +12784,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11092,8 +12801,8 @@ entry:
   %this = alloca %System.Text.UTF8Encoding addrspace(1)*
   store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
   %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.UTF8Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
@@ -11105,16 +12814,16 @@ entry:
 ; <label>:6                                       ; preds = %1
   %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %8 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %10, %System.Text.EncoderFallback addrspace(1)* %8)
   %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %12 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
-  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %11, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %11, i32 0, i32 3
@@ -11127,8 +12836,8 @@ entry:
   %18 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %18, %System.String addrspace(1)* %17)
   %19 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %18 to %System.Text.EncoderFallback addrspace(1)*
-  %NullCheck6 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %16, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %16, i32 0, i32 2
@@ -11138,8 +12847,8 @@ entry:
   %24 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %24, %System.String addrspace(1)* %23)
   %25 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %24 to %System.Text.DecoderFallback addrspace(1)*
-  %NullCheck8 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %22, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %22, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %20
   %27 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %22, i32 0, i32 3
@@ -11150,19 +12859,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %20
+ThrowNullRef8:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11192,8 +12901,8 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load i32, i32* %arg1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -11211,8 +12920,8 @@ entry:
 ; <label>:15                                      ; preds = %8
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %17 = load i32, i32* %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 %17
@@ -11228,7 +12937,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11280,7 +12989,7 @@ entry:
 }
 
 INFO:  jitting method Hashtable::Insert using LLILCJit
-Failed to read Hashtable.Insert[loadElemA]
+Failed to read Hashtable.Insert[storeElem]
 INFO:  jitting method ConsoleEncoding::.ctor using LLILCJit
 Successfully read ConsoleEncoding..ctor
 
@@ -11295,8 +13004,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %1)
   %2 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
@@ -11332,8 +13041,8 @@ entry:
   %2 = call %System.Text.InternalEncoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalEncoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %1)
   %3 = bitcast %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2 to %System.Text.EncoderFallback addrspace(1)*
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
@@ -11343,8 +13052,8 @@ entry:
   %8 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %7)
   %9 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %8 to %System.Text.DecoderFallback addrspace(1)*
-  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %6, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.Encoding addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %4
   %11 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %6, i32 0, i32 3
@@ -11355,7 +13064,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11374,15 +13083,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* %1)
   %2 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   %6 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, i32 0, i32 1
@@ -11393,7 +13102,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11421,8 +13130,8 @@ entry:
   store %System.Text.InternalDecoderBestFitFallback addrspace(1)* %param0, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
   %0 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
@@ -11432,15 +13141,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %4)
   %5 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %6)
   %9 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, i32 0, i32 1
@@ -11451,11 +13160,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11523,8 +13232,8 @@ entry:
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
   %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = load i64, i64 addrspace(1)* %19
@@ -11588,8 +13297,8 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.ConsoleStream addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
@@ -11620,31 +13329,31 @@ entry:
   store i8 %param4, i8* %arg4
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %3, %System.IO.Stream addrspace(1)* %1)
   %4 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %4, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
   %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %4, i32 0, i32 4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %5)
   %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %6
   %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
   %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
   %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = load i64, i64 addrspace(1)* %13
@@ -11656,8 +13365,8 @@ entry:
   %21 = load i64, i64* %20
   %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %8, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %8, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %14
   %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 5
@@ -11675,24 +13384,24 @@ entry:
   %31 = load i32, i32* %arg3
   %32 = sext i32 %31 to i64
   %33 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %32)
-  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %30, null
-  br i1 %NullCheck10, label %34, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.StreamWriter addrspace(1)* %30, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %35, %"System.Char[]" addrspace(1)* %33)
   %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %37, null
-  br i1 %NullCheck12, label %38, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.StreamWriter addrspace(1)* %37, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %38
 
 ; <label>:38                                      ; preds = %34
   %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
   %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
   %41 = load i32, i32* %arg3
   %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %42, null
-  br i1 %NullCheck14, label %43, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %42, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
   %44 = load i64, i64 addrspace(1)* %42
@@ -11706,30 +13415,30 @@ entry:
   %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
   %53 = sext i32 %52 to i64
   %54 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %53)
-  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
-  br i1 %NullCheck16, label %55, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %55
 
 ; <label>:55                                      ; preds = %43
   %56 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %56, %"System.Byte[]" addrspace(1)* %54)
   %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %58 = load i32, i32* %arg3
-  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %57, null
-  br i1 %NullCheck18, label %59, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.StreamWriter addrspace(1)* %57, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %59
 
 ; <label>:59                                      ; preds = %55
   %60 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 10
   store i32 %58, i32 addrspace(1)* %60
   %61 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %61, null
-  br i1 %NullCheck20, label %62, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.IO.StreamWriter addrspace(1)* %61, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %62
 
 ; <label>:62                                      ; preds = %59
   %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
   %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
   %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
   %67 = load i64, i64 addrspace(1)* %65
@@ -11747,15 +13456,15 @@ entry:
 
 ; <label>:78                                      ; preds = %66
   %79 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %79, null
-  br i1 %NullCheck24, label %80, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.StreamWriter addrspace(1)* %79, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %80
 
 ; <label>:80                                      ; preds = %78
   %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
   %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
   %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %83, null
-  br i1 %NullCheck26, label %84, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %83, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
   %85 = load i64, i64 addrspace(1)* %83
@@ -11772,8 +13481,8 @@ entry:
 
 ; <label>:95                                      ; preds = %84
   %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.IO.StreamWriter addrspace(1)* %96, null
-  br i1 %NullCheck28, label %97, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.IO.StreamWriter addrspace(1)* %96, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %97
 
 ; <label>:97                                      ; preds = %95
   %98 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 12
@@ -11787,8 +13496,8 @@ entry:
   %103 = icmp eq i32 %102, 0
   %104 = sext i1 %103 to i32
   %105 = trunc i32 %104 to i8
-  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %100, null
-  br i1 %NullCheck30, label %106, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.IO.StreamWriter addrspace(1)* %100, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %106
 
 ; <label>:106                                     ; preds = %99
   %107 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %100, i32 0, i32 13
@@ -11799,63 +13508,63 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %6
+ThrowNullRef4:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %29
+ThrowNullRef10:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %34
+ThrowNullRef12:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %38
+ThrowNullRef14:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %43
+ThrowNullRef16:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %55
+ThrowNullRef18:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %59
+ThrowNullRef20:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %62
+ThrowNullRef22:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %78
+ThrowNullRef24:                                   ; preds = %78
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %80
+ThrowNullRef26:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %95
+ThrowNullRef28:                                   ; preds = %95
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11868,15 +13577,15 @@ entry:
   %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = load i64, i64 addrspace(1)* %4
@@ -11894,7 +13603,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11944,35 +13653,35 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
   %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderNLS addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %7 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.EncoderNLS addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Text.Encoding addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.Encoding addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Text.EncoderNLS addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.EncoderNLS addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
   %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck8 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = load i64, i64 addrspace(1)* %16
@@ -11991,19 +13700,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12029,8 +13738,8 @@ entry:
   %this = alloca %System.Text.Encoding addrspace(1)*
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
@@ -12050,15 +13759,15 @@ entry:
   %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
   store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
   %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
   store i32 0, i32 addrspace(1)* %2
   %3 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, i32 0, i32 2
@@ -12068,15 +13777,15 @@ entry:
 
 ; <label>:8                                       ; preds = %4
   %9 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
   %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
   %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = load i64, i64 addrspace(1)* %13
@@ -12097,15 +13806,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12120,16 +13829,16 @@ entry:
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = load i32, i32* %arg1
   %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
   %7 = load i64, i64 addrspace(1)* %5
@@ -12147,7 +13856,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12184,8 +13893,8 @@ entry:
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
   %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
   %16 = load i64, i64 addrspace(1)* %14
@@ -12206,8 +13915,8 @@ entry:
   %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
   %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
   %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %31, null
-  br i1 %NullCheck2, label %32, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = load i64, i64 addrspace(1)* %31
@@ -12250,7 +13959,7 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12263,14 +13972,14 @@ entry:
   %this = alloca %System.Text.EncoderReplacementFallback addrspace(1)*
   store %System.Text.EncoderReplacementFallback addrspace(1)* %param0, %System.Text.EncoderReplacementFallback addrspace(1)** %this
   %0 = load %System.Text.EncoderReplacementFallback addrspace(1)*, %System.Text.EncoderReplacementFallback addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -12281,7 +13990,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12311,8 +14020,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
@@ -12344,8 +14053,8 @@ entry:
   %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
   store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
@@ -12357,8 +14066,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Threading.Tasks.Task addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %7)
@@ -12381,7 +14090,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12400,8 +14109,8 @@ entry:
   store i8 %param1, i8* %arg1
   store i8 %param2, i8* %arg2
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
@@ -12415,8 +14124,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1, %5
   %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 9
@@ -12447,8 +14156,8 @@ entry:
 
 ; <label>:25                                      ; preds = %8, %20
   %26 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %26, null
-  br i1 %NullCheck4, label %27, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %26, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %26, i32 0, i32 12
@@ -12459,22 +14168,22 @@ entry:
 
 ; <label>:32                                      ; preds = %27
   %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %33, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.IO.StreamWriter addrspace(1)* %33, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %32
   %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 12
   store i8 1, i8 addrspace(1)* %35
   %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
-  br i1 %NullCheck8, label %37, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
   %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
   %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck10 = icmp ne i64 addrspace(1)* %40, null
-  br i1 %NullCheck10, label %41, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64 addrspace(1)* %40, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i64, i64 addrspace(1)* %40
@@ -12488,8 +14197,8 @@ entry:
   %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
   store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
   %51 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %NullCheck12 = icmp ne %"System.Byte[]" addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Byte[]" addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %41
   %53 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %51, i32 0, i32 1
@@ -12501,16 +14210,16 @@ entry:
 
 ; <label>:58                                      ; preds = %52
   %59 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %59, null
-  br i1 %NullCheck14, label %60, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.IO.StreamWriter addrspace(1)* %59, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %60
 
 ; <label>:60                                      ; preds = %58
   %61 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %59, i32 0, i32 3
   %62 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
   %64 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %NullCheck16 = icmp ne %"System.Byte[]" addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %"System.Byte[]" addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %60
   %66 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %64, i32 0, i32 1
@@ -12518,8 +14227,8 @@ entry:
   %68 = zext i32 %67 to i64
   %69 = trunc i64 %68 to i32
   %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck18, label %71, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
   %72 = load i64, i64 addrspace(1)* %70
@@ -12535,29 +14244,29 @@ entry:
 
 ; <label>:80                                      ; preds = %27, %52, %71
   %81 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %81, null
-  br i1 %NullCheck20, label %82, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.IO.StreamWriter addrspace(1)* %81, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
 
 ; <label>:82                                      ; preds = %80
   %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %81, i32 0, i32 5
   %84 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %83, align 8
   %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.IO.StreamWriter addrspace(1)* %85, null
-  br i1 %NullCheck22, label %86, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.IO.StreamWriter addrspace(1)* %85, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %86
 
 ; <label>:86                                      ; preds = %82
   %87 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 7
   %88 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %87, align 8
   %89 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %89, null
-  br i1 %NullCheck24, label %90, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.StreamWriter addrspace(1)* %89, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %90
 
 ; <label>:90                                      ; preds = %86
   %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %89, i32 0, i32 9
   %92 = load i32, i32 addrspace(1)* %91, align 8
   %93 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.IO.StreamWriter addrspace(1)* %93, null
-  br i1 %NullCheck26, label %94, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.IO.StreamWriter addrspace(1)* %93, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %93, i32 0, i32 6
@@ -12565,8 +14274,8 @@ entry:
   %97 = load i8, i8* %arg2
   %98 = zext i8 %97 to i32
   %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
-  %NullCheck28 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck28, label %100, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
   %101 = load i64, i64 addrspace(1)* %99
@@ -12581,8 +14290,8 @@ entry:
   %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
   store i32 %110, i32* %loc1
   %111 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %111, null
-  br i1 %NullCheck30, label %112, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.IO.StreamWriter addrspace(1)* %111, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %112
 
 ; <label>:112                                     ; preds = %100
   %113 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %111, i32 0, i32 9
@@ -12593,23 +14302,23 @@ entry:
 
 ; <label>:116                                     ; preds = %112
   %117 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck32 = icmp ne %System.IO.StreamWriter addrspace(1)* %117, null
-  br i1 %NullCheck32, label %118, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.IO.StreamWriter addrspace(1)* %117, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %118
 
 ; <label>:118                                     ; preds = %116
   %119 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %117, i32 0, i32 3
   %120 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %119, align 8
   %121 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.IO.StreamWriter addrspace(1)* %121, null
-  br i1 %NullCheck34, label %122, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.IO.StreamWriter addrspace(1)* %121, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %122
 
 ; <label>:122                                     ; preds = %118
   %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
   %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
   %125 = load i32, i32* %loc1
   %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
-  %NullCheck36 = icmp ne i64 addrspace(1)* %126, null
-  br i1 %NullCheck36, label %127, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64 addrspace(1)* %126, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
   %128 = load i64, i64 addrspace(1)* %126
@@ -12631,15 +14340,15 @@ entry:
 
 ; <label>:140                                     ; preds = %136
   %141 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.IO.StreamWriter addrspace(1)* %141, null
-  br i1 %NullCheck38, label %142, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.IO.StreamWriter addrspace(1)* %141, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %142
 
 ; <label>:142                                     ; preds = %140
   %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
   %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
   %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
-  %NullCheck40 = icmp ne i64 addrspace(1)* %145, null
-  br i1 %NullCheck40, label %146, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i64 addrspace(1)* %145, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
   %147 = load i64, i64 addrspace(1)* %145
@@ -12660,83 +14369,83 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %25
+ThrowNullRef4:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %32
+ThrowNullRef6:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %37
+ThrowNullRef10:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %41
+ThrowNullRef12:                                   ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %58
+ThrowNullRef14:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %60
+ThrowNullRef16:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %65
+ThrowNullRef18:                                   ; preds = %65
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %80
+ThrowNullRef20:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %82
+ThrowNullRef22:                                   ; preds = %82
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %86
+ThrowNullRef24:                                   ; preds = %86
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %90
+ThrowNullRef26:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %94
+ThrowNullRef28:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %100
+ThrowNullRef30:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %116
+ThrowNullRef32:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %118
+ThrowNullRef34:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %122
+ThrowNullRef36:                                   ; preds = %122
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %140
+ThrowNullRef38:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %142
+ThrowNullRef40:                                   ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12803,8 +14512,8 @@ entry:
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %1 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
-  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
@@ -12812,8 +14521,8 @@ entry:
   %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
   %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
   %8 = load i64, i64 addrspace(1)* %6
@@ -12829,8 +14538,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %17, %System.IFormatProvider addrspace(1)* %16)
   %18 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %19 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %18, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.SyncTextWriter addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %7
   %21 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %18, i32 0, i32 4
@@ -12841,11 +14550,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12858,8 +14567,8 @@ entry:
   %this = alloca %System.IO.TextWriter addrspace(1)*
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.TextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
@@ -12869,8 +14578,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.Threading.Thread addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Threading.Thread addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %6)
@@ -12879,8 +14588,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1
   %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.TextWriter addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.TextWriter addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %11, i32 0, i32 2
@@ -12891,11 +14600,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13092,8 +14801,8 @@ entry:
   store float %param1, float* %arg1
   store i8 0, i8* %loc1
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
@@ -13103,16 +14812,16 @@ entry:
   %5 = addrspacecast i8* %loc1 to i8 addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %4, i8 addrspace(1)* %5)
   %6 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.SyncTextWriter addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
   %10 = load float, float* %arg1
   %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
   %13 = load i64, i64 addrspace(1)* %11
@@ -13147,11 +14856,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13168,8 +14877,8 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load float, float* %arg1
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -13183,8 +14892,8 @@ entry:
   call void %11(%System.IO.TextWriter addrspace(1)* %0, float %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
   %15 = load i64, i64 addrspace(1)* %13
@@ -13202,7 +14911,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13220,8 +14929,8 @@ entry:
   %1 = addrspacecast float* %arg1 to float addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -13236,8 +14945,8 @@ entry:
   %14 = bitcast float addrspace(1)* %1 to %System.Single addrspace(1)*
   %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Single addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Single addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
   %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
   %18 = load i64, i64 addrspace(1)* %16
@@ -13255,7 +14964,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13271,8 +14980,8 @@ entry:
   store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
   %0 = load %System.Single addrspace(1)*, %System.Single addrspace(1)** %this
   %1 = bitcast %System.Single addrspace(1)* %0 to float addrspace(1)*
-  %NullCheck = icmp ne float addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq float addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load float, float addrspace(1)* %1, align 8
@@ -13297,8 +15006,8 @@ entry:
   %loc0 = alloca %System.Globalization.NumberFormatInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 3
@@ -13308,8 +15017,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
@@ -13319,24 +15028,24 @@ entry:
   store %System.Globalization.NumberFormatInfo addrspace(1)* %10, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
   %11 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %7
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
   %15 = load i8, i8 addrspace(1)* %14, align 8
   %16 = zext i8 %15 to i32
   %17 = trunc i32 %16 to i8
-  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %11, null
-  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %11, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %13
   %19 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %11, i32 0, i32 29
   store i8 %17, i8 addrspace(1)* %19
   %20 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %21 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %20, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %20, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %18
   %23 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %20, i32 0, i32 3
@@ -13345,8 +15054,8 @@ entry:
 
 ; <label>:24                                      ; preds = %1, %22
   %25 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %25, null
-  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %25, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %26
 
 ; <label>:26                                      ; preds = %24
   %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %25, i32 0, i32 3
@@ -13357,23 +15066,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %18
+ThrowNullRef8:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13398,168 +15107,168 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 18
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %8, align 8
-  %NullCheck2 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %5, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %5, i32 0, i32 4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %9)
   %12 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 19
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %15, align 8
-  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %12, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %12, i32 0, i32 5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %16)
   %19 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %20 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %20, null
-  br i1 %NullCheck8, label %21, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %20, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %20, i32 0, i32 23
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  %NullCheck10 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %19, null
-  br i1 %NullCheck10, label %24, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %19, i32 0, i32 7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %25, %System.String addrspace(1)* %23)
   %26 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %27 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %27, i32 0, i32 22
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %29, align 8
-  %NullCheck14 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %26, null
-  br i1 %NullCheck14, label %31, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %26, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %26, i32 0, i32 6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %32, %System.String addrspace(1)* %30)
   %33 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %34 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Globalization.CultureData addrspace(1)* %34, null
-  br i1 %NullCheck16, label %35, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Globalization.CultureData addrspace(1)* %34, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %34, i32 0, i32 51
   %37 = load i32, i32 addrspace(1)* %36, align 8
-  %NullCheck18 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %33, null
-  br i1 %NullCheck18, label %38, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %33, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %33, i32 0, i32 21
   store i32 %37, i32 addrspace(1)* %39
   %40 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %41 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Globalization.CultureData addrspace(1)* %41, null
-  br i1 %NullCheck20, label %42, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Globalization.CultureData addrspace(1)* %41, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %41, i32 0, i32 52
   %44 = load i32, i32 addrspace(1)* %43, align 8
-  %NullCheck22 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %40, null
-  br i1 %NullCheck22, label %45, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %40, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %40, i32 0, i32 25
   store i32 %44, i32 addrspace(1)* %46
   %47 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %48 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.Globalization.CultureData addrspace(1)* %48, null
-  br i1 %NullCheck24, label %49, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Globalization.CultureData addrspace(1)* %48, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %49
 
 ; <label>:49                                      ; preds = %45
   %50 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %48, i32 0, i32 29
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck26 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %47, null
-  br i1 %NullCheck26, label %52, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %47, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %47, i32 0, i32 10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %53, %System.String addrspace(1)* %51)
   %54 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %55 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Globalization.CultureData addrspace(1)* %55, null
-  br i1 %NullCheck28, label %56, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Globalization.CultureData addrspace(1)* %55, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %56
 
 ; <label>:56                                      ; preds = %52
   %57 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %55, i32 0, i32 35
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %57, align 8
-  %NullCheck30 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %54, null
-  br i1 %NullCheck30, label %59, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %54, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %54, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %60, %System.String addrspace(1)* %58)
   %61 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %62 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck32 = icmp ne %System.Globalization.CultureData addrspace(1)* %62, null
-  br i1 %NullCheck32, label %63, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Globalization.CultureData addrspace(1)* %62, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %62, i32 0, i32 34
   %65 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %64, align 8
-  %NullCheck34 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %61, null
-  br i1 %NullCheck34, label %66, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %61, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %61, i32 0, i32 9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %67, %System.String addrspace(1)* %65)
   %68 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %69 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck36 = icmp ne %System.Globalization.CultureData addrspace(1)* %69, null
-  br i1 %NullCheck36, label %70, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Globalization.CultureData addrspace(1)* %69, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %70
 
 ; <label>:70                                      ; preds = %66
   %71 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %69, i32 0, i32 55
   %72 = load i32, i32 addrspace(1)* %71, align 8
-  %NullCheck38 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %68, null
-  br i1 %NullCheck38, label %73, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %68, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %68, i32 0, i32 22
   store i32 %72, i32 addrspace(1)* %74
   %75 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %76 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck40 = icmp ne %System.Globalization.CultureData addrspace(1)* %76, null
-  br i1 %NullCheck40, label %77, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Globalization.CultureData addrspace(1)* %76, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %76, i32 0, i32 57
   %79 = load i32, i32 addrspace(1)* %78, align 8
-  %NullCheck42 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %75, null
-  br i1 %NullCheck42, label %80, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %75, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %80
 
 ; <label>:80                                      ; preds = %77
   %81 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %75, i32 0, i32 24
   store i32 %79, i32 addrspace(1)* %81
   %82 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %83 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck44 = icmp ne %System.Globalization.CultureData addrspace(1)* %83, null
-  br i1 %NullCheck44, label %84, label %ThrowNullRef43
+  %NullCheck43 = icmp eq %System.Globalization.CultureData addrspace(1)* %83, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %84
 
 ; <label>:84                                      ; preds = %80
   %85 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %83, i32 0, i32 56
   %86 = load i32, i32 addrspace(1)* %85, align 8
-  %NullCheck46 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %82, null
-  br i1 %NullCheck46, label %87, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %82, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %82, i32 0, i32 23
@@ -13568,8 +15277,8 @@ entry:
 
 ; <label>:89                                      ; preds = %entry
   %90 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck100 = icmp ne %System.Globalization.CultureData addrspace(1)* %90, null
-  br i1 %NullCheck100, label %91, label %ThrowNullRef99
+  %NullCheck99 = icmp eq %System.Globalization.CultureData addrspace(1)* %90, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %91
 
 ; <label>:91                                      ; preds = %89
   %92 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %90, i32 0, i32 2
@@ -13587,8 +15296,8 @@ entry:
   %102 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %103 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %104 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %103)
-  %NullCheck48 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %102, null
-  br i1 %NullCheck48, label %105, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %102, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %105
 
 ; <label>:105                                     ; preds = %101
   %106 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %102, i32 0, i32 1
@@ -13596,8 +15305,8 @@ entry:
   %107 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %108 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %109 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %108)
-  %NullCheck50 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %107, null
-  br i1 %NullCheck50, label %110, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %107, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %110
 
 ; <label>:110                                     ; preds = %105
   %111 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %107, i32 0, i32 2
@@ -13605,8 +15314,8 @@ entry:
   %112 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %113 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %114 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %113)
-  %NullCheck52 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %112, null
-  br i1 %NullCheck52, label %115, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %112, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %115
 
 ; <label>:115                                     ; preds = %110
   %116 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %112, i32 0, i32 27
@@ -13614,8 +15323,8 @@ entry:
   %117 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %118 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %119 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %118)
-  %NullCheck54 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %117, null
-  br i1 %NullCheck54, label %120, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %117, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %120
 
 ; <label>:120                                     ; preds = %115
   %121 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %117, i32 0, i32 26
@@ -13623,8 +15332,8 @@ entry:
   %122 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %123 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %124 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %123)
-  %NullCheck56 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %122, null
-  br i1 %NullCheck56, label %125, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %122, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %125
 
 ; <label>:125                                     ; preds = %120
   %126 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %122, i32 0, i32 17
@@ -13632,8 +15341,8 @@ entry:
   %127 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %128 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %129 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %128)
-  %NullCheck58 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %127, null
-  br i1 %NullCheck58, label %130, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %127, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %130
 
 ; <label>:130                                     ; preds = %125
   %131 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %127, i32 0, i32 18
@@ -13641,8 +15350,8 @@ entry:
   %132 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %133 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %134 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %133)
-  %NullCheck60 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %132, null
-  br i1 %NullCheck60, label %135, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %132, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %135
 
 ; <label>:135                                     ; preds = %130
   %136 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %132, i32 0, i32 14
@@ -13650,8 +15359,8 @@ entry:
   %137 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %138 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %139 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %138)
-  %NullCheck62 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %137, null
-  br i1 %NullCheck62, label %140, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %137, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %140
 
 ; <label>:140                                     ; preds = %135
   %141 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %137, i32 0, i32 13
@@ -13659,71 +15368,71 @@ entry:
   %142 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %143 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %144 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %143)
-  %NullCheck64 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %142, null
-  br i1 %NullCheck64, label %145, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %142, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %145
 
 ; <label>:145                                     ; preds = %140
   %146 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %142, i32 0, i32 12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %146, %System.String addrspace(1)* %144)
   %147 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %148 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck66 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %148, null
-  br i1 %NullCheck66, label %149, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %148, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %149
 
 ; <label>:149                                     ; preds = %145
   %150 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %148, i32 0, i32 21
   %151 = load i32, i32 addrspace(1)* %150, align 8
-  %NullCheck68 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %147, null
-  br i1 %NullCheck68, label %152, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %147, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %152
 
 ; <label>:152                                     ; preds = %149
   %153 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %147, i32 0, i32 28
   store i32 %151, i32 addrspace(1)* %153
   %154 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %155 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck70 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %155, null
-  br i1 %NullCheck70, label %156, label %ThrowNullRef69
+  %NullCheck69 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %155, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %156
 
 ; <label>:156                                     ; preds = %152
   %157 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %155, i32 0, i32 6
   %158 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %157, align 8
-  %NullCheck72 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %154, null
-  br i1 %NullCheck72, label %159, label %ThrowNullRef71
+  %NullCheck71 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %154, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %159
 
 ; <label>:159                                     ; preds = %156
   %160 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %154, i32 0, i32 15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %160, %System.String addrspace(1)* %158)
   %161 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %162 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck74 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %162, null
-  br i1 %NullCheck74, label %163, label %ThrowNullRef73
+  %NullCheck73 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %162, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %163
 
 ; <label>:163                                     ; preds = %159
   %164 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %162, i32 0, i32 1
   %165 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %164, align 8
-  %NullCheck76 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %161, null
-  br i1 %NullCheck76, label %166, label %ThrowNullRef75
+  %NullCheck75 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %161, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %166
 
 ; <label>:166                                     ; preds = %163
   %167 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %161, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %167, %"System.Int32[]" addrspace(1)* %165)
   %168 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %169 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck78 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %169, null
-  br i1 %NullCheck78, label %170, label %ThrowNullRef77
+  %NullCheck77 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %169, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %170
 
 ; <label>:170                                     ; preds = %166
   %171 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %169, i32 0, i32 7
   %172 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %171, align 8
-  %NullCheck80 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %168, null
-  br i1 %NullCheck80, label %173, label %ThrowNullRef79
+  %NullCheck79 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %168, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %173
 
 ; <label>:173                                     ; preds = %170
   %174 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %168, i32 0, i32 16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %174, %System.String addrspace(1)* %172)
   %175 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck82 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %175, null
-  br i1 %NullCheck82, label %176, label %ThrowNullRef81
+  %NullCheck81 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %175, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %176
 
 ; <label>:176                                     ; preds = %173
   %177 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %175, i32 0, i32 4
@@ -13733,14 +15442,14 @@ entry:
 
 ; <label>:180                                     ; preds = %176
   %181 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck84 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %181, null
-  br i1 %NullCheck84, label %182, label %ThrowNullRef83
+  %NullCheck83 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %181, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %182
 
 ; <label>:182                                     ; preds = %180
   %183 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %181, i32 0, i32 4
   %184 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %183, align 8
-  %NullCheck86 = icmp ne %System.String addrspace(1)* %184, null
-  br i1 %NullCheck86, label %185, label %ThrowNullRef85
+  %NullCheck85 = icmp eq %System.String addrspace(1)* %184, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %185
 
 ; <label>:185                                     ; preds = %182
   %186 = getelementptr inbounds %System.String, %System.String addrspace(1)* %184, i32 0, i32 1
@@ -13751,8 +15460,8 @@ entry:
 ; <label>:189                                     ; preds = %176, %185
   %190 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck98 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %190, null
-  br i1 %NullCheck98, label %192, label %ThrowNullRef97
+  %NullCheck97 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %190, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %192
 
 ; <label>:192                                     ; preds = %189
   %193 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %190, i32 0, i32 4
@@ -13761,8 +15470,8 @@ entry:
 
 ; <label>:194                                     ; preds = %185, %192
   %195 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck88 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %195, null
-  br i1 %NullCheck88, label %196, label %ThrowNullRef87
+  %NullCheck87 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %195, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %196
 
 ; <label>:196                                     ; preds = %194
   %197 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %195, i32 0, i32 9
@@ -13772,14 +15481,14 @@ entry:
 
 ; <label>:200                                     ; preds = %196
   %201 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck90 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %201, null
-  br i1 %NullCheck90, label %202, label %ThrowNullRef89
+  %NullCheck89 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %201, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %202
 
 ; <label>:202                                     ; preds = %200
   %203 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %201, i32 0, i32 9
   %204 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %203, align 8
-  %NullCheck92 = icmp ne %System.String addrspace(1)* %204, null
-  br i1 %NullCheck92, label %205, label %ThrowNullRef91
+  %NullCheck91 = icmp eq %System.String addrspace(1)* %204, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %205
 
 ; <label>:205                                     ; preds = %202
   %206 = getelementptr inbounds %System.String, %System.String addrspace(1)* %204, i32 0, i32 1
@@ -13790,14 +15499,14 @@ entry:
 ; <label>:209                                     ; preds = %196, %205
   %210 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %211 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck94 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %211, null
-  br i1 %NullCheck94, label %212, label %ThrowNullRef93
+  %NullCheck93 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %211, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %212
 
 ; <label>:212                                     ; preds = %209
   %213 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %211, i32 0, i32 6
   %214 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %213, align 8
-  %NullCheck96 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %210, null
-  br i1 %NullCheck96, label %215, label %ThrowNullRef95
+  %NullCheck95 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %210, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %215
 
 ; <label>:215                                     ; preds = %212
   %216 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %210, i32 0, i32 9
@@ -13811,203 +15520,203 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %17
+ThrowNullRef8:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %21
+ThrowNullRef10:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %24
+ThrowNullRef12:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %28
+ThrowNullRef14:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %31
+ThrowNullRef16:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %35
+ThrowNullRef18:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %38
+ThrowNullRef20:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %42
+ThrowNullRef22:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %45
+ThrowNullRef24:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %49
+ThrowNullRef26:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %52
+ThrowNullRef28:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %56
+ThrowNullRef30:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %59
+ThrowNullRef32:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %63
+ThrowNullRef34:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %66
+ThrowNullRef36:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %70
+ThrowNullRef38:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %73
+ThrowNullRef40:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %77
+ThrowNullRef42:                                   ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %80
+ThrowNullRef44:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %84
+ThrowNullRef46:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %101
+ThrowNullRef48:                                   ; preds = %101
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %105
+ThrowNullRef50:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %110
+ThrowNullRef52:                                   ; preds = %110
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %115
+ThrowNullRef54:                                   ; preds = %115
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %120
+ThrowNullRef56:                                   ; preds = %120
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %125
+ThrowNullRef58:                                   ; preds = %125
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %130
+ThrowNullRef60:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %135
+ThrowNullRef62:                                   ; preds = %135
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %140
+ThrowNullRef64:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %145
+ThrowNullRef66:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %149
+ThrowNullRef68:                                   ; preds = %149
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %152
+ThrowNullRef70:                                   ; preds = %152
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %156
+ThrowNullRef72:                                   ; preds = %156
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %159
+ThrowNullRef74:                                   ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %163
+ThrowNullRef76:                                   ; preds = %163
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %166
+ThrowNullRef78:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %170
+ThrowNullRef80:                                   ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %173
+ThrowNullRef82:                                   ; preds = %173
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %180
+ThrowNullRef84:                                   ; preds = %180
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %182
+ThrowNullRef86:                                   ; preds = %182
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %194
+ThrowNullRef88:                                   ; preds = %194
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %200
+ThrowNullRef90:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %202
+ThrowNullRef92:                                   ; preds = %202
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %209
+ThrowNullRef94:                                   ; preds = %209
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %212
+ThrowNullRef96:                                   ; preds = %212
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %189
+ThrowNullRef98:                                   ; preds = %189
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %89
+ThrowNullRef100:                                  ; preds = %89
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14035,8 +15744,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 21
@@ -14049,8 +15758,8 @@ entry:
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 16)
   %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 21
@@ -14059,8 +15768,8 @@ entry:
 
 ; <label>:12                                      ; preds = %1, %10
   %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 21
@@ -14071,11 +15780,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %12
+ThrowNullRef4:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14091,8 +15800,8 @@ entry:
   store i32 %param1, i32* %arg1
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %1 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
@@ -14159,8 +15868,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 33
@@ -14173,8 +15882,8 @@ entry:
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 24)
   %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 33
@@ -14183,8 +15892,8 @@ entry:
 
 ; <label>:12                                      ; preds = %1, %10
   %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 33
@@ -14195,11 +15904,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %12
+ThrowNullRef4:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14212,8 +15921,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 53
@@ -14225,8 +15934,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 116)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 53
@@ -14235,8 +15944,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 53
@@ -14247,11 +15956,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14280,8 +15989,8 @@ entry:
 
 ; <label>:7                                       ; preds = %entry, %4
   %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %7
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 2
@@ -14305,8 +16014,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 54
@@ -14318,8 +16027,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 117)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
@@ -14328,8 +16037,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 54
@@ -14340,11 +16049,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14357,8 +16066,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 27
@@ -14370,8 +16079,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 118)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 27
@@ -14380,8 +16089,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 27
@@ -14392,11 +16101,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14409,8 +16118,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 28
@@ -14422,8 +16131,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 119)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 28
@@ -14432,8 +16141,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 28
@@ -14444,11 +16153,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14461,8 +16170,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 26
@@ -14474,8 +16183,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 107)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 26
@@ -14484,8 +16193,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 26
@@ -14496,11 +16205,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14513,8 +16222,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 25
@@ -14526,8 +16235,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 106)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 25
@@ -14536,8 +16245,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 25
@@ -14548,11 +16257,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14565,8 +16274,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 24
@@ -14578,8 +16287,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 105)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 24
@@ -14588,8 +16297,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 24
@@ -14600,11 +16309,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14629,8 +16338,8 @@ entry:
   %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %3)
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %2
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -14641,15 +16350,15 @@ entry:
 
 ; <label>:8                                       ; preds = %62
   %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 9
   %12 = load i32, i32 addrspace(1)* %11, align 8
   %13 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.IO.StreamWriter addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %13, i32 0, i32 10
@@ -14664,15 +16373,15 @@ entry:
 
 ; <label>:20                                      ; preds = %14, %18
   %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
   %24 = load i32, i32 addrspace(1)* %23, align 8
   %25 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %25, null
-  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.StreamWriter addrspace(1)* %25, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %25, i32 0, i32 9
@@ -14693,36 +16402,36 @@ entry:
   %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %37 = load i32, i32* %loc1
   %38 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.StreamWriter addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %35
   %40 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %38, i32 0, i32 7
   %41 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %40, align 8
   %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
-  br i1 %NullCheck14, label %43, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %39
   %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 9
   %45 = load i32, i32 addrspace(1)* %44, align 8
   %46 = load i32, i32* %loc2
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %36, null
-  br i1 %NullCheck16, label %47, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %36, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %47
 
 ; <label>:47                                      ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %36, i32 %37, %"System.Char[]" addrspace(1)* %41, i32 %45, i32 %46)
   %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
   %51 = load i32, i32 addrspace(1)* %50, align 8
   %52 = load i32, i32* %loc2
   %53 = add i32 %51, %52
-  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
-  br i1 %NullCheck20, label %54, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %54
 
 ; <label>:54                                      ; preds = %49
   %55 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
@@ -14744,8 +16453,8 @@ entry:
 
 ; <label>:65                                      ; preds = %62
   %66 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %66, null
-  br i1 %NullCheck2, label %67, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %66, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %67
 
 ; <label>:67                                      ; preds = %65
   %68 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %66, i32 0, i32 11
@@ -14766,49 +16475,259 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %65
+ThrowNullRef2:                                    ; preds = %65
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %20
+ThrowNullRef8:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %22
+ThrowNullRef10:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %35
+ThrowNullRef12:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %43
+ThrowNullRef16:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %47
+ThrowNullRef18:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method String::CopyTo using LLILCJit
-Failed to read String.CopyTo[loadElemA]
+Successfully read String.CopyTo
+
+define void @String.CopyTo(%System.String addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  %loc1 = alloca i16 addrspace(1)*
+  %loc2 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %1 = icmp ne %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg4
+  %7 = icmp sge i32 %6, 0
+  br i1 %7, label %13, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  unreachable
+
+; <label>:13                                      ; preds = %5
+  %14 = load i32, i32* %arg1
+  %15 = icmp sge i32 %14, 0
+  br i1 %15, label %21, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %18)
+  %20 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %20, %System.String addrspace(1)* %17, %System.String addrspace(1)* %19)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %20) #0
+  unreachable
+
+; <label>:21                                      ; preds = %13
+  %22 = load i32, i32* %arg4
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck, label %ThrowNullRef, label %24
+
+; <label>:24                                      ; preds = %21
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load i32, i32* %arg1
+  %28 = sub i32 %26, %27
+  %29 = icmp sle i32 %22, %28
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34, %System.String addrspace(1)* %31, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %24
+  %36 = load i32, i32* %arg3
+  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %37, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
+
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
+  %40 = load i32, i32 addrspace(1)* %39
+  %41 = zext i32 %40 to i64
+  %42 = trunc i64 %41 to i32
+  %43 = load i32, i32* %arg4
+  %44 = sub i32 %42, %43
+  %45 = icmp sgt i32 %36, %44
+  br i1 %45, label %49, label %46
+
+; <label>:46                                      ; preds = %38
+  %47 = load i32, i32* %arg3
+  %48 = icmp sge i32 %47, 0
+  br i1 %48, label %54, label %49
+
+; <label>:49                                      ; preds = %38, %46
+  %50 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %52 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %51)
+  %53 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53, %System.String addrspace(1)* %50, %System.String addrspace(1)* %52)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53) #0
+  unreachable
+
+; <label>:54                                      ; preds = %46
+  %55 = load i32, i32* %arg4
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %97, label %57
+
+; <label>:57                                      ; preds = %54
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %59
+
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 2
+  %61 = bitcast [0 x i16] addrspace(1)* %60 to i16 addrspace(1)*
+  store i16 addrspace(1)* %61, i16 addrspace(1)** %loc0
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  store %"System.Char[]" addrspace(1)* %62, %"System.Char[]" addrspace(1)** %loc2
+  %63 = icmp eq %"System.Char[]" addrspace(1)* %62, null
+  br i1 %63, label %72, label %64
+
+; <label>:64                                      ; preds = %59
+  %65 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc2
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %65, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %66
+
+; <label>:66                                      ; preds = %64
+  %67 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %65, i32 0, i32 1
+  %68 = load i32, i32 addrspace(1)* %67
+  %69 = zext i32 %68 to i64
+  %70 = trunc i64 %69 to i32
+  %71 = icmp ne i32 %70, 0
+  br i1 %71, label %73, label %72
+
+; <label>:72                                      ; preds = %59, %66
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  br label %81
+
+; <label>:73                                      ; preds = %66
+  %74 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc2
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %74, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %75
+
+; <label>:75                                      ; preds = %73
+  %76 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %74, i32 0, i32 1
+  %77 = load i32, i32 addrspace(1)* %76
+  %78 = zext i32 %77 to i64
+  %BoundsCheck = icmp uge i64 0, %78
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %79
+
+; <label>:79                                      ; preds = %75
+  %80 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %74, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %80, i16 addrspace(1)** %loc1
+  br label %81
+
+; <label>:81                                      ; preds = %72, %79
+  %82 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %83 = ptrtoint i16 addrspace(1)* %82 to i64
+  %84 = load i32, i32* %arg3
+  %85 = sext i32 %84 to i64
+  %86 = mul i64 %85, 2
+  %87 = add i64 %83, %86
+  %88 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %89 = ptrtoint i16 addrspace(1)* %88 to i64
+  %90 = load i32, i32* %arg1
+  %91 = sext i32 %90 to i64
+  %92 = mul i64 %91, 2
+  %93 = add i64 %89, %92
+  %94 = load i32, i32* %arg4
+  %95 = inttoptr i64 %87 to i16*
+  %96 = inttoptr i64 %93 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %95, i16* %96, i32 %94)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  br label %97
+
+; <label>:97                                      ; preds = %54, %81
+  ret void
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
 Successfully read ConsoleEncoding.GetPreamble
 
@@ -14845,7 +16764,365 @@ entry:
 }
 
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[loadElemA]
+Successfully read EncoderNLS.GetBytes
+
+define i32 @EncoderNLS.GetBytes(%System.Text.EncoderNLS addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3, %"System.Byte[]" addrspace(1)* %param4, i32 %param5, i8 %param6) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %arg4 = alloca %"System.Byte[]" addrspace(1)*
+  %arg5 = alloca i32
+  %arg6 = alloca i8
+  %loc0 = alloca i32
+  %loc1 = alloca i16 addrspace(1)*
+  %loc2 = alloca i8 addrspace(1)*
+  %loc3 = alloca i32
+  %loc4 = alloca %"System.Char[]" addrspace(1)*
+  %loc5 = alloca %"System.Byte[]" addrspace(1)*
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  store %"System.Byte[]" addrspace(1)* %param4, %"System.Byte[]" addrspace(1)** %arg4
+  store i32 %param5, i32* %arg5
+  store i8 %param6, i8* %arg6
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %1 = icmp eq %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %17, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %7 = icmp eq %"System.Char[]" addrspace(1)* %6, null
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %12
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %12
+
+; <label>:12                                      ; preds = %8, %10
+  %13 = phi %System.String addrspace(1)* [ %9, %8 ], [ %11, %10 ]
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %14)
+  %16 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16, %System.String addrspace(1)* %13, %System.String addrspace(1)* %15)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16) #0
+  unreachable
+
+; <label>:17                                      ; preds = %2
+  %18 = load i32, i32* %arg2
+  %19 = icmp slt i32 %18, 0
+  br i1 %19, label %23, label %20
+
+; <label>:20                                      ; preds = %17
+  %21 = load i32, i32* %arg3
+  %22 = icmp sge i32 %21, 0
+  br i1 %22, label %35, label %23
+
+; <label>:23                                      ; preds = %17, %20
+  %24 = load i32, i32* %arg2
+  %25 = icmp slt i32 %24, 0
+  br i1 %25, label %28, label %26
+
+; <label>:26                                      ; preds = %23
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %30
+
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %30
+
+; <label>:30                                      ; preds = %26, %28
+  %31 = phi %System.String addrspace(1)* [ %27, %26 ], [ %29, %28 ]
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34, %System.String addrspace(1)* %31, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %20
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck, label %ThrowNullRef, label %37
+
+; <label>:37                                      ; preds = %35
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = load i32, i32* %arg2
+  %43 = sub i32 %41, %42
+  %44 = load i32, i32* %arg3
+  %45 = icmp sge i32 %43, %44
+  br i1 %45, label %51, label %46
+
+; <label>:46                                      ; preds = %37
+  %47 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %48 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %49 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %48)
+  %50 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %50, %System.String addrspace(1)* %47, %System.String addrspace(1)* %49)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %50) #0
+  unreachable
+
+; <label>:51                                      ; preds = %37
+  %52 = load i32, i32* %arg5
+  %53 = icmp slt i32 %52, 0
+  br i1 %53, label %63, label %54
+
+; <label>:54                                      ; preds = %51
+  %55 = load i32, i32* %arg5
+  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck1 = icmp eq %"System.Byte[]" addrspace(1)* %56, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %57
+
+; <label>:57                                      ; preds = %54
+  %58 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = zext i32 %59 to i64
+  %61 = trunc i64 %60 to i32
+  %62 = icmp sle i32 %55, %61
+  br i1 %62, label %68, label %63
+
+; <label>:63                                      ; preds = %51, %57
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %66 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %65)
+  %67 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %67, %System.String addrspace(1)* %64, %System.String addrspace(1)* %66)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %67) #0
+  unreachable
+
+; <label>:68                                      ; preds = %57
+  %69 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %69, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %69, i32 0, i32 1
+  %72 = load i32, i32 addrspace(1)* %71
+  %73 = zext i32 %72 to i64
+  %74 = trunc i64 %73 to i32
+  %75 = icmp ne i32 %74, 0
+  br i1 %75, label %78, label %76
+
+; <label>:76                                      ; preds = %70
+  %77 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1)
+  store %"System.Char[]" addrspace(1)* %77, %"System.Char[]" addrspace(1)** %arg1
+  br label %78
+
+; <label>:78                                      ; preds = %70, %76
+  %79 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck5 = icmp eq %"System.Byte[]" addrspace(1)* %79, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %80
+
+; <label>:80                                      ; preds = %78
+  %81 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %79, i32 0, i32 1
+  %82 = load i32, i32 addrspace(1)* %81
+  %83 = zext i32 %82 to i64
+  %84 = trunc i64 %83 to i32
+  %85 = load i32, i32* %arg5
+  %86 = sub i32 %84, %85
+  store i32 %86, i32* %loc0
+  %87 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck7 = icmp eq %"System.Byte[]" addrspace(1)* %87, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %88
+
+; <label>:88                                      ; preds = %80
+  %89 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %87, i32 0, i32 1
+  %90 = load i32, i32 addrspace(1)* %89
+  %91 = zext i32 %90 to i64
+  %92 = trunc i64 %91 to i32
+  %93 = icmp ne i32 %92, 0
+  br i1 %93, label %96, label %94
+
+; <label>:94                                      ; preds = %88
+  %95 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1)
+  store %"System.Byte[]" addrspace(1)* %95, %"System.Byte[]" addrspace(1)** %arg4
+  br label %96
+
+; <label>:96                                      ; preds = %88, %94
+  %97 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  store %"System.Char[]" addrspace(1)* %97, %"System.Char[]" addrspace(1)** %loc4
+  %98 = icmp eq %"System.Char[]" addrspace(1)* %97, null
+  br i1 %98, label %107, label %99
+
+; <label>:99                                      ; preds = %96
+  %100 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc4
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %100, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %101
+
+; <label>:101                                     ; preds = %99
+  %102 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %100, i32 0, i32 1
+  %103 = load i32, i32 addrspace(1)* %102
+  %104 = zext i32 %103 to i64
+  %105 = trunc i64 %104 to i32
+  %106 = icmp ne i32 %105, 0
+  br i1 %106, label %108, label %107
+
+; <label>:107                                     ; preds = %96, %101
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  br label %116
+
+; <label>:108                                     ; preds = %101
+  %109 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc4
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %109, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %110
+
+; <label>:110                                     ; preds = %108
+  %111 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %109, i32 0, i32 1
+  %112 = load i32, i32 addrspace(1)* %111
+  %113 = zext i32 %112 to i64
+  %BoundsCheck = icmp uge i64 0, %113
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %114
+
+; <label>:114                                     ; preds = %110
+  %115 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %109, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %115, i16 addrspace(1)** %loc1
+  br label %116
+
+; <label>:116                                     ; preds = %107, %114
+  %117 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  store %"System.Byte[]" addrspace(1)* %117, %"System.Byte[]" addrspace(1)** %loc5
+  %118 = icmp eq %"System.Byte[]" addrspace(1)* %117, null
+  br i1 %118, label %127, label %119
+
+; <label>:119                                     ; preds = %116
+  %120 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc5
+  %NullCheck13 = icmp eq %"System.Byte[]" addrspace(1)* %120, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %121
+
+; <label>:121                                     ; preds = %119
+  %122 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %120, i32 0, i32 1
+  %123 = load i32, i32 addrspace(1)* %122
+  %124 = zext i32 %123 to i64
+  %125 = trunc i64 %124 to i32
+  %126 = icmp ne i32 %125, 0
+  br i1 %126, label %128, label %127
+
+; <label>:127                                     ; preds = %116, %121
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc2
+  br label %136
+
+; <label>:128                                     ; preds = %121
+  %129 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc5
+  %NullCheck15 = icmp eq %"System.Byte[]" addrspace(1)* %129, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %130
+
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %129, i32 0, i32 1
+  %132 = load i32, i32 addrspace(1)* %131
+  %133 = zext i32 %132 to i64
+  %BoundsCheck17 = icmp uge i64 0, %133
+  br i1 %BoundsCheck17, label %ThrowIndexOutOfRange18, label %134
+
+; <label>:134                                     ; preds = %130
+  %135 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %129, i32 0, i32 3, i32 0
+  store i8 addrspace(1)* %135, i8 addrspace(1)** %loc2
+  br label %136
+
+; <label>:136                                     ; preds = %127, %134
+  %137 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %138 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %139 = ptrtoint i16 addrspace(1)* %138 to i64
+  %140 = load i32, i32* %arg2
+  %141 = sext i32 %140 to i64
+  %142 = mul i64 %141, 2
+  %143 = add i64 %139, %142
+  %144 = load i32, i32* %arg3
+  %145 = load i8 addrspace(1)*, i8 addrspace(1)** %loc2
+  %146 = ptrtoint i8 addrspace(1)* %145 to i64
+  %147 = load i32, i32* %arg5
+  %148 = sext i32 %147 to i64
+  %149 = add i64 %146, %148
+  %150 = load i32, i32* %loc0
+  %151 = load i8, i8* %arg6
+  %152 = zext i8 %151 to i32
+  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i64 addrspace(1)*
+  %NullCheck19 = icmp eq i64 addrspace(1)* %153, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %154
+
+; <label>:154                                     ; preds = %136
+  %155 = load i64, i64 addrspace(1)* %153
+  %156 = add i64 %155, 72
+  %157 = inttoptr i64 %156 to i64*
+  %158 = load i64, i64* %157
+  %159 = add i64 %158, 0
+  %160 = inttoptr i64 %159 to i64*
+  %161 = load i64, i64* %160
+  %162 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to %System.Text.Encoder addrspace(1)*
+  %163 = inttoptr i64 %143 to i16*
+  %164 = inttoptr i64 %149 to i8*
+  %165 = trunc i32 %152 to i8
+  %166 = inttoptr i64 %161 to i32 (%System.Text.Encoder addrspace(1)*, i16*, i32, i8*, i32, i8)*
+  %167 = call i32 %166(%System.Text.Encoder addrspace(1)* %162, i16* %163, i32 %144, i8* %164, i32 %150, i8 %165)
+  store i32 %167, i32* %loc3
+  br label %168
+
+; <label>:168                                     ; preds = %154
+  %169 = load i32, i32* %loc3
+  ret i32 %169
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %110
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %119
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange18:                           ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
 Successfully read EncoderNLS.GetBytes
 
@@ -14934,22 +17211,22 @@ entry:
   %40 = load i8, i8* %arg5
   %41 = zext i8 %40 to i32
   %42 = trunc i32 %41 to i8
-  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %39, null
-  br i1 %NullCheck, label %43, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderNLS addrspace(1)* %39, null
+  br i1 %NullCheck, label %ThrowNullRef, label %43
 
 ; <label>:43                                      ; preds = %38
   %44 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
   store i8 %42, i8 addrspace(1)* %44
   %45 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %45, null
-  br i1 %NullCheck2, label %46, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.EncoderNLS addrspace(1)* %45, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %46
 
 ; <label>:46                                      ; preds = %43
   %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %45, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %47
   %48 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.EncoderNLS addrspace(1)* %48, null
-  br i1 %NullCheck4, label %49, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.EncoderNLS addrspace(1)* %48, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %49
 
 ; <label>:49                                      ; preds = %46
   %50 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %48, i32 0, i32 3
@@ -14960,8 +17237,8 @@ entry:
   %55 = load i32, i32* %arg4
   %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck6, label %58, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
   %59 = load i64, i64 addrspace(1)* %57
@@ -14979,15 +17256,15 @@ ThrowNullRef:                                     ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %43
+ThrowNullRef2:                                    ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %46
+ThrowNullRef4:                                    ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %49
+ThrowNullRef6:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -15015,8 +17292,8 @@ entry:
   %4 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0 to %System.IO.ConsoleStream addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*)(%System.IO.ConsoleStream addrspace(1)* %4, %"System.Byte[]" addrspace(1)* %1, i32 %2, i32 %3)
   %5 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
@@ -15101,8 +17378,8 @@ entry:
 
 ; <label>:22                                      ; preds = %8
   %23 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %23, null
-  br i1 %NullCheck, label %24, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Byte[]" addrspace(1)* %23, null
+  br i1 %NullCheck, label %ThrowNullRef, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
@@ -15124,8 +17401,8 @@ entry:
 
 ; <label>:36                                      ; preds = %24
   %37 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %37, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.ConsoleStream addrspace(1)* %37, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %37, i32 0, i32 4
@@ -15146,13 +17423,138 @@ ThrowNullRef:                                     ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %36
+ThrowNullRef2:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
-Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
+Successfully read WindowsConsoleStream.WriteFileNative
+
+define i32 @WindowsConsoleStream.WriteFileNative(i64 %param0, %"System.Byte[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i64
+  %arg1 = alloca %"System.Byte[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i8 addrspace(1)*
+  %loc2 = alloca %"System.Byte[]" addrspace(1)*
+  %loc3 = alloca i32
+  store i64 %param0, i64* %arg0
+  store %"System.Byte[]" addrspace(1)* %param1, %"System.Byte[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Byte[]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = zext i32 %3 to i64
+  %5 = icmp ne i64 %4, 0
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %1
+  ret i32 0
+
+; <label>:7                                       ; preds = %1
+  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  store %"System.Byte[]" addrspace(1)* %8, %"System.Byte[]" addrspace(1)** %loc2
+  %9 = icmp eq %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %9, label %18, label %10
+
+; <label>:10                                      ; preds = %7
+  %11 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc2
+  %NullCheck1 = icmp eq %"System.Byte[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %11, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp ne i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %7, %12
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc1
+  br label %27
+
+; <label>:19                                      ; preds = %12
+  %20 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc2
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %20, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %BoundsCheck = icmp uge i64 0, %24
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %25
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %20, i32 0, i32 3, i32 0
+  store i8 addrspace(1)* %26, i8 addrspace(1)** %loc1
+  br label %27
+
+; <label>:27                                      ; preds = %18, %25
+  %28 = load i64, i64* %arg0
+  %29 = load i8 addrspace(1)*, i8 addrspace(1)** %loc1
+  %30 = ptrtoint i8 addrspace(1)* %29 to i64
+  %31 = load i32, i32* %arg2
+  %32 = sext i32 %31 to i64
+  %33 = add i64 %30, %32
+  %34 = load i32, i32* %arg3
+  %35 = addrspacecast i32* %loc3 to i32 addrspace(1)*
+  %36 = inttoptr i64 %33 to i8*
+  %37 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i8*, i32, i32 addrspace(1)*, i64)*)(i64 %28, i8* %36, i32 %34, i32 addrspace(1)* %35, i64 0)
+  %38 = icmp ugt i32 %37, 0
+  %39 = sext i1 %38 to i32
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc1
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %42, label %41
+
+; <label>:41                                      ; preds = %27
+  ret i32 0
+
+; <label>:42                                      ; preds = %27
+  %43 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  store i32 %43, i32* %loc0
+  %44 = load i32, i32* %loc0
+  %45 = icmp eq i32 %44, 232
+  br i1 %45, label %49, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = load i32, i32* %loc0
+  %48 = icmp ne i32 %47, 109
+  br i1 %48, label %50, label %49
+
+; <label>:49                                      ; preds = %42, %46
+  ret i32 0
+
+; <label>:50                                      ; preds = %46
+  %51 = load i32, i32* %loc0
+  ret i32 %51
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
 Successfully read WindowsConsoleStream.Flush
 
@@ -15161,8 +17563,8 @@ entry:
   %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
   store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
@@ -15197,8 +17599,8 @@ entry:
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
   %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load i64, i64 addrspace(1)* %1
@@ -15237,15 +17639,15 @@ entry:
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.TextWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
   %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %3, align 8
   %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
   %7 = load i64, i64 addrspace(1)* %5
@@ -15263,7 +17665,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -15292,8 +17694,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %4)
   store i32 0, i32* %loc0
   %5 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Char[]" addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
@@ -15305,15 +17707,15 @@ entry:
 
 ; <label>:11                                      ; preds = %69
   %12 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %12, i32 0, i32 9
   %15 = load i32, i32 addrspace(1)* %14, align 8
   %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.IO.StreamWriter addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %16, i32 0, i32 10
@@ -15328,15 +17730,15 @@ entry:
 
 ; <label>:23                                      ; preds = %17, %21
   %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %24, null
-  br i1 %NullCheck8, label %25, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %24, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 10
   %27 = load i32, i32 addrspace(1)* %26, align 8
   %28 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %28, null
-  br i1 %NullCheck10, label %29, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.StreamWriter addrspace(1)* %28, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %28, i32 0, i32 9
@@ -15358,15 +17760,15 @@ entry:
   %40 = load i32, i32* %loc0
   %41 = mul i32 %40, 2
   %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
-  br i1 %NullCheck12, label %43, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %43
 
 ; <label>:43                                      ; preds = %38
   %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 7
   %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %44, align 8
   %46 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %46, null
-  br i1 %NullCheck14, label %47, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.IO.StreamWriter addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %47
 
 ; <label>:47                                      ; preds = %43
   %48 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %46, i32 0, i32 9
@@ -15378,16 +17780,16 @@ entry:
   %54 = bitcast %"System.Char[]" addrspace(1)* %45 to %System.Array addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %53, i32 %41, %System.Array addrspace(1)* %54, i32 %50, i32 %52)
   %55 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
-  br i1 %NullCheck16, label %56, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %56
 
 ; <label>:56                                      ; preds = %47
   %57 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
   %58 = load i32, i32 addrspace(1)* %57, align 8
   %59 = load i32, i32* %loc2
   %60 = add i32 %58, %59
-  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
-  br i1 %NullCheck18, label %61, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %61
 
 ; <label>:61                                      ; preds = %56
   %62 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
@@ -15409,8 +17811,8 @@ entry:
 
 ; <label>:72                                      ; preds = %69
   %73 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %73, null
-  br i1 %NullCheck2, label %74, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %73, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %74
 
 ; <label>:74                                      ; preds = %72
   %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %73, i32 0, i32 11
@@ -15431,39 +17833,39 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %72
+ThrowNullRef2:                                    ; preds = %72
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %23
+ThrowNullRef8:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef10:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %43
+ThrowNullRef14:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %47
+ThrowNullRef16:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %56
+ThrowNullRef18:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPSub.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPSub.error.txt
@@ -25,8 +25,8 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
@@ -40,8 +40,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
   %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
@@ -75,7 +75,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -90,8 +90,8 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %NullCheck = icmp ne i8 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = load i8, i8 addrspace(1)* %0, align 8
@@ -125,8 +125,8 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
@@ -159,8 +159,8 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -184,8 +184,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
   store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
@@ -195,8 +195,8 @@ entry:
 ; <label>:4                                       ; preds = %1
   %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
   %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
@@ -206,8 +206,8 @@ entry:
   %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
@@ -221,14 +221,14 @@ entry:
 
 ; <label>:17                                      ; preds = %14
   %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
   %21 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
@@ -238,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -249,8 +249,8 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
@@ -261,27 +261,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %30
+ThrowNullRef10:                                   ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -301,7 +301,89 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
-Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
+Successfully read AppDomainSetup.GetUnsecureApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.GetUnsecureApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %NullCheck = icmp eq %"System.String[]" addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %BoundsCheck = icmp uge i64 0, %5
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %6
+
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 3, i32 0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
+  ret %System.String addrspace(1)* %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_Value using LLILCJit
+Successfully read AppDomainSetup.get_Value
+
+define %"System.String[]" addrspace(1)* @AppDomainSetup.get_Value(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.String[]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 18)
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.String[]" addrspace(1)* addrspace(1)*, %"System.String[]" addrspace(1)*)*)(%"System.String[]" addrspace(1)* addrspace(1)* %9, %"System.String[]" addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %11, i32 0, i32 1
+  %14 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %13, align 8
+  ret %"System.String[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -319,8 +401,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -368,16 +450,16 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
   %5 = load i32, i32 addrspace(1)* %4
   %6 = sub i32 %5, 1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -389,7 +471,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -421,8 +503,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
@@ -456,8 +538,8 @@ entry:
 ; <label>:27                                      ; preds = %19
   %28 = load i32, i32* %arg1
   %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
-  br i1 %NullCheck2, label %30, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %29, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %30
 
 ; <label>:30                                      ; preds = %27
   %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
@@ -493,8 +575,8 @@ entry:
 ; <label>:49                                      ; preds = %46
   %50 = load i32, i32* %arg2
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck4, label %52, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
@@ -517,11 +599,11 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %27
+ThrowNullRef2:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %49
+ThrowNullRef4:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -544,16 +626,16 @@ entry:
   %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %0)
   store %System.String addrspace(1)* %1, %System.String addrspace(1)** %loc0
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 2
   %5 = bitcast [0 x i16] addrspace(1)* %4 to i16 addrspace(1)*
   store i16 addrspace(1)* %5, i16 addrspace(1)** %loc1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %3
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2
@@ -580,7 +662,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -691,15 +773,15 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %NullCheck132 = icmp ne i8* %21, null
-  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+  %NullCheck131 = icmp eq i8* %21, null
+  br i1 %NullCheck131, label %ThrowNullRef132, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = load i8, i8* %21, align 8
   %24 = zext i8 %23 to i32
   %25 = trunc i32 %24 to i8
-  %NullCheck134 = icmp ne i8* %20, null
-  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+  %NullCheck133 = icmp eq i8* %20, null
+  br i1 %NullCheck133, label %ThrowNullRef134, label %26
 
 ; <label>:26                                      ; preds = %22
   store i8 %25, i8* %20, align 8
@@ -709,16 +791,16 @@ entry:
   %28 = load i8*, i8** %arg0
   %29 = load i8*, i8** %arg1
   %30 = bitcast i8* %29 to i16*
-  %NullCheck128 = icmp ne i16* %30, null
-  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+  %NullCheck127 = icmp eq i16* %30, null
+  br i1 %NullCheck127, label %ThrowNullRef128, label %31
 
 ; <label>:31                                      ; preds = %27
   %32 = load i16, i16* %30, align 8
   %33 = sext i16 %32 to i32
   %34 = bitcast i8* %28 to i16*
   %35 = trunc i32 %33 to i16
-  %NullCheck130 = icmp ne i16* %34, null
-  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+  %NullCheck129 = icmp eq i16* %34, null
+  br i1 %NullCheck129, label %ThrowNullRef130, label %36
 
 ; <label>:36                                      ; preds = %31
   store i16 %35, i16* %34, align 8
@@ -728,16 +810,16 @@ entry:
   %38 = load i8*, i8** %arg0
   %39 = load i8*, i8** %arg1
   %40 = bitcast i8* %39 to i16*
-  %NullCheck120 = icmp ne i16* %40, null
-  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+  %NullCheck119 = icmp eq i16* %40, null
+  br i1 %NullCheck119, label %ThrowNullRef120, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i16, i16* %40, align 8
   %43 = sext i16 %42 to i32
   %44 = bitcast i8* %38 to i16*
   %45 = trunc i32 %43 to i16
-  %NullCheck122 = icmp ne i16* %44, null
-  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+  %NullCheck121 = icmp eq i16* %44, null
+  br i1 %NullCheck121, label %ThrowNullRef122, label %46
 
 ; <label>:46                                      ; preds = %41
   store i16 %45, i16* %44, align 8
@@ -745,15 +827,15 @@ entry:
   %48 = getelementptr inbounds i8, i8* %47, i64 2
   %49 = load i8*, i8** %arg1
   %50 = getelementptr inbounds i8, i8* %49, i64 2
-  %NullCheck124 = icmp ne i8* %50, null
-  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+  %NullCheck123 = icmp eq i8* %50, null
+  br i1 %NullCheck123, label %ThrowNullRef124, label %51
 
 ; <label>:51                                      ; preds = %46
   %52 = load i8, i8* %50, align 8
   %53 = zext i8 %52 to i32
   %54 = trunc i32 %53 to i8
-  %NullCheck126 = icmp ne i8* %48, null
-  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+  %NullCheck125 = icmp eq i8* %48, null
+  br i1 %NullCheck125, label %ThrowNullRef126, label %55
 
 ; <label>:55                                      ; preds = %51
   store i8 %54, i8* %48, align 8
@@ -763,14 +845,14 @@ entry:
   %57 = load i8*, i8** %arg0
   %58 = load i8*, i8** %arg1
   %59 = bitcast i8* %58 to i32*
-  %NullCheck116 = icmp ne i32* %59, null
-  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+  %NullCheck115 = icmp eq i32* %59, null
+  br i1 %NullCheck115, label %ThrowNullRef116, label %60
 
 ; <label>:60                                      ; preds = %56
   %61 = load i32, i32* %59, align 8
   %62 = bitcast i8* %57 to i32*
-  %NullCheck118 = icmp ne i32* %62, null
-  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+  %NullCheck117 = icmp eq i32* %62, null
+  br i1 %NullCheck117, label %ThrowNullRef118, label %63
 
 ; <label>:63                                      ; preds = %60
   store i32 %61, i32* %62, align 8
@@ -780,14 +862,14 @@ entry:
   %65 = load i8*, i8** %arg0
   %66 = load i8*, i8** %arg1
   %67 = bitcast i8* %66 to i32*
-  %NullCheck108 = icmp ne i32* %67, null
-  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+  %NullCheck107 = icmp eq i32* %67, null
+  br i1 %NullCheck107, label %ThrowNullRef108, label %68
 
 ; <label>:68                                      ; preds = %64
   %69 = load i32, i32* %67, align 8
   %70 = bitcast i8* %65 to i32*
-  %NullCheck110 = icmp ne i32* %70, null
-  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+  %NullCheck109 = icmp eq i32* %70, null
+  br i1 %NullCheck109, label %ThrowNullRef110, label %71
 
 ; <label>:71                                      ; preds = %68
   store i32 %69, i32* %70, align 8
@@ -795,15 +877,15 @@ entry:
   %73 = getelementptr inbounds i8, i8* %72, i64 4
   %74 = load i8*, i8** %arg1
   %75 = getelementptr inbounds i8, i8* %74, i64 4
-  %NullCheck112 = icmp ne i8* %75, null
-  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+  %NullCheck111 = icmp eq i8* %75, null
+  br i1 %NullCheck111, label %ThrowNullRef112, label %76
 
 ; <label>:76                                      ; preds = %71
   %77 = load i8, i8* %75, align 8
   %78 = zext i8 %77 to i32
   %79 = trunc i32 %78 to i8
-  %NullCheck114 = icmp ne i8* %73, null
-  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+  %NullCheck113 = icmp eq i8* %73, null
+  br i1 %NullCheck113, label %ThrowNullRef114, label %80
 
 ; <label>:80                                      ; preds = %76
   store i8 %79, i8* %73, align 8
@@ -813,14 +895,14 @@ entry:
   %82 = load i8*, i8** %arg0
   %83 = load i8*, i8** %arg1
   %84 = bitcast i8* %83 to i32*
-  %NullCheck100 = icmp ne i32* %84, null
-  br i1 %NullCheck100, label %85, label %ThrowNullRef99
+  %NullCheck99 = icmp eq i32* %84, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %85
 
 ; <label>:85                                      ; preds = %81
   %86 = load i32, i32* %84, align 8
   %87 = bitcast i8* %82 to i32*
-  %NullCheck102 = icmp ne i32* %87, null
-  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+  %NullCheck101 = icmp eq i32* %87, null
+  br i1 %NullCheck101, label %ThrowNullRef102, label %88
 
 ; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
@@ -829,16 +911,16 @@ entry:
   %91 = load i8*, i8** %arg1
   %92 = getelementptr inbounds i8, i8* %91, i64 4
   %93 = bitcast i8* %92 to i16*
-  %NullCheck104 = icmp ne i16* %93, null
-  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+  %NullCheck103 = icmp eq i16* %93, null
+  br i1 %NullCheck103, label %ThrowNullRef104, label %94
 
 ; <label>:94                                      ; preds = %88
   %95 = load i16, i16* %93, align 8
   %96 = sext i16 %95 to i32
   %97 = bitcast i8* %90 to i16*
   %98 = trunc i32 %96 to i16
-  %NullCheck106 = icmp ne i16* %97, null
-  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+  %NullCheck105 = icmp eq i16* %97, null
+  br i1 %NullCheck105, label %ThrowNullRef106, label %99
 
 ; <label>:99                                      ; preds = %94
   store i16 %98, i16* %97, align 8
@@ -848,14 +930,14 @@ entry:
   %101 = load i8*, i8** %arg0
   %102 = load i8*, i8** %arg1
   %103 = bitcast i8* %102 to i32*
-  %NullCheck88 = icmp ne i32* %103, null
-  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+  %NullCheck87 = icmp eq i32* %103, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %104
 
 ; <label>:104                                     ; preds = %100
   %105 = load i32, i32* %103, align 8
   %106 = bitcast i8* %101 to i32*
-  %NullCheck90 = icmp ne i32* %106, null
-  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+  %NullCheck89 = icmp eq i32* %106, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %107
 
 ; <label>:107                                     ; preds = %104
   store i32 %105, i32* %106, align 8
@@ -864,16 +946,16 @@ entry:
   %110 = load i8*, i8** %arg1
   %111 = getelementptr inbounds i8, i8* %110, i64 4
   %112 = bitcast i8* %111 to i16*
-  %NullCheck92 = icmp ne i16* %112, null
-  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+  %NullCheck91 = icmp eq i16* %112, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %113
 
 ; <label>:113                                     ; preds = %107
   %114 = load i16, i16* %112, align 8
   %115 = sext i16 %114 to i32
   %116 = bitcast i8* %109 to i16*
   %117 = trunc i32 %115 to i16
-  %NullCheck94 = icmp ne i16* %116, null
-  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+  %NullCheck93 = icmp eq i16* %116, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %118
 
 ; <label>:118                                     ; preds = %113
   store i16 %117, i16* %116, align 8
@@ -881,15 +963,15 @@ entry:
   %120 = getelementptr inbounds i8, i8* %119, i64 6
   %121 = load i8*, i8** %arg1
   %122 = getelementptr inbounds i8, i8* %121, i64 6
-  %NullCheck96 = icmp ne i8* %122, null
-  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+  %NullCheck95 = icmp eq i8* %122, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %123
 
 ; <label>:123                                     ; preds = %118
   %124 = load i8, i8* %122, align 8
   %125 = zext i8 %124 to i32
   %126 = trunc i32 %125 to i8
-  %NullCheck98 = icmp ne i8* %120, null
-  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+  %NullCheck97 = icmp eq i8* %120, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %127
 
 ; <label>:127                                     ; preds = %123
   store i8 %126, i8* %120, align 8
@@ -899,14 +981,14 @@ entry:
   %129 = load i8*, i8** %arg0
   %130 = load i8*, i8** %arg1
   %131 = bitcast i8* %130 to i64*
-  %NullCheck84 = icmp ne i64* %131, null
-  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+  %NullCheck83 = icmp eq i64* %131, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %132
 
 ; <label>:132                                     ; preds = %128
   %133 = load i64, i64* %131, align 8
   %134 = bitcast i8* %129 to i64*
-  %NullCheck86 = icmp ne i64* %134, null
-  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+  %NullCheck85 = icmp eq i64* %134, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %135
 
 ; <label>:135                                     ; preds = %132
   store i64 %133, i64* %134, align 8
@@ -916,14 +998,14 @@ entry:
   %137 = load i8*, i8** %arg0
   %138 = load i8*, i8** %arg1
   %139 = bitcast i8* %138 to i64*
-  %NullCheck76 = icmp ne i64* %139, null
-  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+  %NullCheck75 = icmp eq i64* %139, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %140
 
 ; <label>:140                                     ; preds = %136
   %141 = load i64, i64* %139, align 8
   %142 = bitcast i8* %137 to i64*
-  %NullCheck78 = icmp ne i64* %142, null
-  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+  %NullCheck77 = icmp eq i64* %142, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %143
 
 ; <label>:143                                     ; preds = %140
   store i64 %141, i64* %142, align 8
@@ -931,15 +1013,15 @@ entry:
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %NullCheck80 = icmp ne i8* %147, null
-  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+  %NullCheck79 = icmp eq i8* %147, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %148
 
 ; <label>:148                                     ; preds = %143
   %149 = load i8, i8* %147, align 8
   %150 = zext i8 %149 to i32
   %151 = trunc i32 %150 to i8
-  %NullCheck82 = icmp ne i8* %145, null
-  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+  %NullCheck81 = icmp eq i8* %145, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %152
 
 ; <label>:152                                     ; preds = %148
   store i8 %151, i8* %145, align 8
@@ -949,14 +1031,14 @@ entry:
   %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
   %156 = bitcast i8* %155 to i64*
-  %NullCheck68 = icmp ne i64* %156, null
-  br i1 %NullCheck68, label %157, label %ThrowNullRef67
+  %NullCheck67 = icmp eq i64* %156, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %157
 
 ; <label>:157                                     ; preds = %153
   %158 = load i64, i64* %156, align 8
   %159 = bitcast i8* %154 to i64*
-  %NullCheck70 = icmp ne i64* %159, null
-  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+  %NullCheck69 = icmp eq i64* %159, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %160
 
 ; <label>:160                                     ; preds = %157
   store i64 %158, i64* %159, align 8
@@ -965,16 +1047,16 @@ entry:
   %163 = load i8*, i8** %arg1
   %164 = getelementptr inbounds i8, i8* %163, i64 8
   %165 = bitcast i8* %164 to i16*
-  %NullCheck72 = icmp ne i16* %165, null
-  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+  %NullCheck71 = icmp eq i16* %165, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %166
 
 ; <label>:166                                     ; preds = %160
   %167 = load i16, i16* %165, align 8
   %168 = sext i16 %167 to i32
   %169 = bitcast i8* %162 to i16*
   %170 = trunc i32 %168 to i16
-  %NullCheck74 = icmp ne i16* %169, null
-  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+  %NullCheck73 = icmp eq i16* %169, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %171
 
 ; <label>:171                                     ; preds = %166
   store i16 %170, i16* %169, align 8
@@ -984,14 +1066,14 @@ entry:
   %173 = load i8*, i8** %arg0
   %174 = load i8*, i8** %arg1
   %175 = bitcast i8* %174 to i64*
-  %NullCheck56 = icmp ne i64* %175, null
-  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+  %NullCheck55 = icmp eq i64* %175, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %176
 
 ; <label>:176                                     ; preds = %172
   %177 = load i64, i64* %175, align 8
   %178 = bitcast i8* %173 to i64*
-  %NullCheck58 = icmp ne i64* %178, null
-  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+  %NullCheck57 = icmp eq i64* %178, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %179
 
 ; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
@@ -1000,16 +1082,16 @@ entry:
   %182 = load i8*, i8** %arg1
   %183 = getelementptr inbounds i8, i8* %182, i64 8
   %184 = bitcast i8* %183 to i16*
-  %NullCheck60 = icmp ne i16* %184, null
-  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+  %NullCheck59 = icmp eq i16* %184, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %185
 
 ; <label>:185                                     ; preds = %179
   %186 = load i16, i16* %184, align 8
   %187 = sext i16 %186 to i32
   %188 = bitcast i8* %181 to i16*
   %189 = trunc i32 %187 to i16
-  %NullCheck62 = icmp ne i16* %188, null
-  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+  %NullCheck61 = icmp eq i16* %188, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %190
 
 ; <label>:190                                     ; preds = %185
   store i16 %189, i16* %188, align 8
@@ -1017,15 +1099,15 @@ entry:
   %192 = getelementptr inbounds i8, i8* %191, i64 10
   %193 = load i8*, i8** %arg1
   %194 = getelementptr inbounds i8, i8* %193, i64 10
-  %NullCheck64 = icmp ne i8* %194, null
-  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+  %NullCheck63 = icmp eq i8* %194, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %195
 
 ; <label>:195                                     ; preds = %190
   %196 = load i8, i8* %194, align 8
   %197 = zext i8 %196 to i32
   %198 = trunc i32 %197 to i8
-  %NullCheck66 = icmp ne i8* %192, null
-  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+  %NullCheck65 = icmp eq i8* %192, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %199
 
 ; <label>:199                                     ; preds = %195
   store i8 %198, i8* %192, align 8
@@ -1035,14 +1117,14 @@ entry:
   %201 = load i8*, i8** %arg0
   %202 = load i8*, i8** %arg1
   %203 = bitcast i8* %202 to i64*
-  %NullCheck48 = icmp ne i64* %203, null
-  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+  %NullCheck47 = icmp eq i64* %203, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %204
 
 ; <label>:204                                     ; preds = %200
   %205 = load i64, i64* %203, align 8
   %206 = bitcast i8* %201 to i64*
-  %NullCheck50 = icmp ne i64* %206, null
-  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+  %NullCheck49 = icmp eq i64* %206, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %207
 
 ; <label>:207                                     ; preds = %204
   store i64 %205, i64* %206, align 8
@@ -1051,14 +1133,14 @@ entry:
   %210 = load i8*, i8** %arg1
   %211 = getelementptr inbounds i8, i8* %210, i64 8
   %212 = bitcast i8* %211 to i32*
-  %NullCheck52 = icmp ne i32* %212, null
-  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+  %NullCheck51 = icmp eq i32* %212, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %213
 
 ; <label>:213                                     ; preds = %207
   %214 = load i32, i32* %212, align 8
   %215 = bitcast i8* %209 to i32*
-  %NullCheck54 = icmp ne i32* %215, null
-  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+  %NullCheck53 = icmp eq i32* %215, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %216
 
 ; <label>:216                                     ; preds = %213
   store i32 %214, i32* %215, align 8
@@ -1068,14 +1150,14 @@ entry:
   %218 = load i8*, i8** %arg0
   %219 = load i8*, i8** %arg1
   %220 = bitcast i8* %219 to i64*
-  %NullCheck36 = icmp ne i64* %220, null
-  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64* %220, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %221
 
 ; <label>:221                                     ; preds = %217
   %222 = load i64, i64* %220, align 8
   %223 = bitcast i8* %218 to i64*
-  %NullCheck38 = icmp ne i64* %223, null
-  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+  %NullCheck37 = icmp eq i64* %223, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %224
 
 ; <label>:224                                     ; preds = %221
   store i64 %222, i64* %223, align 8
@@ -1084,14 +1166,14 @@ entry:
   %227 = load i8*, i8** %arg1
   %228 = getelementptr inbounds i8, i8* %227, i64 8
   %229 = bitcast i8* %228 to i32*
-  %NullCheck40 = icmp ne i32* %229, null
-  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i32* %229, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %230
 
 ; <label>:230                                     ; preds = %224
   %231 = load i32, i32* %229, align 8
   %232 = bitcast i8* %226 to i32*
-  %NullCheck42 = icmp ne i32* %232, null
-  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+  %NullCheck41 = icmp eq i32* %232, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %233
 
 ; <label>:233                                     ; preds = %230
   store i32 %231, i32* %232, align 8
@@ -1099,15 +1181,15 @@ entry:
   %235 = getelementptr inbounds i8, i8* %234, i64 12
   %236 = load i8*, i8** %arg1
   %237 = getelementptr inbounds i8, i8* %236, i64 12
-  %NullCheck44 = icmp ne i8* %237, null
-  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i8* %237, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %238
 
 ; <label>:238                                     ; preds = %233
   %239 = load i8, i8* %237, align 8
   %240 = zext i8 %239 to i32
   %241 = trunc i32 %240 to i8
-  %NullCheck46 = icmp ne i8* %235, null
-  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+  %NullCheck45 = icmp eq i8* %235, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %242
 
 ; <label>:242                                     ; preds = %238
   store i8 %241, i8* %235, align 8
@@ -1117,14 +1199,14 @@ entry:
   %244 = load i8*, i8** %arg0
   %245 = load i8*, i8** %arg1
   %246 = bitcast i8* %245 to i64*
-  %NullCheck24 = icmp ne i64* %246, null
-  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64* %246, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %247
 
 ; <label>:247                                     ; preds = %243
   %248 = load i64, i64* %246, align 8
   %249 = bitcast i8* %244 to i64*
-  %NullCheck26 = icmp ne i64* %249, null
-  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64* %249, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %250
 
 ; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
@@ -1133,14 +1215,14 @@ entry:
   %253 = load i8*, i8** %arg1
   %254 = getelementptr inbounds i8, i8* %253, i64 8
   %255 = bitcast i8* %254 to i32*
-  %NullCheck28 = icmp ne i32* %255, null
-  br i1 %NullCheck28, label %256, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i32* %255, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %256
 
 ; <label>:256                                     ; preds = %250
   %257 = load i32, i32* %255, align 8
   %258 = bitcast i8* %252 to i32*
-  %NullCheck30 = icmp ne i32* %258, null
-  br i1 %NullCheck30, label %259, label %ThrowNullRef29
+  %NullCheck29 = icmp eq i32* %258, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %259
 
 ; <label>:259                                     ; preds = %256
   store i32 %257, i32* %258, align 8
@@ -1149,16 +1231,16 @@ entry:
   %262 = load i8*, i8** %arg1
   %263 = getelementptr inbounds i8, i8* %262, i64 12
   %264 = bitcast i8* %263 to i16*
-  %NullCheck32 = icmp ne i16* %264, null
-  br i1 %NullCheck32, label %265, label %ThrowNullRef31
+  %NullCheck31 = icmp eq i16* %264, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %265
 
 ; <label>:265                                     ; preds = %259
   %266 = load i16, i16* %264, align 8
   %267 = sext i16 %266 to i32
   %268 = bitcast i8* %261 to i16*
   %269 = trunc i32 %267 to i16
-  %NullCheck34 = icmp ne i16* %268, null
-  br i1 %NullCheck34, label %270, label %ThrowNullRef33
+  %NullCheck33 = icmp eq i16* %268, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %270
 
 ; <label>:270                                     ; preds = %265
   store i16 %269, i16* %268, align 8
@@ -1168,14 +1250,14 @@ entry:
   %272 = load i8*, i8** %arg0
   %273 = load i8*, i8** %arg1
   %274 = bitcast i8* %273 to i64*
-  %NullCheck8 = icmp ne i64* %274, null
-  br i1 %NullCheck8, label %275, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64* %274, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %275
 
 ; <label>:275                                     ; preds = %271
   %276 = load i64, i64* %274, align 8
   %277 = bitcast i8* %272 to i64*
-  %NullCheck10 = icmp ne i64* %277, null
-  br i1 %NullCheck10, label %278, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %277, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %278
 
 ; <label>:278                                     ; preds = %275
   store i64 %276, i64* %277, align 8
@@ -1184,14 +1266,14 @@ entry:
   %281 = load i8*, i8** %arg1
   %282 = getelementptr inbounds i8, i8* %281, i64 8
   %283 = bitcast i8* %282 to i32*
-  %NullCheck12 = icmp ne i32* %283, null
-  br i1 %NullCheck12, label %284, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i32* %283, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %284
 
 ; <label>:284                                     ; preds = %278
   %285 = load i32, i32* %283, align 8
   %286 = bitcast i8* %280 to i32*
-  %NullCheck14 = icmp ne i32* %286, null
-  br i1 %NullCheck14, label %287, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i32* %286, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %287
 
 ; <label>:287                                     ; preds = %284
   store i32 %285, i32* %286, align 8
@@ -1200,16 +1282,16 @@ entry:
   %290 = load i8*, i8** %arg1
   %291 = getelementptr inbounds i8, i8* %290, i64 12
   %292 = bitcast i8* %291 to i16*
-  %NullCheck16 = icmp ne i16* %292, null
-  br i1 %NullCheck16, label %293, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i16* %292, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %293
 
 ; <label>:293                                     ; preds = %287
   %294 = load i16, i16* %292, align 8
   %295 = sext i16 %294 to i32
   %296 = bitcast i8* %289 to i16*
   %297 = trunc i32 %295 to i16
-  %NullCheck18 = icmp ne i16* %296, null
-  br i1 %NullCheck18, label %298, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i16* %296, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %298
 
 ; <label>:298                                     ; preds = %293
   store i16 %297, i16* %296, align 8
@@ -1217,15 +1299,15 @@ entry:
   %300 = getelementptr inbounds i8, i8* %299, i64 14
   %301 = load i8*, i8** %arg1
   %302 = getelementptr inbounds i8, i8* %301, i64 14
-  %NullCheck20 = icmp ne i8* %302, null
-  br i1 %NullCheck20, label %303, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i8* %302, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %303
 
 ; <label>:303                                     ; preds = %298
   %304 = load i8, i8* %302, align 8
   %305 = zext i8 %304 to i32
   %306 = trunc i32 %305 to i8
-  %NullCheck22 = icmp ne i8* %300, null
-  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i8* %300, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %307
 
 ; <label>:307                                     ; preds = %303
   store i8 %306, i8* %300, align 8
@@ -1235,14 +1317,14 @@ entry:
   %309 = load i8*, i8** %arg0
   %310 = load i8*, i8** %arg1
   %311 = bitcast i8* %310 to i64*
-  %NullCheck = icmp ne i64* %311, null
-  br i1 %NullCheck, label %312, label %ThrowNullRef
+  %NullCheck = icmp eq i64* %311, null
+  br i1 %NullCheck, label %ThrowNullRef, label %312
 
 ; <label>:312                                     ; preds = %308
   %313 = load i64, i64* %311, align 8
   %314 = bitcast i8* %309 to i64*
-  %NullCheck2 = icmp ne i64* %314, null
-  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64* %314, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %315
 
 ; <label>:315                                     ; preds = %312
   store i64 %313, i64* %314, align 8
@@ -1251,14 +1333,14 @@ entry:
   %318 = load i8*, i8** %arg1
   %319 = getelementptr inbounds i8, i8* %318, i64 8
   %320 = bitcast i8* %319 to i64*
-  %NullCheck4 = icmp ne i64* %320, null
-  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64* %320, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %321
 
 ; <label>:321                                     ; preds = %315
   %322 = load i64, i64* %320, align 8
   %323 = bitcast i8* %317 to i64*
-  %NullCheck6 = icmp ne i64* %323, null
-  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64* %323, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %324
 
 ; <label>:324                                     ; preds = %321
   store i64 %322, i64* %323, align 8
@@ -1286,15 +1368,15 @@ entry:
 ; <label>:338                                     ; preds = %333
   %339 = load i8*, i8** %arg0
   %340 = load i8*, i8** %arg1
-  %NullCheck136 = icmp ne i8* %340, null
-  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+  %NullCheck135 = icmp eq i8* %340, null
+  br i1 %NullCheck135, label %ThrowNullRef136, label %341
 
 ; <label>:341                                     ; preds = %338
   %342 = load i8, i8* %340, align 8
   %343 = zext i8 %342 to i32
   %344 = trunc i32 %343 to i8
-  %NullCheck138 = icmp ne i8* %339, null
-  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+  %NullCheck137 = icmp eq i8* %339, null
+  br i1 %NullCheck137, label %ThrowNullRef138, label %345
 
 ; <label>:345                                     ; preds = %341
   store i8 %344, i8* %339, align 8
@@ -1317,16 +1399,16 @@ entry:
   %357 = load i8*, i8** %arg0
   %358 = load i8*, i8** %arg1
   %359 = bitcast i8* %358 to i16*
-  %NullCheck140 = icmp ne i16* %359, null
-  br i1 %NullCheck140, label %360, label %ThrowNullRef139
+  %NullCheck139 = icmp eq i16* %359, null
+  br i1 %NullCheck139, label %ThrowNullRef140, label %360
 
 ; <label>:360                                     ; preds = %356
   %361 = load i16, i16* %359, align 8
   %362 = sext i16 %361 to i32
   %363 = bitcast i8* %357 to i16*
   %364 = trunc i32 %362 to i16
-  %NullCheck142 = icmp ne i16* %363, null
-  br i1 %NullCheck142, label %365, label %ThrowNullRef141
+  %NullCheck141 = icmp eq i16* %363, null
+  br i1 %NullCheck141, label %ThrowNullRef142, label %365
 
 ; <label>:365                                     ; preds = %360
   store i16 %364, i16* %363, align 8
@@ -1352,14 +1434,14 @@ entry:
   %378 = load i8*, i8** %arg0
   %379 = load i8*, i8** %arg1
   %380 = bitcast i8* %379 to i32*
-  %NullCheck144 = icmp ne i32* %380, null
-  br i1 %NullCheck144, label %381, label %ThrowNullRef143
+  %NullCheck143 = icmp eq i32* %380, null
+  br i1 %NullCheck143, label %ThrowNullRef144, label %381
 
 ; <label>:381                                     ; preds = %377
   %382 = load i32, i32* %380, align 8
   %383 = bitcast i8* %378 to i32*
-  %NullCheck146 = icmp ne i32* %383, null
-  br i1 %NullCheck146, label %384, label %ThrowNullRef145
+  %NullCheck145 = icmp eq i32* %383, null
+  br i1 %NullCheck145, label %ThrowNullRef146, label %384
 
 ; <label>:384                                     ; preds = %381
   store i32 %382, i32* %383, align 8
@@ -1384,14 +1466,14 @@ entry:
   %395 = load i8*, i8** %arg0
   %396 = load i8*, i8** %arg1
   %397 = bitcast i8* %396 to i64*
-  %NullCheck164 = icmp ne i64* %397, null
-  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+  %NullCheck163 = icmp eq i64* %397, null
+  br i1 %NullCheck163, label %ThrowNullRef164, label %398
 
 ; <label>:398                                     ; preds = %394
   %399 = load i64, i64* %397, align 8
   %400 = bitcast i8* %395 to i64*
-  %NullCheck166 = icmp ne i64* %400, null
-  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+  %NullCheck165 = icmp eq i64* %400, null
+  br i1 %NullCheck165, label %ThrowNullRef166, label %401
 
 ; <label>:401                                     ; preds = %398
   store i64 %399, i64* %400, align 8
@@ -1400,14 +1482,14 @@ entry:
   %404 = load i8*, i8** %arg1
   %405 = getelementptr inbounds i8, i8* %404, i64 8
   %406 = bitcast i8* %405 to i64*
-  %NullCheck168 = icmp ne i64* %406, null
-  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+  %NullCheck167 = icmp eq i64* %406, null
+  br i1 %NullCheck167, label %ThrowNullRef168, label %407
 
 ; <label>:407                                     ; preds = %401
   %408 = load i64, i64* %406, align 8
   %409 = bitcast i8* %403 to i64*
-  %NullCheck170 = icmp ne i64* %409, null
-  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+  %NullCheck169 = icmp eq i64* %409, null
+  br i1 %NullCheck169, label %ThrowNullRef170, label %410
 
 ; <label>:410                                     ; preds = %407
   store i64 %408, i64* %409, align 8
@@ -1437,14 +1519,14 @@ entry:
   %425 = load i8*, i8** %arg0
   %426 = load i8*, i8** %arg1
   %427 = bitcast i8* %426 to i64*
-  %NullCheck148 = icmp ne i64* %427, null
-  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+  %NullCheck147 = icmp eq i64* %427, null
+  br i1 %NullCheck147, label %ThrowNullRef148, label %428
 
 ; <label>:428                                     ; preds = %424
   %429 = load i64, i64* %427, align 8
   %430 = bitcast i8* %425 to i64*
-  %NullCheck150 = icmp ne i64* %430, null
-  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+  %NullCheck149 = icmp eq i64* %430, null
+  br i1 %NullCheck149, label %ThrowNullRef150, label %431
 
 ; <label>:431                                     ; preds = %428
   store i64 %429, i64* %430, align 8
@@ -1466,14 +1548,14 @@ entry:
   %441 = load i8*, i8** %arg0
   %442 = load i8*, i8** %arg1
   %443 = bitcast i8* %442 to i32*
-  %NullCheck152 = icmp ne i32* %443, null
-  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+  %NullCheck151 = icmp eq i32* %443, null
+  br i1 %NullCheck151, label %ThrowNullRef152, label %444
 
 ; <label>:444                                     ; preds = %440
   %445 = load i32, i32* %443, align 8
   %446 = bitcast i8* %441 to i32*
-  %NullCheck154 = icmp ne i32* %446, null
-  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+  %NullCheck153 = icmp eq i32* %446, null
+  br i1 %NullCheck153, label %ThrowNullRef154, label %447
 
 ; <label>:447                                     ; preds = %444
   store i32 %445, i32* %446, align 8
@@ -1495,16 +1577,16 @@ entry:
   %457 = load i8*, i8** %arg0
   %458 = load i8*, i8** %arg1
   %459 = bitcast i8* %458 to i16*
-  %NullCheck156 = icmp ne i16* %459, null
-  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+  %NullCheck155 = icmp eq i16* %459, null
+  br i1 %NullCheck155, label %ThrowNullRef156, label %460
 
 ; <label>:460                                     ; preds = %456
   %461 = load i16, i16* %459, align 8
   %462 = sext i16 %461 to i32
   %463 = bitcast i8* %457 to i16*
   %464 = trunc i32 %462 to i16
-  %NullCheck158 = icmp ne i16* %463, null
-  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+  %NullCheck157 = icmp eq i16* %463, null
+  br i1 %NullCheck157, label %ThrowNullRef158, label %465
 
 ; <label>:465                                     ; preds = %460
   store i16 %464, i16* %463, align 8
@@ -1525,15 +1607,15 @@ entry:
 ; <label>:474                                     ; preds = %470
   %475 = load i8*, i8** %arg0
   %476 = load i8*, i8** %arg1
-  %NullCheck160 = icmp ne i8* %476, null
-  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+  %NullCheck159 = icmp eq i8* %476, null
+  br i1 %NullCheck159, label %ThrowNullRef160, label %477
 
 ; <label>:477                                     ; preds = %474
   %478 = load i8, i8* %476, align 8
   %479 = zext i8 %478 to i32
   %480 = trunc i32 %479 to i8
-  %NullCheck162 = icmp ne i8* %475, null
-  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+  %NullCheck161 = icmp eq i8* %475, null
+  br i1 %NullCheck161, label %ThrowNullRef162, label %481
 
 ; <label>:481                                     ; preds = %477
   store i8 %480, i8* %475, align 8
@@ -1553,343 +1635,343 @@ ThrowNullRef:                                     ; preds = %308
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %312
+ThrowNullRef2:                                    ; preds = %312
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %315
+ThrowNullRef4:                                    ; preds = %315
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %321
+ThrowNullRef6:                                    ; preds = %321
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %271
+ThrowNullRef8:                                    ; preds = %271
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %275
+ThrowNullRef10:                                   ; preds = %275
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %278
+ThrowNullRef12:                                   ; preds = %278
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %284
+ThrowNullRef14:                                   ; preds = %284
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %287
+ThrowNullRef16:                                   ; preds = %287
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %293
+ThrowNullRef18:                                   ; preds = %293
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %298
+ThrowNullRef20:                                   ; preds = %298
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %303
+ThrowNullRef22:                                   ; preds = %303
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %243
+ThrowNullRef24:                                   ; preds = %243
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %247
+ThrowNullRef26:                                   ; preds = %247
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %250
+ThrowNullRef28:                                   ; preds = %250
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %256
+ThrowNullRef30:                                   ; preds = %256
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %259
+ThrowNullRef32:                                   ; preds = %259
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %265
+ThrowNullRef34:                                   ; preds = %265
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %217
+ThrowNullRef36:                                   ; preds = %217
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %221
+ThrowNullRef38:                                   ; preds = %221
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %224
+ThrowNullRef40:                                   ; preds = %224
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %230
+ThrowNullRef42:                                   ; preds = %230
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %233
+ThrowNullRef44:                                   ; preds = %233
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %238
+ThrowNullRef46:                                   ; preds = %238
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %200
+ThrowNullRef48:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %204
+ThrowNullRef50:                                   ; preds = %204
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %207
+ThrowNullRef52:                                   ; preds = %207
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %213
+ThrowNullRef54:                                   ; preds = %213
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %172
+ThrowNullRef56:                                   ; preds = %172
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %176
+ThrowNullRef58:                                   ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %179
+ThrowNullRef60:                                   ; preds = %179
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %185
+ThrowNullRef62:                                   ; preds = %185
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %190
+ThrowNullRef64:                                   ; preds = %190
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %195
+ThrowNullRef66:                                   ; preds = %195
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %153
+ThrowNullRef68:                                   ; preds = %153
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %157
+ThrowNullRef70:                                   ; preds = %157
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %160
+ThrowNullRef72:                                   ; preds = %160
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %166
+ThrowNullRef74:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %136
+ThrowNullRef76:                                   ; preds = %136
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %140
+ThrowNullRef78:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %143
+ThrowNullRef80:                                   ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %148
+ThrowNullRef82:                                   ; preds = %148
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %128
+ThrowNullRef84:                                   ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %132
+ThrowNullRef86:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %100
+ThrowNullRef88:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %104
+ThrowNullRef90:                                   ; preds = %104
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %107
+ThrowNullRef92:                                   ; preds = %107
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %113
+ThrowNullRef94:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %118
+ThrowNullRef96:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %123
+ThrowNullRef98:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %81
+ThrowNullRef100:                                  ; preds = %81
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef101:                                  ; preds = %85
+ThrowNullRef102:                                  ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef103:                                  ; preds = %88
+ThrowNullRef104:                                  ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef105:                                  ; preds = %94
+ThrowNullRef106:                                  ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef107:                                  ; preds = %64
+ThrowNullRef108:                                  ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef109:                                  ; preds = %68
+ThrowNullRef110:                                  ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef111:                                  ; preds = %71
+ThrowNullRef112:                                  ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef113:                                  ; preds = %76
+ThrowNullRef114:                                  ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef115:                                  ; preds = %56
+ThrowNullRef116:                                  ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef117:                                  ; preds = %60
+ThrowNullRef118:                                  ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef119:                                  ; preds = %37
+ThrowNullRef120:                                  ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef121:                                  ; preds = %41
+ThrowNullRef122:                                  ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef123:                                  ; preds = %46
+ThrowNullRef124:                                  ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef125:                                  ; preds = %51
+ThrowNullRef126:                                  ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef127:                                  ; preds = %27
+ThrowNullRef128:                                  ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef129:                                  ; preds = %31
+ThrowNullRef130:                                  ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef131:                                  ; preds = %19
+ThrowNullRef132:                                  ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef133:                                  ; preds = %22
+ThrowNullRef134:                                  ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef135:                                  ; preds = %338
+ThrowNullRef136:                                  ; preds = %338
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef137:                                  ; preds = %341
+ThrowNullRef138:                                  ; preds = %341
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef139:                                  ; preds = %356
+ThrowNullRef140:                                  ; preds = %356
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef141:                                  ; preds = %360
+ThrowNullRef142:                                  ; preds = %360
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef143:                                  ; preds = %377
+ThrowNullRef144:                                  ; preds = %377
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef145:                                  ; preds = %381
+ThrowNullRef146:                                  ; preds = %381
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef147:                                  ; preds = %424
+ThrowNullRef148:                                  ; preds = %424
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef149:                                  ; preds = %428
+ThrowNullRef150:                                  ; preds = %428
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef151:                                  ; preds = %440
+ThrowNullRef152:                                  ; preds = %440
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef153:                                  ; preds = %444
+ThrowNullRef154:                                  ; preds = %444
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef155:                                  ; preds = %456
+ThrowNullRef156:                                  ; preds = %456
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef157:                                  ; preds = %460
+ThrowNullRef158:                                  ; preds = %460
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef159:                                  ; preds = %474
+ThrowNullRef160:                                  ; preds = %474
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef161:                                  ; preds = %477
+ThrowNullRef162:                                  ; preds = %477
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef163:                                  ; preds = %394
+ThrowNullRef164:                                  ; preds = %394
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef165:                                  ; preds = %398
+ThrowNullRef166:                                  ; preds = %398
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef167:                                  ; preds = %401
+ThrowNullRef168:                                  ; preds = %401
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef169:                                  ; preds = %407
+ThrowNullRef170:                                  ; preds = %407
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1939,8 +2021,8 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
-  br i1 %NullCheck, label %22, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %ThrowNullRef, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
@@ -1948,8 +2030,8 @@ entry:
   store i32 %24, i32* %loc0
   %25 = load i32, i32* %loc0
   %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %26, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %27
 
 ; <label>:27                                      ; preds = %22
   %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
@@ -1971,7 +2053,7 @@ ThrowNullRef:                                     ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1989,8 +2071,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -2022,15 +2104,15 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2048,16 +2130,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
   %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
   store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %15
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
@@ -2072,8 +2154,8 @@ entry:
   %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
   %29 = ptrtoint i16 addrspace(1)* %28 to i64
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %19
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
@@ -2089,19 +2171,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2114,8 +2196,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
@@ -2128,7 +2210,7 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[loadElem]
+Failed to read AppDomain.PrepareDataForSetup[storeElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
@@ -2202,8 +2284,8 @@ entry:
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
-  br i1 %NullCheck24, label %27, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = load i64, i64 addrspace(1)* %26
@@ -2218,8 +2300,8 @@ entry:
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
-  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
   %41 = load i64, i64 addrspace(1)* %39
@@ -2236,8 +2318,8 @@ entry:
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
-  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
   %54 = load i64, i64 addrspace(1)* %52
@@ -2252,8 +2334,8 @@ entry:
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
   %67 = load i64, i64 addrspace(1)* %65
@@ -2270,8 +2352,8 @@ entry:
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
-  br i1 %NullCheck16, label %79, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
   %80 = load i64, i64 addrspace(1)* %78
@@ -2286,8 +2368,8 @@ entry:
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
-  br i1 %NullCheck18, label %92, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
   %93 = load i64, i64 addrspace(1)* %91
@@ -2304,8 +2386,8 @@ entry:
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
-  br i1 %NullCheck12, label %105, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = load i64, i64 addrspace(1)* %104
@@ -2320,8 +2402,8 @@ entry:
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
-  br i1 %NullCheck14, label %118, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
   %119 = load i64, i64 addrspace(1)* %117
@@ -2337,8 +2419,8 @@ entry:
 
 ; <label>:128                                     ; preds = %20
   %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
-  br i1 %NullCheck4, label %130, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %129, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %130
 
 ; <label>:130                                     ; preds = %128
   %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
@@ -2346,8 +2428,8 @@ entry:
   %133 = load i16, i16 addrspace(1)* %132, align 8
   %134 = zext i16 %133 to i32
   %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
-  br i1 %NullCheck6, label %136, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %135, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %136
 
 ; <label>:136                                     ; preds = %130
   %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
@@ -2360,8 +2442,8 @@ entry:
 
 ; <label>:143                                     ; preds = %136
   %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
-  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %144, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %145
 
 ; <label>:145                                     ; preds = %143
   %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
@@ -2369,8 +2451,8 @@ entry:
   %148 = load i16, i16 addrspace(1)* %147, align 8
   %149 = zext i16 %148 to i32
   %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %150, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %151
 
 ; <label>:151                                     ; preds = %145
   %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
@@ -2388,8 +2470,8 @@ entry:
 
 ; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
-  br i1 %NullCheck, label %163, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %ThrowNullRef, label %163
 
 ; <label>:163                                     ; preds = %161
   %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
@@ -2399,8 +2481,8 @@ entry:
 
 ; <label>:167                                     ; preds = %163
   %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
-  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %168, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %169
 
 ; <label>:169                                     ; preds = %167
   %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
@@ -2432,55 +2514,55 @@ ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %167
+ThrowNullRef2:                                    ; preds = %167
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %128
+ThrowNullRef4:                                    ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %130
+ThrowNullRef6:                                    ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %143
+ThrowNullRef8:                                    ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %145
+ThrowNullRef10:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %102
+ThrowNullRef12:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %105
+ThrowNullRef14:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %76
+ThrowNullRef16:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %79
+ThrowNullRef18:                                   ; preds = %79
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %50
+ThrowNullRef20:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %53
+ThrowNullRef22:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %24
+ThrowNullRef24:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %27
+ThrowNullRef26:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2503,15 +2585,15 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2519,16 +2601,16 @@ entry:
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
   store i32 %8, i32* %loc0
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
   %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
   store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
@@ -2546,16 +2628,16 @@ entry:
 
 ; <label>:23                                      ; preds = %64
   %24 = load i16*, i16** %loc3
-  %NullCheck12 = icmp ne i16* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i16* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
   store i32 %27, i32* %loc5
   %28 = load i16*, i16** %loc4
-  %NullCheck14 = icmp ne i16* %28, null
-  br i1 %NullCheck14, label %29, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %28, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = load i16, i16* %28, align 8
@@ -2620,15 +2702,15 @@ entry:
 
 ; <label>:67                                      ; preds = %64
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
-  br i1 %NullCheck8, label %69, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %68, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %69
 
 ; <label>:69                                      ; preds = %67
   %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
   %71 = load i32, i32 addrspace(1)* %70
   %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
-  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %73
 
 ; <label>:73                                      ; preds = %69
   %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
@@ -2645,31 +2727,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %67
+ThrowNullRef8:                                    ; preds = %67
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %69
+ThrowNullRef10:                                   ; preds = %69
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2710,14 +2792,14 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
   %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
@@ -2730,14 +2812,14 @@ entry:
 
 ; <label>:11                                      ; preds = %4
   %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
   %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
@@ -2749,14 +2831,14 @@ entry:
 
 ; <label>:22                                      ; preds = %16
   %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
   %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
-  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
-  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
@@ -2804,23 +2886,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2836,7 +2918,280 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[loadElem]
+Successfully read RuntimeType.IsAssignableFrom
+
+define i8 @RuntimeType.IsAssignableFrom(%System.RuntimeType addrspace(1)* %param0, %System.Type addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.RuntimeType addrspace(1)*
+  %arg1 = alloca %System.Type addrspace(1)*
+  %loc0 = alloca %System.RuntimeType addrspace(1)*
+  %loc1 = alloca %"System.Type[]" addrspace(1)*
+  %loc2 = alloca i32
+  store %System.RuntimeType addrspace(1)* %param0, %System.RuntimeType addrspace(1)** %this
+  store %System.Type addrspace(1)* %param1, %System.Type addrspace(1)** %arg1
+  %0 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %1 = icmp ne %System.Type addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i8 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %5 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %6 = bitcast %System.Type addrspace(1)* %4 to %System.Object addrspace(1)*
+  %7 = bitcast %System.RuntimeType addrspace(1)* %5 to %System.Object addrspace(1)*
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %6, %System.Object addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %3
+  ret i8 1
+
+; <label>:12                                      ; preds = %3
+  %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 152
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 32
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
+  %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
+  %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
+  store %System.RuntimeType addrspace(1)* %25, %System.RuntimeType addrspace(1)** %loc0
+  %26 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %27 = icmp eq %System.RuntimeType addrspace(1)* %26, null
+  br i1 %27, label %34, label %28
+
+; <label>:28                                      ; preds = %15
+  %29 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %30 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)*)*)(%System.RuntimeType addrspace(1)* %29, %System.RuntimeType addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+; <label>:34                                      ; preds = %15
+  %35 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %36 = call %System.Reflection.Emit.TypeBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Reflection.Emit.TypeBuilder addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %35)
+  %37 = icmp eq %System.Reflection.Emit.TypeBuilder addrspace(1)* %36, null
+  br i1 %37, label %139, label %38
+
+; <label>:38                                      ; preds = %34
+  %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %42
+
+; <label>:42                                      ; preds = %38
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 152
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 40
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
+  %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
+  %53 = zext i8 %52 to i32
+  %54 = icmp eq i32 %53, 0
+  br i1 %54, label %56, label %55
+
+; <label>:55                                      ; preds = %42
+  ret i8 1
+
+; <label>:56                                      ; preds = %42
+  %57 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %58 = bitcast %System.RuntimeType addrspace(1)* %57 to %System.Type addrspace(1)*
+  %59 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %58)
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %64 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.Type addrspace(1)* %63, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = bitcast %System.RuntimeType addrspace(1)* %64 to %System.Type addrspace(1)*
+  %67 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %63, %System.Type addrspace(1)* %66)
+  %68 = zext i8 %67 to i32
+  %69 = trunc i32 %68 to i8
+  ret i8 %69
+
+; <label>:70                                      ; preds = %56
+  %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
+  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %73
+
+; <label>:73                                      ; preds = %70
+  %74 = load i64, i64 addrspace(1)* %72
+  %75 = add i64 %74, 128
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = add i64 %77, 0
+  %79 = inttoptr i64 %78 to i64*
+  %80 = load i64, i64* %79
+  %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
+  %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
+  %83 = call i8 %82(%System.Type addrspace(1)* %81)
+  %84 = zext i8 %83 to i32
+  %85 = icmp eq i32 %84, 0
+  br i1 %85, label %139, label %86
+
+; <label>:86                                      ; preds = %73
+  %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
+  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %89
+
+; <label>:89                                      ; preds = %86
+  %90 = load i64, i64 addrspace(1)* %88
+  %91 = add i64 %90, 128
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = add i64 %93, 24
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
+  %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
+  %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
+  store %"System.Type[]" addrspace(1)* %99, %"System.Type[]" addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %129
+
+; <label>:100                                     ; preds = %132
+  %101 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %102 = load i32, i32* %loc2
+  %NullCheck11 = icmp eq %"System.Type[]" addrspace(1)* %101, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %103
+
+; <label>:103                                     ; preds = %100
+  %104 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 1
+  %105 = load i32, i32 addrspace(1)* %104
+  %106 = zext i32 %105 to i64
+  %107 = zext i32 %102 to i64
+  %BoundsCheck = icmp uge i64 %107, %106
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %108
+
+; <label>:108                                     ; preds = %103
+  %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
+  %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
+  %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
+  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %113
+
+; <label>:113                                     ; preds = %108
+  %114 = load i64, i64 addrspace(1)* %112
+  %115 = add i64 %114, 152
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = add i64 %117, 56
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
+  %123 = zext i8 %122 to i32
+  %124 = icmp ne i32 %123, 0
+  br i1 %124, label %126, label %125
+
+; <label>:125                                     ; preds = %113
+  ret i8 0
+
+; <label>:126                                     ; preds = %113
+  %127 = load i32, i32* %loc2
+  %128 = add i32 %127, 1
+  store i32 %128, i32* %loc2
+  br label %129
+
+; <label>:129                                     ; preds = %89, %126
+  %130 = load i32, i32* %loc2
+  %131 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %NullCheck9 = icmp eq %"System.Type[]" addrspace(1)* %131, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %132
+
+; <label>:132                                     ; preds = %129
+  %133 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %131, i32 0, i32 1
+  %134 = load i32, i32 addrspace(1)* %133
+  %135 = zext i32 %134 to i64
+  %136 = trunc i64 %135 to i32
+  %137 = icmp slt i32 %130, %136
+  br i1 %137, label %100, label %138
+
+; <label>:138                                     ; preds = %132
+  ret i8 1
+
+; <label>:139                                     ; preds = %34, %73
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %129
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %103
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -2893,7 +3248,7 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElem]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -2904,8 +3259,8 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -2997,8 +3352,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
@@ -3059,8 +3414,8 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -3087,8 +3442,8 @@ entry:
 
 ; <label>:17                                      ; preds = %5, %11
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
@@ -3097,8 +3452,8 @@ entry:
 
 ; <label>:22                                      ; preds = %1, %11
   %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
@@ -3109,11 +3464,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %17
+ThrowNullRef2:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %22
+ThrowNullRef4:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3167,15 +3522,15 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
   %15 = load i32, i32 addrspace(1)* %14
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
@@ -3198,7 +3553,7 @@ ThrowNullRef:                                     ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef2:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3232,8 +3587,8 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
@@ -3312,8 +3667,8 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -3327,8 +3682,8 @@ entry:
 ; <label>:5                                       ; preds = %43
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %7 = load i32, i32* %loc1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck6, label %8, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
@@ -3366,8 +3721,8 @@ entry:
 ; <label>:32                                      ; preds = %21, %25
   %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
   %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
-  br i1 %NullCheck8, label %35, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = trunc i32 %34 to i16
@@ -3380,8 +3735,8 @@ entry:
 ; <label>:40                                      ; preds = %1, %35
   %41 = load i32, i32* %loc1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
-  br i1 %NullCheck2, label %43, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %42, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
@@ -3392,8 +3747,8 @@ entry:
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
   %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
-  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
   %51 = load i64, i64 addrspace(1)* %49
@@ -3412,19 +3767,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %40
+ThrowNullRef2:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %47
+ThrowNullRef4:                                    ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %5
+ThrowNullRef6:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %32
+ThrowNullRef8:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3467,8 +3822,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
@@ -3492,11 +3847,391 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(i16* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store i16* %param0, i16** %arg0
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load i32, i32* %arg3
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %42, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %37, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg2
+  %13 = load i32, i32* %arg3
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %37, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %24 = load i32, i32* %arg2
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load i16*, i16** %arg0
+  %35 = load i32, i32* %arg3
+  %36 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %36, i16* %34, i32 %35)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:37                                      ; preds = %5, %16
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %39)
+  %41 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41, %System.String addrspace(1)* %38, %System.String addrspace(1)* %40)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41) #0
+  unreachable
+
+; <label>:42                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
-Failed to read StringBuilder.ToString[loadElemA]
+Successfully read StringBuilder.ToString
+
+define %System.String addrspace(1)* @StringBuilder.ToString(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i16*
+  %loc3 = alloca %"System.Char[]" addrspace(1)*
+  %loc4 = alloca i32
+  %loc5 = alloca i32
+  %loc6 = alloca i16 addrspace(1)*
+  %loc7 = alloca %System.String addrspace(1)*
+  %loc8 = alloca %"System.Char[]" addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %0)
+  %2 = icmp ne i32 %1, 0
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %4
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %6)
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %7)
+  store %System.String addrspace(1)* %8, %System.String addrspace(1)** %loc0
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.Text.StringBuilder addrspace(1)* %9, %System.Text.StringBuilder addrspace(1)** %loc1
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  store %System.String addrspace(1)* %10, %System.String addrspace(1)** %loc7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc7
+  %12 = ptrtoint %System.String addrspace(1)* %11 to i64
+  %13 = icmp eq i64 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %5
+  %15 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %16 = sext i32 %15 to i64
+  %17 = add i64 %12, %16
+  br label %18
+
+; <label>:18                                      ; preds = %5, %14
+  %19 = phi i64 [ %12, %5 ], [ %17, %14 ]
+  %20 = inttoptr i64 %19 to i16*
+  store i16* %20, i16** %loc2
+  br label %21
+
+; <label>:21                                      ; preds = %98, %18
+  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %22, null
+  br i1 %NullCheck, label %ThrowNullRef, label %23
+
+; <label>:23                                      ; preds = %21
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 3
+  %25 = load i32, i32 addrspace(1)* %24, align 8
+  %26 = icmp sle i32 %25, 0
+  br i1 %26, label %96, label %27
+
+; <label>:27                                      ; preds = %23
+  %28 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %28, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %29
+
+; <label>:29                                      ; preds = %27
+  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %28, i32 0, i32 1
+  %31 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %30, align 8
+  store %"System.Char[]" addrspace(1)* %31, %"System.Char[]" addrspace(1)** %loc3
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %33
+
+; <label>:33                                      ; preds = %29
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  store i32 %35, i32* %loc4
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  %39 = load i32, i32 addrspace(1)* %38, align 8
+  store i32 %39, i32* %loc5
+  %40 = load i32, i32* %loc5
+  %41 = load i32, i32* %loc4
+  %42 = add i32 %40, %41
+  %43 = zext i32 %42 to i64
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %45
+
+; <label>:45                                      ; preds = %37
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = sext i32 %47 to i64
+  %49 = icmp sgt i64 %43, %48
+  br i1 %49, label %91, label %50
+
+; <label>:50                                      ; preds = %45
+  %51 = load i32, i32* %loc5
+  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %52, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %53
+
+; <label>:53                                      ; preds = %50
+  %54 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %52, i32 0, i32 1
+  %55 = load i32, i32 addrspace(1)* %54
+  %56 = zext i32 %55 to i64
+  %57 = trunc i64 %56 to i32
+  %58 = icmp ugt i32 %51, %57
+  br i1 %58, label %91, label %59
+
+; <label>:59                                      ; preds = %53
+  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  store %"System.Char[]" addrspace(1)* %60, %"System.Char[]" addrspace(1)** %loc8
+  %61 = icmp eq %"System.Char[]" addrspace(1)* %60, null
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %63, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %64
+
+; <label>:64                                      ; preds = %62
+  %65 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %63, i32 0, i32 1
+  %66 = load i32, i32 addrspace(1)* %65
+  %67 = zext i32 %66 to i64
+  %68 = trunc i64 %67 to i32
+  %69 = icmp ne i32 %68, 0
+  br i1 %69, label %71, label %70
+
+; <label>:70                                      ; preds = %59, %64
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:71                                      ; preds = %64
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %73
+
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %BoundsCheck = icmp uge i64 0, %76
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %77
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %78, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:79                                      ; preds = %70, %77
+  %80 = load i16*, i16** %loc2
+  %81 = load i32, i32* %loc4
+  %82 = sext i32 %81 to i64
+  %83 = mul i64 %82, 2
+  %84 = bitcast i16* %80 to i8*
+  %85 = getelementptr inbounds i8, i8* %84, i64 %83
+  %86 = load i16 addrspace(1)*, i16 addrspace(1)** %loc6
+  %87 = ptrtoint i16 addrspace(1)* %86 to i64
+  %88 = load i32, i32* %loc5
+  %89 = bitcast i8* %85 to i16*
+  %90 = inttoptr i64 %87 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %89, i16* %90, i32 %88)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %96
+
+; <label>:91                                      ; preds = %45, %53
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %94 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %93)
+  %95 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95, %System.String addrspace(1)* %92, %System.String addrspace(1)* %94)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95) #0
+  unreachable
+
+; <label>:96                                      ; preds = %23, %79
+  %97 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %97, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %98
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %97, i32 0, i32 2
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  store %System.Text.StringBuilder addrspace(1)* %100, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %102 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %102, label %21, label %103
+
+; <label>:103                                     ; preds = %98
+  store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc7
+  %104 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  ret %System.String addrspace(1)* %104
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method StringBuilder::get_Length using LLILCJit
+Successfully read StringBuilder.get_Length
+
+define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
+Successfully read RuntimeHelpers.get_OffsetToStringData
+
+define i32 @RuntimeHelpers.get_OffsetToStringData() {
+entry:
+  ret i32 12
+}
+
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
 Successfully read CultureData.CreateCultureData
 
@@ -3514,23 +4249,23 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
   store i8 %4, i8 addrspace(1)* %6
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
@@ -3549,11 +4284,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3566,50 +4301,50 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
   store i32 -1, i32 addrspace(1)* %2
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
   store i32 -1, i32 addrspace(1)* %8
   %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
   store i32 -1, i32 addrspace(1)* %14
   %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
   store i32 -1, i32 addrspace(1)* %17
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
@@ -3623,27 +4358,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3675,7 +4410,136 @@ Failed to read Dictionary`2.Insert[non-const derefAddress]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
 Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
-Failed to read HashHelpers.GetPrime[loadElem]
+Successfully read HashHelpers.GetPrime
+
+define i32 @HashHelpers.GetPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %6, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5, %System.String addrspace(1)* %4)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5) #0
+  unreachable
+
+; <label>:6                                       ; preds = %entry
+  store i32 0, i32* %loc0
+  br label %29
+
+; <label>:7                                       ; preds = %35
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 1296
+  %10 = addrspacecast i8 addrspace(1)* %9 to %"System.Int32[]" addrspace(1)**
+  %11 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %10
+  %12 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Int32[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = zext i32 %15 to i64
+  %17 = zext i32 %12 to i64
+  %BoundsCheck = icmp uge i64 %17, %16
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 3, i32 %12
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  store i32 %20, i32* %loc1
+  %21 = load i32, i32* %loc1
+  %22 = load i32, i32* %arg0
+  %23 = icmp slt i32 %21, %22
+  br i1 %23, label %26, label %24
+
+; <label>:24                                      ; preds = %18
+  %25 = load i32, i32* %loc1
+  ret i32 %25
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %loc0
+  %28 = add i32 %27, 1
+  store i32 %28, i32* %loc0
+  br label %29
+
+; <label>:29                                      ; preds = %6, %26
+  %30 = load i32, i32* %loc0
+  %31 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %32 = getelementptr inbounds i8, i8 addrspace(1)* %31, i64 1296
+  %33 = addrspacecast i8 addrspace(1)* %32 to %"System.Int32[]" addrspace(1)**
+  %34 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %33
+  %NullCheck = icmp eq %"System.Int32[]" addrspace(1)* %34, null
+  br i1 %NullCheck, label %ThrowNullRef, label %35
+
+; <label>:35                                      ; preds = %29
+  %36 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %34, i32 0, i32 1
+  %37 = load i32, i32 addrspace(1)* %36
+  %38 = zext i32 %37 to i64
+  %39 = trunc i64 %38 to i32
+  %40 = icmp slt i32 %30, %39
+  br i1 %40, label %7, label %41
+
+; <label>:41                                      ; preds = %35
+  %42 = load i32, i32* %arg0
+  %43 = or i32 %42, 1
+  store i32 %43, i32* %loc2
+  br label %59
+
+; <label>:44                                      ; preds = %59
+  %45 = load i32, i32* %loc2
+  %46 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %45)
+  %47 = zext i8 %46 to i32
+  %48 = icmp eq i32 %47, 0
+  br i1 %48, label %56, label %49
+
+; <label>:49                                      ; preds = %44
+  %50 = load i32, i32* %loc2
+  %51 = sub i32 %50, 1
+  %52 = srem i32 %51, 101
+  %53 = icmp eq i32 %52, 0
+  br i1 %53, label %56, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = load i32, i32* %loc2
+  ret i32 %55
+
+; <label>:56                                      ; preds = %44, %49
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %57, 2
+  store i32 %58, i32* %loc2
+  br label %59
+
+; <label>:59                                      ; preds = %41, %56
+  %60 = load i32, i32* %loc2
+  %61 = icmp slt i32 %60, 2147483647
+  br i1 %61, label %44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load i32, i32* %arg0
+  ret i32 %63
+
+ThrowNullRef:                                     ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
 Successfully read GenericEqualityComparer`1.GetHashCode
 
@@ -3694,14 +4558,14 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
   %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load i64, i64 addrspace(1)* %7
@@ -3720,7 +4584,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3750,8 +4614,8 @@ entry:
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
@@ -3796,8 +4660,8 @@ entry:
   %35 = bitcast i16* %34 to i8*
   %36 = getelementptr inbounds i8, i8* %35, i64 2
   %37 = bitcast i8* %36 to i16*
-  %NullCheck4 = icmp ne i16* %37, null
-  br i1 %NullCheck4, label %38, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %37, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %38
 
 ; <label>:38                                      ; preds = %27
   %39 = load i16, i16* %37, align 8
@@ -3824,8 +4688,8 @@ entry:
 
 ; <label>:54                                      ; preds = %22, %43
   %55 = load i16*, i16** %loc4
-  %NullCheck2 = icmp ne i16* %55, null
-  br i1 %NullCheck2, label %56, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i16* %55, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %56
 
 ; <label>:56                                      ; preds = %54
   %57 = load i16, i16* %55, align 8
@@ -3850,11 +4714,11 @@ ThrowNullRef:                                     ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %54
+ThrowNullRef2:                                    ; preds = %54
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %27
+ThrowNullRef4:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3871,8 +4735,8 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -3907,8 +4771,8 @@ entry:
 
 ; <label>:26                                      ; preds = %19
   %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
-  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %28
 
 ; <label>:28                                      ; preds = %26
   %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
@@ -3920,7 +4784,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3972,8 +4836,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
@@ -3984,26 +4848,26 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
-  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
@@ -4014,8 +4878,8 @@ entry:
 ; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
@@ -4024,8 +4888,8 @@ entry:
 
 ; <label>:25                                      ; preds = %1, %16, %23
   %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
-  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
@@ -4036,27 +4900,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %20
+ThrowNullRef10:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4069,8 +4933,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -4081,8 +4945,8 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
@@ -4091,8 +4955,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1, %8
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
@@ -4103,11 +4967,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4128,24 +4992,24 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   store i32 %3, i32* %loc0
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
   %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
   store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck4, label %9, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
@@ -4164,15 +5028,15 @@ entry:
 ; <label>:18                                      ; preds = %70
   %19 = load i16*, i16** %loc3
   %20 = bitcast i16* %19 to i64*
-  %NullCheck10 = icmp ne i64* %20, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %20, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = load i64, i64* %20, align 8
   %23 = load i16*, i16** %loc4
   %24 = bitcast i16* %23 to i64*
-  %NullCheck12 = icmp ne i64* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = load i64, i64* %24, align 8
@@ -4188,8 +5052,8 @@ entry:
   %31 = bitcast i16* %30 to i8*
   %32 = getelementptr inbounds i8, i8* %31, i64 8
   %33 = bitcast i8* %32 to i64*
-  %NullCheck14 = icmp ne i64* %33, null
-  br i1 %NullCheck14, label %34, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = load i64, i64* %33, align 8
@@ -4197,8 +5061,8 @@ entry:
   %37 = bitcast i16* %36 to i8*
   %38 = getelementptr inbounds i8, i8* %37, i64 8
   %39 = bitcast i8* %38 to i64*
-  %NullCheck16 = icmp ne i64* %39, null
-  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %40
 
 ; <label>:40                                      ; preds = %34
   %41 = load i64, i64* %39, align 8
@@ -4214,8 +5078,8 @@ entry:
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %NullCheck18 = icmp ne i64* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = load i64, i64* %48, align 8
@@ -4223,8 +5087,8 @@ entry:
   %52 = bitcast i16* %51 to i8*
   %53 = getelementptr inbounds i8, i8* %52, i64 16
   %54 = bitcast i8* %53 to i64*
-  %NullCheck20 = icmp ne i64* %54, null
-  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64* %54, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %55
 
 ; <label>:55                                      ; preds = %49
   %56 = load i64, i64* %54, align 8
@@ -4262,15 +5126,15 @@ entry:
 ; <label>:74                                      ; preds = %95
   %75 = load i16*, i16** %loc3
   %76 = bitcast i16* %75 to i32*
-  %NullCheck6 = icmp ne i32* %76, null
-  br i1 %NullCheck6, label %77, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32* %76, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %77
 
 ; <label>:77                                      ; preds = %74
   %78 = load i32, i32* %76, align 8
   %79 = load i16*, i16** %loc4
   %80 = bitcast i16* %79 to i32*
-  %NullCheck8 = icmp ne i32* %80, null
-  br i1 %NullCheck8, label %81, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i32* %80, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %81
 
 ; <label>:81                                      ; preds = %77
   %82 = load i32, i32* %80, align 8
@@ -4318,43 +5182,43 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %74
+ThrowNullRef6:                                    ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %77
+ThrowNullRef8:                                    ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %29
+ThrowNullRef14:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %34
+ThrowNullRef16:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4376,8 +5240,8 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load i64, i64 addrspace(1)* %4
@@ -4389,8 +5253,8 @@ entry:
   %12 = load i64, i64* %11
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %5
   %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
@@ -4399,8 +5263,8 @@ entry:
   %18 = load i8, i8* %arg2
   %19 = zext i8 %18 to i32
   %20 = trunc i32 %19 to i8
-  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %15
   %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
@@ -4411,11 +5275,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4442,8 +5306,8 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
@@ -4466,16 +5330,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
   %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = load i64, i64 addrspace(1)* %19
@@ -4500,8 +5364,8 @@ entry:
 ; <label>:35                                      ; preds = %30
   %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
@@ -4514,8 +5378,8 @@ entry:
 
 ; <label>:42                                      ; preds = %1, %38
   %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
-  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
@@ -4526,19 +5390,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %35
+ThrowNullRef2:                                    ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %42
+ThrowNullRef8:                                    ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4551,14 +5415,14 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
@@ -4570,7 +5434,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4583,8 +5447,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
@@ -4613,51 +5477,51 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
   %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
   %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
   %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
   %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
-  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
   store i64 %21, i64 addrspace(1)* %23
   %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %25 = load i64, i64* %loc0
-  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
@@ -4668,27 +5532,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %22
+ThrowNullRef12:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4701,8 +5565,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
@@ -4713,19 +5577,19 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
@@ -4734,8 +5598,8 @@ entry:
 
 ; <label>:15                                      ; preds = %1, %13
   %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
@@ -4746,19 +5610,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %15
+ThrowNullRef8:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4771,8 +5635,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -4831,8 +5695,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
@@ -4882,8 +5746,8 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
-  br i1 %NullCheck, label %17, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %ThrowNullRef, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
@@ -4894,15 +5758,15 @@ entry:
 
 ; <label>:22                                      ; preds = %17
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
-  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
   %26 = load i32, i32 addrspace(1)* %25
   %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
-  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %27, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
@@ -4925,8 +5789,8 @@ entry:
 ; <label>:40                                      ; preds = %17
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
-  br i1 %NullCheck6, label %43, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %41, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
@@ -4938,34 +5802,17 @@ ThrowNullRef:                                     ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %24
+ThrowNullRef4:                                    ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %40
+ThrowNullRef6:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
-}
-
-INFO:  jitting method Object::ReferenceEquals using LLILCJit
-Successfully read Object.ReferenceEquals
-
-define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
-entry:
-  %arg0 = alloca %System.Object addrspace(1)*
-  %arg1 = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
-  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
-  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = icmp eq %System.Object addrspace(1)* %0, %1
-  %3 = sext i1 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
 }
 
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
@@ -4978,21 +5825,21 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
   %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
-  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
@@ -5007,28 +5854,28 @@ entry:
 ; <label>:13                                      ; preds = %8, %12
   %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
   %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
   %21 = load i32, i32 addrspace(1)* %20, align 8
   %22 = add i32 %21, 1
-  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
   store i32 %22, i32 addrspace(1)* %24
   %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
@@ -5039,27 +5886,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5077,7 +5924,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::Setup using LLILCJit
-Failed to read AppDomain.Setup[loadElem]
+Failed to read AppDomain.Setup[unbox]
 INFO:  jitting method Thread::GetDomain using LLILCJit
 Successfully read Thread.GetDomain
 
@@ -5108,8 +5955,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
@@ -5122,14 +5969,14 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
   %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
@@ -5141,11 +5988,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5173,8 +6020,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -5189,7 +6036,328 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
 Failed to read KeyCollection.System.Collections.Generic.IEnumerable<TKey>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Successfully read Enumerator.MoveNext
+
+define i8 @Enumerator.MoveNext(%"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.RuntimeTypeHandle* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*
+  %"$TypeArg" = alloca %System.RuntimeTypeHandle*
+  store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
+  %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 8
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %76, label %12
+
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
+  br label %76
+
+; <label>:13                                      ; preds = %85
+  %14 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck19 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %15
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, i32 0, i32 0
+  %17 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %16, align 8
+  %NullCheck21 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, i32 0, i32 2
+  %20 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %19, align 8
+  %21 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck23 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %22
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, i32 0, i32 2
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %NullCheck25 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 3, i32 %24
+  %NullCheck27 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %32
+
+; <label>:32                                      ; preds = %30
+  %33 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, i32 0, i32 2
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = icmp slt i32 %34, 0
+  br i1 %35, label %68, label %36
+
+; <label>:36                                      ; preds = %32
+  %37 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %38 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck29 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %39
+
+; <label>:39                                      ; preds = %36
+  %40 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, i32 0, i32 0
+  %41 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %40, align 8
+  %NullCheck31 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, i32 0, i32 2
+  %44 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %43, align 8
+  %45 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck33 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, i32 0, i32 2
+  %48 = load i32, i32 addrspace(1)* %47, align 8
+  %NullCheck35 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %49
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = zext i32 %51 to i64
+  %53 = zext i32 %48 to i64
+  %BoundsCheck37 = icmp uge i64 %53, %52
+  br i1 %BoundsCheck37, label %ThrowIndexOutOfRange38, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 3, i32 %48
+  %NullCheck39 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %56
+
+; <label>:56                                      ; preds = %54
+  %57 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, i32 0, i32 0
+  %58 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck41 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %59
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %60, %System.__Canon addrspace(1)* %58)
+  %61 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck43 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  %64 = load i32, i32 addrspace(1)* %63, align 8
+  %65 = add i32 %64, 1
+  %NullCheck45 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  store i32 %65, i32 addrspace(1)* %67
+  ret i8 1
+
+; <label>:68                                      ; preds = %32
+  %69 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck47 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %73 = add i32 %72, 1
+  %NullCheck49 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %74
+
+; <label>:74                                      ; preds = %70
+  %75 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  store i32 %73, i32 addrspace(1)* %75
+  br label %76
+
+; <label>:76                                      ; preds = %8, %12, %74
+  %77 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %78
+
+; <label>:78                                      ; preds = %76
+  %79 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, i32 0, i32 2
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck7 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %82
+
+; <label>:82                                      ; preds = %78
+  %83 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, i32 0, i32 0
+  %84 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %83, align 8
+  %NullCheck9 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %85
+
+; <label>:85                                      ; preds = %82
+  %86 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, i32 0, i32 7
+  %87 = load i32, i32 addrspace(1)* %86, align 8
+  %88 = icmp ult i32 %80, %87
+  br i1 %88, label %13, label %89
+
+; <label>:89                                      ; preds = %85
+  %90 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %91 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck11 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %92
+
+; <label>:92                                      ; preds = %89
+  %93 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, i32 0, i32 0
+  %94 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck13 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %95
+
+; <label>:95                                      ; preds = %92
+  %96 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, i32 0, i32 7
+  %97 = load i32, i32 addrspace(1)* %96, align 8
+  %98 = add i32 %97, 1
+  %NullCheck15 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %99
+
+; <label>:99                                      ; preds = %95
+  %100 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, i32 0, i32 2
+  store i32 %98, i32 addrspace(1)* %100
+  %101 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck17 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %102
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %103, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %92
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef22:                                   ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef24:                                   ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef26:                                   ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef28:                                   ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef30:                                   ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef32:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef34:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef36:                                   ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange38:                           ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef40:                                   ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef42:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef44:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef46:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef48:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef50:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -5200,8 +6368,8 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -5232,9 +6400,9 @@ Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
 Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
-Failed to read String.MakeSeparatorList[loadElemA]
+Failed to read String.MakeSeparatorList[storeElem]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
-Failed to read String.InternalSplitKeepEmptyEntries[loadElem]
+Failed to read String.InternalSplitKeepEmptyEntries[storeElem]
 INFO:  jitting method Path::IsRelative using LLILCJit
 Successfully read Path.IsRelative
 
@@ -5243,8 +6411,8 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -5254,8 +6422,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
@@ -5271,8 +6439,8 @@ entry:
 
 ; <label>:17                                      ; preds = %7
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
@@ -5288,8 +6456,8 @@ entry:
 
 ; <label>:29                                      ; preds = %19
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %31
 
 ; <label>:31                                      ; preds = %29
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
@@ -5300,8 +6468,8 @@ entry:
 
 ; <label>:36                                      ; preds = %31
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
-  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %37, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
@@ -5312,8 +6480,8 @@ entry:
 
 ; <label>:43                                      ; preds = %31, %38
   %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
-  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %45
 
 ; <label>:45                                      ; preds = %43
   %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
@@ -5324,8 +6492,8 @@ entry:
 
 ; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %50
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
@@ -5336,8 +6504,8 @@ entry:
 
 ; <label>:57                                      ; preds = %1, %7, %19, %45, %52
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
-  br i1 %NullCheck14, label %59, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %59
 
 ; <label>:59                                      ; preds = %57
   %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
@@ -5347,8 +6515,8 @@ entry:
 
 ; <label>:63                                      ; preds = %59
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
@@ -5359,8 +6527,8 @@ entry:
 
 ; <label>:70                                      ; preds = %65
   %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
-  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.String addrspace(1)* %71, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %72
 
 ; <label>:72                                      ; preds = %70
   %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
@@ -5379,39 +6547,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %17
+ThrowNullRef4:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %29
+ThrowNullRef6:                                    ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %36
+ThrowNullRef8:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %43
+ThrowNullRef10:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %50
+ThrowNullRef12:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %57
+ThrowNullRef14:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %63
+ThrowNullRef16:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %70
+ThrowNullRef18:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5419,7 +6587,293 @@ ThrowNullRef17:                                   ; preds = %70
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
-Failed to read String.TrimHelper[loadElem]
+Successfully read String.TrimHelper
+
+define %System.String addrspace(1)* @String.TrimHelper(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i16
+  %loc4 = alloca i32
+  %loc5 = alloca i16
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = sub i32 %3, 1
+  store i32 %4, i32* %loc0
+  store i32 0, i32* %loc1
+  %5 = load i32, i32* %arg2
+  %6 = icmp eq i32 %5, 1
+  br i1 %6, label %62, label %7
+
+; <label>:7                                       ; preds = %1
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:8                                       ; preds = %58
+  store i32 0, i32* %loc2
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load i32, i32* %loc1
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2, i32 %10
+  %13 = load i16, i16 addrspace(1)* %12
+  %14 = zext i16 %13 to i32
+  %15 = trunc i32 %14 to i16
+  store i16 %15, i16* %loc3
+  store i32 0, i32* %loc2
+  br label %34
+
+; <label>:16                                      ; preds = %37
+  %17 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %18 = load i32, i32* %loc2
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %17, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %19
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = zext i32 %18 to i64
+  %BoundsCheck = icmp uge i64 %23, %22
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %24
+
+; <label>:24                                      ; preds = %19
+  %25 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 3, i32 %18
+  %26 = load i16, i16 addrspace(1)* %25, align 8
+  %27 = zext i16 %26 to i32
+  %28 = load i16, i16* %loc3
+  %29 = zext i16 %28 to i32
+  %30 = icmp eq i32 %27, %29
+  br i1 %30, label %43, label %31
+
+; <label>:31                                      ; preds = %24
+  %32 = load i32, i32* %loc2
+  %33 = add i32 %32, 1
+  store i32 %33, i32* %loc2
+  br label %34
+
+; <label>:34                                      ; preds = %11, %31
+  %35 = load i32, i32* %loc2
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = icmp slt i32 %35, %41
+  br i1 %42, label %16, label %43
+
+; <label>:43                                      ; preds = %24, %37
+  %44 = load i32, i32* %loc2
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %45, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp eq i32 %44, %50
+  br i1 %51, label %62, label %52
+
+; <label>:52                                      ; preds = %46
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %7, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %57, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %58
+
+; <label>:58                                      ; preds = %55
+  %59 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %60 = load i32, i32 addrspace(1)* %59
+  %61 = icmp slt i32 %56, %60
+  br i1 %61, label %8, label %62
+
+; <label>:62                                      ; preds = %1, %46, %58
+  %63 = load i32, i32* %arg2
+  %64 = icmp eq i32 %63, 0
+  br i1 %64, label %122, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %66, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %67
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %66, i32 0, i32 1
+  %69 = load i32, i32 addrspace(1)* %68
+  %70 = sub i32 %69, 1
+  store i32 %70, i32* %loc0
+  br label %118
+
+; <label>:71                                      ; preds = %118
+  store i32 0, i32* %loc4
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %73 = load i32, i32* %loc0
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %74
+
+; <label>:74                                      ; preds = %71
+  %75 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 2, i32 %73
+  %76 = load i16, i16 addrspace(1)* %75
+  %77 = zext i16 %76 to i32
+  %78 = trunc i32 %77 to i16
+  store i16 %78, i16* %loc5
+  store i32 0, i32* %loc4
+  br label %97
+
+; <label>:79                                      ; preds = %100
+  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %81 = load i32, i32* %loc4
+  %NullCheck19 = icmp eq %"System.Char[]" addrspace(1)* %80, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
+
+; <label>:82                                      ; preds = %79
+  %83 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 1
+  %84 = load i32, i32 addrspace(1)* %83
+  %85 = zext i32 %84 to i64
+  %86 = zext i32 %81 to i64
+  %BoundsCheck21 = icmp uge i64 %86, %85
+  br i1 %BoundsCheck21, label %ThrowIndexOutOfRange22, label %87
+
+; <label>:87                                      ; preds = %82
+  %88 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 3, i32 %81
+  %89 = load i16, i16 addrspace(1)* %88, align 8
+  %90 = zext i16 %89 to i32
+  %91 = load i16, i16* %loc5
+  %92 = zext i16 %91 to i32
+  %93 = icmp eq i32 %90, %92
+  br i1 %93, label %106, label %94
+
+; <label>:94                                      ; preds = %87
+  %95 = load i32, i32* %loc4
+  %96 = add i32 %95, 1
+  store i32 %96, i32* %loc4
+  br label %97
+
+; <label>:97                                      ; preds = %74, %94
+  %98 = load i32, i32* %loc4
+  %99 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck15 = icmp eq %"System.Char[]" addrspace(1)* %99, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %100
+
+; <label>:100                                     ; preds = %97
+  %101 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %99, i32 0, i32 1
+  %102 = load i32, i32 addrspace(1)* %101
+  %103 = zext i32 %102 to i64
+  %104 = trunc i64 %103 to i32
+  %105 = icmp slt i32 %98, %104
+  br i1 %105, label %79, label %106
+
+; <label>:106                                     ; preds = %87, %100
+  %107 = load i32, i32* %loc4
+  %108 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck17 = icmp eq %"System.Char[]" addrspace(1)* %108, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %109
+
+; <label>:109                                     ; preds = %106
+  %110 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %108, i32 0, i32 1
+  %111 = load i32, i32 addrspace(1)* %110
+  %112 = zext i32 %111 to i64
+  %113 = trunc i64 %112 to i32
+  %114 = icmp eq i32 %107, %113
+  br i1 %114, label %122, label %115
+
+; <label>:115                                     ; preds = %109
+  %116 = load i32, i32* %loc0
+  %117 = sub i32 %116, 1
+  store i32 %117, i32* %loc0
+  br label %118
+
+; <label>:118                                     ; preds = %67, %115
+  %119 = load i32, i32* %loc0
+  %120 = load i32, i32* %loc1
+  %121 = icmp sge i32 %119, %120
+  br i1 %121, label %71, label %122
+
+; <label>:122                                     ; preds = %62, %109, %118
+  %123 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %124 = load i32, i32* %loc1
+  %125 = load i32, i32* %loc0
+  %126 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %123, i32 %124, i32 %125)
+  ret %System.String addrspace(1)* %126
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %97
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange22:                           ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
 Successfully read String.CreateTrimmedString
 
@@ -5439,8 +6893,8 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
@@ -5535,8 +6989,8 @@ entry:
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i64 2872
   %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
   %8 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %7
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %3
   %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
@@ -5553,8 +7007,8 @@ entry:
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 2864
   %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
   %21 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %20
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
-  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %22
 
 ; <label>:22                                      ; preds = %16
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
@@ -5569,7 +7023,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %16
+ThrowNullRef2:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5586,8 +7040,8 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5613,8 +7067,8 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
@@ -5632,8 +7086,8 @@ entry:
 
 ; <label>:12                                      ; preds = %4
   %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
@@ -5644,8 +7098,8 @@ entry:
 
 ; <label>:19                                      ; preds = %14
   %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %19
   %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
@@ -5660,21 +7114,21 @@ entry:
   %31 = zext i16 %30 to i32
   %32 = bitcast i8* %29 to i16*
   %33 = trunc i32 %31 to i16
-  %NullCheck6 = icmp ne i16* %32, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i16* %32, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %21
   store i16 %33, i16* %32, align 8
   %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %36
 
 ; <label>:36                                      ; preds = %34
   %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
   %38 = load i32, i32 addrspace(1)* %37, align 8
   %39 = add i32 %38, 1
-  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %40
 
 ; <label>:40                                      ; preds = %36
   %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
@@ -5683,16 +7137,16 @@ entry:
 
 ; <label>:42                                      ; preds = %14
   %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
-  br i1 %NullCheck12, label %44, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
   %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
   %47 = load i16, i16* %arg1
   %48 = zext i16 %47 to i32
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = trunc i32 %48 to i16
@@ -5703,31 +7157,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %19
+ThrowNullRef4:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %21
+ThrowNullRef6:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %36
+ThrowNullRef10:                                   ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %42
+ThrowNullRef12:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %44
+ThrowNullRef14:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5740,8 +7194,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -5752,8 +7206,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
@@ -5762,14 +7216,14 @@ entry:
 
 ; <label>:11                                      ; preds = %1
   %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
@@ -5779,15 +7233,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5808,8 +7262,8 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5822,8 +7276,8 @@ entry:
 
 ; <label>:8                                       ; preds = %3
   %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
@@ -5842,15 +7296,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
-  br i1 %NullCheck4, label %22, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
   %24 = load i16*, i16* addrspace(1)* %23, align 8
   %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %25, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
@@ -5859,8 +7313,8 @@ entry:
   store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
@@ -5874,8 +7328,8 @@ entry:
 
 ; <label>:37                                      ; preds = %65
   %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %37
   %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
@@ -5886,16 +7340,16 @@ entry:
   %45 = bitcast i16* %41 to i8*
   %46 = getelementptr inbounds i8, i8* %45, i64 %44
   %47 = bitcast i8* %46 to i16*
-  %NullCheck14 = icmp ne i16* %47, null
-  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %47, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %48
 
 ; <label>:48                                      ; preds = %39
   %49 = load i16, i16* %47, align 8
   %50 = zext i16 %49 to i32
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %52 = load i32, i32* %loc1
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %53
 
 ; <label>:53                                      ; preds = %48
   %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
@@ -5916,8 +7370,8 @@ entry:
 ; <label>:62                                      ; preds = %36, %59
   %63 = load i32, i32* %loc1
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck10, label %65, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %65
 
 ; <label>:65                                      ; preds = %62
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
@@ -5936,15 +7390,15 @@ entry:
 
 ; <label>:74                                      ; preds = %70
   %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
-  br i1 %NullCheck18, label %76, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %76
 
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
   %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
-  br i1 %NullCheck20, label %80, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
   %81 = load i64, i64 addrspace(1)* %79
@@ -5958,8 +7412,8 @@ entry:
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
   %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
-  br i1 %NullCheck22, label %92, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.String addrspace(1)* %90, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %92
 
 ; <label>:92                                      ; preds = %80
   %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
@@ -5969,15 +7423,15 @@ entry:
 
 ; <label>:96                                      ; preds = %70
   %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
-  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %98
 
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
   %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
-  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
   %103 = load i64, i64 addrspace(1)* %101
@@ -5991,8 +7445,8 @@ entry:
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
   %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
-  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.String addrspace(1)* %112, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %114
 
 ; <label>:114                                     ; preds = %102
   %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
@@ -6004,59 +7458,59 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %20
+ThrowNullRef4:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %22
+ThrowNullRef6:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %26
+ThrowNullRef8:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %62
+ThrowNullRef10:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %48
+ThrowNullRef16:                                   ; preds = %48
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %74
+ThrowNullRef18:                                   ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %76
+ThrowNullRef20:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %80
+ThrowNullRef22:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %96
+ThrowNullRef24:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %98
+ThrowNullRef26:                                   ; preds = %98
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %102
+ThrowNullRef28:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6069,15 +7523,15 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
   %3 = load i16*, i16* addrspace(1)* %2, align 8
   %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
@@ -6087,8 +7541,8 @@ entry:
   %10 = bitcast i16* %3 to i8*
   %11 = getelementptr inbounds i8, i8* %10, i64 %9
   %12 = bitcast i8* %11 to i16*
-  %NullCheck4 = icmp ne i16* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %5
   store i16 0, i16* %12, align 8
@@ -6098,11 +7552,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6119,8 +7573,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -6131,8 +7585,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
@@ -6144,15 +7598,15 @@ entry:
 
 ; <label>:14                                      ; preds = %1
   %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
   %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
   %21 = load i64, i64 addrspace(1)* %19
@@ -6171,15 +7625,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %14
+ThrowNullRef4:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %16
+ThrowNullRef6:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6302,14 +7756,6 @@ entry:
   ret %System.String addrspace(1)* %57
 }
 
-INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
-Successfully read RuntimeHelpers.get_OffsetToStringData
-
-define i32 @RuntimeHelpers.get_OffsetToStringData() {
-entry:
-  ret i32 12
-}
-
 INFO:  jitting method String::Equals using LLILCJit
 Successfully read String.Equals
 
@@ -6381,8 +7827,8 @@ entry:
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
-  br i1 %NullCheck24, label %29, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
   %30 = load i64, i64 addrspace(1)* %28
@@ -6397,8 +7843,8 @@ entry:
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
-  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
   %43 = load i64, i64 addrspace(1)* %41
@@ -6418,8 +7864,8 @@ entry:
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
   %59 = load i64, i64 addrspace(1)* %57
@@ -6434,8 +7880,8 @@ entry:
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck22, label %71, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
   %72 = load i64, i64 addrspace(1)* %70
@@ -6455,8 +7901,8 @@ entry:
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
-  br i1 %NullCheck16, label %87, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = load i64, i64 addrspace(1)* %86
@@ -6471,8 +7917,8 @@ entry:
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck18, label %100, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
   %101 = load i64, i64 addrspace(1)* %99
@@ -6492,8 +7938,8 @@ entry:
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
-  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
   %117 = load i64, i64 addrspace(1)* %115
@@ -6508,8 +7954,8 @@ entry:
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
-  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
   %130 = load i64, i64 addrspace(1)* %128
@@ -6528,15 +7974,15 @@ entry:
 
 ; <label>:142                                     ; preds = %22
   %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
-  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %143, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %144
 
 ; <label>:144                                     ; preds = %142
   %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
   %146 = load i32, i32 addrspace(1)* %145
   %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
-  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %147, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %148
 
 ; <label>:148                                     ; preds = %144
   %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
@@ -6557,15 +8003,15 @@ entry:
 
 ; <label>:159                                     ; preds = %22
   %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
-  br i1 %NullCheck, label %161, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %ThrowNullRef, label %161
 
 ; <label>:161                                     ; preds = %159
   %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
   %163 = load i32, i32 addrspace(1)* %162
   %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
-  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %164, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %165
 
 ; <label>:165                                     ; preds = %161
   %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
@@ -6578,8 +8024,8 @@ entry:
 
 ; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
-  br i1 %NullCheck4, label %172, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %171, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %172
 
 ; <label>:172                                     ; preds = %170
   %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
@@ -6589,8 +8035,8 @@ entry:
 
 ; <label>:176                                     ; preds = %172
   %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
-  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %177, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %178
 
 ; <label>:178                                     ; preds = %176
   %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
@@ -6629,55 +8075,55 @@ ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %161
+ThrowNullRef2:                                    ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %170
+ThrowNullRef4:                                    ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %176
+ThrowNullRef6:                                    ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %142
+ThrowNullRef8:                                    ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %144
+ThrowNullRef10:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %113
+ThrowNullRef12:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %116
+ThrowNullRef14:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %84
+ThrowNullRef16:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %87
+ThrowNullRef18:                                   ; preds = %87
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %55
+ThrowNullRef20:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %58
+ThrowNullRef22:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %26
+ThrowNullRef24:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %29
+ThrowNullRef26:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,8 +8161,8 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck, label %14, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %ThrowNullRef, label %14
 
 ; <label>:14                                      ; preds = %8
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
@@ -6760,8 +8206,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
@@ -6770,14 +8216,14 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32, i32* %loc0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %10
   %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
   %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
@@ -6790,15 +8236,15 @@ entry:
 ; <label>:25                                      ; preds = %19
   %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
-  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
   %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
@@ -6807,8 +8253,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %37 = load i32, i32* %loc0
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %38, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %38
 
 ; <label>:38                                      ; preds = %32
   %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
@@ -6817,14 +8263,14 @@ entry:
 
 ; <label>:40                                      ; preds = %19
   %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %40
   %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
   %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
-  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
-  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
@@ -6832,8 +8278,8 @@ entry:
   %48 = zext i32 %47 to i64
   %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
-  br i1 %NullCheck16, label %51, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %51
 
 ; <label>:51                                      ; preds = %45
   %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
@@ -6847,15 +8293,15 @@ entry:
 ; <label>:57                                      ; preds = %51
   %58 = load i16*, i16** %arg1
   %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
-  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %60
 
 ; <label>:60                                      ; preds = %57
   %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
   %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
-  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %64
 
 ; <label>:64                                      ; preds = %60
   %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
@@ -6864,22 +8310,22 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
   %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
-  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %70
 
 ; <label>:70                                      ; preds = %64
   %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
   %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
-  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
-  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
   %75 = load i32, i32 addrspace(1)* %74
   %76 = zext i32 %75 to i64
   %77 = trunc i64 %76 to i32
-  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
-  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %78
 
 ; <label>:78                                      ; preds = %73
   %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
@@ -6901,8 +8347,8 @@ entry:
   %90 = bitcast i16* %86 to i8*
   %91 = getelementptr inbounds i8, i8* %90, i64 %89
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %93
 
 ; <label>:93                                      ; preds = %80
   %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
@@ -6912,8 +8358,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %99 = load i32, i32* %loc2
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %100
 
 ; <label>:100                                     ; preds = %93
   %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
@@ -6928,63 +8374,63 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %25
+ThrowNullRef6:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %32
+ThrowNullRef10:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %40
+ThrowNullRef12:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %45
+ThrowNullRef16:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %57
+ThrowNullRef18:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %60
+ThrowNullRef20:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %64
+ThrowNullRef22:                                   ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %70
+ThrowNullRef24:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %73
+ThrowNullRef26:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %80
+ThrowNullRef28:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %93
+ThrowNullRef30:                                   ; preds = %93
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7004,8 +8450,8 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
@@ -7033,43 +8479,43 @@ entry:
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %14
   %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
   %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   %28 = load i32, i32 addrspace(1)* %27, align 8
   %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
-  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %30
 
 ; <label>:30                                      ; preds = %26
   %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
   %32 = load i32, i32 addrspace(1)* %31, align 8
   %33 = add i32 %28, %32
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %34
 
 ; <label>:34                                      ; preds = %30
   %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   store i32 %33, i32 addrspace(1)* %35
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
   store i32 0, i32 addrspace(1)* %38
   %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %40
 
 ; <label>:40                                      ; preds = %37
   %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
@@ -7082,8 +8528,8 @@ entry:
 
 ; <label>:47                                      ; preds = %40
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
@@ -7098,8 +8544,8 @@ entry:
   %54 = load i32, i32* %loc0
   %55 = sext i32 %54 to i64
   %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
-  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %57
 
 ; <label>:57                                      ; preds = %52
   %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
@@ -7110,68 +8556,35 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %14
+ThrowNullRef2:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %23
+ThrowNullRef4:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %26
+ThrowNullRef6:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %30
+ThrowNullRef8:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %34
+ThrowNullRef10:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %47
+ThrowNullRef14:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %52
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-}
-
-INFO:  jitting method StringBuilder::get_Length using LLILCJit
-Successfully read StringBuilder.get_Length
-
-define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.StringBuilder addrspace(1)*
-  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
-  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
-
-; <label>:1                                       ; preds = %entry
-  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %3 = load i32, i32 addrspace(1)* %2, align 8
-  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
-
-; <label>:5                                       ; preds = %1
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = add i32 %3, %7
-  ret i32 %8
-
-ThrowNullRef:                                     ; preds = %entry
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef16:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7213,70 +8626,70 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
   %6 = load i32, i32 addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
   store i32 %6, i32 addrspace(1)* %8
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
   %13 = load i32, i32 addrspace(1)* %12, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
   store i32 %13, i32 addrspace(1)* %15
   %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
-  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %18
 
 ; <label>:18                                      ; preds = %14
   %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
   %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
   %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
   %34 = load i32, i32 addrspace(1)* %33, align 8
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
-  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
@@ -7287,39 +8700,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %28
+ThrowNullRef16:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %32
+ThrowNullRef18:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7455,13 +8868,13 @@ entry:
 ; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
@@ -7477,16 +8890,16 @@ entry:
 
 ; <label>:18                                      ; preds = %15
   %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
   store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
   %22 = load i32, i32* %loc0
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %24
 
 ; <label>:24                                      ; preds = %20
   %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
@@ -7498,13 +8911,13 @@ entry:
 ; <label>:28                                      ; preds = %15, %24
   %29 = load i32, i32* %arg1
   %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %31
   %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
@@ -7517,20 +8930,20 @@ entry:
   %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
-  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
   %46 = load i32, i32 addrspace(1)* %45, align 8
   %47 = sub i32 %40, %46
-  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
-  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i32 addrspace(1)* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %48
 
 ; <label>:48                                      ; preds = %44
   store i32 %47, i32 addrspace(1)* %39, align 8
@@ -7538,21 +8951,21 @@ entry:
 
 ; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
-  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %51
 
 ; <label>:51                                      ; preds = %49
   %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %53
 
 ; <label>:53                                      ; preds = %51
   %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
   %55 = load i32, i32 addrspace(1)* %54, align 8
   %56 = load i32, i32* %arg2
   %57 = sub i32 %55, %56
-  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %58
 
 ; <label>:58                                      ; preds = %53
   %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
@@ -7562,13 +8975,13 @@ entry:
 ; <label>:60                                      ; preds = %33, %58
   %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
   %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
-  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %63
 
 ; <label>:63                                      ; preds = %60
   %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
-  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
-  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
@@ -7578,15 +8991,15 @@ entry:
 
 ; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
-  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i32 addrspace(1)* %69, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %70
 
 ; <label>:70                                      ; preds = %68
   %71 = load i32, i32 addrspace(1)* %69, align 8
   store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
-  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
@@ -7596,8 +9009,8 @@ entry:
   store i32 %77, i32* %loc4
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
-  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %80
 
 ; <label>:80                                      ; preds = %73
   %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
@@ -7607,71 +9020,71 @@ entry:
 ; <label>:83                                      ; preds = %80
   store i32 0, i32* %loc3
   %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
-  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
-  br i1 %NullCheck26, label %88, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i32 addrspace(1)* %87, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %88
 
 ; <label>:88                                      ; preds = %85
   %89 = load i32, i32 addrspace(1)* %87, align 8
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
-  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %90
 
 ; <label>:90                                      ; preds = %88
   %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
   store i32 %89, i32 addrspace(1)* %91
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
-  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
-  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %96
 
 ; <label>:96                                      ; preds = %94
   %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
-  br i1 %NullCheck34, label %100, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %100
 
 ; <label>:100                                     ; preds = %96
   %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
-  br i1 %NullCheck36, label %102, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %102
 
 ; <label>:102                                     ; preds = %100
   %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
   %104 = load i32, i32 addrspace(1)* %103, align 8
   %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
-  br i1 %NullCheck38, label %106, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %106
 
 ; <label>:106                                     ; preds = %102
   %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
-  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
-  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %108
 
 ; <label>:108                                     ; preds = %106
   %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
   %110 = load i32, i32 addrspace(1)* %109, align 8
   %111 = add i32 %104, %110
-  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %112
 
 ; <label>:112                                     ; preds = %108
   %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
   store i32 %111, i32 addrspace(1)* %113
   %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
-  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i32 addrspace(1)* %114, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %115
 
 ; <label>:115                                     ; preds = %112
   %116 = load i32, i32 addrspace(1)* %114, align 8
@@ -7681,19 +9094,19 @@ entry:
 ; <label>:118                                     ; preds = %115
   %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
-  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %121
 
 ; <label>:121                                     ; preds = %118
   %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
-  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
-  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %123
 
 ; <label>:123                                     ; preds = %121
   %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
   %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
-  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
-  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %126
 
 ; <label>:126                                     ; preds = %123
   %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
@@ -7705,8 +9118,8 @@ entry:
 
 ; <label>:130                                     ; preds = %80, %115, %126
   %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %132
 
 ; <label>:132                                     ; preds = %130
   %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7715,8 +9128,8 @@ entry:
   %136 = load i32, i32* %loc3
   %137 = sub i32 %135, %136
   %138 = sub i32 %134, %137
-  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %139
 
 ; <label>:139                                     ; preds = %132
   %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7728,16 +9141,16 @@ entry:
 
 ; <label>:144                                     ; preds = %139
   %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
-  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %146
 
 ; <label>:146                                     ; preds = %144
   %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
   %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
   %149 = load i32, i32* %loc2
   %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
-  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %151
 
 ; <label>:151                                     ; preds = %146
   %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
@@ -7754,145 +9167,249 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %18
+ThrowNullRef4:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %31
+ThrowNullRef10:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %44
+ThrowNullRef16:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %68
+ThrowNullRef18:                                   ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %70
+ThrowNullRef20:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %73
+ThrowNullRef22:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %83
+ThrowNullRef24:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %85
+ThrowNullRef26:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %88
+ThrowNullRef28:                                   ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %90
+ThrowNullRef30:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %94
+ThrowNullRef32:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %96
+ThrowNullRef34:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %100
+ThrowNullRef36:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %102
+ThrowNullRef38:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %106
+ThrowNullRef40:                                   ; preds = %106
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %108
+ThrowNullRef42:                                   ; preds = %108
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %112
+ThrowNullRef44:                                   ; preds = %112
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %118
+ThrowNullRef46:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %121
+ThrowNullRef48:                                   ; preds = %121
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %123
+ThrowNullRef50:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %130
+ThrowNullRef52:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %132
+ThrowNullRef54:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %144
+ThrowNullRef56:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %146
+ThrowNullRef58:                                   ; preds = %146
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %60
+ThrowNullRef60:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %63
+ThrowNullRef62:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %49
+ThrowNullRef64:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %51
+ThrowNullRef66:                                   ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %53
+ThrowNullRef68:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(%"System.Char[]" addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %arg0 = alloca %"System.Char[]" addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store %"System.Char[]" addrspace(1)* %param0, %"System.Char[]" addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load i32, i32* %arg4
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %43, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %38, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg1
+  %13 = load i32, i32* %arg4
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %38, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %24 = load i32, i32* %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %35 = load i32, i32* %arg3
+  %36 = load i32, i32* %arg4
+  %37 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %37, %"System.Char[]" addrspace(1)* %34, i32 %35, i32 %36)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:38                                      ; preds = %5, %16
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Successfully read Buffer._Memmove
 
@@ -7914,7 +9431,7 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[loadElem]
+Failed to read AppDomain.SetDataHelper[storeElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -7923,8 +9440,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
@@ -7934,8 +9451,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
@@ -7947,15 +9464,15 @@ entry:
   %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
   %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
@@ -7966,15 +9483,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7992,7 +9509,79 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
-Failed to read Dictionary`2.TryGetValue[loadElemA]
+Successfully read Dictionary`2.TryGetValue
+
+define i8 @"Dictionary`2.TryGetValue"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)* addrspace(1)* %param2) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  %arg2 = alloca %System.__Canon addrspace(1)* addrspace(1)*
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  store %System.__Canon addrspace(1)* addrspace(1)* %param2, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  store i32 %2, i32* %loc0
+  %3 = load i32, i32* %loc0
+  %4 = icmp slt i32 %3, 0
+  br i1 %4, label %22, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 2
+  %10 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %9, align 8
+  %11 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = zext i32 %11 to i64
+  %BoundsCheck = icmp uge i64 %16, %15
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 3, i32 %11
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %20, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %6, %System.__Canon addrspace(1)* %21)
+  ret i8 1
+
+; <label>:22                                      ; preds = %entry
+  %23 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %23, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -8058,8 +9647,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
@@ -8091,8 +9680,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
@@ -8171,15 +9760,15 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck, label %19, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %ThrowNullRef, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
   %21 = load i32, i32 addrspace(1)* %20
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
@@ -8202,7 +9791,7 @@ ThrowNullRef:                                     ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %19
+ThrowNullRef2:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8248,8 +9837,8 @@ entry:
   %0 = alloca %System.AppDomainHandle
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %1 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %1, i32 0, i32 15
@@ -8269,8 +9858,8 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
@@ -8286,7 +9875,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -8299,8 +9888,8 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -8327,8 +9916,8 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
@@ -8352,8 +9941,8 @@ entry:
   %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
   store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
@@ -8363,8 +9952,8 @@ entry:
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
@@ -8374,8 +9963,8 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %9
   %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
@@ -8384,8 +9973,8 @@ entry:
 
 ; <label>:18                                      ; preds = %3, %16
   %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
@@ -8397,15 +9986,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %18
+ThrowNullRef6:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8418,8 +10007,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
@@ -8453,15 +10042,15 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
@@ -8473,7 +10062,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8481,7 +10070,7 @@ ThrowNullRef1:                                    ; preds = %1
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
 Failed to read Dictionary`2.System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
@@ -8506,8 +10095,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
@@ -8524,8 +10113,8 @@ entry:
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -8544,7 +10133,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8577,8 +10166,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = load i64, i64* %arg2
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = trunc i32 %3 to i8
@@ -8634,46 +10223,46 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
   %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
-  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
-  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
-  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
@@ -8684,27 +10273,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %20
+ThrowNullRef12:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8717,8 +10306,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -8756,22 +10345,22 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
   %9 = load i64, i64 addrspace(1)* %8, align 8
   %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
   %13 = load i64, i64 addrspace(1)* %12, align 8
   %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %11
   %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
@@ -8788,11 +10377,11 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8882,8 +10471,8 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
@@ -8900,8 +10489,8 @@ entry:
 ; <label>:8                                       ; preds = %1
   %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
   %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
@@ -8911,15 +10500,15 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
   %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
   %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
-  br i1 %NullCheck6, label %21, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
@@ -8946,15 +10535,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8992,15 +10581,15 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
   store i8 %3, i8 addrspace(1)* %5
   %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
@@ -9011,7 +10600,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9027,8 +10616,8 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -9041,8 +10630,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
@@ -9058,7 +10647,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9080,8 +10669,8 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
@@ -9096,8 +10685,8 @@ entry:
 ; <label>:12                                      ; preds = %6
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
@@ -9112,8 +10701,8 @@ entry:
 ; <label>:21                                      ; preds = %15
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
@@ -9128,8 +10717,8 @@ entry:
 ; <label>:30                                      ; preds = %24
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %31, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
@@ -9144,8 +10733,8 @@ entry:
 ; <label>:39                                      ; preds = %33
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
-  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %40, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %42
 
 ; <label>:42                                      ; preds = %39
   %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
@@ -9164,19 +10753,19 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %21
+ThrowNullRef4:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %30
+ThrowNullRef6:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %39
+ThrowNullRef8:                                    ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9243,8 +10832,8 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
@@ -9264,57 +10853,57 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
   store i8 0, i8 addrspace(1)* %2
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
   store i8 0, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
   store i8 0, i8 addrspace(1)* %17
   %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
   store i8 0, i8 addrspace(1)* %20
   %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
-  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
@@ -9325,31 +10914,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %19
+ThrowNullRef14:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9367,8 +10956,8 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
@@ -9380,8 +10969,8 @@ entry:
 
 ; <label>:9                                       ; preds = %4
   %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %9
   %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
@@ -9395,7 +10984,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef2:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9420,8 +11009,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
@@ -9512,8 +11101,8 @@ entry:
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
@@ -9524,8 +11113,8 @@ entry:
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = load i64, i64 addrspace(1)* %12
@@ -9537,8 +11126,8 @@ entry:
   %20 = load i64, i64* %19
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
-  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %13
   %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
@@ -9555,8 +11144,8 @@ entry:
 ; <label>:30                                      ; preds = %25
   %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %32 = load i32, i32* %arg2
-  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
-  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
@@ -9570,15 +11159,15 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %30
+ThrowNullRef2:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9622,87 +11211,87 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
   %10 = load i8, i8 addrspace(1)* %9, align 8
   %11 = zext i8 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %8
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
   store i8 %12, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
   %19 = load i8, i8 addrspace(1)* %18, align 8
   %20 = zext i8 %19 to i32
   %21 = trunc i32 %20 to i8
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
   store i8 %21, i8 addrspace(1)* %23
   %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
   %28 = load i8, i8 addrspace(1)* %27, align 8
   %29 = zext i8 %28 to i32
   %30 = trunc i32 %29 to i8
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
-  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %31
 
 ; <label>:31                                      ; preds = %26
   %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
   store i8 %30, i8 addrspace(1)* %32
   %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
-  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
-  br i1 %NullCheck14, label %40, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %40
 
 ; <label>:40                                      ; preds = %35
   %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
   store i8 %39, i8 addrspace(1)* %41
   %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
-  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %44
 
 ; <label>:44                                      ; preds = %40
   %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
   %46 = load i8, i8 addrspace(1)* %45, align 8
   %47 = zext i8 %46 to i32
   %48 = trunc i32 %47 to i8
-  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
   store i8 %48, i8 addrspace(1)* %50
   %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
-  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
@@ -9713,29 +11302,29 @@ entry:
 ; <label>:56                                      ; preds = %52
   %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
-  br i1 %NullCheck22, label %59, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
   %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
   %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
-  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
-  br i1 %NullCheck24, label %63, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
   %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
-  br i1 %NullCheck26, label %66, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
   %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
-  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
-  br i1 %NullCheck28, label %69, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %69
 
 ; <label>:69                                      ; preds = %66
   %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
@@ -9744,15 +11333,15 @@ entry:
 
 ; <label>:71                                      ; preds = %105
   %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
-  br i1 %NullCheck34, label %73, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %73
 
 ; <label>:73                                      ; preds = %71
   %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
   %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
   %76 = load i32, i32* %loc0
-  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
-  br i1 %NullCheck36, label %77, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
@@ -9766,8 +11355,8 @@ entry:
 
 ; <label>:83                                      ; preds = %77
   %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
-  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
@@ -9775,14 +11364,14 @@ entry:
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
   %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
-  br i1 %NullCheck40, label %91, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
 ; <label>:91                                      ; preds = %85
   %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
   %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
-  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck42, label %94, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %94
 
 ; <label>:94                                      ; preds = %91
   %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
@@ -9798,14 +11387,14 @@ entry:
 ; <label>:99                                      ; preds = %69, %96
   %100 = load i32, i32* %loc0
   %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
-  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %102
 
 ; <label>:102                                     ; preds = %99
   %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
   %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
-  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
-  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
@@ -9819,87 +11408,87 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %26
+ThrowNullRef10:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %31
+ThrowNullRef12:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %35
+ThrowNullRef14:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %40
+ThrowNullRef16:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %56
+ThrowNullRef22:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %59
+ThrowNullRef24:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %63
+ThrowNullRef26:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %66
+ThrowNullRef28:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %102
+ThrowNullRef32:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %71
+ThrowNullRef34:                                   ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %73
+ThrowNullRef36:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %83
+ThrowNullRef38:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %85
+ThrowNullRef40:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %91
+ThrowNullRef42:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9943,15 +11532,15 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
   %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
@@ -9961,28 +11550,28 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
   %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %12
   %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
   %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
   %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
-  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
@@ -9993,23 +11582,23 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %12
+ThrowNullRef6:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10031,15 +11620,15 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
   %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = load i64, i64 addrspace(1)* %7
@@ -10077,13 +11666,13 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[loadElem]
+Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -10111,8 +11700,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -10178,8 +11767,8 @@ entry:
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load float, float* %arg0
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -10313,8 +11902,8 @@ entry:
   store i64 %param0, i64* %arg0
   store i64 %param1, i64* %arg1
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
@@ -10322,8 +11911,8 @@ entry:
   %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
   %5 = load i16*, i16* addrspace(1)* %4, align 8
   %6 = addrspacecast i64* %arg1 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = bitcast i64 addrspace(1)* %6 to i8 addrspace(1)*
@@ -10339,7 +11928,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10373,8 +11962,8 @@ entry:
   %1 = load i32, i32* %arg1
   %2 = sext i32 %1 to i64
   %3 = inttoptr i64 %2 to i16*
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -10427,8 +12016,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, i32)*)(%System.IO.ConsoleStream addrspace(1)* %2, i32 %1)
   %3 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %4 = load i64, i64* %arg1
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
@@ -10439,8 +12028,8 @@ entry:
   %10 = icmp eq i32 %9, 3
   %11 = sext i1 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %5
   %14 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, i32 0, i32 5
@@ -10451,7 +12040,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10474,8 +12063,8 @@ entry:
   %5 = icmp eq i32 %4, 1
   %6 = sext i1 %5 to i32
   %7 = trunc i32 %6 to i8
-  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %2, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.ConsoleStream addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
@@ -10486,8 +12075,8 @@ entry:
   %13 = icmp eq i32 %12, 2
   %14 = sext i1 %13 to i32
   %15 = trunc i32 %14 to i8
-  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %10, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.ConsoleStream addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %8
   %17 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %10, i32 0, i32 4
@@ -10498,7 +12087,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10537,8 +12126,8 @@ entry:
   %arg0 = alloca i64
   store i64 %param0, i64* %arg0
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
@@ -10573,8 +12162,8 @@ entry:
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
   %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = load i64, i64 addrspace(1)* %7
@@ -10678,7 +12267,127 @@ entry:
 INFO:  jitting method Encoding::GetEncoding using LLILCJit
 Failed to read Encoding.GetEncoding[convertToHelperArgumentType]
 INFO:  jitting method EncodingProvider::GetEncodingFromProvider using LLILCJit
-Failed to read EncodingProvider.GetEncodingFromProvider[loadElem]
+Successfully read EncodingProvider.GetEncodingFromProvider
+
+define %System.Text.Encoding addrspace(1)* @EncodingProvider.GetEncodingFromProvider(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca %"System.Text.EncodingProvider[]" addrspace(1)*
+  %loc1 = alloca %System.Text.EncodingProvider addrspace(1)*
+  %loc2 = alloca %System.Text.Encoding addrspace(1)*
+  %loc3 = alloca %System.Text.Encoding addrspace(1)*
+  %loc4 = alloca %"System.Text.EncodingProvider[]" addrspace(1)*
+  %loc5 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1059)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2392
+  %2 = addrspacecast i8 addrspace(1)* %1 to %"System.Text.EncodingProvider[]" addrspace(1)**
+  %3 = load volatile %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %2
+  %4 = icmp ne %"System.Text.EncodingProvider[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %entry
+  ret %System.Text.Encoding addrspace(1)* null
+
+; <label>:6                                       ; preds = %entry
+  %7 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1059)
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i64 2392
+  %9 = addrspacecast i8 addrspace(1)* %8 to %"System.Text.EncodingProvider[]" addrspace(1)**
+  %10 = load volatile %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %9
+  store %"System.Text.EncodingProvider[]" addrspace(1)* %10, %"System.Text.EncodingProvider[]" addrspace(1)** %loc0
+  %11 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc0
+  store %"System.Text.EncodingProvider[]" addrspace(1)* %11, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  store i32 0, i32* %loc5
+  br label %43
+
+; <label>:12                                      ; preds = %46
+  %13 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  %14 = load i32, i32* %loc5
+  %NullCheck1 = icmp eq %"System.Text.EncodingProvider[]" addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %13, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = zext i32 %17 to i64
+  %19 = zext i32 %14 to i64
+  %BoundsCheck = icmp uge i64 %19, %18
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %20
+
+; <label>:20                                      ; preds = %15
+  %21 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %13, i32 0, i32 3, i32 %14
+  %22 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)* addrspace(1)* %21, align 8
+  store %System.Text.EncodingProvider addrspace(1)* %22, %System.Text.EncodingProvider addrspace(1)** %loc1
+  %23 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)** %loc1
+  %24 = load i32, i32* %arg0
+  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i64 addrspace(1)*
+  %NullCheck3 = icmp eq i64 addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
+
+; <label>:26                                      ; preds = %20
+  %27 = load i64, i64 addrspace(1)* %25
+  %28 = add i64 %27, 64
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 40
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Text.Encoding addrspace(1)* (%System.Text.EncodingProvider addrspace(1)*, i32)*
+  %35 = call %System.Text.Encoding addrspace(1)* %34(%System.Text.EncodingProvider addrspace(1)* %23, i32 %24)
+  store %System.Text.Encoding addrspace(1)* %35, %System.Text.Encoding addrspace(1)** %loc2
+  %36 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc2
+  %37 = icmp eq %System.Text.Encoding addrspace(1)* %36, null
+  br i1 %37, label %40, label %38
+
+; <label>:38                                      ; preds = %26
+  %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc2
+  store %System.Text.Encoding addrspace(1)* %39, %System.Text.Encoding addrspace(1)** %loc3
+  br label %53
+
+; <label>:40                                      ; preds = %26
+  %41 = load i32, i32* %loc5
+  %42 = add i32 %41, 1
+  store i32 %42, i32* %loc5
+  br label %43
+
+; <label>:43                                      ; preds = %6, %40
+  %44 = load i32, i32* %loc5
+  %45 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  %NullCheck = icmp eq %"System.Text.EncodingProvider[]" addrspace(1)* %45, null
+  br i1 %NullCheck, label %ThrowNullRef, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp slt i32 %44, %50
+  br i1 %51, label %12, label %52
+
+; <label>:52                                      ; preds = %46
+  ret %System.Text.Encoding addrspace(1)* null
+
+; <label>:53                                      ; preds = %38
+  %54 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc3
+  ret %System.Text.Encoding addrspace(1)* %54
+
+ThrowNullRef:                                     ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method EncodingProvider::.cctor using LLILCJit
 Successfully read EncodingProvider..cctor
 
@@ -10697,7 +12406,7 @@ Failed to read Encoding.get_InternalSyncObject[Call HasTypeArg]
 INFO:  jitting method Hashtable::.ctor using LLILCJit
 Failed to read Hashtable..ctor[Volatile store]
 INFO:  jitting method Hashtable::get_Item using LLILCJit
-Failed to read Hashtable.get_Item[loadElemA]
+Failed to read Hashtable.get_Item[loadNonPrimitiveObj]
 INFO:  jitting method Hashtable::InitHash using LLILCJit
 Successfully read Hashtable.InitHash
 
@@ -10717,8 +12426,8 @@ entry:
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -10734,15 +12443,15 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
   %15 = load i32, i32* %loc0
-  %NullCheck2 = icmp ne i32 addrspace(1)* %14, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i32 addrspace(1)* %14, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %3
   store i32 %15, i32 addrspace(1)* %14, align 8
   %17 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %18 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %NullCheck4 = icmp ne i32 addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i32 addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = load i32, i32 addrspace(1)* %18, align 8
@@ -10751,8 +12460,8 @@ entry:
   %23 = sub i32 %22, 1
   %24 = urem i32 %21, %23
   %25 = add i32 1, %24
-  %NullCheck6 = icmp ne i32 addrspace(1)* %17, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32 addrspace(1)* %17, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %19
   store i32 %25, i32 addrspace(1)* %17, align 8
@@ -10763,15 +12472,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %19
+ThrowNullRef6:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10786,8 +12495,8 @@ entry:
   store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
   store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %NullCheck = icmp ne %System.Collections.Hashtable addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Collections.Hashtable addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
@@ -10797,16 +12506,16 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Collections.Hashtable addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Collections.Hashtable addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
   %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck4 = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %9, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
   %13 = inttoptr i64 %11 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
@@ -10816,8 +12525,8 @@ entry:
 ; <label>:15                                      ; preds = %1
   %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -10835,15 +12544,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10857,8 +12566,8 @@ entry:
   store %System.Int32 addrspace(1)* %param0, %System.Int32 addrspace(1)** %this
   %0 = load %System.Int32 addrspace(1)*, %System.Int32 addrspace(1)** %this
   %1 = bitcast %System.Int32 addrspace(1)* %0 to i32 addrspace(1)*
-  %NullCheck = icmp ne i32 addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq i32 addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load i32, i32 addrspace(1)* %1, align 8
@@ -10934,8 +12643,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.UTF8Encoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
@@ -10944,15 +12653,15 @@ entry:
   %9 = load i8, i8* %arg2
   %10 = zext i8 %9 to i32
   %11 = trunc i32 %10 to i8
-  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %8, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %6
   %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %8, i32 0, i32 8
   store i8 %11, i8 addrspace(1)* %13
   %14 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %14, i32 0, i32 8
@@ -10964,8 +12673,8 @@ entry:
 ; <label>:20                                      ; preds = %15
   %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %22, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %22, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = load i64, i64 addrspace(1)* %22
@@ -10987,15 +12696,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %12
+ThrowNullRef4:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11010,8 +12719,8 @@ entry:
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
@@ -11033,16 +12742,16 @@ entry:
 ; <label>:10                                      ; preds = %1
   %11 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
   %12 = load i32, i32* %arg1
-  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %11, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.Encoding addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
   store i32 %12, i32 addrspace(1)* %14
   %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
   %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = load i64, i64 addrspace(1)* %16
@@ -11060,11 +12769,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11077,8 +12786,8 @@ entry:
   %this = alloca %System.Text.UTF8Encoding addrspace(1)*
   store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
   %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.UTF8Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
@@ -11090,16 +12799,16 @@ entry:
 ; <label>:6                                       ; preds = %1
   %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %8 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %10, %System.Text.EncoderFallback addrspace(1)* %8)
   %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %12 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
-  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %11, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %11, i32 0, i32 3
@@ -11112,8 +12821,8 @@ entry:
   %18 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %18, %System.String addrspace(1)* %17)
   %19 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %18 to %System.Text.EncoderFallback addrspace(1)*
-  %NullCheck6 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %16, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %16, i32 0, i32 2
@@ -11123,8 +12832,8 @@ entry:
   %24 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %24, %System.String addrspace(1)* %23)
   %25 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %24 to %System.Text.DecoderFallback addrspace(1)*
-  %NullCheck8 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %22, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %22, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %20
   %27 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %22, i32 0, i32 3
@@ -11135,19 +12844,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %20
+ThrowNullRef8:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11177,8 +12886,8 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load i32, i32* %arg1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -11196,8 +12905,8 @@ entry:
 ; <label>:15                                      ; preds = %8
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %17 = load i32, i32* %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 %17
@@ -11213,7 +12922,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11265,7 +12974,7 @@ entry:
 }
 
 INFO:  jitting method Hashtable::Insert using LLILCJit
-Failed to read Hashtable.Insert[loadElemA]
+Failed to read Hashtable.Insert[storeElem]
 INFO:  jitting method ConsoleEncoding::.ctor using LLILCJit
 Successfully read ConsoleEncoding..ctor
 
@@ -11280,8 +12989,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %1)
   %2 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
@@ -11317,8 +13026,8 @@ entry:
   %2 = call %System.Text.InternalEncoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalEncoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %1)
   %3 = bitcast %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2 to %System.Text.EncoderFallback addrspace(1)*
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
@@ -11328,8 +13037,8 @@ entry:
   %8 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %7)
   %9 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %8 to %System.Text.DecoderFallback addrspace(1)*
-  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %6, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.Encoding addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %4
   %11 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %6, i32 0, i32 3
@@ -11340,7 +13049,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11359,15 +13068,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* %1)
   %2 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   %6 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, i32 0, i32 1
@@ -11378,7 +13087,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11406,8 +13115,8 @@ entry:
   store %System.Text.InternalDecoderBestFitFallback addrspace(1)* %param0, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
   %0 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
@@ -11417,15 +13126,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %4)
   %5 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %6)
   %9 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, i32 0, i32 1
@@ -11436,11 +13145,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11508,8 +13217,8 @@ entry:
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
   %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = load i64, i64 addrspace(1)* %19
@@ -11573,8 +13282,8 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.ConsoleStream addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
@@ -11605,31 +13314,31 @@ entry:
   store i8 %param4, i8* %arg4
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %3, %System.IO.Stream addrspace(1)* %1)
   %4 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %4, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
   %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %4, i32 0, i32 4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %5)
   %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %6
   %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
   %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
   %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = load i64, i64 addrspace(1)* %13
@@ -11641,8 +13350,8 @@ entry:
   %21 = load i64, i64* %20
   %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %8, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %8, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %14
   %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 5
@@ -11660,24 +13369,24 @@ entry:
   %31 = load i32, i32* %arg3
   %32 = sext i32 %31 to i64
   %33 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %32)
-  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %30, null
-  br i1 %NullCheck10, label %34, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.StreamWriter addrspace(1)* %30, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %35, %"System.Char[]" addrspace(1)* %33)
   %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %37, null
-  br i1 %NullCheck12, label %38, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.StreamWriter addrspace(1)* %37, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %38
 
 ; <label>:38                                      ; preds = %34
   %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
   %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
   %41 = load i32, i32* %arg3
   %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %42, null
-  br i1 %NullCheck14, label %43, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %42, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
   %44 = load i64, i64 addrspace(1)* %42
@@ -11691,30 +13400,30 @@ entry:
   %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
   %53 = sext i32 %52 to i64
   %54 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %53)
-  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
-  br i1 %NullCheck16, label %55, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %55
 
 ; <label>:55                                      ; preds = %43
   %56 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %56, %"System.Byte[]" addrspace(1)* %54)
   %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %58 = load i32, i32* %arg3
-  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %57, null
-  br i1 %NullCheck18, label %59, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.StreamWriter addrspace(1)* %57, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %59
 
 ; <label>:59                                      ; preds = %55
   %60 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 10
   store i32 %58, i32 addrspace(1)* %60
   %61 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %61, null
-  br i1 %NullCheck20, label %62, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.IO.StreamWriter addrspace(1)* %61, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %62
 
 ; <label>:62                                      ; preds = %59
   %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
   %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
   %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
   %67 = load i64, i64 addrspace(1)* %65
@@ -11732,15 +13441,15 @@ entry:
 
 ; <label>:78                                      ; preds = %66
   %79 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %79, null
-  br i1 %NullCheck24, label %80, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.StreamWriter addrspace(1)* %79, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %80
 
 ; <label>:80                                      ; preds = %78
   %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
   %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
   %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %83, null
-  br i1 %NullCheck26, label %84, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %83, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
   %85 = load i64, i64 addrspace(1)* %83
@@ -11757,8 +13466,8 @@ entry:
 
 ; <label>:95                                      ; preds = %84
   %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.IO.StreamWriter addrspace(1)* %96, null
-  br i1 %NullCheck28, label %97, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.IO.StreamWriter addrspace(1)* %96, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %97
 
 ; <label>:97                                      ; preds = %95
   %98 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 12
@@ -11772,8 +13481,8 @@ entry:
   %103 = icmp eq i32 %102, 0
   %104 = sext i1 %103 to i32
   %105 = trunc i32 %104 to i8
-  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %100, null
-  br i1 %NullCheck30, label %106, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.IO.StreamWriter addrspace(1)* %100, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %106
 
 ; <label>:106                                     ; preds = %99
   %107 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %100, i32 0, i32 13
@@ -11784,63 +13493,63 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %6
+ThrowNullRef4:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %29
+ThrowNullRef10:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %34
+ThrowNullRef12:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %38
+ThrowNullRef14:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %43
+ThrowNullRef16:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %55
+ThrowNullRef18:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %59
+ThrowNullRef20:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %62
+ThrowNullRef22:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %78
+ThrowNullRef24:                                   ; preds = %78
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %80
+ThrowNullRef26:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %95
+ThrowNullRef28:                                   ; preds = %95
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11853,15 +13562,15 @@ entry:
   %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = load i64, i64 addrspace(1)* %4
@@ -11879,7 +13588,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11929,35 +13638,35 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
   %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderNLS addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %7 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.EncoderNLS addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Text.Encoding addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.Encoding addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Text.EncoderNLS addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.EncoderNLS addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
   %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck8 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = load i64, i64 addrspace(1)* %16
@@ -11976,19 +13685,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12014,8 +13723,8 @@ entry:
   %this = alloca %System.Text.Encoding addrspace(1)*
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
@@ -12035,15 +13744,15 @@ entry:
   %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
   store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
   %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
   store i32 0, i32 addrspace(1)* %2
   %3 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, i32 0, i32 2
@@ -12053,15 +13762,15 @@ entry:
 
 ; <label>:8                                       ; preds = %4
   %9 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
   %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
   %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = load i64, i64 addrspace(1)* %13
@@ -12082,15 +13791,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12105,16 +13814,16 @@ entry:
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = load i32, i32* %arg1
   %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
   %7 = load i64, i64 addrspace(1)* %5
@@ -12132,7 +13841,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12169,8 +13878,8 @@ entry:
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
   %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
   %16 = load i64, i64 addrspace(1)* %14
@@ -12191,8 +13900,8 @@ entry:
   %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
   %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
   %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %31, null
-  br i1 %NullCheck2, label %32, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = load i64, i64 addrspace(1)* %31
@@ -12235,7 +13944,7 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12248,14 +13957,14 @@ entry:
   %this = alloca %System.Text.EncoderReplacementFallback addrspace(1)*
   store %System.Text.EncoderReplacementFallback addrspace(1)* %param0, %System.Text.EncoderReplacementFallback addrspace(1)** %this
   %0 = load %System.Text.EncoderReplacementFallback addrspace(1)*, %System.Text.EncoderReplacementFallback addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -12266,7 +13975,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12296,8 +14005,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
@@ -12329,8 +14038,8 @@ entry:
   %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
   store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
@@ -12342,8 +14051,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Threading.Tasks.Task addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %7)
@@ -12366,7 +14075,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12385,8 +14094,8 @@ entry:
   store i8 %param1, i8* %arg1
   store i8 %param2, i8* %arg2
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
@@ -12400,8 +14109,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1, %5
   %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 9
@@ -12432,8 +14141,8 @@ entry:
 
 ; <label>:25                                      ; preds = %8, %20
   %26 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %26, null
-  br i1 %NullCheck4, label %27, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %26, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %26, i32 0, i32 12
@@ -12444,22 +14153,22 @@ entry:
 
 ; <label>:32                                      ; preds = %27
   %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %33, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.IO.StreamWriter addrspace(1)* %33, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %32
   %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 12
   store i8 1, i8 addrspace(1)* %35
   %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
-  br i1 %NullCheck8, label %37, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
   %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
   %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck10 = icmp ne i64 addrspace(1)* %40, null
-  br i1 %NullCheck10, label %41, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64 addrspace(1)* %40, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i64, i64 addrspace(1)* %40
@@ -12473,8 +14182,8 @@ entry:
   %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
   store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
   %51 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %NullCheck12 = icmp ne %"System.Byte[]" addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Byte[]" addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %41
   %53 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %51, i32 0, i32 1
@@ -12486,16 +14195,16 @@ entry:
 
 ; <label>:58                                      ; preds = %52
   %59 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %59, null
-  br i1 %NullCheck14, label %60, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.IO.StreamWriter addrspace(1)* %59, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %60
 
 ; <label>:60                                      ; preds = %58
   %61 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %59, i32 0, i32 3
   %62 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
   %64 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %NullCheck16 = icmp ne %"System.Byte[]" addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %"System.Byte[]" addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %60
   %66 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %64, i32 0, i32 1
@@ -12503,8 +14212,8 @@ entry:
   %68 = zext i32 %67 to i64
   %69 = trunc i64 %68 to i32
   %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck18, label %71, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
   %72 = load i64, i64 addrspace(1)* %70
@@ -12520,29 +14229,29 @@ entry:
 
 ; <label>:80                                      ; preds = %27, %52, %71
   %81 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %81, null
-  br i1 %NullCheck20, label %82, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.IO.StreamWriter addrspace(1)* %81, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
 
 ; <label>:82                                      ; preds = %80
   %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %81, i32 0, i32 5
   %84 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %83, align 8
   %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.IO.StreamWriter addrspace(1)* %85, null
-  br i1 %NullCheck22, label %86, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.IO.StreamWriter addrspace(1)* %85, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %86
 
 ; <label>:86                                      ; preds = %82
   %87 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 7
   %88 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %87, align 8
   %89 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %89, null
-  br i1 %NullCheck24, label %90, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.StreamWriter addrspace(1)* %89, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %90
 
 ; <label>:90                                      ; preds = %86
   %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %89, i32 0, i32 9
   %92 = load i32, i32 addrspace(1)* %91, align 8
   %93 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.IO.StreamWriter addrspace(1)* %93, null
-  br i1 %NullCheck26, label %94, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.IO.StreamWriter addrspace(1)* %93, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %93, i32 0, i32 6
@@ -12550,8 +14259,8 @@ entry:
   %97 = load i8, i8* %arg2
   %98 = zext i8 %97 to i32
   %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
-  %NullCheck28 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck28, label %100, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
   %101 = load i64, i64 addrspace(1)* %99
@@ -12566,8 +14275,8 @@ entry:
   %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
   store i32 %110, i32* %loc1
   %111 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %111, null
-  br i1 %NullCheck30, label %112, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.IO.StreamWriter addrspace(1)* %111, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %112
 
 ; <label>:112                                     ; preds = %100
   %113 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %111, i32 0, i32 9
@@ -12578,23 +14287,23 @@ entry:
 
 ; <label>:116                                     ; preds = %112
   %117 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck32 = icmp ne %System.IO.StreamWriter addrspace(1)* %117, null
-  br i1 %NullCheck32, label %118, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.IO.StreamWriter addrspace(1)* %117, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %118
 
 ; <label>:118                                     ; preds = %116
   %119 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %117, i32 0, i32 3
   %120 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %119, align 8
   %121 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.IO.StreamWriter addrspace(1)* %121, null
-  br i1 %NullCheck34, label %122, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.IO.StreamWriter addrspace(1)* %121, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %122
 
 ; <label>:122                                     ; preds = %118
   %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
   %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
   %125 = load i32, i32* %loc1
   %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
-  %NullCheck36 = icmp ne i64 addrspace(1)* %126, null
-  br i1 %NullCheck36, label %127, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64 addrspace(1)* %126, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
   %128 = load i64, i64 addrspace(1)* %126
@@ -12616,15 +14325,15 @@ entry:
 
 ; <label>:140                                     ; preds = %136
   %141 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.IO.StreamWriter addrspace(1)* %141, null
-  br i1 %NullCheck38, label %142, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.IO.StreamWriter addrspace(1)* %141, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %142
 
 ; <label>:142                                     ; preds = %140
   %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
   %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
   %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
-  %NullCheck40 = icmp ne i64 addrspace(1)* %145, null
-  br i1 %NullCheck40, label %146, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i64 addrspace(1)* %145, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
   %147 = load i64, i64 addrspace(1)* %145
@@ -12645,83 +14354,83 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %25
+ThrowNullRef4:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %32
+ThrowNullRef6:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %37
+ThrowNullRef10:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %41
+ThrowNullRef12:                                   ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %58
+ThrowNullRef14:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %60
+ThrowNullRef16:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %65
+ThrowNullRef18:                                   ; preds = %65
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %80
+ThrowNullRef20:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %82
+ThrowNullRef22:                                   ; preds = %82
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %86
+ThrowNullRef24:                                   ; preds = %86
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %90
+ThrowNullRef26:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %94
+ThrowNullRef28:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %100
+ThrowNullRef30:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %116
+ThrowNullRef32:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %118
+ThrowNullRef34:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %122
+ThrowNullRef36:                                   ; preds = %122
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %140
+ThrowNullRef38:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %142
+ThrowNullRef40:                                   ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12788,8 +14497,8 @@ entry:
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %1 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
-  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
@@ -12797,8 +14506,8 @@ entry:
   %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
   %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
   %8 = load i64, i64 addrspace(1)* %6
@@ -12814,8 +14523,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %17, %System.IFormatProvider addrspace(1)* %16)
   %18 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %19 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %18, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.SyncTextWriter addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %7
   %21 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %18, i32 0, i32 4
@@ -12826,11 +14535,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12843,8 +14552,8 @@ entry:
   %this = alloca %System.IO.TextWriter addrspace(1)*
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.TextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
@@ -12854,8 +14563,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.Threading.Thread addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Threading.Thread addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %6)
@@ -12864,8 +14573,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1
   %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.TextWriter addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.TextWriter addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %11, i32 0, i32 2
@@ -12876,11 +14585,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13077,8 +14786,8 @@ entry:
   store float %param1, float* %arg1
   store i8 0, i8* %loc1
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
@@ -13088,16 +14797,16 @@ entry:
   %5 = addrspacecast i8* %loc1 to i8 addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %4, i8 addrspace(1)* %5)
   %6 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.SyncTextWriter addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
   %10 = load float, float* %arg1
   %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
   %13 = load i64, i64 addrspace(1)* %11
@@ -13132,11 +14841,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13153,8 +14862,8 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load float, float* %arg1
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -13168,8 +14877,8 @@ entry:
   call void %11(%System.IO.TextWriter addrspace(1)* %0, float %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
   %15 = load i64, i64 addrspace(1)* %13
@@ -13187,7 +14896,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13205,8 +14914,8 @@ entry:
   %1 = addrspacecast float* %arg1 to float addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -13221,8 +14930,8 @@ entry:
   %14 = bitcast float addrspace(1)* %1 to %System.Single addrspace(1)*
   %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Single addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Single addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
   %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
   %18 = load i64, i64 addrspace(1)* %16
@@ -13240,7 +14949,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13256,8 +14965,8 @@ entry:
   store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
   %0 = load %System.Single addrspace(1)*, %System.Single addrspace(1)** %this
   %1 = bitcast %System.Single addrspace(1)* %0 to float addrspace(1)*
-  %NullCheck = icmp ne float addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq float addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load float, float addrspace(1)* %1, align 8
@@ -13282,8 +14991,8 @@ entry:
   %loc0 = alloca %System.Globalization.NumberFormatInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 3
@@ -13293,8 +15002,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
@@ -13304,24 +15013,24 @@ entry:
   store %System.Globalization.NumberFormatInfo addrspace(1)* %10, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
   %11 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %7
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
   %15 = load i8, i8 addrspace(1)* %14, align 8
   %16 = zext i8 %15 to i32
   %17 = trunc i32 %16 to i8
-  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %11, null
-  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %11, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %13
   %19 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %11, i32 0, i32 29
   store i8 %17, i8 addrspace(1)* %19
   %20 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %21 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %20, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %20, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %18
   %23 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %20, i32 0, i32 3
@@ -13330,8 +15039,8 @@ entry:
 
 ; <label>:24                                      ; preds = %1, %22
   %25 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %25, null
-  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %25, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %26
 
 ; <label>:26                                      ; preds = %24
   %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %25, i32 0, i32 3
@@ -13342,23 +15051,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %18
+ThrowNullRef8:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13383,168 +15092,168 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 18
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %8, align 8
-  %NullCheck2 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %5, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %5, i32 0, i32 4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %9)
   %12 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 19
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %15, align 8
-  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %12, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %12, i32 0, i32 5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %16)
   %19 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %20 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %20, null
-  br i1 %NullCheck8, label %21, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %20, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %20, i32 0, i32 23
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  %NullCheck10 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %19, null
-  br i1 %NullCheck10, label %24, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %19, i32 0, i32 7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %25, %System.String addrspace(1)* %23)
   %26 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %27 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %27, i32 0, i32 22
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %29, align 8
-  %NullCheck14 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %26, null
-  br i1 %NullCheck14, label %31, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %26, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %26, i32 0, i32 6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %32, %System.String addrspace(1)* %30)
   %33 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %34 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Globalization.CultureData addrspace(1)* %34, null
-  br i1 %NullCheck16, label %35, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Globalization.CultureData addrspace(1)* %34, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %34, i32 0, i32 51
   %37 = load i32, i32 addrspace(1)* %36, align 8
-  %NullCheck18 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %33, null
-  br i1 %NullCheck18, label %38, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %33, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %33, i32 0, i32 21
   store i32 %37, i32 addrspace(1)* %39
   %40 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %41 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Globalization.CultureData addrspace(1)* %41, null
-  br i1 %NullCheck20, label %42, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Globalization.CultureData addrspace(1)* %41, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %41, i32 0, i32 52
   %44 = load i32, i32 addrspace(1)* %43, align 8
-  %NullCheck22 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %40, null
-  br i1 %NullCheck22, label %45, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %40, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %40, i32 0, i32 25
   store i32 %44, i32 addrspace(1)* %46
   %47 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %48 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.Globalization.CultureData addrspace(1)* %48, null
-  br i1 %NullCheck24, label %49, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Globalization.CultureData addrspace(1)* %48, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %49
 
 ; <label>:49                                      ; preds = %45
   %50 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %48, i32 0, i32 29
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck26 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %47, null
-  br i1 %NullCheck26, label %52, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %47, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %47, i32 0, i32 10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %53, %System.String addrspace(1)* %51)
   %54 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %55 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Globalization.CultureData addrspace(1)* %55, null
-  br i1 %NullCheck28, label %56, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Globalization.CultureData addrspace(1)* %55, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %56
 
 ; <label>:56                                      ; preds = %52
   %57 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %55, i32 0, i32 35
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %57, align 8
-  %NullCheck30 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %54, null
-  br i1 %NullCheck30, label %59, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %54, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %54, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %60, %System.String addrspace(1)* %58)
   %61 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %62 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck32 = icmp ne %System.Globalization.CultureData addrspace(1)* %62, null
-  br i1 %NullCheck32, label %63, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Globalization.CultureData addrspace(1)* %62, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %62, i32 0, i32 34
   %65 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %64, align 8
-  %NullCheck34 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %61, null
-  br i1 %NullCheck34, label %66, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %61, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %61, i32 0, i32 9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %67, %System.String addrspace(1)* %65)
   %68 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %69 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck36 = icmp ne %System.Globalization.CultureData addrspace(1)* %69, null
-  br i1 %NullCheck36, label %70, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Globalization.CultureData addrspace(1)* %69, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %70
 
 ; <label>:70                                      ; preds = %66
   %71 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %69, i32 0, i32 55
   %72 = load i32, i32 addrspace(1)* %71, align 8
-  %NullCheck38 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %68, null
-  br i1 %NullCheck38, label %73, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %68, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %68, i32 0, i32 22
   store i32 %72, i32 addrspace(1)* %74
   %75 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %76 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck40 = icmp ne %System.Globalization.CultureData addrspace(1)* %76, null
-  br i1 %NullCheck40, label %77, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Globalization.CultureData addrspace(1)* %76, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %76, i32 0, i32 57
   %79 = load i32, i32 addrspace(1)* %78, align 8
-  %NullCheck42 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %75, null
-  br i1 %NullCheck42, label %80, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %75, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %80
 
 ; <label>:80                                      ; preds = %77
   %81 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %75, i32 0, i32 24
   store i32 %79, i32 addrspace(1)* %81
   %82 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %83 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck44 = icmp ne %System.Globalization.CultureData addrspace(1)* %83, null
-  br i1 %NullCheck44, label %84, label %ThrowNullRef43
+  %NullCheck43 = icmp eq %System.Globalization.CultureData addrspace(1)* %83, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %84
 
 ; <label>:84                                      ; preds = %80
   %85 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %83, i32 0, i32 56
   %86 = load i32, i32 addrspace(1)* %85, align 8
-  %NullCheck46 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %82, null
-  br i1 %NullCheck46, label %87, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %82, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %82, i32 0, i32 23
@@ -13553,8 +15262,8 @@ entry:
 
 ; <label>:89                                      ; preds = %entry
   %90 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck100 = icmp ne %System.Globalization.CultureData addrspace(1)* %90, null
-  br i1 %NullCheck100, label %91, label %ThrowNullRef99
+  %NullCheck99 = icmp eq %System.Globalization.CultureData addrspace(1)* %90, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %91
 
 ; <label>:91                                      ; preds = %89
   %92 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %90, i32 0, i32 2
@@ -13572,8 +15281,8 @@ entry:
   %102 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %103 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %104 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %103)
-  %NullCheck48 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %102, null
-  br i1 %NullCheck48, label %105, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %102, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %105
 
 ; <label>:105                                     ; preds = %101
   %106 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %102, i32 0, i32 1
@@ -13581,8 +15290,8 @@ entry:
   %107 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %108 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %109 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %108)
-  %NullCheck50 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %107, null
-  br i1 %NullCheck50, label %110, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %107, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %110
 
 ; <label>:110                                     ; preds = %105
   %111 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %107, i32 0, i32 2
@@ -13590,8 +15299,8 @@ entry:
   %112 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %113 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %114 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %113)
-  %NullCheck52 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %112, null
-  br i1 %NullCheck52, label %115, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %112, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %115
 
 ; <label>:115                                     ; preds = %110
   %116 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %112, i32 0, i32 27
@@ -13599,8 +15308,8 @@ entry:
   %117 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %118 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %119 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %118)
-  %NullCheck54 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %117, null
-  br i1 %NullCheck54, label %120, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %117, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %120
 
 ; <label>:120                                     ; preds = %115
   %121 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %117, i32 0, i32 26
@@ -13608,8 +15317,8 @@ entry:
   %122 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %123 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %124 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %123)
-  %NullCheck56 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %122, null
-  br i1 %NullCheck56, label %125, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %122, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %125
 
 ; <label>:125                                     ; preds = %120
   %126 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %122, i32 0, i32 17
@@ -13617,8 +15326,8 @@ entry:
   %127 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %128 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %129 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %128)
-  %NullCheck58 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %127, null
-  br i1 %NullCheck58, label %130, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %127, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %130
 
 ; <label>:130                                     ; preds = %125
   %131 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %127, i32 0, i32 18
@@ -13626,8 +15335,8 @@ entry:
   %132 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %133 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %134 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %133)
-  %NullCheck60 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %132, null
-  br i1 %NullCheck60, label %135, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %132, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %135
 
 ; <label>:135                                     ; preds = %130
   %136 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %132, i32 0, i32 14
@@ -13635,8 +15344,8 @@ entry:
   %137 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %138 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %139 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %138)
-  %NullCheck62 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %137, null
-  br i1 %NullCheck62, label %140, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %137, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %140
 
 ; <label>:140                                     ; preds = %135
   %141 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %137, i32 0, i32 13
@@ -13644,71 +15353,71 @@ entry:
   %142 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %143 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %144 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %143)
-  %NullCheck64 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %142, null
-  br i1 %NullCheck64, label %145, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %142, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %145
 
 ; <label>:145                                     ; preds = %140
   %146 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %142, i32 0, i32 12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %146, %System.String addrspace(1)* %144)
   %147 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %148 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck66 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %148, null
-  br i1 %NullCheck66, label %149, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %148, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %149
 
 ; <label>:149                                     ; preds = %145
   %150 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %148, i32 0, i32 21
   %151 = load i32, i32 addrspace(1)* %150, align 8
-  %NullCheck68 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %147, null
-  br i1 %NullCheck68, label %152, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %147, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %152
 
 ; <label>:152                                     ; preds = %149
   %153 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %147, i32 0, i32 28
   store i32 %151, i32 addrspace(1)* %153
   %154 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %155 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck70 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %155, null
-  br i1 %NullCheck70, label %156, label %ThrowNullRef69
+  %NullCheck69 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %155, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %156
 
 ; <label>:156                                     ; preds = %152
   %157 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %155, i32 0, i32 6
   %158 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %157, align 8
-  %NullCheck72 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %154, null
-  br i1 %NullCheck72, label %159, label %ThrowNullRef71
+  %NullCheck71 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %154, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %159
 
 ; <label>:159                                     ; preds = %156
   %160 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %154, i32 0, i32 15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %160, %System.String addrspace(1)* %158)
   %161 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %162 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck74 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %162, null
-  br i1 %NullCheck74, label %163, label %ThrowNullRef73
+  %NullCheck73 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %162, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %163
 
 ; <label>:163                                     ; preds = %159
   %164 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %162, i32 0, i32 1
   %165 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %164, align 8
-  %NullCheck76 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %161, null
-  br i1 %NullCheck76, label %166, label %ThrowNullRef75
+  %NullCheck75 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %161, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %166
 
 ; <label>:166                                     ; preds = %163
   %167 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %161, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %167, %"System.Int32[]" addrspace(1)* %165)
   %168 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %169 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck78 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %169, null
-  br i1 %NullCheck78, label %170, label %ThrowNullRef77
+  %NullCheck77 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %169, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %170
 
 ; <label>:170                                     ; preds = %166
   %171 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %169, i32 0, i32 7
   %172 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %171, align 8
-  %NullCheck80 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %168, null
-  br i1 %NullCheck80, label %173, label %ThrowNullRef79
+  %NullCheck79 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %168, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %173
 
 ; <label>:173                                     ; preds = %170
   %174 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %168, i32 0, i32 16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %174, %System.String addrspace(1)* %172)
   %175 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck82 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %175, null
-  br i1 %NullCheck82, label %176, label %ThrowNullRef81
+  %NullCheck81 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %175, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %176
 
 ; <label>:176                                     ; preds = %173
   %177 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %175, i32 0, i32 4
@@ -13718,14 +15427,14 @@ entry:
 
 ; <label>:180                                     ; preds = %176
   %181 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck84 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %181, null
-  br i1 %NullCheck84, label %182, label %ThrowNullRef83
+  %NullCheck83 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %181, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %182
 
 ; <label>:182                                     ; preds = %180
   %183 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %181, i32 0, i32 4
   %184 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %183, align 8
-  %NullCheck86 = icmp ne %System.String addrspace(1)* %184, null
-  br i1 %NullCheck86, label %185, label %ThrowNullRef85
+  %NullCheck85 = icmp eq %System.String addrspace(1)* %184, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %185
 
 ; <label>:185                                     ; preds = %182
   %186 = getelementptr inbounds %System.String, %System.String addrspace(1)* %184, i32 0, i32 1
@@ -13736,8 +15445,8 @@ entry:
 ; <label>:189                                     ; preds = %176, %185
   %190 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck98 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %190, null
-  br i1 %NullCheck98, label %192, label %ThrowNullRef97
+  %NullCheck97 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %190, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %192
 
 ; <label>:192                                     ; preds = %189
   %193 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %190, i32 0, i32 4
@@ -13746,8 +15455,8 @@ entry:
 
 ; <label>:194                                     ; preds = %185, %192
   %195 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck88 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %195, null
-  br i1 %NullCheck88, label %196, label %ThrowNullRef87
+  %NullCheck87 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %195, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %196
 
 ; <label>:196                                     ; preds = %194
   %197 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %195, i32 0, i32 9
@@ -13757,14 +15466,14 @@ entry:
 
 ; <label>:200                                     ; preds = %196
   %201 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck90 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %201, null
-  br i1 %NullCheck90, label %202, label %ThrowNullRef89
+  %NullCheck89 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %201, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %202
 
 ; <label>:202                                     ; preds = %200
   %203 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %201, i32 0, i32 9
   %204 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %203, align 8
-  %NullCheck92 = icmp ne %System.String addrspace(1)* %204, null
-  br i1 %NullCheck92, label %205, label %ThrowNullRef91
+  %NullCheck91 = icmp eq %System.String addrspace(1)* %204, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %205
 
 ; <label>:205                                     ; preds = %202
   %206 = getelementptr inbounds %System.String, %System.String addrspace(1)* %204, i32 0, i32 1
@@ -13775,14 +15484,14 @@ entry:
 ; <label>:209                                     ; preds = %196, %205
   %210 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %211 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck94 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %211, null
-  br i1 %NullCheck94, label %212, label %ThrowNullRef93
+  %NullCheck93 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %211, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %212
 
 ; <label>:212                                     ; preds = %209
   %213 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %211, i32 0, i32 6
   %214 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %213, align 8
-  %NullCheck96 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %210, null
-  br i1 %NullCheck96, label %215, label %ThrowNullRef95
+  %NullCheck95 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %210, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %215
 
 ; <label>:215                                     ; preds = %212
   %216 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %210, i32 0, i32 9
@@ -13796,203 +15505,203 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %17
+ThrowNullRef8:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %21
+ThrowNullRef10:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %24
+ThrowNullRef12:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %28
+ThrowNullRef14:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %31
+ThrowNullRef16:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %35
+ThrowNullRef18:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %38
+ThrowNullRef20:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %42
+ThrowNullRef22:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %45
+ThrowNullRef24:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %49
+ThrowNullRef26:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %52
+ThrowNullRef28:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %56
+ThrowNullRef30:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %59
+ThrowNullRef32:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %63
+ThrowNullRef34:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %66
+ThrowNullRef36:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %70
+ThrowNullRef38:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %73
+ThrowNullRef40:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %77
+ThrowNullRef42:                                   ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %80
+ThrowNullRef44:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %84
+ThrowNullRef46:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %101
+ThrowNullRef48:                                   ; preds = %101
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %105
+ThrowNullRef50:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %110
+ThrowNullRef52:                                   ; preds = %110
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %115
+ThrowNullRef54:                                   ; preds = %115
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %120
+ThrowNullRef56:                                   ; preds = %120
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %125
+ThrowNullRef58:                                   ; preds = %125
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %130
+ThrowNullRef60:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %135
+ThrowNullRef62:                                   ; preds = %135
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %140
+ThrowNullRef64:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %145
+ThrowNullRef66:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %149
+ThrowNullRef68:                                   ; preds = %149
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %152
+ThrowNullRef70:                                   ; preds = %152
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %156
+ThrowNullRef72:                                   ; preds = %156
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %159
+ThrowNullRef74:                                   ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %163
+ThrowNullRef76:                                   ; preds = %163
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %166
+ThrowNullRef78:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %170
+ThrowNullRef80:                                   ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %173
+ThrowNullRef82:                                   ; preds = %173
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %180
+ThrowNullRef84:                                   ; preds = %180
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %182
+ThrowNullRef86:                                   ; preds = %182
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %194
+ThrowNullRef88:                                   ; preds = %194
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %200
+ThrowNullRef90:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %202
+ThrowNullRef92:                                   ; preds = %202
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %209
+ThrowNullRef94:                                   ; preds = %209
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %212
+ThrowNullRef96:                                   ; preds = %212
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %189
+ThrowNullRef98:                                   ; preds = %189
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %89
+ThrowNullRef100:                                  ; preds = %89
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14020,8 +15729,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 21
@@ -14034,8 +15743,8 @@ entry:
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 16)
   %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 21
@@ -14044,8 +15753,8 @@ entry:
 
 ; <label>:12                                      ; preds = %1, %10
   %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 21
@@ -14056,11 +15765,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %12
+ThrowNullRef4:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14076,8 +15785,8 @@ entry:
   store i32 %param1, i32* %arg1
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %1 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
@@ -14144,8 +15853,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 33
@@ -14158,8 +15867,8 @@ entry:
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 24)
   %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 33
@@ -14168,8 +15877,8 @@ entry:
 
 ; <label>:12                                      ; preds = %1, %10
   %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 33
@@ -14180,11 +15889,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %12
+ThrowNullRef4:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14197,8 +15906,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 53
@@ -14210,8 +15919,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 116)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 53
@@ -14220,8 +15929,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 53
@@ -14232,11 +15941,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14265,8 +15974,8 @@ entry:
 
 ; <label>:7                                       ; preds = %entry, %4
   %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %7
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 2
@@ -14290,8 +15999,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 54
@@ -14303,8 +16012,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 117)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
@@ -14313,8 +16022,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 54
@@ -14325,11 +16034,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14342,8 +16051,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 27
@@ -14355,8 +16064,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 118)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 27
@@ -14365,8 +16074,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 27
@@ -14377,11 +16086,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14394,8 +16103,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 28
@@ -14407,8 +16116,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 119)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 28
@@ -14417,8 +16126,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 28
@@ -14429,11 +16138,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14446,8 +16155,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 26
@@ -14459,8 +16168,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 107)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 26
@@ -14469,8 +16178,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 26
@@ -14481,11 +16190,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14498,8 +16207,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 25
@@ -14511,8 +16220,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 106)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 25
@@ -14521,8 +16230,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 25
@@ -14533,11 +16242,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14550,8 +16259,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 24
@@ -14563,8 +16272,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 105)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 24
@@ -14573,8 +16282,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 24
@@ -14585,11 +16294,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14614,8 +16323,8 @@ entry:
   %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %3)
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %2
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -14626,15 +16335,15 @@ entry:
 
 ; <label>:8                                       ; preds = %62
   %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 9
   %12 = load i32, i32 addrspace(1)* %11, align 8
   %13 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.IO.StreamWriter addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %13, i32 0, i32 10
@@ -14649,15 +16358,15 @@ entry:
 
 ; <label>:20                                      ; preds = %14, %18
   %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
   %24 = load i32, i32 addrspace(1)* %23, align 8
   %25 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %25, null
-  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.StreamWriter addrspace(1)* %25, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %25, i32 0, i32 9
@@ -14678,36 +16387,36 @@ entry:
   %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %37 = load i32, i32* %loc1
   %38 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.StreamWriter addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %35
   %40 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %38, i32 0, i32 7
   %41 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %40, align 8
   %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
-  br i1 %NullCheck14, label %43, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %39
   %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 9
   %45 = load i32, i32 addrspace(1)* %44, align 8
   %46 = load i32, i32* %loc2
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %36, null
-  br i1 %NullCheck16, label %47, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %36, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %47
 
 ; <label>:47                                      ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %36, i32 %37, %"System.Char[]" addrspace(1)* %41, i32 %45, i32 %46)
   %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
   %51 = load i32, i32 addrspace(1)* %50, align 8
   %52 = load i32, i32* %loc2
   %53 = add i32 %51, %52
-  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
-  br i1 %NullCheck20, label %54, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %54
 
 ; <label>:54                                      ; preds = %49
   %55 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
@@ -14729,8 +16438,8 @@ entry:
 
 ; <label>:65                                      ; preds = %62
   %66 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %66, null
-  br i1 %NullCheck2, label %67, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %66, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %67
 
 ; <label>:67                                      ; preds = %65
   %68 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %66, i32 0, i32 11
@@ -14751,49 +16460,259 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %65
+ThrowNullRef2:                                    ; preds = %65
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %20
+ThrowNullRef8:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %22
+ThrowNullRef10:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %35
+ThrowNullRef12:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %43
+ThrowNullRef16:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %47
+ThrowNullRef18:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method String::CopyTo using LLILCJit
-Failed to read String.CopyTo[loadElemA]
+Successfully read String.CopyTo
+
+define void @String.CopyTo(%System.String addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  %loc1 = alloca i16 addrspace(1)*
+  %loc2 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %1 = icmp ne %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg4
+  %7 = icmp sge i32 %6, 0
+  br i1 %7, label %13, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  unreachable
+
+; <label>:13                                      ; preds = %5
+  %14 = load i32, i32* %arg1
+  %15 = icmp sge i32 %14, 0
+  br i1 %15, label %21, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %18)
+  %20 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %20, %System.String addrspace(1)* %17, %System.String addrspace(1)* %19)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %20) #0
+  unreachable
+
+; <label>:21                                      ; preds = %13
+  %22 = load i32, i32* %arg4
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck, label %ThrowNullRef, label %24
+
+; <label>:24                                      ; preds = %21
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load i32, i32* %arg1
+  %28 = sub i32 %26, %27
+  %29 = icmp sle i32 %22, %28
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34, %System.String addrspace(1)* %31, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %24
+  %36 = load i32, i32* %arg3
+  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %37, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
+
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
+  %40 = load i32, i32 addrspace(1)* %39
+  %41 = zext i32 %40 to i64
+  %42 = trunc i64 %41 to i32
+  %43 = load i32, i32* %arg4
+  %44 = sub i32 %42, %43
+  %45 = icmp sgt i32 %36, %44
+  br i1 %45, label %49, label %46
+
+; <label>:46                                      ; preds = %38
+  %47 = load i32, i32* %arg3
+  %48 = icmp sge i32 %47, 0
+  br i1 %48, label %54, label %49
+
+; <label>:49                                      ; preds = %38, %46
+  %50 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %52 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %51)
+  %53 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53, %System.String addrspace(1)* %50, %System.String addrspace(1)* %52)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53) #0
+  unreachable
+
+; <label>:54                                      ; preds = %46
+  %55 = load i32, i32* %arg4
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %97, label %57
+
+; <label>:57                                      ; preds = %54
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %59
+
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 2
+  %61 = bitcast [0 x i16] addrspace(1)* %60 to i16 addrspace(1)*
+  store i16 addrspace(1)* %61, i16 addrspace(1)** %loc0
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  store %"System.Char[]" addrspace(1)* %62, %"System.Char[]" addrspace(1)** %loc2
+  %63 = icmp eq %"System.Char[]" addrspace(1)* %62, null
+  br i1 %63, label %72, label %64
+
+; <label>:64                                      ; preds = %59
+  %65 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc2
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %65, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %66
+
+; <label>:66                                      ; preds = %64
+  %67 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %65, i32 0, i32 1
+  %68 = load i32, i32 addrspace(1)* %67
+  %69 = zext i32 %68 to i64
+  %70 = trunc i64 %69 to i32
+  %71 = icmp ne i32 %70, 0
+  br i1 %71, label %73, label %72
+
+; <label>:72                                      ; preds = %59, %66
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  br label %81
+
+; <label>:73                                      ; preds = %66
+  %74 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc2
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %74, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %75
+
+; <label>:75                                      ; preds = %73
+  %76 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %74, i32 0, i32 1
+  %77 = load i32, i32 addrspace(1)* %76
+  %78 = zext i32 %77 to i64
+  %BoundsCheck = icmp uge i64 0, %78
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %79
+
+; <label>:79                                      ; preds = %75
+  %80 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %74, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %80, i16 addrspace(1)** %loc1
+  br label %81
+
+; <label>:81                                      ; preds = %72, %79
+  %82 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %83 = ptrtoint i16 addrspace(1)* %82 to i64
+  %84 = load i32, i32* %arg3
+  %85 = sext i32 %84 to i64
+  %86 = mul i64 %85, 2
+  %87 = add i64 %83, %86
+  %88 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %89 = ptrtoint i16 addrspace(1)* %88 to i64
+  %90 = load i32, i32* %arg1
+  %91 = sext i32 %90 to i64
+  %92 = mul i64 %91, 2
+  %93 = add i64 %89, %92
+  %94 = load i32, i32* %arg4
+  %95 = inttoptr i64 %87 to i16*
+  %96 = inttoptr i64 %93 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %95, i16* %96, i32 %94)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  br label %97
+
+; <label>:97                                      ; preds = %54, %81
+  ret void
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
 Successfully read ConsoleEncoding.GetPreamble
 
@@ -14830,7 +16749,365 @@ entry:
 }
 
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[loadElemA]
+Successfully read EncoderNLS.GetBytes
+
+define i32 @EncoderNLS.GetBytes(%System.Text.EncoderNLS addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3, %"System.Byte[]" addrspace(1)* %param4, i32 %param5, i8 %param6) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %arg4 = alloca %"System.Byte[]" addrspace(1)*
+  %arg5 = alloca i32
+  %arg6 = alloca i8
+  %loc0 = alloca i32
+  %loc1 = alloca i16 addrspace(1)*
+  %loc2 = alloca i8 addrspace(1)*
+  %loc3 = alloca i32
+  %loc4 = alloca %"System.Char[]" addrspace(1)*
+  %loc5 = alloca %"System.Byte[]" addrspace(1)*
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  store %"System.Byte[]" addrspace(1)* %param4, %"System.Byte[]" addrspace(1)** %arg4
+  store i32 %param5, i32* %arg5
+  store i8 %param6, i8* %arg6
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %1 = icmp eq %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %17, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %7 = icmp eq %"System.Char[]" addrspace(1)* %6, null
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %12
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %12
+
+; <label>:12                                      ; preds = %8, %10
+  %13 = phi %System.String addrspace(1)* [ %9, %8 ], [ %11, %10 ]
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %14)
+  %16 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16, %System.String addrspace(1)* %13, %System.String addrspace(1)* %15)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16) #0
+  unreachable
+
+; <label>:17                                      ; preds = %2
+  %18 = load i32, i32* %arg2
+  %19 = icmp slt i32 %18, 0
+  br i1 %19, label %23, label %20
+
+; <label>:20                                      ; preds = %17
+  %21 = load i32, i32* %arg3
+  %22 = icmp sge i32 %21, 0
+  br i1 %22, label %35, label %23
+
+; <label>:23                                      ; preds = %17, %20
+  %24 = load i32, i32* %arg2
+  %25 = icmp slt i32 %24, 0
+  br i1 %25, label %28, label %26
+
+; <label>:26                                      ; preds = %23
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %30
+
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %30
+
+; <label>:30                                      ; preds = %26, %28
+  %31 = phi %System.String addrspace(1)* [ %27, %26 ], [ %29, %28 ]
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34, %System.String addrspace(1)* %31, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %20
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck, label %ThrowNullRef, label %37
+
+; <label>:37                                      ; preds = %35
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = load i32, i32* %arg2
+  %43 = sub i32 %41, %42
+  %44 = load i32, i32* %arg3
+  %45 = icmp sge i32 %43, %44
+  br i1 %45, label %51, label %46
+
+; <label>:46                                      ; preds = %37
+  %47 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %48 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %49 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %48)
+  %50 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %50, %System.String addrspace(1)* %47, %System.String addrspace(1)* %49)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %50) #0
+  unreachable
+
+; <label>:51                                      ; preds = %37
+  %52 = load i32, i32* %arg5
+  %53 = icmp slt i32 %52, 0
+  br i1 %53, label %63, label %54
+
+; <label>:54                                      ; preds = %51
+  %55 = load i32, i32* %arg5
+  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck1 = icmp eq %"System.Byte[]" addrspace(1)* %56, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %57
+
+; <label>:57                                      ; preds = %54
+  %58 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = zext i32 %59 to i64
+  %61 = trunc i64 %60 to i32
+  %62 = icmp sle i32 %55, %61
+  br i1 %62, label %68, label %63
+
+; <label>:63                                      ; preds = %51, %57
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %66 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %65)
+  %67 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %67, %System.String addrspace(1)* %64, %System.String addrspace(1)* %66)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %67) #0
+  unreachable
+
+; <label>:68                                      ; preds = %57
+  %69 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %69, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %69, i32 0, i32 1
+  %72 = load i32, i32 addrspace(1)* %71
+  %73 = zext i32 %72 to i64
+  %74 = trunc i64 %73 to i32
+  %75 = icmp ne i32 %74, 0
+  br i1 %75, label %78, label %76
+
+; <label>:76                                      ; preds = %70
+  %77 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1)
+  store %"System.Char[]" addrspace(1)* %77, %"System.Char[]" addrspace(1)** %arg1
+  br label %78
+
+; <label>:78                                      ; preds = %70, %76
+  %79 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck5 = icmp eq %"System.Byte[]" addrspace(1)* %79, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %80
+
+; <label>:80                                      ; preds = %78
+  %81 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %79, i32 0, i32 1
+  %82 = load i32, i32 addrspace(1)* %81
+  %83 = zext i32 %82 to i64
+  %84 = trunc i64 %83 to i32
+  %85 = load i32, i32* %arg5
+  %86 = sub i32 %84, %85
+  store i32 %86, i32* %loc0
+  %87 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck7 = icmp eq %"System.Byte[]" addrspace(1)* %87, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %88
+
+; <label>:88                                      ; preds = %80
+  %89 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %87, i32 0, i32 1
+  %90 = load i32, i32 addrspace(1)* %89
+  %91 = zext i32 %90 to i64
+  %92 = trunc i64 %91 to i32
+  %93 = icmp ne i32 %92, 0
+  br i1 %93, label %96, label %94
+
+; <label>:94                                      ; preds = %88
+  %95 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1)
+  store %"System.Byte[]" addrspace(1)* %95, %"System.Byte[]" addrspace(1)** %arg4
+  br label %96
+
+; <label>:96                                      ; preds = %88, %94
+  %97 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  store %"System.Char[]" addrspace(1)* %97, %"System.Char[]" addrspace(1)** %loc4
+  %98 = icmp eq %"System.Char[]" addrspace(1)* %97, null
+  br i1 %98, label %107, label %99
+
+; <label>:99                                      ; preds = %96
+  %100 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc4
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %100, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %101
+
+; <label>:101                                     ; preds = %99
+  %102 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %100, i32 0, i32 1
+  %103 = load i32, i32 addrspace(1)* %102
+  %104 = zext i32 %103 to i64
+  %105 = trunc i64 %104 to i32
+  %106 = icmp ne i32 %105, 0
+  br i1 %106, label %108, label %107
+
+; <label>:107                                     ; preds = %96, %101
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  br label %116
+
+; <label>:108                                     ; preds = %101
+  %109 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc4
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %109, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %110
+
+; <label>:110                                     ; preds = %108
+  %111 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %109, i32 0, i32 1
+  %112 = load i32, i32 addrspace(1)* %111
+  %113 = zext i32 %112 to i64
+  %BoundsCheck = icmp uge i64 0, %113
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %114
+
+; <label>:114                                     ; preds = %110
+  %115 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %109, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %115, i16 addrspace(1)** %loc1
+  br label %116
+
+; <label>:116                                     ; preds = %107, %114
+  %117 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  store %"System.Byte[]" addrspace(1)* %117, %"System.Byte[]" addrspace(1)** %loc5
+  %118 = icmp eq %"System.Byte[]" addrspace(1)* %117, null
+  br i1 %118, label %127, label %119
+
+; <label>:119                                     ; preds = %116
+  %120 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc5
+  %NullCheck13 = icmp eq %"System.Byte[]" addrspace(1)* %120, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %121
+
+; <label>:121                                     ; preds = %119
+  %122 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %120, i32 0, i32 1
+  %123 = load i32, i32 addrspace(1)* %122
+  %124 = zext i32 %123 to i64
+  %125 = trunc i64 %124 to i32
+  %126 = icmp ne i32 %125, 0
+  br i1 %126, label %128, label %127
+
+; <label>:127                                     ; preds = %116, %121
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc2
+  br label %136
+
+; <label>:128                                     ; preds = %121
+  %129 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc5
+  %NullCheck15 = icmp eq %"System.Byte[]" addrspace(1)* %129, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %130
+
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %129, i32 0, i32 1
+  %132 = load i32, i32 addrspace(1)* %131
+  %133 = zext i32 %132 to i64
+  %BoundsCheck17 = icmp uge i64 0, %133
+  br i1 %BoundsCheck17, label %ThrowIndexOutOfRange18, label %134
+
+; <label>:134                                     ; preds = %130
+  %135 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %129, i32 0, i32 3, i32 0
+  store i8 addrspace(1)* %135, i8 addrspace(1)** %loc2
+  br label %136
+
+; <label>:136                                     ; preds = %127, %134
+  %137 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %138 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %139 = ptrtoint i16 addrspace(1)* %138 to i64
+  %140 = load i32, i32* %arg2
+  %141 = sext i32 %140 to i64
+  %142 = mul i64 %141, 2
+  %143 = add i64 %139, %142
+  %144 = load i32, i32* %arg3
+  %145 = load i8 addrspace(1)*, i8 addrspace(1)** %loc2
+  %146 = ptrtoint i8 addrspace(1)* %145 to i64
+  %147 = load i32, i32* %arg5
+  %148 = sext i32 %147 to i64
+  %149 = add i64 %146, %148
+  %150 = load i32, i32* %loc0
+  %151 = load i8, i8* %arg6
+  %152 = zext i8 %151 to i32
+  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i64 addrspace(1)*
+  %NullCheck19 = icmp eq i64 addrspace(1)* %153, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %154
+
+; <label>:154                                     ; preds = %136
+  %155 = load i64, i64 addrspace(1)* %153
+  %156 = add i64 %155, 72
+  %157 = inttoptr i64 %156 to i64*
+  %158 = load i64, i64* %157
+  %159 = add i64 %158, 0
+  %160 = inttoptr i64 %159 to i64*
+  %161 = load i64, i64* %160
+  %162 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to %System.Text.Encoder addrspace(1)*
+  %163 = inttoptr i64 %143 to i16*
+  %164 = inttoptr i64 %149 to i8*
+  %165 = trunc i32 %152 to i8
+  %166 = inttoptr i64 %161 to i32 (%System.Text.Encoder addrspace(1)*, i16*, i32, i8*, i32, i8)*
+  %167 = call i32 %166(%System.Text.Encoder addrspace(1)* %162, i16* %163, i32 %144, i8* %164, i32 %150, i8 %165)
+  store i32 %167, i32* %loc3
+  br label %168
+
+; <label>:168                                     ; preds = %154
+  %169 = load i32, i32* %loc3
+  ret i32 %169
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %110
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %119
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange18:                           ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
 Successfully read EncoderNLS.GetBytes
 
@@ -14919,22 +17196,22 @@ entry:
   %40 = load i8, i8* %arg5
   %41 = zext i8 %40 to i32
   %42 = trunc i32 %41 to i8
-  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %39, null
-  br i1 %NullCheck, label %43, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderNLS addrspace(1)* %39, null
+  br i1 %NullCheck, label %ThrowNullRef, label %43
 
 ; <label>:43                                      ; preds = %38
   %44 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
   store i8 %42, i8 addrspace(1)* %44
   %45 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %45, null
-  br i1 %NullCheck2, label %46, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.EncoderNLS addrspace(1)* %45, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %46
 
 ; <label>:46                                      ; preds = %43
   %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %45, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %47
   %48 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.EncoderNLS addrspace(1)* %48, null
-  br i1 %NullCheck4, label %49, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.EncoderNLS addrspace(1)* %48, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %49
 
 ; <label>:49                                      ; preds = %46
   %50 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %48, i32 0, i32 3
@@ -14945,8 +17222,8 @@ entry:
   %55 = load i32, i32* %arg4
   %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck6, label %58, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
   %59 = load i64, i64 addrspace(1)* %57
@@ -14964,15 +17241,15 @@ ThrowNullRef:                                     ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %43
+ThrowNullRef2:                                    ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %46
+ThrowNullRef4:                                    ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %49
+ThrowNullRef6:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -15000,8 +17277,8 @@ entry:
   %4 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0 to %System.IO.ConsoleStream addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*)(%System.IO.ConsoleStream addrspace(1)* %4, %"System.Byte[]" addrspace(1)* %1, i32 %2, i32 %3)
   %5 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
@@ -15086,8 +17363,8 @@ entry:
 
 ; <label>:22                                      ; preds = %8
   %23 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %23, null
-  br i1 %NullCheck, label %24, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Byte[]" addrspace(1)* %23, null
+  br i1 %NullCheck, label %ThrowNullRef, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
@@ -15109,8 +17386,8 @@ entry:
 
 ; <label>:36                                      ; preds = %24
   %37 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %37, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.ConsoleStream addrspace(1)* %37, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %37, i32 0, i32 4
@@ -15131,13 +17408,138 @@ ThrowNullRef:                                     ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %36
+ThrowNullRef2:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
-Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
+Successfully read WindowsConsoleStream.WriteFileNative
+
+define i32 @WindowsConsoleStream.WriteFileNative(i64 %param0, %"System.Byte[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i64
+  %arg1 = alloca %"System.Byte[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i8 addrspace(1)*
+  %loc2 = alloca %"System.Byte[]" addrspace(1)*
+  %loc3 = alloca i32
+  store i64 %param0, i64* %arg0
+  store %"System.Byte[]" addrspace(1)* %param1, %"System.Byte[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Byte[]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = zext i32 %3 to i64
+  %5 = icmp ne i64 %4, 0
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %1
+  ret i32 0
+
+; <label>:7                                       ; preds = %1
+  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  store %"System.Byte[]" addrspace(1)* %8, %"System.Byte[]" addrspace(1)** %loc2
+  %9 = icmp eq %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %9, label %18, label %10
+
+; <label>:10                                      ; preds = %7
+  %11 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc2
+  %NullCheck1 = icmp eq %"System.Byte[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %11, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp ne i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %7, %12
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc1
+  br label %27
+
+; <label>:19                                      ; preds = %12
+  %20 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc2
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %20, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %BoundsCheck = icmp uge i64 0, %24
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %25
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %20, i32 0, i32 3, i32 0
+  store i8 addrspace(1)* %26, i8 addrspace(1)** %loc1
+  br label %27
+
+; <label>:27                                      ; preds = %18, %25
+  %28 = load i64, i64* %arg0
+  %29 = load i8 addrspace(1)*, i8 addrspace(1)** %loc1
+  %30 = ptrtoint i8 addrspace(1)* %29 to i64
+  %31 = load i32, i32* %arg2
+  %32 = sext i32 %31 to i64
+  %33 = add i64 %30, %32
+  %34 = load i32, i32* %arg3
+  %35 = addrspacecast i32* %loc3 to i32 addrspace(1)*
+  %36 = inttoptr i64 %33 to i8*
+  %37 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i8*, i32, i32 addrspace(1)*, i64)*)(i64 %28, i8* %36, i32 %34, i32 addrspace(1)* %35, i64 0)
+  %38 = icmp ugt i32 %37, 0
+  %39 = sext i1 %38 to i32
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc1
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %42, label %41
+
+; <label>:41                                      ; preds = %27
+  ret i32 0
+
+; <label>:42                                      ; preds = %27
+  %43 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  store i32 %43, i32* %loc0
+  %44 = load i32, i32* %loc0
+  %45 = icmp eq i32 %44, 232
+  br i1 %45, label %49, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = load i32, i32* %loc0
+  %48 = icmp ne i32 %47, 109
+  br i1 %48, label %50, label %49
+
+; <label>:49                                      ; preds = %42, %46
+  ret i32 0
+
+; <label>:50                                      ; preds = %46
+  %51 = load i32, i32* %loc0
+  ret i32 %51
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
 Successfully read WindowsConsoleStream.Flush
 
@@ -15146,8 +17548,8 @@ entry:
   %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
   store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
@@ -15182,8 +17584,8 @@ entry:
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
   %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load i64, i64 addrspace(1)* %1
@@ -15222,15 +17624,15 @@ entry:
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.TextWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
   %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %3, align 8
   %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
   %7 = load i64, i64 addrspace(1)* %5
@@ -15248,7 +17650,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -15277,8 +17679,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %4)
   store i32 0, i32* %loc0
   %5 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Char[]" addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
@@ -15290,15 +17692,15 @@ entry:
 
 ; <label>:11                                      ; preds = %69
   %12 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %12, i32 0, i32 9
   %15 = load i32, i32 addrspace(1)* %14, align 8
   %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.IO.StreamWriter addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %16, i32 0, i32 10
@@ -15313,15 +17715,15 @@ entry:
 
 ; <label>:23                                      ; preds = %17, %21
   %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %24, null
-  br i1 %NullCheck8, label %25, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %24, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 10
   %27 = load i32, i32 addrspace(1)* %26, align 8
   %28 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %28, null
-  br i1 %NullCheck10, label %29, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.StreamWriter addrspace(1)* %28, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %28, i32 0, i32 9
@@ -15343,15 +17745,15 @@ entry:
   %40 = load i32, i32* %loc0
   %41 = mul i32 %40, 2
   %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
-  br i1 %NullCheck12, label %43, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %43
 
 ; <label>:43                                      ; preds = %38
   %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 7
   %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %44, align 8
   %46 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %46, null
-  br i1 %NullCheck14, label %47, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.IO.StreamWriter addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %47
 
 ; <label>:47                                      ; preds = %43
   %48 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %46, i32 0, i32 9
@@ -15363,16 +17765,16 @@ entry:
   %54 = bitcast %"System.Char[]" addrspace(1)* %45 to %System.Array addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %53, i32 %41, %System.Array addrspace(1)* %54, i32 %50, i32 %52)
   %55 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
-  br i1 %NullCheck16, label %56, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %56
 
 ; <label>:56                                      ; preds = %47
   %57 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
   %58 = load i32, i32 addrspace(1)* %57, align 8
   %59 = load i32, i32* %loc2
   %60 = add i32 %58, %59
-  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
-  br i1 %NullCheck18, label %61, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %61
 
 ; <label>:61                                      ; preds = %56
   %62 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
@@ -15394,8 +17796,8 @@ entry:
 
 ; <label>:72                                      ; preds = %69
   %73 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %73, null
-  br i1 %NullCheck2, label %74, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %73, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %74
 
 ; <label>:74                                      ; preds = %72
   %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %73, i32 0, i32 11
@@ -15416,39 +17818,39 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %72
+ThrowNullRef2:                                    ; preds = %72
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %23
+ThrowNullRef8:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef10:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %43
+ThrowNullRef14:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %47
+ThrowNullRef16:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %56
+ThrowNullRef18:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPSubConst.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPSubConst.error.txt
@@ -25,8 +25,8 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
@@ -40,8 +40,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
   %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
@@ -75,7 +75,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -90,8 +90,8 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %NullCheck = icmp ne i8 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = load i8, i8 addrspace(1)* %0, align 8
@@ -125,8 +125,8 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
@@ -159,8 +159,8 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -184,8 +184,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
   store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
@@ -195,8 +195,8 @@ entry:
 ; <label>:4                                       ; preds = %1
   %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
   %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
@@ -206,8 +206,8 @@ entry:
   %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
@@ -221,14 +221,14 @@ entry:
 
 ; <label>:17                                      ; preds = %14
   %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
   %21 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
@@ -238,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -249,8 +249,8 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
@@ -261,27 +261,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %30
+ThrowNullRef10:                                   ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -301,7 +301,89 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
-Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
+Successfully read AppDomainSetup.GetUnsecureApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.GetUnsecureApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %NullCheck = icmp eq %"System.String[]" addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %BoundsCheck = icmp uge i64 0, %5
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %6
+
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 3, i32 0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
+  ret %System.String addrspace(1)* %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_Value using LLILCJit
+Successfully read AppDomainSetup.get_Value
+
+define %"System.String[]" addrspace(1)* @AppDomainSetup.get_Value(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.String[]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 18)
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.String[]" addrspace(1)* addrspace(1)*, %"System.String[]" addrspace(1)*)*)(%"System.String[]" addrspace(1)* addrspace(1)* %9, %"System.String[]" addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %11, i32 0, i32 1
+  %14 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %13, align 8
+  ret %"System.String[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -319,8 +401,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -368,16 +450,16 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
   %5 = load i32, i32 addrspace(1)* %4
   %6 = sub i32 %5, 1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -389,7 +471,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -421,8 +503,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
@@ -456,8 +538,8 @@ entry:
 ; <label>:27                                      ; preds = %19
   %28 = load i32, i32* %arg1
   %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
-  br i1 %NullCheck2, label %30, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %29, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %30
 
 ; <label>:30                                      ; preds = %27
   %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
@@ -493,8 +575,8 @@ entry:
 ; <label>:49                                      ; preds = %46
   %50 = load i32, i32* %arg2
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck4, label %52, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
@@ -517,11 +599,11 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %27
+ThrowNullRef2:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %49
+ThrowNullRef4:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -544,16 +626,16 @@ entry:
   %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %0)
   store %System.String addrspace(1)* %1, %System.String addrspace(1)** %loc0
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 2
   %5 = bitcast [0 x i16] addrspace(1)* %4 to i16 addrspace(1)*
   store i16 addrspace(1)* %5, i16 addrspace(1)** %loc1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %3
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2
@@ -580,7 +662,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -691,15 +773,15 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %NullCheck132 = icmp ne i8* %21, null
-  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+  %NullCheck131 = icmp eq i8* %21, null
+  br i1 %NullCheck131, label %ThrowNullRef132, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = load i8, i8* %21, align 8
   %24 = zext i8 %23 to i32
   %25 = trunc i32 %24 to i8
-  %NullCheck134 = icmp ne i8* %20, null
-  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+  %NullCheck133 = icmp eq i8* %20, null
+  br i1 %NullCheck133, label %ThrowNullRef134, label %26
 
 ; <label>:26                                      ; preds = %22
   store i8 %25, i8* %20, align 8
@@ -709,16 +791,16 @@ entry:
   %28 = load i8*, i8** %arg0
   %29 = load i8*, i8** %arg1
   %30 = bitcast i8* %29 to i16*
-  %NullCheck128 = icmp ne i16* %30, null
-  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+  %NullCheck127 = icmp eq i16* %30, null
+  br i1 %NullCheck127, label %ThrowNullRef128, label %31
 
 ; <label>:31                                      ; preds = %27
   %32 = load i16, i16* %30, align 8
   %33 = sext i16 %32 to i32
   %34 = bitcast i8* %28 to i16*
   %35 = trunc i32 %33 to i16
-  %NullCheck130 = icmp ne i16* %34, null
-  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+  %NullCheck129 = icmp eq i16* %34, null
+  br i1 %NullCheck129, label %ThrowNullRef130, label %36
 
 ; <label>:36                                      ; preds = %31
   store i16 %35, i16* %34, align 8
@@ -728,16 +810,16 @@ entry:
   %38 = load i8*, i8** %arg0
   %39 = load i8*, i8** %arg1
   %40 = bitcast i8* %39 to i16*
-  %NullCheck120 = icmp ne i16* %40, null
-  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+  %NullCheck119 = icmp eq i16* %40, null
+  br i1 %NullCheck119, label %ThrowNullRef120, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i16, i16* %40, align 8
   %43 = sext i16 %42 to i32
   %44 = bitcast i8* %38 to i16*
   %45 = trunc i32 %43 to i16
-  %NullCheck122 = icmp ne i16* %44, null
-  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+  %NullCheck121 = icmp eq i16* %44, null
+  br i1 %NullCheck121, label %ThrowNullRef122, label %46
 
 ; <label>:46                                      ; preds = %41
   store i16 %45, i16* %44, align 8
@@ -745,15 +827,15 @@ entry:
   %48 = getelementptr inbounds i8, i8* %47, i64 2
   %49 = load i8*, i8** %arg1
   %50 = getelementptr inbounds i8, i8* %49, i64 2
-  %NullCheck124 = icmp ne i8* %50, null
-  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+  %NullCheck123 = icmp eq i8* %50, null
+  br i1 %NullCheck123, label %ThrowNullRef124, label %51
 
 ; <label>:51                                      ; preds = %46
   %52 = load i8, i8* %50, align 8
   %53 = zext i8 %52 to i32
   %54 = trunc i32 %53 to i8
-  %NullCheck126 = icmp ne i8* %48, null
-  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+  %NullCheck125 = icmp eq i8* %48, null
+  br i1 %NullCheck125, label %ThrowNullRef126, label %55
 
 ; <label>:55                                      ; preds = %51
   store i8 %54, i8* %48, align 8
@@ -763,14 +845,14 @@ entry:
   %57 = load i8*, i8** %arg0
   %58 = load i8*, i8** %arg1
   %59 = bitcast i8* %58 to i32*
-  %NullCheck116 = icmp ne i32* %59, null
-  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+  %NullCheck115 = icmp eq i32* %59, null
+  br i1 %NullCheck115, label %ThrowNullRef116, label %60
 
 ; <label>:60                                      ; preds = %56
   %61 = load i32, i32* %59, align 8
   %62 = bitcast i8* %57 to i32*
-  %NullCheck118 = icmp ne i32* %62, null
-  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+  %NullCheck117 = icmp eq i32* %62, null
+  br i1 %NullCheck117, label %ThrowNullRef118, label %63
 
 ; <label>:63                                      ; preds = %60
   store i32 %61, i32* %62, align 8
@@ -780,14 +862,14 @@ entry:
   %65 = load i8*, i8** %arg0
   %66 = load i8*, i8** %arg1
   %67 = bitcast i8* %66 to i32*
-  %NullCheck108 = icmp ne i32* %67, null
-  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+  %NullCheck107 = icmp eq i32* %67, null
+  br i1 %NullCheck107, label %ThrowNullRef108, label %68
 
 ; <label>:68                                      ; preds = %64
   %69 = load i32, i32* %67, align 8
   %70 = bitcast i8* %65 to i32*
-  %NullCheck110 = icmp ne i32* %70, null
-  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+  %NullCheck109 = icmp eq i32* %70, null
+  br i1 %NullCheck109, label %ThrowNullRef110, label %71
 
 ; <label>:71                                      ; preds = %68
   store i32 %69, i32* %70, align 8
@@ -795,15 +877,15 @@ entry:
   %73 = getelementptr inbounds i8, i8* %72, i64 4
   %74 = load i8*, i8** %arg1
   %75 = getelementptr inbounds i8, i8* %74, i64 4
-  %NullCheck112 = icmp ne i8* %75, null
-  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+  %NullCheck111 = icmp eq i8* %75, null
+  br i1 %NullCheck111, label %ThrowNullRef112, label %76
 
 ; <label>:76                                      ; preds = %71
   %77 = load i8, i8* %75, align 8
   %78 = zext i8 %77 to i32
   %79 = trunc i32 %78 to i8
-  %NullCheck114 = icmp ne i8* %73, null
-  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+  %NullCheck113 = icmp eq i8* %73, null
+  br i1 %NullCheck113, label %ThrowNullRef114, label %80
 
 ; <label>:80                                      ; preds = %76
   store i8 %79, i8* %73, align 8
@@ -813,14 +895,14 @@ entry:
   %82 = load i8*, i8** %arg0
   %83 = load i8*, i8** %arg1
   %84 = bitcast i8* %83 to i32*
-  %NullCheck100 = icmp ne i32* %84, null
-  br i1 %NullCheck100, label %85, label %ThrowNullRef99
+  %NullCheck99 = icmp eq i32* %84, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %85
 
 ; <label>:85                                      ; preds = %81
   %86 = load i32, i32* %84, align 8
   %87 = bitcast i8* %82 to i32*
-  %NullCheck102 = icmp ne i32* %87, null
-  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+  %NullCheck101 = icmp eq i32* %87, null
+  br i1 %NullCheck101, label %ThrowNullRef102, label %88
 
 ; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
@@ -829,16 +911,16 @@ entry:
   %91 = load i8*, i8** %arg1
   %92 = getelementptr inbounds i8, i8* %91, i64 4
   %93 = bitcast i8* %92 to i16*
-  %NullCheck104 = icmp ne i16* %93, null
-  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+  %NullCheck103 = icmp eq i16* %93, null
+  br i1 %NullCheck103, label %ThrowNullRef104, label %94
 
 ; <label>:94                                      ; preds = %88
   %95 = load i16, i16* %93, align 8
   %96 = sext i16 %95 to i32
   %97 = bitcast i8* %90 to i16*
   %98 = trunc i32 %96 to i16
-  %NullCheck106 = icmp ne i16* %97, null
-  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+  %NullCheck105 = icmp eq i16* %97, null
+  br i1 %NullCheck105, label %ThrowNullRef106, label %99
 
 ; <label>:99                                      ; preds = %94
   store i16 %98, i16* %97, align 8
@@ -848,14 +930,14 @@ entry:
   %101 = load i8*, i8** %arg0
   %102 = load i8*, i8** %arg1
   %103 = bitcast i8* %102 to i32*
-  %NullCheck88 = icmp ne i32* %103, null
-  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+  %NullCheck87 = icmp eq i32* %103, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %104
 
 ; <label>:104                                     ; preds = %100
   %105 = load i32, i32* %103, align 8
   %106 = bitcast i8* %101 to i32*
-  %NullCheck90 = icmp ne i32* %106, null
-  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+  %NullCheck89 = icmp eq i32* %106, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %107
 
 ; <label>:107                                     ; preds = %104
   store i32 %105, i32* %106, align 8
@@ -864,16 +946,16 @@ entry:
   %110 = load i8*, i8** %arg1
   %111 = getelementptr inbounds i8, i8* %110, i64 4
   %112 = bitcast i8* %111 to i16*
-  %NullCheck92 = icmp ne i16* %112, null
-  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+  %NullCheck91 = icmp eq i16* %112, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %113
 
 ; <label>:113                                     ; preds = %107
   %114 = load i16, i16* %112, align 8
   %115 = sext i16 %114 to i32
   %116 = bitcast i8* %109 to i16*
   %117 = trunc i32 %115 to i16
-  %NullCheck94 = icmp ne i16* %116, null
-  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+  %NullCheck93 = icmp eq i16* %116, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %118
 
 ; <label>:118                                     ; preds = %113
   store i16 %117, i16* %116, align 8
@@ -881,15 +963,15 @@ entry:
   %120 = getelementptr inbounds i8, i8* %119, i64 6
   %121 = load i8*, i8** %arg1
   %122 = getelementptr inbounds i8, i8* %121, i64 6
-  %NullCheck96 = icmp ne i8* %122, null
-  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+  %NullCheck95 = icmp eq i8* %122, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %123
 
 ; <label>:123                                     ; preds = %118
   %124 = load i8, i8* %122, align 8
   %125 = zext i8 %124 to i32
   %126 = trunc i32 %125 to i8
-  %NullCheck98 = icmp ne i8* %120, null
-  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+  %NullCheck97 = icmp eq i8* %120, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %127
 
 ; <label>:127                                     ; preds = %123
   store i8 %126, i8* %120, align 8
@@ -899,14 +981,14 @@ entry:
   %129 = load i8*, i8** %arg0
   %130 = load i8*, i8** %arg1
   %131 = bitcast i8* %130 to i64*
-  %NullCheck84 = icmp ne i64* %131, null
-  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+  %NullCheck83 = icmp eq i64* %131, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %132
 
 ; <label>:132                                     ; preds = %128
   %133 = load i64, i64* %131, align 8
   %134 = bitcast i8* %129 to i64*
-  %NullCheck86 = icmp ne i64* %134, null
-  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+  %NullCheck85 = icmp eq i64* %134, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %135
 
 ; <label>:135                                     ; preds = %132
   store i64 %133, i64* %134, align 8
@@ -916,14 +998,14 @@ entry:
   %137 = load i8*, i8** %arg0
   %138 = load i8*, i8** %arg1
   %139 = bitcast i8* %138 to i64*
-  %NullCheck76 = icmp ne i64* %139, null
-  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+  %NullCheck75 = icmp eq i64* %139, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %140
 
 ; <label>:140                                     ; preds = %136
   %141 = load i64, i64* %139, align 8
   %142 = bitcast i8* %137 to i64*
-  %NullCheck78 = icmp ne i64* %142, null
-  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+  %NullCheck77 = icmp eq i64* %142, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %143
 
 ; <label>:143                                     ; preds = %140
   store i64 %141, i64* %142, align 8
@@ -931,15 +1013,15 @@ entry:
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %NullCheck80 = icmp ne i8* %147, null
-  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+  %NullCheck79 = icmp eq i8* %147, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %148
 
 ; <label>:148                                     ; preds = %143
   %149 = load i8, i8* %147, align 8
   %150 = zext i8 %149 to i32
   %151 = trunc i32 %150 to i8
-  %NullCheck82 = icmp ne i8* %145, null
-  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+  %NullCheck81 = icmp eq i8* %145, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %152
 
 ; <label>:152                                     ; preds = %148
   store i8 %151, i8* %145, align 8
@@ -949,14 +1031,14 @@ entry:
   %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
   %156 = bitcast i8* %155 to i64*
-  %NullCheck68 = icmp ne i64* %156, null
-  br i1 %NullCheck68, label %157, label %ThrowNullRef67
+  %NullCheck67 = icmp eq i64* %156, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %157
 
 ; <label>:157                                     ; preds = %153
   %158 = load i64, i64* %156, align 8
   %159 = bitcast i8* %154 to i64*
-  %NullCheck70 = icmp ne i64* %159, null
-  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+  %NullCheck69 = icmp eq i64* %159, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %160
 
 ; <label>:160                                     ; preds = %157
   store i64 %158, i64* %159, align 8
@@ -965,16 +1047,16 @@ entry:
   %163 = load i8*, i8** %arg1
   %164 = getelementptr inbounds i8, i8* %163, i64 8
   %165 = bitcast i8* %164 to i16*
-  %NullCheck72 = icmp ne i16* %165, null
-  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+  %NullCheck71 = icmp eq i16* %165, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %166
 
 ; <label>:166                                     ; preds = %160
   %167 = load i16, i16* %165, align 8
   %168 = sext i16 %167 to i32
   %169 = bitcast i8* %162 to i16*
   %170 = trunc i32 %168 to i16
-  %NullCheck74 = icmp ne i16* %169, null
-  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+  %NullCheck73 = icmp eq i16* %169, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %171
 
 ; <label>:171                                     ; preds = %166
   store i16 %170, i16* %169, align 8
@@ -984,14 +1066,14 @@ entry:
   %173 = load i8*, i8** %arg0
   %174 = load i8*, i8** %arg1
   %175 = bitcast i8* %174 to i64*
-  %NullCheck56 = icmp ne i64* %175, null
-  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+  %NullCheck55 = icmp eq i64* %175, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %176
 
 ; <label>:176                                     ; preds = %172
   %177 = load i64, i64* %175, align 8
   %178 = bitcast i8* %173 to i64*
-  %NullCheck58 = icmp ne i64* %178, null
-  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+  %NullCheck57 = icmp eq i64* %178, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %179
 
 ; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
@@ -1000,16 +1082,16 @@ entry:
   %182 = load i8*, i8** %arg1
   %183 = getelementptr inbounds i8, i8* %182, i64 8
   %184 = bitcast i8* %183 to i16*
-  %NullCheck60 = icmp ne i16* %184, null
-  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+  %NullCheck59 = icmp eq i16* %184, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %185
 
 ; <label>:185                                     ; preds = %179
   %186 = load i16, i16* %184, align 8
   %187 = sext i16 %186 to i32
   %188 = bitcast i8* %181 to i16*
   %189 = trunc i32 %187 to i16
-  %NullCheck62 = icmp ne i16* %188, null
-  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+  %NullCheck61 = icmp eq i16* %188, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %190
 
 ; <label>:190                                     ; preds = %185
   store i16 %189, i16* %188, align 8
@@ -1017,15 +1099,15 @@ entry:
   %192 = getelementptr inbounds i8, i8* %191, i64 10
   %193 = load i8*, i8** %arg1
   %194 = getelementptr inbounds i8, i8* %193, i64 10
-  %NullCheck64 = icmp ne i8* %194, null
-  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+  %NullCheck63 = icmp eq i8* %194, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %195
 
 ; <label>:195                                     ; preds = %190
   %196 = load i8, i8* %194, align 8
   %197 = zext i8 %196 to i32
   %198 = trunc i32 %197 to i8
-  %NullCheck66 = icmp ne i8* %192, null
-  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+  %NullCheck65 = icmp eq i8* %192, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %199
 
 ; <label>:199                                     ; preds = %195
   store i8 %198, i8* %192, align 8
@@ -1035,14 +1117,14 @@ entry:
   %201 = load i8*, i8** %arg0
   %202 = load i8*, i8** %arg1
   %203 = bitcast i8* %202 to i64*
-  %NullCheck48 = icmp ne i64* %203, null
-  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+  %NullCheck47 = icmp eq i64* %203, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %204
 
 ; <label>:204                                     ; preds = %200
   %205 = load i64, i64* %203, align 8
   %206 = bitcast i8* %201 to i64*
-  %NullCheck50 = icmp ne i64* %206, null
-  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+  %NullCheck49 = icmp eq i64* %206, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %207
 
 ; <label>:207                                     ; preds = %204
   store i64 %205, i64* %206, align 8
@@ -1051,14 +1133,14 @@ entry:
   %210 = load i8*, i8** %arg1
   %211 = getelementptr inbounds i8, i8* %210, i64 8
   %212 = bitcast i8* %211 to i32*
-  %NullCheck52 = icmp ne i32* %212, null
-  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+  %NullCheck51 = icmp eq i32* %212, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %213
 
 ; <label>:213                                     ; preds = %207
   %214 = load i32, i32* %212, align 8
   %215 = bitcast i8* %209 to i32*
-  %NullCheck54 = icmp ne i32* %215, null
-  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+  %NullCheck53 = icmp eq i32* %215, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %216
 
 ; <label>:216                                     ; preds = %213
   store i32 %214, i32* %215, align 8
@@ -1068,14 +1150,14 @@ entry:
   %218 = load i8*, i8** %arg0
   %219 = load i8*, i8** %arg1
   %220 = bitcast i8* %219 to i64*
-  %NullCheck36 = icmp ne i64* %220, null
-  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64* %220, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %221
 
 ; <label>:221                                     ; preds = %217
   %222 = load i64, i64* %220, align 8
   %223 = bitcast i8* %218 to i64*
-  %NullCheck38 = icmp ne i64* %223, null
-  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+  %NullCheck37 = icmp eq i64* %223, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %224
 
 ; <label>:224                                     ; preds = %221
   store i64 %222, i64* %223, align 8
@@ -1084,14 +1166,14 @@ entry:
   %227 = load i8*, i8** %arg1
   %228 = getelementptr inbounds i8, i8* %227, i64 8
   %229 = bitcast i8* %228 to i32*
-  %NullCheck40 = icmp ne i32* %229, null
-  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i32* %229, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %230
 
 ; <label>:230                                     ; preds = %224
   %231 = load i32, i32* %229, align 8
   %232 = bitcast i8* %226 to i32*
-  %NullCheck42 = icmp ne i32* %232, null
-  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+  %NullCheck41 = icmp eq i32* %232, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %233
 
 ; <label>:233                                     ; preds = %230
   store i32 %231, i32* %232, align 8
@@ -1099,15 +1181,15 @@ entry:
   %235 = getelementptr inbounds i8, i8* %234, i64 12
   %236 = load i8*, i8** %arg1
   %237 = getelementptr inbounds i8, i8* %236, i64 12
-  %NullCheck44 = icmp ne i8* %237, null
-  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i8* %237, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %238
 
 ; <label>:238                                     ; preds = %233
   %239 = load i8, i8* %237, align 8
   %240 = zext i8 %239 to i32
   %241 = trunc i32 %240 to i8
-  %NullCheck46 = icmp ne i8* %235, null
-  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+  %NullCheck45 = icmp eq i8* %235, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %242
 
 ; <label>:242                                     ; preds = %238
   store i8 %241, i8* %235, align 8
@@ -1117,14 +1199,14 @@ entry:
   %244 = load i8*, i8** %arg0
   %245 = load i8*, i8** %arg1
   %246 = bitcast i8* %245 to i64*
-  %NullCheck24 = icmp ne i64* %246, null
-  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64* %246, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %247
 
 ; <label>:247                                     ; preds = %243
   %248 = load i64, i64* %246, align 8
   %249 = bitcast i8* %244 to i64*
-  %NullCheck26 = icmp ne i64* %249, null
-  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64* %249, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %250
 
 ; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
@@ -1133,14 +1215,14 @@ entry:
   %253 = load i8*, i8** %arg1
   %254 = getelementptr inbounds i8, i8* %253, i64 8
   %255 = bitcast i8* %254 to i32*
-  %NullCheck28 = icmp ne i32* %255, null
-  br i1 %NullCheck28, label %256, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i32* %255, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %256
 
 ; <label>:256                                     ; preds = %250
   %257 = load i32, i32* %255, align 8
   %258 = bitcast i8* %252 to i32*
-  %NullCheck30 = icmp ne i32* %258, null
-  br i1 %NullCheck30, label %259, label %ThrowNullRef29
+  %NullCheck29 = icmp eq i32* %258, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %259
 
 ; <label>:259                                     ; preds = %256
   store i32 %257, i32* %258, align 8
@@ -1149,16 +1231,16 @@ entry:
   %262 = load i8*, i8** %arg1
   %263 = getelementptr inbounds i8, i8* %262, i64 12
   %264 = bitcast i8* %263 to i16*
-  %NullCheck32 = icmp ne i16* %264, null
-  br i1 %NullCheck32, label %265, label %ThrowNullRef31
+  %NullCheck31 = icmp eq i16* %264, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %265
 
 ; <label>:265                                     ; preds = %259
   %266 = load i16, i16* %264, align 8
   %267 = sext i16 %266 to i32
   %268 = bitcast i8* %261 to i16*
   %269 = trunc i32 %267 to i16
-  %NullCheck34 = icmp ne i16* %268, null
-  br i1 %NullCheck34, label %270, label %ThrowNullRef33
+  %NullCheck33 = icmp eq i16* %268, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %270
 
 ; <label>:270                                     ; preds = %265
   store i16 %269, i16* %268, align 8
@@ -1168,14 +1250,14 @@ entry:
   %272 = load i8*, i8** %arg0
   %273 = load i8*, i8** %arg1
   %274 = bitcast i8* %273 to i64*
-  %NullCheck8 = icmp ne i64* %274, null
-  br i1 %NullCheck8, label %275, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64* %274, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %275
 
 ; <label>:275                                     ; preds = %271
   %276 = load i64, i64* %274, align 8
   %277 = bitcast i8* %272 to i64*
-  %NullCheck10 = icmp ne i64* %277, null
-  br i1 %NullCheck10, label %278, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %277, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %278
 
 ; <label>:278                                     ; preds = %275
   store i64 %276, i64* %277, align 8
@@ -1184,14 +1266,14 @@ entry:
   %281 = load i8*, i8** %arg1
   %282 = getelementptr inbounds i8, i8* %281, i64 8
   %283 = bitcast i8* %282 to i32*
-  %NullCheck12 = icmp ne i32* %283, null
-  br i1 %NullCheck12, label %284, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i32* %283, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %284
 
 ; <label>:284                                     ; preds = %278
   %285 = load i32, i32* %283, align 8
   %286 = bitcast i8* %280 to i32*
-  %NullCheck14 = icmp ne i32* %286, null
-  br i1 %NullCheck14, label %287, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i32* %286, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %287
 
 ; <label>:287                                     ; preds = %284
   store i32 %285, i32* %286, align 8
@@ -1200,16 +1282,16 @@ entry:
   %290 = load i8*, i8** %arg1
   %291 = getelementptr inbounds i8, i8* %290, i64 12
   %292 = bitcast i8* %291 to i16*
-  %NullCheck16 = icmp ne i16* %292, null
-  br i1 %NullCheck16, label %293, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i16* %292, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %293
 
 ; <label>:293                                     ; preds = %287
   %294 = load i16, i16* %292, align 8
   %295 = sext i16 %294 to i32
   %296 = bitcast i8* %289 to i16*
   %297 = trunc i32 %295 to i16
-  %NullCheck18 = icmp ne i16* %296, null
-  br i1 %NullCheck18, label %298, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i16* %296, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %298
 
 ; <label>:298                                     ; preds = %293
   store i16 %297, i16* %296, align 8
@@ -1217,15 +1299,15 @@ entry:
   %300 = getelementptr inbounds i8, i8* %299, i64 14
   %301 = load i8*, i8** %arg1
   %302 = getelementptr inbounds i8, i8* %301, i64 14
-  %NullCheck20 = icmp ne i8* %302, null
-  br i1 %NullCheck20, label %303, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i8* %302, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %303
 
 ; <label>:303                                     ; preds = %298
   %304 = load i8, i8* %302, align 8
   %305 = zext i8 %304 to i32
   %306 = trunc i32 %305 to i8
-  %NullCheck22 = icmp ne i8* %300, null
-  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i8* %300, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %307
 
 ; <label>:307                                     ; preds = %303
   store i8 %306, i8* %300, align 8
@@ -1235,14 +1317,14 @@ entry:
   %309 = load i8*, i8** %arg0
   %310 = load i8*, i8** %arg1
   %311 = bitcast i8* %310 to i64*
-  %NullCheck = icmp ne i64* %311, null
-  br i1 %NullCheck, label %312, label %ThrowNullRef
+  %NullCheck = icmp eq i64* %311, null
+  br i1 %NullCheck, label %ThrowNullRef, label %312
 
 ; <label>:312                                     ; preds = %308
   %313 = load i64, i64* %311, align 8
   %314 = bitcast i8* %309 to i64*
-  %NullCheck2 = icmp ne i64* %314, null
-  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64* %314, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %315
 
 ; <label>:315                                     ; preds = %312
   store i64 %313, i64* %314, align 8
@@ -1251,14 +1333,14 @@ entry:
   %318 = load i8*, i8** %arg1
   %319 = getelementptr inbounds i8, i8* %318, i64 8
   %320 = bitcast i8* %319 to i64*
-  %NullCheck4 = icmp ne i64* %320, null
-  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64* %320, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %321
 
 ; <label>:321                                     ; preds = %315
   %322 = load i64, i64* %320, align 8
   %323 = bitcast i8* %317 to i64*
-  %NullCheck6 = icmp ne i64* %323, null
-  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64* %323, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %324
 
 ; <label>:324                                     ; preds = %321
   store i64 %322, i64* %323, align 8
@@ -1286,15 +1368,15 @@ entry:
 ; <label>:338                                     ; preds = %333
   %339 = load i8*, i8** %arg0
   %340 = load i8*, i8** %arg1
-  %NullCheck136 = icmp ne i8* %340, null
-  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+  %NullCheck135 = icmp eq i8* %340, null
+  br i1 %NullCheck135, label %ThrowNullRef136, label %341
 
 ; <label>:341                                     ; preds = %338
   %342 = load i8, i8* %340, align 8
   %343 = zext i8 %342 to i32
   %344 = trunc i32 %343 to i8
-  %NullCheck138 = icmp ne i8* %339, null
-  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+  %NullCheck137 = icmp eq i8* %339, null
+  br i1 %NullCheck137, label %ThrowNullRef138, label %345
 
 ; <label>:345                                     ; preds = %341
   store i8 %344, i8* %339, align 8
@@ -1317,16 +1399,16 @@ entry:
   %357 = load i8*, i8** %arg0
   %358 = load i8*, i8** %arg1
   %359 = bitcast i8* %358 to i16*
-  %NullCheck140 = icmp ne i16* %359, null
-  br i1 %NullCheck140, label %360, label %ThrowNullRef139
+  %NullCheck139 = icmp eq i16* %359, null
+  br i1 %NullCheck139, label %ThrowNullRef140, label %360
 
 ; <label>:360                                     ; preds = %356
   %361 = load i16, i16* %359, align 8
   %362 = sext i16 %361 to i32
   %363 = bitcast i8* %357 to i16*
   %364 = trunc i32 %362 to i16
-  %NullCheck142 = icmp ne i16* %363, null
-  br i1 %NullCheck142, label %365, label %ThrowNullRef141
+  %NullCheck141 = icmp eq i16* %363, null
+  br i1 %NullCheck141, label %ThrowNullRef142, label %365
 
 ; <label>:365                                     ; preds = %360
   store i16 %364, i16* %363, align 8
@@ -1352,14 +1434,14 @@ entry:
   %378 = load i8*, i8** %arg0
   %379 = load i8*, i8** %arg1
   %380 = bitcast i8* %379 to i32*
-  %NullCheck144 = icmp ne i32* %380, null
-  br i1 %NullCheck144, label %381, label %ThrowNullRef143
+  %NullCheck143 = icmp eq i32* %380, null
+  br i1 %NullCheck143, label %ThrowNullRef144, label %381
 
 ; <label>:381                                     ; preds = %377
   %382 = load i32, i32* %380, align 8
   %383 = bitcast i8* %378 to i32*
-  %NullCheck146 = icmp ne i32* %383, null
-  br i1 %NullCheck146, label %384, label %ThrowNullRef145
+  %NullCheck145 = icmp eq i32* %383, null
+  br i1 %NullCheck145, label %ThrowNullRef146, label %384
 
 ; <label>:384                                     ; preds = %381
   store i32 %382, i32* %383, align 8
@@ -1384,14 +1466,14 @@ entry:
   %395 = load i8*, i8** %arg0
   %396 = load i8*, i8** %arg1
   %397 = bitcast i8* %396 to i64*
-  %NullCheck164 = icmp ne i64* %397, null
-  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+  %NullCheck163 = icmp eq i64* %397, null
+  br i1 %NullCheck163, label %ThrowNullRef164, label %398
 
 ; <label>:398                                     ; preds = %394
   %399 = load i64, i64* %397, align 8
   %400 = bitcast i8* %395 to i64*
-  %NullCheck166 = icmp ne i64* %400, null
-  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+  %NullCheck165 = icmp eq i64* %400, null
+  br i1 %NullCheck165, label %ThrowNullRef166, label %401
 
 ; <label>:401                                     ; preds = %398
   store i64 %399, i64* %400, align 8
@@ -1400,14 +1482,14 @@ entry:
   %404 = load i8*, i8** %arg1
   %405 = getelementptr inbounds i8, i8* %404, i64 8
   %406 = bitcast i8* %405 to i64*
-  %NullCheck168 = icmp ne i64* %406, null
-  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+  %NullCheck167 = icmp eq i64* %406, null
+  br i1 %NullCheck167, label %ThrowNullRef168, label %407
 
 ; <label>:407                                     ; preds = %401
   %408 = load i64, i64* %406, align 8
   %409 = bitcast i8* %403 to i64*
-  %NullCheck170 = icmp ne i64* %409, null
-  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+  %NullCheck169 = icmp eq i64* %409, null
+  br i1 %NullCheck169, label %ThrowNullRef170, label %410
 
 ; <label>:410                                     ; preds = %407
   store i64 %408, i64* %409, align 8
@@ -1437,14 +1519,14 @@ entry:
   %425 = load i8*, i8** %arg0
   %426 = load i8*, i8** %arg1
   %427 = bitcast i8* %426 to i64*
-  %NullCheck148 = icmp ne i64* %427, null
-  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+  %NullCheck147 = icmp eq i64* %427, null
+  br i1 %NullCheck147, label %ThrowNullRef148, label %428
 
 ; <label>:428                                     ; preds = %424
   %429 = load i64, i64* %427, align 8
   %430 = bitcast i8* %425 to i64*
-  %NullCheck150 = icmp ne i64* %430, null
-  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+  %NullCheck149 = icmp eq i64* %430, null
+  br i1 %NullCheck149, label %ThrowNullRef150, label %431
 
 ; <label>:431                                     ; preds = %428
   store i64 %429, i64* %430, align 8
@@ -1466,14 +1548,14 @@ entry:
   %441 = load i8*, i8** %arg0
   %442 = load i8*, i8** %arg1
   %443 = bitcast i8* %442 to i32*
-  %NullCheck152 = icmp ne i32* %443, null
-  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+  %NullCheck151 = icmp eq i32* %443, null
+  br i1 %NullCheck151, label %ThrowNullRef152, label %444
 
 ; <label>:444                                     ; preds = %440
   %445 = load i32, i32* %443, align 8
   %446 = bitcast i8* %441 to i32*
-  %NullCheck154 = icmp ne i32* %446, null
-  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+  %NullCheck153 = icmp eq i32* %446, null
+  br i1 %NullCheck153, label %ThrowNullRef154, label %447
 
 ; <label>:447                                     ; preds = %444
   store i32 %445, i32* %446, align 8
@@ -1495,16 +1577,16 @@ entry:
   %457 = load i8*, i8** %arg0
   %458 = load i8*, i8** %arg1
   %459 = bitcast i8* %458 to i16*
-  %NullCheck156 = icmp ne i16* %459, null
-  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+  %NullCheck155 = icmp eq i16* %459, null
+  br i1 %NullCheck155, label %ThrowNullRef156, label %460
 
 ; <label>:460                                     ; preds = %456
   %461 = load i16, i16* %459, align 8
   %462 = sext i16 %461 to i32
   %463 = bitcast i8* %457 to i16*
   %464 = trunc i32 %462 to i16
-  %NullCheck158 = icmp ne i16* %463, null
-  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+  %NullCheck157 = icmp eq i16* %463, null
+  br i1 %NullCheck157, label %ThrowNullRef158, label %465
 
 ; <label>:465                                     ; preds = %460
   store i16 %464, i16* %463, align 8
@@ -1525,15 +1607,15 @@ entry:
 ; <label>:474                                     ; preds = %470
   %475 = load i8*, i8** %arg0
   %476 = load i8*, i8** %arg1
-  %NullCheck160 = icmp ne i8* %476, null
-  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+  %NullCheck159 = icmp eq i8* %476, null
+  br i1 %NullCheck159, label %ThrowNullRef160, label %477
 
 ; <label>:477                                     ; preds = %474
   %478 = load i8, i8* %476, align 8
   %479 = zext i8 %478 to i32
   %480 = trunc i32 %479 to i8
-  %NullCheck162 = icmp ne i8* %475, null
-  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+  %NullCheck161 = icmp eq i8* %475, null
+  br i1 %NullCheck161, label %ThrowNullRef162, label %481
 
 ; <label>:481                                     ; preds = %477
   store i8 %480, i8* %475, align 8
@@ -1553,343 +1635,343 @@ ThrowNullRef:                                     ; preds = %308
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %312
+ThrowNullRef2:                                    ; preds = %312
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %315
+ThrowNullRef4:                                    ; preds = %315
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %321
+ThrowNullRef6:                                    ; preds = %321
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %271
+ThrowNullRef8:                                    ; preds = %271
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %275
+ThrowNullRef10:                                   ; preds = %275
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %278
+ThrowNullRef12:                                   ; preds = %278
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %284
+ThrowNullRef14:                                   ; preds = %284
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %287
+ThrowNullRef16:                                   ; preds = %287
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %293
+ThrowNullRef18:                                   ; preds = %293
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %298
+ThrowNullRef20:                                   ; preds = %298
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %303
+ThrowNullRef22:                                   ; preds = %303
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %243
+ThrowNullRef24:                                   ; preds = %243
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %247
+ThrowNullRef26:                                   ; preds = %247
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %250
+ThrowNullRef28:                                   ; preds = %250
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %256
+ThrowNullRef30:                                   ; preds = %256
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %259
+ThrowNullRef32:                                   ; preds = %259
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %265
+ThrowNullRef34:                                   ; preds = %265
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %217
+ThrowNullRef36:                                   ; preds = %217
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %221
+ThrowNullRef38:                                   ; preds = %221
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %224
+ThrowNullRef40:                                   ; preds = %224
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %230
+ThrowNullRef42:                                   ; preds = %230
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %233
+ThrowNullRef44:                                   ; preds = %233
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %238
+ThrowNullRef46:                                   ; preds = %238
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %200
+ThrowNullRef48:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %204
+ThrowNullRef50:                                   ; preds = %204
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %207
+ThrowNullRef52:                                   ; preds = %207
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %213
+ThrowNullRef54:                                   ; preds = %213
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %172
+ThrowNullRef56:                                   ; preds = %172
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %176
+ThrowNullRef58:                                   ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %179
+ThrowNullRef60:                                   ; preds = %179
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %185
+ThrowNullRef62:                                   ; preds = %185
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %190
+ThrowNullRef64:                                   ; preds = %190
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %195
+ThrowNullRef66:                                   ; preds = %195
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %153
+ThrowNullRef68:                                   ; preds = %153
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %157
+ThrowNullRef70:                                   ; preds = %157
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %160
+ThrowNullRef72:                                   ; preds = %160
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %166
+ThrowNullRef74:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %136
+ThrowNullRef76:                                   ; preds = %136
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %140
+ThrowNullRef78:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %143
+ThrowNullRef80:                                   ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %148
+ThrowNullRef82:                                   ; preds = %148
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %128
+ThrowNullRef84:                                   ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %132
+ThrowNullRef86:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %100
+ThrowNullRef88:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %104
+ThrowNullRef90:                                   ; preds = %104
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %107
+ThrowNullRef92:                                   ; preds = %107
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %113
+ThrowNullRef94:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %118
+ThrowNullRef96:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %123
+ThrowNullRef98:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %81
+ThrowNullRef100:                                  ; preds = %81
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef101:                                  ; preds = %85
+ThrowNullRef102:                                  ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef103:                                  ; preds = %88
+ThrowNullRef104:                                  ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef105:                                  ; preds = %94
+ThrowNullRef106:                                  ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef107:                                  ; preds = %64
+ThrowNullRef108:                                  ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef109:                                  ; preds = %68
+ThrowNullRef110:                                  ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef111:                                  ; preds = %71
+ThrowNullRef112:                                  ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef113:                                  ; preds = %76
+ThrowNullRef114:                                  ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef115:                                  ; preds = %56
+ThrowNullRef116:                                  ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef117:                                  ; preds = %60
+ThrowNullRef118:                                  ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef119:                                  ; preds = %37
+ThrowNullRef120:                                  ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef121:                                  ; preds = %41
+ThrowNullRef122:                                  ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef123:                                  ; preds = %46
+ThrowNullRef124:                                  ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef125:                                  ; preds = %51
+ThrowNullRef126:                                  ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef127:                                  ; preds = %27
+ThrowNullRef128:                                  ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef129:                                  ; preds = %31
+ThrowNullRef130:                                  ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef131:                                  ; preds = %19
+ThrowNullRef132:                                  ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef133:                                  ; preds = %22
+ThrowNullRef134:                                  ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef135:                                  ; preds = %338
+ThrowNullRef136:                                  ; preds = %338
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef137:                                  ; preds = %341
+ThrowNullRef138:                                  ; preds = %341
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef139:                                  ; preds = %356
+ThrowNullRef140:                                  ; preds = %356
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef141:                                  ; preds = %360
+ThrowNullRef142:                                  ; preds = %360
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef143:                                  ; preds = %377
+ThrowNullRef144:                                  ; preds = %377
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef145:                                  ; preds = %381
+ThrowNullRef146:                                  ; preds = %381
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef147:                                  ; preds = %424
+ThrowNullRef148:                                  ; preds = %424
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef149:                                  ; preds = %428
+ThrowNullRef150:                                  ; preds = %428
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef151:                                  ; preds = %440
+ThrowNullRef152:                                  ; preds = %440
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef153:                                  ; preds = %444
+ThrowNullRef154:                                  ; preds = %444
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef155:                                  ; preds = %456
+ThrowNullRef156:                                  ; preds = %456
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef157:                                  ; preds = %460
+ThrowNullRef158:                                  ; preds = %460
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef159:                                  ; preds = %474
+ThrowNullRef160:                                  ; preds = %474
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef161:                                  ; preds = %477
+ThrowNullRef162:                                  ; preds = %477
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef163:                                  ; preds = %394
+ThrowNullRef164:                                  ; preds = %394
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef165:                                  ; preds = %398
+ThrowNullRef166:                                  ; preds = %398
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef167:                                  ; preds = %401
+ThrowNullRef168:                                  ; preds = %401
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef169:                                  ; preds = %407
+ThrowNullRef170:                                  ; preds = %407
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1939,8 +2021,8 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
-  br i1 %NullCheck, label %22, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %ThrowNullRef, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
@@ -1948,8 +2030,8 @@ entry:
   store i32 %24, i32* %loc0
   %25 = load i32, i32* %loc0
   %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %26, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %27
 
 ; <label>:27                                      ; preds = %22
   %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
@@ -1971,7 +2053,7 @@ ThrowNullRef:                                     ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1989,8 +2071,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -2022,15 +2104,15 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2048,16 +2130,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
   %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
   store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %15
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
@@ -2072,8 +2154,8 @@ entry:
   %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
   %29 = ptrtoint i16 addrspace(1)* %28 to i64
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %19
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
@@ -2089,19 +2171,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2114,8 +2196,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
@@ -2128,7 +2210,7 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[loadElem]
+Failed to read AppDomain.PrepareDataForSetup[storeElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
@@ -2202,8 +2284,8 @@ entry:
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
-  br i1 %NullCheck24, label %27, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = load i64, i64 addrspace(1)* %26
@@ -2218,8 +2300,8 @@ entry:
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
-  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
   %41 = load i64, i64 addrspace(1)* %39
@@ -2236,8 +2318,8 @@ entry:
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
-  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
   %54 = load i64, i64 addrspace(1)* %52
@@ -2252,8 +2334,8 @@ entry:
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
   %67 = load i64, i64 addrspace(1)* %65
@@ -2270,8 +2352,8 @@ entry:
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
-  br i1 %NullCheck16, label %79, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
   %80 = load i64, i64 addrspace(1)* %78
@@ -2286,8 +2368,8 @@ entry:
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
-  br i1 %NullCheck18, label %92, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
   %93 = load i64, i64 addrspace(1)* %91
@@ -2304,8 +2386,8 @@ entry:
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
-  br i1 %NullCheck12, label %105, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = load i64, i64 addrspace(1)* %104
@@ -2320,8 +2402,8 @@ entry:
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
-  br i1 %NullCheck14, label %118, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
   %119 = load i64, i64 addrspace(1)* %117
@@ -2337,8 +2419,8 @@ entry:
 
 ; <label>:128                                     ; preds = %20
   %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
-  br i1 %NullCheck4, label %130, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %129, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %130
 
 ; <label>:130                                     ; preds = %128
   %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
@@ -2346,8 +2428,8 @@ entry:
   %133 = load i16, i16 addrspace(1)* %132, align 8
   %134 = zext i16 %133 to i32
   %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
-  br i1 %NullCheck6, label %136, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %135, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %136
 
 ; <label>:136                                     ; preds = %130
   %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
@@ -2360,8 +2442,8 @@ entry:
 
 ; <label>:143                                     ; preds = %136
   %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
-  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %144, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %145
 
 ; <label>:145                                     ; preds = %143
   %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
@@ -2369,8 +2451,8 @@ entry:
   %148 = load i16, i16 addrspace(1)* %147, align 8
   %149 = zext i16 %148 to i32
   %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %150, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %151
 
 ; <label>:151                                     ; preds = %145
   %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
@@ -2388,8 +2470,8 @@ entry:
 
 ; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
-  br i1 %NullCheck, label %163, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %ThrowNullRef, label %163
 
 ; <label>:163                                     ; preds = %161
   %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
@@ -2399,8 +2481,8 @@ entry:
 
 ; <label>:167                                     ; preds = %163
   %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
-  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %168, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %169
 
 ; <label>:169                                     ; preds = %167
   %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
@@ -2432,55 +2514,55 @@ ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %167
+ThrowNullRef2:                                    ; preds = %167
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %128
+ThrowNullRef4:                                    ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %130
+ThrowNullRef6:                                    ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %143
+ThrowNullRef8:                                    ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %145
+ThrowNullRef10:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %102
+ThrowNullRef12:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %105
+ThrowNullRef14:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %76
+ThrowNullRef16:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %79
+ThrowNullRef18:                                   ; preds = %79
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %50
+ThrowNullRef20:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %53
+ThrowNullRef22:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %24
+ThrowNullRef24:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %27
+ThrowNullRef26:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2503,15 +2585,15 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2519,16 +2601,16 @@ entry:
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
   store i32 %8, i32* %loc0
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
   %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
   store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
@@ -2546,16 +2628,16 @@ entry:
 
 ; <label>:23                                      ; preds = %64
   %24 = load i16*, i16** %loc3
-  %NullCheck12 = icmp ne i16* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i16* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
   store i32 %27, i32* %loc5
   %28 = load i16*, i16** %loc4
-  %NullCheck14 = icmp ne i16* %28, null
-  br i1 %NullCheck14, label %29, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %28, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = load i16, i16* %28, align 8
@@ -2620,15 +2702,15 @@ entry:
 
 ; <label>:67                                      ; preds = %64
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
-  br i1 %NullCheck8, label %69, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %68, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %69
 
 ; <label>:69                                      ; preds = %67
   %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
   %71 = load i32, i32 addrspace(1)* %70
   %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
-  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %73
 
 ; <label>:73                                      ; preds = %69
   %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
@@ -2645,31 +2727,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %67
+ThrowNullRef8:                                    ; preds = %67
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %69
+ThrowNullRef10:                                   ; preds = %69
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2710,14 +2792,14 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
   %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
@@ -2730,14 +2812,14 @@ entry:
 
 ; <label>:11                                      ; preds = %4
   %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
   %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
@@ -2749,14 +2831,14 @@ entry:
 
 ; <label>:22                                      ; preds = %16
   %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
   %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
-  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
-  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
@@ -2804,23 +2886,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2836,7 +2918,280 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[loadElem]
+Successfully read RuntimeType.IsAssignableFrom
+
+define i8 @RuntimeType.IsAssignableFrom(%System.RuntimeType addrspace(1)* %param0, %System.Type addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.RuntimeType addrspace(1)*
+  %arg1 = alloca %System.Type addrspace(1)*
+  %loc0 = alloca %System.RuntimeType addrspace(1)*
+  %loc1 = alloca %"System.Type[]" addrspace(1)*
+  %loc2 = alloca i32
+  store %System.RuntimeType addrspace(1)* %param0, %System.RuntimeType addrspace(1)** %this
+  store %System.Type addrspace(1)* %param1, %System.Type addrspace(1)** %arg1
+  %0 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %1 = icmp ne %System.Type addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i8 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %5 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %6 = bitcast %System.Type addrspace(1)* %4 to %System.Object addrspace(1)*
+  %7 = bitcast %System.RuntimeType addrspace(1)* %5 to %System.Object addrspace(1)*
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %6, %System.Object addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %3
+  ret i8 1
+
+; <label>:12                                      ; preds = %3
+  %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 152
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 32
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
+  %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
+  %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
+  store %System.RuntimeType addrspace(1)* %25, %System.RuntimeType addrspace(1)** %loc0
+  %26 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %27 = icmp eq %System.RuntimeType addrspace(1)* %26, null
+  br i1 %27, label %34, label %28
+
+; <label>:28                                      ; preds = %15
+  %29 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %30 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)*)*)(%System.RuntimeType addrspace(1)* %29, %System.RuntimeType addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+; <label>:34                                      ; preds = %15
+  %35 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %36 = call %System.Reflection.Emit.TypeBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Reflection.Emit.TypeBuilder addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %35)
+  %37 = icmp eq %System.Reflection.Emit.TypeBuilder addrspace(1)* %36, null
+  br i1 %37, label %139, label %38
+
+; <label>:38                                      ; preds = %34
+  %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %42
+
+; <label>:42                                      ; preds = %38
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 152
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 40
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
+  %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
+  %53 = zext i8 %52 to i32
+  %54 = icmp eq i32 %53, 0
+  br i1 %54, label %56, label %55
+
+; <label>:55                                      ; preds = %42
+  ret i8 1
+
+; <label>:56                                      ; preds = %42
+  %57 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %58 = bitcast %System.RuntimeType addrspace(1)* %57 to %System.Type addrspace(1)*
+  %59 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %58)
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %64 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.Type addrspace(1)* %63, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = bitcast %System.RuntimeType addrspace(1)* %64 to %System.Type addrspace(1)*
+  %67 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %63, %System.Type addrspace(1)* %66)
+  %68 = zext i8 %67 to i32
+  %69 = trunc i32 %68 to i8
+  ret i8 %69
+
+; <label>:70                                      ; preds = %56
+  %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
+  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %73
+
+; <label>:73                                      ; preds = %70
+  %74 = load i64, i64 addrspace(1)* %72
+  %75 = add i64 %74, 128
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = add i64 %77, 0
+  %79 = inttoptr i64 %78 to i64*
+  %80 = load i64, i64* %79
+  %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
+  %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
+  %83 = call i8 %82(%System.Type addrspace(1)* %81)
+  %84 = zext i8 %83 to i32
+  %85 = icmp eq i32 %84, 0
+  br i1 %85, label %139, label %86
+
+; <label>:86                                      ; preds = %73
+  %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
+  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %89
+
+; <label>:89                                      ; preds = %86
+  %90 = load i64, i64 addrspace(1)* %88
+  %91 = add i64 %90, 128
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = add i64 %93, 24
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
+  %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
+  %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
+  store %"System.Type[]" addrspace(1)* %99, %"System.Type[]" addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %129
+
+; <label>:100                                     ; preds = %132
+  %101 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %102 = load i32, i32* %loc2
+  %NullCheck11 = icmp eq %"System.Type[]" addrspace(1)* %101, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %103
+
+; <label>:103                                     ; preds = %100
+  %104 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 1
+  %105 = load i32, i32 addrspace(1)* %104
+  %106 = zext i32 %105 to i64
+  %107 = zext i32 %102 to i64
+  %BoundsCheck = icmp uge i64 %107, %106
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %108
+
+; <label>:108                                     ; preds = %103
+  %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
+  %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
+  %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
+  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %113
+
+; <label>:113                                     ; preds = %108
+  %114 = load i64, i64 addrspace(1)* %112
+  %115 = add i64 %114, 152
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = add i64 %117, 56
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
+  %123 = zext i8 %122 to i32
+  %124 = icmp ne i32 %123, 0
+  br i1 %124, label %126, label %125
+
+; <label>:125                                     ; preds = %113
+  ret i8 0
+
+; <label>:126                                     ; preds = %113
+  %127 = load i32, i32* %loc2
+  %128 = add i32 %127, 1
+  store i32 %128, i32* %loc2
+  br label %129
+
+; <label>:129                                     ; preds = %89, %126
+  %130 = load i32, i32* %loc2
+  %131 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %NullCheck9 = icmp eq %"System.Type[]" addrspace(1)* %131, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %132
+
+; <label>:132                                     ; preds = %129
+  %133 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %131, i32 0, i32 1
+  %134 = load i32, i32 addrspace(1)* %133
+  %135 = zext i32 %134 to i64
+  %136 = trunc i64 %135 to i32
+  %137 = icmp slt i32 %130, %136
+  br i1 %137, label %100, label %138
+
+; <label>:138                                     ; preds = %132
+  ret i8 1
+
+; <label>:139                                     ; preds = %34, %73
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %129
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %103
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -2893,7 +3248,7 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElem]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -2904,8 +3259,8 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -2997,8 +3352,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
@@ -3059,8 +3414,8 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -3087,8 +3442,8 @@ entry:
 
 ; <label>:17                                      ; preds = %5, %11
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
@@ -3097,8 +3452,8 @@ entry:
 
 ; <label>:22                                      ; preds = %1, %11
   %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
@@ -3109,11 +3464,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %17
+ThrowNullRef2:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %22
+ThrowNullRef4:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3167,15 +3522,15 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
   %15 = load i32, i32 addrspace(1)* %14
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
@@ -3198,7 +3553,7 @@ ThrowNullRef:                                     ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef2:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3232,8 +3587,8 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
@@ -3312,8 +3667,8 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -3327,8 +3682,8 @@ entry:
 ; <label>:5                                       ; preds = %43
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %7 = load i32, i32* %loc1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck6, label %8, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
@@ -3366,8 +3721,8 @@ entry:
 ; <label>:32                                      ; preds = %21, %25
   %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
   %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
-  br i1 %NullCheck8, label %35, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = trunc i32 %34 to i16
@@ -3380,8 +3735,8 @@ entry:
 ; <label>:40                                      ; preds = %1, %35
   %41 = load i32, i32* %loc1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
-  br i1 %NullCheck2, label %43, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %42, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
@@ -3392,8 +3747,8 @@ entry:
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
   %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
-  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
   %51 = load i64, i64 addrspace(1)* %49
@@ -3412,19 +3767,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %40
+ThrowNullRef2:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %47
+ThrowNullRef4:                                    ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %5
+ThrowNullRef6:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %32
+ThrowNullRef8:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3467,8 +3822,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
@@ -3492,11 +3847,391 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(i16* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store i16* %param0, i16** %arg0
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load i32, i32* %arg3
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %42, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %37, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg2
+  %13 = load i32, i32* %arg3
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %37, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %24 = load i32, i32* %arg2
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load i16*, i16** %arg0
+  %35 = load i32, i32* %arg3
+  %36 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %36, i16* %34, i32 %35)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:37                                      ; preds = %5, %16
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %39)
+  %41 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41, %System.String addrspace(1)* %38, %System.String addrspace(1)* %40)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41) #0
+  unreachable
+
+; <label>:42                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
-Failed to read StringBuilder.ToString[loadElemA]
+Successfully read StringBuilder.ToString
+
+define %System.String addrspace(1)* @StringBuilder.ToString(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i16*
+  %loc3 = alloca %"System.Char[]" addrspace(1)*
+  %loc4 = alloca i32
+  %loc5 = alloca i32
+  %loc6 = alloca i16 addrspace(1)*
+  %loc7 = alloca %System.String addrspace(1)*
+  %loc8 = alloca %"System.Char[]" addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %0)
+  %2 = icmp ne i32 %1, 0
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %4
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %6)
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %7)
+  store %System.String addrspace(1)* %8, %System.String addrspace(1)** %loc0
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.Text.StringBuilder addrspace(1)* %9, %System.Text.StringBuilder addrspace(1)** %loc1
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  store %System.String addrspace(1)* %10, %System.String addrspace(1)** %loc7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc7
+  %12 = ptrtoint %System.String addrspace(1)* %11 to i64
+  %13 = icmp eq i64 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %5
+  %15 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %16 = sext i32 %15 to i64
+  %17 = add i64 %12, %16
+  br label %18
+
+; <label>:18                                      ; preds = %5, %14
+  %19 = phi i64 [ %12, %5 ], [ %17, %14 ]
+  %20 = inttoptr i64 %19 to i16*
+  store i16* %20, i16** %loc2
+  br label %21
+
+; <label>:21                                      ; preds = %98, %18
+  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %22, null
+  br i1 %NullCheck, label %ThrowNullRef, label %23
+
+; <label>:23                                      ; preds = %21
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 3
+  %25 = load i32, i32 addrspace(1)* %24, align 8
+  %26 = icmp sle i32 %25, 0
+  br i1 %26, label %96, label %27
+
+; <label>:27                                      ; preds = %23
+  %28 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %28, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %29
+
+; <label>:29                                      ; preds = %27
+  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %28, i32 0, i32 1
+  %31 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %30, align 8
+  store %"System.Char[]" addrspace(1)* %31, %"System.Char[]" addrspace(1)** %loc3
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %33
+
+; <label>:33                                      ; preds = %29
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  store i32 %35, i32* %loc4
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  %39 = load i32, i32 addrspace(1)* %38, align 8
+  store i32 %39, i32* %loc5
+  %40 = load i32, i32* %loc5
+  %41 = load i32, i32* %loc4
+  %42 = add i32 %40, %41
+  %43 = zext i32 %42 to i64
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %45
+
+; <label>:45                                      ; preds = %37
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = sext i32 %47 to i64
+  %49 = icmp sgt i64 %43, %48
+  br i1 %49, label %91, label %50
+
+; <label>:50                                      ; preds = %45
+  %51 = load i32, i32* %loc5
+  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %52, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %53
+
+; <label>:53                                      ; preds = %50
+  %54 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %52, i32 0, i32 1
+  %55 = load i32, i32 addrspace(1)* %54
+  %56 = zext i32 %55 to i64
+  %57 = trunc i64 %56 to i32
+  %58 = icmp ugt i32 %51, %57
+  br i1 %58, label %91, label %59
+
+; <label>:59                                      ; preds = %53
+  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  store %"System.Char[]" addrspace(1)* %60, %"System.Char[]" addrspace(1)** %loc8
+  %61 = icmp eq %"System.Char[]" addrspace(1)* %60, null
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %63, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %64
+
+; <label>:64                                      ; preds = %62
+  %65 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %63, i32 0, i32 1
+  %66 = load i32, i32 addrspace(1)* %65
+  %67 = zext i32 %66 to i64
+  %68 = trunc i64 %67 to i32
+  %69 = icmp ne i32 %68, 0
+  br i1 %69, label %71, label %70
+
+; <label>:70                                      ; preds = %59, %64
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:71                                      ; preds = %64
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %73
+
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %BoundsCheck = icmp uge i64 0, %76
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %77
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %78, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:79                                      ; preds = %70, %77
+  %80 = load i16*, i16** %loc2
+  %81 = load i32, i32* %loc4
+  %82 = sext i32 %81 to i64
+  %83 = mul i64 %82, 2
+  %84 = bitcast i16* %80 to i8*
+  %85 = getelementptr inbounds i8, i8* %84, i64 %83
+  %86 = load i16 addrspace(1)*, i16 addrspace(1)** %loc6
+  %87 = ptrtoint i16 addrspace(1)* %86 to i64
+  %88 = load i32, i32* %loc5
+  %89 = bitcast i8* %85 to i16*
+  %90 = inttoptr i64 %87 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %89, i16* %90, i32 %88)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %96
+
+; <label>:91                                      ; preds = %45, %53
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %94 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %93)
+  %95 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95, %System.String addrspace(1)* %92, %System.String addrspace(1)* %94)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95) #0
+  unreachable
+
+; <label>:96                                      ; preds = %23, %79
+  %97 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %97, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %98
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %97, i32 0, i32 2
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  store %System.Text.StringBuilder addrspace(1)* %100, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %102 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %102, label %21, label %103
+
+; <label>:103                                     ; preds = %98
+  store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc7
+  %104 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  ret %System.String addrspace(1)* %104
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method StringBuilder::get_Length using LLILCJit
+Successfully read StringBuilder.get_Length
+
+define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
+Successfully read RuntimeHelpers.get_OffsetToStringData
+
+define i32 @RuntimeHelpers.get_OffsetToStringData() {
+entry:
+  ret i32 12
+}
+
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
 Successfully read CultureData.CreateCultureData
 
@@ -3514,23 +4249,23 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
   store i8 %4, i8 addrspace(1)* %6
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
@@ -3549,11 +4284,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3566,50 +4301,50 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
   store i32 -1, i32 addrspace(1)* %2
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
   store i32 -1, i32 addrspace(1)* %8
   %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
   store i32 -1, i32 addrspace(1)* %14
   %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
   store i32 -1, i32 addrspace(1)* %17
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
@@ -3623,27 +4358,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3675,7 +4410,136 @@ Failed to read Dictionary`2.Insert[non-const derefAddress]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
 Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
-Failed to read HashHelpers.GetPrime[loadElem]
+Successfully read HashHelpers.GetPrime
+
+define i32 @HashHelpers.GetPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %6, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5, %System.String addrspace(1)* %4)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5) #0
+  unreachable
+
+; <label>:6                                       ; preds = %entry
+  store i32 0, i32* %loc0
+  br label %29
+
+; <label>:7                                       ; preds = %35
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 1296
+  %10 = addrspacecast i8 addrspace(1)* %9 to %"System.Int32[]" addrspace(1)**
+  %11 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %10
+  %12 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Int32[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = zext i32 %15 to i64
+  %17 = zext i32 %12 to i64
+  %BoundsCheck = icmp uge i64 %17, %16
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 3, i32 %12
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  store i32 %20, i32* %loc1
+  %21 = load i32, i32* %loc1
+  %22 = load i32, i32* %arg0
+  %23 = icmp slt i32 %21, %22
+  br i1 %23, label %26, label %24
+
+; <label>:24                                      ; preds = %18
+  %25 = load i32, i32* %loc1
+  ret i32 %25
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %loc0
+  %28 = add i32 %27, 1
+  store i32 %28, i32* %loc0
+  br label %29
+
+; <label>:29                                      ; preds = %6, %26
+  %30 = load i32, i32* %loc0
+  %31 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %32 = getelementptr inbounds i8, i8 addrspace(1)* %31, i64 1296
+  %33 = addrspacecast i8 addrspace(1)* %32 to %"System.Int32[]" addrspace(1)**
+  %34 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %33
+  %NullCheck = icmp eq %"System.Int32[]" addrspace(1)* %34, null
+  br i1 %NullCheck, label %ThrowNullRef, label %35
+
+; <label>:35                                      ; preds = %29
+  %36 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %34, i32 0, i32 1
+  %37 = load i32, i32 addrspace(1)* %36
+  %38 = zext i32 %37 to i64
+  %39 = trunc i64 %38 to i32
+  %40 = icmp slt i32 %30, %39
+  br i1 %40, label %7, label %41
+
+; <label>:41                                      ; preds = %35
+  %42 = load i32, i32* %arg0
+  %43 = or i32 %42, 1
+  store i32 %43, i32* %loc2
+  br label %59
+
+; <label>:44                                      ; preds = %59
+  %45 = load i32, i32* %loc2
+  %46 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %45)
+  %47 = zext i8 %46 to i32
+  %48 = icmp eq i32 %47, 0
+  br i1 %48, label %56, label %49
+
+; <label>:49                                      ; preds = %44
+  %50 = load i32, i32* %loc2
+  %51 = sub i32 %50, 1
+  %52 = srem i32 %51, 101
+  %53 = icmp eq i32 %52, 0
+  br i1 %53, label %56, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = load i32, i32* %loc2
+  ret i32 %55
+
+; <label>:56                                      ; preds = %44, %49
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %57, 2
+  store i32 %58, i32* %loc2
+  br label %59
+
+; <label>:59                                      ; preds = %41, %56
+  %60 = load i32, i32* %loc2
+  %61 = icmp slt i32 %60, 2147483647
+  br i1 %61, label %44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load i32, i32* %arg0
+  ret i32 %63
+
+ThrowNullRef:                                     ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
 Successfully read GenericEqualityComparer`1.GetHashCode
 
@@ -3694,14 +4558,14 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
   %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load i64, i64 addrspace(1)* %7
@@ -3720,7 +4584,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3750,8 +4614,8 @@ entry:
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
@@ -3796,8 +4660,8 @@ entry:
   %35 = bitcast i16* %34 to i8*
   %36 = getelementptr inbounds i8, i8* %35, i64 2
   %37 = bitcast i8* %36 to i16*
-  %NullCheck4 = icmp ne i16* %37, null
-  br i1 %NullCheck4, label %38, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %37, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %38
 
 ; <label>:38                                      ; preds = %27
   %39 = load i16, i16* %37, align 8
@@ -3824,8 +4688,8 @@ entry:
 
 ; <label>:54                                      ; preds = %22, %43
   %55 = load i16*, i16** %loc4
-  %NullCheck2 = icmp ne i16* %55, null
-  br i1 %NullCheck2, label %56, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i16* %55, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %56
 
 ; <label>:56                                      ; preds = %54
   %57 = load i16, i16* %55, align 8
@@ -3850,11 +4714,11 @@ ThrowNullRef:                                     ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %54
+ThrowNullRef2:                                    ; preds = %54
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %27
+ThrowNullRef4:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3871,8 +4735,8 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -3907,8 +4771,8 @@ entry:
 
 ; <label>:26                                      ; preds = %19
   %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
-  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %28
 
 ; <label>:28                                      ; preds = %26
   %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
@@ -3920,7 +4784,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3972,8 +4836,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
@@ -3984,26 +4848,26 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
-  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
@@ -4014,8 +4878,8 @@ entry:
 ; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
@@ -4024,8 +4888,8 @@ entry:
 
 ; <label>:25                                      ; preds = %1, %16, %23
   %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
-  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
@@ -4036,27 +4900,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %20
+ThrowNullRef10:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4069,8 +4933,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -4081,8 +4945,8 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
@@ -4091,8 +4955,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1, %8
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
@@ -4103,11 +4967,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4128,24 +4992,24 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   store i32 %3, i32* %loc0
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
   %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
   store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck4, label %9, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
@@ -4164,15 +5028,15 @@ entry:
 ; <label>:18                                      ; preds = %70
   %19 = load i16*, i16** %loc3
   %20 = bitcast i16* %19 to i64*
-  %NullCheck10 = icmp ne i64* %20, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %20, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = load i64, i64* %20, align 8
   %23 = load i16*, i16** %loc4
   %24 = bitcast i16* %23 to i64*
-  %NullCheck12 = icmp ne i64* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = load i64, i64* %24, align 8
@@ -4188,8 +5052,8 @@ entry:
   %31 = bitcast i16* %30 to i8*
   %32 = getelementptr inbounds i8, i8* %31, i64 8
   %33 = bitcast i8* %32 to i64*
-  %NullCheck14 = icmp ne i64* %33, null
-  br i1 %NullCheck14, label %34, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = load i64, i64* %33, align 8
@@ -4197,8 +5061,8 @@ entry:
   %37 = bitcast i16* %36 to i8*
   %38 = getelementptr inbounds i8, i8* %37, i64 8
   %39 = bitcast i8* %38 to i64*
-  %NullCheck16 = icmp ne i64* %39, null
-  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %40
 
 ; <label>:40                                      ; preds = %34
   %41 = load i64, i64* %39, align 8
@@ -4214,8 +5078,8 @@ entry:
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %NullCheck18 = icmp ne i64* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = load i64, i64* %48, align 8
@@ -4223,8 +5087,8 @@ entry:
   %52 = bitcast i16* %51 to i8*
   %53 = getelementptr inbounds i8, i8* %52, i64 16
   %54 = bitcast i8* %53 to i64*
-  %NullCheck20 = icmp ne i64* %54, null
-  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64* %54, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %55
 
 ; <label>:55                                      ; preds = %49
   %56 = load i64, i64* %54, align 8
@@ -4262,15 +5126,15 @@ entry:
 ; <label>:74                                      ; preds = %95
   %75 = load i16*, i16** %loc3
   %76 = bitcast i16* %75 to i32*
-  %NullCheck6 = icmp ne i32* %76, null
-  br i1 %NullCheck6, label %77, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32* %76, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %77
 
 ; <label>:77                                      ; preds = %74
   %78 = load i32, i32* %76, align 8
   %79 = load i16*, i16** %loc4
   %80 = bitcast i16* %79 to i32*
-  %NullCheck8 = icmp ne i32* %80, null
-  br i1 %NullCheck8, label %81, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i32* %80, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %81
 
 ; <label>:81                                      ; preds = %77
   %82 = load i32, i32* %80, align 8
@@ -4318,43 +5182,43 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %74
+ThrowNullRef6:                                    ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %77
+ThrowNullRef8:                                    ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %29
+ThrowNullRef14:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %34
+ThrowNullRef16:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4376,8 +5240,8 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load i64, i64 addrspace(1)* %4
@@ -4389,8 +5253,8 @@ entry:
   %12 = load i64, i64* %11
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %5
   %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
@@ -4399,8 +5263,8 @@ entry:
   %18 = load i8, i8* %arg2
   %19 = zext i8 %18 to i32
   %20 = trunc i32 %19 to i8
-  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %15
   %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
@@ -4411,11 +5275,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4442,8 +5306,8 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
@@ -4466,16 +5330,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
   %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = load i64, i64 addrspace(1)* %19
@@ -4500,8 +5364,8 @@ entry:
 ; <label>:35                                      ; preds = %30
   %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
@@ -4514,8 +5378,8 @@ entry:
 
 ; <label>:42                                      ; preds = %1, %38
   %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
-  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
@@ -4526,19 +5390,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %35
+ThrowNullRef2:                                    ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %42
+ThrowNullRef8:                                    ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4551,14 +5415,14 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
@@ -4570,7 +5434,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4583,8 +5447,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
@@ -4613,51 +5477,51 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
   %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
   %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
   %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
   %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
-  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
   store i64 %21, i64 addrspace(1)* %23
   %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %25 = load i64, i64* %loc0
-  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
@@ -4668,27 +5532,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %22
+ThrowNullRef12:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4701,8 +5565,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
@@ -4713,19 +5577,19 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
@@ -4734,8 +5598,8 @@ entry:
 
 ; <label>:15                                      ; preds = %1, %13
   %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
@@ -4746,19 +5610,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %15
+ThrowNullRef8:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4771,8 +5635,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -4831,8 +5695,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
@@ -4882,8 +5746,8 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
-  br i1 %NullCheck, label %17, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %ThrowNullRef, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
@@ -4894,15 +5758,15 @@ entry:
 
 ; <label>:22                                      ; preds = %17
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
-  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
   %26 = load i32, i32 addrspace(1)* %25
   %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
-  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %27, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
@@ -4925,8 +5789,8 @@ entry:
 ; <label>:40                                      ; preds = %17
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
-  br i1 %NullCheck6, label %43, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %41, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
@@ -4938,34 +5802,17 @@ ThrowNullRef:                                     ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %24
+ThrowNullRef4:                                    ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %40
+ThrowNullRef6:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
-}
-
-INFO:  jitting method Object::ReferenceEquals using LLILCJit
-Successfully read Object.ReferenceEquals
-
-define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
-entry:
-  %arg0 = alloca %System.Object addrspace(1)*
-  %arg1 = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
-  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
-  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = icmp eq %System.Object addrspace(1)* %0, %1
-  %3 = sext i1 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
 }
 
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
@@ -4978,21 +5825,21 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
   %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
-  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
@@ -5007,28 +5854,28 @@ entry:
 ; <label>:13                                      ; preds = %8, %12
   %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
   %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
   %21 = load i32, i32 addrspace(1)* %20, align 8
   %22 = add i32 %21, 1
-  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
   store i32 %22, i32 addrspace(1)* %24
   %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
@@ -5039,27 +5886,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5077,7 +5924,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::Setup using LLILCJit
-Failed to read AppDomain.Setup[loadElem]
+Failed to read AppDomain.Setup[unbox]
 INFO:  jitting method Thread::GetDomain using LLILCJit
 Successfully read Thread.GetDomain
 
@@ -5108,8 +5955,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
@@ -5122,14 +5969,14 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
   %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
@@ -5141,11 +5988,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5173,8 +6020,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -5189,7 +6036,328 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
 Failed to read KeyCollection.System.Collections.Generic.IEnumerable<TKey>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Successfully read Enumerator.MoveNext
+
+define i8 @Enumerator.MoveNext(%"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.RuntimeTypeHandle* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*
+  %"$TypeArg" = alloca %System.RuntimeTypeHandle*
+  store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
+  %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 8
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %76, label %12
+
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
+  br label %76
+
+; <label>:13                                      ; preds = %85
+  %14 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck19 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %15
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, i32 0, i32 0
+  %17 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %16, align 8
+  %NullCheck21 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, i32 0, i32 2
+  %20 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %19, align 8
+  %21 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck23 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %22
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, i32 0, i32 2
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %NullCheck25 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 3, i32 %24
+  %NullCheck27 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %32
+
+; <label>:32                                      ; preds = %30
+  %33 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, i32 0, i32 2
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = icmp slt i32 %34, 0
+  br i1 %35, label %68, label %36
+
+; <label>:36                                      ; preds = %32
+  %37 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %38 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck29 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %39
+
+; <label>:39                                      ; preds = %36
+  %40 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, i32 0, i32 0
+  %41 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %40, align 8
+  %NullCheck31 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, i32 0, i32 2
+  %44 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %43, align 8
+  %45 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck33 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, i32 0, i32 2
+  %48 = load i32, i32 addrspace(1)* %47, align 8
+  %NullCheck35 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %49
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = zext i32 %51 to i64
+  %53 = zext i32 %48 to i64
+  %BoundsCheck37 = icmp uge i64 %53, %52
+  br i1 %BoundsCheck37, label %ThrowIndexOutOfRange38, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 3, i32 %48
+  %NullCheck39 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %56
+
+; <label>:56                                      ; preds = %54
+  %57 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, i32 0, i32 0
+  %58 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck41 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %59
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %60, %System.__Canon addrspace(1)* %58)
+  %61 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck43 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  %64 = load i32, i32 addrspace(1)* %63, align 8
+  %65 = add i32 %64, 1
+  %NullCheck45 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  store i32 %65, i32 addrspace(1)* %67
+  ret i8 1
+
+; <label>:68                                      ; preds = %32
+  %69 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck47 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %73 = add i32 %72, 1
+  %NullCheck49 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %74
+
+; <label>:74                                      ; preds = %70
+  %75 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  store i32 %73, i32 addrspace(1)* %75
+  br label %76
+
+; <label>:76                                      ; preds = %8, %12, %74
+  %77 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %78
+
+; <label>:78                                      ; preds = %76
+  %79 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, i32 0, i32 2
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck7 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %82
+
+; <label>:82                                      ; preds = %78
+  %83 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, i32 0, i32 0
+  %84 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %83, align 8
+  %NullCheck9 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %85
+
+; <label>:85                                      ; preds = %82
+  %86 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, i32 0, i32 7
+  %87 = load i32, i32 addrspace(1)* %86, align 8
+  %88 = icmp ult i32 %80, %87
+  br i1 %88, label %13, label %89
+
+; <label>:89                                      ; preds = %85
+  %90 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %91 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck11 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %92
+
+; <label>:92                                      ; preds = %89
+  %93 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, i32 0, i32 0
+  %94 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck13 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %95
+
+; <label>:95                                      ; preds = %92
+  %96 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, i32 0, i32 7
+  %97 = load i32, i32 addrspace(1)* %96, align 8
+  %98 = add i32 %97, 1
+  %NullCheck15 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %99
+
+; <label>:99                                      ; preds = %95
+  %100 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, i32 0, i32 2
+  store i32 %98, i32 addrspace(1)* %100
+  %101 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck17 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %102
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %103, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %92
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef22:                                   ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef24:                                   ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef26:                                   ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef28:                                   ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef30:                                   ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef32:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef34:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef36:                                   ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange38:                           ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef40:                                   ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef42:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef44:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef46:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef48:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef50:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -5200,8 +6368,8 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -5232,9 +6400,9 @@ Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
 Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
-Failed to read String.MakeSeparatorList[loadElemA]
+Failed to read String.MakeSeparatorList[storeElem]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
-Failed to read String.InternalSplitKeepEmptyEntries[loadElem]
+Failed to read String.InternalSplitKeepEmptyEntries[storeElem]
 INFO:  jitting method Path::IsRelative using LLILCJit
 Successfully read Path.IsRelative
 
@@ -5243,8 +6411,8 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -5254,8 +6422,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
@@ -5271,8 +6439,8 @@ entry:
 
 ; <label>:17                                      ; preds = %7
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
@@ -5288,8 +6456,8 @@ entry:
 
 ; <label>:29                                      ; preds = %19
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %31
 
 ; <label>:31                                      ; preds = %29
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
@@ -5300,8 +6468,8 @@ entry:
 
 ; <label>:36                                      ; preds = %31
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
-  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %37, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
@@ -5312,8 +6480,8 @@ entry:
 
 ; <label>:43                                      ; preds = %31, %38
   %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
-  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %45
 
 ; <label>:45                                      ; preds = %43
   %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
@@ -5324,8 +6492,8 @@ entry:
 
 ; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %50
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
@@ -5336,8 +6504,8 @@ entry:
 
 ; <label>:57                                      ; preds = %1, %7, %19, %45, %52
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
-  br i1 %NullCheck14, label %59, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %59
 
 ; <label>:59                                      ; preds = %57
   %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
@@ -5347,8 +6515,8 @@ entry:
 
 ; <label>:63                                      ; preds = %59
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
@@ -5359,8 +6527,8 @@ entry:
 
 ; <label>:70                                      ; preds = %65
   %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
-  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.String addrspace(1)* %71, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %72
 
 ; <label>:72                                      ; preds = %70
   %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
@@ -5379,39 +6547,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %17
+ThrowNullRef4:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %29
+ThrowNullRef6:                                    ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %36
+ThrowNullRef8:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %43
+ThrowNullRef10:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %50
+ThrowNullRef12:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %57
+ThrowNullRef14:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %63
+ThrowNullRef16:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %70
+ThrowNullRef18:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5419,7 +6587,293 @@ ThrowNullRef17:                                   ; preds = %70
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
-Failed to read String.TrimHelper[loadElem]
+Successfully read String.TrimHelper
+
+define %System.String addrspace(1)* @String.TrimHelper(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i16
+  %loc4 = alloca i32
+  %loc5 = alloca i16
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = sub i32 %3, 1
+  store i32 %4, i32* %loc0
+  store i32 0, i32* %loc1
+  %5 = load i32, i32* %arg2
+  %6 = icmp eq i32 %5, 1
+  br i1 %6, label %62, label %7
+
+; <label>:7                                       ; preds = %1
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:8                                       ; preds = %58
+  store i32 0, i32* %loc2
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load i32, i32* %loc1
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2, i32 %10
+  %13 = load i16, i16 addrspace(1)* %12
+  %14 = zext i16 %13 to i32
+  %15 = trunc i32 %14 to i16
+  store i16 %15, i16* %loc3
+  store i32 0, i32* %loc2
+  br label %34
+
+; <label>:16                                      ; preds = %37
+  %17 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %18 = load i32, i32* %loc2
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %17, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %19
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = zext i32 %18 to i64
+  %BoundsCheck = icmp uge i64 %23, %22
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %24
+
+; <label>:24                                      ; preds = %19
+  %25 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 3, i32 %18
+  %26 = load i16, i16 addrspace(1)* %25, align 8
+  %27 = zext i16 %26 to i32
+  %28 = load i16, i16* %loc3
+  %29 = zext i16 %28 to i32
+  %30 = icmp eq i32 %27, %29
+  br i1 %30, label %43, label %31
+
+; <label>:31                                      ; preds = %24
+  %32 = load i32, i32* %loc2
+  %33 = add i32 %32, 1
+  store i32 %33, i32* %loc2
+  br label %34
+
+; <label>:34                                      ; preds = %11, %31
+  %35 = load i32, i32* %loc2
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = icmp slt i32 %35, %41
+  br i1 %42, label %16, label %43
+
+; <label>:43                                      ; preds = %24, %37
+  %44 = load i32, i32* %loc2
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %45, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp eq i32 %44, %50
+  br i1 %51, label %62, label %52
+
+; <label>:52                                      ; preds = %46
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %7, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %57, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %58
+
+; <label>:58                                      ; preds = %55
+  %59 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %60 = load i32, i32 addrspace(1)* %59
+  %61 = icmp slt i32 %56, %60
+  br i1 %61, label %8, label %62
+
+; <label>:62                                      ; preds = %1, %46, %58
+  %63 = load i32, i32* %arg2
+  %64 = icmp eq i32 %63, 0
+  br i1 %64, label %122, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %66, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %67
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %66, i32 0, i32 1
+  %69 = load i32, i32 addrspace(1)* %68
+  %70 = sub i32 %69, 1
+  store i32 %70, i32* %loc0
+  br label %118
+
+; <label>:71                                      ; preds = %118
+  store i32 0, i32* %loc4
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %73 = load i32, i32* %loc0
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %74
+
+; <label>:74                                      ; preds = %71
+  %75 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 2, i32 %73
+  %76 = load i16, i16 addrspace(1)* %75
+  %77 = zext i16 %76 to i32
+  %78 = trunc i32 %77 to i16
+  store i16 %78, i16* %loc5
+  store i32 0, i32* %loc4
+  br label %97
+
+; <label>:79                                      ; preds = %100
+  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %81 = load i32, i32* %loc4
+  %NullCheck19 = icmp eq %"System.Char[]" addrspace(1)* %80, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
+
+; <label>:82                                      ; preds = %79
+  %83 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 1
+  %84 = load i32, i32 addrspace(1)* %83
+  %85 = zext i32 %84 to i64
+  %86 = zext i32 %81 to i64
+  %BoundsCheck21 = icmp uge i64 %86, %85
+  br i1 %BoundsCheck21, label %ThrowIndexOutOfRange22, label %87
+
+; <label>:87                                      ; preds = %82
+  %88 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 3, i32 %81
+  %89 = load i16, i16 addrspace(1)* %88, align 8
+  %90 = zext i16 %89 to i32
+  %91 = load i16, i16* %loc5
+  %92 = zext i16 %91 to i32
+  %93 = icmp eq i32 %90, %92
+  br i1 %93, label %106, label %94
+
+; <label>:94                                      ; preds = %87
+  %95 = load i32, i32* %loc4
+  %96 = add i32 %95, 1
+  store i32 %96, i32* %loc4
+  br label %97
+
+; <label>:97                                      ; preds = %74, %94
+  %98 = load i32, i32* %loc4
+  %99 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck15 = icmp eq %"System.Char[]" addrspace(1)* %99, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %100
+
+; <label>:100                                     ; preds = %97
+  %101 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %99, i32 0, i32 1
+  %102 = load i32, i32 addrspace(1)* %101
+  %103 = zext i32 %102 to i64
+  %104 = trunc i64 %103 to i32
+  %105 = icmp slt i32 %98, %104
+  br i1 %105, label %79, label %106
+
+; <label>:106                                     ; preds = %87, %100
+  %107 = load i32, i32* %loc4
+  %108 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck17 = icmp eq %"System.Char[]" addrspace(1)* %108, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %109
+
+; <label>:109                                     ; preds = %106
+  %110 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %108, i32 0, i32 1
+  %111 = load i32, i32 addrspace(1)* %110
+  %112 = zext i32 %111 to i64
+  %113 = trunc i64 %112 to i32
+  %114 = icmp eq i32 %107, %113
+  br i1 %114, label %122, label %115
+
+; <label>:115                                     ; preds = %109
+  %116 = load i32, i32* %loc0
+  %117 = sub i32 %116, 1
+  store i32 %117, i32* %loc0
+  br label %118
+
+; <label>:118                                     ; preds = %67, %115
+  %119 = load i32, i32* %loc0
+  %120 = load i32, i32* %loc1
+  %121 = icmp sge i32 %119, %120
+  br i1 %121, label %71, label %122
+
+; <label>:122                                     ; preds = %62, %109, %118
+  %123 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %124 = load i32, i32* %loc1
+  %125 = load i32, i32* %loc0
+  %126 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %123, i32 %124, i32 %125)
+  ret %System.String addrspace(1)* %126
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %97
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange22:                           ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
 Successfully read String.CreateTrimmedString
 
@@ -5439,8 +6893,8 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
@@ -5535,8 +6989,8 @@ entry:
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i64 2872
   %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
   %8 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %7
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %3
   %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
@@ -5553,8 +7007,8 @@ entry:
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 2864
   %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
   %21 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %20
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
-  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %22
 
 ; <label>:22                                      ; preds = %16
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
@@ -5569,7 +7023,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %16
+ThrowNullRef2:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5586,8 +7040,8 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5613,8 +7067,8 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
@@ -5632,8 +7086,8 @@ entry:
 
 ; <label>:12                                      ; preds = %4
   %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
@@ -5644,8 +7098,8 @@ entry:
 
 ; <label>:19                                      ; preds = %14
   %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %19
   %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
@@ -5660,21 +7114,21 @@ entry:
   %31 = zext i16 %30 to i32
   %32 = bitcast i8* %29 to i16*
   %33 = trunc i32 %31 to i16
-  %NullCheck6 = icmp ne i16* %32, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i16* %32, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %21
   store i16 %33, i16* %32, align 8
   %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %36
 
 ; <label>:36                                      ; preds = %34
   %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
   %38 = load i32, i32 addrspace(1)* %37, align 8
   %39 = add i32 %38, 1
-  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %40
 
 ; <label>:40                                      ; preds = %36
   %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
@@ -5683,16 +7137,16 @@ entry:
 
 ; <label>:42                                      ; preds = %14
   %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
-  br i1 %NullCheck12, label %44, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
   %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
   %47 = load i16, i16* %arg1
   %48 = zext i16 %47 to i32
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = trunc i32 %48 to i16
@@ -5703,31 +7157,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %19
+ThrowNullRef4:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %21
+ThrowNullRef6:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %36
+ThrowNullRef10:                                   ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %42
+ThrowNullRef12:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %44
+ThrowNullRef14:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5740,8 +7194,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -5752,8 +7206,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
@@ -5762,14 +7216,14 @@ entry:
 
 ; <label>:11                                      ; preds = %1
   %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
@@ -5779,15 +7233,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5808,8 +7262,8 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5822,8 +7276,8 @@ entry:
 
 ; <label>:8                                       ; preds = %3
   %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
@@ -5842,15 +7296,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
-  br i1 %NullCheck4, label %22, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
   %24 = load i16*, i16* addrspace(1)* %23, align 8
   %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %25, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
@@ -5859,8 +7313,8 @@ entry:
   store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
@@ -5874,8 +7328,8 @@ entry:
 
 ; <label>:37                                      ; preds = %65
   %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %37
   %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
@@ -5886,16 +7340,16 @@ entry:
   %45 = bitcast i16* %41 to i8*
   %46 = getelementptr inbounds i8, i8* %45, i64 %44
   %47 = bitcast i8* %46 to i16*
-  %NullCheck14 = icmp ne i16* %47, null
-  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %47, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %48
 
 ; <label>:48                                      ; preds = %39
   %49 = load i16, i16* %47, align 8
   %50 = zext i16 %49 to i32
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %52 = load i32, i32* %loc1
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %53
 
 ; <label>:53                                      ; preds = %48
   %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
@@ -5916,8 +7370,8 @@ entry:
 ; <label>:62                                      ; preds = %36, %59
   %63 = load i32, i32* %loc1
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck10, label %65, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %65
 
 ; <label>:65                                      ; preds = %62
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
@@ -5936,15 +7390,15 @@ entry:
 
 ; <label>:74                                      ; preds = %70
   %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
-  br i1 %NullCheck18, label %76, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %76
 
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
   %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
-  br i1 %NullCheck20, label %80, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
   %81 = load i64, i64 addrspace(1)* %79
@@ -5958,8 +7412,8 @@ entry:
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
   %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
-  br i1 %NullCheck22, label %92, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.String addrspace(1)* %90, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %92
 
 ; <label>:92                                      ; preds = %80
   %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
@@ -5969,15 +7423,15 @@ entry:
 
 ; <label>:96                                      ; preds = %70
   %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
-  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %98
 
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
   %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
-  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
   %103 = load i64, i64 addrspace(1)* %101
@@ -5991,8 +7445,8 @@ entry:
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
   %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
-  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.String addrspace(1)* %112, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %114
 
 ; <label>:114                                     ; preds = %102
   %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
@@ -6004,59 +7458,59 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %20
+ThrowNullRef4:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %22
+ThrowNullRef6:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %26
+ThrowNullRef8:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %62
+ThrowNullRef10:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %48
+ThrowNullRef16:                                   ; preds = %48
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %74
+ThrowNullRef18:                                   ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %76
+ThrowNullRef20:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %80
+ThrowNullRef22:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %96
+ThrowNullRef24:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %98
+ThrowNullRef26:                                   ; preds = %98
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %102
+ThrowNullRef28:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6069,15 +7523,15 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
   %3 = load i16*, i16* addrspace(1)* %2, align 8
   %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
@@ -6087,8 +7541,8 @@ entry:
   %10 = bitcast i16* %3 to i8*
   %11 = getelementptr inbounds i8, i8* %10, i64 %9
   %12 = bitcast i8* %11 to i16*
-  %NullCheck4 = icmp ne i16* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %5
   store i16 0, i16* %12, align 8
@@ -6098,11 +7552,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6119,8 +7573,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -6131,8 +7585,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
@@ -6144,15 +7598,15 @@ entry:
 
 ; <label>:14                                      ; preds = %1
   %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
   %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
   %21 = load i64, i64 addrspace(1)* %19
@@ -6171,15 +7625,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %14
+ThrowNullRef4:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %16
+ThrowNullRef6:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6302,14 +7756,6 @@ entry:
   ret %System.String addrspace(1)* %57
 }
 
-INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
-Successfully read RuntimeHelpers.get_OffsetToStringData
-
-define i32 @RuntimeHelpers.get_OffsetToStringData() {
-entry:
-  ret i32 12
-}
-
 INFO:  jitting method String::Equals using LLILCJit
 Successfully read String.Equals
 
@@ -6381,8 +7827,8 @@ entry:
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
-  br i1 %NullCheck24, label %29, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
   %30 = load i64, i64 addrspace(1)* %28
@@ -6397,8 +7843,8 @@ entry:
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
-  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
   %43 = load i64, i64 addrspace(1)* %41
@@ -6418,8 +7864,8 @@ entry:
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
   %59 = load i64, i64 addrspace(1)* %57
@@ -6434,8 +7880,8 @@ entry:
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck22, label %71, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
   %72 = load i64, i64 addrspace(1)* %70
@@ -6455,8 +7901,8 @@ entry:
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
-  br i1 %NullCheck16, label %87, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = load i64, i64 addrspace(1)* %86
@@ -6471,8 +7917,8 @@ entry:
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck18, label %100, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
   %101 = load i64, i64 addrspace(1)* %99
@@ -6492,8 +7938,8 @@ entry:
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
-  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
   %117 = load i64, i64 addrspace(1)* %115
@@ -6508,8 +7954,8 @@ entry:
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
-  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
   %130 = load i64, i64 addrspace(1)* %128
@@ -6528,15 +7974,15 @@ entry:
 
 ; <label>:142                                     ; preds = %22
   %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
-  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %143, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %144
 
 ; <label>:144                                     ; preds = %142
   %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
   %146 = load i32, i32 addrspace(1)* %145
   %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
-  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %147, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %148
 
 ; <label>:148                                     ; preds = %144
   %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
@@ -6557,15 +8003,15 @@ entry:
 
 ; <label>:159                                     ; preds = %22
   %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
-  br i1 %NullCheck, label %161, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %ThrowNullRef, label %161
 
 ; <label>:161                                     ; preds = %159
   %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
   %163 = load i32, i32 addrspace(1)* %162
   %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
-  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %164, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %165
 
 ; <label>:165                                     ; preds = %161
   %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
@@ -6578,8 +8024,8 @@ entry:
 
 ; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
-  br i1 %NullCheck4, label %172, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %171, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %172
 
 ; <label>:172                                     ; preds = %170
   %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
@@ -6589,8 +8035,8 @@ entry:
 
 ; <label>:176                                     ; preds = %172
   %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
-  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %177, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %178
 
 ; <label>:178                                     ; preds = %176
   %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
@@ -6629,55 +8075,55 @@ ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %161
+ThrowNullRef2:                                    ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %170
+ThrowNullRef4:                                    ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %176
+ThrowNullRef6:                                    ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %142
+ThrowNullRef8:                                    ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %144
+ThrowNullRef10:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %113
+ThrowNullRef12:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %116
+ThrowNullRef14:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %84
+ThrowNullRef16:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %87
+ThrowNullRef18:                                   ; preds = %87
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %55
+ThrowNullRef20:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %58
+ThrowNullRef22:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %26
+ThrowNullRef24:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %29
+ThrowNullRef26:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,8 +8161,8 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck, label %14, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %ThrowNullRef, label %14
 
 ; <label>:14                                      ; preds = %8
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
@@ -6760,8 +8206,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
@@ -6770,14 +8216,14 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32, i32* %loc0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %10
   %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
   %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
@@ -6790,15 +8236,15 @@ entry:
 ; <label>:25                                      ; preds = %19
   %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
-  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
   %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
@@ -6807,8 +8253,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %37 = load i32, i32* %loc0
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %38, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %38
 
 ; <label>:38                                      ; preds = %32
   %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
@@ -6817,14 +8263,14 @@ entry:
 
 ; <label>:40                                      ; preds = %19
   %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %40
   %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
   %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
-  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
-  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
@@ -6832,8 +8278,8 @@ entry:
   %48 = zext i32 %47 to i64
   %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
-  br i1 %NullCheck16, label %51, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %51
 
 ; <label>:51                                      ; preds = %45
   %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
@@ -6847,15 +8293,15 @@ entry:
 ; <label>:57                                      ; preds = %51
   %58 = load i16*, i16** %arg1
   %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
-  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %60
 
 ; <label>:60                                      ; preds = %57
   %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
   %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
-  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %64
 
 ; <label>:64                                      ; preds = %60
   %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
@@ -6864,22 +8310,22 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
   %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
-  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %70
 
 ; <label>:70                                      ; preds = %64
   %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
   %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
-  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
-  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
   %75 = load i32, i32 addrspace(1)* %74
   %76 = zext i32 %75 to i64
   %77 = trunc i64 %76 to i32
-  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
-  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %78
 
 ; <label>:78                                      ; preds = %73
   %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
@@ -6901,8 +8347,8 @@ entry:
   %90 = bitcast i16* %86 to i8*
   %91 = getelementptr inbounds i8, i8* %90, i64 %89
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %93
 
 ; <label>:93                                      ; preds = %80
   %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
@@ -6912,8 +8358,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %99 = load i32, i32* %loc2
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %100
 
 ; <label>:100                                     ; preds = %93
   %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
@@ -6928,63 +8374,63 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %25
+ThrowNullRef6:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %32
+ThrowNullRef10:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %40
+ThrowNullRef12:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %45
+ThrowNullRef16:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %57
+ThrowNullRef18:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %60
+ThrowNullRef20:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %64
+ThrowNullRef22:                                   ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %70
+ThrowNullRef24:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %73
+ThrowNullRef26:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %80
+ThrowNullRef28:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %93
+ThrowNullRef30:                                   ; preds = %93
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7004,8 +8450,8 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
@@ -7033,43 +8479,43 @@ entry:
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %14
   %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
   %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   %28 = load i32, i32 addrspace(1)* %27, align 8
   %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
-  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %30
 
 ; <label>:30                                      ; preds = %26
   %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
   %32 = load i32, i32 addrspace(1)* %31, align 8
   %33 = add i32 %28, %32
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %34
 
 ; <label>:34                                      ; preds = %30
   %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   store i32 %33, i32 addrspace(1)* %35
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
   store i32 0, i32 addrspace(1)* %38
   %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %40
 
 ; <label>:40                                      ; preds = %37
   %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
@@ -7082,8 +8528,8 @@ entry:
 
 ; <label>:47                                      ; preds = %40
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
@@ -7098,8 +8544,8 @@ entry:
   %54 = load i32, i32* %loc0
   %55 = sext i32 %54 to i64
   %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
-  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %57
 
 ; <label>:57                                      ; preds = %52
   %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
@@ -7110,68 +8556,35 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %14
+ThrowNullRef2:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %23
+ThrowNullRef4:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %26
+ThrowNullRef6:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %30
+ThrowNullRef8:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %34
+ThrowNullRef10:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %47
+ThrowNullRef14:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %52
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-}
-
-INFO:  jitting method StringBuilder::get_Length using LLILCJit
-Successfully read StringBuilder.get_Length
-
-define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.StringBuilder addrspace(1)*
-  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
-  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
-
-; <label>:1                                       ; preds = %entry
-  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %3 = load i32, i32 addrspace(1)* %2, align 8
-  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
-
-; <label>:5                                       ; preds = %1
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = add i32 %3, %7
-  ret i32 %8
-
-ThrowNullRef:                                     ; preds = %entry
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef16:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7213,70 +8626,70 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
   %6 = load i32, i32 addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
   store i32 %6, i32 addrspace(1)* %8
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
   %13 = load i32, i32 addrspace(1)* %12, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
   store i32 %13, i32 addrspace(1)* %15
   %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
-  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %18
 
 ; <label>:18                                      ; preds = %14
   %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
   %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
   %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
   %34 = load i32, i32 addrspace(1)* %33, align 8
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
-  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
@@ -7287,39 +8700,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %28
+ThrowNullRef16:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %32
+ThrowNullRef18:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7455,13 +8868,13 @@ entry:
 ; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
@@ -7477,16 +8890,16 @@ entry:
 
 ; <label>:18                                      ; preds = %15
   %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
   store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
   %22 = load i32, i32* %loc0
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %24
 
 ; <label>:24                                      ; preds = %20
   %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
@@ -7498,13 +8911,13 @@ entry:
 ; <label>:28                                      ; preds = %15, %24
   %29 = load i32, i32* %arg1
   %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %31
   %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
@@ -7517,20 +8930,20 @@ entry:
   %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
-  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
   %46 = load i32, i32 addrspace(1)* %45, align 8
   %47 = sub i32 %40, %46
-  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
-  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i32 addrspace(1)* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %48
 
 ; <label>:48                                      ; preds = %44
   store i32 %47, i32 addrspace(1)* %39, align 8
@@ -7538,21 +8951,21 @@ entry:
 
 ; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
-  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %51
 
 ; <label>:51                                      ; preds = %49
   %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %53
 
 ; <label>:53                                      ; preds = %51
   %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
   %55 = load i32, i32 addrspace(1)* %54, align 8
   %56 = load i32, i32* %arg2
   %57 = sub i32 %55, %56
-  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %58
 
 ; <label>:58                                      ; preds = %53
   %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
@@ -7562,13 +8975,13 @@ entry:
 ; <label>:60                                      ; preds = %33, %58
   %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
   %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
-  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %63
 
 ; <label>:63                                      ; preds = %60
   %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
-  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
-  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
@@ -7578,15 +8991,15 @@ entry:
 
 ; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
-  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i32 addrspace(1)* %69, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %70
 
 ; <label>:70                                      ; preds = %68
   %71 = load i32, i32 addrspace(1)* %69, align 8
   store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
-  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
@@ -7596,8 +9009,8 @@ entry:
   store i32 %77, i32* %loc4
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
-  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %80
 
 ; <label>:80                                      ; preds = %73
   %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
@@ -7607,71 +9020,71 @@ entry:
 ; <label>:83                                      ; preds = %80
   store i32 0, i32* %loc3
   %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
-  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
-  br i1 %NullCheck26, label %88, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i32 addrspace(1)* %87, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %88
 
 ; <label>:88                                      ; preds = %85
   %89 = load i32, i32 addrspace(1)* %87, align 8
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
-  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %90
 
 ; <label>:90                                      ; preds = %88
   %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
   store i32 %89, i32 addrspace(1)* %91
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
-  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
-  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %96
 
 ; <label>:96                                      ; preds = %94
   %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
-  br i1 %NullCheck34, label %100, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %100
 
 ; <label>:100                                     ; preds = %96
   %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
-  br i1 %NullCheck36, label %102, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %102
 
 ; <label>:102                                     ; preds = %100
   %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
   %104 = load i32, i32 addrspace(1)* %103, align 8
   %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
-  br i1 %NullCheck38, label %106, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %106
 
 ; <label>:106                                     ; preds = %102
   %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
-  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
-  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %108
 
 ; <label>:108                                     ; preds = %106
   %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
   %110 = load i32, i32 addrspace(1)* %109, align 8
   %111 = add i32 %104, %110
-  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %112
 
 ; <label>:112                                     ; preds = %108
   %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
   store i32 %111, i32 addrspace(1)* %113
   %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
-  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i32 addrspace(1)* %114, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %115
 
 ; <label>:115                                     ; preds = %112
   %116 = load i32, i32 addrspace(1)* %114, align 8
@@ -7681,19 +9094,19 @@ entry:
 ; <label>:118                                     ; preds = %115
   %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
-  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %121
 
 ; <label>:121                                     ; preds = %118
   %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
-  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
-  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %123
 
 ; <label>:123                                     ; preds = %121
   %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
   %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
-  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
-  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %126
 
 ; <label>:126                                     ; preds = %123
   %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
@@ -7705,8 +9118,8 @@ entry:
 
 ; <label>:130                                     ; preds = %80, %115, %126
   %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %132
 
 ; <label>:132                                     ; preds = %130
   %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7715,8 +9128,8 @@ entry:
   %136 = load i32, i32* %loc3
   %137 = sub i32 %135, %136
   %138 = sub i32 %134, %137
-  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %139
 
 ; <label>:139                                     ; preds = %132
   %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7728,16 +9141,16 @@ entry:
 
 ; <label>:144                                     ; preds = %139
   %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
-  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %146
 
 ; <label>:146                                     ; preds = %144
   %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
   %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
   %149 = load i32, i32* %loc2
   %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
-  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %151
 
 ; <label>:151                                     ; preds = %146
   %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
@@ -7754,145 +9167,249 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %18
+ThrowNullRef4:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %31
+ThrowNullRef10:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %44
+ThrowNullRef16:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %68
+ThrowNullRef18:                                   ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %70
+ThrowNullRef20:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %73
+ThrowNullRef22:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %83
+ThrowNullRef24:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %85
+ThrowNullRef26:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %88
+ThrowNullRef28:                                   ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %90
+ThrowNullRef30:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %94
+ThrowNullRef32:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %96
+ThrowNullRef34:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %100
+ThrowNullRef36:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %102
+ThrowNullRef38:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %106
+ThrowNullRef40:                                   ; preds = %106
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %108
+ThrowNullRef42:                                   ; preds = %108
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %112
+ThrowNullRef44:                                   ; preds = %112
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %118
+ThrowNullRef46:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %121
+ThrowNullRef48:                                   ; preds = %121
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %123
+ThrowNullRef50:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %130
+ThrowNullRef52:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %132
+ThrowNullRef54:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %144
+ThrowNullRef56:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %146
+ThrowNullRef58:                                   ; preds = %146
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %60
+ThrowNullRef60:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %63
+ThrowNullRef62:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %49
+ThrowNullRef64:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %51
+ThrowNullRef66:                                   ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %53
+ThrowNullRef68:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(%"System.Char[]" addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %arg0 = alloca %"System.Char[]" addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store %"System.Char[]" addrspace(1)* %param0, %"System.Char[]" addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load i32, i32* %arg4
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %43, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %38, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg1
+  %13 = load i32, i32* %arg4
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %38, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %24 = load i32, i32* %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %35 = load i32, i32* %arg3
+  %36 = load i32, i32* %arg4
+  %37 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %37, %"System.Char[]" addrspace(1)* %34, i32 %35, i32 %36)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:38                                      ; preds = %5, %16
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Successfully read Buffer._Memmove
 
@@ -7914,7 +9431,7 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[loadElem]
+Failed to read AppDomain.SetDataHelper[storeElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -7923,8 +9440,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
@@ -7934,8 +9451,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
@@ -7947,15 +9464,15 @@ entry:
   %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
   %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
@@ -7966,15 +9483,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7992,7 +9509,79 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
-Failed to read Dictionary`2.TryGetValue[loadElemA]
+Successfully read Dictionary`2.TryGetValue
+
+define i8 @"Dictionary`2.TryGetValue"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)* addrspace(1)* %param2) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  %arg2 = alloca %System.__Canon addrspace(1)* addrspace(1)*
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  store %System.__Canon addrspace(1)* addrspace(1)* %param2, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  store i32 %2, i32* %loc0
+  %3 = load i32, i32* %loc0
+  %4 = icmp slt i32 %3, 0
+  br i1 %4, label %22, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 2
+  %10 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %9, align 8
+  %11 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = zext i32 %11 to i64
+  %BoundsCheck = icmp uge i64 %16, %15
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 3, i32 %11
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %20, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %6, %System.__Canon addrspace(1)* %21)
+  ret i8 1
+
+; <label>:22                                      ; preds = %entry
+  %23 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %23, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -8058,8 +9647,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
@@ -8091,8 +9680,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
@@ -8171,15 +9760,15 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck, label %19, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %ThrowNullRef, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
   %21 = load i32, i32 addrspace(1)* %20
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
@@ -8202,7 +9791,7 @@ ThrowNullRef:                                     ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %19
+ThrowNullRef2:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8248,8 +9837,8 @@ entry:
   %0 = alloca %System.AppDomainHandle
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %1 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %1, i32 0, i32 15
@@ -8269,8 +9858,8 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
@@ -8286,7 +9875,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -8299,8 +9888,8 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -8327,8 +9916,8 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
@@ -8352,8 +9941,8 @@ entry:
   %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
   store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
@@ -8363,8 +9952,8 @@ entry:
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
@@ -8374,8 +9963,8 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %9
   %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
@@ -8384,8 +9973,8 @@ entry:
 
 ; <label>:18                                      ; preds = %3, %16
   %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
@@ -8397,15 +9986,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %18
+ThrowNullRef6:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8418,8 +10007,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
@@ -8453,15 +10042,15 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
@@ -8473,7 +10062,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8481,7 +10070,7 @@ ThrowNullRef1:                                    ; preds = %1
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
 Failed to read Dictionary`2.System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
@@ -8506,8 +10095,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
@@ -8524,8 +10113,8 @@ entry:
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -8544,7 +10133,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8577,8 +10166,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = load i64, i64* %arg2
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = trunc i32 %3 to i8
@@ -8634,46 +10223,46 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
   %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
-  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
-  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
-  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
@@ -8684,27 +10273,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %20
+ThrowNullRef12:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8717,8 +10306,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -8756,22 +10345,22 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
   %9 = load i64, i64 addrspace(1)* %8, align 8
   %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
   %13 = load i64, i64 addrspace(1)* %12, align 8
   %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %11
   %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
@@ -8788,11 +10377,11 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8882,8 +10471,8 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
@@ -8900,8 +10489,8 @@ entry:
 ; <label>:8                                       ; preds = %1
   %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
   %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
@@ -8911,15 +10500,15 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
   %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
   %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
-  br i1 %NullCheck6, label %21, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
@@ -8946,15 +10535,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8992,15 +10581,15 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
   store i8 %3, i8 addrspace(1)* %5
   %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
@@ -9011,7 +10600,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9027,8 +10616,8 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -9041,8 +10630,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
@@ -9058,7 +10647,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9080,8 +10669,8 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
@@ -9096,8 +10685,8 @@ entry:
 ; <label>:12                                      ; preds = %6
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
@@ -9112,8 +10701,8 @@ entry:
 ; <label>:21                                      ; preds = %15
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
@@ -9128,8 +10717,8 @@ entry:
 ; <label>:30                                      ; preds = %24
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %31, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
@@ -9144,8 +10733,8 @@ entry:
 ; <label>:39                                      ; preds = %33
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
-  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %40, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %42
 
 ; <label>:42                                      ; preds = %39
   %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
@@ -9164,19 +10753,19 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %21
+ThrowNullRef4:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %30
+ThrowNullRef6:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %39
+ThrowNullRef8:                                    ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9243,8 +10832,8 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
@@ -9264,57 +10853,57 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
   store i8 0, i8 addrspace(1)* %2
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
   store i8 0, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
   store i8 0, i8 addrspace(1)* %17
   %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
   store i8 0, i8 addrspace(1)* %20
   %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
-  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
@@ -9325,31 +10914,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %19
+ThrowNullRef14:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9367,8 +10956,8 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
@@ -9380,8 +10969,8 @@ entry:
 
 ; <label>:9                                       ; preds = %4
   %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %9
   %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
@@ -9395,7 +10984,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef2:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9420,8 +11009,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
@@ -9512,8 +11101,8 @@ entry:
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
@@ -9524,8 +11113,8 @@ entry:
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = load i64, i64 addrspace(1)* %12
@@ -9537,8 +11126,8 @@ entry:
   %20 = load i64, i64* %19
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
-  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %13
   %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
@@ -9555,8 +11144,8 @@ entry:
 ; <label>:30                                      ; preds = %25
   %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %32 = load i32, i32* %arg2
-  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
-  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
@@ -9570,15 +11159,15 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %30
+ThrowNullRef2:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9622,87 +11211,87 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
   %10 = load i8, i8 addrspace(1)* %9, align 8
   %11 = zext i8 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %8
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
   store i8 %12, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
   %19 = load i8, i8 addrspace(1)* %18, align 8
   %20 = zext i8 %19 to i32
   %21 = trunc i32 %20 to i8
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
   store i8 %21, i8 addrspace(1)* %23
   %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
   %28 = load i8, i8 addrspace(1)* %27, align 8
   %29 = zext i8 %28 to i32
   %30 = trunc i32 %29 to i8
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
-  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %31
 
 ; <label>:31                                      ; preds = %26
   %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
   store i8 %30, i8 addrspace(1)* %32
   %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
-  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
-  br i1 %NullCheck14, label %40, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %40
 
 ; <label>:40                                      ; preds = %35
   %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
   store i8 %39, i8 addrspace(1)* %41
   %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
-  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %44
 
 ; <label>:44                                      ; preds = %40
   %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
   %46 = load i8, i8 addrspace(1)* %45, align 8
   %47 = zext i8 %46 to i32
   %48 = trunc i32 %47 to i8
-  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
   store i8 %48, i8 addrspace(1)* %50
   %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
-  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
@@ -9713,29 +11302,29 @@ entry:
 ; <label>:56                                      ; preds = %52
   %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
-  br i1 %NullCheck22, label %59, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
   %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
   %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
-  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
-  br i1 %NullCheck24, label %63, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
   %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
-  br i1 %NullCheck26, label %66, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
   %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
-  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
-  br i1 %NullCheck28, label %69, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %69
 
 ; <label>:69                                      ; preds = %66
   %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
@@ -9744,15 +11333,15 @@ entry:
 
 ; <label>:71                                      ; preds = %105
   %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
-  br i1 %NullCheck34, label %73, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %73
 
 ; <label>:73                                      ; preds = %71
   %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
   %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
   %76 = load i32, i32* %loc0
-  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
-  br i1 %NullCheck36, label %77, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
@@ -9766,8 +11355,8 @@ entry:
 
 ; <label>:83                                      ; preds = %77
   %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
-  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
@@ -9775,14 +11364,14 @@ entry:
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
   %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
-  br i1 %NullCheck40, label %91, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
 ; <label>:91                                      ; preds = %85
   %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
   %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
-  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck42, label %94, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %94
 
 ; <label>:94                                      ; preds = %91
   %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
@@ -9798,14 +11387,14 @@ entry:
 ; <label>:99                                      ; preds = %69, %96
   %100 = load i32, i32* %loc0
   %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
-  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %102
 
 ; <label>:102                                     ; preds = %99
   %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
   %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
-  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
-  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
@@ -9819,87 +11408,87 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %26
+ThrowNullRef10:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %31
+ThrowNullRef12:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %35
+ThrowNullRef14:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %40
+ThrowNullRef16:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %56
+ThrowNullRef22:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %59
+ThrowNullRef24:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %63
+ThrowNullRef26:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %66
+ThrowNullRef28:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %102
+ThrowNullRef32:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %71
+ThrowNullRef34:                                   ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %73
+ThrowNullRef36:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %83
+ThrowNullRef38:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %85
+ThrowNullRef40:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %91
+ThrowNullRef42:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9943,15 +11532,15 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
   %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
@@ -9961,28 +11550,28 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
   %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %12
   %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
   %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
   %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
-  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
@@ -9993,23 +11582,23 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %12
+ThrowNullRef6:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10031,15 +11620,15 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
   %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = load i64, i64 addrspace(1)* %7
@@ -10077,13 +11666,13 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[loadElem]
+Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -10111,8 +11700,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -10175,8 +11764,8 @@ entry:
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load float, float* %arg0
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -10310,8 +11899,8 @@ entry:
   store i64 %param0, i64* %arg0
   store i64 %param1, i64* %arg1
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
@@ -10319,8 +11908,8 @@ entry:
   %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
   %5 = load i16*, i16* addrspace(1)* %4, align 8
   %6 = addrspacecast i64* %arg1 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = bitcast i64 addrspace(1)* %6 to i8 addrspace(1)*
@@ -10336,7 +11925,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10370,8 +11959,8 @@ entry:
   %1 = load i32, i32* %arg1
   %2 = sext i32 %1 to i64
   %3 = inttoptr i64 %2 to i16*
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -10424,8 +12013,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, i32)*)(%System.IO.ConsoleStream addrspace(1)* %2, i32 %1)
   %3 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %4 = load i64, i64* %arg1
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
@@ -10436,8 +12025,8 @@ entry:
   %10 = icmp eq i32 %9, 3
   %11 = sext i1 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %5
   %14 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, i32 0, i32 5
@@ -10448,7 +12037,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10471,8 +12060,8 @@ entry:
   %5 = icmp eq i32 %4, 1
   %6 = sext i1 %5 to i32
   %7 = trunc i32 %6 to i8
-  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %2, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.ConsoleStream addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
@@ -10483,8 +12072,8 @@ entry:
   %13 = icmp eq i32 %12, 2
   %14 = sext i1 %13 to i32
   %15 = trunc i32 %14 to i8
-  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %10, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.ConsoleStream addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %8
   %17 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %10, i32 0, i32 4
@@ -10495,7 +12084,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10534,8 +12123,8 @@ entry:
   %arg0 = alloca i64
   store i64 %param0, i64* %arg0
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
@@ -10570,8 +12159,8 @@ entry:
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
   %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = load i64, i64 addrspace(1)* %7
@@ -10675,7 +12264,127 @@ entry:
 INFO:  jitting method Encoding::GetEncoding using LLILCJit
 Failed to read Encoding.GetEncoding[convertToHelperArgumentType]
 INFO:  jitting method EncodingProvider::GetEncodingFromProvider using LLILCJit
-Failed to read EncodingProvider.GetEncodingFromProvider[loadElem]
+Successfully read EncodingProvider.GetEncodingFromProvider
+
+define %System.Text.Encoding addrspace(1)* @EncodingProvider.GetEncodingFromProvider(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca %"System.Text.EncodingProvider[]" addrspace(1)*
+  %loc1 = alloca %System.Text.EncodingProvider addrspace(1)*
+  %loc2 = alloca %System.Text.Encoding addrspace(1)*
+  %loc3 = alloca %System.Text.Encoding addrspace(1)*
+  %loc4 = alloca %"System.Text.EncodingProvider[]" addrspace(1)*
+  %loc5 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1059)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2392
+  %2 = addrspacecast i8 addrspace(1)* %1 to %"System.Text.EncodingProvider[]" addrspace(1)**
+  %3 = load volatile %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %2
+  %4 = icmp ne %"System.Text.EncodingProvider[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %entry
+  ret %System.Text.Encoding addrspace(1)* null
+
+; <label>:6                                       ; preds = %entry
+  %7 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1059)
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i64 2392
+  %9 = addrspacecast i8 addrspace(1)* %8 to %"System.Text.EncodingProvider[]" addrspace(1)**
+  %10 = load volatile %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %9
+  store %"System.Text.EncodingProvider[]" addrspace(1)* %10, %"System.Text.EncodingProvider[]" addrspace(1)** %loc0
+  %11 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc0
+  store %"System.Text.EncodingProvider[]" addrspace(1)* %11, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  store i32 0, i32* %loc5
+  br label %43
+
+; <label>:12                                      ; preds = %46
+  %13 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  %14 = load i32, i32* %loc5
+  %NullCheck1 = icmp eq %"System.Text.EncodingProvider[]" addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %13, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = zext i32 %17 to i64
+  %19 = zext i32 %14 to i64
+  %BoundsCheck = icmp uge i64 %19, %18
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %20
+
+; <label>:20                                      ; preds = %15
+  %21 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %13, i32 0, i32 3, i32 %14
+  %22 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)* addrspace(1)* %21, align 8
+  store %System.Text.EncodingProvider addrspace(1)* %22, %System.Text.EncodingProvider addrspace(1)** %loc1
+  %23 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)** %loc1
+  %24 = load i32, i32* %arg0
+  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i64 addrspace(1)*
+  %NullCheck3 = icmp eq i64 addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
+
+; <label>:26                                      ; preds = %20
+  %27 = load i64, i64 addrspace(1)* %25
+  %28 = add i64 %27, 64
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 40
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Text.Encoding addrspace(1)* (%System.Text.EncodingProvider addrspace(1)*, i32)*
+  %35 = call %System.Text.Encoding addrspace(1)* %34(%System.Text.EncodingProvider addrspace(1)* %23, i32 %24)
+  store %System.Text.Encoding addrspace(1)* %35, %System.Text.Encoding addrspace(1)** %loc2
+  %36 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc2
+  %37 = icmp eq %System.Text.Encoding addrspace(1)* %36, null
+  br i1 %37, label %40, label %38
+
+; <label>:38                                      ; preds = %26
+  %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc2
+  store %System.Text.Encoding addrspace(1)* %39, %System.Text.Encoding addrspace(1)** %loc3
+  br label %53
+
+; <label>:40                                      ; preds = %26
+  %41 = load i32, i32* %loc5
+  %42 = add i32 %41, 1
+  store i32 %42, i32* %loc5
+  br label %43
+
+; <label>:43                                      ; preds = %6, %40
+  %44 = load i32, i32* %loc5
+  %45 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  %NullCheck = icmp eq %"System.Text.EncodingProvider[]" addrspace(1)* %45, null
+  br i1 %NullCheck, label %ThrowNullRef, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp slt i32 %44, %50
+  br i1 %51, label %12, label %52
+
+; <label>:52                                      ; preds = %46
+  ret %System.Text.Encoding addrspace(1)* null
+
+; <label>:53                                      ; preds = %38
+  %54 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc3
+  ret %System.Text.Encoding addrspace(1)* %54
+
+ThrowNullRef:                                     ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method EncodingProvider::.cctor using LLILCJit
 Successfully read EncodingProvider..cctor
 
@@ -10694,7 +12403,7 @@ Failed to read Encoding.get_InternalSyncObject[Call HasTypeArg]
 INFO:  jitting method Hashtable::.ctor using LLILCJit
 Failed to read Hashtable..ctor[Volatile store]
 INFO:  jitting method Hashtable::get_Item using LLILCJit
-Failed to read Hashtable.get_Item[loadElemA]
+Failed to read Hashtable.get_Item[loadNonPrimitiveObj]
 INFO:  jitting method Hashtable::InitHash using LLILCJit
 Successfully read Hashtable.InitHash
 
@@ -10714,8 +12423,8 @@ entry:
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -10731,15 +12440,15 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
   %15 = load i32, i32* %loc0
-  %NullCheck2 = icmp ne i32 addrspace(1)* %14, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i32 addrspace(1)* %14, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %3
   store i32 %15, i32 addrspace(1)* %14, align 8
   %17 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %18 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %NullCheck4 = icmp ne i32 addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i32 addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = load i32, i32 addrspace(1)* %18, align 8
@@ -10748,8 +12457,8 @@ entry:
   %23 = sub i32 %22, 1
   %24 = urem i32 %21, %23
   %25 = add i32 1, %24
-  %NullCheck6 = icmp ne i32 addrspace(1)* %17, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32 addrspace(1)* %17, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %19
   store i32 %25, i32 addrspace(1)* %17, align 8
@@ -10760,15 +12469,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %19
+ThrowNullRef6:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10783,8 +12492,8 @@ entry:
   store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
   store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %NullCheck = icmp ne %System.Collections.Hashtable addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Collections.Hashtable addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
@@ -10794,16 +12503,16 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Collections.Hashtable addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Collections.Hashtable addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
   %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck4 = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %9, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
   %13 = inttoptr i64 %11 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
@@ -10813,8 +12522,8 @@ entry:
 ; <label>:15                                      ; preds = %1
   %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -10832,15 +12541,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10854,8 +12563,8 @@ entry:
   store %System.Int32 addrspace(1)* %param0, %System.Int32 addrspace(1)** %this
   %0 = load %System.Int32 addrspace(1)*, %System.Int32 addrspace(1)** %this
   %1 = bitcast %System.Int32 addrspace(1)* %0 to i32 addrspace(1)*
-  %NullCheck = icmp ne i32 addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq i32 addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load i32, i32 addrspace(1)* %1, align 8
@@ -10931,8 +12640,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.UTF8Encoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
@@ -10941,15 +12650,15 @@ entry:
   %9 = load i8, i8* %arg2
   %10 = zext i8 %9 to i32
   %11 = trunc i32 %10 to i8
-  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %8, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %6
   %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %8, i32 0, i32 8
   store i8 %11, i8 addrspace(1)* %13
   %14 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %14, i32 0, i32 8
@@ -10961,8 +12670,8 @@ entry:
 ; <label>:20                                      ; preds = %15
   %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %22, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %22, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = load i64, i64 addrspace(1)* %22
@@ -10984,15 +12693,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %12
+ThrowNullRef4:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11007,8 +12716,8 @@ entry:
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
@@ -11030,16 +12739,16 @@ entry:
 ; <label>:10                                      ; preds = %1
   %11 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
   %12 = load i32, i32* %arg1
-  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %11, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.Encoding addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
   store i32 %12, i32 addrspace(1)* %14
   %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
   %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = load i64, i64 addrspace(1)* %16
@@ -11057,11 +12766,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11074,8 +12783,8 @@ entry:
   %this = alloca %System.Text.UTF8Encoding addrspace(1)*
   store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
   %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.UTF8Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
@@ -11087,16 +12796,16 @@ entry:
 ; <label>:6                                       ; preds = %1
   %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %8 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %10, %System.Text.EncoderFallback addrspace(1)* %8)
   %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %12 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
-  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %11, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %11, i32 0, i32 3
@@ -11109,8 +12818,8 @@ entry:
   %18 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %18, %System.String addrspace(1)* %17)
   %19 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %18 to %System.Text.EncoderFallback addrspace(1)*
-  %NullCheck6 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %16, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %16, i32 0, i32 2
@@ -11120,8 +12829,8 @@ entry:
   %24 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %24, %System.String addrspace(1)* %23)
   %25 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %24 to %System.Text.DecoderFallback addrspace(1)*
-  %NullCheck8 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %22, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %22, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %20
   %27 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %22, i32 0, i32 3
@@ -11132,19 +12841,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %20
+ThrowNullRef8:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11174,8 +12883,8 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load i32, i32* %arg1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -11193,8 +12902,8 @@ entry:
 ; <label>:15                                      ; preds = %8
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %17 = load i32, i32* %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 %17
@@ -11210,7 +12919,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11262,7 +12971,7 @@ entry:
 }
 
 INFO:  jitting method Hashtable::Insert using LLILCJit
-Failed to read Hashtable.Insert[loadElemA]
+Failed to read Hashtable.Insert[storeElem]
 INFO:  jitting method ConsoleEncoding::.ctor using LLILCJit
 Successfully read ConsoleEncoding..ctor
 
@@ -11277,8 +12986,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %1)
   %2 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
@@ -11314,8 +13023,8 @@ entry:
   %2 = call %System.Text.InternalEncoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalEncoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %1)
   %3 = bitcast %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2 to %System.Text.EncoderFallback addrspace(1)*
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
@@ -11325,8 +13034,8 @@ entry:
   %8 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %7)
   %9 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %8 to %System.Text.DecoderFallback addrspace(1)*
-  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %6, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.Encoding addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %4
   %11 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %6, i32 0, i32 3
@@ -11337,7 +13046,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11356,15 +13065,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* %1)
   %2 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   %6 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, i32 0, i32 1
@@ -11375,7 +13084,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11403,8 +13112,8 @@ entry:
   store %System.Text.InternalDecoderBestFitFallback addrspace(1)* %param0, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
   %0 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
@@ -11414,15 +13123,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %4)
   %5 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %6)
   %9 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, i32 0, i32 1
@@ -11433,11 +13142,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11505,8 +13214,8 @@ entry:
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
   %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = load i64, i64 addrspace(1)* %19
@@ -11570,8 +13279,8 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.ConsoleStream addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
@@ -11602,31 +13311,31 @@ entry:
   store i8 %param4, i8* %arg4
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %3, %System.IO.Stream addrspace(1)* %1)
   %4 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %4, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
   %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %4, i32 0, i32 4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %5)
   %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %6
   %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
   %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
   %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = load i64, i64 addrspace(1)* %13
@@ -11638,8 +13347,8 @@ entry:
   %21 = load i64, i64* %20
   %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %8, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %8, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %14
   %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 5
@@ -11657,24 +13366,24 @@ entry:
   %31 = load i32, i32* %arg3
   %32 = sext i32 %31 to i64
   %33 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %32)
-  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %30, null
-  br i1 %NullCheck10, label %34, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.StreamWriter addrspace(1)* %30, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %35, %"System.Char[]" addrspace(1)* %33)
   %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %37, null
-  br i1 %NullCheck12, label %38, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.StreamWriter addrspace(1)* %37, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %38
 
 ; <label>:38                                      ; preds = %34
   %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
   %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
   %41 = load i32, i32* %arg3
   %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %42, null
-  br i1 %NullCheck14, label %43, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %42, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
   %44 = load i64, i64 addrspace(1)* %42
@@ -11688,30 +13397,30 @@ entry:
   %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
   %53 = sext i32 %52 to i64
   %54 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %53)
-  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
-  br i1 %NullCheck16, label %55, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %55
 
 ; <label>:55                                      ; preds = %43
   %56 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %56, %"System.Byte[]" addrspace(1)* %54)
   %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %58 = load i32, i32* %arg3
-  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %57, null
-  br i1 %NullCheck18, label %59, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.StreamWriter addrspace(1)* %57, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %59
 
 ; <label>:59                                      ; preds = %55
   %60 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 10
   store i32 %58, i32 addrspace(1)* %60
   %61 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %61, null
-  br i1 %NullCheck20, label %62, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.IO.StreamWriter addrspace(1)* %61, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %62
 
 ; <label>:62                                      ; preds = %59
   %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
   %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
   %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
   %67 = load i64, i64 addrspace(1)* %65
@@ -11729,15 +13438,15 @@ entry:
 
 ; <label>:78                                      ; preds = %66
   %79 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %79, null
-  br i1 %NullCheck24, label %80, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.StreamWriter addrspace(1)* %79, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %80
 
 ; <label>:80                                      ; preds = %78
   %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
   %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
   %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %83, null
-  br i1 %NullCheck26, label %84, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %83, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
   %85 = load i64, i64 addrspace(1)* %83
@@ -11754,8 +13463,8 @@ entry:
 
 ; <label>:95                                      ; preds = %84
   %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.IO.StreamWriter addrspace(1)* %96, null
-  br i1 %NullCheck28, label %97, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.IO.StreamWriter addrspace(1)* %96, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %97
 
 ; <label>:97                                      ; preds = %95
   %98 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 12
@@ -11769,8 +13478,8 @@ entry:
   %103 = icmp eq i32 %102, 0
   %104 = sext i1 %103 to i32
   %105 = trunc i32 %104 to i8
-  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %100, null
-  br i1 %NullCheck30, label %106, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.IO.StreamWriter addrspace(1)* %100, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %106
 
 ; <label>:106                                     ; preds = %99
   %107 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %100, i32 0, i32 13
@@ -11781,63 +13490,63 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %6
+ThrowNullRef4:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %29
+ThrowNullRef10:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %34
+ThrowNullRef12:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %38
+ThrowNullRef14:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %43
+ThrowNullRef16:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %55
+ThrowNullRef18:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %59
+ThrowNullRef20:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %62
+ThrowNullRef22:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %78
+ThrowNullRef24:                                   ; preds = %78
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %80
+ThrowNullRef26:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %95
+ThrowNullRef28:                                   ; preds = %95
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11850,15 +13559,15 @@ entry:
   %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = load i64, i64 addrspace(1)* %4
@@ -11876,7 +13585,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11926,35 +13635,35 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
   %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderNLS addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %7 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.EncoderNLS addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Text.Encoding addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.Encoding addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Text.EncoderNLS addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.EncoderNLS addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
   %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck8 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = load i64, i64 addrspace(1)* %16
@@ -11973,19 +13682,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12011,8 +13720,8 @@ entry:
   %this = alloca %System.Text.Encoding addrspace(1)*
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
@@ -12032,15 +13741,15 @@ entry:
   %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
   store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
   %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
   store i32 0, i32 addrspace(1)* %2
   %3 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, i32 0, i32 2
@@ -12050,15 +13759,15 @@ entry:
 
 ; <label>:8                                       ; preds = %4
   %9 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
   %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
   %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = load i64, i64 addrspace(1)* %13
@@ -12079,15 +13788,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12102,16 +13811,16 @@ entry:
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = load i32, i32* %arg1
   %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
   %7 = load i64, i64 addrspace(1)* %5
@@ -12129,7 +13838,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12166,8 +13875,8 @@ entry:
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
   %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
   %16 = load i64, i64 addrspace(1)* %14
@@ -12188,8 +13897,8 @@ entry:
   %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
   %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
   %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %31, null
-  br i1 %NullCheck2, label %32, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = load i64, i64 addrspace(1)* %31
@@ -12232,7 +13941,7 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12245,14 +13954,14 @@ entry:
   %this = alloca %System.Text.EncoderReplacementFallback addrspace(1)*
   store %System.Text.EncoderReplacementFallback addrspace(1)* %param0, %System.Text.EncoderReplacementFallback addrspace(1)** %this
   %0 = load %System.Text.EncoderReplacementFallback addrspace(1)*, %System.Text.EncoderReplacementFallback addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -12263,7 +13972,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12293,8 +14002,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
@@ -12326,8 +14035,8 @@ entry:
   %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
   store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
@@ -12339,8 +14048,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Threading.Tasks.Task addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %7)
@@ -12363,7 +14072,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12382,8 +14091,8 @@ entry:
   store i8 %param1, i8* %arg1
   store i8 %param2, i8* %arg2
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
@@ -12397,8 +14106,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1, %5
   %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 9
@@ -12429,8 +14138,8 @@ entry:
 
 ; <label>:25                                      ; preds = %8, %20
   %26 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %26, null
-  br i1 %NullCheck4, label %27, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %26, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %26, i32 0, i32 12
@@ -12441,22 +14150,22 @@ entry:
 
 ; <label>:32                                      ; preds = %27
   %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %33, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.IO.StreamWriter addrspace(1)* %33, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %32
   %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 12
   store i8 1, i8 addrspace(1)* %35
   %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
-  br i1 %NullCheck8, label %37, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
   %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
   %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck10 = icmp ne i64 addrspace(1)* %40, null
-  br i1 %NullCheck10, label %41, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64 addrspace(1)* %40, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i64, i64 addrspace(1)* %40
@@ -12470,8 +14179,8 @@ entry:
   %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
   store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
   %51 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %NullCheck12 = icmp ne %"System.Byte[]" addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Byte[]" addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %41
   %53 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %51, i32 0, i32 1
@@ -12483,16 +14192,16 @@ entry:
 
 ; <label>:58                                      ; preds = %52
   %59 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %59, null
-  br i1 %NullCheck14, label %60, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.IO.StreamWriter addrspace(1)* %59, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %60
 
 ; <label>:60                                      ; preds = %58
   %61 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %59, i32 0, i32 3
   %62 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
   %64 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %NullCheck16 = icmp ne %"System.Byte[]" addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %"System.Byte[]" addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %60
   %66 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %64, i32 0, i32 1
@@ -12500,8 +14209,8 @@ entry:
   %68 = zext i32 %67 to i64
   %69 = trunc i64 %68 to i32
   %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck18, label %71, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
   %72 = load i64, i64 addrspace(1)* %70
@@ -12517,29 +14226,29 @@ entry:
 
 ; <label>:80                                      ; preds = %27, %52, %71
   %81 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %81, null
-  br i1 %NullCheck20, label %82, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.IO.StreamWriter addrspace(1)* %81, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
 
 ; <label>:82                                      ; preds = %80
   %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %81, i32 0, i32 5
   %84 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %83, align 8
   %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.IO.StreamWriter addrspace(1)* %85, null
-  br i1 %NullCheck22, label %86, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.IO.StreamWriter addrspace(1)* %85, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %86
 
 ; <label>:86                                      ; preds = %82
   %87 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 7
   %88 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %87, align 8
   %89 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %89, null
-  br i1 %NullCheck24, label %90, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.StreamWriter addrspace(1)* %89, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %90
 
 ; <label>:90                                      ; preds = %86
   %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %89, i32 0, i32 9
   %92 = load i32, i32 addrspace(1)* %91, align 8
   %93 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.IO.StreamWriter addrspace(1)* %93, null
-  br i1 %NullCheck26, label %94, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.IO.StreamWriter addrspace(1)* %93, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %93, i32 0, i32 6
@@ -12547,8 +14256,8 @@ entry:
   %97 = load i8, i8* %arg2
   %98 = zext i8 %97 to i32
   %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
-  %NullCheck28 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck28, label %100, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
   %101 = load i64, i64 addrspace(1)* %99
@@ -12563,8 +14272,8 @@ entry:
   %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
   store i32 %110, i32* %loc1
   %111 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %111, null
-  br i1 %NullCheck30, label %112, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.IO.StreamWriter addrspace(1)* %111, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %112
 
 ; <label>:112                                     ; preds = %100
   %113 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %111, i32 0, i32 9
@@ -12575,23 +14284,23 @@ entry:
 
 ; <label>:116                                     ; preds = %112
   %117 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck32 = icmp ne %System.IO.StreamWriter addrspace(1)* %117, null
-  br i1 %NullCheck32, label %118, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.IO.StreamWriter addrspace(1)* %117, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %118
 
 ; <label>:118                                     ; preds = %116
   %119 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %117, i32 0, i32 3
   %120 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %119, align 8
   %121 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.IO.StreamWriter addrspace(1)* %121, null
-  br i1 %NullCheck34, label %122, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.IO.StreamWriter addrspace(1)* %121, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %122
 
 ; <label>:122                                     ; preds = %118
   %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
   %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
   %125 = load i32, i32* %loc1
   %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
-  %NullCheck36 = icmp ne i64 addrspace(1)* %126, null
-  br i1 %NullCheck36, label %127, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64 addrspace(1)* %126, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
   %128 = load i64, i64 addrspace(1)* %126
@@ -12613,15 +14322,15 @@ entry:
 
 ; <label>:140                                     ; preds = %136
   %141 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.IO.StreamWriter addrspace(1)* %141, null
-  br i1 %NullCheck38, label %142, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.IO.StreamWriter addrspace(1)* %141, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %142
 
 ; <label>:142                                     ; preds = %140
   %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
   %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
   %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
-  %NullCheck40 = icmp ne i64 addrspace(1)* %145, null
-  br i1 %NullCheck40, label %146, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i64 addrspace(1)* %145, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
   %147 = load i64, i64 addrspace(1)* %145
@@ -12642,83 +14351,83 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %25
+ThrowNullRef4:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %32
+ThrowNullRef6:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %37
+ThrowNullRef10:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %41
+ThrowNullRef12:                                   ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %58
+ThrowNullRef14:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %60
+ThrowNullRef16:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %65
+ThrowNullRef18:                                   ; preds = %65
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %80
+ThrowNullRef20:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %82
+ThrowNullRef22:                                   ; preds = %82
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %86
+ThrowNullRef24:                                   ; preds = %86
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %90
+ThrowNullRef26:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %94
+ThrowNullRef28:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %100
+ThrowNullRef30:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %116
+ThrowNullRef32:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %118
+ThrowNullRef34:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %122
+ThrowNullRef36:                                   ; preds = %122
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %140
+ThrowNullRef38:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %142
+ThrowNullRef40:                                   ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12785,8 +14494,8 @@ entry:
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %1 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
-  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
@@ -12794,8 +14503,8 @@ entry:
   %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
   %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
   %8 = load i64, i64 addrspace(1)* %6
@@ -12811,8 +14520,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %17, %System.IFormatProvider addrspace(1)* %16)
   %18 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %19 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %18, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.SyncTextWriter addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %7
   %21 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %18, i32 0, i32 4
@@ -12823,11 +14532,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12840,8 +14549,8 @@ entry:
   %this = alloca %System.IO.TextWriter addrspace(1)*
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.TextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
@@ -12851,8 +14560,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.Threading.Thread addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Threading.Thread addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %6)
@@ -12861,8 +14570,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1
   %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.TextWriter addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.TextWriter addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %11, i32 0, i32 2
@@ -12873,11 +14582,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13074,8 +14783,8 @@ entry:
   store float %param1, float* %arg1
   store i8 0, i8* %loc1
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
@@ -13085,16 +14794,16 @@ entry:
   %5 = addrspacecast i8* %loc1 to i8 addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %4, i8 addrspace(1)* %5)
   %6 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.SyncTextWriter addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
   %10 = load float, float* %arg1
   %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
   %13 = load i64, i64 addrspace(1)* %11
@@ -13129,11 +14838,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13150,8 +14859,8 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load float, float* %arg1
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -13165,8 +14874,8 @@ entry:
   call void %11(%System.IO.TextWriter addrspace(1)* %0, float %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
   %15 = load i64, i64 addrspace(1)* %13
@@ -13184,7 +14893,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13202,8 +14911,8 @@ entry:
   %1 = addrspacecast float* %arg1 to float addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -13218,8 +14927,8 @@ entry:
   %14 = bitcast float addrspace(1)* %1 to %System.Single addrspace(1)*
   %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Single addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Single addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
   %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
   %18 = load i64, i64 addrspace(1)* %16
@@ -13237,7 +14946,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13253,8 +14962,8 @@ entry:
   store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
   %0 = load %System.Single addrspace(1)*, %System.Single addrspace(1)** %this
   %1 = bitcast %System.Single addrspace(1)* %0 to float addrspace(1)*
-  %NullCheck = icmp ne float addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq float addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load float, float addrspace(1)* %1, align 8
@@ -13279,8 +14988,8 @@ entry:
   %loc0 = alloca %System.Globalization.NumberFormatInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 3
@@ -13290,8 +14999,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
@@ -13301,24 +15010,24 @@ entry:
   store %System.Globalization.NumberFormatInfo addrspace(1)* %10, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
   %11 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %7
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
   %15 = load i8, i8 addrspace(1)* %14, align 8
   %16 = zext i8 %15 to i32
   %17 = trunc i32 %16 to i8
-  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %11, null
-  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %11, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %13
   %19 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %11, i32 0, i32 29
   store i8 %17, i8 addrspace(1)* %19
   %20 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %21 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %20, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %20, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %18
   %23 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %20, i32 0, i32 3
@@ -13327,8 +15036,8 @@ entry:
 
 ; <label>:24                                      ; preds = %1, %22
   %25 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %25, null
-  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %25, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %26
 
 ; <label>:26                                      ; preds = %24
   %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %25, i32 0, i32 3
@@ -13339,23 +15048,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %18
+ThrowNullRef8:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13380,168 +15089,168 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 18
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %8, align 8
-  %NullCheck2 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %5, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %5, i32 0, i32 4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %9)
   %12 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 19
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %15, align 8
-  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %12, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %12, i32 0, i32 5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %16)
   %19 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %20 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %20, null
-  br i1 %NullCheck8, label %21, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %20, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %20, i32 0, i32 23
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  %NullCheck10 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %19, null
-  br i1 %NullCheck10, label %24, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %19, i32 0, i32 7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %25, %System.String addrspace(1)* %23)
   %26 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %27 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %27, i32 0, i32 22
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %29, align 8
-  %NullCheck14 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %26, null
-  br i1 %NullCheck14, label %31, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %26, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %26, i32 0, i32 6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %32, %System.String addrspace(1)* %30)
   %33 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %34 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Globalization.CultureData addrspace(1)* %34, null
-  br i1 %NullCheck16, label %35, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Globalization.CultureData addrspace(1)* %34, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %34, i32 0, i32 51
   %37 = load i32, i32 addrspace(1)* %36, align 8
-  %NullCheck18 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %33, null
-  br i1 %NullCheck18, label %38, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %33, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %33, i32 0, i32 21
   store i32 %37, i32 addrspace(1)* %39
   %40 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %41 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Globalization.CultureData addrspace(1)* %41, null
-  br i1 %NullCheck20, label %42, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Globalization.CultureData addrspace(1)* %41, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %41, i32 0, i32 52
   %44 = load i32, i32 addrspace(1)* %43, align 8
-  %NullCheck22 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %40, null
-  br i1 %NullCheck22, label %45, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %40, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %40, i32 0, i32 25
   store i32 %44, i32 addrspace(1)* %46
   %47 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %48 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.Globalization.CultureData addrspace(1)* %48, null
-  br i1 %NullCheck24, label %49, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Globalization.CultureData addrspace(1)* %48, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %49
 
 ; <label>:49                                      ; preds = %45
   %50 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %48, i32 0, i32 29
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck26 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %47, null
-  br i1 %NullCheck26, label %52, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %47, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %47, i32 0, i32 10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %53, %System.String addrspace(1)* %51)
   %54 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %55 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Globalization.CultureData addrspace(1)* %55, null
-  br i1 %NullCheck28, label %56, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Globalization.CultureData addrspace(1)* %55, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %56
 
 ; <label>:56                                      ; preds = %52
   %57 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %55, i32 0, i32 35
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %57, align 8
-  %NullCheck30 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %54, null
-  br i1 %NullCheck30, label %59, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %54, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %54, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %60, %System.String addrspace(1)* %58)
   %61 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %62 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck32 = icmp ne %System.Globalization.CultureData addrspace(1)* %62, null
-  br i1 %NullCheck32, label %63, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Globalization.CultureData addrspace(1)* %62, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %62, i32 0, i32 34
   %65 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %64, align 8
-  %NullCheck34 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %61, null
-  br i1 %NullCheck34, label %66, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %61, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %61, i32 0, i32 9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %67, %System.String addrspace(1)* %65)
   %68 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %69 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck36 = icmp ne %System.Globalization.CultureData addrspace(1)* %69, null
-  br i1 %NullCheck36, label %70, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Globalization.CultureData addrspace(1)* %69, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %70
 
 ; <label>:70                                      ; preds = %66
   %71 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %69, i32 0, i32 55
   %72 = load i32, i32 addrspace(1)* %71, align 8
-  %NullCheck38 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %68, null
-  br i1 %NullCheck38, label %73, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %68, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %68, i32 0, i32 22
   store i32 %72, i32 addrspace(1)* %74
   %75 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %76 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck40 = icmp ne %System.Globalization.CultureData addrspace(1)* %76, null
-  br i1 %NullCheck40, label %77, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Globalization.CultureData addrspace(1)* %76, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %76, i32 0, i32 57
   %79 = load i32, i32 addrspace(1)* %78, align 8
-  %NullCheck42 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %75, null
-  br i1 %NullCheck42, label %80, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %75, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %80
 
 ; <label>:80                                      ; preds = %77
   %81 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %75, i32 0, i32 24
   store i32 %79, i32 addrspace(1)* %81
   %82 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %83 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck44 = icmp ne %System.Globalization.CultureData addrspace(1)* %83, null
-  br i1 %NullCheck44, label %84, label %ThrowNullRef43
+  %NullCheck43 = icmp eq %System.Globalization.CultureData addrspace(1)* %83, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %84
 
 ; <label>:84                                      ; preds = %80
   %85 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %83, i32 0, i32 56
   %86 = load i32, i32 addrspace(1)* %85, align 8
-  %NullCheck46 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %82, null
-  br i1 %NullCheck46, label %87, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %82, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %82, i32 0, i32 23
@@ -13550,8 +15259,8 @@ entry:
 
 ; <label>:89                                      ; preds = %entry
   %90 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck100 = icmp ne %System.Globalization.CultureData addrspace(1)* %90, null
-  br i1 %NullCheck100, label %91, label %ThrowNullRef99
+  %NullCheck99 = icmp eq %System.Globalization.CultureData addrspace(1)* %90, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %91
 
 ; <label>:91                                      ; preds = %89
   %92 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %90, i32 0, i32 2
@@ -13569,8 +15278,8 @@ entry:
   %102 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %103 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %104 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %103)
-  %NullCheck48 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %102, null
-  br i1 %NullCheck48, label %105, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %102, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %105
 
 ; <label>:105                                     ; preds = %101
   %106 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %102, i32 0, i32 1
@@ -13578,8 +15287,8 @@ entry:
   %107 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %108 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %109 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %108)
-  %NullCheck50 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %107, null
-  br i1 %NullCheck50, label %110, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %107, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %110
 
 ; <label>:110                                     ; preds = %105
   %111 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %107, i32 0, i32 2
@@ -13587,8 +15296,8 @@ entry:
   %112 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %113 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %114 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %113)
-  %NullCheck52 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %112, null
-  br i1 %NullCheck52, label %115, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %112, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %115
 
 ; <label>:115                                     ; preds = %110
   %116 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %112, i32 0, i32 27
@@ -13596,8 +15305,8 @@ entry:
   %117 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %118 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %119 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %118)
-  %NullCheck54 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %117, null
-  br i1 %NullCheck54, label %120, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %117, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %120
 
 ; <label>:120                                     ; preds = %115
   %121 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %117, i32 0, i32 26
@@ -13605,8 +15314,8 @@ entry:
   %122 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %123 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %124 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %123)
-  %NullCheck56 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %122, null
-  br i1 %NullCheck56, label %125, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %122, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %125
 
 ; <label>:125                                     ; preds = %120
   %126 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %122, i32 0, i32 17
@@ -13614,8 +15323,8 @@ entry:
   %127 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %128 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %129 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %128)
-  %NullCheck58 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %127, null
-  br i1 %NullCheck58, label %130, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %127, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %130
 
 ; <label>:130                                     ; preds = %125
   %131 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %127, i32 0, i32 18
@@ -13623,8 +15332,8 @@ entry:
   %132 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %133 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %134 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %133)
-  %NullCheck60 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %132, null
-  br i1 %NullCheck60, label %135, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %132, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %135
 
 ; <label>:135                                     ; preds = %130
   %136 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %132, i32 0, i32 14
@@ -13632,8 +15341,8 @@ entry:
   %137 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %138 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %139 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %138)
-  %NullCheck62 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %137, null
-  br i1 %NullCheck62, label %140, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %137, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %140
 
 ; <label>:140                                     ; preds = %135
   %141 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %137, i32 0, i32 13
@@ -13641,71 +15350,71 @@ entry:
   %142 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %143 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %144 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %143)
-  %NullCheck64 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %142, null
-  br i1 %NullCheck64, label %145, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %142, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %145
 
 ; <label>:145                                     ; preds = %140
   %146 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %142, i32 0, i32 12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %146, %System.String addrspace(1)* %144)
   %147 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %148 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck66 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %148, null
-  br i1 %NullCheck66, label %149, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %148, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %149
 
 ; <label>:149                                     ; preds = %145
   %150 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %148, i32 0, i32 21
   %151 = load i32, i32 addrspace(1)* %150, align 8
-  %NullCheck68 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %147, null
-  br i1 %NullCheck68, label %152, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %147, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %152
 
 ; <label>:152                                     ; preds = %149
   %153 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %147, i32 0, i32 28
   store i32 %151, i32 addrspace(1)* %153
   %154 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %155 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck70 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %155, null
-  br i1 %NullCheck70, label %156, label %ThrowNullRef69
+  %NullCheck69 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %155, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %156
 
 ; <label>:156                                     ; preds = %152
   %157 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %155, i32 0, i32 6
   %158 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %157, align 8
-  %NullCheck72 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %154, null
-  br i1 %NullCheck72, label %159, label %ThrowNullRef71
+  %NullCheck71 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %154, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %159
 
 ; <label>:159                                     ; preds = %156
   %160 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %154, i32 0, i32 15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %160, %System.String addrspace(1)* %158)
   %161 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %162 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck74 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %162, null
-  br i1 %NullCheck74, label %163, label %ThrowNullRef73
+  %NullCheck73 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %162, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %163
 
 ; <label>:163                                     ; preds = %159
   %164 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %162, i32 0, i32 1
   %165 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %164, align 8
-  %NullCheck76 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %161, null
-  br i1 %NullCheck76, label %166, label %ThrowNullRef75
+  %NullCheck75 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %161, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %166
 
 ; <label>:166                                     ; preds = %163
   %167 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %161, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %167, %"System.Int32[]" addrspace(1)* %165)
   %168 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %169 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck78 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %169, null
-  br i1 %NullCheck78, label %170, label %ThrowNullRef77
+  %NullCheck77 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %169, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %170
 
 ; <label>:170                                     ; preds = %166
   %171 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %169, i32 0, i32 7
   %172 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %171, align 8
-  %NullCheck80 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %168, null
-  br i1 %NullCheck80, label %173, label %ThrowNullRef79
+  %NullCheck79 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %168, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %173
 
 ; <label>:173                                     ; preds = %170
   %174 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %168, i32 0, i32 16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %174, %System.String addrspace(1)* %172)
   %175 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck82 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %175, null
-  br i1 %NullCheck82, label %176, label %ThrowNullRef81
+  %NullCheck81 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %175, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %176
 
 ; <label>:176                                     ; preds = %173
   %177 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %175, i32 0, i32 4
@@ -13715,14 +15424,14 @@ entry:
 
 ; <label>:180                                     ; preds = %176
   %181 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck84 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %181, null
-  br i1 %NullCheck84, label %182, label %ThrowNullRef83
+  %NullCheck83 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %181, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %182
 
 ; <label>:182                                     ; preds = %180
   %183 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %181, i32 0, i32 4
   %184 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %183, align 8
-  %NullCheck86 = icmp ne %System.String addrspace(1)* %184, null
-  br i1 %NullCheck86, label %185, label %ThrowNullRef85
+  %NullCheck85 = icmp eq %System.String addrspace(1)* %184, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %185
 
 ; <label>:185                                     ; preds = %182
   %186 = getelementptr inbounds %System.String, %System.String addrspace(1)* %184, i32 0, i32 1
@@ -13733,8 +15442,8 @@ entry:
 ; <label>:189                                     ; preds = %176, %185
   %190 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck98 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %190, null
-  br i1 %NullCheck98, label %192, label %ThrowNullRef97
+  %NullCheck97 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %190, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %192
 
 ; <label>:192                                     ; preds = %189
   %193 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %190, i32 0, i32 4
@@ -13743,8 +15452,8 @@ entry:
 
 ; <label>:194                                     ; preds = %185, %192
   %195 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck88 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %195, null
-  br i1 %NullCheck88, label %196, label %ThrowNullRef87
+  %NullCheck87 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %195, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %196
 
 ; <label>:196                                     ; preds = %194
   %197 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %195, i32 0, i32 9
@@ -13754,14 +15463,14 @@ entry:
 
 ; <label>:200                                     ; preds = %196
   %201 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck90 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %201, null
-  br i1 %NullCheck90, label %202, label %ThrowNullRef89
+  %NullCheck89 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %201, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %202
 
 ; <label>:202                                     ; preds = %200
   %203 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %201, i32 0, i32 9
   %204 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %203, align 8
-  %NullCheck92 = icmp ne %System.String addrspace(1)* %204, null
-  br i1 %NullCheck92, label %205, label %ThrowNullRef91
+  %NullCheck91 = icmp eq %System.String addrspace(1)* %204, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %205
 
 ; <label>:205                                     ; preds = %202
   %206 = getelementptr inbounds %System.String, %System.String addrspace(1)* %204, i32 0, i32 1
@@ -13772,14 +15481,14 @@ entry:
 ; <label>:209                                     ; preds = %196, %205
   %210 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %211 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck94 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %211, null
-  br i1 %NullCheck94, label %212, label %ThrowNullRef93
+  %NullCheck93 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %211, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %212
 
 ; <label>:212                                     ; preds = %209
   %213 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %211, i32 0, i32 6
   %214 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %213, align 8
-  %NullCheck96 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %210, null
-  br i1 %NullCheck96, label %215, label %ThrowNullRef95
+  %NullCheck95 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %210, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %215
 
 ; <label>:215                                     ; preds = %212
   %216 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %210, i32 0, i32 9
@@ -13793,203 +15502,203 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %17
+ThrowNullRef8:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %21
+ThrowNullRef10:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %24
+ThrowNullRef12:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %28
+ThrowNullRef14:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %31
+ThrowNullRef16:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %35
+ThrowNullRef18:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %38
+ThrowNullRef20:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %42
+ThrowNullRef22:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %45
+ThrowNullRef24:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %49
+ThrowNullRef26:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %52
+ThrowNullRef28:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %56
+ThrowNullRef30:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %59
+ThrowNullRef32:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %63
+ThrowNullRef34:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %66
+ThrowNullRef36:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %70
+ThrowNullRef38:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %73
+ThrowNullRef40:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %77
+ThrowNullRef42:                                   ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %80
+ThrowNullRef44:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %84
+ThrowNullRef46:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %101
+ThrowNullRef48:                                   ; preds = %101
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %105
+ThrowNullRef50:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %110
+ThrowNullRef52:                                   ; preds = %110
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %115
+ThrowNullRef54:                                   ; preds = %115
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %120
+ThrowNullRef56:                                   ; preds = %120
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %125
+ThrowNullRef58:                                   ; preds = %125
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %130
+ThrowNullRef60:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %135
+ThrowNullRef62:                                   ; preds = %135
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %140
+ThrowNullRef64:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %145
+ThrowNullRef66:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %149
+ThrowNullRef68:                                   ; preds = %149
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %152
+ThrowNullRef70:                                   ; preds = %152
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %156
+ThrowNullRef72:                                   ; preds = %156
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %159
+ThrowNullRef74:                                   ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %163
+ThrowNullRef76:                                   ; preds = %163
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %166
+ThrowNullRef78:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %170
+ThrowNullRef80:                                   ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %173
+ThrowNullRef82:                                   ; preds = %173
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %180
+ThrowNullRef84:                                   ; preds = %180
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %182
+ThrowNullRef86:                                   ; preds = %182
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %194
+ThrowNullRef88:                                   ; preds = %194
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %200
+ThrowNullRef90:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %202
+ThrowNullRef92:                                   ; preds = %202
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %209
+ThrowNullRef94:                                   ; preds = %209
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %212
+ThrowNullRef96:                                   ; preds = %212
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %189
+ThrowNullRef98:                                   ; preds = %189
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %89
+ThrowNullRef100:                                  ; preds = %89
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14017,8 +15726,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 21
@@ -14031,8 +15740,8 @@ entry:
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 16)
   %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 21
@@ -14041,8 +15750,8 @@ entry:
 
 ; <label>:12                                      ; preds = %1, %10
   %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 21
@@ -14053,11 +15762,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %12
+ThrowNullRef4:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14073,8 +15782,8 @@ entry:
   store i32 %param1, i32* %arg1
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %1 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
@@ -14141,8 +15850,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 33
@@ -14155,8 +15864,8 @@ entry:
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 24)
   %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 33
@@ -14165,8 +15874,8 @@ entry:
 
 ; <label>:12                                      ; preds = %1, %10
   %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 33
@@ -14177,11 +15886,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %12
+ThrowNullRef4:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14194,8 +15903,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 53
@@ -14207,8 +15916,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 116)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 53
@@ -14217,8 +15926,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 53
@@ -14229,11 +15938,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14262,8 +15971,8 @@ entry:
 
 ; <label>:7                                       ; preds = %entry, %4
   %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %7
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 2
@@ -14287,8 +15996,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 54
@@ -14300,8 +16009,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 117)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
@@ -14310,8 +16019,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 54
@@ -14322,11 +16031,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14339,8 +16048,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 27
@@ -14352,8 +16061,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 118)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 27
@@ -14362,8 +16071,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 27
@@ -14374,11 +16083,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14391,8 +16100,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 28
@@ -14404,8 +16113,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 119)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 28
@@ -14414,8 +16123,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 28
@@ -14426,11 +16135,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14443,8 +16152,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 26
@@ -14456,8 +16165,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 107)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 26
@@ -14466,8 +16175,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 26
@@ -14478,11 +16187,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14495,8 +16204,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 25
@@ -14508,8 +16217,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 106)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 25
@@ -14518,8 +16227,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 25
@@ -14530,11 +16239,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14547,8 +16256,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 24
@@ -14560,8 +16269,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 105)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 24
@@ -14570,8 +16279,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 24
@@ -14582,11 +16291,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14611,8 +16320,8 @@ entry:
   %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %3)
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %2
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -14623,15 +16332,15 @@ entry:
 
 ; <label>:8                                       ; preds = %62
   %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 9
   %12 = load i32, i32 addrspace(1)* %11, align 8
   %13 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.IO.StreamWriter addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %13, i32 0, i32 10
@@ -14646,15 +16355,15 @@ entry:
 
 ; <label>:20                                      ; preds = %14, %18
   %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
   %24 = load i32, i32 addrspace(1)* %23, align 8
   %25 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %25, null
-  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.StreamWriter addrspace(1)* %25, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %25, i32 0, i32 9
@@ -14675,36 +16384,36 @@ entry:
   %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %37 = load i32, i32* %loc1
   %38 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.StreamWriter addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %35
   %40 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %38, i32 0, i32 7
   %41 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %40, align 8
   %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
-  br i1 %NullCheck14, label %43, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %39
   %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 9
   %45 = load i32, i32 addrspace(1)* %44, align 8
   %46 = load i32, i32* %loc2
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %36, null
-  br i1 %NullCheck16, label %47, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %36, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %47
 
 ; <label>:47                                      ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %36, i32 %37, %"System.Char[]" addrspace(1)* %41, i32 %45, i32 %46)
   %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
   %51 = load i32, i32 addrspace(1)* %50, align 8
   %52 = load i32, i32* %loc2
   %53 = add i32 %51, %52
-  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
-  br i1 %NullCheck20, label %54, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %54
 
 ; <label>:54                                      ; preds = %49
   %55 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
@@ -14726,8 +16435,8 @@ entry:
 
 ; <label>:65                                      ; preds = %62
   %66 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %66, null
-  br i1 %NullCheck2, label %67, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %66, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %67
 
 ; <label>:67                                      ; preds = %65
   %68 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %66, i32 0, i32 11
@@ -14748,49 +16457,259 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %65
+ThrowNullRef2:                                    ; preds = %65
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %20
+ThrowNullRef8:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %22
+ThrowNullRef10:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %35
+ThrowNullRef12:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %43
+ThrowNullRef16:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %47
+ThrowNullRef18:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method String::CopyTo using LLILCJit
-Failed to read String.CopyTo[loadElemA]
+Successfully read String.CopyTo
+
+define void @String.CopyTo(%System.String addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  %loc1 = alloca i16 addrspace(1)*
+  %loc2 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %1 = icmp ne %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg4
+  %7 = icmp sge i32 %6, 0
+  br i1 %7, label %13, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  unreachable
+
+; <label>:13                                      ; preds = %5
+  %14 = load i32, i32* %arg1
+  %15 = icmp sge i32 %14, 0
+  br i1 %15, label %21, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %18)
+  %20 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %20, %System.String addrspace(1)* %17, %System.String addrspace(1)* %19)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %20) #0
+  unreachable
+
+; <label>:21                                      ; preds = %13
+  %22 = load i32, i32* %arg4
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck, label %ThrowNullRef, label %24
+
+; <label>:24                                      ; preds = %21
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load i32, i32* %arg1
+  %28 = sub i32 %26, %27
+  %29 = icmp sle i32 %22, %28
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34, %System.String addrspace(1)* %31, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %24
+  %36 = load i32, i32* %arg3
+  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %37, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
+
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
+  %40 = load i32, i32 addrspace(1)* %39
+  %41 = zext i32 %40 to i64
+  %42 = trunc i64 %41 to i32
+  %43 = load i32, i32* %arg4
+  %44 = sub i32 %42, %43
+  %45 = icmp sgt i32 %36, %44
+  br i1 %45, label %49, label %46
+
+; <label>:46                                      ; preds = %38
+  %47 = load i32, i32* %arg3
+  %48 = icmp sge i32 %47, 0
+  br i1 %48, label %54, label %49
+
+; <label>:49                                      ; preds = %38, %46
+  %50 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %52 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %51)
+  %53 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53, %System.String addrspace(1)* %50, %System.String addrspace(1)* %52)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53) #0
+  unreachable
+
+; <label>:54                                      ; preds = %46
+  %55 = load i32, i32* %arg4
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %97, label %57
+
+; <label>:57                                      ; preds = %54
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %59
+
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 2
+  %61 = bitcast [0 x i16] addrspace(1)* %60 to i16 addrspace(1)*
+  store i16 addrspace(1)* %61, i16 addrspace(1)** %loc0
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  store %"System.Char[]" addrspace(1)* %62, %"System.Char[]" addrspace(1)** %loc2
+  %63 = icmp eq %"System.Char[]" addrspace(1)* %62, null
+  br i1 %63, label %72, label %64
+
+; <label>:64                                      ; preds = %59
+  %65 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc2
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %65, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %66
+
+; <label>:66                                      ; preds = %64
+  %67 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %65, i32 0, i32 1
+  %68 = load i32, i32 addrspace(1)* %67
+  %69 = zext i32 %68 to i64
+  %70 = trunc i64 %69 to i32
+  %71 = icmp ne i32 %70, 0
+  br i1 %71, label %73, label %72
+
+; <label>:72                                      ; preds = %59, %66
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  br label %81
+
+; <label>:73                                      ; preds = %66
+  %74 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc2
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %74, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %75
+
+; <label>:75                                      ; preds = %73
+  %76 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %74, i32 0, i32 1
+  %77 = load i32, i32 addrspace(1)* %76
+  %78 = zext i32 %77 to i64
+  %BoundsCheck = icmp uge i64 0, %78
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %79
+
+; <label>:79                                      ; preds = %75
+  %80 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %74, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %80, i16 addrspace(1)** %loc1
+  br label %81
+
+; <label>:81                                      ; preds = %72, %79
+  %82 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %83 = ptrtoint i16 addrspace(1)* %82 to i64
+  %84 = load i32, i32* %arg3
+  %85 = sext i32 %84 to i64
+  %86 = mul i64 %85, 2
+  %87 = add i64 %83, %86
+  %88 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %89 = ptrtoint i16 addrspace(1)* %88 to i64
+  %90 = load i32, i32* %arg1
+  %91 = sext i32 %90 to i64
+  %92 = mul i64 %91, 2
+  %93 = add i64 %89, %92
+  %94 = load i32, i32* %arg4
+  %95 = inttoptr i64 %87 to i16*
+  %96 = inttoptr i64 %93 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %95, i16* %96, i32 %94)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  br label %97
+
+; <label>:97                                      ; preds = %54, %81
+  ret void
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
 Successfully read ConsoleEncoding.GetPreamble
 
@@ -14827,7 +16746,365 @@ entry:
 }
 
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[loadElemA]
+Successfully read EncoderNLS.GetBytes
+
+define i32 @EncoderNLS.GetBytes(%System.Text.EncoderNLS addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3, %"System.Byte[]" addrspace(1)* %param4, i32 %param5, i8 %param6) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %arg4 = alloca %"System.Byte[]" addrspace(1)*
+  %arg5 = alloca i32
+  %arg6 = alloca i8
+  %loc0 = alloca i32
+  %loc1 = alloca i16 addrspace(1)*
+  %loc2 = alloca i8 addrspace(1)*
+  %loc3 = alloca i32
+  %loc4 = alloca %"System.Char[]" addrspace(1)*
+  %loc5 = alloca %"System.Byte[]" addrspace(1)*
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  store %"System.Byte[]" addrspace(1)* %param4, %"System.Byte[]" addrspace(1)** %arg4
+  store i32 %param5, i32* %arg5
+  store i8 %param6, i8* %arg6
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %1 = icmp eq %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %17, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %7 = icmp eq %"System.Char[]" addrspace(1)* %6, null
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %12
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %12
+
+; <label>:12                                      ; preds = %8, %10
+  %13 = phi %System.String addrspace(1)* [ %9, %8 ], [ %11, %10 ]
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %14)
+  %16 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16, %System.String addrspace(1)* %13, %System.String addrspace(1)* %15)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16) #0
+  unreachable
+
+; <label>:17                                      ; preds = %2
+  %18 = load i32, i32* %arg2
+  %19 = icmp slt i32 %18, 0
+  br i1 %19, label %23, label %20
+
+; <label>:20                                      ; preds = %17
+  %21 = load i32, i32* %arg3
+  %22 = icmp sge i32 %21, 0
+  br i1 %22, label %35, label %23
+
+; <label>:23                                      ; preds = %17, %20
+  %24 = load i32, i32* %arg2
+  %25 = icmp slt i32 %24, 0
+  br i1 %25, label %28, label %26
+
+; <label>:26                                      ; preds = %23
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %30
+
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %30
+
+; <label>:30                                      ; preds = %26, %28
+  %31 = phi %System.String addrspace(1)* [ %27, %26 ], [ %29, %28 ]
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34, %System.String addrspace(1)* %31, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %20
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck, label %ThrowNullRef, label %37
+
+; <label>:37                                      ; preds = %35
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = load i32, i32* %arg2
+  %43 = sub i32 %41, %42
+  %44 = load i32, i32* %arg3
+  %45 = icmp sge i32 %43, %44
+  br i1 %45, label %51, label %46
+
+; <label>:46                                      ; preds = %37
+  %47 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %48 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %49 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %48)
+  %50 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %50, %System.String addrspace(1)* %47, %System.String addrspace(1)* %49)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %50) #0
+  unreachable
+
+; <label>:51                                      ; preds = %37
+  %52 = load i32, i32* %arg5
+  %53 = icmp slt i32 %52, 0
+  br i1 %53, label %63, label %54
+
+; <label>:54                                      ; preds = %51
+  %55 = load i32, i32* %arg5
+  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck1 = icmp eq %"System.Byte[]" addrspace(1)* %56, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %57
+
+; <label>:57                                      ; preds = %54
+  %58 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = zext i32 %59 to i64
+  %61 = trunc i64 %60 to i32
+  %62 = icmp sle i32 %55, %61
+  br i1 %62, label %68, label %63
+
+; <label>:63                                      ; preds = %51, %57
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %66 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %65)
+  %67 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %67, %System.String addrspace(1)* %64, %System.String addrspace(1)* %66)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %67) #0
+  unreachable
+
+; <label>:68                                      ; preds = %57
+  %69 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %69, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %69, i32 0, i32 1
+  %72 = load i32, i32 addrspace(1)* %71
+  %73 = zext i32 %72 to i64
+  %74 = trunc i64 %73 to i32
+  %75 = icmp ne i32 %74, 0
+  br i1 %75, label %78, label %76
+
+; <label>:76                                      ; preds = %70
+  %77 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1)
+  store %"System.Char[]" addrspace(1)* %77, %"System.Char[]" addrspace(1)** %arg1
+  br label %78
+
+; <label>:78                                      ; preds = %70, %76
+  %79 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck5 = icmp eq %"System.Byte[]" addrspace(1)* %79, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %80
+
+; <label>:80                                      ; preds = %78
+  %81 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %79, i32 0, i32 1
+  %82 = load i32, i32 addrspace(1)* %81
+  %83 = zext i32 %82 to i64
+  %84 = trunc i64 %83 to i32
+  %85 = load i32, i32* %arg5
+  %86 = sub i32 %84, %85
+  store i32 %86, i32* %loc0
+  %87 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck7 = icmp eq %"System.Byte[]" addrspace(1)* %87, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %88
+
+; <label>:88                                      ; preds = %80
+  %89 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %87, i32 0, i32 1
+  %90 = load i32, i32 addrspace(1)* %89
+  %91 = zext i32 %90 to i64
+  %92 = trunc i64 %91 to i32
+  %93 = icmp ne i32 %92, 0
+  br i1 %93, label %96, label %94
+
+; <label>:94                                      ; preds = %88
+  %95 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1)
+  store %"System.Byte[]" addrspace(1)* %95, %"System.Byte[]" addrspace(1)** %arg4
+  br label %96
+
+; <label>:96                                      ; preds = %88, %94
+  %97 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  store %"System.Char[]" addrspace(1)* %97, %"System.Char[]" addrspace(1)** %loc4
+  %98 = icmp eq %"System.Char[]" addrspace(1)* %97, null
+  br i1 %98, label %107, label %99
+
+; <label>:99                                      ; preds = %96
+  %100 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc4
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %100, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %101
+
+; <label>:101                                     ; preds = %99
+  %102 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %100, i32 0, i32 1
+  %103 = load i32, i32 addrspace(1)* %102
+  %104 = zext i32 %103 to i64
+  %105 = trunc i64 %104 to i32
+  %106 = icmp ne i32 %105, 0
+  br i1 %106, label %108, label %107
+
+; <label>:107                                     ; preds = %96, %101
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  br label %116
+
+; <label>:108                                     ; preds = %101
+  %109 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc4
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %109, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %110
+
+; <label>:110                                     ; preds = %108
+  %111 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %109, i32 0, i32 1
+  %112 = load i32, i32 addrspace(1)* %111
+  %113 = zext i32 %112 to i64
+  %BoundsCheck = icmp uge i64 0, %113
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %114
+
+; <label>:114                                     ; preds = %110
+  %115 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %109, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %115, i16 addrspace(1)** %loc1
+  br label %116
+
+; <label>:116                                     ; preds = %107, %114
+  %117 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  store %"System.Byte[]" addrspace(1)* %117, %"System.Byte[]" addrspace(1)** %loc5
+  %118 = icmp eq %"System.Byte[]" addrspace(1)* %117, null
+  br i1 %118, label %127, label %119
+
+; <label>:119                                     ; preds = %116
+  %120 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc5
+  %NullCheck13 = icmp eq %"System.Byte[]" addrspace(1)* %120, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %121
+
+; <label>:121                                     ; preds = %119
+  %122 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %120, i32 0, i32 1
+  %123 = load i32, i32 addrspace(1)* %122
+  %124 = zext i32 %123 to i64
+  %125 = trunc i64 %124 to i32
+  %126 = icmp ne i32 %125, 0
+  br i1 %126, label %128, label %127
+
+; <label>:127                                     ; preds = %116, %121
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc2
+  br label %136
+
+; <label>:128                                     ; preds = %121
+  %129 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc5
+  %NullCheck15 = icmp eq %"System.Byte[]" addrspace(1)* %129, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %130
+
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %129, i32 0, i32 1
+  %132 = load i32, i32 addrspace(1)* %131
+  %133 = zext i32 %132 to i64
+  %BoundsCheck17 = icmp uge i64 0, %133
+  br i1 %BoundsCheck17, label %ThrowIndexOutOfRange18, label %134
+
+; <label>:134                                     ; preds = %130
+  %135 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %129, i32 0, i32 3, i32 0
+  store i8 addrspace(1)* %135, i8 addrspace(1)** %loc2
+  br label %136
+
+; <label>:136                                     ; preds = %127, %134
+  %137 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %138 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %139 = ptrtoint i16 addrspace(1)* %138 to i64
+  %140 = load i32, i32* %arg2
+  %141 = sext i32 %140 to i64
+  %142 = mul i64 %141, 2
+  %143 = add i64 %139, %142
+  %144 = load i32, i32* %arg3
+  %145 = load i8 addrspace(1)*, i8 addrspace(1)** %loc2
+  %146 = ptrtoint i8 addrspace(1)* %145 to i64
+  %147 = load i32, i32* %arg5
+  %148 = sext i32 %147 to i64
+  %149 = add i64 %146, %148
+  %150 = load i32, i32* %loc0
+  %151 = load i8, i8* %arg6
+  %152 = zext i8 %151 to i32
+  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i64 addrspace(1)*
+  %NullCheck19 = icmp eq i64 addrspace(1)* %153, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %154
+
+; <label>:154                                     ; preds = %136
+  %155 = load i64, i64 addrspace(1)* %153
+  %156 = add i64 %155, 72
+  %157 = inttoptr i64 %156 to i64*
+  %158 = load i64, i64* %157
+  %159 = add i64 %158, 0
+  %160 = inttoptr i64 %159 to i64*
+  %161 = load i64, i64* %160
+  %162 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to %System.Text.Encoder addrspace(1)*
+  %163 = inttoptr i64 %143 to i16*
+  %164 = inttoptr i64 %149 to i8*
+  %165 = trunc i32 %152 to i8
+  %166 = inttoptr i64 %161 to i32 (%System.Text.Encoder addrspace(1)*, i16*, i32, i8*, i32, i8)*
+  %167 = call i32 %166(%System.Text.Encoder addrspace(1)* %162, i16* %163, i32 %144, i8* %164, i32 %150, i8 %165)
+  store i32 %167, i32* %loc3
+  br label %168
+
+; <label>:168                                     ; preds = %154
+  %169 = load i32, i32* %loc3
+  ret i32 %169
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %110
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %119
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange18:                           ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
 Successfully read EncoderNLS.GetBytes
 
@@ -14916,22 +17193,22 @@ entry:
   %40 = load i8, i8* %arg5
   %41 = zext i8 %40 to i32
   %42 = trunc i32 %41 to i8
-  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %39, null
-  br i1 %NullCheck, label %43, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderNLS addrspace(1)* %39, null
+  br i1 %NullCheck, label %ThrowNullRef, label %43
 
 ; <label>:43                                      ; preds = %38
   %44 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
   store i8 %42, i8 addrspace(1)* %44
   %45 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %45, null
-  br i1 %NullCheck2, label %46, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.EncoderNLS addrspace(1)* %45, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %46
 
 ; <label>:46                                      ; preds = %43
   %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %45, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %47
   %48 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.EncoderNLS addrspace(1)* %48, null
-  br i1 %NullCheck4, label %49, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.EncoderNLS addrspace(1)* %48, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %49
 
 ; <label>:49                                      ; preds = %46
   %50 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %48, i32 0, i32 3
@@ -14942,8 +17219,8 @@ entry:
   %55 = load i32, i32* %arg4
   %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck6, label %58, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
   %59 = load i64, i64 addrspace(1)* %57
@@ -14961,15 +17238,15 @@ ThrowNullRef:                                     ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %43
+ThrowNullRef2:                                    ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %46
+ThrowNullRef4:                                    ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %49
+ThrowNullRef6:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14997,8 +17274,8 @@ entry:
   %4 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0 to %System.IO.ConsoleStream addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*)(%System.IO.ConsoleStream addrspace(1)* %4, %"System.Byte[]" addrspace(1)* %1, i32 %2, i32 %3)
   %5 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
@@ -15083,8 +17360,8 @@ entry:
 
 ; <label>:22                                      ; preds = %8
   %23 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %23, null
-  br i1 %NullCheck, label %24, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Byte[]" addrspace(1)* %23, null
+  br i1 %NullCheck, label %ThrowNullRef, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
@@ -15106,8 +17383,8 @@ entry:
 
 ; <label>:36                                      ; preds = %24
   %37 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %37, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.ConsoleStream addrspace(1)* %37, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %37, i32 0, i32 4
@@ -15128,13 +17405,138 @@ ThrowNullRef:                                     ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %36
+ThrowNullRef2:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
-Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
+Successfully read WindowsConsoleStream.WriteFileNative
+
+define i32 @WindowsConsoleStream.WriteFileNative(i64 %param0, %"System.Byte[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i64
+  %arg1 = alloca %"System.Byte[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i8 addrspace(1)*
+  %loc2 = alloca %"System.Byte[]" addrspace(1)*
+  %loc3 = alloca i32
+  store i64 %param0, i64* %arg0
+  store %"System.Byte[]" addrspace(1)* %param1, %"System.Byte[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Byte[]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = zext i32 %3 to i64
+  %5 = icmp ne i64 %4, 0
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %1
+  ret i32 0
+
+; <label>:7                                       ; preds = %1
+  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  store %"System.Byte[]" addrspace(1)* %8, %"System.Byte[]" addrspace(1)** %loc2
+  %9 = icmp eq %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %9, label %18, label %10
+
+; <label>:10                                      ; preds = %7
+  %11 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc2
+  %NullCheck1 = icmp eq %"System.Byte[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %11, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp ne i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %7, %12
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc1
+  br label %27
+
+; <label>:19                                      ; preds = %12
+  %20 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc2
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %20, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %BoundsCheck = icmp uge i64 0, %24
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %25
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %20, i32 0, i32 3, i32 0
+  store i8 addrspace(1)* %26, i8 addrspace(1)** %loc1
+  br label %27
+
+; <label>:27                                      ; preds = %18, %25
+  %28 = load i64, i64* %arg0
+  %29 = load i8 addrspace(1)*, i8 addrspace(1)** %loc1
+  %30 = ptrtoint i8 addrspace(1)* %29 to i64
+  %31 = load i32, i32* %arg2
+  %32 = sext i32 %31 to i64
+  %33 = add i64 %30, %32
+  %34 = load i32, i32* %arg3
+  %35 = addrspacecast i32* %loc3 to i32 addrspace(1)*
+  %36 = inttoptr i64 %33 to i8*
+  %37 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i8*, i32, i32 addrspace(1)*, i64)*)(i64 %28, i8* %36, i32 %34, i32 addrspace(1)* %35, i64 0)
+  %38 = icmp ugt i32 %37, 0
+  %39 = sext i1 %38 to i32
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc1
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %42, label %41
+
+; <label>:41                                      ; preds = %27
+  ret i32 0
+
+; <label>:42                                      ; preds = %27
+  %43 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  store i32 %43, i32* %loc0
+  %44 = load i32, i32* %loc0
+  %45 = icmp eq i32 %44, 232
+  br i1 %45, label %49, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = load i32, i32* %loc0
+  %48 = icmp ne i32 %47, 109
+  br i1 %48, label %50, label %49
+
+; <label>:49                                      ; preds = %42, %46
+  ret i32 0
+
+; <label>:50                                      ; preds = %46
+  %51 = load i32, i32* %loc0
+  ret i32 %51
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
 Successfully read WindowsConsoleStream.Flush
 
@@ -15143,8 +17545,8 @@ entry:
   %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
   store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
@@ -15179,8 +17581,8 @@ entry:
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
   %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load i64, i64 addrspace(1)* %1
@@ -15219,15 +17621,15 @@ entry:
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.TextWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
   %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %3, align 8
   %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
   %7 = load i64, i64 addrspace(1)* %5
@@ -15245,7 +17647,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -15274,8 +17676,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %4)
   store i32 0, i32* %loc0
   %5 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Char[]" addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
@@ -15287,15 +17689,15 @@ entry:
 
 ; <label>:11                                      ; preds = %69
   %12 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %12, i32 0, i32 9
   %15 = load i32, i32 addrspace(1)* %14, align 8
   %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.IO.StreamWriter addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %16, i32 0, i32 10
@@ -15310,15 +17712,15 @@ entry:
 
 ; <label>:23                                      ; preds = %17, %21
   %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %24, null
-  br i1 %NullCheck8, label %25, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %24, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 10
   %27 = load i32, i32 addrspace(1)* %26, align 8
   %28 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %28, null
-  br i1 %NullCheck10, label %29, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.StreamWriter addrspace(1)* %28, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %28, i32 0, i32 9
@@ -15340,15 +17742,15 @@ entry:
   %40 = load i32, i32* %loc0
   %41 = mul i32 %40, 2
   %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
-  br i1 %NullCheck12, label %43, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %43
 
 ; <label>:43                                      ; preds = %38
   %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 7
   %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %44, align 8
   %46 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %46, null
-  br i1 %NullCheck14, label %47, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.IO.StreamWriter addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %47
 
 ; <label>:47                                      ; preds = %43
   %48 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %46, i32 0, i32 9
@@ -15360,16 +17762,16 @@ entry:
   %54 = bitcast %"System.Char[]" addrspace(1)* %45 to %System.Array addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %53, i32 %41, %System.Array addrspace(1)* %54, i32 %50, i32 %52)
   %55 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
-  br i1 %NullCheck16, label %56, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %56
 
 ; <label>:56                                      ; preds = %47
   %57 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
   %58 = load i32, i32 addrspace(1)* %57, align 8
   %59 = load i32, i32* %loc2
   %60 = add i32 %58, %59
-  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
-  br i1 %NullCheck18, label %61, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %61
 
 ; <label>:61                                      ; preds = %56
   %62 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
@@ -15391,8 +17793,8 @@ entry:
 
 ; <label>:72                                      ; preds = %69
   %73 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %73, null
-  br i1 %NullCheck2, label %74, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %73, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %74
 
 ; <label>:74                                      ; preds = %72
   %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %73, i32 0, i32 11
@@ -15413,39 +17815,39 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %72
+ThrowNullRef2:                                    ; preds = %72
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %23
+ThrowNullRef8:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef10:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %43
+ThrowNullRef14:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %47
+ThrowNullRef16:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %56
+ThrowNullRef18:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPVar.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPVar.error.txt
@@ -25,8 +25,8 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
@@ -40,8 +40,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
   %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
@@ -75,7 +75,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -90,8 +90,8 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %NullCheck = icmp ne i8 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = load i8, i8 addrspace(1)* %0, align 8
@@ -125,8 +125,8 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
@@ -159,8 +159,8 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -184,8 +184,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
   store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
@@ -195,8 +195,8 @@ entry:
 ; <label>:4                                       ; preds = %1
   %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
   %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
@@ -206,8 +206,8 @@ entry:
   %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
@@ -221,14 +221,14 @@ entry:
 
 ; <label>:17                                      ; preds = %14
   %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
   %21 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
@@ -238,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -249,8 +249,8 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
@@ -261,27 +261,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %30
+ThrowNullRef10:                                   ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -301,7 +301,89 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
-Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
+Successfully read AppDomainSetup.GetUnsecureApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.GetUnsecureApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %NullCheck = icmp eq %"System.String[]" addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %BoundsCheck = icmp uge i64 0, %5
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %6
+
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 3, i32 0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
+  ret %System.String addrspace(1)* %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_Value using LLILCJit
+Successfully read AppDomainSetup.get_Value
+
+define %"System.String[]" addrspace(1)* @AppDomainSetup.get_Value(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.String[]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 18)
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.String[]" addrspace(1)* addrspace(1)*, %"System.String[]" addrspace(1)*)*)(%"System.String[]" addrspace(1)* addrspace(1)* %9, %"System.String[]" addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %11, i32 0, i32 1
+  %14 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %13, align 8
+  ret %"System.String[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -319,8 +401,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -368,16 +450,16 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
   %5 = load i32, i32 addrspace(1)* %4
   %6 = sub i32 %5, 1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -389,7 +471,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -421,8 +503,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
@@ -456,8 +538,8 @@ entry:
 ; <label>:27                                      ; preds = %19
   %28 = load i32, i32* %arg1
   %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
-  br i1 %NullCheck2, label %30, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %29, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %30
 
 ; <label>:30                                      ; preds = %27
   %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
@@ -493,8 +575,8 @@ entry:
 ; <label>:49                                      ; preds = %46
   %50 = load i32, i32* %arg2
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck4, label %52, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
@@ -517,11 +599,11 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %27
+ThrowNullRef2:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %49
+ThrowNullRef4:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -544,16 +626,16 @@ entry:
   %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %0)
   store %System.String addrspace(1)* %1, %System.String addrspace(1)** %loc0
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 2
   %5 = bitcast [0 x i16] addrspace(1)* %4 to i16 addrspace(1)*
   store i16 addrspace(1)* %5, i16 addrspace(1)** %loc1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %3
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2
@@ -580,7 +662,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -691,15 +773,15 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %NullCheck132 = icmp ne i8* %21, null
-  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+  %NullCheck131 = icmp eq i8* %21, null
+  br i1 %NullCheck131, label %ThrowNullRef132, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = load i8, i8* %21, align 8
   %24 = zext i8 %23 to i32
   %25 = trunc i32 %24 to i8
-  %NullCheck134 = icmp ne i8* %20, null
-  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+  %NullCheck133 = icmp eq i8* %20, null
+  br i1 %NullCheck133, label %ThrowNullRef134, label %26
 
 ; <label>:26                                      ; preds = %22
   store i8 %25, i8* %20, align 8
@@ -709,16 +791,16 @@ entry:
   %28 = load i8*, i8** %arg0
   %29 = load i8*, i8** %arg1
   %30 = bitcast i8* %29 to i16*
-  %NullCheck128 = icmp ne i16* %30, null
-  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+  %NullCheck127 = icmp eq i16* %30, null
+  br i1 %NullCheck127, label %ThrowNullRef128, label %31
 
 ; <label>:31                                      ; preds = %27
   %32 = load i16, i16* %30, align 8
   %33 = sext i16 %32 to i32
   %34 = bitcast i8* %28 to i16*
   %35 = trunc i32 %33 to i16
-  %NullCheck130 = icmp ne i16* %34, null
-  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+  %NullCheck129 = icmp eq i16* %34, null
+  br i1 %NullCheck129, label %ThrowNullRef130, label %36
 
 ; <label>:36                                      ; preds = %31
   store i16 %35, i16* %34, align 8
@@ -728,16 +810,16 @@ entry:
   %38 = load i8*, i8** %arg0
   %39 = load i8*, i8** %arg1
   %40 = bitcast i8* %39 to i16*
-  %NullCheck120 = icmp ne i16* %40, null
-  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+  %NullCheck119 = icmp eq i16* %40, null
+  br i1 %NullCheck119, label %ThrowNullRef120, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i16, i16* %40, align 8
   %43 = sext i16 %42 to i32
   %44 = bitcast i8* %38 to i16*
   %45 = trunc i32 %43 to i16
-  %NullCheck122 = icmp ne i16* %44, null
-  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+  %NullCheck121 = icmp eq i16* %44, null
+  br i1 %NullCheck121, label %ThrowNullRef122, label %46
 
 ; <label>:46                                      ; preds = %41
   store i16 %45, i16* %44, align 8
@@ -745,15 +827,15 @@ entry:
   %48 = getelementptr inbounds i8, i8* %47, i64 2
   %49 = load i8*, i8** %arg1
   %50 = getelementptr inbounds i8, i8* %49, i64 2
-  %NullCheck124 = icmp ne i8* %50, null
-  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+  %NullCheck123 = icmp eq i8* %50, null
+  br i1 %NullCheck123, label %ThrowNullRef124, label %51
 
 ; <label>:51                                      ; preds = %46
   %52 = load i8, i8* %50, align 8
   %53 = zext i8 %52 to i32
   %54 = trunc i32 %53 to i8
-  %NullCheck126 = icmp ne i8* %48, null
-  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+  %NullCheck125 = icmp eq i8* %48, null
+  br i1 %NullCheck125, label %ThrowNullRef126, label %55
 
 ; <label>:55                                      ; preds = %51
   store i8 %54, i8* %48, align 8
@@ -763,14 +845,14 @@ entry:
   %57 = load i8*, i8** %arg0
   %58 = load i8*, i8** %arg1
   %59 = bitcast i8* %58 to i32*
-  %NullCheck116 = icmp ne i32* %59, null
-  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+  %NullCheck115 = icmp eq i32* %59, null
+  br i1 %NullCheck115, label %ThrowNullRef116, label %60
 
 ; <label>:60                                      ; preds = %56
   %61 = load i32, i32* %59, align 8
   %62 = bitcast i8* %57 to i32*
-  %NullCheck118 = icmp ne i32* %62, null
-  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+  %NullCheck117 = icmp eq i32* %62, null
+  br i1 %NullCheck117, label %ThrowNullRef118, label %63
 
 ; <label>:63                                      ; preds = %60
   store i32 %61, i32* %62, align 8
@@ -780,14 +862,14 @@ entry:
   %65 = load i8*, i8** %arg0
   %66 = load i8*, i8** %arg1
   %67 = bitcast i8* %66 to i32*
-  %NullCheck108 = icmp ne i32* %67, null
-  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+  %NullCheck107 = icmp eq i32* %67, null
+  br i1 %NullCheck107, label %ThrowNullRef108, label %68
 
 ; <label>:68                                      ; preds = %64
   %69 = load i32, i32* %67, align 8
   %70 = bitcast i8* %65 to i32*
-  %NullCheck110 = icmp ne i32* %70, null
-  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+  %NullCheck109 = icmp eq i32* %70, null
+  br i1 %NullCheck109, label %ThrowNullRef110, label %71
 
 ; <label>:71                                      ; preds = %68
   store i32 %69, i32* %70, align 8
@@ -795,15 +877,15 @@ entry:
   %73 = getelementptr inbounds i8, i8* %72, i64 4
   %74 = load i8*, i8** %arg1
   %75 = getelementptr inbounds i8, i8* %74, i64 4
-  %NullCheck112 = icmp ne i8* %75, null
-  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+  %NullCheck111 = icmp eq i8* %75, null
+  br i1 %NullCheck111, label %ThrowNullRef112, label %76
 
 ; <label>:76                                      ; preds = %71
   %77 = load i8, i8* %75, align 8
   %78 = zext i8 %77 to i32
   %79 = trunc i32 %78 to i8
-  %NullCheck114 = icmp ne i8* %73, null
-  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+  %NullCheck113 = icmp eq i8* %73, null
+  br i1 %NullCheck113, label %ThrowNullRef114, label %80
 
 ; <label>:80                                      ; preds = %76
   store i8 %79, i8* %73, align 8
@@ -813,14 +895,14 @@ entry:
   %82 = load i8*, i8** %arg0
   %83 = load i8*, i8** %arg1
   %84 = bitcast i8* %83 to i32*
-  %NullCheck100 = icmp ne i32* %84, null
-  br i1 %NullCheck100, label %85, label %ThrowNullRef99
+  %NullCheck99 = icmp eq i32* %84, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %85
 
 ; <label>:85                                      ; preds = %81
   %86 = load i32, i32* %84, align 8
   %87 = bitcast i8* %82 to i32*
-  %NullCheck102 = icmp ne i32* %87, null
-  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+  %NullCheck101 = icmp eq i32* %87, null
+  br i1 %NullCheck101, label %ThrowNullRef102, label %88
 
 ; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
@@ -829,16 +911,16 @@ entry:
   %91 = load i8*, i8** %arg1
   %92 = getelementptr inbounds i8, i8* %91, i64 4
   %93 = bitcast i8* %92 to i16*
-  %NullCheck104 = icmp ne i16* %93, null
-  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+  %NullCheck103 = icmp eq i16* %93, null
+  br i1 %NullCheck103, label %ThrowNullRef104, label %94
 
 ; <label>:94                                      ; preds = %88
   %95 = load i16, i16* %93, align 8
   %96 = sext i16 %95 to i32
   %97 = bitcast i8* %90 to i16*
   %98 = trunc i32 %96 to i16
-  %NullCheck106 = icmp ne i16* %97, null
-  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+  %NullCheck105 = icmp eq i16* %97, null
+  br i1 %NullCheck105, label %ThrowNullRef106, label %99
 
 ; <label>:99                                      ; preds = %94
   store i16 %98, i16* %97, align 8
@@ -848,14 +930,14 @@ entry:
   %101 = load i8*, i8** %arg0
   %102 = load i8*, i8** %arg1
   %103 = bitcast i8* %102 to i32*
-  %NullCheck88 = icmp ne i32* %103, null
-  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+  %NullCheck87 = icmp eq i32* %103, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %104
 
 ; <label>:104                                     ; preds = %100
   %105 = load i32, i32* %103, align 8
   %106 = bitcast i8* %101 to i32*
-  %NullCheck90 = icmp ne i32* %106, null
-  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+  %NullCheck89 = icmp eq i32* %106, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %107
 
 ; <label>:107                                     ; preds = %104
   store i32 %105, i32* %106, align 8
@@ -864,16 +946,16 @@ entry:
   %110 = load i8*, i8** %arg1
   %111 = getelementptr inbounds i8, i8* %110, i64 4
   %112 = bitcast i8* %111 to i16*
-  %NullCheck92 = icmp ne i16* %112, null
-  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+  %NullCheck91 = icmp eq i16* %112, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %113
 
 ; <label>:113                                     ; preds = %107
   %114 = load i16, i16* %112, align 8
   %115 = sext i16 %114 to i32
   %116 = bitcast i8* %109 to i16*
   %117 = trunc i32 %115 to i16
-  %NullCheck94 = icmp ne i16* %116, null
-  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+  %NullCheck93 = icmp eq i16* %116, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %118
 
 ; <label>:118                                     ; preds = %113
   store i16 %117, i16* %116, align 8
@@ -881,15 +963,15 @@ entry:
   %120 = getelementptr inbounds i8, i8* %119, i64 6
   %121 = load i8*, i8** %arg1
   %122 = getelementptr inbounds i8, i8* %121, i64 6
-  %NullCheck96 = icmp ne i8* %122, null
-  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+  %NullCheck95 = icmp eq i8* %122, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %123
 
 ; <label>:123                                     ; preds = %118
   %124 = load i8, i8* %122, align 8
   %125 = zext i8 %124 to i32
   %126 = trunc i32 %125 to i8
-  %NullCheck98 = icmp ne i8* %120, null
-  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+  %NullCheck97 = icmp eq i8* %120, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %127
 
 ; <label>:127                                     ; preds = %123
   store i8 %126, i8* %120, align 8
@@ -899,14 +981,14 @@ entry:
   %129 = load i8*, i8** %arg0
   %130 = load i8*, i8** %arg1
   %131 = bitcast i8* %130 to i64*
-  %NullCheck84 = icmp ne i64* %131, null
-  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+  %NullCheck83 = icmp eq i64* %131, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %132
 
 ; <label>:132                                     ; preds = %128
   %133 = load i64, i64* %131, align 8
   %134 = bitcast i8* %129 to i64*
-  %NullCheck86 = icmp ne i64* %134, null
-  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+  %NullCheck85 = icmp eq i64* %134, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %135
 
 ; <label>:135                                     ; preds = %132
   store i64 %133, i64* %134, align 8
@@ -916,14 +998,14 @@ entry:
   %137 = load i8*, i8** %arg0
   %138 = load i8*, i8** %arg1
   %139 = bitcast i8* %138 to i64*
-  %NullCheck76 = icmp ne i64* %139, null
-  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+  %NullCheck75 = icmp eq i64* %139, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %140
 
 ; <label>:140                                     ; preds = %136
   %141 = load i64, i64* %139, align 8
   %142 = bitcast i8* %137 to i64*
-  %NullCheck78 = icmp ne i64* %142, null
-  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+  %NullCheck77 = icmp eq i64* %142, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %143
 
 ; <label>:143                                     ; preds = %140
   store i64 %141, i64* %142, align 8
@@ -931,15 +1013,15 @@ entry:
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %NullCheck80 = icmp ne i8* %147, null
-  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+  %NullCheck79 = icmp eq i8* %147, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %148
 
 ; <label>:148                                     ; preds = %143
   %149 = load i8, i8* %147, align 8
   %150 = zext i8 %149 to i32
   %151 = trunc i32 %150 to i8
-  %NullCheck82 = icmp ne i8* %145, null
-  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+  %NullCheck81 = icmp eq i8* %145, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %152
 
 ; <label>:152                                     ; preds = %148
   store i8 %151, i8* %145, align 8
@@ -949,14 +1031,14 @@ entry:
   %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
   %156 = bitcast i8* %155 to i64*
-  %NullCheck68 = icmp ne i64* %156, null
-  br i1 %NullCheck68, label %157, label %ThrowNullRef67
+  %NullCheck67 = icmp eq i64* %156, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %157
 
 ; <label>:157                                     ; preds = %153
   %158 = load i64, i64* %156, align 8
   %159 = bitcast i8* %154 to i64*
-  %NullCheck70 = icmp ne i64* %159, null
-  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+  %NullCheck69 = icmp eq i64* %159, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %160
 
 ; <label>:160                                     ; preds = %157
   store i64 %158, i64* %159, align 8
@@ -965,16 +1047,16 @@ entry:
   %163 = load i8*, i8** %arg1
   %164 = getelementptr inbounds i8, i8* %163, i64 8
   %165 = bitcast i8* %164 to i16*
-  %NullCheck72 = icmp ne i16* %165, null
-  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+  %NullCheck71 = icmp eq i16* %165, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %166
 
 ; <label>:166                                     ; preds = %160
   %167 = load i16, i16* %165, align 8
   %168 = sext i16 %167 to i32
   %169 = bitcast i8* %162 to i16*
   %170 = trunc i32 %168 to i16
-  %NullCheck74 = icmp ne i16* %169, null
-  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+  %NullCheck73 = icmp eq i16* %169, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %171
 
 ; <label>:171                                     ; preds = %166
   store i16 %170, i16* %169, align 8
@@ -984,14 +1066,14 @@ entry:
   %173 = load i8*, i8** %arg0
   %174 = load i8*, i8** %arg1
   %175 = bitcast i8* %174 to i64*
-  %NullCheck56 = icmp ne i64* %175, null
-  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+  %NullCheck55 = icmp eq i64* %175, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %176
 
 ; <label>:176                                     ; preds = %172
   %177 = load i64, i64* %175, align 8
   %178 = bitcast i8* %173 to i64*
-  %NullCheck58 = icmp ne i64* %178, null
-  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+  %NullCheck57 = icmp eq i64* %178, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %179
 
 ; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
@@ -1000,16 +1082,16 @@ entry:
   %182 = load i8*, i8** %arg1
   %183 = getelementptr inbounds i8, i8* %182, i64 8
   %184 = bitcast i8* %183 to i16*
-  %NullCheck60 = icmp ne i16* %184, null
-  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+  %NullCheck59 = icmp eq i16* %184, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %185
 
 ; <label>:185                                     ; preds = %179
   %186 = load i16, i16* %184, align 8
   %187 = sext i16 %186 to i32
   %188 = bitcast i8* %181 to i16*
   %189 = trunc i32 %187 to i16
-  %NullCheck62 = icmp ne i16* %188, null
-  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+  %NullCheck61 = icmp eq i16* %188, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %190
 
 ; <label>:190                                     ; preds = %185
   store i16 %189, i16* %188, align 8
@@ -1017,15 +1099,15 @@ entry:
   %192 = getelementptr inbounds i8, i8* %191, i64 10
   %193 = load i8*, i8** %arg1
   %194 = getelementptr inbounds i8, i8* %193, i64 10
-  %NullCheck64 = icmp ne i8* %194, null
-  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+  %NullCheck63 = icmp eq i8* %194, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %195
 
 ; <label>:195                                     ; preds = %190
   %196 = load i8, i8* %194, align 8
   %197 = zext i8 %196 to i32
   %198 = trunc i32 %197 to i8
-  %NullCheck66 = icmp ne i8* %192, null
-  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+  %NullCheck65 = icmp eq i8* %192, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %199
 
 ; <label>:199                                     ; preds = %195
   store i8 %198, i8* %192, align 8
@@ -1035,14 +1117,14 @@ entry:
   %201 = load i8*, i8** %arg0
   %202 = load i8*, i8** %arg1
   %203 = bitcast i8* %202 to i64*
-  %NullCheck48 = icmp ne i64* %203, null
-  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+  %NullCheck47 = icmp eq i64* %203, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %204
 
 ; <label>:204                                     ; preds = %200
   %205 = load i64, i64* %203, align 8
   %206 = bitcast i8* %201 to i64*
-  %NullCheck50 = icmp ne i64* %206, null
-  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+  %NullCheck49 = icmp eq i64* %206, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %207
 
 ; <label>:207                                     ; preds = %204
   store i64 %205, i64* %206, align 8
@@ -1051,14 +1133,14 @@ entry:
   %210 = load i8*, i8** %arg1
   %211 = getelementptr inbounds i8, i8* %210, i64 8
   %212 = bitcast i8* %211 to i32*
-  %NullCheck52 = icmp ne i32* %212, null
-  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+  %NullCheck51 = icmp eq i32* %212, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %213
 
 ; <label>:213                                     ; preds = %207
   %214 = load i32, i32* %212, align 8
   %215 = bitcast i8* %209 to i32*
-  %NullCheck54 = icmp ne i32* %215, null
-  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+  %NullCheck53 = icmp eq i32* %215, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %216
 
 ; <label>:216                                     ; preds = %213
   store i32 %214, i32* %215, align 8
@@ -1068,14 +1150,14 @@ entry:
   %218 = load i8*, i8** %arg0
   %219 = load i8*, i8** %arg1
   %220 = bitcast i8* %219 to i64*
-  %NullCheck36 = icmp ne i64* %220, null
-  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64* %220, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %221
 
 ; <label>:221                                     ; preds = %217
   %222 = load i64, i64* %220, align 8
   %223 = bitcast i8* %218 to i64*
-  %NullCheck38 = icmp ne i64* %223, null
-  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+  %NullCheck37 = icmp eq i64* %223, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %224
 
 ; <label>:224                                     ; preds = %221
   store i64 %222, i64* %223, align 8
@@ -1084,14 +1166,14 @@ entry:
   %227 = load i8*, i8** %arg1
   %228 = getelementptr inbounds i8, i8* %227, i64 8
   %229 = bitcast i8* %228 to i32*
-  %NullCheck40 = icmp ne i32* %229, null
-  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i32* %229, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %230
 
 ; <label>:230                                     ; preds = %224
   %231 = load i32, i32* %229, align 8
   %232 = bitcast i8* %226 to i32*
-  %NullCheck42 = icmp ne i32* %232, null
-  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+  %NullCheck41 = icmp eq i32* %232, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %233
 
 ; <label>:233                                     ; preds = %230
   store i32 %231, i32* %232, align 8
@@ -1099,15 +1181,15 @@ entry:
   %235 = getelementptr inbounds i8, i8* %234, i64 12
   %236 = load i8*, i8** %arg1
   %237 = getelementptr inbounds i8, i8* %236, i64 12
-  %NullCheck44 = icmp ne i8* %237, null
-  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i8* %237, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %238
 
 ; <label>:238                                     ; preds = %233
   %239 = load i8, i8* %237, align 8
   %240 = zext i8 %239 to i32
   %241 = trunc i32 %240 to i8
-  %NullCheck46 = icmp ne i8* %235, null
-  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+  %NullCheck45 = icmp eq i8* %235, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %242
 
 ; <label>:242                                     ; preds = %238
   store i8 %241, i8* %235, align 8
@@ -1117,14 +1199,14 @@ entry:
   %244 = load i8*, i8** %arg0
   %245 = load i8*, i8** %arg1
   %246 = bitcast i8* %245 to i64*
-  %NullCheck24 = icmp ne i64* %246, null
-  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64* %246, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %247
 
 ; <label>:247                                     ; preds = %243
   %248 = load i64, i64* %246, align 8
   %249 = bitcast i8* %244 to i64*
-  %NullCheck26 = icmp ne i64* %249, null
-  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64* %249, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %250
 
 ; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
@@ -1133,14 +1215,14 @@ entry:
   %253 = load i8*, i8** %arg1
   %254 = getelementptr inbounds i8, i8* %253, i64 8
   %255 = bitcast i8* %254 to i32*
-  %NullCheck28 = icmp ne i32* %255, null
-  br i1 %NullCheck28, label %256, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i32* %255, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %256
 
 ; <label>:256                                     ; preds = %250
   %257 = load i32, i32* %255, align 8
   %258 = bitcast i8* %252 to i32*
-  %NullCheck30 = icmp ne i32* %258, null
-  br i1 %NullCheck30, label %259, label %ThrowNullRef29
+  %NullCheck29 = icmp eq i32* %258, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %259
 
 ; <label>:259                                     ; preds = %256
   store i32 %257, i32* %258, align 8
@@ -1149,16 +1231,16 @@ entry:
   %262 = load i8*, i8** %arg1
   %263 = getelementptr inbounds i8, i8* %262, i64 12
   %264 = bitcast i8* %263 to i16*
-  %NullCheck32 = icmp ne i16* %264, null
-  br i1 %NullCheck32, label %265, label %ThrowNullRef31
+  %NullCheck31 = icmp eq i16* %264, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %265
 
 ; <label>:265                                     ; preds = %259
   %266 = load i16, i16* %264, align 8
   %267 = sext i16 %266 to i32
   %268 = bitcast i8* %261 to i16*
   %269 = trunc i32 %267 to i16
-  %NullCheck34 = icmp ne i16* %268, null
-  br i1 %NullCheck34, label %270, label %ThrowNullRef33
+  %NullCheck33 = icmp eq i16* %268, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %270
 
 ; <label>:270                                     ; preds = %265
   store i16 %269, i16* %268, align 8
@@ -1168,14 +1250,14 @@ entry:
   %272 = load i8*, i8** %arg0
   %273 = load i8*, i8** %arg1
   %274 = bitcast i8* %273 to i64*
-  %NullCheck8 = icmp ne i64* %274, null
-  br i1 %NullCheck8, label %275, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64* %274, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %275
 
 ; <label>:275                                     ; preds = %271
   %276 = load i64, i64* %274, align 8
   %277 = bitcast i8* %272 to i64*
-  %NullCheck10 = icmp ne i64* %277, null
-  br i1 %NullCheck10, label %278, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %277, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %278
 
 ; <label>:278                                     ; preds = %275
   store i64 %276, i64* %277, align 8
@@ -1184,14 +1266,14 @@ entry:
   %281 = load i8*, i8** %arg1
   %282 = getelementptr inbounds i8, i8* %281, i64 8
   %283 = bitcast i8* %282 to i32*
-  %NullCheck12 = icmp ne i32* %283, null
-  br i1 %NullCheck12, label %284, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i32* %283, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %284
 
 ; <label>:284                                     ; preds = %278
   %285 = load i32, i32* %283, align 8
   %286 = bitcast i8* %280 to i32*
-  %NullCheck14 = icmp ne i32* %286, null
-  br i1 %NullCheck14, label %287, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i32* %286, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %287
 
 ; <label>:287                                     ; preds = %284
   store i32 %285, i32* %286, align 8
@@ -1200,16 +1282,16 @@ entry:
   %290 = load i8*, i8** %arg1
   %291 = getelementptr inbounds i8, i8* %290, i64 12
   %292 = bitcast i8* %291 to i16*
-  %NullCheck16 = icmp ne i16* %292, null
-  br i1 %NullCheck16, label %293, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i16* %292, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %293
 
 ; <label>:293                                     ; preds = %287
   %294 = load i16, i16* %292, align 8
   %295 = sext i16 %294 to i32
   %296 = bitcast i8* %289 to i16*
   %297 = trunc i32 %295 to i16
-  %NullCheck18 = icmp ne i16* %296, null
-  br i1 %NullCheck18, label %298, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i16* %296, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %298
 
 ; <label>:298                                     ; preds = %293
   store i16 %297, i16* %296, align 8
@@ -1217,15 +1299,15 @@ entry:
   %300 = getelementptr inbounds i8, i8* %299, i64 14
   %301 = load i8*, i8** %arg1
   %302 = getelementptr inbounds i8, i8* %301, i64 14
-  %NullCheck20 = icmp ne i8* %302, null
-  br i1 %NullCheck20, label %303, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i8* %302, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %303
 
 ; <label>:303                                     ; preds = %298
   %304 = load i8, i8* %302, align 8
   %305 = zext i8 %304 to i32
   %306 = trunc i32 %305 to i8
-  %NullCheck22 = icmp ne i8* %300, null
-  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i8* %300, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %307
 
 ; <label>:307                                     ; preds = %303
   store i8 %306, i8* %300, align 8
@@ -1235,14 +1317,14 @@ entry:
   %309 = load i8*, i8** %arg0
   %310 = load i8*, i8** %arg1
   %311 = bitcast i8* %310 to i64*
-  %NullCheck = icmp ne i64* %311, null
-  br i1 %NullCheck, label %312, label %ThrowNullRef
+  %NullCheck = icmp eq i64* %311, null
+  br i1 %NullCheck, label %ThrowNullRef, label %312
 
 ; <label>:312                                     ; preds = %308
   %313 = load i64, i64* %311, align 8
   %314 = bitcast i8* %309 to i64*
-  %NullCheck2 = icmp ne i64* %314, null
-  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64* %314, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %315
 
 ; <label>:315                                     ; preds = %312
   store i64 %313, i64* %314, align 8
@@ -1251,14 +1333,14 @@ entry:
   %318 = load i8*, i8** %arg1
   %319 = getelementptr inbounds i8, i8* %318, i64 8
   %320 = bitcast i8* %319 to i64*
-  %NullCheck4 = icmp ne i64* %320, null
-  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64* %320, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %321
 
 ; <label>:321                                     ; preds = %315
   %322 = load i64, i64* %320, align 8
   %323 = bitcast i8* %317 to i64*
-  %NullCheck6 = icmp ne i64* %323, null
-  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64* %323, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %324
 
 ; <label>:324                                     ; preds = %321
   store i64 %322, i64* %323, align 8
@@ -1286,15 +1368,15 @@ entry:
 ; <label>:338                                     ; preds = %333
   %339 = load i8*, i8** %arg0
   %340 = load i8*, i8** %arg1
-  %NullCheck136 = icmp ne i8* %340, null
-  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+  %NullCheck135 = icmp eq i8* %340, null
+  br i1 %NullCheck135, label %ThrowNullRef136, label %341
 
 ; <label>:341                                     ; preds = %338
   %342 = load i8, i8* %340, align 8
   %343 = zext i8 %342 to i32
   %344 = trunc i32 %343 to i8
-  %NullCheck138 = icmp ne i8* %339, null
-  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+  %NullCheck137 = icmp eq i8* %339, null
+  br i1 %NullCheck137, label %ThrowNullRef138, label %345
 
 ; <label>:345                                     ; preds = %341
   store i8 %344, i8* %339, align 8
@@ -1317,16 +1399,16 @@ entry:
   %357 = load i8*, i8** %arg0
   %358 = load i8*, i8** %arg1
   %359 = bitcast i8* %358 to i16*
-  %NullCheck140 = icmp ne i16* %359, null
-  br i1 %NullCheck140, label %360, label %ThrowNullRef139
+  %NullCheck139 = icmp eq i16* %359, null
+  br i1 %NullCheck139, label %ThrowNullRef140, label %360
 
 ; <label>:360                                     ; preds = %356
   %361 = load i16, i16* %359, align 8
   %362 = sext i16 %361 to i32
   %363 = bitcast i8* %357 to i16*
   %364 = trunc i32 %362 to i16
-  %NullCheck142 = icmp ne i16* %363, null
-  br i1 %NullCheck142, label %365, label %ThrowNullRef141
+  %NullCheck141 = icmp eq i16* %363, null
+  br i1 %NullCheck141, label %ThrowNullRef142, label %365
 
 ; <label>:365                                     ; preds = %360
   store i16 %364, i16* %363, align 8
@@ -1352,14 +1434,14 @@ entry:
   %378 = load i8*, i8** %arg0
   %379 = load i8*, i8** %arg1
   %380 = bitcast i8* %379 to i32*
-  %NullCheck144 = icmp ne i32* %380, null
-  br i1 %NullCheck144, label %381, label %ThrowNullRef143
+  %NullCheck143 = icmp eq i32* %380, null
+  br i1 %NullCheck143, label %ThrowNullRef144, label %381
 
 ; <label>:381                                     ; preds = %377
   %382 = load i32, i32* %380, align 8
   %383 = bitcast i8* %378 to i32*
-  %NullCheck146 = icmp ne i32* %383, null
-  br i1 %NullCheck146, label %384, label %ThrowNullRef145
+  %NullCheck145 = icmp eq i32* %383, null
+  br i1 %NullCheck145, label %ThrowNullRef146, label %384
 
 ; <label>:384                                     ; preds = %381
   store i32 %382, i32* %383, align 8
@@ -1384,14 +1466,14 @@ entry:
   %395 = load i8*, i8** %arg0
   %396 = load i8*, i8** %arg1
   %397 = bitcast i8* %396 to i64*
-  %NullCheck164 = icmp ne i64* %397, null
-  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+  %NullCheck163 = icmp eq i64* %397, null
+  br i1 %NullCheck163, label %ThrowNullRef164, label %398
 
 ; <label>:398                                     ; preds = %394
   %399 = load i64, i64* %397, align 8
   %400 = bitcast i8* %395 to i64*
-  %NullCheck166 = icmp ne i64* %400, null
-  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+  %NullCheck165 = icmp eq i64* %400, null
+  br i1 %NullCheck165, label %ThrowNullRef166, label %401
 
 ; <label>:401                                     ; preds = %398
   store i64 %399, i64* %400, align 8
@@ -1400,14 +1482,14 @@ entry:
   %404 = load i8*, i8** %arg1
   %405 = getelementptr inbounds i8, i8* %404, i64 8
   %406 = bitcast i8* %405 to i64*
-  %NullCheck168 = icmp ne i64* %406, null
-  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+  %NullCheck167 = icmp eq i64* %406, null
+  br i1 %NullCheck167, label %ThrowNullRef168, label %407
 
 ; <label>:407                                     ; preds = %401
   %408 = load i64, i64* %406, align 8
   %409 = bitcast i8* %403 to i64*
-  %NullCheck170 = icmp ne i64* %409, null
-  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+  %NullCheck169 = icmp eq i64* %409, null
+  br i1 %NullCheck169, label %ThrowNullRef170, label %410
 
 ; <label>:410                                     ; preds = %407
   store i64 %408, i64* %409, align 8
@@ -1437,14 +1519,14 @@ entry:
   %425 = load i8*, i8** %arg0
   %426 = load i8*, i8** %arg1
   %427 = bitcast i8* %426 to i64*
-  %NullCheck148 = icmp ne i64* %427, null
-  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+  %NullCheck147 = icmp eq i64* %427, null
+  br i1 %NullCheck147, label %ThrowNullRef148, label %428
 
 ; <label>:428                                     ; preds = %424
   %429 = load i64, i64* %427, align 8
   %430 = bitcast i8* %425 to i64*
-  %NullCheck150 = icmp ne i64* %430, null
-  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+  %NullCheck149 = icmp eq i64* %430, null
+  br i1 %NullCheck149, label %ThrowNullRef150, label %431
 
 ; <label>:431                                     ; preds = %428
   store i64 %429, i64* %430, align 8
@@ -1466,14 +1548,14 @@ entry:
   %441 = load i8*, i8** %arg0
   %442 = load i8*, i8** %arg1
   %443 = bitcast i8* %442 to i32*
-  %NullCheck152 = icmp ne i32* %443, null
-  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+  %NullCheck151 = icmp eq i32* %443, null
+  br i1 %NullCheck151, label %ThrowNullRef152, label %444
 
 ; <label>:444                                     ; preds = %440
   %445 = load i32, i32* %443, align 8
   %446 = bitcast i8* %441 to i32*
-  %NullCheck154 = icmp ne i32* %446, null
-  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+  %NullCheck153 = icmp eq i32* %446, null
+  br i1 %NullCheck153, label %ThrowNullRef154, label %447
 
 ; <label>:447                                     ; preds = %444
   store i32 %445, i32* %446, align 8
@@ -1495,16 +1577,16 @@ entry:
   %457 = load i8*, i8** %arg0
   %458 = load i8*, i8** %arg1
   %459 = bitcast i8* %458 to i16*
-  %NullCheck156 = icmp ne i16* %459, null
-  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+  %NullCheck155 = icmp eq i16* %459, null
+  br i1 %NullCheck155, label %ThrowNullRef156, label %460
 
 ; <label>:460                                     ; preds = %456
   %461 = load i16, i16* %459, align 8
   %462 = sext i16 %461 to i32
   %463 = bitcast i8* %457 to i16*
   %464 = trunc i32 %462 to i16
-  %NullCheck158 = icmp ne i16* %463, null
-  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+  %NullCheck157 = icmp eq i16* %463, null
+  br i1 %NullCheck157, label %ThrowNullRef158, label %465
 
 ; <label>:465                                     ; preds = %460
   store i16 %464, i16* %463, align 8
@@ -1525,15 +1607,15 @@ entry:
 ; <label>:474                                     ; preds = %470
   %475 = load i8*, i8** %arg0
   %476 = load i8*, i8** %arg1
-  %NullCheck160 = icmp ne i8* %476, null
-  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+  %NullCheck159 = icmp eq i8* %476, null
+  br i1 %NullCheck159, label %ThrowNullRef160, label %477
 
 ; <label>:477                                     ; preds = %474
   %478 = load i8, i8* %476, align 8
   %479 = zext i8 %478 to i32
   %480 = trunc i32 %479 to i8
-  %NullCheck162 = icmp ne i8* %475, null
-  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+  %NullCheck161 = icmp eq i8* %475, null
+  br i1 %NullCheck161, label %ThrowNullRef162, label %481
 
 ; <label>:481                                     ; preds = %477
   store i8 %480, i8* %475, align 8
@@ -1553,343 +1635,343 @@ ThrowNullRef:                                     ; preds = %308
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %312
+ThrowNullRef2:                                    ; preds = %312
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %315
+ThrowNullRef4:                                    ; preds = %315
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %321
+ThrowNullRef6:                                    ; preds = %321
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %271
+ThrowNullRef8:                                    ; preds = %271
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %275
+ThrowNullRef10:                                   ; preds = %275
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %278
+ThrowNullRef12:                                   ; preds = %278
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %284
+ThrowNullRef14:                                   ; preds = %284
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %287
+ThrowNullRef16:                                   ; preds = %287
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %293
+ThrowNullRef18:                                   ; preds = %293
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %298
+ThrowNullRef20:                                   ; preds = %298
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %303
+ThrowNullRef22:                                   ; preds = %303
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %243
+ThrowNullRef24:                                   ; preds = %243
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %247
+ThrowNullRef26:                                   ; preds = %247
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %250
+ThrowNullRef28:                                   ; preds = %250
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %256
+ThrowNullRef30:                                   ; preds = %256
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %259
+ThrowNullRef32:                                   ; preds = %259
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %265
+ThrowNullRef34:                                   ; preds = %265
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %217
+ThrowNullRef36:                                   ; preds = %217
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %221
+ThrowNullRef38:                                   ; preds = %221
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %224
+ThrowNullRef40:                                   ; preds = %224
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %230
+ThrowNullRef42:                                   ; preds = %230
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %233
+ThrowNullRef44:                                   ; preds = %233
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %238
+ThrowNullRef46:                                   ; preds = %238
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %200
+ThrowNullRef48:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %204
+ThrowNullRef50:                                   ; preds = %204
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %207
+ThrowNullRef52:                                   ; preds = %207
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %213
+ThrowNullRef54:                                   ; preds = %213
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %172
+ThrowNullRef56:                                   ; preds = %172
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %176
+ThrowNullRef58:                                   ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %179
+ThrowNullRef60:                                   ; preds = %179
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %185
+ThrowNullRef62:                                   ; preds = %185
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %190
+ThrowNullRef64:                                   ; preds = %190
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %195
+ThrowNullRef66:                                   ; preds = %195
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %153
+ThrowNullRef68:                                   ; preds = %153
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %157
+ThrowNullRef70:                                   ; preds = %157
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %160
+ThrowNullRef72:                                   ; preds = %160
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %166
+ThrowNullRef74:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %136
+ThrowNullRef76:                                   ; preds = %136
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %140
+ThrowNullRef78:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %143
+ThrowNullRef80:                                   ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %148
+ThrowNullRef82:                                   ; preds = %148
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %128
+ThrowNullRef84:                                   ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %132
+ThrowNullRef86:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %100
+ThrowNullRef88:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %104
+ThrowNullRef90:                                   ; preds = %104
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %107
+ThrowNullRef92:                                   ; preds = %107
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %113
+ThrowNullRef94:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %118
+ThrowNullRef96:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %123
+ThrowNullRef98:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %81
+ThrowNullRef100:                                  ; preds = %81
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef101:                                  ; preds = %85
+ThrowNullRef102:                                  ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef103:                                  ; preds = %88
+ThrowNullRef104:                                  ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef105:                                  ; preds = %94
+ThrowNullRef106:                                  ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef107:                                  ; preds = %64
+ThrowNullRef108:                                  ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef109:                                  ; preds = %68
+ThrowNullRef110:                                  ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef111:                                  ; preds = %71
+ThrowNullRef112:                                  ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef113:                                  ; preds = %76
+ThrowNullRef114:                                  ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef115:                                  ; preds = %56
+ThrowNullRef116:                                  ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef117:                                  ; preds = %60
+ThrowNullRef118:                                  ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef119:                                  ; preds = %37
+ThrowNullRef120:                                  ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef121:                                  ; preds = %41
+ThrowNullRef122:                                  ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef123:                                  ; preds = %46
+ThrowNullRef124:                                  ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef125:                                  ; preds = %51
+ThrowNullRef126:                                  ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef127:                                  ; preds = %27
+ThrowNullRef128:                                  ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef129:                                  ; preds = %31
+ThrowNullRef130:                                  ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef131:                                  ; preds = %19
+ThrowNullRef132:                                  ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef133:                                  ; preds = %22
+ThrowNullRef134:                                  ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef135:                                  ; preds = %338
+ThrowNullRef136:                                  ; preds = %338
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef137:                                  ; preds = %341
+ThrowNullRef138:                                  ; preds = %341
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef139:                                  ; preds = %356
+ThrowNullRef140:                                  ; preds = %356
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef141:                                  ; preds = %360
+ThrowNullRef142:                                  ; preds = %360
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef143:                                  ; preds = %377
+ThrowNullRef144:                                  ; preds = %377
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef145:                                  ; preds = %381
+ThrowNullRef146:                                  ; preds = %381
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef147:                                  ; preds = %424
+ThrowNullRef148:                                  ; preds = %424
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef149:                                  ; preds = %428
+ThrowNullRef150:                                  ; preds = %428
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef151:                                  ; preds = %440
+ThrowNullRef152:                                  ; preds = %440
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef153:                                  ; preds = %444
+ThrowNullRef154:                                  ; preds = %444
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef155:                                  ; preds = %456
+ThrowNullRef156:                                  ; preds = %456
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef157:                                  ; preds = %460
+ThrowNullRef158:                                  ; preds = %460
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef159:                                  ; preds = %474
+ThrowNullRef160:                                  ; preds = %474
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef161:                                  ; preds = %477
+ThrowNullRef162:                                  ; preds = %477
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef163:                                  ; preds = %394
+ThrowNullRef164:                                  ; preds = %394
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef165:                                  ; preds = %398
+ThrowNullRef166:                                  ; preds = %398
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef167:                                  ; preds = %401
+ThrowNullRef168:                                  ; preds = %401
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef169:                                  ; preds = %407
+ThrowNullRef170:                                  ; preds = %407
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1939,8 +2021,8 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
-  br i1 %NullCheck, label %22, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %ThrowNullRef, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
@@ -1948,8 +2030,8 @@ entry:
   store i32 %24, i32* %loc0
   %25 = load i32, i32* %loc0
   %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %26, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %27
 
 ; <label>:27                                      ; preds = %22
   %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
@@ -1971,7 +2053,7 @@ ThrowNullRef:                                     ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1989,8 +2071,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -2022,15 +2104,15 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2048,16 +2130,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
   %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
   store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %15
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
@@ -2072,8 +2154,8 @@ entry:
   %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
   %29 = ptrtoint i16 addrspace(1)* %28 to i64
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %19
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
@@ -2089,19 +2171,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2114,8 +2196,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
@@ -2128,7 +2210,7 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[loadElem]
+Failed to read AppDomain.PrepareDataForSetup[storeElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
@@ -2202,8 +2284,8 @@ entry:
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
-  br i1 %NullCheck24, label %27, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = load i64, i64 addrspace(1)* %26
@@ -2218,8 +2300,8 @@ entry:
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
-  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
   %41 = load i64, i64 addrspace(1)* %39
@@ -2236,8 +2318,8 @@ entry:
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
-  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
   %54 = load i64, i64 addrspace(1)* %52
@@ -2252,8 +2334,8 @@ entry:
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
   %67 = load i64, i64 addrspace(1)* %65
@@ -2270,8 +2352,8 @@ entry:
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
-  br i1 %NullCheck16, label %79, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
   %80 = load i64, i64 addrspace(1)* %78
@@ -2286,8 +2368,8 @@ entry:
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
-  br i1 %NullCheck18, label %92, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
   %93 = load i64, i64 addrspace(1)* %91
@@ -2304,8 +2386,8 @@ entry:
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
-  br i1 %NullCheck12, label %105, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = load i64, i64 addrspace(1)* %104
@@ -2320,8 +2402,8 @@ entry:
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
-  br i1 %NullCheck14, label %118, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
   %119 = load i64, i64 addrspace(1)* %117
@@ -2337,8 +2419,8 @@ entry:
 
 ; <label>:128                                     ; preds = %20
   %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
-  br i1 %NullCheck4, label %130, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %129, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %130
 
 ; <label>:130                                     ; preds = %128
   %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
@@ -2346,8 +2428,8 @@ entry:
   %133 = load i16, i16 addrspace(1)* %132, align 8
   %134 = zext i16 %133 to i32
   %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
-  br i1 %NullCheck6, label %136, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %135, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %136
 
 ; <label>:136                                     ; preds = %130
   %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
@@ -2360,8 +2442,8 @@ entry:
 
 ; <label>:143                                     ; preds = %136
   %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
-  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %144, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %145
 
 ; <label>:145                                     ; preds = %143
   %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
@@ -2369,8 +2451,8 @@ entry:
   %148 = load i16, i16 addrspace(1)* %147, align 8
   %149 = zext i16 %148 to i32
   %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %150, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %151
 
 ; <label>:151                                     ; preds = %145
   %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
@@ -2388,8 +2470,8 @@ entry:
 
 ; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
-  br i1 %NullCheck, label %163, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %ThrowNullRef, label %163
 
 ; <label>:163                                     ; preds = %161
   %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
@@ -2399,8 +2481,8 @@ entry:
 
 ; <label>:167                                     ; preds = %163
   %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
-  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %168, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %169
 
 ; <label>:169                                     ; preds = %167
   %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
@@ -2432,55 +2514,55 @@ ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %167
+ThrowNullRef2:                                    ; preds = %167
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %128
+ThrowNullRef4:                                    ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %130
+ThrowNullRef6:                                    ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %143
+ThrowNullRef8:                                    ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %145
+ThrowNullRef10:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %102
+ThrowNullRef12:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %105
+ThrowNullRef14:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %76
+ThrowNullRef16:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %79
+ThrowNullRef18:                                   ; preds = %79
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %50
+ThrowNullRef20:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %53
+ThrowNullRef22:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %24
+ThrowNullRef24:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %27
+ThrowNullRef26:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2503,15 +2585,15 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2519,16 +2601,16 @@ entry:
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
   store i32 %8, i32* %loc0
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
   %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
   store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
@@ -2546,16 +2628,16 @@ entry:
 
 ; <label>:23                                      ; preds = %64
   %24 = load i16*, i16** %loc3
-  %NullCheck12 = icmp ne i16* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i16* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
   store i32 %27, i32* %loc5
   %28 = load i16*, i16** %loc4
-  %NullCheck14 = icmp ne i16* %28, null
-  br i1 %NullCheck14, label %29, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %28, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = load i16, i16* %28, align 8
@@ -2620,15 +2702,15 @@ entry:
 
 ; <label>:67                                      ; preds = %64
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
-  br i1 %NullCheck8, label %69, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %68, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %69
 
 ; <label>:69                                      ; preds = %67
   %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
   %71 = load i32, i32 addrspace(1)* %70
   %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
-  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %73
 
 ; <label>:73                                      ; preds = %69
   %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
@@ -2645,31 +2727,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %67
+ThrowNullRef8:                                    ; preds = %67
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %69
+ThrowNullRef10:                                   ; preds = %69
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2710,14 +2792,14 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
   %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
@@ -2730,14 +2812,14 @@ entry:
 
 ; <label>:11                                      ; preds = %4
   %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
   %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
@@ -2749,14 +2831,14 @@ entry:
 
 ; <label>:22                                      ; preds = %16
   %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
   %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
-  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
-  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
@@ -2804,23 +2886,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2836,7 +2918,280 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[loadElem]
+Successfully read RuntimeType.IsAssignableFrom
+
+define i8 @RuntimeType.IsAssignableFrom(%System.RuntimeType addrspace(1)* %param0, %System.Type addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.RuntimeType addrspace(1)*
+  %arg1 = alloca %System.Type addrspace(1)*
+  %loc0 = alloca %System.RuntimeType addrspace(1)*
+  %loc1 = alloca %"System.Type[]" addrspace(1)*
+  %loc2 = alloca i32
+  store %System.RuntimeType addrspace(1)* %param0, %System.RuntimeType addrspace(1)** %this
+  store %System.Type addrspace(1)* %param1, %System.Type addrspace(1)** %arg1
+  %0 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %1 = icmp ne %System.Type addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i8 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %5 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %6 = bitcast %System.Type addrspace(1)* %4 to %System.Object addrspace(1)*
+  %7 = bitcast %System.RuntimeType addrspace(1)* %5 to %System.Object addrspace(1)*
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %6, %System.Object addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %3
+  ret i8 1
+
+; <label>:12                                      ; preds = %3
+  %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 152
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 32
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
+  %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
+  %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
+  store %System.RuntimeType addrspace(1)* %25, %System.RuntimeType addrspace(1)** %loc0
+  %26 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %27 = icmp eq %System.RuntimeType addrspace(1)* %26, null
+  br i1 %27, label %34, label %28
+
+; <label>:28                                      ; preds = %15
+  %29 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %30 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)*)*)(%System.RuntimeType addrspace(1)* %29, %System.RuntimeType addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+; <label>:34                                      ; preds = %15
+  %35 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %36 = call %System.Reflection.Emit.TypeBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Reflection.Emit.TypeBuilder addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %35)
+  %37 = icmp eq %System.Reflection.Emit.TypeBuilder addrspace(1)* %36, null
+  br i1 %37, label %139, label %38
+
+; <label>:38                                      ; preds = %34
+  %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %42
+
+; <label>:42                                      ; preds = %38
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 152
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 40
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
+  %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
+  %53 = zext i8 %52 to i32
+  %54 = icmp eq i32 %53, 0
+  br i1 %54, label %56, label %55
+
+; <label>:55                                      ; preds = %42
+  ret i8 1
+
+; <label>:56                                      ; preds = %42
+  %57 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %58 = bitcast %System.RuntimeType addrspace(1)* %57 to %System.Type addrspace(1)*
+  %59 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %58)
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %64 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.Type addrspace(1)* %63, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = bitcast %System.RuntimeType addrspace(1)* %64 to %System.Type addrspace(1)*
+  %67 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %63, %System.Type addrspace(1)* %66)
+  %68 = zext i8 %67 to i32
+  %69 = trunc i32 %68 to i8
+  ret i8 %69
+
+; <label>:70                                      ; preds = %56
+  %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
+  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %73
+
+; <label>:73                                      ; preds = %70
+  %74 = load i64, i64 addrspace(1)* %72
+  %75 = add i64 %74, 128
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = add i64 %77, 0
+  %79 = inttoptr i64 %78 to i64*
+  %80 = load i64, i64* %79
+  %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
+  %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
+  %83 = call i8 %82(%System.Type addrspace(1)* %81)
+  %84 = zext i8 %83 to i32
+  %85 = icmp eq i32 %84, 0
+  br i1 %85, label %139, label %86
+
+; <label>:86                                      ; preds = %73
+  %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
+  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %89
+
+; <label>:89                                      ; preds = %86
+  %90 = load i64, i64 addrspace(1)* %88
+  %91 = add i64 %90, 128
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = add i64 %93, 24
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
+  %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
+  %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
+  store %"System.Type[]" addrspace(1)* %99, %"System.Type[]" addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %129
+
+; <label>:100                                     ; preds = %132
+  %101 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %102 = load i32, i32* %loc2
+  %NullCheck11 = icmp eq %"System.Type[]" addrspace(1)* %101, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %103
+
+; <label>:103                                     ; preds = %100
+  %104 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 1
+  %105 = load i32, i32 addrspace(1)* %104
+  %106 = zext i32 %105 to i64
+  %107 = zext i32 %102 to i64
+  %BoundsCheck = icmp uge i64 %107, %106
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %108
+
+; <label>:108                                     ; preds = %103
+  %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
+  %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
+  %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
+  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %113
+
+; <label>:113                                     ; preds = %108
+  %114 = load i64, i64 addrspace(1)* %112
+  %115 = add i64 %114, 152
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = add i64 %117, 56
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
+  %123 = zext i8 %122 to i32
+  %124 = icmp ne i32 %123, 0
+  br i1 %124, label %126, label %125
+
+; <label>:125                                     ; preds = %113
+  ret i8 0
+
+; <label>:126                                     ; preds = %113
+  %127 = load i32, i32* %loc2
+  %128 = add i32 %127, 1
+  store i32 %128, i32* %loc2
+  br label %129
+
+; <label>:129                                     ; preds = %89, %126
+  %130 = load i32, i32* %loc2
+  %131 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %NullCheck9 = icmp eq %"System.Type[]" addrspace(1)* %131, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %132
+
+; <label>:132                                     ; preds = %129
+  %133 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %131, i32 0, i32 1
+  %134 = load i32, i32 addrspace(1)* %133
+  %135 = zext i32 %134 to i64
+  %136 = trunc i64 %135 to i32
+  %137 = icmp slt i32 %130, %136
+  br i1 %137, label %100, label %138
+
+; <label>:138                                     ; preds = %132
+  ret i8 1
+
+; <label>:139                                     ; preds = %34, %73
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %129
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %103
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -2893,7 +3248,7 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElem]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -2904,8 +3259,8 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -2997,8 +3352,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
@@ -3059,8 +3414,8 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -3087,8 +3442,8 @@ entry:
 
 ; <label>:17                                      ; preds = %5, %11
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
@@ -3097,8 +3452,8 @@ entry:
 
 ; <label>:22                                      ; preds = %1, %11
   %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
@@ -3109,11 +3464,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %17
+ThrowNullRef2:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %22
+ThrowNullRef4:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3167,15 +3522,15 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
   %15 = load i32, i32 addrspace(1)* %14
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
@@ -3198,7 +3553,7 @@ ThrowNullRef:                                     ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef2:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3232,8 +3587,8 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
@@ -3312,8 +3667,8 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -3327,8 +3682,8 @@ entry:
 ; <label>:5                                       ; preds = %43
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %7 = load i32, i32* %loc1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck6, label %8, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
@@ -3366,8 +3721,8 @@ entry:
 ; <label>:32                                      ; preds = %21, %25
   %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
   %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
-  br i1 %NullCheck8, label %35, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = trunc i32 %34 to i16
@@ -3380,8 +3735,8 @@ entry:
 ; <label>:40                                      ; preds = %1, %35
   %41 = load i32, i32* %loc1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
-  br i1 %NullCheck2, label %43, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %42, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
@@ -3392,8 +3747,8 @@ entry:
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
   %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
-  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
   %51 = load i64, i64 addrspace(1)* %49
@@ -3412,19 +3767,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %40
+ThrowNullRef2:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %47
+ThrowNullRef4:                                    ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %5
+ThrowNullRef6:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %32
+ThrowNullRef8:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3467,8 +3822,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
@@ -3492,11 +3847,391 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(i16* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store i16* %param0, i16** %arg0
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load i32, i32* %arg3
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %42, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %37, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg2
+  %13 = load i32, i32* %arg3
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %37, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %24 = load i32, i32* %arg2
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load i16*, i16** %arg0
+  %35 = load i32, i32* %arg3
+  %36 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %36, i16* %34, i32 %35)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:37                                      ; preds = %5, %16
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %39)
+  %41 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41, %System.String addrspace(1)* %38, %System.String addrspace(1)* %40)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41) #0
+  unreachable
+
+; <label>:42                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
-Failed to read StringBuilder.ToString[loadElemA]
+Successfully read StringBuilder.ToString
+
+define %System.String addrspace(1)* @StringBuilder.ToString(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i16*
+  %loc3 = alloca %"System.Char[]" addrspace(1)*
+  %loc4 = alloca i32
+  %loc5 = alloca i32
+  %loc6 = alloca i16 addrspace(1)*
+  %loc7 = alloca %System.String addrspace(1)*
+  %loc8 = alloca %"System.Char[]" addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %0)
+  %2 = icmp ne i32 %1, 0
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %4
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %6)
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %7)
+  store %System.String addrspace(1)* %8, %System.String addrspace(1)** %loc0
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.Text.StringBuilder addrspace(1)* %9, %System.Text.StringBuilder addrspace(1)** %loc1
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  store %System.String addrspace(1)* %10, %System.String addrspace(1)** %loc7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc7
+  %12 = ptrtoint %System.String addrspace(1)* %11 to i64
+  %13 = icmp eq i64 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %5
+  %15 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %16 = sext i32 %15 to i64
+  %17 = add i64 %12, %16
+  br label %18
+
+; <label>:18                                      ; preds = %5, %14
+  %19 = phi i64 [ %12, %5 ], [ %17, %14 ]
+  %20 = inttoptr i64 %19 to i16*
+  store i16* %20, i16** %loc2
+  br label %21
+
+; <label>:21                                      ; preds = %98, %18
+  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %22, null
+  br i1 %NullCheck, label %ThrowNullRef, label %23
+
+; <label>:23                                      ; preds = %21
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 3
+  %25 = load i32, i32 addrspace(1)* %24, align 8
+  %26 = icmp sle i32 %25, 0
+  br i1 %26, label %96, label %27
+
+; <label>:27                                      ; preds = %23
+  %28 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %28, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %29
+
+; <label>:29                                      ; preds = %27
+  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %28, i32 0, i32 1
+  %31 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %30, align 8
+  store %"System.Char[]" addrspace(1)* %31, %"System.Char[]" addrspace(1)** %loc3
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %33
+
+; <label>:33                                      ; preds = %29
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  store i32 %35, i32* %loc4
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  %39 = load i32, i32 addrspace(1)* %38, align 8
+  store i32 %39, i32* %loc5
+  %40 = load i32, i32* %loc5
+  %41 = load i32, i32* %loc4
+  %42 = add i32 %40, %41
+  %43 = zext i32 %42 to i64
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %45
+
+; <label>:45                                      ; preds = %37
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = sext i32 %47 to i64
+  %49 = icmp sgt i64 %43, %48
+  br i1 %49, label %91, label %50
+
+; <label>:50                                      ; preds = %45
+  %51 = load i32, i32* %loc5
+  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %52, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %53
+
+; <label>:53                                      ; preds = %50
+  %54 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %52, i32 0, i32 1
+  %55 = load i32, i32 addrspace(1)* %54
+  %56 = zext i32 %55 to i64
+  %57 = trunc i64 %56 to i32
+  %58 = icmp ugt i32 %51, %57
+  br i1 %58, label %91, label %59
+
+; <label>:59                                      ; preds = %53
+  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  store %"System.Char[]" addrspace(1)* %60, %"System.Char[]" addrspace(1)** %loc8
+  %61 = icmp eq %"System.Char[]" addrspace(1)* %60, null
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %63, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %64
+
+; <label>:64                                      ; preds = %62
+  %65 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %63, i32 0, i32 1
+  %66 = load i32, i32 addrspace(1)* %65
+  %67 = zext i32 %66 to i64
+  %68 = trunc i64 %67 to i32
+  %69 = icmp ne i32 %68, 0
+  br i1 %69, label %71, label %70
+
+; <label>:70                                      ; preds = %59, %64
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:71                                      ; preds = %64
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %73
+
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %BoundsCheck = icmp uge i64 0, %76
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %77
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %78, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:79                                      ; preds = %70, %77
+  %80 = load i16*, i16** %loc2
+  %81 = load i32, i32* %loc4
+  %82 = sext i32 %81 to i64
+  %83 = mul i64 %82, 2
+  %84 = bitcast i16* %80 to i8*
+  %85 = getelementptr inbounds i8, i8* %84, i64 %83
+  %86 = load i16 addrspace(1)*, i16 addrspace(1)** %loc6
+  %87 = ptrtoint i16 addrspace(1)* %86 to i64
+  %88 = load i32, i32* %loc5
+  %89 = bitcast i8* %85 to i16*
+  %90 = inttoptr i64 %87 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %89, i16* %90, i32 %88)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %96
+
+; <label>:91                                      ; preds = %45, %53
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %94 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %93)
+  %95 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95, %System.String addrspace(1)* %92, %System.String addrspace(1)* %94)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95) #0
+  unreachable
+
+; <label>:96                                      ; preds = %23, %79
+  %97 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %97, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %98
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %97, i32 0, i32 2
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  store %System.Text.StringBuilder addrspace(1)* %100, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %102 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %102, label %21, label %103
+
+; <label>:103                                     ; preds = %98
+  store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc7
+  %104 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  ret %System.String addrspace(1)* %104
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method StringBuilder::get_Length using LLILCJit
+Successfully read StringBuilder.get_Length
+
+define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
+Successfully read RuntimeHelpers.get_OffsetToStringData
+
+define i32 @RuntimeHelpers.get_OffsetToStringData() {
+entry:
+  ret i32 12
+}
+
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
 Successfully read CultureData.CreateCultureData
 
@@ -3514,23 +4249,23 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
   store i8 %4, i8 addrspace(1)* %6
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
@@ -3549,11 +4284,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3566,50 +4301,50 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
   store i32 -1, i32 addrspace(1)* %2
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
   store i32 -1, i32 addrspace(1)* %8
   %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
   store i32 -1, i32 addrspace(1)* %14
   %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
   store i32 -1, i32 addrspace(1)* %17
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
@@ -3623,27 +4358,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3675,7 +4410,136 @@ Failed to read Dictionary`2.Insert[non-const derefAddress]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
 Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
-Failed to read HashHelpers.GetPrime[loadElem]
+Successfully read HashHelpers.GetPrime
+
+define i32 @HashHelpers.GetPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %6, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5, %System.String addrspace(1)* %4)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5) #0
+  unreachable
+
+; <label>:6                                       ; preds = %entry
+  store i32 0, i32* %loc0
+  br label %29
+
+; <label>:7                                       ; preds = %35
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 1296
+  %10 = addrspacecast i8 addrspace(1)* %9 to %"System.Int32[]" addrspace(1)**
+  %11 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %10
+  %12 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Int32[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = zext i32 %15 to i64
+  %17 = zext i32 %12 to i64
+  %BoundsCheck = icmp uge i64 %17, %16
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 3, i32 %12
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  store i32 %20, i32* %loc1
+  %21 = load i32, i32* %loc1
+  %22 = load i32, i32* %arg0
+  %23 = icmp slt i32 %21, %22
+  br i1 %23, label %26, label %24
+
+; <label>:24                                      ; preds = %18
+  %25 = load i32, i32* %loc1
+  ret i32 %25
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %loc0
+  %28 = add i32 %27, 1
+  store i32 %28, i32* %loc0
+  br label %29
+
+; <label>:29                                      ; preds = %6, %26
+  %30 = load i32, i32* %loc0
+  %31 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %32 = getelementptr inbounds i8, i8 addrspace(1)* %31, i64 1296
+  %33 = addrspacecast i8 addrspace(1)* %32 to %"System.Int32[]" addrspace(1)**
+  %34 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %33
+  %NullCheck = icmp eq %"System.Int32[]" addrspace(1)* %34, null
+  br i1 %NullCheck, label %ThrowNullRef, label %35
+
+; <label>:35                                      ; preds = %29
+  %36 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %34, i32 0, i32 1
+  %37 = load i32, i32 addrspace(1)* %36
+  %38 = zext i32 %37 to i64
+  %39 = trunc i64 %38 to i32
+  %40 = icmp slt i32 %30, %39
+  br i1 %40, label %7, label %41
+
+; <label>:41                                      ; preds = %35
+  %42 = load i32, i32* %arg0
+  %43 = or i32 %42, 1
+  store i32 %43, i32* %loc2
+  br label %59
+
+; <label>:44                                      ; preds = %59
+  %45 = load i32, i32* %loc2
+  %46 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %45)
+  %47 = zext i8 %46 to i32
+  %48 = icmp eq i32 %47, 0
+  br i1 %48, label %56, label %49
+
+; <label>:49                                      ; preds = %44
+  %50 = load i32, i32* %loc2
+  %51 = sub i32 %50, 1
+  %52 = srem i32 %51, 101
+  %53 = icmp eq i32 %52, 0
+  br i1 %53, label %56, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = load i32, i32* %loc2
+  ret i32 %55
+
+; <label>:56                                      ; preds = %44, %49
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %57, 2
+  store i32 %58, i32* %loc2
+  br label %59
+
+; <label>:59                                      ; preds = %41, %56
+  %60 = load i32, i32* %loc2
+  %61 = icmp slt i32 %60, 2147483647
+  br i1 %61, label %44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load i32, i32* %arg0
+  ret i32 %63
+
+ThrowNullRef:                                     ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
 Successfully read GenericEqualityComparer`1.GetHashCode
 
@@ -3694,14 +4558,14 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
   %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load i64, i64 addrspace(1)* %7
@@ -3720,7 +4584,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3750,8 +4614,8 @@ entry:
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
@@ -3796,8 +4660,8 @@ entry:
   %35 = bitcast i16* %34 to i8*
   %36 = getelementptr inbounds i8, i8* %35, i64 2
   %37 = bitcast i8* %36 to i16*
-  %NullCheck4 = icmp ne i16* %37, null
-  br i1 %NullCheck4, label %38, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %37, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %38
 
 ; <label>:38                                      ; preds = %27
   %39 = load i16, i16* %37, align 8
@@ -3824,8 +4688,8 @@ entry:
 
 ; <label>:54                                      ; preds = %22, %43
   %55 = load i16*, i16** %loc4
-  %NullCheck2 = icmp ne i16* %55, null
-  br i1 %NullCheck2, label %56, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i16* %55, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %56
 
 ; <label>:56                                      ; preds = %54
   %57 = load i16, i16* %55, align 8
@@ -3850,11 +4714,11 @@ ThrowNullRef:                                     ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %54
+ThrowNullRef2:                                    ; preds = %54
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %27
+ThrowNullRef4:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3871,8 +4735,8 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -3907,8 +4771,8 @@ entry:
 
 ; <label>:26                                      ; preds = %19
   %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
-  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %28
 
 ; <label>:28                                      ; preds = %26
   %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
@@ -3920,7 +4784,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3972,8 +4836,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
@@ -3984,26 +4848,26 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
-  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
@@ -4014,8 +4878,8 @@ entry:
 ; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
@@ -4024,8 +4888,8 @@ entry:
 
 ; <label>:25                                      ; preds = %1, %16, %23
   %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
-  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
@@ -4036,27 +4900,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %20
+ThrowNullRef10:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4069,8 +4933,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -4081,8 +4945,8 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
@@ -4091,8 +4955,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1, %8
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
@@ -4103,11 +4967,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4128,24 +4992,24 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   store i32 %3, i32* %loc0
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
   %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
   store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck4, label %9, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
@@ -4164,15 +5028,15 @@ entry:
 ; <label>:18                                      ; preds = %70
   %19 = load i16*, i16** %loc3
   %20 = bitcast i16* %19 to i64*
-  %NullCheck10 = icmp ne i64* %20, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %20, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = load i64, i64* %20, align 8
   %23 = load i16*, i16** %loc4
   %24 = bitcast i16* %23 to i64*
-  %NullCheck12 = icmp ne i64* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = load i64, i64* %24, align 8
@@ -4188,8 +5052,8 @@ entry:
   %31 = bitcast i16* %30 to i8*
   %32 = getelementptr inbounds i8, i8* %31, i64 8
   %33 = bitcast i8* %32 to i64*
-  %NullCheck14 = icmp ne i64* %33, null
-  br i1 %NullCheck14, label %34, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = load i64, i64* %33, align 8
@@ -4197,8 +5061,8 @@ entry:
   %37 = bitcast i16* %36 to i8*
   %38 = getelementptr inbounds i8, i8* %37, i64 8
   %39 = bitcast i8* %38 to i64*
-  %NullCheck16 = icmp ne i64* %39, null
-  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %40
 
 ; <label>:40                                      ; preds = %34
   %41 = load i64, i64* %39, align 8
@@ -4214,8 +5078,8 @@ entry:
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %NullCheck18 = icmp ne i64* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = load i64, i64* %48, align 8
@@ -4223,8 +5087,8 @@ entry:
   %52 = bitcast i16* %51 to i8*
   %53 = getelementptr inbounds i8, i8* %52, i64 16
   %54 = bitcast i8* %53 to i64*
-  %NullCheck20 = icmp ne i64* %54, null
-  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64* %54, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %55
 
 ; <label>:55                                      ; preds = %49
   %56 = load i64, i64* %54, align 8
@@ -4262,15 +5126,15 @@ entry:
 ; <label>:74                                      ; preds = %95
   %75 = load i16*, i16** %loc3
   %76 = bitcast i16* %75 to i32*
-  %NullCheck6 = icmp ne i32* %76, null
-  br i1 %NullCheck6, label %77, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32* %76, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %77
 
 ; <label>:77                                      ; preds = %74
   %78 = load i32, i32* %76, align 8
   %79 = load i16*, i16** %loc4
   %80 = bitcast i16* %79 to i32*
-  %NullCheck8 = icmp ne i32* %80, null
-  br i1 %NullCheck8, label %81, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i32* %80, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %81
 
 ; <label>:81                                      ; preds = %77
   %82 = load i32, i32* %80, align 8
@@ -4318,43 +5182,43 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %74
+ThrowNullRef6:                                    ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %77
+ThrowNullRef8:                                    ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %29
+ThrowNullRef14:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %34
+ThrowNullRef16:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4376,8 +5240,8 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load i64, i64 addrspace(1)* %4
@@ -4389,8 +5253,8 @@ entry:
   %12 = load i64, i64* %11
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %5
   %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
@@ -4399,8 +5263,8 @@ entry:
   %18 = load i8, i8* %arg2
   %19 = zext i8 %18 to i32
   %20 = trunc i32 %19 to i8
-  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %15
   %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
@@ -4411,11 +5275,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4442,8 +5306,8 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
@@ -4466,16 +5330,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
   %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = load i64, i64 addrspace(1)* %19
@@ -4500,8 +5364,8 @@ entry:
 ; <label>:35                                      ; preds = %30
   %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
@@ -4514,8 +5378,8 @@ entry:
 
 ; <label>:42                                      ; preds = %1, %38
   %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
-  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
@@ -4526,19 +5390,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %35
+ThrowNullRef2:                                    ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %42
+ThrowNullRef8:                                    ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4551,14 +5415,14 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
@@ -4570,7 +5434,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4583,8 +5447,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
@@ -4613,51 +5477,51 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
   %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
   %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
   %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
   %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
-  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
   store i64 %21, i64 addrspace(1)* %23
   %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %25 = load i64, i64* %loc0
-  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
@@ -4668,27 +5532,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %22
+ThrowNullRef12:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4701,8 +5565,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
@@ -4713,19 +5577,19 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
@@ -4734,8 +5598,8 @@ entry:
 
 ; <label>:15                                      ; preds = %1, %13
   %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
@@ -4746,19 +5610,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %15
+ThrowNullRef8:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4771,8 +5635,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -4831,8 +5695,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
@@ -4882,8 +5746,8 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
-  br i1 %NullCheck, label %17, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %ThrowNullRef, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
@@ -4894,15 +5758,15 @@ entry:
 
 ; <label>:22                                      ; preds = %17
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
-  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
   %26 = load i32, i32 addrspace(1)* %25
   %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
-  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %27, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
@@ -4925,8 +5789,8 @@ entry:
 ; <label>:40                                      ; preds = %17
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
-  br i1 %NullCheck6, label %43, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %41, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
@@ -4938,34 +5802,17 @@ ThrowNullRef:                                     ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %24
+ThrowNullRef4:                                    ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %40
+ThrowNullRef6:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
-}
-
-INFO:  jitting method Object::ReferenceEquals using LLILCJit
-Successfully read Object.ReferenceEquals
-
-define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
-entry:
-  %arg0 = alloca %System.Object addrspace(1)*
-  %arg1 = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
-  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
-  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = icmp eq %System.Object addrspace(1)* %0, %1
-  %3 = sext i1 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
 }
 
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
@@ -4978,21 +5825,21 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
   %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
-  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
@@ -5007,28 +5854,28 @@ entry:
 ; <label>:13                                      ; preds = %8, %12
   %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
   %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
   %21 = load i32, i32 addrspace(1)* %20, align 8
   %22 = add i32 %21, 1
-  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
   store i32 %22, i32 addrspace(1)* %24
   %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
@@ -5039,27 +5886,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5077,7 +5924,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::Setup using LLILCJit
-Failed to read AppDomain.Setup[loadElem]
+Failed to read AppDomain.Setup[unbox]
 INFO:  jitting method Thread::GetDomain using LLILCJit
 Successfully read Thread.GetDomain
 
@@ -5108,8 +5955,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
@@ -5122,14 +5969,14 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
   %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
@@ -5141,11 +5988,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5173,8 +6020,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -5189,7 +6036,328 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
 Failed to read KeyCollection.System.Collections.Generic.IEnumerable<TKey>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Successfully read Enumerator.MoveNext
+
+define i8 @Enumerator.MoveNext(%"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.RuntimeTypeHandle* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*
+  %"$TypeArg" = alloca %System.RuntimeTypeHandle*
+  store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
+  %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 8
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %76, label %12
+
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
+  br label %76
+
+; <label>:13                                      ; preds = %85
+  %14 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck19 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %15
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, i32 0, i32 0
+  %17 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %16, align 8
+  %NullCheck21 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, i32 0, i32 2
+  %20 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %19, align 8
+  %21 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck23 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %22
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, i32 0, i32 2
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %NullCheck25 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 3, i32 %24
+  %NullCheck27 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %32
+
+; <label>:32                                      ; preds = %30
+  %33 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, i32 0, i32 2
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = icmp slt i32 %34, 0
+  br i1 %35, label %68, label %36
+
+; <label>:36                                      ; preds = %32
+  %37 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %38 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck29 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %39
+
+; <label>:39                                      ; preds = %36
+  %40 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, i32 0, i32 0
+  %41 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %40, align 8
+  %NullCheck31 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, i32 0, i32 2
+  %44 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %43, align 8
+  %45 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck33 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, i32 0, i32 2
+  %48 = load i32, i32 addrspace(1)* %47, align 8
+  %NullCheck35 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %49
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = zext i32 %51 to i64
+  %53 = zext i32 %48 to i64
+  %BoundsCheck37 = icmp uge i64 %53, %52
+  br i1 %BoundsCheck37, label %ThrowIndexOutOfRange38, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 3, i32 %48
+  %NullCheck39 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %56
+
+; <label>:56                                      ; preds = %54
+  %57 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, i32 0, i32 0
+  %58 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck41 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %59
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %60, %System.__Canon addrspace(1)* %58)
+  %61 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck43 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  %64 = load i32, i32 addrspace(1)* %63, align 8
+  %65 = add i32 %64, 1
+  %NullCheck45 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  store i32 %65, i32 addrspace(1)* %67
+  ret i8 1
+
+; <label>:68                                      ; preds = %32
+  %69 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck47 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %73 = add i32 %72, 1
+  %NullCheck49 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %74
+
+; <label>:74                                      ; preds = %70
+  %75 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  store i32 %73, i32 addrspace(1)* %75
+  br label %76
+
+; <label>:76                                      ; preds = %8, %12, %74
+  %77 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %78
+
+; <label>:78                                      ; preds = %76
+  %79 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, i32 0, i32 2
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck7 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %82
+
+; <label>:82                                      ; preds = %78
+  %83 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, i32 0, i32 0
+  %84 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %83, align 8
+  %NullCheck9 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %85
+
+; <label>:85                                      ; preds = %82
+  %86 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, i32 0, i32 7
+  %87 = load i32, i32 addrspace(1)* %86, align 8
+  %88 = icmp ult i32 %80, %87
+  br i1 %88, label %13, label %89
+
+; <label>:89                                      ; preds = %85
+  %90 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %91 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck11 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %92
+
+; <label>:92                                      ; preds = %89
+  %93 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, i32 0, i32 0
+  %94 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck13 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %95
+
+; <label>:95                                      ; preds = %92
+  %96 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, i32 0, i32 7
+  %97 = load i32, i32 addrspace(1)* %96, align 8
+  %98 = add i32 %97, 1
+  %NullCheck15 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %99
+
+; <label>:99                                      ; preds = %95
+  %100 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, i32 0, i32 2
+  store i32 %98, i32 addrspace(1)* %100
+  %101 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck17 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %102
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %103, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %92
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef22:                                   ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef24:                                   ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef26:                                   ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef28:                                   ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef30:                                   ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef32:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef34:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef36:                                   ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange38:                           ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef40:                                   ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef42:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef44:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef46:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef48:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef50:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -5200,8 +6368,8 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -5232,9 +6400,9 @@ Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
 Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
-Failed to read String.MakeSeparatorList[loadElemA]
+Failed to read String.MakeSeparatorList[storeElem]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
-Failed to read String.InternalSplitKeepEmptyEntries[loadElem]
+Failed to read String.InternalSplitKeepEmptyEntries[storeElem]
 INFO:  jitting method Path::IsRelative using LLILCJit
 Successfully read Path.IsRelative
 
@@ -5243,8 +6411,8 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -5254,8 +6422,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
@@ -5271,8 +6439,8 @@ entry:
 
 ; <label>:17                                      ; preds = %7
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
@@ -5288,8 +6456,8 @@ entry:
 
 ; <label>:29                                      ; preds = %19
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %31
 
 ; <label>:31                                      ; preds = %29
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
@@ -5300,8 +6468,8 @@ entry:
 
 ; <label>:36                                      ; preds = %31
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
-  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %37, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
@@ -5312,8 +6480,8 @@ entry:
 
 ; <label>:43                                      ; preds = %31, %38
   %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
-  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %45
 
 ; <label>:45                                      ; preds = %43
   %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
@@ -5324,8 +6492,8 @@ entry:
 
 ; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %50
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
@@ -5336,8 +6504,8 @@ entry:
 
 ; <label>:57                                      ; preds = %1, %7, %19, %45, %52
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
-  br i1 %NullCheck14, label %59, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %59
 
 ; <label>:59                                      ; preds = %57
   %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
@@ -5347,8 +6515,8 @@ entry:
 
 ; <label>:63                                      ; preds = %59
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
@@ -5359,8 +6527,8 @@ entry:
 
 ; <label>:70                                      ; preds = %65
   %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
-  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.String addrspace(1)* %71, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %72
 
 ; <label>:72                                      ; preds = %70
   %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
@@ -5379,39 +6547,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %17
+ThrowNullRef4:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %29
+ThrowNullRef6:                                    ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %36
+ThrowNullRef8:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %43
+ThrowNullRef10:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %50
+ThrowNullRef12:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %57
+ThrowNullRef14:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %63
+ThrowNullRef16:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %70
+ThrowNullRef18:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5419,7 +6587,293 @@ ThrowNullRef17:                                   ; preds = %70
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
-Failed to read String.TrimHelper[loadElem]
+Successfully read String.TrimHelper
+
+define %System.String addrspace(1)* @String.TrimHelper(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i16
+  %loc4 = alloca i32
+  %loc5 = alloca i16
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = sub i32 %3, 1
+  store i32 %4, i32* %loc0
+  store i32 0, i32* %loc1
+  %5 = load i32, i32* %arg2
+  %6 = icmp eq i32 %5, 1
+  br i1 %6, label %62, label %7
+
+; <label>:7                                       ; preds = %1
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:8                                       ; preds = %58
+  store i32 0, i32* %loc2
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load i32, i32* %loc1
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2, i32 %10
+  %13 = load i16, i16 addrspace(1)* %12
+  %14 = zext i16 %13 to i32
+  %15 = trunc i32 %14 to i16
+  store i16 %15, i16* %loc3
+  store i32 0, i32* %loc2
+  br label %34
+
+; <label>:16                                      ; preds = %37
+  %17 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %18 = load i32, i32* %loc2
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %17, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %19
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = zext i32 %18 to i64
+  %BoundsCheck = icmp uge i64 %23, %22
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %24
+
+; <label>:24                                      ; preds = %19
+  %25 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 3, i32 %18
+  %26 = load i16, i16 addrspace(1)* %25, align 8
+  %27 = zext i16 %26 to i32
+  %28 = load i16, i16* %loc3
+  %29 = zext i16 %28 to i32
+  %30 = icmp eq i32 %27, %29
+  br i1 %30, label %43, label %31
+
+; <label>:31                                      ; preds = %24
+  %32 = load i32, i32* %loc2
+  %33 = add i32 %32, 1
+  store i32 %33, i32* %loc2
+  br label %34
+
+; <label>:34                                      ; preds = %11, %31
+  %35 = load i32, i32* %loc2
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = icmp slt i32 %35, %41
+  br i1 %42, label %16, label %43
+
+; <label>:43                                      ; preds = %24, %37
+  %44 = load i32, i32* %loc2
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %45, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp eq i32 %44, %50
+  br i1 %51, label %62, label %52
+
+; <label>:52                                      ; preds = %46
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %7, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %57, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %58
+
+; <label>:58                                      ; preds = %55
+  %59 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %60 = load i32, i32 addrspace(1)* %59
+  %61 = icmp slt i32 %56, %60
+  br i1 %61, label %8, label %62
+
+; <label>:62                                      ; preds = %1, %46, %58
+  %63 = load i32, i32* %arg2
+  %64 = icmp eq i32 %63, 0
+  br i1 %64, label %122, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %66, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %67
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %66, i32 0, i32 1
+  %69 = load i32, i32 addrspace(1)* %68
+  %70 = sub i32 %69, 1
+  store i32 %70, i32* %loc0
+  br label %118
+
+; <label>:71                                      ; preds = %118
+  store i32 0, i32* %loc4
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %73 = load i32, i32* %loc0
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %74
+
+; <label>:74                                      ; preds = %71
+  %75 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 2, i32 %73
+  %76 = load i16, i16 addrspace(1)* %75
+  %77 = zext i16 %76 to i32
+  %78 = trunc i32 %77 to i16
+  store i16 %78, i16* %loc5
+  store i32 0, i32* %loc4
+  br label %97
+
+; <label>:79                                      ; preds = %100
+  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %81 = load i32, i32* %loc4
+  %NullCheck19 = icmp eq %"System.Char[]" addrspace(1)* %80, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
+
+; <label>:82                                      ; preds = %79
+  %83 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 1
+  %84 = load i32, i32 addrspace(1)* %83
+  %85 = zext i32 %84 to i64
+  %86 = zext i32 %81 to i64
+  %BoundsCheck21 = icmp uge i64 %86, %85
+  br i1 %BoundsCheck21, label %ThrowIndexOutOfRange22, label %87
+
+; <label>:87                                      ; preds = %82
+  %88 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 3, i32 %81
+  %89 = load i16, i16 addrspace(1)* %88, align 8
+  %90 = zext i16 %89 to i32
+  %91 = load i16, i16* %loc5
+  %92 = zext i16 %91 to i32
+  %93 = icmp eq i32 %90, %92
+  br i1 %93, label %106, label %94
+
+; <label>:94                                      ; preds = %87
+  %95 = load i32, i32* %loc4
+  %96 = add i32 %95, 1
+  store i32 %96, i32* %loc4
+  br label %97
+
+; <label>:97                                      ; preds = %74, %94
+  %98 = load i32, i32* %loc4
+  %99 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck15 = icmp eq %"System.Char[]" addrspace(1)* %99, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %100
+
+; <label>:100                                     ; preds = %97
+  %101 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %99, i32 0, i32 1
+  %102 = load i32, i32 addrspace(1)* %101
+  %103 = zext i32 %102 to i64
+  %104 = trunc i64 %103 to i32
+  %105 = icmp slt i32 %98, %104
+  br i1 %105, label %79, label %106
+
+; <label>:106                                     ; preds = %87, %100
+  %107 = load i32, i32* %loc4
+  %108 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck17 = icmp eq %"System.Char[]" addrspace(1)* %108, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %109
+
+; <label>:109                                     ; preds = %106
+  %110 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %108, i32 0, i32 1
+  %111 = load i32, i32 addrspace(1)* %110
+  %112 = zext i32 %111 to i64
+  %113 = trunc i64 %112 to i32
+  %114 = icmp eq i32 %107, %113
+  br i1 %114, label %122, label %115
+
+; <label>:115                                     ; preds = %109
+  %116 = load i32, i32* %loc0
+  %117 = sub i32 %116, 1
+  store i32 %117, i32* %loc0
+  br label %118
+
+; <label>:118                                     ; preds = %67, %115
+  %119 = load i32, i32* %loc0
+  %120 = load i32, i32* %loc1
+  %121 = icmp sge i32 %119, %120
+  br i1 %121, label %71, label %122
+
+; <label>:122                                     ; preds = %62, %109, %118
+  %123 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %124 = load i32, i32* %loc1
+  %125 = load i32, i32* %loc0
+  %126 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %123, i32 %124, i32 %125)
+  ret %System.String addrspace(1)* %126
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %97
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange22:                           ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
 Successfully read String.CreateTrimmedString
 
@@ -5439,8 +6893,8 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
@@ -5535,8 +6989,8 @@ entry:
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i64 2872
   %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
   %8 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %7
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %3
   %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
@@ -5553,8 +7007,8 @@ entry:
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 2864
   %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
   %21 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %20
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
-  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %22
 
 ; <label>:22                                      ; preds = %16
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
@@ -5569,7 +7023,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %16
+ThrowNullRef2:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5586,8 +7040,8 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5613,8 +7067,8 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
@@ -5632,8 +7086,8 @@ entry:
 
 ; <label>:12                                      ; preds = %4
   %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
@@ -5644,8 +7098,8 @@ entry:
 
 ; <label>:19                                      ; preds = %14
   %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %19
   %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
@@ -5660,21 +7114,21 @@ entry:
   %31 = zext i16 %30 to i32
   %32 = bitcast i8* %29 to i16*
   %33 = trunc i32 %31 to i16
-  %NullCheck6 = icmp ne i16* %32, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i16* %32, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %21
   store i16 %33, i16* %32, align 8
   %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %36
 
 ; <label>:36                                      ; preds = %34
   %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
   %38 = load i32, i32 addrspace(1)* %37, align 8
   %39 = add i32 %38, 1
-  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %40
 
 ; <label>:40                                      ; preds = %36
   %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
@@ -5683,16 +7137,16 @@ entry:
 
 ; <label>:42                                      ; preds = %14
   %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
-  br i1 %NullCheck12, label %44, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
   %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
   %47 = load i16, i16* %arg1
   %48 = zext i16 %47 to i32
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = trunc i32 %48 to i16
@@ -5703,31 +7157,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %19
+ThrowNullRef4:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %21
+ThrowNullRef6:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %36
+ThrowNullRef10:                                   ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %42
+ThrowNullRef12:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %44
+ThrowNullRef14:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5740,8 +7194,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -5752,8 +7206,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
@@ -5762,14 +7216,14 @@ entry:
 
 ; <label>:11                                      ; preds = %1
   %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
@@ -5779,15 +7233,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5808,8 +7262,8 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5822,8 +7276,8 @@ entry:
 
 ; <label>:8                                       ; preds = %3
   %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
@@ -5842,15 +7296,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
-  br i1 %NullCheck4, label %22, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
   %24 = load i16*, i16* addrspace(1)* %23, align 8
   %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %25, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
@@ -5859,8 +7313,8 @@ entry:
   store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
@@ -5874,8 +7328,8 @@ entry:
 
 ; <label>:37                                      ; preds = %65
   %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %37
   %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
@@ -5886,16 +7340,16 @@ entry:
   %45 = bitcast i16* %41 to i8*
   %46 = getelementptr inbounds i8, i8* %45, i64 %44
   %47 = bitcast i8* %46 to i16*
-  %NullCheck14 = icmp ne i16* %47, null
-  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %47, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %48
 
 ; <label>:48                                      ; preds = %39
   %49 = load i16, i16* %47, align 8
   %50 = zext i16 %49 to i32
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %52 = load i32, i32* %loc1
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %53
 
 ; <label>:53                                      ; preds = %48
   %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
@@ -5916,8 +7370,8 @@ entry:
 ; <label>:62                                      ; preds = %36, %59
   %63 = load i32, i32* %loc1
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck10, label %65, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %65
 
 ; <label>:65                                      ; preds = %62
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
@@ -5936,15 +7390,15 @@ entry:
 
 ; <label>:74                                      ; preds = %70
   %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
-  br i1 %NullCheck18, label %76, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %76
 
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
   %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
-  br i1 %NullCheck20, label %80, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
   %81 = load i64, i64 addrspace(1)* %79
@@ -5958,8 +7412,8 @@ entry:
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
   %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
-  br i1 %NullCheck22, label %92, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.String addrspace(1)* %90, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %92
 
 ; <label>:92                                      ; preds = %80
   %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
@@ -5969,15 +7423,15 @@ entry:
 
 ; <label>:96                                      ; preds = %70
   %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
-  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %98
 
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
   %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
-  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
   %103 = load i64, i64 addrspace(1)* %101
@@ -5991,8 +7445,8 @@ entry:
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
   %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
-  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.String addrspace(1)* %112, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %114
 
 ; <label>:114                                     ; preds = %102
   %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
@@ -6004,59 +7458,59 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %20
+ThrowNullRef4:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %22
+ThrowNullRef6:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %26
+ThrowNullRef8:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %62
+ThrowNullRef10:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %48
+ThrowNullRef16:                                   ; preds = %48
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %74
+ThrowNullRef18:                                   ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %76
+ThrowNullRef20:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %80
+ThrowNullRef22:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %96
+ThrowNullRef24:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %98
+ThrowNullRef26:                                   ; preds = %98
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %102
+ThrowNullRef28:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6069,15 +7523,15 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
   %3 = load i16*, i16* addrspace(1)* %2, align 8
   %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
@@ -6087,8 +7541,8 @@ entry:
   %10 = bitcast i16* %3 to i8*
   %11 = getelementptr inbounds i8, i8* %10, i64 %9
   %12 = bitcast i8* %11 to i16*
-  %NullCheck4 = icmp ne i16* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %5
   store i16 0, i16* %12, align 8
@@ -6098,11 +7552,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6119,8 +7573,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -6131,8 +7585,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
@@ -6144,15 +7598,15 @@ entry:
 
 ; <label>:14                                      ; preds = %1
   %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
   %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
   %21 = load i64, i64 addrspace(1)* %19
@@ -6171,15 +7625,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %14
+ThrowNullRef4:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %16
+ThrowNullRef6:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6302,14 +7756,6 @@ entry:
   ret %System.String addrspace(1)* %57
 }
 
-INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
-Successfully read RuntimeHelpers.get_OffsetToStringData
-
-define i32 @RuntimeHelpers.get_OffsetToStringData() {
-entry:
-  ret i32 12
-}
-
 INFO:  jitting method String::Equals using LLILCJit
 Successfully read String.Equals
 
@@ -6381,8 +7827,8 @@ entry:
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
-  br i1 %NullCheck24, label %29, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
   %30 = load i64, i64 addrspace(1)* %28
@@ -6397,8 +7843,8 @@ entry:
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
-  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
   %43 = load i64, i64 addrspace(1)* %41
@@ -6418,8 +7864,8 @@ entry:
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
   %59 = load i64, i64 addrspace(1)* %57
@@ -6434,8 +7880,8 @@ entry:
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck22, label %71, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
   %72 = load i64, i64 addrspace(1)* %70
@@ -6455,8 +7901,8 @@ entry:
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
-  br i1 %NullCheck16, label %87, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = load i64, i64 addrspace(1)* %86
@@ -6471,8 +7917,8 @@ entry:
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck18, label %100, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
   %101 = load i64, i64 addrspace(1)* %99
@@ -6492,8 +7938,8 @@ entry:
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
-  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
   %117 = load i64, i64 addrspace(1)* %115
@@ -6508,8 +7954,8 @@ entry:
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
-  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
   %130 = load i64, i64 addrspace(1)* %128
@@ -6528,15 +7974,15 @@ entry:
 
 ; <label>:142                                     ; preds = %22
   %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
-  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %143, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %144
 
 ; <label>:144                                     ; preds = %142
   %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
   %146 = load i32, i32 addrspace(1)* %145
   %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
-  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %147, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %148
 
 ; <label>:148                                     ; preds = %144
   %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
@@ -6557,15 +8003,15 @@ entry:
 
 ; <label>:159                                     ; preds = %22
   %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
-  br i1 %NullCheck, label %161, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %ThrowNullRef, label %161
 
 ; <label>:161                                     ; preds = %159
   %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
   %163 = load i32, i32 addrspace(1)* %162
   %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
-  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %164, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %165
 
 ; <label>:165                                     ; preds = %161
   %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
@@ -6578,8 +8024,8 @@ entry:
 
 ; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
-  br i1 %NullCheck4, label %172, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %171, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %172
 
 ; <label>:172                                     ; preds = %170
   %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
@@ -6589,8 +8035,8 @@ entry:
 
 ; <label>:176                                     ; preds = %172
   %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
-  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %177, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %178
 
 ; <label>:178                                     ; preds = %176
   %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
@@ -6629,55 +8075,55 @@ ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %161
+ThrowNullRef2:                                    ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %170
+ThrowNullRef4:                                    ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %176
+ThrowNullRef6:                                    ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %142
+ThrowNullRef8:                                    ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %144
+ThrowNullRef10:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %113
+ThrowNullRef12:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %116
+ThrowNullRef14:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %84
+ThrowNullRef16:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %87
+ThrowNullRef18:                                   ; preds = %87
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %55
+ThrowNullRef20:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %58
+ThrowNullRef22:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %26
+ThrowNullRef24:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %29
+ThrowNullRef26:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,8 +8161,8 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck, label %14, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %ThrowNullRef, label %14
 
 ; <label>:14                                      ; preds = %8
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
@@ -6760,8 +8206,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
@@ -6770,14 +8216,14 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32, i32* %loc0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %10
   %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
   %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
@@ -6790,15 +8236,15 @@ entry:
 ; <label>:25                                      ; preds = %19
   %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
-  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
   %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
@@ -6807,8 +8253,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %37 = load i32, i32* %loc0
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %38, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %38
 
 ; <label>:38                                      ; preds = %32
   %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
@@ -6817,14 +8263,14 @@ entry:
 
 ; <label>:40                                      ; preds = %19
   %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %40
   %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
   %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
-  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
-  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
@@ -6832,8 +8278,8 @@ entry:
   %48 = zext i32 %47 to i64
   %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
-  br i1 %NullCheck16, label %51, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %51
 
 ; <label>:51                                      ; preds = %45
   %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
@@ -6847,15 +8293,15 @@ entry:
 ; <label>:57                                      ; preds = %51
   %58 = load i16*, i16** %arg1
   %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
-  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %60
 
 ; <label>:60                                      ; preds = %57
   %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
   %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
-  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %64
 
 ; <label>:64                                      ; preds = %60
   %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
@@ -6864,22 +8310,22 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
   %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
-  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %70
 
 ; <label>:70                                      ; preds = %64
   %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
   %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
-  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
-  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
   %75 = load i32, i32 addrspace(1)* %74
   %76 = zext i32 %75 to i64
   %77 = trunc i64 %76 to i32
-  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
-  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %78
 
 ; <label>:78                                      ; preds = %73
   %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
@@ -6901,8 +8347,8 @@ entry:
   %90 = bitcast i16* %86 to i8*
   %91 = getelementptr inbounds i8, i8* %90, i64 %89
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %93
 
 ; <label>:93                                      ; preds = %80
   %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
@@ -6912,8 +8358,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %99 = load i32, i32* %loc2
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %100
 
 ; <label>:100                                     ; preds = %93
   %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
@@ -6928,63 +8374,63 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %25
+ThrowNullRef6:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %32
+ThrowNullRef10:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %40
+ThrowNullRef12:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %45
+ThrowNullRef16:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %57
+ThrowNullRef18:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %60
+ThrowNullRef20:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %64
+ThrowNullRef22:                                   ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %70
+ThrowNullRef24:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %73
+ThrowNullRef26:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %80
+ThrowNullRef28:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %93
+ThrowNullRef30:                                   ; preds = %93
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7004,8 +8450,8 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
@@ -7033,43 +8479,43 @@ entry:
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %14
   %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
   %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   %28 = load i32, i32 addrspace(1)* %27, align 8
   %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
-  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %30
 
 ; <label>:30                                      ; preds = %26
   %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
   %32 = load i32, i32 addrspace(1)* %31, align 8
   %33 = add i32 %28, %32
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %34
 
 ; <label>:34                                      ; preds = %30
   %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   store i32 %33, i32 addrspace(1)* %35
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
   store i32 0, i32 addrspace(1)* %38
   %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %40
 
 ; <label>:40                                      ; preds = %37
   %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
@@ -7082,8 +8528,8 @@ entry:
 
 ; <label>:47                                      ; preds = %40
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
@@ -7098,8 +8544,8 @@ entry:
   %54 = load i32, i32* %loc0
   %55 = sext i32 %54 to i64
   %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
-  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %57
 
 ; <label>:57                                      ; preds = %52
   %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
@@ -7110,68 +8556,35 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %14
+ThrowNullRef2:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %23
+ThrowNullRef4:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %26
+ThrowNullRef6:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %30
+ThrowNullRef8:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %34
+ThrowNullRef10:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %47
+ThrowNullRef14:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %52
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-}
-
-INFO:  jitting method StringBuilder::get_Length using LLILCJit
-Successfully read StringBuilder.get_Length
-
-define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.StringBuilder addrspace(1)*
-  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
-  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
-
-; <label>:1                                       ; preds = %entry
-  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %3 = load i32, i32 addrspace(1)* %2, align 8
-  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
-
-; <label>:5                                       ; preds = %1
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = add i32 %3, %7
-  ret i32 %8
-
-ThrowNullRef:                                     ; preds = %entry
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef16:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7213,70 +8626,70 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
   %6 = load i32, i32 addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
   store i32 %6, i32 addrspace(1)* %8
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
   %13 = load i32, i32 addrspace(1)* %12, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
   store i32 %13, i32 addrspace(1)* %15
   %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
-  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %18
 
 ; <label>:18                                      ; preds = %14
   %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
   %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
   %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
   %34 = load i32, i32 addrspace(1)* %33, align 8
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
-  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
@@ -7287,39 +8700,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %28
+ThrowNullRef16:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %32
+ThrowNullRef18:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7455,13 +8868,13 @@ entry:
 ; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
@@ -7477,16 +8890,16 @@ entry:
 
 ; <label>:18                                      ; preds = %15
   %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
   store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
   %22 = load i32, i32* %loc0
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %24
 
 ; <label>:24                                      ; preds = %20
   %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
@@ -7498,13 +8911,13 @@ entry:
 ; <label>:28                                      ; preds = %15, %24
   %29 = load i32, i32* %arg1
   %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %31
   %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
@@ -7517,20 +8930,20 @@ entry:
   %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
-  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
   %46 = load i32, i32 addrspace(1)* %45, align 8
   %47 = sub i32 %40, %46
-  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
-  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i32 addrspace(1)* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %48
 
 ; <label>:48                                      ; preds = %44
   store i32 %47, i32 addrspace(1)* %39, align 8
@@ -7538,21 +8951,21 @@ entry:
 
 ; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
-  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %51
 
 ; <label>:51                                      ; preds = %49
   %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %53
 
 ; <label>:53                                      ; preds = %51
   %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
   %55 = load i32, i32 addrspace(1)* %54, align 8
   %56 = load i32, i32* %arg2
   %57 = sub i32 %55, %56
-  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %58
 
 ; <label>:58                                      ; preds = %53
   %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
@@ -7562,13 +8975,13 @@ entry:
 ; <label>:60                                      ; preds = %33, %58
   %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
   %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
-  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %63
 
 ; <label>:63                                      ; preds = %60
   %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
-  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
-  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
@@ -7578,15 +8991,15 @@ entry:
 
 ; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
-  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i32 addrspace(1)* %69, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %70
 
 ; <label>:70                                      ; preds = %68
   %71 = load i32, i32 addrspace(1)* %69, align 8
   store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
-  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
@@ -7596,8 +9009,8 @@ entry:
   store i32 %77, i32* %loc4
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
-  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %80
 
 ; <label>:80                                      ; preds = %73
   %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
@@ -7607,71 +9020,71 @@ entry:
 ; <label>:83                                      ; preds = %80
   store i32 0, i32* %loc3
   %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
-  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
-  br i1 %NullCheck26, label %88, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i32 addrspace(1)* %87, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %88
 
 ; <label>:88                                      ; preds = %85
   %89 = load i32, i32 addrspace(1)* %87, align 8
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
-  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %90
 
 ; <label>:90                                      ; preds = %88
   %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
   store i32 %89, i32 addrspace(1)* %91
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
-  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
-  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %96
 
 ; <label>:96                                      ; preds = %94
   %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
-  br i1 %NullCheck34, label %100, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %100
 
 ; <label>:100                                     ; preds = %96
   %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
-  br i1 %NullCheck36, label %102, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %102
 
 ; <label>:102                                     ; preds = %100
   %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
   %104 = load i32, i32 addrspace(1)* %103, align 8
   %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
-  br i1 %NullCheck38, label %106, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %106
 
 ; <label>:106                                     ; preds = %102
   %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
-  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
-  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %108
 
 ; <label>:108                                     ; preds = %106
   %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
   %110 = load i32, i32 addrspace(1)* %109, align 8
   %111 = add i32 %104, %110
-  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %112
 
 ; <label>:112                                     ; preds = %108
   %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
   store i32 %111, i32 addrspace(1)* %113
   %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
-  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i32 addrspace(1)* %114, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %115
 
 ; <label>:115                                     ; preds = %112
   %116 = load i32, i32 addrspace(1)* %114, align 8
@@ -7681,19 +9094,19 @@ entry:
 ; <label>:118                                     ; preds = %115
   %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
-  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %121
 
 ; <label>:121                                     ; preds = %118
   %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
-  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
-  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %123
 
 ; <label>:123                                     ; preds = %121
   %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
   %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
-  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
-  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %126
 
 ; <label>:126                                     ; preds = %123
   %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
@@ -7705,8 +9118,8 @@ entry:
 
 ; <label>:130                                     ; preds = %80, %115, %126
   %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %132
 
 ; <label>:132                                     ; preds = %130
   %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7715,8 +9128,8 @@ entry:
   %136 = load i32, i32* %loc3
   %137 = sub i32 %135, %136
   %138 = sub i32 %134, %137
-  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %139
 
 ; <label>:139                                     ; preds = %132
   %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7728,16 +9141,16 @@ entry:
 
 ; <label>:144                                     ; preds = %139
   %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
-  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %146
 
 ; <label>:146                                     ; preds = %144
   %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
   %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
   %149 = load i32, i32* %loc2
   %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
-  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %151
 
 ; <label>:151                                     ; preds = %146
   %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
@@ -7754,145 +9167,249 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %18
+ThrowNullRef4:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %31
+ThrowNullRef10:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %44
+ThrowNullRef16:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %68
+ThrowNullRef18:                                   ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %70
+ThrowNullRef20:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %73
+ThrowNullRef22:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %83
+ThrowNullRef24:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %85
+ThrowNullRef26:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %88
+ThrowNullRef28:                                   ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %90
+ThrowNullRef30:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %94
+ThrowNullRef32:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %96
+ThrowNullRef34:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %100
+ThrowNullRef36:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %102
+ThrowNullRef38:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %106
+ThrowNullRef40:                                   ; preds = %106
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %108
+ThrowNullRef42:                                   ; preds = %108
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %112
+ThrowNullRef44:                                   ; preds = %112
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %118
+ThrowNullRef46:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %121
+ThrowNullRef48:                                   ; preds = %121
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %123
+ThrowNullRef50:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %130
+ThrowNullRef52:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %132
+ThrowNullRef54:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %144
+ThrowNullRef56:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %146
+ThrowNullRef58:                                   ; preds = %146
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %60
+ThrowNullRef60:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %63
+ThrowNullRef62:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %49
+ThrowNullRef64:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %51
+ThrowNullRef66:                                   ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %53
+ThrowNullRef68:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(%"System.Char[]" addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %arg0 = alloca %"System.Char[]" addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store %"System.Char[]" addrspace(1)* %param0, %"System.Char[]" addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load i32, i32* %arg4
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %43, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %38, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg1
+  %13 = load i32, i32* %arg4
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %38, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %24 = load i32, i32* %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %35 = load i32, i32* %arg3
+  %36 = load i32, i32* %arg4
+  %37 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %37, %"System.Char[]" addrspace(1)* %34, i32 %35, i32 %36)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:38                                      ; preds = %5, %16
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Successfully read Buffer._Memmove
 
@@ -7914,7 +9431,7 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[loadElem]
+Failed to read AppDomain.SetDataHelper[storeElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -7923,8 +9440,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
@@ -7934,8 +9451,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
@@ -7947,15 +9464,15 @@ entry:
   %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
   %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
@@ -7966,15 +9483,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7992,7 +9509,79 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
-Failed to read Dictionary`2.TryGetValue[loadElemA]
+Successfully read Dictionary`2.TryGetValue
+
+define i8 @"Dictionary`2.TryGetValue"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)* addrspace(1)* %param2) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  %arg2 = alloca %System.__Canon addrspace(1)* addrspace(1)*
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  store %System.__Canon addrspace(1)* addrspace(1)* %param2, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  store i32 %2, i32* %loc0
+  %3 = load i32, i32* %loc0
+  %4 = icmp slt i32 %3, 0
+  br i1 %4, label %22, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 2
+  %10 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %9, align 8
+  %11 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = zext i32 %11 to i64
+  %BoundsCheck = icmp uge i64 %16, %15
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 3, i32 %11
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %20, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %6, %System.__Canon addrspace(1)* %21)
+  ret i8 1
+
+; <label>:22                                      ; preds = %entry
+  %23 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %23, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -8058,8 +9647,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
@@ -8091,8 +9680,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
@@ -8171,15 +9760,15 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck, label %19, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %ThrowNullRef, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
   %21 = load i32, i32 addrspace(1)* %20
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
@@ -8202,7 +9791,7 @@ ThrowNullRef:                                     ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %19
+ThrowNullRef2:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8248,8 +9837,8 @@ entry:
   %0 = alloca %System.AppDomainHandle
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %1 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %1, i32 0, i32 15
@@ -8269,8 +9858,8 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
@@ -8286,7 +9875,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -8299,8 +9888,8 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -8327,8 +9916,8 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
@@ -8352,8 +9941,8 @@ entry:
   %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
   store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
@@ -8363,8 +9952,8 @@ entry:
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
@@ -8374,8 +9963,8 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %9
   %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
@@ -8384,8 +9973,8 @@ entry:
 
 ; <label>:18                                      ; preds = %3, %16
   %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
@@ -8397,15 +9986,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %18
+ThrowNullRef6:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8418,8 +10007,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
@@ -8453,15 +10042,15 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
@@ -8473,7 +10062,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8481,7 +10070,7 @@ ThrowNullRef1:                                    ; preds = %1
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
 Failed to read Dictionary`2.System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
@@ -8506,8 +10095,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
@@ -8524,8 +10113,8 @@ entry:
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -8544,7 +10133,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8577,8 +10166,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = load i64, i64* %arg2
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = trunc i32 %3 to i8
@@ -8634,46 +10223,46 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
   %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
-  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
-  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
-  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
@@ -8684,27 +10273,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %20
+ThrowNullRef12:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8717,8 +10306,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -8756,22 +10345,22 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
   %9 = load i64, i64 addrspace(1)* %8, align 8
   %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
   %13 = load i64, i64 addrspace(1)* %12, align 8
   %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %11
   %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
@@ -8788,11 +10377,11 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8882,8 +10471,8 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
@@ -8900,8 +10489,8 @@ entry:
 ; <label>:8                                       ; preds = %1
   %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
   %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
@@ -8911,15 +10500,15 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
   %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
   %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
-  br i1 %NullCheck6, label %21, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
@@ -8946,15 +10535,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8992,15 +10581,15 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
   store i8 %3, i8 addrspace(1)* %5
   %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
@@ -9011,7 +10600,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9027,8 +10616,8 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -9041,8 +10630,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
@@ -9058,7 +10647,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9080,8 +10669,8 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
@@ -9096,8 +10685,8 @@ entry:
 ; <label>:12                                      ; preds = %6
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
@@ -9112,8 +10701,8 @@ entry:
 ; <label>:21                                      ; preds = %15
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
@@ -9128,8 +10717,8 @@ entry:
 ; <label>:30                                      ; preds = %24
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %31, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
@@ -9144,8 +10733,8 @@ entry:
 ; <label>:39                                      ; preds = %33
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
-  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %40, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %42
 
 ; <label>:42                                      ; preds = %39
   %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
@@ -9164,19 +10753,19 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %21
+ThrowNullRef4:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %30
+ThrowNullRef6:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %39
+ThrowNullRef8:                                    ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9243,8 +10832,8 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
@@ -9264,57 +10853,57 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
   store i8 0, i8 addrspace(1)* %2
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
   store i8 0, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
   store i8 0, i8 addrspace(1)* %17
   %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
   store i8 0, i8 addrspace(1)* %20
   %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
-  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
@@ -9325,31 +10914,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %19
+ThrowNullRef14:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9367,8 +10956,8 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
@@ -9380,8 +10969,8 @@ entry:
 
 ; <label>:9                                       ; preds = %4
   %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %9
   %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
@@ -9395,7 +10984,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef2:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9420,8 +11009,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
@@ -9512,8 +11101,8 @@ entry:
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
@@ -9524,8 +11113,8 @@ entry:
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = load i64, i64 addrspace(1)* %12
@@ -9537,8 +11126,8 @@ entry:
   %20 = load i64, i64* %19
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
-  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %13
   %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
@@ -9555,8 +11144,8 @@ entry:
 ; <label>:30                                      ; preds = %25
   %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %32 = load i32, i32* %arg2
-  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
-  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
@@ -9570,15 +11159,15 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %30
+ThrowNullRef2:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9622,87 +11211,87 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
   %10 = load i8, i8 addrspace(1)* %9, align 8
   %11 = zext i8 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %8
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
   store i8 %12, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
   %19 = load i8, i8 addrspace(1)* %18, align 8
   %20 = zext i8 %19 to i32
   %21 = trunc i32 %20 to i8
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
   store i8 %21, i8 addrspace(1)* %23
   %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
   %28 = load i8, i8 addrspace(1)* %27, align 8
   %29 = zext i8 %28 to i32
   %30 = trunc i32 %29 to i8
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
-  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %31
 
 ; <label>:31                                      ; preds = %26
   %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
   store i8 %30, i8 addrspace(1)* %32
   %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
-  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
-  br i1 %NullCheck14, label %40, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %40
 
 ; <label>:40                                      ; preds = %35
   %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
   store i8 %39, i8 addrspace(1)* %41
   %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
-  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %44
 
 ; <label>:44                                      ; preds = %40
   %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
   %46 = load i8, i8 addrspace(1)* %45, align 8
   %47 = zext i8 %46 to i32
   %48 = trunc i32 %47 to i8
-  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
   store i8 %48, i8 addrspace(1)* %50
   %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
-  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
@@ -9713,29 +11302,29 @@ entry:
 ; <label>:56                                      ; preds = %52
   %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
-  br i1 %NullCheck22, label %59, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
   %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
   %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
-  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
-  br i1 %NullCheck24, label %63, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
   %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
-  br i1 %NullCheck26, label %66, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
   %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
-  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
-  br i1 %NullCheck28, label %69, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %69
 
 ; <label>:69                                      ; preds = %66
   %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
@@ -9744,15 +11333,15 @@ entry:
 
 ; <label>:71                                      ; preds = %105
   %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
-  br i1 %NullCheck34, label %73, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %73
 
 ; <label>:73                                      ; preds = %71
   %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
   %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
   %76 = load i32, i32* %loc0
-  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
-  br i1 %NullCheck36, label %77, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
@@ -9766,8 +11355,8 @@ entry:
 
 ; <label>:83                                      ; preds = %77
   %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
-  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
@@ -9775,14 +11364,14 @@ entry:
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
   %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
-  br i1 %NullCheck40, label %91, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
 ; <label>:91                                      ; preds = %85
   %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
   %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
-  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck42, label %94, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %94
 
 ; <label>:94                                      ; preds = %91
   %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
@@ -9798,14 +11387,14 @@ entry:
 ; <label>:99                                      ; preds = %69, %96
   %100 = load i32, i32* %loc0
   %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
-  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %102
 
 ; <label>:102                                     ; preds = %99
   %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
   %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
-  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
-  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
@@ -9819,87 +11408,87 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %26
+ThrowNullRef10:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %31
+ThrowNullRef12:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %35
+ThrowNullRef14:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %40
+ThrowNullRef16:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %56
+ThrowNullRef22:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %59
+ThrowNullRef24:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %63
+ThrowNullRef26:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %66
+ThrowNullRef28:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %102
+ThrowNullRef32:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %71
+ThrowNullRef34:                                   ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %73
+ThrowNullRef36:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %83
+ThrowNullRef38:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %85
+ThrowNullRef40:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %91
+ThrowNullRef42:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9943,15 +11532,15 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
   %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
@@ -9961,28 +11550,28 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
   %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %12
   %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
   %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
   %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
-  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
@@ -9993,23 +11582,23 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %12
+ThrowNullRef6:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10031,15 +11620,15 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
   %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = load i64, i64 addrspace(1)* %7
@@ -10077,13 +11666,13 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[loadElem]
+Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -10111,8 +11700,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -10181,8 +11770,8 @@ entry:
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load float, float* %arg0
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -10316,8 +11905,8 @@ entry:
   store i64 %param0, i64* %arg0
   store i64 %param1, i64* %arg1
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
@@ -10325,8 +11914,8 @@ entry:
   %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
   %5 = load i16*, i16* addrspace(1)* %4, align 8
   %6 = addrspacecast i64* %arg1 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = bitcast i64 addrspace(1)* %6 to i8 addrspace(1)*
@@ -10342,7 +11931,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10376,8 +11965,8 @@ entry:
   %1 = load i32, i32* %arg1
   %2 = sext i32 %1 to i64
   %3 = inttoptr i64 %2 to i16*
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -10430,8 +12019,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, i32)*)(%System.IO.ConsoleStream addrspace(1)* %2, i32 %1)
   %3 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %4 = load i64, i64* %arg1
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
@@ -10442,8 +12031,8 @@ entry:
   %10 = icmp eq i32 %9, 3
   %11 = sext i1 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %5
   %14 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, i32 0, i32 5
@@ -10454,7 +12043,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10477,8 +12066,8 @@ entry:
   %5 = icmp eq i32 %4, 1
   %6 = sext i1 %5 to i32
   %7 = trunc i32 %6 to i8
-  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %2, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.ConsoleStream addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
@@ -10489,8 +12078,8 @@ entry:
   %13 = icmp eq i32 %12, 2
   %14 = sext i1 %13 to i32
   %15 = trunc i32 %14 to i8
-  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %10, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.ConsoleStream addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %8
   %17 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %10, i32 0, i32 4
@@ -10501,7 +12090,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10540,8 +12129,8 @@ entry:
   %arg0 = alloca i64
   store i64 %param0, i64* %arg0
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
@@ -10576,8 +12165,8 @@ entry:
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
   %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = load i64, i64 addrspace(1)* %7
@@ -10681,7 +12270,127 @@ entry:
 INFO:  jitting method Encoding::GetEncoding using LLILCJit
 Failed to read Encoding.GetEncoding[convertToHelperArgumentType]
 INFO:  jitting method EncodingProvider::GetEncodingFromProvider using LLILCJit
-Failed to read EncodingProvider.GetEncodingFromProvider[loadElem]
+Successfully read EncodingProvider.GetEncodingFromProvider
+
+define %System.Text.Encoding addrspace(1)* @EncodingProvider.GetEncodingFromProvider(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca %"System.Text.EncodingProvider[]" addrspace(1)*
+  %loc1 = alloca %System.Text.EncodingProvider addrspace(1)*
+  %loc2 = alloca %System.Text.Encoding addrspace(1)*
+  %loc3 = alloca %System.Text.Encoding addrspace(1)*
+  %loc4 = alloca %"System.Text.EncodingProvider[]" addrspace(1)*
+  %loc5 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1059)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2392
+  %2 = addrspacecast i8 addrspace(1)* %1 to %"System.Text.EncodingProvider[]" addrspace(1)**
+  %3 = load volatile %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %2
+  %4 = icmp ne %"System.Text.EncodingProvider[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %entry
+  ret %System.Text.Encoding addrspace(1)* null
+
+; <label>:6                                       ; preds = %entry
+  %7 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1059)
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i64 2392
+  %9 = addrspacecast i8 addrspace(1)* %8 to %"System.Text.EncodingProvider[]" addrspace(1)**
+  %10 = load volatile %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %9
+  store %"System.Text.EncodingProvider[]" addrspace(1)* %10, %"System.Text.EncodingProvider[]" addrspace(1)** %loc0
+  %11 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc0
+  store %"System.Text.EncodingProvider[]" addrspace(1)* %11, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  store i32 0, i32* %loc5
+  br label %43
+
+; <label>:12                                      ; preds = %46
+  %13 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  %14 = load i32, i32* %loc5
+  %NullCheck1 = icmp eq %"System.Text.EncodingProvider[]" addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %13, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = zext i32 %17 to i64
+  %19 = zext i32 %14 to i64
+  %BoundsCheck = icmp uge i64 %19, %18
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %20
+
+; <label>:20                                      ; preds = %15
+  %21 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %13, i32 0, i32 3, i32 %14
+  %22 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)* addrspace(1)* %21, align 8
+  store %System.Text.EncodingProvider addrspace(1)* %22, %System.Text.EncodingProvider addrspace(1)** %loc1
+  %23 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)** %loc1
+  %24 = load i32, i32* %arg0
+  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i64 addrspace(1)*
+  %NullCheck3 = icmp eq i64 addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
+
+; <label>:26                                      ; preds = %20
+  %27 = load i64, i64 addrspace(1)* %25
+  %28 = add i64 %27, 64
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 40
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Text.Encoding addrspace(1)* (%System.Text.EncodingProvider addrspace(1)*, i32)*
+  %35 = call %System.Text.Encoding addrspace(1)* %34(%System.Text.EncodingProvider addrspace(1)* %23, i32 %24)
+  store %System.Text.Encoding addrspace(1)* %35, %System.Text.Encoding addrspace(1)** %loc2
+  %36 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc2
+  %37 = icmp eq %System.Text.Encoding addrspace(1)* %36, null
+  br i1 %37, label %40, label %38
+
+; <label>:38                                      ; preds = %26
+  %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc2
+  store %System.Text.Encoding addrspace(1)* %39, %System.Text.Encoding addrspace(1)** %loc3
+  br label %53
+
+; <label>:40                                      ; preds = %26
+  %41 = load i32, i32* %loc5
+  %42 = add i32 %41, 1
+  store i32 %42, i32* %loc5
+  br label %43
+
+; <label>:43                                      ; preds = %6, %40
+  %44 = load i32, i32* %loc5
+  %45 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  %NullCheck = icmp eq %"System.Text.EncodingProvider[]" addrspace(1)* %45, null
+  br i1 %NullCheck, label %ThrowNullRef, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp slt i32 %44, %50
+  br i1 %51, label %12, label %52
+
+; <label>:52                                      ; preds = %46
+  ret %System.Text.Encoding addrspace(1)* null
+
+; <label>:53                                      ; preds = %38
+  %54 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc3
+  ret %System.Text.Encoding addrspace(1)* %54
+
+ThrowNullRef:                                     ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method EncodingProvider::.cctor using LLILCJit
 Successfully read EncodingProvider..cctor
 
@@ -10700,7 +12409,7 @@ Failed to read Encoding.get_InternalSyncObject[Call HasTypeArg]
 INFO:  jitting method Hashtable::.ctor using LLILCJit
 Failed to read Hashtable..ctor[Volatile store]
 INFO:  jitting method Hashtable::get_Item using LLILCJit
-Failed to read Hashtable.get_Item[loadElemA]
+Failed to read Hashtable.get_Item[loadNonPrimitiveObj]
 INFO:  jitting method Hashtable::InitHash using LLILCJit
 Successfully read Hashtable.InitHash
 
@@ -10720,8 +12429,8 @@ entry:
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -10737,15 +12446,15 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
   %15 = load i32, i32* %loc0
-  %NullCheck2 = icmp ne i32 addrspace(1)* %14, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i32 addrspace(1)* %14, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %3
   store i32 %15, i32 addrspace(1)* %14, align 8
   %17 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %18 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %NullCheck4 = icmp ne i32 addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i32 addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = load i32, i32 addrspace(1)* %18, align 8
@@ -10754,8 +12463,8 @@ entry:
   %23 = sub i32 %22, 1
   %24 = urem i32 %21, %23
   %25 = add i32 1, %24
-  %NullCheck6 = icmp ne i32 addrspace(1)* %17, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32 addrspace(1)* %17, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %19
   store i32 %25, i32 addrspace(1)* %17, align 8
@@ -10766,15 +12475,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %19
+ThrowNullRef6:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10789,8 +12498,8 @@ entry:
   store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
   store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %NullCheck = icmp ne %System.Collections.Hashtable addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Collections.Hashtable addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
@@ -10800,16 +12509,16 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Collections.Hashtable addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Collections.Hashtable addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
   %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck4 = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %9, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
   %13 = inttoptr i64 %11 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
@@ -10819,8 +12528,8 @@ entry:
 ; <label>:15                                      ; preds = %1
   %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -10838,15 +12547,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10860,8 +12569,8 @@ entry:
   store %System.Int32 addrspace(1)* %param0, %System.Int32 addrspace(1)** %this
   %0 = load %System.Int32 addrspace(1)*, %System.Int32 addrspace(1)** %this
   %1 = bitcast %System.Int32 addrspace(1)* %0 to i32 addrspace(1)*
-  %NullCheck = icmp ne i32 addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq i32 addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load i32, i32 addrspace(1)* %1, align 8
@@ -10937,8 +12646,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.UTF8Encoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
@@ -10947,15 +12656,15 @@ entry:
   %9 = load i8, i8* %arg2
   %10 = zext i8 %9 to i32
   %11 = trunc i32 %10 to i8
-  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %8, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %6
   %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %8, i32 0, i32 8
   store i8 %11, i8 addrspace(1)* %13
   %14 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %14, i32 0, i32 8
@@ -10967,8 +12676,8 @@ entry:
 ; <label>:20                                      ; preds = %15
   %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %22, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %22, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = load i64, i64 addrspace(1)* %22
@@ -10990,15 +12699,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %12
+ThrowNullRef4:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11013,8 +12722,8 @@ entry:
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
@@ -11036,16 +12745,16 @@ entry:
 ; <label>:10                                      ; preds = %1
   %11 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
   %12 = load i32, i32* %arg1
-  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %11, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.Encoding addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
   store i32 %12, i32 addrspace(1)* %14
   %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
   %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = load i64, i64 addrspace(1)* %16
@@ -11063,11 +12772,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11080,8 +12789,8 @@ entry:
   %this = alloca %System.Text.UTF8Encoding addrspace(1)*
   store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
   %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.UTF8Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
@@ -11093,16 +12802,16 @@ entry:
 ; <label>:6                                       ; preds = %1
   %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %8 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %10, %System.Text.EncoderFallback addrspace(1)* %8)
   %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %12 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
-  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %11, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %11, i32 0, i32 3
@@ -11115,8 +12824,8 @@ entry:
   %18 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %18, %System.String addrspace(1)* %17)
   %19 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %18 to %System.Text.EncoderFallback addrspace(1)*
-  %NullCheck6 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %16, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %16, i32 0, i32 2
@@ -11126,8 +12835,8 @@ entry:
   %24 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %24, %System.String addrspace(1)* %23)
   %25 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %24 to %System.Text.DecoderFallback addrspace(1)*
-  %NullCheck8 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %22, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %22, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %20
   %27 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %22, i32 0, i32 3
@@ -11138,19 +12847,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %20
+ThrowNullRef8:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11180,8 +12889,8 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load i32, i32* %arg1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -11199,8 +12908,8 @@ entry:
 ; <label>:15                                      ; preds = %8
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %17 = load i32, i32* %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 %17
@@ -11216,7 +12925,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11268,7 +12977,7 @@ entry:
 }
 
 INFO:  jitting method Hashtable::Insert using LLILCJit
-Failed to read Hashtable.Insert[loadElemA]
+Failed to read Hashtable.Insert[storeElem]
 INFO:  jitting method ConsoleEncoding::.ctor using LLILCJit
 Successfully read ConsoleEncoding..ctor
 
@@ -11283,8 +12992,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %1)
   %2 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
@@ -11320,8 +13029,8 @@ entry:
   %2 = call %System.Text.InternalEncoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalEncoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %1)
   %3 = bitcast %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2 to %System.Text.EncoderFallback addrspace(1)*
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
@@ -11331,8 +13040,8 @@ entry:
   %8 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %7)
   %9 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %8 to %System.Text.DecoderFallback addrspace(1)*
-  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %6, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.Encoding addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %4
   %11 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %6, i32 0, i32 3
@@ -11343,7 +13052,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11362,15 +13071,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* %1)
   %2 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   %6 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, i32 0, i32 1
@@ -11381,7 +13090,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11409,8 +13118,8 @@ entry:
   store %System.Text.InternalDecoderBestFitFallback addrspace(1)* %param0, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
   %0 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
@@ -11420,15 +13129,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %4)
   %5 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %6)
   %9 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, i32 0, i32 1
@@ -11439,11 +13148,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11511,8 +13220,8 @@ entry:
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
   %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = load i64, i64 addrspace(1)* %19
@@ -11576,8 +13285,8 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.ConsoleStream addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
@@ -11608,31 +13317,31 @@ entry:
   store i8 %param4, i8* %arg4
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %3, %System.IO.Stream addrspace(1)* %1)
   %4 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %4, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
   %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %4, i32 0, i32 4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %5)
   %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %6
   %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
   %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
   %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = load i64, i64 addrspace(1)* %13
@@ -11644,8 +13353,8 @@ entry:
   %21 = load i64, i64* %20
   %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %8, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %8, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %14
   %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 5
@@ -11663,24 +13372,24 @@ entry:
   %31 = load i32, i32* %arg3
   %32 = sext i32 %31 to i64
   %33 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %32)
-  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %30, null
-  br i1 %NullCheck10, label %34, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.StreamWriter addrspace(1)* %30, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %35, %"System.Char[]" addrspace(1)* %33)
   %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %37, null
-  br i1 %NullCheck12, label %38, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.StreamWriter addrspace(1)* %37, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %38
 
 ; <label>:38                                      ; preds = %34
   %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
   %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
   %41 = load i32, i32* %arg3
   %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %42, null
-  br i1 %NullCheck14, label %43, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %42, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
   %44 = load i64, i64 addrspace(1)* %42
@@ -11694,30 +13403,30 @@ entry:
   %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
   %53 = sext i32 %52 to i64
   %54 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %53)
-  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
-  br i1 %NullCheck16, label %55, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %55
 
 ; <label>:55                                      ; preds = %43
   %56 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %56, %"System.Byte[]" addrspace(1)* %54)
   %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %58 = load i32, i32* %arg3
-  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %57, null
-  br i1 %NullCheck18, label %59, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.StreamWriter addrspace(1)* %57, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %59
 
 ; <label>:59                                      ; preds = %55
   %60 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 10
   store i32 %58, i32 addrspace(1)* %60
   %61 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %61, null
-  br i1 %NullCheck20, label %62, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.IO.StreamWriter addrspace(1)* %61, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %62
 
 ; <label>:62                                      ; preds = %59
   %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
   %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
   %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
   %67 = load i64, i64 addrspace(1)* %65
@@ -11735,15 +13444,15 @@ entry:
 
 ; <label>:78                                      ; preds = %66
   %79 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %79, null
-  br i1 %NullCheck24, label %80, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.StreamWriter addrspace(1)* %79, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %80
 
 ; <label>:80                                      ; preds = %78
   %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
   %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
   %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %83, null
-  br i1 %NullCheck26, label %84, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %83, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
   %85 = load i64, i64 addrspace(1)* %83
@@ -11760,8 +13469,8 @@ entry:
 
 ; <label>:95                                      ; preds = %84
   %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.IO.StreamWriter addrspace(1)* %96, null
-  br i1 %NullCheck28, label %97, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.IO.StreamWriter addrspace(1)* %96, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %97
 
 ; <label>:97                                      ; preds = %95
   %98 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 12
@@ -11775,8 +13484,8 @@ entry:
   %103 = icmp eq i32 %102, 0
   %104 = sext i1 %103 to i32
   %105 = trunc i32 %104 to i8
-  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %100, null
-  br i1 %NullCheck30, label %106, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.IO.StreamWriter addrspace(1)* %100, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %106
 
 ; <label>:106                                     ; preds = %99
   %107 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %100, i32 0, i32 13
@@ -11787,63 +13496,63 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %6
+ThrowNullRef4:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %29
+ThrowNullRef10:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %34
+ThrowNullRef12:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %38
+ThrowNullRef14:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %43
+ThrowNullRef16:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %55
+ThrowNullRef18:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %59
+ThrowNullRef20:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %62
+ThrowNullRef22:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %78
+ThrowNullRef24:                                   ; preds = %78
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %80
+ThrowNullRef26:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %95
+ThrowNullRef28:                                   ; preds = %95
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11856,15 +13565,15 @@ entry:
   %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = load i64, i64 addrspace(1)* %4
@@ -11882,7 +13591,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11932,35 +13641,35 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
   %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderNLS addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %7 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.EncoderNLS addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Text.Encoding addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.Encoding addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Text.EncoderNLS addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.EncoderNLS addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
   %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck8 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = load i64, i64 addrspace(1)* %16
@@ -11979,19 +13688,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12017,8 +13726,8 @@ entry:
   %this = alloca %System.Text.Encoding addrspace(1)*
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
@@ -12038,15 +13747,15 @@ entry:
   %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
   store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
   %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
   store i32 0, i32 addrspace(1)* %2
   %3 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, i32 0, i32 2
@@ -12056,15 +13765,15 @@ entry:
 
 ; <label>:8                                       ; preds = %4
   %9 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
   %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
   %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = load i64, i64 addrspace(1)* %13
@@ -12085,15 +13794,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12108,16 +13817,16 @@ entry:
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = load i32, i32* %arg1
   %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
   %7 = load i64, i64 addrspace(1)* %5
@@ -12135,7 +13844,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12172,8 +13881,8 @@ entry:
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
   %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
   %16 = load i64, i64 addrspace(1)* %14
@@ -12194,8 +13903,8 @@ entry:
   %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
   %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
   %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %31, null
-  br i1 %NullCheck2, label %32, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = load i64, i64 addrspace(1)* %31
@@ -12238,7 +13947,7 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12251,14 +13960,14 @@ entry:
   %this = alloca %System.Text.EncoderReplacementFallback addrspace(1)*
   store %System.Text.EncoderReplacementFallback addrspace(1)* %param0, %System.Text.EncoderReplacementFallback addrspace(1)** %this
   %0 = load %System.Text.EncoderReplacementFallback addrspace(1)*, %System.Text.EncoderReplacementFallback addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -12269,7 +13978,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12299,8 +14008,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
@@ -12332,8 +14041,8 @@ entry:
   %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
   store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
@@ -12345,8 +14054,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Threading.Tasks.Task addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %7)
@@ -12369,7 +14078,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12388,8 +14097,8 @@ entry:
   store i8 %param1, i8* %arg1
   store i8 %param2, i8* %arg2
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
@@ -12403,8 +14112,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1, %5
   %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 9
@@ -12435,8 +14144,8 @@ entry:
 
 ; <label>:25                                      ; preds = %8, %20
   %26 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %26, null
-  br i1 %NullCheck4, label %27, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %26, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %26, i32 0, i32 12
@@ -12447,22 +14156,22 @@ entry:
 
 ; <label>:32                                      ; preds = %27
   %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %33, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.IO.StreamWriter addrspace(1)* %33, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %32
   %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 12
   store i8 1, i8 addrspace(1)* %35
   %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
-  br i1 %NullCheck8, label %37, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
   %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
   %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck10 = icmp ne i64 addrspace(1)* %40, null
-  br i1 %NullCheck10, label %41, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64 addrspace(1)* %40, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i64, i64 addrspace(1)* %40
@@ -12476,8 +14185,8 @@ entry:
   %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
   store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
   %51 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %NullCheck12 = icmp ne %"System.Byte[]" addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Byte[]" addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %41
   %53 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %51, i32 0, i32 1
@@ -12489,16 +14198,16 @@ entry:
 
 ; <label>:58                                      ; preds = %52
   %59 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %59, null
-  br i1 %NullCheck14, label %60, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.IO.StreamWriter addrspace(1)* %59, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %60
 
 ; <label>:60                                      ; preds = %58
   %61 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %59, i32 0, i32 3
   %62 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
   %64 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %NullCheck16 = icmp ne %"System.Byte[]" addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %"System.Byte[]" addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %60
   %66 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %64, i32 0, i32 1
@@ -12506,8 +14215,8 @@ entry:
   %68 = zext i32 %67 to i64
   %69 = trunc i64 %68 to i32
   %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck18, label %71, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
   %72 = load i64, i64 addrspace(1)* %70
@@ -12523,29 +14232,29 @@ entry:
 
 ; <label>:80                                      ; preds = %27, %52, %71
   %81 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %81, null
-  br i1 %NullCheck20, label %82, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.IO.StreamWriter addrspace(1)* %81, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
 
 ; <label>:82                                      ; preds = %80
   %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %81, i32 0, i32 5
   %84 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %83, align 8
   %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.IO.StreamWriter addrspace(1)* %85, null
-  br i1 %NullCheck22, label %86, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.IO.StreamWriter addrspace(1)* %85, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %86
 
 ; <label>:86                                      ; preds = %82
   %87 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 7
   %88 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %87, align 8
   %89 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %89, null
-  br i1 %NullCheck24, label %90, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.StreamWriter addrspace(1)* %89, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %90
 
 ; <label>:90                                      ; preds = %86
   %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %89, i32 0, i32 9
   %92 = load i32, i32 addrspace(1)* %91, align 8
   %93 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.IO.StreamWriter addrspace(1)* %93, null
-  br i1 %NullCheck26, label %94, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.IO.StreamWriter addrspace(1)* %93, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %93, i32 0, i32 6
@@ -12553,8 +14262,8 @@ entry:
   %97 = load i8, i8* %arg2
   %98 = zext i8 %97 to i32
   %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
-  %NullCheck28 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck28, label %100, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
   %101 = load i64, i64 addrspace(1)* %99
@@ -12569,8 +14278,8 @@ entry:
   %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
   store i32 %110, i32* %loc1
   %111 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %111, null
-  br i1 %NullCheck30, label %112, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.IO.StreamWriter addrspace(1)* %111, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %112
 
 ; <label>:112                                     ; preds = %100
   %113 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %111, i32 0, i32 9
@@ -12581,23 +14290,23 @@ entry:
 
 ; <label>:116                                     ; preds = %112
   %117 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck32 = icmp ne %System.IO.StreamWriter addrspace(1)* %117, null
-  br i1 %NullCheck32, label %118, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.IO.StreamWriter addrspace(1)* %117, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %118
 
 ; <label>:118                                     ; preds = %116
   %119 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %117, i32 0, i32 3
   %120 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %119, align 8
   %121 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.IO.StreamWriter addrspace(1)* %121, null
-  br i1 %NullCheck34, label %122, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.IO.StreamWriter addrspace(1)* %121, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %122
 
 ; <label>:122                                     ; preds = %118
   %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
   %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
   %125 = load i32, i32* %loc1
   %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
-  %NullCheck36 = icmp ne i64 addrspace(1)* %126, null
-  br i1 %NullCheck36, label %127, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64 addrspace(1)* %126, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
   %128 = load i64, i64 addrspace(1)* %126
@@ -12619,15 +14328,15 @@ entry:
 
 ; <label>:140                                     ; preds = %136
   %141 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.IO.StreamWriter addrspace(1)* %141, null
-  br i1 %NullCheck38, label %142, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.IO.StreamWriter addrspace(1)* %141, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %142
 
 ; <label>:142                                     ; preds = %140
   %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
   %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
   %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
-  %NullCheck40 = icmp ne i64 addrspace(1)* %145, null
-  br i1 %NullCheck40, label %146, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i64 addrspace(1)* %145, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
   %147 = load i64, i64 addrspace(1)* %145
@@ -12648,83 +14357,83 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %25
+ThrowNullRef4:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %32
+ThrowNullRef6:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %37
+ThrowNullRef10:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %41
+ThrowNullRef12:                                   ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %58
+ThrowNullRef14:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %60
+ThrowNullRef16:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %65
+ThrowNullRef18:                                   ; preds = %65
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %80
+ThrowNullRef20:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %82
+ThrowNullRef22:                                   ; preds = %82
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %86
+ThrowNullRef24:                                   ; preds = %86
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %90
+ThrowNullRef26:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %94
+ThrowNullRef28:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %100
+ThrowNullRef30:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %116
+ThrowNullRef32:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %118
+ThrowNullRef34:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %122
+ThrowNullRef36:                                   ; preds = %122
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %140
+ThrowNullRef38:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %142
+ThrowNullRef40:                                   ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12791,8 +14500,8 @@ entry:
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %1 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
-  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
@@ -12800,8 +14509,8 @@ entry:
   %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
   %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
   %8 = load i64, i64 addrspace(1)* %6
@@ -12817,8 +14526,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %17, %System.IFormatProvider addrspace(1)* %16)
   %18 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %19 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %18, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.SyncTextWriter addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %7
   %21 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %18, i32 0, i32 4
@@ -12829,11 +14538,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12846,8 +14555,8 @@ entry:
   %this = alloca %System.IO.TextWriter addrspace(1)*
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.TextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
@@ -12857,8 +14566,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.Threading.Thread addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Threading.Thread addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %6)
@@ -12867,8 +14576,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1
   %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.TextWriter addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.TextWriter addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %11, i32 0, i32 2
@@ -12879,11 +14588,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13080,8 +14789,8 @@ entry:
   store float %param1, float* %arg1
   store i8 0, i8* %loc1
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
@@ -13091,16 +14800,16 @@ entry:
   %5 = addrspacecast i8* %loc1 to i8 addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %4, i8 addrspace(1)* %5)
   %6 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.SyncTextWriter addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
   %10 = load float, float* %arg1
   %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
   %13 = load i64, i64 addrspace(1)* %11
@@ -13135,11 +14844,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13156,8 +14865,8 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load float, float* %arg1
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -13171,8 +14880,8 @@ entry:
   call void %11(%System.IO.TextWriter addrspace(1)* %0, float %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
   %15 = load i64, i64 addrspace(1)* %13
@@ -13190,7 +14899,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13208,8 +14917,8 @@ entry:
   %1 = addrspacecast float* %arg1 to float addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -13224,8 +14933,8 @@ entry:
   %14 = bitcast float addrspace(1)* %1 to %System.Single addrspace(1)*
   %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Single addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Single addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
   %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
   %18 = load i64, i64 addrspace(1)* %16
@@ -13243,7 +14952,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13259,8 +14968,8 @@ entry:
   store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
   %0 = load %System.Single addrspace(1)*, %System.Single addrspace(1)** %this
   %1 = bitcast %System.Single addrspace(1)* %0 to float addrspace(1)*
-  %NullCheck = icmp ne float addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq float addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load float, float addrspace(1)* %1, align 8
@@ -13285,8 +14994,8 @@ entry:
   %loc0 = alloca %System.Globalization.NumberFormatInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 3
@@ -13296,8 +15005,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
@@ -13307,24 +15016,24 @@ entry:
   store %System.Globalization.NumberFormatInfo addrspace(1)* %10, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
   %11 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %7
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
   %15 = load i8, i8 addrspace(1)* %14, align 8
   %16 = zext i8 %15 to i32
   %17 = trunc i32 %16 to i8
-  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %11, null
-  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %11, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %13
   %19 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %11, i32 0, i32 29
   store i8 %17, i8 addrspace(1)* %19
   %20 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %21 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %20, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %20, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %18
   %23 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %20, i32 0, i32 3
@@ -13333,8 +15042,8 @@ entry:
 
 ; <label>:24                                      ; preds = %1, %22
   %25 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %25, null
-  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %25, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %26
 
 ; <label>:26                                      ; preds = %24
   %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %25, i32 0, i32 3
@@ -13345,23 +15054,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %18
+ThrowNullRef8:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13386,168 +15095,168 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 18
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %8, align 8
-  %NullCheck2 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %5, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %5, i32 0, i32 4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %9)
   %12 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 19
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %15, align 8
-  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %12, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %12, i32 0, i32 5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %16)
   %19 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %20 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %20, null
-  br i1 %NullCheck8, label %21, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %20, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %20, i32 0, i32 23
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  %NullCheck10 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %19, null
-  br i1 %NullCheck10, label %24, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %19, i32 0, i32 7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %25, %System.String addrspace(1)* %23)
   %26 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %27 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %27, i32 0, i32 22
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %29, align 8
-  %NullCheck14 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %26, null
-  br i1 %NullCheck14, label %31, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %26, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %26, i32 0, i32 6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %32, %System.String addrspace(1)* %30)
   %33 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %34 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Globalization.CultureData addrspace(1)* %34, null
-  br i1 %NullCheck16, label %35, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Globalization.CultureData addrspace(1)* %34, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %34, i32 0, i32 51
   %37 = load i32, i32 addrspace(1)* %36, align 8
-  %NullCheck18 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %33, null
-  br i1 %NullCheck18, label %38, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %33, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %33, i32 0, i32 21
   store i32 %37, i32 addrspace(1)* %39
   %40 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %41 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Globalization.CultureData addrspace(1)* %41, null
-  br i1 %NullCheck20, label %42, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Globalization.CultureData addrspace(1)* %41, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %41, i32 0, i32 52
   %44 = load i32, i32 addrspace(1)* %43, align 8
-  %NullCheck22 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %40, null
-  br i1 %NullCheck22, label %45, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %40, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %40, i32 0, i32 25
   store i32 %44, i32 addrspace(1)* %46
   %47 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %48 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.Globalization.CultureData addrspace(1)* %48, null
-  br i1 %NullCheck24, label %49, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Globalization.CultureData addrspace(1)* %48, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %49
 
 ; <label>:49                                      ; preds = %45
   %50 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %48, i32 0, i32 29
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck26 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %47, null
-  br i1 %NullCheck26, label %52, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %47, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %47, i32 0, i32 10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %53, %System.String addrspace(1)* %51)
   %54 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %55 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Globalization.CultureData addrspace(1)* %55, null
-  br i1 %NullCheck28, label %56, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Globalization.CultureData addrspace(1)* %55, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %56
 
 ; <label>:56                                      ; preds = %52
   %57 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %55, i32 0, i32 35
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %57, align 8
-  %NullCheck30 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %54, null
-  br i1 %NullCheck30, label %59, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %54, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %54, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %60, %System.String addrspace(1)* %58)
   %61 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %62 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck32 = icmp ne %System.Globalization.CultureData addrspace(1)* %62, null
-  br i1 %NullCheck32, label %63, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Globalization.CultureData addrspace(1)* %62, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %62, i32 0, i32 34
   %65 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %64, align 8
-  %NullCheck34 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %61, null
-  br i1 %NullCheck34, label %66, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %61, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %61, i32 0, i32 9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %67, %System.String addrspace(1)* %65)
   %68 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %69 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck36 = icmp ne %System.Globalization.CultureData addrspace(1)* %69, null
-  br i1 %NullCheck36, label %70, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Globalization.CultureData addrspace(1)* %69, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %70
 
 ; <label>:70                                      ; preds = %66
   %71 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %69, i32 0, i32 55
   %72 = load i32, i32 addrspace(1)* %71, align 8
-  %NullCheck38 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %68, null
-  br i1 %NullCheck38, label %73, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %68, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %68, i32 0, i32 22
   store i32 %72, i32 addrspace(1)* %74
   %75 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %76 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck40 = icmp ne %System.Globalization.CultureData addrspace(1)* %76, null
-  br i1 %NullCheck40, label %77, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Globalization.CultureData addrspace(1)* %76, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %76, i32 0, i32 57
   %79 = load i32, i32 addrspace(1)* %78, align 8
-  %NullCheck42 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %75, null
-  br i1 %NullCheck42, label %80, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %75, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %80
 
 ; <label>:80                                      ; preds = %77
   %81 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %75, i32 0, i32 24
   store i32 %79, i32 addrspace(1)* %81
   %82 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %83 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck44 = icmp ne %System.Globalization.CultureData addrspace(1)* %83, null
-  br i1 %NullCheck44, label %84, label %ThrowNullRef43
+  %NullCheck43 = icmp eq %System.Globalization.CultureData addrspace(1)* %83, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %84
 
 ; <label>:84                                      ; preds = %80
   %85 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %83, i32 0, i32 56
   %86 = load i32, i32 addrspace(1)* %85, align 8
-  %NullCheck46 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %82, null
-  br i1 %NullCheck46, label %87, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %82, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %82, i32 0, i32 23
@@ -13556,8 +15265,8 @@ entry:
 
 ; <label>:89                                      ; preds = %entry
   %90 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck100 = icmp ne %System.Globalization.CultureData addrspace(1)* %90, null
-  br i1 %NullCheck100, label %91, label %ThrowNullRef99
+  %NullCheck99 = icmp eq %System.Globalization.CultureData addrspace(1)* %90, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %91
 
 ; <label>:91                                      ; preds = %89
   %92 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %90, i32 0, i32 2
@@ -13575,8 +15284,8 @@ entry:
   %102 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %103 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %104 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %103)
-  %NullCheck48 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %102, null
-  br i1 %NullCheck48, label %105, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %102, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %105
 
 ; <label>:105                                     ; preds = %101
   %106 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %102, i32 0, i32 1
@@ -13584,8 +15293,8 @@ entry:
   %107 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %108 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %109 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %108)
-  %NullCheck50 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %107, null
-  br i1 %NullCheck50, label %110, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %107, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %110
 
 ; <label>:110                                     ; preds = %105
   %111 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %107, i32 0, i32 2
@@ -13593,8 +15302,8 @@ entry:
   %112 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %113 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %114 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %113)
-  %NullCheck52 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %112, null
-  br i1 %NullCheck52, label %115, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %112, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %115
 
 ; <label>:115                                     ; preds = %110
   %116 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %112, i32 0, i32 27
@@ -13602,8 +15311,8 @@ entry:
   %117 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %118 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %119 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %118)
-  %NullCheck54 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %117, null
-  br i1 %NullCheck54, label %120, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %117, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %120
 
 ; <label>:120                                     ; preds = %115
   %121 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %117, i32 0, i32 26
@@ -13611,8 +15320,8 @@ entry:
   %122 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %123 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %124 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %123)
-  %NullCheck56 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %122, null
-  br i1 %NullCheck56, label %125, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %122, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %125
 
 ; <label>:125                                     ; preds = %120
   %126 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %122, i32 0, i32 17
@@ -13620,8 +15329,8 @@ entry:
   %127 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %128 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %129 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %128)
-  %NullCheck58 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %127, null
-  br i1 %NullCheck58, label %130, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %127, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %130
 
 ; <label>:130                                     ; preds = %125
   %131 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %127, i32 0, i32 18
@@ -13629,8 +15338,8 @@ entry:
   %132 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %133 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %134 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %133)
-  %NullCheck60 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %132, null
-  br i1 %NullCheck60, label %135, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %132, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %135
 
 ; <label>:135                                     ; preds = %130
   %136 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %132, i32 0, i32 14
@@ -13638,8 +15347,8 @@ entry:
   %137 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %138 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %139 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %138)
-  %NullCheck62 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %137, null
-  br i1 %NullCheck62, label %140, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %137, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %140
 
 ; <label>:140                                     ; preds = %135
   %141 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %137, i32 0, i32 13
@@ -13647,71 +15356,71 @@ entry:
   %142 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %143 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %144 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %143)
-  %NullCheck64 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %142, null
-  br i1 %NullCheck64, label %145, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %142, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %145
 
 ; <label>:145                                     ; preds = %140
   %146 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %142, i32 0, i32 12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %146, %System.String addrspace(1)* %144)
   %147 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %148 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck66 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %148, null
-  br i1 %NullCheck66, label %149, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %148, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %149
 
 ; <label>:149                                     ; preds = %145
   %150 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %148, i32 0, i32 21
   %151 = load i32, i32 addrspace(1)* %150, align 8
-  %NullCheck68 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %147, null
-  br i1 %NullCheck68, label %152, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %147, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %152
 
 ; <label>:152                                     ; preds = %149
   %153 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %147, i32 0, i32 28
   store i32 %151, i32 addrspace(1)* %153
   %154 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %155 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck70 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %155, null
-  br i1 %NullCheck70, label %156, label %ThrowNullRef69
+  %NullCheck69 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %155, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %156
 
 ; <label>:156                                     ; preds = %152
   %157 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %155, i32 0, i32 6
   %158 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %157, align 8
-  %NullCheck72 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %154, null
-  br i1 %NullCheck72, label %159, label %ThrowNullRef71
+  %NullCheck71 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %154, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %159
 
 ; <label>:159                                     ; preds = %156
   %160 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %154, i32 0, i32 15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %160, %System.String addrspace(1)* %158)
   %161 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %162 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck74 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %162, null
-  br i1 %NullCheck74, label %163, label %ThrowNullRef73
+  %NullCheck73 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %162, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %163
 
 ; <label>:163                                     ; preds = %159
   %164 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %162, i32 0, i32 1
   %165 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %164, align 8
-  %NullCheck76 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %161, null
-  br i1 %NullCheck76, label %166, label %ThrowNullRef75
+  %NullCheck75 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %161, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %166
 
 ; <label>:166                                     ; preds = %163
   %167 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %161, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %167, %"System.Int32[]" addrspace(1)* %165)
   %168 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %169 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck78 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %169, null
-  br i1 %NullCheck78, label %170, label %ThrowNullRef77
+  %NullCheck77 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %169, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %170
 
 ; <label>:170                                     ; preds = %166
   %171 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %169, i32 0, i32 7
   %172 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %171, align 8
-  %NullCheck80 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %168, null
-  br i1 %NullCheck80, label %173, label %ThrowNullRef79
+  %NullCheck79 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %168, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %173
 
 ; <label>:173                                     ; preds = %170
   %174 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %168, i32 0, i32 16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %174, %System.String addrspace(1)* %172)
   %175 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck82 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %175, null
-  br i1 %NullCheck82, label %176, label %ThrowNullRef81
+  %NullCheck81 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %175, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %176
 
 ; <label>:176                                     ; preds = %173
   %177 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %175, i32 0, i32 4
@@ -13721,14 +15430,14 @@ entry:
 
 ; <label>:180                                     ; preds = %176
   %181 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck84 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %181, null
-  br i1 %NullCheck84, label %182, label %ThrowNullRef83
+  %NullCheck83 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %181, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %182
 
 ; <label>:182                                     ; preds = %180
   %183 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %181, i32 0, i32 4
   %184 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %183, align 8
-  %NullCheck86 = icmp ne %System.String addrspace(1)* %184, null
-  br i1 %NullCheck86, label %185, label %ThrowNullRef85
+  %NullCheck85 = icmp eq %System.String addrspace(1)* %184, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %185
 
 ; <label>:185                                     ; preds = %182
   %186 = getelementptr inbounds %System.String, %System.String addrspace(1)* %184, i32 0, i32 1
@@ -13739,8 +15448,8 @@ entry:
 ; <label>:189                                     ; preds = %176, %185
   %190 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck98 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %190, null
-  br i1 %NullCheck98, label %192, label %ThrowNullRef97
+  %NullCheck97 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %190, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %192
 
 ; <label>:192                                     ; preds = %189
   %193 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %190, i32 0, i32 4
@@ -13749,8 +15458,8 @@ entry:
 
 ; <label>:194                                     ; preds = %185, %192
   %195 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck88 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %195, null
-  br i1 %NullCheck88, label %196, label %ThrowNullRef87
+  %NullCheck87 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %195, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %196
 
 ; <label>:196                                     ; preds = %194
   %197 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %195, i32 0, i32 9
@@ -13760,14 +15469,14 @@ entry:
 
 ; <label>:200                                     ; preds = %196
   %201 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck90 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %201, null
-  br i1 %NullCheck90, label %202, label %ThrowNullRef89
+  %NullCheck89 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %201, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %202
 
 ; <label>:202                                     ; preds = %200
   %203 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %201, i32 0, i32 9
   %204 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %203, align 8
-  %NullCheck92 = icmp ne %System.String addrspace(1)* %204, null
-  br i1 %NullCheck92, label %205, label %ThrowNullRef91
+  %NullCheck91 = icmp eq %System.String addrspace(1)* %204, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %205
 
 ; <label>:205                                     ; preds = %202
   %206 = getelementptr inbounds %System.String, %System.String addrspace(1)* %204, i32 0, i32 1
@@ -13778,14 +15487,14 @@ entry:
 ; <label>:209                                     ; preds = %196, %205
   %210 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %211 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck94 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %211, null
-  br i1 %NullCheck94, label %212, label %ThrowNullRef93
+  %NullCheck93 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %211, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %212
 
 ; <label>:212                                     ; preds = %209
   %213 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %211, i32 0, i32 6
   %214 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %213, align 8
-  %NullCheck96 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %210, null
-  br i1 %NullCheck96, label %215, label %ThrowNullRef95
+  %NullCheck95 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %210, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %215
 
 ; <label>:215                                     ; preds = %212
   %216 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %210, i32 0, i32 9
@@ -13799,203 +15508,203 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %17
+ThrowNullRef8:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %21
+ThrowNullRef10:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %24
+ThrowNullRef12:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %28
+ThrowNullRef14:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %31
+ThrowNullRef16:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %35
+ThrowNullRef18:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %38
+ThrowNullRef20:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %42
+ThrowNullRef22:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %45
+ThrowNullRef24:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %49
+ThrowNullRef26:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %52
+ThrowNullRef28:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %56
+ThrowNullRef30:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %59
+ThrowNullRef32:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %63
+ThrowNullRef34:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %66
+ThrowNullRef36:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %70
+ThrowNullRef38:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %73
+ThrowNullRef40:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %77
+ThrowNullRef42:                                   ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %80
+ThrowNullRef44:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %84
+ThrowNullRef46:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %101
+ThrowNullRef48:                                   ; preds = %101
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %105
+ThrowNullRef50:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %110
+ThrowNullRef52:                                   ; preds = %110
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %115
+ThrowNullRef54:                                   ; preds = %115
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %120
+ThrowNullRef56:                                   ; preds = %120
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %125
+ThrowNullRef58:                                   ; preds = %125
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %130
+ThrowNullRef60:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %135
+ThrowNullRef62:                                   ; preds = %135
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %140
+ThrowNullRef64:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %145
+ThrowNullRef66:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %149
+ThrowNullRef68:                                   ; preds = %149
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %152
+ThrowNullRef70:                                   ; preds = %152
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %156
+ThrowNullRef72:                                   ; preds = %156
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %159
+ThrowNullRef74:                                   ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %163
+ThrowNullRef76:                                   ; preds = %163
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %166
+ThrowNullRef78:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %170
+ThrowNullRef80:                                   ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %173
+ThrowNullRef82:                                   ; preds = %173
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %180
+ThrowNullRef84:                                   ; preds = %180
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %182
+ThrowNullRef86:                                   ; preds = %182
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %194
+ThrowNullRef88:                                   ; preds = %194
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %200
+ThrowNullRef90:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %202
+ThrowNullRef92:                                   ; preds = %202
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %209
+ThrowNullRef94:                                   ; preds = %209
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %212
+ThrowNullRef96:                                   ; preds = %212
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %189
+ThrowNullRef98:                                   ; preds = %189
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %89
+ThrowNullRef100:                                  ; preds = %89
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14023,8 +15732,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 21
@@ -14037,8 +15746,8 @@ entry:
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 16)
   %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 21
@@ -14047,8 +15756,8 @@ entry:
 
 ; <label>:12                                      ; preds = %1, %10
   %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 21
@@ -14059,11 +15768,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %12
+ThrowNullRef4:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14079,8 +15788,8 @@ entry:
   store i32 %param1, i32* %arg1
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %1 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
@@ -14147,8 +15856,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 33
@@ -14161,8 +15870,8 @@ entry:
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 24)
   %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 33
@@ -14171,8 +15880,8 @@ entry:
 
 ; <label>:12                                      ; preds = %1, %10
   %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 33
@@ -14183,11 +15892,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %12
+ThrowNullRef4:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14200,8 +15909,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 53
@@ -14213,8 +15922,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 116)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 53
@@ -14223,8 +15932,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 53
@@ -14235,11 +15944,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14268,8 +15977,8 @@ entry:
 
 ; <label>:7                                       ; preds = %entry, %4
   %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %7
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 2
@@ -14293,8 +16002,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 54
@@ -14306,8 +16015,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 117)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
@@ -14316,8 +16025,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 54
@@ -14328,11 +16037,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14345,8 +16054,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 27
@@ -14358,8 +16067,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 118)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 27
@@ -14368,8 +16077,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 27
@@ -14380,11 +16089,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14397,8 +16106,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 28
@@ -14410,8 +16119,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 119)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 28
@@ -14420,8 +16129,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 28
@@ -14432,11 +16141,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14449,8 +16158,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 26
@@ -14462,8 +16171,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 107)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 26
@@ -14472,8 +16181,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 26
@@ -14484,11 +16193,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14501,8 +16210,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 25
@@ -14514,8 +16223,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 106)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 25
@@ -14524,8 +16233,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 25
@@ -14536,11 +16245,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14553,8 +16262,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 24
@@ -14566,8 +16275,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 105)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 24
@@ -14576,8 +16285,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 24
@@ -14588,11 +16297,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14617,8 +16326,8 @@ entry:
   %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %3)
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %2
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -14629,15 +16338,15 @@ entry:
 
 ; <label>:8                                       ; preds = %62
   %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 9
   %12 = load i32, i32 addrspace(1)* %11, align 8
   %13 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.IO.StreamWriter addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %13, i32 0, i32 10
@@ -14652,15 +16361,15 @@ entry:
 
 ; <label>:20                                      ; preds = %14, %18
   %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
   %24 = load i32, i32 addrspace(1)* %23, align 8
   %25 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %25, null
-  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.StreamWriter addrspace(1)* %25, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %25, i32 0, i32 9
@@ -14681,36 +16390,36 @@ entry:
   %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %37 = load i32, i32* %loc1
   %38 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.StreamWriter addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %35
   %40 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %38, i32 0, i32 7
   %41 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %40, align 8
   %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
-  br i1 %NullCheck14, label %43, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %39
   %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 9
   %45 = load i32, i32 addrspace(1)* %44, align 8
   %46 = load i32, i32* %loc2
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %36, null
-  br i1 %NullCheck16, label %47, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %36, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %47
 
 ; <label>:47                                      ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %36, i32 %37, %"System.Char[]" addrspace(1)* %41, i32 %45, i32 %46)
   %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
   %51 = load i32, i32 addrspace(1)* %50, align 8
   %52 = load i32, i32* %loc2
   %53 = add i32 %51, %52
-  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
-  br i1 %NullCheck20, label %54, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %54
 
 ; <label>:54                                      ; preds = %49
   %55 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
@@ -14732,8 +16441,8 @@ entry:
 
 ; <label>:65                                      ; preds = %62
   %66 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %66, null
-  br i1 %NullCheck2, label %67, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %66, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %67
 
 ; <label>:67                                      ; preds = %65
   %68 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %66, i32 0, i32 11
@@ -14754,49 +16463,259 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %65
+ThrowNullRef2:                                    ; preds = %65
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %20
+ThrowNullRef8:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %22
+ThrowNullRef10:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %35
+ThrowNullRef12:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %43
+ThrowNullRef16:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %47
+ThrowNullRef18:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method String::CopyTo using LLILCJit
-Failed to read String.CopyTo[loadElemA]
+Successfully read String.CopyTo
+
+define void @String.CopyTo(%System.String addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  %loc1 = alloca i16 addrspace(1)*
+  %loc2 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %1 = icmp ne %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg4
+  %7 = icmp sge i32 %6, 0
+  br i1 %7, label %13, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  unreachable
+
+; <label>:13                                      ; preds = %5
+  %14 = load i32, i32* %arg1
+  %15 = icmp sge i32 %14, 0
+  br i1 %15, label %21, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %18)
+  %20 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %20, %System.String addrspace(1)* %17, %System.String addrspace(1)* %19)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %20) #0
+  unreachable
+
+; <label>:21                                      ; preds = %13
+  %22 = load i32, i32* %arg4
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck, label %ThrowNullRef, label %24
+
+; <label>:24                                      ; preds = %21
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load i32, i32* %arg1
+  %28 = sub i32 %26, %27
+  %29 = icmp sle i32 %22, %28
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34, %System.String addrspace(1)* %31, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %24
+  %36 = load i32, i32* %arg3
+  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %37, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
+
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
+  %40 = load i32, i32 addrspace(1)* %39
+  %41 = zext i32 %40 to i64
+  %42 = trunc i64 %41 to i32
+  %43 = load i32, i32* %arg4
+  %44 = sub i32 %42, %43
+  %45 = icmp sgt i32 %36, %44
+  br i1 %45, label %49, label %46
+
+; <label>:46                                      ; preds = %38
+  %47 = load i32, i32* %arg3
+  %48 = icmp sge i32 %47, 0
+  br i1 %48, label %54, label %49
+
+; <label>:49                                      ; preds = %38, %46
+  %50 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %52 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %51)
+  %53 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53, %System.String addrspace(1)* %50, %System.String addrspace(1)* %52)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53) #0
+  unreachable
+
+; <label>:54                                      ; preds = %46
+  %55 = load i32, i32* %arg4
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %97, label %57
+
+; <label>:57                                      ; preds = %54
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %59
+
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 2
+  %61 = bitcast [0 x i16] addrspace(1)* %60 to i16 addrspace(1)*
+  store i16 addrspace(1)* %61, i16 addrspace(1)** %loc0
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  store %"System.Char[]" addrspace(1)* %62, %"System.Char[]" addrspace(1)** %loc2
+  %63 = icmp eq %"System.Char[]" addrspace(1)* %62, null
+  br i1 %63, label %72, label %64
+
+; <label>:64                                      ; preds = %59
+  %65 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc2
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %65, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %66
+
+; <label>:66                                      ; preds = %64
+  %67 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %65, i32 0, i32 1
+  %68 = load i32, i32 addrspace(1)* %67
+  %69 = zext i32 %68 to i64
+  %70 = trunc i64 %69 to i32
+  %71 = icmp ne i32 %70, 0
+  br i1 %71, label %73, label %72
+
+; <label>:72                                      ; preds = %59, %66
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  br label %81
+
+; <label>:73                                      ; preds = %66
+  %74 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc2
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %74, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %75
+
+; <label>:75                                      ; preds = %73
+  %76 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %74, i32 0, i32 1
+  %77 = load i32, i32 addrspace(1)* %76
+  %78 = zext i32 %77 to i64
+  %BoundsCheck = icmp uge i64 0, %78
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %79
+
+; <label>:79                                      ; preds = %75
+  %80 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %74, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %80, i16 addrspace(1)** %loc1
+  br label %81
+
+; <label>:81                                      ; preds = %72, %79
+  %82 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %83 = ptrtoint i16 addrspace(1)* %82 to i64
+  %84 = load i32, i32* %arg3
+  %85 = sext i32 %84 to i64
+  %86 = mul i64 %85, 2
+  %87 = add i64 %83, %86
+  %88 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %89 = ptrtoint i16 addrspace(1)* %88 to i64
+  %90 = load i32, i32* %arg1
+  %91 = sext i32 %90 to i64
+  %92 = mul i64 %91, 2
+  %93 = add i64 %89, %92
+  %94 = load i32, i32* %arg4
+  %95 = inttoptr i64 %87 to i16*
+  %96 = inttoptr i64 %93 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %95, i16* %96, i32 %94)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  br label %97
+
+; <label>:97                                      ; preds = %54, %81
+  ret void
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
 Successfully read ConsoleEncoding.GetPreamble
 
@@ -14833,7 +16752,365 @@ entry:
 }
 
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[loadElemA]
+Successfully read EncoderNLS.GetBytes
+
+define i32 @EncoderNLS.GetBytes(%System.Text.EncoderNLS addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3, %"System.Byte[]" addrspace(1)* %param4, i32 %param5, i8 %param6) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %arg4 = alloca %"System.Byte[]" addrspace(1)*
+  %arg5 = alloca i32
+  %arg6 = alloca i8
+  %loc0 = alloca i32
+  %loc1 = alloca i16 addrspace(1)*
+  %loc2 = alloca i8 addrspace(1)*
+  %loc3 = alloca i32
+  %loc4 = alloca %"System.Char[]" addrspace(1)*
+  %loc5 = alloca %"System.Byte[]" addrspace(1)*
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  store %"System.Byte[]" addrspace(1)* %param4, %"System.Byte[]" addrspace(1)** %arg4
+  store i32 %param5, i32* %arg5
+  store i8 %param6, i8* %arg6
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %1 = icmp eq %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %17, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %7 = icmp eq %"System.Char[]" addrspace(1)* %6, null
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %12
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %12
+
+; <label>:12                                      ; preds = %8, %10
+  %13 = phi %System.String addrspace(1)* [ %9, %8 ], [ %11, %10 ]
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %14)
+  %16 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16, %System.String addrspace(1)* %13, %System.String addrspace(1)* %15)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16) #0
+  unreachable
+
+; <label>:17                                      ; preds = %2
+  %18 = load i32, i32* %arg2
+  %19 = icmp slt i32 %18, 0
+  br i1 %19, label %23, label %20
+
+; <label>:20                                      ; preds = %17
+  %21 = load i32, i32* %arg3
+  %22 = icmp sge i32 %21, 0
+  br i1 %22, label %35, label %23
+
+; <label>:23                                      ; preds = %17, %20
+  %24 = load i32, i32* %arg2
+  %25 = icmp slt i32 %24, 0
+  br i1 %25, label %28, label %26
+
+; <label>:26                                      ; preds = %23
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %30
+
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %30
+
+; <label>:30                                      ; preds = %26, %28
+  %31 = phi %System.String addrspace(1)* [ %27, %26 ], [ %29, %28 ]
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34, %System.String addrspace(1)* %31, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %20
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck, label %ThrowNullRef, label %37
+
+; <label>:37                                      ; preds = %35
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = load i32, i32* %arg2
+  %43 = sub i32 %41, %42
+  %44 = load i32, i32* %arg3
+  %45 = icmp sge i32 %43, %44
+  br i1 %45, label %51, label %46
+
+; <label>:46                                      ; preds = %37
+  %47 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %48 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %49 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %48)
+  %50 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %50, %System.String addrspace(1)* %47, %System.String addrspace(1)* %49)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %50) #0
+  unreachable
+
+; <label>:51                                      ; preds = %37
+  %52 = load i32, i32* %arg5
+  %53 = icmp slt i32 %52, 0
+  br i1 %53, label %63, label %54
+
+; <label>:54                                      ; preds = %51
+  %55 = load i32, i32* %arg5
+  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck1 = icmp eq %"System.Byte[]" addrspace(1)* %56, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %57
+
+; <label>:57                                      ; preds = %54
+  %58 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = zext i32 %59 to i64
+  %61 = trunc i64 %60 to i32
+  %62 = icmp sle i32 %55, %61
+  br i1 %62, label %68, label %63
+
+; <label>:63                                      ; preds = %51, %57
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %66 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %65)
+  %67 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %67, %System.String addrspace(1)* %64, %System.String addrspace(1)* %66)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %67) #0
+  unreachable
+
+; <label>:68                                      ; preds = %57
+  %69 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %69, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %69, i32 0, i32 1
+  %72 = load i32, i32 addrspace(1)* %71
+  %73 = zext i32 %72 to i64
+  %74 = trunc i64 %73 to i32
+  %75 = icmp ne i32 %74, 0
+  br i1 %75, label %78, label %76
+
+; <label>:76                                      ; preds = %70
+  %77 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1)
+  store %"System.Char[]" addrspace(1)* %77, %"System.Char[]" addrspace(1)** %arg1
+  br label %78
+
+; <label>:78                                      ; preds = %70, %76
+  %79 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck5 = icmp eq %"System.Byte[]" addrspace(1)* %79, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %80
+
+; <label>:80                                      ; preds = %78
+  %81 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %79, i32 0, i32 1
+  %82 = load i32, i32 addrspace(1)* %81
+  %83 = zext i32 %82 to i64
+  %84 = trunc i64 %83 to i32
+  %85 = load i32, i32* %arg5
+  %86 = sub i32 %84, %85
+  store i32 %86, i32* %loc0
+  %87 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck7 = icmp eq %"System.Byte[]" addrspace(1)* %87, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %88
+
+; <label>:88                                      ; preds = %80
+  %89 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %87, i32 0, i32 1
+  %90 = load i32, i32 addrspace(1)* %89
+  %91 = zext i32 %90 to i64
+  %92 = trunc i64 %91 to i32
+  %93 = icmp ne i32 %92, 0
+  br i1 %93, label %96, label %94
+
+; <label>:94                                      ; preds = %88
+  %95 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1)
+  store %"System.Byte[]" addrspace(1)* %95, %"System.Byte[]" addrspace(1)** %arg4
+  br label %96
+
+; <label>:96                                      ; preds = %88, %94
+  %97 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  store %"System.Char[]" addrspace(1)* %97, %"System.Char[]" addrspace(1)** %loc4
+  %98 = icmp eq %"System.Char[]" addrspace(1)* %97, null
+  br i1 %98, label %107, label %99
+
+; <label>:99                                      ; preds = %96
+  %100 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc4
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %100, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %101
+
+; <label>:101                                     ; preds = %99
+  %102 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %100, i32 0, i32 1
+  %103 = load i32, i32 addrspace(1)* %102
+  %104 = zext i32 %103 to i64
+  %105 = trunc i64 %104 to i32
+  %106 = icmp ne i32 %105, 0
+  br i1 %106, label %108, label %107
+
+; <label>:107                                     ; preds = %96, %101
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  br label %116
+
+; <label>:108                                     ; preds = %101
+  %109 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc4
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %109, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %110
+
+; <label>:110                                     ; preds = %108
+  %111 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %109, i32 0, i32 1
+  %112 = load i32, i32 addrspace(1)* %111
+  %113 = zext i32 %112 to i64
+  %BoundsCheck = icmp uge i64 0, %113
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %114
+
+; <label>:114                                     ; preds = %110
+  %115 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %109, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %115, i16 addrspace(1)** %loc1
+  br label %116
+
+; <label>:116                                     ; preds = %107, %114
+  %117 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  store %"System.Byte[]" addrspace(1)* %117, %"System.Byte[]" addrspace(1)** %loc5
+  %118 = icmp eq %"System.Byte[]" addrspace(1)* %117, null
+  br i1 %118, label %127, label %119
+
+; <label>:119                                     ; preds = %116
+  %120 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc5
+  %NullCheck13 = icmp eq %"System.Byte[]" addrspace(1)* %120, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %121
+
+; <label>:121                                     ; preds = %119
+  %122 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %120, i32 0, i32 1
+  %123 = load i32, i32 addrspace(1)* %122
+  %124 = zext i32 %123 to i64
+  %125 = trunc i64 %124 to i32
+  %126 = icmp ne i32 %125, 0
+  br i1 %126, label %128, label %127
+
+; <label>:127                                     ; preds = %116, %121
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc2
+  br label %136
+
+; <label>:128                                     ; preds = %121
+  %129 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc5
+  %NullCheck15 = icmp eq %"System.Byte[]" addrspace(1)* %129, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %130
+
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %129, i32 0, i32 1
+  %132 = load i32, i32 addrspace(1)* %131
+  %133 = zext i32 %132 to i64
+  %BoundsCheck17 = icmp uge i64 0, %133
+  br i1 %BoundsCheck17, label %ThrowIndexOutOfRange18, label %134
+
+; <label>:134                                     ; preds = %130
+  %135 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %129, i32 0, i32 3, i32 0
+  store i8 addrspace(1)* %135, i8 addrspace(1)** %loc2
+  br label %136
+
+; <label>:136                                     ; preds = %127, %134
+  %137 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %138 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %139 = ptrtoint i16 addrspace(1)* %138 to i64
+  %140 = load i32, i32* %arg2
+  %141 = sext i32 %140 to i64
+  %142 = mul i64 %141, 2
+  %143 = add i64 %139, %142
+  %144 = load i32, i32* %arg3
+  %145 = load i8 addrspace(1)*, i8 addrspace(1)** %loc2
+  %146 = ptrtoint i8 addrspace(1)* %145 to i64
+  %147 = load i32, i32* %arg5
+  %148 = sext i32 %147 to i64
+  %149 = add i64 %146, %148
+  %150 = load i32, i32* %loc0
+  %151 = load i8, i8* %arg6
+  %152 = zext i8 %151 to i32
+  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i64 addrspace(1)*
+  %NullCheck19 = icmp eq i64 addrspace(1)* %153, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %154
+
+; <label>:154                                     ; preds = %136
+  %155 = load i64, i64 addrspace(1)* %153
+  %156 = add i64 %155, 72
+  %157 = inttoptr i64 %156 to i64*
+  %158 = load i64, i64* %157
+  %159 = add i64 %158, 0
+  %160 = inttoptr i64 %159 to i64*
+  %161 = load i64, i64* %160
+  %162 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to %System.Text.Encoder addrspace(1)*
+  %163 = inttoptr i64 %143 to i16*
+  %164 = inttoptr i64 %149 to i8*
+  %165 = trunc i32 %152 to i8
+  %166 = inttoptr i64 %161 to i32 (%System.Text.Encoder addrspace(1)*, i16*, i32, i8*, i32, i8)*
+  %167 = call i32 %166(%System.Text.Encoder addrspace(1)* %162, i16* %163, i32 %144, i8* %164, i32 %150, i8 %165)
+  store i32 %167, i32* %loc3
+  br label %168
+
+; <label>:168                                     ; preds = %154
+  %169 = load i32, i32* %loc3
+  ret i32 %169
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %110
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %119
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange18:                           ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
 Successfully read EncoderNLS.GetBytes
 
@@ -14922,22 +17199,22 @@ entry:
   %40 = load i8, i8* %arg5
   %41 = zext i8 %40 to i32
   %42 = trunc i32 %41 to i8
-  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %39, null
-  br i1 %NullCheck, label %43, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderNLS addrspace(1)* %39, null
+  br i1 %NullCheck, label %ThrowNullRef, label %43
 
 ; <label>:43                                      ; preds = %38
   %44 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
   store i8 %42, i8 addrspace(1)* %44
   %45 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %45, null
-  br i1 %NullCheck2, label %46, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.EncoderNLS addrspace(1)* %45, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %46
 
 ; <label>:46                                      ; preds = %43
   %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %45, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %47
   %48 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.EncoderNLS addrspace(1)* %48, null
-  br i1 %NullCheck4, label %49, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.EncoderNLS addrspace(1)* %48, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %49
 
 ; <label>:49                                      ; preds = %46
   %50 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %48, i32 0, i32 3
@@ -14948,8 +17225,8 @@ entry:
   %55 = load i32, i32* %arg4
   %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck6, label %58, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
   %59 = load i64, i64 addrspace(1)* %57
@@ -14967,15 +17244,15 @@ ThrowNullRef:                                     ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %43
+ThrowNullRef2:                                    ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %46
+ThrowNullRef4:                                    ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %49
+ThrowNullRef6:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -15003,8 +17280,8 @@ entry:
   %4 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0 to %System.IO.ConsoleStream addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*)(%System.IO.ConsoleStream addrspace(1)* %4, %"System.Byte[]" addrspace(1)* %1, i32 %2, i32 %3)
   %5 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
@@ -15089,8 +17366,8 @@ entry:
 
 ; <label>:22                                      ; preds = %8
   %23 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %23, null
-  br i1 %NullCheck, label %24, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Byte[]" addrspace(1)* %23, null
+  br i1 %NullCheck, label %ThrowNullRef, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
@@ -15112,8 +17389,8 @@ entry:
 
 ; <label>:36                                      ; preds = %24
   %37 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %37, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.ConsoleStream addrspace(1)* %37, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %37, i32 0, i32 4
@@ -15134,13 +17411,138 @@ ThrowNullRef:                                     ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %36
+ThrowNullRef2:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
-Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
+Successfully read WindowsConsoleStream.WriteFileNative
+
+define i32 @WindowsConsoleStream.WriteFileNative(i64 %param0, %"System.Byte[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i64
+  %arg1 = alloca %"System.Byte[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i8 addrspace(1)*
+  %loc2 = alloca %"System.Byte[]" addrspace(1)*
+  %loc3 = alloca i32
+  store i64 %param0, i64* %arg0
+  store %"System.Byte[]" addrspace(1)* %param1, %"System.Byte[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Byte[]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = zext i32 %3 to i64
+  %5 = icmp ne i64 %4, 0
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %1
+  ret i32 0
+
+; <label>:7                                       ; preds = %1
+  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  store %"System.Byte[]" addrspace(1)* %8, %"System.Byte[]" addrspace(1)** %loc2
+  %9 = icmp eq %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %9, label %18, label %10
+
+; <label>:10                                      ; preds = %7
+  %11 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc2
+  %NullCheck1 = icmp eq %"System.Byte[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %11, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp ne i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %7, %12
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc1
+  br label %27
+
+; <label>:19                                      ; preds = %12
+  %20 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc2
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %20, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %BoundsCheck = icmp uge i64 0, %24
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %25
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %20, i32 0, i32 3, i32 0
+  store i8 addrspace(1)* %26, i8 addrspace(1)** %loc1
+  br label %27
+
+; <label>:27                                      ; preds = %18, %25
+  %28 = load i64, i64* %arg0
+  %29 = load i8 addrspace(1)*, i8 addrspace(1)** %loc1
+  %30 = ptrtoint i8 addrspace(1)* %29 to i64
+  %31 = load i32, i32* %arg2
+  %32 = sext i32 %31 to i64
+  %33 = add i64 %30, %32
+  %34 = load i32, i32* %arg3
+  %35 = addrspacecast i32* %loc3 to i32 addrspace(1)*
+  %36 = inttoptr i64 %33 to i8*
+  %37 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i8*, i32, i32 addrspace(1)*, i64)*)(i64 %28, i8* %36, i32 %34, i32 addrspace(1)* %35, i64 0)
+  %38 = icmp ugt i32 %37, 0
+  %39 = sext i1 %38 to i32
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc1
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %42, label %41
+
+; <label>:41                                      ; preds = %27
+  ret i32 0
+
+; <label>:42                                      ; preds = %27
+  %43 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  store i32 %43, i32* %loc0
+  %44 = load i32, i32* %loc0
+  %45 = icmp eq i32 %44, 232
+  br i1 %45, label %49, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = load i32, i32* %loc0
+  %48 = icmp ne i32 %47, 109
+  br i1 %48, label %50, label %49
+
+; <label>:49                                      ; preds = %42, %46
+  ret i32 0
+
+; <label>:50                                      ; preds = %46
+  %51 = load i32, i32* %loc0
+  ret i32 %51
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
 Successfully read WindowsConsoleStream.Flush
 
@@ -15149,8 +17551,8 @@ entry:
   %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
   store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
@@ -15185,8 +17587,8 @@ entry:
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
   %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load i64, i64 addrspace(1)* %1
@@ -15225,15 +17627,15 @@ entry:
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.TextWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
   %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %3, align 8
   %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
   %7 = load i64, i64 addrspace(1)* %5
@@ -15251,7 +17653,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -15280,8 +17682,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %4)
   store i32 0, i32* %loc0
   %5 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Char[]" addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
@@ -15293,15 +17695,15 @@ entry:
 
 ; <label>:11                                      ; preds = %69
   %12 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %12, i32 0, i32 9
   %15 = load i32, i32 addrspace(1)* %14, align 8
   %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.IO.StreamWriter addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %16, i32 0, i32 10
@@ -15316,15 +17718,15 @@ entry:
 
 ; <label>:23                                      ; preds = %17, %21
   %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %24, null
-  br i1 %NullCheck8, label %25, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %24, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 10
   %27 = load i32, i32 addrspace(1)* %26, align 8
   %28 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %28, null
-  br i1 %NullCheck10, label %29, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.StreamWriter addrspace(1)* %28, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %28, i32 0, i32 9
@@ -15346,15 +17748,15 @@ entry:
   %40 = load i32, i32* %loc0
   %41 = mul i32 %40, 2
   %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
-  br i1 %NullCheck12, label %43, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %43
 
 ; <label>:43                                      ; preds = %38
   %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 7
   %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %44, align 8
   %46 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %46, null
-  br i1 %NullCheck14, label %47, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.IO.StreamWriter addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %47
 
 ; <label>:47                                      ; preds = %43
   %48 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %46, i32 0, i32 9
@@ -15366,16 +17768,16 @@ entry:
   %54 = bitcast %"System.Char[]" addrspace(1)* %45 to %System.Array addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %53, i32 %41, %System.Array addrspace(1)* %54, i32 %50, i32 %52)
   %55 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
-  br i1 %NullCheck16, label %56, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %56
 
 ; <label>:56                                      ; preds = %47
   %57 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
   %58 = load i32, i32 addrspace(1)* %57, align 8
   %59 = load i32, i32* %loc2
   %60 = add i32 %58, %59
-  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
-  br i1 %NullCheck18, label %61, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %61
 
 ; <label>:61                                      ; preds = %56
   %62 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
@@ -15397,8 +17799,8 @@ entry:
 
 ; <label>:72                                      ; preds = %69
   %73 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %73, null
-  br i1 %NullCheck2, label %74, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %73, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %74
 
 ; <label>:74                                      ; preds = %72
   %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %73, i32 0, i32 11
@@ -15419,39 +17821,39 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %72
+ThrowNullRef2:                                    ; preds = %72
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %23
+ThrowNullRef8:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef10:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %43
+ThrowNullRef14:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %47
+ThrowNullRef16:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %56
+ThrowNullRef18:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FactorialRec.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FactorialRec.error.txt
@@ -25,8 +25,8 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
@@ -40,8 +40,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
   %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
@@ -75,7 +75,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -90,8 +90,8 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %NullCheck = icmp ne i8 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = load i8, i8 addrspace(1)* %0, align 8
@@ -125,8 +125,8 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
@@ -159,8 +159,8 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -184,8 +184,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
   store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
@@ -195,8 +195,8 @@ entry:
 ; <label>:4                                       ; preds = %1
   %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
   %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
@@ -206,8 +206,8 @@ entry:
   %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
@@ -221,14 +221,14 @@ entry:
 
 ; <label>:17                                      ; preds = %14
   %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
   %21 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
@@ -238,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -249,8 +249,8 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
@@ -261,27 +261,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %30
+ThrowNullRef10:                                   ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -301,7 +301,89 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
-Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
+Successfully read AppDomainSetup.GetUnsecureApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.GetUnsecureApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %NullCheck = icmp eq %"System.String[]" addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %BoundsCheck = icmp uge i64 0, %5
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %6
+
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 3, i32 0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
+  ret %System.String addrspace(1)* %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_Value using LLILCJit
+Successfully read AppDomainSetup.get_Value
+
+define %"System.String[]" addrspace(1)* @AppDomainSetup.get_Value(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.String[]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 18)
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.String[]" addrspace(1)* addrspace(1)*, %"System.String[]" addrspace(1)*)*)(%"System.String[]" addrspace(1)* addrspace(1)* %9, %"System.String[]" addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %11, i32 0, i32 1
+  %14 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %13, align 8
+  ret %"System.String[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -319,8 +401,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -368,16 +450,16 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
   %5 = load i32, i32 addrspace(1)* %4
   %6 = sub i32 %5, 1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -389,7 +471,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -421,8 +503,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
@@ -456,8 +538,8 @@ entry:
 ; <label>:27                                      ; preds = %19
   %28 = load i32, i32* %arg1
   %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
-  br i1 %NullCheck2, label %30, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %29, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %30
 
 ; <label>:30                                      ; preds = %27
   %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
@@ -493,8 +575,8 @@ entry:
 ; <label>:49                                      ; preds = %46
   %50 = load i32, i32* %arg2
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck4, label %52, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
@@ -517,11 +599,11 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %27
+ThrowNullRef2:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %49
+ThrowNullRef4:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -544,16 +626,16 @@ entry:
   %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %0)
   store %System.String addrspace(1)* %1, %System.String addrspace(1)** %loc0
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 2
   %5 = bitcast [0 x i16] addrspace(1)* %4 to i16 addrspace(1)*
   store i16 addrspace(1)* %5, i16 addrspace(1)** %loc1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %3
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2
@@ -580,7 +662,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -691,15 +773,15 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %NullCheck132 = icmp ne i8* %21, null
-  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+  %NullCheck131 = icmp eq i8* %21, null
+  br i1 %NullCheck131, label %ThrowNullRef132, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = load i8, i8* %21, align 8
   %24 = zext i8 %23 to i32
   %25 = trunc i32 %24 to i8
-  %NullCheck134 = icmp ne i8* %20, null
-  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+  %NullCheck133 = icmp eq i8* %20, null
+  br i1 %NullCheck133, label %ThrowNullRef134, label %26
 
 ; <label>:26                                      ; preds = %22
   store i8 %25, i8* %20, align 8
@@ -709,16 +791,16 @@ entry:
   %28 = load i8*, i8** %arg0
   %29 = load i8*, i8** %arg1
   %30 = bitcast i8* %29 to i16*
-  %NullCheck128 = icmp ne i16* %30, null
-  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+  %NullCheck127 = icmp eq i16* %30, null
+  br i1 %NullCheck127, label %ThrowNullRef128, label %31
 
 ; <label>:31                                      ; preds = %27
   %32 = load i16, i16* %30, align 8
   %33 = sext i16 %32 to i32
   %34 = bitcast i8* %28 to i16*
   %35 = trunc i32 %33 to i16
-  %NullCheck130 = icmp ne i16* %34, null
-  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+  %NullCheck129 = icmp eq i16* %34, null
+  br i1 %NullCheck129, label %ThrowNullRef130, label %36
 
 ; <label>:36                                      ; preds = %31
   store i16 %35, i16* %34, align 8
@@ -728,16 +810,16 @@ entry:
   %38 = load i8*, i8** %arg0
   %39 = load i8*, i8** %arg1
   %40 = bitcast i8* %39 to i16*
-  %NullCheck120 = icmp ne i16* %40, null
-  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+  %NullCheck119 = icmp eq i16* %40, null
+  br i1 %NullCheck119, label %ThrowNullRef120, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i16, i16* %40, align 8
   %43 = sext i16 %42 to i32
   %44 = bitcast i8* %38 to i16*
   %45 = trunc i32 %43 to i16
-  %NullCheck122 = icmp ne i16* %44, null
-  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+  %NullCheck121 = icmp eq i16* %44, null
+  br i1 %NullCheck121, label %ThrowNullRef122, label %46
 
 ; <label>:46                                      ; preds = %41
   store i16 %45, i16* %44, align 8
@@ -745,15 +827,15 @@ entry:
   %48 = getelementptr inbounds i8, i8* %47, i64 2
   %49 = load i8*, i8** %arg1
   %50 = getelementptr inbounds i8, i8* %49, i64 2
-  %NullCheck124 = icmp ne i8* %50, null
-  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+  %NullCheck123 = icmp eq i8* %50, null
+  br i1 %NullCheck123, label %ThrowNullRef124, label %51
 
 ; <label>:51                                      ; preds = %46
   %52 = load i8, i8* %50, align 8
   %53 = zext i8 %52 to i32
   %54 = trunc i32 %53 to i8
-  %NullCheck126 = icmp ne i8* %48, null
-  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+  %NullCheck125 = icmp eq i8* %48, null
+  br i1 %NullCheck125, label %ThrowNullRef126, label %55
 
 ; <label>:55                                      ; preds = %51
   store i8 %54, i8* %48, align 8
@@ -763,14 +845,14 @@ entry:
   %57 = load i8*, i8** %arg0
   %58 = load i8*, i8** %arg1
   %59 = bitcast i8* %58 to i32*
-  %NullCheck116 = icmp ne i32* %59, null
-  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+  %NullCheck115 = icmp eq i32* %59, null
+  br i1 %NullCheck115, label %ThrowNullRef116, label %60
 
 ; <label>:60                                      ; preds = %56
   %61 = load i32, i32* %59, align 8
   %62 = bitcast i8* %57 to i32*
-  %NullCheck118 = icmp ne i32* %62, null
-  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+  %NullCheck117 = icmp eq i32* %62, null
+  br i1 %NullCheck117, label %ThrowNullRef118, label %63
 
 ; <label>:63                                      ; preds = %60
   store i32 %61, i32* %62, align 8
@@ -780,14 +862,14 @@ entry:
   %65 = load i8*, i8** %arg0
   %66 = load i8*, i8** %arg1
   %67 = bitcast i8* %66 to i32*
-  %NullCheck108 = icmp ne i32* %67, null
-  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+  %NullCheck107 = icmp eq i32* %67, null
+  br i1 %NullCheck107, label %ThrowNullRef108, label %68
 
 ; <label>:68                                      ; preds = %64
   %69 = load i32, i32* %67, align 8
   %70 = bitcast i8* %65 to i32*
-  %NullCheck110 = icmp ne i32* %70, null
-  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+  %NullCheck109 = icmp eq i32* %70, null
+  br i1 %NullCheck109, label %ThrowNullRef110, label %71
 
 ; <label>:71                                      ; preds = %68
   store i32 %69, i32* %70, align 8
@@ -795,15 +877,15 @@ entry:
   %73 = getelementptr inbounds i8, i8* %72, i64 4
   %74 = load i8*, i8** %arg1
   %75 = getelementptr inbounds i8, i8* %74, i64 4
-  %NullCheck112 = icmp ne i8* %75, null
-  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+  %NullCheck111 = icmp eq i8* %75, null
+  br i1 %NullCheck111, label %ThrowNullRef112, label %76
 
 ; <label>:76                                      ; preds = %71
   %77 = load i8, i8* %75, align 8
   %78 = zext i8 %77 to i32
   %79 = trunc i32 %78 to i8
-  %NullCheck114 = icmp ne i8* %73, null
-  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+  %NullCheck113 = icmp eq i8* %73, null
+  br i1 %NullCheck113, label %ThrowNullRef114, label %80
 
 ; <label>:80                                      ; preds = %76
   store i8 %79, i8* %73, align 8
@@ -813,14 +895,14 @@ entry:
   %82 = load i8*, i8** %arg0
   %83 = load i8*, i8** %arg1
   %84 = bitcast i8* %83 to i32*
-  %NullCheck100 = icmp ne i32* %84, null
-  br i1 %NullCheck100, label %85, label %ThrowNullRef99
+  %NullCheck99 = icmp eq i32* %84, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %85
 
 ; <label>:85                                      ; preds = %81
   %86 = load i32, i32* %84, align 8
   %87 = bitcast i8* %82 to i32*
-  %NullCheck102 = icmp ne i32* %87, null
-  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+  %NullCheck101 = icmp eq i32* %87, null
+  br i1 %NullCheck101, label %ThrowNullRef102, label %88
 
 ; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
@@ -829,16 +911,16 @@ entry:
   %91 = load i8*, i8** %arg1
   %92 = getelementptr inbounds i8, i8* %91, i64 4
   %93 = bitcast i8* %92 to i16*
-  %NullCheck104 = icmp ne i16* %93, null
-  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+  %NullCheck103 = icmp eq i16* %93, null
+  br i1 %NullCheck103, label %ThrowNullRef104, label %94
 
 ; <label>:94                                      ; preds = %88
   %95 = load i16, i16* %93, align 8
   %96 = sext i16 %95 to i32
   %97 = bitcast i8* %90 to i16*
   %98 = trunc i32 %96 to i16
-  %NullCheck106 = icmp ne i16* %97, null
-  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+  %NullCheck105 = icmp eq i16* %97, null
+  br i1 %NullCheck105, label %ThrowNullRef106, label %99
 
 ; <label>:99                                      ; preds = %94
   store i16 %98, i16* %97, align 8
@@ -848,14 +930,14 @@ entry:
   %101 = load i8*, i8** %arg0
   %102 = load i8*, i8** %arg1
   %103 = bitcast i8* %102 to i32*
-  %NullCheck88 = icmp ne i32* %103, null
-  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+  %NullCheck87 = icmp eq i32* %103, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %104
 
 ; <label>:104                                     ; preds = %100
   %105 = load i32, i32* %103, align 8
   %106 = bitcast i8* %101 to i32*
-  %NullCheck90 = icmp ne i32* %106, null
-  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+  %NullCheck89 = icmp eq i32* %106, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %107
 
 ; <label>:107                                     ; preds = %104
   store i32 %105, i32* %106, align 8
@@ -864,16 +946,16 @@ entry:
   %110 = load i8*, i8** %arg1
   %111 = getelementptr inbounds i8, i8* %110, i64 4
   %112 = bitcast i8* %111 to i16*
-  %NullCheck92 = icmp ne i16* %112, null
-  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+  %NullCheck91 = icmp eq i16* %112, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %113
 
 ; <label>:113                                     ; preds = %107
   %114 = load i16, i16* %112, align 8
   %115 = sext i16 %114 to i32
   %116 = bitcast i8* %109 to i16*
   %117 = trunc i32 %115 to i16
-  %NullCheck94 = icmp ne i16* %116, null
-  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+  %NullCheck93 = icmp eq i16* %116, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %118
 
 ; <label>:118                                     ; preds = %113
   store i16 %117, i16* %116, align 8
@@ -881,15 +963,15 @@ entry:
   %120 = getelementptr inbounds i8, i8* %119, i64 6
   %121 = load i8*, i8** %arg1
   %122 = getelementptr inbounds i8, i8* %121, i64 6
-  %NullCheck96 = icmp ne i8* %122, null
-  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+  %NullCheck95 = icmp eq i8* %122, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %123
 
 ; <label>:123                                     ; preds = %118
   %124 = load i8, i8* %122, align 8
   %125 = zext i8 %124 to i32
   %126 = trunc i32 %125 to i8
-  %NullCheck98 = icmp ne i8* %120, null
-  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+  %NullCheck97 = icmp eq i8* %120, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %127
 
 ; <label>:127                                     ; preds = %123
   store i8 %126, i8* %120, align 8
@@ -899,14 +981,14 @@ entry:
   %129 = load i8*, i8** %arg0
   %130 = load i8*, i8** %arg1
   %131 = bitcast i8* %130 to i64*
-  %NullCheck84 = icmp ne i64* %131, null
-  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+  %NullCheck83 = icmp eq i64* %131, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %132
 
 ; <label>:132                                     ; preds = %128
   %133 = load i64, i64* %131, align 8
   %134 = bitcast i8* %129 to i64*
-  %NullCheck86 = icmp ne i64* %134, null
-  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+  %NullCheck85 = icmp eq i64* %134, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %135
 
 ; <label>:135                                     ; preds = %132
   store i64 %133, i64* %134, align 8
@@ -916,14 +998,14 @@ entry:
   %137 = load i8*, i8** %arg0
   %138 = load i8*, i8** %arg1
   %139 = bitcast i8* %138 to i64*
-  %NullCheck76 = icmp ne i64* %139, null
-  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+  %NullCheck75 = icmp eq i64* %139, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %140
 
 ; <label>:140                                     ; preds = %136
   %141 = load i64, i64* %139, align 8
   %142 = bitcast i8* %137 to i64*
-  %NullCheck78 = icmp ne i64* %142, null
-  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+  %NullCheck77 = icmp eq i64* %142, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %143
 
 ; <label>:143                                     ; preds = %140
   store i64 %141, i64* %142, align 8
@@ -931,15 +1013,15 @@ entry:
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %NullCheck80 = icmp ne i8* %147, null
-  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+  %NullCheck79 = icmp eq i8* %147, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %148
 
 ; <label>:148                                     ; preds = %143
   %149 = load i8, i8* %147, align 8
   %150 = zext i8 %149 to i32
   %151 = trunc i32 %150 to i8
-  %NullCheck82 = icmp ne i8* %145, null
-  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+  %NullCheck81 = icmp eq i8* %145, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %152
 
 ; <label>:152                                     ; preds = %148
   store i8 %151, i8* %145, align 8
@@ -949,14 +1031,14 @@ entry:
   %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
   %156 = bitcast i8* %155 to i64*
-  %NullCheck68 = icmp ne i64* %156, null
-  br i1 %NullCheck68, label %157, label %ThrowNullRef67
+  %NullCheck67 = icmp eq i64* %156, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %157
 
 ; <label>:157                                     ; preds = %153
   %158 = load i64, i64* %156, align 8
   %159 = bitcast i8* %154 to i64*
-  %NullCheck70 = icmp ne i64* %159, null
-  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+  %NullCheck69 = icmp eq i64* %159, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %160
 
 ; <label>:160                                     ; preds = %157
   store i64 %158, i64* %159, align 8
@@ -965,16 +1047,16 @@ entry:
   %163 = load i8*, i8** %arg1
   %164 = getelementptr inbounds i8, i8* %163, i64 8
   %165 = bitcast i8* %164 to i16*
-  %NullCheck72 = icmp ne i16* %165, null
-  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+  %NullCheck71 = icmp eq i16* %165, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %166
 
 ; <label>:166                                     ; preds = %160
   %167 = load i16, i16* %165, align 8
   %168 = sext i16 %167 to i32
   %169 = bitcast i8* %162 to i16*
   %170 = trunc i32 %168 to i16
-  %NullCheck74 = icmp ne i16* %169, null
-  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+  %NullCheck73 = icmp eq i16* %169, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %171
 
 ; <label>:171                                     ; preds = %166
   store i16 %170, i16* %169, align 8
@@ -984,14 +1066,14 @@ entry:
   %173 = load i8*, i8** %arg0
   %174 = load i8*, i8** %arg1
   %175 = bitcast i8* %174 to i64*
-  %NullCheck56 = icmp ne i64* %175, null
-  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+  %NullCheck55 = icmp eq i64* %175, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %176
 
 ; <label>:176                                     ; preds = %172
   %177 = load i64, i64* %175, align 8
   %178 = bitcast i8* %173 to i64*
-  %NullCheck58 = icmp ne i64* %178, null
-  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+  %NullCheck57 = icmp eq i64* %178, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %179
 
 ; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
@@ -1000,16 +1082,16 @@ entry:
   %182 = load i8*, i8** %arg1
   %183 = getelementptr inbounds i8, i8* %182, i64 8
   %184 = bitcast i8* %183 to i16*
-  %NullCheck60 = icmp ne i16* %184, null
-  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+  %NullCheck59 = icmp eq i16* %184, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %185
 
 ; <label>:185                                     ; preds = %179
   %186 = load i16, i16* %184, align 8
   %187 = sext i16 %186 to i32
   %188 = bitcast i8* %181 to i16*
   %189 = trunc i32 %187 to i16
-  %NullCheck62 = icmp ne i16* %188, null
-  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+  %NullCheck61 = icmp eq i16* %188, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %190
 
 ; <label>:190                                     ; preds = %185
   store i16 %189, i16* %188, align 8
@@ -1017,15 +1099,15 @@ entry:
   %192 = getelementptr inbounds i8, i8* %191, i64 10
   %193 = load i8*, i8** %arg1
   %194 = getelementptr inbounds i8, i8* %193, i64 10
-  %NullCheck64 = icmp ne i8* %194, null
-  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+  %NullCheck63 = icmp eq i8* %194, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %195
 
 ; <label>:195                                     ; preds = %190
   %196 = load i8, i8* %194, align 8
   %197 = zext i8 %196 to i32
   %198 = trunc i32 %197 to i8
-  %NullCheck66 = icmp ne i8* %192, null
-  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+  %NullCheck65 = icmp eq i8* %192, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %199
 
 ; <label>:199                                     ; preds = %195
   store i8 %198, i8* %192, align 8
@@ -1035,14 +1117,14 @@ entry:
   %201 = load i8*, i8** %arg0
   %202 = load i8*, i8** %arg1
   %203 = bitcast i8* %202 to i64*
-  %NullCheck48 = icmp ne i64* %203, null
-  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+  %NullCheck47 = icmp eq i64* %203, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %204
 
 ; <label>:204                                     ; preds = %200
   %205 = load i64, i64* %203, align 8
   %206 = bitcast i8* %201 to i64*
-  %NullCheck50 = icmp ne i64* %206, null
-  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+  %NullCheck49 = icmp eq i64* %206, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %207
 
 ; <label>:207                                     ; preds = %204
   store i64 %205, i64* %206, align 8
@@ -1051,14 +1133,14 @@ entry:
   %210 = load i8*, i8** %arg1
   %211 = getelementptr inbounds i8, i8* %210, i64 8
   %212 = bitcast i8* %211 to i32*
-  %NullCheck52 = icmp ne i32* %212, null
-  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+  %NullCheck51 = icmp eq i32* %212, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %213
 
 ; <label>:213                                     ; preds = %207
   %214 = load i32, i32* %212, align 8
   %215 = bitcast i8* %209 to i32*
-  %NullCheck54 = icmp ne i32* %215, null
-  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+  %NullCheck53 = icmp eq i32* %215, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %216
 
 ; <label>:216                                     ; preds = %213
   store i32 %214, i32* %215, align 8
@@ -1068,14 +1150,14 @@ entry:
   %218 = load i8*, i8** %arg0
   %219 = load i8*, i8** %arg1
   %220 = bitcast i8* %219 to i64*
-  %NullCheck36 = icmp ne i64* %220, null
-  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64* %220, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %221
 
 ; <label>:221                                     ; preds = %217
   %222 = load i64, i64* %220, align 8
   %223 = bitcast i8* %218 to i64*
-  %NullCheck38 = icmp ne i64* %223, null
-  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+  %NullCheck37 = icmp eq i64* %223, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %224
 
 ; <label>:224                                     ; preds = %221
   store i64 %222, i64* %223, align 8
@@ -1084,14 +1166,14 @@ entry:
   %227 = load i8*, i8** %arg1
   %228 = getelementptr inbounds i8, i8* %227, i64 8
   %229 = bitcast i8* %228 to i32*
-  %NullCheck40 = icmp ne i32* %229, null
-  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i32* %229, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %230
 
 ; <label>:230                                     ; preds = %224
   %231 = load i32, i32* %229, align 8
   %232 = bitcast i8* %226 to i32*
-  %NullCheck42 = icmp ne i32* %232, null
-  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+  %NullCheck41 = icmp eq i32* %232, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %233
 
 ; <label>:233                                     ; preds = %230
   store i32 %231, i32* %232, align 8
@@ -1099,15 +1181,15 @@ entry:
   %235 = getelementptr inbounds i8, i8* %234, i64 12
   %236 = load i8*, i8** %arg1
   %237 = getelementptr inbounds i8, i8* %236, i64 12
-  %NullCheck44 = icmp ne i8* %237, null
-  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i8* %237, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %238
 
 ; <label>:238                                     ; preds = %233
   %239 = load i8, i8* %237, align 8
   %240 = zext i8 %239 to i32
   %241 = trunc i32 %240 to i8
-  %NullCheck46 = icmp ne i8* %235, null
-  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+  %NullCheck45 = icmp eq i8* %235, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %242
 
 ; <label>:242                                     ; preds = %238
   store i8 %241, i8* %235, align 8
@@ -1117,14 +1199,14 @@ entry:
   %244 = load i8*, i8** %arg0
   %245 = load i8*, i8** %arg1
   %246 = bitcast i8* %245 to i64*
-  %NullCheck24 = icmp ne i64* %246, null
-  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64* %246, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %247
 
 ; <label>:247                                     ; preds = %243
   %248 = load i64, i64* %246, align 8
   %249 = bitcast i8* %244 to i64*
-  %NullCheck26 = icmp ne i64* %249, null
-  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64* %249, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %250
 
 ; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
@@ -1133,14 +1215,14 @@ entry:
   %253 = load i8*, i8** %arg1
   %254 = getelementptr inbounds i8, i8* %253, i64 8
   %255 = bitcast i8* %254 to i32*
-  %NullCheck28 = icmp ne i32* %255, null
-  br i1 %NullCheck28, label %256, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i32* %255, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %256
 
 ; <label>:256                                     ; preds = %250
   %257 = load i32, i32* %255, align 8
   %258 = bitcast i8* %252 to i32*
-  %NullCheck30 = icmp ne i32* %258, null
-  br i1 %NullCheck30, label %259, label %ThrowNullRef29
+  %NullCheck29 = icmp eq i32* %258, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %259
 
 ; <label>:259                                     ; preds = %256
   store i32 %257, i32* %258, align 8
@@ -1149,16 +1231,16 @@ entry:
   %262 = load i8*, i8** %arg1
   %263 = getelementptr inbounds i8, i8* %262, i64 12
   %264 = bitcast i8* %263 to i16*
-  %NullCheck32 = icmp ne i16* %264, null
-  br i1 %NullCheck32, label %265, label %ThrowNullRef31
+  %NullCheck31 = icmp eq i16* %264, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %265
 
 ; <label>:265                                     ; preds = %259
   %266 = load i16, i16* %264, align 8
   %267 = sext i16 %266 to i32
   %268 = bitcast i8* %261 to i16*
   %269 = trunc i32 %267 to i16
-  %NullCheck34 = icmp ne i16* %268, null
-  br i1 %NullCheck34, label %270, label %ThrowNullRef33
+  %NullCheck33 = icmp eq i16* %268, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %270
 
 ; <label>:270                                     ; preds = %265
   store i16 %269, i16* %268, align 8
@@ -1168,14 +1250,14 @@ entry:
   %272 = load i8*, i8** %arg0
   %273 = load i8*, i8** %arg1
   %274 = bitcast i8* %273 to i64*
-  %NullCheck8 = icmp ne i64* %274, null
-  br i1 %NullCheck8, label %275, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64* %274, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %275
 
 ; <label>:275                                     ; preds = %271
   %276 = load i64, i64* %274, align 8
   %277 = bitcast i8* %272 to i64*
-  %NullCheck10 = icmp ne i64* %277, null
-  br i1 %NullCheck10, label %278, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %277, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %278
 
 ; <label>:278                                     ; preds = %275
   store i64 %276, i64* %277, align 8
@@ -1184,14 +1266,14 @@ entry:
   %281 = load i8*, i8** %arg1
   %282 = getelementptr inbounds i8, i8* %281, i64 8
   %283 = bitcast i8* %282 to i32*
-  %NullCheck12 = icmp ne i32* %283, null
-  br i1 %NullCheck12, label %284, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i32* %283, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %284
 
 ; <label>:284                                     ; preds = %278
   %285 = load i32, i32* %283, align 8
   %286 = bitcast i8* %280 to i32*
-  %NullCheck14 = icmp ne i32* %286, null
-  br i1 %NullCheck14, label %287, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i32* %286, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %287
 
 ; <label>:287                                     ; preds = %284
   store i32 %285, i32* %286, align 8
@@ -1200,16 +1282,16 @@ entry:
   %290 = load i8*, i8** %arg1
   %291 = getelementptr inbounds i8, i8* %290, i64 12
   %292 = bitcast i8* %291 to i16*
-  %NullCheck16 = icmp ne i16* %292, null
-  br i1 %NullCheck16, label %293, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i16* %292, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %293
 
 ; <label>:293                                     ; preds = %287
   %294 = load i16, i16* %292, align 8
   %295 = sext i16 %294 to i32
   %296 = bitcast i8* %289 to i16*
   %297 = trunc i32 %295 to i16
-  %NullCheck18 = icmp ne i16* %296, null
-  br i1 %NullCheck18, label %298, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i16* %296, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %298
 
 ; <label>:298                                     ; preds = %293
   store i16 %297, i16* %296, align 8
@@ -1217,15 +1299,15 @@ entry:
   %300 = getelementptr inbounds i8, i8* %299, i64 14
   %301 = load i8*, i8** %arg1
   %302 = getelementptr inbounds i8, i8* %301, i64 14
-  %NullCheck20 = icmp ne i8* %302, null
-  br i1 %NullCheck20, label %303, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i8* %302, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %303
 
 ; <label>:303                                     ; preds = %298
   %304 = load i8, i8* %302, align 8
   %305 = zext i8 %304 to i32
   %306 = trunc i32 %305 to i8
-  %NullCheck22 = icmp ne i8* %300, null
-  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i8* %300, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %307
 
 ; <label>:307                                     ; preds = %303
   store i8 %306, i8* %300, align 8
@@ -1235,14 +1317,14 @@ entry:
   %309 = load i8*, i8** %arg0
   %310 = load i8*, i8** %arg1
   %311 = bitcast i8* %310 to i64*
-  %NullCheck = icmp ne i64* %311, null
-  br i1 %NullCheck, label %312, label %ThrowNullRef
+  %NullCheck = icmp eq i64* %311, null
+  br i1 %NullCheck, label %ThrowNullRef, label %312
 
 ; <label>:312                                     ; preds = %308
   %313 = load i64, i64* %311, align 8
   %314 = bitcast i8* %309 to i64*
-  %NullCheck2 = icmp ne i64* %314, null
-  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64* %314, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %315
 
 ; <label>:315                                     ; preds = %312
   store i64 %313, i64* %314, align 8
@@ -1251,14 +1333,14 @@ entry:
   %318 = load i8*, i8** %arg1
   %319 = getelementptr inbounds i8, i8* %318, i64 8
   %320 = bitcast i8* %319 to i64*
-  %NullCheck4 = icmp ne i64* %320, null
-  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64* %320, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %321
 
 ; <label>:321                                     ; preds = %315
   %322 = load i64, i64* %320, align 8
   %323 = bitcast i8* %317 to i64*
-  %NullCheck6 = icmp ne i64* %323, null
-  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64* %323, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %324
 
 ; <label>:324                                     ; preds = %321
   store i64 %322, i64* %323, align 8
@@ -1286,15 +1368,15 @@ entry:
 ; <label>:338                                     ; preds = %333
   %339 = load i8*, i8** %arg0
   %340 = load i8*, i8** %arg1
-  %NullCheck136 = icmp ne i8* %340, null
-  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+  %NullCheck135 = icmp eq i8* %340, null
+  br i1 %NullCheck135, label %ThrowNullRef136, label %341
 
 ; <label>:341                                     ; preds = %338
   %342 = load i8, i8* %340, align 8
   %343 = zext i8 %342 to i32
   %344 = trunc i32 %343 to i8
-  %NullCheck138 = icmp ne i8* %339, null
-  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+  %NullCheck137 = icmp eq i8* %339, null
+  br i1 %NullCheck137, label %ThrowNullRef138, label %345
 
 ; <label>:345                                     ; preds = %341
   store i8 %344, i8* %339, align 8
@@ -1317,16 +1399,16 @@ entry:
   %357 = load i8*, i8** %arg0
   %358 = load i8*, i8** %arg1
   %359 = bitcast i8* %358 to i16*
-  %NullCheck140 = icmp ne i16* %359, null
-  br i1 %NullCheck140, label %360, label %ThrowNullRef139
+  %NullCheck139 = icmp eq i16* %359, null
+  br i1 %NullCheck139, label %ThrowNullRef140, label %360
 
 ; <label>:360                                     ; preds = %356
   %361 = load i16, i16* %359, align 8
   %362 = sext i16 %361 to i32
   %363 = bitcast i8* %357 to i16*
   %364 = trunc i32 %362 to i16
-  %NullCheck142 = icmp ne i16* %363, null
-  br i1 %NullCheck142, label %365, label %ThrowNullRef141
+  %NullCheck141 = icmp eq i16* %363, null
+  br i1 %NullCheck141, label %ThrowNullRef142, label %365
 
 ; <label>:365                                     ; preds = %360
   store i16 %364, i16* %363, align 8
@@ -1352,14 +1434,14 @@ entry:
   %378 = load i8*, i8** %arg0
   %379 = load i8*, i8** %arg1
   %380 = bitcast i8* %379 to i32*
-  %NullCheck144 = icmp ne i32* %380, null
-  br i1 %NullCheck144, label %381, label %ThrowNullRef143
+  %NullCheck143 = icmp eq i32* %380, null
+  br i1 %NullCheck143, label %ThrowNullRef144, label %381
 
 ; <label>:381                                     ; preds = %377
   %382 = load i32, i32* %380, align 8
   %383 = bitcast i8* %378 to i32*
-  %NullCheck146 = icmp ne i32* %383, null
-  br i1 %NullCheck146, label %384, label %ThrowNullRef145
+  %NullCheck145 = icmp eq i32* %383, null
+  br i1 %NullCheck145, label %ThrowNullRef146, label %384
 
 ; <label>:384                                     ; preds = %381
   store i32 %382, i32* %383, align 8
@@ -1384,14 +1466,14 @@ entry:
   %395 = load i8*, i8** %arg0
   %396 = load i8*, i8** %arg1
   %397 = bitcast i8* %396 to i64*
-  %NullCheck164 = icmp ne i64* %397, null
-  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+  %NullCheck163 = icmp eq i64* %397, null
+  br i1 %NullCheck163, label %ThrowNullRef164, label %398
 
 ; <label>:398                                     ; preds = %394
   %399 = load i64, i64* %397, align 8
   %400 = bitcast i8* %395 to i64*
-  %NullCheck166 = icmp ne i64* %400, null
-  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+  %NullCheck165 = icmp eq i64* %400, null
+  br i1 %NullCheck165, label %ThrowNullRef166, label %401
 
 ; <label>:401                                     ; preds = %398
   store i64 %399, i64* %400, align 8
@@ -1400,14 +1482,14 @@ entry:
   %404 = load i8*, i8** %arg1
   %405 = getelementptr inbounds i8, i8* %404, i64 8
   %406 = bitcast i8* %405 to i64*
-  %NullCheck168 = icmp ne i64* %406, null
-  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+  %NullCheck167 = icmp eq i64* %406, null
+  br i1 %NullCheck167, label %ThrowNullRef168, label %407
 
 ; <label>:407                                     ; preds = %401
   %408 = load i64, i64* %406, align 8
   %409 = bitcast i8* %403 to i64*
-  %NullCheck170 = icmp ne i64* %409, null
-  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+  %NullCheck169 = icmp eq i64* %409, null
+  br i1 %NullCheck169, label %ThrowNullRef170, label %410
 
 ; <label>:410                                     ; preds = %407
   store i64 %408, i64* %409, align 8
@@ -1437,14 +1519,14 @@ entry:
   %425 = load i8*, i8** %arg0
   %426 = load i8*, i8** %arg1
   %427 = bitcast i8* %426 to i64*
-  %NullCheck148 = icmp ne i64* %427, null
-  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+  %NullCheck147 = icmp eq i64* %427, null
+  br i1 %NullCheck147, label %ThrowNullRef148, label %428
 
 ; <label>:428                                     ; preds = %424
   %429 = load i64, i64* %427, align 8
   %430 = bitcast i8* %425 to i64*
-  %NullCheck150 = icmp ne i64* %430, null
-  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+  %NullCheck149 = icmp eq i64* %430, null
+  br i1 %NullCheck149, label %ThrowNullRef150, label %431
 
 ; <label>:431                                     ; preds = %428
   store i64 %429, i64* %430, align 8
@@ -1466,14 +1548,14 @@ entry:
   %441 = load i8*, i8** %arg0
   %442 = load i8*, i8** %arg1
   %443 = bitcast i8* %442 to i32*
-  %NullCheck152 = icmp ne i32* %443, null
-  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+  %NullCheck151 = icmp eq i32* %443, null
+  br i1 %NullCheck151, label %ThrowNullRef152, label %444
 
 ; <label>:444                                     ; preds = %440
   %445 = load i32, i32* %443, align 8
   %446 = bitcast i8* %441 to i32*
-  %NullCheck154 = icmp ne i32* %446, null
-  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+  %NullCheck153 = icmp eq i32* %446, null
+  br i1 %NullCheck153, label %ThrowNullRef154, label %447
 
 ; <label>:447                                     ; preds = %444
   store i32 %445, i32* %446, align 8
@@ -1495,16 +1577,16 @@ entry:
   %457 = load i8*, i8** %arg0
   %458 = load i8*, i8** %arg1
   %459 = bitcast i8* %458 to i16*
-  %NullCheck156 = icmp ne i16* %459, null
-  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+  %NullCheck155 = icmp eq i16* %459, null
+  br i1 %NullCheck155, label %ThrowNullRef156, label %460
 
 ; <label>:460                                     ; preds = %456
   %461 = load i16, i16* %459, align 8
   %462 = sext i16 %461 to i32
   %463 = bitcast i8* %457 to i16*
   %464 = trunc i32 %462 to i16
-  %NullCheck158 = icmp ne i16* %463, null
-  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+  %NullCheck157 = icmp eq i16* %463, null
+  br i1 %NullCheck157, label %ThrowNullRef158, label %465
 
 ; <label>:465                                     ; preds = %460
   store i16 %464, i16* %463, align 8
@@ -1525,15 +1607,15 @@ entry:
 ; <label>:474                                     ; preds = %470
   %475 = load i8*, i8** %arg0
   %476 = load i8*, i8** %arg1
-  %NullCheck160 = icmp ne i8* %476, null
-  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+  %NullCheck159 = icmp eq i8* %476, null
+  br i1 %NullCheck159, label %ThrowNullRef160, label %477
 
 ; <label>:477                                     ; preds = %474
   %478 = load i8, i8* %476, align 8
   %479 = zext i8 %478 to i32
   %480 = trunc i32 %479 to i8
-  %NullCheck162 = icmp ne i8* %475, null
-  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+  %NullCheck161 = icmp eq i8* %475, null
+  br i1 %NullCheck161, label %ThrowNullRef162, label %481
 
 ; <label>:481                                     ; preds = %477
   store i8 %480, i8* %475, align 8
@@ -1553,343 +1635,343 @@ ThrowNullRef:                                     ; preds = %308
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %312
+ThrowNullRef2:                                    ; preds = %312
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %315
+ThrowNullRef4:                                    ; preds = %315
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %321
+ThrowNullRef6:                                    ; preds = %321
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %271
+ThrowNullRef8:                                    ; preds = %271
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %275
+ThrowNullRef10:                                   ; preds = %275
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %278
+ThrowNullRef12:                                   ; preds = %278
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %284
+ThrowNullRef14:                                   ; preds = %284
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %287
+ThrowNullRef16:                                   ; preds = %287
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %293
+ThrowNullRef18:                                   ; preds = %293
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %298
+ThrowNullRef20:                                   ; preds = %298
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %303
+ThrowNullRef22:                                   ; preds = %303
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %243
+ThrowNullRef24:                                   ; preds = %243
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %247
+ThrowNullRef26:                                   ; preds = %247
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %250
+ThrowNullRef28:                                   ; preds = %250
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %256
+ThrowNullRef30:                                   ; preds = %256
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %259
+ThrowNullRef32:                                   ; preds = %259
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %265
+ThrowNullRef34:                                   ; preds = %265
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %217
+ThrowNullRef36:                                   ; preds = %217
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %221
+ThrowNullRef38:                                   ; preds = %221
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %224
+ThrowNullRef40:                                   ; preds = %224
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %230
+ThrowNullRef42:                                   ; preds = %230
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %233
+ThrowNullRef44:                                   ; preds = %233
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %238
+ThrowNullRef46:                                   ; preds = %238
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %200
+ThrowNullRef48:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %204
+ThrowNullRef50:                                   ; preds = %204
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %207
+ThrowNullRef52:                                   ; preds = %207
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %213
+ThrowNullRef54:                                   ; preds = %213
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %172
+ThrowNullRef56:                                   ; preds = %172
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %176
+ThrowNullRef58:                                   ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %179
+ThrowNullRef60:                                   ; preds = %179
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %185
+ThrowNullRef62:                                   ; preds = %185
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %190
+ThrowNullRef64:                                   ; preds = %190
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %195
+ThrowNullRef66:                                   ; preds = %195
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %153
+ThrowNullRef68:                                   ; preds = %153
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %157
+ThrowNullRef70:                                   ; preds = %157
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %160
+ThrowNullRef72:                                   ; preds = %160
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %166
+ThrowNullRef74:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %136
+ThrowNullRef76:                                   ; preds = %136
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %140
+ThrowNullRef78:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %143
+ThrowNullRef80:                                   ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %148
+ThrowNullRef82:                                   ; preds = %148
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %128
+ThrowNullRef84:                                   ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %132
+ThrowNullRef86:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %100
+ThrowNullRef88:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %104
+ThrowNullRef90:                                   ; preds = %104
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %107
+ThrowNullRef92:                                   ; preds = %107
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %113
+ThrowNullRef94:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %118
+ThrowNullRef96:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %123
+ThrowNullRef98:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %81
+ThrowNullRef100:                                  ; preds = %81
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef101:                                  ; preds = %85
+ThrowNullRef102:                                  ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef103:                                  ; preds = %88
+ThrowNullRef104:                                  ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef105:                                  ; preds = %94
+ThrowNullRef106:                                  ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef107:                                  ; preds = %64
+ThrowNullRef108:                                  ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef109:                                  ; preds = %68
+ThrowNullRef110:                                  ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef111:                                  ; preds = %71
+ThrowNullRef112:                                  ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef113:                                  ; preds = %76
+ThrowNullRef114:                                  ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef115:                                  ; preds = %56
+ThrowNullRef116:                                  ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef117:                                  ; preds = %60
+ThrowNullRef118:                                  ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef119:                                  ; preds = %37
+ThrowNullRef120:                                  ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef121:                                  ; preds = %41
+ThrowNullRef122:                                  ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef123:                                  ; preds = %46
+ThrowNullRef124:                                  ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef125:                                  ; preds = %51
+ThrowNullRef126:                                  ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef127:                                  ; preds = %27
+ThrowNullRef128:                                  ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef129:                                  ; preds = %31
+ThrowNullRef130:                                  ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef131:                                  ; preds = %19
+ThrowNullRef132:                                  ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef133:                                  ; preds = %22
+ThrowNullRef134:                                  ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef135:                                  ; preds = %338
+ThrowNullRef136:                                  ; preds = %338
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef137:                                  ; preds = %341
+ThrowNullRef138:                                  ; preds = %341
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef139:                                  ; preds = %356
+ThrowNullRef140:                                  ; preds = %356
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef141:                                  ; preds = %360
+ThrowNullRef142:                                  ; preds = %360
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef143:                                  ; preds = %377
+ThrowNullRef144:                                  ; preds = %377
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef145:                                  ; preds = %381
+ThrowNullRef146:                                  ; preds = %381
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef147:                                  ; preds = %424
+ThrowNullRef148:                                  ; preds = %424
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef149:                                  ; preds = %428
+ThrowNullRef150:                                  ; preds = %428
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef151:                                  ; preds = %440
+ThrowNullRef152:                                  ; preds = %440
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef153:                                  ; preds = %444
+ThrowNullRef154:                                  ; preds = %444
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef155:                                  ; preds = %456
+ThrowNullRef156:                                  ; preds = %456
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef157:                                  ; preds = %460
+ThrowNullRef158:                                  ; preds = %460
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef159:                                  ; preds = %474
+ThrowNullRef160:                                  ; preds = %474
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef161:                                  ; preds = %477
+ThrowNullRef162:                                  ; preds = %477
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef163:                                  ; preds = %394
+ThrowNullRef164:                                  ; preds = %394
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef165:                                  ; preds = %398
+ThrowNullRef166:                                  ; preds = %398
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef167:                                  ; preds = %401
+ThrowNullRef168:                                  ; preds = %401
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef169:                                  ; preds = %407
+ThrowNullRef170:                                  ; preds = %407
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1939,8 +2021,8 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
-  br i1 %NullCheck, label %22, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %ThrowNullRef, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
@@ -1948,8 +2030,8 @@ entry:
   store i32 %24, i32* %loc0
   %25 = load i32, i32* %loc0
   %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %26, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %27
 
 ; <label>:27                                      ; preds = %22
   %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
@@ -1971,7 +2053,7 @@ ThrowNullRef:                                     ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1989,8 +2071,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -2022,15 +2104,15 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2048,16 +2130,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
   %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
   store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %15
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
@@ -2072,8 +2154,8 @@ entry:
   %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
   %29 = ptrtoint i16 addrspace(1)* %28 to i64
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %19
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
@@ -2089,19 +2171,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2114,8 +2196,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
@@ -2128,7 +2210,7 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[loadElem]
+Failed to read AppDomain.PrepareDataForSetup[storeElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
@@ -2202,8 +2284,8 @@ entry:
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
-  br i1 %NullCheck24, label %27, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = load i64, i64 addrspace(1)* %26
@@ -2218,8 +2300,8 @@ entry:
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
-  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
   %41 = load i64, i64 addrspace(1)* %39
@@ -2236,8 +2318,8 @@ entry:
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
-  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
   %54 = load i64, i64 addrspace(1)* %52
@@ -2252,8 +2334,8 @@ entry:
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
   %67 = load i64, i64 addrspace(1)* %65
@@ -2270,8 +2352,8 @@ entry:
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
-  br i1 %NullCheck16, label %79, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
   %80 = load i64, i64 addrspace(1)* %78
@@ -2286,8 +2368,8 @@ entry:
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
-  br i1 %NullCheck18, label %92, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
   %93 = load i64, i64 addrspace(1)* %91
@@ -2304,8 +2386,8 @@ entry:
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
-  br i1 %NullCheck12, label %105, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = load i64, i64 addrspace(1)* %104
@@ -2320,8 +2402,8 @@ entry:
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
-  br i1 %NullCheck14, label %118, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
   %119 = load i64, i64 addrspace(1)* %117
@@ -2337,8 +2419,8 @@ entry:
 
 ; <label>:128                                     ; preds = %20
   %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
-  br i1 %NullCheck4, label %130, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %129, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %130
 
 ; <label>:130                                     ; preds = %128
   %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
@@ -2346,8 +2428,8 @@ entry:
   %133 = load i16, i16 addrspace(1)* %132, align 8
   %134 = zext i16 %133 to i32
   %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
-  br i1 %NullCheck6, label %136, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %135, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %136
 
 ; <label>:136                                     ; preds = %130
   %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
@@ -2360,8 +2442,8 @@ entry:
 
 ; <label>:143                                     ; preds = %136
   %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
-  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %144, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %145
 
 ; <label>:145                                     ; preds = %143
   %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
@@ -2369,8 +2451,8 @@ entry:
   %148 = load i16, i16 addrspace(1)* %147, align 8
   %149 = zext i16 %148 to i32
   %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %150, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %151
 
 ; <label>:151                                     ; preds = %145
   %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
@@ -2388,8 +2470,8 @@ entry:
 
 ; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
-  br i1 %NullCheck, label %163, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %ThrowNullRef, label %163
 
 ; <label>:163                                     ; preds = %161
   %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
@@ -2399,8 +2481,8 @@ entry:
 
 ; <label>:167                                     ; preds = %163
   %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
-  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %168, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %169
 
 ; <label>:169                                     ; preds = %167
   %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
@@ -2432,55 +2514,55 @@ ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %167
+ThrowNullRef2:                                    ; preds = %167
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %128
+ThrowNullRef4:                                    ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %130
+ThrowNullRef6:                                    ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %143
+ThrowNullRef8:                                    ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %145
+ThrowNullRef10:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %102
+ThrowNullRef12:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %105
+ThrowNullRef14:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %76
+ThrowNullRef16:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %79
+ThrowNullRef18:                                   ; preds = %79
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %50
+ThrowNullRef20:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %53
+ThrowNullRef22:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %24
+ThrowNullRef24:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %27
+ThrowNullRef26:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2503,15 +2585,15 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2519,16 +2601,16 @@ entry:
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
   store i32 %8, i32* %loc0
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
   %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
   store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
@@ -2546,16 +2628,16 @@ entry:
 
 ; <label>:23                                      ; preds = %64
   %24 = load i16*, i16** %loc3
-  %NullCheck12 = icmp ne i16* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i16* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
   store i32 %27, i32* %loc5
   %28 = load i16*, i16** %loc4
-  %NullCheck14 = icmp ne i16* %28, null
-  br i1 %NullCheck14, label %29, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %28, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = load i16, i16* %28, align 8
@@ -2620,15 +2702,15 @@ entry:
 
 ; <label>:67                                      ; preds = %64
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
-  br i1 %NullCheck8, label %69, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %68, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %69
 
 ; <label>:69                                      ; preds = %67
   %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
   %71 = load i32, i32 addrspace(1)* %70
   %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
-  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %73
 
 ; <label>:73                                      ; preds = %69
   %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
@@ -2645,31 +2727,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %67
+ThrowNullRef8:                                    ; preds = %67
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %69
+ThrowNullRef10:                                   ; preds = %69
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2710,14 +2792,14 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
   %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
@@ -2730,14 +2812,14 @@ entry:
 
 ; <label>:11                                      ; preds = %4
   %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
   %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
@@ -2749,14 +2831,14 @@ entry:
 
 ; <label>:22                                      ; preds = %16
   %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
   %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
-  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
-  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
@@ -2804,23 +2886,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2836,7 +2918,280 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[loadElem]
+Successfully read RuntimeType.IsAssignableFrom
+
+define i8 @RuntimeType.IsAssignableFrom(%System.RuntimeType addrspace(1)* %param0, %System.Type addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.RuntimeType addrspace(1)*
+  %arg1 = alloca %System.Type addrspace(1)*
+  %loc0 = alloca %System.RuntimeType addrspace(1)*
+  %loc1 = alloca %"System.Type[]" addrspace(1)*
+  %loc2 = alloca i32
+  store %System.RuntimeType addrspace(1)* %param0, %System.RuntimeType addrspace(1)** %this
+  store %System.Type addrspace(1)* %param1, %System.Type addrspace(1)** %arg1
+  %0 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %1 = icmp ne %System.Type addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i8 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %5 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %6 = bitcast %System.Type addrspace(1)* %4 to %System.Object addrspace(1)*
+  %7 = bitcast %System.RuntimeType addrspace(1)* %5 to %System.Object addrspace(1)*
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %6, %System.Object addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %3
+  ret i8 1
+
+; <label>:12                                      ; preds = %3
+  %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 152
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 32
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
+  %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
+  %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
+  store %System.RuntimeType addrspace(1)* %25, %System.RuntimeType addrspace(1)** %loc0
+  %26 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %27 = icmp eq %System.RuntimeType addrspace(1)* %26, null
+  br i1 %27, label %34, label %28
+
+; <label>:28                                      ; preds = %15
+  %29 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %30 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)*)*)(%System.RuntimeType addrspace(1)* %29, %System.RuntimeType addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+; <label>:34                                      ; preds = %15
+  %35 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %36 = call %System.Reflection.Emit.TypeBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Reflection.Emit.TypeBuilder addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %35)
+  %37 = icmp eq %System.Reflection.Emit.TypeBuilder addrspace(1)* %36, null
+  br i1 %37, label %139, label %38
+
+; <label>:38                                      ; preds = %34
+  %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %42
+
+; <label>:42                                      ; preds = %38
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 152
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 40
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
+  %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
+  %53 = zext i8 %52 to i32
+  %54 = icmp eq i32 %53, 0
+  br i1 %54, label %56, label %55
+
+; <label>:55                                      ; preds = %42
+  ret i8 1
+
+; <label>:56                                      ; preds = %42
+  %57 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %58 = bitcast %System.RuntimeType addrspace(1)* %57 to %System.Type addrspace(1)*
+  %59 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %58)
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %64 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.Type addrspace(1)* %63, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = bitcast %System.RuntimeType addrspace(1)* %64 to %System.Type addrspace(1)*
+  %67 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %63, %System.Type addrspace(1)* %66)
+  %68 = zext i8 %67 to i32
+  %69 = trunc i32 %68 to i8
+  ret i8 %69
+
+; <label>:70                                      ; preds = %56
+  %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
+  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %73
+
+; <label>:73                                      ; preds = %70
+  %74 = load i64, i64 addrspace(1)* %72
+  %75 = add i64 %74, 128
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = add i64 %77, 0
+  %79 = inttoptr i64 %78 to i64*
+  %80 = load i64, i64* %79
+  %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
+  %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
+  %83 = call i8 %82(%System.Type addrspace(1)* %81)
+  %84 = zext i8 %83 to i32
+  %85 = icmp eq i32 %84, 0
+  br i1 %85, label %139, label %86
+
+; <label>:86                                      ; preds = %73
+  %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
+  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %89
+
+; <label>:89                                      ; preds = %86
+  %90 = load i64, i64 addrspace(1)* %88
+  %91 = add i64 %90, 128
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = add i64 %93, 24
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
+  %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
+  %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
+  store %"System.Type[]" addrspace(1)* %99, %"System.Type[]" addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %129
+
+; <label>:100                                     ; preds = %132
+  %101 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %102 = load i32, i32* %loc2
+  %NullCheck11 = icmp eq %"System.Type[]" addrspace(1)* %101, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %103
+
+; <label>:103                                     ; preds = %100
+  %104 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 1
+  %105 = load i32, i32 addrspace(1)* %104
+  %106 = zext i32 %105 to i64
+  %107 = zext i32 %102 to i64
+  %BoundsCheck = icmp uge i64 %107, %106
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %108
+
+; <label>:108                                     ; preds = %103
+  %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
+  %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
+  %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
+  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %113
+
+; <label>:113                                     ; preds = %108
+  %114 = load i64, i64 addrspace(1)* %112
+  %115 = add i64 %114, 152
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = add i64 %117, 56
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
+  %123 = zext i8 %122 to i32
+  %124 = icmp ne i32 %123, 0
+  br i1 %124, label %126, label %125
+
+; <label>:125                                     ; preds = %113
+  ret i8 0
+
+; <label>:126                                     ; preds = %113
+  %127 = load i32, i32* %loc2
+  %128 = add i32 %127, 1
+  store i32 %128, i32* %loc2
+  br label %129
+
+; <label>:129                                     ; preds = %89, %126
+  %130 = load i32, i32* %loc2
+  %131 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %NullCheck9 = icmp eq %"System.Type[]" addrspace(1)* %131, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %132
+
+; <label>:132                                     ; preds = %129
+  %133 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %131, i32 0, i32 1
+  %134 = load i32, i32 addrspace(1)* %133
+  %135 = zext i32 %134 to i64
+  %136 = trunc i64 %135 to i32
+  %137 = icmp slt i32 %130, %136
+  br i1 %137, label %100, label %138
+
+; <label>:138                                     ; preds = %132
+  ret i8 1
+
+; <label>:139                                     ; preds = %34, %73
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %129
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %103
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -2893,7 +3248,7 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElem]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -2904,8 +3259,8 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -2997,8 +3352,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
@@ -3059,8 +3414,8 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -3087,8 +3442,8 @@ entry:
 
 ; <label>:17                                      ; preds = %5, %11
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
@@ -3097,8 +3452,8 @@ entry:
 
 ; <label>:22                                      ; preds = %1, %11
   %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
@@ -3109,11 +3464,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %17
+ThrowNullRef2:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %22
+ThrowNullRef4:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3167,15 +3522,15 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
   %15 = load i32, i32 addrspace(1)* %14
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
@@ -3198,7 +3553,7 @@ ThrowNullRef:                                     ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef2:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3232,8 +3587,8 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
@@ -3312,8 +3667,8 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -3327,8 +3682,8 @@ entry:
 ; <label>:5                                       ; preds = %43
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %7 = load i32, i32* %loc1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck6, label %8, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
@@ -3366,8 +3721,8 @@ entry:
 ; <label>:32                                      ; preds = %21, %25
   %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
   %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
-  br i1 %NullCheck8, label %35, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = trunc i32 %34 to i16
@@ -3380,8 +3735,8 @@ entry:
 ; <label>:40                                      ; preds = %1, %35
   %41 = load i32, i32* %loc1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
-  br i1 %NullCheck2, label %43, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %42, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
@@ -3392,8 +3747,8 @@ entry:
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
   %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
-  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
   %51 = load i64, i64 addrspace(1)* %49
@@ -3412,19 +3767,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %40
+ThrowNullRef2:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %47
+ThrowNullRef4:                                    ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %5
+ThrowNullRef6:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %32
+ThrowNullRef8:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3467,8 +3822,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
@@ -3492,11 +3847,391 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(i16* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store i16* %param0, i16** %arg0
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load i32, i32* %arg3
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %42, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %37, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg2
+  %13 = load i32, i32* %arg3
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %37, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %24 = load i32, i32* %arg2
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load i16*, i16** %arg0
+  %35 = load i32, i32* %arg3
+  %36 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %36, i16* %34, i32 %35)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:37                                      ; preds = %5, %16
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %39)
+  %41 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41, %System.String addrspace(1)* %38, %System.String addrspace(1)* %40)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41) #0
+  unreachable
+
+; <label>:42                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
-Failed to read StringBuilder.ToString[loadElemA]
+Successfully read StringBuilder.ToString
+
+define %System.String addrspace(1)* @StringBuilder.ToString(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i16*
+  %loc3 = alloca %"System.Char[]" addrspace(1)*
+  %loc4 = alloca i32
+  %loc5 = alloca i32
+  %loc6 = alloca i16 addrspace(1)*
+  %loc7 = alloca %System.String addrspace(1)*
+  %loc8 = alloca %"System.Char[]" addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %0)
+  %2 = icmp ne i32 %1, 0
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %4
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %6)
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %7)
+  store %System.String addrspace(1)* %8, %System.String addrspace(1)** %loc0
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.Text.StringBuilder addrspace(1)* %9, %System.Text.StringBuilder addrspace(1)** %loc1
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  store %System.String addrspace(1)* %10, %System.String addrspace(1)** %loc7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc7
+  %12 = ptrtoint %System.String addrspace(1)* %11 to i64
+  %13 = icmp eq i64 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %5
+  %15 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %16 = sext i32 %15 to i64
+  %17 = add i64 %12, %16
+  br label %18
+
+; <label>:18                                      ; preds = %5, %14
+  %19 = phi i64 [ %12, %5 ], [ %17, %14 ]
+  %20 = inttoptr i64 %19 to i16*
+  store i16* %20, i16** %loc2
+  br label %21
+
+; <label>:21                                      ; preds = %98, %18
+  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %22, null
+  br i1 %NullCheck, label %ThrowNullRef, label %23
+
+; <label>:23                                      ; preds = %21
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 3
+  %25 = load i32, i32 addrspace(1)* %24, align 8
+  %26 = icmp sle i32 %25, 0
+  br i1 %26, label %96, label %27
+
+; <label>:27                                      ; preds = %23
+  %28 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %28, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %29
+
+; <label>:29                                      ; preds = %27
+  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %28, i32 0, i32 1
+  %31 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %30, align 8
+  store %"System.Char[]" addrspace(1)* %31, %"System.Char[]" addrspace(1)** %loc3
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %33
+
+; <label>:33                                      ; preds = %29
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  store i32 %35, i32* %loc4
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  %39 = load i32, i32 addrspace(1)* %38, align 8
+  store i32 %39, i32* %loc5
+  %40 = load i32, i32* %loc5
+  %41 = load i32, i32* %loc4
+  %42 = add i32 %40, %41
+  %43 = zext i32 %42 to i64
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %45
+
+; <label>:45                                      ; preds = %37
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = sext i32 %47 to i64
+  %49 = icmp sgt i64 %43, %48
+  br i1 %49, label %91, label %50
+
+; <label>:50                                      ; preds = %45
+  %51 = load i32, i32* %loc5
+  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %52, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %53
+
+; <label>:53                                      ; preds = %50
+  %54 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %52, i32 0, i32 1
+  %55 = load i32, i32 addrspace(1)* %54
+  %56 = zext i32 %55 to i64
+  %57 = trunc i64 %56 to i32
+  %58 = icmp ugt i32 %51, %57
+  br i1 %58, label %91, label %59
+
+; <label>:59                                      ; preds = %53
+  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  store %"System.Char[]" addrspace(1)* %60, %"System.Char[]" addrspace(1)** %loc8
+  %61 = icmp eq %"System.Char[]" addrspace(1)* %60, null
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %63, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %64
+
+; <label>:64                                      ; preds = %62
+  %65 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %63, i32 0, i32 1
+  %66 = load i32, i32 addrspace(1)* %65
+  %67 = zext i32 %66 to i64
+  %68 = trunc i64 %67 to i32
+  %69 = icmp ne i32 %68, 0
+  br i1 %69, label %71, label %70
+
+; <label>:70                                      ; preds = %59, %64
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:71                                      ; preds = %64
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %73
+
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %BoundsCheck = icmp uge i64 0, %76
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %77
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %78, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:79                                      ; preds = %70, %77
+  %80 = load i16*, i16** %loc2
+  %81 = load i32, i32* %loc4
+  %82 = sext i32 %81 to i64
+  %83 = mul i64 %82, 2
+  %84 = bitcast i16* %80 to i8*
+  %85 = getelementptr inbounds i8, i8* %84, i64 %83
+  %86 = load i16 addrspace(1)*, i16 addrspace(1)** %loc6
+  %87 = ptrtoint i16 addrspace(1)* %86 to i64
+  %88 = load i32, i32* %loc5
+  %89 = bitcast i8* %85 to i16*
+  %90 = inttoptr i64 %87 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %89, i16* %90, i32 %88)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %96
+
+; <label>:91                                      ; preds = %45, %53
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %94 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %93)
+  %95 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95, %System.String addrspace(1)* %92, %System.String addrspace(1)* %94)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95) #0
+  unreachable
+
+; <label>:96                                      ; preds = %23, %79
+  %97 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %97, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %98
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %97, i32 0, i32 2
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  store %System.Text.StringBuilder addrspace(1)* %100, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %102 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %102, label %21, label %103
+
+; <label>:103                                     ; preds = %98
+  store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc7
+  %104 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  ret %System.String addrspace(1)* %104
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method StringBuilder::get_Length using LLILCJit
+Successfully read StringBuilder.get_Length
+
+define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
+Successfully read RuntimeHelpers.get_OffsetToStringData
+
+define i32 @RuntimeHelpers.get_OffsetToStringData() {
+entry:
+  ret i32 12
+}
+
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
 Successfully read CultureData.CreateCultureData
 
@@ -3514,23 +4249,23 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
   store i8 %4, i8 addrspace(1)* %6
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
@@ -3549,11 +4284,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3566,50 +4301,50 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
   store i32 -1, i32 addrspace(1)* %2
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
   store i32 -1, i32 addrspace(1)* %8
   %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
   store i32 -1, i32 addrspace(1)* %14
   %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
   store i32 -1, i32 addrspace(1)* %17
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
@@ -3623,27 +4358,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3675,7 +4410,136 @@ Failed to read Dictionary`2.Insert[non-const derefAddress]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
 Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
-Failed to read HashHelpers.GetPrime[loadElem]
+Successfully read HashHelpers.GetPrime
+
+define i32 @HashHelpers.GetPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %6, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5, %System.String addrspace(1)* %4)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5) #0
+  unreachable
+
+; <label>:6                                       ; preds = %entry
+  store i32 0, i32* %loc0
+  br label %29
+
+; <label>:7                                       ; preds = %35
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 1296
+  %10 = addrspacecast i8 addrspace(1)* %9 to %"System.Int32[]" addrspace(1)**
+  %11 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %10
+  %12 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Int32[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = zext i32 %15 to i64
+  %17 = zext i32 %12 to i64
+  %BoundsCheck = icmp uge i64 %17, %16
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 3, i32 %12
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  store i32 %20, i32* %loc1
+  %21 = load i32, i32* %loc1
+  %22 = load i32, i32* %arg0
+  %23 = icmp slt i32 %21, %22
+  br i1 %23, label %26, label %24
+
+; <label>:24                                      ; preds = %18
+  %25 = load i32, i32* %loc1
+  ret i32 %25
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %loc0
+  %28 = add i32 %27, 1
+  store i32 %28, i32* %loc0
+  br label %29
+
+; <label>:29                                      ; preds = %6, %26
+  %30 = load i32, i32* %loc0
+  %31 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %32 = getelementptr inbounds i8, i8 addrspace(1)* %31, i64 1296
+  %33 = addrspacecast i8 addrspace(1)* %32 to %"System.Int32[]" addrspace(1)**
+  %34 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %33
+  %NullCheck = icmp eq %"System.Int32[]" addrspace(1)* %34, null
+  br i1 %NullCheck, label %ThrowNullRef, label %35
+
+; <label>:35                                      ; preds = %29
+  %36 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %34, i32 0, i32 1
+  %37 = load i32, i32 addrspace(1)* %36
+  %38 = zext i32 %37 to i64
+  %39 = trunc i64 %38 to i32
+  %40 = icmp slt i32 %30, %39
+  br i1 %40, label %7, label %41
+
+; <label>:41                                      ; preds = %35
+  %42 = load i32, i32* %arg0
+  %43 = or i32 %42, 1
+  store i32 %43, i32* %loc2
+  br label %59
+
+; <label>:44                                      ; preds = %59
+  %45 = load i32, i32* %loc2
+  %46 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %45)
+  %47 = zext i8 %46 to i32
+  %48 = icmp eq i32 %47, 0
+  br i1 %48, label %56, label %49
+
+; <label>:49                                      ; preds = %44
+  %50 = load i32, i32* %loc2
+  %51 = sub i32 %50, 1
+  %52 = srem i32 %51, 101
+  %53 = icmp eq i32 %52, 0
+  br i1 %53, label %56, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = load i32, i32* %loc2
+  ret i32 %55
+
+; <label>:56                                      ; preds = %44, %49
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %57, 2
+  store i32 %58, i32* %loc2
+  br label %59
+
+; <label>:59                                      ; preds = %41, %56
+  %60 = load i32, i32* %loc2
+  %61 = icmp slt i32 %60, 2147483647
+  br i1 %61, label %44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load i32, i32* %arg0
+  ret i32 %63
+
+ThrowNullRef:                                     ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
 Successfully read GenericEqualityComparer`1.GetHashCode
 
@@ -3694,14 +4558,14 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
   %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load i64, i64 addrspace(1)* %7
@@ -3720,7 +4584,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3750,8 +4614,8 @@ entry:
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
@@ -3796,8 +4660,8 @@ entry:
   %35 = bitcast i16* %34 to i8*
   %36 = getelementptr inbounds i8, i8* %35, i64 2
   %37 = bitcast i8* %36 to i16*
-  %NullCheck4 = icmp ne i16* %37, null
-  br i1 %NullCheck4, label %38, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %37, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %38
 
 ; <label>:38                                      ; preds = %27
   %39 = load i16, i16* %37, align 8
@@ -3824,8 +4688,8 @@ entry:
 
 ; <label>:54                                      ; preds = %22, %43
   %55 = load i16*, i16** %loc4
-  %NullCheck2 = icmp ne i16* %55, null
-  br i1 %NullCheck2, label %56, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i16* %55, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %56
 
 ; <label>:56                                      ; preds = %54
   %57 = load i16, i16* %55, align 8
@@ -3850,11 +4714,11 @@ ThrowNullRef:                                     ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %54
+ThrowNullRef2:                                    ; preds = %54
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %27
+ThrowNullRef4:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3871,8 +4735,8 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -3907,8 +4771,8 @@ entry:
 
 ; <label>:26                                      ; preds = %19
   %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
-  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %28
 
 ; <label>:28                                      ; preds = %26
   %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
@@ -3920,7 +4784,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3972,8 +4836,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
@@ -3984,26 +4848,26 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
-  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
@@ -4014,8 +4878,8 @@ entry:
 ; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
@@ -4024,8 +4888,8 @@ entry:
 
 ; <label>:25                                      ; preds = %1, %16, %23
   %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
-  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
@@ -4036,27 +4900,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %20
+ThrowNullRef10:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4069,8 +4933,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -4081,8 +4945,8 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
@@ -4091,8 +4955,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1, %8
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
@@ -4103,11 +4967,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4128,24 +4992,24 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   store i32 %3, i32* %loc0
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
   %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
   store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck4, label %9, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
@@ -4164,15 +5028,15 @@ entry:
 ; <label>:18                                      ; preds = %70
   %19 = load i16*, i16** %loc3
   %20 = bitcast i16* %19 to i64*
-  %NullCheck10 = icmp ne i64* %20, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %20, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = load i64, i64* %20, align 8
   %23 = load i16*, i16** %loc4
   %24 = bitcast i16* %23 to i64*
-  %NullCheck12 = icmp ne i64* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = load i64, i64* %24, align 8
@@ -4188,8 +5052,8 @@ entry:
   %31 = bitcast i16* %30 to i8*
   %32 = getelementptr inbounds i8, i8* %31, i64 8
   %33 = bitcast i8* %32 to i64*
-  %NullCheck14 = icmp ne i64* %33, null
-  br i1 %NullCheck14, label %34, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = load i64, i64* %33, align 8
@@ -4197,8 +5061,8 @@ entry:
   %37 = bitcast i16* %36 to i8*
   %38 = getelementptr inbounds i8, i8* %37, i64 8
   %39 = bitcast i8* %38 to i64*
-  %NullCheck16 = icmp ne i64* %39, null
-  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %40
 
 ; <label>:40                                      ; preds = %34
   %41 = load i64, i64* %39, align 8
@@ -4214,8 +5078,8 @@ entry:
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %NullCheck18 = icmp ne i64* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = load i64, i64* %48, align 8
@@ -4223,8 +5087,8 @@ entry:
   %52 = bitcast i16* %51 to i8*
   %53 = getelementptr inbounds i8, i8* %52, i64 16
   %54 = bitcast i8* %53 to i64*
-  %NullCheck20 = icmp ne i64* %54, null
-  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64* %54, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %55
 
 ; <label>:55                                      ; preds = %49
   %56 = load i64, i64* %54, align 8
@@ -4262,15 +5126,15 @@ entry:
 ; <label>:74                                      ; preds = %95
   %75 = load i16*, i16** %loc3
   %76 = bitcast i16* %75 to i32*
-  %NullCheck6 = icmp ne i32* %76, null
-  br i1 %NullCheck6, label %77, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32* %76, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %77
 
 ; <label>:77                                      ; preds = %74
   %78 = load i32, i32* %76, align 8
   %79 = load i16*, i16** %loc4
   %80 = bitcast i16* %79 to i32*
-  %NullCheck8 = icmp ne i32* %80, null
-  br i1 %NullCheck8, label %81, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i32* %80, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %81
 
 ; <label>:81                                      ; preds = %77
   %82 = load i32, i32* %80, align 8
@@ -4318,43 +5182,43 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %74
+ThrowNullRef6:                                    ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %77
+ThrowNullRef8:                                    ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %29
+ThrowNullRef14:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %34
+ThrowNullRef16:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4376,8 +5240,8 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load i64, i64 addrspace(1)* %4
@@ -4389,8 +5253,8 @@ entry:
   %12 = load i64, i64* %11
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %5
   %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
@@ -4399,8 +5263,8 @@ entry:
   %18 = load i8, i8* %arg2
   %19 = zext i8 %18 to i32
   %20 = trunc i32 %19 to i8
-  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %15
   %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
@@ -4411,11 +5275,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4442,8 +5306,8 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
@@ -4466,16 +5330,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
   %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = load i64, i64 addrspace(1)* %19
@@ -4500,8 +5364,8 @@ entry:
 ; <label>:35                                      ; preds = %30
   %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
@@ -4514,8 +5378,8 @@ entry:
 
 ; <label>:42                                      ; preds = %1, %38
   %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
-  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
@@ -4526,19 +5390,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %35
+ThrowNullRef2:                                    ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %42
+ThrowNullRef8:                                    ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4551,14 +5415,14 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
@@ -4570,7 +5434,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4583,8 +5447,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
@@ -4613,51 +5477,51 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
   %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
   %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
   %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
   %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
-  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
   store i64 %21, i64 addrspace(1)* %23
   %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %25 = load i64, i64* %loc0
-  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
@@ -4668,27 +5532,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %22
+ThrowNullRef12:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4701,8 +5565,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
@@ -4713,19 +5577,19 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
@@ -4734,8 +5598,8 @@ entry:
 
 ; <label>:15                                      ; preds = %1, %13
   %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
@@ -4746,19 +5610,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %15
+ThrowNullRef8:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4771,8 +5635,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -4831,8 +5695,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
@@ -4882,8 +5746,8 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
-  br i1 %NullCheck, label %17, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %ThrowNullRef, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
@@ -4894,15 +5758,15 @@ entry:
 
 ; <label>:22                                      ; preds = %17
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
-  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
   %26 = load i32, i32 addrspace(1)* %25
   %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
-  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %27, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
@@ -4925,8 +5789,8 @@ entry:
 ; <label>:40                                      ; preds = %17
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
-  br i1 %NullCheck6, label %43, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %41, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
@@ -4938,34 +5802,17 @@ ThrowNullRef:                                     ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %24
+ThrowNullRef4:                                    ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %40
+ThrowNullRef6:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
-}
-
-INFO:  jitting method Object::ReferenceEquals using LLILCJit
-Successfully read Object.ReferenceEquals
-
-define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
-entry:
-  %arg0 = alloca %System.Object addrspace(1)*
-  %arg1 = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
-  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
-  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = icmp eq %System.Object addrspace(1)* %0, %1
-  %3 = sext i1 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
 }
 
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
@@ -4978,21 +5825,21 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
   %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
-  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
@@ -5007,28 +5854,28 @@ entry:
 ; <label>:13                                      ; preds = %8, %12
   %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
   %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
   %21 = load i32, i32 addrspace(1)* %20, align 8
   %22 = add i32 %21, 1
-  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
   store i32 %22, i32 addrspace(1)* %24
   %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
@@ -5039,27 +5886,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5077,7 +5924,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::Setup using LLILCJit
-Failed to read AppDomain.Setup[loadElem]
+Failed to read AppDomain.Setup[unbox]
 INFO:  jitting method Thread::GetDomain using LLILCJit
 Successfully read Thread.GetDomain
 
@@ -5108,8 +5955,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
@@ -5122,14 +5969,14 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
   %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
@@ -5141,11 +5988,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5173,8 +6020,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -5189,7 +6036,328 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
 Failed to read KeyCollection.System.Collections.Generic.IEnumerable<TKey>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Successfully read Enumerator.MoveNext
+
+define i8 @Enumerator.MoveNext(%"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.RuntimeTypeHandle* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*
+  %"$TypeArg" = alloca %System.RuntimeTypeHandle*
+  store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
+  %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 8
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %76, label %12
+
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
+  br label %76
+
+; <label>:13                                      ; preds = %85
+  %14 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck19 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %15
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, i32 0, i32 0
+  %17 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %16, align 8
+  %NullCheck21 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, i32 0, i32 2
+  %20 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %19, align 8
+  %21 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck23 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %22
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, i32 0, i32 2
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %NullCheck25 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 3, i32 %24
+  %NullCheck27 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %32
+
+; <label>:32                                      ; preds = %30
+  %33 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, i32 0, i32 2
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = icmp slt i32 %34, 0
+  br i1 %35, label %68, label %36
+
+; <label>:36                                      ; preds = %32
+  %37 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %38 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck29 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %39
+
+; <label>:39                                      ; preds = %36
+  %40 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, i32 0, i32 0
+  %41 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %40, align 8
+  %NullCheck31 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, i32 0, i32 2
+  %44 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %43, align 8
+  %45 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck33 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, i32 0, i32 2
+  %48 = load i32, i32 addrspace(1)* %47, align 8
+  %NullCheck35 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %49
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = zext i32 %51 to i64
+  %53 = zext i32 %48 to i64
+  %BoundsCheck37 = icmp uge i64 %53, %52
+  br i1 %BoundsCheck37, label %ThrowIndexOutOfRange38, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 3, i32 %48
+  %NullCheck39 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %56
+
+; <label>:56                                      ; preds = %54
+  %57 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, i32 0, i32 0
+  %58 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck41 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %59
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %60, %System.__Canon addrspace(1)* %58)
+  %61 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck43 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  %64 = load i32, i32 addrspace(1)* %63, align 8
+  %65 = add i32 %64, 1
+  %NullCheck45 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  store i32 %65, i32 addrspace(1)* %67
+  ret i8 1
+
+; <label>:68                                      ; preds = %32
+  %69 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck47 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %73 = add i32 %72, 1
+  %NullCheck49 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %74
+
+; <label>:74                                      ; preds = %70
+  %75 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  store i32 %73, i32 addrspace(1)* %75
+  br label %76
+
+; <label>:76                                      ; preds = %8, %12, %74
+  %77 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %78
+
+; <label>:78                                      ; preds = %76
+  %79 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, i32 0, i32 2
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck7 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %82
+
+; <label>:82                                      ; preds = %78
+  %83 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, i32 0, i32 0
+  %84 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %83, align 8
+  %NullCheck9 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %85
+
+; <label>:85                                      ; preds = %82
+  %86 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, i32 0, i32 7
+  %87 = load i32, i32 addrspace(1)* %86, align 8
+  %88 = icmp ult i32 %80, %87
+  br i1 %88, label %13, label %89
+
+; <label>:89                                      ; preds = %85
+  %90 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %91 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck11 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %92
+
+; <label>:92                                      ; preds = %89
+  %93 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, i32 0, i32 0
+  %94 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck13 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %95
+
+; <label>:95                                      ; preds = %92
+  %96 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, i32 0, i32 7
+  %97 = load i32, i32 addrspace(1)* %96, align 8
+  %98 = add i32 %97, 1
+  %NullCheck15 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %99
+
+; <label>:99                                      ; preds = %95
+  %100 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, i32 0, i32 2
+  store i32 %98, i32 addrspace(1)* %100
+  %101 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck17 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %102
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %103, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %92
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef22:                                   ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef24:                                   ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef26:                                   ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef28:                                   ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef30:                                   ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef32:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef34:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef36:                                   ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange38:                           ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef40:                                   ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef42:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef44:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef46:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef48:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef50:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -5200,8 +6368,8 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -5232,9 +6400,9 @@ Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
 Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
-Failed to read String.MakeSeparatorList[loadElemA]
+Failed to read String.MakeSeparatorList[storeElem]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
-Failed to read String.InternalSplitKeepEmptyEntries[loadElem]
+Failed to read String.InternalSplitKeepEmptyEntries[storeElem]
 INFO:  jitting method Path::IsRelative using LLILCJit
 Successfully read Path.IsRelative
 
@@ -5243,8 +6411,8 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -5254,8 +6422,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
@@ -5271,8 +6439,8 @@ entry:
 
 ; <label>:17                                      ; preds = %7
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
@@ -5288,8 +6456,8 @@ entry:
 
 ; <label>:29                                      ; preds = %19
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %31
 
 ; <label>:31                                      ; preds = %29
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
@@ -5300,8 +6468,8 @@ entry:
 
 ; <label>:36                                      ; preds = %31
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
-  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %37, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
@@ -5312,8 +6480,8 @@ entry:
 
 ; <label>:43                                      ; preds = %31, %38
   %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
-  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %45
 
 ; <label>:45                                      ; preds = %43
   %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
@@ -5324,8 +6492,8 @@ entry:
 
 ; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %50
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
@@ -5336,8 +6504,8 @@ entry:
 
 ; <label>:57                                      ; preds = %1, %7, %19, %45, %52
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
-  br i1 %NullCheck14, label %59, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %59
 
 ; <label>:59                                      ; preds = %57
   %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
@@ -5347,8 +6515,8 @@ entry:
 
 ; <label>:63                                      ; preds = %59
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
@@ -5359,8 +6527,8 @@ entry:
 
 ; <label>:70                                      ; preds = %65
   %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
-  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.String addrspace(1)* %71, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %72
 
 ; <label>:72                                      ; preds = %70
   %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
@@ -5379,39 +6547,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %17
+ThrowNullRef4:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %29
+ThrowNullRef6:                                    ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %36
+ThrowNullRef8:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %43
+ThrowNullRef10:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %50
+ThrowNullRef12:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %57
+ThrowNullRef14:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %63
+ThrowNullRef16:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %70
+ThrowNullRef18:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5419,7 +6587,293 @@ ThrowNullRef17:                                   ; preds = %70
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
-Failed to read String.TrimHelper[loadElem]
+Successfully read String.TrimHelper
+
+define %System.String addrspace(1)* @String.TrimHelper(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i16
+  %loc4 = alloca i32
+  %loc5 = alloca i16
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = sub i32 %3, 1
+  store i32 %4, i32* %loc0
+  store i32 0, i32* %loc1
+  %5 = load i32, i32* %arg2
+  %6 = icmp eq i32 %5, 1
+  br i1 %6, label %62, label %7
+
+; <label>:7                                       ; preds = %1
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:8                                       ; preds = %58
+  store i32 0, i32* %loc2
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load i32, i32* %loc1
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2, i32 %10
+  %13 = load i16, i16 addrspace(1)* %12
+  %14 = zext i16 %13 to i32
+  %15 = trunc i32 %14 to i16
+  store i16 %15, i16* %loc3
+  store i32 0, i32* %loc2
+  br label %34
+
+; <label>:16                                      ; preds = %37
+  %17 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %18 = load i32, i32* %loc2
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %17, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %19
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = zext i32 %18 to i64
+  %BoundsCheck = icmp uge i64 %23, %22
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %24
+
+; <label>:24                                      ; preds = %19
+  %25 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 3, i32 %18
+  %26 = load i16, i16 addrspace(1)* %25, align 8
+  %27 = zext i16 %26 to i32
+  %28 = load i16, i16* %loc3
+  %29 = zext i16 %28 to i32
+  %30 = icmp eq i32 %27, %29
+  br i1 %30, label %43, label %31
+
+; <label>:31                                      ; preds = %24
+  %32 = load i32, i32* %loc2
+  %33 = add i32 %32, 1
+  store i32 %33, i32* %loc2
+  br label %34
+
+; <label>:34                                      ; preds = %11, %31
+  %35 = load i32, i32* %loc2
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = icmp slt i32 %35, %41
+  br i1 %42, label %16, label %43
+
+; <label>:43                                      ; preds = %24, %37
+  %44 = load i32, i32* %loc2
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %45, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp eq i32 %44, %50
+  br i1 %51, label %62, label %52
+
+; <label>:52                                      ; preds = %46
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %7, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %57, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %58
+
+; <label>:58                                      ; preds = %55
+  %59 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %60 = load i32, i32 addrspace(1)* %59
+  %61 = icmp slt i32 %56, %60
+  br i1 %61, label %8, label %62
+
+; <label>:62                                      ; preds = %1, %46, %58
+  %63 = load i32, i32* %arg2
+  %64 = icmp eq i32 %63, 0
+  br i1 %64, label %122, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %66, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %67
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %66, i32 0, i32 1
+  %69 = load i32, i32 addrspace(1)* %68
+  %70 = sub i32 %69, 1
+  store i32 %70, i32* %loc0
+  br label %118
+
+; <label>:71                                      ; preds = %118
+  store i32 0, i32* %loc4
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %73 = load i32, i32* %loc0
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %74
+
+; <label>:74                                      ; preds = %71
+  %75 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 2, i32 %73
+  %76 = load i16, i16 addrspace(1)* %75
+  %77 = zext i16 %76 to i32
+  %78 = trunc i32 %77 to i16
+  store i16 %78, i16* %loc5
+  store i32 0, i32* %loc4
+  br label %97
+
+; <label>:79                                      ; preds = %100
+  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %81 = load i32, i32* %loc4
+  %NullCheck19 = icmp eq %"System.Char[]" addrspace(1)* %80, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
+
+; <label>:82                                      ; preds = %79
+  %83 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 1
+  %84 = load i32, i32 addrspace(1)* %83
+  %85 = zext i32 %84 to i64
+  %86 = zext i32 %81 to i64
+  %BoundsCheck21 = icmp uge i64 %86, %85
+  br i1 %BoundsCheck21, label %ThrowIndexOutOfRange22, label %87
+
+; <label>:87                                      ; preds = %82
+  %88 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 3, i32 %81
+  %89 = load i16, i16 addrspace(1)* %88, align 8
+  %90 = zext i16 %89 to i32
+  %91 = load i16, i16* %loc5
+  %92 = zext i16 %91 to i32
+  %93 = icmp eq i32 %90, %92
+  br i1 %93, label %106, label %94
+
+; <label>:94                                      ; preds = %87
+  %95 = load i32, i32* %loc4
+  %96 = add i32 %95, 1
+  store i32 %96, i32* %loc4
+  br label %97
+
+; <label>:97                                      ; preds = %74, %94
+  %98 = load i32, i32* %loc4
+  %99 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck15 = icmp eq %"System.Char[]" addrspace(1)* %99, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %100
+
+; <label>:100                                     ; preds = %97
+  %101 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %99, i32 0, i32 1
+  %102 = load i32, i32 addrspace(1)* %101
+  %103 = zext i32 %102 to i64
+  %104 = trunc i64 %103 to i32
+  %105 = icmp slt i32 %98, %104
+  br i1 %105, label %79, label %106
+
+; <label>:106                                     ; preds = %87, %100
+  %107 = load i32, i32* %loc4
+  %108 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck17 = icmp eq %"System.Char[]" addrspace(1)* %108, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %109
+
+; <label>:109                                     ; preds = %106
+  %110 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %108, i32 0, i32 1
+  %111 = load i32, i32 addrspace(1)* %110
+  %112 = zext i32 %111 to i64
+  %113 = trunc i64 %112 to i32
+  %114 = icmp eq i32 %107, %113
+  br i1 %114, label %122, label %115
+
+; <label>:115                                     ; preds = %109
+  %116 = load i32, i32* %loc0
+  %117 = sub i32 %116, 1
+  store i32 %117, i32* %loc0
+  br label %118
+
+; <label>:118                                     ; preds = %67, %115
+  %119 = load i32, i32* %loc0
+  %120 = load i32, i32* %loc1
+  %121 = icmp sge i32 %119, %120
+  br i1 %121, label %71, label %122
+
+; <label>:122                                     ; preds = %62, %109, %118
+  %123 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %124 = load i32, i32* %loc1
+  %125 = load i32, i32* %loc0
+  %126 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %123, i32 %124, i32 %125)
+  ret %System.String addrspace(1)* %126
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %97
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange22:                           ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
 Successfully read String.CreateTrimmedString
 
@@ -5439,8 +6893,8 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
@@ -5535,8 +6989,8 @@ entry:
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i64 2872
   %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
   %8 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %7
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %3
   %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
@@ -5553,8 +7007,8 @@ entry:
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 2864
   %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
   %21 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %20
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
-  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %22
 
 ; <label>:22                                      ; preds = %16
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
@@ -5569,7 +7023,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %16
+ThrowNullRef2:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5586,8 +7040,8 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5613,8 +7067,8 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
@@ -5632,8 +7086,8 @@ entry:
 
 ; <label>:12                                      ; preds = %4
   %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
@@ -5644,8 +7098,8 @@ entry:
 
 ; <label>:19                                      ; preds = %14
   %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %19
   %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
@@ -5660,21 +7114,21 @@ entry:
   %31 = zext i16 %30 to i32
   %32 = bitcast i8* %29 to i16*
   %33 = trunc i32 %31 to i16
-  %NullCheck6 = icmp ne i16* %32, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i16* %32, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %21
   store i16 %33, i16* %32, align 8
   %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %36
 
 ; <label>:36                                      ; preds = %34
   %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
   %38 = load i32, i32 addrspace(1)* %37, align 8
   %39 = add i32 %38, 1
-  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %40
 
 ; <label>:40                                      ; preds = %36
   %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
@@ -5683,16 +7137,16 @@ entry:
 
 ; <label>:42                                      ; preds = %14
   %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
-  br i1 %NullCheck12, label %44, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
   %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
   %47 = load i16, i16* %arg1
   %48 = zext i16 %47 to i32
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = trunc i32 %48 to i16
@@ -5703,31 +7157,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %19
+ThrowNullRef4:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %21
+ThrowNullRef6:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %36
+ThrowNullRef10:                                   ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %42
+ThrowNullRef12:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %44
+ThrowNullRef14:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5740,8 +7194,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -5752,8 +7206,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
@@ -5762,14 +7216,14 @@ entry:
 
 ; <label>:11                                      ; preds = %1
   %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
@@ -5779,15 +7233,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5808,8 +7262,8 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5822,8 +7276,8 @@ entry:
 
 ; <label>:8                                       ; preds = %3
   %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
@@ -5842,15 +7296,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
-  br i1 %NullCheck4, label %22, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
   %24 = load i16*, i16* addrspace(1)* %23, align 8
   %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %25, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
@@ -5859,8 +7313,8 @@ entry:
   store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
@@ -5874,8 +7328,8 @@ entry:
 
 ; <label>:37                                      ; preds = %65
   %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %37
   %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
@@ -5886,16 +7340,16 @@ entry:
   %45 = bitcast i16* %41 to i8*
   %46 = getelementptr inbounds i8, i8* %45, i64 %44
   %47 = bitcast i8* %46 to i16*
-  %NullCheck14 = icmp ne i16* %47, null
-  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %47, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %48
 
 ; <label>:48                                      ; preds = %39
   %49 = load i16, i16* %47, align 8
   %50 = zext i16 %49 to i32
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %52 = load i32, i32* %loc1
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %53
 
 ; <label>:53                                      ; preds = %48
   %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
@@ -5916,8 +7370,8 @@ entry:
 ; <label>:62                                      ; preds = %36, %59
   %63 = load i32, i32* %loc1
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck10, label %65, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %65
 
 ; <label>:65                                      ; preds = %62
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
@@ -5936,15 +7390,15 @@ entry:
 
 ; <label>:74                                      ; preds = %70
   %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
-  br i1 %NullCheck18, label %76, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %76
 
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
   %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
-  br i1 %NullCheck20, label %80, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
   %81 = load i64, i64 addrspace(1)* %79
@@ -5958,8 +7412,8 @@ entry:
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
   %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
-  br i1 %NullCheck22, label %92, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.String addrspace(1)* %90, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %92
 
 ; <label>:92                                      ; preds = %80
   %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
@@ -5969,15 +7423,15 @@ entry:
 
 ; <label>:96                                      ; preds = %70
   %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
-  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %98
 
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
   %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
-  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
   %103 = load i64, i64 addrspace(1)* %101
@@ -5991,8 +7445,8 @@ entry:
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
   %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
-  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.String addrspace(1)* %112, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %114
 
 ; <label>:114                                     ; preds = %102
   %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
@@ -6004,59 +7458,59 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %20
+ThrowNullRef4:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %22
+ThrowNullRef6:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %26
+ThrowNullRef8:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %62
+ThrowNullRef10:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %48
+ThrowNullRef16:                                   ; preds = %48
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %74
+ThrowNullRef18:                                   ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %76
+ThrowNullRef20:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %80
+ThrowNullRef22:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %96
+ThrowNullRef24:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %98
+ThrowNullRef26:                                   ; preds = %98
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %102
+ThrowNullRef28:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6069,15 +7523,15 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
   %3 = load i16*, i16* addrspace(1)* %2, align 8
   %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
@@ -6087,8 +7541,8 @@ entry:
   %10 = bitcast i16* %3 to i8*
   %11 = getelementptr inbounds i8, i8* %10, i64 %9
   %12 = bitcast i8* %11 to i16*
-  %NullCheck4 = icmp ne i16* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %5
   store i16 0, i16* %12, align 8
@@ -6098,11 +7552,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6119,8 +7573,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -6131,8 +7585,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
@@ -6144,15 +7598,15 @@ entry:
 
 ; <label>:14                                      ; preds = %1
   %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
   %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
   %21 = load i64, i64 addrspace(1)* %19
@@ -6171,15 +7625,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %14
+ThrowNullRef4:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %16
+ThrowNullRef6:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6302,14 +7756,6 @@ entry:
   ret %System.String addrspace(1)* %57
 }
 
-INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
-Successfully read RuntimeHelpers.get_OffsetToStringData
-
-define i32 @RuntimeHelpers.get_OffsetToStringData() {
-entry:
-  ret i32 12
-}
-
 INFO:  jitting method String::Equals using LLILCJit
 Successfully read String.Equals
 
@@ -6381,8 +7827,8 @@ entry:
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
-  br i1 %NullCheck24, label %29, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
   %30 = load i64, i64 addrspace(1)* %28
@@ -6397,8 +7843,8 @@ entry:
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
-  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
   %43 = load i64, i64 addrspace(1)* %41
@@ -6418,8 +7864,8 @@ entry:
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
   %59 = load i64, i64 addrspace(1)* %57
@@ -6434,8 +7880,8 @@ entry:
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck22, label %71, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
   %72 = load i64, i64 addrspace(1)* %70
@@ -6455,8 +7901,8 @@ entry:
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
-  br i1 %NullCheck16, label %87, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = load i64, i64 addrspace(1)* %86
@@ -6471,8 +7917,8 @@ entry:
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck18, label %100, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
   %101 = load i64, i64 addrspace(1)* %99
@@ -6492,8 +7938,8 @@ entry:
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
-  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
   %117 = load i64, i64 addrspace(1)* %115
@@ -6508,8 +7954,8 @@ entry:
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
-  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
   %130 = load i64, i64 addrspace(1)* %128
@@ -6528,15 +7974,15 @@ entry:
 
 ; <label>:142                                     ; preds = %22
   %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
-  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %143, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %144
 
 ; <label>:144                                     ; preds = %142
   %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
   %146 = load i32, i32 addrspace(1)* %145
   %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
-  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %147, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %148
 
 ; <label>:148                                     ; preds = %144
   %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
@@ -6557,15 +8003,15 @@ entry:
 
 ; <label>:159                                     ; preds = %22
   %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
-  br i1 %NullCheck, label %161, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %ThrowNullRef, label %161
 
 ; <label>:161                                     ; preds = %159
   %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
   %163 = load i32, i32 addrspace(1)* %162
   %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
-  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %164, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %165
 
 ; <label>:165                                     ; preds = %161
   %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
@@ -6578,8 +8024,8 @@ entry:
 
 ; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
-  br i1 %NullCheck4, label %172, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %171, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %172
 
 ; <label>:172                                     ; preds = %170
   %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
@@ -6589,8 +8035,8 @@ entry:
 
 ; <label>:176                                     ; preds = %172
   %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
-  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %177, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %178
 
 ; <label>:178                                     ; preds = %176
   %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
@@ -6629,55 +8075,55 @@ ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %161
+ThrowNullRef2:                                    ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %170
+ThrowNullRef4:                                    ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %176
+ThrowNullRef6:                                    ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %142
+ThrowNullRef8:                                    ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %144
+ThrowNullRef10:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %113
+ThrowNullRef12:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %116
+ThrowNullRef14:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %84
+ThrowNullRef16:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %87
+ThrowNullRef18:                                   ; preds = %87
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %55
+ThrowNullRef20:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %58
+ThrowNullRef22:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %26
+ThrowNullRef24:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %29
+ThrowNullRef26:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,8 +8161,8 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck, label %14, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %ThrowNullRef, label %14
 
 ; <label>:14                                      ; preds = %8
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
@@ -6760,8 +8206,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
@@ -6770,14 +8216,14 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32, i32* %loc0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %10
   %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
   %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
@@ -6790,15 +8236,15 @@ entry:
 ; <label>:25                                      ; preds = %19
   %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
-  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
   %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
@@ -6807,8 +8253,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %37 = load i32, i32* %loc0
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %38, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %38
 
 ; <label>:38                                      ; preds = %32
   %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
@@ -6817,14 +8263,14 @@ entry:
 
 ; <label>:40                                      ; preds = %19
   %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %40
   %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
   %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
-  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
-  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
@@ -6832,8 +8278,8 @@ entry:
   %48 = zext i32 %47 to i64
   %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
-  br i1 %NullCheck16, label %51, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %51
 
 ; <label>:51                                      ; preds = %45
   %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
@@ -6847,15 +8293,15 @@ entry:
 ; <label>:57                                      ; preds = %51
   %58 = load i16*, i16** %arg1
   %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
-  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %60
 
 ; <label>:60                                      ; preds = %57
   %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
   %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
-  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %64
 
 ; <label>:64                                      ; preds = %60
   %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
@@ -6864,22 +8310,22 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
   %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
-  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %70
 
 ; <label>:70                                      ; preds = %64
   %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
   %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
-  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
-  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
   %75 = load i32, i32 addrspace(1)* %74
   %76 = zext i32 %75 to i64
   %77 = trunc i64 %76 to i32
-  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
-  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %78
 
 ; <label>:78                                      ; preds = %73
   %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
@@ -6901,8 +8347,8 @@ entry:
   %90 = bitcast i16* %86 to i8*
   %91 = getelementptr inbounds i8, i8* %90, i64 %89
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %93
 
 ; <label>:93                                      ; preds = %80
   %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
@@ -6912,8 +8358,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %99 = load i32, i32* %loc2
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %100
 
 ; <label>:100                                     ; preds = %93
   %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
@@ -6928,63 +8374,63 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %25
+ThrowNullRef6:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %32
+ThrowNullRef10:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %40
+ThrowNullRef12:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %45
+ThrowNullRef16:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %57
+ThrowNullRef18:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %60
+ThrowNullRef20:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %64
+ThrowNullRef22:                                   ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %70
+ThrowNullRef24:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %73
+ThrowNullRef26:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %80
+ThrowNullRef28:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %93
+ThrowNullRef30:                                   ; preds = %93
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7004,8 +8450,8 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
@@ -7033,43 +8479,43 @@ entry:
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %14
   %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
   %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   %28 = load i32, i32 addrspace(1)* %27, align 8
   %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
-  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %30
 
 ; <label>:30                                      ; preds = %26
   %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
   %32 = load i32, i32 addrspace(1)* %31, align 8
   %33 = add i32 %28, %32
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %34
 
 ; <label>:34                                      ; preds = %30
   %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   store i32 %33, i32 addrspace(1)* %35
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
   store i32 0, i32 addrspace(1)* %38
   %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %40
 
 ; <label>:40                                      ; preds = %37
   %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
@@ -7082,8 +8528,8 @@ entry:
 
 ; <label>:47                                      ; preds = %40
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
@@ -7098,8 +8544,8 @@ entry:
   %54 = load i32, i32* %loc0
   %55 = sext i32 %54 to i64
   %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
-  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %57
 
 ; <label>:57                                      ; preds = %52
   %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
@@ -7110,68 +8556,35 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %14
+ThrowNullRef2:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %23
+ThrowNullRef4:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %26
+ThrowNullRef6:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %30
+ThrowNullRef8:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %34
+ThrowNullRef10:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %47
+ThrowNullRef14:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %52
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-}
-
-INFO:  jitting method StringBuilder::get_Length using LLILCJit
-Successfully read StringBuilder.get_Length
-
-define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.StringBuilder addrspace(1)*
-  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
-  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
-
-; <label>:1                                       ; preds = %entry
-  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %3 = load i32, i32 addrspace(1)* %2, align 8
-  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
-
-; <label>:5                                       ; preds = %1
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = add i32 %3, %7
-  ret i32 %8
-
-ThrowNullRef:                                     ; preds = %entry
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef16:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7213,70 +8626,70 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
   %6 = load i32, i32 addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
   store i32 %6, i32 addrspace(1)* %8
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
   %13 = load i32, i32 addrspace(1)* %12, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
   store i32 %13, i32 addrspace(1)* %15
   %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
-  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %18
 
 ; <label>:18                                      ; preds = %14
   %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
   %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
   %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
   %34 = load i32, i32 addrspace(1)* %33, align 8
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
-  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
@@ -7287,39 +8700,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %28
+ThrowNullRef16:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %32
+ThrowNullRef18:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7455,13 +8868,13 @@ entry:
 ; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
@@ -7477,16 +8890,16 @@ entry:
 
 ; <label>:18                                      ; preds = %15
   %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
   store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
   %22 = load i32, i32* %loc0
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %24
 
 ; <label>:24                                      ; preds = %20
   %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
@@ -7498,13 +8911,13 @@ entry:
 ; <label>:28                                      ; preds = %15, %24
   %29 = load i32, i32* %arg1
   %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %31
   %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
@@ -7517,20 +8930,20 @@ entry:
   %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
-  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
   %46 = load i32, i32 addrspace(1)* %45, align 8
   %47 = sub i32 %40, %46
-  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
-  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i32 addrspace(1)* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %48
 
 ; <label>:48                                      ; preds = %44
   store i32 %47, i32 addrspace(1)* %39, align 8
@@ -7538,21 +8951,21 @@ entry:
 
 ; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
-  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %51
 
 ; <label>:51                                      ; preds = %49
   %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %53
 
 ; <label>:53                                      ; preds = %51
   %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
   %55 = load i32, i32 addrspace(1)* %54, align 8
   %56 = load i32, i32* %arg2
   %57 = sub i32 %55, %56
-  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %58
 
 ; <label>:58                                      ; preds = %53
   %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
@@ -7562,13 +8975,13 @@ entry:
 ; <label>:60                                      ; preds = %33, %58
   %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
   %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
-  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %63
 
 ; <label>:63                                      ; preds = %60
   %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
-  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
-  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
@@ -7578,15 +8991,15 @@ entry:
 
 ; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
-  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i32 addrspace(1)* %69, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %70
 
 ; <label>:70                                      ; preds = %68
   %71 = load i32, i32 addrspace(1)* %69, align 8
   store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
-  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
@@ -7596,8 +9009,8 @@ entry:
   store i32 %77, i32* %loc4
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
-  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %80
 
 ; <label>:80                                      ; preds = %73
   %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
@@ -7607,71 +9020,71 @@ entry:
 ; <label>:83                                      ; preds = %80
   store i32 0, i32* %loc3
   %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
-  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
-  br i1 %NullCheck26, label %88, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i32 addrspace(1)* %87, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %88
 
 ; <label>:88                                      ; preds = %85
   %89 = load i32, i32 addrspace(1)* %87, align 8
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
-  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %90
 
 ; <label>:90                                      ; preds = %88
   %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
   store i32 %89, i32 addrspace(1)* %91
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
-  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
-  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %96
 
 ; <label>:96                                      ; preds = %94
   %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
-  br i1 %NullCheck34, label %100, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %100
 
 ; <label>:100                                     ; preds = %96
   %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
-  br i1 %NullCheck36, label %102, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %102
 
 ; <label>:102                                     ; preds = %100
   %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
   %104 = load i32, i32 addrspace(1)* %103, align 8
   %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
-  br i1 %NullCheck38, label %106, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %106
 
 ; <label>:106                                     ; preds = %102
   %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
-  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
-  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %108
 
 ; <label>:108                                     ; preds = %106
   %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
   %110 = load i32, i32 addrspace(1)* %109, align 8
   %111 = add i32 %104, %110
-  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %112
 
 ; <label>:112                                     ; preds = %108
   %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
   store i32 %111, i32 addrspace(1)* %113
   %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
-  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i32 addrspace(1)* %114, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %115
 
 ; <label>:115                                     ; preds = %112
   %116 = load i32, i32 addrspace(1)* %114, align 8
@@ -7681,19 +9094,19 @@ entry:
 ; <label>:118                                     ; preds = %115
   %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
-  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %121
 
 ; <label>:121                                     ; preds = %118
   %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
-  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
-  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %123
 
 ; <label>:123                                     ; preds = %121
   %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
   %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
-  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
-  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %126
 
 ; <label>:126                                     ; preds = %123
   %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
@@ -7705,8 +9118,8 @@ entry:
 
 ; <label>:130                                     ; preds = %80, %115, %126
   %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %132
 
 ; <label>:132                                     ; preds = %130
   %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7715,8 +9128,8 @@ entry:
   %136 = load i32, i32* %loc3
   %137 = sub i32 %135, %136
   %138 = sub i32 %134, %137
-  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %139
 
 ; <label>:139                                     ; preds = %132
   %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7728,16 +9141,16 @@ entry:
 
 ; <label>:144                                     ; preds = %139
   %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
-  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %146
 
 ; <label>:146                                     ; preds = %144
   %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
   %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
   %149 = load i32, i32* %loc2
   %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
-  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %151
 
 ; <label>:151                                     ; preds = %146
   %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
@@ -7754,145 +9167,249 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %18
+ThrowNullRef4:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %31
+ThrowNullRef10:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %44
+ThrowNullRef16:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %68
+ThrowNullRef18:                                   ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %70
+ThrowNullRef20:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %73
+ThrowNullRef22:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %83
+ThrowNullRef24:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %85
+ThrowNullRef26:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %88
+ThrowNullRef28:                                   ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %90
+ThrowNullRef30:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %94
+ThrowNullRef32:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %96
+ThrowNullRef34:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %100
+ThrowNullRef36:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %102
+ThrowNullRef38:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %106
+ThrowNullRef40:                                   ; preds = %106
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %108
+ThrowNullRef42:                                   ; preds = %108
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %112
+ThrowNullRef44:                                   ; preds = %112
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %118
+ThrowNullRef46:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %121
+ThrowNullRef48:                                   ; preds = %121
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %123
+ThrowNullRef50:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %130
+ThrowNullRef52:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %132
+ThrowNullRef54:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %144
+ThrowNullRef56:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %146
+ThrowNullRef58:                                   ; preds = %146
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %60
+ThrowNullRef60:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %63
+ThrowNullRef62:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %49
+ThrowNullRef64:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %51
+ThrowNullRef66:                                   ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %53
+ThrowNullRef68:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(%"System.Char[]" addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %arg0 = alloca %"System.Char[]" addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store %"System.Char[]" addrspace(1)* %param0, %"System.Char[]" addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load i32, i32* %arg4
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %43, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %38, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg1
+  %13 = load i32, i32* %arg4
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %38, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %24 = load i32, i32* %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %35 = load i32, i32* %arg3
+  %36 = load i32, i32* %arg4
+  %37 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %37, %"System.Char[]" addrspace(1)* %34, i32 %35, i32 %36)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:38                                      ; preds = %5, %16
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Successfully read Buffer._Memmove
 
@@ -7914,7 +9431,7 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[loadElem]
+Failed to read AppDomain.SetDataHelper[storeElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -7923,8 +9440,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
@@ -7934,8 +9451,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
@@ -7947,15 +9464,15 @@ entry:
   %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
   %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
@@ -7966,15 +9483,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7992,7 +9509,79 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
-Failed to read Dictionary`2.TryGetValue[loadElemA]
+Successfully read Dictionary`2.TryGetValue
+
+define i8 @"Dictionary`2.TryGetValue"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)* addrspace(1)* %param2) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  %arg2 = alloca %System.__Canon addrspace(1)* addrspace(1)*
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  store %System.__Canon addrspace(1)* addrspace(1)* %param2, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  store i32 %2, i32* %loc0
+  %3 = load i32, i32* %loc0
+  %4 = icmp slt i32 %3, 0
+  br i1 %4, label %22, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 2
+  %10 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %9, align 8
+  %11 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = zext i32 %11 to i64
+  %BoundsCheck = icmp uge i64 %16, %15
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 3, i32 %11
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %20, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %6, %System.__Canon addrspace(1)* %21)
+  ret i8 1
+
+; <label>:22                                      ; preds = %entry
+  %23 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %23, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -8058,8 +9647,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
@@ -8091,8 +9680,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
@@ -8171,15 +9760,15 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck, label %19, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %ThrowNullRef, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
   %21 = load i32, i32 addrspace(1)* %20
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
@@ -8202,7 +9791,7 @@ ThrowNullRef:                                     ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %19
+ThrowNullRef2:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8248,8 +9837,8 @@ entry:
   %0 = alloca %System.AppDomainHandle
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %1 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %1, i32 0, i32 15
@@ -8269,8 +9858,8 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
@@ -8286,7 +9875,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -8299,8 +9888,8 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -8327,8 +9916,8 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
@@ -8352,8 +9941,8 @@ entry:
   %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
   store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
@@ -8363,8 +9952,8 @@ entry:
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
@@ -8374,8 +9963,8 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %9
   %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
@@ -8384,8 +9973,8 @@ entry:
 
 ; <label>:18                                      ; preds = %3, %16
   %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
@@ -8397,15 +9986,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %18
+ThrowNullRef6:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8418,8 +10007,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
@@ -8453,15 +10042,15 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
@@ -8473,7 +10062,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8481,7 +10070,7 @@ ThrowNullRef1:                                    ; preds = %1
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
 Failed to read Dictionary`2.System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
@@ -8506,8 +10095,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
@@ -8524,8 +10113,8 @@ entry:
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -8544,7 +10133,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8577,8 +10166,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = load i64, i64* %arg2
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = trunc i32 %3 to i8
@@ -8634,46 +10223,46 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
   %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
-  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
-  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
-  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
@@ -8684,27 +10273,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %20
+ThrowNullRef12:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8717,8 +10306,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -8756,22 +10345,22 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
   %9 = load i64, i64 addrspace(1)* %8, align 8
   %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
   %13 = load i64, i64 addrspace(1)* %12, align 8
   %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %11
   %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
@@ -8788,11 +10377,11 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8882,8 +10471,8 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
@@ -8900,8 +10489,8 @@ entry:
 ; <label>:8                                       ; preds = %1
   %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
   %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
@@ -8911,15 +10500,15 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
   %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
   %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
-  br i1 %NullCheck6, label %21, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
@@ -8946,15 +10535,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8992,15 +10581,15 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
   store i8 %3, i8 addrspace(1)* %5
   %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
@@ -9011,7 +10600,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9027,8 +10616,8 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -9041,8 +10630,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
@@ -9058,7 +10647,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9080,8 +10669,8 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
@@ -9096,8 +10685,8 @@ entry:
 ; <label>:12                                      ; preds = %6
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
@@ -9112,8 +10701,8 @@ entry:
 ; <label>:21                                      ; preds = %15
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
@@ -9128,8 +10717,8 @@ entry:
 ; <label>:30                                      ; preds = %24
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %31, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
@@ -9144,8 +10733,8 @@ entry:
 ; <label>:39                                      ; preds = %33
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
-  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %40, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %42
 
 ; <label>:42                                      ; preds = %39
   %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
@@ -9164,19 +10753,19 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %21
+ThrowNullRef4:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %30
+ThrowNullRef6:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %39
+ThrowNullRef8:                                    ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9243,8 +10832,8 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
@@ -9264,57 +10853,57 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
   store i8 0, i8 addrspace(1)* %2
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
   store i8 0, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
   store i8 0, i8 addrspace(1)* %17
   %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
   store i8 0, i8 addrspace(1)* %20
   %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
-  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
@@ -9325,31 +10914,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %19
+ThrowNullRef14:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9367,8 +10956,8 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
@@ -9380,8 +10969,8 @@ entry:
 
 ; <label>:9                                       ; preds = %4
   %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %9
   %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
@@ -9395,7 +10984,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef2:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9420,8 +11009,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
@@ -9512,8 +11101,8 @@ entry:
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
@@ -9524,8 +11113,8 @@ entry:
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = load i64, i64 addrspace(1)* %12
@@ -9537,8 +11126,8 @@ entry:
   %20 = load i64, i64* %19
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
-  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %13
   %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
@@ -9555,8 +11144,8 @@ entry:
 ; <label>:30                                      ; preds = %25
   %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %32 = load i32, i32* %arg2
-  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
-  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
@@ -9570,15 +11159,15 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %30
+ThrowNullRef2:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9622,87 +11211,87 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
   %10 = load i8, i8 addrspace(1)* %9, align 8
   %11 = zext i8 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %8
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
   store i8 %12, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
   %19 = load i8, i8 addrspace(1)* %18, align 8
   %20 = zext i8 %19 to i32
   %21 = trunc i32 %20 to i8
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
   store i8 %21, i8 addrspace(1)* %23
   %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
   %28 = load i8, i8 addrspace(1)* %27, align 8
   %29 = zext i8 %28 to i32
   %30 = trunc i32 %29 to i8
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
-  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %31
 
 ; <label>:31                                      ; preds = %26
   %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
   store i8 %30, i8 addrspace(1)* %32
   %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
-  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
-  br i1 %NullCheck14, label %40, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %40
 
 ; <label>:40                                      ; preds = %35
   %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
   store i8 %39, i8 addrspace(1)* %41
   %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
-  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %44
 
 ; <label>:44                                      ; preds = %40
   %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
   %46 = load i8, i8 addrspace(1)* %45, align 8
   %47 = zext i8 %46 to i32
   %48 = trunc i32 %47 to i8
-  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
   store i8 %48, i8 addrspace(1)* %50
   %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
-  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
@@ -9713,29 +11302,29 @@ entry:
 ; <label>:56                                      ; preds = %52
   %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
-  br i1 %NullCheck22, label %59, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
   %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
   %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
-  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
-  br i1 %NullCheck24, label %63, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
   %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
-  br i1 %NullCheck26, label %66, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
   %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
-  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
-  br i1 %NullCheck28, label %69, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %69
 
 ; <label>:69                                      ; preds = %66
   %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
@@ -9744,15 +11333,15 @@ entry:
 
 ; <label>:71                                      ; preds = %105
   %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
-  br i1 %NullCheck34, label %73, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %73
 
 ; <label>:73                                      ; preds = %71
   %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
   %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
   %76 = load i32, i32* %loc0
-  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
-  br i1 %NullCheck36, label %77, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
@@ -9766,8 +11355,8 @@ entry:
 
 ; <label>:83                                      ; preds = %77
   %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
-  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
@@ -9775,14 +11364,14 @@ entry:
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
   %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
-  br i1 %NullCheck40, label %91, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
 ; <label>:91                                      ; preds = %85
   %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
   %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
-  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck42, label %94, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %94
 
 ; <label>:94                                      ; preds = %91
   %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
@@ -9798,14 +11387,14 @@ entry:
 ; <label>:99                                      ; preds = %69, %96
   %100 = load i32, i32* %loc0
   %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
-  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %102
 
 ; <label>:102                                     ; preds = %99
   %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
   %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
-  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
-  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
@@ -9819,87 +11408,87 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %26
+ThrowNullRef10:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %31
+ThrowNullRef12:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %35
+ThrowNullRef14:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %40
+ThrowNullRef16:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %56
+ThrowNullRef22:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %59
+ThrowNullRef24:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %63
+ThrowNullRef26:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %66
+ThrowNullRef28:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %102
+ThrowNullRef32:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %71
+ThrowNullRef34:                                   ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %73
+ThrowNullRef36:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %83
+ThrowNullRef38:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %85
+ThrowNullRef40:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %91
+ThrowNullRef42:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9943,15 +11532,15 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
   %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
@@ -9961,28 +11550,28 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
   %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %12
   %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
   %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
   %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
-  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
@@ -9993,23 +11582,23 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %12
+ThrowNullRef6:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10031,15 +11620,15 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
   %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = load i64, i64 addrspace(1)* %7
@@ -10077,13 +11666,13 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[loadElem]
+Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -10111,8 +11700,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -10212,8 +11801,8 @@ entry:
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load i32, i32* %arg0
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -10347,8 +11936,8 @@ entry:
   store i64 %param0, i64* %arg0
   store i64 %param1, i64* %arg1
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
@@ -10356,8 +11945,8 @@ entry:
   %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
   %5 = load i16*, i16* addrspace(1)* %4, align 8
   %6 = addrspacecast i64* %arg1 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = bitcast i64 addrspace(1)* %6 to i8 addrspace(1)*
@@ -10373,7 +11962,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10407,8 +11996,8 @@ entry:
   %1 = load i32, i32* %arg1
   %2 = sext i32 %1 to i64
   %3 = inttoptr i64 %2 to i16*
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -10461,8 +12050,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, i32)*)(%System.IO.ConsoleStream addrspace(1)* %2, i32 %1)
   %3 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %4 = load i64, i64* %arg1
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
@@ -10473,8 +12062,8 @@ entry:
   %10 = icmp eq i32 %9, 3
   %11 = sext i1 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %5
   %14 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, i32 0, i32 5
@@ -10485,7 +12074,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10508,8 +12097,8 @@ entry:
   %5 = icmp eq i32 %4, 1
   %6 = sext i1 %5 to i32
   %7 = trunc i32 %6 to i8
-  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %2, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.ConsoleStream addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
@@ -10520,8 +12109,8 @@ entry:
   %13 = icmp eq i32 %12, 2
   %14 = sext i1 %13 to i32
   %15 = trunc i32 %14 to i8
-  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %10, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.ConsoleStream addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %8
   %17 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %10, i32 0, i32 4
@@ -10532,7 +12121,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10571,8 +12160,8 @@ entry:
   %arg0 = alloca i64
   store i64 %param0, i64* %arg0
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
@@ -10607,8 +12196,8 @@ entry:
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
   %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = load i64, i64 addrspace(1)* %7
@@ -10712,7 +12301,127 @@ entry:
 INFO:  jitting method Encoding::GetEncoding using LLILCJit
 Failed to read Encoding.GetEncoding[convertToHelperArgumentType]
 INFO:  jitting method EncodingProvider::GetEncodingFromProvider using LLILCJit
-Failed to read EncodingProvider.GetEncodingFromProvider[loadElem]
+Successfully read EncodingProvider.GetEncodingFromProvider
+
+define %System.Text.Encoding addrspace(1)* @EncodingProvider.GetEncodingFromProvider(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca %"System.Text.EncodingProvider[]" addrspace(1)*
+  %loc1 = alloca %System.Text.EncodingProvider addrspace(1)*
+  %loc2 = alloca %System.Text.Encoding addrspace(1)*
+  %loc3 = alloca %System.Text.Encoding addrspace(1)*
+  %loc4 = alloca %"System.Text.EncodingProvider[]" addrspace(1)*
+  %loc5 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1059)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2392
+  %2 = addrspacecast i8 addrspace(1)* %1 to %"System.Text.EncodingProvider[]" addrspace(1)**
+  %3 = load volatile %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %2
+  %4 = icmp ne %"System.Text.EncodingProvider[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %entry
+  ret %System.Text.Encoding addrspace(1)* null
+
+; <label>:6                                       ; preds = %entry
+  %7 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1059)
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i64 2392
+  %9 = addrspacecast i8 addrspace(1)* %8 to %"System.Text.EncodingProvider[]" addrspace(1)**
+  %10 = load volatile %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %9
+  store %"System.Text.EncodingProvider[]" addrspace(1)* %10, %"System.Text.EncodingProvider[]" addrspace(1)** %loc0
+  %11 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc0
+  store %"System.Text.EncodingProvider[]" addrspace(1)* %11, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  store i32 0, i32* %loc5
+  br label %43
+
+; <label>:12                                      ; preds = %46
+  %13 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  %14 = load i32, i32* %loc5
+  %NullCheck1 = icmp eq %"System.Text.EncodingProvider[]" addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %13, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = zext i32 %17 to i64
+  %19 = zext i32 %14 to i64
+  %BoundsCheck = icmp uge i64 %19, %18
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %20
+
+; <label>:20                                      ; preds = %15
+  %21 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %13, i32 0, i32 3, i32 %14
+  %22 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)* addrspace(1)* %21, align 8
+  store %System.Text.EncodingProvider addrspace(1)* %22, %System.Text.EncodingProvider addrspace(1)** %loc1
+  %23 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)** %loc1
+  %24 = load i32, i32* %arg0
+  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i64 addrspace(1)*
+  %NullCheck3 = icmp eq i64 addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
+
+; <label>:26                                      ; preds = %20
+  %27 = load i64, i64 addrspace(1)* %25
+  %28 = add i64 %27, 64
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 40
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Text.Encoding addrspace(1)* (%System.Text.EncodingProvider addrspace(1)*, i32)*
+  %35 = call %System.Text.Encoding addrspace(1)* %34(%System.Text.EncodingProvider addrspace(1)* %23, i32 %24)
+  store %System.Text.Encoding addrspace(1)* %35, %System.Text.Encoding addrspace(1)** %loc2
+  %36 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc2
+  %37 = icmp eq %System.Text.Encoding addrspace(1)* %36, null
+  br i1 %37, label %40, label %38
+
+; <label>:38                                      ; preds = %26
+  %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc2
+  store %System.Text.Encoding addrspace(1)* %39, %System.Text.Encoding addrspace(1)** %loc3
+  br label %53
+
+; <label>:40                                      ; preds = %26
+  %41 = load i32, i32* %loc5
+  %42 = add i32 %41, 1
+  store i32 %42, i32* %loc5
+  br label %43
+
+; <label>:43                                      ; preds = %6, %40
+  %44 = load i32, i32* %loc5
+  %45 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  %NullCheck = icmp eq %"System.Text.EncodingProvider[]" addrspace(1)* %45, null
+  br i1 %NullCheck, label %ThrowNullRef, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp slt i32 %44, %50
+  br i1 %51, label %12, label %52
+
+; <label>:52                                      ; preds = %46
+  ret %System.Text.Encoding addrspace(1)* null
+
+; <label>:53                                      ; preds = %38
+  %54 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc3
+  ret %System.Text.Encoding addrspace(1)* %54
+
+ThrowNullRef:                                     ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method EncodingProvider::.cctor using LLILCJit
 Successfully read EncodingProvider..cctor
 
@@ -10731,7 +12440,7 @@ Failed to read Encoding.get_InternalSyncObject[Call HasTypeArg]
 INFO:  jitting method Hashtable::.ctor using LLILCJit
 Failed to read Hashtable..ctor[Volatile store]
 INFO:  jitting method Hashtable::get_Item using LLILCJit
-Failed to read Hashtable.get_Item[loadElemA]
+Failed to read Hashtable.get_Item[loadNonPrimitiveObj]
 INFO:  jitting method Hashtable::InitHash using LLILCJit
 Successfully read Hashtable.InitHash
 
@@ -10751,8 +12460,8 @@ entry:
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -10768,15 +12477,15 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
   %15 = load i32, i32* %loc0
-  %NullCheck2 = icmp ne i32 addrspace(1)* %14, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i32 addrspace(1)* %14, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %3
   store i32 %15, i32 addrspace(1)* %14, align 8
   %17 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %18 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %NullCheck4 = icmp ne i32 addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i32 addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = load i32, i32 addrspace(1)* %18, align 8
@@ -10785,8 +12494,8 @@ entry:
   %23 = sub i32 %22, 1
   %24 = urem i32 %21, %23
   %25 = add i32 1, %24
-  %NullCheck6 = icmp ne i32 addrspace(1)* %17, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32 addrspace(1)* %17, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %19
   store i32 %25, i32 addrspace(1)* %17, align 8
@@ -10797,15 +12506,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %19
+ThrowNullRef6:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10820,8 +12529,8 @@ entry:
   store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
   store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %NullCheck = icmp ne %System.Collections.Hashtable addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Collections.Hashtable addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
@@ -10831,16 +12540,16 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Collections.Hashtable addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Collections.Hashtable addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
   %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck4 = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %9, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
   %13 = inttoptr i64 %11 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
@@ -10850,8 +12559,8 @@ entry:
 ; <label>:15                                      ; preds = %1
   %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -10869,15 +12578,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10891,8 +12600,8 @@ entry:
   store %System.Int32 addrspace(1)* %param0, %System.Int32 addrspace(1)** %this
   %0 = load %System.Int32 addrspace(1)*, %System.Int32 addrspace(1)** %this
   %1 = bitcast %System.Int32 addrspace(1)* %0 to i32 addrspace(1)*
-  %NullCheck = icmp ne i32 addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq i32 addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load i32, i32 addrspace(1)* %1, align 8
@@ -10968,8 +12677,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.UTF8Encoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
@@ -10978,15 +12687,15 @@ entry:
   %9 = load i8, i8* %arg2
   %10 = zext i8 %9 to i32
   %11 = trunc i32 %10 to i8
-  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %8, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %6
   %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %8, i32 0, i32 8
   store i8 %11, i8 addrspace(1)* %13
   %14 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %14, i32 0, i32 8
@@ -10998,8 +12707,8 @@ entry:
 ; <label>:20                                      ; preds = %15
   %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %22, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %22, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = load i64, i64 addrspace(1)* %22
@@ -11021,15 +12730,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %12
+ThrowNullRef4:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11044,8 +12753,8 @@ entry:
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
@@ -11067,16 +12776,16 @@ entry:
 ; <label>:10                                      ; preds = %1
   %11 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
   %12 = load i32, i32* %arg1
-  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %11, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.Encoding addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
   store i32 %12, i32 addrspace(1)* %14
   %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
   %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = load i64, i64 addrspace(1)* %16
@@ -11094,11 +12803,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11111,8 +12820,8 @@ entry:
   %this = alloca %System.Text.UTF8Encoding addrspace(1)*
   store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
   %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.UTF8Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
@@ -11124,16 +12833,16 @@ entry:
 ; <label>:6                                       ; preds = %1
   %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %8 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %10, %System.Text.EncoderFallback addrspace(1)* %8)
   %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %12 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
-  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %11, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %11, i32 0, i32 3
@@ -11146,8 +12855,8 @@ entry:
   %18 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %18, %System.String addrspace(1)* %17)
   %19 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %18 to %System.Text.EncoderFallback addrspace(1)*
-  %NullCheck6 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %16, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %16, i32 0, i32 2
@@ -11157,8 +12866,8 @@ entry:
   %24 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %24, %System.String addrspace(1)* %23)
   %25 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %24 to %System.Text.DecoderFallback addrspace(1)*
-  %NullCheck8 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %22, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %22, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %20
   %27 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %22, i32 0, i32 3
@@ -11169,19 +12878,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %20
+ThrowNullRef8:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11211,8 +12920,8 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load i32, i32* %arg1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -11230,8 +12939,8 @@ entry:
 ; <label>:15                                      ; preds = %8
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %17 = load i32, i32* %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 %17
@@ -11247,7 +12956,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11299,7 +13008,7 @@ entry:
 }
 
 INFO:  jitting method Hashtable::Insert using LLILCJit
-Failed to read Hashtable.Insert[loadElemA]
+Failed to read Hashtable.Insert[storeElem]
 INFO:  jitting method ConsoleEncoding::.ctor using LLILCJit
 Successfully read ConsoleEncoding..ctor
 
@@ -11314,8 +13023,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %1)
   %2 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
@@ -11351,8 +13060,8 @@ entry:
   %2 = call %System.Text.InternalEncoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalEncoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %1)
   %3 = bitcast %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2 to %System.Text.EncoderFallback addrspace(1)*
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
@@ -11362,8 +13071,8 @@ entry:
   %8 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %7)
   %9 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %8 to %System.Text.DecoderFallback addrspace(1)*
-  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %6, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.Encoding addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %4
   %11 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %6, i32 0, i32 3
@@ -11374,7 +13083,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11393,15 +13102,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* %1)
   %2 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   %6 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, i32 0, i32 1
@@ -11412,7 +13121,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11440,8 +13149,8 @@ entry:
   store %System.Text.InternalDecoderBestFitFallback addrspace(1)* %param0, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
   %0 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
@@ -11451,15 +13160,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %4)
   %5 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %6)
   %9 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, i32 0, i32 1
@@ -11470,11 +13179,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11542,8 +13251,8 @@ entry:
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
   %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = load i64, i64 addrspace(1)* %19
@@ -11607,8 +13316,8 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.ConsoleStream addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
@@ -11639,31 +13348,31 @@ entry:
   store i8 %param4, i8* %arg4
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %3, %System.IO.Stream addrspace(1)* %1)
   %4 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %4, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
   %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %4, i32 0, i32 4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %5)
   %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %6
   %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
   %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
   %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = load i64, i64 addrspace(1)* %13
@@ -11675,8 +13384,8 @@ entry:
   %21 = load i64, i64* %20
   %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %8, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %8, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %14
   %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 5
@@ -11694,24 +13403,24 @@ entry:
   %31 = load i32, i32* %arg3
   %32 = sext i32 %31 to i64
   %33 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %32)
-  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %30, null
-  br i1 %NullCheck10, label %34, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.StreamWriter addrspace(1)* %30, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %35, %"System.Char[]" addrspace(1)* %33)
   %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %37, null
-  br i1 %NullCheck12, label %38, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.StreamWriter addrspace(1)* %37, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %38
 
 ; <label>:38                                      ; preds = %34
   %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
   %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
   %41 = load i32, i32* %arg3
   %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %42, null
-  br i1 %NullCheck14, label %43, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %42, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
   %44 = load i64, i64 addrspace(1)* %42
@@ -11725,30 +13434,30 @@ entry:
   %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
   %53 = sext i32 %52 to i64
   %54 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %53)
-  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
-  br i1 %NullCheck16, label %55, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %55
 
 ; <label>:55                                      ; preds = %43
   %56 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %56, %"System.Byte[]" addrspace(1)* %54)
   %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %58 = load i32, i32* %arg3
-  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %57, null
-  br i1 %NullCheck18, label %59, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.StreamWriter addrspace(1)* %57, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %59
 
 ; <label>:59                                      ; preds = %55
   %60 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 10
   store i32 %58, i32 addrspace(1)* %60
   %61 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %61, null
-  br i1 %NullCheck20, label %62, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.IO.StreamWriter addrspace(1)* %61, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %62
 
 ; <label>:62                                      ; preds = %59
   %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
   %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
   %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
   %67 = load i64, i64 addrspace(1)* %65
@@ -11766,15 +13475,15 @@ entry:
 
 ; <label>:78                                      ; preds = %66
   %79 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %79, null
-  br i1 %NullCheck24, label %80, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.StreamWriter addrspace(1)* %79, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %80
 
 ; <label>:80                                      ; preds = %78
   %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
   %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
   %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %83, null
-  br i1 %NullCheck26, label %84, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %83, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
   %85 = load i64, i64 addrspace(1)* %83
@@ -11791,8 +13500,8 @@ entry:
 
 ; <label>:95                                      ; preds = %84
   %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.IO.StreamWriter addrspace(1)* %96, null
-  br i1 %NullCheck28, label %97, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.IO.StreamWriter addrspace(1)* %96, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %97
 
 ; <label>:97                                      ; preds = %95
   %98 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 12
@@ -11806,8 +13515,8 @@ entry:
   %103 = icmp eq i32 %102, 0
   %104 = sext i1 %103 to i32
   %105 = trunc i32 %104 to i8
-  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %100, null
-  br i1 %NullCheck30, label %106, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.IO.StreamWriter addrspace(1)* %100, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %106
 
 ; <label>:106                                     ; preds = %99
   %107 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %100, i32 0, i32 13
@@ -11818,63 +13527,63 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %6
+ThrowNullRef4:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %29
+ThrowNullRef10:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %34
+ThrowNullRef12:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %38
+ThrowNullRef14:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %43
+ThrowNullRef16:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %55
+ThrowNullRef18:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %59
+ThrowNullRef20:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %62
+ThrowNullRef22:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %78
+ThrowNullRef24:                                   ; preds = %78
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %80
+ThrowNullRef26:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %95
+ThrowNullRef28:                                   ; preds = %95
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11887,15 +13596,15 @@ entry:
   %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = load i64, i64 addrspace(1)* %4
@@ -11913,7 +13622,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11963,35 +13672,35 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
   %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderNLS addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %7 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.EncoderNLS addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Text.Encoding addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.Encoding addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Text.EncoderNLS addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.EncoderNLS addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
   %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck8 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = load i64, i64 addrspace(1)* %16
@@ -12010,19 +13719,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12048,8 +13757,8 @@ entry:
   %this = alloca %System.Text.Encoding addrspace(1)*
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
@@ -12069,15 +13778,15 @@ entry:
   %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
   store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
   %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
   store i32 0, i32 addrspace(1)* %2
   %3 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, i32 0, i32 2
@@ -12087,15 +13796,15 @@ entry:
 
 ; <label>:8                                       ; preds = %4
   %9 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
   %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
   %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = load i64, i64 addrspace(1)* %13
@@ -12116,15 +13825,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12139,16 +13848,16 @@ entry:
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = load i32, i32* %arg1
   %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
   %7 = load i64, i64 addrspace(1)* %5
@@ -12166,7 +13875,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12203,8 +13912,8 @@ entry:
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
   %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
   %16 = load i64, i64 addrspace(1)* %14
@@ -12225,8 +13934,8 @@ entry:
   %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
   %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
   %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %31, null
-  br i1 %NullCheck2, label %32, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = load i64, i64 addrspace(1)* %31
@@ -12269,7 +13978,7 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12282,14 +13991,14 @@ entry:
   %this = alloca %System.Text.EncoderReplacementFallback addrspace(1)*
   store %System.Text.EncoderReplacementFallback addrspace(1)* %param0, %System.Text.EncoderReplacementFallback addrspace(1)** %this
   %0 = load %System.Text.EncoderReplacementFallback addrspace(1)*, %System.Text.EncoderReplacementFallback addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -12300,7 +14009,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12330,8 +14039,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
@@ -12363,8 +14072,8 @@ entry:
   %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
   store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
@@ -12376,8 +14085,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Threading.Tasks.Task addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %7)
@@ -12400,7 +14109,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12419,8 +14128,8 @@ entry:
   store i8 %param1, i8* %arg1
   store i8 %param2, i8* %arg2
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
@@ -12434,8 +14143,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1, %5
   %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 9
@@ -12466,8 +14175,8 @@ entry:
 
 ; <label>:25                                      ; preds = %8, %20
   %26 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %26, null
-  br i1 %NullCheck4, label %27, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %26, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %26, i32 0, i32 12
@@ -12478,22 +14187,22 @@ entry:
 
 ; <label>:32                                      ; preds = %27
   %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %33, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.IO.StreamWriter addrspace(1)* %33, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %32
   %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 12
   store i8 1, i8 addrspace(1)* %35
   %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
-  br i1 %NullCheck8, label %37, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
   %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
   %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck10 = icmp ne i64 addrspace(1)* %40, null
-  br i1 %NullCheck10, label %41, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64 addrspace(1)* %40, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i64, i64 addrspace(1)* %40
@@ -12507,8 +14216,8 @@ entry:
   %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
   store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
   %51 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %NullCheck12 = icmp ne %"System.Byte[]" addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Byte[]" addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %41
   %53 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %51, i32 0, i32 1
@@ -12520,16 +14229,16 @@ entry:
 
 ; <label>:58                                      ; preds = %52
   %59 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %59, null
-  br i1 %NullCheck14, label %60, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.IO.StreamWriter addrspace(1)* %59, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %60
 
 ; <label>:60                                      ; preds = %58
   %61 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %59, i32 0, i32 3
   %62 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
   %64 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %NullCheck16 = icmp ne %"System.Byte[]" addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %"System.Byte[]" addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %60
   %66 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %64, i32 0, i32 1
@@ -12537,8 +14246,8 @@ entry:
   %68 = zext i32 %67 to i64
   %69 = trunc i64 %68 to i32
   %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck18, label %71, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
   %72 = load i64, i64 addrspace(1)* %70
@@ -12554,29 +14263,29 @@ entry:
 
 ; <label>:80                                      ; preds = %27, %52, %71
   %81 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %81, null
-  br i1 %NullCheck20, label %82, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.IO.StreamWriter addrspace(1)* %81, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
 
 ; <label>:82                                      ; preds = %80
   %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %81, i32 0, i32 5
   %84 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %83, align 8
   %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.IO.StreamWriter addrspace(1)* %85, null
-  br i1 %NullCheck22, label %86, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.IO.StreamWriter addrspace(1)* %85, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %86
 
 ; <label>:86                                      ; preds = %82
   %87 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 7
   %88 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %87, align 8
   %89 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %89, null
-  br i1 %NullCheck24, label %90, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.StreamWriter addrspace(1)* %89, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %90
 
 ; <label>:90                                      ; preds = %86
   %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %89, i32 0, i32 9
   %92 = load i32, i32 addrspace(1)* %91, align 8
   %93 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.IO.StreamWriter addrspace(1)* %93, null
-  br i1 %NullCheck26, label %94, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.IO.StreamWriter addrspace(1)* %93, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %93, i32 0, i32 6
@@ -12584,8 +14293,8 @@ entry:
   %97 = load i8, i8* %arg2
   %98 = zext i8 %97 to i32
   %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
-  %NullCheck28 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck28, label %100, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
   %101 = load i64, i64 addrspace(1)* %99
@@ -12600,8 +14309,8 @@ entry:
   %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
   store i32 %110, i32* %loc1
   %111 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %111, null
-  br i1 %NullCheck30, label %112, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.IO.StreamWriter addrspace(1)* %111, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %112
 
 ; <label>:112                                     ; preds = %100
   %113 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %111, i32 0, i32 9
@@ -12612,23 +14321,23 @@ entry:
 
 ; <label>:116                                     ; preds = %112
   %117 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck32 = icmp ne %System.IO.StreamWriter addrspace(1)* %117, null
-  br i1 %NullCheck32, label %118, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.IO.StreamWriter addrspace(1)* %117, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %118
 
 ; <label>:118                                     ; preds = %116
   %119 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %117, i32 0, i32 3
   %120 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %119, align 8
   %121 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.IO.StreamWriter addrspace(1)* %121, null
-  br i1 %NullCheck34, label %122, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.IO.StreamWriter addrspace(1)* %121, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %122
 
 ; <label>:122                                     ; preds = %118
   %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
   %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
   %125 = load i32, i32* %loc1
   %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
-  %NullCheck36 = icmp ne i64 addrspace(1)* %126, null
-  br i1 %NullCheck36, label %127, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64 addrspace(1)* %126, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
   %128 = load i64, i64 addrspace(1)* %126
@@ -12650,15 +14359,15 @@ entry:
 
 ; <label>:140                                     ; preds = %136
   %141 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.IO.StreamWriter addrspace(1)* %141, null
-  br i1 %NullCheck38, label %142, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.IO.StreamWriter addrspace(1)* %141, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %142
 
 ; <label>:142                                     ; preds = %140
   %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
   %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
   %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
-  %NullCheck40 = icmp ne i64 addrspace(1)* %145, null
-  br i1 %NullCheck40, label %146, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i64 addrspace(1)* %145, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
   %147 = load i64, i64 addrspace(1)* %145
@@ -12679,83 +14388,83 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %25
+ThrowNullRef4:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %32
+ThrowNullRef6:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %37
+ThrowNullRef10:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %41
+ThrowNullRef12:                                   ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %58
+ThrowNullRef14:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %60
+ThrowNullRef16:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %65
+ThrowNullRef18:                                   ; preds = %65
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %80
+ThrowNullRef20:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %82
+ThrowNullRef22:                                   ; preds = %82
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %86
+ThrowNullRef24:                                   ; preds = %86
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %90
+ThrowNullRef26:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %94
+ThrowNullRef28:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %100
+ThrowNullRef30:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %116
+ThrowNullRef32:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %118
+ThrowNullRef34:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %122
+ThrowNullRef36:                                   ; preds = %122
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %140
+ThrowNullRef38:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %142
+ThrowNullRef40:                                   ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12822,8 +14531,8 @@ entry:
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %1 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
-  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
@@ -12831,8 +14540,8 @@ entry:
   %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
   %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
   %8 = load i64, i64 addrspace(1)* %6
@@ -12848,8 +14557,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %17, %System.IFormatProvider addrspace(1)* %16)
   %18 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %19 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %18, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.SyncTextWriter addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %7
   %21 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %18, i32 0, i32 4
@@ -12860,11 +14569,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12877,8 +14586,8 @@ entry:
   %this = alloca %System.IO.TextWriter addrspace(1)*
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.TextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
@@ -12888,8 +14597,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.Threading.Thread addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Threading.Thread addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %6)
@@ -12898,8 +14607,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1
   %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.TextWriter addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.TextWriter addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %11, i32 0, i32 2
@@ -12910,11 +14619,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13111,8 +14820,8 @@ entry:
   store i32 %param1, i32* %arg1
   store i8 0, i8* %loc1
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
@@ -13122,16 +14831,16 @@ entry:
   %5 = addrspacecast i8* %loc1 to i8 addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %4, i8 addrspace(1)* %5)
   %6 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.SyncTextWriter addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
   %10 = load i32, i32* %arg1
   %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
   %13 = load i64, i64 addrspace(1)* %11
@@ -13166,11 +14875,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13187,8 +14896,8 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load i32, i32* %arg1
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -13202,8 +14911,8 @@ entry:
   call void %11(%System.IO.TextWriter addrspace(1)* %0, i32 %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
   %15 = load i64, i64 addrspace(1)* %13
@@ -13221,7 +14930,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13239,8 +14948,8 @@ entry:
   %1 = addrspacecast i32* %arg1 to i32 addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -13255,8 +14964,8 @@ entry:
   %14 = bitcast i32 addrspace(1)* %1 to %System.Int32 addrspace(1)*
   %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Int32 addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Int32 addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
   %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
   %18 = load i64, i64 addrspace(1)* %16
@@ -13274,7 +14983,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13290,8 +14999,8 @@ entry:
   store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
   %0 = load %System.Int32 addrspace(1)*, %System.Int32 addrspace(1)** %this
   %1 = bitcast %System.Int32 addrspace(1)* %0 to i32 addrspace(1)*
-  %NullCheck = icmp ne i32 addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq i32 addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load i32, i32 addrspace(1)* %1, align 8
@@ -13316,8 +15025,8 @@ entry:
   %loc0 = alloca %System.Globalization.NumberFormatInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 3
@@ -13327,8 +15036,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
@@ -13338,24 +15047,24 @@ entry:
   store %System.Globalization.NumberFormatInfo addrspace(1)* %10, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
   %11 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %7
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
   %15 = load i8, i8 addrspace(1)* %14, align 8
   %16 = zext i8 %15 to i32
   %17 = trunc i32 %16 to i8
-  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %11, null
-  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %11, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %13
   %19 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %11, i32 0, i32 29
   store i8 %17, i8 addrspace(1)* %19
   %20 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %21 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %20, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %20, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %18
   %23 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %20, i32 0, i32 3
@@ -13364,8 +15073,8 @@ entry:
 
 ; <label>:24                                      ; preds = %1, %22
   %25 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %25, null
-  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %25, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %26
 
 ; <label>:26                                      ; preds = %24
   %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %25, i32 0, i32 3
@@ -13376,23 +15085,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %18
+ThrowNullRef8:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13417,168 +15126,168 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 18
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %8, align 8
-  %NullCheck2 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %5, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %5, i32 0, i32 4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %9)
   %12 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 19
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %15, align 8
-  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %12, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %12, i32 0, i32 5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %16)
   %19 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %20 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %20, null
-  br i1 %NullCheck8, label %21, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %20, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %20, i32 0, i32 23
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  %NullCheck10 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %19, null
-  br i1 %NullCheck10, label %24, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %19, i32 0, i32 7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %25, %System.String addrspace(1)* %23)
   %26 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %27 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %27, i32 0, i32 22
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %29, align 8
-  %NullCheck14 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %26, null
-  br i1 %NullCheck14, label %31, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %26, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %26, i32 0, i32 6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %32, %System.String addrspace(1)* %30)
   %33 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %34 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Globalization.CultureData addrspace(1)* %34, null
-  br i1 %NullCheck16, label %35, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Globalization.CultureData addrspace(1)* %34, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %34, i32 0, i32 51
   %37 = load i32, i32 addrspace(1)* %36, align 8
-  %NullCheck18 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %33, null
-  br i1 %NullCheck18, label %38, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %33, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %33, i32 0, i32 21
   store i32 %37, i32 addrspace(1)* %39
   %40 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %41 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Globalization.CultureData addrspace(1)* %41, null
-  br i1 %NullCheck20, label %42, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Globalization.CultureData addrspace(1)* %41, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %41, i32 0, i32 52
   %44 = load i32, i32 addrspace(1)* %43, align 8
-  %NullCheck22 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %40, null
-  br i1 %NullCheck22, label %45, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %40, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %40, i32 0, i32 25
   store i32 %44, i32 addrspace(1)* %46
   %47 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %48 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.Globalization.CultureData addrspace(1)* %48, null
-  br i1 %NullCheck24, label %49, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Globalization.CultureData addrspace(1)* %48, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %49
 
 ; <label>:49                                      ; preds = %45
   %50 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %48, i32 0, i32 29
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck26 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %47, null
-  br i1 %NullCheck26, label %52, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %47, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %47, i32 0, i32 10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %53, %System.String addrspace(1)* %51)
   %54 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %55 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Globalization.CultureData addrspace(1)* %55, null
-  br i1 %NullCheck28, label %56, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Globalization.CultureData addrspace(1)* %55, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %56
 
 ; <label>:56                                      ; preds = %52
   %57 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %55, i32 0, i32 35
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %57, align 8
-  %NullCheck30 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %54, null
-  br i1 %NullCheck30, label %59, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %54, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %54, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %60, %System.String addrspace(1)* %58)
   %61 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %62 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck32 = icmp ne %System.Globalization.CultureData addrspace(1)* %62, null
-  br i1 %NullCheck32, label %63, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Globalization.CultureData addrspace(1)* %62, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %62, i32 0, i32 34
   %65 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %64, align 8
-  %NullCheck34 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %61, null
-  br i1 %NullCheck34, label %66, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %61, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %61, i32 0, i32 9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %67, %System.String addrspace(1)* %65)
   %68 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %69 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck36 = icmp ne %System.Globalization.CultureData addrspace(1)* %69, null
-  br i1 %NullCheck36, label %70, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Globalization.CultureData addrspace(1)* %69, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %70
 
 ; <label>:70                                      ; preds = %66
   %71 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %69, i32 0, i32 55
   %72 = load i32, i32 addrspace(1)* %71, align 8
-  %NullCheck38 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %68, null
-  br i1 %NullCheck38, label %73, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %68, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %68, i32 0, i32 22
   store i32 %72, i32 addrspace(1)* %74
   %75 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %76 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck40 = icmp ne %System.Globalization.CultureData addrspace(1)* %76, null
-  br i1 %NullCheck40, label %77, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Globalization.CultureData addrspace(1)* %76, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %76, i32 0, i32 57
   %79 = load i32, i32 addrspace(1)* %78, align 8
-  %NullCheck42 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %75, null
-  br i1 %NullCheck42, label %80, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %75, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %80
 
 ; <label>:80                                      ; preds = %77
   %81 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %75, i32 0, i32 24
   store i32 %79, i32 addrspace(1)* %81
   %82 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %83 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck44 = icmp ne %System.Globalization.CultureData addrspace(1)* %83, null
-  br i1 %NullCheck44, label %84, label %ThrowNullRef43
+  %NullCheck43 = icmp eq %System.Globalization.CultureData addrspace(1)* %83, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %84
 
 ; <label>:84                                      ; preds = %80
   %85 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %83, i32 0, i32 56
   %86 = load i32, i32 addrspace(1)* %85, align 8
-  %NullCheck46 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %82, null
-  br i1 %NullCheck46, label %87, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %82, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %82, i32 0, i32 23
@@ -13587,8 +15296,8 @@ entry:
 
 ; <label>:89                                      ; preds = %entry
   %90 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck100 = icmp ne %System.Globalization.CultureData addrspace(1)* %90, null
-  br i1 %NullCheck100, label %91, label %ThrowNullRef99
+  %NullCheck99 = icmp eq %System.Globalization.CultureData addrspace(1)* %90, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %91
 
 ; <label>:91                                      ; preds = %89
   %92 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %90, i32 0, i32 2
@@ -13606,8 +15315,8 @@ entry:
   %102 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %103 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %104 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %103)
-  %NullCheck48 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %102, null
-  br i1 %NullCheck48, label %105, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %102, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %105
 
 ; <label>:105                                     ; preds = %101
   %106 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %102, i32 0, i32 1
@@ -13615,8 +15324,8 @@ entry:
   %107 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %108 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %109 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %108)
-  %NullCheck50 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %107, null
-  br i1 %NullCheck50, label %110, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %107, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %110
 
 ; <label>:110                                     ; preds = %105
   %111 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %107, i32 0, i32 2
@@ -13624,8 +15333,8 @@ entry:
   %112 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %113 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %114 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %113)
-  %NullCheck52 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %112, null
-  br i1 %NullCheck52, label %115, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %112, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %115
 
 ; <label>:115                                     ; preds = %110
   %116 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %112, i32 0, i32 27
@@ -13633,8 +15342,8 @@ entry:
   %117 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %118 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %119 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %118)
-  %NullCheck54 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %117, null
-  br i1 %NullCheck54, label %120, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %117, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %120
 
 ; <label>:120                                     ; preds = %115
   %121 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %117, i32 0, i32 26
@@ -13642,8 +15351,8 @@ entry:
   %122 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %123 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %124 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %123)
-  %NullCheck56 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %122, null
-  br i1 %NullCheck56, label %125, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %122, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %125
 
 ; <label>:125                                     ; preds = %120
   %126 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %122, i32 0, i32 17
@@ -13651,8 +15360,8 @@ entry:
   %127 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %128 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %129 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %128)
-  %NullCheck58 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %127, null
-  br i1 %NullCheck58, label %130, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %127, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %130
 
 ; <label>:130                                     ; preds = %125
   %131 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %127, i32 0, i32 18
@@ -13660,8 +15369,8 @@ entry:
   %132 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %133 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %134 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %133)
-  %NullCheck60 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %132, null
-  br i1 %NullCheck60, label %135, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %132, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %135
 
 ; <label>:135                                     ; preds = %130
   %136 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %132, i32 0, i32 14
@@ -13669,8 +15378,8 @@ entry:
   %137 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %138 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %139 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %138)
-  %NullCheck62 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %137, null
-  br i1 %NullCheck62, label %140, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %137, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %140
 
 ; <label>:140                                     ; preds = %135
   %141 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %137, i32 0, i32 13
@@ -13678,71 +15387,71 @@ entry:
   %142 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %143 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %144 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %143)
-  %NullCheck64 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %142, null
-  br i1 %NullCheck64, label %145, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %142, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %145
 
 ; <label>:145                                     ; preds = %140
   %146 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %142, i32 0, i32 12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %146, %System.String addrspace(1)* %144)
   %147 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %148 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck66 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %148, null
-  br i1 %NullCheck66, label %149, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %148, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %149
 
 ; <label>:149                                     ; preds = %145
   %150 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %148, i32 0, i32 21
   %151 = load i32, i32 addrspace(1)* %150, align 8
-  %NullCheck68 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %147, null
-  br i1 %NullCheck68, label %152, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %147, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %152
 
 ; <label>:152                                     ; preds = %149
   %153 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %147, i32 0, i32 28
   store i32 %151, i32 addrspace(1)* %153
   %154 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %155 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck70 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %155, null
-  br i1 %NullCheck70, label %156, label %ThrowNullRef69
+  %NullCheck69 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %155, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %156
 
 ; <label>:156                                     ; preds = %152
   %157 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %155, i32 0, i32 6
   %158 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %157, align 8
-  %NullCheck72 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %154, null
-  br i1 %NullCheck72, label %159, label %ThrowNullRef71
+  %NullCheck71 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %154, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %159
 
 ; <label>:159                                     ; preds = %156
   %160 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %154, i32 0, i32 15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %160, %System.String addrspace(1)* %158)
   %161 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %162 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck74 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %162, null
-  br i1 %NullCheck74, label %163, label %ThrowNullRef73
+  %NullCheck73 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %162, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %163
 
 ; <label>:163                                     ; preds = %159
   %164 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %162, i32 0, i32 1
   %165 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %164, align 8
-  %NullCheck76 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %161, null
-  br i1 %NullCheck76, label %166, label %ThrowNullRef75
+  %NullCheck75 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %161, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %166
 
 ; <label>:166                                     ; preds = %163
   %167 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %161, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %167, %"System.Int32[]" addrspace(1)* %165)
   %168 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %169 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck78 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %169, null
-  br i1 %NullCheck78, label %170, label %ThrowNullRef77
+  %NullCheck77 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %169, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %170
 
 ; <label>:170                                     ; preds = %166
   %171 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %169, i32 0, i32 7
   %172 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %171, align 8
-  %NullCheck80 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %168, null
-  br i1 %NullCheck80, label %173, label %ThrowNullRef79
+  %NullCheck79 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %168, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %173
 
 ; <label>:173                                     ; preds = %170
   %174 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %168, i32 0, i32 16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %174, %System.String addrspace(1)* %172)
   %175 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck82 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %175, null
-  br i1 %NullCheck82, label %176, label %ThrowNullRef81
+  %NullCheck81 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %175, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %176
 
 ; <label>:176                                     ; preds = %173
   %177 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %175, i32 0, i32 4
@@ -13752,14 +15461,14 @@ entry:
 
 ; <label>:180                                     ; preds = %176
   %181 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck84 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %181, null
-  br i1 %NullCheck84, label %182, label %ThrowNullRef83
+  %NullCheck83 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %181, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %182
 
 ; <label>:182                                     ; preds = %180
   %183 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %181, i32 0, i32 4
   %184 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %183, align 8
-  %NullCheck86 = icmp ne %System.String addrspace(1)* %184, null
-  br i1 %NullCheck86, label %185, label %ThrowNullRef85
+  %NullCheck85 = icmp eq %System.String addrspace(1)* %184, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %185
 
 ; <label>:185                                     ; preds = %182
   %186 = getelementptr inbounds %System.String, %System.String addrspace(1)* %184, i32 0, i32 1
@@ -13770,8 +15479,8 @@ entry:
 ; <label>:189                                     ; preds = %176, %185
   %190 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck98 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %190, null
-  br i1 %NullCheck98, label %192, label %ThrowNullRef97
+  %NullCheck97 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %190, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %192
 
 ; <label>:192                                     ; preds = %189
   %193 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %190, i32 0, i32 4
@@ -13780,8 +15489,8 @@ entry:
 
 ; <label>:194                                     ; preds = %185, %192
   %195 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck88 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %195, null
-  br i1 %NullCheck88, label %196, label %ThrowNullRef87
+  %NullCheck87 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %195, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %196
 
 ; <label>:196                                     ; preds = %194
   %197 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %195, i32 0, i32 9
@@ -13791,14 +15500,14 @@ entry:
 
 ; <label>:200                                     ; preds = %196
   %201 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck90 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %201, null
-  br i1 %NullCheck90, label %202, label %ThrowNullRef89
+  %NullCheck89 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %201, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %202
 
 ; <label>:202                                     ; preds = %200
   %203 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %201, i32 0, i32 9
   %204 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %203, align 8
-  %NullCheck92 = icmp ne %System.String addrspace(1)* %204, null
-  br i1 %NullCheck92, label %205, label %ThrowNullRef91
+  %NullCheck91 = icmp eq %System.String addrspace(1)* %204, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %205
 
 ; <label>:205                                     ; preds = %202
   %206 = getelementptr inbounds %System.String, %System.String addrspace(1)* %204, i32 0, i32 1
@@ -13809,14 +15518,14 @@ entry:
 ; <label>:209                                     ; preds = %196, %205
   %210 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %211 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck94 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %211, null
-  br i1 %NullCheck94, label %212, label %ThrowNullRef93
+  %NullCheck93 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %211, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %212
 
 ; <label>:212                                     ; preds = %209
   %213 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %211, i32 0, i32 6
   %214 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %213, align 8
-  %NullCheck96 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %210, null
-  br i1 %NullCheck96, label %215, label %ThrowNullRef95
+  %NullCheck95 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %210, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %215
 
 ; <label>:215                                     ; preds = %212
   %216 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %210, i32 0, i32 9
@@ -13830,203 +15539,203 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %17
+ThrowNullRef8:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %21
+ThrowNullRef10:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %24
+ThrowNullRef12:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %28
+ThrowNullRef14:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %31
+ThrowNullRef16:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %35
+ThrowNullRef18:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %38
+ThrowNullRef20:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %42
+ThrowNullRef22:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %45
+ThrowNullRef24:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %49
+ThrowNullRef26:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %52
+ThrowNullRef28:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %56
+ThrowNullRef30:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %59
+ThrowNullRef32:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %63
+ThrowNullRef34:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %66
+ThrowNullRef36:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %70
+ThrowNullRef38:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %73
+ThrowNullRef40:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %77
+ThrowNullRef42:                                   ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %80
+ThrowNullRef44:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %84
+ThrowNullRef46:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %101
+ThrowNullRef48:                                   ; preds = %101
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %105
+ThrowNullRef50:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %110
+ThrowNullRef52:                                   ; preds = %110
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %115
+ThrowNullRef54:                                   ; preds = %115
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %120
+ThrowNullRef56:                                   ; preds = %120
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %125
+ThrowNullRef58:                                   ; preds = %125
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %130
+ThrowNullRef60:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %135
+ThrowNullRef62:                                   ; preds = %135
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %140
+ThrowNullRef64:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %145
+ThrowNullRef66:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %149
+ThrowNullRef68:                                   ; preds = %149
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %152
+ThrowNullRef70:                                   ; preds = %152
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %156
+ThrowNullRef72:                                   ; preds = %156
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %159
+ThrowNullRef74:                                   ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %163
+ThrowNullRef76:                                   ; preds = %163
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %166
+ThrowNullRef78:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %170
+ThrowNullRef80:                                   ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %173
+ThrowNullRef82:                                   ; preds = %173
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %180
+ThrowNullRef84:                                   ; preds = %180
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %182
+ThrowNullRef86:                                   ; preds = %182
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %194
+ThrowNullRef88:                                   ; preds = %194
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %200
+ThrowNullRef90:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %202
+ThrowNullRef92:                                   ; preds = %202
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %209
+ThrowNullRef94:                                   ; preds = %209
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %212
+ThrowNullRef96:                                   ; preds = %212
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %189
+ThrowNullRef98:                                   ; preds = %189
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %89
+ThrowNullRef100:                                  ; preds = %89
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14054,8 +15763,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 21
@@ -14068,8 +15777,8 @@ entry:
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 16)
   %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 21
@@ -14078,8 +15787,8 @@ entry:
 
 ; <label>:12                                      ; preds = %1, %10
   %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 21
@@ -14090,11 +15799,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %12
+ThrowNullRef4:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14110,8 +15819,8 @@ entry:
   store i32 %param1, i32* %arg1
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %1 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
@@ -14178,8 +15887,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 33
@@ -14192,8 +15901,8 @@ entry:
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 24)
   %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 33
@@ -14202,8 +15911,8 @@ entry:
 
 ; <label>:12                                      ; preds = %1, %10
   %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 33
@@ -14214,11 +15923,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %12
+ThrowNullRef4:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14231,8 +15940,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 53
@@ -14244,8 +15953,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 116)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 53
@@ -14254,8 +15963,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 53
@@ -14266,11 +15975,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14299,8 +16008,8 @@ entry:
 
 ; <label>:7                                       ; preds = %entry, %4
   %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %7
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 2
@@ -14324,8 +16033,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 54
@@ -14337,8 +16046,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 117)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
@@ -14347,8 +16056,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 54
@@ -14359,11 +16068,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14376,8 +16085,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 27
@@ -14389,8 +16098,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 118)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 27
@@ -14399,8 +16108,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 27
@@ -14411,11 +16120,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14428,8 +16137,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 28
@@ -14441,8 +16150,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 119)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 28
@@ -14451,8 +16160,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 28
@@ -14463,11 +16172,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14480,8 +16189,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 26
@@ -14493,8 +16202,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 107)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 26
@@ -14503,8 +16212,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 26
@@ -14515,11 +16224,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14532,8 +16241,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 25
@@ -14545,8 +16254,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 106)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 25
@@ -14555,8 +16264,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 25
@@ -14567,11 +16276,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14584,8 +16293,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 24
@@ -14597,8 +16306,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 105)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 24
@@ -14607,8 +16316,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 24
@@ -14619,11 +16328,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14648,8 +16357,8 @@ entry:
   %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %3)
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %2
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -14660,15 +16369,15 @@ entry:
 
 ; <label>:8                                       ; preds = %62
   %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 9
   %12 = load i32, i32 addrspace(1)* %11, align 8
   %13 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.IO.StreamWriter addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %13, i32 0, i32 10
@@ -14683,15 +16392,15 @@ entry:
 
 ; <label>:20                                      ; preds = %14, %18
   %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
   %24 = load i32, i32 addrspace(1)* %23, align 8
   %25 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %25, null
-  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.StreamWriter addrspace(1)* %25, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %25, i32 0, i32 9
@@ -14712,36 +16421,36 @@ entry:
   %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %37 = load i32, i32* %loc1
   %38 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.StreamWriter addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %35
   %40 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %38, i32 0, i32 7
   %41 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %40, align 8
   %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
-  br i1 %NullCheck14, label %43, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %39
   %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 9
   %45 = load i32, i32 addrspace(1)* %44, align 8
   %46 = load i32, i32* %loc2
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %36, null
-  br i1 %NullCheck16, label %47, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %36, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %47
 
 ; <label>:47                                      ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %36, i32 %37, %"System.Char[]" addrspace(1)* %41, i32 %45, i32 %46)
   %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
   %51 = load i32, i32 addrspace(1)* %50, align 8
   %52 = load i32, i32* %loc2
   %53 = add i32 %51, %52
-  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
-  br i1 %NullCheck20, label %54, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %54
 
 ; <label>:54                                      ; preds = %49
   %55 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
@@ -14763,8 +16472,8 @@ entry:
 
 ; <label>:65                                      ; preds = %62
   %66 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %66, null
-  br i1 %NullCheck2, label %67, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %66, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %67
 
 ; <label>:67                                      ; preds = %65
   %68 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %66, i32 0, i32 11
@@ -14785,49 +16494,259 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %65
+ThrowNullRef2:                                    ; preds = %65
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %20
+ThrowNullRef8:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %22
+ThrowNullRef10:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %35
+ThrowNullRef12:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %43
+ThrowNullRef16:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %47
+ThrowNullRef18:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method String::CopyTo using LLILCJit
-Failed to read String.CopyTo[loadElemA]
+Successfully read String.CopyTo
+
+define void @String.CopyTo(%System.String addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  %loc1 = alloca i16 addrspace(1)*
+  %loc2 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %1 = icmp ne %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg4
+  %7 = icmp sge i32 %6, 0
+  br i1 %7, label %13, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  unreachable
+
+; <label>:13                                      ; preds = %5
+  %14 = load i32, i32* %arg1
+  %15 = icmp sge i32 %14, 0
+  br i1 %15, label %21, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %18)
+  %20 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %20, %System.String addrspace(1)* %17, %System.String addrspace(1)* %19)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %20) #0
+  unreachable
+
+; <label>:21                                      ; preds = %13
+  %22 = load i32, i32* %arg4
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck, label %ThrowNullRef, label %24
+
+; <label>:24                                      ; preds = %21
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load i32, i32* %arg1
+  %28 = sub i32 %26, %27
+  %29 = icmp sle i32 %22, %28
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34, %System.String addrspace(1)* %31, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %24
+  %36 = load i32, i32* %arg3
+  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %37, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
+
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
+  %40 = load i32, i32 addrspace(1)* %39
+  %41 = zext i32 %40 to i64
+  %42 = trunc i64 %41 to i32
+  %43 = load i32, i32* %arg4
+  %44 = sub i32 %42, %43
+  %45 = icmp sgt i32 %36, %44
+  br i1 %45, label %49, label %46
+
+; <label>:46                                      ; preds = %38
+  %47 = load i32, i32* %arg3
+  %48 = icmp sge i32 %47, 0
+  br i1 %48, label %54, label %49
+
+; <label>:49                                      ; preds = %38, %46
+  %50 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %52 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %51)
+  %53 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53, %System.String addrspace(1)* %50, %System.String addrspace(1)* %52)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53) #0
+  unreachable
+
+; <label>:54                                      ; preds = %46
+  %55 = load i32, i32* %arg4
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %97, label %57
+
+; <label>:57                                      ; preds = %54
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %59
+
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 2
+  %61 = bitcast [0 x i16] addrspace(1)* %60 to i16 addrspace(1)*
+  store i16 addrspace(1)* %61, i16 addrspace(1)** %loc0
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  store %"System.Char[]" addrspace(1)* %62, %"System.Char[]" addrspace(1)** %loc2
+  %63 = icmp eq %"System.Char[]" addrspace(1)* %62, null
+  br i1 %63, label %72, label %64
+
+; <label>:64                                      ; preds = %59
+  %65 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc2
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %65, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %66
+
+; <label>:66                                      ; preds = %64
+  %67 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %65, i32 0, i32 1
+  %68 = load i32, i32 addrspace(1)* %67
+  %69 = zext i32 %68 to i64
+  %70 = trunc i64 %69 to i32
+  %71 = icmp ne i32 %70, 0
+  br i1 %71, label %73, label %72
+
+; <label>:72                                      ; preds = %59, %66
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  br label %81
+
+; <label>:73                                      ; preds = %66
+  %74 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc2
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %74, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %75
+
+; <label>:75                                      ; preds = %73
+  %76 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %74, i32 0, i32 1
+  %77 = load i32, i32 addrspace(1)* %76
+  %78 = zext i32 %77 to i64
+  %BoundsCheck = icmp uge i64 0, %78
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %79
+
+; <label>:79                                      ; preds = %75
+  %80 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %74, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %80, i16 addrspace(1)** %loc1
+  br label %81
+
+; <label>:81                                      ; preds = %72, %79
+  %82 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %83 = ptrtoint i16 addrspace(1)* %82 to i64
+  %84 = load i32, i32* %arg3
+  %85 = sext i32 %84 to i64
+  %86 = mul i64 %85, 2
+  %87 = add i64 %83, %86
+  %88 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %89 = ptrtoint i16 addrspace(1)* %88 to i64
+  %90 = load i32, i32* %arg1
+  %91 = sext i32 %90 to i64
+  %92 = mul i64 %91, 2
+  %93 = add i64 %89, %92
+  %94 = load i32, i32* %arg4
+  %95 = inttoptr i64 %87 to i16*
+  %96 = inttoptr i64 %93 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %95, i16* %96, i32 %94)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  br label %97
+
+; <label>:97                                      ; preds = %54, %81
+  ret void
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
 Successfully read ConsoleEncoding.GetPreamble
 
@@ -14864,7 +16783,365 @@ entry:
 }
 
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[loadElemA]
+Successfully read EncoderNLS.GetBytes
+
+define i32 @EncoderNLS.GetBytes(%System.Text.EncoderNLS addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3, %"System.Byte[]" addrspace(1)* %param4, i32 %param5, i8 %param6) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %arg4 = alloca %"System.Byte[]" addrspace(1)*
+  %arg5 = alloca i32
+  %arg6 = alloca i8
+  %loc0 = alloca i32
+  %loc1 = alloca i16 addrspace(1)*
+  %loc2 = alloca i8 addrspace(1)*
+  %loc3 = alloca i32
+  %loc4 = alloca %"System.Char[]" addrspace(1)*
+  %loc5 = alloca %"System.Byte[]" addrspace(1)*
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  store %"System.Byte[]" addrspace(1)* %param4, %"System.Byte[]" addrspace(1)** %arg4
+  store i32 %param5, i32* %arg5
+  store i8 %param6, i8* %arg6
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %1 = icmp eq %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %17, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %7 = icmp eq %"System.Char[]" addrspace(1)* %6, null
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %12
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %12
+
+; <label>:12                                      ; preds = %8, %10
+  %13 = phi %System.String addrspace(1)* [ %9, %8 ], [ %11, %10 ]
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %14)
+  %16 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16, %System.String addrspace(1)* %13, %System.String addrspace(1)* %15)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16) #0
+  unreachable
+
+; <label>:17                                      ; preds = %2
+  %18 = load i32, i32* %arg2
+  %19 = icmp slt i32 %18, 0
+  br i1 %19, label %23, label %20
+
+; <label>:20                                      ; preds = %17
+  %21 = load i32, i32* %arg3
+  %22 = icmp sge i32 %21, 0
+  br i1 %22, label %35, label %23
+
+; <label>:23                                      ; preds = %17, %20
+  %24 = load i32, i32* %arg2
+  %25 = icmp slt i32 %24, 0
+  br i1 %25, label %28, label %26
+
+; <label>:26                                      ; preds = %23
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %30
+
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %30
+
+; <label>:30                                      ; preds = %26, %28
+  %31 = phi %System.String addrspace(1)* [ %27, %26 ], [ %29, %28 ]
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34, %System.String addrspace(1)* %31, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %20
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck, label %ThrowNullRef, label %37
+
+; <label>:37                                      ; preds = %35
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = load i32, i32* %arg2
+  %43 = sub i32 %41, %42
+  %44 = load i32, i32* %arg3
+  %45 = icmp sge i32 %43, %44
+  br i1 %45, label %51, label %46
+
+; <label>:46                                      ; preds = %37
+  %47 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %48 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %49 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %48)
+  %50 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %50, %System.String addrspace(1)* %47, %System.String addrspace(1)* %49)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %50) #0
+  unreachable
+
+; <label>:51                                      ; preds = %37
+  %52 = load i32, i32* %arg5
+  %53 = icmp slt i32 %52, 0
+  br i1 %53, label %63, label %54
+
+; <label>:54                                      ; preds = %51
+  %55 = load i32, i32* %arg5
+  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck1 = icmp eq %"System.Byte[]" addrspace(1)* %56, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %57
+
+; <label>:57                                      ; preds = %54
+  %58 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = zext i32 %59 to i64
+  %61 = trunc i64 %60 to i32
+  %62 = icmp sle i32 %55, %61
+  br i1 %62, label %68, label %63
+
+; <label>:63                                      ; preds = %51, %57
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %66 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %65)
+  %67 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %67, %System.String addrspace(1)* %64, %System.String addrspace(1)* %66)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %67) #0
+  unreachable
+
+; <label>:68                                      ; preds = %57
+  %69 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %69, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %69, i32 0, i32 1
+  %72 = load i32, i32 addrspace(1)* %71
+  %73 = zext i32 %72 to i64
+  %74 = trunc i64 %73 to i32
+  %75 = icmp ne i32 %74, 0
+  br i1 %75, label %78, label %76
+
+; <label>:76                                      ; preds = %70
+  %77 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1)
+  store %"System.Char[]" addrspace(1)* %77, %"System.Char[]" addrspace(1)** %arg1
+  br label %78
+
+; <label>:78                                      ; preds = %70, %76
+  %79 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck5 = icmp eq %"System.Byte[]" addrspace(1)* %79, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %80
+
+; <label>:80                                      ; preds = %78
+  %81 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %79, i32 0, i32 1
+  %82 = load i32, i32 addrspace(1)* %81
+  %83 = zext i32 %82 to i64
+  %84 = trunc i64 %83 to i32
+  %85 = load i32, i32* %arg5
+  %86 = sub i32 %84, %85
+  store i32 %86, i32* %loc0
+  %87 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck7 = icmp eq %"System.Byte[]" addrspace(1)* %87, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %88
+
+; <label>:88                                      ; preds = %80
+  %89 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %87, i32 0, i32 1
+  %90 = load i32, i32 addrspace(1)* %89
+  %91 = zext i32 %90 to i64
+  %92 = trunc i64 %91 to i32
+  %93 = icmp ne i32 %92, 0
+  br i1 %93, label %96, label %94
+
+; <label>:94                                      ; preds = %88
+  %95 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1)
+  store %"System.Byte[]" addrspace(1)* %95, %"System.Byte[]" addrspace(1)** %arg4
+  br label %96
+
+; <label>:96                                      ; preds = %88, %94
+  %97 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  store %"System.Char[]" addrspace(1)* %97, %"System.Char[]" addrspace(1)** %loc4
+  %98 = icmp eq %"System.Char[]" addrspace(1)* %97, null
+  br i1 %98, label %107, label %99
+
+; <label>:99                                      ; preds = %96
+  %100 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc4
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %100, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %101
+
+; <label>:101                                     ; preds = %99
+  %102 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %100, i32 0, i32 1
+  %103 = load i32, i32 addrspace(1)* %102
+  %104 = zext i32 %103 to i64
+  %105 = trunc i64 %104 to i32
+  %106 = icmp ne i32 %105, 0
+  br i1 %106, label %108, label %107
+
+; <label>:107                                     ; preds = %96, %101
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  br label %116
+
+; <label>:108                                     ; preds = %101
+  %109 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc4
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %109, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %110
+
+; <label>:110                                     ; preds = %108
+  %111 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %109, i32 0, i32 1
+  %112 = load i32, i32 addrspace(1)* %111
+  %113 = zext i32 %112 to i64
+  %BoundsCheck = icmp uge i64 0, %113
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %114
+
+; <label>:114                                     ; preds = %110
+  %115 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %109, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %115, i16 addrspace(1)** %loc1
+  br label %116
+
+; <label>:116                                     ; preds = %107, %114
+  %117 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  store %"System.Byte[]" addrspace(1)* %117, %"System.Byte[]" addrspace(1)** %loc5
+  %118 = icmp eq %"System.Byte[]" addrspace(1)* %117, null
+  br i1 %118, label %127, label %119
+
+; <label>:119                                     ; preds = %116
+  %120 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc5
+  %NullCheck13 = icmp eq %"System.Byte[]" addrspace(1)* %120, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %121
+
+; <label>:121                                     ; preds = %119
+  %122 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %120, i32 0, i32 1
+  %123 = load i32, i32 addrspace(1)* %122
+  %124 = zext i32 %123 to i64
+  %125 = trunc i64 %124 to i32
+  %126 = icmp ne i32 %125, 0
+  br i1 %126, label %128, label %127
+
+; <label>:127                                     ; preds = %116, %121
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc2
+  br label %136
+
+; <label>:128                                     ; preds = %121
+  %129 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc5
+  %NullCheck15 = icmp eq %"System.Byte[]" addrspace(1)* %129, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %130
+
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %129, i32 0, i32 1
+  %132 = load i32, i32 addrspace(1)* %131
+  %133 = zext i32 %132 to i64
+  %BoundsCheck17 = icmp uge i64 0, %133
+  br i1 %BoundsCheck17, label %ThrowIndexOutOfRange18, label %134
+
+; <label>:134                                     ; preds = %130
+  %135 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %129, i32 0, i32 3, i32 0
+  store i8 addrspace(1)* %135, i8 addrspace(1)** %loc2
+  br label %136
+
+; <label>:136                                     ; preds = %127, %134
+  %137 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %138 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %139 = ptrtoint i16 addrspace(1)* %138 to i64
+  %140 = load i32, i32* %arg2
+  %141 = sext i32 %140 to i64
+  %142 = mul i64 %141, 2
+  %143 = add i64 %139, %142
+  %144 = load i32, i32* %arg3
+  %145 = load i8 addrspace(1)*, i8 addrspace(1)** %loc2
+  %146 = ptrtoint i8 addrspace(1)* %145 to i64
+  %147 = load i32, i32* %arg5
+  %148 = sext i32 %147 to i64
+  %149 = add i64 %146, %148
+  %150 = load i32, i32* %loc0
+  %151 = load i8, i8* %arg6
+  %152 = zext i8 %151 to i32
+  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i64 addrspace(1)*
+  %NullCheck19 = icmp eq i64 addrspace(1)* %153, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %154
+
+; <label>:154                                     ; preds = %136
+  %155 = load i64, i64 addrspace(1)* %153
+  %156 = add i64 %155, 72
+  %157 = inttoptr i64 %156 to i64*
+  %158 = load i64, i64* %157
+  %159 = add i64 %158, 0
+  %160 = inttoptr i64 %159 to i64*
+  %161 = load i64, i64* %160
+  %162 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to %System.Text.Encoder addrspace(1)*
+  %163 = inttoptr i64 %143 to i16*
+  %164 = inttoptr i64 %149 to i8*
+  %165 = trunc i32 %152 to i8
+  %166 = inttoptr i64 %161 to i32 (%System.Text.Encoder addrspace(1)*, i16*, i32, i8*, i32, i8)*
+  %167 = call i32 %166(%System.Text.Encoder addrspace(1)* %162, i16* %163, i32 %144, i8* %164, i32 %150, i8 %165)
+  store i32 %167, i32* %loc3
+  br label %168
+
+; <label>:168                                     ; preds = %154
+  %169 = load i32, i32* %loc3
+  ret i32 %169
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %110
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %119
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange18:                           ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
 Successfully read EncoderNLS.GetBytes
 
@@ -14953,22 +17230,22 @@ entry:
   %40 = load i8, i8* %arg5
   %41 = zext i8 %40 to i32
   %42 = trunc i32 %41 to i8
-  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %39, null
-  br i1 %NullCheck, label %43, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderNLS addrspace(1)* %39, null
+  br i1 %NullCheck, label %ThrowNullRef, label %43
 
 ; <label>:43                                      ; preds = %38
   %44 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
   store i8 %42, i8 addrspace(1)* %44
   %45 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %45, null
-  br i1 %NullCheck2, label %46, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.EncoderNLS addrspace(1)* %45, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %46
 
 ; <label>:46                                      ; preds = %43
   %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %45, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %47
   %48 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.EncoderNLS addrspace(1)* %48, null
-  br i1 %NullCheck4, label %49, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.EncoderNLS addrspace(1)* %48, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %49
 
 ; <label>:49                                      ; preds = %46
   %50 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %48, i32 0, i32 3
@@ -14979,8 +17256,8 @@ entry:
   %55 = load i32, i32* %arg4
   %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck6, label %58, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
   %59 = load i64, i64 addrspace(1)* %57
@@ -14998,15 +17275,15 @@ ThrowNullRef:                                     ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %43
+ThrowNullRef2:                                    ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %46
+ThrowNullRef4:                                    ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %49
+ThrowNullRef6:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -15034,8 +17311,8 @@ entry:
   %4 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0 to %System.IO.ConsoleStream addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*)(%System.IO.ConsoleStream addrspace(1)* %4, %"System.Byte[]" addrspace(1)* %1, i32 %2, i32 %3)
   %5 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
@@ -15120,8 +17397,8 @@ entry:
 
 ; <label>:22                                      ; preds = %8
   %23 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %23, null
-  br i1 %NullCheck, label %24, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Byte[]" addrspace(1)* %23, null
+  br i1 %NullCheck, label %ThrowNullRef, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
@@ -15143,8 +17420,8 @@ entry:
 
 ; <label>:36                                      ; preds = %24
   %37 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %37, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.ConsoleStream addrspace(1)* %37, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %37, i32 0, i32 4
@@ -15165,13 +17442,138 @@ ThrowNullRef:                                     ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %36
+ThrowNullRef2:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
-Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
+Successfully read WindowsConsoleStream.WriteFileNative
+
+define i32 @WindowsConsoleStream.WriteFileNative(i64 %param0, %"System.Byte[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i64
+  %arg1 = alloca %"System.Byte[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i8 addrspace(1)*
+  %loc2 = alloca %"System.Byte[]" addrspace(1)*
+  %loc3 = alloca i32
+  store i64 %param0, i64* %arg0
+  store %"System.Byte[]" addrspace(1)* %param1, %"System.Byte[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Byte[]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = zext i32 %3 to i64
+  %5 = icmp ne i64 %4, 0
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %1
+  ret i32 0
+
+; <label>:7                                       ; preds = %1
+  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  store %"System.Byte[]" addrspace(1)* %8, %"System.Byte[]" addrspace(1)** %loc2
+  %9 = icmp eq %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %9, label %18, label %10
+
+; <label>:10                                      ; preds = %7
+  %11 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc2
+  %NullCheck1 = icmp eq %"System.Byte[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %11, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp ne i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %7, %12
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc1
+  br label %27
+
+; <label>:19                                      ; preds = %12
+  %20 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc2
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %20, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %BoundsCheck = icmp uge i64 0, %24
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %25
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %20, i32 0, i32 3, i32 0
+  store i8 addrspace(1)* %26, i8 addrspace(1)** %loc1
+  br label %27
+
+; <label>:27                                      ; preds = %18, %25
+  %28 = load i64, i64* %arg0
+  %29 = load i8 addrspace(1)*, i8 addrspace(1)** %loc1
+  %30 = ptrtoint i8 addrspace(1)* %29 to i64
+  %31 = load i32, i32* %arg2
+  %32 = sext i32 %31 to i64
+  %33 = add i64 %30, %32
+  %34 = load i32, i32* %arg3
+  %35 = addrspacecast i32* %loc3 to i32 addrspace(1)*
+  %36 = inttoptr i64 %33 to i8*
+  %37 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i8*, i32, i32 addrspace(1)*, i64)*)(i64 %28, i8* %36, i32 %34, i32 addrspace(1)* %35, i64 0)
+  %38 = icmp ugt i32 %37, 0
+  %39 = sext i1 %38 to i32
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc1
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %42, label %41
+
+; <label>:41                                      ; preds = %27
+  ret i32 0
+
+; <label>:42                                      ; preds = %27
+  %43 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  store i32 %43, i32* %loc0
+  %44 = load i32, i32* %loc0
+  %45 = icmp eq i32 %44, 232
+  br i1 %45, label %49, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = load i32, i32* %loc0
+  %48 = icmp ne i32 %47, 109
+  br i1 %48, label %50, label %49
+
+; <label>:49                                      ; preds = %42, %46
+  ret i32 0
+
+; <label>:50                                      ; preds = %46
+  %51 = load i32, i32* %loc0
+  ret i32 %51
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
 Successfully read WindowsConsoleStream.Flush
 
@@ -15180,8 +17582,8 @@ entry:
   %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
   store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
@@ -15216,8 +17618,8 @@ entry:
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
   %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load i64, i64 addrspace(1)* %1
@@ -15256,15 +17658,15 @@ entry:
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.TextWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
   %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %3, align 8
   %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
   %7 = load i64, i64 addrspace(1)* %5
@@ -15282,7 +17684,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -15311,8 +17713,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %4)
   store i32 0, i32* %loc0
   %5 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Char[]" addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
@@ -15324,15 +17726,15 @@ entry:
 
 ; <label>:11                                      ; preds = %69
   %12 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %12, i32 0, i32 9
   %15 = load i32, i32 addrspace(1)* %14, align 8
   %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.IO.StreamWriter addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %16, i32 0, i32 10
@@ -15347,15 +17749,15 @@ entry:
 
 ; <label>:23                                      ; preds = %17, %21
   %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %24, null
-  br i1 %NullCheck8, label %25, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %24, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 10
   %27 = load i32, i32 addrspace(1)* %26, align 8
   %28 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %28, null
-  br i1 %NullCheck10, label %29, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.StreamWriter addrspace(1)* %28, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %28, i32 0, i32 9
@@ -15377,15 +17779,15 @@ entry:
   %40 = load i32, i32* %loc0
   %41 = mul i32 %40, 2
   %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
-  br i1 %NullCheck12, label %43, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %43
 
 ; <label>:43                                      ; preds = %38
   %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 7
   %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %44, align 8
   %46 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %46, null
-  br i1 %NullCheck14, label %47, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.IO.StreamWriter addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %47
 
 ; <label>:47                                      ; preds = %43
   %48 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %46, i32 0, i32 9
@@ -15397,16 +17799,16 @@ entry:
   %54 = bitcast %"System.Char[]" addrspace(1)* %45 to %System.Array addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %53, i32 %41, %System.Array addrspace(1)* %54, i32 %50, i32 %52)
   %55 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
-  br i1 %NullCheck16, label %56, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %56
 
 ; <label>:56                                      ; preds = %47
   %57 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
   %58 = load i32, i32 addrspace(1)* %57, align 8
   %59 = load i32, i32* %loc2
   %60 = add i32 %58, %59
-  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
-  br i1 %NullCheck18, label %61, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %61
 
 ; <label>:61                                      ; preds = %56
   %62 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
@@ -15428,8 +17830,8 @@ entry:
 
 ; <label>:72                                      ; preds = %69
   %73 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %73, null
-  br i1 %NullCheck2, label %74, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %73, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %74
 
 ; <label>:74                                      ; preds = %72
   %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %73, i32 0, i32 11
@@ -15450,39 +17852,39 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %72
+ThrowNullRef2:                                    ; preds = %72
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %23
+ThrowNullRef8:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef10:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %43
+ThrowNullRef14:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %47
+ThrowNullRef16:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %56
+ThrowNullRef18:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FibLoop.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FibLoop.error.txt
@@ -25,8 +25,8 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
@@ -40,8 +40,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
   %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
@@ -75,7 +75,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -90,8 +90,8 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %NullCheck = icmp ne i8 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = load i8, i8 addrspace(1)* %0, align 8
@@ -125,8 +125,8 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
@@ -159,8 +159,8 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -184,8 +184,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
   store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
@@ -195,8 +195,8 @@ entry:
 ; <label>:4                                       ; preds = %1
   %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
   %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
@@ -206,8 +206,8 @@ entry:
   %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
@@ -221,14 +221,14 @@ entry:
 
 ; <label>:17                                      ; preds = %14
   %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
   %21 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
@@ -238,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -249,8 +249,8 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
@@ -261,27 +261,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %30
+ThrowNullRef10:                                   ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -301,7 +301,89 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
-Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
+Successfully read AppDomainSetup.GetUnsecureApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.GetUnsecureApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %NullCheck = icmp eq %"System.String[]" addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %BoundsCheck = icmp uge i64 0, %5
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %6
+
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 3, i32 0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
+  ret %System.String addrspace(1)* %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_Value using LLILCJit
+Successfully read AppDomainSetup.get_Value
+
+define %"System.String[]" addrspace(1)* @AppDomainSetup.get_Value(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.String[]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 18)
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.String[]" addrspace(1)* addrspace(1)*, %"System.String[]" addrspace(1)*)*)(%"System.String[]" addrspace(1)* addrspace(1)* %9, %"System.String[]" addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %11, i32 0, i32 1
+  %14 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %13, align 8
+  ret %"System.String[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -319,8 +401,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -368,16 +450,16 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
   %5 = load i32, i32 addrspace(1)* %4
   %6 = sub i32 %5, 1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -389,7 +471,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -421,8 +503,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
@@ -456,8 +538,8 @@ entry:
 ; <label>:27                                      ; preds = %19
   %28 = load i32, i32* %arg1
   %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
-  br i1 %NullCheck2, label %30, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %29, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %30
 
 ; <label>:30                                      ; preds = %27
   %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
@@ -493,8 +575,8 @@ entry:
 ; <label>:49                                      ; preds = %46
   %50 = load i32, i32* %arg2
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck4, label %52, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
@@ -517,11 +599,11 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %27
+ThrowNullRef2:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %49
+ThrowNullRef4:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -544,16 +626,16 @@ entry:
   %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %0)
   store %System.String addrspace(1)* %1, %System.String addrspace(1)** %loc0
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 2
   %5 = bitcast [0 x i16] addrspace(1)* %4 to i16 addrspace(1)*
   store i16 addrspace(1)* %5, i16 addrspace(1)** %loc1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %3
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2
@@ -580,7 +662,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -691,15 +773,15 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %NullCheck132 = icmp ne i8* %21, null
-  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+  %NullCheck131 = icmp eq i8* %21, null
+  br i1 %NullCheck131, label %ThrowNullRef132, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = load i8, i8* %21, align 8
   %24 = zext i8 %23 to i32
   %25 = trunc i32 %24 to i8
-  %NullCheck134 = icmp ne i8* %20, null
-  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+  %NullCheck133 = icmp eq i8* %20, null
+  br i1 %NullCheck133, label %ThrowNullRef134, label %26
 
 ; <label>:26                                      ; preds = %22
   store i8 %25, i8* %20, align 8
@@ -709,16 +791,16 @@ entry:
   %28 = load i8*, i8** %arg0
   %29 = load i8*, i8** %arg1
   %30 = bitcast i8* %29 to i16*
-  %NullCheck128 = icmp ne i16* %30, null
-  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+  %NullCheck127 = icmp eq i16* %30, null
+  br i1 %NullCheck127, label %ThrowNullRef128, label %31
 
 ; <label>:31                                      ; preds = %27
   %32 = load i16, i16* %30, align 8
   %33 = sext i16 %32 to i32
   %34 = bitcast i8* %28 to i16*
   %35 = trunc i32 %33 to i16
-  %NullCheck130 = icmp ne i16* %34, null
-  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+  %NullCheck129 = icmp eq i16* %34, null
+  br i1 %NullCheck129, label %ThrowNullRef130, label %36
 
 ; <label>:36                                      ; preds = %31
   store i16 %35, i16* %34, align 8
@@ -728,16 +810,16 @@ entry:
   %38 = load i8*, i8** %arg0
   %39 = load i8*, i8** %arg1
   %40 = bitcast i8* %39 to i16*
-  %NullCheck120 = icmp ne i16* %40, null
-  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+  %NullCheck119 = icmp eq i16* %40, null
+  br i1 %NullCheck119, label %ThrowNullRef120, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i16, i16* %40, align 8
   %43 = sext i16 %42 to i32
   %44 = bitcast i8* %38 to i16*
   %45 = trunc i32 %43 to i16
-  %NullCheck122 = icmp ne i16* %44, null
-  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+  %NullCheck121 = icmp eq i16* %44, null
+  br i1 %NullCheck121, label %ThrowNullRef122, label %46
 
 ; <label>:46                                      ; preds = %41
   store i16 %45, i16* %44, align 8
@@ -745,15 +827,15 @@ entry:
   %48 = getelementptr inbounds i8, i8* %47, i64 2
   %49 = load i8*, i8** %arg1
   %50 = getelementptr inbounds i8, i8* %49, i64 2
-  %NullCheck124 = icmp ne i8* %50, null
-  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+  %NullCheck123 = icmp eq i8* %50, null
+  br i1 %NullCheck123, label %ThrowNullRef124, label %51
 
 ; <label>:51                                      ; preds = %46
   %52 = load i8, i8* %50, align 8
   %53 = zext i8 %52 to i32
   %54 = trunc i32 %53 to i8
-  %NullCheck126 = icmp ne i8* %48, null
-  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+  %NullCheck125 = icmp eq i8* %48, null
+  br i1 %NullCheck125, label %ThrowNullRef126, label %55
 
 ; <label>:55                                      ; preds = %51
   store i8 %54, i8* %48, align 8
@@ -763,14 +845,14 @@ entry:
   %57 = load i8*, i8** %arg0
   %58 = load i8*, i8** %arg1
   %59 = bitcast i8* %58 to i32*
-  %NullCheck116 = icmp ne i32* %59, null
-  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+  %NullCheck115 = icmp eq i32* %59, null
+  br i1 %NullCheck115, label %ThrowNullRef116, label %60
 
 ; <label>:60                                      ; preds = %56
   %61 = load i32, i32* %59, align 8
   %62 = bitcast i8* %57 to i32*
-  %NullCheck118 = icmp ne i32* %62, null
-  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+  %NullCheck117 = icmp eq i32* %62, null
+  br i1 %NullCheck117, label %ThrowNullRef118, label %63
 
 ; <label>:63                                      ; preds = %60
   store i32 %61, i32* %62, align 8
@@ -780,14 +862,14 @@ entry:
   %65 = load i8*, i8** %arg0
   %66 = load i8*, i8** %arg1
   %67 = bitcast i8* %66 to i32*
-  %NullCheck108 = icmp ne i32* %67, null
-  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+  %NullCheck107 = icmp eq i32* %67, null
+  br i1 %NullCheck107, label %ThrowNullRef108, label %68
 
 ; <label>:68                                      ; preds = %64
   %69 = load i32, i32* %67, align 8
   %70 = bitcast i8* %65 to i32*
-  %NullCheck110 = icmp ne i32* %70, null
-  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+  %NullCheck109 = icmp eq i32* %70, null
+  br i1 %NullCheck109, label %ThrowNullRef110, label %71
 
 ; <label>:71                                      ; preds = %68
   store i32 %69, i32* %70, align 8
@@ -795,15 +877,15 @@ entry:
   %73 = getelementptr inbounds i8, i8* %72, i64 4
   %74 = load i8*, i8** %arg1
   %75 = getelementptr inbounds i8, i8* %74, i64 4
-  %NullCheck112 = icmp ne i8* %75, null
-  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+  %NullCheck111 = icmp eq i8* %75, null
+  br i1 %NullCheck111, label %ThrowNullRef112, label %76
 
 ; <label>:76                                      ; preds = %71
   %77 = load i8, i8* %75, align 8
   %78 = zext i8 %77 to i32
   %79 = trunc i32 %78 to i8
-  %NullCheck114 = icmp ne i8* %73, null
-  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+  %NullCheck113 = icmp eq i8* %73, null
+  br i1 %NullCheck113, label %ThrowNullRef114, label %80
 
 ; <label>:80                                      ; preds = %76
   store i8 %79, i8* %73, align 8
@@ -813,14 +895,14 @@ entry:
   %82 = load i8*, i8** %arg0
   %83 = load i8*, i8** %arg1
   %84 = bitcast i8* %83 to i32*
-  %NullCheck100 = icmp ne i32* %84, null
-  br i1 %NullCheck100, label %85, label %ThrowNullRef99
+  %NullCheck99 = icmp eq i32* %84, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %85
 
 ; <label>:85                                      ; preds = %81
   %86 = load i32, i32* %84, align 8
   %87 = bitcast i8* %82 to i32*
-  %NullCheck102 = icmp ne i32* %87, null
-  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+  %NullCheck101 = icmp eq i32* %87, null
+  br i1 %NullCheck101, label %ThrowNullRef102, label %88
 
 ; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
@@ -829,16 +911,16 @@ entry:
   %91 = load i8*, i8** %arg1
   %92 = getelementptr inbounds i8, i8* %91, i64 4
   %93 = bitcast i8* %92 to i16*
-  %NullCheck104 = icmp ne i16* %93, null
-  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+  %NullCheck103 = icmp eq i16* %93, null
+  br i1 %NullCheck103, label %ThrowNullRef104, label %94
 
 ; <label>:94                                      ; preds = %88
   %95 = load i16, i16* %93, align 8
   %96 = sext i16 %95 to i32
   %97 = bitcast i8* %90 to i16*
   %98 = trunc i32 %96 to i16
-  %NullCheck106 = icmp ne i16* %97, null
-  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+  %NullCheck105 = icmp eq i16* %97, null
+  br i1 %NullCheck105, label %ThrowNullRef106, label %99
 
 ; <label>:99                                      ; preds = %94
   store i16 %98, i16* %97, align 8
@@ -848,14 +930,14 @@ entry:
   %101 = load i8*, i8** %arg0
   %102 = load i8*, i8** %arg1
   %103 = bitcast i8* %102 to i32*
-  %NullCheck88 = icmp ne i32* %103, null
-  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+  %NullCheck87 = icmp eq i32* %103, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %104
 
 ; <label>:104                                     ; preds = %100
   %105 = load i32, i32* %103, align 8
   %106 = bitcast i8* %101 to i32*
-  %NullCheck90 = icmp ne i32* %106, null
-  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+  %NullCheck89 = icmp eq i32* %106, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %107
 
 ; <label>:107                                     ; preds = %104
   store i32 %105, i32* %106, align 8
@@ -864,16 +946,16 @@ entry:
   %110 = load i8*, i8** %arg1
   %111 = getelementptr inbounds i8, i8* %110, i64 4
   %112 = bitcast i8* %111 to i16*
-  %NullCheck92 = icmp ne i16* %112, null
-  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+  %NullCheck91 = icmp eq i16* %112, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %113
 
 ; <label>:113                                     ; preds = %107
   %114 = load i16, i16* %112, align 8
   %115 = sext i16 %114 to i32
   %116 = bitcast i8* %109 to i16*
   %117 = trunc i32 %115 to i16
-  %NullCheck94 = icmp ne i16* %116, null
-  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+  %NullCheck93 = icmp eq i16* %116, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %118
 
 ; <label>:118                                     ; preds = %113
   store i16 %117, i16* %116, align 8
@@ -881,15 +963,15 @@ entry:
   %120 = getelementptr inbounds i8, i8* %119, i64 6
   %121 = load i8*, i8** %arg1
   %122 = getelementptr inbounds i8, i8* %121, i64 6
-  %NullCheck96 = icmp ne i8* %122, null
-  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+  %NullCheck95 = icmp eq i8* %122, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %123
 
 ; <label>:123                                     ; preds = %118
   %124 = load i8, i8* %122, align 8
   %125 = zext i8 %124 to i32
   %126 = trunc i32 %125 to i8
-  %NullCheck98 = icmp ne i8* %120, null
-  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+  %NullCheck97 = icmp eq i8* %120, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %127
 
 ; <label>:127                                     ; preds = %123
   store i8 %126, i8* %120, align 8
@@ -899,14 +981,14 @@ entry:
   %129 = load i8*, i8** %arg0
   %130 = load i8*, i8** %arg1
   %131 = bitcast i8* %130 to i64*
-  %NullCheck84 = icmp ne i64* %131, null
-  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+  %NullCheck83 = icmp eq i64* %131, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %132
 
 ; <label>:132                                     ; preds = %128
   %133 = load i64, i64* %131, align 8
   %134 = bitcast i8* %129 to i64*
-  %NullCheck86 = icmp ne i64* %134, null
-  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+  %NullCheck85 = icmp eq i64* %134, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %135
 
 ; <label>:135                                     ; preds = %132
   store i64 %133, i64* %134, align 8
@@ -916,14 +998,14 @@ entry:
   %137 = load i8*, i8** %arg0
   %138 = load i8*, i8** %arg1
   %139 = bitcast i8* %138 to i64*
-  %NullCheck76 = icmp ne i64* %139, null
-  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+  %NullCheck75 = icmp eq i64* %139, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %140
 
 ; <label>:140                                     ; preds = %136
   %141 = load i64, i64* %139, align 8
   %142 = bitcast i8* %137 to i64*
-  %NullCheck78 = icmp ne i64* %142, null
-  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+  %NullCheck77 = icmp eq i64* %142, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %143
 
 ; <label>:143                                     ; preds = %140
   store i64 %141, i64* %142, align 8
@@ -931,15 +1013,15 @@ entry:
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %NullCheck80 = icmp ne i8* %147, null
-  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+  %NullCheck79 = icmp eq i8* %147, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %148
 
 ; <label>:148                                     ; preds = %143
   %149 = load i8, i8* %147, align 8
   %150 = zext i8 %149 to i32
   %151 = trunc i32 %150 to i8
-  %NullCheck82 = icmp ne i8* %145, null
-  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+  %NullCheck81 = icmp eq i8* %145, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %152
 
 ; <label>:152                                     ; preds = %148
   store i8 %151, i8* %145, align 8
@@ -949,14 +1031,14 @@ entry:
   %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
   %156 = bitcast i8* %155 to i64*
-  %NullCheck68 = icmp ne i64* %156, null
-  br i1 %NullCheck68, label %157, label %ThrowNullRef67
+  %NullCheck67 = icmp eq i64* %156, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %157
 
 ; <label>:157                                     ; preds = %153
   %158 = load i64, i64* %156, align 8
   %159 = bitcast i8* %154 to i64*
-  %NullCheck70 = icmp ne i64* %159, null
-  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+  %NullCheck69 = icmp eq i64* %159, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %160
 
 ; <label>:160                                     ; preds = %157
   store i64 %158, i64* %159, align 8
@@ -965,16 +1047,16 @@ entry:
   %163 = load i8*, i8** %arg1
   %164 = getelementptr inbounds i8, i8* %163, i64 8
   %165 = bitcast i8* %164 to i16*
-  %NullCheck72 = icmp ne i16* %165, null
-  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+  %NullCheck71 = icmp eq i16* %165, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %166
 
 ; <label>:166                                     ; preds = %160
   %167 = load i16, i16* %165, align 8
   %168 = sext i16 %167 to i32
   %169 = bitcast i8* %162 to i16*
   %170 = trunc i32 %168 to i16
-  %NullCheck74 = icmp ne i16* %169, null
-  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+  %NullCheck73 = icmp eq i16* %169, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %171
 
 ; <label>:171                                     ; preds = %166
   store i16 %170, i16* %169, align 8
@@ -984,14 +1066,14 @@ entry:
   %173 = load i8*, i8** %arg0
   %174 = load i8*, i8** %arg1
   %175 = bitcast i8* %174 to i64*
-  %NullCheck56 = icmp ne i64* %175, null
-  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+  %NullCheck55 = icmp eq i64* %175, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %176
 
 ; <label>:176                                     ; preds = %172
   %177 = load i64, i64* %175, align 8
   %178 = bitcast i8* %173 to i64*
-  %NullCheck58 = icmp ne i64* %178, null
-  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+  %NullCheck57 = icmp eq i64* %178, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %179
 
 ; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
@@ -1000,16 +1082,16 @@ entry:
   %182 = load i8*, i8** %arg1
   %183 = getelementptr inbounds i8, i8* %182, i64 8
   %184 = bitcast i8* %183 to i16*
-  %NullCheck60 = icmp ne i16* %184, null
-  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+  %NullCheck59 = icmp eq i16* %184, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %185
 
 ; <label>:185                                     ; preds = %179
   %186 = load i16, i16* %184, align 8
   %187 = sext i16 %186 to i32
   %188 = bitcast i8* %181 to i16*
   %189 = trunc i32 %187 to i16
-  %NullCheck62 = icmp ne i16* %188, null
-  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+  %NullCheck61 = icmp eq i16* %188, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %190
 
 ; <label>:190                                     ; preds = %185
   store i16 %189, i16* %188, align 8
@@ -1017,15 +1099,15 @@ entry:
   %192 = getelementptr inbounds i8, i8* %191, i64 10
   %193 = load i8*, i8** %arg1
   %194 = getelementptr inbounds i8, i8* %193, i64 10
-  %NullCheck64 = icmp ne i8* %194, null
-  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+  %NullCheck63 = icmp eq i8* %194, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %195
 
 ; <label>:195                                     ; preds = %190
   %196 = load i8, i8* %194, align 8
   %197 = zext i8 %196 to i32
   %198 = trunc i32 %197 to i8
-  %NullCheck66 = icmp ne i8* %192, null
-  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+  %NullCheck65 = icmp eq i8* %192, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %199
 
 ; <label>:199                                     ; preds = %195
   store i8 %198, i8* %192, align 8
@@ -1035,14 +1117,14 @@ entry:
   %201 = load i8*, i8** %arg0
   %202 = load i8*, i8** %arg1
   %203 = bitcast i8* %202 to i64*
-  %NullCheck48 = icmp ne i64* %203, null
-  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+  %NullCheck47 = icmp eq i64* %203, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %204
 
 ; <label>:204                                     ; preds = %200
   %205 = load i64, i64* %203, align 8
   %206 = bitcast i8* %201 to i64*
-  %NullCheck50 = icmp ne i64* %206, null
-  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+  %NullCheck49 = icmp eq i64* %206, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %207
 
 ; <label>:207                                     ; preds = %204
   store i64 %205, i64* %206, align 8
@@ -1051,14 +1133,14 @@ entry:
   %210 = load i8*, i8** %arg1
   %211 = getelementptr inbounds i8, i8* %210, i64 8
   %212 = bitcast i8* %211 to i32*
-  %NullCheck52 = icmp ne i32* %212, null
-  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+  %NullCheck51 = icmp eq i32* %212, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %213
 
 ; <label>:213                                     ; preds = %207
   %214 = load i32, i32* %212, align 8
   %215 = bitcast i8* %209 to i32*
-  %NullCheck54 = icmp ne i32* %215, null
-  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+  %NullCheck53 = icmp eq i32* %215, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %216
 
 ; <label>:216                                     ; preds = %213
   store i32 %214, i32* %215, align 8
@@ -1068,14 +1150,14 @@ entry:
   %218 = load i8*, i8** %arg0
   %219 = load i8*, i8** %arg1
   %220 = bitcast i8* %219 to i64*
-  %NullCheck36 = icmp ne i64* %220, null
-  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64* %220, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %221
 
 ; <label>:221                                     ; preds = %217
   %222 = load i64, i64* %220, align 8
   %223 = bitcast i8* %218 to i64*
-  %NullCheck38 = icmp ne i64* %223, null
-  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+  %NullCheck37 = icmp eq i64* %223, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %224
 
 ; <label>:224                                     ; preds = %221
   store i64 %222, i64* %223, align 8
@@ -1084,14 +1166,14 @@ entry:
   %227 = load i8*, i8** %arg1
   %228 = getelementptr inbounds i8, i8* %227, i64 8
   %229 = bitcast i8* %228 to i32*
-  %NullCheck40 = icmp ne i32* %229, null
-  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i32* %229, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %230
 
 ; <label>:230                                     ; preds = %224
   %231 = load i32, i32* %229, align 8
   %232 = bitcast i8* %226 to i32*
-  %NullCheck42 = icmp ne i32* %232, null
-  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+  %NullCheck41 = icmp eq i32* %232, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %233
 
 ; <label>:233                                     ; preds = %230
   store i32 %231, i32* %232, align 8
@@ -1099,15 +1181,15 @@ entry:
   %235 = getelementptr inbounds i8, i8* %234, i64 12
   %236 = load i8*, i8** %arg1
   %237 = getelementptr inbounds i8, i8* %236, i64 12
-  %NullCheck44 = icmp ne i8* %237, null
-  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i8* %237, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %238
 
 ; <label>:238                                     ; preds = %233
   %239 = load i8, i8* %237, align 8
   %240 = zext i8 %239 to i32
   %241 = trunc i32 %240 to i8
-  %NullCheck46 = icmp ne i8* %235, null
-  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+  %NullCheck45 = icmp eq i8* %235, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %242
 
 ; <label>:242                                     ; preds = %238
   store i8 %241, i8* %235, align 8
@@ -1117,14 +1199,14 @@ entry:
   %244 = load i8*, i8** %arg0
   %245 = load i8*, i8** %arg1
   %246 = bitcast i8* %245 to i64*
-  %NullCheck24 = icmp ne i64* %246, null
-  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64* %246, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %247
 
 ; <label>:247                                     ; preds = %243
   %248 = load i64, i64* %246, align 8
   %249 = bitcast i8* %244 to i64*
-  %NullCheck26 = icmp ne i64* %249, null
-  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64* %249, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %250
 
 ; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
@@ -1133,14 +1215,14 @@ entry:
   %253 = load i8*, i8** %arg1
   %254 = getelementptr inbounds i8, i8* %253, i64 8
   %255 = bitcast i8* %254 to i32*
-  %NullCheck28 = icmp ne i32* %255, null
-  br i1 %NullCheck28, label %256, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i32* %255, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %256
 
 ; <label>:256                                     ; preds = %250
   %257 = load i32, i32* %255, align 8
   %258 = bitcast i8* %252 to i32*
-  %NullCheck30 = icmp ne i32* %258, null
-  br i1 %NullCheck30, label %259, label %ThrowNullRef29
+  %NullCheck29 = icmp eq i32* %258, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %259
 
 ; <label>:259                                     ; preds = %256
   store i32 %257, i32* %258, align 8
@@ -1149,16 +1231,16 @@ entry:
   %262 = load i8*, i8** %arg1
   %263 = getelementptr inbounds i8, i8* %262, i64 12
   %264 = bitcast i8* %263 to i16*
-  %NullCheck32 = icmp ne i16* %264, null
-  br i1 %NullCheck32, label %265, label %ThrowNullRef31
+  %NullCheck31 = icmp eq i16* %264, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %265
 
 ; <label>:265                                     ; preds = %259
   %266 = load i16, i16* %264, align 8
   %267 = sext i16 %266 to i32
   %268 = bitcast i8* %261 to i16*
   %269 = trunc i32 %267 to i16
-  %NullCheck34 = icmp ne i16* %268, null
-  br i1 %NullCheck34, label %270, label %ThrowNullRef33
+  %NullCheck33 = icmp eq i16* %268, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %270
 
 ; <label>:270                                     ; preds = %265
   store i16 %269, i16* %268, align 8
@@ -1168,14 +1250,14 @@ entry:
   %272 = load i8*, i8** %arg0
   %273 = load i8*, i8** %arg1
   %274 = bitcast i8* %273 to i64*
-  %NullCheck8 = icmp ne i64* %274, null
-  br i1 %NullCheck8, label %275, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64* %274, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %275
 
 ; <label>:275                                     ; preds = %271
   %276 = load i64, i64* %274, align 8
   %277 = bitcast i8* %272 to i64*
-  %NullCheck10 = icmp ne i64* %277, null
-  br i1 %NullCheck10, label %278, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %277, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %278
 
 ; <label>:278                                     ; preds = %275
   store i64 %276, i64* %277, align 8
@@ -1184,14 +1266,14 @@ entry:
   %281 = load i8*, i8** %arg1
   %282 = getelementptr inbounds i8, i8* %281, i64 8
   %283 = bitcast i8* %282 to i32*
-  %NullCheck12 = icmp ne i32* %283, null
-  br i1 %NullCheck12, label %284, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i32* %283, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %284
 
 ; <label>:284                                     ; preds = %278
   %285 = load i32, i32* %283, align 8
   %286 = bitcast i8* %280 to i32*
-  %NullCheck14 = icmp ne i32* %286, null
-  br i1 %NullCheck14, label %287, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i32* %286, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %287
 
 ; <label>:287                                     ; preds = %284
   store i32 %285, i32* %286, align 8
@@ -1200,16 +1282,16 @@ entry:
   %290 = load i8*, i8** %arg1
   %291 = getelementptr inbounds i8, i8* %290, i64 12
   %292 = bitcast i8* %291 to i16*
-  %NullCheck16 = icmp ne i16* %292, null
-  br i1 %NullCheck16, label %293, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i16* %292, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %293
 
 ; <label>:293                                     ; preds = %287
   %294 = load i16, i16* %292, align 8
   %295 = sext i16 %294 to i32
   %296 = bitcast i8* %289 to i16*
   %297 = trunc i32 %295 to i16
-  %NullCheck18 = icmp ne i16* %296, null
-  br i1 %NullCheck18, label %298, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i16* %296, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %298
 
 ; <label>:298                                     ; preds = %293
   store i16 %297, i16* %296, align 8
@@ -1217,15 +1299,15 @@ entry:
   %300 = getelementptr inbounds i8, i8* %299, i64 14
   %301 = load i8*, i8** %arg1
   %302 = getelementptr inbounds i8, i8* %301, i64 14
-  %NullCheck20 = icmp ne i8* %302, null
-  br i1 %NullCheck20, label %303, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i8* %302, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %303
 
 ; <label>:303                                     ; preds = %298
   %304 = load i8, i8* %302, align 8
   %305 = zext i8 %304 to i32
   %306 = trunc i32 %305 to i8
-  %NullCheck22 = icmp ne i8* %300, null
-  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i8* %300, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %307
 
 ; <label>:307                                     ; preds = %303
   store i8 %306, i8* %300, align 8
@@ -1235,14 +1317,14 @@ entry:
   %309 = load i8*, i8** %arg0
   %310 = load i8*, i8** %arg1
   %311 = bitcast i8* %310 to i64*
-  %NullCheck = icmp ne i64* %311, null
-  br i1 %NullCheck, label %312, label %ThrowNullRef
+  %NullCheck = icmp eq i64* %311, null
+  br i1 %NullCheck, label %ThrowNullRef, label %312
 
 ; <label>:312                                     ; preds = %308
   %313 = load i64, i64* %311, align 8
   %314 = bitcast i8* %309 to i64*
-  %NullCheck2 = icmp ne i64* %314, null
-  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64* %314, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %315
 
 ; <label>:315                                     ; preds = %312
   store i64 %313, i64* %314, align 8
@@ -1251,14 +1333,14 @@ entry:
   %318 = load i8*, i8** %arg1
   %319 = getelementptr inbounds i8, i8* %318, i64 8
   %320 = bitcast i8* %319 to i64*
-  %NullCheck4 = icmp ne i64* %320, null
-  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64* %320, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %321
 
 ; <label>:321                                     ; preds = %315
   %322 = load i64, i64* %320, align 8
   %323 = bitcast i8* %317 to i64*
-  %NullCheck6 = icmp ne i64* %323, null
-  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64* %323, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %324
 
 ; <label>:324                                     ; preds = %321
   store i64 %322, i64* %323, align 8
@@ -1286,15 +1368,15 @@ entry:
 ; <label>:338                                     ; preds = %333
   %339 = load i8*, i8** %arg0
   %340 = load i8*, i8** %arg1
-  %NullCheck136 = icmp ne i8* %340, null
-  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+  %NullCheck135 = icmp eq i8* %340, null
+  br i1 %NullCheck135, label %ThrowNullRef136, label %341
 
 ; <label>:341                                     ; preds = %338
   %342 = load i8, i8* %340, align 8
   %343 = zext i8 %342 to i32
   %344 = trunc i32 %343 to i8
-  %NullCheck138 = icmp ne i8* %339, null
-  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+  %NullCheck137 = icmp eq i8* %339, null
+  br i1 %NullCheck137, label %ThrowNullRef138, label %345
 
 ; <label>:345                                     ; preds = %341
   store i8 %344, i8* %339, align 8
@@ -1317,16 +1399,16 @@ entry:
   %357 = load i8*, i8** %arg0
   %358 = load i8*, i8** %arg1
   %359 = bitcast i8* %358 to i16*
-  %NullCheck140 = icmp ne i16* %359, null
-  br i1 %NullCheck140, label %360, label %ThrowNullRef139
+  %NullCheck139 = icmp eq i16* %359, null
+  br i1 %NullCheck139, label %ThrowNullRef140, label %360
 
 ; <label>:360                                     ; preds = %356
   %361 = load i16, i16* %359, align 8
   %362 = sext i16 %361 to i32
   %363 = bitcast i8* %357 to i16*
   %364 = trunc i32 %362 to i16
-  %NullCheck142 = icmp ne i16* %363, null
-  br i1 %NullCheck142, label %365, label %ThrowNullRef141
+  %NullCheck141 = icmp eq i16* %363, null
+  br i1 %NullCheck141, label %ThrowNullRef142, label %365
 
 ; <label>:365                                     ; preds = %360
   store i16 %364, i16* %363, align 8
@@ -1352,14 +1434,14 @@ entry:
   %378 = load i8*, i8** %arg0
   %379 = load i8*, i8** %arg1
   %380 = bitcast i8* %379 to i32*
-  %NullCheck144 = icmp ne i32* %380, null
-  br i1 %NullCheck144, label %381, label %ThrowNullRef143
+  %NullCheck143 = icmp eq i32* %380, null
+  br i1 %NullCheck143, label %ThrowNullRef144, label %381
 
 ; <label>:381                                     ; preds = %377
   %382 = load i32, i32* %380, align 8
   %383 = bitcast i8* %378 to i32*
-  %NullCheck146 = icmp ne i32* %383, null
-  br i1 %NullCheck146, label %384, label %ThrowNullRef145
+  %NullCheck145 = icmp eq i32* %383, null
+  br i1 %NullCheck145, label %ThrowNullRef146, label %384
 
 ; <label>:384                                     ; preds = %381
   store i32 %382, i32* %383, align 8
@@ -1384,14 +1466,14 @@ entry:
   %395 = load i8*, i8** %arg0
   %396 = load i8*, i8** %arg1
   %397 = bitcast i8* %396 to i64*
-  %NullCheck164 = icmp ne i64* %397, null
-  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+  %NullCheck163 = icmp eq i64* %397, null
+  br i1 %NullCheck163, label %ThrowNullRef164, label %398
 
 ; <label>:398                                     ; preds = %394
   %399 = load i64, i64* %397, align 8
   %400 = bitcast i8* %395 to i64*
-  %NullCheck166 = icmp ne i64* %400, null
-  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+  %NullCheck165 = icmp eq i64* %400, null
+  br i1 %NullCheck165, label %ThrowNullRef166, label %401
 
 ; <label>:401                                     ; preds = %398
   store i64 %399, i64* %400, align 8
@@ -1400,14 +1482,14 @@ entry:
   %404 = load i8*, i8** %arg1
   %405 = getelementptr inbounds i8, i8* %404, i64 8
   %406 = bitcast i8* %405 to i64*
-  %NullCheck168 = icmp ne i64* %406, null
-  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+  %NullCheck167 = icmp eq i64* %406, null
+  br i1 %NullCheck167, label %ThrowNullRef168, label %407
 
 ; <label>:407                                     ; preds = %401
   %408 = load i64, i64* %406, align 8
   %409 = bitcast i8* %403 to i64*
-  %NullCheck170 = icmp ne i64* %409, null
-  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+  %NullCheck169 = icmp eq i64* %409, null
+  br i1 %NullCheck169, label %ThrowNullRef170, label %410
 
 ; <label>:410                                     ; preds = %407
   store i64 %408, i64* %409, align 8
@@ -1437,14 +1519,14 @@ entry:
   %425 = load i8*, i8** %arg0
   %426 = load i8*, i8** %arg1
   %427 = bitcast i8* %426 to i64*
-  %NullCheck148 = icmp ne i64* %427, null
-  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+  %NullCheck147 = icmp eq i64* %427, null
+  br i1 %NullCheck147, label %ThrowNullRef148, label %428
 
 ; <label>:428                                     ; preds = %424
   %429 = load i64, i64* %427, align 8
   %430 = bitcast i8* %425 to i64*
-  %NullCheck150 = icmp ne i64* %430, null
-  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+  %NullCheck149 = icmp eq i64* %430, null
+  br i1 %NullCheck149, label %ThrowNullRef150, label %431
 
 ; <label>:431                                     ; preds = %428
   store i64 %429, i64* %430, align 8
@@ -1466,14 +1548,14 @@ entry:
   %441 = load i8*, i8** %arg0
   %442 = load i8*, i8** %arg1
   %443 = bitcast i8* %442 to i32*
-  %NullCheck152 = icmp ne i32* %443, null
-  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+  %NullCheck151 = icmp eq i32* %443, null
+  br i1 %NullCheck151, label %ThrowNullRef152, label %444
 
 ; <label>:444                                     ; preds = %440
   %445 = load i32, i32* %443, align 8
   %446 = bitcast i8* %441 to i32*
-  %NullCheck154 = icmp ne i32* %446, null
-  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+  %NullCheck153 = icmp eq i32* %446, null
+  br i1 %NullCheck153, label %ThrowNullRef154, label %447
 
 ; <label>:447                                     ; preds = %444
   store i32 %445, i32* %446, align 8
@@ -1495,16 +1577,16 @@ entry:
   %457 = load i8*, i8** %arg0
   %458 = load i8*, i8** %arg1
   %459 = bitcast i8* %458 to i16*
-  %NullCheck156 = icmp ne i16* %459, null
-  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+  %NullCheck155 = icmp eq i16* %459, null
+  br i1 %NullCheck155, label %ThrowNullRef156, label %460
 
 ; <label>:460                                     ; preds = %456
   %461 = load i16, i16* %459, align 8
   %462 = sext i16 %461 to i32
   %463 = bitcast i8* %457 to i16*
   %464 = trunc i32 %462 to i16
-  %NullCheck158 = icmp ne i16* %463, null
-  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+  %NullCheck157 = icmp eq i16* %463, null
+  br i1 %NullCheck157, label %ThrowNullRef158, label %465
 
 ; <label>:465                                     ; preds = %460
   store i16 %464, i16* %463, align 8
@@ -1525,15 +1607,15 @@ entry:
 ; <label>:474                                     ; preds = %470
   %475 = load i8*, i8** %arg0
   %476 = load i8*, i8** %arg1
-  %NullCheck160 = icmp ne i8* %476, null
-  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+  %NullCheck159 = icmp eq i8* %476, null
+  br i1 %NullCheck159, label %ThrowNullRef160, label %477
 
 ; <label>:477                                     ; preds = %474
   %478 = load i8, i8* %476, align 8
   %479 = zext i8 %478 to i32
   %480 = trunc i32 %479 to i8
-  %NullCheck162 = icmp ne i8* %475, null
-  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+  %NullCheck161 = icmp eq i8* %475, null
+  br i1 %NullCheck161, label %ThrowNullRef162, label %481
 
 ; <label>:481                                     ; preds = %477
   store i8 %480, i8* %475, align 8
@@ -1553,343 +1635,343 @@ ThrowNullRef:                                     ; preds = %308
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %312
+ThrowNullRef2:                                    ; preds = %312
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %315
+ThrowNullRef4:                                    ; preds = %315
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %321
+ThrowNullRef6:                                    ; preds = %321
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %271
+ThrowNullRef8:                                    ; preds = %271
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %275
+ThrowNullRef10:                                   ; preds = %275
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %278
+ThrowNullRef12:                                   ; preds = %278
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %284
+ThrowNullRef14:                                   ; preds = %284
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %287
+ThrowNullRef16:                                   ; preds = %287
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %293
+ThrowNullRef18:                                   ; preds = %293
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %298
+ThrowNullRef20:                                   ; preds = %298
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %303
+ThrowNullRef22:                                   ; preds = %303
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %243
+ThrowNullRef24:                                   ; preds = %243
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %247
+ThrowNullRef26:                                   ; preds = %247
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %250
+ThrowNullRef28:                                   ; preds = %250
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %256
+ThrowNullRef30:                                   ; preds = %256
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %259
+ThrowNullRef32:                                   ; preds = %259
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %265
+ThrowNullRef34:                                   ; preds = %265
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %217
+ThrowNullRef36:                                   ; preds = %217
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %221
+ThrowNullRef38:                                   ; preds = %221
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %224
+ThrowNullRef40:                                   ; preds = %224
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %230
+ThrowNullRef42:                                   ; preds = %230
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %233
+ThrowNullRef44:                                   ; preds = %233
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %238
+ThrowNullRef46:                                   ; preds = %238
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %200
+ThrowNullRef48:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %204
+ThrowNullRef50:                                   ; preds = %204
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %207
+ThrowNullRef52:                                   ; preds = %207
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %213
+ThrowNullRef54:                                   ; preds = %213
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %172
+ThrowNullRef56:                                   ; preds = %172
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %176
+ThrowNullRef58:                                   ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %179
+ThrowNullRef60:                                   ; preds = %179
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %185
+ThrowNullRef62:                                   ; preds = %185
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %190
+ThrowNullRef64:                                   ; preds = %190
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %195
+ThrowNullRef66:                                   ; preds = %195
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %153
+ThrowNullRef68:                                   ; preds = %153
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %157
+ThrowNullRef70:                                   ; preds = %157
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %160
+ThrowNullRef72:                                   ; preds = %160
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %166
+ThrowNullRef74:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %136
+ThrowNullRef76:                                   ; preds = %136
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %140
+ThrowNullRef78:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %143
+ThrowNullRef80:                                   ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %148
+ThrowNullRef82:                                   ; preds = %148
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %128
+ThrowNullRef84:                                   ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %132
+ThrowNullRef86:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %100
+ThrowNullRef88:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %104
+ThrowNullRef90:                                   ; preds = %104
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %107
+ThrowNullRef92:                                   ; preds = %107
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %113
+ThrowNullRef94:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %118
+ThrowNullRef96:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %123
+ThrowNullRef98:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %81
+ThrowNullRef100:                                  ; preds = %81
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef101:                                  ; preds = %85
+ThrowNullRef102:                                  ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef103:                                  ; preds = %88
+ThrowNullRef104:                                  ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef105:                                  ; preds = %94
+ThrowNullRef106:                                  ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef107:                                  ; preds = %64
+ThrowNullRef108:                                  ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef109:                                  ; preds = %68
+ThrowNullRef110:                                  ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef111:                                  ; preds = %71
+ThrowNullRef112:                                  ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef113:                                  ; preds = %76
+ThrowNullRef114:                                  ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef115:                                  ; preds = %56
+ThrowNullRef116:                                  ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef117:                                  ; preds = %60
+ThrowNullRef118:                                  ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef119:                                  ; preds = %37
+ThrowNullRef120:                                  ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef121:                                  ; preds = %41
+ThrowNullRef122:                                  ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef123:                                  ; preds = %46
+ThrowNullRef124:                                  ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef125:                                  ; preds = %51
+ThrowNullRef126:                                  ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef127:                                  ; preds = %27
+ThrowNullRef128:                                  ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef129:                                  ; preds = %31
+ThrowNullRef130:                                  ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef131:                                  ; preds = %19
+ThrowNullRef132:                                  ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef133:                                  ; preds = %22
+ThrowNullRef134:                                  ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef135:                                  ; preds = %338
+ThrowNullRef136:                                  ; preds = %338
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef137:                                  ; preds = %341
+ThrowNullRef138:                                  ; preds = %341
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef139:                                  ; preds = %356
+ThrowNullRef140:                                  ; preds = %356
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef141:                                  ; preds = %360
+ThrowNullRef142:                                  ; preds = %360
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef143:                                  ; preds = %377
+ThrowNullRef144:                                  ; preds = %377
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef145:                                  ; preds = %381
+ThrowNullRef146:                                  ; preds = %381
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef147:                                  ; preds = %424
+ThrowNullRef148:                                  ; preds = %424
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef149:                                  ; preds = %428
+ThrowNullRef150:                                  ; preds = %428
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef151:                                  ; preds = %440
+ThrowNullRef152:                                  ; preds = %440
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef153:                                  ; preds = %444
+ThrowNullRef154:                                  ; preds = %444
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef155:                                  ; preds = %456
+ThrowNullRef156:                                  ; preds = %456
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef157:                                  ; preds = %460
+ThrowNullRef158:                                  ; preds = %460
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef159:                                  ; preds = %474
+ThrowNullRef160:                                  ; preds = %474
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef161:                                  ; preds = %477
+ThrowNullRef162:                                  ; preds = %477
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef163:                                  ; preds = %394
+ThrowNullRef164:                                  ; preds = %394
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef165:                                  ; preds = %398
+ThrowNullRef166:                                  ; preds = %398
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef167:                                  ; preds = %401
+ThrowNullRef168:                                  ; preds = %401
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef169:                                  ; preds = %407
+ThrowNullRef170:                                  ; preds = %407
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1939,8 +2021,8 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
-  br i1 %NullCheck, label %22, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %ThrowNullRef, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
@@ -1948,8 +2030,8 @@ entry:
   store i32 %24, i32* %loc0
   %25 = load i32, i32* %loc0
   %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %26, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %27
 
 ; <label>:27                                      ; preds = %22
   %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
@@ -1971,7 +2053,7 @@ ThrowNullRef:                                     ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1989,8 +2071,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -2022,15 +2104,15 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2048,16 +2130,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
   %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
   store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %15
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
@@ -2072,8 +2154,8 @@ entry:
   %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
   %29 = ptrtoint i16 addrspace(1)* %28 to i64
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %19
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
@@ -2089,19 +2171,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2114,8 +2196,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
@@ -2128,7 +2210,7 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[loadElem]
+Failed to read AppDomain.PrepareDataForSetup[storeElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
@@ -2202,8 +2284,8 @@ entry:
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
-  br i1 %NullCheck24, label %27, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = load i64, i64 addrspace(1)* %26
@@ -2218,8 +2300,8 @@ entry:
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
-  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
   %41 = load i64, i64 addrspace(1)* %39
@@ -2236,8 +2318,8 @@ entry:
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
-  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
   %54 = load i64, i64 addrspace(1)* %52
@@ -2252,8 +2334,8 @@ entry:
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
   %67 = load i64, i64 addrspace(1)* %65
@@ -2270,8 +2352,8 @@ entry:
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
-  br i1 %NullCheck16, label %79, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
   %80 = load i64, i64 addrspace(1)* %78
@@ -2286,8 +2368,8 @@ entry:
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
-  br i1 %NullCheck18, label %92, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
   %93 = load i64, i64 addrspace(1)* %91
@@ -2304,8 +2386,8 @@ entry:
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
-  br i1 %NullCheck12, label %105, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = load i64, i64 addrspace(1)* %104
@@ -2320,8 +2402,8 @@ entry:
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
-  br i1 %NullCheck14, label %118, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
   %119 = load i64, i64 addrspace(1)* %117
@@ -2337,8 +2419,8 @@ entry:
 
 ; <label>:128                                     ; preds = %20
   %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
-  br i1 %NullCheck4, label %130, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %129, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %130
 
 ; <label>:130                                     ; preds = %128
   %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
@@ -2346,8 +2428,8 @@ entry:
   %133 = load i16, i16 addrspace(1)* %132, align 8
   %134 = zext i16 %133 to i32
   %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
-  br i1 %NullCheck6, label %136, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %135, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %136
 
 ; <label>:136                                     ; preds = %130
   %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
@@ -2360,8 +2442,8 @@ entry:
 
 ; <label>:143                                     ; preds = %136
   %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
-  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %144, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %145
 
 ; <label>:145                                     ; preds = %143
   %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
@@ -2369,8 +2451,8 @@ entry:
   %148 = load i16, i16 addrspace(1)* %147, align 8
   %149 = zext i16 %148 to i32
   %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %150, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %151
 
 ; <label>:151                                     ; preds = %145
   %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
@@ -2388,8 +2470,8 @@ entry:
 
 ; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
-  br i1 %NullCheck, label %163, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %ThrowNullRef, label %163
 
 ; <label>:163                                     ; preds = %161
   %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
@@ -2399,8 +2481,8 @@ entry:
 
 ; <label>:167                                     ; preds = %163
   %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
-  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %168, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %169
 
 ; <label>:169                                     ; preds = %167
   %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
@@ -2432,55 +2514,55 @@ ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %167
+ThrowNullRef2:                                    ; preds = %167
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %128
+ThrowNullRef4:                                    ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %130
+ThrowNullRef6:                                    ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %143
+ThrowNullRef8:                                    ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %145
+ThrowNullRef10:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %102
+ThrowNullRef12:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %105
+ThrowNullRef14:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %76
+ThrowNullRef16:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %79
+ThrowNullRef18:                                   ; preds = %79
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %50
+ThrowNullRef20:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %53
+ThrowNullRef22:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %24
+ThrowNullRef24:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %27
+ThrowNullRef26:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2503,15 +2585,15 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2519,16 +2601,16 @@ entry:
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
   store i32 %8, i32* %loc0
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
   %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
   store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
@@ -2546,16 +2628,16 @@ entry:
 
 ; <label>:23                                      ; preds = %64
   %24 = load i16*, i16** %loc3
-  %NullCheck12 = icmp ne i16* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i16* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
   store i32 %27, i32* %loc5
   %28 = load i16*, i16** %loc4
-  %NullCheck14 = icmp ne i16* %28, null
-  br i1 %NullCheck14, label %29, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %28, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = load i16, i16* %28, align 8
@@ -2620,15 +2702,15 @@ entry:
 
 ; <label>:67                                      ; preds = %64
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
-  br i1 %NullCheck8, label %69, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %68, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %69
 
 ; <label>:69                                      ; preds = %67
   %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
   %71 = load i32, i32 addrspace(1)* %70
   %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
-  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %73
 
 ; <label>:73                                      ; preds = %69
   %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
@@ -2645,31 +2727,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %67
+ThrowNullRef8:                                    ; preds = %67
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %69
+ThrowNullRef10:                                   ; preds = %69
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2710,14 +2792,14 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
   %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
@@ -2730,14 +2812,14 @@ entry:
 
 ; <label>:11                                      ; preds = %4
   %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
   %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
@@ -2749,14 +2831,14 @@ entry:
 
 ; <label>:22                                      ; preds = %16
   %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
   %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
-  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
-  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
@@ -2804,23 +2886,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2836,7 +2918,280 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[loadElem]
+Successfully read RuntimeType.IsAssignableFrom
+
+define i8 @RuntimeType.IsAssignableFrom(%System.RuntimeType addrspace(1)* %param0, %System.Type addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.RuntimeType addrspace(1)*
+  %arg1 = alloca %System.Type addrspace(1)*
+  %loc0 = alloca %System.RuntimeType addrspace(1)*
+  %loc1 = alloca %"System.Type[]" addrspace(1)*
+  %loc2 = alloca i32
+  store %System.RuntimeType addrspace(1)* %param0, %System.RuntimeType addrspace(1)** %this
+  store %System.Type addrspace(1)* %param1, %System.Type addrspace(1)** %arg1
+  %0 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %1 = icmp ne %System.Type addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i8 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %5 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %6 = bitcast %System.Type addrspace(1)* %4 to %System.Object addrspace(1)*
+  %7 = bitcast %System.RuntimeType addrspace(1)* %5 to %System.Object addrspace(1)*
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %6, %System.Object addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %3
+  ret i8 1
+
+; <label>:12                                      ; preds = %3
+  %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 152
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 32
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
+  %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
+  %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
+  store %System.RuntimeType addrspace(1)* %25, %System.RuntimeType addrspace(1)** %loc0
+  %26 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %27 = icmp eq %System.RuntimeType addrspace(1)* %26, null
+  br i1 %27, label %34, label %28
+
+; <label>:28                                      ; preds = %15
+  %29 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %30 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)*)*)(%System.RuntimeType addrspace(1)* %29, %System.RuntimeType addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+; <label>:34                                      ; preds = %15
+  %35 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %36 = call %System.Reflection.Emit.TypeBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Reflection.Emit.TypeBuilder addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %35)
+  %37 = icmp eq %System.Reflection.Emit.TypeBuilder addrspace(1)* %36, null
+  br i1 %37, label %139, label %38
+
+; <label>:38                                      ; preds = %34
+  %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %42
+
+; <label>:42                                      ; preds = %38
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 152
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 40
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
+  %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
+  %53 = zext i8 %52 to i32
+  %54 = icmp eq i32 %53, 0
+  br i1 %54, label %56, label %55
+
+; <label>:55                                      ; preds = %42
+  ret i8 1
+
+; <label>:56                                      ; preds = %42
+  %57 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %58 = bitcast %System.RuntimeType addrspace(1)* %57 to %System.Type addrspace(1)*
+  %59 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %58)
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %64 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.Type addrspace(1)* %63, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = bitcast %System.RuntimeType addrspace(1)* %64 to %System.Type addrspace(1)*
+  %67 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %63, %System.Type addrspace(1)* %66)
+  %68 = zext i8 %67 to i32
+  %69 = trunc i32 %68 to i8
+  ret i8 %69
+
+; <label>:70                                      ; preds = %56
+  %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
+  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %73
+
+; <label>:73                                      ; preds = %70
+  %74 = load i64, i64 addrspace(1)* %72
+  %75 = add i64 %74, 128
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = add i64 %77, 0
+  %79 = inttoptr i64 %78 to i64*
+  %80 = load i64, i64* %79
+  %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
+  %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
+  %83 = call i8 %82(%System.Type addrspace(1)* %81)
+  %84 = zext i8 %83 to i32
+  %85 = icmp eq i32 %84, 0
+  br i1 %85, label %139, label %86
+
+; <label>:86                                      ; preds = %73
+  %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
+  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %89
+
+; <label>:89                                      ; preds = %86
+  %90 = load i64, i64 addrspace(1)* %88
+  %91 = add i64 %90, 128
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = add i64 %93, 24
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
+  %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
+  %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
+  store %"System.Type[]" addrspace(1)* %99, %"System.Type[]" addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %129
+
+; <label>:100                                     ; preds = %132
+  %101 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %102 = load i32, i32* %loc2
+  %NullCheck11 = icmp eq %"System.Type[]" addrspace(1)* %101, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %103
+
+; <label>:103                                     ; preds = %100
+  %104 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 1
+  %105 = load i32, i32 addrspace(1)* %104
+  %106 = zext i32 %105 to i64
+  %107 = zext i32 %102 to i64
+  %BoundsCheck = icmp uge i64 %107, %106
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %108
+
+; <label>:108                                     ; preds = %103
+  %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
+  %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
+  %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
+  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %113
+
+; <label>:113                                     ; preds = %108
+  %114 = load i64, i64 addrspace(1)* %112
+  %115 = add i64 %114, 152
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = add i64 %117, 56
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
+  %123 = zext i8 %122 to i32
+  %124 = icmp ne i32 %123, 0
+  br i1 %124, label %126, label %125
+
+; <label>:125                                     ; preds = %113
+  ret i8 0
+
+; <label>:126                                     ; preds = %113
+  %127 = load i32, i32* %loc2
+  %128 = add i32 %127, 1
+  store i32 %128, i32* %loc2
+  br label %129
+
+; <label>:129                                     ; preds = %89, %126
+  %130 = load i32, i32* %loc2
+  %131 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %NullCheck9 = icmp eq %"System.Type[]" addrspace(1)* %131, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %132
+
+; <label>:132                                     ; preds = %129
+  %133 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %131, i32 0, i32 1
+  %134 = load i32, i32 addrspace(1)* %133
+  %135 = zext i32 %134 to i64
+  %136 = trunc i64 %135 to i32
+  %137 = icmp slt i32 %130, %136
+  br i1 %137, label %100, label %138
+
+; <label>:138                                     ; preds = %132
+  ret i8 1
+
+; <label>:139                                     ; preds = %34, %73
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %129
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %103
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -2893,7 +3248,7 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElem]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -2904,8 +3259,8 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -2997,8 +3352,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
@@ -3059,8 +3414,8 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -3087,8 +3442,8 @@ entry:
 
 ; <label>:17                                      ; preds = %5, %11
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
@@ -3097,8 +3452,8 @@ entry:
 
 ; <label>:22                                      ; preds = %1, %11
   %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
@@ -3109,11 +3464,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %17
+ThrowNullRef2:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %22
+ThrowNullRef4:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3167,15 +3522,15 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
   %15 = load i32, i32 addrspace(1)* %14
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
@@ -3198,7 +3553,7 @@ ThrowNullRef:                                     ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef2:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3232,8 +3587,8 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
@@ -3312,8 +3667,8 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -3327,8 +3682,8 @@ entry:
 ; <label>:5                                       ; preds = %43
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %7 = load i32, i32* %loc1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck6, label %8, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
@@ -3366,8 +3721,8 @@ entry:
 ; <label>:32                                      ; preds = %21, %25
   %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
   %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
-  br i1 %NullCheck8, label %35, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = trunc i32 %34 to i16
@@ -3380,8 +3735,8 @@ entry:
 ; <label>:40                                      ; preds = %1, %35
   %41 = load i32, i32* %loc1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
-  br i1 %NullCheck2, label %43, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %42, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
@@ -3392,8 +3747,8 @@ entry:
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
   %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
-  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
   %51 = load i64, i64 addrspace(1)* %49
@@ -3412,19 +3767,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %40
+ThrowNullRef2:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %47
+ThrowNullRef4:                                    ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %5
+ThrowNullRef6:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %32
+ThrowNullRef8:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3467,8 +3822,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
@@ -3492,11 +3847,391 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(i16* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store i16* %param0, i16** %arg0
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load i32, i32* %arg3
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %42, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %37, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg2
+  %13 = load i32, i32* %arg3
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %37, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %24 = load i32, i32* %arg2
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load i16*, i16** %arg0
+  %35 = load i32, i32* %arg3
+  %36 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %36, i16* %34, i32 %35)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:37                                      ; preds = %5, %16
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %39)
+  %41 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41, %System.String addrspace(1)* %38, %System.String addrspace(1)* %40)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41) #0
+  unreachable
+
+; <label>:42                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
-Failed to read StringBuilder.ToString[loadElemA]
+Successfully read StringBuilder.ToString
+
+define %System.String addrspace(1)* @StringBuilder.ToString(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i16*
+  %loc3 = alloca %"System.Char[]" addrspace(1)*
+  %loc4 = alloca i32
+  %loc5 = alloca i32
+  %loc6 = alloca i16 addrspace(1)*
+  %loc7 = alloca %System.String addrspace(1)*
+  %loc8 = alloca %"System.Char[]" addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %0)
+  %2 = icmp ne i32 %1, 0
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %4
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %6)
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %7)
+  store %System.String addrspace(1)* %8, %System.String addrspace(1)** %loc0
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.Text.StringBuilder addrspace(1)* %9, %System.Text.StringBuilder addrspace(1)** %loc1
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  store %System.String addrspace(1)* %10, %System.String addrspace(1)** %loc7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc7
+  %12 = ptrtoint %System.String addrspace(1)* %11 to i64
+  %13 = icmp eq i64 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %5
+  %15 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %16 = sext i32 %15 to i64
+  %17 = add i64 %12, %16
+  br label %18
+
+; <label>:18                                      ; preds = %5, %14
+  %19 = phi i64 [ %12, %5 ], [ %17, %14 ]
+  %20 = inttoptr i64 %19 to i16*
+  store i16* %20, i16** %loc2
+  br label %21
+
+; <label>:21                                      ; preds = %98, %18
+  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %22, null
+  br i1 %NullCheck, label %ThrowNullRef, label %23
+
+; <label>:23                                      ; preds = %21
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 3
+  %25 = load i32, i32 addrspace(1)* %24, align 8
+  %26 = icmp sle i32 %25, 0
+  br i1 %26, label %96, label %27
+
+; <label>:27                                      ; preds = %23
+  %28 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %28, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %29
+
+; <label>:29                                      ; preds = %27
+  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %28, i32 0, i32 1
+  %31 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %30, align 8
+  store %"System.Char[]" addrspace(1)* %31, %"System.Char[]" addrspace(1)** %loc3
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %33
+
+; <label>:33                                      ; preds = %29
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  store i32 %35, i32* %loc4
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  %39 = load i32, i32 addrspace(1)* %38, align 8
+  store i32 %39, i32* %loc5
+  %40 = load i32, i32* %loc5
+  %41 = load i32, i32* %loc4
+  %42 = add i32 %40, %41
+  %43 = zext i32 %42 to i64
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %45
+
+; <label>:45                                      ; preds = %37
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = sext i32 %47 to i64
+  %49 = icmp sgt i64 %43, %48
+  br i1 %49, label %91, label %50
+
+; <label>:50                                      ; preds = %45
+  %51 = load i32, i32* %loc5
+  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %52, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %53
+
+; <label>:53                                      ; preds = %50
+  %54 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %52, i32 0, i32 1
+  %55 = load i32, i32 addrspace(1)* %54
+  %56 = zext i32 %55 to i64
+  %57 = trunc i64 %56 to i32
+  %58 = icmp ugt i32 %51, %57
+  br i1 %58, label %91, label %59
+
+; <label>:59                                      ; preds = %53
+  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  store %"System.Char[]" addrspace(1)* %60, %"System.Char[]" addrspace(1)** %loc8
+  %61 = icmp eq %"System.Char[]" addrspace(1)* %60, null
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %63, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %64
+
+; <label>:64                                      ; preds = %62
+  %65 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %63, i32 0, i32 1
+  %66 = load i32, i32 addrspace(1)* %65
+  %67 = zext i32 %66 to i64
+  %68 = trunc i64 %67 to i32
+  %69 = icmp ne i32 %68, 0
+  br i1 %69, label %71, label %70
+
+; <label>:70                                      ; preds = %59, %64
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:71                                      ; preds = %64
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %73
+
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %BoundsCheck = icmp uge i64 0, %76
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %77
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %78, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:79                                      ; preds = %70, %77
+  %80 = load i16*, i16** %loc2
+  %81 = load i32, i32* %loc4
+  %82 = sext i32 %81 to i64
+  %83 = mul i64 %82, 2
+  %84 = bitcast i16* %80 to i8*
+  %85 = getelementptr inbounds i8, i8* %84, i64 %83
+  %86 = load i16 addrspace(1)*, i16 addrspace(1)** %loc6
+  %87 = ptrtoint i16 addrspace(1)* %86 to i64
+  %88 = load i32, i32* %loc5
+  %89 = bitcast i8* %85 to i16*
+  %90 = inttoptr i64 %87 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %89, i16* %90, i32 %88)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %96
+
+; <label>:91                                      ; preds = %45, %53
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %94 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %93)
+  %95 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95, %System.String addrspace(1)* %92, %System.String addrspace(1)* %94)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95) #0
+  unreachable
+
+; <label>:96                                      ; preds = %23, %79
+  %97 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %97, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %98
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %97, i32 0, i32 2
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  store %System.Text.StringBuilder addrspace(1)* %100, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %102 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %102, label %21, label %103
+
+; <label>:103                                     ; preds = %98
+  store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc7
+  %104 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  ret %System.String addrspace(1)* %104
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method StringBuilder::get_Length using LLILCJit
+Successfully read StringBuilder.get_Length
+
+define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
+Successfully read RuntimeHelpers.get_OffsetToStringData
+
+define i32 @RuntimeHelpers.get_OffsetToStringData() {
+entry:
+  ret i32 12
+}
+
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
 Successfully read CultureData.CreateCultureData
 
@@ -3514,23 +4249,23 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
   store i8 %4, i8 addrspace(1)* %6
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
@@ -3549,11 +4284,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3566,50 +4301,50 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
   store i32 -1, i32 addrspace(1)* %2
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
   store i32 -1, i32 addrspace(1)* %8
   %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
   store i32 -1, i32 addrspace(1)* %14
   %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
   store i32 -1, i32 addrspace(1)* %17
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
@@ -3623,27 +4358,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3675,7 +4410,136 @@ Failed to read Dictionary`2.Insert[non-const derefAddress]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
 Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
-Failed to read HashHelpers.GetPrime[loadElem]
+Successfully read HashHelpers.GetPrime
+
+define i32 @HashHelpers.GetPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %6, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5, %System.String addrspace(1)* %4)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5) #0
+  unreachable
+
+; <label>:6                                       ; preds = %entry
+  store i32 0, i32* %loc0
+  br label %29
+
+; <label>:7                                       ; preds = %35
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 1296
+  %10 = addrspacecast i8 addrspace(1)* %9 to %"System.Int32[]" addrspace(1)**
+  %11 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %10
+  %12 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Int32[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = zext i32 %15 to i64
+  %17 = zext i32 %12 to i64
+  %BoundsCheck = icmp uge i64 %17, %16
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 3, i32 %12
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  store i32 %20, i32* %loc1
+  %21 = load i32, i32* %loc1
+  %22 = load i32, i32* %arg0
+  %23 = icmp slt i32 %21, %22
+  br i1 %23, label %26, label %24
+
+; <label>:24                                      ; preds = %18
+  %25 = load i32, i32* %loc1
+  ret i32 %25
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %loc0
+  %28 = add i32 %27, 1
+  store i32 %28, i32* %loc0
+  br label %29
+
+; <label>:29                                      ; preds = %6, %26
+  %30 = load i32, i32* %loc0
+  %31 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %32 = getelementptr inbounds i8, i8 addrspace(1)* %31, i64 1296
+  %33 = addrspacecast i8 addrspace(1)* %32 to %"System.Int32[]" addrspace(1)**
+  %34 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %33
+  %NullCheck = icmp eq %"System.Int32[]" addrspace(1)* %34, null
+  br i1 %NullCheck, label %ThrowNullRef, label %35
+
+; <label>:35                                      ; preds = %29
+  %36 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %34, i32 0, i32 1
+  %37 = load i32, i32 addrspace(1)* %36
+  %38 = zext i32 %37 to i64
+  %39 = trunc i64 %38 to i32
+  %40 = icmp slt i32 %30, %39
+  br i1 %40, label %7, label %41
+
+; <label>:41                                      ; preds = %35
+  %42 = load i32, i32* %arg0
+  %43 = or i32 %42, 1
+  store i32 %43, i32* %loc2
+  br label %59
+
+; <label>:44                                      ; preds = %59
+  %45 = load i32, i32* %loc2
+  %46 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %45)
+  %47 = zext i8 %46 to i32
+  %48 = icmp eq i32 %47, 0
+  br i1 %48, label %56, label %49
+
+; <label>:49                                      ; preds = %44
+  %50 = load i32, i32* %loc2
+  %51 = sub i32 %50, 1
+  %52 = srem i32 %51, 101
+  %53 = icmp eq i32 %52, 0
+  br i1 %53, label %56, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = load i32, i32* %loc2
+  ret i32 %55
+
+; <label>:56                                      ; preds = %44, %49
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %57, 2
+  store i32 %58, i32* %loc2
+  br label %59
+
+; <label>:59                                      ; preds = %41, %56
+  %60 = load i32, i32* %loc2
+  %61 = icmp slt i32 %60, 2147483647
+  br i1 %61, label %44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load i32, i32* %arg0
+  ret i32 %63
+
+ThrowNullRef:                                     ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
 Successfully read GenericEqualityComparer`1.GetHashCode
 
@@ -3694,14 +4558,14 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
   %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load i64, i64 addrspace(1)* %7
@@ -3720,7 +4584,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3750,8 +4614,8 @@ entry:
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
@@ -3796,8 +4660,8 @@ entry:
   %35 = bitcast i16* %34 to i8*
   %36 = getelementptr inbounds i8, i8* %35, i64 2
   %37 = bitcast i8* %36 to i16*
-  %NullCheck4 = icmp ne i16* %37, null
-  br i1 %NullCheck4, label %38, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %37, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %38
 
 ; <label>:38                                      ; preds = %27
   %39 = load i16, i16* %37, align 8
@@ -3824,8 +4688,8 @@ entry:
 
 ; <label>:54                                      ; preds = %22, %43
   %55 = load i16*, i16** %loc4
-  %NullCheck2 = icmp ne i16* %55, null
-  br i1 %NullCheck2, label %56, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i16* %55, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %56
 
 ; <label>:56                                      ; preds = %54
   %57 = load i16, i16* %55, align 8
@@ -3850,11 +4714,11 @@ ThrowNullRef:                                     ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %54
+ThrowNullRef2:                                    ; preds = %54
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %27
+ThrowNullRef4:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3871,8 +4735,8 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -3907,8 +4771,8 @@ entry:
 
 ; <label>:26                                      ; preds = %19
   %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
-  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %28
 
 ; <label>:28                                      ; preds = %26
   %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
@@ -3920,7 +4784,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3972,8 +4836,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
@@ -3984,26 +4848,26 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
-  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
@@ -4014,8 +4878,8 @@ entry:
 ; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
@@ -4024,8 +4888,8 @@ entry:
 
 ; <label>:25                                      ; preds = %1, %16, %23
   %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
-  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
@@ -4036,27 +4900,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %20
+ThrowNullRef10:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4069,8 +4933,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -4081,8 +4945,8 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
@@ -4091,8 +4955,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1, %8
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
@@ -4103,11 +4967,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4128,24 +4992,24 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   store i32 %3, i32* %loc0
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
   %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
   store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck4, label %9, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
@@ -4164,15 +5028,15 @@ entry:
 ; <label>:18                                      ; preds = %70
   %19 = load i16*, i16** %loc3
   %20 = bitcast i16* %19 to i64*
-  %NullCheck10 = icmp ne i64* %20, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %20, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = load i64, i64* %20, align 8
   %23 = load i16*, i16** %loc4
   %24 = bitcast i16* %23 to i64*
-  %NullCheck12 = icmp ne i64* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = load i64, i64* %24, align 8
@@ -4188,8 +5052,8 @@ entry:
   %31 = bitcast i16* %30 to i8*
   %32 = getelementptr inbounds i8, i8* %31, i64 8
   %33 = bitcast i8* %32 to i64*
-  %NullCheck14 = icmp ne i64* %33, null
-  br i1 %NullCheck14, label %34, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = load i64, i64* %33, align 8
@@ -4197,8 +5061,8 @@ entry:
   %37 = bitcast i16* %36 to i8*
   %38 = getelementptr inbounds i8, i8* %37, i64 8
   %39 = bitcast i8* %38 to i64*
-  %NullCheck16 = icmp ne i64* %39, null
-  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %40
 
 ; <label>:40                                      ; preds = %34
   %41 = load i64, i64* %39, align 8
@@ -4214,8 +5078,8 @@ entry:
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %NullCheck18 = icmp ne i64* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = load i64, i64* %48, align 8
@@ -4223,8 +5087,8 @@ entry:
   %52 = bitcast i16* %51 to i8*
   %53 = getelementptr inbounds i8, i8* %52, i64 16
   %54 = bitcast i8* %53 to i64*
-  %NullCheck20 = icmp ne i64* %54, null
-  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64* %54, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %55
 
 ; <label>:55                                      ; preds = %49
   %56 = load i64, i64* %54, align 8
@@ -4262,15 +5126,15 @@ entry:
 ; <label>:74                                      ; preds = %95
   %75 = load i16*, i16** %loc3
   %76 = bitcast i16* %75 to i32*
-  %NullCheck6 = icmp ne i32* %76, null
-  br i1 %NullCheck6, label %77, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32* %76, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %77
 
 ; <label>:77                                      ; preds = %74
   %78 = load i32, i32* %76, align 8
   %79 = load i16*, i16** %loc4
   %80 = bitcast i16* %79 to i32*
-  %NullCheck8 = icmp ne i32* %80, null
-  br i1 %NullCheck8, label %81, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i32* %80, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %81
 
 ; <label>:81                                      ; preds = %77
   %82 = load i32, i32* %80, align 8
@@ -4318,43 +5182,43 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %74
+ThrowNullRef6:                                    ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %77
+ThrowNullRef8:                                    ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %29
+ThrowNullRef14:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %34
+ThrowNullRef16:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4376,8 +5240,8 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load i64, i64 addrspace(1)* %4
@@ -4389,8 +5253,8 @@ entry:
   %12 = load i64, i64* %11
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %5
   %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
@@ -4399,8 +5263,8 @@ entry:
   %18 = load i8, i8* %arg2
   %19 = zext i8 %18 to i32
   %20 = trunc i32 %19 to i8
-  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %15
   %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
@@ -4411,11 +5275,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4442,8 +5306,8 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
@@ -4466,16 +5330,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
   %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = load i64, i64 addrspace(1)* %19
@@ -4500,8 +5364,8 @@ entry:
 ; <label>:35                                      ; preds = %30
   %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
@@ -4514,8 +5378,8 @@ entry:
 
 ; <label>:42                                      ; preds = %1, %38
   %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
-  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
@@ -4526,19 +5390,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %35
+ThrowNullRef2:                                    ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %42
+ThrowNullRef8:                                    ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4551,14 +5415,14 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
@@ -4570,7 +5434,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4583,8 +5447,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
@@ -4613,51 +5477,51 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
   %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
   %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
   %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
   %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
-  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
   store i64 %21, i64 addrspace(1)* %23
   %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %25 = load i64, i64* %loc0
-  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
@@ -4668,27 +5532,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %22
+ThrowNullRef12:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4701,8 +5565,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
@@ -4713,19 +5577,19 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
@@ -4734,8 +5598,8 @@ entry:
 
 ; <label>:15                                      ; preds = %1, %13
   %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
@@ -4746,19 +5610,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %15
+ThrowNullRef8:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4771,8 +5635,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -4831,8 +5695,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
@@ -4882,8 +5746,8 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
-  br i1 %NullCheck, label %17, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %ThrowNullRef, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
@@ -4894,15 +5758,15 @@ entry:
 
 ; <label>:22                                      ; preds = %17
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
-  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
   %26 = load i32, i32 addrspace(1)* %25
   %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
-  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %27, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
@@ -4925,8 +5789,8 @@ entry:
 ; <label>:40                                      ; preds = %17
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
-  br i1 %NullCheck6, label %43, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %41, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
@@ -4938,34 +5802,17 @@ ThrowNullRef:                                     ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %24
+ThrowNullRef4:                                    ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %40
+ThrowNullRef6:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
-}
-
-INFO:  jitting method Object::ReferenceEquals using LLILCJit
-Successfully read Object.ReferenceEquals
-
-define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
-entry:
-  %arg0 = alloca %System.Object addrspace(1)*
-  %arg1 = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
-  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
-  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = icmp eq %System.Object addrspace(1)* %0, %1
-  %3 = sext i1 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
 }
 
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
@@ -4978,21 +5825,21 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
   %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
-  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
@@ -5007,28 +5854,28 @@ entry:
 ; <label>:13                                      ; preds = %8, %12
   %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
   %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
   %21 = load i32, i32 addrspace(1)* %20, align 8
   %22 = add i32 %21, 1
-  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
   store i32 %22, i32 addrspace(1)* %24
   %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
@@ -5039,27 +5886,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5077,7 +5924,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::Setup using LLILCJit
-Failed to read AppDomain.Setup[loadElem]
+Failed to read AppDomain.Setup[unbox]
 INFO:  jitting method Thread::GetDomain using LLILCJit
 Successfully read Thread.GetDomain
 
@@ -5108,8 +5955,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
@@ -5122,14 +5969,14 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
   %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
@@ -5141,11 +5988,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5173,8 +6020,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -5189,7 +6036,328 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
 Failed to read KeyCollection.System.Collections.Generic.IEnumerable<TKey>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Successfully read Enumerator.MoveNext
+
+define i8 @Enumerator.MoveNext(%"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.RuntimeTypeHandle* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*
+  %"$TypeArg" = alloca %System.RuntimeTypeHandle*
+  store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
+  %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 8
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %76, label %12
+
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
+  br label %76
+
+; <label>:13                                      ; preds = %85
+  %14 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck19 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %15
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, i32 0, i32 0
+  %17 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %16, align 8
+  %NullCheck21 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, i32 0, i32 2
+  %20 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %19, align 8
+  %21 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck23 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %22
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, i32 0, i32 2
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %NullCheck25 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 3, i32 %24
+  %NullCheck27 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %32
+
+; <label>:32                                      ; preds = %30
+  %33 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, i32 0, i32 2
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = icmp slt i32 %34, 0
+  br i1 %35, label %68, label %36
+
+; <label>:36                                      ; preds = %32
+  %37 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %38 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck29 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %39
+
+; <label>:39                                      ; preds = %36
+  %40 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, i32 0, i32 0
+  %41 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %40, align 8
+  %NullCheck31 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, i32 0, i32 2
+  %44 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %43, align 8
+  %45 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck33 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, i32 0, i32 2
+  %48 = load i32, i32 addrspace(1)* %47, align 8
+  %NullCheck35 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %49
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = zext i32 %51 to i64
+  %53 = zext i32 %48 to i64
+  %BoundsCheck37 = icmp uge i64 %53, %52
+  br i1 %BoundsCheck37, label %ThrowIndexOutOfRange38, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 3, i32 %48
+  %NullCheck39 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %56
+
+; <label>:56                                      ; preds = %54
+  %57 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, i32 0, i32 0
+  %58 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck41 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %59
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %60, %System.__Canon addrspace(1)* %58)
+  %61 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck43 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  %64 = load i32, i32 addrspace(1)* %63, align 8
+  %65 = add i32 %64, 1
+  %NullCheck45 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  store i32 %65, i32 addrspace(1)* %67
+  ret i8 1
+
+; <label>:68                                      ; preds = %32
+  %69 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck47 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %73 = add i32 %72, 1
+  %NullCheck49 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %74
+
+; <label>:74                                      ; preds = %70
+  %75 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  store i32 %73, i32 addrspace(1)* %75
+  br label %76
+
+; <label>:76                                      ; preds = %8, %12, %74
+  %77 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %78
+
+; <label>:78                                      ; preds = %76
+  %79 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, i32 0, i32 2
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck7 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %82
+
+; <label>:82                                      ; preds = %78
+  %83 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, i32 0, i32 0
+  %84 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %83, align 8
+  %NullCheck9 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %85
+
+; <label>:85                                      ; preds = %82
+  %86 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, i32 0, i32 7
+  %87 = load i32, i32 addrspace(1)* %86, align 8
+  %88 = icmp ult i32 %80, %87
+  br i1 %88, label %13, label %89
+
+; <label>:89                                      ; preds = %85
+  %90 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %91 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck11 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %92
+
+; <label>:92                                      ; preds = %89
+  %93 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, i32 0, i32 0
+  %94 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck13 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %95
+
+; <label>:95                                      ; preds = %92
+  %96 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, i32 0, i32 7
+  %97 = load i32, i32 addrspace(1)* %96, align 8
+  %98 = add i32 %97, 1
+  %NullCheck15 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %99
+
+; <label>:99                                      ; preds = %95
+  %100 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, i32 0, i32 2
+  store i32 %98, i32 addrspace(1)* %100
+  %101 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck17 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %102
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %103, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %92
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef22:                                   ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef24:                                   ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef26:                                   ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef28:                                   ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef30:                                   ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef32:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef34:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef36:                                   ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange38:                           ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef40:                                   ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef42:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef44:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef46:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef48:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef50:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -5200,8 +6368,8 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -5232,9 +6400,9 @@ Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
 Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
-Failed to read String.MakeSeparatorList[loadElemA]
+Failed to read String.MakeSeparatorList[storeElem]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
-Failed to read String.InternalSplitKeepEmptyEntries[loadElem]
+Failed to read String.InternalSplitKeepEmptyEntries[storeElem]
 INFO:  jitting method Path::IsRelative using LLILCJit
 Successfully read Path.IsRelative
 
@@ -5243,8 +6411,8 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -5254,8 +6422,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
@@ -5271,8 +6439,8 @@ entry:
 
 ; <label>:17                                      ; preds = %7
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
@@ -5288,8 +6456,8 @@ entry:
 
 ; <label>:29                                      ; preds = %19
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %31
 
 ; <label>:31                                      ; preds = %29
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
@@ -5300,8 +6468,8 @@ entry:
 
 ; <label>:36                                      ; preds = %31
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
-  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %37, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
@@ -5312,8 +6480,8 @@ entry:
 
 ; <label>:43                                      ; preds = %31, %38
   %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
-  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %45
 
 ; <label>:45                                      ; preds = %43
   %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
@@ -5324,8 +6492,8 @@ entry:
 
 ; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %50
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
@@ -5336,8 +6504,8 @@ entry:
 
 ; <label>:57                                      ; preds = %1, %7, %19, %45, %52
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
-  br i1 %NullCheck14, label %59, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %59
 
 ; <label>:59                                      ; preds = %57
   %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
@@ -5347,8 +6515,8 @@ entry:
 
 ; <label>:63                                      ; preds = %59
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
@@ -5359,8 +6527,8 @@ entry:
 
 ; <label>:70                                      ; preds = %65
   %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
-  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.String addrspace(1)* %71, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %72
 
 ; <label>:72                                      ; preds = %70
   %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
@@ -5379,39 +6547,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %17
+ThrowNullRef4:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %29
+ThrowNullRef6:                                    ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %36
+ThrowNullRef8:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %43
+ThrowNullRef10:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %50
+ThrowNullRef12:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %57
+ThrowNullRef14:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %63
+ThrowNullRef16:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %70
+ThrowNullRef18:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5419,7 +6587,293 @@ ThrowNullRef17:                                   ; preds = %70
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
-Failed to read String.TrimHelper[loadElem]
+Successfully read String.TrimHelper
+
+define %System.String addrspace(1)* @String.TrimHelper(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i16
+  %loc4 = alloca i32
+  %loc5 = alloca i16
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = sub i32 %3, 1
+  store i32 %4, i32* %loc0
+  store i32 0, i32* %loc1
+  %5 = load i32, i32* %arg2
+  %6 = icmp eq i32 %5, 1
+  br i1 %6, label %62, label %7
+
+; <label>:7                                       ; preds = %1
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:8                                       ; preds = %58
+  store i32 0, i32* %loc2
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load i32, i32* %loc1
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2, i32 %10
+  %13 = load i16, i16 addrspace(1)* %12
+  %14 = zext i16 %13 to i32
+  %15 = trunc i32 %14 to i16
+  store i16 %15, i16* %loc3
+  store i32 0, i32* %loc2
+  br label %34
+
+; <label>:16                                      ; preds = %37
+  %17 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %18 = load i32, i32* %loc2
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %17, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %19
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = zext i32 %18 to i64
+  %BoundsCheck = icmp uge i64 %23, %22
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %24
+
+; <label>:24                                      ; preds = %19
+  %25 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 3, i32 %18
+  %26 = load i16, i16 addrspace(1)* %25, align 8
+  %27 = zext i16 %26 to i32
+  %28 = load i16, i16* %loc3
+  %29 = zext i16 %28 to i32
+  %30 = icmp eq i32 %27, %29
+  br i1 %30, label %43, label %31
+
+; <label>:31                                      ; preds = %24
+  %32 = load i32, i32* %loc2
+  %33 = add i32 %32, 1
+  store i32 %33, i32* %loc2
+  br label %34
+
+; <label>:34                                      ; preds = %11, %31
+  %35 = load i32, i32* %loc2
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = icmp slt i32 %35, %41
+  br i1 %42, label %16, label %43
+
+; <label>:43                                      ; preds = %24, %37
+  %44 = load i32, i32* %loc2
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %45, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp eq i32 %44, %50
+  br i1 %51, label %62, label %52
+
+; <label>:52                                      ; preds = %46
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %7, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %57, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %58
+
+; <label>:58                                      ; preds = %55
+  %59 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %60 = load i32, i32 addrspace(1)* %59
+  %61 = icmp slt i32 %56, %60
+  br i1 %61, label %8, label %62
+
+; <label>:62                                      ; preds = %1, %46, %58
+  %63 = load i32, i32* %arg2
+  %64 = icmp eq i32 %63, 0
+  br i1 %64, label %122, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %66, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %67
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %66, i32 0, i32 1
+  %69 = load i32, i32 addrspace(1)* %68
+  %70 = sub i32 %69, 1
+  store i32 %70, i32* %loc0
+  br label %118
+
+; <label>:71                                      ; preds = %118
+  store i32 0, i32* %loc4
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %73 = load i32, i32* %loc0
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %74
+
+; <label>:74                                      ; preds = %71
+  %75 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 2, i32 %73
+  %76 = load i16, i16 addrspace(1)* %75
+  %77 = zext i16 %76 to i32
+  %78 = trunc i32 %77 to i16
+  store i16 %78, i16* %loc5
+  store i32 0, i32* %loc4
+  br label %97
+
+; <label>:79                                      ; preds = %100
+  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %81 = load i32, i32* %loc4
+  %NullCheck19 = icmp eq %"System.Char[]" addrspace(1)* %80, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
+
+; <label>:82                                      ; preds = %79
+  %83 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 1
+  %84 = load i32, i32 addrspace(1)* %83
+  %85 = zext i32 %84 to i64
+  %86 = zext i32 %81 to i64
+  %BoundsCheck21 = icmp uge i64 %86, %85
+  br i1 %BoundsCheck21, label %ThrowIndexOutOfRange22, label %87
+
+; <label>:87                                      ; preds = %82
+  %88 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 3, i32 %81
+  %89 = load i16, i16 addrspace(1)* %88, align 8
+  %90 = zext i16 %89 to i32
+  %91 = load i16, i16* %loc5
+  %92 = zext i16 %91 to i32
+  %93 = icmp eq i32 %90, %92
+  br i1 %93, label %106, label %94
+
+; <label>:94                                      ; preds = %87
+  %95 = load i32, i32* %loc4
+  %96 = add i32 %95, 1
+  store i32 %96, i32* %loc4
+  br label %97
+
+; <label>:97                                      ; preds = %74, %94
+  %98 = load i32, i32* %loc4
+  %99 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck15 = icmp eq %"System.Char[]" addrspace(1)* %99, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %100
+
+; <label>:100                                     ; preds = %97
+  %101 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %99, i32 0, i32 1
+  %102 = load i32, i32 addrspace(1)* %101
+  %103 = zext i32 %102 to i64
+  %104 = trunc i64 %103 to i32
+  %105 = icmp slt i32 %98, %104
+  br i1 %105, label %79, label %106
+
+; <label>:106                                     ; preds = %87, %100
+  %107 = load i32, i32* %loc4
+  %108 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck17 = icmp eq %"System.Char[]" addrspace(1)* %108, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %109
+
+; <label>:109                                     ; preds = %106
+  %110 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %108, i32 0, i32 1
+  %111 = load i32, i32 addrspace(1)* %110
+  %112 = zext i32 %111 to i64
+  %113 = trunc i64 %112 to i32
+  %114 = icmp eq i32 %107, %113
+  br i1 %114, label %122, label %115
+
+; <label>:115                                     ; preds = %109
+  %116 = load i32, i32* %loc0
+  %117 = sub i32 %116, 1
+  store i32 %117, i32* %loc0
+  br label %118
+
+; <label>:118                                     ; preds = %67, %115
+  %119 = load i32, i32* %loc0
+  %120 = load i32, i32* %loc1
+  %121 = icmp sge i32 %119, %120
+  br i1 %121, label %71, label %122
+
+; <label>:122                                     ; preds = %62, %109, %118
+  %123 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %124 = load i32, i32* %loc1
+  %125 = load i32, i32* %loc0
+  %126 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %123, i32 %124, i32 %125)
+  ret %System.String addrspace(1)* %126
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %97
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange22:                           ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
 Successfully read String.CreateTrimmedString
 
@@ -5439,8 +6893,8 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
@@ -5535,8 +6989,8 @@ entry:
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i64 2872
   %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
   %8 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %7
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %3
   %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
@@ -5553,8 +7007,8 @@ entry:
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 2864
   %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
   %21 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %20
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
-  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %22
 
 ; <label>:22                                      ; preds = %16
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
@@ -5569,7 +7023,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %16
+ThrowNullRef2:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5586,8 +7040,8 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5613,8 +7067,8 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
@@ -5632,8 +7086,8 @@ entry:
 
 ; <label>:12                                      ; preds = %4
   %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
@@ -5644,8 +7098,8 @@ entry:
 
 ; <label>:19                                      ; preds = %14
   %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %19
   %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
@@ -5660,21 +7114,21 @@ entry:
   %31 = zext i16 %30 to i32
   %32 = bitcast i8* %29 to i16*
   %33 = trunc i32 %31 to i16
-  %NullCheck6 = icmp ne i16* %32, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i16* %32, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %21
   store i16 %33, i16* %32, align 8
   %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %36
 
 ; <label>:36                                      ; preds = %34
   %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
   %38 = load i32, i32 addrspace(1)* %37, align 8
   %39 = add i32 %38, 1
-  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %40
 
 ; <label>:40                                      ; preds = %36
   %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
@@ -5683,16 +7137,16 @@ entry:
 
 ; <label>:42                                      ; preds = %14
   %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
-  br i1 %NullCheck12, label %44, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
   %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
   %47 = load i16, i16* %arg1
   %48 = zext i16 %47 to i32
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = trunc i32 %48 to i16
@@ -5703,31 +7157,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %19
+ThrowNullRef4:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %21
+ThrowNullRef6:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %36
+ThrowNullRef10:                                   ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %42
+ThrowNullRef12:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %44
+ThrowNullRef14:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5740,8 +7194,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -5752,8 +7206,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
@@ -5762,14 +7216,14 @@ entry:
 
 ; <label>:11                                      ; preds = %1
   %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
@@ -5779,15 +7233,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5808,8 +7262,8 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5822,8 +7276,8 @@ entry:
 
 ; <label>:8                                       ; preds = %3
   %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
@@ -5842,15 +7296,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
-  br i1 %NullCheck4, label %22, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
   %24 = load i16*, i16* addrspace(1)* %23, align 8
   %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %25, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
@@ -5859,8 +7313,8 @@ entry:
   store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
@@ -5874,8 +7328,8 @@ entry:
 
 ; <label>:37                                      ; preds = %65
   %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %37
   %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
@@ -5886,16 +7340,16 @@ entry:
   %45 = bitcast i16* %41 to i8*
   %46 = getelementptr inbounds i8, i8* %45, i64 %44
   %47 = bitcast i8* %46 to i16*
-  %NullCheck14 = icmp ne i16* %47, null
-  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %47, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %48
 
 ; <label>:48                                      ; preds = %39
   %49 = load i16, i16* %47, align 8
   %50 = zext i16 %49 to i32
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %52 = load i32, i32* %loc1
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %53
 
 ; <label>:53                                      ; preds = %48
   %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
@@ -5916,8 +7370,8 @@ entry:
 ; <label>:62                                      ; preds = %36, %59
   %63 = load i32, i32* %loc1
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck10, label %65, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %65
 
 ; <label>:65                                      ; preds = %62
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
@@ -5936,15 +7390,15 @@ entry:
 
 ; <label>:74                                      ; preds = %70
   %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
-  br i1 %NullCheck18, label %76, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %76
 
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
   %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
-  br i1 %NullCheck20, label %80, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
   %81 = load i64, i64 addrspace(1)* %79
@@ -5958,8 +7412,8 @@ entry:
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
   %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
-  br i1 %NullCheck22, label %92, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.String addrspace(1)* %90, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %92
 
 ; <label>:92                                      ; preds = %80
   %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
@@ -5969,15 +7423,15 @@ entry:
 
 ; <label>:96                                      ; preds = %70
   %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
-  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %98
 
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
   %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
-  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
   %103 = load i64, i64 addrspace(1)* %101
@@ -5991,8 +7445,8 @@ entry:
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
   %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
-  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.String addrspace(1)* %112, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %114
 
 ; <label>:114                                     ; preds = %102
   %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
@@ -6004,59 +7458,59 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %20
+ThrowNullRef4:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %22
+ThrowNullRef6:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %26
+ThrowNullRef8:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %62
+ThrowNullRef10:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %48
+ThrowNullRef16:                                   ; preds = %48
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %74
+ThrowNullRef18:                                   ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %76
+ThrowNullRef20:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %80
+ThrowNullRef22:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %96
+ThrowNullRef24:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %98
+ThrowNullRef26:                                   ; preds = %98
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %102
+ThrowNullRef28:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6069,15 +7523,15 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
   %3 = load i16*, i16* addrspace(1)* %2, align 8
   %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
@@ -6087,8 +7541,8 @@ entry:
   %10 = bitcast i16* %3 to i8*
   %11 = getelementptr inbounds i8, i8* %10, i64 %9
   %12 = bitcast i8* %11 to i16*
-  %NullCheck4 = icmp ne i16* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %5
   store i16 0, i16* %12, align 8
@@ -6098,11 +7552,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6119,8 +7573,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -6131,8 +7585,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
@@ -6144,15 +7598,15 @@ entry:
 
 ; <label>:14                                      ; preds = %1
   %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
   %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
   %21 = load i64, i64 addrspace(1)* %19
@@ -6171,15 +7625,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %14
+ThrowNullRef4:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %16
+ThrowNullRef6:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6302,14 +7756,6 @@ entry:
   ret %System.String addrspace(1)* %57
 }
 
-INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
-Successfully read RuntimeHelpers.get_OffsetToStringData
-
-define i32 @RuntimeHelpers.get_OffsetToStringData() {
-entry:
-  ret i32 12
-}
-
 INFO:  jitting method String::Equals using LLILCJit
 Successfully read String.Equals
 
@@ -6381,8 +7827,8 @@ entry:
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
-  br i1 %NullCheck24, label %29, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
   %30 = load i64, i64 addrspace(1)* %28
@@ -6397,8 +7843,8 @@ entry:
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
-  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
   %43 = load i64, i64 addrspace(1)* %41
@@ -6418,8 +7864,8 @@ entry:
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
   %59 = load i64, i64 addrspace(1)* %57
@@ -6434,8 +7880,8 @@ entry:
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck22, label %71, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
   %72 = load i64, i64 addrspace(1)* %70
@@ -6455,8 +7901,8 @@ entry:
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
-  br i1 %NullCheck16, label %87, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = load i64, i64 addrspace(1)* %86
@@ -6471,8 +7917,8 @@ entry:
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck18, label %100, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
   %101 = load i64, i64 addrspace(1)* %99
@@ -6492,8 +7938,8 @@ entry:
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
-  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
   %117 = load i64, i64 addrspace(1)* %115
@@ -6508,8 +7954,8 @@ entry:
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
-  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
   %130 = load i64, i64 addrspace(1)* %128
@@ -6528,15 +7974,15 @@ entry:
 
 ; <label>:142                                     ; preds = %22
   %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
-  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %143, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %144
 
 ; <label>:144                                     ; preds = %142
   %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
   %146 = load i32, i32 addrspace(1)* %145
   %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
-  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %147, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %148
 
 ; <label>:148                                     ; preds = %144
   %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
@@ -6557,15 +8003,15 @@ entry:
 
 ; <label>:159                                     ; preds = %22
   %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
-  br i1 %NullCheck, label %161, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %ThrowNullRef, label %161
 
 ; <label>:161                                     ; preds = %159
   %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
   %163 = load i32, i32 addrspace(1)* %162
   %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
-  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %164, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %165
 
 ; <label>:165                                     ; preds = %161
   %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
@@ -6578,8 +8024,8 @@ entry:
 
 ; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
-  br i1 %NullCheck4, label %172, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %171, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %172
 
 ; <label>:172                                     ; preds = %170
   %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
@@ -6589,8 +8035,8 @@ entry:
 
 ; <label>:176                                     ; preds = %172
   %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
-  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %177, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %178
 
 ; <label>:178                                     ; preds = %176
   %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
@@ -6629,55 +8075,55 @@ ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %161
+ThrowNullRef2:                                    ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %170
+ThrowNullRef4:                                    ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %176
+ThrowNullRef6:                                    ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %142
+ThrowNullRef8:                                    ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %144
+ThrowNullRef10:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %113
+ThrowNullRef12:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %116
+ThrowNullRef14:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %84
+ThrowNullRef16:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %87
+ThrowNullRef18:                                   ; preds = %87
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %55
+ThrowNullRef20:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %58
+ThrowNullRef22:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %26
+ThrowNullRef24:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %29
+ThrowNullRef26:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,8 +8161,8 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck, label %14, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %ThrowNullRef, label %14
 
 ; <label>:14                                      ; preds = %8
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
@@ -6760,8 +8206,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
@@ -6770,14 +8216,14 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32, i32* %loc0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %10
   %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
   %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
@@ -6790,15 +8236,15 @@ entry:
 ; <label>:25                                      ; preds = %19
   %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
-  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
   %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
@@ -6807,8 +8253,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %37 = load i32, i32* %loc0
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %38, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %38
 
 ; <label>:38                                      ; preds = %32
   %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
@@ -6817,14 +8263,14 @@ entry:
 
 ; <label>:40                                      ; preds = %19
   %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %40
   %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
   %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
-  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
-  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
@@ -6832,8 +8278,8 @@ entry:
   %48 = zext i32 %47 to i64
   %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
-  br i1 %NullCheck16, label %51, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %51
 
 ; <label>:51                                      ; preds = %45
   %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
@@ -6847,15 +8293,15 @@ entry:
 ; <label>:57                                      ; preds = %51
   %58 = load i16*, i16** %arg1
   %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
-  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %60
 
 ; <label>:60                                      ; preds = %57
   %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
   %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
-  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %64
 
 ; <label>:64                                      ; preds = %60
   %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
@@ -6864,22 +8310,22 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
   %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
-  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %70
 
 ; <label>:70                                      ; preds = %64
   %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
   %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
-  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
-  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
   %75 = load i32, i32 addrspace(1)* %74
   %76 = zext i32 %75 to i64
   %77 = trunc i64 %76 to i32
-  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
-  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %78
 
 ; <label>:78                                      ; preds = %73
   %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
@@ -6901,8 +8347,8 @@ entry:
   %90 = bitcast i16* %86 to i8*
   %91 = getelementptr inbounds i8, i8* %90, i64 %89
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %93
 
 ; <label>:93                                      ; preds = %80
   %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
@@ -6912,8 +8358,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %99 = load i32, i32* %loc2
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %100
 
 ; <label>:100                                     ; preds = %93
   %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
@@ -6928,63 +8374,63 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %25
+ThrowNullRef6:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %32
+ThrowNullRef10:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %40
+ThrowNullRef12:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %45
+ThrowNullRef16:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %57
+ThrowNullRef18:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %60
+ThrowNullRef20:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %64
+ThrowNullRef22:                                   ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %70
+ThrowNullRef24:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %73
+ThrowNullRef26:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %80
+ThrowNullRef28:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %93
+ThrowNullRef30:                                   ; preds = %93
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7004,8 +8450,8 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
@@ -7033,43 +8479,43 @@ entry:
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %14
   %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
   %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   %28 = load i32, i32 addrspace(1)* %27, align 8
   %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
-  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %30
 
 ; <label>:30                                      ; preds = %26
   %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
   %32 = load i32, i32 addrspace(1)* %31, align 8
   %33 = add i32 %28, %32
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %34
 
 ; <label>:34                                      ; preds = %30
   %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   store i32 %33, i32 addrspace(1)* %35
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
   store i32 0, i32 addrspace(1)* %38
   %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %40
 
 ; <label>:40                                      ; preds = %37
   %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
@@ -7082,8 +8528,8 @@ entry:
 
 ; <label>:47                                      ; preds = %40
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
@@ -7098,8 +8544,8 @@ entry:
   %54 = load i32, i32* %loc0
   %55 = sext i32 %54 to i64
   %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
-  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %57
 
 ; <label>:57                                      ; preds = %52
   %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
@@ -7110,68 +8556,35 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %14
+ThrowNullRef2:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %23
+ThrowNullRef4:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %26
+ThrowNullRef6:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %30
+ThrowNullRef8:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %34
+ThrowNullRef10:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %47
+ThrowNullRef14:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %52
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-}
-
-INFO:  jitting method StringBuilder::get_Length using LLILCJit
-Successfully read StringBuilder.get_Length
-
-define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.StringBuilder addrspace(1)*
-  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
-  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
-
-; <label>:1                                       ; preds = %entry
-  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %3 = load i32, i32 addrspace(1)* %2, align 8
-  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
-
-; <label>:5                                       ; preds = %1
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = add i32 %3, %7
-  ret i32 %8
-
-ThrowNullRef:                                     ; preds = %entry
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef16:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7213,70 +8626,70 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
   %6 = load i32, i32 addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
   store i32 %6, i32 addrspace(1)* %8
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
   %13 = load i32, i32 addrspace(1)* %12, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
   store i32 %13, i32 addrspace(1)* %15
   %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
-  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %18
 
 ; <label>:18                                      ; preds = %14
   %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
   %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
   %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
   %34 = load i32, i32 addrspace(1)* %33, align 8
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
-  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
@@ -7287,39 +8700,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %28
+ThrowNullRef16:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %32
+ThrowNullRef18:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7455,13 +8868,13 @@ entry:
 ; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
@@ -7477,16 +8890,16 @@ entry:
 
 ; <label>:18                                      ; preds = %15
   %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
   store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
   %22 = load i32, i32* %loc0
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %24
 
 ; <label>:24                                      ; preds = %20
   %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
@@ -7498,13 +8911,13 @@ entry:
 ; <label>:28                                      ; preds = %15, %24
   %29 = load i32, i32* %arg1
   %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %31
   %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
@@ -7517,20 +8930,20 @@ entry:
   %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
-  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
   %46 = load i32, i32 addrspace(1)* %45, align 8
   %47 = sub i32 %40, %46
-  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
-  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i32 addrspace(1)* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %48
 
 ; <label>:48                                      ; preds = %44
   store i32 %47, i32 addrspace(1)* %39, align 8
@@ -7538,21 +8951,21 @@ entry:
 
 ; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
-  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %51
 
 ; <label>:51                                      ; preds = %49
   %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %53
 
 ; <label>:53                                      ; preds = %51
   %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
   %55 = load i32, i32 addrspace(1)* %54, align 8
   %56 = load i32, i32* %arg2
   %57 = sub i32 %55, %56
-  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %58
 
 ; <label>:58                                      ; preds = %53
   %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
@@ -7562,13 +8975,13 @@ entry:
 ; <label>:60                                      ; preds = %33, %58
   %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
   %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
-  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %63
 
 ; <label>:63                                      ; preds = %60
   %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
-  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
-  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
@@ -7578,15 +8991,15 @@ entry:
 
 ; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
-  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i32 addrspace(1)* %69, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %70
 
 ; <label>:70                                      ; preds = %68
   %71 = load i32, i32 addrspace(1)* %69, align 8
   store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
-  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
@@ -7596,8 +9009,8 @@ entry:
   store i32 %77, i32* %loc4
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
-  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %80
 
 ; <label>:80                                      ; preds = %73
   %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
@@ -7607,71 +9020,71 @@ entry:
 ; <label>:83                                      ; preds = %80
   store i32 0, i32* %loc3
   %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
-  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
-  br i1 %NullCheck26, label %88, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i32 addrspace(1)* %87, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %88
 
 ; <label>:88                                      ; preds = %85
   %89 = load i32, i32 addrspace(1)* %87, align 8
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
-  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %90
 
 ; <label>:90                                      ; preds = %88
   %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
   store i32 %89, i32 addrspace(1)* %91
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
-  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
-  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %96
 
 ; <label>:96                                      ; preds = %94
   %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
-  br i1 %NullCheck34, label %100, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %100
 
 ; <label>:100                                     ; preds = %96
   %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
-  br i1 %NullCheck36, label %102, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %102
 
 ; <label>:102                                     ; preds = %100
   %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
   %104 = load i32, i32 addrspace(1)* %103, align 8
   %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
-  br i1 %NullCheck38, label %106, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %106
 
 ; <label>:106                                     ; preds = %102
   %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
-  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
-  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %108
 
 ; <label>:108                                     ; preds = %106
   %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
   %110 = load i32, i32 addrspace(1)* %109, align 8
   %111 = add i32 %104, %110
-  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %112
 
 ; <label>:112                                     ; preds = %108
   %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
   store i32 %111, i32 addrspace(1)* %113
   %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
-  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i32 addrspace(1)* %114, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %115
 
 ; <label>:115                                     ; preds = %112
   %116 = load i32, i32 addrspace(1)* %114, align 8
@@ -7681,19 +9094,19 @@ entry:
 ; <label>:118                                     ; preds = %115
   %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
-  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %121
 
 ; <label>:121                                     ; preds = %118
   %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
-  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
-  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %123
 
 ; <label>:123                                     ; preds = %121
   %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
   %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
-  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
-  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %126
 
 ; <label>:126                                     ; preds = %123
   %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
@@ -7705,8 +9118,8 @@ entry:
 
 ; <label>:130                                     ; preds = %80, %115, %126
   %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %132
 
 ; <label>:132                                     ; preds = %130
   %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7715,8 +9128,8 @@ entry:
   %136 = load i32, i32* %loc3
   %137 = sub i32 %135, %136
   %138 = sub i32 %134, %137
-  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %139
 
 ; <label>:139                                     ; preds = %132
   %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7728,16 +9141,16 @@ entry:
 
 ; <label>:144                                     ; preds = %139
   %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
-  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %146
 
 ; <label>:146                                     ; preds = %144
   %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
   %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
   %149 = load i32, i32* %loc2
   %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
-  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %151
 
 ; <label>:151                                     ; preds = %146
   %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
@@ -7754,145 +9167,249 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %18
+ThrowNullRef4:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %31
+ThrowNullRef10:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %44
+ThrowNullRef16:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %68
+ThrowNullRef18:                                   ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %70
+ThrowNullRef20:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %73
+ThrowNullRef22:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %83
+ThrowNullRef24:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %85
+ThrowNullRef26:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %88
+ThrowNullRef28:                                   ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %90
+ThrowNullRef30:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %94
+ThrowNullRef32:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %96
+ThrowNullRef34:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %100
+ThrowNullRef36:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %102
+ThrowNullRef38:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %106
+ThrowNullRef40:                                   ; preds = %106
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %108
+ThrowNullRef42:                                   ; preds = %108
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %112
+ThrowNullRef44:                                   ; preds = %112
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %118
+ThrowNullRef46:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %121
+ThrowNullRef48:                                   ; preds = %121
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %123
+ThrowNullRef50:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %130
+ThrowNullRef52:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %132
+ThrowNullRef54:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %144
+ThrowNullRef56:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %146
+ThrowNullRef58:                                   ; preds = %146
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %60
+ThrowNullRef60:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %63
+ThrowNullRef62:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %49
+ThrowNullRef64:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %51
+ThrowNullRef66:                                   ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %53
+ThrowNullRef68:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(%"System.Char[]" addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %arg0 = alloca %"System.Char[]" addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store %"System.Char[]" addrspace(1)* %param0, %"System.Char[]" addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load i32, i32* %arg4
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %43, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %38, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg1
+  %13 = load i32, i32* %arg4
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %38, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %24 = load i32, i32* %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %35 = load i32, i32* %arg3
+  %36 = load i32, i32* %arg4
+  %37 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %37, %"System.Char[]" addrspace(1)* %34, i32 %35, i32 %36)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:38                                      ; preds = %5, %16
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Successfully read Buffer._Memmove
 
@@ -7914,7 +9431,7 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[loadElem]
+Failed to read AppDomain.SetDataHelper[storeElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -7923,8 +9440,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
@@ -7934,8 +9451,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
@@ -7947,15 +9464,15 @@ entry:
   %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
   %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
@@ -7966,15 +9483,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7992,7 +9509,79 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
-Failed to read Dictionary`2.TryGetValue[loadElemA]
+Successfully read Dictionary`2.TryGetValue
+
+define i8 @"Dictionary`2.TryGetValue"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)* addrspace(1)* %param2) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  %arg2 = alloca %System.__Canon addrspace(1)* addrspace(1)*
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  store %System.__Canon addrspace(1)* addrspace(1)* %param2, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  store i32 %2, i32* %loc0
+  %3 = load i32, i32* %loc0
+  %4 = icmp slt i32 %3, 0
+  br i1 %4, label %22, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 2
+  %10 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %9, align 8
+  %11 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = zext i32 %11 to i64
+  %BoundsCheck = icmp uge i64 %16, %15
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 3, i32 %11
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %20, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %6, %System.__Canon addrspace(1)* %21)
+  ret i8 1
+
+; <label>:22                                      ; preds = %entry
+  %23 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %23, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -8058,8 +9647,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
@@ -8091,8 +9680,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
@@ -8171,15 +9760,15 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck, label %19, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %ThrowNullRef, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
   %21 = load i32, i32 addrspace(1)* %20
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
@@ -8202,7 +9791,7 @@ ThrowNullRef:                                     ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %19
+ThrowNullRef2:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8248,8 +9837,8 @@ entry:
   %0 = alloca %System.AppDomainHandle
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %1 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %1, i32 0, i32 15
@@ -8269,8 +9858,8 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
@@ -8286,7 +9875,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -8299,8 +9888,8 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -8327,8 +9916,8 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
@@ -8352,8 +9941,8 @@ entry:
   %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
   store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
@@ -8363,8 +9952,8 @@ entry:
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
@@ -8374,8 +9963,8 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %9
   %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
@@ -8384,8 +9973,8 @@ entry:
 
 ; <label>:18                                      ; preds = %3, %16
   %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
@@ -8397,15 +9986,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %18
+ThrowNullRef6:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8418,8 +10007,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
@@ -8453,15 +10042,15 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
@@ -8473,7 +10062,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8481,7 +10070,7 @@ ThrowNullRef1:                                    ; preds = %1
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
 Failed to read Dictionary`2.System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
@@ -8506,8 +10095,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
@@ -8524,8 +10113,8 @@ entry:
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -8544,7 +10133,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8577,8 +10166,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = load i64, i64* %arg2
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = trunc i32 %3 to i8
@@ -8634,46 +10223,46 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
   %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
-  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
-  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
-  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
@@ -8684,27 +10273,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %20
+ThrowNullRef12:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8717,8 +10306,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -8756,22 +10345,22 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
   %9 = load i64, i64 addrspace(1)* %8, align 8
   %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
   %13 = load i64, i64 addrspace(1)* %12, align 8
   %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %11
   %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
@@ -8788,11 +10377,11 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8882,8 +10471,8 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
@@ -8900,8 +10489,8 @@ entry:
 ; <label>:8                                       ; preds = %1
   %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
   %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
@@ -8911,15 +10500,15 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
   %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
   %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
-  br i1 %NullCheck6, label %21, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
@@ -8946,15 +10535,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8992,15 +10581,15 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
   store i8 %3, i8 addrspace(1)* %5
   %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
@@ -9011,7 +10600,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9027,8 +10616,8 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -9041,8 +10630,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
@@ -9058,7 +10647,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9080,8 +10669,8 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
@@ -9096,8 +10685,8 @@ entry:
 ; <label>:12                                      ; preds = %6
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
@@ -9112,8 +10701,8 @@ entry:
 ; <label>:21                                      ; preds = %15
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
@@ -9128,8 +10717,8 @@ entry:
 ; <label>:30                                      ; preds = %24
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %31, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
@@ -9144,8 +10733,8 @@ entry:
 ; <label>:39                                      ; preds = %33
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
-  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %40, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %42
 
 ; <label>:42                                      ; preds = %39
   %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
@@ -9164,19 +10753,19 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %21
+ThrowNullRef4:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %30
+ThrowNullRef6:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %39
+ThrowNullRef8:                                    ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9243,8 +10832,8 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
@@ -9264,57 +10853,57 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
   store i8 0, i8 addrspace(1)* %2
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
   store i8 0, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
   store i8 0, i8 addrspace(1)* %17
   %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
   store i8 0, i8 addrspace(1)* %20
   %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
-  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
@@ -9325,31 +10914,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %19
+ThrowNullRef14:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9367,8 +10956,8 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
@@ -9380,8 +10969,8 @@ entry:
 
 ; <label>:9                                       ; preds = %4
   %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %9
   %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
@@ -9395,7 +10984,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef2:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9420,8 +11009,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
@@ -9512,8 +11101,8 @@ entry:
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
@@ -9524,8 +11113,8 @@ entry:
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = load i64, i64 addrspace(1)* %12
@@ -9537,8 +11126,8 @@ entry:
   %20 = load i64, i64* %19
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
-  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %13
   %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
@@ -9555,8 +11144,8 @@ entry:
 ; <label>:30                                      ; preds = %25
   %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %32 = load i32, i32* %arg2
-  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
-  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
@@ -9570,15 +11159,15 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %30
+ThrowNullRef2:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9622,87 +11211,87 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
   %10 = load i8, i8 addrspace(1)* %9, align 8
   %11 = zext i8 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %8
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
   store i8 %12, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
   %19 = load i8, i8 addrspace(1)* %18, align 8
   %20 = zext i8 %19 to i32
   %21 = trunc i32 %20 to i8
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
   store i8 %21, i8 addrspace(1)* %23
   %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
   %28 = load i8, i8 addrspace(1)* %27, align 8
   %29 = zext i8 %28 to i32
   %30 = trunc i32 %29 to i8
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
-  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %31
 
 ; <label>:31                                      ; preds = %26
   %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
   store i8 %30, i8 addrspace(1)* %32
   %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
-  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
-  br i1 %NullCheck14, label %40, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %40
 
 ; <label>:40                                      ; preds = %35
   %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
   store i8 %39, i8 addrspace(1)* %41
   %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
-  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %44
 
 ; <label>:44                                      ; preds = %40
   %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
   %46 = load i8, i8 addrspace(1)* %45, align 8
   %47 = zext i8 %46 to i32
   %48 = trunc i32 %47 to i8
-  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
   store i8 %48, i8 addrspace(1)* %50
   %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
-  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
@@ -9713,29 +11302,29 @@ entry:
 ; <label>:56                                      ; preds = %52
   %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
-  br i1 %NullCheck22, label %59, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
   %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
   %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
-  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
-  br i1 %NullCheck24, label %63, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
   %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
-  br i1 %NullCheck26, label %66, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
   %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
-  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
-  br i1 %NullCheck28, label %69, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %69
 
 ; <label>:69                                      ; preds = %66
   %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
@@ -9744,15 +11333,15 @@ entry:
 
 ; <label>:71                                      ; preds = %105
   %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
-  br i1 %NullCheck34, label %73, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %73
 
 ; <label>:73                                      ; preds = %71
   %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
   %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
   %76 = load i32, i32* %loc0
-  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
-  br i1 %NullCheck36, label %77, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
@@ -9766,8 +11355,8 @@ entry:
 
 ; <label>:83                                      ; preds = %77
   %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
-  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
@@ -9775,14 +11364,14 @@ entry:
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
   %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
-  br i1 %NullCheck40, label %91, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
 ; <label>:91                                      ; preds = %85
   %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
   %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
-  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck42, label %94, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %94
 
 ; <label>:94                                      ; preds = %91
   %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
@@ -9798,14 +11387,14 @@ entry:
 ; <label>:99                                      ; preds = %69, %96
   %100 = load i32, i32* %loc0
   %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
-  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %102
 
 ; <label>:102                                     ; preds = %99
   %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
   %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
-  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
-  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
@@ -9819,87 +11408,87 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %26
+ThrowNullRef10:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %31
+ThrowNullRef12:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %35
+ThrowNullRef14:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %40
+ThrowNullRef16:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %56
+ThrowNullRef22:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %59
+ThrowNullRef24:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %63
+ThrowNullRef26:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %66
+ThrowNullRef28:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %102
+ThrowNullRef32:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %71
+ThrowNullRef34:                                   ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %73
+ThrowNullRef36:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %83
+ThrowNullRef38:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %85
+ThrowNullRef40:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %91
+ThrowNullRef42:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9943,15 +11532,15 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
   %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
@@ -9961,28 +11550,28 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
   %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %12
   %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
   %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
   %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
-  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
@@ -9993,23 +11582,23 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %12
+ThrowNullRef6:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10031,15 +11620,15 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
   %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = load i64, i64 addrspace(1)* %7
@@ -10077,13 +11666,13 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[loadElem]
+Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -10111,8 +11700,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FiboRec.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FiboRec.error.txt
@@ -25,8 +25,8 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
@@ -40,8 +40,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
   %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
@@ -75,7 +75,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -90,8 +90,8 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %NullCheck = icmp ne i8 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = load i8, i8 addrspace(1)* %0, align 8
@@ -125,8 +125,8 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
@@ -159,8 +159,8 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -184,8 +184,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
   store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
@@ -195,8 +195,8 @@ entry:
 ; <label>:4                                       ; preds = %1
   %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
   %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
@@ -206,8 +206,8 @@ entry:
   %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
@@ -221,14 +221,14 @@ entry:
 
 ; <label>:17                                      ; preds = %14
   %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
   %21 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
@@ -238,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -249,8 +249,8 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
@@ -261,27 +261,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %30
+ThrowNullRef10:                                   ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -301,7 +301,89 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
-Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
+Successfully read AppDomainSetup.GetUnsecureApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.GetUnsecureApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %NullCheck = icmp eq %"System.String[]" addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %BoundsCheck = icmp uge i64 0, %5
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %6
+
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 3, i32 0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
+  ret %System.String addrspace(1)* %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_Value using LLILCJit
+Successfully read AppDomainSetup.get_Value
+
+define %"System.String[]" addrspace(1)* @AppDomainSetup.get_Value(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.String[]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 18)
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.String[]" addrspace(1)* addrspace(1)*, %"System.String[]" addrspace(1)*)*)(%"System.String[]" addrspace(1)* addrspace(1)* %9, %"System.String[]" addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %11, i32 0, i32 1
+  %14 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %13, align 8
+  ret %"System.String[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -319,8 +401,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -368,16 +450,16 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
   %5 = load i32, i32 addrspace(1)* %4
   %6 = sub i32 %5, 1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -389,7 +471,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -421,8 +503,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
@@ -456,8 +538,8 @@ entry:
 ; <label>:27                                      ; preds = %19
   %28 = load i32, i32* %arg1
   %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
-  br i1 %NullCheck2, label %30, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %29, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %30
 
 ; <label>:30                                      ; preds = %27
   %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
@@ -493,8 +575,8 @@ entry:
 ; <label>:49                                      ; preds = %46
   %50 = load i32, i32* %arg2
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck4, label %52, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
@@ -517,11 +599,11 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %27
+ThrowNullRef2:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %49
+ThrowNullRef4:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -544,16 +626,16 @@ entry:
   %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %0)
   store %System.String addrspace(1)* %1, %System.String addrspace(1)** %loc0
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 2
   %5 = bitcast [0 x i16] addrspace(1)* %4 to i16 addrspace(1)*
   store i16 addrspace(1)* %5, i16 addrspace(1)** %loc1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %3
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2
@@ -580,7 +662,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -691,15 +773,15 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %NullCheck132 = icmp ne i8* %21, null
-  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+  %NullCheck131 = icmp eq i8* %21, null
+  br i1 %NullCheck131, label %ThrowNullRef132, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = load i8, i8* %21, align 8
   %24 = zext i8 %23 to i32
   %25 = trunc i32 %24 to i8
-  %NullCheck134 = icmp ne i8* %20, null
-  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+  %NullCheck133 = icmp eq i8* %20, null
+  br i1 %NullCheck133, label %ThrowNullRef134, label %26
 
 ; <label>:26                                      ; preds = %22
   store i8 %25, i8* %20, align 8
@@ -709,16 +791,16 @@ entry:
   %28 = load i8*, i8** %arg0
   %29 = load i8*, i8** %arg1
   %30 = bitcast i8* %29 to i16*
-  %NullCheck128 = icmp ne i16* %30, null
-  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+  %NullCheck127 = icmp eq i16* %30, null
+  br i1 %NullCheck127, label %ThrowNullRef128, label %31
 
 ; <label>:31                                      ; preds = %27
   %32 = load i16, i16* %30, align 8
   %33 = sext i16 %32 to i32
   %34 = bitcast i8* %28 to i16*
   %35 = trunc i32 %33 to i16
-  %NullCheck130 = icmp ne i16* %34, null
-  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+  %NullCheck129 = icmp eq i16* %34, null
+  br i1 %NullCheck129, label %ThrowNullRef130, label %36
 
 ; <label>:36                                      ; preds = %31
   store i16 %35, i16* %34, align 8
@@ -728,16 +810,16 @@ entry:
   %38 = load i8*, i8** %arg0
   %39 = load i8*, i8** %arg1
   %40 = bitcast i8* %39 to i16*
-  %NullCheck120 = icmp ne i16* %40, null
-  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+  %NullCheck119 = icmp eq i16* %40, null
+  br i1 %NullCheck119, label %ThrowNullRef120, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i16, i16* %40, align 8
   %43 = sext i16 %42 to i32
   %44 = bitcast i8* %38 to i16*
   %45 = trunc i32 %43 to i16
-  %NullCheck122 = icmp ne i16* %44, null
-  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+  %NullCheck121 = icmp eq i16* %44, null
+  br i1 %NullCheck121, label %ThrowNullRef122, label %46
 
 ; <label>:46                                      ; preds = %41
   store i16 %45, i16* %44, align 8
@@ -745,15 +827,15 @@ entry:
   %48 = getelementptr inbounds i8, i8* %47, i64 2
   %49 = load i8*, i8** %arg1
   %50 = getelementptr inbounds i8, i8* %49, i64 2
-  %NullCheck124 = icmp ne i8* %50, null
-  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+  %NullCheck123 = icmp eq i8* %50, null
+  br i1 %NullCheck123, label %ThrowNullRef124, label %51
 
 ; <label>:51                                      ; preds = %46
   %52 = load i8, i8* %50, align 8
   %53 = zext i8 %52 to i32
   %54 = trunc i32 %53 to i8
-  %NullCheck126 = icmp ne i8* %48, null
-  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+  %NullCheck125 = icmp eq i8* %48, null
+  br i1 %NullCheck125, label %ThrowNullRef126, label %55
 
 ; <label>:55                                      ; preds = %51
   store i8 %54, i8* %48, align 8
@@ -763,14 +845,14 @@ entry:
   %57 = load i8*, i8** %arg0
   %58 = load i8*, i8** %arg1
   %59 = bitcast i8* %58 to i32*
-  %NullCheck116 = icmp ne i32* %59, null
-  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+  %NullCheck115 = icmp eq i32* %59, null
+  br i1 %NullCheck115, label %ThrowNullRef116, label %60
 
 ; <label>:60                                      ; preds = %56
   %61 = load i32, i32* %59, align 8
   %62 = bitcast i8* %57 to i32*
-  %NullCheck118 = icmp ne i32* %62, null
-  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+  %NullCheck117 = icmp eq i32* %62, null
+  br i1 %NullCheck117, label %ThrowNullRef118, label %63
 
 ; <label>:63                                      ; preds = %60
   store i32 %61, i32* %62, align 8
@@ -780,14 +862,14 @@ entry:
   %65 = load i8*, i8** %arg0
   %66 = load i8*, i8** %arg1
   %67 = bitcast i8* %66 to i32*
-  %NullCheck108 = icmp ne i32* %67, null
-  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+  %NullCheck107 = icmp eq i32* %67, null
+  br i1 %NullCheck107, label %ThrowNullRef108, label %68
 
 ; <label>:68                                      ; preds = %64
   %69 = load i32, i32* %67, align 8
   %70 = bitcast i8* %65 to i32*
-  %NullCheck110 = icmp ne i32* %70, null
-  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+  %NullCheck109 = icmp eq i32* %70, null
+  br i1 %NullCheck109, label %ThrowNullRef110, label %71
 
 ; <label>:71                                      ; preds = %68
   store i32 %69, i32* %70, align 8
@@ -795,15 +877,15 @@ entry:
   %73 = getelementptr inbounds i8, i8* %72, i64 4
   %74 = load i8*, i8** %arg1
   %75 = getelementptr inbounds i8, i8* %74, i64 4
-  %NullCheck112 = icmp ne i8* %75, null
-  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+  %NullCheck111 = icmp eq i8* %75, null
+  br i1 %NullCheck111, label %ThrowNullRef112, label %76
 
 ; <label>:76                                      ; preds = %71
   %77 = load i8, i8* %75, align 8
   %78 = zext i8 %77 to i32
   %79 = trunc i32 %78 to i8
-  %NullCheck114 = icmp ne i8* %73, null
-  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+  %NullCheck113 = icmp eq i8* %73, null
+  br i1 %NullCheck113, label %ThrowNullRef114, label %80
 
 ; <label>:80                                      ; preds = %76
   store i8 %79, i8* %73, align 8
@@ -813,14 +895,14 @@ entry:
   %82 = load i8*, i8** %arg0
   %83 = load i8*, i8** %arg1
   %84 = bitcast i8* %83 to i32*
-  %NullCheck100 = icmp ne i32* %84, null
-  br i1 %NullCheck100, label %85, label %ThrowNullRef99
+  %NullCheck99 = icmp eq i32* %84, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %85
 
 ; <label>:85                                      ; preds = %81
   %86 = load i32, i32* %84, align 8
   %87 = bitcast i8* %82 to i32*
-  %NullCheck102 = icmp ne i32* %87, null
-  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+  %NullCheck101 = icmp eq i32* %87, null
+  br i1 %NullCheck101, label %ThrowNullRef102, label %88
 
 ; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
@@ -829,16 +911,16 @@ entry:
   %91 = load i8*, i8** %arg1
   %92 = getelementptr inbounds i8, i8* %91, i64 4
   %93 = bitcast i8* %92 to i16*
-  %NullCheck104 = icmp ne i16* %93, null
-  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+  %NullCheck103 = icmp eq i16* %93, null
+  br i1 %NullCheck103, label %ThrowNullRef104, label %94
 
 ; <label>:94                                      ; preds = %88
   %95 = load i16, i16* %93, align 8
   %96 = sext i16 %95 to i32
   %97 = bitcast i8* %90 to i16*
   %98 = trunc i32 %96 to i16
-  %NullCheck106 = icmp ne i16* %97, null
-  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+  %NullCheck105 = icmp eq i16* %97, null
+  br i1 %NullCheck105, label %ThrowNullRef106, label %99
 
 ; <label>:99                                      ; preds = %94
   store i16 %98, i16* %97, align 8
@@ -848,14 +930,14 @@ entry:
   %101 = load i8*, i8** %arg0
   %102 = load i8*, i8** %arg1
   %103 = bitcast i8* %102 to i32*
-  %NullCheck88 = icmp ne i32* %103, null
-  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+  %NullCheck87 = icmp eq i32* %103, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %104
 
 ; <label>:104                                     ; preds = %100
   %105 = load i32, i32* %103, align 8
   %106 = bitcast i8* %101 to i32*
-  %NullCheck90 = icmp ne i32* %106, null
-  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+  %NullCheck89 = icmp eq i32* %106, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %107
 
 ; <label>:107                                     ; preds = %104
   store i32 %105, i32* %106, align 8
@@ -864,16 +946,16 @@ entry:
   %110 = load i8*, i8** %arg1
   %111 = getelementptr inbounds i8, i8* %110, i64 4
   %112 = bitcast i8* %111 to i16*
-  %NullCheck92 = icmp ne i16* %112, null
-  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+  %NullCheck91 = icmp eq i16* %112, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %113
 
 ; <label>:113                                     ; preds = %107
   %114 = load i16, i16* %112, align 8
   %115 = sext i16 %114 to i32
   %116 = bitcast i8* %109 to i16*
   %117 = trunc i32 %115 to i16
-  %NullCheck94 = icmp ne i16* %116, null
-  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+  %NullCheck93 = icmp eq i16* %116, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %118
 
 ; <label>:118                                     ; preds = %113
   store i16 %117, i16* %116, align 8
@@ -881,15 +963,15 @@ entry:
   %120 = getelementptr inbounds i8, i8* %119, i64 6
   %121 = load i8*, i8** %arg1
   %122 = getelementptr inbounds i8, i8* %121, i64 6
-  %NullCheck96 = icmp ne i8* %122, null
-  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+  %NullCheck95 = icmp eq i8* %122, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %123
 
 ; <label>:123                                     ; preds = %118
   %124 = load i8, i8* %122, align 8
   %125 = zext i8 %124 to i32
   %126 = trunc i32 %125 to i8
-  %NullCheck98 = icmp ne i8* %120, null
-  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+  %NullCheck97 = icmp eq i8* %120, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %127
 
 ; <label>:127                                     ; preds = %123
   store i8 %126, i8* %120, align 8
@@ -899,14 +981,14 @@ entry:
   %129 = load i8*, i8** %arg0
   %130 = load i8*, i8** %arg1
   %131 = bitcast i8* %130 to i64*
-  %NullCheck84 = icmp ne i64* %131, null
-  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+  %NullCheck83 = icmp eq i64* %131, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %132
 
 ; <label>:132                                     ; preds = %128
   %133 = load i64, i64* %131, align 8
   %134 = bitcast i8* %129 to i64*
-  %NullCheck86 = icmp ne i64* %134, null
-  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+  %NullCheck85 = icmp eq i64* %134, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %135
 
 ; <label>:135                                     ; preds = %132
   store i64 %133, i64* %134, align 8
@@ -916,14 +998,14 @@ entry:
   %137 = load i8*, i8** %arg0
   %138 = load i8*, i8** %arg1
   %139 = bitcast i8* %138 to i64*
-  %NullCheck76 = icmp ne i64* %139, null
-  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+  %NullCheck75 = icmp eq i64* %139, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %140
 
 ; <label>:140                                     ; preds = %136
   %141 = load i64, i64* %139, align 8
   %142 = bitcast i8* %137 to i64*
-  %NullCheck78 = icmp ne i64* %142, null
-  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+  %NullCheck77 = icmp eq i64* %142, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %143
 
 ; <label>:143                                     ; preds = %140
   store i64 %141, i64* %142, align 8
@@ -931,15 +1013,15 @@ entry:
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %NullCheck80 = icmp ne i8* %147, null
-  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+  %NullCheck79 = icmp eq i8* %147, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %148
 
 ; <label>:148                                     ; preds = %143
   %149 = load i8, i8* %147, align 8
   %150 = zext i8 %149 to i32
   %151 = trunc i32 %150 to i8
-  %NullCheck82 = icmp ne i8* %145, null
-  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+  %NullCheck81 = icmp eq i8* %145, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %152
 
 ; <label>:152                                     ; preds = %148
   store i8 %151, i8* %145, align 8
@@ -949,14 +1031,14 @@ entry:
   %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
   %156 = bitcast i8* %155 to i64*
-  %NullCheck68 = icmp ne i64* %156, null
-  br i1 %NullCheck68, label %157, label %ThrowNullRef67
+  %NullCheck67 = icmp eq i64* %156, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %157
 
 ; <label>:157                                     ; preds = %153
   %158 = load i64, i64* %156, align 8
   %159 = bitcast i8* %154 to i64*
-  %NullCheck70 = icmp ne i64* %159, null
-  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+  %NullCheck69 = icmp eq i64* %159, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %160
 
 ; <label>:160                                     ; preds = %157
   store i64 %158, i64* %159, align 8
@@ -965,16 +1047,16 @@ entry:
   %163 = load i8*, i8** %arg1
   %164 = getelementptr inbounds i8, i8* %163, i64 8
   %165 = bitcast i8* %164 to i16*
-  %NullCheck72 = icmp ne i16* %165, null
-  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+  %NullCheck71 = icmp eq i16* %165, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %166
 
 ; <label>:166                                     ; preds = %160
   %167 = load i16, i16* %165, align 8
   %168 = sext i16 %167 to i32
   %169 = bitcast i8* %162 to i16*
   %170 = trunc i32 %168 to i16
-  %NullCheck74 = icmp ne i16* %169, null
-  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+  %NullCheck73 = icmp eq i16* %169, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %171
 
 ; <label>:171                                     ; preds = %166
   store i16 %170, i16* %169, align 8
@@ -984,14 +1066,14 @@ entry:
   %173 = load i8*, i8** %arg0
   %174 = load i8*, i8** %arg1
   %175 = bitcast i8* %174 to i64*
-  %NullCheck56 = icmp ne i64* %175, null
-  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+  %NullCheck55 = icmp eq i64* %175, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %176
 
 ; <label>:176                                     ; preds = %172
   %177 = load i64, i64* %175, align 8
   %178 = bitcast i8* %173 to i64*
-  %NullCheck58 = icmp ne i64* %178, null
-  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+  %NullCheck57 = icmp eq i64* %178, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %179
 
 ; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
@@ -1000,16 +1082,16 @@ entry:
   %182 = load i8*, i8** %arg1
   %183 = getelementptr inbounds i8, i8* %182, i64 8
   %184 = bitcast i8* %183 to i16*
-  %NullCheck60 = icmp ne i16* %184, null
-  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+  %NullCheck59 = icmp eq i16* %184, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %185
 
 ; <label>:185                                     ; preds = %179
   %186 = load i16, i16* %184, align 8
   %187 = sext i16 %186 to i32
   %188 = bitcast i8* %181 to i16*
   %189 = trunc i32 %187 to i16
-  %NullCheck62 = icmp ne i16* %188, null
-  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+  %NullCheck61 = icmp eq i16* %188, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %190
 
 ; <label>:190                                     ; preds = %185
   store i16 %189, i16* %188, align 8
@@ -1017,15 +1099,15 @@ entry:
   %192 = getelementptr inbounds i8, i8* %191, i64 10
   %193 = load i8*, i8** %arg1
   %194 = getelementptr inbounds i8, i8* %193, i64 10
-  %NullCheck64 = icmp ne i8* %194, null
-  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+  %NullCheck63 = icmp eq i8* %194, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %195
 
 ; <label>:195                                     ; preds = %190
   %196 = load i8, i8* %194, align 8
   %197 = zext i8 %196 to i32
   %198 = trunc i32 %197 to i8
-  %NullCheck66 = icmp ne i8* %192, null
-  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+  %NullCheck65 = icmp eq i8* %192, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %199
 
 ; <label>:199                                     ; preds = %195
   store i8 %198, i8* %192, align 8
@@ -1035,14 +1117,14 @@ entry:
   %201 = load i8*, i8** %arg0
   %202 = load i8*, i8** %arg1
   %203 = bitcast i8* %202 to i64*
-  %NullCheck48 = icmp ne i64* %203, null
-  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+  %NullCheck47 = icmp eq i64* %203, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %204
 
 ; <label>:204                                     ; preds = %200
   %205 = load i64, i64* %203, align 8
   %206 = bitcast i8* %201 to i64*
-  %NullCheck50 = icmp ne i64* %206, null
-  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+  %NullCheck49 = icmp eq i64* %206, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %207
 
 ; <label>:207                                     ; preds = %204
   store i64 %205, i64* %206, align 8
@@ -1051,14 +1133,14 @@ entry:
   %210 = load i8*, i8** %arg1
   %211 = getelementptr inbounds i8, i8* %210, i64 8
   %212 = bitcast i8* %211 to i32*
-  %NullCheck52 = icmp ne i32* %212, null
-  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+  %NullCheck51 = icmp eq i32* %212, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %213
 
 ; <label>:213                                     ; preds = %207
   %214 = load i32, i32* %212, align 8
   %215 = bitcast i8* %209 to i32*
-  %NullCheck54 = icmp ne i32* %215, null
-  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+  %NullCheck53 = icmp eq i32* %215, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %216
 
 ; <label>:216                                     ; preds = %213
   store i32 %214, i32* %215, align 8
@@ -1068,14 +1150,14 @@ entry:
   %218 = load i8*, i8** %arg0
   %219 = load i8*, i8** %arg1
   %220 = bitcast i8* %219 to i64*
-  %NullCheck36 = icmp ne i64* %220, null
-  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64* %220, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %221
 
 ; <label>:221                                     ; preds = %217
   %222 = load i64, i64* %220, align 8
   %223 = bitcast i8* %218 to i64*
-  %NullCheck38 = icmp ne i64* %223, null
-  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+  %NullCheck37 = icmp eq i64* %223, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %224
 
 ; <label>:224                                     ; preds = %221
   store i64 %222, i64* %223, align 8
@@ -1084,14 +1166,14 @@ entry:
   %227 = load i8*, i8** %arg1
   %228 = getelementptr inbounds i8, i8* %227, i64 8
   %229 = bitcast i8* %228 to i32*
-  %NullCheck40 = icmp ne i32* %229, null
-  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i32* %229, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %230
 
 ; <label>:230                                     ; preds = %224
   %231 = load i32, i32* %229, align 8
   %232 = bitcast i8* %226 to i32*
-  %NullCheck42 = icmp ne i32* %232, null
-  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+  %NullCheck41 = icmp eq i32* %232, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %233
 
 ; <label>:233                                     ; preds = %230
   store i32 %231, i32* %232, align 8
@@ -1099,15 +1181,15 @@ entry:
   %235 = getelementptr inbounds i8, i8* %234, i64 12
   %236 = load i8*, i8** %arg1
   %237 = getelementptr inbounds i8, i8* %236, i64 12
-  %NullCheck44 = icmp ne i8* %237, null
-  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i8* %237, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %238
 
 ; <label>:238                                     ; preds = %233
   %239 = load i8, i8* %237, align 8
   %240 = zext i8 %239 to i32
   %241 = trunc i32 %240 to i8
-  %NullCheck46 = icmp ne i8* %235, null
-  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+  %NullCheck45 = icmp eq i8* %235, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %242
 
 ; <label>:242                                     ; preds = %238
   store i8 %241, i8* %235, align 8
@@ -1117,14 +1199,14 @@ entry:
   %244 = load i8*, i8** %arg0
   %245 = load i8*, i8** %arg1
   %246 = bitcast i8* %245 to i64*
-  %NullCheck24 = icmp ne i64* %246, null
-  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64* %246, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %247
 
 ; <label>:247                                     ; preds = %243
   %248 = load i64, i64* %246, align 8
   %249 = bitcast i8* %244 to i64*
-  %NullCheck26 = icmp ne i64* %249, null
-  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64* %249, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %250
 
 ; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
@@ -1133,14 +1215,14 @@ entry:
   %253 = load i8*, i8** %arg1
   %254 = getelementptr inbounds i8, i8* %253, i64 8
   %255 = bitcast i8* %254 to i32*
-  %NullCheck28 = icmp ne i32* %255, null
-  br i1 %NullCheck28, label %256, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i32* %255, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %256
 
 ; <label>:256                                     ; preds = %250
   %257 = load i32, i32* %255, align 8
   %258 = bitcast i8* %252 to i32*
-  %NullCheck30 = icmp ne i32* %258, null
-  br i1 %NullCheck30, label %259, label %ThrowNullRef29
+  %NullCheck29 = icmp eq i32* %258, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %259
 
 ; <label>:259                                     ; preds = %256
   store i32 %257, i32* %258, align 8
@@ -1149,16 +1231,16 @@ entry:
   %262 = load i8*, i8** %arg1
   %263 = getelementptr inbounds i8, i8* %262, i64 12
   %264 = bitcast i8* %263 to i16*
-  %NullCheck32 = icmp ne i16* %264, null
-  br i1 %NullCheck32, label %265, label %ThrowNullRef31
+  %NullCheck31 = icmp eq i16* %264, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %265
 
 ; <label>:265                                     ; preds = %259
   %266 = load i16, i16* %264, align 8
   %267 = sext i16 %266 to i32
   %268 = bitcast i8* %261 to i16*
   %269 = trunc i32 %267 to i16
-  %NullCheck34 = icmp ne i16* %268, null
-  br i1 %NullCheck34, label %270, label %ThrowNullRef33
+  %NullCheck33 = icmp eq i16* %268, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %270
 
 ; <label>:270                                     ; preds = %265
   store i16 %269, i16* %268, align 8
@@ -1168,14 +1250,14 @@ entry:
   %272 = load i8*, i8** %arg0
   %273 = load i8*, i8** %arg1
   %274 = bitcast i8* %273 to i64*
-  %NullCheck8 = icmp ne i64* %274, null
-  br i1 %NullCheck8, label %275, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64* %274, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %275
 
 ; <label>:275                                     ; preds = %271
   %276 = load i64, i64* %274, align 8
   %277 = bitcast i8* %272 to i64*
-  %NullCheck10 = icmp ne i64* %277, null
-  br i1 %NullCheck10, label %278, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %277, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %278
 
 ; <label>:278                                     ; preds = %275
   store i64 %276, i64* %277, align 8
@@ -1184,14 +1266,14 @@ entry:
   %281 = load i8*, i8** %arg1
   %282 = getelementptr inbounds i8, i8* %281, i64 8
   %283 = bitcast i8* %282 to i32*
-  %NullCheck12 = icmp ne i32* %283, null
-  br i1 %NullCheck12, label %284, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i32* %283, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %284
 
 ; <label>:284                                     ; preds = %278
   %285 = load i32, i32* %283, align 8
   %286 = bitcast i8* %280 to i32*
-  %NullCheck14 = icmp ne i32* %286, null
-  br i1 %NullCheck14, label %287, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i32* %286, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %287
 
 ; <label>:287                                     ; preds = %284
   store i32 %285, i32* %286, align 8
@@ -1200,16 +1282,16 @@ entry:
   %290 = load i8*, i8** %arg1
   %291 = getelementptr inbounds i8, i8* %290, i64 12
   %292 = bitcast i8* %291 to i16*
-  %NullCheck16 = icmp ne i16* %292, null
-  br i1 %NullCheck16, label %293, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i16* %292, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %293
 
 ; <label>:293                                     ; preds = %287
   %294 = load i16, i16* %292, align 8
   %295 = sext i16 %294 to i32
   %296 = bitcast i8* %289 to i16*
   %297 = trunc i32 %295 to i16
-  %NullCheck18 = icmp ne i16* %296, null
-  br i1 %NullCheck18, label %298, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i16* %296, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %298
 
 ; <label>:298                                     ; preds = %293
   store i16 %297, i16* %296, align 8
@@ -1217,15 +1299,15 @@ entry:
   %300 = getelementptr inbounds i8, i8* %299, i64 14
   %301 = load i8*, i8** %arg1
   %302 = getelementptr inbounds i8, i8* %301, i64 14
-  %NullCheck20 = icmp ne i8* %302, null
-  br i1 %NullCheck20, label %303, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i8* %302, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %303
 
 ; <label>:303                                     ; preds = %298
   %304 = load i8, i8* %302, align 8
   %305 = zext i8 %304 to i32
   %306 = trunc i32 %305 to i8
-  %NullCheck22 = icmp ne i8* %300, null
-  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i8* %300, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %307
 
 ; <label>:307                                     ; preds = %303
   store i8 %306, i8* %300, align 8
@@ -1235,14 +1317,14 @@ entry:
   %309 = load i8*, i8** %arg0
   %310 = load i8*, i8** %arg1
   %311 = bitcast i8* %310 to i64*
-  %NullCheck = icmp ne i64* %311, null
-  br i1 %NullCheck, label %312, label %ThrowNullRef
+  %NullCheck = icmp eq i64* %311, null
+  br i1 %NullCheck, label %ThrowNullRef, label %312
 
 ; <label>:312                                     ; preds = %308
   %313 = load i64, i64* %311, align 8
   %314 = bitcast i8* %309 to i64*
-  %NullCheck2 = icmp ne i64* %314, null
-  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64* %314, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %315
 
 ; <label>:315                                     ; preds = %312
   store i64 %313, i64* %314, align 8
@@ -1251,14 +1333,14 @@ entry:
   %318 = load i8*, i8** %arg1
   %319 = getelementptr inbounds i8, i8* %318, i64 8
   %320 = bitcast i8* %319 to i64*
-  %NullCheck4 = icmp ne i64* %320, null
-  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64* %320, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %321
 
 ; <label>:321                                     ; preds = %315
   %322 = load i64, i64* %320, align 8
   %323 = bitcast i8* %317 to i64*
-  %NullCheck6 = icmp ne i64* %323, null
-  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64* %323, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %324
 
 ; <label>:324                                     ; preds = %321
   store i64 %322, i64* %323, align 8
@@ -1286,15 +1368,15 @@ entry:
 ; <label>:338                                     ; preds = %333
   %339 = load i8*, i8** %arg0
   %340 = load i8*, i8** %arg1
-  %NullCheck136 = icmp ne i8* %340, null
-  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+  %NullCheck135 = icmp eq i8* %340, null
+  br i1 %NullCheck135, label %ThrowNullRef136, label %341
 
 ; <label>:341                                     ; preds = %338
   %342 = load i8, i8* %340, align 8
   %343 = zext i8 %342 to i32
   %344 = trunc i32 %343 to i8
-  %NullCheck138 = icmp ne i8* %339, null
-  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+  %NullCheck137 = icmp eq i8* %339, null
+  br i1 %NullCheck137, label %ThrowNullRef138, label %345
 
 ; <label>:345                                     ; preds = %341
   store i8 %344, i8* %339, align 8
@@ -1317,16 +1399,16 @@ entry:
   %357 = load i8*, i8** %arg0
   %358 = load i8*, i8** %arg1
   %359 = bitcast i8* %358 to i16*
-  %NullCheck140 = icmp ne i16* %359, null
-  br i1 %NullCheck140, label %360, label %ThrowNullRef139
+  %NullCheck139 = icmp eq i16* %359, null
+  br i1 %NullCheck139, label %ThrowNullRef140, label %360
 
 ; <label>:360                                     ; preds = %356
   %361 = load i16, i16* %359, align 8
   %362 = sext i16 %361 to i32
   %363 = bitcast i8* %357 to i16*
   %364 = trunc i32 %362 to i16
-  %NullCheck142 = icmp ne i16* %363, null
-  br i1 %NullCheck142, label %365, label %ThrowNullRef141
+  %NullCheck141 = icmp eq i16* %363, null
+  br i1 %NullCheck141, label %ThrowNullRef142, label %365
 
 ; <label>:365                                     ; preds = %360
   store i16 %364, i16* %363, align 8
@@ -1352,14 +1434,14 @@ entry:
   %378 = load i8*, i8** %arg0
   %379 = load i8*, i8** %arg1
   %380 = bitcast i8* %379 to i32*
-  %NullCheck144 = icmp ne i32* %380, null
-  br i1 %NullCheck144, label %381, label %ThrowNullRef143
+  %NullCheck143 = icmp eq i32* %380, null
+  br i1 %NullCheck143, label %ThrowNullRef144, label %381
 
 ; <label>:381                                     ; preds = %377
   %382 = load i32, i32* %380, align 8
   %383 = bitcast i8* %378 to i32*
-  %NullCheck146 = icmp ne i32* %383, null
-  br i1 %NullCheck146, label %384, label %ThrowNullRef145
+  %NullCheck145 = icmp eq i32* %383, null
+  br i1 %NullCheck145, label %ThrowNullRef146, label %384
 
 ; <label>:384                                     ; preds = %381
   store i32 %382, i32* %383, align 8
@@ -1384,14 +1466,14 @@ entry:
   %395 = load i8*, i8** %arg0
   %396 = load i8*, i8** %arg1
   %397 = bitcast i8* %396 to i64*
-  %NullCheck164 = icmp ne i64* %397, null
-  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+  %NullCheck163 = icmp eq i64* %397, null
+  br i1 %NullCheck163, label %ThrowNullRef164, label %398
 
 ; <label>:398                                     ; preds = %394
   %399 = load i64, i64* %397, align 8
   %400 = bitcast i8* %395 to i64*
-  %NullCheck166 = icmp ne i64* %400, null
-  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+  %NullCheck165 = icmp eq i64* %400, null
+  br i1 %NullCheck165, label %ThrowNullRef166, label %401
 
 ; <label>:401                                     ; preds = %398
   store i64 %399, i64* %400, align 8
@@ -1400,14 +1482,14 @@ entry:
   %404 = load i8*, i8** %arg1
   %405 = getelementptr inbounds i8, i8* %404, i64 8
   %406 = bitcast i8* %405 to i64*
-  %NullCheck168 = icmp ne i64* %406, null
-  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+  %NullCheck167 = icmp eq i64* %406, null
+  br i1 %NullCheck167, label %ThrowNullRef168, label %407
 
 ; <label>:407                                     ; preds = %401
   %408 = load i64, i64* %406, align 8
   %409 = bitcast i8* %403 to i64*
-  %NullCheck170 = icmp ne i64* %409, null
-  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+  %NullCheck169 = icmp eq i64* %409, null
+  br i1 %NullCheck169, label %ThrowNullRef170, label %410
 
 ; <label>:410                                     ; preds = %407
   store i64 %408, i64* %409, align 8
@@ -1437,14 +1519,14 @@ entry:
   %425 = load i8*, i8** %arg0
   %426 = load i8*, i8** %arg1
   %427 = bitcast i8* %426 to i64*
-  %NullCheck148 = icmp ne i64* %427, null
-  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+  %NullCheck147 = icmp eq i64* %427, null
+  br i1 %NullCheck147, label %ThrowNullRef148, label %428
 
 ; <label>:428                                     ; preds = %424
   %429 = load i64, i64* %427, align 8
   %430 = bitcast i8* %425 to i64*
-  %NullCheck150 = icmp ne i64* %430, null
-  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+  %NullCheck149 = icmp eq i64* %430, null
+  br i1 %NullCheck149, label %ThrowNullRef150, label %431
 
 ; <label>:431                                     ; preds = %428
   store i64 %429, i64* %430, align 8
@@ -1466,14 +1548,14 @@ entry:
   %441 = load i8*, i8** %arg0
   %442 = load i8*, i8** %arg1
   %443 = bitcast i8* %442 to i32*
-  %NullCheck152 = icmp ne i32* %443, null
-  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+  %NullCheck151 = icmp eq i32* %443, null
+  br i1 %NullCheck151, label %ThrowNullRef152, label %444
 
 ; <label>:444                                     ; preds = %440
   %445 = load i32, i32* %443, align 8
   %446 = bitcast i8* %441 to i32*
-  %NullCheck154 = icmp ne i32* %446, null
-  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+  %NullCheck153 = icmp eq i32* %446, null
+  br i1 %NullCheck153, label %ThrowNullRef154, label %447
 
 ; <label>:447                                     ; preds = %444
   store i32 %445, i32* %446, align 8
@@ -1495,16 +1577,16 @@ entry:
   %457 = load i8*, i8** %arg0
   %458 = load i8*, i8** %arg1
   %459 = bitcast i8* %458 to i16*
-  %NullCheck156 = icmp ne i16* %459, null
-  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+  %NullCheck155 = icmp eq i16* %459, null
+  br i1 %NullCheck155, label %ThrowNullRef156, label %460
 
 ; <label>:460                                     ; preds = %456
   %461 = load i16, i16* %459, align 8
   %462 = sext i16 %461 to i32
   %463 = bitcast i8* %457 to i16*
   %464 = trunc i32 %462 to i16
-  %NullCheck158 = icmp ne i16* %463, null
-  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+  %NullCheck157 = icmp eq i16* %463, null
+  br i1 %NullCheck157, label %ThrowNullRef158, label %465
 
 ; <label>:465                                     ; preds = %460
   store i16 %464, i16* %463, align 8
@@ -1525,15 +1607,15 @@ entry:
 ; <label>:474                                     ; preds = %470
   %475 = load i8*, i8** %arg0
   %476 = load i8*, i8** %arg1
-  %NullCheck160 = icmp ne i8* %476, null
-  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+  %NullCheck159 = icmp eq i8* %476, null
+  br i1 %NullCheck159, label %ThrowNullRef160, label %477
 
 ; <label>:477                                     ; preds = %474
   %478 = load i8, i8* %476, align 8
   %479 = zext i8 %478 to i32
   %480 = trunc i32 %479 to i8
-  %NullCheck162 = icmp ne i8* %475, null
-  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+  %NullCheck161 = icmp eq i8* %475, null
+  br i1 %NullCheck161, label %ThrowNullRef162, label %481
 
 ; <label>:481                                     ; preds = %477
   store i8 %480, i8* %475, align 8
@@ -1553,343 +1635,343 @@ ThrowNullRef:                                     ; preds = %308
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %312
+ThrowNullRef2:                                    ; preds = %312
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %315
+ThrowNullRef4:                                    ; preds = %315
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %321
+ThrowNullRef6:                                    ; preds = %321
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %271
+ThrowNullRef8:                                    ; preds = %271
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %275
+ThrowNullRef10:                                   ; preds = %275
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %278
+ThrowNullRef12:                                   ; preds = %278
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %284
+ThrowNullRef14:                                   ; preds = %284
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %287
+ThrowNullRef16:                                   ; preds = %287
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %293
+ThrowNullRef18:                                   ; preds = %293
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %298
+ThrowNullRef20:                                   ; preds = %298
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %303
+ThrowNullRef22:                                   ; preds = %303
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %243
+ThrowNullRef24:                                   ; preds = %243
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %247
+ThrowNullRef26:                                   ; preds = %247
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %250
+ThrowNullRef28:                                   ; preds = %250
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %256
+ThrowNullRef30:                                   ; preds = %256
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %259
+ThrowNullRef32:                                   ; preds = %259
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %265
+ThrowNullRef34:                                   ; preds = %265
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %217
+ThrowNullRef36:                                   ; preds = %217
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %221
+ThrowNullRef38:                                   ; preds = %221
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %224
+ThrowNullRef40:                                   ; preds = %224
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %230
+ThrowNullRef42:                                   ; preds = %230
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %233
+ThrowNullRef44:                                   ; preds = %233
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %238
+ThrowNullRef46:                                   ; preds = %238
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %200
+ThrowNullRef48:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %204
+ThrowNullRef50:                                   ; preds = %204
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %207
+ThrowNullRef52:                                   ; preds = %207
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %213
+ThrowNullRef54:                                   ; preds = %213
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %172
+ThrowNullRef56:                                   ; preds = %172
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %176
+ThrowNullRef58:                                   ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %179
+ThrowNullRef60:                                   ; preds = %179
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %185
+ThrowNullRef62:                                   ; preds = %185
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %190
+ThrowNullRef64:                                   ; preds = %190
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %195
+ThrowNullRef66:                                   ; preds = %195
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %153
+ThrowNullRef68:                                   ; preds = %153
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %157
+ThrowNullRef70:                                   ; preds = %157
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %160
+ThrowNullRef72:                                   ; preds = %160
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %166
+ThrowNullRef74:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %136
+ThrowNullRef76:                                   ; preds = %136
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %140
+ThrowNullRef78:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %143
+ThrowNullRef80:                                   ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %148
+ThrowNullRef82:                                   ; preds = %148
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %128
+ThrowNullRef84:                                   ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %132
+ThrowNullRef86:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %100
+ThrowNullRef88:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %104
+ThrowNullRef90:                                   ; preds = %104
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %107
+ThrowNullRef92:                                   ; preds = %107
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %113
+ThrowNullRef94:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %118
+ThrowNullRef96:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %123
+ThrowNullRef98:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %81
+ThrowNullRef100:                                  ; preds = %81
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef101:                                  ; preds = %85
+ThrowNullRef102:                                  ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef103:                                  ; preds = %88
+ThrowNullRef104:                                  ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef105:                                  ; preds = %94
+ThrowNullRef106:                                  ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef107:                                  ; preds = %64
+ThrowNullRef108:                                  ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef109:                                  ; preds = %68
+ThrowNullRef110:                                  ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef111:                                  ; preds = %71
+ThrowNullRef112:                                  ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef113:                                  ; preds = %76
+ThrowNullRef114:                                  ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef115:                                  ; preds = %56
+ThrowNullRef116:                                  ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef117:                                  ; preds = %60
+ThrowNullRef118:                                  ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef119:                                  ; preds = %37
+ThrowNullRef120:                                  ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef121:                                  ; preds = %41
+ThrowNullRef122:                                  ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef123:                                  ; preds = %46
+ThrowNullRef124:                                  ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef125:                                  ; preds = %51
+ThrowNullRef126:                                  ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef127:                                  ; preds = %27
+ThrowNullRef128:                                  ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef129:                                  ; preds = %31
+ThrowNullRef130:                                  ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef131:                                  ; preds = %19
+ThrowNullRef132:                                  ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef133:                                  ; preds = %22
+ThrowNullRef134:                                  ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef135:                                  ; preds = %338
+ThrowNullRef136:                                  ; preds = %338
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef137:                                  ; preds = %341
+ThrowNullRef138:                                  ; preds = %341
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef139:                                  ; preds = %356
+ThrowNullRef140:                                  ; preds = %356
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef141:                                  ; preds = %360
+ThrowNullRef142:                                  ; preds = %360
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef143:                                  ; preds = %377
+ThrowNullRef144:                                  ; preds = %377
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef145:                                  ; preds = %381
+ThrowNullRef146:                                  ; preds = %381
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef147:                                  ; preds = %424
+ThrowNullRef148:                                  ; preds = %424
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef149:                                  ; preds = %428
+ThrowNullRef150:                                  ; preds = %428
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef151:                                  ; preds = %440
+ThrowNullRef152:                                  ; preds = %440
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef153:                                  ; preds = %444
+ThrowNullRef154:                                  ; preds = %444
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef155:                                  ; preds = %456
+ThrowNullRef156:                                  ; preds = %456
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef157:                                  ; preds = %460
+ThrowNullRef158:                                  ; preds = %460
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef159:                                  ; preds = %474
+ThrowNullRef160:                                  ; preds = %474
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef161:                                  ; preds = %477
+ThrowNullRef162:                                  ; preds = %477
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef163:                                  ; preds = %394
+ThrowNullRef164:                                  ; preds = %394
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef165:                                  ; preds = %398
+ThrowNullRef166:                                  ; preds = %398
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef167:                                  ; preds = %401
+ThrowNullRef168:                                  ; preds = %401
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef169:                                  ; preds = %407
+ThrowNullRef170:                                  ; preds = %407
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1939,8 +2021,8 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
-  br i1 %NullCheck, label %22, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %ThrowNullRef, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
@@ -1948,8 +2030,8 @@ entry:
   store i32 %24, i32* %loc0
   %25 = load i32, i32* %loc0
   %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %26, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %27
 
 ; <label>:27                                      ; preds = %22
   %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
@@ -1971,7 +2053,7 @@ ThrowNullRef:                                     ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1989,8 +2071,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -2022,15 +2104,15 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2048,16 +2130,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
   %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
   store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %15
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
@@ -2072,8 +2154,8 @@ entry:
   %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
   %29 = ptrtoint i16 addrspace(1)* %28 to i64
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %19
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
@@ -2089,19 +2171,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2114,8 +2196,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
@@ -2128,7 +2210,7 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[loadElem]
+Failed to read AppDomain.PrepareDataForSetup[storeElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
@@ -2202,8 +2284,8 @@ entry:
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
-  br i1 %NullCheck24, label %27, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = load i64, i64 addrspace(1)* %26
@@ -2218,8 +2300,8 @@ entry:
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
-  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
   %41 = load i64, i64 addrspace(1)* %39
@@ -2236,8 +2318,8 @@ entry:
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
-  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
   %54 = load i64, i64 addrspace(1)* %52
@@ -2252,8 +2334,8 @@ entry:
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
   %67 = load i64, i64 addrspace(1)* %65
@@ -2270,8 +2352,8 @@ entry:
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
-  br i1 %NullCheck16, label %79, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
   %80 = load i64, i64 addrspace(1)* %78
@@ -2286,8 +2368,8 @@ entry:
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
-  br i1 %NullCheck18, label %92, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
   %93 = load i64, i64 addrspace(1)* %91
@@ -2304,8 +2386,8 @@ entry:
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
-  br i1 %NullCheck12, label %105, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = load i64, i64 addrspace(1)* %104
@@ -2320,8 +2402,8 @@ entry:
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
-  br i1 %NullCheck14, label %118, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
   %119 = load i64, i64 addrspace(1)* %117
@@ -2337,8 +2419,8 @@ entry:
 
 ; <label>:128                                     ; preds = %20
   %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
-  br i1 %NullCheck4, label %130, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %129, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %130
 
 ; <label>:130                                     ; preds = %128
   %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
@@ -2346,8 +2428,8 @@ entry:
   %133 = load i16, i16 addrspace(1)* %132, align 8
   %134 = zext i16 %133 to i32
   %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
-  br i1 %NullCheck6, label %136, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %135, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %136
 
 ; <label>:136                                     ; preds = %130
   %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
@@ -2360,8 +2442,8 @@ entry:
 
 ; <label>:143                                     ; preds = %136
   %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
-  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %144, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %145
 
 ; <label>:145                                     ; preds = %143
   %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
@@ -2369,8 +2451,8 @@ entry:
   %148 = load i16, i16 addrspace(1)* %147, align 8
   %149 = zext i16 %148 to i32
   %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %150, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %151
 
 ; <label>:151                                     ; preds = %145
   %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
@@ -2388,8 +2470,8 @@ entry:
 
 ; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
-  br i1 %NullCheck, label %163, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %ThrowNullRef, label %163
 
 ; <label>:163                                     ; preds = %161
   %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
@@ -2399,8 +2481,8 @@ entry:
 
 ; <label>:167                                     ; preds = %163
   %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
-  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %168, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %169
 
 ; <label>:169                                     ; preds = %167
   %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
@@ -2432,55 +2514,55 @@ ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %167
+ThrowNullRef2:                                    ; preds = %167
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %128
+ThrowNullRef4:                                    ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %130
+ThrowNullRef6:                                    ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %143
+ThrowNullRef8:                                    ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %145
+ThrowNullRef10:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %102
+ThrowNullRef12:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %105
+ThrowNullRef14:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %76
+ThrowNullRef16:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %79
+ThrowNullRef18:                                   ; preds = %79
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %50
+ThrowNullRef20:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %53
+ThrowNullRef22:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %24
+ThrowNullRef24:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %27
+ThrowNullRef26:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2503,15 +2585,15 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2519,16 +2601,16 @@ entry:
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
   store i32 %8, i32* %loc0
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
   %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
   store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
@@ -2546,16 +2628,16 @@ entry:
 
 ; <label>:23                                      ; preds = %64
   %24 = load i16*, i16** %loc3
-  %NullCheck12 = icmp ne i16* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i16* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
   store i32 %27, i32* %loc5
   %28 = load i16*, i16** %loc4
-  %NullCheck14 = icmp ne i16* %28, null
-  br i1 %NullCheck14, label %29, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %28, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = load i16, i16* %28, align 8
@@ -2620,15 +2702,15 @@ entry:
 
 ; <label>:67                                      ; preds = %64
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
-  br i1 %NullCheck8, label %69, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %68, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %69
 
 ; <label>:69                                      ; preds = %67
   %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
   %71 = load i32, i32 addrspace(1)* %70
   %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
-  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %73
 
 ; <label>:73                                      ; preds = %69
   %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
@@ -2645,31 +2727,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %67
+ThrowNullRef8:                                    ; preds = %67
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %69
+ThrowNullRef10:                                   ; preds = %69
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2710,14 +2792,14 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
   %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
@@ -2730,14 +2812,14 @@ entry:
 
 ; <label>:11                                      ; preds = %4
   %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
   %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
@@ -2749,14 +2831,14 @@ entry:
 
 ; <label>:22                                      ; preds = %16
   %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
   %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
-  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
-  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
@@ -2804,23 +2886,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2836,7 +2918,280 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[loadElem]
+Successfully read RuntimeType.IsAssignableFrom
+
+define i8 @RuntimeType.IsAssignableFrom(%System.RuntimeType addrspace(1)* %param0, %System.Type addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.RuntimeType addrspace(1)*
+  %arg1 = alloca %System.Type addrspace(1)*
+  %loc0 = alloca %System.RuntimeType addrspace(1)*
+  %loc1 = alloca %"System.Type[]" addrspace(1)*
+  %loc2 = alloca i32
+  store %System.RuntimeType addrspace(1)* %param0, %System.RuntimeType addrspace(1)** %this
+  store %System.Type addrspace(1)* %param1, %System.Type addrspace(1)** %arg1
+  %0 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %1 = icmp ne %System.Type addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i8 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %5 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %6 = bitcast %System.Type addrspace(1)* %4 to %System.Object addrspace(1)*
+  %7 = bitcast %System.RuntimeType addrspace(1)* %5 to %System.Object addrspace(1)*
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %6, %System.Object addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %3
+  ret i8 1
+
+; <label>:12                                      ; preds = %3
+  %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 152
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 32
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
+  %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
+  %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
+  store %System.RuntimeType addrspace(1)* %25, %System.RuntimeType addrspace(1)** %loc0
+  %26 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %27 = icmp eq %System.RuntimeType addrspace(1)* %26, null
+  br i1 %27, label %34, label %28
+
+; <label>:28                                      ; preds = %15
+  %29 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %30 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)*)*)(%System.RuntimeType addrspace(1)* %29, %System.RuntimeType addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+; <label>:34                                      ; preds = %15
+  %35 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %36 = call %System.Reflection.Emit.TypeBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Reflection.Emit.TypeBuilder addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %35)
+  %37 = icmp eq %System.Reflection.Emit.TypeBuilder addrspace(1)* %36, null
+  br i1 %37, label %139, label %38
+
+; <label>:38                                      ; preds = %34
+  %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %42
+
+; <label>:42                                      ; preds = %38
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 152
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 40
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
+  %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
+  %53 = zext i8 %52 to i32
+  %54 = icmp eq i32 %53, 0
+  br i1 %54, label %56, label %55
+
+; <label>:55                                      ; preds = %42
+  ret i8 1
+
+; <label>:56                                      ; preds = %42
+  %57 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %58 = bitcast %System.RuntimeType addrspace(1)* %57 to %System.Type addrspace(1)*
+  %59 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %58)
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %64 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.Type addrspace(1)* %63, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = bitcast %System.RuntimeType addrspace(1)* %64 to %System.Type addrspace(1)*
+  %67 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %63, %System.Type addrspace(1)* %66)
+  %68 = zext i8 %67 to i32
+  %69 = trunc i32 %68 to i8
+  ret i8 %69
+
+; <label>:70                                      ; preds = %56
+  %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
+  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %73
+
+; <label>:73                                      ; preds = %70
+  %74 = load i64, i64 addrspace(1)* %72
+  %75 = add i64 %74, 128
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = add i64 %77, 0
+  %79 = inttoptr i64 %78 to i64*
+  %80 = load i64, i64* %79
+  %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
+  %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
+  %83 = call i8 %82(%System.Type addrspace(1)* %81)
+  %84 = zext i8 %83 to i32
+  %85 = icmp eq i32 %84, 0
+  br i1 %85, label %139, label %86
+
+; <label>:86                                      ; preds = %73
+  %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
+  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %89
+
+; <label>:89                                      ; preds = %86
+  %90 = load i64, i64 addrspace(1)* %88
+  %91 = add i64 %90, 128
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = add i64 %93, 24
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
+  %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
+  %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
+  store %"System.Type[]" addrspace(1)* %99, %"System.Type[]" addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %129
+
+; <label>:100                                     ; preds = %132
+  %101 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %102 = load i32, i32* %loc2
+  %NullCheck11 = icmp eq %"System.Type[]" addrspace(1)* %101, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %103
+
+; <label>:103                                     ; preds = %100
+  %104 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 1
+  %105 = load i32, i32 addrspace(1)* %104
+  %106 = zext i32 %105 to i64
+  %107 = zext i32 %102 to i64
+  %BoundsCheck = icmp uge i64 %107, %106
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %108
+
+; <label>:108                                     ; preds = %103
+  %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
+  %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
+  %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
+  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %113
+
+; <label>:113                                     ; preds = %108
+  %114 = load i64, i64 addrspace(1)* %112
+  %115 = add i64 %114, 152
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = add i64 %117, 56
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
+  %123 = zext i8 %122 to i32
+  %124 = icmp ne i32 %123, 0
+  br i1 %124, label %126, label %125
+
+; <label>:125                                     ; preds = %113
+  ret i8 0
+
+; <label>:126                                     ; preds = %113
+  %127 = load i32, i32* %loc2
+  %128 = add i32 %127, 1
+  store i32 %128, i32* %loc2
+  br label %129
+
+; <label>:129                                     ; preds = %89, %126
+  %130 = load i32, i32* %loc2
+  %131 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %NullCheck9 = icmp eq %"System.Type[]" addrspace(1)* %131, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %132
+
+; <label>:132                                     ; preds = %129
+  %133 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %131, i32 0, i32 1
+  %134 = load i32, i32 addrspace(1)* %133
+  %135 = zext i32 %134 to i64
+  %136 = trunc i64 %135 to i32
+  %137 = icmp slt i32 %130, %136
+  br i1 %137, label %100, label %138
+
+; <label>:138                                     ; preds = %132
+  ret i8 1
+
+; <label>:139                                     ; preds = %34, %73
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %129
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %103
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -2893,7 +3248,7 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElem]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -2904,8 +3259,8 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -2997,8 +3352,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
@@ -3059,8 +3414,8 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -3087,8 +3442,8 @@ entry:
 
 ; <label>:17                                      ; preds = %5, %11
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
@@ -3097,8 +3452,8 @@ entry:
 
 ; <label>:22                                      ; preds = %1, %11
   %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
@@ -3109,11 +3464,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %17
+ThrowNullRef2:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %22
+ThrowNullRef4:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3167,15 +3522,15 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
   %15 = load i32, i32 addrspace(1)* %14
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
@@ -3198,7 +3553,7 @@ ThrowNullRef:                                     ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef2:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3232,8 +3587,8 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
@@ -3312,8 +3667,8 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -3327,8 +3682,8 @@ entry:
 ; <label>:5                                       ; preds = %43
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %7 = load i32, i32* %loc1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck6, label %8, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
@@ -3366,8 +3721,8 @@ entry:
 ; <label>:32                                      ; preds = %21, %25
   %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
   %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
-  br i1 %NullCheck8, label %35, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = trunc i32 %34 to i16
@@ -3380,8 +3735,8 @@ entry:
 ; <label>:40                                      ; preds = %1, %35
   %41 = load i32, i32* %loc1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
-  br i1 %NullCheck2, label %43, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %42, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
@@ -3392,8 +3747,8 @@ entry:
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
   %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
-  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
   %51 = load i64, i64 addrspace(1)* %49
@@ -3412,19 +3767,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %40
+ThrowNullRef2:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %47
+ThrowNullRef4:                                    ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %5
+ThrowNullRef6:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %32
+ThrowNullRef8:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3467,8 +3822,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
@@ -3492,11 +3847,391 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(i16* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store i16* %param0, i16** %arg0
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load i32, i32* %arg3
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %42, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %37, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg2
+  %13 = load i32, i32* %arg3
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %37, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %24 = load i32, i32* %arg2
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load i16*, i16** %arg0
+  %35 = load i32, i32* %arg3
+  %36 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %36, i16* %34, i32 %35)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:37                                      ; preds = %5, %16
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %39)
+  %41 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41, %System.String addrspace(1)* %38, %System.String addrspace(1)* %40)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41) #0
+  unreachable
+
+; <label>:42                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
-Failed to read StringBuilder.ToString[loadElemA]
+Successfully read StringBuilder.ToString
+
+define %System.String addrspace(1)* @StringBuilder.ToString(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i16*
+  %loc3 = alloca %"System.Char[]" addrspace(1)*
+  %loc4 = alloca i32
+  %loc5 = alloca i32
+  %loc6 = alloca i16 addrspace(1)*
+  %loc7 = alloca %System.String addrspace(1)*
+  %loc8 = alloca %"System.Char[]" addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %0)
+  %2 = icmp ne i32 %1, 0
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %4
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %6)
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %7)
+  store %System.String addrspace(1)* %8, %System.String addrspace(1)** %loc0
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.Text.StringBuilder addrspace(1)* %9, %System.Text.StringBuilder addrspace(1)** %loc1
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  store %System.String addrspace(1)* %10, %System.String addrspace(1)** %loc7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc7
+  %12 = ptrtoint %System.String addrspace(1)* %11 to i64
+  %13 = icmp eq i64 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %5
+  %15 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %16 = sext i32 %15 to i64
+  %17 = add i64 %12, %16
+  br label %18
+
+; <label>:18                                      ; preds = %5, %14
+  %19 = phi i64 [ %12, %5 ], [ %17, %14 ]
+  %20 = inttoptr i64 %19 to i16*
+  store i16* %20, i16** %loc2
+  br label %21
+
+; <label>:21                                      ; preds = %98, %18
+  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %22, null
+  br i1 %NullCheck, label %ThrowNullRef, label %23
+
+; <label>:23                                      ; preds = %21
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 3
+  %25 = load i32, i32 addrspace(1)* %24, align 8
+  %26 = icmp sle i32 %25, 0
+  br i1 %26, label %96, label %27
+
+; <label>:27                                      ; preds = %23
+  %28 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %28, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %29
+
+; <label>:29                                      ; preds = %27
+  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %28, i32 0, i32 1
+  %31 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %30, align 8
+  store %"System.Char[]" addrspace(1)* %31, %"System.Char[]" addrspace(1)** %loc3
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %33
+
+; <label>:33                                      ; preds = %29
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  store i32 %35, i32* %loc4
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  %39 = load i32, i32 addrspace(1)* %38, align 8
+  store i32 %39, i32* %loc5
+  %40 = load i32, i32* %loc5
+  %41 = load i32, i32* %loc4
+  %42 = add i32 %40, %41
+  %43 = zext i32 %42 to i64
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %45
+
+; <label>:45                                      ; preds = %37
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = sext i32 %47 to i64
+  %49 = icmp sgt i64 %43, %48
+  br i1 %49, label %91, label %50
+
+; <label>:50                                      ; preds = %45
+  %51 = load i32, i32* %loc5
+  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %52, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %53
+
+; <label>:53                                      ; preds = %50
+  %54 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %52, i32 0, i32 1
+  %55 = load i32, i32 addrspace(1)* %54
+  %56 = zext i32 %55 to i64
+  %57 = trunc i64 %56 to i32
+  %58 = icmp ugt i32 %51, %57
+  br i1 %58, label %91, label %59
+
+; <label>:59                                      ; preds = %53
+  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  store %"System.Char[]" addrspace(1)* %60, %"System.Char[]" addrspace(1)** %loc8
+  %61 = icmp eq %"System.Char[]" addrspace(1)* %60, null
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %63, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %64
+
+; <label>:64                                      ; preds = %62
+  %65 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %63, i32 0, i32 1
+  %66 = load i32, i32 addrspace(1)* %65
+  %67 = zext i32 %66 to i64
+  %68 = trunc i64 %67 to i32
+  %69 = icmp ne i32 %68, 0
+  br i1 %69, label %71, label %70
+
+; <label>:70                                      ; preds = %59, %64
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:71                                      ; preds = %64
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %73
+
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %BoundsCheck = icmp uge i64 0, %76
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %77
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %78, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:79                                      ; preds = %70, %77
+  %80 = load i16*, i16** %loc2
+  %81 = load i32, i32* %loc4
+  %82 = sext i32 %81 to i64
+  %83 = mul i64 %82, 2
+  %84 = bitcast i16* %80 to i8*
+  %85 = getelementptr inbounds i8, i8* %84, i64 %83
+  %86 = load i16 addrspace(1)*, i16 addrspace(1)** %loc6
+  %87 = ptrtoint i16 addrspace(1)* %86 to i64
+  %88 = load i32, i32* %loc5
+  %89 = bitcast i8* %85 to i16*
+  %90 = inttoptr i64 %87 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %89, i16* %90, i32 %88)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %96
+
+; <label>:91                                      ; preds = %45, %53
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %94 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %93)
+  %95 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95, %System.String addrspace(1)* %92, %System.String addrspace(1)* %94)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95) #0
+  unreachable
+
+; <label>:96                                      ; preds = %23, %79
+  %97 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %97, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %98
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %97, i32 0, i32 2
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  store %System.Text.StringBuilder addrspace(1)* %100, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %102 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %102, label %21, label %103
+
+; <label>:103                                     ; preds = %98
+  store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc7
+  %104 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  ret %System.String addrspace(1)* %104
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method StringBuilder::get_Length using LLILCJit
+Successfully read StringBuilder.get_Length
+
+define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
+Successfully read RuntimeHelpers.get_OffsetToStringData
+
+define i32 @RuntimeHelpers.get_OffsetToStringData() {
+entry:
+  ret i32 12
+}
+
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
 Successfully read CultureData.CreateCultureData
 
@@ -3514,23 +4249,23 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
   store i8 %4, i8 addrspace(1)* %6
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
@@ -3549,11 +4284,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3566,50 +4301,50 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
   store i32 -1, i32 addrspace(1)* %2
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
   store i32 -1, i32 addrspace(1)* %8
   %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
   store i32 -1, i32 addrspace(1)* %14
   %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
   store i32 -1, i32 addrspace(1)* %17
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
@@ -3623,27 +4358,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3675,7 +4410,136 @@ Failed to read Dictionary`2.Insert[non-const derefAddress]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
 Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
-Failed to read HashHelpers.GetPrime[loadElem]
+Successfully read HashHelpers.GetPrime
+
+define i32 @HashHelpers.GetPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %6, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5, %System.String addrspace(1)* %4)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5) #0
+  unreachable
+
+; <label>:6                                       ; preds = %entry
+  store i32 0, i32* %loc0
+  br label %29
+
+; <label>:7                                       ; preds = %35
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 1296
+  %10 = addrspacecast i8 addrspace(1)* %9 to %"System.Int32[]" addrspace(1)**
+  %11 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %10
+  %12 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Int32[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = zext i32 %15 to i64
+  %17 = zext i32 %12 to i64
+  %BoundsCheck = icmp uge i64 %17, %16
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 3, i32 %12
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  store i32 %20, i32* %loc1
+  %21 = load i32, i32* %loc1
+  %22 = load i32, i32* %arg0
+  %23 = icmp slt i32 %21, %22
+  br i1 %23, label %26, label %24
+
+; <label>:24                                      ; preds = %18
+  %25 = load i32, i32* %loc1
+  ret i32 %25
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %loc0
+  %28 = add i32 %27, 1
+  store i32 %28, i32* %loc0
+  br label %29
+
+; <label>:29                                      ; preds = %6, %26
+  %30 = load i32, i32* %loc0
+  %31 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %32 = getelementptr inbounds i8, i8 addrspace(1)* %31, i64 1296
+  %33 = addrspacecast i8 addrspace(1)* %32 to %"System.Int32[]" addrspace(1)**
+  %34 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %33
+  %NullCheck = icmp eq %"System.Int32[]" addrspace(1)* %34, null
+  br i1 %NullCheck, label %ThrowNullRef, label %35
+
+; <label>:35                                      ; preds = %29
+  %36 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %34, i32 0, i32 1
+  %37 = load i32, i32 addrspace(1)* %36
+  %38 = zext i32 %37 to i64
+  %39 = trunc i64 %38 to i32
+  %40 = icmp slt i32 %30, %39
+  br i1 %40, label %7, label %41
+
+; <label>:41                                      ; preds = %35
+  %42 = load i32, i32* %arg0
+  %43 = or i32 %42, 1
+  store i32 %43, i32* %loc2
+  br label %59
+
+; <label>:44                                      ; preds = %59
+  %45 = load i32, i32* %loc2
+  %46 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %45)
+  %47 = zext i8 %46 to i32
+  %48 = icmp eq i32 %47, 0
+  br i1 %48, label %56, label %49
+
+; <label>:49                                      ; preds = %44
+  %50 = load i32, i32* %loc2
+  %51 = sub i32 %50, 1
+  %52 = srem i32 %51, 101
+  %53 = icmp eq i32 %52, 0
+  br i1 %53, label %56, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = load i32, i32* %loc2
+  ret i32 %55
+
+; <label>:56                                      ; preds = %44, %49
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %57, 2
+  store i32 %58, i32* %loc2
+  br label %59
+
+; <label>:59                                      ; preds = %41, %56
+  %60 = load i32, i32* %loc2
+  %61 = icmp slt i32 %60, 2147483647
+  br i1 %61, label %44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load i32, i32* %arg0
+  ret i32 %63
+
+ThrowNullRef:                                     ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
 Successfully read GenericEqualityComparer`1.GetHashCode
 
@@ -3694,14 +4558,14 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
   %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load i64, i64 addrspace(1)* %7
@@ -3720,7 +4584,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3750,8 +4614,8 @@ entry:
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
@@ -3796,8 +4660,8 @@ entry:
   %35 = bitcast i16* %34 to i8*
   %36 = getelementptr inbounds i8, i8* %35, i64 2
   %37 = bitcast i8* %36 to i16*
-  %NullCheck4 = icmp ne i16* %37, null
-  br i1 %NullCheck4, label %38, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %37, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %38
 
 ; <label>:38                                      ; preds = %27
   %39 = load i16, i16* %37, align 8
@@ -3824,8 +4688,8 @@ entry:
 
 ; <label>:54                                      ; preds = %22, %43
   %55 = load i16*, i16** %loc4
-  %NullCheck2 = icmp ne i16* %55, null
-  br i1 %NullCheck2, label %56, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i16* %55, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %56
 
 ; <label>:56                                      ; preds = %54
   %57 = load i16, i16* %55, align 8
@@ -3850,11 +4714,11 @@ ThrowNullRef:                                     ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %54
+ThrowNullRef2:                                    ; preds = %54
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %27
+ThrowNullRef4:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3871,8 +4735,8 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -3907,8 +4771,8 @@ entry:
 
 ; <label>:26                                      ; preds = %19
   %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
-  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %28
 
 ; <label>:28                                      ; preds = %26
   %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
@@ -3920,7 +4784,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3972,8 +4836,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
@@ -3984,26 +4848,26 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
-  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
@@ -4014,8 +4878,8 @@ entry:
 ; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
@@ -4024,8 +4888,8 @@ entry:
 
 ; <label>:25                                      ; preds = %1, %16, %23
   %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
-  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
@@ -4036,27 +4900,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %20
+ThrowNullRef10:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4069,8 +4933,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -4081,8 +4945,8 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
@@ -4091,8 +4955,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1, %8
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
@@ -4103,11 +4967,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4128,24 +4992,24 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   store i32 %3, i32* %loc0
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
   %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
   store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck4, label %9, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
@@ -4164,15 +5028,15 @@ entry:
 ; <label>:18                                      ; preds = %70
   %19 = load i16*, i16** %loc3
   %20 = bitcast i16* %19 to i64*
-  %NullCheck10 = icmp ne i64* %20, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %20, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = load i64, i64* %20, align 8
   %23 = load i16*, i16** %loc4
   %24 = bitcast i16* %23 to i64*
-  %NullCheck12 = icmp ne i64* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = load i64, i64* %24, align 8
@@ -4188,8 +5052,8 @@ entry:
   %31 = bitcast i16* %30 to i8*
   %32 = getelementptr inbounds i8, i8* %31, i64 8
   %33 = bitcast i8* %32 to i64*
-  %NullCheck14 = icmp ne i64* %33, null
-  br i1 %NullCheck14, label %34, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = load i64, i64* %33, align 8
@@ -4197,8 +5061,8 @@ entry:
   %37 = bitcast i16* %36 to i8*
   %38 = getelementptr inbounds i8, i8* %37, i64 8
   %39 = bitcast i8* %38 to i64*
-  %NullCheck16 = icmp ne i64* %39, null
-  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %40
 
 ; <label>:40                                      ; preds = %34
   %41 = load i64, i64* %39, align 8
@@ -4214,8 +5078,8 @@ entry:
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %NullCheck18 = icmp ne i64* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = load i64, i64* %48, align 8
@@ -4223,8 +5087,8 @@ entry:
   %52 = bitcast i16* %51 to i8*
   %53 = getelementptr inbounds i8, i8* %52, i64 16
   %54 = bitcast i8* %53 to i64*
-  %NullCheck20 = icmp ne i64* %54, null
-  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64* %54, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %55
 
 ; <label>:55                                      ; preds = %49
   %56 = load i64, i64* %54, align 8
@@ -4262,15 +5126,15 @@ entry:
 ; <label>:74                                      ; preds = %95
   %75 = load i16*, i16** %loc3
   %76 = bitcast i16* %75 to i32*
-  %NullCheck6 = icmp ne i32* %76, null
-  br i1 %NullCheck6, label %77, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32* %76, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %77
 
 ; <label>:77                                      ; preds = %74
   %78 = load i32, i32* %76, align 8
   %79 = load i16*, i16** %loc4
   %80 = bitcast i16* %79 to i32*
-  %NullCheck8 = icmp ne i32* %80, null
-  br i1 %NullCheck8, label %81, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i32* %80, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %81
 
 ; <label>:81                                      ; preds = %77
   %82 = load i32, i32* %80, align 8
@@ -4318,43 +5182,43 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %74
+ThrowNullRef6:                                    ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %77
+ThrowNullRef8:                                    ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %29
+ThrowNullRef14:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %34
+ThrowNullRef16:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4376,8 +5240,8 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load i64, i64 addrspace(1)* %4
@@ -4389,8 +5253,8 @@ entry:
   %12 = load i64, i64* %11
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %5
   %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
@@ -4399,8 +5263,8 @@ entry:
   %18 = load i8, i8* %arg2
   %19 = zext i8 %18 to i32
   %20 = trunc i32 %19 to i8
-  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %15
   %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
@@ -4411,11 +5275,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4442,8 +5306,8 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
@@ -4466,16 +5330,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
   %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = load i64, i64 addrspace(1)* %19
@@ -4500,8 +5364,8 @@ entry:
 ; <label>:35                                      ; preds = %30
   %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
@@ -4514,8 +5378,8 @@ entry:
 
 ; <label>:42                                      ; preds = %1, %38
   %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
-  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
@@ -4526,19 +5390,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %35
+ThrowNullRef2:                                    ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %42
+ThrowNullRef8:                                    ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4551,14 +5415,14 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
@@ -4570,7 +5434,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4583,8 +5447,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
@@ -4613,51 +5477,51 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
   %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
   %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
   %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
   %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
-  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
   store i64 %21, i64 addrspace(1)* %23
   %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %25 = load i64, i64* %loc0
-  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
@@ -4668,27 +5532,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %22
+ThrowNullRef12:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4701,8 +5565,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
@@ -4713,19 +5577,19 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
@@ -4734,8 +5598,8 @@ entry:
 
 ; <label>:15                                      ; preds = %1, %13
   %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
@@ -4746,19 +5610,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %15
+ThrowNullRef8:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4771,8 +5635,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -4831,8 +5695,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
@@ -4882,8 +5746,8 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
-  br i1 %NullCheck, label %17, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %ThrowNullRef, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
@@ -4894,15 +5758,15 @@ entry:
 
 ; <label>:22                                      ; preds = %17
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
-  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
   %26 = load i32, i32 addrspace(1)* %25
   %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
-  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %27, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
@@ -4925,8 +5789,8 @@ entry:
 ; <label>:40                                      ; preds = %17
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
-  br i1 %NullCheck6, label %43, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %41, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
@@ -4938,34 +5802,17 @@ ThrowNullRef:                                     ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %24
+ThrowNullRef4:                                    ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %40
+ThrowNullRef6:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
-}
-
-INFO:  jitting method Object::ReferenceEquals using LLILCJit
-Successfully read Object.ReferenceEquals
-
-define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
-entry:
-  %arg0 = alloca %System.Object addrspace(1)*
-  %arg1 = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
-  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
-  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = icmp eq %System.Object addrspace(1)* %0, %1
-  %3 = sext i1 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
 }
 
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
@@ -4978,21 +5825,21 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
   %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
-  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
@@ -5007,28 +5854,28 @@ entry:
 ; <label>:13                                      ; preds = %8, %12
   %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
   %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
   %21 = load i32, i32 addrspace(1)* %20, align 8
   %22 = add i32 %21, 1
-  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
   store i32 %22, i32 addrspace(1)* %24
   %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
@@ -5039,27 +5886,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5077,7 +5924,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::Setup using LLILCJit
-Failed to read AppDomain.Setup[loadElem]
+Failed to read AppDomain.Setup[unbox]
 INFO:  jitting method Thread::GetDomain using LLILCJit
 Successfully read Thread.GetDomain
 
@@ -5108,8 +5955,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
@@ -5122,14 +5969,14 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
   %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
@@ -5141,11 +5988,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5173,8 +6020,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -5189,7 +6036,328 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
 Failed to read KeyCollection.System.Collections.Generic.IEnumerable<TKey>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Successfully read Enumerator.MoveNext
+
+define i8 @Enumerator.MoveNext(%"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.RuntimeTypeHandle* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*
+  %"$TypeArg" = alloca %System.RuntimeTypeHandle*
+  store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
+  %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 8
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %76, label %12
+
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
+  br label %76
+
+; <label>:13                                      ; preds = %85
+  %14 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck19 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %15
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, i32 0, i32 0
+  %17 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %16, align 8
+  %NullCheck21 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, i32 0, i32 2
+  %20 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %19, align 8
+  %21 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck23 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %22
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, i32 0, i32 2
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %NullCheck25 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 3, i32 %24
+  %NullCheck27 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %32
+
+; <label>:32                                      ; preds = %30
+  %33 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, i32 0, i32 2
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = icmp slt i32 %34, 0
+  br i1 %35, label %68, label %36
+
+; <label>:36                                      ; preds = %32
+  %37 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %38 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck29 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %39
+
+; <label>:39                                      ; preds = %36
+  %40 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, i32 0, i32 0
+  %41 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %40, align 8
+  %NullCheck31 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, i32 0, i32 2
+  %44 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %43, align 8
+  %45 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck33 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, i32 0, i32 2
+  %48 = load i32, i32 addrspace(1)* %47, align 8
+  %NullCheck35 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %49
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = zext i32 %51 to i64
+  %53 = zext i32 %48 to i64
+  %BoundsCheck37 = icmp uge i64 %53, %52
+  br i1 %BoundsCheck37, label %ThrowIndexOutOfRange38, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 3, i32 %48
+  %NullCheck39 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %56
+
+; <label>:56                                      ; preds = %54
+  %57 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, i32 0, i32 0
+  %58 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck41 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %59
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %60, %System.__Canon addrspace(1)* %58)
+  %61 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck43 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  %64 = load i32, i32 addrspace(1)* %63, align 8
+  %65 = add i32 %64, 1
+  %NullCheck45 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  store i32 %65, i32 addrspace(1)* %67
+  ret i8 1
+
+; <label>:68                                      ; preds = %32
+  %69 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck47 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %73 = add i32 %72, 1
+  %NullCheck49 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %74
+
+; <label>:74                                      ; preds = %70
+  %75 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  store i32 %73, i32 addrspace(1)* %75
+  br label %76
+
+; <label>:76                                      ; preds = %8, %12, %74
+  %77 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %78
+
+; <label>:78                                      ; preds = %76
+  %79 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, i32 0, i32 2
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck7 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %82
+
+; <label>:82                                      ; preds = %78
+  %83 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, i32 0, i32 0
+  %84 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %83, align 8
+  %NullCheck9 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %85
+
+; <label>:85                                      ; preds = %82
+  %86 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, i32 0, i32 7
+  %87 = load i32, i32 addrspace(1)* %86, align 8
+  %88 = icmp ult i32 %80, %87
+  br i1 %88, label %13, label %89
+
+; <label>:89                                      ; preds = %85
+  %90 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %91 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck11 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %92
+
+; <label>:92                                      ; preds = %89
+  %93 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, i32 0, i32 0
+  %94 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck13 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %95
+
+; <label>:95                                      ; preds = %92
+  %96 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, i32 0, i32 7
+  %97 = load i32, i32 addrspace(1)* %96, align 8
+  %98 = add i32 %97, 1
+  %NullCheck15 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %99
+
+; <label>:99                                      ; preds = %95
+  %100 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, i32 0, i32 2
+  store i32 %98, i32 addrspace(1)* %100
+  %101 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck17 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %102
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %103, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %92
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef22:                                   ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef24:                                   ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef26:                                   ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef28:                                   ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef30:                                   ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef32:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef34:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef36:                                   ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange38:                           ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef40:                                   ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef42:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef44:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef46:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef48:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef50:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -5200,8 +6368,8 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -5232,9 +6400,9 @@ Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
 Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
-Failed to read String.MakeSeparatorList[loadElemA]
+Failed to read String.MakeSeparatorList[storeElem]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
-Failed to read String.InternalSplitKeepEmptyEntries[loadElem]
+Failed to read String.InternalSplitKeepEmptyEntries[storeElem]
 INFO:  jitting method Path::IsRelative using LLILCJit
 Successfully read Path.IsRelative
 
@@ -5243,8 +6411,8 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -5254,8 +6422,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
@@ -5271,8 +6439,8 @@ entry:
 
 ; <label>:17                                      ; preds = %7
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
@@ -5288,8 +6456,8 @@ entry:
 
 ; <label>:29                                      ; preds = %19
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %31
 
 ; <label>:31                                      ; preds = %29
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
@@ -5300,8 +6468,8 @@ entry:
 
 ; <label>:36                                      ; preds = %31
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
-  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %37, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
@@ -5312,8 +6480,8 @@ entry:
 
 ; <label>:43                                      ; preds = %31, %38
   %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
-  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %45
 
 ; <label>:45                                      ; preds = %43
   %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
@@ -5324,8 +6492,8 @@ entry:
 
 ; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %50
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
@@ -5336,8 +6504,8 @@ entry:
 
 ; <label>:57                                      ; preds = %1, %7, %19, %45, %52
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
-  br i1 %NullCheck14, label %59, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %59
 
 ; <label>:59                                      ; preds = %57
   %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
@@ -5347,8 +6515,8 @@ entry:
 
 ; <label>:63                                      ; preds = %59
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
@@ -5359,8 +6527,8 @@ entry:
 
 ; <label>:70                                      ; preds = %65
   %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
-  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.String addrspace(1)* %71, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %72
 
 ; <label>:72                                      ; preds = %70
   %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
@@ -5379,39 +6547,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %17
+ThrowNullRef4:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %29
+ThrowNullRef6:                                    ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %36
+ThrowNullRef8:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %43
+ThrowNullRef10:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %50
+ThrowNullRef12:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %57
+ThrowNullRef14:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %63
+ThrowNullRef16:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %70
+ThrowNullRef18:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5419,7 +6587,293 @@ ThrowNullRef17:                                   ; preds = %70
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
-Failed to read String.TrimHelper[loadElem]
+Successfully read String.TrimHelper
+
+define %System.String addrspace(1)* @String.TrimHelper(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i16
+  %loc4 = alloca i32
+  %loc5 = alloca i16
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = sub i32 %3, 1
+  store i32 %4, i32* %loc0
+  store i32 0, i32* %loc1
+  %5 = load i32, i32* %arg2
+  %6 = icmp eq i32 %5, 1
+  br i1 %6, label %62, label %7
+
+; <label>:7                                       ; preds = %1
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:8                                       ; preds = %58
+  store i32 0, i32* %loc2
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load i32, i32* %loc1
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2, i32 %10
+  %13 = load i16, i16 addrspace(1)* %12
+  %14 = zext i16 %13 to i32
+  %15 = trunc i32 %14 to i16
+  store i16 %15, i16* %loc3
+  store i32 0, i32* %loc2
+  br label %34
+
+; <label>:16                                      ; preds = %37
+  %17 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %18 = load i32, i32* %loc2
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %17, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %19
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = zext i32 %18 to i64
+  %BoundsCheck = icmp uge i64 %23, %22
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %24
+
+; <label>:24                                      ; preds = %19
+  %25 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 3, i32 %18
+  %26 = load i16, i16 addrspace(1)* %25, align 8
+  %27 = zext i16 %26 to i32
+  %28 = load i16, i16* %loc3
+  %29 = zext i16 %28 to i32
+  %30 = icmp eq i32 %27, %29
+  br i1 %30, label %43, label %31
+
+; <label>:31                                      ; preds = %24
+  %32 = load i32, i32* %loc2
+  %33 = add i32 %32, 1
+  store i32 %33, i32* %loc2
+  br label %34
+
+; <label>:34                                      ; preds = %11, %31
+  %35 = load i32, i32* %loc2
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = icmp slt i32 %35, %41
+  br i1 %42, label %16, label %43
+
+; <label>:43                                      ; preds = %24, %37
+  %44 = load i32, i32* %loc2
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %45, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp eq i32 %44, %50
+  br i1 %51, label %62, label %52
+
+; <label>:52                                      ; preds = %46
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %7, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %57, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %58
+
+; <label>:58                                      ; preds = %55
+  %59 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %60 = load i32, i32 addrspace(1)* %59
+  %61 = icmp slt i32 %56, %60
+  br i1 %61, label %8, label %62
+
+; <label>:62                                      ; preds = %1, %46, %58
+  %63 = load i32, i32* %arg2
+  %64 = icmp eq i32 %63, 0
+  br i1 %64, label %122, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %66, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %67
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %66, i32 0, i32 1
+  %69 = load i32, i32 addrspace(1)* %68
+  %70 = sub i32 %69, 1
+  store i32 %70, i32* %loc0
+  br label %118
+
+; <label>:71                                      ; preds = %118
+  store i32 0, i32* %loc4
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %73 = load i32, i32* %loc0
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %74
+
+; <label>:74                                      ; preds = %71
+  %75 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 2, i32 %73
+  %76 = load i16, i16 addrspace(1)* %75
+  %77 = zext i16 %76 to i32
+  %78 = trunc i32 %77 to i16
+  store i16 %78, i16* %loc5
+  store i32 0, i32* %loc4
+  br label %97
+
+; <label>:79                                      ; preds = %100
+  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %81 = load i32, i32* %loc4
+  %NullCheck19 = icmp eq %"System.Char[]" addrspace(1)* %80, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
+
+; <label>:82                                      ; preds = %79
+  %83 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 1
+  %84 = load i32, i32 addrspace(1)* %83
+  %85 = zext i32 %84 to i64
+  %86 = zext i32 %81 to i64
+  %BoundsCheck21 = icmp uge i64 %86, %85
+  br i1 %BoundsCheck21, label %ThrowIndexOutOfRange22, label %87
+
+; <label>:87                                      ; preds = %82
+  %88 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 3, i32 %81
+  %89 = load i16, i16 addrspace(1)* %88, align 8
+  %90 = zext i16 %89 to i32
+  %91 = load i16, i16* %loc5
+  %92 = zext i16 %91 to i32
+  %93 = icmp eq i32 %90, %92
+  br i1 %93, label %106, label %94
+
+; <label>:94                                      ; preds = %87
+  %95 = load i32, i32* %loc4
+  %96 = add i32 %95, 1
+  store i32 %96, i32* %loc4
+  br label %97
+
+; <label>:97                                      ; preds = %74, %94
+  %98 = load i32, i32* %loc4
+  %99 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck15 = icmp eq %"System.Char[]" addrspace(1)* %99, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %100
+
+; <label>:100                                     ; preds = %97
+  %101 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %99, i32 0, i32 1
+  %102 = load i32, i32 addrspace(1)* %101
+  %103 = zext i32 %102 to i64
+  %104 = trunc i64 %103 to i32
+  %105 = icmp slt i32 %98, %104
+  br i1 %105, label %79, label %106
+
+; <label>:106                                     ; preds = %87, %100
+  %107 = load i32, i32* %loc4
+  %108 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck17 = icmp eq %"System.Char[]" addrspace(1)* %108, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %109
+
+; <label>:109                                     ; preds = %106
+  %110 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %108, i32 0, i32 1
+  %111 = load i32, i32 addrspace(1)* %110
+  %112 = zext i32 %111 to i64
+  %113 = trunc i64 %112 to i32
+  %114 = icmp eq i32 %107, %113
+  br i1 %114, label %122, label %115
+
+; <label>:115                                     ; preds = %109
+  %116 = load i32, i32* %loc0
+  %117 = sub i32 %116, 1
+  store i32 %117, i32* %loc0
+  br label %118
+
+; <label>:118                                     ; preds = %67, %115
+  %119 = load i32, i32* %loc0
+  %120 = load i32, i32* %loc1
+  %121 = icmp sge i32 %119, %120
+  br i1 %121, label %71, label %122
+
+; <label>:122                                     ; preds = %62, %109, %118
+  %123 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %124 = load i32, i32* %loc1
+  %125 = load i32, i32* %loc0
+  %126 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %123, i32 %124, i32 %125)
+  ret %System.String addrspace(1)* %126
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %97
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange22:                           ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
 Successfully read String.CreateTrimmedString
 
@@ -5439,8 +6893,8 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
@@ -5535,8 +6989,8 @@ entry:
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i64 2872
   %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
   %8 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %7
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %3
   %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
@@ -5553,8 +7007,8 @@ entry:
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 2864
   %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
   %21 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %20
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
-  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %22
 
 ; <label>:22                                      ; preds = %16
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
@@ -5569,7 +7023,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %16
+ThrowNullRef2:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5586,8 +7040,8 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5613,8 +7067,8 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
@@ -5632,8 +7086,8 @@ entry:
 
 ; <label>:12                                      ; preds = %4
   %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
@@ -5644,8 +7098,8 @@ entry:
 
 ; <label>:19                                      ; preds = %14
   %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %19
   %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
@@ -5660,21 +7114,21 @@ entry:
   %31 = zext i16 %30 to i32
   %32 = bitcast i8* %29 to i16*
   %33 = trunc i32 %31 to i16
-  %NullCheck6 = icmp ne i16* %32, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i16* %32, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %21
   store i16 %33, i16* %32, align 8
   %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %36
 
 ; <label>:36                                      ; preds = %34
   %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
   %38 = load i32, i32 addrspace(1)* %37, align 8
   %39 = add i32 %38, 1
-  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %40
 
 ; <label>:40                                      ; preds = %36
   %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
@@ -5683,16 +7137,16 @@ entry:
 
 ; <label>:42                                      ; preds = %14
   %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
-  br i1 %NullCheck12, label %44, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
   %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
   %47 = load i16, i16* %arg1
   %48 = zext i16 %47 to i32
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = trunc i32 %48 to i16
@@ -5703,31 +7157,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %19
+ThrowNullRef4:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %21
+ThrowNullRef6:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %36
+ThrowNullRef10:                                   ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %42
+ThrowNullRef12:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %44
+ThrowNullRef14:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5740,8 +7194,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -5752,8 +7206,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
@@ -5762,14 +7216,14 @@ entry:
 
 ; <label>:11                                      ; preds = %1
   %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
@@ -5779,15 +7233,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5808,8 +7262,8 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5822,8 +7276,8 @@ entry:
 
 ; <label>:8                                       ; preds = %3
   %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
@@ -5842,15 +7296,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
-  br i1 %NullCheck4, label %22, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
   %24 = load i16*, i16* addrspace(1)* %23, align 8
   %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %25, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
@@ -5859,8 +7313,8 @@ entry:
   store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
@@ -5874,8 +7328,8 @@ entry:
 
 ; <label>:37                                      ; preds = %65
   %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %37
   %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
@@ -5886,16 +7340,16 @@ entry:
   %45 = bitcast i16* %41 to i8*
   %46 = getelementptr inbounds i8, i8* %45, i64 %44
   %47 = bitcast i8* %46 to i16*
-  %NullCheck14 = icmp ne i16* %47, null
-  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %47, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %48
 
 ; <label>:48                                      ; preds = %39
   %49 = load i16, i16* %47, align 8
   %50 = zext i16 %49 to i32
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %52 = load i32, i32* %loc1
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %53
 
 ; <label>:53                                      ; preds = %48
   %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
@@ -5916,8 +7370,8 @@ entry:
 ; <label>:62                                      ; preds = %36, %59
   %63 = load i32, i32* %loc1
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck10, label %65, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %65
 
 ; <label>:65                                      ; preds = %62
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
@@ -5936,15 +7390,15 @@ entry:
 
 ; <label>:74                                      ; preds = %70
   %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
-  br i1 %NullCheck18, label %76, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %76
 
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
   %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
-  br i1 %NullCheck20, label %80, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
   %81 = load i64, i64 addrspace(1)* %79
@@ -5958,8 +7412,8 @@ entry:
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
   %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
-  br i1 %NullCheck22, label %92, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.String addrspace(1)* %90, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %92
 
 ; <label>:92                                      ; preds = %80
   %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
@@ -5969,15 +7423,15 @@ entry:
 
 ; <label>:96                                      ; preds = %70
   %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
-  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %98
 
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
   %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
-  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
   %103 = load i64, i64 addrspace(1)* %101
@@ -5991,8 +7445,8 @@ entry:
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
   %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
-  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.String addrspace(1)* %112, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %114
 
 ; <label>:114                                     ; preds = %102
   %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
@@ -6004,59 +7458,59 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %20
+ThrowNullRef4:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %22
+ThrowNullRef6:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %26
+ThrowNullRef8:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %62
+ThrowNullRef10:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %48
+ThrowNullRef16:                                   ; preds = %48
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %74
+ThrowNullRef18:                                   ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %76
+ThrowNullRef20:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %80
+ThrowNullRef22:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %96
+ThrowNullRef24:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %98
+ThrowNullRef26:                                   ; preds = %98
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %102
+ThrowNullRef28:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6069,15 +7523,15 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
   %3 = load i16*, i16* addrspace(1)* %2, align 8
   %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
@@ -6087,8 +7541,8 @@ entry:
   %10 = bitcast i16* %3 to i8*
   %11 = getelementptr inbounds i8, i8* %10, i64 %9
   %12 = bitcast i8* %11 to i16*
-  %NullCheck4 = icmp ne i16* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %5
   store i16 0, i16* %12, align 8
@@ -6098,11 +7552,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6119,8 +7573,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -6131,8 +7585,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
@@ -6144,15 +7598,15 @@ entry:
 
 ; <label>:14                                      ; preds = %1
   %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
   %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
   %21 = load i64, i64 addrspace(1)* %19
@@ -6171,15 +7625,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %14
+ThrowNullRef4:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %16
+ThrowNullRef6:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6302,14 +7756,6 @@ entry:
   ret %System.String addrspace(1)* %57
 }
 
-INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
-Successfully read RuntimeHelpers.get_OffsetToStringData
-
-define i32 @RuntimeHelpers.get_OffsetToStringData() {
-entry:
-  ret i32 12
-}
-
 INFO:  jitting method String::Equals using LLILCJit
 Successfully read String.Equals
 
@@ -6381,8 +7827,8 @@ entry:
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
-  br i1 %NullCheck24, label %29, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
   %30 = load i64, i64 addrspace(1)* %28
@@ -6397,8 +7843,8 @@ entry:
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
-  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
   %43 = load i64, i64 addrspace(1)* %41
@@ -6418,8 +7864,8 @@ entry:
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
   %59 = load i64, i64 addrspace(1)* %57
@@ -6434,8 +7880,8 @@ entry:
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck22, label %71, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
   %72 = load i64, i64 addrspace(1)* %70
@@ -6455,8 +7901,8 @@ entry:
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
-  br i1 %NullCheck16, label %87, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = load i64, i64 addrspace(1)* %86
@@ -6471,8 +7917,8 @@ entry:
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck18, label %100, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
   %101 = load i64, i64 addrspace(1)* %99
@@ -6492,8 +7938,8 @@ entry:
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
-  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
   %117 = load i64, i64 addrspace(1)* %115
@@ -6508,8 +7954,8 @@ entry:
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
-  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
   %130 = load i64, i64 addrspace(1)* %128
@@ -6528,15 +7974,15 @@ entry:
 
 ; <label>:142                                     ; preds = %22
   %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
-  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %143, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %144
 
 ; <label>:144                                     ; preds = %142
   %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
   %146 = load i32, i32 addrspace(1)* %145
   %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
-  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %147, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %148
 
 ; <label>:148                                     ; preds = %144
   %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
@@ -6557,15 +8003,15 @@ entry:
 
 ; <label>:159                                     ; preds = %22
   %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
-  br i1 %NullCheck, label %161, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %ThrowNullRef, label %161
 
 ; <label>:161                                     ; preds = %159
   %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
   %163 = load i32, i32 addrspace(1)* %162
   %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
-  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %164, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %165
 
 ; <label>:165                                     ; preds = %161
   %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
@@ -6578,8 +8024,8 @@ entry:
 
 ; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
-  br i1 %NullCheck4, label %172, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %171, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %172
 
 ; <label>:172                                     ; preds = %170
   %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
@@ -6589,8 +8035,8 @@ entry:
 
 ; <label>:176                                     ; preds = %172
   %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
-  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %177, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %178
 
 ; <label>:178                                     ; preds = %176
   %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
@@ -6629,55 +8075,55 @@ ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %161
+ThrowNullRef2:                                    ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %170
+ThrowNullRef4:                                    ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %176
+ThrowNullRef6:                                    ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %142
+ThrowNullRef8:                                    ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %144
+ThrowNullRef10:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %113
+ThrowNullRef12:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %116
+ThrowNullRef14:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %84
+ThrowNullRef16:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %87
+ThrowNullRef18:                                   ; preds = %87
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %55
+ThrowNullRef20:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %58
+ThrowNullRef22:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %26
+ThrowNullRef24:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %29
+ThrowNullRef26:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,8 +8161,8 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck, label %14, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %ThrowNullRef, label %14
 
 ; <label>:14                                      ; preds = %8
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
@@ -6760,8 +8206,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
@@ -6770,14 +8216,14 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32, i32* %loc0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %10
   %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
   %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
@@ -6790,15 +8236,15 @@ entry:
 ; <label>:25                                      ; preds = %19
   %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
-  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
   %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
@@ -6807,8 +8253,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %37 = load i32, i32* %loc0
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %38, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %38
 
 ; <label>:38                                      ; preds = %32
   %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
@@ -6817,14 +8263,14 @@ entry:
 
 ; <label>:40                                      ; preds = %19
   %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %40
   %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
   %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
-  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
-  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
@@ -6832,8 +8278,8 @@ entry:
   %48 = zext i32 %47 to i64
   %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
-  br i1 %NullCheck16, label %51, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %51
 
 ; <label>:51                                      ; preds = %45
   %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
@@ -6847,15 +8293,15 @@ entry:
 ; <label>:57                                      ; preds = %51
   %58 = load i16*, i16** %arg1
   %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
-  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %60
 
 ; <label>:60                                      ; preds = %57
   %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
   %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
-  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %64
 
 ; <label>:64                                      ; preds = %60
   %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
@@ -6864,22 +8310,22 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
   %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
-  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %70
 
 ; <label>:70                                      ; preds = %64
   %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
   %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
-  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
-  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
   %75 = load i32, i32 addrspace(1)* %74
   %76 = zext i32 %75 to i64
   %77 = trunc i64 %76 to i32
-  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
-  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %78
 
 ; <label>:78                                      ; preds = %73
   %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
@@ -6901,8 +8347,8 @@ entry:
   %90 = bitcast i16* %86 to i8*
   %91 = getelementptr inbounds i8, i8* %90, i64 %89
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %93
 
 ; <label>:93                                      ; preds = %80
   %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
@@ -6912,8 +8358,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %99 = load i32, i32* %loc2
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %100
 
 ; <label>:100                                     ; preds = %93
   %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
@@ -6928,63 +8374,63 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %25
+ThrowNullRef6:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %32
+ThrowNullRef10:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %40
+ThrowNullRef12:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %45
+ThrowNullRef16:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %57
+ThrowNullRef18:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %60
+ThrowNullRef20:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %64
+ThrowNullRef22:                                   ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %70
+ThrowNullRef24:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %73
+ThrowNullRef26:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %80
+ThrowNullRef28:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %93
+ThrowNullRef30:                                   ; preds = %93
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7004,8 +8450,8 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
@@ -7033,43 +8479,43 @@ entry:
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %14
   %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
   %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   %28 = load i32, i32 addrspace(1)* %27, align 8
   %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
-  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %30
 
 ; <label>:30                                      ; preds = %26
   %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
   %32 = load i32, i32 addrspace(1)* %31, align 8
   %33 = add i32 %28, %32
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %34
 
 ; <label>:34                                      ; preds = %30
   %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   store i32 %33, i32 addrspace(1)* %35
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
   store i32 0, i32 addrspace(1)* %38
   %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %40
 
 ; <label>:40                                      ; preds = %37
   %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
@@ -7082,8 +8528,8 @@ entry:
 
 ; <label>:47                                      ; preds = %40
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
@@ -7098,8 +8544,8 @@ entry:
   %54 = load i32, i32* %loc0
   %55 = sext i32 %54 to i64
   %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
-  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %57
 
 ; <label>:57                                      ; preds = %52
   %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
@@ -7110,68 +8556,35 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %14
+ThrowNullRef2:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %23
+ThrowNullRef4:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %26
+ThrowNullRef6:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %30
+ThrowNullRef8:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %34
+ThrowNullRef10:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %47
+ThrowNullRef14:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %52
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-}
-
-INFO:  jitting method StringBuilder::get_Length using LLILCJit
-Successfully read StringBuilder.get_Length
-
-define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.StringBuilder addrspace(1)*
-  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
-  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
-
-; <label>:1                                       ; preds = %entry
-  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %3 = load i32, i32 addrspace(1)* %2, align 8
-  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
-
-; <label>:5                                       ; preds = %1
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = add i32 %3, %7
-  ret i32 %8
-
-ThrowNullRef:                                     ; preds = %entry
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef16:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7213,70 +8626,70 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
   %6 = load i32, i32 addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
   store i32 %6, i32 addrspace(1)* %8
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
   %13 = load i32, i32 addrspace(1)* %12, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
   store i32 %13, i32 addrspace(1)* %15
   %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
-  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %18
 
 ; <label>:18                                      ; preds = %14
   %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
   %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
   %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
   %34 = load i32, i32 addrspace(1)* %33, align 8
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
-  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
@@ -7287,39 +8700,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %28
+ThrowNullRef16:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %32
+ThrowNullRef18:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7455,13 +8868,13 @@ entry:
 ; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
@@ -7477,16 +8890,16 @@ entry:
 
 ; <label>:18                                      ; preds = %15
   %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
   store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
   %22 = load i32, i32* %loc0
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %24
 
 ; <label>:24                                      ; preds = %20
   %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
@@ -7498,13 +8911,13 @@ entry:
 ; <label>:28                                      ; preds = %15, %24
   %29 = load i32, i32* %arg1
   %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %31
   %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
@@ -7517,20 +8930,20 @@ entry:
   %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
-  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
   %46 = load i32, i32 addrspace(1)* %45, align 8
   %47 = sub i32 %40, %46
-  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
-  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i32 addrspace(1)* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %48
 
 ; <label>:48                                      ; preds = %44
   store i32 %47, i32 addrspace(1)* %39, align 8
@@ -7538,21 +8951,21 @@ entry:
 
 ; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
-  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %51
 
 ; <label>:51                                      ; preds = %49
   %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %53
 
 ; <label>:53                                      ; preds = %51
   %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
   %55 = load i32, i32 addrspace(1)* %54, align 8
   %56 = load i32, i32* %arg2
   %57 = sub i32 %55, %56
-  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %58
 
 ; <label>:58                                      ; preds = %53
   %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
@@ -7562,13 +8975,13 @@ entry:
 ; <label>:60                                      ; preds = %33, %58
   %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
   %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
-  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %63
 
 ; <label>:63                                      ; preds = %60
   %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
-  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
-  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
@@ -7578,15 +8991,15 @@ entry:
 
 ; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
-  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i32 addrspace(1)* %69, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %70
 
 ; <label>:70                                      ; preds = %68
   %71 = load i32, i32 addrspace(1)* %69, align 8
   store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
-  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
@@ -7596,8 +9009,8 @@ entry:
   store i32 %77, i32* %loc4
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
-  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %80
 
 ; <label>:80                                      ; preds = %73
   %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
@@ -7607,71 +9020,71 @@ entry:
 ; <label>:83                                      ; preds = %80
   store i32 0, i32* %loc3
   %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
-  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
-  br i1 %NullCheck26, label %88, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i32 addrspace(1)* %87, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %88
 
 ; <label>:88                                      ; preds = %85
   %89 = load i32, i32 addrspace(1)* %87, align 8
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
-  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %90
 
 ; <label>:90                                      ; preds = %88
   %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
   store i32 %89, i32 addrspace(1)* %91
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
-  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
-  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %96
 
 ; <label>:96                                      ; preds = %94
   %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
-  br i1 %NullCheck34, label %100, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %100
 
 ; <label>:100                                     ; preds = %96
   %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
-  br i1 %NullCheck36, label %102, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %102
 
 ; <label>:102                                     ; preds = %100
   %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
   %104 = load i32, i32 addrspace(1)* %103, align 8
   %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
-  br i1 %NullCheck38, label %106, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %106
 
 ; <label>:106                                     ; preds = %102
   %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
-  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
-  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %108
 
 ; <label>:108                                     ; preds = %106
   %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
   %110 = load i32, i32 addrspace(1)* %109, align 8
   %111 = add i32 %104, %110
-  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %112
 
 ; <label>:112                                     ; preds = %108
   %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
   store i32 %111, i32 addrspace(1)* %113
   %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
-  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i32 addrspace(1)* %114, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %115
 
 ; <label>:115                                     ; preds = %112
   %116 = load i32, i32 addrspace(1)* %114, align 8
@@ -7681,19 +9094,19 @@ entry:
 ; <label>:118                                     ; preds = %115
   %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
-  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %121
 
 ; <label>:121                                     ; preds = %118
   %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
-  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
-  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %123
 
 ; <label>:123                                     ; preds = %121
   %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
   %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
-  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
-  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %126
 
 ; <label>:126                                     ; preds = %123
   %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
@@ -7705,8 +9118,8 @@ entry:
 
 ; <label>:130                                     ; preds = %80, %115, %126
   %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %132
 
 ; <label>:132                                     ; preds = %130
   %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7715,8 +9128,8 @@ entry:
   %136 = load i32, i32* %loc3
   %137 = sub i32 %135, %136
   %138 = sub i32 %134, %137
-  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %139
 
 ; <label>:139                                     ; preds = %132
   %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7728,16 +9141,16 @@ entry:
 
 ; <label>:144                                     ; preds = %139
   %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
-  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %146
 
 ; <label>:146                                     ; preds = %144
   %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
   %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
   %149 = load i32, i32* %loc2
   %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
-  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %151
 
 ; <label>:151                                     ; preds = %146
   %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
@@ -7754,145 +9167,249 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %18
+ThrowNullRef4:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %31
+ThrowNullRef10:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %44
+ThrowNullRef16:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %68
+ThrowNullRef18:                                   ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %70
+ThrowNullRef20:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %73
+ThrowNullRef22:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %83
+ThrowNullRef24:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %85
+ThrowNullRef26:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %88
+ThrowNullRef28:                                   ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %90
+ThrowNullRef30:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %94
+ThrowNullRef32:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %96
+ThrowNullRef34:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %100
+ThrowNullRef36:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %102
+ThrowNullRef38:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %106
+ThrowNullRef40:                                   ; preds = %106
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %108
+ThrowNullRef42:                                   ; preds = %108
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %112
+ThrowNullRef44:                                   ; preds = %112
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %118
+ThrowNullRef46:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %121
+ThrowNullRef48:                                   ; preds = %121
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %123
+ThrowNullRef50:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %130
+ThrowNullRef52:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %132
+ThrowNullRef54:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %144
+ThrowNullRef56:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %146
+ThrowNullRef58:                                   ; preds = %146
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %60
+ThrowNullRef60:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %63
+ThrowNullRef62:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %49
+ThrowNullRef64:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %51
+ThrowNullRef66:                                   ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %53
+ThrowNullRef68:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(%"System.Char[]" addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %arg0 = alloca %"System.Char[]" addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store %"System.Char[]" addrspace(1)* %param0, %"System.Char[]" addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load i32, i32* %arg4
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %43, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %38, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg1
+  %13 = load i32, i32* %arg4
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %38, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %24 = load i32, i32* %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %35 = load i32, i32* %arg3
+  %36 = load i32, i32* %arg4
+  %37 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %37, %"System.Char[]" addrspace(1)* %34, i32 %35, i32 %36)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:38                                      ; preds = %5, %16
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Successfully read Buffer._Memmove
 
@@ -7914,7 +9431,7 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[loadElem]
+Failed to read AppDomain.SetDataHelper[storeElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -7923,8 +9440,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
@@ -7934,8 +9451,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
@@ -7947,15 +9464,15 @@ entry:
   %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
   %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
@@ -7966,15 +9483,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7992,7 +9509,79 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
-Failed to read Dictionary`2.TryGetValue[loadElemA]
+Successfully read Dictionary`2.TryGetValue
+
+define i8 @"Dictionary`2.TryGetValue"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)* addrspace(1)* %param2) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  %arg2 = alloca %System.__Canon addrspace(1)* addrspace(1)*
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  store %System.__Canon addrspace(1)* addrspace(1)* %param2, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  store i32 %2, i32* %loc0
+  %3 = load i32, i32* %loc0
+  %4 = icmp slt i32 %3, 0
+  br i1 %4, label %22, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 2
+  %10 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %9, align 8
+  %11 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = zext i32 %11 to i64
+  %BoundsCheck = icmp uge i64 %16, %15
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 3, i32 %11
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %20, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %6, %System.__Canon addrspace(1)* %21)
+  ret i8 1
+
+; <label>:22                                      ; preds = %entry
+  %23 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %23, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -8058,8 +9647,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
@@ -8091,8 +9680,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
@@ -8171,15 +9760,15 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck, label %19, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %ThrowNullRef, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
   %21 = load i32, i32 addrspace(1)* %20
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
@@ -8202,7 +9791,7 @@ ThrowNullRef:                                     ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %19
+ThrowNullRef2:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8248,8 +9837,8 @@ entry:
   %0 = alloca %System.AppDomainHandle
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %1 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %1, i32 0, i32 15
@@ -8269,8 +9858,8 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
@@ -8286,7 +9875,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -8299,8 +9888,8 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -8327,8 +9916,8 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
@@ -8352,8 +9941,8 @@ entry:
   %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
   store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
@@ -8363,8 +9952,8 @@ entry:
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
@@ -8374,8 +9963,8 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %9
   %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
@@ -8384,8 +9973,8 @@ entry:
 
 ; <label>:18                                      ; preds = %3, %16
   %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
@@ -8397,15 +9986,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %18
+ThrowNullRef6:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8418,8 +10007,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
@@ -8453,15 +10042,15 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
@@ -8473,7 +10062,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8481,7 +10070,7 @@ ThrowNullRef1:                                    ; preds = %1
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
 Failed to read Dictionary`2.System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
@@ -8506,8 +10095,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
@@ -8524,8 +10113,8 @@ entry:
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -8544,7 +10133,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8577,8 +10166,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = load i64, i64* %arg2
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = trunc i32 %3 to i8
@@ -8634,46 +10223,46 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
   %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
-  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
-  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
-  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
@@ -8684,27 +10273,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %20
+ThrowNullRef12:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8717,8 +10306,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -8756,22 +10345,22 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
   %9 = load i64, i64 addrspace(1)* %8, align 8
   %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
   %13 = load i64, i64 addrspace(1)* %12, align 8
   %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %11
   %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
@@ -8788,11 +10377,11 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8882,8 +10471,8 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
@@ -8900,8 +10489,8 @@ entry:
 ; <label>:8                                       ; preds = %1
   %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
   %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
@@ -8911,15 +10500,15 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
   %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
   %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
-  br i1 %NullCheck6, label %21, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
@@ -8946,15 +10535,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8992,15 +10581,15 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
   store i8 %3, i8 addrspace(1)* %5
   %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
@@ -9011,7 +10600,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9027,8 +10616,8 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -9041,8 +10630,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
@@ -9058,7 +10647,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9080,8 +10669,8 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
@@ -9096,8 +10685,8 @@ entry:
 ; <label>:12                                      ; preds = %6
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
@@ -9112,8 +10701,8 @@ entry:
 ; <label>:21                                      ; preds = %15
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
@@ -9128,8 +10717,8 @@ entry:
 ; <label>:30                                      ; preds = %24
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %31, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
@@ -9144,8 +10733,8 @@ entry:
 ; <label>:39                                      ; preds = %33
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
-  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %40, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %42
 
 ; <label>:42                                      ; preds = %39
   %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
@@ -9164,19 +10753,19 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %21
+ThrowNullRef4:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %30
+ThrowNullRef6:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %39
+ThrowNullRef8:                                    ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9243,8 +10832,8 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
@@ -9264,57 +10853,57 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
   store i8 0, i8 addrspace(1)* %2
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
   store i8 0, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
   store i8 0, i8 addrspace(1)* %17
   %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
   store i8 0, i8 addrspace(1)* %20
   %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
-  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
@@ -9325,31 +10914,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %19
+ThrowNullRef14:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9367,8 +10956,8 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
@@ -9380,8 +10969,8 @@ entry:
 
 ; <label>:9                                       ; preds = %4
   %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %9
   %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
@@ -9395,7 +10984,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef2:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9420,8 +11009,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
@@ -9512,8 +11101,8 @@ entry:
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
@@ -9524,8 +11113,8 @@ entry:
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = load i64, i64 addrspace(1)* %12
@@ -9537,8 +11126,8 @@ entry:
   %20 = load i64, i64* %19
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
-  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %13
   %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
@@ -9555,8 +11144,8 @@ entry:
 ; <label>:30                                      ; preds = %25
   %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %32 = load i32, i32* %arg2
-  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
-  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
@@ -9570,15 +11159,15 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %30
+ThrowNullRef2:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9622,87 +11211,87 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
   %10 = load i8, i8 addrspace(1)* %9, align 8
   %11 = zext i8 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %8
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
   store i8 %12, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
   %19 = load i8, i8 addrspace(1)* %18, align 8
   %20 = zext i8 %19 to i32
   %21 = trunc i32 %20 to i8
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
   store i8 %21, i8 addrspace(1)* %23
   %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
   %28 = load i8, i8 addrspace(1)* %27, align 8
   %29 = zext i8 %28 to i32
   %30 = trunc i32 %29 to i8
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
-  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %31
 
 ; <label>:31                                      ; preds = %26
   %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
   store i8 %30, i8 addrspace(1)* %32
   %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
-  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
-  br i1 %NullCheck14, label %40, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %40
 
 ; <label>:40                                      ; preds = %35
   %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
   store i8 %39, i8 addrspace(1)* %41
   %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
-  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %44
 
 ; <label>:44                                      ; preds = %40
   %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
   %46 = load i8, i8 addrspace(1)* %45, align 8
   %47 = zext i8 %46 to i32
   %48 = trunc i32 %47 to i8
-  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
   store i8 %48, i8 addrspace(1)* %50
   %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
-  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
@@ -9713,29 +11302,29 @@ entry:
 ; <label>:56                                      ; preds = %52
   %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
-  br i1 %NullCheck22, label %59, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
   %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
   %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
-  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
-  br i1 %NullCheck24, label %63, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
   %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
-  br i1 %NullCheck26, label %66, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
   %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
-  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
-  br i1 %NullCheck28, label %69, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %69
 
 ; <label>:69                                      ; preds = %66
   %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
@@ -9744,15 +11333,15 @@ entry:
 
 ; <label>:71                                      ; preds = %105
   %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
-  br i1 %NullCheck34, label %73, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %73
 
 ; <label>:73                                      ; preds = %71
   %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
   %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
   %76 = load i32, i32* %loc0
-  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
-  br i1 %NullCheck36, label %77, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
@@ -9766,8 +11355,8 @@ entry:
 
 ; <label>:83                                      ; preds = %77
   %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
-  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
@@ -9775,14 +11364,14 @@ entry:
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
   %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
-  br i1 %NullCheck40, label %91, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
 ; <label>:91                                      ; preds = %85
   %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
   %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
-  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck42, label %94, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %94
 
 ; <label>:94                                      ; preds = %91
   %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
@@ -9798,14 +11387,14 @@ entry:
 ; <label>:99                                      ; preds = %69, %96
   %100 = load i32, i32* %loc0
   %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
-  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %102
 
 ; <label>:102                                     ; preds = %99
   %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
   %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
-  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
-  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
@@ -9819,87 +11408,87 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %26
+ThrowNullRef10:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %31
+ThrowNullRef12:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %35
+ThrowNullRef14:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %40
+ThrowNullRef16:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %56
+ThrowNullRef22:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %59
+ThrowNullRef24:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %63
+ThrowNullRef26:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %66
+ThrowNullRef28:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %102
+ThrowNullRef32:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %71
+ThrowNullRef34:                                   ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %73
+ThrowNullRef36:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %83
+ThrowNullRef38:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %85
+ThrowNullRef40:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %91
+ThrowNullRef42:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9943,15 +11532,15 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
   %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
@@ -9961,28 +11550,28 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
   %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %12
   %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
   %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
   %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
-  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
@@ -9993,23 +11582,23 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %12
+ThrowNullRef6:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10031,15 +11620,15 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
   %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = load i64, i64 addrspace(1)* %7
@@ -10077,13 +11666,13 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[loadElem]
+Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -10111,8 +11700,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Gcd.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Gcd.error.txt
@@ -25,8 +25,8 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
@@ -40,8 +40,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
   %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
@@ -75,7 +75,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -90,8 +90,8 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %NullCheck = icmp ne i8 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = load i8, i8 addrspace(1)* %0, align 8
@@ -125,8 +125,8 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
@@ -159,8 +159,8 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -184,8 +184,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
   store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
@@ -195,8 +195,8 @@ entry:
 ; <label>:4                                       ; preds = %1
   %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
   %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
@@ -206,8 +206,8 @@ entry:
   %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
@@ -221,14 +221,14 @@ entry:
 
 ; <label>:17                                      ; preds = %14
   %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
   %21 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
@@ -238,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -249,8 +249,8 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
@@ -261,27 +261,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %30
+ThrowNullRef10:                                   ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -301,7 +301,89 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
-Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
+Successfully read AppDomainSetup.GetUnsecureApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.GetUnsecureApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %NullCheck = icmp eq %"System.String[]" addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %BoundsCheck = icmp uge i64 0, %5
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %6
+
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 3, i32 0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
+  ret %System.String addrspace(1)* %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_Value using LLILCJit
+Successfully read AppDomainSetup.get_Value
+
+define %"System.String[]" addrspace(1)* @AppDomainSetup.get_Value(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.String[]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 18)
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.String[]" addrspace(1)* addrspace(1)*, %"System.String[]" addrspace(1)*)*)(%"System.String[]" addrspace(1)* addrspace(1)* %9, %"System.String[]" addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %11, i32 0, i32 1
+  %14 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %13, align 8
+  ret %"System.String[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -319,8 +401,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -368,16 +450,16 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
   %5 = load i32, i32 addrspace(1)* %4
   %6 = sub i32 %5, 1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -389,7 +471,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -421,8 +503,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
@@ -456,8 +538,8 @@ entry:
 ; <label>:27                                      ; preds = %19
   %28 = load i32, i32* %arg1
   %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
-  br i1 %NullCheck2, label %30, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %29, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %30
 
 ; <label>:30                                      ; preds = %27
   %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
@@ -493,8 +575,8 @@ entry:
 ; <label>:49                                      ; preds = %46
   %50 = load i32, i32* %arg2
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck4, label %52, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
@@ -517,11 +599,11 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %27
+ThrowNullRef2:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %49
+ThrowNullRef4:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -544,16 +626,16 @@ entry:
   %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %0)
   store %System.String addrspace(1)* %1, %System.String addrspace(1)** %loc0
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 2
   %5 = bitcast [0 x i16] addrspace(1)* %4 to i16 addrspace(1)*
   store i16 addrspace(1)* %5, i16 addrspace(1)** %loc1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %3
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2
@@ -580,7 +662,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -691,15 +773,15 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %NullCheck132 = icmp ne i8* %21, null
-  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+  %NullCheck131 = icmp eq i8* %21, null
+  br i1 %NullCheck131, label %ThrowNullRef132, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = load i8, i8* %21, align 8
   %24 = zext i8 %23 to i32
   %25 = trunc i32 %24 to i8
-  %NullCheck134 = icmp ne i8* %20, null
-  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+  %NullCheck133 = icmp eq i8* %20, null
+  br i1 %NullCheck133, label %ThrowNullRef134, label %26
 
 ; <label>:26                                      ; preds = %22
   store i8 %25, i8* %20, align 8
@@ -709,16 +791,16 @@ entry:
   %28 = load i8*, i8** %arg0
   %29 = load i8*, i8** %arg1
   %30 = bitcast i8* %29 to i16*
-  %NullCheck128 = icmp ne i16* %30, null
-  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+  %NullCheck127 = icmp eq i16* %30, null
+  br i1 %NullCheck127, label %ThrowNullRef128, label %31
 
 ; <label>:31                                      ; preds = %27
   %32 = load i16, i16* %30, align 8
   %33 = sext i16 %32 to i32
   %34 = bitcast i8* %28 to i16*
   %35 = trunc i32 %33 to i16
-  %NullCheck130 = icmp ne i16* %34, null
-  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+  %NullCheck129 = icmp eq i16* %34, null
+  br i1 %NullCheck129, label %ThrowNullRef130, label %36
 
 ; <label>:36                                      ; preds = %31
   store i16 %35, i16* %34, align 8
@@ -728,16 +810,16 @@ entry:
   %38 = load i8*, i8** %arg0
   %39 = load i8*, i8** %arg1
   %40 = bitcast i8* %39 to i16*
-  %NullCheck120 = icmp ne i16* %40, null
-  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+  %NullCheck119 = icmp eq i16* %40, null
+  br i1 %NullCheck119, label %ThrowNullRef120, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i16, i16* %40, align 8
   %43 = sext i16 %42 to i32
   %44 = bitcast i8* %38 to i16*
   %45 = trunc i32 %43 to i16
-  %NullCheck122 = icmp ne i16* %44, null
-  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+  %NullCheck121 = icmp eq i16* %44, null
+  br i1 %NullCheck121, label %ThrowNullRef122, label %46
 
 ; <label>:46                                      ; preds = %41
   store i16 %45, i16* %44, align 8
@@ -745,15 +827,15 @@ entry:
   %48 = getelementptr inbounds i8, i8* %47, i64 2
   %49 = load i8*, i8** %arg1
   %50 = getelementptr inbounds i8, i8* %49, i64 2
-  %NullCheck124 = icmp ne i8* %50, null
-  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+  %NullCheck123 = icmp eq i8* %50, null
+  br i1 %NullCheck123, label %ThrowNullRef124, label %51
 
 ; <label>:51                                      ; preds = %46
   %52 = load i8, i8* %50, align 8
   %53 = zext i8 %52 to i32
   %54 = trunc i32 %53 to i8
-  %NullCheck126 = icmp ne i8* %48, null
-  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+  %NullCheck125 = icmp eq i8* %48, null
+  br i1 %NullCheck125, label %ThrowNullRef126, label %55
 
 ; <label>:55                                      ; preds = %51
   store i8 %54, i8* %48, align 8
@@ -763,14 +845,14 @@ entry:
   %57 = load i8*, i8** %arg0
   %58 = load i8*, i8** %arg1
   %59 = bitcast i8* %58 to i32*
-  %NullCheck116 = icmp ne i32* %59, null
-  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+  %NullCheck115 = icmp eq i32* %59, null
+  br i1 %NullCheck115, label %ThrowNullRef116, label %60
 
 ; <label>:60                                      ; preds = %56
   %61 = load i32, i32* %59, align 8
   %62 = bitcast i8* %57 to i32*
-  %NullCheck118 = icmp ne i32* %62, null
-  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+  %NullCheck117 = icmp eq i32* %62, null
+  br i1 %NullCheck117, label %ThrowNullRef118, label %63
 
 ; <label>:63                                      ; preds = %60
   store i32 %61, i32* %62, align 8
@@ -780,14 +862,14 @@ entry:
   %65 = load i8*, i8** %arg0
   %66 = load i8*, i8** %arg1
   %67 = bitcast i8* %66 to i32*
-  %NullCheck108 = icmp ne i32* %67, null
-  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+  %NullCheck107 = icmp eq i32* %67, null
+  br i1 %NullCheck107, label %ThrowNullRef108, label %68
 
 ; <label>:68                                      ; preds = %64
   %69 = load i32, i32* %67, align 8
   %70 = bitcast i8* %65 to i32*
-  %NullCheck110 = icmp ne i32* %70, null
-  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+  %NullCheck109 = icmp eq i32* %70, null
+  br i1 %NullCheck109, label %ThrowNullRef110, label %71
 
 ; <label>:71                                      ; preds = %68
   store i32 %69, i32* %70, align 8
@@ -795,15 +877,15 @@ entry:
   %73 = getelementptr inbounds i8, i8* %72, i64 4
   %74 = load i8*, i8** %arg1
   %75 = getelementptr inbounds i8, i8* %74, i64 4
-  %NullCheck112 = icmp ne i8* %75, null
-  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+  %NullCheck111 = icmp eq i8* %75, null
+  br i1 %NullCheck111, label %ThrowNullRef112, label %76
 
 ; <label>:76                                      ; preds = %71
   %77 = load i8, i8* %75, align 8
   %78 = zext i8 %77 to i32
   %79 = trunc i32 %78 to i8
-  %NullCheck114 = icmp ne i8* %73, null
-  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+  %NullCheck113 = icmp eq i8* %73, null
+  br i1 %NullCheck113, label %ThrowNullRef114, label %80
 
 ; <label>:80                                      ; preds = %76
   store i8 %79, i8* %73, align 8
@@ -813,14 +895,14 @@ entry:
   %82 = load i8*, i8** %arg0
   %83 = load i8*, i8** %arg1
   %84 = bitcast i8* %83 to i32*
-  %NullCheck100 = icmp ne i32* %84, null
-  br i1 %NullCheck100, label %85, label %ThrowNullRef99
+  %NullCheck99 = icmp eq i32* %84, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %85
 
 ; <label>:85                                      ; preds = %81
   %86 = load i32, i32* %84, align 8
   %87 = bitcast i8* %82 to i32*
-  %NullCheck102 = icmp ne i32* %87, null
-  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+  %NullCheck101 = icmp eq i32* %87, null
+  br i1 %NullCheck101, label %ThrowNullRef102, label %88
 
 ; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
@@ -829,16 +911,16 @@ entry:
   %91 = load i8*, i8** %arg1
   %92 = getelementptr inbounds i8, i8* %91, i64 4
   %93 = bitcast i8* %92 to i16*
-  %NullCheck104 = icmp ne i16* %93, null
-  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+  %NullCheck103 = icmp eq i16* %93, null
+  br i1 %NullCheck103, label %ThrowNullRef104, label %94
 
 ; <label>:94                                      ; preds = %88
   %95 = load i16, i16* %93, align 8
   %96 = sext i16 %95 to i32
   %97 = bitcast i8* %90 to i16*
   %98 = trunc i32 %96 to i16
-  %NullCheck106 = icmp ne i16* %97, null
-  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+  %NullCheck105 = icmp eq i16* %97, null
+  br i1 %NullCheck105, label %ThrowNullRef106, label %99
 
 ; <label>:99                                      ; preds = %94
   store i16 %98, i16* %97, align 8
@@ -848,14 +930,14 @@ entry:
   %101 = load i8*, i8** %arg0
   %102 = load i8*, i8** %arg1
   %103 = bitcast i8* %102 to i32*
-  %NullCheck88 = icmp ne i32* %103, null
-  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+  %NullCheck87 = icmp eq i32* %103, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %104
 
 ; <label>:104                                     ; preds = %100
   %105 = load i32, i32* %103, align 8
   %106 = bitcast i8* %101 to i32*
-  %NullCheck90 = icmp ne i32* %106, null
-  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+  %NullCheck89 = icmp eq i32* %106, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %107
 
 ; <label>:107                                     ; preds = %104
   store i32 %105, i32* %106, align 8
@@ -864,16 +946,16 @@ entry:
   %110 = load i8*, i8** %arg1
   %111 = getelementptr inbounds i8, i8* %110, i64 4
   %112 = bitcast i8* %111 to i16*
-  %NullCheck92 = icmp ne i16* %112, null
-  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+  %NullCheck91 = icmp eq i16* %112, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %113
 
 ; <label>:113                                     ; preds = %107
   %114 = load i16, i16* %112, align 8
   %115 = sext i16 %114 to i32
   %116 = bitcast i8* %109 to i16*
   %117 = trunc i32 %115 to i16
-  %NullCheck94 = icmp ne i16* %116, null
-  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+  %NullCheck93 = icmp eq i16* %116, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %118
 
 ; <label>:118                                     ; preds = %113
   store i16 %117, i16* %116, align 8
@@ -881,15 +963,15 @@ entry:
   %120 = getelementptr inbounds i8, i8* %119, i64 6
   %121 = load i8*, i8** %arg1
   %122 = getelementptr inbounds i8, i8* %121, i64 6
-  %NullCheck96 = icmp ne i8* %122, null
-  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+  %NullCheck95 = icmp eq i8* %122, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %123
 
 ; <label>:123                                     ; preds = %118
   %124 = load i8, i8* %122, align 8
   %125 = zext i8 %124 to i32
   %126 = trunc i32 %125 to i8
-  %NullCheck98 = icmp ne i8* %120, null
-  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+  %NullCheck97 = icmp eq i8* %120, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %127
 
 ; <label>:127                                     ; preds = %123
   store i8 %126, i8* %120, align 8
@@ -899,14 +981,14 @@ entry:
   %129 = load i8*, i8** %arg0
   %130 = load i8*, i8** %arg1
   %131 = bitcast i8* %130 to i64*
-  %NullCheck84 = icmp ne i64* %131, null
-  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+  %NullCheck83 = icmp eq i64* %131, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %132
 
 ; <label>:132                                     ; preds = %128
   %133 = load i64, i64* %131, align 8
   %134 = bitcast i8* %129 to i64*
-  %NullCheck86 = icmp ne i64* %134, null
-  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+  %NullCheck85 = icmp eq i64* %134, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %135
 
 ; <label>:135                                     ; preds = %132
   store i64 %133, i64* %134, align 8
@@ -916,14 +998,14 @@ entry:
   %137 = load i8*, i8** %arg0
   %138 = load i8*, i8** %arg1
   %139 = bitcast i8* %138 to i64*
-  %NullCheck76 = icmp ne i64* %139, null
-  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+  %NullCheck75 = icmp eq i64* %139, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %140
 
 ; <label>:140                                     ; preds = %136
   %141 = load i64, i64* %139, align 8
   %142 = bitcast i8* %137 to i64*
-  %NullCheck78 = icmp ne i64* %142, null
-  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+  %NullCheck77 = icmp eq i64* %142, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %143
 
 ; <label>:143                                     ; preds = %140
   store i64 %141, i64* %142, align 8
@@ -931,15 +1013,15 @@ entry:
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %NullCheck80 = icmp ne i8* %147, null
-  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+  %NullCheck79 = icmp eq i8* %147, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %148
 
 ; <label>:148                                     ; preds = %143
   %149 = load i8, i8* %147, align 8
   %150 = zext i8 %149 to i32
   %151 = trunc i32 %150 to i8
-  %NullCheck82 = icmp ne i8* %145, null
-  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+  %NullCheck81 = icmp eq i8* %145, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %152
 
 ; <label>:152                                     ; preds = %148
   store i8 %151, i8* %145, align 8
@@ -949,14 +1031,14 @@ entry:
   %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
   %156 = bitcast i8* %155 to i64*
-  %NullCheck68 = icmp ne i64* %156, null
-  br i1 %NullCheck68, label %157, label %ThrowNullRef67
+  %NullCheck67 = icmp eq i64* %156, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %157
 
 ; <label>:157                                     ; preds = %153
   %158 = load i64, i64* %156, align 8
   %159 = bitcast i8* %154 to i64*
-  %NullCheck70 = icmp ne i64* %159, null
-  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+  %NullCheck69 = icmp eq i64* %159, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %160
 
 ; <label>:160                                     ; preds = %157
   store i64 %158, i64* %159, align 8
@@ -965,16 +1047,16 @@ entry:
   %163 = load i8*, i8** %arg1
   %164 = getelementptr inbounds i8, i8* %163, i64 8
   %165 = bitcast i8* %164 to i16*
-  %NullCheck72 = icmp ne i16* %165, null
-  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+  %NullCheck71 = icmp eq i16* %165, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %166
 
 ; <label>:166                                     ; preds = %160
   %167 = load i16, i16* %165, align 8
   %168 = sext i16 %167 to i32
   %169 = bitcast i8* %162 to i16*
   %170 = trunc i32 %168 to i16
-  %NullCheck74 = icmp ne i16* %169, null
-  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+  %NullCheck73 = icmp eq i16* %169, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %171
 
 ; <label>:171                                     ; preds = %166
   store i16 %170, i16* %169, align 8
@@ -984,14 +1066,14 @@ entry:
   %173 = load i8*, i8** %arg0
   %174 = load i8*, i8** %arg1
   %175 = bitcast i8* %174 to i64*
-  %NullCheck56 = icmp ne i64* %175, null
-  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+  %NullCheck55 = icmp eq i64* %175, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %176
 
 ; <label>:176                                     ; preds = %172
   %177 = load i64, i64* %175, align 8
   %178 = bitcast i8* %173 to i64*
-  %NullCheck58 = icmp ne i64* %178, null
-  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+  %NullCheck57 = icmp eq i64* %178, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %179
 
 ; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
@@ -1000,16 +1082,16 @@ entry:
   %182 = load i8*, i8** %arg1
   %183 = getelementptr inbounds i8, i8* %182, i64 8
   %184 = bitcast i8* %183 to i16*
-  %NullCheck60 = icmp ne i16* %184, null
-  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+  %NullCheck59 = icmp eq i16* %184, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %185
 
 ; <label>:185                                     ; preds = %179
   %186 = load i16, i16* %184, align 8
   %187 = sext i16 %186 to i32
   %188 = bitcast i8* %181 to i16*
   %189 = trunc i32 %187 to i16
-  %NullCheck62 = icmp ne i16* %188, null
-  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+  %NullCheck61 = icmp eq i16* %188, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %190
 
 ; <label>:190                                     ; preds = %185
   store i16 %189, i16* %188, align 8
@@ -1017,15 +1099,15 @@ entry:
   %192 = getelementptr inbounds i8, i8* %191, i64 10
   %193 = load i8*, i8** %arg1
   %194 = getelementptr inbounds i8, i8* %193, i64 10
-  %NullCheck64 = icmp ne i8* %194, null
-  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+  %NullCheck63 = icmp eq i8* %194, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %195
 
 ; <label>:195                                     ; preds = %190
   %196 = load i8, i8* %194, align 8
   %197 = zext i8 %196 to i32
   %198 = trunc i32 %197 to i8
-  %NullCheck66 = icmp ne i8* %192, null
-  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+  %NullCheck65 = icmp eq i8* %192, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %199
 
 ; <label>:199                                     ; preds = %195
   store i8 %198, i8* %192, align 8
@@ -1035,14 +1117,14 @@ entry:
   %201 = load i8*, i8** %arg0
   %202 = load i8*, i8** %arg1
   %203 = bitcast i8* %202 to i64*
-  %NullCheck48 = icmp ne i64* %203, null
-  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+  %NullCheck47 = icmp eq i64* %203, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %204
 
 ; <label>:204                                     ; preds = %200
   %205 = load i64, i64* %203, align 8
   %206 = bitcast i8* %201 to i64*
-  %NullCheck50 = icmp ne i64* %206, null
-  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+  %NullCheck49 = icmp eq i64* %206, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %207
 
 ; <label>:207                                     ; preds = %204
   store i64 %205, i64* %206, align 8
@@ -1051,14 +1133,14 @@ entry:
   %210 = load i8*, i8** %arg1
   %211 = getelementptr inbounds i8, i8* %210, i64 8
   %212 = bitcast i8* %211 to i32*
-  %NullCheck52 = icmp ne i32* %212, null
-  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+  %NullCheck51 = icmp eq i32* %212, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %213
 
 ; <label>:213                                     ; preds = %207
   %214 = load i32, i32* %212, align 8
   %215 = bitcast i8* %209 to i32*
-  %NullCheck54 = icmp ne i32* %215, null
-  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+  %NullCheck53 = icmp eq i32* %215, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %216
 
 ; <label>:216                                     ; preds = %213
   store i32 %214, i32* %215, align 8
@@ -1068,14 +1150,14 @@ entry:
   %218 = load i8*, i8** %arg0
   %219 = load i8*, i8** %arg1
   %220 = bitcast i8* %219 to i64*
-  %NullCheck36 = icmp ne i64* %220, null
-  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64* %220, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %221
 
 ; <label>:221                                     ; preds = %217
   %222 = load i64, i64* %220, align 8
   %223 = bitcast i8* %218 to i64*
-  %NullCheck38 = icmp ne i64* %223, null
-  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+  %NullCheck37 = icmp eq i64* %223, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %224
 
 ; <label>:224                                     ; preds = %221
   store i64 %222, i64* %223, align 8
@@ -1084,14 +1166,14 @@ entry:
   %227 = load i8*, i8** %arg1
   %228 = getelementptr inbounds i8, i8* %227, i64 8
   %229 = bitcast i8* %228 to i32*
-  %NullCheck40 = icmp ne i32* %229, null
-  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i32* %229, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %230
 
 ; <label>:230                                     ; preds = %224
   %231 = load i32, i32* %229, align 8
   %232 = bitcast i8* %226 to i32*
-  %NullCheck42 = icmp ne i32* %232, null
-  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+  %NullCheck41 = icmp eq i32* %232, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %233
 
 ; <label>:233                                     ; preds = %230
   store i32 %231, i32* %232, align 8
@@ -1099,15 +1181,15 @@ entry:
   %235 = getelementptr inbounds i8, i8* %234, i64 12
   %236 = load i8*, i8** %arg1
   %237 = getelementptr inbounds i8, i8* %236, i64 12
-  %NullCheck44 = icmp ne i8* %237, null
-  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i8* %237, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %238
 
 ; <label>:238                                     ; preds = %233
   %239 = load i8, i8* %237, align 8
   %240 = zext i8 %239 to i32
   %241 = trunc i32 %240 to i8
-  %NullCheck46 = icmp ne i8* %235, null
-  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+  %NullCheck45 = icmp eq i8* %235, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %242
 
 ; <label>:242                                     ; preds = %238
   store i8 %241, i8* %235, align 8
@@ -1117,14 +1199,14 @@ entry:
   %244 = load i8*, i8** %arg0
   %245 = load i8*, i8** %arg1
   %246 = bitcast i8* %245 to i64*
-  %NullCheck24 = icmp ne i64* %246, null
-  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64* %246, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %247
 
 ; <label>:247                                     ; preds = %243
   %248 = load i64, i64* %246, align 8
   %249 = bitcast i8* %244 to i64*
-  %NullCheck26 = icmp ne i64* %249, null
-  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64* %249, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %250
 
 ; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
@@ -1133,14 +1215,14 @@ entry:
   %253 = load i8*, i8** %arg1
   %254 = getelementptr inbounds i8, i8* %253, i64 8
   %255 = bitcast i8* %254 to i32*
-  %NullCheck28 = icmp ne i32* %255, null
-  br i1 %NullCheck28, label %256, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i32* %255, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %256
 
 ; <label>:256                                     ; preds = %250
   %257 = load i32, i32* %255, align 8
   %258 = bitcast i8* %252 to i32*
-  %NullCheck30 = icmp ne i32* %258, null
-  br i1 %NullCheck30, label %259, label %ThrowNullRef29
+  %NullCheck29 = icmp eq i32* %258, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %259
 
 ; <label>:259                                     ; preds = %256
   store i32 %257, i32* %258, align 8
@@ -1149,16 +1231,16 @@ entry:
   %262 = load i8*, i8** %arg1
   %263 = getelementptr inbounds i8, i8* %262, i64 12
   %264 = bitcast i8* %263 to i16*
-  %NullCheck32 = icmp ne i16* %264, null
-  br i1 %NullCheck32, label %265, label %ThrowNullRef31
+  %NullCheck31 = icmp eq i16* %264, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %265
 
 ; <label>:265                                     ; preds = %259
   %266 = load i16, i16* %264, align 8
   %267 = sext i16 %266 to i32
   %268 = bitcast i8* %261 to i16*
   %269 = trunc i32 %267 to i16
-  %NullCheck34 = icmp ne i16* %268, null
-  br i1 %NullCheck34, label %270, label %ThrowNullRef33
+  %NullCheck33 = icmp eq i16* %268, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %270
 
 ; <label>:270                                     ; preds = %265
   store i16 %269, i16* %268, align 8
@@ -1168,14 +1250,14 @@ entry:
   %272 = load i8*, i8** %arg0
   %273 = load i8*, i8** %arg1
   %274 = bitcast i8* %273 to i64*
-  %NullCheck8 = icmp ne i64* %274, null
-  br i1 %NullCheck8, label %275, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64* %274, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %275
 
 ; <label>:275                                     ; preds = %271
   %276 = load i64, i64* %274, align 8
   %277 = bitcast i8* %272 to i64*
-  %NullCheck10 = icmp ne i64* %277, null
-  br i1 %NullCheck10, label %278, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %277, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %278
 
 ; <label>:278                                     ; preds = %275
   store i64 %276, i64* %277, align 8
@@ -1184,14 +1266,14 @@ entry:
   %281 = load i8*, i8** %arg1
   %282 = getelementptr inbounds i8, i8* %281, i64 8
   %283 = bitcast i8* %282 to i32*
-  %NullCheck12 = icmp ne i32* %283, null
-  br i1 %NullCheck12, label %284, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i32* %283, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %284
 
 ; <label>:284                                     ; preds = %278
   %285 = load i32, i32* %283, align 8
   %286 = bitcast i8* %280 to i32*
-  %NullCheck14 = icmp ne i32* %286, null
-  br i1 %NullCheck14, label %287, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i32* %286, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %287
 
 ; <label>:287                                     ; preds = %284
   store i32 %285, i32* %286, align 8
@@ -1200,16 +1282,16 @@ entry:
   %290 = load i8*, i8** %arg1
   %291 = getelementptr inbounds i8, i8* %290, i64 12
   %292 = bitcast i8* %291 to i16*
-  %NullCheck16 = icmp ne i16* %292, null
-  br i1 %NullCheck16, label %293, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i16* %292, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %293
 
 ; <label>:293                                     ; preds = %287
   %294 = load i16, i16* %292, align 8
   %295 = sext i16 %294 to i32
   %296 = bitcast i8* %289 to i16*
   %297 = trunc i32 %295 to i16
-  %NullCheck18 = icmp ne i16* %296, null
-  br i1 %NullCheck18, label %298, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i16* %296, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %298
 
 ; <label>:298                                     ; preds = %293
   store i16 %297, i16* %296, align 8
@@ -1217,15 +1299,15 @@ entry:
   %300 = getelementptr inbounds i8, i8* %299, i64 14
   %301 = load i8*, i8** %arg1
   %302 = getelementptr inbounds i8, i8* %301, i64 14
-  %NullCheck20 = icmp ne i8* %302, null
-  br i1 %NullCheck20, label %303, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i8* %302, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %303
 
 ; <label>:303                                     ; preds = %298
   %304 = load i8, i8* %302, align 8
   %305 = zext i8 %304 to i32
   %306 = trunc i32 %305 to i8
-  %NullCheck22 = icmp ne i8* %300, null
-  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i8* %300, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %307
 
 ; <label>:307                                     ; preds = %303
   store i8 %306, i8* %300, align 8
@@ -1235,14 +1317,14 @@ entry:
   %309 = load i8*, i8** %arg0
   %310 = load i8*, i8** %arg1
   %311 = bitcast i8* %310 to i64*
-  %NullCheck = icmp ne i64* %311, null
-  br i1 %NullCheck, label %312, label %ThrowNullRef
+  %NullCheck = icmp eq i64* %311, null
+  br i1 %NullCheck, label %ThrowNullRef, label %312
 
 ; <label>:312                                     ; preds = %308
   %313 = load i64, i64* %311, align 8
   %314 = bitcast i8* %309 to i64*
-  %NullCheck2 = icmp ne i64* %314, null
-  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64* %314, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %315
 
 ; <label>:315                                     ; preds = %312
   store i64 %313, i64* %314, align 8
@@ -1251,14 +1333,14 @@ entry:
   %318 = load i8*, i8** %arg1
   %319 = getelementptr inbounds i8, i8* %318, i64 8
   %320 = bitcast i8* %319 to i64*
-  %NullCheck4 = icmp ne i64* %320, null
-  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64* %320, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %321
 
 ; <label>:321                                     ; preds = %315
   %322 = load i64, i64* %320, align 8
   %323 = bitcast i8* %317 to i64*
-  %NullCheck6 = icmp ne i64* %323, null
-  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64* %323, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %324
 
 ; <label>:324                                     ; preds = %321
   store i64 %322, i64* %323, align 8
@@ -1286,15 +1368,15 @@ entry:
 ; <label>:338                                     ; preds = %333
   %339 = load i8*, i8** %arg0
   %340 = load i8*, i8** %arg1
-  %NullCheck136 = icmp ne i8* %340, null
-  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+  %NullCheck135 = icmp eq i8* %340, null
+  br i1 %NullCheck135, label %ThrowNullRef136, label %341
 
 ; <label>:341                                     ; preds = %338
   %342 = load i8, i8* %340, align 8
   %343 = zext i8 %342 to i32
   %344 = trunc i32 %343 to i8
-  %NullCheck138 = icmp ne i8* %339, null
-  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+  %NullCheck137 = icmp eq i8* %339, null
+  br i1 %NullCheck137, label %ThrowNullRef138, label %345
 
 ; <label>:345                                     ; preds = %341
   store i8 %344, i8* %339, align 8
@@ -1317,16 +1399,16 @@ entry:
   %357 = load i8*, i8** %arg0
   %358 = load i8*, i8** %arg1
   %359 = bitcast i8* %358 to i16*
-  %NullCheck140 = icmp ne i16* %359, null
-  br i1 %NullCheck140, label %360, label %ThrowNullRef139
+  %NullCheck139 = icmp eq i16* %359, null
+  br i1 %NullCheck139, label %ThrowNullRef140, label %360
 
 ; <label>:360                                     ; preds = %356
   %361 = load i16, i16* %359, align 8
   %362 = sext i16 %361 to i32
   %363 = bitcast i8* %357 to i16*
   %364 = trunc i32 %362 to i16
-  %NullCheck142 = icmp ne i16* %363, null
-  br i1 %NullCheck142, label %365, label %ThrowNullRef141
+  %NullCheck141 = icmp eq i16* %363, null
+  br i1 %NullCheck141, label %ThrowNullRef142, label %365
 
 ; <label>:365                                     ; preds = %360
   store i16 %364, i16* %363, align 8
@@ -1352,14 +1434,14 @@ entry:
   %378 = load i8*, i8** %arg0
   %379 = load i8*, i8** %arg1
   %380 = bitcast i8* %379 to i32*
-  %NullCheck144 = icmp ne i32* %380, null
-  br i1 %NullCheck144, label %381, label %ThrowNullRef143
+  %NullCheck143 = icmp eq i32* %380, null
+  br i1 %NullCheck143, label %ThrowNullRef144, label %381
 
 ; <label>:381                                     ; preds = %377
   %382 = load i32, i32* %380, align 8
   %383 = bitcast i8* %378 to i32*
-  %NullCheck146 = icmp ne i32* %383, null
-  br i1 %NullCheck146, label %384, label %ThrowNullRef145
+  %NullCheck145 = icmp eq i32* %383, null
+  br i1 %NullCheck145, label %ThrowNullRef146, label %384
 
 ; <label>:384                                     ; preds = %381
   store i32 %382, i32* %383, align 8
@@ -1384,14 +1466,14 @@ entry:
   %395 = load i8*, i8** %arg0
   %396 = load i8*, i8** %arg1
   %397 = bitcast i8* %396 to i64*
-  %NullCheck164 = icmp ne i64* %397, null
-  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+  %NullCheck163 = icmp eq i64* %397, null
+  br i1 %NullCheck163, label %ThrowNullRef164, label %398
 
 ; <label>:398                                     ; preds = %394
   %399 = load i64, i64* %397, align 8
   %400 = bitcast i8* %395 to i64*
-  %NullCheck166 = icmp ne i64* %400, null
-  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+  %NullCheck165 = icmp eq i64* %400, null
+  br i1 %NullCheck165, label %ThrowNullRef166, label %401
 
 ; <label>:401                                     ; preds = %398
   store i64 %399, i64* %400, align 8
@@ -1400,14 +1482,14 @@ entry:
   %404 = load i8*, i8** %arg1
   %405 = getelementptr inbounds i8, i8* %404, i64 8
   %406 = bitcast i8* %405 to i64*
-  %NullCheck168 = icmp ne i64* %406, null
-  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+  %NullCheck167 = icmp eq i64* %406, null
+  br i1 %NullCheck167, label %ThrowNullRef168, label %407
 
 ; <label>:407                                     ; preds = %401
   %408 = load i64, i64* %406, align 8
   %409 = bitcast i8* %403 to i64*
-  %NullCheck170 = icmp ne i64* %409, null
-  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+  %NullCheck169 = icmp eq i64* %409, null
+  br i1 %NullCheck169, label %ThrowNullRef170, label %410
 
 ; <label>:410                                     ; preds = %407
   store i64 %408, i64* %409, align 8
@@ -1437,14 +1519,14 @@ entry:
   %425 = load i8*, i8** %arg0
   %426 = load i8*, i8** %arg1
   %427 = bitcast i8* %426 to i64*
-  %NullCheck148 = icmp ne i64* %427, null
-  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+  %NullCheck147 = icmp eq i64* %427, null
+  br i1 %NullCheck147, label %ThrowNullRef148, label %428
 
 ; <label>:428                                     ; preds = %424
   %429 = load i64, i64* %427, align 8
   %430 = bitcast i8* %425 to i64*
-  %NullCheck150 = icmp ne i64* %430, null
-  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+  %NullCheck149 = icmp eq i64* %430, null
+  br i1 %NullCheck149, label %ThrowNullRef150, label %431
 
 ; <label>:431                                     ; preds = %428
   store i64 %429, i64* %430, align 8
@@ -1466,14 +1548,14 @@ entry:
   %441 = load i8*, i8** %arg0
   %442 = load i8*, i8** %arg1
   %443 = bitcast i8* %442 to i32*
-  %NullCheck152 = icmp ne i32* %443, null
-  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+  %NullCheck151 = icmp eq i32* %443, null
+  br i1 %NullCheck151, label %ThrowNullRef152, label %444
 
 ; <label>:444                                     ; preds = %440
   %445 = load i32, i32* %443, align 8
   %446 = bitcast i8* %441 to i32*
-  %NullCheck154 = icmp ne i32* %446, null
-  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+  %NullCheck153 = icmp eq i32* %446, null
+  br i1 %NullCheck153, label %ThrowNullRef154, label %447
 
 ; <label>:447                                     ; preds = %444
   store i32 %445, i32* %446, align 8
@@ -1495,16 +1577,16 @@ entry:
   %457 = load i8*, i8** %arg0
   %458 = load i8*, i8** %arg1
   %459 = bitcast i8* %458 to i16*
-  %NullCheck156 = icmp ne i16* %459, null
-  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+  %NullCheck155 = icmp eq i16* %459, null
+  br i1 %NullCheck155, label %ThrowNullRef156, label %460
 
 ; <label>:460                                     ; preds = %456
   %461 = load i16, i16* %459, align 8
   %462 = sext i16 %461 to i32
   %463 = bitcast i8* %457 to i16*
   %464 = trunc i32 %462 to i16
-  %NullCheck158 = icmp ne i16* %463, null
-  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+  %NullCheck157 = icmp eq i16* %463, null
+  br i1 %NullCheck157, label %ThrowNullRef158, label %465
 
 ; <label>:465                                     ; preds = %460
   store i16 %464, i16* %463, align 8
@@ -1525,15 +1607,15 @@ entry:
 ; <label>:474                                     ; preds = %470
   %475 = load i8*, i8** %arg0
   %476 = load i8*, i8** %arg1
-  %NullCheck160 = icmp ne i8* %476, null
-  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+  %NullCheck159 = icmp eq i8* %476, null
+  br i1 %NullCheck159, label %ThrowNullRef160, label %477
 
 ; <label>:477                                     ; preds = %474
   %478 = load i8, i8* %476, align 8
   %479 = zext i8 %478 to i32
   %480 = trunc i32 %479 to i8
-  %NullCheck162 = icmp ne i8* %475, null
-  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+  %NullCheck161 = icmp eq i8* %475, null
+  br i1 %NullCheck161, label %ThrowNullRef162, label %481
 
 ; <label>:481                                     ; preds = %477
   store i8 %480, i8* %475, align 8
@@ -1553,343 +1635,343 @@ ThrowNullRef:                                     ; preds = %308
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %312
+ThrowNullRef2:                                    ; preds = %312
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %315
+ThrowNullRef4:                                    ; preds = %315
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %321
+ThrowNullRef6:                                    ; preds = %321
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %271
+ThrowNullRef8:                                    ; preds = %271
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %275
+ThrowNullRef10:                                   ; preds = %275
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %278
+ThrowNullRef12:                                   ; preds = %278
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %284
+ThrowNullRef14:                                   ; preds = %284
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %287
+ThrowNullRef16:                                   ; preds = %287
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %293
+ThrowNullRef18:                                   ; preds = %293
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %298
+ThrowNullRef20:                                   ; preds = %298
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %303
+ThrowNullRef22:                                   ; preds = %303
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %243
+ThrowNullRef24:                                   ; preds = %243
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %247
+ThrowNullRef26:                                   ; preds = %247
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %250
+ThrowNullRef28:                                   ; preds = %250
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %256
+ThrowNullRef30:                                   ; preds = %256
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %259
+ThrowNullRef32:                                   ; preds = %259
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %265
+ThrowNullRef34:                                   ; preds = %265
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %217
+ThrowNullRef36:                                   ; preds = %217
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %221
+ThrowNullRef38:                                   ; preds = %221
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %224
+ThrowNullRef40:                                   ; preds = %224
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %230
+ThrowNullRef42:                                   ; preds = %230
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %233
+ThrowNullRef44:                                   ; preds = %233
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %238
+ThrowNullRef46:                                   ; preds = %238
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %200
+ThrowNullRef48:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %204
+ThrowNullRef50:                                   ; preds = %204
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %207
+ThrowNullRef52:                                   ; preds = %207
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %213
+ThrowNullRef54:                                   ; preds = %213
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %172
+ThrowNullRef56:                                   ; preds = %172
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %176
+ThrowNullRef58:                                   ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %179
+ThrowNullRef60:                                   ; preds = %179
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %185
+ThrowNullRef62:                                   ; preds = %185
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %190
+ThrowNullRef64:                                   ; preds = %190
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %195
+ThrowNullRef66:                                   ; preds = %195
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %153
+ThrowNullRef68:                                   ; preds = %153
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %157
+ThrowNullRef70:                                   ; preds = %157
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %160
+ThrowNullRef72:                                   ; preds = %160
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %166
+ThrowNullRef74:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %136
+ThrowNullRef76:                                   ; preds = %136
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %140
+ThrowNullRef78:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %143
+ThrowNullRef80:                                   ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %148
+ThrowNullRef82:                                   ; preds = %148
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %128
+ThrowNullRef84:                                   ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %132
+ThrowNullRef86:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %100
+ThrowNullRef88:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %104
+ThrowNullRef90:                                   ; preds = %104
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %107
+ThrowNullRef92:                                   ; preds = %107
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %113
+ThrowNullRef94:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %118
+ThrowNullRef96:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %123
+ThrowNullRef98:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %81
+ThrowNullRef100:                                  ; preds = %81
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef101:                                  ; preds = %85
+ThrowNullRef102:                                  ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef103:                                  ; preds = %88
+ThrowNullRef104:                                  ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef105:                                  ; preds = %94
+ThrowNullRef106:                                  ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef107:                                  ; preds = %64
+ThrowNullRef108:                                  ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef109:                                  ; preds = %68
+ThrowNullRef110:                                  ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef111:                                  ; preds = %71
+ThrowNullRef112:                                  ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef113:                                  ; preds = %76
+ThrowNullRef114:                                  ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef115:                                  ; preds = %56
+ThrowNullRef116:                                  ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef117:                                  ; preds = %60
+ThrowNullRef118:                                  ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef119:                                  ; preds = %37
+ThrowNullRef120:                                  ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef121:                                  ; preds = %41
+ThrowNullRef122:                                  ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef123:                                  ; preds = %46
+ThrowNullRef124:                                  ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef125:                                  ; preds = %51
+ThrowNullRef126:                                  ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef127:                                  ; preds = %27
+ThrowNullRef128:                                  ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef129:                                  ; preds = %31
+ThrowNullRef130:                                  ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef131:                                  ; preds = %19
+ThrowNullRef132:                                  ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef133:                                  ; preds = %22
+ThrowNullRef134:                                  ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef135:                                  ; preds = %338
+ThrowNullRef136:                                  ; preds = %338
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef137:                                  ; preds = %341
+ThrowNullRef138:                                  ; preds = %341
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef139:                                  ; preds = %356
+ThrowNullRef140:                                  ; preds = %356
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef141:                                  ; preds = %360
+ThrowNullRef142:                                  ; preds = %360
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef143:                                  ; preds = %377
+ThrowNullRef144:                                  ; preds = %377
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef145:                                  ; preds = %381
+ThrowNullRef146:                                  ; preds = %381
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef147:                                  ; preds = %424
+ThrowNullRef148:                                  ; preds = %424
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef149:                                  ; preds = %428
+ThrowNullRef150:                                  ; preds = %428
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef151:                                  ; preds = %440
+ThrowNullRef152:                                  ; preds = %440
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef153:                                  ; preds = %444
+ThrowNullRef154:                                  ; preds = %444
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef155:                                  ; preds = %456
+ThrowNullRef156:                                  ; preds = %456
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef157:                                  ; preds = %460
+ThrowNullRef158:                                  ; preds = %460
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef159:                                  ; preds = %474
+ThrowNullRef160:                                  ; preds = %474
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef161:                                  ; preds = %477
+ThrowNullRef162:                                  ; preds = %477
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef163:                                  ; preds = %394
+ThrowNullRef164:                                  ; preds = %394
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef165:                                  ; preds = %398
+ThrowNullRef166:                                  ; preds = %398
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef167:                                  ; preds = %401
+ThrowNullRef168:                                  ; preds = %401
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef169:                                  ; preds = %407
+ThrowNullRef170:                                  ; preds = %407
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1939,8 +2021,8 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
-  br i1 %NullCheck, label %22, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %ThrowNullRef, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
@@ -1948,8 +2030,8 @@ entry:
   store i32 %24, i32* %loc0
   %25 = load i32, i32* %loc0
   %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %26, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %27
 
 ; <label>:27                                      ; preds = %22
   %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
@@ -1971,7 +2053,7 @@ ThrowNullRef:                                     ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1989,8 +2071,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -2022,15 +2104,15 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2048,16 +2130,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
   %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
   store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %15
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
@@ -2072,8 +2154,8 @@ entry:
   %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
   %29 = ptrtoint i16 addrspace(1)* %28 to i64
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %19
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
@@ -2089,19 +2171,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2114,8 +2196,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
@@ -2128,7 +2210,7 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[loadElem]
+Failed to read AppDomain.PrepareDataForSetup[storeElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
@@ -2202,8 +2284,8 @@ entry:
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
-  br i1 %NullCheck24, label %27, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = load i64, i64 addrspace(1)* %26
@@ -2218,8 +2300,8 @@ entry:
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
-  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
   %41 = load i64, i64 addrspace(1)* %39
@@ -2236,8 +2318,8 @@ entry:
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
-  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
   %54 = load i64, i64 addrspace(1)* %52
@@ -2252,8 +2334,8 @@ entry:
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
   %67 = load i64, i64 addrspace(1)* %65
@@ -2270,8 +2352,8 @@ entry:
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
-  br i1 %NullCheck16, label %79, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
   %80 = load i64, i64 addrspace(1)* %78
@@ -2286,8 +2368,8 @@ entry:
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
-  br i1 %NullCheck18, label %92, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
   %93 = load i64, i64 addrspace(1)* %91
@@ -2304,8 +2386,8 @@ entry:
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
-  br i1 %NullCheck12, label %105, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = load i64, i64 addrspace(1)* %104
@@ -2320,8 +2402,8 @@ entry:
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
-  br i1 %NullCheck14, label %118, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
   %119 = load i64, i64 addrspace(1)* %117
@@ -2337,8 +2419,8 @@ entry:
 
 ; <label>:128                                     ; preds = %20
   %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
-  br i1 %NullCheck4, label %130, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %129, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %130
 
 ; <label>:130                                     ; preds = %128
   %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
@@ -2346,8 +2428,8 @@ entry:
   %133 = load i16, i16 addrspace(1)* %132, align 8
   %134 = zext i16 %133 to i32
   %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
-  br i1 %NullCheck6, label %136, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %135, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %136
 
 ; <label>:136                                     ; preds = %130
   %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
@@ -2360,8 +2442,8 @@ entry:
 
 ; <label>:143                                     ; preds = %136
   %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
-  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %144, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %145
 
 ; <label>:145                                     ; preds = %143
   %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
@@ -2369,8 +2451,8 @@ entry:
   %148 = load i16, i16 addrspace(1)* %147, align 8
   %149 = zext i16 %148 to i32
   %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %150, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %151
 
 ; <label>:151                                     ; preds = %145
   %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
@@ -2388,8 +2470,8 @@ entry:
 
 ; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
-  br i1 %NullCheck, label %163, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %ThrowNullRef, label %163
 
 ; <label>:163                                     ; preds = %161
   %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
@@ -2399,8 +2481,8 @@ entry:
 
 ; <label>:167                                     ; preds = %163
   %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
-  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %168, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %169
 
 ; <label>:169                                     ; preds = %167
   %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
@@ -2432,55 +2514,55 @@ ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %167
+ThrowNullRef2:                                    ; preds = %167
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %128
+ThrowNullRef4:                                    ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %130
+ThrowNullRef6:                                    ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %143
+ThrowNullRef8:                                    ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %145
+ThrowNullRef10:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %102
+ThrowNullRef12:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %105
+ThrowNullRef14:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %76
+ThrowNullRef16:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %79
+ThrowNullRef18:                                   ; preds = %79
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %50
+ThrowNullRef20:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %53
+ThrowNullRef22:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %24
+ThrowNullRef24:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %27
+ThrowNullRef26:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2503,15 +2585,15 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2519,16 +2601,16 @@ entry:
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
   store i32 %8, i32* %loc0
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
   %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
   store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
@@ -2546,16 +2628,16 @@ entry:
 
 ; <label>:23                                      ; preds = %64
   %24 = load i16*, i16** %loc3
-  %NullCheck12 = icmp ne i16* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i16* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
   store i32 %27, i32* %loc5
   %28 = load i16*, i16** %loc4
-  %NullCheck14 = icmp ne i16* %28, null
-  br i1 %NullCheck14, label %29, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %28, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = load i16, i16* %28, align 8
@@ -2620,15 +2702,15 @@ entry:
 
 ; <label>:67                                      ; preds = %64
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
-  br i1 %NullCheck8, label %69, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %68, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %69
 
 ; <label>:69                                      ; preds = %67
   %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
   %71 = load i32, i32 addrspace(1)* %70
   %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
-  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %73
 
 ; <label>:73                                      ; preds = %69
   %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
@@ -2645,31 +2727,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %67
+ThrowNullRef8:                                    ; preds = %67
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %69
+ThrowNullRef10:                                   ; preds = %69
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2710,14 +2792,14 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
   %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
@@ -2730,14 +2812,14 @@ entry:
 
 ; <label>:11                                      ; preds = %4
   %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
   %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
@@ -2749,14 +2831,14 @@ entry:
 
 ; <label>:22                                      ; preds = %16
   %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
   %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
-  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
-  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
@@ -2804,23 +2886,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2836,7 +2918,280 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[loadElem]
+Successfully read RuntimeType.IsAssignableFrom
+
+define i8 @RuntimeType.IsAssignableFrom(%System.RuntimeType addrspace(1)* %param0, %System.Type addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.RuntimeType addrspace(1)*
+  %arg1 = alloca %System.Type addrspace(1)*
+  %loc0 = alloca %System.RuntimeType addrspace(1)*
+  %loc1 = alloca %"System.Type[]" addrspace(1)*
+  %loc2 = alloca i32
+  store %System.RuntimeType addrspace(1)* %param0, %System.RuntimeType addrspace(1)** %this
+  store %System.Type addrspace(1)* %param1, %System.Type addrspace(1)** %arg1
+  %0 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %1 = icmp ne %System.Type addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i8 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %5 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %6 = bitcast %System.Type addrspace(1)* %4 to %System.Object addrspace(1)*
+  %7 = bitcast %System.RuntimeType addrspace(1)* %5 to %System.Object addrspace(1)*
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %6, %System.Object addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %3
+  ret i8 1
+
+; <label>:12                                      ; preds = %3
+  %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 152
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 32
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
+  %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
+  %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
+  store %System.RuntimeType addrspace(1)* %25, %System.RuntimeType addrspace(1)** %loc0
+  %26 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %27 = icmp eq %System.RuntimeType addrspace(1)* %26, null
+  br i1 %27, label %34, label %28
+
+; <label>:28                                      ; preds = %15
+  %29 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %30 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)*)*)(%System.RuntimeType addrspace(1)* %29, %System.RuntimeType addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+; <label>:34                                      ; preds = %15
+  %35 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %36 = call %System.Reflection.Emit.TypeBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Reflection.Emit.TypeBuilder addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %35)
+  %37 = icmp eq %System.Reflection.Emit.TypeBuilder addrspace(1)* %36, null
+  br i1 %37, label %139, label %38
+
+; <label>:38                                      ; preds = %34
+  %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %42
+
+; <label>:42                                      ; preds = %38
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 152
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 40
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
+  %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
+  %53 = zext i8 %52 to i32
+  %54 = icmp eq i32 %53, 0
+  br i1 %54, label %56, label %55
+
+; <label>:55                                      ; preds = %42
+  ret i8 1
+
+; <label>:56                                      ; preds = %42
+  %57 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %58 = bitcast %System.RuntimeType addrspace(1)* %57 to %System.Type addrspace(1)*
+  %59 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %58)
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %64 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.Type addrspace(1)* %63, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = bitcast %System.RuntimeType addrspace(1)* %64 to %System.Type addrspace(1)*
+  %67 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %63, %System.Type addrspace(1)* %66)
+  %68 = zext i8 %67 to i32
+  %69 = trunc i32 %68 to i8
+  ret i8 %69
+
+; <label>:70                                      ; preds = %56
+  %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
+  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %73
+
+; <label>:73                                      ; preds = %70
+  %74 = load i64, i64 addrspace(1)* %72
+  %75 = add i64 %74, 128
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = add i64 %77, 0
+  %79 = inttoptr i64 %78 to i64*
+  %80 = load i64, i64* %79
+  %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
+  %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
+  %83 = call i8 %82(%System.Type addrspace(1)* %81)
+  %84 = zext i8 %83 to i32
+  %85 = icmp eq i32 %84, 0
+  br i1 %85, label %139, label %86
+
+; <label>:86                                      ; preds = %73
+  %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
+  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %89
+
+; <label>:89                                      ; preds = %86
+  %90 = load i64, i64 addrspace(1)* %88
+  %91 = add i64 %90, 128
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = add i64 %93, 24
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
+  %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
+  %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
+  store %"System.Type[]" addrspace(1)* %99, %"System.Type[]" addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %129
+
+; <label>:100                                     ; preds = %132
+  %101 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %102 = load i32, i32* %loc2
+  %NullCheck11 = icmp eq %"System.Type[]" addrspace(1)* %101, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %103
+
+; <label>:103                                     ; preds = %100
+  %104 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 1
+  %105 = load i32, i32 addrspace(1)* %104
+  %106 = zext i32 %105 to i64
+  %107 = zext i32 %102 to i64
+  %BoundsCheck = icmp uge i64 %107, %106
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %108
+
+; <label>:108                                     ; preds = %103
+  %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
+  %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
+  %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
+  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %113
+
+; <label>:113                                     ; preds = %108
+  %114 = load i64, i64 addrspace(1)* %112
+  %115 = add i64 %114, 152
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = add i64 %117, 56
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
+  %123 = zext i8 %122 to i32
+  %124 = icmp ne i32 %123, 0
+  br i1 %124, label %126, label %125
+
+; <label>:125                                     ; preds = %113
+  ret i8 0
+
+; <label>:126                                     ; preds = %113
+  %127 = load i32, i32* %loc2
+  %128 = add i32 %127, 1
+  store i32 %128, i32* %loc2
+  br label %129
+
+; <label>:129                                     ; preds = %89, %126
+  %130 = load i32, i32* %loc2
+  %131 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %NullCheck9 = icmp eq %"System.Type[]" addrspace(1)* %131, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %132
+
+; <label>:132                                     ; preds = %129
+  %133 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %131, i32 0, i32 1
+  %134 = load i32, i32 addrspace(1)* %133
+  %135 = zext i32 %134 to i64
+  %136 = trunc i64 %135 to i32
+  %137 = icmp slt i32 %130, %136
+  br i1 %137, label %100, label %138
+
+; <label>:138                                     ; preds = %132
+  ret i8 1
+
+; <label>:139                                     ; preds = %34, %73
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %129
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %103
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -2893,7 +3248,7 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElem]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -2904,8 +3259,8 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -2997,8 +3352,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
@@ -3059,8 +3414,8 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -3087,8 +3442,8 @@ entry:
 
 ; <label>:17                                      ; preds = %5, %11
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
@@ -3097,8 +3452,8 @@ entry:
 
 ; <label>:22                                      ; preds = %1, %11
   %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
@@ -3109,11 +3464,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %17
+ThrowNullRef2:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %22
+ThrowNullRef4:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3167,15 +3522,15 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
   %15 = load i32, i32 addrspace(1)* %14
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
@@ -3198,7 +3553,7 @@ ThrowNullRef:                                     ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef2:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3232,8 +3587,8 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
@@ -3312,8 +3667,8 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -3327,8 +3682,8 @@ entry:
 ; <label>:5                                       ; preds = %43
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %7 = load i32, i32* %loc1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck6, label %8, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
@@ -3366,8 +3721,8 @@ entry:
 ; <label>:32                                      ; preds = %21, %25
   %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
   %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
-  br i1 %NullCheck8, label %35, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = trunc i32 %34 to i16
@@ -3380,8 +3735,8 @@ entry:
 ; <label>:40                                      ; preds = %1, %35
   %41 = load i32, i32* %loc1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
-  br i1 %NullCheck2, label %43, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %42, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
@@ -3392,8 +3747,8 @@ entry:
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
   %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
-  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
   %51 = load i64, i64 addrspace(1)* %49
@@ -3412,19 +3767,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %40
+ThrowNullRef2:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %47
+ThrowNullRef4:                                    ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %5
+ThrowNullRef6:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %32
+ThrowNullRef8:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3467,8 +3822,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
@@ -3492,11 +3847,391 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(i16* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store i16* %param0, i16** %arg0
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load i32, i32* %arg3
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %42, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %37, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg2
+  %13 = load i32, i32* %arg3
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %37, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %24 = load i32, i32* %arg2
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load i16*, i16** %arg0
+  %35 = load i32, i32* %arg3
+  %36 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %36, i16* %34, i32 %35)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:37                                      ; preds = %5, %16
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %39)
+  %41 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41, %System.String addrspace(1)* %38, %System.String addrspace(1)* %40)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41) #0
+  unreachable
+
+; <label>:42                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
-Failed to read StringBuilder.ToString[loadElemA]
+Successfully read StringBuilder.ToString
+
+define %System.String addrspace(1)* @StringBuilder.ToString(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i16*
+  %loc3 = alloca %"System.Char[]" addrspace(1)*
+  %loc4 = alloca i32
+  %loc5 = alloca i32
+  %loc6 = alloca i16 addrspace(1)*
+  %loc7 = alloca %System.String addrspace(1)*
+  %loc8 = alloca %"System.Char[]" addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %0)
+  %2 = icmp ne i32 %1, 0
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %4
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %6)
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %7)
+  store %System.String addrspace(1)* %8, %System.String addrspace(1)** %loc0
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.Text.StringBuilder addrspace(1)* %9, %System.Text.StringBuilder addrspace(1)** %loc1
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  store %System.String addrspace(1)* %10, %System.String addrspace(1)** %loc7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc7
+  %12 = ptrtoint %System.String addrspace(1)* %11 to i64
+  %13 = icmp eq i64 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %5
+  %15 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %16 = sext i32 %15 to i64
+  %17 = add i64 %12, %16
+  br label %18
+
+; <label>:18                                      ; preds = %5, %14
+  %19 = phi i64 [ %12, %5 ], [ %17, %14 ]
+  %20 = inttoptr i64 %19 to i16*
+  store i16* %20, i16** %loc2
+  br label %21
+
+; <label>:21                                      ; preds = %98, %18
+  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %22, null
+  br i1 %NullCheck, label %ThrowNullRef, label %23
+
+; <label>:23                                      ; preds = %21
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 3
+  %25 = load i32, i32 addrspace(1)* %24, align 8
+  %26 = icmp sle i32 %25, 0
+  br i1 %26, label %96, label %27
+
+; <label>:27                                      ; preds = %23
+  %28 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %28, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %29
+
+; <label>:29                                      ; preds = %27
+  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %28, i32 0, i32 1
+  %31 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %30, align 8
+  store %"System.Char[]" addrspace(1)* %31, %"System.Char[]" addrspace(1)** %loc3
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %33
+
+; <label>:33                                      ; preds = %29
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  store i32 %35, i32* %loc4
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  %39 = load i32, i32 addrspace(1)* %38, align 8
+  store i32 %39, i32* %loc5
+  %40 = load i32, i32* %loc5
+  %41 = load i32, i32* %loc4
+  %42 = add i32 %40, %41
+  %43 = zext i32 %42 to i64
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %45
+
+; <label>:45                                      ; preds = %37
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = sext i32 %47 to i64
+  %49 = icmp sgt i64 %43, %48
+  br i1 %49, label %91, label %50
+
+; <label>:50                                      ; preds = %45
+  %51 = load i32, i32* %loc5
+  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %52, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %53
+
+; <label>:53                                      ; preds = %50
+  %54 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %52, i32 0, i32 1
+  %55 = load i32, i32 addrspace(1)* %54
+  %56 = zext i32 %55 to i64
+  %57 = trunc i64 %56 to i32
+  %58 = icmp ugt i32 %51, %57
+  br i1 %58, label %91, label %59
+
+; <label>:59                                      ; preds = %53
+  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  store %"System.Char[]" addrspace(1)* %60, %"System.Char[]" addrspace(1)** %loc8
+  %61 = icmp eq %"System.Char[]" addrspace(1)* %60, null
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %63, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %64
+
+; <label>:64                                      ; preds = %62
+  %65 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %63, i32 0, i32 1
+  %66 = load i32, i32 addrspace(1)* %65
+  %67 = zext i32 %66 to i64
+  %68 = trunc i64 %67 to i32
+  %69 = icmp ne i32 %68, 0
+  br i1 %69, label %71, label %70
+
+; <label>:70                                      ; preds = %59, %64
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:71                                      ; preds = %64
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %73
+
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %BoundsCheck = icmp uge i64 0, %76
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %77
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %78, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:79                                      ; preds = %70, %77
+  %80 = load i16*, i16** %loc2
+  %81 = load i32, i32* %loc4
+  %82 = sext i32 %81 to i64
+  %83 = mul i64 %82, 2
+  %84 = bitcast i16* %80 to i8*
+  %85 = getelementptr inbounds i8, i8* %84, i64 %83
+  %86 = load i16 addrspace(1)*, i16 addrspace(1)** %loc6
+  %87 = ptrtoint i16 addrspace(1)* %86 to i64
+  %88 = load i32, i32* %loc5
+  %89 = bitcast i8* %85 to i16*
+  %90 = inttoptr i64 %87 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %89, i16* %90, i32 %88)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %96
+
+; <label>:91                                      ; preds = %45, %53
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %94 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %93)
+  %95 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95, %System.String addrspace(1)* %92, %System.String addrspace(1)* %94)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95) #0
+  unreachable
+
+; <label>:96                                      ; preds = %23, %79
+  %97 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %97, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %98
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %97, i32 0, i32 2
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  store %System.Text.StringBuilder addrspace(1)* %100, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %102 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %102, label %21, label %103
+
+; <label>:103                                     ; preds = %98
+  store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc7
+  %104 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  ret %System.String addrspace(1)* %104
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method StringBuilder::get_Length using LLILCJit
+Successfully read StringBuilder.get_Length
+
+define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
+Successfully read RuntimeHelpers.get_OffsetToStringData
+
+define i32 @RuntimeHelpers.get_OffsetToStringData() {
+entry:
+  ret i32 12
+}
+
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
 Successfully read CultureData.CreateCultureData
 
@@ -3514,23 +4249,23 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
   store i8 %4, i8 addrspace(1)* %6
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
@@ -3549,11 +4284,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3566,50 +4301,50 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
   store i32 -1, i32 addrspace(1)* %2
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
   store i32 -1, i32 addrspace(1)* %8
   %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
   store i32 -1, i32 addrspace(1)* %14
   %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
   store i32 -1, i32 addrspace(1)* %17
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
@@ -3623,27 +4358,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3675,7 +4410,136 @@ Failed to read Dictionary`2.Insert[non-const derefAddress]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
 Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
-Failed to read HashHelpers.GetPrime[loadElem]
+Successfully read HashHelpers.GetPrime
+
+define i32 @HashHelpers.GetPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %6, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5, %System.String addrspace(1)* %4)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5) #0
+  unreachable
+
+; <label>:6                                       ; preds = %entry
+  store i32 0, i32* %loc0
+  br label %29
+
+; <label>:7                                       ; preds = %35
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 1296
+  %10 = addrspacecast i8 addrspace(1)* %9 to %"System.Int32[]" addrspace(1)**
+  %11 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %10
+  %12 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Int32[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = zext i32 %15 to i64
+  %17 = zext i32 %12 to i64
+  %BoundsCheck = icmp uge i64 %17, %16
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 3, i32 %12
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  store i32 %20, i32* %loc1
+  %21 = load i32, i32* %loc1
+  %22 = load i32, i32* %arg0
+  %23 = icmp slt i32 %21, %22
+  br i1 %23, label %26, label %24
+
+; <label>:24                                      ; preds = %18
+  %25 = load i32, i32* %loc1
+  ret i32 %25
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %loc0
+  %28 = add i32 %27, 1
+  store i32 %28, i32* %loc0
+  br label %29
+
+; <label>:29                                      ; preds = %6, %26
+  %30 = load i32, i32* %loc0
+  %31 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %32 = getelementptr inbounds i8, i8 addrspace(1)* %31, i64 1296
+  %33 = addrspacecast i8 addrspace(1)* %32 to %"System.Int32[]" addrspace(1)**
+  %34 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %33
+  %NullCheck = icmp eq %"System.Int32[]" addrspace(1)* %34, null
+  br i1 %NullCheck, label %ThrowNullRef, label %35
+
+; <label>:35                                      ; preds = %29
+  %36 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %34, i32 0, i32 1
+  %37 = load i32, i32 addrspace(1)* %36
+  %38 = zext i32 %37 to i64
+  %39 = trunc i64 %38 to i32
+  %40 = icmp slt i32 %30, %39
+  br i1 %40, label %7, label %41
+
+; <label>:41                                      ; preds = %35
+  %42 = load i32, i32* %arg0
+  %43 = or i32 %42, 1
+  store i32 %43, i32* %loc2
+  br label %59
+
+; <label>:44                                      ; preds = %59
+  %45 = load i32, i32* %loc2
+  %46 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %45)
+  %47 = zext i8 %46 to i32
+  %48 = icmp eq i32 %47, 0
+  br i1 %48, label %56, label %49
+
+; <label>:49                                      ; preds = %44
+  %50 = load i32, i32* %loc2
+  %51 = sub i32 %50, 1
+  %52 = srem i32 %51, 101
+  %53 = icmp eq i32 %52, 0
+  br i1 %53, label %56, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = load i32, i32* %loc2
+  ret i32 %55
+
+; <label>:56                                      ; preds = %44, %49
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %57, 2
+  store i32 %58, i32* %loc2
+  br label %59
+
+; <label>:59                                      ; preds = %41, %56
+  %60 = load i32, i32* %loc2
+  %61 = icmp slt i32 %60, 2147483647
+  br i1 %61, label %44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load i32, i32* %arg0
+  ret i32 %63
+
+ThrowNullRef:                                     ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
 Successfully read GenericEqualityComparer`1.GetHashCode
 
@@ -3694,14 +4558,14 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
   %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load i64, i64 addrspace(1)* %7
@@ -3720,7 +4584,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3750,8 +4614,8 @@ entry:
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
@@ -3796,8 +4660,8 @@ entry:
   %35 = bitcast i16* %34 to i8*
   %36 = getelementptr inbounds i8, i8* %35, i64 2
   %37 = bitcast i8* %36 to i16*
-  %NullCheck4 = icmp ne i16* %37, null
-  br i1 %NullCheck4, label %38, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %37, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %38
 
 ; <label>:38                                      ; preds = %27
   %39 = load i16, i16* %37, align 8
@@ -3824,8 +4688,8 @@ entry:
 
 ; <label>:54                                      ; preds = %22, %43
   %55 = load i16*, i16** %loc4
-  %NullCheck2 = icmp ne i16* %55, null
-  br i1 %NullCheck2, label %56, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i16* %55, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %56
 
 ; <label>:56                                      ; preds = %54
   %57 = load i16, i16* %55, align 8
@@ -3850,11 +4714,11 @@ ThrowNullRef:                                     ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %54
+ThrowNullRef2:                                    ; preds = %54
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %27
+ThrowNullRef4:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3871,8 +4735,8 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -3907,8 +4771,8 @@ entry:
 
 ; <label>:26                                      ; preds = %19
   %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
-  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %28
 
 ; <label>:28                                      ; preds = %26
   %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
@@ -3920,7 +4784,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3972,8 +4836,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
@@ -3984,26 +4848,26 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
-  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
@@ -4014,8 +4878,8 @@ entry:
 ; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
@@ -4024,8 +4888,8 @@ entry:
 
 ; <label>:25                                      ; preds = %1, %16, %23
   %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
-  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
@@ -4036,27 +4900,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %20
+ThrowNullRef10:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4069,8 +4933,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -4081,8 +4945,8 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
@@ -4091,8 +4955,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1, %8
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
@@ -4103,11 +4967,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4128,24 +4992,24 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   store i32 %3, i32* %loc0
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
   %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
   store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck4, label %9, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
@@ -4164,15 +5028,15 @@ entry:
 ; <label>:18                                      ; preds = %70
   %19 = load i16*, i16** %loc3
   %20 = bitcast i16* %19 to i64*
-  %NullCheck10 = icmp ne i64* %20, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %20, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = load i64, i64* %20, align 8
   %23 = load i16*, i16** %loc4
   %24 = bitcast i16* %23 to i64*
-  %NullCheck12 = icmp ne i64* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = load i64, i64* %24, align 8
@@ -4188,8 +5052,8 @@ entry:
   %31 = bitcast i16* %30 to i8*
   %32 = getelementptr inbounds i8, i8* %31, i64 8
   %33 = bitcast i8* %32 to i64*
-  %NullCheck14 = icmp ne i64* %33, null
-  br i1 %NullCheck14, label %34, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = load i64, i64* %33, align 8
@@ -4197,8 +5061,8 @@ entry:
   %37 = bitcast i16* %36 to i8*
   %38 = getelementptr inbounds i8, i8* %37, i64 8
   %39 = bitcast i8* %38 to i64*
-  %NullCheck16 = icmp ne i64* %39, null
-  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %40
 
 ; <label>:40                                      ; preds = %34
   %41 = load i64, i64* %39, align 8
@@ -4214,8 +5078,8 @@ entry:
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %NullCheck18 = icmp ne i64* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = load i64, i64* %48, align 8
@@ -4223,8 +5087,8 @@ entry:
   %52 = bitcast i16* %51 to i8*
   %53 = getelementptr inbounds i8, i8* %52, i64 16
   %54 = bitcast i8* %53 to i64*
-  %NullCheck20 = icmp ne i64* %54, null
-  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64* %54, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %55
 
 ; <label>:55                                      ; preds = %49
   %56 = load i64, i64* %54, align 8
@@ -4262,15 +5126,15 @@ entry:
 ; <label>:74                                      ; preds = %95
   %75 = load i16*, i16** %loc3
   %76 = bitcast i16* %75 to i32*
-  %NullCheck6 = icmp ne i32* %76, null
-  br i1 %NullCheck6, label %77, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32* %76, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %77
 
 ; <label>:77                                      ; preds = %74
   %78 = load i32, i32* %76, align 8
   %79 = load i16*, i16** %loc4
   %80 = bitcast i16* %79 to i32*
-  %NullCheck8 = icmp ne i32* %80, null
-  br i1 %NullCheck8, label %81, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i32* %80, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %81
 
 ; <label>:81                                      ; preds = %77
   %82 = load i32, i32* %80, align 8
@@ -4318,43 +5182,43 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %74
+ThrowNullRef6:                                    ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %77
+ThrowNullRef8:                                    ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %29
+ThrowNullRef14:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %34
+ThrowNullRef16:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4376,8 +5240,8 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load i64, i64 addrspace(1)* %4
@@ -4389,8 +5253,8 @@ entry:
   %12 = load i64, i64* %11
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %5
   %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
@@ -4399,8 +5263,8 @@ entry:
   %18 = load i8, i8* %arg2
   %19 = zext i8 %18 to i32
   %20 = trunc i32 %19 to i8
-  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %15
   %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
@@ -4411,11 +5275,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4442,8 +5306,8 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
@@ -4466,16 +5330,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
   %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = load i64, i64 addrspace(1)* %19
@@ -4500,8 +5364,8 @@ entry:
 ; <label>:35                                      ; preds = %30
   %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
@@ -4514,8 +5378,8 @@ entry:
 
 ; <label>:42                                      ; preds = %1, %38
   %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
-  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
@@ -4526,19 +5390,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %35
+ThrowNullRef2:                                    ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %42
+ThrowNullRef8:                                    ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4551,14 +5415,14 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
@@ -4570,7 +5434,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4583,8 +5447,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
@@ -4613,51 +5477,51 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
   %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
   %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
   %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
   %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
-  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
   store i64 %21, i64 addrspace(1)* %23
   %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %25 = load i64, i64* %loc0
-  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
@@ -4668,27 +5532,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %22
+ThrowNullRef12:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4701,8 +5565,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
@@ -4713,19 +5577,19 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
@@ -4734,8 +5598,8 @@ entry:
 
 ; <label>:15                                      ; preds = %1, %13
   %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
@@ -4746,19 +5610,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %15
+ThrowNullRef8:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4771,8 +5635,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -4831,8 +5695,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
@@ -4882,8 +5746,8 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
-  br i1 %NullCheck, label %17, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %ThrowNullRef, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
@@ -4894,15 +5758,15 @@ entry:
 
 ; <label>:22                                      ; preds = %17
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
-  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
   %26 = load i32, i32 addrspace(1)* %25
   %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
-  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %27, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
@@ -4925,8 +5789,8 @@ entry:
 ; <label>:40                                      ; preds = %17
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
-  br i1 %NullCheck6, label %43, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %41, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
@@ -4938,34 +5802,17 @@ ThrowNullRef:                                     ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %24
+ThrowNullRef4:                                    ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %40
+ThrowNullRef6:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
-}
-
-INFO:  jitting method Object::ReferenceEquals using LLILCJit
-Successfully read Object.ReferenceEquals
-
-define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
-entry:
-  %arg0 = alloca %System.Object addrspace(1)*
-  %arg1 = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
-  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
-  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = icmp eq %System.Object addrspace(1)* %0, %1
-  %3 = sext i1 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
 }
 
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
@@ -4978,21 +5825,21 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
   %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
-  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
@@ -5007,28 +5854,28 @@ entry:
 ; <label>:13                                      ; preds = %8, %12
   %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
   %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
   %21 = load i32, i32 addrspace(1)* %20, align 8
   %22 = add i32 %21, 1
-  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
   store i32 %22, i32 addrspace(1)* %24
   %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
@@ -5039,27 +5886,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5077,7 +5924,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::Setup using LLILCJit
-Failed to read AppDomain.Setup[loadElem]
+Failed to read AppDomain.Setup[unbox]
 INFO:  jitting method Thread::GetDomain using LLILCJit
 Successfully read Thread.GetDomain
 
@@ -5108,8 +5955,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
@@ -5122,14 +5969,14 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
   %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
@@ -5141,11 +5988,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5173,8 +6020,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -5189,7 +6036,328 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
 Failed to read KeyCollection.System.Collections.Generic.IEnumerable<TKey>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Successfully read Enumerator.MoveNext
+
+define i8 @Enumerator.MoveNext(%"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.RuntimeTypeHandle* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*
+  %"$TypeArg" = alloca %System.RuntimeTypeHandle*
+  store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
+  %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 8
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %76, label %12
+
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
+  br label %76
+
+; <label>:13                                      ; preds = %85
+  %14 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck19 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %15
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, i32 0, i32 0
+  %17 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %16, align 8
+  %NullCheck21 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, i32 0, i32 2
+  %20 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %19, align 8
+  %21 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck23 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %22
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, i32 0, i32 2
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %NullCheck25 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 3, i32 %24
+  %NullCheck27 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %32
+
+; <label>:32                                      ; preds = %30
+  %33 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, i32 0, i32 2
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = icmp slt i32 %34, 0
+  br i1 %35, label %68, label %36
+
+; <label>:36                                      ; preds = %32
+  %37 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %38 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck29 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %39
+
+; <label>:39                                      ; preds = %36
+  %40 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, i32 0, i32 0
+  %41 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %40, align 8
+  %NullCheck31 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, i32 0, i32 2
+  %44 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %43, align 8
+  %45 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck33 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, i32 0, i32 2
+  %48 = load i32, i32 addrspace(1)* %47, align 8
+  %NullCheck35 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %49
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = zext i32 %51 to i64
+  %53 = zext i32 %48 to i64
+  %BoundsCheck37 = icmp uge i64 %53, %52
+  br i1 %BoundsCheck37, label %ThrowIndexOutOfRange38, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 3, i32 %48
+  %NullCheck39 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %56
+
+; <label>:56                                      ; preds = %54
+  %57 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, i32 0, i32 0
+  %58 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck41 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %59
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %60, %System.__Canon addrspace(1)* %58)
+  %61 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck43 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  %64 = load i32, i32 addrspace(1)* %63, align 8
+  %65 = add i32 %64, 1
+  %NullCheck45 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  store i32 %65, i32 addrspace(1)* %67
+  ret i8 1
+
+; <label>:68                                      ; preds = %32
+  %69 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck47 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %73 = add i32 %72, 1
+  %NullCheck49 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %74
+
+; <label>:74                                      ; preds = %70
+  %75 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  store i32 %73, i32 addrspace(1)* %75
+  br label %76
+
+; <label>:76                                      ; preds = %8, %12, %74
+  %77 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %78
+
+; <label>:78                                      ; preds = %76
+  %79 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, i32 0, i32 2
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck7 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %82
+
+; <label>:82                                      ; preds = %78
+  %83 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, i32 0, i32 0
+  %84 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %83, align 8
+  %NullCheck9 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %85
+
+; <label>:85                                      ; preds = %82
+  %86 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, i32 0, i32 7
+  %87 = load i32, i32 addrspace(1)* %86, align 8
+  %88 = icmp ult i32 %80, %87
+  br i1 %88, label %13, label %89
+
+; <label>:89                                      ; preds = %85
+  %90 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %91 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck11 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %92
+
+; <label>:92                                      ; preds = %89
+  %93 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, i32 0, i32 0
+  %94 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck13 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %95
+
+; <label>:95                                      ; preds = %92
+  %96 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, i32 0, i32 7
+  %97 = load i32, i32 addrspace(1)* %96, align 8
+  %98 = add i32 %97, 1
+  %NullCheck15 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %99
+
+; <label>:99                                      ; preds = %95
+  %100 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, i32 0, i32 2
+  store i32 %98, i32 addrspace(1)* %100
+  %101 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck17 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %102
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %103, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %92
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef22:                                   ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef24:                                   ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef26:                                   ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef28:                                   ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef30:                                   ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef32:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef34:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef36:                                   ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange38:                           ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef40:                                   ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef42:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef44:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef46:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef48:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef50:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -5200,8 +6368,8 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -5232,9 +6400,9 @@ Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
 Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
-Failed to read String.MakeSeparatorList[loadElemA]
+Failed to read String.MakeSeparatorList[storeElem]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
-Failed to read String.InternalSplitKeepEmptyEntries[loadElem]
+Failed to read String.InternalSplitKeepEmptyEntries[storeElem]
 INFO:  jitting method Path::IsRelative using LLILCJit
 Successfully read Path.IsRelative
 
@@ -5243,8 +6411,8 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -5254,8 +6422,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
@@ -5271,8 +6439,8 @@ entry:
 
 ; <label>:17                                      ; preds = %7
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
@@ -5288,8 +6456,8 @@ entry:
 
 ; <label>:29                                      ; preds = %19
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %31
 
 ; <label>:31                                      ; preds = %29
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
@@ -5300,8 +6468,8 @@ entry:
 
 ; <label>:36                                      ; preds = %31
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
-  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %37, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
@@ -5312,8 +6480,8 @@ entry:
 
 ; <label>:43                                      ; preds = %31, %38
   %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
-  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %45
 
 ; <label>:45                                      ; preds = %43
   %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
@@ -5324,8 +6492,8 @@ entry:
 
 ; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %50
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
@@ -5336,8 +6504,8 @@ entry:
 
 ; <label>:57                                      ; preds = %1, %7, %19, %45, %52
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
-  br i1 %NullCheck14, label %59, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %59
 
 ; <label>:59                                      ; preds = %57
   %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
@@ -5347,8 +6515,8 @@ entry:
 
 ; <label>:63                                      ; preds = %59
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
@@ -5359,8 +6527,8 @@ entry:
 
 ; <label>:70                                      ; preds = %65
   %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
-  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.String addrspace(1)* %71, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %72
 
 ; <label>:72                                      ; preds = %70
   %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
@@ -5379,39 +6547,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %17
+ThrowNullRef4:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %29
+ThrowNullRef6:                                    ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %36
+ThrowNullRef8:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %43
+ThrowNullRef10:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %50
+ThrowNullRef12:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %57
+ThrowNullRef14:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %63
+ThrowNullRef16:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %70
+ThrowNullRef18:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5419,7 +6587,293 @@ ThrowNullRef17:                                   ; preds = %70
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
-Failed to read String.TrimHelper[loadElem]
+Successfully read String.TrimHelper
+
+define %System.String addrspace(1)* @String.TrimHelper(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i16
+  %loc4 = alloca i32
+  %loc5 = alloca i16
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = sub i32 %3, 1
+  store i32 %4, i32* %loc0
+  store i32 0, i32* %loc1
+  %5 = load i32, i32* %arg2
+  %6 = icmp eq i32 %5, 1
+  br i1 %6, label %62, label %7
+
+; <label>:7                                       ; preds = %1
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:8                                       ; preds = %58
+  store i32 0, i32* %loc2
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load i32, i32* %loc1
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2, i32 %10
+  %13 = load i16, i16 addrspace(1)* %12
+  %14 = zext i16 %13 to i32
+  %15 = trunc i32 %14 to i16
+  store i16 %15, i16* %loc3
+  store i32 0, i32* %loc2
+  br label %34
+
+; <label>:16                                      ; preds = %37
+  %17 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %18 = load i32, i32* %loc2
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %17, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %19
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = zext i32 %18 to i64
+  %BoundsCheck = icmp uge i64 %23, %22
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %24
+
+; <label>:24                                      ; preds = %19
+  %25 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 3, i32 %18
+  %26 = load i16, i16 addrspace(1)* %25, align 8
+  %27 = zext i16 %26 to i32
+  %28 = load i16, i16* %loc3
+  %29 = zext i16 %28 to i32
+  %30 = icmp eq i32 %27, %29
+  br i1 %30, label %43, label %31
+
+; <label>:31                                      ; preds = %24
+  %32 = load i32, i32* %loc2
+  %33 = add i32 %32, 1
+  store i32 %33, i32* %loc2
+  br label %34
+
+; <label>:34                                      ; preds = %11, %31
+  %35 = load i32, i32* %loc2
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = icmp slt i32 %35, %41
+  br i1 %42, label %16, label %43
+
+; <label>:43                                      ; preds = %24, %37
+  %44 = load i32, i32* %loc2
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %45, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp eq i32 %44, %50
+  br i1 %51, label %62, label %52
+
+; <label>:52                                      ; preds = %46
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %7, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %57, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %58
+
+; <label>:58                                      ; preds = %55
+  %59 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %60 = load i32, i32 addrspace(1)* %59
+  %61 = icmp slt i32 %56, %60
+  br i1 %61, label %8, label %62
+
+; <label>:62                                      ; preds = %1, %46, %58
+  %63 = load i32, i32* %arg2
+  %64 = icmp eq i32 %63, 0
+  br i1 %64, label %122, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %66, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %67
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %66, i32 0, i32 1
+  %69 = load i32, i32 addrspace(1)* %68
+  %70 = sub i32 %69, 1
+  store i32 %70, i32* %loc0
+  br label %118
+
+; <label>:71                                      ; preds = %118
+  store i32 0, i32* %loc4
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %73 = load i32, i32* %loc0
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %74
+
+; <label>:74                                      ; preds = %71
+  %75 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 2, i32 %73
+  %76 = load i16, i16 addrspace(1)* %75
+  %77 = zext i16 %76 to i32
+  %78 = trunc i32 %77 to i16
+  store i16 %78, i16* %loc5
+  store i32 0, i32* %loc4
+  br label %97
+
+; <label>:79                                      ; preds = %100
+  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %81 = load i32, i32* %loc4
+  %NullCheck19 = icmp eq %"System.Char[]" addrspace(1)* %80, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
+
+; <label>:82                                      ; preds = %79
+  %83 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 1
+  %84 = load i32, i32 addrspace(1)* %83
+  %85 = zext i32 %84 to i64
+  %86 = zext i32 %81 to i64
+  %BoundsCheck21 = icmp uge i64 %86, %85
+  br i1 %BoundsCheck21, label %ThrowIndexOutOfRange22, label %87
+
+; <label>:87                                      ; preds = %82
+  %88 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 3, i32 %81
+  %89 = load i16, i16 addrspace(1)* %88, align 8
+  %90 = zext i16 %89 to i32
+  %91 = load i16, i16* %loc5
+  %92 = zext i16 %91 to i32
+  %93 = icmp eq i32 %90, %92
+  br i1 %93, label %106, label %94
+
+; <label>:94                                      ; preds = %87
+  %95 = load i32, i32* %loc4
+  %96 = add i32 %95, 1
+  store i32 %96, i32* %loc4
+  br label %97
+
+; <label>:97                                      ; preds = %74, %94
+  %98 = load i32, i32* %loc4
+  %99 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck15 = icmp eq %"System.Char[]" addrspace(1)* %99, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %100
+
+; <label>:100                                     ; preds = %97
+  %101 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %99, i32 0, i32 1
+  %102 = load i32, i32 addrspace(1)* %101
+  %103 = zext i32 %102 to i64
+  %104 = trunc i64 %103 to i32
+  %105 = icmp slt i32 %98, %104
+  br i1 %105, label %79, label %106
+
+; <label>:106                                     ; preds = %87, %100
+  %107 = load i32, i32* %loc4
+  %108 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck17 = icmp eq %"System.Char[]" addrspace(1)* %108, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %109
+
+; <label>:109                                     ; preds = %106
+  %110 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %108, i32 0, i32 1
+  %111 = load i32, i32 addrspace(1)* %110
+  %112 = zext i32 %111 to i64
+  %113 = trunc i64 %112 to i32
+  %114 = icmp eq i32 %107, %113
+  br i1 %114, label %122, label %115
+
+; <label>:115                                     ; preds = %109
+  %116 = load i32, i32* %loc0
+  %117 = sub i32 %116, 1
+  store i32 %117, i32* %loc0
+  br label %118
+
+; <label>:118                                     ; preds = %67, %115
+  %119 = load i32, i32* %loc0
+  %120 = load i32, i32* %loc1
+  %121 = icmp sge i32 %119, %120
+  br i1 %121, label %71, label %122
+
+; <label>:122                                     ; preds = %62, %109, %118
+  %123 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %124 = load i32, i32* %loc1
+  %125 = load i32, i32* %loc0
+  %126 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %123, i32 %124, i32 %125)
+  ret %System.String addrspace(1)* %126
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %97
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange22:                           ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
 Successfully read String.CreateTrimmedString
 
@@ -5439,8 +6893,8 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
@@ -5535,8 +6989,8 @@ entry:
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i64 2872
   %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
   %8 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %7
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %3
   %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
@@ -5553,8 +7007,8 @@ entry:
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 2864
   %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
   %21 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %20
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
-  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %22
 
 ; <label>:22                                      ; preds = %16
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
@@ -5569,7 +7023,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %16
+ThrowNullRef2:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5586,8 +7040,8 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5613,8 +7067,8 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
@@ -5632,8 +7086,8 @@ entry:
 
 ; <label>:12                                      ; preds = %4
   %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
@@ -5644,8 +7098,8 @@ entry:
 
 ; <label>:19                                      ; preds = %14
   %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %19
   %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
@@ -5660,21 +7114,21 @@ entry:
   %31 = zext i16 %30 to i32
   %32 = bitcast i8* %29 to i16*
   %33 = trunc i32 %31 to i16
-  %NullCheck6 = icmp ne i16* %32, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i16* %32, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %21
   store i16 %33, i16* %32, align 8
   %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %36
 
 ; <label>:36                                      ; preds = %34
   %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
   %38 = load i32, i32 addrspace(1)* %37, align 8
   %39 = add i32 %38, 1
-  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %40
 
 ; <label>:40                                      ; preds = %36
   %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
@@ -5683,16 +7137,16 @@ entry:
 
 ; <label>:42                                      ; preds = %14
   %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
-  br i1 %NullCheck12, label %44, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
   %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
   %47 = load i16, i16* %arg1
   %48 = zext i16 %47 to i32
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = trunc i32 %48 to i16
@@ -5703,31 +7157,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %19
+ThrowNullRef4:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %21
+ThrowNullRef6:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %36
+ThrowNullRef10:                                   ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %42
+ThrowNullRef12:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %44
+ThrowNullRef14:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5740,8 +7194,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -5752,8 +7206,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
@@ -5762,14 +7216,14 @@ entry:
 
 ; <label>:11                                      ; preds = %1
   %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
@@ -5779,15 +7233,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5808,8 +7262,8 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5822,8 +7276,8 @@ entry:
 
 ; <label>:8                                       ; preds = %3
   %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
@@ -5842,15 +7296,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
-  br i1 %NullCheck4, label %22, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
   %24 = load i16*, i16* addrspace(1)* %23, align 8
   %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %25, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
@@ -5859,8 +7313,8 @@ entry:
   store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
@@ -5874,8 +7328,8 @@ entry:
 
 ; <label>:37                                      ; preds = %65
   %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %37
   %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
@@ -5886,16 +7340,16 @@ entry:
   %45 = bitcast i16* %41 to i8*
   %46 = getelementptr inbounds i8, i8* %45, i64 %44
   %47 = bitcast i8* %46 to i16*
-  %NullCheck14 = icmp ne i16* %47, null
-  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %47, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %48
 
 ; <label>:48                                      ; preds = %39
   %49 = load i16, i16* %47, align 8
   %50 = zext i16 %49 to i32
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %52 = load i32, i32* %loc1
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %53
 
 ; <label>:53                                      ; preds = %48
   %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
@@ -5916,8 +7370,8 @@ entry:
 ; <label>:62                                      ; preds = %36, %59
   %63 = load i32, i32* %loc1
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck10, label %65, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %65
 
 ; <label>:65                                      ; preds = %62
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
@@ -5936,15 +7390,15 @@ entry:
 
 ; <label>:74                                      ; preds = %70
   %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
-  br i1 %NullCheck18, label %76, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %76
 
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
   %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
-  br i1 %NullCheck20, label %80, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
   %81 = load i64, i64 addrspace(1)* %79
@@ -5958,8 +7412,8 @@ entry:
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
   %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
-  br i1 %NullCheck22, label %92, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.String addrspace(1)* %90, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %92
 
 ; <label>:92                                      ; preds = %80
   %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
@@ -5969,15 +7423,15 @@ entry:
 
 ; <label>:96                                      ; preds = %70
   %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
-  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %98
 
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
   %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
-  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
   %103 = load i64, i64 addrspace(1)* %101
@@ -5991,8 +7445,8 @@ entry:
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
   %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
-  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.String addrspace(1)* %112, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %114
 
 ; <label>:114                                     ; preds = %102
   %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
@@ -6004,59 +7458,59 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %20
+ThrowNullRef4:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %22
+ThrowNullRef6:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %26
+ThrowNullRef8:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %62
+ThrowNullRef10:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %48
+ThrowNullRef16:                                   ; preds = %48
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %74
+ThrowNullRef18:                                   ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %76
+ThrowNullRef20:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %80
+ThrowNullRef22:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %96
+ThrowNullRef24:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %98
+ThrowNullRef26:                                   ; preds = %98
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %102
+ThrowNullRef28:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6069,15 +7523,15 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
   %3 = load i16*, i16* addrspace(1)* %2, align 8
   %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
@@ -6087,8 +7541,8 @@ entry:
   %10 = bitcast i16* %3 to i8*
   %11 = getelementptr inbounds i8, i8* %10, i64 %9
   %12 = bitcast i8* %11 to i16*
-  %NullCheck4 = icmp ne i16* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %5
   store i16 0, i16* %12, align 8
@@ -6098,11 +7552,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6119,8 +7573,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -6131,8 +7585,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
@@ -6144,15 +7598,15 @@ entry:
 
 ; <label>:14                                      ; preds = %1
   %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
   %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
   %21 = load i64, i64 addrspace(1)* %19
@@ -6171,15 +7625,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %14
+ThrowNullRef4:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %16
+ThrowNullRef6:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6302,14 +7756,6 @@ entry:
   ret %System.String addrspace(1)* %57
 }
 
-INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
-Successfully read RuntimeHelpers.get_OffsetToStringData
-
-define i32 @RuntimeHelpers.get_OffsetToStringData() {
-entry:
-  ret i32 12
-}
-
 INFO:  jitting method String::Equals using LLILCJit
 Successfully read String.Equals
 
@@ -6381,8 +7827,8 @@ entry:
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
-  br i1 %NullCheck24, label %29, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
   %30 = load i64, i64 addrspace(1)* %28
@@ -6397,8 +7843,8 @@ entry:
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
-  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
   %43 = load i64, i64 addrspace(1)* %41
@@ -6418,8 +7864,8 @@ entry:
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
   %59 = load i64, i64 addrspace(1)* %57
@@ -6434,8 +7880,8 @@ entry:
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck22, label %71, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
   %72 = load i64, i64 addrspace(1)* %70
@@ -6455,8 +7901,8 @@ entry:
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
-  br i1 %NullCheck16, label %87, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = load i64, i64 addrspace(1)* %86
@@ -6471,8 +7917,8 @@ entry:
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck18, label %100, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
   %101 = load i64, i64 addrspace(1)* %99
@@ -6492,8 +7938,8 @@ entry:
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
-  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
   %117 = load i64, i64 addrspace(1)* %115
@@ -6508,8 +7954,8 @@ entry:
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
-  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
   %130 = load i64, i64 addrspace(1)* %128
@@ -6528,15 +7974,15 @@ entry:
 
 ; <label>:142                                     ; preds = %22
   %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
-  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %143, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %144
 
 ; <label>:144                                     ; preds = %142
   %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
   %146 = load i32, i32 addrspace(1)* %145
   %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
-  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %147, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %148
 
 ; <label>:148                                     ; preds = %144
   %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
@@ -6557,15 +8003,15 @@ entry:
 
 ; <label>:159                                     ; preds = %22
   %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
-  br i1 %NullCheck, label %161, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %ThrowNullRef, label %161
 
 ; <label>:161                                     ; preds = %159
   %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
   %163 = load i32, i32 addrspace(1)* %162
   %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
-  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %164, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %165
 
 ; <label>:165                                     ; preds = %161
   %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
@@ -6578,8 +8024,8 @@ entry:
 
 ; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
-  br i1 %NullCheck4, label %172, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %171, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %172
 
 ; <label>:172                                     ; preds = %170
   %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
@@ -6589,8 +8035,8 @@ entry:
 
 ; <label>:176                                     ; preds = %172
   %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
-  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %177, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %178
 
 ; <label>:178                                     ; preds = %176
   %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
@@ -6629,55 +8075,55 @@ ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %161
+ThrowNullRef2:                                    ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %170
+ThrowNullRef4:                                    ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %176
+ThrowNullRef6:                                    ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %142
+ThrowNullRef8:                                    ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %144
+ThrowNullRef10:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %113
+ThrowNullRef12:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %116
+ThrowNullRef14:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %84
+ThrowNullRef16:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %87
+ThrowNullRef18:                                   ; preds = %87
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %55
+ThrowNullRef20:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %58
+ThrowNullRef22:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %26
+ThrowNullRef24:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %29
+ThrowNullRef26:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,8 +8161,8 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck, label %14, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %ThrowNullRef, label %14
 
 ; <label>:14                                      ; preds = %8
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
@@ -6760,8 +8206,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
@@ -6770,14 +8216,14 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32, i32* %loc0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %10
   %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
   %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
@@ -6790,15 +8236,15 @@ entry:
 ; <label>:25                                      ; preds = %19
   %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
-  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
   %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
@@ -6807,8 +8253,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %37 = load i32, i32* %loc0
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %38, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %38
 
 ; <label>:38                                      ; preds = %32
   %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
@@ -6817,14 +8263,14 @@ entry:
 
 ; <label>:40                                      ; preds = %19
   %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %40
   %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
   %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
-  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
-  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
@@ -6832,8 +8278,8 @@ entry:
   %48 = zext i32 %47 to i64
   %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
-  br i1 %NullCheck16, label %51, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %51
 
 ; <label>:51                                      ; preds = %45
   %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
@@ -6847,15 +8293,15 @@ entry:
 ; <label>:57                                      ; preds = %51
   %58 = load i16*, i16** %arg1
   %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
-  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %60
 
 ; <label>:60                                      ; preds = %57
   %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
   %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
-  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %64
 
 ; <label>:64                                      ; preds = %60
   %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
@@ -6864,22 +8310,22 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
   %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
-  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %70
 
 ; <label>:70                                      ; preds = %64
   %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
   %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
-  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
-  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
   %75 = load i32, i32 addrspace(1)* %74
   %76 = zext i32 %75 to i64
   %77 = trunc i64 %76 to i32
-  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
-  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %78
 
 ; <label>:78                                      ; preds = %73
   %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
@@ -6901,8 +8347,8 @@ entry:
   %90 = bitcast i16* %86 to i8*
   %91 = getelementptr inbounds i8, i8* %90, i64 %89
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %93
 
 ; <label>:93                                      ; preds = %80
   %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
@@ -6912,8 +8358,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %99 = load i32, i32* %loc2
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %100
 
 ; <label>:100                                     ; preds = %93
   %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
@@ -6928,63 +8374,63 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %25
+ThrowNullRef6:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %32
+ThrowNullRef10:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %40
+ThrowNullRef12:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %45
+ThrowNullRef16:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %57
+ThrowNullRef18:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %60
+ThrowNullRef20:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %64
+ThrowNullRef22:                                   ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %70
+ThrowNullRef24:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %73
+ThrowNullRef26:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %80
+ThrowNullRef28:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %93
+ThrowNullRef30:                                   ; preds = %93
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7004,8 +8450,8 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
@@ -7033,43 +8479,43 @@ entry:
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %14
   %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
   %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   %28 = load i32, i32 addrspace(1)* %27, align 8
   %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
-  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %30
 
 ; <label>:30                                      ; preds = %26
   %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
   %32 = load i32, i32 addrspace(1)* %31, align 8
   %33 = add i32 %28, %32
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %34
 
 ; <label>:34                                      ; preds = %30
   %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   store i32 %33, i32 addrspace(1)* %35
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
   store i32 0, i32 addrspace(1)* %38
   %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %40
 
 ; <label>:40                                      ; preds = %37
   %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
@@ -7082,8 +8528,8 @@ entry:
 
 ; <label>:47                                      ; preds = %40
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
@@ -7098,8 +8544,8 @@ entry:
   %54 = load i32, i32* %loc0
   %55 = sext i32 %54 to i64
   %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
-  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %57
 
 ; <label>:57                                      ; preds = %52
   %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
@@ -7110,68 +8556,35 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %14
+ThrowNullRef2:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %23
+ThrowNullRef4:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %26
+ThrowNullRef6:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %30
+ThrowNullRef8:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %34
+ThrowNullRef10:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %47
+ThrowNullRef14:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %52
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-}
-
-INFO:  jitting method StringBuilder::get_Length using LLILCJit
-Successfully read StringBuilder.get_Length
-
-define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.StringBuilder addrspace(1)*
-  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
-  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
-
-; <label>:1                                       ; preds = %entry
-  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %3 = load i32, i32 addrspace(1)* %2, align 8
-  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
-
-; <label>:5                                       ; preds = %1
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = add i32 %3, %7
-  ret i32 %8
-
-ThrowNullRef:                                     ; preds = %entry
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef16:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7213,70 +8626,70 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
   %6 = load i32, i32 addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
   store i32 %6, i32 addrspace(1)* %8
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
   %13 = load i32, i32 addrspace(1)* %12, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
   store i32 %13, i32 addrspace(1)* %15
   %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
-  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %18
 
 ; <label>:18                                      ; preds = %14
   %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
   %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
   %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
   %34 = load i32, i32 addrspace(1)* %33, align 8
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
-  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
@@ -7287,39 +8700,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %28
+ThrowNullRef16:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %32
+ThrowNullRef18:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7455,13 +8868,13 @@ entry:
 ; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
@@ -7477,16 +8890,16 @@ entry:
 
 ; <label>:18                                      ; preds = %15
   %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
   store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
   %22 = load i32, i32* %loc0
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %24
 
 ; <label>:24                                      ; preds = %20
   %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
@@ -7498,13 +8911,13 @@ entry:
 ; <label>:28                                      ; preds = %15, %24
   %29 = load i32, i32* %arg1
   %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %31
   %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
@@ -7517,20 +8930,20 @@ entry:
   %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
-  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
   %46 = load i32, i32 addrspace(1)* %45, align 8
   %47 = sub i32 %40, %46
-  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
-  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i32 addrspace(1)* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %48
 
 ; <label>:48                                      ; preds = %44
   store i32 %47, i32 addrspace(1)* %39, align 8
@@ -7538,21 +8951,21 @@ entry:
 
 ; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
-  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %51
 
 ; <label>:51                                      ; preds = %49
   %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %53
 
 ; <label>:53                                      ; preds = %51
   %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
   %55 = load i32, i32 addrspace(1)* %54, align 8
   %56 = load i32, i32* %arg2
   %57 = sub i32 %55, %56
-  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %58
 
 ; <label>:58                                      ; preds = %53
   %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
@@ -7562,13 +8975,13 @@ entry:
 ; <label>:60                                      ; preds = %33, %58
   %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
   %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
-  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %63
 
 ; <label>:63                                      ; preds = %60
   %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
-  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
-  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
@@ -7578,15 +8991,15 @@ entry:
 
 ; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
-  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i32 addrspace(1)* %69, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %70
 
 ; <label>:70                                      ; preds = %68
   %71 = load i32, i32 addrspace(1)* %69, align 8
   store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
-  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
@@ -7596,8 +9009,8 @@ entry:
   store i32 %77, i32* %loc4
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
-  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %80
 
 ; <label>:80                                      ; preds = %73
   %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
@@ -7607,71 +9020,71 @@ entry:
 ; <label>:83                                      ; preds = %80
   store i32 0, i32* %loc3
   %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
-  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
-  br i1 %NullCheck26, label %88, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i32 addrspace(1)* %87, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %88
 
 ; <label>:88                                      ; preds = %85
   %89 = load i32, i32 addrspace(1)* %87, align 8
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
-  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %90
 
 ; <label>:90                                      ; preds = %88
   %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
   store i32 %89, i32 addrspace(1)* %91
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
-  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
-  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %96
 
 ; <label>:96                                      ; preds = %94
   %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
-  br i1 %NullCheck34, label %100, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %100
 
 ; <label>:100                                     ; preds = %96
   %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
-  br i1 %NullCheck36, label %102, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %102
 
 ; <label>:102                                     ; preds = %100
   %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
   %104 = load i32, i32 addrspace(1)* %103, align 8
   %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
-  br i1 %NullCheck38, label %106, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %106
 
 ; <label>:106                                     ; preds = %102
   %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
-  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
-  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %108
 
 ; <label>:108                                     ; preds = %106
   %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
   %110 = load i32, i32 addrspace(1)* %109, align 8
   %111 = add i32 %104, %110
-  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %112
 
 ; <label>:112                                     ; preds = %108
   %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
   store i32 %111, i32 addrspace(1)* %113
   %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
-  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i32 addrspace(1)* %114, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %115
 
 ; <label>:115                                     ; preds = %112
   %116 = load i32, i32 addrspace(1)* %114, align 8
@@ -7681,19 +9094,19 @@ entry:
 ; <label>:118                                     ; preds = %115
   %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
-  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %121
 
 ; <label>:121                                     ; preds = %118
   %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
-  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
-  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %123
 
 ; <label>:123                                     ; preds = %121
   %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
   %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
-  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
-  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %126
 
 ; <label>:126                                     ; preds = %123
   %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
@@ -7705,8 +9118,8 @@ entry:
 
 ; <label>:130                                     ; preds = %80, %115, %126
   %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %132
 
 ; <label>:132                                     ; preds = %130
   %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7715,8 +9128,8 @@ entry:
   %136 = load i32, i32* %loc3
   %137 = sub i32 %135, %136
   %138 = sub i32 %134, %137
-  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %139
 
 ; <label>:139                                     ; preds = %132
   %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7728,16 +9141,16 @@ entry:
 
 ; <label>:144                                     ; preds = %139
   %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
-  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %146
 
 ; <label>:146                                     ; preds = %144
   %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
   %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
   %149 = load i32, i32* %loc2
   %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
-  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %151
 
 ; <label>:151                                     ; preds = %146
   %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
@@ -7754,145 +9167,249 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %18
+ThrowNullRef4:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %31
+ThrowNullRef10:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %44
+ThrowNullRef16:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %68
+ThrowNullRef18:                                   ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %70
+ThrowNullRef20:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %73
+ThrowNullRef22:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %83
+ThrowNullRef24:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %85
+ThrowNullRef26:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %88
+ThrowNullRef28:                                   ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %90
+ThrowNullRef30:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %94
+ThrowNullRef32:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %96
+ThrowNullRef34:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %100
+ThrowNullRef36:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %102
+ThrowNullRef38:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %106
+ThrowNullRef40:                                   ; preds = %106
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %108
+ThrowNullRef42:                                   ; preds = %108
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %112
+ThrowNullRef44:                                   ; preds = %112
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %118
+ThrowNullRef46:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %121
+ThrowNullRef48:                                   ; preds = %121
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %123
+ThrowNullRef50:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %130
+ThrowNullRef52:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %132
+ThrowNullRef54:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %144
+ThrowNullRef56:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %146
+ThrowNullRef58:                                   ; preds = %146
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %60
+ThrowNullRef60:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %63
+ThrowNullRef62:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %49
+ThrowNullRef64:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %51
+ThrowNullRef66:                                   ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %53
+ThrowNullRef68:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(%"System.Char[]" addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %arg0 = alloca %"System.Char[]" addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store %"System.Char[]" addrspace(1)* %param0, %"System.Char[]" addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load i32, i32* %arg4
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %43, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %38, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg1
+  %13 = load i32, i32* %arg4
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %38, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %24 = load i32, i32* %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %35 = load i32, i32* %arg3
+  %36 = load i32, i32* %arg4
+  %37 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %37, %"System.Char[]" addrspace(1)* %34, i32 %35, i32 %36)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:38                                      ; preds = %5, %16
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Successfully read Buffer._Memmove
 
@@ -7914,7 +9431,7 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[loadElem]
+Failed to read AppDomain.SetDataHelper[storeElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -7923,8 +9440,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
@@ -7934,8 +9451,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
@@ -7947,15 +9464,15 @@ entry:
   %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
   %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
@@ -7966,15 +9483,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7992,7 +9509,79 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
-Failed to read Dictionary`2.TryGetValue[loadElemA]
+Successfully read Dictionary`2.TryGetValue
+
+define i8 @"Dictionary`2.TryGetValue"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)* addrspace(1)* %param2) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  %arg2 = alloca %System.__Canon addrspace(1)* addrspace(1)*
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  store %System.__Canon addrspace(1)* addrspace(1)* %param2, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  store i32 %2, i32* %loc0
+  %3 = load i32, i32* %loc0
+  %4 = icmp slt i32 %3, 0
+  br i1 %4, label %22, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 2
+  %10 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %9, align 8
+  %11 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = zext i32 %11 to i64
+  %BoundsCheck = icmp uge i64 %16, %15
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 3, i32 %11
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %20, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %6, %System.__Canon addrspace(1)* %21)
+  ret i8 1
+
+; <label>:22                                      ; preds = %entry
+  %23 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %23, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -8058,8 +9647,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
@@ -8091,8 +9680,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
@@ -8171,15 +9760,15 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck, label %19, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %ThrowNullRef, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
   %21 = load i32, i32 addrspace(1)* %20
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
@@ -8202,7 +9791,7 @@ ThrowNullRef:                                     ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %19
+ThrowNullRef2:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8248,8 +9837,8 @@ entry:
   %0 = alloca %System.AppDomainHandle
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %1 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %1, i32 0, i32 15
@@ -8269,8 +9858,8 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
@@ -8286,7 +9875,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -8299,8 +9888,8 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -8327,8 +9916,8 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
@@ -8352,8 +9941,8 @@ entry:
   %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
   store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
@@ -8363,8 +9952,8 @@ entry:
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
@@ -8374,8 +9963,8 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %9
   %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
@@ -8384,8 +9973,8 @@ entry:
 
 ; <label>:18                                      ; preds = %3, %16
   %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
@@ -8397,15 +9986,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %18
+ThrowNullRef6:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8418,8 +10007,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
@@ -8453,15 +10042,15 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
@@ -8473,7 +10062,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8481,7 +10070,7 @@ ThrowNullRef1:                                    ; preds = %1
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
 Failed to read Dictionary`2.System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
@@ -8506,8 +10095,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
@@ -8524,8 +10113,8 @@ entry:
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -8544,7 +10133,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8577,8 +10166,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = load i64, i64* %arg2
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = trunc i32 %3 to i8
@@ -8634,46 +10223,46 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
   %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
-  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
-  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
-  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
@@ -8684,27 +10273,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %20
+ThrowNullRef12:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8717,8 +10306,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -8756,22 +10345,22 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
   %9 = load i64, i64 addrspace(1)* %8, align 8
   %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
   %13 = load i64, i64 addrspace(1)* %12, align 8
   %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %11
   %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
@@ -8788,11 +10377,11 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8882,8 +10471,8 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
@@ -8900,8 +10489,8 @@ entry:
 ; <label>:8                                       ; preds = %1
   %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
   %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
@@ -8911,15 +10500,15 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
   %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
   %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
-  br i1 %NullCheck6, label %21, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
@@ -8946,15 +10535,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8992,15 +10581,15 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
   store i8 %3, i8 addrspace(1)* %5
   %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
@@ -9011,7 +10600,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9027,8 +10616,8 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -9041,8 +10630,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
@@ -9058,7 +10647,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9080,8 +10669,8 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
@@ -9096,8 +10685,8 @@ entry:
 ; <label>:12                                      ; preds = %6
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
@@ -9112,8 +10701,8 @@ entry:
 ; <label>:21                                      ; preds = %15
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
@@ -9128,8 +10717,8 @@ entry:
 ; <label>:30                                      ; preds = %24
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %31, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
@@ -9144,8 +10733,8 @@ entry:
 ; <label>:39                                      ; preds = %33
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
-  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %40, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %42
 
 ; <label>:42                                      ; preds = %39
   %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
@@ -9164,19 +10753,19 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %21
+ThrowNullRef4:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %30
+ThrowNullRef6:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %39
+ThrowNullRef8:                                    ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9243,8 +10832,8 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
@@ -9264,57 +10853,57 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
   store i8 0, i8 addrspace(1)* %2
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
   store i8 0, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
   store i8 0, i8 addrspace(1)* %17
   %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
   store i8 0, i8 addrspace(1)* %20
   %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
-  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
@@ -9325,31 +10914,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %19
+ThrowNullRef14:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9367,8 +10956,8 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
@@ -9380,8 +10969,8 @@ entry:
 
 ; <label>:9                                       ; preds = %4
   %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %9
   %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
@@ -9395,7 +10984,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef2:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9420,8 +11009,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
@@ -9512,8 +11101,8 @@ entry:
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
@@ -9524,8 +11113,8 @@ entry:
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = load i64, i64 addrspace(1)* %12
@@ -9537,8 +11126,8 @@ entry:
   %20 = load i64, i64* %19
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
-  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %13
   %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
@@ -9555,8 +11144,8 @@ entry:
 ; <label>:30                                      ; preds = %25
   %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %32 = load i32, i32* %arg2
-  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
-  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
@@ -9570,15 +11159,15 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %30
+ThrowNullRef2:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9622,87 +11211,87 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
   %10 = load i8, i8 addrspace(1)* %9, align 8
   %11 = zext i8 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %8
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
   store i8 %12, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
   %19 = load i8, i8 addrspace(1)* %18, align 8
   %20 = zext i8 %19 to i32
   %21 = trunc i32 %20 to i8
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
   store i8 %21, i8 addrspace(1)* %23
   %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
   %28 = load i8, i8 addrspace(1)* %27, align 8
   %29 = zext i8 %28 to i32
   %30 = trunc i32 %29 to i8
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
-  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %31
 
 ; <label>:31                                      ; preds = %26
   %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
   store i8 %30, i8 addrspace(1)* %32
   %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
-  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
-  br i1 %NullCheck14, label %40, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %40
 
 ; <label>:40                                      ; preds = %35
   %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
   store i8 %39, i8 addrspace(1)* %41
   %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
-  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %44
 
 ; <label>:44                                      ; preds = %40
   %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
   %46 = load i8, i8 addrspace(1)* %45, align 8
   %47 = zext i8 %46 to i32
   %48 = trunc i32 %47 to i8
-  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
   store i8 %48, i8 addrspace(1)* %50
   %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
-  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
@@ -9713,29 +11302,29 @@ entry:
 ; <label>:56                                      ; preds = %52
   %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
-  br i1 %NullCheck22, label %59, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
   %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
   %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
-  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
-  br i1 %NullCheck24, label %63, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
   %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
-  br i1 %NullCheck26, label %66, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
   %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
-  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
-  br i1 %NullCheck28, label %69, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %69
 
 ; <label>:69                                      ; preds = %66
   %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
@@ -9744,15 +11333,15 @@ entry:
 
 ; <label>:71                                      ; preds = %105
   %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
-  br i1 %NullCheck34, label %73, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %73
 
 ; <label>:73                                      ; preds = %71
   %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
   %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
   %76 = load i32, i32* %loc0
-  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
-  br i1 %NullCheck36, label %77, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
@@ -9766,8 +11355,8 @@ entry:
 
 ; <label>:83                                      ; preds = %77
   %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
-  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
@@ -9775,14 +11364,14 @@ entry:
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
   %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
-  br i1 %NullCheck40, label %91, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
 ; <label>:91                                      ; preds = %85
   %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
   %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
-  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck42, label %94, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %94
 
 ; <label>:94                                      ; preds = %91
   %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
@@ -9798,14 +11387,14 @@ entry:
 ; <label>:99                                      ; preds = %69, %96
   %100 = load i32, i32* %loc0
   %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
-  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %102
 
 ; <label>:102                                     ; preds = %99
   %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
   %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
-  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
-  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
@@ -9819,87 +11408,87 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %26
+ThrowNullRef10:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %31
+ThrowNullRef12:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %35
+ThrowNullRef14:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %40
+ThrowNullRef16:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %56
+ThrowNullRef22:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %59
+ThrowNullRef24:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %63
+ThrowNullRef26:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %66
+ThrowNullRef28:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %102
+ThrowNullRef32:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %71
+ThrowNullRef34:                                   ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %73
+ThrowNullRef36:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %83
+ThrowNullRef38:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %85
+ThrowNullRef40:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %91
+ThrowNullRef42:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9943,15 +11532,15 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
   %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
@@ -9961,28 +11550,28 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
   %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %12
   %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
   %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
   %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
-  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
@@ -9993,23 +11582,23 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %12
+ThrowNullRef6:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10031,15 +11620,15 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
   %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = load i64, i64 addrspace(1)* %7
@@ -10077,13 +11666,13 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[loadElem]
+Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -10111,8 +11700,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -10205,7 +11794,7 @@ entry:
 INFO:  jitting method BringUpTest::print using LLILCJit
 Failed to read BringUpTest.print[storeElem]
 INFO:  jitting method String::Concat using LLILCJit
-Failed to read String.Concat[loadElem]
+Failed to read String.Concat[storeElem]
 INFO:  jitting method String::ToString using LLILCJit
 Successfully read String.ToString
 
@@ -10226,8 +11815,8 @@ entry:
   store %System.Int32 addrspace(1)* %param0, %System.Int32 addrspace(1)** %this
   %0 = load %System.Int32 addrspace(1)*, %System.Int32 addrspace(1)** %this
   %1 = bitcast %System.Int32 addrspace(1)* %0 to i32 addrspace(1)*
-  %NullCheck = icmp ne i32 addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq i32 addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load i32, i32 addrspace(1)* %1, align 8
@@ -10430,8 +12019,8 @@ entry:
   %loc0 = alloca %System.Globalization.NumberFormatInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 3
@@ -10441,8 +12030,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
@@ -10452,24 +12041,24 @@ entry:
   store %System.Globalization.NumberFormatInfo addrspace(1)* %10, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
   %11 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %7
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
   %15 = load i8, i8 addrspace(1)* %14, align 8
   %16 = zext i8 %15 to i32
   %17 = trunc i32 %16 to i8
-  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %11, null
-  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %11, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %13
   %19 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %11, i32 0, i32 29
   store i8 %17, i8 addrspace(1)* %19
   %20 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %21 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %20, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %20, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %18
   %23 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %20, i32 0, i32 3
@@ -10478,8 +12067,8 @@ entry:
 
 ; <label>:24                                      ; preds = %1, %22
   %25 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %25, null
-  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %25, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %26
 
 ; <label>:26                                      ; preds = %24
   %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %25, i32 0, i32 3
@@ -10490,23 +12079,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %18
+ThrowNullRef8:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10531,168 +12120,168 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 18
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %8, align 8
-  %NullCheck2 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %5, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %5, i32 0, i32 4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %9)
   %12 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 19
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %15, align 8
-  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %12, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %12, i32 0, i32 5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %16)
   %19 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %20 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %20, null
-  br i1 %NullCheck8, label %21, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %20, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %20, i32 0, i32 23
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  %NullCheck10 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %19, null
-  br i1 %NullCheck10, label %24, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %19, i32 0, i32 7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %25, %System.String addrspace(1)* %23)
   %26 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %27 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %27, i32 0, i32 22
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %29, align 8
-  %NullCheck14 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %26, null
-  br i1 %NullCheck14, label %31, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %26, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %26, i32 0, i32 6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %32, %System.String addrspace(1)* %30)
   %33 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %34 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Globalization.CultureData addrspace(1)* %34, null
-  br i1 %NullCheck16, label %35, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Globalization.CultureData addrspace(1)* %34, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %34, i32 0, i32 51
   %37 = load i32, i32 addrspace(1)* %36, align 8
-  %NullCheck18 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %33, null
-  br i1 %NullCheck18, label %38, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %33, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %33, i32 0, i32 21
   store i32 %37, i32 addrspace(1)* %39
   %40 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %41 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Globalization.CultureData addrspace(1)* %41, null
-  br i1 %NullCheck20, label %42, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Globalization.CultureData addrspace(1)* %41, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %41, i32 0, i32 52
   %44 = load i32, i32 addrspace(1)* %43, align 8
-  %NullCheck22 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %40, null
-  br i1 %NullCheck22, label %45, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %40, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %40, i32 0, i32 25
   store i32 %44, i32 addrspace(1)* %46
   %47 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %48 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.Globalization.CultureData addrspace(1)* %48, null
-  br i1 %NullCheck24, label %49, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Globalization.CultureData addrspace(1)* %48, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %49
 
 ; <label>:49                                      ; preds = %45
   %50 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %48, i32 0, i32 29
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck26 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %47, null
-  br i1 %NullCheck26, label %52, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %47, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %47, i32 0, i32 10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %53, %System.String addrspace(1)* %51)
   %54 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %55 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Globalization.CultureData addrspace(1)* %55, null
-  br i1 %NullCheck28, label %56, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Globalization.CultureData addrspace(1)* %55, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %56
 
 ; <label>:56                                      ; preds = %52
   %57 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %55, i32 0, i32 35
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %57, align 8
-  %NullCheck30 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %54, null
-  br i1 %NullCheck30, label %59, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %54, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %54, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %60, %System.String addrspace(1)* %58)
   %61 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %62 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck32 = icmp ne %System.Globalization.CultureData addrspace(1)* %62, null
-  br i1 %NullCheck32, label %63, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Globalization.CultureData addrspace(1)* %62, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %62, i32 0, i32 34
   %65 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %64, align 8
-  %NullCheck34 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %61, null
-  br i1 %NullCheck34, label %66, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %61, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %61, i32 0, i32 9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %67, %System.String addrspace(1)* %65)
   %68 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %69 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck36 = icmp ne %System.Globalization.CultureData addrspace(1)* %69, null
-  br i1 %NullCheck36, label %70, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Globalization.CultureData addrspace(1)* %69, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %70
 
 ; <label>:70                                      ; preds = %66
   %71 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %69, i32 0, i32 55
   %72 = load i32, i32 addrspace(1)* %71, align 8
-  %NullCheck38 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %68, null
-  br i1 %NullCheck38, label %73, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %68, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %68, i32 0, i32 22
   store i32 %72, i32 addrspace(1)* %74
   %75 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %76 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck40 = icmp ne %System.Globalization.CultureData addrspace(1)* %76, null
-  br i1 %NullCheck40, label %77, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Globalization.CultureData addrspace(1)* %76, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %76, i32 0, i32 57
   %79 = load i32, i32 addrspace(1)* %78, align 8
-  %NullCheck42 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %75, null
-  br i1 %NullCheck42, label %80, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %75, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %80
 
 ; <label>:80                                      ; preds = %77
   %81 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %75, i32 0, i32 24
   store i32 %79, i32 addrspace(1)* %81
   %82 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %83 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck44 = icmp ne %System.Globalization.CultureData addrspace(1)* %83, null
-  br i1 %NullCheck44, label %84, label %ThrowNullRef43
+  %NullCheck43 = icmp eq %System.Globalization.CultureData addrspace(1)* %83, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %84
 
 ; <label>:84                                      ; preds = %80
   %85 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %83, i32 0, i32 56
   %86 = load i32, i32 addrspace(1)* %85, align 8
-  %NullCheck46 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %82, null
-  br i1 %NullCheck46, label %87, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %82, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %82, i32 0, i32 23
@@ -10701,8 +12290,8 @@ entry:
 
 ; <label>:89                                      ; preds = %entry
   %90 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck100 = icmp ne %System.Globalization.CultureData addrspace(1)* %90, null
-  br i1 %NullCheck100, label %91, label %ThrowNullRef99
+  %NullCheck99 = icmp eq %System.Globalization.CultureData addrspace(1)* %90, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %91
 
 ; <label>:91                                      ; preds = %89
   %92 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %90, i32 0, i32 2
@@ -10720,8 +12309,8 @@ entry:
   %102 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %103 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %104 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %103)
-  %NullCheck48 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %102, null
-  br i1 %NullCheck48, label %105, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %102, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %105
 
 ; <label>:105                                     ; preds = %101
   %106 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %102, i32 0, i32 1
@@ -10729,8 +12318,8 @@ entry:
   %107 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %108 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %109 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %108)
-  %NullCheck50 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %107, null
-  br i1 %NullCheck50, label %110, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %107, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %110
 
 ; <label>:110                                     ; preds = %105
   %111 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %107, i32 0, i32 2
@@ -10738,8 +12327,8 @@ entry:
   %112 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %113 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %114 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %113)
-  %NullCheck52 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %112, null
-  br i1 %NullCheck52, label %115, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %112, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %115
 
 ; <label>:115                                     ; preds = %110
   %116 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %112, i32 0, i32 27
@@ -10747,8 +12336,8 @@ entry:
   %117 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %118 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %119 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %118)
-  %NullCheck54 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %117, null
-  br i1 %NullCheck54, label %120, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %117, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %120
 
 ; <label>:120                                     ; preds = %115
   %121 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %117, i32 0, i32 26
@@ -10756,8 +12345,8 @@ entry:
   %122 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %123 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %124 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %123)
-  %NullCheck56 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %122, null
-  br i1 %NullCheck56, label %125, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %122, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %125
 
 ; <label>:125                                     ; preds = %120
   %126 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %122, i32 0, i32 17
@@ -10765,8 +12354,8 @@ entry:
   %127 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %128 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %129 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %128)
-  %NullCheck58 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %127, null
-  br i1 %NullCheck58, label %130, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %127, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %130
 
 ; <label>:130                                     ; preds = %125
   %131 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %127, i32 0, i32 18
@@ -10774,8 +12363,8 @@ entry:
   %132 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %133 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %134 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %133)
-  %NullCheck60 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %132, null
-  br i1 %NullCheck60, label %135, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %132, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %135
 
 ; <label>:135                                     ; preds = %130
   %136 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %132, i32 0, i32 14
@@ -10783,8 +12372,8 @@ entry:
   %137 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %138 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %139 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %138)
-  %NullCheck62 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %137, null
-  br i1 %NullCheck62, label %140, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %137, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %140
 
 ; <label>:140                                     ; preds = %135
   %141 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %137, i32 0, i32 13
@@ -10792,71 +12381,71 @@ entry:
   %142 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %143 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %144 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %143)
-  %NullCheck64 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %142, null
-  br i1 %NullCheck64, label %145, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %142, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %145
 
 ; <label>:145                                     ; preds = %140
   %146 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %142, i32 0, i32 12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %146, %System.String addrspace(1)* %144)
   %147 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %148 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck66 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %148, null
-  br i1 %NullCheck66, label %149, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %148, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %149
 
 ; <label>:149                                     ; preds = %145
   %150 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %148, i32 0, i32 21
   %151 = load i32, i32 addrspace(1)* %150, align 8
-  %NullCheck68 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %147, null
-  br i1 %NullCheck68, label %152, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %147, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %152
 
 ; <label>:152                                     ; preds = %149
   %153 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %147, i32 0, i32 28
   store i32 %151, i32 addrspace(1)* %153
   %154 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %155 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck70 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %155, null
-  br i1 %NullCheck70, label %156, label %ThrowNullRef69
+  %NullCheck69 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %155, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %156
 
 ; <label>:156                                     ; preds = %152
   %157 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %155, i32 0, i32 6
   %158 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %157, align 8
-  %NullCheck72 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %154, null
-  br i1 %NullCheck72, label %159, label %ThrowNullRef71
+  %NullCheck71 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %154, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %159
 
 ; <label>:159                                     ; preds = %156
   %160 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %154, i32 0, i32 15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %160, %System.String addrspace(1)* %158)
   %161 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %162 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck74 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %162, null
-  br i1 %NullCheck74, label %163, label %ThrowNullRef73
+  %NullCheck73 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %162, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %163
 
 ; <label>:163                                     ; preds = %159
   %164 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %162, i32 0, i32 1
   %165 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %164, align 8
-  %NullCheck76 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %161, null
-  br i1 %NullCheck76, label %166, label %ThrowNullRef75
+  %NullCheck75 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %161, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %166
 
 ; <label>:166                                     ; preds = %163
   %167 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %161, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %167, %"System.Int32[]" addrspace(1)* %165)
   %168 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %169 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck78 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %169, null
-  br i1 %NullCheck78, label %170, label %ThrowNullRef77
+  %NullCheck77 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %169, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %170
 
 ; <label>:170                                     ; preds = %166
   %171 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %169, i32 0, i32 7
   %172 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %171, align 8
-  %NullCheck80 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %168, null
-  br i1 %NullCheck80, label %173, label %ThrowNullRef79
+  %NullCheck79 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %168, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %173
 
 ; <label>:173                                     ; preds = %170
   %174 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %168, i32 0, i32 16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %174, %System.String addrspace(1)* %172)
   %175 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck82 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %175, null
-  br i1 %NullCheck82, label %176, label %ThrowNullRef81
+  %NullCheck81 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %175, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %176
 
 ; <label>:176                                     ; preds = %173
   %177 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %175, i32 0, i32 4
@@ -10866,14 +12455,14 @@ entry:
 
 ; <label>:180                                     ; preds = %176
   %181 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck84 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %181, null
-  br i1 %NullCheck84, label %182, label %ThrowNullRef83
+  %NullCheck83 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %181, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %182
 
 ; <label>:182                                     ; preds = %180
   %183 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %181, i32 0, i32 4
   %184 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %183, align 8
-  %NullCheck86 = icmp ne %System.String addrspace(1)* %184, null
-  br i1 %NullCheck86, label %185, label %ThrowNullRef85
+  %NullCheck85 = icmp eq %System.String addrspace(1)* %184, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %185
 
 ; <label>:185                                     ; preds = %182
   %186 = getelementptr inbounds %System.String, %System.String addrspace(1)* %184, i32 0, i32 1
@@ -10884,8 +12473,8 @@ entry:
 ; <label>:189                                     ; preds = %176, %185
   %190 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck98 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %190, null
-  br i1 %NullCheck98, label %192, label %ThrowNullRef97
+  %NullCheck97 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %190, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %192
 
 ; <label>:192                                     ; preds = %189
   %193 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %190, i32 0, i32 4
@@ -10894,8 +12483,8 @@ entry:
 
 ; <label>:194                                     ; preds = %185, %192
   %195 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck88 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %195, null
-  br i1 %NullCheck88, label %196, label %ThrowNullRef87
+  %NullCheck87 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %195, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %196
 
 ; <label>:196                                     ; preds = %194
   %197 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %195, i32 0, i32 9
@@ -10905,14 +12494,14 @@ entry:
 
 ; <label>:200                                     ; preds = %196
   %201 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck90 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %201, null
-  br i1 %NullCheck90, label %202, label %ThrowNullRef89
+  %NullCheck89 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %201, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %202
 
 ; <label>:202                                     ; preds = %200
   %203 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %201, i32 0, i32 9
   %204 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %203, align 8
-  %NullCheck92 = icmp ne %System.String addrspace(1)* %204, null
-  br i1 %NullCheck92, label %205, label %ThrowNullRef91
+  %NullCheck91 = icmp eq %System.String addrspace(1)* %204, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %205
 
 ; <label>:205                                     ; preds = %202
   %206 = getelementptr inbounds %System.String, %System.String addrspace(1)* %204, i32 0, i32 1
@@ -10923,14 +12512,14 @@ entry:
 ; <label>:209                                     ; preds = %196, %205
   %210 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %211 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck94 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %211, null
-  br i1 %NullCheck94, label %212, label %ThrowNullRef93
+  %NullCheck93 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %211, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %212
 
 ; <label>:212                                     ; preds = %209
   %213 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %211, i32 0, i32 6
   %214 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %213, align 8
-  %NullCheck96 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %210, null
-  br i1 %NullCheck96, label %215, label %ThrowNullRef95
+  %NullCheck95 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %210, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %215
 
 ; <label>:215                                     ; preds = %212
   %216 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %210, i32 0, i32 9
@@ -10944,203 +12533,203 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %17
+ThrowNullRef8:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %21
+ThrowNullRef10:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %24
+ThrowNullRef12:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %28
+ThrowNullRef14:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %31
+ThrowNullRef16:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %35
+ThrowNullRef18:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %38
+ThrowNullRef20:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %42
+ThrowNullRef22:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %45
+ThrowNullRef24:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %49
+ThrowNullRef26:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %52
+ThrowNullRef28:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %56
+ThrowNullRef30:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %59
+ThrowNullRef32:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %63
+ThrowNullRef34:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %66
+ThrowNullRef36:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %70
+ThrowNullRef38:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %73
+ThrowNullRef40:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %77
+ThrowNullRef42:                                   ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %80
+ThrowNullRef44:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %84
+ThrowNullRef46:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %101
+ThrowNullRef48:                                   ; preds = %101
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %105
+ThrowNullRef50:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %110
+ThrowNullRef52:                                   ; preds = %110
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %115
+ThrowNullRef54:                                   ; preds = %115
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %120
+ThrowNullRef56:                                   ; preds = %120
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %125
+ThrowNullRef58:                                   ; preds = %125
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %130
+ThrowNullRef60:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %135
+ThrowNullRef62:                                   ; preds = %135
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %140
+ThrowNullRef64:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %145
+ThrowNullRef66:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %149
+ThrowNullRef68:                                   ; preds = %149
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %152
+ThrowNullRef70:                                   ; preds = %152
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %156
+ThrowNullRef72:                                   ; preds = %156
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %159
+ThrowNullRef74:                                   ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %163
+ThrowNullRef76:                                   ; preds = %163
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %166
+ThrowNullRef78:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %170
+ThrowNullRef80:                                   ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %173
+ThrowNullRef82:                                   ; preds = %173
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %180
+ThrowNullRef84:                                   ; preds = %180
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %182
+ThrowNullRef86:                                   ; preds = %182
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %194
+ThrowNullRef88:                                   ; preds = %194
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %200
+ThrowNullRef90:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %202
+ThrowNullRef92:                                   ; preds = %202
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %209
+ThrowNullRef94:                                   ; preds = %209
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %212
+ThrowNullRef96:                                   ; preds = %212
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %189
+ThrowNullRef98:                                   ; preds = %189
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %89
+ThrowNullRef100:                                  ; preds = %89
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11168,8 +12757,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 21
@@ -11182,8 +12771,8 @@ entry:
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 16)
   %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 21
@@ -11192,8 +12781,8 @@ entry:
 
 ; <label>:12                                      ; preds = %1, %10
   %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 21
@@ -11204,11 +12793,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %12
+ThrowNullRef4:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11224,8 +12813,8 @@ entry:
   store i32 %param1, i32* %arg1
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %1 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
@@ -11292,8 +12881,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 33
@@ -11306,8 +12895,8 @@ entry:
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 24)
   %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 33
@@ -11316,8 +12905,8 @@ entry:
 
 ; <label>:12                                      ; preds = %1, %10
   %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 33
@@ -11328,11 +12917,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %12
+ThrowNullRef4:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11345,8 +12934,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 53
@@ -11358,8 +12947,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 116)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 53
@@ -11368,8 +12957,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 53
@@ -11380,11 +12969,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11413,8 +13002,8 @@ entry:
 
 ; <label>:7                                       ; preds = %entry, %4
   %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %7
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 2
@@ -11438,8 +13027,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 54
@@ -11451,8 +13040,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 117)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
@@ -11461,8 +13050,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 54
@@ -11473,11 +13062,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11490,8 +13079,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 27
@@ -11503,8 +13092,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 118)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 27
@@ -11513,8 +13102,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 27
@@ -11525,11 +13114,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11542,8 +13131,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 28
@@ -11555,8 +13144,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 119)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 28
@@ -11565,8 +13154,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 28
@@ -11577,11 +13166,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11594,8 +13183,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 26
@@ -11607,8 +13196,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 107)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 26
@@ -11617,8 +13206,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 26
@@ -11629,11 +13218,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11646,8 +13235,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 25
@@ -11659,8 +13248,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 106)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 25
@@ -11669,8 +13258,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 25
@@ -11681,11 +13270,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11698,8 +13287,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 24
@@ -11711,8 +13300,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 105)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 24
@@ -11721,8 +13310,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 24
@@ -11733,17 +13322,127 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method String::ConcatArray using LLILCJit
-Failed to read String.ConcatArray[loadElem]
+Successfully read String.ConcatArray
+
+define %System.String addrspace(1)* @String.ConcatArray(%"System.String[]" addrspace(1)* %param0, i32 %param1) {
+entry:
+  %arg0 = alloca %"System.String[]" addrspace(1)*
+  %arg1 = alloca i32
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store %"System.String[]" addrspace(1)* %param0, %"System.String[]" addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  %0 = load i32, i32* %arg1
+  %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %0)
+  store %System.String addrspace(1)* %1, %System.String addrspace(1)** %loc0
+  store i32 0, i32* %loc1
+  store i32 0, i32* %loc2
+  br label %32
+
+; <label>:2                                       ; preds = %35
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %4 = load i32, i32* %loc1
+  %5 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)** %arg0
+  %6 = load i32, i32* %loc2
+  %NullCheck1 = icmp eq %"System.String[]" addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
+
+; <label>:7                                       ; preds = %2
+  %8 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %5, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  %10 = zext i32 %9 to i64
+  %11 = zext i32 %6 to i64
+  %BoundsCheck = icmp uge i64 %11, %10
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %12
+
+; <label>:12                                      ; preds = %7
+  %13 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %5, i32 0, i32 3, i32 %6
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %3, i32 %4, %System.String addrspace(1)* %14)
+  %15 = load i32, i32* %loc1
+  %16 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)** %arg0
+  %17 = load i32, i32* %loc2
+  %NullCheck3 = icmp eq %"System.String[]" addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %18
+
+; <label>:18                                      ; preds = %12
+  %19 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %16, i32 0, i32 1
+  %20 = load i32, i32 addrspace(1)* %19
+  %21 = zext i32 %20 to i64
+  %22 = zext i32 %17 to i64
+  %BoundsCheck5 = icmp uge i64 %22, %21
+  br i1 %BoundsCheck5, label %ThrowIndexOutOfRange6, label %23
+
+; <label>:23                                      ; preds = %18
+  %24 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %16, i32 0, i32 3, i32 %17
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %24, align 8
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %28 = load i32, i32 addrspace(1)* %27
+  %29 = add i32 %15, %28
+  store i32 %29, i32* %loc1
+  %30 = load i32, i32* %loc2
+  %31 = add i32 %30, 1
+  store i32 %31, i32* %loc2
+  br label %32
+
+; <label>:32                                      ; preds = %entry, %26
+  %33 = load i32, i32* %loc2
+  %34 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)** %arg0
+  %NullCheck = icmp eq %"System.String[]" addrspace(1)* %34, null
+  br i1 %NullCheck, label %ThrowNullRef, label %35
+
+; <label>:35                                      ; preds = %32
+  %36 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %34, i32 0, i32 1
+  %37 = load i32, i32 addrspace(1)* %36
+  %38 = zext i32 %37 to i64
+  %39 = trunc i64 %38 to i32
+  %40 = icmp slt i32 %33, %39
+  br i1 %40, label %2, label %41
+
+; <label>:41                                      ; preds = %35
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  ret %System.String addrspace(1)* %42
+
+ThrowNullRef:                                     ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange6:                            ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Console::WriteLine using LLILCJit
 Successfully read Console.WriteLine
 
@@ -11754,8 +13453,8 @@ entry:
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -11889,8 +13588,8 @@ entry:
   store i64 %param0, i64* %arg0
   store i64 %param1, i64* %arg1
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
@@ -11898,8 +13597,8 @@ entry:
   %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
   %5 = load i16*, i16* addrspace(1)* %4, align 8
   %6 = addrspacecast i64* %arg1 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = bitcast i64 addrspace(1)* %6 to i8 addrspace(1)*
@@ -11915,7 +13614,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11949,8 +13648,8 @@ entry:
   %1 = load i32, i32* %arg1
   %2 = sext i32 %1 to i64
   %3 = inttoptr i64 %2 to i16*
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -12003,8 +13702,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, i32)*)(%System.IO.ConsoleStream addrspace(1)* %2, i32 %1)
   %3 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %4 = load i64, i64* %arg1
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
@@ -12015,8 +13714,8 @@ entry:
   %10 = icmp eq i32 %9, 3
   %11 = sext i1 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %5
   %14 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, i32 0, i32 5
@@ -12027,7 +13726,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12050,8 +13749,8 @@ entry:
   %5 = icmp eq i32 %4, 1
   %6 = sext i1 %5 to i32
   %7 = trunc i32 %6 to i8
-  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %2, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.ConsoleStream addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
@@ -12062,8 +13761,8 @@ entry:
   %13 = icmp eq i32 %12, 2
   %14 = sext i1 %13 to i32
   %15 = trunc i32 %14 to i8
-  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %10, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.ConsoleStream addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %8
   %17 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %10, i32 0, i32 4
@@ -12074,7 +13773,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12113,8 +13812,8 @@ entry:
   %arg0 = alloca i64
   store i64 %param0, i64* %arg0
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
@@ -12149,8 +13848,8 @@ entry:
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
   %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = load i64, i64 addrspace(1)* %7
@@ -12254,7 +13953,127 @@ entry:
 INFO:  jitting method Encoding::GetEncoding using LLILCJit
 Failed to read Encoding.GetEncoding[convertToHelperArgumentType]
 INFO:  jitting method EncodingProvider::GetEncodingFromProvider using LLILCJit
-Failed to read EncodingProvider.GetEncodingFromProvider[loadElem]
+Successfully read EncodingProvider.GetEncodingFromProvider
+
+define %System.Text.Encoding addrspace(1)* @EncodingProvider.GetEncodingFromProvider(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca %"System.Text.EncodingProvider[]" addrspace(1)*
+  %loc1 = alloca %System.Text.EncodingProvider addrspace(1)*
+  %loc2 = alloca %System.Text.Encoding addrspace(1)*
+  %loc3 = alloca %System.Text.Encoding addrspace(1)*
+  %loc4 = alloca %"System.Text.EncodingProvider[]" addrspace(1)*
+  %loc5 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1059)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2392
+  %2 = addrspacecast i8 addrspace(1)* %1 to %"System.Text.EncodingProvider[]" addrspace(1)**
+  %3 = load volatile %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %2
+  %4 = icmp ne %"System.Text.EncodingProvider[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %entry
+  ret %System.Text.Encoding addrspace(1)* null
+
+; <label>:6                                       ; preds = %entry
+  %7 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1059)
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i64 2392
+  %9 = addrspacecast i8 addrspace(1)* %8 to %"System.Text.EncodingProvider[]" addrspace(1)**
+  %10 = load volatile %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %9
+  store %"System.Text.EncodingProvider[]" addrspace(1)* %10, %"System.Text.EncodingProvider[]" addrspace(1)** %loc0
+  %11 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc0
+  store %"System.Text.EncodingProvider[]" addrspace(1)* %11, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  store i32 0, i32* %loc5
+  br label %43
+
+; <label>:12                                      ; preds = %46
+  %13 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  %14 = load i32, i32* %loc5
+  %NullCheck1 = icmp eq %"System.Text.EncodingProvider[]" addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %13, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = zext i32 %17 to i64
+  %19 = zext i32 %14 to i64
+  %BoundsCheck = icmp uge i64 %19, %18
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %20
+
+; <label>:20                                      ; preds = %15
+  %21 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %13, i32 0, i32 3, i32 %14
+  %22 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)* addrspace(1)* %21, align 8
+  store %System.Text.EncodingProvider addrspace(1)* %22, %System.Text.EncodingProvider addrspace(1)** %loc1
+  %23 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)** %loc1
+  %24 = load i32, i32* %arg0
+  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i64 addrspace(1)*
+  %NullCheck3 = icmp eq i64 addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
+
+; <label>:26                                      ; preds = %20
+  %27 = load i64, i64 addrspace(1)* %25
+  %28 = add i64 %27, 64
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 40
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Text.Encoding addrspace(1)* (%System.Text.EncodingProvider addrspace(1)*, i32)*
+  %35 = call %System.Text.Encoding addrspace(1)* %34(%System.Text.EncodingProvider addrspace(1)* %23, i32 %24)
+  store %System.Text.Encoding addrspace(1)* %35, %System.Text.Encoding addrspace(1)** %loc2
+  %36 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc2
+  %37 = icmp eq %System.Text.Encoding addrspace(1)* %36, null
+  br i1 %37, label %40, label %38
+
+; <label>:38                                      ; preds = %26
+  %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc2
+  store %System.Text.Encoding addrspace(1)* %39, %System.Text.Encoding addrspace(1)** %loc3
+  br label %53
+
+; <label>:40                                      ; preds = %26
+  %41 = load i32, i32* %loc5
+  %42 = add i32 %41, 1
+  store i32 %42, i32* %loc5
+  br label %43
+
+; <label>:43                                      ; preds = %6, %40
+  %44 = load i32, i32* %loc5
+  %45 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  %NullCheck = icmp eq %"System.Text.EncodingProvider[]" addrspace(1)* %45, null
+  br i1 %NullCheck, label %ThrowNullRef, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp slt i32 %44, %50
+  br i1 %51, label %12, label %52
+
+; <label>:52                                      ; preds = %46
+  ret %System.Text.Encoding addrspace(1)* null
+
+; <label>:53                                      ; preds = %38
+  %54 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc3
+  ret %System.Text.Encoding addrspace(1)* %54
+
+ThrowNullRef:                                     ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method EncodingProvider::.cctor using LLILCJit
 Successfully read EncodingProvider..cctor
 
@@ -12273,7 +14092,7 @@ Failed to read Encoding.get_InternalSyncObject[Call HasTypeArg]
 INFO:  jitting method Hashtable::.ctor using LLILCJit
 Failed to read Hashtable..ctor[Volatile store]
 INFO:  jitting method Hashtable::get_Item using LLILCJit
-Failed to read Hashtable.get_Item[loadElemA]
+Failed to read Hashtable.get_Item[loadNonPrimitiveObj]
 INFO:  jitting method Hashtable::InitHash using LLILCJit
 Successfully read Hashtable.InitHash
 
@@ -12293,8 +14112,8 @@ entry:
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -12310,15 +14129,15 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
   %15 = load i32, i32* %loc0
-  %NullCheck2 = icmp ne i32 addrspace(1)* %14, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i32 addrspace(1)* %14, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %3
   store i32 %15, i32 addrspace(1)* %14, align 8
   %17 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %18 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %NullCheck4 = icmp ne i32 addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i32 addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = load i32, i32 addrspace(1)* %18, align 8
@@ -12327,8 +14146,8 @@ entry:
   %23 = sub i32 %22, 1
   %24 = urem i32 %21, %23
   %25 = add i32 1, %24
-  %NullCheck6 = icmp ne i32 addrspace(1)* %17, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32 addrspace(1)* %17, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %19
   store i32 %25, i32 addrspace(1)* %17, align 8
@@ -12339,15 +14158,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %19
+ThrowNullRef6:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12362,8 +14181,8 @@ entry:
   store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
   store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %NullCheck = icmp ne %System.Collections.Hashtable addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Collections.Hashtable addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
@@ -12373,16 +14192,16 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Collections.Hashtable addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Collections.Hashtable addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
   %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck4 = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %9, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
   %13 = inttoptr i64 %11 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
@@ -12392,8 +14211,8 @@ entry:
 ; <label>:15                                      ; preds = %1
   %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -12411,15 +14230,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12433,8 +14252,8 @@ entry:
   store %System.Int32 addrspace(1)* %param0, %System.Int32 addrspace(1)** %this
   %0 = load %System.Int32 addrspace(1)*, %System.Int32 addrspace(1)** %this
   %1 = bitcast %System.Int32 addrspace(1)* %0 to i32 addrspace(1)*
-  %NullCheck = icmp ne i32 addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq i32 addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load i32, i32 addrspace(1)* %1, align 8
@@ -12510,8 +14329,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.UTF8Encoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
@@ -12520,15 +14339,15 @@ entry:
   %9 = load i8, i8* %arg2
   %10 = zext i8 %9 to i32
   %11 = trunc i32 %10 to i8
-  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %8, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %6
   %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %8, i32 0, i32 8
   store i8 %11, i8 addrspace(1)* %13
   %14 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %14, i32 0, i32 8
@@ -12540,8 +14359,8 @@ entry:
 ; <label>:20                                      ; preds = %15
   %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %22, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %22, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = load i64, i64 addrspace(1)* %22
@@ -12563,15 +14382,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %12
+ThrowNullRef4:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12586,8 +14405,8 @@ entry:
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
@@ -12609,16 +14428,16 @@ entry:
 ; <label>:10                                      ; preds = %1
   %11 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
   %12 = load i32, i32* %arg1
-  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %11, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.Encoding addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
   store i32 %12, i32 addrspace(1)* %14
   %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
   %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = load i64, i64 addrspace(1)* %16
@@ -12636,11 +14455,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12653,8 +14472,8 @@ entry:
   %this = alloca %System.Text.UTF8Encoding addrspace(1)*
   store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
   %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.UTF8Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
@@ -12666,16 +14485,16 @@ entry:
 ; <label>:6                                       ; preds = %1
   %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %8 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %10, %System.Text.EncoderFallback addrspace(1)* %8)
   %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %12 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
-  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %11, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %11, i32 0, i32 3
@@ -12688,8 +14507,8 @@ entry:
   %18 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %18, %System.String addrspace(1)* %17)
   %19 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %18 to %System.Text.EncoderFallback addrspace(1)*
-  %NullCheck6 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %16, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %16, i32 0, i32 2
@@ -12699,8 +14518,8 @@ entry:
   %24 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %24, %System.String addrspace(1)* %23)
   %25 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %24 to %System.Text.DecoderFallback addrspace(1)*
-  %NullCheck8 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %22, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %22, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %20
   %27 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %22, i32 0, i32 3
@@ -12711,19 +14530,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %20
+ThrowNullRef8:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12753,8 +14572,8 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load i32, i32* %arg1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -12772,8 +14591,8 @@ entry:
 ; <label>:15                                      ; preds = %8
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %17 = load i32, i32* %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 %17
@@ -12789,7 +14608,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12841,7 +14660,7 @@ entry:
 }
 
 INFO:  jitting method Hashtable::Insert using LLILCJit
-Failed to read Hashtable.Insert[loadElemA]
+Failed to read Hashtable.Insert[storeElem]
 INFO:  jitting method ConsoleEncoding::.ctor using LLILCJit
 Successfully read ConsoleEncoding..ctor
 
@@ -12856,8 +14675,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %1)
   %2 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
@@ -12893,8 +14712,8 @@ entry:
   %2 = call %System.Text.InternalEncoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalEncoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %1)
   %3 = bitcast %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2 to %System.Text.EncoderFallback addrspace(1)*
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
@@ -12904,8 +14723,8 @@ entry:
   %8 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %7)
   %9 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %8 to %System.Text.DecoderFallback addrspace(1)*
-  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %6, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.Encoding addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %4
   %11 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %6, i32 0, i32 3
@@ -12916,7 +14735,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12935,15 +14754,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* %1)
   %2 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   %6 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, i32 0, i32 1
@@ -12954,7 +14773,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12982,8 +14801,8 @@ entry:
   store %System.Text.InternalDecoderBestFitFallback addrspace(1)* %param0, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
   %0 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
@@ -12993,15 +14812,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %4)
   %5 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %6)
   %9 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, i32 0, i32 1
@@ -13012,11 +14831,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13084,8 +14903,8 @@ entry:
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
   %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = load i64, i64 addrspace(1)* %19
@@ -13149,8 +14968,8 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.ConsoleStream addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
@@ -13181,31 +15000,31 @@ entry:
   store i8 %param4, i8* %arg4
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %3, %System.IO.Stream addrspace(1)* %1)
   %4 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %4, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
   %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %4, i32 0, i32 4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %5)
   %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %6
   %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
   %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
   %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = load i64, i64 addrspace(1)* %13
@@ -13217,8 +15036,8 @@ entry:
   %21 = load i64, i64* %20
   %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %8, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %8, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %14
   %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 5
@@ -13236,24 +15055,24 @@ entry:
   %31 = load i32, i32* %arg3
   %32 = sext i32 %31 to i64
   %33 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %32)
-  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %30, null
-  br i1 %NullCheck10, label %34, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.StreamWriter addrspace(1)* %30, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %35, %"System.Char[]" addrspace(1)* %33)
   %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %37, null
-  br i1 %NullCheck12, label %38, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.StreamWriter addrspace(1)* %37, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %38
 
 ; <label>:38                                      ; preds = %34
   %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
   %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
   %41 = load i32, i32* %arg3
   %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %42, null
-  br i1 %NullCheck14, label %43, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %42, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
   %44 = load i64, i64 addrspace(1)* %42
@@ -13267,30 +15086,30 @@ entry:
   %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
   %53 = sext i32 %52 to i64
   %54 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %53)
-  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
-  br i1 %NullCheck16, label %55, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %55
 
 ; <label>:55                                      ; preds = %43
   %56 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %56, %"System.Byte[]" addrspace(1)* %54)
   %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %58 = load i32, i32* %arg3
-  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %57, null
-  br i1 %NullCheck18, label %59, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.StreamWriter addrspace(1)* %57, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %59
 
 ; <label>:59                                      ; preds = %55
   %60 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 10
   store i32 %58, i32 addrspace(1)* %60
   %61 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %61, null
-  br i1 %NullCheck20, label %62, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.IO.StreamWriter addrspace(1)* %61, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %62
 
 ; <label>:62                                      ; preds = %59
   %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
   %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
   %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
   %67 = load i64, i64 addrspace(1)* %65
@@ -13308,15 +15127,15 @@ entry:
 
 ; <label>:78                                      ; preds = %66
   %79 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %79, null
-  br i1 %NullCheck24, label %80, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.StreamWriter addrspace(1)* %79, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %80
 
 ; <label>:80                                      ; preds = %78
   %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
   %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
   %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %83, null
-  br i1 %NullCheck26, label %84, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %83, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
   %85 = load i64, i64 addrspace(1)* %83
@@ -13333,8 +15152,8 @@ entry:
 
 ; <label>:95                                      ; preds = %84
   %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.IO.StreamWriter addrspace(1)* %96, null
-  br i1 %NullCheck28, label %97, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.IO.StreamWriter addrspace(1)* %96, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %97
 
 ; <label>:97                                      ; preds = %95
   %98 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 12
@@ -13348,8 +15167,8 @@ entry:
   %103 = icmp eq i32 %102, 0
   %104 = sext i1 %103 to i32
   %105 = trunc i32 %104 to i8
-  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %100, null
-  br i1 %NullCheck30, label %106, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.IO.StreamWriter addrspace(1)* %100, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %106
 
 ; <label>:106                                     ; preds = %99
   %107 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %100, i32 0, i32 13
@@ -13360,63 +15179,63 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %6
+ThrowNullRef4:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %29
+ThrowNullRef10:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %34
+ThrowNullRef12:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %38
+ThrowNullRef14:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %43
+ThrowNullRef16:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %55
+ThrowNullRef18:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %59
+ThrowNullRef20:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %62
+ThrowNullRef22:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %78
+ThrowNullRef24:                                   ; preds = %78
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %80
+ThrowNullRef26:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %95
+ThrowNullRef28:                                   ; preds = %95
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13429,15 +15248,15 @@ entry:
   %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = load i64, i64 addrspace(1)* %4
@@ -13455,7 +15274,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13505,35 +15324,35 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
   %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderNLS addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %7 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.EncoderNLS addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Text.Encoding addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.Encoding addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Text.EncoderNLS addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.EncoderNLS addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
   %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck8 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = load i64, i64 addrspace(1)* %16
@@ -13552,19 +15371,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13590,8 +15409,8 @@ entry:
   %this = alloca %System.Text.Encoding addrspace(1)*
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
@@ -13611,15 +15430,15 @@ entry:
   %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
   store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
   %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
   store i32 0, i32 addrspace(1)* %2
   %3 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, i32 0, i32 2
@@ -13629,15 +15448,15 @@ entry:
 
 ; <label>:8                                       ; preds = %4
   %9 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
   %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
   %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = load i64, i64 addrspace(1)* %13
@@ -13658,15 +15477,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13681,16 +15500,16 @@ entry:
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = load i32, i32* %arg1
   %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
   %7 = load i64, i64 addrspace(1)* %5
@@ -13708,7 +15527,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13745,8 +15564,8 @@ entry:
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
   %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
   %16 = load i64, i64 addrspace(1)* %14
@@ -13767,8 +15586,8 @@ entry:
   %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
   %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
   %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %31, null
-  br i1 %NullCheck2, label %32, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = load i64, i64 addrspace(1)* %31
@@ -13811,7 +15630,7 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13824,14 +15643,14 @@ entry:
   %this = alloca %System.Text.EncoderReplacementFallback addrspace(1)*
   store %System.Text.EncoderReplacementFallback addrspace(1)* %param0, %System.Text.EncoderReplacementFallback addrspace(1)** %this
   %0 = load %System.Text.EncoderReplacementFallback addrspace(1)*, %System.Text.EncoderReplacementFallback addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -13842,7 +15661,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13872,8 +15691,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
@@ -13905,8 +15724,8 @@ entry:
   %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
   store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
@@ -13918,8 +15737,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Threading.Tasks.Task addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %7)
@@ -13942,7 +15761,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13961,8 +15780,8 @@ entry:
   store i8 %param1, i8* %arg1
   store i8 %param2, i8* %arg2
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
@@ -13976,8 +15795,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1, %5
   %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 9
@@ -14008,8 +15827,8 @@ entry:
 
 ; <label>:25                                      ; preds = %8, %20
   %26 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %26, null
-  br i1 %NullCheck4, label %27, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %26, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %26, i32 0, i32 12
@@ -14020,22 +15839,22 @@ entry:
 
 ; <label>:32                                      ; preds = %27
   %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %33, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.IO.StreamWriter addrspace(1)* %33, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %32
   %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 12
   store i8 1, i8 addrspace(1)* %35
   %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
-  br i1 %NullCheck8, label %37, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
   %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
   %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck10 = icmp ne i64 addrspace(1)* %40, null
-  br i1 %NullCheck10, label %41, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64 addrspace(1)* %40, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i64, i64 addrspace(1)* %40
@@ -14049,8 +15868,8 @@ entry:
   %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
   store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
   %51 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %NullCheck12 = icmp ne %"System.Byte[]" addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Byte[]" addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %41
   %53 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %51, i32 0, i32 1
@@ -14062,16 +15881,16 @@ entry:
 
 ; <label>:58                                      ; preds = %52
   %59 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %59, null
-  br i1 %NullCheck14, label %60, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.IO.StreamWriter addrspace(1)* %59, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %60
 
 ; <label>:60                                      ; preds = %58
   %61 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %59, i32 0, i32 3
   %62 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
   %64 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %NullCheck16 = icmp ne %"System.Byte[]" addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %"System.Byte[]" addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %60
   %66 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %64, i32 0, i32 1
@@ -14079,8 +15898,8 @@ entry:
   %68 = zext i32 %67 to i64
   %69 = trunc i64 %68 to i32
   %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck18, label %71, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
   %72 = load i64, i64 addrspace(1)* %70
@@ -14096,29 +15915,29 @@ entry:
 
 ; <label>:80                                      ; preds = %27, %52, %71
   %81 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %81, null
-  br i1 %NullCheck20, label %82, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.IO.StreamWriter addrspace(1)* %81, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
 
 ; <label>:82                                      ; preds = %80
   %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %81, i32 0, i32 5
   %84 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %83, align 8
   %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.IO.StreamWriter addrspace(1)* %85, null
-  br i1 %NullCheck22, label %86, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.IO.StreamWriter addrspace(1)* %85, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %86
 
 ; <label>:86                                      ; preds = %82
   %87 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 7
   %88 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %87, align 8
   %89 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %89, null
-  br i1 %NullCheck24, label %90, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.StreamWriter addrspace(1)* %89, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %90
 
 ; <label>:90                                      ; preds = %86
   %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %89, i32 0, i32 9
   %92 = load i32, i32 addrspace(1)* %91, align 8
   %93 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.IO.StreamWriter addrspace(1)* %93, null
-  br i1 %NullCheck26, label %94, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.IO.StreamWriter addrspace(1)* %93, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %93, i32 0, i32 6
@@ -14126,8 +15945,8 @@ entry:
   %97 = load i8, i8* %arg2
   %98 = zext i8 %97 to i32
   %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
-  %NullCheck28 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck28, label %100, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
   %101 = load i64, i64 addrspace(1)* %99
@@ -14142,8 +15961,8 @@ entry:
   %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
   store i32 %110, i32* %loc1
   %111 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %111, null
-  br i1 %NullCheck30, label %112, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.IO.StreamWriter addrspace(1)* %111, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %112
 
 ; <label>:112                                     ; preds = %100
   %113 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %111, i32 0, i32 9
@@ -14154,23 +15973,23 @@ entry:
 
 ; <label>:116                                     ; preds = %112
   %117 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck32 = icmp ne %System.IO.StreamWriter addrspace(1)* %117, null
-  br i1 %NullCheck32, label %118, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.IO.StreamWriter addrspace(1)* %117, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %118
 
 ; <label>:118                                     ; preds = %116
   %119 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %117, i32 0, i32 3
   %120 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %119, align 8
   %121 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.IO.StreamWriter addrspace(1)* %121, null
-  br i1 %NullCheck34, label %122, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.IO.StreamWriter addrspace(1)* %121, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %122
 
 ; <label>:122                                     ; preds = %118
   %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
   %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
   %125 = load i32, i32* %loc1
   %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
-  %NullCheck36 = icmp ne i64 addrspace(1)* %126, null
-  br i1 %NullCheck36, label %127, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64 addrspace(1)* %126, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
   %128 = load i64, i64 addrspace(1)* %126
@@ -14192,15 +16011,15 @@ entry:
 
 ; <label>:140                                     ; preds = %136
   %141 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.IO.StreamWriter addrspace(1)* %141, null
-  br i1 %NullCheck38, label %142, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.IO.StreamWriter addrspace(1)* %141, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %142
 
 ; <label>:142                                     ; preds = %140
   %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
   %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
   %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
-  %NullCheck40 = icmp ne i64 addrspace(1)* %145, null
-  br i1 %NullCheck40, label %146, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i64 addrspace(1)* %145, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
   %147 = load i64, i64 addrspace(1)* %145
@@ -14221,83 +16040,83 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %25
+ThrowNullRef4:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %32
+ThrowNullRef6:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %37
+ThrowNullRef10:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %41
+ThrowNullRef12:                                   ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %58
+ThrowNullRef14:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %60
+ThrowNullRef16:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %65
+ThrowNullRef18:                                   ; preds = %65
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %80
+ThrowNullRef20:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %82
+ThrowNullRef22:                                   ; preds = %82
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %86
+ThrowNullRef24:                                   ; preds = %86
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %90
+ThrowNullRef26:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %94
+ThrowNullRef28:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %100
+ThrowNullRef30:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %116
+ThrowNullRef32:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %118
+ThrowNullRef34:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %122
+ThrowNullRef36:                                   ; preds = %122
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %140
+ThrowNullRef38:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %142
+ThrowNullRef40:                                   ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14364,8 +16183,8 @@ entry:
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %1 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
-  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
@@ -14373,8 +16192,8 @@ entry:
   %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
   %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
   %8 = load i64, i64 addrspace(1)* %6
@@ -14390,8 +16209,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %17, %System.IFormatProvider addrspace(1)* %16)
   %18 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %19 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %18, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.SyncTextWriter addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %7
   %21 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %18, i32 0, i32 4
@@ -14402,11 +16221,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14419,8 +16238,8 @@ entry:
   %this = alloca %System.IO.TextWriter addrspace(1)*
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.TextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
@@ -14430,8 +16249,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.Threading.Thread addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Threading.Thread addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %6)
@@ -14440,8 +16259,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1
   %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.TextWriter addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.TextWriter addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %11, i32 0, i32 2
@@ -14452,11 +16271,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14476,8 +16295,8 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   store i8 0, i8* %loc1
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
@@ -14487,16 +16306,16 @@ entry:
   %5 = addrspacecast i8* %loc1 to i8 addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %4, i8 addrspace(1)* %5)
   %6 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.SyncTextWriter addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
   %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
   %13 = load i64, i64 addrspace(1)* %11
@@ -14531,19 +16350,229 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
-Failed to read TextWriter.WriteLine[loadElem]
+Failed to read TextWriter.WriteLine[storeElem]
 INFO:  jitting method String::CopyTo using LLILCJit
-Failed to read String.CopyTo[loadElemA]
+Successfully read String.CopyTo
+
+define void @String.CopyTo(%System.String addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  %loc1 = alloca i16 addrspace(1)*
+  %loc2 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %1 = icmp ne %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg4
+  %7 = icmp sge i32 %6, 0
+  br i1 %7, label %13, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  unreachable
+
+; <label>:13                                      ; preds = %5
+  %14 = load i32, i32* %arg1
+  %15 = icmp sge i32 %14, 0
+  br i1 %15, label %21, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %18)
+  %20 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %20, %System.String addrspace(1)* %17, %System.String addrspace(1)* %19)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %20) #0
+  unreachable
+
+; <label>:21                                      ; preds = %13
+  %22 = load i32, i32* %arg4
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck, label %ThrowNullRef, label %24
+
+; <label>:24                                      ; preds = %21
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load i32, i32* %arg1
+  %28 = sub i32 %26, %27
+  %29 = icmp sle i32 %22, %28
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34, %System.String addrspace(1)* %31, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %24
+  %36 = load i32, i32* %arg3
+  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %37, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
+
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
+  %40 = load i32, i32 addrspace(1)* %39
+  %41 = zext i32 %40 to i64
+  %42 = trunc i64 %41 to i32
+  %43 = load i32, i32* %arg4
+  %44 = sub i32 %42, %43
+  %45 = icmp sgt i32 %36, %44
+  br i1 %45, label %49, label %46
+
+; <label>:46                                      ; preds = %38
+  %47 = load i32, i32* %arg3
+  %48 = icmp sge i32 %47, 0
+  br i1 %48, label %54, label %49
+
+; <label>:49                                      ; preds = %38, %46
+  %50 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %52 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %51)
+  %53 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53, %System.String addrspace(1)* %50, %System.String addrspace(1)* %52)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53) #0
+  unreachable
+
+; <label>:54                                      ; preds = %46
+  %55 = load i32, i32* %arg4
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %97, label %57
+
+; <label>:57                                      ; preds = %54
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %59
+
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 2
+  %61 = bitcast [0 x i16] addrspace(1)* %60 to i16 addrspace(1)*
+  store i16 addrspace(1)* %61, i16 addrspace(1)** %loc0
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  store %"System.Char[]" addrspace(1)* %62, %"System.Char[]" addrspace(1)** %loc2
+  %63 = icmp eq %"System.Char[]" addrspace(1)* %62, null
+  br i1 %63, label %72, label %64
+
+; <label>:64                                      ; preds = %59
+  %65 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc2
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %65, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %66
+
+; <label>:66                                      ; preds = %64
+  %67 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %65, i32 0, i32 1
+  %68 = load i32, i32 addrspace(1)* %67
+  %69 = zext i32 %68 to i64
+  %70 = trunc i64 %69 to i32
+  %71 = icmp ne i32 %70, 0
+  br i1 %71, label %73, label %72
+
+; <label>:72                                      ; preds = %59, %66
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  br label %81
+
+; <label>:73                                      ; preds = %66
+  %74 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc2
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %74, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %75
+
+; <label>:75                                      ; preds = %73
+  %76 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %74, i32 0, i32 1
+  %77 = load i32, i32 addrspace(1)* %76
+  %78 = zext i32 %77 to i64
+  %BoundsCheck = icmp uge i64 0, %78
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %79
+
+; <label>:79                                      ; preds = %75
+  %80 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %74, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %80, i16 addrspace(1)** %loc1
+  br label %81
+
+; <label>:81                                      ; preds = %72, %79
+  %82 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %83 = ptrtoint i16 addrspace(1)* %82 to i64
+  %84 = load i32, i32* %arg3
+  %85 = sext i32 %84 to i64
+  %86 = mul i64 %85, 2
+  %87 = add i64 %83, %86
+  %88 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %89 = ptrtoint i16 addrspace(1)* %88 to i64
+  %90 = load i32, i32* %arg1
+  %91 = sext i32 %90 to i64
+  %92 = mul i64 %91, 2
+  %93 = add i64 %89, %92
+  %94 = load i32, i32* %arg4
+  %95 = inttoptr i64 %87 to i16*
+  %96 = inttoptr i64 %93 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %95, i16* %96, i32 %94)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  br label %97
+
+; <label>:97                                      ; preds = %54, %81
+  ret void
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StreamWriter::Write using LLILCJit
 Successfully read StreamWriter.Write
 
@@ -14601,8 +16630,8 @@ entry:
 
 ; <label>:23                                      ; preds = %15
   %24 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Char[]" addrspace(1)* %24, null
-  br i1 %NullCheck, label %25, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %24, null
+  br i1 %NullCheck, label %ThrowNullRef, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %24, i32 0, i32 1
@@ -14630,15 +16659,15 @@ entry:
 
 ; <label>:40                                      ; preds = %98
   %41 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %41, null
-  br i1 %NullCheck4, label %42, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %41, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %42
 
 ; <label>:42                                      ; preds = %40
   %43 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
   %44 = load i32, i32 addrspace(1)* %43, align 8
   %45 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %45, null
-  br i1 %NullCheck6, label %46, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.IO.StreamWriter addrspace(1)* %45, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %46
 
 ; <label>:46                                      ; preds = %42
   %47 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %45, i32 0, i32 10
@@ -14653,15 +16682,15 @@ entry:
 
 ; <label>:52                                      ; preds = %46, %50
   %53 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %53, null
-  br i1 %NullCheck8, label %54, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %53, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %54
 
 ; <label>:54                                      ; preds = %52
   %55 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %53, i32 0, i32 10
   %56 = load i32, i32 addrspace(1)* %55, align 8
   %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %57, null
-  br i1 %NullCheck10, label %58, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.StreamWriter addrspace(1)* %57, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %58
 
 ; <label>:58                                      ; preds = %54
   %59 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 9
@@ -14683,15 +16712,15 @@ entry:
   %69 = load i32, i32* %arg2
   %70 = mul i32 %69, 2
   %71 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %71, null
-  br i1 %NullCheck12, label %72, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.StreamWriter addrspace(1)* %71, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %72
 
 ; <label>:72                                      ; preds = %67
   %73 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %71, i32 0, i32 7
   %74 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %73, align 8
   %75 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %75, null
-  br i1 %NullCheck14, label %76, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.IO.StreamWriter addrspace(1)* %75, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %76
 
 ; <label>:76                                      ; preds = %72
   %77 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %75, i32 0, i32 9
@@ -14703,16 +16732,16 @@ entry:
   %83 = bitcast %"System.Char[]" addrspace(1)* %74 to %System.Array addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %82, i32 %70, %System.Array addrspace(1)* %83, i32 %79, i32 %81)
   %84 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %84, null
-  br i1 %NullCheck16, label %85, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.IO.StreamWriter addrspace(1)* %84, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %85
 
 ; <label>:85                                      ; preds = %76
   %86 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %84, i32 0, i32 9
   %87 = load i32, i32 addrspace(1)* %86, align 8
   %88 = load i32, i32* %loc0
   %89 = add i32 %87, %88
-  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %84, null
-  br i1 %NullCheck18, label %90, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.StreamWriter addrspace(1)* %84, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %90
 
 ; <label>:90                                      ; preds = %85
   %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %84, i32 0, i32 9
@@ -14734,8 +16763,8 @@ entry:
 
 ; <label>:101                                     ; preds = %98
   %102 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %102, null
-  br i1 %NullCheck2, label %103, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %102, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %103
 
 ; <label>:103                                     ; preds = %101
   %104 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %102, i32 0, i32 11
@@ -14756,39 +16785,39 @@ ThrowNullRef:                                     ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %101
+ThrowNullRef2:                                    ; preds = %101
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %40
+ThrowNullRef4:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %42
+ThrowNullRef6:                                    ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %52
+ThrowNullRef8:                                    ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %54
+ThrowNullRef10:                                   ; preds = %54
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %67
+ThrowNullRef12:                                   ; preds = %67
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %72
+ThrowNullRef14:                                   ; preds = %72
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %76
+ThrowNullRef16:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %85
+ThrowNullRef18:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14829,7 +16858,365 @@ entry:
 }
 
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[loadElemA]
+Successfully read EncoderNLS.GetBytes
+
+define i32 @EncoderNLS.GetBytes(%System.Text.EncoderNLS addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3, %"System.Byte[]" addrspace(1)* %param4, i32 %param5, i8 %param6) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %arg4 = alloca %"System.Byte[]" addrspace(1)*
+  %arg5 = alloca i32
+  %arg6 = alloca i8
+  %loc0 = alloca i32
+  %loc1 = alloca i16 addrspace(1)*
+  %loc2 = alloca i8 addrspace(1)*
+  %loc3 = alloca i32
+  %loc4 = alloca %"System.Char[]" addrspace(1)*
+  %loc5 = alloca %"System.Byte[]" addrspace(1)*
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  store %"System.Byte[]" addrspace(1)* %param4, %"System.Byte[]" addrspace(1)** %arg4
+  store i32 %param5, i32* %arg5
+  store i8 %param6, i8* %arg6
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %1 = icmp eq %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %17, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %7 = icmp eq %"System.Char[]" addrspace(1)* %6, null
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %12
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %12
+
+; <label>:12                                      ; preds = %8, %10
+  %13 = phi %System.String addrspace(1)* [ %9, %8 ], [ %11, %10 ]
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %14)
+  %16 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16, %System.String addrspace(1)* %13, %System.String addrspace(1)* %15)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16) #0
+  unreachable
+
+; <label>:17                                      ; preds = %2
+  %18 = load i32, i32* %arg2
+  %19 = icmp slt i32 %18, 0
+  br i1 %19, label %23, label %20
+
+; <label>:20                                      ; preds = %17
+  %21 = load i32, i32* %arg3
+  %22 = icmp sge i32 %21, 0
+  br i1 %22, label %35, label %23
+
+; <label>:23                                      ; preds = %17, %20
+  %24 = load i32, i32* %arg2
+  %25 = icmp slt i32 %24, 0
+  br i1 %25, label %28, label %26
+
+; <label>:26                                      ; preds = %23
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %30
+
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %30
+
+; <label>:30                                      ; preds = %26, %28
+  %31 = phi %System.String addrspace(1)* [ %27, %26 ], [ %29, %28 ]
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34, %System.String addrspace(1)* %31, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %20
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck, label %ThrowNullRef, label %37
+
+; <label>:37                                      ; preds = %35
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = load i32, i32* %arg2
+  %43 = sub i32 %41, %42
+  %44 = load i32, i32* %arg3
+  %45 = icmp sge i32 %43, %44
+  br i1 %45, label %51, label %46
+
+; <label>:46                                      ; preds = %37
+  %47 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %48 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %49 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %48)
+  %50 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %50, %System.String addrspace(1)* %47, %System.String addrspace(1)* %49)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %50) #0
+  unreachable
+
+; <label>:51                                      ; preds = %37
+  %52 = load i32, i32* %arg5
+  %53 = icmp slt i32 %52, 0
+  br i1 %53, label %63, label %54
+
+; <label>:54                                      ; preds = %51
+  %55 = load i32, i32* %arg5
+  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck1 = icmp eq %"System.Byte[]" addrspace(1)* %56, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %57
+
+; <label>:57                                      ; preds = %54
+  %58 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = zext i32 %59 to i64
+  %61 = trunc i64 %60 to i32
+  %62 = icmp sle i32 %55, %61
+  br i1 %62, label %68, label %63
+
+; <label>:63                                      ; preds = %51, %57
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %66 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %65)
+  %67 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %67, %System.String addrspace(1)* %64, %System.String addrspace(1)* %66)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %67) #0
+  unreachable
+
+; <label>:68                                      ; preds = %57
+  %69 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %69, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %69, i32 0, i32 1
+  %72 = load i32, i32 addrspace(1)* %71
+  %73 = zext i32 %72 to i64
+  %74 = trunc i64 %73 to i32
+  %75 = icmp ne i32 %74, 0
+  br i1 %75, label %78, label %76
+
+; <label>:76                                      ; preds = %70
+  %77 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1)
+  store %"System.Char[]" addrspace(1)* %77, %"System.Char[]" addrspace(1)** %arg1
+  br label %78
+
+; <label>:78                                      ; preds = %70, %76
+  %79 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck5 = icmp eq %"System.Byte[]" addrspace(1)* %79, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %80
+
+; <label>:80                                      ; preds = %78
+  %81 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %79, i32 0, i32 1
+  %82 = load i32, i32 addrspace(1)* %81
+  %83 = zext i32 %82 to i64
+  %84 = trunc i64 %83 to i32
+  %85 = load i32, i32* %arg5
+  %86 = sub i32 %84, %85
+  store i32 %86, i32* %loc0
+  %87 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck7 = icmp eq %"System.Byte[]" addrspace(1)* %87, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %88
+
+; <label>:88                                      ; preds = %80
+  %89 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %87, i32 0, i32 1
+  %90 = load i32, i32 addrspace(1)* %89
+  %91 = zext i32 %90 to i64
+  %92 = trunc i64 %91 to i32
+  %93 = icmp ne i32 %92, 0
+  br i1 %93, label %96, label %94
+
+; <label>:94                                      ; preds = %88
+  %95 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1)
+  store %"System.Byte[]" addrspace(1)* %95, %"System.Byte[]" addrspace(1)** %arg4
+  br label %96
+
+; <label>:96                                      ; preds = %88, %94
+  %97 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  store %"System.Char[]" addrspace(1)* %97, %"System.Char[]" addrspace(1)** %loc4
+  %98 = icmp eq %"System.Char[]" addrspace(1)* %97, null
+  br i1 %98, label %107, label %99
+
+; <label>:99                                      ; preds = %96
+  %100 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc4
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %100, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %101
+
+; <label>:101                                     ; preds = %99
+  %102 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %100, i32 0, i32 1
+  %103 = load i32, i32 addrspace(1)* %102
+  %104 = zext i32 %103 to i64
+  %105 = trunc i64 %104 to i32
+  %106 = icmp ne i32 %105, 0
+  br i1 %106, label %108, label %107
+
+; <label>:107                                     ; preds = %96, %101
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  br label %116
+
+; <label>:108                                     ; preds = %101
+  %109 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc4
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %109, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %110
+
+; <label>:110                                     ; preds = %108
+  %111 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %109, i32 0, i32 1
+  %112 = load i32, i32 addrspace(1)* %111
+  %113 = zext i32 %112 to i64
+  %BoundsCheck = icmp uge i64 0, %113
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %114
+
+; <label>:114                                     ; preds = %110
+  %115 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %109, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %115, i16 addrspace(1)** %loc1
+  br label %116
+
+; <label>:116                                     ; preds = %107, %114
+  %117 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  store %"System.Byte[]" addrspace(1)* %117, %"System.Byte[]" addrspace(1)** %loc5
+  %118 = icmp eq %"System.Byte[]" addrspace(1)* %117, null
+  br i1 %118, label %127, label %119
+
+; <label>:119                                     ; preds = %116
+  %120 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc5
+  %NullCheck13 = icmp eq %"System.Byte[]" addrspace(1)* %120, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %121
+
+; <label>:121                                     ; preds = %119
+  %122 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %120, i32 0, i32 1
+  %123 = load i32, i32 addrspace(1)* %122
+  %124 = zext i32 %123 to i64
+  %125 = trunc i64 %124 to i32
+  %126 = icmp ne i32 %125, 0
+  br i1 %126, label %128, label %127
+
+; <label>:127                                     ; preds = %116, %121
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc2
+  br label %136
+
+; <label>:128                                     ; preds = %121
+  %129 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc5
+  %NullCheck15 = icmp eq %"System.Byte[]" addrspace(1)* %129, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %130
+
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %129, i32 0, i32 1
+  %132 = load i32, i32 addrspace(1)* %131
+  %133 = zext i32 %132 to i64
+  %BoundsCheck17 = icmp uge i64 0, %133
+  br i1 %BoundsCheck17, label %ThrowIndexOutOfRange18, label %134
+
+; <label>:134                                     ; preds = %130
+  %135 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %129, i32 0, i32 3, i32 0
+  store i8 addrspace(1)* %135, i8 addrspace(1)** %loc2
+  br label %136
+
+; <label>:136                                     ; preds = %127, %134
+  %137 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %138 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %139 = ptrtoint i16 addrspace(1)* %138 to i64
+  %140 = load i32, i32* %arg2
+  %141 = sext i32 %140 to i64
+  %142 = mul i64 %141, 2
+  %143 = add i64 %139, %142
+  %144 = load i32, i32* %arg3
+  %145 = load i8 addrspace(1)*, i8 addrspace(1)** %loc2
+  %146 = ptrtoint i8 addrspace(1)* %145 to i64
+  %147 = load i32, i32* %arg5
+  %148 = sext i32 %147 to i64
+  %149 = add i64 %146, %148
+  %150 = load i32, i32* %loc0
+  %151 = load i8, i8* %arg6
+  %152 = zext i8 %151 to i32
+  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i64 addrspace(1)*
+  %NullCheck19 = icmp eq i64 addrspace(1)* %153, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %154
+
+; <label>:154                                     ; preds = %136
+  %155 = load i64, i64 addrspace(1)* %153
+  %156 = add i64 %155, 72
+  %157 = inttoptr i64 %156 to i64*
+  %158 = load i64, i64* %157
+  %159 = add i64 %158, 0
+  %160 = inttoptr i64 %159 to i64*
+  %161 = load i64, i64* %160
+  %162 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to %System.Text.Encoder addrspace(1)*
+  %163 = inttoptr i64 %143 to i16*
+  %164 = inttoptr i64 %149 to i8*
+  %165 = trunc i32 %152 to i8
+  %166 = inttoptr i64 %161 to i32 (%System.Text.Encoder addrspace(1)*, i16*, i32, i8*, i32, i8)*
+  %167 = call i32 %166(%System.Text.Encoder addrspace(1)* %162, i16* %163, i32 %144, i8* %164, i32 %150, i8 %165)
+  store i32 %167, i32* %loc3
+  br label %168
+
+; <label>:168                                     ; preds = %154
+  %169 = load i32, i32* %loc3
+  ret i32 %169
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %110
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %119
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange18:                           ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
 Successfully read EncoderNLS.GetBytes
 
@@ -14918,22 +17305,22 @@ entry:
   %40 = load i8, i8* %arg5
   %41 = zext i8 %40 to i32
   %42 = trunc i32 %41 to i8
-  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %39, null
-  br i1 %NullCheck, label %43, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderNLS addrspace(1)* %39, null
+  br i1 %NullCheck, label %ThrowNullRef, label %43
 
 ; <label>:43                                      ; preds = %38
   %44 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
   store i8 %42, i8 addrspace(1)* %44
   %45 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %45, null
-  br i1 %NullCheck2, label %46, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.EncoderNLS addrspace(1)* %45, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %46
 
 ; <label>:46                                      ; preds = %43
   %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %45, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %47
   %48 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.EncoderNLS addrspace(1)* %48, null
-  br i1 %NullCheck4, label %49, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.EncoderNLS addrspace(1)* %48, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %49
 
 ; <label>:49                                      ; preds = %46
   %50 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %48, i32 0, i32 3
@@ -14944,8 +17331,8 @@ entry:
   %55 = load i32, i32* %arg4
   %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck6, label %58, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
   %59 = load i64, i64 addrspace(1)* %57
@@ -14963,15 +17350,15 @@ ThrowNullRef:                                     ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %43
+ThrowNullRef2:                                    ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %46
+ThrowNullRef4:                                    ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %49
+ThrowNullRef6:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14999,8 +17386,8 @@ entry:
   %4 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0 to %System.IO.ConsoleStream addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*)(%System.IO.ConsoleStream addrspace(1)* %4, %"System.Byte[]" addrspace(1)* %1, i32 %2, i32 %3)
   %5 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
@@ -15085,8 +17472,8 @@ entry:
 
 ; <label>:22                                      ; preds = %8
   %23 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %23, null
-  br i1 %NullCheck, label %24, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Byte[]" addrspace(1)* %23, null
+  br i1 %NullCheck, label %ThrowNullRef, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
@@ -15108,8 +17495,8 @@ entry:
 
 ; <label>:36                                      ; preds = %24
   %37 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %37, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.ConsoleStream addrspace(1)* %37, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %37, i32 0, i32 4
@@ -15130,13 +17517,138 @@ ThrowNullRef:                                     ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %36
+ThrowNullRef2:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
-Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
+Successfully read WindowsConsoleStream.WriteFileNative
+
+define i32 @WindowsConsoleStream.WriteFileNative(i64 %param0, %"System.Byte[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i64
+  %arg1 = alloca %"System.Byte[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i8 addrspace(1)*
+  %loc2 = alloca %"System.Byte[]" addrspace(1)*
+  %loc3 = alloca i32
+  store i64 %param0, i64* %arg0
+  store %"System.Byte[]" addrspace(1)* %param1, %"System.Byte[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Byte[]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = zext i32 %3 to i64
+  %5 = icmp ne i64 %4, 0
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %1
+  ret i32 0
+
+; <label>:7                                       ; preds = %1
+  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  store %"System.Byte[]" addrspace(1)* %8, %"System.Byte[]" addrspace(1)** %loc2
+  %9 = icmp eq %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %9, label %18, label %10
+
+; <label>:10                                      ; preds = %7
+  %11 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc2
+  %NullCheck1 = icmp eq %"System.Byte[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %11, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp ne i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %7, %12
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc1
+  br label %27
+
+; <label>:19                                      ; preds = %12
+  %20 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc2
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %20, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %BoundsCheck = icmp uge i64 0, %24
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %25
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %20, i32 0, i32 3, i32 0
+  store i8 addrspace(1)* %26, i8 addrspace(1)** %loc1
+  br label %27
+
+; <label>:27                                      ; preds = %18, %25
+  %28 = load i64, i64* %arg0
+  %29 = load i8 addrspace(1)*, i8 addrspace(1)** %loc1
+  %30 = ptrtoint i8 addrspace(1)* %29 to i64
+  %31 = load i32, i32* %arg2
+  %32 = sext i32 %31 to i64
+  %33 = add i64 %30, %32
+  %34 = load i32, i32* %arg3
+  %35 = addrspacecast i32* %loc3 to i32 addrspace(1)*
+  %36 = inttoptr i64 %33 to i8*
+  %37 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i8*, i32, i32 addrspace(1)*, i64)*)(i64 %28, i8* %36, i32 %34, i32 addrspace(1)* %35, i64 0)
+  %38 = icmp ugt i32 %37, 0
+  %39 = sext i1 %38 to i32
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc1
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %42, label %41
+
+; <label>:41                                      ; preds = %27
+  ret i32 0
+
+; <label>:42                                      ; preds = %27
+  %43 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  store i32 %43, i32* %loc0
+  %44 = load i32, i32* %loc0
+  %45 = icmp eq i32 %44, 232
+  br i1 %45, label %49, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = load i32, i32* %loc0
+  %48 = icmp ne i32 %47, 109
+  br i1 %48, label %50, label %49
+
+; <label>:49                                      ; preds = %42, %46
+  ret i32 0
+
+; <label>:50                                      ; preds = %46
+  %51 = load i32, i32* %loc0
+  ret i32 %51
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
 Successfully read WindowsConsoleStream.Flush
 
@@ -15145,8 +17657,8 @@ entry:
   %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
   store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
@@ -15181,8 +17693,8 @@ entry:
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
   %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load i64, i64 addrspace(1)* %1
@@ -15245,8 +17757,8 @@ entry:
 ; <label>:11                                      ; preds = %5, %8
   %12 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
   %13 = bitcast %System.Object addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck, label %14, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck, label %ThrowNullRef, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = load i64, i64 addrspace(1)* %13
@@ -15260,8 +17772,8 @@ entry:
   %23 = call %System.String addrspace(1)* %22(%System.Object addrspace(1)* %12)
   %24 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %25 = bitcast %System.Object addrspace(1)* %24 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %25, null
-  br i1 %NullCheck2, label %26, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %25, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %26
 
 ; <label>:26                                      ; preds = %14
   %27 = load i64, i64 addrspace(1)* %25
@@ -15280,7 +17792,7 @@ ThrowNullRef:                                     ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %14
+ThrowNullRef2:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Ge1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Ge1.error.txt
@@ -25,8 +25,8 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
@@ -40,8 +40,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
   %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
@@ -75,7 +75,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -90,8 +90,8 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %NullCheck = icmp ne i8 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = load i8, i8 addrspace(1)* %0, align 8
@@ -125,8 +125,8 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
@@ -159,8 +159,8 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -184,8 +184,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
   store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
@@ -195,8 +195,8 @@ entry:
 ; <label>:4                                       ; preds = %1
   %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
   %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
@@ -206,8 +206,8 @@ entry:
   %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
@@ -221,14 +221,14 @@ entry:
 
 ; <label>:17                                      ; preds = %14
   %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
   %21 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
@@ -238,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -249,8 +249,8 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
@@ -261,27 +261,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %30
+ThrowNullRef10:                                   ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -301,7 +301,89 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
-Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
+Successfully read AppDomainSetup.GetUnsecureApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.GetUnsecureApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %NullCheck = icmp eq %"System.String[]" addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %BoundsCheck = icmp uge i64 0, %5
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %6
+
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 3, i32 0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
+  ret %System.String addrspace(1)* %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_Value using LLILCJit
+Successfully read AppDomainSetup.get_Value
+
+define %"System.String[]" addrspace(1)* @AppDomainSetup.get_Value(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.String[]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 18)
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.String[]" addrspace(1)* addrspace(1)*, %"System.String[]" addrspace(1)*)*)(%"System.String[]" addrspace(1)* addrspace(1)* %9, %"System.String[]" addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %11, i32 0, i32 1
+  %14 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %13, align 8
+  ret %"System.String[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -319,8 +401,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -368,16 +450,16 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
   %5 = load i32, i32 addrspace(1)* %4
   %6 = sub i32 %5, 1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -389,7 +471,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -421,8 +503,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
@@ -456,8 +538,8 @@ entry:
 ; <label>:27                                      ; preds = %19
   %28 = load i32, i32* %arg1
   %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
-  br i1 %NullCheck2, label %30, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %29, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %30
 
 ; <label>:30                                      ; preds = %27
   %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
@@ -493,8 +575,8 @@ entry:
 ; <label>:49                                      ; preds = %46
   %50 = load i32, i32* %arg2
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck4, label %52, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
@@ -517,11 +599,11 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %27
+ThrowNullRef2:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %49
+ThrowNullRef4:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -544,16 +626,16 @@ entry:
   %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %0)
   store %System.String addrspace(1)* %1, %System.String addrspace(1)** %loc0
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 2
   %5 = bitcast [0 x i16] addrspace(1)* %4 to i16 addrspace(1)*
   store i16 addrspace(1)* %5, i16 addrspace(1)** %loc1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %3
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2
@@ -580,7 +662,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -691,15 +773,15 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %NullCheck132 = icmp ne i8* %21, null
-  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+  %NullCheck131 = icmp eq i8* %21, null
+  br i1 %NullCheck131, label %ThrowNullRef132, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = load i8, i8* %21, align 8
   %24 = zext i8 %23 to i32
   %25 = trunc i32 %24 to i8
-  %NullCheck134 = icmp ne i8* %20, null
-  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+  %NullCheck133 = icmp eq i8* %20, null
+  br i1 %NullCheck133, label %ThrowNullRef134, label %26
 
 ; <label>:26                                      ; preds = %22
   store i8 %25, i8* %20, align 8
@@ -709,16 +791,16 @@ entry:
   %28 = load i8*, i8** %arg0
   %29 = load i8*, i8** %arg1
   %30 = bitcast i8* %29 to i16*
-  %NullCheck128 = icmp ne i16* %30, null
-  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+  %NullCheck127 = icmp eq i16* %30, null
+  br i1 %NullCheck127, label %ThrowNullRef128, label %31
 
 ; <label>:31                                      ; preds = %27
   %32 = load i16, i16* %30, align 8
   %33 = sext i16 %32 to i32
   %34 = bitcast i8* %28 to i16*
   %35 = trunc i32 %33 to i16
-  %NullCheck130 = icmp ne i16* %34, null
-  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+  %NullCheck129 = icmp eq i16* %34, null
+  br i1 %NullCheck129, label %ThrowNullRef130, label %36
 
 ; <label>:36                                      ; preds = %31
   store i16 %35, i16* %34, align 8
@@ -728,16 +810,16 @@ entry:
   %38 = load i8*, i8** %arg0
   %39 = load i8*, i8** %arg1
   %40 = bitcast i8* %39 to i16*
-  %NullCheck120 = icmp ne i16* %40, null
-  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+  %NullCheck119 = icmp eq i16* %40, null
+  br i1 %NullCheck119, label %ThrowNullRef120, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i16, i16* %40, align 8
   %43 = sext i16 %42 to i32
   %44 = bitcast i8* %38 to i16*
   %45 = trunc i32 %43 to i16
-  %NullCheck122 = icmp ne i16* %44, null
-  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+  %NullCheck121 = icmp eq i16* %44, null
+  br i1 %NullCheck121, label %ThrowNullRef122, label %46
 
 ; <label>:46                                      ; preds = %41
   store i16 %45, i16* %44, align 8
@@ -745,15 +827,15 @@ entry:
   %48 = getelementptr inbounds i8, i8* %47, i64 2
   %49 = load i8*, i8** %arg1
   %50 = getelementptr inbounds i8, i8* %49, i64 2
-  %NullCheck124 = icmp ne i8* %50, null
-  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+  %NullCheck123 = icmp eq i8* %50, null
+  br i1 %NullCheck123, label %ThrowNullRef124, label %51
 
 ; <label>:51                                      ; preds = %46
   %52 = load i8, i8* %50, align 8
   %53 = zext i8 %52 to i32
   %54 = trunc i32 %53 to i8
-  %NullCheck126 = icmp ne i8* %48, null
-  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+  %NullCheck125 = icmp eq i8* %48, null
+  br i1 %NullCheck125, label %ThrowNullRef126, label %55
 
 ; <label>:55                                      ; preds = %51
   store i8 %54, i8* %48, align 8
@@ -763,14 +845,14 @@ entry:
   %57 = load i8*, i8** %arg0
   %58 = load i8*, i8** %arg1
   %59 = bitcast i8* %58 to i32*
-  %NullCheck116 = icmp ne i32* %59, null
-  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+  %NullCheck115 = icmp eq i32* %59, null
+  br i1 %NullCheck115, label %ThrowNullRef116, label %60
 
 ; <label>:60                                      ; preds = %56
   %61 = load i32, i32* %59, align 8
   %62 = bitcast i8* %57 to i32*
-  %NullCheck118 = icmp ne i32* %62, null
-  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+  %NullCheck117 = icmp eq i32* %62, null
+  br i1 %NullCheck117, label %ThrowNullRef118, label %63
 
 ; <label>:63                                      ; preds = %60
   store i32 %61, i32* %62, align 8
@@ -780,14 +862,14 @@ entry:
   %65 = load i8*, i8** %arg0
   %66 = load i8*, i8** %arg1
   %67 = bitcast i8* %66 to i32*
-  %NullCheck108 = icmp ne i32* %67, null
-  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+  %NullCheck107 = icmp eq i32* %67, null
+  br i1 %NullCheck107, label %ThrowNullRef108, label %68
 
 ; <label>:68                                      ; preds = %64
   %69 = load i32, i32* %67, align 8
   %70 = bitcast i8* %65 to i32*
-  %NullCheck110 = icmp ne i32* %70, null
-  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+  %NullCheck109 = icmp eq i32* %70, null
+  br i1 %NullCheck109, label %ThrowNullRef110, label %71
 
 ; <label>:71                                      ; preds = %68
   store i32 %69, i32* %70, align 8
@@ -795,15 +877,15 @@ entry:
   %73 = getelementptr inbounds i8, i8* %72, i64 4
   %74 = load i8*, i8** %arg1
   %75 = getelementptr inbounds i8, i8* %74, i64 4
-  %NullCheck112 = icmp ne i8* %75, null
-  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+  %NullCheck111 = icmp eq i8* %75, null
+  br i1 %NullCheck111, label %ThrowNullRef112, label %76
 
 ; <label>:76                                      ; preds = %71
   %77 = load i8, i8* %75, align 8
   %78 = zext i8 %77 to i32
   %79 = trunc i32 %78 to i8
-  %NullCheck114 = icmp ne i8* %73, null
-  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+  %NullCheck113 = icmp eq i8* %73, null
+  br i1 %NullCheck113, label %ThrowNullRef114, label %80
 
 ; <label>:80                                      ; preds = %76
   store i8 %79, i8* %73, align 8
@@ -813,14 +895,14 @@ entry:
   %82 = load i8*, i8** %arg0
   %83 = load i8*, i8** %arg1
   %84 = bitcast i8* %83 to i32*
-  %NullCheck100 = icmp ne i32* %84, null
-  br i1 %NullCheck100, label %85, label %ThrowNullRef99
+  %NullCheck99 = icmp eq i32* %84, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %85
 
 ; <label>:85                                      ; preds = %81
   %86 = load i32, i32* %84, align 8
   %87 = bitcast i8* %82 to i32*
-  %NullCheck102 = icmp ne i32* %87, null
-  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+  %NullCheck101 = icmp eq i32* %87, null
+  br i1 %NullCheck101, label %ThrowNullRef102, label %88
 
 ; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
@@ -829,16 +911,16 @@ entry:
   %91 = load i8*, i8** %arg1
   %92 = getelementptr inbounds i8, i8* %91, i64 4
   %93 = bitcast i8* %92 to i16*
-  %NullCheck104 = icmp ne i16* %93, null
-  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+  %NullCheck103 = icmp eq i16* %93, null
+  br i1 %NullCheck103, label %ThrowNullRef104, label %94
 
 ; <label>:94                                      ; preds = %88
   %95 = load i16, i16* %93, align 8
   %96 = sext i16 %95 to i32
   %97 = bitcast i8* %90 to i16*
   %98 = trunc i32 %96 to i16
-  %NullCheck106 = icmp ne i16* %97, null
-  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+  %NullCheck105 = icmp eq i16* %97, null
+  br i1 %NullCheck105, label %ThrowNullRef106, label %99
 
 ; <label>:99                                      ; preds = %94
   store i16 %98, i16* %97, align 8
@@ -848,14 +930,14 @@ entry:
   %101 = load i8*, i8** %arg0
   %102 = load i8*, i8** %arg1
   %103 = bitcast i8* %102 to i32*
-  %NullCheck88 = icmp ne i32* %103, null
-  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+  %NullCheck87 = icmp eq i32* %103, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %104
 
 ; <label>:104                                     ; preds = %100
   %105 = load i32, i32* %103, align 8
   %106 = bitcast i8* %101 to i32*
-  %NullCheck90 = icmp ne i32* %106, null
-  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+  %NullCheck89 = icmp eq i32* %106, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %107
 
 ; <label>:107                                     ; preds = %104
   store i32 %105, i32* %106, align 8
@@ -864,16 +946,16 @@ entry:
   %110 = load i8*, i8** %arg1
   %111 = getelementptr inbounds i8, i8* %110, i64 4
   %112 = bitcast i8* %111 to i16*
-  %NullCheck92 = icmp ne i16* %112, null
-  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+  %NullCheck91 = icmp eq i16* %112, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %113
 
 ; <label>:113                                     ; preds = %107
   %114 = load i16, i16* %112, align 8
   %115 = sext i16 %114 to i32
   %116 = bitcast i8* %109 to i16*
   %117 = trunc i32 %115 to i16
-  %NullCheck94 = icmp ne i16* %116, null
-  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+  %NullCheck93 = icmp eq i16* %116, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %118
 
 ; <label>:118                                     ; preds = %113
   store i16 %117, i16* %116, align 8
@@ -881,15 +963,15 @@ entry:
   %120 = getelementptr inbounds i8, i8* %119, i64 6
   %121 = load i8*, i8** %arg1
   %122 = getelementptr inbounds i8, i8* %121, i64 6
-  %NullCheck96 = icmp ne i8* %122, null
-  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+  %NullCheck95 = icmp eq i8* %122, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %123
 
 ; <label>:123                                     ; preds = %118
   %124 = load i8, i8* %122, align 8
   %125 = zext i8 %124 to i32
   %126 = trunc i32 %125 to i8
-  %NullCheck98 = icmp ne i8* %120, null
-  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+  %NullCheck97 = icmp eq i8* %120, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %127
 
 ; <label>:127                                     ; preds = %123
   store i8 %126, i8* %120, align 8
@@ -899,14 +981,14 @@ entry:
   %129 = load i8*, i8** %arg0
   %130 = load i8*, i8** %arg1
   %131 = bitcast i8* %130 to i64*
-  %NullCheck84 = icmp ne i64* %131, null
-  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+  %NullCheck83 = icmp eq i64* %131, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %132
 
 ; <label>:132                                     ; preds = %128
   %133 = load i64, i64* %131, align 8
   %134 = bitcast i8* %129 to i64*
-  %NullCheck86 = icmp ne i64* %134, null
-  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+  %NullCheck85 = icmp eq i64* %134, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %135
 
 ; <label>:135                                     ; preds = %132
   store i64 %133, i64* %134, align 8
@@ -916,14 +998,14 @@ entry:
   %137 = load i8*, i8** %arg0
   %138 = load i8*, i8** %arg1
   %139 = bitcast i8* %138 to i64*
-  %NullCheck76 = icmp ne i64* %139, null
-  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+  %NullCheck75 = icmp eq i64* %139, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %140
 
 ; <label>:140                                     ; preds = %136
   %141 = load i64, i64* %139, align 8
   %142 = bitcast i8* %137 to i64*
-  %NullCheck78 = icmp ne i64* %142, null
-  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+  %NullCheck77 = icmp eq i64* %142, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %143
 
 ; <label>:143                                     ; preds = %140
   store i64 %141, i64* %142, align 8
@@ -931,15 +1013,15 @@ entry:
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %NullCheck80 = icmp ne i8* %147, null
-  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+  %NullCheck79 = icmp eq i8* %147, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %148
 
 ; <label>:148                                     ; preds = %143
   %149 = load i8, i8* %147, align 8
   %150 = zext i8 %149 to i32
   %151 = trunc i32 %150 to i8
-  %NullCheck82 = icmp ne i8* %145, null
-  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+  %NullCheck81 = icmp eq i8* %145, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %152
 
 ; <label>:152                                     ; preds = %148
   store i8 %151, i8* %145, align 8
@@ -949,14 +1031,14 @@ entry:
   %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
   %156 = bitcast i8* %155 to i64*
-  %NullCheck68 = icmp ne i64* %156, null
-  br i1 %NullCheck68, label %157, label %ThrowNullRef67
+  %NullCheck67 = icmp eq i64* %156, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %157
 
 ; <label>:157                                     ; preds = %153
   %158 = load i64, i64* %156, align 8
   %159 = bitcast i8* %154 to i64*
-  %NullCheck70 = icmp ne i64* %159, null
-  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+  %NullCheck69 = icmp eq i64* %159, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %160
 
 ; <label>:160                                     ; preds = %157
   store i64 %158, i64* %159, align 8
@@ -965,16 +1047,16 @@ entry:
   %163 = load i8*, i8** %arg1
   %164 = getelementptr inbounds i8, i8* %163, i64 8
   %165 = bitcast i8* %164 to i16*
-  %NullCheck72 = icmp ne i16* %165, null
-  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+  %NullCheck71 = icmp eq i16* %165, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %166
 
 ; <label>:166                                     ; preds = %160
   %167 = load i16, i16* %165, align 8
   %168 = sext i16 %167 to i32
   %169 = bitcast i8* %162 to i16*
   %170 = trunc i32 %168 to i16
-  %NullCheck74 = icmp ne i16* %169, null
-  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+  %NullCheck73 = icmp eq i16* %169, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %171
 
 ; <label>:171                                     ; preds = %166
   store i16 %170, i16* %169, align 8
@@ -984,14 +1066,14 @@ entry:
   %173 = load i8*, i8** %arg0
   %174 = load i8*, i8** %arg1
   %175 = bitcast i8* %174 to i64*
-  %NullCheck56 = icmp ne i64* %175, null
-  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+  %NullCheck55 = icmp eq i64* %175, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %176
 
 ; <label>:176                                     ; preds = %172
   %177 = load i64, i64* %175, align 8
   %178 = bitcast i8* %173 to i64*
-  %NullCheck58 = icmp ne i64* %178, null
-  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+  %NullCheck57 = icmp eq i64* %178, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %179
 
 ; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
@@ -1000,16 +1082,16 @@ entry:
   %182 = load i8*, i8** %arg1
   %183 = getelementptr inbounds i8, i8* %182, i64 8
   %184 = bitcast i8* %183 to i16*
-  %NullCheck60 = icmp ne i16* %184, null
-  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+  %NullCheck59 = icmp eq i16* %184, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %185
 
 ; <label>:185                                     ; preds = %179
   %186 = load i16, i16* %184, align 8
   %187 = sext i16 %186 to i32
   %188 = bitcast i8* %181 to i16*
   %189 = trunc i32 %187 to i16
-  %NullCheck62 = icmp ne i16* %188, null
-  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+  %NullCheck61 = icmp eq i16* %188, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %190
 
 ; <label>:190                                     ; preds = %185
   store i16 %189, i16* %188, align 8
@@ -1017,15 +1099,15 @@ entry:
   %192 = getelementptr inbounds i8, i8* %191, i64 10
   %193 = load i8*, i8** %arg1
   %194 = getelementptr inbounds i8, i8* %193, i64 10
-  %NullCheck64 = icmp ne i8* %194, null
-  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+  %NullCheck63 = icmp eq i8* %194, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %195
 
 ; <label>:195                                     ; preds = %190
   %196 = load i8, i8* %194, align 8
   %197 = zext i8 %196 to i32
   %198 = trunc i32 %197 to i8
-  %NullCheck66 = icmp ne i8* %192, null
-  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+  %NullCheck65 = icmp eq i8* %192, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %199
 
 ; <label>:199                                     ; preds = %195
   store i8 %198, i8* %192, align 8
@@ -1035,14 +1117,14 @@ entry:
   %201 = load i8*, i8** %arg0
   %202 = load i8*, i8** %arg1
   %203 = bitcast i8* %202 to i64*
-  %NullCheck48 = icmp ne i64* %203, null
-  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+  %NullCheck47 = icmp eq i64* %203, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %204
 
 ; <label>:204                                     ; preds = %200
   %205 = load i64, i64* %203, align 8
   %206 = bitcast i8* %201 to i64*
-  %NullCheck50 = icmp ne i64* %206, null
-  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+  %NullCheck49 = icmp eq i64* %206, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %207
 
 ; <label>:207                                     ; preds = %204
   store i64 %205, i64* %206, align 8
@@ -1051,14 +1133,14 @@ entry:
   %210 = load i8*, i8** %arg1
   %211 = getelementptr inbounds i8, i8* %210, i64 8
   %212 = bitcast i8* %211 to i32*
-  %NullCheck52 = icmp ne i32* %212, null
-  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+  %NullCheck51 = icmp eq i32* %212, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %213
 
 ; <label>:213                                     ; preds = %207
   %214 = load i32, i32* %212, align 8
   %215 = bitcast i8* %209 to i32*
-  %NullCheck54 = icmp ne i32* %215, null
-  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+  %NullCheck53 = icmp eq i32* %215, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %216
 
 ; <label>:216                                     ; preds = %213
   store i32 %214, i32* %215, align 8
@@ -1068,14 +1150,14 @@ entry:
   %218 = load i8*, i8** %arg0
   %219 = load i8*, i8** %arg1
   %220 = bitcast i8* %219 to i64*
-  %NullCheck36 = icmp ne i64* %220, null
-  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64* %220, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %221
 
 ; <label>:221                                     ; preds = %217
   %222 = load i64, i64* %220, align 8
   %223 = bitcast i8* %218 to i64*
-  %NullCheck38 = icmp ne i64* %223, null
-  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+  %NullCheck37 = icmp eq i64* %223, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %224
 
 ; <label>:224                                     ; preds = %221
   store i64 %222, i64* %223, align 8
@@ -1084,14 +1166,14 @@ entry:
   %227 = load i8*, i8** %arg1
   %228 = getelementptr inbounds i8, i8* %227, i64 8
   %229 = bitcast i8* %228 to i32*
-  %NullCheck40 = icmp ne i32* %229, null
-  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i32* %229, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %230
 
 ; <label>:230                                     ; preds = %224
   %231 = load i32, i32* %229, align 8
   %232 = bitcast i8* %226 to i32*
-  %NullCheck42 = icmp ne i32* %232, null
-  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+  %NullCheck41 = icmp eq i32* %232, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %233
 
 ; <label>:233                                     ; preds = %230
   store i32 %231, i32* %232, align 8
@@ -1099,15 +1181,15 @@ entry:
   %235 = getelementptr inbounds i8, i8* %234, i64 12
   %236 = load i8*, i8** %arg1
   %237 = getelementptr inbounds i8, i8* %236, i64 12
-  %NullCheck44 = icmp ne i8* %237, null
-  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i8* %237, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %238
 
 ; <label>:238                                     ; preds = %233
   %239 = load i8, i8* %237, align 8
   %240 = zext i8 %239 to i32
   %241 = trunc i32 %240 to i8
-  %NullCheck46 = icmp ne i8* %235, null
-  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+  %NullCheck45 = icmp eq i8* %235, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %242
 
 ; <label>:242                                     ; preds = %238
   store i8 %241, i8* %235, align 8
@@ -1117,14 +1199,14 @@ entry:
   %244 = load i8*, i8** %arg0
   %245 = load i8*, i8** %arg1
   %246 = bitcast i8* %245 to i64*
-  %NullCheck24 = icmp ne i64* %246, null
-  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64* %246, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %247
 
 ; <label>:247                                     ; preds = %243
   %248 = load i64, i64* %246, align 8
   %249 = bitcast i8* %244 to i64*
-  %NullCheck26 = icmp ne i64* %249, null
-  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64* %249, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %250
 
 ; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
@@ -1133,14 +1215,14 @@ entry:
   %253 = load i8*, i8** %arg1
   %254 = getelementptr inbounds i8, i8* %253, i64 8
   %255 = bitcast i8* %254 to i32*
-  %NullCheck28 = icmp ne i32* %255, null
-  br i1 %NullCheck28, label %256, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i32* %255, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %256
 
 ; <label>:256                                     ; preds = %250
   %257 = load i32, i32* %255, align 8
   %258 = bitcast i8* %252 to i32*
-  %NullCheck30 = icmp ne i32* %258, null
-  br i1 %NullCheck30, label %259, label %ThrowNullRef29
+  %NullCheck29 = icmp eq i32* %258, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %259
 
 ; <label>:259                                     ; preds = %256
   store i32 %257, i32* %258, align 8
@@ -1149,16 +1231,16 @@ entry:
   %262 = load i8*, i8** %arg1
   %263 = getelementptr inbounds i8, i8* %262, i64 12
   %264 = bitcast i8* %263 to i16*
-  %NullCheck32 = icmp ne i16* %264, null
-  br i1 %NullCheck32, label %265, label %ThrowNullRef31
+  %NullCheck31 = icmp eq i16* %264, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %265
 
 ; <label>:265                                     ; preds = %259
   %266 = load i16, i16* %264, align 8
   %267 = sext i16 %266 to i32
   %268 = bitcast i8* %261 to i16*
   %269 = trunc i32 %267 to i16
-  %NullCheck34 = icmp ne i16* %268, null
-  br i1 %NullCheck34, label %270, label %ThrowNullRef33
+  %NullCheck33 = icmp eq i16* %268, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %270
 
 ; <label>:270                                     ; preds = %265
   store i16 %269, i16* %268, align 8
@@ -1168,14 +1250,14 @@ entry:
   %272 = load i8*, i8** %arg0
   %273 = load i8*, i8** %arg1
   %274 = bitcast i8* %273 to i64*
-  %NullCheck8 = icmp ne i64* %274, null
-  br i1 %NullCheck8, label %275, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64* %274, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %275
 
 ; <label>:275                                     ; preds = %271
   %276 = load i64, i64* %274, align 8
   %277 = bitcast i8* %272 to i64*
-  %NullCheck10 = icmp ne i64* %277, null
-  br i1 %NullCheck10, label %278, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %277, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %278
 
 ; <label>:278                                     ; preds = %275
   store i64 %276, i64* %277, align 8
@@ -1184,14 +1266,14 @@ entry:
   %281 = load i8*, i8** %arg1
   %282 = getelementptr inbounds i8, i8* %281, i64 8
   %283 = bitcast i8* %282 to i32*
-  %NullCheck12 = icmp ne i32* %283, null
-  br i1 %NullCheck12, label %284, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i32* %283, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %284
 
 ; <label>:284                                     ; preds = %278
   %285 = load i32, i32* %283, align 8
   %286 = bitcast i8* %280 to i32*
-  %NullCheck14 = icmp ne i32* %286, null
-  br i1 %NullCheck14, label %287, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i32* %286, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %287
 
 ; <label>:287                                     ; preds = %284
   store i32 %285, i32* %286, align 8
@@ -1200,16 +1282,16 @@ entry:
   %290 = load i8*, i8** %arg1
   %291 = getelementptr inbounds i8, i8* %290, i64 12
   %292 = bitcast i8* %291 to i16*
-  %NullCheck16 = icmp ne i16* %292, null
-  br i1 %NullCheck16, label %293, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i16* %292, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %293
 
 ; <label>:293                                     ; preds = %287
   %294 = load i16, i16* %292, align 8
   %295 = sext i16 %294 to i32
   %296 = bitcast i8* %289 to i16*
   %297 = trunc i32 %295 to i16
-  %NullCheck18 = icmp ne i16* %296, null
-  br i1 %NullCheck18, label %298, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i16* %296, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %298
 
 ; <label>:298                                     ; preds = %293
   store i16 %297, i16* %296, align 8
@@ -1217,15 +1299,15 @@ entry:
   %300 = getelementptr inbounds i8, i8* %299, i64 14
   %301 = load i8*, i8** %arg1
   %302 = getelementptr inbounds i8, i8* %301, i64 14
-  %NullCheck20 = icmp ne i8* %302, null
-  br i1 %NullCheck20, label %303, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i8* %302, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %303
 
 ; <label>:303                                     ; preds = %298
   %304 = load i8, i8* %302, align 8
   %305 = zext i8 %304 to i32
   %306 = trunc i32 %305 to i8
-  %NullCheck22 = icmp ne i8* %300, null
-  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i8* %300, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %307
 
 ; <label>:307                                     ; preds = %303
   store i8 %306, i8* %300, align 8
@@ -1235,14 +1317,14 @@ entry:
   %309 = load i8*, i8** %arg0
   %310 = load i8*, i8** %arg1
   %311 = bitcast i8* %310 to i64*
-  %NullCheck = icmp ne i64* %311, null
-  br i1 %NullCheck, label %312, label %ThrowNullRef
+  %NullCheck = icmp eq i64* %311, null
+  br i1 %NullCheck, label %ThrowNullRef, label %312
 
 ; <label>:312                                     ; preds = %308
   %313 = load i64, i64* %311, align 8
   %314 = bitcast i8* %309 to i64*
-  %NullCheck2 = icmp ne i64* %314, null
-  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64* %314, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %315
 
 ; <label>:315                                     ; preds = %312
   store i64 %313, i64* %314, align 8
@@ -1251,14 +1333,14 @@ entry:
   %318 = load i8*, i8** %arg1
   %319 = getelementptr inbounds i8, i8* %318, i64 8
   %320 = bitcast i8* %319 to i64*
-  %NullCheck4 = icmp ne i64* %320, null
-  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64* %320, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %321
 
 ; <label>:321                                     ; preds = %315
   %322 = load i64, i64* %320, align 8
   %323 = bitcast i8* %317 to i64*
-  %NullCheck6 = icmp ne i64* %323, null
-  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64* %323, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %324
 
 ; <label>:324                                     ; preds = %321
   store i64 %322, i64* %323, align 8
@@ -1286,15 +1368,15 @@ entry:
 ; <label>:338                                     ; preds = %333
   %339 = load i8*, i8** %arg0
   %340 = load i8*, i8** %arg1
-  %NullCheck136 = icmp ne i8* %340, null
-  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+  %NullCheck135 = icmp eq i8* %340, null
+  br i1 %NullCheck135, label %ThrowNullRef136, label %341
 
 ; <label>:341                                     ; preds = %338
   %342 = load i8, i8* %340, align 8
   %343 = zext i8 %342 to i32
   %344 = trunc i32 %343 to i8
-  %NullCheck138 = icmp ne i8* %339, null
-  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+  %NullCheck137 = icmp eq i8* %339, null
+  br i1 %NullCheck137, label %ThrowNullRef138, label %345
 
 ; <label>:345                                     ; preds = %341
   store i8 %344, i8* %339, align 8
@@ -1317,16 +1399,16 @@ entry:
   %357 = load i8*, i8** %arg0
   %358 = load i8*, i8** %arg1
   %359 = bitcast i8* %358 to i16*
-  %NullCheck140 = icmp ne i16* %359, null
-  br i1 %NullCheck140, label %360, label %ThrowNullRef139
+  %NullCheck139 = icmp eq i16* %359, null
+  br i1 %NullCheck139, label %ThrowNullRef140, label %360
 
 ; <label>:360                                     ; preds = %356
   %361 = load i16, i16* %359, align 8
   %362 = sext i16 %361 to i32
   %363 = bitcast i8* %357 to i16*
   %364 = trunc i32 %362 to i16
-  %NullCheck142 = icmp ne i16* %363, null
-  br i1 %NullCheck142, label %365, label %ThrowNullRef141
+  %NullCheck141 = icmp eq i16* %363, null
+  br i1 %NullCheck141, label %ThrowNullRef142, label %365
 
 ; <label>:365                                     ; preds = %360
   store i16 %364, i16* %363, align 8
@@ -1352,14 +1434,14 @@ entry:
   %378 = load i8*, i8** %arg0
   %379 = load i8*, i8** %arg1
   %380 = bitcast i8* %379 to i32*
-  %NullCheck144 = icmp ne i32* %380, null
-  br i1 %NullCheck144, label %381, label %ThrowNullRef143
+  %NullCheck143 = icmp eq i32* %380, null
+  br i1 %NullCheck143, label %ThrowNullRef144, label %381
 
 ; <label>:381                                     ; preds = %377
   %382 = load i32, i32* %380, align 8
   %383 = bitcast i8* %378 to i32*
-  %NullCheck146 = icmp ne i32* %383, null
-  br i1 %NullCheck146, label %384, label %ThrowNullRef145
+  %NullCheck145 = icmp eq i32* %383, null
+  br i1 %NullCheck145, label %ThrowNullRef146, label %384
 
 ; <label>:384                                     ; preds = %381
   store i32 %382, i32* %383, align 8
@@ -1384,14 +1466,14 @@ entry:
   %395 = load i8*, i8** %arg0
   %396 = load i8*, i8** %arg1
   %397 = bitcast i8* %396 to i64*
-  %NullCheck164 = icmp ne i64* %397, null
-  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+  %NullCheck163 = icmp eq i64* %397, null
+  br i1 %NullCheck163, label %ThrowNullRef164, label %398
 
 ; <label>:398                                     ; preds = %394
   %399 = load i64, i64* %397, align 8
   %400 = bitcast i8* %395 to i64*
-  %NullCheck166 = icmp ne i64* %400, null
-  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+  %NullCheck165 = icmp eq i64* %400, null
+  br i1 %NullCheck165, label %ThrowNullRef166, label %401
 
 ; <label>:401                                     ; preds = %398
   store i64 %399, i64* %400, align 8
@@ -1400,14 +1482,14 @@ entry:
   %404 = load i8*, i8** %arg1
   %405 = getelementptr inbounds i8, i8* %404, i64 8
   %406 = bitcast i8* %405 to i64*
-  %NullCheck168 = icmp ne i64* %406, null
-  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+  %NullCheck167 = icmp eq i64* %406, null
+  br i1 %NullCheck167, label %ThrowNullRef168, label %407
 
 ; <label>:407                                     ; preds = %401
   %408 = load i64, i64* %406, align 8
   %409 = bitcast i8* %403 to i64*
-  %NullCheck170 = icmp ne i64* %409, null
-  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+  %NullCheck169 = icmp eq i64* %409, null
+  br i1 %NullCheck169, label %ThrowNullRef170, label %410
 
 ; <label>:410                                     ; preds = %407
   store i64 %408, i64* %409, align 8
@@ -1437,14 +1519,14 @@ entry:
   %425 = load i8*, i8** %arg0
   %426 = load i8*, i8** %arg1
   %427 = bitcast i8* %426 to i64*
-  %NullCheck148 = icmp ne i64* %427, null
-  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+  %NullCheck147 = icmp eq i64* %427, null
+  br i1 %NullCheck147, label %ThrowNullRef148, label %428
 
 ; <label>:428                                     ; preds = %424
   %429 = load i64, i64* %427, align 8
   %430 = bitcast i8* %425 to i64*
-  %NullCheck150 = icmp ne i64* %430, null
-  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+  %NullCheck149 = icmp eq i64* %430, null
+  br i1 %NullCheck149, label %ThrowNullRef150, label %431
 
 ; <label>:431                                     ; preds = %428
   store i64 %429, i64* %430, align 8
@@ -1466,14 +1548,14 @@ entry:
   %441 = load i8*, i8** %arg0
   %442 = load i8*, i8** %arg1
   %443 = bitcast i8* %442 to i32*
-  %NullCheck152 = icmp ne i32* %443, null
-  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+  %NullCheck151 = icmp eq i32* %443, null
+  br i1 %NullCheck151, label %ThrowNullRef152, label %444
 
 ; <label>:444                                     ; preds = %440
   %445 = load i32, i32* %443, align 8
   %446 = bitcast i8* %441 to i32*
-  %NullCheck154 = icmp ne i32* %446, null
-  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+  %NullCheck153 = icmp eq i32* %446, null
+  br i1 %NullCheck153, label %ThrowNullRef154, label %447
 
 ; <label>:447                                     ; preds = %444
   store i32 %445, i32* %446, align 8
@@ -1495,16 +1577,16 @@ entry:
   %457 = load i8*, i8** %arg0
   %458 = load i8*, i8** %arg1
   %459 = bitcast i8* %458 to i16*
-  %NullCheck156 = icmp ne i16* %459, null
-  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+  %NullCheck155 = icmp eq i16* %459, null
+  br i1 %NullCheck155, label %ThrowNullRef156, label %460
 
 ; <label>:460                                     ; preds = %456
   %461 = load i16, i16* %459, align 8
   %462 = sext i16 %461 to i32
   %463 = bitcast i8* %457 to i16*
   %464 = trunc i32 %462 to i16
-  %NullCheck158 = icmp ne i16* %463, null
-  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+  %NullCheck157 = icmp eq i16* %463, null
+  br i1 %NullCheck157, label %ThrowNullRef158, label %465
 
 ; <label>:465                                     ; preds = %460
   store i16 %464, i16* %463, align 8
@@ -1525,15 +1607,15 @@ entry:
 ; <label>:474                                     ; preds = %470
   %475 = load i8*, i8** %arg0
   %476 = load i8*, i8** %arg1
-  %NullCheck160 = icmp ne i8* %476, null
-  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+  %NullCheck159 = icmp eq i8* %476, null
+  br i1 %NullCheck159, label %ThrowNullRef160, label %477
 
 ; <label>:477                                     ; preds = %474
   %478 = load i8, i8* %476, align 8
   %479 = zext i8 %478 to i32
   %480 = trunc i32 %479 to i8
-  %NullCheck162 = icmp ne i8* %475, null
-  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+  %NullCheck161 = icmp eq i8* %475, null
+  br i1 %NullCheck161, label %ThrowNullRef162, label %481
 
 ; <label>:481                                     ; preds = %477
   store i8 %480, i8* %475, align 8
@@ -1553,343 +1635,343 @@ ThrowNullRef:                                     ; preds = %308
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %312
+ThrowNullRef2:                                    ; preds = %312
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %315
+ThrowNullRef4:                                    ; preds = %315
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %321
+ThrowNullRef6:                                    ; preds = %321
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %271
+ThrowNullRef8:                                    ; preds = %271
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %275
+ThrowNullRef10:                                   ; preds = %275
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %278
+ThrowNullRef12:                                   ; preds = %278
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %284
+ThrowNullRef14:                                   ; preds = %284
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %287
+ThrowNullRef16:                                   ; preds = %287
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %293
+ThrowNullRef18:                                   ; preds = %293
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %298
+ThrowNullRef20:                                   ; preds = %298
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %303
+ThrowNullRef22:                                   ; preds = %303
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %243
+ThrowNullRef24:                                   ; preds = %243
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %247
+ThrowNullRef26:                                   ; preds = %247
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %250
+ThrowNullRef28:                                   ; preds = %250
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %256
+ThrowNullRef30:                                   ; preds = %256
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %259
+ThrowNullRef32:                                   ; preds = %259
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %265
+ThrowNullRef34:                                   ; preds = %265
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %217
+ThrowNullRef36:                                   ; preds = %217
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %221
+ThrowNullRef38:                                   ; preds = %221
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %224
+ThrowNullRef40:                                   ; preds = %224
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %230
+ThrowNullRef42:                                   ; preds = %230
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %233
+ThrowNullRef44:                                   ; preds = %233
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %238
+ThrowNullRef46:                                   ; preds = %238
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %200
+ThrowNullRef48:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %204
+ThrowNullRef50:                                   ; preds = %204
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %207
+ThrowNullRef52:                                   ; preds = %207
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %213
+ThrowNullRef54:                                   ; preds = %213
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %172
+ThrowNullRef56:                                   ; preds = %172
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %176
+ThrowNullRef58:                                   ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %179
+ThrowNullRef60:                                   ; preds = %179
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %185
+ThrowNullRef62:                                   ; preds = %185
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %190
+ThrowNullRef64:                                   ; preds = %190
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %195
+ThrowNullRef66:                                   ; preds = %195
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %153
+ThrowNullRef68:                                   ; preds = %153
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %157
+ThrowNullRef70:                                   ; preds = %157
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %160
+ThrowNullRef72:                                   ; preds = %160
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %166
+ThrowNullRef74:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %136
+ThrowNullRef76:                                   ; preds = %136
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %140
+ThrowNullRef78:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %143
+ThrowNullRef80:                                   ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %148
+ThrowNullRef82:                                   ; preds = %148
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %128
+ThrowNullRef84:                                   ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %132
+ThrowNullRef86:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %100
+ThrowNullRef88:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %104
+ThrowNullRef90:                                   ; preds = %104
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %107
+ThrowNullRef92:                                   ; preds = %107
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %113
+ThrowNullRef94:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %118
+ThrowNullRef96:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %123
+ThrowNullRef98:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %81
+ThrowNullRef100:                                  ; preds = %81
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef101:                                  ; preds = %85
+ThrowNullRef102:                                  ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef103:                                  ; preds = %88
+ThrowNullRef104:                                  ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef105:                                  ; preds = %94
+ThrowNullRef106:                                  ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef107:                                  ; preds = %64
+ThrowNullRef108:                                  ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef109:                                  ; preds = %68
+ThrowNullRef110:                                  ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef111:                                  ; preds = %71
+ThrowNullRef112:                                  ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef113:                                  ; preds = %76
+ThrowNullRef114:                                  ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef115:                                  ; preds = %56
+ThrowNullRef116:                                  ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef117:                                  ; preds = %60
+ThrowNullRef118:                                  ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef119:                                  ; preds = %37
+ThrowNullRef120:                                  ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef121:                                  ; preds = %41
+ThrowNullRef122:                                  ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef123:                                  ; preds = %46
+ThrowNullRef124:                                  ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef125:                                  ; preds = %51
+ThrowNullRef126:                                  ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef127:                                  ; preds = %27
+ThrowNullRef128:                                  ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef129:                                  ; preds = %31
+ThrowNullRef130:                                  ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef131:                                  ; preds = %19
+ThrowNullRef132:                                  ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef133:                                  ; preds = %22
+ThrowNullRef134:                                  ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef135:                                  ; preds = %338
+ThrowNullRef136:                                  ; preds = %338
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef137:                                  ; preds = %341
+ThrowNullRef138:                                  ; preds = %341
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef139:                                  ; preds = %356
+ThrowNullRef140:                                  ; preds = %356
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef141:                                  ; preds = %360
+ThrowNullRef142:                                  ; preds = %360
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef143:                                  ; preds = %377
+ThrowNullRef144:                                  ; preds = %377
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef145:                                  ; preds = %381
+ThrowNullRef146:                                  ; preds = %381
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef147:                                  ; preds = %424
+ThrowNullRef148:                                  ; preds = %424
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef149:                                  ; preds = %428
+ThrowNullRef150:                                  ; preds = %428
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef151:                                  ; preds = %440
+ThrowNullRef152:                                  ; preds = %440
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef153:                                  ; preds = %444
+ThrowNullRef154:                                  ; preds = %444
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef155:                                  ; preds = %456
+ThrowNullRef156:                                  ; preds = %456
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef157:                                  ; preds = %460
+ThrowNullRef158:                                  ; preds = %460
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef159:                                  ; preds = %474
+ThrowNullRef160:                                  ; preds = %474
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef161:                                  ; preds = %477
+ThrowNullRef162:                                  ; preds = %477
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef163:                                  ; preds = %394
+ThrowNullRef164:                                  ; preds = %394
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef165:                                  ; preds = %398
+ThrowNullRef166:                                  ; preds = %398
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef167:                                  ; preds = %401
+ThrowNullRef168:                                  ; preds = %401
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef169:                                  ; preds = %407
+ThrowNullRef170:                                  ; preds = %407
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1939,8 +2021,8 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
-  br i1 %NullCheck, label %22, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %ThrowNullRef, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
@@ -1948,8 +2030,8 @@ entry:
   store i32 %24, i32* %loc0
   %25 = load i32, i32* %loc0
   %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %26, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %27
 
 ; <label>:27                                      ; preds = %22
   %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
@@ -1971,7 +2053,7 @@ ThrowNullRef:                                     ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1989,8 +2071,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -2022,15 +2104,15 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2048,16 +2130,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
   %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
   store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %15
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
@@ -2072,8 +2154,8 @@ entry:
   %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
   %29 = ptrtoint i16 addrspace(1)* %28 to i64
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %19
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
@@ -2089,19 +2171,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2114,8 +2196,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
@@ -2128,7 +2210,7 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[loadElem]
+Failed to read AppDomain.PrepareDataForSetup[storeElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
@@ -2202,8 +2284,8 @@ entry:
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
-  br i1 %NullCheck24, label %27, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = load i64, i64 addrspace(1)* %26
@@ -2218,8 +2300,8 @@ entry:
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
-  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
   %41 = load i64, i64 addrspace(1)* %39
@@ -2236,8 +2318,8 @@ entry:
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
-  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
   %54 = load i64, i64 addrspace(1)* %52
@@ -2252,8 +2334,8 @@ entry:
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
   %67 = load i64, i64 addrspace(1)* %65
@@ -2270,8 +2352,8 @@ entry:
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
-  br i1 %NullCheck16, label %79, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
   %80 = load i64, i64 addrspace(1)* %78
@@ -2286,8 +2368,8 @@ entry:
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
-  br i1 %NullCheck18, label %92, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
   %93 = load i64, i64 addrspace(1)* %91
@@ -2304,8 +2386,8 @@ entry:
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
-  br i1 %NullCheck12, label %105, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = load i64, i64 addrspace(1)* %104
@@ -2320,8 +2402,8 @@ entry:
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
-  br i1 %NullCheck14, label %118, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
   %119 = load i64, i64 addrspace(1)* %117
@@ -2337,8 +2419,8 @@ entry:
 
 ; <label>:128                                     ; preds = %20
   %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
-  br i1 %NullCheck4, label %130, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %129, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %130
 
 ; <label>:130                                     ; preds = %128
   %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
@@ -2346,8 +2428,8 @@ entry:
   %133 = load i16, i16 addrspace(1)* %132, align 8
   %134 = zext i16 %133 to i32
   %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
-  br i1 %NullCheck6, label %136, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %135, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %136
 
 ; <label>:136                                     ; preds = %130
   %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
@@ -2360,8 +2442,8 @@ entry:
 
 ; <label>:143                                     ; preds = %136
   %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
-  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %144, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %145
 
 ; <label>:145                                     ; preds = %143
   %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
@@ -2369,8 +2451,8 @@ entry:
   %148 = load i16, i16 addrspace(1)* %147, align 8
   %149 = zext i16 %148 to i32
   %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %150, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %151
 
 ; <label>:151                                     ; preds = %145
   %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
@@ -2388,8 +2470,8 @@ entry:
 
 ; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
-  br i1 %NullCheck, label %163, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %ThrowNullRef, label %163
 
 ; <label>:163                                     ; preds = %161
   %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
@@ -2399,8 +2481,8 @@ entry:
 
 ; <label>:167                                     ; preds = %163
   %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
-  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %168, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %169
 
 ; <label>:169                                     ; preds = %167
   %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
@@ -2432,55 +2514,55 @@ ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %167
+ThrowNullRef2:                                    ; preds = %167
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %128
+ThrowNullRef4:                                    ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %130
+ThrowNullRef6:                                    ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %143
+ThrowNullRef8:                                    ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %145
+ThrowNullRef10:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %102
+ThrowNullRef12:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %105
+ThrowNullRef14:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %76
+ThrowNullRef16:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %79
+ThrowNullRef18:                                   ; preds = %79
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %50
+ThrowNullRef20:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %53
+ThrowNullRef22:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %24
+ThrowNullRef24:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %27
+ThrowNullRef26:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2503,15 +2585,15 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2519,16 +2601,16 @@ entry:
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
   store i32 %8, i32* %loc0
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
   %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
   store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
@@ -2546,16 +2628,16 @@ entry:
 
 ; <label>:23                                      ; preds = %64
   %24 = load i16*, i16** %loc3
-  %NullCheck12 = icmp ne i16* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i16* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
   store i32 %27, i32* %loc5
   %28 = load i16*, i16** %loc4
-  %NullCheck14 = icmp ne i16* %28, null
-  br i1 %NullCheck14, label %29, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %28, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = load i16, i16* %28, align 8
@@ -2620,15 +2702,15 @@ entry:
 
 ; <label>:67                                      ; preds = %64
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
-  br i1 %NullCheck8, label %69, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %68, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %69
 
 ; <label>:69                                      ; preds = %67
   %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
   %71 = load i32, i32 addrspace(1)* %70
   %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
-  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %73
 
 ; <label>:73                                      ; preds = %69
   %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
@@ -2645,31 +2727,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %67
+ThrowNullRef8:                                    ; preds = %67
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %69
+ThrowNullRef10:                                   ; preds = %69
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2710,14 +2792,14 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
   %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
@@ -2730,14 +2812,14 @@ entry:
 
 ; <label>:11                                      ; preds = %4
   %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
   %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
@@ -2749,14 +2831,14 @@ entry:
 
 ; <label>:22                                      ; preds = %16
   %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
   %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
-  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
-  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
@@ -2804,23 +2886,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2836,7 +2918,280 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[loadElem]
+Successfully read RuntimeType.IsAssignableFrom
+
+define i8 @RuntimeType.IsAssignableFrom(%System.RuntimeType addrspace(1)* %param0, %System.Type addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.RuntimeType addrspace(1)*
+  %arg1 = alloca %System.Type addrspace(1)*
+  %loc0 = alloca %System.RuntimeType addrspace(1)*
+  %loc1 = alloca %"System.Type[]" addrspace(1)*
+  %loc2 = alloca i32
+  store %System.RuntimeType addrspace(1)* %param0, %System.RuntimeType addrspace(1)** %this
+  store %System.Type addrspace(1)* %param1, %System.Type addrspace(1)** %arg1
+  %0 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %1 = icmp ne %System.Type addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i8 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %5 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %6 = bitcast %System.Type addrspace(1)* %4 to %System.Object addrspace(1)*
+  %7 = bitcast %System.RuntimeType addrspace(1)* %5 to %System.Object addrspace(1)*
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %6, %System.Object addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %3
+  ret i8 1
+
+; <label>:12                                      ; preds = %3
+  %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 152
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 32
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
+  %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
+  %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
+  store %System.RuntimeType addrspace(1)* %25, %System.RuntimeType addrspace(1)** %loc0
+  %26 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %27 = icmp eq %System.RuntimeType addrspace(1)* %26, null
+  br i1 %27, label %34, label %28
+
+; <label>:28                                      ; preds = %15
+  %29 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %30 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)*)*)(%System.RuntimeType addrspace(1)* %29, %System.RuntimeType addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+; <label>:34                                      ; preds = %15
+  %35 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %36 = call %System.Reflection.Emit.TypeBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Reflection.Emit.TypeBuilder addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %35)
+  %37 = icmp eq %System.Reflection.Emit.TypeBuilder addrspace(1)* %36, null
+  br i1 %37, label %139, label %38
+
+; <label>:38                                      ; preds = %34
+  %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %42
+
+; <label>:42                                      ; preds = %38
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 152
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 40
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
+  %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
+  %53 = zext i8 %52 to i32
+  %54 = icmp eq i32 %53, 0
+  br i1 %54, label %56, label %55
+
+; <label>:55                                      ; preds = %42
+  ret i8 1
+
+; <label>:56                                      ; preds = %42
+  %57 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %58 = bitcast %System.RuntimeType addrspace(1)* %57 to %System.Type addrspace(1)*
+  %59 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %58)
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %64 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.Type addrspace(1)* %63, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = bitcast %System.RuntimeType addrspace(1)* %64 to %System.Type addrspace(1)*
+  %67 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %63, %System.Type addrspace(1)* %66)
+  %68 = zext i8 %67 to i32
+  %69 = trunc i32 %68 to i8
+  ret i8 %69
+
+; <label>:70                                      ; preds = %56
+  %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
+  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %73
+
+; <label>:73                                      ; preds = %70
+  %74 = load i64, i64 addrspace(1)* %72
+  %75 = add i64 %74, 128
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = add i64 %77, 0
+  %79 = inttoptr i64 %78 to i64*
+  %80 = load i64, i64* %79
+  %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
+  %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
+  %83 = call i8 %82(%System.Type addrspace(1)* %81)
+  %84 = zext i8 %83 to i32
+  %85 = icmp eq i32 %84, 0
+  br i1 %85, label %139, label %86
+
+; <label>:86                                      ; preds = %73
+  %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
+  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %89
+
+; <label>:89                                      ; preds = %86
+  %90 = load i64, i64 addrspace(1)* %88
+  %91 = add i64 %90, 128
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = add i64 %93, 24
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
+  %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
+  %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
+  store %"System.Type[]" addrspace(1)* %99, %"System.Type[]" addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %129
+
+; <label>:100                                     ; preds = %132
+  %101 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %102 = load i32, i32* %loc2
+  %NullCheck11 = icmp eq %"System.Type[]" addrspace(1)* %101, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %103
+
+; <label>:103                                     ; preds = %100
+  %104 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 1
+  %105 = load i32, i32 addrspace(1)* %104
+  %106 = zext i32 %105 to i64
+  %107 = zext i32 %102 to i64
+  %BoundsCheck = icmp uge i64 %107, %106
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %108
+
+; <label>:108                                     ; preds = %103
+  %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
+  %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
+  %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
+  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %113
+
+; <label>:113                                     ; preds = %108
+  %114 = load i64, i64 addrspace(1)* %112
+  %115 = add i64 %114, 152
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = add i64 %117, 56
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
+  %123 = zext i8 %122 to i32
+  %124 = icmp ne i32 %123, 0
+  br i1 %124, label %126, label %125
+
+; <label>:125                                     ; preds = %113
+  ret i8 0
+
+; <label>:126                                     ; preds = %113
+  %127 = load i32, i32* %loc2
+  %128 = add i32 %127, 1
+  store i32 %128, i32* %loc2
+  br label %129
+
+; <label>:129                                     ; preds = %89, %126
+  %130 = load i32, i32* %loc2
+  %131 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %NullCheck9 = icmp eq %"System.Type[]" addrspace(1)* %131, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %132
+
+; <label>:132                                     ; preds = %129
+  %133 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %131, i32 0, i32 1
+  %134 = load i32, i32 addrspace(1)* %133
+  %135 = zext i32 %134 to i64
+  %136 = trunc i64 %135 to i32
+  %137 = icmp slt i32 %130, %136
+  br i1 %137, label %100, label %138
+
+; <label>:138                                     ; preds = %132
+  ret i8 1
+
+; <label>:139                                     ; preds = %34, %73
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %129
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %103
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -2893,7 +3248,7 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElem]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -2904,8 +3259,8 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -2997,8 +3352,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
@@ -3059,8 +3414,8 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -3087,8 +3442,8 @@ entry:
 
 ; <label>:17                                      ; preds = %5, %11
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
@@ -3097,8 +3452,8 @@ entry:
 
 ; <label>:22                                      ; preds = %1, %11
   %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
@@ -3109,11 +3464,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %17
+ThrowNullRef2:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %22
+ThrowNullRef4:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3167,15 +3522,15 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
   %15 = load i32, i32 addrspace(1)* %14
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
@@ -3198,7 +3553,7 @@ ThrowNullRef:                                     ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef2:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3232,8 +3587,8 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
@@ -3312,8 +3667,8 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -3327,8 +3682,8 @@ entry:
 ; <label>:5                                       ; preds = %43
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %7 = load i32, i32* %loc1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck6, label %8, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
@@ -3366,8 +3721,8 @@ entry:
 ; <label>:32                                      ; preds = %21, %25
   %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
   %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
-  br i1 %NullCheck8, label %35, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = trunc i32 %34 to i16
@@ -3380,8 +3735,8 @@ entry:
 ; <label>:40                                      ; preds = %1, %35
   %41 = load i32, i32* %loc1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
-  br i1 %NullCheck2, label %43, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %42, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
@@ -3392,8 +3747,8 @@ entry:
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
   %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
-  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
   %51 = load i64, i64 addrspace(1)* %49
@@ -3412,19 +3767,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %40
+ThrowNullRef2:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %47
+ThrowNullRef4:                                    ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %5
+ThrowNullRef6:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %32
+ThrowNullRef8:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3467,8 +3822,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
@@ -3492,11 +3847,391 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(i16* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store i16* %param0, i16** %arg0
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load i32, i32* %arg3
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %42, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %37, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg2
+  %13 = load i32, i32* %arg3
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %37, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %24 = load i32, i32* %arg2
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load i16*, i16** %arg0
+  %35 = load i32, i32* %arg3
+  %36 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %36, i16* %34, i32 %35)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:37                                      ; preds = %5, %16
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %39)
+  %41 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41, %System.String addrspace(1)* %38, %System.String addrspace(1)* %40)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41) #0
+  unreachable
+
+; <label>:42                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
-Failed to read StringBuilder.ToString[loadElemA]
+Successfully read StringBuilder.ToString
+
+define %System.String addrspace(1)* @StringBuilder.ToString(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i16*
+  %loc3 = alloca %"System.Char[]" addrspace(1)*
+  %loc4 = alloca i32
+  %loc5 = alloca i32
+  %loc6 = alloca i16 addrspace(1)*
+  %loc7 = alloca %System.String addrspace(1)*
+  %loc8 = alloca %"System.Char[]" addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %0)
+  %2 = icmp ne i32 %1, 0
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %4
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %6)
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %7)
+  store %System.String addrspace(1)* %8, %System.String addrspace(1)** %loc0
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.Text.StringBuilder addrspace(1)* %9, %System.Text.StringBuilder addrspace(1)** %loc1
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  store %System.String addrspace(1)* %10, %System.String addrspace(1)** %loc7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc7
+  %12 = ptrtoint %System.String addrspace(1)* %11 to i64
+  %13 = icmp eq i64 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %5
+  %15 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %16 = sext i32 %15 to i64
+  %17 = add i64 %12, %16
+  br label %18
+
+; <label>:18                                      ; preds = %5, %14
+  %19 = phi i64 [ %12, %5 ], [ %17, %14 ]
+  %20 = inttoptr i64 %19 to i16*
+  store i16* %20, i16** %loc2
+  br label %21
+
+; <label>:21                                      ; preds = %98, %18
+  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %22, null
+  br i1 %NullCheck, label %ThrowNullRef, label %23
+
+; <label>:23                                      ; preds = %21
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 3
+  %25 = load i32, i32 addrspace(1)* %24, align 8
+  %26 = icmp sle i32 %25, 0
+  br i1 %26, label %96, label %27
+
+; <label>:27                                      ; preds = %23
+  %28 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %28, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %29
+
+; <label>:29                                      ; preds = %27
+  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %28, i32 0, i32 1
+  %31 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %30, align 8
+  store %"System.Char[]" addrspace(1)* %31, %"System.Char[]" addrspace(1)** %loc3
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %33
+
+; <label>:33                                      ; preds = %29
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  store i32 %35, i32* %loc4
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  %39 = load i32, i32 addrspace(1)* %38, align 8
+  store i32 %39, i32* %loc5
+  %40 = load i32, i32* %loc5
+  %41 = load i32, i32* %loc4
+  %42 = add i32 %40, %41
+  %43 = zext i32 %42 to i64
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %45
+
+; <label>:45                                      ; preds = %37
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = sext i32 %47 to i64
+  %49 = icmp sgt i64 %43, %48
+  br i1 %49, label %91, label %50
+
+; <label>:50                                      ; preds = %45
+  %51 = load i32, i32* %loc5
+  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %52, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %53
+
+; <label>:53                                      ; preds = %50
+  %54 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %52, i32 0, i32 1
+  %55 = load i32, i32 addrspace(1)* %54
+  %56 = zext i32 %55 to i64
+  %57 = trunc i64 %56 to i32
+  %58 = icmp ugt i32 %51, %57
+  br i1 %58, label %91, label %59
+
+; <label>:59                                      ; preds = %53
+  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  store %"System.Char[]" addrspace(1)* %60, %"System.Char[]" addrspace(1)** %loc8
+  %61 = icmp eq %"System.Char[]" addrspace(1)* %60, null
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %63, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %64
+
+; <label>:64                                      ; preds = %62
+  %65 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %63, i32 0, i32 1
+  %66 = load i32, i32 addrspace(1)* %65
+  %67 = zext i32 %66 to i64
+  %68 = trunc i64 %67 to i32
+  %69 = icmp ne i32 %68, 0
+  br i1 %69, label %71, label %70
+
+; <label>:70                                      ; preds = %59, %64
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:71                                      ; preds = %64
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %73
+
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %BoundsCheck = icmp uge i64 0, %76
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %77
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %78, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:79                                      ; preds = %70, %77
+  %80 = load i16*, i16** %loc2
+  %81 = load i32, i32* %loc4
+  %82 = sext i32 %81 to i64
+  %83 = mul i64 %82, 2
+  %84 = bitcast i16* %80 to i8*
+  %85 = getelementptr inbounds i8, i8* %84, i64 %83
+  %86 = load i16 addrspace(1)*, i16 addrspace(1)** %loc6
+  %87 = ptrtoint i16 addrspace(1)* %86 to i64
+  %88 = load i32, i32* %loc5
+  %89 = bitcast i8* %85 to i16*
+  %90 = inttoptr i64 %87 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %89, i16* %90, i32 %88)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %96
+
+; <label>:91                                      ; preds = %45, %53
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %94 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %93)
+  %95 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95, %System.String addrspace(1)* %92, %System.String addrspace(1)* %94)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95) #0
+  unreachable
+
+; <label>:96                                      ; preds = %23, %79
+  %97 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %97, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %98
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %97, i32 0, i32 2
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  store %System.Text.StringBuilder addrspace(1)* %100, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %102 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %102, label %21, label %103
+
+; <label>:103                                     ; preds = %98
+  store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc7
+  %104 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  ret %System.String addrspace(1)* %104
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method StringBuilder::get_Length using LLILCJit
+Successfully read StringBuilder.get_Length
+
+define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
+Successfully read RuntimeHelpers.get_OffsetToStringData
+
+define i32 @RuntimeHelpers.get_OffsetToStringData() {
+entry:
+  ret i32 12
+}
+
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
 Successfully read CultureData.CreateCultureData
 
@@ -3514,23 +4249,23 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
   store i8 %4, i8 addrspace(1)* %6
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
@@ -3549,11 +4284,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3566,50 +4301,50 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
   store i32 -1, i32 addrspace(1)* %2
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
   store i32 -1, i32 addrspace(1)* %8
   %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
   store i32 -1, i32 addrspace(1)* %14
   %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
   store i32 -1, i32 addrspace(1)* %17
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
@@ -3623,27 +4358,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3675,7 +4410,136 @@ Failed to read Dictionary`2.Insert[non-const derefAddress]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
 Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
-Failed to read HashHelpers.GetPrime[loadElem]
+Successfully read HashHelpers.GetPrime
+
+define i32 @HashHelpers.GetPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %6, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5, %System.String addrspace(1)* %4)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5) #0
+  unreachable
+
+; <label>:6                                       ; preds = %entry
+  store i32 0, i32* %loc0
+  br label %29
+
+; <label>:7                                       ; preds = %35
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 1296
+  %10 = addrspacecast i8 addrspace(1)* %9 to %"System.Int32[]" addrspace(1)**
+  %11 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %10
+  %12 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Int32[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = zext i32 %15 to i64
+  %17 = zext i32 %12 to i64
+  %BoundsCheck = icmp uge i64 %17, %16
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 3, i32 %12
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  store i32 %20, i32* %loc1
+  %21 = load i32, i32* %loc1
+  %22 = load i32, i32* %arg0
+  %23 = icmp slt i32 %21, %22
+  br i1 %23, label %26, label %24
+
+; <label>:24                                      ; preds = %18
+  %25 = load i32, i32* %loc1
+  ret i32 %25
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %loc0
+  %28 = add i32 %27, 1
+  store i32 %28, i32* %loc0
+  br label %29
+
+; <label>:29                                      ; preds = %6, %26
+  %30 = load i32, i32* %loc0
+  %31 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %32 = getelementptr inbounds i8, i8 addrspace(1)* %31, i64 1296
+  %33 = addrspacecast i8 addrspace(1)* %32 to %"System.Int32[]" addrspace(1)**
+  %34 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %33
+  %NullCheck = icmp eq %"System.Int32[]" addrspace(1)* %34, null
+  br i1 %NullCheck, label %ThrowNullRef, label %35
+
+; <label>:35                                      ; preds = %29
+  %36 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %34, i32 0, i32 1
+  %37 = load i32, i32 addrspace(1)* %36
+  %38 = zext i32 %37 to i64
+  %39 = trunc i64 %38 to i32
+  %40 = icmp slt i32 %30, %39
+  br i1 %40, label %7, label %41
+
+; <label>:41                                      ; preds = %35
+  %42 = load i32, i32* %arg0
+  %43 = or i32 %42, 1
+  store i32 %43, i32* %loc2
+  br label %59
+
+; <label>:44                                      ; preds = %59
+  %45 = load i32, i32* %loc2
+  %46 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %45)
+  %47 = zext i8 %46 to i32
+  %48 = icmp eq i32 %47, 0
+  br i1 %48, label %56, label %49
+
+; <label>:49                                      ; preds = %44
+  %50 = load i32, i32* %loc2
+  %51 = sub i32 %50, 1
+  %52 = srem i32 %51, 101
+  %53 = icmp eq i32 %52, 0
+  br i1 %53, label %56, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = load i32, i32* %loc2
+  ret i32 %55
+
+; <label>:56                                      ; preds = %44, %49
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %57, 2
+  store i32 %58, i32* %loc2
+  br label %59
+
+; <label>:59                                      ; preds = %41, %56
+  %60 = load i32, i32* %loc2
+  %61 = icmp slt i32 %60, 2147483647
+  br i1 %61, label %44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load i32, i32* %arg0
+  ret i32 %63
+
+ThrowNullRef:                                     ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
 Successfully read GenericEqualityComparer`1.GetHashCode
 
@@ -3694,14 +4558,14 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
   %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load i64, i64 addrspace(1)* %7
@@ -3720,7 +4584,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3750,8 +4614,8 @@ entry:
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
@@ -3796,8 +4660,8 @@ entry:
   %35 = bitcast i16* %34 to i8*
   %36 = getelementptr inbounds i8, i8* %35, i64 2
   %37 = bitcast i8* %36 to i16*
-  %NullCheck4 = icmp ne i16* %37, null
-  br i1 %NullCheck4, label %38, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %37, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %38
 
 ; <label>:38                                      ; preds = %27
   %39 = load i16, i16* %37, align 8
@@ -3824,8 +4688,8 @@ entry:
 
 ; <label>:54                                      ; preds = %22, %43
   %55 = load i16*, i16** %loc4
-  %NullCheck2 = icmp ne i16* %55, null
-  br i1 %NullCheck2, label %56, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i16* %55, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %56
 
 ; <label>:56                                      ; preds = %54
   %57 = load i16, i16* %55, align 8
@@ -3850,11 +4714,11 @@ ThrowNullRef:                                     ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %54
+ThrowNullRef2:                                    ; preds = %54
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %27
+ThrowNullRef4:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3871,8 +4735,8 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -3907,8 +4771,8 @@ entry:
 
 ; <label>:26                                      ; preds = %19
   %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
-  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %28
 
 ; <label>:28                                      ; preds = %26
   %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
@@ -3920,7 +4784,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3972,8 +4836,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
@@ -3984,26 +4848,26 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
-  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
@@ -4014,8 +4878,8 @@ entry:
 ; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
@@ -4024,8 +4888,8 @@ entry:
 
 ; <label>:25                                      ; preds = %1, %16, %23
   %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
-  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
@@ -4036,27 +4900,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %20
+ThrowNullRef10:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4069,8 +4933,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -4081,8 +4945,8 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
@@ -4091,8 +4955,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1, %8
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
@@ -4103,11 +4967,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4128,24 +4992,24 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   store i32 %3, i32* %loc0
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
   %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
   store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck4, label %9, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
@@ -4164,15 +5028,15 @@ entry:
 ; <label>:18                                      ; preds = %70
   %19 = load i16*, i16** %loc3
   %20 = bitcast i16* %19 to i64*
-  %NullCheck10 = icmp ne i64* %20, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %20, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = load i64, i64* %20, align 8
   %23 = load i16*, i16** %loc4
   %24 = bitcast i16* %23 to i64*
-  %NullCheck12 = icmp ne i64* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = load i64, i64* %24, align 8
@@ -4188,8 +5052,8 @@ entry:
   %31 = bitcast i16* %30 to i8*
   %32 = getelementptr inbounds i8, i8* %31, i64 8
   %33 = bitcast i8* %32 to i64*
-  %NullCheck14 = icmp ne i64* %33, null
-  br i1 %NullCheck14, label %34, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = load i64, i64* %33, align 8
@@ -4197,8 +5061,8 @@ entry:
   %37 = bitcast i16* %36 to i8*
   %38 = getelementptr inbounds i8, i8* %37, i64 8
   %39 = bitcast i8* %38 to i64*
-  %NullCheck16 = icmp ne i64* %39, null
-  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %40
 
 ; <label>:40                                      ; preds = %34
   %41 = load i64, i64* %39, align 8
@@ -4214,8 +5078,8 @@ entry:
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %NullCheck18 = icmp ne i64* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = load i64, i64* %48, align 8
@@ -4223,8 +5087,8 @@ entry:
   %52 = bitcast i16* %51 to i8*
   %53 = getelementptr inbounds i8, i8* %52, i64 16
   %54 = bitcast i8* %53 to i64*
-  %NullCheck20 = icmp ne i64* %54, null
-  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64* %54, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %55
 
 ; <label>:55                                      ; preds = %49
   %56 = load i64, i64* %54, align 8
@@ -4262,15 +5126,15 @@ entry:
 ; <label>:74                                      ; preds = %95
   %75 = load i16*, i16** %loc3
   %76 = bitcast i16* %75 to i32*
-  %NullCheck6 = icmp ne i32* %76, null
-  br i1 %NullCheck6, label %77, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32* %76, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %77
 
 ; <label>:77                                      ; preds = %74
   %78 = load i32, i32* %76, align 8
   %79 = load i16*, i16** %loc4
   %80 = bitcast i16* %79 to i32*
-  %NullCheck8 = icmp ne i32* %80, null
-  br i1 %NullCheck8, label %81, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i32* %80, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %81
 
 ; <label>:81                                      ; preds = %77
   %82 = load i32, i32* %80, align 8
@@ -4318,43 +5182,43 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %74
+ThrowNullRef6:                                    ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %77
+ThrowNullRef8:                                    ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %29
+ThrowNullRef14:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %34
+ThrowNullRef16:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4376,8 +5240,8 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load i64, i64 addrspace(1)* %4
@@ -4389,8 +5253,8 @@ entry:
   %12 = load i64, i64* %11
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %5
   %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
@@ -4399,8 +5263,8 @@ entry:
   %18 = load i8, i8* %arg2
   %19 = zext i8 %18 to i32
   %20 = trunc i32 %19 to i8
-  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %15
   %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
@@ -4411,11 +5275,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4442,8 +5306,8 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
@@ -4466,16 +5330,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
   %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = load i64, i64 addrspace(1)* %19
@@ -4500,8 +5364,8 @@ entry:
 ; <label>:35                                      ; preds = %30
   %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
@@ -4514,8 +5378,8 @@ entry:
 
 ; <label>:42                                      ; preds = %1, %38
   %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
-  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
@@ -4526,19 +5390,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %35
+ThrowNullRef2:                                    ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %42
+ThrowNullRef8:                                    ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4551,14 +5415,14 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
@@ -4570,7 +5434,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4583,8 +5447,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
@@ -4613,51 +5477,51 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
   %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
   %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
   %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
   %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
-  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
   store i64 %21, i64 addrspace(1)* %23
   %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %25 = load i64, i64* %loc0
-  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
@@ -4668,27 +5532,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %22
+ThrowNullRef12:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4701,8 +5565,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
@@ -4713,19 +5577,19 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
@@ -4734,8 +5598,8 @@ entry:
 
 ; <label>:15                                      ; preds = %1, %13
   %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
@@ -4746,19 +5610,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %15
+ThrowNullRef8:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4771,8 +5635,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -4831,8 +5695,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
@@ -4882,8 +5746,8 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
-  br i1 %NullCheck, label %17, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %ThrowNullRef, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
@@ -4894,15 +5758,15 @@ entry:
 
 ; <label>:22                                      ; preds = %17
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
-  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
   %26 = load i32, i32 addrspace(1)* %25
   %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
-  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %27, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
@@ -4925,8 +5789,8 @@ entry:
 ; <label>:40                                      ; preds = %17
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
-  br i1 %NullCheck6, label %43, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %41, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
@@ -4938,34 +5802,17 @@ ThrowNullRef:                                     ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %24
+ThrowNullRef4:                                    ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %40
+ThrowNullRef6:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
-}
-
-INFO:  jitting method Object::ReferenceEquals using LLILCJit
-Successfully read Object.ReferenceEquals
-
-define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
-entry:
-  %arg0 = alloca %System.Object addrspace(1)*
-  %arg1 = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
-  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
-  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = icmp eq %System.Object addrspace(1)* %0, %1
-  %3 = sext i1 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
 }
 
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
@@ -4978,21 +5825,21 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
   %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
-  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
@@ -5007,28 +5854,28 @@ entry:
 ; <label>:13                                      ; preds = %8, %12
   %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
   %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
   %21 = load i32, i32 addrspace(1)* %20, align 8
   %22 = add i32 %21, 1
-  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
   store i32 %22, i32 addrspace(1)* %24
   %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
@@ -5039,27 +5886,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5077,7 +5924,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::Setup using LLILCJit
-Failed to read AppDomain.Setup[loadElem]
+Failed to read AppDomain.Setup[unbox]
 INFO:  jitting method Thread::GetDomain using LLILCJit
 Successfully read Thread.GetDomain
 
@@ -5108,8 +5955,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
@@ -5122,14 +5969,14 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
   %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
@@ -5141,11 +5988,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5173,8 +6020,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -5189,7 +6036,328 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
 Failed to read KeyCollection.System.Collections.Generic.IEnumerable<TKey>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Successfully read Enumerator.MoveNext
+
+define i8 @Enumerator.MoveNext(%"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.RuntimeTypeHandle* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*
+  %"$TypeArg" = alloca %System.RuntimeTypeHandle*
+  store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
+  %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 8
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %76, label %12
+
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
+  br label %76
+
+; <label>:13                                      ; preds = %85
+  %14 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck19 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %15
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, i32 0, i32 0
+  %17 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %16, align 8
+  %NullCheck21 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, i32 0, i32 2
+  %20 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %19, align 8
+  %21 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck23 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %22
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, i32 0, i32 2
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %NullCheck25 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 3, i32 %24
+  %NullCheck27 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %32
+
+; <label>:32                                      ; preds = %30
+  %33 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, i32 0, i32 2
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = icmp slt i32 %34, 0
+  br i1 %35, label %68, label %36
+
+; <label>:36                                      ; preds = %32
+  %37 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %38 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck29 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %39
+
+; <label>:39                                      ; preds = %36
+  %40 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, i32 0, i32 0
+  %41 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %40, align 8
+  %NullCheck31 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, i32 0, i32 2
+  %44 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %43, align 8
+  %45 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck33 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, i32 0, i32 2
+  %48 = load i32, i32 addrspace(1)* %47, align 8
+  %NullCheck35 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %49
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = zext i32 %51 to i64
+  %53 = zext i32 %48 to i64
+  %BoundsCheck37 = icmp uge i64 %53, %52
+  br i1 %BoundsCheck37, label %ThrowIndexOutOfRange38, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 3, i32 %48
+  %NullCheck39 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %56
+
+; <label>:56                                      ; preds = %54
+  %57 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, i32 0, i32 0
+  %58 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck41 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %59
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %60, %System.__Canon addrspace(1)* %58)
+  %61 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck43 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  %64 = load i32, i32 addrspace(1)* %63, align 8
+  %65 = add i32 %64, 1
+  %NullCheck45 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  store i32 %65, i32 addrspace(1)* %67
+  ret i8 1
+
+; <label>:68                                      ; preds = %32
+  %69 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck47 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %73 = add i32 %72, 1
+  %NullCheck49 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %74
+
+; <label>:74                                      ; preds = %70
+  %75 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  store i32 %73, i32 addrspace(1)* %75
+  br label %76
+
+; <label>:76                                      ; preds = %8, %12, %74
+  %77 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %78
+
+; <label>:78                                      ; preds = %76
+  %79 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, i32 0, i32 2
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck7 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %82
+
+; <label>:82                                      ; preds = %78
+  %83 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, i32 0, i32 0
+  %84 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %83, align 8
+  %NullCheck9 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %85
+
+; <label>:85                                      ; preds = %82
+  %86 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, i32 0, i32 7
+  %87 = load i32, i32 addrspace(1)* %86, align 8
+  %88 = icmp ult i32 %80, %87
+  br i1 %88, label %13, label %89
+
+; <label>:89                                      ; preds = %85
+  %90 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %91 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck11 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %92
+
+; <label>:92                                      ; preds = %89
+  %93 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, i32 0, i32 0
+  %94 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck13 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %95
+
+; <label>:95                                      ; preds = %92
+  %96 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, i32 0, i32 7
+  %97 = load i32, i32 addrspace(1)* %96, align 8
+  %98 = add i32 %97, 1
+  %NullCheck15 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %99
+
+; <label>:99                                      ; preds = %95
+  %100 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, i32 0, i32 2
+  store i32 %98, i32 addrspace(1)* %100
+  %101 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck17 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %102
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %103, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %92
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef22:                                   ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef24:                                   ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef26:                                   ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef28:                                   ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef30:                                   ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef32:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef34:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef36:                                   ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange38:                           ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef40:                                   ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef42:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef44:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef46:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef48:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef50:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -5200,8 +6368,8 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -5232,9 +6400,9 @@ Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
 Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
-Failed to read String.MakeSeparatorList[loadElemA]
+Failed to read String.MakeSeparatorList[storeElem]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
-Failed to read String.InternalSplitKeepEmptyEntries[loadElem]
+Failed to read String.InternalSplitKeepEmptyEntries[storeElem]
 INFO:  jitting method Path::IsRelative using LLILCJit
 Successfully read Path.IsRelative
 
@@ -5243,8 +6411,8 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -5254,8 +6422,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
@@ -5271,8 +6439,8 @@ entry:
 
 ; <label>:17                                      ; preds = %7
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
@@ -5288,8 +6456,8 @@ entry:
 
 ; <label>:29                                      ; preds = %19
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %31
 
 ; <label>:31                                      ; preds = %29
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
@@ -5300,8 +6468,8 @@ entry:
 
 ; <label>:36                                      ; preds = %31
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
-  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %37, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
@@ -5312,8 +6480,8 @@ entry:
 
 ; <label>:43                                      ; preds = %31, %38
   %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
-  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %45
 
 ; <label>:45                                      ; preds = %43
   %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
@@ -5324,8 +6492,8 @@ entry:
 
 ; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %50
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
@@ -5336,8 +6504,8 @@ entry:
 
 ; <label>:57                                      ; preds = %1, %7, %19, %45, %52
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
-  br i1 %NullCheck14, label %59, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %59
 
 ; <label>:59                                      ; preds = %57
   %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
@@ -5347,8 +6515,8 @@ entry:
 
 ; <label>:63                                      ; preds = %59
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
@@ -5359,8 +6527,8 @@ entry:
 
 ; <label>:70                                      ; preds = %65
   %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
-  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.String addrspace(1)* %71, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %72
 
 ; <label>:72                                      ; preds = %70
   %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
@@ -5379,39 +6547,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %17
+ThrowNullRef4:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %29
+ThrowNullRef6:                                    ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %36
+ThrowNullRef8:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %43
+ThrowNullRef10:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %50
+ThrowNullRef12:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %57
+ThrowNullRef14:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %63
+ThrowNullRef16:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %70
+ThrowNullRef18:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5419,7 +6587,293 @@ ThrowNullRef17:                                   ; preds = %70
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
-Failed to read String.TrimHelper[loadElem]
+Successfully read String.TrimHelper
+
+define %System.String addrspace(1)* @String.TrimHelper(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i16
+  %loc4 = alloca i32
+  %loc5 = alloca i16
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = sub i32 %3, 1
+  store i32 %4, i32* %loc0
+  store i32 0, i32* %loc1
+  %5 = load i32, i32* %arg2
+  %6 = icmp eq i32 %5, 1
+  br i1 %6, label %62, label %7
+
+; <label>:7                                       ; preds = %1
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:8                                       ; preds = %58
+  store i32 0, i32* %loc2
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load i32, i32* %loc1
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2, i32 %10
+  %13 = load i16, i16 addrspace(1)* %12
+  %14 = zext i16 %13 to i32
+  %15 = trunc i32 %14 to i16
+  store i16 %15, i16* %loc3
+  store i32 0, i32* %loc2
+  br label %34
+
+; <label>:16                                      ; preds = %37
+  %17 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %18 = load i32, i32* %loc2
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %17, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %19
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = zext i32 %18 to i64
+  %BoundsCheck = icmp uge i64 %23, %22
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %24
+
+; <label>:24                                      ; preds = %19
+  %25 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 3, i32 %18
+  %26 = load i16, i16 addrspace(1)* %25, align 8
+  %27 = zext i16 %26 to i32
+  %28 = load i16, i16* %loc3
+  %29 = zext i16 %28 to i32
+  %30 = icmp eq i32 %27, %29
+  br i1 %30, label %43, label %31
+
+; <label>:31                                      ; preds = %24
+  %32 = load i32, i32* %loc2
+  %33 = add i32 %32, 1
+  store i32 %33, i32* %loc2
+  br label %34
+
+; <label>:34                                      ; preds = %11, %31
+  %35 = load i32, i32* %loc2
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = icmp slt i32 %35, %41
+  br i1 %42, label %16, label %43
+
+; <label>:43                                      ; preds = %24, %37
+  %44 = load i32, i32* %loc2
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %45, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp eq i32 %44, %50
+  br i1 %51, label %62, label %52
+
+; <label>:52                                      ; preds = %46
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %7, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %57, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %58
+
+; <label>:58                                      ; preds = %55
+  %59 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %60 = load i32, i32 addrspace(1)* %59
+  %61 = icmp slt i32 %56, %60
+  br i1 %61, label %8, label %62
+
+; <label>:62                                      ; preds = %1, %46, %58
+  %63 = load i32, i32* %arg2
+  %64 = icmp eq i32 %63, 0
+  br i1 %64, label %122, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %66, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %67
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %66, i32 0, i32 1
+  %69 = load i32, i32 addrspace(1)* %68
+  %70 = sub i32 %69, 1
+  store i32 %70, i32* %loc0
+  br label %118
+
+; <label>:71                                      ; preds = %118
+  store i32 0, i32* %loc4
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %73 = load i32, i32* %loc0
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %74
+
+; <label>:74                                      ; preds = %71
+  %75 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 2, i32 %73
+  %76 = load i16, i16 addrspace(1)* %75
+  %77 = zext i16 %76 to i32
+  %78 = trunc i32 %77 to i16
+  store i16 %78, i16* %loc5
+  store i32 0, i32* %loc4
+  br label %97
+
+; <label>:79                                      ; preds = %100
+  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %81 = load i32, i32* %loc4
+  %NullCheck19 = icmp eq %"System.Char[]" addrspace(1)* %80, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
+
+; <label>:82                                      ; preds = %79
+  %83 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 1
+  %84 = load i32, i32 addrspace(1)* %83
+  %85 = zext i32 %84 to i64
+  %86 = zext i32 %81 to i64
+  %BoundsCheck21 = icmp uge i64 %86, %85
+  br i1 %BoundsCheck21, label %ThrowIndexOutOfRange22, label %87
+
+; <label>:87                                      ; preds = %82
+  %88 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 3, i32 %81
+  %89 = load i16, i16 addrspace(1)* %88, align 8
+  %90 = zext i16 %89 to i32
+  %91 = load i16, i16* %loc5
+  %92 = zext i16 %91 to i32
+  %93 = icmp eq i32 %90, %92
+  br i1 %93, label %106, label %94
+
+; <label>:94                                      ; preds = %87
+  %95 = load i32, i32* %loc4
+  %96 = add i32 %95, 1
+  store i32 %96, i32* %loc4
+  br label %97
+
+; <label>:97                                      ; preds = %74, %94
+  %98 = load i32, i32* %loc4
+  %99 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck15 = icmp eq %"System.Char[]" addrspace(1)* %99, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %100
+
+; <label>:100                                     ; preds = %97
+  %101 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %99, i32 0, i32 1
+  %102 = load i32, i32 addrspace(1)* %101
+  %103 = zext i32 %102 to i64
+  %104 = trunc i64 %103 to i32
+  %105 = icmp slt i32 %98, %104
+  br i1 %105, label %79, label %106
+
+; <label>:106                                     ; preds = %87, %100
+  %107 = load i32, i32* %loc4
+  %108 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck17 = icmp eq %"System.Char[]" addrspace(1)* %108, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %109
+
+; <label>:109                                     ; preds = %106
+  %110 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %108, i32 0, i32 1
+  %111 = load i32, i32 addrspace(1)* %110
+  %112 = zext i32 %111 to i64
+  %113 = trunc i64 %112 to i32
+  %114 = icmp eq i32 %107, %113
+  br i1 %114, label %122, label %115
+
+; <label>:115                                     ; preds = %109
+  %116 = load i32, i32* %loc0
+  %117 = sub i32 %116, 1
+  store i32 %117, i32* %loc0
+  br label %118
+
+; <label>:118                                     ; preds = %67, %115
+  %119 = load i32, i32* %loc0
+  %120 = load i32, i32* %loc1
+  %121 = icmp sge i32 %119, %120
+  br i1 %121, label %71, label %122
+
+; <label>:122                                     ; preds = %62, %109, %118
+  %123 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %124 = load i32, i32* %loc1
+  %125 = load i32, i32* %loc0
+  %126 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %123, i32 %124, i32 %125)
+  ret %System.String addrspace(1)* %126
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %97
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange22:                           ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
 Successfully read String.CreateTrimmedString
 
@@ -5439,8 +6893,8 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
@@ -5535,8 +6989,8 @@ entry:
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i64 2872
   %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
   %8 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %7
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %3
   %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
@@ -5553,8 +7007,8 @@ entry:
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 2864
   %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
   %21 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %20
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
-  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %22
 
 ; <label>:22                                      ; preds = %16
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
@@ -5569,7 +7023,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %16
+ThrowNullRef2:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5586,8 +7040,8 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5613,8 +7067,8 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
@@ -5632,8 +7086,8 @@ entry:
 
 ; <label>:12                                      ; preds = %4
   %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
@@ -5644,8 +7098,8 @@ entry:
 
 ; <label>:19                                      ; preds = %14
   %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %19
   %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
@@ -5660,21 +7114,21 @@ entry:
   %31 = zext i16 %30 to i32
   %32 = bitcast i8* %29 to i16*
   %33 = trunc i32 %31 to i16
-  %NullCheck6 = icmp ne i16* %32, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i16* %32, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %21
   store i16 %33, i16* %32, align 8
   %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %36
 
 ; <label>:36                                      ; preds = %34
   %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
   %38 = load i32, i32 addrspace(1)* %37, align 8
   %39 = add i32 %38, 1
-  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %40
 
 ; <label>:40                                      ; preds = %36
   %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
@@ -5683,16 +7137,16 @@ entry:
 
 ; <label>:42                                      ; preds = %14
   %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
-  br i1 %NullCheck12, label %44, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
   %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
   %47 = load i16, i16* %arg1
   %48 = zext i16 %47 to i32
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = trunc i32 %48 to i16
@@ -5703,31 +7157,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %19
+ThrowNullRef4:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %21
+ThrowNullRef6:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %36
+ThrowNullRef10:                                   ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %42
+ThrowNullRef12:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %44
+ThrowNullRef14:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5740,8 +7194,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -5752,8 +7206,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
@@ -5762,14 +7216,14 @@ entry:
 
 ; <label>:11                                      ; preds = %1
   %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
@@ -5779,15 +7233,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5808,8 +7262,8 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5822,8 +7276,8 @@ entry:
 
 ; <label>:8                                       ; preds = %3
   %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
@@ -5842,15 +7296,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
-  br i1 %NullCheck4, label %22, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
   %24 = load i16*, i16* addrspace(1)* %23, align 8
   %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %25, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
@@ -5859,8 +7313,8 @@ entry:
   store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
@@ -5874,8 +7328,8 @@ entry:
 
 ; <label>:37                                      ; preds = %65
   %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %37
   %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
@@ -5886,16 +7340,16 @@ entry:
   %45 = bitcast i16* %41 to i8*
   %46 = getelementptr inbounds i8, i8* %45, i64 %44
   %47 = bitcast i8* %46 to i16*
-  %NullCheck14 = icmp ne i16* %47, null
-  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %47, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %48
 
 ; <label>:48                                      ; preds = %39
   %49 = load i16, i16* %47, align 8
   %50 = zext i16 %49 to i32
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %52 = load i32, i32* %loc1
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %53
 
 ; <label>:53                                      ; preds = %48
   %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
@@ -5916,8 +7370,8 @@ entry:
 ; <label>:62                                      ; preds = %36, %59
   %63 = load i32, i32* %loc1
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck10, label %65, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %65
 
 ; <label>:65                                      ; preds = %62
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
@@ -5936,15 +7390,15 @@ entry:
 
 ; <label>:74                                      ; preds = %70
   %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
-  br i1 %NullCheck18, label %76, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %76
 
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
   %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
-  br i1 %NullCheck20, label %80, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
   %81 = load i64, i64 addrspace(1)* %79
@@ -5958,8 +7412,8 @@ entry:
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
   %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
-  br i1 %NullCheck22, label %92, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.String addrspace(1)* %90, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %92
 
 ; <label>:92                                      ; preds = %80
   %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
@@ -5969,15 +7423,15 @@ entry:
 
 ; <label>:96                                      ; preds = %70
   %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
-  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %98
 
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
   %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
-  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
   %103 = load i64, i64 addrspace(1)* %101
@@ -5991,8 +7445,8 @@ entry:
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
   %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
-  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.String addrspace(1)* %112, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %114
 
 ; <label>:114                                     ; preds = %102
   %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
@@ -6004,59 +7458,59 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %20
+ThrowNullRef4:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %22
+ThrowNullRef6:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %26
+ThrowNullRef8:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %62
+ThrowNullRef10:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %48
+ThrowNullRef16:                                   ; preds = %48
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %74
+ThrowNullRef18:                                   ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %76
+ThrowNullRef20:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %80
+ThrowNullRef22:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %96
+ThrowNullRef24:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %98
+ThrowNullRef26:                                   ; preds = %98
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %102
+ThrowNullRef28:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6069,15 +7523,15 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
   %3 = load i16*, i16* addrspace(1)* %2, align 8
   %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
@@ -6087,8 +7541,8 @@ entry:
   %10 = bitcast i16* %3 to i8*
   %11 = getelementptr inbounds i8, i8* %10, i64 %9
   %12 = bitcast i8* %11 to i16*
-  %NullCheck4 = icmp ne i16* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %5
   store i16 0, i16* %12, align 8
@@ -6098,11 +7552,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6119,8 +7573,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -6131,8 +7585,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
@@ -6144,15 +7598,15 @@ entry:
 
 ; <label>:14                                      ; preds = %1
   %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
   %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
   %21 = load i64, i64 addrspace(1)* %19
@@ -6171,15 +7625,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %14
+ThrowNullRef4:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %16
+ThrowNullRef6:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6302,14 +7756,6 @@ entry:
   ret %System.String addrspace(1)* %57
 }
 
-INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
-Successfully read RuntimeHelpers.get_OffsetToStringData
-
-define i32 @RuntimeHelpers.get_OffsetToStringData() {
-entry:
-  ret i32 12
-}
-
 INFO:  jitting method String::Equals using LLILCJit
 Successfully read String.Equals
 
@@ -6381,8 +7827,8 @@ entry:
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
-  br i1 %NullCheck24, label %29, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
   %30 = load i64, i64 addrspace(1)* %28
@@ -6397,8 +7843,8 @@ entry:
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
-  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
   %43 = load i64, i64 addrspace(1)* %41
@@ -6418,8 +7864,8 @@ entry:
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
   %59 = load i64, i64 addrspace(1)* %57
@@ -6434,8 +7880,8 @@ entry:
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck22, label %71, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
   %72 = load i64, i64 addrspace(1)* %70
@@ -6455,8 +7901,8 @@ entry:
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
-  br i1 %NullCheck16, label %87, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = load i64, i64 addrspace(1)* %86
@@ -6471,8 +7917,8 @@ entry:
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck18, label %100, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
   %101 = load i64, i64 addrspace(1)* %99
@@ -6492,8 +7938,8 @@ entry:
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
-  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
   %117 = load i64, i64 addrspace(1)* %115
@@ -6508,8 +7954,8 @@ entry:
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
-  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
   %130 = load i64, i64 addrspace(1)* %128
@@ -6528,15 +7974,15 @@ entry:
 
 ; <label>:142                                     ; preds = %22
   %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
-  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %143, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %144
 
 ; <label>:144                                     ; preds = %142
   %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
   %146 = load i32, i32 addrspace(1)* %145
   %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
-  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %147, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %148
 
 ; <label>:148                                     ; preds = %144
   %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
@@ -6557,15 +8003,15 @@ entry:
 
 ; <label>:159                                     ; preds = %22
   %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
-  br i1 %NullCheck, label %161, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %ThrowNullRef, label %161
 
 ; <label>:161                                     ; preds = %159
   %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
   %163 = load i32, i32 addrspace(1)* %162
   %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
-  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %164, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %165
 
 ; <label>:165                                     ; preds = %161
   %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
@@ -6578,8 +8024,8 @@ entry:
 
 ; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
-  br i1 %NullCheck4, label %172, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %171, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %172
 
 ; <label>:172                                     ; preds = %170
   %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
@@ -6589,8 +8035,8 @@ entry:
 
 ; <label>:176                                     ; preds = %172
   %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
-  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %177, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %178
 
 ; <label>:178                                     ; preds = %176
   %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
@@ -6629,55 +8075,55 @@ ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %161
+ThrowNullRef2:                                    ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %170
+ThrowNullRef4:                                    ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %176
+ThrowNullRef6:                                    ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %142
+ThrowNullRef8:                                    ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %144
+ThrowNullRef10:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %113
+ThrowNullRef12:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %116
+ThrowNullRef14:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %84
+ThrowNullRef16:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %87
+ThrowNullRef18:                                   ; preds = %87
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %55
+ThrowNullRef20:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %58
+ThrowNullRef22:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %26
+ThrowNullRef24:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %29
+ThrowNullRef26:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,8 +8161,8 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck, label %14, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %ThrowNullRef, label %14
 
 ; <label>:14                                      ; preds = %8
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
@@ -6760,8 +8206,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
@@ -6770,14 +8216,14 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32, i32* %loc0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %10
   %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
   %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
@@ -6790,15 +8236,15 @@ entry:
 ; <label>:25                                      ; preds = %19
   %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
-  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
   %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
@@ -6807,8 +8253,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %37 = load i32, i32* %loc0
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %38, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %38
 
 ; <label>:38                                      ; preds = %32
   %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
@@ -6817,14 +8263,14 @@ entry:
 
 ; <label>:40                                      ; preds = %19
   %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %40
   %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
   %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
-  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
-  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
@@ -6832,8 +8278,8 @@ entry:
   %48 = zext i32 %47 to i64
   %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
-  br i1 %NullCheck16, label %51, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %51
 
 ; <label>:51                                      ; preds = %45
   %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
@@ -6847,15 +8293,15 @@ entry:
 ; <label>:57                                      ; preds = %51
   %58 = load i16*, i16** %arg1
   %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
-  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %60
 
 ; <label>:60                                      ; preds = %57
   %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
   %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
-  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %64
 
 ; <label>:64                                      ; preds = %60
   %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
@@ -6864,22 +8310,22 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
   %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
-  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %70
 
 ; <label>:70                                      ; preds = %64
   %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
   %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
-  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
-  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
   %75 = load i32, i32 addrspace(1)* %74
   %76 = zext i32 %75 to i64
   %77 = trunc i64 %76 to i32
-  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
-  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %78
 
 ; <label>:78                                      ; preds = %73
   %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
@@ -6901,8 +8347,8 @@ entry:
   %90 = bitcast i16* %86 to i8*
   %91 = getelementptr inbounds i8, i8* %90, i64 %89
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %93
 
 ; <label>:93                                      ; preds = %80
   %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
@@ -6912,8 +8358,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %99 = load i32, i32* %loc2
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %100
 
 ; <label>:100                                     ; preds = %93
   %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
@@ -6928,63 +8374,63 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %25
+ThrowNullRef6:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %32
+ThrowNullRef10:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %40
+ThrowNullRef12:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %45
+ThrowNullRef16:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %57
+ThrowNullRef18:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %60
+ThrowNullRef20:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %64
+ThrowNullRef22:                                   ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %70
+ThrowNullRef24:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %73
+ThrowNullRef26:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %80
+ThrowNullRef28:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %93
+ThrowNullRef30:                                   ; preds = %93
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7004,8 +8450,8 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
@@ -7033,43 +8479,43 @@ entry:
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %14
   %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
   %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   %28 = load i32, i32 addrspace(1)* %27, align 8
   %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
-  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %30
 
 ; <label>:30                                      ; preds = %26
   %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
   %32 = load i32, i32 addrspace(1)* %31, align 8
   %33 = add i32 %28, %32
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %34
 
 ; <label>:34                                      ; preds = %30
   %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   store i32 %33, i32 addrspace(1)* %35
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
   store i32 0, i32 addrspace(1)* %38
   %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %40
 
 ; <label>:40                                      ; preds = %37
   %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
@@ -7082,8 +8528,8 @@ entry:
 
 ; <label>:47                                      ; preds = %40
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
@@ -7098,8 +8544,8 @@ entry:
   %54 = load i32, i32* %loc0
   %55 = sext i32 %54 to i64
   %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
-  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %57
 
 ; <label>:57                                      ; preds = %52
   %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
@@ -7110,68 +8556,35 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %14
+ThrowNullRef2:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %23
+ThrowNullRef4:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %26
+ThrowNullRef6:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %30
+ThrowNullRef8:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %34
+ThrowNullRef10:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %47
+ThrowNullRef14:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %52
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-}
-
-INFO:  jitting method StringBuilder::get_Length using LLILCJit
-Successfully read StringBuilder.get_Length
-
-define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.StringBuilder addrspace(1)*
-  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
-  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
-
-; <label>:1                                       ; preds = %entry
-  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %3 = load i32, i32 addrspace(1)* %2, align 8
-  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
-
-; <label>:5                                       ; preds = %1
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = add i32 %3, %7
-  ret i32 %8
-
-ThrowNullRef:                                     ; preds = %entry
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef16:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7213,70 +8626,70 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
   %6 = load i32, i32 addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
   store i32 %6, i32 addrspace(1)* %8
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
   %13 = load i32, i32 addrspace(1)* %12, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
   store i32 %13, i32 addrspace(1)* %15
   %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
-  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %18
 
 ; <label>:18                                      ; preds = %14
   %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
   %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
   %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
   %34 = load i32, i32 addrspace(1)* %33, align 8
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
-  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
@@ -7287,39 +8700,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %28
+ThrowNullRef16:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %32
+ThrowNullRef18:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7455,13 +8868,13 @@ entry:
 ; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
@@ -7477,16 +8890,16 @@ entry:
 
 ; <label>:18                                      ; preds = %15
   %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
   store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
   %22 = load i32, i32* %loc0
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %24
 
 ; <label>:24                                      ; preds = %20
   %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
@@ -7498,13 +8911,13 @@ entry:
 ; <label>:28                                      ; preds = %15, %24
   %29 = load i32, i32* %arg1
   %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %31
   %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
@@ -7517,20 +8930,20 @@ entry:
   %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
-  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
   %46 = load i32, i32 addrspace(1)* %45, align 8
   %47 = sub i32 %40, %46
-  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
-  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i32 addrspace(1)* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %48
 
 ; <label>:48                                      ; preds = %44
   store i32 %47, i32 addrspace(1)* %39, align 8
@@ -7538,21 +8951,21 @@ entry:
 
 ; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
-  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %51
 
 ; <label>:51                                      ; preds = %49
   %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %53
 
 ; <label>:53                                      ; preds = %51
   %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
   %55 = load i32, i32 addrspace(1)* %54, align 8
   %56 = load i32, i32* %arg2
   %57 = sub i32 %55, %56
-  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %58
 
 ; <label>:58                                      ; preds = %53
   %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
@@ -7562,13 +8975,13 @@ entry:
 ; <label>:60                                      ; preds = %33, %58
   %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
   %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
-  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %63
 
 ; <label>:63                                      ; preds = %60
   %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
-  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
-  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
@@ -7578,15 +8991,15 @@ entry:
 
 ; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
-  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i32 addrspace(1)* %69, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %70
 
 ; <label>:70                                      ; preds = %68
   %71 = load i32, i32 addrspace(1)* %69, align 8
   store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
-  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
@@ -7596,8 +9009,8 @@ entry:
   store i32 %77, i32* %loc4
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
-  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %80
 
 ; <label>:80                                      ; preds = %73
   %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
@@ -7607,71 +9020,71 @@ entry:
 ; <label>:83                                      ; preds = %80
   store i32 0, i32* %loc3
   %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
-  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
-  br i1 %NullCheck26, label %88, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i32 addrspace(1)* %87, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %88
 
 ; <label>:88                                      ; preds = %85
   %89 = load i32, i32 addrspace(1)* %87, align 8
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
-  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %90
 
 ; <label>:90                                      ; preds = %88
   %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
   store i32 %89, i32 addrspace(1)* %91
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
-  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
-  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %96
 
 ; <label>:96                                      ; preds = %94
   %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
-  br i1 %NullCheck34, label %100, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %100
 
 ; <label>:100                                     ; preds = %96
   %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
-  br i1 %NullCheck36, label %102, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %102
 
 ; <label>:102                                     ; preds = %100
   %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
   %104 = load i32, i32 addrspace(1)* %103, align 8
   %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
-  br i1 %NullCheck38, label %106, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %106
 
 ; <label>:106                                     ; preds = %102
   %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
-  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
-  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %108
 
 ; <label>:108                                     ; preds = %106
   %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
   %110 = load i32, i32 addrspace(1)* %109, align 8
   %111 = add i32 %104, %110
-  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %112
 
 ; <label>:112                                     ; preds = %108
   %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
   store i32 %111, i32 addrspace(1)* %113
   %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
-  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i32 addrspace(1)* %114, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %115
 
 ; <label>:115                                     ; preds = %112
   %116 = load i32, i32 addrspace(1)* %114, align 8
@@ -7681,19 +9094,19 @@ entry:
 ; <label>:118                                     ; preds = %115
   %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
-  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %121
 
 ; <label>:121                                     ; preds = %118
   %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
-  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
-  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %123
 
 ; <label>:123                                     ; preds = %121
   %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
   %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
-  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
-  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %126
 
 ; <label>:126                                     ; preds = %123
   %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
@@ -7705,8 +9118,8 @@ entry:
 
 ; <label>:130                                     ; preds = %80, %115, %126
   %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %132
 
 ; <label>:132                                     ; preds = %130
   %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7715,8 +9128,8 @@ entry:
   %136 = load i32, i32* %loc3
   %137 = sub i32 %135, %136
   %138 = sub i32 %134, %137
-  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %139
 
 ; <label>:139                                     ; preds = %132
   %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7728,16 +9141,16 @@ entry:
 
 ; <label>:144                                     ; preds = %139
   %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
-  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %146
 
 ; <label>:146                                     ; preds = %144
   %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
   %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
   %149 = load i32, i32* %loc2
   %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
-  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %151
 
 ; <label>:151                                     ; preds = %146
   %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
@@ -7754,145 +9167,249 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %18
+ThrowNullRef4:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %31
+ThrowNullRef10:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %44
+ThrowNullRef16:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %68
+ThrowNullRef18:                                   ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %70
+ThrowNullRef20:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %73
+ThrowNullRef22:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %83
+ThrowNullRef24:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %85
+ThrowNullRef26:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %88
+ThrowNullRef28:                                   ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %90
+ThrowNullRef30:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %94
+ThrowNullRef32:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %96
+ThrowNullRef34:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %100
+ThrowNullRef36:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %102
+ThrowNullRef38:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %106
+ThrowNullRef40:                                   ; preds = %106
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %108
+ThrowNullRef42:                                   ; preds = %108
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %112
+ThrowNullRef44:                                   ; preds = %112
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %118
+ThrowNullRef46:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %121
+ThrowNullRef48:                                   ; preds = %121
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %123
+ThrowNullRef50:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %130
+ThrowNullRef52:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %132
+ThrowNullRef54:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %144
+ThrowNullRef56:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %146
+ThrowNullRef58:                                   ; preds = %146
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %60
+ThrowNullRef60:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %63
+ThrowNullRef62:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %49
+ThrowNullRef64:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %51
+ThrowNullRef66:                                   ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %53
+ThrowNullRef68:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(%"System.Char[]" addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %arg0 = alloca %"System.Char[]" addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store %"System.Char[]" addrspace(1)* %param0, %"System.Char[]" addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load i32, i32* %arg4
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %43, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %38, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg1
+  %13 = load i32, i32* %arg4
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %38, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %24 = load i32, i32* %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %35 = load i32, i32* %arg3
+  %36 = load i32, i32* %arg4
+  %37 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %37, %"System.Char[]" addrspace(1)* %34, i32 %35, i32 %36)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:38                                      ; preds = %5, %16
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Successfully read Buffer._Memmove
 
@@ -7914,7 +9431,7 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[loadElem]
+Failed to read AppDomain.SetDataHelper[storeElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -7923,8 +9440,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
@@ -7934,8 +9451,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
@@ -7947,15 +9464,15 @@ entry:
   %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
   %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
@@ -7966,15 +9483,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7992,7 +9509,79 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
-Failed to read Dictionary`2.TryGetValue[loadElemA]
+Successfully read Dictionary`2.TryGetValue
+
+define i8 @"Dictionary`2.TryGetValue"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)* addrspace(1)* %param2) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  %arg2 = alloca %System.__Canon addrspace(1)* addrspace(1)*
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  store %System.__Canon addrspace(1)* addrspace(1)* %param2, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  store i32 %2, i32* %loc0
+  %3 = load i32, i32* %loc0
+  %4 = icmp slt i32 %3, 0
+  br i1 %4, label %22, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 2
+  %10 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %9, align 8
+  %11 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = zext i32 %11 to i64
+  %BoundsCheck = icmp uge i64 %16, %15
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 3, i32 %11
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %20, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %6, %System.__Canon addrspace(1)* %21)
+  ret i8 1
+
+; <label>:22                                      ; preds = %entry
+  %23 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %23, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -8058,8 +9647,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
@@ -8091,8 +9680,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
@@ -8171,15 +9760,15 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck, label %19, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %ThrowNullRef, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
   %21 = load i32, i32 addrspace(1)* %20
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
@@ -8202,7 +9791,7 @@ ThrowNullRef:                                     ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %19
+ThrowNullRef2:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8248,8 +9837,8 @@ entry:
   %0 = alloca %System.AppDomainHandle
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %1 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %1, i32 0, i32 15
@@ -8269,8 +9858,8 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
@@ -8286,7 +9875,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -8299,8 +9888,8 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -8327,8 +9916,8 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
@@ -8352,8 +9941,8 @@ entry:
   %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
   store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
@@ -8363,8 +9952,8 @@ entry:
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
@@ -8374,8 +9963,8 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %9
   %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
@@ -8384,8 +9973,8 @@ entry:
 
 ; <label>:18                                      ; preds = %3, %16
   %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
@@ -8397,15 +9986,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %18
+ThrowNullRef6:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8418,8 +10007,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
@@ -8453,15 +10042,15 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
@@ -8473,7 +10062,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8481,7 +10070,7 @@ ThrowNullRef1:                                    ; preds = %1
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
 Failed to read Dictionary`2.System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
@@ -8506,8 +10095,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
@@ -8524,8 +10113,8 @@ entry:
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -8544,7 +10133,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8577,8 +10166,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = load i64, i64* %arg2
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = trunc i32 %3 to i8
@@ -8634,46 +10223,46 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
   %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
-  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
-  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
-  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
@@ -8684,27 +10273,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %20
+ThrowNullRef12:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8717,8 +10306,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -8756,22 +10345,22 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
   %9 = load i64, i64 addrspace(1)* %8, align 8
   %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
   %13 = load i64, i64 addrspace(1)* %12, align 8
   %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %11
   %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
@@ -8788,11 +10377,11 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8882,8 +10471,8 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
@@ -8900,8 +10489,8 @@ entry:
 ; <label>:8                                       ; preds = %1
   %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
   %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
@@ -8911,15 +10500,15 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
   %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
   %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
-  br i1 %NullCheck6, label %21, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
@@ -8946,15 +10535,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8992,15 +10581,15 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
   store i8 %3, i8 addrspace(1)* %5
   %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
@@ -9011,7 +10600,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9027,8 +10616,8 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -9041,8 +10630,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
@@ -9058,7 +10647,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9080,8 +10669,8 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
@@ -9096,8 +10685,8 @@ entry:
 ; <label>:12                                      ; preds = %6
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
@@ -9112,8 +10701,8 @@ entry:
 ; <label>:21                                      ; preds = %15
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
@@ -9128,8 +10717,8 @@ entry:
 ; <label>:30                                      ; preds = %24
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %31, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
@@ -9144,8 +10733,8 @@ entry:
 ; <label>:39                                      ; preds = %33
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
-  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %40, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %42
 
 ; <label>:42                                      ; preds = %39
   %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
@@ -9164,19 +10753,19 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %21
+ThrowNullRef4:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %30
+ThrowNullRef6:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %39
+ThrowNullRef8:                                    ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9243,8 +10832,8 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
@@ -9264,57 +10853,57 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
   store i8 0, i8 addrspace(1)* %2
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
   store i8 0, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
   store i8 0, i8 addrspace(1)* %17
   %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
   store i8 0, i8 addrspace(1)* %20
   %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
-  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
@@ -9325,31 +10914,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %19
+ThrowNullRef14:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9367,8 +10956,8 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
@@ -9380,8 +10969,8 @@ entry:
 
 ; <label>:9                                       ; preds = %4
   %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %9
   %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
@@ -9395,7 +10984,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef2:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9420,8 +11009,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
@@ -9512,8 +11101,8 @@ entry:
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
@@ -9524,8 +11113,8 @@ entry:
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = load i64, i64 addrspace(1)* %12
@@ -9537,8 +11126,8 @@ entry:
   %20 = load i64, i64* %19
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
-  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %13
   %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
@@ -9555,8 +11144,8 @@ entry:
 ; <label>:30                                      ; preds = %25
   %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %32 = load i32, i32* %arg2
-  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
-  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
@@ -9570,15 +11159,15 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %30
+ThrowNullRef2:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9622,87 +11211,87 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
   %10 = load i8, i8 addrspace(1)* %9, align 8
   %11 = zext i8 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %8
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
   store i8 %12, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
   %19 = load i8, i8 addrspace(1)* %18, align 8
   %20 = zext i8 %19 to i32
   %21 = trunc i32 %20 to i8
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
   store i8 %21, i8 addrspace(1)* %23
   %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
   %28 = load i8, i8 addrspace(1)* %27, align 8
   %29 = zext i8 %28 to i32
   %30 = trunc i32 %29 to i8
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
-  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %31
 
 ; <label>:31                                      ; preds = %26
   %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
   store i8 %30, i8 addrspace(1)* %32
   %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
-  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
-  br i1 %NullCheck14, label %40, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %40
 
 ; <label>:40                                      ; preds = %35
   %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
   store i8 %39, i8 addrspace(1)* %41
   %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
-  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %44
 
 ; <label>:44                                      ; preds = %40
   %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
   %46 = load i8, i8 addrspace(1)* %45, align 8
   %47 = zext i8 %46 to i32
   %48 = trunc i32 %47 to i8
-  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
   store i8 %48, i8 addrspace(1)* %50
   %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
-  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
@@ -9713,29 +11302,29 @@ entry:
 ; <label>:56                                      ; preds = %52
   %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
-  br i1 %NullCheck22, label %59, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
   %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
   %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
-  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
-  br i1 %NullCheck24, label %63, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
   %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
-  br i1 %NullCheck26, label %66, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
   %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
-  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
-  br i1 %NullCheck28, label %69, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %69
 
 ; <label>:69                                      ; preds = %66
   %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
@@ -9744,15 +11333,15 @@ entry:
 
 ; <label>:71                                      ; preds = %105
   %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
-  br i1 %NullCheck34, label %73, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %73
 
 ; <label>:73                                      ; preds = %71
   %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
   %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
   %76 = load i32, i32* %loc0
-  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
-  br i1 %NullCheck36, label %77, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
@@ -9766,8 +11355,8 @@ entry:
 
 ; <label>:83                                      ; preds = %77
   %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
-  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
@@ -9775,14 +11364,14 @@ entry:
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
   %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
-  br i1 %NullCheck40, label %91, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
 ; <label>:91                                      ; preds = %85
   %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
   %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
-  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck42, label %94, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %94
 
 ; <label>:94                                      ; preds = %91
   %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
@@ -9798,14 +11387,14 @@ entry:
 ; <label>:99                                      ; preds = %69, %96
   %100 = load i32, i32* %loc0
   %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
-  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %102
 
 ; <label>:102                                     ; preds = %99
   %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
   %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
-  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
-  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
@@ -9819,87 +11408,87 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %26
+ThrowNullRef10:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %31
+ThrowNullRef12:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %35
+ThrowNullRef14:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %40
+ThrowNullRef16:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %56
+ThrowNullRef22:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %59
+ThrowNullRef24:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %63
+ThrowNullRef26:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %66
+ThrowNullRef28:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %102
+ThrowNullRef32:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %71
+ThrowNullRef34:                                   ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %73
+ThrowNullRef36:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %83
+ThrowNullRef38:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %85
+ThrowNullRef40:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %91
+ThrowNullRef42:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9943,15 +11532,15 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
   %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
@@ -9961,28 +11550,28 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
   %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %12
   %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
   %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
   %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
-  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
@@ -9993,23 +11582,23 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %12
+ThrowNullRef6:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10031,15 +11620,15 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
   %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = load i64, i64 addrspace(1)* %7
@@ -10077,13 +11666,13 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[loadElem]
+Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -10111,8 +11700,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Gt1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Gt1.error.txt
@@ -25,8 +25,8 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
@@ -40,8 +40,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
   %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
@@ -75,7 +75,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -90,8 +90,8 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %NullCheck = icmp ne i8 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = load i8, i8 addrspace(1)* %0, align 8
@@ -125,8 +125,8 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
@@ -159,8 +159,8 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -184,8 +184,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
   store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
@@ -195,8 +195,8 @@ entry:
 ; <label>:4                                       ; preds = %1
   %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
   %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
@@ -206,8 +206,8 @@ entry:
   %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
@@ -221,14 +221,14 @@ entry:
 
 ; <label>:17                                      ; preds = %14
   %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
   %21 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
@@ -238,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -249,8 +249,8 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
@@ -261,27 +261,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %30
+ThrowNullRef10:                                   ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -301,7 +301,89 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
-Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
+Successfully read AppDomainSetup.GetUnsecureApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.GetUnsecureApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %NullCheck = icmp eq %"System.String[]" addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %BoundsCheck = icmp uge i64 0, %5
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %6
+
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 3, i32 0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
+  ret %System.String addrspace(1)* %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_Value using LLILCJit
+Successfully read AppDomainSetup.get_Value
+
+define %"System.String[]" addrspace(1)* @AppDomainSetup.get_Value(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.String[]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 18)
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.String[]" addrspace(1)* addrspace(1)*, %"System.String[]" addrspace(1)*)*)(%"System.String[]" addrspace(1)* addrspace(1)* %9, %"System.String[]" addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %11, i32 0, i32 1
+  %14 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %13, align 8
+  ret %"System.String[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -319,8 +401,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -368,16 +450,16 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
   %5 = load i32, i32 addrspace(1)* %4
   %6 = sub i32 %5, 1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -389,7 +471,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -421,8 +503,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
@@ -456,8 +538,8 @@ entry:
 ; <label>:27                                      ; preds = %19
   %28 = load i32, i32* %arg1
   %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
-  br i1 %NullCheck2, label %30, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %29, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %30
 
 ; <label>:30                                      ; preds = %27
   %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
@@ -493,8 +575,8 @@ entry:
 ; <label>:49                                      ; preds = %46
   %50 = load i32, i32* %arg2
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck4, label %52, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
@@ -517,11 +599,11 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %27
+ThrowNullRef2:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %49
+ThrowNullRef4:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -544,16 +626,16 @@ entry:
   %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %0)
   store %System.String addrspace(1)* %1, %System.String addrspace(1)** %loc0
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 2
   %5 = bitcast [0 x i16] addrspace(1)* %4 to i16 addrspace(1)*
   store i16 addrspace(1)* %5, i16 addrspace(1)** %loc1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %3
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2
@@ -580,7 +662,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -691,15 +773,15 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %NullCheck132 = icmp ne i8* %21, null
-  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+  %NullCheck131 = icmp eq i8* %21, null
+  br i1 %NullCheck131, label %ThrowNullRef132, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = load i8, i8* %21, align 8
   %24 = zext i8 %23 to i32
   %25 = trunc i32 %24 to i8
-  %NullCheck134 = icmp ne i8* %20, null
-  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+  %NullCheck133 = icmp eq i8* %20, null
+  br i1 %NullCheck133, label %ThrowNullRef134, label %26
 
 ; <label>:26                                      ; preds = %22
   store i8 %25, i8* %20, align 8
@@ -709,16 +791,16 @@ entry:
   %28 = load i8*, i8** %arg0
   %29 = load i8*, i8** %arg1
   %30 = bitcast i8* %29 to i16*
-  %NullCheck128 = icmp ne i16* %30, null
-  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+  %NullCheck127 = icmp eq i16* %30, null
+  br i1 %NullCheck127, label %ThrowNullRef128, label %31
 
 ; <label>:31                                      ; preds = %27
   %32 = load i16, i16* %30, align 8
   %33 = sext i16 %32 to i32
   %34 = bitcast i8* %28 to i16*
   %35 = trunc i32 %33 to i16
-  %NullCheck130 = icmp ne i16* %34, null
-  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+  %NullCheck129 = icmp eq i16* %34, null
+  br i1 %NullCheck129, label %ThrowNullRef130, label %36
 
 ; <label>:36                                      ; preds = %31
   store i16 %35, i16* %34, align 8
@@ -728,16 +810,16 @@ entry:
   %38 = load i8*, i8** %arg0
   %39 = load i8*, i8** %arg1
   %40 = bitcast i8* %39 to i16*
-  %NullCheck120 = icmp ne i16* %40, null
-  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+  %NullCheck119 = icmp eq i16* %40, null
+  br i1 %NullCheck119, label %ThrowNullRef120, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i16, i16* %40, align 8
   %43 = sext i16 %42 to i32
   %44 = bitcast i8* %38 to i16*
   %45 = trunc i32 %43 to i16
-  %NullCheck122 = icmp ne i16* %44, null
-  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+  %NullCheck121 = icmp eq i16* %44, null
+  br i1 %NullCheck121, label %ThrowNullRef122, label %46
 
 ; <label>:46                                      ; preds = %41
   store i16 %45, i16* %44, align 8
@@ -745,15 +827,15 @@ entry:
   %48 = getelementptr inbounds i8, i8* %47, i64 2
   %49 = load i8*, i8** %arg1
   %50 = getelementptr inbounds i8, i8* %49, i64 2
-  %NullCheck124 = icmp ne i8* %50, null
-  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+  %NullCheck123 = icmp eq i8* %50, null
+  br i1 %NullCheck123, label %ThrowNullRef124, label %51
 
 ; <label>:51                                      ; preds = %46
   %52 = load i8, i8* %50, align 8
   %53 = zext i8 %52 to i32
   %54 = trunc i32 %53 to i8
-  %NullCheck126 = icmp ne i8* %48, null
-  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+  %NullCheck125 = icmp eq i8* %48, null
+  br i1 %NullCheck125, label %ThrowNullRef126, label %55
 
 ; <label>:55                                      ; preds = %51
   store i8 %54, i8* %48, align 8
@@ -763,14 +845,14 @@ entry:
   %57 = load i8*, i8** %arg0
   %58 = load i8*, i8** %arg1
   %59 = bitcast i8* %58 to i32*
-  %NullCheck116 = icmp ne i32* %59, null
-  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+  %NullCheck115 = icmp eq i32* %59, null
+  br i1 %NullCheck115, label %ThrowNullRef116, label %60
 
 ; <label>:60                                      ; preds = %56
   %61 = load i32, i32* %59, align 8
   %62 = bitcast i8* %57 to i32*
-  %NullCheck118 = icmp ne i32* %62, null
-  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+  %NullCheck117 = icmp eq i32* %62, null
+  br i1 %NullCheck117, label %ThrowNullRef118, label %63
 
 ; <label>:63                                      ; preds = %60
   store i32 %61, i32* %62, align 8
@@ -780,14 +862,14 @@ entry:
   %65 = load i8*, i8** %arg0
   %66 = load i8*, i8** %arg1
   %67 = bitcast i8* %66 to i32*
-  %NullCheck108 = icmp ne i32* %67, null
-  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+  %NullCheck107 = icmp eq i32* %67, null
+  br i1 %NullCheck107, label %ThrowNullRef108, label %68
 
 ; <label>:68                                      ; preds = %64
   %69 = load i32, i32* %67, align 8
   %70 = bitcast i8* %65 to i32*
-  %NullCheck110 = icmp ne i32* %70, null
-  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+  %NullCheck109 = icmp eq i32* %70, null
+  br i1 %NullCheck109, label %ThrowNullRef110, label %71
 
 ; <label>:71                                      ; preds = %68
   store i32 %69, i32* %70, align 8
@@ -795,15 +877,15 @@ entry:
   %73 = getelementptr inbounds i8, i8* %72, i64 4
   %74 = load i8*, i8** %arg1
   %75 = getelementptr inbounds i8, i8* %74, i64 4
-  %NullCheck112 = icmp ne i8* %75, null
-  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+  %NullCheck111 = icmp eq i8* %75, null
+  br i1 %NullCheck111, label %ThrowNullRef112, label %76
 
 ; <label>:76                                      ; preds = %71
   %77 = load i8, i8* %75, align 8
   %78 = zext i8 %77 to i32
   %79 = trunc i32 %78 to i8
-  %NullCheck114 = icmp ne i8* %73, null
-  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+  %NullCheck113 = icmp eq i8* %73, null
+  br i1 %NullCheck113, label %ThrowNullRef114, label %80
 
 ; <label>:80                                      ; preds = %76
   store i8 %79, i8* %73, align 8
@@ -813,14 +895,14 @@ entry:
   %82 = load i8*, i8** %arg0
   %83 = load i8*, i8** %arg1
   %84 = bitcast i8* %83 to i32*
-  %NullCheck100 = icmp ne i32* %84, null
-  br i1 %NullCheck100, label %85, label %ThrowNullRef99
+  %NullCheck99 = icmp eq i32* %84, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %85
 
 ; <label>:85                                      ; preds = %81
   %86 = load i32, i32* %84, align 8
   %87 = bitcast i8* %82 to i32*
-  %NullCheck102 = icmp ne i32* %87, null
-  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+  %NullCheck101 = icmp eq i32* %87, null
+  br i1 %NullCheck101, label %ThrowNullRef102, label %88
 
 ; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
@@ -829,16 +911,16 @@ entry:
   %91 = load i8*, i8** %arg1
   %92 = getelementptr inbounds i8, i8* %91, i64 4
   %93 = bitcast i8* %92 to i16*
-  %NullCheck104 = icmp ne i16* %93, null
-  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+  %NullCheck103 = icmp eq i16* %93, null
+  br i1 %NullCheck103, label %ThrowNullRef104, label %94
 
 ; <label>:94                                      ; preds = %88
   %95 = load i16, i16* %93, align 8
   %96 = sext i16 %95 to i32
   %97 = bitcast i8* %90 to i16*
   %98 = trunc i32 %96 to i16
-  %NullCheck106 = icmp ne i16* %97, null
-  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+  %NullCheck105 = icmp eq i16* %97, null
+  br i1 %NullCheck105, label %ThrowNullRef106, label %99
 
 ; <label>:99                                      ; preds = %94
   store i16 %98, i16* %97, align 8
@@ -848,14 +930,14 @@ entry:
   %101 = load i8*, i8** %arg0
   %102 = load i8*, i8** %arg1
   %103 = bitcast i8* %102 to i32*
-  %NullCheck88 = icmp ne i32* %103, null
-  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+  %NullCheck87 = icmp eq i32* %103, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %104
 
 ; <label>:104                                     ; preds = %100
   %105 = load i32, i32* %103, align 8
   %106 = bitcast i8* %101 to i32*
-  %NullCheck90 = icmp ne i32* %106, null
-  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+  %NullCheck89 = icmp eq i32* %106, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %107
 
 ; <label>:107                                     ; preds = %104
   store i32 %105, i32* %106, align 8
@@ -864,16 +946,16 @@ entry:
   %110 = load i8*, i8** %arg1
   %111 = getelementptr inbounds i8, i8* %110, i64 4
   %112 = bitcast i8* %111 to i16*
-  %NullCheck92 = icmp ne i16* %112, null
-  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+  %NullCheck91 = icmp eq i16* %112, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %113
 
 ; <label>:113                                     ; preds = %107
   %114 = load i16, i16* %112, align 8
   %115 = sext i16 %114 to i32
   %116 = bitcast i8* %109 to i16*
   %117 = trunc i32 %115 to i16
-  %NullCheck94 = icmp ne i16* %116, null
-  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+  %NullCheck93 = icmp eq i16* %116, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %118
 
 ; <label>:118                                     ; preds = %113
   store i16 %117, i16* %116, align 8
@@ -881,15 +963,15 @@ entry:
   %120 = getelementptr inbounds i8, i8* %119, i64 6
   %121 = load i8*, i8** %arg1
   %122 = getelementptr inbounds i8, i8* %121, i64 6
-  %NullCheck96 = icmp ne i8* %122, null
-  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+  %NullCheck95 = icmp eq i8* %122, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %123
 
 ; <label>:123                                     ; preds = %118
   %124 = load i8, i8* %122, align 8
   %125 = zext i8 %124 to i32
   %126 = trunc i32 %125 to i8
-  %NullCheck98 = icmp ne i8* %120, null
-  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+  %NullCheck97 = icmp eq i8* %120, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %127
 
 ; <label>:127                                     ; preds = %123
   store i8 %126, i8* %120, align 8
@@ -899,14 +981,14 @@ entry:
   %129 = load i8*, i8** %arg0
   %130 = load i8*, i8** %arg1
   %131 = bitcast i8* %130 to i64*
-  %NullCheck84 = icmp ne i64* %131, null
-  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+  %NullCheck83 = icmp eq i64* %131, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %132
 
 ; <label>:132                                     ; preds = %128
   %133 = load i64, i64* %131, align 8
   %134 = bitcast i8* %129 to i64*
-  %NullCheck86 = icmp ne i64* %134, null
-  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+  %NullCheck85 = icmp eq i64* %134, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %135
 
 ; <label>:135                                     ; preds = %132
   store i64 %133, i64* %134, align 8
@@ -916,14 +998,14 @@ entry:
   %137 = load i8*, i8** %arg0
   %138 = load i8*, i8** %arg1
   %139 = bitcast i8* %138 to i64*
-  %NullCheck76 = icmp ne i64* %139, null
-  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+  %NullCheck75 = icmp eq i64* %139, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %140
 
 ; <label>:140                                     ; preds = %136
   %141 = load i64, i64* %139, align 8
   %142 = bitcast i8* %137 to i64*
-  %NullCheck78 = icmp ne i64* %142, null
-  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+  %NullCheck77 = icmp eq i64* %142, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %143
 
 ; <label>:143                                     ; preds = %140
   store i64 %141, i64* %142, align 8
@@ -931,15 +1013,15 @@ entry:
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %NullCheck80 = icmp ne i8* %147, null
-  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+  %NullCheck79 = icmp eq i8* %147, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %148
 
 ; <label>:148                                     ; preds = %143
   %149 = load i8, i8* %147, align 8
   %150 = zext i8 %149 to i32
   %151 = trunc i32 %150 to i8
-  %NullCheck82 = icmp ne i8* %145, null
-  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+  %NullCheck81 = icmp eq i8* %145, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %152
 
 ; <label>:152                                     ; preds = %148
   store i8 %151, i8* %145, align 8
@@ -949,14 +1031,14 @@ entry:
   %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
   %156 = bitcast i8* %155 to i64*
-  %NullCheck68 = icmp ne i64* %156, null
-  br i1 %NullCheck68, label %157, label %ThrowNullRef67
+  %NullCheck67 = icmp eq i64* %156, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %157
 
 ; <label>:157                                     ; preds = %153
   %158 = load i64, i64* %156, align 8
   %159 = bitcast i8* %154 to i64*
-  %NullCheck70 = icmp ne i64* %159, null
-  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+  %NullCheck69 = icmp eq i64* %159, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %160
 
 ; <label>:160                                     ; preds = %157
   store i64 %158, i64* %159, align 8
@@ -965,16 +1047,16 @@ entry:
   %163 = load i8*, i8** %arg1
   %164 = getelementptr inbounds i8, i8* %163, i64 8
   %165 = bitcast i8* %164 to i16*
-  %NullCheck72 = icmp ne i16* %165, null
-  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+  %NullCheck71 = icmp eq i16* %165, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %166
 
 ; <label>:166                                     ; preds = %160
   %167 = load i16, i16* %165, align 8
   %168 = sext i16 %167 to i32
   %169 = bitcast i8* %162 to i16*
   %170 = trunc i32 %168 to i16
-  %NullCheck74 = icmp ne i16* %169, null
-  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+  %NullCheck73 = icmp eq i16* %169, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %171
 
 ; <label>:171                                     ; preds = %166
   store i16 %170, i16* %169, align 8
@@ -984,14 +1066,14 @@ entry:
   %173 = load i8*, i8** %arg0
   %174 = load i8*, i8** %arg1
   %175 = bitcast i8* %174 to i64*
-  %NullCheck56 = icmp ne i64* %175, null
-  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+  %NullCheck55 = icmp eq i64* %175, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %176
 
 ; <label>:176                                     ; preds = %172
   %177 = load i64, i64* %175, align 8
   %178 = bitcast i8* %173 to i64*
-  %NullCheck58 = icmp ne i64* %178, null
-  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+  %NullCheck57 = icmp eq i64* %178, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %179
 
 ; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
@@ -1000,16 +1082,16 @@ entry:
   %182 = load i8*, i8** %arg1
   %183 = getelementptr inbounds i8, i8* %182, i64 8
   %184 = bitcast i8* %183 to i16*
-  %NullCheck60 = icmp ne i16* %184, null
-  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+  %NullCheck59 = icmp eq i16* %184, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %185
 
 ; <label>:185                                     ; preds = %179
   %186 = load i16, i16* %184, align 8
   %187 = sext i16 %186 to i32
   %188 = bitcast i8* %181 to i16*
   %189 = trunc i32 %187 to i16
-  %NullCheck62 = icmp ne i16* %188, null
-  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+  %NullCheck61 = icmp eq i16* %188, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %190
 
 ; <label>:190                                     ; preds = %185
   store i16 %189, i16* %188, align 8
@@ -1017,15 +1099,15 @@ entry:
   %192 = getelementptr inbounds i8, i8* %191, i64 10
   %193 = load i8*, i8** %arg1
   %194 = getelementptr inbounds i8, i8* %193, i64 10
-  %NullCheck64 = icmp ne i8* %194, null
-  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+  %NullCheck63 = icmp eq i8* %194, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %195
 
 ; <label>:195                                     ; preds = %190
   %196 = load i8, i8* %194, align 8
   %197 = zext i8 %196 to i32
   %198 = trunc i32 %197 to i8
-  %NullCheck66 = icmp ne i8* %192, null
-  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+  %NullCheck65 = icmp eq i8* %192, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %199
 
 ; <label>:199                                     ; preds = %195
   store i8 %198, i8* %192, align 8
@@ -1035,14 +1117,14 @@ entry:
   %201 = load i8*, i8** %arg0
   %202 = load i8*, i8** %arg1
   %203 = bitcast i8* %202 to i64*
-  %NullCheck48 = icmp ne i64* %203, null
-  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+  %NullCheck47 = icmp eq i64* %203, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %204
 
 ; <label>:204                                     ; preds = %200
   %205 = load i64, i64* %203, align 8
   %206 = bitcast i8* %201 to i64*
-  %NullCheck50 = icmp ne i64* %206, null
-  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+  %NullCheck49 = icmp eq i64* %206, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %207
 
 ; <label>:207                                     ; preds = %204
   store i64 %205, i64* %206, align 8
@@ -1051,14 +1133,14 @@ entry:
   %210 = load i8*, i8** %arg1
   %211 = getelementptr inbounds i8, i8* %210, i64 8
   %212 = bitcast i8* %211 to i32*
-  %NullCheck52 = icmp ne i32* %212, null
-  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+  %NullCheck51 = icmp eq i32* %212, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %213
 
 ; <label>:213                                     ; preds = %207
   %214 = load i32, i32* %212, align 8
   %215 = bitcast i8* %209 to i32*
-  %NullCheck54 = icmp ne i32* %215, null
-  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+  %NullCheck53 = icmp eq i32* %215, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %216
 
 ; <label>:216                                     ; preds = %213
   store i32 %214, i32* %215, align 8
@@ -1068,14 +1150,14 @@ entry:
   %218 = load i8*, i8** %arg0
   %219 = load i8*, i8** %arg1
   %220 = bitcast i8* %219 to i64*
-  %NullCheck36 = icmp ne i64* %220, null
-  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64* %220, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %221
 
 ; <label>:221                                     ; preds = %217
   %222 = load i64, i64* %220, align 8
   %223 = bitcast i8* %218 to i64*
-  %NullCheck38 = icmp ne i64* %223, null
-  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+  %NullCheck37 = icmp eq i64* %223, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %224
 
 ; <label>:224                                     ; preds = %221
   store i64 %222, i64* %223, align 8
@@ -1084,14 +1166,14 @@ entry:
   %227 = load i8*, i8** %arg1
   %228 = getelementptr inbounds i8, i8* %227, i64 8
   %229 = bitcast i8* %228 to i32*
-  %NullCheck40 = icmp ne i32* %229, null
-  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i32* %229, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %230
 
 ; <label>:230                                     ; preds = %224
   %231 = load i32, i32* %229, align 8
   %232 = bitcast i8* %226 to i32*
-  %NullCheck42 = icmp ne i32* %232, null
-  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+  %NullCheck41 = icmp eq i32* %232, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %233
 
 ; <label>:233                                     ; preds = %230
   store i32 %231, i32* %232, align 8
@@ -1099,15 +1181,15 @@ entry:
   %235 = getelementptr inbounds i8, i8* %234, i64 12
   %236 = load i8*, i8** %arg1
   %237 = getelementptr inbounds i8, i8* %236, i64 12
-  %NullCheck44 = icmp ne i8* %237, null
-  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i8* %237, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %238
 
 ; <label>:238                                     ; preds = %233
   %239 = load i8, i8* %237, align 8
   %240 = zext i8 %239 to i32
   %241 = trunc i32 %240 to i8
-  %NullCheck46 = icmp ne i8* %235, null
-  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+  %NullCheck45 = icmp eq i8* %235, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %242
 
 ; <label>:242                                     ; preds = %238
   store i8 %241, i8* %235, align 8
@@ -1117,14 +1199,14 @@ entry:
   %244 = load i8*, i8** %arg0
   %245 = load i8*, i8** %arg1
   %246 = bitcast i8* %245 to i64*
-  %NullCheck24 = icmp ne i64* %246, null
-  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64* %246, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %247
 
 ; <label>:247                                     ; preds = %243
   %248 = load i64, i64* %246, align 8
   %249 = bitcast i8* %244 to i64*
-  %NullCheck26 = icmp ne i64* %249, null
-  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64* %249, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %250
 
 ; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
@@ -1133,14 +1215,14 @@ entry:
   %253 = load i8*, i8** %arg1
   %254 = getelementptr inbounds i8, i8* %253, i64 8
   %255 = bitcast i8* %254 to i32*
-  %NullCheck28 = icmp ne i32* %255, null
-  br i1 %NullCheck28, label %256, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i32* %255, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %256
 
 ; <label>:256                                     ; preds = %250
   %257 = load i32, i32* %255, align 8
   %258 = bitcast i8* %252 to i32*
-  %NullCheck30 = icmp ne i32* %258, null
-  br i1 %NullCheck30, label %259, label %ThrowNullRef29
+  %NullCheck29 = icmp eq i32* %258, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %259
 
 ; <label>:259                                     ; preds = %256
   store i32 %257, i32* %258, align 8
@@ -1149,16 +1231,16 @@ entry:
   %262 = load i8*, i8** %arg1
   %263 = getelementptr inbounds i8, i8* %262, i64 12
   %264 = bitcast i8* %263 to i16*
-  %NullCheck32 = icmp ne i16* %264, null
-  br i1 %NullCheck32, label %265, label %ThrowNullRef31
+  %NullCheck31 = icmp eq i16* %264, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %265
 
 ; <label>:265                                     ; preds = %259
   %266 = load i16, i16* %264, align 8
   %267 = sext i16 %266 to i32
   %268 = bitcast i8* %261 to i16*
   %269 = trunc i32 %267 to i16
-  %NullCheck34 = icmp ne i16* %268, null
-  br i1 %NullCheck34, label %270, label %ThrowNullRef33
+  %NullCheck33 = icmp eq i16* %268, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %270
 
 ; <label>:270                                     ; preds = %265
   store i16 %269, i16* %268, align 8
@@ -1168,14 +1250,14 @@ entry:
   %272 = load i8*, i8** %arg0
   %273 = load i8*, i8** %arg1
   %274 = bitcast i8* %273 to i64*
-  %NullCheck8 = icmp ne i64* %274, null
-  br i1 %NullCheck8, label %275, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64* %274, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %275
 
 ; <label>:275                                     ; preds = %271
   %276 = load i64, i64* %274, align 8
   %277 = bitcast i8* %272 to i64*
-  %NullCheck10 = icmp ne i64* %277, null
-  br i1 %NullCheck10, label %278, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %277, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %278
 
 ; <label>:278                                     ; preds = %275
   store i64 %276, i64* %277, align 8
@@ -1184,14 +1266,14 @@ entry:
   %281 = load i8*, i8** %arg1
   %282 = getelementptr inbounds i8, i8* %281, i64 8
   %283 = bitcast i8* %282 to i32*
-  %NullCheck12 = icmp ne i32* %283, null
-  br i1 %NullCheck12, label %284, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i32* %283, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %284
 
 ; <label>:284                                     ; preds = %278
   %285 = load i32, i32* %283, align 8
   %286 = bitcast i8* %280 to i32*
-  %NullCheck14 = icmp ne i32* %286, null
-  br i1 %NullCheck14, label %287, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i32* %286, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %287
 
 ; <label>:287                                     ; preds = %284
   store i32 %285, i32* %286, align 8
@@ -1200,16 +1282,16 @@ entry:
   %290 = load i8*, i8** %arg1
   %291 = getelementptr inbounds i8, i8* %290, i64 12
   %292 = bitcast i8* %291 to i16*
-  %NullCheck16 = icmp ne i16* %292, null
-  br i1 %NullCheck16, label %293, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i16* %292, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %293
 
 ; <label>:293                                     ; preds = %287
   %294 = load i16, i16* %292, align 8
   %295 = sext i16 %294 to i32
   %296 = bitcast i8* %289 to i16*
   %297 = trunc i32 %295 to i16
-  %NullCheck18 = icmp ne i16* %296, null
-  br i1 %NullCheck18, label %298, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i16* %296, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %298
 
 ; <label>:298                                     ; preds = %293
   store i16 %297, i16* %296, align 8
@@ -1217,15 +1299,15 @@ entry:
   %300 = getelementptr inbounds i8, i8* %299, i64 14
   %301 = load i8*, i8** %arg1
   %302 = getelementptr inbounds i8, i8* %301, i64 14
-  %NullCheck20 = icmp ne i8* %302, null
-  br i1 %NullCheck20, label %303, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i8* %302, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %303
 
 ; <label>:303                                     ; preds = %298
   %304 = load i8, i8* %302, align 8
   %305 = zext i8 %304 to i32
   %306 = trunc i32 %305 to i8
-  %NullCheck22 = icmp ne i8* %300, null
-  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i8* %300, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %307
 
 ; <label>:307                                     ; preds = %303
   store i8 %306, i8* %300, align 8
@@ -1235,14 +1317,14 @@ entry:
   %309 = load i8*, i8** %arg0
   %310 = load i8*, i8** %arg1
   %311 = bitcast i8* %310 to i64*
-  %NullCheck = icmp ne i64* %311, null
-  br i1 %NullCheck, label %312, label %ThrowNullRef
+  %NullCheck = icmp eq i64* %311, null
+  br i1 %NullCheck, label %ThrowNullRef, label %312
 
 ; <label>:312                                     ; preds = %308
   %313 = load i64, i64* %311, align 8
   %314 = bitcast i8* %309 to i64*
-  %NullCheck2 = icmp ne i64* %314, null
-  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64* %314, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %315
 
 ; <label>:315                                     ; preds = %312
   store i64 %313, i64* %314, align 8
@@ -1251,14 +1333,14 @@ entry:
   %318 = load i8*, i8** %arg1
   %319 = getelementptr inbounds i8, i8* %318, i64 8
   %320 = bitcast i8* %319 to i64*
-  %NullCheck4 = icmp ne i64* %320, null
-  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64* %320, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %321
 
 ; <label>:321                                     ; preds = %315
   %322 = load i64, i64* %320, align 8
   %323 = bitcast i8* %317 to i64*
-  %NullCheck6 = icmp ne i64* %323, null
-  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64* %323, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %324
 
 ; <label>:324                                     ; preds = %321
   store i64 %322, i64* %323, align 8
@@ -1286,15 +1368,15 @@ entry:
 ; <label>:338                                     ; preds = %333
   %339 = load i8*, i8** %arg0
   %340 = load i8*, i8** %arg1
-  %NullCheck136 = icmp ne i8* %340, null
-  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+  %NullCheck135 = icmp eq i8* %340, null
+  br i1 %NullCheck135, label %ThrowNullRef136, label %341
 
 ; <label>:341                                     ; preds = %338
   %342 = load i8, i8* %340, align 8
   %343 = zext i8 %342 to i32
   %344 = trunc i32 %343 to i8
-  %NullCheck138 = icmp ne i8* %339, null
-  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+  %NullCheck137 = icmp eq i8* %339, null
+  br i1 %NullCheck137, label %ThrowNullRef138, label %345
 
 ; <label>:345                                     ; preds = %341
   store i8 %344, i8* %339, align 8
@@ -1317,16 +1399,16 @@ entry:
   %357 = load i8*, i8** %arg0
   %358 = load i8*, i8** %arg1
   %359 = bitcast i8* %358 to i16*
-  %NullCheck140 = icmp ne i16* %359, null
-  br i1 %NullCheck140, label %360, label %ThrowNullRef139
+  %NullCheck139 = icmp eq i16* %359, null
+  br i1 %NullCheck139, label %ThrowNullRef140, label %360
 
 ; <label>:360                                     ; preds = %356
   %361 = load i16, i16* %359, align 8
   %362 = sext i16 %361 to i32
   %363 = bitcast i8* %357 to i16*
   %364 = trunc i32 %362 to i16
-  %NullCheck142 = icmp ne i16* %363, null
-  br i1 %NullCheck142, label %365, label %ThrowNullRef141
+  %NullCheck141 = icmp eq i16* %363, null
+  br i1 %NullCheck141, label %ThrowNullRef142, label %365
 
 ; <label>:365                                     ; preds = %360
   store i16 %364, i16* %363, align 8
@@ -1352,14 +1434,14 @@ entry:
   %378 = load i8*, i8** %arg0
   %379 = load i8*, i8** %arg1
   %380 = bitcast i8* %379 to i32*
-  %NullCheck144 = icmp ne i32* %380, null
-  br i1 %NullCheck144, label %381, label %ThrowNullRef143
+  %NullCheck143 = icmp eq i32* %380, null
+  br i1 %NullCheck143, label %ThrowNullRef144, label %381
 
 ; <label>:381                                     ; preds = %377
   %382 = load i32, i32* %380, align 8
   %383 = bitcast i8* %378 to i32*
-  %NullCheck146 = icmp ne i32* %383, null
-  br i1 %NullCheck146, label %384, label %ThrowNullRef145
+  %NullCheck145 = icmp eq i32* %383, null
+  br i1 %NullCheck145, label %ThrowNullRef146, label %384
 
 ; <label>:384                                     ; preds = %381
   store i32 %382, i32* %383, align 8
@@ -1384,14 +1466,14 @@ entry:
   %395 = load i8*, i8** %arg0
   %396 = load i8*, i8** %arg1
   %397 = bitcast i8* %396 to i64*
-  %NullCheck164 = icmp ne i64* %397, null
-  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+  %NullCheck163 = icmp eq i64* %397, null
+  br i1 %NullCheck163, label %ThrowNullRef164, label %398
 
 ; <label>:398                                     ; preds = %394
   %399 = load i64, i64* %397, align 8
   %400 = bitcast i8* %395 to i64*
-  %NullCheck166 = icmp ne i64* %400, null
-  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+  %NullCheck165 = icmp eq i64* %400, null
+  br i1 %NullCheck165, label %ThrowNullRef166, label %401
 
 ; <label>:401                                     ; preds = %398
   store i64 %399, i64* %400, align 8
@@ -1400,14 +1482,14 @@ entry:
   %404 = load i8*, i8** %arg1
   %405 = getelementptr inbounds i8, i8* %404, i64 8
   %406 = bitcast i8* %405 to i64*
-  %NullCheck168 = icmp ne i64* %406, null
-  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+  %NullCheck167 = icmp eq i64* %406, null
+  br i1 %NullCheck167, label %ThrowNullRef168, label %407
 
 ; <label>:407                                     ; preds = %401
   %408 = load i64, i64* %406, align 8
   %409 = bitcast i8* %403 to i64*
-  %NullCheck170 = icmp ne i64* %409, null
-  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+  %NullCheck169 = icmp eq i64* %409, null
+  br i1 %NullCheck169, label %ThrowNullRef170, label %410
 
 ; <label>:410                                     ; preds = %407
   store i64 %408, i64* %409, align 8
@@ -1437,14 +1519,14 @@ entry:
   %425 = load i8*, i8** %arg0
   %426 = load i8*, i8** %arg1
   %427 = bitcast i8* %426 to i64*
-  %NullCheck148 = icmp ne i64* %427, null
-  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+  %NullCheck147 = icmp eq i64* %427, null
+  br i1 %NullCheck147, label %ThrowNullRef148, label %428
 
 ; <label>:428                                     ; preds = %424
   %429 = load i64, i64* %427, align 8
   %430 = bitcast i8* %425 to i64*
-  %NullCheck150 = icmp ne i64* %430, null
-  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+  %NullCheck149 = icmp eq i64* %430, null
+  br i1 %NullCheck149, label %ThrowNullRef150, label %431
 
 ; <label>:431                                     ; preds = %428
   store i64 %429, i64* %430, align 8
@@ -1466,14 +1548,14 @@ entry:
   %441 = load i8*, i8** %arg0
   %442 = load i8*, i8** %arg1
   %443 = bitcast i8* %442 to i32*
-  %NullCheck152 = icmp ne i32* %443, null
-  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+  %NullCheck151 = icmp eq i32* %443, null
+  br i1 %NullCheck151, label %ThrowNullRef152, label %444
 
 ; <label>:444                                     ; preds = %440
   %445 = load i32, i32* %443, align 8
   %446 = bitcast i8* %441 to i32*
-  %NullCheck154 = icmp ne i32* %446, null
-  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+  %NullCheck153 = icmp eq i32* %446, null
+  br i1 %NullCheck153, label %ThrowNullRef154, label %447
 
 ; <label>:447                                     ; preds = %444
   store i32 %445, i32* %446, align 8
@@ -1495,16 +1577,16 @@ entry:
   %457 = load i8*, i8** %arg0
   %458 = load i8*, i8** %arg1
   %459 = bitcast i8* %458 to i16*
-  %NullCheck156 = icmp ne i16* %459, null
-  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+  %NullCheck155 = icmp eq i16* %459, null
+  br i1 %NullCheck155, label %ThrowNullRef156, label %460
 
 ; <label>:460                                     ; preds = %456
   %461 = load i16, i16* %459, align 8
   %462 = sext i16 %461 to i32
   %463 = bitcast i8* %457 to i16*
   %464 = trunc i32 %462 to i16
-  %NullCheck158 = icmp ne i16* %463, null
-  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+  %NullCheck157 = icmp eq i16* %463, null
+  br i1 %NullCheck157, label %ThrowNullRef158, label %465
 
 ; <label>:465                                     ; preds = %460
   store i16 %464, i16* %463, align 8
@@ -1525,15 +1607,15 @@ entry:
 ; <label>:474                                     ; preds = %470
   %475 = load i8*, i8** %arg0
   %476 = load i8*, i8** %arg1
-  %NullCheck160 = icmp ne i8* %476, null
-  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+  %NullCheck159 = icmp eq i8* %476, null
+  br i1 %NullCheck159, label %ThrowNullRef160, label %477
 
 ; <label>:477                                     ; preds = %474
   %478 = load i8, i8* %476, align 8
   %479 = zext i8 %478 to i32
   %480 = trunc i32 %479 to i8
-  %NullCheck162 = icmp ne i8* %475, null
-  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+  %NullCheck161 = icmp eq i8* %475, null
+  br i1 %NullCheck161, label %ThrowNullRef162, label %481
 
 ; <label>:481                                     ; preds = %477
   store i8 %480, i8* %475, align 8
@@ -1553,343 +1635,343 @@ ThrowNullRef:                                     ; preds = %308
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %312
+ThrowNullRef2:                                    ; preds = %312
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %315
+ThrowNullRef4:                                    ; preds = %315
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %321
+ThrowNullRef6:                                    ; preds = %321
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %271
+ThrowNullRef8:                                    ; preds = %271
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %275
+ThrowNullRef10:                                   ; preds = %275
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %278
+ThrowNullRef12:                                   ; preds = %278
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %284
+ThrowNullRef14:                                   ; preds = %284
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %287
+ThrowNullRef16:                                   ; preds = %287
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %293
+ThrowNullRef18:                                   ; preds = %293
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %298
+ThrowNullRef20:                                   ; preds = %298
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %303
+ThrowNullRef22:                                   ; preds = %303
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %243
+ThrowNullRef24:                                   ; preds = %243
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %247
+ThrowNullRef26:                                   ; preds = %247
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %250
+ThrowNullRef28:                                   ; preds = %250
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %256
+ThrowNullRef30:                                   ; preds = %256
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %259
+ThrowNullRef32:                                   ; preds = %259
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %265
+ThrowNullRef34:                                   ; preds = %265
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %217
+ThrowNullRef36:                                   ; preds = %217
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %221
+ThrowNullRef38:                                   ; preds = %221
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %224
+ThrowNullRef40:                                   ; preds = %224
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %230
+ThrowNullRef42:                                   ; preds = %230
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %233
+ThrowNullRef44:                                   ; preds = %233
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %238
+ThrowNullRef46:                                   ; preds = %238
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %200
+ThrowNullRef48:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %204
+ThrowNullRef50:                                   ; preds = %204
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %207
+ThrowNullRef52:                                   ; preds = %207
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %213
+ThrowNullRef54:                                   ; preds = %213
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %172
+ThrowNullRef56:                                   ; preds = %172
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %176
+ThrowNullRef58:                                   ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %179
+ThrowNullRef60:                                   ; preds = %179
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %185
+ThrowNullRef62:                                   ; preds = %185
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %190
+ThrowNullRef64:                                   ; preds = %190
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %195
+ThrowNullRef66:                                   ; preds = %195
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %153
+ThrowNullRef68:                                   ; preds = %153
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %157
+ThrowNullRef70:                                   ; preds = %157
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %160
+ThrowNullRef72:                                   ; preds = %160
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %166
+ThrowNullRef74:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %136
+ThrowNullRef76:                                   ; preds = %136
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %140
+ThrowNullRef78:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %143
+ThrowNullRef80:                                   ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %148
+ThrowNullRef82:                                   ; preds = %148
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %128
+ThrowNullRef84:                                   ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %132
+ThrowNullRef86:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %100
+ThrowNullRef88:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %104
+ThrowNullRef90:                                   ; preds = %104
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %107
+ThrowNullRef92:                                   ; preds = %107
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %113
+ThrowNullRef94:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %118
+ThrowNullRef96:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %123
+ThrowNullRef98:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %81
+ThrowNullRef100:                                  ; preds = %81
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef101:                                  ; preds = %85
+ThrowNullRef102:                                  ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef103:                                  ; preds = %88
+ThrowNullRef104:                                  ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef105:                                  ; preds = %94
+ThrowNullRef106:                                  ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef107:                                  ; preds = %64
+ThrowNullRef108:                                  ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef109:                                  ; preds = %68
+ThrowNullRef110:                                  ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef111:                                  ; preds = %71
+ThrowNullRef112:                                  ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef113:                                  ; preds = %76
+ThrowNullRef114:                                  ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef115:                                  ; preds = %56
+ThrowNullRef116:                                  ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef117:                                  ; preds = %60
+ThrowNullRef118:                                  ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef119:                                  ; preds = %37
+ThrowNullRef120:                                  ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef121:                                  ; preds = %41
+ThrowNullRef122:                                  ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef123:                                  ; preds = %46
+ThrowNullRef124:                                  ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef125:                                  ; preds = %51
+ThrowNullRef126:                                  ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef127:                                  ; preds = %27
+ThrowNullRef128:                                  ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef129:                                  ; preds = %31
+ThrowNullRef130:                                  ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef131:                                  ; preds = %19
+ThrowNullRef132:                                  ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef133:                                  ; preds = %22
+ThrowNullRef134:                                  ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef135:                                  ; preds = %338
+ThrowNullRef136:                                  ; preds = %338
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef137:                                  ; preds = %341
+ThrowNullRef138:                                  ; preds = %341
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef139:                                  ; preds = %356
+ThrowNullRef140:                                  ; preds = %356
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef141:                                  ; preds = %360
+ThrowNullRef142:                                  ; preds = %360
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef143:                                  ; preds = %377
+ThrowNullRef144:                                  ; preds = %377
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef145:                                  ; preds = %381
+ThrowNullRef146:                                  ; preds = %381
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef147:                                  ; preds = %424
+ThrowNullRef148:                                  ; preds = %424
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef149:                                  ; preds = %428
+ThrowNullRef150:                                  ; preds = %428
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef151:                                  ; preds = %440
+ThrowNullRef152:                                  ; preds = %440
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef153:                                  ; preds = %444
+ThrowNullRef154:                                  ; preds = %444
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef155:                                  ; preds = %456
+ThrowNullRef156:                                  ; preds = %456
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef157:                                  ; preds = %460
+ThrowNullRef158:                                  ; preds = %460
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef159:                                  ; preds = %474
+ThrowNullRef160:                                  ; preds = %474
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef161:                                  ; preds = %477
+ThrowNullRef162:                                  ; preds = %477
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef163:                                  ; preds = %394
+ThrowNullRef164:                                  ; preds = %394
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef165:                                  ; preds = %398
+ThrowNullRef166:                                  ; preds = %398
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef167:                                  ; preds = %401
+ThrowNullRef168:                                  ; preds = %401
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef169:                                  ; preds = %407
+ThrowNullRef170:                                  ; preds = %407
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1939,8 +2021,8 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
-  br i1 %NullCheck, label %22, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %ThrowNullRef, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
@@ -1948,8 +2030,8 @@ entry:
   store i32 %24, i32* %loc0
   %25 = load i32, i32* %loc0
   %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %26, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %27
 
 ; <label>:27                                      ; preds = %22
   %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
@@ -1971,7 +2053,7 @@ ThrowNullRef:                                     ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1989,8 +2071,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -2022,15 +2104,15 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2048,16 +2130,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
   %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
   store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %15
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
@@ -2072,8 +2154,8 @@ entry:
   %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
   %29 = ptrtoint i16 addrspace(1)* %28 to i64
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %19
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
@@ -2089,19 +2171,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2114,8 +2196,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
@@ -2128,7 +2210,7 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[loadElem]
+Failed to read AppDomain.PrepareDataForSetup[storeElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
@@ -2202,8 +2284,8 @@ entry:
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
-  br i1 %NullCheck24, label %27, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = load i64, i64 addrspace(1)* %26
@@ -2218,8 +2300,8 @@ entry:
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
-  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
   %41 = load i64, i64 addrspace(1)* %39
@@ -2236,8 +2318,8 @@ entry:
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
-  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
   %54 = load i64, i64 addrspace(1)* %52
@@ -2252,8 +2334,8 @@ entry:
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
   %67 = load i64, i64 addrspace(1)* %65
@@ -2270,8 +2352,8 @@ entry:
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
-  br i1 %NullCheck16, label %79, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
   %80 = load i64, i64 addrspace(1)* %78
@@ -2286,8 +2368,8 @@ entry:
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
-  br i1 %NullCheck18, label %92, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
   %93 = load i64, i64 addrspace(1)* %91
@@ -2304,8 +2386,8 @@ entry:
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
-  br i1 %NullCheck12, label %105, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = load i64, i64 addrspace(1)* %104
@@ -2320,8 +2402,8 @@ entry:
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
-  br i1 %NullCheck14, label %118, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
   %119 = load i64, i64 addrspace(1)* %117
@@ -2337,8 +2419,8 @@ entry:
 
 ; <label>:128                                     ; preds = %20
   %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
-  br i1 %NullCheck4, label %130, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %129, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %130
 
 ; <label>:130                                     ; preds = %128
   %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
@@ -2346,8 +2428,8 @@ entry:
   %133 = load i16, i16 addrspace(1)* %132, align 8
   %134 = zext i16 %133 to i32
   %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
-  br i1 %NullCheck6, label %136, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %135, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %136
 
 ; <label>:136                                     ; preds = %130
   %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
@@ -2360,8 +2442,8 @@ entry:
 
 ; <label>:143                                     ; preds = %136
   %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
-  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %144, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %145
 
 ; <label>:145                                     ; preds = %143
   %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
@@ -2369,8 +2451,8 @@ entry:
   %148 = load i16, i16 addrspace(1)* %147, align 8
   %149 = zext i16 %148 to i32
   %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %150, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %151
 
 ; <label>:151                                     ; preds = %145
   %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
@@ -2388,8 +2470,8 @@ entry:
 
 ; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
-  br i1 %NullCheck, label %163, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %ThrowNullRef, label %163
 
 ; <label>:163                                     ; preds = %161
   %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
@@ -2399,8 +2481,8 @@ entry:
 
 ; <label>:167                                     ; preds = %163
   %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
-  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %168, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %169
 
 ; <label>:169                                     ; preds = %167
   %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
@@ -2432,55 +2514,55 @@ ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %167
+ThrowNullRef2:                                    ; preds = %167
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %128
+ThrowNullRef4:                                    ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %130
+ThrowNullRef6:                                    ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %143
+ThrowNullRef8:                                    ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %145
+ThrowNullRef10:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %102
+ThrowNullRef12:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %105
+ThrowNullRef14:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %76
+ThrowNullRef16:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %79
+ThrowNullRef18:                                   ; preds = %79
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %50
+ThrowNullRef20:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %53
+ThrowNullRef22:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %24
+ThrowNullRef24:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %27
+ThrowNullRef26:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2503,15 +2585,15 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2519,16 +2601,16 @@ entry:
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
   store i32 %8, i32* %loc0
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
   %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
   store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
@@ -2546,16 +2628,16 @@ entry:
 
 ; <label>:23                                      ; preds = %64
   %24 = load i16*, i16** %loc3
-  %NullCheck12 = icmp ne i16* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i16* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
   store i32 %27, i32* %loc5
   %28 = load i16*, i16** %loc4
-  %NullCheck14 = icmp ne i16* %28, null
-  br i1 %NullCheck14, label %29, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %28, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = load i16, i16* %28, align 8
@@ -2620,15 +2702,15 @@ entry:
 
 ; <label>:67                                      ; preds = %64
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
-  br i1 %NullCheck8, label %69, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %68, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %69
 
 ; <label>:69                                      ; preds = %67
   %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
   %71 = load i32, i32 addrspace(1)* %70
   %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
-  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %73
 
 ; <label>:73                                      ; preds = %69
   %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
@@ -2645,31 +2727,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %67
+ThrowNullRef8:                                    ; preds = %67
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %69
+ThrowNullRef10:                                   ; preds = %69
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2710,14 +2792,14 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
   %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
@@ -2730,14 +2812,14 @@ entry:
 
 ; <label>:11                                      ; preds = %4
   %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
   %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
@@ -2749,14 +2831,14 @@ entry:
 
 ; <label>:22                                      ; preds = %16
   %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
   %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
-  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
-  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
@@ -2804,23 +2886,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2836,7 +2918,280 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[loadElem]
+Successfully read RuntimeType.IsAssignableFrom
+
+define i8 @RuntimeType.IsAssignableFrom(%System.RuntimeType addrspace(1)* %param0, %System.Type addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.RuntimeType addrspace(1)*
+  %arg1 = alloca %System.Type addrspace(1)*
+  %loc0 = alloca %System.RuntimeType addrspace(1)*
+  %loc1 = alloca %"System.Type[]" addrspace(1)*
+  %loc2 = alloca i32
+  store %System.RuntimeType addrspace(1)* %param0, %System.RuntimeType addrspace(1)** %this
+  store %System.Type addrspace(1)* %param1, %System.Type addrspace(1)** %arg1
+  %0 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %1 = icmp ne %System.Type addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i8 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %5 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %6 = bitcast %System.Type addrspace(1)* %4 to %System.Object addrspace(1)*
+  %7 = bitcast %System.RuntimeType addrspace(1)* %5 to %System.Object addrspace(1)*
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %6, %System.Object addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %3
+  ret i8 1
+
+; <label>:12                                      ; preds = %3
+  %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 152
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 32
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
+  %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
+  %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
+  store %System.RuntimeType addrspace(1)* %25, %System.RuntimeType addrspace(1)** %loc0
+  %26 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %27 = icmp eq %System.RuntimeType addrspace(1)* %26, null
+  br i1 %27, label %34, label %28
+
+; <label>:28                                      ; preds = %15
+  %29 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %30 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)*)*)(%System.RuntimeType addrspace(1)* %29, %System.RuntimeType addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+; <label>:34                                      ; preds = %15
+  %35 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %36 = call %System.Reflection.Emit.TypeBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Reflection.Emit.TypeBuilder addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %35)
+  %37 = icmp eq %System.Reflection.Emit.TypeBuilder addrspace(1)* %36, null
+  br i1 %37, label %139, label %38
+
+; <label>:38                                      ; preds = %34
+  %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %42
+
+; <label>:42                                      ; preds = %38
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 152
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 40
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
+  %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
+  %53 = zext i8 %52 to i32
+  %54 = icmp eq i32 %53, 0
+  br i1 %54, label %56, label %55
+
+; <label>:55                                      ; preds = %42
+  ret i8 1
+
+; <label>:56                                      ; preds = %42
+  %57 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %58 = bitcast %System.RuntimeType addrspace(1)* %57 to %System.Type addrspace(1)*
+  %59 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %58)
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %64 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.Type addrspace(1)* %63, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = bitcast %System.RuntimeType addrspace(1)* %64 to %System.Type addrspace(1)*
+  %67 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %63, %System.Type addrspace(1)* %66)
+  %68 = zext i8 %67 to i32
+  %69 = trunc i32 %68 to i8
+  ret i8 %69
+
+; <label>:70                                      ; preds = %56
+  %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
+  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %73
+
+; <label>:73                                      ; preds = %70
+  %74 = load i64, i64 addrspace(1)* %72
+  %75 = add i64 %74, 128
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = add i64 %77, 0
+  %79 = inttoptr i64 %78 to i64*
+  %80 = load i64, i64* %79
+  %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
+  %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
+  %83 = call i8 %82(%System.Type addrspace(1)* %81)
+  %84 = zext i8 %83 to i32
+  %85 = icmp eq i32 %84, 0
+  br i1 %85, label %139, label %86
+
+; <label>:86                                      ; preds = %73
+  %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
+  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %89
+
+; <label>:89                                      ; preds = %86
+  %90 = load i64, i64 addrspace(1)* %88
+  %91 = add i64 %90, 128
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = add i64 %93, 24
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
+  %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
+  %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
+  store %"System.Type[]" addrspace(1)* %99, %"System.Type[]" addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %129
+
+; <label>:100                                     ; preds = %132
+  %101 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %102 = load i32, i32* %loc2
+  %NullCheck11 = icmp eq %"System.Type[]" addrspace(1)* %101, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %103
+
+; <label>:103                                     ; preds = %100
+  %104 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 1
+  %105 = load i32, i32 addrspace(1)* %104
+  %106 = zext i32 %105 to i64
+  %107 = zext i32 %102 to i64
+  %BoundsCheck = icmp uge i64 %107, %106
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %108
+
+; <label>:108                                     ; preds = %103
+  %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
+  %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
+  %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
+  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %113
+
+; <label>:113                                     ; preds = %108
+  %114 = load i64, i64 addrspace(1)* %112
+  %115 = add i64 %114, 152
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = add i64 %117, 56
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
+  %123 = zext i8 %122 to i32
+  %124 = icmp ne i32 %123, 0
+  br i1 %124, label %126, label %125
+
+; <label>:125                                     ; preds = %113
+  ret i8 0
+
+; <label>:126                                     ; preds = %113
+  %127 = load i32, i32* %loc2
+  %128 = add i32 %127, 1
+  store i32 %128, i32* %loc2
+  br label %129
+
+; <label>:129                                     ; preds = %89, %126
+  %130 = load i32, i32* %loc2
+  %131 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %NullCheck9 = icmp eq %"System.Type[]" addrspace(1)* %131, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %132
+
+; <label>:132                                     ; preds = %129
+  %133 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %131, i32 0, i32 1
+  %134 = load i32, i32 addrspace(1)* %133
+  %135 = zext i32 %134 to i64
+  %136 = trunc i64 %135 to i32
+  %137 = icmp slt i32 %130, %136
+  br i1 %137, label %100, label %138
+
+; <label>:138                                     ; preds = %132
+  ret i8 1
+
+; <label>:139                                     ; preds = %34, %73
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %129
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %103
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -2893,7 +3248,7 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElem]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -2904,8 +3259,8 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -2997,8 +3352,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
@@ -3059,8 +3414,8 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -3087,8 +3442,8 @@ entry:
 
 ; <label>:17                                      ; preds = %5, %11
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
@@ -3097,8 +3452,8 @@ entry:
 
 ; <label>:22                                      ; preds = %1, %11
   %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
@@ -3109,11 +3464,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %17
+ThrowNullRef2:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %22
+ThrowNullRef4:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3167,15 +3522,15 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
   %15 = load i32, i32 addrspace(1)* %14
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
@@ -3198,7 +3553,7 @@ ThrowNullRef:                                     ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef2:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3232,8 +3587,8 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
@@ -3312,8 +3667,8 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -3327,8 +3682,8 @@ entry:
 ; <label>:5                                       ; preds = %43
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %7 = load i32, i32* %loc1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck6, label %8, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
@@ -3366,8 +3721,8 @@ entry:
 ; <label>:32                                      ; preds = %21, %25
   %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
   %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
-  br i1 %NullCheck8, label %35, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = trunc i32 %34 to i16
@@ -3380,8 +3735,8 @@ entry:
 ; <label>:40                                      ; preds = %1, %35
   %41 = load i32, i32* %loc1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
-  br i1 %NullCheck2, label %43, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %42, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
@@ -3392,8 +3747,8 @@ entry:
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
   %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
-  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
   %51 = load i64, i64 addrspace(1)* %49
@@ -3412,19 +3767,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %40
+ThrowNullRef2:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %47
+ThrowNullRef4:                                    ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %5
+ThrowNullRef6:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %32
+ThrowNullRef8:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3467,8 +3822,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
@@ -3492,11 +3847,391 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(i16* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store i16* %param0, i16** %arg0
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load i32, i32* %arg3
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %42, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %37, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg2
+  %13 = load i32, i32* %arg3
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %37, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %24 = load i32, i32* %arg2
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load i16*, i16** %arg0
+  %35 = load i32, i32* %arg3
+  %36 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %36, i16* %34, i32 %35)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:37                                      ; preds = %5, %16
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %39)
+  %41 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41, %System.String addrspace(1)* %38, %System.String addrspace(1)* %40)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41) #0
+  unreachable
+
+; <label>:42                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
-Failed to read StringBuilder.ToString[loadElemA]
+Successfully read StringBuilder.ToString
+
+define %System.String addrspace(1)* @StringBuilder.ToString(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i16*
+  %loc3 = alloca %"System.Char[]" addrspace(1)*
+  %loc4 = alloca i32
+  %loc5 = alloca i32
+  %loc6 = alloca i16 addrspace(1)*
+  %loc7 = alloca %System.String addrspace(1)*
+  %loc8 = alloca %"System.Char[]" addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %0)
+  %2 = icmp ne i32 %1, 0
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %4
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %6)
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %7)
+  store %System.String addrspace(1)* %8, %System.String addrspace(1)** %loc0
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.Text.StringBuilder addrspace(1)* %9, %System.Text.StringBuilder addrspace(1)** %loc1
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  store %System.String addrspace(1)* %10, %System.String addrspace(1)** %loc7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc7
+  %12 = ptrtoint %System.String addrspace(1)* %11 to i64
+  %13 = icmp eq i64 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %5
+  %15 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %16 = sext i32 %15 to i64
+  %17 = add i64 %12, %16
+  br label %18
+
+; <label>:18                                      ; preds = %5, %14
+  %19 = phi i64 [ %12, %5 ], [ %17, %14 ]
+  %20 = inttoptr i64 %19 to i16*
+  store i16* %20, i16** %loc2
+  br label %21
+
+; <label>:21                                      ; preds = %98, %18
+  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %22, null
+  br i1 %NullCheck, label %ThrowNullRef, label %23
+
+; <label>:23                                      ; preds = %21
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 3
+  %25 = load i32, i32 addrspace(1)* %24, align 8
+  %26 = icmp sle i32 %25, 0
+  br i1 %26, label %96, label %27
+
+; <label>:27                                      ; preds = %23
+  %28 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %28, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %29
+
+; <label>:29                                      ; preds = %27
+  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %28, i32 0, i32 1
+  %31 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %30, align 8
+  store %"System.Char[]" addrspace(1)* %31, %"System.Char[]" addrspace(1)** %loc3
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %33
+
+; <label>:33                                      ; preds = %29
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  store i32 %35, i32* %loc4
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  %39 = load i32, i32 addrspace(1)* %38, align 8
+  store i32 %39, i32* %loc5
+  %40 = load i32, i32* %loc5
+  %41 = load i32, i32* %loc4
+  %42 = add i32 %40, %41
+  %43 = zext i32 %42 to i64
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %45
+
+; <label>:45                                      ; preds = %37
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = sext i32 %47 to i64
+  %49 = icmp sgt i64 %43, %48
+  br i1 %49, label %91, label %50
+
+; <label>:50                                      ; preds = %45
+  %51 = load i32, i32* %loc5
+  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %52, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %53
+
+; <label>:53                                      ; preds = %50
+  %54 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %52, i32 0, i32 1
+  %55 = load i32, i32 addrspace(1)* %54
+  %56 = zext i32 %55 to i64
+  %57 = trunc i64 %56 to i32
+  %58 = icmp ugt i32 %51, %57
+  br i1 %58, label %91, label %59
+
+; <label>:59                                      ; preds = %53
+  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  store %"System.Char[]" addrspace(1)* %60, %"System.Char[]" addrspace(1)** %loc8
+  %61 = icmp eq %"System.Char[]" addrspace(1)* %60, null
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %63, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %64
+
+; <label>:64                                      ; preds = %62
+  %65 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %63, i32 0, i32 1
+  %66 = load i32, i32 addrspace(1)* %65
+  %67 = zext i32 %66 to i64
+  %68 = trunc i64 %67 to i32
+  %69 = icmp ne i32 %68, 0
+  br i1 %69, label %71, label %70
+
+; <label>:70                                      ; preds = %59, %64
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:71                                      ; preds = %64
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %73
+
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %BoundsCheck = icmp uge i64 0, %76
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %77
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %78, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:79                                      ; preds = %70, %77
+  %80 = load i16*, i16** %loc2
+  %81 = load i32, i32* %loc4
+  %82 = sext i32 %81 to i64
+  %83 = mul i64 %82, 2
+  %84 = bitcast i16* %80 to i8*
+  %85 = getelementptr inbounds i8, i8* %84, i64 %83
+  %86 = load i16 addrspace(1)*, i16 addrspace(1)** %loc6
+  %87 = ptrtoint i16 addrspace(1)* %86 to i64
+  %88 = load i32, i32* %loc5
+  %89 = bitcast i8* %85 to i16*
+  %90 = inttoptr i64 %87 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %89, i16* %90, i32 %88)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %96
+
+; <label>:91                                      ; preds = %45, %53
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %94 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %93)
+  %95 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95, %System.String addrspace(1)* %92, %System.String addrspace(1)* %94)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95) #0
+  unreachable
+
+; <label>:96                                      ; preds = %23, %79
+  %97 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %97, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %98
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %97, i32 0, i32 2
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  store %System.Text.StringBuilder addrspace(1)* %100, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %102 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %102, label %21, label %103
+
+; <label>:103                                     ; preds = %98
+  store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc7
+  %104 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  ret %System.String addrspace(1)* %104
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method StringBuilder::get_Length using LLILCJit
+Successfully read StringBuilder.get_Length
+
+define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
+Successfully read RuntimeHelpers.get_OffsetToStringData
+
+define i32 @RuntimeHelpers.get_OffsetToStringData() {
+entry:
+  ret i32 12
+}
+
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
 Successfully read CultureData.CreateCultureData
 
@@ -3514,23 +4249,23 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
   store i8 %4, i8 addrspace(1)* %6
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
@@ -3549,11 +4284,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3566,50 +4301,50 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
   store i32 -1, i32 addrspace(1)* %2
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
   store i32 -1, i32 addrspace(1)* %8
   %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
   store i32 -1, i32 addrspace(1)* %14
   %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
   store i32 -1, i32 addrspace(1)* %17
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
@@ -3623,27 +4358,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3675,7 +4410,136 @@ Failed to read Dictionary`2.Insert[non-const derefAddress]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
 Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
-Failed to read HashHelpers.GetPrime[loadElem]
+Successfully read HashHelpers.GetPrime
+
+define i32 @HashHelpers.GetPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %6, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5, %System.String addrspace(1)* %4)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5) #0
+  unreachable
+
+; <label>:6                                       ; preds = %entry
+  store i32 0, i32* %loc0
+  br label %29
+
+; <label>:7                                       ; preds = %35
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 1296
+  %10 = addrspacecast i8 addrspace(1)* %9 to %"System.Int32[]" addrspace(1)**
+  %11 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %10
+  %12 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Int32[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = zext i32 %15 to i64
+  %17 = zext i32 %12 to i64
+  %BoundsCheck = icmp uge i64 %17, %16
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 3, i32 %12
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  store i32 %20, i32* %loc1
+  %21 = load i32, i32* %loc1
+  %22 = load i32, i32* %arg0
+  %23 = icmp slt i32 %21, %22
+  br i1 %23, label %26, label %24
+
+; <label>:24                                      ; preds = %18
+  %25 = load i32, i32* %loc1
+  ret i32 %25
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %loc0
+  %28 = add i32 %27, 1
+  store i32 %28, i32* %loc0
+  br label %29
+
+; <label>:29                                      ; preds = %6, %26
+  %30 = load i32, i32* %loc0
+  %31 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %32 = getelementptr inbounds i8, i8 addrspace(1)* %31, i64 1296
+  %33 = addrspacecast i8 addrspace(1)* %32 to %"System.Int32[]" addrspace(1)**
+  %34 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %33
+  %NullCheck = icmp eq %"System.Int32[]" addrspace(1)* %34, null
+  br i1 %NullCheck, label %ThrowNullRef, label %35
+
+; <label>:35                                      ; preds = %29
+  %36 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %34, i32 0, i32 1
+  %37 = load i32, i32 addrspace(1)* %36
+  %38 = zext i32 %37 to i64
+  %39 = trunc i64 %38 to i32
+  %40 = icmp slt i32 %30, %39
+  br i1 %40, label %7, label %41
+
+; <label>:41                                      ; preds = %35
+  %42 = load i32, i32* %arg0
+  %43 = or i32 %42, 1
+  store i32 %43, i32* %loc2
+  br label %59
+
+; <label>:44                                      ; preds = %59
+  %45 = load i32, i32* %loc2
+  %46 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %45)
+  %47 = zext i8 %46 to i32
+  %48 = icmp eq i32 %47, 0
+  br i1 %48, label %56, label %49
+
+; <label>:49                                      ; preds = %44
+  %50 = load i32, i32* %loc2
+  %51 = sub i32 %50, 1
+  %52 = srem i32 %51, 101
+  %53 = icmp eq i32 %52, 0
+  br i1 %53, label %56, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = load i32, i32* %loc2
+  ret i32 %55
+
+; <label>:56                                      ; preds = %44, %49
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %57, 2
+  store i32 %58, i32* %loc2
+  br label %59
+
+; <label>:59                                      ; preds = %41, %56
+  %60 = load i32, i32* %loc2
+  %61 = icmp slt i32 %60, 2147483647
+  br i1 %61, label %44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load i32, i32* %arg0
+  ret i32 %63
+
+ThrowNullRef:                                     ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
 Successfully read GenericEqualityComparer`1.GetHashCode
 
@@ -3694,14 +4558,14 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
   %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load i64, i64 addrspace(1)* %7
@@ -3720,7 +4584,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3750,8 +4614,8 @@ entry:
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
@@ -3796,8 +4660,8 @@ entry:
   %35 = bitcast i16* %34 to i8*
   %36 = getelementptr inbounds i8, i8* %35, i64 2
   %37 = bitcast i8* %36 to i16*
-  %NullCheck4 = icmp ne i16* %37, null
-  br i1 %NullCheck4, label %38, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %37, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %38
 
 ; <label>:38                                      ; preds = %27
   %39 = load i16, i16* %37, align 8
@@ -3824,8 +4688,8 @@ entry:
 
 ; <label>:54                                      ; preds = %22, %43
   %55 = load i16*, i16** %loc4
-  %NullCheck2 = icmp ne i16* %55, null
-  br i1 %NullCheck2, label %56, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i16* %55, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %56
 
 ; <label>:56                                      ; preds = %54
   %57 = load i16, i16* %55, align 8
@@ -3850,11 +4714,11 @@ ThrowNullRef:                                     ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %54
+ThrowNullRef2:                                    ; preds = %54
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %27
+ThrowNullRef4:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3871,8 +4735,8 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -3907,8 +4771,8 @@ entry:
 
 ; <label>:26                                      ; preds = %19
   %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
-  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %28
 
 ; <label>:28                                      ; preds = %26
   %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
@@ -3920,7 +4784,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3972,8 +4836,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
@@ -3984,26 +4848,26 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
-  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
@@ -4014,8 +4878,8 @@ entry:
 ; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
@@ -4024,8 +4888,8 @@ entry:
 
 ; <label>:25                                      ; preds = %1, %16, %23
   %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
-  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
@@ -4036,27 +4900,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %20
+ThrowNullRef10:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4069,8 +4933,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -4081,8 +4945,8 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
@@ -4091,8 +4955,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1, %8
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
@@ -4103,11 +4967,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4128,24 +4992,24 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   store i32 %3, i32* %loc0
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
   %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
   store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck4, label %9, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
@@ -4164,15 +5028,15 @@ entry:
 ; <label>:18                                      ; preds = %70
   %19 = load i16*, i16** %loc3
   %20 = bitcast i16* %19 to i64*
-  %NullCheck10 = icmp ne i64* %20, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %20, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = load i64, i64* %20, align 8
   %23 = load i16*, i16** %loc4
   %24 = bitcast i16* %23 to i64*
-  %NullCheck12 = icmp ne i64* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = load i64, i64* %24, align 8
@@ -4188,8 +5052,8 @@ entry:
   %31 = bitcast i16* %30 to i8*
   %32 = getelementptr inbounds i8, i8* %31, i64 8
   %33 = bitcast i8* %32 to i64*
-  %NullCheck14 = icmp ne i64* %33, null
-  br i1 %NullCheck14, label %34, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = load i64, i64* %33, align 8
@@ -4197,8 +5061,8 @@ entry:
   %37 = bitcast i16* %36 to i8*
   %38 = getelementptr inbounds i8, i8* %37, i64 8
   %39 = bitcast i8* %38 to i64*
-  %NullCheck16 = icmp ne i64* %39, null
-  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %40
 
 ; <label>:40                                      ; preds = %34
   %41 = load i64, i64* %39, align 8
@@ -4214,8 +5078,8 @@ entry:
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %NullCheck18 = icmp ne i64* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = load i64, i64* %48, align 8
@@ -4223,8 +5087,8 @@ entry:
   %52 = bitcast i16* %51 to i8*
   %53 = getelementptr inbounds i8, i8* %52, i64 16
   %54 = bitcast i8* %53 to i64*
-  %NullCheck20 = icmp ne i64* %54, null
-  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64* %54, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %55
 
 ; <label>:55                                      ; preds = %49
   %56 = load i64, i64* %54, align 8
@@ -4262,15 +5126,15 @@ entry:
 ; <label>:74                                      ; preds = %95
   %75 = load i16*, i16** %loc3
   %76 = bitcast i16* %75 to i32*
-  %NullCheck6 = icmp ne i32* %76, null
-  br i1 %NullCheck6, label %77, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32* %76, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %77
 
 ; <label>:77                                      ; preds = %74
   %78 = load i32, i32* %76, align 8
   %79 = load i16*, i16** %loc4
   %80 = bitcast i16* %79 to i32*
-  %NullCheck8 = icmp ne i32* %80, null
-  br i1 %NullCheck8, label %81, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i32* %80, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %81
 
 ; <label>:81                                      ; preds = %77
   %82 = load i32, i32* %80, align 8
@@ -4318,43 +5182,43 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %74
+ThrowNullRef6:                                    ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %77
+ThrowNullRef8:                                    ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %29
+ThrowNullRef14:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %34
+ThrowNullRef16:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4376,8 +5240,8 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load i64, i64 addrspace(1)* %4
@@ -4389,8 +5253,8 @@ entry:
   %12 = load i64, i64* %11
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %5
   %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
@@ -4399,8 +5263,8 @@ entry:
   %18 = load i8, i8* %arg2
   %19 = zext i8 %18 to i32
   %20 = trunc i32 %19 to i8
-  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %15
   %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
@@ -4411,11 +5275,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4442,8 +5306,8 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
@@ -4466,16 +5330,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
   %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = load i64, i64 addrspace(1)* %19
@@ -4500,8 +5364,8 @@ entry:
 ; <label>:35                                      ; preds = %30
   %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
@@ -4514,8 +5378,8 @@ entry:
 
 ; <label>:42                                      ; preds = %1, %38
   %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
-  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
@@ -4526,19 +5390,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %35
+ThrowNullRef2:                                    ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %42
+ThrowNullRef8:                                    ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4551,14 +5415,14 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
@@ -4570,7 +5434,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4583,8 +5447,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
@@ -4613,51 +5477,51 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
   %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
   %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
   %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
   %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
-  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
   store i64 %21, i64 addrspace(1)* %23
   %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %25 = load i64, i64* %loc0
-  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
@@ -4668,27 +5532,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %22
+ThrowNullRef12:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4701,8 +5565,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
@@ -4713,19 +5577,19 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
@@ -4734,8 +5598,8 @@ entry:
 
 ; <label>:15                                      ; preds = %1, %13
   %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
@@ -4746,19 +5610,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %15
+ThrowNullRef8:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4771,8 +5635,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -4831,8 +5695,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
@@ -4882,8 +5746,8 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
-  br i1 %NullCheck, label %17, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %ThrowNullRef, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
@@ -4894,15 +5758,15 @@ entry:
 
 ; <label>:22                                      ; preds = %17
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
-  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
   %26 = load i32, i32 addrspace(1)* %25
   %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
-  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %27, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
@@ -4925,8 +5789,8 @@ entry:
 ; <label>:40                                      ; preds = %17
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
-  br i1 %NullCheck6, label %43, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %41, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
@@ -4938,34 +5802,17 @@ ThrowNullRef:                                     ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %24
+ThrowNullRef4:                                    ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %40
+ThrowNullRef6:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
-}
-
-INFO:  jitting method Object::ReferenceEquals using LLILCJit
-Successfully read Object.ReferenceEquals
-
-define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
-entry:
-  %arg0 = alloca %System.Object addrspace(1)*
-  %arg1 = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
-  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
-  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = icmp eq %System.Object addrspace(1)* %0, %1
-  %3 = sext i1 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
 }
 
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
@@ -4978,21 +5825,21 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
   %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
-  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
@@ -5007,28 +5854,28 @@ entry:
 ; <label>:13                                      ; preds = %8, %12
   %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
   %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
   %21 = load i32, i32 addrspace(1)* %20, align 8
   %22 = add i32 %21, 1
-  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
   store i32 %22, i32 addrspace(1)* %24
   %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
@@ -5039,27 +5886,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5077,7 +5924,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::Setup using LLILCJit
-Failed to read AppDomain.Setup[loadElem]
+Failed to read AppDomain.Setup[unbox]
 INFO:  jitting method Thread::GetDomain using LLILCJit
 Successfully read Thread.GetDomain
 
@@ -5108,8 +5955,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
@@ -5122,14 +5969,14 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
   %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
@@ -5141,11 +5988,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5173,8 +6020,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -5189,7 +6036,328 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
 Failed to read KeyCollection.System.Collections.Generic.IEnumerable<TKey>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Successfully read Enumerator.MoveNext
+
+define i8 @Enumerator.MoveNext(%"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.RuntimeTypeHandle* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*
+  %"$TypeArg" = alloca %System.RuntimeTypeHandle*
+  store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
+  %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 8
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %76, label %12
+
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
+  br label %76
+
+; <label>:13                                      ; preds = %85
+  %14 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck19 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %15
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, i32 0, i32 0
+  %17 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %16, align 8
+  %NullCheck21 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, i32 0, i32 2
+  %20 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %19, align 8
+  %21 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck23 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %22
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, i32 0, i32 2
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %NullCheck25 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 3, i32 %24
+  %NullCheck27 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %32
+
+; <label>:32                                      ; preds = %30
+  %33 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, i32 0, i32 2
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = icmp slt i32 %34, 0
+  br i1 %35, label %68, label %36
+
+; <label>:36                                      ; preds = %32
+  %37 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %38 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck29 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %39
+
+; <label>:39                                      ; preds = %36
+  %40 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, i32 0, i32 0
+  %41 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %40, align 8
+  %NullCheck31 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, i32 0, i32 2
+  %44 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %43, align 8
+  %45 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck33 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, i32 0, i32 2
+  %48 = load i32, i32 addrspace(1)* %47, align 8
+  %NullCheck35 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %49
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = zext i32 %51 to i64
+  %53 = zext i32 %48 to i64
+  %BoundsCheck37 = icmp uge i64 %53, %52
+  br i1 %BoundsCheck37, label %ThrowIndexOutOfRange38, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 3, i32 %48
+  %NullCheck39 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %56
+
+; <label>:56                                      ; preds = %54
+  %57 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, i32 0, i32 0
+  %58 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck41 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %59
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %60, %System.__Canon addrspace(1)* %58)
+  %61 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck43 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  %64 = load i32, i32 addrspace(1)* %63, align 8
+  %65 = add i32 %64, 1
+  %NullCheck45 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  store i32 %65, i32 addrspace(1)* %67
+  ret i8 1
+
+; <label>:68                                      ; preds = %32
+  %69 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck47 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %73 = add i32 %72, 1
+  %NullCheck49 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %74
+
+; <label>:74                                      ; preds = %70
+  %75 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  store i32 %73, i32 addrspace(1)* %75
+  br label %76
+
+; <label>:76                                      ; preds = %8, %12, %74
+  %77 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %78
+
+; <label>:78                                      ; preds = %76
+  %79 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, i32 0, i32 2
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck7 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %82
+
+; <label>:82                                      ; preds = %78
+  %83 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, i32 0, i32 0
+  %84 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %83, align 8
+  %NullCheck9 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %85
+
+; <label>:85                                      ; preds = %82
+  %86 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, i32 0, i32 7
+  %87 = load i32, i32 addrspace(1)* %86, align 8
+  %88 = icmp ult i32 %80, %87
+  br i1 %88, label %13, label %89
+
+; <label>:89                                      ; preds = %85
+  %90 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %91 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck11 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %92
+
+; <label>:92                                      ; preds = %89
+  %93 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, i32 0, i32 0
+  %94 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck13 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %95
+
+; <label>:95                                      ; preds = %92
+  %96 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, i32 0, i32 7
+  %97 = load i32, i32 addrspace(1)* %96, align 8
+  %98 = add i32 %97, 1
+  %NullCheck15 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %99
+
+; <label>:99                                      ; preds = %95
+  %100 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, i32 0, i32 2
+  store i32 %98, i32 addrspace(1)* %100
+  %101 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck17 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %102
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %103, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %92
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef22:                                   ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef24:                                   ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef26:                                   ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef28:                                   ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef30:                                   ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef32:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef34:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef36:                                   ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange38:                           ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef40:                                   ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef42:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef44:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef46:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef48:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef50:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -5200,8 +6368,8 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -5232,9 +6400,9 @@ Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
 Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
-Failed to read String.MakeSeparatorList[loadElemA]
+Failed to read String.MakeSeparatorList[storeElem]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
-Failed to read String.InternalSplitKeepEmptyEntries[loadElem]
+Failed to read String.InternalSplitKeepEmptyEntries[storeElem]
 INFO:  jitting method Path::IsRelative using LLILCJit
 Successfully read Path.IsRelative
 
@@ -5243,8 +6411,8 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -5254,8 +6422,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
@@ -5271,8 +6439,8 @@ entry:
 
 ; <label>:17                                      ; preds = %7
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
@@ -5288,8 +6456,8 @@ entry:
 
 ; <label>:29                                      ; preds = %19
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %31
 
 ; <label>:31                                      ; preds = %29
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
@@ -5300,8 +6468,8 @@ entry:
 
 ; <label>:36                                      ; preds = %31
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
-  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %37, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
@@ -5312,8 +6480,8 @@ entry:
 
 ; <label>:43                                      ; preds = %31, %38
   %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
-  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %45
 
 ; <label>:45                                      ; preds = %43
   %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
@@ -5324,8 +6492,8 @@ entry:
 
 ; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %50
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
@@ -5336,8 +6504,8 @@ entry:
 
 ; <label>:57                                      ; preds = %1, %7, %19, %45, %52
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
-  br i1 %NullCheck14, label %59, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %59
 
 ; <label>:59                                      ; preds = %57
   %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
@@ -5347,8 +6515,8 @@ entry:
 
 ; <label>:63                                      ; preds = %59
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
@@ -5359,8 +6527,8 @@ entry:
 
 ; <label>:70                                      ; preds = %65
   %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
-  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.String addrspace(1)* %71, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %72
 
 ; <label>:72                                      ; preds = %70
   %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
@@ -5379,39 +6547,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %17
+ThrowNullRef4:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %29
+ThrowNullRef6:                                    ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %36
+ThrowNullRef8:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %43
+ThrowNullRef10:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %50
+ThrowNullRef12:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %57
+ThrowNullRef14:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %63
+ThrowNullRef16:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %70
+ThrowNullRef18:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5419,7 +6587,293 @@ ThrowNullRef17:                                   ; preds = %70
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
-Failed to read String.TrimHelper[loadElem]
+Successfully read String.TrimHelper
+
+define %System.String addrspace(1)* @String.TrimHelper(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i16
+  %loc4 = alloca i32
+  %loc5 = alloca i16
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = sub i32 %3, 1
+  store i32 %4, i32* %loc0
+  store i32 0, i32* %loc1
+  %5 = load i32, i32* %arg2
+  %6 = icmp eq i32 %5, 1
+  br i1 %6, label %62, label %7
+
+; <label>:7                                       ; preds = %1
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:8                                       ; preds = %58
+  store i32 0, i32* %loc2
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load i32, i32* %loc1
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2, i32 %10
+  %13 = load i16, i16 addrspace(1)* %12
+  %14 = zext i16 %13 to i32
+  %15 = trunc i32 %14 to i16
+  store i16 %15, i16* %loc3
+  store i32 0, i32* %loc2
+  br label %34
+
+; <label>:16                                      ; preds = %37
+  %17 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %18 = load i32, i32* %loc2
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %17, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %19
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = zext i32 %18 to i64
+  %BoundsCheck = icmp uge i64 %23, %22
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %24
+
+; <label>:24                                      ; preds = %19
+  %25 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 3, i32 %18
+  %26 = load i16, i16 addrspace(1)* %25, align 8
+  %27 = zext i16 %26 to i32
+  %28 = load i16, i16* %loc3
+  %29 = zext i16 %28 to i32
+  %30 = icmp eq i32 %27, %29
+  br i1 %30, label %43, label %31
+
+; <label>:31                                      ; preds = %24
+  %32 = load i32, i32* %loc2
+  %33 = add i32 %32, 1
+  store i32 %33, i32* %loc2
+  br label %34
+
+; <label>:34                                      ; preds = %11, %31
+  %35 = load i32, i32* %loc2
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = icmp slt i32 %35, %41
+  br i1 %42, label %16, label %43
+
+; <label>:43                                      ; preds = %24, %37
+  %44 = load i32, i32* %loc2
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %45, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp eq i32 %44, %50
+  br i1 %51, label %62, label %52
+
+; <label>:52                                      ; preds = %46
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %7, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %57, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %58
+
+; <label>:58                                      ; preds = %55
+  %59 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %60 = load i32, i32 addrspace(1)* %59
+  %61 = icmp slt i32 %56, %60
+  br i1 %61, label %8, label %62
+
+; <label>:62                                      ; preds = %1, %46, %58
+  %63 = load i32, i32* %arg2
+  %64 = icmp eq i32 %63, 0
+  br i1 %64, label %122, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %66, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %67
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %66, i32 0, i32 1
+  %69 = load i32, i32 addrspace(1)* %68
+  %70 = sub i32 %69, 1
+  store i32 %70, i32* %loc0
+  br label %118
+
+; <label>:71                                      ; preds = %118
+  store i32 0, i32* %loc4
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %73 = load i32, i32* %loc0
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %74
+
+; <label>:74                                      ; preds = %71
+  %75 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 2, i32 %73
+  %76 = load i16, i16 addrspace(1)* %75
+  %77 = zext i16 %76 to i32
+  %78 = trunc i32 %77 to i16
+  store i16 %78, i16* %loc5
+  store i32 0, i32* %loc4
+  br label %97
+
+; <label>:79                                      ; preds = %100
+  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %81 = load i32, i32* %loc4
+  %NullCheck19 = icmp eq %"System.Char[]" addrspace(1)* %80, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
+
+; <label>:82                                      ; preds = %79
+  %83 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 1
+  %84 = load i32, i32 addrspace(1)* %83
+  %85 = zext i32 %84 to i64
+  %86 = zext i32 %81 to i64
+  %BoundsCheck21 = icmp uge i64 %86, %85
+  br i1 %BoundsCheck21, label %ThrowIndexOutOfRange22, label %87
+
+; <label>:87                                      ; preds = %82
+  %88 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 3, i32 %81
+  %89 = load i16, i16 addrspace(1)* %88, align 8
+  %90 = zext i16 %89 to i32
+  %91 = load i16, i16* %loc5
+  %92 = zext i16 %91 to i32
+  %93 = icmp eq i32 %90, %92
+  br i1 %93, label %106, label %94
+
+; <label>:94                                      ; preds = %87
+  %95 = load i32, i32* %loc4
+  %96 = add i32 %95, 1
+  store i32 %96, i32* %loc4
+  br label %97
+
+; <label>:97                                      ; preds = %74, %94
+  %98 = load i32, i32* %loc4
+  %99 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck15 = icmp eq %"System.Char[]" addrspace(1)* %99, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %100
+
+; <label>:100                                     ; preds = %97
+  %101 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %99, i32 0, i32 1
+  %102 = load i32, i32 addrspace(1)* %101
+  %103 = zext i32 %102 to i64
+  %104 = trunc i64 %103 to i32
+  %105 = icmp slt i32 %98, %104
+  br i1 %105, label %79, label %106
+
+; <label>:106                                     ; preds = %87, %100
+  %107 = load i32, i32* %loc4
+  %108 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck17 = icmp eq %"System.Char[]" addrspace(1)* %108, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %109
+
+; <label>:109                                     ; preds = %106
+  %110 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %108, i32 0, i32 1
+  %111 = load i32, i32 addrspace(1)* %110
+  %112 = zext i32 %111 to i64
+  %113 = trunc i64 %112 to i32
+  %114 = icmp eq i32 %107, %113
+  br i1 %114, label %122, label %115
+
+; <label>:115                                     ; preds = %109
+  %116 = load i32, i32* %loc0
+  %117 = sub i32 %116, 1
+  store i32 %117, i32* %loc0
+  br label %118
+
+; <label>:118                                     ; preds = %67, %115
+  %119 = load i32, i32* %loc0
+  %120 = load i32, i32* %loc1
+  %121 = icmp sge i32 %119, %120
+  br i1 %121, label %71, label %122
+
+; <label>:122                                     ; preds = %62, %109, %118
+  %123 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %124 = load i32, i32* %loc1
+  %125 = load i32, i32* %loc0
+  %126 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %123, i32 %124, i32 %125)
+  ret %System.String addrspace(1)* %126
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %97
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange22:                           ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
 Successfully read String.CreateTrimmedString
 
@@ -5439,8 +6893,8 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
@@ -5535,8 +6989,8 @@ entry:
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i64 2872
   %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
   %8 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %7
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %3
   %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
@@ -5553,8 +7007,8 @@ entry:
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 2864
   %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
   %21 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %20
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
-  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %22
 
 ; <label>:22                                      ; preds = %16
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
@@ -5569,7 +7023,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %16
+ThrowNullRef2:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5586,8 +7040,8 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5613,8 +7067,8 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
@@ -5632,8 +7086,8 @@ entry:
 
 ; <label>:12                                      ; preds = %4
   %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
@@ -5644,8 +7098,8 @@ entry:
 
 ; <label>:19                                      ; preds = %14
   %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %19
   %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
@@ -5660,21 +7114,21 @@ entry:
   %31 = zext i16 %30 to i32
   %32 = bitcast i8* %29 to i16*
   %33 = trunc i32 %31 to i16
-  %NullCheck6 = icmp ne i16* %32, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i16* %32, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %21
   store i16 %33, i16* %32, align 8
   %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %36
 
 ; <label>:36                                      ; preds = %34
   %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
   %38 = load i32, i32 addrspace(1)* %37, align 8
   %39 = add i32 %38, 1
-  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %40
 
 ; <label>:40                                      ; preds = %36
   %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
@@ -5683,16 +7137,16 @@ entry:
 
 ; <label>:42                                      ; preds = %14
   %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
-  br i1 %NullCheck12, label %44, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
   %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
   %47 = load i16, i16* %arg1
   %48 = zext i16 %47 to i32
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = trunc i32 %48 to i16
@@ -5703,31 +7157,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %19
+ThrowNullRef4:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %21
+ThrowNullRef6:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %36
+ThrowNullRef10:                                   ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %42
+ThrowNullRef12:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %44
+ThrowNullRef14:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5740,8 +7194,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -5752,8 +7206,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
@@ -5762,14 +7216,14 @@ entry:
 
 ; <label>:11                                      ; preds = %1
   %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
@@ -5779,15 +7233,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5808,8 +7262,8 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5822,8 +7276,8 @@ entry:
 
 ; <label>:8                                       ; preds = %3
   %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
@@ -5842,15 +7296,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
-  br i1 %NullCheck4, label %22, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
   %24 = load i16*, i16* addrspace(1)* %23, align 8
   %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %25, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
@@ -5859,8 +7313,8 @@ entry:
   store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
@@ -5874,8 +7328,8 @@ entry:
 
 ; <label>:37                                      ; preds = %65
   %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %37
   %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
@@ -5886,16 +7340,16 @@ entry:
   %45 = bitcast i16* %41 to i8*
   %46 = getelementptr inbounds i8, i8* %45, i64 %44
   %47 = bitcast i8* %46 to i16*
-  %NullCheck14 = icmp ne i16* %47, null
-  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %47, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %48
 
 ; <label>:48                                      ; preds = %39
   %49 = load i16, i16* %47, align 8
   %50 = zext i16 %49 to i32
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %52 = load i32, i32* %loc1
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %53
 
 ; <label>:53                                      ; preds = %48
   %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
@@ -5916,8 +7370,8 @@ entry:
 ; <label>:62                                      ; preds = %36, %59
   %63 = load i32, i32* %loc1
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck10, label %65, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %65
 
 ; <label>:65                                      ; preds = %62
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
@@ -5936,15 +7390,15 @@ entry:
 
 ; <label>:74                                      ; preds = %70
   %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
-  br i1 %NullCheck18, label %76, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %76
 
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
   %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
-  br i1 %NullCheck20, label %80, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
   %81 = load i64, i64 addrspace(1)* %79
@@ -5958,8 +7412,8 @@ entry:
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
   %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
-  br i1 %NullCheck22, label %92, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.String addrspace(1)* %90, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %92
 
 ; <label>:92                                      ; preds = %80
   %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
@@ -5969,15 +7423,15 @@ entry:
 
 ; <label>:96                                      ; preds = %70
   %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
-  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %98
 
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
   %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
-  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
   %103 = load i64, i64 addrspace(1)* %101
@@ -5991,8 +7445,8 @@ entry:
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
   %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
-  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.String addrspace(1)* %112, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %114
 
 ; <label>:114                                     ; preds = %102
   %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
@@ -6004,59 +7458,59 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %20
+ThrowNullRef4:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %22
+ThrowNullRef6:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %26
+ThrowNullRef8:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %62
+ThrowNullRef10:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %48
+ThrowNullRef16:                                   ; preds = %48
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %74
+ThrowNullRef18:                                   ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %76
+ThrowNullRef20:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %80
+ThrowNullRef22:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %96
+ThrowNullRef24:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %98
+ThrowNullRef26:                                   ; preds = %98
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %102
+ThrowNullRef28:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6069,15 +7523,15 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
   %3 = load i16*, i16* addrspace(1)* %2, align 8
   %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
@@ -6087,8 +7541,8 @@ entry:
   %10 = bitcast i16* %3 to i8*
   %11 = getelementptr inbounds i8, i8* %10, i64 %9
   %12 = bitcast i8* %11 to i16*
-  %NullCheck4 = icmp ne i16* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %5
   store i16 0, i16* %12, align 8
@@ -6098,11 +7552,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6119,8 +7573,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -6131,8 +7585,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
@@ -6144,15 +7598,15 @@ entry:
 
 ; <label>:14                                      ; preds = %1
   %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
   %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
   %21 = load i64, i64 addrspace(1)* %19
@@ -6171,15 +7625,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %14
+ThrowNullRef4:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %16
+ThrowNullRef6:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6302,14 +7756,6 @@ entry:
   ret %System.String addrspace(1)* %57
 }
 
-INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
-Successfully read RuntimeHelpers.get_OffsetToStringData
-
-define i32 @RuntimeHelpers.get_OffsetToStringData() {
-entry:
-  ret i32 12
-}
-
 INFO:  jitting method String::Equals using LLILCJit
 Successfully read String.Equals
 
@@ -6381,8 +7827,8 @@ entry:
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
-  br i1 %NullCheck24, label %29, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
   %30 = load i64, i64 addrspace(1)* %28
@@ -6397,8 +7843,8 @@ entry:
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
-  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
   %43 = load i64, i64 addrspace(1)* %41
@@ -6418,8 +7864,8 @@ entry:
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
   %59 = load i64, i64 addrspace(1)* %57
@@ -6434,8 +7880,8 @@ entry:
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck22, label %71, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
   %72 = load i64, i64 addrspace(1)* %70
@@ -6455,8 +7901,8 @@ entry:
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
-  br i1 %NullCheck16, label %87, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = load i64, i64 addrspace(1)* %86
@@ -6471,8 +7917,8 @@ entry:
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck18, label %100, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
   %101 = load i64, i64 addrspace(1)* %99
@@ -6492,8 +7938,8 @@ entry:
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
-  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
   %117 = load i64, i64 addrspace(1)* %115
@@ -6508,8 +7954,8 @@ entry:
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
-  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
   %130 = load i64, i64 addrspace(1)* %128
@@ -6528,15 +7974,15 @@ entry:
 
 ; <label>:142                                     ; preds = %22
   %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
-  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %143, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %144
 
 ; <label>:144                                     ; preds = %142
   %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
   %146 = load i32, i32 addrspace(1)* %145
   %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
-  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %147, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %148
 
 ; <label>:148                                     ; preds = %144
   %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
@@ -6557,15 +8003,15 @@ entry:
 
 ; <label>:159                                     ; preds = %22
   %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
-  br i1 %NullCheck, label %161, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %ThrowNullRef, label %161
 
 ; <label>:161                                     ; preds = %159
   %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
   %163 = load i32, i32 addrspace(1)* %162
   %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
-  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %164, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %165
 
 ; <label>:165                                     ; preds = %161
   %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
@@ -6578,8 +8024,8 @@ entry:
 
 ; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
-  br i1 %NullCheck4, label %172, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %171, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %172
 
 ; <label>:172                                     ; preds = %170
   %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
@@ -6589,8 +8035,8 @@ entry:
 
 ; <label>:176                                     ; preds = %172
   %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
-  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %177, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %178
 
 ; <label>:178                                     ; preds = %176
   %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
@@ -6629,55 +8075,55 @@ ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %161
+ThrowNullRef2:                                    ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %170
+ThrowNullRef4:                                    ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %176
+ThrowNullRef6:                                    ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %142
+ThrowNullRef8:                                    ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %144
+ThrowNullRef10:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %113
+ThrowNullRef12:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %116
+ThrowNullRef14:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %84
+ThrowNullRef16:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %87
+ThrowNullRef18:                                   ; preds = %87
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %55
+ThrowNullRef20:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %58
+ThrowNullRef22:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %26
+ThrowNullRef24:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %29
+ThrowNullRef26:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,8 +8161,8 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck, label %14, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %ThrowNullRef, label %14
 
 ; <label>:14                                      ; preds = %8
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
@@ -6760,8 +8206,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
@@ -6770,14 +8216,14 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32, i32* %loc0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %10
   %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
   %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
@@ -6790,15 +8236,15 @@ entry:
 ; <label>:25                                      ; preds = %19
   %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
-  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
   %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
@@ -6807,8 +8253,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %37 = load i32, i32* %loc0
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %38, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %38
 
 ; <label>:38                                      ; preds = %32
   %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
@@ -6817,14 +8263,14 @@ entry:
 
 ; <label>:40                                      ; preds = %19
   %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %40
   %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
   %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
-  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
-  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
@@ -6832,8 +8278,8 @@ entry:
   %48 = zext i32 %47 to i64
   %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
-  br i1 %NullCheck16, label %51, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %51
 
 ; <label>:51                                      ; preds = %45
   %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
@@ -6847,15 +8293,15 @@ entry:
 ; <label>:57                                      ; preds = %51
   %58 = load i16*, i16** %arg1
   %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
-  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %60
 
 ; <label>:60                                      ; preds = %57
   %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
   %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
-  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %64
 
 ; <label>:64                                      ; preds = %60
   %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
@@ -6864,22 +8310,22 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
   %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
-  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %70
 
 ; <label>:70                                      ; preds = %64
   %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
   %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
-  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
-  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
   %75 = load i32, i32 addrspace(1)* %74
   %76 = zext i32 %75 to i64
   %77 = trunc i64 %76 to i32
-  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
-  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %78
 
 ; <label>:78                                      ; preds = %73
   %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
@@ -6901,8 +8347,8 @@ entry:
   %90 = bitcast i16* %86 to i8*
   %91 = getelementptr inbounds i8, i8* %90, i64 %89
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %93
 
 ; <label>:93                                      ; preds = %80
   %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
@@ -6912,8 +8358,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %99 = load i32, i32* %loc2
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %100
 
 ; <label>:100                                     ; preds = %93
   %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
@@ -6928,63 +8374,63 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %25
+ThrowNullRef6:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %32
+ThrowNullRef10:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %40
+ThrowNullRef12:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %45
+ThrowNullRef16:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %57
+ThrowNullRef18:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %60
+ThrowNullRef20:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %64
+ThrowNullRef22:                                   ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %70
+ThrowNullRef24:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %73
+ThrowNullRef26:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %80
+ThrowNullRef28:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %93
+ThrowNullRef30:                                   ; preds = %93
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7004,8 +8450,8 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
@@ -7033,43 +8479,43 @@ entry:
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %14
   %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
   %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   %28 = load i32, i32 addrspace(1)* %27, align 8
   %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
-  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %30
 
 ; <label>:30                                      ; preds = %26
   %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
   %32 = load i32, i32 addrspace(1)* %31, align 8
   %33 = add i32 %28, %32
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %34
 
 ; <label>:34                                      ; preds = %30
   %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   store i32 %33, i32 addrspace(1)* %35
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
   store i32 0, i32 addrspace(1)* %38
   %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %40
 
 ; <label>:40                                      ; preds = %37
   %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
@@ -7082,8 +8528,8 @@ entry:
 
 ; <label>:47                                      ; preds = %40
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
@@ -7098,8 +8544,8 @@ entry:
   %54 = load i32, i32* %loc0
   %55 = sext i32 %54 to i64
   %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
-  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %57
 
 ; <label>:57                                      ; preds = %52
   %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
@@ -7110,68 +8556,35 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %14
+ThrowNullRef2:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %23
+ThrowNullRef4:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %26
+ThrowNullRef6:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %30
+ThrowNullRef8:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %34
+ThrowNullRef10:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %47
+ThrowNullRef14:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %52
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-}
-
-INFO:  jitting method StringBuilder::get_Length using LLILCJit
-Successfully read StringBuilder.get_Length
-
-define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.StringBuilder addrspace(1)*
-  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
-  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
-
-; <label>:1                                       ; preds = %entry
-  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %3 = load i32, i32 addrspace(1)* %2, align 8
-  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
-
-; <label>:5                                       ; preds = %1
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = add i32 %3, %7
-  ret i32 %8
-
-ThrowNullRef:                                     ; preds = %entry
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef16:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7213,70 +8626,70 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
   %6 = load i32, i32 addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
   store i32 %6, i32 addrspace(1)* %8
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
   %13 = load i32, i32 addrspace(1)* %12, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
   store i32 %13, i32 addrspace(1)* %15
   %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
-  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %18
 
 ; <label>:18                                      ; preds = %14
   %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
   %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
   %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
   %34 = load i32, i32 addrspace(1)* %33, align 8
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
-  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
@@ -7287,39 +8700,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %28
+ThrowNullRef16:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %32
+ThrowNullRef18:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7455,13 +8868,13 @@ entry:
 ; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
@@ -7477,16 +8890,16 @@ entry:
 
 ; <label>:18                                      ; preds = %15
   %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
   store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
   %22 = load i32, i32* %loc0
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %24
 
 ; <label>:24                                      ; preds = %20
   %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
@@ -7498,13 +8911,13 @@ entry:
 ; <label>:28                                      ; preds = %15, %24
   %29 = load i32, i32* %arg1
   %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %31
   %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
@@ -7517,20 +8930,20 @@ entry:
   %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
-  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
   %46 = load i32, i32 addrspace(1)* %45, align 8
   %47 = sub i32 %40, %46
-  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
-  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i32 addrspace(1)* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %48
 
 ; <label>:48                                      ; preds = %44
   store i32 %47, i32 addrspace(1)* %39, align 8
@@ -7538,21 +8951,21 @@ entry:
 
 ; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
-  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %51
 
 ; <label>:51                                      ; preds = %49
   %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %53
 
 ; <label>:53                                      ; preds = %51
   %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
   %55 = load i32, i32 addrspace(1)* %54, align 8
   %56 = load i32, i32* %arg2
   %57 = sub i32 %55, %56
-  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %58
 
 ; <label>:58                                      ; preds = %53
   %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
@@ -7562,13 +8975,13 @@ entry:
 ; <label>:60                                      ; preds = %33, %58
   %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
   %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
-  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %63
 
 ; <label>:63                                      ; preds = %60
   %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
-  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
-  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
@@ -7578,15 +8991,15 @@ entry:
 
 ; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
-  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i32 addrspace(1)* %69, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %70
 
 ; <label>:70                                      ; preds = %68
   %71 = load i32, i32 addrspace(1)* %69, align 8
   store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
-  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
@@ -7596,8 +9009,8 @@ entry:
   store i32 %77, i32* %loc4
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
-  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %80
 
 ; <label>:80                                      ; preds = %73
   %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
@@ -7607,71 +9020,71 @@ entry:
 ; <label>:83                                      ; preds = %80
   store i32 0, i32* %loc3
   %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
-  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
-  br i1 %NullCheck26, label %88, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i32 addrspace(1)* %87, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %88
 
 ; <label>:88                                      ; preds = %85
   %89 = load i32, i32 addrspace(1)* %87, align 8
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
-  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %90
 
 ; <label>:90                                      ; preds = %88
   %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
   store i32 %89, i32 addrspace(1)* %91
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
-  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
-  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %96
 
 ; <label>:96                                      ; preds = %94
   %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
-  br i1 %NullCheck34, label %100, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %100
 
 ; <label>:100                                     ; preds = %96
   %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
-  br i1 %NullCheck36, label %102, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %102
 
 ; <label>:102                                     ; preds = %100
   %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
   %104 = load i32, i32 addrspace(1)* %103, align 8
   %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
-  br i1 %NullCheck38, label %106, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %106
 
 ; <label>:106                                     ; preds = %102
   %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
-  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
-  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %108
 
 ; <label>:108                                     ; preds = %106
   %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
   %110 = load i32, i32 addrspace(1)* %109, align 8
   %111 = add i32 %104, %110
-  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %112
 
 ; <label>:112                                     ; preds = %108
   %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
   store i32 %111, i32 addrspace(1)* %113
   %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
-  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i32 addrspace(1)* %114, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %115
 
 ; <label>:115                                     ; preds = %112
   %116 = load i32, i32 addrspace(1)* %114, align 8
@@ -7681,19 +9094,19 @@ entry:
 ; <label>:118                                     ; preds = %115
   %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
-  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %121
 
 ; <label>:121                                     ; preds = %118
   %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
-  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
-  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %123
 
 ; <label>:123                                     ; preds = %121
   %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
   %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
-  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
-  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %126
 
 ; <label>:126                                     ; preds = %123
   %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
@@ -7705,8 +9118,8 @@ entry:
 
 ; <label>:130                                     ; preds = %80, %115, %126
   %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %132
 
 ; <label>:132                                     ; preds = %130
   %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7715,8 +9128,8 @@ entry:
   %136 = load i32, i32* %loc3
   %137 = sub i32 %135, %136
   %138 = sub i32 %134, %137
-  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %139
 
 ; <label>:139                                     ; preds = %132
   %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7728,16 +9141,16 @@ entry:
 
 ; <label>:144                                     ; preds = %139
   %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
-  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %146
 
 ; <label>:146                                     ; preds = %144
   %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
   %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
   %149 = load i32, i32* %loc2
   %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
-  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %151
 
 ; <label>:151                                     ; preds = %146
   %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
@@ -7754,145 +9167,249 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %18
+ThrowNullRef4:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %31
+ThrowNullRef10:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %44
+ThrowNullRef16:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %68
+ThrowNullRef18:                                   ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %70
+ThrowNullRef20:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %73
+ThrowNullRef22:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %83
+ThrowNullRef24:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %85
+ThrowNullRef26:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %88
+ThrowNullRef28:                                   ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %90
+ThrowNullRef30:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %94
+ThrowNullRef32:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %96
+ThrowNullRef34:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %100
+ThrowNullRef36:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %102
+ThrowNullRef38:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %106
+ThrowNullRef40:                                   ; preds = %106
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %108
+ThrowNullRef42:                                   ; preds = %108
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %112
+ThrowNullRef44:                                   ; preds = %112
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %118
+ThrowNullRef46:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %121
+ThrowNullRef48:                                   ; preds = %121
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %123
+ThrowNullRef50:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %130
+ThrowNullRef52:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %132
+ThrowNullRef54:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %144
+ThrowNullRef56:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %146
+ThrowNullRef58:                                   ; preds = %146
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %60
+ThrowNullRef60:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %63
+ThrowNullRef62:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %49
+ThrowNullRef64:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %51
+ThrowNullRef66:                                   ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %53
+ThrowNullRef68:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(%"System.Char[]" addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %arg0 = alloca %"System.Char[]" addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store %"System.Char[]" addrspace(1)* %param0, %"System.Char[]" addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load i32, i32* %arg4
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %43, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %38, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg1
+  %13 = load i32, i32* %arg4
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %38, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %24 = load i32, i32* %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %35 = load i32, i32* %arg3
+  %36 = load i32, i32* %arg4
+  %37 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %37, %"System.Char[]" addrspace(1)* %34, i32 %35, i32 %36)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:38                                      ; preds = %5, %16
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Successfully read Buffer._Memmove
 
@@ -7914,7 +9431,7 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[loadElem]
+Failed to read AppDomain.SetDataHelper[storeElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -7923,8 +9440,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
@@ -7934,8 +9451,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
@@ -7947,15 +9464,15 @@ entry:
   %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
   %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
@@ -7966,15 +9483,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7992,7 +9509,79 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
-Failed to read Dictionary`2.TryGetValue[loadElemA]
+Successfully read Dictionary`2.TryGetValue
+
+define i8 @"Dictionary`2.TryGetValue"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)* addrspace(1)* %param2) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  %arg2 = alloca %System.__Canon addrspace(1)* addrspace(1)*
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  store %System.__Canon addrspace(1)* addrspace(1)* %param2, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  store i32 %2, i32* %loc0
+  %3 = load i32, i32* %loc0
+  %4 = icmp slt i32 %3, 0
+  br i1 %4, label %22, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 2
+  %10 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %9, align 8
+  %11 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = zext i32 %11 to i64
+  %BoundsCheck = icmp uge i64 %16, %15
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 3, i32 %11
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %20, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %6, %System.__Canon addrspace(1)* %21)
+  ret i8 1
+
+; <label>:22                                      ; preds = %entry
+  %23 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %23, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -8058,8 +9647,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
@@ -8091,8 +9680,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
@@ -8171,15 +9760,15 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck, label %19, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %ThrowNullRef, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
   %21 = load i32, i32 addrspace(1)* %20
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
@@ -8202,7 +9791,7 @@ ThrowNullRef:                                     ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %19
+ThrowNullRef2:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8248,8 +9837,8 @@ entry:
   %0 = alloca %System.AppDomainHandle
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %1 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %1, i32 0, i32 15
@@ -8269,8 +9858,8 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
@@ -8286,7 +9875,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -8299,8 +9888,8 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -8327,8 +9916,8 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
@@ -8352,8 +9941,8 @@ entry:
   %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
   store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
@@ -8363,8 +9952,8 @@ entry:
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
@@ -8374,8 +9963,8 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %9
   %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
@@ -8384,8 +9973,8 @@ entry:
 
 ; <label>:18                                      ; preds = %3, %16
   %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
@@ -8397,15 +9986,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %18
+ThrowNullRef6:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8418,8 +10007,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
@@ -8453,15 +10042,15 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
@@ -8473,7 +10062,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8481,7 +10070,7 @@ ThrowNullRef1:                                    ; preds = %1
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
 Failed to read Dictionary`2.System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
@@ -8506,8 +10095,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
@@ -8524,8 +10113,8 @@ entry:
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -8544,7 +10133,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8577,8 +10166,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = load i64, i64* %arg2
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = trunc i32 %3 to i8
@@ -8634,46 +10223,46 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
   %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
-  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
-  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
-  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
@@ -8684,27 +10273,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %20
+ThrowNullRef12:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8717,8 +10306,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -8756,22 +10345,22 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
   %9 = load i64, i64 addrspace(1)* %8, align 8
   %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
   %13 = load i64, i64 addrspace(1)* %12, align 8
   %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %11
   %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
@@ -8788,11 +10377,11 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8882,8 +10471,8 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
@@ -8900,8 +10489,8 @@ entry:
 ; <label>:8                                       ; preds = %1
   %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
   %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
@@ -8911,15 +10500,15 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
   %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
   %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
-  br i1 %NullCheck6, label %21, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
@@ -8946,15 +10535,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8992,15 +10581,15 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
   store i8 %3, i8 addrspace(1)* %5
   %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
@@ -9011,7 +10600,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9027,8 +10616,8 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -9041,8 +10630,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
@@ -9058,7 +10647,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9080,8 +10669,8 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
@@ -9096,8 +10685,8 @@ entry:
 ; <label>:12                                      ; preds = %6
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
@@ -9112,8 +10701,8 @@ entry:
 ; <label>:21                                      ; preds = %15
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
@@ -9128,8 +10717,8 @@ entry:
 ; <label>:30                                      ; preds = %24
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %31, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
@@ -9144,8 +10733,8 @@ entry:
 ; <label>:39                                      ; preds = %33
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
-  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %40, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %42
 
 ; <label>:42                                      ; preds = %39
   %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
@@ -9164,19 +10753,19 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %21
+ThrowNullRef4:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %30
+ThrowNullRef6:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %39
+ThrowNullRef8:                                    ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9243,8 +10832,8 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
@@ -9264,57 +10853,57 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
   store i8 0, i8 addrspace(1)* %2
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
   store i8 0, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
   store i8 0, i8 addrspace(1)* %17
   %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
   store i8 0, i8 addrspace(1)* %20
   %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
-  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
@@ -9325,31 +10914,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %19
+ThrowNullRef14:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9367,8 +10956,8 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
@@ -9380,8 +10969,8 @@ entry:
 
 ; <label>:9                                       ; preds = %4
   %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %9
   %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
@@ -9395,7 +10984,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef2:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9420,8 +11009,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
@@ -9512,8 +11101,8 @@ entry:
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
@@ -9524,8 +11113,8 @@ entry:
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = load i64, i64 addrspace(1)* %12
@@ -9537,8 +11126,8 @@ entry:
   %20 = load i64, i64* %19
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
-  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %13
   %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
@@ -9555,8 +11144,8 @@ entry:
 ; <label>:30                                      ; preds = %25
   %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %32 = load i32, i32* %arg2
-  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
-  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
@@ -9570,15 +11159,15 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %30
+ThrowNullRef2:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9622,87 +11211,87 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
   %10 = load i8, i8 addrspace(1)* %9, align 8
   %11 = zext i8 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %8
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
   store i8 %12, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
   %19 = load i8, i8 addrspace(1)* %18, align 8
   %20 = zext i8 %19 to i32
   %21 = trunc i32 %20 to i8
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
   store i8 %21, i8 addrspace(1)* %23
   %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
   %28 = load i8, i8 addrspace(1)* %27, align 8
   %29 = zext i8 %28 to i32
   %30 = trunc i32 %29 to i8
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
-  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %31
 
 ; <label>:31                                      ; preds = %26
   %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
   store i8 %30, i8 addrspace(1)* %32
   %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
-  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
-  br i1 %NullCheck14, label %40, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %40
 
 ; <label>:40                                      ; preds = %35
   %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
   store i8 %39, i8 addrspace(1)* %41
   %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
-  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %44
 
 ; <label>:44                                      ; preds = %40
   %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
   %46 = load i8, i8 addrspace(1)* %45, align 8
   %47 = zext i8 %46 to i32
   %48 = trunc i32 %47 to i8
-  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
   store i8 %48, i8 addrspace(1)* %50
   %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
-  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
@@ -9713,29 +11302,29 @@ entry:
 ; <label>:56                                      ; preds = %52
   %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
-  br i1 %NullCheck22, label %59, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
   %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
   %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
-  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
-  br i1 %NullCheck24, label %63, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
   %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
-  br i1 %NullCheck26, label %66, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
   %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
-  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
-  br i1 %NullCheck28, label %69, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %69
 
 ; <label>:69                                      ; preds = %66
   %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
@@ -9744,15 +11333,15 @@ entry:
 
 ; <label>:71                                      ; preds = %105
   %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
-  br i1 %NullCheck34, label %73, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %73
 
 ; <label>:73                                      ; preds = %71
   %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
   %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
   %76 = load i32, i32* %loc0
-  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
-  br i1 %NullCheck36, label %77, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
@@ -9766,8 +11355,8 @@ entry:
 
 ; <label>:83                                      ; preds = %77
   %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
-  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
@@ -9775,14 +11364,14 @@ entry:
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
   %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
-  br i1 %NullCheck40, label %91, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
 ; <label>:91                                      ; preds = %85
   %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
   %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
-  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck42, label %94, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %94
 
 ; <label>:94                                      ; preds = %91
   %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
@@ -9798,14 +11387,14 @@ entry:
 ; <label>:99                                      ; preds = %69, %96
   %100 = load i32, i32* %loc0
   %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
-  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %102
 
 ; <label>:102                                     ; preds = %99
   %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
   %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
-  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
-  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
@@ -9819,87 +11408,87 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %26
+ThrowNullRef10:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %31
+ThrowNullRef12:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %35
+ThrowNullRef14:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %40
+ThrowNullRef16:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %56
+ThrowNullRef22:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %59
+ThrowNullRef24:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %63
+ThrowNullRef26:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %66
+ThrowNullRef28:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %102
+ThrowNullRef32:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %71
+ThrowNullRef34:                                   ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %73
+ThrowNullRef36:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %83
+ThrowNullRef38:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %85
+ThrowNullRef40:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %91
+ThrowNullRef42:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9943,15 +11532,15 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
   %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
@@ -9961,28 +11550,28 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
   %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %12
   %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
   %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
   %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
-  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
@@ -9993,23 +11582,23 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %12
+ThrowNullRef6:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10031,15 +11620,15 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
   %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = load i64, i64 addrspace(1)* %7
@@ -10077,13 +11666,13 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[loadElem]
+Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -10111,8 +11700,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Ind1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Ind1.error.txt
@@ -25,8 +25,8 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
@@ -40,8 +40,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
   %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
@@ -75,7 +75,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -90,8 +90,8 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %NullCheck = icmp ne i8 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = load i8, i8 addrspace(1)* %0, align 8
@@ -125,8 +125,8 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
@@ -159,8 +159,8 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -184,8 +184,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
   store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
@@ -195,8 +195,8 @@ entry:
 ; <label>:4                                       ; preds = %1
   %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
   %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
@@ -206,8 +206,8 @@ entry:
   %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
@@ -221,14 +221,14 @@ entry:
 
 ; <label>:17                                      ; preds = %14
   %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
   %21 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
@@ -238,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -249,8 +249,8 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
@@ -261,27 +261,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %30
+ThrowNullRef10:                                   ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -301,7 +301,89 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
-Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
+Successfully read AppDomainSetup.GetUnsecureApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.GetUnsecureApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %NullCheck = icmp eq %"System.String[]" addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %BoundsCheck = icmp uge i64 0, %5
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %6
+
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 3, i32 0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
+  ret %System.String addrspace(1)* %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_Value using LLILCJit
+Successfully read AppDomainSetup.get_Value
+
+define %"System.String[]" addrspace(1)* @AppDomainSetup.get_Value(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.String[]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 18)
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.String[]" addrspace(1)* addrspace(1)*, %"System.String[]" addrspace(1)*)*)(%"System.String[]" addrspace(1)* addrspace(1)* %9, %"System.String[]" addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %11, i32 0, i32 1
+  %14 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %13, align 8
+  ret %"System.String[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -319,8 +401,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -368,16 +450,16 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
   %5 = load i32, i32 addrspace(1)* %4
   %6 = sub i32 %5, 1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -389,7 +471,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -421,8 +503,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
@@ -456,8 +538,8 @@ entry:
 ; <label>:27                                      ; preds = %19
   %28 = load i32, i32* %arg1
   %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
-  br i1 %NullCheck2, label %30, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %29, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %30
 
 ; <label>:30                                      ; preds = %27
   %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
@@ -493,8 +575,8 @@ entry:
 ; <label>:49                                      ; preds = %46
   %50 = load i32, i32* %arg2
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck4, label %52, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
@@ -517,11 +599,11 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %27
+ThrowNullRef2:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %49
+ThrowNullRef4:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -544,16 +626,16 @@ entry:
   %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %0)
   store %System.String addrspace(1)* %1, %System.String addrspace(1)** %loc0
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 2
   %5 = bitcast [0 x i16] addrspace(1)* %4 to i16 addrspace(1)*
   store i16 addrspace(1)* %5, i16 addrspace(1)** %loc1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %3
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2
@@ -580,7 +662,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -691,15 +773,15 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %NullCheck132 = icmp ne i8* %21, null
-  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+  %NullCheck131 = icmp eq i8* %21, null
+  br i1 %NullCheck131, label %ThrowNullRef132, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = load i8, i8* %21, align 8
   %24 = zext i8 %23 to i32
   %25 = trunc i32 %24 to i8
-  %NullCheck134 = icmp ne i8* %20, null
-  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+  %NullCheck133 = icmp eq i8* %20, null
+  br i1 %NullCheck133, label %ThrowNullRef134, label %26
 
 ; <label>:26                                      ; preds = %22
   store i8 %25, i8* %20, align 8
@@ -709,16 +791,16 @@ entry:
   %28 = load i8*, i8** %arg0
   %29 = load i8*, i8** %arg1
   %30 = bitcast i8* %29 to i16*
-  %NullCheck128 = icmp ne i16* %30, null
-  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+  %NullCheck127 = icmp eq i16* %30, null
+  br i1 %NullCheck127, label %ThrowNullRef128, label %31
 
 ; <label>:31                                      ; preds = %27
   %32 = load i16, i16* %30, align 8
   %33 = sext i16 %32 to i32
   %34 = bitcast i8* %28 to i16*
   %35 = trunc i32 %33 to i16
-  %NullCheck130 = icmp ne i16* %34, null
-  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+  %NullCheck129 = icmp eq i16* %34, null
+  br i1 %NullCheck129, label %ThrowNullRef130, label %36
 
 ; <label>:36                                      ; preds = %31
   store i16 %35, i16* %34, align 8
@@ -728,16 +810,16 @@ entry:
   %38 = load i8*, i8** %arg0
   %39 = load i8*, i8** %arg1
   %40 = bitcast i8* %39 to i16*
-  %NullCheck120 = icmp ne i16* %40, null
-  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+  %NullCheck119 = icmp eq i16* %40, null
+  br i1 %NullCheck119, label %ThrowNullRef120, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i16, i16* %40, align 8
   %43 = sext i16 %42 to i32
   %44 = bitcast i8* %38 to i16*
   %45 = trunc i32 %43 to i16
-  %NullCheck122 = icmp ne i16* %44, null
-  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+  %NullCheck121 = icmp eq i16* %44, null
+  br i1 %NullCheck121, label %ThrowNullRef122, label %46
 
 ; <label>:46                                      ; preds = %41
   store i16 %45, i16* %44, align 8
@@ -745,15 +827,15 @@ entry:
   %48 = getelementptr inbounds i8, i8* %47, i64 2
   %49 = load i8*, i8** %arg1
   %50 = getelementptr inbounds i8, i8* %49, i64 2
-  %NullCheck124 = icmp ne i8* %50, null
-  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+  %NullCheck123 = icmp eq i8* %50, null
+  br i1 %NullCheck123, label %ThrowNullRef124, label %51
 
 ; <label>:51                                      ; preds = %46
   %52 = load i8, i8* %50, align 8
   %53 = zext i8 %52 to i32
   %54 = trunc i32 %53 to i8
-  %NullCheck126 = icmp ne i8* %48, null
-  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+  %NullCheck125 = icmp eq i8* %48, null
+  br i1 %NullCheck125, label %ThrowNullRef126, label %55
 
 ; <label>:55                                      ; preds = %51
   store i8 %54, i8* %48, align 8
@@ -763,14 +845,14 @@ entry:
   %57 = load i8*, i8** %arg0
   %58 = load i8*, i8** %arg1
   %59 = bitcast i8* %58 to i32*
-  %NullCheck116 = icmp ne i32* %59, null
-  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+  %NullCheck115 = icmp eq i32* %59, null
+  br i1 %NullCheck115, label %ThrowNullRef116, label %60
 
 ; <label>:60                                      ; preds = %56
   %61 = load i32, i32* %59, align 8
   %62 = bitcast i8* %57 to i32*
-  %NullCheck118 = icmp ne i32* %62, null
-  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+  %NullCheck117 = icmp eq i32* %62, null
+  br i1 %NullCheck117, label %ThrowNullRef118, label %63
 
 ; <label>:63                                      ; preds = %60
   store i32 %61, i32* %62, align 8
@@ -780,14 +862,14 @@ entry:
   %65 = load i8*, i8** %arg0
   %66 = load i8*, i8** %arg1
   %67 = bitcast i8* %66 to i32*
-  %NullCheck108 = icmp ne i32* %67, null
-  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+  %NullCheck107 = icmp eq i32* %67, null
+  br i1 %NullCheck107, label %ThrowNullRef108, label %68
 
 ; <label>:68                                      ; preds = %64
   %69 = load i32, i32* %67, align 8
   %70 = bitcast i8* %65 to i32*
-  %NullCheck110 = icmp ne i32* %70, null
-  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+  %NullCheck109 = icmp eq i32* %70, null
+  br i1 %NullCheck109, label %ThrowNullRef110, label %71
 
 ; <label>:71                                      ; preds = %68
   store i32 %69, i32* %70, align 8
@@ -795,15 +877,15 @@ entry:
   %73 = getelementptr inbounds i8, i8* %72, i64 4
   %74 = load i8*, i8** %arg1
   %75 = getelementptr inbounds i8, i8* %74, i64 4
-  %NullCheck112 = icmp ne i8* %75, null
-  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+  %NullCheck111 = icmp eq i8* %75, null
+  br i1 %NullCheck111, label %ThrowNullRef112, label %76
 
 ; <label>:76                                      ; preds = %71
   %77 = load i8, i8* %75, align 8
   %78 = zext i8 %77 to i32
   %79 = trunc i32 %78 to i8
-  %NullCheck114 = icmp ne i8* %73, null
-  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+  %NullCheck113 = icmp eq i8* %73, null
+  br i1 %NullCheck113, label %ThrowNullRef114, label %80
 
 ; <label>:80                                      ; preds = %76
   store i8 %79, i8* %73, align 8
@@ -813,14 +895,14 @@ entry:
   %82 = load i8*, i8** %arg0
   %83 = load i8*, i8** %arg1
   %84 = bitcast i8* %83 to i32*
-  %NullCheck100 = icmp ne i32* %84, null
-  br i1 %NullCheck100, label %85, label %ThrowNullRef99
+  %NullCheck99 = icmp eq i32* %84, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %85
 
 ; <label>:85                                      ; preds = %81
   %86 = load i32, i32* %84, align 8
   %87 = bitcast i8* %82 to i32*
-  %NullCheck102 = icmp ne i32* %87, null
-  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+  %NullCheck101 = icmp eq i32* %87, null
+  br i1 %NullCheck101, label %ThrowNullRef102, label %88
 
 ; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
@@ -829,16 +911,16 @@ entry:
   %91 = load i8*, i8** %arg1
   %92 = getelementptr inbounds i8, i8* %91, i64 4
   %93 = bitcast i8* %92 to i16*
-  %NullCheck104 = icmp ne i16* %93, null
-  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+  %NullCheck103 = icmp eq i16* %93, null
+  br i1 %NullCheck103, label %ThrowNullRef104, label %94
 
 ; <label>:94                                      ; preds = %88
   %95 = load i16, i16* %93, align 8
   %96 = sext i16 %95 to i32
   %97 = bitcast i8* %90 to i16*
   %98 = trunc i32 %96 to i16
-  %NullCheck106 = icmp ne i16* %97, null
-  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+  %NullCheck105 = icmp eq i16* %97, null
+  br i1 %NullCheck105, label %ThrowNullRef106, label %99
 
 ; <label>:99                                      ; preds = %94
   store i16 %98, i16* %97, align 8
@@ -848,14 +930,14 @@ entry:
   %101 = load i8*, i8** %arg0
   %102 = load i8*, i8** %arg1
   %103 = bitcast i8* %102 to i32*
-  %NullCheck88 = icmp ne i32* %103, null
-  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+  %NullCheck87 = icmp eq i32* %103, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %104
 
 ; <label>:104                                     ; preds = %100
   %105 = load i32, i32* %103, align 8
   %106 = bitcast i8* %101 to i32*
-  %NullCheck90 = icmp ne i32* %106, null
-  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+  %NullCheck89 = icmp eq i32* %106, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %107
 
 ; <label>:107                                     ; preds = %104
   store i32 %105, i32* %106, align 8
@@ -864,16 +946,16 @@ entry:
   %110 = load i8*, i8** %arg1
   %111 = getelementptr inbounds i8, i8* %110, i64 4
   %112 = bitcast i8* %111 to i16*
-  %NullCheck92 = icmp ne i16* %112, null
-  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+  %NullCheck91 = icmp eq i16* %112, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %113
 
 ; <label>:113                                     ; preds = %107
   %114 = load i16, i16* %112, align 8
   %115 = sext i16 %114 to i32
   %116 = bitcast i8* %109 to i16*
   %117 = trunc i32 %115 to i16
-  %NullCheck94 = icmp ne i16* %116, null
-  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+  %NullCheck93 = icmp eq i16* %116, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %118
 
 ; <label>:118                                     ; preds = %113
   store i16 %117, i16* %116, align 8
@@ -881,15 +963,15 @@ entry:
   %120 = getelementptr inbounds i8, i8* %119, i64 6
   %121 = load i8*, i8** %arg1
   %122 = getelementptr inbounds i8, i8* %121, i64 6
-  %NullCheck96 = icmp ne i8* %122, null
-  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+  %NullCheck95 = icmp eq i8* %122, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %123
 
 ; <label>:123                                     ; preds = %118
   %124 = load i8, i8* %122, align 8
   %125 = zext i8 %124 to i32
   %126 = trunc i32 %125 to i8
-  %NullCheck98 = icmp ne i8* %120, null
-  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+  %NullCheck97 = icmp eq i8* %120, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %127
 
 ; <label>:127                                     ; preds = %123
   store i8 %126, i8* %120, align 8
@@ -899,14 +981,14 @@ entry:
   %129 = load i8*, i8** %arg0
   %130 = load i8*, i8** %arg1
   %131 = bitcast i8* %130 to i64*
-  %NullCheck84 = icmp ne i64* %131, null
-  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+  %NullCheck83 = icmp eq i64* %131, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %132
 
 ; <label>:132                                     ; preds = %128
   %133 = load i64, i64* %131, align 8
   %134 = bitcast i8* %129 to i64*
-  %NullCheck86 = icmp ne i64* %134, null
-  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+  %NullCheck85 = icmp eq i64* %134, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %135
 
 ; <label>:135                                     ; preds = %132
   store i64 %133, i64* %134, align 8
@@ -916,14 +998,14 @@ entry:
   %137 = load i8*, i8** %arg0
   %138 = load i8*, i8** %arg1
   %139 = bitcast i8* %138 to i64*
-  %NullCheck76 = icmp ne i64* %139, null
-  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+  %NullCheck75 = icmp eq i64* %139, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %140
 
 ; <label>:140                                     ; preds = %136
   %141 = load i64, i64* %139, align 8
   %142 = bitcast i8* %137 to i64*
-  %NullCheck78 = icmp ne i64* %142, null
-  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+  %NullCheck77 = icmp eq i64* %142, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %143
 
 ; <label>:143                                     ; preds = %140
   store i64 %141, i64* %142, align 8
@@ -931,15 +1013,15 @@ entry:
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %NullCheck80 = icmp ne i8* %147, null
-  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+  %NullCheck79 = icmp eq i8* %147, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %148
 
 ; <label>:148                                     ; preds = %143
   %149 = load i8, i8* %147, align 8
   %150 = zext i8 %149 to i32
   %151 = trunc i32 %150 to i8
-  %NullCheck82 = icmp ne i8* %145, null
-  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+  %NullCheck81 = icmp eq i8* %145, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %152
 
 ; <label>:152                                     ; preds = %148
   store i8 %151, i8* %145, align 8
@@ -949,14 +1031,14 @@ entry:
   %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
   %156 = bitcast i8* %155 to i64*
-  %NullCheck68 = icmp ne i64* %156, null
-  br i1 %NullCheck68, label %157, label %ThrowNullRef67
+  %NullCheck67 = icmp eq i64* %156, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %157
 
 ; <label>:157                                     ; preds = %153
   %158 = load i64, i64* %156, align 8
   %159 = bitcast i8* %154 to i64*
-  %NullCheck70 = icmp ne i64* %159, null
-  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+  %NullCheck69 = icmp eq i64* %159, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %160
 
 ; <label>:160                                     ; preds = %157
   store i64 %158, i64* %159, align 8
@@ -965,16 +1047,16 @@ entry:
   %163 = load i8*, i8** %arg1
   %164 = getelementptr inbounds i8, i8* %163, i64 8
   %165 = bitcast i8* %164 to i16*
-  %NullCheck72 = icmp ne i16* %165, null
-  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+  %NullCheck71 = icmp eq i16* %165, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %166
 
 ; <label>:166                                     ; preds = %160
   %167 = load i16, i16* %165, align 8
   %168 = sext i16 %167 to i32
   %169 = bitcast i8* %162 to i16*
   %170 = trunc i32 %168 to i16
-  %NullCheck74 = icmp ne i16* %169, null
-  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+  %NullCheck73 = icmp eq i16* %169, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %171
 
 ; <label>:171                                     ; preds = %166
   store i16 %170, i16* %169, align 8
@@ -984,14 +1066,14 @@ entry:
   %173 = load i8*, i8** %arg0
   %174 = load i8*, i8** %arg1
   %175 = bitcast i8* %174 to i64*
-  %NullCheck56 = icmp ne i64* %175, null
-  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+  %NullCheck55 = icmp eq i64* %175, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %176
 
 ; <label>:176                                     ; preds = %172
   %177 = load i64, i64* %175, align 8
   %178 = bitcast i8* %173 to i64*
-  %NullCheck58 = icmp ne i64* %178, null
-  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+  %NullCheck57 = icmp eq i64* %178, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %179
 
 ; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
@@ -1000,16 +1082,16 @@ entry:
   %182 = load i8*, i8** %arg1
   %183 = getelementptr inbounds i8, i8* %182, i64 8
   %184 = bitcast i8* %183 to i16*
-  %NullCheck60 = icmp ne i16* %184, null
-  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+  %NullCheck59 = icmp eq i16* %184, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %185
 
 ; <label>:185                                     ; preds = %179
   %186 = load i16, i16* %184, align 8
   %187 = sext i16 %186 to i32
   %188 = bitcast i8* %181 to i16*
   %189 = trunc i32 %187 to i16
-  %NullCheck62 = icmp ne i16* %188, null
-  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+  %NullCheck61 = icmp eq i16* %188, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %190
 
 ; <label>:190                                     ; preds = %185
   store i16 %189, i16* %188, align 8
@@ -1017,15 +1099,15 @@ entry:
   %192 = getelementptr inbounds i8, i8* %191, i64 10
   %193 = load i8*, i8** %arg1
   %194 = getelementptr inbounds i8, i8* %193, i64 10
-  %NullCheck64 = icmp ne i8* %194, null
-  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+  %NullCheck63 = icmp eq i8* %194, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %195
 
 ; <label>:195                                     ; preds = %190
   %196 = load i8, i8* %194, align 8
   %197 = zext i8 %196 to i32
   %198 = trunc i32 %197 to i8
-  %NullCheck66 = icmp ne i8* %192, null
-  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+  %NullCheck65 = icmp eq i8* %192, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %199
 
 ; <label>:199                                     ; preds = %195
   store i8 %198, i8* %192, align 8
@@ -1035,14 +1117,14 @@ entry:
   %201 = load i8*, i8** %arg0
   %202 = load i8*, i8** %arg1
   %203 = bitcast i8* %202 to i64*
-  %NullCheck48 = icmp ne i64* %203, null
-  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+  %NullCheck47 = icmp eq i64* %203, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %204
 
 ; <label>:204                                     ; preds = %200
   %205 = load i64, i64* %203, align 8
   %206 = bitcast i8* %201 to i64*
-  %NullCheck50 = icmp ne i64* %206, null
-  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+  %NullCheck49 = icmp eq i64* %206, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %207
 
 ; <label>:207                                     ; preds = %204
   store i64 %205, i64* %206, align 8
@@ -1051,14 +1133,14 @@ entry:
   %210 = load i8*, i8** %arg1
   %211 = getelementptr inbounds i8, i8* %210, i64 8
   %212 = bitcast i8* %211 to i32*
-  %NullCheck52 = icmp ne i32* %212, null
-  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+  %NullCheck51 = icmp eq i32* %212, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %213
 
 ; <label>:213                                     ; preds = %207
   %214 = load i32, i32* %212, align 8
   %215 = bitcast i8* %209 to i32*
-  %NullCheck54 = icmp ne i32* %215, null
-  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+  %NullCheck53 = icmp eq i32* %215, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %216
 
 ; <label>:216                                     ; preds = %213
   store i32 %214, i32* %215, align 8
@@ -1068,14 +1150,14 @@ entry:
   %218 = load i8*, i8** %arg0
   %219 = load i8*, i8** %arg1
   %220 = bitcast i8* %219 to i64*
-  %NullCheck36 = icmp ne i64* %220, null
-  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64* %220, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %221
 
 ; <label>:221                                     ; preds = %217
   %222 = load i64, i64* %220, align 8
   %223 = bitcast i8* %218 to i64*
-  %NullCheck38 = icmp ne i64* %223, null
-  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+  %NullCheck37 = icmp eq i64* %223, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %224
 
 ; <label>:224                                     ; preds = %221
   store i64 %222, i64* %223, align 8
@@ -1084,14 +1166,14 @@ entry:
   %227 = load i8*, i8** %arg1
   %228 = getelementptr inbounds i8, i8* %227, i64 8
   %229 = bitcast i8* %228 to i32*
-  %NullCheck40 = icmp ne i32* %229, null
-  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i32* %229, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %230
 
 ; <label>:230                                     ; preds = %224
   %231 = load i32, i32* %229, align 8
   %232 = bitcast i8* %226 to i32*
-  %NullCheck42 = icmp ne i32* %232, null
-  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+  %NullCheck41 = icmp eq i32* %232, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %233
 
 ; <label>:233                                     ; preds = %230
   store i32 %231, i32* %232, align 8
@@ -1099,15 +1181,15 @@ entry:
   %235 = getelementptr inbounds i8, i8* %234, i64 12
   %236 = load i8*, i8** %arg1
   %237 = getelementptr inbounds i8, i8* %236, i64 12
-  %NullCheck44 = icmp ne i8* %237, null
-  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i8* %237, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %238
 
 ; <label>:238                                     ; preds = %233
   %239 = load i8, i8* %237, align 8
   %240 = zext i8 %239 to i32
   %241 = trunc i32 %240 to i8
-  %NullCheck46 = icmp ne i8* %235, null
-  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+  %NullCheck45 = icmp eq i8* %235, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %242
 
 ; <label>:242                                     ; preds = %238
   store i8 %241, i8* %235, align 8
@@ -1117,14 +1199,14 @@ entry:
   %244 = load i8*, i8** %arg0
   %245 = load i8*, i8** %arg1
   %246 = bitcast i8* %245 to i64*
-  %NullCheck24 = icmp ne i64* %246, null
-  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64* %246, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %247
 
 ; <label>:247                                     ; preds = %243
   %248 = load i64, i64* %246, align 8
   %249 = bitcast i8* %244 to i64*
-  %NullCheck26 = icmp ne i64* %249, null
-  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64* %249, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %250
 
 ; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
@@ -1133,14 +1215,14 @@ entry:
   %253 = load i8*, i8** %arg1
   %254 = getelementptr inbounds i8, i8* %253, i64 8
   %255 = bitcast i8* %254 to i32*
-  %NullCheck28 = icmp ne i32* %255, null
-  br i1 %NullCheck28, label %256, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i32* %255, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %256
 
 ; <label>:256                                     ; preds = %250
   %257 = load i32, i32* %255, align 8
   %258 = bitcast i8* %252 to i32*
-  %NullCheck30 = icmp ne i32* %258, null
-  br i1 %NullCheck30, label %259, label %ThrowNullRef29
+  %NullCheck29 = icmp eq i32* %258, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %259
 
 ; <label>:259                                     ; preds = %256
   store i32 %257, i32* %258, align 8
@@ -1149,16 +1231,16 @@ entry:
   %262 = load i8*, i8** %arg1
   %263 = getelementptr inbounds i8, i8* %262, i64 12
   %264 = bitcast i8* %263 to i16*
-  %NullCheck32 = icmp ne i16* %264, null
-  br i1 %NullCheck32, label %265, label %ThrowNullRef31
+  %NullCheck31 = icmp eq i16* %264, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %265
 
 ; <label>:265                                     ; preds = %259
   %266 = load i16, i16* %264, align 8
   %267 = sext i16 %266 to i32
   %268 = bitcast i8* %261 to i16*
   %269 = trunc i32 %267 to i16
-  %NullCheck34 = icmp ne i16* %268, null
-  br i1 %NullCheck34, label %270, label %ThrowNullRef33
+  %NullCheck33 = icmp eq i16* %268, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %270
 
 ; <label>:270                                     ; preds = %265
   store i16 %269, i16* %268, align 8
@@ -1168,14 +1250,14 @@ entry:
   %272 = load i8*, i8** %arg0
   %273 = load i8*, i8** %arg1
   %274 = bitcast i8* %273 to i64*
-  %NullCheck8 = icmp ne i64* %274, null
-  br i1 %NullCheck8, label %275, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64* %274, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %275
 
 ; <label>:275                                     ; preds = %271
   %276 = load i64, i64* %274, align 8
   %277 = bitcast i8* %272 to i64*
-  %NullCheck10 = icmp ne i64* %277, null
-  br i1 %NullCheck10, label %278, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %277, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %278
 
 ; <label>:278                                     ; preds = %275
   store i64 %276, i64* %277, align 8
@@ -1184,14 +1266,14 @@ entry:
   %281 = load i8*, i8** %arg1
   %282 = getelementptr inbounds i8, i8* %281, i64 8
   %283 = bitcast i8* %282 to i32*
-  %NullCheck12 = icmp ne i32* %283, null
-  br i1 %NullCheck12, label %284, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i32* %283, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %284
 
 ; <label>:284                                     ; preds = %278
   %285 = load i32, i32* %283, align 8
   %286 = bitcast i8* %280 to i32*
-  %NullCheck14 = icmp ne i32* %286, null
-  br i1 %NullCheck14, label %287, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i32* %286, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %287
 
 ; <label>:287                                     ; preds = %284
   store i32 %285, i32* %286, align 8
@@ -1200,16 +1282,16 @@ entry:
   %290 = load i8*, i8** %arg1
   %291 = getelementptr inbounds i8, i8* %290, i64 12
   %292 = bitcast i8* %291 to i16*
-  %NullCheck16 = icmp ne i16* %292, null
-  br i1 %NullCheck16, label %293, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i16* %292, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %293
 
 ; <label>:293                                     ; preds = %287
   %294 = load i16, i16* %292, align 8
   %295 = sext i16 %294 to i32
   %296 = bitcast i8* %289 to i16*
   %297 = trunc i32 %295 to i16
-  %NullCheck18 = icmp ne i16* %296, null
-  br i1 %NullCheck18, label %298, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i16* %296, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %298
 
 ; <label>:298                                     ; preds = %293
   store i16 %297, i16* %296, align 8
@@ -1217,15 +1299,15 @@ entry:
   %300 = getelementptr inbounds i8, i8* %299, i64 14
   %301 = load i8*, i8** %arg1
   %302 = getelementptr inbounds i8, i8* %301, i64 14
-  %NullCheck20 = icmp ne i8* %302, null
-  br i1 %NullCheck20, label %303, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i8* %302, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %303
 
 ; <label>:303                                     ; preds = %298
   %304 = load i8, i8* %302, align 8
   %305 = zext i8 %304 to i32
   %306 = trunc i32 %305 to i8
-  %NullCheck22 = icmp ne i8* %300, null
-  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i8* %300, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %307
 
 ; <label>:307                                     ; preds = %303
   store i8 %306, i8* %300, align 8
@@ -1235,14 +1317,14 @@ entry:
   %309 = load i8*, i8** %arg0
   %310 = load i8*, i8** %arg1
   %311 = bitcast i8* %310 to i64*
-  %NullCheck = icmp ne i64* %311, null
-  br i1 %NullCheck, label %312, label %ThrowNullRef
+  %NullCheck = icmp eq i64* %311, null
+  br i1 %NullCheck, label %ThrowNullRef, label %312
 
 ; <label>:312                                     ; preds = %308
   %313 = load i64, i64* %311, align 8
   %314 = bitcast i8* %309 to i64*
-  %NullCheck2 = icmp ne i64* %314, null
-  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64* %314, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %315
 
 ; <label>:315                                     ; preds = %312
   store i64 %313, i64* %314, align 8
@@ -1251,14 +1333,14 @@ entry:
   %318 = load i8*, i8** %arg1
   %319 = getelementptr inbounds i8, i8* %318, i64 8
   %320 = bitcast i8* %319 to i64*
-  %NullCheck4 = icmp ne i64* %320, null
-  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64* %320, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %321
 
 ; <label>:321                                     ; preds = %315
   %322 = load i64, i64* %320, align 8
   %323 = bitcast i8* %317 to i64*
-  %NullCheck6 = icmp ne i64* %323, null
-  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64* %323, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %324
 
 ; <label>:324                                     ; preds = %321
   store i64 %322, i64* %323, align 8
@@ -1286,15 +1368,15 @@ entry:
 ; <label>:338                                     ; preds = %333
   %339 = load i8*, i8** %arg0
   %340 = load i8*, i8** %arg1
-  %NullCheck136 = icmp ne i8* %340, null
-  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+  %NullCheck135 = icmp eq i8* %340, null
+  br i1 %NullCheck135, label %ThrowNullRef136, label %341
 
 ; <label>:341                                     ; preds = %338
   %342 = load i8, i8* %340, align 8
   %343 = zext i8 %342 to i32
   %344 = trunc i32 %343 to i8
-  %NullCheck138 = icmp ne i8* %339, null
-  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+  %NullCheck137 = icmp eq i8* %339, null
+  br i1 %NullCheck137, label %ThrowNullRef138, label %345
 
 ; <label>:345                                     ; preds = %341
   store i8 %344, i8* %339, align 8
@@ -1317,16 +1399,16 @@ entry:
   %357 = load i8*, i8** %arg0
   %358 = load i8*, i8** %arg1
   %359 = bitcast i8* %358 to i16*
-  %NullCheck140 = icmp ne i16* %359, null
-  br i1 %NullCheck140, label %360, label %ThrowNullRef139
+  %NullCheck139 = icmp eq i16* %359, null
+  br i1 %NullCheck139, label %ThrowNullRef140, label %360
 
 ; <label>:360                                     ; preds = %356
   %361 = load i16, i16* %359, align 8
   %362 = sext i16 %361 to i32
   %363 = bitcast i8* %357 to i16*
   %364 = trunc i32 %362 to i16
-  %NullCheck142 = icmp ne i16* %363, null
-  br i1 %NullCheck142, label %365, label %ThrowNullRef141
+  %NullCheck141 = icmp eq i16* %363, null
+  br i1 %NullCheck141, label %ThrowNullRef142, label %365
 
 ; <label>:365                                     ; preds = %360
   store i16 %364, i16* %363, align 8
@@ -1352,14 +1434,14 @@ entry:
   %378 = load i8*, i8** %arg0
   %379 = load i8*, i8** %arg1
   %380 = bitcast i8* %379 to i32*
-  %NullCheck144 = icmp ne i32* %380, null
-  br i1 %NullCheck144, label %381, label %ThrowNullRef143
+  %NullCheck143 = icmp eq i32* %380, null
+  br i1 %NullCheck143, label %ThrowNullRef144, label %381
 
 ; <label>:381                                     ; preds = %377
   %382 = load i32, i32* %380, align 8
   %383 = bitcast i8* %378 to i32*
-  %NullCheck146 = icmp ne i32* %383, null
-  br i1 %NullCheck146, label %384, label %ThrowNullRef145
+  %NullCheck145 = icmp eq i32* %383, null
+  br i1 %NullCheck145, label %ThrowNullRef146, label %384
 
 ; <label>:384                                     ; preds = %381
   store i32 %382, i32* %383, align 8
@@ -1384,14 +1466,14 @@ entry:
   %395 = load i8*, i8** %arg0
   %396 = load i8*, i8** %arg1
   %397 = bitcast i8* %396 to i64*
-  %NullCheck164 = icmp ne i64* %397, null
-  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+  %NullCheck163 = icmp eq i64* %397, null
+  br i1 %NullCheck163, label %ThrowNullRef164, label %398
 
 ; <label>:398                                     ; preds = %394
   %399 = load i64, i64* %397, align 8
   %400 = bitcast i8* %395 to i64*
-  %NullCheck166 = icmp ne i64* %400, null
-  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+  %NullCheck165 = icmp eq i64* %400, null
+  br i1 %NullCheck165, label %ThrowNullRef166, label %401
 
 ; <label>:401                                     ; preds = %398
   store i64 %399, i64* %400, align 8
@@ -1400,14 +1482,14 @@ entry:
   %404 = load i8*, i8** %arg1
   %405 = getelementptr inbounds i8, i8* %404, i64 8
   %406 = bitcast i8* %405 to i64*
-  %NullCheck168 = icmp ne i64* %406, null
-  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+  %NullCheck167 = icmp eq i64* %406, null
+  br i1 %NullCheck167, label %ThrowNullRef168, label %407
 
 ; <label>:407                                     ; preds = %401
   %408 = load i64, i64* %406, align 8
   %409 = bitcast i8* %403 to i64*
-  %NullCheck170 = icmp ne i64* %409, null
-  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+  %NullCheck169 = icmp eq i64* %409, null
+  br i1 %NullCheck169, label %ThrowNullRef170, label %410
 
 ; <label>:410                                     ; preds = %407
   store i64 %408, i64* %409, align 8
@@ -1437,14 +1519,14 @@ entry:
   %425 = load i8*, i8** %arg0
   %426 = load i8*, i8** %arg1
   %427 = bitcast i8* %426 to i64*
-  %NullCheck148 = icmp ne i64* %427, null
-  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+  %NullCheck147 = icmp eq i64* %427, null
+  br i1 %NullCheck147, label %ThrowNullRef148, label %428
 
 ; <label>:428                                     ; preds = %424
   %429 = load i64, i64* %427, align 8
   %430 = bitcast i8* %425 to i64*
-  %NullCheck150 = icmp ne i64* %430, null
-  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+  %NullCheck149 = icmp eq i64* %430, null
+  br i1 %NullCheck149, label %ThrowNullRef150, label %431
 
 ; <label>:431                                     ; preds = %428
   store i64 %429, i64* %430, align 8
@@ -1466,14 +1548,14 @@ entry:
   %441 = load i8*, i8** %arg0
   %442 = load i8*, i8** %arg1
   %443 = bitcast i8* %442 to i32*
-  %NullCheck152 = icmp ne i32* %443, null
-  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+  %NullCheck151 = icmp eq i32* %443, null
+  br i1 %NullCheck151, label %ThrowNullRef152, label %444
 
 ; <label>:444                                     ; preds = %440
   %445 = load i32, i32* %443, align 8
   %446 = bitcast i8* %441 to i32*
-  %NullCheck154 = icmp ne i32* %446, null
-  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+  %NullCheck153 = icmp eq i32* %446, null
+  br i1 %NullCheck153, label %ThrowNullRef154, label %447
 
 ; <label>:447                                     ; preds = %444
   store i32 %445, i32* %446, align 8
@@ -1495,16 +1577,16 @@ entry:
   %457 = load i8*, i8** %arg0
   %458 = load i8*, i8** %arg1
   %459 = bitcast i8* %458 to i16*
-  %NullCheck156 = icmp ne i16* %459, null
-  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+  %NullCheck155 = icmp eq i16* %459, null
+  br i1 %NullCheck155, label %ThrowNullRef156, label %460
 
 ; <label>:460                                     ; preds = %456
   %461 = load i16, i16* %459, align 8
   %462 = sext i16 %461 to i32
   %463 = bitcast i8* %457 to i16*
   %464 = trunc i32 %462 to i16
-  %NullCheck158 = icmp ne i16* %463, null
-  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+  %NullCheck157 = icmp eq i16* %463, null
+  br i1 %NullCheck157, label %ThrowNullRef158, label %465
 
 ; <label>:465                                     ; preds = %460
   store i16 %464, i16* %463, align 8
@@ -1525,15 +1607,15 @@ entry:
 ; <label>:474                                     ; preds = %470
   %475 = load i8*, i8** %arg0
   %476 = load i8*, i8** %arg1
-  %NullCheck160 = icmp ne i8* %476, null
-  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+  %NullCheck159 = icmp eq i8* %476, null
+  br i1 %NullCheck159, label %ThrowNullRef160, label %477
 
 ; <label>:477                                     ; preds = %474
   %478 = load i8, i8* %476, align 8
   %479 = zext i8 %478 to i32
   %480 = trunc i32 %479 to i8
-  %NullCheck162 = icmp ne i8* %475, null
-  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+  %NullCheck161 = icmp eq i8* %475, null
+  br i1 %NullCheck161, label %ThrowNullRef162, label %481
 
 ; <label>:481                                     ; preds = %477
   store i8 %480, i8* %475, align 8
@@ -1553,343 +1635,343 @@ ThrowNullRef:                                     ; preds = %308
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %312
+ThrowNullRef2:                                    ; preds = %312
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %315
+ThrowNullRef4:                                    ; preds = %315
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %321
+ThrowNullRef6:                                    ; preds = %321
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %271
+ThrowNullRef8:                                    ; preds = %271
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %275
+ThrowNullRef10:                                   ; preds = %275
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %278
+ThrowNullRef12:                                   ; preds = %278
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %284
+ThrowNullRef14:                                   ; preds = %284
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %287
+ThrowNullRef16:                                   ; preds = %287
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %293
+ThrowNullRef18:                                   ; preds = %293
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %298
+ThrowNullRef20:                                   ; preds = %298
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %303
+ThrowNullRef22:                                   ; preds = %303
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %243
+ThrowNullRef24:                                   ; preds = %243
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %247
+ThrowNullRef26:                                   ; preds = %247
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %250
+ThrowNullRef28:                                   ; preds = %250
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %256
+ThrowNullRef30:                                   ; preds = %256
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %259
+ThrowNullRef32:                                   ; preds = %259
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %265
+ThrowNullRef34:                                   ; preds = %265
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %217
+ThrowNullRef36:                                   ; preds = %217
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %221
+ThrowNullRef38:                                   ; preds = %221
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %224
+ThrowNullRef40:                                   ; preds = %224
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %230
+ThrowNullRef42:                                   ; preds = %230
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %233
+ThrowNullRef44:                                   ; preds = %233
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %238
+ThrowNullRef46:                                   ; preds = %238
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %200
+ThrowNullRef48:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %204
+ThrowNullRef50:                                   ; preds = %204
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %207
+ThrowNullRef52:                                   ; preds = %207
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %213
+ThrowNullRef54:                                   ; preds = %213
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %172
+ThrowNullRef56:                                   ; preds = %172
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %176
+ThrowNullRef58:                                   ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %179
+ThrowNullRef60:                                   ; preds = %179
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %185
+ThrowNullRef62:                                   ; preds = %185
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %190
+ThrowNullRef64:                                   ; preds = %190
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %195
+ThrowNullRef66:                                   ; preds = %195
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %153
+ThrowNullRef68:                                   ; preds = %153
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %157
+ThrowNullRef70:                                   ; preds = %157
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %160
+ThrowNullRef72:                                   ; preds = %160
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %166
+ThrowNullRef74:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %136
+ThrowNullRef76:                                   ; preds = %136
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %140
+ThrowNullRef78:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %143
+ThrowNullRef80:                                   ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %148
+ThrowNullRef82:                                   ; preds = %148
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %128
+ThrowNullRef84:                                   ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %132
+ThrowNullRef86:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %100
+ThrowNullRef88:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %104
+ThrowNullRef90:                                   ; preds = %104
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %107
+ThrowNullRef92:                                   ; preds = %107
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %113
+ThrowNullRef94:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %118
+ThrowNullRef96:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %123
+ThrowNullRef98:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %81
+ThrowNullRef100:                                  ; preds = %81
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef101:                                  ; preds = %85
+ThrowNullRef102:                                  ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef103:                                  ; preds = %88
+ThrowNullRef104:                                  ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef105:                                  ; preds = %94
+ThrowNullRef106:                                  ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef107:                                  ; preds = %64
+ThrowNullRef108:                                  ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef109:                                  ; preds = %68
+ThrowNullRef110:                                  ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef111:                                  ; preds = %71
+ThrowNullRef112:                                  ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef113:                                  ; preds = %76
+ThrowNullRef114:                                  ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef115:                                  ; preds = %56
+ThrowNullRef116:                                  ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef117:                                  ; preds = %60
+ThrowNullRef118:                                  ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef119:                                  ; preds = %37
+ThrowNullRef120:                                  ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef121:                                  ; preds = %41
+ThrowNullRef122:                                  ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef123:                                  ; preds = %46
+ThrowNullRef124:                                  ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef125:                                  ; preds = %51
+ThrowNullRef126:                                  ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef127:                                  ; preds = %27
+ThrowNullRef128:                                  ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef129:                                  ; preds = %31
+ThrowNullRef130:                                  ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef131:                                  ; preds = %19
+ThrowNullRef132:                                  ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef133:                                  ; preds = %22
+ThrowNullRef134:                                  ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef135:                                  ; preds = %338
+ThrowNullRef136:                                  ; preds = %338
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef137:                                  ; preds = %341
+ThrowNullRef138:                                  ; preds = %341
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef139:                                  ; preds = %356
+ThrowNullRef140:                                  ; preds = %356
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef141:                                  ; preds = %360
+ThrowNullRef142:                                  ; preds = %360
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef143:                                  ; preds = %377
+ThrowNullRef144:                                  ; preds = %377
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef145:                                  ; preds = %381
+ThrowNullRef146:                                  ; preds = %381
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef147:                                  ; preds = %424
+ThrowNullRef148:                                  ; preds = %424
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef149:                                  ; preds = %428
+ThrowNullRef150:                                  ; preds = %428
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef151:                                  ; preds = %440
+ThrowNullRef152:                                  ; preds = %440
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef153:                                  ; preds = %444
+ThrowNullRef154:                                  ; preds = %444
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef155:                                  ; preds = %456
+ThrowNullRef156:                                  ; preds = %456
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef157:                                  ; preds = %460
+ThrowNullRef158:                                  ; preds = %460
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef159:                                  ; preds = %474
+ThrowNullRef160:                                  ; preds = %474
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef161:                                  ; preds = %477
+ThrowNullRef162:                                  ; preds = %477
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef163:                                  ; preds = %394
+ThrowNullRef164:                                  ; preds = %394
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef165:                                  ; preds = %398
+ThrowNullRef166:                                  ; preds = %398
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef167:                                  ; preds = %401
+ThrowNullRef168:                                  ; preds = %401
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef169:                                  ; preds = %407
+ThrowNullRef170:                                  ; preds = %407
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1939,8 +2021,8 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
-  br i1 %NullCheck, label %22, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %ThrowNullRef, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
@@ -1948,8 +2030,8 @@ entry:
   store i32 %24, i32* %loc0
   %25 = load i32, i32* %loc0
   %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %26, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %27
 
 ; <label>:27                                      ; preds = %22
   %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
@@ -1971,7 +2053,7 @@ ThrowNullRef:                                     ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1989,8 +2071,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -2022,15 +2104,15 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2048,16 +2130,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
   %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
   store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %15
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
@@ -2072,8 +2154,8 @@ entry:
   %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
   %29 = ptrtoint i16 addrspace(1)* %28 to i64
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %19
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
@@ -2089,19 +2171,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2114,8 +2196,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
@@ -2128,7 +2210,7 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[loadElem]
+Failed to read AppDomain.PrepareDataForSetup[storeElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
@@ -2202,8 +2284,8 @@ entry:
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
-  br i1 %NullCheck24, label %27, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = load i64, i64 addrspace(1)* %26
@@ -2218,8 +2300,8 @@ entry:
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
-  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
   %41 = load i64, i64 addrspace(1)* %39
@@ -2236,8 +2318,8 @@ entry:
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
-  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
   %54 = load i64, i64 addrspace(1)* %52
@@ -2252,8 +2334,8 @@ entry:
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
   %67 = load i64, i64 addrspace(1)* %65
@@ -2270,8 +2352,8 @@ entry:
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
-  br i1 %NullCheck16, label %79, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
   %80 = load i64, i64 addrspace(1)* %78
@@ -2286,8 +2368,8 @@ entry:
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
-  br i1 %NullCheck18, label %92, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
   %93 = load i64, i64 addrspace(1)* %91
@@ -2304,8 +2386,8 @@ entry:
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
-  br i1 %NullCheck12, label %105, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = load i64, i64 addrspace(1)* %104
@@ -2320,8 +2402,8 @@ entry:
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
-  br i1 %NullCheck14, label %118, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
   %119 = load i64, i64 addrspace(1)* %117
@@ -2337,8 +2419,8 @@ entry:
 
 ; <label>:128                                     ; preds = %20
   %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
-  br i1 %NullCheck4, label %130, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %129, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %130
 
 ; <label>:130                                     ; preds = %128
   %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
@@ -2346,8 +2428,8 @@ entry:
   %133 = load i16, i16 addrspace(1)* %132, align 8
   %134 = zext i16 %133 to i32
   %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
-  br i1 %NullCheck6, label %136, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %135, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %136
 
 ; <label>:136                                     ; preds = %130
   %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
@@ -2360,8 +2442,8 @@ entry:
 
 ; <label>:143                                     ; preds = %136
   %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
-  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %144, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %145
 
 ; <label>:145                                     ; preds = %143
   %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
@@ -2369,8 +2451,8 @@ entry:
   %148 = load i16, i16 addrspace(1)* %147, align 8
   %149 = zext i16 %148 to i32
   %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %150, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %151
 
 ; <label>:151                                     ; preds = %145
   %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
@@ -2388,8 +2470,8 @@ entry:
 
 ; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
-  br i1 %NullCheck, label %163, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %ThrowNullRef, label %163
 
 ; <label>:163                                     ; preds = %161
   %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
@@ -2399,8 +2481,8 @@ entry:
 
 ; <label>:167                                     ; preds = %163
   %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
-  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %168, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %169
 
 ; <label>:169                                     ; preds = %167
   %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
@@ -2432,55 +2514,55 @@ ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %167
+ThrowNullRef2:                                    ; preds = %167
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %128
+ThrowNullRef4:                                    ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %130
+ThrowNullRef6:                                    ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %143
+ThrowNullRef8:                                    ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %145
+ThrowNullRef10:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %102
+ThrowNullRef12:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %105
+ThrowNullRef14:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %76
+ThrowNullRef16:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %79
+ThrowNullRef18:                                   ; preds = %79
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %50
+ThrowNullRef20:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %53
+ThrowNullRef22:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %24
+ThrowNullRef24:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %27
+ThrowNullRef26:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2503,15 +2585,15 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2519,16 +2601,16 @@ entry:
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
   store i32 %8, i32* %loc0
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
   %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
   store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
@@ -2546,16 +2628,16 @@ entry:
 
 ; <label>:23                                      ; preds = %64
   %24 = load i16*, i16** %loc3
-  %NullCheck12 = icmp ne i16* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i16* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
   store i32 %27, i32* %loc5
   %28 = load i16*, i16** %loc4
-  %NullCheck14 = icmp ne i16* %28, null
-  br i1 %NullCheck14, label %29, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %28, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = load i16, i16* %28, align 8
@@ -2620,15 +2702,15 @@ entry:
 
 ; <label>:67                                      ; preds = %64
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
-  br i1 %NullCheck8, label %69, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %68, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %69
 
 ; <label>:69                                      ; preds = %67
   %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
   %71 = load i32, i32 addrspace(1)* %70
   %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
-  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %73
 
 ; <label>:73                                      ; preds = %69
   %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
@@ -2645,31 +2727,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %67
+ThrowNullRef8:                                    ; preds = %67
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %69
+ThrowNullRef10:                                   ; preds = %69
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2710,14 +2792,14 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
   %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
@@ -2730,14 +2812,14 @@ entry:
 
 ; <label>:11                                      ; preds = %4
   %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
   %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
@@ -2749,14 +2831,14 @@ entry:
 
 ; <label>:22                                      ; preds = %16
   %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
   %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
-  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
-  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
@@ -2804,23 +2886,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2836,7 +2918,280 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[loadElem]
+Successfully read RuntimeType.IsAssignableFrom
+
+define i8 @RuntimeType.IsAssignableFrom(%System.RuntimeType addrspace(1)* %param0, %System.Type addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.RuntimeType addrspace(1)*
+  %arg1 = alloca %System.Type addrspace(1)*
+  %loc0 = alloca %System.RuntimeType addrspace(1)*
+  %loc1 = alloca %"System.Type[]" addrspace(1)*
+  %loc2 = alloca i32
+  store %System.RuntimeType addrspace(1)* %param0, %System.RuntimeType addrspace(1)** %this
+  store %System.Type addrspace(1)* %param1, %System.Type addrspace(1)** %arg1
+  %0 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %1 = icmp ne %System.Type addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i8 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %5 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %6 = bitcast %System.Type addrspace(1)* %4 to %System.Object addrspace(1)*
+  %7 = bitcast %System.RuntimeType addrspace(1)* %5 to %System.Object addrspace(1)*
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %6, %System.Object addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %3
+  ret i8 1
+
+; <label>:12                                      ; preds = %3
+  %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 152
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 32
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
+  %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
+  %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
+  store %System.RuntimeType addrspace(1)* %25, %System.RuntimeType addrspace(1)** %loc0
+  %26 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %27 = icmp eq %System.RuntimeType addrspace(1)* %26, null
+  br i1 %27, label %34, label %28
+
+; <label>:28                                      ; preds = %15
+  %29 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %30 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)*)*)(%System.RuntimeType addrspace(1)* %29, %System.RuntimeType addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+; <label>:34                                      ; preds = %15
+  %35 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %36 = call %System.Reflection.Emit.TypeBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Reflection.Emit.TypeBuilder addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %35)
+  %37 = icmp eq %System.Reflection.Emit.TypeBuilder addrspace(1)* %36, null
+  br i1 %37, label %139, label %38
+
+; <label>:38                                      ; preds = %34
+  %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %42
+
+; <label>:42                                      ; preds = %38
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 152
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 40
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
+  %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
+  %53 = zext i8 %52 to i32
+  %54 = icmp eq i32 %53, 0
+  br i1 %54, label %56, label %55
+
+; <label>:55                                      ; preds = %42
+  ret i8 1
+
+; <label>:56                                      ; preds = %42
+  %57 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %58 = bitcast %System.RuntimeType addrspace(1)* %57 to %System.Type addrspace(1)*
+  %59 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %58)
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %64 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.Type addrspace(1)* %63, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = bitcast %System.RuntimeType addrspace(1)* %64 to %System.Type addrspace(1)*
+  %67 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %63, %System.Type addrspace(1)* %66)
+  %68 = zext i8 %67 to i32
+  %69 = trunc i32 %68 to i8
+  ret i8 %69
+
+; <label>:70                                      ; preds = %56
+  %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
+  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %73
+
+; <label>:73                                      ; preds = %70
+  %74 = load i64, i64 addrspace(1)* %72
+  %75 = add i64 %74, 128
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = add i64 %77, 0
+  %79 = inttoptr i64 %78 to i64*
+  %80 = load i64, i64* %79
+  %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
+  %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
+  %83 = call i8 %82(%System.Type addrspace(1)* %81)
+  %84 = zext i8 %83 to i32
+  %85 = icmp eq i32 %84, 0
+  br i1 %85, label %139, label %86
+
+; <label>:86                                      ; preds = %73
+  %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
+  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %89
+
+; <label>:89                                      ; preds = %86
+  %90 = load i64, i64 addrspace(1)* %88
+  %91 = add i64 %90, 128
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = add i64 %93, 24
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
+  %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
+  %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
+  store %"System.Type[]" addrspace(1)* %99, %"System.Type[]" addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %129
+
+; <label>:100                                     ; preds = %132
+  %101 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %102 = load i32, i32* %loc2
+  %NullCheck11 = icmp eq %"System.Type[]" addrspace(1)* %101, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %103
+
+; <label>:103                                     ; preds = %100
+  %104 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 1
+  %105 = load i32, i32 addrspace(1)* %104
+  %106 = zext i32 %105 to i64
+  %107 = zext i32 %102 to i64
+  %BoundsCheck = icmp uge i64 %107, %106
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %108
+
+; <label>:108                                     ; preds = %103
+  %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
+  %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
+  %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
+  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %113
+
+; <label>:113                                     ; preds = %108
+  %114 = load i64, i64 addrspace(1)* %112
+  %115 = add i64 %114, 152
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = add i64 %117, 56
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
+  %123 = zext i8 %122 to i32
+  %124 = icmp ne i32 %123, 0
+  br i1 %124, label %126, label %125
+
+; <label>:125                                     ; preds = %113
+  ret i8 0
+
+; <label>:126                                     ; preds = %113
+  %127 = load i32, i32* %loc2
+  %128 = add i32 %127, 1
+  store i32 %128, i32* %loc2
+  br label %129
+
+; <label>:129                                     ; preds = %89, %126
+  %130 = load i32, i32* %loc2
+  %131 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %NullCheck9 = icmp eq %"System.Type[]" addrspace(1)* %131, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %132
+
+; <label>:132                                     ; preds = %129
+  %133 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %131, i32 0, i32 1
+  %134 = load i32, i32 addrspace(1)* %133
+  %135 = zext i32 %134 to i64
+  %136 = trunc i64 %135 to i32
+  %137 = icmp slt i32 %130, %136
+  br i1 %137, label %100, label %138
+
+; <label>:138                                     ; preds = %132
+  ret i8 1
+
+; <label>:139                                     ; preds = %34, %73
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %129
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %103
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -2893,7 +3248,7 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElem]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -2904,8 +3259,8 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -2997,8 +3352,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
@@ -3059,8 +3414,8 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -3087,8 +3442,8 @@ entry:
 
 ; <label>:17                                      ; preds = %5, %11
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
@@ -3097,8 +3452,8 @@ entry:
 
 ; <label>:22                                      ; preds = %1, %11
   %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
@@ -3109,11 +3464,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %17
+ThrowNullRef2:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %22
+ThrowNullRef4:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3167,15 +3522,15 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
   %15 = load i32, i32 addrspace(1)* %14
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
@@ -3198,7 +3553,7 @@ ThrowNullRef:                                     ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef2:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3232,8 +3587,8 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
@@ -3312,8 +3667,8 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -3327,8 +3682,8 @@ entry:
 ; <label>:5                                       ; preds = %43
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %7 = load i32, i32* %loc1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck6, label %8, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
@@ -3366,8 +3721,8 @@ entry:
 ; <label>:32                                      ; preds = %21, %25
   %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
   %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
-  br i1 %NullCheck8, label %35, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = trunc i32 %34 to i16
@@ -3380,8 +3735,8 @@ entry:
 ; <label>:40                                      ; preds = %1, %35
   %41 = load i32, i32* %loc1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
-  br i1 %NullCheck2, label %43, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %42, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
@@ -3392,8 +3747,8 @@ entry:
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
   %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
-  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
   %51 = load i64, i64 addrspace(1)* %49
@@ -3412,19 +3767,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %40
+ThrowNullRef2:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %47
+ThrowNullRef4:                                    ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %5
+ThrowNullRef6:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %32
+ThrowNullRef8:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3467,8 +3822,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
@@ -3492,11 +3847,391 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(i16* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store i16* %param0, i16** %arg0
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load i32, i32* %arg3
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %42, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %37, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg2
+  %13 = load i32, i32* %arg3
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %37, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %24 = load i32, i32* %arg2
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load i16*, i16** %arg0
+  %35 = load i32, i32* %arg3
+  %36 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %36, i16* %34, i32 %35)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:37                                      ; preds = %5, %16
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %39)
+  %41 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41, %System.String addrspace(1)* %38, %System.String addrspace(1)* %40)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41) #0
+  unreachable
+
+; <label>:42                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
-Failed to read StringBuilder.ToString[loadElemA]
+Successfully read StringBuilder.ToString
+
+define %System.String addrspace(1)* @StringBuilder.ToString(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i16*
+  %loc3 = alloca %"System.Char[]" addrspace(1)*
+  %loc4 = alloca i32
+  %loc5 = alloca i32
+  %loc6 = alloca i16 addrspace(1)*
+  %loc7 = alloca %System.String addrspace(1)*
+  %loc8 = alloca %"System.Char[]" addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %0)
+  %2 = icmp ne i32 %1, 0
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %4
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %6)
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %7)
+  store %System.String addrspace(1)* %8, %System.String addrspace(1)** %loc0
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.Text.StringBuilder addrspace(1)* %9, %System.Text.StringBuilder addrspace(1)** %loc1
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  store %System.String addrspace(1)* %10, %System.String addrspace(1)** %loc7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc7
+  %12 = ptrtoint %System.String addrspace(1)* %11 to i64
+  %13 = icmp eq i64 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %5
+  %15 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %16 = sext i32 %15 to i64
+  %17 = add i64 %12, %16
+  br label %18
+
+; <label>:18                                      ; preds = %5, %14
+  %19 = phi i64 [ %12, %5 ], [ %17, %14 ]
+  %20 = inttoptr i64 %19 to i16*
+  store i16* %20, i16** %loc2
+  br label %21
+
+; <label>:21                                      ; preds = %98, %18
+  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %22, null
+  br i1 %NullCheck, label %ThrowNullRef, label %23
+
+; <label>:23                                      ; preds = %21
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 3
+  %25 = load i32, i32 addrspace(1)* %24, align 8
+  %26 = icmp sle i32 %25, 0
+  br i1 %26, label %96, label %27
+
+; <label>:27                                      ; preds = %23
+  %28 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %28, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %29
+
+; <label>:29                                      ; preds = %27
+  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %28, i32 0, i32 1
+  %31 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %30, align 8
+  store %"System.Char[]" addrspace(1)* %31, %"System.Char[]" addrspace(1)** %loc3
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %33
+
+; <label>:33                                      ; preds = %29
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  store i32 %35, i32* %loc4
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  %39 = load i32, i32 addrspace(1)* %38, align 8
+  store i32 %39, i32* %loc5
+  %40 = load i32, i32* %loc5
+  %41 = load i32, i32* %loc4
+  %42 = add i32 %40, %41
+  %43 = zext i32 %42 to i64
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %45
+
+; <label>:45                                      ; preds = %37
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = sext i32 %47 to i64
+  %49 = icmp sgt i64 %43, %48
+  br i1 %49, label %91, label %50
+
+; <label>:50                                      ; preds = %45
+  %51 = load i32, i32* %loc5
+  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %52, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %53
+
+; <label>:53                                      ; preds = %50
+  %54 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %52, i32 0, i32 1
+  %55 = load i32, i32 addrspace(1)* %54
+  %56 = zext i32 %55 to i64
+  %57 = trunc i64 %56 to i32
+  %58 = icmp ugt i32 %51, %57
+  br i1 %58, label %91, label %59
+
+; <label>:59                                      ; preds = %53
+  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  store %"System.Char[]" addrspace(1)* %60, %"System.Char[]" addrspace(1)** %loc8
+  %61 = icmp eq %"System.Char[]" addrspace(1)* %60, null
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %63, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %64
+
+; <label>:64                                      ; preds = %62
+  %65 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %63, i32 0, i32 1
+  %66 = load i32, i32 addrspace(1)* %65
+  %67 = zext i32 %66 to i64
+  %68 = trunc i64 %67 to i32
+  %69 = icmp ne i32 %68, 0
+  br i1 %69, label %71, label %70
+
+; <label>:70                                      ; preds = %59, %64
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:71                                      ; preds = %64
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %73
+
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %BoundsCheck = icmp uge i64 0, %76
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %77
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %78, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:79                                      ; preds = %70, %77
+  %80 = load i16*, i16** %loc2
+  %81 = load i32, i32* %loc4
+  %82 = sext i32 %81 to i64
+  %83 = mul i64 %82, 2
+  %84 = bitcast i16* %80 to i8*
+  %85 = getelementptr inbounds i8, i8* %84, i64 %83
+  %86 = load i16 addrspace(1)*, i16 addrspace(1)** %loc6
+  %87 = ptrtoint i16 addrspace(1)* %86 to i64
+  %88 = load i32, i32* %loc5
+  %89 = bitcast i8* %85 to i16*
+  %90 = inttoptr i64 %87 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %89, i16* %90, i32 %88)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %96
+
+; <label>:91                                      ; preds = %45, %53
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %94 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %93)
+  %95 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95, %System.String addrspace(1)* %92, %System.String addrspace(1)* %94)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95) #0
+  unreachable
+
+; <label>:96                                      ; preds = %23, %79
+  %97 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %97, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %98
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %97, i32 0, i32 2
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  store %System.Text.StringBuilder addrspace(1)* %100, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %102 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %102, label %21, label %103
+
+; <label>:103                                     ; preds = %98
+  store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc7
+  %104 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  ret %System.String addrspace(1)* %104
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method StringBuilder::get_Length using LLILCJit
+Successfully read StringBuilder.get_Length
+
+define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
+Successfully read RuntimeHelpers.get_OffsetToStringData
+
+define i32 @RuntimeHelpers.get_OffsetToStringData() {
+entry:
+  ret i32 12
+}
+
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
 Successfully read CultureData.CreateCultureData
 
@@ -3514,23 +4249,23 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
   store i8 %4, i8 addrspace(1)* %6
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
@@ -3549,11 +4284,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3566,50 +4301,50 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
   store i32 -1, i32 addrspace(1)* %2
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
   store i32 -1, i32 addrspace(1)* %8
   %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
   store i32 -1, i32 addrspace(1)* %14
   %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
   store i32 -1, i32 addrspace(1)* %17
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
@@ -3623,27 +4358,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3675,7 +4410,136 @@ Failed to read Dictionary`2.Insert[non-const derefAddress]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
 Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
-Failed to read HashHelpers.GetPrime[loadElem]
+Successfully read HashHelpers.GetPrime
+
+define i32 @HashHelpers.GetPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %6, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5, %System.String addrspace(1)* %4)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5) #0
+  unreachable
+
+; <label>:6                                       ; preds = %entry
+  store i32 0, i32* %loc0
+  br label %29
+
+; <label>:7                                       ; preds = %35
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 1296
+  %10 = addrspacecast i8 addrspace(1)* %9 to %"System.Int32[]" addrspace(1)**
+  %11 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %10
+  %12 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Int32[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = zext i32 %15 to i64
+  %17 = zext i32 %12 to i64
+  %BoundsCheck = icmp uge i64 %17, %16
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 3, i32 %12
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  store i32 %20, i32* %loc1
+  %21 = load i32, i32* %loc1
+  %22 = load i32, i32* %arg0
+  %23 = icmp slt i32 %21, %22
+  br i1 %23, label %26, label %24
+
+; <label>:24                                      ; preds = %18
+  %25 = load i32, i32* %loc1
+  ret i32 %25
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %loc0
+  %28 = add i32 %27, 1
+  store i32 %28, i32* %loc0
+  br label %29
+
+; <label>:29                                      ; preds = %6, %26
+  %30 = load i32, i32* %loc0
+  %31 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %32 = getelementptr inbounds i8, i8 addrspace(1)* %31, i64 1296
+  %33 = addrspacecast i8 addrspace(1)* %32 to %"System.Int32[]" addrspace(1)**
+  %34 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %33
+  %NullCheck = icmp eq %"System.Int32[]" addrspace(1)* %34, null
+  br i1 %NullCheck, label %ThrowNullRef, label %35
+
+; <label>:35                                      ; preds = %29
+  %36 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %34, i32 0, i32 1
+  %37 = load i32, i32 addrspace(1)* %36
+  %38 = zext i32 %37 to i64
+  %39 = trunc i64 %38 to i32
+  %40 = icmp slt i32 %30, %39
+  br i1 %40, label %7, label %41
+
+; <label>:41                                      ; preds = %35
+  %42 = load i32, i32* %arg0
+  %43 = or i32 %42, 1
+  store i32 %43, i32* %loc2
+  br label %59
+
+; <label>:44                                      ; preds = %59
+  %45 = load i32, i32* %loc2
+  %46 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %45)
+  %47 = zext i8 %46 to i32
+  %48 = icmp eq i32 %47, 0
+  br i1 %48, label %56, label %49
+
+; <label>:49                                      ; preds = %44
+  %50 = load i32, i32* %loc2
+  %51 = sub i32 %50, 1
+  %52 = srem i32 %51, 101
+  %53 = icmp eq i32 %52, 0
+  br i1 %53, label %56, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = load i32, i32* %loc2
+  ret i32 %55
+
+; <label>:56                                      ; preds = %44, %49
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %57, 2
+  store i32 %58, i32* %loc2
+  br label %59
+
+; <label>:59                                      ; preds = %41, %56
+  %60 = load i32, i32* %loc2
+  %61 = icmp slt i32 %60, 2147483647
+  br i1 %61, label %44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load i32, i32* %arg0
+  ret i32 %63
+
+ThrowNullRef:                                     ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
 Successfully read GenericEqualityComparer`1.GetHashCode
 
@@ -3694,14 +4558,14 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
   %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load i64, i64 addrspace(1)* %7
@@ -3720,7 +4584,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3750,8 +4614,8 @@ entry:
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
@@ -3796,8 +4660,8 @@ entry:
   %35 = bitcast i16* %34 to i8*
   %36 = getelementptr inbounds i8, i8* %35, i64 2
   %37 = bitcast i8* %36 to i16*
-  %NullCheck4 = icmp ne i16* %37, null
-  br i1 %NullCheck4, label %38, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %37, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %38
 
 ; <label>:38                                      ; preds = %27
   %39 = load i16, i16* %37, align 8
@@ -3824,8 +4688,8 @@ entry:
 
 ; <label>:54                                      ; preds = %22, %43
   %55 = load i16*, i16** %loc4
-  %NullCheck2 = icmp ne i16* %55, null
-  br i1 %NullCheck2, label %56, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i16* %55, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %56
 
 ; <label>:56                                      ; preds = %54
   %57 = load i16, i16* %55, align 8
@@ -3850,11 +4714,11 @@ ThrowNullRef:                                     ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %54
+ThrowNullRef2:                                    ; preds = %54
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %27
+ThrowNullRef4:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3871,8 +4735,8 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -3907,8 +4771,8 @@ entry:
 
 ; <label>:26                                      ; preds = %19
   %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
-  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %28
 
 ; <label>:28                                      ; preds = %26
   %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
@@ -3920,7 +4784,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3972,8 +4836,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
@@ -3984,26 +4848,26 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
-  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
@@ -4014,8 +4878,8 @@ entry:
 ; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
@@ -4024,8 +4888,8 @@ entry:
 
 ; <label>:25                                      ; preds = %1, %16, %23
   %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
-  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
@@ -4036,27 +4900,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %20
+ThrowNullRef10:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4069,8 +4933,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -4081,8 +4945,8 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
@@ -4091,8 +4955,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1, %8
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
@@ -4103,11 +4967,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4128,24 +4992,24 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   store i32 %3, i32* %loc0
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
   %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
   store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck4, label %9, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
@@ -4164,15 +5028,15 @@ entry:
 ; <label>:18                                      ; preds = %70
   %19 = load i16*, i16** %loc3
   %20 = bitcast i16* %19 to i64*
-  %NullCheck10 = icmp ne i64* %20, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %20, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = load i64, i64* %20, align 8
   %23 = load i16*, i16** %loc4
   %24 = bitcast i16* %23 to i64*
-  %NullCheck12 = icmp ne i64* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = load i64, i64* %24, align 8
@@ -4188,8 +5052,8 @@ entry:
   %31 = bitcast i16* %30 to i8*
   %32 = getelementptr inbounds i8, i8* %31, i64 8
   %33 = bitcast i8* %32 to i64*
-  %NullCheck14 = icmp ne i64* %33, null
-  br i1 %NullCheck14, label %34, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = load i64, i64* %33, align 8
@@ -4197,8 +5061,8 @@ entry:
   %37 = bitcast i16* %36 to i8*
   %38 = getelementptr inbounds i8, i8* %37, i64 8
   %39 = bitcast i8* %38 to i64*
-  %NullCheck16 = icmp ne i64* %39, null
-  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %40
 
 ; <label>:40                                      ; preds = %34
   %41 = load i64, i64* %39, align 8
@@ -4214,8 +5078,8 @@ entry:
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %NullCheck18 = icmp ne i64* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = load i64, i64* %48, align 8
@@ -4223,8 +5087,8 @@ entry:
   %52 = bitcast i16* %51 to i8*
   %53 = getelementptr inbounds i8, i8* %52, i64 16
   %54 = bitcast i8* %53 to i64*
-  %NullCheck20 = icmp ne i64* %54, null
-  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64* %54, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %55
 
 ; <label>:55                                      ; preds = %49
   %56 = load i64, i64* %54, align 8
@@ -4262,15 +5126,15 @@ entry:
 ; <label>:74                                      ; preds = %95
   %75 = load i16*, i16** %loc3
   %76 = bitcast i16* %75 to i32*
-  %NullCheck6 = icmp ne i32* %76, null
-  br i1 %NullCheck6, label %77, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32* %76, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %77
 
 ; <label>:77                                      ; preds = %74
   %78 = load i32, i32* %76, align 8
   %79 = load i16*, i16** %loc4
   %80 = bitcast i16* %79 to i32*
-  %NullCheck8 = icmp ne i32* %80, null
-  br i1 %NullCheck8, label %81, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i32* %80, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %81
 
 ; <label>:81                                      ; preds = %77
   %82 = load i32, i32* %80, align 8
@@ -4318,43 +5182,43 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %74
+ThrowNullRef6:                                    ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %77
+ThrowNullRef8:                                    ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %29
+ThrowNullRef14:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %34
+ThrowNullRef16:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4376,8 +5240,8 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load i64, i64 addrspace(1)* %4
@@ -4389,8 +5253,8 @@ entry:
   %12 = load i64, i64* %11
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %5
   %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
@@ -4399,8 +5263,8 @@ entry:
   %18 = load i8, i8* %arg2
   %19 = zext i8 %18 to i32
   %20 = trunc i32 %19 to i8
-  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %15
   %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
@@ -4411,11 +5275,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4442,8 +5306,8 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
@@ -4466,16 +5330,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
   %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = load i64, i64 addrspace(1)* %19
@@ -4500,8 +5364,8 @@ entry:
 ; <label>:35                                      ; preds = %30
   %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
@@ -4514,8 +5378,8 @@ entry:
 
 ; <label>:42                                      ; preds = %1, %38
   %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
-  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
@@ -4526,19 +5390,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %35
+ThrowNullRef2:                                    ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %42
+ThrowNullRef8:                                    ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4551,14 +5415,14 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
@@ -4570,7 +5434,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4583,8 +5447,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
@@ -4613,51 +5477,51 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
   %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
   %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
   %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
   %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
-  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
   store i64 %21, i64 addrspace(1)* %23
   %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %25 = load i64, i64* %loc0
-  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
@@ -4668,27 +5532,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %22
+ThrowNullRef12:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4701,8 +5565,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
@@ -4713,19 +5577,19 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
@@ -4734,8 +5598,8 @@ entry:
 
 ; <label>:15                                      ; preds = %1, %13
   %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
@@ -4746,19 +5610,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %15
+ThrowNullRef8:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4771,8 +5635,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -4831,8 +5695,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
@@ -4882,8 +5746,8 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
-  br i1 %NullCheck, label %17, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %ThrowNullRef, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
@@ -4894,15 +5758,15 @@ entry:
 
 ; <label>:22                                      ; preds = %17
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
-  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
   %26 = load i32, i32 addrspace(1)* %25
   %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
-  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %27, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
@@ -4925,8 +5789,8 @@ entry:
 ; <label>:40                                      ; preds = %17
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
-  br i1 %NullCheck6, label %43, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %41, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
@@ -4938,34 +5802,17 @@ ThrowNullRef:                                     ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %24
+ThrowNullRef4:                                    ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %40
+ThrowNullRef6:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
-}
-
-INFO:  jitting method Object::ReferenceEquals using LLILCJit
-Successfully read Object.ReferenceEquals
-
-define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
-entry:
-  %arg0 = alloca %System.Object addrspace(1)*
-  %arg1 = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
-  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
-  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = icmp eq %System.Object addrspace(1)* %0, %1
-  %3 = sext i1 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
 }
 
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
@@ -4978,21 +5825,21 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
   %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
-  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
@@ -5007,28 +5854,28 @@ entry:
 ; <label>:13                                      ; preds = %8, %12
   %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
   %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
   %21 = load i32, i32 addrspace(1)* %20, align 8
   %22 = add i32 %21, 1
-  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
   store i32 %22, i32 addrspace(1)* %24
   %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
@@ -5039,27 +5886,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5077,7 +5924,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::Setup using LLILCJit
-Failed to read AppDomain.Setup[loadElem]
+Failed to read AppDomain.Setup[unbox]
 INFO:  jitting method Thread::GetDomain using LLILCJit
 Successfully read Thread.GetDomain
 
@@ -5108,8 +5955,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
@@ -5122,14 +5969,14 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
   %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
@@ -5141,11 +5988,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5173,8 +6020,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -5189,7 +6036,328 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
 Failed to read KeyCollection.System.Collections.Generic.IEnumerable<TKey>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Successfully read Enumerator.MoveNext
+
+define i8 @Enumerator.MoveNext(%"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.RuntimeTypeHandle* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*
+  %"$TypeArg" = alloca %System.RuntimeTypeHandle*
+  store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
+  %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 8
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %76, label %12
+
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
+  br label %76
+
+; <label>:13                                      ; preds = %85
+  %14 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck19 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %15
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, i32 0, i32 0
+  %17 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %16, align 8
+  %NullCheck21 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, i32 0, i32 2
+  %20 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %19, align 8
+  %21 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck23 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %22
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, i32 0, i32 2
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %NullCheck25 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 3, i32 %24
+  %NullCheck27 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %32
+
+; <label>:32                                      ; preds = %30
+  %33 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, i32 0, i32 2
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = icmp slt i32 %34, 0
+  br i1 %35, label %68, label %36
+
+; <label>:36                                      ; preds = %32
+  %37 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %38 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck29 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %39
+
+; <label>:39                                      ; preds = %36
+  %40 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, i32 0, i32 0
+  %41 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %40, align 8
+  %NullCheck31 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, i32 0, i32 2
+  %44 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %43, align 8
+  %45 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck33 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, i32 0, i32 2
+  %48 = load i32, i32 addrspace(1)* %47, align 8
+  %NullCheck35 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %49
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = zext i32 %51 to i64
+  %53 = zext i32 %48 to i64
+  %BoundsCheck37 = icmp uge i64 %53, %52
+  br i1 %BoundsCheck37, label %ThrowIndexOutOfRange38, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 3, i32 %48
+  %NullCheck39 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %56
+
+; <label>:56                                      ; preds = %54
+  %57 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, i32 0, i32 0
+  %58 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck41 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %59
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %60, %System.__Canon addrspace(1)* %58)
+  %61 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck43 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  %64 = load i32, i32 addrspace(1)* %63, align 8
+  %65 = add i32 %64, 1
+  %NullCheck45 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  store i32 %65, i32 addrspace(1)* %67
+  ret i8 1
+
+; <label>:68                                      ; preds = %32
+  %69 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck47 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %73 = add i32 %72, 1
+  %NullCheck49 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %74
+
+; <label>:74                                      ; preds = %70
+  %75 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  store i32 %73, i32 addrspace(1)* %75
+  br label %76
+
+; <label>:76                                      ; preds = %8, %12, %74
+  %77 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %78
+
+; <label>:78                                      ; preds = %76
+  %79 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, i32 0, i32 2
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck7 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %82
+
+; <label>:82                                      ; preds = %78
+  %83 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, i32 0, i32 0
+  %84 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %83, align 8
+  %NullCheck9 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %85
+
+; <label>:85                                      ; preds = %82
+  %86 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, i32 0, i32 7
+  %87 = load i32, i32 addrspace(1)* %86, align 8
+  %88 = icmp ult i32 %80, %87
+  br i1 %88, label %13, label %89
+
+; <label>:89                                      ; preds = %85
+  %90 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %91 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck11 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %92
+
+; <label>:92                                      ; preds = %89
+  %93 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, i32 0, i32 0
+  %94 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck13 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %95
+
+; <label>:95                                      ; preds = %92
+  %96 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, i32 0, i32 7
+  %97 = load i32, i32 addrspace(1)* %96, align 8
+  %98 = add i32 %97, 1
+  %NullCheck15 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %99
+
+; <label>:99                                      ; preds = %95
+  %100 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, i32 0, i32 2
+  store i32 %98, i32 addrspace(1)* %100
+  %101 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck17 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %102
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %103, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %92
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef22:                                   ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef24:                                   ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef26:                                   ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef28:                                   ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef30:                                   ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef32:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef34:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef36:                                   ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange38:                           ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef40:                                   ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef42:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef44:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef46:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef48:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef50:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -5200,8 +6368,8 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -5232,9 +6400,9 @@ Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
 Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
-Failed to read String.MakeSeparatorList[loadElemA]
+Failed to read String.MakeSeparatorList[storeElem]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
-Failed to read String.InternalSplitKeepEmptyEntries[loadElem]
+Failed to read String.InternalSplitKeepEmptyEntries[storeElem]
 INFO:  jitting method Path::IsRelative using LLILCJit
 Successfully read Path.IsRelative
 
@@ -5243,8 +6411,8 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -5254,8 +6422,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
@@ -5271,8 +6439,8 @@ entry:
 
 ; <label>:17                                      ; preds = %7
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
@@ -5288,8 +6456,8 @@ entry:
 
 ; <label>:29                                      ; preds = %19
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %31
 
 ; <label>:31                                      ; preds = %29
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
@@ -5300,8 +6468,8 @@ entry:
 
 ; <label>:36                                      ; preds = %31
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
-  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %37, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
@@ -5312,8 +6480,8 @@ entry:
 
 ; <label>:43                                      ; preds = %31, %38
   %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
-  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %45
 
 ; <label>:45                                      ; preds = %43
   %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
@@ -5324,8 +6492,8 @@ entry:
 
 ; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %50
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
@@ -5336,8 +6504,8 @@ entry:
 
 ; <label>:57                                      ; preds = %1, %7, %19, %45, %52
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
-  br i1 %NullCheck14, label %59, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %59
 
 ; <label>:59                                      ; preds = %57
   %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
@@ -5347,8 +6515,8 @@ entry:
 
 ; <label>:63                                      ; preds = %59
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
@@ -5359,8 +6527,8 @@ entry:
 
 ; <label>:70                                      ; preds = %65
   %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
-  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.String addrspace(1)* %71, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %72
 
 ; <label>:72                                      ; preds = %70
   %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
@@ -5379,39 +6547,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %17
+ThrowNullRef4:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %29
+ThrowNullRef6:                                    ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %36
+ThrowNullRef8:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %43
+ThrowNullRef10:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %50
+ThrowNullRef12:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %57
+ThrowNullRef14:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %63
+ThrowNullRef16:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %70
+ThrowNullRef18:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5419,7 +6587,293 @@ ThrowNullRef17:                                   ; preds = %70
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
-Failed to read String.TrimHelper[loadElem]
+Successfully read String.TrimHelper
+
+define %System.String addrspace(1)* @String.TrimHelper(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i16
+  %loc4 = alloca i32
+  %loc5 = alloca i16
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = sub i32 %3, 1
+  store i32 %4, i32* %loc0
+  store i32 0, i32* %loc1
+  %5 = load i32, i32* %arg2
+  %6 = icmp eq i32 %5, 1
+  br i1 %6, label %62, label %7
+
+; <label>:7                                       ; preds = %1
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:8                                       ; preds = %58
+  store i32 0, i32* %loc2
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load i32, i32* %loc1
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2, i32 %10
+  %13 = load i16, i16 addrspace(1)* %12
+  %14 = zext i16 %13 to i32
+  %15 = trunc i32 %14 to i16
+  store i16 %15, i16* %loc3
+  store i32 0, i32* %loc2
+  br label %34
+
+; <label>:16                                      ; preds = %37
+  %17 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %18 = load i32, i32* %loc2
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %17, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %19
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = zext i32 %18 to i64
+  %BoundsCheck = icmp uge i64 %23, %22
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %24
+
+; <label>:24                                      ; preds = %19
+  %25 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 3, i32 %18
+  %26 = load i16, i16 addrspace(1)* %25, align 8
+  %27 = zext i16 %26 to i32
+  %28 = load i16, i16* %loc3
+  %29 = zext i16 %28 to i32
+  %30 = icmp eq i32 %27, %29
+  br i1 %30, label %43, label %31
+
+; <label>:31                                      ; preds = %24
+  %32 = load i32, i32* %loc2
+  %33 = add i32 %32, 1
+  store i32 %33, i32* %loc2
+  br label %34
+
+; <label>:34                                      ; preds = %11, %31
+  %35 = load i32, i32* %loc2
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = icmp slt i32 %35, %41
+  br i1 %42, label %16, label %43
+
+; <label>:43                                      ; preds = %24, %37
+  %44 = load i32, i32* %loc2
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %45, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp eq i32 %44, %50
+  br i1 %51, label %62, label %52
+
+; <label>:52                                      ; preds = %46
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %7, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %57, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %58
+
+; <label>:58                                      ; preds = %55
+  %59 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %60 = load i32, i32 addrspace(1)* %59
+  %61 = icmp slt i32 %56, %60
+  br i1 %61, label %8, label %62
+
+; <label>:62                                      ; preds = %1, %46, %58
+  %63 = load i32, i32* %arg2
+  %64 = icmp eq i32 %63, 0
+  br i1 %64, label %122, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %66, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %67
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %66, i32 0, i32 1
+  %69 = load i32, i32 addrspace(1)* %68
+  %70 = sub i32 %69, 1
+  store i32 %70, i32* %loc0
+  br label %118
+
+; <label>:71                                      ; preds = %118
+  store i32 0, i32* %loc4
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %73 = load i32, i32* %loc0
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %74
+
+; <label>:74                                      ; preds = %71
+  %75 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 2, i32 %73
+  %76 = load i16, i16 addrspace(1)* %75
+  %77 = zext i16 %76 to i32
+  %78 = trunc i32 %77 to i16
+  store i16 %78, i16* %loc5
+  store i32 0, i32* %loc4
+  br label %97
+
+; <label>:79                                      ; preds = %100
+  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %81 = load i32, i32* %loc4
+  %NullCheck19 = icmp eq %"System.Char[]" addrspace(1)* %80, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
+
+; <label>:82                                      ; preds = %79
+  %83 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 1
+  %84 = load i32, i32 addrspace(1)* %83
+  %85 = zext i32 %84 to i64
+  %86 = zext i32 %81 to i64
+  %BoundsCheck21 = icmp uge i64 %86, %85
+  br i1 %BoundsCheck21, label %ThrowIndexOutOfRange22, label %87
+
+; <label>:87                                      ; preds = %82
+  %88 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 3, i32 %81
+  %89 = load i16, i16 addrspace(1)* %88, align 8
+  %90 = zext i16 %89 to i32
+  %91 = load i16, i16* %loc5
+  %92 = zext i16 %91 to i32
+  %93 = icmp eq i32 %90, %92
+  br i1 %93, label %106, label %94
+
+; <label>:94                                      ; preds = %87
+  %95 = load i32, i32* %loc4
+  %96 = add i32 %95, 1
+  store i32 %96, i32* %loc4
+  br label %97
+
+; <label>:97                                      ; preds = %74, %94
+  %98 = load i32, i32* %loc4
+  %99 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck15 = icmp eq %"System.Char[]" addrspace(1)* %99, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %100
+
+; <label>:100                                     ; preds = %97
+  %101 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %99, i32 0, i32 1
+  %102 = load i32, i32 addrspace(1)* %101
+  %103 = zext i32 %102 to i64
+  %104 = trunc i64 %103 to i32
+  %105 = icmp slt i32 %98, %104
+  br i1 %105, label %79, label %106
+
+; <label>:106                                     ; preds = %87, %100
+  %107 = load i32, i32* %loc4
+  %108 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck17 = icmp eq %"System.Char[]" addrspace(1)* %108, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %109
+
+; <label>:109                                     ; preds = %106
+  %110 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %108, i32 0, i32 1
+  %111 = load i32, i32 addrspace(1)* %110
+  %112 = zext i32 %111 to i64
+  %113 = trunc i64 %112 to i32
+  %114 = icmp eq i32 %107, %113
+  br i1 %114, label %122, label %115
+
+; <label>:115                                     ; preds = %109
+  %116 = load i32, i32* %loc0
+  %117 = sub i32 %116, 1
+  store i32 %117, i32* %loc0
+  br label %118
+
+; <label>:118                                     ; preds = %67, %115
+  %119 = load i32, i32* %loc0
+  %120 = load i32, i32* %loc1
+  %121 = icmp sge i32 %119, %120
+  br i1 %121, label %71, label %122
+
+; <label>:122                                     ; preds = %62, %109, %118
+  %123 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %124 = load i32, i32* %loc1
+  %125 = load i32, i32* %loc0
+  %126 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %123, i32 %124, i32 %125)
+  ret %System.String addrspace(1)* %126
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %97
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange22:                           ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
 Successfully read String.CreateTrimmedString
 
@@ -5439,8 +6893,8 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
@@ -5535,8 +6989,8 @@ entry:
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i64 2872
   %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
   %8 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %7
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %3
   %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
@@ -5553,8 +7007,8 @@ entry:
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 2864
   %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
   %21 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %20
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
-  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %22
 
 ; <label>:22                                      ; preds = %16
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
@@ -5569,7 +7023,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %16
+ThrowNullRef2:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5586,8 +7040,8 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5613,8 +7067,8 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
@@ -5632,8 +7086,8 @@ entry:
 
 ; <label>:12                                      ; preds = %4
   %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
@@ -5644,8 +7098,8 @@ entry:
 
 ; <label>:19                                      ; preds = %14
   %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %19
   %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
@@ -5660,21 +7114,21 @@ entry:
   %31 = zext i16 %30 to i32
   %32 = bitcast i8* %29 to i16*
   %33 = trunc i32 %31 to i16
-  %NullCheck6 = icmp ne i16* %32, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i16* %32, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %21
   store i16 %33, i16* %32, align 8
   %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %36
 
 ; <label>:36                                      ; preds = %34
   %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
   %38 = load i32, i32 addrspace(1)* %37, align 8
   %39 = add i32 %38, 1
-  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %40
 
 ; <label>:40                                      ; preds = %36
   %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
@@ -5683,16 +7137,16 @@ entry:
 
 ; <label>:42                                      ; preds = %14
   %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
-  br i1 %NullCheck12, label %44, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
   %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
   %47 = load i16, i16* %arg1
   %48 = zext i16 %47 to i32
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = trunc i32 %48 to i16
@@ -5703,31 +7157,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %19
+ThrowNullRef4:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %21
+ThrowNullRef6:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %36
+ThrowNullRef10:                                   ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %42
+ThrowNullRef12:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %44
+ThrowNullRef14:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5740,8 +7194,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -5752,8 +7206,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
@@ -5762,14 +7216,14 @@ entry:
 
 ; <label>:11                                      ; preds = %1
   %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
@@ -5779,15 +7233,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5808,8 +7262,8 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5822,8 +7276,8 @@ entry:
 
 ; <label>:8                                       ; preds = %3
   %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
@@ -5842,15 +7296,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
-  br i1 %NullCheck4, label %22, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
   %24 = load i16*, i16* addrspace(1)* %23, align 8
   %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %25, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
@@ -5859,8 +7313,8 @@ entry:
   store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
@@ -5874,8 +7328,8 @@ entry:
 
 ; <label>:37                                      ; preds = %65
   %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %37
   %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
@@ -5886,16 +7340,16 @@ entry:
   %45 = bitcast i16* %41 to i8*
   %46 = getelementptr inbounds i8, i8* %45, i64 %44
   %47 = bitcast i8* %46 to i16*
-  %NullCheck14 = icmp ne i16* %47, null
-  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %47, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %48
 
 ; <label>:48                                      ; preds = %39
   %49 = load i16, i16* %47, align 8
   %50 = zext i16 %49 to i32
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %52 = load i32, i32* %loc1
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %53
 
 ; <label>:53                                      ; preds = %48
   %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
@@ -5916,8 +7370,8 @@ entry:
 ; <label>:62                                      ; preds = %36, %59
   %63 = load i32, i32* %loc1
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck10, label %65, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %65
 
 ; <label>:65                                      ; preds = %62
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
@@ -5936,15 +7390,15 @@ entry:
 
 ; <label>:74                                      ; preds = %70
   %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
-  br i1 %NullCheck18, label %76, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %76
 
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
   %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
-  br i1 %NullCheck20, label %80, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
   %81 = load i64, i64 addrspace(1)* %79
@@ -5958,8 +7412,8 @@ entry:
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
   %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
-  br i1 %NullCheck22, label %92, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.String addrspace(1)* %90, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %92
 
 ; <label>:92                                      ; preds = %80
   %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
@@ -5969,15 +7423,15 @@ entry:
 
 ; <label>:96                                      ; preds = %70
   %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
-  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %98
 
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
   %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
-  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
   %103 = load i64, i64 addrspace(1)* %101
@@ -5991,8 +7445,8 @@ entry:
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
   %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
-  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.String addrspace(1)* %112, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %114
 
 ; <label>:114                                     ; preds = %102
   %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
@@ -6004,59 +7458,59 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %20
+ThrowNullRef4:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %22
+ThrowNullRef6:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %26
+ThrowNullRef8:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %62
+ThrowNullRef10:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %48
+ThrowNullRef16:                                   ; preds = %48
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %74
+ThrowNullRef18:                                   ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %76
+ThrowNullRef20:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %80
+ThrowNullRef22:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %96
+ThrowNullRef24:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %98
+ThrowNullRef26:                                   ; preds = %98
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %102
+ThrowNullRef28:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6069,15 +7523,15 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
   %3 = load i16*, i16* addrspace(1)* %2, align 8
   %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
@@ -6087,8 +7541,8 @@ entry:
   %10 = bitcast i16* %3 to i8*
   %11 = getelementptr inbounds i8, i8* %10, i64 %9
   %12 = bitcast i8* %11 to i16*
-  %NullCheck4 = icmp ne i16* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %5
   store i16 0, i16* %12, align 8
@@ -6098,11 +7552,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6119,8 +7573,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -6131,8 +7585,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
@@ -6144,15 +7598,15 @@ entry:
 
 ; <label>:14                                      ; preds = %1
   %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
   %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
   %21 = load i64, i64 addrspace(1)* %19
@@ -6171,15 +7625,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %14
+ThrowNullRef4:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %16
+ThrowNullRef6:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6302,14 +7756,6 @@ entry:
   ret %System.String addrspace(1)* %57
 }
 
-INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
-Successfully read RuntimeHelpers.get_OffsetToStringData
-
-define i32 @RuntimeHelpers.get_OffsetToStringData() {
-entry:
-  ret i32 12
-}
-
 INFO:  jitting method String::Equals using LLILCJit
 Successfully read String.Equals
 
@@ -6381,8 +7827,8 @@ entry:
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
-  br i1 %NullCheck24, label %29, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
   %30 = load i64, i64 addrspace(1)* %28
@@ -6397,8 +7843,8 @@ entry:
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
-  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
   %43 = load i64, i64 addrspace(1)* %41
@@ -6418,8 +7864,8 @@ entry:
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
   %59 = load i64, i64 addrspace(1)* %57
@@ -6434,8 +7880,8 @@ entry:
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck22, label %71, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
   %72 = load i64, i64 addrspace(1)* %70
@@ -6455,8 +7901,8 @@ entry:
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
-  br i1 %NullCheck16, label %87, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = load i64, i64 addrspace(1)* %86
@@ -6471,8 +7917,8 @@ entry:
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck18, label %100, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
   %101 = load i64, i64 addrspace(1)* %99
@@ -6492,8 +7938,8 @@ entry:
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
-  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
   %117 = load i64, i64 addrspace(1)* %115
@@ -6508,8 +7954,8 @@ entry:
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
-  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
   %130 = load i64, i64 addrspace(1)* %128
@@ -6528,15 +7974,15 @@ entry:
 
 ; <label>:142                                     ; preds = %22
   %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
-  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %143, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %144
 
 ; <label>:144                                     ; preds = %142
   %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
   %146 = load i32, i32 addrspace(1)* %145
   %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
-  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %147, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %148
 
 ; <label>:148                                     ; preds = %144
   %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
@@ -6557,15 +8003,15 @@ entry:
 
 ; <label>:159                                     ; preds = %22
   %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
-  br i1 %NullCheck, label %161, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %ThrowNullRef, label %161
 
 ; <label>:161                                     ; preds = %159
   %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
   %163 = load i32, i32 addrspace(1)* %162
   %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
-  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %164, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %165
 
 ; <label>:165                                     ; preds = %161
   %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
@@ -6578,8 +8024,8 @@ entry:
 
 ; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
-  br i1 %NullCheck4, label %172, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %171, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %172
 
 ; <label>:172                                     ; preds = %170
   %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
@@ -6589,8 +8035,8 @@ entry:
 
 ; <label>:176                                     ; preds = %172
   %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
-  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %177, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %178
 
 ; <label>:178                                     ; preds = %176
   %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
@@ -6629,55 +8075,55 @@ ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %161
+ThrowNullRef2:                                    ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %170
+ThrowNullRef4:                                    ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %176
+ThrowNullRef6:                                    ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %142
+ThrowNullRef8:                                    ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %144
+ThrowNullRef10:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %113
+ThrowNullRef12:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %116
+ThrowNullRef14:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %84
+ThrowNullRef16:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %87
+ThrowNullRef18:                                   ; preds = %87
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %55
+ThrowNullRef20:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %58
+ThrowNullRef22:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %26
+ThrowNullRef24:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %29
+ThrowNullRef26:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,8 +8161,8 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck, label %14, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %ThrowNullRef, label %14
 
 ; <label>:14                                      ; preds = %8
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
@@ -6760,8 +8206,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
@@ -6770,14 +8216,14 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32, i32* %loc0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %10
   %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
   %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
@@ -6790,15 +8236,15 @@ entry:
 ; <label>:25                                      ; preds = %19
   %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
-  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
   %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
@@ -6807,8 +8253,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %37 = load i32, i32* %loc0
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %38, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %38
 
 ; <label>:38                                      ; preds = %32
   %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
@@ -6817,14 +8263,14 @@ entry:
 
 ; <label>:40                                      ; preds = %19
   %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %40
   %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
   %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
-  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
-  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
@@ -6832,8 +8278,8 @@ entry:
   %48 = zext i32 %47 to i64
   %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
-  br i1 %NullCheck16, label %51, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %51
 
 ; <label>:51                                      ; preds = %45
   %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
@@ -6847,15 +8293,15 @@ entry:
 ; <label>:57                                      ; preds = %51
   %58 = load i16*, i16** %arg1
   %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
-  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %60
 
 ; <label>:60                                      ; preds = %57
   %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
   %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
-  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %64
 
 ; <label>:64                                      ; preds = %60
   %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
@@ -6864,22 +8310,22 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
   %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
-  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %70
 
 ; <label>:70                                      ; preds = %64
   %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
   %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
-  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
-  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
   %75 = load i32, i32 addrspace(1)* %74
   %76 = zext i32 %75 to i64
   %77 = trunc i64 %76 to i32
-  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
-  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %78
 
 ; <label>:78                                      ; preds = %73
   %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
@@ -6901,8 +8347,8 @@ entry:
   %90 = bitcast i16* %86 to i8*
   %91 = getelementptr inbounds i8, i8* %90, i64 %89
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %93
 
 ; <label>:93                                      ; preds = %80
   %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
@@ -6912,8 +8358,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %99 = load i32, i32* %loc2
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %100
 
 ; <label>:100                                     ; preds = %93
   %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
@@ -6928,63 +8374,63 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %25
+ThrowNullRef6:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %32
+ThrowNullRef10:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %40
+ThrowNullRef12:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %45
+ThrowNullRef16:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %57
+ThrowNullRef18:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %60
+ThrowNullRef20:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %64
+ThrowNullRef22:                                   ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %70
+ThrowNullRef24:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %73
+ThrowNullRef26:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %80
+ThrowNullRef28:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %93
+ThrowNullRef30:                                   ; preds = %93
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7004,8 +8450,8 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
@@ -7033,43 +8479,43 @@ entry:
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %14
   %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
   %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   %28 = load i32, i32 addrspace(1)* %27, align 8
   %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
-  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %30
 
 ; <label>:30                                      ; preds = %26
   %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
   %32 = load i32, i32 addrspace(1)* %31, align 8
   %33 = add i32 %28, %32
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %34
 
 ; <label>:34                                      ; preds = %30
   %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   store i32 %33, i32 addrspace(1)* %35
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
   store i32 0, i32 addrspace(1)* %38
   %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %40
 
 ; <label>:40                                      ; preds = %37
   %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
@@ -7082,8 +8528,8 @@ entry:
 
 ; <label>:47                                      ; preds = %40
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
@@ -7098,8 +8544,8 @@ entry:
   %54 = load i32, i32* %loc0
   %55 = sext i32 %54 to i64
   %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
-  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %57
 
 ; <label>:57                                      ; preds = %52
   %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
@@ -7110,68 +8556,35 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %14
+ThrowNullRef2:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %23
+ThrowNullRef4:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %26
+ThrowNullRef6:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %30
+ThrowNullRef8:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %34
+ThrowNullRef10:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %47
+ThrowNullRef14:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %52
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-}
-
-INFO:  jitting method StringBuilder::get_Length using LLILCJit
-Successfully read StringBuilder.get_Length
-
-define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.StringBuilder addrspace(1)*
-  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
-  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
-
-; <label>:1                                       ; preds = %entry
-  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %3 = load i32, i32 addrspace(1)* %2, align 8
-  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
-
-; <label>:5                                       ; preds = %1
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = add i32 %3, %7
-  ret i32 %8
-
-ThrowNullRef:                                     ; preds = %entry
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef16:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7213,70 +8626,70 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
   %6 = load i32, i32 addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
   store i32 %6, i32 addrspace(1)* %8
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
   %13 = load i32, i32 addrspace(1)* %12, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
   store i32 %13, i32 addrspace(1)* %15
   %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
-  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %18
 
 ; <label>:18                                      ; preds = %14
   %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
   %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
   %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
   %34 = load i32, i32 addrspace(1)* %33, align 8
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
-  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
@@ -7287,39 +8700,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %28
+ThrowNullRef16:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %32
+ThrowNullRef18:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7455,13 +8868,13 @@ entry:
 ; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
@@ -7477,16 +8890,16 @@ entry:
 
 ; <label>:18                                      ; preds = %15
   %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
   store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
   %22 = load i32, i32* %loc0
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %24
 
 ; <label>:24                                      ; preds = %20
   %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
@@ -7498,13 +8911,13 @@ entry:
 ; <label>:28                                      ; preds = %15, %24
   %29 = load i32, i32* %arg1
   %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %31
   %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
@@ -7517,20 +8930,20 @@ entry:
   %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
-  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
   %46 = load i32, i32 addrspace(1)* %45, align 8
   %47 = sub i32 %40, %46
-  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
-  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i32 addrspace(1)* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %48
 
 ; <label>:48                                      ; preds = %44
   store i32 %47, i32 addrspace(1)* %39, align 8
@@ -7538,21 +8951,21 @@ entry:
 
 ; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
-  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %51
 
 ; <label>:51                                      ; preds = %49
   %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %53
 
 ; <label>:53                                      ; preds = %51
   %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
   %55 = load i32, i32 addrspace(1)* %54, align 8
   %56 = load i32, i32* %arg2
   %57 = sub i32 %55, %56
-  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %58
 
 ; <label>:58                                      ; preds = %53
   %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
@@ -7562,13 +8975,13 @@ entry:
 ; <label>:60                                      ; preds = %33, %58
   %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
   %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
-  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %63
 
 ; <label>:63                                      ; preds = %60
   %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
-  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
-  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
@@ -7578,15 +8991,15 @@ entry:
 
 ; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
-  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i32 addrspace(1)* %69, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %70
 
 ; <label>:70                                      ; preds = %68
   %71 = load i32, i32 addrspace(1)* %69, align 8
   store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
-  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
@@ -7596,8 +9009,8 @@ entry:
   store i32 %77, i32* %loc4
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
-  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %80
 
 ; <label>:80                                      ; preds = %73
   %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
@@ -7607,71 +9020,71 @@ entry:
 ; <label>:83                                      ; preds = %80
   store i32 0, i32* %loc3
   %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
-  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
-  br i1 %NullCheck26, label %88, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i32 addrspace(1)* %87, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %88
 
 ; <label>:88                                      ; preds = %85
   %89 = load i32, i32 addrspace(1)* %87, align 8
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
-  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %90
 
 ; <label>:90                                      ; preds = %88
   %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
   store i32 %89, i32 addrspace(1)* %91
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
-  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
-  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %96
 
 ; <label>:96                                      ; preds = %94
   %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
-  br i1 %NullCheck34, label %100, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %100
 
 ; <label>:100                                     ; preds = %96
   %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
-  br i1 %NullCheck36, label %102, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %102
 
 ; <label>:102                                     ; preds = %100
   %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
   %104 = load i32, i32 addrspace(1)* %103, align 8
   %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
-  br i1 %NullCheck38, label %106, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %106
 
 ; <label>:106                                     ; preds = %102
   %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
-  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
-  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %108
 
 ; <label>:108                                     ; preds = %106
   %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
   %110 = load i32, i32 addrspace(1)* %109, align 8
   %111 = add i32 %104, %110
-  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %112
 
 ; <label>:112                                     ; preds = %108
   %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
   store i32 %111, i32 addrspace(1)* %113
   %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
-  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i32 addrspace(1)* %114, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %115
 
 ; <label>:115                                     ; preds = %112
   %116 = load i32, i32 addrspace(1)* %114, align 8
@@ -7681,19 +9094,19 @@ entry:
 ; <label>:118                                     ; preds = %115
   %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
-  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %121
 
 ; <label>:121                                     ; preds = %118
   %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
-  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
-  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %123
 
 ; <label>:123                                     ; preds = %121
   %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
   %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
-  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
-  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %126
 
 ; <label>:126                                     ; preds = %123
   %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
@@ -7705,8 +9118,8 @@ entry:
 
 ; <label>:130                                     ; preds = %80, %115, %126
   %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %132
 
 ; <label>:132                                     ; preds = %130
   %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7715,8 +9128,8 @@ entry:
   %136 = load i32, i32* %loc3
   %137 = sub i32 %135, %136
   %138 = sub i32 %134, %137
-  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %139
 
 ; <label>:139                                     ; preds = %132
   %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7728,16 +9141,16 @@ entry:
 
 ; <label>:144                                     ; preds = %139
   %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
-  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %146
 
 ; <label>:146                                     ; preds = %144
   %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
   %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
   %149 = load i32, i32* %loc2
   %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
-  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %151
 
 ; <label>:151                                     ; preds = %146
   %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
@@ -7754,145 +9167,249 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %18
+ThrowNullRef4:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %31
+ThrowNullRef10:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %44
+ThrowNullRef16:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %68
+ThrowNullRef18:                                   ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %70
+ThrowNullRef20:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %73
+ThrowNullRef22:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %83
+ThrowNullRef24:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %85
+ThrowNullRef26:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %88
+ThrowNullRef28:                                   ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %90
+ThrowNullRef30:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %94
+ThrowNullRef32:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %96
+ThrowNullRef34:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %100
+ThrowNullRef36:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %102
+ThrowNullRef38:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %106
+ThrowNullRef40:                                   ; preds = %106
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %108
+ThrowNullRef42:                                   ; preds = %108
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %112
+ThrowNullRef44:                                   ; preds = %112
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %118
+ThrowNullRef46:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %121
+ThrowNullRef48:                                   ; preds = %121
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %123
+ThrowNullRef50:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %130
+ThrowNullRef52:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %132
+ThrowNullRef54:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %144
+ThrowNullRef56:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %146
+ThrowNullRef58:                                   ; preds = %146
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %60
+ThrowNullRef60:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %63
+ThrowNullRef62:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %49
+ThrowNullRef64:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %51
+ThrowNullRef66:                                   ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %53
+ThrowNullRef68:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(%"System.Char[]" addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %arg0 = alloca %"System.Char[]" addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store %"System.Char[]" addrspace(1)* %param0, %"System.Char[]" addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load i32, i32* %arg4
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %43, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %38, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg1
+  %13 = load i32, i32* %arg4
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %38, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %24 = load i32, i32* %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %35 = load i32, i32* %arg3
+  %36 = load i32, i32* %arg4
+  %37 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %37, %"System.Char[]" addrspace(1)* %34, i32 %35, i32 %36)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:38                                      ; preds = %5, %16
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Successfully read Buffer._Memmove
 
@@ -7914,7 +9431,7 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[loadElem]
+Failed to read AppDomain.SetDataHelper[storeElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -7923,8 +9440,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
@@ -7934,8 +9451,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
@@ -7947,15 +9464,15 @@ entry:
   %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
   %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
@@ -7966,15 +9483,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7992,7 +9509,79 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
-Failed to read Dictionary`2.TryGetValue[loadElemA]
+Successfully read Dictionary`2.TryGetValue
+
+define i8 @"Dictionary`2.TryGetValue"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)* addrspace(1)* %param2) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  %arg2 = alloca %System.__Canon addrspace(1)* addrspace(1)*
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  store %System.__Canon addrspace(1)* addrspace(1)* %param2, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  store i32 %2, i32* %loc0
+  %3 = load i32, i32* %loc0
+  %4 = icmp slt i32 %3, 0
+  br i1 %4, label %22, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 2
+  %10 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %9, align 8
+  %11 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = zext i32 %11 to i64
+  %BoundsCheck = icmp uge i64 %16, %15
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 3, i32 %11
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %20, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %6, %System.__Canon addrspace(1)* %21)
+  ret i8 1
+
+; <label>:22                                      ; preds = %entry
+  %23 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %23, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -8058,8 +9647,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
@@ -8091,8 +9680,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
@@ -8171,15 +9760,15 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck, label %19, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %ThrowNullRef, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
   %21 = load i32, i32 addrspace(1)* %20
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
@@ -8202,7 +9791,7 @@ ThrowNullRef:                                     ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %19
+ThrowNullRef2:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8248,8 +9837,8 @@ entry:
   %0 = alloca %System.AppDomainHandle
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %1 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %1, i32 0, i32 15
@@ -8269,8 +9858,8 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
@@ -8286,7 +9875,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -8299,8 +9888,8 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -8327,8 +9916,8 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
@@ -8352,8 +9941,8 @@ entry:
   %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
   store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
@@ -8363,8 +9952,8 @@ entry:
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
@@ -8374,8 +9963,8 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %9
   %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
@@ -8384,8 +9973,8 @@ entry:
 
 ; <label>:18                                      ; preds = %3, %16
   %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
@@ -8397,15 +9986,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %18
+ThrowNullRef6:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8418,8 +10007,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
@@ -8453,15 +10042,15 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
@@ -8473,7 +10062,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8481,7 +10070,7 @@ ThrowNullRef1:                                    ; preds = %1
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
 Failed to read Dictionary`2.System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
@@ -8506,8 +10095,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
@@ -8524,8 +10113,8 @@ entry:
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -8544,7 +10133,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8577,8 +10166,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = load i64, i64* %arg2
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = trunc i32 %3 to i8
@@ -8634,46 +10223,46 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
   %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
-  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
-  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
-  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
@@ -8684,27 +10273,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %20
+ThrowNullRef12:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8717,8 +10306,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -8756,22 +10345,22 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
   %9 = load i64, i64 addrspace(1)* %8, align 8
   %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
   %13 = load i64, i64 addrspace(1)* %12, align 8
   %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %11
   %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
@@ -8788,11 +10377,11 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8882,8 +10471,8 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
@@ -8900,8 +10489,8 @@ entry:
 ; <label>:8                                       ; preds = %1
   %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
   %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
@@ -8911,15 +10500,15 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
   %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
   %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
-  br i1 %NullCheck6, label %21, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
@@ -8946,15 +10535,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8992,15 +10581,15 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
   store i8 %3, i8 addrspace(1)* %5
   %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
@@ -9011,7 +10600,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9027,8 +10616,8 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -9041,8 +10630,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
@@ -9058,7 +10647,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9080,8 +10669,8 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
@@ -9096,8 +10685,8 @@ entry:
 ; <label>:12                                      ; preds = %6
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
@@ -9112,8 +10701,8 @@ entry:
 ; <label>:21                                      ; preds = %15
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
@@ -9128,8 +10717,8 @@ entry:
 ; <label>:30                                      ; preds = %24
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %31, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
@@ -9144,8 +10733,8 @@ entry:
 ; <label>:39                                      ; preds = %33
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
-  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %40, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %42
 
 ; <label>:42                                      ; preds = %39
   %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
@@ -9164,19 +10753,19 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %21
+ThrowNullRef4:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %30
+ThrowNullRef6:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %39
+ThrowNullRef8:                                    ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9243,8 +10832,8 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
@@ -9264,57 +10853,57 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
   store i8 0, i8 addrspace(1)* %2
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
   store i8 0, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
   store i8 0, i8 addrspace(1)* %17
   %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
   store i8 0, i8 addrspace(1)* %20
   %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
-  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
@@ -9325,31 +10914,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %19
+ThrowNullRef14:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9367,8 +10956,8 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
@@ -9380,8 +10969,8 @@ entry:
 
 ; <label>:9                                       ; preds = %4
   %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %9
   %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
@@ -9395,7 +10984,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef2:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9420,8 +11009,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
@@ -9512,8 +11101,8 @@ entry:
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
@@ -9524,8 +11113,8 @@ entry:
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = load i64, i64 addrspace(1)* %12
@@ -9537,8 +11126,8 @@ entry:
   %20 = load i64, i64* %19
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
-  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %13
   %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
@@ -9555,8 +11144,8 @@ entry:
 ; <label>:30                                      ; preds = %25
   %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %32 = load i32, i32* %arg2
-  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
-  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
@@ -9570,15 +11159,15 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %30
+ThrowNullRef2:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9622,87 +11211,87 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
   %10 = load i8, i8 addrspace(1)* %9, align 8
   %11 = zext i8 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %8
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
   store i8 %12, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
   %19 = load i8, i8 addrspace(1)* %18, align 8
   %20 = zext i8 %19 to i32
   %21 = trunc i32 %20 to i8
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
   store i8 %21, i8 addrspace(1)* %23
   %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
   %28 = load i8, i8 addrspace(1)* %27, align 8
   %29 = zext i8 %28 to i32
   %30 = trunc i32 %29 to i8
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
-  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %31
 
 ; <label>:31                                      ; preds = %26
   %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
   store i8 %30, i8 addrspace(1)* %32
   %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
-  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
-  br i1 %NullCheck14, label %40, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %40
 
 ; <label>:40                                      ; preds = %35
   %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
   store i8 %39, i8 addrspace(1)* %41
   %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
-  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %44
 
 ; <label>:44                                      ; preds = %40
   %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
   %46 = load i8, i8 addrspace(1)* %45, align 8
   %47 = zext i8 %46 to i32
   %48 = trunc i32 %47 to i8
-  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
   store i8 %48, i8 addrspace(1)* %50
   %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
-  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
@@ -9713,29 +11302,29 @@ entry:
 ; <label>:56                                      ; preds = %52
   %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
-  br i1 %NullCheck22, label %59, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
   %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
   %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
-  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
-  br i1 %NullCheck24, label %63, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
   %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
-  br i1 %NullCheck26, label %66, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
   %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
-  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
-  br i1 %NullCheck28, label %69, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %69
 
 ; <label>:69                                      ; preds = %66
   %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
@@ -9744,15 +11333,15 @@ entry:
 
 ; <label>:71                                      ; preds = %105
   %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
-  br i1 %NullCheck34, label %73, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %73
 
 ; <label>:73                                      ; preds = %71
   %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
   %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
   %76 = load i32, i32* %loc0
-  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
-  br i1 %NullCheck36, label %77, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
@@ -9766,8 +11355,8 @@ entry:
 
 ; <label>:83                                      ; preds = %77
   %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
-  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
@@ -9775,14 +11364,14 @@ entry:
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
   %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
-  br i1 %NullCheck40, label %91, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
 ; <label>:91                                      ; preds = %85
   %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
   %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
-  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck42, label %94, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %94
 
 ; <label>:94                                      ; preds = %91
   %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
@@ -9798,14 +11387,14 @@ entry:
 ; <label>:99                                      ; preds = %69, %96
   %100 = load i32, i32* %loc0
   %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
-  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %102
 
 ; <label>:102                                     ; preds = %99
   %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
   %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
-  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
-  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
@@ -9819,87 +11408,87 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %26
+ThrowNullRef10:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %31
+ThrowNullRef12:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %35
+ThrowNullRef14:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %40
+ThrowNullRef16:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %56
+ThrowNullRef22:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %59
+ThrowNullRef24:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %63
+ThrowNullRef26:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %66
+ThrowNullRef28:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %102
+ThrowNullRef32:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %71
+ThrowNullRef34:                                   ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %73
+ThrowNullRef36:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %83
+ThrowNullRef38:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %85
+ThrowNullRef40:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %91
+ThrowNullRef42:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9943,15 +11532,15 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
   %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
@@ -9961,28 +11550,28 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
   %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %12
   %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
   %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
   %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
-  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
@@ -9993,23 +11582,23 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %12
+ThrowNullRef6:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10031,15 +11620,15 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
   %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = load i64, i64 addrspace(1)* %7
@@ -10077,13 +11666,13 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[loadElem]
+Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -10111,8 +11700,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -10179,8 +11768,8 @@ entry:
   %arg0 = alloca i32 addrspace(1)*
   store i32 addrspace(1)* %param0, i32 addrspace(1)** %arg0
   %0 = load i32 addrspace(1)*, i32 addrspace(1)** %arg0
-  %NullCheck = icmp ne i32 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i32 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   store i32 1, i32 addrspace(1)* %0, align 8

--- a/test/BaseLine/JIT/CodeGenBringUpTests/InitObj.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/InitObj.error.txt
@@ -25,8 +25,8 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
@@ -40,8 +40,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
   %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
@@ -75,7 +75,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -90,8 +90,8 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %NullCheck = icmp ne i8 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = load i8, i8 addrspace(1)* %0, align 8
@@ -125,8 +125,8 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
@@ -159,8 +159,8 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -184,8 +184,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
   store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
@@ -195,8 +195,8 @@ entry:
 ; <label>:4                                       ; preds = %1
   %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
   %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
@@ -206,8 +206,8 @@ entry:
   %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
@@ -221,14 +221,14 @@ entry:
 
 ; <label>:17                                      ; preds = %14
   %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
   %21 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
@@ -238,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -249,8 +249,8 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
@@ -261,27 +261,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %30
+ThrowNullRef10:                                   ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -301,7 +301,89 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
-Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
+Successfully read AppDomainSetup.GetUnsecureApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.GetUnsecureApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %NullCheck = icmp eq %"System.String[]" addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %BoundsCheck = icmp uge i64 0, %5
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %6
+
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 3, i32 0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
+  ret %System.String addrspace(1)* %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_Value using LLILCJit
+Successfully read AppDomainSetup.get_Value
+
+define %"System.String[]" addrspace(1)* @AppDomainSetup.get_Value(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.String[]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 18)
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.String[]" addrspace(1)* addrspace(1)*, %"System.String[]" addrspace(1)*)*)(%"System.String[]" addrspace(1)* addrspace(1)* %9, %"System.String[]" addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %11, i32 0, i32 1
+  %14 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %13, align 8
+  ret %"System.String[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -319,8 +401,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -368,16 +450,16 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
   %5 = load i32, i32 addrspace(1)* %4
   %6 = sub i32 %5, 1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -389,7 +471,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -421,8 +503,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
@@ -456,8 +538,8 @@ entry:
 ; <label>:27                                      ; preds = %19
   %28 = load i32, i32* %arg1
   %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
-  br i1 %NullCheck2, label %30, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %29, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %30
 
 ; <label>:30                                      ; preds = %27
   %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
@@ -493,8 +575,8 @@ entry:
 ; <label>:49                                      ; preds = %46
   %50 = load i32, i32* %arg2
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck4, label %52, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
@@ -517,11 +599,11 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %27
+ThrowNullRef2:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %49
+ThrowNullRef4:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -544,16 +626,16 @@ entry:
   %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %0)
   store %System.String addrspace(1)* %1, %System.String addrspace(1)** %loc0
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 2
   %5 = bitcast [0 x i16] addrspace(1)* %4 to i16 addrspace(1)*
   store i16 addrspace(1)* %5, i16 addrspace(1)** %loc1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %3
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2
@@ -580,7 +662,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -691,15 +773,15 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %NullCheck132 = icmp ne i8* %21, null
-  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+  %NullCheck131 = icmp eq i8* %21, null
+  br i1 %NullCheck131, label %ThrowNullRef132, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = load i8, i8* %21, align 8
   %24 = zext i8 %23 to i32
   %25 = trunc i32 %24 to i8
-  %NullCheck134 = icmp ne i8* %20, null
-  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+  %NullCheck133 = icmp eq i8* %20, null
+  br i1 %NullCheck133, label %ThrowNullRef134, label %26
 
 ; <label>:26                                      ; preds = %22
   store i8 %25, i8* %20, align 8
@@ -709,16 +791,16 @@ entry:
   %28 = load i8*, i8** %arg0
   %29 = load i8*, i8** %arg1
   %30 = bitcast i8* %29 to i16*
-  %NullCheck128 = icmp ne i16* %30, null
-  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+  %NullCheck127 = icmp eq i16* %30, null
+  br i1 %NullCheck127, label %ThrowNullRef128, label %31
 
 ; <label>:31                                      ; preds = %27
   %32 = load i16, i16* %30, align 8
   %33 = sext i16 %32 to i32
   %34 = bitcast i8* %28 to i16*
   %35 = trunc i32 %33 to i16
-  %NullCheck130 = icmp ne i16* %34, null
-  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+  %NullCheck129 = icmp eq i16* %34, null
+  br i1 %NullCheck129, label %ThrowNullRef130, label %36
 
 ; <label>:36                                      ; preds = %31
   store i16 %35, i16* %34, align 8
@@ -728,16 +810,16 @@ entry:
   %38 = load i8*, i8** %arg0
   %39 = load i8*, i8** %arg1
   %40 = bitcast i8* %39 to i16*
-  %NullCheck120 = icmp ne i16* %40, null
-  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+  %NullCheck119 = icmp eq i16* %40, null
+  br i1 %NullCheck119, label %ThrowNullRef120, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i16, i16* %40, align 8
   %43 = sext i16 %42 to i32
   %44 = bitcast i8* %38 to i16*
   %45 = trunc i32 %43 to i16
-  %NullCheck122 = icmp ne i16* %44, null
-  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+  %NullCheck121 = icmp eq i16* %44, null
+  br i1 %NullCheck121, label %ThrowNullRef122, label %46
 
 ; <label>:46                                      ; preds = %41
   store i16 %45, i16* %44, align 8
@@ -745,15 +827,15 @@ entry:
   %48 = getelementptr inbounds i8, i8* %47, i64 2
   %49 = load i8*, i8** %arg1
   %50 = getelementptr inbounds i8, i8* %49, i64 2
-  %NullCheck124 = icmp ne i8* %50, null
-  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+  %NullCheck123 = icmp eq i8* %50, null
+  br i1 %NullCheck123, label %ThrowNullRef124, label %51
 
 ; <label>:51                                      ; preds = %46
   %52 = load i8, i8* %50, align 8
   %53 = zext i8 %52 to i32
   %54 = trunc i32 %53 to i8
-  %NullCheck126 = icmp ne i8* %48, null
-  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+  %NullCheck125 = icmp eq i8* %48, null
+  br i1 %NullCheck125, label %ThrowNullRef126, label %55
 
 ; <label>:55                                      ; preds = %51
   store i8 %54, i8* %48, align 8
@@ -763,14 +845,14 @@ entry:
   %57 = load i8*, i8** %arg0
   %58 = load i8*, i8** %arg1
   %59 = bitcast i8* %58 to i32*
-  %NullCheck116 = icmp ne i32* %59, null
-  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+  %NullCheck115 = icmp eq i32* %59, null
+  br i1 %NullCheck115, label %ThrowNullRef116, label %60
 
 ; <label>:60                                      ; preds = %56
   %61 = load i32, i32* %59, align 8
   %62 = bitcast i8* %57 to i32*
-  %NullCheck118 = icmp ne i32* %62, null
-  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+  %NullCheck117 = icmp eq i32* %62, null
+  br i1 %NullCheck117, label %ThrowNullRef118, label %63
 
 ; <label>:63                                      ; preds = %60
   store i32 %61, i32* %62, align 8
@@ -780,14 +862,14 @@ entry:
   %65 = load i8*, i8** %arg0
   %66 = load i8*, i8** %arg1
   %67 = bitcast i8* %66 to i32*
-  %NullCheck108 = icmp ne i32* %67, null
-  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+  %NullCheck107 = icmp eq i32* %67, null
+  br i1 %NullCheck107, label %ThrowNullRef108, label %68
 
 ; <label>:68                                      ; preds = %64
   %69 = load i32, i32* %67, align 8
   %70 = bitcast i8* %65 to i32*
-  %NullCheck110 = icmp ne i32* %70, null
-  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+  %NullCheck109 = icmp eq i32* %70, null
+  br i1 %NullCheck109, label %ThrowNullRef110, label %71
 
 ; <label>:71                                      ; preds = %68
   store i32 %69, i32* %70, align 8
@@ -795,15 +877,15 @@ entry:
   %73 = getelementptr inbounds i8, i8* %72, i64 4
   %74 = load i8*, i8** %arg1
   %75 = getelementptr inbounds i8, i8* %74, i64 4
-  %NullCheck112 = icmp ne i8* %75, null
-  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+  %NullCheck111 = icmp eq i8* %75, null
+  br i1 %NullCheck111, label %ThrowNullRef112, label %76
 
 ; <label>:76                                      ; preds = %71
   %77 = load i8, i8* %75, align 8
   %78 = zext i8 %77 to i32
   %79 = trunc i32 %78 to i8
-  %NullCheck114 = icmp ne i8* %73, null
-  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+  %NullCheck113 = icmp eq i8* %73, null
+  br i1 %NullCheck113, label %ThrowNullRef114, label %80
 
 ; <label>:80                                      ; preds = %76
   store i8 %79, i8* %73, align 8
@@ -813,14 +895,14 @@ entry:
   %82 = load i8*, i8** %arg0
   %83 = load i8*, i8** %arg1
   %84 = bitcast i8* %83 to i32*
-  %NullCheck100 = icmp ne i32* %84, null
-  br i1 %NullCheck100, label %85, label %ThrowNullRef99
+  %NullCheck99 = icmp eq i32* %84, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %85
 
 ; <label>:85                                      ; preds = %81
   %86 = load i32, i32* %84, align 8
   %87 = bitcast i8* %82 to i32*
-  %NullCheck102 = icmp ne i32* %87, null
-  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+  %NullCheck101 = icmp eq i32* %87, null
+  br i1 %NullCheck101, label %ThrowNullRef102, label %88
 
 ; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
@@ -829,16 +911,16 @@ entry:
   %91 = load i8*, i8** %arg1
   %92 = getelementptr inbounds i8, i8* %91, i64 4
   %93 = bitcast i8* %92 to i16*
-  %NullCheck104 = icmp ne i16* %93, null
-  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+  %NullCheck103 = icmp eq i16* %93, null
+  br i1 %NullCheck103, label %ThrowNullRef104, label %94
 
 ; <label>:94                                      ; preds = %88
   %95 = load i16, i16* %93, align 8
   %96 = sext i16 %95 to i32
   %97 = bitcast i8* %90 to i16*
   %98 = trunc i32 %96 to i16
-  %NullCheck106 = icmp ne i16* %97, null
-  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+  %NullCheck105 = icmp eq i16* %97, null
+  br i1 %NullCheck105, label %ThrowNullRef106, label %99
 
 ; <label>:99                                      ; preds = %94
   store i16 %98, i16* %97, align 8
@@ -848,14 +930,14 @@ entry:
   %101 = load i8*, i8** %arg0
   %102 = load i8*, i8** %arg1
   %103 = bitcast i8* %102 to i32*
-  %NullCheck88 = icmp ne i32* %103, null
-  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+  %NullCheck87 = icmp eq i32* %103, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %104
 
 ; <label>:104                                     ; preds = %100
   %105 = load i32, i32* %103, align 8
   %106 = bitcast i8* %101 to i32*
-  %NullCheck90 = icmp ne i32* %106, null
-  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+  %NullCheck89 = icmp eq i32* %106, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %107
 
 ; <label>:107                                     ; preds = %104
   store i32 %105, i32* %106, align 8
@@ -864,16 +946,16 @@ entry:
   %110 = load i8*, i8** %arg1
   %111 = getelementptr inbounds i8, i8* %110, i64 4
   %112 = bitcast i8* %111 to i16*
-  %NullCheck92 = icmp ne i16* %112, null
-  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+  %NullCheck91 = icmp eq i16* %112, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %113
 
 ; <label>:113                                     ; preds = %107
   %114 = load i16, i16* %112, align 8
   %115 = sext i16 %114 to i32
   %116 = bitcast i8* %109 to i16*
   %117 = trunc i32 %115 to i16
-  %NullCheck94 = icmp ne i16* %116, null
-  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+  %NullCheck93 = icmp eq i16* %116, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %118
 
 ; <label>:118                                     ; preds = %113
   store i16 %117, i16* %116, align 8
@@ -881,15 +963,15 @@ entry:
   %120 = getelementptr inbounds i8, i8* %119, i64 6
   %121 = load i8*, i8** %arg1
   %122 = getelementptr inbounds i8, i8* %121, i64 6
-  %NullCheck96 = icmp ne i8* %122, null
-  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+  %NullCheck95 = icmp eq i8* %122, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %123
 
 ; <label>:123                                     ; preds = %118
   %124 = load i8, i8* %122, align 8
   %125 = zext i8 %124 to i32
   %126 = trunc i32 %125 to i8
-  %NullCheck98 = icmp ne i8* %120, null
-  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+  %NullCheck97 = icmp eq i8* %120, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %127
 
 ; <label>:127                                     ; preds = %123
   store i8 %126, i8* %120, align 8
@@ -899,14 +981,14 @@ entry:
   %129 = load i8*, i8** %arg0
   %130 = load i8*, i8** %arg1
   %131 = bitcast i8* %130 to i64*
-  %NullCheck84 = icmp ne i64* %131, null
-  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+  %NullCheck83 = icmp eq i64* %131, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %132
 
 ; <label>:132                                     ; preds = %128
   %133 = load i64, i64* %131, align 8
   %134 = bitcast i8* %129 to i64*
-  %NullCheck86 = icmp ne i64* %134, null
-  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+  %NullCheck85 = icmp eq i64* %134, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %135
 
 ; <label>:135                                     ; preds = %132
   store i64 %133, i64* %134, align 8
@@ -916,14 +998,14 @@ entry:
   %137 = load i8*, i8** %arg0
   %138 = load i8*, i8** %arg1
   %139 = bitcast i8* %138 to i64*
-  %NullCheck76 = icmp ne i64* %139, null
-  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+  %NullCheck75 = icmp eq i64* %139, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %140
 
 ; <label>:140                                     ; preds = %136
   %141 = load i64, i64* %139, align 8
   %142 = bitcast i8* %137 to i64*
-  %NullCheck78 = icmp ne i64* %142, null
-  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+  %NullCheck77 = icmp eq i64* %142, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %143
 
 ; <label>:143                                     ; preds = %140
   store i64 %141, i64* %142, align 8
@@ -931,15 +1013,15 @@ entry:
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %NullCheck80 = icmp ne i8* %147, null
-  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+  %NullCheck79 = icmp eq i8* %147, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %148
 
 ; <label>:148                                     ; preds = %143
   %149 = load i8, i8* %147, align 8
   %150 = zext i8 %149 to i32
   %151 = trunc i32 %150 to i8
-  %NullCheck82 = icmp ne i8* %145, null
-  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+  %NullCheck81 = icmp eq i8* %145, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %152
 
 ; <label>:152                                     ; preds = %148
   store i8 %151, i8* %145, align 8
@@ -949,14 +1031,14 @@ entry:
   %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
   %156 = bitcast i8* %155 to i64*
-  %NullCheck68 = icmp ne i64* %156, null
-  br i1 %NullCheck68, label %157, label %ThrowNullRef67
+  %NullCheck67 = icmp eq i64* %156, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %157
 
 ; <label>:157                                     ; preds = %153
   %158 = load i64, i64* %156, align 8
   %159 = bitcast i8* %154 to i64*
-  %NullCheck70 = icmp ne i64* %159, null
-  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+  %NullCheck69 = icmp eq i64* %159, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %160
 
 ; <label>:160                                     ; preds = %157
   store i64 %158, i64* %159, align 8
@@ -965,16 +1047,16 @@ entry:
   %163 = load i8*, i8** %arg1
   %164 = getelementptr inbounds i8, i8* %163, i64 8
   %165 = bitcast i8* %164 to i16*
-  %NullCheck72 = icmp ne i16* %165, null
-  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+  %NullCheck71 = icmp eq i16* %165, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %166
 
 ; <label>:166                                     ; preds = %160
   %167 = load i16, i16* %165, align 8
   %168 = sext i16 %167 to i32
   %169 = bitcast i8* %162 to i16*
   %170 = trunc i32 %168 to i16
-  %NullCheck74 = icmp ne i16* %169, null
-  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+  %NullCheck73 = icmp eq i16* %169, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %171
 
 ; <label>:171                                     ; preds = %166
   store i16 %170, i16* %169, align 8
@@ -984,14 +1066,14 @@ entry:
   %173 = load i8*, i8** %arg0
   %174 = load i8*, i8** %arg1
   %175 = bitcast i8* %174 to i64*
-  %NullCheck56 = icmp ne i64* %175, null
-  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+  %NullCheck55 = icmp eq i64* %175, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %176
 
 ; <label>:176                                     ; preds = %172
   %177 = load i64, i64* %175, align 8
   %178 = bitcast i8* %173 to i64*
-  %NullCheck58 = icmp ne i64* %178, null
-  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+  %NullCheck57 = icmp eq i64* %178, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %179
 
 ; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
@@ -1000,16 +1082,16 @@ entry:
   %182 = load i8*, i8** %arg1
   %183 = getelementptr inbounds i8, i8* %182, i64 8
   %184 = bitcast i8* %183 to i16*
-  %NullCheck60 = icmp ne i16* %184, null
-  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+  %NullCheck59 = icmp eq i16* %184, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %185
 
 ; <label>:185                                     ; preds = %179
   %186 = load i16, i16* %184, align 8
   %187 = sext i16 %186 to i32
   %188 = bitcast i8* %181 to i16*
   %189 = trunc i32 %187 to i16
-  %NullCheck62 = icmp ne i16* %188, null
-  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+  %NullCheck61 = icmp eq i16* %188, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %190
 
 ; <label>:190                                     ; preds = %185
   store i16 %189, i16* %188, align 8
@@ -1017,15 +1099,15 @@ entry:
   %192 = getelementptr inbounds i8, i8* %191, i64 10
   %193 = load i8*, i8** %arg1
   %194 = getelementptr inbounds i8, i8* %193, i64 10
-  %NullCheck64 = icmp ne i8* %194, null
-  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+  %NullCheck63 = icmp eq i8* %194, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %195
 
 ; <label>:195                                     ; preds = %190
   %196 = load i8, i8* %194, align 8
   %197 = zext i8 %196 to i32
   %198 = trunc i32 %197 to i8
-  %NullCheck66 = icmp ne i8* %192, null
-  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+  %NullCheck65 = icmp eq i8* %192, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %199
 
 ; <label>:199                                     ; preds = %195
   store i8 %198, i8* %192, align 8
@@ -1035,14 +1117,14 @@ entry:
   %201 = load i8*, i8** %arg0
   %202 = load i8*, i8** %arg1
   %203 = bitcast i8* %202 to i64*
-  %NullCheck48 = icmp ne i64* %203, null
-  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+  %NullCheck47 = icmp eq i64* %203, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %204
 
 ; <label>:204                                     ; preds = %200
   %205 = load i64, i64* %203, align 8
   %206 = bitcast i8* %201 to i64*
-  %NullCheck50 = icmp ne i64* %206, null
-  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+  %NullCheck49 = icmp eq i64* %206, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %207
 
 ; <label>:207                                     ; preds = %204
   store i64 %205, i64* %206, align 8
@@ -1051,14 +1133,14 @@ entry:
   %210 = load i8*, i8** %arg1
   %211 = getelementptr inbounds i8, i8* %210, i64 8
   %212 = bitcast i8* %211 to i32*
-  %NullCheck52 = icmp ne i32* %212, null
-  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+  %NullCheck51 = icmp eq i32* %212, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %213
 
 ; <label>:213                                     ; preds = %207
   %214 = load i32, i32* %212, align 8
   %215 = bitcast i8* %209 to i32*
-  %NullCheck54 = icmp ne i32* %215, null
-  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+  %NullCheck53 = icmp eq i32* %215, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %216
 
 ; <label>:216                                     ; preds = %213
   store i32 %214, i32* %215, align 8
@@ -1068,14 +1150,14 @@ entry:
   %218 = load i8*, i8** %arg0
   %219 = load i8*, i8** %arg1
   %220 = bitcast i8* %219 to i64*
-  %NullCheck36 = icmp ne i64* %220, null
-  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64* %220, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %221
 
 ; <label>:221                                     ; preds = %217
   %222 = load i64, i64* %220, align 8
   %223 = bitcast i8* %218 to i64*
-  %NullCheck38 = icmp ne i64* %223, null
-  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+  %NullCheck37 = icmp eq i64* %223, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %224
 
 ; <label>:224                                     ; preds = %221
   store i64 %222, i64* %223, align 8
@@ -1084,14 +1166,14 @@ entry:
   %227 = load i8*, i8** %arg1
   %228 = getelementptr inbounds i8, i8* %227, i64 8
   %229 = bitcast i8* %228 to i32*
-  %NullCheck40 = icmp ne i32* %229, null
-  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i32* %229, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %230
 
 ; <label>:230                                     ; preds = %224
   %231 = load i32, i32* %229, align 8
   %232 = bitcast i8* %226 to i32*
-  %NullCheck42 = icmp ne i32* %232, null
-  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+  %NullCheck41 = icmp eq i32* %232, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %233
 
 ; <label>:233                                     ; preds = %230
   store i32 %231, i32* %232, align 8
@@ -1099,15 +1181,15 @@ entry:
   %235 = getelementptr inbounds i8, i8* %234, i64 12
   %236 = load i8*, i8** %arg1
   %237 = getelementptr inbounds i8, i8* %236, i64 12
-  %NullCheck44 = icmp ne i8* %237, null
-  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i8* %237, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %238
 
 ; <label>:238                                     ; preds = %233
   %239 = load i8, i8* %237, align 8
   %240 = zext i8 %239 to i32
   %241 = trunc i32 %240 to i8
-  %NullCheck46 = icmp ne i8* %235, null
-  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+  %NullCheck45 = icmp eq i8* %235, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %242
 
 ; <label>:242                                     ; preds = %238
   store i8 %241, i8* %235, align 8
@@ -1117,14 +1199,14 @@ entry:
   %244 = load i8*, i8** %arg0
   %245 = load i8*, i8** %arg1
   %246 = bitcast i8* %245 to i64*
-  %NullCheck24 = icmp ne i64* %246, null
-  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64* %246, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %247
 
 ; <label>:247                                     ; preds = %243
   %248 = load i64, i64* %246, align 8
   %249 = bitcast i8* %244 to i64*
-  %NullCheck26 = icmp ne i64* %249, null
-  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64* %249, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %250
 
 ; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
@@ -1133,14 +1215,14 @@ entry:
   %253 = load i8*, i8** %arg1
   %254 = getelementptr inbounds i8, i8* %253, i64 8
   %255 = bitcast i8* %254 to i32*
-  %NullCheck28 = icmp ne i32* %255, null
-  br i1 %NullCheck28, label %256, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i32* %255, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %256
 
 ; <label>:256                                     ; preds = %250
   %257 = load i32, i32* %255, align 8
   %258 = bitcast i8* %252 to i32*
-  %NullCheck30 = icmp ne i32* %258, null
-  br i1 %NullCheck30, label %259, label %ThrowNullRef29
+  %NullCheck29 = icmp eq i32* %258, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %259
 
 ; <label>:259                                     ; preds = %256
   store i32 %257, i32* %258, align 8
@@ -1149,16 +1231,16 @@ entry:
   %262 = load i8*, i8** %arg1
   %263 = getelementptr inbounds i8, i8* %262, i64 12
   %264 = bitcast i8* %263 to i16*
-  %NullCheck32 = icmp ne i16* %264, null
-  br i1 %NullCheck32, label %265, label %ThrowNullRef31
+  %NullCheck31 = icmp eq i16* %264, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %265
 
 ; <label>:265                                     ; preds = %259
   %266 = load i16, i16* %264, align 8
   %267 = sext i16 %266 to i32
   %268 = bitcast i8* %261 to i16*
   %269 = trunc i32 %267 to i16
-  %NullCheck34 = icmp ne i16* %268, null
-  br i1 %NullCheck34, label %270, label %ThrowNullRef33
+  %NullCheck33 = icmp eq i16* %268, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %270
 
 ; <label>:270                                     ; preds = %265
   store i16 %269, i16* %268, align 8
@@ -1168,14 +1250,14 @@ entry:
   %272 = load i8*, i8** %arg0
   %273 = load i8*, i8** %arg1
   %274 = bitcast i8* %273 to i64*
-  %NullCheck8 = icmp ne i64* %274, null
-  br i1 %NullCheck8, label %275, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64* %274, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %275
 
 ; <label>:275                                     ; preds = %271
   %276 = load i64, i64* %274, align 8
   %277 = bitcast i8* %272 to i64*
-  %NullCheck10 = icmp ne i64* %277, null
-  br i1 %NullCheck10, label %278, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %277, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %278
 
 ; <label>:278                                     ; preds = %275
   store i64 %276, i64* %277, align 8
@@ -1184,14 +1266,14 @@ entry:
   %281 = load i8*, i8** %arg1
   %282 = getelementptr inbounds i8, i8* %281, i64 8
   %283 = bitcast i8* %282 to i32*
-  %NullCheck12 = icmp ne i32* %283, null
-  br i1 %NullCheck12, label %284, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i32* %283, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %284
 
 ; <label>:284                                     ; preds = %278
   %285 = load i32, i32* %283, align 8
   %286 = bitcast i8* %280 to i32*
-  %NullCheck14 = icmp ne i32* %286, null
-  br i1 %NullCheck14, label %287, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i32* %286, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %287
 
 ; <label>:287                                     ; preds = %284
   store i32 %285, i32* %286, align 8
@@ -1200,16 +1282,16 @@ entry:
   %290 = load i8*, i8** %arg1
   %291 = getelementptr inbounds i8, i8* %290, i64 12
   %292 = bitcast i8* %291 to i16*
-  %NullCheck16 = icmp ne i16* %292, null
-  br i1 %NullCheck16, label %293, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i16* %292, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %293
 
 ; <label>:293                                     ; preds = %287
   %294 = load i16, i16* %292, align 8
   %295 = sext i16 %294 to i32
   %296 = bitcast i8* %289 to i16*
   %297 = trunc i32 %295 to i16
-  %NullCheck18 = icmp ne i16* %296, null
-  br i1 %NullCheck18, label %298, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i16* %296, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %298
 
 ; <label>:298                                     ; preds = %293
   store i16 %297, i16* %296, align 8
@@ -1217,15 +1299,15 @@ entry:
   %300 = getelementptr inbounds i8, i8* %299, i64 14
   %301 = load i8*, i8** %arg1
   %302 = getelementptr inbounds i8, i8* %301, i64 14
-  %NullCheck20 = icmp ne i8* %302, null
-  br i1 %NullCheck20, label %303, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i8* %302, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %303
 
 ; <label>:303                                     ; preds = %298
   %304 = load i8, i8* %302, align 8
   %305 = zext i8 %304 to i32
   %306 = trunc i32 %305 to i8
-  %NullCheck22 = icmp ne i8* %300, null
-  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i8* %300, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %307
 
 ; <label>:307                                     ; preds = %303
   store i8 %306, i8* %300, align 8
@@ -1235,14 +1317,14 @@ entry:
   %309 = load i8*, i8** %arg0
   %310 = load i8*, i8** %arg1
   %311 = bitcast i8* %310 to i64*
-  %NullCheck = icmp ne i64* %311, null
-  br i1 %NullCheck, label %312, label %ThrowNullRef
+  %NullCheck = icmp eq i64* %311, null
+  br i1 %NullCheck, label %ThrowNullRef, label %312
 
 ; <label>:312                                     ; preds = %308
   %313 = load i64, i64* %311, align 8
   %314 = bitcast i8* %309 to i64*
-  %NullCheck2 = icmp ne i64* %314, null
-  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64* %314, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %315
 
 ; <label>:315                                     ; preds = %312
   store i64 %313, i64* %314, align 8
@@ -1251,14 +1333,14 @@ entry:
   %318 = load i8*, i8** %arg1
   %319 = getelementptr inbounds i8, i8* %318, i64 8
   %320 = bitcast i8* %319 to i64*
-  %NullCheck4 = icmp ne i64* %320, null
-  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64* %320, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %321
 
 ; <label>:321                                     ; preds = %315
   %322 = load i64, i64* %320, align 8
   %323 = bitcast i8* %317 to i64*
-  %NullCheck6 = icmp ne i64* %323, null
-  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64* %323, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %324
 
 ; <label>:324                                     ; preds = %321
   store i64 %322, i64* %323, align 8
@@ -1286,15 +1368,15 @@ entry:
 ; <label>:338                                     ; preds = %333
   %339 = load i8*, i8** %arg0
   %340 = load i8*, i8** %arg1
-  %NullCheck136 = icmp ne i8* %340, null
-  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+  %NullCheck135 = icmp eq i8* %340, null
+  br i1 %NullCheck135, label %ThrowNullRef136, label %341
 
 ; <label>:341                                     ; preds = %338
   %342 = load i8, i8* %340, align 8
   %343 = zext i8 %342 to i32
   %344 = trunc i32 %343 to i8
-  %NullCheck138 = icmp ne i8* %339, null
-  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+  %NullCheck137 = icmp eq i8* %339, null
+  br i1 %NullCheck137, label %ThrowNullRef138, label %345
 
 ; <label>:345                                     ; preds = %341
   store i8 %344, i8* %339, align 8
@@ -1317,16 +1399,16 @@ entry:
   %357 = load i8*, i8** %arg0
   %358 = load i8*, i8** %arg1
   %359 = bitcast i8* %358 to i16*
-  %NullCheck140 = icmp ne i16* %359, null
-  br i1 %NullCheck140, label %360, label %ThrowNullRef139
+  %NullCheck139 = icmp eq i16* %359, null
+  br i1 %NullCheck139, label %ThrowNullRef140, label %360
 
 ; <label>:360                                     ; preds = %356
   %361 = load i16, i16* %359, align 8
   %362 = sext i16 %361 to i32
   %363 = bitcast i8* %357 to i16*
   %364 = trunc i32 %362 to i16
-  %NullCheck142 = icmp ne i16* %363, null
-  br i1 %NullCheck142, label %365, label %ThrowNullRef141
+  %NullCheck141 = icmp eq i16* %363, null
+  br i1 %NullCheck141, label %ThrowNullRef142, label %365
 
 ; <label>:365                                     ; preds = %360
   store i16 %364, i16* %363, align 8
@@ -1352,14 +1434,14 @@ entry:
   %378 = load i8*, i8** %arg0
   %379 = load i8*, i8** %arg1
   %380 = bitcast i8* %379 to i32*
-  %NullCheck144 = icmp ne i32* %380, null
-  br i1 %NullCheck144, label %381, label %ThrowNullRef143
+  %NullCheck143 = icmp eq i32* %380, null
+  br i1 %NullCheck143, label %ThrowNullRef144, label %381
 
 ; <label>:381                                     ; preds = %377
   %382 = load i32, i32* %380, align 8
   %383 = bitcast i8* %378 to i32*
-  %NullCheck146 = icmp ne i32* %383, null
-  br i1 %NullCheck146, label %384, label %ThrowNullRef145
+  %NullCheck145 = icmp eq i32* %383, null
+  br i1 %NullCheck145, label %ThrowNullRef146, label %384
 
 ; <label>:384                                     ; preds = %381
   store i32 %382, i32* %383, align 8
@@ -1384,14 +1466,14 @@ entry:
   %395 = load i8*, i8** %arg0
   %396 = load i8*, i8** %arg1
   %397 = bitcast i8* %396 to i64*
-  %NullCheck164 = icmp ne i64* %397, null
-  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+  %NullCheck163 = icmp eq i64* %397, null
+  br i1 %NullCheck163, label %ThrowNullRef164, label %398
 
 ; <label>:398                                     ; preds = %394
   %399 = load i64, i64* %397, align 8
   %400 = bitcast i8* %395 to i64*
-  %NullCheck166 = icmp ne i64* %400, null
-  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+  %NullCheck165 = icmp eq i64* %400, null
+  br i1 %NullCheck165, label %ThrowNullRef166, label %401
 
 ; <label>:401                                     ; preds = %398
   store i64 %399, i64* %400, align 8
@@ -1400,14 +1482,14 @@ entry:
   %404 = load i8*, i8** %arg1
   %405 = getelementptr inbounds i8, i8* %404, i64 8
   %406 = bitcast i8* %405 to i64*
-  %NullCheck168 = icmp ne i64* %406, null
-  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+  %NullCheck167 = icmp eq i64* %406, null
+  br i1 %NullCheck167, label %ThrowNullRef168, label %407
 
 ; <label>:407                                     ; preds = %401
   %408 = load i64, i64* %406, align 8
   %409 = bitcast i8* %403 to i64*
-  %NullCheck170 = icmp ne i64* %409, null
-  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+  %NullCheck169 = icmp eq i64* %409, null
+  br i1 %NullCheck169, label %ThrowNullRef170, label %410
 
 ; <label>:410                                     ; preds = %407
   store i64 %408, i64* %409, align 8
@@ -1437,14 +1519,14 @@ entry:
   %425 = load i8*, i8** %arg0
   %426 = load i8*, i8** %arg1
   %427 = bitcast i8* %426 to i64*
-  %NullCheck148 = icmp ne i64* %427, null
-  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+  %NullCheck147 = icmp eq i64* %427, null
+  br i1 %NullCheck147, label %ThrowNullRef148, label %428
 
 ; <label>:428                                     ; preds = %424
   %429 = load i64, i64* %427, align 8
   %430 = bitcast i8* %425 to i64*
-  %NullCheck150 = icmp ne i64* %430, null
-  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+  %NullCheck149 = icmp eq i64* %430, null
+  br i1 %NullCheck149, label %ThrowNullRef150, label %431
 
 ; <label>:431                                     ; preds = %428
   store i64 %429, i64* %430, align 8
@@ -1466,14 +1548,14 @@ entry:
   %441 = load i8*, i8** %arg0
   %442 = load i8*, i8** %arg1
   %443 = bitcast i8* %442 to i32*
-  %NullCheck152 = icmp ne i32* %443, null
-  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+  %NullCheck151 = icmp eq i32* %443, null
+  br i1 %NullCheck151, label %ThrowNullRef152, label %444
 
 ; <label>:444                                     ; preds = %440
   %445 = load i32, i32* %443, align 8
   %446 = bitcast i8* %441 to i32*
-  %NullCheck154 = icmp ne i32* %446, null
-  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+  %NullCheck153 = icmp eq i32* %446, null
+  br i1 %NullCheck153, label %ThrowNullRef154, label %447
 
 ; <label>:447                                     ; preds = %444
   store i32 %445, i32* %446, align 8
@@ -1495,16 +1577,16 @@ entry:
   %457 = load i8*, i8** %arg0
   %458 = load i8*, i8** %arg1
   %459 = bitcast i8* %458 to i16*
-  %NullCheck156 = icmp ne i16* %459, null
-  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+  %NullCheck155 = icmp eq i16* %459, null
+  br i1 %NullCheck155, label %ThrowNullRef156, label %460
 
 ; <label>:460                                     ; preds = %456
   %461 = load i16, i16* %459, align 8
   %462 = sext i16 %461 to i32
   %463 = bitcast i8* %457 to i16*
   %464 = trunc i32 %462 to i16
-  %NullCheck158 = icmp ne i16* %463, null
-  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+  %NullCheck157 = icmp eq i16* %463, null
+  br i1 %NullCheck157, label %ThrowNullRef158, label %465
 
 ; <label>:465                                     ; preds = %460
   store i16 %464, i16* %463, align 8
@@ -1525,15 +1607,15 @@ entry:
 ; <label>:474                                     ; preds = %470
   %475 = load i8*, i8** %arg0
   %476 = load i8*, i8** %arg1
-  %NullCheck160 = icmp ne i8* %476, null
-  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+  %NullCheck159 = icmp eq i8* %476, null
+  br i1 %NullCheck159, label %ThrowNullRef160, label %477
 
 ; <label>:477                                     ; preds = %474
   %478 = load i8, i8* %476, align 8
   %479 = zext i8 %478 to i32
   %480 = trunc i32 %479 to i8
-  %NullCheck162 = icmp ne i8* %475, null
-  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+  %NullCheck161 = icmp eq i8* %475, null
+  br i1 %NullCheck161, label %ThrowNullRef162, label %481
 
 ; <label>:481                                     ; preds = %477
   store i8 %480, i8* %475, align 8
@@ -1553,343 +1635,343 @@ ThrowNullRef:                                     ; preds = %308
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %312
+ThrowNullRef2:                                    ; preds = %312
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %315
+ThrowNullRef4:                                    ; preds = %315
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %321
+ThrowNullRef6:                                    ; preds = %321
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %271
+ThrowNullRef8:                                    ; preds = %271
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %275
+ThrowNullRef10:                                   ; preds = %275
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %278
+ThrowNullRef12:                                   ; preds = %278
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %284
+ThrowNullRef14:                                   ; preds = %284
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %287
+ThrowNullRef16:                                   ; preds = %287
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %293
+ThrowNullRef18:                                   ; preds = %293
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %298
+ThrowNullRef20:                                   ; preds = %298
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %303
+ThrowNullRef22:                                   ; preds = %303
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %243
+ThrowNullRef24:                                   ; preds = %243
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %247
+ThrowNullRef26:                                   ; preds = %247
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %250
+ThrowNullRef28:                                   ; preds = %250
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %256
+ThrowNullRef30:                                   ; preds = %256
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %259
+ThrowNullRef32:                                   ; preds = %259
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %265
+ThrowNullRef34:                                   ; preds = %265
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %217
+ThrowNullRef36:                                   ; preds = %217
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %221
+ThrowNullRef38:                                   ; preds = %221
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %224
+ThrowNullRef40:                                   ; preds = %224
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %230
+ThrowNullRef42:                                   ; preds = %230
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %233
+ThrowNullRef44:                                   ; preds = %233
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %238
+ThrowNullRef46:                                   ; preds = %238
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %200
+ThrowNullRef48:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %204
+ThrowNullRef50:                                   ; preds = %204
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %207
+ThrowNullRef52:                                   ; preds = %207
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %213
+ThrowNullRef54:                                   ; preds = %213
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %172
+ThrowNullRef56:                                   ; preds = %172
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %176
+ThrowNullRef58:                                   ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %179
+ThrowNullRef60:                                   ; preds = %179
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %185
+ThrowNullRef62:                                   ; preds = %185
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %190
+ThrowNullRef64:                                   ; preds = %190
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %195
+ThrowNullRef66:                                   ; preds = %195
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %153
+ThrowNullRef68:                                   ; preds = %153
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %157
+ThrowNullRef70:                                   ; preds = %157
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %160
+ThrowNullRef72:                                   ; preds = %160
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %166
+ThrowNullRef74:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %136
+ThrowNullRef76:                                   ; preds = %136
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %140
+ThrowNullRef78:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %143
+ThrowNullRef80:                                   ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %148
+ThrowNullRef82:                                   ; preds = %148
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %128
+ThrowNullRef84:                                   ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %132
+ThrowNullRef86:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %100
+ThrowNullRef88:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %104
+ThrowNullRef90:                                   ; preds = %104
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %107
+ThrowNullRef92:                                   ; preds = %107
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %113
+ThrowNullRef94:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %118
+ThrowNullRef96:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %123
+ThrowNullRef98:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %81
+ThrowNullRef100:                                  ; preds = %81
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef101:                                  ; preds = %85
+ThrowNullRef102:                                  ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef103:                                  ; preds = %88
+ThrowNullRef104:                                  ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef105:                                  ; preds = %94
+ThrowNullRef106:                                  ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef107:                                  ; preds = %64
+ThrowNullRef108:                                  ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef109:                                  ; preds = %68
+ThrowNullRef110:                                  ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef111:                                  ; preds = %71
+ThrowNullRef112:                                  ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef113:                                  ; preds = %76
+ThrowNullRef114:                                  ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef115:                                  ; preds = %56
+ThrowNullRef116:                                  ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef117:                                  ; preds = %60
+ThrowNullRef118:                                  ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef119:                                  ; preds = %37
+ThrowNullRef120:                                  ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef121:                                  ; preds = %41
+ThrowNullRef122:                                  ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef123:                                  ; preds = %46
+ThrowNullRef124:                                  ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef125:                                  ; preds = %51
+ThrowNullRef126:                                  ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef127:                                  ; preds = %27
+ThrowNullRef128:                                  ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef129:                                  ; preds = %31
+ThrowNullRef130:                                  ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef131:                                  ; preds = %19
+ThrowNullRef132:                                  ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef133:                                  ; preds = %22
+ThrowNullRef134:                                  ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef135:                                  ; preds = %338
+ThrowNullRef136:                                  ; preds = %338
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef137:                                  ; preds = %341
+ThrowNullRef138:                                  ; preds = %341
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef139:                                  ; preds = %356
+ThrowNullRef140:                                  ; preds = %356
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef141:                                  ; preds = %360
+ThrowNullRef142:                                  ; preds = %360
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef143:                                  ; preds = %377
+ThrowNullRef144:                                  ; preds = %377
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef145:                                  ; preds = %381
+ThrowNullRef146:                                  ; preds = %381
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef147:                                  ; preds = %424
+ThrowNullRef148:                                  ; preds = %424
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef149:                                  ; preds = %428
+ThrowNullRef150:                                  ; preds = %428
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef151:                                  ; preds = %440
+ThrowNullRef152:                                  ; preds = %440
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef153:                                  ; preds = %444
+ThrowNullRef154:                                  ; preds = %444
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef155:                                  ; preds = %456
+ThrowNullRef156:                                  ; preds = %456
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef157:                                  ; preds = %460
+ThrowNullRef158:                                  ; preds = %460
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef159:                                  ; preds = %474
+ThrowNullRef160:                                  ; preds = %474
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef161:                                  ; preds = %477
+ThrowNullRef162:                                  ; preds = %477
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef163:                                  ; preds = %394
+ThrowNullRef164:                                  ; preds = %394
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef165:                                  ; preds = %398
+ThrowNullRef166:                                  ; preds = %398
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef167:                                  ; preds = %401
+ThrowNullRef168:                                  ; preds = %401
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef169:                                  ; preds = %407
+ThrowNullRef170:                                  ; preds = %407
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1939,8 +2021,8 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
-  br i1 %NullCheck, label %22, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %ThrowNullRef, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
@@ -1948,8 +2030,8 @@ entry:
   store i32 %24, i32* %loc0
   %25 = load i32, i32* %loc0
   %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %26, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %27
 
 ; <label>:27                                      ; preds = %22
   %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
@@ -1971,7 +2053,7 @@ ThrowNullRef:                                     ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1989,8 +2071,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -2022,15 +2104,15 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2048,16 +2130,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
   %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
   store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %15
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
@@ -2072,8 +2154,8 @@ entry:
   %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
   %29 = ptrtoint i16 addrspace(1)* %28 to i64
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %19
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
@@ -2089,19 +2171,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2114,8 +2196,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
@@ -2128,7 +2210,7 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[loadElem]
+Failed to read AppDomain.PrepareDataForSetup[storeElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
@@ -2202,8 +2284,8 @@ entry:
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
-  br i1 %NullCheck24, label %27, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = load i64, i64 addrspace(1)* %26
@@ -2218,8 +2300,8 @@ entry:
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
-  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
   %41 = load i64, i64 addrspace(1)* %39
@@ -2236,8 +2318,8 @@ entry:
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
-  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
   %54 = load i64, i64 addrspace(1)* %52
@@ -2252,8 +2334,8 @@ entry:
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
   %67 = load i64, i64 addrspace(1)* %65
@@ -2270,8 +2352,8 @@ entry:
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
-  br i1 %NullCheck16, label %79, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
   %80 = load i64, i64 addrspace(1)* %78
@@ -2286,8 +2368,8 @@ entry:
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
-  br i1 %NullCheck18, label %92, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
   %93 = load i64, i64 addrspace(1)* %91
@@ -2304,8 +2386,8 @@ entry:
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
-  br i1 %NullCheck12, label %105, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = load i64, i64 addrspace(1)* %104
@@ -2320,8 +2402,8 @@ entry:
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
-  br i1 %NullCheck14, label %118, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
   %119 = load i64, i64 addrspace(1)* %117
@@ -2337,8 +2419,8 @@ entry:
 
 ; <label>:128                                     ; preds = %20
   %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
-  br i1 %NullCheck4, label %130, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %129, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %130
 
 ; <label>:130                                     ; preds = %128
   %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
@@ -2346,8 +2428,8 @@ entry:
   %133 = load i16, i16 addrspace(1)* %132, align 8
   %134 = zext i16 %133 to i32
   %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
-  br i1 %NullCheck6, label %136, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %135, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %136
 
 ; <label>:136                                     ; preds = %130
   %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
@@ -2360,8 +2442,8 @@ entry:
 
 ; <label>:143                                     ; preds = %136
   %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
-  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %144, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %145
 
 ; <label>:145                                     ; preds = %143
   %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
@@ -2369,8 +2451,8 @@ entry:
   %148 = load i16, i16 addrspace(1)* %147, align 8
   %149 = zext i16 %148 to i32
   %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %150, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %151
 
 ; <label>:151                                     ; preds = %145
   %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
@@ -2388,8 +2470,8 @@ entry:
 
 ; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
-  br i1 %NullCheck, label %163, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %ThrowNullRef, label %163
 
 ; <label>:163                                     ; preds = %161
   %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
@@ -2399,8 +2481,8 @@ entry:
 
 ; <label>:167                                     ; preds = %163
   %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
-  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %168, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %169
 
 ; <label>:169                                     ; preds = %167
   %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
@@ -2432,55 +2514,55 @@ ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %167
+ThrowNullRef2:                                    ; preds = %167
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %128
+ThrowNullRef4:                                    ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %130
+ThrowNullRef6:                                    ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %143
+ThrowNullRef8:                                    ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %145
+ThrowNullRef10:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %102
+ThrowNullRef12:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %105
+ThrowNullRef14:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %76
+ThrowNullRef16:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %79
+ThrowNullRef18:                                   ; preds = %79
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %50
+ThrowNullRef20:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %53
+ThrowNullRef22:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %24
+ThrowNullRef24:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %27
+ThrowNullRef26:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2503,15 +2585,15 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2519,16 +2601,16 @@ entry:
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
   store i32 %8, i32* %loc0
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
   %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
   store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
@@ -2546,16 +2628,16 @@ entry:
 
 ; <label>:23                                      ; preds = %64
   %24 = load i16*, i16** %loc3
-  %NullCheck12 = icmp ne i16* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i16* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
   store i32 %27, i32* %loc5
   %28 = load i16*, i16** %loc4
-  %NullCheck14 = icmp ne i16* %28, null
-  br i1 %NullCheck14, label %29, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %28, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = load i16, i16* %28, align 8
@@ -2620,15 +2702,15 @@ entry:
 
 ; <label>:67                                      ; preds = %64
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
-  br i1 %NullCheck8, label %69, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %68, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %69
 
 ; <label>:69                                      ; preds = %67
   %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
   %71 = load i32, i32 addrspace(1)* %70
   %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
-  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %73
 
 ; <label>:73                                      ; preds = %69
   %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
@@ -2645,31 +2727,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %67
+ThrowNullRef8:                                    ; preds = %67
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %69
+ThrowNullRef10:                                   ; preds = %69
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2710,14 +2792,14 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
   %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
@@ -2730,14 +2812,14 @@ entry:
 
 ; <label>:11                                      ; preds = %4
   %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
   %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
@@ -2749,14 +2831,14 @@ entry:
 
 ; <label>:22                                      ; preds = %16
   %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
   %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
-  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
-  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
@@ -2804,23 +2886,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2836,7 +2918,280 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[loadElem]
+Successfully read RuntimeType.IsAssignableFrom
+
+define i8 @RuntimeType.IsAssignableFrom(%System.RuntimeType addrspace(1)* %param0, %System.Type addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.RuntimeType addrspace(1)*
+  %arg1 = alloca %System.Type addrspace(1)*
+  %loc0 = alloca %System.RuntimeType addrspace(1)*
+  %loc1 = alloca %"System.Type[]" addrspace(1)*
+  %loc2 = alloca i32
+  store %System.RuntimeType addrspace(1)* %param0, %System.RuntimeType addrspace(1)** %this
+  store %System.Type addrspace(1)* %param1, %System.Type addrspace(1)** %arg1
+  %0 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %1 = icmp ne %System.Type addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i8 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %5 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %6 = bitcast %System.Type addrspace(1)* %4 to %System.Object addrspace(1)*
+  %7 = bitcast %System.RuntimeType addrspace(1)* %5 to %System.Object addrspace(1)*
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %6, %System.Object addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %3
+  ret i8 1
+
+; <label>:12                                      ; preds = %3
+  %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 152
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 32
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
+  %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
+  %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
+  store %System.RuntimeType addrspace(1)* %25, %System.RuntimeType addrspace(1)** %loc0
+  %26 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %27 = icmp eq %System.RuntimeType addrspace(1)* %26, null
+  br i1 %27, label %34, label %28
+
+; <label>:28                                      ; preds = %15
+  %29 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %30 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)*)*)(%System.RuntimeType addrspace(1)* %29, %System.RuntimeType addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+; <label>:34                                      ; preds = %15
+  %35 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %36 = call %System.Reflection.Emit.TypeBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Reflection.Emit.TypeBuilder addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %35)
+  %37 = icmp eq %System.Reflection.Emit.TypeBuilder addrspace(1)* %36, null
+  br i1 %37, label %139, label %38
+
+; <label>:38                                      ; preds = %34
+  %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %42
+
+; <label>:42                                      ; preds = %38
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 152
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 40
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
+  %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
+  %53 = zext i8 %52 to i32
+  %54 = icmp eq i32 %53, 0
+  br i1 %54, label %56, label %55
+
+; <label>:55                                      ; preds = %42
+  ret i8 1
+
+; <label>:56                                      ; preds = %42
+  %57 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %58 = bitcast %System.RuntimeType addrspace(1)* %57 to %System.Type addrspace(1)*
+  %59 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %58)
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %64 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.Type addrspace(1)* %63, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = bitcast %System.RuntimeType addrspace(1)* %64 to %System.Type addrspace(1)*
+  %67 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %63, %System.Type addrspace(1)* %66)
+  %68 = zext i8 %67 to i32
+  %69 = trunc i32 %68 to i8
+  ret i8 %69
+
+; <label>:70                                      ; preds = %56
+  %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
+  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %73
+
+; <label>:73                                      ; preds = %70
+  %74 = load i64, i64 addrspace(1)* %72
+  %75 = add i64 %74, 128
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = add i64 %77, 0
+  %79 = inttoptr i64 %78 to i64*
+  %80 = load i64, i64* %79
+  %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
+  %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
+  %83 = call i8 %82(%System.Type addrspace(1)* %81)
+  %84 = zext i8 %83 to i32
+  %85 = icmp eq i32 %84, 0
+  br i1 %85, label %139, label %86
+
+; <label>:86                                      ; preds = %73
+  %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
+  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %89
+
+; <label>:89                                      ; preds = %86
+  %90 = load i64, i64 addrspace(1)* %88
+  %91 = add i64 %90, 128
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = add i64 %93, 24
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
+  %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
+  %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
+  store %"System.Type[]" addrspace(1)* %99, %"System.Type[]" addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %129
+
+; <label>:100                                     ; preds = %132
+  %101 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %102 = load i32, i32* %loc2
+  %NullCheck11 = icmp eq %"System.Type[]" addrspace(1)* %101, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %103
+
+; <label>:103                                     ; preds = %100
+  %104 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 1
+  %105 = load i32, i32 addrspace(1)* %104
+  %106 = zext i32 %105 to i64
+  %107 = zext i32 %102 to i64
+  %BoundsCheck = icmp uge i64 %107, %106
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %108
+
+; <label>:108                                     ; preds = %103
+  %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
+  %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
+  %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
+  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %113
+
+; <label>:113                                     ; preds = %108
+  %114 = load i64, i64 addrspace(1)* %112
+  %115 = add i64 %114, 152
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = add i64 %117, 56
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
+  %123 = zext i8 %122 to i32
+  %124 = icmp ne i32 %123, 0
+  br i1 %124, label %126, label %125
+
+; <label>:125                                     ; preds = %113
+  ret i8 0
+
+; <label>:126                                     ; preds = %113
+  %127 = load i32, i32* %loc2
+  %128 = add i32 %127, 1
+  store i32 %128, i32* %loc2
+  br label %129
+
+; <label>:129                                     ; preds = %89, %126
+  %130 = load i32, i32* %loc2
+  %131 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %NullCheck9 = icmp eq %"System.Type[]" addrspace(1)* %131, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %132
+
+; <label>:132                                     ; preds = %129
+  %133 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %131, i32 0, i32 1
+  %134 = load i32, i32 addrspace(1)* %133
+  %135 = zext i32 %134 to i64
+  %136 = trunc i64 %135 to i32
+  %137 = icmp slt i32 %130, %136
+  br i1 %137, label %100, label %138
+
+; <label>:138                                     ; preds = %132
+  ret i8 1
+
+; <label>:139                                     ; preds = %34, %73
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %129
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %103
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -2893,7 +3248,7 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElem]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -2904,8 +3259,8 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -2997,8 +3352,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
@@ -3059,8 +3414,8 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -3087,8 +3442,8 @@ entry:
 
 ; <label>:17                                      ; preds = %5, %11
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
@@ -3097,8 +3452,8 @@ entry:
 
 ; <label>:22                                      ; preds = %1, %11
   %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
@@ -3109,11 +3464,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %17
+ThrowNullRef2:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %22
+ThrowNullRef4:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3167,15 +3522,15 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
   %15 = load i32, i32 addrspace(1)* %14
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
@@ -3198,7 +3553,7 @@ ThrowNullRef:                                     ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef2:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3232,8 +3587,8 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
@@ -3312,8 +3667,8 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -3327,8 +3682,8 @@ entry:
 ; <label>:5                                       ; preds = %43
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %7 = load i32, i32* %loc1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck6, label %8, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
@@ -3366,8 +3721,8 @@ entry:
 ; <label>:32                                      ; preds = %21, %25
   %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
   %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
-  br i1 %NullCheck8, label %35, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = trunc i32 %34 to i16
@@ -3380,8 +3735,8 @@ entry:
 ; <label>:40                                      ; preds = %1, %35
   %41 = load i32, i32* %loc1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
-  br i1 %NullCheck2, label %43, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %42, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
@@ -3392,8 +3747,8 @@ entry:
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
   %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
-  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
   %51 = load i64, i64 addrspace(1)* %49
@@ -3412,19 +3767,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %40
+ThrowNullRef2:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %47
+ThrowNullRef4:                                    ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %5
+ThrowNullRef6:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %32
+ThrowNullRef8:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3467,8 +3822,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
@@ -3492,11 +3847,391 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(i16* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store i16* %param0, i16** %arg0
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load i32, i32* %arg3
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %42, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %37, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg2
+  %13 = load i32, i32* %arg3
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %37, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %24 = load i32, i32* %arg2
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load i16*, i16** %arg0
+  %35 = load i32, i32* %arg3
+  %36 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %36, i16* %34, i32 %35)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:37                                      ; preds = %5, %16
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %39)
+  %41 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41, %System.String addrspace(1)* %38, %System.String addrspace(1)* %40)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41) #0
+  unreachable
+
+; <label>:42                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
-Failed to read StringBuilder.ToString[loadElemA]
+Successfully read StringBuilder.ToString
+
+define %System.String addrspace(1)* @StringBuilder.ToString(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i16*
+  %loc3 = alloca %"System.Char[]" addrspace(1)*
+  %loc4 = alloca i32
+  %loc5 = alloca i32
+  %loc6 = alloca i16 addrspace(1)*
+  %loc7 = alloca %System.String addrspace(1)*
+  %loc8 = alloca %"System.Char[]" addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %0)
+  %2 = icmp ne i32 %1, 0
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %4
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %6)
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %7)
+  store %System.String addrspace(1)* %8, %System.String addrspace(1)** %loc0
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.Text.StringBuilder addrspace(1)* %9, %System.Text.StringBuilder addrspace(1)** %loc1
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  store %System.String addrspace(1)* %10, %System.String addrspace(1)** %loc7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc7
+  %12 = ptrtoint %System.String addrspace(1)* %11 to i64
+  %13 = icmp eq i64 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %5
+  %15 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %16 = sext i32 %15 to i64
+  %17 = add i64 %12, %16
+  br label %18
+
+; <label>:18                                      ; preds = %5, %14
+  %19 = phi i64 [ %12, %5 ], [ %17, %14 ]
+  %20 = inttoptr i64 %19 to i16*
+  store i16* %20, i16** %loc2
+  br label %21
+
+; <label>:21                                      ; preds = %98, %18
+  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %22, null
+  br i1 %NullCheck, label %ThrowNullRef, label %23
+
+; <label>:23                                      ; preds = %21
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 3
+  %25 = load i32, i32 addrspace(1)* %24, align 8
+  %26 = icmp sle i32 %25, 0
+  br i1 %26, label %96, label %27
+
+; <label>:27                                      ; preds = %23
+  %28 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %28, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %29
+
+; <label>:29                                      ; preds = %27
+  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %28, i32 0, i32 1
+  %31 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %30, align 8
+  store %"System.Char[]" addrspace(1)* %31, %"System.Char[]" addrspace(1)** %loc3
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %33
+
+; <label>:33                                      ; preds = %29
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  store i32 %35, i32* %loc4
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  %39 = load i32, i32 addrspace(1)* %38, align 8
+  store i32 %39, i32* %loc5
+  %40 = load i32, i32* %loc5
+  %41 = load i32, i32* %loc4
+  %42 = add i32 %40, %41
+  %43 = zext i32 %42 to i64
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %45
+
+; <label>:45                                      ; preds = %37
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = sext i32 %47 to i64
+  %49 = icmp sgt i64 %43, %48
+  br i1 %49, label %91, label %50
+
+; <label>:50                                      ; preds = %45
+  %51 = load i32, i32* %loc5
+  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %52, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %53
+
+; <label>:53                                      ; preds = %50
+  %54 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %52, i32 0, i32 1
+  %55 = load i32, i32 addrspace(1)* %54
+  %56 = zext i32 %55 to i64
+  %57 = trunc i64 %56 to i32
+  %58 = icmp ugt i32 %51, %57
+  br i1 %58, label %91, label %59
+
+; <label>:59                                      ; preds = %53
+  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  store %"System.Char[]" addrspace(1)* %60, %"System.Char[]" addrspace(1)** %loc8
+  %61 = icmp eq %"System.Char[]" addrspace(1)* %60, null
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %63, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %64
+
+; <label>:64                                      ; preds = %62
+  %65 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %63, i32 0, i32 1
+  %66 = load i32, i32 addrspace(1)* %65
+  %67 = zext i32 %66 to i64
+  %68 = trunc i64 %67 to i32
+  %69 = icmp ne i32 %68, 0
+  br i1 %69, label %71, label %70
+
+; <label>:70                                      ; preds = %59, %64
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:71                                      ; preds = %64
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %73
+
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %BoundsCheck = icmp uge i64 0, %76
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %77
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %78, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:79                                      ; preds = %70, %77
+  %80 = load i16*, i16** %loc2
+  %81 = load i32, i32* %loc4
+  %82 = sext i32 %81 to i64
+  %83 = mul i64 %82, 2
+  %84 = bitcast i16* %80 to i8*
+  %85 = getelementptr inbounds i8, i8* %84, i64 %83
+  %86 = load i16 addrspace(1)*, i16 addrspace(1)** %loc6
+  %87 = ptrtoint i16 addrspace(1)* %86 to i64
+  %88 = load i32, i32* %loc5
+  %89 = bitcast i8* %85 to i16*
+  %90 = inttoptr i64 %87 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %89, i16* %90, i32 %88)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %96
+
+; <label>:91                                      ; preds = %45, %53
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %94 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %93)
+  %95 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95, %System.String addrspace(1)* %92, %System.String addrspace(1)* %94)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95) #0
+  unreachable
+
+; <label>:96                                      ; preds = %23, %79
+  %97 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %97, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %98
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %97, i32 0, i32 2
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  store %System.Text.StringBuilder addrspace(1)* %100, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %102 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %102, label %21, label %103
+
+; <label>:103                                     ; preds = %98
+  store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc7
+  %104 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  ret %System.String addrspace(1)* %104
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method StringBuilder::get_Length using LLILCJit
+Successfully read StringBuilder.get_Length
+
+define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
+Successfully read RuntimeHelpers.get_OffsetToStringData
+
+define i32 @RuntimeHelpers.get_OffsetToStringData() {
+entry:
+  ret i32 12
+}
+
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
 Successfully read CultureData.CreateCultureData
 
@@ -3514,23 +4249,23 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
   store i8 %4, i8 addrspace(1)* %6
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
@@ -3549,11 +4284,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3566,50 +4301,50 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
   store i32 -1, i32 addrspace(1)* %2
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
   store i32 -1, i32 addrspace(1)* %8
   %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
   store i32 -1, i32 addrspace(1)* %14
   %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
   store i32 -1, i32 addrspace(1)* %17
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
@@ -3623,27 +4358,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3675,7 +4410,136 @@ Failed to read Dictionary`2.Insert[non-const derefAddress]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
 Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
-Failed to read HashHelpers.GetPrime[loadElem]
+Successfully read HashHelpers.GetPrime
+
+define i32 @HashHelpers.GetPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %6, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5, %System.String addrspace(1)* %4)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5) #0
+  unreachable
+
+; <label>:6                                       ; preds = %entry
+  store i32 0, i32* %loc0
+  br label %29
+
+; <label>:7                                       ; preds = %35
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 1296
+  %10 = addrspacecast i8 addrspace(1)* %9 to %"System.Int32[]" addrspace(1)**
+  %11 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %10
+  %12 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Int32[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = zext i32 %15 to i64
+  %17 = zext i32 %12 to i64
+  %BoundsCheck = icmp uge i64 %17, %16
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 3, i32 %12
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  store i32 %20, i32* %loc1
+  %21 = load i32, i32* %loc1
+  %22 = load i32, i32* %arg0
+  %23 = icmp slt i32 %21, %22
+  br i1 %23, label %26, label %24
+
+; <label>:24                                      ; preds = %18
+  %25 = load i32, i32* %loc1
+  ret i32 %25
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %loc0
+  %28 = add i32 %27, 1
+  store i32 %28, i32* %loc0
+  br label %29
+
+; <label>:29                                      ; preds = %6, %26
+  %30 = load i32, i32* %loc0
+  %31 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %32 = getelementptr inbounds i8, i8 addrspace(1)* %31, i64 1296
+  %33 = addrspacecast i8 addrspace(1)* %32 to %"System.Int32[]" addrspace(1)**
+  %34 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %33
+  %NullCheck = icmp eq %"System.Int32[]" addrspace(1)* %34, null
+  br i1 %NullCheck, label %ThrowNullRef, label %35
+
+; <label>:35                                      ; preds = %29
+  %36 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %34, i32 0, i32 1
+  %37 = load i32, i32 addrspace(1)* %36
+  %38 = zext i32 %37 to i64
+  %39 = trunc i64 %38 to i32
+  %40 = icmp slt i32 %30, %39
+  br i1 %40, label %7, label %41
+
+; <label>:41                                      ; preds = %35
+  %42 = load i32, i32* %arg0
+  %43 = or i32 %42, 1
+  store i32 %43, i32* %loc2
+  br label %59
+
+; <label>:44                                      ; preds = %59
+  %45 = load i32, i32* %loc2
+  %46 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %45)
+  %47 = zext i8 %46 to i32
+  %48 = icmp eq i32 %47, 0
+  br i1 %48, label %56, label %49
+
+; <label>:49                                      ; preds = %44
+  %50 = load i32, i32* %loc2
+  %51 = sub i32 %50, 1
+  %52 = srem i32 %51, 101
+  %53 = icmp eq i32 %52, 0
+  br i1 %53, label %56, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = load i32, i32* %loc2
+  ret i32 %55
+
+; <label>:56                                      ; preds = %44, %49
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %57, 2
+  store i32 %58, i32* %loc2
+  br label %59
+
+; <label>:59                                      ; preds = %41, %56
+  %60 = load i32, i32* %loc2
+  %61 = icmp slt i32 %60, 2147483647
+  br i1 %61, label %44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load i32, i32* %arg0
+  ret i32 %63
+
+ThrowNullRef:                                     ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
 Successfully read GenericEqualityComparer`1.GetHashCode
 
@@ -3694,14 +4558,14 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
   %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load i64, i64 addrspace(1)* %7
@@ -3720,7 +4584,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3750,8 +4614,8 @@ entry:
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
@@ -3796,8 +4660,8 @@ entry:
   %35 = bitcast i16* %34 to i8*
   %36 = getelementptr inbounds i8, i8* %35, i64 2
   %37 = bitcast i8* %36 to i16*
-  %NullCheck4 = icmp ne i16* %37, null
-  br i1 %NullCheck4, label %38, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %37, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %38
 
 ; <label>:38                                      ; preds = %27
   %39 = load i16, i16* %37, align 8
@@ -3824,8 +4688,8 @@ entry:
 
 ; <label>:54                                      ; preds = %22, %43
   %55 = load i16*, i16** %loc4
-  %NullCheck2 = icmp ne i16* %55, null
-  br i1 %NullCheck2, label %56, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i16* %55, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %56
 
 ; <label>:56                                      ; preds = %54
   %57 = load i16, i16* %55, align 8
@@ -3850,11 +4714,11 @@ ThrowNullRef:                                     ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %54
+ThrowNullRef2:                                    ; preds = %54
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %27
+ThrowNullRef4:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3871,8 +4735,8 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -3907,8 +4771,8 @@ entry:
 
 ; <label>:26                                      ; preds = %19
   %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
-  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %28
 
 ; <label>:28                                      ; preds = %26
   %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
@@ -3920,7 +4784,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3972,8 +4836,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
@@ -3984,26 +4848,26 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
-  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
@@ -4014,8 +4878,8 @@ entry:
 ; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
@@ -4024,8 +4888,8 @@ entry:
 
 ; <label>:25                                      ; preds = %1, %16, %23
   %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
-  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
@@ -4036,27 +4900,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %20
+ThrowNullRef10:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4069,8 +4933,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -4081,8 +4945,8 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
@@ -4091,8 +4955,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1, %8
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
@@ -4103,11 +4967,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4128,24 +4992,24 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   store i32 %3, i32* %loc0
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
   %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
   store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck4, label %9, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
@@ -4164,15 +5028,15 @@ entry:
 ; <label>:18                                      ; preds = %70
   %19 = load i16*, i16** %loc3
   %20 = bitcast i16* %19 to i64*
-  %NullCheck10 = icmp ne i64* %20, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %20, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = load i64, i64* %20, align 8
   %23 = load i16*, i16** %loc4
   %24 = bitcast i16* %23 to i64*
-  %NullCheck12 = icmp ne i64* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = load i64, i64* %24, align 8
@@ -4188,8 +5052,8 @@ entry:
   %31 = bitcast i16* %30 to i8*
   %32 = getelementptr inbounds i8, i8* %31, i64 8
   %33 = bitcast i8* %32 to i64*
-  %NullCheck14 = icmp ne i64* %33, null
-  br i1 %NullCheck14, label %34, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = load i64, i64* %33, align 8
@@ -4197,8 +5061,8 @@ entry:
   %37 = bitcast i16* %36 to i8*
   %38 = getelementptr inbounds i8, i8* %37, i64 8
   %39 = bitcast i8* %38 to i64*
-  %NullCheck16 = icmp ne i64* %39, null
-  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %40
 
 ; <label>:40                                      ; preds = %34
   %41 = load i64, i64* %39, align 8
@@ -4214,8 +5078,8 @@ entry:
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %NullCheck18 = icmp ne i64* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = load i64, i64* %48, align 8
@@ -4223,8 +5087,8 @@ entry:
   %52 = bitcast i16* %51 to i8*
   %53 = getelementptr inbounds i8, i8* %52, i64 16
   %54 = bitcast i8* %53 to i64*
-  %NullCheck20 = icmp ne i64* %54, null
-  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64* %54, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %55
 
 ; <label>:55                                      ; preds = %49
   %56 = load i64, i64* %54, align 8
@@ -4262,15 +5126,15 @@ entry:
 ; <label>:74                                      ; preds = %95
   %75 = load i16*, i16** %loc3
   %76 = bitcast i16* %75 to i32*
-  %NullCheck6 = icmp ne i32* %76, null
-  br i1 %NullCheck6, label %77, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32* %76, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %77
 
 ; <label>:77                                      ; preds = %74
   %78 = load i32, i32* %76, align 8
   %79 = load i16*, i16** %loc4
   %80 = bitcast i16* %79 to i32*
-  %NullCheck8 = icmp ne i32* %80, null
-  br i1 %NullCheck8, label %81, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i32* %80, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %81
 
 ; <label>:81                                      ; preds = %77
   %82 = load i32, i32* %80, align 8
@@ -4318,43 +5182,43 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %74
+ThrowNullRef6:                                    ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %77
+ThrowNullRef8:                                    ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %29
+ThrowNullRef14:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %34
+ThrowNullRef16:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4376,8 +5240,8 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load i64, i64 addrspace(1)* %4
@@ -4389,8 +5253,8 @@ entry:
   %12 = load i64, i64* %11
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %5
   %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
@@ -4399,8 +5263,8 @@ entry:
   %18 = load i8, i8* %arg2
   %19 = zext i8 %18 to i32
   %20 = trunc i32 %19 to i8
-  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %15
   %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
@@ -4411,11 +5275,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4442,8 +5306,8 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
@@ -4466,16 +5330,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
   %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = load i64, i64 addrspace(1)* %19
@@ -4500,8 +5364,8 @@ entry:
 ; <label>:35                                      ; preds = %30
   %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
@@ -4514,8 +5378,8 @@ entry:
 
 ; <label>:42                                      ; preds = %1, %38
   %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
-  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
@@ -4526,19 +5390,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %35
+ThrowNullRef2:                                    ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %42
+ThrowNullRef8:                                    ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4551,14 +5415,14 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
@@ -4570,7 +5434,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4583,8 +5447,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
@@ -4613,51 +5477,51 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
   %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
   %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
   %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
   %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
-  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
   store i64 %21, i64 addrspace(1)* %23
   %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %25 = load i64, i64* %loc0
-  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
@@ -4668,27 +5532,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %22
+ThrowNullRef12:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4701,8 +5565,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
@@ -4713,19 +5577,19 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
@@ -4734,8 +5598,8 @@ entry:
 
 ; <label>:15                                      ; preds = %1, %13
   %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
@@ -4746,19 +5610,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %15
+ThrowNullRef8:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4771,8 +5635,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -4831,8 +5695,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
@@ -4882,8 +5746,8 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
-  br i1 %NullCheck, label %17, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %ThrowNullRef, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
@@ -4894,15 +5758,15 @@ entry:
 
 ; <label>:22                                      ; preds = %17
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
-  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
   %26 = load i32, i32 addrspace(1)* %25
   %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
-  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %27, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
@@ -4925,8 +5789,8 @@ entry:
 ; <label>:40                                      ; preds = %17
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
-  br i1 %NullCheck6, label %43, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %41, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
@@ -4938,34 +5802,17 @@ ThrowNullRef:                                     ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %24
+ThrowNullRef4:                                    ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %40
+ThrowNullRef6:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
-}
-
-INFO:  jitting method Object::ReferenceEquals using LLILCJit
-Successfully read Object.ReferenceEquals
-
-define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
-entry:
-  %arg0 = alloca %System.Object addrspace(1)*
-  %arg1 = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
-  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
-  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = icmp eq %System.Object addrspace(1)* %0, %1
-  %3 = sext i1 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
 }
 
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
@@ -4978,21 +5825,21 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
   %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
-  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
@@ -5007,28 +5854,28 @@ entry:
 ; <label>:13                                      ; preds = %8, %12
   %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
   %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
   %21 = load i32, i32 addrspace(1)* %20, align 8
   %22 = add i32 %21, 1
-  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
   store i32 %22, i32 addrspace(1)* %24
   %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
@@ -5039,27 +5886,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5077,7 +5924,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::Setup using LLILCJit
-Failed to read AppDomain.Setup[loadElem]
+Failed to read AppDomain.Setup[unbox]
 INFO:  jitting method Thread::GetDomain using LLILCJit
 Successfully read Thread.GetDomain
 
@@ -5108,8 +5955,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
@@ -5122,14 +5969,14 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
   %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
@@ -5141,11 +5988,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5173,8 +6020,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -5189,7 +6036,328 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
 Failed to read KeyCollection.System.Collections.Generic.IEnumerable<TKey>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Successfully read Enumerator.MoveNext
+
+define i8 @Enumerator.MoveNext(%"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.RuntimeTypeHandle* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*
+  %"$TypeArg" = alloca %System.RuntimeTypeHandle*
+  store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
+  %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 8
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %76, label %12
+
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
+  br label %76
+
+; <label>:13                                      ; preds = %85
+  %14 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck19 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %15
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, i32 0, i32 0
+  %17 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %16, align 8
+  %NullCheck21 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, i32 0, i32 2
+  %20 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %19, align 8
+  %21 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck23 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %22
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, i32 0, i32 2
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %NullCheck25 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 3, i32 %24
+  %NullCheck27 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %32
+
+; <label>:32                                      ; preds = %30
+  %33 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, i32 0, i32 2
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = icmp slt i32 %34, 0
+  br i1 %35, label %68, label %36
+
+; <label>:36                                      ; preds = %32
+  %37 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %38 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck29 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %39
+
+; <label>:39                                      ; preds = %36
+  %40 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, i32 0, i32 0
+  %41 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %40, align 8
+  %NullCheck31 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, i32 0, i32 2
+  %44 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %43, align 8
+  %45 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck33 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, i32 0, i32 2
+  %48 = load i32, i32 addrspace(1)* %47, align 8
+  %NullCheck35 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %49
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = zext i32 %51 to i64
+  %53 = zext i32 %48 to i64
+  %BoundsCheck37 = icmp uge i64 %53, %52
+  br i1 %BoundsCheck37, label %ThrowIndexOutOfRange38, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 3, i32 %48
+  %NullCheck39 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %56
+
+; <label>:56                                      ; preds = %54
+  %57 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, i32 0, i32 0
+  %58 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck41 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %59
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %60, %System.__Canon addrspace(1)* %58)
+  %61 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck43 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  %64 = load i32, i32 addrspace(1)* %63, align 8
+  %65 = add i32 %64, 1
+  %NullCheck45 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  store i32 %65, i32 addrspace(1)* %67
+  ret i8 1
+
+; <label>:68                                      ; preds = %32
+  %69 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck47 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %73 = add i32 %72, 1
+  %NullCheck49 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %74
+
+; <label>:74                                      ; preds = %70
+  %75 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  store i32 %73, i32 addrspace(1)* %75
+  br label %76
+
+; <label>:76                                      ; preds = %8, %12, %74
+  %77 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %78
+
+; <label>:78                                      ; preds = %76
+  %79 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, i32 0, i32 2
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck7 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %82
+
+; <label>:82                                      ; preds = %78
+  %83 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, i32 0, i32 0
+  %84 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %83, align 8
+  %NullCheck9 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %85
+
+; <label>:85                                      ; preds = %82
+  %86 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, i32 0, i32 7
+  %87 = load i32, i32 addrspace(1)* %86, align 8
+  %88 = icmp ult i32 %80, %87
+  br i1 %88, label %13, label %89
+
+; <label>:89                                      ; preds = %85
+  %90 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %91 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck11 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %92
+
+; <label>:92                                      ; preds = %89
+  %93 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, i32 0, i32 0
+  %94 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck13 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %95
+
+; <label>:95                                      ; preds = %92
+  %96 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, i32 0, i32 7
+  %97 = load i32, i32 addrspace(1)* %96, align 8
+  %98 = add i32 %97, 1
+  %NullCheck15 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %99
+
+; <label>:99                                      ; preds = %95
+  %100 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, i32 0, i32 2
+  store i32 %98, i32 addrspace(1)* %100
+  %101 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck17 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %102
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %103, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %92
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef22:                                   ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef24:                                   ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef26:                                   ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef28:                                   ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef30:                                   ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef32:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef34:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef36:                                   ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange38:                           ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef40:                                   ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef42:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef44:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef46:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef48:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef50:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -5200,8 +6368,8 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -5232,9 +6400,9 @@ Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
 Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
-Failed to read String.MakeSeparatorList[loadElemA]
+Failed to read String.MakeSeparatorList[storeElem]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
-Failed to read String.InternalSplitKeepEmptyEntries[loadElem]
+Failed to read String.InternalSplitKeepEmptyEntries[storeElem]
 INFO:  jitting method Path::IsRelative using LLILCJit
 Successfully read Path.IsRelative
 
@@ -5243,8 +6411,8 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -5254,8 +6422,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
@@ -5271,8 +6439,8 @@ entry:
 
 ; <label>:17                                      ; preds = %7
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
@@ -5288,8 +6456,8 @@ entry:
 
 ; <label>:29                                      ; preds = %19
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %31
 
 ; <label>:31                                      ; preds = %29
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
@@ -5300,8 +6468,8 @@ entry:
 
 ; <label>:36                                      ; preds = %31
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
-  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %37, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
@@ -5312,8 +6480,8 @@ entry:
 
 ; <label>:43                                      ; preds = %31, %38
   %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
-  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %45
 
 ; <label>:45                                      ; preds = %43
   %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
@@ -5324,8 +6492,8 @@ entry:
 
 ; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %50
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
@@ -5336,8 +6504,8 @@ entry:
 
 ; <label>:57                                      ; preds = %1, %7, %19, %45, %52
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
-  br i1 %NullCheck14, label %59, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %59
 
 ; <label>:59                                      ; preds = %57
   %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
@@ -5347,8 +6515,8 @@ entry:
 
 ; <label>:63                                      ; preds = %59
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
@@ -5359,8 +6527,8 @@ entry:
 
 ; <label>:70                                      ; preds = %65
   %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
-  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.String addrspace(1)* %71, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %72
 
 ; <label>:72                                      ; preds = %70
   %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
@@ -5379,39 +6547,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %17
+ThrowNullRef4:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %29
+ThrowNullRef6:                                    ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %36
+ThrowNullRef8:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %43
+ThrowNullRef10:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %50
+ThrowNullRef12:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %57
+ThrowNullRef14:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %63
+ThrowNullRef16:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %70
+ThrowNullRef18:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5419,7 +6587,293 @@ ThrowNullRef17:                                   ; preds = %70
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
-Failed to read String.TrimHelper[loadElem]
+Successfully read String.TrimHelper
+
+define %System.String addrspace(1)* @String.TrimHelper(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i16
+  %loc4 = alloca i32
+  %loc5 = alloca i16
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = sub i32 %3, 1
+  store i32 %4, i32* %loc0
+  store i32 0, i32* %loc1
+  %5 = load i32, i32* %arg2
+  %6 = icmp eq i32 %5, 1
+  br i1 %6, label %62, label %7
+
+; <label>:7                                       ; preds = %1
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:8                                       ; preds = %58
+  store i32 0, i32* %loc2
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load i32, i32* %loc1
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2, i32 %10
+  %13 = load i16, i16 addrspace(1)* %12
+  %14 = zext i16 %13 to i32
+  %15 = trunc i32 %14 to i16
+  store i16 %15, i16* %loc3
+  store i32 0, i32* %loc2
+  br label %34
+
+; <label>:16                                      ; preds = %37
+  %17 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %18 = load i32, i32* %loc2
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %17, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %19
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = zext i32 %18 to i64
+  %BoundsCheck = icmp uge i64 %23, %22
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %24
+
+; <label>:24                                      ; preds = %19
+  %25 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 3, i32 %18
+  %26 = load i16, i16 addrspace(1)* %25, align 8
+  %27 = zext i16 %26 to i32
+  %28 = load i16, i16* %loc3
+  %29 = zext i16 %28 to i32
+  %30 = icmp eq i32 %27, %29
+  br i1 %30, label %43, label %31
+
+; <label>:31                                      ; preds = %24
+  %32 = load i32, i32* %loc2
+  %33 = add i32 %32, 1
+  store i32 %33, i32* %loc2
+  br label %34
+
+; <label>:34                                      ; preds = %11, %31
+  %35 = load i32, i32* %loc2
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = icmp slt i32 %35, %41
+  br i1 %42, label %16, label %43
+
+; <label>:43                                      ; preds = %24, %37
+  %44 = load i32, i32* %loc2
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %45, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp eq i32 %44, %50
+  br i1 %51, label %62, label %52
+
+; <label>:52                                      ; preds = %46
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %7, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %57, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %58
+
+; <label>:58                                      ; preds = %55
+  %59 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %60 = load i32, i32 addrspace(1)* %59
+  %61 = icmp slt i32 %56, %60
+  br i1 %61, label %8, label %62
+
+; <label>:62                                      ; preds = %1, %46, %58
+  %63 = load i32, i32* %arg2
+  %64 = icmp eq i32 %63, 0
+  br i1 %64, label %122, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %66, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %67
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %66, i32 0, i32 1
+  %69 = load i32, i32 addrspace(1)* %68
+  %70 = sub i32 %69, 1
+  store i32 %70, i32* %loc0
+  br label %118
+
+; <label>:71                                      ; preds = %118
+  store i32 0, i32* %loc4
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %73 = load i32, i32* %loc0
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %74
+
+; <label>:74                                      ; preds = %71
+  %75 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 2, i32 %73
+  %76 = load i16, i16 addrspace(1)* %75
+  %77 = zext i16 %76 to i32
+  %78 = trunc i32 %77 to i16
+  store i16 %78, i16* %loc5
+  store i32 0, i32* %loc4
+  br label %97
+
+; <label>:79                                      ; preds = %100
+  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %81 = load i32, i32* %loc4
+  %NullCheck19 = icmp eq %"System.Char[]" addrspace(1)* %80, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
+
+; <label>:82                                      ; preds = %79
+  %83 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 1
+  %84 = load i32, i32 addrspace(1)* %83
+  %85 = zext i32 %84 to i64
+  %86 = zext i32 %81 to i64
+  %BoundsCheck21 = icmp uge i64 %86, %85
+  br i1 %BoundsCheck21, label %ThrowIndexOutOfRange22, label %87
+
+; <label>:87                                      ; preds = %82
+  %88 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 3, i32 %81
+  %89 = load i16, i16 addrspace(1)* %88, align 8
+  %90 = zext i16 %89 to i32
+  %91 = load i16, i16* %loc5
+  %92 = zext i16 %91 to i32
+  %93 = icmp eq i32 %90, %92
+  br i1 %93, label %106, label %94
+
+; <label>:94                                      ; preds = %87
+  %95 = load i32, i32* %loc4
+  %96 = add i32 %95, 1
+  store i32 %96, i32* %loc4
+  br label %97
+
+; <label>:97                                      ; preds = %74, %94
+  %98 = load i32, i32* %loc4
+  %99 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck15 = icmp eq %"System.Char[]" addrspace(1)* %99, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %100
+
+; <label>:100                                     ; preds = %97
+  %101 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %99, i32 0, i32 1
+  %102 = load i32, i32 addrspace(1)* %101
+  %103 = zext i32 %102 to i64
+  %104 = trunc i64 %103 to i32
+  %105 = icmp slt i32 %98, %104
+  br i1 %105, label %79, label %106
+
+; <label>:106                                     ; preds = %87, %100
+  %107 = load i32, i32* %loc4
+  %108 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck17 = icmp eq %"System.Char[]" addrspace(1)* %108, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %109
+
+; <label>:109                                     ; preds = %106
+  %110 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %108, i32 0, i32 1
+  %111 = load i32, i32 addrspace(1)* %110
+  %112 = zext i32 %111 to i64
+  %113 = trunc i64 %112 to i32
+  %114 = icmp eq i32 %107, %113
+  br i1 %114, label %122, label %115
+
+; <label>:115                                     ; preds = %109
+  %116 = load i32, i32* %loc0
+  %117 = sub i32 %116, 1
+  store i32 %117, i32* %loc0
+  br label %118
+
+; <label>:118                                     ; preds = %67, %115
+  %119 = load i32, i32* %loc0
+  %120 = load i32, i32* %loc1
+  %121 = icmp sge i32 %119, %120
+  br i1 %121, label %71, label %122
+
+; <label>:122                                     ; preds = %62, %109, %118
+  %123 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %124 = load i32, i32* %loc1
+  %125 = load i32, i32* %loc0
+  %126 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %123, i32 %124, i32 %125)
+  ret %System.String addrspace(1)* %126
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %97
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange22:                           ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
 Successfully read String.CreateTrimmedString
 
@@ -5439,8 +6893,8 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
@@ -5535,8 +6989,8 @@ entry:
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i64 2872
   %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
   %8 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %7
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %3
   %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
@@ -5553,8 +7007,8 @@ entry:
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 2864
   %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
   %21 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %20
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
-  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %22
 
 ; <label>:22                                      ; preds = %16
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
@@ -5569,7 +7023,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %16
+ThrowNullRef2:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5586,8 +7040,8 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5613,8 +7067,8 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
@@ -5632,8 +7086,8 @@ entry:
 
 ; <label>:12                                      ; preds = %4
   %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
@@ -5644,8 +7098,8 @@ entry:
 
 ; <label>:19                                      ; preds = %14
   %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %19
   %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
@@ -5660,21 +7114,21 @@ entry:
   %31 = zext i16 %30 to i32
   %32 = bitcast i8* %29 to i16*
   %33 = trunc i32 %31 to i16
-  %NullCheck6 = icmp ne i16* %32, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i16* %32, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %21
   store i16 %33, i16* %32, align 8
   %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %36
 
 ; <label>:36                                      ; preds = %34
   %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
   %38 = load i32, i32 addrspace(1)* %37, align 8
   %39 = add i32 %38, 1
-  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %40
 
 ; <label>:40                                      ; preds = %36
   %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
@@ -5683,16 +7137,16 @@ entry:
 
 ; <label>:42                                      ; preds = %14
   %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
-  br i1 %NullCheck12, label %44, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
   %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
   %47 = load i16, i16* %arg1
   %48 = zext i16 %47 to i32
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = trunc i32 %48 to i16
@@ -5703,31 +7157,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %19
+ThrowNullRef4:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %21
+ThrowNullRef6:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %36
+ThrowNullRef10:                                   ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %42
+ThrowNullRef12:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %44
+ThrowNullRef14:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5740,8 +7194,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -5752,8 +7206,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
@@ -5762,14 +7216,14 @@ entry:
 
 ; <label>:11                                      ; preds = %1
   %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
@@ -5779,15 +7233,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5808,8 +7262,8 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5822,8 +7276,8 @@ entry:
 
 ; <label>:8                                       ; preds = %3
   %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
@@ -5842,15 +7296,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
-  br i1 %NullCheck4, label %22, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
   %24 = load i16*, i16* addrspace(1)* %23, align 8
   %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %25, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
@@ -5859,8 +7313,8 @@ entry:
   store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
@@ -5874,8 +7328,8 @@ entry:
 
 ; <label>:37                                      ; preds = %65
   %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %37
   %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
@@ -5886,16 +7340,16 @@ entry:
   %45 = bitcast i16* %41 to i8*
   %46 = getelementptr inbounds i8, i8* %45, i64 %44
   %47 = bitcast i8* %46 to i16*
-  %NullCheck14 = icmp ne i16* %47, null
-  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %47, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %48
 
 ; <label>:48                                      ; preds = %39
   %49 = load i16, i16* %47, align 8
   %50 = zext i16 %49 to i32
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %52 = load i32, i32* %loc1
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %53
 
 ; <label>:53                                      ; preds = %48
   %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
@@ -5916,8 +7370,8 @@ entry:
 ; <label>:62                                      ; preds = %36, %59
   %63 = load i32, i32* %loc1
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck10, label %65, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %65
 
 ; <label>:65                                      ; preds = %62
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
@@ -5936,15 +7390,15 @@ entry:
 
 ; <label>:74                                      ; preds = %70
   %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
-  br i1 %NullCheck18, label %76, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %76
 
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
   %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
-  br i1 %NullCheck20, label %80, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
   %81 = load i64, i64 addrspace(1)* %79
@@ -5958,8 +7412,8 @@ entry:
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
   %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
-  br i1 %NullCheck22, label %92, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.String addrspace(1)* %90, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %92
 
 ; <label>:92                                      ; preds = %80
   %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
@@ -5969,15 +7423,15 @@ entry:
 
 ; <label>:96                                      ; preds = %70
   %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
-  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %98
 
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
   %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
-  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
   %103 = load i64, i64 addrspace(1)* %101
@@ -5991,8 +7445,8 @@ entry:
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
   %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
-  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.String addrspace(1)* %112, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %114
 
 ; <label>:114                                     ; preds = %102
   %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
@@ -6004,59 +7458,59 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %20
+ThrowNullRef4:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %22
+ThrowNullRef6:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %26
+ThrowNullRef8:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %62
+ThrowNullRef10:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %48
+ThrowNullRef16:                                   ; preds = %48
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %74
+ThrowNullRef18:                                   ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %76
+ThrowNullRef20:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %80
+ThrowNullRef22:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %96
+ThrowNullRef24:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %98
+ThrowNullRef26:                                   ; preds = %98
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %102
+ThrowNullRef28:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6069,15 +7523,15 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
   %3 = load i16*, i16* addrspace(1)* %2, align 8
   %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
@@ -6087,8 +7541,8 @@ entry:
   %10 = bitcast i16* %3 to i8*
   %11 = getelementptr inbounds i8, i8* %10, i64 %9
   %12 = bitcast i8* %11 to i16*
-  %NullCheck4 = icmp ne i16* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %5
   store i16 0, i16* %12, align 8
@@ -6098,11 +7552,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6119,8 +7573,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -6131,8 +7585,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
@@ -6144,15 +7598,15 @@ entry:
 
 ; <label>:14                                      ; preds = %1
   %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
   %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
   %21 = load i64, i64 addrspace(1)* %19
@@ -6171,15 +7625,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %14
+ThrowNullRef4:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %16
+ThrowNullRef6:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6302,14 +7756,6 @@ entry:
   ret %System.String addrspace(1)* %57
 }
 
-INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
-Successfully read RuntimeHelpers.get_OffsetToStringData
-
-define i32 @RuntimeHelpers.get_OffsetToStringData() {
-entry:
-  ret i32 12
-}
-
 INFO:  jitting method String::Equals using LLILCJit
 Successfully read String.Equals
 
@@ -6381,8 +7827,8 @@ entry:
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
-  br i1 %NullCheck24, label %29, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
   %30 = load i64, i64 addrspace(1)* %28
@@ -6397,8 +7843,8 @@ entry:
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
-  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
   %43 = load i64, i64 addrspace(1)* %41
@@ -6418,8 +7864,8 @@ entry:
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
   %59 = load i64, i64 addrspace(1)* %57
@@ -6434,8 +7880,8 @@ entry:
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck22, label %71, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
   %72 = load i64, i64 addrspace(1)* %70
@@ -6455,8 +7901,8 @@ entry:
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
-  br i1 %NullCheck16, label %87, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = load i64, i64 addrspace(1)* %86
@@ -6471,8 +7917,8 @@ entry:
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck18, label %100, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
   %101 = load i64, i64 addrspace(1)* %99
@@ -6492,8 +7938,8 @@ entry:
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
-  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
   %117 = load i64, i64 addrspace(1)* %115
@@ -6508,8 +7954,8 @@ entry:
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
-  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
   %130 = load i64, i64 addrspace(1)* %128
@@ -6528,15 +7974,15 @@ entry:
 
 ; <label>:142                                     ; preds = %22
   %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
-  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %143, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %144
 
 ; <label>:144                                     ; preds = %142
   %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
   %146 = load i32, i32 addrspace(1)* %145
   %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
-  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %147, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %148
 
 ; <label>:148                                     ; preds = %144
   %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
@@ -6557,15 +8003,15 @@ entry:
 
 ; <label>:159                                     ; preds = %22
   %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
-  br i1 %NullCheck, label %161, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %ThrowNullRef, label %161
 
 ; <label>:161                                     ; preds = %159
   %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
   %163 = load i32, i32 addrspace(1)* %162
   %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
-  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %164, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %165
 
 ; <label>:165                                     ; preds = %161
   %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
@@ -6578,8 +8024,8 @@ entry:
 
 ; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
-  br i1 %NullCheck4, label %172, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %171, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %172
 
 ; <label>:172                                     ; preds = %170
   %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
@@ -6589,8 +8035,8 @@ entry:
 
 ; <label>:176                                     ; preds = %172
   %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
-  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %177, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %178
 
 ; <label>:178                                     ; preds = %176
   %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
@@ -6629,55 +8075,55 @@ ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %161
+ThrowNullRef2:                                    ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %170
+ThrowNullRef4:                                    ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %176
+ThrowNullRef6:                                    ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %142
+ThrowNullRef8:                                    ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %144
+ThrowNullRef10:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %113
+ThrowNullRef12:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %116
+ThrowNullRef14:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %84
+ThrowNullRef16:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %87
+ThrowNullRef18:                                   ; preds = %87
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %55
+ThrowNullRef20:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %58
+ThrowNullRef22:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %26
+ThrowNullRef24:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %29
+ThrowNullRef26:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,8 +8161,8 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck, label %14, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %ThrowNullRef, label %14
 
 ; <label>:14                                      ; preds = %8
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
@@ -6760,8 +8206,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
@@ -6770,14 +8216,14 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32, i32* %loc0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %10
   %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
   %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
@@ -6790,15 +8236,15 @@ entry:
 ; <label>:25                                      ; preds = %19
   %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
-  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
   %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
@@ -6807,8 +8253,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %37 = load i32, i32* %loc0
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %38, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %38
 
 ; <label>:38                                      ; preds = %32
   %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
@@ -6817,14 +8263,14 @@ entry:
 
 ; <label>:40                                      ; preds = %19
   %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %40
   %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
   %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
-  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
-  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
@@ -6832,8 +8278,8 @@ entry:
   %48 = zext i32 %47 to i64
   %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
-  br i1 %NullCheck16, label %51, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %51
 
 ; <label>:51                                      ; preds = %45
   %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
@@ -6847,15 +8293,15 @@ entry:
 ; <label>:57                                      ; preds = %51
   %58 = load i16*, i16** %arg1
   %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
-  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %60
 
 ; <label>:60                                      ; preds = %57
   %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
   %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
-  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %64
 
 ; <label>:64                                      ; preds = %60
   %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
@@ -6864,22 +8310,22 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
   %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
-  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %70
 
 ; <label>:70                                      ; preds = %64
   %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
   %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
-  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
-  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
   %75 = load i32, i32 addrspace(1)* %74
   %76 = zext i32 %75 to i64
   %77 = trunc i64 %76 to i32
-  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
-  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %78
 
 ; <label>:78                                      ; preds = %73
   %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
@@ -6901,8 +8347,8 @@ entry:
   %90 = bitcast i16* %86 to i8*
   %91 = getelementptr inbounds i8, i8* %90, i64 %89
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %93
 
 ; <label>:93                                      ; preds = %80
   %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
@@ -6912,8 +8358,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %99 = load i32, i32* %loc2
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %100
 
 ; <label>:100                                     ; preds = %93
   %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
@@ -6928,63 +8374,63 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %25
+ThrowNullRef6:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %32
+ThrowNullRef10:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %40
+ThrowNullRef12:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %45
+ThrowNullRef16:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %57
+ThrowNullRef18:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %60
+ThrowNullRef20:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %64
+ThrowNullRef22:                                   ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %70
+ThrowNullRef24:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %73
+ThrowNullRef26:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %80
+ThrowNullRef28:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %93
+ThrowNullRef30:                                   ; preds = %93
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7004,8 +8450,8 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
@@ -7033,43 +8479,43 @@ entry:
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %14
   %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
   %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   %28 = load i32, i32 addrspace(1)* %27, align 8
   %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
-  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %30
 
 ; <label>:30                                      ; preds = %26
   %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
   %32 = load i32, i32 addrspace(1)* %31, align 8
   %33 = add i32 %28, %32
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %34
 
 ; <label>:34                                      ; preds = %30
   %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   store i32 %33, i32 addrspace(1)* %35
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
   store i32 0, i32 addrspace(1)* %38
   %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %40
 
 ; <label>:40                                      ; preds = %37
   %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
@@ -7082,8 +8528,8 @@ entry:
 
 ; <label>:47                                      ; preds = %40
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
@@ -7098,8 +8544,8 @@ entry:
   %54 = load i32, i32* %loc0
   %55 = sext i32 %54 to i64
   %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
-  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %57
 
 ; <label>:57                                      ; preds = %52
   %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
@@ -7110,68 +8556,35 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %14
+ThrowNullRef2:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %23
+ThrowNullRef4:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %26
+ThrowNullRef6:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %30
+ThrowNullRef8:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %34
+ThrowNullRef10:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %47
+ThrowNullRef14:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %52
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-}
-
-INFO:  jitting method StringBuilder::get_Length using LLILCJit
-Successfully read StringBuilder.get_Length
-
-define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.StringBuilder addrspace(1)*
-  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
-  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
-
-; <label>:1                                       ; preds = %entry
-  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %3 = load i32, i32 addrspace(1)* %2, align 8
-  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
-
-; <label>:5                                       ; preds = %1
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = add i32 %3, %7
-  ret i32 %8
-
-ThrowNullRef:                                     ; preds = %entry
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef16:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7213,70 +8626,70 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
   %6 = load i32, i32 addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
   store i32 %6, i32 addrspace(1)* %8
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
   %13 = load i32, i32 addrspace(1)* %12, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
   store i32 %13, i32 addrspace(1)* %15
   %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
-  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %18
 
 ; <label>:18                                      ; preds = %14
   %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
   %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
   %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
   %34 = load i32, i32 addrspace(1)* %33, align 8
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
-  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
@@ -7287,39 +8700,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %28
+ThrowNullRef16:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %32
+ThrowNullRef18:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7455,13 +8868,13 @@ entry:
 ; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
@@ -7477,16 +8890,16 @@ entry:
 
 ; <label>:18                                      ; preds = %15
   %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
   store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
   %22 = load i32, i32* %loc0
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %24
 
 ; <label>:24                                      ; preds = %20
   %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
@@ -7498,13 +8911,13 @@ entry:
 ; <label>:28                                      ; preds = %15, %24
   %29 = load i32, i32* %arg1
   %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %31
   %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
@@ -7517,20 +8930,20 @@ entry:
   %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
-  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
   %46 = load i32, i32 addrspace(1)* %45, align 8
   %47 = sub i32 %40, %46
-  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
-  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i32 addrspace(1)* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %48
 
 ; <label>:48                                      ; preds = %44
   store i32 %47, i32 addrspace(1)* %39, align 8
@@ -7538,21 +8951,21 @@ entry:
 
 ; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
-  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %51
 
 ; <label>:51                                      ; preds = %49
   %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %53
 
 ; <label>:53                                      ; preds = %51
   %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
   %55 = load i32, i32 addrspace(1)* %54, align 8
   %56 = load i32, i32* %arg2
   %57 = sub i32 %55, %56
-  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %58
 
 ; <label>:58                                      ; preds = %53
   %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
@@ -7562,13 +8975,13 @@ entry:
 ; <label>:60                                      ; preds = %33, %58
   %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
   %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
-  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %63
 
 ; <label>:63                                      ; preds = %60
   %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
-  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
-  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
@@ -7578,15 +8991,15 @@ entry:
 
 ; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
-  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i32 addrspace(1)* %69, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %70
 
 ; <label>:70                                      ; preds = %68
   %71 = load i32, i32 addrspace(1)* %69, align 8
   store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
-  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
@@ -7596,8 +9009,8 @@ entry:
   store i32 %77, i32* %loc4
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
-  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %80
 
 ; <label>:80                                      ; preds = %73
   %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
@@ -7607,71 +9020,71 @@ entry:
 ; <label>:83                                      ; preds = %80
   store i32 0, i32* %loc3
   %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
-  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
-  br i1 %NullCheck26, label %88, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i32 addrspace(1)* %87, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %88
 
 ; <label>:88                                      ; preds = %85
   %89 = load i32, i32 addrspace(1)* %87, align 8
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
-  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %90
 
 ; <label>:90                                      ; preds = %88
   %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
   store i32 %89, i32 addrspace(1)* %91
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
-  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
-  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %96
 
 ; <label>:96                                      ; preds = %94
   %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
-  br i1 %NullCheck34, label %100, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %100
 
 ; <label>:100                                     ; preds = %96
   %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
-  br i1 %NullCheck36, label %102, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %102
 
 ; <label>:102                                     ; preds = %100
   %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
   %104 = load i32, i32 addrspace(1)* %103, align 8
   %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
-  br i1 %NullCheck38, label %106, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %106
 
 ; <label>:106                                     ; preds = %102
   %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
-  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
-  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %108
 
 ; <label>:108                                     ; preds = %106
   %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
   %110 = load i32, i32 addrspace(1)* %109, align 8
   %111 = add i32 %104, %110
-  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %112
 
 ; <label>:112                                     ; preds = %108
   %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
   store i32 %111, i32 addrspace(1)* %113
   %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
-  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i32 addrspace(1)* %114, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %115
 
 ; <label>:115                                     ; preds = %112
   %116 = load i32, i32 addrspace(1)* %114, align 8
@@ -7681,19 +9094,19 @@ entry:
 ; <label>:118                                     ; preds = %115
   %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
-  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %121
 
 ; <label>:121                                     ; preds = %118
   %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
-  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
-  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %123
 
 ; <label>:123                                     ; preds = %121
   %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
   %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
-  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
-  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %126
 
 ; <label>:126                                     ; preds = %123
   %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
@@ -7705,8 +9118,8 @@ entry:
 
 ; <label>:130                                     ; preds = %80, %115, %126
   %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %132
 
 ; <label>:132                                     ; preds = %130
   %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7715,8 +9128,8 @@ entry:
   %136 = load i32, i32* %loc3
   %137 = sub i32 %135, %136
   %138 = sub i32 %134, %137
-  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %139
 
 ; <label>:139                                     ; preds = %132
   %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7728,16 +9141,16 @@ entry:
 
 ; <label>:144                                     ; preds = %139
   %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
-  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %146
 
 ; <label>:146                                     ; preds = %144
   %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
   %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
   %149 = load i32, i32* %loc2
   %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
-  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %151
 
 ; <label>:151                                     ; preds = %146
   %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
@@ -7754,145 +9167,249 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %18
+ThrowNullRef4:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %31
+ThrowNullRef10:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %44
+ThrowNullRef16:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %68
+ThrowNullRef18:                                   ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %70
+ThrowNullRef20:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %73
+ThrowNullRef22:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %83
+ThrowNullRef24:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %85
+ThrowNullRef26:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %88
+ThrowNullRef28:                                   ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %90
+ThrowNullRef30:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %94
+ThrowNullRef32:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %96
+ThrowNullRef34:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %100
+ThrowNullRef36:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %102
+ThrowNullRef38:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %106
+ThrowNullRef40:                                   ; preds = %106
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %108
+ThrowNullRef42:                                   ; preds = %108
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %112
+ThrowNullRef44:                                   ; preds = %112
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %118
+ThrowNullRef46:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %121
+ThrowNullRef48:                                   ; preds = %121
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %123
+ThrowNullRef50:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %130
+ThrowNullRef52:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %132
+ThrowNullRef54:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %144
+ThrowNullRef56:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %146
+ThrowNullRef58:                                   ; preds = %146
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %60
+ThrowNullRef60:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %63
+ThrowNullRef62:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %49
+ThrowNullRef64:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %51
+ThrowNullRef66:                                   ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %53
+ThrowNullRef68:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(%"System.Char[]" addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %arg0 = alloca %"System.Char[]" addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store %"System.Char[]" addrspace(1)* %param0, %"System.Char[]" addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load i32, i32* %arg4
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %43, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %38, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg1
+  %13 = load i32, i32* %arg4
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %38, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %24 = load i32, i32* %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %35 = load i32, i32* %arg3
+  %36 = load i32, i32* %arg4
+  %37 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %37, %"System.Char[]" addrspace(1)* %34, i32 %35, i32 %36)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:38                                      ; preds = %5, %16
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Successfully read Buffer._Memmove
 
@@ -7914,7 +9431,7 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[loadElem]
+Failed to read AppDomain.SetDataHelper[storeElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -7923,8 +9440,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
@@ -7934,8 +9451,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
@@ -7947,15 +9464,15 @@ entry:
   %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
   %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
@@ -7966,15 +9483,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7992,7 +9509,79 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
-Failed to read Dictionary`2.TryGetValue[loadElemA]
+Successfully read Dictionary`2.TryGetValue
+
+define i8 @"Dictionary`2.TryGetValue"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)* addrspace(1)* %param2) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  %arg2 = alloca %System.__Canon addrspace(1)* addrspace(1)*
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  store %System.__Canon addrspace(1)* addrspace(1)* %param2, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  store i32 %2, i32* %loc0
+  %3 = load i32, i32* %loc0
+  %4 = icmp slt i32 %3, 0
+  br i1 %4, label %22, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 2
+  %10 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %9, align 8
+  %11 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = zext i32 %11 to i64
+  %BoundsCheck = icmp uge i64 %16, %15
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 3, i32 %11
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %20, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %6, %System.__Canon addrspace(1)* %21)
+  ret i8 1
+
+; <label>:22                                      ; preds = %entry
+  %23 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %23, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -8058,8 +9647,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
@@ -8091,8 +9680,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
@@ -8171,15 +9760,15 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck, label %19, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %ThrowNullRef, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
   %21 = load i32, i32 addrspace(1)* %20
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
@@ -8202,7 +9791,7 @@ ThrowNullRef:                                     ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %19
+ThrowNullRef2:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8248,8 +9837,8 @@ entry:
   %0 = alloca %System.AppDomainHandle
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %1 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %1, i32 0, i32 15
@@ -8269,8 +9858,8 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
@@ -8286,7 +9875,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -8299,8 +9888,8 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -8327,8 +9916,8 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
@@ -8352,8 +9941,8 @@ entry:
   %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
   store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
@@ -8363,8 +9952,8 @@ entry:
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
@@ -8374,8 +9963,8 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %9
   %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
@@ -8384,8 +9973,8 @@ entry:
 
 ; <label>:18                                      ; preds = %3, %16
   %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
@@ -8397,15 +9986,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %18
+ThrowNullRef6:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8418,8 +10007,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
@@ -8453,15 +10042,15 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
@@ -8473,7 +10062,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8481,7 +10070,7 @@ ThrowNullRef1:                                    ; preds = %1
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
 Failed to read Dictionary`2.System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
@@ -8506,8 +10095,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
@@ -8524,8 +10113,8 @@ entry:
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -8544,7 +10133,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8577,8 +10166,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = load i64, i64* %arg2
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = trunc i32 %3 to i8
@@ -8634,46 +10223,46 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
   %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
-  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
-  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
-  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
@@ -8684,27 +10273,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %20
+ThrowNullRef12:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8717,8 +10306,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -8756,22 +10345,22 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
   %9 = load i64, i64 addrspace(1)* %8, align 8
   %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
   %13 = load i64, i64 addrspace(1)* %12, align 8
   %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %11
   %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
@@ -8788,11 +10377,11 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8882,8 +10471,8 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
@@ -8900,8 +10489,8 @@ entry:
 ; <label>:8                                       ; preds = %1
   %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
   %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
@@ -8911,15 +10500,15 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
   %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
   %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
-  br i1 %NullCheck6, label %21, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
@@ -8946,15 +10535,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8992,15 +10581,15 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
   store i8 %3, i8 addrspace(1)* %5
   %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
@@ -9011,7 +10600,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9027,8 +10616,8 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -9041,8 +10630,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
@@ -9058,7 +10647,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9080,8 +10669,8 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
@@ -9096,8 +10685,8 @@ entry:
 ; <label>:12                                      ; preds = %6
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
@@ -9112,8 +10701,8 @@ entry:
 ; <label>:21                                      ; preds = %15
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
@@ -9128,8 +10717,8 @@ entry:
 ; <label>:30                                      ; preds = %24
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %31, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
@@ -9144,8 +10733,8 @@ entry:
 ; <label>:39                                      ; preds = %33
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
-  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %40, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %42
 
 ; <label>:42                                      ; preds = %39
   %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
@@ -9164,19 +10753,19 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %21
+ThrowNullRef4:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %30
+ThrowNullRef6:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %39
+ThrowNullRef8:                                    ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9243,8 +10832,8 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
@@ -9264,57 +10853,57 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
   store i8 0, i8 addrspace(1)* %2
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
   store i8 0, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
   store i8 0, i8 addrspace(1)* %17
   %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
   store i8 0, i8 addrspace(1)* %20
   %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
-  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
@@ -9325,31 +10914,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %19
+ThrowNullRef14:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9367,8 +10956,8 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
@@ -9380,8 +10969,8 @@ entry:
 
 ; <label>:9                                       ; preds = %4
   %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %9
   %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
@@ -9395,7 +10984,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef2:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9420,8 +11009,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
@@ -9512,8 +11101,8 @@ entry:
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
@@ -9524,8 +11113,8 @@ entry:
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = load i64, i64 addrspace(1)* %12
@@ -9537,8 +11126,8 @@ entry:
   %20 = load i64, i64* %19
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
-  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %13
   %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
@@ -9555,8 +11144,8 @@ entry:
 ; <label>:30                                      ; preds = %25
   %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %32 = load i32, i32* %arg2
-  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
-  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
@@ -9570,15 +11159,15 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %30
+ThrowNullRef2:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9622,87 +11211,87 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
   %10 = load i8, i8 addrspace(1)* %9, align 8
   %11 = zext i8 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %8
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
   store i8 %12, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
   %19 = load i8, i8 addrspace(1)* %18, align 8
   %20 = zext i8 %19 to i32
   %21 = trunc i32 %20 to i8
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
   store i8 %21, i8 addrspace(1)* %23
   %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
   %28 = load i8, i8 addrspace(1)* %27, align 8
   %29 = zext i8 %28 to i32
   %30 = trunc i32 %29 to i8
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
-  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %31
 
 ; <label>:31                                      ; preds = %26
   %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
   store i8 %30, i8 addrspace(1)* %32
   %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
-  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
-  br i1 %NullCheck14, label %40, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %40
 
 ; <label>:40                                      ; preds = %35
   %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
   store i8 %39, i8 addrspace(1)* %41
   %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
-  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %44
 
 ; <label>:44                                      ; preds = %40
   %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
   %46 = load i8, i8 addrspace(1)* %45, align 8
   %47 = zext i8 %46 to i32
   %48 = trunc i32 %47 to i8
-  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
   store i8 %48, i8 addrspace(1)* %50
   %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
-  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
@@ -9713,29 +11302,29 @@ entry:
 ; <label>:56                                      ; preds = %52
   %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
-  br i1 %NullCheck22, label %59, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
   %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
   %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
-  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
-  br i1 %NullCheck24, label %63, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
   %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
-  br i1 %NullCheck26, label %66, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
   %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
-  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
-  br i1 %NullCheck28, label %69, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %69
 
 ; <label>:69                                      ; preds = %66
   %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
@@ -9744,15 +11333,15 @@ entry:
 
 ; <label>:71                                      ; preds = %105
   %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
-  br i1 %NullCheck34, label %73, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %73
 
 ; <label>:73                                      ; preds = %71
   %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
   %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
   %76 = load i32, i32* %loc0
-  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
-  br i1 %NullCheck36, label %77, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
@@ -9766,8 +11355,8 @@ entry:
 
 ; <label>:83                                      ; preds = %77
   %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
-  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
@@ -9775,14 +11364,14 @@ entry:
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
   %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
-  br i1 %NullCheck40, label %91, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
 ; <label>:91                                      ; preds = %85
   %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
   %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
-  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck42, label %94, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %94
 
 ; <label>:94                                      ; preds = %91
   %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
@@ -9798,14 +11387,14 @@ entry:
 ; <label>:99                                      ; preds = %69, %96
   %100 = load i32, i32* %loc0
   %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
-  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %102
 
 ; <label>:102                                     ; preds = %99
   %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
   %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
-  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
-  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
@@ -9819,87 +11408,87 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %26
+ThrowNullRef10:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %31
+ThrowNullRef12:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %35
+ThrowNullRef14:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %40
+ThrowNullRef16:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %56
+ThrowNullRef22:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %59
+ThrowNullRef24:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %63
+ThrowNullRef26:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %66
+ThrowNullRef28:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %102
+ThrowNullRef32:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %71
+ThrowNullRef34:                                   ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %73
+ThrowNullRef36:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %83
+ThrowNullRef38:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %85
+ThrowNullRef40:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %91
+ThrowNullRef42:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9943,15 +11532,15 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
   %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
@@ -9961,28 +11550,28 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
   %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %12
   %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
   %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
   %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
-  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
@@ -9993,23 +11582,23 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %12
+ThrowNullRef6:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10031,15 +11620,15 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
   %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = load i64, i64 addrspace(1)* %7
@@ -10077,13 +11666,13 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[loadElem]
+Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -10111,8 +11700,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -10177,15 +11766,15 @@ entry:
   %0 = addrspacecast %MyClass* %loc0 to %MyClass addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%MyClass addrspace(1)*, i32, i32)*)(%MyClass addrspace(1)* %0, i32 0, i32 12)
   %1 = addrspacecast %MyClass* %loc0 to %MyClass addrspace(1)*
-  %NullCheck = icmp ne %MyClass addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %MyClass addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %MyClass, %MyClass addrspace(1)* %1, i32 0, i32 0
   %4 = load i32, i32 addrspace(1)* %3, align 8
   %5 = addrspacecast %MyClass* %loc0 to %MyClass addrspace(1)*
-  %NullCheck2 = icmp ne %MyClass addrspace(1)* %5, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %MyClass addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
   %7 = getelementptr inbounds %MyClass, %MyClass addrspace(1)* %5, i32 0, i32 1
@@ -10195,15 +11784,15 @@ entry:
 
 ; <label>:10                                      ; preds = %6
   %11 = addrspacecast %MyClass* %loc0 to %MyClass addrspace(1)*
-  %NullCheck4 = icmp ne %MyClass addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %MyClass addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %MyClass, %MyClass addrspace(1)* %11, i32 0, i32 1
   %14 = load i32, i32 addrspace(1)* %13, align 8
   %15 = addrspacecast %MyClass* %loc0 to %MyClass addrspace(1)*
-  %NullCheck6 = icmp ne %MyClass addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %MyClass addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %12
   %17 = getelementptr inbounds %MyClass, %MyClass addrspace(1)* %15, i32 0, i32 2
@@ -10213,8 +11802,8 @@ entry:
 
 ; <label>:20                                      ; preds = %16
   %21 = addrspacecast %MyClass* %loc0 to %MyClass addrspace(1)*
-  %NullCheck8 = icmp ne %MyClass addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %MyClass addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %MyClass, %MyClass addrspace(1)* %21, i32 0, i32 2
@@ -10231,19 +11820,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %12
+ThrowNullRef6:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %20
+ThrowNullRef8:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }

--- a/test/BaseLine/JIT/CodeGenBringUpTests/InstanceCalls.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/InstanceCalls.error.txt
@@ -25,8 +25,8 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
@@ -40,8 +40,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
   %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
@@ -75,7 +75,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -90,8 +90,8 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %NullCheck = icmp ne i8 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = load i8, i8 addrspace(1)* %0, align 8
@@ -125,8 +125,8 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
@@ -159,8 +159,8 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -184,8 +184,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
   store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
@@ -195,8 +195,8 @@ entry:
 ; <label>:4                                       ; preds = %1
   %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
   %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
@@ -206,8 +206,8 @@ entry:
   %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
@@ -221,14 +221,14 @@ entry:
 
 ; <label>:17                                      ; preds = %14
   %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
   %21 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
@@ -238,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -249,8 +249,8 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
@@ -261,27 +261,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %30
+ThrowNullRef10:                                   ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -301,7 +301,89 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
-Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
+Successfully read AppDomainSetup.GetUnsecureApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.GetUnsecureApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %NullCheck = icmp eq %"System.String[]" addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %BoundsCheck = icmp uge i64 0, %5
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %6
+
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 3, i32 0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
+  ret %System.String addrspace(1)* %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_Value using LLILCJit
+Successfully read AppDomainSetup.get_Value
+
+define %"System.String[]" addrspace(1)* @AppDomainSetup.get_Value(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.String[]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 18)
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.String[]" addrspace(1)* addrspace(1)*, %"System.String[]" addrspace(1)*)*)(%"System.String[]" addrspace(1)* addrspace(1)* %9, %"System.String[]" addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %11, i32 0, i32 1
+  %14 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %13, align 8
+  ret %"System.String[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -319,8 +401,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -368,16 +450,16 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
   %5 = load i32, i32 addrspace(1)* %4
   %6 = sub i32 %5, 1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -389,7 +471,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -421,8 +503,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
@@ -456,8 +538,8 @@ entry:
 ; <label>:27                                      ; preds = %19
   %28 = load i32, i32* %arg1
   %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
-  br i1 %NullCheck2, label %30, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %29, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %30
 
 ; <label>:30                                      ; preds = %27
   %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
@@ -493,8 +575,8 @@ entry:
 ; <label>:49                                      ; preds = %46
   %50 = load i32, i32* %arg2
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck4, label %52, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
@@ -517,11 +599,11 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %27
+ThrowNullRef2:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %49
+ThrowNullRef4:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -544,16 +626,16 @@ entry:
   %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %0)
   store %System.String addrspace(1)* %1, %System.String addrspace(1)** %loc0
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 2
   %5 = bitcast [0 x i16] addrspace(1)* %4 to i16 addrspace(1)*
   store i16 addrspace(1)* %5, i16 addrspace(1)** %loc1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %3
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2
@@ -580,7 +662,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -691,15 +773,15 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %NullCheck132 = icmp ne i8* %21, null
-  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+  %NullCheck131 = icmp eq i8* %21, null
+  br i1 %NullCheck131, label %ThrowNullRef132, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = load i8, i8* %21, align 8
   %24 = zext i8 %23 to i32
   %25 = trunc i32 %24 to i8
-  %NullCheck134 = icmp ne i8* %20, null
-  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+  %NullCheck133 = icmp eq i8* %20, null
+  br i1 %NullCheck133, label %ThrowNullRef134, label %26
 
 ; <label>:26                                      ; preds = %22
   store i8 %25, i8* %20, align 8
@@ -709,16 +791,16 @@ entry:
   %28 = load i8*, i8** %arg0
   %29 = load i8*, i8** %arg1
   %30 = bitcast i8* %29 to i16*
-  %NullCheck128 = icmp ne i16* %30, null
-  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+  %NullCheck127 = icmp eq i16* %30, null
+  br i1 %NullCheck127, label %ThrowNullRef128, label %31
 
 ; <label>:31                                      ; preds = %27
   %32 = load i16, i16* %30, align 8
   %33 = sext i16 %32 to i32
   %34 = bitcast i8* %28 to i16*
   %35 = trunc i32 %33 to i16
-  %NullCheck130 = icmp ne i16* %34, null
-  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+  %NullCheck129 = icmp eq i16* %34, null
+  br i1 %NullCheck129, label %ThrowNullRef130, label %36
 
 ; <label>:36                                      ; preds = %31
   store i16 %35, i16* %34, align 8
@@ -728,16 +810,16 @@ entry:
   %38 = load i8*, i8** %arg0
   %39 = load i8*, i8** %arg1
   %40 = bitcast i8* %39 to i16*
-  %NullCheck120 = icmp ne i16* %40, null
-  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+  %NullCheck119 = icmp eq i16* %40, null
+  br i1 %NullCheck119, label %ThrowNullRef120, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i16, i16* %40, align 8
   %43 = sext i16 %42 to i32
   %44 = bitcast i8* %38 to i16*
   %45 = trunc i32 %43 to i16
-  %NullCheck122 = icmp ne i16* %44, null
-  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+  %NullCheck121 = icmp eq i16* %44, null
+  br i1 %NullCheck121, label %ThrowNullRef122, label %46
 
 ; <label>:46                                      ; preds = %41
   store i16 %45, i16* %44, align 8
@@ -745,15 +827,15 @@ entry:
   %48 = getelementptr inbounds i8, i8* %47, i64 2
   %49 = load i8*, i8** %arg1
   %50 = getelementptr inbounds i8, i8* %49, i64 2
-  %NullCheck124 = icmp ne i8* %50, null
-  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+  %NullCheck123 = icmp eq i8* %50, null
+  br i1 %NullCheck123, label %ThrowNullRef124, label %51
 
 ; <label>:51                                      ; preds = %46
   %52 = load i8, i8* %50, align 8
   %53 = zext i8 %52 to i32
   %54 = trunc i32 %53 to i8
-  %NullCheck126 = icmp ne i8* %48, null
-  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+  %NullCheck125 = icmp eq i8* %48, null
+  br i1 %NullCheck125, label %ThrowNullRef126, label %55
 
 ; <label>:55                                      ; preds = %51
   store i8 %54, i8* %48, align 8
@@ -763,14 +845,14 @@ entry:
   %57 = load i8*, i8** %arg0
   %58 = load i8*, i8** %arg1
   %59 = bitcast i8* %58 to i32*
-  %NullCheck116 = icmp ne i32* %59, null
-  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+  %NullCheck115 = icmp eq i32* %59, null
+  br i1 %NullCheck115, label %ThrowNullRef116, label %60
 
 ; <label>:60                                      ; preds = %56
   %61 = load i32, i32* %59, align 8
   %62 = bitcast i8* %57 to i32*
-  %NullCheck118 = icmp ne i32* %62, null
-  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+  %NullCheck117 = icmp eq i32* %62, null
+  br i1 %NullCheck117, label %ThrowNullRef118, label %63
 
 ; <label>:63                                      ; preds = %60
   store i32 %61, i32* %62, align 8
@@ -780,14 +862,14 @@ entry:
   %65 = load i8*, i8** %arg0
   %66 = load i8*, i8** %arg1
   %67 = bitcast i8* %66 to i32*
-  %NullCheck108 = icmp ne i32* %67, null
-  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+  %NullCheck107 = icmp eq i32* %67, null
+  br i1 %NullCheck107, label %ThrowNullRef108, label %68
 
 ; <label>:68                                      ; preds = %64
   %69 = load i32, i32* %67, align 8
   %70 = bitcast i8* %65 to i32*
-  %NullCheck110 = icmp ne i32* %70, null
-  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+  %NullCheck109 = icmp eq i32* %70, null
+  br i1 %NullCheck109, label %ThrowNullRef110, label %71
 
 ; <label>:71                                      ; preds = %68
   store i32 %69, i32* %70, align 8
@@ -795,15 +877,15 @@ entry:
   %73 = getelementptr inbounds i8, i8* %72, i64 4
   %74 = load i8*, i8** %arg1
   %75 = getelementptr inbounds i8, i8* %74, i64 4
-  %NullCheck112 = icmp ne i8* %75, null
-  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+  %NullCheck111 = icmp eq i8* %75, null
+  br i1 %NullCheck111, label %ThrowNullRef112, label %76
 
 ; <label>:76                                      ; preds = %71
   %77 = load i8, i8* %75, align 8
   %78 = zext i8 %77 to i32
   %79 = trunc i32 %78 to i8
-  %NullCheck114 = icmp ne i8* %73, null
-  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+  %NullCheck113 = icmp eq i8* %73, null
+  br i1 %NullCheck113, label %ThrowNullRef114, label %80
 
 ; <label>:80                                      ; preds = %76
   store i8 %79, i8* %73, align 8
@@ -813,14 +895,14 @@ entry:
   %82 = load i8*, i8** %arg0
   %83 = load i8*, i8** %arg1
   %84 = bitcast i8* %83 to i32*
-  %NullCheck100 = icmp ne i32* %84, null
-  br i1 %NullCheck100, label %85, label %ThrowNullRef99
+  %NullCheck99 = icmp eq i32* %84, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %85
 
 ; <label>:85                                      ; preds = %81
   %86 = load i32, i32* %84, align 8
   %87 = bitcast i8* %82 to i32*
-  %NullCheck102 = icmp ne i32* %87, null
-  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+  %NullCheck101 = icmp eq i32* %87, null
+  br i1 %NullCheck101, label %ThrowNullRef102, label %88
 
 ; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
@@ -829,16 +911,16 @@ entry:
   %91 = load i8*, i8** %arg1
   %92 = getelementptr inbounds i8, i8* %91, i64 4
   %93 = bitcast i8* %92 to i16*
-  %NullCheck104 = icmp ne i16* %93, null
-  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+  %NullCheck103 = icmp eq i16* %93, null
+  br i1 %NullCheck103, label %ThrowNullRef104, label %94
 
 ; <label>:94                                      ; preds = %88
   %95 = load i16, i16* %93, align 8
   %96 = sext i16 %95 to i32
   %97 = bitcast i8* %90 to i16*
   %98 = trunc i32 %96 to i16
-  %NullCheck106 = icmp ne i16* %97, null
-  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+  %NullCheck105 = icmp eq i16* %97, null
+  br i1 %NullCheck105, label %ThrowNullRef106, label %99
 
 ; <label>:99                                      ; preds = %94
   store i16 %98, i16* %97, align 8
@@ -848,14 +930,14 @@ entry:
   %101 = load i8*, i8** %arg0
   %102 = load i8*, i8** %arg1
   %103 = bitcast i8* %102 to i32*
-  %NullCheck88 = icmp ne i32* %103, null
-  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+  %NullCheck87 = icmp eq i32* %103, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %104
 
 ; <label>:104                                     ; preds = %100
   %105 = load i32, i32* %103, align 8
   %106 = bitcast i8* %101 to i32*
-  %NullCheck90 = icmp ne i32* %106, null
-  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+  %NullCheck89 = icmp eq i32* %106, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %107
 
 ; <label>:107                                     ; preds = %104
   store i32 %105, i32* %106, align 8
@@ -864,16 +946,16 @@ entry:
   %110 = load i8*, i8** %arg1
   %111 = getelementptr inbounds i8, i8* %110, i64 4
   %112 = bitcast i8* %111 to i16*
-  %NullCheck92 = icmp ne i16* %112, null
-  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+  %NullCheck91 = icmp eq i16* %112, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %113
 
 ; <label>:113                                     ; preds = %107
   %114 = load i16, i16* %112, align 8
   %115 = sext i16 %114 to i32
   %116 = bitcast i8* %109 to i16*
   %117 = trunc i32 %115 to i16
-  %NullCheck94 = icmp ne i16* %116, null
-  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+  %NullCheck93 = icmp eq i16* %116, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %118
 
 ; <label>:118                                     ; preds = %113
   store i16 %117, i16* %116, align 8
@@ -881,15 +963,15 @@ entry:
   %120 = getelementptr inbounds i8, i8* %119, i64 6
   %121 = load i8*, i8** %arg1
   %122 = getelementptr inbounds i8, i8* %121, i64 6
-  %NullCheck96 = icmp ne i8* %122, null
-  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+  %NullCheck95 = icmp eq i8* %122, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %123
 
 ; <label>:123                                     ; preds = %118
   %124 = load i8, i8* %122, align 8
   %125 = zext i8 %124 to i32
   %126 = trunc i32 %125 to i8
-  %NullCheck98 = icmp ne i8* %120, null
-  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+  %NullCheck97 = icmp eq i8* %120, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %127
 
 ; <label>:127                                     ; preds = %123
   store i8 %126, i8* %120, align 8
@@ -899,14 +981,14 @@ entry:
   %129 = load i8*, i8** %arg0
   %130 = load i8*, i8** %arg1
   %131 = bitcast i8* %130 to i64*
-  %NullCheck84 = icmp ne i64* %131, null
-  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+  %NullCheck83 = icmp eq i64* %131, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %132
 
 ; <label>:132                                     ; preds = %128
   %133 = load i64, i64* %131, align 8
   %134 = bitcast i8* %129 to i64*
-  %NullCheck86 = icmp ne i64* %134, null
-  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+  %NullCheck85 = icmp eq i64* %134, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %135
 
 ; <label>:135                                     ; preds = %132
   store i64 %133, i64* %134, align 8
@@ -916,14 +998,14 @@ entry:
   %137 = load i8*, i8** %arg0
   %138 = load i8*, i8** %arg1
   %139 = bitcast i8* %138 to i64*
-  %NullCheck76 = icmp ne i64* %139, null
-  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+  %NullCheck75 = icmp eq i64* %139, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %140
 
 ; <label>:140                                     ; preds = %136
   %141 = load i64, i64* %139, align 8
   %142 = bitcast i8* %137 to i64*
-  %NullCheck78 = icmp ne i64* %142, null
-  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+  %NullCheck77 = icmp eq i64* %142, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %143
 
 ; <label>:143                                     ; preds = %140
   store i64 %141, i64* %142, align 8
@@ -931,15 +1013,15 @@ entry:
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %NullCheck80 = icmp ne i8* %147, null
-  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+  %NullCheck79 = icmp eq i8* %147, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %148
 
 ; <label>:148                                     ; preds = %143
   %149 = load i8, i8* %147, align 8
   %150 = zext i8 %149 to i32
   %151 = trunc i32 %150 to i8
-  %NullCheck82 = icmp ne i8* %145, null
-  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+  %NullCheck81 = icmp eq i8* %145, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %152
 
 ; <label>:152                                     ; preds = %148
   store i8 %151, i8* %145, align 8
@@ -949,14 +1031,14 @@ entry:
   %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
   %156 = bitcast i8* %155 to i64*
-  %NullCheck68 = icmp ne i64* %156, null
-  br i1 %NullCheck68, label %157, label %ThrowNullRef67
+  %NullCheck67 = icmp eq i64* %156, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %157
 
 ; <label>:157                                     ; preds = %153
   %158 = load i64, i64* %156, align 8
   %159 = bitcast i8* %154 to i64*
-  %NullCheck70 = icmp ne i64* %159, null
-  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+  %NullCheck69 = icmp eq i64* %159, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %160
 
 ; <label>:160                                     ; preds = %157
   store i64 %158, i64* %159, align 8
@@ -965,16 +1047,16 @@ entry:
   %163 = load i8*, i8** %arg1
   %164 = getelementptr inbounds i8, i8* %163, i64 8
   %165 = bitcast i8* %164 to i16*
-  %NullCheck72 = icmp ne i16* %165, null
-  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+  %NullCheck71 = icmp eq i16* %165, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %166
 
 ; <label>:166                                     ; preds = %160
   %167 = load i16, i16* %165, align 8
   %168 = sext i16 %167 to i32
   %169 = bitcast i8* %162 to i16*
   %170 = trunc i32 %168 to i16
-  %NullCheck74 = icmp ne i16* %169, null
-  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+  %NullCheck73 = icmp eq i16* %169, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %171
 
 ; <label>:171                                     ; preds = %166
   store i16 %170, i16* %169, align 8
@@ -984,14 +1066,14 @@ entry:
   %173 = load i8*, i8** %arg0
   %174 = load i8*, i8** %arg1
   %175 = bitcast i8* %174 to i64*
-  %NullCheck56 = icmp ne i64* %175, null
-  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+  %NullCheck55 = icmp eq i64* %175, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %176
 
 ; <label>:176                                     ; preds = %172
   %177 = load i64, i64* %175, align 8
   %178 = bitcast i8* %173 to i64*
-  %NullCheck58 = icmp ne i64* %178, null
-  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+  %NullCheck57 = icmp eq i64* %178, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %179
 
 ; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
@@ -1000,16 +1082,16 @@ entry:
   %182 = load i8*, i8** %arg1
   %183 = getelementptr inbounds i8, i8* %182, i64 8
   %184 = bitcast i8* %183 to i16*
-  %NullCheck60 = icmp ne i16* %184, null
-  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+  %NullCheck59 = icmp eq i16* %184, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %185
 
 ; <label>:185                                     ; preds = %179
   %186 = load i16, i16* %184, align 8
   %187 = sext i16 %186 to i32
   %188 = bitcast i8* %181 to i16*
   %189 = trunc i32 %187 to i16
-  %NullCheck62 = icmp ne i16* %188, null
-  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+  %NullCheck61 = icmp eq i16* %188, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %190
 
 ; <label>:190                                     ; preds = %185
   store i16 %189, i16* %188, align 8
@@ -1017,15 +1099,15 @@ entry:
   %192 = getelementptr inbounds i8, i8* %191, i64 10
   %193 = load i8*, i8** %arg1
   %194 = getelementptr inbounds i8, i8* %193, i64 10
-  %NullCheck64 = icmp ne i8* %194, null
-  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+  %NullCheck63 = icmp eq i8* %194, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %195
 
 ; <label>:195                                     ; preds = %190
   %196 = load i8, i8* %194, align 8
   %197 = zext i8 %196 to i32
   %198 = trunc i32 %197 to i8
-  %NullCheck66 = icmp ne i8* %192, null
-  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+  %NullCheck65 = icmp eq i8* %192, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %199
 
 ; <label>:199                                     ; preds = %195
   store i8 %198, i8* %192, align 8
@@ -1035,14 +1117,14 @@ entry:
   %201 = load i8*, i8** %arg0
   %202 = load i8*, i8** %arg1
   %203 = bitcast i8* %202 to i64*
-  %NullCheck48 = icmp ne i64* %203, null
-  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+  %NullCheck47 = icmp eq i64* %203, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %204
 
 ; <label>:204                                     ; preds = %200
   %205 = load i64, i64* %203, align 8
   %206 = bitcast i8* %201 to i64*
-  %NullCheck50 = icmp ne i64* %206, null
-  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+  %NullCheck49 = icmp eq i64* %206, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %207
 
 ; <label>:207                                     ; preds = %204
   store i64 %205, i64* %206, align 8
@@ -1051,14 +1133,14 @@ entry:
   %210 = load i8*, i8** %arg1
   %211 = getelementptr inbounds i8, i8* %210, i64 8
   %212 = bitcast i8* %211 to i32*
-  %NullCheck52 = icmp ne i32* %212, null
-  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+  %NullCheck51 = icmp eq i32* %212, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %213
 
 ; <label>:213                                     ; preds = %207
   %214 = load i32, i32* %212, align 8
   %215 = bitcast i8* %209 to i32*
-  %NullCheck54 = icmp ne i32* %215, null
-  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+  %NullCheck53 = icmp eq i32* %215, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %216
 
 ; <label>:216                                     ; preds = %213
   store i32 %214, i32* %215, align 8
@@ -1068,14 +1150,14 @@ entry:
   %218 = load i8*, i8** %arg0
   %219 = load i8*, i8** %arg1
   %220 = bitcast i8* %219 to i64*
-  %NullCheck36 = icmp ne i64* %220, null
-  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64* %220, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %221
 
 ; <label>:221                                     ; preds = %217
   %222 = load i64, i64* %220, align 8
   %223 = bitcast i8* %218 to i64*
-  %NullCheck38 = icmp ne i64* %223, null
-  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+  %NullCheck37 = icmp eq i64* %223, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %224
 
 ; <label>:224                                     ; preds = %221
   store i64 %222, i64* %223, align 8
@@ -1084,14 +1166,14 @@ entry:
   %227 = load i8*, i8** %arg1
   %228 = getelementptr inbounds i8, i8* %227, i64 8
   %229 = bitcast i8* %228 to i32*
-  %NullCheck40 = icmp ne i32* %229, null
-  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i32* %229, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %230
 
 ; <label>:230                                     ; preds = %224
   %231 = load i32, i32* %229, align 8
   %232 = bitcast i8* %226 to i32*
-  %NullCheck42 = icmp ne i32* %232, null
-  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+  %NullCheck41 = icmp eq i32* %232, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %233
 
 ; <label>:233                                     ; preds = %230
   store i32 %231, i32* %232, align 8
@@ -1099,15 +1181,15 @@ entry:
   %235 = getelementptr inbounds i8, i8* %234, i64 12
   %236 = load i8*, i8** %arg1
   %237 = getelementptr inbounds i8, i8* %236, i64 12
-  %NullCheck44 = icmp ne i8* %237, null
-  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i8* %237, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %238
 
 ; <label>:238                                     ; preds = %233
   %239 = load i8, i8* %237, align 8
   %240 = zext i8 %239 to i32
   %241 = trunc i32 %240 to i8
-  %NullCheck46 = icmp ne i8* %235, null
-  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+  %NullCheck45 = icmp eq i8* %235, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %242
 
 ; <label>:242                                     ; preds = %238
   store i8 %241, i8* %235, align 8
@@ -1117,14 +1199,14 @@ entry:
   %244 = load i8*, i8** %arg0
   %245 = load i8*, i8** %arg1
   %246 = bitcast i8* %245 to i64*
-  %NullCheck24 = icmp ne i64* %246, null
-  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64* %246, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %247
 
 ; <label>:247                                     ; preds = %243
   %248 = load i64, i64* %246, align 8
   %249 = bitcast i8* %244 to i64*
-  %NullCheck26 = icmp ne i64* %249, null
-  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64* %249, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %250
 
 ; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
@@ -1133,14 +1215,14 @@ entry:
   %253 = load i8*, i8** %arg1
   %254 = getelementptr inbounds i8, i8* %253, i64 8
   %255 = bitcast i8* %254 to i32*
-  %NullCheck28 = icmp ne i32* %255, null
-  br i1 %NullCheck28, label %256, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i32* %255, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %256
 
 ; <label>:256                                     ; preds = %250
   %257 = load i32, i32* %255, align 8
   %258 = bitcast i8* %252 to i32*
-  %NullCheck30 = icmp ne i32* %258, null
-  br i1 %NullCheck30, label %259, label %ThrowNullRef29
+  %NullCheck29 = icmp eq i32* %258, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %259
 
 ; <label>:259                                     ; preds = %256
   store i32 %257, i32* %258, align 8
@@ -1149,16 +1231,16 @@ entry:
   %262 = load i8*, i8** %arg1
   %263 = getelementptr inbounds i8, i8* %262, i64 12
   %264 = bitcast i8* %263 to i16*
-  %NullCheck32 = icmp ne i16* %264, null
-  br i1 %NullCheck32, label %265, label %ThrowNullRef31
+  %NullCheck31 = icmp eq i16* %264, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %265
 
 ; <label>:265                                     ; preds = %259
   %266 = load i16, i16* %264, align 8
   %267 = sext i16 %266 to i32
   %268 = bitcast i8* %261 to i16*
   %269 = trunc i32 %267 to i16
-  %NullCheck34 = icmp ne i16* %268, null
-  br i1 %NullCheck34, label %270, label %ThrowNullRef33
+  %NullCheck33 = icmp eq i16* %268, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %270
 
 ; <label>:270                                     ; preds = %265
   store i16 %269, i16* %268, align 8
@@ -1168,14 +1250,14 @@ entry:
   %272 = load i8*, i8** %arg0
   %273 = load i8*, i8** %arg1
   %274 = bitcast i8* %273 to i64*
-  %NullCheck8 = icmp ne i64* %274, null
-  br i1 %NullCheck8, label %275, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64* %274, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %275
 
 ; <label>:275                                     ; preds = %271
   %276 = load i64, i64* %274, align 8
   %277 = bitcast i8* %272 to i64*
-  %NullCheck10 = icmp ne i64* %277, null
-  br i1 %NullCheck10, label %278, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %277, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %278
 
 ; <label>:278                                     ; preds = %275
   store i64 %276, i64* %277, align 8
@@ -1184,14 +1266,14 @@ entry:
   %281 = load i8*, i8** %arg1
   %282 = getelementptr inbounds i8, i8* %281, i64 8
   %283 = bitcast i8* %282 to i32*
-  %NullCheck12 = icmp ne i32* %283, null
-  br i1 %NullCheck12, label %284, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i32* %283, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %284
 
 ; <label>:284                                     ; preds = %278
   %285 = load i32, i32* %283, align 8
   %286 = bitcast i8* %280 to i32*
-  %NullCheck14 = icmp ne i32* %286, null
-  br i1 %NullCheck14, label %287, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i32* %286, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %287
 
 ; <label>:287                                     ; preds = %284
   store i32 %285, i32* %286, align 8
@@ -1200,16 +1282,16 @@ entry:
   %290 = load i8*, i8** %arg1
   %291 = getelementptr inbounds i8, i8* %290, i64 12
   %292 = bitcast i8* %291 to i16*
-  %NullCheck16 = icmp ne i16* %292, null
-  br i1 %NullCheck16, label %293, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i16* %292, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %293
 
 ; <label>:293                                     ; preds = %287
   %294 = load i16, i16* %292, align 8
   %295 = sext i16 %294 to i32
   %296 = bitcast i8* %289 to i16*
   %297 = trunc i32 %295 to i16
-  %NullCheck18 = icmp ne i16* %296, null
-  br i1 %NullCheck18, label %298, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i16* %296, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %298
 
 ; <label>:298                                     ; preds = %293
   store i16 %297, i16* %296, align 8
@@ -1217,15 +1299,15 @@ entry:
   %300 = getelementptr inbounds i8, i8* %299, i64 14
   %301 = load i8*, i8** %arg1
   %302 = getelementptr inbounds i8, i8* %301, i64 14
-  %NullCheck20 = icmp ne i8* %302, null
-  br i1 %NullCheck20, label %303, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i8* %302, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %303
 
 ; <label>:303                                     ; preds = %298
   %304 = load i8, i8* %302, align 8
   %305 = zext i8 %304 to i32
   %306 = trunc i32 %305 to i8
-  %NullCheck22 = icmp ne i8* %300, null
-  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i8* %300, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %307
 
 ; <label>:307                                     ; preds = %303
   store i8 %306, i8* %300, align 8
@@ -1235,14 +1317,14 @@ entry:
   %309 = load i8*, i8** %arg0
   %310 = load i8*, i8** %arg1
   %311 = bitcast i8* %310 to i64*
-  %NullCheck = icmp ne i64* %311, null
-  br i1 %NullCheck, label %312, label %ThrowNullRef
+  %NullCheck = icmp eq i64* %311, null
+  br i1 %NullCheck, label %ThrowNullRef, label %312
 
 ; <label>:312                                     ; preds = %308
   %313 = load i64, i64* %311, align 8
   %314 = bitcast i8* %309 to i64*
-  %NullCheck2 = icmp ne i64* %314, null
-  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64* %314, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %315
 
 ; <label>:315                                     ; preds = %312
   store i64 %313, i64* %314, align 8
@@ -1251,14 +1333,14 @@ entry:
   %318 = load i8*, i8** %arg1
   %319 = getelementptr inbounds i8, i8* %318, i64 8
   %320 = bitcast i8* %319 to i64*
-  %NullCheck4 = icmp ne i64* %320, null
-  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64* %320, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %321
 
 ; <label>:321                                     ; preds = %315
   %322 = load i64, i64* %320, align 8
   %323 = bitcast i8* %317 to i64*
-  %NullCheck6 = icmp ne i64* %323, null
-  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64* %323, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %324
 
 ; <label>:324                                     ; preds = %321
   store i64 %322, i64* %323, align 8
@@ -1286,15 +1368,15 @@ entry:
 ; <label>:338                                     ; preds = %333
   %339 = load i8*, i8** %arg0
   %340 = load i8*, i8** %arg1
-  %NullCheck136 = icmp ne i8* %340, null
-  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+  %NullCheck135 = icmp eq i8* %340, null
+  br i1 %NullCheck135, label %ThrowNullRef136, label %341
 
 ; <label>:341                                     ; preds = %338
   %342 = load i8, i8* %340, align 8
   %343 = zext i8 %342 to i32
   %344 = trunc i32 %343 to i8
-  %NullCheck138 = icmp ne i8* %339, null
-  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+  %NullCheck137 = icmp eq i8* %339, null
+  br i1 %NullCheck137, label %ThrowNullRef138, label %345
 
 ; <label>:345                                     ; preds = %341
   store i8 %344, i8* %339, align 8
@@ -1317,16 +1399,16 @@ entry:
   %357 = load i8*, i8** %arg0
   %358 = load i8*, i8** %arg1
   %359 = bitcast i8* %358 to i16*
-  %NullCheck140 = icmp ne i16* %359, null
-  br i1 %NullCheck140, label %360, label %ThrowNullRef139
+  %NullCheck139 = icmp eq i16* %359, null
+  br i1 %NullCheck139, label %ThrowNullRef140, label %360
 
 ; <label>:360                                     ; preds = %356
   %361 = load i16, i16* %359, align 8
   %362 = sext i16 %361 to i32
   %363 = bitcast i8* %357 to i16*
   %364 = trunc i32 %362 to i16
-  %NullCheck142 = icmp ne i16* %363, null
-  br i1 %NullCheck142, label %365, label %ThrowNullRef141
+  %NullCheck141 = icmp eq i16* %363, null
+  br i1 %NullCheck141, label %ThrowNullRef142, label %365
 
 ; <label>:365                                     ; preds = %360
   store i16 %364, i16* %363, align 8
@@ -1352,14 +1434,14 @@ entry:
   %378 = load i8*, i8** %arg0
   %379 = load i8*, i8** %arg1
   %380 = bitcast i8* %379 to i32*
-  %NullCheck144 = icmp ne i32* %380, null
-  br i1 %NullCheck144, label %381, label %ThrowNullRef143
+  %NullCheck143 = icmp eq i32* %380, null
+  br i1 %NullCheck143, label %ThrowNullRef144, label %381
 
 ; <label>:381                                     ; preds = %377
   %382 = load i32, i32* %380, align 8
   %383 = bitcast i8* %378 to i32*
-  %NullCheck146 = icmp ne i32* %383, null
-  br i1 %NullCheck146, label %384, label %ThrowNullRef145
+  %NullCheck145 = icmp eq i32* %383, null
+  br i1 %NullCheck145, label %ThrowNullRef146, label %384
 
 ; <label>:384                                     ; preds = %381
   store i32 %382, i32* %383, align 8
@@ -1384,14 +1466,14 @@ entry:
   %395 = load i8*, i8** %arg0
   %396 = load i8*, i8** %arg1
   %397 = bitcast i8* %396 to i64*
-  %NullCheck164 = icmp ne i64* %397, null
-  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+  %NullCheck163 = icmp eq i64* %397, null
+  br i1 %NullCheck163, label %ThrowNullRef164, label %398
 
 ; <label>:398                                     ; preds = %394
   %399 = load i64, i64* %397, align 8
   %400 = bitcast i8* %395 to i64*
-  %NullCheck166 = icmp ne i64* %400, null
-  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+  %NullCheck165 = icmp eq i64* %400, null
+  br i1 %NullCheck165, label %ThrowNullRef166, label %401
 
 ; <label>:401                                     ; preds = %398
   store i64 %399, i64* %400, align 8
@@ -1400,14 +1482,14 @@ entry:
   %404 = load i8*, i8** %arg1
   %405 = getelementptr inbounds i8, i8* %404, i64 8
   %406 = bitcast i8* %405 to i64*
-  %NullCheck168 = icmp ne i64* %406, null
-  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+  %NullCheck167 = icmp eq i64* %406, null
+  br i1 %NullCheck167, label %ThrowNullRef168, label %407
 
 ; <label>:407                                     ; preds = %401
   %408 = load i64, i64* %406, align 8
   %409 = bitcast i8* %403 to i64*
-  %NullCheck170 = icmp ne i64* %409, null
-  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+  %NullCheck169 = icmp eq i64* %409, null
+  br i1 %NullCheck169, label %ThrowNullRef170, label %410
 
 ; <label>:410                                     ; preds = %407
   store i64 %408, i64* %409, align 8
@@ -1437,14 +1519,14 @@ entry:
   %425 = load i8*, i8** %arg0
   %426 = load i8*, i8** %arg1
   %427 = bitcast i8* %426 to i64*
-  %NullCheck148 = icmp ne i64* %427, null
-  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+  %NullCheck147 = icmp eq i64* %427, null
+  br i1 %NullCheck147, label %ThrowNullRef148, label %428
 
 ; <label>:428                                     ; preds = %424
   %429 = load i64, i64* %427, align 8
   %430 = bitcast i8* %425 to i64*
-  %NullCheck150 = icmp ne i64* %430, null
-  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+  %NullCheck149 = icmp eq i64* %430, null
+  br i1 %NullCheck149, label %ThrowNullRef150, label %431
 
 ; <label>:431                                     ; preds = %428
   store i64 %429, i64* %430, align 8
@@ -1466,14 +1548,14 @@ entry:
   %441 = load i8*, i8** %arg0
   %442 = load i8*, i8** %arg1
   %443 = bitcast i8* %442 to i32*
-  %NullCheck152 = icmp ne i32* %443, null
-  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+  %NullCheck151 = icmp eq i32* %443, null
+  br i1 %NullCheck151, label %ThrowNullRef152, label %444
 
 ; <label>:444                                     ; preds = %440
   %445 = load i32, i32* %443, align 8
   %446 = bitcast i8* %441 to i32*
-  %NullCheck154 = icmp ne i32* %446, null
-  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+  %NullCheck153 = icmp eq i32* %446, null
+  br i1 %NullCheck153, label %ThrowNullRef154, label %447
 
 ; <label>:447                                     ; preds = %444
   store i32 %445, i32* %446, align 8
@@ -1495,16 +1577,16 @@ entry:
   %457 = load i8*, i8** %arg0
   %458 = load i8*, i8** %arg1
   %459 = bitcast i8* %458 to i16*
-  %NullCheck156 = icmp ne i16* %459, null
-  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+  %NullCheck155 = icmp eq i16* %459, null
+  br i1 %NullCheck155, label %ThrowNullRef156, label %460
 
 ; <label>:460                                     ; preds = %456
   %461 = load i16, i16* %459, align 8
   %462 = sext i16 %461 to i32
   %463 = bitcast i8* %457 to i16*
   %464 = trunc i32 %462 to i16
-  %NullCheck158 = icmp ne i16* %463, null
-  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+  %NullCheck157 = icmp eq i16* %463, null
+  br i1 %NullCheck157, label %ThrowNullRef158, label %465
 
 ; <label>:465                                     ; preds = %460
   store i16 %464, i16* %463, align 8
@@ -1525,15 +1607,15 @@ entry:
 ; <label>:474                                     ; preds = %470
   %475 = load i8*, i8** %arg0
   %476 = load i8*, i8** %arg1
-  %NullCheck160 = icmp ne i8* %476, null
-  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+  %NullCheck159 = icmp eq i8* %476, null
+  br i1 %NullCheck159, label %ThrowNullRef160, label %477
 
 ; <label>:477                                     ; preds = %474
   %478 = load i8, i8* %476, align 8
   %479 = zext i8 %478 to i32
   %480 = trunc i32 %479 to i8
-  %NullCheck162 = icmp ne i8* %475, null
-  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+  %NullCheck161 = icmp eq i8* %475, null
+  br i1 %NullCheck161, label %ThrowNullRef162, label %481
 
 ; <label>:481                                     ; preds = %477
   store i8 %480, i8* %475, align 8
@@ -1553,343 +1635,343 @@ ThrowNullRef:                                     ; preds = %308
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %312
+ThrowNullRef2:                                    ; preds = %312
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %315
+ThrowNullRef4:                                    ; preds = %315
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %321
+ThrowNullRef6:                                    ; preds = %321
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %271
+ThrowNullRef8:                                    ; preds = %271
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %275
+ThrowNullRef10:                                   ; preds = %275
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %278
+ThrowNullRef12:                                   ; preds = %278
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %284
+ThrowNullRef14:                                   ; preds = %284
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %287
+ThrowNullRef16:                                   ; preds = %287
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %293
+ThrowNullRef18:                                   ; preds = %293
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %298
+ThrowNullRef20:                                   ; preds = %298
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %303
+ThrowNullRef22:                                   ; preds = %303
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %243
+ThrowNullRef24:                                   ; preds = %243
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %247
+ThrowNullRef26:                                   ; preds = %247
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %250
+ThrowNullRef28:                                   ; preds = %250
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %256
+ThrowNullRef30:                                   ; preds = %256
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %259
+ThrowNullRef32:                                   ; preds = %259
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %265
+ThrowNullRef34:                                   ; preds = %265
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %217
+ThrowNullRef36:                                   ; preds = %217
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %221
+ThrowNullRef38:                                   ; preds = %221
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %224
+ThrowNullRef40:                                   ; preds = %224
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %230
+ThrowNullRef42:                                   ; preds = %230
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %233
+ThrowNullRef44:                                   ; preds = %233
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %238
+ThrowNullRef46:                                   ; preds = %238
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %200
+ThrowNullRef48:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %204
+ThrowNullRef50:                                   ; preds = %204
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %207
+ThrowNullRef52:                                   ; preds = %207
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %213
+ThrowNullRef54:                                   ; preds = %213
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %172
+ThrowNullRef56:                                   ; preds = %172
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %176
+ThrowNullRef58:                                   ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %179
+ThrowNullRef60:                                   ; preds = %179
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %185
+ThrowNullRef62:                                   ; preds = %185
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %190
+ThrowNullRef64:                                   ; preds = %190
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %195
+ThrowNullRef66:                                   ; preds = %195
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %153
+ThrowNullRef68:                                   ; preds = %153
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %157
+ThrowNullRef70:                                   ; preds = %157
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %160
+ThrowNullRef72:                                   ; preds = %160
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %166
+ThrowNullRef74:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %136
+ThrowNullRef76:                                   ; preds = %136
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %140
+ThrowNullRef78:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %143
+ThrowNullRef80:                                   ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %148
+ThrowNullRef82:                                   ; preds = %148
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %128
+ThrowNullRef84:                                   ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %132
+ThrowNullRef86:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %100
+ThrowNullRef88:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %104
+ThrowNullRef90:                                   ; preds = %104
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %107
+ThrowNullRef92:                                   ; preds = %107
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %113
+ThrowNullRef94:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %118
+ThrowNullRef96:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %123
+ThrowNullRef98:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %81
+ThrowNullRef100:                                  ; preds = %81
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef101:                                  ; preds = %85
+ThrowNullRef102:                                  ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef103:                                  ; preds = %88
+ThrowNullRef104:                                  ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef105:                                  ; preds = %94
+ThrowNullRef106:                                  ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef107:                                  ; preds = %64
+ThrowNullRef108:                                  ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef109:                                  ; preds = %68
+ThrowNullRef110:                                  ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef111:                                  ; preds = %71
+ThrowNullRef112:                                  ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef113:                                  ; preds = %76
+ThrowNullRef114:                                  ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef115:                                  ; preds = %56
+ThrowNullRef116:                                  ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef117:                                  ; preds = %60
+ThrowNullRef118:                                  ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef119:                                  ; preds = %37
+ThrowNullRef120:                                  ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef121:                                  ; preds = %41
+ThrowNullRef122:                                  ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef123:                                  ; preds = %46
+ThrowNullRef124:                                  ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef125:                                  ; preds = %51
+ThrowNullRef126:                                  ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef127:                                  ; preds = %27
+ThrowNullRef128:                                  ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef129:                                  ; preds = %31
+ThrowNullRef130:                                  ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef131:                                  ; preds = %19
+ThrowNullRef132:                                  ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef133:                                  ; preds = %22
+ThrowNullRef134:                                  ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef135:                                  ; preds = %338
+ThrowNullRef136:                                  ; preds = %338
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef137:                                  ; preds = %341
+ThrowNullRef138:                                  ; preds = %341
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef139:                                  ; preds = %356
+ThrowNullRef140:                                  ; preds = %356
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef141:                                  ; preds = %360
+ThrowNullRef142:                                  ; preds = %360
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef143:                                  ; preds = %377
+ThrowNullRef144:                                  ; preds = %377
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef145:                                  ; preds = %381
+ThrowNullRef146:                                  ; preds = %381
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef147:                                  ; preds = %424
+ThrowNullRef148:                                  ; preds = %424
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef149:                                  ; preds = %428
+ThrowNullRef150:                                  ; preds = %428
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef151:                                  ; preds = %440
+ThrowNullRef152:                                  ; preds = %440
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef153:                                  ; preds = %444
+ThrowNullRef154:                                  ; preds = %444
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef155:                                  ; preds = %456
+ThrowNullRef156:                                  ; preds = %456
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef157:                                  ; preds = %460
+ThrowNullRef158:                                  ; preds = %460
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef159:                                  ; preds = %474
+ThrowNullRef160:                                  ; preds = %474
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef161:                                  ; preds = %477
+ThrowNullRef162:                                  ; preds = %477
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef163:                                  ; preds = %394
+ThrowNullRef164:                                  ; preds = %394
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef165:                                  ; preds = %398
+ThrowNullRef166:                                  ; preds = %398
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef167:                                  ; preds = %401
+ThrowNullRef168:                                  ; preds = %401
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef169:                                  ; preds = %407
+ThrowNullRef170:                                  ; preds = %407
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1939,8 +2021,8 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
-  br i1 %NullCheck, label %22, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %ThrowNullRef, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
@@ -1948,8 +2030,8 @@ entry:
   store i32 %24, i32* %loc0
   %25 = load i32, i32* %loc0
   %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %26, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %27
 
 ; <label>:27                                      ; preds = %22
   %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
@@ -1971,7 +2053,7 @@ ThrowNullRef:                                     ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1989,8 +2071,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -2022,15 +2104,15 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2048,16 +2130,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
   %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
   store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %15
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
@@ -2072,8 +2154,8 @@ entry:
   %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
   %29 = ptrtoint i16 addrspace(1)* %28 to i64
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %19
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
@@ -2089,19 +2171,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2114,8 +2196,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
@@ -2128,7 +2210,7 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[loadElem]
+Failed to read AppDomain.PrepareDataForSetup[storeElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
@@ -2202,8 +2284,8 @@ entry:
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
-  br i1 %NullCheck24, label %27, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = load i64, i64 addrspace(1)* %26
@@ -2218,8 +2300,8 @@ entry:
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
-  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
   %41 = load i64, i64 addrspace(1)* %39
@@ -2236,8 +2318,8 @@ entry:
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
-  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
   %54 = load i64, i64 addrspace(1)* %52
@@ -2252,8 +2334,8 @@ entry:
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
   %67 = load i64, i64 addrspace(1)* %65
@@ -2270,8 +2352,8 @@ entry:
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
-  br i1 %NullCheck16, label %79, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
   %80 = load i64, i64 addrspace(1)* %78
@@ -2286,8 +2368,8 @@ entry:
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
-  br i1 %NullCheck18, label %92, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
   %93 = load i64, i64 addrspace(1)* %91
@@ -2304,8 +2386,8 @@ entry:
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
-  br i1 %NullCheck12, label %105, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = load i64, i64 addrspace(1)* %104
@@ -2320,8 +2402,8 @@ entry:
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
-  br i1 %NullCheck14, label %118, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
   %119 = load i64, i64 addrspace(1)* %117
@@ -2337,8 +2419,8 @@ entry:
 
 ; <label>:128                                     ; preds = %20
   %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
-  br i1 %NullCheck4, label %130, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %129, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %130
 
 ; <label>:130                                     ; preds = %128
   %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
@@ -2346,8 +2428,8 @@ entry:
   %133 = load i16, i16 addrspace(1)* %132, align 8
   %134 = zext i16 %133 to i32
   %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
-  br i1 %NullCheck6, label %136, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %135, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %136
 
 ; <label>:136                                     ; preds = %130
   %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
@@ -2360,8 +2442,8 @@ entry:
 
 ; <label>:143                                     ; preds = %136
   %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
-  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %144, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %145
 
 ; <label>:145                                     ; preds = %143
   %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
@@ -2369,8 +2451,8 @@ entry:
   %148 = load i16, i16 addrspace(1)* %147, align 8
   %149 = zext i16 %148 to i32
   %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %150, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %151
 
 ; <label>:151                                     ; preds = %145
   %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
@@ -2388,8 +2470,8 @@ entry:
 
 ; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
-  br i1 %NullCheck, label %163, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %ThrowNullRef, label %163
 
 ; <label>:163                                     ; preds = %161
   %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
@@ -2399,8 +2481,8 @@ entry:
 
 ; <label>:167                                     ; preds = %163
   %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
-  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %168, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %169
 
 ; <label>:169                                     ; preds = %167
   %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
@@ -2432,55 +2514,55 @@ ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %167
+ThrowNullRef2:                                    ; preds = %167
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %128
+ThrowNullRef4:                                    ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %130
+ThrowNullRef6:                                    ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %143
+ThrowNullRef8:                                    ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %145
+ThrowNullRef10:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %102
+ThrowNullRef12:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %105
+ThrowNullRef14:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %76
+ThrowNullRef16:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %79
+ThrowNullRef18:                                   ; preds = %79
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %50
+ThrowNullRef20:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %53
+ThrowNullRef22:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %24
+ThrowNullRef24:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %27
+ThrowNullRef26:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2503,15 +2585,15 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2519,16 +2601,16 @@ entry:
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
   store i32 %8, i32* %loc0
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
   %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
   store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
@@ -2546,16 +2628,16 @@ entry:
 
 ; <label>:23                                      ; preds = %64
   %24 = load i16*, i16** %loc3
-  %NullCheck12 = icmp ne i16* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i16* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
   store i32 %27, i32* %loc5
   %28 = load i16*, i16** %loc4
-  %NullCheck14 = icmp ne i16* %28, null
-  br i1 %NullCheck14, label %29, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %28, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = load i16, i16* %28, align 8
@@ -2620,15 +2702,15 @@ entry:
 
 ; <label>:67                                      ; preds = %64
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
-  br i1 %NullCheck8, label %69, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %68, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %69
 
 ; <label>:69                                      ; preds = %67
   %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
   %71 = load i32, i32 addrspace(1)* %70
   %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
-  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %73
 
 ; <label>:73                                      ; preds = %69
   %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
@@ -2645,31 +2727,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %67
+ThrowNullRef8:                                    ; preds = %67
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %69
+ThrowNullRef10:                                   ; preds = %69
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2710,14 +2792,14 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
   %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
@@ -2730,14 +2812,14 @@ entry:
 
 ; <label>:11                                      ; preds = %4
   %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
   %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
@@ -2749,14 +2831,14 @@ entry:
 
 ; <label>:22                                      ; preds = %16
   %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
   %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
-  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
-  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
@@ -2804,23 +2886,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2836,7 +2918,280 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[loadElem]
+Successfully read RuntimeType.IsAssignableFrom
+
+define i8 @RuntimeType.IsAssignableFrom(%System.RuntimeType addrspace(1)* %param0, %System.Type addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.RuntimeType addrspace(1)*
+  %arg1 = alloca %System.Type addrspace(1)*
+  %loc0 = alloca %System.RuntimeType addrspace(1)*
+  %loc1 = alloca %"System.Type[]" addrspace(1)*
+  %loc2 = alloca i32
+  store %System.RuntimeType addrspace(1)* %param0, %System.RuntimeType addrspace(1)** %this
+  store %System.Type addrspace(1)* %param1, %System.Type addrspace(1)** %arg1
+  %0 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %1 = icmp ne %System.Type addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i8 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %5 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %6 = bitcast %System.Type addrspace(1)* %4 to %System.Object addrspace(1)*
+  %7 = bitcast %System.RuntimeType addrspace(1)* %5 to %System.Object addrspace(1)*
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %6, %System.Object addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %3
+  ret i8 1
+
+; <label>:12                                      ; preds = %3
+  %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 152
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 32
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
+  %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
+  %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
+  store %System.RuntimeType addrspace(1)* %25, %System.RuntimeType addrspace(1)** %loc0
+  %26 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %27 = icmp eq %System.RuntimeType addrspace(1)* %26, null
+  br i1 %27, label %34, label %28
+
+; <label>:28                                      ; preds = %15
+  %29 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %30 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)*)*)(%System.RuntimeType addrspace(1)* %29, %System.RuntimeType addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+; <label>:34                                      ; preds = %15
+  %35 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %36 = call %System.Reflection.Emit.TypeBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Reflection.Emit.TypeBuilder addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %35)
+  %37 = icmp eq %System.Reflection.Emit.TypeBuilder addrspace(1)* %36, null
+  br i1 %37, label %139, label %38
+
+; <label>:38                                      ; preds = %34
+  %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %42
+
+; <label>:42                                      ; preds = %38
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 152
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 40
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
+  %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
+  %53 = zext i8 %52 to i32
+  %54 = icmp eq i32 %53, 0
+  br i1 %54, label %56, label %55
+
+; <label>:55                                      ; preds = %42
+  ret i8 1
+
+; <label>:56                                      ; preds = %42
+  %57 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %58 = bitcast %System.RuntimeType addrspace(1)* %57 to %System.Type addrspace(1)*
+  %59 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %58)
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %64 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.Type addrspace(1)* %63, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = bitcast %System.RuntimeType addrspace(1)* %64 to %System.Type addrspace(1)*
+  %67 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %63, %System.Type addrspace(1)* %66)
+  %68 = zext i8 %67 to i32
+  %69 = trunc i32 %68 to i8
+  ret i8 %69
+
+; <label>:70                                      ; preds = %56
+  %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
+  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %73
+
+; <label>:73                                      ; preds = %70
+  %74 = load i64, i64 addrspace(1)* %72
+  %75 = add i64 %74, 128
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = add i64 %77, 0
+  %79 = inttoptr i64 %78 to i64*
+  %80 = load i64, i64* %79
+  %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
+  %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
+  %83 = call i8 %82(%System.Type addrspace(1)* %81)
+  %84 = zext i8 %83 to i32
+  %85 = icmp eq i32 %84, 0
+  br i1 %85, label %139, label %86
+
+; <label>:86                                      ; preds = %73
+  %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
+  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %89
+
+; <label>:89                                      ; preds = %86
+  %90 = load i64, i64 addrspace(1)* %88
+  %91 = add i64 %90, 128
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = add i64 %93, 24
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
+  %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
+  %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
+  store %"System.Type[]" addrspace(1)* %99, %"System.Type[]" addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %129
+
+; <label>:100                                     ; preds = %132
+  %101 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %102 = load i32, i32* %loc2
+  %NullCheck11 = icmp eq %"System.Type[]" addrspace(1)* %101, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %103
+
+; <label>:103                                     ; preds = %100
+  %104 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 1
+  %105 = load i32, i32 addrspace(1)* %104
+  %106 = zext i32 %105 to i64
+  %107 = zext i32 %102 to i64
+  %BoundsCheck = icmp uge i64 %107, %106
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %108
+
+; <label>:108                                     ; preds = %103
+  %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
+  %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
+  %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
+  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %113
+
+; <label>:113                                     ; preds = %108
+  %114 = load i64, i64 addrspace(1)* %112
+  %115 = add i64 %114, 152
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = add i64 %117, 56
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
+  %123 = zext i8 %122 to i32
+  %124 = icmp ne i32 %123, 0
+  br i1 %124, label %126, label %125
+
+; <label>:125                                     ; preds = %113
+  ret i8 0
+
+; <label>:126                                     ; preds = %113
+  %127 = load i32, i32* %loc2
+  %128 = add i32 %127, 1
+  store i32 %128, i32* %loc2
+  br label %129
+
+; <label>:129                                     ; preds = %89, %126
+  %130 = load i32, i32* %loc2
+  %131 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %NullCheck9 = icmp eq %"System.Type[]" addrspace(1)* %131, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %132
+
+; <label>:132                                     ; preds = %129
+  %133 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %131, i32 0, i32 1
+  %134 = load i32, i32 addrspace(1)* %133
+  %135 = zext i32 %134 to i64
+  %136 = trunc i64 %135 to i32
+  %137 = icmp slt i32 %130, %136
+  br i1 %137, label %100, label %138
+
+; <label>:138                                     ; preds = %132
+  ret i8 1
+
+; <label>:139                                     ; preds = %34, %73
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %129
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %103
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -2893,7 +3248,7 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElem]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -2904,8 +3259,8 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -2997,8 +3352,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
@@ -3059,8 +3414,8 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -3087,8 +3442,8 @@ entry:
 
 ; <label>:17                                      ; preds = %5, %11
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
@@ -3097,8 +3452,8 @@ entry:
 
 ; <label>:22                                      ; preds = %1, %11
   %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
@@ -3109,11 +3464,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %17
+ThrowNullRef2:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %22
+ThrowNullRef4:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3167,15 +3522,15 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
   %15 = load i32, i32 addrspace(1)* %14
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
@@ -3198,7 +3553,7 @@ ThrowNullRef:                                     ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef2:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3232,8 +3587,8 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
@@ -3312,8 +3667,8 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -3327,8 +3682,8 @@ entry:
 ; <label>:5                                       ; preds = %43
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %7 = load i32, i32* %loc1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck6, label %8, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
@@ -3366,8 +3721,8 @@ entry:
 ; <label>:32                                      ; preds = %21, %25
   %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
   %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
-  br i1 %NullCheck8, label %35, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = trunc i32 %34 to i16
@@ -3380,8 +3735,8 @@ entry:
 ; <label>:40                                      ; preds = %1, %35
   %41 = load i32, i32* %loc1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
-  br i1 %NullCheck2, label %43, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %42, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
@@ -3392,8 +3747,8 @@ entry:
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
   %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
-  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
   %51 = load i64, i64 addrspace(1)* %49
@@ -3412,19 +3767,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %40
+ThrowNullRef2:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %47
+ThrowNullRef4:                                    ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %5
+ThrowNullRef6:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %32
+ThrowNullRef8:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3467,8 +3822,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
@@ -3492,11 +3847,391 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(i16* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store i16* %param0, i16** %arg0
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load i32, i32* %arg3
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %42, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %37, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg2
+  %13 = load i32, i32* %arg3
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %37, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %24 = load i32, i32* %arg2
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load i16*, i16** %arg0
+  %35 = load i32, i32* %arg3
+  %36 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %36, i16* %34, i32 %35)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:37                                      ; preds = %5, %16
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %39)
+  %41 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41, %System.String addrspace(1)* %38, %System.String addrspace(1)* %40)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41) #0
+  unreachable
+
+; <label>:42                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
-Failed to read StringBuilder.ToString[loadElemA]
+Successfully read StringBuilder.ToString
+
+define %System.String addrspace(1)* @StringBuilder.ToString(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i16*
+  %loc3 = alloca %"System.Char[]" addrspace(1)*
+  %loc4 = alloca i32
+  %loc5 = alloca i32
+  %loc6 = alloca i16 addrspace(1)*
+  %loc7 = alloca %System.String addrspace(1)*
+  %loc8 = alloca %"System.Char[]" addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %0)
+  %2 = icmp ne i32 %1, 0
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %4
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %6)
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %7)
+  store %System.String addrspace(1)* %8, %System.String addrspace(1)** %loc0
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.Text.StringBuilder addrspace(1)* %9, %System.Text.StringBuilder addrspace(1)** %loc1
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  store %System.String addrspace(1)* %10, %System.String addrspace(1)** %loc7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc7
+  %12 = ptrtoint %System.String addrspace(1)* %11 to i64
+  %13 = icmp eq i64 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %5
+  %15 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %16 = sext i32 %15 to i64
+  %17 = add i64 %12, %16
+  br label %18
+
+; <label>:18                                      ; preds = %5, %14
+  %19 = phi i64 [ %12, %5 ], [ %17, %14 ]
+  %20 = inttoptr i64 %19 to i16*
+  store i16* %20, i16** %loc2
+  br label %21
+
+; <label>:21                                      ; preds = %98, %18
+  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %22, null
+  br i1 %NullCheck, label %ThrowNullRef, label %23
+
+; <label>:23                                      ; preds = %21
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 3
+  %25 = load i32, i32 addrspace(1)* %24, align 8
+  %26 = icmp sle i32 %25, 0
+  br i1 %26, label %96, label %27
+
+; <label>:27                                      ; preds = %23
+  %28 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %28, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %29
+
+; <label>:29                                      ; preds = %27
+  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %28, i32 0, i32 1
+  %31 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %30, align 8
+  store %"System.Char[]" addrspace(1)* %31, %"System.Char[]" addrspace(1)** %loc3
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %33
+
+; <label>:33                                      ; preds = %29
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  store i32 %35, i32* %loc4
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  %39 = load i32, i32 addrspace(1)* %38, align 8
+  store i32 %39, i32* %loc5
+  %40 = load i32, i32* %loc5
+  %41 = load i32, i32* %loc4
+  %42 = add i32 %40, %41
+  %43 = zext i32 %42 to i64
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %45
+
+; <label>:45                                      ; preds = %37
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = sext i32 %47 to i64
+  %49 = icmp sgt i64 %43, %48
+  br i1 %49, label %91, label %50
+
+; <label>:50                                      ; preds = %45
+  %51 = load i32, i32* %loc5
+  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %52, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %53
+
+; <label>:53                                      ; preds = %50
+  %54 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %52, i32 0, i32 1
+  %55 = load i32, i32 addrspace(1)* %54
+  %56 = zext i32 %55 to i64
+  %57 = trunc i64 %56 to i32
+  %58 = icmp ugt i32 %51, %57
+  br i1 %58, label %91, label %59
+
+; <label>:59                                      ; preds = %53
+  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  store %"System.Char[]" addrspace(1)* %60, %"System.Char[]" addrspace(1)** %loc8
+  %61 = icmp eq %"System.Char[]" addrspace(1)* %60, null
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %63, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %64
+
+; <label>:64                                      ; preds = %62
+  %65 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %63, i32 0, i32 1
+  %66 = load i32, i32 addrspace(1)* %65
+  %67 = zext i32 %66 to i64
+  %68 = trunc i64 %67 to i32
+  %69 = icmp ne i32 %68, 0
+  br i1 %69, label %71, label %70
+
+; <label>:70                                      ; preds = %59, %64
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:71                                      ; preds = %64
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %73
+
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %BoundsCheck = icmp uge i64 0, %76
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %77
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %78, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:79                                      ; preds = %70, %77
+  %80 = load i16*, i16** %loc2
+  %81 = load i32, i32* %loc4
+  %82 = sext i32 %81 to i64
+  %83 = mul i64 %82, 2
+  %84 = bitcast i16* %80 to i8*
+  %85 = getelementptr inbounds i8, i8* %84, i64 %83
+  %86 = load i16 addrspace(1)*, i16 addrspace(1)** %loc6
+  %87 = ptrtoint i16 addrspace(1)* %86 to i64
+  %88 = load i32, i32* %loc5
+  %89 = bitcast i8* %85 to i16*
+  %90 = inttoptr i64 %87 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %89, i16* %90, i32 %88)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %96
+
+; <label>:91                                      ; preds = %45, %53
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %94 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %93)
+  %95 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95, %System.String addrspace(1)* %92, %System.String addrspace(1)* %94)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95) #0
+  unreachable
+
+; <label>:96                                      ; preds = %23, %79
+  %97 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %97, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %98
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %97, i32 0, i32 2
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  store %System.Text.StringBuilder addrspace(1)* %100, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %102 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %102, label %21, label %103
+
+; <label>:103                                     ; preds = %98
+  store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc7
+  %104 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  ret %System.String addrspace(1)* %104
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method StringBuilder::get_Length using LLILCJit
+Successfully read StringBuilder.get_Length
+
+define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
+Successfully read RuntimeHelpers.get_OffsetToStringData
+
+define i32 @RuntimeHelpers.get_OffsetToStringData() {
+entry:
+  ret i32 12
+}
+
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
 Successfully read CultureData.CreateCultureData
 
@@ -3514,23 +4249,23 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
   store i8 %4, i8 addrspace(1)* %6
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
@@ -3549,11 +4284,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3566,50 +4301,50 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
   store i32 -1, i32 addrspace(1)* %2
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
   store i32 -1, i32 addrspace(1)* %8
   %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
   store i32 -1, i32 addrspace(1)* %14
   %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
   store i32 -1, i32 addrspace(1)* %17
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
@@ -3623,27 +4358,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3675,7 +4410,136 @@ Failed to read Dictionary`2.Insert[non-const derefAddress]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
 Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
-Failed to read HashHelpers.GetPrime[loadElem]
+Successfully read HashHelpers.GetPrime
+
+define i32 @HashHelpers.GetPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %6, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5, %System.String addrspace(1)* %4)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5) #0
+  unreachable
+
+; <label>:6                                       ; preds = %entry
+  store i32 0, i32* %loc0
+  br label %29
+
+; <label>:7                                       ; preds = %35
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 1296
+  %10 = addrspacecast i8 addrspace(1)* %9 to %"System.Int32[]" addrspace(1)**
+  %11 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %10
+  %12 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Int32[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = zext i32 %15 to i64
+  %17 = zext i32 %12 to i64
+  %BoundsCheck = icmp uge i64 %17, %16
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 3, i32 %12
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  store i32 %20, i32* %loc1
+  %21 = load i32, i32* %loc1
+  %22 = load i32, i32* %arg0
+  %23 = icmp slt i32 %21, %22
+  br i1 %23, label %26, label %24
+
+; <label>:24                                      ; preds = %18
+  %25 = load i32, i32* %loc1
+  ret i32 %25
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %loc0
+  %28 = add i32 %27, 1
+  store i32 %28, i32* %loc0
+  br label %29
+
+; <label>:29                                      ; preds = %6, %26
+  %30 = load i32, i32* %loc0
+  %31 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %32 = getelementptr inbounds i8, i8 addrspace(1)* %31, i64 1296
+  %33 = addrspacecast i8 addrspace(1)* %32 to %"System.Int32[]" addrspace(1)**
+  %34 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %33
+  %NullCheck = icmp eq %"System.Int32[]" addrspace(1)* %34, null
+  br i1 %NullCheck, label %ThrowNullRef, label %35
+
+; <label>:35                                      ; preds = %29
+  %36 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %34, i32 0, i32 1
+  %37 = load i32, i32 addrspace(1)* %36
+  %38 = zext i32 %37 to i64
+  %39 = trunc i64 %38 to i32
+  %40 = icmp slt i32 %30, %39
+  br i1 %40, label %7, label %41
+
+; <label>:41                                      ; preds = %35
+  %42 = load i32, i32* %arg0
+  %43 = or i32 %42, 1
+  store i32 %43, i32* %loc2
+  br label %59
+
+; <label>:44                                      ; preds = %59
+  %45 = load i32, i32* %loc2
+  %46 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %45)
+  %47 = zext i8 %46 to i32
+  %48 = icmp eq i32 %47, 0
+  br i1 %48, label %56, label %49
+
+; <label>:49                                      ; preds = %44
+  %50 = load i32, i32* %loc2
+  %51 = sub i32 %50, 1
+  %52 = srem i32 %51, 101
+  %53 = icmp eq i32 %52, 0
+  br i1 %53, label %56, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = load i32, i32* %loc2
+  ret i32 %55
+
+; <label>:56                                      ; preds = %44, %49
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %57, 2
+  store i32 %58, i32* %loc2
+  br label %59
+
+; <label>:59                                      ; preds = %41, %56
+  %60 = load i32, i32* %loc2
+  %61 = icmp slt i32 %60, 2147483647
+  br i1 %61, label %44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load i32, i32* %arg0
+  ret i32 %63
+
+ThrowNullRef:                                     ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
 Successfully read GenericEqualityComparer`1.GetHashCode
 
@@ -3694,14 +4558,14 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
   %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load i64, i64 addrspace(1)* %7
@@ -3720,7 +4584,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3750,8 +4614,8 @@ entry:
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
@@ -3796,8 +4660,8 @@ entry:
   %35 = bitcast i16* %34 to i8*
   %36 = getelementptr inbounds i8, i8* %35, i64 2
   %37 = bitcast i8* %36 to i16*
-  %NullCheck4 = icmp ne i16* %37, null
-  br i1 %NullCheck4, label %38, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %37, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %38
 
 ; <label>:38                                      ; preds = %27
   %39 = load i16, i16* %37, align 8
@@ -3824,8 +4688,8 @@ entry:
 
 ; <label>:54                                      ; preds = %22, %43
   %55 = load i16*, i16** %loc4
-  %NullCheck2 = icmp ne i16* %55, null
-  br i1 %NullCheck2, label %56, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i16* %55, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %56
 
 ; <label>:56                                      ; preds = %54
   %57 = load i16, i16* %55, align 8
@@ -3850,11 +4714,11 @@ ThrowNullRef:                                     ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %54
+ThrowNullRef2:                                    ; preds = %54
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %27
+ThrowNullRef4:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3871,8 +4735,8 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -3907,8 +4771,8 @@ entry:
 
 ; <label>:26                                      ; preds = %19
   %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
-  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %28
 
 ; <label>:28                                      ; preds = %26
   %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
@@ -3920,7 +4784,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3972,8 +4836,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
@@ -3984,26 +4848,26 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
-  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
@@ -4014,8 +4878,8 @@ entry:
 ; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
@@ -4024,8 +4888,8 @@ entry:
 
 ; <label>:25                                      ; preds = %1, %16, %23
   %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
-  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
@@ -4036,27 +4900,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %20
+ThrowNullRef10:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4069,8 +4933,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -4081,8 +4945,8 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
@@ -4091,8 +4955,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1, %8
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
@@ -4103,11 +4967,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4128,24 +4992,24 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   store i32 %3, i32* %loc0
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
   %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
   store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck4, label %9, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
@@ -4164,15 +5028,15 @@ entry:
 ; <label>:18                                      ; preds = %70
   %19 = load i16*, i16** %loc3
   %20 = bitcast i16* %19 to i64*
-  %NullCheck10 = icmp ne i64* %20, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %20, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = load i64, i64* %20, align 8
   %23 = load i16*, i16** %loc4
   %24 = bitcast i16* %23 to i64*
-  %NullCheck12 = icmp ne i64* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = load i64, i64* %24, align 8
@@ -4188,8 +5052,8 @@ entry:
   %31 = bitcast i16* %30 to i8*
   %32 = getelementptr inbounds i8, i8* %31, i64 8
   %33 = bitcast i8* %32 to i64*
-  %NullCheck14 = icmp ne i64* %33, null
-  br i1 %NullCheck14, label %34, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = load i64, i64* %33, align 8
@@ -4197,8 +5061,8 @@ entry:
   %37 = bitcast i16* %36 to i8*
   %38 = getelementptr inbounds i8, i8* %37, i64 8
   %39 = bitcast i8* %38 to i64*
-  %NullCheck16 = icmp ne i64* %39, null
-  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %40
 
 ; <label>:40                                      ; preds = %34
   %41 = load i64, i64* %39, align 8
@@ -4214,8 +5078,8 @@ entry:
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %NullCheck18 = icmp ne i64* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = load i64, i64* %48, align 8
@@ -4223,8 +5087,8 @@ entry:
   %52 = bitcast i16* %51 to i8*
   %53 = getelementptr inbounds i8, i8* %52, i64 16
   %54 = bitcast i8* %53 to i64*
-  %NullCheck20 = icmp ne i64* %54, null
-  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64* %54, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %55
 
 ; <label>:55                                      ; preds = %49
   %56 = load i64, i64* %54, align 8
@@ -4262,15 +5126,15 @@ entry:
 ; <label>:74                                      ; preds = %95
   %75 = load i16*, i16** %loc3
   %76 = bitcast i16* %75 to i32*
-  %NullCheck6 = icmp ne i32* %76, null
-  br i1 %NullCheck6, label %77, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32* %76, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %77
 
 ; <label>:77                                      ; preds = %74
   %78 = load i32, i32* %76, align 8
   %79 = load i16*, i16** %loc4
   %80 = bitcast i16* %79 to i32*
-  %NullCheck8 = icmp ne i32* %80, null
-  br i1 %NullCheck8, label %81, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i32* %80, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %81
 
 ; <label>:81                                      ; preds = %77
   %82 = load i32, i32* %80, align 8
@@ -4318,43 +5182,43 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %74
+ThrowNullRef6:                                    ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %77
+ThrowNullRef8:                                    ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %29
+ThrowNullRef14:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %34
+ThrowNullRef16:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4376,8 +5240,8 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load i64, i64 addrspace(1)* %4
@@ -4389,8 +5253,8 @@ entry:
   %12 = load i64, i64* %11
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %5
   %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
@@ -4399,8 +5263,8 @@ entry:
   %18 = load i8, i8* %arg2
   %19 = zext i8 %18 to i32
   %20 = trunc i32 %19 to i8
-  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %15
   %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
@@ -4411,11 +5275,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4442,8 +5306,8 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
@@ -4466,16 +5330,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
   %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = load i64, i64 addrspace(1)* %19
@@ -4500,8 +5364,8 @@ entry:
 ; <label>:35                                      ; preds = %30
   %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
@@ -4514,8 +5378,8 @@ entry:
 
 ; <label>:42                                      ; preds = %1, %38
   %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
-  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
@@ -4526,19 +5390,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %35
+ThrowNullRef2:                                    ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %42
+ThrowNullRef8:                                    ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4551,14 +5415,14 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
@@ -4570,7 +5434,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4583,8 +5447,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
@@ -4613,51 +5477,51 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
   %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
   %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
   %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
   %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
-  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
   store i64 %21, i64 addrspace(1)* %23
   %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %25 = load i64, i64* %loc0
-  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
@@ -4668,27 +5532,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %22
+ThrowNullRef12:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4701,8 +5565,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
@@ -4713,19 +5577,19 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
@@ -4734,8 +5598,8 @@ entry:
 
 ; <label>:15                                      ; preds = %1, %13
   %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
@@ -4746,19 +5610,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %15
+ThrowNullRef8:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4771,8 +5635,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -4831,8 +5695,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
@@ -4882,8 +5746,8 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
-  br i1 %NullCheck, label %17, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %ThrowNullRef, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
@@ -4894,15 +5758,15 @@ entry:
 
 ; <label>:22                                      ; preds = %17
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
-  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
   %26 = load i32, i32 addrspace(1)* %25
   %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
-  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %27, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
@@ -4925,8 +5789,8 @@ entry:
 ; <label>:40                                      ; preds = %17
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
-  br i1 %NullCheck6, label %43, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %41, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
@@ -4938,34 +5802,17 @@ ThrowNullRef:                                     ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %24
+ThrowNullRef4:                                    ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %40
+ThrowNullRef6:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
-}
-
-INFO:  jitting method Object::ReferenceEquals using LLILCJit
-Successfully read Object.ReferenceEquals
-
-define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
-entry:
-  %arg0 = alloca %System.Object addrspace(1)*
-  %arg1 = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
-  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
-  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = icmp eq %System.Object addrspace(1)* %0, %1
-  %3 = sext i1 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
 }
 
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
@@ -4978,21 +5825,21 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
   %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
-  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
@@ -5007,28 +5854,28 @@ entry:
 ; <label>:13                                      ; preds = %8, %12
   %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
   %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
   %21 = load i32, i32 addrspace(1)* %20, align 8
   %22 = add i32 %21, 1
-  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
   store i32 %22, i32 addrspace(1)* %24
   %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
@@ -5039,27 +5886,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5077,7 +5924,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::Setup using LLILCJit
-Failed to read AppDomain.Setup[loadElem]
+Failed to read AppDomain.Setup[unbox]
 INFO:  jitting method Thread::GetDomain using LLILCJit
 Successfully read Thread.GetDomain
 
@@ -5108,8 +5955,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
@@ -5122,14 +5969,14 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
   %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
@@ -5141,11 +5988,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5173,8 +6020,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -5189,7 +6036,328 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
 Failed to read KeyCollection.System.Collections.Generic.IEnumerable<TKey>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Successfully read Enumerator.MoveNext
+
+define i8 @Enumerator.MoveNext(%"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.RuntimeTypeHandle* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*
+  %"$TypeArg" = alloca %System.RuntimeTypeHandle*
+  store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
+  %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 8
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %76, label %12
+
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
+  br label %76
+
+; <label>:13                                      ; preds = %85
+  %14 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck19 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %15
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, i32 0, i32 0
+  %17 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %16, align 8
+  %NullCheck21 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, i32 0, i32 2
+  %20 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %19, align 8
+  %21 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck23 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %22
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, i32 0, i32 2
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %NullCheck25 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 3, i32 %24
+  %NullCheck27 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %32
+
+; <label>:32                                      ; preds = %30
+  %33 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, i32 0, i32 2
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = icmp slt i32 %34, 0
+  br i1 %35, label %68, label %36
+
+; <label>:36                                      ; preds = %32
+  %37 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %38 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck29 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %39
+
+; <label>:39                                      ; preds = %36
+  %40 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, i32 0, i32 0
+  %41 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %40, align 8
+  %NullCheck31 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, i32 0, i32 2
+  %44 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %43, align 8
+  %45 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck33 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, i32 0, i32 2
+  %48 = load i32, i32 addrspace(1)* %47, align 8
+  %NullCheck35 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %49
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = zext i32 %51 to i64
+  %53 = zext i32 %48 to i64
+  %BoundsCheck37 = icmp uge i64 %53, %52
+  br i1 %BoundsCheck37, label %ThrowIndexOutOfRange38, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 3, i32 %48
+  %NullCheck39 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %56
+
+; <label>:56                                      ; preds = %54
+  %57 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, i32 0, i32 0
+  %58 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck41 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %59
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %60, %System.__Canon addrspace(1)* %58)
+  %61 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck43 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  %64 = load i32, i32 addrspace(1)* %63, align 8
+  %65 = add i32 %64, 1
+  %NullCheck45 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  store i32 %65, i32 addrspace(1)* %67
+  ret i8 1
+
+; <label>:68                                      ; preds = %32
+  %69 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck47 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %73 = add i32 %72, 1
+  %NullCheck49 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %74
+
+; <label>:74                                      ; preds = %70
+  %75 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  store i32 %73, i32 addrspace(1)* %75
+  br label %76
+
+; <label>:76                                      ; preds = %8, %12, %74
+  %77 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %78
+
+; <label>:78                                      ; preds = %76
+  %79 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, i32 0, i32 2
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck7 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %82
+
+; <label>:82                                      ; preds = %78
+  %83 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, i32 0, i32 0
+  %84 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %83, align 8
+  %NullCheck9 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %85
+
+; <label>:85                                      ; preds = %82
+  %86 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, i32 0, i32 7
+  %87 = load i32, i32 addrspace(1)* %86, align 8
+  %88 = icmp ult i32 %80, %87
+  br i1 %88, label %13, label %89
+
+; <label>:89                                      ; preds = %85
+  %90 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %91 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck11 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %92
+
+; <label>:92                                      ; preds = %89
+  %93 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, i32 0, i32 0
+  %94 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck13 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %95
+
+; <label>:95                                      ; preds = %92
+  %96 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, i32 0, i32 7
+  %97 = load i32, i32 addrspace(1)* %96, align 8
+  %98 = add i32 %97, 1
+  %NullCheck15 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %99
+
+; <label>:99                                      ; preds = %95
+  %100 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, i32 0, i32 2
+  store i32 %98, i32 addrspace(1)* %100
+  %101 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck17 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %102
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %103, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %92
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef22:                                   ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef24:                                   ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef26:                                   ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef28:                                   ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef30:                                   ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef32:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef34:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef36:                                   ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange38:                           ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef40:                                   ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef42:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef44:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef46:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef48:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef50:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -5200,8 +6368,8 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -5232,9 +6400,9 @@ Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
 Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
-Failed to read String.MakeSeparatorList[loadElemA]
+Failed to read String.MakeSeparatorList[storeElem]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
-Failed to read String.InternalSplitKeepEmptyEntries[loadElem]
+Failed to read String.InternalSplitKeepEmptyEntries[storeElem]
 INFO:  jitting method Path::IsRelative using LLILCJit
 Successfully read Path.IsRelative
 
@@ -5243,8 +6411,8 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -5254,8 +6422,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
@@ -5271,8 +6439,8 @@ entry:
 
 ; <label>:17                                      ; preds = %7
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
@@ -5288,8 +6456,8 @@ entry:
 
 ; <label>:29                                      ; preds = %19
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %31
 
 ; <label>:31                                      ; preds = %29
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
@@ -5300,8 +6468,8 @@ entry:
 
 ; <label>:36                                      ; preds = %31
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
-  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %37, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
@@ -5312,8 +6480,8 @@ entry:
 
 ; <label>:43                                      ; preds = %31, %38
   %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
-  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %45
 
 ; <label>:45                                      ; preds = %43
   %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
@@ -5324,8 +6492,8 @@ entry:
 
 ; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %50
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
@@ -5336,8 +6504,8 @@ entry:
 
 ; <label>:57                                      ; preds = %1, %7, %19, %45, %52
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
-  br i1 %NullCheck14, label %59, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %59
 
 ; <label>:59                                      ; preds = %57
   %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
@@ -5347,8 +6515,8 @@ entry:
 
 ; <label>:63                                      ; preds = %59
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
@@ -5359,8 +6527,8 @@ entry:
 
 ; <label>:70                                      ; preds = %65
   %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
-  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.String addrspace(1)* %71, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %72
 
 ; <label>:72                                      ; preds = %70
   %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
@@ -5379,39 +6547,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %17
+ThrowNullRef4:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %29
+ThrowNullRef6:                                    ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %36
+ThrowNullRef8:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %43
+ThrowNullRef10:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %50
+ThrowNullRef12:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %57
+ThrowNullRef14:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %63
+ThrowNullRef16:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %70
+ThrowNullRef18:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5419,7 +6587,293 @@ ThrowNullRef17:                                   ; preds = %70
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
-Failed to read String.TrimHelper[loadElem]
+Successfully read String.TrimHelper
+
+define %System.String addrspace(1)* @String.TrimHelper(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i16
+  %loc4 = alloca i32
+  %loc5 = alloca i16
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = sub i32 %3, 1
+  store i32 %4, i32* %loc0
+  store i32 0, i32* %loc1
+  %5 = load i32, i32* %arg2
+  %6 = icmp eq i32 %5, 1
+  br i1 %6, label %62, label %7
+
+; <label>:7                                       ; preds = %1
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:8                                       ; preds = %58
+  store i32 0, i32* %loc2
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load i32, i32* %loc1
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2, i32 %10
+  %13 = load i16, i16 addrspace(1)* %12
+  %14 = zext i16 %13 to i32
+  %15 = trunc i32 %14 to i16
+  store i16 %15, i16* %loc3
+  store i32 0, i32* %loc2
+  br label %34
+
+; <label>:16                                      ; preds = %37
+  %17 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %18 = load i32, i32* %loc2
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %17, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %19
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = zext i32 %18 to i64
+  %BoundsCheck = icmp uge i64 %23, %22
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %24
+
+; <label>:24                                      ; preds = %19
+  %25 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 3, i32 %18
+  %26 = load i16, i16 addrspace(1)* %25, align 8
+  %27 = zext i16 %26 to i32
+  %28 = load i16, i16* %loc3
+  %29 = zext i16 %28 to i32
+  %30 = icmp eq i32 %27, %29
+  br i1 %30, label %43, label %31
+
+; <label>:31                                      ; preds = %24
+  %32 = load i32, i32* %loc2
+  %33 = add i32 %32, 1
+  store i32 %33, i32* %loc2
+  br label %34
+
+; <label>:34                                      ; preds = %11, %31
+  %35 = load i32, i32* %loc2
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = icmp slt i32 %35, %41
+  br i1 %42, label %16, label %43
+
+; <label>:43                                      ; preds = %24, %37
+  %44 = load i32, i32* %loc2
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %45, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp eq i32 %44, %50
+  br i1 %51, label %62, label %52
+
+; <label>:52                                      ; preds = %46
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %7, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %57, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %58
+
+; <label>:58                                      ; preds = %55
+  %59 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %60 = load i32, i32 addrspace(1)* %59
+  %61 = icmp slt i32 %56, %60
+  br i1 %61, label %8, label %62
+
+; <label>:62                                      ; preds = %1, %46, %58
+  %63 = load i32, i32* %arg2
+  %64 = icmp eq i32 %63, 0
+  br i1 %64, label %122, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %66, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %67
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %66, i32 0, i32 1
+  %69 = load i32, i32 addrspace(1)* %68
+  %70 = sub i32 %69, 1
+  store i32 %70, i32* %loc0
+  br label %118
+
+; <label>:71                                      ; preds = %118
+  store i32 0, i32* %loc4
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %73 = load i32, i32* %loc0
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %74
+
+; <label>:74                                      ; preds = %71
+  %75 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 2, i32 %73
+  %76 = load i16, i16 addrspace(1)* %75
+  %77 = zext i16 %76 to i32
+  %78 = trunc i32 %77 to i16
+  store i16 %78, i16* %loc5
+  store i32 0, i32* %loc4
+  br label %97
+
+; <label>:79                                      ; preds = %100
+  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %81 = load i32, i32* %loc4
+  %NullCheck19 = icmp eq %"System.Char[]" addrspace(1)* %80, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
+
+; <label>:82                                      ; preds = %79
+  %83 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 1
+  %84 = load i32, i32 addrspace(1)* %83
+  %85 = zext i32 %84 to i64
+  %86 = zext i32 %81 to i64
+  %BoundsCheck21 = icmp uge i64 %86, %85
+  br i1 %BoundsCheck21, label %ThrowIndexOutOfRange22, label %87
+
+; <label>:87                                      ; preds = %82
+  %88 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 3, i32 %81
+  %89 = load i16, i16 addrspace(1)* %88, align 8
+  %90 = zext i16 %89 to i32
+  %91 = load i16, i16* %loc5
+  %92 = zext i16 %91 to i32
+  %93 = icmp eq i32 %90, %92
+  br i1 %93, label %106, label %94
+
+; <label>:94                                      ; preds = %87
+  %95 = load i32, i32* %loc4
+  %96 = add i32 %95, 1
+  store i32 %96, i32* %loc4
+  br label %97
+
+; <label>:97                                      ; preds = %74, %94
+  %98 = load i32, i32* %loc4
+  %99 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck15 = icmp eq %"System.Char[]" addrspace(1)* %99, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %100
+
+; <label>:100                                     ; preds = %97
+  %101 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %99, i32 0, i32 1
+  %102 = load i32, i32 addrspace(1)* %101
+  %103 = zext i32 %102 to i64
+  %104 = trunc i64 %103 to i32
+  %105 = icmp slt i32 %98, %104
+  br i1 %105, label %79, label %106
+
+; <label>:106                                     ; preds = %87, %100
+  %107 = load i32, i32* %loc4
+  %108 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck17 = icmp eq %"System.Char[]" addrspace(1)* %108, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %109
+
+; <label>:109                                     ; preds = %106
+  %110 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %108, i32 0, i32 1
+  %111 = load i32, i32 addrspace(1)* %110
+  %112 = zext i32 %111 to i64
+  %113 = trunc i64 %112 to i32
+  %114 = icmp eq i32 %107, %113
+  br i1 %114, label %122, label %115
+
+; <label>:115                                     ; preds = %109
+  %116 = load i32, i32* %loc0
+  %117 = sub i32 %116, 1
+  store i32 %117, i32* %loc0
+  br label %118
+
+; <label>:118                                     ; preds = %67, %115
+  %119 = load i32, i32* %loc0
+  %120 = load i32, i32* %loc1
+  %121 = icmp sge i32 %119, %120
+  br i1 %121, label %71, label %122
+
+; <label>:122                                     ; preds = %62, %109, %118
+  %123 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %124 = load i32, i32* %loc1
+  %125 = load i32, i32* %loc0
+  %126 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %123, i32 %124, i32 %125)
+  ret %System.String addrspace(1)* %126
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %97
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange22:                           ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
 Successfully read String.CreateTrimmedString
 
@@ -5439,8 +6893,8 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
@@ -5535,8 +6989,8 @@ entry:
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i64 2872
   %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
   %8 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %7
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %3
   %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
@@ -5553,8 +7007,8 @@ entry:
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 2864
   %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
   %21 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %20
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
-  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %22
 
 ; <label>:22                                      ; preds = %16
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
@@ -5569,7 +7023,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %16
+ThrowNullRef2:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5586,8 +7040,8 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5613,8 +7067,8 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
@@ -5632,8 +7086,8 @@ entry:
 
 ; <label>:12                                      ; preds = %4
   %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
@@ -5644,8 +7098,8 @@ entry:
 
 ; <label>:19                                      ; preds = %14
   %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %19
   %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
@@ -5660,21 +7114,21 @@ entry:
   %31 = zext i16 %30 to i32
   %32 = bitcast i8* %29 to i16*
   %33 = trunc i32 %31 to i16
-  %NullCheck6 = icmp ne i16* %32, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i16* %32, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %21
   store i16 %33, i16* %32, align 8
   %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %36
 
 ; <label>:36                                      ; preds = %34
   %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
   %38 = load i32, i32 addrspace(1)* %37, align 8
   %39 = add i32 %38, 1
-  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %40
 
 ; <label>:40                                      ; preds = %36
   %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
@@ -5683,16 +7137,16 @@ entry:
 
 ; <label>:42                                      ; preds = %14
   %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
-  br i1 %NullCheck12, label %44, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
   %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
   %47 = load i16, i16* %arg1
   %48 = zext i16 %47 to i32
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = trunc i32 %48 to i16
@@ -5703,31 +7157,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %19
+ThrowNullRef4:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %21
+ThrowNullRef6:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %36
+ThrowNullRef10:                                   ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %42
+ThrowNullRef12:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %44
+ThrowNullRef14:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5740,8 +7194,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -5752,8 +7206,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
@@ -5762,14 +7216,14 @@ entry:
 
 ; <label>:11                                      ; preds = %1
   %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
@@ -5779,15 +7233,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5808,8 +7262,8 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5822,8 +7276,8 @@ entry:
 
 ; <label>:8                                       ; preds = %3
   %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
@@ -5842,15 +7296,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
-  br i1 %NullCheck4, label %22, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
   %24 = load i16*, i16* addrspace(1)* %23, align 8
   %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %25, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
@@ -5859,8 +7313,8 @@ entry:
   store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
@@ -5874,8 +7328,8 @@ entry:
 
 ; <label>:37                                      ; preds = %65
   %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %37
   %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
@@ -5886,16 +7340,16 @@ entry:
   %45 = bitcast i16* %41 to i8*
   %46 = getelementptr inbounds i8, i8* %45, i64 %44
   %47 = bitcast i8* %46 to i16*
-  %NullCheck14 = icmp ne i16* %47, null
-  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %47, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %48
 
 ; <label>:48                                      ; preds = %39
   %49 = load i16, i16* %47, align 8
   %50 = zext i16 %49 to i32
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %52 = load i32, i32* %loc1
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %53
 
 ; <label>:53                                      ; preds = %48
   %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
@@ -5916,8 +7370,8 @@ entry:
 ; <label>:62                                      ; preds = %36, %59
   %63 = load i32, i32* %loc1
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck10, label %65, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %65
 
 ; <label>:65                                      ; preds = %62
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
@@ -5936,15 +7390,15 @@ entry:
 
 ; <label>:74                                      ; preds = %70
   %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
-  br i1 %NullCheck18, label %76, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %76
 
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
   %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
-  br i1 %NullCheck20, label %80, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
   %81 = load i64, i64 addrspace(1)* %79
@@ -5958,8 +7412,8 @@ entry:
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
   %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
-  br i1 %NullCheck22, label %92, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.String addrspace(1)* %90, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %92
 
 ; <label>:92                                      ; preds = %80
   %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
@@ -5969,15 +7423,15 @@ entry:
 
 ; <label>:96                                      ; preds = %70
   %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
-  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %98
 
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
   %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
-  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
   %103 = load i64, i64 addrspace(1)* %101
@@ -5991,8 +7445,8 @@ entry:
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
   %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
-  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.String addrspace(1)* %112, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %114
 
 ; <label>:114                                     ; preds = %102
   %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
@@ -6004,59 +7458,59 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %20
+ThrowNullRef4:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %22
+ThrowNullRef6:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %26
+ThrowNullRef8:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %62
+ThrowNullRef10:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %48
+ThrowNullRef16:                                   ; preds = %48
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %74
+ThrowNullRef18:                                   ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %76
+ThrowNullRef20:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %80
+ThrowNullRef22:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %96
+ThrowNullRef24:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %98
+ThrowNullRef26:                                   ; preds = %98
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %102
+ThrowNullRef28:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6069,15 +7523,15 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
   %3 = load i16*, i16* addrspace(1)* %2, align 8
   %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
@@ -6087,8 +7541,8 @@ entry:
   %10 = bitcast i16* %3 to i8*
   %11 = getelementptr inbounds i8, i8* %10, i64 %9
   %12 = bitcast i8* %11 to i16*
-  %NullCheck4 = icmp ne i16* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %5
   store i16 0, i16* %12, align 8
@@ -6098,11 +7552,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6119,8 +7573,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -6131,8 +7585,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
@@ -6144,15 +7598,15 @@ entry:
 
 ; <label>:14                                      ; preds = %1
   %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
   %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
   %21 = load i64, i64 addrspace(1)* %19
@@ -6171,15 +7625,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %14
+ThrowNullRef4:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %16
+ThrowNullRef6:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6302,14 +7756,6 @@ entry:
   ret %System.String addrspace(1)* %57
 }
 
-INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
-Successfully read RuntimeHelpers.get_OffsetToStringData
-
-define i32 @RuntimeHelpers.get_OffsetToStringData() {
-entry:
-  ret i32 12
-}
-
 INFO:  jitting method String::Equals using LLILCJit
 Successfully read String.Equals
 
@@ -6381,8 +7827,8 @@ entry:
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
-  br i1 %NullCheck24, label %29, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
   %30 = load i64, i64 addrspace(1)* %28
@@ -6397,8 +7843,8 @@ entry:
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
-  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
   %43 = load i64, i64 addrspace(1)* %41
@@ -6418,8 +7864,8 @@ entry:
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
   %59 = load i64, i64 addrspace(1)* %57
@@ -6434,8 +7880,8 @@ entry:
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck22, label %71, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
   %72 = load i64, i64 addrspace(1)* %70
@@ -6455,8 +7901,8 @@ entry:
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
-  br i1 %NullCheck16, label %87, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = load i64, i64 addrspace(1)* %86
@@ -6471,8 +7917,8 @@ entry:
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck18, label %100, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
   %101 = load i64, i64 addrspace(1)* %99
@@ -6492,8 +7938,8 @@ entry:
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
-  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
   %117 = load i64, i64 addrspace(1)* %115
@@ -6508,8 +7954,8 @@ entry:
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
-  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
   %130 = load i64, i64 addrspace(1)* %128
@@ -6528,15 +7974,15 @@ entry:
 
 ; <label>:142                                     ; preds = %22
   %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
-  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %143, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %144
 
 ; <label>:144                                     ; preds = %142
   %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
   %146 = load i32, i32 addrspace(1)* %145
   %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
-  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %147, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %148
 
 ; <label>:148                                     ; preds = %144
   %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
@@ -6557,15 +8003,15 @@ entry:
 
 ; <label>:159                                     ; preds = %22
   %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
-  br i1 %NullCheck, label %161, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %ThrowNullRef, label %161
 
 ; <label>:161                                     ; preds = %159
   %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
   %163 = load i32, i32 addrspace(1)* %162
   %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
-  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %164, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %165
 
 ; <label>:165                                     ; preds = %161
   %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
@@ -6578,8 +8024,8 @@ entry:
 
 ; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
-  br i1 %NullCheck4, label %172, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %171, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %172
 
 ; <label>:172                                     ; preds = %170
   %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
@@ -6589,8 +8035,8 @@ entry:
 
 ; <label>:176                                     ; preds = %172
   %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
-  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %177, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %178
 
 ; <label>:178                                     ; preds = %176
   %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
@@ -6629,55 +8075,55 @@ ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %161
+ThrowNullRef2:                                    ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %170
+ThrowNullRef4:                                    ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %176
+ThrowNullRef6:                                    ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %142
+ThrowNullRef8:                                    ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %144
+ThrowNullRef10:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %113
+ThrowNullRef12:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %116
+ThrowNullRef14:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %84
+ThrowNullRef16:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %87
+ThrowNullRef18:                                   ; preds = %87
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %55
+ThrowNullRef20:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %58
+ThrowNullRef22:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %26
+ThrowNullRef24:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %29
+ThrowNullRef26:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,8 +8161,8 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck, label %14, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %ThrowNullRef, label %14
 
 ; <label>:14                                      ; preds = %8
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
@@ -6760,8 +8206,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
@@ -6770,14 +8216,14 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32, i32* %loc0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %10
   %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
   %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
@@ -6790,15 +8236,15 @@ entry:
 ; <label>:25                                      ; preds = %19
   %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
-  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
   %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
@@ -6807,8 +8253,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %37 = load i32, i32* %loc0
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %38, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %38
 
 ; <label>:38                                      ; preds = %32
   %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
@@ -6817,14 +8263,14 @@ entry:
 
 ; <label>:40                                      ; preds = %19
   %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %40
   %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
   %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
-  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
-  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
@@ -6832,8 +8278,8 @@ entry:
   %48 = zext i32 %47 to i64
   %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
-  br i1 %NullCheck16, label %51, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %51
 
 ; <label>:51                                      ; preds = %45
   %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
@@ -6847,15 +8293,15 @@ entry:
 ; <label>:57                                      ; preds = %51
   %58 = load i16*, i16** %arg1
   %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
-  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %60
 
 ; <label>:60                                      ; preds = %57
   %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
   %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
-  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %64
 
 ; <label>:64                                      ; preds = %60
   %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
@@ -6864,22 +8310,22 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
   %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
-  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %70
 
 ; <label>:70                                      ; preds = %64
   %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
   %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
-  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
-  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
   %75 = load i32, i32 addrspace(1)* %74
   %76 = zext i32 %75 to i64
   %77 = trunc i64 %76 to i32
-  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
-  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %78
 
 ; <label>:78                                      ; preds = %73
   %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
@@ -6901,8 +8347,8 @@ entry:
   %90 = bitcast i16* %86 to i8*
   %91 = getelementptr inbounds i8, i8* %90, i64 %89
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %93
 
 ; <label>:93                                      ; preds = %80
   %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
@@ -6912,8 +8358,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %99 = load i32, i32* %loc2
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %100
 
 ; <label>:100                                     ; preds = %93
   %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
@@ -6928,63 +8374,63 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %25
+ThrowNullRef6:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %32
+ThrowNullRef10:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %40
+ThrowNullRef12:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %45
+ThrowNullRef16:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %57
+ThrowNullRef18:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %60
+ThrowNullRef20:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %64
+ThrowNullRef22:                                   ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %70
+ThrowNullRef24:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %73
+ThrowNullRef26:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %80
+ThrowNullRef28:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %93
+ThrowNullRef30:                                   ; preds = %93
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7004,8 +8450,8 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
@@ -7033,43 +8479,43 @@ entry:
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %14
   %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
   %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   %28 = load i32, i32 addrspace(1)* %27, align 8
   %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
-  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %30
 
 ; <label>:30                                      ; preds = %26
   %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
   %32 = load i32, i32 addrspace(1)* %31, align 8
   %33 = add i32 %28, %32
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %34
 
 ; <label>:34                                      ; preds = %30
   %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   store i32 %33, i32 addrspace(1)* %35
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
   store i32 0, i32 addrspace(1)* %38
   %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %40
 
 ; <label>:40                                      ; preds = %37
   %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
@@ -7082,8 +8528,8 @@ entry:
 
 ; <label>:47                                      ; preds = %40
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
@@ -7098,8 +8544,8 @@ entry:
   %54 = load i32, i32* %loc0
   %55 = sext i32 %54 to i64
   %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
-  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %57
 
 ; <label>:57                                      ; preds = %52
   %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
@@ -7110,68 +8556,35 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %14
+ThrowNullRef2:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %23
+ThrowNullRef4:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %26
+ThrowNullRef6:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %30
+ThrowNullRef8:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %34
+ThrowNullRef10:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %47
+ThrowNullRef14:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %52
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-}
-
-INFO:  jitting method StringBuilder::get_Length using LLILCJit
-Successfully read StringBuilder.get_Length
-
-define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.StringBuilder addrspace(1)*
-  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
-  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
-
-; <label>:1                                       ; preds = %entry
-  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %3 = load i32, i32 addrspace(1)* %2, align 8
-  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
-
-; <label>:5                                       ; preds = %1
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = add i32 %3, %7
-  ret i32 %8
-
-ThrowNullRef:                                     ; preds = %entry
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef16:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7213,70 +8626,70 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
   %6 = load i32, i32 addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
   store i32 %6, i32 addrspace(1)* %8
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
   %13 = load i32, i32 addrspace(1)* %12, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
   store i32 %13, i32 addrspace(1)* %15
   %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
-  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %18
 
 ; <label>:18                                      ; preds = %14
   %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
   %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
   %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
   %34 = load i32, i32 addrspace(1)* %33, align 8
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
-  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
@@ -7287,39 +8700,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %28
+ThrowNullRef16:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %32
+ThrowNullRef18:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7455,13 +8868,13 @@ entry:
 ; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
@@ -7477,16 +8890,16 @@ entry:
 
 ; <label>:18                                      ; preds = %15
   %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
   store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
   %22 = load i32, i32* %loc0
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %24
 
 ; <label>:24                                      ; preds = %20
   %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
@@ -7498,13 +8911,13 @@ entry:
 ; <label>:28                                      ; preds = %15, %24
   %29 = load i32, i32* %arg1
   %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %31
   %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
@@ -7517,20 +8930,20 @@ entry:
   %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
-  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
   %46 = load i32, i32 addrspace(1)* %45, align 8
   %47 = sub i32 %40, %46
-  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
-  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i32 addrspace(1)* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %48
 
 ; <label>:48                                      ; preds = %44
   store i32 %47, i32 addrspace(1)* %39, align 8
@@ -7538,21 +8951,21 @@ entry:
 
 ; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
-  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %51
 
 ; <label>:51                                      ; preds = %49
   %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %53
 
 ; <label>:53                                      ; preds = %51
   %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
   %55 = load i32, i32 addrspace(1)* %54, align 8
   %56 = load i32, i32* %arg2
   %57 = sub i32 %55, %56
-  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %58
 
 ; <label>:58                                      ; preds = %53
   %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
@@ -7562,13 +8975,13 @@ entry:
 ; <label>:60                                      ; preds = %33, %58
   %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
   %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
-  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %63
 
 ; <label>:63                                      ; preds = %60
   %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
-  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
-  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
@@ -7578,15 +8991,15 @@ entry:
 
 ; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
-  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i32 addrspace(1)* %69, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %70
 
 ; <label>:70                                      ; preds = %68
   %71 = load i32, i32 addrspace(1)* %69, align 8
   store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
-  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
@@ -7596,8 +9009,8 @@ entry:
   store i32 %77, i32* %loc4
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
-  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %80
 
 ; <label>:80                                      ; preds = %73
   %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
@@ -7607,71 +9020,71 @@ entry:
 ; <label>:83                                      ; preds = %80
   store i32 0, i32* %loc3
   %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
-  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
-  br i1 %NullCheck26, label %88, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i32 addrspace(1)* %87, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %88
 
 ; <label>:88                                      ; preds = %85
   %89 = load i32, i32 addrspace(1)* %87, align 8
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
-  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %90
 
 ; <label>:90                                      ; preds = %88
   %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
   store i32 %89, i32 addrspace(1)* %91
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
-  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
-  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %96
 
 ; <label>:96                                      ; preds = %94
   %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
-  br i1 %NullCheck34, label %100, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %100
 
 ; <label>:100                                     ; preds = %96
   %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
-  br i1 %NullCheck36, label %102, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %102
 
 ; <label>:102                                     ; preds = %100
   %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
   %104 = load i32, i32 addrspace(1)* %103, align 8
   %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
-  br i1 %NullCheck38, label %106, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %106
 
 ; <label>:106                                     ; preds = %102
   %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
-  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
-  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %108
 
 ; <label>:108                                     ; preds = %106
   %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
   %110 = load i32, i32 addrspace(1)* %109, align 8
   %111 = add i32 %104, %110
-  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %112
 
 ; <label>:112                                     ; preds = %108
   %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
   store i32 %111, i32 addrspace(1)* %113
   %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
-  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i32 addrspace(1)* %114, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %115
 
 ; <label>:115                                     ; preds = %112
   %116 = load i32, i32 addrspace(1)* %114, align 8
@@ -7681,19 +9094,19 @@ entry:
 ; <label>:118                                     ; preds = %115
   %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
-  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %121
 
 ; <label>:121                                     ; preds = %118
   %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
-  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
-  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %123
 
 ; <label>:123                                     ; preds = %121
   %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
   %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
-  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
-  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %126
 
 ; <label>:126                                     ; preds = %123
   %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
@@ -7705,8 +9118,8 @@ entry:
 
 ; <label>:130                                     ; preds = %80, %115, %126
   %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %132
 
 ; <label>:132                                     ; preds = %130
   %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7715,8 +9128,8 @@ entry:
   %136 = load i32, i32* %loc3
   %137 = sub i32 %135, %136
   %138 = sub i32 %134, %137
-  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %139
 
 ; <label>:139                                     ; preds = %132
   %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7728,16 +9141,16 @@ entry:
 
 ; <label>:144                                     ; preds = %139
   %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
-  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %146
 
 ; <label>:146                                     ; preds = %144
   %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
   %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
   %149 = load i32, i32* %loc2
   %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
-  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %151
 
 ; <label>:151                                     ; preds = %146
   %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
@@ -7754,145 +9167,249 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %18
+ThrowNullRef4:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %31
+ThrowNullRef10:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %44
+ThrowNullRef16:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %68
+ThrowNullRef18:                                   ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %70
+ThrowNullRef20:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %73
+ThrowNullRef22:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %83
+ThrowNullRef24:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %85
+ThrowNullRef26:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %88
+ThrowNullRef28:                                   ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %90
+ThrowNullRef30:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %94
+ThrowNullRef32:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %96
+ThrowNullRef34:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %100
+ThrowNullRef36:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %102
+ThrowNullRef38:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %106
+ThrowNullRef40:                                   ; preds = %106
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %108
+ThrowNullRef42:                                   ; preds = %108
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %112
+ThrowNullRef44:                                   ; preds = %112
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %118
+ThrowNullRef46:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %121
+ThrowNullRef48:                                   ; preds = %121
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %123
+ThrowNullRef50:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %130
+ThrowNullRef52:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %132
+ThrowNullRef54:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %144
+ThrowNullRef56:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %146
+ThrowNullRef58:                                   ; preds = %146
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %60
+ThrowNullRef60:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %63
+ThrowNullRef62:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %49
+ThrowNullRef64:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %51
+ThrowNullRef66:                                   ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %53
+ThrowNullRef68:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(%"System.Char[]" addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %arg0 = alloca %"System.Char[]" addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store %"System.Char[]" addrspace(1)* %param0, %"System.Char[]" addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load i32, i32* %arg4
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %43, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %38, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg1
+  %13 = load i32, i32* %arg4
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %38, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %24 = load i32, i32* %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %35 = load i32, i32* %arg3
+  %36 = load i32, i32* %arg4
+  %37 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %37, %"System.Char[]" addrspace(1)* %34, i32 %35, i32 %36)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:38                                      ; preds = %5, %16
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Successfully read Buffer._Memmove
 
@@ -7914,7 +9431,7 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[loadElem]
+Failed to read AppDomain.SetDataHelper[storeElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -7923,8 +9440,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
@@ -7934,8 +9451,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
@@ -7947,15 +9464,15 @@ entry:
   %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
   %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
@@ -7966,15 +9483,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7992,7 +9509,79 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
-Failed to read Dictionary`2.TryGetValue[loadElemA]
+Successfully read Dictionary`2.TryGetValue
+
+define i8 @"Dictionary`2.TryGetValue"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)* addrspace(1)* %param2) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  %arg2 = alloca %System.__Canon addrspace(1)* addrspace(1)*
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  store %System.__Canon addrspace(1)* addrspace(1)* %param2, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  store i32 %2, i32* %loc0
+  %3 = load i32, i32* %loc0
+  %4 = icmp slt i32 %3, 0
+  br i1 %4, label %22, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 2
+  %10 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %9, align 8
+  %11 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = zext i32 %11 to i64
+  %BoundsCheck = icmp uge i64 %16, %15
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 3, i32 %11
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %20, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %6, %System.__Canon addrspace(1)* %21)
+  ret i8 1
+
+; <label>:22                                      ; preds = %entry
+  %23 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %23, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -8058,8 +9647,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
@@ -8091,8 +9680,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
@@ -8171,15 +9760,15 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck, label %19, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %ThrowNullRef, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
   %21 = load i32, i32 addrspace(1)* %20
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
@@ -8202,7 +9791,7 @@ ThrowNullRef:                                     ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %19
+ThrowNullRef2:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8248,8 +9837,8 @@ entry:
   %0 = alloca %System.AppDomainHandle
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %1 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %1, i32 0, i32 15
@@ -8269,8 +9858,8 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
@@ -8286,7 +9875,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -8299,8 +9888,8 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -8327,8 +9916,8 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
@@ -8352,8 +9941,8 @@ entry:
   %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
   store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
@@ -8363,8 +9952,8 @@ entry:
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
@@ -8374,8 +9963,8 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %9
   %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
@@ -8384,8 +9973,8 @@ entry:
 
 ; <label>:18                                      ; preds = %3, %16
   %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
@@ -8397,15 +9986,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %18
+ThrowNullRef6:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8418,8 +10007,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
@@ -8453,15 +10042,15 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
@@ -8473,7 +10062,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8481,7 +10070,7 @@ ThrowNullRef1:                                    ; preds = %1
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
 Failed to read Dictionary`2.System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
@@ -8506,8 +10095,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
@@ -8524,8 +10113,8 @@ entry:
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -8544,7 +10133,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8577,8 +10166,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = load i64, i64* %arg2
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = trunc i32 %3 to i8
@@ -8634,46 +10223,46 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
   %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
-  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
-  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
-  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
@@ -8684,27 +10273,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %20
+ThrowNullRef12:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8717,8 +10306,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -8756,22 +10345,22 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
   %9 = load i64, i64 addrspace(1)* %8, align 8
   %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
   %13 = load i64, i64 addrspace(1)* %12, align 8
   %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %11
   %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
@@ -8788,11 +10377,11 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8882,8 +10471,8 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
@@ -8900,8 +10489,8 @@ entry:
 ; <label>:8                                       ; preds = %1
   %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
   %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
@@ -8911,15 +10500,15 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
   %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
   %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
-  br i1 %NullCheck6, label %21, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
@@ -8946,15 +10535,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8992,15 +10581,15 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
   store i8 %3, i8 addrspace(1)* %5
   %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
@@ -9011,7 +10600,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9027,8 +10616,8 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -9041,8 +10630,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
@@ -9058,7 +10647,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9080,8 +10669,8 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
@@ -9096,8 +10685,8 @@ entry:
 ; <label>:12                                      ; preds = %6
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
@@ -9112,8 +10701,8 @@ entry:
 ; <label>:21                                      ; preds = %15
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
@@ -9128,8 +10717,8 @@ entry:
 ; <label>:30                                      ; preds = %24
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %31, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
@@ -9144,8 +10733,8 @@ entry:
 ; <label>:39                                      ; preds = %33
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
-  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %40, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %42
 
 ; <label>:42                                      ; preds = %39
   %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
@@ -9164,19 +10753,19 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %21
+ThrowNullRef4:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %30
+ThrowNullRef6:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %39
+ThrowNullRef8:                                    ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9243,8 +10832,8 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
@@ -9264,57 +10853,57 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
   store i8 0, i8 addrspace(1)* %2
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
   store i8 0, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
   store i8 0, i8 addrspace(1)* %17
   %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
   store i8 0, i8 addrspace(1)* %20
   %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
-  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
@@ -9325,31 +10914,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %19
+ThrowNullRef14:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9367,8 +10956,8 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
@@ -9380,8 +10969,8 @@ entry:
 
 ; <label>:9                                       ; preds = %4
   %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %9
   %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
@@ -9395,7 +10984,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef2:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9420,8 +11009,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
@@ -9512,8 +11101,8 @@ entry:
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
@@ -9524,8 +11113,8 @@ entry:
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = load i64, i64 addrspace(1)* %12
@@ -9537,8 +11126,8 @@ entry:
   %20 = load i64, i64* %19
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
-  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %13
   %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
@@ -9555,8 +11144,8 @@ entry:
 ; <label>:30                                      ; preds = %25
   %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %32 = load i32, i32* %arg2
-  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
-  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
@@ -9570,15 +11159,15 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %30
+ThrowNullRef2:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9622,87 +11211,87 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
   %10 = load i8, i8 addrspace(1)* %9, align 8
   %11 = zext i8 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %8
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
   store i8 %12, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
   %19 = load i8, i8 addrspace(1)* %18, align 8
   %20 = zext i8 %19 to i32
   %21 = trunc i32 %20 to i8
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
   store i8 %21, i8 addrspace(1)* %23
   %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
   %28 = load i8, i8 addrspace(1)* %27, align 8
   %29 = zext i8 %28 to i32
   %30 = trunc i32 %29 to i8
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
-  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %31
 
 ; <label>:31                                      ; preds = %26
   %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
   store i8 %30, i8 addrspace(1)* %32
   %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
-  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
-  br i1 %NullCheck14, label %40, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %40
 
 ; <label>:40                                      ; preds = %35
   %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
   store i8 %39, i8 addrspace(1)* %41
   %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
-  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %44
 
 ; <label>:44                                      ; preds = %40
   %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
   %46 = load i8, i8 addrspace(1)* %45, align 8
   %47 = zext i8 %46 to i32
   %48 = trunc i32 %47 to i8
-  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
   store i8 %48, i8 addrspace(1)* %50
   %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
-  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
@@ -9713,29 +11302,29 @@ entry:
 ; <label>:56                                      ; preds = %52
   %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
-  br i1 %NullCheck22, label %59, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
   %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
   %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
-  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
-  br i1 %NullCheck24, label %63, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
   %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
-  br i1 %NullCheck26, label %66, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
   %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
-  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
-  br i1 %NullCheck28, label %69, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %69
 
 ; <label>:69                                      ; preds = %66
   %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
@@ -9744,15 +11333,15 @@ entry:
 
 ; <label>:71                                      ; preds = %105
   %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
-  br i1 %NullCheck34, label %73, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %73
 
 ; <label>:73                                      ; preds = %71
   %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
   %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
   %76 = load i32, i32* %loc0
-  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
-  br i1 %NullCheck36, label %77, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
@@ -9766,8 +11355,8 @@ entry:
 
 ; <label>:83                                      ; preds = %77
   %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
-  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
@@ -9775,14 +11364,14 @@ entry:
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
   %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
-  br i1 %NullCheck40, label %91, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
 ; <label>:91                                      ; preds = %85
   %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
   %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
-  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck42, label %94, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %94
 
 ; <label>:94                                      ; preds = %91
   %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
@@ -9798,14 +11387,14 @@ entry:
 ; <label>:99                                      ; preds = %69, %96
   %100 = load i32, i32* %loc0
   %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
-  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %102
 
 ; <label>:102                                     ; preds = %99
   %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
   %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
-  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
-  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
@@ -9819,87 +11408,87 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %26
+ThrowNullRef10:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %31
+ThrowNullRef12:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %35
+ThrowNullRef14:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %40
+ThrowNullRef16:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %56
+ThrowNullRef22:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %59
+ThrowNullRef24:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %63
+ThrowNullRef26:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %66
+ThrowNullRef28:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %102
+ThrowNullRef32:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %71
+ThrowNullRef34:                                   ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %73
+ThrowNullRef36:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %83
+ThrowNullRef38:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %85
+ThrowNullRef40:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %91
+ThrowNullRef42:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9943,15 +11532,15 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
   %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
@@ -9961,28 +11550,28 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
   %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %12
   %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
   %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
   %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
-  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
@@ -9993,23 +11582,23 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %12
+ThrowNullRef6:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10031,15 +11620,15 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
   %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = load i64, i64 addrspace(1)* %7
@@ -10077,13 +11666,13 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[loadElem]
+Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -10111,8 +11700,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -10169,16 +11758,16 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %MiscMethods addrspace(1)*, %MiscMethods addrspace(1)** %this
   %3 = load i32, i32* %arg1
-  %NullCheck = icmp ne %MiscMethods addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %MiscMethods addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %MiscMethods, %MiscMethods addrspace(1)* %2, i32 0, i32 1
   store i32 %3, i32 addrspace(1)* %5
   %6 = load %MiscMethods addrspace(1)*, %MiscMethods addrspace(1)** %this
   %7 = load i32, i32* %arg2
-  %NullCheck2 = icmp ne %MiscMethods addrspace(1)* %6, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %MiscMethods addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %MiscMethods, %MiscMethods addrspace(1)* %6, i32 0, i32 2
@@ -10189,7 +11778,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10204,15 +11793,15 @@ entry:
   store %MiscMethods addrspace(1)* %param0, %MiscMethods addrspace(1)** %this
   store %MiscMethods addrspace(1)* %param1, %MiscMethods addrspace(1)** %arg1
   %0 = load %MiscMethods addrspace(1)*, %MiscMethods addrspace(1)** %this
-  %NullCheck = icmp ne %MiscMethods addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %MiscMethods addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %MiscMethods, %MiscMethods addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %MiscMethods addrspace(1)*, %MiscMethods addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %MiscMethods addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %MiscMethods addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %MiscMethods, %MiscMethods addrspace(1)* %4, i32 0, i32 1
@@ -10222,15 +11811,15 @@ entry:
 
 ; <label>:9                                       ; preds = %5
   %10 = load %MiscMethods addrspace(1)*, %MiscMethods addrspace(1)** %this
-  %NullCheck4 = icmp ne %MiscMethods addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %MiscMethods addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %9
   %12 = getelementptr inbounds %MiscMethods, %MiscMethods addrspace(1)* %10, i32 0, i32 2
   %13 = load i32, i32 addrspace(1)* %12, align 8
   %14 = load %MiscMethods addrspace(1)*, %MiscMethods addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %MiscMethods addrspace(1)* %14, null
-  br i1 %NullCheck6, label %15, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %MiscMethods addrspace(1)* %14, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %15
 
 ; <label>:15                                      ; preds = %11
   %16 = getelementptr inbounds %MiscMethods, %MiscMethods addrspace(1)* %14, i32 0, i32 2
@@ -10247,15 +11836,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10274,8 +11863,8 @@ entry:
   store i32 100, i32* %loc0
   %0 = load %MiscMethods addrspace(1)*, %MiscMethods addrspace(1)** %arg0
   %1 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %MiscMethods addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %MiscMethods addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%MiscMethods addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%MiscMethods addrspace(1)* %0, %"System.Int32[]" addrspace(1)* %1)
@@ -10290,8 +11879,8 @@ entry:
 
 ; <label>:7                                       ; preds = %2, %6
   %8 = load %MiscMethods addrspace(1)*, %MiscMethods addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %MiscMethods addrspace(1)* %8, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %MiscMethods addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %7
   %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%MiscMethods addrspace(1)*, i32, i32, i32, i32, i32)*)(%MiscMethods addrspace(1)* %8, i32 1, i32 2, i32 3, i32 4, i32 5)
@@ -10312,13 +11901,82 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method MiscMethods::Sum using LLILCJit
-Failed to read MiscMethods.Sum[loadElem]
+Successfully read MiscMethods.Sum
+
+define i32 @MiscMethods.Sum(%MiscMethods addrspace(1)* %param0, %"System.Int32[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %MiscMethods addrspace(1)*
+  %arg1 = alloca %"System.Int32[]" addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  store %MiscMethods addrspace(1)* %param0, %MiscMethods addrspace(1)** %this
+  store %"System.Int32[]" addrspace(1)* %param1, %"System.Int32[]" addrspace(1)** %arg1
+  store i32 0, i32* %loc0
+  store i32 0, i32* %loc1
+  br label %15
+
+; <label>:0                                       ; preds = %18
+  %1 = load i32, i32* %loc0
+  %2 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %arg1
+  %3 = load i32, i32* %loc1
+  %NullCheck1 = icmp eq %"System.Int32[]" addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
+
+; <label>:4                                       ; preds = %0
+  %5 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %2, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = zext i32 %6 to i64
+  %8 = zext i32 %3 to i64
+  %BoundsCheck = icmp uge i64 %8, %7
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %9
+
+; <label>:9                                       ; preds = %4
+  %10 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %2, i32 0, i32 3, i32 %3
+  %11 = load i32, i32 addrspace(1)* %10, align 8
+  %12 = add i32 %1, %11
+  store i32 %12, i32* %loc0
+  %13 = load i32, i32* %loc1
+  %14 = add i32 %13, 1
+  store i32 %14, i32* %loc1
+  br label %15
+
+; <label>:15                                      ; preds = %entry, %9
+  %16 = load i32, i32* %loc1
+  %17 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Int32[]" addrspace(1)* %17, null
+  br i1 %NullCheck, label %ThrowNullRef, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %17, i32 0, i32 1
+  %20 = load i32, i32 addrspace(1)* %19
+  %21 = zext i32 %20 to i64
+  %22 = trunc i64 %21 to i32
+  %23 = icmp slt i32 %16, %22
+  br i1 %23, label %0, label %24
+
+; <label>:24                                      ; preds = %18
+  %25 = load i32, i32* %loc0
+  ret i32 %25
+
+ThrowNullRef:                                     ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method MiscMethods::Sum using LLILCJit
 Successfully read MiscMethods.Sum
 
@@ -10362,8 +12020,8 @@ entry:
   store i32 100, i32* %loc0
   %0 = load %MiscMethods addrspace(1)*, %MiscMethods addrspace(1)** %arg0
   %1 = load %"System.Single[]" addrspace(1)*, %"System.Single[]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %MiscMethods addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %MiscMethods addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = call float inttoptr (i64 NORMALIZED_ADDRESS to float (%MiscMethods addrspace(1)*, %"System.Single[]" addrspace(1)*)*)(%MiscMethods addrspace(1)* %0, %"System.Single[]" addrspace(1)* %1)
@@ -10380,8 +12038,8 @@ entry:
 
 ; <label>:9                                       ; preds = %2, %8
   %10 = load %MiscMethods addrspace(1)*, %MiscMethods addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %MiscMethods addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %MiscMethods addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %9
   %12 = call float inttoptr (i64 NORMALIZED_ADDRESS to float (%MiscMethods addrspace(1)*, float, float, float, float, float)*)(%MiscMethods addrspace(1)* %10, float 1.000000e+00, float 2.000000e+00, float 3.000000e+00, float 4.000000e+00, float 5.000000e+00)
@@ -10404,13 +12062,82 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef2:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method MiscMethods::Sum using LLILCJit
-Failed to read MiscMethods.Sum[loadElem]
+Successfully read MiscMethods.Sum
+
+define float @MiscMethods.Sum(%MiscMethods addrspace(1)* %param0, %"System.Single[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %MiscMethods addrspace(1)*
+  %arg1 = alloca %"System.Single[]" addrspace(1)*
+  %loc0 = alloca float
+  %loc1 = alloca i32
+  store %MiscMethods addrspace(1)* %param0, %MiscMethods addrspace(1)** %this
+  store %"System.Single[]" addrspace(1)* %param1, %"System.Single[]" addrspace(1)** %arg1
+  store float 0.000000e+00, float* %loc0
+  store i32 0, i32* %loc1
+  br label %15
+
+; <label>:0                                       ; preds = %18
+  %1 = load float, float* %loc0
+  %2 = load %"System.Single[]" addrspace(1)*, %"System.Single[]" addrspace(1)** %arg1
+  %3 = load i32, i32* %loc1
+  %NullCheck1 = icmp eq %"System.Single[]" addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
+
+; <label>:4                                       ; preds = %0
+  %5 = getelementptr inbounds %"System.Single[]", %"System.Single[]" addrspace(1)* %2, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = zext i32 %6 to i64
+  %8 = zext i32 %3 to i64
+  %BoundsCheck = icmp uge i64 %8, %7
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %9
+
+; <label>:9                                       ; preds = %4
+  %10 = getelementptr inbounds %"System.Single[]", %"System.Single[]" addrspace(1)* %2, i32 0, i32 3, i32 %3
+  %11 = load float, float addrspace(1)* %10, align 8
+  %12 = fadd float %1, %11
+  store float %12, float* %loc0
+  %13 = load i32, i32* %loc1
+  %14 = add i32 %13, 1
+  store i32 %14, i32* %loc1
+  br label %15
+
+; <label>:15                                      ; preds = %entry, %9
+  %16 = load i32, i32* %loc1
+  %17 = load %"System.Single[]" addrspace(1)*, %"System.Single[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Single[]" addrspace(1)* %17, null
+  br i1 %NullCheck, label %ThrowNullRef, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %"System.Single[]", %"System.Single[]" addrspace(1)* %17, i32 0, i32 1
+  %20 = load i32, i32 addrspace(1)* %19
+  %21 = zext i32 %20 to i64
+  %22 = trunc i64 %21 to i32
+  %23 = icmp slt i32 %16, %22
+  br i1 %23, label %0, label %24
+
+; <label>:24                                      ; preds = %18
+  %25 = load float, float* %loc0
+  ret float %25
+
+ThrowNullRef:                                     ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method BringUpTest::floatEqual using LLILCJit
 Failed to read BringUpTest.floatEqual[abs]
 INFO:  jitting method MiscMethods::Sum using LLILCJit
@@ -10467,8 +12194,8 @@ entry:
   store i32 100, i32* %loc0
   %0 = load %MiscMethods addrspace(1)*, %MiscMethods addrspace(1)** %arg0
   %1 = load %"System.Double[]" addrspace(1)*, %"System.Double[]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %MiscMethods addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %MiscMethods addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = call double inttoptr (i64 NORMALIZED_ADDRESS to double (%MiscMethods addrspace(1)*, %"System.Double[]" addrspace(1)*)*)(%MiscMethods addrspace(1)* %0, %"System.Double[]" addrspace(1)* %1)
@@ -10479,8 +12206,8 @@ entry:
   %7 = load double, double* %arg4
   %8 = load double, double* %arg5
   %9 = load double, double* %arg6
-  %NullCheck2 = icmp ne %MiscMethods addrspace(1)* %4, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %MiscMethods addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %2
   %11 = call double inttoptr (i64 NORMALIZED_ADDRESS to double (%MiscMethods addrspace(1)*, double, double, double, double, double)*)(%MiscMethods addrspace(1)* %4, double %5, double %6, double %7, double %8, double %9)
@@ -10504,13 +12231,82 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method MiscMethods::Sum using LLILCJit
-Failed to read MiscMethods.Sum[loadElem]
+Successfully read MiscMethods.Sum
+
+define double @MiscMethods.Sum(%MiscMethods addrspace(1)* %param0, %"System.Double[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %MiscMethods addrspace(1)*
+  %arg1 = alloca %"System.Double[]" addrspace(1)*
+  %loc0 = alloca double
+  %loc1 = alloca i32
+  store %MiscMethods addrspace(1)* %param0, %MiscMethods addrspace(1)** %this
+  store %"System.Double[]" addrspace(1)* %param1, %"System.Double[]" addrspace(1)** %arg1
+  store double 0.000000e+00, double* %loc0
+  store i32 0, i32* %loc1
+  br label %15
+
+; <label>:0                                       ; preds = %18
+  %1 = load double, double* %loc0
+  %2 = load %"System.Double[]" addrspace(1)*, %"System.Double[]" addrspace(1)** %arg1
+  %3 = load i32, i32* %loc1
+  %NullCheck1 = icmp eq %"System.Double[]" addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
+
+; <label>:4                                       ; preds = %0
+  %5 = getelementptr inbounds %"System.Double[]", %"System.Double[]" addrspace(1)* %2, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = zext i32 %6 to i64
+  %8 = zext i32 %3 to i64
+  %BoundsCheck = icmp uge i64 %8, %7
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %9
+
+; <label>:9                                       ; preds = %4
+  %10 = getelementptr inbounds %"System.Double[]", %"System.Double[]" addrspace(1)* %2, i32 0, i32 3, i32 %3
+  %11 = load double, double addrspace(1)* %10, align 8
+  %12 = fadd double %1, %11
+  store double %12, double* %loc0
+  %13 = load i32, i32* %loc1
+  %14 = add i32 %13, 1
+  store i32 %14, i32* %loc1
+  br label %15
+
+; <label>:15                                      ; preds = %entry, %9
+  %16 = load i32, i32* %loc1
+  %17 = load %"System.Double[]" addrspace(1)*, %"System.Double[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Double[]" addrspace(1)* %17, null
+  br i1 %NullCheck, label %ThrowNullRef, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %"System.Double[]", %"System.Double[]" addrspace(1)* %17, i32 0, i32 1
+  %20 = load i32, i32 addrspace(1)* %19
+  %21 = zext i32 %20 to i64
+  %22 = trunc i64 %21 to i32
+  %23 = icmp slt i32 %16, %22
+  br i1 %23, label %0, label %24
+
+; <label>:24                                      ; preds = %18
+  %25 = load double, double* %loc0
+  ret double %25
+
+ThrowNullRef:                                     ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method MiscMethods::Sum using LLILCJit
 Successfully read MiscMethods.Sum
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/IntArraySum.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/IntArraySum.error.txt
@@ -25,8 +25,8 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
@@ -40,8 +40,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
   %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
@@ -75,7 +75,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -90,8 +90,8 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %NullCheck = icmp ne i8 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = load i8, i8 addrspace(1)* %0, align 8
@@ -125,8 +125,8 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
@@ -159,8 +159,8 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -184,8 +184,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
   store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
@@ -195,8 +195,8 @@ entry:
 ; <label>:4                                       ; preds = %1
   %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
   %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
@@ -206,8 +206,8 @@ entry:
   %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
@@ -221,14 +221,14 @@ entry:
 
 ; <label>:17                                      ; preds = %14
   %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
   %21 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
@@ -238,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -249,8 +249,8 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
@@ -261,27 +261,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %30
+ThrowNullRef10:                                   ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -301,7 +301,89 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
-Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
+Successfully read AppDomainSetup.GetUnsecureApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.GetUnsecureApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %NullCheck = icmp eq %"System.String[]" addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %BoundsCheck = icmp uge i64 0, %5
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %6
+
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 3, i32 0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
+  ret %System.String addrspace(1)* %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_Value using LLILCJit
+Successfully read AppDomainSetup.get_Value
+
+define %"System.String[]" addrspace(1)* @AppDomainSetup.get_Value(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.String[]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 18)
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.String[]" addrspace(1)* addrspace(1)*, %"System.String[]" addrspace(1)*)*)(%"System.String[]" addrspace(1)* addrspace(1)* %9, %"System.String[]" addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %11, i32 0, i32 1
+  %14 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %13, align 8
+  ret %"System.String[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -319,8 +401,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -368,16 +450,16 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
   %5 = load i32, i32 addrspace(1)* %4
   %6 = sub i32 %5, 1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -389,7 +471,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -421,8 +503,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
@@ -456,8 +538,8 @@ entry:
 ; <label>:27                                      ; preds = %19
   %28 = load i32, i32* %arg1
   %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
-  br i1 %NullCheck2, label %30, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %29, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %30
 
 ; <label>:30                                      ; preds = %27
   %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
@@ -493,8 +575,8 @@ entry:
 ; <label>:49                                      ; preds = %46
   %50 = load i32, i32* %arg2
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck4, label %52, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
@@ -517,11 +599,11 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %27
+ThrowNullRef2:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %49
+ThrowNullRef4:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -544,16 +626,16 @@ entry:
   %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %0)
   store %System.String addrspace(1)* %1, %System.String addrspace(1)** %loc0
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 2
   %5 = bitcast [0 x i16] addrspace(1)* %4 to i16 addrspace(1)*
   store i16 addrspace(1)* %5, i16 addrspace(1)** %loc1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %3
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2
@@ -580,7 +662,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -691,15 +773,15 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %NullCheck132 = icmp ne i8* %21, null
-  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+  %NullCheck131 = icmp eq i8* %21, null
+  br i1 %NullCheck131, label %ThrowNullRef132, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = load i8, i8* %21, align 8
   %24 = zext i8 %23 to i32
   %25 = trunc i32 %24 to i8
-  %NullCheck134 = icmp ne i8* %20, null
-  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+  %NullCheck133 = icmp eq i8* %20, null
+  br i1 %NullCheck133, label %ThrowNullRef134, label %26
 
 ; <label>:26                                      ; preds = %22
   store i8 %25, i8* %20, align 8
@@ -709,16 +791,16 @@ entry:
   %28 = load i8*, i8** %arg0
   %29 = load i8*, i8** %arg1
   %30 = bitcast i8* %29 to i16*
-  %NullCheck128 = icmp ne i16* %30, null
-  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+  %NullCheck127 = icmp eq i16* %30, null
+  br i1 %NullCheck127, label %ThrowNullRef128, label %31
 
 ; <label>:31                                      ; preds = %27
   %32 = load i16, i16* %30, align 8
   %33 = sext i16 %32 to i32
   %34 = bitcast i8* %28 to i16*
   %35 = trunc i32 %33 to i16
-  %NullCheck130 = icmp ne i16* %34, null
-  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+  %NullCheck129 = icmp eq i16* %34, null
+  br i1 %NullCheck129, label %ThrowNullRef130, label %36
 
 ; <label>:36                                      ; preds = %31
   store i16 %35, i16* %34, align 8
@@ -728,16 +810,16 @@ entry:
   %38 = load i8*, i8** %arg0
   %39 = load i8*, i8** %arg1
   %40 = bitcast i8* %39 to i16*
-  %NullCheck120 = icmp ne i16* %40, null
-  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+  %NullCheck119 = icmp eq i16* %40, null
+  br i1 %NullCheck119, label %ThrowNullRef120, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i16, i16* %40, align 8
   %43 = sext i16 %42 to i32
   %44 = bitcast i8* %38 to i16*
   %45 = trunc i32 %43 to i16
-  %NullCheck122 = icmp ne i16* %44, null
-  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+  %NullCheck121 = icmp eq i16* %44, null
+  br i1 %NullCheck121, label %ThrowNullRef122, label %46
 
 ; <label>:46                                      ; preds = %41
   store i16 %45, i16* %44, align 8
@@ -745,15 +827,15 @@ entry:
   %48 = getelementptr inbounds i8, i8* %47, i64 2
   %49 = load i8*, i8** %arg1
   %50 = getelementptr inbounds i8, i8* %49, i64 2
-  %NullCheck124 = icmp ne i8* %50, null
-  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+  %NullCheck123 = icmp eq i8* %50, null
+  br i1 %NullCheck123, label %ThrowNullRef124, label %51
 
 ; <label>:51                                      ; preds = %46
   %52 = load i8, i8* %50, align 8
   %53 = zext i8 %52 to i32
   %54 = trunc i32 %53 to i8
-  %NullCheck126 = icmp ne i8* %48, null
-  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+  %NullCheck125 = icmp eq i8* %48, null
+  br i1 %NullCheck125, label %ThrowNullRef126, label %55
 
 ; <label>:55                                      ; preds = %51
   store i8 %54, i8* %48, align 8
@@ -763,14 +845,14 @@ entry:
   %57 = load i8*, i8** %arg0
   %58 = load i8*, i8** %arg1
   %59 = bitcast i8* %58 to i32*
-  %NullCheck116 = icmp ne i32* %59, null
-  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+  %NullCheck115 = icmp eq i32* %59, null
+  br i1 %NullCheck115, label %ThrowNullRef116, label %60
 
 ; <label>:60                                      ; preds = %56
   %61 = load i32, i32* %59, align 8
   %62 = bitcast i8* %57 to i32*
-  %NullCheck118 = icmp ne i32* %62, null
-  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+  %NullCheck117 = icmp eq i32* %62, null
+  br i1 %NullCheck117, label %ThrowNullRef118, label %63
 
 ; <label>:63                                      ; preds = %60
   store i32 %61, i32* %62, align 8
@@ -780,14 +862,14 @@ entry:
   %65 = load i8*, i8** %arg0
   %66 = load i8*, i8** %arg1
   %67 = bitcast i8* %66 to i32*
-  %NullCheck108 = icmp ne i32* %67, null
-  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+  %NullCheck107 = icmp eq i32* %67, null
+  br i1 %NullCheck107, label %ThrowNullRef108, label %68
 
 ; <label>:68                                      ; preds = %64
   %69 = load i32, i32* %67, align 8
   %70 = bitcast i8* %65 to i32*
-  %NullCheck110 = icmp ne i32* %70, null
-  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+  %NullCheck109 = icmp eq i32* %70, null
+  br i1 %NullCheck109, label %ThrowNullRef110, label %71
 
 ; <label>:71                                      ; preds = %68
   store i32 %69, i32* %70, align 8
@@ -795,15 +877,15 @@ entry:
   %73 = getelementptr inbounds i8, i8* %72, i64 4
   %74 = load i8*, i8** %arg1
   %75 = getelementptr inbounds i8, i8* %74, i64 4
-  %NullCheck112 = icmp ne i8* %75, null
-  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+  %NullCheck111 = icmp eq i8* %75, null
+  br i1 %NullCheck111, label %ThrowNullRef112, label %76
 
 ; <label>:76                                      ; preds = %71
   %77 = load i8, i8* %75, align 8
   %78 = zext i8 %77 to i32
   %79 = trunc i32 %78 to i8
-  %NullCheck114 = icmp ne i8* %73, null
-  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+  %NullCheck113 = icmp eq i8* %73, null
+  br i1 %NullCheck113, label %ThrowNullRef114, label %80
 
 ; <label>:80                                      ; preds = %76
   store i8 %79, i8* %73, align 8
@@ -813,14 +895,14 @@ entry:
   %82 = load i8*, i8** %arg0
   %83 = load i8*, i8** %arg1
   %84 = bitcast i8* %83 to i32*
-  %NullCheck100 = icmp ne i32* %84, null
-  br i1 %NullCheck100, label %85, label %ThrowNullRef99
+  %NullCheck99 = icmp eq i32* %84, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %85
 
 ; <label>:85                                      ; preds = %81
   %86 = load i32, i32* %84, align 8
   %87 = bitcast i8* %82 to i32*
-  %NullCheck102 = icmp ne i32* %87, null
-  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+  %NullCheck101 = icmp eq i32* %87, null
+  br i1 %NullCheck101, label %ThrowNullRef102, label %88
 
 ; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
@@ -829,16 +911,16 @@ entry:
   %91 = load i8*, i8** %arg1
   %92 = getelementptr inbounds i8, i8* %91, i64 4
   %93 = bitcast i8* %92 to i16*
-  %NullCheck104 = icmp ne i16* %93, null
-  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+  %NullCheck103 = icmp eq i16* %93, null
+  br i1 %NullCheck103, label %ThrowNullRef104, label %94
 
 ; <label>:94                                      ; preds = %88
   %95 = load i16, i16* %93, align 8
   %96 = sext i16 %95 to i32
   %97 = bitcast i8* %90 to i16*
   %98 = trunc i32 %96 to i16
-  %NullCheck106 = icmp ne i16* %97, null
-  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+  %NullCheck105 = icmp eq i16* %97, null
+  br i1 %NullCheck105, label %ThrowNullRef106, label %99
 
 ; <label>:99                                      ; preds = %94
   store i16 %98, i16* %97, align 8
@@ -848,14 +930,14 @@ entry:
   %101 = load i8*, i8** %arg0
   %102 = load i8*, i8** %arg1
   %103 = bitcast i8* %102 to i32*
-  %NullCheck88 = icmp ne i32* %103, null
-  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+  %NullCheck87 = icmp eq i32* %103, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %104
 
 ; <label>:104                                     ; preds = %100
   %105 = load i32, i32* %103, align 8
   %106 = bitcast i8* %101 to i32*
-  %NullCheck90 = icmp ne i32* %106, null
-  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+  %NullCheck89 = icmp eq i32* %106, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %107
 
 ; <label>:107                                     ; preds = %104
   store i32 %105, i32* %106, align 8
@@ -864,16 +946,16 @@ entry:
   %110 = load i8*, i8** %arg1
   %111 = getelementptr inbounds i8, i8* %110, i64 4
   %112 = bitcast i8* %111 to i16*
-  %NullCheck92 = icmp ne i16* %112, null
-  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+  %NullCheck91 = icmp eq i16* %112, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %113
 
 ; <label>:113                                     ; preds = %107
   %114 = load i16, i16* %112, align 8
   %115 = sext i16 %114 to i32
   %116 = bitcast i8* %109 to i16*
   %117 = trunc i32 %115 to i16
-  %NullCheck94 = icmp ne i16* %116, null
-  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+  %NullCheck93 = icmp eq i16* %116, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %118
 
 ; <label>:118                                     ; preds = %113
   store i16 %117, i16* %116, align 8
@@ -881,15 +963,15 @@ entry:
   %120 = getelementptr inbounds i8, i8* %119, i64 6
   %121 = load i8*, i8** %arg1
   %122 = getelementptr inbounds i8, i8* %121, i64 6
-  %NullCheck96 = icmp ne i8* %122, null
-  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+  %NullCheck95 = icmp eq i8* %122, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %123
 
 ; <label>:123                                     ; preds = %118
   %124 = load i8, i8* %122, align 8
   %125 = zext i8 %124 to i32
   %126 = trunc i32 %125 to i8
-  %NullCheck98 = icmp ne i8* %120, null
-  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+  %NullCheck97 = icmp eq i8* %120, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %127
 
 ; <label>:127                                     ; preds = %123
   store i8 %126, i8* %120, align 8
@@ -899,14 +981,14 @@ entry:
   %129 = load i8*, i8** %arg0
   %130 = load i8*, i8** %arg1
   %131 = bitcast i8* %130 to i64*
-  %NullCheck84 = icmp ne i64* %131, null
-  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+  %NullCheck83 = icmp eq i64* %131, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %132
 
 ; <label>:132                                     ; preds = %128
   %133 = load i64, i64* %131, align 8
   %134 = bitcast i8* %129 to i64*
-  %NullCheck86 = icmp ne i64* %134, null
-  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+  %NullCheck85 = icmp eq i64* %134, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %135
 
 ; <label>:135                                     ; preds = %132
   store i64 %133, i64* %134, align 8
@@ -916,14 +998,14 @@ entry:
   %137 = load i8*, i8** %arg0
   %138 = load i8*, i8** %arg1
   %139 = bitcast i8* %138 to i64*
-  %NullCheck76 = icmp ne i64* %139, null
-  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+  %NullCheck75 = icmp eq i64* %139, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %140
 
 ; <label>:140                                     ; preds = %136
   %141 = load i64, i64* %139, align 8
   %142 = bitcast i8* %137 to i64*
-  %NullCheck78 = icmp ne i64* %142, null
-  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+  %NullCheck77 = icmp eq i64* %142, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %143
 
 ; <label>:143                                     ; preds = %140
   store i64 %141, i64* %142, align 8
@@ -931,15 +1013,15 @@ entry:
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %NullCheck80 = icmp ne i8* %147, null
-  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+  %NullCheck79 = icmp eq i8* %147, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %148
 
 ; <label>:148                                     ; preds = %143
   %149 = load i8, i8* %147, align 8
   %150 = zext i8 %149 to i32
   %151 = trunc i32 %150 to i8
-  %NullCheck82 = icmp ne i8* %145, null
-  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+  %NullCheck81 = icmp eq i8* %145, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %152
 
 ; <label>:152                                     ; preds = %148
   store i8 %151, i8* %145, align 8
@@ -949,14 +1031,14 @@ entry:
   %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
   %156 = bitcast i8* %155 to i64*
-  %NullCheck68 = icmp ne i64* %156, null
-  br i1 %NullCheck68, label %157, label %ThrowNullRef67
+  %NullCheck67 = icmp eq i64* %156, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %157
 
 ; <label>:157                                     ; preds = %153
   %158 = load i64, i64* %156, align 8
   %159 = bitcast i8* %154 to i64*
-  %NullCheck70 = icmp ne i64* %159, null
-  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+  %NullCheck69 = icmp eq i64* %159, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %160
 
 ; <label>:160                                     ; preds = %157
   store i64 %158, i64* %159, align 8
@@ -965,16 +1047,16 @@ entry:
   %163 = load i8*, i8** %arg1
   %164 = getelementptr inbounds i8, i8* %163, i64 8
   %165 = bitcast i8* %164 to i16*
-  %NullCheck72 = icmp ne i16* %165, null
-  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+  %NullCheck71 = icmp eq i16* %165, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %166
 
 ; <label>:166                                     ; preds = %160
   %167 = load i16, i16* %165, align 8
   %168 = sext i16 %167 to i32
   %169 = bitcast i8* %162 to i16*
   %170 = trunc i32 %168 to i16
-  %NullCheck74 = icmp ne i16* %169, null
-  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+  %NullCheck73 = icmp eq i16* %169, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %171
 
 ; <label>:171                                     ; preds = %166
   store i16 %170, i16* %169, align 8
@@ -984,14 +1066,14 @@ entry:
   %173 = load i8*, i8** %arg0
   %174 = load i8*, i8** %arg1
   %175 = bitcast i8* %174 to i64*
-  %NullCheck56 = icmp ne i64* %175, null
-  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+  %NullCheck55 = icmp eq i64* %175, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %176
 
 ; <label>:176                                     ; preds = %172
   %177 = load i64, i64* %175, align 8
   %178 = bitcast i8* %173 to i64*
-  %NullCheck58 = icmp ne i64* %178, null
-  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+  %NullCheck57 = icmp eq i64* %178, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %179
 
 ; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
@@ -1000,16 +1082,16 @@ entry:
   %182 = load i8*, i8** %arg1
   %183 = getelementptr inbounds i8, i8* %182, i64 8
   %184 = bitcast i8* %183 to i16*
-  %NullCheck60 = icmp ne i16* %184, null
-  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+  %NullCheck59 = icmp eq i16* %184, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %185
 
 ; <label>:185                                     ; preds = %179
   %186 = load i16, i16* %184, align 8
   %187 = sext i16 %186 to i32
   %188 = bitcast i8* %181 to i16*
   %189 = trunc i32 %187 to i16
-  %NullCheck62 = icmp ne i16* %188, null
-  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+  %NullCheck61 = icmp eq i16* %188, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %190
 
 ; <label>:190                                     ; preds = %185
   store i16 %189, i16* %188, align 8
@@ -1017,15 +1099,15 @@ entry:
   %192 = getelementptr inbounds i8, i8* %191, i64 10
   %193 = load i8*, i8** %arg1
   %194 = getelementptr inbounds i8, i8* %193, i64 10
-  %NullCheck64 = icmp ne i8* %194, null
-  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+  %NullCheck63 = icmp eq i8* %194, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %195
 
 ; <label>:195                                     ; preds = %190
   %196 = load i8, i8* %194, align 8
   %197 = zext i8 %196 to i32
   %198 = trunc i32 %197 to i8
-  %NullCheck66 = icmp ne i8* %192, null
-  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+  %NullCheck65 = icmp eq i8* %192, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %199
 
 ; <label>:199                                     ; preds = %195
   store i8 %198, i8* %192, align 8
@@ -1035,14 +1117,14 @@ entry:
   %201 = load i8*, i8** %arg0
   %202 = load i8*, i8** %arg1
   %203 = bitcast i8* %202 to i64*
-  %NullCheck48 = icmp ne i64* %203, null
-  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+  %NullCheck47 = icmp eq i64* %203, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %204
 
 ; <label>:204                                     ; preds = %200
   %205 = load i64, i64* %203, align 8
   %206 = bitcast i8* %201 to i64*
-  %NullCheck50 = icmp ne i64* %206, null
-  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+  %NullCheck49 = icmp eq i64* %206, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %207
 
 ; <label>:207                                     ; preds = %204
   store i64 %205, i64* %206, align 8
@@ -1051,14 +1133,14 @@ entry:
   %210 = load i8*, i8** %arg1
   %211 = getelementptr inbounds i8, i8* %210, i64 8
   %212 = bitcast i8* %211 to i32*
-  %NullCheck52 = icmp ne i32* %212, null
-  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+  %NullCheck51 = icmp eq i32* %212, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %213
 
 ; <label>:213                                     ; preds = %207
   %214 = load i32, i32* %212, align 8
   %215 = bitcast i8* %209 to i32*
-  %NullCheck54 = icmp ne i32* %215, null
-  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+  %NullCheck53 = icmp eq i32* %215, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %216
 
 ; <label>:216                                     ; preds = %213
   store i32 %214, i32* %215, align 8
@@ -1068,14 +1150,14 @@ entry:
   %218 = load i8*, i8** %arg0
   %219 = load i8*, i8** %arg1
   %220 = bitcast i8* %219 to i64*
-  %NullCheck36 = icmp ne i64* %220, null
-  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64* %220, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %221
 
 ; <label>:221                                     ; preds = %217
   %222 = load i64, i64* %220, align 8
   %223 = bitcast i8* %218 to i64*
-  %NullCheck38 = icmp ne i64* %223, null
-  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+  %NullCheck37 = icmp eq i64* %223, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %224
 
 ; <label>:224                                     ; preds = %221
   store i64 %222, i64* %223, align 8
@@ -1084,14 +1166,14 @@ entry:
   %227 = load i8*, i8** %arg1
   %228 = getelementptr inbounds i8, i8* %227, i64 8
   %229 = bitcast i8* %228 to i32*
-  %NullCheck40 = icmp ne i32* %229, null
-  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i32* %229, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %230
 
 ; <label>:230                                     ; preds = %224
   %231 = load i32, i32* %229, align 8
   %232 = bitcast i8* %226 to i32*
-  %NullCheck42 = icmp ne i32* %232, null
-  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+  %NullCheck41 = icmp eq i32* %232, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %233
 
 ; <label>:233                                     ; preds = %230
   store i32 %231, i32* %232, align 8
@@ -1099,15 +1181,15 @@ entry:
   %235 = getelementptr inbounds i8, i8* %234, i64 12
   %236 = load i8*, i8** %arg1
   %237 = getelementptr inbounds i8, i8* %236, i64 12
-  %NullCheck44 = icmp ne i8* %237, null
-  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i8* %237, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %238
 
 ; <label>:238                                     ; preds = %233
   %239 = load i8, i8* %237, align 8
   %240 = zext i8 %239 to i32
   %241 = trunc i32 %240 to i8
-  %NullCheck46 = icmp ne i8* %235, null
-  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+  %NullCheck45 = icmp eq i8* %235, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %242
 
 ; <label>:242                                     ; preds = %238
   store i8 %241, i8* %235, align 8
@@ -1117,14 +1199,14 @@ entry:
   %244 = load i8*, i8** %arg0
   %245 = load i8*, i8** %arg1
   %246 = bitcast i8* %245 to i64*
-  %NullCheck24 = icmp ne i64* %246, null
-  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64* %246, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %247
 
 ; <label>:247                                     ; preds = %243
   %248 = load i64, i64* %246, align 8
   %249 = bitcast i8* %244 to i64*
-  %NullCheck26 = icmp ne i64* %249, null
-  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64* %249, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %250
 
 ; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
@@ -1133,14 +1215,14 @@ entry:
   %253 = load i8*, i8** %arg1
   %254 = getelementptr inbounds i8, i8* %253, i64 8
   %255 = bitcast i8* %254 to i32*
-  %NullCheck28 = icmp ne i32* %255, null
-  br i1 %NullCheck28, label %256, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i32* %255, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %256
 
 ; <label>:256                                     ; preds = %250
   %257 = load i32, i32* %255, align 8
   %258 = bitcast i8* %252 to i32*
-  %NullCheck30 = icmp ne i32* %258, null
-  br i1 %NullCheck30, label %259, label %ThrowNullRef29
+  %NullCheck29 = icmp eq i32* %258, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %259
 
 ; <label>:259                                     ; preds = %256
   store i32 %257, i32* %258, align 8
@@ -1149,16 +1231,16 @@ entry:
   %262 = load i8*, i8** %arg1
   %263 = getelementptr inbounds i8, i8* %262, i64 12
   %264 = bitcast i8* %263 to i16*
-  %NullCheck32 = icmp ne i16* %264, null
-  br i1 %NullCheck32, label %265, label %ThrowNullRef31
+  %NullCheck31 = icmp eq i16* %264, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %265
 
 ; <label>:265                                     ; preds = %259
   %266 = load i16, i16* %264, align 8
   %267 = sext i16 %266 to i32
   %268 = bitcast i8* %261 to i16*
   %269 = trunc i32 %267 to i16
-  %NullCheck34 = icmp ne i16* %268, null
-  br i1 %NullCheck34, label %270, label %ThrowNullRef33
+  %NullCheck33 = icmp eq i16* %268, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %270
 
 ; <label>:270                                     ; preds = %265
   store i16 %269, i16* %268, align 8
@@ -1168,14 +1250,14 @@ entry:
   %272 = load i8*, i8** %arg0
   %273 = load i8*, i8** %arg1
   %274 = bitcast i8* %273 to i64*
-  %NullCheck8 = icmp ne i64* %274, null
-  br i1 %NullCheck8, label %275, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64* %274, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %275
 
 ; <label>:275                                     ; preds = %271
   %276 = load i64, i64* %274, align 8
   %277 = bitcast i8* %272 to i64*
-  %NullCheck10 = icmp ne i64* %277, null
-  br i1 %NullCheck10, label %278, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %277, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %278
 
 ; <label>:278                                     ; preds = %275
   store i64 %276, i64* %277, align 8
@@ -1184,14 +1266,14 @@ entry:
   %281 = load i8*, i8** %arg1
   %282 = getelementptr inbounds i8, i8* %281, i64 8
   %283 = bitcast i8* %282 to i32*
-  %NullCheck12 = icmp ne i32* %283, null
-  br i1 %NullCheck12, label %284, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i32* %283, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %284
 
 ; <label>:284                                     ; preds = %278
   %285 = load i32, i32* %283, align 8
   %286 = bitcast i8* %280 to i32*
-  %NullCheck14 = icmp ne i32* %286, null
-  br i1 %NullCheck14, label %287, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i32* %286, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %287
 
 ; <label>:287                                     ; preds = %284
   store i32 %285, i32* %286, align 8
@@ -1200,16 +1282,16 @@ entry:
   %290 = load i8*, i8** %arg1
   %291 = getelementptr inbounds i8, i8* %290, i64 12
   %292 = bitcast i8* %291 to i16*
-  %NullCheck16 = icmp ne i16* %292, null
-  br i1 %NullCheck16, label %293, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i16* %292, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %293
 
 ; <label>:293                                     ; preds = %287
   %294 = load i16, i16* %292, align 8
   %295 = sext i16 %294 to i32
   %296 = bitcast i8* %289 to i16*
   %297 = trunc i32 %295 to i16
-  %NullCheck18 = icmp ne i16* %296, null
-  br i1 %NullCheck18, label %298, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i16* %296, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %298
 
 ; <label>:298                                     ; preds = %293
   store i16 %297, i16* %296, align 8
@@ -1217,15 +1299,15 @@ entry:
   %300 = getelementptr inbounds i8, i8* %299, i64 14
   %301 = load i8*, i8** %arg1
   %302 = getelementptr inbounds i8, i8* %301, i64 14
-  %NullCheck20 = icmp ne i8* %302, null
-  br i1 %NullCheck20, label %303, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i8* %302, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %303
 
 ; <label>:303                                     ; preds = %298
   %304 = load i8, i8* %302, align 8
   %305 = zext i8 %304 to i32
   %306 = trunc i32 %305 to i8
-  %NullCheck22 = icmp ne i8* %300, null
-  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i8* %300, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %307
 
 ; <label>:307                                     ; preds = %303
   store i8 %306, i8* %300, align 8
@@ -1235,14 +1317,14 @@ entry:
   %309 = load i8*, i8** %arg0
   %310 = load i8*, i8** %arg1
   %311 = bitcast i8* %310 to i64*
-  %NullCheck = icmp ne i64* %311, null
-  br i1 %NullCheck, label %312, label %ThrowNullRef
+  %NullCheck = icmp eq i64* %311, null
+  br i1 %NullCheck, label %ThrowNullRef, label %312
 
 ; <label>:312                                     ; preds = %308
   %313 = load i64, i64* %311, align 8
   %314 = bitcast i8* %309 to i64*
-  %NullCheck2 = icmp ne i64* %314, null
-  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64* %314, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %315
 
 ; <label>:315                                     ; preds = %312
   store i64 %313, i64* %314, align 8
@@ -1251,14 +1333,14 @@ entry:
   %318 = load i8*, i8** %arg1
   %319 = getelementptr inbounds i8, i8* %318, i64 8
   %320 = bitcast i8* %319 to i64*
-  %NullCheck4 = icmp ne i64* %320, null
-  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64* %320, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %321
 
 ; <label>:321                                     ; preds = %315
   %322 = load i64, i64* %320, align 8
   %323 = bitcast i8* %317 to i64*
-  %NullCheck6 = icmp ne i64* %323, null
-  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64* %323, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %324
 
 ; <label>:324                                     ; preds = %321
   store i64 %322, i64* %323, align 8
@@ -1286,15 +1368,15 @@ entry:
 ; <label>:338                                     ; preds = %333
   %339 = load i8*, i8** %arg0
   %340 = load i8*, i8** %arg1
-  %NullCheck136 = icmp ne i8* %340, null
-  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+  %NullCheck135 = icmp eq i8* %340, null
+  br i1 %NullCheck135, label %ThrowNullRef136, label %341
 
 ; <label>:341                                     ; preds = %338
   %342 = load i8, i8* %340, align 8
   %343 = zext i8 %342 to i32
   %344 = trunc i32 %343 to i8
-  %NullCheck138 = icmp ne i8* %339, null
-  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+  %NullCheck137 = icmp eq i8* %339, null
+  br i1 %NullCheck137, label %ThrowNullRef138, label %345
 
 ; <label>:345                                     ; preds = %341
   store i8 %344, i8* %339, align 8
@@ -1317,16 +1399,16 @@ entry:
   %357 = load i8*, i8** %arg0
   %358 = load i8*, i8** %arg1
   %359 = bitcast i8* %358 to i16*
-  %NullCheck140 = icmp ne i16* %359, null
-  br i1 %NullCheck140, label %360, label %ThrowNullRef139
+  %NullCheck139 = icmp eq i16* %359, null
+  br i1 %NullCheck139, label %ThrowNullRef140, label %360
 
 ; <label>:360                                     ; preds = %356
   %361 = load i16, i16* %359, align 8
   %362 = sext i16 %361 to i32
   %363 = bitcast i8* %357 to i16*
   %364 = trunc i32 %362 to i16
-  %NullCheck142 = icmp ne i16* %363, null
-  br i1 %NullCheck142, label %365, label %ThrowNullRef141
+  %NullCheck141 = icmp eq i16* %363, null
+  br i1 %NullCheck141, label %ThrowNullRef142, label %365
 
 ; <label>:365                                     ; preds = %360
   store i16 %364, i16* %363, align 8
@@ -1352,14 +1434,14 @@ entry:
   %378 = load i8*, i8** %arg0
   %379 = load i8*, i8** %arg1
   %380 = bitcast i8* %379 to i32*
-  %NullCheck144 = icmp ne i32* %380, null
-  br i1 %NullCheck144, label %381, label %ThrowNullRef143
+  %NullCheck143 = icmp eq i32* %380, null
+  br i1 %NullCheck143, label %ThrowNullRef144, label %381
 
 ; <label>:381                                     ; preds = %377
   %382 = load i32, i32* %380, align 8
   %383 = bitcast i8* %378 to i32*
-  %NullCheck146 = icmp ne i32* %383, null
-  br i1 %NullCheck146, label %384, label %ThrowNullRef145
+  %NullCheck145 = icmp eq i32* %383, null
+  br i1 %NullCheck145, label %ThrowNullRef146, label %384
 
 ; <label>:384                                     ; preds = %381
   store i32 %382, i32* %383, align 8
@@ -1384,14 +1466,14 @@ entry:
   %395 = load i8*, i8** %arg0
   %396 = load i8*, i8** %arg1
   %397 = bitcast i8* %396 to i64*
-  %NullCheck164 = icmp ne i64* %397, null
-  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+  %NullCheck163 = icmp eq i64* %397, null
+  br i1 %NullCheck163, label %ThrowNullRef164, label %398
 
 ; <label>:398                                     ; preds = %394
   %399 = load i64, i64* %397, align 8
   %400 = bitcast i8* %395 to i64*
-  %NullCheck166 = icmp ne i64* %400, null
-  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+  %NullCheck165 = icmp eq i64* %400, null
+  br i1 %NullCheck165, label %ThrowNullRef166, label %401
 
 ; <label>:401                                     ; preds = %398
   store i64 %399, i64* %400, align 8
@@ -1400,14 +1482,14 @@ entry:
   %404 = load i8*, i8** %arg1
   %405 = getelementptr inbounds i8, i8* %404, i64 8
   %406 = bitcast i8* %405 to i64*
-  %NullCheck168 = icmp ne i64* %406, null
-  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+  %NullCheck167 = icmp eq i64* %406, null
+  br i1 %NullCheck167, label %ThrowNullRef168, label %407
 
 ; <label>:407                                     ; preds = %401
   %408 = load i64, i64* %406, align 8
   %409 = bitcast i8* %403 to i64*
-  %NullCheck170 = icmp ne i64* %409, null
-  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+  %NullCheck169 = icmp eq i64* %409, null
+  br i1 %NullCheck169, label %ThrowNullRef170, label %410
 
 ; <label>:410                                     ; preds = %407
   store i64 %408, i64* %409, align 8
@@ -1437,14 +1519,14 @@ entry:
   %425 = load i8*, i8** %arg0
   %426 = load i8*, i8** %arg1
   %427 = bitcast i8* %426 to i64*
-  %NullCheck148 = icmp ne i64* %427, null
-  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+  %NullCheck147 = icmp eq i64* %427, null
+  br i1 %NullCheck147, label %ThrowNullRef148, label %428
 
 ; <label>:428                                     ; preds = %424
   %429 = load i64, i64* %427, align 8
   %430 = bitcast i8* %425 to i64*
-  %NullCheck150 = icmp ne i64* %430, null
-  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+  %NullCheck149 = icmp eq i64* %430, null
+  br i1 %NullCheck149, label %ThrowNullRef150, label %431
 
 ; <label>:431                                     ; preds = %428
   store i64 %429, i64* %430, align 8
@@ -1466,14 +1548,14 @@ entry:
   %441 = load i8*, i8** %arg0
   %442 = load i8*, i8** %arg1
   %443 = bitcast i8* %442 to i32*
-  %NullCheck152 = icmp ne i32* %443, null
-  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+  %NullCheck151 = icmp eq i32* %443, null
+  br i1 %NullCheck151, label %ThrowNullRef152, label %444
 
 ; <label>:444                                     ; preds = %440
   %445 = load i32, i32* %443, align 8
   %446 = bitcast i8* %441 to i32*
-  %NullCheck154 = icmp ne i32* %446, null
-  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+  %NullCheck153 = icmp eq i32* %446, null
+  br i1 %NullCheck153, label %ThrowNullRef154, label %447
 
 ; <label>:447                                     ; preds = %444
   store i32 %445, i32* %446, align 8
@@ -1495,16 +1577,16 @@ entry:
   %457 = load i8*, i8** %arg0
   %458 = load i8*, i8** %arg1
   %459 = bitcast i8* %458 to i16*
-  %NullCheck156 = icmp ne i16* %459, null
-  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+  %NullCheck155 = icmp eq i16* %459, null
+  br i1 %NullCheck155, label %ThrowNullRef156, label %460
 
 ; <label>:460                                     ; preds = %456
   %461 = load i16, i16* %459, align 8
   %462 = sext i16 %461 to i32
   %463 = bitcast i8* %457 to i16*
   %464 = trunc i32 %462 to i16
-  %NullCheck158 = icmp ne i16* %463, null
-  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+  %NullCheck157 = icmp eq i16* %463, null
+  br i1 %NullCheck157, label %ThrowNullRef158, label %465
 
 ; <label>:465                                     ; preds = %460
   store i16 %464, i16* %463, align 8
@@ -1525,15 +1607,15 @@ entry:
 ; <label>:474                                     ; preds = %470
   %475 = load i8*, i8** %arg0
   %476 = load i8*, i8** %arg1
-  %NullCheck160 = icmp ne i8* %476, null
-  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+  %NullCheck159 = icmp eq i8* %476, null
+  br i1 %NullCheck159, label %ThrowNullRef160, label %477
 
 ; <label>:477                                     ; preds = %474
   %478 = load i8, i8* %476, align 8
   %479 = zext i8 %478 to i32
   %480 = trunc i32 %479 to i8
-  %NullCheck162 = icmp ne i8* %475, null
-  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+  %NullCheck161 = icmp eq i8* %475, null
+  br i1 %NullCheck161, label %ThrowNullRef162, label %481
 
 ; <label>:481                                     ; preds = %477
   store i8 %480, i8* %475, align 8
@@ -1553,343 +1635,343 @@ ThrowNullRef:                                     ; preds = %308
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %312
+ThrowNullRef2:                                    ; preds = %312
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %315
+ThrowNullRef4:                                    ; preds = %315
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %321
+ThrowNullRef6:                                    ; preds = %321
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %271
+ThrowNullRef8:                                    ; preds = %271
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %275
+ThrowNullRef10:                                   ; preds = %275
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %278
+ThrowNullRef12:                                   ; preds = %278
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %284
+ThrowNullRef14:                                   ; preds = %284
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %287
+ThrowNullRef16:                                   ; preds = %287
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %293
+ThrowNullRef18:                                   ; preds = %293
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %298
+ThrowNullRef20:                                   ; preds = %298
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %303
+ThrowNullRef22:                                   ; preds = %303
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %243
+ThrowNullRef24:                                   ; preds = %243
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %247
+ThrowNullRef26:                                   ; preds = %247
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %250
+ThrowNullRef28:                                   ; preds = %250
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %256
+ThrowNullRef30:                                   ; preds = %256
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %259
+ThrowNullRef32:                                   ; preds = %259
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %265
+ThrowNullRef34:                                   ; preds = %265
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %217
+ThrowNullRef36:                                   ; preds = %217
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %221
+ThrowNullRef38:                                   ; preds = %221
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %224
+ThrowNullRef40:                                   ; preds = %224
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %230
+ThrowNullRef42:                                   ; preds = %230
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %233
+ThrowNullRef44:                                   ; preds = %233
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %238
+ThrowNullRef46:                                   ; preds = %238
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %200
+ThrowNullRef48:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %204
+ThrowNullRef50:                                   ; preds = %204
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %207
+ThrowNullRef52:                                   ; preds = %207
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %213
+ThrowNullRef54:                                   ; preds = %213
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %172
+ThrowNullRef56:                                   ; preds = %172
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %176
+ThrowNullRef58:                                   ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %179
+ThrowNullRef60:                                   ; preds = %179
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %185
+ThrowNullRef62:                                   ; preds = %185
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %190
+ThrowNullRef64:                                   ; preds = %190
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %195
+ThrowNullRef66:                                   ; preds = %195
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %153
+ThrowNullRef68:                                   ; preds = %153
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %157
+ThrowNullRef70:                                   ; preds = %157
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %160
+ThrowNullRef72:                                   ; preds = %160
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %166
+ThrowNullRef74:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %136
+ThrowNullRef76:                                   ; preds = %136
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %140
+ThrowNullRef78:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %143
+ThrowNullRef80:                                   ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %148
+ThrowNullRef82:                                   ; preds = %148
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %128
+ThrowNullRef84:                                   ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %132
+ThrowNullRef86:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %100
+ThrowNullRef88:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %104
+ThrowNullRef90:                                   ; preds = %104
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %107
+ThrowNullRef92:                                   ; preds = %107
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %113
+ThrowNullRef94:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %118
+ThrowNullRef96:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %123
+ThrowNullRef98:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %81
+ThrowNullRef100:                                  ; preds = %81
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef101:                                  ; preds = %85
+ThrowNullRef102:                                  ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef103:                                  ; preds = %88
+ThrowNullRef104:                                  ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef105:                                  ; preds = %94
+ThrowNullRef106:                                  ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef107:                                  ; preds = %64
+ThrowNullRef108:                                  ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef109:                                  ; preds = %68
+ThrowNullRef110:                                  ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef111:                                  ; preds = %71
+ThrowNullRef112:                                  ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef113:                                  ; preds = %76
+ThrowNullRef114:                                  ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef115:                                  ; preds = %56
+ThrowNullRef116:                                  ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef117:                                  ; preds = %60
+ThrowNullRef118:                                  ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef119:                                  ; preds = %37
+ThrowNullRef120:                                  ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef121:                                  ; preds = %41
+ThrowNullRef122:                                  ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef123:                                  ; preds = %46
+ThrowNullRef124:                                  ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef125:                                  ; preds = %51
+ThrowNullRef126:                                  ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef127:                                  ; preds = %27
+ThrowNullRef128:                                  ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef129:                                  ; preds = %31
+ThrowNullRef130:                                  ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef131:                                  ; preds = %19
+ThrowNullRef132:                                  ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef133:                                  ; preds = %22
+ThrowNullRef134:                                  ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef135:                                  ; preds = %338
+ThrowNullRef136:                                  ; preds = %338
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef137:                                  ; preds = %341
+ThrowNullRef138:                                  ; preds = %341
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef139:                                  ; preds = %356
+ThrowNullRef140:                                  ; preds = %356
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef141:                                  ; preds = %360
+ThrowNullRef142:                                  ; preds = %360
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef143:                                  ; preds = %377
+ThrowNullRef144:                                  ; preds = %377
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef145:                                  ; preds = %381
+ThrowNullRef146:                                  ; preds = %381
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef147:                                  ; preds = %424
+ThrowNullRef148:                                  ; preds = %424
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef149:                                  ; preds = %428
+ThrowNullRef150:                                  ; preds = %428
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef151:                                  ; preds = %440
+ThrowNullRef152:                                  ; preds = %440
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef153:                                  ; preds = %444
+ThrowNullRef154:                                  ; preds = %444
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef155:                                  ; preds = %456
+ThrowNullRef156:                                  ; preds = %456
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef157:                                  ; preds = %460
+ThrowNullRef158:                                  ; preds = %460
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef159:                                  ; preds = %474
+ThrowNullRef160:                                  ; preds = %474
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef161:                                  ; preds = %477
+ThrowNullRef162:                                  ; preds = %477
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef163:                                  ; preds = %394
+ThrowNullRef164:                                  ; preds = %394
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef165:                                  ; preds = %398
+ThrowNullRef166:                                  ; preds = %398
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef167:                                  ; preds = %401
+ThrowNullRef168:                                  ; preds = %401
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef169:                                  ; preds = %407
+ThrowNullRef170:                                  ; preds = %407
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1939,8 +2021,8 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
-  br i1 %NullCheck, label %22, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %ThrowNullRef, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
@@ -1948,8 +2030,8 @@ entry:
   store i32 %24, i32* %loc0
   %25 = load i32, i32* %loc0
   %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %26, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %27
 
 ; <label>:27                                      ; preds = %22
   %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
@@ -1971,7 +2053,7 @@ ThrowNullRef:                                     ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1989,8 +2071,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -2022,15 +2104,15 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2048,16 +2130,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
   %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
   store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %15
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
@@ -2072,8 +2154,8 @@ entry:
   %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
   %29 = ptrtoint i16 addrspace(1)* %28 to i64
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %19
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
@@ -2089,19 +2171,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2114,8 +2196,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
@@ -2128,7 +2210,7 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[loadElem]
+Failed to read AppDomain.PrepareDataForSetup[storeElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
@@ -2202,8 +2284,8 @@ entry:
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
-  br i1 %NullCheck24, label %27, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = load i64, i64 addrspace(1)* %26
@@ -2218,8 +2300,8 @@ entry:
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
-  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
   %41 = load i64, i64 addrspace(1)* %39
@@ -2236,8 +2318,8 @@ entry:
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
-  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
   %54 = load i64, i64 addrspace(1)* %52
@@ -2252,8 +2334,8 @@ entry:
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
   %67 = load i64, i64 addrspace(1)* %65
@@ -2270,8 +2352,8 @@ entry:
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
-  br i1 %NullCheck16, label %79, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
   %80 = load i64, i64 addrspace(1)* %78
@@ -2286,8 +2368,8 @@ entry:
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
-  br i1 %NullCheck18, label %92, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
   %93 = load i64, i64 addrspace(1)* %91
@@ -2304,8 +2386,8 @@ entry:
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
-  br i1 %NullCheck12, label %105, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = load i64, i64 addrspace(1)* %104
@@ -2320,8 +2402,8 @@ entry:
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
-  br i1 %NullCheck14, label %118, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
   %119 = load i64, i64 addrspace(1)* %117
@@ -2337,8 +2419,8 @@ entry:
 
 ; <label>:128                                     ; preds = %20
   %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
-  br i1 %NullCheck4, label %130, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %129, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %130
 
 ; <label>:130                                     ; preds = %128
   %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
@@ -2346,8 +2428,8 @@ entry:
   %133 = load i16, i16 addrspace(1)* %132, align 8
   %134 = zext i16 %133 to i32
   %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
-  br i1 %NullCheck6, label %136, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %135, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %136
 
 ; <label>:136                                     ; preds = %130
   %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
@@ -2360,8 +2442,8 @@ entry:
 
 ; <label>:143                                     ; preds = %136
   %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
-  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %144, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %145
 
 ; <label>:145                                     ; preds = %143
   %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
@@ -2369,8 +2451,8 @@ entry:
   %148 = load i16, i16 addrspace(1)* %147, align 8
   %149 = zext i16 %148 to i32
   %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %150, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %151
 
 ; <label>:151                                     ; preds = %145
   %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
@@ -2388,8 +2470,8 @@ entry:
 
 ; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
-  br i1 %NullCheck, label %163, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %ThrowNullRef, label %163
 
 ; <label>:163                                     ; preds = %161
   %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
@@ -2399,8 +2481,8 @@ entry:
 
 ; <label>:167                                     ; preds = %163
   %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
-  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %168, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %169
 
 ; <label>:169                                     ; preds = %167
   %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
@@ -2432,55 +2514,55 @@ ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %167
+ThrowNullRef2:                                    ; preds = %167
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %128
+ThrowNullRef4:                                    ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %130
+ThrowNullRef6:                                    ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %143
+ThrowNullRef8:                                    ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %145
+ThrowNullRef10:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %102
+ThrowNullRef12:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %105
+ThrowNullRef14:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %76
+ThrowNullRef16:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %79
+ThrowNullRef18:                                   ; preds = %79
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %50
+ThrowNullRef20:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %53
+ThrowNullRef22:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %24
+ThrowNullRef24:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %27
+ThrowNullRef26:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2503,15 +2585,15 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2519,16 +2601,16 @@ entry:
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
   store i32 %8, i32* %loc0
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
   %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
   store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
@@ -2546,16 +2628,16 @@ entry:
 
 ; <label>:23                                      ; preds = %64
   %24 = load i16*, i16** %loc3
-  %NullCheck12 = icmp ne i16* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i16* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
   store i32 %27, i32* %loc5
   %28 = load i16*, i16** %loc4
-  %NullCheck14 = icmp ne i16* %28, null
-  br i1 %NullCheck14, label %29, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %28, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = load i16, i16* %28, align 8
@@ -2620,15 +2702,15 @@ entry:
 
 ; <label>:67                                      ; preds = %64
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
-  br i1 %NullCheck8, label %69, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %68, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %69
 
 ; <label>:69                                      ; preds = %67
   %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
   %71 = load i32, i32 addrspace(1)* %70
   %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
-  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %73
 
 ; <label>:73                                      ; preds = %69
   %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
@@ -2645,31 +2727,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %67
+ThrowNullRef8:                                    ; preds = %67
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %69
+ThrowNullRef10:                                   ; preds = %69
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2710,14 +2792,14 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
   %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
@@ -2730,14 +2812,14 @@ entry:
 
 ; <label>:11                                      ; preds = %4
   %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
   %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
@@ -2749,14 +2831,14 @@ entry:
 
 ; <label>:22                                      ; preds = %16
   %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
   %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
-  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
-  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
@@ -2804,23 +2886,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2836,7 +2918,280 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[loadElem]
+Successfully read RuntimeType.IsAssignableFrom
+
+define i8 @RuntimeType.IsAssignableFrom(%System.RuntimeType addrspace(1)* %param0, %System.Type addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.RuntimeType addrspace(1)*
+  %arg1 = alloca %System.Type addrspace(1)*
+  %loc0 = alloca %System.RuntimeType addrspace(1)*
+  %loc1 = alloca %"System.Type[]" addrspace(1)*
+  %loc2 = alloca i32
+  store %System.RuntimeType addrspace(1)* %param0, %System.RuntimeType addrspace(1)** %this
+  store %System.Type addrspace(1)* %param1, %System.Type addrspace(1)** %arg1
+  %0 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %1 = icmp ne %System.Type addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i8 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %5 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %6 = bitcast %System.Type addrspace(1)* %4 to %System.Object addrspace(1)*
+  %7 = bitcast %System.RuntimeType addrspace(1)* %5 to %System.Object addrspace(1)*
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %6, %System.Object addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %3
+  ret i8 1
+
+; <label>:12                                      ; preds = %3
+  %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 152
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 32
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
+  %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
+  %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
+  store %System.RuntimeType addrspace(1)* %25, %System.RuntimeType addrspace(1)** %loc0
+  %26 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %27 = icmp eq %System.RuntimeType addrspace(1)* %26, null
+  br i1 %27, label %34, label %28
+
+; <label>:28                                      ; preds = %15
+  %29 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %30 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)*)*)(%System.RuntimeType addrspace(1)* %29, %System.RuntimeType addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+; <label>:34                                      ; preds = %15
+  %35 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %36 = call %System.Reflection.Emit.TypeBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Reflection.Emit.TypeBuilder addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %35)
+  %37 = icmp eq %System.Reflection.Emit.TypeBuilder addrspace(1)* %36, null
+  br i1 %37, label %139, label %38
+
+; <label>:38                                      ; preds = %34
+  %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %42
+
+; <label>:42                                      ; preds = %38
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 152
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 40
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
+  %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
+  %53 = zext i8 %52 to i32
+  %54 = icmp eq i32 %53, 0
+  br i1 %54, label %56, label %55
+
+; <label>:55                                      ; preds = %42
+  ret i8 1
+
+; <label>:56                                      ; preds = %42
+  %57 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %58 = bitcast %System.RuntimeType addrspace(1)* %57 to %System.Type addrspace(1)*
+  %59 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %58)
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %64 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.Type addrspace(1)* %63, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = bitcast %System.RuntimeType addrspace(1)* %64 to %System.Type addrspace(1)*
+  %67 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %63, %System.Type addrspace(1)* %66)
+  %68 = zext i8 %67 to i32
+  %69 = trunc i32 %68 to i8
+  ret i8 %69
+
+; <label>:70                                      ; preds = %56
+  %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
+  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %73
+
+; <label>:73                                      ; preds = %70
+  %74 = load i64, i64 addrspace(1)* %72
+  %75 = add i64 %74, 128
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = add i64 %77, 0
+  %79 = inttoptr i64 %78 to i64*
+  %80 = load i64, i64* %79
+  %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
+  %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
+  %83 = call i8 %82(%System.Type addrspace(1)* %81)
+  %84 = zext i8 %83 to i32
+  %85 = icmp eq i32 %84, 0
+  br i1 %85, label %139, label %86
+
+; <label>:86                                      ; preds = %73
+  %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
+  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %89
+
+; <label>:89                                      ; preds = %86
+  %90 = load i64, i64 addrspace(1)* %88
+  %91 = add i64 %90, 128
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = add i64 %93, 24
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
+  %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
+  %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
+  store %"System.Type[]" addrspace(1)* %99, %"System.Type[]" addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %129
+
+; <label>:100                                     ; preds = %132
+  %101 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %102 = load i32, i32* %loc2
+  %NullCheck11 = icmp eq %"System.Type[]" addrspace(1)* %101, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %103
+
+; <label>:103                                     ; preds = %100
+  %104 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 1
+  %105 = load i32, i32 addrspace(1)* %104
+  %106 = zext i32 %105 to i64
+  %107 = zext i32 %102 to i64
+  %BoundsCheck = icmp uge i64 %107, %106
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %108
+
+; <label>:108                                     ; preds = %103
+  %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
+  %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
+  %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
+  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %113
+
+; <label>:113                                     ; preds = %108
+  %114 = load i64, i64 addrspace(1)* %112
+  %115 = add i64 %114, 152
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = add i64 %117, 56
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
+  %123 = zext i8 %122 to i32
+  %124 = icmp ne i32 %123, 0
+  br i1 %124, label %126, label %125
+
+; <label>:125                                     ; preds = %113
+  ret i8 0
+
+; <label>:126                                     ; preds = %113
+  %127 = load i32, i32* %loc2
+  %128 = add i32 %127, 1
+  store i32 %128, i32* %loc2
+  br label %129
+
+; <label>:129                                     ; preds = %89, %126
+  %130 = load i32, i32* %loc2
+  %131 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %NullCheck9 = icmp eq %"System.Type[]" addrspace(1)* %131, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %132
+
+; <label>:132                                     ; preds = %129
+  %133 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %131, i32 0, i32 1
+  %134 = load i32, i32 addrspace(1)* %133
+  %135 = zext i32 %134 to i64
+  %136 = trunc i64 %135 to i32
+  %137 = icmp slt i32 %130, %136
+  br i1 %137, label %100, label %138
+
+; <label>:138                                     ; preds = %132
+  ret i8 1
+
+; <label>:139                                     ; preds = %34, %73
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %129
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %103
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -2893,7 +3248,7 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElem]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -2904,8 +3259,8 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -2997,8 +3352,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
@@ -3059,8 +3414,8 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -3087,8 +3442,8 @@ entry:
 
 ; <label>:17                                      ; preds = %5, %11
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
@@ -3097,8 +3452,8 @@ entry:
 
 ; <label>:22                                      ; preds = %1, %11
   %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
@@ -3109,11 +3464,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %17
+ThrowNullRef2:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %22
+ThrowNullRef4:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3167,15 +3522,15 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
   %15 = load i32, i32 addrspace(1)* %14
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
@@ -3198,7 +3553,7 @@ ThrowNullRef:                                     ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef2:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3232,8 +3587,8 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
@@ -3312,8 +3667,8 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -3327,8 +3682,8 @@ entry:
 ; <label>:5                                       ; preds = %43
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %7 = load i32, i32* %loc1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck6, label %8, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
@@ -3366,8 +3721,8 @@ entry:
 ; <label>:32                                      ; preds = %21, %25
   %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
   %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
-  br i1 %NullCheck8, label %35, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = trunc i32 %34 to i16
@@ -3380,8 +3735,8 @@ entry:
 ; <label>:40                                      ; preds = %1, %35
   %41 = load i32, i32* %loc1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
-  br i1 %NullCheck2, label %43, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %42, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
@@ -3392,8 +3747,8 @@ entry:
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
   %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
-  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
   %51 = load i64, i64 addrspace(1)* %49
@@ -3412,19 +3767,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %40
+ThrowNullRef2:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %47
+ThrowNullRef4:                                    ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %5
+ThrowNullRef6:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %32
+ThrowNullRef8:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3467,8 +3822,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
@@ -3492,11 +3847,391 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(i16* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store i16* %param0, i16** %arg0
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load i32, i32* %arg3
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %42, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %37, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg2
+  %13 = load i32, i32* %arg3
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %37, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %24 = load i32, i32* %arg2
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load i16*, i16** %arg0
+  %35 = load i32, i32* %arg3
+  %36 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %36, i16* %34, i32 %35)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:37                                      ; preds = %5, %16
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %39)
+  %41 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41, %System.String addrspace(1)* %38, %System.String addrspace(1)* %40)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41) #0
+  unreachable
+
+; <label>:42                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
-Failed to read StringBuilder.ToString[loadElemA]
+Successfully read StringBuilder.ToString
+
+define %System.String addrspace(1)* @StringBuilder.ToString(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i16*
+  %loc3 = alloca %"System.Char[]" addrspace(1)*
+  %loc4 = alloca i32
+  %loc5 = alloca i32
+  %loc6 = alloca i16 addrspace(1)*
+  %loc7 = alloca %System.String addrspace(1)*
+  %loc8 = alloca %"System.Char[]" addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %0)
+  %2 = icmp ne i32 %1, 0
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %4
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %6)
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %7)
+  store %System.String addrspace(1)* %8, %System.String addrspace(1)** %loc0
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.Text.StringBuilder addrspace(1)* %9, %System.Text.StringBuilder addrspace(1)** %loc1
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  store %System.String addrspace(1)* %10, %System.String addrspace(1)** %loc7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc7
+  %12 = ptrtoint %System.String addrspace(1)* %11 to i64
+  %13 = icmp eq i64 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %5
+  %15 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %16 = sext i32 %15 to i64
+  %17 = add i64 %12, %16
+  br label %18
+
+; <label>:18                                      ; preds = %5, %14
+  %19 = phi i64 [ %12, %5 ], [ %17, %14 ]
+  %20 = inttoptr i64 %19 to i16*
+  store i16* %20, i16** %loc2
+  br label %21
+
+; <label>:21                                      ; preds = %98, %18
+  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %22, null
+  br i1 %NullCheck, label %ThrowNullRef, label %23
+
+; <label>:23                                      ; preds = %21
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 3
+  %25 = load i32, i32 addrspace(1)* %24, align 8
+  %26 = icmp sle i32 %25, 0
+  br i1 %26, label %96, label %27
+
+; <label>:27                                      ; preds = %23
+  %28 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %28, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %29
+
+; <label>:29                                      ; preds = %27
+  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %28, i32 0, i32 1
+  %31 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %30, align 8
+  store %"System.Char[]" addrspace(1)* %31, %"System.Char[]" addrspace(1)** %loc3
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %33
+
+; <label>:33                                      ; preds = %29
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  store i32 %35, i32* %loc4
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  %39 = load i32, i32 addrspace(1)* %38, align 8
+  store i32 %39, i32* %loc5
+  %40 = load i32, i32* %loc5
+  %41 = load i32, i32* %loc4
+  %42 = add i32 %40, %41
+  %43 = zext i32 %42 to i64
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %45
+
+; <label>:45                                      ; preds = %37
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = sext i32 %47 to i64
+  %49 = icmp sgt i64 %43, %48
+  br i1 %49, label %91, label %50
+
+; <label>:50                                      ; preds = %45
+  %51 = load i32, i32* %loc5
+  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %52, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %53
+
+; <label>:53                                      ; preds = %50
+  %54 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %52, i32 0, i32 1
+  %55 = load i32, i32 addrspace(1)* %54
+  %56 = zext i32 %55 to i64
+  %57 = trunc i64 %56 to i32
+  %58 = icmp ugt i32 %51, %57
+  br i1 %58, label %91, label %59
+
+; <label>:59                                      ; preds = %53
+  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  store %"System.Char[]" addrspace(1)* %60, %"System.Char[]" addrspace(1)** %loc8
+  %61 = icmp eq %"System.Char[]" addrspace(1)* %60, null
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %63, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %64
+
+; <label>:64                                      ; preds = %62
+  %65 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %63, i32 0, i32 1
+  %66 = load i32, i32 addrspace(1)* %65
+  %67 = zext i32 %66 to i64
+  %68 = trunc i64 %67 to i32
+  %69 = icmp ne i32 %68, 0
+  br i1 %69, label %71, label %70
+
+; <label>:70                                      ; preds = %59, %64
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:71                                      ; preds = %64
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %73
+
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %BoundsCheck = icmp uge i64 0, %76
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %77
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %78, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:79                                      ; preds = %70, %77
+  %80 = load i16*, i16** %loc2
+  %81 = load i32, i32* %loc4
+  %82 = sext i32 %81 to i64
+  %83 = mul i64 %82, 2
+  %84 = bitcast i16* %80 to i8*
+  %85 = getelementptr inbounds i8, i8* %84, i64 %83
+  %86 = load i16 addrspace(1)*, i16 addrspace(1)** %loc6
+  %87 = ptrtoint i16 addrspace(1)* %86 to i64
+  %88 = load i32, i32* %loc5
+  %89 = bitcast i8* %85 to i16*
+  %90 = inttoptr i64 %87 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %89, i16* %90, i32 %88)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %96
+
+; <label>:91                                      ; preds = %45, %53
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %94 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %93)
+  %95 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95, %System.String addrspace(1)* %92, %System.String addrspace(1)* %94)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95) #0
+  unreachable
+
+; <label>:96                                      ; preds = %23, %79
+  %97 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %97, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %98
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %97, i32 0, i32 2
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  store %System.Text.StringBuilder addrspace(1)* %100, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %102 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %102, label %21, label %103
+
+; <label>:103                                     ; preds = %98
+  store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc7
+  %104 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  ret %System.String addrspace(1)* %104
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method StringBuilder::get_Length using LLILCJit
+Successfully read StringBuilder.get_Length
+
+define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
+Successfully read RuntimeHelpers.get_OffsetToStringData
+
+define i32 @RuntimeHelpers.get_OffsetToStringData() {
+entry:
+  ret i32 12
+}
+
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
 Successfully read CultureData.CreateCultureData
 
@@ -3514,23 +4249,23 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
   store i8 %4, i8 addrspace(1)* %6
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
@@ -3549,11 +4284,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3566,50 +4301,50 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
   store i32 -1, i32 addrspace(1)* %2
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
   store i32 -1, i32 addrspace(1)* %8
   %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
   store i32 -1, i32 addrspace(1)* %14
   %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
   store i32 -1, i32 addrspace(1)* %17
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
@@ -3623,27 +4358,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3675,7 +4410,136 @@ Failed to read Dictionary`2.Insert[non-const derefAddress]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
 Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
-Failed to read HashHelpers.GetPrime[loadElem]
+Successfully read HashHelpers.GetPrime
+
+define i32 @HashHelpers.GetPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %6, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5, %System.String addrspace(1)* %4)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5) #0
+  unreachable
+
+; <label>:6                                       ; preds = %entry
+  store i32 0, i32* %loc0
+  br label %29
+
+; <label>:7                                       ; preds = %35
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 1296
+  %10 = addrspacecast i8 addrspace(1)* %9 to %"System.Int32[]" addrspace(1)**
+  %11 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %10
+  %12 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Int32[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = zext i32 %15 to i64
+  %17 = zext i32 %12 to i64
+  %BoundsCheck = icmp uge i64 %17, %16
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 3, i32 %12
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  store i32 %20, i32* %loc1
+  %21 = load i32, i32* %loc1
+  %22 = load i32, i32* %arg0
+  %23 = icmp slt i32 %21, %22
+  br i1 %23, label %26, label %24
+
+; <label>:24                                      ; preds = %18
+  %25 = load i32, i32* %loc1
+  ret i32 %25
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %loc0
+  %28 = add i32 %27, 1
+  store i32 %28, i32* %loc0
+  br label %29
+
+; <label>:29                                      ; preds = %6, %26
+  %30 = load i32, i32* %loc0
+  %31 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %32 = getelementptr inbounds i8, i8 addrspace(1)* %31, i64 1296
+  %33 = addrspacecast i8 addrspace(1)* %32 to %"System.Int32[]" addrspace(1)**
+  %34 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %33
+  %NullCheck = icmp eq %"System.Int32[]" addrspace(1)* %34, null
+  br i1 %NullCheck, label %ThrowNullRef, label %35
+
+; <label>:35                                      ; preds = %29
+  %36 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %34, i32 0, i32 1
+  %37 = load i32, i32 addrspace(1)* %36
+  %38 = zext i32 %37 to i64
+  %39 = trunc i64 %38 to i32
+  %40 = icmp slt i32 %30, %39
+  br i1 %40, label %7, label %41
+
+; <label>:41                                      ; preds = %35
+  %42 = load i32, i32* %arg0
+  %43 = or i32 %42, 1
+  store i32 %43, i32* %loc2
+  br label %59
+
+; <label>:44                                      ; preds = %59
+  %45 = load i32, i32* %loc2
+  %46 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %45)
+  %47 = zext i8 %46 to i32
+  %48 = icmp eq i32 %47, 0
+  br i1 %48, label %56, label %49
+
+; <label>:49                                      ; preds = %44
+  %50 = load i32, i32* %loc2
+  %51 = sub i32 %50, 1
+  %52 = srem i32 %51, 101
+  %53 = icmp eq i32 %52, 0
+  br i1 %53, label %56, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = load i32, i32* %loc2
+  ret i32 %55
+
+; <label>:56                                      ; preds = %44, %49
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %57, 2
+  store i32 %58, i32* %loc2
+  br label %59
+
+; <label>:59                                      ; preds = %41, %56
+  %60 = load i32, i32* %loc2
+  %61 = icmp slt i32 %60, 2147483647
+  br i1 %61, label %44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load i32, i32* %arg0
+  ret i32 %63
+
+ThrowNullRef:                                     ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
 Successfully read GenericEqualityComparer`1.GetHashCode
 
@@ -3694,14 +4558,14 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
   %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load i64, i64 addrspace(1)* %7
@@ -3720,7 +4584,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3750,8 +4614,8 @@ entry:
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
@@ -3796,8 +4660,8 @@ entry:
   %35 = bitcast i16* %34 to i8*
   %36 = getelementptr inbounds i8, i8* %35, i64 2
   %37 = bitcast i8* %36 to i16*
-  %NullCheck4 = icmp ne i16* %37, null
-  br i1 %NullCheck4, label %38, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %37, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %38
 
 ; <label>:38                                      ; preds = %27
   %39 = load i16, i16* %37, align 8
@@ -3824,8 +4688,8 @@ entry:
 
 ; <label>:54                                      ; preds = %22, %43
   %55 = load i16*, i16** %loc4
-  %NullCheck2 = icmp ne i16* %55, null
-  br i1 %NullCheck2, label %56, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i16* %55, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %56
 
 ; <label>:56                                      ; preds = %54
   %57 = load i16, i16* %55, align 8
@@ -3850,11 +4714,11 @@ ThrowNullRef:                                     ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %54
+ThrowNullRef2:                                    ; preds = %54
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %27
+ThrowNullRef4:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3871,8 +4735,8 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -3907,8 +4771,8 @@ entry:
 
 ; <label>:26                                      ; preds = %19
   %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
-  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %28
 
 ; <label>:28                                      ; preds = %26
   %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
@@ -3920,7 +4784,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3972,8 +4836,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
@@ -3984,26 +4848,26 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
-  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
@@ -4014,8 +4878,8 @@ entry:
 ; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
@@ -4024,8 +4888,8 @@ entry:
 
 ; <label>:25                                      ; preds = %1, %16, %23
   %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
-  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
@@ -4036,27 +4900,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %20
+ThrowNullRef10:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4069,8 +4933,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -4081,8 +4945,8 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
@@ -4091,8 +4955,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1, %8
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
@@ -4103,11 +4967,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4128,24 +4992,24 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   store i32 %3, i32* %loc0
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
   %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
   store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck4, label %9, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
@@ -4164,15 +5028,15 @@ entry:
 ; <label>:18                                      ; preds = %70
   %19 = load i16*, i16** %loc3
   %20 = bitcast i16* %19 to i64*
-  %NullCheck10 = icmp ne i64* %20, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %20, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = load i64, i64* %20, align 8
   %23 = load i16*, i16** %loc4
   %24 = bitcast i16* %23 to i64*
-  %NullCheck12 = icmp ne i64* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = load i64, i64* %24, align 8
@@ -4188,8 +5052,8 @@ entry:
   %31 = bitcast i16* %30 to i8*
   %32 = getelementptr inbounds i8, i8* %31, i64 8
   %33 = bitcast i8* %32 to i64*
-  %NullCheck14 = icmp ne i64* %33, null
-  br i1 %NullCheck14, label %34, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = load i64, i64* %33, align 8
@@ -4197,8 +5061,8 @@ entry:
   %37 = bitcast i16* %36 to i8*
   %38 = getelementptr inbounds i8, i8* %37, i64 8
   %39 = bitcast i8* %38 to i64*
-  %NullCheck16 = icmp ne i64* %39, null
-  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %40
 
 ; <label>:40                                      ; preds = %34
   %41 = load i64, i64* %39, align 8
@@ -4214,8 +5078,8 @@ entry:
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %NullCheck18 = icmp ne i64* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = load i64, i64* %48, align 8
@@ -4223,8 +5087,8 @@ entry:
   %52 = bitcast i16* %51 to i8*
   %53 = getelementptr inbounds i8, i8* %52, i64 16
   %54 = bitcast i8* %53 to i64*
-  %NullCheck20 = icmp ne i64* %54, null
-  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64* %54, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %55
 
 ; <label>:55                                      ; preds = %49
   %56 = load i64, i64* %54, align 8
@@ -4262,15 +5126,15 @@ entry:
 ; <label>:74                                      ; preds = %95
   %75 = load i16*, i16** %loc3
   %76 = bitcast i16* %75 to i32*
-  %NullCheck6 = icmp ne i32* %76, null
-  br i1 %NullCheck6, label %77, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32* %76, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %77
 
 ; <label>:77                                      ; preds = %74
   %78 = load i32, i32* %76, align 8
   %79 = load i16*, i16** %loc4
   %80 = bitcast i16* %79 to i32*
-  %NullCheck8 = icmp ne i32* %80, null
-  br i1 %NullCheck8, label %81, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i32* %80, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %81
 
 ; <label>:81                                      ; preds = %77
   %82 = load i32, i32* %80, align 8
@@ -4318,43 +5182,43 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %74
+ThrowNullRef6:                                    ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %77
+ThrowNullRef8:                                    ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %29
+ThrowNullRef14:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %34
+ThrowNullRef16:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4376,8 +5240,8 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load i64, i64 addrspace(1)* %4
@@ -4389,8 +5253,8 @@ entry:
   %12 = load i64, i64* %11
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %5
   %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
@@ -4399,8 +5263,8 @@ entry:
   %18 = load i8, i8* %arg2
   %19 = zext i8 %18 to i32
   %20 = trunc i32 %19 to i8
-  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %15
   %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
@@ -4411,11 +5275,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4442,8 +5306,8 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
@@ -4466,16 +5330,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
   %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = load i64, i64 addrspace(1)* %19
@@ -4500,8 +5364,8 @@ entry:
 ; <label>:35                                      ; preds = %30
   %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
@@ -4514,8 +5378,8 @@ entry:
 
 ; <label>:42                                      ; preds = %1, %38
   %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
-  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
@@ -4526,19 +5390,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %35
+ThrowNullRef2:                                    ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %42
+ThrowNullRef8:                                    ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4551,14 +5415,14 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
@@ -4570,7 +5434,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4583,8 +5447,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
@@ -4613,51 +5477,51 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
   %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
   %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
   %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
   %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
-  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
   store i64 %21, i64 addrspace(1)* %23
   %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %25 = load i64, i64* %loc0
-  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
@@ -4668,27 +5532,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %22
+ThrowNullRef12:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4701,8 +5565,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
@@ -4713,19 +5577,19 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
@@ -4734,8 +5598,8 @@ entry:
 
 ; <label>:15                                      ; preds = %1, %13
   %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
@@ -4746,19 +5610,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %15
+ThrowNullRef8:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4771,8 +5635,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -4831,8 +5695,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
@@ -4882,8 +5746,8 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
-  br i1 %NullCheck, label %17, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %ThrowNullRef, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
@@ -4894,15 +5758,15 @@ entry:
 
 ; <label>:22                                      ; preds = %17
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
-  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
   %26 = load i32, i32 addrspace(1)* %25
   %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
-  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %27, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
@@ -4925,8 +5789,8 @@ entry:
 ; <label>:40                                      ; preds = %17
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
-  br i1 %NullCheck6, label %43, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %41, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
@@ -4938,34 +5802,17 @@ ThrowNullRef:                                     ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %24
+ThrowNullRef4:                                    ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %40
+ThrowNullRef6:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
-}
-
-INFO:  jitting method Object::ReferenceEquals using LLILCJit
-Successfully read Object.ReferenceEquals
-
-define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
-entry:
-  %arg0 = alloca %System.Object addrspace(1)*
-  %arg1 = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
-  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
-  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = icmp eq %System.Object addrspace(1)* %0, %1
-  %3 = sext i1 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
 }
 
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
@@ -4978,21 +5825,21 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
   %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
-  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
@@ -5007,28 +5854,28 @@ entry:
 ; <label>:13                                      ; preds = %8, %12
   %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
   %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
   %21 = load i32, i32 addrspace(1)* %20, align 8
   %22 = add i32 %21, 1
-  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
   store i32 %22, i32 addrspace(1)* %24
   %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
@@ -5039,27 +5886,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5077,7 +5924,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::Setup using LLILCJit
-Failed to read AppDomain.Setup[loadElem]
+Failed to read AppDomain.Setup[unbox]
 INFO:  jitting method Thread::GetDomain using LLILCJit
 Successfully read Thread.GetDomain
 
@@ -5108,8 +5955,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
@@ -5122,14 +5969,14 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
   %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
@@ -5141,11 +5988,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5173,8 +6020,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -5189,7 +6036,328 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
 Failed to read KeyCollection.System.Collections.Generic.IEnumerable<TKey>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Successfully read Enumerator.MoveNext
+
+define i8 @Enumerator.MoveNext(%"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.RuntimeTypeHandle* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*
+  %"$TypeArg" = alloca %System.RuntimeTypeHandle*
+  store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
+  %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 8
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %76, label %12
+
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
+  br label %76
+
+; <label>:13                                      ; preds = %85
+  %14 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck19 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %15
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, i32 0, i32 0
+  %17 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %16, align 8
+  %NullCheck21 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, i32 0, i32 2
+  %20 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %19, align 8
+  %21 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck23 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %22
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, i32 0, i32 2
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %NullCheck25 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 3, i32 %24
+  %NullCheck27 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %32
+
+; <label>:32                                      ; preds = %30
+  %33 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, i32 0, i32 2
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = icmp slt i32 %34, 0
+  br i1 %35, label %68, label %36
+
+; <label>:36                                      ; preds = %32
+  %37 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %38 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck29 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %39
+
+; <label>:39                                      ; preds = %36
+  %40 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, i32 0, i32 0
+  %41 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %40, align 8
+  %NullCheck31 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, i32 0, i32 2
+  %44 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %43, align 8
+  %45 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck33 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, i32 0, i32 2
+  %48 = load i32, i32 addrspace(1)* %47, align 8
+  %NullCheck35 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %49
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = zext i32 %51 to i64
+  %53 = zext i32 %48 to i64
+  %BoundsCheck37 = icmp uge i64 %53, %52
+  br i1 %BoundsCheck37, label %ThrowIndexOutOfRange38, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 3, i32 %48
+  %NullCheck39 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %56
+
+; <label>:56                                      ; preds = %54
+  %57 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, i32 0, i32 0
+  %58 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck41 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %59
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %60, %System.__Canon addrspace(1)* %58)
+  %61 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck43 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  %64 = load i32, i32 addrspace(1)* %63, align 8
+  %65 = add i32 %64, 1
+  %NullCheck45 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  store i32 %65, i32 addrspace(1)* %67
+  ret i8 1
+
+; <label>:68                                      ; preds = %32
+  %69 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck47 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %73 = add i32 %72, 1
+  %NullCheck49 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %74
+
+; <label>:74                                      ; preds = %70
+  %75 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  store i32 %73, i32 addrspace(1)* %75
+  br label %76
+
+; <label>:76                                      ; preds = %8, %12, %74
+  %77 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %78
+
+; <label>:78                                      ; preds = %76
+  %79 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, i32 0, i32 2
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck7 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %82
+
+; <label>:82                                      ; preds = %78
+  %83 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, i32 0, i32 0
+  %84 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %83, align 8
+  %NullCheck9 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %85
+
+; <label>:85                                      ; preds = %82
+  %86 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, i32 0, i32 7
+  %87 = load i32, i32 addrspace(1)* %86, align 8
+  %88 = icmp ult i32 %80, %87
+  br i1 %88, label %13, label %89
+
+; <label>:89                                      ; preds = %85
+  %90 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %91 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck11 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %92
+
+; <label>:92                                      ; preds = %89
+  %93 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, i32 0, i32 0
+  %94 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck13 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %95
+
+; <label>:95                                      ; preds = %92
+  %96 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, i32 0, i32 7
+  %97 = load i32, i32 addrspace(1)* %96, align 8
+  %98 = add i32 %97, 1
+  %NullCheck15 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %99
+
+; <label>:99                                      ; preds = %95
+  %100 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, i32 0, i32 2
+  store i32 %98, i32 addrspace(1)* %100
+  %101 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck17 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %102
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %103, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %92
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef22:                                   ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef24:                                   ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef26:                                   ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef28:                                   ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef30:                                   ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef32:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef34:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef36:                                   ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange38:                           ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef40:                                   ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef42:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef44:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef46:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef48:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef50:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -5200,8 +6368,8 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -5232,9 +6400,9 @@ Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
 Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
-Failed to read String.MakeSeparatorList[loadElemA]
+Failed to read String.MakeSeparatorList[storeElem]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
-Failed to read String.InternalSplitKeepEmptyEntries[loadElem]
+Failed to read String.InternalSplitKeepEmptyEntries[storeElem]
 INFO:  jitting method Path::IsRelative using LLILCJit
 Successfully read Path.IsRelative
 
@@ -5243,8 +6411,8 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -5254,8 +6422,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
@@ -5271,8 +6439,8 @@ entry:
 
 ; <label>:17                                      ; preds = %7
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
@@ -5288,8 +6456,8 @@ entry:
 
 ; <label>:29                                      ; preds = %19
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %31
 
 ; <label>:31                                      ; preds = %29
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
@@ -5300,8 +6468,8 @@ entry:
 
 ; <label>:36                                      ; preds = %31
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
-  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %37, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
@@ -5312,8 +6480,8 @@ entry:
 
 ; <label>:43                                      ; preds = %31, %38
   %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
-  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %45
 
 ; <label>:45                                      ; preds = %43
   %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
@@ -5324,8 +6492,8 @@ entry:
 
 ; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %50
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
@@ -5336,8 +6504,8 @@ entry:
 
 ; <label>:57                                      ; preds = %1, %7, %19, %45, %52
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
-  br i1 %NullCheck14, label %59, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %59
 
 ; <label>:59                                      ; preds = %57
   %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
@@ -5347,8 +6515,8 @@ entry:
 
 ; <label>:63                                      ; preds = %59
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
@@ -5359,8 +6527,8 @@ entry:
 
 ; <label>:70                                      ; preds = %65
   %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
-  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.String addrspace(1)* %71, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %72
 
 ; <label>:72                                      ; preds = %70
   %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
@@ -5379,39 +6547,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %17
+ThrowNullRef4:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %29
+ThrowNullRef6:                                    ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %36
+ThrowNullRef8:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %43
+ThrowNullRef10:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %50
+ThrowNullRef12:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %57
+ThrowNullRef14:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %63
+ThrowNullRef16:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %70
+ThrowNullRef18:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5419,7 +6587,293 @@ ThrowNullRef17:                                   ; preds = %70
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
-Failed to read String.TrimHelper[loadElem]
+Successfully read String.TrimHelper
+
+define %System.String addrspace(1)* @String.TrimHelper(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i16
+  %loc4 = alloca i32
+  %loc5 = alloca i16
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = sub i32 %3, 1
+  store i32 %4, i32* %loc0
+  store i32 0, i32* %loc1
+  %5 = load i32, i32* %arg2
+  %6 = icmp eq i32 %5, 1
+  br i1 %6, label %62, label %7
+
+; <label>:7                                       ; preds = %1
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:8                                       ; preds = %58
+  store i32 0, i32* %loc2
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load i32, i32* %loc1
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2, i32 %10
+  %13 = load i16, i16 addrspace(1)* %12
+  %14 = zext i16 %13 to i32
+  %15 = trunc i32 %14 to i16
+  store i16 %15, i16* %loc3
+  store i32 0, i32* %loc2
+  br label %34
+
+; <label>:16                                      ; preds = %37
+  %17 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %18 = load i32, i32* %loc2
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %17, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %19
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = zext i32 %18 to i64
+  %BoundsCheck = icmp uge i64 %23, %22
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %24
+
+; <label>:24                                      ; preds = %19
+  %25 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 3, i32 %18
+  %26 = load i16, i16 addrspace(1)* %25, align 8
+  %27 = zext i16 %26 to i32
+  %28 = load i16, i16* %loc3
+  %29 = zext i16 %28 to i32
+  %30 = icmp eq i32 %27, %29
+  br i1 %30, label %43, label %31
+
+; <label>:31                                      ; preds = %24
+  %32 = load i32, i32* %loc2
+  %33 = add i32 %32, 1
+  store i32 %33, i32* %loc2
+  br label %34
+
+; <label>:34                                      ; preds = %11, %31
+  %35 = load i32, i32* %loc2
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = icmp slt i32 %35, %41
+  br i1 %42, label %16, label %43
+
+; <label>:43                                      ; preds = %24, %37
+  %44 = load i32, i32* %loc2
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %45, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp eq i32 %44, %50
+  br i1 %51, label %62, label %52
+
+; <label>:52                                      ; preds = %46
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %7, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %57, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %58
+
+; <label>:58                                      ; preds = %55
+  %59 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %60 = load i32, i32 addrspace(1)* %59
+  %61 = icmp slt i32 %56, %60
+  br i1 %61, label %8, label %62
+
+; <label>:62                                      ; preds = %1, %46, %58
+  %63 = load i32, i32* %arg2
+  %64 = icmp eq i32 %63, 0
+  br i1 %64, label %122, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %66, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %67
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %66, i32 0, i32 1
+  %69 = load i32, i32 addrspace(1)* %68
+  %70 = sub i32 %69, 1
+  store i32 %70, i32* %loc0
+  br label %118
+
+; <label>:71                                      ; preds = %118
+  store i32 0, i32* %loc4
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %73 = load i32, i32* %loc0
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %74
+
+; <label>:74                                      ; preds = %71
+  %75 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 2, i32 %73
+  %76 = load i16, i16 addrspace(1)* %75
+  %77 = zext i16 %76 to i32
+  %78 = trunc i32 %77 to i16
+  store i16 %78, i16* %loc5
+  store i32 0, i32* %loc4
+  br label %97
+
+; <label>:79                                      ; preds = %100
+  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %81 = load i32, i32* %loc4
+  %NullCheck19 = icmp eq %"System.Char[]" addrspace(1)* %80, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
+
+; <label>:82                                      ; preds = %79
+  %83 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 1
+  %84 = load i32, i32 addrspace(1)* %83
+  %85 = zext i32 %84 to i64
+  %86 = zext i32 %81 to i64
+  %BoundsCheck21 = icmp uge i64 %86, %85
+  br i1 %BoundsCheck21, label %ThrowIndexOutOfRange22, label %87
+
+; <label>:87                                      ; preds = %82
+  %88 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 3, i32 %81
+  %89 = load i16, i16 addrspace(1)* %88, align 8
+  %90 = zext i16 %89 to i32
+  %91 = load i16, i16* %loc5
+  %92 = zext i16 %91 to i32
+  %93 = icmp eq i32 %90, %92
+  br i1 %93, label %106, label %94
+
+; <label>:94                                      ; preds = %87
+  %95 = load i32, i32* %loc4
+  %96 = add i32 %95, 1
+  store i32 %96, i32* %loc4
+  br label %97
+
+; <label>:97                                      ; preds = %74, %94
+  %98 = load i32, i32* %loc4
+  %99 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck15 = icmp eq %"System.Char[]" addrspace(1)* %99, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %100
+
+; <label>:100                                     ; preds = %97
+  %101 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %99, i32 0, i32 1
+  %102 = load i32, i32 addrspace(1)* %101
+  %103 = zext i32 %102 to i64
+  %104 = trunc i64 %103 to i32
+  %105 = icmp slt i32 %98, %104
+  br i1 %105, label %79, label %106
+
+; <label>:106                                     ; preds = %87, %100
+  %107 = load i32, i32* %loc4
+  %108 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck17 = icmp eq %"System.Char[]" addrspace(1)* %108, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %109
+
+; <label>:109                                     ; preds = %106
+  %110 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %108, i32 0, i32 1
+  %111 = load i32, i32 addrspace(1)* %110
+  %112 = zext i32 %111 to i64
+  %113 = trunc i64 %112 to i32
+  %114 = icmp eq i32 %107, %113
+  br i1 %114, label %122, label %115
+
+; <label>:115                                     ; preds = %109
+  %116 = load i32, i32* %loc0
+  %117 = sub i32 %116, 1
+  store i32 %117, i32* %loc0
+  br label %118
+
+; <label>:118                                     ; preds = %67, %115
+  %119 = load i32, i32* %loc0
+  %120 = load i32, i32* %loc1
+  %121 = icmp sge i32 %119, %120
+  br i1 %121, label %71, label %122
+
+; <label>:122                                     ; preds = %62, %109, %118
+  %123 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %124 = load i32, i32* %loc1
+  %125 = load i32, i32* %loc0
+  %126 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %123, i32 %124, i32 %125)
+  ret %System.String addrspace(1)* %126
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %97
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange22:                           ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
 Successfully read String.CreateTrimmedString
 
@@ -5439,8 +6893,8 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
@@ -5535,8 +6989,8 @@ entry:
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i64 2872
   %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
   %8 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %7
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %3
   %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
@@ -5553,8 +7007,8 @@ entry:
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 2864
   %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
   %21 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %20
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
-  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %22
 
 ; <label>:22                                      ; preds = %16
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
@@ -5569,7 +7023,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %16
+ThrowNullRef2:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5586,8 +7040,8 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5613,8 +7067,8 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
@@ -5632,8 +7086,8 @@ entry:
 
 ; <label>:12                                      ; preds = %4
   %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
@@ -5644,8 +7098,8 @@ entry:
 
 ; <label>:19                                      ; preds = %14
   %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %19
   %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
@@ -5660,21 +7114,21 @@ entry:
   %31 = zext i16 %30 to i32
   %32 = bitcast i8* %29 to i16*
   %33 = trunc i32 %31 to i16
-  %NullCheck6 = icmp ne i16* %32, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i16* %32, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %21
   store i16 %33, i16* %32, align 8
   %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %36
 
 ; <label>:36                                      ; preds = %34
   %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
   %38 = load i32, i32 addrspace(1)* %37, align 8
   %39 = add i32 %38, 1
-  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %40
 
 ; <label>:40                                      ; preds = %36
   %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
@@ -5683,16 +7137,16 @@ entry:
 
 ; <label>:42                                      ; preds = %14
   %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
-  br i1 %NullCheck12, label %44, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
   %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
   %47 = load i16, i16* %arg1
   %48 = zext i16 %47 to i32
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = trunc i32 %48 to i16
@@ -5703,31 +7157,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %19
+ThrowNullRef4:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %21
+ThrowNullRef6:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %36
+ThrowNullRef10:                                   ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %42
+ThrowNullRef12:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %44
+ThrowNullRef14:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5740,8 +7194,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -5752,8 +7206,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
@@ -5762,14 +7216,14 @@ entry:
 
 ; <label>:11                                      ; preds = %1
   %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
@@ -5779,15 +7233,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5808,8 +7262,8 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5822,8 +7276,8 @@ entry:
 
 ; <label>:8                                       ; preds = %3
   %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
@@ -5842,15 +7296,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
-  br i1 %NullCheck4, label %22, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
   %24 = load i16*, i16* addrspace(1)* %23, align 8
   %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %25, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
@@ -5859,8 +7313,8 @@ entry:
   store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
@@ -5874,8 +7328,8 @@ entry:
 
 ; <label>:37                                      ; preds = %65
   %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %37
   %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
@@ -5886,16 +7340,16 @@ entry:
   %45 = bitcast i16* %41 to i8*
   %46 = getelementptr inbounds i8, i8* %45, i64 %44
   %47 = bitcast i8* %46 to i16*
-  %NullCheck14 = icmp ne i16* %47, null
-  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %47, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %48
 
 ; <label>:48                                      ; preds = %39
   %49 = load i16, i16* %47, align 8
   %50 = zext i16 %49 to i32
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %52 = load i32, i32* %loc1
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %53
 
 ; <label>:53                                      ; preds = %48
   %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
@@ -5916,8 +7370,8 @@ entry:
 ; <label>:62                                      ; preds = %36, %59
   %63 = load i32, i32* %loc1
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck10, label %65, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %65
 
 ; <label>:65                                      ; preds = %62
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
@@ -5936,15 +7390,15 @@ entry:
 
 ; <label>:74                                      ; preds = %70
   %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
-  br i1 %NullCheck18, label %76, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %76
 
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
   %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
-  br i1 %NullCheck20, label %80, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
   %81 = load i64, i64 addrspace(1)* %79
@@ -5958,8 +7412,8 @@ entry:
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
   %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
-  br i1 %NullCheck22, label %92, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.String addrspace(1)* %90, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %92
 
 ; <label>:92                                      ; preds = %80
   %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
@@ -5969,15 +7423,15 @@ entry:
 
 ; <label>:96                                      ; preds = %70
   %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
-  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %98
 
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
   %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
-  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
   %103 = load i64, i64 addrspace(1)* %101
@@ -5991,8 +7445,8 @@ entry:
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
   %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
-  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.String addrspace(1)* %112, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %114
 
 ; <label>:114                                     ; preds = %102
   %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
@@ -6004,59 +7458,59 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %20
+ThrowNullRef4:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %22
+ThrowNullRef6:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %26
+ThrowNullRef8:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %62
+ThrowNullRef10:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %48
+ThrowNullRef16:                                   ; preds = %48
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %74
+ThrowNullRef18:                                   ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %76
+ThrowNullRef20:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %80
+ThrowNullRef22:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %96
+ThrowNullRef24:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %98
+ThrowNullRef26:                                   ; preds = %98
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %102
+ThrowNullRef28:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6069,15 +7523,15 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
   %3 = load i16*, i16* addrspace(1)* %2, align 8
   %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
@@ -6087,8 +7541,8 @@ entry:
   %10 = bitcast i16* %3 to i8*
   %11 = getelementptr inbounds i8, i8* %10, i64 %9
   %12 = bitcast i8* %11 to i16*
-  %NullCheck4 = icmp ne i16* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %5
   store i16 0, i16* %12, align 8
@@ -6098,11 +7552,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6119,8 +7573,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -6131,8 +7585,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
@@ -6144,15 +7598,15 @@ entry:
 
 ; <label>:14                                      ; preds = %1
   %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
   %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
   %21 = load i64, i64 addrspace(1)* %19
@@ -6171,15 +7625,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %14
+ThrowNullRef4:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %16
+ThrowNullRef6:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6302,14 +7756,6 @@ entry:
   ret %System.String addrspace(1)* %57
 }
 
-INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
-Successfully read RuntimeHelpers.get_OffsetToStringData
-
-define i32 @RuntimeHelpers.get_OffsetToStringData() {
-entry:
-  ret i32 12
-}
-
 INFO:  jitting method String::Equals using LLILCJit
 Successfully read String.Equals
 
@@ -6381,8 +7827,8 @@ entry:
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
-  br i1 %NullCheck24, label %29, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
   %30 = load i64, i64 addrspace(1)* %28
@@ -6397,8 +7843,8 @@ entry:
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
-  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
   %43 = load i64, i64 addrspace(1)* %41
@@ -6418,8 +7864,8 @@ entry:
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
   %59 = load i64, i64 addrspace(1)* %57
@@ -6434,8 +7880,8 @@ entry:
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck22, label %71, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
   %72 = load i64, i64 addrspace(1)* %70
@@ -6455,8 +7901,8 @@ entry:
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
-  br i1 %NullCheck16, label %87, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = load i64, i64 addrspace(1)* %86
@@ -6471,8 +7917,8 @@ entry:
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck18, label %100, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
   %101 = load i64, i64 addrspace(1)* %99
@@ -6492,8 +7938,8 @@ entry:
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
-  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
   %117 = load i64, i64 addrspace(1)* %115
@@ -6508,8 +7954,8 @@ entry:
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
-  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
   %130 = load i64, i64 addrspace(1)* %128
@@ -6528,15 +7974,15 @@ entry:
 
 ; <label>:142                                     ; preds = %22
   %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
-  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %143, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %144
 
 ; <label>:144                                     ; preds = %142
   %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
   %146 = load i32, i32 addrspace(1)* %145
   %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
-  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %147, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %148
 
 ; <label>:148                                     ; preds = %144
   %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
@@ -6557,15 +8003,15 @@ entry:
 
 ; <label>:159                                     ; preds = %22
   %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
-  br i1 %NullCheck, label %161, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %ThrowNullRef, label %161
 
 ; <label>:161                                     ; preds = %159
   %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
   %163 = load i32, i32 addrspace(1)* %162
   %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
-  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %164, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %165
 
 ; <label>:165                                     ; preds = %161
   %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
@@ -6578,8 +8024,8 @@ entry:
 
 ; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
-  br i1 %NullCheck4, label %172, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %171, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %172
 
 ; <label>:172                                     ; preds = %170
   %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
@@ -6589,8 +8035,8 @@ entry:
 
 ; <label>:176                                     ; preds = %172
   %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
-  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %177, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %178
 
 ; <label>:178                                     ; preds = %176
   %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
@@ -6629,55 +8075,55 @@ ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %161
+ThrowNullRef2:                                    ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %170
+ThrowNullRef4:                                    ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %176
+ThrowNullRef6:                                    ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %142
+ThrowNullRef8:                                    ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %144
+ThrowNullRef10:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %113
+ThrowNullRef12:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %116
+ThrowNullRef14:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %84
+ThrowNullRef16:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %87
+ThrowNullRef18:                                   ; preds = %87
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %55
+ThrowNullRef20:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %58
+ThrowNullRef22:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %26
+ThrowNullRef24:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %29
+ThrowNullRef26:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,8 +8161,8 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck, label %14, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %ThrowNullRef, label %14
 
 ; <label>:14                                      ; preds = %8
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
@@ -6760,8 +8206,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
@@ -6770,14 +8216,14 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32, i32* %loc0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %10
   %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
   %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
@@ -6790,15 +8236,15 @@ entry:
 ; <label>:25                                      ; preds = %19
   %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
-  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
   %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
@@ -6807,8 +8253,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %37 = load i32, i32* %loc0
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %38, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %38
 
 ; <label>:38                                      ; preds = %32
   %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
@@ -6817,14 +8263,14 @@ entry:
 
 ; <label>:40                                      ; preds = %19
   %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %40
   %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
   %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
-  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
-  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
@@ -6832,8 +8278,8 @@ entry:
   %48 = zext i32 %47 to i64
   %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
-  br i1 %NullCheck16, label %51, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %51
 
 ; <label>:51                                      ; preds = %45
   %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
@@ -6847,15 +8293,15 @@ entry:
 ; <label>:57                                      ; preds = %51
   %58 = load i16*, i16** %arg1
   %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
-  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %60
 
 ; <label>:60                                      ; preds = %57
   %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
   %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
-  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %64
 
 ; <label>:64                                      ; preds = %60
   %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
@@ -6864,22 +8310,22 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
   %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
-  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %70
 
 ; <label>:70                                      ; preds = %64
   %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
   %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
-  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
-  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
   %75 = load i32, i32 addrspace(1)* %74
   %76 = zext i32 %75 to i64
   %77 = trunc i64 %76 to i32
-  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
-  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %78
 
 ; <label>:78                                      ; preds = %73
   %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
@@ -6901,8 +8347,8 @@ entry:
   %90 = bitcast i16* %86 to i8*
   %91 = getelementptr inbounds i8, i8* %90, i64 %89
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %93
 
 ; <label>:93                                      ; preds = %80
   %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
@@ -6912,8 +8358,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %99 = load i32, i32* %loc2
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %100
 
 ; <label>:100                                     ; preds = %93
   %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
@@ -6928,63 +8374,63 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %25
+ThrowNullRef6:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %32
+ThrowNullRef10:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %40
+ThrowNullRef12:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %45
+ThrowNullRef16:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %57
+ThrowNullRef18:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %60
+ThrowNullRef20:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %64
+ThrowNullRef22:                                   ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %70
+ThrowNullRef24:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %73
+ThrowNullRef26:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %80
+ThrowNullRef28:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %93
+ThrowNullRef30:                                   ; preds = %93
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7004,8 +8450,8 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
@@ -7033,43 +8479,43 @@ entry:
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %14
   %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
   %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   %28 = load i32, i32 addrspace(1)* %27, align 8
   %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
-  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %30
 
 ; <label>:30                                      ; preds = %26
   %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
   %32 = load i32, i32 addrspace(1)* %31, align 8
   %33 = add i32 %28, %32
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %34
 
 ; <label>:34                                      ; preds = %30
   %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   store i32 %33, i32 addrspace(1)* %35
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
   store i32 0, i32 addrspace(1)* %38
   %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %40
 
 ; <label>:40                                      ; preds = %37
   %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
@@ -7082,8 +8528,8 @@ entry:
 
 ; <label>:47                                      ; preds = %40
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
@@ -7098,8 +8544,8 @@ entry:
   %54 = load i32, i32* %loc0
   %55 = sext i32 %54 to i64
   %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
-  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %57
 
 ; <label>:57                                      ; preds = %52
   %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
@@ -7110,68 +8556,35 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %14
+ThrowNullRef2:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %23
+ThrowNullRef4:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %26
+ThrowNullRef6:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %30
+ThrowNullRef8:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %34
+ThrowNullRef10:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %47
+ThrowNullRef14:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %52
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-}
-
-INFO:  jitting method StringBuilder::get_Length using LLILCJit
-Successfully read StringBuilder.get_Length
-
-define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.StringBuilder addrspace(1)*
-  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
-  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
-
-; <label>:1                                       ; preds = %entry
-  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %3 = load i32, i32 addrspace(1)* %2, align 8
-  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
-
-; <label>:5                                       ; preds = %1
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = add i32 %3, %7
-  ret i32 %8
-
-ThrowNullRef:                                     ; preds = %entry
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef16:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7213,70 +8626,70 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
   %6 = load i32, i32 addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
   store i32 %6, i32 addrspace(1)* %8
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
   %13 = load i32, i32 addrspace(1)* %12, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
   store i32 %13, i32 addrspace(1)* %15
   %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
-  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %18
 
 ; <label>:18                                      ; preds = %14
   %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
   %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
   %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
   %34 = load i32, i32 addrspace(1)* %33, align 8
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
-  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
@@ -7287,39 +8700,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %28
+ThrowNullRef16:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %32
+ThrowNullRef18:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7455,13 +8868,13 @@ entry:
 ; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
@@ -7477,16 +8890,16 @@ entry:
 
 ; <label>:18                                      ; preds = %15
   %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
   store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
   %22 = load i32, i32* %loc0
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %24
 
 ; <label>:24                                      ; preds = %20
   %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
@@ -7498,13 +8911,13 @@ entry:
 ; <label>:28                                      ; preds = %15, %24
   %29 = load i32, i32* %arg1
   %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %31
   %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
@@ -7517,20 +8930,20 @@ entry:
   %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
-  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
   %46 = load i32, i32 addrspace(1)* %45, align 8
   %47 = sub i32 %40, %46
-  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
-  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i32 addrspace(1)* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %48
 
 ; <label>:48                                      ; preds = %44
   store i32 %47, i32 addrspace(1)* %39, align 8
@@ -7538,21 +8951,21 @@ entry:
 
 ; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
-  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %51
 
 ; <label>:51                                      ; preds = %49
   %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %53
 
 ; <label>:53                                      ; preds = %51
   %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
   %55 = load i32, i32 addrspace(1)* %54, align 8
   %56 = load i32, i32* %arg2
   %57 = sub i32 %55, %56
-  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %58
 
 ; <label>:58                                      ; preds = %53
   %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
@@ -7562,13 +8975,13 @@ entry:
 ; <label>:60                                      ; preds = %33, %58
   %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
   %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
-  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %63
 
 ; <label>:63                                      ; preds = %60
   %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
-  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
-  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
@@ -7578,15 +8991,15 @@ entry:
 
 ; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
-  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i32 addrspace(1)* %69, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %70
 
 ; <label>:70                                      ; preds = %68
   %71 = load i32, i32 addrspace(1)* %69, align 8
   store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
-  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
@@ -7596,8 +9009,8 @@ entry:
   store i32 %77, i32* %loc4
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
-  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %80
 
 ; <label>:80                                      ; preds = %73
   %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
@@ -7607,71 +9020,71 @@ entry:
 ; <label>:83                                      ; preds = %80
   store i32 0, i32* %loc3
   %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
-  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
-  br i1 %NullCheck26, label %88, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i32 addrspace(1)* %87, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %88
 
 ; <label>:88                                      ; preds = %85
   %89 = load i32, i32 addrspace(1)* %87, align 8
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
-  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %90
 
 ; <label>:90                                      ; preds = %88
   %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
   store i32 %89, i32 addrspace(1)* %91
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
-  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
-  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %96
 
 ; <label>:96                                      ; preds = %94
   %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
-  br i1 %NullCheck34, label %100, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %100
 
 ; <label>:100                                     ; preds = %96
   %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
-  br i1 %NullCheck36, label %102, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %102
 
 ; <label>:102                                     ; preds = %100
   %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
   %104 = load i32, i32 addrspace(1)* %103, align 8
   %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
-  br i1 %NullCheck38, label %106, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %106
 
 ; <label>:106                                     ; preds = %102
   %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
-  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
-  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %108
 
 ; <label>:108                                     ; preds = %106
   %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
   %110 = load i32, i32 addrspace(1)* %109, align 8
   %111 = add i32 %104, %110
-  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %112
 
 ; <label>:112                                     ; preds = %108
   %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
   store i32 %111, i32 addrspace(1)* %113
   %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
-  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i32 addrspace(1)* %114, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %115
 
 ; <label>:115                                     ; preds = %112
   %116 = load i32, i32 addrspace(1)* %114, align 8
@@ -7681,19 +9094,19 @@ entry:
 ; <label>:118                                     ; preds = %115
   %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
-  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %121
 
 ; <label>:121                                     ; preds = %118
   %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
-  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
-  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %123
 
 ; <label>:123                                     ; preds = %121
   %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
   %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
-  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
-  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %126
 
 ; <label>:126                                     ; preds = %123
   %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
@@ -7705,8 +9118,8 @@ entry:
 
 ; <label>:130                                     ; preds = %80, %115, %126
   %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %132
 
 ; <label>:132                                     ; preds = %130
   %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7715,8 +9128,8 @@ entry:
   %136 = load i32, i32* %loc3
   %137 = sub i32 %135, %136
   %138 = sub i32 %134, %137
-  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %139
 
 ; <label>:139                                     ; preds = %132
   %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7728,16 +9141,16 @@ entry:
 
 ; <label>:144                                     ; preds = %139
   %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
-  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %146
 
 ; <label>:146                                     ; preds = %144
   %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
   %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
   %149 = load i32, i32* %loc2
   %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
-  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %151
 
 ; <label>:151                                     ; preds = %146
   %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
@@ -7754,145 +9167,249 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %18
+ThrowNullRef4:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %31
+ThrowNullRef10:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %44
+ThrowNullRef16:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %68
+ThrowNullRef18:                                   ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %70
+ThrowNullRef20:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %73
+ThrowNullRef22:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %83
+ThrowNullRef24:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %85
+ThrowNullRef26:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %88
+ThrowNullRef28:                                   ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %90
+ThrowNullRef30:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %94
+ThrowNullRef32:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %96
+ThrowNullRef34:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %100
+ThrowNullRef36:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %102
+ThrowNullRef38:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %106
+ThrowNullRef40:                                   ; preds = %106
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %108
+ThrowNullRef42:                                   ; preds = %108
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %112
+ThrowNullRef44:                                   ; preds = %112
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %118
+ThrowNullRef46:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %121
+ThrowNullRef48:                                   ; preds = %121
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %123
+ThrowNullRef50:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %130
+ThrowNullRef52:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %132
+ThrowNullRef54:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %144
+ThrowNullRef56:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %146
+ThrowNullRef58:                                   ; preds = %146
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %60
+ThrowNullRef60:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %63
+ThrowNullRef62:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %49
+ThrowNullRef64:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %51
+ThrowNullRef66:                                   ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %53
+ThrowNullRef68:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(%"System.Char[]" addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %arg0 = alloca %"System.Char[]" addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store %"System.Char[]" addrspace(1)* %param0, %"System.Char[]" addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load i32, i32* %arg4
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %43, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %38, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg1
+  %13 = load i32, i32* %arg4
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %38, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %24 = load i32, i32* %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %35 = load i32, i32* %arg3
+  %36 = load i32, i32* %arg4
+  %37 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %37, %"System.Char[]" addrspace(1)* %34, i32 %35, i32 %36)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:38                                      ; preds = %5, %16
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Successfully read Buffer._Memmove
 
@@ -7914,7 +9431,7 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[loadElem]
+Failed to read AppDomain.SetDataHelper[storeElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -7923,8 +9440,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
@@ -7934,8 +9451,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
@@ -7947,15 +9464,15 @@ entry:
   %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
   %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
@@ -7966,15 +9483,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7992,7 +9509,79 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
-Failed to read Dictionary`2.TryGetValue[loadElemA]
+Successfully read Dictionary`2.TryGetValue
+
+define i8 @"Dictionary`2.TryGetValue"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)* addrspace(1)* %param2) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  %arg2 = alloca %System.__Canon addrspace(1)* addrspace(1)*
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  store %System.__Canon addrspace(1)* addrspace(1)* %param2, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  store i32 %2, i32* %loc0
+  %3 = load i32, i32* %loc0
+  %4 = icmp slt i32 %3, 0
+  br i1 %4, label %22, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 2
+  %10 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %9, align 8
+  %11 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = zext i32 %11 to i64
+  %BoundsCheck = icmp uge i64 %16, %15
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 3, i32 %11
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %20, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %6, %System.__Canon addrspace(1)* %21)
+  ret i8 1
+
+; <label>:22                                      ; preds = %entry
+  %23 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %23, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -8058,8 +9647,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
@@ -8091,8 +9680,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
@@ -8171,15 +9760,15 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck, label %19, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %ThrowNullRef, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
   %21 = load i32, i32 addrspace(1)* %20
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
@@ -8202,7 +9791,7 @@ ThrowNullRef:                                     ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %19
+ThrowNullRef2:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8248,8 +9837,8 @@ entry:
   %0 = alloca %System.AppDomainHandle
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %1 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %1, i32 0, i32 15
@@ -8269,8 +9858,8 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
@@ -8286,7 +9875,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -8299,8 +9888,8 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -8327,8 +9916,8 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
@@ -8352,8 +9941,8 @@ entry:
   %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
   store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
@@ -8363,8 +9952,8 @@ entry:
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
@@ -8374,8 +9963,8 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %9
   %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
@@ -8384,8 +9973,8 @@ entry:
 
 ; <label>:18                                      ; preds = %3, %16
   %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
@@ -8397,15 +9986,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %18
+ThrowNullRef6:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8418,8 +10007,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
@@ -8453,15 +10042,15 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
@@ -8473,7 +10062,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8481,7 +10070,7 @@ ThrowNullRef1:                                    ; preds = %1
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
 Failed to read Dictionary`2.System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
@@ -8506,8 +10095,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
@@ -8524,8 +10113,8 @@ entry:
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -8544,7 +10133,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8577,8 +10166,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = load i64, i64* %arg2
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = trunc i32 %3 to i8
@@ -8634,46 +10223,46 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
   %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
-  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
-  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
-  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
@@ -8684,27 +10273,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %20
+ThrowNullRef12:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8717,8 +10306,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -8756,22 +10345,22 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
   %9 = load i64, i64 addrspace(1)* %8, align 8
   %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
   %13 = load i64, i64 addrspace(1)* %12, align 8
   %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %11
   %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
@@ -8788,11 +10377,11 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8882,8 +10471,8 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
@@ -8900,8 +10489,8 @@ entry:
 ; <label>:8                                       ; preds = %1
   %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
   %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
@@ -8911,15 +10500,15 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
   %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
   %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
-  br i1 %NullCheck6, label %21, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
@@ -8946,15 +10535,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8992,15 +10581,15 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
   store i8 %3, i8 addrspace(1)* %5
   %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
@@ -9011,7 +10600,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9027,8 +10616,8 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -9041,8 +10630,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
@@ -9058,7 +10647,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9080,8 +10669,8 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
@@ -9096,8 +10685,8 @@ entry:
 ; <label>:12                                      ; preds = %6
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
@@ -9112,8 +10701,8 @@ entry:
 ; <label>:21                                      ; preds = %15
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
@@ -9128,8 +10717,8 @@ entry:
 ; <label>:30                                      ; preds = %24
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %31, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
@@ -9144,8 +10733,8 @@ entry:
 ; <label>:39                                      ; preds = %33
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
-  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %40, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %42
 
 ; <label>:42                                      ; preds = %39
   %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
@@ -9164,19 +10753,19 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %21
+ThrowNullRef4:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %30
+ThrowNullRef6:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %39
+ThrowNullRef8:                                    ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9243,8 +10832,8 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
@@ -9264,57 +10853,57 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
   store i8 0, i8 addrspace(1)* %2
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
   store i8 0, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
   store i8 0, i8 addrspace(1)* %17
   %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
   store i8 0, i8 addrspace(1)* %20
   %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
-  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
@@ -9325,31 +10914,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %19
+ThrowNullRef14:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9367,8 +10956,8 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
@@ -9380,8 +10969,8 @@ entry:
 
 ; <label>:9                                       ; preds = %4
   %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %9
   %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
@@ -9395,7 +10984,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef2:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9420,8 +11009,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
@@ -9512,8 +11101,8 @@ entry:
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
@@ -9524,8 +11113,8 @@ entry:
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = load i64, i64 addrspace(1)* %12
@@ -9537,8 +11126,8 @@ entry:
   %20 = load i64, i64* %19
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
-  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %13
   %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
@@ -9555,8 +11144,8 @@ entry:
 ; <label>:30                                      ; preds = %25
   %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %32 = load i32, i32* %arg2
-  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
-  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
@@ -9570,15 +11159,15 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %30
+ThrowNullRef2:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9622,87 +11211,87 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
   %10 = load i8, i8 addrspace(1)* %9, align 8
   %11 = zext i8 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %8
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
   store i8 %12, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
   %19 = load i8, i8 addrspace(1)* %18, align 8
   %20 = zext i8 %19 to i32
   %21 = trunc i32 %20 to i8
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
   store i8 %21, i8 addrspace(1)* %23
   %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
   %28 = load i8, i8 addrspace(1)* %27, align 8
   %29 = zext i8 %28 to i32
   %30 = trunc i32 %29 to i8
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
-  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %31
 
 ; <label>:31                                      ; preds = %26
   %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
   store i8 %30, i8 addrspace(1)* %32
   %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
-  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
-  br i1 %NullCheck14, label %40, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %40
 
 ; <label>:40                                      ; preds = %35
   %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
   store i8 %39, i8 addrspace(1)* %41
   %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
-  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %44
 
 ; <label>:44                                      ; preds = %40
   %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
   %46 = load i8, i8 addrspace(1)* %45, align 8
   %47 = zext i8 %46 to i32
   %48 = trunc i32 %47 to i8
-  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
   store i8 %48, i8 addrspace(1)* %50
   %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
-  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
@@ -9713,29 +11302,29 @@ entry:
 ; <label>:56                                      ; preds = %52
   %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
-  br i1 %NullCheck22, label %59, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
   %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
   %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
-  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
-  br i1 %NullCheck24, label %63, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
   %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
-  br i1 %NullCheck26, label %66, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
   %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
-  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
-  br i1 %NullCheck28, label %69, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %69
 
 ; <label>:69                                      ; preds = %66
   %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
@@ -9744,15 +11333,15 @@ entry:
 
 ; <label>:71                                      ; preds = %105
   %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
-  br i1 %NullCheck34, label %73, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %73
 
 ; <label>:73                                      ; preds = %71
   %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
   %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
   %76 = load i32, i32* %loc0
-  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
-  br i1 %NullCheck36, label %77, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
@@ -9766,8 +11355,8 @@ entry:
 
 ; <label>:83                                      ; preds = %77
   %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
-  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
@@ -9775,14 +11364,14 @@ entry:
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
   %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
-  br i1 %NullCheck40, label %91, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
 ; <label>:91                                      ; preds = %85
   %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
   %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
-  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck42, label %94, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %94
 
 ; <label>:94                                      ; preds = %91
   %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
@@ -9798,14 +11387,14 @@ entry:
 ; <label>:99                                      ; preds = %69, %96
   %100 = load i32, i32* %loc0
   %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
-  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %102
 
 ; <label>:102                                     ; preds = %99
   %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
   %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
-  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
-  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
@@ -9819,87 +11408,87 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %26
+ThrowNullRef10:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %31
+ThrowNullRef12:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %35
+ThrowNullRef14:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %40
+ThrowNullRef16:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %56
+ThrowNullRef22:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %59
+ThrowNullRef24:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %63
+ThrowNullRef26:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %66
+ThrowNullRef28:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %102
+ThrowNullRef32:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %71
+ThrowNullRef34:                                   ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %73
+ThrowNullRef36:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %83
+ThrowNullRef38:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %85
+ThrowNullRef40:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %91
+ThrowNullRef42:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9943,15 +11532,15 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
   %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
@@ -9961,28 +11550,28 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
   %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %12
   %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
   %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
   %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
-  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
@@ -9993,23 +11582,23 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %12
+ThrowNullRef6:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10031,15 +11620,15 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
   %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = load i64, i64 addrspace(1)* %7
@@ -10077,13 +11666,13 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[loadElem]
+Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -10111,8 +11700,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -10154,5 +11743,62 @@ entry:
 INFO:  jitting method BringUpTest::Main using LLILCJit
 Failed to read BringUpTest.Main[convertHandle]
 INFO:  jitting method BringUpTest::IntArraySum using LLILCJit
-Failed to read BringUpTest.IntArraySum[loadElem]
+Successfully read BringUpTest.IntArraySum
+
+define i32 @BringUpTest.IntArraySum(%"System.Int32[]" addrspace(1)* %param0, i32 %param1) {
+entry:
+  %arg0 = alloca %"System.Int32[]" addrspace(1)*
+  %arg1 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  store %"System.Int32[]" addrspace(1)* %param0, %"System.Int32[]" addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  store i32 0, i32* %loc0
+  store i32 0, i32* %loc1
+  br label %15
+
+; <label>:0                                       ; preds = %15
+  %1 = load i32, i32* %loc0
+  %2 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %arg0
+  %3 = load i32, i32* %loc1
+  %NullCheck = icmp eq %"System.Int32[]" addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
+
+; <label>:4                                       ; preds = %0
+  %5 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %2, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = zext i32 %6 to i64
+  %8 = zext i32 %3 to i64
+  %BoundsCheck = icmp uge i64 %8, %7
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %9
+
+; <label>:9                                       ; preds = %4
+  %10 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %2, i32 0, i32 3, i32 %3
+  %11 = load i32, i32 addrspace(1)* %10, align 8
+  %12 = add i32 %1, %11
+  store i32 %12, i32* %loc0
+  %13 = load i32, i32* %loc1
+  %14 = add i32 %13, 1
+  store i32 %14, i32* %loc1
+  br label %15
+
+; <label>:15                                      ; preds = %entry, %9
+  %16 = load i32, i32* %loc1
+  %17 = load i32, i32* %arg1
+  %18 = icmp slt i32 %16, %17
+  br i1 %18, label %0, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = load i32, i32* %loc0
+  ret i32 %20
+
+ThrowNullRef:                                     ; preds = %0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/IntConv.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/IntConv.error.txt
@@ -25,8 +25,8 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
@@ -40,8 +40,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
   %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
@@ -75,7 +75,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -90,8 +90,8 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %NullCheck = icmp ne i8 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = load i8, i8 addrspace(1)* %0, align 8
@@ -125,8 +125,8 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
@@ -159,8 +159,8 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -184,8 +184,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
   store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
@@ -195,8 +195,8 @@ entry:
 ; <label>:4                                       ; preds = %1
   %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
   %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
@@ -206,8 +206,8 @@ entry:
   %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
@@ -221,14 +221,14 @@ entry:
 
 ; <label>:17                                      ; preds = %14
   %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
   %21 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
@@ -238,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -249,8 +249,8 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
@@ -261,27 +261,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %30
+ThrowNullRef10:                                   ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -301,7 +301,89 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
-Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
+Successfully read AppDomainSetup.GetUnsecureApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.GetUnsecureApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %NullCheck = icmp eq %"System.String[]" addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %BoundsCheck = icmp uge i64 0, %5
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %6
+
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 3, i32 0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
+  ret %System.String addrspace(1)* %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_Value using LLILCJit
+Successfully read AppDomainSetup.get_Value
+
+define %"System.String[]" addrspace(1)* @AppDomainSetup.get_Value(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.String[]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 18)
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.String[]" addrspace(1)* addrspace(1)*, %"System.String[]" addrspace(1)*)*)(%"System.String[]" addrspace(1)* addrspace(1)* %9, %"System.String[]" addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %11, i32 0, i32 1
+  %14 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %13, align 8
+  ret %"System.String[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -319,8 +401,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -368,16 +450,16 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
   %5 = load i32, i32 addrspace(1)* %4
   %6 = sub i32 %5, 1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -389,7 +471,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -421,8 +503,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
@@ -456,8 +538,8 @@ entry:
 ; <label>:27                                      ; preds = %19
   %28 = load i32, i32* %arg1
   %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
-  br i1 %NullCheck2, label %30, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %29, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %30
 
 ; <label>:30                                      ; preds = %27
   %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
@@ -493,8 +575,8 @@ entry:
 ; <label>:49                                      ; preds = %46
   %50 = load i32, i32* %arg2
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck4, label %52, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
@@ -517,11 +599,11 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %27
+ThrowNullRef2:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %49
+ThrowNullRef4:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -544,16 +626,16 @@ entry:
   %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %0)
   store %System.String addrspace(1)* %1, %System.String addrspace(1)** %loc0
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 2
   %5 = bitcast [0 x i16] addrspace(1)* %4 to i16 addrspace(1)*
   store i16 addrspace(1)* %5, i16 addrspace(1)** %loc1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %3
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2
@@ -580,7 +662,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -691,15 +773,15 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %NullCheck132 = icmp ne i8* %21, null
-  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+  %NullCheck131 = icmp eq i8* %21, null
+  br i1 %NullCheck131, label %ThrowNullRef132, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = load i8, i8* %21, align 8
   %24 = zext i8 %23 to i32
   %25 = trunc i32 %24 to i8
-  %NullCheck134 = icmp ne i8* %20, null
-  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+  %NullCheck133 = icmp eq i8* %20, null
+  br i1 %NullCheck133, label %ThrowNullRef134, label %26
 
 ; <label>:26                                      ; preds = %22
   store i8 %25, i8* %20, align 8
@@ -709,16 +791,16 @@ entry:
   %28 = load i8*, i8** %arg0
   %29 = load i8*, i8** %arg1
   %30 = bitcast i8* %29 to i16*
-  %NullCheck128 = icmp ne i16* %30, null
-  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+  %NullCheck127 = icmp eq i16* %30, null
+  br i1 %NullCheck127, label %ThrowNullRef128, label %31
 
 ; <label>:31                                      ; preds = %27
   %32 = load i16, i16* %30, align 8
   %33 = sext i16 %32 to i32
   %34 = bitcast i8* %28 to i16*
   %35 = trunc i32 %33 to i16
-  %NullCheck130 = icmp ne i16* %34, null
-  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+  %NullCheck129 = icmp eq i16* %34, null
+  br i1 %NullCheck129, label %ThrowNullRef130, label %36
 
 ; <label>:36                                      ; preds = %31
   store i16 %35, i16* %34, align 8
@@ -728,16 +810,16 @@ entry:
   %38 = load i8*, i8** %arg0
   %39 = load i8*, i8** %arg1
   %40 = bitcast i8* %39 to i16*
-  %NullCheck120 = icmp ne i16* %40, null
-  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+  %NullCheck119 = icmp eq i16* %40, null
+  br i1 %NullCheck119, label %ThrowNullRef120, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i16, i16* %40, align 8
   %43 = sext i16 %42 to i32
   %44 = bitcast i8* %38 to i16*
   %45 = trunc i32 %43 to i16
-  %NullCheck122 = icmp ne i16* %44, null
-  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+  %NullCheck121 = icmp eq i16* %44, null
+  br i1 %NullCheck121, label %ThrowNullRef122, label %46
 
 ; <label>:46                                      ; preds = %41
   store i16 %45, i16* %44, align 8
@@ -745,15 +827,15 @@ entry:
   %48 = getelementptr inbounds i8, i8* %47, i64 2
   %49 = load i8*, i8** %arg1
   %50 = getelementptr inbounds i8, i8* %49, i64 2
-  %NullCheck124 = icmp ne i8* %50, null
-  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+  %NullCheck123 = icmp eq i8* %50, null
+  br i1 %NullCheck123, label %ThrowNullRef124, label %51
 
 ; <label>:51                                      ; preds = %46
   %52 = load i8, i8* %50, align 8
   %53 = zext i8 %52 to i32
   %54 = trunc i32 %53 to i8
-  %NullCheck126 = icmp ne i8* %48, null
-  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+  %NullCheck125 = icmp eq i8* %48, null
+  br i1 %NullCheck125, label %ThrowNullRef126, label %55
 
 ; <label>:55                                      ; preds = %51
   store i8 %54, i8* %48, align 8
@@ -763,14 +845,14 @@ entry:
   %57 = load i8*, i8** %arg0
   %58 = load i8*, i8** %arg1
   %59 = bitcast i8* %58 to i32*
-  %NullCheck116 = icmp ne i32* %59, null
-  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+  %NullCheck115 = icmp eq i32* %59, null
+  br i1 %NullCheck115, label %ThrowNullRef116, label %60
 
 ; <label>:60                                      ; preds = %56
   %61 = load i32, i32* %59, align 8
   %62 = bitcast i8* %57 to i32*
-  %NullCheck118 = icmp ne i32* %62, null
-  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+  %NullCheck117 = icmp eq i32* %62, null
+  br i1 %NullCheck117, label %ThrowNullRef118, label %63
 
 ; <label>:63                                      ; preds = %60
   store i32 %61, i32* %62, align 8
@@ -780,14 +862,14 @@ entry:
   %65 = load i8*, i8** %arg0
   %66 = load i8*, i8** %arg1
   %67 = bitcast i8* %66 to i32*
-  %NullCheck108 = icmp ne i32* %67, null
-  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+  %NullCheck107 = icmp eq i32* %67, null
+  br i1 %NullCheck107, label %ThrowNullRef108, label %68
 
 ; <label>:68                                      ; preds = %64
   %69 = load i32, i32* %67, align 8
   %70 = bitcast i8* %65 to i32*
-  %NullCheck110 = icmp ne i32* %70, null
-  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+  %NullCheck109 = icmp eq i32* %70, null
+  br i1 %NullCheck109, label %ThrowNullRef110, label %71
 
 ; <label>:71                                      ; preds = %68
   store i32 %69, i32* %70, align 8
@@ -795,15 +877,15 @@ entry:
   %73 = getelementptr inbounds i8, i8* %72, i64 4
   %74 = load i8*, i8** %arg1
   %75 = getelementptr inbounds i8, i8* %74, i64 4
-  %NullCheck112 = icmp ne i8* %75, null
-  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+  %NullCheck111 = icmp eq i8* %75, null
+  br i1 %NullCheck111, label %ThrowNullRef112, label %76
 
 ; <label>:76                                      ; preds = %71
   %77 = load i8, i8* %75, align 8
   %78 = zext i8 %77 to i32
   %79 = trunc i32 %78 to i8
-  %NullCheck114 = icmp ne i8* %73, null
-  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+  %NullCheck113 = icmp eq i8* %73, null
+  br i1 %NullCheck113, label %ThrowNullRef114, label %80
 
 ; <label>:80                                      ; preds = %76
   store i8 %79, i8* %73, align 8
@@ -813,14 +895,14 @@ entry:
   %82 = load i8*, i8** %arg0
   %83 = load i8*, i8** %arg1
   %84 = bitcast i8* %83 to i32*
-  %NullCheck100 = icmp ne i32* %84, null
-  br i1 %NullCheck100, label %85, label %ThrowNullRef99
+  %NullCheck99 = icmp eq i32* %84, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %85
 
 ; <label>:85                                      ; preds = %81
   %86 = load i32, i32* %84, align 8
   %87 = bitcast i8* %82 to i32*
-  %NullCheck102 = icmp ne i32* %87, null
-  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+  %NullCheck101 = icmp eq i32* %87, null
+  br i1 %NullCheck101, label %ThrowNullRef102, label %88
 
 ; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
@@ -829,16 +911,16 @@ entry:
   %91 = load i8*, i8** %arg1
   %92 = getelementptr inbounds i8, i8* %91, i64 4
   %93 = bitcast i8* %92 to i16*
-  %NullCheck104 = icmp ne i16* %93, null
-  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+  %NullCheck103 = icmp eq i16* %93, null
+  br i1 %NullCheck103, label %ThrowNullRef104, label %94
 
 ; <label>:94                                      ; preds = %88
   %95 = load i16, i16* %93, align 8
   %96 = sext i16 %95 to i32
   %97 = bitcast i8* %90 to i16*
   %98 = trunc i32 %96 to i16
-  %NullCheck106 = icmp ne i16* %97, null
-  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+  %NullCheck105 = icmp eq i16* %97, null
+  br i1 %NullCheck105, label %ThrowNullRef106, label %99
 
 ; <label>:99                                      ; preds = %94
   store i16 %98, i16* %97, align 8
@@ -848,14 +930,14 @@ entry:
   %101 = load i8*, i8** %arg0
   %102 = load i8*, i8** %arg1
   %103 = bitcast i8* %102 to i32*
-  %NullCheck88 = icmp ne i32* %103, null
-  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+  %NullCheck87 = icmp eq i32* %103, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %104
 
 ; <label>:104                                     ; preds = %100
   %105 = load i32, i32* %103, align 8
   %106 = bitcast i8* %101 to i32*
-  %NullCheck90 = icmp ne i32* %106, null
-  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+  %NullCheck89 = icmp eq i32* %106, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %107
 
 ; <label>:107                                     ; preds = %104
   store i32 %105, i32* %106, align 8
@@ -864,16 +946,16 @@ entry:
   %110 = load i8*, i8** %arg1
   %111 = getelementptr inbounds i8, i8* %110, i64 4
   %112 = bitcast i8* %111 to i16*
-  %NullCheck92 = icmp ne i16* %112, null
-  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+  %NullCheck91 = icmp eq i16* %112, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %113
 
 ; <label>:113                                     ; preds = %107
   %114 = load i16, i16* %112, align 8
   %115 = sext i16 %114 to i32
   %116 = bitcast i8* %109 to i16*
   %117 = trunc i32 %115 to i16
-  %NullCheck94 = icmp ne i16* %116, null
-  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+  %NullCheck93 = icmp eq i16* %116, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %118
 
 ; <label>:118                                     ; preds = %113
   store i16 %117, i16* %116, align 8
@@ -881,15 +963,15 @@ entry:
   %120 = getelementptr inbounds i8, i8* %119, i64 6
   %121 = load i8*, i8** %arg1
   %122 = getelementptr inbounds i8, i8* %121, i64 6
-  %NullCheck96 = icmp ne i8* %122, null
-  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+  %NullCheck95 = icmp eq i8* %122, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %123
 
 ; <label>:123                                     ; preds = %118
   %124 = load i8, i8* %122, align 8
   %125 = zext i8 %124 to i32
   %126 = trunc i32 %125 to i8
-  %NullCheck98 = icmp ne i8* %120, null
-  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+  %NullCheck97 = icmp eq i8* %120, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %127
 
 ; <label>:127                                     ; preds = %123
   store i8 %126, i8* %120, align 8
@@ -899,14 +981,14 @@ entry:
   %129 = load i8*, i8** %arg0
   %130 = load i8*, i8** %arg1
   %131 = bitcast i8* %130 to i64*
-  %NullCheck84 = icmp ne i64* %131, null
-  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+  %NullCheck83 = icmp eq i64* %131, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %132
 
 ; <label>:132                                     ; preds = %128
   %133 = load i64, i64* %131, align 8
   %134 = bitcast i8* %129 to i64*
-  %NullCheck86 = icmp ne i64* %134, null
-  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+  %NullCheck85 = icmp eq i64* %134, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %135
 
 ; <label>:135                                     ; preds = %132
   store i64 %133, i64* %134, align 8
@@ -916,14 +998,14 @@ entry:
   %137 = load i8*, i8** %arg0
   %138 = load i8*, i8** %arg1
   %139 = bitcast i8* %138 to i64*
-  %NullCheck76 = icmp ne i64* %139, null
-  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+  %NullCheck75 = icmp eq i64* %139, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %140
 
 ; <label>:140                                     ; preds = %136
   %141 = load i64, i64* %139, align 8
   %142 = bitcast i8* %137 to i64*
-  %NullCheck78 = icmp ne i64* %142, null
-  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+  %NullCheck77 = icmp eq i64* %142, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %143
 
 ; <label>:143                                     ; preds = %140
   store i64 %141, i64* %142, align 8
@@ -931,15 +1013,15 @@ entry:
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %NullCheck80 = icmp ne i8* %147, null
-  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+  %NullCheck79 = icmp eq i8* %147, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %148
 
 ; <label>:148                                     ; preds = %143
   %149 = load i8, i8* %147, align 8
   %150 = zext i8 %149 to i32
   %151 = trunc i32 %150 to i8
-  %NullCheck82 = icmp ne i8* %145, null
-  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+  %NullCheck81 = icmp eq i8* %145, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %152
 
 ; <label>:152                                     ; preds = %148
   store i8 %151, i8* %145, align 8
@@ -949,14 +1031,14 @@ entry:
   %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
   %156 = bitcast i8* %155 to i64*
-  %NullCheck68 = icmp ne i64* %156, null
-  br i1 %NullCheck68, label %157, label %ThrowNullRef67
+  %NullCheck67 = icmp eq i64* %156, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %157
 
 ; <label>:157                                     ; preds = %153
   %158 = load i64, i64* %156, align 8
   %159 = bitcast i8* %154 to i64*
-  %NullCheck70 = icmp ne i64* %159, null
-  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+  %NullCheck69 = icmp eq i64* %159, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %160
 
 ; <label>:160                                     ; preds = %157
   store i64 %158, i64* %159, align 8
@@ -965,16 +1047,16 @@ entry:
   %163 = load i8*, i8** %arg1
   %164 = getelementptr inbounds i8, i8* %163, i64 8
   %165 = bitcast i8* %164 to i16*
-  %NullCheck72 = icmp ne i16* %165, null
-  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+  %NullCheck71 = icmp eq i16* %165, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %166
 
 ; <label>:166                                     ; preds = %160
   %167 = load i16, i16* %165, align 8
   %168 = sext i16 %167 to i32
   %169 = bitcast i8* %162 to i16*
   %170 = trunc i32 %168 to i16
-  %NullCheck74 = icmp ne i16* %169, null
-  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+  %NullCheck73 = icmp eq i16* %169, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %171
 
 ; <label>:171                                     ; preds = %166
   store i16 %170, i16* %169, align 8
@@ -984,14 +1066,14 @@ entry:
   %173 = load i8*, i8** %arg0
   %174 = load i8*, i8** %arg1
   %175 = bitcast i8* %174 to i64*
-  %NullCheck56 = icmp ne i64* %175, null
-  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+  %NullCheck55 = icmp eq i64* %175, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %176
 
 ; <label>:176                                     ; preds = %172
   %177 = load i64, i64* %175, align 8
   %178 = bitcast i8* %173 to i64*
-  %NullCheck58 = icmp ne i64* %178, null
-  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+  %NullCheck57 = icmp eq i64* %178, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %179
 
 ; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
@@ -1000,16 +1082,16 @@ entry:
   %182 = load i8*, i8** %arg1
   %183 = getelementptr inbounds i8, i8* %182, i64 8
   %184 = bitcast i8* %183 to i16*
-  %NullCheck60 = icmp ne i16* %184, null
-  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+  %NullCheck59 = icmp eq i16* %184, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %185
 
 ; <label>:185                                     ; preds = %179
   %186 = load i16, i16* %184, align 8
   %187 = sext i16 %186 to i32
   %188 = bitcast i8* %181 to i16*
   %189 = trunc i32 %187 to i16
-  %NullCheck62 = icmp ne i16* %188, null
-  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+  %NullCheck61 = icmp eq i16* %188, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %190
 
 ; <label>:190                                     ; preds = %185
   store i16 %189, i16* %188, align 8
@@ -1017,15 +1099,15 @@ entry:
   %192 = getelementptr inbounds i8, i8* %191, i64 10
   %193 = load i8*, i8** %arg1
   %194 = getelementptr inbounds i8, i8* %193, i64 10
-  %NullCheck64 = icmp ne i8* %194, null
-  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+  %NullCheck63 = icmp eq i8* %194, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %195
 
 ; <label>:195                                     ; preds = %190
   %196 = load i8, i8* %194, align 8
   %197 = zext i8 %196 to i32
   %198 = trunc i32 %197 to i8
-  %NullCheck66 = icmp ne i8* %192, null
-  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+  %NullCheck65 = icmp eq i8* %192, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %199
 
 ; <label>:199                                     ; preds = %195
   store i8 %198, i8* %192, align 8
@@ -1035,14 +1117,14 @@ entry:
   %201 = load i8*, i8** %arg0
   %202 = load i8*, i8** %arg1
   %203 = bitcast i8* %202 to i64*
-  %NullCheck48 = icmp ne i64* %203, null
-  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+  %NullCheck47 = icmp eq i64* %203, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %204
 
 ; <label>:204                                     ; preds = %200
   %205 = load i64, i64* %203, align 8
   %206 = bitcast i8* %201 to i64*
-  %NullCheck50 = icmp ne i64* %206, null
-  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+  %NullCheck49 = icmp eq i64* %206, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %207
 
 ; <label>:207                                     ; preds = %204
   store i64 %205, i64* %206, align 8
@@ -1051,14 +1133,14 @@ entry:
   %210 = load i8*, i8** %arg1
   %211 = getelementptr inbounds i8, i8* %210, i64 8
   %212 = bitcast i8* %211 to i32*
-  %NullCheck52 = icmp ne i32* %212, null
-  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+  %NullCheck51 = icmp eq i32* %212, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %213
 
 ; <label>:213                                     ; preds = %207
   %214 = load i32, i32* %212, align 8
   %215 = bitcast i8* %209 to i32*
-  %NullCheck54 = icmp ne i32* %215, null
-  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+  %NullCheck53 = icmp eq i32* %215, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %216
 
 ; <label>:216                                     ; preds = %213
   store i32 %214, i32* %215, align 8
@@ -1068,14 +1150,14 @@ entry:
   %218 = load i8*, i8** %arg0
   %219 = load i8*, i8** %arg1
   %220 = bitcast i8* %219 to i64*
-  %NullCheck36 = icmp ne i64* %220, null
-  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64* %220, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %221
 
 ; <label>:221                                     ; preds = %217
   %222 = load i64, i64* %220, align 8
   %223 = bitcast i8* %218 to i64*
-  %NullCheck38 = icmp ne i64* %223, null
-  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+  %NullCheck37 = icmp eq i64* %223, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %224
 
 ; <label>:224                                     ; preds = %221
   store i64 %222, i64* %223, align 8
@@ -1084,14 +1166,14 @@ entry:
   %227 = load i8*, i8** %arg1
   %228 = getelementptr inbounds i8, i8* %227, i64 8
   %229 = bitcast i8* %228 to i32*
-  %NullCheck40 = icmp ne i32* %229, null
-  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i32* %229, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %230
 
 ; <label>:230                                     ; preds = %224
   %231 = load i32, i32* %229, align 8
   %232 = bitcast i8* %226 to i32*
-  %NullCheck42 = icmp ne i32* %232, null
-  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+  %NullCheck41 = icmp eq i32* %232, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %233
 
 ; <label>:233                                     ; preds = %230
   store i32 %231, i32* %232, align 8
@@ -1099,15 +1181,15 @@ entry:
   %235 = getelementptr inbounds i8, i8* %234, i64 12
   %236 = load i8*, i8** %arg1
   %237 = getelementptr inbounds i8, i8* %236, i64 12
-  %NullCheck44 = icmp ne i8* %237, null
-  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i8* %237, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %238
 
 ; <label>:238                                     ; preds = %233
   %239 = load i8, i8* %237, align 8
   %240 = zext i8 %239 to i32
   %241 = trunc i32 %240 to i8
-  %NullCheck46 = icmp ne i8* %235, null
-  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+  %NullCheck45 = icmp eq i8* %235, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %242
 
 ; <label>:242                                     ; preds = %238
   store i8 %241, i8* %235, align 8
@@ -1117,14 +1199,14 @@ entry:
   %244 = load i8*, i8** %arg0
   %245 = load i8*, i8** %arg1
   %246 = bitcast i8* %245 to i64*
-  %NullCheck24 = icmp ne i64* %246, null
-  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64* %246, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %247
 
 ; <label>:247                                     ; preds = %243
   %248 = load i64, i64* %246, align 8
   %249 = bitcast i8* %244 to i64*
-  %NullCheck26 = icmp ne i64* %249, null
-  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64* %249, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %250
 
 ; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
@@ -1133,14 +1215,14 @@ entry:
   %253 = load i8*, i8** %arg1
   %254 = getelementptr inbounds i8, i8* %253, i64 8
   %255 = bitcast i8* %254 to i32*
-  %NullCheck28 = icmp ne i32* %255, null
-  br i1 %NullCheck28, label %256, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i32* %255, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %256
 
 ; <label>:256                                     ; preds = %250
   %257 = load i32, i32* %255, align 8
   %258 = bitcast i8* %252 to i32*
-  %NullCheck30 = icmp ne i32* %258, null
-  br i1 %NullCheck30, label %259, label %ThrowNullRef29
+  %NullCheck29 = icmp eq i32* %258, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %259
 
 ; <label>:259                                     ; preds = %256
   store i32 %257, i32* %258, align 8
@@ -1149,16 +1231,16 @@ entry:
   %262 = load i8*, i8** %arg1
   %263 = getelementptr inbounds i8, i8* %262, i64 12
   %264 = bitcast i8* %263 to i16*
-  %NullCheck32 = icmp ne i16* %264, null
-  br i1 %NullCheck32, label %265, label %ThrowNullRef31
+  %NullCheck31 = icmp eq i16* %264, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %265
 
 ; <label>:265                                     ; preds = %259
   %266 = load i16, i16* %264, align 8
   %267 = sext i16 %266 to i32
   %268 = bitcast i8* %261 to i16*
   %269 = trunc i32 %267 to i16
-  %NullCheck34 = icmp ne i16* %268, null
-  br i1 %NullCheck34, label %270, label %ThrowNullRef33
+  %NullCheck33 = icmp eq i16* %268, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %270
 
 ; <label>:270                                     ; preds = %265
   store i16 %269, i16* %268, align 8
@@ -1168,14 +1250,14 @@ entry:
   %272 = load i8*, i8** %arg0
   %273 = load i8*, i8** %arg1
   %274 = bitcast i8* %273 to i64*
-  %NullCheck8 = icmp ne i64* %274, null
-  br i1 %NullCheck8, label %275, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64* %274, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %275
 
 ; <label>:275                                     ; preds = %271
   %276 = load i64, i64* %274, align 8
   %277 = bitcast i8* %272 to i64*
-  %NullCheck10 = icmp ne i64* %277, null
-  br i1 %NullCheck10, label %278, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %277, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %278
 
 ; <label>:278                                     ; preds = %275
   store i64 %276, i64* %277, align 8
@@ -1184,14 +1266,14 @@ entry:
   %281 = load i8*, i8** %arg1
   %282 = getelementptr inbounds i8, i8* %281, i64 8
   %283 = bitcast i8* %282 to i32*
-  %NullCheck12 = icmp ne i32* %283, null
-  br i1 %NullCheck12, label %284, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i32* %283, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %284
 
 ; <label>:284                                     ; preds = %278
   %285 = load i32, i32* %283, align 8
   %286 = bitcast i8* %280 to i32*
-  %NullCheck14 = icmp ne i32* %286, null
-  br i1 %NullCheck14, label %287, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i32* %286, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %287
 
 ; <label>:287                                     ; preds = %284
   store i32 %285, i32* %286, align 8
@@ -1200,16 +1282,16 @@ entry:
   %290 = load i8*, i8** %arg1
   %291 = getelementptr inbounds i8, i8* %290, i64 12
   %292 = bitcast i8* %291 to i16*
-  %NullCheck16 = icmp ne i16* %292, null
-  br i1 %NullCheck16, label %293, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i16* %292, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %293
 
 ; <label>:293                                     ; preds = %287
   %294 = load i16, i16* %292, align 8
   %295 = sext i16 %294 to i32
   %296 = bitcast i8* %289 to i16*
   %297 = trunc i32 %295 to i16
-  %NullCheck18 = icmp ne i16* %296, null
-  br i1 %NullCheck18, label %298, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i16* %296, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %298
 
 ; <label>:298                                     ; preds = %293
   store i16 %297, i16* %296, align 8
@@ -1217,15 +1299,15 @@ entry:
   %300 = getelementptr inbounds i8, i8* %299, i64 14
   %301 = load i8*, i8** %arg1
   %302 = getelementptr inbounds i8, i8* %301, i64 14
-  %NullCheck20 = icmp ne i8* %302, null
-  br i1 %NullCheck20, label %303, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i8* %302, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %303
 
 ; <label>:303                                     ; preds = %298
   %304 = load i8, i8* %302, align 8
   %305 = zext i8 %304 to i32
   %306 = trunc i32 %305 to i8
-  %NullCheck22 = icmp ne i8* %300, null
-  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i8* %300, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %307
 
 ; <label>:307                                     ; preds = %303
   store i8 %306, i8* %300, align 8
@@ -1235,14 +1317,14 @@ entry:
   %309 = load i8*, i8** %arg0
   %310 = load i8*, i8** %arg1
   %311 = bitcast i8* %310 to i64*
-  %NullCheck = icmp ne i64* %311, null
-  br i1 %NullCheck, label %312, label %ThrowNullRef
+  %NullCheck = icmp eq i64* %311, null
+  br i1 %NullCheck, label %ThrowNullRef, label %312
 
 ; <label>:312                                     ; preds = %308
   %313 = load i64, i64* %311, align 8
   %314 = bitcast i8* %309 to i64*
-  %NullCheck2 = icmp ne i64* %314, null
-  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64* %314, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %315
 
 ; <label>:315                                     ; preds = %312
   store i64 %313, i64* %314, align 8
@@ -1251,14 +1333,14 @@ entry:
   %318 = load i8*, i8** %arg1
   %319 = getelementptr inbounds i8, i8* %318, i64 8
   %320 = bitcast i8* %319 to i64*
-  %NullCheck4 = icmp ne i64* %320, null
-  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64* %320, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %321
 
 ; <label>:321                                     ; preds = %315
   %322 = load i64, i64* %320, align 8
   %323 = bitcast i8* %317 to i64*
-  %NullCheck6 = icmp ne i64* %323, null
-  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64* %323, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %324
 
 ; <label>:324                                     ; preds = %321
   store i64 %322, i64* %323, align 8
@@ -1286,15 +1368,15 @@ entry:
 ; <label>:338                                     ; preds = %333
   %339 = load i8*, i8** %arg0
   %340 = load i8*, i8** %arg1
-  %NullCheck136 = icmp ne i8* %340, null
-  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+  %NullCheck135 = icmp eq i8* %340, null
+  br i1 %NullCheck135, label %ThrowNullRef136, label %341
 
 ; <label>:341                                     ; preds = %338
   %342 = load i8, i8* %340, align 8
   %343 = zext i8 %342 to i32
   %344 = trunc i32 %343 to i8
-  %NullCheck138 = icmp ne i8* %339, null
-  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+  %NullCheck137 = icmp eq i8* %339, null
+  br i1 %NullCheck137, label %ThrowNullRef138, label %345
 
 ; <label>:345                                     ; preds = %341
   store i8 %344, i8* %339, align 8
@@ -1317,16 +1399,16 @@ entry:
   %357 = load i8*, i8** %arg0
   %358 = load i8*, i8** %arg1
   %359 = bitcast i8* %358 to i16*
-  %NullCheck140 = icmp ne i16* %359, null
-  br i1 %NullCheck140, label %360, label %ThrowNullRef139
+  %NullCheck139 = icmp eq i16* %359, null
+  br i1 %NullCheck139, label %ThrowNullRef140, label %360
 
 ; <label>:360                                     ; preds = %356
   %361 = load i16, i16* %359, align 8
   %362 = sext i16 %361 to i32
   %363 = bitcast i8* %357 to i16*
   %364 = trunc i32 %362 to i16
-  %NullCheck142 = icmp ne i16* %363, null
-  br i1 %NullCheck142, label %365, label %ThrowNullRef141
+  %NullCheck141 = icmp eq i16* %363, null
+  br i1 %NullCheck141, label %ThrowNullRef142, label %365
 
 ; <label>:365                                     ; preds = %360
   store i16 %364, i16* %363, align 8
@@ -1352,14 +1434,14 @@ entry:
   %378 = load i8*, i8** %arg0
   %379 = load i8*, i8** %arg1
   %380 = bitcast i8* %379 to i32*
-  %NullCheck144 = icmp ne i32* %380, null
-  br i1 %NullCheck144, label %381, label %ThrowNullRef143
+  %NullCheck143 = icmp eq i32* %380, null
+  br i1 %NullCheck143, label %ThrowNullRef144, label %381
 
 ; <label>:381                                     ; preds = %377
   %382 = load i32, i32* %380, align 8
   %383 = bitcast i8* %378 to i32*
-  %NullCheck146 = icmp ne i32* %383, null
-  br i1 %NullCheck146, label %384, label %ThrowNullRef145
+  %NullCheck145 = icmp eq i32* %383, null
+  br i1 %NullCheck145, label %ThrowNullRef146, label %384
 
 ; <label>:384                                     ; preds = %381
   store i32 %382, i32* %383, align 8
@@ -1384,14 +1466,14 @@ entry:
   %395 = load i8*, i8** %arg0
   %396 = load i8*, i8** %arg1
   %397 = bitcast i8* %396 to i64*
-  %NullCheck164 = icmp ne i64* %397, null
-  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+  %NullCheck163 = icmp eq i64* %397, null
+  br i1 %NullCheck163, label %ThrowNullRef164, label %398
 
 ; <label>:398                                     ; preds = %394
   %399 = load i64, i64* %397, align 8
   %400 = bitcast i8* %395 to i64*
-  %NullCheck166 = icmp ne i64* %400, null
-  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+  %NullCheck165 = icmp eq i64* %400, null
+  br i1 %NullCheck165, label %ThrowNullRef166, label %401
 
 ; <label>:401                                     ; preds = %398
   store i64 %399, i64* %400, align 8
@@ -1400,14 +1482,14 @@ entry:
   %404 = load i8*, i8** %arg1
   %405 = getelementptr inbounds i8, i8* %404, i64 8
   %406 = bitcast i8* %405 to i64*
-  %NullCheck168 = icmp ne i64* %406, null
-  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+  %NullCheck167 = icmp eq i64* %406, null
+  br i1 %NullCheck167, label %ThrowNullRef168, label %407
 
 ; <label>:407                                     ; preds = %401
   %408 = load i64, i64* %406, align 8
   %409 = bitcast i8* %403 to i64*
-  %NullCheck170 = icmp ne i64* %409, null
-  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+  %NullCheck169 = icmp eq i64* %409, null
+  br i1 %NullCheck169, label %ThrowNullRef170, label %410
 
 ; <label>:410                                     ; preds = %407
   store i64 %408, i64* %409, align 8
@@ -1437,14 +1519,14 @@ entry:
   %425 = load i8*, i8** %arg0
   %426 = load i8*, i8** %arg1
   %427 = bitcast i8* %426 to i64*
-  %NullCheck148 = icmp ne i64* %427, null
-  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+  %NullCheck147 = icmp eq i64* %427, null
+  br i1 %NullCheck147, label %ThrowNullRef148, label %428
 
 ; <label>:428                                     ; preds = %424
   %429 = load i64, i64* %427, align 8
   %430 = bitcast i8* %425 to i64*
-  %NullCheck150 = icmp ne i64* %430, null
-  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+  %NullCheck149 = icmp eq i64* %430, null
+  br i1 %NullCheck149, label %ThrowNullRef150, label %431
 
 ; <label>:431                                     ; preds = %428
   store i64 %429, i64* %430, align 8
@@ -1466,14 +1548,14 @@ entry:
   %441 = load i8*, i8** %arg0
   %442 = load i8*, i8** %arg1
   %443 = bitcast i8* %442 to i32*
-  %NullCheck152 = icmp ne i32* %443, null
-  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+  %NullCheck151 = icmp eq i32* %443, null
+  br i1 %NullCheck151, label %ThrowNullRef152, label %444
 
 ; <label>:444                                     ; preds = %440
   %445 = load i32, i32* %443, align 8
   %446 = bitcast i8* %441 to i32*
-  %NullCheck154 = icmp ne i32* %446, null
-  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+  %NullCheck153 = icmp eq i32* %446, null
+  br i1 %NullCheck153, label %ThrowNullRef154, label %447
 
 ; <label>:447                                     ; preds = %444
   store i32 %445, i32* %446, align 8
@@ -1495,16 +1577,16 @@ entry:
   %457 = load i8*, i8** %arg0
   %458 = load i8*, i8** %arg1
   %459 = bitcast i8* %458 to i16*
-  %NullCheck156 = icmp ne i16* %459, null
-  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+  %NullCheck155 = icmp eq i16* %459, null
+  br i1 %NullCheck155, label %ThrowNullRef156, label %460
 
 ; <label>:460                                     ; preds = %456
   %461 = load i16, i16* %459, align 8
   %462 = sext i16 %461 to i32
   %463 = bitcast i8* %457 to i16*
   %464 = trunc i32 %462 to i16
-  %NullCheck158 = icmp ne i16* %463, null
-  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+  %NullCheck157 = icmp eq i16* %463, null
+  br i1 %NullCheck157, label %ThrowNullRef158, label %465
 
 ; <label>:465                                     ; preds = %460
   store i16 %464, i16* %463, align 8
@@ -1525,15 +1607,15 @@ entry:
 ; <label>:474                                     ; preds = %470
   %475 = load i8*, i8** %arg0
   %476 = load i8*, i8** %arg1
-  %NullCheck160 = icmp ne i8* %476, null
-  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+  %NullCheck159 = icmp eq i8* %476, null
+  br i1 %NullCheck159, label %ThrowNullRef160, label %477
 
 ; <label>:477                                     ; preds = %474
   %478 = load i8, i8* %476, align 8
   %479 = zext i8 %478 to i32
   %480 = trunc i32 %479 to i8
-  %NullCheck162 = icmp ne i8* %475, null
-  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+  %NullCheck161 = icmp eq i8* %475, null
+  br i1 %NullCheck161, label %ThrowNullRef162, label %481
 
 ; <label>:481                                     ; preds = %477
   store i8 %480, i8* %475, align 8
@@ -1553,343 +1635,343 @@ ThrowNullRef:                                     ; preds = %308
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %312
+ThrowNullRef2:                                    ; preds = %312
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %315
+ThrowNullRef4:                                    ; preds = %315
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %321
+ThrowNullRef6:                                    ; preds = %321
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %271
+ThrowNullRef8:                                    ; preds = %271
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %275
+ThrowNullRef10:                                   ; preds = %275
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %278
+ThrowNullRef12:                                   ; preds = %278
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %284
+ThrowNullRef14:                                   ; preds = %284
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %287
+ThrowNullRef16:                                   ; preds = %287
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %293
+ThrowNullRef18:                                   ; preds = %293
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %298
+ThrowNullRef20:                                   ; preds = %298
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %303
+ThrowNullRef22:                                   ; preds = %303
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %243
+ThrowNullRef24:                                   ; preds = %243
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %247
+ThrowNullRef26:                                   ; preds = %247
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %250
+ThrowNullRef28:                                   ; preds = %250
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %256
+ThrowNullRef30:                                   ; preds = %256
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %259
+ThrowNullRef32:                                   ; preds = %259
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %265
+ThrowNullRef34:                                   ; preds = %265
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %217
+ThrowNullRef36:                                   ; preds = %217
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %221
+ThrowNullRef38:                                   ; preds = %221
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %224
+ThrowNullRef40:                                   ; preds = %224
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %230
+ThrowNullRef42:                                   ; preds = %230
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %233
+ThrowNullRef44:                                   ; preds = %233
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %238
+ThrowNullRef46:                                   ; preds = %238
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %200
+ThrowNullRef48:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %204
+ThrowNullRef50:                                   ; preds = %204
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %207
+ThrowNullRef52:                                   ; preds = %207
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %213
+ThrowNullRef54:                                   ; preds = %213
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %172
+ThrowNullRef56:                                   ; preds = %172
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %176
+ThrowNullRef58:                                   ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %179
+ThrowNullRef60:                                   ; preds = %179
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %185
+ThrowNullRef62:                                   ; preds = %185
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %190
+ThrowNullRef64:                                   ; preds = %190
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %195
+ThrowNullRef66:                                   ; preds = %195
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %153
+ThrowNullRef68:                                   ; preds = %153
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %157
+ThrowNullRef70:                                   ; preds = %157
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %160
+ThrowNullRef72:                                   ; preds = %160
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %166
+ThrowNullRef74:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %136
+ThrowNullRef76:                                   ; preds = %136
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %140
+ThrowNullRef78:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %143
+ThrowNullRef80:                                   ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %148
+ThrowNullRef82:                                   ; preds = %148
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %128
+ThrowNullRef84:                                   ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %132
+ThrowNullRef86:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %100
+ThrowNullRef88:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %104
+ThrowNullRef90:                                   ; preds = %104
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %107
+ThrowNullRef92:                                   ; preds = %107
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %113
+ThrowNullRef94:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %118
+ThrowNullRef96:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %123
+ThrowNullRef98:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %81
+ThrowNullRef100:                                  ; preds = %81
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef101:                                  ; preds = %85
+ThrowNullRef102:                                  ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef103:                                  ; preds = %88
+ThrowNullRef104:                                  ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef105:                                  ; preds = %94
+ThrowNullRef106:                                  ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef107:                                  ; preds = %64
+ThrowNullRef108:                                  ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef109:                                  ; preds = %68
+ThrowNullRef110:                                  ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef111:                                  ; preds = %71
+ThrowNullRef112:                                  ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef113:                                  ; preds = %76
+ThrowNullRef114:                                  ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef115:                                  ; preds = %56
+ThrowNullRef116:                                  ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef117:                                  ; preds = %60
+ThrowNullRef118:                                  ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef119:                                  ; preds = %37
+ThrowNullRef120:                                  ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef121:                                  ; preds = %41
+ThrowNullRef122:                                  ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef123:                                  ; preds = %46
+ThrowNullRef124:                                  ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef125:                                  ; preds = %51
+ThrowNullRef126:                                  ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef127:                                  ; preds = %27
+ThrowNullRef128:                                  ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef129:                                  ; preds = %31
+ThrowNullRef130:                                  ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef131:                                  ; preds = %19
+ThrowNullRef132:                                  ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef133:                                  ; preds = %22
+ThrowNullRef134:                                  ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef135:                                  ; preds = %338
+ThrowNullRef136:                                  ; preds = %338
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef137:                                  ; preds = %341
+ThrowNullRef138:                                  ; preds = %341
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef139:                                  ; preds = %356
+ThrowNullRef140:                                  ; preds = %356
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef141:                                  ; preds = %360
+ThrowNullRef142:                                  ; preds = %360
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef143:                                  ; preds = %377
+ThrowNullRef144:                                  ; preds = %377
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef145:                                  ; preds = %381
+ThrowNullRef146:                                  ; preds = %381
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef147:                                  ; preds = %424
+ThrowNullRef148:                                  ; preds = %424
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef149:                                  ; preds = %428
+ThrowNullRef150:                                  ; preds = %428
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef151:                                  ; preds = %440
+ThrowNullRef152:                                  ; preds = %440
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef153:                                  ; preds = %444
+ThrowNullRef154:                                  ; preds = %444
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef155:                                  ; preds = %456
+ThrowNullRef156:                                  ; preds = %456
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef157:                                  ; preds = %460
+ThrowNullRef158:                                  ; preds = %460
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef159:                                  ; preds = %474
+ThrowNullRef160:                                  ; preds = %474
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef161:                                  ; preds = %477
+ThrowNullRef162:                                  ; preds = %477
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef163:                                  ; preds = %394
+ThrowNullRef164:                                  ; preds = %394
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef165:                                  ; preds = %398
+ThrowNullRef166:                                  ; preds = %398
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef167:                                  ; preds = %401
+ThrowNullRef168:                                  ; preds = %401
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef169:                                  ; preds = %407
+ThrowNullRef170:                                  ; preds = %407
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1939,8 +2021,8 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
-  br i1 %NullCheck, label %22, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %ThrowNullRef, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
@@ -1948,8 +2030,8 @@ entry:
   store i32 %24, i32* %loc0
   %25 = load i32, i32* %loc0
   %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %26, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %27
 
 ; <label>:27                                      ; preds = %22
   %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
@@ -1971,7 +2053,7 @@ ThrowNullRef:                                     ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1989,8 +2071,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -2022,15 +2104,15 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2048,16 +2130,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
   %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
   store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %15
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
@@ -2072,8 +2154,8 @@ entry:
   %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
   %29 = ptrtoint i16 addrspace(1)* %28 to i64
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %19
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
@@ -2089,19 +2171,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2114,8 +2196,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
@@ -2128,7 +2210,7 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[loadElem]
+Failed to read AppDomain.PrepareDataForSetup[storeElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
@@ -2202,8 +2284,8 @@ entry:
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
-  br i1 %NullCheck24, label %27, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = load i64, i64 addrspace(1)* %26
@@ -2218,8 +2300,8 @@ entry:
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
-  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
   %41 = load i64, i64 addrspace(1)* %39
@@ -2236,8 +2318,8 @@ entry:
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
-  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
   %54 = load i64, i64 addrspace(1)* %52
@@ -2252,8 +2334,8 @@ entry:
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
   %67 = load i64, i64 addrspace(1)* %65
@@ -2270,8 +2352,8 @@ entry:
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
-  br i1 %NullCheck16, label %79, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
   %80 = load i64, i64 addrspace(1)* %78
@@ -2286,8 +2368,8 @@ entry:
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
-  br i1 %NullCheck18, label %92, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
   %93 = load i64, i64 addrspace(1)* %91
@@ -2304,8 +2386,8 @@ entry:
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
-  br i1 %NullCheck12, label %105, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = load i64, i64 addrspace(1)* %104
@@ -2320,8 +2402,8 @@ entry:
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
-  br i1 %NullCheck14, label %118, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
   %119 = load i64, i64 addrspace(1)* %117
@@ -2337,8 +2419,8 @@ entry:
 
 ; <label>:128                                     ; preds = %20
   %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
-  br i1 %NullCheck4, label %130, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %129, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %130
 
 ; <label>:130                                     ; preds = %128
   %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
@@ -2346,8 +2428,8 @@ entry:
   %133 = load i16, i16 addrspace(1)* %132, align 8
   %134 = zext i16 %133 to i32
   %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
-  br i1 %NullCheck6, label %136, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %135, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %136
 
 ; <label>:136                                     ; preds = %130
   %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
@@ -2360,8 +2442,8 @@ entry:
 
 ; <label>:143                                     ; preds = %136
   %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
-  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %144, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %145
 
 ; <label>:145                                     ; preds = %143
   %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
@@ -2369,8 +2451,8 @@ entry:
   %148 = load i16, i16 addrspace(1)* %147, align 8
   %149 = zext i16 %148 to i32
   %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %150, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %151
 
 ; <label>:151                                     ; preds = %145
   %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
@@ -2388,8 +2470,8 @@ entry:
 
 ; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
-  br i1 %NullCheck, label %163, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %ThrowNullRef, label %163
 
 ; <label>:163                                     ; preds = %161
   %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
@@ -2399,8 +2481,8 @@ entry:
 
 ; <label>:167                                     ; preds = %163
   %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
-  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %168, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %169
 
 ; <label>:169                                     ; preds = %167
   %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
@@ -2432,55 +2514,55 @@ ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %167
+ThrowNullRef2:                                    ; preds = %167
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %128
+ThrowNullRef4:                                    ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %130
+ThrowNullRef6:                                    ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %143
+ThrowNullRef8:                                    ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %145
+ThrowNullRef10:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %102
+ThrowNullRef12:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %105
+ThrowNullRef14:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %76
+ThrowNullRef16:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %79
+ThrowNullRef18:                                   ; preds = %79
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %50
+ThrowNullRef20:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %53
+ThrowNullRef22:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %24
+ThrowNullRef24:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %27
+ThrowNullRef26:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2503,15 +2585,15 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2519,16 +2601,16 @@ entry:
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
   store i32 %8, i32* %loc0
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
   %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
   store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
@@ -2546,16 +2628,16 @@ entry:
 
 ; <label>:23                                      ; preds = %64
   %24 = load i16*, i16** %loc3
-  %NullCheck12 = icmp ne i16* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i16* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
   store i32 %27, i32* %loc5
   %28 = load i16*, i16** %loc4
-  %NullCheck14 = icmp ne i16* %28, null
-  br i1 %NullCheck14, label %29, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %28, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = load i16, i16* %28, align 8
@@ -2620,15 +2702,15 @@ entry:
 
 ; <label>:67                                      ; preds = %64
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
-  br i1 %NullCheck8, label %69, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %68, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %69
 
 ; <label>:69                                      ; preds = %67
   %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
   %71 = load i32, i32 addrspace(1)* %70
   %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
-  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %73
 
 ; <label>:73                                      ; preds = %69
   %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
@@ -2645,31 +2727,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %67
+ThrowNullRef8:                                    ; preds = %67
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %69
+ThrowNullRef10:                                   ; preds = %69
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2710,14 +2792,14 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
   %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
@@ -2730,14 +2812,14 @@ entry:
 
 ; <label>:11                                      ; preds = %4
   %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
   %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
@@ -2749,14 +2831,14 @@ entry:
 
 ; <label>:22                                      ; preds = %16
   %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
   %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
-  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
-  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
@@ -2804,23 +2886,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2836,7 +2918,280 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[loadElem]
+Successfully read RuntimeType.IsAssignableFrom
+
+define i8 @RuntimeType.IsAssignableFrom(%System.RuntimeType addrspace(1)* %param0, %System.Type addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.RuntimeType addrspace(1)*
+  %arg1 = alloca %System.Type addrspace(1)*
+  %loc0 = alloca %System.RuntimeType addrspace(1)*
+  %loc1 = alloca %"System.Type[]" addrspace(1)*
+  %loc2 = alloca i32
+  store %System.RuntimeType addrspace(1)* %param0, %System.RuntimeType addrspace(1)** %this
+  store %System.Type addrspace(1)* %param1, %System.Type addrspace(1)** %arg1
+  %0 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %1 = icmp ne %System.Type addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i8 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %5 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %6 = bitcast %System.Type addrspace(1)* %4 to %System.Object addrspace(1)*
+  %7 = bitcast %System.RuntimeType addrspace(1)* %5 to %System.Object addrspace(1)*
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %6, %System.Object addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %3
+  ret i8 1
+
+; <label>:12                                      ; preds = %3
+  %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 152
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 32
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
+  %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
+  %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
+  store %System.RuntimeType addrspace(1)* %25, %System.RuntimeType addrspace(1)** %loc0
+  %26 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %27 = icmp eq %System.RuntimeType addrspace(1)* %26, null
+  br i1 %27, label %34, label %28
+
+; <label>:28                                      ; preds = %15
+  %29 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %30 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)*)*)(%System.RuntimeType addrspace(1)* %29, %System.RuntimeType addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+; <label>:34                                      ; preds = %15
+  %35 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %36 = call %System.Reflection.Emit.TypeBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Reflection.Emit.TypeBuilder addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %35)
+  %37 = icmp eq %System.Reflection.Emit.TypeBuilder addrspace(1)* %36, null
+  br i1 %37, label %139, label %38
+
+; <label>:38                                      ; preds = %34
+  %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %42
+
+; <label>:42                                      ; preds = %38
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 152
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 40
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
+  %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
+  %53 = zext i8 %52 to i32
+  %54 = icmp eq i32 %53, 0
+  br i1 %54, label %56, label %55
+
+; <label>:55                                      ; preds = %42
+  ret i8 1
+
+; <label>:56                                      ; preds = %42
+  %57 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %58 = bitcast %System.RuntimeType addrspace(1)* %57 to %System.Type addrspace(1)*
+  %59 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %58)
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %64 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.Type addrspace(1)* %63, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = bitcast %System.RuntimeType addrspace(1)* %64 to %System.Type addrspace(1)*
+  %67 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %63, %System.Type addrspace(1)* %66)
+  %68 = zext i8 %67 to i32
+  %69 = trunc i32 %68 to i8
+  ret i8 %69
+
+; <label>:70                                      ; preds = %56
+  %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
+  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %73
+
+; <label>:73                                      ; preds = %70
+  %74 = load i64, i64 addrspace(1)* %72
+  %75 = add i64 %74, 128
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = add i64 %77, 0
+  %79 = inttoptr i64 %78 to i64*
+  %80 = load i64, i64* %79
+  %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
+  %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
+  %83 = call i8 %82(%System.Type addrspace(1)* %81)
+  %84 = zext i8 %83 to i32
+  %85 = icmp eq i32 %84, 0
+  br i1 %85, label %139, label %86
+
+; <label>:86                                      ; preds = %73
+  %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
+  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %89
+
+; <label>:89                                      ; preds = %86
+  %90 = load i64, i64 addrspace(1)* %88
+  %91 = add i64 %90, 128
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = add i64 %93, 24
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
+  %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
+  %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
+  store %"System.Type[]" addrspace(1)* %99, %"System.Type[]" addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %129
+
+; <label>:100                                     ; preds = %132
+  %101 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %102 = load i32, i32* %loc2
+  %NullCheck11 = icmp eq %"System.Type[]" addrspace(1)* %101, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %103
+
+; <label>:103                                     ; preds = %100
+  %104 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 1
+  %105 = load i32, i32 addrspace(1)* %104
+  %106 = zext i32 %105 to i64
+  %107 = zext i32 %102 to i64
+  %BoundsCheck = icmp uge i64 %107, %106
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %108
+
+; <label>:108                                     ; preds = %103
+  %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
+  %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
+  %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
+  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %113
+
+; <label>:113                                     ; preds = %108
+  %114 = load i64, i64 addrspace(1)* %112
+  %115 = add i64 %114, 152
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = add i64 %117, 56
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
+  %123 = zext i8 %122 to i32
+  %124 = icmp ne i32 %123, 0
+  br i1 %124, label %126, label %125
+
+; <label>:125                                     ; preds = %113
+  ret i8 0
+
+; <label>:126                                     ; preds = %113
+  %127 = load i32, i32* %loc2
+  %128 = add i32 %127, 1
+  store i32 %128, i32* %loc2
+  br label %129
+
+; <label>:129                                     ; preds = %89, %126
+  %130 = load i32, i32* %loc2
+  %131 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %NullCheck9 = icmp eq %"System.Type[]" addrspace(1)* %131, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %132
+
+; <label>:132                                     ; preds = %129
+  %133 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %131, i32 0, i32 1
+  %134 = load i32, i32 addrspace(1)* %133
+  %135 = zext i32 %134 to i64
+  %136 = trunc i64 %135 to i32
+  %137 = icmp slt i32 %130, %136
+  br i1 %137, label %100, label %138
+
+; <label>:138                                     ; preds = %132
+  ret i8 1
+
+; <label>:139                                     ; preds = %34, %73
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %129
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %103
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -2893,7 +3248,7 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElem]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -2904,8 +3259,8 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -2997,8 +3352,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
@@ -3059,8 +3414,8 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -3087,8 +3442,8 @@ entry:
 
 ; <label>:17                                      ; preds = %5, %11
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
@@ -3097,8 +3452,8 @@ entry:
 
 ; <label>:22                                      ; preds = %1, %11
   %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
@@ -3109,11 +3464,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %17
+ThrowNullRef2:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %22
+ThrowNullRef4:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3167,15 +3522,15 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
   %15 = load i32, i32 addrspace(1)* %14
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
@@ -3198,7 +3553,7 @@ ThrowNullRef:                                     ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef2:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3232,8 +3587,8 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
@@ -3312,8 +3667,8 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -3327,8 +3682,8 @@ entry:
 ; <label>:5                                       ; preds = %43
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %7 = load i32, i32* %loc1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck6, label %8, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
@@ -3366,8 +3721,8 @@ entry:
 ; <label>:32                                      ; preds = %21, %25
   %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
   %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
-  br i1 %NullCheck8, label %35, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = trunc i32 %34 to i16
@@ -3380,8 +3735,8 @@ entry:
 ; <label>:40                                      ; preds = %1, %35
   %41 = load i32, i32* %loc1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
-  br i1 %NullCheck2, label %43, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %42, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
@@ -3392,8 +3747,8 @@ entry:
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
   %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
-  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
   %51 = load i64, i64 addrspace(1)* %49
@@ -3412,19 +3767,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %40
+ThrowNullRef2:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %47
+ThrowNullRef4:                                    ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %5
+ThrowNullRef6:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %32
+ThrowNullRef8:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3467,8 +3822,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
@@ -3492,11 +3847,391 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(i16* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store i16* %param0, i16** %arg0
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load i32, i32* %arg3
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %42, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %37, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg2
+  %13 = load i32, i32* %arg3
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %37, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %24 = load i32, i32* %arg2
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load i16*, i16** %arg0
+  %35 = load i32, i32* %arg3
+  %36 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %36, i16* %34, i32 %35)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:37                                      ; preds = %5, %16
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %39)
+  %41 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41, %System.String addrspace(1)* %38, %System.String addrspace(1)* %40)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41) #0
+  unreachable
+
+; <label>:42                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
-Failed to read StringBuilder.ToString[loadElemA]
+Successfully read StringBuilder.ToString
+
+define %System.String addrspace(1)* @StringBuilder.ToString(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i16*
+  %loc3 = alloca %"System.Char[]" addrspace(1)*
+  %loc4 = alloca i32
+  %loc5 = alloca i32
+  %loc6 = alloca i16 addrspace(1)*
+  %loc7 = alloca %System.String addrspace(1)*
+  %loc8 = alloca %"System.Char[]" addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %0)
+  %2 = icmp ne i32 %1, 0
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %4
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %6)
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %7)
+  store %System.String addrspace(1)* %8, %System.String addrspace(1)** %loc0
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.Text.StringBuilder addrspace(1)* %9, %System.Text.StringBuilder addrspace(1)** %loc1
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  store %System.String addrspace(1)* %10, %System.String addrspace(1)** %loc7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc7
+  %12 = ptrtoint %System.String addrspace(1)* %11 to i64
+  %13 = icmp eq i64 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %5
+  %15 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %16 = sext i32 %15 to i64
+  %17 = add i64 %12, %16
+  br label %18
+
+; <label>:18                                      ; preds = %5, %14
+  %19 = phi i64 [ %12, %5 ], [ %17, %14 ]
+  %20 = inttoptr i64 %19 to i16*
+  store i16* %20, i16** %loc2
+  br label %21
+
+; <label>:21                                      ; preds = %98, %18
+  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %22, null
+  br i1 %NullCheck, label %ThrowNullRef, label %23
+
+; <label>:23                                      ; preds = %21
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 3
+  %25 = load i32, i32 addrspace(1)* %24, align 8
+  %26 = icmp sle i32 %25, 0
+  br i1 %26, label %96, label %27
+
+; <label>:27                                      ; preds = %23
+  %28 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %28, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %29
+
+; <label>:29                                      ; preds = %27
+  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %28, i32 0, i32 1
+  %31 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %30, align 8
+  store %"System.Char[]" addrspace(1)* %31, %"System.Char[]" addrspace(1)** %loc3
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %33
+
+; <label>:33                                      ; preds = %29
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  store i32 %35, i32* %loc4
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  %39 = load i32, i32 addrspace(1)* %38, align 8
+  store i32 %39, i32* %loc5
+  %40 = load i32, i32* %loc5
+  %41 = load i32, i32* %loc4
+  %42 = add i32 %40, %41
+  %43 = zext i32 %42 to i64
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %45
+
+; <label>:45                                      ; preds = %37
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = sext i32 %47 to i64
+  %49 = icmp sgt i64 %43, %48
+  br i1 %49, label %91, label %50
+
+; <label>:50                                      ; preds = %45
+  %51 = load i32, i32* %loc5
+  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %52, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %53
+
+; <label>:53                                      ; preds = %50
+  %54 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %52, i32 0, i32 1
+  %55 = load i32, i32 addrspace(1)* %54
+  %56 = zext i32 %55 to i64
+  %57 = trunc i64 %56 to i32
+  %58 = icmp ugt i32 %51, %57
+  br i1 %58, label %91, label %59
+
+; <label>:59                                      ; preds = %53
+  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  store %"System.Char[]" addrspace(1)* %60, %"System.Char[]" addrspace(1)** %loc8
+  %61 = icmp eq %"System.Char[]" addrspace(1)* %60, null
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %63, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %64
+
+; <label>:64                                      ; preds = %62
+  %65 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %63, i32 0, i32 1
+  %66 = load i32, i32 addrspace(1)* %65
+  %67 = zext i32 %66 to i64
+  %68 = trunc i64 %67 to i32
+  %69 = icmp ne i32 %68, 0
+  br i1 %69, label %71, label %70
+
+; <label>:70                                      ; preds = %59, %64
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:71                                      ; preds = %64
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %73
+
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %BoundsCheck = icmp uge i64 0, %76
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %77
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %78, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:79                                      ; preds = %70, %77
+  %80 = load i16*, i16** %loc2
+  %81 = load i32, i32* %loc4
+  %82 = sext i32 %81 to i64
+  %83 = mul i64 %82, 2
+  %84 = bitcast i16* %80 to i8*
+  %85 = getelementptr inbounds i8, i8* %84, i64 %83
+  %86 = load i16 addrspace(1)*, i16 addrspace(1)** %loc6
+  %87 = ptrtoint i16 addrspace(1)* %86 to i64
+  %88 = load i32, i32* %loc5
+  %89 = bitcast i8* %85 to i16*
+  %90 = inttoptr i64 %87 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %89, i16* %90, i32 %88)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %96
+
+; <label>:91                                      ; preds = %45, %53
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %94 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %93)
+  %95 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95, %System.String addrspace(1)* %92, %System.String addrspace(1)* %94)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95) #0
+  unreachable
+
+; <label>:96                                      ; preds = %23, %79
+  %97 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %97, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %98
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %97, i32 0, i32 2
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  store %System.Text.StringBuilder addrspace(1)* %100, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %102 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %102, label %21, label %103
+
+; <label>:103                                     ; preds = %98
+  store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc7
+  %104 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  ret %System.String addrspace(1)* %104
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method StringBuilder::get_Length using LLILCJit
+Successfully read StringBuilder.get_Length
+
+define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
+Successfully read RuntimeHelpers.get_OffsetToStringData
+
+define i32 @RuntimeHelpers.get_OffsetToStringData() {
+entry:
+  ret i32 12
+}
+
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
 Successfully read CultureData.CreateCultureData
 
@@ -3514,23 +4249,23 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
   store i8 %4, i8 addrspace(1)* %6
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
@@ -3549,11 +4284,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3566,50 +4301,50 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
   store i32 -1, i32 addrspace(1)* %2
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
   store i32 -1, i32 addrspace(1)* %8
   %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
   store i32 -1, i32 addrspace(1)* %14
   %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
   store i32 -1, i32 addrspace(1)* %17
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
@@ -3623,27 +4358,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3675,7 +4410,136 @@ Failed to read Dictionary`2.Insert[non-const derefAddress]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
 Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
-Failed to read HashHelpers.GetPrime[loadElem]
+Successfully read HashHelpers.GetPrime
+
+define i32 @HashHelpers.GetPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %6, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5, %System.String addrspace(1)* %4)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5) #0
+  unreachable
+
+; <label>:6                                       ; preds = %entry
+  store i32 0, i32* %loc0
+  br label %29
+
+; <label>:7                                       ; preds = %35
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 1296
+  %10 = addrspacecast i8 addrspace(1)* %9 to %"System.Int32[]" addrspace(1)**
+  %11 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %10
+  %12 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Int32[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = zext i32 %15 to i64
+  %17 = zext i32 %12 to i64
+  %BoundsCheck = icmp uge i64 %17, %16
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 3, i32 %12
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  store i32 %20, i32* %loc1
+  %21 = load i32, i32* %loc1
+  %22 = load i32, i32* %arg0
+  %23 = icmp slt i32 %21, %22
+  br i1 %23, label %26, label %24
+
+; <label>:24                                      ; preds = %18
+  %25 = load i32, i32* %loc1
+  ret i32 %25
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %loc0
+  %28 = add i32 %27, 1
+  store i32 %28, i32* %loc0
+  br label %29
+
+; <label>:29                                      ; preds = %6, %26
+  %30 = load i32, i32* %loc0
+  %31 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %32 = getelementptr inbounds i8, i8 addrspace(1)* %31, i64 1296
+  %33 = addrspacecast i8 addrspace(1)* %32 to %"System.Int32[]" addrspace(1)**
+  %34 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %33
+  %NullCheck = icmp eq %"System.Int32[]" addrspace(1)* %34, null
+  br i1 %NullCheck, label %ThrowNullRef, label %35
+
+; <label>:35                                      ; preds = %29
+  %36 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %34, i32 0, i32 1
+  %37 = load i32, i32 addrspace(1)* %36
+  %38 = zext i32 %37 to i64
+  %39 = trunc i64 %38 to i32
+  %40 = icmp slt i32 %30, %39
+  br i1 %40, label %7, label %41
+
+; <label>:41                                      ; preds = %35
+  %42 = load i32, i32* %arg0
+  %43 = or i32 %42, 1
+  store i32 %43, i32* %loc2
+  br label %59
+
+; <label>:44                                      ; preds = %59
+  %45 = load i32, i32* %loc2
+  %46 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %45)
+  %47 = zext i8 %46 to i32
+  %48 = icmp eq i32 %47, 0
+  br i1 %48, label %56, label %49
+
+; <label>:49                                      ; preds = %44
+  %50 = load i32, i32* %loc2
+  %51 = sub i32 %50, 1
+  %52 = srem i32 %51, 101
+  %53 = icmp eq i32 %52, 0
+  br i1 %53, label %56, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = load i32, i32* %loc2
+  ret i32 %55
+
+; <label>:56                                      ; preds = %44, %49
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %57, 2
+  store i32 %58, i32* %loc2
+  br label %59
+
+; <label>:59                                      ; preds = %41, %56
+  %60 = load i32, i32* %loc2
+  %61 = icmp slt i32 %60, 2147483647
+  br i1 %61, label %44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load i32, i32* %arg0
+  ret i32 %63
+
+ThrowNullRef:                                     ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
 Successfully read GenericEqualityComparer`1.GetHashCode
 
@@ -3694,14 +4558,14 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
   %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load i64, i64 addrspace(1)* %7
@@ -3720,7 +4584,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3750,8 +4614,8 @@ entry:
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
@@ -3796,8 +4660,8 @@ entry:
   %35 = bitcast i16* %34 to i8*
   %36 = getelementptr inbounds i8, i8* %35, i64 2
   %37 = bitcast i8* %36 to i16*
-  %NullCheck4 = icmp ne i16* %37, null
-  br i1 %NullCheck4, label %38, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %37, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %38
 
 ; <label>:38                                      ; preds = %27
   %39 = load i16, i16* %37, align 8
@@ -3824,8 +4688,8 @@ entry:
 
 ; <label>:54                                      ; preds = %22, %43
   %55 = load i16*, i16** %loc4
-  %NullCheck2 = icmp ne i16* %55, null
-  br i1 %NullCheck2, label %56, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i16* %55, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %56
 
 ; <label>:56                                      ; preds = %54
   %57 = load i16, i16* %55, align 8
@@ -3850,11 +4714,11 @@ ThrowNullRef:                                     ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %54
+ThrowNullRef2:                                    ; preds = %54
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %27
+ThrowNullRef4:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3871,8 +4735,8 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -3907,8 +4771,8 @@ entry:
 
 ; <label>:26                                      ; preds = %19
   %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
-  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %28
 
 ; <label>:28                                      ; preds = %26
   %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
@@ -3920,7 +4784,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3972,8 +4836,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
@@ -3984,26 +4848,26 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
-  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
@@ -4014,8 +4878,8 @@ entry:
 ; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
@@ -4024,8 +4888,8 @@ entry:
 
 ; <label>:25                                      ; preds = %1, %16, %23
   %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
-  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
@@ -4036,27 +4900,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %20
+ThrowNullRef10:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4069,8 +4933,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -4081,8 +4945,8 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
@@ -4091,8 +4955,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1, %8
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
@@ -4103,11 +4967,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4128,24 +4992,24 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   store i32 %3, i32* %loc0
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
   %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
   store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck4, label %9, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
@@ -4164,15 +5028,15 @@ entry:
 ; <label>:18                                      ; preds = %70
   %19 = load i16*, i16** %loc3
   %20 = bitcast i16* %19 to i64*
-  %NullCheck10 = icmp ne i64* %20, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %20, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = load i64, i64* %20, align 8
   %23 = load i16*, i16** %loc4
   %24 = bitcast i16* %23 to i64*
-  %NullCheck12 = icmp ne i64* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = load i64, i64* %24, align 8
@@ -4188,8 +5052,8 @@ entry:
   %31 = bitcast i16* %30 to i8*
   %32 = getelementptr inbounds i8, i8* %31, i64 8
   %33 = bitcast i8* %32 to i64*
-  %NullCheck14 = icmp ne i64* %33, null
-  br i1 %NullCheck14, label %34, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = load i64, i64* %33, align 8
@@ -4197,8 +5061,8 @@ entry:
   %37 = bitcast i16* %36 to i8*
   %38 = getelementptr inbounds i8, i8* %37, i64 8
   %39 = bitcast i8* %38 to i64*
-  %NullCheck16 = icmp ne i64* %39, null
-  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %40
 
 ; <label>:40                                      ; preds = %34
   %41 = load i64, i64* %39, align 8
@@ -4214,8 +5078,8 @@ entry:
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %NullCheck18 = icmp ne i64* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = load i64, i64* %48, align 8
@@ -4223,8 +5087,8 @@ entry:
   %52 = bitcast i16* %51 to i8*
   %53 = getelementptr inbounds i8, i8* %52, i64 16
   %54 = bitcast i8* %53 to i64*
-  %NullCheck20 = icmp ne i64* %54, null
-  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64* %54, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %55
 
 ; <label>:55                                      ; preds = %49
   %56 = load i64, i64* %54, align 8
@@ -4262,15 +5126,15 @@ entry:
 ; <label>:74                                      ; preds = %95
   %75 = load i16*, i16** %loc3
   %76 = bitcast i16* %75 to i32*
-  %NullCheck6 = icmp ne i32* %76, null
-  br i1 %NullCheck6, label %77, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32* %76, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %77
 
 ; <label>:77                                      ; preds = %74
   %78 = load i32, i32* %76, align 8
   %79 = load i16*, i16** %loc4
   %80 = bitcast i16* %79 to i32*
-  %NullCheck8 = icmp ne i32* %80, null
-  br i1 %NullCheck8, label %81, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i32* %80, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %81
 
 ; <label>:81                                      ; preds = %77
   %82 = load i32, i32* %80, align 8
@@ -4318,43 +5182,43 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %74
+ThrowNullRef6:                                    ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %77
+ThrowNullRef8:                                    ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %29
+ThrowNullRef14:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %34
+ThrowNullRef16:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4376,8 +5240,8 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load i64, i64 addrspace(1)* %4
@@ -4389,8 +5253,8 @@ entry:
   %12 = load i64, i64* %11
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %5
   %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
@@ -4399,8 +5263,8 @@ entry:
   %18 = load i8, i8* %arg2
   %19 = zext i8 %18 to i32
   %20 = trunc i32 %19 to i8
-  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %15
   %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
@@ -4411,11 +5275,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4442,8 +5306,8 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
@@ -4466,16 +5330,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
   %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = load i64, i64 addrspace(1)* %19
@@ -4500,8 +5364,8 @@ entry:
 ; <label>:35                                      ; preds = %30
   %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
@@ -4514,8 +5378,8 @@ entry:
 
 ; <label>:42                                      ; preds = %1, %38
   %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
-  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
@@ -4526,19 +5390,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %35
+ThrowNullRef2:                                    ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %42
+ThrowNullRef8:                                    ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4551,14 +5415,14 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
@@ -4570,7 +5434,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4583,8 +5447,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
@@ -4613,51 +5477,51 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
   %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
   %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
   %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
   %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
-  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
   store i64 %21, i64 addrspace(1)* %23
   %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %25 = load i64, i64* %loc0
-  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
@@ -4668,27 +5532,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %22
+ThrowNullRef12:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4701,8 +5565,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
@@ -4713,19 +5577,19 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
@@ -4734,8 +5598,8 @@ entry:
 
 ; <label>:15                                      ; preds = %1, %13
   %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
@@ -4746,19 +5610,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %15
+ThrowNullRef8:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4771,8 +5635,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -4831,8 +5695,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
@@ -4882,8 +5746,8 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
-  br i1 %NullCheck, label %17, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %ThrowNullRef, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
@@ -4894,15 +5758,15 @@ entry:
 
 ; <label>:22                                      ; preds = %17
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
-  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
   %26 = load i32, i32 addrspace(1)* %25
   %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
-  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %27, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
@@ -4925,8 +5789,8 @@ entry:
 ; <label>:40                                      ; preds = %17
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
-  br i1 %NullCheck6, label %43, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %41, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
@@ -4938,34 +5802,17 @@ ThrowNullRef:                                     ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %24
+ThrowNullRef4:                                    ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %40
+ThrowNullRef6:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
-}
-
-INFO:  jitting method Object::ReferenceEquals using LLILCJit
-Successfully read Object.ReferenceEquals
-
-define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
-entry:
-  %arg0 = alloca %System.Object addrspace(1)*
-  %arg1 = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
-  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
-  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = icmp eq %System.Object addrspace(1)* %0, %1
-  %3 = sext i1 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
 }
 
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
@@ -4978,21 +5825,21 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
   %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
-  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
@@ -5007,28 +5854,28 @@ entry:
 ; <label>:13                                      ; preds = %8, %12
   %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
   %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
   %21 = load i32, i32 addrspace(1)* %20, align 8
   %22 = add i32 %21, 1
-  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
   store i32 %22, i32 addrspace(1)* %24
   %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
@@ -5039,27 +5886,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5077,7 +5924,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::Setup using LLILCJit
-Failed to read AppDomain.Setup[loadElem]
+Failed to read AppDomain.Setup[unbox]
 INFO:  jitting method Thread::GetDomain using LLILCJit
 Successfully read Thread.GetDomain
 
@@ -5108,8 +5955,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
@@ -5122,14 +5969,14 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
   %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
@@ -5141,11 +5988,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5173,8 +6020,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -5189,7 +6036,328 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
 Failed to read KeyCollection.System.Collections.Generic.IEnumerable<TKey>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Successfully read Enumerator.MoveNext
+
+define i8 @Enumerator.MoveNext(%"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.RuntimeTypeHandle* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*
+  %"$TypeArg" = alloca %System.RuntimeTypeHandle*
+  store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
+  %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 8
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %76, label %12
+
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
+  br label %76
+
+; <label>:13                                      ; preds = %85
+  %14 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck19 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %15
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, i32 0, i32 0
+  %17 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %16, align 8
+  %NullCheck21 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, i32 0, i32 2
+  %20 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %19, align 8
+  %21 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck23 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %22
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, i32 0, i32 2
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %NullCheck25 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 3, i32 %24
+  %NullCheck27 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %32
+
+; <label>:32                                      ; preds = %30
+  %33 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, i32 0, i32 2
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = icmp slt i32 %34, 0
+  br i1 %35, label %68, label %36
+
+; <label>:36                                      ; preds = %32
+  %37 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %38 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck29 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %39
+
+; <label>:39                                      ; preds = %36
+  %40 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, i32 0, i32 0
+  %41 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %40, align 8
+  %NullCheck31 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, i32 0, i32 2
+  %44 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %43, align 8
+  %45 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck33 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, i32 0, i32 2
+  %48 = load i32, i32 addrspace(1)* %47, align 8
+  %NullCheck35 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %49
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = zext i32 %51 to i64
+  %53 = zext i32 %48 to i64
+  %BoundsCheck37 = icmp uge i64 %53, %52
+  br i1 %BoundsCheck37, label %ThrowIndexOutOfRange38, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 3, i32 %48
+  %NullCheck39 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %56
+
+; <label>:56                                      ; preds = %54
+  %57 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, i32 0, i32 0
+  %58 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck41 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %59
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %60, %System.__Canon addrspace(1)* %58)
+  %61 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck43 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  %64 = load i32, i32 addrspace(1)* %63, align 8
+  %65 = add i32 %64, 1
+  %NullCheck45 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  store i32 %65, i32 addrspace(1)* %67
+  ret i8 1
+
+; <label>:68                                      ; preds = %32
+  %69 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck47 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %73 = add i32 %72, 1
+  %NullCheck49 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %74
+
+; <label>:74                                      ; preds = %70
+  %75 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  store i32 %73, i32 addrspace(1)* %75
+  br label %76
+
+; <label>:76                                      ; preds = %8, %12, %74
+  %77 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %78
+
+; <label>:78                                      ; preds = %76
+  %79 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, i32 0, i32 2
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck7 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %82
+
+; <label>:82                                      ; preds = %78
+  %83 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, i32 0, i32 0
+  %84 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %83, align 8
+  %NullCheck9 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %85
+
+; <label>:85                                      ; preds = %82
+  %86 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, i32 0, i32 7
+  %87 = load i32, i32 addrspace(1)* %86, align 8
+  %88 = icmp ult i32 %80, %87
+  br i1 %88, label %13, label %89
+
+; <label>:89                                      ; preds = %85
+  %90 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %91 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck11 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %92
+
+; <label>:92                                      ; preds = %89
+  %93 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, i32 0, i32 0
+  %94 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck13 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %95
+
+; <label>:95                                      ; preds = %92
+  %96 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, i32 0, i32 7
+  %97 = load i32, i32 addrspace(1)* %96, align 8
+  %98 = add i32 %97, 1
+  %NullCheck15 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %99
+
+; <label>:99                                      ; preds = %95
+  %100 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, i32 0, i32 2
+  store i32 %98, i32 addrspace(1)* %100
+  %101 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck17 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %102
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %103, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %92
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef22:                                   ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef24:                                   ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef26:                                   ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef28:                                   ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef30:                                   ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef32:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef34:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef36:                                   ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange38:                           ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef40:                                   ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef42:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef44:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef46:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef48:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef50:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -5200,8 +6368,8 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -5232,9 +6400,9 @@ Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
 Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
-Failed to read String.MakeSeparatorList[loadElemA]
+Failed to read String.MakeSeparatorList[storeElem]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
-Failed to read String.InternalSplitKeepEmptyEntries[loadElem]
+Failed to read String.InternalSplitKeepEmptyEntries[storeElem]
 INFO:  jitting method Path::IsRelative using LLILCJit
 Successfully read Path.IsRelative
 
@@ -5243,8 +6411,8 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -5254,8 +6422,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
@@ -5271,8 +6439,8 @@ entry:
 
 ; <label>:17                                      ; preds = %7
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
@@ -5288,8 +6456,8 @@ entry:
 
 ; <label>:29                                      ; preds = %19
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %31
 
 ; <label>:31                                      ; preds = %29
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
@@ -5300,8 +6468,8 @@ entry:
 
 ; <label>:36                                      ; preds = %31
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
-  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %37, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
@@ -5312,8 +6480,8 @@ entry:
 
 ; <label>:43                                      ; preds = %31, %38
   %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
-  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %45
 
 ; <label>:45                                      ; preds = %43
   %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
@@ -5324,8 +6492,8 @@ entry:
 
 ; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %50
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
@@ -5336,8 +6504,8 @@ entry:
 
 ; <label>:57                                      ; preds = %1, %7, %19, %45, %52
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
-  br i1 %NullCheck14, label %59, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %59
 
 ; <label>:59                                      ; preds = %57
   %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
@@ -5347,8 +6515,8 @@ entry:
 
 ; <label>:63                                      ; preds = %59
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
@@ -5359,8 +6527,8 @@ entry:
 
 ; <label>:70                                      ; preds = %65
   %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
-  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.String addrspace(1)* %71, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %72
 
 ; <label>:72                                      ; preds = %70
   %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
@@ -5379,39 +6547,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %17
+ThrowNullRef4:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %29
+ThrowNullRef6:                                    ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %36
+ThrowNullRef8:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %43
+ThrowNullRef10:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %50
+ThrowNullRef12:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %57
+ThrowNullRef14:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %63
+ThrowNullRef16:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %70
+ThrowNullRef18:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5419,7 +6587,293 @@ ThrowNullRef17:                                   ; preds = %70
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
-Failed to read String.TrimHelper[loadElem]
+Successfully read String.TrimHelper
+
+define %System.String addrspace(1)* @String.TrimHelper(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i16
+  %loc4 = alloca i32
+  %loc5 = alloca i16
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = sub i32 %3, 1
+  store i32 %4, i32* %loc0
+  store i32 0, i32* %loc1
+  %5 = load i32, i32* %arg2
+  %6 = icmp eq i32 %5, 1
+  br i1 %6, label %62, label %7
+
+; <label>:7                                       ; preds = %1
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:8                                       ; preds = %58
+  store i32 0, i32* %loc2
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load i32, i32* %loc1
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2, i32 %10
+  %13 = load i16, i16 addrspace(1)* %12
+  %14 = zext i16 %13 to i32
+  %15 = trunc i32 %14 to i16
+  store i16 %15, i16* %loc3
+  store i32 0, i32* %loc2
+  br label %34
+
+; <label>:16                                      ; preds = %37
+  %17 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %18 = load i32, i32* %loc2
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %17, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %19
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = zext i32 %18 to i64
+  %BoundsCheck = icmp uge i64 %23, %22
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %24
+
+; <label>:24                                      ; preds = %19
+  %25 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 3, i32 %18
+  %26 = load i16, i16 addrspace(1)* %25, align 8
+  %27 = zext i16 %26 to i32
+  %28 = load i16, i16* %loc3
+  %29 = zext i16 %28 to i32
+  %30 = icmp eq i32 %27, %29
+  br i1 %30, label %43, label %31
+
+; <label>:31                                      ; preds = %24
+  %32 = load i32, i32* %loc2
+  %33 = add i32 %32, 1
+  store i32 %33, i32* %loc2
+  br label %34
+
+; <label>:34                                      ; preds = %11, %31
+  %35 = load i32, i32* %loc2
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = icmp slt i32 %35, %41
+  br i1 %42, label %16, label %43
+
+; <label>:43                                      ; preds = %24, %37
+  %44 = load i32, i32* %loc2
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %45, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp eq i32 %44, %50
+  br i1 %51, label %62, label %52
+
+; <label>:52                                      ; preds = %46
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %7, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %57, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %58
+
+; <label>:58                                      ; preds = %55
+  %59 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %60 = load i32, i32 addrspace(1)* %59
+  %61 = icmp slt i32 %56, %60
+  br i1 %61, label %8, label %62
+
+; <label>:62                                      ; preds = %1, %46, %58
+  %63 = load i32, i32* %arg2
+  %64 = icmp eq i32 %63, 0
+  br i1 %64, label %122, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %66, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %67
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %66, i32 0, i32 1
+  %69 = load i32, i32 addrspace(1)* %68
+  %70 = sub i32 %69, 1
+  store i32 %70, i32* %loc0
+  br label %118
+
+; <label>:71                                      ; preds = %118
+  store i32 0, i32* %loc4
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %73 = load i32, i32* %loc0
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %74
+
+; <label>:74                                      ; preds = %71
+  %75 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 2, i32 %73
+  %76 = load i16, i16 addrspace(1)* %75
+  %77 = zext i16 %76 to i32
+  %78 = trunc i32 %77 to i16
+  store i16 %78, i16* %loc5
+  store i32 0, i32* %loc4
+  br label %97
+
+; <label>:79                                      ; preds = %100
+  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %81 = load i32, i32* %loc4
+  %NullCheck19 = icmp eq %"System.Char[]" addrspace(1)* %80, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
+
+; <label>:82                                      ; preds = %79
+  %83 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 1
+  %84 = load i32, i32 addrspace(1)* %83
+  %85 = zext i32 %84 to i64
+  %86 = zext i32 %81 to i64
+  %BoundsCheck21 = icmp uge i64 %86, %85
+  br i1 %BoundsCheck21, label %ThrowIndexOutOfRange22, label %87
+
+; <label>:87                                      ; preds = %82
+  %88 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 3, i32 %81
+  %89 = load i16, i16 addrspace(1)* %88, align 8
+  %90 = zext i16 %89 to i32
+  %91 = load i16, i16* %loc5
+  %92 = zext i16 %91 to i32
+  %93 = icmp eq i32 %90, %92
+  br i1 %93, label %106, label %94
+
+; <label>:94                                      ; preds = %87
+  %95 = load i32, i32* %loc4
+  %96 = add i32 %95, 1
+  store i32 %96, i32* %loc4
+  br label %97
+
+; <label>:97                                      ; preds = %74, %94
+  %98 = load i32, i32* %loc4
+  %99 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck15 = icmp eq %"System.Char[]" addrspace(1)* %99, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %100
+
+; <label>:100                                     ; preds = %97
+  %101 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %99, i32 0, i32 1
+  %102 = load i32, i32 addrspace(1)* %101
+  %103 = zext i32 %102 to i64
+  %104 = trunc i64 %103 to i32
+  %105 = icmp slt i32 %98, %104
+  br i1 %105, label %79, label %106
+
+; <label>:106                                     ; preds = %87, %100
+  %107 = load i32, i32* %loc4
+  %108 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck17 = icmp eq %"System.Char[]" addrspace(1)* %108, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %109
+
+; <label>:109                                     ; preds = %106
+  %110 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %108, i32 0, i32 1
+  %111 = load i32, i32 addrspace(1)* %110
+  %112 = zext i32 %111 to i64
+  %113 = trunc i64 %112 to i32
+  %114 = icmp eq i32 %107, %113
+  br i1 %114, label %122, label %115
+
+; <label>:115                                     ; preds = %109
+  %116 = load i32, i32* %loc0
+  %117 = sub i32 %116, 1
+  store i32 %117, i32* %loc0
+  br label %118
+
+; <label>:118                                     ; preds = %67, %115
+  %119 = load i32, i32* %loc0
+  %120 = load i32, i32* %loc1
+  %121 = icmp sge i32 %119, %120
+  br i1 %121, label %71, label %122
+
+; <label>:122                                     ; preds = %62, %109, %118
+  %123 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %124 = load i32, i32* %loc1
+  %125 = load i32, i32* %loc0
+  %126 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %123, i32 %124, i32 %125)
+  ret %System.String addrspace(1)* %126
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %97
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange22:                           ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
 Successfully read String.CreateTrimmedString
 
@@ -5439,8 +6893,8 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
@@ -5535,8 +6989,8 @@ entry:
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i64 2872
   %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
   %8 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %7
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %3
   %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
@@ -5553,8 +7007,8 @@ entry:
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 2864
   %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
   %21 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %20
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
-  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %22
 
 ; <label>:22                                      ; preds = %16
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
@@ -5569,7 +7023,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %16
+ThrowNullRef2:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5586,8 +7040,8 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5613,8 +7067,8 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
@@ -5632,8 +7086,8 @@ entry:
 
 ; <label>:12                                      ; preds = %4
   %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
@@ -5644,8 +7098,8 @@ entry:
 
 ; <label>:19                                      ; preds = %14
   %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %19
   %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
@@ -5660,21 +7114,21 @@ entry:
   %31 = zext i16 %30 to i32
   %32 = bitcast i8* %29 to i16*
   %33 = trunc i32 %31 to i16
-  %NullCheck6 = icmp ne i16* %32, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i16* %32, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %21
   store i16 %33, i16* %32, align 8
   %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %36
 
 ; <label>:36                                      ; preds = %34
   %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
   %38 = load i32, i32 addrspace(1)* %37, align 8
   %39 = add i32 %38, 1
-  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %40
 
 ; <label>:40                                      ; preds = %36
   %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
@@ -5683,16 +7137,16 @@ entry:
 
 ; <label>:42                                      ; preds = %14
   %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
-  br i1 %NullCheck12, label %44, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
   %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
   %47 = load i16, i16* %arg1
   %48 = zext i16 %47 to i32
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = trunc i32 %48 to i16
@@ -5703,31 +7157,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %19
+ThrowNullRef4:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %21
+ThrowNullRef6:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %36
+ThrowNullRef10:                                   ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %42
+ThrowNullRef12:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %44
+ThrowNullRef14:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5740,8 +7194,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -5752,8 +7206,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
@@ -5762,14 +7216,14 @@ entry:
 
 ; <label>:11                                      ; preds = %1
   %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
@@ -5779,15 +7233,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5808,8 +7262,8 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5822,8 +7276,8 @@ entry:
 
 ; <label>:8                                       ; preds = %3
   %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
@@ -5842,15 +7296,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
-  br i1 %NullCheck4, label %22, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
   %24 = load i16*, i16* addrspace(1)* %23, align 8
   %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %25, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
@@ -5859,8 +7313,8 @@ entry:
   store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
@@ -5874,8 +7328,8 @@ entry:
 
 ; <label>:37                                      ; preds = %65
   %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %37
   %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
@@ -5886,16 +7340,16 @@ entry:
   %45 = bitcast i16* %41 to i8*
   %46 = getelementptr inbounds i8, i8* %45, i64 %44
   %47 = bitcast i8* %46 to i16*
-  %NullCheck14 = icmp ne i16* %47, null
-  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %47, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %48
 
 ; <label>:48                                      ; preds = %39
   %49 = load i16, i16* %47, align 8
   %50 = zext i16 %49 to i32
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %52 = load i32, i32* %loc1
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %53
 
 ; <label>:53                                      ; preds = %48
   %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
@@ -5916,8 +7370,8 @@ entry:
 ; <label>:62                                      ; preds = %36, %59
   %63 = load i32, i32* %loc1
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck10, label %65, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %65
 
 ; <label>:65                                      ; preds = %62
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
@@ -5936,15 +7390,15 @@ entry:
 
 ; <label>:74                                      ; preds = %70
   %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
-  br i1 %NullCheck18, label %76, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %76
 
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
   %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
-  br i1 %NullCheck20, label %80, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
   %81 = load i64, i64 addrspace(1)* %79
@@ -5958,8 +7412,8 @@ entry:
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
   %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
-  br i1 %NullCheck22, label %92, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.String addrspace(1)* %90, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %92
 
 ; <label>:92                                      ; preds = %80
   %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
@@ -5969,15 +7423,15 @@ entry:
 
 ; <label>:96                                      ; preds = %70
   %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
-  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %98
 
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
   %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
-  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
   %103 = load i64, i64 addrspace(1)* %101
@@ -5991,8 +7445,8 @@ entry:
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
   %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
-  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.String addrspace(1)* %112, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %114
 
 ; <label>:114                                     ; preds = %102
   %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
@@ -6004,59 +7458,59 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %20
+ThrowNullRef4:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %22
+ThrowNullRef6:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %26
+ThrowNullRef8:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %62
+ThrowNullRef10:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %48
+ThrowNullRef16:                                   ; preds = %48
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %74
+ThrowNullRef18:                                   ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %76
+ThrowNullRef20:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %80
+ThrowNullRef22:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %96
+ThrowNullRef24:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %98
+ThrowNullRef26:                                   ; preds = %98
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %102
+ThrowNullRef28:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6069,15 +7523,15 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
   %3 = load i16*, i16* addrspace(1)* %2, align 8
   %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
@@ -6087,8 +7541,8 @@ entry:
   %10 = bitcast i16* %3 to i8*
   %11 = getelementptr inbounds i8, i8* %10, i64 %9
   %12 = bitcast i8* %11 to i16*
-  %NullCheck4 = icmp ne i16* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %5
   store i16 0, i16* %12, align 8
@@ -6098,11 +7552,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6119,8 +7573,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -6131,8 +7585,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
@@ -6144,15 +7598,15 @@ entry:
 
 ; <label>:14                                      ; preds = %1
   %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
   %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
   %21 = load i64, i64 addrspace(1)* %19
@@ -6171,15 +7625,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %14
+ThrowNullRef4:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %16
+ThrowNullRef6:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6302,14 +7756,6 @@ entry:
   ret %System.String addrspace(1)* %57
 }
 
-INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
-Successfully read RuntimeHelpers.get_OffsetToStringData
-
-define i32 @RuntimeHelpers.get_OffsetToStringData() {
-entry:
-  ret i32 12
-}
-
 INFO:  jitting method String::Equals using LLILCJit
 Successfully read String.Equals
 
@@ -6381,8 +7827,8 @@ entry:
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
-  br i1 %NullCheck24, label %29, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
   %30 = load i64, i64 addrspace(1)* %28
@@ -6397,8 +7843,8 @@ entry:
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
-  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
   %43 = load i64, i64 addrspace(1)* %41
@@ -6418,8 +7864,8 @@ entry:
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
   %59 = load i64, i64 addrspace(1)* %57
@@ -6434,8 +7880,8 @@ entry:
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck22, label %71, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
   %72 = load i64, i64 addrspace(1)* %70
@@ -6455,8 +7901,8 @@ entry:
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
-  br i1 %NullCheck16, label %87, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = load i64, i64 addrspace(1)* %86
@@ -6471,8 +7917,8 @@ entry:
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck18, label %100, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
   %101 = load i64, i64 addrspace(1)* %99
@@ -6492,8 +7938,8 @@ entry:
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
-  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
   %117 = load i64, i64 addrspace(1)* %115
@@ -6508,8 +7954,8 @@ entry:
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
-  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
   %130 = load i64, i64 addrspace(1)* %128
@@ -6528,15 +7974,15 @@ entry:
 
 ; <label>:142                                     ; preds = %22
   %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
-  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %143, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %144
 
 ; <label>:144                                     ; preds = %142
   %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
   %146 = load i32, i32 addrspace(1)* %145
   %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
-  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %147, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %148
 
 ; <label>:148                                     ; preds = %144
   %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
@@ -6557,15 +8003,15 @@ entry:
 
 ; <label>:159                                     ; preds = %22
   %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
-  br i1 %NullCheck, label %161, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %ThrowNullRef, label %161
 
 ; <label>:161                                     ; preds = %159
   %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
   %163 = load i32, i32 addrspace(1)* %162
   %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
-  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %164, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %165
 
 ; <label>:165                                     ; preds = %161
   %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
@@ -6578,8 +8024,8 @@ entry:
 
 ; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
-  br i1 %NullCheck4, label %172, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %171, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %172
 
 ; <label>:172                                     ; preds = %170
   %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
@@ -6589,8 +8035,8 @@ entry:
 
 ; <label>:176                                     ; preds = %172
   %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
-  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %177, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %178
 
 ; <label>:178                                     ; preds = %176
   %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
@@ -6629,55 +8075,55 @@ ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %161
+ThrowNullRef2:                                    ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %170
+ThrowNullRef4:                                    ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %176
+ThrowNullRef6:                                    ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %142
+ThrowNullRef8:                                    ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %144
+ThrowNullRef10:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %113
+ThrowNullRef12:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %116
+ThrowNullRef14:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %84
+ThrowNullRef16:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %87
+ThrowNullRef18:                                   ; preds = %87
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %55
+ThrowNullRef20:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %58
+ThrowNullRef22:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %26
+ThrowNullRef24:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %29
+ThrowNullRef26:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,8 +8161,8 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck, label %14, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %ThrowNullRef, label %14
 
 ; <label>:14                                      ; preds = %8
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
@@ -6760,8 +8206,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
@@ -6770,14 +8216,14 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32, i32* %loc0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %10
   %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
   %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
@@ -6790,15 +8236,15 @@ entry:
 ; <label>:25                                      ; preds = %19
   %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
-  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
   %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
@@ -6807,8 +8253,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %37 = load i32, i32* %loc0
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %38, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %38
 
 ; <label>:38                                      ; preds = %32
   %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
@@ -6817,14 +8263,14 @@ entry:
 
 ; <label>:40                                      ; preds = %19
   %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %40
   %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
   %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
-  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
-  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
@@ -6832,8 +8278,8 @@ entry:
   %48 = zext i32 %47 to i64
   %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
-  br i1 %NullCheck16, label %51, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %51
 
 ; <label>:51                                      ; preds = %45
   %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
@@ -6847,15 +8293,15 @@ entry:
 ; <label>:57                                      ; preds = %51
   %58 = load i16*, i16** %arg1
   %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
-  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %60
 
 ; <label>:60                                      ; preds = %57
   %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
   %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
-  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %64
 
 ; <label>:64                                      ; preds = %60
   %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
@@ -6864,22 +8310,22 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
   %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
-  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %70
 
 ; <label>:70                                      ; preds = %64
   %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
   %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
-  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
-  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
   %75 = load i32, i32 addrspace(1)* %74
   %76 = zext i32 %75 to i64
   %77 = trunc i64 %76 to i32
-  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
-  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %78
 
 ; <label>:78                                      ; preds = %73
   %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
@@ -6901,8 +8347,8 @@ entry:
   %90 = bitcast i16* %86 to i8*
   %91 = getelementptr inbounds i8, i8* %90, i64 %89
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %93
 
 ; <label>:93                                      ; preds = %80
   %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
@@ -6912,8 +8358,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %99 = load i32, i32* %loc2
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %100
 
 ; <label>:100                                     ; preds = %93
   %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
@@ -6928,63 +8374,63 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %25
+ThrowNullRef6:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %32
+ThrowNullRef10:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %40
+ThrowNullRef12:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %45
+ThrowNullRef16:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %57
+ThrowNullRef18:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %60
+ThrowNullRef20:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %64
+ThrowNullRef22:                                   ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %70
+ThrowNullRef24:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %73
+ThrowNullRef26:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %80
+ThrowNullRef28:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %93
+ThrowNullRef30:                                   ; preds = %93
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7004,8 +8450,8 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
@@ -7033,43 +8479,43 @@ entry:
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %14
   %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
   %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   %28 = load i32, i32 addrspace(1)* %27, align 8
   %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
-  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %30
 
 ; <label>:30                                      ; preds = %26
   %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
   %32 = load i32, i32 addrspace(1)* %31, align 8
   %33 = add i32 %28, %32
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %34
 
 ; <label>:34                                      ; preds = %30
   %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   store i32 %33, i32 addrspace(1)* %35
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
   store i32 0, i32 addrspace(1)* %38
   %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %40
 
 ; <label>:40                                      ; preds = %37
   %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
@@ -7082,8 +8528,8 @@ entry:
 
 ; <label>:47                                      ; preds = %40
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
@@ -7098,8 +8544,8 @@ entry:
   %54 = load i32, i32* %loc0
   %55 = sext i32 %54 to i64
   %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
-  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %57
 
 ; <label>:57                                      ; preds = %52
   %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
@@ -7110,68 +8556,35 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %14
+ThrowNullRef2:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %23
+ThrowNullRef4:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %26
+ThrowNullRef6:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %30
+ThrowNullRef8:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %34
+ThrowNullRef10:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %47
+ThrowNullRef14:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %52
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-}
-
-INFO:  jitting method StringBuilder::get_Length using LLILCJit
-Successfully read StringBuilder.get_Length
-
-define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.StringBuilder addrspace(1)*
-  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
-  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
-
-; <label>:1                                       ; preds = %entry
-  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %3 = load i32, i32 addrspace(1)* %2, align 8
-  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
-
-; <label>:5                                       ; preds = %1
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = add i32 %3, %7
-  ret i32 %8
-
-ThrowNullRef:                                     ; preds = %entry
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef16:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7213,70 +8626,70 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
   %6 = load i32, i32 addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
   store i32 %6, i32 addrspace(1)* %8
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
   %13 = load i32, i32 addrspace(1)* %12, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
   store i32 %13, i32 addrspace(1)* %15
   %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
-  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %18
 
 ; <label>:18                                      ; preds = %14
   %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
   %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
   %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
   %34 = load i32, i32 addrspace(1)* %33, align 8
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
-  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
@@ -7287,39 +8700,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %28
+ThrowNullRef16:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %32
+ThrowNullRef18:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7455,13 +8868,13 @@ entry:
 ; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
@@ -7477,16 +8890,16 @@ entry:
 
 ; <label>:18                                      ; preds = %15
   %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
   store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
   %22 = load i32, i32* %loc0
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %24
 
 ; <label>:24                                      ; preds = %20
   %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
@@ -7498,13 +8911,13 @@ entry:
 ; <label>:28                                      ; preds = %15, %24
   %29 = load i32, i32* %arg1
   %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %31
   %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
@@ -7517,20 +8930,20 @@ entry:
   %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
-  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
   %46 = load i32, i32 addrspace(1)* %45, align 8
   %47 = sub i32 %40, %46
-  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
-  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i32 addrspace(1)* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %48
 
 ; <label>:48                                      ; preds = %44
   store i32 %47, i32 addrspace(1)* %39, align 8
@@ -7538,21 +8951,21 @@ entry:
 
 ; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
-  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %51
 
 ; <label>:51                                      ; preds = %49
   %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %53
 
 ; <label>:53                                      ; preds = %51
   %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
   %55 = load i32, i32 addrspace(1)* %54, align 8
   %56 = load i32, i32* %arg2
   %57 = sub i32 %55, %56
-  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %58
 
 ; <label>:58                                      ; preds = %53
   %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
@@ -7562,13 +8975,13 @@ entry:
 ; <label>:60                                      ; preds = %33, %58
   %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
   %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
-  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %63
 
 ; <label>:63                                      ; preds = %60
   %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
-  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
-  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
@@ -7578,15 +8991,15 @@ entry:
 
 ; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
-  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i32 addrspace(1)* %69, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %70
 
 ; <label>:70                                      ; preds = %68
   %71 = load i32, i32 addrspace(1)* %69, align 8
   store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
-  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
@@ -7596,8 +9009,8 @@ entry:
   store i32 %77, i32* %loc4
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
-  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %80
 
 ; <label>:80                                      ; preds = %73
   %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
@@ -7607,71 +9020,71 @@ entry:
 ; <label>:83                                      ; preds = %80
   store i32 0, i32* %loc3
   %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
-  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
-  br i1 %NullCheck26, label %88, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i32 addrspace(1)* %87, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %88
 
 ; <label>:88                                      ; preds = %85
   %89 = load i32, i32 addrspace(1)* %87, align 8
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
-  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %90
 
 ; <label>:90                                      ; preds = %88
   %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
   store i32 %89, i32 addrspace(1)* %91
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
-  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
-  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %96
 
 ; <label>:96                                      ; preds = %94
   %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
-  br i1 %NullCheck34, label %100, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %100
 
 ; <label>:100                                     ; preds = %96
   %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
-  br i1 %NullCheck36, label %102, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %102
 
 ; <label>:102                                     ; preds = %100
   %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
   %104 = load i32, i32 addrspace(1)* %103, align 8
   %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
-  br i1 %NullCheck38, label %106, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %106
 
 ; <label>:106                                     ; preds = %102
   %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
-  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
-  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %108
 
 ; <label>:108                                     ; preds = %106
   %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
   %110 = load i32, i32 addrspace(1)* %109, align 8
   %111 = add i32 %104, %110
-  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %112
 
 ; <label>:112                                     ; preds = %108
   %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
   store i32 %111, i32 addrspace(1)* %113
   %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
-  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i32 addrspace(1)* %114, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %115
 
 ; <label>:115                                     ; preds = %112
   %116 = load i32, i32 addrspace(1)* %114, align 8
@@ -7681,19 +9094,19 @@ entry:
 ; <label>:118                                     ; preds = %115
   %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
-  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %121
 
 ; <label>:121                                     ; preds = %118
   %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
-  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
-  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %123
 
 ; <label>:123                                     ; preds = %121
   %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
   %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
-  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
-  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %126
 
 ; <label>:126                                     ; preds = %123
   %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
@@ -7705,8 +9118,8 @@ entry:
 
 ; <label>:130                                     ; preds = %80, %115, %126
   %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %132
 
 ; <label>:132                                     ; preds = %130
   %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7715,8 +9128,8 @@ entry:
   %136 = load i32, i32* %loc3
   %137 = sub i32 %135, %136
   %138 = sub i32 %134, %137
-  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %139
 
 ; <label>:139                                     ; preds = %132
   %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7728,16 +9141,16 @@ entry:
 
 ; <label>:144                                     ; preds = %139
   %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
-  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %146
 
 ; <label>:146                                     ; preds = %144
   %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
   %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
   %149 = load i32, i32* %loc2
   %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
-  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %151
 
 ; <label>:151                                     ; preds = %146
   %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
@@ -7754,145 +9167,249 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %18
+ThrowNullRef4:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %31
+ThrowNullRef10:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %44
+ThrowNullRef16:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %68
+ThrowNullRef18:                                   ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %70
+ThrowNullRef20:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %73
+ThrowNullRef22:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %83
+ThrowNullRef24:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %85
+ThrowNullRef26:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %88
+ThrowNullRef28:                                   ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %90
+ThrowNullRef30:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %94
+ThrowNullRef32:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %96
+ThrowNullRef34:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %100
+ThrowNullRef36:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %102
+ThrowNullRef38:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %106
+ThrowNullRef40:                                   ; preds = %106
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %108
+ThrowNullRef42:                                   ; preds = %108
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %112
+ThrowNullRef44:                                   ; preds = %112
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %118
+ThrowNullRef46:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %121
+ThrowNullRef48:                                   ; preds = %121
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %123
+ThrowNullRef50:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %130
+ThrowNullRef52:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %132
+ThrowNullRef54:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %144
+ThrowNullRef56:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %146
+ThrowNullRef58:                                   ; preds = %146
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %60
+ThrowNullRef60:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %63
+ThrowNullRef62:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %49
+ThrowNullRef64:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %51
+ThrowNullRef66:                                   ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %53
+ThrowNullRef68:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(%"System.Char[]" addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %arg0 = alloca %"System.Char[]" addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store %"System.Char[]" addrspace(1)* %param0, %"System.Char[]" addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load i32, i32* %arg4
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %43, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %38, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg1
+  %13 = load i32, i32* %arg4
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %38, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %24 = load i32, i32* %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %35 = load i32, i32* %arg3
+  %36 = load i32, i32* %arg4
+  %37 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %37, %"System.Char[]" addrspace(1)* %34, i32 %35, i32 %36)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:38                                      ; preds = %5, %16
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Successfully read Buffer._Memmove
 
@@ -7914,7 +9431,7 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[loadElem]
+Failed to read AppDomain.SetDataHelper[storeElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -7923,8 +9440,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
@@ -7934,8 +9451,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
@@ -7947,15 +9464,15 @@ entry:
   %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
   %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
@@ -7966,15 +9483,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7992,7 +9509,79 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
-Failed to read Dictionary`2.TryGetValue[loadElemA]
+Successfully read Dictionary`2.TryGetValue
+
+define i8 @"Dictionary`2.TryGetValue"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)* addrspace(1)* %param2) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  %arg2 = alloca %System.__Canon addrspace(1)* addrspace(1)*
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  store %System.__Canon addrspace(1)* addrspace(1)* %param2, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  store i32 %2, i32* %loc0
+  %3 = load i32, i32* %loc0
+  %4 = icmp slt i32 %3, 0
+  br i1 %4, label %22, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 2
+  %10 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %9, align 8
+  %11 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = zext i32 %11 to i64
+  %BoundsCheck = icmp uge i64 %16, %15
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 3, i32 %11
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %20, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %6, %System.__Canon addrspace(1)* %21)
+  ret i8 1
+
+; <label>:22                                      ; preds = %entry
+  %23 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %23, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -8058,8 +9647,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
@@ -8091,8 +9680,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
@@ -8171,15 +9760,15 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck, label %19, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %ThrowNullRef, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
   %21 = load i32, i32 addrspace(1)* %20
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
@@ -8202,7 +9791,7 @@ ThrowNullRef:                                     ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %19
+ThrowNullRef2:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8248,8 +9837,8 @@ entry:
   %0 = alloca %System.AppDomainHandle
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %1 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %1, i32 0, i32 15
@@ -8269,8 +9858,8 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
@@ -8286,7 +9875,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -8299,8 +9888,8 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -8327,8 +9916,8 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
@@ -8352,8 +9941,8 @@ entry:
   %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
   store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
@@ -8363,8 +9952,8 @@ entry:
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
@@ -8374,8 +9963,8 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %9
   %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
@@ -8384,8 +9973,8 @@ entry:
 
 ; <label>:18                                      ; preds = %3, %16
   %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
@@ -8397,15 +9986,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %18
+ThrowNullRef6:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8418,8 +10007,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
@@ -8453,15 +10042,15 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
@@ -8473,7 +10062,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8481,7 +10070,7 @@ ThrowNullRef1:                                    ; preds = %1
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
 Failed to read Dictionary`2.System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
@@ -8506,8 +10095,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
@@ -8524,8 +10113,8 @@ entry:
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -8544,7 +10133,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8577,8 +10166,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = load i64, i64* %arg2
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = trunc i32 %3 to i8
@@ -8634,46 +10223,46 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
   %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
-  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
-  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
-  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
@@ -8684,27 +10273,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %20
+ThrowNullRef12:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8717,8 +10306,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -8756,22 +10345,22 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
   %9 = load i64, i64 addrspace(1)* %8, align 8
   %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
   %13 = load i64, i64 addrspace(1)* %12, align 8
   %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %11
   %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
@@ -8788,11 +10377,11 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8882,8 +10471,8 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
@@ -8900,8 +10489,8 @@ entry:
 ; <label>:8                                       ; preds = %1
   %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
   %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
@@ -8911,15 +10500,15 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
   %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
   %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
-  br i1 %NullCheck6, label %21, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
@@ -8946,15 +10535,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8992,15 +10581,15 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
   store i8 %3, i8 addrspace(1)* %5
   %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
@@ -9011,7 +10600,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9027,8 +10616,8 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -9041,8 +10630,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
@@ -9058,7 +10647,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9080,8 +10669,8 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
@@ -9096,8 +10685,8 @@ entry:
 ; <label>:12                                      ; preds = %6
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
@@ -9112,8 +10701,8 @@ entry:
 ; <label>:21                                      ; preds = %15
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
@@ -9128,8 +10717,8 @@ entry:
 ; <label>:30                                      ; preds = %24
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %31, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
@@ -9144,8 +10733,8 @@ entry:
 ; <label>:39                                      ; preds = %33
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
-  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %40, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %42
 
 ; <label>:42                                      ; preds = %39
   %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
@@ -9164,19 +10753,19 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %21
+ThrowNullRef4:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %30
+ThrowNullRef6:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %39
+ThrowNullRef8:                                    ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9243,8 +10832,8 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
@@ -9264,57 +10853,57 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
   store i8 0, i8 addrspace(1)* %2
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
   store i8 0, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
   store i8 0, i8 addrspace(1)* %17
   %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
   store i8 0, i8 addrspace(1)* %20
   %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
-  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
@@ -9325,31 +10914,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %19
+ThrowNullRef14:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9367,8 +10956,8 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
@@ -9380,8 +10969,8 @@ entry:
 
 ; <label>:9                                       ; preds = %4
   %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %9
   %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
@@ -9395,7 +10984,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef2:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9420,8 +11009,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
@@ -9512,8 +11101,8 @@ entry:
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
@@ -9524,8 +11113,8 @@ entry:
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = load i64, i64 addrspace(1)* %12
@@ -9537,8 +11126,8 @@ entry:
   %20 = load i64, i64* %19
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
-  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %13
   %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
@@ -9555,8 +11144,8 @@ entry:
 ; <label>:30                                      ; preds = %25
   %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %32 = load i32, i32* %arg2
-  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
-  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
@@ -9570,15 +11159,15 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %30
+ThrowNullRef2:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9622,87 +11211,87 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
   %10 = load i8, i8 addrspace(1)* %9, align 8
   %11 = zext i8 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %8
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
   store i8 %12, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
   %19 = load i8, i8 addrspace(1)* %18, align 8
   %20 = zext i8 %19 to i32
   %21 = trunc i32 %20 to i8
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
   store i8 %21, i8 addrspace(1)* %23
   %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
   %28 = load i8, i8 addrspace(1)* %27, align 8
   %29 = zext i8 %28 to i32
   %30 = trunc i32 %29 to i8
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
-  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %31
 
 ; <label>:31                                      ; preds = %26
   %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
   store i8 %30, i8 addrspace(1)* %32
   %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
-  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
-  br i1 %NullCheck14, label %40, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %40
 
 ; <label>:40                                      ; preds = %35
   %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
   store i8 %39, i8 addrspace(1)* %41
   %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
-  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %44
 
 ; <label>:44                                      ; preds = %40
   %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
   %46 = load i8, i8 addrspace(1)* %45, align 8
   %47 = zext i8 %46 to i32
   %48 = trunc i32 %47 to i8
-  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
   store i8 %48, i8 addrspace(1)* %50
   %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
-  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
@@ -9713,29 +11302,29 @@ entry:
 ; <label>:56                                      ; preds = %52
   %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
-  br i1 %NullCheck22, label %59, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
   %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
   %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
-  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
-  br i1 %NullCheck24, label %63, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
   %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
-  br i1 %NullCheck26, label %66, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
   %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
-  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
-  br i1 %NullCheck28, label %69, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %69
 
 ; <label>:69                                      ; preds = %66
   %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
@@ -9744,15 +11333,15 @@ entry:
 
 ; <label>:71                                      ; preds = %105
   %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
-  br i1 %NullCheck34, label %73, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %73
 
 ; <label>:73                                      ; preds = %71
   %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
   %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
   %76 = load i32, i32* %loc0
-  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
-  br i1 %NullCheck36, label %77, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
@@ -9766,8 +11355,8 @@ entry:
 
 ; <label>:83                                      ; preds = %77
   %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
-  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
@@ -9775,14 +11364,14 @@ entry:
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
   %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
-  br i1 %NullCheck40, label %91, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
 ; <label>:91                                      ; preds = %85
   %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
   %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
-  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck42, label %94, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %94
 
 ; <label>:94                                      ; preds = %91
   %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
@@ -9798,14 +11387,14 @@ entry:
 ; <label>:99                                      ; preds = %69, %96
   %100 = load i32, i32* %loc0
   %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
-  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %102
 
 ; <label>:102                                     ; preds = %99
   %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
   %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
-  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
-  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
@@ -9819,87 +11408,87 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %26
+ThrowNullRef10:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %31
+ThrowNullRef12:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %35
+ThrowNullRef14:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %40
+ThrowNullRef16:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %56
+ThrowNullRef22:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %59
+ThrowNullRef24:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %63
+ThrowNullRef26:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %66
+ThrowNullRef28:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %102
+ThrowNullRef32:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %71
+ThrowNullRef34:                                   ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %73
+ThrowNullRef36:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %83
+ThrowNullRef38:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %85
+ThrowNullRef40:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %91
+ThrowNullRef42:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9943,15 +11532,15 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
   %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
@@ -9961,28 +11550,28 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
   %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %12
   %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
   %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
   %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
-  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
@@ -9993,23 +11582,23 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %12
+ThrowNullRef6:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10031,15 +11620,15 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
   %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = load i64, i64 addrspace(1)* %7
@@ -10077,13 +11666,13 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[loadElem]
+Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -10111,8 +11700,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -10261,8 +11850,8 @@ entry:
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load i64, i64* %arg0
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -10396,8 +11985,8 @@ entry:
   store i64 %param0, i64* %arg0
   store i64 %param1, i64* %arg1
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
@@ -10405,8 +11994,8 @@ entry:
   %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
   %5 = load i16*, i16* addrspace(1)* %4, align 8
   %6 = addrspacecast i64* %arg1 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = bitcast i64 addrspace(1)* %6 to i8 addrspace(1)*
@@ -10422,7 +12011,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10456,8 +12045,8 @@ entry:
   %1 = load i32, i32* %arg1
   %2 = sext i32 %1 to i64
   %3 = inttoptr i64 %2 to i16*
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -10510,8 +12099,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, i32)*)(%System.IO.ConsoleStream addrspace(1)* %2, i32 %1)
   %3 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %4 = load i64, i64* %arg1
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
@@ -10522,8 +12111,8 @@ entry:
   %10 = icmp eq i32 %9, 3
   %11 = sext i1 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %5
   %14 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, i32 0, i32 5
@@ -10534,7 +12123,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10557,8 +12146,8 @@ entry:
   %5 = icmp eq i32 %4, 1
   %6 = sext i1 %5 to i32
   %7 = trunc i32 %6 to i8
-  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %2, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.ConsoleStream addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
@@ -10569,8 +12158,8 @@ entry:
   %13 = icmp eq i32 %12, 2
   %14 = sext i1 %13 to i32
   %15 = trunc i32 %14 to i8
-  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %10, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.ConsoleStream addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %8
   %17 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %10, i32 0, i32 4
@@ -10581,7 +12170,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10620,8 +12209,8 @@ entry:
   %arg0 = alloca i64
   store i64 %param0, i64* %arg0
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
@@ -10656,8 +12245,8 @@ entry:
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
   %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = load i64, i64 addrspace(1)* %7
@@ -10761,7 +12350,127 @@ entry:
 INFO:  jitting method Encoding::GetEncoding using LLILCJit
 Failed to read Encoding.GetEncoding[convertToHelperArgumentType]
 INFO:  jitting method EncodingProvider::GetEncodingFromProvider using LLILCJit
-Failed to read EncodingProvider.GetEncodingFromProvider[loadElem]
+Successfully read EncodingProvider.GetEncodingFromProvider
+
+define %System.Text.Encoding addrspace(1)* @EncodingProvider.GetEncodingFromProvider(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca %"System.Text.EncodingProvider[]" addrspace(1)*
+  %loc1 = alloca %System.Text.EncodingProvider addrspace(1)*
+  %loc2 = alloca %System.Text.Encoding addrspace(1)*
+  %loc3 = alloca %System.Text.Encoding addrspace(1)*
+  %loc4 = alloca %"System.Text.EncodingProvider[]" addrspace(1)*
+  %loc5 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1059)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2392
+  %2 = addrspacecast i8 addrspace(1)* %1 to %"System.Text.EncodingProvider[]" addrspace(1)**
+  %3 = load volatile %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %2
+  %4 = icmp ne %"System.Text.EncodingProvider[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %entry
+  ret %System.Text.Encoding addrspace(1)* null
+
+; <label>:6                                       ; preds = %entry
+  %7 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1059)
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i64 2392
+  %9 = addrspacecast i8 addrspace(1)* %8 to %"System.Text.EncodingProvider[]" addrspace(1)**
+  %10 = load volatile %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %9
+  store %"System.Text.EncodingProvider[]" addrspace(1)* %10, %"System.Text.EncodingProvider[]" addrspace(1)** %loc0
+  %11 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc0
+  store %"System.Text.EncodingProvider[]" addrspace(1)* %11, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  store i32 0, i32* %loc5
+  br label %43
+
+; <label>:12                                      ; preds = %46
+  %13 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  %14 = load i32, i32* %loc5
+  %NullCheck1 = icmp eq %"System.Text.EncodingProvider[]" addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %13, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = zext i32 %17 to i64
+  %19 = zext i32 %14 to i64
+  %BoundsCheck = icmp uge i64 %19, %18
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %20
+
+; <label>:20                                      ; preds = %15
+  %21 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %13, i32 0, i32 3, i32 %14
+  %22 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)* addrspace(1)* %21, align 8
+  store %System.Text.EncodingProvider addrspace(1)* %22, %System.Text.EncodingProvider addrspace(1)** %loc1
+  %23 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)** %loc1
+  %24 = load i32, i32* %arg0
+  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i64 addrspace(1)*
+  %NullCheck3 = icmp eq i64 addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
+
+; <label>:26                                      ; preds = %20
+  %27 = load i64, i64 addrspace(1)* %25
+  %28 = add i64 %27, 64
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 40
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Text.Encoding addrspace(1)* (%System.Text.EncodingProvider addrspace(1)*, i32)*
+  %35 = call %System.Text.Encoding addrspace(1)* %34(%System.Text.EncodingProvider addrspace(1)* %23, i32 %24)
+  store %System.Text.Encoding addrspace(1)* %35, %System.Text.Encoding addrspace(1)** %loc2
+  %36 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc2
+  %37 = icmp eq %System.Text.Encoding addrspace(1)* %36, null
+  br i1 %37, label %40, label %38
+
+; <label>:38                                      ; preds = %26
+  %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc2
+  store %System.Text.Encoding addrspace(1)* %39, %System.Text.Encoding addrspace(1)** %loc3
+  br label %53
+
+; <label>:40                                      ; preds = %26
+  %41 = load i32, i32* %loc5
+  %42 = add i32 %41, 1
+  store i32 %42, i32* %loc5
+  br label %43
+
+; <label>:43                                      ; preds = %6, %40
+  %44 = load i32, i32* %loc5
+  %45 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  %NullCheck = icmp eq %"System.Text.EncodingProvider[]" addrspace(1)* %45, null
+  br i1 %NullCheck, label %ThrowNullRef, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp slt i32 %44, %50
+  br i1 %51, label %12, label %52
+
+; <label>:52                                      ; preds = %46
+  ret %System.Text.Encoding addrspace(1)* null
+
+; <label>:53                                      ; preds = %38
+  %54 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc3
+  ret %System.Text.Encoding addrspace(1)* %54
+
+ThrowNullRef:                                     ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method EncodingProvider::.cctor using LLILCJit
 Successfully read EncodingProvider..cctor
 
@@ -10780,7 +12489,7 @@ Failed to read Encoding.get_InternalSyncObject[Call HasTypeArg]
 INFO:  jitting method Hashtable::.ctor using LLILCJit
 Failed to read Hashtable..ctor[Volatile store]
 INFO:  jitting method Hashtable::get_Item using LLILCJit
-Failed to read Hashtable.get_Item[loadElemA]
+Failed to read Hashtable.get_Item[loadNonPrimitiveObj]
 INFO:  jitting method Hashtable::InitHash using LLILCJit
 Successfully read Hashtable.InitHash
 
@@ -10800,8 +12509,8 @@ entry:
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -10817,15 +12526,15 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
   %15 = load i32, i32* %loc0
-  %NullCheck2 = icmp ne i32 addrspace(1)* %14, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i32 addrspace(1)* %14, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %3
   store i32 %15, i32 addrspace(1)* %14, align 8
   %17 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %18 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %NullCheck4 = icmp ne i32 addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i32 addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = load i32, i32 addrspace(1)* %18, align 8
@@ -10834,8 +12543,8 @@ entry:
   %23 = sub i32 %22, 1
   %24 = urem i32 %21, %23
   %25 = add i32 1, %24
-  %NullCheck6 = icmp ne i32 addrspace(1)* %17, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32 addrspace(1)* %17, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %19
   store i32 %25, i32 addrspace(1)* %17, align 8
@@ -10846,15 +12555,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %19
+ThrowNullRef6:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10869,8 +12578,8 @@ entry:
   store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
   store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %NullCheck = icmp ne %System.Collections.Hashtable addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Collections.Hashtable addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
@@ -10880,16 +12589,16 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Collections.Hashtable addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Collections.Hashtable addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
   %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck4 = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %9, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
   %13 = inttoptr i64 %11 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
@@ -10899,8 +12608,8 @@ entry:
 ; <label>:15                                      ; preds = %1
   %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -10918,15 +12627,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10940,8 +12649,8 @@ entry:
   store %System.Int32 addrspace(1)* %param0, %System.Int32 addrspace(1)** %this
   %0 = load %System.Int32 addrspace(1)*, %System.Int32 addrspace(1)** %this
   %1 = bitcast %System.Int32 addrspace(1)* %0 to i32 addrspace(1)*
-  %NullCheck = icmp ne i32 addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq i32 addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load i32, i32 addrspace(1)* %1, align 8
@@ -11017,8 +12726,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.UTF8Encoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
@@ -11027,15 +12736,15 @@ entry:
   %9 = load i8, i8* %arg2
   %10 = zext i8 %9 to i32
   %11 = trunc i32 %10 to i8
-  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %8, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %6
   %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %8, i32 0, i32 8
   store i8 %11, i8 addrspace(1)* %13
   %14 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %14, i32 0, i32 8
@@ -11047,8 +12756,8 @@ entry:
 ; <label>:20                                      ; preds = %15
   %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %22, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %22, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = load i64, i64 addrspace(1)* %22
@@ -11070,15 +12779,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %12
+ThrowNullRef4:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11093,8 +12802,8 @@ entry:
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
@@ -11116,16 +12825,16 @@ entry:
 ; <label>:10                                      ; preds = %1
   %11 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
   %12 = load i32, i32* %arg1
-  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %11, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.Encoding addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
   store i32 %12, i32 addrspace(1)* %14
   %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
   %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = load i64, i64 addrspace(1)* %16
@@ -11143,11 +12852,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11160,8 +12869,8 @@ entry:
   %this = alloca %System.Text.UTF8Encoding addrspace(1)*
   store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
   %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.UTF8Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
@@ -11173,16 +12882,16 @@ entry:
 ; <label>:6                                       ; preds = %1
   %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %8 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %10, %System.Text.EncoderFallback addrspace(1)* %8)
   %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %12 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
-  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %11, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %11, i32 0, i32 3
@@ -11195,8 +12904,8 @@ entry:
   %18 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %18, %System.String addrspace(1)* %17)
   %19 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %18 to %System.Text.EncoderFallback addrspace(1)*
-  %NullCheck6 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %16, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %16, i32 0, i32 2
@@ -11206,8 +12915,8 @@ entry:
   %24 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %24, %System.String addrspace(1)* %23)
   %25 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %24 to %System.Text.DecoderFallback addrspace(1)*
-  %NullCheck8 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %22, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %22, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %20
   %27 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %22, i32 0, i32 3
@@ -11218,19 +12927,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %20
+ThrowNullRef8:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11260,8 +12969,8 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load i32, i32* %arg1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -11279,8 +12988,8 @@ entry:
 ; <label>:15                                      ; preds = %8
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %17 = load i32, i32* %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 %17
@@ -11296,7 +13005,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11348,7 +13057,7 @@ entry:
 }
 
 INFO:  jitting method Hashtable::Insert using LLILCJit
-Failed to read Hashtable.Insert[loadElemA]
+Failed to read Hashtable.Insert[storeElem]
 INFO:  jitting method ConsoleEncoding::.ctor using LLILCJit
 Successfully read ConsoleEncoding..ctor
 
@@ -11363,8 +13072,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %1)
   %2 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
@@ -11400,8 +13109,8 @@ entry:
   %2 = call %System.Text.InternalEncoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalEncoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %1)
   %3 = bitcast %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2 to %System.Text.EncoderFallback addrspace(1)*
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
@@ -11411,8 +13120,8 @@ entry:
   %8 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %7)
   %9 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %8 to %System.Text.DecoderFallback addrspace(1)*
-  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %6, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.Encoding addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %4
   %11 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %6, i32 0, i32 3
@@ -11423,7 +13132,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11442,15 +13151,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* %1)
   %2 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   %6 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, i32 0, i32 1
@@ -11461,7 +13170,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11489,8 +13198,8 @@ entry:
   store %System.Text.InternalDecoderBestFitFallback addrspace(1)* %param0, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
   %0 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
@@ -11500,15 +13209,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %4)
   %5 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %6)
   %9 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, i32 0, i32 1
@@ -11519,11 +13228,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11591,8 +13300,8 @@ entry:
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
   %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = load i64, i64 addrspace(1)* %19
@@ -11656,8 +13365,8 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.ConsoleStream addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
@@ -11688,31 +13397,31 @@ entry:
   store i8 %param4, i8* %arg4
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %3, %System.IO.Stream addrspace(1)* %1)
   %4 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %4, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
   %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %4, i32 0, i32 4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %5)
   %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %6
   %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
   %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
   %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = load i64, i64 addrspace(1)* %13
@@ -11724,8 +13433,8 @@ entry:
   %21 = load i64, i64* %20
   %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %8, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %8, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %14
   %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 5
@@ -11743,24 +13452,24 @@ entry:
   %31 = load i32, i32* %arg3
   %32 = sext i32 %31 to i64
   %33 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %32)
-  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %30, null
-  br i1 %NullCheck10, label %34, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.StreamWriter addrspace(1)* %30, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %35, %"System.Char[]" addrspace(1)* %33)
   %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %37, null
-  br i1 %NullCheck12, label %38, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.StreamWriter addrspace(1)* %37, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %38
 
 ; <label>:38                                      ; preds = %34
   %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
   %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
   %41 = load i32, i32* %arg3
   %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %42, null
-  br i1 %NullCheck14, label %43, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %42, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
   %44 = load i64, i64 addrspace(1)* %42
@@ -11774,30 +13483,30 @@ entry:
   %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
   %53 = sext i32 %52 to i64
   %54 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %53)
-  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
-  br i1 %NullCheck16, label %55, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %55
 
 ; <label>:55                                      ; preds = %43
   %56 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %56, %"System.Byte[]" addrspace(1)* %54)
   %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %58 = load i32, i32* %arg3
-  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %57, null
-  br i1 %NullCheck18, label %59, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.StreamWriter addrspace(1)* %57, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %59
 
 ; <label>:59                                      ; preds = %55
   %60 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 10
   store i32 %58, i32 addrspace(1)* %60
   %61 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %61, null
-  br i1 %NullCheck20, label %62, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.IO.StreamWriter addrspace(1)* %61, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %62
 
 ; <label>:62                                      ; preds = %59
   %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
   %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
   %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
   %67 = load i64, i64 addrspace(1)* %65
@@ -11815,15 +13524,15 @@ entry:
 
 ; <label>:78                                      ; preds = %66
   %79 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %79, null
-  br i1 %NullCheck24, label %80, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.StreamWriter addrspace(1)* %79, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %80
 
 ; <label>:80                                      ; preds = %78
   %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
   %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
   %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %83, null
-  br i1 %NullCheck26, label %84, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %83, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
   %85 = load i64, i64 addrspace(1)* %83
@@ -11840,8 +13549,8 @@ entry:
 
 ; <label>:95                                      ; preds = %84
   %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.IO.StreamWriter addrspace(1)* %96, null
-  br i1 %NullCheck28, label %97, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.IO.StreamWriter addrspace(1)* %96, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %97
 
 ; <label>:97                                      ; preds = %95
   %98 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 12
@@ -11855,8 +13564,8 @@ entry:
   %103 = icmp eq i32 %102, 0
   %104 = sext i1 %103 to i32
   %105 = trunc i32 %104 to i8
-  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %100, null
-  br i1 %NullCheck30, label %106, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.IO.StreamWriter addrspace(1)* %100, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %106
 
 ; <label>:106                                     ; preds = %99
   %107 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %100, i32 0, i32 13
@@ -11867,63 +13576,63 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %6
+ThrowNullRef4:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %29
+ThrowNullRef10:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %34
+ThrowNullRef12:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %38
+ThrowNullRef14:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %43
+ThrowNullRef16:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %55
+ThrowNullRef18:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %59
+ThrowNullRef20:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %62
+ThrowNullRef22:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %78
+ThrowNullRef24:                                   ; preds = %78
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %80
+ThrowNullRef26:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %95
+ThrowNullRef28:                                   ; preds = %95
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11936,15 +13645,15 @@ entry:
   %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = load i64, i64 addrspace(1)* %4
@@ -11962,7 +13671,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12012,35 +13721,35 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
   %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderNLS addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %7 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.EncoderNLS addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Text.Encoding addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.Encoding addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Text.EncoderNLS addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.EncoderNLS addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
   %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck8 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = load i64, i64 addrspace(1)* %16
@@ -12059,19 +13768,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12097,8 +13806,8 @@ entry:
   %this = alloca %System.Text.Encoding addrspace(1)*
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
@@ -12118,15 +13827,15 @@ entry:
   %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
   store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
   %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
   store i32 0, i32 addrspace(1)* %2
   %3 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, i32 0, i32 2
@@ -12136,15 +13845,15 @@ entry:
 
 ; <label>:8                                       ; preds = %4
   %9 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
   %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
   %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = load i64, i64 addrspace(1)* %13
@@ -12165,15 +13874,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12188,16 +13897,16 @@ entry:
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = load i32, i32* %arg1
   %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
   %7 = load i64, i64 addrspace(1)* %5
@@ -12215,7 +13924,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12252,8 +13961,8 @@ entry:
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
   %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
   %16 = load i64, i64 addrspace(1)* %14
@@ -12274,8 +13983,8 @@ entry:
   %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
   %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
   %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %31, null
-  br i1 %NullCheck2, label %32, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = load i64, i64 addrspace(1)* %31
@@ -12318,7 +14027,7 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12331,14 +14040,14 @@ entry:
   %this = alloca %System.Text.EncoderReplacementFallback addrspace(1)*
   store %System.Text.EncoderReplacementFallback addrspace(1)* %param0, %System.Text.EncoderReplacementFallback addrspace(1)** %this
   %0 = load %System.Text.EncoderReplacementFallback addrspace(1)*, %System.Text.EncoderReplacementFallback addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -12349,7 +14058,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12379,8 +14088,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
@@ -12412,8 +14121,8 @@ entry:
   %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
   store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
@@ -12425,8 +14134,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Threading.Tasks.Task addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %7)
@@ -12449,7 +14158,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12468,8 +14177,8 @@ entry:
   store i8 %param1, i8* %arg1
   store i8 %param2, i8* %arg2
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
@@ -12483,8 +14192,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1, %5
   %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 9
@@ -12515,8 +14224,8 @@ entry:
 
 ; <label>:25                                      ; preds = %8, %20
   %26 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %26, null
-  br i1 %NullCheck4, label %27, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %26, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %26, i32 0, i32 12
@@ -12527,22 +14236,22 @@ entry:
 
 ; <label>:32                                      ; preds = %27
   %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %33, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.IO.StreamWriter addrspace(1)* %33, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %32
   %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 12
   store i8 1, i8 addrspace(1)* %35
   %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
-  br i1 %NullCheck8, label %37, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
   %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
   %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck10 = icmp ne i64 addrspace(1)* %40, null
-  br i1 %NullCheck10, label %41, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64 addrspace(1)* %40, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i64, i64 addrspace(1)* %40
@@ -12556,8 +14265,8 @@ entry:
   %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
   store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
   %51 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %NullCheck12 = icmp ne %"System.Byte[]" addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Byte[]" addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %41
   %53 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %51, i32 0, i32 1
@@ -12569,16 +14278,16 @@ entry:
 
 ; <label>:58                                      ; preds = %52
   %59 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %59, null
-  br i1 %NullCheck14, label %60, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.IO.StreamWriter addrspace(1)* %59, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %60
 
 ; <label>:60                                      ; preds = %58
   %61 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %59, i32 0, i32 3
   %62 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
   %64 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %NullCheck16 = icmp ne %"System.Byte[]" addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %"System.Byte[]" addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %60
   %66 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %64, i32 0, i32 1
@@ -12586,8 +14295,8 @@ entry:
   %68 = zext i32 %67 to i64
   %69 = trunc i64 %68 to i32
   %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck18, label %71, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
   %72 = load i64, i64 addrspace(1)* %70
@@ -12603,29 +14312,29 @@ entry:
 
 ; <label>:80                                      ; preds = %27, %52, %71
   %81 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %81, null
-  br i1 %NullCheck20, label %82, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.IO.StreamWriter addrspace(1)* %81, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
 
 ; <label>:82                                      ; preds = %80
   %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %81, i32 0, i32 5
   %84 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %83, align 8
   %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.IO.StreamWriter addrspace(1)* %85, null
-  br i1 %NullCheck22, label %86, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.IO.StreamWriter addrspace(1)* %85, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %86
 
 ; <label>:86                                      ; preds = %82
   %87 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 7
   %88 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %87, align 8
   %89 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %89, null
-  br i1 %NullCheck24, label %90, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.StreamWriter addrspace(1)* %89, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %90
 
 ; <label>:90                                      ; preds = %86
   %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %89, i32 0, i32 9
   %92 = load i32, i32 addrspace(1)* %91, align 8
   %93 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.IO.StreamWriter addrspace(1)* %93, null
-  br i1 %NullCheck26, label %94, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.IO.StreamWriter addrspace(1)* %93, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %93, i32 0, i32 6
@@ -12633,8 +14342,8 @@ entry:
   %97 = load i8, i8* %arg2
   %98 = zext i8 %97 to i32
   %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
-  %NullCheck28 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck28, label %100, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
   %101 = load i64, i64 addrspace(1)* %99
@@ -12649,8 +14358,8 @@ entry:
   %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
   store i32 %110, i32* %loc1
   %111 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %111, null
-  br i1 %NullCheck30, label %112, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.IO.StreamWriter addrspace(1)* %111, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %112
 
 ; <label>:112                                     ; preds = %100
   %113 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %111, i32 0, i32 9
@@ -12661,23 +14370,23 @@ entry:
 
 ; <label>:116                                     ; preds = %112
   %117 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck32 = icmp ne %System.IO.StreamWriter addrspace(1)* %117, null
-  br i1 %NullCheck32, label %118, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.IO.StreamWriter addrspace(1)* %117, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %118
 
 ; <label>:118                                     ; preds = %116
   %119 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %117, i32 0, i32 3
   %120 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %119, align 8
   %121 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.IO.StreamWriter addrspace(1)* %121, null
-  br i1 %NullCheck34, label %122, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.IO.StreamWriter addrspace(1)* %121, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %122
 
 ; <label>:122                                     ; preds = %118
   %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
   %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
   %125 = load i32, i32* %loc1
   %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
-  %NullCheck36 = icmp ne i64 addrspace(1)* %126, null
-  br i1 %NullCheck36, label %127, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64 addrspace(1)* %126, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
   %128 = load i64, i64 addrspace(1)* %126
@@ -12699,15 +14408,15 @@ entry:
 
 ; <label>:140                                     ; preds = %136
   %141 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.IO.StreamWriter addrspace(1)* %141, null
-  br i1 %NullCheck38, label %142, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.IO.StreamWriter addrspace(1)* %141, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %142
 
 ; <label>:142                                     ; preds = %140
   %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
   %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
   %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
-  %NullCheck40 = icmp ne i64 addrspace(1)* %145, null
-  br i1 %NullCheck40, label %146, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i64 addrspace(1)* %145, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
   %147 = load i64, i64 addrspace(1)* %145
@@ -12728,83 +14437,83 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %25
+ThrowNullRef4:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %32
+ThrowNullRef6:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %37
+ThrowNullRef10:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %41
+ThrowNullRef12:                                   ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %58
+ThrowNullRef14:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %60
+ThrowNullRef16:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %65
+ThrowNullRef18:                                   ; preds = %65
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %80
+ThrowNullRef20:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %82
+ThrowNullRef22:                                   ; preds = %82
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %86
+ThrowNullRef24:                                   ; preds = %86
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %90
+ThrowNullRef26:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %94
+ThrowNullRef28:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %100
+ThrowNullRef30:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %116
+ThrowNullRef32:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %118
+ThrowNullRef34:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %122
+ThrowNullRef36:                                   ; preds = %122
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %140
+ThrowNullRef38:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %142
+ThrowNullRef40:                                   ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12871,8 +14580,8 @@ entry:
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %1 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
-  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
@@ -12880,8 +14589,8 @@ entry:
   %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
   %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
   %8 = load i64, i64 addrspace(1)* %6
@@ -12897,8 +14606,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %17, %System.IFormatProvider addrspace(1)* %16)
   %18 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %19 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %18, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.SyncTextWriter addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %7
   %21 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %18, i32 0, i32 4
@@ -12909,11 +14618,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12926,8 +14635,8 @@ entry:
   %this = alloca %System.IO.TextWriter addrspace(1)*
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.TextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
@@ -12937,8 +14646,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.Threading.Thread addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Threading.Thread addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %6)
@@ -12947,8 +14656,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1
   %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.TextWriter addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.TextWriter addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %11, i32 0, i32 2
@@ -12959,11 +14668,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13160,8 +14869,8 @@ entry:
   store i64 %param1, i64* %arg1
   store i8 0, i8* %loc1
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
@@ -13171,16 +14880,16 @@ entry:
   %5 = addrspacecast i8* %loc1 to i8 addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %4, i8 addrspace(1)* %5)
   %6 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.SyncTextWriter addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
   %10 = load i64, i64* %arg1
   %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
   %13 = load i64, i64 addrspace(1)* %11
@@ -13215,11 +14924,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13236,8 +14945,8 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load i64, i64* %arg1
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -13251,8 +14960,8 @@ entry:
   call void %11(%System.IO.TextWriter addrspace(1)* %0, i64 %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
   %15 = load i64, i64 addrspace(1)* %13
@@ -13270,7 +14979,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13288,8 +14997,8 @@ entry:
   %1 = addrspacecast i64* %arg1 to i64 addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -13304,8 +15013,8 @@ entry:
   %14 = bitcast i64 addrspace(1)* %1 to %System.Int64 addrspace(1)*
   %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Int64 addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Int64 addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
   %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
   %18 = load i64, i64 addrspace(1)* %16
@@ -13323,7 +15032,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13339,8 +15048,8 @@ entry:
   store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
   %0 = load %System.Int64 addrspace(1)*, %System.Int64 addrspace(1)** %this
   %1 = bitcast %System.Int64 addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load i64, i64 addrspace(1)* %1, align 8
@@ -13365,8 +15074,8 @@ entry:
   %loc0 = alloca %System.Globalization.NumberFormatInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 3
@@ -13376,8 +15085,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
@@ -13387,24 +15096,24 @@ entry:
   store %System.Globalization.NumberFormatInfo addrspace(1)* %10, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
   %11 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %7
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
   %15 = load i8, i8 addrspace(1)* %14, align 8
   %16 = zext i8 %15 to i32
   %17 = trunc i32 %16 to i8
-  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %11, null
-  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %11, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %13
   %19 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %11, i32 0, i32 29
   store i8 %17, i8 addrspace(1)* %19
   %20 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %21 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %20, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %20, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %18
   %23 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %20, i32 0, i32 3
@@ -13413,8 +15122,8 @@ entry:
 
 ; <label>:24                                      ; preds = %1, %22
   %25 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %25, null
-  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %25, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %26
 
 ; <label>:26                                      ; preds = %24
   %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %25, i32 0, i32 3
@@ -13425,23 +15134,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %18
+ThrowNullRef8:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13466,168 +15175,168 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 18
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %8, align 8
-  %NullCheck2 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %5, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %5, i32 0, i32 4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %9)
   %12 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 19
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %15, align 8
-  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %12, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %12, i32 0, i32 5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %16)
   %19 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %20 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %20, null
-  br i1 %NullCheck8, label %21, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %20, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %20, i32 0, i32 23
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  %NullCheck10 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %19, null
-  br i1 %NullCheck10, label %24, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %19, i32 0, i32 7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %25, %System.String addrspace(1)* %23)
   %26 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %27 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %27, i32 0, i32 22
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %29, align 8
-  %NullCheck14 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %26, null
-  br i1 %NullCheck14, label %31, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %26, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %26, i32 0, i32 6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %32, %System.String addrspace(1)* %30)
   %33 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %34 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Globalization.CultureData addrspace(1)* %34, null
-  br i1 %NullCheck16, label %35, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Globalization.CultureData addrspace(1)* %34, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %34, i32 0, i32 51
   %37 = load i32, i32 addrspace(1)* %36, align 8
-  %NullCheck18 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %33, null
-  br i1 %NullCheck18, label %38, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %33, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %33, i32 0, i32 21
   store i32 %37, i32 addrspace(1)* %39
   %40 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %41 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Globalization.CultureData addrspace(1)* %41, null
-  br i1 %NullCheck20, label %42, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Globalization.CultureData addrspace(1)* %41, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %41, i32 0, i32 52
   %44 = load i32, i32 addrspace(1)* %43, align 8
-  %NullCheck22 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %40, null
-  br i1 %NullCheck22, label %45, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %40, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %40, i32 0, i32 25
   store i32 %44, i32 addrspace(1)* %46
   %47 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %48 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.Globalization.CultureData addrspace(1)* %48, null
-  br i1 %NullCheck24, label %49, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Globalization.CultureData addrspace(1)* %48, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %49
 
 ; <label>:49                                      ; preds = %45
   %50 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %48, i32 0, i32 29
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck26 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %47, null
-  br i1 %NullCheck26, label %52, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %47, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %47, i32 0, i32 10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %53, %System.String addrspace(1)* %51)
   %54 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %55 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Globalization.CultureData addrspace(1)* %55, null
-  br i1 %NullCheck28, label %56, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Globalization.CultureData addrspace(1)* %55, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %56
 
 ; <label>:56                                      ; preds = %52
   %57 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %55, i32 0, i32 35
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %57, align 8
-  %NullCheck30 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %54, null
-  br i1 %NullCheck30, label %59, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %54, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %54, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %60, %System.String addrspace(1)* %58)
   %61 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %62 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck32 = icmp ne %System.Globalization.CultureData addrspace(1)* %62, null
-  br i1 %NullCheck32, label %63, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Globalization.CultureData addrspace(1)* %62, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %62, i32 0, i32 34
   %65 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %64, align 8
-  %NullCheck34 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %61, null
-  br i1 %NullCheck34, label %66, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %61, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %61, i32 0, i32 9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %67, %System.String addrspace(1)* %65)
   %68 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %69 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck36 = icmp ne %System.Globalization.CultureData addrspace(1)* %69, null
-  br i1 %NullCheck36, label %70, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Globalization.CultureData addrspace(1)* %69, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %70
 
 ; <label>:70                                      ; preds = %66
   %71 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %69, i32 0, i32 55
   %72 = load i32, i32 addrspace(1)* %71, align 8
-  %NullCheck38 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %68, null
-  br i1 %NullCheck38, label %73, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %68, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %68, i32 0, i32 22
   store i32 %72, i32 addrspace(1)* %74
   %75 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %76 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck40 = icmp ne %System.Globalization.CultureData addrspace(1)* %76, null
-  br i1 %NullCheck40, label %77, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Globalization.CultureData addrspace(1)* %76, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %76, i32 0, i32 57
   %79 = load i32, i32 addrspace(1)* %78, align 8
-  %NullCheck42 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %75, null
-  br i1 %NullCheck42, label %80, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %75, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %80
 
 ; <label>:80                                      ; preds = %77
   %81 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %75, i32 0, i32 24
   store i32 %79, i32 addrspace(1)* %81
   %82 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %83 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck44 = icmp ne %System.Globalization.CultureData addrspace(1)* %83, null
-  br i1 %NullCheck44, label %84, label %ThrowNullRef43
+  %NullCheck43 = icmp eq %System.Globalization.CultureData addrspace(1)* %83, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %84
 
 ; <label>:84                                      ; preds = %80
   %85 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %83, i32 0, i32 56
   %86 = load i32, i32 addrspace(1)* %85, align 8
-  %NullCheck46 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %82, null
-  br i1 %NullCheck46, label %87, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %82, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %82, i32 0, i32 23
@@ -13636,8 +15345,8 @@ entry:
 
 ; <label>:89                                      ; preds = %entry
   %90 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck100 = icmp ne %System.Globalization.CultureData addrspace(1)* %90, null
-  br i1 %NullCheck100, label %91, label %ThrowNullRef99
+  %NullCheck99 = icmp eq %System.Globalization.CultureData addrspace(1)* %90, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %91
 
 ; <label>:91                                      ; preds = %89
   %92 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %90, i32 0, i32 2
@@ -13655,8 +15364,8 @@ entry:
   %102 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %103 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %104 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %103)
-  %NullCheck48 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %102, null
-  br i1 %NullCheck48, label %105, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %102, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %105
 
 ; <label>:105                                     ; preds = %101
   %106 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %102, i32 0, i32 1
@@ -13664,8 +15373,8 @@ entry:
   %107 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %108 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %109 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %108)
-  %NullCheck50 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %107, null
-  br i1 %NullCheck50, label %110, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %107, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %110
 
 ; <label>:110                                     ; preds = %105
   %111 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %107, i32 0, i32 2
@@ -13673,8 +15382,8 @@ entry:
   %112 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %113 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %114 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %113)
-  %NullCheck52 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %112, null
-  br i1 %NullCheck52, label %115, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %112, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %115
 
 ; <label>:115                                     ; preds = %110
   %116 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %112, i32 0, i32 27
@@ -13682,8 +15391,8 @@ entry:
   %117 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %118 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %119 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %118)
-  %NullCheck54 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %117, null
-  br i1 %NullCheck54, label %120, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %117, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %120
 
 ; <label>:120                                     ; preds = %115
   %121 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %117, i32 0, i32 26
@@ -13691,8 +15400,8 @@ entry:
   %122 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %123 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %124 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %123)
-  %NullCheck56 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %122, null
-  br i1 %NullCheck56, label %125, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %122, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %125
 
 ; <label>:125                                     ; preds = %120
   %126 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %122, i32 0, i32 17
@@ -13700,8 +15409,8 @@ entry:
   %127 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %128 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %129 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %128)
-  %NullCheck58 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %127, null
-  br i1 %NullCheck58, label %130, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %127, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %130
 
 ; <label>:130                                     ; preds = %125
   %131 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %127, i32 0, i32 18
@@ -13709,8 +15418,8 @@ entry:
   %132 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %133 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %134 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %133)
-  %NullCheck60 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %132, null
-  br i1 %NullCheck60, label %135, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %132, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %135
 
 ; <label>:135                                     ; preds = %130
   %136 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %132, i32 0, i32 14
@@ -13718,8 +15427,8 @@ entry:
   %137 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %138 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %139 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %138)
-  %NullCheck62 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %137, null
-  br i1 %NullCheck62, label %140, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %137, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %140
 
 ; <label>:140                                     ; preds = %135
   %141 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %137, i32 0, i32 13
@@ -13727,71 +15436,71 @@ entry:
   %142 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %143 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %144 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %143)
-  %NullCheck64 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %142, null
-  br i1 %NullCheck64, label %145, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %142, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %145
 
 ; <label>:145                                     ; preds = %140
   %146 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %142, i32 0, i32 12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %146, %System.String addrspace(1)* %144)
   %147 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %148 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck66 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %148, null
-  br i1 %NullCheck66, label %149, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %148, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %149
 
 ; <label>:149                                     ; preds = %145
   %150 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %148, i32 0, i32 21
   %151 = load i32, i32 addrspace(1)* %150, align 8
-  %NullCheck68 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %147, null
-  br i1 %NullCheck68, label %152, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %147, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %152
 
 ; <label>:152                                     ; preds = %149
   %153 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %147, i32 0, i32 28
   store i32 %151, i32 addrspace(1)* %153
   %154 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %155 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck70 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %155, null
-  br i1 %NullCheck70, label %156, label %ThrowNullRef69
+  %NullCheck69 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %155, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %156
 
 ; <label>:156                                     ; preds = %152
   %157 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %155, i32 0, i32 6
   %158 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %157, align 8
-  %NullCheck72 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %154, null
-  br i1 %NullCheck72, label %159, label %ThrowNullRef71
+  %NullCheck71 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %154, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %159
 
 ; <label>:159                                     ; preds = %156
   %160 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %154, i32 0, i32 15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %160, %System.String addrspace(1)* %158)
   %161 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %162 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck74 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %162, null
-  br i1 %NullCheck74, label %163, label %ThrowNullRef73
+  %NullCheck73 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %162, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %163
 
 ; <label>:163                                     ; preds = %159
   %164 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %162, i32 0, i32 1
   %165 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %164, align 8
-  %NullCheck76 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %161, null
-  br i1 %NullCheck76, label %166, label %ThrowNullRef75
+  %NullCheck75 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %161, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %166
 
 ; <label>:166                                     ; preds = %163
   %167 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %161, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %167, %"System.Int32[]" addrspace(1)* %165)
   %168 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %169 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck78 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %169, null
-  br i1 %NullCheck78, label %170, label %ThrowNullRef77
+  %NullCheck77 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %169, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %170
 
 ; <label>:170                                     ; preds = %166
   %171 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %169, i32 0, i32 7
   %172 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %171, align 8
-  %NullCheck80 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %168, null
-  br i1 %NullCheck80, label %173, label %ThrowNullRef79
+  %NullCheck79 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %168, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %173
 
 ; <label>:173                                     ; preds = %170
   %174 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %168, i32 0, i32 16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %174, %System.String addrspace(1)* %172)
   %175 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck82 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %175, null
-  br i1 %NullCheck82, label %176, label %ThrowNullRef81
+  %NullCheck81 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %175, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %176
 
 ; <label>:176                                     ; preds = %173
   %177 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %175, i32 0, i32 4
@@ -13801,14 +15510,14 @@ entry:
 
 ; <label>:180                                     ; preds = %176
   %181 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck84 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %181, null
-  br i1 %NullCheck84, label %182, label %ThrowNullRef83
+  %NullCheck83 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %181, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %182
 
 ; <label>:182                                     ; preds = %180
   %183 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %181, i32 0, i32 4
   %184 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %183, align 8
-  %NullCheck86 = icmp ne %System.String addrspace(1)* %184, null
-  br i1 %NullCheck86, label %185, label %ThrowNullRef85
+  %NullCheck85 = icmp eq %System.String addrspace(1)* %184, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %185
 
 ; <label>:185                                     ; preds = %182
   %186 = getelementptr inbounds %System.String, %System.String addrspace(1)* %184, i32 0, i32 1
@@ -13819,8 +15528,8 @@ entry:
 ; <label>:189                                     ; preds = %176, %185
   %190 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck98 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %190, null
-  br i1 %NullCheck98, label %192, label %ThrowNullRef97
+  %NullCheck97 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %190, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %192
 
 ; <label>:192                                     ; preds = %189
   %193 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %190, i32 0, i32 4
@@ -13829,8 +15538,8 @@ entry:
 
 ; <label>:194                                     ; preds = %185, %192
   %195 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck88 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %195, null
-  br i1 %NullCheck88, label %196, label %ThrowNullRef87
+  %NullCheck87 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %195, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %196
 
 ; <label>:196                                     ; preds = %194
   %197 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %195, i32 0, i32 9
@@ -13840,14 +15549,14 @@ entry:
 
 ; <label>:200                                     ; preds = %196
   %201 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck90 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %201, null
-  br i1 %NullCheck90, label %202, label %ThrowNullRef89
+  %NullCheck89 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %201, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %202
 
 ; <label>:202                                     ; preds = %200
   %203 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %201, i32 0, i32 9
   %204 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %203, align 8
-  %NullCheck92 = icmp ne %System.String addrspace(1)* %204, null
-  br i1 %NullCheck92, label %205, label %ThrowNullRef91
+  %NullCheck91 = icmp eq %System.String addrspace(1)* %204, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %205
 
 ; <label>:205                                     ; preds = %202
   %206 = getelementptr inbounds %System.String, %System.String addrspace(1)* %204, i32 0, i32 1
@@ -13858,14 +15567,14 @@ entry:
 ; <label>:209                                     ; preds = %196, %205
   %210 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %211 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck94 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %211, null
-  br i1 %NullCheck94, label %212, label %ThrowNullRef93
+  %NullCheck93 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %211, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %212
 
 ; <label>:212                                     ; preds = %209
   %213 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %211, i32 0, i32 6
   %214 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %213, align 8
-  %NullCheck96 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %210, null
-  br i1 %NullCheck96, label %215, label %ThrowNullRef95
+  %NullCheck95 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %210, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %215
 
 ; <label>:215                                     ; preds = %212
   %216 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %210, i32 0, i32 9
@@ -13879,203 +15588,203 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %17
+ThrowNullRef8:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %21
+ThrowNullRef10:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %24
+ThrowNullRef12:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %28
+ThrowNullRef14:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %31
+ThrowNullRef16:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %35
+ThrowNullRef18:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %38
+ThrowNullRef20:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %42
+ThrowNullRef22:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %45
+ThrowNullRef24:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %49
+ThrowNullRef26:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %52
+ThrowNullRef28:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %56
+ThrowNullRef30:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %59
+ThrowNullRef32:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %63
+ThrowNullRef34:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %66
+ThrowNullRef36:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %70
+ThrowNullRef38:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %73
+ThrowNullRef40:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %77
+ThrowNullRef42:                                   ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %80
+ThrowNullRef44:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %84
+ThrowNullRef46:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %101
+ThrowNullRef48:                                   ; preds = %101
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %105
+ThrowNullRef50:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %110
+ThrowNullRef52:                                   ; preds = %110
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %115
+ThrowNullRef54:                                   ; preds = %115
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %120
+ThrowNullRef56:                                   ; preds = %120
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %125
+ThrowNullRef58:                                   ; preds = %125
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %130
+ThrowNullRef60:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %135
+ThrowNullRef62:                                   ; preds = %135
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %140
+ThrowNullRef64:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %145
+ThrowNullRef66:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %149
+ThrowNullRef68:                                   ; preds = %149
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %152
+ThrowNullRef70:                                   ; preds = %152
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %156
+ThrowNullRef72:                                   ; preds = %156
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %159
+ThrowNullRef74:                                   ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %163
+ThrowNullRef76:                                   ; preds = %163
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %166
+ThrowNullRef78:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %170
+ThrowNullRef80:                                   ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %173
+ThrowNullRef82:                                   ; preds = %173
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %180
+ThrowNullRef84:                                   ; preds = %180
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %182
+ThrowNullRef86:                                   ; preds = %182
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %194
+ThrowNullRef88:                                   ; preds = %194
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %200
+ThrowNullRef90:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %202
+ThrowNullRef92:                                   ; preds = %202
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %209
+ThrowNullRef94:                                   ; preds = %209
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %212
+ThrowNullRef96:                                   ; preds = %212
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %189
+ThrowNullRef98:                                   ; preds = %189
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %89
+ThrowNullRef100:                                  ; preds = %89
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14103,8 +15812,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 21
@@ -14117,8 +15826,8 @@ entry:
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 16)
   %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 21
@@ -14127,8 +15836,8 @@ entry:
 
 ; <label>:12                                      ; preds = %1, %10
   %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 21
@@ -14139,11 +15848,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %12
+ThrowNullRef4:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14159,8 +15868,8 @@ entry:
   store i32 %param1, i32* %arg1
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %1 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
@@ -14227,8 +15936,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 33
@@ -14241,8 +15950,8 @@ entry:
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 24)
   %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 33
@@ -14251,8 +15960,8 @@ entry:
 
 ; <label>:12                                      ; preds = %1, %10
   %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 33
@@ -14263,11 +15972,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %12
+ThrowNullRef4:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14280,8 +15989,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 53
@@ -14293,8 +16002,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 116)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 53
@@ -14303,8 +16012,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 53
@@ -14315,11 +16024,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14348,8 +16057,8 @@ entry:
 
 ; <label>:7                                       ; preds = %entry, %4
   %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %7
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 2
@@ -14373,8 +16082,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 54
@@ -14386,8 +16095,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 117)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
@@ -14396,8 +16105,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 54
@@ -14408,11 +16117,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14425,8 +16134,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 27
@@ -14438,8 +16147,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 118)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 27
@@ -14448,8 +16157,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 27
@@ -14460,11 +16169,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14477,8 +16186,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 28
@@ -14490,8 +16199,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 119)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 28
@@ -14500,8 +16209,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 28
@@ -14512,11 +16221,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14529,8 +16238,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 26
@@ -14542,8 +16251,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 107)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 26
@@ -14552,8 +16261,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 26
@@ -14564,11 +16273,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14581,8 +16290,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 25
@@ -14594,8 +16303,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 106)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 25
@@ -14604,8 +16313,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 25
@@ -14616,11 +16325,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14633,8 +16342,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 24
@@ -14646,8 +16355,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 105)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 24
@@ -14656,8 +16365,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 24
@@ -14668,11 +16377,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14697,8 +16406,8 @@ entry:
   %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %3)
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %2
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -14709,15 +16418,15 @@ entry:
 
 ; <label>:8                                       ; preds = %62
   %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 9
   %12 = load i32, i32 addrspace(1)* %11, align 8
   %13 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.IO.StreamWriter addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %13, i32 0, i32 10
@@ -14732,15 +16441,15 @@ entry:
 
 ; <label>:20                                      ; preds = %14, %18
   %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
   %24 = load i32, i32 addrspace(1)* %23, align 8
   %25 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %25, null
-  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.StreamWriter addrspace(1)* %25, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %25, i32 0, i32 9
@@ -14761,36 +16470,36 @@ entry:
   %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %37 = load i32, i32* %loc1
   %38 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.StreamWriter addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %35
   %40 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %38, i32 0, i32 7
   %41 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %40, align 8
   %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
-  br i1 %NullCheck14, label %43, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %39
   %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 9
   %45 = load i32, i32 addrspace(1)* %44, align 8
   %46 = load i32, i32* %loc2
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %36, null
-  br i1 %NullCheck16, label %47, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %36, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %47
 
 ; <label>:47                                      ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %36, i32 %37, %"System.Char[]" addrspace(1)* %41, i32 %45, i32 %46)
   %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
   %51 = load i32, i32 addrspace(1)* %50, align 8
   %52 = load i32, i32* %loc2
   %53 = add i32 %51, %52
-  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
-  br i1 %NullCheck20, label %54, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %54
 
 ; <label>:54                                      ; preds = %49
   %55 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
@@ -14812,8 +16521,8 @@ entry:
 
 ; <label>:65                                      ; preds = %62
   %66 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %66, null
-  br i1 %NullCheck2, label %67, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %66, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %67
 
 ; <label>:67                                      ; preds = %65
   %68 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %66, i32 0, i32 11
@@ -14834,49 +16543,259 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %65
+ThrowNullRef2:                                    ; preds = %65
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %20
+ThrowNullRef8:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %22
+ThrowNullRef10:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %35
+ThrowNullRef12:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %43
+ThrowNullRef16:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %47
+ThrowNullRef18:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method String::CopyTo using LLILCJit
-Failed to read String.CopyTo[loadElemA]
+Successfully read String.CopyTo
+
+define void @String.CopyTo(%System.String addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  %loc1 = alloca i16 addrspace(1)*
+  %loc2 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %1 = icmp ne %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg4
+  %7 = icmp sge i32 %6, 0
+  br i1 %7, label %13, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  unreachable
+
+; <label>:13                                      ; preds = %5
+  %14 = load i32, i32* %arg1
+  %15 = icmp sge i32 %14, 0
+  br i1 %15, label %21, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %18)
+  %20 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %20, %System.String addrspace(1)* %17, %System.String addrspace(1)* %19)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %20) #0
+  unreachable
+
+; <label>:21                                      ; preds = %13
+  %22 = load i32, i32* %arg4
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck, label %ThrowNullRef, label %24
+
+; <label>:24                                      ; preds = %21
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load i32, i32* %arg1
+  %28 = sub i32 %26, %27
+  %29 = icmp sle i32 %22, %28
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34, %System.String addrspace(1)* %31, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %24
+  %36 = load i32, i32* %arg3
+  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %37, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
+
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
+  %40 = load i32, i32 addrspace(1)* %39
+  %41 = zext i32 %40 to i64
+  %42 = trunc i64 %41 to i32
+  %43 = load i32, i32* %arg4
+  %44 = sub i32 %42, %43
+  %45 = icmp sgt i32 %36, %44
+  br i1 %45, label %49, label %46
+
+; <label>:46                                      ; preds = %38
+  %47 = load i32, i32* %arg3
+  %48 = icmp sge i32 %47, 0
+  br i1 %48, label %54, label %49
+
+; <label>:49                                      ; preds = %38, %46
+  %50 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %52 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %51)
+  %53 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53, %System.String addrspace(1)* %50, %System.String addrspace(1)* %52)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53) #0
+  unreachable
+
+; <label>:54                                      ; preds = %46
+  %55 = load i32, i32* %arg4
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %97, label %57
+
+; <label>:57                                      ; preds = %54
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %59
+
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 2
+  %61 = bitcast [0 x i16] addrspace(1)* %60 to i16 addrspace(1)*
+  store i16 addrspace(1)* %61, i16 addrspace(1)** %loc0
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  store %"System.Char[]" addrspace(1)* %62, %"System.Char[]" addrspace(1)** %loc2
+  %63 = icmp eq %"System.Char[]" addrspace(1)* %62, null
+  br i1 %63, label %72, label %64
+
+; <label>:64                                      ; preds = %59
+  %65 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc2
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %65, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %66
+
+; <label>:66                                      ; preds = %64
+  %67 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %65, i32 0, i32 1
+  %68 = load i32, i32 addrspace(1)* %67
+  %69 = zext i32 %68 to i64
+  %70 = trunc i64 %69 to i32
+  %71 = icmp ne i32 %70, 0
+  br i1 %71, label %73, label %72
+
+; <label>:72                                      ; preds = %59, %66
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  br label %81
+
+; <label>:73                                      ; preds = %66
+  %74 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc2
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %74, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %75
+
+; <label>:75                                      ; preds = %73
+  %76 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %74, i32 0, i32 1
+  %77 = load i32, i32 addrspace(1)* %76
+  %78 = zext i32 %77 to i64
+  %BoundsCheck = icmp uge i64 0, %78
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %79
+
+; <label>:79                                      ; preds = %75
+  %80 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %74, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %80, i16 addrspace(1)** %loc1
+  br label %81
+
+; <label>:81                                      ; preds = %72, %79
+  %82 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %83 = ptrtoint i16 addrspace(1)* %82 to i64
+  %84 = load i32, i32* %arg3
+  %85 = sext i32 %84 to i64
+  %86 = mul i64 %85, 2
+  %87 = add i64 %83, %86
+  %88 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %89 = ptrtoint i16 addrspace(1)* %88 to i64
+  %90 = load i32, i32* %arg1
+  %91 = sext i32 %90 to i64
+  %92 = mul i64 %91, 2
+  %93 = add i64 %89, %92
+  %94 = load i32, i32* %arg4
+  %95 = inttoptr i64 %87 to i16*
+  %96 = inttoptr i64 %93 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %95, i16* %96, i32 %94)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  br label %97
+
+; <label>:97                                      ; preds = %54, %81
+  ret void
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
 Successfully read ConsoleEncoding.GetPreamble
 
@@ -14913,7 +16832,365 @@ entry:
 }
 
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[loadElemA]
+Successfully read EncoderNLS.GetBytes
+
+define i32 @EncoderNLS.GetBytes(%System.Text.EncoderNLS addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3, %"System.Byte[]" addrspace(1)* %param4, i32 %param5, i8 %param6) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %arg4 = alloca %"System.Byte[]" addrspace(1)*
+  %arg5 = alloca i32
+  %arg6 = alloca i8
+  %loc0 = alloca i32
+  %loc1 = alloca i16 addrspace(1)*
+  %loc2 = alloca i8 addrspace(1)*
+  %loc3 = alloca i32
+  %loc4 = alloca %"System.Char[]" addrspace(1)*
+  %loc5 = alloca %"System.Byte[]" addrspace(1)*
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  store %"System.Byte[]" addrspace(1)* %param4, %"System.Byte[]" addrspace(1)** %arg4
+  store i32 %param5, i32* %arg5
+  store i8 %param6, i8* %arg6
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %1 = icmp eq %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %17, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %7 = icmp eq %"System.Char[]" addrspace(1)* %6, null
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %12
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %12
+
+; <label>:12                                      ; preds = %8, %10
+  %13 = phi %System.String addrspace(1)* [ %9, %8 ], [ %11, %10 ]
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %14)
+  %16 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16, %System.String addrspace(1)* %13, %System.String addrspace(1)* %15)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16) #0
+  unreachable
+
+; <label>:17                                      ; preds = %2
+  %18 = load i32, i32* %arg2
+  %19 = icmp slt i32 %18, 0
+  br i1 %19, label %23, label %20
+
+; <label>:20                                      ; preds = %17
+  %21 = load i32, i32* %arg3
+  %22 = icmp sge i32 %21, 0
+  br i1 %22, label %35, label %23
+
+; <label>:23                                      ; preds = %17, %20
+  %24 = load i32, i32* %arg2
+  %25 = icmp slt i32 %24, 0
+  br i1 %25, label %28, label %26
+
+; <label>:26                                      ; preds = %23
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %30
+
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %30
+
+; <label>:30                                      ; preds = %26, %28
+  %31 = phi %System.String addrspace(1)* [ %27, %26 ], [ %29, %28 ]
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34, %System.String addrspace(1)* %31, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %20
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck, label %ThrowNullRef, label %37
+
+; <label>:37                                      ; preds = %35
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = load i32, i32* %arg2
+  %43 = sub i32 %41, %42
+  %44 = load i32, i32* %arg3
+  %45 = icmp sge i32 %43, %44
+  br i1 %45, label %51, label %46
+
+; <label>:46                                      ; preds = %37
+  %47 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %48 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %49 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %48)
+  %50 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %50, %System.String addrspace(1)* %47, %System.String addrspace(1)* %49)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %50) #0
+  unreachable
+
+; <label>:51                                      ; preds = %37
+  %52 = load i32, i32* %arg5
+  %53 = icmp slt i32 %52, 0
+  br i1 %53, label %63, label %54
+
+; <label>:54                                      ; preds = %51
+  %55 = load i32, i32* %arg5
+  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck1 = icmp eq %"System.Byte[]" addrspace(1)* %56, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %57
+
+; <label>:57                                      ; preds = %54
+  %58 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = zext i32 %59 to i64
+  %61 = trunc i64 %60 to i32
+  %62 = icmp sle i32 %55, %61
+  br i1 %62, label %68, label %63
+
+; <label>:63                                      ; preds = %51, %57
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %66 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %65)
+  %67 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %67, %System.String addrspace(1)* %64, %System.String addrspace(1)* %66)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %67) #0
+  unreachable
+
+; <label>:68                                      ; preds = %57
+  %69 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %69, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %69, i32 0, i32 1
+  %72 = load i32, i32 addrspace(1)* %71
+  %73 = zext i32 %72 to i64
+  %74 = trunc i64 %73 to i32
+  %75 = icmp ne i32 %74, 0
+  br i1 %75, label %78, label %76
+
+; <label>:76                                      ; preds = %70
+  %77 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1)
+  store %"System.Char[]" addrspace(1)* %77, %"System.Char[]" addrspace(1)** %arg1
+  br label %78
+
+; <label>:78                                      ; preds = %70, %76
+  %79 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck5 = icmp eq %"System.Byte[]" addrspace(1)* %79, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %80
+
+; <label>:80                                      ; preds = %78
+  %81 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %79, i32 0, i32 1
+  %82 = load i32, i32 addrspace(1)* %81
+  %83 = zext i32 %82 to i64
+  %84 = trunc i64 %83 to i32
+  %85 = load i32, i32* %arg5
+  %86 = sub i32 %84, %85
+  store i32 %86, i32* %loc0
+  %87 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck7 = icmp eq %"System.Byte[]" addrspace(1)* %87, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %88
+
+; <label>:88                                      ; preds = %80
+  %89 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %87, i32 0, i32 1
+  %90 = load i32, i32 addrspace(1)* %89
+  %91 = zext i32 %90 to i64
+  %92 = trunc i64 %91 to i32
+  %93 = icmp ne i32 %92, 0
+  br i1 %93, label %96, label %94
+
+; <label>:94                                      ; preds = %88
+  %95 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1)
+  store %"System.Byte[]" addrspace(1)* %95, %"System.Byte[]" addrspace(1)** %arg4
+  br label %96
+
+; <label>:96                                      ; preds = %88, %94
+  %97 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  store %"System.Char[]" addrspace(1)* %97, %"System.Char[]" addrspace(1)** %loc4
+  %98 = icmp eq %"System.Char[]" addrspace(1)* %97, null
+  br i1 %98, label %107, label %99
+
+; <label>:99                                      ; preds = %96
+  %100 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc4
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %100, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %101
+
+; <label>:101                                     ; preds = %99
+  %102 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %100, i32 0, i32 1
+  %103 = load i32, i32 addrspace(1)* %102
+  %104 = zext i32 %103 to i64
+  %105 = trunc i64 %104 to i32
+  %106 = icmp ne i32 %105, 0
+  br i1 %106, label %108, label %107
+
+; <label>:107                                     ; preds = %96, %101
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  br label %116
+
+; <label>:108                                     ; preds = %101
+  %109 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc4
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %109, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %110
+
+; <label>:110                                     ; preds = %108
+  %111 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %109, i32 0, i32 1
+  %112 = load i32, i32 addrspace(1)* %111
+  %113 = zext i32 %112 to i64
+  %BoundsCheck = icmp uge i64 0, %113
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %114
+
+; <label>:114                                     ; preds = %110
+  %115 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %109, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %115, i16 addrspace(1)** %loc1
+  br label %116
+
+; <label>:116                                     ; preds = %107, %114
+  %117 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  store %"System.Byte[]" addrspace(1)* %117, %"System.Byte[]" addrspace(1)** %loc5
+  %118 = icmp eq %"System.Byte[]" addrspace(1)* %117, null
+  br i1 %118, label %127, label %119
+
+; <label>:119                                     ; preds = %116
+  %120 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc5
+  %NullCheck13 = icmp eq %"System.Byte[]" addrspace(1)* %120, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %121
+
+; <label>:121                                     ; preds = %119
+  %122 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %120, i32 0, i32 1
+  %123 = load i32, i32 addrspace(1)* %122
+  %124 = zext i32 %123 to i64
+  %125 = trunc i64 %124 to i32
+  %126 = icmp ne i32 %125, 0
+  br i1 %126, label %128, label %127
+
+; <label>:127                                     ; preds = %116, %121
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc2
+  br label %136
+
+; <label>:128                                     ; preds = %121
+  %129 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc5
+  %NullCheck15 = icmp eq %"System.Byte[]" addrspace(1)* %129, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %130
+
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %129, i32 0, i32 1
+  %132 = load i32, i32 addrspace(1)* %131
+  %133 = zext i32 %132 to i64
+  %BoundsCheck17 = icmp uge i64 0, %133
+  br i1 %BoundsCheck17, label %ThrowIndexOutOfRange18, label %134
+
+; <label>:134                                     ; preds = %130
+  %135 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %129, i32 0, i32 3, i32 0
+  store i8 addrspace(1)* %135, i8 addrspace(1)** %loc2
+  br label %136
+
+; <label>:136                                     ; preds = %127, %134
+  %137 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %138 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %139 = ptrtoint i16 addrspace(1)* %138 to i64
+  %140 = load i32, i32* %arg2
+  %141 = sext i32 %140 to i64
+  %142 = mul i64 %141, 2
+  %143 = add i64 %139, %142
+  %144 = load i32, i32* %arg3
+  %145 = load i8 addrspace(1)*, i8 addrspace(1)** %loc2
+  %146 = ptrtoint i8 addrspace(1)* %145 to i64
+  %147 = load i32, i32* %arg5
+  %148 = sext i32 %147 to i64
+  %149 = add i64 %146, %148
+  %150 = load i32, i32* %loc0
+  %151 = load i8, i8* %arg6
+  %152 = zext i8 %151 to i32
+  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i64 addrspace(1)*
+  %NullCheck19 = icmp eq i64 addrspace(1)* %153, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %154
+
+; <label>:154                                     ; preds = %136
+  %155 = load i64, i64 addrspace(1)* %153
+  %156 = add i64 %155, 72
+  %157 = inttoptr i64 %156 to i64*
+  %158 = load i64, i64* %157
+  %159 = add i64 %158, 0
+  %160 = inttoptr i64 %159 to i64*
+  %161 = load i64, i64* %160
+  %162 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to %System.Text.Encoder addrspace(1)*
+  %163 = inttoptr i64 %143 to i16*
+  %164 = inttoptr i64 %149 to i8*
+  %165 = trunc i32 %152 to i8
+  %166 = inttoptr i64 %161 to i32 (%System.Text.Encoder addrspace(1)*, i16*, i32, i8*, i32, i8)*
+  %167 = call i32 %166(%System.Text.Encoder addrspace(1)* %162, i16* %163, i32 %144, i8* %164, i32 %150, i8 %165)
+  store i32 %167, i32* %loc3
+  br label %168
+
+; <label>:168                                     ; preds = %154
+  %169 = load i32, i32* %loc3
+  ret i32 %169
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %110
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %119
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange18:                           ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
 Successfully read EncoderNLS.GetBytes
 
@@ -15002,22 +17279,22 @@ entry:
   %40 = load i8, i8* %arg5
   %41 = zext i8 %40 to i32
   %42 = trunc i32 %41 to i8
-  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %39, null
-  br i1 %NullCheck, label %43, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderNLS addrspace(1)* %39, null
+  br i1 %NullCheck, label %ThrowNullRef, label %43
 
 ; <label>:43                                      ; preds = %38
   %44 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
   store i8 %42, i8 addrspace(1)* %44
   %45 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %45, null
-  br i1 %NullCheck2, label %46, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.EncoderNLS addrspace(1)* %45, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %46
 
 ; <label>:46                                      ; preds = %43
   %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %45, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %47
   %48 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.EncoderNLS addrspace(1)* %48, null
-  br i1 %NullCheck4, label %49, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.EncoderNLS addrspace(1)* %48, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %49
 
 ; <label>:49                                      ; preds = %46
   %50 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %48, i32 0, i32 3
@@ -15028,8 +17305,8 @@ entry:
   %55 = load i32, i32* %arg4
   %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck6, label %58, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
   %59 = load i64, i64 addrspace(1)* %57
@@ -15047,15 +17324,15 @@ ThrowNullRef:                                     ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %43
+ThrowNullRef2:                                    ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %46
+ThrowNullRef4:                                    ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %49
+ThrowNullRef6:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -15083,8 +17360,8 @@ entry:
   %4 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0 to %System.IO.ConsoleStream addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*)(%System.IO.ConsoleStream addrspace(1)* %4, %"System.Byte[]" addrspace(1)* %1, i32 %2, i32 %3)
   %5 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
@@ -15169,8 +17446,8 @@ entry:
 
 ; <label>:22                                      ; preds = %8
   %23 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %23, null
-  br i1 %NullCheck, label %24, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Byte[]" addrspace(1)* %23, null
+  br i1 %NullCheck, label %ThrowNullRef, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
@@ -15192,8 +17469,8 @@ entry:
 
 ; <label>:36                                      ; preds = %24
   %37 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %37, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.ConsoleStream addrspace(1)* %37, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %37, i32 0, i32 4
@@ -15214,13 +17491,138 @@ ThrowNullRef:                                     ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %36
+ThrowNullRef2:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
-Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
+Successfully read WindowsConsoleStream.WriteFileNative
+
+define i32 @WindowsConsoleStream.WriteFileNative(i64 %param0, %"System.Byte[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i64
+  %arg1 = alloca %"System.Byte[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i8 addrspace(1)*
+  %loc2 = alloca %"System.Byte[]" addrspace(1)*
+  %loc3 = alloca i32
+  store i64 %param0, i64* %arg0
+  store %"System.Byte[]" addrspace(1)* %param1, %"System.Byte[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Byte[]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = zext i32 %3 to i64
+  %5 = icmp ne i64 %4, 0
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %1
+  ret i32 0
+
+; <label>:7                                       ; preds = %1
+  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  store %"System.Byte[]" addrspace(1)* %8, %"System.Byte[]" addrspace(1)** %loc2
+  %9 = icmp eq %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %9, label %18, label %10
+
+; <label>:10                                      ; preds = %7
+  %11 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc2
+  %NullCheck1 = icmp eq %"System.Byte[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %11, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp ne i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %7, %12
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc1
+  br label %27
+
+; <label>:19                                      ; preds = %12
+  %20 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc2
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %20, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %BoundsCheck = icmp uge i64 0, %24
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %25
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %20, i32 0, i32 3, i32 0
+  store i8 addrspace(1)* %26, i8 addrspace(1)** %loc1
+  br label %27
+
+; <label>:27                                      ; preds = %18, %25
+  %28 = load i64, i64* %arg0
+  %29 = load i8 addrspace(1)*, i8 addrspace(1)** %loc1
+  %30 = ptrtoint i8 addrspace(1)* %29 to i64
+  %31 = load i32, i32* %arg2
+  %32 = sext i32 %31 to i64
+  %33 = add i64 %30, %32
+  %34 = load i32, i32* %arg3
+  %35 = addrspacecast i32* %loc3 to i32 addrspace(1)*
+  %36 = inttoptr i64 %33 to i8*
+  %37 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i8*, i32, i32 addrspace(1)*, i64)*)(i64 %28, i8* %36, i32 %34, i32 addrspace(1)* %35, i64 0)
+  %38 = icmp ugt i32 %37, 0
+  %39 = sext i1 %38 to i32
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc1
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %42, label %41
+
+; <label>:41                                      ; preds = %27
+  ret i32 0
+
+; <label>:42                                      ; preds = %27
+  %43 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  store i32 %43, i32* %loc0
+  %44 = load i32, i32* %loc0
+  %45 = icmp eq i32 %44, 232
+  br i1 %45, label %49, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = load i32, i32* %loc0
+  %48 = icmp ne i32 %47, 109
+  br i1 %48, label %50, label %49
+
+; <label>:49                                      ; preds = %42, %46
+  ret i32 0
+
+; <label>:50                                      ; preds = %46
+  %51 = load i32, i32* %loc0
+  ret i32 %51
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
 Successfully read WindowsConsoleStream.Flush
 
@@ -15229,8 +17631,8 @@ entry:
   %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
   store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
@@ -15265,8 +17667,8 @@ entry:
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
   %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load i64, i64 addrspace(1)* %1
@@ -15305,15 +17707,15 @@ entry:
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.TextWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
   %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %3, align 8
   %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
   %7 = load i64, i64 addrspace(1)* %5
@@ -15331,7 +17733,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -15360,8 +17762,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %4)
   store i32 0, i32* %loc0
   %5 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Char[]" addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
@@ -15373,15 +17775,15 @@ entry:
 
 ; <label>:11                                      ; preds = %69
   %12 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %12, i32 0, i32 9
   %15 = load i32, i32 addrspace(1)* %14, align 8
   %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.IO.StreamWriter addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %16, i32 0, i32 10
@@ -15396,15 +17798,15 @@ entry:
 
 ; <label>:23                                      ; preds = %17, %21
   %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %24, null
-  br i1 %NullCheck8, label %25, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %24, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 10
   %27 = load i32, i32 addrspace(1)* %26, align 8
   %28 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %28, null
-  br i1 %NullCheck10, label %29, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.StreamWriter addrspace(1)* %28, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %28, i32 0, i32 9
@@ -15426,15 +17828,15 @@ entry:
   %40 = load i32, i32* %loc0
   %41 = mul i32 %40, 2
   %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
-  br i1 %NullCheck12, label %43, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %43
 
 ; <label>:43                                      ; preds = %38
   %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 7
   %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %44, align 8
   %46 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %46, null
-  br i1 %NullCheck14, label %47, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.IO.StreamWriter addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %47
 
 ; <label>:47                                      ; preds = %43
   %48 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %46, i32 0, i32 9
@@ -15446,16 +17848,16 @@ entry:
   %54 = bitcast %"System.Char[]" addrspace(1)* %45 to %System.Array addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %53, i32 %41, %System.Array addrspace(1)* %54, i32 %50, i32 %52)
   %55 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
-  br i1 %NullCheck16, label %56, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %56
 
 ; <label>:56                                      ; preds = %47
   %57 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
   %58 = load i32, i32 addrspace(1)* %57, align 8
   %59 = load i32, i32* %loc2
   %60 = add i32 %58, %59
-  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
-  br i1 %NullCheck18, label %61, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %61
 
 ; <label>:61                                      ; preds = %56
   %62 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
@@ -15477,8 +17879,8 @@ entry:
 
 ; <label>:72                                      ; preds = %69
   %73 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %73, null
-  br i1 %NullCheck2, label %74, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %73, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %74
 
 ; <label>:74                                      ; preds = %72
   %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %73, i32 0, i32 11
@@ -15499,39 +17901,39 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %72
+ThrowNullRef2:                                    ; preds = %72
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %23
+ThrowNullRef8:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef10:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %43
+ThrowNullRef14:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %47
+ThrowNullRef16:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %56
+ThrowNullRef18:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -15570,8 +17972,8 @@ entry:
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load i32, i32* %arg0
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -15603,8 +18005,8 @@ entry:
   store i32 %param1, i32* %arg1
   store i8 0, i8* %loc1
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
@@ -15614,16 +18016,16 @@ entry:
   %5 = addrspacecast i8* %loc1 to i8 addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %4, i8 addrspace(1)* %5)
   %6 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.SyncTextWriter addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
   %10 = load i32, i32* %arg1
   %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
   %13 = load i64, i64 addrspace(1)* %11
@@ -15658,11 +18060,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -15679,8 +18081,8 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load i32, i32* %arg1
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -15694,8 +18096,8 @@ entry:
   call void %11(%System.IO.TextWriter addrspace(1)* %0, i32 %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
   %15 = load i64, i64 addrspace(1)* %13
@@ -15713,7 +18115,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -15731,8 +18133,8 @@ entry:
   %1 = addrspacecast i32* %arg1 to i32 addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -15747,8 +18149,8 @@ entry:
   %14 = bitcast i32 addrspace(1)* %1 to %System.Int32 addrspace(1)*
   %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Int32 addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Int32 addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
   %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
   %18 = load i64, i64 addrspace(1)* %16
@@ -15766,7 +18168,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -15782,8 +18184,8 @@ entry:
   store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
   %0 = load %System.Int32 addrspace(1)*, %System.Int32 addrspace(1)** %this
   %1 = bitcast %System.Int32 addrspace(1)* %0 to i32 addrspace(1)*
-  %NullCheck = icmp ne i32 addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq i32 addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load i32, i32 addrspace(1)* %1, align 8
@@ -15846,8 +18248,8 @@ entry:
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load i32, i32* %arg0
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -15879,8 +18281,8 @@ entry:
   store i32 %param1, i32* %arg1
   store i8 0, i8* %loc1
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
@@ -15890,16 +18292,16 @@ entry:
   %5 = addrspacecast i8* %loc1 to i8 addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %4, i8 addrspace(1)* %5)
   %6 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.SyncTextWriter addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
   %10 = load i32, i32* %arg1
   %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
   %13 = load i64, i64 addrspace(1)* %11
@@ -15934,11 +18336,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -15955,8 +18357,8 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load i32, i32* %arg1
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -15970,8 +18372,8 @@ entry:
   call void %11(%System.IO.TextWriter addrspace(1)* %0, i32 %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
   %15 = load i64, i64 addrspace(1)* %13
@@ -15989,7 +18391,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -16007,8 +18409,8 @@ entry:
   %1 = addrspacecast i32* %arg1 to i32 addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -16023,8 +18425,8 @@ entry:
   %14 = bitcast i32 addrspace(1)* %1 to %System.UInt32 addrspace(1)*
   %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.UInt32 addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.UInt32 addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
   %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
   %18 = load i64, i64 addrspace(1)* %16
@@ -16042,7 +18444,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -16058,8 +18460,8 @@ entry:
   store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
   %0 = load %System.UInt32 addrspace(1)*, %System.UInt32 addrspace(1)** %this
   %1 = bitcast %System.UInt32 addrspace(1)* %0 to i32 addrspace(1)*
-  %NullCheck = icmp ne i32 addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq i32 addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load i32, i32 addrspace(1)* %1, align 8

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrue1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrue1.error.txt
@@ -25,8 +25,8 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
@@ -40,8 +40,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
   %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
@@ -75,7 +75,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -90,8 +90,8 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %NullCheck = icmp ne i8 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = load i8, i8 addrspace(1)* %0, align 8
@@ -125,8 +125,8 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
@@ -159,8 +159,8 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -184,8 +184,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
   store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
@@ -195,8 +195,8 @@ entry:
 ; <label>:4                                       ; preds = %1
   %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
   %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
@@ -206,8 +206,8 @@ entry:
   %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
@@ -221,14 +221,14 @@ entry:
 
 ; <label>:17                                      ; preds = %14
   %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
   %21 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
@@ -238,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -249,8 +249,8 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
@@ -261,27 +261,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %30
+ThrowNullRef10:                                   ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -301,7 +301,89 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
-Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
+Successfully read AppDomainSetup.GetUnsecureApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.GetUnsecureApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %NullCheck = icmp eq %"System.String[]" addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %BoundsCheck = icmp uge i64 0, %5
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %6
+
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 3, i32 0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
+  ret %System.String addrspace(1)* %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_Value using LLILCJit
+Successfully read AppDomainSetup.get_Value
+
+define %"System.String[]" addrspace(1)* @AppDomainSetup.get_Value(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.String[]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 18)
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.String[]" addrspace(1)* addrspace(1)*, %"System.String[]" addrspace(1)*)*)(%"System.String[]" addrspace(1)* addrspace(1)* %9, %"System.String[]" addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %11, i32 0, i32 1
+  %14 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %13, align 8
+  ret %"System.String[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -319,8 +401,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -368,16 +450,16 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
   %5 = load i32, i32 addrspace(1)* %4
   %6 = sub i32 %5, 1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -389,7 +471,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -421,8 +503,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
@@ -456,8 +538,8 @@ entry:
 ; <label>:27                                      ; preds = %19
   %28 = load i32, i32* %arg1
   %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
-  br i1 %NullCheck2, label %30, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %29, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %30
 
 ; <label>:30                                      ; preds = %27
   %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
@@ -493,8 +575,8 @@ entry:
 ; <label>:49                                      ; preds = %46
   %50 = load i32, i32* %arg2
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck4, label %52, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
@@ -517,11 +599,11 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %27
+ThrowNullRef2:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %49
+ThrowNullRef4:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -544,16 +626,16 @@ entry:
   %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %0)
   store %System.String addrspace(1)* %1, %System.String addrspace(1)** %loc0
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 2
   %5 = bitcast [0 x i16] addrspace(1)* %4 to i16 addrspace(1)*
   store i16 addrspace(1)* %5, i16 addrspace(1)** %loc1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %3
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2
@@ -580,7 +662,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -691,15 +773,15 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %NullCheck132 = icmp ne i8* %21, null
-  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+  %NullCheck131 = icmp eq i8* %21, null
+  br i1 %NullCheck131, label %ThrowNullRef132, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = load i8, i8* %21, align 8
   %24 = zext i8 %23 to i32
   %25 = trunc i32 %24 to i8
-  %NullCheck134 = icmp ne i8* %20, null
-  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+  %NullCheck133 = icmp eq i8* %20, null
+  br i1 %NullCheck133, label %ThrowNullRef134, label %26
 
 ; <label>:26                                      ; preds = %22
   store i8 %25, i8* %20, align 8
@@ -709,16 +791,16 @@ entry:
   %28 = load i8*, i8** %arg0
   %29 = load i8*, i8** %arg1
   %30 = bitcast i8* %29 to i16*
-  %NullCheck128 = icmp ne i16* %30, null
-  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+  %NullCheck127 = icmp eq i16* %30, null
+  br i1 %NullCheck127, label %ThrowNullRef128, label %31
 
 ; <label>:31                                      ; preds = %27
   %32 = load i16, i16* %30, align 8
   %33 = sext i16 %32 to i32
   %34 = bitcast i8* %28 to i16*
   %35 = trunc i32 %33 to i16
-  %NullCheck130 = icmp ne i16* %34, null
-  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+  %NullCheck129 = icmp eq i16* %34, null
+  br i1 %NullCheck129, label %ThrowNullRef130, label %36
 
 ; <label>:36                                      ; preds = %31
   store i16 %35, i16* %34, align 8
@@ -728,16 +810,16 @@ entry:
   %38 = load i8*, i8** %arg0
   %39 = load i8*, i8** %arg1
   %40 = bitcast i8* %39 to i16*
-  %NullCheck120 = icmp ne i16* %40, null
-  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+  %NullCheck119 = icmp eq i16* %40, null
+  br i1 %NullCheck119, label %ThrowNullRef120, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i16, i16* %40, align 8
   %43 = sext i16 %42 to i32
   %44 = bitcast i8* %38 to i16*
   %45 = trunc i32 %43 to i16
-  %NullCheck122 = icmp ne i16* %44, null
-  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+  %NullCheck121 = icmp eq i16* %44, null
+  br i1 %NullCheck121, label %ThrowNullRef122, label %46
 
 ; <label>:46                                      ; preds = %41
   store i16 %45, i16* %44, align 8
@@ -745,15 +827,15 @@ entry:
   %48 = getelementptr inbounds i8, i8* %47, i64 2
   %49 = load i8*, i8** %arg1
   %50 = getelementptr inbounds i8, i8* %49, i64 2
-  %NullCheck124 = icmp ne i8* %50, null
-  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+  %NullCheck123 = icmp eq i8* %50, null
+  br i1 %NullCheck123, label %ThrowNullRef124, label %51
 
 ; <label>:51                                      ; preds = %46
   %52 = load i8, i8* %50, align 8
   %53 = zext i8 %52 to i32
   %54 = trunc i32 %53 to i8
-  %NullCheck126 = icmp ne i8* %48, null
-  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+  %NullCheck125 = icmp eq i8* %48, null
+  br i1 %NullCheck125, label %ThrowNullRef126, label %55
 
 ; <label>:55                                      ; preds = %51
   store i8 %54, i8* %48, align 8
@@ -763,14 +845,14 @@ entry:
   %57 = load i8*, i8** %arg0
   %58 = load i8*, i8** %arg1
   %59 = bitcast i8* %58 to i32*
-  %NullCheck116 = icmp ne i32* %59, null
-  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+  %NullCheck115 = icmp eq i32* %59, null
+  br i1 %NullCheck115, label %ThrowNullRef116, label %60
 
 ; <label>:60                                      ; preds = %56
   %61 = load i32, i32* %59, align 8
   %62 = bitcast i8* %57 to i32*
-  %NullCheck118 = icmp ne i32* %62, null
-  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+  %NullCheck117 = icmp eq i32* %62, null
+  br i1 %NullCheck117, label %ThrowNullRef118, label %63
 
 ; <label>:63                                      ; preds = %60
   store i32 %61, i32* %62, align 8
@@ -780,14 +862,14 @@ entry:
   %65 = load i8*, i8** %arg0
   %66 = load i8*, i8** %arg1
   %67 = bitcast i8* %66 to i32*
-  %NullCheck108 = icmp ne i32* %67, null
-  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+  %NullCheck107 = icmp eq i32* %67, null
+  br i1 %NullCheck107, label %ThrowNullRef108, label %68
 
 ; <label>:68                                      ; preds = %64
   %69 = load i32, i32* %67, align 8
   %70 = bitcast i8* %65 to i32*
-  %NullCheck110 = icmp ne i32* %70, null
-  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+  %NullCheck109 = icmp eq i32* %70, null
+  br i1 %NullCheck109, label %ThrowNullRef110, label %71
 
 ; <label>:71                                      ; preds = %68
   store i32 %69, i32* %70, align 8
@@ -795,15 +877,15 @@ entry:
   %73 = getelementptr inbounds i8, i8* %72, i64 4
   %74 = load i8*, i8** %arg1
   %75 = getelementptr inbounds i8, i8* %74, i64 4
-  %NullCheck112 = icmp ne i8* %75, null
-  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+  %NullCheck111 = icmp eq i8* %75, null
+  br i1 %NullCheck111, label %ThrowNullRef112, label %76
 
 ; <label>:76                                      ; preds = %71
   %77 = load i8, i8* %75, align 8
   %78 = zext i8 %77 to i32
   %79 = trunc i32 %78 to i8
-  %NullCheck114 = icmp ne i8* %73, null
-  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+  %NullCheck113 = icmp eq i8* %73, null
+  br i1 %NullCheck113, label %ThrowNullRef114, label %80
 
 ; <label>:80                                      ; preds = %76
   store i8 %79, i8* %73, align 8
@@ -813,14 +895,14 @@ entry:
   %82 = load i8*, i8** %arg0
   %83 = load i8*, i8** %arg1
   %84 = bitcast i8* %83 to i32*
-  %NullCheck100 = icmp ne i32* %84, null
-  br i1 %NullCheck100, label %85, label %ThrowNullRef99
+  %NullCheck99 = icmp eq i32* %84, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %85
 
 ; <label>:85                                      ; preds = %81
   %86 = load i32, i32* %84, align 8
   %87 = bitcast i8* %82 to i32*
-  %NullCheck102 = icmp ne i32* %87, null
-  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+  %NullCheck101 = icmp eq i32* %87, null
+  br i1 %NullCheck101, label %ThrowNullRef102, label %88
 
 ; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
@@ -829,16 +911,16 @@ entry:
   %91 = load i8*, i8** %arg1
   %92 = getelementptr inbounds i8, i8* %91, i64 4
   %93 = bitcast i8* %92 to i16*
-  %NullCheck104 = icmp ne i16* %93, null
-  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+  %NullCheck103 = icmp eq i16* %93, null
+  br i1 %NullCheck103, label %ThrowNullRef104, label %94
 
 ; <label>:94                                      ; preds = %88
   %95 = load i16, i16* %93, align 8
   %96 = sext i16 %95 to i32
   %97 = bitcast i8* %90 to i16*
   %98 = trunc i32 %96 to i16
-  %NullCheck106 = icmp ne i16* %97, null
-  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+  %NullCheck105 = icmp eq i16* %97, null
+  br i1 %NullCheck105, label %ThrowNullRef106, label %99
 
 ; <label>:99                                      ; preds = %94
   store i16 %98, i16* %97, align 8
@@ -848,14 +930,14 @@ entry:
   %101 = load i8*, i8** %arg0
   %102 = load i8*, i8** %arg1
   %103 = bitcast i8* %102 to i32*
-  %NullCheck88 = icmp ne i32* %103, null
-  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+  %NullCheck87 = icmp eq i32* %103, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %104
 
 ; <label>:104                                     ; preds = %100
   %105 = load i32, i32* %103, align 8
   %106 = bitcast i8* %101 to i32*
-  %NullCheck90 = icmp ne i32* %106, null
-  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+  %NullCheck89 = icmp eq i32* %106, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %107
 
 ; <label>:107                                     ; preds = %104
   store i32 %105, i32* %106, align 8
@@ -864,16 +946,16 @@ entry:
   %110 = load i8*, i8** %arg1
   %111 = getelementptr inbounds i8, i8* %110, i64 4
   %112 = bitcast i8* %111 to i16*
-  %NullCheck92 = icmp ne i16* %112, null
-  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+  %NullCheck91 = icmp eq i16* %112, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %113
 
 ; <label>:113                                     ; preds = %107
   %114 = load i16, i16* %112, align 8
   %115 = sext i16 %114 to i32
   %116 = bitcast i8* %109 to i16*
   %117 = trunc i32 %115 to i16
-  %NullCheck94 = icmp ne i16* %116, null
-  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+  %NullCheck93 = icmp eq i16* %116, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %118
 
 ; <label>:118                                     ; preds = %113
   store i16 %117, i16* %116, align 8
@@ -881,15 +963,15 @@ entry:
   %120 = getelementptr inbounds i8, i8* %119, i64 6
   %121 = load i8*, i8** %arg1
   %122 = getelementptr inbounds i8, i8* %121, i64 6
-  %NullCheck96 = icmp ne i8* %122, null
-  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+  %NullCheck95 = icmp eq i8* %122, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %123
 
 ; <label>:123                                     ; preds = %118
   %124 = load i8, i8* %122, align 8
   %125 = zext i8 %124 to i32
   %126 = trunc i32 %125 to i8
-  %NullCheck98 = icmp ne i8* %120, null
-  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+  %NullCheck97 = icmp eq i8* %120, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %127
 
 ; <label>:127                                     ; preds = %123
   store i8 %126, i8* %120, align 8
@@ -899,14 +981,14 @@ entry:
   %129 = load i8*, i8** %arg0
   %130 = load i8*, i8** %arg1
   %131 = bitcast i8* %130 to i64*
-  %NullCheck84 = icmp ne i64* %131, null
-  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+  %NullCheck83 = icmp eq i64* %131, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %132
 
 ; <label>:132                                     ; preds = %128
   %133 = load i64, i64* %131, align 8
   %134 = bitcast i8* %129 to i64*
-  %NullCheck86 = icmp ne i64* %134, null
-  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+  %NullCheck85 = icmp eq i64* %134, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %135
 
 ; <label>:135                                     ; preds = %132
   store i64 %133, i64* %134, align 8
@@ -916,14 +998,14 @@ entry:
   %137 = load i8*, i8** %arg0
   %138 = load i8*, i8** %arg1
   %139 = bitcast i8* %138 to i64*
-  %NullCheck76 = icmp ne i64* %139, null
-  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+  %NullCheck75 = icmp eq i64* %139, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %140
 
 ; <label>:140                                     ; preds = %136
   %141 = load i64, i64* %139, align 8
   %142 = bitcast i8* %137 to i64*
-  %NullCheck78 = icmp ne i64* %142, null
-  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+  %NullCheck77 = icmp eq i64* %142, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %143
 
 ; <label>:143                                     ; preds = %140
   store i64 %141, i64* %142, align 8
@@ -931,15 +1013,15 @@ entry:
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %NullCheck80 = icmp ne i8* %147, null
-  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+  %NullCheck79 = icmp eq i8* %147, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %148
 
 ; <label>:148                                     ; preds = %143
   %149 = load i8, i8* %147, align 8
   %150 = zext i8 %149 to i32
   %151 = trunc i32 %150 to i8
-  %NullCheck82 = icmp ne i8* %145, null
-  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+  %NullCheck81 = icmp eq i8* %145, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %152
 
 ; <label>:152                                     ; preds = %148
   store i8 %151, i8* %145, align 8
@@ -949,14 +1031,14 @@ entry:
   %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
   %156 = bitcast i8* %155 to i64*
-  %NullCheck68 = icmp ne i64* %156, null
-  br i1 %NullCheck68, label %157, label %ThrowNullRef67
+  %NullCheck67 = icmp eq i64* %156, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %157
 
 ; <label>:157                                     ; preds = %153
   %158 = load i64, i64* %156, align 8
   %159 = bitcast i8* %154 to i64*
-  %NullCheck70 = icmp ne i64* %159, null
-  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+  %NullCheck69 = icmp eq i64* %159, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %160
 
 ; <label>:160                                     ; preds = %157
   store i64 %158, i64* %159, align 8
@@ -965,16 +1047,16 @@ entry:
   %163 = load i8*, i8** %arg1
   %164 = getelementptr inbounds i8, i8* %163, i64 8
   %165 = bitcast i8* %164 to i16*
-  %NullCheck72 = icmp ne i16* %165, null
-  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+  %NullCheck71 = icmp eq i16* %165, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %166
 
 ; <label>:166                                     ; preds = %160
   %167 = load i16, i16* %165, align 8
   %168 = sext i16 %167 to i32
   %169 = bitcast i8* %162 to i16*
   %170 = trunc i32 %168 to i16
-  %NullCheck74 = icmp ne i16* %169, null
-  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+  %NullCheck73 = icmp eq i16* %169, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %171
 
 ; <label>:171                                     ; preds = %166
   store i16 %170, i16* %169, align 8
@@ -984,14 +1066,14 @@ entry:
   %173 = load i8*, i8** %arg0
   %174 = load i8*, i8** %arg1
   %175 = bitcast i8* %174 to i64*
-  %NullCheck56 = icmp ne i64* %175, null
-  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+  %NullCheck55 = icmp eq i64* %175, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %176
 
 ; <label>:176                                     ; preds = %172
   %177 = load i64, i64* %175, align 8
   %178 = bitcast i8* %173 to i64*
-  %NullCheck58 = icmp ne i64* %178, null
-  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+  %NullCheck57 = icmp eq i64* %178, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %179
 
 ; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
@@ -1000,16 +1082,16 @@ entry:
   %182 = load i8*, i8** %arg1
   %183 = getelementptr inbounds i8, i8* %182, i64 8
   %184 = bitcast i8* %183 to i16*
-  %NullCheck60 = icmp ne i16* %184, null
-  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+  %NullCheck59 = icmp eq i16* %184, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %185
 
 ; <label>:185                                     ; preds = %179
   %186 = load i16, i16* %184, align 8
   %187 = sext i16 %186 to i32
   %188 = bitcast i8* %181 to i16*
   %189 = trunc i32 %187 to i16
-  %NullCheck62 = icmp ne i16* %188, null
-  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+  %NullCheck61 = icmp eq i16* %188, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %190
 
 ; <label>:190                                     ; preds = %185
   store i16 %189, i16* %188, align 8
@@ -1017,15 +1099,15 @@ entry:
   %192 = getelementptr inbounds i8, i8* %191, i64 10
   %193 = load i8*, i8** %arg1
   %194 = getelementptr inbounds i8, i8* %193, i64 10
-  %NullCheck64 = icmp ne i8* %194, null
-  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+  %NullCheck63 = icmp eq i8* %194, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %195
 
 ; <label>:195                                     ; preds = %190
   %196 = load i8, i8* %194, align 8
   %197 = zext i8 %196 to i32
   %198 = trunc i32 %197 to i8
-  %NullCheck66 = icmp ne i8* %192, null
-  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+  %NullCheck65 = icmp eq i8* %192, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %199
 
 ; <label>:199                                     ; preds = %195
   store i8 %198, i8* %192, align 8
@@ -1035,14 +1117,14 @@ entry:
   %201 = load i8*, i8** %arg0
   %202 = load i8*, i8** %arg1
   %203 = bitcast i8* %202 to i64*
-  %NullCheck48 = icmp ne i64* %203, null
-  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+  %NullCheck47 = icmp eq i64* %203, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %204
 
 ; <label>:204                                     ; preds = %200
   %205 = load i64, i64* %203, align 8
   %206 = bitcast i8* %201 to i64*
-  %NullCheck50 = icmp ne i64* %206, null
-  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+  %NullCheck49 = icmp eq i64* %206, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %207
 
 ; <label>:207                                     ; preds = %204
   store i64 %205, i64* %206, align 8
@@ -1051,14 +1133,14 @@ entry:
   %210 = load i8*, i8** %arg1
   %211 = getelementptr inbounds i8, i8* %210, i64 8
   %212 = bitcast i8* %211 to i32*
-  %NullCheck52 = icmp ne i32* %212, null
-  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+  %NullCheck51 = icmp eq i32* %212, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %213
 
 ; <label>:213                                     ; preds = %207
   %214 = load i32, i32* %212, align 8
   %215 = bitcast i8* %209 to i32*
-  %NullCheck54 = icmp ne i32* %215, null
-  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+  %NullCheck53 = icmp eq i32* %215, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %216
 
 ; <label>:216                                     ; preds = %213
   store i32 %214, i32* %215, align 8
@@ -1068,14 +1150,14 @@ entry:
   %218 = load i8*, i8** %arg0
   %219 = load i8*, i8** %arg1
   %220 = bitcast i8* %219 to i64*
-  %NullCheck36 = icmp ne i64* %220, null
-  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64* %220, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %221
 
 ; <label>:221                                     ; preds = %217
   %222 = load i64, i64* %220, align 8
   %223 = bitcast i8* %218 to i64*
-  %NullCheck38 = icmp ne i64* %223, null
-  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+  %NullCheck37 = icmp eq i64* %223, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %224
 
 ; <label>:224                                     ; preds = %221
   store i64 %222, i64* %223, align 8
@@ -1084,14 +1166,14 @@ entry:
   %227 = load i8*, i8** %arg1
   %228 = getelementptr inbounds i8, i8* %227, i64 8
   %229 = bitcast i8* %228 to i32*
-  %NullCheck40 = icmp ne i32* %229, null
-  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i32* %229, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %230
 
 ; <label>:230                                     ; preds = %224
   %231 = load i32, i32* %229, align 8
   %232 = bitcast i8* %226 to i32*
-  %NullCheck42 = icmp ne i32* %232, null
-  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+  %NullCheck41 = icmp eq i32* %232, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %233
 
 ; <label>:233                                     ; preds = %230
   store i32 %231, i32* %232, align 8
@@ -1099,15 +1181,15 @@ entry:
   %235 = getelementptr inbounds i8, i8* %234, i64 12
   %236 = load i8*, i8** %arg1
   %237 = getelementptr inbounds i8, i8* %236, i64 12
-  %NullCheck44 = icmp ne i8* %237, null
-  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i8* %237, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %238
 
 ; <label>:238                                     ; preds = %233
   %239 = load i8, i8* %237, align 8
   %240 = zext i8 %239 to i32
   %241 = trunc i32 %240 to i8
-  %NullCheck46 = icmp ne i8* %235, null
-  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+  %NullCheck45 = icmp eq i8* %235, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %242
 
 ; <label>:242                                     ; preds = %238
   store i8 %241, i8* %235, align 8
@@ -1117,14 +1199,14 @@ entry:
   %244 = load i8*, i8** %arg0
   %245 = load i8*, i8** %arg1
   %246 = bitcast i8* %245 to i64*
-  %NullCheck24 = icmp ne i64* %246, null
-  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64* %246, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %247
 
 ; <label>:247                                     ; preds = %243
   %248 = load i64, i64* %246, align 8
   %249 = bitcast i8* %244 to i64*
-  %NullCheck26 = icmp ne i64* %249, null
-  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64* %249, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %250
 
 ; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
@@ -1133,14 +1215,14 @@ entry:
   %253 = load i8*, i8** %arg1
   %254 = getelementptr inbounds i8, i8* %253, i64 8
   %255 = bitcast i8* %254 to i32*
-  %NullCheck28 = icmp ne i32* %255, null
-  br i1 %NullCheck28, label %256, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i32* %255, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %256
 
 ; <label>:256                                     ; preds = %250
   %257 = load i32, i32* %255, align 8
   %258 = bitcast i8* %252 to i32*
-  %NullCheck30 = icmp ne i32* %258, null
-  br i1 %NullCheck30, label %259, label %ThrowNullRef29
+  %NullCheck29 = icmp eq i32* %258, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %259
 
 ; <label>:259                                     ; preds = %256
   store i32 %257, i32* %258, align 8
@@ -1149,16 +1231,16 @@ entry:
   %262 = load i8*, i8** %arg1
   %263 = getelementptr inbounds i8, i8* %262, i64 12
   %264 = bitcast i8* %263 to i16*
-  %NullCheck32 = icmp ne i16* %264, null
-  br i1 %NullCheck32, label %265, label %ThrowNullRef31
+  %NullCheck31 = icmp eq i16* %264, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %265
 
 ; <label>:265                                     ; preds = %259
   %266 = load i16, i16* %264, align 8
   %267 = sext i16 %266 to i32
   %268 = bitcast i8* %261 to i16*
   %269 = trunc i32 %267 to i16
-  %NullCheck34 = icmp ne i16* %268, null
-  br i1 %NullCheck34, label %270, label %ThrowNullRef33
+  %NullCheck33 = icmp eq i16* %268, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %270
 
 ; <label>:270                                     ; preds = %265
   store i16 %269, i16* %268, align 8
@@ -1168,14 +1250,14 @@ entry:
   %272 = load i8*, i8** %arg0
   %273 = load i8*, i8** %arg1
   %274 = bitcast i8* %273 to i64*
-  %NullCheck8 = icmp ne i64* %274, null
-  br i1 %NullCheck8, label %275, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64* %274, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %275
 
 ; <label>:275                                     ; preds = %271
   %276 = load i64, i64* %274, align 8
   %277 = bitcast i8* %272 to i64*
-  %NullCheck10 = icmp ne i64* %277, null
-  br i1 %NullCheck10, label %278, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %277, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %278
 
 ; <label>:278                                     ; preds = %275
   store i64 %276, i64* %277, align 8
@@ -1184,14 +1266,14 @@ entry:
   %281 = load i8*, i8** %arg1
   %282 = getelementptr inbounds i8, i8* %281, i64 8
   %283 = bitcast i8* %282 to i32*
-  %NullCheck12 = icmp ne i32* %283, null
-  br i1 %NullCheck12, label %284, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i32* %283, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %284
 
 ; <label>:284                                     ; preds = %278
   %285 = load i32, i32* %283, align 8
   %286 = bitcast i8* %280 to i32*
-  %NullCheck14 = icmp ne i32* %286, null
-  br i1 %NullCheck14, label %287, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i32* %286, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %287
 
 ; <label>:287                                     ; preds = %284
   store i32 %285, i32* %286, align 8
@@ -1200,16 +1282,16 @@ entry:
   %290 = load i8*, i8** %arg1
   %291 = getelementptr inbounds i8, i8* %290, i64 12
   %292 = bitcast i8* %291 to i16*
-  %NullCheck16 = icmp ne i16* %292, null
-  br i1 %NullCheck16, label %293, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i16* %292, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %293
 
 ; <label>:293                                     ; preds = %287
   %294 = load i16, i16* %292, align 8
   %295 = sext i16 %294 to i32
   %296 = bitcast i8* %289 to i16*
   %297 = trunc i32 %295 to i16
-  %NullCheck18 = icmp ne i16* %296, null
-  br i1 %NullCheck18, label %298, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i16* %296, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %298
 
 ; <label>:298                                     ; preds = %293
   store i16 %297, i16* %296, align 8
@@ -1217,15 +1299,15 @@ entry:
   %300 = getelementptr inbounds i8, i8* %299, i64 14
   %301 = load i8*, i8** %arg1
   %302 = getelementptr inbounds i8, i8* %301, i64 14
-  %NullCheck20 = icmp ne i8* %302, null
-  br i1 %NullCheck20, label %303, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i8* %302, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %303
 
 ; <label>:303                                     ; preds = %298
   %304 = load i8, i8* %302, align 8
   %305 = zext i8 %304 to i32
   %306 = trunc i32 %305 to i8
-  %NullCheck22 = icmp ne i8* %300, null
-  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i8* %300, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %307
 
 ; <label>:307                                     ; preds = %303
   store i8 %306, i8* %300, align 8
@@ -1235,14 +1317,14 @@ entry:
   %309 = load i8*, i8** %arg0
   %310 = load i8*, i8** %arg1
   %311 = bitcast i8* %310 to i64*
-  %NullCheck = icmp ne i64* %311, null
-  br i1 %NullCheck, label %312, label %ThrowNullRef
+  %NullCheck = icmp eq i64* %311, null
+  br i1 %NullCheck, label %ThrowNullRef, label %312
 
 ; <label>:312                                     ; preds = %308
   %313 = load i64, i64* %311, align 8
   %314 = bitcast i8* %309 to i64*
-  %NullCheck2 = icmp ne i64* %314, null
-  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64* %314, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %315
 
 ; <label>:315                                     ; preds = %312
   store i64 %313, i64* %314, align 8
@@ -1251,14 +1333,14 @@ entry:
   %318 = load i8*, i8** %arg1
   %319 = getelementptr inbounds i8, i8* %318, i64 8
   %320 = bitcast i8* %319 to i64*
-  %NullCheck4 = icmp ne i64* %320, null
-  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64* %320, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %321
 
 ; <label>:321                                     ; preds = %315
   %322 = load i64, i64* %320, align 8
   %323 = bitcast i8* %317 to i64*
-  %NullCheck6 = icmp ne i64* %323, null
-  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64* %323, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %324
 
 ; <label>:324                                     ; preds = %321
   store i64 %322, i64* %323, align 8
@@ -1286,15 +1368,15 @@ entry:
 ; <label>:338                                     ; preds = %333
   %339 = load i8*, i8** %arg0
   %340 = load i8*, i8** %arg1
-  %NullCheck136 = icmp ne i8* %340, null
-  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+  %NullCheck135 = icmp eq i8* %340, null
+  br i1 %NullCheck135, label %ThrowNullRef136, label %341
 
 ; <label>:341                                     ; preds = %338
   %342 = load i8, i8* %340, align 8
   %343 = zext i8 %342 to i32
   %344 = trunc i32 %343 to i8
-  %NullCheck138 = icmp ne i8* %339, null
-  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+  %NullCheck137 = icmp eq i8* %339, null
+  br i1 %NullCheck137, label %ThrowNullRef138, label %345
 
 ; <label>:345                                     ; preds = %341
   store i8 %344, i8* %339, align 8
@@ -1317,16 +1399,16 @@ entry:
   %357 = load i8*, i8** %arg0
   %358 = load i8*, i8** %arg1
   %359 = bitcast i8* %358 to i16*
-  %NullCheck140 = icmp ne i16* %359, null
-  br i1 %NullCheck140, label %360, label %ThrowNullRef139
+  %NullCheck139 = icmp eq i16* %359, null
+  br i1 %NullCheck139, label %ThrowNullRef140, label %360
 
 ; <label>:360                                     ; preds = %356
   %361 = load i16, i16* %359, align 8
   %362 = sext i16 %361 to i32
   %363 = bitcast i8* %357 to i16*
   %364 = trunc i32 %362 to i16
-  %NullCheck142 = icmp ne i16* %363, null
-  br i1 %NullCheck142, label %365, label %ThrowNullRef141
+  %NullCheck141 = icmp eq i16* %363, null
+  br i1 %NullCheck141, label %ThrowNullRef142, label %365
 
 ; <label>:365                                     ; preds = %360
   store i16 %364, i16* %363, align 8
@@ -1352,14 +1434,14 @@ entry:
   %378 = load i8*, i8** %arg0
   %379 = load i8*, i8** %arg1
   %380 = bitcast i8* %379 to i32*
-  %NullCheck144 = icmp ne i32* %380, null
-  br i1 %NullCheck144, label %381, label %ThrowNullRef143
+  %NullCheck143 = icmp eq i32* %380, null
+  br i1 %NullCheck143, label %ThrowNullRef144, label %381
 
 ; <label>:381                                     ; preds = %377
   %382 = load i32, i32* %380, align 8
   %383 = bitcast i8* %378 to i32*
-  %NullCheck146 = icmp ne i32* %383, null
-  br i1 %NullCheck146, label %384, label %ThrowNullRef145
+  %NullCheck145 = icmp eq i32* %383, null
+  br i1 %NullCheck145, label %ThrowNullRef146, label %384
 
 ; <label>:384                                     ; preds = %381
   store i32 %382, i32* %383, align 8
@@ -1384,14 +1466,14 @@ entry:
   %395 = load i8*, i8** %arg0
   %396 = load i8*, i8** %arg1
   %397 = bitcast i8* %396 to i64*
-  %NullCheck164 = icmp ne i64* %397, null
-  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+  %NullCheck163 = icmp eq i64* %397, null
+  br i1 %NullCheck163, label %ThrowNullRef164, label %398
 
 ; <label>:398                                     ; preds = %394
   %399 = load i64, i64* %397, align 8
   %400 = bitcast i8* %395 to i64*
-  %NullCheck166 = icmp ne i64* %400, null
-  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+  %NullCheck165 = icmp eq i64* %400, null
+  br i1 %NullCheck165, label %ThrowNullRef166, label %401
 
 ; <label>:401                                     ; preds = %398
   store i64 %399, i64* %400, align 8
@@ -1400,14 +1482,14 @@ entry:
   %404 = load i8*, i8** %arg1
   %405 = getelementptr inbounds i8, i8* %404, i64 8
   %406 = bitcast i8* %405 to i64*
-  %NullCheck168 = icmp ne i64* %406, null
-  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+  %NullCheck167 = icmp eq i64* %406, null
+  br i1 %NullCheck167, label %ThrowNullRef168, label %407
 
 ; <label>:407                                     ; preds = %401
   %408 = load i64, i64* %406, align 8
   %409 = bitcast i8* %403 to i64*
-  %NullCheck170 = icmp ne i64* %409, null
-  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+  %NullCheck169 = icmp eq i64* %409, null
+  br i1 %NullCheck169, label %ThrowNullRef170, label %410
 
 ; <label>:410                                     ; preds = %407
   store i64 %408, i64* %409, align 8
@@ -1437,14 +1519,14 @@ entry:
   %425 = load i8*, i8** %arg0
   %426 = load i8*, i8** %arg1
   %427 = bitcast i8* %426 to i64*
-  %NullCheck148 = icmp ne i64* %427, null
-  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+  %NullCheck147 = icmp eq i64* %427, null
+  br i1 %NullCheck147, label %ThrowNullRef148, label %428
 
 ; <label>:428                                     ; preds = %424
   %429 = load i64, i64* %427, align 8
   %430 = bitcast i8* %425 to i64*
-  %NullCheck150 = icmp ne i64* %430, null
-  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+  %NullCheck149 = icmp eq i64* %430, null
+  br i1 %NullCheck149, label %ThrowNullRef150, label %431
 
 ; <label>:431                                     ; preds = %428
   store i64 %429, i64* %430, align 8
@@ -1466,14 +1548,14 @@ entry:
   %441 = load i8*, i8** %arg0
   %442 = load i8*, i8** %arg1
   %443 = bitcast i8* %442 to i32*
-  %NullCheck152 = icmp ne i32* %443, null
-  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+  %NullCheck151 = icmp eq i32* %443, null
+  br i1 %NullCheck151, label %ThrowNullRef152, label %444
 
 ; <label>:444                                     ; preds = %440
   %445 = load i32, i32* %443, align 8
   %446 = bitcast i8* %441 to i32*
-  %NullCheck154 = icmp ne i32* %446, null
-  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+  %NullCheck153 = icmp eq i32* %446, null
+  br i1 %NullCheck153, label %ThrowNullRef154, label %447
 
 ; <label>:447                                     ; preds = %444
   store i32 %445, i32* %446, align 8
@@ -1495,16 +1577,16 @@ entry:
   %457 = load i8*, i8** %arg0
   %458 = load i8*, i8** %arg1
   %459 = bitcast i8* %458 to i16*
-  %NullCheck156 = icmp ne i16* %459, null
-  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+  %NullCheck155 = icmp eq i16* %459, null
+  br i1 %NullCheck155, label %ThrowNullRef156, label %460
 
 ; <label>:460                                     ; preds = %456
   %461 = load i16, i16* %459, align 8
   %462 = sext i16 %461 to i32
   %463 = bitcast i8* %457 to i16*
   %464 = trunc i32 %462 to i16
-  %NullCheck158 = icmp ne i16* %463, null
-  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+  %NullCheck157 = icmp eq i16* %463, null
+  br i1 %NullCheck157, label %ThrowNullRef158, label %465
 
 ; <label>:465                                     ; preds = %460
   store i16 %464, i16* %463, align 8
@@ -1525,15 +1607,15 @@ entry:
 ; <label>:474                                     ; preds = %470
   %475 = load i8*, i8** %arg0
   %476 = load i8*, i8** %arg1
-  %NullCheck160 = icmp ne i8* %476, null
-  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+  %NullCheck159 = icmp eq i8* %476, null
+  br i1 %NullCheck159, label %ThrowNullRef160, label %477
 
 ; <label>:477                                     ; preds = %474
   %478 = load i8, i8* %476, align 8
   %479 = zext i8 %478 to i32
   %480 = trunc i32 %479 to i8
-  %NullCheck162 = icmp ne i8* %475, null
-  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+  %NullCheck161 = icmp eq i8* %475, null
+  br i1 %NullCheck161, label %ThrowNullRef162, label %481
 
 ; <label>:481                                     ; preds = %477
   store i8 %480, i8* %475, align 8
@@ -1553,343 +1635,343 @@ ThrowNullRef:                                     ; preds = %308
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %312
+ThrowNullRef2:                                    ; preds = %312
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %315
+ThrowNullRef4:                                    ; preds = %315
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %321
+ThrowNullRef6:                                    ; preds = %321
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %271
+ThrowNullRef8:                                    ; preds = %271
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %275
+ThrowNullRef10:                                   ; preds = %275
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %278
+ThrowNullRef12:                                   ; preds = %278
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %284
+ThrowNullRef14:                                   ; preds = %284
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %287
+ThrowNullRef16:                                   ; preds = %287
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %293
+ThrowNullRef18:                                   ; preds = %293
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %298
+ThrowNullRef20:                                   ; preds = %298
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %303
+ThrowNullRef22:                                   ; preds = %303
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %243
+ThrowNullRef24:                                   ; preds = %243
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %247
+ThrowNullRef26:                                   ; preds = %247
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %250
+ThrowNullRef28:                                   ; preds = %250
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %256
+ThrowNullRef30:                                   ; preds = %256
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %259
+ThrowNullRef32:                                   ; preds = %259
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %265
+ThrowNullRef34:                                   ; preds = %265
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %217
+ThrowNullRef36:                                   ; preds = %217
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %221
+ThrowNullRef38:                                   ; preds = %221
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %224
+ThrowNullRef40:                                   ; preds = %224
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %230
+ThrowNullRef42:                                   ; preds = %230
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %233
+ThrowNullRef44:                                   ; preds = %233
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %238
+ThrowNullRef46:                                   ; preds = %238
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %200
+ThrowNullRef48:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %204
+ThrowNullRef50:                                   ; preds = %204
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %207
+ThrowNullRef52:                                   ; preds = %207
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %213
+ThrowNullRef54:                                   ; preds = %213
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %172
+ThrowNullRef56:                                   ; preds = %172
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %176
+ThrowNullRef58:                                   ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %179
+ThrowNullRef60:                                   ; preds = %179
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %185
+ThrowNullRef62:                                   ; preds = %185
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %190
+ThrowNullRef64:                                   ; preds = %190
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %195
+ThrowNullRef66:                                   ; preds = %195
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %153
+ThrowNullRef68:                                   ; preds = %153
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %157
+ThrowNullRef70:                                   ; preds = %157
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %160
+ThrowNullRef72:                                   ; preds = %160
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %166
+ThrowNullRef74:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %136
+ThrowNullRef76:                                   ; preds = %136
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %140
+ThrowNullRef78:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %143
+ThrowNullRef80:                                   ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %148
+ThrowNullRef82:                                   ; preds = %148
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %128
+ThrowNullRef84:                                   ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %132
+ThrowNullRef86:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %100
+ThrowNullRef88:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %104
+ThrowNullRef90:                                   ; preds = %104
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %107
+ThrowNullRef92:                                   ; preds = %107
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %113
+ThrowNullRef94:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %118
+ThrowNullRef96:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %123
+ThrowNullRef98:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %81
+ThrowNullRef100:                                  ; preds = %81
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef101:                                  ; preds = %85
+ThrowNullRef102:                                  ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef103:                                  ; preds = %88
+ThrowNullRef104:                                  ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef105:                                  ; preds = %94
+ThrowNullRef106:                                  ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef107:                                  ; preds = %64
+ThrowNullRef108:                                  ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef109:                                  ; preds = %68
+ThrowNullRef110:                                  ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef111:                                  ; preds = %71
+ThrowNullRef112:                                  ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef113:                                  ; preds = %76
+ThrowNullRef114:                                  ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef115:                                  ; preds = %56
+ThrowNullRef116:                                  ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef117:                                  ; preds = %60
+ThrowNullRef118:                                  ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef119:                                  ; preds = %37
+ThrowNullRef120:                                  ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef121:                                  ; preds = %41
+ThrowNullRef122:                                  ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef123:                                  ; preds = %46
+ThrowNullRef124:                                  ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef125:                                  ; preds = %51
+ThrowNullRef126:                                  ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef127:                                  ; preds = %27
+ThrowNullRef128:                                  ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef129:                                  ; preds = %31
+ThrowNullRef130:                                  ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef131:                                  ; preds = %19
+ThrowNullRef132:                                  ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef133:                                  ; preds = %22
+ThrowNullRef134:                                  ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef135:                                  ; preds = %338
+ThrowNullRef136:                                  ; preds = %338
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef137:                                  ; preds = %341
+ThrowNullRef138:                                  ; preds = %341
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef139:                                  ; preds = %356
+ThrowNullRef140:                                  ; preds = %356
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef141:                                  ; preds = %360
+ThrowNullRef142:                                  ; preds = %360
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef143:                                  ; preds = %377
+ThrowNullRef144:                                  ; preds = %377
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef145:                                  ; preds = %381
+ThrowNullRef146:                                  ; preds = %381
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef147:                                  ; preds = %424
+ThrowNullRef148:                                  ; preds = %424
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef149:                                  ; preds = %428
+ThrowNullRef150:                                  ; preds = %428
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef151:                                  ; preds = %440
+ThrowNullRef152:                                  ; preds = %440
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef153:                                  ; preds = %444
+ThrowNullRef154:                                  ; preds = %444
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef155:                                  ; preds = %456
+ThrowNullRef156:                                  ; preds = %456
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef157:                                  ; preds = %460
+ThrowNullRef158:                                  ; preds = %460
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef159:                                  ; preds = %474
+ThrowNullRef160:                                  ; preds = %474
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef161:                                  ; preds = %477
+ThrowNullRef162:                                  ; preds = %477
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef163:                                  ; preds = %394
+ThrowNullRef164:                                  ; preds = %394
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef165:                                  ; preds = %398
+ThrowNullRef166:                                  ; preds = %398
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef167:                                  ; preds = %401
+ThrowNullRef168:                                  ; preds = %401
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef169:                                  ; preds = %407
+ThrowNullRef170:                                  ; preds = %407
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1939,8 +2021,8 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
-  br i1 %NullCheck, label %22, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %ThrowNullRef, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
@@ -1948,8 +2030,8 @@ entry:
   store i32 %24, i32* %loc0
   %25 = load i32, i32* %loc0
   %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %26, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %27
 
 ; <label>:27                                      ; preds = %22
   %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
@@ -1971,7 +2053,7 @@ ThrowNullRef:                                     ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1989,8 +2071,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -2022,15 +2104,15 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2048,16 +2130,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
   %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
   store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %15
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
@@ -2072,8 +2154,8 @@ entry:
   %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
   %29 = ptrtoint i16 addrspace(1)* %28 to i64
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %19
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
@@ -2089,19 +2171,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2114,8 +2196,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
@@ -2128,7 +2210,7 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[loadElem]
+Failed to read AppDomain.PrepareDataForSetup[storeElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
@@ -2202,8 +2284,8 @@ entry:
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
-  br i1 %NullCheck24, label %27, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = load i64, i64 addrspace(1)* %26
@@ -2218,8 +2300,8 @@ entry:
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
-  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
   %41 = load i64, i64 addrspace(1)* %39
@@ -2236,8 +2318,8 @@ entry:
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
-  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
   %54 = load i64, i64 addrspace(1)* %52
@@ -2252,8 +2334,8 @@ entry:
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
   %67 = load i64, i64 addrspace(1)* %65
@@ -2270,8 +2352,8 @@ entry:
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
-  br i1 %NullCheck16, label %79, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
   %80 = load i64, i64 addrspace(1)* %78
@@ -2286,8 +2368,8 @@ entry:
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
-  br i1 %NullCheck18, label %92, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
   %93 = load i64, i64 addrspace(1)* %91
@@ -2304,8 +2386,8 @@ entry:
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
-  br i1 %NullCheck12, label %105, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = load i64, i64 addrspace(1)* %104
@@ -2320,8 +2402,8 @@ entry:
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
-  br i1 %NullCheck14, label %118, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
   %119 = load i64, i64 addrspace(1)* %117
@@ -2337,8 +2419,8 @@ entry:
 
 ; <label>:128                                     ; preds = %20
   %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
-  br i1 %NullCheck4, label %130, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %129, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %130
 
 ; <label>:130                                     ; preds = %128
   %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
@@ -2346,8 +2428,8 @@ entry:
   %133 = load i16, i16 addrspace(1)* %132, align 8
   %134 = zext i16 %133 to i32
   %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
-  br i1 %NullCheck6, label %136, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %135, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %136
 
 ; <label>:136                                     ; preds = %130
   %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
@@ -2360,8 +2442,8 @@ entry:
 
 ; <label>:143                                     ; preds = %136
   %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
-  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %144, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %145
 
 ; <label>:145                                     ; preds = %143
   %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
@@ -2369,8 +2451,8 @@ entry:
   %148 = load i16, i16 addrspace(1)* %147, align 8
   %149 = zext i16 %148 to i32
   %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %150, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %151
 
 ; <label>:151                                     ; preds = %145
   %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
@@ -2388,8 +2470,8 @@ entry:
 
 ; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
-  br i1 %NullCheck, label %163, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %ThrowNullRef, label %163
 
 ; <label>:163                                     ; preds = %161
   %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
@@ -2399,8 +2481,8 @@ entry:
 
 ; <label>:167                                     ; preds = %163
   %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
-  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %168, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %169
 
 ; <label>:169                                     ; preds = %167
   %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
@@ -2432,55 +2514,55 @@ ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %167
+ThrowNullRef2:                                    ; preds = %167
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %128
+ThrowNullRef4:                                    ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %130
+ThrowNullRef6:                                    ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %143
+ThrowNullRef8:                                    ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %145
+ThrowNullRef10:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %102
+ThrowNullRef12:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %105
+ThrowNullRef14:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %76
+ThrowNullRef16:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %79
+ThrowNullRef18:                                   ; preds = %79
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %50
+ThrowNullRef20:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %53
+ThrowNullRef22:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %24
+ThrowNullRef24:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %27
+ThrowNullRef26:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2503,15 +2585,15 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2519,16 +2601,16 @@ entry:
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
   store i32 %8, i32* %loc0
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
   %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
   store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
@@ -2546,16 +2628,16 @@ entry:
 
 ; <label>:23                                      ; preds = %64
   %24 = load i16*, i16** %loc3
-  %NullCheck12 = icmp ne i16* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i16* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
   store i32 %27, i32* %loc5
   %28 = load i16*, i16** %loc4
-  %NullCheck14 = icmp ne i16* %28, null
-  br i1 %NullCheck14, label %29, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %28, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = load i16, i16* %28, align 8
@@ -2620,15 +2702,15 @@ entry:
 
 ; <label>:67                                      ; preds = %64
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
-  br i1 %NullCheck8, label %69, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %68, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %69
 
 ; <label>:69                                      ; preds = %67
   %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
   %71 = load i32, i32 addrspace(1)* %70
   %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
-  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %73
 
 ; <label>:73                                      ; preds = %69
   %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
@@ -2645,31 +2727,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %67
+ThrowNullRef8:                                    ; preds = %67
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %69
+ThrowNullRef10:                                   ; preds = %69
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2710,14 +2792,14 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
   %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
@@ -2730,14 +2812,14 @@ entry:
 
 ; <label>:11                                      ; preds = %4
   %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
   %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
@@ -2749,14 +2831,14 @@ entry:
 
 ; <label>:22                                      ; preds = %16
   %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
   %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
-  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
-  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
@@ -2804,23 +2886,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2836,7 +2918,280 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[loadElem]
+Successfully read RuntimeType.IsAssignableFrom
+
+define i8 @RuntimeType.IsAssignableFrom(%System.RuntimeType addrspace(1)* %param0, %System.Type addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.RuntimeType addrspace(1)*
+  %arg1 = alloca %System.Type addrspace(1)*
+  %loc0 = alloca %System.RuntimeType addrspace(1)*
+  %loc1 = alloca %"System.Type[]" addrspace(1)*
+  %loc2 = alloca i32
+  store %System.RuntimeType addrspace(1)* %param0, %System.RuntimeType addrspace(1)** %this
+  store %System.Type addrspace(1)* %param1, %System.Type addrspace(1)** %arg1
+  %0 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %1 = icmp ne %System.Type addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i8 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %5 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %6 = bitcast %System.Type addrspace(1)* %4 to %System.Object addrspace(1)*
+  %7 = bitcast %System.RuntimeType addrspace(1)* %5 to %System.Object addrspace(1)*
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %6, %System.Object addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %3
+  ret i8 1
+
+; <label>:12                                      ; preds = %3
+  %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 152
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 32
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
+  %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
+  %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
+  store %System.RuntimeType addrspace(1)* %25, %System.RuntimeType addrspace(1)** %loc0
+  %26 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %27 = icmp eq %System.RuntimeType addrspace(1)* %26, null
+  br i1 %27, label %34, label %28
+
+; <label>:28                                      ; preds = %15
+  %29 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %30 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)*)*)(%System.RuntimeType addrspace(1)* %29, %System.RuntimeType addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+; <label>:34                                      ; preds = %15
+  %35 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %36 = call %System.Reflection.Emit.TypeBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Reflection.Emit.TypeBuilder addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %35)
+  %37 = icmp eq %System.Reflection.Emit.TypeBuilder addrspace(1)* %36, null
+  br i1 %37, label %139, label %38
+
+; <label>:38                                      ; preds = %34
+  %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %42
+
+; <label>:42                                      ; preds = %38
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 152
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 40
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
+  %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
+  %53 = zext i8 %52 to i32
+  %54 = icmp eq i32 %53, 0
+  br i1 %54, label %56, label %55
+
+; <label>:55                                      ; preds = %42
+  ret i8 1
+
+; <label>:56                                      ; preds = %42
+  %57 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %58 = bitcast %System.RuntimeType addrspace(1)* %57 to %System.Type addrspace(1)*
+  %59 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %58)
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %64 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.Type addrspace(1)* %63, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = bitcast %System.RuntimeType addrspace(1)* %64 to %System.Type addrspace(1)*
+  %67 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %63, %System.Type addrspace(1)* %66)
+  %68 = zext i8 %67 to i32
+  %69 = trunc i32 %68 to i8
+  ret i8 %69
+
+; <label>:70                                      ; preds = %56
+  %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
+  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %73
+
+; <label>:73                                      ; preds = %70
+  %74 = load i64, i64 addrspace(1)* %72
+  %75 = add i64 %74, 128
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = add i64 %77, 0
+  %79 = inttoptr i64 %78 to i64*
+  %80 = load i64, i64* %79
+  %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
+  %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
+  %83 = call i8 %82(%System.Type addrspace(1)* %81)
+  %84 = zext i8 %83 to i32
+  %85 = icmp eq i32 %84, 0
+  br i1 %85, label %139, label %86
+
+; <label>:86                                      ; preds = %73
+  %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
+  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %89
+
+; <label>:89                                      ; preds = %86
+  %90 = load i64, i64 addrspace(1)* %88
+  %91 = add i64 %90, 128
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = add i64 %93, 24
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
+  %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
+  %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
+  store %"System.Type[]" addrspace(1)* %99, %"System.Type[]" addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %129
+
+; <label>:100                                     ; preds = %132
+  %101 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %102 = load i32, i32* %loc2
+  %NullCheck11 = icmp eq %"System.Type[]" addrspace(1)* %101, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %103
+
+; <label>:103                                     ; preds = %100
+  %104 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 1
+  %105 = load i32, i32 addrspace(1)* %104
+  %106 = zext i32 %105 to i64
+  %107 = zext i32 %102 to i64
+  %BoundsCheck = icmp uge i64 %107, %106
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %108
+
+; <label>:108                                     ; preds = %103
+  %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
+  %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
+  %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
+  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %113
+
+; <label>:113                                     ; preds = %108
+  %114 = load i64, i64 addrspace(1)* %112
+  %115 = add i64 %114, 152
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = add i64 %117, 56
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
+  %123 = zext i8 %122 to i32
+  %124 = icmp ne i32 %123, 0
+  br i1 %124, label %126, label %125
+
+; <label>:125                                     ; preds = %113
+  ret i8 0
+
+; <label>:126                                     ; preds = %113
+  %127 = load i32, i32* %loc2
+  %128 = add i32 %127, 1
+  store i32 %128, i32* %loc2
+  br label %129
+
+; <label>:129                                     ; preds = %89, %126
+  %130 = load i32, i32* %loc2
+  %131 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %NullCheck9 = icmp eq %"System.Type[]" addrspace(1)* %131, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %132
+
+; <label>:132                                     ; preds = %129
+  %133 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %131, i32 0, i32 1
+  %134 = load i32, i32 addrspace(1)* %133
+  %135 = zext i32 %134 to i64
+  %136 = trunc i64 %135 to i32
+  %137 = icmp slt i32 %130, %136
+  br i1 %137, label %100, label %138
+
+; <label>:138                                     ; preds = %132
+  ret i8 1
+
+; <label>:139                                     ; preds = %34, %73
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %129
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %103
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -2893,7 +3248,7 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElem]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -2904,8 +3259,8 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -2997,8 +3352,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
@@ -3059,8 +3414,8 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -3087,8 +3442,8 @@ entry:
 
 ; <label>:17                                      ; preds = %5, %11
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
@@ -3097,8 +3452,8 @@ entry:
 
 ; <label>:22                                      ; preds = %1, %11
   %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
@@ -3109,11 +3464,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %17
+ThrowNullRef2:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %22
+ThrowNullRef4:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3167,15 +3522,15 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
   %15 = load i32, i32 addrspace(1)* %14
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
@@ -3198,7 +3553,7 @@ ThrowNullRef:                                     ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef2:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3232,8 +3587,8 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
@@ -3312,8 +3667,8 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -3327,8 +3682,8 @@ entry:
 ; <label>:5                                       ; preds = %43
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %7 = load i32, i32* %loc1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck6, label %8, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
@@ -3366,8 +3721,8 @@ entry:
 ; <label>:32                                      ; preds = %21, %25
   %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
   %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
-  br i1 %NullCheck8, label %35, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = trunc i32 %34 to i16
@@ -3380,8 +3735,8 @@ entry:
 ; <label>:40                                      ; preds = %1, %35
   %41 = load i32, i32* %loc1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
-  br i1 %NullCheck2, label %43, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %42, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
@@ -3392,8 +3747,8 @@ entry:
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
   %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
-  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
   %51 = load i64, i64 addrspace(1)* %49
@@ -3412,19 +3767,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %40
+ThrowNullRef2:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %47
+ThrowNullRef4:                                    ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %5
+ThrowNullRef6:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %32
+ThrowNullRef8:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3467,8 +3822,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
@@ -3492,11 +3847,391 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(i16* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store i16* %param0, i16** %arg0
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load i32, i32* %arg3
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %42, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %37, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg2
+  %13 = load i32, i32* %arg3
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %37, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %24 = load i32, i32* %arg2
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load i16*, i16** %arg0
+  %35 = load i32, i32* %arg3
+  %36 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %36, i16* %34, i32 %35)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:37                                      ; preds = %5, %16
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %39)
+  %41 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41, %System.String addrspace(1)* %38, %System.String addrspace(1)* %40)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41) #0
+  unreachable
+
+; <label>:42                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
-Failed to read StringBuilder.ToString[loadElemA]
+Successfully read StringBuilder.ToString
+
+define %System.String addrspace(1)* @StringBuilder.ToString(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i16*
+  %loc3 = alloca %"System.Char[]" addrspace(1)*
+  %loc4 = alloca i32
+  %loc5 = alloca i32
+  %loc6 = alloca i16 addrspace(1)*
+  %loc7 = alloca %System.String addrspace(1)*
+  %loc8 = alloca %"System.Char[]" addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %0)
+  %2 = icmp ne i32 %1, 0
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %4
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %6)
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %7)
+  store %System.String addrspace(1)* %8, %System.String addrspace(1)** %loc0
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.Text.StringBuilder addrspace(1)* %9, %System.Text.StringBuilder addrspace(1)** %loc1
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  store %System.String addrspace(1)* %10, %System.String addrspace(1)** %loc7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc7
+  %12 = ptrtoint %System.String addrspace(1)* %11 to i64
+  %13 = icmp eq i64 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %5
+  %15 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %16 = sext i32 %15 to i64
+  %17 = add i64 %12, %16
+  br label %18
+
+; <label>:18                                      ; preds = %5, %14
+  %19 = phi i64 [ %12, %5 ], [ %17, %14 ]
+  %20 = inttoptr i64 %19 to i16*
+  store i16* %20, i16** %loc2
+  br label %21
+
+; <label>:21                                      ; preds = %98, %18
+  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %22, null
+  br i1 %NullCheck, label %ThrowNullRef, label %23
+
+; <label>:23                                      ; preds = %21
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 3
+  %25 = load i32, i32 addrspace(1)* %24, align 8
+  %26 = icmp sle i32 %25, 0
+  br i1 %26, label %96, label %27
+
+; <label>:27                                      ; preds = %23
+  %28 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %28, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %29
+
+; <label>:29                                      ; preds = %27
+  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %28, i32 0, i32 1
+  %31 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %30, align 8
+  store %"System.Char[]" addrspace(1)* %31, %"System.Char[]" addrspace(1)** %loc3
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %33
+
+; <label>:33                                      ; preds = %29
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  store i32 %35, i32* %loc4
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  %39 = load i32, i32 addrspace(1)* %38, align 8
+  store i32 %39, i32* %loc5
+  %40 = load i32, i32* %loc5
+  %41 = load i32, i32* %loc4
+  %42 = add i32 %40, %41
+  %43 = zext i32 %42 to i64
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %45
+
+; <label>:45                                      ; preds = %37
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = sext i32 %47 to i64
+  %49 = icmp sgt i64 %43, %48
+  br i1 %49, label %91, label %50
+
+; <label>:50                                      ; preds = %45
+  %51 = load i32, i32* %loc5
+  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %52, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %53
+
+; <label>:53                                      ; preds = %50
+  %54 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %52, i32 0, i32 1
+  %55 = load i32, i32 addrspace(1)* %54
+  %56 = zext i32 %55 to i64
+  %57 = trunc i64 %56 to i32
+  %58 = icmp ugt i32 %51, %57
+  br i1 %58, label %91, label %59
+
+; <label>:59                                      ; preds = %53
+  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  store %"System.Char[]" addrspace(1)* %60, %"System.Char[]" addrspace(1)** %loc8
+  %61 = icmp eq %"System.Char[]" addrspace(1)* %60, null
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %63, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %64
+
+; <label>:64                                      ; preds = %62
+  %65 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %63, i32 0, i32 1
+  %66 = load i32, i32 addrspace(1)* %65
+  %67 = zext i32 %66 to i64
+  %68 = trunc i64 %67 to i32
+  %69 = icmp ne i32 %68, 0
+  br i1 %69, label %71, label %70
+
+; <label>:70                                      ; preds = %59, %64
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:71                                      ; preds = %64
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %73
+
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %BoundsCheck = icmp uge i64 0, %76
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %77
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %78, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:79                                      ; preds = %70, %77
+  %80 = load i16*, i16** %loc2
+  %81 = load i32, i32* %loc4
+  %82 = sext i32 %81 to i64
+  %83 = mul i64 %82, 2
+  %84 = bitcast i16* %80 to i8*
+  %85 = getelementptr inbounds i8, i8* %84, i64 %83
+  %86 = load i16 addrspace(1)*, i16 addrspace(1)** %loc6
+  %87 = ptrtoint i16 addrspace(1)* %86 to i64
+  %88 = load i32, i32* %loc5
+  %89 = bitcast i8* %85 to i16*
+  %90 = inttoptr i64 %87 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %89, i16* %90, i32 %88)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %96
+
+; <label>:91                                      ; preds = %45, %53
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %94 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %93)
+  %95 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95, %System.String addrspace(1)* %92, %System.String addrspace(1)* %94)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95) #0
+  unreachable
+
+; <label>:96                                      ; preds = %23, %79
+  %97 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %97, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %98
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %97, i32 0, i32 2
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  store %System.Text.StringBuilder addrspace(1)* %100, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %102 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %102, label %21, label %103
+
+; <label>:103                                     ; preds = %98
+  store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc7
+  %104 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  ret %System.String addrspace(1)* %104
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method StringBuilder::get_Length using LLILCJit
+Successfully read StringBuilder.get_Length
+
+define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
+Successfully read RuntimeHelpers.get_OffsetToStringData
+
+define i32 @RuntimeHelpers.get_OffsetToStringData() {
+entry:
+  ret i32 12
+}
+
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
 Successfully read CultureData.CreateCultureData
 
@@ -3514,23 +4249,23 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
   store i8 %4, i8 addrspace(1)* %6
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
@@ -3549,11 +4284,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3566,50 +4301,50 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
   store i32 -1, i32 addrspace(1)* %2
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
   store i32 -1, i32 addrspace(1)* %8
   %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
   store i32 -1, i32 addrspace(1)* %14
   %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
   store i32 -1, i32 addrspace(1)* %17
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
@@ -3623,27 +4358,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3675,7 +4410,136 @@ Failed to read Dictionary`2.Insert[non-const derefAddress]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
 Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
-Failed to read HashHelpers.GetPrime[loadElem]
+Successfully read HashHelpers.GetPrime
+
+define i32 @HashHelpers.GetPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %6, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5, %System.String addrspace(1)* %4)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5) #0
+  unreachable
+
+; <label>:6                                       ; preds = %entry
+  store i32 0, i32* %loc0
+  br label %29
+
+; <label>:7                                       ; preds = %35
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 1296
+  %10 = addrspacecast i8 addrspace(1)* %9 to %"System.Int32[]" addrspace(1)**
+  %11 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %10
+  %12 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Int32[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = zext i32 %15 to i64
+  %17 = zext i32 %12 to i64
+  %BoundsCheck = icmp uge i64 %17, %16
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 3, i32 %12
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  store i32 %20, i32* %loc1
+  %21 = load i32, i32* %loc1
+  %22 = load i32, i32* %arg0
+  %23 = icmp slt i32 %21, %22
+  br i1 %23, label %26, label %24
+
+; <label>:24                                      ; preds = %18
+  %25 = load i32, i32* %loc1
+  ret i32 %25
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %loc0
+  %28 = add i32 %27, 1
+  store i32 %28, i32* %loc0
+  br label %29
+
+; <label>:29                                      ; preds = %6, %26
+  %30 = load i32, i32* %loc0
+  %31 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %32 = getelementptr inbounds i8, i8 addrspace(1)* %31, i64 1296
+  %33 = addrspacecast i8 addrspace(1)* %32 to %"System.Int32[]" addrspace(1)**
+  %34 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %33
+  %NullCheck = icmp eq %"System.Int32[]" addrspace(1)* %34, null
+  br i1 %NullCheck, label %ThrowNullRef, label %35
+
+; <label>:35                                      ; preds = %29
+  %36 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %34, i32 0, i32 1
+  %37 = load i32, i32 addrspace(1)* %36
+  %38 = zext i32 %37 to i64
+  %39 = trunc i64 %38 to i32
+  %40 = icmp slt i32 %30, %39
+  br i1 %40, label %7, label %41
+
+; <label>:41                                      ; preds = %35
+  %42 = load i32, i32* %arg0
+  %43 = or i32 %42, 1
+  store i32 %43, i32* %loc2
+  br label %59
+
+; <label>:44                                      ; preds = %59
+  %45 = load i32, i32* %loc2
+  %46 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %45)
+  %47 = zext i8 %46 to i32
+  %48 = icmp eq i32 %47, 0
+  br i1 %48, label %56, label %49
+
+; <label>:49                                      ; preds = %44
+  %50 = load i32, i32* %loc2
+  %51 = sub i32 %50, 1
+  %52 = srem i32 %51, 101
+  %53 = icmp eq i32 %52, 0
+  br i1 %53, label %56, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = load i32, i32* %loc2
+  ret i32 %55
+
+; <label>:56                                      ; preds = %44, %49
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %57, 2
+  store i32 %58, i32* %loc2
+  br label %59
+
+; <label>:59                                      ; preds = %41, %56
+  %60 = load i32, i32* %loc2
+  %61 = icmp slt i32 %60, 2147483647
+  br i1 %61, label %44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load i32, i32* %arg0
+  ret i32 %63
+
+ThrowNullRef:                                     ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
 Successfully read GenericEqualityComparer`1.GetHashCode
 
@@ -3694,14 +4558,14 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
   %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load i64, i64 addrspace(1)* %7
@@ -3720,7 +4584,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3750,8 +4614,8 @@ entry:
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
@@ -3796,8 +4660,8 @@ entry:
   %35 = bitcast i16* %34 to i8*
   %36 = getelementptr inbounds i8, i8* %35, i64 2
   %37 = bitcast i8* %36 to i16*
-  %NullCheck4 = icmp ne i16* %37, null
-  br i1 %NullCheck4, label %38, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %37, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %38
 
 ; <label>:38                                      ; preds = %27
   %39 = load i16, i16* %37, align 8
@@ -3824,8 +4688,8 @@ entry:
 
 ; <label>:54                                      ; preds = %22, %43
   %55 = load i16*, i16** %loc4
-  %NullCheck2 = icmp ne i16* %55, null
-  br i1 %NullCheck2, label %56, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i16* %55, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %56
 
 ; <label>:56                                      ; preds = %54
   %57 = load i16, i16* %55, align 8
@@ -3850,11 +4714,11 @@ ThrowNullRef:                                     ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %54
+ThrowNullRef2:                                    ; preds = %54
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %27
+ThrowNullRef4:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3871,8 +4735,8 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -3907,8 +4771,8 @@ entry:
 
 ; <label>:26                                      ; preds = %19
   %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
-  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %28
 
 ; <label>:28                                      ; preds = %26
   %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
@@ -3920,7 +4784,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3972,8 +4836,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
@@ -3984,26 +4848,26 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
-  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
@@ -4014,8 +4878,8 @@ entry:
 ; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
@@ -4024,8 +4888,8 @@ entry:
 
 ; <label>:25                                      ; preds = %1, %16, %23
   %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
-  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
@@ -4036,27 +4900,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %20
+ThrowNullRef10:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4069,8 +4933,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -4081,8 +4945,8 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
@@ -4091,8 +4955,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1, %8
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
@@ -4103,11 +4967,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4128,24 +4992,24 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   store i32 %3, i32* %loc0
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
   %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
   store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck4, label %9, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
@@ -4164,15 +5028,15 @@ entry:
 ; <label>:18                                      ; preds = %70
   %19 = load i16*, i16** %loc3
   %20 = bitcast i16* %19 to i64*
-  %NullCheck10 = icmp ne i64* %20, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %20, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = load i64, i64* %20, align 8
   %23 = load i16*, i16** %loc4
   %24 = bitcast i16* %23 to i64*
-  %NullCheck12 = icmp ne i64* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = load i64, i64* %24, align 8
@@ -4188,8 +5052,8 @@ entry:
   %31 = bitcast i16* %30 to i8*
   %32 = getelementptr inbounds i8, i8* %31, i64 8
   %33 = bitcast i8* %32 to i64*
-  %NullCheck14 = icmp ne i64* %33, null
-  br i1 %NullCheck14, label %34, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = load i64, i64* %33, align 8
@@ -4197,8 +5061,8 @@ entry:
   %37 = bitcast i16* %36 to i8*
   %38 = getelementptr inbounds i8, i8* %37, i64 8
   %39 = bitcast i8* %38 to i64*
-  %NullCheck16 = icmp ne i64* %39, null
-  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %40
 
 ; <label>:40                                      ; preds = %34
   %41 = load i64, i64* %39, align 8
@@ -4214,8 +5078,8 @@ entry:
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %NullCheck18 = icmp ne i64* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = load i64, i64* %48, align 8
@@ -4223,8 +5087,8 @@ entry:
   %52 = bitcast i16* %51 to i8*
   %53 = getelementptr inbounds i8, i8* %52, i64 16
   %54 = bitcast i8* %53 to i64*
-  %NullCheck20 = icmp ne i64* %54, null
-  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64* %54, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %55
 
 ; <label>:55                                      ; preds = %49
   %56 = load i64, i64* %54, align 8
@@ -4262,15 +5126,15 @@ entry:
 ; <label>:74                                      ; preds = %95
   %75 = load i16*, i16** %loc3
   %76 = bitcast i16* %75 to i32*
-  %NullCheck6 = icmp ne i32* %76, null
-  br i1 %NullCheck6, label %77, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32* %76, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %77
 
 ; <label>:77                                      ; preds = %74
   %78 = load i32, i32* %76, align 8
   %79 = load i16*, i16** %loc4
   %80 = bitcast i16* %79 to i32*
-  %NullCheck8 = icmp ne i32* %80, null
-  br i1 %NullCheck8, label %81, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i32* %80, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %81
 
 ; <label>:81                                      ; preds = %77
   %82 = load i32, i32* %80, align 8
@@ -4318,43 +5182,43 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %74
+ThrowNullRef6:                                    ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %77
+ThrowNullRef8:                                    ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %29
+ThrowNullRef14:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %34
+ThrowNullRef16:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4376,8 +5240,8 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load i64, i64 addrspace(1)* %4
@@ -4389,8 +5253,8 @@ entry:
   %12 = load i64, i64* %11
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %5
   %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
@@ -4399,8 +5263,8 @@ entry:
   %18 = load i8, i8* %arg2
   %19 = zext i8 %18 to i32
   %20 = trunc i32 %19 to i8
-  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %15
   %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
@@ -4411,11 +5275,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4442,8 +5306,8 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
@@ -4466,16 +5330,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
   %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = load i64, i64 addrspace(1)* %19
@@ -4500,8 +5364,8 @@ entry:
 ; <label>:35                                      ; preds = %30
   %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
@@ -4514,8 +5378,8 @@ entry:
 
 ; <label>:42                                      ; preds = %1, %38
   %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
-  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
@@ -4526,19 +5390,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %35
+ThrowNullRef2:                                    ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %42
+ThrowNullRef8:                                    ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4551,14 +5415,14 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
@@ -4570,7 +5434,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4583,8 +5447,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
@@ -4613,51 +5477,51 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
   %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
   %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
   %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
   %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
-  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
   store i64 %21, i64 addrspace(1)* %23
   %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %25 = load i64, i64* %loc0
-  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
@@ -4668,27 +5532,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %22
+ThrowNullRef12:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4701,8 +5565,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
@@ -4713,19 +5577,19 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
@@ -4734,8 +5598,8 @@ entry:
 
 ; <label>:15                                      ; preds = %1, %13
   %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
@@ -4746,19 +5610,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %15
+ThrowNullRef8:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4771,8 +5635,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -4831,8 +5695,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
@@ -4882,8 +5746,8 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
-  br i1 %NullCheck, label %17, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %ThrowNullRef, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
@@ -4894,15 +5758,15 @@ entry:
 
 ; <label>:22                                      ; preds = %17
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
-  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
   %26 = load i32, i32 addrspace(1)* %25
   %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
-  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %27, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
@@ -4925,8 +5789,8 @@ entry:
 ; <label>:40                                      ; preds = %17
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
-  br i1 %NullCheck6, label %43, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %41, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
@@ -4938,34 +5802,17 @@ ThrowNullRef:                                     ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %24
+ThrowNullRef4:                                    ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %40
+ThrowNullRef6:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
-}
-
-INFO:  jitting method Object::ReferenceEquals using LLILCJit
-Successfully read Object.ReferenceEquals
-
-define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
-entry:
-  %arg0 = alloca %System.Object addrspace(1)*
-  %arg1 = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
-  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
-  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = icmp eq %System.Object addrspace(1)* %0, %1
-  %3 = sext i1 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
 }
 
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
@@ -4978,21 +5825,21 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
   %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
-  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
@@ -5007,28 +5854,28 @@ entry:
 ; <label>:13                                      ; preds = %8, %12
   %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
   %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
   %21 = load i32, i32 addrspace(1)* %20, align 8
   %22 = add i32 %21, 1
-  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
   store i32 %22, i32 addrspace(1)* %24
   %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
@@ -5039,27 +5886,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5077,7 +5924,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::Setup using LLILCJit
-Failed to read AppDomain.Setup[loadElem]
+Failed to read AppDomain.Setup[unbox]
 INFO:  jitting method Thread::GetDomain using LLILCJit
 Successfully read Thread.GetDomain
 
@@ -5108,8 +5955,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
@@ -5122,14 +5969,14 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
   %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
@@ -5141,11 +5988,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5173,8 +6020,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -5189,7 +6036,328 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
 Failed to read KeyCollection.System.Collections.Generic.IEnumerable<TKey>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Successfully read Enumerator.MoveNext
+
+define i8 @Enumerator.MoveNext(%"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.RuntimeTypeHandle* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*
+  %"$TypeArg" = alloca %System.RuntimeTypeHandle*
+  store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
+  %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 8
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %76, label %12
+
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
+  br label %76
+
+; <label>:13                                      ; preds = %85
+  %14 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck19 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %15
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, i32 0, i32 0
+  %17 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %16, align 8
+  %NullCheck21 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, i32 0, i32 2
+  %20 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %19, align 8
+  %21 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck23 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %22
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, i32 0, i32 2
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %NullCheck25 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 3, i32 %24
+  %NullCheck27 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %32
+
+; <label>:32                                      ; preds = %30
+  %33 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, i32 0, i32 2
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = icmp slt i32 %34, 0
+  br i1 %35, label %68, label %36
+
+; <label>:36                                      ; preds = %32
+  %37 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %38 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck29 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %39
+
+; <label>:39                                      ; preds = %36
+  %40 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, i32 0, i32 0
+  %41 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %40, align 8
+  %NullCheck31 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, i32 0, i32 2
+  %44 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %43, align 8
+  %45 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck33 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, i32 0, i32 2
+  %48 = load i32, i32 addrspace(1)* %47, align 8
+  %NullCheck35 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %49
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = zext i32 %51 to i64
+  %53 = zext i32 %48 to i64
+  %BoundsCheck37 = icmp uge i64 %53, %52
+  br i1 %BoundsCheck37, label %ThrowIndexOutOfRange38, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 3, i32 %48
+  %NullCheck39 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %56
+
+; <label>:56                                      ; preds = %54
+  %57 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, i32 0, i32 0
+  %58 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck41 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %59
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %60, %System.__Canon addrspace(1)* %58)
+  %61 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck43 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  %64 = load i32, i32 addrspace(1)* %63, align 8
+  %65 = add i32 %64, 1
+  %NullCheck45 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  store i32 %65, i32 addrspace(1)* %67
+  ret i8 1
+
+; <label>:68                                      ; preds = %32
+  %69 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck47 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %73 = add i32 %72, 1
+  %NullCheck49 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %74
+
+; <label>:74                                      ; preds = %70
+  %75 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  store i32 %73, i32 addrspace(1)* %75
+  br label %76
+
+; <label>:76                                      ; preds = %8, %12, %74
+  %77 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %78
+
+; <label>:78                                      ; preds = %76
+  %79 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, i32 0, i32 2
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck7 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %82
+
+; <label>:82                                      ; preds = %78
+  %83 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, i32 0, i32 0
+  %84 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %83, align 8
+  %NullCheck9 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %85
+
+; <label>:85                                      ; preds = %82
+  %86 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, i32 0, i32 7
+  %87 = load i32, i32 addrspace(1)* %86, align 8
+  %88 = icmp ult i32 %80, %87
+  br i1 %88, label %13, label %89
+
+; <label>:89                                      ; preds = %85
+  %90 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %91 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck11 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %92
+
+; <label>:92                                      ; preds = %89
+  %93 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, i32 0, i32 0
+  %94 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck13 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %95
+
+; <label>:95                                      ; preds = %92
+  %96 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, i32 0, i32 7
+  %97 = load i32, i32 addrspace(1)* %96, align 8
+  %98 = add i32 %97, 1
+  %NullCheck15 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %99
+
+; <label>:99                                      ; preds = %95
+  %100 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, i32 0, i32 2
+  store i32 %98, i32 addrspace(1)* %100
+  %101 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck17 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %102
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %103, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %92
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef22:                                   ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef24:                                   ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef26:                                   ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef28:                                   ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef30:                                   ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef32:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef34:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef36:                                   ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange38:                           ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef40:                                   ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef42:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef44:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef46:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef48:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef50:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -5200,8 +6368,8 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -5232,9 +6400,9 @@ Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
 Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
-Failed to read String.MakeSeparatorList[loadElemA]
+Failed to read String.MakeSeparatorList[storeElem]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
-Failed to read String.InternalSplitKeepEmptyEntries[loadElem]
+Failed to read String.InternalSplitKeepEmptyEntries[storeElem]
 INFO:  jitting method Path::IsRelative using LLILCJit
 Successfully read Path.IsRelative
 
@@ -5243,8 +6411,8 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -5254,8 +6422,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
@@ -5271,8 +6439,8 @@ entry:
 
 ; <label>:17                                      ; preds = %7
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
@@ -5288,8 +6456,8 @@ entry:
 
 ; <label>:29                                      ; preds = %19
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %31
 
 ; <label>:31                                      ; preds = %29
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
@@ -5300,8 +6468,8 @@ entry:
 
 ; <label>:36                                      ; preds = %31
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
-  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %37, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
@@ -5312,8 +6480,8 @@ entry:
 
 ; <label>:43                                      ; preds = %31, %38
   %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
-  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %45
 
 ; <label>:45                                      ; preds = %43
   %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
@@ -5324,8 +6492,8 @@ entry:
 
 ; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %50
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
@@ -5336,8 +6504,8 @@ entry:
 
 ; <label>:57                                      ; preds = %1, %7, %19, %45, %52
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
-  br i1 %NullCheck14, label %59, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %59
 
 ; <label>:59                                      ; preds = %57
   %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
@@ -5347,8 +6515,8 @@ entry:
 
 ; <label>:63                                      ; preds = %59
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
@@ -5359,8 +6527,8 @@ entry:
 
 ; <label>:70                                      ; preds = %65
   %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
-  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.String addrspace(1)* %71, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %72
 
 ; <label>:72                                      ; preds = %70
   %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
@@ -5379,39 +6547,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %17
+ThrowNullRef4:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %29
+ThrowNullRef6:                                    ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %36
+ThrowNullRef8:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %43
+ThrowNullRef10:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %50
+ThrowNullRef12:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %57
+ThrowNullRef14:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %63
+ThrowNullRef16:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %70
+ThrowNullRef18:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5419,7 +6587,293 @@ ThrowNullRef17:                                   ; preds = %70
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
-Failed to read String.TrimHelper[loadElem]
+Successfully read String.TrimHelper
+
+define %System.String addrspace(1)* @String.TrimHelper(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i16
+  %loc4 = alloca i32
+  %loc5 = alloca i16
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = sub i32 %3, 1
+  store i32 %4, i32* %loc0
+  store i32 0, i32* %loc1
+  %5 = load i32, i32* %arg2
+  %6 = icmp eq i32 %5, 1
+  br i1 %6, label %62, label %7
+
+; <label>:7                                       ; preds = %1
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:8                                       ; preds = %58
+  store i32 0, i32* %loc2
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load i32, i32* %loc1
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2, i32 %10
+  %13 = load i16, i16 addrspace(1)* %12
+  %14 = zext i16 %13 to i32
+  %15 = trunc i32 %14 to i16
+  store i16 %15, i16* %loc3
+  store i32 0, i32* %loc2
+  br label %34
+
+; <label>:16                                      ; preds = %37
+  %17 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %18 = load i32, i32* %loc2
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %17, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %19
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = zext i32 %18 to i64
+  %BoundsCheck = icmp uge i64 %23, %22
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %24
+
+; <label>:24                                      ; preds = %19
+  %25 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 3, i32 %18
+  %26 = load i16, i16 addrspace(1)* %25, align 8
+  %27 = zext i16 %26 to i32
+  %28 = load i16, i16* %loc3
+  %29 = zext i16 %28 to i32
+  %30 = icmp eq i32 %27, %29
+  br i1 %30, label %43, label %31
+
+; <label>:31                                      ; preds = %24
+  %32 = load i32, i32* %loc2
+  %33 = add i32 %32, 1
+  store i32 %33, i32* %loc2
+  br label %34
+
+; <label>:34                                      ; preds = %11, %31
+  %35 = load i32, i32* %loc2
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = icmp slt i32 %35, %41
+  br i1 %42, label %16, label %43
+
+; <label>:43                                      ; preds = %24, %37
+  %44 = load i32, i32* %loc2
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %45, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp eq i32 %44, %50
+  br i1 %51, label %62, label %52
+
+; <label>:52                                      ; preds = %46
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %7, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %57, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %58
+
+; <label>:58                                      ; preds = %55
+  %59 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %60 = load i32, i32 addrspace(1)* %59
+  %61 = icmp slt i32 %56, %60
+  br i1 %61, label %8, label %62
+
+; <label>:62                                      ; preds = %1, %46, %58
+  %63 = load i32, i32* %arg2
+  %64 = icmp eq i32 %63, 0
+  br i1 %64, label %122, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %66, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %67
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %66, i32 0, i32 1
+  %69 = load i32, i32 addrspace(1)* %68
+  %70 = sub i32 %69, 1
+  store i32 %70, i32* %loc0
+  br label %118
+
+; <label>:71                                      ; preds = %118
+  store i32 0, i32* %loc4
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %73 = load i32, i32* %loc0
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %74
+
+; <label>:74                                      ; preds = %71
+  %75 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 2, i32 %73
+  %76 = load i16, i16 addrspace(1)* %75
+  %77 = zext i16 %76 to i32
+  %78 = trunc i32 %77 to i16
+  store i16 %78, i16* %loc5
+  store i32 0, i32* %loc4
+  br label %97
+
+; <label>:79                                      ; preds = %100
+  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %81 = load i32, i32* %loc4
+  %NullCheck19 = icmp eq %"System.Char[]" addrspace(1)* %80, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
+
+; <label>:82                                      ; preds = %79
+  %83 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 1
+  %84 = load i32, i32 addrspace(1)* %83
+  %85 = zext i32 %84 to i64
+  %86 = zext i32 %81 to i64
+  %BoundsCheck21 = icmp uge i64 %86, %85
+  br i1 %BoundsCheck21, label %ThrowIndexOutOfRange22, label %87
+
+; <label>:87                                      ; preds = %82
+  %88 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 3, i32 %81
+  %89 = load i16, i16 addrspace(1)* %88, align 8
+  %90 = zext i16 %89 to i32
+  %91 = load i16, i16* %loc5
+  %92 = zext i16 %91 to i32
+  %93 = icmp eq i32 %90, %92
+  br i1 %93, label %106, label %94
+
+; <label>:94                                      ; preds = %87
+  %95 = load i32, i32* %loc4
+  %96 = add i32 %95, 1
+  store i32 %96, i32* %loc4
+  br label %97
+
+; <label>:97                                      ; preds = %74, %94
+  %98 = load i32, i32* %loc4
+  %99 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck15 = icmp eq %"System.Char[]" addrspace(1)* %99, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %100
+
+; <label>:100                                     ; preds = %97
+  %101 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %99, i32 0, i32 1
+  %102 = load i32, i32 addrspace(1)* %101
+  %103 = zext i32 %102 to i64
+  %104 = trunc i64 %103 to i32
+  %105 = icmp slt i32 %98, %104
+  br i1 %105, label %79, label %106
+
+; <label>:106                                     ; preds = %87, %100
+  %107 = load i32, i32* %loc4
+  %108 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck17 = icmp eq %"System.Char[]" addrspace(1)* %108, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %109
+
+; <label>:109                                     ; preds = %106
+  %110 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %108, i32 0, i32 1
+  %111 = load i32, i32 addrspace(1)* %110
+  %112 = zext i32 %111 to i64
+  %113 = trunc i64 %112 to i32
+  %114 = icmp eq i32 %107, %113
+  br i1 %114, label %122, label %115
+
+; <label>:115                                     ; preds = %109
+  %116 = load i32, i32* %loc0
+  %117 = sub i32 %116, 1
+  store i32 %117, i32* %loc0
+  br label %118
+
+; <label>:118                                     ; preds = %67, %115
+  %119 = load i32, i32* %loc0
+  %120 = load i32, i32* %loc1
+  %121 = icmp sge i32 %119, %120
+  br i1 %121, label %71, label %122
+
+; <label>:122                                     ; preds = %62, %109, %118
+  %123 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %124 = load i32, i32* %loc1
+  %125 = load i32, i32* %loc0
+  %126 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %123, i32 %124, i32 %125)
+  ret %System.String addrspace(1)* %126
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %97
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange22:                           ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
 Successfully read String.CreateTrimmedString
 
@@ -5439,8 +6893,8 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
@@ -5535,8 +6989,8 @@ entry:
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i64 2872
   %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
   %8 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %7
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %3
   %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
@@ -5553,8 +7007,8 @@ entry:
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 2864
   %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
   %21 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %20
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
-  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %22
 
 ; <label>:22                                      ; preds = %16
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
@@ -5569,7 +7023,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %16
+ThrowNullRef2:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5586,8 +7040,8 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5613,8 +7067,8 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
@@ -5632,8 +7086,8 @@ entry:
 
 ; <label>:12                                      ; preds = %4
   %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
@@ -5644,8 +7098,8 @@ entry:
 
 ; <label>:19                                      ; preds = %14
   %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %19
   %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
@@ -5660,21 +7114,21 @@ entry:
   %31 = zext i16 %30 to i32
   %32 = bitcast i8* %29 to i16*
   %33 = trunc i32 %31 to i16
-  %NullCheck6 = icmp ne i16* %32, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i16* %32, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %21
   store i16 %33, i16* %32, align 8
   %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %36
 
 ; <label>:36                                      ; preds = %34
   %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
   %38 = load i32, i32 addrspace(1)* %37, align 8
   %39 = add i32 %38, 1
-  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %40
 
 ; <label>:40                                      ; preds = %36
   %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
@@ -5683,16 +7137,16 @@ entry:
 
 ; <label>:42                                      ; preds = %14
   %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
-  br i1 %NullCheck12, label %44, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
   %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
   %47 = load i16, i16* %arg1
   %48 = zext i16 %47 to i32
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = trunc i32 %48 to i16
@@ -5703,31 +7157,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %19
+ThrowNullRef4:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %21
+ThrowNullRef6:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %36
+ThrowNullRef10:                                   ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %42
+ThrowNullRef12:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %44
+ThrowNullRef14:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5740,8 +7194,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -5752,8 +7206,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
@@ -5762,14 +7216,14 @@ entry:
 
 ; <label>:11                                      ; preds = %1
   %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
@@ -5779,15 +7233,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5808,8 +7262,8 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5822,8 +7276,8 @@ entry:
 
 ; <label>:8                                       ; preds = %3
   %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
@@ -5842,15 +7296,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
-  br i1 %NullCheck4, label %22, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
   %24 = load i16*, i16* addrspace(1)* %23, align 8
   %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %25, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
@@ -5859,8 +7313,8 @@ entry:
   store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
@@ -5874,8 +7328,8 @@ entry:
 
 ; <label>:37                                      ; preds = %65
   %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %37
   %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
@@ -5886,16 +7340,16 @@ entry:
   %45 = bitcast i16* %41 to i8*
   %46 = getelementptr inbounds i8, i8* %45, i64 %44
   %47 = bitcast i8* %46 to i16*
-  %NullCheck14 = icmp ne i16* %47, null
-  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %47, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %48
 
 ; <label>:48                                      ; preds = %39
   %49 = load i16, i16* %47, align 8
   %50 = zext i16 %49 to i32
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %52 = load i32, i32* %loc1
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %53
 
 ; <label>:53                                      ; preds = %48
   %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
@@ -5916,8 +7370,8 @@ entry:
 ; <label>:62                                      ; preds = %36, %59
   %63 = load i32, i32* %loc1
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck10, label %65, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %65
 
 ; <label>:65                                      ; preds = %62
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
@@ -5936,15 +7390,15 @@ entry:
 
 ; <label>:74                                      ; preds = %70
   %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
-  br i1 %NullCheck18, label %76, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %76
 
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
   %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
-  br i1 %NullCheck20, label %80, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
   %81 = load i64, i64 addrspace(1)* %79
@@ -5958,8 +7412,8 @@ entry:
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
   %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
-  br i1 %NullCheck22, label %92, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.String addrspace(1)* %90, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %92
 
 ; <label>:92                                      ; preds = %80
   %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
@@ -5969,15 +7423,15 @@ entry:
 
 ; <label>:96                                      ; preds = %70
   %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
-  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %98
 
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
   %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
-  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
   %103 = load i64, i64 addrspace(1)* %101
@@ -5991,8 +7445,8 @@ entry:
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
   %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
-  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.String addrspace(1)* %112, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %114
 
 ; <label>:114                                     ; preds = %102
   %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
@@ -6004,59 +7458,59 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %20
+ThrowNullRef4:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %22
+ThrowNullRef6:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %26
+ThrowNullRef8:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %62
+ThrowNullRef10:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %48
+ThrowNullRef16:                                   ; preds = %48
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %74
+ThrowNullRef18:                                   ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %76
+ThrowNullRef20:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %80
+ThrowNullRef22:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %96
+ThrowNullRef24:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %98
+ThrowNullRef26:                                   ; preds = %98
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %102
+ThrowNullRef28:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6069,15 +7523,15 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
   %3 = load i16*, i16* addrspace(1)* %2, align 8
   %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
@@ -6087,8 +7541,8 @@ entry:
   %10 = bitcast i16* %3 to i8*
   %11 = getelementptr inbounds i8, i8* %10, i64 %9
   %12 = bitcast i8* %11 to i16*
-  %NullCheck4 = icmp ne i16* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %5
   store i16 0, i16* %12, align 8
@@ -6098,11 +7552,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6119,8 +7573,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -6131,8 +7585,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
@@ -6144,15 +7598,15 @@ entry:
 
 ; <label>:14                                      ; preds = %1
   %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
   %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
   %21 = load i64, i64 addrspace(1)* %19
@@ -6171,15 +7625,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %14
+ThrowNullRef4:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %16
+ThrowNullRef6:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6302,14 +7756,6 @@ entry:
   ret %System.String addrspace(1)* %57
 }
 
-INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
-Successfully read RuntimeHelpers.get_OffsetToStringData
-
-define i32 @RuntimeHelpers.get_OffsetToStringData() {
-entry:
-  ret i32 12
-}
-
 INFO:  jitting method String::Equals using LLILCJit
 Successfully read String.Equals
 
@@ -6381,8 +7827,8 @@ entry:
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
-  br i1 %NullCheck24, label %29, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
   %30 = load i64, i64 addrspace(1)* %28
@@ -6397,8 +7843,8 @@ entry:
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
-  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
   %43 = load i64, i64 addrspace(1)* %41
@@ -6418,8 +7864,8 @@ entry:
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
   %59 = load i64, i64 addrspace(1)* %57
@@ -6434,8 +7880,8 @@ entry:
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck22, label %71, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
   %72 = load i64, i64 addrspace(1)* %70
@@ -6455,8 +7901,8 @@ entry:
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
-  br i1 %NullCheck16, label %87, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = load i64, i64 addrspace(1)* %86
@@ -6471,8 +7917,8 @@ entry:
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck18, label %100, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
   %101 = load i64, i64 addrspace(1)* %99
@@ -6492,8 +7938,8 @@ entry:
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
-  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
   %117 = load i64, i64 addrspace(1)* %115
@@ -6508,8 +7954,8 @@ entry:
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
-  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
   %130 = load i64, i64 addrspace(1)* %128
@@ -6528,15 +7974,15 @@ entry:
 
 ; <label>:142                                     ; preds = %22
   %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
-  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %143, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %144
 
 ; <label>:144                                     ; preds = %142
   %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
   %146 = load i32, i32 addrspace(1)* %145
   %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
-  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %147, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %148
 
 ; <label>:148                                     ; preds = %144
   %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
@@ -6557,15 +8003,15 @@ entry:
 
 ; <label>:159                                     ; preds = %22
   %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
-  br i1 %NullCheck, label %161, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %ThrowNullRef, label %161
 
 ; <label>:161                                     ; preds = %159
   %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
   %163 = load i32, i32 addrspace(1)* %162
   %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
-  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %164, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %165
 
 ; <label>:165                                     ; preds = %161
   %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
@@ -6578,8 +8024,8 @@ entry:
 
 ; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
-  br i1 %NullCheck4, label %172, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %171, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %172
 
 ; <label>:172                                     ; preds = %170
   %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
@@ -6589,8 +8035,8 @@ entry:
 
 ; <label>:176                                     ; preds = %172
   %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
-  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %177, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %178
 
 ; <label>:178                                     ; preds = %176
   %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
@@ -6629,55 +8075,55 @@ ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %161
+ThrowNullRef2:                                    ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %170
+ThrowNullRef4:                                    ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %176
+ThrowNullRef6:                                    ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %142
+ThrowNullRef8:                                    ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %144
+ThrowNullRef10:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %113
+ThrowNullRef12:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %116
+ThrowNullRef14:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %84
+ThrowNullRef16:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %87
+ThrowNullRef18:                                   ; preds = %87
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %55
+ThrowNullRef20:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %58
+ThrowNullRef22:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %26
+ThrowNullRef24:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %29
+ThrowNullRef26:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,8 +8161,8 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck, label %14, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %ThrowNullRef, label %14
 
 ; <label>:14                                      ; preds = %8
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
@@ -6760,8 +8206,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
@@ -6770,14 +8216,14 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32, i32* %loc0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %10
   %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
   %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
@@ -6790,15 +8236,15 @@ entry:
 ; <label>:25                                      ; preds = %19
   %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
-  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
   %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
@@ -6807,8 +8253,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %37 = load i32, i32* %loc0
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %38, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %38
 
 ; <label>:38                                      ; preds = %32
   %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
@@ -6817,14 +8263,14 @@ entry:
 
 ; <label>:40                                      ; preds = %19
   %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %40
   %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
   %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
-  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
-  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
@@ -6832,8 +8278,8 @@ entry:
   %48 = zext i32 %47 to i64
   %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
-  br i1 %NullCheck16, label %51, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %51
 
 ; <label>:51                                      ; preds = %45
   %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
@@ -6847,15 +8293,15 @@ entry:
 ; <label>:57                                      ; preds = %51
   %58 = load i16*, i16** %arg1
   %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
-  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %60
 
 ; <label>:60                                      ; preds = %57
   %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
   %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
-  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %64
 
 ; <label>:64                                      ; preds = %60
   %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
@@ -6864,22 +8310,22 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
   %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
-  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %70
 
 ; <label>:70                                      ; preds = %64
   %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
   %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
-  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
-  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
   %75 = load i32, i32 addrspace(1)* %74
   %76 = zext i32 %75 to i64
   %77 = trunc i64 %76 to i32
-  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
-  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %78
 
 ; <label>:78                                      ; preds = %73
   %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
@@ -6901,8 +8347,8 @@ entry:
   %90 = bitcast i16* %86 to i8*
   %91 = getelementptr inbounds i8, i8* %90, i64 %89
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %93
 
 ; <label>:93                                      ; preds = %80
   %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
@@ -6912,8 +8358,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %99 = load i32, i32* %loc2
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %100
 
 ; <label>:100                                     ; preds = %93
   %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
@@ -6928,63 +8374,63 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %25
+ThrowNullRef6:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %32
+ThrowNullRef10:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %40
+ThrowNullRef12:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %45
+ThrowNullRef16:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %57
+ThrowNullRef18:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %60
+ThrowNullRef20:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %64
+ThrowNullRef22:                                   ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %70
+ThrowNullRef24:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %73
+ThrowNullRef26:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %80
+ThrowNullRef28:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %93
+ThrowNullRef30:                                   ; preds = %93
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7004,8 +8450,8 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
@@ -7033,43 +8479,43 @@ entry:
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %14
   %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
   %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   %28 = load i32, i32 addrspace(1)* %27, align 8
   %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
-  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %30
 
 ; <label>:30                                      ; preds = %26
   %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
   %32 = load i32, i32 addrspace(1)* %31, align 8
   %33 = add i32 %28, %32
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %34
 
 ; <label>:34                                      ; preds = %30
   %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   store i32 %33, i32 addrspace(1)* %35
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
   store i32 0, i32 addrspace(1)* %38
   %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %40
 
 ; <label>:40                                      ; preds = %37
   %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
@@ -7082,8 +8528,8 @@ entry:
 
 ; <label>:47                                      ; preds = %40
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
@@ -7098,8 +8544,8 @@ entry:
   %54 = load i32, i32* %loc0
   %55 = sext i32 %54 to i64
   %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
-  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %57
 
 ; <label>:57                                      ; preds = %52
   %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
@@ -7110,68 +8556,35 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %14
+ThrowNullRef2:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %23
+ThrowNullRef4:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %26
+ThrowNullRef6:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %30
+ThrowNullRef8:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %34
+ThrowNullRef10:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %47
+ThrowNullRef14:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %52
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-}
-
-INFO:  jitting method StringBuilder::get_Length using LLILCJit
-Successfully read StringBuilder.get_Length
-
-define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.StringBuilder addrspace(1)*
-  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
-  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
-
-; <label>:1                                       ; preds = %entry
-  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %3 = load i32, i32 addrspace(1)* %2, align 8
-  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
-
-; <label>:5                                       ; preds = %1
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = add i32 %3, %7
-  ret i32 %8
-
-ThrowNullRef:                                     ; preds = %entry
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef16:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7213,70 +8626,70 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
   %6 = load i32, i32 addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
   store i32 %6, i32 addrspace(1)* %8
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
   %13 = load i32, i32 addrspace(1)* %12, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
   store i32 %13, i32 addrspace(1)* %15
   %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
-  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %18
 
 ; <label>:18                                      ; preds = %14
   %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
   %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
   %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
   %34 = load i32, i32 addrspace(1)* %33, align 8
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
-  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
@@ -7287,39 +8700,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %28
+ThrowNullRef16:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %32
+ThrowNullRef18:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7455,13 +8868,13 @@ entry:
 ; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
@@ -7477,16 +8890,16 @@ entry:
 
 ; <label>:18                                      ; preds = %15
   %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
   store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
   %22 = load i32, i32* %loc0
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %24
 
 ; <label>:24                                      ; preds = %20
   %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
@@ -7498,13 +8911,13 @@ entry:
 ; <label>:28                                      ; preds = %15, %24
   %29 = load i32, i32* %arg1
   %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %31
   %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
@@ -7517,20 +8930,20 @@ entry:
   %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
-  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
   %46 = load i32, i32 addrspace(1)* %45, align 8
   %47 = sub i32 %40, %46
-  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
-  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i32 addrspace(1)* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %48
 
 ; <label>:48                                      ; preds = %44
   store i32 %47, i32 addrspace(1)* %39, align 8
@@ -7538,21 +8951,21 @@ entry:
 
 ; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
-  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %51
 
 ; <label>:51                                      ; preds = %49
   %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %53
 
 ; <label>:53                                      ; preds = %51
   %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
   %55 = load i32, i32 addrspace(1)* %54, align 8
   %56 = load i32, i32* %arg2
   %57 = sub i32 %55, %56
-  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %58
 
 ; <label>:58                                      ; preds = %53
   %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
@@ -7562,13 +8975,13 @@ entry:
 ; <label>:60                                      ; preds = %33, %58
   %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
   %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
-  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %63
 
 ; <label>:63                                      ; preds = %60
   %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
-  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
-  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
@@ -7578,15 +8991,15 @@ entry:
 
 ; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
-  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i32 addrspace(1)* %69, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %70
 
 ; <label>:70                                      ; preds = %68
   %71 = load i32, i32 addrspace(1)* %69, align 8
   store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
-  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
@@ -7596,8 +9009,8 @@ entry:
   store i32 %77, i32* %loc4
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
-  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %80
 
 ; <label>:80                                      ; preds = %73
   %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
@@ -7607,71 +9020,71 @@ entry:
 ; <label>:83                                      ; preds = %80
   store i32 0, i32* %loc3
   %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
-  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
-  br i1 %NullCheck26, label %88, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i32 addrspace(1)* %87, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %88
 
 ; <label>:88                                      ; preds = %85
   %89 = load i32, i32 addrspace(1)* %87, align 8
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
-  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %90
 
 ; <label>:90                                      ; preds = %88
   %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
   store i32 %89, i32 addrspace(1)* %91
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
-  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
-  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %96
 
 ; <label>:96                                      ; preds = %94
   %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
-  br i1 %NullCheck34, label %100, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %100
 
 ; <label>:100                                     ; preds = %96
   %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
-  br i1 %NullCheck36, label %102, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %102
 
 ; <label>:102                                     ; preds = %100
   %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
   %104 = load i32, i32 addrspace(1)* %103, align 8
   %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
-  br i1 %NullCheck38, label %106, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %106
 
 ; <label>:106                                     ; preds = %102
   %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
-  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
-  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %108
 
 ; <label>:108                                     ; preds = %106
   %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
   %110 = load i32, i32 addrspace(1)* %109, align 8
   %111 = add i32 %104, %110
-  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %112
 
 ; <label>:112                                     ; preds = %108
   %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
   store i32 %111, i32 addrspace(1)* %113
   %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
-  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i32 addrspace(1)* %114, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %115
 
 ; <label>:115                                     ; preds = %112
   %116 = load i32, i32 addrspace(1)* %114, align 8
@@ -7681,19 +9094,19 @@ entry:
 ; <label>:118                                     ; preds = %115
   %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
-  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %121
 
 ; <label>:121                                     ; preds = %118
   %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
-  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
-  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %123
 
 ; <label>:123                                     ; preds = %121
   %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
   %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
-  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
-  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %126
 
 ; <label>:126                                     ; preds = %123
   %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
@@ -7705,8 +9118,8 @@ entry:
 
 ; <label>:130                                     ; preds = %80, %115, %126
   %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %132
 
 ; <label>:132                                     ; preds = %130
   %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7715,8 +9128,8 @@ entry:
   %136 = load i32, i32* %loc3
   %137 = sub i32 %135, %136
   %138 = sub i32 %134, %137
-  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %139
 
 ; <label>:139                                     ; preds = %132
   %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7728,16 +9141,16 @@ entry:
 
 ; <label>:144                                     ; preds = %139
   %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
-  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %146
 
 ; <label>:146                                     ; preds = %144
   %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
   %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
   %149 = load i32, i32* %loc2
   %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
-  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %151
 
 ; <label>:151                                     ; preds = %146
   %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
@@ -7754,145 +9167,249 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %18
+ThrowNullRef4:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %31
+ThrowNullRef10:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %44
+ThrowNullRef16:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %68
+ThrowNullRef18:                                   ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %70
+ThrowNullRef20:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %73
+ThrowNullRef22:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %83
+ThrowNullRef24:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %85
+ThrowNullRef26:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %88
+ThrowNullRef28:                                   ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %90
+ThrowNullRef30:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %94
+ThrowNullRef32:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %96
+ThrowNullRef34:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %100
+ThrowNullRef36:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %102
+ThrowNullRef38:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %106
+ThrowNullRef40:                                   ; preds = %106
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %108
+ThrowNullRef42:                                   ; preds = %108
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %112
+ThrowNullRef44:                                   ; preds = %112
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %118
+ThrowNullRef46:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %121
+ThrowNullRef48:                                   ; preds = %121
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %123
+ThrowNullRef50:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %130
+ThrowNullRef52:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %132
+ThrowNullRef54:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %144
+ThrowNullRef56:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %146
+ThrowNullRef58:                                   ; preds = %146
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %60
+ThrowNullRef60:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %63
+ThrowNullRef62:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %49
+ThrowNullRef64:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %51
+ThrowNullRef66:                                   ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %53
+ThrowNullRef68:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(%"System.Char[]" addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %arg0 = alloca %"System.Char[]" addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store %"System.Char[]" addrspace(1)* %param0, %"System.Char[]" addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load i32, i32* %arg4
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %43, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %38, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg1
+  %13 = load i32, i32* %arg4
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %38, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %24 = load i32, i32* %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %35 = load i32, i32* %arg3
+  %36 = load i32, i32* %arg4
+  %37 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %37, %"System.Char[]" addrspace(1)* %34, i32 %35, i32 %36)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:38                                      ; preds = %5, %16
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Successfully read Buffer._Memmove
 
@@ -7914,7 +9431,7 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[loadElem]
+Failed to read AppDomain.SetDataHelper[storeElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -7923,8 +9440,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
@@ -7934,8 +9451,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
@@ -7947,15 +9464,15 @@ entry:
   %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
   %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
@@ -7966,15 +9483,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7992,7 +9509,79 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
-Failed to read Dictionary`2.TryGetValue[loadElemA]
+Successfully read Dictionary`2.TryGetValue
+
+define i8 @"Dictionary`2.TryGetValue"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)* addrspace(1)* %param2) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  %arg2 = alloca %System.__Canon addrspace(1)* addrspace(1)*
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  store %System.__Canon addrspace(1)* addrspace(1)* %param2, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  store i32 %2, i32* %loc0
+  %3 = load i32, i32* %loc0
+  %4 = icmp slt i32 %3, 0
+  br i1 %4, label %22, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 2
+  %10 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %9, align 8
+  %11 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = zext i32 %11 to i64
+  %BoundsCheck = icmp uge i64 %16, %15
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 3, i32 %11
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %20, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %6, %System.__Canon addrspace(1)* %21)
+  ret i8 1
+
+; <label>:22                                      ; preds = %entry
+  %23 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %23, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -8058,8 +9647,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
@@ -8091,8 +9680,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
@@ -8171,15 +9760,15 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck, label %19, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %ThrowNullRef, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
   %21 = load i32, i32 addrspace(1)* %20
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
@@ -8202,7 +9791,7 @@ ThrowNullRef:                                     ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %19
+ThrowNullRef2:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8248,8 +9837,8 @@ entry:
   %0 = alloca %System.AppDomainHandle
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %1 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %1, i32 0, i32 15
@@ -8269,8 +9858,8 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
@@ -8286,7 +9875,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -8299,8 +9888,8 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -8327,8 +9916,8 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
@@ -8352,8 +9941,8 @@ entry:
   %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
   store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
@@ -8363,8 +9952,8 @@ entry:
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
@@ -8374,8 +9963,8 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %9
   %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
@@ -8384,8 +9973,8 @@ entry:
 
 ; <label>:18                                      ; preds = %3, %16
   %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
@@ -8397,15 +9986,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %18
+ThrowNullRef6:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8418,8 +10007,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
@@ -8453,15 +10042,15 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
@@ -8473,7 +10062,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8481,7 +10070,7 @@ ThrowNullRef1:                                    ; preds = %1
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
 Failed to read Dictionary`2.System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
@@ -8506,8 +10095,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
@@ -8524,8 +10113,8 @@ entry:
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -8544,7 +10133,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8577,8 +10166,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = load i64, i64* %arg2
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = trunc i32 %3 to i8
@@ -8634,46 +10223,46 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
   %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
-  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
-  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
-  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
@@ -8684,27 +10273,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %20
+ThrowNullRef12:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8717,8 +10306,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -8756,22 +10345,22 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
   %9 = load i64, i64 addrspace(1)* %8, align 8
   %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
   %13 = load i64, i64 addrspace(1)* %12, align 8
   %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %11
   %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
@@ -8788,11 +10377,11 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8882,8 +10471,8 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
@@ -8900,8 +10489,8 @@ entry:
 ; <label>:8                                       ; preds = %1
   %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
   %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
@@ -8911,15 +10500,15 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
   %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
   %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
-  br i1 %NullCheck6, label %21, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
@@ -8946,15 +10535,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8992,15 +10581,15 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
   store i8 %3, i8 addrspace(1)* %5
   %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
@@ -9011,7 +10600,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9027,8 +10616,8 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -9041,8 +10630,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
@@ -9058,7 +10647,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9080,8 +10669,8 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
@@ -9096,8 +10685,8 @@ entry:
 ; <label>:12                                      ; preds = %6
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
@@ -9112,8 +10701,8 @@ entry:
 ; <label>:21                                      ; preds = %15
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
@@ -9128,8 +10717,8 @@ entry:
 ; <label>:30                                      ; preds = %24
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %31, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
@@ -9144,8 +10733,8 @@ entry:
 ; <label>:39                                      ; preds = %33
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
-  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %40, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %42
 
 ; <label>:42                                      ; preds = %39
   %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
@@ -9164,19 +10753,19 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %21
+ThrowNullRef4:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %30
+ThrowNullRef6:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %39
+ThrowNullRef8:                                    ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9243,8 +10832,8 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
@@ -9264,57 +10853,57 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
   store i8 0, i8 addrspace(1)* %2
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
   store i8 0, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
   store i8 0, i8 addrspace(1)* %17
   %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
   store i8 0, i8 addrspace(1)* %20
   %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
-  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
@@ -9325,31 +10914,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %19
+ThrowNullRef14:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9367,8 +10956,8 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
@@ -9380,8 +10969,8 @@ entry:
 
 ; <label>:9                                       ; preds = %4
   %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %9
   %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
@@ -9395,7 +10984,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef2:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9420,8 +11009,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
@@ -9512,8 +11101,8 @@ entry:
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
@@ -9524,8 +11113,8 @@ entry:
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = load i64, i64 addrspace(1)* %12
@@ -9537,8 +11126,8 @@ entry:
   %20 = load i64, i64* %19
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
-  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %13
   %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
@@ -9555,8 +11144,8 @@ entry:
 ; <label>:30                                      ; preds = %25
   %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %32 = load i32, i32* %arg2
-  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
-  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
@@ -9570,15 +11159,15 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %30
+ThrowNullRef2:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9622,87 +11211,87 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
   %10 = load i8, i8 addrspace(1)* %9, align 8
   %11 = zext i8 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %8
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
   store i8 %12, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
   %19 = load i8, i8 addrspace(1)* %18, align 8
   %20 = zext i8 %19 to i32
   %21 = trunc i32 %20 to i8
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
   store i8 %21, i8 addrspace(1)* %23
   %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
   %28 = load i8, i8 addrspace(1)* %27, align 8
   %29 = zext i8 %28 to i32
   %30 = trunc i32 %29 to i8
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
-  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %31
 
 ; <label>:31                                      ; preds = %26
   %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
   store i8 %30, i8 addrspace(1)* %32
   %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
-  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
-  br i1 %NullCheck14, label %40, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %40
 
 ; <label>:40                                      ; preds = %35
   %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
   store i8 %39, i8 addrspace(1)* %41
   %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
-  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %44
 
 ; <label>:44                                      ; preds = %40
   %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
   %46 = load i8, i8 addrspace(1)* %45, align 8
   %47 = zext i8 %46 to i32
   %48 = trunc i32 %47 to i8
-  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
   store i8 %48, i8 addrspace(1)* %50
   %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
-  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
@@ -9713,29 +11302,29 @@ entry:
 ; <label>:56                                      ; preds = %52
   %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
-  br i1 %NullCheck22, label %59, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
   %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
   %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
-  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
-  br i1 %NullCheck24, label %63, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
   %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
-  br i1 %NullCheck26, label %66, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
   %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
-  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
-  br i1 %NullCheck28, label %69, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %69
 
 ; <label>:69                                      ; preds = %66
   %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
@@ -9744,15 +11333,15 @@ entry:
 
 ; <label>:71                                      ; preds = %105
   %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
-  br i1 %NullCheck34, label %73, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %73
 
 ; <label>:73                                      ; preds = %71
   %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
   %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
   %76 = load i32, i32* %loc0
-  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
-  br i1 %NullCheck36, label %77, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
@@ -9766,8 +11355,8 @@ entry:
 
 ; <label>:83                                      ; preds = %77
   %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
-  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
@@ -9775,14 +11364,14 @@ entry:
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
   %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
-  br i1 %NullCheck40, label %91, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
 ; <label>:91                                      ; preds = %85
   %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
   %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
-  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck42, label %94, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %94
 
 ; <label>:94                                      ; preds = %91
   %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
@@ -9798,14 +11387,14 @@ entry:
 ; <label>:99                                      ; preds = %69, %96
   %100 = load i32, i32* %loc0
   %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
-  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %102
 
 ; <label>:102                                     ; preds = %99
   %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
   %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
-  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
-  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
@@ -9819,87 +11408,87 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %26
+ThrowNullRef10:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %31
+ThrowNullRef12:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %35
+ThrowNullRef14:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %40
+ThrowNullRef16:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %56
+ThrowNullRef22:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %59
+ThrowNullRef24:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %63
+ThrowNullRef26:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %66
+ThrowNullRef28:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %102
+ThrowNullRef32:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %71
+ThrowNullRef34:                                   ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %73
+ThrowNullRef36:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %83
+ThrowNullRef38:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %85
+ThrowNullRef40:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %91
+ThrowNullRef42:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9943,15 +11532,15 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
   %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
@@ -9961,28 +11550,28 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
   %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %12
   %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
   %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
   %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
-  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
@@ -9993,23 +11582,23 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %12
+ThrowNullRef6:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10031,15 +11620,15 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
   %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = load i64, i64 addrspace(1)* %7
@@ -10077,13 +11666,13 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[loadElem]
+Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -10111,8 +11700,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueEqDbl.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueEqDbl.error.txt
@@ -25,8 +25,8 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
@@ -40,8 +40,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
   %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
@@ -75,7 +75,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -90,8 +90,8 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %NullCheck = icmp ne i8 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = load i8, i8 addrspace(1)* %0, align 8
@@ -125,8 +125,8 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
@@ -159,8 +159,8 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -184,8 +184,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
   store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
@@ -195,8 +195,8 @@ entry:
 ; <label>:4                                       ; preds = %1
   %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
   %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
@@ -206,8 +206,8 @@ entry:
   %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
@@ -221,14 +221,14 @@ entry:
 
 ; <label>:17                                      ; preds = %14
   %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
   %21 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
@@ -238,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -249,8 +249,8 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
@@ -261,27 +261,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %30
+ThrowNullRef10:                                   ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -301,7 +301,89 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
-Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
+Successfully read AppDomainSetup.GetUnsecureApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.GetUnsecureApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %NullCheck = icmp eq %"System.String[]" addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %BoundsCheck = icmp uge i64 0, %5
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %6
+
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 3, i32 0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
+  ret %System.String addrspace(1)* %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_Value using LLILCJit
+Successfully read AppDomainSetup.get_Value
+
+define %"System.String[]" addrspace(1)* @AppDomainSetup.get_Value(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.String[]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 18)
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.String[]" addrspace(1)* addrspace(1)*, %"System.String[]" addrspace(1)*)*)(%"System.String[]" addrspace(1)* addrspace(1)* %9, %"System.String[]" addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %11, i32 0, i32 1
+  %14 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %13, align 8
+  ret %"System.String[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -319,8 +401,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -368,16 +450,16 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
   %5 = load i32, i32 addrspace(1)* %4
   %6 = sub i32 %5, 1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -389,7 +471,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -421,8 +503,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
@@ -456,8 +538,8 @@ entry:
 ; <label>:27                                      ; preds = %19
   %28 = load i32, i32* %arg1
   %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
-  br i1 %NullCheck2, label %30, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %29, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %30
 
 ; <label>:30                                      ; preds = %27
   %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
@@ -493,8 +575,8 @@ entry:
 ; <label>:49                                      ; preds = %46
   %50 = load i32, i32* %arg2
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck4, label %52, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
@@ -517,11 +599,11 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %27
+ThrowNullRef2:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %49
+ThrowNullRef4:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -544,16 +626,16 @@ entry:
   %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %0)
   store %System.String addrspace(1)* %1, %System.String addrspace(1)** %loc0
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 2
   %5 = bitcast [0 x i16] addrspace(1)* %4 to i16 addrspace(1)*
   store i16 addrspace(1)* %5, i16 addrspace(1)** %loc1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %3
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2
@@ -580,7 +662,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -691,15 +773,15 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %NullCheck132 = icmp ne i8* %21, null
-  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+  %NullCheck131 = icmp eq i8* %21, null
+  br i1 %NullCheck131, label %ThrowNullRef132, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = load i8, i8* %21, align 8
   %24 = zext i8 %23 to i32
   %25 = trunc i32 %24 to i8
-  %NullCheck134 = icmp ne i8* %20, null
-  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+  %NullCheck133 = icmp eq i8* %20, null
+  br i1 %NullCheck133, label %ThrowNullRef134, label %26
 
 ; <label>:26                                      ; preds = %22
   store i8 %25, i8* %20, align 8
@@ -709,16 +791,16 @@ entry:
   %28 = load i8*, i8** %arg0
   %29 = load i8*, i8** %arg1
   %30 = bitcast i8* %29 to i16*
-  %NullCheck128 = icmp ne i16* %30, null
-  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+  %NullCheck127 = icmp eq i16* %30, null
+  br i1 %NullCheck127, label %ThrowNullRef128, label %31
 
 ; <label>:31                                      ; preds = %27
   %32 = load i16, i16* %30, align 8
   %33 = sext i16 %32 to i32
   %34 = bitcast i8* %28 to i16*
   %35 = trunc i32 %33 to i16
-  %NullCheck130 = icmp ne i16* %34, null
-  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+  %NullCheck129 = icmp eq i16* %34, null
+  br i1 %NullCheck129, label %ThrowNullRef130, label %36
 
 ; <label>:36                                      ; preds = %31
   store i16 %35, i16* %34, align 8
@@ -728,16 +810,16 @@ entry:
   %38 = load i8*, i8** %arg0
   %39 = load i8*, i8** %arg1
   %40 = bitcast i8* %39 to i16*
-  %NullCheck120 = icmp ne i16* %40, null
-  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+  %NullCheck119 = icmp eq i16* %40, null
+  br i1 %NullCheck119, label %ThrowNullRef120, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i16, i16* %40, align 8
   %43 = sext i16 %42 to i32
   %44 = bitcast i8* %38 to i16*
   %45 = trunc i32 %43 to i16
-  %NullCheck122 = icmp ne i16* %44, null
-  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+  %NullCheck121 = icmp eq i16* %44, null
+  br i1 %NullCheck121, label %ThrowNullRef122, label %46
 
 ; <label>:46                                      ; preds = %41
   store i16 %45, i16* %44, align 8
@@ -745,15 +827,15 @@ entry:
   %48 = getelementptr inbounds i8, i8* %47, i64 2
   %49 = load i8*, i8** %arg1
   %50 = getelementptr inbounds i8, i8* %49, i64 2
-  %NullCheck124 = icmp ne i8* %50, null
-  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+  %NullCheck123 = icmp eq i8* %50, null
+  br i1 %NullCheck123, label %ThrowNullRef124, label %51
 
 ; <label>:51                                      ; preds = %46
   %52 = load i8, i8* %50, align 8
   %53 = zext i8 %52 to i32
   %54 = trunc i32 %53 to i8
-  %NullCheck126 = icmp ne i8* %48, null
-  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+  %NullCheck125 = icmp eq i8* %48, null
+  br i1 %NullCheck125, label %ThrowNullRef126, label %55
 
 ; <label>:55                                      ; preds = %51
   store i8 %54, i8* %48, align 8
@@ -763,14 +845,14 @@ entry:
   %57 = load i8*, i8** %arg0
   %58 = load i8*, i8** %arg1
   %59 = bitcast i8* %58 to i32*
-  %NullCheck116 = icmp ne i32* %59, null
-  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+  %NullCheck115 = icmp eq i32* %59, null
+  br i1 %NullCheck115, label %ThrowNullRef116, label %60
 
 ; <label>:60                                      ; preds = %56
   %61 = load i32, i32* %59, align 8
   %62 = bitcast i8* %57 to i32*
-  %NullCheck118 = icmp ne i32* %62, null
-  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+  %NullCheck117 = icmp eq i32* %62, null
+  br i1 %NullCheck117, label %ThrowNullRef118, label %63
 
 ; <label>:63                                      ; preds = %60
   store i32 %61, i32* %62, align 8
@@ -780,14 +862,14 @@ entry:
   %65 = load i8*, i8** %arg0
   %66 = load i8*, i8** %arg1
   %67 = bitcast i8* %66 to i32*
-  %NullCheck108 = icmp ne i32* %67, null
-  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+  %NullCheck107 = icmp eq i32* %67, null
+  br i1 %NullCheck107, label %ThrowNullRef108, label %68
 
 ; <label>:68                                      ; preds = %64
   %69 = load i32, i32* %67, align 8
   %70 = bitcast i8* %65 to i32*
-  %NullCheck110 = icmp ne i32* %70, null
-  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+  %NullCheck109 = icmp eq i32* %70, null
+  br i1 %NullCheck109, label %ThrowNullRef110, label %71
 
 ; <label>:71                                      ; preds = %68
   store i32 %69, i32* %70, align 8
@@ -795,15 +877,15 @@ entry:
   %73 = getelementptr inbounds i8, i8* %72, i64 4
   %74 = load i8*, i8** %arg1
   %75 = getelementptr inbounds i8, i8* %74, i64 4
-  %NullCheck112 = icmp ne i8* %75, null
-  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+  %NullCheck111 = icmp eq i8* %75, null
+  br i1 %NullCheck111, label %ThrowNullRef112, label %76
 
 ; <label>:76                                      ; preds = %71
   %77 = load i8, i8* %75, align 8
   %78 = zext i8 %77 to i32
   %79 = trunc i32 %78 to i8
-  %NullCheck114 = icmp ne i8* %73, null
-  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+  %NullCheck113 = icmp eq i8* %73, null
+  br i1 %NullCheck113, label %ThrowNullRef114, label %80
 
 ; <label>:80                                      ; preds = %76
   store i8 %79, i8* %73, align 8
@@ -813,14 +895,14 @@ entry:
   %82 = load i8*, i8** %arg0
   %83 = load i8*, i8** %arg1
   %84 = bitcast i8* %83 to i32*
-  %NullCheck100 = icmp ne i32* %84, null
-  br i1 %NullCheck100, label %85, label %ThrowNullRef99
+  %NullCheck99 = icmp eq i32* %84, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %85
 
 ; <label>:85                                      ; preds = %81
   %86 = load i32, i32* %84, align 8
   %87 = bitcast i8* %82 to i32*
-  %NullCheck102 = icmp ne i32* %87, null
-  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+  %NullCheck101 = icmp eq i32* %87, null
+  br i1 %NullCheck101, label %ThrowNullRef102, label %88
 
 ; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
@@ -829,16 +911,16 @@ entry:
   %91 = load i8*, i8** %arg1
   %92 = getelementptr inbounds i8, i8* %91, i64 4
   %93 = bitcast i8* %92 to i16*
-  %NullCheck104 = icmp ne i16* %93, null
-  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+  %NullCheck103 = icmp eq i16* %93, null
+  br i1 %NullCheck103, label %ThrowNullRef104, label %94
 
 ; <label>:94                                      ; preds = %88
   %95 = load i16, i16* %93, align 8
   %96 = sext i16 %95 to i32
   %97 = bitcast i8* %90 to i16*
   %98 = trunc i32 %96 to i16
-  %NullCheck106 = icmp ne i16* %97, null
-  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+  %NullCheck105 = icmp eq i16* %97, null
+  br i1 %NullCheck105, label %ThrowNullRef106, label %99
 
 ; <label>:99                                      ; preds = %94
   store i16 %98, i16* %97, align 8
@@ -848,14 +930,14 @@ entry:
   %101 = load i8*, i8** %arg0
   %102 = load i8*, i8** %arg1
   %103 = bitcast i8* %102 to i32*
-  %NullCheck88 = icmp ne i32* %103, null
-  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+  %NullCheck87 = icmp eq i32* %103, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %104
 
 ; <label>:104                                     ; preds = %100
   %105 = load i32, i32* %103, align 8
   %106 = bitcast i8* %101 to i32*
-  %NullCheck90 = icmp ne i32* %106, null
-  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+  %NullCheck89 = icmp eq i32* %106, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %107
 
 ; <label>:107                                     ; preds = %104
   store i32 %105, i32* %106, align 8
@@ -864,16 +946,16 @@ entry:
   %110 = load i8*, i8** %arg1
   %111 = getelementptr inbounds i8, i8* %110, i64 4
   %112 = bitcast i8* %111 to i16*
-  %NullCheck92 = icmp ne i16* %112, null
-  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+  %NullCheck91 = icmp eq i16* %112, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %113
 
 ; <label>:113                                     ; preds = %107
   %114 = load i16, i16* %112, align 8
   %115 = sext i16 %114 to i32
   %116 = bitcast i8* %109 to i16*
   %117 = trunc i32 %115 to i16
-  %NullCheck94 = icmp ne i16* %116, null
-  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+  %NullCheck93 = icmp eq i16* %116, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %118
 
 ; <label>:118                                     ; preds = %113
   store i16 %117, i16* %116, align 8
@@ -881,15 +963,15 @@ entry:
   %120 = getelementptr inbounds i8, i8* %119, i64 6
   %121 = load i8*, i8** %arg1
   %122 = getelementptr inbounds i8, i8* %121, i64 6
-  %NullCheck96 = icmp ne i8* %122, null
-  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+  %NullCheck95 = icmp eq i8* %122, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %123
 
 ; <label>:123                                     ; preds = %118
   %124 = load i8, i8* %122, align 8
   %125 = zext i8 %124 to i32
   %126 = trunc i32 %125 to i8
-  %NullCheck98 = icmp ne i8* %120, null
-  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+  %NullCheck97 = icmp eq i8* %120, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %127
 
 ; <label>:127                                     ; preds = %123
   store i8 %126, i8* %120, align 8
@@ -899,14 +981,14 @@ entry:
   %129 = load i8*, i8** %arg0
   %130 = load i8*, i8** %arg1
   %131 = bitcast i8* %130 to i64*
-  %NullCheck84 = icmp ne i64* %131, null
-  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+  %NullCheck83 = icmp eq i64* %131, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %132
 
 ; <label>:132                                     ; preds = %128
   %133 = load i64, i64* %131, align 8
   %134 = bitcast i8* %129 to i64*
-  %NullCheck86 = icmp ne i64* %134, null
-  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+  %NullCheck85 = icmp eq i64* %134, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %135
 
 ; <label>:135                                     ; preds = %132
   store i64 %133, i64* %134, align 8
@@ -916,14 +998,14 @@ entry:
   %137 = load i8*, i8** %arg0
   %138 = load i8*, i8** %arg1
   %139 = bitcast i8* %138 to i64*
-  %NullCheck76 = icmp ne i64* %139, null
-  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+  %NullCheck75 = icmp eq i64* %139, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %140
 
 ; <label>:140                                     ; preds = %136
   %141 = load i64, i64* %139, align 8
   %142 = bitcast i8* %137 to i64*
-  %NullCheck78 = icmp ne i64* %142, null
-  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+  %NullCheck77 = icmp eq i64* %142, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %143
 
 ; <label>:143                                     ; preds = %140
   store i64 %141, i64* %142, align 8
@@ -931,15 +1013,15 @@ entry:
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %NullCheck80 = icmp ne i8* %147, null
-  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+  %NullCheck79 = icmp eq i8* %147, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %148
 
 ; <label>:148                                     ; preds = %143
   %149 = load i8, i8* %147, align 8
   %150 = zext i8 %149 to i32
   %151 = trunc i32 %150 to i8
-  %NullCheck82 = icmp ne i8* %145, null
-  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+  %NullCheck81 = icmp eq i8* %145, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %152
 
 ; <label>:152                                     ; preds = %148
   store i8 %151, i8* %145, align 8
@@ -949,14 +1031,14 @@ entry:
   %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
   %156 = bitcast i8* %155 to i64*
-  %NullCheck68 = icmp ne i64* %156, null
-  br i1 %NullCheck68, label %157, label %ThrowNullRef67
+  %NullCheck67 = icmp eq i64* %156, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %157
 
 ; <label>:157                                     ; preds = %153
   %158 = load i64, i64* %156, align 8
   %159 = bitcast i8* %154 to i64*
-  %NullCheck70 = icmp ne i64* %159, null
-  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+  %NullCheck69 = icmp eq i64* %159, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %160
 
 ; <label>:160                                     ; preds = %157
   store i64 %158, i64* %159, align 8
@@ -965,16 +1047,16 @@ entry:
   %163 = load i8*, i8** %arg1
   %164 = getelementptr inbounds i8, i8* %163, i64 8
   %165 = bitcast i8* %164 to i16*
-  %NullCheck72 = icmp ne i16* %165, null
-  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+  %NullCheck71 = icmp eq i16* %165, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %166
 
 ; <label>:166                                     ; preds = %160
   %167 = load i16, i16* %165, align 8
   %168 = sext i16 %167 to i32
   %169 = bitcast i8* %162 to i16*
   %170 = trunc i32 %168 to i16
-  %NullCheck74 = icmp ne i16* %169, null
-  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+  %NullCheck73 = icmp eq i16* %169, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %171
 
 ; <label>:171                                     ; preds = %166
   store i16 %170, i16* %169, align 8
@@ -984,14 +1066,14 @@ entry:
   %173 = load i8*, i8** %arg0
   %174 = load i8*, i8** %arg1
   %175 = bitcast i8* %174 to i64*
-  %NullCheck56 = icmp ne i64* %175, null
-  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+  %NullCheck55 = icmp eq i64* %175, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %176
 
 ; <label>:176                                     ; preds = %172
   %177 = load i64, i64* %175, align 8
   %178 = bitcast i8* %173 to i64*
-  %NullCheck58 = icmp ne i64* %178, null
-  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+  %NullCheck57 = icmp eq i64* %178, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %179
 
 ; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
@@ -1000,16 +1082,16 @@ entry:
   %182 = load i8*, i8** %arg1
   %183 = getelementptr inbounds i8, i8* %182, i64 8
   %184 = bitcast i8* %183 to i16*
-  %NullCheck60 = icmp ne i16* %184, null
-  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+  %NullCheck59 = icmp eq i16* %184, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %185
 
 ; <label>:185                                     ; preds = %179
   %186 = load i16, i16* %184, align 8
   %187 = sext i16 %186 to i32
   %188 = bitcast i8* %181 to i16*
   %189 = trunc i32 %187 to i16
-  %NullCheck62 = icmp ne i16* %188, null
-  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+  %NullCheck61 = icmp eq i16* %188, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %190
 
 ; <label>:190                                     ; preds = %185
   store i16 %189, i16* %188, align 8
@@ -1017,15 +1099,15 @@ entry:
   %192 = getelementptr inbounds i8, i8* %191, i64 10
   %193 = load i8*, i8** %arg1
   %194 = getelementptr inbounds i8, i8* %193, i64 10
-  %NullCheck64 = icmp ne i8* %194, null
-  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+  %NullCheck63 = icmp eq i8* %194, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %195
 
 ; <label>:195                                     ; preds = %190
   %196 = load i8, i8* %194, align 8
   %197 = zext i8 %196 to i32
   %198 = trunc i32 %197 to i8
-  %NullCheck66 = icmp ne i8* %192, null
-  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+  %NullCheck65 = icmp eq i8* %192, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %199
 
 ; <label>:199                                     ; preds = %195
   store i8 %198, i8* %192, align 8
@@ -1035,14 +1117,14 @@ entry:
   %201 = load i8*, i8** %arg0
   %202 = load i8*, i8** %arg1
   %203 = bitcast i8* %202 to i64*
-  %NullCheck48 = icmp ne i64* %203, null
-  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+  %NullCheck47 = icmp eq i64* %203, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %204
 
 ; <label>:204                                     ; preds = %200
   %205 = load i64, i64* %203, align 8
   %206 = bitcast i8* %201 to i64*
-  %NullCheck50 = icmp ne i64* %206, null
-  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+  %NullCheck49 = icmp eq i64* %206, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %207
 
 ; <label>:207                                     ; preds = %204
   store i64 %205, i64* %206, align 8
@@ -1051,14 +1133,14 @@ entry:
   %210 = load i8*, i8** %arg1
   %211 = getelementptr inbounds i8, i8* %210, i64 8
   %212 = bitcast i8* %211 to i32*
-  %NullCheck52 = icmp ne i32* %212, null
-  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+  %NullCheck51 = icmp eq i32* %212, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %213
 
 ; <label>:213                                     ; preds = %207
   %214 = load i32, i32* %212, align 8
   %215 = bitcast i8* %209 to i32*
-  %NullCheck54 = icmp ne i32* %215, null
-  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+  %NullCheck53 = icmp eq i32* %215, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %216
 
 ; <label>:216                                     ; preds = %213
   store i32 %214, i32* %215, align 8
@@ -1068,14 +1150,14 @@ entry:
   %218 = load i8*, i8** %arg0
   %219 = load i8*, i8** %arg1
   %220 = bitcast i8* %219 to i64*
-  %NullCheck36 = icmp ne i64* %220, null
-  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64* %220, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %221
 
 ; <label>:221                                     ; preds = %217
   %222 = load i64, i64* %220, align 8
   %223 = bitcast i8* %218 to i64*
-  %NullCheck38 = icmp ne i64* %223, null
-  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+  %NullCheck37 = icmp eq i64* %223, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %224
 
 ; <label>:224                                     ; preds = %221
   store i64 %222, i64* %223, align 8
@@ -1084,14 +1166,14 @@ entry:
   %227 = load i8*, i8** %arg1
   %228 = getelementptr inbounds i8, i8* %227, i64 8
   %229 = bitcast i8* %228 to i32*
-  %NullCheck40 = icmp ne i32* %229, null
-  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i32* %229, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %230
 
 ; <label>:230                                     ; preds = %224
   %231 = load i32, i32* %229, align 8
   %232 = bitcast i8* %226 to i32*
-  %NullCheck42 = icmp ne i32* %232, null
-  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+  %NullCheck41 = icmp eq i32* %232, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %233
 
 ; <label>:233                                     ; preds = %230
   store i32 %231, i32* %232, align 8
@@ -1099,15 +1181,15 @@ entry:
   %235 = getelementptr inbounds i8, i8* %234, i64 12
   %236 = load i8*, i8** %arg1
   %237 = getelementptr inbounds i8, i8* %236, i64 12
-  %NullCheck44 = icmp ne i8* %237, null
-  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i8* %237, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %238
 
 ; <label>:238                                     ; preds = %233
   %239 = load i8, i8* %237, align 8
   %240 = zext i8 %239 to i32
   %241 = trunc i32 %240 to i8
-  %NullCheck46 = icmp ne i8* %235, null
-  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+  %NullCheck45 = icmp eq i8* %235, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %242
 
 ; <label>:242                                     ; preds = %238
   store i8 %241, i8* %235, align 8
@@ -1117,14 +1199,14 @@ entry:
   %244 = load i8*, i8** %arg0
   %245 = load i8*, i8** %arg1
   %246 = bitcast i8* %245 to i64*
-  %NullCheck24 = icmp ne i64* %246, null
-  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64* %246, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %247
 
 ; <label>:247                                     ; preds = %243
   %248 = load i64, i64* %246, align 8
   %249 = bitcast i8* %244 to i64*
-  %NullCheck26 = icmp ne i64* %249, null
-  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64* %249, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %250
 
 ; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
@@ -1133,14 +1215,14 @@ entry:
   %253 = load i8*, i8** %arg1
   %254 = getelementptr inbounds i8, i8* %253, i64 8
   %255 = bitcast i8* %254 to i32*
-  %NullCheck28 = icmp ne i32* %255, null
-  br i1 %NullCheck28, label %256, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i32* %255, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %256
 
 ; <label>:256                                     ; preds = %250
   %257 = load i32, i32* %255, align 8
   %258 = bitcast i8* %252 to i32*
-  %NullCheck30 = icmp ne i32* %258, null
-  br i1 %NullCheck30, label %259, label %ThrowNullRef29
+  %NullCheck29 = icmp eq i32* %258, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %259
 
 ; <label>:259                                     ; preds = %256
   store i32 %257, i32* %258, align 8
@@ -1149,16 +1231,16 @@ entry:
   %262 = load i8*, i8** %arg1
   %263 = getelementptr inbounds i8, i8* %262, i64 12
   %264 = bitcast i8* %263 to i16*
-  %NullCheck32 = icmp ne i16* %264, null
-  br i1 %NullCheck32, label %265, label %ThrowNullRef31
+  %NullCheck31 = icmp eq i16* %264, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %265
 
 ; <label>:265                                     ; preds = %259
   %266 = load i16, i16* %264, align 8
   %267 = sext i16 %266 to i32
   %268 = bitcast i8* %261 to i16*
   %269 = trunc i32 %267 to i16
-  %NullCheck34 = icmp ne i16* %268, null
-  br i1 %NullCheck34, label %270, label %ThrowNullRef33
+  %NullCheck33 = icmp eq i16* %268, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %270
 
 ; <label>:270                                     ; preds = %265
   store i16 %269, i16* %268, align 8
@@ -1168,14 +1250,14 @@ entry:
   %272 = load i8*, i8** %arg0
   %273 = load i8*, i8** %arg1
   %274 = bitcast i8* %273 to i64*
-  %NullCheck8 = icmp ne i64* %274, null
-  br i1 %NullCheck8, label %275, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64* %274, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %275
 
 ; <label>:275                                     ; preds = %271
   %276 = load i64, i64* %274, align 8
   %277 = bitcast i8* %272 to i64*
-  %NullCheck10 = icmp ne i64* %277, null
-  br i1 %NullCheck10, label %278, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %277, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %278
 
 ; <label>:278                                     ; preds = %275
   store i64 %276, i64* %277, align 8
@@ -1184,14 +1266,14 @@ entry:
   %281 = load i8*, i8** %arg1
   %282 = getelementptr inbounds i8, i8* %281, i64 8
   %283 = bitcast i8* %282 to i32*
-  %NullCheck12 = icmp ne i32* %283, null
-  br i1 %NullCheck12, label %284, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i32* %283, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %284
 
 ; <label>:284                                     ; preds = %278
   %285 = load i32, i32* %283, align 8
   %286 = bitcast i8* %280 to i32*
-  %NullCheck14 = icmp ne i32* %286, null
-  br i1 %NullCheck14, label %287, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i32* %286, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %287
 
 ; <label>:287                                     ; preds = %284
   store i32 %285, i32* %286, align 8
@@ -1200,16 +1282,16 @@ entry:
   %290 = load i8*, i8** %arg1
   %291 = getelementptr inbounds i8, i8* %290, i64 12
   %292 = bitcast i8* %291 to i16*
-  %NullCheck16 = icmp ne i16* %292, null
-  br i1 %NullCheck16, label %293, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i16* %292, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %293
 
 ; <label>:293                                     ; preds = %287
   %294 = load i16, i16* %292, align 8
   %295 = sext i16 %294 to i32
   %296 = bitcast i8* %289 to i16*
   %297 = trunc i32 %295 to i16
-  %NullCheck18 = icmp ne i16* %296, null
-  br i1 %NullCheck18, label %298, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i16* %296, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %298
 
 ; <label>:298                                     ; preds = %293
   store i16 %297, i16* %296, align 8
@@ -1217,15 +1299,15 @@ entry:
   %300 = getelementptr inbounds i8, i8* %299, i64 14
   %301 = load i8*, i8** %arg1
   %302 = getelementptr inbounds i8, i8* %301, i64 14
-  %NullCheck20 = icmp ne i8* %302, null
-  br i1 %NullCheck20, label %303, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i8* %302, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %303
 
 ; <label>:303                                     ; preds = %298
   %304 = load i8, i8* %302, align 8
   %305 = zext i8 %304 to i32
   %306 = trunc i32 %305 to i8
-  %NullCheck22 = icmp ne i8* %300, null
-  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i8* %300, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %307
 
 ; <label>:307                                     ; preds = %303
   store i8 %306, i8* %300, align 8
@@ -1235,14 +1317,14 @@ entry:
   %309 = load i8*, i8** %arg0
   %310 = load i8*, i8** %arg1
   %311 = bitcast i8* %310 to i64*
-  %NullCheck = icmp ne i64* %311, null
-  br i1 %NullCheck, label %312, label %ThrowNullRef
+  %NullCheck = icmp eq i64* %311, null
+  br i1 %NullCheck, label %ThrowNullRef, label %312
 
 ; <label>:312                                     ; preds = %308
   %313 = load i64, i64* %311, align 8
   %314 = bitcast i8* %309 to i64*
-  %NullCheck2 = icmp ne i64* %314, null
-  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64* %314, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %315
 
 ; <label>:315                                     ; preds = %312
   store i64 %313, i64* %314, align 8
@@ -1251,14 +1333,14 @@ entry:
   %318 = load i8*, i8** %arg1
   %319 = getelementptr inbounds i8, i8* %318, i64 8
   %320 = bitcast i8* %319 to i64*
-  %NullCheck4 = icmp ne i64* %320, null
-  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64* %320, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %321
 
 ; <label>:321                                     ; preds = %315
   %322 = load i64, i64* %320, align 8
   %323 = bitcast i8* %317 to i64*
-  %NullCheck6 = icmp ne i64* %323, null
-  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64* %323, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %324
 
 ; <label>:324                                     ; preds = %321
   store i64 %322, i64* %323, align 8
@@ -1286,15 +1368,15 @@ entry:
 ; <label>:338                                     ; preds = %333
   %339 = load i8*, i8** %arg0
   %340 = load i8*, i8** %arg1
-  %NullCheck136 = icmp ne i8* %340, null
-  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+  %NullCheck135 = icmp eq i8* %340, null
+  br i1 %NullCheck135, label %ThrowNullRef136, label %341
 
 ; <label>:341                                     ; preds = %338
   %342 = load i8, i8* %340, align 8
   %343 = zext i8 %342 to i32
   %344 = trunc i32 %343 to i8
-  %NullCheck138 = icmp ne i8* %339, null
-  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+  %NullCheck137 = icmp eq i8* %339, null
+  br i1 %NullCheck137, label %ThrowNullRef138, label %345
 
 ; <label>:345                                     ; preds = %341
   store i8 %344, i8* %339, align 8
@@ -1317,16 +1399,16 @@ entry:
   %357 = load i8*, i8** %arg0
   %358 = load i8*, i8** %arg1
   %359 = bitcast i8* %358 to i16*
-  %NullCheck140 = icmp ne i16* %359, null
-  br i1 %NullCheck140, label %360, label %ThrowNullRef139
+  %NullCheck139 = icmp eq i16* %359, null
+  br i1 %NullCheck139, label %ThrowNullRef140, label %360
 
 ; <label>:360                                     ; preds = %356
   %361 = load i16, i16* %359, align 8
   %362 = sext i16 %361 to i32
   %363 = bitcast i8* %357 to i16*
   %364 = trunc i32 %362 to i16
-  %NullCheck142 = icmp ne i16* %363, null
-  br i1 %NullCheck142, label %365, label %ThrowNullRef141
+  %NullCheck141 = icmp eq i16* %363, null
+  br i1 %NullCheck141, label %ThrowNullRef142, label %365
 
 ; <label>:365                                     ; preds = %360
   store i16 %364, i16* %363, align 8
@@ -1352,14 +1434,14 @@ entry:
   %378 = load i8*, i8** %arg0
   %379 = load i8*, i8** %arg1
   %380 = bitcast i8* %379 to i32*
-  %NullCheck144 = icmp ne i32* %380, null
-  br i1 %NullCheck144, label %381, label %ThrowNullRef143
+  %NullCheck143 = icmp eq i32* %380, null
+  br i1 %NullCheck143, label %ThrowNullRef144, label %381
 
 ; <label>:381                                     ; preds = %377
   %382 = load i32, i32* %380, align 8
   %383 = bitcast i8* %378 to i32*
-  %NullCheck146 = icmp ne i32* %383, null
-  br i1 %NullCheck146, label %384, label %ThrowNullRef145
+  %NullCheck145 = icmp eq i32* %383, null
+  br i1 %NullCheck145, label %ThrowNullRef146, label %384
 
 ; <label>:384                                     ; preds = %381
   store i32 %382, i32* %383, align 8
@@ -1384,14 +1466,14 @@ entry:
   %395 = load i8*, i8** %arg0
   %396 = load i8*, i8** %arg1
   %397 = bitcast i8* %396 to i64*
-  %NullCheck164 = icmp ne i64* %397, null
-  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+  %NullCheck163 = icmp eq i64* %397, null
+  br i1 %NullCheck163, label %ThrowNullRef164, label %398
 
 ; <label>:398                                     ; preds = %394
   %399 = load i64, i64* %397, align 8
   %400 = bitcast i8* %395 to i64*
-  %NullCheck166 = icmp ne i64* %400, null
-  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+  %NullCheck165 = icmp eq i64* %400, null
+  br i1 %NullCheck165, label %ThrowNullRef166, label %401
 
 ; <label>:401                                     ; preds = %398
   store i64 %399, i64* %400, align 8
@@ -1400,14 +1482,14 @@ entry:
   %404 = load i8*, i8** %arg1
   %405 = getelementptr inbounds i8, i8* %404, i64 8
   %406 = bitcast i8* %405 to i64*
-  %NullCheck168 = icmp ne i64* %406, null
-  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+  %NullCheck167 = icmp eq i64* %406, null
+  br i1 %NullCheck167, label %ThrowNullRef168, label %407
 
 ; <label>:407                                     ; preds = %401
   %408 = load i64, i64* %406, align 8
   %409 = bitcast i8* %403 to i64*
-  %NullCheck170 = icmp ne i64* %409, null
-  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+  %NullCheck169 = icmp eq i64* %409, null
+  br i1 %NullCheck169, label %ThrowNullRef170, label %410
 
 ; <label>:410                                     ; preds = %407
   store i64 %408, i64* %409, align 8
@@ -1437,14 +1519,14 @@ entry:
   %425 = load i8*, i8** %arg0
   %426 = load i8*, i8** %arg1
   %427 = bitcast i8* %426 to i64*
-  %NullCheck148 = icmp ne i64* %427, null
-  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+  %NullCheck147 = icmp eq i64* %427, null
+  br i1 %NullCheck147, label %ThrowNullRef148, label %428
 
 ; <label>:428                                     ; preds = %424
   %429 = load i64, i64* %427, align 8
   %430 = bitcast i8* %425 to i64*
-  %NullCheck150 = icmp ne i64* %430, null
-  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+  %NullCheck149 = icmp eq i64* %430, null
+  br i1 %NullCheck149, label %ThrowNullRef150, label %431
 
 ; <label>:431                                     ; preds = %428
   store i64 %429, i64* %430, align 8
@@ -1466,14 +1548,14 @@ entry:
   %441 = load i8*, i8** %arg0
   %442 = load i8*, i8** %arg1
   %443 = bitcast i8* %442 to i32*
-  %NullCheck152 = icmp ne i32* %443, null
-  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+  %NullCheck151 = icmp eq i32* %443, null
+  br i1 %NullCheck151, label %ThrowNullRef152, label %444
 
 ; <label>:444                                     ; preds = %440
   %445 = load i32, i32* %443, align 8
   %446 = bitcast i8* %441 to i32*
-  %NullCheck154 = icmp ne i32* %446, null
-  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+  %NullCheck153 = icmp eq i32* %446, null
+  br i1 %NullCheck153, label %ThrowNullRef154, label %447
 
 ; <label>:447                                     ; preds = %444
   store i32 %445, i32* %446, align 8
@@ -1495,16 +1577,16 @@ entry:
   %457 = load i8*, i8** %arg0
   %458 = load i8*, i8** %arg1
   %459 = bitcast i8* %458 to i16*
-  %NullCheck156 = icmp ne i16* %459, null
-  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+  %NullCheck155 = icmp eq i16* %459, null
+  br i1 %NullCheck155, label %ThrowNullRef156, label %460
 
 ; <label>:460                                     ; preds = %456
   %461 = load i16, i16* %459, align 8
   %462 = sext i16 %461 to i32
   %463 = bitcast i8* %457 to i16*
   %464 = trunc i32 %462 to i16
-  %NullCheck158 = icmp ne i16* %463, null
-  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+  %NullCheck157 = icmp eq i16* %463, null
+  br i1 %NullCheck157, label %ThrowNullRef158, label %465
 
 ; <label>:465                                     ; preds = %460
   store i16 %464, i16* %463, align 8
@@ -1525,15 +1607,15 @@ entry:
 ; <label>:474                                     ; preds = %470
   %475 = load i8*, i8** %arg0
   %476 = load i8*, i8** %arg1
-  %NullCheck160 = icmp ne i8* %476, null
-  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+  %NullCheck159 = icmp eq i8* %476, null
+  br i1 %NullCheck159, label %ThrowNullRef160, label %477
 
 ; <label>:477                                     ; preds = %474
   %478 = load i8, i8* %476, align 8
   %479 = zext i8 %478 to i32
   %480 = trunc i32 %479 to i8
-  %NullCheck162 = icmp ne i8* %475, null
-  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+  %NullCheck161 = icmp eq i8* %475, null
+  br i1 %NullCheck161, label %ThrowNullRef162, label %481
 
 ; <label>:481                                     ; preds = %477
   store i8 %480, i8* %475, align 8
@@ -1553,343 +1635,343 @@ ThrowNullRef:                                     ; preds = %308
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %312
+ThrowNullRef2:                                    ; preds = %312
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %315
+ThrowNullRef4:                                    ; preds = %315
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %321
+ThrowNullRef6:                                    ; preds = %321
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %271
+ThrowNullRef8:                                    ; preds = %271
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %275
+ThrowNullRef10:                                   ; preds = %275
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %278
+ThrowNullRef12:                                   ; preds = %278
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %284
+ThrowNullRef14:                                   ; preds = %284
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %287
+ThrowNullRef16:                                   ; preds = %287
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %293
+ThrowNullRef18:                                   ; preds = %293
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %298
+ThrowNullRef20:                                   ; preds = %298
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %303
+ThrowNullRef22:                                   ; preds = %303
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %243
+ThrowNullRef24:                                   ; preds = %243
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %247
+ThrowNullRef26:                                   ; preds = %247
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %250
+ThrowNullRef28:                                   ; preds = %250
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %256
+ThrowNullRef30:                                   ; preds = %256
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %259
+ThrowNullRef32:                                   ; preds = %259
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %265
+ThrowNullRef34:                                   ; preds = %265
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %217
+ThrowNullRef36:                                   ; preds = %217
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %221
+ThrowNullRef38:                                   ; preds = %221
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %224
+ThrowNullRef40:                                   ; preds = %224
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %230
+ThrowNullRef42:                                   ; preds = %230
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %233
+ThrowNullRef44:                                   ; preds = %233
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %238
+ThrowNullRef46:                                   ; preds = %238
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %200
+ThrowNullRef48:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %204
+ThrowNullRef50:                                   ; preds = %204
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %207
+ThrowNullRef52:                                   ; preds = %207
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %213
+ThrowNullRef54:                                   ; preds = %213
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %172
+ThrowNullRef56:                                   ; preds = %172
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %176
+ThrowNullRef58:                                   ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %179
+ThrowNullRef60:                                   ; preds = %179
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %185
+ThrowNullRef62:                                   ; preds = %185
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %190
+ThrowNullRef64:                                   ; preds = %190
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %195
+ThrowNullRef66:                                   ; preds = %195
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %153
+ThrowNullRef68:                                   ; preds = %153
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %157
+ThrowNullRef70:                                   ; preds = %157
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %160
+ThrowNullRef72:                                   ; preds = %160
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %166
+ThrowNullRef74:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %136
+ThrowNullRef76:                                   ; preds = %136
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %140
+ThrowNullRef78:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %143
+ThrowNullRef80:                                   ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %148
+ThrowNullRef82:                                   ; preds = %148
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %128
+ThrowNullRef84:                                   ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %132
+ThrowNullRef86:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %100
+ThrowNullRef88:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %104
+ThrowNullRef90:                                   ; preds = %104
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %107
+ThrowNullRef92:                                   ; preds = %107
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %113
+ThrowNullRef94:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %118
+ThrowNullRef96:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %123
+ThrowNullRef98:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %81
+ThrowNullRef100:                                  ; preds = %81
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef101:                                  ; preds = %85
+ThrowNullRef102:                                  ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef103:                                  ; preds = %88
+ThrowNullRef104:                                  ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef105:                                  ; preds = %94
+ThrowNullRef106:                                  ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef107:                                  ; preds = %64
+ThrowNullRef108:                                  ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef109:                                  ; preds = %68
+ThrowNullRef110:                                  ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef111:                                  ; preds = %71
+ThrowNullRef112:                                  ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef113:                                  ; preds = %76
+ThrowNullRef114:                                  ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef115:                                  ; preds = %56
+ThrowNullRef116:                                  ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef117:                                  ; preds = %60
+ThrowNullRef118:                                  ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef119:                                  ; preds = %37
+ThrowNullRef120:                                  ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef121:                                  ; preds = %41
+ThrowNullRef122:                                  ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef123:                                  ; preds = %46
+ThrowNullRef124:                                  ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef125:                                  ; preds = %51
+ThrowNullRef126:                                  ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef127:                                  ; preds = %27
+ThrowNullRef128:                                  ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef129:                                  ; preds = %31
+ThrowNullRef130:                                  ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef131:                                  ; preds = %19
+ThrowNullRef132:                                  ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef133:                                  ; preds = %22
+ThrowNullRef134:                                  ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef135:                                  ; preds = %338
+ThrowNullRef136:                                  ; preds = %338
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef137:                                  ; preds = %341
+ThrowNullRef138:                                  ; preds = %341
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef139:                                  ; preds = %356
+ThrowNullRef140:                                  ; preds = %356
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef141:                                  ; preds = %360
+ThrowNullRef142:                                  ; preds = %360
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef143:                                  ; preds = %377
+ThrowNullRef144:                                  ; preds = %377
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef145:                                  ; preds = %381
+ThrowNullRef146:                                  ; preds = %381
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef147:                                  ; preds = %424
+ThrowNullRef148:                                  ; preds = %424
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef149:                                  ; preds = %428
+ThrowNullRef150:                                  ; preds = %428
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef151:                                  ; preds = %440
+ThrowNullRef152:                                  ; preds = %440
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef153:                                  ; preds = %444
+ThrowNullRef154:                                  ; preds = %444
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef155:                                  ; preds = %456
+ThrowNullRef156:                                  ; preds = %456
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef157:                                  ; preds = %460
+ThrowNullRef158:                                  ; preds = %460
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef159:                                  ; preds = %474
+ThrowNullRef160:                                  ; preds = %474
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef161:                                  ; preds = %477
+ThrowNullRef162:                                  ; preds = %477
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef163:                                  ; preds = %394
+ThrowNullRef164:                                  ; preds = %394
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef165:                                  ; preds = %398
+ThrowNullRef166:                                  ; preds = %398
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef167:                                  ; preds = %401
+ThrowNullRef168:                                  ; preds = %401
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef169:                                  ; preds = %407
+ThrowNullRef170:                                  ; preds = %407
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1939,8 +2021,8 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
-  br i1 %NullCheck, label %22, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %ThrowNullRef, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
@@ -1948,8 +2030,8 @@ entry:
   store i32 %24, i32* %loc0
   %25 = load i32, i32* %loc0
   %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %26, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %27
 
 ; <label>:27                                      ; preds = %22
   %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
@@ -1971,7 +2053,7 @@ ThrowNullRef:                                     ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1989,8 +2071,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -2022,15 +2104,15 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2048,16 +2130,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
   %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
   store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %15
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
@@ -2072,8 +2154,8 @@ entry:
   %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
   %29 = ptrtoint i16 addrspace(1)* %28 to i64
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %19
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
@@ -2089,19 +2171,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2114,8 +2196,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
@@ -2128,7 +2210,7 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[loadElem]
+Failed to read AppDomain.PrepareDataForSetup[storeElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
@@ -2202,8 +2284,8 @@ entry:
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
-  br i1 %NullCheck24, label %27, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = load i64, i64 addrspace(1)* %26
@@ -2218,8 +2300,8 @@ entry:
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
-  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
   %41 = load i64, i64 addrspace(1)* %39
@@ -2236,8 +2318,8 @@ entry:
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
-  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
   %54 = load i64, i64 addrspace(1)* %52
@@ -2252,8 +2334,8 @@ entry:
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
   %67 = load i64, i64 addrspace(1)* %65
@@ -2270,8 +2352,8 @@ entry:
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
-  br i1 %NullCheck16, label %79, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
   %80 = load i64, i64 addrspace(1)* %78
@@ -2286,8 +2368,8 @@ entry:
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
-  br i1 %NullCheck18, label %92, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
   %93 = load i64, i64 addrspace(1)* %91
@@ -2304,8 +2386,8 @@ entry:
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
-  br i1 %NullCheck12, label %105, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = load i64, i64 addrspace(1)* %104
@@ -2320,8 +2402,8 @@ entry:
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
-  br i1 %NullCheck14, label %118, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
   %119 = load i64, i64 addrspace(1)* %117
@@ -2337,8 +2419,8 @@ entry:
 
 ; <label>:128                                     ; preds = %20
   %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
-  br i1 %NullCheck4, label %130, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %129, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %130
 
 ; <label>:130                                     ; preds = %128
   %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
@@ -2346,8 +2428,8 @@ entry:
   %133 = load i16, i16 addrspace(1)* %132, align 8
   %134 = zext i16 %133 to i32
   %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
-  br i1 %NullCheck6, label %136, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %135, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %136
 
 ; <label>:136                                     ; preds = %130
   %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
@@ -2360,8 +2442,8 @@ entry:
 
 ; <label>:143                                     ; preds = %136
   %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
-  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %144, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %145
 
 ; <label>:145                                     ; preds = %143
   %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
@@ -2369,8 +2451,8 @@ entry:
   %148 = load i16, i16 addrspace(1)* %147, align 8
   %149 = zext i16 %148 to i32
   %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %150, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %151
 
 ; <label>:151                                     ; preds = %145
   %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
@@ -2388,8 +2470,8 @@ entry:
 
 ; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
-  br i1 %NullCheck, label %163, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %ThrowNullRef, label %163
 
 ; <label>:163                                     ; preds = %161
   %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
@@ -2399,8 +2481,8 @@ entry:
 
 ; <label>:167                                     ; preds = %163
   %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
-  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %168, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %169
 
 ; <label>:169                                     ; preds = %167
   %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
@@ -2432,55 +2514,55 @@ ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %167
+ThrowNullRef2:                                    ; preds = %167
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %128
+ThrowNullRef4:                                    ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %130
+ThrowNullRef6:                                    ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %143
+ThrowNullRef8:                                    ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %145
+ThrowNullRef10:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %102
+ThrowNullRef12:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %105
+ThrowNullRef14:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %76
+ThrowNullRef16:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %79
+ThrowNullRef18:                                   ; preds = %79
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %50
+ThrowNullRef20:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %53
+ThrowNullRef22:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %24
+ThrowNullRef24:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %27
+ThrowNullRef26:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2503,15 +2585,15 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2519,16 +2601,16 @@ entry:
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
   store i32 %8, i32* %loc0
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
   %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
   store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
@@ -2546,16 +2628,16 @@ entry:
 
 ; <label>:23                                      ; preds = %64
   %24 = load i16*, i16** %loc3
-  %NullCheck12 = icmp ne i16* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i16* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
   store i32 %27, i32* %loc5
   %28 = load i16*, i16** %loc4
-  %NullCheck14 = icmp ne i16* %28, null
-  br i1 %NullCheck14, label %29, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %28, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = load i16, i16* %28, align 8
@@ -2620,15 +2702,15 @@ entry:
 
 ; <label>:67                                      ; preds = %64
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
-  br i1 %NullCheck8, label %69, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %68, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %69
 
 ; <label>:69                                      ; preds = %67
   %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
   %71 = load i32, i32 addrspace(1)* %70
   %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
-  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %73
 
 ; <label>:73                                      ; preds = %69
   %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
@@ -2645,31 +2727,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %67
+ThrowNullRef8:                                    ; preds = %67
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %69
+ThrowNullRef10:                                   ; preds = %69
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2710,14 +2792,14 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
   %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
@@ -2730,14 +2812,14 @@ entry:
 
 ; <label>:11                                      ; preds = %4
   %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
   %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
@@ -2749,14 +2831,14 @@ entry:
 
 ; <label>:22                                      ; preds = %16
   %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
   %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
-  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
-  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
@@ -2804,23 +2886,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2836,7 +2918,280 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[loadElem]
+Successfully read RuntimeType.IsAssignableFrom
+
+define i8 @RuntimeType.IsAssignableFrom(%System.RuntimeType addrspace(1)* %param0, %System.Type addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.RuntimeType addrspace(1)*
+  %arg1 = alloca %System.Type addrspace(1)*
+  %loc0 = alloca %System.RuntimeType addrspace(1)*
+  %loc1 = alloca %"System.Type[]" addrspace(1)*
+  %loc2 = alloca i32
+  store %System.RuntimeType addrspace(1)* %param0, %System.RuntimeType addrspace(1)** %this
+  store %System.Type addrspace(1)* %param1, %System.Type addrspace(1)** %arg1
+  %0 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %1 = icmp ne %System.Type addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i8 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %5 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %6 = bitcast %System.Type addrspace(1)* %4 to %System.Object addrspace(1)*
+  %7 = bitcast %System.RuntimeType addrspace(1)* %5 to %System.Object addrspace(1)*
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %6, %System.Object addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %3
+  ret i8 1
+
+; <label>:12                                      ; preds = %3
+  %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 152
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 32
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
+  %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
+  %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
+  store %System.RuntimeType addrspace(1)* %25, %System.RuntimeType addrspace(1)** %loc0
+  %26 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %27 = icmp eq %System.RuntimeType addrspace(1)* %26, null
+  br i1 %27, label %34, label %28
+
+; <label>:28                                      ; preds = %15
+  %29 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %30 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)*)*)(%System.RuntimeType addrspace(1)* %29, %System.RuntimeType addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+; <label>:34                                      ; preds = %15
+  %35 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %36 = call %System.Reflection.Emit.TypeBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Reflection.Emit.TypeBuilder addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %35)
+  %37 = icmp eq %System.Reflection.Emit.TypeBuilder addrspace(1)* %36, null
+  br i1 %37, label %139, label %38
+
+; <label>:38                                      ; preds = %34
+  %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %42
+
+; <label>:42                                      ; preds = %38
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 152
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 40
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
+  %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
+  %53 = zext i8 %52 to i32
+  %54 = icmp eq i32 %53, 0
+  br i1 %54, label %56, label %55
+
+; <label>:55                                      ; preds = %42
+  ret i8 1
+
+; <label>:56                                      ; preds = %42
+  %57 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %58 = bitcast %System.RuntimeType addrspace(1)* %57 to %System.Type addrspace(1)*
+  %59 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %58)
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %64 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.Type addrspace(1)* %63, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = bitcast %System.RuntimeType addrspace(1)* %64 to %System.Type addrspace(1)*
+  %67 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %63, %System.Type addrspace(1)* %66)
+  %68 = zext i8 %67 to i32
+  %69 = trunc i32 %68 to i8
+  ret i8 %69
+
+; <label>:70                                      ; preds = %56
+  %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
+  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %73
+
+; <label>:73                                      ; preds = %70
+  %74 = load i64, i64 addrspace(1)* %72
+  %75 = add i64 %74, 128
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = add i64 %77, 0
+  %79 = inttoptr i64 %78 to i64*
+  %80 = load i64, i64* %79
+  %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
+  %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
+  %83 = call i8 %82(%System.Type addrspace(1)* %81)
+  %84 = zext i8 %83 to i32
+  %85 = icmp eq i32 %84, 0
+  br i1 %85, label %139, label %86
+
+; <label>:86                                      ; preds = %73
+  %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
+  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %89
+
+; <label>:89                                      ; preds = %86
+  %90 = load i64, i64 addrspace(1)* %88
+  %91 = add i64 %90, 128
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = add i64 %93, 24
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
+  %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
+  %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
+  store %"System.Type[]" addrspace(1)* %99, %"System.Type[]" addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %129
+
+; <label>:100                                     ; preds = %132
+  %101 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %102 = load i32, i32* %loc2
+  %NullCheck11 = icmp eq %"System.Type[]" addrspace(1)* %101, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %103
+
+; <label>:103                                     ; preds = %100
+  %104 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 1
+  %105 = load i32, i32 addrspace(1)* %104
+  %106 = zext i32 %105 to i64
+  %107 = zext i32 %102 to i64
+  %BoundsCheck = icmp uge i64 %107, %106
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %108
+
+; <label>:108                                     ; preds = %103
+  %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
+  %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
+  %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
+  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %113
+
+; <label>:113                                     ; preds = %108
+  %114 = load i64, i64 addrspace(1)* %112
+  %115 = add i64 %114, 152
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = add i64 %117, 56
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
+  %123 = zext i8 %122 to i32
+  %124 = icmp ne i32 %123, 0
+  br i1 %124, label %126, label %125
+
+; <label>:125                                     ; preds = %113
+  ret i8 0
+
+; <label>:126                                     ; preds = %113
+  %127 = load i32, i32* %loc2
+  %128 = add i32 %127, 1
+  store i32 %128, i32* %loc2
+  br label %129
+
+; <label>:129                                     ; preds = %89, %126
+  %130 = load i32, i32* %loc2
+  %131 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %NullCheck9 = icmp eq %"System.Type[]" addrspace(1)* %131, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %132
+
+; <label>:132                                     ; preds = %129
+  %133 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %131, i32 0, i32 1
+  %134 = load i32, i32 addrspace(1)* %133
+  %135 = zext i32 %134 to i64
+  %136 = trunc i64 %135 to i32
+  %137 = icmp slt i32 %130, %136
+  br i1 %137, label %100, label %138
+
+; <label>:138                                     ; preds = %132
+  ret i8 1
+
+; <label>:139                                     ; preds = %34, %73
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %129
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %103
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -2893,7 +3248,7 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElem]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -2904,8 +3259,8 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -2997,8 +3352,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
@@ -3059,8 +3414,8 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -3087,8 +3442,8 @@ entry:
 
 ; <label>:17                                      ; preds = %5, %11
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
@@ -3097,8 +3452,8 @@ entry:
 
 ; <label>:22                                      ; preds = %1, %11
   %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
@@ -3109,11 +3464,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %17
+ThrowNullRef2:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %22
+ThrowNullRef4:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3167,15 +3522,15 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
   %15 = load i32, i32 addrspace(1)* %14
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
@@ -3198,7 +3553,7 @@ ThrowNullRef:                                     ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef2:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3232,8 +3587,8 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
@@ -3312,8 +3667,8 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -3327,8 +3682,8 @@ entry:
 ; <label>:5                                       ; preds = %43
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %7 = load i32, i32* %loc1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck6, label %8, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
@@ -3366,8 +3721,8 @@ entry:
 ; <label>:32                                      ; preds = %21, %25
   %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
   %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
-  br i1 %NullCheck8, label %35, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = trunc i32 %34 to i16
@@ -3380,8 +3735,8 @@ entry:
 ; <label>:40                                      ; preds = %1, %35
   %41 = load i32, i32* %loc1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
-  br i1 %NullCheck2, label %43, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %42, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
@@ -3392,8 +3747,8 @@ entry:
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
   %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
-  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
   %51 = load i64, i64 addrspace(1)* %49
@@ -3412,19 +3767,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %40
+ThrowNullRef2:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %47
+ThrowNullRef4:                                    ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %5
+ThrowNullRef6:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %32
+ThrowNullRef8:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3467,8 +3822,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
@@ -3492,11 +3847,391 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(i16* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store i16* %param0, i16** %arg0
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load i32, i32* %arg3
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %42, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %37, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg2
+  %13 = load i32, i32* %arg3
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %37, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %24 = load i32, i32* %arg2
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load i16*, i16** %arg0
+  %35 = load i32, i32* %arg3
+  %36 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %36, i16* %34, i32 %35)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:37                                      ; preds = %5, %16
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %39)
+  %41 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41, %System.String addrspace(1)* %38, %System.String addrspace(1)* %40)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41) #0
+  unreachable
+
+; <label>:42                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
-Failed to read StringBuilder.ToString[loadElemA]
+Successfully read StringBuilder.ToString
+
+define %System.String addrspace(1)* @StringBuilder.ToString(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i16*
+  %loc3 = alloca %"System.Char[]" addrspace(1)*
+  %loc4 = alloca i32
+  %loc5 = alloca i32
+  %loc6 = alloca i16 addrspace(1)*
+  %loc7 = alloca %System.String addrspace(1)*
+  %loc8 = alloca %"System.Char[]" addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %0)
+  %2 = icmp ne i32 %1, 0
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %4
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %6)
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %7)
+  store %System.String addrspace(1)* %8, %System.String addrspace(1)** %loc0
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.Text.StringBuilder addrspace(1)* %9, %System.Text.StringBuilder addrspace(1)** %loc1
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  store %System.String addrspace(1)* %10, %System.String addrspace(1)** %loc7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc7
+  %12 = ptrtoint %System.String addrspace(1)* %11 to i64
+  %13 = icmp eq i64 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %5
+  %15 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %16 = sext i32 %15 to i64
+  %17 = add i64 %12, %16
+  br label %18
+
+; <label>:18                                      ; preds = %5, %14
+  %19 = phi i64 [ %12, %5 ], [ %17, %14 ]
+  %20 = inttoptr i64 %19 to i16*
+  store i16* %20, i16** %loc2
+  br label %21
+
+; <label>:21                                      ; preds = %98, %18
+  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %22, null
+  br i1 %NullCheck, label %ThrowNullRef, label %23
+
+; <label>:23                                      ; preds = %21
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 3
+  %25 = load i32, i32 addrspace(1)* %24, align 8
+  %26 = icmp sle i32 %25, 0
+  br i1 %26, label %96, label %27
+
+; <label>:27                                      ; preds = %23
+  %28 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %28, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %29
+
+; <label>:29                                      ; preds = %27
+  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %28, i32 0, i32 1
+  %31 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %30, align 8
+  store %"System.Char[]" addrspace(1)* %31, %"System.Char[]" addrspace(1)** %loc3
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %33
+
+; <label>:33                                      ; preds = %29
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  store i32 %35, i32* %loc4
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  %39 = load i32, i32 addrspace(1)* %38, align 8
+  store i32 %39, i32* %loc5
+  %40 = load i32, i32* %loc5
+  %41 = load i32, i32* %loc4
+  %42 = add i32 %40, %41
+  %43 = zext i32 %42 to i64
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %45
+
+; <label>:45                                      ; preds = %37
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = sext i32 %47 to i64
+  %49 = icmp sgt i64 %43, %48
+  br i1 %49, label %91, label %50
+
+; <label>:50                                      ; preds = %45
+  %51 = load i32, i32* %loc5
+  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %52, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %53
+
+; <label>:53                                      ; preds = %50
+  %54 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %52, i32 0, i32 1
+  %55 = load i32, i32 addrspace(1)* %54
+  %56 = zext i32 %55 to i64
+  %57 = trunc i64 %56 to i32
+  %58 = icmp ugt i32 %51, %57
+  br i1 %58, label %91, label %59
+
+; <label>:59                                      ; preds = %53
+  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  store %"System.Char[]" addrspace(1)* %60, %"System.Char[]" addrspace(1)** %loc8
+  %61 = icmp eq %"System.Char[]" addrspace(1)* %60, null
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %63, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %64
+
+; <label>:64                                      ; preds = %62
+  %65 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %63, i32 0, i32 1
+  %66 = load i32, i32 addrspace(1)* %65
+  %67 = zext i32 %66 to i64
+  %68 = trunc i64 %67 to i32
+  %69 = icmp ne i32 %68, 0
+  br i1 %69, label %71, label %70
+
+; <label>:70                                      ; preds = %59, %64
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:71                                      ; preds = %64
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %73
+
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %BoundsCheck = icmp uge i64 0, %76
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %77
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %78, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:79                                      ; preds = %70, %77
+  %80 = load i16*, i16** %loc2
+  %81 = load i32, i32* %loc4
+  %82 = sext i32 %81 to i64
+  %83 = mul i64 %82, 2
+  %84 = bitcast i16* %80 to i8*
+  %85 = getelementptr inbounds i8, i8* %84, i64 %83
+  %86 = load i16 addrspace(1)*, i16 addrspace(1)** %loc6
+  %87 = ptrtoint i16 addrspace(1)* %86 to i64
+  %88 = load i32, i32* %loc5
+  %89 = bitcast i8* %85 to i16*
+  %90 = inttoptr i64 %87 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %89, i16* %90, i32 %88)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %96
+
+; <label>:91                                      ; preds = %45, %53
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %94 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %93)
+  %95 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95, %System.String addrspace(1)* %92, %System.String addrspace(1)* %94)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95) #0
+  unreachable
+
+; <label>:96                                      ; preds = %23, %79
+  %97 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %97, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %98
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %97, i32 0, i32 2
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  store %System.Text.StringBuilder addrspace(1)* %100, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %102 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %102, label %21, label %103
+
+; <label>:103                                     ; preds = %98
+  store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc7
+  %104 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  ret %System.String addrspace(1)* %104
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method StringBuilder::get_Length using LLILCJit
+Successfully read StringBuilder.get_Length
+
+define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
+Successfully read RuntimeHelpers.get_OffsetToStringData
+
+define i32 @RuntimeHelpers.get_OffsetToStringData() {
+entry:
+  ret i32 12
+}
+
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
 Successfully read CultureData.CreateCultureData
 
@@ -3514,23 +4249,23 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
   store i8 %4, i8 addrspace(1)* %6
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
@@ -3549,11 +4284,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3566,50 +4301,50 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
   store i32 -1, i32 addrspace(1)* %2
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
   store i32 -1, i32 addrspace(1)* %8
   %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
   store i32 -1, i32 addrspace(1)* %14
   %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
   store i32 -1, i32 addrspace(1)* %17
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
@@ -3623,27 +4358,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3675,7 +4410,136 @@ Failed to read Dictionary`2.Insert[non-const derefAddress]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
 Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
-Failed to read HashHelpers.GetPrime[loadElem]
+Successfully read HashHelpers.GetPrime
+
+define i32 @HashHelpers.GetPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %6, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5, %System.String addrspace(1)* %4)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5) #0
+  unreachable
+
+; <label>:6                                       ; preds = %entry
+  store i32 0, i32* %loc0
+  br label %29
+
+; <label>:7                                       ; preds = %35
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 1296
+  %10 = addrspacecast i8 addrspace(1)* %9 to %"System.Int32[]" addrspace(1)**
+  %11 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %10
+  %12 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Int32[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = zext i32 %15 to i64
+  %17 = zext i32 %12 to i64
+  %BoundsCheck = icmp uge i64 %17, %16
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 3, i32 %12
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  store i32 %20, i32* %loc1
+  %21 = load i32, i32* %loc1
+  %22 = load i32, i32* %arg0
+  %23 = icmp slt i32 %21, %22
+  br i1 %23, label %26, label %24
+
+; <label>:24                                      ; preds = %18
+  %25 = load i32, i32* %loc1
+  ret i32 %25
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %loc0
+  %28 = add i32 %27, 1
+  store i32 %28, i32* %loc0
+  br label %29
+
+; <label>:29                                      ; preds = %6, %26
+  %30 = load i32, i32* %loc0
+  %31 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %32 = getelementptr inbounds i8, i8 addrspace(1)* %31, i64 1296
+  %33 = addrspacecast i8 addrspace(1)* %32 to %"System.Int32[]" addrspace(1)**
+  %34 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %33
+  %NullCheck = icmp eq %"System.Int32[]" addrspace(1)* %34, null
+  br i1 %NullCheck, label %ThrowNullRef, label %35
+
+; <label>:35                                      ; preds = %29
+  %36 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %34, i32 0, i32 1
+  %37 = load i32, i32 addrspace(1)* %36
+  %38 = zext i32 %37 to i64
+  %39 = trunc i64 %38 to i32
+  %40 = icmp slt i32 %30, %39
+  br i1 %40, label %7, label %41
+
+; <label>:41                                      ; preds = %35
+  %42 = load i32, i32* %arg0
+  %43 = or i32 %42, 1
+  store i32 %43, i32* %loc2
+  br label %59
+
+; <label>:44                                      ; preds = %59
+  %45 = load i32, i32* %loc2
+  %46 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %45)
+  %47 = zext i8 %46 to i32
+  %48 = icmp eq i32 %47, 0
+  br i1 %48, label %56, label %49
+
+; <label>:49                                      ; preds = %44
+  %50 = load i32, i32* %loc2
+  %51 = sub i32 %50, 1
+  %52 = srem i32 %51, 101
+  %53 = icmp eq i32 %52, 0
+  br i1 %53, label %56, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = load i32, i32* %loc2
+  ret i32 %55
+
+; <label>:56                                      ; preds = %44, %49
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %57, 2
+  store i32 %58, i32* %loc2
+  br label %59
+
+; <label>:59                                      ; preds = %41, %56
+  %60 = load i32, i32* %loc2
+  %61 = icmp slt i32 %60, 2147483647
+  br i1 %61, label %44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load i32, i32* %arg0
+  ret i32 %63
+
+ThrowNullRef:                                     ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
 Successfully read GenericEqualityComparer`1.GetHashCode
 
@@ -3694,14 +4558,14 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
   %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load i64, i64 addrspace(1)* %7
@@ -3720,7 +4584,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3750,8 +4614,8 @@ entry:
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
@@ -3796,8 +4660,8 @@ entry:
   %35 = bitcast i16* %34 to i8*
   %36 = getelementptr inbounds i8, i8* %35, i64 2
   %37 = bitcast i8* %36 to i16*
-  %NullCheck4 = icmp ne i16* %37, null
-  br i1 %NullCheck4, label %38, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %37, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %38
 
 ; <label>:38                                      ; preds = %27
   %39 = load i16, i16* %37, align 8
@@ -3824,8 +4688,8 @@ entry:
 
 ; <label>:54                                      ; preds = %22, %43
   %55 = load i16*, i16** %loc4
-  %NullCheck2 = icmp ne i16* %55, null
-  br i1 %NullCheck2, label %56, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i16* %55, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %56
 
 ; <label>:56                                      ; preds = %54
   %57 = load i16, i16* %55, align 8
@@ -3850,11 +4714,11 @@ ThrowNullRef:                                     ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %54
+ThrowNullRef2:                                    ; preds = %54
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %27
+ThrowNullRef4:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3871,8 +4735,8 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -3907,8 +4771,8 @@ entry:
 
 ; <label>:26                                      ; preds = %19
   %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
-  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %28
 
 ; <label>:28                                      ; preds = %26
   %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
@@ -3920,7 +4784,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3972,8 +4836,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
@@ -3984,26 +4848,26 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
-  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
@@ -4014,8 +4878,8 @@ entry:
 ; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
@@ -4024,8 +4888,8 @@ entry:
 
 ; <label>:25                                      ; preds = %1, %16, %23
   %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
-  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
@@ -4036,27 +4900,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %20
+ThrowNullRef10:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4069,8 +4933,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -4081,8 +4945,8 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
@@ -4091,8 +4955,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1, %8
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
@@ -4103,11 +4967,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4128,24 +4992,24 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   store i32 %3, i32* %loc0
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
   %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
   store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck4, label %9, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
@@ -4164,15 +5028,15 @@ entry:
 ; <label>:18                                      ; preds = %70
   %19 = load i16*, i16** %loc3
   %20 = bitcast i16* %19 to i64*
-  %NullCheck10 = icmp ne i64* %20, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %20, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = load i64, i64* %20, align 8
   %23 = load i16*, i16** %loc4
   %24 = bitcast i16* %23 to i64*
-  %NullCheck12 = icmp ne i64* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = load i64, i64* %24, align 8
@@ -4188,8 +5052,8 @@ entry:
   %31 = bitcast i16* %30 to i8*
   %32 = getelementptr inbounds i8, i8* %31, i64 8
   %33 = bitcast i8* %32 to i64*
-  %NullCheck14 = icmp ne i64* %33, null
-  br i1 %NullCheck14, label %34, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = load i64, i64* %33, align 8
@@ -4197,8 +5061,8 @@ entry:
   %37 = bitcast i16* %36 to i8*
   %38 = getelementptr inbounds i8, i8* %37, i64 8
   %39 = bitcast i8* %38 to i64*
-  %NullCheck16 = icmp ne i64* %39, null
-  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %40
 
 ; <label>:40                                      ; preds = %34
   %41 = load i64, i64* %39, align 8
@@ -4214,8 +5078,8 @@ entry:
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %NullCheck18 = icmp ne i64* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = load i64, i64* %48, align 8
@@ -4223,8 +5087,8 @@ entry:
   %52 = bitcast i16* %51 to i8*
   %53 = getelementptr inbounds i8, i8* %52, i64 16
   %54 = bitcast i8* %53 to i64*
-  %NullCheck20 = icmp ne i64* %54, null
-  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64* %54, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %55
 
 ; <label>:55                                      ; preds = %49
   %56 = load i64, i64* %54, align 8
@@ -4262,15 +5126,15 @@ entry:
 ; <label>:74                                      ; preds = %95
   %75 = load i16*, i16** %loc3
   %76 = bitcast i16* %75 to i32*
-  %NullCheck6 = icmp ne i32* %76, null
-  br i1 %NullCheck6, label %77, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32* %76, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %77
 
 ; <label>:77                                      ; preds = %74
   %78 = load i32, i32* %76, align 8
   %79 = load i16*, i16** %loc4
   %80 = bitcast i16* %79 to i32*
-  %NullCheck8 = icmp ne i32* %80, null
-  br i1 %NullCheck8, label %81, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i32* %80, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %81
 
 ; <label>:81                                      ; preds = %77
   %82 = load i32, i32* %80, align 8
@@ -4318,43 +5182,43 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %74
+ThrowNullRef6:                                    ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %77
+ThrowNullRef8:                                    ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %29
+ThrowNullRef14:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %34
+ThrowNullRef16:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4376,8 +5240,8 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load i64, i64 addrspace(1)* %4
@@ -4389,8 +5253,8 @@ entry:
   %12 = load i64, i64* %11
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %5
   %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
@@ -4399,8 +5263,8 @@ entry:
   %18 = load i8, i8* %arg2
   %19 = zext i8 %18 to i32
   %20 = trunc i32 %19 to i8
-  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %15
   %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
@@ -4411,11 +5275,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4442,8 +5306,8 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
@@ -4466,16 +5330,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
   %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = load i64, i64 addrspace(1)* %19
@@ -4500,8 +5364,8 @@ entry:
 ; <label>:35                                      ; preds = %30
   %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
@@ -4514,8 +5378,8 @@ entry:
 
 ; <label>:42                                      ; preds = %1, %38
   %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
-  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
@@ -4526,19 +5390,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %35
+ThrowNullRef2:                                    ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %42
+ThrowNullRef8:                                    ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4551,14 +5415,14 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
@@ -4570,7 +5434,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4583,8 +5447,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
@@ -4613,51 +5477,51 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
   %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
   %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
   %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
   %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
-  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
   store i64 %21, i64 addrspace(1)* %23
   %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %25 = load i64, i64* %loc0
-  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
@@ -4668,27 +5532,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %22
+ThrowNullRef12:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4701,8 +5565,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
@@ -4713,19 +5577,19 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
@@ -4734,8 +5598,8 @@ entry:
 
 ; <label>:15                                      ; preds = %1, %13
   %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
@@ -4746,19 +5610,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %15
+ThrowNullRef8:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4771,8 +5635,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -4831,8 +5695,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
@@ -4882,8 +5746,8 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
-  br i1 %NullCheck, label %17, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %ThrowNullRef, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
@@ -4894,15 +5758,15 @@ entry:
 
 ; <label>:22                                      ; preds = %17
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
-  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
   %26 = load i32, i32 addrspace(1)* %25
   %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
-  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %27, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
@@ -4925,8 +5789,8 @@ entry:
 ; <label>:40                                      ; preds = %17
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
-  br i1 %NullCheck6, label %43, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %41, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
@@ -4938,34 +5802,17 @@ ThrowNullRef:                                     ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %24
+ThrowNullRef4:                                    ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %40
+ThrowNullRef6:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
-}
-
-INFO:  jitting method Object::ReferenceEquals using LLILCJit
-Successfully read Object.ReferenceEquals
-
-define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
-entry:
-  %arg0 = alloca %System.Object addrspace(1)*
-  %arg1 = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
-  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
-  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = icmp eq %System.Object addrspace(1)* %0, %1
-  %3 = sext i1 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
 }
 
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
@@ -4978,21 +5825,21 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
   %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
-  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
@@ -5007,28 +5854,28 @@ entry:
 ; <label>:13                                      ; preds = %8, %12
   %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
   %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
   %21 = load i32, i32 addrspace(1)* %20, align 8
   %22 = add i32 %21, 1
-  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
   store i32 %22, i32 addrspace(1)* %24
   %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
@@ -5039,27 +5886,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5077,7 +5924,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::Setup using LLILCJit
-Failed to read AppDomain.Setup[loadElem]
+Failed to read AppDomain.Setup[unbox]
 INFO:  jitting method Thread::GetDomain using LLILCJit
 Successfully read Thread.GetDomain
 
@@ -5108,8 +5955,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
@@ -5122,14 +5969,14 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
   %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
@@ -5141,11 +5988,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5173,8 +6020,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -5189,7 +6036,328 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
 Failed to read KeyCollection.System.Collections.Generic.IEnumerable<TKey>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Successfully read Enumerator.MoveNext
+
+define i8 @Enumerator.MoveNext(%"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.RuntimeTypeHandle* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*
+  %"$TypeArg" = alloca %System.RuntimeTypeHandle*
+  store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
+  %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 8
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %76, label %12
+
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
+  br label %76
+
+; <label>:13                                      ; preds = %85
+  %14 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck19 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %15
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, i32 0, i32 0
+  %17 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %16, align 8
+  %NullCheck21 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, i32 0, i32 2
+  %20 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %19, align 8
+  %21 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck23 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %22
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, i32 0, i32 2
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %NullCheck25 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 3, i32 %24
+  %NullCheck27 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %32
+
+; <label>:32                                      ; preds = %30
+  %33 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, i32 0, i32 2
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = icmp slt i32 %34, 0
+  br i1 %35, label %68, label %36
+
+; <label>:36                                      ; preds = %32
+  %37 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %38 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck29 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %39
+
+; <label>:39                                      ; preds = %36
+  %40 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, i32 0, i32 0
+  %41 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %40, align 8
+  %NullCheck31 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, i32 0, i32 2
+  %44 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %43, align 8
+  %45 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck33 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, i32 0, i32 2
+  %48 = load i32, i32 addrspace(1)* %47, align 8
+  %NullCheck35 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %49
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = zext i32 %51 to i64
+  %53 = zext i32 %48 to i64
+  %BoundsCheck37 = icmp uge i64 %53, %52
+  br i1 %BoundsCheck37, label %ThrowIndexOutOfRange38, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 3, i32 %48
+  %NullCheck39 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %56
+
+; <label>:56                                      ; preds = %54
+  %57 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, i32 0, i32 0
+  %58 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck41 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %59
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %60, %System.__Canon addrspace(1)* %58)
+  %61 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck43 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  %64 = load i32, i32 addrspace(1)* %63, align 8
+  %65 = add i32 %64, 1
+  %NullCheck45 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  store i32 %65, i32 addrspace(1)* %67
+  ret i8 1
+
+; <label>:68                                      ; preds = %32
+  %69 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck47 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %73 = add i32 %72, 1
+  %NullCheck49 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %74
+
+; <label>:74                                      ; preds = %70
+  %75 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  store i32 %73, i32 addrspace(1)* %75
+  br label %76
+
+; <label>:76                                      ; preds = %8, %12, %74
+  %77 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %78
+
+; <label>:78                                      ; preds = %76
+  %79 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, i32 0, i32 2
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck7 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %82
+
+; <label>:82                                      ; preds = %78
+  %83 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, i32 0, i32 0
+  %84 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %83, align 8
+  %NullCheck9 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %85
+
+; <label>:85                                      ; preds = %82
+  %86 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, i32 0, i32 7
+  %87 = load i32, i32 addrspace(1)* %86, align 8
+  %88 = icmp ult i32 %80, %87
+  br i1 %88, label %13, label %89
+
+; <label>:89                                      ; preds = %85
+  %90 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %91 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck11 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %92
+
+; <label>:92                                      ; preds = %89
+  %93 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, i32 0, i32 0
+  %94 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck13 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %95
+
+; <label>:95                                      ; preds = %92
+  %96 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, i32 0, i32 7
+  %97 = load i32, i32 addrspace(1)* %96, align 8
+  %98 = add i32 %97, 1
+  %NullCheck15 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %99
+
+; <label>:99                                      ; preds = %95
+  %100 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, i32 0, i32 2
+  store i32 %98, i32 addrspace(1)* %100
+  %101 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck17 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %102
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %103, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %92
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef22:                                   ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef24:                                   ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef26:                                   ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef28:                                   ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef30:                                   ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef32:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef34:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef36:                                   ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange38:                           ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef40:                                   ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef42:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef44:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef46:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef48:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef50:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -5200,8 +6368,8 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -5232,9 +6400,9 @@ Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
 Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
-Failed to read String.MakeSeparatorList[loadElemA]
+Failed to read String.MakeSeparatorList[storeElem]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
-Failed to read String.InternalSplitKeepEmptyEntries[loadElem]
+Failed to read String.InternalSplitKeepEmptyEntries[storeElem]
 INFO:  jitting method Path::IsRelative using LLILCJit
 Successfully read Path.IsRelative
 
@@ -5243,8 +6411,8 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -5254,8 +6422,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
@@ -5271,8 +6439,8 @@ entry:
 
 ; <label>:17                                      ; preds = %7
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
@@ -5288,8 +6456,8 @@ entry:
 
 ; <label>:29                                      ; preds = %19
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %31
 
 ; <label>:31                                      ; preds = %29
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
@@ -5300,8 +6468,8 @@ entry:
 
 ; <label>:36                                      ; preds = %31
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
-  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %37, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
@@ -5312,8 +6480,8 @@ entry:
 
 ; <label>:43                                      ; preds = %31, %38
   %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
-  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %45
 
 ; <label>:45                                      ; preds = %43
   %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
@@ -5324,8 +6492,8 @@ entry:
 
 ; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %50
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
@@ -5336,8 +6504,8 @@ entry:
 
 ; <label>:57                                      ; preds = %1, %7, %19, %45, %52
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
-  br i1 %NullCheck14, label %59, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %59
 
 ; <label>:59                                      ; preds = %57
   %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
@@ -5347,8 +6515,8 @@ entry:
 
 ; <label>:63                                      ; preds = %59
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
@@ -5359,8 +6527,8 @@ entry:
 
 ; <label>:70                                      ; preds = %65
   %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
-  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.String addrspace(1)* %71, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %72
 
 ; <label>:72                                      ; preds = %70
   %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
@@ -5379,39 +6547,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %17
+ThrowNullRef4:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %29
+ThrowNullRef6:                                    ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %36
+ThrowNullRef8:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %43
+ThrowNullRef10:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %50
+ThrowNullRef12:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %57
+ThrowNullRef14:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %63
+ThrowNullRef16:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %70
+ThrowNullRef18:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5419,7 +6587,293 @@ ThrowNullRef17:                                   ; preds = %70
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
-Failed to read String.TrimHelper[loadElem]
+Successfully read String.TrimHelper
+
+define %System.String addrspace(1)* @String.TrimHelper(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i16
+  %loc4 = alloca i32
+  %loc5 = alloca i16
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = sub i32 %3, 1
+  store i32 %4, i32* %loc0
+  store i32 0, i32* %loc1
+  %5 = load i32, i32* %arg2
+  %6 = icmp eq i32 %5, 1
+  br i1 %6, label %62, label %7
+
+; <label>:7                                       ; preds = %1
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:8                                       ; preds = %58
+  store i32 0, i32* %loc2
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load i32, i32* %loc1
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2, i32 %10
+  %13 = load i16, i16 addrspace(1)* %12
+  %14 = zext i16 %13 to i32
+  %15 = trunc i32 %14 to i16
+  store i16 %15, i16* %loc3
+  store i32 0, i32* %loc2
+  br label %34
+
+; <label>:16                                      ; preds = %37
+  %17 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %18 = load i32, i32* %loc2
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %17, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %19
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = zext i32 %18 to i64
+  %BoundsCheck = icmp uge i64 %23, %22
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %24
+
+; <label>:24                                      ; preds = %19
+  %25 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 3, i32 %18
+  %26 = load i16, i16 addrspace(1)* %25, align 8
+  %27 = zext i16 %26 to i32
+  %28 = load i16, i16* %loc3
+  %29 = zext i16 %28 to i32
+  %30 = icmp eq i32 %27, %29
+  br i1 %30, label %43, label %31
+
+; <label>:31                                      ; preds = %24
+  %32 = load i32, i32* %loc2
+  %33 = add i32 %32, 1
+  store i32 %33, i32* %loc2
+  br label %34
+
+; <label>:34                                      ; preds = %11, %31
+  %35 = load i32, i32* %loc2
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = icmp slt i32 %35, %41
+  br i1 %42, label %16, label %43
+
+; <label>:43                                      ; preds = %24, %37
+  %44 = load i32, i32* %loc2
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %45, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp eq i32 %44, %50
+  br i1 %51, label %62, label %52
+
+; <label>:52                                      ; preds = %46
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %7, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %57, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %58
+
+; <label>:58                                      ; preds = %55
+  %59 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %60 = load i32, i32 addrspace(1)* %59
+  %61 = icmp slt i32 %56, %60
+  br i1 %61, label %8, label %62
+
+; <label>:62                                      ; preds = %1, %46, %58
+  %63 = load i32, i32* %arg2
+  %64 = icmp eq i32 %63, 0
+  br i1 %64, label %122, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %66, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %67
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %66, i32 0, i32 1
+  %69 = load i32, i32 addrspace(1)* %68
+  %70 = sub i32 %69, 1
+  store i32 %70, i32* %loc0
+  br label %118
+
+; <label>:71                                      ; preds = %118
+  store i32 0, i32* %loc4
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %73 = load i32, i32* %loc0
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %74
+
+; <label>:74                                      ; preds = %71
+  %75 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 2, i32 %73
+  %76 = load i16, i16 addrspace(1)* %75
+  %77 = zext i16 %76 to i32
+  %78 = trunc i32 %77 to i16
+  store i16 %78, i16* %loc5
+  store i32 0, i32* %loc4
+  br label %97
+
+; <label>:79                                      ; preds = %100
+  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %81 = load i32, i32* %loc4
+  %NullCheck19 = icmp eq %"System.Char[]" addrspace(1)* %80, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
+
+; <label>:82                                      ; preds = %79
+  %83 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 1
+  %84 = load i32, i32 addrspace(1)* %83
+  %85 = zext i32 %84 to i64
+  %86 = zext i32 %81 to i64
+  %BoundsCheck21 = icmp uge i64 %86, %85
+  br i1 %BoundsCheck21, label %ThrowIndexOutOfRange22, label %87
+
+; <label>:87                                      ; preds = %82
+  %88 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 3, i32 %81
+  %89 = load i16, i16 addrspace(1)* %88, align 8
+  %90 = zext i16 %89 to i32
+  %91 = load i16, i16* %loc5
+  %92 = zext i16 %91 to i32
+  %93 = icmp eq i32 %90, %92
+  br i1 %93, label %106, label %94
+
+; <label>:94                                      ; preds = %87
+  %95 = load i32, i32* %loc4
+  %96 = add i32 %95, 1
+  store i32 %96, i32* %loc4
+  br label %97
+
+; <label>:97                                      ; preds = %74, %94
+  %98 = load i32, i32* %loc4
+  %99 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck15 = icmp eq %"System.Char[]" addrspace(1)* %99, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %100
+
+; <label>:100                                     ; preds = %97
+  %101 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %99, i32 0, i32 1
+  %102 = load i32, i32 addrspace(1)* %101
+  %103 = zext i32 %102 to i64
+  %104 = trunc i64 %103 to i32
+  %105 = icmp slt i32 %98, %104
+  br i1 %105, label %79, label %106
+
+; <label>:106                                     ; preds = %87, %100
+  %107 = load i32, i32* %loc4
+  %108 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck17 = icmp eq %"System.Char[]" addrspace(1)* %108, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %109
+
+; <label>:109                                     ; preds = %106
+  %110 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %108, i32 0, i32 1
+  %111 = load i32, i32 addrspace(1)* %110
+  %112 = zext i32 %111 to i64
+  %113 = trunc i64 %112 to i32
+  %114 = icmp eq i32 %107, %113
+  br i1 %114, label %122, label %115
+
+; <label>:115                                     ; preds = %109
+  %116 = load i32, i32* %loc0
+  %117 = sub i32 %116, 1
+  store i32 %117, i32* %loc0
+  br label %118
+
+; <label>:118                                     ; preds = %67, %115
+  %119 = load i32, i32* %loc0
+  %120 = load i32, i32* %loc1
+  %121 = icmp sge i32 %119, %120
+  br i1 %121, label %71, label %122
+
+; <label>:122                                     ; preds = %62, %109, %118
+  %123 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %124 = load i32, i32* %loc1
+  %125 = load i32, i32* %loc0
+  %126 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %123, i32 %124, i32 %125)
+  ret %System.String addrspace(1)* %126
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %97
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange22:                           ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
 Successfully read String.CreateTrimmedString
 
@@ -5439,8 +6893,8 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
@@ -5535,8 +6989,8 @@ entry:
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i64 2872
   %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
   %8 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %7
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %3
   %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
@@ -5553,8 +7007,8 @@ entry:
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 2864
   %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
   %21 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %20
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
-  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %22
 
 ; <label>:22                                      ; preds = %16
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
@@ -5569,7 +7023,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %16
+ThrowNullRef2:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5586,8 +7040,8 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5613,8 +7067,8 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
@@ -5632,8 +7086,8 @@ entry:
 
 ; <label>:12                                      ; preds = %4
   %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
@@ -5644,8 +7098,8 @@ entry:
 
 ; <label>:19                                      ; preds = %14
   %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %19
   %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
@@ -5660,21 +7114,21 @@ entry:
   %31 = zext i16 %30 to i32
   %32 = bitcast i8* %29 to i16*
   %33 = trunc i32 %31 to i16
-  %NullCheck6 = icmp ne i16* %32, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i16* %32, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %21
   store i16 %33, i16* %32, align 8
   %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %36
 
 ; <label>:36                                      ; preds = %34
   %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
   %38 = load i32, i32 addrspace(1)* %37, align 8
   %39 = add i32 %38, 1
-  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %40
 
 ; <label>:40                                      ; preds = %36
   %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
@@ -5683,16 +7137,16 @@ entry:
 
 ; <label>:42                                      ; preds = %14
   %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
-  br i1 %NullCheck12, label %44, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
   %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
   %47 = load i16, i16* %arg1
   %48 = zext i16 %47 to i32
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = trunc i32 %48 to i16
@@ -5703,31 +7157,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %19
+ThrowNullRef4:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %21
+ThrowNullRef6:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %36
+ThrowNullRef10:                                   ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %42
+ThrowNullRef12:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %44
+ThrowNullRef14:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5740,8 +7194,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -5752,8 +7206,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
@@ -5762,14 +7216,14 @@ entry:
 
 ; <label>:11                                      ; preds = %1
   %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
@@ -5779,15 +7233,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5808,8 +7262,8 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5822,8 +7276,8 @@ entry:
 
 ; <label>:8                                       ; preds = %3
   %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
@@ -5842,15 +7296,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
-  br i1 %NullCheck4, label %22, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
   %24 = load i16*, i16* addrspace(1)* %23, align 8
   %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %25, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
@@ -5859,8 +7313,8 @@ entry:
   store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
@@ -5874,8 +7328,8 @@ entry:
 
 ; <label>:37                                      ; preds = %65
   %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %37
   %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
@@ -5886,16 +7340,16 @@ entry:
   %45 = bitcast i16* %41 to i8*
   %46 = getelementptr inbounds i8, i8* %45, i64 %44
   %47 = bitcast i8* %46 to i16*
-  %NullCheck14 = icmp ne i16* %47, null
-  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %47, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %48
 
 ; <label>:48                                      ; preds = %39
   %49 = load i16, i16* %47, align 8
   %50 = zext i16 %49 to i32
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %52 = load i32, i32* %loc1
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %53
 
 ; <label>:53                                      ; preds = %48
   %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
@@ -5916,8 +7370,8 @@ entry:
 ; <label>:62                                      ; preds = %36, %59
   %63 = load i32, i32* %loc1
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck10, label %65, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %65
 
 ; <label>:65                                      ; preds = %62
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
@@ -5936,15 +7390,15 @@ entry:
 
 ; <label>:74                                      ; preds = %70
   %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
-  br i1 %NullCheck18, label %76, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %76
 
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
   %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
-  br i1 %NullCheck20, label %80, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
   %81 = load i64, i64 addrspace(1)* %79
@@ -5958,8 +7412,8 @@ entry:
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
   %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
-  br i1 %NullCheck22, label %92, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.String addrspace(1)* %90, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %92
 
 ; <label>:92                                      ; preds = %80
   %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
@@ -5969,15 +7423,15 @@ entry:
 
 ; <label>:96                                      ; preds = %70
   %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
-  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %98
 
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
   %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
-  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
   %103 = load i64, i64 addrspace(1)* %101
@@ -5991,8 +7445,8 @@ entry:
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
   %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
-  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.String addrspace(1)* %112, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %114
 
 ; <label>:114                                     ; preds = %102
   %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
@@ -6004,59 +7458,59 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %20
+ThrowNullRef4:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %22
+ThrowNullRef6:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %26
+ThrowNullRef8:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %62
+ThrowNullRef10:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %48
+ThrowNullRef16:                                   ; preds = %48
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %74
+ThrowNullRef18:                                   ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %76
+ThrowNullRef20:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %80
+ThrowNullRef22:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %96
+ThrowNullRef24:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %98
+ThrowNullRef26:                                   ; preds = %98
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %102
+ThrowNullRef28:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6069,15 +7523,15 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
   %3 = load i16*, i16* addrspace(1)* %2, align 8
   %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
@@ -6087,8 +7541,8 @@ entry:
   %10 = bitcast i16* %3 to i8*
   %11 = getelementptr inbounds i8, i8* %10, i64 %9
   %12 = bitcast i8* %11 to i16*
-  %NullCheck4 = icmp ne i16* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %5
   store i16 0, i16* %12, align 8
@@ -6098,11 +7552,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6119,8 +7573,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -6131,8 +7585,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
@@ -6144,15 +7598,15 @@ entry:
 
 ; <label>:14                                      ; preds = %1
   %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
   %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
   %21 = load i64, i64 addrspace(1)* %19
@@ -6171,15 +7625,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %14
+ThrowNullRef4:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %16
+ThrowNullRef6:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6302,14 +7756,6 @@ entry:
   ret %System.String addrspace(1)* %57
 }
 
-INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
-Successfully read RuntimeHelpers.get_OffsetToStringData
-
-define i32 @RuntimeHelpers.get_OffsetToStringData() {
-entry:
-  ret i32 12
-}
-
 INFO:  jitting method String::Equals using LLILCJit
 Successfully read String.Equals
 
@@ -6381,8 +7827,8 @@ entry:
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
-  br i1 %NullCheck24, label %29, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
   %30 = load i64, i64 addrspace(1)* %28
@@ -6397,8 +7843,8 @@ entry:
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
-  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
   %43 = load i64, i64 addrspace(1)* %41
@@ -6418,8 +7864,8 @@ entry:
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
   %59 = load i64, i64 addrspace(1)* %57
@@ -6434,8 +7880,8 @@ entry:
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck22, label %71, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
   %72 = load i64, i64 addrspace(1)* %70
@@ -6455,8 +7901,8 @@ entry:
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
-  br i1 %NullCheck16, label %87, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = load i64, i64 addrspace(1)* %86
@@ -6471,8 +7917,8 @@ entry:
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck18, label %100, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
   %101 = load i64, i64 addrspace(1)* %99
@@ -6492,8 +7938,8 @@ entry:
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
-  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
   %117 = load i64, i64 addrspace(1)* %115
@@ -6508,8 +7954,8 @@ entry:
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
-  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
   %130 = load i64, i64 addrspace(1)* %128
@@ -6528,15 +7974,15 @@ entry:
 
 ; <label>:142                                     ; preds = %22
   %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
-  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %143, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %144
 
 ; <label>:144                                     ; preds = %142
   %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
   %146 = load i32, i32 addrspace(1)* %145
   %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
-  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %147, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %148
 
 ; <label>:148                                     ; preds = %144
   %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
@@ -6557,15 +8003,15 @@ entry:
 
 ; <label>:159                                     ; preds = %22
   %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
-  br i1 %NullCheck, label %161, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %ThrowNullRef, label %161
 
 ; <label>:161                                     ; preds = %159
   %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
   %163 = load i32, i32 addrspace(1)* %162
   %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
-  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %164, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %165
 
 ; <label>:165                                     ; preds = %161
   %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
@@ -6578,8 +8024,8 @@ entry:
 
 ; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
-  br i1 %NullCheck4, label %172, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %171, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %172
 
 ; <label>:172                                     ; preds = %170
   %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
@@ -6589,8 +8035,8 @@ entry:
 
 ; <label>:176                                     ; preds = %172
   %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
-  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %177, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %178
 
 ; <label>:178                                     ; preds = %176
   %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
@@ -6629,55 +8075,55 @@ ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %161
+ThrowNullRef2:                                    ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %170
+ThrowNullRef4:                                    ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %176
+ThrowNullRef6:                                    ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %142
+ThrowNullRef8:                                    ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %144
+ThrowNullRef10:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %113
+ThrowNullRef12:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %116
+ThrowNullRef14:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %84
+ThrowNullRef16:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %87
+ThrowNullRef18:                                   ; preds = %87
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %55
+ThrowNullRef20:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %58
+ThrowNullRef22:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %26
+ThrowNullRef24:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %29
+ThrowNullRef26:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,8 +8161,8 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck, label %14, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %ThrowNullRef, label %14
 
 ; <label>:14                                      ; preds = %8
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
@@ -6760,8 +8206,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
@@ -6770,14 +8216,14 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32, i32* %loc0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %10
   %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
   %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
@@ -6790,15 +8236,15 @@ entry:
 ; <label>:25                                      ; preds = %19
   %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
-  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
   %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
@@ -6807,8 +8253,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %37 = load i32, i32* %loc0
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %38, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %38
 
 ; <label>:38                                      ; preds = %32
   %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
@@ -6817,14 +8263,14 @@ entry:
 
 ; <label>:40                                      ; preds = %19
   %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %40
   %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
   %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
-  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
-  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
@@ -6832,8 +8278,8 @@ entry:
   %48 = zext i32 %47 to i64
   %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
-  br i1 %NullCheck16, label %51, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %51
 
 ; <label>:51                                      ; preds = %45
   %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
@@ -6847,15 +8293,15 @@ entry:
 ; <label>:57                                      ; preds = %51
   %58 = load i16*, i16** %arg1
   %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
-  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %60
 
 ; <label>:60                                      ; preds = %57
   %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
   %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
-  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %64
 
 ; <label>:64                                      ; preds = %60
   %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
@@ -6864,22 +8310,22 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
   %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
-  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %70
 
 ; <label>:70                                      ; preds = %64
   %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
   %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
-  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
-  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
   %75 = load i32, i32 addrspace(1)* %74
   %76 = zext i32 %75 to i64
   %77 = trunc i64 %76 to i32
-  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
-  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %78
 
 ; <label>:78                                      ; preds = %73
   %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
@@ -6901,8 +8347,8 @@ entry:
   %90 = bitcast i16* %86 to i8*
   %91 = getelementptr inbounds i8, i8* %90, i64 %89
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %93
 
 ; <label>:93                                      ; preds = %80
   %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
@@ -6912,8 +8358,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %99 = load i32, i32* %loc2
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %100
 
 ; <label>:100                                     ; preds = %93
   %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
@@ -6928,63 +8374,63 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %25
+ThrowNullRef6:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %32
+ThrowNullRef10:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %40
+ThrowNullRef12:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %45
+ThrowNullRef16:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %57
+ThrowNullRef18:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %60
+ThrowNullRef20:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %64
+ThrowNullRef22:                                   ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %70
+ThrowNullRef24:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %73
+ThrowNullRef26:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %80
+ThrowNullRef28:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %93
+ThrowNullRef30:                                   ; preds = %93
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7004,8 +8450,8 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
@@ -7033,43 +8479,43 @@ entry:
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %14
   %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
   %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   %28 = load i32, i32 addrspace(1)* %27, align 8
   %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
-  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %30
 
 ; <label>:30                                      ; preds = %26
   %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
   %32 = load i32, i32 addrspace(1)* %31, align 8
   %33 = add i32 %28, %32
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %34
 
 ; <label>:34                                      ; preds = %30
   %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   store i32 %33, i32 addrspace(1)* %35
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
   store i32 0, i32 addrspace(1)* %38
   %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %40
 
 ; <label>:40                                      ; preds = %37
   %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
@@ -7082,8 +8528,8 @@ entry:
 
 ; <label>:47                                      ; preds = %40
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
@@ -7098,8 +8544,8 @@ entry:
   %54 = load i32, i32* %loc0
   %55 = sext i32 %54 to i64
   %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
-  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %57
 
 ; <label>:57                                      ; preds = %52
   %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
@@ -7110,68 +8556,35 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %14
+ThrowNullRef2:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %23
+ThrowNullRef4:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %26
+ThrowNullRef6:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %30
+ThrowNullRef8:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %34
+ThrowNullRef10:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %47
+ThrowNullRef14:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %52
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-}
-
-INFO:  jitting method StringBuilder::get_Length using LLILCJit
-Successfully read StringBuilder.get_Length
-
-define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.StringBuilder addrspace(1)*
-  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
-  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
-
-; <label>:1                                       ; preds = %entry
-  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %3 = load i32, i32 addrspace(1)* %2, align 8
-  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
-
-; <label>:5                                       ; preds = %1
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = add i32 %3, %7
-  ret i32 %8
-
-ThrowNullRef:                                     ; preds = %entry
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef16:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7213,70 +8626,70 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
   %6 = load i32, i32 addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
   store i32 %6, i32 addrspace(1)* %8
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
   %13 = load i32, i32 addrspace(1)* %12, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
   store i32 %13, i32 addrspace(1)* %15
   %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
-  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %18
 
 ; <label>:18                                      ; preds = %14
   %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
   %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
   %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
   %34 = load i32, i32 addrspace(1)* %33, align 8
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
-  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
@@ -7287,39 +8700,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %28
+ThrowNullRef16:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %32
+ThrowNullRef18:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7455,13 +8868,13 @@ entry:
 ; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
@@ -7477,16 +8890,16 @@ entry:
 
 ; <label>:18                                      ; preds = %15
   %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
   store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
   %22 = load i32, i32* %loc0
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %24
 
 ; <label>:24                                      ; preds = %20
   %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
@@ -7498,13 +8911,13 @@ entry:
 ; <label>:28                                      ; preds = %15, %24
   %29 = load i32, i32* %arg1
   %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %31
   %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
@@ -7517,20 +8930,20 @@ entry:
   %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
-  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
   %46 = load i32, i32 addrspace(1)* %45, align 8
   %47 = sub i32 %40, %46
-  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
-  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i32 addrspace(1)* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %48
 
 ; <label>:48                                      ; preds = %44
   store i32 %47, i32 addrspace(1)* %39, align 8
@@ -7538,21 +8951,21 @@ entry:
 
 ; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
-  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %51
 
 ; <label>:51                                      ; preds = %49
   %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %53
 
 ; <label>:53                                      ; preds = %51
   %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
   %55 = load i32, i32 addrspace(1)* %54, align 8
   %56 = load i32, i32* %arg2
   %57 = sub i32 %55, %56
-  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %58
 
 ; <label>:58                                      ; preds = %53
   %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
@@ -7562,13 +8975,13 @@ entry:
 ; <label>:60                                      ; preds = %33, %58
   %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
   %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
-  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %63
 
 ; <label>:63                                      ; preds = %60
   %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
-  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
-  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
@@ -7578,15 +8991,15 @@ entry:
 
 ; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
-  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i32 addrspace(1)* %69, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %70
 
 ; <label>:70                                      ; preds = %68
   %71 = load i32, i32 addrspace(1)* %69, align 8
   store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
-  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
@@ -7596,8 +9009,8 @@ entry:
   store i32 %77, i32* %loc4
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
-  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %80
 
 ; <label>:80                                      ; preds = %73
   %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
@@ -7607,71 +9020,71 @@ entry:
 ; <label>:83                                      ; preds = %80
   store i32 0, i32* %loc3
   %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
-  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
-  br i1 %NullCheck26, label %88, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i32 addrspace(1)* %87, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %88
 
 ; <label>:88                                      ; preds = %85
   %89 = load i32, i32 addrspace(1)* %87, align 8
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
-  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %90
 
 ; <label>:90                                      ; preds = %88
   %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
   store i32 %89, i32 addrspace(1)* %91
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
-  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
-  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %96
 
 ; <label>:96                                      ; preds = %94
   %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
-  br i1 %NullCheck34, label %100, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %100
 
 ; <label>:100                                     ; preds = %96
   %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
-  br i1 %NullCheck36, label %102, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %102
 
 ; <label>:102                                     ; preds = %100
   %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
   %104 = load i32, i32 addrspace(1)* %103, align 8
   %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
-  br i1 %NullCheck38, label %106, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %106
 
 ; <label>:106                                     ; preds = %102
   %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
-  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
-  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %108
 
 ; <label>:108                                     ; preds = %106
   %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
   %110 = load i32, i32 addrspace(1)* %109, align 8
   %111 = add i32 %104, %110
-  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %112
 
 ; <label>:112                                     ; preds = %108
   %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
   store i32 %111, i32 addrspace(1)* %113
   %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
-  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i32 addrspace(1)* %114, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %115
 
 ; <label>:115                                     ; preds = %112
   %116 = load i32, i32 addrspace(1)* %114, align 8
@@ -7681,19 +9094,19 @@ entry:
 ; <label>:118                                     ; preds = %115
   %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
-  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %121
 
 ; <label>:121                                     ; preds = %118
   %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
-  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
-  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %123
 
 ; <label>:123                                     ; preds = %121
   %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
   %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
-  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
-  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %126
 
 ; <label>:126                                     ; preds = %123
   %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
@@ -7705,8 +9118,8 @@ entry:
 
 ; <label>:130                                     ; preds = %80, %115, %126
   %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %132
 
 ; <label>:132                                     ; preds = %130
   %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7715,8 +9128,8 @@ entry:
   %136 = load i32, i32* %loc3
   %137 = sub i32 %135, %136
   %138 = sub i32 %134, %137
-  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %139
 
 ; <label>:139                                     ; preds = %132
   %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7728,16 +9141,16 @@ entry:
 
 ; <label>:144                                     ; preds = %139
   %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
-  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %146
 
 ; <label>:146                                     ; preds = %144
   %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
   %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
   %149 = load i32, i32* %loc2
   %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
-  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %151
 
 ; <label>:151                                     ; preds = %146
   %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
@@ -7754,145 +9167,249 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %18
+ThrowNullRef4:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %31
+ThrowNullRef10:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %44
+ThrowNullRef16:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %68
+ThrowNullRef18:                                   ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %70
+ThrowNullRef20:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %73
+ThrowNullRef22:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %83
+ThrowNullRef24:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %85
+ThrowNullRef26:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %88
+ThrowNullRef28:                                   ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %90
+ThrowNullRef30:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %94
+ThrowNullRef32:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %96
+ThrowNullRef34:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %100
+ThrowNullRef36:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %102
+ThrowNullRef38:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %106
+ThrowNullRef40:                                   ; preds = %106
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %108
+ThrowNullRef42:                                   ; preds = %108
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %112
+ThrowNullRef44:                                   ; preds = %112
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %118
+ThrowNullRef46:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %121
+ThrowNullRef48:                                   ; preds = %121
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %123
+ThrowNullRef50:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %130
+ThrowNullRef52:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %132
+ThrowNullRef54:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %144
+ThrowNullRef56:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %146
+ThrowNullRef58:                                   ; preds = %146
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %60
+ThrowNullRef60:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %63
+ThrowNullRef62:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %49
+ThrowNullRef64:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %51
+ThrowNullRef66:                                   ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %53
+ThrowNullRef68:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(%"System.Char[]" addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %arg0 = alloca %"System.Char[]" addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store %"System.Char[]" addrspace(1)* %param0, %"System.Char[]" addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load i32, i32* %arg4
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %43, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %38, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg1
+  %13 = load i32, i32* %arg4
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %38, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %24 = load i32, i32* %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %35 = load i32, i32* %arg3
+  %36 = load i32, i32* %arg4
+  %37 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %37, %"System.Char[]" addrspace(1)* %34, i32 %35, i32 %36)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:38                                      ; preds = %5, %16
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Successfully read Buffer._Memmove
 
@@ -7914,7 +9431,7 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[loadElem]
+Failed to read AppDomain.SetDataHelper[storeElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -7923,8 +9440,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
@@ -7934,8 +9451,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
@@ -7947,15 +9464,15 @@ entry:
   %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
   %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
@@ -7966,15 +9483,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7992,7 +9509,79 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
-Failed to read Dictionary`2.TryGetValue[loadElemA]
+Successfully read Dictionary`2.TryGetValue
+
+define i8 @"Dictionary`2.TryGetValue"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)* addrspace(1)* %param2) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  %arg2 = alloca %System.__Canon addrspace(1)* addrspace(1)*
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  store %System.__Canon addrspace(1)* addrspace(1)* %param2, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  store i32 %2, i32* %loc0
+  %3 = load i32, i32* %loc0
+  %4 = icmp slt i32 %3, 0
+  br i1 %4, label %22, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 2
+  %10 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %9, align 8
+  %11 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = zext i32 %11 to i64
+  %BoundsCheck = icmp uge i64 %16, %15
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 3, i32 %11
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %20, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %6, %System.__Canon addrspace(1)* %21)
+  ret i8 1
+
+; <label>:22                                      ; preds = %entry
+  %23 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %23, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -8058,8 +9647,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
@@ -8091,8 +9680,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
@@ -8171,15 +9760,15 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck, label %19, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %ThrowNullRef, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
   %21 = load i32, i32 addrspace(1)* %20
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
@@ -8202,7 +9791,7 @@ ThrowNullRef:                                     ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %19
+ThrowNullRef2:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8248,8 +9837,8 @@ entry:
   %0 = alloca %System.AppDomainHandle
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %1 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %1, i32 0, i32 15
@@ -8269,8 +9858,8 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
@@ -8286,7 +9875,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -8299,8 +9888,8 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -8327,8 +9916,8 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
@@ -8352,8 +9941,8 @@ entry:
   %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
   store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
@@ -8363,8 +9952,8 @@ entry:
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
@@ -8374,8 +9963,8 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %9
   %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
@@ -8384,8 +9973,8 @@ entry:
 
 ; <label>:18                                      ; preds = %3, %16
   %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
@@ -8397,15 +9986,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %18
+ThrowNullRef6:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8418,8 +10007,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
@@ -8453,15 +10042,15 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
@@ -8473,7 +10062,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8481,7 +10070,7 @@ ThrowNullRef1:                                    ; preds = %1
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
 Failed to read Dictionary`2.System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
@@ -8506,8 +10095,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
@@ -8524,8 +10113,8 @@ entry:
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -8544,7 +10133,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8577,8 +10166,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = load i64, i64* %arg2
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = trunc i32 %3 to i8
@@ -8634,46 +10223,46 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
   %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
-  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
-  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
-  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
@@ -8684,27 +10273,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %20
+ThrowNullRef12:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8717,8 +10306,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -8756,22 +10345,22 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
   %9 = load i64, i64 addrspace(1)* %8, align 8
   %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
   %13 = load i64, i64 addrspace(1)* %12, align 8
   %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %11
   %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
@@ -8788,11 +10377,11 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8882,8 +10471,8 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
@@ -8900,8 +10489,8 @@ entry:
 ; <label>:8                                       ; preds = %1
   %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
   %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
@@ -8911,15 +10500,15 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
   %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
   %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
-  br i1 %NullCheck6, label %21, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
@@ -8946,15 +10535,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8992,15 +10581,15 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
   store i8 %3, i8 addrspace(1)* %5
   %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
@@ -9011,7 +10600,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9027,8 +10616,8 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -9041,8 +10630,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
@@ -9058,7 +10647,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9080,8 +10669,8 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
@@ -9096,8 +10685,8 @@ entry:
 ; <label>:12                                      ; preds = %6
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
@@ -9112,8 +10701,8 @@ entry:
 ; <label>:21                                      ; preds = %15
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
@@ -9128,8 +10717,8 @@ entry:
 ; <label>:30                                      ; preds = %24
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %31, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
@@ -9144,8 +10733,8 @@ entry:
 ; <label>:39                                      ; preds = %33
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
-  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %40, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %42
 
 ; <label>:42                                      ; preds = %39
   %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
@@ -9164,19 +10753,19 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %21
+ThrowNullRef4:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %30
+ThrowNullRef6:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %39
+ThrowNullRef8:                                    ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9243,8 +10832,8 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
@@ -9264,57 +10853,57 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
   store i8 0, i8 addrspace(1)* %2
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
   store i8 0, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
   store i8 0, i8 addrspace(1)* %17
   %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
   store i8 0, i8 addrspace(1)* %20
   %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
-  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
@@ -9325,31 +10914,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %19
+ThrowNullRef14:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9367,8 +10956,8 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
@@ -9380,8 +10969,8 @@ entry:
 
 ; <label>:9                                       ; preds = %4
   %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %9
   %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
@@ -9395,7 +10984,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef2:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9420,8 +11009,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
@@ -9512,8 +11101,8 @@ entry:
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
@@ -9524,8 +11113,8 @@ entry:
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = load i64, i64 addrspace(1)* %12
@@ -9537,8 +11126,8 @@ entry:
   %20 = load i64, i64* %19
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
-  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %13
   %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
@@ -9555,8 +11144,8 @@ entry:
 ; <label>:30                                      ; preds = %25
   %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %32 = load i32, i32* %arg2
-  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
-  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
@@ -9570,15 +11159,15 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %30
+ThrowNullRef2:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9622,87 +11211,87 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
   %10 = load i8, i8 addrspace(1)* %9, align 8
   %11 = zext i8 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %8
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
   store i8 %12, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
   %19 = load i8, i8 addrspace(1)* %18, align 8
   %20 = zext i8 %19 to i32
   %21 = trunc i32 %20 to i8
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
   store i8 %21, i8 addrspace(1)* %23
   %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
   %28 = load i8, i8 addrspace(1)* %27, align 8
   %29 = zext i8 %28 to i32
   %30 = trunc i32 %29 to i8
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
-  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %31
 
 ; <label>:31                                      ; preds = %26
   %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
   store i8 %30, i8 addrspace(1)* %32
   %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
-  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
-  br i1 %NullCheck14, label %40, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %40
 
 ; <label>:40                                      ; preds = %35
   %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
   store i8 %39, i8 addrspace(1)* %41
   %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
-  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %44
 
 ; <label>:44                                      ; preds = %40
   %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
   %46 = load i8, i8 addrspace(1)* %45, align 8
   %47 = zext i8 %46 to i32
   %48 = trunc i32 %47 to i8
-  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
   store i8 %48, i8 addrspace(1)* %50
   %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
-  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
@@ -9713,29 +11302,29 @@ entry:
 ; <label>:56                                      ; preds = %52
   %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
-  br i1 %NullCheck22, label %59, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
   %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
   %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
-  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
-  br i1 %NullCheck24, label %63, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
   %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
-  br i1 %NullCheck26, label %66, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
   %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
-  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
-  br i1 %NullCheck28, label %69, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %69
 
 ; <label>:69                                      ; preds = %66
   %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
@@ -9744,15 +11333,15 @@ entry:
 
 ; <label>:71                                      ; preds = %105
   %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
-  br i1 %NullCheck34, label %73, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %73
 
 ; <label>:73                                      ; preds = %71
   %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
   %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
   %76 = load i32, i32* %loc0
-  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
-  br i1 %NullCheck36, label %77, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
@@ -9766,8 +11355,8 @@ entry:
 
 ; <label>:83                                      ; preds = %77
   %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
-  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
@@ -9775,14 +11364,14 @@ entry:
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
   %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
-  br i1 %NullCheck40, label %91, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
 ; <label>:91                                      ; preds = %85
   %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
   %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
-  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck42, label %94, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %94
 
 ; <label>:94                                      ; preds = %91
   %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
@@ -9798,14 +11387,14 @@ entry:
 ; <label>:99                                      ; preds = %69, %96
   %100 = load i32, i32* %loc0
   %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
-  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %102
 
 ; <label>:102                                     ; preds = %99
   %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
   %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
-  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
-  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
@@ -9819,87 +11408,87 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %26
+ThrowNullRef10:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %31
+ThrowNullRef12:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %35
+ThrowNullRef14:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %40
+ThrowNullRef16:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %56
+ThrowNullRef22:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %59
+ThrowNullRef24:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %63
+ThrowNullRef26:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %66
+ThrowNullRef28:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %102
+ThrowNullRef32:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %71
+ThrowNullRef34:                                   ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %73
+ThrowNullRef36:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %83
+ThrowNullRef38:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %85
+ThrowNullRef40:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %91
+ThrowNullRef42:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9943,15 +11532,15 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
   %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
@@ -9961,28 +11550,28 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
   %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %12
   %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
   %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
   %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
-  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
@@ -9993,23 +11582,23 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %12
+ThrowNullRef6:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10031,15 +11620,15 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
   %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = load i64, i64 addrspace(1)* %7
@@ -10077,13 +11666,13 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[loadElem]
+Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -10111,8 +11700,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueEqFP.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueEqFP.error.txt
@@ -25,8 +25,8 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
@@ -40,8 +40,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
   %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
@@ -75,7 +75,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -90,8 +90,8 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %NullCheck = icmp ne i8 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = load i8, i8 addrspace(1)* %0, align 8
@@ -125,8 +125,8 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
@@ -159,8 +159,8 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -184,8 +184,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
   store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
@@ -195,8 +195,8 @@ entry:
 ; <label>:4                                       ; preds = %1
   %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
   %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
@@ -206,8 +206,8 @@ entry:
   %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
@@ -221,14 +221,14 @@ entry:
 
 ; <label>:17                                      ; preds = %14
   %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
   %21 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
@@ -238,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -249,8 +249,8 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
@@ -261,27 +261,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %30
+ThrowNullRef10:                                   ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -301,7 +301,89 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
-Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
+Successfully read AppDomainSetup.GetUnsecureApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.GetUnsecureApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %NullCheck = icmp eq %"System.String[]" addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %BoundsCheck = icmp uge i64 0, %5
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %6
+
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 3, i32 0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
+  ret %System.String addrspace(1)* %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_Value using LLILCJit
+Successfully read AppDomainSetup.get_Value
+
+define %"System.String[]" addrspace(1)* @AppDomainSetup.get_Value(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.String[]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 18)
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.String[]" addrspace(1)* addrspace(1)*, %"System.String[]" addrspace(1)*)*)(%"System.String[]" addrspace(1)* addrspace(1)* %9, %"System.String[]" addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %11, i32 0, i32 1
+  %14 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %13, align 8
+  ret %"System.String[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -319,8 +401,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -368,16 +450,16 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
   %5 = load i32, i32 addrspace(1)* %4
   %6 = sub i32 %5, 1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -389,7 +471,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -421,8 +503,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
@@ -456,8 +538,8 @@ entry:
 ; <label>:27                                      ; preds = %19
   %28 = load i32, i32* %arg1
   %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
-  br i1 %NullCheck2, label %30, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %29, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %30
 
 ; <label>:30                                      ; preds = %27
   %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
@@ -493,8 +575,8 @@ entry:
 ; <label>:49                                      ; preds = %46
   %50 = load i32, i32* %arg2
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck4, label %52, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
@@ -517,11 +599,11 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %27
+ThrowNullRef2:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %49
+ThrowNullRef4:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -544,16 +626,16 @@ entry:
   %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %0)
   store %System.String addrspace(1)* %1, %System.String addrspace(1)** %loc0
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 2
   %5 = bitcast [0 x i16] addrspace(1)* %4 to i16 addrspace(1)*
   store i16 addrspace(1)* %5, i16 addrspace(1)** %loc1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %3
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2
@@ -580,7 +662,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -691,15 +773,15 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %NullCheck132 = icmp ne i8* %21, null
-  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+  %NullCheck131 = icmp eq i8* %21, null
+  br i1 %NullCheck131, label %ThrowNullRef132, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = load i8, i8* %21, align 8
   %24 = zext i8 %23 to i32
   %25 = trunc i32 %24 to i8
-  %NullCheck134 = icmp ne i8* %20, null
-  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+  %NullCheck133 = icmp eq i8* %20, null
+  br i1 %NullCheck133, label %ThrowNullRef134, label %26
 
 ; <label>:26                                      ; preds = %22
   store i8 %25, i8* %20, align 8
@@ -709,16 +791,16 @@ entry:
   %28 = load i8*, i8** %arg0
   %29 = load i8*, i8** %arg1
   %30 = bitcast i8* %29 to i16*
-  %NullCheck128 = icmp ne i16* %30, null
-  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+  %NullCheck127 = icmp eq i16* %30, null
+  br i1 %NullCheck127, label %ThrowNullRef128, label %31
 
 ; <label>:31                                      ; preds = %27
   %32 = load i16, i16* %30, align 8
   %33 = sext i16 %32 to i32
   %34 = bitcast i8* %28 to i16*
   %35 = trunc i32 %33 to i16
-  %NullCheck130 = icmp ne i16* %34, null
-  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+  %NullCheck129 = icmp eq i16* %34, null
+  br i1 %NullCheck129, label %ThrowNullRef130, label %36
 
 ; <label>:36                                      ; preds = %31
   store i16 %35, i16* %34, align 8
@@ -728,16 +810,16 @@ entry:
   %38 = load i8*, i8** %arg0
   %39 = load i8*, i8** %arg1
   %40 = bitcast i8* %39 to i16*
-  %NullCheck120 = icmp ne i16* %40, null
-  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+  %NullCheck119 = icmp eq i16* %40, null
+  br i1 %NullCheck119, label %ThrowNullRef120, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i16, i16* %40, align 8
   %43 = sext i16 %42 to i32
   %44 = bitcast i8* %38 to i16*
   %45 = trunc i32 %43 to i16
-  %NullCheck122 = icmp ne i16* %44, null
-  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+  %NullCheck121 = icmp eq i16* %44, null
+  br i1 %NullCheck121, label %ThrowNullRef122, label %46
 
 ; <label>:46                                      ; preds = %41
   store i16 %45, i16* %44, align 8
@@ -745,15 +827,15 @@ entry:
   %48 = getelementptr inbounds i8, i8* %47, i64 2
   %49 = load i8*, i8** %arg1
   %50 = getelementptr inbounds i8, i8* %49, i64 2
-  %NullCheck124 = icmp ne i8* %50, null
-  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+  %NullCheck123 = icmp eq i8* %50, null
+  br i1 %NullCheck123, label %ThrowNullRef124, label %51
 
 ; <label>:51                                      ; preds = %46
   %52 = load i8, i8* %50, align 8
   %53 = zext i8 %52 to i32
   %54 = trunc i32 %53 to i8
-  %NullCheck126 = icmp ne i8* %48, null
-  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+  %NullCheck125 = icmp eq i8* %48, null
+  br i1 %NullCheck125, label %ThrowNullRef126, label %55
 
 ; <label>:55                                      ; preds = %51
   store i8 %54, i8* %48, align 8
@@ -763,14 +845,14 @@ entry:
   %57 = load i8*, i8** %arg0
   %58 = load i8*, i8** %arg1
   %59 = bitcast i8* %58 to i32*
-  %NullCheck116 = icmp ne i32* %59, null
-  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+  %NullCheck115 = icmp eq i32* %59, null
+  br i1 %NullCheck115, label %ThrowNullRef116, label %60
 
 ; <label>:60                                      ; preds = %56
   %61 = load i32, i32* %59, align 8
   %62 = bitcast i8* %57 to i32*
-  %NullCheck118 = icmp ne i32* %62, null
-  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+  %NullCheck117 = icmp eq i32* %62, null
+  br i1 %NullCheck117, label %ThrowNullRef118, label %63
 
 ; <label>:63                                      ; preds = %60
   store i32 %61, i32* %62, align 8
@@ -780,14 +862,14 @@ entry:
   %65 = load i8*, i8** %arg0
   %66 = load i8*, i8** %arg1
   %67 = bitcast i8* %66 to i32*
-  %NullCheck108 = icmp ne i32* %67, null
-  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+  %NullCheck107 = icmp eq i32* %67, null
+  br i1 %NullCheck107, label %ThrowNullRef108, label %68
 
 ; <label>:68                                      ; preds = %64
   %69 = load i32, i32* %67, align 8
   %70 = bitcast i8* %65 to i32*
-  %NullCheck110 = icmp ne i32* %70, null
-  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+  %NullCheck109 = icmp eq i32* %70, null
+  br i1 %NullCheck109, label %ThrowNullRef110, label %71
 
 ; <label>:71                                      ; preds = %68
   store i32 %69, i32* %70, align 8
@@ -795,15 +877,15 @@ entry:
   %73 = getelementptr inbounds i8, i8* %72, i64 4
   %74 = load i8*, i8** %arg1
   %75 = getelementptr inbounds i8, i8* %74, i64 4
-  %NullCheck112 = icmp ne i8* %75, null
-  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+  %NullCheck111 = icmp eq i8* %75, null
+  br i1 %NullCheck111, label %ThrowNullRef112, label %76
 
 ; <label>:76                                      ; preds = %71
   %77 = load i8, i8* %75, align 8
   %78 = zext i8 %77 to i32
   %79 = trunc i32 %78 to i8
-  %NullCheck114 = icmp ne i8* %73, null
-  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+  %NullCheck113 = icmp eq i8* %73, null
+  br i1 %NullCheck113, label %ThrowNullRef114, label %80
 
 ; <label>:80                                      ; preds = %76
   store i8 %79, i8* %73, align 8
@@ -813,14 +895,14 @@ entry:
   %82 = load i8*, i8** %arg0
   %83 = load i8*, i8** %arg1
   %84 = bitcast i8* %83 to i32*
-  %NullCheck100 = icmp ne i32* %84, null
-  br i1 %NullCheck100, label %85, label %ThrowNullRef99
+  %NullCheck99 = icmp eq i32* %84, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %85
 
 ; <label>:85                                      ; preds = %81
   %86 = load i32, i32* %84, align 8
   %87 = bitcast i8* %82 to i32*
-  %NullCheck102 = icmp ne i32* %87, null
-  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+  %NullCheck101 = icmp eq i32* %87, null
+  br i1 %NullCheck101, label %ThrowNullRef102, label %88
 
 ; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
@@ -829,16 +911,16 @@ entry:
   %91 = load i8*, i8** %arg1
   %92 = getelementptr inbounds i8, i8* %91, i64 4
   %93 = bitcast i8* %92 to i16*
-  %NullCheck104 = icmp ne i16* %93, null
-  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+  %NullCheck103 = icmp eq i16* %93, null
+  br i1 %NullCheck103, label %ThrowNullRef104, label %94
 
 ; <label>:94                                      ; preds = %88
   %95 = load i16, i16* %93, align 8
   %96 = sext i16 %95 to i32
   %97 = bitcast i8* %90 to i16*
   %98 = trunc i32 %96 to i16
-  %NullCheck106 = icmp ne i16* %97, null
-  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+  %NullCheck105 = icmp eq i16* %97, null
+  br i1 %NullCheck105, label %ThrowNullRef106, label %99
 
 ; <label>:99                                      ; preds = %94
   store i16 %98, i16* %97, align 8
@@ -848,14 +930,14 @@ entry:
   %101 = load i8*, i8** %arg0
   %102 = load i8*, i8** %arg1
   %103 = bitcast i8* %102 to i32*
-  %NullCheck88 = icmp ne i32* %103, null
-  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+  %NullCheck87 = icmp eq i32* %103, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %104
 
 ; <label>:104                                     ; preds = %100
   %105 = load i32, i32* %103, align 8
   %106 = bitcast i8* %101 to i32*
-  %NullCheck90 = icmp ne i32* %106, null
-  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+  %NullCheck89 = icmp eq i32* %106, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %107
 
 ; <label>:107                                     ; preds = %104
   store i32 %105, i32* %106, align 8
@@ -864,16 +946,16 @@ entry:
   %110 = load i8*, i8** %arg1
   %111 = getelementptr inbounds i8, i8* %110, i64 4
   %112 = bitcast i8* %111 to i16*
-  %NullCheck92 = icmp ne i16* %112, null
-  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+  %NullCheck91 = icmp eq i16* %112, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %113
 
 ; <label>:113                                     ; preds = %107
   %114 = load i16, i16* %112, align 8
   %115 = sext i16 %114 to i32
   %116 = bitcast i8* %109 to i16*
   %117 = trunc i32 %115 to i16
-  %NullCheck94 = icmp ne i16* %116, null
-  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+  %NullCheck93 = icmp eq i16* %116, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %118
 
 ; <label>:118                                     ; preds = %113
   store i16 %117, i16* %116, align 8
@@ -881,15 +963,15 @@ entry:
   %120 = getelementptr inbounds i8, i8* %119, i64 6
   %121 = load i8*, i8** %arg1
   %122 = getelementptr inbounds i8, i8* %121, i64 6
-  %NullCheck96 = icmp ne i8* %122, null
-  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+  %NullCheck95 = icmp eq i8* %122, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %123
 
 ; <label>:123                                     ; preds = %118
   %124 = load i8, i8* %122, align 8
   %125 = zext i8 %124 to i32
   %126 = trunc i32 %125 to i8
-  %NullCheck98 = icmp ne i8* %120, null
-  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+  %NullCheck97 = icmp eq i8* %120, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %127
 
 ; <label>:127                                     ; preds = %123
   store i8 %126, i8* %120, align 8
@@ -899,14 +981,14 @@ entry:
   %129 = load i8*, i8** %arg0
   %130 = load i8*, i8** %arg1
   %131 = bitcast i8* %130 to i64*
-  %NullCheck84 = icmp ne i64* %131, null
-  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+  %NullCheck83 = icmp eq i64* %131, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %132
 
 ; <label>:132                                     ; preds = %128
   %133 = load i64, i64* %131, align 8
   %134 = bitcast i8* %129 to i64*
-  %NullCheck86 = icmp ne i64* %134, null
-  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+  %NullCheck85 = icmp eq i64* %134, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %135
 
 ; <label>:135                                     ; preds = %132
   store i64 %133, i64* %134, align 8
@@ -916,14 +998,14 @@ entry:
   %137 = load i8*, i8** %arg0
   %138 = load i8*, i8** %arg1
   %139 = bitcast i8* %138 to i64*
-  %NullCheck76 = icmp ne i64* %139, null
-  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+  %NullCheck75 = icmp eq i64* %139, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %140
 
 ; <label>:140                                     ; preds = %136
   %141 = load i64, i64* %139, align 8
   %142 = bitcast i8* %137 to i64*
-  %NullCheck78 = icmp ne i64* %142, null
-  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+  %NullCheck77 = icmp eq i64* %142, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %143
 
 ; <label>:143                                     ; preds = %140
   store i64 %141, i64* %142, align 8
@@ -931,15 +1013,15 @@ entry:
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %NullCheck80 = icmp ne i8* %147, null
-  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+  %NullCheck79 = icmp eq i8* %147, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %148
 
 ; <label>:148                                     ; preds = %143
   %149 = load i8, i8* %147, align 8
   %150 = zext i8 %149 to i32
   %151 = trunc i32 %150 to i8
-  %NullCheck82 = icmp ne i8* %145, null
-  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+  %NullCheck81 = icmp eq i8* %145, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %152
 
 ; <label>:152                                     ; preds = %148
   store i8 %151, i8* %145, align 8
@@ -949,14 +1031,14 @@ entry:
   %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
   %156 = bitcast i8* %155 to i64*
-  %NullCheck68 = icmp ne i64* %156, null
-  br i1 %NullCheck68, label %157, label %ThrowNullRef67
+  %NullCheck67 = icmp eq i64* %156, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %157
 
 ; <label>:157                                     ; preds = %153
   %158 = load i64, i64* %156, align 8
   %159 = bitcast i8* %154 to i64*
-  %NullCheck70 = icmp ne i64* %159, null
-  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+  %NullCheck69 = icmp eq i64* %159, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %160
 
 ; <label>:160                                     ; preds = %157
   store i64 %158, i64* %159, align 8
@@ -965,16 +1047,16 @@ entry:
   %163 = load i8*, i8** %arg1
   %164 = getelementptr inbounds i8, i8* %163, i64 8
   %165 = bitcast i8* %164 to i16*
-  %NullCheck72 = icmp ne i16* %165, null
-  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+  %NullCheck71 = icmp eq i16* %165, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %166
 
 ; <label>:166                                     ; preds = %160
   %167 = load i16, i16* %165, align 8
   %168 = sext i16 %167 to i32
   %169 = bitcast i8* %162 to i16*
   %170 = trunc i32 %168 to i16
-  %NullCheck74 = icmp ne i16* %169, null
-  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+  %NullCheck73 = icmp eq i16* %169, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %171
 
 ; <label>:171                                     ; preds = %166
   store i16 %170, i16* %169, align 8
@@ -984,14 +1066,14 @@ entry:
   %173 = load i8*, i8** %arg0
   %174 = load i8*, i8** %arg1
   %175 = bitcast i8* %174 to i64*
-  %NullCheck56 = icmp ne i64* %175, null
-  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+  %NullCheck55 = icmp eq i64* %175, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %176
 
 ; <label>:176                                     ; preds = %172
   %177 = load i64, i64* %175, align 8
   %178 = bitcast i8* %173 to i64*
-  %NullCheck58 = icmp ne i64* %178, null
-  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+  %NullCheck57 = icmp eq i64* %178, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %179
 
 ; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
@@ -1000,16 +1082,16 @@ entry:
   %182 = load i8*, i8** %arg1
   %183 = getelementptr inbounds i8, i8* %182, i64 8
   %184 = bitcast i8* %183 to i16*
-  %NullCheck60 = icmp ne i16* %184, null
-  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+  %NullCheck59 = icmp eq i16* %184, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %185
 
 ; <label>:185                                     ; preds = %179
   %186 = load i16, i16* %184, align 8
   %187 = sext i16 %186 to i32
   %188 = bitcast i8* %181 to i16*
   %189 = trunc i32 %187 to i16
-  %NullCheck62 = icmp ne i16* %188, null
-  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+  %NullCheck61 = icmp eq i16* %188, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %190
 
 ; <label>:190                                     ; preds = %185
   store i16 %189, i16* %188, align 8
@@ -1017,15 +1099,15 @@ entry:
   %192 = getelementptr inbounds i8, i8* %191, i64 10
   %193 = load i8*, i8** %arg1
   %194 = getelementptr inbounds i8, i8* %193, i64 10
-  %NullCheck64 = icmp ne i8* %194, null
-  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+  %NullCheck63 = icmp eq i8* %194, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %195
 
 ; <label>:195                                     ; preds = %190
   %196 = load i8, i8* %194, align 8
   %197 = zext i8 %196 to i32
   %198 = trunc i32 %197 to i8
-  %NullCheck66 = icmp ne i8* %192, null
-  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+  %NullCheck65 = icmp eq i8* %192, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %199
 
 ; <label>:199                                     ; preds = %195
   store i8 %198, i8* %192, align 8
@@ -1035,14 +1117,14 @@ entry:
   %201 = load i8*, i8** %arg0
   %202 = load i8*, i8** %arg1
   %203 = bitcast i8* %202 to i64*
-  %NullCheck48 = icmp ne i64* %203, null
-  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+  %NullCheck47 = icmp eq i64* %203, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %204
 
 ; <label>:204                                     ; preds = %200
   %205 = load i64, i64* %203, align 8
   %206 = bitcast i8* %201 to i64*
-  %NullCheck50 = icmp ne i64* %206, null
-  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+  %NullCheck49 = icmp eq i64* %206, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %207
 
 ; <label>:207                                     ; preds = %204
   store i64 %205, i64* %206, align 8
@@ -1051,14 +1133,14 @@ entry:
   %210 = load i8*, i8** %arg1
   %211 = getelementptr inbounds i8, i8* %210, i64 8
   %212 = bitcast i8* %211 to i32*
-  %NullCheck52 = icmp ne i32* %212, null
-  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+  %NullCheck51 = icmp eq i32* %212, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %213
 
 ; <label>:213                                     ; preds = %207
   %214 = load i32, i32* %212, align 8
   %215 = bitcast i8* %209 to i32*
-  %NullCheck54 = icmp ne i32* %215, null
-  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+  %NullCheck53 = icmp eq i32* %215, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %216
 
 ; <label>:216                                     ; preds = %213
   store i32 %214, i32* %215, align 8
@@ -1068,14 +1150,14 @@ entry:
   %218 = load i8*, i8** %arg0
   %219 = load i8*, i8** %arg1
   %220 = bitcast i8* %219 to i64*
-  %NullCheck36 = icmp ne i64* %220, null
-  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64* %220, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %221
 
 ; <label>:221                                     ; preds = %217
   %222 = load i64, i64* %220, align 8
   %223 = bitcast i8* %218 to i64*
-  %NullCheck38 = icmp ne i64* %223, null
-  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+  %NullCheck37 = icmp eq i64* %223, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %224
 
 ; <label>:224                                     ; preds = %221
   store i64 %222, i64* %223, align 8
@@ -1084,14 +1166,14 @@ entry:
   %227 = load i8*, i8** %arg1
   %228 = getelementptr inbounds i8, i8* %227, i64 8
   %229 = bitcast i8* %228 to i32*
-  %NullCheck40 = icmp ne i32* %229, null
-  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i32* %229, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %230
 
 ; <label>:230                                     ; preds = %224
   %231 = load i32, i32* %229, align 8
   %232 = bitcast i8* %226 to i32*
-  %NullCheck42 = icmp ne i32* %232, null
-  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+  %NullCheck41 = icmp eq i32* %232, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %233
 
 ; <label>:233                                     ; preds = %230
   store i32 %231, i32* %232, align 8
@@ -1099,15 +1181,15 @@ entry:
   %235 = getelementptr inbounds i8, i8* %234, i64 12
   %236 = load i8*, i8** %arg1
   %237 = getelementptr inbounds i8, i8* %236, i64 12
-  %NullCheck44 = icmp ne i8* %237, null
-  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i8* %237, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %238
 
 ; <label>:238                                     ; preds = %233
   %239 = load i8, i8* %237, align 8
   %240 = zext i8 %239 to i32
   %241 = trunc i32 %240 to i8
-  %NullCheck46 = icmp ne i8* %235, null
-  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+  %NullCheck45 = icmp eq i8* %235, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %242
 
 ; <label>:242                                     ; preds = %238
   store i8 %241, i8* %235, align 8
@@ -1117,14 +1199,14 @@ entry:
   %244 = load i8*, i8** %arg0
   %245 = load i8*, i8** %arg1
   %246 = bitcast i8* %245 to i64*
-  %NullCheck24 = icmp ne i64* %246, null
-  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64* %246, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %247
 
 ; <label>:247                                     ; preds = %243
   %248 = load i64, i64* %246, align 8
   %249 = bitcast i8* %244 to i64*
-  %NullCheck26 = icmp ne i64* %249, null
-  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64* %249, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %250
 
 ; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
@@ -1133,14 +1215,14 @@ entry:
   %253 = load i8*, i8** %arg1
   %254 = getelementptr inbounds i8, i8* %253, i64 8
   %255 = bitcast i8* %254 to i32*
-  %NullCheck28 = icmp ne i32* %255, null
-  br i1 %NullCheck28, label %256, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i32* %255, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %256
 
 ; <label>:256                                     ; preds = %250
   %257 = load i32, i32* %255, align 8
   %258 = bitcast i8* %252 to i32*
-  %NullCheck30 = icmp ne i32* %258, null
-  br i1 %NullCheck30, label %259, label %ThrowNullRef29
+  %NullCheck29 = icmp eq i32* %258, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %259
 
 ; <label>:259                                     ; preds = %256
   store i32 %257, i32* %258, align 8
@@ -1149,16 +1231,16 @@ entry:
   %262 = load i8*, i8** %arg1
   %263 = getelementptr inbounds i8, i8* %262, i64 12
   %264 = bitcast i8* %263 to i16*
-  %NullCheck32 = icmp ne i16* %264, null
-  br i1 %NullCheck32, label %265, label %ThrowNullRef31
+  %NullCheck31 = icmp eq i16* %264, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %265
 
 ; <label>:265                                     ; preds = %259
   %266 = load i16, i16* %264, align 8
   %267 = sext i16 %266 to i32
   %268 = bitcast i8* %261 to i16*
   %269 = trunc i32 %267 to i16
-  %NullCheck34 = icmp ne i16* %268, null
-  br i1 %NullCheck34, label %270, label %ThrowNullRef33
+  %NullCheck33 = icmp eq i16* %268, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %270
 
 ; <label>:270                                     ; preds = %265
   store i16 %269, i16* %268, align 8
@@ -1168,14 +1250,14 @@ entry:
   %272 = load i8*, i8** %arg0
   %273 = load i8*, i8** %arg1
   %274 = bitcast i8* %273 to i64*
-  %NullCheck8 = icmp ne i64* %274, null
-  br i1 %NullCheck8, label %275, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64* %274, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %275
 
 ; <label>:275                                     ; preds = %271
   %276 = load i64, i64* %274, align 8
   %277 = bitcast i8* %272 to i64*
-  %NullCheck10 = icmp ne i64* %277, null
-  br i1 %NullCheck10, label %278, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %277, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %278
 
 ; <label>:278                                     ; preds = %275
   store i64 %276, i64* %277, align 8
@@ -1184,14 +1266,14 @@ entry:
   %281 = load i8*, i8** %arg1
   %282 = getelementptr inbounds i8, i8* %281, i64 8
   %283 = bitcast i8* %282 to i32*
-  %NullCheck12 = icmp ne i32* %283, null
-  br i1 %NullCheck12, label %284, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i32* %283, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %284
 
 ; <label>:284                                     ; preds = %278
   %285 = load i32, i32* %283, align 8
   %286 = bitcast i8* %280 to i32*
-  %NullCheck14 = icmp ne i32* %286, null
-  br i1 %NullCheck14, label %287, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i32* %286, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %287
 
 ; <label>:287                                     ; preds = %284
   store i32 %285, i32* %286, align 8
@@ -1200,16 +1282,16 @@ entry:
   %290 = load i8*, i8** %arg1
   %291 = getelementptr inbounds i8, i8* %290, i64 12
   %292 = bitcast i8* %291 to i16*
-  %NullCheck16 = icmp ne i16* %292, null
-  br i1 %NullCheck16, label %293, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i16* %292, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %293
 
 ; <label>:293                                     ; preds = %287
   %294 = load i16, i16* %292, align 8
   %295 = sext i16 %294 to i32
   %296 = bitcast i8* %289 to i16*
   %297 = trunc i32 %295 to i16
-  %NullCheck18 = icmp ne i16* %296, null
-  br i1 %NullCheck18, label %298, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i16* %296, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %298
 
 ; <label>:298                                     ; preds = %293
   store i16 %297, i16* %296, align 8
@@ -1217,15 +1299,15 @@ entry:
   %300 = getelementptr inbounds i8, i8* %299, i64 14
   %301 = load i8*, i8** %arg1
   %302 = getelementptr inbounds i8, i8* %301, i64 14
-  %NullCheck20 = icmp ne i8* %302, null
-  br i1 %NullCheck20, label %303, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i8* %302, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %303
 
 ; <label>:303                                     ; preds = %298
   %304 = load i8, i8* %302, align 8
   %305 = zext i8 %304 to i32
   %306 = trunc i32 %305 to i8
-  %NullCheck22 = icmp ne i8* %300, null
-  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i8* %300, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %307
 
 ; <label>:307                                     ; preds = %303
   store i8 %306, i8* %300, align 8
@@ -1235,14 +1317,14 @@ entry:
   %309 = load i8*, i8** %arg0
   %310 = load i8*, i8** %arg1
   %311 = bitcast i8* %310 to i64*
-  %NullCheck = icmp ne i64* %311, null
-  br i1 %NullCheck, label %312, label %ThrowNullRef
+  %NullCheck = icmp eq i64* %311, null
+  br i1 %NullCheck, label %ThrowNullRef, label %312
 
 ; <label>:312                                     ; preds = %308
   %313 = load i64, i64* %311, align 8
   %314 = bitcast i8* %309 to i64*
-  %NullCheck2 = icmp ne i64* %314, null
-  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64* %314, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %315
 
 ; <label>:315                                     ; preds = %312
   store i64 %313, i64* %314, align 8
@@ -1251,14 +1333,14 @@ entry:
   %318 = load i8*, i8** %arg1
   %319 = getelementptr inbounds i8, i8* %318, i64 8
   %320 = bitcast i8* %319 to i64*
-  %NullCheck4 = icmp ne i64* %320, null
-  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64* %320, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %321
 
 ; <label>:321                                     ; preds = %315
   %322 = load i64, i64* %320, align 8
   %323 = bitcast i8* %317 to i64*
-  %NullCheck6 = icmp ne i64* %323, null
-  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64* %323, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %324
 
 ; <label>:324                                     ; preds = %321
   store i64 %322, i64* %323, align 8
@@ -1286,15 +1368,15 @@ entry:
 ; <label>:338                                     ; preds = %333
   %339 = load i8*, i8** %arg0
   %340 = load i8*, i8** %arg1
-  %NullCheck136 = icmp ne i8* %340, null
-  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+  %NullCheck135 = icmp eq i8* %340, null
+  br i1 %NullCheck135, label %ThrowNullRef136, label %341
 
 ; <label>:341                                     ; preds = %338
   %342 = load i8, i8* %340, align 8
   %343 = zext i8 %342 to i32
   %344 = trunc i32 %343 to i8
-  %NullCheck138 = icmp ne i8* %339, null
-  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+  %NullCheck137 = icmp eq i8* %339, null
+  br i1 %NullCheck137, label %ThrowNullRef138, label %345
 
 ; <label>:345                                     ; preds = %341
   store i8 %344, i8* %339, align 8
@@ -1317,16 +1399,16 @@ entry:
   %357 = load i8*, i8** %arg0
   %358 = load i8*, i8** %arg1
   %359 = bitcast i8* %358 to i16*
-  %NullCheck140 = icmp ne i16* %359, null
-  br i1 %NullCheck140, label %360, label %ThrowNullRef139
+  %NullCheck139 = icmp eq i16* %359, null
+  br i1 %NullCheck139, label %ThrowNullRef140, label %360
 
 ; <label>:360                                     ; preds = %356
   %361 = load i16, i16* %359, align 8
   %362 = sext i16 %361 to i32
   %363 = bitcast i8* %357 to i16*
   %364 = trunc i32 %362 to i16
-  %NullCheck142 = icmp ne i16* %363, null
-  br i1 %NullCheck142, label %365, label %ThrowNullRef141
+  %NullCheck141 = icmp eq i16* %363, null
+  br i1 %NullCheck141, label %ThrowNullRef142, label %365
 
 ; <label>:365                                     ; preds = %360
   store i16 %364, i16* %363, align 8
@@ -1352,14 +1434,14 @@ entry:
   %378 = load i8*, i8** %arg0
   %379 = load i8*, i8** %arg1
   %380 = bitcast i8* %379 to i32*
-  %NullCheck144 = icmp ne i32* %380, null
-  br i1 %NullCheck144, label %381, label %ThrowNullRef143
+  %NullCheck143 = icmp eq i32* %380, null
+  br i1 %NullCheck143, label %ThrowNullRef144, label %381
 
 ; <label>:381                                     ; preds = %377
   %382 = load i32, i32* %380, align 8
   %383 = bitcast i8* %378 to i32*
-  %NullCheck146 = icmp ne i32* %383, null
-  br i1 %NullCheck146, label %384, label %ThrowNullRef145
+  %NullCheck145 = icmp eq i32* %383, null
+  br i1 %NullCheck145, label %ThrowNullRef146, label %384
 
 ; <label>:384                                     ; preds = %381
   store i32 %382, i32* %383, align 8
@@ -1384,14 +1466,14 @@ entry:
   %395 = load i8*, i8** %arg0
   %396 = load i8*, i8** %arg1
   %397 = bitcast i8* %396 to i64*
-  %NullCheck164 = icmp ne i64* %397, null
-  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+  %NullCheck163 = icmp eq i64* %397, null
+  br i1 %NullCheck163, label %ThrowNullRef164, label %398
 
 ; <label>:398                                     ; preds = %394
   %399 = load i64, i64* %397, align 8
   %400 = bitcast i8* %395 to i64*
-  %NullCheck166 = icmp ne i64* %400, null
-  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+  %NullCheck165 = icmp eq i64* %400, null
+  br i1 %NullCheck165, label %ThrowNullRef166, label %401
 
 ; <label>:401                                     ; preds = %398
   store i64 %399, i64* %400, align 8
@@ -1400,14 +1482,14 @@ entry:
   %404 = load i8*, i8** %arg1
   %405 = getelementptr inbounds i8, i8* %404, i64 8
   %406 = bitcast i8* %405 to i64*
-  %NullCheck168 = icmp ne i64* %406, null
-  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+  %NullCheck167 = icmp eq i64* %406, null
+  br i1 %NullCheck167, label %ThrowNullRef168, label %407
 
 ; <label>:407                                     ; preds = %401
   %408 = load i64, i64* %406, align 8
   %409 = bitcast i8* %403 to i64*
-  %NullCheck170 = icmp ne i64* %409, null
-  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+  %NullCheck169 = icmp eq i64* %409, null
+  br i1 %NullCheck169, label %ThrowNullRef170, label %410
 
 ; <label>:410                                     ; preds = %407
   store i64 %408, i64* %409, align 8
@@ -1437,14 +1519,14 @@ entry:
   %425 = load i8*, i8** %arg0
   %426 = load i8*, i8** %arg1
   %427 = bitcast i8* %426 to i64*
-  %NullCheck148 = icmp ne i64* %427, null
-  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+  %NullCheck147 = icmp eq i64* %427, null
+  br i1 %NullCheck147, label %ThrowNullRef148, label %428
 
 ; <label>:428                                     ; preds = %424
   %429 = load i64, i64* %427, align 8
   %430 = bitcast i8* %425 to i64*
-  %NullCheck150 = icmp ne i64* %430, null
-  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+  %NullCheck149 = icmp eq i64* %430, null
+  br i1 %NullCheck149, label %ThrowNullRef150, label %431
 
 ; <label>:431                                     ; preds = %428
   store i64 %429, i64* %430, align 8
@@ -1466,14 +1548,14 @@ entry:
   %441 = load i8*, i8** %arg0
   %442 = load i8*, i8** %arg1
   %443 = bitcast i8* %442 to i32*
-  %NullCheck152 = icmp ne i32* %443, null
-  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+  %NullCheck151 = icmp eq i32* %443, null
+  br i1 %NullCheck151, label %ThrowNullRef152, label %444
 
 ; <label>:444                                     ; preds = %440
   %445 = load i32, i32* %443, align 8
   %446 = bitcast i8* %441 to i32*
-  %NullCheck154 = icmp ne i32* %446, null
-  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+  %NullCheck153 = icmp eq i32* %446, null
+  br i1 %NullCheck153, label %ThrowNullRef154, label %447
 
 ; <label>:447                                     ; preds = %444
   store i32 %445, i32* %446, align 8
@@ -1495,16 +1577,16 @@ entry:
   %457 = load i8*, i8** %arg0
   %458 = load i8*, i8** %arg1
   %459 = bitcast i8* %458 to i16*
-  %NullCheck156 = icmp ne i16* %459, null
-  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+  %NullCheck155 = icmp eq i16* %459, null
+  br i1 %NullCheck155, label %ThrowNullRef156, label %460
 
 ; <label>:460                                     ; preds = %456
   %461 = load i16, i16* %459, align 8
   %462 = sext i16 %461 to i32
   %463 = bitcast i8* %457 to i16*
   %464 = trunc i32 %462 to i16
-  %NullCheck158 = icmp ne i16* %463, null
-  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+  %NullCheck157 = icmp eq i16* %463, null
+  br i1 %NullCheck157, label %ThrowNullRef158, label %465
 
 ; <label>:465                                     ; preds = %460
   store i16 %464, i16* %463, align 8
@@ -1525,15 +1607,15 @@ entry:
 ; <label>:474                                     ; preds = %470
   %475 = load i8*, i8** %arg0
   %476 = load i8*, i8** %arg1
-  %NullCheck160 = icmp ne i8* %476, null
-  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+  %NullCheck159 = icmp eq i8* %476, null
+  br i1 %NullCheck159, label %ThrowNullRef160, label %477
 
 ; <label>:477                                     ; preds = %474
   %478 = load i8, i8* %476, align 8
   %479 = zext i8 %478 to i32
   %480 = trunc i32 %479 to i8
-  %NullCheck162 = icmp ne i8* %475, null
-  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+  %NullCheck161 = icmp eq i8* %475, null
+  br i1 %NullCheck161, label %ThrowNullRef162, label %481
 
 ; <label>:481                                     ; preds = %477
   store i8 %480, i8* %475, align 8
@@ -1553,343 +1635,343 @@ ThrowNullRef:                                     ; preds = %308
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %312
+ThrowNullRef2:                                    ; preds = %312
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %315
+ThrowNullRef4:                                    ; preds = %315
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %321
+ThrowNullRef6:                                    ; preds = %321
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %271
+ThrowNullRef8:                                    ; preds = %271
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %275
+ThrowNullRef10:                                   ; preds = %275
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %278
+ThrowNullRef12:                                   ; preds = %278
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %284
+ThrowNullRef14:                                   ; preds = %284
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %287
+ThrowNullRef16:                                   ; preds = %287
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %293
+ThrowNullRef18:                                   ; preds = %293
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %298
+ThrowNullRef20:                                   ; preds = %298
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %303
+ThrowNullRef22:                                   ; preds = %303
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %243
+ThrowNullRef24:                                   ; preds = %243
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %247
+ThrowNullRef26:                                   ; preds = %247
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %250
+ThrowNullRef28:                                   ; preds = %250
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %256
+ThrowNullRef30:                                   ; preds = %256
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %259
+ThrowNullRef32:                                   ; preds = %259
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %265
+ThrowNullRef34:                                   ; preds = %265
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %217
+ThrowNullRef36:                                   ; preds = %217
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %221
+ThrowNullRef38:                                   ; preds = %221
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %224
+ThrowNullRef40:                                   ; preds = %224
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %230
+ThrowNullRef42:                                   ; preds = %230
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %233
+ThrowNullRef44:                                   ; preds = %233
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %238
+ThrowNullRef46:                                   ; preds = %238
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %200
+ThrowNullRef48:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %204
+ThrowNullRef50:                                   ; preds = %204
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %207
+ThrowNullRef52:                                   ; preds = %207
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %213
+ThrowNullRef54:                                   ; preds = %213
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %172
+ThrowNullRef56:                                   ; preds = %172
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %176
+ThrowNullRef58:                                   ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %179
+ThrowNullRef60:                                   ; preds = %179
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %185
+ThrowNullRef62:                                   ; preds = %185
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %190
+ThrowNullRef64:                                   ; preds = %190
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %195
+ThrowNullRef66:                                   ; preds = %195
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %153
+ThrowNullRef68:                                   ; preds = %153
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %157
+ThrowNullRef70:                                   ; preds = %157
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %160
+ThrowNullRef72:                                   ; preds = %160
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %166
+ThrowNullRef74:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %136
+ThrowNullRef76:                                   ; preds = %136
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %140
+ThrowNullRef78:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %143
+ThrowNullRef80:                                   ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %148
+ThrowNullRef82:                                   ; preds = %148
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %128
+ThrowNullRef84:                                   ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %132
+ThrowNullRef86:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %100
+ThrowNullRef88:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %104
+ThrowNullRef90:                                   ; preds = %104
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %107
+ThrowNullRef92:                                   ; preds = %107
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %113
+ThrowNullRef94:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %118
+ThrowNullRef96:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %123
+ThrowNullRef98:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %81
+ThrowNullRef100:                                  ; preds = %81
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef101:                                  ; preds = %85
+ThrowNullRef102:                                  ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef103:                                  ; preds = %88
+ThrowNullRef104:                                  ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef105:                                  ; preds = %94
+ThrowNullRef106:                                  ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef107:                                  ; preds = %64
+ThrowNullRef108:                                  ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef109:                                  ; preds = %68
+ThrowNullRef110:                                  ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef111:                                  ; preds = %71
+ThrowNullRef112:                                  ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef113:                                  ; preds = %76
+ThrowNullRef114:                                  ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef115:                                  ; preds = %56
+ThrowNullRef116:                                  ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef117:                                  ; preds = %60
+ThrowNullRef118:                                  ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef119:                                  ; preds = %37
+ThrowNullRef120:                                  ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef121:                                  ; preds = %41
+ThrowNullRef122:                                  ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef123:                                  ; preds = %46
+ThrowNullRef124:                                  ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef125:                                  ; preds = %51
+ThrowNullRef126:                                  ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef127:                                  ; preds = %27
+ThrowNullRef128:                                  ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef129:                                  ; preds = %31
+ThrowNullRef130:                                  ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef131:                                  ; preds = %19
+ThrowNullRef132:                                  ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef133:                                  ; preds = %22
+ThrowNullRef134:                                  ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef135:                                  ; preds = %338
+ThrowNullRef136:                                  ; preds = %338
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef137:                                  ; preds = %341
+ThrowNullRef138:                                  ; preds = %341
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef139:                                  ; preds = %356
+ThrowNullRef140:                                  ; preds = %356
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef141:                                  ; preds = %360
+ThrowNullRef142:                                  ; preds = %360
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef143:                                  ; preds = %377
+ThrowNullRef144:                                  ; preds = %377
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef145:                                  ; preds = %381
+ThrowNullRef146:                                  ; preds = %381
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef147:                                  ; preds = %424
+ThrowNullRef148:                                  ; preds = %424
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef149:                                  ; preds = %428
+ThrowNullRef150:                                  ; preds = %428
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef151:                                  ; preds = %440
+ThrowNullRef152:                                  ; preds = %440
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef153:                                  ; preds = %444
+ThrowNullRef154:                                  ; preds = %444
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef155:                                  ; preds = %456
+ThrowNullRef156:                                  ; preds = %456
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef157:                                  ; preds = %460
+ThrowNullRef158:                                  ; preds = %460
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef159:                                  ; preds = %474
+ThrowNullRef160:                                  ; preds = %474
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef161:                                  ; preds = %477
+ThrowNullRef162:                                  ; preds = %477
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef163:                                  ; preds = %394
+ThrowNullRef164:                                  ; preds = %394
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef165:                                  ; preds = %398
+ThrowNullRef166:                                  ; preds = %398
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef167:                                  ; preds = %401
+ThrowNullRef168:                                  ; preds = %401
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef169:                                  ; preds = %407
+ThrowNullRef170:                                  ; preds = %407
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1939,8 +2021,8 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
-  br i1 %NullCheck, label %22, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %ThrowNullRef, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
@@ -1948,8 +2030,8 @@ entry:
   store i32 %24, i32* %loc0
   %25 = load i32, i32* %loc0
   %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %26, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %27
 
 ; <label>:27                                      ; preds = %22
   %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
@@ -1971,7 +2053,7 @@ ThrowNullRef:                                     ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1989,8 +2071,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -2022,15 +2104,15 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2048,16 +2130,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
   %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
   store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %15
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
@@ -2072,8 +2154,8 @@ entry:
   %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
   %29 = ptrtoint i16 addrspace(1)* %28 to i64
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %19
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
@@ -2089,19 +2171,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2114,8 +2196,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
@@ -2128,7 +2210,7 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[loadElem]
+Failed to read AppDomain.PrepareDataForSetup[storeElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
@@ -2202,8 +2284,8 @@ entry:
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
-  br i1 %NullCheck24, label %27, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = load i64, i64 addrspace(1)* %26
@@ -2218,8 +2300,8 @@ entry:
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
-  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
   %41 = load i64, i64 addrspace(1)* %39
@@ -2236,8 +2318,8 @@ entry:
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
-  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
   %54 = load i64, i64 addrspace(1)* %52
@@ -2252,8 +2334,8 @@ entry:
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
   %67 = load i64, i64 addrspace(1)* %65
@@ -2270,8 +2352,8 @@ entry:
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
-  br i1 %NullCheck16, label %79, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
   %80 = load i64, i64 addrspace(1)* %78
@@ -2286,8 +2368,8 @@ entry:
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
-  br i1 %NullCheck18, label %92, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
   %93 = load i64, i64 addrspace(1)* %91
@@ -2304,8 +2386,8 @@ entry:
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
-  br i1 %NullCheck12, label %105, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = load i64, i64 addrspace(1)* %104
@@ -2320,8 +2402,8 @@ entry:
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
-  br i1 %NullCheck14, label %118, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
   %119 = load i64, i64 addrspace(1)* %117
@@ -2337,8 +2419,8 @@ entry:
 
 ; <label>:128                                     ; preds = %20
   %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
-  br i1 %NullCheck4, label %130, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %129, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %130
 
 ; <label>:130                                     ; preds = %128
   %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
@@ -2346,8 +2428,8 @@ entry:
   %133 = load i16, i16 addrspace(1)* %132, align 8
   %134 = zext i16 %133 to i32
   %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
-  br i1 %NullCheck6, label %136, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %135, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %136
 
 ; <label>:136                                     ; preds = %130
   %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
@@ -2360,8 +2442,8 @@ entry:
 
 ; <label>:143                                     ; preds = %136
   %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
-  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %144, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %145
 
 ; <label>:145                                     ; preds = %143
   %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
@@ -2369,8 +2451,8 @@ entry:
   %148 = load i16, i16 addrspace(1)* %147, align 8
   %149 = zext i16 %148 to i32
   %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %150, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %151
 
 ; <label>:151                                     ; preds = %145
   %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
@@ -2388,8 +2470,8 @@ entry:
 
 ; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
-  br i1 %NullCheck, label %163, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %ThrowNullRef, label %163
 
 ; <label>:163                                     ; preds = %161
   %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
@@ -2399,8 +2481,8 @@ entry:
 
 ; <label>:167                                     ; preds = %163
   %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
-  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %168, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %169
 
 ; <label>:169                                     ; preds = %167
   %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
@@ -2432,55 +2514,55 @@ ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %167
+ThrowNullRef2:                                    ; preds = %167
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %128
+ThrowNullRef4:                                    ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %130
+ThrowNullRef6:                                    ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %143
+ThrowNullRef8:                                    ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %145
+ThrowNullRef10:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %102
+ThrowNullRef12:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %105
+ThrowNullRef14:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %76
+ThrowNullRef16:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %79
+ThrowNullRef18:                                   ; preds = %79
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %50
+ThrowNullRef20:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %53
+ThrowNullRef22:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %24
+ThrowNullRef24:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %27
+ThrowNullRef26:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2503,15 +2585,15 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2519,16 +2601,16 @@ entry:
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
   store i32 %8, i32* %loc0
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
   %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
   store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
@@ -2546,16 +2628,16 @@ entry:
 
 ; <label>:23                                      ; preds = %64
   %24 = load i16*, i16** %loc3
-  %NullCheck12 = icmp ne i16* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i16* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
   store i32 %27, i32* %loc5
   %28 = load i16*, i16** %loc4
-  %NullCheck14 = icmp ne i16* %28, null
-  br i1 %NullCheck14, label %29, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %28, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = load i16, i16* %28, align 8
@@ -2620,15 +2702,15 @@ entry:
 
 ; <label>:67                                      ; preds = %64
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
-  br i1 %NullCheck8, label %69, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %68, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %69
 
 ; <label>:69                                      ; preds = %67
   %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
   %71 = load i32, i32 addrspace(1)* %70
   %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
-  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %73
 
 ; <label>:73                                      ; preds = %69
   %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
@@ -2645,31 +2727,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %67
+ThrowNullRef8:                                    ; preds = %67
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %69
+ThrowNullRef10:                                   ; preds = %69
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2710,14 +2792,14 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
   %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
@@ -2730,14 +2812,14 @@ entry:
 
 ; <label>:11                                      ; preds = %4
   %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
   %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
@@ -2749,14 +2831,14 @@ entry:
 
 ; <label>:22                                      ; preds = %16
   %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
   %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
-  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
-  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
@@ -2804,23 +2886,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2836,7 +2918,280 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[loadElem]
+Successfully read RuntimeType.IsAssignableFrom
+
+define i8 @RuntimeType.IsAssignableFrom(%System.RuntimeType addrspace(1)* %param0, %System.Type addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.RuntimeType addrspace(1)*
+  %arg1 = alloca %System.Type addrspace(1)*
+  %loc0 = alloca %System.RuntimeType addrspace(1)*
+  %loc1 = alloca %"System.Type[]" addrspace(1)*
+  %loc2 = alloca i32
+  store %System.RuntimeType addrspace(1)* %param0, %System.RuntimeType addrspace(1)** %this
+  store %System.Type addrspace(1)* %param1, %System.Type addrspace(1)** %arg1
+  %0 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %1 = icmp ne %System.Type addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i8 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %5 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %6 = bitcast %System.Type addrspace(1)* %4 to %System.Object addrspace(1)*
+  %7 = bitcast %System.RuntimeType addrspace(1)* %5 to %System.Object addrspace(1)*
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %6, %System.Object addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %3
+  ret i8 1
+
+; <label>:12                                      ; preds = %3
+  %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 152
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 32
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
+  %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
+  %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
+  store %System.RuntimeType addrspace(1)* %25, %System.RuntimeType addrspace(1)** %loc0
+  %26 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %27 = icmp eq %System.RuntimeType addrspace(1)* %26, null
+  br i1 %27, label %34, label %28
+
+; <label>:28                                      ; preds = %15
+  %29 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %30 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)*)*)(%System.RuntimeType addrspace(1)* %29, %System.RuntimeType addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+; <label>:34                                      ; preds = %15
+  %35 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %36 = call %System.Reflection.Emit.TypeBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Reflection.Emit.TypeBuilder addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %35)
+  %37 = icmp eq %System.Reflection.Emit.TypeBuilder addrspace(1)* %36, null
+  br i1 %37, label %139, label %38
+
+; <label>:38                                      ; preds = %34
+  %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %42
+
+; <label>:42                                      ; preds = %38
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 152
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 40
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
+  %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
+  %53 = zext i8 %52 to i32
+  %54 = icmp eq i32 %53, 0
+  br i1 %54, label %56, label %55
+
+; <label>:55                                      ; preds = %42
+  ret i8 1
+
+; <label>:56                                      ; preds = %42
+  %57 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %58 = bitcast %System.RuntimeType addrspace(1)* %57 to %System.Type addrspace(1)*
+  %59 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %58)
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %64 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.Type addrspace(1)* %63, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = bitcast %System.RuntimeType addrspace(1)* %64 to %System.Type addrspace(1)*
+  %67 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %63, %System.Type addrspace(1)* %66)
+  %68 = zext i8 %67 to i32
+  %69 = trunc i32 %68 to i8
+  ret i8 %69
+
+; <label>:70                                      ; preds = %56
+  %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
+  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %73
+
+; <label>:73                                      ; preds = %70
+  %74 = load i64, i64 addrspace(1)* %72
+  %75 = add i64 %74, 128
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = add i64 %77, 0
+  %79 = inttoptr i64 %78 to i64*
+  %80 = load i64, i64* %79
+  %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
+  %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
+  %83 = call i8 %82(%System.Type addrspace(1)* %81)
+  %84 = zext i8 %83 to i32
+  %85 = icmp eq i32 %84, 0
+  br i1 %85, label %139, label %86
+
+; <label>:86                                      ; preds = %73
+  %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
+  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %89
+
+; <label>:89                                      ; preds = %86
+  %90 = load i64, i64 addrspace(1)* %88
+  %91 = add i64 %90, 128
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = add i64 %93, 24
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
+  %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
+  %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
+  store %"System.Type[]" addrspace(1)* %99, %"System.Type[]" addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %129
+
+; <label>:100                                     ; preds = %132
+  %101 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %102 = load i32, i32* %loc2
+  %NullCheck11 = icmp eq %"System.Type[]" addrspace(1)* %101, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %103
+
+; <label>:103                                     ; preds = %100
+  %104 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 1
+  %105 = load i32, i32 addrspace(1)* %104
+  %106 = zext i32 %105 to i64
+  %107 = zext i32 %102 to i64
+  %BoundsCheck = icmp uge i64 %107, %106
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %108
+
+; <label>:108                                     ; preds = %103
+  %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
+  %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
+  %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
+  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %113
+
+; <label>:113                                     ; preds = %108
+  %114 = load i64, i64 addrspace(1)* %112
+  %115 = add i64 %114, 152
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = add i64 %117, 56
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
+  %123 = zext i8 %122 to i32
+  %124 = icmp ne i32 %123, 0
+  br i1 %124, label %126, label %125
+
+; <label>:125                                     ; preds = %113
+  ret i8 0
+
+; <label>:126                                     ; preds = %113
+  %127 = load i32, i32* %loc2
+  %128 = add i32 %127, 1
+  store i32 %128, i32* %loc2
+  br label %129
+
+; <label>:129                                     ; preds = %89, %126
+  %130 = load i32, i32* %loc2
+  %131 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %NullCheck9 = icmp eq %"System.Type[]" addrspace(1)* %131, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %132
+
+; <label>:132                                     ; preds = %129
+  %133 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %131, i32 0, i32 1
+  %134 = load i32, i32 addrspace(1)* %133
+  %135 = zext i32 %134 to i64
+  %136 = trunc i64 %135 to i32
+  %137 = icmp slt i32 %130, %136
+  br i1 %137, label %100, label %138
+
+; <label>:138                                     ; preds = %132
+  ret i8 1
+
+; <label>:139                                     ; preds = %34, %73
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %129
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %103
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -2893,7 +3248,7 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElem]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -2904,8 +3259,8 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -2997,8 +3352,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
@@ -3059,8 +3414,8 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -3087,8 +3442,8 @@ entry:
 
 ; <label>:17                                      ; preds = %5, %11
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
@@ -3097,8 +3452,8 @@ entry:
 
 ; <label>:22                                      ; preds = %1, %11
   %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
@@ -3109,11 +3464,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %17
+ThrowNullRef2:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %22
+ThrowNullRef4:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3167,15 +3522,15 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
   %15 = load i32, i32 addrspace(1)* %14
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
@@ -3198,7 +3553,7 @@ ThrowNullRef:                                     ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef2:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3232,8 +3587,8 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
@@ -3312,8 +3667,8 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -3327,8 +3682,8 @@ entry:
 ; <label>:5                                       ; preds = %43
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %7 = load i32, i32* %loc1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck6, label %8, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
@@ -3366,8 +3721,8 @@ entry:
 ; <label>:32                                      ; preds = %21, %25
   %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
   %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
-  br i1 %NullCheck8, label %35, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = trunc i32 %34 to i16
@@ -3380,8 +3735,8 @@ entry:
 ; <label>:40                                      ; preds = %1, %35
   %41 = load i32, i32* %loc1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
-  br i1 %NullCheck2, label %43, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %42, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
@@ -3392,8 +3747,8 @@ entry:
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
   %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
-  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
   %51 = load i64, i64 addrspace(1)* %49
@@ -3412,19 +3767,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %40
+ThrowNullRef2:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %47
+ThrowNullRef4:                                    ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %5
+ThrowNullRef6:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %32
+ThrowNullRef8:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3467,8 +3822,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
@@ -3492,11 +3847,391 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(i16* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store i16* %param0, i16** %arg0
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load i32, i32* %arg3
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %42, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %37, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg2
+  %13 = load i32, i32* %arg3
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %37, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %24 = load i32, i32* %arg2
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load i16*, i16** %arg0
+  %35 = load i32, i32* %arg3
+  %36 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %36, i16* %34, i32 %35)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:37                                      ; preds = %5, %16
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %39)
+  %41 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41, %System.String addrspace(1)* %38, %System.String addrspace(1)* %40)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41) #0
+  unreachable
+
+; <label>:42                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
-Failed to read StringBuilder.ToString[loadElemA]
+Successfully read StringBuilder.ToString
+
+define %System.String addrspace(1)* @StringBuilder.ToString(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i16*
+  %loc3 = alloca %"System.Char[]" addrspace(1)*
+  %loc4 = alloca i32
+  %loc5 = alloca i32
+  %loc6 = alloca i16 addrspace(1)*
+  %loc7 = alloca %System.String addrspace(1)*
+  %loc8 = alloca %"System.Char[]" addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %0)
+  %2 = icmp ne i32 %1, 0
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %4
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %6)
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %7)
+  store %System.String addrspace(1)* %8, %System.String addrspace(1)** %loc0
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.Text.StringBuilder addrspace(1)* %9, %System.Text.StringBuilder addrspace(1)** %loc1
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  store %System.String addrspace(1)* %10, %System.String addrspace(1)** %loc7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc7
+  %12 = ptrtoint %System.String addrspace(1)* %11 to i64
+  %13 = icmp eq i64 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %5
+  %15 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %16 = sext i32 %15 to i64
+  %17 = add i64 %12, %16
+  br label %18
+
+; <label>:18                                      ; preds = %5, %14
+  %19 = phi i64 [ %12, %5 ], [ %17, %14 ]
+  %20 = inttoptr i64 %19 to i16*
+  store i16* %20, i16** %loc2
+  br label %21
+
+; <label>:21                                      ; preds = %98, %18
+  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %22, null
+  br i1 %NullCheck, label %ThrowNullRef, label %23
+
+; <label>:23                                      ; preds = %21
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 3
+  %25 = load i32, i32 addrspace(1)* %24, align 8
+  %26 = icmp sle i32 %25, 0
+  br i1 %26, label %96, label %27
+
+; <label>:27                                      ; preds = %23
+  %28 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %28, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %29
+
+; <label>:29                                      ; preds = %27
+  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %28, i32 0, i32 1
+  %31 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %30, align 8
+  store %"System.Char[]" addrspace(1)* %31, %"System.Char[]" addrspace(1)** %loc3
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %33
+
+; <label>:33                                      ; preds = %29
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  store i32 %35, i32* %loc4
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  %39 = load i32, i32 addrspace(1)* %38, align 8
+  store i32 %39, i32* %loc5
+  %40 = load i32, i32* %loc5
+  %41 = load i32, i32* %loc4
+  %42 = add i32 %40, %41
+  %43 = zext i32 %42 to i64
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %45
+
+; <label>:45                                      ; preds = %37
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = sext i32 %47 to i64
+  %49 = icmp sgt i64 %43, %48
+  br i1 %49, label %91, label %50
+
+; <label>:50                                      ; preds = %45
+  %51 = load i32, i32* %loc5
+  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %52, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %53
+
+; <label>:53                                      ; preds = %50
+  %54 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %52, i32 0, i32 1
+  %55 = load i32, i32 addrspace(1)* %54
+  %56 = zext i32 %55 to i64
+  %57 = trunc i64 %56 to i32
+  %58 = icmp ugt i32 %51, %57
+  br i1 %58, label %91, label %59
+
+; <label>:59                                      ; preds = %53
+  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  store %"System.Char[]" addrspace(1)* %60, %"System.Char[]" addrspace(1)** %loc8
+  %61 = icmp eq %"System.Char[]" addrspace(1)* %60, null
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %63, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %64
+
+; <label>:64                                      ; preds = %62
+  %65 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %63, i32 0, i32 1
+  %66 = load i32, i32 addrspace(1)* %65
+  %67 = zext i32 %66 to i64
+  %68 = trunc i64 %67 to i32
+  %69 = icmp ne i32 %68, 0
+  br i1 %69, label %71, label %70
+
+; <label>:70                                      ; preds = %59, %64
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:71                                      ; preds = %64
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %73
+
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %BoundsCheck = icmp uge i64 0, %76
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %77
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %78, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:79                                      ; preds = %70, %77
+  %80 = load i16*, i16** %loc2
+  %81 = load i32, i32* %loc4
+  %82 = sext i32 %81 to i64
+  %83 = mul i64 %82, 2
+  %84 = bitcast i16* %80 to i8*
+  %85 = getelementptr inbounds i8, i8* %84, i64 %83
+  %86 = load i16 addrspace(1)*, i16 addrspace(1)** %loc6
+  %87 = ptrtoint i16 addrspace(1)* %86 to i64
+  %88 = load i32, i32* %loc5
+  %89 = bitcast i8* %85 to i16*
+  %90 = inttoptr i64 %87 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %89, i16* %90, i32 %88)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %96
+
+; <label>:91                                      ; preds = %45, %53
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %94 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %93)
+  %95 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95, %System.String addrspace(1)* %92, %System.String addrspace(1)* %94)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95) #0
+  unreachable
+
+; <label>:96                                      ; preds = %23, %79
+  %97 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %97, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %98
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %97, i32 0, i32 2
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  store %System.Text.StringBuilder addrspace(1)* %100, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %102 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %102, label %21, label %103
+
+; <label>:103                                     ; preds = %98
+  store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc7
+  %104 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  ret %System.String addrspace(1)* %104
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method StringBuilder::get_Length using LLILCJit
+Successfully read StringBuilder.get_Length
+
+define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
+Successfully read RuntimeHelpers.get_OffsetToStringData
+
+define i32 @RuntimeHelpers.get_OffsetToStringData() {
+entry:
+  ret i32 12
+}
+
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
 Successfully read CultureData.CreateCultureData
 
@@ -3514,23 +4249,23 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
   store i8 %4, i8 addrspace(1)* %6
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
@@ -3549,11 +4284,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3566,50 +4301,50 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
   store i32 -1, i32 addrspace(1)* %2
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
   store i32 -1, i32 addrspace(1)* %8
   %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
   store i32 -1, i32 addrspace(1)* %14
   %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
   store i32 -1, i32 addrspace(1)* %17
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
@@ -3623,27 +4358,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3675,7 +4410,136 @@ Failed to read Dictionary`2.Insert[non-const derefAddress]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
 Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
-Failed to read HashHelpers.GetPrime[loadElem]
+Successfully read HashHelpers.GetPrime
+
+define i32 @HashHelpers.GetPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %6, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5, %System.String addrspace(1)* %4)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5) #0
+  unreachable
+
+; <label>:6                                       ; preds = %entry
+  store i32 0, i32* %loc0
+  br label %29
+
+; <label>:7                                       ; preds = %35
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 1296
+  %10 = addrspacecast i8 addrspace(1)* %9 to %"System.Int32[]" addrspace(1)**
+  %11 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %10
+  %12 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Int32[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = zext i32 %15 to i64
+  %17 = zext i32 %12 to i64
+  %BoundsCheck = icmp uge i64 %17, %16
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 3, i32 %12
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  store i32 %20, i32* %loc1
+  %21 = load i32, i32* %loc1
+  %22 = load i32, i32* %arg0
+  %23 = icmp slt i32 %21, %22
+  br i1 %23, label %26, label %24
+
+; <label>:24                                      ; preds = %18
+  %25 = load i32, i32* %loc1
+  ret i32 %25
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %loc0
+  %28 = add i32 %27, 1
+  store i32 %28, i32* %loc0
+  br label %29
+
+; <label>:29                                      ; preds = %6, %26
+  %30 = load i32, i32* %loc0
+  %31 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %32 = getelementptr inbounds i8, i8 addrspace(1)* %31, i64 1296
+  %33 = addrspacecast i8 addrspace(1)* %32 to %"System.Int32[]" addrspace(1)**
+  %34 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %33
+  %NullCheck = icmp eq %"System.Int32[]" addrspace(1)* %34, null
+  br i1 %NullCheck, label %ThrowNullRef, label %35
+
+; <label>:35                                      ; preds = %29
+  %36 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %34, i32 0, i32 1
+  %37 = load i32, i32 addrspace(1)* %36
+  %38 = zext i32 %37 to i64
+  %39 = trunc i64 %38 to i32
+  %40 = icmp slt i32 %30, %39
+  br i1 %40, label %7, label %41
+
+; <label>:41                                      ; preds = %35
+  %42 = load i32, i32* %arg0
+  %43 = or i32 %42, 1
+  store i32 %43, i32* %loc2
+  br label %59
+
+; <label>:44                                      ; preds = %59
+  %45 = load i32, i32* %loc2
+  %46 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %45)
+  %47 = zext i8 %46 to i32
+  %48 = icmp eq i32 %47, 0
+  br i1 %48, label %56, label %49
+
+; <label>:49                                      ; preds = %44
+  %50 = load i32, i32* %loc2
+  %51 = sub i32 %50, 1
+  %52 = srem i32 %51, 101
+  %53 = icmp eq i32 %52, 0
+  br i1 %53, label %56, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = load i32, i32* %loc2
+  ret i32 %55
+
+; <label>:56                                      ; preds = %44, %49
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %57, 2
+  store i32 %58, i32* %loc2
+  br label %59
+
+; <label>:59                                      ; preds = %41, %56
+  %60 = load i32, i32* %loc2
+  %61 = icmp slt i32 %60, 2147483647
+  br i1 %61, label %44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load i32, i32* %arg0
+  ret i32 %63
+
+ThrowNullRef:                                     ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
 Successfully read GenericEqualityComparer`1.GetHashCode
 
@@ -3694,14 +4558,14 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
   %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load i64, i64 addrspace(1)* %7
@@ -3720,7 +4584,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3750,8 +4614,8 @@ entry:
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
@@ -3796,8 +4660,8 @@ entry:
   %35 = bitcast i16* %34 to i8*
   %36 = getelementptr inbounds i8, i8* %35, i64 2
   %37 = bitcast i8* %36 to i16*
-  %NullCheck4 = icmp ne i16* %37, null
-  br i1 %NullCheck4, label %38, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %37, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %38
 
 ; <label>:38                                      ; preds = %27
   %39 = load i16, i16* %37, align 8
@@ -3824,8 +4688,8 @@ entry:
 
 ; <label>:54                                      ; preds = %22, %43
   %55 = load i16*, i16** %loc4
-  %NullCheck2 = icmp ne i16* %55, null
-  br i1 %NullCheck2, label %56, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i16* %55, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %56
 
 ; <label>:56                                      ; preds = %54
   %57 = load i16, i16* %55, align 8
@@ -3850,11 +4714,11 @@ ThrowNullRef:                                     ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %54
+ThrowNullRef2:                                    ; preds = %54
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %27
+ThrowNullRef4:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3871,8 +4735,8 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -3907,8 +4771,8 @@ entry:
 
 ; <label>:26                                      ; preds = %19
   %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
-  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %28
 
 ; <label>:28                                      ; preds = %26
   %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
@@ -3920,7 +4784,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3972,8 +4836,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
@@ -3984,26 +4848,26 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
-  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
@@ -4014,8 +4878,8 @@ entry:
 ; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
@@ -4024,8 +4888,8 @@ entry:
 
 ; <label>:25                                      ; preds = %1, %16, %23
   %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
-  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
@@ -4036,27 +4900,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %20
+ThrowNullRef10:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4069,8 +4933,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -4081,8 +4945,8 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
@@ -4091,8 +4955,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1, %8
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
@@ -4103,11 +4967,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4128,24 +4992,24 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   store i32 %3, i32* %loc0
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
   %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
   store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck4, label %9, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
@@ -4164,15 +5028,15 @@ entry:
 ; <label>:18                                      ; preds = %70
   %19 = load i16*, i16** %loc3
   %20 = bitcast i16* %19 to i64*
-  %NullCheck10 = icmp ne i64* %20, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %20, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = load i64, i64* %20, align 8
   %23 = load i16*, i16** %loc4
   %24 = bitcast i16* %23 to i64*
-  %NullCheck12 = icmp ne i64* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = load i64, i64* %24, align 8
@@ -4188,8 +5052,8 @@ entry:
   %31 = bitcast i16* %30 to i8*
   %32 = getelementptr inbounds i8, i8* %31, i64 8
   %33 = bitcast i8* %32 to i64*
-  %NullCheck14 = icmp ne i64* %33, null
-  br i1 %NullCheck14, label %34, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = load i64, i64* %33, align 8
@@ -4197,8 +5061,8 @@ entry:
   %37 = bitcast i16* %36 to i8*
   %38 = getelementptr inbounds i8, i8* %37, i64 8
   %39 = bitcast i8* %38 to i64*
-  %NullCheck16 = icmp ne i64* %39, null
-  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %40
 
 ; <label>:40                                      ; preds = %34
   %41 = load i64, i64* %39, align 8
@@ -4214,8 +5078,8 @@ entry:
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %NullCheck18 = icmp ne i64* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = load i64, i64* %48, align 8
@@ -4223,8 +5087,8 @@ entry:
   %52 = bitcast i16* %51 to i8*
   %53 = getelementptr inbounds i8, i8* %52, i64 16
   %54 = bitcast i8* %53 to i64*
-  %NullCheck20 = icmp ne i64* %54, null
-  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64* %54, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %55
 
 ; <label>:55                                      ; preds = %49
   %56 = load i64, i64* %54, align 8
@@ -4262,15 +5126,15 @@ entry:
 ; <label>:74                                      ; preds = %95
   %75 = load i16*, i16** %loc3
   %76 = bitcast i16* %75 to i32*
-  %NullCheck6 = icmp ne i32* %76, null
-  br i1 %NullCheck6, label %77, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32* %76, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %77
 
 ; <label>:77                                      ; preds = %74
   %78 = load i32, i32* %76, align 8
   %79 = load i16*, i16** %loc4
   %80 = bitcast i16* %79 to i32*
-  %NullCheck8 = icmp ne i32* %80, null
-  br i1 %NullCheck8, label %81, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i32* %80, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %81
 
 ; <label>:81                                      ; preds = %77
   %82 = load i32, i32* %80, align 8
@@ -4318,43 +5182,43 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %74
+ThrowNullRef6:                                    ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %77
+ThrowNullRef8:                                    ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %29
+ThrowNullRef14:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %34
+ThrowNullRef16:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4376,8 +5240,8 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load i64, i64 addrspace(1)* %4
@@ -4389,8 +5253,8 @@ entry:
   %12 = load i64, i64* %11
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %5
   %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
@@ -4399,8 +5263,8 @@ entry:
   %18 = load i8, i8* %arg2
   %19 = zext i8 %18 to i32
   %20 = trunc i32 %19 to i8
-  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %15
   %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
@@ -4411,11 +5275,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4442,8 +5306,8 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
@@ -4466,16 +5330,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
   %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = load i64, i64 addrspace(1)* %19
@@ -4500,8 +5364,8 @@ entry:
 ; <label>:35                                      ; preds = %30
   %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
@@ -4514,8 +5378,8 @@ entry:
 
 ; <label>:42                                      ; preds = %1, %38
   %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
-  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
@@ -4526,19 +5390,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %35
+ThrowNullRef2:                                    ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %42
+ThrowNullRef8:                                    ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4551,14 +5415,14 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
@@ -4570,7 +5434,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4583,8 +5447,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
@@ -4613,51 +5477,51 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
   %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
   %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
   %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
   %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
-  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
   store i64 %21, i64 addrspace(1)* %23
   %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %25 = load i64, i64* %loc0
-  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
@@ -4668,27 +5532,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %22
+ThrowNullRef12:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4701,8 +5565,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
@@ -4713,19 +5577,19 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
@@ -4734,8 +5598,8 @@ entry:
 
 ; <label>:15                                      ; preds = %1, %13
   %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
@@ -4746,19 +5610,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %15
+ThrowNullRef8:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4771,8 +5635,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -4831,8 +5695,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
@@ -4882,8 +5746,8 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
-  br i1 %NullCheck, label %17, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %ThrowNullRef, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
@@ -4894,15 +5758,15 @@ entry:
 
 ; <label>:22                                      ; preds = %17
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
-  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
   %26 = load i32, i32 addrspace(1)* %25
   %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
-  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %27, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
@@ -4925,8 +5789,8 @@ entry:
 ; <label>:40                                      ; preds = %17
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
-  br i1 %NullCheck6, label %43, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %41, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
@@ -4938,34 +5802,17 @@ ThrowNullRef:                                     ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %24
+ThrowNullRef4:                                    ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %40
+ThrowNullRef6:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
-}
-
-INFO:  jitting method Object::ReferenceEquals using LLILCJit
-Successfully read Object.ReferenceEquals
-
-define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
-entry:
-  %arg0 = alloca %System.Object addrspace(1)*
-  %arg1 = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
-  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
-  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = icmp eq %System.Object addrspace(1)* %0, %1
-  %3 = sext i1 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
 }
 
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
@@ -4978,21 +5825,21 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
   %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
-  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
@@ -5007,28 +5854,28 @@ entry:
 ; <label>:13                                      ; preds = %8, %12
   %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
   %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
   %21 = load i32, i32 addrspace(1)* %20, align 8
   %22 = add i32 %21, 1
-  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
   store i32 %22, i32 addrspace(1)* %24
   %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
@@ -5039,27 +5886,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5077,7 +5924,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::Setup using LLILCJit
-Failed to read AppDomain.Setup[loadElem]
+Failed to read AppDomain.Setup[unbox]
 INFO:  jitting method Thread::GetDomain using LLILCJit
 Successfully read Thread.GetDomain
 
@@ -5108,8 +5955,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
@@ -5122,14 +5969,14 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
   %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
@@ -5141,11 +5988,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5173,8 +6020,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -5189,7 +6036,328 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
 Failed to read KeyCollection.System.Collections.Generic.IEnumerable<TKey>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Successfully read Enumerator.MoveNext
+
+define i8 @Enumerator.MoveNext(%"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.RuntimeTypeHandle* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*
+  %"$TypeArg" = alloca %System.RuntimeTypeHandle*
+  store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
+  %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 8
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %76, label %12
+
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
+  br label %76
+
+; <label>:13                                      ; preds = %85
+  %14 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck19 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %15
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, i32 0, i32 0
+  %17 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %16, align 8
+  %NullCheck21 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, i32 0, i32 2
+  %20 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %19, align 8
+  %21 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck23 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %22
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, i32 0, i32 2
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %NullCheck25 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 3, i32 %24
+  %NullCheck27 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %32
+
+; <label>:32                                      ; preds = %30
+  %33 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, i32 0, i32 2
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = icmp slt i32 %34, 0
+  br i1 %35, label %68, label %36
+
+; <label>:36                                      ; preds = %32
+  %37 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %38 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck29 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %39
+
+; <label>:39                                      ; preds = %36
+  %40 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, i32 0, i32 0
+  %41 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %40, align 8
+  %NullCheck31 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, i32 0, i32 2
+  %44 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %43, align 8
+  %45 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck33 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, i32 0, i32 2
+  %48 = load i32, i32 addrspace(1)* %47, align 8
+  %NullCheck35 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %49
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = zext i32 %51 to i64
+  %53 = zext i32 %48 to i64
+  %BoundsCheck37 = icmp uge i64 %53, %52
+  br i1 %BoundsCheck37, label %ThrowIndexOutOfRange38, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 3, i32 %48
+  %NullCheck39 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %56
+
+; <label>:56                                      ; preds = %54
+  %57 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, i32 0, i32 0
+  %58 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck41 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %59
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %60, %System.__Canon addrspace(1)* %58)
+  %61 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck43 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  %64 = load i32, i32 addrspace(1)* %63, align 8
+  %65 = add i32 %64, 1
+  %NullCheck45 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  store i32 %65, i32 addrspace(1)* %67
+  ret i8 1
+
+; <label>:68                                      ; preds = %32
+  %69 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck47 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %73 = add i32 %72, 1
+  %NullCheck49 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %74
+
+; <label>:74                                      ; preds = %70
+  %75 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  store i32 %73, i32 addrspace(1)* %75
+  br label %76
+
+; <label>:76                                      ; preds = %8, %12, %74
+  %77 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %78
+
+; <label>:78                                      ; preds = %76
+  %79 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, i32 0, i32 2
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck7 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %82
+
+; <label>:82                                      ; preds = %78
+  %83 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, i32 0, i32 0
+  %84 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %83, align 8
+  %NullCheck9 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %85
+
+; <label>:85                                      ; preds = %82
+  %86 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, i32 0, i32 7
+  %87 = load i32, i32 addrspace(1)* %86, align 8
+  %88 = icmp ult i32 %80, %87
+  br i1 %88, label %13, label %89
+
+; <label>:89                                      ; preds = %85
+  %90 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %91 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck11 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %92
+
+; <label>:92                                      ; preds = %89
+  %93 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, i32 0, i32 0
+  %94 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck13 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %95
+
+; <label>:95                                      ; preds = %92
+  %96 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, i32 0, i32 7
+  %97 = load i32, i32 addrspace(1)* %96, align 8
+  %98 = add i32 %97, 1
+  %NullCheck15 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %99
+
+; <label>:99                                      ; preds = %95
+  %100 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, i32 0, i32 2
+  store i32 %98, i32 addrspace(1)* %100
+  %101 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck17 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %102
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %103, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %92
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef22:                                   ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef24:                                   ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef26:                                   ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef28:                                   ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef30:                                   ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef32:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef34:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef36:                                   ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange38:                           ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef40:                                   ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef42:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef44:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef46:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef48:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef50:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -5200,8 +6368,8 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -5232,9 +6400,9 @@ Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
 Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
-Failed to read String.MakeSeparatorList[loadElemA]
+Failed to read String.MakeSeparatorList[storeElem]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
-Failed to read String.InternalSplitKeepEmptyEntries[loadElem]
+Failed to read String.InternalSplitKeepEmptyEntries[storeElem]
 INFO:  jitting method Path::IsRelative using LLILCJit
 Successfully read Path.IsRelative
 
@@ -5243,8 +6411,8 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -5254,8 +6422,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
@@ -5271,8 +6439,8 @@ entry:
 
 ; <label>:17                                      ; preds = %7
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
@@ -5288,8 +6456,8 @@ entry:
 
 ; <label>:29                                      ; preds = %19
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %31
 
 ; <label>:31                                      ; preds = %29
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
@@ -5300,8 +6468,8 @@ entry:
 
 ; <label>:36                                      ; preds = %31
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
-  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %37, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
@@ -5312,8 +6480,8 @@ entry:
 
 ; <label>:43                                      ; preds = %31, %38
   %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
-  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %45
 
 ; <label>:45                                      ; preds = %43
   %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
@@ -5324,8 +6492,8 @@ entry:
 
 ; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %50
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
@@ -5336,8 +6504,8 @@ entry:
 
 ; <label>:57                                      ; preds = %1, %7, %19, %45, %52
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
-  br i1 %NullCheck14, label %59, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %59
 
 ; <label>:59                                      ; preds = %57
   %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
@@ -5347,8 +6515,8 @@ entry:
 
 ; <label>:63                                      ; preds = %59
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
@@ -5359,8 +6527,8 @@ entry:
 
 ; <label>:70                                      ; preds = %65
   %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
-  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.String addrspace(1)* %71, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %72
 
 ; <label>:72                                      ; preds = %70
   %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
@@ -5379,39 +6547,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %17
+ThrowNullRef4:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %29
+ThrowNullRef6:                                    ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %36
+ThrowNullRef8:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %43
+ThrowNullRef10:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %50
+ThrowNullRef12:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %57
+ThrowNullRef14:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %63
+ThrowNullRef16:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %70
+ThrowNullRef18:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5419,7 +6587,293 @@ ThrowNullRef17:                                   ; preds = %70
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
-Failed to read String.TrimHelper[loadElem]
+Successfully read String.TrimHelper
+
+define %System.String addrspace(1)* @String.TrimHelper(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i16
+  %loc4 = alloca i32
+  %loc5 = alloca i16
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = sub i32 %3, 1
+  store i32 %4, i32* %loc0
+  store i32 0, i32* %loc1
+  %5 = load i32, i32* %arg2
+  %6 = icmp eq i32 %5, 1
+  br i1 %6, label %62, label %7
+
+; <label>:7                                       ; preds = %1
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:8                                       ; preds = %58
+  store i32 0, i32* %loc2
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load i32, i32* %loc1
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2, i32 %10
+  %13 = load i16, i16 addrspace(1)* %12
+  %14 = zext i16 %13 to i32
+  %15 = trunc i32 %14 to i16
+  store i16 %15, i16* %loc3
+  store i32 0, i32* %loc2
+  br label %34
+
+; <label>:16                                      ; preds = %37
+  %17 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %18 = load i32, i32* %loc2
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %17, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %19
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = zext i32 %18 to i64
+  %BoundsCheck = icmp uge i64 %23, %22
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %24
+
+; <label>:24                                      ; preds = %19
+  %25 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 3, i32 %18
+  %26 = load i16, i16 addrspace(1)* %25, align 8
+  %27 = zext i16 %26 to i32
+  %28 = load i16, i16* %loc3
+  %29 = zext i16 %28 to i32
+  %30 = icmp eq i32 %27, %29
+  br i1 %30, label %43, label %31
+
+; <label>:31                                      ; preds = %24
+  %32 = load i32, i32* %loc2
+  %33 = add i32 %32, 1
+  store i32 %33, i32* %loc2
+  br label %34
+
+; <label>:34                                      ; preds = %11, %31
+  %35 = load i32, i32* %loc2
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = icmp slt i32 %35, %41
+  br i1 %42, label %16, label %43
+
+; <label>:43                                      ; preds = %24, %37
+  %44 = load i32, i32* %loc2
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %45, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp eq i32 %44, %50
+  br i1 %51, label %62, label %52
+
+; <label>:52                                      ; preds = %46
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %7, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %57, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %58
+
+; <label>:58                                      ; preds = %55
+  %59 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %60 = load i32, i32 addrspace(1)* %59
+  %61 = icmp slt i32 %56, %60
+  br i1 %61, label %8, label %62
+
+; <label>:62                                      ; preds = %1, %46, %58
+  %63 = load i32, i32* %arg2
+  %64 = icmp eq i32 %63, 0
+  br i1 %64, label %122, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %66, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %67
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %66, i32 0, i32 1
+  %69 = load i32, i32 addrspace(1)* %68
+  %70 = sub i32 %69, 1
+  store i32 %70, i32* %loc0
+  br label %118
+
+; <label>:71                                      ; preds = %118
+  store i32 0, i32* %loc4
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %73 = load i32, i32* %loc0
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %74
+
+; <label>:74                                      ; preds = %71
+  %75 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 2, i32 %73
+  %76 = load i16, i16 addrspace(1)* %75
+  %77 = zext i16 %76 to i32
+  %78 = trunc i32 %77 to i16
+  store i16 %78, i16* %loc5
+  store i32 0, i32* %loc4
+  br label %97
+
+; <label>:79                                      ; preds = %100
+  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %81 = load i32, i32* %loc4
+  %NullCheck19 = icmp eq %"System.Char[]" addrspace(1)* %80, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
+
+; <label>:82                                      ; preds = %79
+  %83 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 1
+  %84 = load i32, i32 addrspace(1)* %83
+  %85 = zext i32 %84 to i64
+  %86 = zext i32 %81 to i64
+  %BoundsCheck21 = icmp uge i64 %86, %85
+  br i1 %BoundsCheck21, label %ThrowIndexOutOfRange22, label %87
+
+; <label>:87                                      ; preds = %82
+  %88 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 3, i32 %81
+  %89 = load i16, i16 addrspace(1)* %88, align 8
+  %90 = zext i16 %89 to i32
+  %91 = load i16, i16* %loc5
+  %92 = zext i16 %91 to i32
+  %93 = icmp eq i32 %90, %92
+  br i1 %93, label %106, label %94
+
+; <label>:94                                      ; preds = %87
+  %95 = load i32, i32* %loc4
+  %96 = add i32 %95, 1
+  store i32 %96, i32* %loc4
+  br label %97
+
+; <label>:97                                      ; preds = %74, %94
+  %98 = load i32, i32* %loc4
+  %99 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck15 = icmp eq %"System.Char[]" addrspace(1)* %99, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %100
+
+; <label>:100                                     ; preds = %97
+  %101 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %99, i32 0, i32 1
+  %102 = load i32, i32 addrspace(1)* %101
+  %103 = zext i32 %102 to i64
+  %104 = trunc i64 %103 to i32
+  %105 = icmp slt i32 %98, %104
+  br i1 %105, label %79, label %106
+
+; <label>:106                                     ; preds = %87, %100
+  %107 = load i32, i32* %loc4
+  %108 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck17 = icmp eq %"System.Char[]" addrspace(1)* %108, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %109
+
+; <label>:109                                     ; preds = %106
+  %110 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %108, i32 0, i32 1
+  %111 = load i32, i32 addrspace(1)* %110
+  %112 = zext i32 %111 to i64
+  %113 = trunc i64 %112 to i32
+  %114 = icmp eq i32 %107, %113
+  br i1 %114, label %122, label %115
+
+; <label>:115                                     ; preds = %109
+  %116 = load i32, i32* %loc0
+  %117 = sub i32 %116, 1
+  store i32 %117, i32* %loc0
+  br label %118
+
+; <label>:118                                     ; preds = %67, %115
+  %119 = load i32, i32* %loc0
+  %120 = load i32, i32* %loc1
+  %121 = icmp sge i32 %119, %120
+  br i1 %121, label %71, label %122
+
+; <label>:122                                     ; preds = %62, %109, %118
+  %123 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %124 = load i32, i32* %loc1
+  %125 = load i32, i32* %loc0
+  %126 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %123, i32 %124, i32 %125)
+  ret %System.String addrspace(1)* %126
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %97
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange22:                           ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
 Successfully read String.CreateTrimmedString
 
@@ -5439,8 +6893,8 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
@@ -5535,8 +6989,8 @@ entry:
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i64 2872
   %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
   %8 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %7
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %3
   %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
@@ -5553,8 +7007,8 @@ entry:
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 2864
   %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
   %21 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %20
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
-  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %22
 
 ; <label>:22                                      ; preds = %16
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
@@ -5569,7 +7023,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %16
+ThrowNullRef2:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5586,8 +7040,8 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5613,8 +7067,8 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
@@ -5632,8 +7086,8 @@ entry:
 
 ; <label>:12                                      ; preds = %4
   %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
@@ -5644,8 +7098,8 @@ entry:
 
 ; <label>:19                                      ; preds = %14
   %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %19
   %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
@@ -5660,21 +7114,21 @@ entry:
   %31 = zext i16 %30 to i32
   %32 = bitcast i8* %29 to i16*
   %33 = trunc i32 %31 to i16
-  %NullCheck6 = icmp ne i16* %32, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i16* %32, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %21
   store i16 %33, i16* %32, align 8
   %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %36
 
 ; <label>:36                                      ; preds = %34
   %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
   %38 = load i32, i32 addrspace(1)* %37, align 8
   %39 = add i32 %38, 1
-  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %40
 
 ; <label>:40                                      ; preds = %36
   %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
@@ -5683,16 +7137,16 @@ entry:
 
 ; <label>:42                                      ; preds = %14
   %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
-  br i1 %NullCheck12, label %44, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
   %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
   %47 = load i16, i16* %arg1
   %48 = zext i16 %47 to i32
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = trunc i32 %48 to i16
@@ -5703,31 +7157,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %19
+ThrowNullRef4:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %21
+ThrowNullRef6:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %36
+ThrowNullRef10:                                   ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %42
+ThrowNullRef12:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %44
+ThrowNullRef14:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5740,8 +7194,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -5752,8 +7206,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
@@ -5762,14 +7216,14 @@ entry:
 
 ; <label>:11                                      ; preds = %1
   %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
@@ -5779,15 +7233,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5808,8 +7262,8 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5822,8 +7276,8 @@ entry:
 
 ; <label>:8                                       ; preds = %3
   %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
@@ -5842,15 +7296,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
-  br i1 %NullCheck4, label %22, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
   %24 = load i16*, i16* addrspace(1)* %23, align 8
   %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %25, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
@@ -5859,8 +7313,8 @@ entry:
   store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
@@ -5874,8 +7328,8 @@ entry:
 
 ; <label>:37                                      ; preds = %65
   %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %37
   %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
@@ -5886,16 +7340,16 @@ entry:
   %45 = bitcast i16* %41 to i8*
   %46 = getelementptr inbounds i8, i8* %45, i64 %44
   %47 = bitcast i8* %46 to i16*
-  %NullCheck14 = icmp ne i16* %47, null
-  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %47, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %48
 
 ; <label>:48                                      ; preds = %39
   %49 = load i16, i16* %47, align 8
   %50 = zext i16 %49 to i32
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %52 = load i32, i32* %loc1
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %53
 
 ; <label>:53                                      ; preds = %48
   %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
@@ -5916,8 +7370,8 @@ entry:
 ; <label>:62                                      ; preds = %36, %59
   %63 = load i32, i32* %loc1
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck10, label %65, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %65
 
 ; <label>:65                                      ; preds = %62
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
@@ -5936,15 +7390,15 @@ entry:
 
 ; <label>:74                                      ; preds = %70
   %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
-  br i1 %NullCheck18, label %76, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %76
 
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
   %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
-  br i1 %NullCheck20, label %80, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
   %81 = load i64, i64 addrspace(1)* %79
@@ -5958,8 +7412,8 @@ entry:
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
   %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
-  br i1 %NullCheck22, label %92, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.String addrspace(1)* %90, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %92
 
 ; <label>:92                                      ; preds = %80
   %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
@@ -5969,15 +7423,15 @@ entry:
 
 ; <label>:96                                      ; preds = %70
   %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
-  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %98
 
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
   %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
-  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
   %103 = load i64, i64 addrspace(1)* %101
@@ -5991,8 +7445,8 @@ entry:
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
   %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
-  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.String addrspace(1)* %112, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %114
 
 ; <label>:114                                     ; preds = %102
   %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
@@ -6004,59 +7458,59 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %20
+ThrowNullRef4:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %22
+ThrowNullRef6:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %26
+ThrowNullRef8:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %62
+ThrowNullRef10:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %48
+ThrowNullRef16:                                   ; preds = %48
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %74
+ThrowNullRef18:                                   ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %76
+ThrowNullRef20:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %80
+ThrowNullRef22:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %96
+ThrowNullRef24:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %98
+ThrowNullRef26:                                   ; preds = %98
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %102
+ThrowNullRef28:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6069,15 +7523,15 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
   %3 = load i16*, i16* addrspace(1)* %2, align 8
   %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
@@ -6087,8 +7541,8 @@ entry:
   %10 = bitcast i16* %3 to i8*
   %11 = getelementptr inbounds i8, i8* %10, i64 %9
   %12 = bitcast i8* %11 to i16*
-  %NullCheck4 = icmp ne i16* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %5
   store i16 0, i16* %12, align 8
@@ -6098,11 +7552,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6119,8 +7573,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -6131,8 +7585,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
@@ -6144,15 +7598,15 @@ entry:
 
 ; <label>:14                                      ; preds = %1
   %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
   %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
   %21 = load i64, i64 addrspace(1)* %19
@@ -6171,15 +7625,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %14
+ThrowNullRef4:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %16
+ThrowNullRef6:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6302,14 +7756,6 @@ entry:
   ret %System.String addrspace(1)* %57
 }
 
-INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
-Successfully read RuntimeHelpers.get_OffsetToStringData
-
-define i32 @RuntimeHelpers.get_OffsetToStringData() {
-entry:
-  ret i32 12
-}
-
 INFO:  jitting method String::Equals using LLILCJit
 Successfully read String.Equals
 
@@ -6381,8 +7827,8 @@ entry:
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
-  br i1 %NullCheck24, label %29, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
   %30 = load i64, i64 addrspace(1)* %28
@@ -6397,8 +7843,8 @@ entry:
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
-  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
   %43 = load i64, i64 addrspace(1)* %41
@@ -6418,8 +7864,8 @@ entry:
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
   %59 = load i64, i64 addrspace(1)* %57
@@ -6434,8 +7880,8 @@ entry:
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck22, label %71, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
   %72 = load i64, i64 addrspace(1)* %70
@@ -6455,8 +7901,8 @@ entry:
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
-  br i1 %NullCheck16, label %87, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = load i64, i64 addrspace(1)* %86
@@ -6471,8 +7917,8 @@ entry:
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck18, label %100, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
   %101 = load i64, i64 addrspace(1)* %99
@@ -6492,8 +7938,8 @@ entry:
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
-  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
   %117 = load i64, i64 addrspace(1)* %115
@@ -6508,8 +7954,8 @@ entry:
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
-  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
   %130 = load i64, i64 addrspace(1)* %128
@@ -6528,15 +7974,15 @@ entry:
 
 ; <label>:142                                     ; preds = %22
   %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
-  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %143, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %144
 
 ; <label>:144                                     ; preds = %142
   %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
   %146 = load i32, i32 addrspace(1)* %145
   %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
-  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %147, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %148
 
 ; <label>:148                                     ; preds = %144
   %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
@@ -6557,15 +8003,15 @@ entry:
 
 ; <label>:159                                     ; preds = %22
   %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
-  br i1 %NullCheck, label %161, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %ThrowNullRef, label %161
 
 ; <label>:161                                     ; preds = %159
   %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
   %163 = load i32, i32 addrspace(1)* %162
   %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
-  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %164, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %165
 
 ; <label>:165                                     ; preds = %161
   %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
@@ -6578,8 +8024,8 @@ entry:
 
 ; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
-  br i1 %NullCheck4, label %172, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %171, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %172
 
 ; <label>:172                                     ; preds = %170
   %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
@@ -6589,8 +8035,8 @@ entry:
 
 ; <label>:176                                     ; preds = %172
   %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
-  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %177, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %178
 
 ; <label>:178                                     ; preds = %176
   %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
@@ -6629,55 +8075,55 @@ ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %161
+ThrowNullRef2:                                    ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %170
+ThrowNullRef4:                                    ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %176
+ThrowNullRef6:                                    ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %142
+ThrowNullRef8:                                    ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %144
+ThrowNullRef10:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %113
+ThrowNullRef12:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %116
+ThrowNullRef14:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %84
+ThrowNullRef16:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %87
+ThrowNullRef18:                                   ; preds = %87
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %55
+ThrowNullRef20:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %58
+ThrowNullRef22:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %26
+ThrowNullRef24:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %29
+ThrowNullRef26:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,8 +8161,8 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck, label %14, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %ThrowNullRef, label %14
 
 ; <label>:14                                      ; preds = %8
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
@@ -6760,8 +8206,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
@@ -6770,14 +8216,14 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32, i32* %loc0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %10
   %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
   %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
@@ -6790,15 +8236,15 @@ entry:
 ; <label>:25                                      ; preds = %19
   %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
-  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
   %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
@@ -6807,8 +8253,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %37 = load i32, i32* %loc0
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %38, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %38
 
 ; <label>:38                                      ; preds = %32
   %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
@@ -6817,14 +8263,14 @@ entry:
 
 ; <label>:40                                      ; preds = %19
   %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %40
   %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
   %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
-  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
-  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
@@ -6832,8 +8278,8 @@ entry:
   %48 = zext i32 %47 to i64
   %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
-  br i1 %NullCheck16, label %51, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %51
 
 ; <label>:51                                      ; preds = %45
   %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
@@ -6847,15 +8293,15 @@ entry:
 ; <label>:57                                      ; preds = %51
   %58 = load i16*, i16** %arg1
   %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
-  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %60
 
 ; <label>:60                                      ; preds = %57
   %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
   %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
-  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %64
 
 ; <label>:64                                      ; preds = %60
   %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
@@ -6864,22 +8310,22 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
   %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
-  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %70
 
 ; <label>:70                                      ; preds = %64
   %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
   %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
-  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
-  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
   %75 = load i32, i32 addrspace(1)* %74
   %76 = zext i32 %75 to i64
   %77 = trunc i64 %76 to i32
-  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
-  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %78
 
 ; <label>:78                                      ; preds = %73
   %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
@@ -6901,8 +8347,8 @@ entry:
   %90 = bitcast i16* %86 to i8*
   %91 = getelementptr inbounds i8, i8* %90, i64 %89
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %93
 
 ; <label>:93                                      ; preds = %80
   %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
@@ -6912,8 +8358,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %99 = load i32, i32* %loc2
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %100
 
 ; <label>:100                                     ; preds = %93
   %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
@@ -6928,63 +8374,63 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %25
+ThrowNullRef6:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %32
+ThrowNullRef10:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %40
+ThrowNullRef12:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %45
+ThrowNullRef16:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %57
+ThrowNullRef18:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %60
+ThrowNullRef20:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %64
+ThrowNullRef22:                                   ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %70
+ThrowNullRef24:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %73
+ThrowNullRef26:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %80
+ThrowNullRef28:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %93
+ThrowNullRef30:                                   ; preds = %93
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7004,8 +8450,8 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
@@ -7033,43 +8479,43 @@ entry:
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %14
   %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
   %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   %28 = load i32, i32 addrspace(1)* %27, align 8
   %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
-  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %30
 
 ; <label>:30                                      ; preds = %26
   %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
   %32 = load i32, i32 addrspace(1)* %31, align 8
   %33 = add i32 %28, %32
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %34
 
 ; <label>:34                                      ; preds = %30
   %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   store i32 %33, i32 addrspace(1)* %35
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
   store i32 0, i32 addrspace(1)* %38
   %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %40
 
 ; <label>:40                                      ; preds = %37
   %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
@@ -7082,8 +8528,8 @@ entry:
 
 ; <label>:47                                      ; preds = %40
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
@@ -7098,8 +8544,8 @@ entry:
   %54 = load i32, i32* %loc0
   %55 = sext i32 %54 to i64
   %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
-  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %57
 
 ; <label>:57                                      ; preds = %52
   %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
@@ -7110,68 +8556,35 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %14
+ThrowNullRef2:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %23
+ThrowNullRef4:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %26
+ThrowNullRef6:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %30
+ThrowNullRef8:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %34
+ThrowNullRef10:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %47
+ThrowNullRef14:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %52
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-}
-
-INFO:  jitting method StringBuilder::get_Length using LLILCJit
-Successfully read StringBuilder.get_Length
-
-define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.StringBuilder addrspace(1)*
-  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
-  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
-
-; <label>:1                                       ; preds = %entry
-  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %3 = load i32, i32 addrspace(1)* %2, align 8
-  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
-
-; <label>:5                                       ; preds = %1
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = add i32 %3, %7
-  ret i32 %8
-
-ThrowNullRef:                                     ; preds = %entry
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef16:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7213,70 +8626,70 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
   %6 = load i32, i32 addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
   store i32 %6, i32 addrspace(1)* %8
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
   %13 = load i32, i32 addrspace(1)* %12, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
   store i32 %13, i32 addrspace(1)* %15
   %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
-  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %18
 
 ; <label>:18                                      ; preds = %14
   %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
   %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
   %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
   %34 = load i32, i32 addrspace(1)* %33, align 8
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
-  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
@@ -7287,39 +8700,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %28
+ThrowNullRef16:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %32
+ThrowNullRef18:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7455,13 +8868,13 @@ entry:
 ; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
@@ -7477,16 +8890,16 @@ entry:
 
 ; <label>:18                                      ; preds = %15
   %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
   store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
   %22 = load i32, i32* %loc0
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %24
 
 ; <label>:24                                      ; preds = %20
   %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
@@ -7498,13 +8911,13 @@ entry:
 ; <label>:28                                      ; preds = %15, %24
   %29 = load i32, i32* %arg1
   %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %31
   %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
@@ -7517,20 +8930,20 @@ entry:
   %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
-  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
   %46 = load i32, i32 addrspace(1)* %45, align 8
   %47 = sub i32 %40, %46
-  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
-  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i32 addrspace(1)* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %48
 
 ; <label>:48                                      ; preds = %44
   store i32 %47, i32 addrspace(1)* %39, align 8
@@ -7538,21 +8951,21 @@ entry:
 
 ; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
-  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %51
 
 ; <label>:51                                      ; preds = %49
   %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %53
 
 ; <label>:53                                      ; preds = %51
   %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
   %55 = load i32, i32 addrspace(1)* %54, align 8
   %56 = load i32, i32* %arg2
   %57 = sub i32 %55, %56
-  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %58
 
 ; <label>:58                                      ; preds = %53
   %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
@@ -7562,13 +8975,13 @@ entry:
 ; <label>:60                                      ; preds = %33, %58
   %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
   %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
-  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %63
 
 ; <label>:63                                      ; preds = %60
   %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
-  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
-  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
@@ -7578,15 +8991,15 @@ entry:
 
 ; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
-  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i32 addrspace(1)* %69, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %70
 
 ; <label>:70                                      ; preds = %68
   %71 = load i32, i32 addrspace(1)* %69, align 8
   store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
-  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
@@ -7596,8 +9009,8 @@ entry:
   store i32 %77, i32* %loc4
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
-  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %80
 
 ; <label>:80                                      ; preds = %73
   %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
@@ -7607,71 +9020,71 @@ entry:
 ; <label>:83                                      ; preds = %80
   store i32 0, i32* %loc3
   %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
-  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
-  br i1 %NullCheck26, label %88, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i32 addrspace(1)* %87, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %88
 
 ; <label>:88                                      ; preds = %85
   %89 = load i32, i32 addrspace(1)* %87, align 8
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
-  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %90
 
 ; <label>:90                                      ; preds = %88
   %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
   store i32 %89, i32 addrspace(1)* %91
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
-  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
-  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %96
 
 ; <label>:96                                      ; preds = %94
   %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
-  br i1 %NullCheck34, label %100, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %100
 
 ; <label>:100                                     ; preds = %96
   %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
-  br i1 %NullCheck36, label %102, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %102
 
 ; <label>:102                                     ; preds = %100
   %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
   %104 = load i32, i32 addrspace(1)* %103, align 8
   %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
-  br i1 %NullCheck38, label %106, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %106
 
 ; <label>:106                                     ; preds = %102
   %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
-  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
-  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %108
 
 ; <label>:108                                     ; preds = %106
   %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
   %110 = load i32, i32 addrspace(1)* %109, align 8
   %111 = add i32 %104, %110
-  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %112
 
 ; <label>:112                                     ; preds = %108
   %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
   store i32 %111, i32 addrspace(1)* %113
   %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
-  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i32 addrspace(1)* %114, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %115
 
 ; <label>:115                                     ; preds = %112
   %116 = load i32, i32 addrspace(1)* %114, align 8
@@ -7681,19 +9094,19 @@ entry:
 ; <label>:118                                     ; preds = %115
   %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
-  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %121
 
 ; <label>:121                                     ; preds = %118
   %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
-  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
-  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %123
 
 ; <label>:123                                     ; preds = %121
   %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
   %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
-  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
-  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %126
 
 ; <label>:126                                     ; preds = %123
   %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
@@ -7705,8 +9118,8 @@ entry:
 
 ; <label>:130                                     ; preds = %80, %115, %126
   %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %132
 
 ; <label>:132                                     ; preds = %130
   %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7715,8 +9128,8 @@ entry:
   %136 = load i32, i32* %loc3
   %137 = sub i32 %135, %136
   %138 = sub i32 %134, %137
-  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %139
 
 ; <label>:139                                     ; preds = %132
   %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7728,16 +9141,16 @@ entry:
 
 ; <label>:144                                     ; preds = %139
   %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
-  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %146
 
 ; <label>:146                                     ; preds = %144
   %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
   %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
   %149 = load i32, i32* %loc2
   %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
-  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %151
 
 ; <label>:151                                     ; preds = %146
   %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
@@ -7754,145 +9167,249 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %18
+ThrowNullRef4:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %31
+ThrowNullRef10:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %44
+ThrowNullRef16:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %68
+ThrowNullRef18:                                   ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %70
+ThrowNullRef20:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %73
+ThrowNullRef22:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %83
+ThrowNullRef24:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %85
+ThrowNullRef26:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %88
+ThrowNullRef28:                                   ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %90
+ThrowNullRef30:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %94
+ThrowNullRef32:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %96
+ThrowNullRef34:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %100
+ThrowNullRef36:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %102
+ThrowNullRef38:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %106
+ThrowNullRef40:                                   ; preds = %106
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %108
+ThrowNullRef42:                                   ; preds = %108
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %112
+ThrowNullRef44:                                   ; preds = %112
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %118
+ThrowNullRef46:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %121
+ThrowNullRef48:                                   ; preds = %121
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %123
+ThrowNullRef50:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %130
+ThrowNullRef52:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %132
+ThrowNullRef54:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %144
+ThrowNullRef56:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %146
+ThrowNullRef58:                                   ; preds = %146
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %60
+ThrowNullRef60:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %63
+ThrowNullRef62:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %49
+ThrowNullRef64:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %51
+ThrowNullRef66:                                   ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %53
+ThrowNullRef68:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(%"System.Char[]" addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %arg0 = alloca %"System.Char[]" addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store %"System.Char[]" addrspace(1)* %param0, %"System.Char[]" addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load i32, i32* %arg4
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %43, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %38, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg1
+  %13 = load i32, i32* %arg4
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %38, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %24 = load i32, i32* %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %35 = load i32, i32* %arg3
+  %36 = load i32, i32* %arg4
+  %37 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %37, %"System.Char[]" addrspace(1)* %34, i32 %35, i32 %36)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:38                                      ; preds = %5, %16
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Successfully read Buffer._Memmove
 
@@ -7914,7 +9431,7 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[loadElem]
+Failed to read AppDomain.SetDataHelper[storeElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -7923,8 +9440,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
@@ -7934,8 +9451,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
@@ -7947,15 +9464,15 @@ entry:
   %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
   %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
@@ -7966,15 +9483,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7992,7 +9509,79 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
-Failed to read Dictionary`2.TryGetValue[loadElemA]
+Successfully read Dictionary`2.TryGetValue
+
+define i8 @"Dictionary`2.TryGetValue"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)* addrspace(1)* %param2) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  %arg2 = alloca %System.__Canon addrspace(1)* addrspace(1)*
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  store %System.__Canon addrspace(1)* addrspace(1)* %param2, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  store i32 %2, i32* %loc0
+  %3 = load i32, i32* %loc0
+  %4 = icmp slt i32 %3, 0
+  br i1 %4, label %22, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 2
+  %10 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %9, align 8
+  %11 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = zext i32 %11 to i64
+  %BoundsCheck = icmp uge i64 %16, %15
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 3, i32 %11
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %20, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %6, %System.__Canon addrspace(1)* %21)
+  ret i8 1
+
+; <label>:22                                      ; preds = %entry
+  %23 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %23, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -8058,8 +9647,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
@@ -8091,8 +9680,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
@@ -8171,15 +9760,15 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck, label %19, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %ThrowNullRef, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
   %21 = load i32, i32 addrspace(1)* %20
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
@@ -8202,7 +9791,7 @@ ThrowNullRef:                                     ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %19
+ThrowNullRef2:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8248,8 +9837,8 @@ entry:
   %0 = alloca %System.AppDomainHandle
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %1 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %1, i32 0, i32 15
@@ -8269,8 +9858,8 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
@@ -8286,7 +9875,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -8299,8 +9888,8 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -8327,8 +9916,8 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
@@ -8352,8 +9941,8 @@ entry:
   %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
   store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
@@ -8363,8 +9952,8 @@ entry:
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
@@ -8374,8 +9963,8 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %9
   %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
@@ -8384,8 +9973,8 @@ entry:
 
 ; <label>:18                                      ; preds = %3, %16
   %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
@@ -8397,15 +9986,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %18
+ThrowNullRef6:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8418,8 +10007,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
@@ -8453,15 +10042,15 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
@@ -8473,7 +10062,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8481,7 +10070,7 @@ ThrowNullRef1:                                    ; preds = %1
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
 Failed to read Dictionary`2.System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
@@ -8506,8 +10095,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
@@ -8524,8 +10113,8 @@ entry:
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -8544,7 +10133,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8577,8 +10166,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = load i64, i64* %arg2
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = trunc i32 %3 to i8
@@ -8634,46 +10223,46 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
   %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
-  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
-  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
-  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
@@ -8684,27 +10273,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %20
+ThrowNullRef12:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8717,8 +10306,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -8756,22 +10345,22 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
   %9 = load i64, i64 addrspace(1)* %8, align 8
   %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
   %13 = load i64, i64 addrspace(1)* %12, align 8
   %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %11
   %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
@@ -8788,11 +10377,11 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8882,8 +10471,8 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
@@ -8900,8 +10489,8 @@ entry:
 ; <label>:8                                       ; preds = %1
   %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
   %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
@@ -8911,15 +10500,15 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
   %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
   %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
-  br i1 %NullCheck6, label %21, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
@@ -8946,15 +10535,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8992,15 +10581,15 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
   store i8 %3, i8 addrspace(1)* %5
   %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
@@ -9011,7 +10600,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9027,8 +10616,8 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -9041,8 +10630,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
@@ -9058,7 +10647,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9080,8 +10669,8 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
@@ -9096,8 +10685,8 @@ entry:
 ; <label>:12                                      ; preds = %6
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
@@ -9112,8 +10701,8 @@ entry:
 ; <label>:21                                      ; preds = %15
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
@@ -9128,8 +10717,8 @@ entry:
 ; <label>:30                                      ; preds = %24
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %31, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
@@ -9144,8 +10733,8 @@ entry:
 ; <label>:39                                      ; preds = %33
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
-  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %40, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %42
 
 ; <label>:42                                      ; preds = %39
   %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
@@ -9164,19 +10753,19 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %21
+ThrowNullRef4:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %30
+ThrowNullRef6:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %39
+ThrowNullRef8:                                    ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9243,8 +10832,8 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
@@ -9264,57 +10853,57 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
   store i8 0, i8 addrspace(1)* %2
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
   store i8 0, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
   store i8 0, i8 addrspace(1)* %17
   %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
   store i8 0, i8 addrspace(1)* %20
   %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
-  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
@@ -9325,31 +10914,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %19
+ThrowNullRef14:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9367,8 +10956,8 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
@@ -9380,8 +10969,8 @@ entry:
 
 ; <label>:9                                       ; preds = %4
   %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %9
   %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
@@ -9395,7 +10984,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef2:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9420,8 +11009,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
@@ -9512,8 +11101,8 @@ entry:
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
@@ -9524,8 +11113,8 @@ entry:
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = load i64, i64 addrspace(1)* %12
@@ -9537,8 +11126,8 @@ entry:
   %20 = load i64, i64* %19
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
-  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %13
   %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
@@ -9555,8 +11144,8 @@ entry:
 ; <label>:30                                      ; preds = %25
   %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %32 = load i32, i32* %arg2
-  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
-  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
@@ -9570,15 +11159,15 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %30
+ThrowNullRef2:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9622,87 +11211,87 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
   %10 = load i8, i8 addrspace(1)* %9, align 8
   %11 = zext i8 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %8
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
   store i8 %12, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
   %19 = load i8, i8 addrspace(1)* %18, align 8
   %20 = zext i8 %19 to i32
   %21 = trunc i32 %20 to i8
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
   store i8 %21, i8 addrspace(1)* %23
   %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
   %28 = load i8, i8 addrspace(1)* %27, align 8
   %29 = zext i8 %28 to i32
   %30 = trunc i32 %29 to i8
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
-  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %31
 
 ; <label>:31                                      ; preds = %26
   %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
   store i8 %30, i8 addrspace(1)* %32
   %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
-  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
-  br i1 %NullCheck14, label %40, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %40
 
 ; <label>:40                                      ; preds = %35
   %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
   store i8 %39, i8 addrspace(1)* %41
   %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
-  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %44
 
 ; <label>:44                                      ; preds = %40
   %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
   %46 = load i8, i8 addrspace(1)* %45, align 8
   %47 = zext i8 %46 to i32
   %48 = trunc i32 %47 to i8
-  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
   store i8 %48, i8 addrspace(1)* %50
   %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
-  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
@@ -9713,29 +11302,29 @@ entry:
 ; <label>:56                                      ; preds = %52
   %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
-  br i1 %NullCheck22, label %59, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
   %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
   %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
-  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
-  br i1 %NullCheck24, label %63, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
   %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
-  br i1 %NullCheck26, label %66, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
   %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
-  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
-  br i1 %NullCheck28, label %69, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %69
 
 ; <label>:69                                      ; preds = %66
   %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
@@ -9744,15 +11333,15 @@ entry:
 
 ; <label>:71                                      ; preds = %105
   %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
-  br i1 %NullCheck34, label %73, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %73
 
 ; <label>:73                                      ; preds = %71
   %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
   %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
   %76 = load i32, i32* %loc0
-  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
-  br i1 %NullCheck36, label %77, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
@@ -9766,8 +11355,8 @@ entry:
 
 ; <label>:83                                      ; preds = %77
   %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
-  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
@@ -9775,14 +11364,14 @@ entry:
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
   %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
-  br i1 %NullCheck40, label %91, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
 ; <label>:91                                      ; preds = %85
   %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
   %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
-  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck42, label %94, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %94
 
 ; <label>:94                                      ; preds = %91
   %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
@@ -9798,14 +11387,14 @@ entry:
 ; <label>:99                                      ; preds = %69, %96
   %100 = load i32, i32* %loc0
   %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
-  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %102
 
 ; <label>:102                                     ; preds = %99
   %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
   %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
-  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
-  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
@@ -9819,87 +11408,87 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %26
+ThrowNullRef10:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %31
+ThrowNullRef12:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %35
+ThrowNullRef14:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %40
+ThrowNullRef16:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %56
+ThrowNullRef22:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %59
+ThrowNullRef24:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %63
+ThrowNullRef26:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %66
+ThrowNullRef28:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %102
+ThrowNullRef32:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %71
+ThrowNullRef34:                                   ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %73
+ThrowNullRef36:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %83
+ThrowNullRef38:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %85
+ThrowNullRef40:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %91
+ThrowNullRef42:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9943,15 +11532,15 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
   %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
@@ -9961,28 +11550,28 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
   %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %12
   %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
   %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
   %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
-  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
@@ -9993,23 +11582,23 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %12
+ThrowNullRef6:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10031,15 +11620,15 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
   %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = load i64, i64 addrspace(1)* %7
@@ -10077,13 +11666,13 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[loadElem]
+Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -10111,8 +11700,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueEqInt1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueEqInt1.error.txt
@@ -25,8 +25,8 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
@@ -40,8 +40,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
   %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
@@ -75,7 +75,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -90,8 +90,8 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %NullCheck = icmp ne i8 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = load i8, i8 addrspace(1)* %0, align 8
@@ -125,8 +125,8 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
@@ -159,8 +159,8 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -184,8 +184,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
   store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
@@ -195,8 +195,8 @@ entry:
 ; <label>:4                                       ; preds = %1
   %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
   %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
@@ -206,8 +206,8 @@ entry:
   %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
@@ -221,14 +221,14 @@ entry:
 
 ; <label>:17                                      ; preds = %14
   %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
   %21 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
@@ -238,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -249,8 +249,8 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
@@ -261,27 +261,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %30
+ThrowNullRef10:                                   ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -301,7 +301,89 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
-Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
+Successfully read AppDomainSetup.GetUnsecureApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.GetUnsecureApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %NullCheck = icmp eq %"System.String[]" addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %BoundsCheck = icmp uge i64 0, %5
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %6
+
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 3, i32 0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
+  ret %System.String addrspace(1)* %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_Value using LLILCJit
+Successfully read AppDomainSetup.get_Value
+
+define %"System.String[]" addrspace(1)* @AppDomainSetup.get_Value(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.String[]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 18)
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.String[]" addrspace(1)* addrspace(1)*, %"System.String[]" addrspace(1)*)*)(%"System.String[]" addrspace(1)* addrspace(1)* %9, %"System.String[]" addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %11, i32 0, i32 1
+  %14 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %13, align 8
+  ret %"System.String[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -319,8 +401,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -368,16 +450,16 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
   %5 = load i32, i32 addrspace(1)* %4
   %6 = sub i32 %5, 1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -389,7 +471,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -421,8 +503,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
@@ -456,8 +538,8 @@ entry:
 ; <label>:27                                      ; preds = %19
   %28 = load i32, i32* %arg1
   %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
-  br i1 %NullCheck2, label %30, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %29, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %30
 
 ; <label>:30                                      ; preds = %27
   %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
@@ -493,8 +575,8 @@ entry:
 ; <label>:49                                      ; preds = %46
   %50 = load i32, i32* %arg2
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck4, label %52, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
@@ -517,11 +599,11 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %27
+ThrowNullRef2:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %49
+ThrowNullRef4:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -544,16 +626,16 @@ entry:
   %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %0)
   store %System.String addrspace(1)* %1, %System.String addrspace(1)** %loc0
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 2
   %5 = bitcast [0 x i16] addrspace(1)* %4 to i16 addrspace(1)*
   store i16 addrspace(1)* %5, i16 addrspace(1)** %loc1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %3
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2
@@ -580,7 +662,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -691,15 +773,15 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %NullCheck132 = icmp ne i8* %21, null
-  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+  %NullCheck131 = icmp eq i8* %21, null
+  br i1 %NullCheck131, label %ThrowNullRef132, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = load i8, i8* %21, align 8
   %24 = zext i8 %23 to i32
   %25 = trunc i32 %24 to i8
-  %NullCheck134 = icmp ne i8* %20, null
-  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+  %NullCheck133 = icmp eq i8* %20, null
+  br i1 %NullCheck133, label %ThrowNullRef134, label %26
 
 ; <label>:26                                      ; preds = %22
   store i8 %25, i8* %20, align 8
@@ -709,16 +791,16 @@ entry:
   %28 = load i8*, i8** %arg0
   %29 = load i8*, i8** %arg1
   %30 = bitcast i8* %29 to i16*
-  %NullCheck128 = icmp ne i16* %30, null
-  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+  %NullCheck127 = icmp eq i16* %30, null
+  br i1 %NullCheck127, label %ThrowNullRef128, label %31
 
 ; <label>:31                                      ; preds = %27
   %32 = load i16, i16* %30, align 8
   %33 = sext i16 %32 to i32
   %34 = bitcast i8* %28 to i16*
   %35 = trunc i32 %33 to i16
-  %NullCheck130 = icmp ne i16* %34, null
-  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+  %NullCheck129 = icmp eq i16* %34, null
+  br i1 %NullCheck129, label %ThrowNullRef130, label %36
 
 ; <label>:36                                      ; preds = %31
   store i16 %35, i16* %34, align 8
@@ -728,16 +810,16 @@ entry:
   %38 = load i8*, i8** %arg0
   %39 = load i8*, i8** %arg1
   %40 = bitcast i8* %39 to i16*
-  %NullCheck120 = icmp ne i16* %40, null
-  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+  %NullCheck119 = icmp eq i16* %40, null
+  br i1 %NullCheck119, label %ThrowNullRef120, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i16, i16* %40, align 8
   %43 = sext i16 %42 to i32
   %44 = bitcast i8* %38 to i16*
   %45 = trunc i32 %43 to i16
-  %NullCheck122 = icmp ne i16* %44, null
-  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+  %NullCheck121 = icmp eq i16* %44, null
+  br i1 %NullCheck121, label %ThrowNullRef122, label %46
 
 ; <label>:46                                      ; preds = %41
   store i16 %45, i16* %44, align 8
@@ -745,15 +827,15 @@ entry:
   %48 = getelementptr inbounds i8, i8* %47, i64 2
   %49 = load i8*, i8** %arg1
   %50 = getelementptr inbounds i8, i8* %49, i64 2
-  %NullCheck124 = icmp ne i8* %50, null
-  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+  %NullCheck123 = icmp eq i8* %50, null
+  br i1 %NullCheck123, label %ThrowNullRef124, label %51
 
 ; <label>:51                                      ; preds = %46
   %52 = load i8, i8* %50, align 8
   %53 = zext i8 %52 to i32
   %54 = trunc i32 %53 to i8
-  %NullCheck126 = icmp ne i8* %48, null
-  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+  %NullCheck125 = icmp eq i8* %48, null
+  br i1 %NullCheck125, label %ThrowNullRef126, label %55
 
 ; <label>:55                                      ; preds = %51
   store i8 %54, i8* %48, align 8
@@ -763,14 +845,14 @@ entry:
   %57 = load i8*, i8** %arg0
   %58 = load i8*, i8** %arg1
   %59 = bitcast i8* %58 to i32*
-  %NullCheck116 = icmp ne i32* %59, null
-  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+  %NullCheck115 = icmp eq i32* %59, null
+  br i1 %NullCheck115, label %ThrowNullRef116, label %60
 
 ; <label>:60                                      ; preds = %56
   %61 = load i32, i32* %59, align 8
   %62 = bitcast i8* %57 to i32*
-  %NullCheck118 = icmp ne i32* %62, null
-  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+  %NullCheck117 = icmp eq i32* %62, null
+  br i1 %NullCheck117, label %ThrowNullRef118, label %63
 
 ; <label>:63                                      ; preds = %60
   store i32 %61, i32* %62, align 8
@@ -780,14 +862,14 @@ entry:
   %65 = load i8*, i8** %arg0
   %66 = load i8*, i8** %arg1
   %67 = bitcast i8* %66 to i32*
-  %NullCheck108 = icmp ne i32* %67, null
-  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+  %NullCheck107 = icmp eq i32* %67, null
+  br i1 %NullCheck107, label %ThrowNullRef108, label %68
 
 ; <label>:68                                      ; preds = %64
   %69 = load i32, i32* %67, align 8
   %70 = bitcast i8* %65 to i32*
-  %NullCheck110 = icmp ne i32* %70, null
-  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+  %NullCheck109 = icmp eq i32* %70, null
+  br i1 %NullCheck109, label %ThrowNullRef110, label %71
 
 ; <label>:71                                      ; preds = %68
   store i32 %69, i32* %70, align 8
@@ -795,15 +877,15 @@ entry:
   %73 = getelementptr inbounds i8, i8* %72, i64 4
   %74 = load i8*, i8** %arg1
   %75 = getelementptr inbounds i8, i8* %74, i64 4
-  %NullCheck112 = icmp ne i8* %75, null
-  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+  %NullCheck111 = icmp eq i8* %75, null
+  br i1 %NullCheck111, label %ThrowNullRef112, label %76
 
 ; <label>:76                                      ; preds = %71
   %77 = load i8, i8* %75, align 8
   %78 = zext i8 %77 to i32
   %79 = trunc i32 %78 to i8
-  %NullCheck114 = icmp ne i8* %73, null
-  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+  %NullCheck113 = icmp eq i8* %73, null
+  br i1 %NullCheck113, label %ThrowNullRef114, label %80
 
 ; <label>:80                                      ; preds = %76
   store i8 %79, i8* %73, align 8
@@ -813,14 +895,14 @@ entry:
   %82 = load i8*, i8** %arg0
   %83 = load i8*, i8** %arg1
   %84 = bitcast i8* %83 to i32*
-  %NullCheck100 = icmp ne i32* %84, null
-  br i1 %NullCheck100, label %85, label %ThrowNullRef99
+  %NullCheck99 = icmp eq i32* %84, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %85
 
 ; <label>:85                                      ; preds = %81
   %86 = load i32, i32* %84, align 8
   %87 = bitcast i8* %82 to i32*
-  %NullCheck102 = icmp ne i32* %87, null
-  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+  %NullCheck101 = icmp eq i32* %87, null
+  br i1 %NullCheck101, label %ThrowNullRef102, label %88
 
 ; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
@@ -829,16 +911,16 @@ entry:
   %91 = load i8*, i8** %arg1
   %92 = getelementptr inbounds i8, i8* %91, i64 4
   %93 = bitcast i8* %92 to i16*
-  %NullCheck104 = icmp ne i16* %93, null
-  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+  %NullCheck103 = icmp eq i16* %93, null
+  br i1 %NullCheck103, label %ThrowNullRef104, label %94
 
 ; <label>:94                                      ; preds = %88
   %95 = load i16, i16* %93, align 8
   %96 = sext i16 %95 to i32
   %97 = bitcast i8* %90 to i16*
   %98 = trunc i32 %96 to i16
-  %NullCheck106 = icmp ne i16* %97, null
-  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+  %NullCheck105 = icmp eq i16* %97, null
+  br i1 %NullCheck105, label %ThrowNullRef106, label %99
 
 ; <label>:99                                      ; preds = %94
   store i16 %98, i16* %97, align 8
@@ -848,14 +930,14 @@ entry:
   %101 = load i8*, i8** %arg0
   %102 = load i8*, i8** %arg1
   %103 = bitcast i8* %102 to i32*
-  %NullCheck88 = icmp ne i32* %103, null
-  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+  %NullCheck87 = icmp eq i32* %103, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %104
 
 ; <label>:104                                     ; preds = %100
   %105 = load i32, i32* %103, align 8
   %106 = bitcast i8* %101 to i32*
-  %NullCheck90 = icmp ne i32* %106, null
-  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+  %NullCheck89 = icmp eq i32* %106, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %107
 
 ; <label>:107                                     ; preds = %104
   store i32 %105, i32* %106, align 8
@@ -864,16 +946,16 @@ entry:
   %110 = load i8*, i8** %arg1
   %111 = getelementptr inbounds i8, i8* %110, i64 4
   %112 = bitcast i8* %111 to i16*
-  %NullCheck92 = icmp ne i16* %112, null
-  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+  %NullCheck91 = icmp eq i16* %112, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %113
 
 ; <label>:113                                     ; preds = %107
   %114 = load i16, i16* %112, align 8
   %115 = sext i16 %114 to i32
   %116 = bitcast i8* %109 to i16*
   %117 = trunc i32 %115 to i16
-  %NullCheck94 = icmp ne i16* %116, null
-  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+  %NullCheck93 = icmp eq i16* %116, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %118
 
 ; <label>:118                                     ; preds = %113
   store i16 %117, i16* %116, align 8
@@ -881,15 +963,15 @@ entry:
   %120 = getelementptr inbounds i8, i8* %119, i64 6
   %121 = load i8*, i8** %arg1
   %122 = getelementptr inbounds i8, i8* %121, i64 6
-  %NullCheck96 = icmp ne i8* %122, null
-  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+  %NullCheck95 = icmp eq i8* %122, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %123
 
 ; <label>:123                                     ; preds = %118
   %124 = load i8, i8* %122, align 8
   %125 = zext i8 %124 to i32
   %126 = trunc i32 %125 to i8
-  %NullCheck98 = icmp ne i8* %120, null
-  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+  %NullCheck97 = icmp eq i8* %120, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %127
 
 ; <label>:127                                     ; preds = %123
   store i8 %126, i8* %120, align 8
@@ -899,14 +981,14 @@ entry:
   %129 = load i8*, i8** %arg0
   %130 = load i8*, i8** %arg1
   %131 = bitcast i8* %130 to i64*
-  %NullCheck84 = icmp ne i64* %131, null
-  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+  %NullCheck83 = icmp eq i64* %131, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %132
 
 ; <label>:132                                     ; preds = %128
   %133 = load i64, i64* %131, align 8
   %134 = bitcast i8* %129 to i64*
-  %NullCheck86 = icmp ne i64* %134, null
-  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+  %NullCheck85 = icmp eq i64* %134, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %135
 
 ; <label>:135                                     ; preds = %132
   store i64 %133, i64* %134, align 8
@@ -916,14 +998,14 @@ entry:
   %137 = load i8*, i8** %arg0
   %138 = load i8*, i8** %arg1
   %139 = bitcast i8* %138 to i64*
-  %NullCheck76 = icmp ne i64* %139, null
-  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+  %NullCheck75 = icmp eq i64* %139, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %140
 
 ; <label>:140                                     ; preds = %136
   %141 = load i64, i64* %139, align 8
   %142 = bitcast i8* %137 to i64*
-  %NullCheck78 = icmp ne i64* %142, null
-  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+  %NullCheck77 = icmp eq i64* %142, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %143
 
 ; <label>:143                                     ; preds = %140
   store i64 %141, i64* %142, align 8
@@ -931,15 +1013,15 @@ entry:
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %NullCheck80 = icmp ne i8* %147, null
-  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+  %NullCheck79 = icmp eq i8* %147, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %148
 
 ; <label>:148                                     ; preds = %143
   %149 = load i8, i8* %147, align 8
   %150 = zext i8 %149 to i32
   %151 = trunc i32 %150 to i8
-  %NullCheck82 = icmp ne i8* %145, null
-  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+  %NullCheck81 = icmp eq i8* %145, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %152
 
 ; <label>:152                                     ; preds = %148
   store i8 %151, i8* %145, align 8
@@ -949,14 +1031,14 @@ entry:
   %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
   %156 = bitcast i8* %155 to i64*
-  %NullCheck68 = icmp ne i64* %156, null
-  br i1 %NullCheck68, label %157, label %ThrowNullRef67
+  %NullCheck67 = icmp eq i64* %156, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %157
 
 ; <label>:157                                     ; preds = %153
   %158 = load i64, i64* %156, align 8
   %159 = bitcast i8* %154 to i64*
-  %NullCheck70 = icmp ne i64* %159, null
-  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+  %NullCheck69 = icmp eq i64* %159, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %160
 
 ; <label>:160                                     ; preds = %157
   store i64 %158, i64* %159, align 8
@@ -965,16 +1047,16 @@ entry:
   %163 = load i8*, i8** %arg1
   %164 = getelementptr inbounds i8, i8* %163, i64 8
   %165 = bitcast i8* %164 to i16*
-  %NullCheck72 = icmp ne i16* %165, null
-  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+  %NullCheck71 = icmp eq i16* %165, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %166
 
 ; <label>:166                                     ; preds = %160
   %167 = load i16, i16* %165, align 8
   %168 = sext i16 %167 to i32
   %169 = bitcast i8* %162 to i16*
   %170 = trunc i32 %168 to i16
-  %NullCheck74 = icmp ne i16* %169, null
-  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+  %NullCheck73 = icmp eq i16* %169, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %171
 
 ; <label>:171                                     ; preds = %166
   store i16 %170, i16* %169, align 8
@@ -984,14 +1066,14 @@ entry:
   %173 = load i8*, i8** %arg0
   %174 = load i8*, i8** %arg1
   %175 = bitcast i8* %174 to i64*
-  %NullCheck56 = icmp ne i64* %175, null
-  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+  %NullCheck55 = icmp eq i64* %175, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %176
 
 ; <label>:176                                     ; preds = %172
   %177 = load i64, i64* %175, align 8
   %178 = bitcast i8* %173 to i64*
-  %NullCheck58 = icmp ne i64* %178, null
-  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+  %NullCheck57 = icmp eq i64* %178, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %179
 
 ; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
@@ -1000,16 +1082,16 @@ entry:
   %182 = load i8*, i8** %arg1
   %183 = getelementptr inbounds i8, i8* %182, i64 8
   %184 = bitcast i8* %183 to i16*
-  %NullCheck60 = icmp ne i16* %184, null
-  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+  %NullCheck59 = icmp eq i16* %184, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %185
 
 ; <label>:185                                     ; preds = %179
   %186 = load i16, i16* %184, align 8
   %187 = sext i16 %186 to i32
   %188 = bitcast i8* %181 to i16*
   %189 = trunc i32 %187 to i16
-  %NullCheck62 = icmp ne i16* %188, null
-  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+  %NullCheck61 = icmp eq i16* %188, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %190
 
 ; <label>:190                                     ; preds = %185
   store i16 %189, i16* %188, align 8
@@ -1017,15 +1099,15 @@ entry:
   %192 = getelementptr inbounds i8, i8* %191, i64 10
   %193 = load i8*, i8** %arg1
   %194 = getelementptr inbounds i8, i8* %193, i64 10
-  %NullCheck64 = icmp ne i8* %194, null
-  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+  %NullCheck63 = icmp eq i8* %194, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %195
 
 ; <label>:195                                     ; preds = %190
   %196 = load i8, i8* %194, align 8
   %197 = zext i8 %196 to i32
   %198 = trunc i32 %197 to i8
-  %NullCheck66 = icmp ne i8* %192, null
-  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+  %NullCheck65 = icmp eq i8* %192, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %199
 
 ; <label>:199                                     ; preds = %195
   store i8 %198, i8* %192, align 8
@@ -1035,14 +1117,14 @@ entry:
   %201 = load i8*, i8** %arg0
   %202 = load i8*, i8** %arg1
   %203 = bitcast i8* %202 to i64*
-  %NullCheck48 = icmp ne i64* %203, null
-  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+  %NullCheck47 = icmp eq i64* %203, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %204
 
 ; <label>:204                                     ; preds = %200
   %205 = load i64, i64* %203, align 8
   %206 = bitcast i8* %201 to i64*
-  %NullCheck50 = icmp ne i64* %206, null
-  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+  %NullCheck49 = icmp eq i64* %206, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %207
 
 ; <label>:207                                     ; preds = %204
   store i64 %205, i64* %206, align 8
@@ -1051,14 +1133,14 @@ entry:
   %210 = load i8*, i8** %arg1
   %211 = getelementptr inbounds i8, i8* %210, i64 8
   %212 = bitcast i8* %211 to i32*
-  %NullCheck52 = icmp ne i32* %212, null
-  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+  %NullCheck51 = icmp eq i32* %212, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %213
 
 ; <label>:213                                     ; preds = %207
   %214 = load i32, i32* %212, align 8
   %215 = bitcast i8* %209 to i32*
-  %NullCheck54 = icmp ne i32* %215, null
-  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+  %NullCheck53 = icmp eq i32* %215, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %216
 
 ; <label>:216                                     ; preds = %213
   store i32 %214, i32* %215, align 8
@@ -1068,14 +1150,14 @@ entry:
   %218 = load i8*, i8** %arg0
   %219 = load i8*, i8** %arg1
   %220 = bitcast i8* %219 to i64*
-  %NullCheck36 = icmp ne i64* %220, null
-  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64* %220, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %221
 
 ; <label>:221                                     ; preds = %217
   %222 = load i64, i64* %220, align 8
   %223 = bitcast i8* %218 to i64*
-  %NullCheck38 = icmp ne i64* %223, null
-  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+  %NullCheck37 = icmp eq i64* %223, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %224
 
 ; <label>:224                                     ; preds = %221
   store i64 %222, i64* %223, align 8
@@ -1084,14 +1166,14 @@ entry:
   %227 = load i8*, i8** %arg1
   %228 = getelementptr inbounds i8, i8* %227, i64 8
   %229 = bitcast i8* %228 to i32*
-  %NullCheck40 = icmp ne i32* %229, null
-  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i32* %229, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %230
 
 ; <label>:230                                     ; preds = %224
   %231 = load i32, i32* %229, align 8
   %232 = bitcast i8* %226 to i32*
-  %NullCheck42 = icmp ne i32* %232, null
-  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+  %NullCheck41 = icmp eq i32* %232, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %233
 
 ; <label>:233                                     ; preds = %230
   store i32 %231, i32* %232, align 8
@@ -1099,15 +1181,15 @@ entry:
   %235 = getelementptr inbounds i8, i8* %234, i64 12
   %236 = load i8*, i8** %arg1
   %237 = getelementptr inbounds i8, i8* %236, i64 12
-  %NullCheck44 = icmp ne i8* %237, null
-  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i8* %237, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %238
 
 ; <label>:238                                     ; preds = %233
   %239 = load i8, i8* %237, align 8
   %240 = zext i8 %239 to i32
   %241 = trunc i32 %240 to i8
-  %NullCheck46 = icmp ne i8* %235, null
-  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+  %NullCheck45 = icmp eq i8* %235, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %242
 
 ; <label>:242                                     ; preds = %238
   store i8 %241, i8* %235, align 8
@@ -1117,14 +1199,14 @@ entry:
   %244 = load i8*, i8** %arg0
   %245 = load i8*, i8** %arg1
   %246 = bitcast i8* %245 to i64*
-  %NullCheck24 = icmp ne i64* %246, null
-  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64* %246, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %247
 
 ; <label>:247                                     ; preds = %243
   %248 = load i64, i64* %246, align 8
   %249 = bitcast i8* %244 to i64*
-  %NullCheck26 = icmp ne i64* %249, null
-  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64* %249, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %250
 
 ; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
@@ -1133,14 +1215,14 @@ entry:
   %253 = load i8*, i8** %arg1
   %254 = getelementptr inbounds i8, i8* %253, i64 8
   %255 = bitcast i8* %254 to i32*
-  %NullCheck28 = icmp ne i32* %255, null
-  br i1 %NullCheck28, label %256, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i32* %255, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %256
 
 ; <label>:256                                     ; preds = %250
   %257 = load i32, i32* %255, align 8
   %258 = bitcast i8* %252 to i32*
-  %NullCheck30 = icmp ne i32* %258, null
-  br i1 %NullCheck30, label %259, label %ThrowNullRef29
+  %NullCheck29 = icmp eq i32* %258, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %259
 
 ; <label>:259                                     ; preds = %256
   store i32 %257, i32* %258, align 8
@@ -1149,16 +1231,16 @@ entry:
   %262 = load i8*, i8** %arg1
   %263 = getelementptr inbounds i8, i8* %262, i64 12
   %264 = bitcast i8* %263 to i16*
-  %NullCheck32 = icmp ne i16* %264, null
-  br i1 %NullCheck32, label %265, label %ThrowNullRef31
+  %NullCheck31 = icmp eq i16* %264, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %265
 
 ; <label>:265                                     ; preds = %259
   %266 = load i16, i16* %264, align 8
   %267 = sext i16 %266 to i32
   %268 = bitcast i8* %261 to i16*
   %269 = trunc i32 %267 to i16
-  %NullCheck34 = icmp ne i16* %268, null
-  br i1 %NullCheck34, label %270, label %ThrowNullRef33
+  %NullCheck33 = icmp eq i16* %268, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %270
 
 ; <label>:270                                     ; preds = %265
   store i16 %269, i16* %268, align 8
@@ -1168,14 +1250,14 @@ entry:
   %272 = load i8*, i8** %arg0
   %273 = load i8*, i8** %arg1
   %274 = bitcast i8* %273 to i64*
-  %NullCheck8 = icmp ne i64* %274, null
-  br i1 %NullCheck8, label %275, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64* %274, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %275
 
 ; <label>:275                                     ; preds = %271
   %276 = load i64, i64* %274, align 8
   %277 = bitcast i8* %272 to i64*
-  %NullCheck10 = icmp ne i64* %277, null
-  br i1 %NullCheck10, label %278, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %277, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %278
 
 ; <label>:278                                     ; preds = %275
   store i64 %276, i64* %277, align 8
@@ -1184,14 +1266,14 @@ entry:
   %281 = load i8*, i8** %arg1
   %282 = getelementptr inbounds i8, i8* %281, i64 8
   %283 = bitcast i8* %282 to i32*
-  %NullCheck12 = icmp ne i32* %283, null
-  br i1 %NullCheck12, label %284, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i32* %283, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %284
 
 ; <label>:284                                     ; preds = %278
   %285 = load i32, i32* %283, align 8
   %286 = bitcast i8* %280 to i32*
-  %NullCheck14 = icmp ne i32* %286, null
-  br i1 %NullCheck14, label %287, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i32* %286, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %287
 
 ; <label>:287                                     ; preds = %284
   store i32 %285, i32* %286, align 8
@@ -1200,16 +1282,16 @@ entry:
   %290 = load i8*, i8** %arg1
   %291 = getelementptr inbounds i8, i8* %290, i64 12
   %292 = bitcast i8* %291 to i16*
-  %NullCheck16 = icmp ne i16* %292, null
-  br i1 %NullCheck16, label %293, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i16* %292, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %293
 
 ; <label>:293                                     ; preds = %287
   %294 = load i16, i16* %292, align 8
   %295 = sext i16 %294 to i32
   %296 = bitcast i8* %289 to i16*
   %297 = trunc i32 %295 to i16
-  %NullCheck18 = icmp ne i16* %296, null
-  br i1 %NullCheck18, label %298, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i16* %296, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %298
 
 ; <label>:298                                     ; preds = %293
   store i16 %297, i16* %296, align 8
@@ -1217,15 +1299,15 @@ entry:
   %300 = getelementptr inbounds i8, i8* %299, i64 14
   %301 = load i8*, i8** %arg1
   %302 = getelementptr inbounds i8, i8* %301, i64 14
-  %NullCheck20 = icmp ne i8* %302, null
-  br i1 %NullCheck20, label %303, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i8* %302, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %303
 
 ; <label>:303                                     ; preds = %298
   %304 = load i8, i8* %302, align 8
   %305 = zext i8 %304 to i32
   %306 = trunc i32 %305 to i8
-  %NullCheck22 = icmp ne i8* %300, null
-  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i8* %300, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %307
 
 ; <label>:307                                     ; preds = %303
   store i8 %306, i8* %300, align 8
@@ -1235,14 +1317,14 @@ entry:
   %309 = load i8*, i8** %arg0
   %310 = load i8*, i8** %arg1
   %311 = bitcast i8* %310 to i64*
-  %NullCheck = icmp ne i64* %311, null
-  br i1 %NullCheck, label %312, label %ThrowNullRef
+  %NullCheck = icmp eq i64* %311, null
+  br i1 %NullCheck, label %ThrowNullRef, label %312
 
 ; <label>:312                                     ; preds = %308
   %313 = load i64, i64* %311, align 8
   %314 = bitcast i8* %309 to i64*
-  %NullCheck2 = icmp ne i64* %314, null
-  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64* %314, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %315
 
 ; <label>:315                                     ; preds = %312
   store i64 %313, i64* %314, align 8
@@ -1251,14 +1333,14 @@ entry:
   %318 = load i8*, i8** %arg1
   %319 = getelementptr inbounds i8, i8* %318, i64 8
   %320 = bitcast i8* %319 to i64*
-  %NullCheck4 = icmp ne i64* %320, null
-  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64* %320, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %321
 
 ; <label>:321                                     ; preds = %315
   %322 = load i64, i64* %320, align 8
   %323 = bitcast i8* %317 to i64*
-  %NullCheck6 = icmp ne i64* %323, null
-  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64* %323, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %324
 
 ; <label>:324                                     ; preds = %321
   store i64 %322, i64* %323, align 8
@@ -1286,15 +1368,15 @@ entry:
 ; <label>:338                                     ; preds = %333
   %339 = load i8*, i8** %arg0
   %340 = load i8*, i8** %arg1
-  %NullCheck136 = icmp ne i8* %340, null
-  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+  %NullCheck135 = icmp eq i8* %340, null
+  br i1 %NullCheck135, label %ThrowNullRef136, label %341
 
 ; <label>:341                                     ; preds = %338
   %342 = load i8, i8* %340, align 8
   %343 = zext i8 %342 to i32
   %344 = trunc i32 %343 to i8
-  %NullCheck138 = icmp ne i8* %339, null
-  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+  %NullCheck137 = icmp eq i8* %339, null
+  br i1 %NullCheck137, label %ThrowNullRef138, label %345
 
 ; <label>:345                                     ; preds = %341
   store i8 %344, i8* %339, align 8
@@ -1317,16 +1399,16 @@ entry:
   %357 = load i8*, i8** %arg0
   %358 = load i8*, i8** %arg1
   %359 = bitcast i8* %358 to i16*
-  %NullCheck140 = icmp ne i16* %359, null
-  br i1 %NullCheck140, label %360, label %ThrowNullRef139
+  %NullCheck139 = icmp eq i16* %359, null
+  br i1 %NullCheck139, label %ThrowNullRef140, label %360
 
 ; <label>:360                                     ; preds = %356
   %361 = load i16, i16* %359, align 8
   %362 = sext i16 %361 to i32
   %363 = bitcast i8* %357 to i16*
   %364 = trunc i32 %362 to i16
-  %NullCheck142 = icmp ne i16* %363, null
-  br i1 %NullCheck142, label %365, label %ThrowNullRef141
+  %NullCheck141 = icmp eq i16* %363, null
+  br i1 %NullCheck141, label %ThrowNullRef142, label %365
 
 ; <label>:365                                     ; preds = %360
   store i16 %364, i16* %363, align 8
@@ -1352,14 +1434,14 @@ entry:
   %378 = load i8*, i8** %arg0
   %379 = load i8*, i8** %arg1
   %380 = bitcast i8* %379 to i32*
-  %NullCheck144 = icmp ne i32* %380, null
-  br i1 %NullCheck144, label %381, label %ThrowNullRef143
+  %NullCheck143 = icmp eq i32* %380, null
+  br i1 %NullCheck143, label %ThrowNullRef144, label %381
 
 ; <label>:381                                     ; preds = %377
   %382 = load i32, i32* %380, align 8
   %383 = bitcast i8* %378 to i32*
-  %NullCheck146 = icmp ne i32* %383, null
-  br i1 %NullCheck146, label %384, label %ThrowNullRef145
+  %NullCheck145 = icmp eq i32* %383, null
+  br i1 %NullCheck145, label %ThrowNullRef146, label %384
 
 ; <label>:384                                     ; preds = %381
   store i32 %382, i32* %383, align 8
@@ -1384,14 +1466,14 @@ entry:
   %395 = load i8*, i8** %arg0
   %396 = load i8*, i8** %arg1
   %397 = bitcast i8* %396 to i64*
-  %NullCheck164 = icmp ne i64* %397, null
-  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+  %NullCheck163 = icmp eq i64* %397, null
+  br i1 %NullCheck163, label %ThrowNullRef164, label %398
 
 ; <label>:398                                     ; preds = %394
   %399 = load i64, i64* %397, align 8
   %400 = bitcast i8* %395 to i64*
-  %NullCheck166 = icmp ne i64* %400, null
-  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+  %NullCheck165 = icmp eq i64* %400, null
+  br i1 %NullCheck165, label %ThrowNullRef166, label %401
 
 ; <label>:401                                     ; preds = %398
   store i64 %399, i64* %400, align 8
@@ -1400,14 +1482,14 @@ entry:
   %404 = load i8*, i8** %arg1
   %405 = getelementptr inbounds i8, i8* %404, i64 8
   %406 = bitcast i8* %405 to i64*
-  %NullCheck168 = icmp ne i64* %406, null
-  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+  %NullCheck167 = icmp eq i64* %406, null
+  br i1 %NullCheck167, label %ThrowNullRef168, label %407
 
 ; <label>:407                                     ; preds = %401
   %408 = load i64, i64* %406, align 8
   %409 = bitcast i8* %403 to i64*
-  %NullCheck170 = icmp ne i64* %409, null
-  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+  %NullCheck169 = icmp eq i64* %409, null
+  br i1 %NullCheck169, label %ThrowNullRef170, label %410
 
 ; <label>:410                                     ; preds = %407
   store i64 %408, i64* %409, align 8
@@ -1437,14 +1519,14 @@ entry:
   %425 = load i8*, i8** %arg0
   %426 = load i8*, i8** %arg1
   %427 = bitcast i8* %426 to i64*
-  %NullCheck148 = icmp ne i64* %427, null
-  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+  %NullCheck147 = icmp eq i64* %427, null
+  br i1 %NullCheck147, label %ThrowNullRef148, label %428
 
 ; <label>:428                                     ; preds = %424
   %429 = load i64, i64* %427, align 8
   %430 = bitcast i8* %425 to i64*
-  %NullCheck150 = icmp ne i64* %430, null
-  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+  %NullCheck149 = icmp eq i64* %430, null
+  br i1 %NullCheck149, label %ThrowNullRef150, label %431
 
 ; <label>:431                                     ; preds = %428
   store i64 %429, i64* %430, align 8
@@ -1466,14 +1548,14 @@ entry:
   %441 = load i8*, i8** %arg0
   %442 = load i8*, i8** %arg1
   %443 = bitcast i8* %442 to i32*
-  %NullCheck152 = icmp ne i32* %443, null
-  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+  %NullCheck151 = icmp eq i32* %443, null
+  br i1 %NullCheck151, label %ThrowNullRef152, label %444
 
 ; <label>:444                                     ; preds = %440
   %445 = load i32, i32* %443, align 8
   %446 = bitcast i8* %441 to i32*
-  %NullCheck154 = icmp ne i32* %446, null
-  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+  %NullCheck153 = icmp eq i32* %446, null
+  br i1 %NullCheck153, label %ThrowNullRef154, label %447
 
 ; <label>:447                                     ; preds = %444
   store i32 %445, i32* %446, align 8
@@ -1495,16 +1577,16 @@ entry:
   %457 = load i8*, i8** %arg0
   %458 = load i8*, i8** %arg1
   %459 = bitcast i8* %458 to i16*
-  %NullCheck156 = icmp ne i16* %459, null
-  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+  %NullCheck155 = icmp eq i16* %459, null
+  br i1 %NullCheck155, label %ThrowNullRef156, label %460
 
 ; <label>:460                                     ; preds = %456
   %461 = load i16, i16* %459, align 8
   %462 = sext i16 %461 to i32
   %463 = bitcast i8* %457 to i16*
   %464 = trunc i32 %462 to i16
-  %NullCheck158 = icmp ne i16* %463, null
-  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+  %NullCheck157 = icmp eq i16* %463, null
+  br i1 %NullCheck157, label %ThrowNullRef158, label %465
 
 ; <label>:465                                     ; preds = %460
   store i16 %464, i16* %463, align 8
@@ -1525,15 +1607,15 @@ entry:
 ; <label>:474                                     ; preds = %470
   %475 = load i8*, i8** %arg0
   %476 = load i8*, i8** %arg1
-  %NullCheck160 = icmp ne i8* %476, null
-  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+  %NullCheck159 = icmp eq i8* %476, null
+  br i1 %NullCheck159, label %ThrowNullRef160, label %477
 
 ; <label>:477                                     ; preds = %474
   %478 = load i8, i8* %476, align 8
   %479 = zext i8 %478 to i32
   %480 = trunc i32 %479 to i8
-  %NullCheck162 = icmp ne i8* %475, null
-  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+  %NullCheck161 = icmp eq i8* %475, null
+  br i1 %NullCheck161, label %ThrowNullRef162, label %481
 
 ; <label>:481                                     ; preds = %477
   store i8 %480, i8* %475, align 8
@@ -1553,343 +1635,343 @@ ThrowNullRef:                                     ; preds = %308
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %312
+ThrowNullRef2:                                    ; preds = %312
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %315
+ThrowNullRef4:                                    ; preds = %315
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %321
+ThrowNullRef6:                                    ; preds = %321
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %271
+ThrowNullRef8:                                    ; preds = %271
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %275
+ThrowNullRef10:                                   ; preds = %275
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %278
+ThrowNullRef12:                                   ; preds = %278
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %284
+ThrowNullRef14:                                   ; preds = %284
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %287
+ThrowNullRef16:                                   ; preds = %287
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %293
+ThrowNullRef18:                                   ; preds = %293
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %298
+ThrowNullRef20:                                   ; preds = %298
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %303
+ThrowNullRef22:                                   ; preds = %303
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %243
+ThrowNullRef24:                                   ; preds = %243
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %247
+ThrowNullRef26:                                   ; preds = %247
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %250
+ThrowNullRef28:                                   ; preds = %250
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %256
+ThrowNullRef30:                                   ; preds = %256
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %259
+ThrowNullRef32:                                   ; preds = %259
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %265
+ThrowNullRef34:                                   ; preds = %265
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %217
+ThrowNullRef36:                                   ; preds = %217
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %221
+ThrowNullRef38:                                   ; preds = %221
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %224
+ThrowNullRef40:                                   ; preds = %224
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %230
+ThrowNullRef42:                                   ; preds = %230
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %233
+ThrowNullRef44:                                   ; preds = %233
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %238
+ThrowNullRef46:                                   ; preds = %238
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %200
+ThrowNullRef48:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %204
+ThrowNullRef50:                                   ; preds = %204
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %207
+ThrowNullRef52:                                   ; preds = %207
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %213
+ThrowNullRef54:                                   ; preds = %213
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %172
+ThrowNullRef56:                                   ; preds = %172
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %176
+ThrowNullRef58:                                   ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %179
+ThrowNullRef60:                                   ; preds = %179
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %185
+ThrowNullRef62:                                   ; preds = %185
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %190
+ThrowNullRef64:                                   ; preds = %190
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %195
+ThrowNullRef66:                                   ; preds = %195
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %153
+ThrowNullRef68:                                   ; preds = %153
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %157
+ThrowNullRef70:                                   ; preds = %157
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %160
+ThrowNullRef72:                                   ; preds = %160
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %166
+ThrowNullRef74:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %136
+ThrowNullRef76:                                   ; preds = %136
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %140
+ThrowNullRef78:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %143
+ThrowNullRef80:                                   ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %148
+ThrowNullRef82:                                   ; preds = %148
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %128
+ThrowNullRef84:                                   ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %132
+ThrowNullRef86:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %100
+ThrowNullRef88:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %104
+ThrowNullRef90:                                   ; preds = %104
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %107
+ThrowNullRef92:                                   ; preds = %107
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %113
+ThrowNullRef94:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %118
+ThrowNullRef96:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %123
+ThrowNullRef98:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %81
+ThrowNullRef100:                                  ; preds = %81
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef101:                                  ; preds = %85
+ThrowNullRef102:                                  ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef103:                                  ; preds = %88
+ThrowNullRef104:                                  ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef105:                                  ; preds = %94
+ThrowNullRef106:                                  ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef107:                                  ; preds = %64
+ThrowNullRef108:                                  ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef109:                                  ; preds = %68
+ThrowNullRef110:                                  ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef111:                                  ; preds = %71
+ThrowNullRef112:                                  ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef113:                                  ; preds = %76
+ThrowNullRef114:                                  ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef115:                                  ; preds = %56
+ThrowNullRef116:                                  ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef117:                                  ; preds = %60
+ThrowNullRef118:                                  ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef119:                                  ; preds = %37
+ThrowNullRef120:                                  ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef121:                                  ; preds = %41
+ThrowNullRef122:                                  ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef123:                                  ; preds = %46
+ThrowNullRef124:                                  ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef125:                                  ; preds = %51
+ThrowNullRef126:                                  ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef127:                                  ; preds = %27
+ThrowNullRef128:                                  ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef129:                                  ; preds = %31
+ThrowNullRef130:                                  ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef131:                                  ; preds = %19
+ThrowNullRef132:                                  ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef133:                                  ; preds = %22
+ThrowNullRef134:                                  ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef135:                                  ; preds = %338
+ThrowNullRef136:                                  ; preds = %338
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef137:                                  ; preds = %341
+ThrowNullRef138:                                  ; preds = %341
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef139:                                  ; preds = %356
+ThrowNullRef140:                                  ; preds = %356
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef141:                                  ; preds = %360
+ThrowNullRef142:                                  ; preds = %360
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef143:                                  ; preds = %377
+ThrowNullRef144:                                  ; preds = %377
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef145:                                  ; preds = %381
+ThrowNullRef146:                                  ; preds = %381
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef147:                                  ; preds = %424
+ThrowNullRef148:                                  ; preds = %424
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef149:                                  ; preds = %428
+ThrowNullRef150:                                  ; preds = %428
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef151:                                  ; preds = %440
+ThrowNullRef152:                                  ; preds = %440
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef153:                                  ; preds = %444
+ThrowNullRef154:                                  ; preds = %444
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef155:                                  ; preds = %456
+ThrowNullRef156:                                  ; preds = %456
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef157:                                  ; preds = %460
+ThrowNullRef158:                                  ; preds = %460
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef159:                                  ; preds = %474
+ThrowNullRef160:                                  ; preds = %474
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef161:                                  ; preds = %477
+ThrowNullRef162:                                  ; preds = %477
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef163:                                  ; preds = %394
+ThrowNullRef164:                                  ; preds = %394
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef165:                                  ; preds = %398
+ThrowNullRef166:                                  ; preds = %398
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef167:                                  ; preds = %401
+ThrowNullRef168:                                  ; preds = %401
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef169:                                  ; preds = %407
+ThrowNullRef170:                                  ; preds = %407
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1939,8 +2021,8 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
-  br i1 %NullCheck, label %22, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %ThrowNullRef, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
@@ -1948,8 +2030,8 @@ entry:
   store i32 %24, i32* %loc0
   %25 = load i32, i32* %loc0
   %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %26, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %27
 
 ; <label>:27                                      ; preds = %22
   %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
@@ -1971,7 +2053,7 @@ ThrowNullRef:                                     ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1989,8 +2071,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -2022,15 +2104,15 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2048,16 +2130,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
   %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
   store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %15
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
@@ -2072,8 +2154,8 @@ entry:
   %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
   %29 = ptrtoint i16 addrspace(1)* %28 to i64
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %19
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
@@ -2089,19 +2171,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2114,8 +2196,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
@@ -2128,7 +2210,7 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[loadElem]
+Failed to read AppDomain.PrepareDataForSetup[storeElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
@@ -2202,8 +2284,8 @@ entry:
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
-  br i1 %NullCheck24, label %27, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = load i64, i64 addrspace(1)* %26
@@ -2218,8 +2300,8 @@ entry:
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
-  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
   %41 = load i64, i64 addrspace(1)* %39
@@ -2236,8 +2318,8 @@ entry:
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
-  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
   %54 = load i64, i64 addrspace(1)* %52
@@ -2252,8 +2334,8 @@ entry:
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
   %67 = load i64, i64 addrspace(1)* %65
@@ -2270,8 +2352,8 @@ entry:
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
-  br i1 %NullCheck16, label %79, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
   %80 = load i64, i64 addrspace(1)* %78
@@ -2286,8 +2368,8 @@ entry:
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
-  br i1 %NullCheck18, label %92, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
   %93 = load i64, i64 addrspace(1)* %91
@@ -2304,8 +2386,8 @@ entry:
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
-  br i1 %NullCheck12, label %105, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = load i64, i64 addrspace(1)* %104
@@ -2320,8 +2402,8 @@ entry:
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
-  br i1 %NullCheck14, label %118, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
   %119 = load i64, i64 addrspace(1)* %117
@@ -2337,8 +2419,8 @@ entry:
 
 ; <label>:128                                     ; preds = %20
   %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
-  br i1 %NullCheck4, label %130, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %129, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %130
 
 ; <label>:130                                     ; preds = %128
   %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
@@ -2346,8 +2428,8 @@ entry:
   %133 = load i16, i16 addrspace(1)* %132, align 8
   %134 = zext i16 %133 to i32
   %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
-  br i1 %NullCheck6, label %136, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %135, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %136
 
 ; <label>:136                                     ; preds = %130
   %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
@@ -2360,8 +2442,8 @@ entry:
 
 ; <label>:143                                     ; preds = %136
   %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
-  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %144, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %145
 
 ; <label>:145                                     ; preds = %143
   %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
@@ -2369,8 +2451,8 @@ entry:
   %148 = load i16, i16 addrspace(1)* %147, align 8
   %149 = zext i16 %148 to i32
   %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %150, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %151
 
 ; <label>:151                                     ; preds = %145
   %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
@@ -2388,8 +2470,8 @@ entry:
 
 ; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
-  br i1 %NullCheck, label %163, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %ThrowNullRef, label %163
 
 ; <label>:163                                     ; preds = %161
   %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
@@ -2399,8 +2481,8 @@ entry:
 
 ; <label>:167                                     ; preds = %163
   %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
-  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %168, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %169
 
 ; <label>:169                                     ; preds = %167
   %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
@@ -2432,55 +2514,55 @@ ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %167
+ThrowNullRef2:                                    ; preds = %167
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %128
+ThrowNullRef4:                                    ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %130
+ThrowNullRef6:                                    ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %143
+ThrowNullRef8:                                    ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %145
+ThrowNullRef10:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %102
+ThrowNullRef12:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %105
+ThrowNullRef14:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %76
+ThrowNullRef16:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %79
+ThrowNullRef18:                                   ; preds = %79
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %50
+ThrowNullRef20:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %53
+ThrowNullRef22:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %24
+ThrowNullRef24:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %27
+ThrowNullRef26:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2503,15 +2585,15 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2519,16 +2601,16 @@ entry:
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
   store i32 %8, i32* %loc0
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
   %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
   store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
@@ -2546,16 +2628,16 @@ entry:
 
 ; <label>:23                                      ; preds = %64
   %24 = load i16*, i16** %loc3
-  %NullCheck12 = icmp ne i16* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i16* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
   store i32 %27, i32* %loc5
   %28 = load i16*, i16** %loc4
-  %NullCheck14 = icmp ne i16* %28, null
-  br i1 %NullCheck14, label %29, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %28, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = load i16, i16* %28, align 8
@@ -2620,15 +2702,15 @@ entry:
 
 ; <label>:67                                      ; preds = %64
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
-  br i1 %NullCheck8, label %69, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %68, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %69
 
 ; <label>:69                                      ; preds = %67
   %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
   %71 = load i32, i32 addrspace(1)* %70
   %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
-  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %73
 
 ; <label>:73                                      ; preds = %69
   %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
@@ -2645,31 +2727,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %67
+ThrowNullRef8:                                    ; preds = %67
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %69
+ThrowNullRef10:                                   ; preds = %69
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2710,14 +2792,14 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
   %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
@@ -2730,14 +2812,14 @@ entry:
 
 ; <label>:11                                      ; preds = %4
   %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
   %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
@@ -2749,14 +2831,14 @@ entry:
 
 ; <label>:22                                      ; preds = %16
   %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
   %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
-  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
-  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
@@ -2804,23 +2886,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2836,7 +2918,280 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[loadElem]
+Successfully read RuntimeType.IsAssignableFrom
+
+define i8 @RuntimeType.IsAssignableFrom(%System.RuntimeType addrspace(1)* %param0, %System.Type addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.RuntimeType addrspace(1)*
+  %arg1 = alloca %System.Type addrspace(1)*
+  %loc0 = alloca %System.RuntimeType addrspace(1)*
+  %loc1 = alloca %"System.Type[]" addrspace(1)*
+  %loc2 = alloca i32
+  store %System.RuntimeType addrspace(1)* %param0, %System.RuntimeType addrspace(1)** %this
+  store %System.Type addrspace(1)* %param1, %System.Type addrspace(1)** %arg1
+  %0 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %1 = icmp ne %System.Type addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i8 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %5 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %6 = bitcast %System.Type addrspace(1)* %4 to %System.Object addrspace(1)*
+  %7 = bitcast %System.RuntimeType addrspace(1)* %5 to %System.Object addrspace(1)*
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %6, %System.Object addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %3
+  ret i8 1
+
+; <label>:12                                      ; preds = %3
+  %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 152
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 32
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
+  %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
+  %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
+  store %System.RuntimeType addrspace(1)* %25, %System.RuntimeType addrspace(1)** %loc0
+  %26 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %27 = icmp eq %System.RuntimeType addrspace(1)* %26, null
+  br i1 %27, label %34, label %28
+
+; <label>:28                                      ; preds = %15
+  %29 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %30 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)*)*)(%System.RuntimeType addrspace(1)* %29, %System.RuntimeType addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+; <label>:34                                      ; preds = %15
+  %35 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %36 = call %System.Reflection.Emit.TypeBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Reflection.Emit.TypeBuilder addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %35)
+  %37 = icmp eq %System.Reflection.Emit.TypeBuilder addrspace(1)* %36, null
+  br i1 %37, label %139, label %38
+
+; <label>:38                                      ; preds = %34
+  %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %42
+
+; <label>:42                                      ; preds = %38
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 152
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 40
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
+  %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
+  %53 = zext i8 %52 to i32
+  %54 = icmp eq i32 %53, 0
+  br i1 %54, label %56, label %55
+
+; <label>:55                                      ; preds = %42
+  ret i8 1
+
+; <label>:56                                      ; preds = %42
+  %57 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %58 = bitcast %System.RuntimeType addrspace(1)* %57 to %System.Type addrspace(1)*
+  %59 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %58)
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %64 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.Type addrspace(1)* %63, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = bitcast %System.RuntimeType addrspace(1)* %64 to %System.Type addrspace(1)*
+  %67 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %63, %System.Type addrspace(1)* %66)
+  %68 = zext i8 %67 to i32
+  %69 = trunc i32 %68 to i8
+  ret i8 %69
+
+; <label>:70                                      ; preds = %56
+  %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
+  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %73
+
+; <label>:73                                      ; preds = %70
+  %74 = load i64, i64 addrspace(1)* %72
+  %75 = add i64 %74, 128
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = add i64 %77, 0
+  %79 = inttoptr i64 %78 to i64*
+  %80 = load i64, i64* %79
+  %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
+  %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
+  %83 = call i8 %82(%System.Type addrspace(1)* %81)
+  %84 = zext i8 %83 to i32
+  %85 = icmp eq i32 %84, 0
+  br i1 %85, label %139, label %86
+
+; <label>:86                                      ; preds = %73
+  %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
+  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %89
+
+; <label>:89                                      ; preds = %86
+  %90 = load i64, i64 addrspace(1)* %88
+  %91 = add i64 %90, 128
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = add i64 %93, 24
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
+  %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
+  %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
+  store %"System.Type[]" addrspace(1)* %99, %"System.Type[]" addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %129
+
+; <label>:100                                     ; preds = %132
+  %101 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %102 = load i32, i32* %loc2
+  %NullCheck11 = icmp eq %"System.Type[]" addrspace(1)* %101, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %103
+
+; <label>:103                                     ; preds = %100
+  %104 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 1
+  %105 = load i32, i32 addrspace(1)* %104
+  %106 = zext i32 %105 to i64
+  %107 = zext i32 %102 to i64
+  %BoundsCheck = icmp uge i64 %107, %106
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %108
+
+; <label>:108                                     ; preds = %103
+  %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
+  %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
+  %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
+  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %113
+
+; <label>:113                                     ; preds = %108
+  %114 = load i64, i64 addrspace(1)* %112
+  %115 = add i64 %114, 152
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = add i64 %117, 56
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
+  %123 = zext i8 %122 to i32
+  %124 = icmp ne i32 %123, 0
+  br i1 %124, label %126, label %125
+
+; <label>:125                                     ; preds = %113
+  ret i8 0
+
+; <label>:126                                     ; preds = %113
+  %127 = load i32, i32* %loc2
+  %128 = add i32 %127, 1
+  store i32 %128, i32* %loc2
+  br label %129
+
+; <label>:129                                     ; preds = %89, %126
+  %130 = load i32, i32* %loc2
+  %131 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %NullCheck9 = icmp eq %"System.Type[]" addrspace(1)* %131, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %132
+
+; <label>:132                                     ; preds = %129
+  %133 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %131, i32 0, i32 1
+  %134 = load i32, i32 addrspace(1)* %133
+  %135 = zext i32 %134 to i64
+  %136 = trunc i64 %135 to i32
+  %137 = icmp slt i32 %130, %136
+  br i1 %137, label %100, label %138
+
+; <label>:138                                     ; preds = %132
+  ret i8 1
+
+; <label>:139                                     ; preds = %34, %73
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %129
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %103
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -2893,7 +3248,7 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElem]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -2904,8 +3259,8 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -2997,8 +3352,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
@@ -3059,8 +3414,8 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -3087,8 +3442,8 @@ entry:
 
 ; <label>:17                                      ; preds = %5, %11
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
@@ -3097,8 +3452,8 @@ entry:
 
 ; <label>:22                                      ; preds = %1, %11
   %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
@@ -3109,11 +3464,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %17
+ThrowNullRef2:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %22
+ThrowNullRef4:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3167,15 +3522,15 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
   %15 = load i32, i32 addrspace(1)* %14
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
@@ -3198,7 +3553,7 @@ ThrowNullRef:                                     ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef2:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3232,8 +3587,8 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
@@ -3312,8 +3667,8 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -3327,8 +3682,8 @@ entry:
 ; <label>:5                                       ; preds = %43
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %7 = load i32, i32* %loc1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck6, label %8, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
@@ -3366,8 +3721,8 @@ entry:
 ; <label>:32                                      ; preds = %21, %25
   %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
   %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
-  br i1 %NullCheck8, label %35, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = trunc i32 %34 to i16
@@ -3380,8 +3735,8 @@ entry:
 ; <label>:40                                      ; preds = %1, %35
   %41 = load i32, i32* %loc1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
-  br i1 %NullCheck2, label %43, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %42, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
@@ -3392,8 +3747,8 @@ entry:
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
   %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
-  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
   %51 = load i64, i64 addrspace(1)* %49
@@ -3412,19 +3767,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %40
+ThrowNullRef2:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %47
+ThrowNullRef4:                                    ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %5
+ThrowNullRef6:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %32
+ThrowNullRef8:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3467,8 +3822,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
@@ -3492,11 +3847,391 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(i16* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store i16* %param0, i16** %arg0
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load i32, i32* %arg3
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %42, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %37, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg2
+  %13 = load i32, i32* %arg3
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %37, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %24 = load i32, i32* %arg2
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load i16*, i16** %arg0
+  %35 = load i32, i32* %arg3
+  %36 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %36, i16* %34, i32 %35)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:37                                      ; preds = %5, %16
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %39)
+  %41 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41, %System.String addrspace(1)* %38, %System.String addrspace(1)* %40)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41) #0
+  unreachable
+
+; <label>:42                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
-Failed to read StringBuilder.ToString[loadElemA]
+Successfully read StringBuilder.ToString
+
+define %System.String addrspace(1)* @StringBuilder.ToString(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i16*
+  %loc3 = alloca %"System.Char[]" addrspace(1)*
+  %loc4 = alloca i32
+  %loc5 = alloca i32
+  %loc6 = alloca i16 addrspace(1)*
+  %loc7 = alloca %System.String addrspace(1)*
+  %loc8 = alloca %"System.Char[]" addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %0)
+  %2 = icmp ne i32 %1, 0
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %4
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %6)
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %7)
+  store %System.String addrspace(1)* %8, %System.String addrspace(1)** %loc0
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.Text.StringBuilder addrspace(1)* %9, %System.Text.StringBuilder addrspace(1)** %loc1
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  store %System.String addrspace(1)* %10, %System.String addrspace(1)** %loc7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc7
+  %12 = ptrtoint %System.String addrspace(1)* %11 to i64
+  %13 = icmp eq i64 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %5
+  %15 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %16 = sext i32 %15 to i64
+  %17 = add i64 %12, %16
+  br label %18
+
+; <label>:18                                      ; preds = %5, %14
+  %19 = phi i64 [ %12, %5 ], [ %17, %14 ]
+  %20 = inttoptr i64 %19 to i16*
+  store i16* %20, i16** %loc2
+  br label %21
+
+; <label>:21                                      ; preds = %98, %18
+  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %22, null
+  br i1 %NullCheck, label %ThrowNullRef, label %23
+
+; <label>:23                                      ; preds = %21
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 3
+  %25 = load i32, i32 addrspace(1)* %24, align 8
+  %26 = icmp sle i32 %25, 0
+  br i1 %26, label %96, label %27
+
+; <label>:27                                      ; preds = %23
+  %28 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %28, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %29
+
+; <label>:29                                      ; preds = %27
+  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %28, i32 0, i32 1
+  %31 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %30, align 8
+  store %"System.Char[]" addrspace(1)* %31, %"System.Char[]" addrspace(1)** %loc3
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %33
+
+; <label>:33                                      ; preds = %29
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  store i32 %35, i32* %loc4
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  %39 = load i32, i32 addrspace(1)* %38, align 8
+  store i32 %39, i32* %loc5
+  %40 = load i32, i32* %loc5
+  %41 = load i32, i32* %loc4
+  %42 = add i32 %40, %41
+  %43 = zext i32 %42 to i64
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %45
+
+; <label>:45                                      ; preds = %37
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = sext i32 %47 to i64
+  %49 = icmp sgt i64 %43, %48
+  br i1 %49, label %91, label %50
+
+; <label>:50                                      ; preds = %45
+  %51 = load i32, i32* %loc5
+  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %52, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %53
+
+; <label>:53                                      ; preds = %50
+  %54 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %52, i32 0, i32 1
+  %55 = load i32, i32 addrspace(1)* %54
+  %56 = zext i32 %55 to i64
+  %57 = trunc i64 %56 to i32
+  %58 = icmp ugt i32 %51, %57
+  br i1 %58, label %91, label %59
+
+; <label>:59                                      ; preds = %53
+  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  store %"System.Char[]" addrspace(1)* %60, %"System.Char[]" addrspace(1)** %loc8
+  %61 = icmp eq %"System.Char[]" addrspace(1)* %60, null
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %63, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %64
+
+; <label>:64                                      ; preds = %62
+  %65 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %63, i32 0, i32 1
+  %66 = load i32, i32 addrspace(1)* %65
+  %67 = zext i32 %66 to i64
+  %68 = trunc i64 %67 to i32
+  %69 = icmp ne i32 %68, 0
+  br i1 %69, label %71, label %70
+
+; <label>:70                                      ; preds = %59, %64
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:71                                      ; preds = %64
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %73
+
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %BoundsCheck = icmp uge i64 0, %76
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %77
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %78, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:79                                      ; preds = %70, %77
+  %80 = load i16*, i16** %loc2
+  %81 = load i32, i32* %loc4
+  %82 = sext i32 %81 to i64
+  %83 = mul i64 %82, 2
+  %84 = bitcast i16* %80 to i8*
+  %85 = getelementptr inbounds i8, i8* %84, i64 %83
+  %86 = load i16 addrspace(1)*, i16 addrspace(1)** %loc6
+  %87 = ptrtoint i16 addrspace(1)* %86 to i64
+  %88 = load i32, i32* %loc5
+  %89 = bitcast i8* %85 to i16*
+  %90 = inttoptr i64 %87 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %89, i16* %90, i32 %88)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %96
+
+; <label>:91                                      ; preds = %45, %53
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %94 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %93)
+  %95 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95, %System.String addrspace(1)* %92, %System.String addrspace(1)* %94)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95) #0
+  unreachable
+
+; <label>:96                                      ; preds = %23, %79
+  %97 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %97, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %98
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %97, i32 0, i32 2
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  store %System.Text.StringBuilder addrspace(1)* %100, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %102 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %102, label %21, label %103
+
+; <label>:103                                     ; preds = %98
+  store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc7
+  %104 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  ret %System.String addrspace(1)* %104
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method StringBuilder::get_Length using LLILCJit
+Successfully read StringBuilder.get_Length
+
+define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
+Successfully read RuntimeHelpers.get_OffsetToStringData
+
+define i32 @RuntimeHelpers.get_OffsetToStringData() {
+entry:
+  ret i32 12
+}
+
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
 Successfully read CultureData.CreateCultureData
 
@@ -3514,23 +4249,23 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
   store i8 %4, i8 addrspace(1)* %6
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
@@ -3549,11 +4284,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3566,50 +4301,50 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
   store i32 -1, i32 addrspace(1)* %2
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
   store i32 -1, i32 addrspace(1)* %8
   %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
   store i32 -1, i32 addrspace(1)* %14
   %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
   store i32 -1, i32 addrspace(1)* %17
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
@@ -3623,27 +4358,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3675,7 +4410,136 @@ Failed to read Dictionary`2.Insert[non-const derefAddress]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
 Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
-Failed to read HashHelpers.GetPrime[loadElem]
+Successfully read HashHelpers.GetPrime
+
+define i32 @HashHelpers.GetPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %6, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5, %System.String addrspace(1)* %4)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5) #0
+  unreachable
+
+; <label>:6                                       ; preds = %entry
+  store i32 0, i32* %loc0
+  br label %29
+
+; <label>:7                                       ; preds = %35
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 1296
+  %10 = addrspacecast i8 addrspace(1)* %9 to %"System.Int32[]" addrspace(1)**
+  %11 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %10
+  %12 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Int32[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = zext i32 %15 to i64
+  %17 = zext i32 %12 to i64
+  %BoundsCheck = icmp uge i64 %17, %16
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 3, i32 %12
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  store i32 %20, i32* %loc1
+  %21 = load i32, i32* %loc1
+  %22 = load i32, i32* %arg0
+  %23 = icmp slt i32 %21, %22
+  br i1 %23, label %26, label %24
+
+; <label>:24                                      ; preds = %18
+  %25 = load i32, i32* %loc1
+  ret i32 %25
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %loc0
+  %28 = add i32 %27, 1
+  store i32 %28, i32* %loc0
+  br label %29
+
+; <label>:29                                      ; preds = %6, %26
+  %30 = load i32, i32* %loc0
+  %31 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %32 = getelementptr inbounds i8, i8 addrspace(1)* %31, i64 1296
+  %33 = addrspacecast i8 addrspace(1)* %32 to %"System.Int32[]" addrspace(1)**
+  %34 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %33
+  %NullCheck = icmp eq %"System.Int32[]" addrspace(1)* %34, null
+  br i1 %NullCheck, label %ThrowNullRef, label %35
+
+; <label>:35                                      ; preds = %29
+  %36 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %34, i32 0, i32 1
+  %37 = load i32, i32 addrspace(1)* %36
+  %38 = zext i32 %37 to i64
+  %39 = trunc i64 %38 to i32
+  %40 = icmp slt i32 %30, %39
+  br i1 %40, label %7, label %41
+
+; <label>:41                                      ; preds = %35
+  %42 = load i32, i32* %arg0
+  %43 = or i32 %42, 1
+  store i32 %43, i32* %loc2
+  br label %59
+
+; <label>:44                                      ; preds = %59
+  %45 = load i32, i32* %loc2
+  %46 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %45)
+  %47 = zext i8 %46 to i32
+  %48 = icmp eq i32 %47, 0
+  br i1 %48, label %56, label %49
+
+; <label>:49                                      ; preds = %44
+  %50 = load i32, i32* %loc2
+  %51 = sub i32 %50, 1
+  %52 = srem i32 %51, 101
+  %53 = icmp eq i32 %52, 0
+  br i1 %53, label %56, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = load i32, i32* %loc2
+  ret i32 %55
+
+; <label>:56                                      ; preds = %44, %49
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %57, 2
+  store i32 %58, i32* %loc2
+  br label %59
+
+; <label>:59                                      ; preds = %41, %56
+  %60 = load i32, i32* %loc2
+  %61 = icmp slt i32 %60, 2147483647
+  br i1 %61, label %44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load i32, i32* %arg0
+  ret i32 %63
+
+ThrowNullRef:                                     ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
 Successfully read GenericEqualityComparer`1.GetHashCode
 
@@ -3694,14 +4558,14 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
   %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load i64, i64 addrspace(1)* %7
@@ -3720,7 +4584,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3750,8 +4614,8 @@ entry:
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
@@ -3796,8 +4660,8 @@ entry:
   %35 = bitcast i16* %34 to i8*
   %36 = getelementptr inbounds i8, i8* %35, i64 2
   %37 = bitcast i8* %36 to i16*
-  %NullCheck4 = icmp ne i16* %37, null
-  br i1 %NullCheck4, label %38, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %37, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %38
 
 ; <label>:38                                      ; preds = %27
   %39 = load i16, i16* %37, align 8
@@ -3824,8 +4688,8 @@ entry:
 
 ; <label>:54                                      ; preds = %22, %43
   %55 = load i16*, i16** %loc4
-  %NullCheck2 = icmp ne i16* %55, null
-  br i1 %NullCheck2, label %56, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i16* %55, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %56
 
 ; <label>:56                                      ; preds = %54
   %57 = load i16, i16* %55, align 8
@@ -3850,11 +4714,11 @@ ThrowNullRef:                                     ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %54
+ThrowNullRef2:                                    ; preds = %54
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %27
+ThrowNullRef4:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3871,8 +4735,8 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -3907,8 +4771,8 @@ entry:
 
 ; <label>:26                                      ; preds = %19
   %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
-  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %28
 
 ; <label>:28                                      ; preds = %26
   %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
@@ -3920,7 +4784,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3972,8 +4836,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
@@ -3984,26 +4848,26 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
-  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
@@ -4014,8 +4878,8 @@ entry:
 ; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
@@ -4024,8 +4888,8 @@ entry:
 
 ; <label>:25                                      ; preds = %1, %16, %23
   %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
-  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
@@ -4036,27 +4900,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %20
+ThrowNullRef10:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4069,8 +4933,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -4081,8 +4945,8 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
@@ -4091,8 +4955,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1, %8
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
@@ -4103,11 +4967,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4128,24 +4992,24 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   store i32 %3, i32* %loc0
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
   %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
   store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck4, label %9, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
@@ -4164,15 +5028,15 @@ entry:
 ; <label>:18                                      ; preds = %70
   %19 = load i16*, i16** %loc3
   %20 = bitcast i16* %19 to i64*
-  %NullCheck10 = icmp ne i64* %20, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %20, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = load i64, i64* %20, align 8
   %23 = load i16*, i16** %loc4
   %24 = bitcast i16* %23 to i64*
-  %NullCheck12 = icmp ne i64* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = load i64, i64* %24, align 8
@@ -4188,8 +5052,8 @@ entry:
   %31 = bitcast i16* %30 to i8*
   %32 = getelementptr inbounds i8, i8* %31, i64 8
   %33 = bitcast i8* %32 to i64*
-  %NullCheck14 = icmp ne i64* %33, null
-  br i1 %NullCheck14, label %34, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = load i64, i64* %33, align 8
@@ -4197,8 +5061,8 @@ entry:
   %37 = bitcast i16* %36 to i8*
   %38 = getelementptr inbounds i8, i8* %37, i64 8
   %39 = bitcast i8* %38 to i64*
-  %NullCheck16 = icmp ne i64* %39, null
-  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %40
 
 ; <label>:40                                      ; preds = %34
   %41 = load i64, i64* %39, align 8
@@ -4214,8 +5078,8 @@ entry:
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %NullCheck18 = icmp ne i64* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = load i64, i64* %48, align 8
@@ -4223,8 +5087,8 @@ entry:
   %52 = bitcast i16* %51 to i8*
   %53 = getelementptr inbounds i8, i8* %52, i64 16
   %54 = bitcast i8* %53 to i64*
-  %NullCheck20 = icmp ne i64* %54, null
-  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64* %54, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %55
 
 ; <label>:55                                      ; preds = %49
   %56 = load i64, i64* %54, align 8
@@ -4262,15 +5126,15 @@ entry:
 ; <label>:74                                      ; preds = %95
   %75 = load i16*, i16** %loc3
   %76 = bitcast i16* %75 to i32*
-  %NullCheck6 = icmp ne i32* %76, null
-  br i1 %NullCheck6, label %77, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32* %76, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %77
 
 ; <label>:77                                      ; preds = %74
   %78 = load i32, i32* %76, align 8
   %79 = load i16*, i16** %loc4
   %80 = bitcast i16* %79 to i32*
-  %NullCheck8 = icmp ne i32* %80, null
-  br i1 %NullCheck8, label %81, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i32* %80, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %81
 
 ; <label>:81                                      ; preds = %77
   %82 = load i32, i32* %80, align 8
@@ -4318,43 +5182,43 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %74
+ThrowNullRef6:                                    ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %77
+ThrowNullRef8:                                    ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %29
+ThrowNullRef14:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %34
+ThrowNullRef16:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4376,8 +5240,8 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load i64, i64 addrspace(1)* %4
@@ -4389,8 +5253,8 @@ entry:
   %12 = load i64, i64* %11
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %5
   %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
@@ -4399,8 +5263,8 @@ entry:
   %18 = load i8, i8* %arg2
   %19 = zext i8 %18 to i32
   %20 = trunc i32 %19 to i8
-  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %15
   %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
@@ -4411,11 +5275,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4442,8 +5306,8 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
@@ -4466,16 +5330,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
   %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = load i64, i64 addrspace(1)* %19
@@ -4500,8 +5364,8 @@ entry:
 ; <label>:35                                      ; preds = %30
   %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
@@ -4514,8 +5378,8 @@ entry:
 
 ; <label>:42                                      ; preds = %1, %38
   %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
-  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
@@ -4526,19 +5390,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %35
+ThrowNullRef2:                                    ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %42
+ThrowNullRef8:                                    ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4551,14 +5415,14 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
@@ -4570,7 +5434,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4583,8 +5447,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
@@ -4613,51 +5477,51 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
   %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
   %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
   %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
   %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
-  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
   store i64 %21, i64 addrspace(1)* %23
   %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %25 = load i64, i64* %loc0
-  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
@@ -4668,27 +5532,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %22
+ThrowNullRef12:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4701,8 +5565,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
@@ -4713,19 +5577,19 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
@@ -4734,8 +5598,8 @@ entry:
 
 ; <label>:15                                      ; preds = %1, %13
   %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
@@ -4746,19 +5610,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %15
+ThrowNullRef8:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4771,8 +5635,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -4831,8 +5695,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
@@ -4882,8 +5746,8 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
-  br i1 %NullCheck, label %17, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %ThrowNullRef, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
@@ -4894,15 +5758,15 @@ entry:
 
 ; <label>:22                                      ; preds = %17
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
-  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
   %26 = load i32, i32 addrspace(1)* %25
   %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
-  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %27, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
@@ -4925,8 +5789,8 @@ entry:
 ; <label>:40                                      ; preds = %17
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
-  br i1 %NullCheck6, label %43, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %41, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
@@ -4938,34 +5802,17 @@ ThrowNullRef:                                     ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %24
+ThrowNullRef4:                                    ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %40
+ThrowNullRef6:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
-}
-
-INFO:  jitting method Object::ReferenceEquals using LLILCJit
-Successfully read Object.ReferenceEquals
-
-define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
-entry:
-  %arg0 = alloca %System.Object addrspace(1)*
-  %arg1 = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
-  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
-  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = icmp eq %System.Object addrspace(1)* %0, %1
-  %3 = sext i1 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
 }
 
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
@@ -4978,21 +5825,21 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
   %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
-  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
@@ -5007,28 +5854,28 @@ entry:
 ; <label>:13                                      ; preds = %8, %12
   %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
   %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
   %21 = load i32, i32 addrspace(1)* %20, align 8
   %22 = add i32 %21, 1
-  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
   store i32 %22, i32 addrspace(1)* %24
   %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
@@ -5039,27 +5886,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5077,7 +5924,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::Setup using LLILCJit
-Failed to read AppDomain.Setup[loadElem]
+Failed to read AppDomain.Setup[unbox]
 INFO:  jitting method Thread::GetDomain using LLILCJit
 Successfully read Thread.GetDomain
 
@@ -5108,8 +5955,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
@@ -5122,14 +5969,14 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
   %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
@@ -5141,11 +5988,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5173,8 +6020,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -5189,7 +6036,328 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
 Failed to read KeyCollection.System.Collections.Generic.IEnumerable<TKey>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Successfully read Enumerator.MoveNext
+
+define i8 @Enumerator.MoveNext(%"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.RuntimeTypeHandle* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*
+  %"$TypeArg" = alloca %System.RuntimeTypeHandle*
+  store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
+  %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 8
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %76, label %12
+
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
+  br label %76
+
+; <label>:13                                      ; preds = %85
+  %14 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck19 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %15
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, i32 0, i32 0
+  %17 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %16, align 8
+  %NullCheck21 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, i32 0, i32 2
+  %20 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %19, align 8
+  %21 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck23 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %22
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, i32 0, i32 2
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %NullCheck25 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 3, i32 %24
+  %NullCheck27 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %32
+
+; <label>:32                                      ; preds = %30
+  %33 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, i32 0, i32 2
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = icmp slt i32 %34, 0
+  br i1 %35, label %68, label %36
+
+; <label>:36                                      ; preds = %32
+  %37 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %38 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck29 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %39
+
+; <label>:39                                      ; preds = %36
+  %40 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, i32 0, i32 0
+  %41 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %40, align 8
+  %NullCheck31 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, i32 0, i32 2
+  %44 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %43, align 8
+  %45 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck33 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, i32 0, i32 2
+  %48 = load i32, i32 addrspace(1)* %47, align 8
+  %NullCheck35 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %49
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = zext i32 %51 to i64
+  %53 = zext i32 %48 to i64
+  %BoundsCheck37 = icmp uge i64 %53, %52
+  br i1 %BoundsCheck37, label %ThrowIndexOutOfRange38, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 3, i32 %48
+  %NullCheck39 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %56
+
+; <label>:56                                      ; preds = %54
+  %57 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, i32 0, i32 0
+  %58 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck41 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %59
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %60, %System.__Canon addrspace(1)* %58)
+  %61 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck43 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  %64 = load i32, i32 addrspace(1)* %63, align 8
+  %65 = add i32 %64, 1
+  %NullCheck45 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  store i32 %65, i32 addrspace(1)* %67
+  ret i8 1
+
+; <label>:68                                      ; preds = %32
+  %69 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck47 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %73 = add i32 %72, 1
+  %NullCheck49 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %74
+
+; <label>:74                                      ; preds = %70
+  %75 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  store i32 %73, i32 addrspace(1)* %75
+  br label %76
+
+; <label>:76                                      ; preds = %8, %12, %74
+  %77 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %78
+
+; <label>:78                                      ; preds = %76
+  %79 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, i32 0, i32 2
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck7 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %82
+
+; <label>:82                                      ; preds = %78
+  %83 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, i32 0, i32 0
+  %84 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %83, align 8
+  %NullCheck9 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %85
+
+; <label>:85                                      ; preds = %82
+  %86 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, i32 0, i32 7
+  %87 = load i32, i32 addrspace(1)* %86, align 8
+  %88 = icmp ult i32 %80, %87
+  br i1 %88, label %13, label %89
+
+; <label>:89                                      ; preds = %85
+  %90 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %91 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck11 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %92
+
+; <label>:92                                      ; preds = %89
+  %93 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, i32 0, i32 0
+  %94 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck13 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %95
+
+; <label>:95                                      ; preds = %92
+  %96 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, i32 0, i32 7
+  %97 = load i32, i32 addrspace(1)* %96, align 8
+  %98 = add i32 %97, 1
+  %NullCheck15 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %99
+
+; <label>:99                                      ; preds = %95
+  %100 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, i32 0, i32 2
+  store i32 %98, i32 addrspace(1)* %100
+  %101 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck17 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %102
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %103, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %92
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef22:                                   ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef24:                                   ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef26:                                   ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef28:                                   ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef30:                                   ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef32:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef34:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef36:                                   ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange38:                           ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef40:                                   ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef42:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef44:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef46:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef48:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef50:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -5200,8 +6368,8 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -5232,9 +6400,9 @@ Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
 Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
-Failed to read String.MakeSeparatorList[loadElemA]
+Failed to read String.MakeSeparatorList[storeElem]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
-Failed to read String.InternalSplitKeepEmptyEntries[loadElem]
+Failed to read String.InternalSplitKeepEmptyEntries[storeElem]
 INFO:  jitting method Path::IsRelative using LLILCJit
 Successfully read Path.IsRelative
 
@@ -5243,8 +6411,8 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -5254,8 +6422,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
@@ -5271,8 +6439,8 @@ entry:
 
 ; <label>:17                                      ; preds = %7
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
@@ -5288,8 +6456,8 @@ entry:
 
 ; <label>:29                                      ; preds = %19
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %31
 
 ; <label>:31                                      ; preds = %29
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
@@ -5300,8 +6468,8 @@ entry:
 
 ; <label>:36                                      ; preds = %31
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
-  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %37, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
@@ -5312,8 +6480,8 @@ entry:
 
 ; <label>:43                                      ; preds = %31, %38
   %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
-  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %45
 
 ; <label>:45                                      ; preds = %43
   %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
@@ -5324,8 +6492,8 @@ entry:
 
 ; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %50
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
@@ -5336,8 +6504,8 @@ entry:
 
 ; <label>:57                                      ; preds = %1, %7, %19, %45, %52
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
-  br i1 %NullCheck14, label %59, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %59
 
 ; <label>:59                                      ; preds = %57
   %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
@@ -5347,8 +6515,8 @@ entry:
 
 ; <label>:63                                      ; preds = %59
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
@@ -5359,8 +6527,8 @@ entry:
 
 ; <label>:70                                      ; preds = %65
   %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
-  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.String addrspace(1)* %71, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %72
 
 ; <label>:72                                      ; preds = %70
   %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
@@ -5379,39 +6547,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %17
+ThrowNullRef4:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %29
+ThrowNullRef6:                                    ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %36
+ThrowNullRef8:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %43
+ThrowNullRef10:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %50
+ThrowNullRef12:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %57
+ThrowNullRef14:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %63
+ThrowNullRef16:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %70
+ThrowNullRef18:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5419,7 +6587,293 @@ ThrowNullRef17:                                   ; preds = %70
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
-Failed to read String.TrimHelper[loadElem]
+Successfully read String.TrimHelper
+
+define %System.String addrspace(1)* @String.TrimHelper(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i16
+  %loc4 = alloca i32
+  %loc5 = alloca i16
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = sub i32 %3, 1
+  store i32 %4, i32* %loc0
+  store i32 0, i32* %loc1
+  %5 = load i32, i32* %arg2
+  %6 = icmp eq i32 %5, 1
+  br i1 %6, label %62, label %7
+
+; <label>:7                                       ; preds = %1
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:8                                       ; preds = %58
+  store i32 0, i32* %loc2
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load i32, i32* %loc1
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2, i32 %10
+  %13 = load i16, i16 addrspace(1)* %12
+  %14 = zext i16 %13 to i32
+  %15 = trunc i32 %14 to i16
+  store i16 %15, i16* %loc3
+  store i32 0, i32* %loc2
+  br label %34
+
+; <label>:16                                      ; preds = %37
+  %17 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %18 = load i32, i32* %loc2
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %17, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %19
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = zext i32 %18 to i64
+  %BoundsCheck = icmp uge i64 %23, %22
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %24
+
+; <label>:24                                      ; preds = %19
+  %25 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 3, i32 %18
+  %26 = load i16, i16 addrspace(1)* %25, align 8
+  %27 = zext i16 %26 to i32
+  %28 = load i16, i16* %loc3
+  %29 = zext i16 %28 to i32
+  %30 = icmp eq i32 %27, %29
+  br i1 %30, label %43, label %31
+
+; <label>:31                                      ; preds = %24
+  %32 = load i32, i32* %loc2
+  %33 = add i32 %32, 1
+  store i32 %33, i32* %loc2
+  br label %34
+
+; <label>:34                                      ; preds = %11, %31
+  %35 = load i32, i32* %loc2
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = icmp slt i32 %35, %41
+  br i1 %42, label %16, label %43
+
+; <label>:43                                      ; preds = %24, %37
+  %44 = load i32, i32* %loc2
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %45, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp eq i32 %44, %50
+  br i1 %51, label %62, label %52
+
+; <label>:52                                      ; preds = %46
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %7, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %57, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %58
+
+; <label>:58                                      ; preds = %55
+  %59 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %60 = load i32, i32 addrspace(1)* %59
+  %61 = icmp slt i32 %56, %60
+  br i1 %61, label %8, label %62
+
+; <label>:62                                      ; preds = %1, %46, %58
+  %63 = load i32, i32* %arg2
+  %64 = icmp eq i32 %63, 0
+  br i1 %64, label %122, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %66, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %67
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %66, i32 0, i32 1
+  %69 = load i32, i32 addrspace(1)* %68
+  %70 = sub i32 %69, 1
+  store i32 %70, i32* %loc0
+  br label %118
+
+; <label>:71                                      ; preds = %118
+  store i32 0, i32* %loc4
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %73 = load i32, i32* %loc0
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %74
+
+; <label>:74                                      ; preds = %71
+  %75 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 2, i32 %73
+  %76 = load i16, i16 addrspace(1)* %75
+  %77 = zext i16 %76 to i32
+  %78 = trunc i32 %77 to i16
+  store i16 %78, i16* %loc5
+  store i32 0, i32* %loc4
+  br label %97
+
+; <label>:79                                      ; preds = %100
+  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %81 = load i32, i32* %loc4
+  %NullCheck19 = icmp eq %"System.Char[]" addrspace(1)* %80, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
+
+; <label>:82                                      ; preds = %79
+  %83 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 1
+  %84 = load i32, i32 addrspace(1)* %83
+  %85 = zext i32 %84 to i64
+  %86 = zext i32 %81 to i64
+  %BoundsCheck21 = icmp uge i64 %86, %85
+  br i1 %BoundsCheck21, label %ThrowIndexOutOfRange22, label %87
+
+; <label>:87                                      ; preds = %82
+  %88 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 3, i32 %81
+  %89 = load i16, i16 addrspace(1)* %88, align 8
+  %90 = zext i16 %89 to i32
+  %91 = load i16, i16* %loc5
+  %92 = zext i16 %91 to i32
+  %93 = icmp eq i32 %90, %92
+  br i1 %93, label %106, label %94
+
+; <label>:94                                      ; preds = %87
+  %95 = load i32, i32* %loc4
+  %96 = add i32 %95, 1
+  store i32 %96, i32* %loc4
+  br label %97
+
+; <label>:97                                      ; preds = %74, %94
+  %98 = load i32, i32* %loc4
+  %99 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck15 = icmp eq %"System.Char[]" addrspace(1)* %99, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %100
+
+; <label>:100                                     ; preds = %97
+  %101 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %99, i32 0, i32 1
+  %102 = load i32, i32 addrspace(1)* %101
+  %103 = zext i32 %102 to i64
+  %104 = trunc i64 %103 to i32
+  %105 = icmp slt i32 %98, %104
+  br i1 %105, label %79, label %106
+
+; <label>:106                                     ; preds = %87, %100
+  %107 = load i32, i32* %loc4
+  %108 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck17 = icmp eq %"System.Char[]" addrspace(1)* %108, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %109
+
+; <label>:109                                     ; preds = %106
+  %110 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %108, i32 0, i32 1
+  %111 = load i32, i32 addrspace(1)* %110
+  %112 = zext i32 %111 to i64
+  %113 = trunc i64 %112 to i32
+  %114 = icmp eq i32 %107, %113
+  br i1 %114, label %122, label %115
+
+; <label>:115                                     ; preds = %109
+  %116 = load i32, i32* %loc0
+  %117 = sub i32 %116, 1
+  store i32 %117, i32* %loc0
+  br label %118
+
+; <label>:118                                     ; preds = %67, %115
+  %119 = load i32, i32* %loc0
+  %120 = load i32, i32* %loc1
+  %121 = icmp sge i32 %119, %120
+  br i1 %121, label %71, label %122
+
+; <label>:122                                     ; preds = %62, %109, %118
+  %123 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %124 = load i32, i32* %loc1
+  %125 = load i32, i32* %loc0
+  %126 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %123, i32 %124, i32 %125)
+  ret %System.String addrspace(1)* %126
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %97
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange22:                           ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
 Successfully read String.CreateTrimmedString
 
@@ -5439,8 +6893,8 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
@@ -5535,8 +6989,8 @@ entry:
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i64 2872
   %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
   %8 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %7
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %3
   %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
@@ -5553,8 +7007,8 @@ entry:
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 2864
   %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
   %21 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %20
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
-  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %22
 
 ; <label>:22                                      ; preds = %16
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
@@ -5569,7 +7023,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %16
+ThrowNullRef2:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5586,8 +7040,8 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5613,8 +7067,8 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
@@ -5632,8 +7086,8 @@ entry:
 
 ; <label>:12                                      ; preds = %4
   %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
@@ -5644,8 +7098,8 @@ entry:
 
 ; <label>:19                                      ; preds = %14
   %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %19
   %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
@@ -5660,21 +7114,21 @@ entry:
   %31 = zext i16 %30 to i32
   %32 = bitcast i8* %29 to i16*
   %33 = trunc i32 %31 to i16
-  %NullCheck6 = icmp ne i16* %32, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i16* %32, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %21
   store i16 %33, i16* %32, align 8
   %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %36
 
 ; <label>:36                                      ; preds = %34
   %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
   %38 = load i32, i32 addrspace(1)* %37, align 8
   %39 = add i32 %38, 1
-  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %40
 
 ; <label>:40                                      ; preds = %36
   %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
@@ -5683,16 +7137,16 @@ entry:
 
 ; <label>:42                                      ; preds = %14
   %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
-  br i1 %NullCheck12, label %44, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
   %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
   %47 = load i16, i16* %arg1
   %48 = zext i16 %47 to i32
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = trunc i32 %48 to i16
@@ -5703,31 +7157,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %19
+ThrowNullRef4:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %21
+ThrowNullRef6:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %36
+ThrowNullRef10:                                   ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %42
+ThrowNullRef12:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %44
+ThrowNullRef14:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5740,8 +7194,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -5752,8 +7206,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
@@ -5762,14 +7216,14 @@ entry:
 
 ; <label>:11                                      ; preds = %1
   %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
@@ -5779,15 +7233,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5808,8 +7262,8 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5822,8 +7276,8 @@ entry:
 
 ; <label>:8                                       ; preds = %3
   %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
@@ -5842,15 +7296,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
-  br i1 %NullCheck4, label %22, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
   %24 = load i16*, i16* addrspace(1)* %23, align 8
   %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %25, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
@@ -5859,8 +7313,8 @@ entry:
   store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
@@ -5874,8 +7328,8 @@ entry:
 
 ; <label>:37                                      ; preds = %65
   %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %37
   %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
@@ -5886,16 +7340,16 @@ entry:
   %45 = bitcast i16* %41 to i8*
   %46 = getelementptr inbounds i8, i8* %45, i64 %44
   %47 = bitcast i8* %46 to i16*
-  %NullCheck14 = icmp ne i16* %47, null
-  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %47, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %48
 
 ; <label>:48                                      ; preds = %39
   %49 = load i16, i16* %47, align 8
   %50 = zext i16 %49 to i32
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %52 = load i32, i32* %loc1
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %53
 
 ; <label>:53                                      ; preds = %48
   %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
@@ -5916,8 +7370,8 @@ entry:
 ; <label>:62                                      ; preds = %36, %59
   %63 = load i32, i32* %loc1
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck10, label %65, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %65
 
 ; <label>:65                                      ; preds = %62
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
@@ -5936,15 +7390,15 @@ entry:
 
 ; <label>:74                                      ; preds = %70
   %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
-  br i1 %NullCheck18, label %76, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %76
 
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
   %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
-  br i1 %NullCheck20, label %80, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
   %81 = load i64, i64 addrspace(1)* %79
@@ -5958,8 +7412,8 @@ entry:
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
   %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
-  br i1 %NullCheck22, label %92, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.String addrspace(1)* %90, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %92
 
 ; <label>:92                                      ; preds = %80
   %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
@@ -5969,15 +7423,15 @@ entry:
 
 ; <label>:96                                      ; preds = %70
   %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
-  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %98
 
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
   %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
-  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
   %103 = load i64, i64 addrspace(1)* %101
@@ -5991,8 +7445,8 @@ entry:
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
   %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
-  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.String addrspace(1)* %112, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %114
 
 ; <label>:114                                     ; preds = %102
   %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
@@ -6004,59 +7458,59 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %20
+ThrowNullRef4:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %22
+ThrowNullRef6:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %26
+ThrowNullRef8:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %62
+ThrowNullRef10:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %48
+ThrowNullRef16:                                   ; preds = %48
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %74
+ThrowNullRef18:                                   ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %76
+ThrowNullRef20:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %80
+ThrowNullRef22:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %96
+ThrowNullRef24:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %98
+ThrowNullRef26:                                   ; preds = %98
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %102
+ThrowNullRef28:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6069,15 +7523,15 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
   %3 = load i16*, i16* addrspace(1)* %2, align 8
   %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
@@ -6087,8 +7541,8 @@ entry:
   %10 = bitcast i16* %3 to i8*
   %11 = getelementptr inbounds i8, i8* %10, i64 %9
   %12 = bitcast i8* %11 to i16*
-  %NullCheck4 = icmp ne i16* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %5
   store i16 0, i16* %12, align 8
@@ -6098,11 +7552,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6119,8 +7573,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -6131,8 +7585,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
@@ -6144,15 +7598,15 @@ entry:
 
 ; <label>:14                                      ; preds = %1
   %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
   %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
   %21 = load i64, i64 addrspace(1)* %19
@@ -6171,15 +7625,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %14
+ThrowNullRef4:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %16
+ThrowNullRef6:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6302,14 +7756,6 @@ entry:
   ret %System.String addrspace(1)* %57
 }
 
-INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
-Successfully read RuntimeHelpers.get_OffsetToStringData
-
-define i32 @RuntimeHelpers.get_OffsetToStringData() {
-entry:
-  ret i32 12
-}
-
 INFO:  jitting method String::Equals using LLILCJit
 Successfully read String.Equals
 
@@ -6381,8 +7827,8 @@ entry:
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
-  br i1 %NullCheck24, label %29, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
   %30 = load i64, i64 addrspace(1)* %28
@@ -6397,8 +7843,8 @@ entry:
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
-  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
   %43 = load i64, i64 addrspace(1)* %41
@@ -6418,8 +7864,8 @@ entry:
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
   %59 = load i64, i64 addrspace(1)* %57
@@ -6434,8 +7880,8 @@ entry:
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck22, label %71, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
   %72 = load i64, i64 addrspace(1)* %70
@@ -6455,8 +7901,8 @@ entry:
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
-  br i1 %NullCheck16, label %87, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = load i64, i64 addrspace(1)* %86
@@ -6471,8 +7917,8 @@ entry:
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck18, label %100, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
   %101 = load i64, i64 addrspace(1)* %99
@@ -6492,8 +7938,8 @@ entry:
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
-  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
   %117 = load i64, i64 addrspace(1)* %115
@@ -6508,8 +7954,8 @@ entry:
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
-  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
   %130 = load i64, i64 addrspace(1)* %128
@@ -6528,15 +7974,15 @@ entry:
 
 ; <label>:142                                     ; preds = %22
   %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
-  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %143, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %144
 
 ; <label>:144                                     ; preds = %142
   %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
   %146 = load i32, i32 addrspace(1)* %145
   %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
-  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %147, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %148
 
 ; <label>:148                                     ; preds = %144
   %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
@@ -6557,15 +8003,15 @@ entry:
 
 ; <label>:159                                     ; preds = %22
   %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
-  br i1 %NullCheck, label %161, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %ThrowNullRef, label %161
 
 ; <label>:161                                     ; preds = %159
   %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
   %163 = load i32, i32 addrspace(1)* %162
   %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
-  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %164, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %165
 
 ; <label>:165                                     ; preds = %161
   %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
@@ -6578,8 +8024,8 @@ entry:
 
 ; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
-  br i1 %NullCheck4, label %172, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %171, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %172
 
 ; <label>:172                                     ; preds = %170
   %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
@@ -6589,8 +8035,8 @@ entry:
 
 ; <label>:176                                     ; preds = %172
   %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
-  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %177, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %178
 
 ; <label>:178                                     ; preds = %176
   %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
@@ -6629,55 +8075,55 @@ ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %161
+ThrowNullRef2:                                    ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %170
+ThrowNullRef4:                                    ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %176
+ThrowNullRef6:                                    ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %142
+ThrowNullRef8:                                    ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %144
+ThrowNullRef10:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %113
+ThrowNullRef12:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %116
+ThrowNullRef14:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %84
+ThrowNullRef16:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %87
+ThrowNullRef18:                                   ; preds = %87
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %55
+ThrowNullRef20:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %58
+ThrowNullRef22:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %26
+ThrowNullRef24:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %29
+ThrowNullRef26:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,8 +8161,8 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck, label %14, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %ThrowNullRef, label %14
 
 ; <label>:14                                      ; preds = %8
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
@@ -6760,8 +8206,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
@@ -6770,14 +8216,14 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32, i32* %loc0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %10
   %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
   %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
@@ -6790,15 +8236,15 @@ entry:
 ; <label>:25                                      ; preds = %19
   %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
-  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
   %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
@@ -6807,8 +8253,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %37 = load i32, i32* %loc0
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %38, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %38
 
 ; <label>:38                                      ; preds = %32
   %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
@@ -6817,14 +8263,14 @@ entry:
 
 ; <label>:40                                      ; preds = %19
   %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %40
   %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
   %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
-  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
-  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
@@ -6832,8 +8278,8 @@ entry:
   %48 = zext i32 %47 to i64
   %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
-  br i1 %NullCheck16, label %51, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %51
 
 ; <label>:51                                      ; preds = %45
   %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
@@ -6847,15 +8293,15 @@ entry:
 ; <label>:57                                      ; preds = %51
   %58 = load i16*, i16** %arg1
   %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
-  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %60
 
 ; <label>:60                                      ; preds = %57
   %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
   %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
-  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %64
 
 ; <label>:64                                      ; preds = %60
   %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
@@ -6864,22 +8310,22 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
   %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
-  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %70
 
 ; <label>:70                                      ; preds = %64
   %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
   %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
-  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
-  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
   %75 = load i32, i32 addrspace(1)* %74
   %76 = zext i32 %75 to i64
   %77 = trunc i64 %76 to i32
-  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
-  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %78
 
 ; <label>:78                                      ; preds = %73
   %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
@@ -6901,8 +8347,8 @@ entry:
   %90 = bitcast i16* %86 to i8*
   %91 = getelementptr inbounds i8, i8* %90, i64 %89
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %93
 
 ; <label>:93                                      ; preds = %80
   %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
@@ -6912,8 +8358,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %99 = load i32, i32* %loc2
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %100
 
 ; <label>:100                                     ; preds = %93
   %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
@@ -6928,63 +8374,63 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %25
+ThrowNullRef6:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %32
+ThrowNullRef10:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %40
+ThrowNullRef12:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %45
+ThrowNullRef16:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %57
+ThrowNullRef18:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %60
+ThrowNullRef20:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %64
+ThrowNullRef22:                                   ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %70
+ThrowNullRef24:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %73
+ThrowNullRef26:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %80
+ThrowNullRef28:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %93
+ThrowNullRef30:                                   ; preds = %93
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7004,8 +8450,8 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
@@ -7033,43 +8479,43 @@ entry:
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %14
   %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
   %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   %28 = load i32, i32 addrspace(1)* %27, align 8
   %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
-  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %30
 
 ; <label>:30                                      ; preds = %26
   %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
   %32 = load i32, i32 addrspace(1)* %31, align 8
   %33 = add i32 %28, %32
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %34
 
 ; <label>:34                                      ; preds = %30
   %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   store i32 %33, i32 addrspace(1)* %35
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
   store i32 0, i32 addrspace(1)* %38
   %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %40
 
 ; <label>:40                                      ; preds = %37
   %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
@@ -7082,8 +8528,8 @@ entry:
 
 ; <label>:47                                      ; preds = %40
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
@@ -7098,8 +8544,8 @@ entry:
   %54 = load i32, i32* %loc0
   %55 = sext i32 %54 to i64
   %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
-  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %57
 
 ; <label>:57                                      ; preds = %52
   %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
@@ -7110,68 +8556,35 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %14
+ThrowNullRef2:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %23
+ThrowNullRef4:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %26
+ThrowNullRef6:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %30
+ThrowNullRef8:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %34
+ThrowNullRef10:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %47
+ThrowNullRef14:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %52
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-}
-
-INFO:  jitting method StringBuilder::get_Length using LLILCJit
-Successfully read StringBuilder.get_Length
-
-define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.StringBuilder addrspace(1)*
-  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
-  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
-
-; <label>:1                                       ; preds = %entry
-  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %3 = load i32, i32 addrspace(1)* %2, align 8
-  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
-
-; <label>:5                                       ; preds = %1
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = add i32 %3, %7
-  ret i32 %8
-
-ThrowNullRef:                                     ; preds = %entry
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef16:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7213,70 +8626,70 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
   %6 = load i32, i32 addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
   store i32 %6, i32 addrspace(1)* %8
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
   %13 = load i32, i32 addrspace(1)* %12, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
   store i32 %13, i32 addrspace(1)* %15
   %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
-  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %18
 
 ; <label>:18                                      ; preds = %14
   %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
   %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
   %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
   %34 = load i32, i32 addrspace(1)* %33, align 8
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
-  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
@@ -7287,39 +8700,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %28
+ThrowNullRef16:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %32
+ThrowNullRef18:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7455,13 +8868,13 @@ entry:
 ; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
@@ -7477,16 +8890,16 @@ entry:
 
 ; <label>:18                                      ; preds = %15
   %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
   store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
   %22 = load i32, i32* %loc0
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %24
 
 ; <label>:24                                      ; preds = %20
   %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
@@ -7498,13 +8911,13 @@ entry:
 ; <label>:28                                      ; preds = %15, %24
   %29 = load i32, i32* %arg1
   %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %31
   %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
@@ -7517,20 +8930,20 @@ entry:
   %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
-  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
   %46 = load i32, i32 addrspace(1)* %45, align 8
   %47 = sub i32 %40, %46
-  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
-  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i32 addrspace(1)* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %48
 
 ; <label>:48                                      ; preds = %44
   store i32 %47, i32 addrspace(1)* %39, align 8
@@ -7538,21 +8951,21 @@ entry:
 
 ; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
-  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %51
 
 ; <label>:51                                      ; preds = %49
   %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %53
 
 ; <label>:53                                      ; preds = %51
   %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
   %55 = load i32, i32 addrspace(1)* %54, align 8
   %56 = load i32, i32* %arg2
   %57 = sub i32 %55, %56
-  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %58
 
 ; <label>:58                                      ; preds = %53
   %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
@@ -7562,13 +8975,13 @@ entry:
 ; <label>:60                                      ; preds = %33, %58
   %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
   %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
-  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %63
 
 ; <label>:63                                      ; preds = %60
   %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
-  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
-  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
@@ -7578,15 +8991,15 @@ entry:
 
 ; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
-  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i32 addrspace(1)* %69, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %70
 
 ; <label>:70                                      ; preds = %68
   %71 = load i32, i32 addrspace(1)* %69, align 8
   store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
-  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
@@ -7596,8 +9009,8 @@ entry:
   store i32 %77, i32* %loc4
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
-  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %80
 
 ; <label>:80                                      ; preds = %73
   %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
@@ -7607,71 +9020,71 @@ entry:
 ; <label>:83                                      ; preds = %80
   store i32 0, i32* %loc3
   %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
-  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
-  br i1 %NullCheck26, label %88, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i32 addrspace(1)* %87, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %88
 
 ; <label>:88                                      ; preds = %85
   %89 = load i32, i32 addrspace(1)* %87, align 8
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
-  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %90
 
 ; <label>:90                                      ; preds = %88
   %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
   store i32 %89, i32 addrspace(1)* %91
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
-  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
-  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %96
 
 ; <label>:96                                      ; preds = %94
   %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
-  br i1 %NullCheck34, label %100, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %100
 
 ; <label>:100                                     ; preds = %96
   %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
-  br i1 %NullCheck36, label %102, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %102
 
 ; <label>:102                                     ; preds = %100
   %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
   %104 = load i32, i32 addrspace(1)* %103, align 8
   %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
-  br i1 %NullCheck38, label %106, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %106
 
 ; <label>:106                                     ; preds = %102
   %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
-  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
-  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %108
 
 ; <label>:108                                     ; preds = %106
   %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
   %110 = load i32, i32 addrspace(1)* %109, align 8
   %111 = add i32 %104, %110
-  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %112
 
 ; <label>:112                                     ; preds = %108
   %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
   store i32 %111, i32 addrspace(1)* %113
   %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
-  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i32 addrspace(1)* %114, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %115
 
 ; <label>:115                                     ; preds = %112
   %116 = load i32, i32 addrspace(1)* %114, align 8
@@ -7681,19 +9094,19 @@ entry:
 ; <label>:118                                     ; preds = %115
   %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
-  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %121
 
 ; <label>:121                                     ; preds = %118
   %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
-  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
-  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %123
 
 ; <label>:123                                     ; preds = %121
   %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
   %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
-  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
-  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %126
 
 ; <label>:126                                     ; preds = %123
   %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
@@ -7705,8 +9118,8 @@ entry:
 
 ; <label>:130                                     ; preds = %80, %115, %126
   %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %132
 
 ; <label>:132                                     ; preds = %130
   %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7715,8 +9128,8 @@ entry:
   %136 = load i32, i32* %loc3
   %137 = sub i32 %135, %136
   %138 = sub i32 %134, %137
-  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %139
 
 ; <label>:139                                     ; preds = %132
   %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7728,16 +9141,16 @@ entry:
 
 ; <label>:144                                     ; preds = %139
   %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
-  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %146
 
 ; <label>:146                                     ; preds = %144
   %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
   %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
   %149 = load i32, i32* %loc2
   %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
-  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %151
 
 ; <label>:151                                     ; preds = %146
   %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
@@ -7754,145 +9167,249 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %18
+ThrowNullRef4:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %31
+ThrowNullRef10:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %44
+ThrowNullRef16:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %68
+ThrowNullRef18:                                   ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %70
+ThrowNullRef20:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %73
+ThrowNullRef22:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %83
+ThrowNullRef24:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %85
+ThrowNullRef26:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %88
+ThrowNullRef28:                                   ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %90
+ThrowNullRef30:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %94
+ThrowNullRef32:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %96
+ThrowNullRef34:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %100
+ThrowNullRef36:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %102
+ThrowNullRef38:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %106
+ThrowNullRef40:                                   ; preds = %106
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %108
+ThrowNullRef42:                                   ; preds = %108
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %112
+ThrowNullRef44:                                   ; preds = %112
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %118
+ThrowNullRef46:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %121
+ThrowNullRef48:                                   ; preds = %121
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %123
+ThrowNullRef50:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %130
+ThrowNullRef52:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %132
+ThrowNullRef54:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %144
+ThrowNullRef56:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %146
+ThrowNullRef58:                                   ; preds = %146
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %60
+ThrowNullRef60:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %63
+ThrowNullRef62:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %49
+ThrowNullRef64:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %51
+ThrowNullRef66:                                   ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %53
+ThrowNullRef68:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(%"System.Char[]" addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %arg0 = alloca %"System.Char[]" addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store %"System.Char[]" addrspace(1)* %param0, %"System.Char[]" addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load i32, i32* %arg4
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %43, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %38, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg1
+  %13 = load i32, i32* %arg4
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %38, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %24 = load i32, i32* %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %35 = load i32, i32* %arg3
+  %36 = load i32, i32* %arg4
+  %37 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %37, %"System.Char[]" addrspace(1)* %34, i32 %35, i32 %36)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:38                                      ; preds = %5, %16
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Successfully read Buffer._Memmove
 
@@ -7914,7 +9431,7 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[loadElem]
+Failed to read AppDomain.SetDataHelper[storeElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -7923,8 +9440,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
@@ -7934,8 +9451,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
@@ -7947,15 +9464,15 @@ entry:
   %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
   %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
@@ -7966,15 +9483,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7992,7 +9509,79 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
-Failed to read Dictionary`2.TryGetValue[loadElemA]
+Successfully read Dictionary`2.TryGetValue
+
+define i8 @"Dictionary`2.TryGetValue"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)* addrspace(1)* %param2) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  %arg2 = alloca %System.__Canon addrspace(1)* addrspace(1)*
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  store %System.__Canon addrspace(1)* addrspace(1)* %param2, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  store i32 %2, i32* %loc0
+  %3 = load i32, i32* %loc0
+  %4 = icmp slt i32 %3, 0
+  br i1 %4, label %22, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 2
+  %10 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %9, align 8
+  %11 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = zext i32 %11 to i64
+  %BoundsCheck = icmp uge i64 %16, %15
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 3, i32 %11
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %20, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %6, %System.__Canon addrspace(1)* %21)
+  ret i8 1
+
+; <label>:22                                      ; preds = %entry
+  %23 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %23, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -8058,8 +9647,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
@@ -8091,8 +9680,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
@@ -8171,15 +9760,15 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck, label %19, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %ThrowNullRef, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
   %21 = load i32, i32 addrspace(1)* %20
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
@@ -8202,7 +9791,7 @@ ThrowNullRef:                                     ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %19
+ThrowNullRef2:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8248,8 +9837,8 @@ entry:
   %0 = alloca %System.AppDomainHandle
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %1 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %1, i32 0, i32 15
@@ -8269,8 +9858,8 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
@@ -8286,7 +9875,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -8299,8 +9888,8 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -8327,8 +9916,8 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
@@ -8352,8 +9941,8 @@ entry:
   %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
   store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
@@ -8363,8 +9952,8 @@ entry:
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
@@ -8374,8 +9963,8 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %9
   %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
@@ -8384,8 +9973,8 @@ entry:
 
 ; <label>:18                                      ; preds = %3, %16
   %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
@@ -8397,15 +9986,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %18
+ThrowNullRef6:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8418,8 +10007,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
@@ -8453,15 +10042,15 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
@@ -8473,7 +10062,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8481,7 +10070,7 @@ ThrowNullRef1:                                    ; preds = %1
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
 Failed to read Dictionary`2.System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
@@ -8506,8 +10095,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
@@ -8524,8 +10113,8 @@ entry:
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -8544,7 +10133,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8577,8 +10166,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = load i64, i64* %arg2
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = trunc i32 %3 to i8
@@ -8634,46 +10223,46 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
   %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
-  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
-  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
-  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
@@ -8684,27 +10273,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %20
+ThrowNullRef12:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8717,8 +10306,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -8756,22 +10345,22 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
   %9 = load i64, i64 addrspace(1)* %8, align 8
   %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
   %13 = load i64, i64 addrspace(1)* %12, align 8
   %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %11
   %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
@@ -8788,11 +10377,11 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8882,8 +10471,8 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
@@ -8900,8 +10489,8 @@ entry:
 ; <label>:8                                       ; preds = %1
   %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
   %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
@@ -8911,15 +10500,15 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
   %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
   %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
-  br i1 %NullCheck6, label %21, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
@@ -8946,15 +10535,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8992,15 +10581,15 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
   store i8 %3, i8 addrspace(1)* %5
   %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
@@ -9011,7 +10600,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9027,8 +10616,8 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -9041,8 +10630,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
@@ -9058,7 +10647,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9080,8 +10669,8 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
@@ -9096,8 +10685,8 @@ entry:
 ; <label>:12                                      ; preds = %6
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
@@ -9112,8 +10701,8 @@ entry:
 ; <label>:21                                      ; preds = %15
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
@@ -9128,8 +10717,8 @@ entry:
 ; <label>:30                                      ; preds = %24
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %31, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
@@ -9144,8 +10733,8 @@ entry:
 ; <label>:39                                      ; preds = %33
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
-  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %40, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %42
 
 ; <label>:42                                      ; preds = %39
   %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
@@ -9164,19 +10753,19 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %21
+ThrowNullRef4:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %30
+ThrowNullRef6:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %39
+ThrowNullRef8:                                    ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9243,8 +10832,8 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
@@ -9264,57 +10853,57 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
   store i8 0, i8 addrspace(1)* %2
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
   store i8 0, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
   store i8 0, i8 addrspace(1)* %17
   %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
   store i8 0, i8 addrspace(1)* %20
   %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
-  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
@@ -9325,31 +10914,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %19
+ThrowNullRef14:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9367,8 +10956,8 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
@@ -9380,8 +10969,8 @@ entry:
 
 ; <label>:9                                       ; preds = %4
   %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %9
   %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
@@ -9395,7 +10984,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef2:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9420,8 +11009,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
@@ -9512,8 +11101,8 @@ entry:
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
@@ -9524,8 +11113,8 @@ entry:
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = load i64, i64 addrspace(1)* %12
@@ -9537,8 +11126,8 @@ entry:
   %20 = load i64, i64* %19
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
-  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %13
   %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
@@ -9555,8 +11144,8 @@ entry:
 ; <label>:30                                      ; preds = %25
   %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %32 = load i32, i32* %arg2
-  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
-  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
@@ -9570,15 +11159,15 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %30
+ThrowNullRef2:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9622,87 +11211,87 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
   %10 = load i8, i8 addrspace(1)* %9, align 8
   %11 = zext i8 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %8
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
   store i8 %12, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
   %19 = load i8, i8 addrspace(1)* %18, align 8
   %20 = zext i8 %19 to i32
   %21 = trunc i32 %20 to i8
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
   store i8 %21, i8 addrspace(1)* %23
   %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
   %28 = load i8, i8 addrspace(1)* %27, align 8
   %29 = zext i8 %28 to i32
   %30 = trunc i32 %29 to i8
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
-  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %31
 
 ; <label>:31                                      ; preds = %26
   %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
   store i8 %30, i8 addrspace(1)* %32
   %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
-  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
-  br i1 %NullCheck14, label %40, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %40
 
 ; <label>:40                                      ; preds = %35
   %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
   store i8 %39, i8 addrspace(1)* %41
   %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
-  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %44
 
 ; <label>:44                                      ; preds = %40
   %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
   %46 = load i8, i8 addrspace(1)* %45, align 8
   %47 = zext i8 %46 to i32
   %48 = trunc i32 %47 to i8
-  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
   store i8 %48, i8 addrspace(1)* %50
   %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
-  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
@@ -9713,29 +11302,29 @@ entry:
 ; <label>:56                                      ; preds = %52
   %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
-  br i1 %NullCheck22, label %59, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
   %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
   %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
-  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
-  br i1 %NullCheck24, label %63, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
   %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
-  br i1 %NullCheck26, label %66, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
   %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
-  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
-  br i1 %NullCheck28, label %69, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %69
 
 ; <label>:69                                      ; preds = %66
   %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
@@ -9744,15 +11333,15 @@ entry:
 
 ; <label>:71                                      ; preds = %105
   %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
-  br i1 %NullCheck34, label %73, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %73
 
 ; <label>:73                                      ; preds = %71
   %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
   %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
   %76 = load i32, i32* %loc0
-  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
-  br i1 %NullCheck36, label %77, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
@@ -9766,8 +11355,8 @@ entry:
 
 ; <label>:83                                      ; preds = %77
   %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
-  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
@@ -9775,14 +11364,14 @@ entry:
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
   %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
-  br i1 %NullCheck40, label %91, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
 ; <label>:91                                      ; preds = %85
   %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
   %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
-  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck42, label %94, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %94
 
 ; <label>:94                                      ; preds = %91
   %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
@@ -9798,14 +11387,14 @@ entry:
 ; <label>:99                                      ; preds = %69, %96
   %100 = load i32, i32* %loc0
   %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
-  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %102
 
 ; <label>:102                                     ; preds = %99
   %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
   %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
-  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
-  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
@@ -9819,87 +11408,87 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %26
+ThrowNullRef10:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %31
+ThrowNullRef12:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %35
+ThrowNullRef14:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %40
+ThrowNullRef16:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %56
+ThrowNullRef22:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %59
+ThrowNullRef24:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %63
+ThrowNullRef26:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %66
+ThrowNullRef28:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %102
+ThrowNullRef32:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %71
+ThrowNullRef34:                                   ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %73
+ThrowNullRef36:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %83
+ThrowNullRef38:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %85
+ThrowNullRef40:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %91
+ThrowNullRef42:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9943,15 +11532,15 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
   %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
@@ -9961,28 +11550,28 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
   %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %12
   %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
   %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
   %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
-  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
@@ -9993,23 +11582,23 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %12
+ThrowNullRef6:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10031,15 +11620,15 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
   %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = load i64, i64 addrspace(1)* %7
@@ -10077,13 +11666,13 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[loadElem]
+Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -10111,8 +11700,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueGeDbl.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueGeDbl.error.txt
@@ -25,8 +25,8 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
@@ -40,8 +40,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
   %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
@@ -75,7 +75,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -90,8 +90,8 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %NullCheck = icmp ne i8 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = load i8, i8 addrspace(1)* %0, align 8
@@ -125,8 +125,8 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
@@ -159,8 +159,8 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -184,8 +184,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
   store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
@@ -195,8 +195,8 @@ entry:
 ; <label>:4                                       ; preds = %1
   %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
   %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
@@ -206,8 +206,8 @@ entry:
   %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
@@ -221,14 +221,14 @@ entry:
 
 ; <label>:17                                      ; preds = %14
   %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
   %21 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
@@ -238,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -249,8 +249,8 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
@@ -261,27 +261,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %30
+ThrowNullRef10:                                   ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -301,7 +301,89 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
-Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
+Successfully read AppDomainSetup.GetUnsecureApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.GetUnsecureApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %NullCheck = icmp eq %"System.String[]" addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %BoundsCheck = icmp uge i64 0, %5
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %6
+
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 3, i32 0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
+  ret %System.String addrspace(1)* %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_Value using LLILCJit
+Successfully read AppDomainSetup.get_Value
+
+define %"System.String[]" addrspace(1)* @AppDomainSetup.get_Value(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.String[]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 18)
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.String[]" addrspace(1)* addrspace(1)*, %"System.String[]" addrspace(1)*)*)(%"System.String[]" addrspace(1)* addrspace(1)* %9, %"System.String[]" addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %11, i32 0, i32 1
+  %14 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %13, align 8
+  ret %"System.String[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -319,8 +401,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -368,16 +450,16 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
   %5 = load i32, i32 addrspace(1)* %4
   %6 = sub i32 %5, 1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -389,7 +471,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -421,8 +503,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
@@ -456,8 +538,8 @@ entry:
 ; <label>:27                                      ; preds = %19
   %28 = load i32, i32* %arg1
   %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
-  br i1 %NullCheck2, label %30, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %29, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %30
 
 ; <label>:30                                      ; preds = %27
   %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
@@ -493,8 +575,8 @@ entry:
 ; <label>:49                                      ; preds = %46
   %50 = load i32, i32* %arg2
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck4, label %52, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
@@ -517,11 +599,11 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %27
+ThrowNullRef2:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %49
+ThrowNullRef4:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -544,16 +626,16 @@ entry:
   %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %0)
   store %System.String addrspace(1)* %1, %System.String addrspace(1)** %loc0
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 2
   %5 = bitcast [0 x i16] addrspace(1)* %4 to i16 addrspace(1)*
   store i16 addrspace(1)* %5, i16 addrspace(1)** %loc1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %3
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2
@@ -580,7 +662,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -691,15 +773,15 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %NullCheck132 = icmp ne i8* %21, null
-  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+  %NullCheck131 = icmp eq i8* %21, null
+  br i1 %NullCheck131, label %ThrowNullRef132, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = load i8, i8* %21, align 8
   %24 = zext i8 %23 to i32
   %25 = trunc i32 %24 to i8
-  %NullCheck134 = icmp ne i8* %20, null
-  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+  %NullCheck133 = icmp eq i8* %20, null
+  br i1 %NullCheck133, label %ThrowNullRef134, label %26
 
 ; <label>:26                                      ; preds = %22
   store i8 %25, i8* %20, align 8
@@ -709,16 +791,16 @@ entry:
   %28 = load i8*, i8** %arg0
   %29 = load i8*, i8** %arg1
   %30 = bitcast i8* %29 to i16*
-  %NullCheck128 = icmp ne i16* %30, null
-  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+  %NullCheck127 = icmp eq i16* %30, null
+  br i1 %NullCheck127, label %ThrowNullRef128, label %31
 
 ; <label>:31                                      ; preds = %27
   %32 = load i16, i16* %30, align 8
   %33 = sext i16 %32 to i32
   %34 = bitcast i8* %28 to i16*
   %35 = trunc i32 %33 to i16
-  %NullCheck130 = icmp ne i16* %34, null
-  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+  %NullCheck129 = icmp eq i16* %34, null
+  br i1 %NullCheck129, label %ThrowNullRef130, label %36
 
 ; <label>:36                                      ; preds = %31
   store i16 %35, i16* %34, align 8
@@ -728,16 +810,16 @@ entry:
   %38 = load i8*, i8** %arg0
   %39 = load i8*, i8** %arg1
   %40 = bitcast i8* %39 to i16*
-  %NullCheck120 = icmp ne i16* %40, null
-  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+  %NullCheck119 = icmp eq i16* %40, null
+  br i1 %NullCheck119, label %ThrowNullRef120, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i16, i16* %40, align 8
   %43 = sext i16 %42 to i32
   %44 = bitcast i8* %38 to i16*
   %45 = trunc i32 %43 to i16
-  %NullCheck122 = icmp ne i16* %44, null
-  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+  %NullCheck121 = icmp eq i16* %44, null
+  br i1 %NullCheck121, label %ThrowNullRef122, label %46
 
 ; <label>:46                                      ; preds = %41
   store i16 %45, i16* %44, align 8
@@ -745,15 +827,15 @@ entry:
   %48 = getelementptr inbounds i8, i8* %47, i64 2
   %49 = load i8*, i8** %arg1
   %50 = getelementptr inbounds i8, i8* %49, i64 2
-  %NullCheck124 = icmp ne i8* %50, null
-  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+  %NullCheck123 = icmp eq i8* %50, null
+  br i1 %NullCheck123, label %ThrowNullRef124, label %51
 
 ; <label>:51                                      ; preds = %46
   %52 = load i8, i8* %50, align 8
   %53 = zext i8 %52 to i32
   %54 = trunc i32 %53 to i8
-  %NullCheck126 = icmp ne i8* %48, null
-  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+  %NullCheck125 = icmp eq i8* %48, null
+  br i1 %NullCheck125, label %ThrowNullRef126, label %55
 
 ; <label>:55                                      ; preds = %51
   store i8 %54, i8* %48, align 8
@@ -763,14 +845,14 @@ entry:
   %57 = load i8*, i8** %arg0
   %58 = load i8*, i8** %arg1
   %59 = bitcast i8* %58 to i32*
-  %NullCheck116 = icmp ne i32* %59, null
-  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+  %NullCheck115 = icmp eq i32* %59, null
+  br i1 %NullCheck115, label %ThrowNullRef116, label %60
 
 ; <label>:60                                      ; preds = %56
   %61 = load i32, i32* %59, align 8
   %62 = bitcast i8* %57 to i32*
-  %NullCheck118 = icmp ne i32* %62, null
-  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+  %NullCheck117 = icmp eq i32* %62, null
+  br i1 %NullCheck117, label %ThrowNullRef118, label %63
 
 ; <label>:63                                      ; preds = %60
   store i32 %61, i32* %62, align 8
@@ -780,14 +862,14 @@ entry:
   %65 = load i8*, i8** %arg0
   %66 = load i8*, i8** %arg1
   %67 = bitcast i8* %66 to i32*
-  %NullCheck108 = icmp ne i32* %67, null
-  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+  %NullCheck107 = icmp eq i32* %67, null
+  br i1 %NullCheck107, label %ThrowNullRef108, label %68
 
 ; <label>:68                                      ; preds = %64
   %69 = load i32, i32* %67, align 8
   %70 = bitcast i8* %65 to i32*
-  %NullCheck110 = icmp ne i32* %70, null
-  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+  %NullCheck109 = icmp eq i32* %70, null
+  br i1 %NullCheck109, label %ThrowNullRef110, label %71
 
 ; <label>:71                                      ; preds = %68
   store i32 %69, i32* %70, align 8
@@ -795,15 +877,15 @@ entry:
   %73 = getelementptr inbounds i8, i8* %72, i64 4
   %74 = load i8*, i8** %arg1
   %75 = getelementptr inbounds i8, i8* %74, i64 4
-  %NullCheck112 = icmp ne i8* %75, null
-  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+  %NullCheck111 = icmp eq i8* %75, null
+  br i1 %NullCheck111, label %ThrowNullRef112, label %76
 
 ; <label>:76                                      ; preds = %71
   %77 = load i8, i8* %75, align 8
   %78 = zext i8 %77 to i32
   %79 = trunc i32 %78 to i8
-  %NullCheck114 = icmp ne i8* %73, null
-  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+  %NullCheck113 = icmp eq i8* %73, null
+  br i1 %NullCheck113, label %ThrowNullRef114, label %80
 
 ; <label>:80                                      ; preds = %76
   store i8 %79, i8* %73, align 8
@@ -813,14 +895,14 @@ entry:
   %82 = load i8*, i8** %arg0
   %83 = load i8*, i8** %arg1
   %84 = bitcast i8* %83 to i32*
-  %NullCheck100 = icmp ne i32* %84, null
-  br i1 %NullCheck100, label %85, label %ThrowNullRef99
+  %NullCheck99 = icmp eq i32* %84, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %85
 
 ; <label>:85                                      ; preds = %81
   %86 = load i32, i32* %84, align 8
   %87 = bitcast i8* %82 to i32*
-  %NullCheck102 = icmp ne i32* %87, null
-  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+  %NullCheck101 = icmp eq i32* %87, null
+  br i1 %NullCheck101, label %ThrowNullRef102, label %88
 
 ; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
@@ -829,16 +911,16 @@ entry:
   %91 = load i8*, i8** %arg1
   %92 = getelementptr inbounds i8, i8* %91, i64 4
   %93 = bitcast i8* %92 to i16*
-  %NullCheck104 = icmp ne i16* %93, null
-  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+  %NullCheck103 = icmp eq i16* %93, null
+  br i1 %NullCheck103, label %ThrowNullRef104, label %94
 
 ; <label>:94                                      ; preds = %88
   %95 = load i16, i16* %93, align 8
   %96 = sext i16 %95 to i32
   %97 = bitcast i8* %90 to i16*
   %98 = trunc i32 %96 to i16
-  %NullCheck106 = icmp ne i16* %97, null
-  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+  %NullCheck105 = icmp eq i16* %97, null
+  br i1 %NullCheck105, label %ThrowNullRef106, label %99
 
 ; <label>:99                                      ; preds = %94
   store i16 %98, i16* %97, align 8
@@ -848,14 +930,14 @@ entry:
   %101 = load i8*, i8** %arg0
   %102 = load i8*, i8** %arg1
   %103 = bitcast i8* %102 to i32*
-  %NullCheck88 = icmp ne i32* %103, null
-  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+  %NullCheck87 = icmp eq i32* %103, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %104
 
 ; <label>:104                                     ; preds = %100
   %105 = load i32, i32* %103, align 8
   %106 = bitcast i8* %101 to i32*
-  %NullCheck90 = icmp ne i32* %106, null
-  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+  %NullCheck89 = icmp eq i32* %106, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %107
 
 ; <label>:107                                     ; preds = %104
   store i32 %105, i32* %106, align 8
@@ -864,16 +946,16 @@ entry:
   %110 = load i8*, i8** %arg1
   %111 = getelementptr inbounds i8, i8* %110, i64 4
   %112 = bitcast i8* %111 to i16*
-  %NullCheck92 = icmp ne i16* %112, null
-  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+  %NullCheck91 = icmp eq i16* %112, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %113
 
 ; <label>:113                                     ; preds = %107
   %114 = load i16, i16* %112, align 8
   %115 = sext i16 %114 to i32
   %116 = bitcast i8* %109 to i16*
   %117 = trunc i32 %115 to i16
-  %NullCheck94 = icmp ne i16* %116, null
-  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+  %NullCheck93 = icmp eq i16* %116, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %118
 
 ; <label>:118                                     ; preds = %113
   store i16 %117, i16* %116, align 8
@@ -881,15 +963,15 @@ entry:
   %120 = getelementptr inbounds i8, i8* %119, i64 6
   %121 = load i8*, i8** %arg1
   %122 = getelementptr inbounds i8, i8* %121, i64 6
-  %NullCheck96 = icmp ne i8* %122, null
-  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+  %NullCheck95 = icmp eq i8* %122, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %123
 
 ; <label>:123                                     ; preds = %118
   %124 = load i8, i8* %122, align 8
   %125 = zext i8 %124 to i32
   %126 = trunc i32 %125 to i8
-  %NullCheck98 = icmp ne i8* %120, null
-  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+  %NullCheck97 = icmp eq i8* %120, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %127
 
 ; <label>:127                                     ; preds = %123
   store i8 %126, i8* %120, align 8
@@ -899,14 +981,14 @@ entry:
   %129 = load i8*, i8** %arg0
   %130 = load i8*, i8** %arg1
   %131 = bitcast i8* %130 to i64*
-  %NullCheck84 = icmp ne i64* %131, null
-  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+  %NullCheck83 = icmp eq i64* %131, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %132
 
 ; <label>:132                                     ; preds = %128
   %133 = load i64, i64* %131, align 8
   %134 = bitcast i8* %129 to i64*
-  %NullCheck86 = icmp ne i64* %134, null
-  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+  %NullCheck85 = icmp eq i64* %134, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %135
 
 ; <label>:135                                     ; preds = %132
   store i64 %133, i64* %134, align 8
@@ -916,14 +998,14 @@ entry:
   %137 = load i8*, i8** %arg0
   %138 = load i8*, i8** %arg1
   %139 = bitcast i8* %138 to i64*
-  %NullCheck76 = icmp ne i64* %139, null
-  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+  %NullCheck75 = icmp eq i64* %139, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %140
 
 ; <label>:140                                     ; preds = %136
   %141 = load i64, i64* %139, align 8
   %142 = bitcast i8* %137 to i64*
-  %NullCheck78 = icmp ne i64* %142, null
-  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+  %NullCheck77 = icmp eq i64* %142, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %143
 
 ; <label>:143                                     ; preds = %140
   store i64 %141, i64* %142, align 8
@@ -931,15 +1013,15 @@ entry:
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %NullCheck80 = icmp ne i8* %147, null
-  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+  %NullCheck79 = icmp eq i8* %147, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %148
 
 ; <label>:148                                     ; preds = %143
   %149 = load i8, i8* %147, align 8
   %150 = zext i8 %149 to i32
   %151 = trunc i32 %150 to i8
-  %NullCheck82 = icmp ne i8* %145, null
-  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+  %NullCheck81 = icmp eq i8* %145, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %152
 
 ; <label>:152                                     ; preds = %148
   store i8 %151, i8* %145, align 8
@@ -949,14 +1031,14 @@ entry:
   %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
   %156 = bitcast i8* %155 to i64*
-  %NullCheck68 = icmp ne i64* %156, null
-  br i1 %NullCheck68, label %157, label %ThrowNullRef67
+  %NullCheck67 = icmp eq i64* %156, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %157
 
 ; <label>:157                                     ; preds = %153
   %158 = load i64, i64* %156, align 8
   %159 = bitcast i8* %154 to i64*
-  %NullCheck70 = icmp ne i64* %159, null
-  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+  %NullCheck69 = icmp eq i64* %159, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %160
 
 ; <label>:160                                     ; preds = %157
   store i64 %158, i64* %159, align 8
@@ -965,16 +1047,16 @@ entry:
   %163 = load i8*, i8** %arg1
   %164 = getelementptr inbounds i8, i8* %163, i64 8
   %165 = bitcast i8* %164 to i16*
-  %NullCheck72 = icmp ne i16* %165, null
-  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+  %NullCheck71 = icmp eq i16* %165, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %166
 
 ; <label>:166                                     ; preds = %160
   %167 = load i16, i16* %165, align 8
   %168 = sext i16 %167 to i32
   %169 = bitcast i8* %162 to i16*
   %170 = trunc i32 %168 to i16
-  %NullCheck74 = icmp ne i16* %169, null
-  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+  %NullCheck73 = icmp eq i16* %169, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %171
 
 ; <label>:171                                     ; preds = %166
   store i16 %170, i16* %169, align 8
@@ -984,14 +1066,14 @@ entry:
   %173 = load i8*, i8** %arg0
   %174 = load i8*, i8** %arg1
   %175 = bitcast i8* %174 to i64*
-  %NullCheck56 = icmp ne i64* %175, null
-  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+  %NullCheck55 = icmp eq i64* %175, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %176
 
 ; <label>:176                                     ; preds = %172
   %177 = load i64, i64* %175, align 8
   %178 = bitcast i8* %173 to i64*
-  %NullCheck58 = icmp ne i64* %178, null
-  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+  %NullCheck57 = icmp eq i64* %178, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %179
 
 ; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
@@ -1000,16 +1082,16 @@ entry:
   %182 = load i8*, i8** %arg1
   %183 = getelementptr inbounds i8, i8* %182, i64 8
   %184 = bitcast i8* %183 to i16*
-  %NullCheck60 = icmp ne i16* %184, null
-  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+  %NullCheck59 = icmp eq i16* %184, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %185
 
 ; <label>:185                                     ; preds = %179
   %186 = load i16, i16* %184, align 8
   %187 = sext i16 %186 to i32
   %188 = bitcast i8* %181 to i16*
   %189 = trunc i32 %187 to i16
-  %NullCheck62 = icmp ne i16* %188, null
-  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+  %NullCheck61 = icmp eq i16* %188, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %190
 
 ; <label>:190                                     ; preds = %185
   store i16 %189, i16* %188, align 8
@@ -1017,15 +1099,15 @@ entry:
   %192 = getelementptr inbounds i8, i8* %191, i64 10
   %193 = load i8*, i8** %arg1
   %194 = getelementptr inbounds i8, i8* %193, i64 10
-  %NullCheck64 = icmp ne i8* %194, null
-  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+  %NullCheck63 = icmp eq i8* %194, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %195
 
 ; <label>:195                                     ; preds = %190
   %196 = load i8, i8* %194, align 8
   %197 = zext i8 %196 to i32
   %198 = trunc i32 %197 to i8
-  %NullCheck66 = icmp ne i8* %192, null
-  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+  %NullCheck65 = icmp eq i8* %192, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %199
 
 ; <label>:199                                     ; preds = %195
   store i8 %198, i8* %192, align 8
@@ -1035,14 +1117,14 @@ entry:
   %201 = load i8*, i8** %arg0
   %202 = load i8*, i8** %arg1
   %203 = bitcast i8* %202 to i64*
-  %NullCheck48 = icmp ne i64* %203, null
-  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+  %NullCheck47 = icmp eq i64* %203, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %204
 
 ; <label>:204                                     ; preds = %200
   %205 = load i64, i64* %203, align 8
   %206 = bitcast i8* %201 to i64*
-  %NullCheck50 = icmp ne i64* %206, null
-  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+  %NullCheck49 = icmp eq i64* %206, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %207
 
 ; <label>:207                                     ; preds = %204
   store i64 %205, i64* %206, align 8
@@ -1051,14 +1133,14 @@ entry:
   %210 = load i8*, i8** %arg1
   %211 = getelementptr inbounds i8, i8* %210, i64 8
   %212 = bitcast i8* %211 to i32*
-  %NullCheck52 = icmp ne i32* %212, null
-  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+  %NullCheck51 = icmp eq i32* %212, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %213
 
 ; <label>:213                                     ; preds = %207
   %214 = load i32, i32* %212, align 8
   %215 = bitcast i8* %209 to i32*
-  %NullCheck54 = icmp ne i32* %215, null
-  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+  %NullCheck53 = icmp eq i32* %215, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %216
 
 ; <label>:216                                     ; preds = %213
   store i32 %214, i32* %215, align 8
@@ -1068,14 +1150,14 @@ entry:
   %218 = load i8*, i8** %arg0
   %219 = load i8*, i8** %arg1
   %220 = bitcast i8* %219 to i64*
-  %NullCheck36 = icmp ne i64* %220, null
-  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64* %220, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %221
 
 ; <label>:221                                     ; preds = %217
   %222 = load i64, i64* %220, align 8
   %223 = bitcast i8* %218 to i64*
-  %NullCheck38 = icmp ne i64* %223, null
-  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+  %NullCheck37 = icmp eq i64* %223, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %224
 
 ; <label>:224                                     ; preds = %221
   store i64 %222, i64* %223, align 8
@@ -1084,14 +1166,14 @@ entry:
   %227 = load i8*, i8** %arg1
   %228 = getelementptr inbounds i8, i8* %227, i64 8
   %229 = bitcast i8* %228 to i32*
-  %NullCheck40 = icmp ne i32* %229, null
-  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i32* %229, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %230
 
 ; <label>:230                                     ; preds = %224
   %231 = load i32, i32* %229, align 8
   %232 = bitcast i8* %226 to i32*
-  %NullCheck42 = icmp ne i32* %232, null
-  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+  %NullCheck41 = icmp eq i32* %232, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %233
 
 ; <label>:233                                     ; preds = %230
   store i32 %231, i32* %232, align 8
@@ -1099,15 +1181,15 @@ entry:
   %235 = getelementptr inbounds i8, i8* %234, i64 12
   %236 = load i8*, i8** %arg1
   %237 = getelementptr inbounds i8, i8* %236, i64 12
-  %NullCheck44 = icmp ne i8* %237, null
-  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i8* %237, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %238
 
 ; <label>:238                                     ; preds = %233
   %239 = load i8, i8* %237, align 8
   %240 = zext i8 %239 to i32
   %241 = trunc i32 %240 to i8
-  %NullCheck46 = icmp ne i8* %235, null
-  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+  %NullCheck45 = icmp eq i8* %235, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %242
 
 ; <label>:242                                     ; preds = %238
   store i8 %241, i8* %235, align 8
@@ -1117,14 +1199,14 @@ entry:
   %244 = load i8*, i8** %arg0
   %245 = load i8*, i8** %arg1
   %246 = bitcast i8* %245 to i64*
-  %NullCheck24 = icmp ne i64* %246, null
-  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64* %246, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %247
 
 ; <label>:247                                     ; preds = %243
   %248 = load i64, i64* %246, align 8
   %249 = bitcast i8* %244 to i64*
-  %NullCheck26 = icmp ne i64* %249, null
-  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64* %249, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %250
 
 ; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
@@ -1133,14 +1215,14 @@ entry:
   %253 = load i8*, i8** %arg1
   %254 = getelementptr inbounds i8, i8* %253, i64 8
   %255 = bitcast i8* %254 to i32*
-  %NullCheck28 = icmp ne i32* %255, null
-  br i1 %NullCheck28, label %256, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i32* %255, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %256
 
 ; <label>:256                                     ; preds = %250
   %257 = load i32, i32* %255, align 8
   %258 = bitcast i8* %252 to i32*
-  %NullCheck30 = icmp ne i32* %258, null
-  br i1 %NullCheck30, label %259, label %ThrowNullRef29
+  %NullCheck29 = icmp eq i32* %258, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %259
 
 ; <label>:259                                     ; preds = %256
   store i32 %257, i32* %258, align 8
@@ -1149,16 +1231,16 @@ entry:
   %262 = load i8*, i8** %arg1
   %263 = getelementptr inbounds i8, i8* %262, i64 12
   %264 = bitcast i8* %263 to i16*
-  %NullCheck32 = icmp ne i16* %264, null
-  br i1 %NullCheck32, label %265, label %ThrowNullRef31
+  %NullCheck31 = icmp eq i16* %264, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %265
 
 ; <label>:265                                     ; preds = %259
   %266 = load i16, i16* %264, align 8
   %267 = sext i16 %266 to i32
   %268 = bitcast i8* %261 to i16*
   %269 = trunc i32 %267 to i16
-  %NullCheck34 = icmp ne i16* %268, null
-  br i1 %NullCheck34, label %270, label %ThrowNullRef33
+  %NullCheck33 = icmp eq i16* %268, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %270
 
 ; <label>:270                                     ; preds = %265
   store i16 %269, i16* %268, align 8
@@ -1168,14 +1250,14 @@ entry:
   %272 = load i8*, i8** %arg0
   %273 = load i8*, i8** %arg1
   %274 = bitcast i8* %273 to i64*
-  %NullCheck8 = icmp ne i64* %274, null
-  br i1 %NullCheck8, label %275, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64* %274, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %275
 
 ; <label>:275                                     ; preds = %271
   %276 = load i64, i64* %274, align 8
   %277 = bitcast i8* %272 to i64*
-  %NullCheck10 = icmp ne i64* %277, null
-  br i1 %NullCheck10, label %278, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %277, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %278
 
 ; <label>:278                                     ; preds = %275
   store i64 %276, i64* %277, align 8
@@ -1184,14 +1266,14 @@ entry:
   %281 = load i8*, i8** %arg1
   %282 = getelementptr inbounds i8, i8* %281, i64 8
   %283 = bitcast i8* %282 to i32*
-  %NullCheck12 = icmp ne i32* %283, null
-  br i1 %NullCheck12, label %284, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i32* %283, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %284
 
 ; <label>:284                                     ; preds = %278
   %285 = load i32, i32* %283, align 8
   %286 = bitcast i8* %280 to i32*
-  %NullCheck14 = icmp ne i32* %286, null
-  br i1 %NullCheck14, label %287, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i32* %286, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %287
 
 ; <label>:287                                     ; preds = %284
   store i32 %285, i32* %286, align 8
@@ -1200,16 +1282,16 @@ entry:
   %290 = load i8*, i8** %arg1
   %291 = getelementptr inbounds i8, i8* %290, i64 12
   %292 = bitcast i8* %291 to i16*
-  %NullCheck16 = icmp ne i16* %292, null
-  br i1 %NullCheck16, label %293, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i16* %292, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %293
 
 ; <label>:293                                     ; preds = %287
   %294 = load i16, i16* %292, align 8
   %295 = sext i16 %294 to i32
   %296 = bitcast i8* %289 to i16*
   %297 = trunc i32 %295 to i16
-  %NullCheck18 = icmp ne i16* %296, null
-  br i1 %NullCheck18, label %298, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i16* %296, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %298
 
 ; <label>:298                                     ; preds = %293
   store i16 %297, i16* %296, align 8
@@ -1217,15 +1299,15 @@ entry:
   %300 = getelementptr inbounds i8, i8* %299, i64 14
   %301 = load i8*, i8** %arg1
   %302 = getelementptr inbounds i8, i8* %301, i64 14
-  %NullCheck20 = icmp ne i8* %302, null
-  br i1 %NullCheck20, label %303, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i8* %302, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %303
 
 ; <label>:303                                     ; preds = %298
   %304 = load i8, i8* %302, align 8
   %305 = zext i8 %304 to i32
   %306 = trunc i32 %305 to i8
-  %NullCheck22 = icmp ne i8* %300, null
-  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i8* %300, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %307
 
 ; <label>:307                                     ; preds = %303
   store i8 %306, i8* %300, align 8
@@ -1235,14 +1317,14 @@ entry:
   %309 = load i8*, i8** %arg0
   %310 = load i8*, i8** %arg1
   %311 = bitcast i8* %310 to i64*
-  %NullCheck = icmp ne i64* %311, null
-  br i1 %NullCheck, label %312, label %ThrowNullRef
+  %NullCheck = icmp eq i64* %311, null
+  br i1 %NullCheck, label %ThrowNullRef, label %312
 
 ; <label>:312                                     ; preds = %308
   %313 = load i64, i64* %311, align 8
   %314 = bitcast i8* %309 to i64*
-  %NullCheck2 = icmp ne i64* %314, null
-  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64* %314, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %315
 
 ; <label>:315                                     ; preds = %312
   store i64 %313, i64* %314, align 8
@@ -1251,14 +1333,14 @@ entry:
   %318 = load i8*, i8** %arg1
   %319 = getelementptr inbounds i8, i8* %318, i64 8
   %320 = bitcast i8* %319 to i64*
-  %NullCheck4 = icmp ne i64* %320, null
-  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64* %320, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %321
 
 ; <label>:321                                     ; preds = %315
   %322 = load i64, i64* %320, align 8
   %323 = bitcast i8* %317 to i64*
-  %NullCheck6 = icmp ne i64* %323, null
-  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64* %323, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %324
 
 ; <label>:324                                     ; preds = %321
   store i64 %322, i64* %323, align 8
@@ -1286,15 +1368,15 @@ entry:
 ; <label>:338                                     ; preds = %333
   %339 = load i8*, i8** %arg0
   %340 = load i8*, i8** %arg1
-  %NullCheck136 = icmp ne i8* %340, null
-  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+  %NullCheck135 = icmp eq i8* %340, null
+  br i1 %NullCheck135, label %ThrowNullRef136, label %341
 
 ; <label>:341                                     ; preds = %338
   %342 = load i8, i8* %340, align 8
   %343 = zext i8 %342 to i32
   %344 = trunc i32 %343 to i8
-  %NullCheck138 = icmp ne i8* %339, null
-  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+  %NullCheck137 = icmp eq i8* %339, null
+  br i1 %NullCheck137, label %ThrowNullRef138, label %345
 
 ; <label>:345                                     ; preds = %341
   store i8 %344, i8* %339, align 8
@@ -1317,16 +1399,16 @@ entry:
   %357 = load i8*, i8** %arg0
   %358 = load i8*, i8** %arg1
   %359 = bitcast i8* %358 to i16*
-  %NullCheck140 = icmp ne i16* %359, null
-  br i1 %NullCheck140, label %360, label %ThrowNullRef139
+  %NullCheck139 = icmp eq i16* %359, null
+  br i1 %NullCheck139, label %ThrowNullRef140, label %360
 
 ; <label>:360                                     ; preds = %356
   %361 = load i16, i16* %359, align 8
   %362 = sext i16 %361 to i32
   %363 = bitcast i8* %357 to i16*
   %364 = trunc i32 %362 to i16
-  %NullCheck142 = icmp ne i16* %363, null
-  br i1 %NullCheck142, label %365, label %ThrowNullRef141
+  %NullCheck141 = icmp eq i16* %363, null
+  br i1 %NullCheck141, label %ThrowNullRef142, label %365
 
 ; <label>:365                                     ; preds = %360
   store i16 %364, i16* %363, align 8
@@ -1352,14 +1434,14 @@ entry:
   %378 = load i8*, i8** %arg0
   %379 = load i8*, i8** %arg1
   %380 = bitcast i8* %379 to i32*
-  %NullCheck144 = icmp ne i32* %380, null
-  br i1 %NullCheck144, label %381, label %ThrowNullRef143
+  %NullCheck143 = icmp eq i32* %380, null
+  br i1 %NullCheck143, label %ThrowNullRef144, label %381
 
 ; <label>:381                                     ; preds = %377
   %382 = load i32, i32* %380, align 8
   %383 = bitcast i8* %378 to i32*
-  %NullCheck146 = icmp ne i32* %383, null
-  br i1 %NullCheck146, label %384, label %ThrowNullRef145
+  %NullCheck145 = icmp eq i32* %383, null
+  br i1 %NullCheck145, label %ThrowNullRef146, label %384
 
 ; <label>:384                                     ; preds = %381
   store i32 %382, i32* %383, align 8
@@ -1384,14 +1466,14 @@ entry:
   %395 = load i8*, i8** %arg0
   %396 = load i8*, i8** %arg1
   %397 = bitcast i8* %396 to i64*
-  %NullCheck164 = icmp ne i64* %397, null
-  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+  %NullCheck163 = icmp eq i64* %397, null
+  br i1 %NullCheck163, label %ThrowNullRef164, label %398
 
 ; <label>:398                                     ; preds = %394
   %399 = load i64, i64* %397, align 8
   %400 = bitcast i8* %395 to i64*
-  %NullCheck166 = icmp ne i64* %400, null
-  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+  %NullCheck165 = icmp eq i64* %400, null
+  br i1 %NullCheck165, label %ThrowNullRef166, label %401
 
 ; <label>:401                                     ; preds = %398
   store i64 %399, i64* %400, align 8
@@ -1400,14 +1482,14 @@ entry:
   %404 = load i8*, i8** %arg1
   %405 = getelementptr inbounds i8, i8* %404, i64 8
   %406 = bitcast i8* %405 to i64*
-  %NullCheck168 = icmp ne i64* %406, null
-  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+  %NullCheck167 = icmp eq i64* %406, null
+  br i1 %NullCheck167, label %ThrowNullRef168, label %407
 
 ; <label>:407                                     ; preds = %401
   %408 = load i64, i64* %406, align 8
   %409 = bitcast i8* %403 to i64*
-  %NullCheck170 = icmp ne i64* %409, null
-  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+  %NullCheck169 = icmp eq i64* %409, null
+  br i1 %NullCheck169, label %ThrowNullRef170, label %410
 
 ; <label>:410                                     ; preds = %407
   store i64 %408, i64* %409, align 8
@@ -1437,14 +1519,14 @@ entry:
   %425 = load i8*, i8** %arg0
   %426 = load i8*, i8** %arg1
   %427 = bitcast i8* %426 to i64*
-  %NullCheck148 = icmp ne i64* %427, null
-  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+  %NullCheck147 = icmp eq i64* %427, null
+  br i1 %NullCheck147, label %ThrowNullRef148, label %428
 
 ; <label>:428                                     ; preds = %424
   %429 = load i64, i64* %427, align 8
   %430 = bitcast i8* %425 to i64*
-  %NullCheck150 = icmp ne i64* %430, null
-  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+  %NullCheck149 = icmp eq i64* %430, null
+  br i1 %NullCheck149, label %ThrowNullRef150, label %431
 
 ; <label>:431                                     ; preds = %428
   store i64 %429, i64* %430, align 8
@@ -1466,14 +1548,14 @@ entry:
   %441 = load i8*, i8** %arg0
   %442 = load i8*, i8** %arg1
   %443 = bitcast i8* %442 to i32*
-  %NullCheck152 = icmp ne i32* %443, null
-  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+  %NullCheck151 = icmp eq i32* %443, null
+  br i1 %NullCheck151, label %ThrowNullRef152, label %444
 
 ; <label>:444                                     ; preds = %440
   %445 = load i32, i32* %443, align 8
   %446 = bitcast i8* %441 to i32*
-  %NullCheck154 = icmp ne i32* %446, null
-  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+  %NullCheck153 = icmp eq i32* %446, null
+  br i1 %NullCheck153, label %ThrowNullRef154, label %447
 
 ; <label>:447                                     ; preds = %444
   store i32 %445, i32* %446, align 8
@@ -1495,16 +1577,16 @@ entry:
   %457 = load i8*, i8** %arg0
   %458 = load i8*, i8** %arg1
   %459 = bitcast i8* %458 to i16*
-  %NullCheck156 = icmp ne i16* %459, null
-  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+  %NullCheck155 = icmp eq i16* %459, null
+  br i1 %NullCheck155, label %ThrowNullRef156, label %460
 
 ; <label>:460                                     ; preds = %456
   %461 = load i16, i16* %459, align 8
   %462 = sext i16 %461 to i32
   %463 = bitcast i8* %457 to i16*
   %464 = trunc i32 %462 to i16
-  %NullCheck158 = icmp ne i16* %463, null
-  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+  %NullCheck157 = icmp eq i16* %463, null
+  br i1 %NullCheck157, label %ThrowNullRef158, label %465
 
 ; <label>:465                                     ; preds = %460
   store i16 %464, i16* %463, align 8
@@ -1525,15 +1607,15 @@ entry:
 ; <label>:474                                     ; preds = %470
   %475 = load i8*, i8** %arg0
   %476 = load i8*, i8** %arg1
-  %NullCheck160 = icmp ne i8* %476, null
-  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+  %NullCheck159 = icmp eq i8* %476, null
+  br i1 %NullCheck159, label %ThrowNullRef160, label %477
 
 ; <label>:477                                     ; preds = %474
   %478 = load i8, i8* %476, align 8
   %479 = zext i8 %478 to i32
   %480 = trunc i32 %479 to i8
-  %NullCheck162 = icmp ne i8* %475, null
-  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+  %NullCheck161 = icmp eq i8* %475, null
+  br i1 %NullCheck161, label %ThrowNullRef162, label %481
 
 ; <label>:481                                     ; preds = %477
   store i8 %480, i8* %475, align 8
@@ -1553,343 +1635,343 @@ ThrowNullRef:                                     ; preds = %308
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %312
+ThrowNullRef2:                                    ; preds = %312
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %315
+ThrowNullRef4:                                    ; preds = %315
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %321
+ThrowNullRef6:                                    ; preds = %321
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %271
+ThrowNullRef8:                                    ; preds = %271
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %275
+ThrowNullRef10:                                   ; preds = %275
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %278
+ThrowNullRef12:                                   ; preds = %278
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %284
+ThrowNullRef14:                                   ; preds = %284
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %287
+ThrowNullRef16:                                   ; preds = %287
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %293
+ThrowNullRef18:                                   ; preds = %293
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %298
+ThrowNullRef20:                                   ; preds = %298
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %303
+ThrowNullRef22:                                   ; preds = %303
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %243
+ThrowNullRef24:                                   ; preds = %243
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %247
+ThrowNullRef26:                                   ; preds = %247
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %250
+ThrowNullRef28:                                   ; preds = %250
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %256
+ThrowNullRef30:                                   ; preds = %256
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %259
+ThrowNullRef32:                                   ; preds = %259
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %265
+ThrowNullRef34:                                   ; preds = %265
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %217
+ThrowNullRef36:                                   ; preds = %217
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %221
+ThrowNullRef38:                                   ; preds = %221
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %224
+ThrowNullRef40:                                   ; preds = %224
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %230
+ThrowNullRef42:                                   ; preds = %230
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %233
+ThrowNullRef44:                                   ; preds = %233
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %238
+ThrowNullRef46:                                   ; preds = %238
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %200
+ThrowNullRef48:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %204
+ThrowNullRef50:                                   ; preds = %204
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %207
+ThrowNullRef52:                                   ; preds = %207
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %213
+ThrowNullRef54:                                   ; preds = %213
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %172
+ThrowNullRef56:                                   ; preds = %172
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %176
+ThrowNullRef58:                                   ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %179
+ThrowNullRef60:                                   ; preds = %179
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %185
+ThrowNullRef62:                                   ; preds = %185
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %190
+ThrowNullRef64:                                   ; preds = %190
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %195
+ThrowNullRef66:                                   ; preds = %195
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %153
+ThrowNullRef68:                                   ; preds = %153
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %157
+ThrowNullRef70:                                   ; preds = %157
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %160
+ThrowNullRef72:                                   ; preds = %160
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %166
+ThrowNullRef74:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %136
+ThrowNullRef76:                                   ; preds = %136
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %140
+ThrowNullRef78:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %143
+ThrowNullRef80:                                   ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %148
+ThrowNullRef82:                                   ; preds = %148
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %128
+ThrowNullRef84:                                   ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %132
+ThrowNullRef86:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %100
+ThrowNullRef88:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %104
+ThrowNullRef90:                                   ; preds = %104
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %107
+ThrowNullRef92:                                   ; preds = %107
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %113
+ThrowNullRef94:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %118
+ThrowNullRef96:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %123
+ThrowNullRef98:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %81
+ThrowNullRef100:                                  ; preds = %81
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef101:                                  ; preds = %85
+ThrowNullRef102:                                  ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef103:                                  ; preds = %88
+ThrowNullRef104:                                  ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef105:                                  ; preds = %94
+ThrowNullRef106:                                  ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef107:                                  ; preds = %64
+ThrowNullRef108:                                  ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef109:                                  ; preds = %68
+ThrowNullRef110:                                  ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef111:                                  ; preds = %71
+ThrowNullRef112:                                  ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef113:                                  ; preds = %76
+ThrowNullRef114:                                  ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef115:                                  ; preds = %56
+ThrowNullRef116:                                  ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef117:                                  ; preds = %60
+ThrowNullRef118:                                  ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef119:                                  ; preds = %37
+ThrowNullRef120:                                  ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef121:                                  ; preds = %41
+ThrowNullRef122:                                  ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef123:                                  ; preds = %46
+ThrowNullRef124:                                  ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef125:                                  ; preds = %51
+ThrowNullRef126:                                  ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef127:                                  ; preds = %27
+ThrowNullRef128:                                  ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef129:                                  ; preds = %31
+ThrowNullRef130:                                  ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef131:                                  ; preds = %19
+ThrowNullRef132:                                  ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef133:                                  ; preds = %22
+ThrowNullRef134:                                  ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef135:                                  ; preds = %338
+ThrowNullRef136:                                  ; preds = %338
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef137:                                  ; preds = %341
+ThrowNullRef138:                                  ; preds = %341
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef139:                                  ; preds = %356
+ThrowNullRef140:                                  ; preds = %356
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef141:                                  ; preds = %360
+ThrowNullRef142:                                  ; preds = %360
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef143:                                  ; preds = %377
+ThrowNullRef144:                                  ; preds = %377
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef145:                                  ; preds = %381
+ThrowNullRef146:                                  ; preds = %381
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef147:                                  ; preds = %424
+ThrowNullRef148:                                  ; preds = %424
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef149:                                  ; preds = %428
+ThrowNullRef150:                                  ; preds = %428
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef151:                                  ; preds = %440
+ThrowNullRef152:                                  ; preds = %440
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef153:                                  ; preds = %444
+ThrowNullRef154:                                  ; preds = %444
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef155:                                  ; preds = %456
+ThrowNullRef156:                                  ; preds = %456
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef157:                                  ; preds = %460
+ThrowNullRef158:                                  ; preds = %460
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef159:                                  ; preds = %474
+ThrowNullRef160:                                  ; preds = %474
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef161:                                  ; preds = %477
+ThrowNullRef162:                                  ; preds = %477
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef163:                                  ; preds = %394
+ThrowNullRef164:                                  ; preds = %394
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef165:                                  ; preds = %398
+ThrowNullRef166:                                  ; preds = %398
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef167:                                  ; preds = %401
+ThrowNullRef168:                                  ; preds = %401
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef169:                                  ; preds = %407
+ThrowNullRef170:                                  ; preds = %407
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1939,8 +2021,8 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
-  br i1 %NullCheck, label %22, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %ThrowNullRef, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
@@ -1948,8 +2030,8 @@ entry:
   store i32 %24, i32* %loc0
   %25 = load i32, i32* %loc0
   %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %26, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %27
 
 ; <label>:27                                      ; preds = %22
   %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
@@ -1971,7 +2053,7 @@ ThrowNullRef:                                     ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1989,8 +2071,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -2022,15 +2104,15 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2048,16 +2130,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
   %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
   store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %15
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
@@ -2072,8 +2154,8 @@ entry:
   %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
   %29 = ptrtoint i16 addrspace(1)* %28 to i64
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %19
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
@@ -2089,19 +2171,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2114,8 +2196,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
@@ -2128,7 +2210,7 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[loadElem]
+Failed to read AppDomain.PrepareDataForSetup[storeElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
@@ -2202,8 +2284,8 @@ entry:
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
-  br i1 %NullCheck24, label %27, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = load i64, i64 addrspace(1)* %26
@@ -2218,8 +2300,8 @@ entry:
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
-  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
   %41 = load i64, i64 addrspace(1)* %39
@@ -2236,8 +2318,8 @@ entry:
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
-  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
   %54 = load i64, i64 addrspace(1)* %52
@@ -2252,8 +2334,8 @@ entry:
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
   %67 = load i64, i64 addrspace(1)* %65
@@ -2270,8 +2352,8 @@ entry:
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
-  br i1 %NullCheck16, label %79, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
   %80 = load i64, i64 addrspace(1)* %78
@@ -2286,8 +2368,8 @@ entry:
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
-  br i1 %NullCheck18, label %92, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
   %93 = load i64, i64 addrspace(1)* %91
@@ -2304,8 +2386,8 @@ entry:
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
-  br i1 %NullCheck12, label %105, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = load i64, i64 addrspace(1)* %104
@@ -2320,8 +2402,8 @@ entry:
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
-  br i1 %NullCheck14, label %118, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
   %119 = load i64, i64 addrspace(1)* %117
@@ -2337,8 +2419,8 @@ entry:
 
 ; <label>:128                                     ; preds = %20
   %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
-  br i1 %NullCheck4, label %130, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %129, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %130
 
 ; <label>:130                                     ; preds = %128
   %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
@@ -2346,8 +2428,8 @@ entry:
   %133 = load i16, i16 addrspace(1)* %132, align 8
   %134 = zext i16 %133 to i32
   %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
-  br i1 %NullCheck6, label %136, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %135, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %136
 
 ; <label>:136                                     ; preds = %130
   %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
@@ -2360,8 +2442,8 @@ entry:
 
 ; <label>:143                                     ; preds = %136
   %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
-  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %144, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %145
 
 ; <label>:145                                     ; preds = %143
   %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
@@ -2369,8 +2451,8 @@ entry:
   %148 = load i16, i16 addrspace(1)* %147, align 8
   %149 = zext i16 %148 to i32
   %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %150, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %151
 
 ; <label>:151                                     ; preds = %145
   %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
@@ -2388,8 +2470,8 @@ entry:
 
 ; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
-  br i1 %NullCheck, label %163, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %ThrowNullRef, label %163
 
 ; <label>:163                                     ; preds = %161
   %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
@@ -2399,8 +2481,8 @@ entry:
 
 ; <label>:167                                     ; preds = %163
   %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
-  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %168, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %169
 
 ; <label>:169                                     ; preds = %167
   %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
@@ -2432,55 +2514,55 @@ ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %167
+ThrowNullRef2:                                    ; preds = %167
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %128
+ThrowNullRef4:                                    ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %130
+ThrowNullRef6:                                    ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %143
+ThrowNullRef8:                                    ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %145
+ThrowNullRef10:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %102
+ThrowNullRef12:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %105
+ThrowNullRef14:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %76
+ThrowNullRef16:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %79
+ThrowNullRef18:                                   ; preds = %79
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %50
+ThrowNullRef20:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %53
+ThrowNullRef22:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %24
+ThrowNullRef24:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %27
+ThrowNullRef26:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2503,15 +2585,15 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2519,16 +2601,16 @@ entry:
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
   store i32 %8, i32* %loc0
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
   %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
   store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
@@ -2546,16 +2628,16 @@ entry:
 
 ; <label>:23                                      ; preds = %64
   %24 = load i16*, i16** %loc3
-  %NullCheck12 = icmp ne i16* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i16* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
   store i32 %27, i32* %loc5
   %28 = load i16*, i16** %loc4
-  %NullCheck14 = icmp ne i16* %28, null
-  br i1 %NullCheck14, label %29, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %28, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = load i16, i16* %28, align 8
@@ -2620,15 +2702,15 @@ entry:
 
 ; <label>:67                                      ; preds = %64
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
-  br i1 %NullCheck8, label %69, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %68, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %69
 
 ; <label>:69                                      ; preds = %67
   %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
   %71 = load i32, i32 addrspace(1)* %70
   %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
-  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %73
 
 ; <label>:73                                      ; preds = %69
   %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
@@ -2645,31 +2727,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %67
+ThrowNullRef8:                                    ; preds = %67
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %69
+ThrowNullRef10:                                   ; preds = %69
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2710,14 +2792,14 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
   %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
@@ -2730,14 +2812,14 @@ entry:
 
 ; <label>:11                                      ; preds = %4
   %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
   %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
@@ -2749,14 +2831,14 @@ entry:
 
 ; <label>:22                                      ; preds = %16
   %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
   %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
-  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
-  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
@@ -2804,23 +2886,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2836,7 +2918,280 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[loadElem]
+Successfully read RuntimeType.IsAssignableFrom
+
+define i8 @RuntimeType.IsAssignableFrom(%System.RuntimeType addrspace(1)* %param0, %System.Type addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.RuntimeType addrspace(1)*
+  %arg1 = alloca %System.Type addrspace(1)*
+  %loc0 = alloca %System.RuntimeType addrspace(1)*
+  %loc1 = alloca %"System.Type[]" addrspace(1)*
+  %loc2 = alloca i32
+  store %System.RuntimeType addrspace(1)* %param0, %System.RuntimeType addrspace(1)** %this
+  store %System.Type addrspace(1)* %param1, %System.Type addrspace(1)** %arg1
+  %0 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %1 = icmp ne %System.Type addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i8 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %5 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %6 = bitcast %System.Type addrspace(1)* %4 to %System.Object addrspace(1)*
+  %7 = bitcast %System.RuntimeType addrspace(1)* %5 to %System.Object addrspace(1)*
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %6, %System.Object addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %3
+  ret i8 1
+
+; <label>:12                                      ; preds = %3
+  %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 152
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 32
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
+  %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
+  %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
+  store %System.RuntimeType addrspace(1)* %25, %System.RuntimeType addrspace(1)** %loc0
+  %26 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %27 = icmp eq %System.RuntimeType addrspace(1)* %26, null
+  br i1 %27, label %34, label %28
+
+; <label>:28                                      ; preds = %15
+  %29 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %30 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)*)*)(%System.RuntimeType addrspace(1)* %29, %System.RuntimeType addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+; <label>:34                                      ; preds = %15
+  %35 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %36 = call %System.Reflection.Emit.TypeBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Reflection.Emit.TypeBuilder addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %35)
+  %37 = icmp eq %System.Reflection.Emit.TypeBuilder addrspace(1)* %36, null
+  br i1 %37, label %139, label %38
+
+; <label>:38                                      ; preds = %34
+  %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %42
+
+; <label>:42                                      ; preds = %38
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 152
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 40
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
+  %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
+  %53 = zext i8 %52 to i32
+  %54 = icmp eq i32 %53, 0
+  br i1 %54, label %56, label %55
+
+; <label>:55                                      ; preds = %42
+  ret i8 1
+
+; <label>:56                                      ; preds = %42
+  %57 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %58 = bitcast %System.RuntimeType addrspace(1)* %57 to %System.Type addrspace(1)*
+  %59 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %58)
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %64 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.Type addrspace(1)* %63, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = bitcast %System.RuntimeType addrspace(1)* %64 to %System.Type addrspace(1)*
+  %67 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %63, %System.Type addrspace(1)* %66)
+  %68 = zext i8 %67 to i32
+  %69 = trunc i32 %68 to i8
+  ret i8 %69
+
+; <label>:70                                      ; preds = %56
+  %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
+  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %73
+
+; <label>:73                                      ; preds = %70
+  %74 = load i64, i64 addrspace(1)* %72
+  %75 = add i64 %74, 128
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = add i64 %77, 0
+  %79 = inttoptr i64 %78 to i64*
+  %80 = load i64, i64* %79
+  %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
+  %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
+  %83 = call i8 %82(%System.Type addrspace(1)* %81)
+  %84 = zext i8 %83 to i32
+  %85 = icmp eq i32 %84, 0
+  br i1 %85, label %139, label %86
+
+; <label>:86                                      ; preds = %73
+  %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
+  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %89
+
+; <label>:89                                      ; preds = %86
+  %90 = load i64, i64 addrspace(1)* %88
+  %91 = add i64 %90, 128
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = add i64 %93, 24
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
+  %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
+  %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
+  store %"System.Type[]" addrspace(1)* %99, %"System.Type[]" addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %129
+
+; <label>:100                                     ; preds = %132
+  %101 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %102 = load i32, i32* %loc2
+  %NullCheck11 = icmp eq %"System.Type[]" addrspace(1)* %101, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %103
+
+; <label>:103                                     ; preds = %100
+  %104 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 1
+  %105 = load i32, i32 addrspace(1)* %104
+  %106 = zext i32 %105 to i64
+  %107 = zext i32 %102 to i64
+  %BoundsCheck = icmp uge i64 %107, %106
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %108
+
+; <label>:108                                     ; preds = %103
+  %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
+  %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
+  %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
+  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %113
+
+; <label>:113                                     ; preds = %108
+  %114 = load i64, i64 addrspace(1)* %112
+  %115 = add i64 %114, 152
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = add i64 %117, 56
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
+  %123 = zext i8 %122 to i32
+  %124 = icmp ne i32 %123, 0
+  br i1 %124, label %126, label %125
+
+; <label>:125                                     ; preds = %113
+  ret i8 0
+
+; <label>:126                                     ; preds = %113
+  %127 = load i32, i32* %loc2
+  %128 = add i32 %127, 1
+  store i32 %128, i32* %loc2
+  br label %129
+
+; <label>:129                                     ; preds = %89, %126
+  %130 = load i32, i32* %loc2
+  %131 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %NullCheck9 = icmp eq %"System.Type[]" addrspace(1)* %131, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %132
+
+; <label>:132                                     ; preds = %129
+  %133 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %131, i32 0, i32 1
+  %134 = load i32, i32 addrspace(1)* %133
+  %135 = zext i32 %134 to i64
+  %136 = trunc i64 %135 to i32
+  %137 = icmp slt i32 %130, %136
+  br i1 %137, label %100, label %138
+
+; <label>:138                                     ; preds = %132
+  ret i8 1
+
+; <label>:139                                     ; preds = %34, %73
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %129
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %103
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -2893,7 +3248,7 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElem]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -2904,8 +3259,8 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -2997,8 +3352,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
@@ -3059,8 +3414,8 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -3087,8 +3442,8 @@ entry:
 
 ; <label>:17                                      ; preds = %5, %11
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
@@ -3097,8 +3452,8 @@ entry:
 
 ; <label>:22                                      ; preds = %1, %11
   %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
@@ -3109,11 +3464,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %17
+ThrowNullRef2:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %22
+ThrowNullRef4:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3167,15 +3522,15 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
   %15 = load i32, i32 addrspace(1)* %14
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
@@ -3198,7 +3553,7 @@ ThrowNullRef:                                     ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef2:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3232,8 +3587,8 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
@@ -3312,8 +3667,8 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -3327,8 +3682,8 @@ entry:
 ; <label>:5                                       ; preds = %43
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %7 = load i32, i32* %loc1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck6, label %8, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
@@ -3366,8 +3721,8 @@ entry:
 ; <label>:32                                      ; preds = %21, %25
   %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
   %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
-  br i1 %NullCheck8, label %35, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = trunc i32 %34 to i16
@@ -3380,8 +3735,8 @@ entry:
 ; <label>:40                                      ; preds = %1, %35
   %41 = load i32, i32* %loc1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
-  br i1 %NullCheck2, label %43, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %42, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
@@ -3392,8 +3747,8 @@ entry:
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
   %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
-  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
   %51 = load i64, i64 addrspace(1)* %49
@@ -3412,19 +3767,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %40
+ThrowNullRef2:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %47
+ThrowNullRef4:                                    ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %5
+ThrowNullRef6:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %32
+ThrowNullRef8:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3467,8 +3822,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
@@ -3492,11 +3847,391 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(i16* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store i16* %param0, i16** %arg0
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load i32, i32* %arg3
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %42, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %37, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg2
+  %13 = load i32, i32* %arg3
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %37, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %24 = load i32, i32* %arg2
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load i16*, i16** %arg0
+  %35 = load i32, i32* %arg3
+  %36 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %36, i16* %34, i32 %35)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:37                                      ; preds = %5, %16
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %39)
+  %41 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41, %System.String addrspace(1)* %38, %System.String addrspace(1)* %40)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41) #0
+  unreachable
+
+; <label>:42                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
-Failed to read StringBuilder.ToString[loadElemA]
+Successfully read StringBuilder.ToString
+
+define %System.String addrspace(1)* @StringBuilder.ToString(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i16*
+  %loc3 = alloca %"System.Char[]" addrspace(1)*
+  %loc4 = alloca i32
+  %loc5 = alloca i32
+  %loc6 = alloca i16 addrspace(1)*
+  %loc7 = alloca %System.String addrspace(1)*
+  %loc8 = alloca %"System.Char[]" addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %0)
+  %2 = icmp ne i32 %1, 0
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %4
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %6)
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %7)
+  store %System.String addrspace(1)* %8, %System.String addrspace(1)** %loc0
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.Text.StringBuilder addrspace(1)* %9, %System.Text.StringBuilder addrspace(1)** %loc1
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  store %System.String addrspace(1)* %10, %System.String addrspace(1)** %loc7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc7
+  %12 = ptrtoint %System.String addrspace(1)* %11 to i64
+  %13 = icmp eq i64 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %5
+  %15 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %16 = sext i32 %15 to i64
+  %17 = add i64 %12, %16
+  br label %18
+
+; <label>:18                                      ; preds = %5, %14
+  %19 = phi i64 [ %12, %5 ], [ %17, %14 ]
+  %20 = inttoptr i64 %19 to i16*
+  store i16* %20, i16** %loc2
+  br label %21
+
+; <label>:21                                      ; preds = %98, %18
+  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %22, null
+  br i1 %NullCheck, label %ThrowNullRef, label %23
+
+; <label>:23                                      ; preds = %21
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 3
+  %25 = load i32, i32 addrspace(1)* %24, align 8
+  %26 = icmp sle i32 %25, 0
+  br i1 %26, label %96, label %27
+
+; <label>:27                                      ; preds = %23
+  %28 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %28, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %29
+
+; <label>:29                                      ; preds = %27
+  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %28, i32 0, i32 1
+  %31 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %30, align 8
+  store %"System.Char[]" addrspace(1)* %31, %"System.Char[]" addrspace(1)** %loc3
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %33
+
+; <label>:33                                      ; preds = %29
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  store i32 %35, i32* %loc4
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  %39 = load i32, i32 addrspace(1)* %38, align 8
+  store i32 %39, i32* %loc5
+  %40 = load i32, i32* %loc5
+  %41 = load i32, i32* %loc4
+  %42 = add i32 %40, %41
+  %43 = zext i32 %42 to i64
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %45
+
+; <label>:45                                      ; preds = %37
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = sext i32 %47 to i64
+  %49 = icmp sgt i64 %43, %48
+  br i1 %49, label %91, label %50
+
+; <label>:50                                      ; preds = %45
+  %51 = load i32, i32* %loc5
+  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %52, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %53
+
+; <label>:53                                      ; preds = %50
+  %54 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %52, i32 0, i32 1
+  %55 = load i32, i32 addrspace(1)* %54
+  %56 = zext i32 %55 to i64
+  %57 = trunc i64 %56 to i32
+  %58 = icmp ugt i32 %51, %57
+  br i1 %58, label %91, label %59
+
+; <label>:59                                      ; preds = %53
+  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  store %"System.Char[]" addrspace(1)* %60, %"System.Char[]" addrspace(1)** %loc8
+  %61 = icmp eq %"System.Char[]" addrspace(1)* %60, null
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %63, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %64
+
+; <label>:64                                      ; preds = %62
+  %65 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %63, i32 0, i32 1
+  %66 = load i32, i32 addrspace(1)* %65
+  %67 = zext i32 %66 to i64
+  %68 = trunc i64 %67 to i32
+  %69 = icmp ne i32 %68, 0
+  br i1 %69, label %71, label %70
+
+; <label>:70                                      ; preds = %59, %64
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:71                                      ; preds = %64
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %73
+
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %BoundsCheck = icmp uge i64 0, %76
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %77
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %78, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:79                                      ; preds = %70, %77
+  %80 = load i16*, i16** %loc2
+  %81 = load i32, i32* %loc4
+  %82 = sext i32 %81 to i64
+  %83 = mul i64 %82, 2
+  %84 = bitcast i16* %80 to i8*
+  %85 = getelementptr inbounds i8, i8* %84, i64 %83
+  %86 = load i16 addrspace(1)*, i16 addrspace(1)** %loc6
+  %87 = ptrtoint i16 addrspace(1)* %86 to i64
+  %88 = load i32, i32* %loc5
+  %89 = bitcast i8* %85 to i16*
+  %90 = inttoptr i64 %87 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %89, i16* %90, i32 %88)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %96
+
+; <label>:91                                      ; preds = %45, %53
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %94 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %93)
+  %95 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95, %System.String addrspace(1)* %92, %System.String addrspace(1)* %94)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95) #0
+  unreachable
+
+; <label>:96                                      ; preds = %23, %79
+  %97 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %97, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %98
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %97, i32 0, i32 2
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  store %System.Text.StringBuilder addrspace(1)* %100, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %102 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %102, label %21, label %103
+
+; <label>:103                                     ; preds = %98
+  store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc7
+  %104 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  ret %System.String addrspace(1)* %104
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method StringBuilder::get_Length using LLILCJit
+Successfully read StringBuilder.get_Length
+
+define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
+Successfully read RuntimeHelpers.get_OffsetToStringData
+
+define i32 @RuntimeHelpers.get_OffsetToStringData() {
+entry:
+  ret i32 12
+}
+
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
 Successfully read CultureData.CreateCultureData
 
@@ -3514,23 +4249,23 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
   store i8 %4, i8 addrspace(1)* %6
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
@@ -3549,11 +4284,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3566,50 +4301,50 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
   store i32 -1, i32 addrspace(1)* %2
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
   store i32 -1, i32 addrspace(1)* %8
   %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
   store i32 -1, i32 addrspace(1)* %14
   %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
   store i32 -1, i32 addrspace(1)* %17
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
@@ -3623,27 +4358,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3675,7 +4410,136 @@ Failed to read Dictionary`2.Insert[non-const derefAddress]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
 Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
-Failed to read HashHelpers.GetPrime[loadElem]
+Successfully read HashHelpers.GetPrime
+
+define i32 @HashHelpers.GetPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %6, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5, %System.String addrspace(1)* %4)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5) #0
+  unreachable
+
+; <label>:6                                       ; preds = %entry
+  store i32 0, i32* %loc0
+  br label %29
+
+; <label>:7                                       ; preds = %35
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 1296
+  %10 = addrspacecast i8 addrspace(1)* %9 to %"System.Int32[]" addrspace(1)**
+  %11 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %10
+  %12 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Int32[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = zext i32 %15 to i64
+  %17 = zext i32 %12 to i64
+  %BoundsCheck = icmp uge i64 %17, %16
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 3, i32 %12
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  store i32 %20, i32* %loc1
+  %21 = load i32, i32* %loc1
+  %22 = load i32, i32* %arg0
+  %23 = icmp slt i32 %21, %22
+  br i1 %23, label %26, label %24
+
+; <label>:24                                      ; preds = %18
+  %25 = load i32, i32* %loc1
+  ret i32 %25
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %loc0
+  %28 = add i32 %27, 1
+  store i32 %28, i32* %loc0
+  br label %29
+
+; <label>:29                                      ; preds = %6, %26
+  %30 = load i32, i32* %loc0
+  %31 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %32 = getelementptr inbounds i8, i8 addrspace(1)* %31, i64 1296
+  %33 = addrspacecast i8 addrspace(1)* %32 to %"System.Int32[]" addrspace(1)**
+  %34 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %33
+  %NullCheck = icmp eq %"System.Int32[]" addrspace(1)* %34, null
+  br i1 %NullCheck, label %ThrowNullRef, label %35
+
+; <label>:35                                      ; preds = %29
+  %36 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %34, i32 0, i32 1
+  %37 = load i32, i32 addrspace(1)* %36
+  %38 = zext i32 %37 to i64
+  %39 = trunc i64 %38 to i32
+  %40 = icmp slt i32 %30, %39
+  br i1 %40, label %7, label %41
+
+; <label>:41                                      ; preds = %35
+  %42 = load i32, i32* %arg0
+  %43 = or i32 %42, 1
+  store i32 %43, i32* %loc2
+  br label %59
+
+; <label>:44                                      ; preds = %59
+  %45 = load i32, i32* %loc2
+  %46 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %45)
+  %47 = zext i8 %46 to i32
+  %48 = icmp eq i32 %47, 0
+  br i1 %48, label %56, label %49
+
+; <label>:49                                      ; preds = %44
+  %50 = load i32, i32* %loc2
+  %51 = sub i32 %50, 1
+  %52 = srem i32 %51, 101
+  %53 = icmp eq i32 %52, 0
+  br i1 %53, label %56, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = load i32, i32* %loc2
+  ret i32 %55
+
+; <label>:56                                      ; preds = %44, %49
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %57, 2
+  store i32 %58, i32* %loc2
+  br label %59
+
+; <label>:59                                      ; preds = %41, %56
+  %60 = load i32, i32* %loc2
+  %61 = icmp slt i32 %60, 2147483647
+  br i1 %61, label %44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load i32, i32* %arg0
+  ret i32 %63
+
+ThrowNullRef:                                     ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
 Successfully read GenericEqualityComparer`1.GetHashCode
 
@@ -3694,14 +4558,14 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
   %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load i64, i64 addrspace(1)* %7
@@ -3720,7 +4584,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3750,8 +4614,8 @@ entry:
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
@@ -3796,8 +4660,8 @@ entry:
   %35 = bitcast i16* %34 to i8*
   %36 = getelementptr inbounds i8, i8* %35, i64 2
   %37 = bitcast i8* %36 to i16*
-  %NullCheck4 = icmp ne i16* %37, null
-  br i1 %NullCheck4, label %38, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %37, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %38
 
 ; <label>:38                                      ; preds = %27
   %39 = load i16, i16* %37, align 8
@@ -3824,8 +4688,8 @@ entry:
 
 ; <label>:54                                      ; preds = %22, %43
   %55 = load i16*, i16** %loc4
-  %NullCheck2 = icmp ne i16* %55, null
-  br i1 %NullCheck2, label %56, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i16* %55, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %56
 
 ; <label>:56                                      ; preds = %54
   %57 = load i16, i16* %55, align 8
@@ -3850,11 +4714,11 @@ ThrowNullRef:                                     ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %54
+ThrowNullRef2:                                    ; preds = %54
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %27
+ThrowNullRef4:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3871,8 +4735,8 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -3907,8 +4771,8 @@ entry:
 
 ; <label>:26                                      ; preds = %19
   %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
-  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %28
 
 ; <label>:28                                      ; preds = %26
   %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
@@ -3920,7 +4784,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3972,8 +4836,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
@@ -3984,26 +4848,26 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
-  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
@@ -4014,8 +4878,8 @@ entry:
 ; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
@@ -4024,8 +4888,8 @@ entry:
 
 ; <label>:25                                      ; preds = %1, %16, %23
   %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
-  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
@@ -4036,27 +4900,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %20
+ThrowNullRef10:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4069,8 +4933,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -4081,8 +4945,8 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
@@ -4091,8 +4955,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1, %8
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
@@ -4103,11 +4967,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4128,24 +4992,24 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   store i32 %3, i32* %loc0
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
   %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
   store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck4, label %9, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
@@ -4164,15 +5028,15 @@ entry:
 ; <label>:18                                      ; preds = %70
   %19 = load i16*, i16** %loc3
   %20 = bitcast i16* %19 to i64*
-  %NullCheck10 = icmp ne i64* %20, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %20, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = load i64, i64* %20, align 8
   %23 = load i16*, i16** %loc4
   %24 = bitcast i16* %23 to i64*
-  %NullCheck12 = icmp ne i64* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = load i64, i64* %24, align 8
@@ -4188,8 +5052,8 @@ entry:
   %31 = bitcast i16* %30 to i8*
   %32 = getelementptr inbounds i8, i8* %31, i64 8
   %33 = bitcast i8* %32 to i64*
-  %NullCheck14 = icmp ne i64* %33, null
-  br i1 %NullCheck14, label %34, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = load i64, i64* %33, align 8
@@ -4197,8 +5061,8 @@ entry:
   %37 = bitcast i16* %36 to i8*
   %38 = getelementptr inbounds i8, i8* %37, i64 8
   %39 = bitcast i8* %38 to i64*
-  %NullCheck16 = icmp ne i64* %39, null
-  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %40
 
 ; <label>:40                                      ; preds = %34
   %41 = load i64, i64* %39, align 8
@@ -4214,8 +5078,8 @@ entry:
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %NullCheck18 = icmp ne i64* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = load i64, i64* %48, align 8
@@ -4223,8 +5087,8 @@ entry:
   %52 = bitcast i16* %51 to i8*
   %53 = getelementptr inbounds i8, i8* %52, i64 16
   %54 = bitcast i8* %53 to i64*
-  %NullCheck20 = icmp ne i64* %54, null
-  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64* %54, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %55
 
 ; <label>:55                                      ; preds = %49
   %56 = load i64, i64* %54, align 8
@@ -4262,15 +5126,15 @@ entry:
 ; <label>:74                                      ; preds = %95
   %75 = load i16*, i16** %loc3
   %76 = bitcast i16* %75 to i32*
-  %NullCheck6 = icmp ne i32* %76, null
-  br i1 %NullCheck6, label %77, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32* %76, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %77
 
 ; <label>:77                                      ; preds = %74
   %78 = load i32, i32* %76, align 8
   %79 = load i16*, i16** %loc4
   %80 = bitcast i16* %79 to i32*
-  %NullCheck8 = icmp ne i32* %80, null
-  br i1 %NullCheck8, label %81, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i32* %80, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %81
 
 ; <label>:81                                      ; preds = %77
   %82 = load i32, i32* %80, align 8
@@ -4318,43 +5182,43 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %74
+ThrowNullRef6:                                    ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %77
+ThrowNullRef8:                                    ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %29
+ThrowNullRef14:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %34
+ThrowNullRef16:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4376,8 +5240,8 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load i64, i64 addrspace(1)* %4
@@ -4389,8 +5253,8 @@ entry:
   %12 = load i64, i64* %11
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %5
   %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
@@ -4399,8 +5263,8 @@ entry:
   %18 = load i8, i8* %arg2
   %19 = zext i8 %18 to i32
   %20 = trunc i32 %19 to i8
-  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %15
   %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
@@ -4411,11 +5275,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4442,8 +5306,8 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
@@ -4466,16 +5330,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
   %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = load i64, i64 addrspace(1)* %19
@@ -4500,8 +5364,8 @@ entry:
 ; <label>:35                                      ; preds = %30
   %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
@@ -4514,8 +5378,8 @@ entry:
 
 ; <label>:42                                      ; preds = %1, %38
   %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
-  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
@@ -4526,19 +5390,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %35
+ThrowNullRef2:                                    ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %42
+ThrowNullRef8:                                    ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4551,14 +5415,14 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
@@ -4570,7 +5434,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4583,8 +5447,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
@@ -4613,51 +5477,51 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
   %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
   %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
   %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
   %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
-  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
   store i64 %21, i64 addrspace(1)* %23
   %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %25 = load i64, i64* %loc0
-  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
@@ -4668,27 +5532,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %22
+ThrowNullRef12:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4701,8 +5565,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
@@ -4713,19 +5577,19 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
@@ -4734,8 +5598,8 @@ entry:
 
 ; <label>:15                                      ; preds = %1, %13
   %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
@@ -4746,19 +5610,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %15
+ThrowNullRef8:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4771,8 +5635,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -4831,8 +5695,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
@@ -4882,8 +5746,8 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
-  br i1 %NullCheck, label %17, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %ThrowNullRef, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
@@ -4894,15 +5758,15 @@ entry:
 
 ; <label>:22                                      ; preds = %17
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
-  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
   %26 = load i32, i32 addrspace(1)* %25
   %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
-  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %27, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
@@ -4925,8 +5789,8 @@ entry:
 ; <label>:40                                      ; preds = %17
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
-  br i1 %NullCheck6, label %43, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %41, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
@@ -4938,34 +5802,17 @@ ThrowNullRef:                                     ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %24
+ThrowNullRef4:                                    ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %40
+ThrowNullRef6:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
-}
-
-INFO:  jitting method Object::ReferenceEquals using LLILCJit
-Successfully read Object.ReferenceEquals
-
-define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
-entry:
-  %arg0 = alloca %System.Object addrspace(1)*
-  %arg1 = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
-  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
-  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = icmp eq %System.Object addrspace(1)* %0, %1
-  %3 = sext i1 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
 }
 
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
@@ -4978,21 +5825,21 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
   %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
-  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
@@ -5007,28 +5854,28 @@ entry:
 ; <label>:13                                      ; preds = %8, %12
   %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
   %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
   %21 = load i32, i32 addrspace(1)* %20, align 8
   %22 = add i32 %21, 1
-  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
   store i32 %22, i32 addrspace(1)* %24
   %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
@@ -5039,27 +5886,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5077,7 +5924,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::Setup using LLILCJit
-Failed to read AppDomain.Setup[loadElem]
+Failed to read AppDomain.Setup[unbox]
 INFO:  jitting method Thread::GetDomain using LLILCJit
 Successfully read Thread.GetDomain
 
@@ -5108,8 +5955,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
@@ -5122,14 +5969,14 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
   %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
@@ -5141,11 +5988,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5173,8 +6020,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -5189,7 +6036,328 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
 Failed to read KeyCollection.System.Collections.Generic.IEnumerable<TKey>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Successfully read Enumerator.MoveNext
+
+define i8 @Enumerator.MoveNext(%"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.RuntimeTypeHandle* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*
+  %"$TypeArg" = alloca %System.RuntimeTypeHandle*
+  store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
+  %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 8
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %76, label %12
+
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
+  br label %76
+
+; <label>:13                                      ; preds = %85
+  %14 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck19 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %15
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, i32 0, i32 0
+  %17 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %16, align 8
+  %NullCheck21 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, i32 0, i32 2
+  %20 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %19, align 8
+  %21 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck23 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %22
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, i32 0, i32 2
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %NullCheck25 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 3, i32 %24
+  %NullCheck27 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %32
+
+; <label>:32                                      ; preds = %30
+  %33 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, i32 0, i32 2
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = icmp slt i32 %34, 0
+  br i1 %35, label %68, label %36
+
+; <label>:36                                      ; preds = %32
+  %37 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %38 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck29 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %39
+
+; <label>:39                                      ; preds = %36
+  %40 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, i32 0, i32 0
+  %41 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %40, align 8
+  %NullCheck31 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, i32 0, i32 2
+  %44 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %43, align 8
+  %45 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck33 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, i32 0, i32 2
+  %48 = load i32, i32 addrspace(1)* %47, align 8
+  %NullCheck35 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %49
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = zext i32 %51 to i64
+  %53 = zext i32 %48 to i64
+  %BoundsCheck37 = icmp uge i64 %53, %52
+  br i1 %BoundsCheck37, label %ThrowIndexOutOfRange38, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 3, i32 %48
+  %NullCheck39 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %56
+
+; <label>:56                                      ; preds = %54
+  %57 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, i32 0, i32 0
+  %58 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck41 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %59
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %60, %System.__Canon addrspace(1)* %58)
+  %61 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck43 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  %64 = load i32, i32 addrspace(1)* %63, align 8
+  %65 = add i32 %64, 1
+  %NullCheck45 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  store i32 %65, i32 addrspace(1)* %67
+  ret i8 1
+
+; <label>:68                                      ; preds = %32
+  %69 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck47 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %73 = add i32 %72, 1
+  %NullCheck49 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %74
+
+; <label>:74                                      ; preds = %70
+  %75 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  store i32 %73, i32 addrspace(1)* %75
+  br label %76
+
+; <label>:76                                      ; preds = %8, %12, %74
+  %77 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %78
+
+; <label>:78                                      ; preds = %76
+  %79 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, i32 0, i32 2
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck7 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %82
+
+; <label>:82                                      ; preds = %78
+  %83 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, i32 0, i32 0
+  %84 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %83, align 8
+  %NullCheck9 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %85
+
+; <label>:85                                      ; preds = %82
+  %86 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, i32 0, i32 7
+  %87 = load i32, i32 addrspace(1)* %86, align 8
+  %88 = icmp ult i32 %80, %87
+  br i1 %88, label %13, label %89
+
+; <label>:89                                      ; preds = %85
+  %90 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %91 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck11 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %92
+
+; <label>:92                                      ; preds = %89
+  %93 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, i32 0, i32 0
+  %94 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck13 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %95
+
+; <label>:95                                      ; preds = %92
+  %96 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, i32 0, i32 7
+  %97 = load i32, i32 addrspace(1)* %96, align 8
+  %98 = add i32 %97, 1
+  %NullCheck15 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %99
+
+; <label>:99                                      ; preds = %95
+  %100 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, i32 0, i32 2
+  store i32 %98, i32 addrspace(1)* %100
+  %101 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck17 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %102
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %103, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %92
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef22:                                   ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef24:                                   ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef26:                                   ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef28:                                   ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef30:                                   ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef32:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef34:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef36:                                   ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange38:                           ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef40:                                   ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef42:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef44:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef46:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef48:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef50:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -5200,8 +6368,8 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -5232,9 +6400,9 @@ Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
 Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
-Failed to read String.MakeSeparatorList[loadElemA]
+Failed to read String.MakeSeparatorList[storeElem]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
-Failed to read String.InternalSplitKeepEmptyEntries[loadElem]
+Failed to read String.InternalSplitKeepEmptyEntries[storeElem]
 INFO:  jitting method Path::IsRelative using LLILCJit
 Successfully read Path.IsRelative
 
@@ -5243,8 +6411,8 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -5254,8 +6422,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
@@ -5271,8 +6439,8 @@ entry:
 
 ; <label>:17                                      ; preds = %7
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
@@ -5288,8 +6456,8 @@ entry:
 
 ; <label>:29                                      ; preds = %19
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %31
 
 ; <label>:31                                      ; preds = %29
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
@@ -5300,8 +6468,8 @@ entry:
 
 ; <label>:36                                      ; preds = %31
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
-  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %37, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
@@ -5312,8 +6480,8 @@ entry:
 
 ; <label>:43                                      ; preds = %31, %38
   %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
-  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %45
 
 ; <label>:45                                      ; preds = %43
   %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
@@ -5324,8 +6492,8 @@ entry:
 
 ; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %50
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
@@ -5336,8 +6504,8 @@ entry:
 
 ; <label>:57                                      ; preds = %1, %7, %19, %45, %52
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
-  br i1 %NullCheck14, label %59, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %59
 
 ; <label>:59                                      ; preds = %57
   %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
@@ -5347,8 +6515,8 @@ entry:
 
 ; <label>:63                                      ; preds = %59
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
@@ -5359,8 +6527,8 @@ entry:
 
 ; <label>:70                                      ; preds = %65
   %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
-  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.String addrspace(1)* %71, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %72
 
 ; <label>:72                                      ; preds = %70
   %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
@@ -5379,39 +6547,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %17
+ThrowNullRef4:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %29
+ThrowNullRef6:                                    ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %36
+ThrowNullRef8:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %43
+ThrowNullRef10:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %50
+ThrowNullRef12:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %57
+ThrowNullRef14:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %63
+ThrowNullRef16:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %70
+ThrowNullRef18:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5419,7 +6587,293 @@ ThrowNullRef17:                                   ; preds = %70
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
-Failed to read String.TrimHelper[loadElem]
+Successfully read String.TrimHelper
+
+define %System.String addrspace(1)* @String.TrimHelper(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i16
+  %loc4 = alloca i32
+  %loc5 = alloca i16
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = sub i32 %3, 1
+  store i32 %4, i32* %loc0
+  store i32 0, i32* %loc1
+  %5 = load i32, i32* %arg2
+  %6 = icmp eq i32 %5, 1
+  br i1 %6, label %62, label %7
+
+; <label>:7                                       ; preds = %1
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:8                                       ; preds = %58
+  store i32 0, i32* %loc2
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load i32, i32* %loc1
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2, i32 %10
+  %13 = load i16, i16 addrspace(1)* %12
+  %14 = zext i16 %13 to i32
+  %15 = trunc i32 %14 to i16
+  store i16 %15, i16* %loc3
+  store i32 0, i32* %loc2
+  br label %34
+
+; <label>:16                                      ; preds = %37
+  %17 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %18 = load i32, i32* %loc2
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %17, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %19
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = zext i32 %18 to i64
+  %BoundsCheck = icmp uge i64 %23, %22
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %24
+
+; <label>:24                                      ; preds = %19
+  %25 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 3, i32 %18
+  %26 = load i16, i16 addrspace(1)* %25, align 8
+  %27 = zext i16 %26 to i32
+  %28 = load i16, i16* %loc3
+  %29 = zext i16 %28 to i32
+  %30 = icmp eq i32 %27, %29
+  br i1 %30, label %43, label %31
+
+; <label>:31                                      ; preds = %24
+  %32 = load i32, i32* %loc2
+  %33 = add i32 %32, 1
+  store i32 %33, i32* %loc2
+  br label %34
+
+; <label>:34                                      ; preds = %11, %31
+  %35 = load i32, i32* %loc2
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = icmp slt i32 %35, %41
+  br i1 %42, label %16, label %43
+
+; <label>:43                                      ; preds = %24, %37
+  %44 = load i32, i32* %loc2
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %45, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp eq i32 %44, %50
+  br i1 %51, label %62, label %52
+
+; <label>:52                                      ; preds = %46
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %7, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %57, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %58
+
+; <label>:58                                      ; preds = %55
+  %59 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %60 = load i32, i32 addrspace(1)* %59
+  %61 = icmp slt i32 %56, %60
+  br i1 %61, label %8, label %62
+
+; <label>:62                                      ; preds = %1, %46, %58
+  %63 = load i32, i32* %arg2
+  %64 = icmp eq i32 %63, 0
+  br i1 %64, label %122, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %66, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %67
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %66, i32 0, i32 1
+  %69 = load i32, i32 addrspace(1)* %68
+  %70 = sub i32 %69, 1
+  store i32 %70, i32* %loc0
+  br label %118
+
+; <label>:71                                      ; preds = %118
+  store i32 0, i32* %loc4
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %73 = load i32, i32* %loc0
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %74
+
+; <label>:74                                      ; preds = %71
+  %75 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 2, i32 %73
+  %76 = load i16, i16 addrspace(1)* %75
+  %77 = zext i16 %76 to i32
+  %78 = trunc i32 %77 to i16
+  store i16 %78, i16* %loc5
+  store i32 0, i32* %loc4
+  br label %97
+
+; <label>:79                                      ; preds = %100
+  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %81 = load i32, i32* %loc4
+  %NullCheck19 = icmp eq %"System.Char[]" addrspace(1)* %80, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
+
+; <label>:82                                      ; preds = %79
+  %83 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 1
+  %84 = load i32, i32 addrspace(1)* %83
+  %85 = zext i32 %84 to i64
+  %86 = zext i32 %81 to i64
+  %BoundsCheck21 = icmp uge i64 %86, %85
+  br i1 %BoundsCheck21, label %ThrowIndexOutOfRange22, label %87
+
+; <label>:87                                      ; preds = %82
+  %88 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 3, i32 %81
+  %89 = load i16, i16 addrspace(1)* %88, align 8
+  %90 = zext i16 %89 to i32
+  %91 = load i16, i16* %loc5
+  %92 = zext i16 %91 to i32
+  %93 = icmp eq i32 %90, %92
+  br i1 %93, label %106, label %94
+
+; <label>:94                                      ; preds = %87
+  %95 = load i32, i32* %loc4
+  %96 = add i32 %95, 1
+  store i32 %96, i32* %loc4
+  br label %97
+
+; <label>:97                                      ; preds = %74, %94
+  %98 = load i32, i32* %loc4
+  %99 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck15 = icmp eq %"System.Char[]" addrspace(1)* %99, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %100
+
+; <label>:100                                     ; preds = %97
+  %101 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %99, i32 0, i32 1
+  %102 = load i32, i32 addrspace(1)* %101
+  %103 = zext i32 %102 to i64
+  %104 = trunc i64 %103 to i32
+  %105 = icmp slt i32 %98, %104
+  br i1 %105, label %79, label %106
+
+; <label>:106                                     ; preds = %87, %100
+  %107 = load i32, i32* %loc4
+  %108 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck17 = icmp eq %"System.Char[]" addrspace(1)* %108, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %109
+
+; <label>:109                                     ; preds = %106
+  %110 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %108, i32 0, i32 1
+  %111 = load i32, i32 addrspace(1)* %110
+  %112 = zext i32 %111 to i64
+  %113 = trunc i64 %112 to i32
+  %114 = icmp eq i32 %107, %113
+  br i1 %114, label %122, label %115
+
+; <label>:115                                     ; preds = %109
+  %116 = load i32, i32* %loc0
+  %117 = sub i32 %116, 1
+  store i32 %117, i32* %loc0
+  br label %118
+
+; <label>:118                                     ; preds = %67, %115
+  %119 = load i32, i32* %loc0
+  %120 = load i32, i32* %loc1
+  %121 = icmp sge i32 %119, %120
+  br i1 %121, label %71, label %122
+
+; <label>:122                                     ; preds = %62, %109, %118
+  %123 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %124 = load i32, i32* %loc1
+  %125 = load i32, i32* %loc0
+  %126 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %123, i32 %124, i32 %125)
+  ret %System.String addrspace(1)* %126
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %97
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange22:                           ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
 Successfully read String.CreateTrimmedString
 
@@ -5439,8 +6893,8 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
@@ -5535,8 +6989,8 @@ entry:
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i64 2872
   %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
   %8 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %7
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %3
   %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
@@ -5553,8 +7007,8 @@ entry:
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 2864
   %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
   %21 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %20
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
-  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %22
 
 ; <label>:22                                      ; preds = %16
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
@@ -5569,7 +7023,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %16
+ThrowNullRef2:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5586,8 +7040,8 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5613,8 +7067,8 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
@@ -5632,8 +7086,8 @@ entry:
 
 ; <label>:12                                      ; preds = %4
   %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
@@ -5644,8 +7098,8 @@ entry:
 
 ; <label>:19                                      ; preds = %14
   %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %19
   %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
@@ -5660,21 +7114,21 @@ entry:
   %31 = zext i16 %30 to i32
   %32 = bitcast i8* %29 to i16*
   %33 = trunc i32 %31 to i16
-  %NullCheck6 = icmp ne i16* %32, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i16* %32, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %21
   store i16 %33, i16* %32, align 8
   %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %36
 
 ; <label>:36                                      ; preds = %34
   %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
   %38 = load i32, i32 addrspace(1)* %37, align 8
   %39 = add i32 %38, 1
-  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %40
 
 ; <label>:40                                      ; preds = %36
   %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
@@ -5683,16 +7137,16 @@ entry:
 
 ; <label>:42                                      ; preds = %14
   %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
-  br i1 %NullCheck12, label %44, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
   %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
   %47 = load i16, i16* %arg1
   %48 = zext i16 %47 to i32
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = trunc i32 %48 to i16
@@ -5703,31 +7157,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %19
+ThrowNullRef4:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %21
+ThrowNullRef6:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %36
+ThrowNullRef10:                                   ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %42
+ThrowNullRef12:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %44
+ThrowNullRef14:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5740,8 +7194,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -5752,8 +7206,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
@@ -5762,14 +7216,14 @@ entry:
 
 ; <label>:11                                      ; preds = %1
   %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
@@ -5779,15 +7233,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5808,8 +7262,8 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5822,8 +7276,8 @@ entry:
 
 ; <label>:8                                       ; preds = %3
   %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
@@ -5842,15 +7296,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
-  br i1 %NullCheck4, label %22, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
   %24 = load i16*, i16* addrspace(1)* %23, align 8
   %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %25, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
@@ -5859,8 +7313,8 @@ entry:
   store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
@@ -5874,8 +7328,8 @@ entry:
 
 ; <label>:37                                      ; preds = %65
   %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %37
   %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
@@ -5886,16 +7340,16 @@ entry:
   %45 = bitcast i16* %41 to i8*
   %46 = getelementptr inbounds i8, i8* %45, i64 %44
   %47 = bitcast i8* %46 to i16*
-  %NullCheck14 = icmp ne i16* %47, null
-  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %47, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %48
 
 ; <label>:48                                      ; preds = %39
   %49 = load i16, i16* %47, align 8
   %50 = zext i16 %49 to i32
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %52 = load i32, i32* %loc1
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %53
 
 ; <label>:53                                      ; preds = %48
   %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
@@ -5916,8 +7370,8 @@ entry:
 ; <label>:62                                      ; preds = %36, %59
   %63 = load i32, i32* %loc1
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck10, label %65, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %65
 
 ; <label>:65                                      ; preds = %62
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
@@ -5936,15 +7390,15 @@ entry:
 
 ; <label>:74                                      ; preds = %70
   %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
-  br i1 %NullCheck18, label %76, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %76
 
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
   %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
-  br i1 %NullCheck20, label %80, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
   %81 = load i64, i64 addrspace(1)* %79
@@ -5958,8 +7412,8 @@ entry:
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
   %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
-  br i1 %NullCheck22, label %92, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.String addrspace(1)* %90, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %92
 
 ; <label>:92                                      ; preds = %80
   %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
@@ -5969,15 +7423,15 @@ entry:
 
 ; <label>:96                                      ; preds = %70
   %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
-  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %98
 
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
   %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
-  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
   %103 = load i64, i64 addrspace(1)* %101
@@ -5991,8 +7445,8 @@ entry:
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
   %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
-  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.String addrspace(1)* %112, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %114
 
 ; <label>:114                                     ; preds = %102
   %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
@@ -6004,59 +7458,59 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %20
+ThrowNullRef4:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %22
+ThrowNullRef6:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %26
+ThrowNullRef8:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %62
+ThrowNullRef10:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %48
+ThrowNullRef16:                                   ; preds = %48
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %74
+ThrowNullRef18:                                   ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %76
+ThrowNullRef20:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %80
+ThrowNullRef22:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %96
+ThrowNullRef24:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %98
+ThrowNullRef26:                                   ; preds = %98
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %102
+ThrowNullRef28:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6069,15 +7523,15 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
   %3 = load i16*, i16* addrspace(1)* %2, align 8
   %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
@@ -6087,8 +7541,8 @@ entry:
   %10 = bitcast i16* %3 to i8*
   %11 = getelementptr inbounds i8, i8* %10, i64 %9
   %12 = bitcast i8* %11 to i16*
-  %NullCheck4 = icmp ne i16* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %5
   store i16 0, i16* %12, align 8
@@ -6098,11 +7552,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6119,8 +7573,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -6131,8 +7585,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
@@ -6144,15 +7598,15 @@ entry:
 
 ; <label>:14                                      ; preds = %1
   %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
   %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
   %21 = load i64, i64 addrspace(1)* %19
@@ -6171,15 +7625,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %14
+ThrowNullRef4:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %16
+ThrowNullRef6:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6302,14 +7756,6 @@ entry:
   ret %System.String addrspace(1)* %57
 }
 
-INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
-Successfully read RuntimeHelpers.get_OffsetToStringData
-
-define i32 @RuntimeHelpers.get_OffsetToStringData() {
-entry:
-  ret i32 12
-}
-
 INFO:  jitting method String::Equals using LLILCJit
 Successfully read String.Equals
 
@@ -6381,8 +7827,8 @@ entry:
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
-  br i1 %NullCheck24, label %29, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
   %30 = load i64, i64 addrspace(1)* %28
@@ -6397,8 +7843,8 @@ entry:
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
-  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
   %43 = load i64, i64 addrspace(1)* %41
@@ -6418,8 +7864,8 @@ entry:
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
   %59 = load i64, i64 addrspace(1)* %57
@@ -6434,8 +7880,8 @@ entry:
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck22, label %71, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
   %72 = load i64, i64 addrspace(1)* %70
@@ -6455,8 +7901,8 @@ entry:
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
-  br i1 %NullCheck16, label %87, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = load i64, i64 addrspace(1)* %86
@@ -6471,8 +7917,8 @@ entry:
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck18, label %100, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
   %101 = load i64, i64 addrspace(1)* %99
@@ -6492,8 +7938,8 @@ entry:
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
-  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
   %117 = load i64, i64 addrspace(1)* %115
@@ -6508,8 +7954,8 @@ entry:
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
-  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
   %130 = load i64, i64 addrspace(1)* %128
@@ -6528,15 +7974,15 @@ entry:
 
 ; <label>:142                                     ; preds = %22
   %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
-  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %143, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %144
 
 ; <label>:144                                     ; preds = %142
   %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
   %146 = load i32, i32 addrspace(1)* %145
   %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
-  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %147, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %148
 
 ; <label>:148                                     ; preds = %144
   %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
@@ -6557,15 +8003,15 @@ entry:
 
 ; <label>:159                                     ; preds = %22
   %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
-  br i1 %NullCheck, label %161, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %ThrowNullRef, label %161
 
 ; <label>:161                                     ; preds = %159
   %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
   %163 = load i32, i32 addrspace(1)* %162
   %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
-  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %164, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %165
 
 ; <label>:165                                     ; preds = %161
   %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
@@ -6578,8 +8024,8 @@ entry:
 
 ; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
-  br i1 %NullCheck4, label %172, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %171, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %172
 
 ; <label>:172                                     ; preds = %170
   %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
@@ -6589,8 +8035,8 @@ entry:
 
 ; <label>:176                                     ; preds = %172
   %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
-  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %177, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %178
 
 ; <label>:178                                     ; preds = %176
   %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
@@ -6629,55 +8075,55 @@ ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %161
+ThrowNullRef2:                                    ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %170
+ThrowNullRef4:                                    ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %176
+ThrowNullRef6:                                    ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %142
+ThrowNullRef8:                                    ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %144
+ThrowNullRef10:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %113
+ThrowNullRef12:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %116
+ThrowNullRef14:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %84
+ThrowNullRef16:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %87
+ThrowNullRef18:                                   ; preds = %87
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %55
+ThrowNullRef20:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %58
+ThrowNullRef22:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %26
+ThrowNullRef24:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %29
+ThrowNullRef26:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,8 +8161,8 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck, label %14, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %ThrowNullRef, label %14
 
 ; <label>:14                                      ; preds = %8
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
@@ -6760,8 +8206,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
@@ -6770,14 +8216,14 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32, i32* %loc0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %10
   %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
   %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
@@ -6790,15 +8236,15 @@ entry:
 ; <label>:25                                      ; preds = %19
   %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
-  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
   %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
@@ -6807,8 +8253,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %37 = load i32, i32* %loc0
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %38, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %38
 
 ; <label>:38                                      ; preds = %32
   %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
@@ -6817,14 +8263,14 @@ entry:
 
 ; <label>:40                                      ; preds = %19
   %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %40
   %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
   %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
-  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
-  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
@@ -6832,8 +8278,8 @@ entry:
   %48 = zext i32 %47 to i64
   %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
-  br i1 %NullCheck16, label %51, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %51
 
 ; <label>:51                                      ; preds = %45
   %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
@@ -6847,15 +8293,15 @@ entry:
 ; <label>:57                                      ; preds = %51
   %58 = load i16*, i16** %arg1
   %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
-  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %60
 
 ; <label>:60                                      ; preds = %57
   %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
   %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
-  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %64
 
 ; <label>:64                                      ; preds = %60
   %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
@@ -6864,22 +8310,22 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
   %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
-  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %70
 
 ; <label>:70                                      ; preds = %64
   %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
   %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
-  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
-  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
   %75 = load i32, i32 addrspace(1)* %74
   %76 = zext i32 %75 to i64
   %77 = trunc i64 %76 to i32
-  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
-  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %78
 
 ; <label>:78                                      ; preds = %73
   %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
@@ -6901,8 +8347,8 @@ entry:
   %90 = bitcast i16* %86 to i8*
   %91 = getelementptr inbounds i8, i8* %90, i64 %89
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %93
 
 ; <label>:93                                      ; preds = %80
   %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
@@ -6912,8 +8358,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %99 = load i32, i32* %loc2
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %100
 
 ; <label>:100                                     ; preds = %93
   %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
@@ -6928,63 +8374,63 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %25
+ThrowNullRef6:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %32
+ThrowNullRef10:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %40
+ThrowNullRef12:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %45
+ThrowNullRef16:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %57
+ThrowNullRef18:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %60
+ThrowNullRef20:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %64
+ThrowNullRef22:                                   ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %70
+ThrowNullRef24:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %73
+ThrowNullRef26:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %80
+ThrowNullRef28:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %93
+ThrowNullRef30:                                   ; preds = %93
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7004,8 +8450,8 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
@@ -7033,43 +8479,43 @@ entry:
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %14
   %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
   %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   %28 = load i32, i32 addrspace(1)* %27, align 8
   %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
-  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %30
 
 ; <label>:30                                      ; preds = %26
   %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
   %32 = load i32, i32 addrspace(1)* %31, align 8
   %33 = add i32 %28, %32
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %34
 
 ; <label>:34                                      ; preds = %30
   %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   store i32 %33, i32 addrspace(1)* %35
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
   store i32 0, i32 addrspace(1)* %38
   %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %40
 
 ; <label>:40                                      ; preds = %37
   %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
@@ -7082,8 +8528,8 @@ entry:
 
 ; <label>:47                                      ; preds = %40
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
@@ -7098,8 +8544,8 @@ entry:
   %54 = load i32, i32* %loc0
   %55 = sext i32 %54 to i64
   %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
-  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %57
 
 ; <label>:57                                      ; preds = %52
   %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
@@ -7110,68 +8556,35 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %14
+ThrowNullRef2:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %23
+ThrowNullRef4:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %26
+ThrowNullRef6:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %30
+ThrowNullRef8:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %34
+ThrowNullRef10:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %47
+ThrowNullRef14:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %52
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-}
-
-INFO:  jitting method StringBuilder::get_Length using LLILCJit
-Successfully read StringBuilder.get_Length
-
-define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.StringBuilder addrspace(1)*
-  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
-  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
-
-; <label>:1                                       ; preds = %entry
-  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %3 = load i32, i32 addrspace(1)* %2, align 8
-  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
-
-; <label>:5                                       ; preds = %1
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = add i32 %3, %7
-  ret i32 %8
-
-ThrowNullRef:                                     ; preds = %entry
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef16:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7213,70 +8626,70 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
   %6 = load i32, i32 addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
   store i32 %6, i32 addrspace(1)* %8
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
   %13 = load i32, i32 addrspace(1)* %12, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
   store i32 %13, i32 addrspace(1)* %15
   %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
-  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %18
 
 ; <label>:18                                      ; preds = %14
   %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
   %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
   %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
   %34 = load i32, i32 addrspace(1)* %33, align 8
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
-  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
@@ -7287,39 +8700,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %28
+ThrowNullRef16:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %32
+ThrowNullRef18:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7455,13 +8868,13 @@ entry:
 ; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
@@ -7477,16 +8890,16 @@ entry:
 
 ; <label>:18                                      ; preds = %15
   %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
   store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
   %22 = load i32, i32* %loc0
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %24
 
 ; <label>:24                                      ; preds = %20
   %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
@@ -7498,13 +8911,13 @@ entry:
 ; <label>:28                                      ; preds = %15, %24
   %29 = load i32, i32* %arg1
   %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %31
   %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
@@ -7517,20 +8930,20 @@ entry:
   %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
-  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
   %46 = load i32, i32 addrspace(1)* %45, align 8
   %47 = sub i32 %40, %46
-  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
-  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i32 addrspace(1)* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %48
 
 ; <label>:48                                      ; preds = %44
   store i32 %47, i32 addrspace(1)* %39, align 8
@@ -7538,21 +8951,21 @@ entry:
 
 ; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
-  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %51
 
 ; <label>:51                                      ; preds = %49
   %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %53
 
 ; <label>:53                                      ; preds = %51
   %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
   %55 = load i32, i32 addrspace(1)* %54, align 8
   %56 = load i32, i32* %arg2
   %57 = sub i32 %55, %56
-  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %58
 
 ; <label>:58                                      ; preds = %53
   %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
@@ -7562,13 +8975,13 @@ entry:
 ; <label>:60                                      ; preds = %33, %58
   %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
   %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
-  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %63
 
 ; <label>:63                                      ; preds = %60
   %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
-  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
-  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
@@ -7578,15 +8991,15 @@ entry:
 
 ; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
-  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i32 addrspace(1)* %69, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %70
 
 ; <label>:70                                      ; preds = %68
   %71 = load i32, i32 addrspace(1)* %69, align 8
   store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
-  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
@@ -7596,8 +9009,8 @@ entry:
   store i32 %77, i32* %loc4
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
-  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %80
 
 ; <label>:80                                      ; preds = %73
   %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
@@ -7607,71 +9020,71 @@ entry:
 ; <label>:83                                      ; preds = %80
   store i32 0, i32* %loc3
   %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
-  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
-  br i1 %NullCheck26, label %88, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i32 addrspace(1)* %87, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %88
 
 ; <label>:88                                      ; preds = %85
   %89 = load i32, i32 addrspace(1)* %87, align 8
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
-  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %90
 
 ; <label>:90                                      ; preds = %88
   %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
   store i32 %89, i32 addrspace(1)* %91
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
-  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
-  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %96
 
 ; <label>:96                                      ; preds = %94
   %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
-  br i1 %NullCheck34, label %100, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %100
 
 ; <label>:100                                     ; preds = %96
   %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
-  br i1 %NullCheck36, label %102, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %102
 
 ; <label>:102                                     ; preds = %100
   %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
   %104 = load i32, i32 addrspace(1)* %103, align 8
   %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
-  br i1 %NullCheck38, label %106, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %106
 
 ; <label>:106                                     ; preds = %102
   %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
-  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
-  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %108
 
 ; <label>:108                                     ; preds = %106
   %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
   %110 = load i32, i32 addrspace(1)* %109, align 8
   %111 = add i32 %104, %110
-  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %112
 
 ; <label>:112                                     ; preds = %108
   %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
   store i32 %111, i32 addrspace(1)* %113
   %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
-  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i32 addrspace(1)* %114, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %115
 
 ; <label>:115                                     ; preds = %112
   %116 = load i32, i32 addrspace(1)* %114, align 8
@@ -7681,19 +9094,19 @@ entry:
 ; <label>:118                                     ; preds = %115
   %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
-  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %121
 
 ; <label>:121                                     ; preds = %118
   %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
-  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
-  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %123
 
 ; <label>:123                                     ; preds = %121
   %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
   %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
-  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
-  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %126
 
 ; <label>:126                                     ; preds = %123
   %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
@@ -7705,8 +9118,8 @@ entry:
 
 ; <label>:130                                     ; preds = %80, %115, %126
   %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %132
 
 ; <label>:132                                     ; preds = %130
   %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7715,8 +9128,8 @@ entry:
   %136 = load i32, i32* %loc3
   %137 = sub i32 %135, %136
   %138 = sub i32 %134, %137
-  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %139
 
 ; <label>:139                                     ; preds = %132
   %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7728,16 +9141,16 @@ entry:
 
 ; <label>:144                                     ; preds = %139
   %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
-  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %146
 
 ; <label>:146                                     ; preds = %144
   %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
   %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
   %149 = load i32, i32* %loc2
   %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
-  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %151
 
 ; <label>:151                                     ; preds = %146
   %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
@@ -7754,145 +9167,249 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %18
+ThrowNullRef4:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %31
+ThrowNullRef10:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %44
+ThrowNullRef16:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %68
+ThrowNullRef18:                                   ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %70
+ThrowNullRef20:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %73
+ThrowNullRef22:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %83
+ThrowNullRef24:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %85
+ThrowNullRef26:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %88
+ThrowNullRef28:                                   ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %90
+ThrowNullRef30:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %94
+ThrowNullRef32:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %96
+ThrowNullRef34:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %100
+ThrowNullRef36:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %102
+ThrowNullRef38:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %106
+ThrowNullRef40:                                   ; preds = %106
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %108
+ThrowNullRef42:                                   ; preds = %108
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %112
+ThrowNullRef44:                                   ; preds = %112
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %118
+ThrowNullRef46:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %121
+ThrowNullRef48:                                   ; preds = %121
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %123
+ThrowNullRef50:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %130
+ThrowNullRef52:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %132
+ThrowNullRef54:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %144
+ThrowNullRef56:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %146
+ThrowNullRef58:                                   ; preds = %146
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %60
+ThrowNullRef60:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %63
+ThrowNullRef62:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %49
+ThrowNullRef64:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %51
+ThrowNullRef66:                                   ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %53
+ThrowNullRef68:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(%"System.Char[]" addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %arg0 = alloca %"System.Char[]" addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store %"System.Char[]" addrspace(1)* %param0, %"System.Char[]" addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load i32, i32* %arg4
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %43, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %38, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg1
+  %13 = load i32, i32* %arg4
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %38, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %24 = load i32, i32* %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %35 = load i32, i32* %arg3
+  %36 = load i32, i32* %arg4
+  %37 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %37, %"System.Char[]" addrspace(1)* %34, i32 %35, i32 %36)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:38                                      ; preds = %5, %16
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Successfully read Buffer._Memmove
 
@@ -7914,7 +9431,7 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[loadElem]
+Failed to read AppDomain.SetDataHelper[storeElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -7923,8 +9440,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
@@ -7934,8 +9451,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
@@ -7947,15 +9464,15 @@ entry:
   %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
   %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
@@ -7966,15 +9483,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7992,7 +9509,79 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
-Failed to read Dictionary`2.TryGetValue[loadElemA]
+Successfully read Dictionary`2.TryGetValue
+
+define i8 @"Dictionary`2.TryGetValue"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)* addrspace(1)* %param2) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  %arg2 = alloca %System.__Canon addrspace(1)* addrspace(1)*
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  store %System.__Canon addrspace(1)* addrspace(1)* %param2, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  store i32 %2, i32* %loc0
+  %3 = load i32, i32* %loc0
+  %4 = icmp slt i32 %3, 0
+  br i1 %4, label %22, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 2
+  %10 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %9, align 8
+  %11 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = zext i32 %11 to i64
+  %BoundsCheck = icmp uge i64 %16, %15
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 3, i32 %11
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %20, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %6, %System.__Canon addrspace(1)* %21)
+  ret i8 1
+
+; <label>:22                                      ; preds = %entry
+  %23 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %23, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -8058,8 +9647,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
@@ -8091,8 +9680,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
@@ -8171,15 +9760,15 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck, label %19, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %ThrowNullRef, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
   %21 = load i32, i32 addrspace(1)* %20
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
@@ -8202,7 +9791,7 @@ ThrowNullRef:                                     ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %19
+ThrowNullRef2:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8248,8 +9837,8 @@ entry:
   %0 = alloca %System.AppDomainHandle
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %1 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %1, i32 0, i32 15
@@ -8269,8 +9858,8 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
@@ -8286,7 +9875,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -8299,8 +9888,8 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -8327,8 +9916,8 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
@@ -8352,8 +9941,8 @@ entry:
   %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
   store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
@@ -8363,8 +9952,8 @@ entry:
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
@@ -8374,8 +9963,8 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %9
   %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
@@ -8384,8 +9973,8 @@ entry:
 
 ; <label>:18                                      ; preds = %3, %16
   %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
@@ -8397,15 +9986,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %18
+ThrowNullRef6:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8418,8 +10007,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
@@ -8453,15 +10042,15 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
@@ -8473,7 +10062,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8481,7 +10070,7 @@ ThrowNullRef1:                                    ; preds = %1
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
 Failed to read Dictionary`2.System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
@@ -8506,8 +10095,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
@@ -8524,8 +10113,8 @@ entry:
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -8544,7 +10133,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8577,8 +10166,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = load i64, i64* %arg2
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = trunc i32 %3 to i8
@@ -8634,46 +10223,46 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
   %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
-  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
-  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
-  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
@@ -8684,27 +10273,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %20
+ThrowNullRef12:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8717,8 +10306,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -8756,22 +10345,22 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
   %9 = load i64, i64 addrspace(1)* %8, align 8
   %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
   %13 = load i64, i64 addrspace(1)* %12, align 8
   %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %11
   %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
@@ -8788,11 +10377,11 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8882,8 +10471,8 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
@@ -8900,8 +10489,8 @@ entry:
 ; <label>:8                                       ; preds = %1
   %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
   %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
@@ -8911,15 +10500,15 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
   %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
   %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
-  br i1 %NullCheck6, label %21, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
@@ -8946,15 +10535,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8992,15 +10581,15 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
   store i8 %3, i8 addrspace(1)* %5
   %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
@@ -9011,7 +10600,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9027,8 +10616,8 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -9041,8 +10630,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
@@ -9058,7 +10647,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9080,8 +10669,8 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
@@ -9096,8 +10685,8 @@ entry:
 ; <label>:12                                      ; preds = %6
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
@@ -9112,8 +10701,8 @@ entry:
 ; <label>:21                                      ; preds = %15
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
@@ -9128,8 +10717,8 @@ entry:
 ; <label>:30                                      ; preds = %24
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %31, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
@@ -9144,8 +10733,8 @@ entry:
 ; <label>:39                                      ; preds = %33
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
-  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %40, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %42
 
 ; <label>:42                                      ; preds = %39
   %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
@@ -9164,19 +10753,19 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %21
+ThrowNullRef4:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %30
+ThrowNullRef6:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %39
+ThrowNullRef8:                                    ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9243,8 +10832,8 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
@@ -9264,57 +10853,57 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
   store i8 0, i8 addrspace(1)* %2
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
   store i8 0, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
   store i8 0, i8 addrspace(1)* %17
   %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
   store i8 0, i8 addrspace(1)* %20
   %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
-  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
@@ -9325,31 +10914,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %19
+ThrowNullRef14:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9367,8 +10956,8 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
@@ -9380,8 +10969,8 @@ entry:
 
 ; <label>:9                                       ; preds = %4
   %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %9
   %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
@@ -9395,7 +10984,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef2:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9420,8 +11009,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
@@ -9512,8 +11101,8 @@ entry:
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
@@ -9524,8 +11113,8 @@ entry:
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = load i64, i64 addrspace(1)* %12
@@ -9537,8 +11126,8 @@ entry:
   %20 = load i64, i64* %19
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
-  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %13
   %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
@@ -9555,8 +11144,8 @@ entry:
 ; <label>:30                                      ; preds = %25
   %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %32 = load i32, i32* %arg2
-  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
-  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
@@ -9570,15 +11159,15 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %30
+ThrowNullRef2:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9622,87 +11211,87 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
   %10 = load i8, i8 addrspace(1)* %9, align 8
   %11 = zext i8 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %8
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
   store i8 %12, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
   %19 = load i8, i8 addrspace(1)* %18, align 8
   %20 = zext i8 %19 to i32
   %21 = trunc i32 %20 to i8
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
   store i8 %21, i8 addrspace(1)* %23
   %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
   %28 = load i8, i8 addrspace(1)* %27, align 8
   %29 = zext i8 %28 to i32
   %30 = trunc i32 %29 to i8
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
-  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %31
 
 ; <label>:31                                      ; preds = %26
   %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
   store i8 %30, i8 addrspace(1)* %32
   %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
-  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
-  br i1 %NullCheck14, label %40, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %40
 
 ; <label>:40                                      ; preds = %35
   %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
   store i8 %39, i8 addrspace(1)* %41
   %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
-  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %44
 
 ; <label>:44                                      ; preds = %40
   %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
   %46 = load i8, i8 addrspace(1)* %45, align 8
   %47 = zext i8 %46 to i32
   %48 = trunc i32 %47 to i8
-  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
   store i8 %48, i8 addrspace(1)* %50
   %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
-  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
@@ -9713,29 +11302,29 @@ entry:
 ; <label>:56                                      ; preds = %52
   %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
-  br i1 %NullCheck22, label %59, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
   %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
   %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
-  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
-  br i1 %NullCheck24, label %63, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
   %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
-  br i1 %NullCheck26, label %66, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
   %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
-  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
-  br i1 %NullCheck28, label %69, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %69
 
 ; <label>:69                                      ; preds = %66
   %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
@@ -9744,15 +11333,15 @@ entry:
 
 ; <label>:71                                      ; preds = %105
   %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
-  br i1 %NullCheck34, label %73, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %73
 
 ; <label>:73                                      ; preds = %71
   %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
   %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
   %76 = load i32, i32* %loc0
-  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
-  br i1 %NullCheck36, label %77, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
@@ -9766,8 +11355,8 @@ entry:
 
 ; <label>:83                                      ; preds = %77
   %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
-  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
@@ -9775,14 +11364,14 @@ entry:
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
   %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
-  br i1 %NullCheck40, label %91, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
 ; <label>:91                                      ; preds = %85
   %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
   %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
-  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck42, label %94, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %94
 
 ; <label>:94                                      ; preds = %91
   %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
@@ -9798,14 +11387,14 @@ entry:
 ; <label>:99                                      ; preds = %69, %96
   %100 = load i32, i32* %loc0
   %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
-  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %102
 
 ; <label>:102                                     ; preds = %99
   %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
   %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
-  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
-  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
@@ -9819,87 +11408,87 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %26
+ThrowNullRef10:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %31
+ThrowNullRef12:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %35
+ThrowNullRef14:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %40
+ThrowNullRef16:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %56
+ThrowNullRef22:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %59
+ThrowNullRef24:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %63
+ThrowNullRef26:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %66
+ThrowNullRef28:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %102
+ThrowNullRef32:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %71
+ThrowNullRef34:                                   ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %73
+ThrowNullRef36:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %83
+ThrowNullRef38:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %85
+ThrowNullRef40:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %91
+ThrowNullRef42:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9943,15 +11532,15 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
   %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
@@ -9961,28 +11550,28 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
   %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %12
   %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
   %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
   %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
-  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
@@ -9993,23 +11582,23 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %12
+ThrowNullRef6:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10031,15 +11620,15 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
   %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = load i64, i64 addrspace(1)* %7
@@ -10077,13 +11666,13 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[loadElem]
+Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -10111,8 +11700,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueGeFP.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueGeFP.error.txt
@@ -25,8 +25,8 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
@@ -40,8 +40,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
   %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
@@ -75,7 +75,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -90,8 +90,8 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %NullCheck = icmp ne i8 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = load i8, i8 addrspace(1)* %0, align 8
@@ -125,8 +125,8 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
@@ -159,8 +159,8 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -184,8 +184,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
   store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
@@ -195,8 +195,8 @@ entry:
 ; <label>:4                                       ; preds = %1
   %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
   %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
@@ -206,8 +206,8 @@ entry:
   %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
@@ -221,14 +221,14 @@ entry:
 
 ; <label>:17                                      ; preds = %14
   %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
   %21 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
@@ -238,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -249,8 +249,8 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
@@ -261,27 +261,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %30
+ThrowNullRef10:                                   ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -301,7 +301,89 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
-Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
+Successfully read AppDomainSetup.GetUnsecureApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.GetUnsecureApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %NullCheck = icmp eq %"System.String[]" addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %BoundsCheck = icmp uge i64 0, %5
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %6
+
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 3, i32 0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
+  ret %System.String addrspace(1)* %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_Value using LLILCJit
+Successfully read AppDomainSetup.get_Value
+
+define %"System.String[]" addrspace(1)* @AppDomainSetup.get_Value(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.String[]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 18)
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.String[]" addrspace(1)* addrspace(1)*, %"System.String[]" addrspace(1)*)*)(%"System.String[]" addrspace(1)* addrspace(1)* %9, %"System.String[]" addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %11, i32 0, i32 1
+  %14 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %13, align 8
+  ret %"System.String[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -319,8 +401,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -368,16 +450,16 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
   %5 = load i32, i32 addrspace(1)* %4
   %6 = sub i32 %5, 1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -389,7 +471,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -421,8 +503,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
@@ -456,8 +538,8 @@ entry:
 ; <label>:27                                      ; preds = %19
   %28 = load i32, i32* %arg1
   %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
-  br i1 %NullCheck2, label %30, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %29, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %30
 
 ; <label>:30                                      ; preds = %27
   %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
@@ -493,8 +575,8 @@ entry:
 ; <label>:49                                      ; preds = %46
   %50 = load i32, i32* %arg2
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck4, label %52, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
@@ -517,11 +599,11 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %27
+ThrowNullRef2:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %49
+ThrowNullRef4:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -544,16 +626,16 @@ entry:
   %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %0)
   store %System.String addrspace(1)* %1, %System.String addrspace(1)** %loc0
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 2
   %5 = bitcast [0 x i16] addrspace(1)* %4 to i16 addrspace(1)*
   store i16 addrspace(1)* %5, i16 addrspace(1)** %loc1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %3
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2
@@ -580,7 +662,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -691,15 +773,15 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %NullCheck132 = icmp ne i8* %21, null
-  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+  %NullCheck131 = icmp eq i8* %21, null
+  br i1 %NullCheck131, label %ThrowNullRef132, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = load i8, i8* %21, align 8
   %24 = zext i8 %23 to i32
   %25 = trunc i32 %24 to i8
-  %NullCheck134 = icmp ne i8* %20, null
-  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+  %NullCheck133 = icmp eq i8* %20, null
+  br i1 %NullCheck133, label %ThrowNullRef134, label %26
 
 ; <label>:26                                      ; preds = %22
   store i8 %25, i8* %20, align 8
@@ -709,16 +791,16 @@ entry:
   %28 = load i8*, i8** %arg0
   %29 = load i8*, i8** %arg1
   %30 = bitcast i8* %29 to i16*
-  %NullCheck128 = icmp ne i16* %30, null
-  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+  %NullCheck127 = icmp eq i16* %30, null
+  br i1 %NullCheck127, label %ThrowNullRef128, label %31
 
 ; <label>:31                                      ; preds = %27
   %32 = load i16, i16* %30, align 8
   %33 = sext i16 %32 to i32
   %34 = bitcast i8* %28 to i16*
   %35 = trunc i32 %33 to i16
-  %NullCheck130 = icmp ne i16* %34, null
-  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+  %NullCheck129 = icmp eq i16* %34, null
+  br i1 %NullCheck129, label %ThrowNullRef130, label %36
 
 ; <label>:36                                      ; preds = %31
   store i16 %35, i16* %34, align 8
@@ -728,16 +810,16 @@ entry:
   %38 = load i8*, i8** %arg0
   %39 = load i8*, i8** %arg1
   %40 = bitcast i8* %39 to i16*
-  %NullCheck120 = icmp ne i16* %40, null
-  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+  %NullCheck119 = icmp eq i16* %40, null
+  br i1 %NullCheck119, label %ThrowNullRef120, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i16, i16* %40, align 8
   %43 = sext i16 %42 to i32
   %44 = bitcast i8* %38 to i16*
   %45 = trunc i32 %43 to i16
-  %NullCheck122 = icmp ne i16* %44, null
-  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+  %NullCheck121 = icmp eq i16* %44, null
+  br i1 %NullCheck121, label %ThrowNullRef122, label %46
 
 ; <label>:46                                      ; preds = %41
   store i16 %45, i16* %44, align 8
@@ -745,15 +827,15 @@ entry:
   %48 = getelementptr inbounds i8, i8* %47, i64 2
   %49 = load i8*, i8** %arg1
   %50 = getelementptr inbounds i8, i8* %49, i64 2
-  %NullCheck124 = icmp ne i8* %50, null
-  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+  %NullCheck123 = icmp eq i8* %50, null
+  br i1 %NullCheck123, label %ThrowNullRef124, label %51
 
 ; <label>:51                                      ; preds = %46
   %52 = load i8, i8* %50, align 8
   %53 = zext i8 %52 to i32
   %54 = trunc i32 %53 to i8
-  %NullCheck126 = icmp ne i8* %48, null
-  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+  %NullCheck125 = icmp eq i8* %48, null
+  br i1 %NullCheck125, label %ThrowNullRef126, label %55
 
 ; <label>:55                                      ; preds = %51
   store i8 %54, i8* %48, align 8
@@ -763,14 +845,14 @@ entry:
   %57 = load i8*, i8** %arg0
   %58 = load i8*, i8** %arg1
   %59 = bitcast i8* %58 to i32*
-  %NullCheck116 = icmp ne i32* %59, null
-  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+  %NullCheck115 = icmp eq i32* %59, null
+  br i1 %NullCheck115, label %ThrowNullRef116, label %60
 
 ; <label>:60                                      ; preds = %56
   %61 = load i32, i32* %59, align 8
   %62 = bitcast i8* %57 to i32*
-  %NullCheck118 = icmp ne i32* %62, null
-  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+  %NullCheck117 = icmp eq i32* %62, null
+  br i1 %NullCheck117, label %ThrowNullRef118, label %63
 
 ; <label>:63                                      ; preds = %60
   store i32 %61, i32* %62, align 8
@@ -780,14 +862,14 @@ entry:
   %65 = load i8*, i8** %arg0
   %66 = load i8*, i8** %arg1
   %67 = bitcast i8* %66 to i32*
-  %NullCheck108 = icmp ne i32* %67, null
-  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+  %NullCheck107 = icmp eq i32* %67, null
+  br i1 %NullCheck107, label %ThrowNullRef108, label %68
 
 ; <label>:68                                      ; preds = %64
   %69 = load i32, i32* %67, align 8
   %70 = bitcast i8* %65 to i32*
-  %NullCheck110 = icmp ne i32* %70, null
-  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+  %NullCheck109 = icmp eq i32* %70, null
+  br i1 %NullCheck109, label %ThrowNullRef110, label %71
 
 ; <label>:71                                      ; preds = %68
   store i32 %69, i32* %70, align 8
@@ -795,15 +877,15 @@ entry:
   %73 = getelementptr inbounds i8, i8* %72, i64 4
   %74 = load i8*, i8** %arg1
   %75 = getelementptr inbounds i8, i8* %74, i64 4
-  %NullCheck112 = icmp ne i8* %75, null
-  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+  %NullCheck111 = icmp eq i8* %75, null
+  br i1 %NullCheck111, label %ThrowNullRef112, label %76
 
 ; <label>:76                                      ; preds = %71
   %77 = load i8, i8* %75, align 8
   %78 = zext i8 %77 to i32
   %79 = trunc i32 %78 to i8
-  %NullCheck114 = icmp ne i8* %73, null
-  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+  %NullCheck113 = icmp eq i8* %73, null
+  br i1 %NullCheck113, label %ThrowNullRef114, label %80
 
 ; <label>:80                                      ; preds = %76
   store i8 %79, i8* %73, align 8
@@ -813,14 +895,14 @@ entry:
   %82 = load i8*, i8** %arg0
   %83 = load i8*, i8** %arg1
   %84 = bitcast i8* %83 to i32*
-  %NullCheck100 = icmp ne i32* %84, null
-  br i1 %NullCheck100, label %85, label %ThrowNullRef99
+  %NullCheck99 = icmp eq i32* %84, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %85
 
 ; <label>:85                                      ; preds = %81
   %86 = load i32, i32* %84, align 8
   %87 = bitcast i8* %82 to i32*
-  %NullCheck102 = icmp ne i32* %87, null
-  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+  %NullCheck101 = icmp eq i32* %87, null
+  br i1 %NullCheck101, label %ThrowNullRef102, label %88
 
 ; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
@@ -829,16 +911,16 @@ entry:
   %91 = load i8*, i8** %arg1
   %92 = getelementptr inbounds i8, i8* %91, i64 4
   %93 = bitcast i8* %92 to i16*
-  %NullCheck104 = icmp ne i16* %93, null
-  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+  %NullCheck103 = icmp eq i16* %93, null
+  br i1 %NullCheck103, label %ThrowNullRef104, label %94
 
 ; <label>:94                                      ; preds = %88
   %95 = load i16, i16* %93, align 8
   %96 = sext i16 %95 to i32
   %97 = bitcast i8* %90 to i16*
   %98 = trunc i32 %96 to i16
-  %NullCheck106 = icmp ne i16* %97, null
-  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+  %NullCheck105 = icmp eq i16* %97, null
+  br i1 %NullCheck105, label %ThrowNullRef106, label %99
 
 ; <label>:99                                      ; preds = %94
   store i16 %98, i16* %97, align 8
@@ -848,14 +930,14 @@ entry:
   %101 = load i8*, i8** %arg0
   %102 = load i8*, i8** %arg1
   %103 = bitcast i8* %102 to i32*
-  %NullCheck88 = icmp ne i32* %103, null
-  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+  %NullCheck87 = icmp eq i32* %103, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %104
 
 ; <label>:104                                     ; preds = %100
   %105 = load i32, i32* %103, align 8
   %106 = bitcast i8* %101 to i32*
-  %NullCheck90 = icmp ne i32* %106, null
-  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+  %NullCheck89 = icmp eq i32* %106, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %107
 
 ; <label>:107                                     ; preds = %104
   store i32 %105, i32* %106, align 8
@@ -864,16 +946,16 @@ entry:
   %110 = load i8*, i8** %arg1
   %111 = getelementptr inbounds i8, i8* %110, i64 4
   %112 = bitcast i8* %111 to i16*
-  %NullCheck92 = icmp ne i16* %112, null
-  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+  %NullCheck91 = icmp eq i16* %112, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %113
 
 ; <label>:113                                     ; preds = %107
   %114 = load i16, i16* %112, align 8
   %115 = sext i16 %114 to i32
   %116 = bitcast i8* %109 to i16*
   %117 = trunc i32 %115 to i16
-  %NullCheck94 = icmp ne i16* %116, null
-  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+  %NullCheck93 = icmp eq i16* %116, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %118
 
 ; <label>:118                                     ; preds = %113
   store i16 %117, i16* %116, align 8
@@ -881,15 +963,15 @@ entry:
   %120 = getelementptr inbounds i8, i8* %119, i64 6
   %121 = load i8*, i8** %arg1
   %122 = getelementptr inbounds i8, i8* %121, i64 6
-  %NullCheck96 = icmp ne i8* %122, null
-  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+  %NullCheck95 = icmp eq i8* %122, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %123
 
 ; <label>:123                                     ; preds = %118
   %124 = load i8, i8* %122, align 8
   %125 = zext i8 %124 to i32
   %126 = trunc i32 %125 to i8
-  %NullCheck98 = icmp ne i8* %120, null
-  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+  %NullCheck97 = icmp eq i8* %120, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %127
 
 ; <label>:127                                     ; preds = %123
   store i8 %126, i8* %120, align 8
@@ -899,14 +981,14 @@ entry:
   %129 = load i8*, i8** %arg0
   %130 = load i8*, i8** %arg1
   %131 = bitcast i8* %130 to i64*
-  %NullCheck84 = icmp ne i64* %131, null
-  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+  %NullCheck83 = icmp eq i64* %131, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %132
 
 ; <label>:132                                     ; preds = %128
   %133 = load i64, i64* %131, align 8
   %134 = bitcast i8* %129 to i64*
-  %NullCheck86 = icmp ne i64* %134, null
-  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+  %NullCheck85 = icmp eq i64* %134, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %135
 
 ; <label>:135                                     ; preds = %132
   store i64 %133, i64* %134, align 8
@@ -916,14 +998,14 @@ entry:
   %137 = load i8*, i8** %arg0
   %138 = load i8*, i8** %arg1
   %139 = bitcast i8* %138 to i64*
-  %NullCheck76 = icmp ne i64* %139, null
-  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+  %NullCheck75 = icmp eq i64* %139, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %140
 
 ; <label>:140                                     ; preds = %136
   %141 = load i64, i64* %139, align 8
   %142 = bitcast i8* %137 to i64*
-  %NullCheck78 = icmp ne i64* %142, null
-  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+  %NullCheck77 = icmp eq i64* %142, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %143
 
 ; <label>:143                                     ; preds = %140
   store i64 %141, i64* %142, align 8
@@ -931,15 +1013,15 @@ entry:
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %NullCheck80 = icmp ne i8* %147, null
-  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+  %NullCheck79 = icmp eq i8* %147, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %148
 
 ; <label>:148                                     ; preds = %143
   %149 = load i8, i8* %147, align 8
   %150 = zext i8 %149 to i32
   %151 = trunc i32 %150 to i8
-  %NullCheck82 = icmp ne i8* %145, null
-  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+  %NullCheck81 = icmp eq i8* %145, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %152
 
 ; <label>:152                                     ; preds = %148
   store i8 %151, i8* %145, align 8
@@ -949,14 +1031,14 @@ entry:
   %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
   %156 = bitcast i8* %155 to i64*
-  %NullCheck68 = icmp ne i64* %156, null
-  br i1 %NullCheck68, label %157, label %ThrowNullRef67
+  %NullCheck67 = icmp eq i64* %156, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %157
 
 ; <label>:157                                     ; preds = %153
   %158 = load i64, i64* %156, align 8
   %159 = bitcast i8* %154 to i64*
-  %NullCheck70 = icmp ne i64* %159, null
-  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+  %NullCheck69 = icmp eq i64* %159, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %160
 
 ; <label>:160                                     ; preds = %157
   store i64 %158, i64* %159, align 8
@@ -965,16 +1047,16 @@ entry:
   %163 = load i8*, i8** %arg1
   %164 = getelementptr inbounds i8, i8* %163, i64 8
   %165 = bitcast i8* %164 to i16*
-  %NullCheck72 = icmp ne i16* %165, null
-  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+  %NullCheck71 = icmp eq i16* %165, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %166
 
 ; <label>:166                                     ; preds = %160
   %167 = load i16, i16* %165, align 8
   %168 = sext i16 %167 to i32
   %169 = bitcast i8* %162 to i16*
   %170 = trunc i32 %168 to i16
-  %NullCheck74 = icmp ne i16* %169, null
-  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+  %NullCheck73 = icmp eq i16* %169, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %171
 
 ; <label>:171                                     ; preds = %166
   store i16 %170, i16* %169, align 8
@@ -984,14 +1066,14 @@ entry:
   %173 = load i8*, i8** %arg0
   %174 = load i8*, i8** %arg1
   %175 = bitcast i8* %174 to i64*
-  %NullCheck56 = icmp ne i64* %175, null
-  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+  %NullCheck55 = icmp eq i64* %175, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %176
 
 ; <label>:176                                     ; preds = %172
   %177 = load i64, i64* %175, align 8
   %178 = bitcast i8* %173 to i64*
-  %NullCheck58 = icmp ne i64* %178, null
-  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+  %NullCheck57 = icmp eq i64* %178, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %179
 
 ; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
@@ -1000,16 +1082,16 @@ entry:
   %182 = load i8*, i8** %arg1
   %183 = getelementptr inbounds i8, i8* %182, i64 8
   %184 = bitcast i8* %183 to i16*
-  %NullCheck60 = icmp ne i16* %184, null
-  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+  %NullCheck59 = icmp eq i16* %184, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %185
 
 ; <label>:185                                     ; preds = %179
   %186 = load i16, i16* %184, align 8
   %187 = sext i16 %186 to i32
   %188 = bitcast i8* %181 to i16*
   %189 = trunc i32 %187 to i16
-  %NullCheck62 = icmp ne i16* %188, null
-  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+  %NullCheck61 = icmp eq i16* %188, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %190
 
 ; <label>:190                                     ; preds = %185
   store i16 %189, i16* %188, align 8
@@ -1017,15 +1099,15 @@ entry:
   %192 = getelementptr inbounds i8, i8* %191, i64 10
   %193 = load i8*, i8** %arg1
   %194 = getelementptr inbounds i8, i8* %193, i64 10
-  %NullCheck64 = icmp ne i8* %194, null
-  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+  %NullCheck63 = icmp eq i8* %194, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %195
 
 ; <label>:195                                     ; preds = %190
   %196 = load i8, i8* %194, align 8
   %197 = zext i8 %196 to i32
   %198 = trunc i32 %197 to i8
-  %NullCheck66 = icmp ne i8* %192, null
-  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+  %NullCheck65 = icmp eq i8* %192, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %199
 
 ; <label>:199                                     ; preds = %195
   store i8 %198, i8* %192, align 8
@@ -1035,14 +1117,14 @@ entry:
   %201 = load i8*, i8** %arg0
   %202 = load i8*, i8** %arg1
   %203 = bitcast i8* %202 to i64*
-  %NullCheck48 = icmp ne i64* %203, null
-  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+  %NullCheck47 = icmp eq i64* %203, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %204
 
 ; <label>:204                                     ; preds = %200
   %205 = load i64, i64* %203, align 8
   %206 = bitcast i8* %201 to i64*
-  %NullCheck50 = icmp ne i64* %206, null
-  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+  %NullCheck49 = icmp eq i64* %206, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %207
 
 ; <label>:207                                     ; preds = %204
   store i64 %205, i64* %206, align 8
@@ -1051,14 +1133,14 @@ entry:
   %210 = load i8*, i8** %arg1
   %211 = getelementptr inbounds i8, i8* %210, i64 8
   %212 = bitcast i8* %211 to i32*
-  %NullCheck52 = icmp ne i32* %212, null
-  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+  %NullCheck51 = icmp eq i32* %212, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %213
 
 ; <label>:213                                     ; preds = %207
   %214 = load i32, i32* %212, align 8
   %215 = bitcast i8* %209 to i32*
-  %NullCheck54 = icmp ne i32* %215, null
-  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+  %NullCheck53 = icmp eq i32* %215, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %216
 
 ; <label>:216                                     ; preds = %213
   store i32 %214, i32* %215, align 8
@@ -1068,14 +1150,14 @@ entry:
   %218 = load i8*, i8** %arg0
   %219 = load i8*, i8** %arg1
   %220 = bitcast i8* %219 to i64*
-  %NullCheck36 = icmp ne i64* %220, null
-  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64* %220, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %221
 
 ; <label>:221                                     ; preds = %217
   %222 = load i64, i64* %220, align 8
   %223 = bitcast i8* %218 to i64*
-  %NullCheck38 = icmp ne i64* %223, null
-  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+  %NullCheck37 = icmp eq i64* %223, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %224
 
 ; <label>:224                                     ; preds = %221
   store i64 %222, i64* %223, align 8
@@ -1084,14 +1166,14 @@ entry:
   %227 = load i8*, i8** %arg1
   %228 = getelementptr inbounds i8, i8* %227, i64 8
   %229 = bitcast i8* %228 to i32*
-  %NullCheck40 = icmp ne i32* %229, null
-  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i32* %229, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %230
 
 ; <label>:230                                     ; preds = %224
   %231 = load i32, i32* %229, align 8
   %232 = bitcast i8* %226 to i32*
-  %NullCheck42 = icmp ne i32* %232, null
-  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+  %NullCheck41 = icmp eq i32* %232, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %233
 
 ; <label>:233                                     ; preds = %230
   store i32 %231, i32* %232, align 8
@@ -1099,15 +1181,15 @@ entry:
   %235 = getelementptr inbounds i8, i8* %234, i64 12
   %236 = load i8*, i8** %arg1
   %237 = getelementptr inbounds i8, i8* %236, i64 12
-  %NullCheck44 = icmp ne i8* %237, null
-  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i8* %237, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %238
 
 ; <label>:238                                     ; preds = %233
   %239 = load i8, i8* %237, align 8
   %240 = zext i8 %239 to i32
   %241 = trunc i32 %240 to i8
-  %NullCheck46 = icmp ne i8* %235, null
-  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+  %NullCheck45 = icmp eq i8* %235, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %242
 
 ; <label>:242                                     ; preds = %238
   store i8 %241, i8* %235, align 8
@@ -1117,14 +1199,14 @@ entry:
   %244 = load i8*, i8** %arg0
   %245 = load i8*, i8** %arg1
   %246 = bitcast i8* %245 to i64*
-  %NullCheck24 = icmp ne i64* %246, null
-  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64* %246, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %247
 
 ; <label>:247                                     ; preds = %243
   %248 = load i64, i64* %246, align 8
   %249 = bitcast i8* %244 to i64*
-  %NullCheck26 = icmp ne i64* %249, null
-  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64* %249, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %250
 
 ; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
@@ -1133,14 +1215,14 @@ entry:
   %253 = load i8*, i8** %arg1
   %254 = getelementptr inbounds i8, i8* %253, i64 8
   %255 = bitcast i8* %254 to i32*
-  %NullCheck28 = icmp ne i32* %255, null
-  br i1 %NullCheck28, label %256, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i32* %255, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %256
 
 ; <label>:256                                     ; preds = %250
   %257 = load i32, i32* %255, align 8
   %258 = bitcast i8* %252 to i32*
-  %NullCheck30 = icmp ne i32* %258, null
-  br i1 %NullCheck30, label %259, label %ThrowNullRef29
+  %NullCheck29 = icmp eq i32* %258, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %259
 
 ; <label>:259                                     ; preds = %256
   store i32 %257, i32* %258, align 8
@@ -1149,16 +1231,16 @@ entry:
   %262 = load i8*, i8** %arg1
   %263 = getelementptr inbounds i8, i8* %262, i64 12
   %264 = bitcast i8* %263 to i16*
-  %NullCheck32 = icmp ne i16* %264, null
-  br i1 %NullCheck32, label %265, label %ThrowNullRef31
+  %NullCheck31 = icmp eq i16* %264, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %265
 
 ; <label>:265                                     ; preds = %259
   %266 = load i16, i16* %264, align 8
   %267 = sext i16 %266 to i32
   %268 = bitcast i8* %261 to i16*
   %269 = trunc i32 %267 to i16
-  %NullCheck34 = icmp ne i16* %268, null
-  br i1 %NullCheck34, label %270, label %ThrowNullRef33
+  %NullCheck33 = icmp eq i16* %268, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %270
 
 ; <label>:270                                     ; preds = %265
   store i16 %269, i16* %268, align 8
@@ -1168,14 +1250,14 @@ entry:
   %272 = load i8*, i8** %arg0
   %273 = load i8*, i8** %arg1
   %274 = bitcast i8* %273 to i64*
-  %NullCheck8 = icmp ne i64* %274, null
-  br i1 %NullCheck8, label %275, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64* %274, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %275
 
 ; <label>:275                                     ; preds = %271
   %276 = load i64, i64* %274, align 8
   %277 = bitcast i8* %272 to i64*
-  %NullCheck10 = icmp ne i64* %277, null
-  br i1 %NullCheck10, label %278, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %277, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %278
 
 ; <label>:278                                     ; preds = %275
   store i64 %276, i64* %277, align 8
@@ -1184,14 +1266,14 @@ entry:
   %281 = load i8*, i8** %arg1
   %282 = getelementptr inbounds i8, i8* %281, i64 8
   %283 = bitcast i8* %282 to i32*
-  %NullCheck12 = icmp ne i32* %283, null
-  br i1 %NullCheck12, label %284, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i32* %283, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %284
 
 ; <label>:284                                     ; preds = %278
   %285 = load i32, i32* %283, align 8
   %286 = bitcast i8* %280 to i32*
-  %NullCheck14 = icmp ne i32* %286, null
-  br i1 %NullCheck14, label %287, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i32* %286, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %287
 
 ; <label>:287                                     ; preds = %284
   store i32 %285, i32* %286, align 8
@@ -1200,16 +1282,16 @@ entry:
   %290 = load i8*, i8** %arg1
   %291 = getelementptr inbounds i8, i8* %290, i64 12
   %292 = bitcast i8* %291 to i16*
-  %NullCheck16 = icmp ne i16* %292, null
-  br i1 %NullCheck16, label %293, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i16* %292, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %293
 
 ; <label>:293                                     ; preds = %287
   %294 = load i16, i16* %292, align 8
   %295 = sext i16 %294 to i32
   %296 = bitcast i8* %289 to i16*
   %297 = trunc i32 %295 to i16
-  %NullCheck18 = icmp ne i16* %296, null
-  br i1 %NullCheck18, label %298, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i16* %296, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %298
 
 ; <label>:298                                     ; preds = %293
   store i16 %297, i16* %296, align 8
@@ -1217,15 +1299,15 @@ entry:
   %300 = getelementptr inbounds i8, i8* %299, i64 14
   %301 = load i8*, i8** %arg1
   %302 = getelementptr inbounds i8, i8* %301, i64 14
-  %NullCheck20 = icmp ne i8* %302, null
-  br i1 %NullCheck20, label %303, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i8* %302, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %303
 
 ; <label>:303                                     ; preds = %298
   %304 = load i8, i8* %302, align 8
   %305 = zext i8 %304 to i32
   %306 = trunc i32 %305 to i8
-  %NullCheck22 = icmp ne i8* %300, null
-  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i8* %300, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %307
 
 ; <label>:307                                     ; preds = %303
   store i8 %306, i8* %300, align 8
@@ -1235,14 +1317,14 @@ entry:
   %309 = load i8*, i8** %arg0
   %310 = load i8*, i8** %arg1
   %311 = bitcast i8* %310 to i64*
-  %NullCheck = icmp ne i64* %311, null
-  br i1 %NullCheck, label %312, label %ThrowNullRef
+  %NullCheck = icmp eq i64* %311, null
+  br i1 %NullCheck, label %ThrowNullRef, label %312
 
 ; <label>:312                                     ; preds = %308
   %313 = load i64, i64* %311, align 8
   %314 = bitcast i8* %309 to i64*
-  %NullCheck2 = icmp ne i64* %314, null
-  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64* %314, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %315
 
 ; <label>:315                                     ; preds = %312
   store i64 %313, i64* %314, align 8
@@ -1251,14 +1333,14 @@ entry:
   %318 = load i8*, i8** %arg1
   %319 = getelementptr inbounds i8, i8* %318, i64 8
   %320 = bitcast i8* %319 to i64*
-  %NullCheck4 = icmp ne i64* %320, null
-  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64* %320, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %321
 
 ; <label>:321                                     ; preds = %315
   %322 = load i64, i64* %320, align 8
   %323 = bitcast i8* %317 to i64*
-  %NullCheck6 = icmp ne i64* %323, null
-  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64* %323, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %324
 
 ; <label>:324                                     ; preds = %321
   store i64 %322, i64* %323, align 8
@@ -1286,15 +1368,15 @@ entry:
 ; <label>:338                                     ; preds = %333
   %339 = load i8*, i8** %arg0
   %340 = load i8*, i8** %arg1
-  %NullCheck136 = icmp ne i8* %340, null
-  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+  %NullCheck135 = icmp eq i8* %340, null
+  br i1 %NullCheck135, label %ThrowNullRef136, label %341
 
 ; <label>:341                                     ; preds = %338
   %342 = load i8, i8* %340, align 8
   %343 = zext i8 %342 to i32
   %344 = trunc i32 %343 to i8
-  %NullCheck138 = icmp ne i8* %339, null
-  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+  %NullCheck137 = icmp eq i8* %339, null
+  br i1 %NullCheck137, label %ThrowNullRef138, label %345
 
 ; <label>:345                                     ; preds = %341
   store i8 %344, i8* %339, align 8
@@ -1317,16 +1399,16 @@ entry:
   %357 = load i8*, i8** %arg0
   %358 = load i8*, i8** %arg1
   %359 = bitcast i8* %358 to i16*
-  %NullCheck140 = icmp ne i16* %359, null
-  br i1 %NullCheck140, label %360, label %ThrowNullRef139
+  %NullCheck139 = icmp eq i16* %359, null
+  br i1 %NullCheck139, label %ThrowNullRef140, label %360
 
 ; <label>:360                                     ; preds = %356
   %361 = load i16, i16* %359, align 8
   %362 = sext i16 %361 to i32
   %363 = bitcast i8* %357 to i16*
   %364 = trunc i32 %362 to i16
-  %NullCheck142 = icmp ne i16* %363, null
-  br i1 %NullCheck142, label %365, label %ThrowNullRef141
+  %NullCheck141 = icmp eq i16* %363, null
+  br i1 %NullCheck141, label %ThrowNullRef142, label %365
 
 ; <label>:365                                     ; preds = %360
   store i16 %364, i16* %363, align 8
@@ -1352,14 +1434,14 @@ entry:
   %378 = load i8*, i8** %arg0
   %379 = load i8*, i8** %arg1
   %380 = bitcast i8* %379 to i32*
-  %NullCheck144 = icmp ne i32* %380, null
-  br i1 %NullCheck144, label %381, label %ThrowNullRef143
+  %NullCheck143 = icmp eq i32* %380, null
+  br i1 %NullCheck143, label %ThrowNullRef144, label %381
 
 ; <label>:381                                     ; preds = %377
   %382 = load i32, i32* %380, align 8
   %383 = bitcast i8* %378 to i32*
-  %NullCheck146 = icmp ne i32* %383, null
-  br i1 %NullCheck146, label %384, label %ThrowNullRef145
+  %NullCheck145 = icmp eq i32* %383, null
+  br i1 %NullCheck145, label %ThrowNullRef146, label %384
 
 ; <label>:384                                     ; preds = %381
   store i32 %382, i32* %383, align 8
@@ -1384,14 +1466,14 @@ entry:
   %395 = load i8*, i8** %arg0
   %396 = load i8*, i8** %arg1
   %397 = bitcast i8* %396 to i64*
-  %NullCheck164 = icmp ne i64* %397, null
-  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+  %NullCheck163 = icmp eq i64* %397, null
+  br i1 %NullCheck163, label %ThrowNullRef164, label %398
 
 ; <label>:398                                     ; preds = %394
   %399 = load i64, i64* %397, align 8
   %400 = bitcast i8* %395 to i64*
-  %NullCheck166 = icmp ne i64* %400, null
-  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+  %NullCheck165 = icmp eq i64* %400, null
+  br i1 %NullCheck165, label %ThrowNullRef166, label %401
 
 ; <label>:401                                     ; preds = %398
   store i64 %399, i64* %400, align 8
@@ -1400,14 +1482,14 @@ entry:
   %404 = load i8*, i8** %arg1
   %405 = getelementptr inbounds i8, i8* %404, i64 8
   %406 = bitcast i8* %405 to i64*
-  %NullCheck168 = icmp ne i64* %406, null
-  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+  %NullCheck167 = icmp eq i64* %406, null
+  br i1 %NullCheck167, label %ThrowNullRef168, label %407
 
 ; <label>:407                                     ; preds = %401
   %408 = load i64, i64* %406, align 8
   %409 = bitcast i8* %403 to i64*
-  %NullCheck170 = icmp ne i64* %409, null
-  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+  %NullCheck169 = icmp eq i64* %409, null
+  br i1 %NullCheck169, label %ThrowNullRef170, label %410
 
 ; <label>:410                                     ; preds = %407
   store i64 %408, i64* %409, align 8
@@ -1437,14 +1519,14 @@ entry:
   %425 = load i8*, i8** %arg0
   %426 = load i8*, i8** %arg1
   %427 = bitcast i8* %426 to i64*
-  %NullCheck148 = icmp ne i64* %427, null
-  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+  %NullCheck147 = icmp eq i64* %427, null
+  br i1 %NullCheck147, label %ThrowNullRef148, label %428
 
 ; <label>:428                                     ; preds = %424
   %429 = load i64, i64* %427, align 8
   %430 = bitcast i8* %425 to i64*
-  %NullCheck150 = icmp ne i64* %430, null
-  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+  %NullCheck149 = icmp eq i64* %430, null
+  br i1 %NullCheck149, label %ThrowNullRef150, label %431
 
 ; <label>:431                                     ; preds = %428
   store i64 %429, i64* %430, align 8
@@ -1466,14 +1548,14 @@ entry:
   %441 = load i8*, i8** %arg0
   %442 = load i8*, i8** %arg1
   %443 = bitcast i8* %442 to i32*
-  %NullCheck152 = icmp ne i32* %443, null
-  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+  %NullCheck151 = icmp eq i32* %443, null
+  br i1 %NullCheck151, label %ThrowNullRef152, label %444
 
 ; <label>:444                                     ; preds = %440
   %445 = load i32, i32* %443, align 8
   %446 = bitcast i8* %441 to i32*
-  %NullCheck154 = icmp ne i32* %446, null
-  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+  %NullCheck153 = icmp eq i32* %446, null
+  br i1 %NullCheck153, label %ThrowNullRef154, label %447
 
 ; <label>:447                                     ; preds = %444
   store i32 %445, i32* %446, align 8
@@ -1495,16 +1577,16 @@ entry:
   %457 = load i8*, i8** %arg0
   %458 = load i8*, i8** %arg1
   %459 = bitcast i8* %458 to i16*
-  %NullCheck156 = icmp ne i16* %459, null
-  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+  %NullCheck155 = icmp eq i16* %459, null
+  br i1 %NullCheck155, label %ThrowNullRef156, label %460
 
 ; <label>:460                                     ; preds = %456
   %461 = load i16, i16* %459, align 8
   %462 = sext i16 %461 to i32
   %463 = bitcast i8* %457 to i16*
   %464 = trunc i32 %462 to i16
-  %NullCheck158 = icmp ne i16* %463, null
-  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+  %NullCheck157 = icmp eq i16* %463, null
+  br i1 %NullCheck157, label %ThrowNullRef158, label %465
 
 ; <label>:465                                     ; preds = %460
   store i16 %464, i16* %463, align 8
@@ -1525,15 +1607,15 @@ entry:
 ; <label>:474                                     ; preds = %470
   %475 = load i8*, i8** %arg0
   %476 = load i8*, i8** %arg1
-  %NullCheck160 = icmp ne i8* %476, null
-  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+  %NullCheck159 = icmp eq i8* %476, null
+  br i1 %NullCheck159, label %ThrowNullRef160, label %477
 
 ; <label>:477                                     ; preds = %474
   %478 = load i8, i8* %476, align 8
   %479 = zext i8 %478 to i32
   %480 = trunc i32 %479 to i8
-  %NullCheck162 = icmp ne i8* %475, null
-  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+  %NullCheck161 = icmp eq i8* %475, null
+  br i1 %NullCheck161, label %ThrowNullRef162, label %481
 
 ; <label>:481                                     ; preds = %477
   store i8 %480, i8* %475, align 8
@@ -1553,343 +1635,343 @@ ThrowNullRef:                                     ; preds = %308
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %312
+ThrowNullRef2:                                    ; preds = %312
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %315
+ThrowNullRef4:                                    ; preds = %315
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %321
+ThrowNullRef6:                                    ; preds = %321
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %271
+ThrowNullRef8:                                    ; preds = %271
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %275
+ThrowNullRef10:                                   ; preds = %275
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %278
+ThrowNullRef12:                                   ; preds = %278
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %284
+ThrowNullRef14:                                   ; preds = %284
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %287
+ThrowNullRef16:                                   ; preds = %287
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %293
+ThrowNullRef18:                                   ; preds = %293
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %298
+ThrowNullRef20:                                   ; preds = %298
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %303
+ThrowNullRef22:                                   ; preds = %303
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %243
+ThrowNullRef24:                                   ; preds = %243
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %247
+ThrowNullRef26:                                   ; preds = %247
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %250
+ThrowNullRef28:                                   ; preds = %250
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %256
+ThrowNullRef30:                                   ; preds = %256
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %259
+ThrowNullRef32:                                   ; preds = %259
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %265
+ThrowNullRef34:                                   ; preds = %265
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %217
+ThrowNullRef36:                                   ; preds = %217
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %221
+ThrowNullRef38:                                   ; preds = %221
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %224
+ThrowNullRef40:                                   ; preds = %224
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %230
+ThrowNullRef42:                                   ; preds = %230
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %233
+ThrowNullRef44:                                   ; preds = %233
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %238
+ThrowNullRef46:                                   ; preds = %238
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %200
+ThrowNullRef48:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %204
+ThrowNullRef50:                                   ; preds = %204
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %207
+ThrowNullRef52:                                   ; preds = %207
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %213
+ThrowNullRef54:                                   ; preds = %213
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %172
+ThrowNullRef56:                                   ; preds = %172
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %176
+ThrowNullRef58:                                   ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %179
+ThrowNullRef60:                                   ; preds = %179
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %185
+ThrowNullRef62:                                   ; preds = %185
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %190
+ThrowNullRef64:                                   ; preds = %190
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %195
+ThrowNullRef66:                                   ; preds = %195
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %153
+ThrowNullRef68:                                   ; preds = %153
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %157
+ThrowNullRef70:                                   ; preds = %157
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %160
+ThrowNullRef72:                                   ; preds = %160
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %166
+ThrowNullRef74:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %136
+ThrowNullRef76:                                   ; preds = %136
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %140
+ThrowNullRef78:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %143
+ThrowNullRef80:                                   ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %148
+ThrowNullRef82:                                   ; preds = %148
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %128
+ThrowNullRef84:                                   ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %132
+ThrowNullRef86:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %100
+ThrowNullRef88:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %104
+ThrowNullRef90:                                   ; preds = %104
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %107
+ThrowNullRef92:                                   ; preds = %107
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %113
+ThrowNullRef94:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %118
+ThrowNullRef96:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %123
+ThrowNullRef98:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %81
+ThrowNullRef100:                                  ; preds = %81
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef101:                                  ; preds = %85
+ThrowNullRef102:                                  ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef103:                                  ; preds = %88
+ThrowNullRef104:                                  ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef105:                                  ; preds = %94
+ThrowNullRef106:                                  ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef107:                                  ; preds = %64
+ThrowNullRef108:                                  ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef109:                                  ; preds = %68
+ThrowNullRef110:                                  ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef111:                                  ; preds = %71
+ThrowNullRef112:                                  ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef113:                                  ; preds = %76
+ThrowNullRef114:                                  ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef115:                                  ; preds = %56
+ThrowNullRef116:                                  ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef117:                                  ; preds = %60
+ThrowNullRef118:                                  ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef119:                                  ; preds = %37
+ThrowNullRef120:                                  ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef121:                                  ; preds = %41
+ThrowNullRef122:                                  ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef123:                                  ; preds = %46
+ThrowNullRef124:                                  ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef125:                                  ; preds = %51
+ThrowNullRef126:                                  ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef127:                                  ; preds = %27
+ThrowNullRef128:                                  ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef129:                                  ; preds = %31
+ThrowNullRef130:                                  ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef131:                                  ; preds = %19
+ThrowNullRef132:                                  ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef133:                                  ; preds = %22
+ThrowNullRef134:                                  ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef135:                                  ; preds = %338
+ThrowNullRef136:                                  ; preds = %338
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef137:                                  ; preds = %341
+ThrowNullRef138:                                  ; preds = %341
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef139:                                  ; preds = %356
+ThrowNullRef140:                                  ; preds = %356
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef141:                                  ; preds = %360
+ThrowNullRef142:                                  ; preds = %360
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef143:                                  ; preds = %377
+ThrowNullRef144:                                  ; preds = %377
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef145:                                  ; preds = %381
+ThrowNullRef146:                                  ; preds = %381
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef147:                                  ; preds = %424
+ThrowNullRef148:                                  ; preds = %424
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef149:                                  ; preds = %428
+ThrowNullRef150:                                  ; preds = %428
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef151:                                  ; preds = %440
+ThrowNullRef152:                                  ; preds = %440
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef153:                                  ; preds = %444
+ThrowNullRef154:                                  ; preds = %444
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef155:                                  ; preds = %456
+ThrowNullRef156:                                  ; preds = %456
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef157:                                  ; preds = %460
+ThrowNullRef158:                                  ; preds = %460
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef159:                                  ; preds = %474
+ThrowNullRef160:                                  ; preds = %474
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef161:                                  ; preds = %477
+ThrowNullRef162:                                  ; preds = %477
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef163:                                  ; preds = %394
+ThrowNullRef164:                                  ; preds = %394
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef165:                                  ; preds = %398
+ThrowNullRef166:                                  ; preds = %398
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef167:                                  ; preds = %401
+ThrowNullRef168:                                  ; preds = %401
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef169:                                  ; preds = %407
+ThrowNullRef170:                                  ; preds = %407
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1939,8 +2021,8 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
-  br i1 %NullCheck, label %22, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %ThrowNullRef, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
@@ -1948,8 +2030,8 @@ entry:
   store i32 %24, i32* %loc0
   %25 = load i32, i32* %loc0
   %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %26, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %27
 
 ; <label>:27                                      ; preds = %22
   %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
@@ -1971,7 +2053,7 @@ ThrowNullRef:                                     ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1989,8 +2071,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -2022,15 +2104,15 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2048,16 +2130,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
   %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
   store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %15
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
@@ -2072,8 +2154,8 @@ entry:
   %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
   %29 = ptrtoint i16 addrspace(1)* %28 to i64
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %19
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
@@ -2089,19 +2171,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2114,8 +2196,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
@@ -2128,7 +2210,7 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[loadElem]
+Failed to read AppDomain.PrepareDataForSetup[storeElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
@@ -2202,8 +2284,8 @@ entry:
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
-  br i1 %NullCheck24, label %27, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = load i64, i64 addrspace(1)* %26
@@ -2218,8 +2300,8 @@ entry:
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
-  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
   %41 = load i64, i64 addrspace(1)* %39
@@ -2236,8 +2318,8 @@ entry:
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
-  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
   %54 = load i64, i64 addrspace(1)* %52
@@ -2252,8 +2334,8 @@ entry:
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
   %67 = load i64, i64 addrspace(1)* %65
@@ -2270,8 +2352,8 @@ entry:
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
-  br i1 %NullCheck16, label %79, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
   %80 = load i64, i64 addrspace(1)* %78
@@ -2286,8 +2368,8 @@ entry:
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
-  br i1 %NullCheck18, label %92, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
   %93 = load i64, i64 addrspace(1)* %91
@@ -2304,8 +2386,8 @@ entry:
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
-  br i1 %NullCheck12, label %105, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = load i64, i64 addrspace(1)* %104
@@ -2320,8 +2402,8 @@ entry:
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
-  br i1 %NullCheck14, label %118, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
   %119 = load i64, i64 addrspace(1)* %117
@@ -2337,8 +2419,8 @@ entry:
 
 ; <label>:128                                     ; preds = %20
   %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
-  br i1 %NullCheck4, label %130, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %129, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %130
 
 ; <label>:130                                     ; preds = %128
   %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
@@ -2346,8 +2428,8 @@ entry:
   %133 = load i16, i16 addrspace(1)* %132, align 8
   %134 = zext i16 %133 to i32
   %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
-  br i1 %NullCheck6, label %136, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %135, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %136
 
 ; <label>:136                                     ; preds = %130
   %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
@@ -2360,8 +2442,8 @@ entry:
 
 ; <label>:143                                     ; preds = %136
   %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
-  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %144, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %145
 
 ; <label>:145                                     ; preds = %143
   %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
@@ -2369,8 +2451,8 @@ entry:
   %148 = load i16, i16 addrspace(1)* %147, align 8
   %149 = zext i16 %148 to i32
   %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %150, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %151
 
 ; <label>:151                                     ; preds = %145
   %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
@@ -2388,8 +2470,8 @@ entry:
 
 ; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
-  br i1 %NullCheck, label %163, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %ThrowNullRef, label %163
 
 ; <label>:163                                     ; preds = %161
   %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
@@ -2399,8 +2481,8 @@ entry:
 
 ; <label>:167                                     ; preds = %163
   %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
-  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %168, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %169
 
 ; <label>:169                                     ; preds = %167
   %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
@@ -2432,55 +2514,55 @@ ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %167
+ThrowNullRef2:                                    ; preds = %167
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %128
+ThrowNullRef4:                                    ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %130
+ThrowNullRef6:                                    ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %143
+ThrowNullRef8:                                    ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %145
+ThrowNullRef10:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %102
+ThrowNullRef12:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %105
+ThrowNullRef14:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %76
+ThrowNullRef16:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %79
+ThrowNullRef18:                                   ; preds = %79
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %50
+ThrowNullRef20:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %53
+ThrowNullRef22:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %24
+ThrowNullRef24:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %27
+ThrowNullRef26:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2503,15 +2585,15 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2519,16 +2601,16 @@ entry:
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
   store i32 %8, i32* %loc0
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
   %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
   store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
@@ -2546,16 +2628,16 @@ entry:
 
 ; <label>:23                                      ; preds = %64
   %24 = load i16*, i16** %loc3
-  %NullCheck12 = icmp ne i16* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i16* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
   store i32 %27, i32* %loc5
   %28 = load i16*, i16** %loc4
-  %NullCheck14 = icmp ne i16* %28, null
-  br i1 %NullCheck14, label %29, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %28, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = load i16, i16* %28, align 8
@@ -2620,15 +2702,15 @@ entry:
 
 ; <label>:67                                      ; preds = %64
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
-  br i1 %NullCheck8, label %69, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %68, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %69
 
 ; <label>:69                                      ; preds = %67
   %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
   %71 = load i32, i32 addrspace(1)* %70
   %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
-  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %73
 
 ; <label>:73                                      ; preds = %69
   %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
@@ -2645,31 +2727,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %67
+ThrowNullRef8:                                    ; preds = %67
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %69
+ThrowNullRef10:                                   ; preds = %69
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2710,14 +2792,14 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
   %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
@@ -2730,14 +2812,14 @@ entry:
 
 ; <label>:11                                      ; preds = %4
   %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
   %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
@@ -2749,14 +2831,14 @@ entry:
 
 ; <label>:22                                      ; preds = %16
   %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
   %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
-  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
-  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
@@ -2804,23 +2886,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2836,7 +2918,280 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[loadElem]
+Successfully read RuntimeType.IsAssignableFrom
+
+define i8 @RuntimeType.IsAssignableFrom(%System.RuntimeType addrspace(1)* %param0, %System.Type addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.RuntimeType addrspace(1)*
+  %arg1 = alloca %System.Type addrspace(1)*
+  %loc0 = alloca %System.RuntimeType addrspace(1)*
+  %loc1 = alloca %"System.Type[]" addrspace(1)*
+  %loc2 = alloca i32
+  store %System.RuntimeType addrspace(1)* %param0, %System.RuntimeType addrspace(1)** %this
+  store %System.Type addrspace(1)* %param1, %System.Type addrspace(1)** %arg1
+  %0 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %1 = icmp ne %System.Type addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i8 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %5 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %6 = bitcast %System.Type addrspace(1)* %4 to %System.Object addrspace(1)*
+  %7 = bitcast %System.RuntimeType addrspace(1)* %5 to %System.Object addrspace(1)*
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %6, %System.Object addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %3
+  ret i8 1
+
+; <label>:12                                      ; preds = %3
+  %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 152
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 32
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
+  %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
+  %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
+  store %System.RuntimeType addrspace(1)* %25, %System.RuntimeType addrspace(1)** %loc0
+  %26 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %27 = icmp eq %System.RuntimeType addrspace(1)* %26, null
+  br i1 %27, label %34, label %28
+
+; <label>:28                                      ; preds = %15
+  %29 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %30 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)*)*)(%System.RuntimeType addrspace(1)* %29, %System.RuntimeType addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+; <label>:34                                      ; preds = %15
+  %35 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %36 = call %System.Reflection.Emit.TypeBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Reflection.Emit.TypeBuilder addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %35)
+  %37 = icmp eq %System.Reflection.Emit.TypeBuilder addrspace(1)* %36, null
+  br i1 %37, label %139, label %38
+
+; <label>:38                                      ; preds = %34
+  %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %42
+
+; <label>:42                                      ; preds = %38
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 152
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 40
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
+  %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
+  %53 = zext i8 %52 to i32
+  %54 = icmp eq i32 %53, 0
+  br i1 %54, label %56, label %55
+
+; <label>:55                                      ; preds = %42
+  ret i8 1
+
+; <label>:56                                      ; preds = %42
+  %57 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %58 = bitcast %System.RuntimeType addrspace(1)* %57 to %System.Type addrspace(1)*
+  %59 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %58)
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %64 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.Type addrspace(1)* %63, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = bitcast %System.RuntimeType addrspace(1)* %64 to %System.Type addrspace(1)*
+  %67 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %63, %System.Type addrspace(1)* %66)
+  %68 = zext i8 %67 to i32
+  %69 = trunc i32 %68 to i8
+  ret i8 %69
+
+; <label>:70                                      ; preds = %56
+  %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
+  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %73
+
+; <label>:73                                      ; preds = %70
+  %74 = load i64, i64 addrspace(1)* %72
+  %75 = add i64 %74, 128
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = add i64 %77, 0
+  %79 = inttoptr i64 %78 to i64*
+  %80 = load i64, i64* %79
+  %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
+  %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
+  %83 = call i8 %82(%System.Type addrspace(1)* %81)
+  %84 = zext i8 %83 to i32
+  %85 = icmp eq i32 %84, 0
+  br i1 %85, label %139, label %86
+
+; <label>:86                                      ; preds = %73
+  %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
+  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %89
+
+; <label>:89                                      ; preds = %86
+  %90 = load i64, i64 addrspace(1)* %88
+  %91 = add i64 %90, 128
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = add i64 %93, 24
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
+  %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
+  %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
+  store %"System.Type[]" addrspace(1)* %99, %"System.Type[]" addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %129
+
+; <label>:100                                     ; preds = %132
+  %101 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %102 = load i32, i32* %loc2
+  %NullCheck11 = icmp eq %"System.Type[]" addrspace(1)* %101, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %103
+
+; <label>:103                                     ; preds = %100
+  %104 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 1
+  %105 = load i32, i32 addrspace(1)* %104
+  %106 = zext i32 %105 to i64
+  %107 = zext i32 %102 to i64
+  %BoundsCheck = icmp uge i64 %107, %106
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %108
+
+; <label>:108                                     ; preds = %103
+  %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
+  %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
+  %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
+  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %113
+
+; <label>:113                                     ; preds = %108
+  %114 = load i64, i64 addrspace(1)* %112
+  %115 = add i64 %114, 152
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = add i64 %117, 56
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
+  %123 = zext i8 %122 to i32
+  %124 = icmp ne i32 %123, 0
+  br i1 %124, label %126, label %125
+
+; <label>:125                                     ; preds = %113
+  ret i8 0
+
+; <label>:126                                     ; preds = %113
+  %127 = load i32, i32* %loc2
+  %128 = add i32 %127, 1
+  store i32 %128, i32* %loc2
+  br label %129
+
+; <label>:129                                     ; preds = %89, %126
+  %130 = load i32, i32* %loc2
+  %131 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %NullCheck9 = icmp eq %"System.Type[]" addrspace(1)* %131, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %132
+
+; <label>:132                                     ; preds = %129
+  %133 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %131, i32 0, i32 1
+  %134 = load i32, i32 addrspace(1)* %133
+  %135 = zext i32 %134 to i64
+  %136 = trunc i64 %135 to i32
+  %137 = icmp slt i32 %130, %136
+  br i1 %137, label %100, label %138
+
+; <label>:138                                     ; preds = %132
+  ret i8 1
+
+; <label>:139                                     ; preds = %34, %73
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %129
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %103
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -2893,7 +3248,7 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElem]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -2904,8 +3259,8 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -2997,8 +3352,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
@@ -3059,8 +3414,8 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -3087,8 +3442,8 @@ entry:
 
 ; <label>:17                                      ; preds = %5, %11
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
@@ -3097,8 +3452,8 @@ entry:
 
 ; <label>:22                                      ; preds = %1, %11
   %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
@@ -3109,11 +3464,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %17
+ThrowNullRef2:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %22
+ThrowNullRef4:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3167,15 +3522,15 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
   %15 = load i32, i32 addrspace(1)* %14
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
@@ -3198,7 +3553,7 @@ ThrowNullRef:                                     ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef2:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3232,8 +3587,8 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
@@ -3312,8 +3667,8 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -3327,8 +3682,8 @@ entry:
 ; <label>:5                                       ; preds = %43
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %7 = load i32, i32* %loc1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck6, label %8, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
@@ -3366,8 +3721,8 @@ entry:
 ; <label>:32                                      ; preds = %21, %25
   %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
   %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
-  br i1 %NullCheck8, label %35, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = trunc i32 %34 to i16
@@ -3380,8 +3735,8 @@ entry:
 ; <label>:40                                      ; preds = %1, %35
   %41 = load i32, i32* %loc1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
-  br i1 %NullCheck2, label %43, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %42, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
@@ -3392,8 +3747,8 @@ entry:
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
   %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
-  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
   %51 = load i64, i64 addrspace(1)* %49
@@ -3412,19 +3767,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %40
+ThrowNullRef2:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %47
+ThrowNullRef4:                                    ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %5
+ThrowNullRef6:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %32
+ThrowNullRef8:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3467,8 +3822,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
@@ -3492,11 +3847,391 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(i16* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store i16* %param0, i16** %arg0
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load i32, i32* %arg3
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %42, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %37, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg2
+  %13 = load i32, i32* %arg3
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %37, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %24 = load i32, i32* %arg2
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load i16*, i16** %arg0
+  %35 = load i32, i32* %arg3
+  %36 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %36, i16* %34, i32 %35)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:37                                      ; preds = %5, %16
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %39)
+  %41 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41, %System.String addrspace(1)* %38, %System.String addrspace(1)* %40)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41) #0
+  unreachable
+
+; <label>:42                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
-Failed to read StringBuilder.ToString[loadElemA]
+Successfully read StringBuilder.ToString
+
+define %System.String addrspace(1)* @StringBuilder.ToString(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i16*
+  %loc3 = alloca %"System.Char[]" addrspace(1)*
+  %loc4 = alloca i32
+  %loc5 = alloca i32
+  %loc6 = alloca i16 addrspace(1)*
+  %loc7 = alloca %System.String addrspace(1)*
+  %loc8 = alloca %"System.Char[]" addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %0)
+  %2 = icmp ne i32 %1, 0
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %4
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %6)
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %7)
+  store %System.String addrspace(1)* %8, %System.String addrspace(1)** %loc0
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.Text.StringBuilder addrspace(1)* %9, %System.Text.StringBuilder addrspace(1)** %loc1
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  store %System.String addrspace(1)* %10, %System.String addrspace(1)** %loc7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc7
+  %12 = ptrtoint %System.String addrspace(1)* %11 to i64
+  %13 = icmp eq i64 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %5
+  %15 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %16 = sext i32 %15 to i64
+  %17 = add i64 %12, %16
+  br label %18
+
+; <label>:18                                      ; preds = %5, %14
+  %19 = phi i64 [ %12, %5 ], [ %17, %14 ]
+  %20 = inttoptr i64 %19 to i16*
+  store i16* %20, i16** %loc2
+  br label %21
+
+; <label>:21                                      ; preds = %98, %18
+  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %22, null
+  br i1 %NullCheck, label %ThrowNullRef, label %23
+
+; <label>:23                                      ; preds = %21
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 3
+  %25 = load i32, i32 addrspace(1)* %24, align 8
+  %26 = icmp sle i32 %25, 0
+  br i1 %26, label %96, label %27
+
+; <label>:27                                      ; preds = %23
+  %28 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %28, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %29
+
+; <label>:29                                      ; preds = %27
+  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %28, i32 0, i32 1
+  %31 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %30, align 8
+  store %"System.Char[]" addrspace(1)* %31, %"System.Char[]" addrspace(1)** %loc3
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %33
+
+; <label>:33                                      ; preds = %29
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  store i32 %35, i32* %loc4
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  %39 = load i32, i32 addrspace(1)* %38, align 8
+  store i32 %39, i32* %loc5
+  %40 = load i32, i32* %loc5
+  %41 = load i32, i32* %loc4
+  %42 = add i32 %40, %41
+  %43 = zext i32 %42 to i64
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %45
+
+; <label>:45                                      ; preds = %37
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = sext i32 %47 to i64
+  %49 = icmp sgt i64 %43, %48
+  br i1 %49, label %91, label %50
+
+; <label>:50                                      ; preds = %45
+  %51 = load i32, i32* %loc5
+  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %52, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %53
+
+; <label>:53                                      ; preds = %50
+  %54 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %52, i32 0, i32 1
+  %55 = load i32, i32 addrspace(1)* %54
+  %56 = zext i32 %55 to i64
+  %57 = trunc i64 %56 to i32
+  %58 = icmp ugt i32 %51, %57
+  br i1 %58, label %91, label %59
+
+; <label>:59                                      ; preds = %53
+  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  store %"System.Char[]" addrspace(1)* %60, %"System.Char[]" addrspace(1)** %loc8
+  %61 = icmp eq %"System.Char[]" addrspace(1)* %60, null
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %63, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %64
+
+; <label>:64                                      ; preds = %62
+  %65 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %63, i32 0, i32 1
+  %66 = load i32, i32 addrspace(1)* %65
+  %67 = zext i32 %66 to i64
+  %68 = trunc i64 %67 to i32
+  %69 = icmp ne i32 %68, 0
+  br i1 %69, label %71, label %70
+
+; <label>:70                                      ; preds = %59, %64
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:71                                      ; preds = %64
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %73
+
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %BoundsCheck = icmp uge i64 0, %76
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %77
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %78, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:79                                      ; preds = %70, %77
+  %80 = load i16*, i16** %loc2
+  %81 = load i32, i32* %loc4
+  %82 = sext i32 %81 to i64
+  %83 = mul i64 %82, 2
+  %84 = bitcast i16* %80 to i8*
+  %85 = getelementptr inbounds i8, i8* %84, i64 %83
+  %86 = load i16 addrspace(1)*, i16 addrspace(1)** %loc6
+  %87 = ptrtoint i16 addrspace(1)* %86 to i64
+  %88 = load i32, i32* %loc5
+  %89 = bitcast i8* %85 to i16*
+  %90 = inttoptr i64 %87 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %89, i16* %90, i32 %88)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %96
+
+; <label>:91                                      ; preds = %45, %53
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %94 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %93)
+  %95 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95, %System.String addrspace(1)* %92, %System.String addrspace(1)* %94)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95) #0
+  unreachable
+
+; <label>:96                                      ; preds = %23, %79
+  %97 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %97, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %98
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %97, i32 0, i32 2
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  store %System.Text.StringBuilder addrspace(1)* %100, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %102 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %102, label %21, label %103
+
+; <label>:103                                     ; preds = %98
+  store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc7
+  %104 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  ret %System.String addrspace(1)* %104
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method StringBuilder::get_Length using LLILCJit
+Successfully read StringBuilder.get_Length
+
+define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
+Successfully read RuntimeHelpers.get_OffsetToStringData
+
+define i32 @RuntimeHelpers.get_OffsetToStringData() {
+entry:
+  ret i32 12
+}
+
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
 Successfully read CultureData.CreateCultureData
 
@@ -3514,23 +4249,23 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
   store i8 %4, i8 addrspace(1)* %6
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
@@ -3549,11 +4284,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3566,50 +4301,50 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
   store i32 -1, i32 addrspace(1)* %2
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
   store i32 -1, i32 addrspace(1)* %8
   %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
   store i32 -1, i32 addrspace(1)* %14
   %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
   store i32 -1, i32 addrspace(1)* %17
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
@@ -3623,27 +4358,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3675,7 +4410,136 @@ Failed to read Dictionary`2.Insert[non-const derefAddress]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
 Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
-Failed to read HashHelpers.GetPrime[loadElem]
+Successfully read HashHelpers.GetPrime
+
+define i32 @HashHelpers.GetPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %6, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5, %System.String addrspace(1)* %4)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5) #0
+  unreachable
+
+; <label>:6                                       ; preds = %entry
+  store i32 0, i32* %loc0
+  br label %29
+
+; <label>:7                                       ; preds = %35
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 1296
+  %10 = addrspacecast i8 addrspace(1)* %9 to %"System.Int32[]" addrspace(1)**
+  %11 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %10
+  %12 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Int32[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = zext i32 %15 to i64
+  %17 = zext i32 %12 to i64
+  %BoundsCheck = icmp uge i64 %17, %16
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 3, i32 %12
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  store i32 %20, i32* %loc1
+  %21 = load i32, i32* %loc1
+  %22 = load i32, i32* %arg0
+  %23 = icmp slt i32 %21, %22
+  br i1 %23, label %26, label %24
+
+; <label>:24                                      ; preds = %18
+  %25 = load i32, i32* %loc1
+  ret i32 %25
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %loc0
+  %28 = add i32 %27, 1
+  store i32 %28, i32* %loc0
+  br label %29
+
+; <label>:29                                      ; preds = %6, %26
+  %30 = load i32, i32* %loc0
+  %31 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %32 = getelementptr inbounds i8, i8 addrspace(1)* %31, i64 1296
+  %33 = addrspacecast i8 addrspace(1)* %32 to %"System.Int32[]" addrspace(1)**
+  %34 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %33
+  %NullCheck = icmp eq %"System.Int32[]" addrspace(1)* %34, null
+  br i1 %NullCheck, label %ThrowNullRef, label %35
+
+; <label>:35                                      ; preds = %29
+  %36 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %34, i32 0, i32 1
+  %37 = load i32, i32 addrspace(1)* %36
+  %38 = zext i32 %37 to i64
+  %39 = trunc i64 %38 to i32
+  %40 = icmp slt i32 %30, %39
+  br i1 %40, label %7, label %41
+
+; <label>:41                                      ; preds = %35
+  %42 = load i32, i32* %arg0
+  %43 = or i32 %42, 1
+  store i32 %43, i32* %loc2
+  br label %59
+
+; <label>:44                                      ; preds = %59
+  %45 = load i32, i32* %loc2
+  %46 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %45)
+  %47 = zext i8 %46 to i32
+  %48 = icmp eq i32 %47, 0
+  br i1 %48, label %56, label %49
+
+; <label>:49                                      ; preds = %44
+  %50 = load i32, i32* %loc2
+  %51 = sub i32 %50, 1
+  %52 = srem i32 %51, 101
+  %53 = icmp eq i32 %52, 0
+  br i1 %53, label %56, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = load i32, i32* %loc2
+  ret i32 %55
+
+; <label>:56                                      ; preds = %44, %49
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %57, 2
+  store i32 %58, i32* %loc2
+  br label %59
+
+; <label>:59                                      ; preds = %41, %56
+  %60 = load i32, i32* %loc2
+  %61 = icmp slt i32 %60, 2147483647
+  br i1 %61, label %44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load i32, i32* %arg0
+  ret i32 %63
+
+ThrowNullRef:                                     ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
 Successfully read GenericEqualityComparer`1.GetHashCode
 
@@ -3694,14 +4558,14 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
   %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load i64, i64 addrspace(1)* %7
@@ -3720,7 +4584,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3750,8 +4614,8 @@ entry:
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
@@ -3796,8 +4660,8 @@ entry:
   %35 = bitcast i16* %34 to i8*
   %36 = getelementptr inbounds i8, i8* %35, i64 2
   %37 = bitcast i8* %36 to i16*
-  %NullCheck4 = icmp ne i16* %37, null
-  br i1 %NullCheck4, label %38, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %37, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %38
 
 ; <label>:38                                      ; preds = %27
   %39 = load i16, i16* %37, align 8
@@ -3824,8 +4688,8 @@ entry:
 
 ; <label>:54                                      ; preds = %22, %43
   %55 = load i16*, i16** %loc4
-  %NullCheck2 = icmp ne i16* %55, null
-  br i1 %NullCheck2, label %56, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i16* %55, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %56
 
 ; <label>:56                                      ; preds = %54
   %57 = load i16, i16* %55, align 8
@@ -3850,11 +4714,11 @@ ThrowNullRef:                                     ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %54
+ThrowNullRef2:                                    ; preds = %54
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %27
+ThrowNullRef4:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3871,8 +4735,8 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -3907,8 +4771,8 @@ entry:
 
 ; <label>:26                                      ; preds = %19
   %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
-  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %28
 
 ; <label>:28                                      ; preds = %26
   %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
@@ -3920,7 +4784,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3972,8 +4836,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
@@ -3984,26 +4848,26 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
-  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
@@ -4014,8 +4878,8 @@ entry:
 ; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
@@ -4024,8 +4888,8 @@ entry:
 
 ; <label>:25                                      ; preds = %1, %16, %23
   %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
-  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
@@ -4036,27 +4900,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %20
+ThrowNullRef10:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4069,8 +4933,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -4081,8 +4945,8 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
@@ -4091,8 +4955,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1, %8
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
@@ -4103,11 +4967,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4128,24 +4992,24 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   store i32 %3, i32* %loc0
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
   %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
   store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck4, label %9, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
@@ -4164,15 +5028,15 @@ entry:
 ; <label>:18                                      ; preds = %70
   %19 = load i16*, i16** %loc3
   %20 = bitcast i16* %19 to i64*
-  %NullCheck10 = icmp ne i64* %20, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %20, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = load i64, i64* %20, align 8
   %23 = load i16*, i16** %loc4
   %24 = bitcast i16* %23 to i64*
-  %NullCheck12 = icmp ne i64* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = load i64, i64* %24, align 8
@@ -4188,8 +5052,8 @@ entry:
   %31 = bitcast i16* %30 to i8*
   %32 = getelementptr inbounds i8, i8* %31, i64 8
   %33 = bitcast i8* %32 to i64*
-  %NullCheck14 = icmp ne i64* %33, null
-  br i1 %NullCheck14, label %34, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = load i64, i64* %33, align 8
@@ -4197,8 +5061,8 @@ entry:
   %37 = bitcast i16* %36 to i8*
   %38 = getelementptr inbounds i8, i8* %37, i64 8
   %39 = bitcast i8* %38 to i64*
-  %NullCheck16 = icmp ne i64* %39, null
-  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %40
 
 ; <label>:40                                      ; preds = %34
   %41 = load i64, i64* %39, align 8
@@ -4214,8 +5078,8 @@ entry:
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %NullCheck18 = icmp ne i64* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = load i64, i64* %48, align 8
@@ -4223,8 +5087,8 @@ entry:
   %52 = bitcast i16* %51 to i8*
   %53 = getelementptr inbounds i8, i8* %52, i64 16
   %54 = bitcast i8* %53 to i64*
-  %NullCheck20 = icmp ne i64* %54, null
-  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64* %54, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %55
 
 ; <label>:55                                      ; preds = %49
   %56 = load i64, i64* %54, align 8
@@ -4262,15 +5126,15 @@ entry:
 ; <label>:74                                      ; preds = %95
   %75 = load i16*, i16** %loc3
   %76 = bitcast i16* %75 to i32*
-  %NullCheck6 = icmp ne i32* %76, null
-  br i1 %NullCheck6, label %77, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32* %76, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %77
 
 ; <label>:77                                      ; preds = %74
   %78 = load i32, i32* %76, align 8
   %79 = load i16*, i16** %loc4
   %80 = bitcast i16* %79 to i32*
-  %NullCheck8 = icmp ne i32* %80, null
-  br i1 %NullCheck8, label %81, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i32* %80, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %81
 
 ; <label>:81                                      ; preds = %77
   %82 = load i32, i32* %80, align 8
@@ -4318,43 +5182,43 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %74
+ThrowNullRef6:                                    ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %77
+ThrowNullRef8:                                    ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %29
+ThrowNullRef14:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %34
+ThrowNullRef16:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4376,8 +5240,8 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load i64, i64 addrspace(1)* %4
@@ -4389,8 +5253,8 @@ entry:
   %12 = load i64, i64* %11
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %5
   %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
@@ -4399,8 +5263,8 @@ entry:
   %18 = load i8, i8* %arg2
   %19 = zext i8 %18 to i32
   %20 = trunc i32 %19 to i8
-  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %15
   %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
@@ -4411,11 +5275,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4442,8 +5306,8 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
@@ -4466,16 +5330,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
   %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = load i64, i64 addrspace(1)* %19
@@ -4500,8 +5364,8 @@ entry:
 ; <label>:35                                      ; preds = %30
   %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
@@ -4514,8 +5378,8 @@ entry:
 
 ; <label>:42                                      ; preds = %1, %38
   %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
-  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
@@ -4526,19 +5390,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %35
+ThrowNullRef2:                                    ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %42
+ThrowNullRef8:                                    ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4551,14 +5415,14 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
@@ -4570,7 +5434,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4583,8 +5447,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
@@ -4613,51 +5477,51 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
   %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
   %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
   %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
   %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
-  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
   store i64 %21, i64 addrspace(1)* %23
   %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %25 = load i64, i64* %loc0
-  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
@@ -4668,27 +5532,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %22
+ThrowNullRef12:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4701,8 +5565,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
@@ -4713,19 +5577,19 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
@@ -4734,8 +5598,8 @@ entry:
 
 ; <label>:15                                      ; preds = %1, %13
   %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
@@ -4746,19 +5610,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %15
+ThrowNullRef8:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4771,8 +5635,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -4831,8 +5695,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
@@ -4882,8 +5746,8 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
-  br i1 %NullCheck, label %17, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %ThrowNullRef, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
@@ -4894,15 +5758,15 @@ entry:
 
 ; <label>:22                                      ; preds = %17
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
-  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
   %26 = load i32, i32 addrspace(1)* %25
   %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
-  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %27, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
@@ -4925,8 +5789,8 @@ entry:
 ; <label>:40                                      ; preds = %17
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
-  br i1 %NullCheck6, label %43, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %41, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
@@ -4938,34 +5802,17 @@ ThrowNullRef:                                     ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %24
+ThrowNullRef4:                                    ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %40
+ThrowNullRef6:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
-}
-
-INFO:  jitting method Object::ReferenceEquals using LLILCJit
-Successfully read Object.ReferenceEquals
-
-define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
-entry:
-  %arg0 = alloca %System.Object addrspace(1)*
-  %arg1 = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
-  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
-  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = icmp eq %System.Object addrspace(1)* %0, %1
-  %3 = sext i1 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
 }
 
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
@@ -4978,21 +5825,21 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
   %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
-  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
@@ -5007,28 +5854,28 @@ entry:
 ; <label>:13                                      ; preds = %8, %12
   %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
   %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
   %21 = load i32, i32 addrspace(1)* %20, align 8
   %22 = add i32 %21, 1
-  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
   store i32 %22, i32 addrspace(1)* %24
   %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
@@ -5039,27 +5886,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5077,7 +5924,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::Setup using LLILCJit
-Failed to read AppDomain.Setup[loadElem]
+Failed to read AppDomain.Setup[unbox]
 INFO:  jitting method Thread::GetDomain using LLILCJit
 Successfully read Thread.GetDomain
 
@@ -5108,8 +5955,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
@@ -5122,14 +5969,14 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
   %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
@@ -5141,11 +5988,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5173,8 +6020,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -5189,7 +6036,328 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
 Failed to read KeyCollection.System.Collections.Generic.IEnumerable<TKey>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Successfully read Enumerator.MoveNext
+
+define i8 @Enumerator.MoveNext(%"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.RuntimeTypeHandle* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*
+  %"$TypeArg" = alloca %System.RuntimeTypeHandle*
+  store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
+  %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 8
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %76, label %12
+
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
+  br label %76
+
+; <label>:13                                      ; preds = %85
+  %14 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck19 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %15
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, i32 0, i32 0
+  %17 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %16, align 8
+  %NullCheck21 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, i32 0, i32 2
+  %20 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %19, align 8
+  %21 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck23 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %22
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, i32 0, i32 2
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %NullCheck25 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 3, i32 %24
+  %NullCheck27 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %32
+
+; <label>:32                                      ; preds = %30
+  %33 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, i32 0, i32 2
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = icmp slt i32 %34, 0
+  br i1 %35, label %68, label %36
+
+; <label>:36                                      ; preds = %32
+  %37 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %38 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck29 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %39
+
+; <label>:39                                      ; preds = %36
+  %40 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, i32 0, i32 0
+  %41 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %40, align 8
+  %NullCheck31 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, i32 0, i32 2
+  %44 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %43, align 8
+  %45 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck33 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, i32 0, i32 2
+  %48 = load i32, i32 addrspace(1)* %47, align 8
+  %NullCheck35 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %49
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = zext i32 %51 to i64
+  %53 = zext i32 %48 to i64
+  %BoundsCheck37 = icmp uge i64 %53, %52
+  br i1 %BoundsCheck37, label %ThrowIndexOutOfRange38, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 3, i32 %48
+  %NullCheck39 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %56
+
+; <label>:56                                      ; preds = %54
+  %57 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, i32 0, i32 0
+  %58 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck41 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %59
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %60, %System.__Canon addrspace(1)* %58)
+  %61 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck43 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  %64 = load i32, i32 addrspace(1)* %63, align 8
+  %65 = add i32 %64, 1
+  %NullCheck45 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  store i32 %65, i32 addrspace(1)* %67
+  ret i8 1
+
+; <label>:68                                      ; preds = %32
+  %69 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck47 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %73 = add i32 %72, 1
+  %NullCheck49 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %74
+
+; <label>:74                                      ; preds = %70
+  %75 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  store i32 %73, i32 addrspace(1)* %75
+  br label %76
+
+; <label>:76                                      ; preds = %8, %12, %74
+  %77 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %78
+
+; <label>:78                                      ; preds = %76
+  %79 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, i32 0, i32 2
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck7 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %82
+
+; <label>:82                                      ; preds = %78
+  %83 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, i32 0, i32 0
+  %84 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %83, align 8
+  %NullCheck9 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %85
+
+; <label>:85                                      ; preds = %82
+  %86 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, i32 0, i32 7
+  %87 = load i32, i32 addrspace(1)* %86, align 8
+  %88 = icmp ult i32 %80, %87
+  br i1 %88, label %13, label %89
+
+; <label>:89                                      ; preds = %85
+  %90 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %91 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck11 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %92
+
+; <label>:92                                      ; preds = %89
+  %93 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, i32 0, i32 0
+  %94 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck13 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %95
+
+; <label>:95                                      ; preds = %92
+  %96 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, i32 0, i32 7
+  %97 = load i32, i32 addrspace(1)* %96, align 8
+  %98 = add i32 %97, 1
+  %NullCheck15 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %99
+
+; <label>:99                                      ; preds = %95
+  %100 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, i32 0, i32 2
+  store i32 %98, i32 addrspace(1)* %100
+  %101 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck17 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %102
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %103, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %92
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef22:                                   ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef24:                                   ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef26:                                   ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef28:                                   ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef30:                                   ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef32:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef34:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef36:                                   ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange38:                           ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef40:                                   ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef42:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef44:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef46:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef48:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef50:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -5200,8 +6368,8 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -5232,9 +6400,9 @@ Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
 Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
-Failed to read String.MakeSeparatorList[loadElemA]
+Failed to read String.MakeSeparatorList[storeElem]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
-Failed to read String.InternalSplitKeepEmptyEntries[loadElem]
+Failed to read String.InternalSplitKeepEmptyEntries[storeElem]
 INFO:  jitting method Path::IsRelative using LLILCJit
 Successfully read Path.IsRelative
 
@@ -5243,8 +6411,8 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -5254,8 +6422,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
@@ -5271,8 +6439,8 @@ entry:
 
 ; <label>:17                                      ; preds = %7
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
@@ -5288,8 +6456,8 @@ entry:
 
 ; <label>:29                                      ; preds = %19
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %31
 
 ; <label>:31                                      ; preds = %29
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
@@ -5300,8 +6468,8 @@ entry:
 
 ; <label>:36                                      ; preds = %31
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
-  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %37, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
@@ -5312,8 +6480,8 @@ entry:
 
 ; <label>:43                                      ; preds = %31, %38
   %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
-  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %45
 
 ; <label>:45                                      ; preds = %43
   %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
@@ -5324,8 +6492,8 @@ entry:
 
 ; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %50
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
@@ -5336,8 +6504,8 @@ entry:
 
 ; <label>:57                                      ; preds = %1, %7, %19, %45, %52
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
-  br i1 %NullCheck14, label %59, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %59
 
 ; <label>:59                                      ; preds = %57
   %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
@@ -5347,8 +6515,8 @@ entry:
 
 ; <label>:63                                      ; preds = %59
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
@@ -5359,8 +6527,8 @@ entry:
 
 ; <label>:70                                      ; preds = %65
   %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
-  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.String addrspace(1)* %71, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %72
 
 ; <label>:72                                      ; preds = %70
   %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
@@ -5379,39 +6547,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %17
+ThrowNullRef4:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %29
+ThrowNullRef6:                                    ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %36
+ThrowNullRef8:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %43
+ThrowNullRef10:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %50
+ThrowNullRef12:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %57
+ThrowNullRef14:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %63
+ThrowNullRef16:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %70
+ThrowNullRef18:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5419,7 +6587,293 @@ ThrowNullRef17:                                   ; preds = %70
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
-Failed to read String.TrimHelper[loadElem]
+Successfully read String.TrimHelper
+
+define %System.String addrspace(1)* @String.TrimHelper(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i16
+  %loc4 = alloca i32
+  %loc5 = alloca i16
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = sub i32 %3, 1
+  store i32 %4, i32* %loc0
+  store i32 0, i32* %loc1
+  %5 = load i32, i32* %arg2
+  %6 = icmp eq i32 %5, 1
+  br i1 %6, label %62, label %7
+
+; <label>:7                                       ; preds = %1
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:8                                       ; preds = %58
+  store i32 0, i32* %loc2
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load i32, i32* %loc1
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2, i32 %10
+  %13 = load i16, i16 addrspace(1)* %12
+  %14 = zext i16 %13 to i32
+  %15 = trunc i32 %14 to i16
+  store i16 %15, i16* %loc3
+  store i32 0, i32* %loc2
+  br label %34
+
+; <label>:16                                      ; preds = %37
+  %17 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %18 = load i32, i32* %loc2
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %17, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %19
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = zext i32 %18 to i64
+  %BoundsCheck = icmp uge i64 %23, %22
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %24
+
+; <label>:24                                      ; preds = %19
+  %25 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 3, i32 %18
+  %26 = load i16, i16 addrspace(1)* %25, align 8
+  %27 = zext i16 %26 to i32
+  %28 = load i16, i16* %loc3
+  %29 = zext i16 %28 to i32
+  %30 = icmp eq i32 %27, %29
+  br i1 %30, label %43, label %31
+
+; <label>:31                                      ; preds = %24
+  %32 = load i32, i32* %loc2
+  %33 = add i32 %32, 1
+  store i32 %33, i32* %loc2
+  br label %34
+
+; <label>:34                                      ; preds = %11, %31
+  %35 = load i32, i32* %loc2
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = icmp slt i32 %35, %41
+  br i1 %42, label %16, label %43
+
+; <label>:43                                      ; preds = %24, %37
+  %44 = load i32, i32* %loc2
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %45, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp eq i32 %44, %50
+  br i1 %51, label %62, label %52
+
+; <label>:52                                      ; preds = %46
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %7, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %57, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %58
+
+; <label>:58                                      ; preds = %55
+  %59 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %60 = load i32, i32 addrspace(1)* %59
+  %61 = icmp slt i32 %56, %60
+  br i1 %61, label %8, label %62
+
+; <label>:62                                      ; preds = %1, %46, %58
+  %63 = load i32, i32* %arg2
+  %64 = icmp eq i32 %63, 0
+  br i1 %64, label %122, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %66, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %67
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %66, i32 0, i32 1
+  %69 = load i32, i32 addrspace(1)* %68
+  %70 = sub i32 %69, 1
+  store i32 %70, i32* %loc0
+  br label %118
+
+; <label>:71                                      ; preds = %118
+  store i32 0, i32* %loc4
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %73 = load i32, i32* %loc0
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %74
+
+; <label>:74                                      ; preds = %71
+  %75 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 2, i32 %73
+  %76 = load i16, i16 addrspace(1)* %75
+  %77 = zext i16 %76 to i32
+  %78 = trunc i32 %77 to i16
+  store i16 %78, i16* %loc5
+  store i32 0, i32* %loc4
+  br label %97
+
+; <label>:79                                      ; preds = %100
+  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %81 = load i32, i32* %loc4
+  %NullCheck19 = icmp eq %"System.Char[]" addrspace(1)* %80, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
+
+; <label>:82                                      ; preds = %79
+  %83 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 1
+  %84 = load i32, i32 addrspace(1)* %83
+  %85 = zext i32 %84 to i64
+  %86 = zext i32 %81 to i64
+  %BoundsCheck21 = icmp uge i64 %86, %85
+  br i1 %BoundsCheck21, label %ThrowIndexOutOfRange22, label %87
+
+; <label>:87                                      ; preds = %82
+  %88 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 3, i32 %81
+  %89 = load i16, i16 addrspace(1)* %88, align 8
+  %90 = zext i16 %89 to i32
+  %91 = load i16, i16* %loc5
+  %92 = zext i16 %91 to i32
+  %93 = icmp eq i32 %90, %92
+  br i1 %93, label %106, label %94
+
+; <label>:94                                      ; preds = %87
+  %95 = load i32, i32* %loc4
+  %96 = add i32 %95, 1
+  store i32 %96, i32* %loc4
+  br label %97
+
+; <label>:97                                      ; preds = %74, %94
+  %98 = load i32, i32* %loc4
+  %99 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck15 = icmp eq %"System.Char[]" addrspace(1)* %99, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %100
+
+; <label>:100                                     ; preds = %97
+  %101 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %99, i32 0, i32 1
+  %102 = load i32, i32 addrspace(1)* %101
+  %103 = zext i32 %102 to i64
+  %104 = trunc i64 %103 to i32
+  %105 = icmp slt i32 %98, %104
+  br i1 %105, label %79, label %106
+
+; <label>:106                                     ; preds = %87, %100
+  %107 = load i32, i32* %loc4
+  %108 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck17 = icmp eq %"System.Char[]" addrspace(1)* %108, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %109
+
+; <label>:109                                     ; preds = %106
+  %110 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %108, i32 0, i32 1
+  %111 = load i32, i32 addrspace(1)* %110
+  %112 = zext i32 %111 to i64
+  %113 = trunc i64 %112 to i32
+  %114 = icmp eq i32 %107, %113
+  br i1 %114, label %122, label %115
+
+; <label>:115                                     ; preds = %109
+  %116 = load i32, i32* %loc0
+  %117 = sub i32 %116, 1
+  store i32 %117, i32* %loc0
+  br label %118
+
+; <label>:118                                     ; preds = %67, %115
+  %119 = load i32, i32* %loc0
+  %120 = load i32, i32* %loc1
+  %121 = icmp sge i32 %119, %120
+  br i1 %121, label %71, label %122
+
+; <label>:122                                     ; preds = %62, %109, %118
+  %123 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %124 = load i32, i32* %loc1
+  %125 = load i32, i32* %loc0
+  %126 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %123, i32 %124, i32 %125)
+  ret %System.String addrspace(1)* %126
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %97
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange22:                           ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
 Successfully read String.CreateTrimmedString
 
@@ -5439,8 +6893,8 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
@@ -5535,8 +6989,8 @@ entry:
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i64 2872
   %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
   %8 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %7
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %3
   %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
@@ -5553,8 +7007,8 @@ entry:
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 2864
   %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
   %21 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %20
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
-  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %22
 
 ; <label>:22                                      ; preds = %16
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
@@ -5569,7 +7023,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %16
+ThrowNullRef2:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5586,8 +7040,8 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5613,8 +7067,8 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
@@ -5632,8 +7086,8 @@ entry:
 
 ; <label>:12                                      ; preds = %4
   %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
@@ -5644,8 +7098,8 @@ entry:
 
 ; <label>:19                                      ; preds = %14
   %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %19
   %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
@@ -5660,21 +7114,21 @@ entry:
   %31 = zext i16 %30 to i32
   %32 = bitcast i8* %29 to i16*
   %33 = trunc i32 %31 to i16
-  %NullCheck6 = icmp ne i16* %32, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i16* %32, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %21
   store i16 %33, i16* %32, align 8
   %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %36
 
 ; <label>:36                                      ; preds = %34
   %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
   %38 = load i32, i32 addrspace(1)* %37, align 8
   %39 = add i32 %38, 1
-  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %40
 
 ; <label>:40                                      ; preds = %36
   %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
@@ -5683,16 +7137,16 @@ entry:
 
 ; <label>:42                                      ; preds = %14
   %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
-  br i1 %NullCheck12, label %44, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
   %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
   %47 = load i16, i16* %arg1
   %48 = zext i16 %47 to i32
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = trunc i32 %48 to i16
@@ -5703,31 +7157,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %19
+ThrowNullRef4:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %21
+ThrowNullRef6:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %36
+ThrowNullRef10:                                   ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %42
+ThrowNullRef12:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %44
+ThrowNullRef14:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5740,8 +7194,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -5752,8 +7206,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
@@ -5762,14 +7216,14 @@ entry:
 
 ; <label>:11                                      ; preds = %1
   %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
@@ -5779,15 +7233,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5808,8 +7262,8 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5822,8 +7276,8 @@ entry:
 
 ; <label>:8                                       ; preds = %3
   %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
@@ -5842,15 +7296,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
-  br i1 %NullCheck4, label %22, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
   %24 = load i16*, i16* addrspace(1)* %23, align 8
   %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %25, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
@@ -5859,8 +7313,8 @@ entry:
   store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
@@ -5874,8 +7328,8 @@ entry:
 
 ; <label>:37                                      ; preds = %65
   %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %37
   %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
@@ -5886,16 +7340,16 @@ entry:
   %45 = bitcast i16* %41 to i8*
   %46 = getelementptr inbounds i8, i8* %45, i64 %44
   %47 = bitcast i8* %46 to i16*
-  %NullCheck14 = icmp ne i16* %47, null
-  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %47, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %48
 
 ; <label>:48                                      ; preds = %39
   %49 = load i16, i16* %47, align 8
   %50 = zext i16 %49 to i32
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %52 = load i32, i32* %loc1
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %53
 
 ; <label>:53                                      ; preds = %48
   %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
@@ -5916,8 +7370,8 @@ entry:
 ; <label>:62                                      ; preds = %36, %59
   %63 = load i32, i32* %loc1
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck10, label %65, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %65
 
 ; <label>:65                                      ; preds = %62
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
@@ -5936,15 +7390,15 @@ entry:
 
 ; <label>:74                                      ; preds = %70
   %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
-  br i1 %NullCheck18, label %76, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %76
 
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
   %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
-  br i1 %NullCheck20, label %80, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
   %81 = load i64, i64 addrspace(1)* %79
@@ -5958,8 +7412,8 @@ entry:
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
   %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
-  br i1 %NullCheck22, label %92, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.String addrspace(1)* %90, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %92
 
 ; <label>:92                                      ; preds = %80
   %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
@@ -5969,15 +7423,15 @@ entry:
 
 ; <label>:96                                      ; preds = %70
   %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
-  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %98
 
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
   %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
-  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
   %103 = load i64, i64 addrspace(1)* %101
@@ -5991,8 +7445,8 @@ entry:
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
   %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
-  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.String addrspace(1)* %112, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %114
 
 ; <label>:114                                     ; preds = %102
   %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
@@ -6004,59 +7458,59 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %20
+ThrowNullRef4:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %22
+ThrowNullRef6:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %26
+ThrowNullRef8:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %62
+ThrowNullRef10:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %48
+ThrowNullRef16:                                   ; preds = %48
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %74
+ThrowNullRef18:                                   ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %76
+ThrowNullRef20:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %80
+ThrowNullRef22:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %96
+ThrowNullRef24:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %98
+ThrowNullRef26:                                   ; preds = %98
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %102
+ThrowNullRef28:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6069,15 +7523,15 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
   %3 = load i16*, i16* addrspace(1)* %2, align 8
   %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
@@ -6087,8 +7541,8 @@ entry:
   %10 = bitcast i16* %3 to i8*
   %11 = getelementptr inbounds i8, i8* %10, i64 %9
   %12 = bitcast i8* %11 to i16*
-  %NullCheck4 = icmp ne i16* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %5
   store i16 0, i16* %12, align 8
@@ -6098,11 +7552,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6119,8 +7573,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -6131,8 +7585,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
@@ -6144,15 +7598,15 @@ entry:
 
 ; <label>:14                                      ; preds = %1
   %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
   %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
   %21 = load i64, i64 addrspace(1)* %19
@@ -6171,15 +7625,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %14
+ThrowNullRef4:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %16
+ThrowNullRef6:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6302,14 +7756,6 @@ entry:
   ret %System.String addrspace(1)* %57
 }
 
-INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
-Successfully read RuntimeHelpers.get_OffsetToStringData
-
-define i32 @RuntimeHelpers.get_OffsetToStringData() {
-entry:
-  ret i32 12
-}
-
 INFO:  jitting method String::Equals using LLILCJit
 Successfully read String.Equals
 
@@ -6381,8 +7827,8 @@ entry:
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
-  br i1 %NullCheck24, label %29, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
   %30 = load i64, i64 addrspace(1)* %28
@@ -6397,8 +7843,8 @@ entry:
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
-  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
   %43 = load i64, i64 addrspace(1)* %41
@@ -6418,8 +7864,8 @@ entry:
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
   %59 = load i64, i64 addrspace(1)* %57
@@ -6434,8 +7880,8 @@ entry:
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck22, label %71, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
   %72 = load i64, i64 addrspace(1)* %70
@@ -6455,8 +7901,8 @@ entry:
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
-  br i1 %NullCheck16, label %87, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = load i64, i64 addrspace(1)* %86
@@ -6471,8 +7917,8 @@ entry:
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck18, label %100, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
   %101 = load i64, i64 addrspace(1)* %99
@@ -6492,8 +7938,8 @@ entry:
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
-  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
   %117 = load i64, i64 addrspace(1)* %115
@@ -6508,8 +7954,8 @@ entry:
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
-  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
   %130 = load i64, i64 addrspace(1)* %128
@@ -6528,15 +7974,15 @@ entry:
 
 ; <label>:142                                     ; preds = %22
   %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
-  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %143, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %144
 
 ; <label>:144                                     ; preds = %142
   %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
   %146 = load i32, i32 addrspace(1)* %145
   %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
-  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %147, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %148
 
 ; <label>:148                                     ; preds = %144
   %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
@@ -6557,15 +8003,15 @@ entry:
 
 ; <label>:159                                     ; preds = %22
   %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
-  br i1 %NullCheck, label %161, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %ThrowNullRef, label %161
 
 ; <label>:161                                     ; preds = %159
   %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
   %163 = load i32, i32 addrspace(1)* %162
   %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
-  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %164, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %165
 
 ; <label>:165                                     ; preds = %161
   %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
@@ -6578,8 +8024,8 @@ entry:
 
 ; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
-  br i1 %NullCheck4, label %172, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %171, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %172
 
 ; <label>:172                                     ; preds = %170
   %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
@@ -6589,8 +8035,8 @@ entry:
 
 ; <label>:176                                     ; preds = %172
   %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
-  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %177, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %178
 
 ; <label>:178                                     ; preds = %176
   %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
@@ -6629,55 +8075,55 @@ ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %161
+ThrowNullRef2:                                    ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %170
+ThrowNullRef4:                                    ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %176
+ThrowNullRef6:                                    ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %142
+ThrowNullRef8:                                    ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %144
+ThrowNullRef10:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %113
+ThrowNullRef12:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %116
+ThrowNullRef14:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %84
+ThrowNullRef16:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %87
+ThrowNullRef18:                                   ; preds = %87
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %55
+ThrowNullRef20:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %58
+ThrowNullRef22:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %26
+ThrowNullRef24:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %29
+ThrowNullRef26:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,8 +8161,8 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck, label %14, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %ThrowNullRef, label %14
 
 ; <label>:14                                      ; preds = %8
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
@@ -6760,8 +8206,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
@@ -6770,14 +8216,14 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32, i32* %loc0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %10
   %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
   %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
@@ -6790,15 +8236,15 @@ entry:
 ; <label>:25                                      ; preds = %19
   %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
-  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
   %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
@@ -6807,8 +8253,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %37 = load i32, i32* %loc0
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %38, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %38
 
 ; <label>:38                                      ; preds = %32
   %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
@@ -6817,14 +8263,14 @@ entry:
 
 ; <label>:40                                      ; preds = %19
   %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %40
   %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
   %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
-  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
-  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
@@ -6832,8 +8278,8 @@ entry:
   %48 = zext i32 %47 to i64
   %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
-  br i1 %NullCheck16, label %51, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %51
 
 ; <label>:51                                      ; preds = %45
   %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
@@ -6847,15 +8293,15 @@ entry:
 ; <label>:57                                      ; preds = %51
   %58 = load i16*, i16** %arg1
   %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
-  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %60
 
 ; <label>:60                                      ; preds = %57
   %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
   %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
-  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %64
 
 ; <label>:64                                      ; preds = %60
   %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
@@ -6864,22 +8310,22 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
   %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
-  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %70
 
 ; <label>:70                                      ; preds = %64
   %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
   %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
-  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
-  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
   %75 = load i32, i32 addrspace(1)* %74
   %76 = zext i32 %75 to i64
   %77 = trunc i64 %76 to i32
-  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
-  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %78
 
 ; <label>:78                                      ; preds = %73
   %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
@@ -6901,8 +8347,8 @@ entry:
   %90 = bitcast i16* %86 to i8*
   %91 = getelementptr inbounds i8, i8* %90, i64 %89
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %93
 
 ; <label>:93                                      ; preds = %80
   %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
@@ -6912,8 +8358,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %99 = load i32, i32* %loc2
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %100
 
 ; <label>:100                                     ; preds = %93
   %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
@@ -6928,63 +8374,63 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %25
+ThrowNullRef6:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %32
+ThrowNullRef10:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %40
+ThrowNullRef12:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %45
+ThrowNullRef16:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %57
+ThrowNullRef18:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %60
+ThrowNullRef20:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %64
+ThrowNullRef22:                                   ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %70
+ThrowNullRef24:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %73
+ThrowNullRef26:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %80
+ThrowNullRef28:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %93
+ThrowNullRef30:                                   ; preds = %93
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7004,8 +8450,8 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
@@ -7033,43 +8479,43 @@ entry:
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %14
   %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
   %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   %28 = load i32, i32 addrspace(1)* %27, align 8
   %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
-  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %30
 
 ; <label>:30                                      ; preds = %26
   %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
   %32 = load i32, i32 addrspace(1)* %31, align 8
   %33 = add i32 %28, %32
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %34
 
 ; <label>:34                                      ; preds = %30
   %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   store i32 %33, i32 addrspace(1)* %35
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
   store i32 0, i32 addrspace(1)* %38
   %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %40
 
 ; <label>:40                                      ; preds = %37
   %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
@@ -7082,8 +8528,8 @@ entry:
 
 ; <label>:47                                      ; preds = %40
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
@@ -7098,8 +8544,8 @@ entry:
   %54 = load i32, i32* %loc0
   %55 = sext i32 %54 to i64
   %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
-  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %57
 
 ; <label>:57                                      ; preds = %52
   %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
@@ -7110,68 +8556,35 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %14
+ThrowNullRef2:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %23
+ThrowNullRef4:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %26
+ThrowNullRef6:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %30
+ThrowNullRef8:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %34
+ThrowNullRef10:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %47
+ThrowNullRef14:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %52
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-}
-
-INFO:  jitting method StringBuilder::get_Length using LLILCJit
-Successfully read StringBuilder.get_Length
-
-define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.StringBuilder addrspace(1)*
-  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
-  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
-
-; <label>:1                                       ; preds = %entry
-  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %3 = load i32, i32 addrspace(1)* %2, align 8
-  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
-
-; <label>:5                                       ; preds = %1
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = add i32 %3, %7
-  ret i32 %8
-
-ThrowNullRef:                                     ; preds = %entry
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef16:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7213,70 +8626,70 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
   %6 = load i32, i32 addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
   store i32 %6, i32 addrspace(1)* %8
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
   %13 = load i32, i32 addrspace(1)* %12, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
   store i32 %13, i32 addrspace(1)* %15
   %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
-  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %18
 
 ; <label>:18                                      ; preds = %14
   %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
   %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
   %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
   %34 = load i32, i32 addrspace(1)* %33, align 8
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
-  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
@@ -7287,39 +8700,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %28
+ThrowNullRef16:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %32
+ThrowNullRef18:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7455,13 +8868,13 @@ entry:
 ; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
@@ -7477,16 +8890,16 @@ entry:
 
 ; <label>:18                                      ; preds = %15
   %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
   store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
   %22 = load i32, i32* %loc0
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %24
 
 ; <label>:24                                      ; preds = %20
   %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
@@ -7498,13 +8911,13 @@ entry:
 ; <label>:28                                      ; preds = %15, %24
   %29 = load i32, i32* %arg1
   %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %31
   %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
@@ -7517,20 +8930,20 @@ entry:
   %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
-  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
   %46 = load i32, i32 addrspace(1)* %45, align 8
   %47 = sub i32 %40, %46
-  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
-  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i32 addrspace(1)* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %48
 
 ; <label>:48                                      ; preds = %44
   store i32 %47, i32 addrspace(1)* %39, align 8
@@ -7538,21 +8951,21 @@ entry:
 
 ; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
-  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %51
 
 ; <label>:51                                      ; preds = %49
   %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %53
 
 ; <label>:53                                      ; preds = %51
   %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
   %55 = load i32, i32 addrspace(1)* %54, align 8
   %56 = load i32, i32* %arg2
   %57 = sub i32 %55, %56
-  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %58
 
 ; <label>:58                                      ; preds = %53
   %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
@@ -7562,13 +8975,13 @@ entry:
 ; <label>:60                                      ; preds = %33, %58
   %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
   %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
-  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %63
 
 ; <label>:63                                      ; preds = %60
   %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
-  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
-  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
@@ -7578,15 +8991,15 @@ entry:
 
 ; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
-  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i32 addrspace(1)* %69, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %70
 
 ; <label>:70                                      ; preds = %68
   %71 = load i32, i32 addrspace(1)* %69, align 8
   store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
-  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
@@ -7596,8 +9009,8 @@ entry:
   store i32 %77, i32* %loc4
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
-  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %80
 
 ; <label>:80                                      ; preds = %73
   %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
@@ -7607,71 +9020,71 @@ entry:
 ; <label>:83                                      ; preds = %80
   store i32 0, i32* %loc3
   %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
-  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
-  br i1 %NullCheck26, label %88, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i32 addrspace(1)* %87, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %88
 
 ; <label>:88                                      ; preds = %85
   %89 = load i32, i32 addrspace(1)* %87, align 8
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
-  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %90
 
 ; <label>:90                                      ; preds = %88
   %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
   store i32 %89, i32 addrspace(1)* %91
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
-  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
-  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %96
 
 ; <label>:96                                      ; preds = %94
   %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
-  br i1 %NullCheck34, label %100, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %100
 
 ; <label>:100                                     ; preds = %96
   %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
-  br i1 %NullCheck36, label %102, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %102
 
 ; <label>:102                                     ; preds = %100
   %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
   %104 = load i32, i32 addrspace(1)* %103, align 8
   %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
-  br i1 %NullCheck38, label %106, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %106
 
 ; <label>:106                                     ; preds = %102
   %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
-  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
-  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %108
 
 ; <label>:108                                     ; preds = %106
   %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
   %110 = load i32, i32 addrspace(1)* %109, align 8
   %111 = add i32 %104, %110
-  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %112
 
 ; <label>:112                                     ; preds = %108
   %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
   store i32 %111, i32 addrspace(1)* %113
   %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
-  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i32 addrspace(1)* %114, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %115
 
 ; <label>:115                                     ; preds = %112
   %116 = load i32, i32 addrspace(1)* %114, align 8
@@ -7681,19 +9094,19 @@ entry:
 ; <label>:118                                     ; preds = %115
   %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
-  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %121
 
 ; <label>:121                                     ; preds = %118
   %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
-  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
-  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %123
 
 ; <label>:123                                     ; preds = %121
   %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
   %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
-  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
-  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %126
 
 ; <label>:126                                     ; preds = %123
   %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
@@ -7705,8 +9118,8 @@ entry:
 
 ; <label>:130                                     ; preds = %80, %115, %126
   %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %132
 
 ; <label>:132                                     ; preds = %130
   %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7715,8 +9128,8 @@ entry:
   %136 = load i32, i32* %loc3
   %137 = sub i32 %135, %136
   %138 = sub i32 %134, %137
-  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %139
 
 ; <label>:139                                     ; preds = %132
   %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7728,16 +9141,16 @@ entry:
 
 ; <label>:144                                     ; preds = %139
   %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
-  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %146
 
 ; <label>:146                                     ; preds = %144
   %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
   %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
   %149 = load i32, i32* %loc2
   %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
-  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %151
 
 ; <label>:151                                     ; preds = %146
   %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
@@ -7754,145 +9167,249 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %18
+ThrowNullRef4:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %31
+ThrowNullRef10:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %44
+ThrowNullRef16:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %68
+ThrowNullRef18:                                   ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %70
+ThrowNullRef20:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %73
+ThrowNullRef22:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %83
+ThrowNullRef24:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %85
+ThrowNullRef26:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %88
+ThrowNullRef28:                                   ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %90
+ThrowNullRef30:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %94
+ThrowNullRef32:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %96
+ThrowNullRef34:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %100
+ThrowNullRef36:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %102
+ThrowNullRef38:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %106
+ThrowNullRef40:                                   ; preds = %106
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %108
+ThrowNullRef42:                                   ; preds = %108
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %112
+ThrowNullRef44:                                   ; preds = %112
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %118
+ThrowNullRef46:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %121
+ThrowNullRef48:                                   ; preds = %121
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %123
+ThrowNullRef50:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %130
+ThrowNullRef52:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %132
+ThrowNullRef54:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %144
+ThrowNullRef56:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %146
+ThrowNullRef58:                                   ; preds = %146
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %60
+ThrowNullRef60:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %63
+ThrowNullRef62:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %49
+ThrowNullRef64:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %51
+ThrowNullRef66:                                   ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %53
+ThrowNullRef68:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(%"System.Char[]" addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %arg0 = alloca %"System.Char[]" addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store %"System.Char[]" addrspace(1)* %param0, %"System.Char[]" addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load i32, i32* %arg4
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %43, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %38, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg1
+  %13 = load i32, i32* %arg4
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %38, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %24 = load i32, i32* %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %35 = load i32, i32* %arg3
+  %36 = load i32, i32* %arg4
+  %37 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %37, %"System.Char[]" addrspace(1)* %34, i32 %35, i32 %36)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:38                                      ; preds = %5, %16
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Successfully read Buffer._Memmove
 
@@ -7914,7 +9431,7 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[loadElem]
+Failed to read AppDomain.SetDataHelper[storeElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -7923,8 +9440,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
@@ -7934,8 +9451,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
@@ -7947,15 +9464,15 @@ entry:
   %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
   %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
@@ -7966,15 +9483,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7992,7 +9509,79 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
-Failed to read Dictionary`2.TryGetValue[loadElemA]
+Successfully read Dictionary`2.TryGetValue
+
+define i8 @"Dictionary`2.TryGetValue"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)* addrspace(1)* %param2) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  %arg2 = alloca %System.__Canon addrspace(1)* addrspace(1)*
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  store %System.__Canon addrspace(1)* addrspace(1)* %param2, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  store i32 %2, i32* %loc0
+  %3 = load i32, i32* %loc0
+  %4 = icmp slt i32 %3, 0
+  br i1 %4, label %22, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 2
+  %10 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %9, align 8
+  %11 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = zext i32 %11 to i64
+  %BoundsCheck = icmp uge i64 %16, %15
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 3, i32 %11
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %20, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %6, %System.__Canon addrspace(1)* %21)
+  ret i8 1
+
+; <label>:22                                      ; preds = %entry
+  %23 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %23, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -8058,8 +9647,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
@@ -8091,8 +9680,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
@@ -8171,15 +9760,15 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck, label %19, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %ThrowNullRef, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
   %21 = load i32, i32 addrspace(1)* %20
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
@@ -8202,7 +9791,7 @@ ThrowNullRef:                                     ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %19
+ThrowNullRef2:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8248,8 +9837,8 @@ entry:
   %0 = alloca %System.AppDomainHandle
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %1 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %1, i32 0, i32 15
@@ -8269,8 +9858,8 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
@@ -8286,7 +9875,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -8299,8 +9888,8 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -8327,8 +9916,8 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
@@ -8352,8 +9941,8 @@ entry:
   %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
   store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
@@ -8363,8 +9952,8 @@ entry:
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
@@ -8374,8 +9963,8 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %9
   %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
@@ -8384,8 +9973,8 @@ entry:
 
 ; <label>:18                                      ; preds = %3, %16
   %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
@@ -8397,15 +9986,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %18
+ThrowNullRef6:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8418,8 +10007,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
@@ -8453,15 +10042,15 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
@@ -8473,7 +10062,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8481,7 +10070,7 @@ ThrowNullRef1:                                    ; preds = %1
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
 Failed to read Dictionary`2.System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
@@ -8506,8 +10095,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
@@ -8524,8 +10113,8 @@ entry:
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -8544,7 +10133,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8577,8 +10166,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = load i64, i64* %arg2
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = trunc i32 %3 to i8
@@ -8634,46 +10223,46 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
   %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
-  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
-  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
-  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
@@ -8684,27 +10273,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %20
+ThrowNullRef12:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8717,8 +10306,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -8756,22 +10345,22 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
   %9 = load i64, i64 addrspace(1)* %8, align 8
   %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
   %13 = load i64, i64 addrspace(1)* %12, align 8
   %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %11
   %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
@@ -8788,11 +10377,11 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8882,8 +10471,8 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
@@ -8900,8 +10489,8 @@ entry:
 ; <label>:8                                       ; preds = %1
   %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
   %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
@@ -8911,15 +10500,15 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
   %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
   %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
-  br i1 %NullCheck6, label %21, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
@@ -8946,15 +10535,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8992,15 +10581,15 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
   store i8 %3, i8 addrspace(1)* %5
   %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
@@ -9011,7 +10600,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9027,8 +10616,8 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -9041,8 +10630,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
@@ -9058,7 +10647,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9080,8 +10669,8 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
@@ -9096,8 +10685,8 @@ entry:
 ; <label>:12                                      ; preds = %6
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
@@ -9112,8 +10701,8 @@ entry:
 ; <label>:21                                      ; preds = %15
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
@@ -9128,8 +10717,8 @@ entry:
 ; <label>:30                                      ; preds = %24
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %31, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
@@ -9144,8 +10733,8 @@ entry:
 ; <label>:39                                      ; preds = %33
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
-  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %40, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %42
 
 ; <label>:42                                      ; preds = %39
   %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
@@ -9164,19 +10753,19 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %21
+ThrowNullRef4:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %30
+ThrowNullRef6:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %39
+ThrowNullRef8:                                    ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9243,8 +10832,8 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
@@ -9264,57 +10853,57 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
   store i8 0, i8 addrspace(1)* %2
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
   store i8 0, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
   store i8 0, i8 addrspace(1)* %17
   %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
   store i8 0, i8 addrspace(1)* %20
   %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
-  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
@@ -9325,31 +10914,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %19
+ThrowNullRef14:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9367,8 +10956,8 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
@@ -9380,8 +10969,8 @@ entry:
 
 ; <label>:9                                       ; preds = %4
   %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %9
   %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
@@ -9395,7 +10984,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef2:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9420,8 +11009,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
@@ -9512,8 +11101,8 @@ entry:
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
@@ -9524,8 +11113,8 @@ entry:
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = load i64, i64 addrspace(1)* %12
@@ -9537,8 +11126,8 @@ entry:
   %20 = load i64, i64* %19
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
-  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %13
   %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
@@ -9555,8 +11144,8 @@ entry:
 ; <label>:30                                      ; preds = %25
   %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %32 = load i32, i32* %arg2
-  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
-  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
@@ -9570,15 +11159,15 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %30
+ThrowNullRef2:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9622,87 +11211,87 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
   %10 = load i8, i8 addrspace(1)* %9, align 8
   %11 = zext i8 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %8
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
   store i8 %12, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
   %19 = load i8, i8 addrspace(1)* %18, align 8
   %20 = zext i8 %19 to i32
   %21 = trunc i32 %20 to i8
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
   store i8 %21, i8 addrspace(1)* %23
   %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
   %28 = load i8, i8 addrspace(1)* %27, align 8
   %29 = zext i8 %28 to i32
   %30 = trunc i32 %29 to i8
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
-  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %31
 
 ; <label>:31                                      ; preds = %26
   %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
   store i8 %30, i8 addrspace(1)* %32
   %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
-  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
-  br i1 %NullCheck14, label %40, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %40
 
 ; <label>:40                                      ; preds = %35
   %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
   store i8 %39, i8 addrspace(1)* %41
   %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
-  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %44
 
 ; <label>:44                                      ; preds = %40
   %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
   %46 = load i8, i8 addrspace(1)* %45, align 8
   %47 = zext i8 %46 to i32
   %48 = trunc i32 %47 to i8
-  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
   store i8 %48, i8 addrspace(1)* %50
   %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
-  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
@@ -9713,29 +11302,29 @@ entry:
 ; <label>:56                                      ; preds = %52
   %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
-  br i1 %NullCheck22, label %59, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
   %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
   %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
-  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
-  br i1 %NullCheck24, label %63, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
   %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
-  br i1 %NullCheck26, label %66, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
   %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
-  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
-  br i1 %NullCheck28, label %69, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %69
 
 ; <label>:69                                      ; preds = %66
   %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
@@ -9744,15 +11333,15 @@ entry:
 
 ; <label>:71                                      ; preds = %105
   %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
-  br i1 %NullCheck34, label %73, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %73
 
 ; <label>:73                                      ; preds = %71
   %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
   %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
   %76 = load i32, i32* %loc0
-  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
-  br i1 %NullCheck36, label %77, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
@@ -9766,8 +11355,8 @@ entry:
 
 ; <label>:83                                      ; preds = %77
   %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
-  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
@@ -9775,14 +11364,14 @@ entry:
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
   %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
-  br i1 %NullCheck40, label %91, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
 ; <label>:91                                      ; preds = %85
   %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
   %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
-  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck42, label %94, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %94
 
 ; <label>:94                                      ; preds = %91
   %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
@@ -9798,14 +11387,14 @@ entry:
 ; <label>:99                                      ; preds = %69, %96
   %100 = load i32, i32* %loc0
   %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
-  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %102
 
 ; <label>:102                                     ; preds = %99
   %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
   %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
-  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
-  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
@@ -9819,87 +11408,87 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %26
+ThrowNullRef10:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %31
+ThrowNullRef12:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %35
+ThrowNullRef14:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %40
+ThrowNullRef16:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %56
+ThrowNullRef22:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %59
+ThrowNullRef24:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %63
+ThrowNullRef26:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %66
+ThrowNullRef28:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %102
+ThrowNullRef32:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %71
+ThrowNullRef34:                                   ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %73
+ThrowNullRef36:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %83
+ThrowNullRef38:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %85
+ThrowNullRef40:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %91
+ThrowNullRef42:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9943,15 +11532,15 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
   %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
@@ -9961,28 +11550,28 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
   %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %12
   %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
   %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
   %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
-  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
@@ -9993,23 +11582,23 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %12
+ThrowNullRef6:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10031,15 +11620,15 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
   %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = load i64, i64 addrspace(1)* %7
@@ -10077,13 +11666,13 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[loadElem]
+Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -10111,8 +11700,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueGeInt1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueGeInt1.error.txt
@@ -25,8 +25,8 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
@@ -40,8 +40,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
   %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
@@ -75,7 +75,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -90,8 +90,8 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %NullCheck = icmp ne i8 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = load i8, i8 addrspace(1)* %0, align 8
@@ -125,8 +125,8 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
@@ -159,8 +159,8 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -184,8 +184,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
   store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
@@ -195,8 +195,8 @@ entry:
 ; <label>:4                                       ; preds = %1
   %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
   %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
@@ -206,8 +206,8 @@ entry:
   %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
@@ -221,14 +221,14 @@ entry:
 
 ; <label>:17                                      ; preds = %14
   %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
   %21 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
@@ -238,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -249,8 +249,8 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
@@ -261,27 +261,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %30
+ThrowNullRef10:                                   ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -301,7 +301,89 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
-Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
+Successfully read AppDomainSetup.GetUnsecureApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.GetUnsecureApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %NullCheck = icmp eq %"System.String[]" addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %BoundsCheck = icmp uge i64 0, %5
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %6
+
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 3, i32 0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
+  ret %System.String addrspace(1)* %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_Value using LLILCJit
+Successfully read AppDomainSetup.get_Value
+
+define %"System.String[]" addrspace(1)* @AppDomainSetup.get_Value(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.String[]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 18)
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.String[]" addrspace(1)* addrspace(1)*, %"System.String[]" addrspace(1)*)*)(%"System.String[]" addrspace(1)* addrspace(1)* %9, %"System.String[]" addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %11, i32 0, i32 1
+  %14 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %13, align 8
+  ret %"System.String[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -319,8 +401,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -368,16 +450,16 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
   %5 = load i32, i32 addrspace(1)* %4
   %6 = sub i32 %5, 1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -389,7 +471,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -421,8 +503,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
@@ -456,8 +538,8 @@ entry:
 ; <label>:27                                      ; preds = %19
   %28 = load i32, i32* %arg1
   %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
-  br i1 %NullCheck2, label %30, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %29, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %30
 
 ; <label>:30                                      ; preds = %27
   %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
@@ -493,8 +575,8 @@ entry:
 ; <label>:49                                      ; preds = %46
   %50 = load i32, i32* %arg2
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck4, label %52, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
@@ -517,11 +599,11 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %27
+ThrowNullRef2:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %49
+ThrowNullRef4:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -544,16 +626,16 @@ entry:
   %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %0)
   store %System.String addrspace(1)* %1, %System.String addrspace(1)** %loc0
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 2
   %5 = bitcast [0 x i16] addrspace(1)* %4 to i16 addrspace(1)*
   store i16 addrspace(1)* %5, i16 addrspace(1)** %loc1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %3
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2
@@ -580,7 +662,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -691,15 +773,15 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %NullCheck132 = icmp ne i8* %21, null
-  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+  %NullCheck131 = icmp eq i8* %21, null
+  br i1 %NullCheck131, label %ThrowNullRef132, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = load i8, i8* %21, align 8
   %24 = zext i8 %23 to i32
   %25 = trunc i32 %24 to i8
-  %NullCheck134 = icmp ne i8* %20, null
-  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+  %NullCheck133 = icmp eq i8* %20, null
+  br i1 %NullCheck133, label %ThrowNullRef134, label %26
 
 ; <label>:26                                      ; preds = %22
   store i8 %25, i8* %20, align 8
@@ -709,16 +791,16 @@ entry:
   %28 = load i8*, i8** %arg0
   %29 = load i8*, i8** %arg1
   %30 = bitcast i8* %29 to i16*
-  %NullCheck128 = icmp ne i16* %30, null
-  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+  %NullCheck127 = icmp eq i16* %30, null
+  br i1 %NullCheck127, label %ThrowNullRef128, label %31
 
 ; <label>:31                                      ; preds = %27
   %32 = load i16, i16* %30, align 8
   %33 = sext i16 %32 to i32
   %34 = bitcast i8* %28 to i16*
   %35 = trunc i32 %33 to i16
-  %NullCheck130 = icmp ne i16* %34, null
-  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+  %NullCheck129 = icmp eq i16* %34, null
+  br i1 %NullCheck129, label %ThrowNullRef130, label %36
 
 ; <label>:36                                      ; preds = %31
   store i16 %35, i16* %34, align 8
@@ -728,16 +810,16 @@ entry:
   %38 = load i8*, i8** %arg0
   %39 = load i8*, i8** %arg1
   %40 = bitcast i8* %39 to i16*
-  %NullCheck120 = icmp ne i16* %40, null
-  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+  %NullCheck119 = icmp eq i16* %40, null
+  br i1 %NullCheck119, label %ThrowNullRef120, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i16, i16* %40, align 8
   %43 = sext i16 %42 to i32
   %44 = bitcast i8* %38 to i16*
   %45 = trunc i32 %43 to i16
-  %NullCheck122 = icmp ne i16* %44, null
-  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+  %NullCheck121 = icmp eq i16* %44, null
+  br i1 %NullCheck121, label %ThrowNullRef122, label %46
 
 ; <label>:46                                      ; preds = %41
   store i16 %45, i16* %44, align 8
@@ -745,15 +827,15 @@ entry:
   %48 = getelementptr inbounds i8, i8* %47, i64 2
   %49 = load i8*, i8** %arg1
   %50 = getelementptr inbounds i8, i8* %49, i64 2
-  %NullCheck124 = icmp ne i8* %50, null
-  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+  %NullCheck123 = icmp eq i8* %50, null
+  br i1 %NullCheck123, label %ThrowNullRef124, label %51
 
 ; <label>:51                                      ; preds = %46
   %52 = load i8, i8* %50, align 8
   %53 = zext i8 %52 to i32
   %54 = trunc i32 %53 to i8
-  %NullCheck126 = icmp ne i8* %48, null
-  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+  %NullCheck125 = icmp eq i8* %48, null
+  br i1 %NullCheck125, label %ThrowNullRef126, label %55
 
 ; <label>:55                                      ; preds = %51
   store i8 %54, i8* %48, align 8
@@ -763,14 +845,14 @@ entry:
   %57 = load i8*, i8** %arg0
   %58 = load i8*, i8** %arg1
   %59 = bitcast i8* %58 to i32*
-  %NullCheck116 = icmp ne i32* %59, null
-  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+  %NullCheck115 = icmp eq i32* %59, null
+  br i1 %NullCheck115, label %ThrowNullRef116, label %60
 
 ; <label>:60                                      ; preds = %56
   %61 = load i32, i32* %59, align 8
   %62 = bitcast i8* %57 to i32*
-  %NullCheck118 = icmp ne i32* %62, null
-  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+  %NullCheck117 = icmp eq i32* %62, null
+  br i1 %NullCheck117, label %ThrowNullRef118, label %63
 
 ; <label>:63                                      ; preds = %60
   store i32 %61, i32* %62, align 8
@@ -780,14 +862,14 @@ entry:
   %65 = load i8*, i8** %arg0
   %66 = load i8*, i8** %arg1
   %67 = bitcast i8* %66 to i32*
-  %NullCheck108 = icmp ne i32* %67, null
-  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+  %NullCheck107 = icmp eq i32* %67, null
+  br i1 %NullCheck107, label %ThrowNullRef108, label %68
 
 ; <label>:68                                      ; preds = %64
   %69 = load i32, i32* %67, align 8
   %70 = bitcast i8* %65 to i32*
-  %NullCheck110 = icmp ne i32* %70, null
-  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+  %NullCheck109 = icmp eq i32* %70, null
+  br i1 %NullCheck109, label %ThrowNullRef110, label %71
 
 ; <label>:71                                      ; preds = %68
   store i32 %69, i32* %70, align 8
@@ -795,15 +877,15 @@ entry:
   %73 = getelementptr inbounds i8, i8* %72, i64 4
   %74 = load i8*, i8** %arg1
   %75 = getelementptr inbounds i8, i8* %74, i64 4
-  %NullCheck112 = icmp ne i8* %75, null
-  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+  %NullCheck111 = icmp eq i8* %75, null
+  br i1 %NullCheck111, label %ThrowNullRef112, label %76
 
 ; <label>:76                                      ; preds = %71
   %77 = load i8, i8* %75, align 8
   %78 = zext i8 %77 to i32
   %79 = trunc i32 %78 to i8
-  %NullCheck114 = icmp ne i8* %73, null
-  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+  %NullCheck113 = icmp eq i8* %73, null
+  br i1 %NullCheck113, label %ThrowNullRef114, label %80
 
 ; <label>:80                                      ; preds = %76
   store i8 %79, i8* %73, align 8
@@ -813,14 +895,14 @@ entry:
   %82 = load i8*, i8** %arg0
   %83 = load i8*, i8** %arg1
   %84 = bitcast i8* %83 to i32*
-  %NullCheck100 = icmp ne i32* %84, null
-  br i1 %NullCheck100, label %85, label %ThrowNullRef99
+  %NullCheck99 = icmp eq i32* %84, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %85
 
 ; <label>:85                                      ; preds = %81
   %86 = load i32, i32* %84, align 8
   %87 = bitcast i8* %82 to i32*
-  %NullCheck102 = icmp ne i32* %87, null
-  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+  %NullCheck101 = icmp eq i32* %87, null
+  br i1 %NullCheck101, label %ThrowNullRef102, label %88
 
 ; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
@@ -829,16 +911,16 @@ entry:
   %91 = load i8*, i8** %arg1
   %92 = getelementptr inbounds i8, i8* %91, i64 4
   %93 = bitcast i8* %92 to i16*
-  %NullCheck104 = icmp ne i16* %93, null
-  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+  %NullCheck103 = icmp eq i16* %93, null
+  br i1 %NullCheck103, label %ThrowNullRef104, label %94
 
 ; <label>:94                                      ; preds = %88
   %95 = load i16, i16* %93, align 8
   %96 = sext i16 %95 to i32
   %97 = bitcast i8* %90 to i16*
   %98 = trunc i32 %96 to i16
-  %NullCheck106 = icmp ne i16* %97, null
-  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+  %NullCheck105 = icmp eq i16* %97, null
+  br i1 %NullCheck105, label %ThrowNullRef106, label %99
 
 ; <label>:99                                      ; preds = %94
   store i16 %98, i16* %97, align 8
@@ -848,14 +930,14 @@ entry:
   %101 = load i8*, i8** %arg0
   %102 = load i8*, i8** %arg1
   %103 = bitcast i8* %102 to i32*
-  %NullCheck88 = icmp ne i32* %103, null
-  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+  %NullCheck87 = icmp eq i32* %103, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %104
 
 ; <label>:104                                     ; preds = %100
   %105 = load i32, i32* %103, align 8
   %106 = bitcast i8* %101 to i32*
-  %NullCheck90 = icmp ne i32* %106, null
-  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+  %NullCheck89 = icmp eq i32* %106, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %107
 
 ; <label>:107                                     ; preds = %104
   store i32 %105, i32* %106, align 8
@@ -864,16 +946,16 @@ entry:
   %110 = load i8*, i8** %arg1
   %111 = getelementptr inbounds i8, i8* %110, i64 4
   %112 = bitcast i8* %111 to i16*
-  %NullCheck92 = icmp ne i16* %112, null
-  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+  %NullCheck91 = icmp eq i16* %112, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %113
 
 ; <label>:113                                     ; preds = %107
   %114 = load i16, i16* %112, align 8
   %115 = sext i16 %114 to i32
   %116 = bitcast i8* %109 to i16*
   %117 = trunc i32 %115 to i16
-  %NullCheck94 = icmp ne i16* %116, null
-  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+  %NullCheck93 = icmp eq i16* %116, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %118
 
 ; <label>:118                                     ; preds = %113
   store i16 %117, i16* %116, align 8
@@ -881,15 +963,15 @@ entry:
   %120 = getelementptr inbounds i8, i8* %119, i64 6
   %121 = load i8*, i8** %arg1
   %122 = getelementptr inbounds i8, i8* %121, i64 6
-  %NullCheck96 = icmp ne i8* %122, null
-  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+  %NullCheck95 = icmp eq i8* %122, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %123
 
 ; <label>:123                                     ; preds = %118
   %124 = load i8, i8* %122, align 8
   %125 = zext i8 %124 to i32
   %126 = trunc i32 %125 to i8
-  %NullCheck98 = icmp ne i8* %120, null
-  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+  %NullCheck97 = icmp eq i8* %120, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %127
 
 ; <label>:127                                     ; preds = %123
   store i8 %126, i8* %120, align 8
@@ -899,14 +981,14 @@ entry:
   %129 = load i8*, i8** %arg0
   %130 = load i8*, i8** %arg1
   %131 = bitcast i8* %130 to i64*
-  %NullCheck84 = icmp ne i64* %131, null
-  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+  %NullCheck83 = icmp eq i64* %131, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %132
 
 ; <label>:132                                     ; preds = %128
   %133 = load i64, i64* %131, align 8
   %134 = bitcast i8* %129 to i64*
-  %NullCheck86 = icmp ne i64* %134, null
-  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+  %NullCheck85 = icmp eq i64* %134, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %135
 
 ; <label>:135                                     ; preds = %132
   store i64 %133, i64* %134, align 8
@@ -916,14 +998,14 @@ entry:
   %137 = load i8*, i8** %arg0
   %138 = load i8*, i8** %arg1
   %139 = bitcast i8* %138 to i64*
-  %NullCheck76 = icmp ne i64* %139, null
-  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+  %NullCheck75 = icmp eq i64* %139, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %140
 
 ; <label>:140                                     ; preds = %136
   %141 = load i64, i64* %139, align 8
   %142 = bitcast i8* %137 to i64*
-  %NullCheck78 = icmp ne i64* %142, null
-  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+  %NullCheck77 = icmp eq i64* %142, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %143
 
 ; <label>:143                                     ; preds = %140
   store i64 %141, i64* %142, align 8
@@ -931,15 +1013,15 @@ entry:
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %NullCheck80 = icmp ne i8* %147, null
-  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+  %NullCheck79 = icmp eq i8* %147, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %148
 
 ; <label>:148                                     ; preds = %143
   %149 = load i8, i8* %147, align 8
   %150 = zext i8 %149 to i32
   %151 = trunc i32 %150 to i8
-  %NullCheck82 = icmp ne i8* %145, null
-  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+  %NullCheck81 = icmp eq i8* %145, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %152
 
 ; <label>:152                                     ; preds = %148
   store i8 %151, i8* %145, align 8
@@ -949,14 +1031,14 @@ entry:
   %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
   %156 = bitcast i8* %155 to i64*
-  %NullCheck68 = icmp ne i64* %156, null
-  br i1 %NullCheck68, label %157, label %ThrowNullRef67
+  %NullCheck67 = icmp eq i64* %156, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %157
 
 ; <label>:157                                     ; preds = %153
   %158 = load i64, i64* %156, align 8
   %159 = bitcast i8* %154 to i64*
-  %NullCheck70 = icmp ne i64* %159, null
-  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+  %NullCheck69 = icmp eq i64* %159, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %160
 
 ; <label>:160                                     ; preds = %157
   store i64 %158, i64* %159, align 8
@@ -965,16 +1047,16 @@ entry:
   %163 = load i8*, i8** %arg1
   %164 = getelementptr inbounds i8, i8* %163, i64 8
   %165 = bitcast i8* %164 to i16*
-  %NullCheck72 = icmp ne i16* %165, null
-  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+  %NullCheck71 = icmp eq i16* %165, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %166
 
 ; <label>:166                                     ; preds = %160
   %167 = load i16, i16* %165, align 8
   %168 = sext i16 %167 to i32
   %169 = bitcast i8* %162 to i16*
   %170 = trunc i32 %168 to i16
-  %NullCheck74 = icmp ne i16* %169, null
-  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+  %NullCheck73 = icmp eq i16* %169, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %171
 
 ; <label>:171                                     ; preds = %166
   store i16 %170, i16* %169, align 8
@@ -984,14 +1066,14 @@ entry:
   %173 = load i8*, i8** %arg0
   %174 = load i8*, i8** %arg1
   %175 = bitcast i8* %174 to i64*
-  %NullCheck56 = icmp ne i64* %175, null
-  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+  %NullCheck55 = icmp eq i64* %175, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %176
 
 ; <label>:176                                     ; preds = %172
   %177 = load i64, i64* %175, align 8
   %178 = bitcast i8* %173 to i64*
-  %NullCheck58 = icmp ne i64* %178, null
-  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+  %NullCheck57 = icmp eq i64* %178, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %179
 
 ; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
@@ -1000,16 +1082,16 @@ entry:
   %182 = load i8*, i8** %arg1
   %183 = getelementptr inbounds i8, i8* %182, i64 8
   %184 = bitcast i8* %183 to i16*
-  %NullCheck60 = icmp ne i16* %184, null
-  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+  %NullCheck59 = icmp eq i16* %184, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %185
 
 ; <label>:185                                     ; preds = %179
   %186 = load i16, i16* %184, align 8
   %187 = sext i16 %186 to i32
   %188 = bitcast i8* %181 to i16*
   %189 = trunc i32 %187 to i16
-  %NullCheck62 = icmp ne i16* %188, null
-  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+  %NullCheck61 = icmp eq i16* %188, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %190
 
 ; <label>:190                                     ; preds = %185
   store i16 %189, i16* %188, align 8
@@ -1017,15 +1099,15 @@ entry:
   %192 = getelementptr inbounds i8, i8* %191, i64 10
   %193 = load i8*, i8** %arg1
   %194 = getelementptr inbounds i8, i8* %193, i64 10
-  %NullCheck64 = icmp ne i8* %194, null
-  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+  %NullCheck63 = icmp eq i8* %194, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %195
 
 ; <label>:195                                     ; preds = %190
   %196 = load i8, i8* %194, align 8
   %197 = zext i8 %196 to i32
   %198 = trunc i32 %197 to i8
-  %NullCheck66 = icmp ne i8* %192, null
-  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+  %NullCheck65 = icmp eq i8* %192, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %199
 
 ; <label>:199                                     ; preds = %195
   store i8 %198, i8* %192, align 8
@@ -1035,14 +1117,14 @@ entry:
   %201 = load i8*, i8** %arg0
   %202 = load i8*, i8** %arg1
   %203 = bitcast i8* %202 to i64*
-  %NullCheck48 = icmp ne i64* %203, null
-  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+  %NullCheck47 = icmp eq i64* %203, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %204
 
 ; <label>:204                                     ; preds = %200
   %205 = load i64, i64* %203, align 8
   %206 = bitcast i8* %201 to i64*
-  %NullCheck50 = icmp ne i64* %206, null
-  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+  %NullCheck49 = icmp eq i64* %206, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %207
 
 ; <label>:207                                     ; preds = %204
   store i64 %205, i64* %206, align 8
@@ -1051,14 +1133,14 @@ entry:
   %210 = load i8*, i8** %arg1
   %211 = getelementptr inbounds i8, i8* %210, i64 8
   %212 = bitcast i8* %211 to i32*
-  %NullCheck52 = icmp ne i32* %212, null
-  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+  %NullCheck51 = icmp eq i32* %212, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %213
 
 ; <label>:213                                     ; preds = %207
   %214 = load i32, i32* %212, align 8
   %215 = bitcast i8* %209 to i32*
-  %NullCheck54 = icmp ne i32* %215, null
-  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+  %NullCheck53 = icmp eq i32* %215, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %216
 
 ; <label>:216                                     ; preds = %213
   store i32 %214, i32* %215, align 8
@@ -1068,14 +1150,14 @@ entry:
   %218 = load i8*, i8** %arg0
   %219 = load i8*, i8** %arg1
   %220 = bitcast i8* %219 to i64*
-  %NullCheck36 = icmp ne i64* %220, null
-  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64* %220, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %221
 
 ; <label>:221                                     ; preds = %217
   %222 = load i64, i64* %220, align 8
   %223 = bitcast i8* %218 to i64*
-  %NullCheck38 = icmp ne i64* %223, null
-  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+  %NullCheck37 = icmp eq i64* %223, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %224
 
 ; <label>:224                                     ; preds = %221
   store i64 %222, i64* %223, align 8
@@ -1084,14 +1166,14 @@ entry:
   %227 = load i8*, i8** %arg1
   %228 = getelementptr inbounds i8, i8* %227, i64 8
   %229 = bitcast i8* %228 to i32*
-  %NullCheck40 = icmp ne i32* %229, null
-  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i32* %229, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %230
 
 ; <label>:230                                     ; preds = %224
   %231 = load i32, i32* %229, align 8
   %232 = bitcast i8* %226 to i32*
-  %NullCheck42 = icmp ne i32* %232, null
-  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+  %NullCheck41 = icmp eq i32* %232, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %233
 
 ; <label>:233                                     ; preds = %230
   store i32 %231, i32* %232, align 8
@@ -1099,15 +1181,15 @@ entry:
   %235 = getelementptr inbounds i8, i8* %234, i64 12
   %236 = load i8*, i8** %arg1
   %237 = getelementptr inbounds i8, i8* %236, i64 12
-  %NullCheck44 = icmp ne i8* %237, null
-  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i8* %237, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %238
 
 ; <label>:238                                     ; preds = %233
   %239 = load i8, i8* %237, align 8
   %240 = zext i8 %239 to i32
   %241 = trunc i32 %240 to i8
-  %NullCheck46 = icmp ne i8* %235, null
-  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+  %NullCheck45 = icmp eq i8* %235, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %242
 
 ; <label>:242                                     ; preds = %238
   store i8 %241, i8* %235, align 8
@@ -1117,14 +1199,14 @@ entry:
   %244 = load i8*, i8** %arg0
   %245 = load i8*, i8** %arg1
   %246 = bitcast i8* %245 to i64*
-  %NullCheck24 = icmp ne i64* %246, null
-  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64* %246, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %247
 
 ; <label>:247                                     ; preds = %243
   %248 = load i64, i64* %246, align 8
   %249 = bitcast i8* %244 to i64*
-  %NullCheck26 = icmp ne i64* %249, null
-  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64* %249, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %250
 
 ; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
@@ -1133,14 +1215,14 @@ entry:
   %253 = load i8*, i8** %arg1
   %254 = getelementptr inbounds i8, i8* %253, i64 8
   %255 = bitcast i8* %254 to i32*
-  %NullCheck28 = icmp ne i32* %255, null
-  br i1 %NullCheck28, label %256, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i32* %255, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %256
 
 ; <label>:256                                     ; preds = %250
   %257 = load i32, i32* %255, align 8
   %258 = bitcast i8* %252 to i32*
-  %NullCheck30 = icmp ne i32* %258, null
-  br i1 %NullCheck30, label %259, label %ThrowNullRef29
+  %NullCheck29 = icmp eq i32* %258, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %259
 
 ; <label>:259                                     ; preds = %256
   store i32 %257, i32* %258, align 8
@@ -1149,16 +1231,16 @@ entry:
   %262 = load i8*, i8** %arg1
   %263 = getelementptr inbounds i8, i8* %262, i64 12
   %264 = bitcast i8* %263 to i16*
-  %NullCheck32 = icmp ne i16* %264, null
-  br i1 %NullCheck32, label %265, label %ThrowNullRef31
+  %NullCheck31 = icmp eq i16* %264, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %265
 
 ; <label>:265                                     ; preds = %259
   %266 = load i16, i16* %264, align 8
   %267 = sext i16 %266 to i32
   %268 = bitcast i8* %261 to i16*
   %269 = trunc i32 %267 to i16
-  %NullCheck34 = icmp ne i16* %268, null
-  br i1 %NullCheck34, label %270, label %ThrowNullRef33
+  %NullCheck33 = icmp eq i16* %268, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %270
 
 ; <label>:270                                     ; preds = %265
   store i16 %269, i16* %268, align 8
@@ -1168,14 +1250,14 @@ entry:
   %272 = load i8*, i8** %arg0
   %273 = load i8*, i8** %arg1
   %274 = bitcast i8* %273 to i64*
-  %NullCheck8 = icmp ne i64* %274, null
-  br i1 %NullCheck8, label %275, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64* %274, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %275
 
 ; <label>:275                                     ; preds = %271
   %276 = load i64, i64* %274, align 8
   %277 = bitcast i8* %272 to i64*
-  %NullCheck10 = icmp ne i64* %277, null
-  br i1 %NullCheck10, label %278, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %277, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %278
 
 ; <label>:278                                     ; preds = %275
   store i64 %276, i64* %277, align 8
@@ -1184,14 +1266,14 @@ entry:
   %281 = load i8*, i8** %arg1
   %282 = getelementptr inbounds i8, i8* %281, i64 8
   %283 = bitcast i8* %282 to i32*
-  %NullCheck12 = icmp ne i32* %283, null
-  br i1 %NullCheck12, label %284, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i32* %283, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %284
 
 ; <label>:284                                     ; preds = %278
   %285 = load i32, i32* %283, align 8
   %286 = bitcast i8* %280 to i32*
-  %NullCheck14 = icmp ne i32* %286, null
-  br i1 %NullCheck14, label %287, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i32* %286, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %287
 
 ; <label>:287                                     ; preds = %284
   store i32 %285, i32* %286, align 8
@@ -1200,16 +1282,16 @@ entry:
   %290 = load i8*, i8** %arg1
   %291 = getelementptr inbounds i8, i8* %290, i64 12
   %292 = bitcast i8* %291 to i16*
-  %NullCheck16 = icmp ne i16* %292, null
-  br i1 %NullCheck16, label %293, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i16* %292, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %293
 
 ; <label>:293                                     ; preds = %287
   %294 = load i16, i16* %292, align 8
   %295 = sext i16 %294 to i32
   %296 = bitcast i8* %289 to i16*
   %297 = trunc i32 %295 to i16
-  %NullCheck18 = icmp ne i16* %296, null
-  br i1 %NullCheck18, label %298, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i16* %296, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %298
 
 ; <label>:298                                     ; preds = %293
   store i16 %297, i16* %296, align 8
@@ -1217,15 +1299,15 @@ entry:
   %300 = getelementptr inbounds i8, i8* %299, i64 14
   %301 = load i8*, i8** %arg1
   %302 = getelementptr inbounds i8, i8* %301, i64 14
-  %NullCheck20 = icmp ne i8* %302, null
-  br i1 %NullCheck20, label %303, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i8* %302, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %303
 
 ; <label>:303                                     ; preds = %298
   %304 = load i8, i8* %302, align 8
   %305 = zext i8 %304 to i32
   %306 = trunc i32 %305 to i8
-  %NullCheck22 = icmp ne i8* %300, null
-  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i8* %300, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %307
 
 ; <label>:307                                     ; preds = %303
   store i8 %306, i8* %300, align 8
@@ -1235,14 +1317,14 @@ entry:
   %309 = load i8*, i8** %arg0
   %310 = load i8*, i8** %arg1
   %311 = bitcast i8* %310 to i64*
-  %NullCheck = icmp ne i64* %311, null
-  br i1 %NullCheck, label %312, label %ThrowNullRef
+  %NullCheck = icmp eq i64* %311, null
+  br i1 %NullCheck, label %ThrowNullRef, label %312
 
 ; <label>:312                                     ; preds = %308
   %313 = load i64, i64* %311, align 8
   %314 = bitcast i8* %309 to i64*
-  %NullCheck2 = icmp ne i64* %314, null
-  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64* %314, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %315
 
 ; <label>:315                                     ; preds = %312
   store i64 %313, i64* %314, align 8
@@ -1251,14 +1333,14 @@ entry:
   %318 = load i8*, i8** %arg1
   %319 = getelementptr inbounds i8, i8* %318, i64 8
   %320 = bitcast i8* %319 to i64*
-  %NullCheck4 = icmp ne i64* %320, null
-  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64* %320, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %321
 
 ; <label>:321                                     ; preds = %315
   %322 = load i64, i64* %320, align 8
   %323 = bitcast i8* %317 to i64*
-  %NullCheck6 = icmp ne i64* %323, null
-  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64* %323, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %324
 
 ; <label>:324                                     ; preds = %321
   store i64 %322, i64* %323, align 8
@@ -1286,15 +1368,15 @@ entry:
 ; <label>:338                                     ; preds = %333
   %339 = load i8*, i8** %arg0
   %340 = load i8*, i8** %arg1
-  %NullCheck136 = icmp ne i8* %340, null
-  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+  %NullCheck135 = icmp eq i8* %340, null
+  br i1 %NullCheck135, label %ThrowNullRef136, label %341
 
 ; <label>:341                                     ; preds = %338
   %342 = load i8, i8* %340, align 8
   %343 = zext i8 %342 to i32
   %344 = trunc i32 %343 to i8
-  %NullCheck138 = icmp ne i8* %339, null
-  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+  %NullCheck137 = icmp eq i8* %339, null
+  br i1 %NullCheck137, label %ThrowNullRef138, label %345
 
 ; <label>:345                                     ; preds = %341
   store i8 %344, i8* %339, align 8
@@ -1317,16 +1399,16 @@ entry:
   %357 = load i8*, i8** %arg0
   %358 = load i8*, i8** %arg1
   %359 = bitcast i8* %358 to i16*
-  %NullCheck140 = icmp ne i16* %359, null
-  br i1 %NullCheck140, label %360, label %ThrowNullRef139
+  %NullCheck139 = icmp eq i16* %359, null
+  br i1 %NullCheck139, label %ThrowNullRef140, label %360
 
 ; <label>:360                                     ; preds = %356
   %361 = load i16, i16* %359, align 8
   %362 = sext i16 %361 to i32
   %363 = bitcast i8* %357 to i16*
   %364 = trunc i32 %362 to i16
-  %NullCheck142 = icmp ne i16* %363, null
-  br i1 %NullCheck142, label %365, label %ThrowNullRef141
+  %NullCheck141 = icmp eq i16* %363, null
+  br i1 %NullCheck141, label %ThrowNullRef142, label %365
 
 ; <label>:365                                     ; preds = %360
   store i16 %364, i16* %363, align 8
@@ -1352,14 +1434,14 @@ entry:
   %378 = load i8*, i8** %arg0
   %379 = load i8*, i8** %arg1
   %380 = bitcast i8* %379 to i32*
-  %NullCheck144 = icmp ne i32* %380, null
-  br i1 %NullCheck144, label %381, label %ThrowNullRef143
+  %NullCheck143 = icmp eq i32* %380, null
+  br i1 %NullCheck143, label %ThrowNullRef144, label %381
 
 ; <label>:381                                     ; preds = %377
   %382 = load i32, i32* %380, align 8
   %383 = bitcast i8* %378 to i32*
-  %NullCheck146 = icmp ne i32* %383, null
-  br i1 %NullCheck146, label %384, label %ThrowNullRef145
+  %NullCheck145 = icmp eq i32* %383, null
+  br i1 %NullCheck145, label %ThrowNullRef146, label %384
 
 ; <label>:384                                     ; preds = %381
   store i32 %382, i32* %383, align 8
@@ -1384,14 +1466,14 @@ entry:
   %395 = load i8*, i8** %arg0
   %396 = load i8*, i8** %arg1
   %397 = bitcast i8* %396 to i64*
-  %NullCheck164 = icmp ne i64* %397, null
-  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+  %NullCheck163 = icmp eq i64* %397, null
+  br i1 %NullCheck163, label %ThrowNullRef164, label %398
 
 ; <label>:398                                     ; preds = %394
   %399 = load i64, i64* %397, align 8
   %400 = bitcast i8* %395 to i64*
-  %NullCheck166 = icmp ne i64* %400, null
-  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+  %NullCheck165 = icmp eq i64* %400, null
+  br i1 %NullCheck165, label %ThrowNullRef166, label %401
 
 ; <label>:401                                     ; preds = %398
   store i64 %399, i64* %400, align 8
@@ -1400,14 +1482,14 @@ entry:
   %404 = load i8*, i8** %arg1
   %405 = getelementptr inbounds i8, i8* %404, i64 8
   %406 = bitcast i8* %405 to i64*
-  %NullCheck168 = icmp ne i64* %406, null
-  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+  %NullCheck167 = icmp eq i64* %406, null
+  br i1 %NullCheck167, label %ThrowNullRef168, label %407
 
 ; <label>:407                                     ; preds = %401
   %408 = load i64, i64* %406, align 8
   %409 = bitcast i8* %403 to i64*
-  %NullCheck170 = icmp ne i64* %409, null
-  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+  %NullCheck169 = icmp eq i64* %409, null
+  br i1 %NullCheck169, label %ThrowNullRef170, label %410
 
 ; <label>:410                                     ; preds = %407
   store i64 %408, i64* %409, align 8
@@ -1437,14 +1519,14 @@ entry:
   %425 = load i8*, i8** %arg0
   %426 = load i8*, i8** %arg1
   %427 = bitcast i8* %426 to i64*
-  %NullCheck148 = icmp ne i64* %427, null
-  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+  %NullCheck147 = icmp eq i64* %427, null
+  br i1 %NullCheck147, label %ThrowNullRef148, label %428
 
 ; <label>:428                                     ; preds = %424
   %429 = load i64, i64* %427, align 8
   %430 = bitcast i8* %425 to i64*
-  %NullCheck150 = icmp ne i64* %430, null
-  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+  %NullCheck149 = icmp eq i64* %430, null
+  br i1 %NullCheck149, label %ThrowNullRef150, label %431
 
 ; <label>:431                                     ; preds = %428
   store i64 %429, i64* %430, align 8
@@ -1466,14 +1548,14 @@ entry:
   %441 = load i8*, i8** %arg0
   %442 = load i8*, i8** %arg1
   %443 = bitcast i8* %442 to i32*
-  %NullCheck152 = icmp ne i32* %443, null
-  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+  %NullCheck151 = icmp eq i32* %443, null
+  br i1 %NullCheck151, label %ThrowNullRef152, label %444
 
 ; <label>:444                                     ; preds = %440
   %445 = load i32, i32* %443, align 8
   %446 = bitcast i8* %441 to i32*
-  %NullCheck154 = icmp ne i32* %446, null
-  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+  %NullCheck153 = icmp eq i32* %446, null
+  br i1 %NullCheck153, label %ThrowNullRef154, label %447
 
 ; <label>:447                                     ; preds = %444
   store i32 %445, i32* %446, align 8
@@ -1495,16 +1577,16 @@ entry:
   %457 = load i8*, i8** %arg0
   %458 = load i8*, i8** %arg1
   %459 = bitcast i8* %458 to i16*
-  %NullCheck156 = icmp ne i16* %459, null
-  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+  %NullCheck155 = icmp eq i16* %459, null
+  br i1 %NullCheck155, label %ThrowNullRef156, label %460
 
 ; <label>:460                                     ; preds = %456
   %461 = load i16, i16* %459, align 8
   %462 = sext i16 %461 to i32
   %463 = bitcast i8* %457 to i16*
   %464 = trunc i32 %462 to i16
-  %NullCheck158 = icmp ne i16* %463, null
-  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+  %NullCheck157 = icmp eq i16* %463, null
+  br i1 %NullCheck157, label %ThrowNullRef158, label %465
 
 ; <label>:465                                     ; preds = %460
   store i16 %464, i16* %463, align 8
@@ -1525,15 +1607,15 @@ entry:
 ; <label>:474                                     ; preds = %470
   %475 = load i8*, i8** %arg0
   %476 = load i8*, i8** %arg1
-  %NullCheck160 = icmp ne i8* %476, null
-  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+  %NullCheck159 = icmp eq i8* %476, null
+  br i1 %NullCheck159, label %ThrowNullRef160, label %477
 
 ; <label>:477                                     ; preds = %474
   %478 = load i8, i8* %476, align 8
   %479 = zext i8 %478 to i32
   %480 = trunc i32 %479 to i8
-  %NullCheck162 = icmp ne i8* %475, null
-  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+  %NullCheck161 = icmp eq i8* %475, null
+  br i1 %NullCheck161, label %ThrowNullRef162, label %481
 
 ; <label>:481                                     ; preds = %477
   store i8 %480, i8* %475, align 8
@@ -1553,343 +1635,343 @@ ThrowNullRef:                                     ; preds = %308
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %312
+ThrowNullRef2:                                    ; preds = %312
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %315
+ThrowNullRef4:                                    ; preds = %315
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %321
+ThrowNullRef6:                                    ; preds = %321
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %271
+ThrowNullRef8:                                    ; preds = %271
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %275
+ThrowNullRef10:                                   ; preds = %275
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %278
+ThrowNullRef12:                                   ; preds = %278
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %284
+ThrowNullRef14:                                   ; preds = %284
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %287
+ThrowNullRef16:                                   ; preds = %287
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %293
+ThrowNullRef18:                                   ; preds = %293
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %298
+ThrowNullRef20:                                   ; preds = %298
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %303
+ThrowNullRef22:                                   ; preds = %303
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %243
+ThrowNullRef24:                                   ; preds = %243
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %247
+ThrowNullRef26:                                   ; preds = %247
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %250
+ThrowNullRef28:                                   ; preds = %250
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %256
+ThrowNullRef30:                                   ; preds = %256
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %259
+ThrowNullRef32:                                   ; preds = %259
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %265
+ThrowNullRef34:                                   ; preds = %265
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %217
+ThrowNullRef36:                                   ; preds = %217
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %221
+ThrowNullRef38:                                   ; preds = %221
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %224
+ThrowNullRef40:                                   ; preds = %224
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %230
+ThrowNullRef42:                                   ; preds = %230
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %233
+ThrowNullRef44:                                   ; preds = %233
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %238
+ThrowNullRef46:                                   ; preds = %238
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %200
+ThrowNullRef48:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %204
+ThrowNullRef50:                                   ; preds = %204
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %207
+ThrowNullRef52:                                   ; preds = %207
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %213
+ThrowNullRef54:                                   ; preds = %213
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %172
+ThrowNullRef56:                                   ; preds = %172
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %176
+ThrowNullRef58:                                   ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %179
+ThrowNullRef60:                                   ; preds = %179
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %185
+ThrowNullRef62:                                   ; preds = %185
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %190
+ThrowNullRef64:                                   ; preds = %190
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %195
+ThrowNullRef66:                                   ; preds = %195
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %153
+ThrowNullRef68:                                   ; preds = %153
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %157
+ThrowNullRef70:                                   ; preds = %157
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %160
+ThrowNullRef72:                                   ; preds = %160
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %166
+ThrowNullRef74:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %136
+ThrowNullRef76:                                   ; preds = %136
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %140
+ThrowNullRef78:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %143
+ThrowNullRef80:                                   ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %148
+ThrowNullRef82:                                   ; preds = %148
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %128
+ThrowNullRef84:                                   ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %132
+ThrowNullRef86:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %100
+ThrowNullRef88:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %104
+ThrowNullRef90:                                   ; preds = %104
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %107
+ThrowNullRef92:                                   ; preds = %107
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %113
+ThrowNullRef94:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %118
+ThrowNullRef96:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %123
+ThrowNullRef98:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %81
+ThrowNullRef100:                                  ; preds = %81
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef101:                                  ; preds = %85
+ThrowNullRef102:                                  ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef103:                                  ; preds = %88
+ThrowNullRef104:                                  ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef105:                                  ; preds = %94
+ThrowNullRef106:                                  ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef107:                                  ; preds = %64
+ThrowNullRef108:                                  ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef109:                                  ; preds = %68
+ThrowNullRef110:                                  ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef111:                                  ; preds = %71
+ThrowNullRef112:                                  ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef113:                                  ; preds = %76
+ThrowNullRef114:                                  ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef115:                                  ; preds = %56
+ThrowNullRef116:                                  ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef117:                                  ; preds = %60
+ThrowNullRef118:                                  ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef119:                                  ; preds = %37
+ThrowNullRef120:                                  ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef121:                                  ; preds = %41
+ThrowNullRef122:                                  ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef123:                                  ; preds = %46
+ThrowNullRef124:                                  ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef125:                                  ; preds = %51
+ThrowNullRef126:                                  ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef127:                                  ; preds = %27
+ThrowNullRef128:                                  ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef129:                                  ; preds = %31
+ThrowNullRef130:                                  ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef131:                                  ; preds = %19
+ThrowNullRef132:                                  ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef133:                                  ; preds = %22
+ThrowNullRef134:                                  ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef135:                                  ; preds = %338
+ThrowNullRef136:                                  ; preds = %338
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef137:                                  ; preds = %341
+ThrowNullRef138:                                  ; preds = %341
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef139:                                  ; preds = %356
+ThrowNullRef140:                                  ; preds = %356
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef141:                                  ; preds = %360
+ThrowNullRef142:                                  ; preds = %360
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef143:                                  ; preds = %377
+ThrowNullRef144:                                  ; preds = %377
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef145:                                  ; preds = %381
+ThrowNullRef146:                                  ; preds = %381
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef147:                                  ; preds = %424
+ThrowNullRef148:                                  ; preds = %424
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef149:                                  ; preds = %428
+ThrowNullRef150:                                  ; preds = %428
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef151:                                  ; preds = %440
+ThrowNullRef152:                                  ; preds = %440
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef153:                                  ; preds = %444
+ThrowNullRef154:                                  ; preds = %444
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef155:                                  ; preds = %456
+ThrowNullRef156:                                  ; preds = %456
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef157:                                  ; preds = %460
+ThrowNullRef158:                                  ; preds = %460
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef159:                                  ; preds = %474
+ThrowNullRef160:                                  ; preds = %474
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef161:                                  ; preds = %477
+ThrowNullRef162:                                  ; preds = %477
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef163:                                  ; preds = %394
+ThrowNullRef164:                                  ; preds = %394
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef165:                                  ; preds = %398
+ThrowNullRef166:                                  ; preds = %398
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef167:                                  ; preds = %401
+ThrowNullRef168:                                  ; preds = %401
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef169:                                  ; preds = %407
+ThrowNullRef170:                                  ; preds = %407
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1939,8 +2021,8 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
-  br i1 %NullCheck, label %22, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %ThrowNullRef, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
@@ -1948,8 +2030,8 @@ entry:
   store i32 %24, i32* %loc0
   %25 = load i32, i32* %loc0
   %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %26, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %27
 
 ; <label>:27                                      ; preds = %22
   %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
@@ -1971,7 +2053,7 @@ ThrowNullRef:                                     ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1989,8 +2071,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -2022,15 +2104,15 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2048,16 +2130,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
   %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
   store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %15
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
@@ -2072,8 +2154,8 @@ entry:
   %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
   %29 = ptrtoint i16 addrspace(1)* %28 to i64
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %19
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
@@ -2089,19 +2171,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2114,8 +2196,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
@@ -2128,7 +2210,7 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[loadElem]
+Failed to read AppDomain.PrepareDataForSetup[storeElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
@@ -2202,8 +2284,8 @@ entry:
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
-  br i1 %NullCheck24, label %27, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = load i64, i64 addrspace(1)* %26
@@ -2218,8 +2300,8 @@ entry:
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
-  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
   %41 = load i64, i64 addrspace(1)* %39
@@ -2236,8 +2318,8 @@ entry:
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
-  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
   %54 = load i64, i64 addrspace(1)* %52
@@ -2252,8 +2334,8 @@ entry:
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
   %67 = load i64, i64 addrspace(1)* %65
@@ -2270,8 +2352,8 @@ entry:
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
-  br i1 %NullCheck16, label %79, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
   %80 = load i64, i64 addrspace(1)* %78
@@ -2286,8 +2368,8 @@ entry:
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
-  br i1 %NullCheck18, label %92, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
   %93 = load i64, i64 addrspace(1)* %91
@@ -2304,8 +2386,8 @@ entry:
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
-  br i1 %NullCheck12, label %105, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = load i64, i64 addrspace(1)* %104
@@ -2320,8 +2402,8 @@ entry:
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
-  br i1 %NullCheck14, label %118, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
   %119 = load i64, i64 addrspace(1)* %117
@@ -2337,8 +2419,8 @@ entry:
 
 ; <label>:128                                     ; preds = %20
   %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
-  br i1 %NullCheck4, label %130, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %129, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %130
 
 ; <label>:130                                     ; preds = %128
   %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
@@ -2346,8 +2428,8 @@ entry:
   %133 = load i16, i16 addrspace(1)* %132, align 8
   %134 = zext i16 %133 to i32
   %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
-  br i1 %NullCheck6, label %136, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %135, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %136
 
 ; <label>:136                                     ; preds = %130
   %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
@@ -2360,8 +2442,8 @@ entry:
 
 ; <label>:143                                     ; preds = %136
   %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
-  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %144, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %145
 
 ; <label>:145                                     ; preds = %143
   %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
@@ -2369,8 +2451,8 @@ entry:
   %148 = load i16, i16 addrspace(1)* %147, align 8
   %149 = zext i16 %148 to i32
   %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %150, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %151
 
 ; <label>:151                                     ; preds = %145
   %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
@@ -2388,8 +2470,8 @@ entry:
 
 ; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
-  br i1 %NullCheck, label %163, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %ThrowNullRef, label %163
 
 ; <label>:163                                     ; preds = %161
   %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
@@ -2399,8 +2481,8 @@ entry:
 
 ; <label>:167                                     ; preds = %163
   %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
-  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %168, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %169
 
 ; <label>:169                                     ; preds = %167
   %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
@@ -2432,55 +2514,55 @@ ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %167
+ThrowNullRef2:                                    ; preds = %167
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %128
+ThrowNullRef4:                                    ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %130
+ThrowNullRef6:                                    ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %143
+ThrowNullRef8:                                    ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %145
+ThrowNullRef10:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %102
+ThrowNullRef12:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %105
+ThrowNullRef14:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %76
+ThrowNullRef16:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %79
+ThrowNullRef18:                                   ; preds = %79
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %50
+ThrowNullRef20:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %53
+ThrowNullRef22:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %24
+ThrowNullRef24:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %27
+ThrowNullRef26:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2503,15 +2585,15 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2519,16 +2601,16 @@ entry:
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
   store i32 %8, i32* %loc0
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
   %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
   store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
@@ -2546,16 +2628,16 @@ entry:
 
 ; <label>:23                                      ; preds = %64
   %24 = load i16*, i16** %loc3
-  %NullCheck12 = icmp ne i16* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i16* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
   store i32 %27, i32* %loc5
   %28 = load i16*, i16** %loc4
-  %NullCheck14 = icmp ne i16* %28, null
-  br i1 %NullCheck14, label %29, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %28, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = load i16, i16* %28, align 8
@@ -2620,15 +2702,15 @@ entry:
 
 ; <label>:67                                      ; preds = %64
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
-  br i1 %NullCheck8, label %69, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %68, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %69
 
 ; <label>:69                                      ; preds = %67
   %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
   %71 = load i32, i32 addrspace(1)* %70
   %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
-  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %73
 
 ; <label>:73                                      ; preds = %69
   %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
@@ -2645,31 +2727,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %67
+ThrowNullRef8:                                    ; preds = %67
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %69
+ThrowNullRef10:                                   ; preds = %69
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2710,14 +2792,14 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
   %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
@@ -2730,14 +2812,14 @@ entry:
 
 ; <label>:11                                      ; preds = %4
   %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
   %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
@@ -2749,14 +2831,14 @@ entry:
 
 ; <label>:22                                      ; preds = %16
   %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
   %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
-  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
-  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
@@ -2804,23 +2886,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2836,7 +2918,280 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[loadElem]
+Successfully read RuntimeType.IsAssignableFrom
+
+define i8 @RuntimeType.IsAssignableFrom(%System.RuntimeType addrspace(1)* %param0, %System.Type addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.RuntimeType addrspace(1)*
+  %arg1 = alloca %System.Type addrspace(1)*
+  %loc0 = alloca %System.RuntimeType addrspace(1)*
+  %loc1 = alloca %"System.Type[]" addrspace(1)*
+  %loc2 = alloca i32
+  store %System.RuntimeType addrspace(1)* %param0, %System.RuntimeType addrspace(1)** %this
+  store %System.Type addrspace(1)* %param1, %System.Type addrspace(1)** %arg1
+  %0 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %1 = icmp ne %System.Type addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i8 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %5 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %6 = bitcast %System.Type addrspace(1)* %4 to %System.Object addrspace(1)*
+  %7 = bitcast %System.RuntimeType addrspace(1)* %5 to %System.Object addrspace(1)*
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %6, %System.Object addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %3
+  ret i8 1
+
+; <label>:12                                      ; preds = %3
+  %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 152
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 32
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
+  %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
+  %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
+  store %System.RuntimeType addrspace(1)* %25, %System.RuntimeType addrspace(1)** %loc0
+  %26 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %27 = icmp eq %System.RuntimeType addrspace(1)* %26, null
+  br i1 %27, label %34, label %28
+
+; <label>:28                                      ; preds = %15
+  %29 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %30 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)*)*)(%System.RuntimeType addrspace(1)* %29, %System.RuntimeType addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+; <label>:34                                      ; preds = %15
+  %35 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %36 = call %System.Reflection.Emit.TypeBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Reflection.Emit.TypeBuilder addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %35)
+  %37 = icmp eq %System.Reflection.Emit.TypeBuilder addrspace(1)* %36, null
+  br i1 %37, label %139, label %38
+
+; <label>:38                                      ; preds = %34
+  %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %42
+
+; <label>:42                                      ; preds = %38
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 152
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 40
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
+  %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
+  %53 = zext i8 %52 to i32
+  %54 = icmp eq i32 %53, 0
+  br i1 %54, label %56, label %55
+
+; <label>:55                                      ; preds = %42
+  ret i8 1
+
+; <label>:56                                      ; preds = %42
+  %57 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %58 = bitcast %System.RuntimeType addrspace(1)* %57 to %System.Type addrspace(1)*
+  %59 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %58)
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %64 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.Type addrspace(1)* %63, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = bitcast %System.RuntimeType addrspace(1)* %64 to %System.Type addrspace(1)*
+  %67 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %63, %System.Type addrspace(1)* %66)
+  %68 = zext i8 %67 to i32
+  %69 = trunc i32 %68 to i8
+  ret i8 %69
+
+; <label>:70                                      ; preds = %56
+  %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
+  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %73
+
+; <label>:73                                      ; preds = %70
+  %74 = load i64, i64 addrspace(1)* %72
+  %75 = add i64 %74, 128
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = add i64 %77, 0
+  %79 = inttoptr i64 %78 to i64*
+  %80 = load i64, i64* %79
+  %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
+  %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
+  %83 = call i8 %82(%System.Type addrspace(1)* %81)
+  %84 = zext i8 %83 to i32
+  %85 = icmp eq i32 %84, 0
+  br i1 %85, label %139, label %86
+
+; <label>:86                                      ; preds = %73
+  %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
+  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %89
+
+; <label>:89                                      ; preds = %86
+  %90 = load i64, i64 addrspace(1)* %88
+  %91 = add i64 %90, 128
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = add i64 %93, 24
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
+  %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
+  %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
+  store %"System.Type[]" addrspace(1)* %99, %"System.Type[]" addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %129
+
+; <label>:100                                     ; preds = %132
+  %101 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %102 = load i32, i32* %loc2
+  %NullCheck11 = icmp eq %"System.Type[]" addrspace(1)* %101, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %103
+
+; <label>:103                                     ; preds = %100
+  %104 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 1
+  %105 = load i32, i32 addrspace(1)* %104
+  %106 = zext i32 %105 to i64
+  %107 = zext i32 %102 to i64
+  %BoundsCheck = icmp uge i64 %107, %106
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %108
+
+; <label>:108                                     ; preds = %103
+  %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
+  %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
+  %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
+  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %113
+
+; <label>:113                                     ; preds = %108
+  %114 = load i64, i64 addrspace(1)* %112
+  %115 = add i64 %114, 152
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = add i64 %117, 56
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
+  %123 = zext i8 %122 to i32
+  %124 = icmp ne i32 %123, 0
+  br i1 %124, label %126, label %125
+
+; <label>:125                                     ; preds = %113
+  ret i8 0
+
+; <label>:126                                     ; preds = %113
+  %127 = load i32, i32* %loc2
+  %128 = add i32 %127, 1
+  store i32 %128, i32* %loc2
+  br label %129
+
+; <label>:129                                     ; preds = %89, %126
+  %130 = load i32, i32* %loc2
+  %131 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %NullCheck9 = icmp eq %"System.Type[]" addrspace(1)* %131, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %132
+
+; <label>:132                                     ; preds = %129
+  %133 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %131, i32 0, i32 1
+  %134 = load i32, i32 addrspace(1)* %133
+  %135 = zext i32 %134 to i64
+  %136 = trunc i64 %135 to i32
+  %137 = icmp slt i32 %130, %136
+  br i1 %137, label %100, label %138
+
+; <label>:138                                     ; preds = %132
+  ret i8 1
+
+; <label>:139                                     ; preds = %34, %73
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %129
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %103
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -2893,7 +3248,7 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElem]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -2904,8 +3259,8 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -2997,8 +3352,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
@@ -3059,8 +3414,8 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -3087,8 +3442,8 @@ entry:
 
 ; <label>:17                                      ; preds = %5, %11
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
@@ -3097,8 +3452,8 @@ entry:
 
 ; <label>:22                                      ; preds = %1, %11
   %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
@@ -3109,11 +3464,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %17
+ThrowNullRef2:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %22
+ThrowNullRef4:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3167,15 +3522,15 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
   %15 = load i32, i32 addrspace(1)* %14
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
@@ -3198,7 +3553,7 @@ ThrowNullRef:                                     ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef2:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3232,8 +3587,8 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
@@ -3312,8 +3667,8 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -3327,8 +3682,8 @@ entry:
 ; <label>:5                                       ; preds = %43
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %7 = load i32, i32* %loc1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck6, label %8, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
@@ -3366,8 +3721,8 @@ entry:
 ; <label>:32                                      ; preds = %21, %25
   %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
   %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
-  br i1 %NullCheck8, label %35, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = trunc i32 %34 to i16
@@ -3380,8 +3735,8 @@ entry:
 ; <label>:40                                      ; preds = %1, %35
   %41 = load i32, i32* %loc1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
-  br i1 %NullCheck2, label %43, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %42, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
@@ -3392,8 +3747,8 @@ entry:
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
   %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
-  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
   %51 = load i64, i64 addrspace(1)* %49
@@ -3412,19 +3767,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %40
+ThrowNullRef2:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %47
+ThrowNullRef4:                                    ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %5
+ThrowNullRef6:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %32
+ThrowNullRef8:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3467,8 +3822,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
@@ -3492,11 +3847,391 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(i16* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store i16* %param0, i16** %arg0
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load i32, i32* %arg3
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %42, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %37, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg2
+  %13 = load i32, i32* %arg3
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %37, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %24 = load i32, i32* %arg2
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load i16*, i16** %arg0
+  %35 = load i32, i32* %arg3
+  %36 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %36, i16* %34, i32 %35)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:37                                      ; preds = %5, %16
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %39)
+  %41 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41, %System.String addrspace(1)* %38, %System.String addrspace(1)* %40)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41) #0
+  unreachable
+
+; <label>:42                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
-Failed to read StringBuilder.ToString[loadElemA]
+Successfully read StringBuilder.ToString
+
+define %System.String addrspace(1)* @StringBuilder.ToString(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i16*
+  %loc3 = alloca %"System.Char[]" addrspace(1)*
+  %loc4 = alloca i32
+  %loc5 = alloca i32
+  %loc6 = alloca i16 addrspace(1)*
+  %loc7 = alloca %System.String addrspace(1)*
+  %loc8 = alloca %"System.Char[]" addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %0)
+  %2 = icmp ne i32 %1, 0
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %4
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %6)
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %7)
+  store %System.String addrspace(1)* %8, %System.String addrspace(1)** %loc0
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.Text.StringBuilder addrspace(1)* %9, %System.Text.StringBuilder addrspace(1)** %loc1
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  store %System.String addrspace(1)* %10, %System.String addrspace(1)** %loc7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc7
+  %12 = ptrtoint %System.String addrspace(1)* %11 to i64
+  %13 = icmp eq i64 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %5
+  %15 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %16 = sext i32 %15 to i64
+  %17 = add i64 %12, %16
+  br label %18
+
+; <label>:18                                      ; preds = %5, %14
+  %19 = phi i64 [ %12, %5 ], [ %17, %14 ]
+  %20 = inttoptr i64 %19 to i16*
+  store i16* %20, i16** %loc2
+  br label %21
+
+; <label>:21                                      ; preds = %98, %18
+  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %22, null
+  br i1 %NullCheck, label %ThrowNullRef, label %23
+
+; <label>:23                                      ; preds = %21
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 3
+  %25 = load i32, i32 addrspace(1)* %24, align 8
+  %26 = icmp sle i32 %25, 0
+  br i1 %26, label %96, label %27
+
+; <label>:27                                      ; preds = %23
+  %28 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %28, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %29
+
+; <label>:29                                      ; preds = %27
+  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %28, i32 0, i32 1
+  %31 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %30, align 8
+  store %"System.Char[]" addrspace(1)* %31, %"System.Char[]" addrspace(1)** %loc3
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %33
+
+; <label>:33                                      ; preds = %29
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  store i32 %35, i32* %loc4
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  %39 = load i32, i32 addrspace(1)* %38, align 8
+  store i32 %39, i32* %loc5
+  %40 = load i32, i32* %loc5
+  %41 = load i32, i32* %loc4
+  %42 = add i32 %40, %41
+  %43 = zext i32 %42 to i64
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %45
+
+; <label>:45                                      ; preds = %37
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = sext i32 %47 to i64
+  %49 = icmp sgt i64 %43, %48
+  br i1 %49, label %91, label %50
+
+; <label>:50                                      ; preds = %45
+  %51 = load i32, i32* %loc5
+  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %52, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %53
+
+; <label>:53                                      ; preds = %50
+  %54 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %52, i32 0, i32 1
+  %55 = load i32, i32 addrspace(1)* %54
+  %56 = zext i32 %55 to i64
+  %57 = trunc i64 %56 to i32
+  %58 = icmp ugt i32 %51, %57
+  br i1 %58, label %91, label %59
+
+; <label>:59                                      ; preds = %53
+  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  store %"System.Char[]" addrspace(1)* %60, %"System.Char[]" addrspace(1)** %loc8
+  %61 = icmp eq %"System.Char[]" addrspace(1)* %60, null
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %63, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %64
+
+; <label>:64                                      ; preds = %62
+  %65 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %63, i32 0, i32 1
+  %66 = load i32, i32 addrspace(1)* %65
+  %67 = zext i32 %66 to i64
+  %68 = trunc i64 %67 to i32
+  %69 = icmp ne i32 %68, 0
+  br i1 %69, label %71, label %70
+
+; <label>:70                                      ; preds = %59, %64
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:71                                      ; preds = %64
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %73
+
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %BoundsCheck = icmp uge i64 0, %76
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %77
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %78, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:79                                      ; preds = %70, %77
+  %80 = load i16*, i16** %loc2
+  %81 = load i32, i32* %loc4
+  %82 = sext i32 %81 to i64
+  %83 = mul i64 %82, 2
+  %84 = bitcast i16* %80 to i8*
+  %85 = getelementptr inbounds i8, i8* %84, i64 %83
+  %86 = load i16 addrspace(1)*, i16 addrspace(1)** %loc6
+  %87 = ptrtoint i16 addrspace(1)* %86 to i64
+  %88 = load i32, i32* %loc5
+  %89 = bitcast i8* %85 to i16*
+  %90 = inttoptr i64 %87 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %89, i16* %90, i32 %88)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %96
+
+; <label>:91                                      ; preds = %45, %53
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %94 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %93)
+  %95 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95, %System.String addrspace(1)* %92, %System.String addrspace(1)* %94)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95) #0
+  unreachable
+
+; <label>:96                                      ; preds = %23, %79
+  %97 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %97, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %98
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %97, i32 0, i32 2
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  store %System.Text.StringBuilder addrspace(1)* %100, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %102 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %102, label %21, label %103
+
+; <label>:103                                     ; preds = %98
+  store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc7
+  %104 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  ret %System.String addrspace(1)* %104
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method StringBuilder::get_Length using LLILCJit
+Successfully read StringBuilder.get_Length
+
+define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
+Successfully read RuntimeHelpers.get_OffsetToStringData
+
+define i32 @RuntimeHelpers.get_OffsetToStringData() {
+entry:
+  ret i32 12
+}
+
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
 Successfully read CultureData.CreateCultureData
 
@@ -3514,23 +4249,23 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
   store i8 %4, i8 addrspace(1)* %6
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
@@ -3549,11 +4284,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3566,50 +4301,50 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
   store i32 -1, i32 addrspace(1)* %2
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
   store i32 -1, i32 addrspace(1)* %8
   %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
   store i32 -1, i32 addrspace(1)* %14
   %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
   store i32 -1, i32 addrspace(1)* %17
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
@@ -3623,27 +4358,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3675,7 +4410,136 @@ Failed to read Dictionary`2.Insert[non-const derefAddress]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
 Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
-Failed to read HashHelpers.GetPrime[loadElem]
+Successfully read HashHelpers.GetPrime
+
+define i32 @HashHelpers.GetPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %6, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5, %System.String addrspace(1)* %4)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5) #0
+  unreachable
+
+; <label>:6                                       ; preds = %entry
+  store i32 0, i32* %loc0
+  br label %29
+
+; <label>:7                                       ; preds = %35
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 1296
+  %10 = addrspacecast i8 addrspace(1)* %9 to %"System.Int32[]" addrspace(1)**
+  %11 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %10
+  %12 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Int32[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = zext i32 %15 to i64
+  %17 = zext i32 %12 to i64
+  %BoundsCheck = icmp uge i64 %17, %16
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 3, i32 %12
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  store i32 %20, i32* %loc1
+  %21 = load i32, i32* %loc1
+  %22 = load i32, i32* %arg0
+  %23 = icmp slt i32 %21, %22
+  br i1 %23, label %26, label %24
+
+; <label>:24                                      ; preds = %18
+  %25 = load i32, i32* %loc1
+  ret i32 %25
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %loc0
+  %28 = add i32 %27, 1
+  store i32 %28, i32* %loc0
+  br label %29
+
+; <label>:29                                      ; preds = %6, %26
+  %30 = load i32, i32* %loc0
+  %31 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %32 = getelementptr inbounds i8, i8 addrspace(1)* %31, i64 1296
+  %33 = addrspacecast i8 addrspace(1)* %32 to %"System.Int32[]" addrspace(1)**
+  %34 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %33
+  %NullCheck = icmp eq %"System.Int32[]" addrspace(1)* %34, null
+  br i1 %NullCheck, label %ThrowNullRef, label %35
+
+; <label>:35                                      ; preds = %29
+  %36 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %34, i32 0, i32 1
+  %37 = load i32, i32 addrspace(1)* %36
+  %38 = zext i32 %37 to i64
+  %39 = trunc i64 %38 to i32
+  %40 = icmp slt i32 %30, %39
+  br i1 %40, label %7, label %41
+
+; <label>:41                                      ; preds = %35
+  %42 = load i32, i32* %arg0
+  %43 = or i32 %42, 1
+  store i32 %43, i32* %loc2
+  br label %59
+
+; <label>:44                                      ; preds = %59
+  %45 = load i32, i32* %loc2
+  %46 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %45)
+  %47 = zext i8 %46 to i32
+  %48 = icmp eq i32 %47, 0
+  br i1 %48, label %56, label %49
+
+; <label>:49                                      ; preds = %44
+  %50 = load i32, i32* %loc2
+  %51 = sub i32 %50, 1
+  %52 = srem i32 %51, 101
+  %53 = icmp eq i32 %52, 0
+  br i1 %53, label %56, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = load i32, i32* %loc2
+  ret i32 %55
+
+; <label>:56                                      ; preds = %44, %49
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %57, 2
+  store i32 %58, i32* %loc2
+  br label %59
+
+; <label>:59                                      ; preds = %41, %56
+  %60 = load i32, i32* %loc2
+  %61 = icmp slt i32 %60, 2147483647
+  br i1 %61, label %44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load i32, i32* %arg0
+  ret i32 %63
+
+ThrowNullRef:                                     ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
 Successfully read GenericEqualityComparer`1.GetHashCode
 
@@ -3694,14 +4558,14 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
   %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load i64, i64 addrspace(1)* %7
@@ -3720,7 +4584,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3750,8 +4614,8 @@ entry:
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
@@ -3796,8 +4660,8 @@ entry:
   %35 = bitcast i16* %34 to i8*
   %36 = getelementptr inbounds i8, i8* %35, i64 2
   %37 = bitcast i8* %36 to i16*
-  %NullCheck4 = icmp ne i16* %37, null
-  br i1 %NullCheck4, label %38, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %37, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %38
 
 ; <label>:38                                      ; preds = %27
   %39 = load i16, i16* %37, align 8
@@ -3824,8 +4688,8 @@ entry:
 
 ; <label>:54                                      ; preds = %22, %43
   %55 = load i16*, i16** %loc4
-  %NullCheck2 = icmp ne i16* %55, null
-  br i1 %NullCheck2, label %56, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i16* %55, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %56
 
 ; <label>:56                                      ; preds = %54
   %57 = load i16, i16* %55, align 8
@@ -3850,11 +4714,11 @@ ThrowNullRef:                                     ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %54
+ThrowNullRef2:                                    ; preds = %54
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %27
+ThrowNullRef4:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3871,8 +4735,8 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -3907,8 +4771,8 @@ entry:
 
 ; <label>:26                                      ; preds = %19
   %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
-  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %28
 
 ; <label>:28                                      ; preds = %26
   %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
@@ -3920,7 +4784,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3972,8 +4836,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
@@ -3984,26 +4848,26 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
-  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
@@ -4014,8 +4878,8 @@ entry:
 ; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
@@ -4024,8 +4888,8 @@ entry:
 
 ; <label>:25                                      ; preds = %1, %16, %23
   %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
-  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
@@ -4036,27 +4900,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %20
+ThrowNullRef10:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4069,8 +4933,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -4081,8 +4945,8 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
@@ -4091,8 +4955,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1, %8
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
@@ -4103,11 +4967,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4128,24 +4992,24 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   store i32 %3, i32* %loc0
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
   %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
   store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck4, label %9, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
@@ -4164,15 +5028,15 @@ entry:
 ; <label>:18                                      ; preds = %70
   %19 = load i16*, i16** %loc3
   %20 = bitcast i16* %19 to i64*
-  %NullCheck10 = icmp ne i64* %20, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %20, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = load i64, i64* %20, align 8
   %23 = load i16*, i16** %loc4
   %24 = bitcast i16* %23 to i64*
-  %NullCheck12 = icmp ne i64* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = load i64, i64* %24, align 8
@@ -4188,8 +5052,8 @@ entry:
   %31 = bitcast i16* %30 to i8*
   %32 = getelementptr inbounds i8, i8* %31, i64 8
   %33 = bitcast i8* %32 to i64*
-  %NullCheck14 = icmp ne i64* %33, null
-  br i1 %NullCheck14, label %34, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = load i64, i64* %33, align 8
@@ -4197,8 +5061,8 @@ entry:
   %37 = bitcast i16* %36 to i8*
   %38 = getelementptr inbounds i8, i8* %37, i64 8
   %39 = bitcast i8* %38 to i64*
-  %NullCheck16 = icmp ne i64* %39, null
-  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %40
 
 ; <label>:40                                      ; preds = %34
   %41 = load i64, i64* %39, align 8
@@ -4214,8 +5078,8 @@ entry:
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %NullCheck18 = icmp ne i64* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = load i64, i64* %48, align 8
@@ -4223,8 +5087,8 @@ entry:
   %52 = bitcast i16* %51 to i8*
   %53 = getelementptr inbounds i8, i8* %52, i64 16
   %54 = bitcast i8* %53 to i64*
-  %NullCheck20 = icmp ne i64* %54, null
-  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64* %54, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %55
 
 ; <label>:55                                      ; preds = %49
   %56 = load i64, i64* %54, align 8
@@ -4262,15 +5126,15 @@ entry:
 ; <label>:74                                      ; preds = %95
   %75 = load i16*, i16** %loc3
   %76 = bitcast i16* %75 to i32*
-  %NullCheck6 = icmp ne i32* %76, null
-  br i1 %NullCheck6, label %77, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32* %76, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %77
 
 ; <label>:77                                      ; preds = %74
   %78 = load i32, i32* %76, align 8
   %79 = load i16*, i16** %loc4
   %80 = bitcast i16* %79 to i32*
-  %NullCheck8 = icmp ne i32* %80, null
-  br i1 %NullCheck8, label %81, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i32* %80, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %81
 
 ; <label>:81                                      ; preds = %77
   %82 = load i32, i32* %80, align 8
@@ -4318,43 +5182,43 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %74
+ThrowNullRef6:                                    ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %77
+ThrowNullRef8:                                    ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %29
+ThrowNullRef14:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %34
+ThrowNullRef16:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4376,8 +5240,8 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load i64, i64 addrspace(1)* %4
@@ -4389,8 +5253,8 @@ entry:
   %12 = load i64, i64* %11
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %5
   %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
@@ -4399,8 +5263,8 @@ entry:
   %18 = load i8, i8* %arg2
   %19 = zext i8 %18 to i32
   %20 = trunc i32 %19 to i8
-  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %15
   %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
@@ -4411,11 +5275,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4442,8 +5306,8 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
@@ -4466,16 +5330,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
   %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = load i64, i64 addrspace(1)* %19
@@ -4500,8 +5364,8 @@ entry:
 ; <label>:35                                      ; preds = %30
   %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
@@ -4514,8 +5378,8 @@ entry:
 
 ; <label>:42                                      ; preds = %1, %38
   %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
-  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
@@ -4526,19 +5390,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %35
+ThrowNullRef2:                                    ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %42
+ThrowNullRef8:                                    ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4551,14 +5415,14 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
@@ -4570,7 +5434,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4583,8 +5447,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
@@ -4613,51 +5477,51 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
   %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
   %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
   %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
   %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
-  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
   store i64 %21, i64 addrspace(1)* %23
   %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %25 = load i64, i64* %loc0
-  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
@@ -4668,27 +5532,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %22
+ThrowNullRef12:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4701,8 +5565,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
@@ -4713,19 +5577,19 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
@@ -4734,8 +5598,8 @@ entry:
 
 ; <label>:15                                      ; preds = %1, %13
   %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
@@ -4746,19 +5610,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %15
+ThrowNullRef8:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4771,8 +5635,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -4831,8 +5695,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
@@ -4882,8 +5746,8 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
-  br i1 %NullCheck, label %17, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %ThrowNullRef, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
@@ -4894,15 +5758,15 @@ entry:
 
 ; <label>:22                                      ; preds = %17
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
-  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
   %26 = load i32, i32 addrspace(1)* %25
   %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
-  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %27, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
@@ -4925,8 +5789,8 @@ entry:
 ; <label>:40                                      ; preds = %17
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
-  br i1 %NullCheck6, label %43, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %41, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
@@ -4938,34 +5802,17 @@ ThrowNullRef:                                     ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %24
+ThrowNullRef4:                                    ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %40
+ThrowNullRef6:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
-}
-
-INFO:  jitting method Object::ReferenceEquals using LLILCJit
-Successfully read Object.ReferenceEquals
-
-define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
-entry:
-  %arg0 = alloca %System.Object addrspace(1)*
-  %arg1 = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
-  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
-  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = icmp eq %System.Object addrspace(1)* %0, %1
-  %3 = sext i1 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
 }
 
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
@@ -4978,21 +5825,21 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
   %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
-  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
@@ -5007,28 +5854,28 @@ entry:
 ; <label>:13                                      ; preds = %8, %12
   %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
   %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
   %21 = load i32, i32 addrspace(1)* %20, align 8
   %22 = add i32 %21, 1
-  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
   store i32 %22, i32 addrspace(1)* %24
   %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
@@ -5039,27 +5886,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5077,7 +5924,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::Setup using LLILCJit
-Failed to read AppDomain.Setup[loadElem]
+Failed to read AppDomain.Setup[unbox]
 INFO:  jitting method Thread::GetDomain using LLILCJit
 Successfully read Thread.GetDomain
 
@@ -5108,8 +5955,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
@@ -5122,14 +5969,14 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
   %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
@@ -5141,11 +5988,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5173,8 +6020,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -5189,7 +6036,328 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
 Failed to read KeyCollection.System.Collections.Generic.IEnumerable<TKey>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Successfully read Enumerator.MoveNext
+
+define i8 @Enumerator.MoveNext(%"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.RuntimeTypeHandle* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*
+  %"$TypeArg" = alloca %System.RuntimeTypeHandle*
+  store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
+  %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 8
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %76, label %12
+
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
+  br label %76
+
+; <label>:13                                      ; preds = %85
+  %14 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck19 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %15
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, i32 0, i32 0
+  %17 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %16, align 8
+  %NullCheck21 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, i32 0, i32 2
+  %20 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %19, align 8
+  %21 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck23 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %22
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, i32 0, i32 2
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %NullCheck25 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 3, i32 %24
+  %NullCheck27 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %32
+
+; <label>:32                                      ; preds = %30
+  %33 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, i32 0, i32 2
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = icmp slt i32 %34, 0
+  br i1 %35, label %68, label %36
+
+; <label>:36                                      ; preds = %32
+  %37 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %38 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck29 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %39
+
+; <label>:39                                      ; preds = %36
+  %40 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, i32 0, i32 0
+  %41 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %40, align 8
+  %NullCheck31 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, i32 0, i32 2
+  %44 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %43, align 8
+  %45 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck33 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, i32 0, i32 2
+  %48 = load i32, i32 addrspace(1)* %47, align 8
+  %NullCheck35 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %49
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = zext i32 %51 to i64
+  %53 = zext i32 %48 to i64
+  %BoundsCheck37 = icmp uge i64 %53, %52
+  br i1 %BoundsCheck37, label %ThrowIndexOutOfRange38, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 3, i32 %48
+  %NullCheck39 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %56
+
+; <label>:56                                      ; preds = %54
+  %57 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, i32 0, i32 0
+  %58 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck41 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %59
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %60, %System.__Canon addrspace(1)* %58)
+  %61 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck43 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  %64 = load i32, i32 addrspace(1)* %63, align 8
+  %65 = add i32 %64, 1
+  %NullCheck45 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  store i32 %65, i32 addrspace(1)* %67
+  ret i8 1
+
+; <label>:68                                      ; preds = %32
+  %69 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck47 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %73 = add i32 %72, 1
+  %NullCheck49 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %74
+
+; <label>:74                                      ; preds = %70
+  %75 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  store i32 %73, i32 addrspace(1)* %75
+  br label %76
+
+; <label>:76                                      ; preds = %8, %12, %74
+  %77 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %78
+
+; <label>:78                                      ; preds = %76
+  %79 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, i32 0, i32 2
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck7 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %82
+
+; <label>:82                                      ; preds = %78
+  %83 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, i32 0, i32 0
+  %84 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %83, align 8
+  %NullCheck9 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %85
+
+; <label>:85                                      ; preds = %82
+  %86 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, i32 0, i32 7
+  %87 = load i32, i32 addrspace(1)* %86, align 8
+  %88 = icmp ult i32 %80, %87
+  br i1 %88, label %13, label %89
+
+; <label>:89                                      ; preds = %85
+  %90 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %91 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck11 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %92
+
+; <label>:92                                      ; preds = %89
+  %93 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, i32 0, i32 0
+  %94 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck13 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %95
+
+; <label>:95                                      ; preds = %92
+  %96 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, i32 0, i32 7
+  %97 = load i32, i32 addrspace(1)* %96, align 8
+  %98 = add i32 %97, 1
+  %NullCheck15 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %99
+
+; <label>:99                                      ; preds = %95
+  %100 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, i32 0, i32 2
+  store i32 %98, i32 addrspace(1)* %100
+  %101 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck17 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %102
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %103, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %92
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef22:                                   ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef24:                                   ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef26:                                   ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef28:                                   ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef30:                                   ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef32:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef34:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef36:                                   ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange38:                           ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef40:                                   ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef42:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef44:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef46:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef48:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef50:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -5200,8 +6368,8 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -5232,9 +6400,9 @@ Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
 Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
-Failed to read String.MakeSeparatorList[loadElemA]
+Failed to read String.MakeSeparatorList[storeElem]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
-Failed to read String.InternalSplitKeepEmptyEntries[loadElem]
+Failed to read String.InternalSplitKeepEmptyEntries[storeElem]
 INFO:  jitting method Path::IsRelative using LLILCJit
 Successfully read Path.IsRelative
 
@@ -5243,8 +6411,8 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -5254,8 +6422,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
@@ -5271,8 +6439,8 @@ entry:
 
 ; <label>:17                                      ; preds = %7
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
@@ -5288,8 +6456,8 @@ entry:
 
 ; <label>:29                                      ; preds = %19
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %31
 
 ; <label>:31                                      ; preds = %29
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
@@ -5300,8 +6468,8 @@ entry:
 
 ; <label>:36                                      ; preds = %31
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
-  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %37, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
@@ -5312,8 +6480,8 @@ entry:
 
 ; <label>:43                                      ; preds = %31, %38
   %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
-  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %45
 
 ; <label>:45                                      ; preds = %43
   %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
@@ -5324,8 +6492,8 @@ entry:
 
 ; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %50
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
@@ -5336,8 +6504,8 @@ entry:
 
 ; <label>:57                                      ; preds = %1, %7, %19, %45, %52
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
-  br i1 %NullCheck14, label %59, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %59
 
 ; <label>:59                                      ; preds = %57
   %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
@@ -5347,8 +6515,8 @@ entry:
 
 ; <label>:63                                      ; preds = %59
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
@@ -5359,8 +6527,8 @@ entry:
 
 ; <label>:70                                      ; preds = %65
   %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
-  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.String addrspace(1)* %71, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %72
 
 ; <label>:72                                      ; preds = %70
   %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
@@ -5379,39 +6547,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %17
+ThrowNullRef4:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %29
+ThrowNullRef6:                                    ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %36
+ThrowNullRef8:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %43
+ThrowNullRef10:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %50
+ThrowNullRef12:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %57
+ThrowNullRef14:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %63
+ThrowNullRef16:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %70
+ThrowNullRef18:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5419,7 +6587,293 @@ ThrowNullRef17:                                   ; preds = %70
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
-Failed to read String.TrimHelper[loadElem]
+Successfully read String.TrimHelper
+
+define %System.String addrspace(1)* @String.TrimHelper(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i16
+  %loc4 = alloca i32
+  %loc5 = alloca i16
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = sub i32 %3, 1
+  store i32 %4, i32* %loc0
+  store i32 0, i32* %loc1
+  %5 = load i32, i32* %arg2
+  %6 = icmp eq i32 %5, 1
+  br i1 %6, label %62, label %7
+
+; <label>:7                                       ; preds = %1
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:8                                       ; preds = %58
+  store i32 0, i32* %loc2
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load i32, i32* %loc1
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2, i32 %10
+  %13 = load i16, i16 addrspace(1)* %12
+  %14 = zext i16 %13 to i32
+  %15 = trunc i32 %14 to i16
+  store i16 %15, i16* %loc3
+  store i32 0, i32* %loc2
+  br label %34
+
+; <label>:16                                      ; preds = %37
+  %17 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %18 = load i32, i32* %loc2
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %17, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %19
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = zext i32 %18 to i64
+  %BoundsCheck = icmp uge i64 %23, %22
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %24
+
+; <label>:24                                      ; preds = %19
+  %25 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 3, i32 %18
+  %26 = load i16, i16 addrspace(1)* %25, align 8
+  %27 = zext i16 %26 to i32
+  %28 = load i16, i16* %loc3
+  %29 = zext i16 %28 to i32
+  %30 = icmp eq i32 %27, %29
+  br i1 %30, label %43, label %31
+
+; <label>:31                                      ; preds = %24
+  %32 = load i32, i32* %loc2
+  %33 = add i32 %32, 1
+  store i32 %33, i32* %loc2
+  br label %34
+
+; <label>:34                                      ; preds = %11, %31
+  %35 = load i32, i32* %loc2
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = icmp slt i32 %35, %41
+  br i1 %42, label %16, label %43
+
+; <label>:43                                      ; preds = %24, %37
+  %44 = load i32, i32* %loc2
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %45, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp eq i32 %44, %50
+  br i1 %51, label %62, label %52
+
+; <label>:52                                      ; preds = %46
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %7, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %57, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %58
+
+; <label>:58                                      ; preds = %55
+  %59 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %60 = load i32, i32 addrspace(1)* %59
+  %61 = icmp slt i32 %56, %60
+  br i1 %61, label %8, label %62
+
+; <label>:62                                      ; preds = %1, %46, %58
+  %63 = load i32, i32* %arg2
+  %64 = icmp eq i32 %63, 0
+  br i1 %64, label %122, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %66, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %67
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %66, i32 0, i32 1
+  %69 = load i32, i32 addrspace(1)* %68
+  %70 = sub i32 %69, 1
+  store i32 %70, i32* %loc0
+  br label %118
+
+; <label>:71                                      ; preds = %118
+  store i32 0, i32* %loc4
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %73 = load i32, i32* %loc0
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %74
+
+; <label>:74                                      ; preds = %71
+  %75 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 2, i32 %73
+  %76 = load i16, i16 addrspace(1)* %75
+  %77 = zext i16 %76 to i32
+  %78 = trunc i32 %77 to i16
+  store i16 %78, i16* %loc5
+  store i32 0, i32* %loc4
+  br label %97
+
+; <label>:79                                      ; preds = %100
+  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %81 = load i32, i32* %loc4
+  %NullCheck19 = icmp eq %"System.Char[]" addrspace(1)* %80, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
+
+; <label>:82                                      ; preds = %79
+  %83 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 1
+  %84 = load i32, i32 addrspace(1)* %83
+  %85 = zext i32 %84 to i64
+  %86 = zext i32 %81 to i64
+  %BoundsCheck21 = icmp uge i64 %86, %85
+  br i1 %BoundsCheck21, label %ThrowIndexOutOfRange22, label %87
+
+; <label>:87                                      ; preds = %82
+  %88 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 3, i32 %81
+  %89 = load i16, i16 addrspace(1)* %88, align 8
+  %90 = zext i16 %89 to i32
+  %91 = load i16, i16* %loc5
+  %92 = zext i16 %91 to i32
+  %93 = icmp eq i32 %90, %92
+  br i1 %93, label %106, label %94
+
+; <label>:94                                      ; preds = %87
+  %95 = load i32, i32* %loc4
+  %96 = add i32 %95, 1
+  store i32 %96, i32* %loc4
+  br label %97
+
+; <label>:97                                      ; preds = %74, %94
+  %98 = load i32, i32* %loc4
+  %99 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck15 = icmp eq %"System.Char[]" addrspace(1)* %99, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %100
+
+; <label>:100                                     ; preds = %97
+  %101 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %99, i32 0, i32 1
+  %102 = load i32, i32 addrspace(1)* %101
+  %103 = zext i32 %102 to i64
+  %104 = trunc i64 %103 to i32
+  %105 = icmp slt i32 %98, %104
+  br i1 %105, label %79, label %106
+
+; <label>:106                                     ; preds = %87, %100
+  %107 = load i32, i32* %loc4
+  %108 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck17 = icmp eq %"System.Char[]" addrspace(1)* %108, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %109
+
+; <label>:109                                     ; preds = %106
+  %110 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %108, i32 0, i32 1
+  %111 = load i32, i32 addrspace(1)* %110
+  %112 = zext i32 %111 to i64
+  %113 = trunc i64 %112 to i32
+  %114 = icmp eq i32 %107, %113
+  br i1 %114, label %122, label %115
+
+; <label>:115                                     ; preds = %109
+  %116 = load i32, i32* %loc0
+  %117 = sub i32 %116, 1
+  store i32 %117, i32* %loc0
+  br label %118
+
+; <label>:118                                     ; preds = %67, %115
+  %119 = load i32, i32* %loc0
+  %120 = load i32, i32* %loc1
+  %121 = icmp sge i32 %119, %120
+  br i1 %121, label %71, label %122
+
+; <label>:122                                     ; preds = %62, %109, %118
+  %123 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %124 = load i32, i32* %loc1
+  %125 = load i32, i32* %loc0
+  %126 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %123, i32 %124, i32 %125)
+  ret %System.String addrspace(1)* %126
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %97
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange22:                           ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
 Successfully read String.CreateTrimmedString
 
@@ -5439,8 +6893,8 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
@@ -5535,8 +6989,8 @@ entry:
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i64 2872
   %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
   %8 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %7
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %3
   %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
@@ -5553,8 +7007,8 @@ entry:
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 2864
   %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
   %21 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %20
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
-  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %22
 
 ; <label>:22                                      ; preds = %16
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
@@ -5569,7 +7023,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %16
+ThrowNullRef2:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5586,8 +7040,8 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5613,8 +7067,8 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
@@ -5632,8 +7086,8 @@ entry:
 
 ; <label>:12                                      ; preds = %4
   %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
@@ -5644,8 +7098,8 @@ entry:
 
 ; <label>:19                                      ; preds = %14
   %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %19
   %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
@@ -5660,21 +7114,21 @@ entry:
   %31 = zext i16 %30 to i32
   %32 = bitcast i8* %29 to i16*
   %33 = trunc i32 %31 to i16
-  %NullCheck6 = icmp ne i16* %32, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i16* %32, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %21
   store i16 %33, i16* %32, align 8
   %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %36
 
 ; <label>:36                                      ; preds = %34
   %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
   %38 = load i32, i32 addrspace(1)* %37, align 8
   %39 = add i32 %38, 1
-  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %40
 
 ; <label>:40                                      ; preds = %36
   %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
@@ -5683,16 +7137,16 @@ entry:
 
 ; <label>:42                                      ; preds = %14
   %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
-  br i1 %NullCheck12, label %44, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
   %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
   %47 = load i16, i16* %arg1
   %48 = zext i16 %47 to i32
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = trunc i32 %48 to i16
@@ -5703,31 +7157,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %19
+ThrowNullRef4:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %21
+ThrowNullRef6:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %36
+ThrowNullRef10:                                   ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %42
+ThrowNullRef12:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %44
+ThrowNullRef14:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5740,8 +7194,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -5752,8 +7206,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
@@ -5762,14 +7216,14 @@ entry:
 
 ; <label>:11                                      ; preds = %1
   %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
@@ -5779,15 +7233,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5808,8 +7262,8 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5822,8 +7276,8 @@ entry:
 
 ; <label>:8                                       ; preds = %3
   %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
@@ -5842,15 +7296,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
-  br i1 %NullCheck4, label %22, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
   %24 = load i16*, i16* addrspace(1)* %23, align 8
   %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %25, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
@@ -5859,8 +7313,8 @@ entry:
   store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
@@ -5874,8 +7328,8 @@ entry:
 
 ; <label>:37                                      ; preds = %65
   %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %37
   %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
@@ -5886,16 +7340,16 @@ entry:
   %45 = bitcast i16* %41 to i8*
   %46 = getelementptr inbounds i8, i8* %45, i64 %44
   %47 = bitcast i8* %46 to i16*
-  %NullCheck14 = icmp ne i16* %47, null
-  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %47, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %48
 
 ; <label>:48                                      ; preds = %39
   %49 = load i16, i16* %47, align 8
   %50 = zext i16 %49 to i32
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %52 = load i32, i32* %loc1
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %53
 
 ; <label>:53                                      ; preds = %48
   %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
@@ -5916,8 +7370,8 @@ entry:
 ; <label>:62                                      ; preds = %36, %59
   %63 = load i32, i32* %loc1
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck10, label %65, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %65
 
 ; <label>:65                                      ; preds = %62
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
@@ -5936,15 +7390,15 @@ entry:
 
 ; <label>:74                                      ; preds = %70
   %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
-  br i1 %NullCheck18, label %76, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %76
 
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
   %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
-  br i1 %NullCheck20, label %80, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
   %81 = load i64, i64 addrspace(1)* %79
@@ -5958,8 +7412,8 @@ entry:
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
   %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
-  br i1 %NullCheck22, label %92, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.String addrspace(1)* %90, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %92
 
 ; <label>:92                                      ; preds = %80
   %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
@@ -5969,15 +7423,15 @@ entry:
 
 ; <label>:96                                      ; preds = %70
   %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
-  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %98
 
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
   %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
-  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
   %103 = load i64, i64 addrspace(1)* %101
@@ -5991,8 +7445,8 @@ entry:
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
   %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
-  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.String addrspace(1)* %112, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %114
 
 ; <label>:114                                     ; preds = %102
   %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
@@ -6004,59 +7458,59 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %20
+ThrowNullRef4:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %22
+ThrowNullRef6:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %26
+ThrowNullRef8:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %62
+ThrowNullRef10:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %48
+ThrowNullRef16:                                   ; preds = %48
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %74
+ThrowNullRef18:                                   ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %76
+ThrowNullRef20:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %80
+ThrowNullRef22:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %96
+ThrowNullRef24:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %98
+ThrowNullRef26:                                   ; preds = %98
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %102
+ThrowNullRef28:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6069,15 +7523,15 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
   %3 = load i16*, i16* addrspace(1)* %2, align 8
   %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
@@ -6087,8 +7541,8 @@ entry:
   %10 = bitcast i16* %3 to i8*
   %11 = getelementptr inbounds i8, i8* %10, i64 %9
   %12 = bitcast i8* %11 to i16*
-  %NullCheck4 = icmp ne i16* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %5
   store i16 0, i16* %12, align 8
@@ -6098,11 +7552,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6119,8 +7573,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -6131,8 +7585,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
@@ -6144,15 +7598,15 @@ entry:
 
 ; <label>:14                                      ; preds = %1
   %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
   %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
   %21 = load i64, i64 addrspace(1)* %19
@@ -6171,15 +7625,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %14
+ThrowNullRef4:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %16
+ThrowNullRef6:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6302,14 +7756,6 @@ entry:
   ret %System.String addrspace(1)* %57
 }
 
-INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
-Successfully read RuntimeHelpers.get_OffsetToStringData
-
-define i32 @RuntimeHelpers.get_OffsetToStringData() {
-entry:
-  ret i32 12
-}
-
 INFO:  jitting method String::Equals using LLILCJit
 Successfully read String.Equals
 
@@ -6381,8 +7827,8 @@ entry:
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
-  br i1 %NullCheck24, label %29, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
   %30 = load i64, i64 addrspace(1)* %28
@@ -6397,8 +7843,8 @@ entry:
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
-  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
   %43 = load i64, i64 addrspace(1)* %41
@@ -6418,8 +7864,8 @@ entry:
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
   %59 = load i64, i64 addrspace(1)* %57
@@ -6434,8 +7880,8 @@ entry:
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck22, label %71, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
   %72 = load i64, i64 addrspace(1)* %70
@@ -6455,8 +7901,8 @@ entry:
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
-  br i1 %NullCheck16, label %87, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = load i64, i64 addrspace(1)* %86
@@ -6471,8 +7917,8 @@ entry:
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck18, label %100, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
   %101 = load i64, i64 addrspace(1)* %99
@@ -6492,8 +7938,8 @@ entry:
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
-  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
   %117 = load i64, i64 addrspace(1)* %115
@@ -6508,8 +7954,8 @@ entry:
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
-  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
   %130 = load i64, i64 addrspace(1)* %128
@@ -6528,15 +7974,15 @@ entry:
 
 ; <label>:142                                     ; preds = %22
   %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
-  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %143, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %144
 
 ; <label>:144                                     ; preds = %142
   %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
   %146 = load i32, i32 addrspace(1)* %145
   %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
-  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %147, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %148
 
 ; <label>:148                                     ; preds = %144
   %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
@@ -6557,15 +8003,15 @@ entry:
 
 ; <label>:159                                     ; preds = %22
   %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
-  br i1 %NullCheck, label %161, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %ThrowNullRef, label %161
 
 ; <label>:161                                     ; preds = %159
   %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
   %163 = load i32, i32 addrspace(1)* %162
   %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
-  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %164, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %165
 
 ; <label>:165                                     ; preds = %161
   %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
@@ -6578,8 +8024,8 @@ entry:
 
 ; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
-  br i1 %NullCheck4, label %172, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %171, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %172
 
 ; <label>:172                                     ; preds = %170
   %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
@@ -6589,8 +8035,8 @@ entry:
 
 ; <label>:176                                     ; preds = %172
   %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
-  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %177, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %178
 
 ; <label>:178                                     ; preds = %176
   %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
@@ -6629,55 +8075,55 @@ ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %161
+ThrowNullRef2:                                    ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %170
+ThrowNullRef4:                                    ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %176
+ThrowNullRef6:                                    ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %142
+ThrowNullRef8:                                    ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %144
+ThrowNullRef10:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %113
+ThrowNullRef12:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %116
+ThrowNullRef14:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %84
+ThrowNullRef16:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %87
+ThrowNullRef18:                                   ; preds = %87
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %55
+ThrowNullRef20:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %58
+ThrowNullRef22:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %26
+ThrowNullRef24:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %29
+ThrowNullRef26:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,8 +8161,8 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck, label %14, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %ThrowNullRef, label %14
 
 ; <label>:14                                      ; preds = %8
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
@@ -6760,8 +8206,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
@@ -6770,14 +8216,14 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32, i32* %loc0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %10
   %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
   %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
@@ -6790,15 +8236,15 @@ entry:
 ; <label>:25                                      ; preds = %19
   %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
-  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
   %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
@@ -6807,8 +8253,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %37 = load i32, i32* %loc0
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %38, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %38
 
 ; <label>:38                                      ; preds = %32
   %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
@@ -6817,14 +8263,14 @@ entry:
 
 ; <label>:40                                      ; preds = %19
   %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %40
   %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
   %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
-  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
-  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
@@ -6832,8 +8278,8 @@ entry:
   %48 = zext i32 %47 to i64
   %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
-  br i1 %NullCheck16, label %51, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %51
 
 ; <label>:51                                      ; preds = %45
   %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
@@ -6847,15 +8293,15 @@ entry:
 ; <label>:57                                      ; preds = %51
   %58 = load i16*, i16** %arg1
   %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
-  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %60
 
 ; <label>:60                                      ; preds = %57
   %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
   %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
-  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %64
 
 ; <label>:64                                      ; preds = %60
   %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
@@ -6864,22 +8310,22 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
   %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
-  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %70
 
 ; <label>:70                                      ; preds = %64
   %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
   %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
-  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
-  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
   %75 = load i32, i32 addrspace(1)* %74
   %76 = zext i32 %75 to i64
   %77 = trunc i64 %76 to i32
-  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
-  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %78
 
 ; <label>:78                                      ; preds = %73
   %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
@@ -6901,8 +8347,8 @@ entry:
   %90 = bitcast i16* %86 to i8*
   %91 = getelementptr inbounds i8, i8* %90, i64 %89
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %93
 
 ; <label>:93                                      ; preds = %80
   %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
@@ -6912,8 +8358,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %99 = load i32, i32* %loc2
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %100
 
 ; <label>:100                                     ; preds = %93
   %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
@@ -6928,63 +8374,63 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %25
+ThrowNullRef6:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %32
+ThrowNullRef10:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %40
+ThrowNullRef12:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %45
+ThrowNullRef16:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %57
+ThrowNullRef18:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %60
+ThrowNullRef20:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %64
+ThrowNullRef22:                                   ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %70
+ThrowNullRef24:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %73
+ThrowNullRef26:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %80
+ThrowNullRef28:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %93
+ThrowNullRef30:                                   ; preds = %93
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7004,8 +8450,8 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
@@ -7033,43 +8479,43 @@ entry:
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %14
   %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
   %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   %28 = load i32, i32 addrspace(1)* %27, align 8
   %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
-  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %30
 
 ; <label>:30                                      ; preds = %26
   %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
   %32 = load i32, i32 addrspace(1)* %31, align 8
   %33 = add i32 %28, %32
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %34
 
 ; <label>:34                                      ; preds = %30
   %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   store i32 %33, i32 addrspace(1)* %35
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
   store i32 0, i32 addrspace(1)* %38
   %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %40
 
 ; <label>:40                                      ; preds = %37
   %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
@@ -7082,8 +8528,8 @@ entry:
 
 ; <label>:47                                      ; preds = %40
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
@@ -7098,8 +8544,8 @@ entry:
   %54 = load i32, i32* %loc0
   %55 = sext i32 %54 to i64
   %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
-  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %57
 
 ; <label>:57                                      ; preds = %52
   %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
@@ -7110,68 +8556,35 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %14
+ThrowNullRef2:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %23
+ThrowNullRef4:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %26
+ThrowNullRef6:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %30
+ThrowNullRef8:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %34
+ThrowNullRef10:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %47
+ThrowNullRef14:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %52
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-}
-
-INFO:  jitting method StringBuilder::get_Length using LLILCJit
-Successfully read StringBuilder.get_Length
-
-define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.StringBuilder addrspace(1)*
-  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
-  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
-
-; <label>:1                                       ; preds = %entry
-  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %3 = load i32, i32 addrspace(1)* %2, align 8
-  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
-
-; <label>:5                                       ; preds = %1
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = add i32 %3, %7
-  ret i32 %8
-
-ThrowNullRef:                                     ; preds = %entry
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef16:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7213,70 +8626,70 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
   %6 = load i32, i32 addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
   store i32 %6, i32 addrspace(1)* %8
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
   %13 = load i32, i32 addrspace(1)* %12, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
   store i32 %13, i32 addrspace(1)* %15
   %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
-  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %18
 
 ; <label>:18                                      ; preds = %14
   %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
   %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
   %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
   %34 = load i32, i32 addrspace(1)* %33, align 8
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
-  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
@@ -7287,39 +8700,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %28
+ThrowNullRef16:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %32
+ThrowNullRef18:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7455,13 +8868,13 @@ entry:
 ; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
@@ -7477,16 +8890,16 @@ entry:
 
 ; <label>:18                                      ; preds = %15
   %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
   store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
   %22 = load i32, i32* %loc0
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %24
 
 ; <label>:24                                      ; preds = %20
   %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
@@ -7498,13 +8911,13 @@ entry:
 ; <label>:28                                      ; preds = %15, %24
   %29 = load i32, i32* %arg1
   %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %31
   %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
@@ -7517,20 +8930,20 @@ entry:
   %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
-  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
   %46 = load i32, i32 addrspace(1)* %45, align 8
   %47 = sub i32 %40, %46
-  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
-  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i32 addrspace(1)* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %48
 
 ; <label>:48                                      ; preds = %44
   store i32 %47, i32 addrspace(1)* %39, align 8
@@ -7538,21 +8951,21 @@ entry:
 
 ; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
-  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %51
 
 ; <label>:51                                      ; preds = %49
   %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %53
 
 ; <label>:53                                      ; preds = %51
   %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
   %55 = load i32, i32 addrspace(1)* %54, align 8
   %56 = load i32, i32* %arg2
   %57 = sub i32 %55, %56
-  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %58
 
 ; <label>:58                                      ; preds = %53
   %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
@@ -7562,13 +8975,13 @@ entry:
 ; <label>:60                                      ; preds = %33, %58
   %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
   %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
-  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %63
 
 ; <label>:63                                      ; preds = %60
   %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
-  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
-  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
@@ -7578,15 +8991,15 @@ entry:
 
 ; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
-  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i32 addrspace(1)* %69, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %70
 
 ; <label>:70                                      ; preds = %68
   %71 = load i32, i32 addrspace(1)* %69, align 8
   store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
-  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
@@ -7596,8 +9009,8 @@ entry:
   store i32 %77, i32* %loc4
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
-  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %80
 
 ; <label>:80                                      ; preds = %73
   %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
@@ -7607,71 +9020,71 @@ entry:
 ; <label>:83                                      ; preds = %80
   store i32 0, i32* %loc3
   %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
-  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
-  br i1 %NullCheck26, label %88, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i32 addrspace(1)* %87, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %88
 
 ; <label>:88                                      ; preds = %85
   %89 = load i32, i32 addrspace(1)* %87, align 8
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
-  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %90
 
 ; <label>:90                                      ; preds = %88
   %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
   store i32 %89, i32 addrspace(1)* %91
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
-  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
-  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %96
 
 ; <label>:96                                      ; preds = %94
   %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
-  br i1 %NullCheck34, label %100, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %100
 
 ; <label>:100                                     ; preds = %96
   %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
-  br i1 %NullCheck36, label %102, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %102
 
 ; <label>:102                                     ; preds = %100
   %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
   %104 = load i32, i32 addrspace(1)* %103, align 8
   %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
-  br i1 %NullCheck38, label %106, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %106
 
 ; <label>:106                                     ; preds = %102
   %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
-  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
-  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %108
 
 ; <label>:108                                     ; preds = %106
   %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
   %110 = load i32, i32 addrspace(1)* %109, align 8
   %111 = add i32 %104, %110
-  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %112
 
 ; <label>:112                                     ; preds = %108
   %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
   store i32 %111, i32 addrspace(1)* %113
   %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
-  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i32 addrspace(1)* %114, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %115
 
 ; <label>:115                                     ; preds = %112
   %116 = load i32, i32 addrspace(1)* %114, align 8
@@ -7681,19 +9094,19 @@ entry:
 ; <label>:118                                     ; preds = %115
   %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
-  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %121
 
 ; <label>:121                                     ; preds = %118
   %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
-  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
-  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %123
 
 ; <label>:123                                     ; preds = %121
   %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
   %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
-  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
-  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %126
 
 ; <label>:126                                     ; preds = %123
   %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
@@ -7705,8 +9118,8 @@ entry:
 
 ; <label>:130                                     ; preds = %80, %115, %126
   %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %132
 
 ; <label>:132                                     ; preds = %130
   %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7715,8 +9128,8 @@ entry:
   %136 = load i32, i32* %loc3
   %137 = sub i32 %135, %136
   %138 = sub i32 %134, %137
-  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %139
 
 ; <label>:139                                     ; preds = %132
   %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7728,16 +9141,16 @@ entry:
 
 ; <label>:144                                     ; preds = %139
   %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
-  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %146
 
 ; <label>:146                                     ; preds = %144
   %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
   %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
   %149 = load i32, i32* %loc2
   %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
-  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %151
 
 ; <label>:151                                     ; preds = %146
   %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
@@ -7754,145 +9167,249 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %18
+ThrowNullRef4:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %31
+ThrowNullRef10:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %44
+ThrowNullRef16:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %68
+ThrowNullRef18:                                   ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %70
+ThrowNullRef20:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %73
+ThrowNullRef22:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %83
+ThrowNullRef24:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %85
+ThrowNullRef26:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %88
+ThrowNullRef28:                                   ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %90
+ThrowNullRef30:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %94
+ThrowNullRef32:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %96
+ThrowNullRef34:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %100
+ThrowNullRef36:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %102
+ThrowNullRef38:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %106
+ThrowNullRef40:                                   ; preds = %106
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %108
+ThrowNullRef42:                                   ; preds = %108
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %112
+ThrowNullRef44:                                   ; preds = %112
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %118
+ThrowNullRef46:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %121
+ThrowNullRef48:                                   ; preds = %121
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %123
+ThrowNullRef50:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %130
+ThrowNullRef52:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %132
+ThrowNullRef54:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %144
+ThrowNullRef56:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %146
+ThrowNullRef58:                                   ; preds = %146
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %60
+ThrowNullRef60:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %63
+ThrowNullRef62:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %49
+ThrowNullRef64:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %51
+ThrowNullRef66:                                   ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %53
+ThrowNullRef68:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(%"System.Char[]" addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %arg0 = alloca %"System.Char[]" addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store %"System.Char[]" addrspace(1)* %param0, %"System.Char[]" addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load i32, i32* %arg4
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %43, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %38, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg1
+  %13 = load i32, i32* %arg4
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %38, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %24 = load i32, i32* %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %35 = load i32, i32* %arg3
+  %36 = load i32, i32* %arg4
+  %37 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %37, %"System.Char[]" addrspace(1)* %34, i32 %35, i32 %36)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:38                                      ; preds = %5, %16
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Successfully read Buffer._Memmove
 
@@ -7914,7 +9431,7 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[loadElem]
+Failed to read AppDomain.SetDataHelper[storeElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -7923,8 +9440,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
@@ -7934,8 +9451,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
@@ -7947,15 +9464,15 @@ entry:
   %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
   %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
@@ -7966,15 +9483,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7992,7 +9509,79 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
-Failed to read Dictionary`2.TryGetValue[loadElemA]
+Successfully read Dictionary`2.TryGetValue
+
+define i8 @"Dictionary`2.TryGetValue"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)* addrspace(1)* %param2) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  %arg2 = alloca %System.__Canon addrspace(1)* addrspace(1)*
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  store %System.__Canon addrspace(1)* addrspace(1)* %param2, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  store i32 %2, i32* %loc0
+  %3 = load i32, i32* %loc0
+  %4 = icmp slt i32 %3, 0
+  br i1 %4, label %22, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 2
+  %10 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %9, align 8
+  %11 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = zext i32 %11 to i64
+  %BoundsCheck = icmp uge i64 %16, %15
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 3, i32 %11
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %20, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %6, %System.__Canon addrspace(1)* %21)
+  ret i8 1
+
+; <label>:22                                      ; preds = %entry
+  %23 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %23, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -8058,8 +9647,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
@@ -8091,8 +9680,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
@@ -8171,15 +9760,15 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck, label %19, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %ThrowNullRef, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
   %21 = load i32, i32 addrspace(1)* %20
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
@@ -8202,7 +9791,7 @@ ThrowNullRef:                                     ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %19
+ThrowNullRef2:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8248,8 +9837,8 @@ entry:
   %0 = alloca %System.AppDomainHandle
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %1 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %1, i32 0, i32 15
@@ -8269,8 +9858,8 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
@@ -8286,7 +9875,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -8299,8 +9888,8 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -8327,8 +9916,8 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
@@ -8352,8 +9941,8 @@ entry:
   %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
   store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
@@ -8363,8 +9952,8 @@ entry:
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
@@ -8374,8 +9963,8 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %9
   %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
@@ -8384,8 +9973,8 @@ entry:
 
 ; <label>:18                                      ; preds = %3, %16
   %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
@@ -8397,15 +9986,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %18
+ThrowNullRef6:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8418,8 +10007,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
@@ -8453,15 +10042,15 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
@@ -8473,7 +10062,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8481,7 +10070,7 @@ ThrowNullRef1:                                    ; preds = %1
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
 Failed to read Dictionary`2.System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
@@ -8506,8 +10095,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
@@ -8524,8 +10113,8 @@ entry:
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -8544,7 +10133,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8577,8 +10166,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = load i64, i64* %arg2
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = trunc i32 %3 to i8
@@ -8634,46 +10223,46 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
   %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
-  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
-  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
-  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
@@ -8684,27 +10273,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %20
+ThrowNullRef12:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8717,8 +10306,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -8756,22 +10345,22 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
   %9 = load i64, i64 addrspace(1)* %8, align 8
   %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
   %13 = load i64, i64 addrspace(1)* %12, align 8
   %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %11
   %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
@@ -8788,11 +10377,11 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8882,8 +10471,8 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
@@ -8900,8 +10489,8 @@ entry:
 ; <label>:8                                       ; preds = %1
   %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
   %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
@@ -8911,15 +10500,15 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
   %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
   %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
-  br i1 %NullCheck6, label %21, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
@@ -8946,15 +10535,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8992,15 +10581,15 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
   store i8 %3, i8 addrspace(1)* %5
   %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
@@ -9011,7 +10600,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9027,8 +10616,8 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -9041,8 +10630,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
@@ -9058,7 +10647,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9080,8 +10669,8 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
@@ -9096,8 +10685,8 @@ entry:
 ; <label>:12                                      ; preds = %6
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
@@ -9112,8 +10701,8 @@ entry:
 ; <label>:21                                      ; preds = %15
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
@@ -9128,8 +10717,8 @@ entry:
 ; <label>:30                                      ; preds = %24
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %31, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
@@ -9144,8 +10733,8 @@ entry:
 ; <label>:39                                      ; preds = %33
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
-  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %40, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %42
 
 ; <label>:42                                      ; preds = %39
   %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
@@ -9164,19 +10753,19 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %21
+ThrowNullRef4:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %30
+ThrowNullRef6:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %39
+ThrowNullRef8:                                    ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9243,8 +10832,8 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
@@ -9264,57 +10853,57 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
   store i8 0, i8 addrspace(1)* %2
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
   store i8 0, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
   store i8 0, i8 addrspace(1)* %17
   %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
   store i8 0, i8 addrspace(1)* %20
   %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
-  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
@@ -9325,31 +10914,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %19
+ThrowNullRef14:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9367,8 +10956,8 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
@@ -9380,8 +10969,8 @@ entry:
 
 ; <label>:9                                       ; preds = %4
   %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %9
   %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
@@ -9395,7 +10984,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef2:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9420,8 +11009,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
@@ -9512,8 +11101,8 @@ entry:
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
@@ -9524,8 +11113,8 @@ entry:
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = load i64, i64 addrspace(1)* %12
@@ -9537,8 +11126,8 @@ entry:
   %20 = load i64, i64* %19
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
-  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %13
   %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
@@ -9555,8 +11144,8 @@ entry:
 ; <label>:30                                      ; preds = %25
   %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %32 = load i32, i32* %arg2
-  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
-  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
@@ -9570,15 +11159,15 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %30
+ThrowNullRef2:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9622,87 +11211,87 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
   %10 = load i8, i8 addrspace(1)* %9, align 8
   %11 = zext i8 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %8
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
   store i8 %12, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
   %19 = load i8, i8 addrspace(1)* %18, align 8
   %20 = zext i8 %19 to i32
   %21 = trunc i32 %20 to i8
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
   store i8 %21, i8 addrspace(1)* %23
   %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
   %28 = load i8, i8 addrspace(1)* %27, align 8
   %29 = zext i8 %28 to i32
   %30 = trunc i32 %29 to i8
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
-  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %31
 
 ; <label>:31                                      ; preds = %26
   %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
   store i8 %30, i8 addrspace(1)* %32
   %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
-  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
-  br i1 %NullCheck14, label %40, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %40
 
 ; <label>:40                                      ; preds = %35
   %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
   store i8 %39, i8 addrspace(1)* %41
   %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
-  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %44
 
 ; <label>:44                                      ; preds = %40
   %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
   %46 = load i8, i8 addrspace(1)* %45, align 8
   %47 = zext i8 %46 to i32
   %48 = trunc i32 %47 to i8
-  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
   store i8 %48, i8 addrspace(1)* %50
   %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
-  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
@@ -9713,29 +11302,29 @@ entry:
 ; <label>:56                                      ; preds = %52
   %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
-  br i1 %NullCheck22, label %59, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
   %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
   %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
-  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
-  br i1 %NullCheck24, label %63, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
   %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
-  br i1 %NullCheck26, label %66, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
   %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
-  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
-  br i1 %NullCheck28, label %69, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %69
 
 ; <label>:69                                      ; preds = %66
   %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
@@ -9744,15 +11333,15 @@ entry:
 
 ; <label>:71                                      ; preds = %105
   %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
-  br i1 %NullCheck34, label %73, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %73
 
 ; <label>:73                                      ; preds = %71
   %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
   %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
   %76 = load i32, i32* %loc0
-  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
-  br i1 %NullCheck36, label %77, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
@@ -9766,8 +11355,8 @@ entry:
 
 ; <label>:83                                      ; preds = %77
   %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
-  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
@@ -9775,14 +11364,14 @@ entry:
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
   %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
-  br i1 %NullCheck40, label %91, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
 ; <label>:91                                      ; preds = %85
   %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
   %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
-  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck42, label %94, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %94
 
 ; <label>:94                                      ; preds = %91
   %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
@@ -9798,14 +11387,14 @@ entry:
 ; <label>:99                                      ; preds = %69, %96
   %100 = load i32, i32* %loc0
   %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
-  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %102
 
 ; <label>:102                                     ; preds = %99
   %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
   %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
-  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
-  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
@@ -9819,87 +11408,87 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %26
+ThrowNullRef10:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %31
+ThrowNullRef12:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %35
+ThrowNullRef14:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %40
+ThrowNullRef16:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %56
+ThrowNullRef22:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %59
+ThrowNullRef24:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %63
+ThrowNullRef26:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %66
+ThrowNullRef28:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %102
+ThrowNullRef32:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %71
+ThrowNullRef34:                                   ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %73
+ThrowNullRef36:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %83
+ThrowNullRef38:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %85
+ThrowNullRef40:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %91
+ThrowNullRef42:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9943,15 +11532,15 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
   %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
@@ -9961,28 +11550,28 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
   %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %12
   %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
   %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
   %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
-  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
@@ -9993,23 +11582,23 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %12
+ThrowNullRef6:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10031,15 +11620,15 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
   %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = load i64, i64 addrspace(1)* %7
@@ -10077,13 +11666,13 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[loadElem]
+Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -10111,8 +11700,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueGtDbl.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueGtDbl.error.txt
@@ -25,8 +25,8 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
@@ -40,8 +40,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
   %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
@@ -75,7 +75,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -90,8 +90,8 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %NullCheck = icmp ne i8 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = load i8, i8 addrspace(1)* %0, align 8
@@ -125,8 +125,8 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
@@ -159,8 +159,8 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -184,8 +184,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
   store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
@@ -195,8 +195,8 @@ entry:
 ; <label>:4                                       ; preds = %1
   %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
   %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
@@ -206,8 +206,8 @@ entry:
   %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
@@ -221,14 +221,14 @@ entry:
 
 ; <label>:17                                      ; preds = %14
   %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
   %21 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
@@ -238,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -249,8 +249,8 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
@@ -261,27 +261,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %30
+ThrowNullRef10:                                   ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -301,7 +301,89 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
-Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
+Successfully read AppDomainSetup.GetUnsecureApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.GetUnsecureApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %NullCheck = icmp eq %"System.String[]" addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %BoundsCheck = icmp uge i64 0, %5
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %6
+
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 3, i32 0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
+  ret %System.String addrspace(1)* %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_Value using LLILCJit
+Successfully read AppDomainSetup.get_Value
+
+define %"System.String[]" addrspace(1)* @AppDomainSetup.get_Value(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.String[]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 18)
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.String[]" addrspace(1)* addrspace(1)*, %"System.String[]" addrspace(1)*)*)(%"System.String[]" addrspace(1)* addrspace(1)* %9, %"System.String[]" addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %11, i32 0, i32 1
+  %14 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %13, align 8
+  ret %"System.String[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -319,8 +401,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -368,16 +450,16 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
   %5 = load i32, i32 addrspace(1)* %4
   %6 = sub i32 %5, 1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -389,7 +471,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -421,8 +503,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
@@ -456,8 +538,8 @@ entry:
 ; <label>:27                                      ; preds = %19
   %28 = load i32, i32* %arg1
   %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
-  br i1 %NullCheck2, label %30, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %29, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %30
 
 ; <label>:30                                      ; preds = %27
   %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
@@ -493,8 +575,8 @@ entry:
 ; <label>:49                                      ; preds = %46
   %50 = load i32, i32* %arg2
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck4, label %52, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
@@ -517,11 +599,11 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %27
+ThrowNullRef2:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %49
+ThrowNullRef4:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -544,16 +626,16 @@ entry:
   %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %0)
   store %System.String addrspace(1)* %1, %System.String addrspace(1)** %loc0
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 2
   %5 = bitcast [0 x i16] addrspace(1)* %4 to i16 addrspace(1)*
   store i16 addrspace(1)* %5, i16 addrspace(1)** %loc1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %3
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2
@@ -580,7 +662,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -691,15 +773,15 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %NullCheck132 = icmp ne i8* %21, null
-  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+  %NullCheck131 = icmp eq i8* %21, null
+  br i1 %NullCheck131, label %ThrowNullRef132, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = load i8, i8* %21, align 8
   %24 = zext i8 %23 to i32
   %25 = trunc i32 %24 to i8
-  %NullCheck134 = icmp ne i8* %20, null
-  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+  %NullCheck133 = icmp eq i8* %20, null
+  br i1 %NullCheck133, label %ThrowNullRef134, label %26
 
 ; <label>:26                                      ; preds = %22
   store i8 %25, i8* %20, align 8
@@ -709,16 +791,16 @@ entry:
   %28 = load i8*, i8** %arg0
   %29 = load i8*, i8** %arg1
   %30 = bitcast i8* %29 to i16*
-  %NullCheck128 = icmp ne i16* %30, null
-  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+  %NullCheck127 = icmp eq i16* %30, null
+  br i1 %NullCheck127, label %ThrowNullRef128, label %31
 
 ; <label>:31                                      ; preds = %27
   %32 = load i16, i16* %30, align 8
   %33 = sext i16 %32 to i32
   %34 = bitcast i8* %28 to i16*
   %35 = trunc i32 %33 to i16
-  %NullCheck130 = icmp ne i16* %34, null
-  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+  %NullCheck129 = icmp eq i16* %34, null
+  br i1 %NullCheck129, label %ThrowNullRef130, label %36
 
 ; <label>:36                                      ; preds = %31
   store i16 %35, i16* %34, align 8
@@ -728,16 +810,16 @@ entry:
   %38 = load i8*, i8** %arg0
   %39 = load i8*, i8** %arg1
   %40 = bitcast i8* %39 to i16*
-  %NullCheck120 = icmp ne i16* %40, null
-  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+  %NullCheck119 = icmp eq i16* %40, null
+  br i1 %NullCheck119, label %ThrowNullRef120, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i16, i16* %40, align 8
   %43 = sext i16 %42 to i32
   %44 = bitcast i8* %38 to i16*
   %45 = trunc i32 %43 to i16
-  %NullCheck122 = icmp ne i16* %44, null
-  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+  %NullCheck121 = icmp eq i16* %44, null
+  br i1 %NullCheck121, label %ThrowNullRef122, label %46
 
 ; <label>:46                                      ; preds = %41
   store i16 %45, i16* %44, align 8
@@ -745,15 +827,15 @@ entry:
   %48 = getelementptr inbounds i8, i8* %47, i64 2
   %49 = load i8*, i8** %arg1
   %50 = getelementptr inbounds i8, i8* %49, i64 2
-  %NullCheck124 = icmp ne i8* %50, null
-  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+  %NullCheck123 = icmp eq i8* %50, null
+  br i1 %NullCheck123, label %ThrowNullRef124, label %51
 
 ; <label>:51                                      ; preds = %46
   %52 = load i8, i8* %50, align 8
   %53 = zext i8 %52 to i32
   %54 = trunc i32 %53 to i8
-  %NullCheck126 = icmp ne i8* %48, null
-  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+  %NullCheck125 = icmp eq i8* %48, null
+  br i1 %NullCheck125, label %ThrowNullRef126, label %55
 
 ; <label>:55                                      ; preds = %51
   store i8 %54, i8* %48, align 8
@@ -763,14 +845,14 @@ entry:
   %57 = load i8*, i8** %arg0
   %58 = load i8*, i8** %arg1
   %59 = bitcast i8* %58 to i32*
-  %NullCheck116 = icmp ne i32* %59, null
-  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+  %NullCheck115 = icmp eq i32* %59, null
+  br i1 %NullCheck115, label %ThrowNullRef116, label %60
 
 ; <label>:60                                      ; preds = %56
   %61 = load i32, i32* %59, align 8
   %62 = bitcast i8* %57 to i32*
-  %NullCheck118 = icmp ne i32* %62, null
-  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+  %NullCheck117 = icmp eq i32* %62, null
+  br i1 %NullCheck117, label %ThrowNullRef118, label %63
 
 ; <label>:63                                      ; preds = %60
   store i32 %61, i32* %62, align 8
@@ -780,14 +862,14 @@ entry:
   %65 = load i8*, i8** %arg0
   %66 = load i8*, i8** %arg1
   %67 = bitcast i8* %66 to i32*
-  %NullCheck108 = icmp ne i32* %67, null
-  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+  %NullCheck107 = icmp eq i32* %67, null
+  br i1 %NullCheck107, label %ThrowNullRef108, label %68
 
 ; <label>:68                                      ; preds = %64
   %69 = load i32, i32* %67, align 8
   %70 = bitcast i8* %65 to i32*
-  %NullCheck110 = icmp ne i32* %70, null
-  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+  %NullCheck109 = icmp eq i32* %70, null
+  br i1 %NullCheck109, label %ThrowNullRef110, label %71
 
 ; <label>:71                                      ; preds = %68
   store i32 %69, i32* %70, align 8
@@ -795,15 +877,15 @@ entry:
   %73 = getelementptr inbounds i8, i8* %72, i64 4
   %74 = load i8*, i8** %arg1
   %75 = getelementptr inbounds i8, i8* %74, i64 4
-  %NullCheck112 = icmp ne i8* %75, null
-  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+  %NullCheck111 = icmp eq i8* %75, null
+  br i1 %NullCheck111, label %ThrowNullRef112, label %76
 
 ; <label>:76                                      ; preds = %71
   %77 = load i8, i8* %75, align 8
   %78 = zext i8 %77 to i32
   %79 = trunc i32 %78 to i8
-  %NullCheck114 = icmp ne i8* %73, null
-  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+  %NullCheck113 = icmp eq i8* %73, null
+  br i1 %NullCheck113, label %ThrowNullRef114, label %80
 
 ; <label>:80                                      ; preds = %76
   store i8 %79, i8* %73, align 8
@@ -813,14 +895,14 @@ entry:
   %82 = load i8*, i8** %arg0
   %83 = load i8*, i8** %arg1
   %84 = bitcast i8* %83 to i32*
-  %NullCheck100 = icmp ne i32* %84, null
-  br i1 %NullCheck100, label %85, label %ThrowNullRef99
+  %NullCheck99 = icmp eq i32* %84, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %85
 
 ; <label>:85                                      ; preds = %81
   %86 = load i32, i32* %84, align 8
   %87 = bitcast i8* %82 to i32*
-  %NullCheck102 = icmp ne i32* %87, null
-  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+  %NullCheck101 = icmp eq i32* %87, null
+  br i1 %NullCheck101, label %ThrowNullRef102, label %88
 
 ; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
@@ -829,16 +911,16 @@ entry:
   %91 = load i8*, i8** %arg1
   %92 = getelementptr inbounds i8, i8* %91, i64 4
   %93 = bitcast i8* %92 to i16*
-  %NullCheck104 = icmp ne i16* %93, null
-  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+  %NullCheck103 = icmp eq i16* %93, null
+  br i1 %NullCheck103, label %ThrowNullRef104, label %94
 
 ; <label>:94                                      ; preds = %88
   %95 = load i16, i16* %93, align 8
   %96 = sext i16 %95 to i32
   %97 = bitcast i8* %90 to i16*
   %98 = trunc i32 %96 to i16
-  %NullCheck106 = icmp ne i16* %97, null
-  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+  %NullCheck105 = icmp eq i16* %97, null
+  br i1 %NullCheck105, label %ThrowNullRef106, label %99
 
 ; <label>:99                                      ; preds = %94
   store i16 %98, i16* %97, align 8
@@ -848,14 +930,14 @@ entry:
   %101 = load i8*, i8** %arg0
   %102 = load i8*, i8** %arg1
   %103 = bitcast i8* %102 to i32*
-  %NullCheck88 = icmp ne i32* %103, null
-  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+  %NullCheck87 = icmp eq i32* %103, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %104
 
 ; <label>:104                                     ; preds = %100
   %105 = load i32, i32* %103, align 8
   %106 = bitcast i8* %101 to i32*
-  %NullCheck90 = icmp ne i32* %106, null
-  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+  %NullCheck89 = icmp eq i32* %106, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %107
 
 ; <label>:107                                     ; preds = %104
   store i32 %105, i32* %106, align 8
@@ -864,16 +946,16 @@ entry:
   %110 = load i8*, i8** %arg1
   %111 = getelementptr inbounds i8, i8* %110, i64 4
   %112 = bitcast i8* %111 to i16*
-  %NullCheck92 = icmp ne i16* %112, null
-  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+  %NullCheck91 = icmp eq i16* %112, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %113
 
 ; <label>:113                                     ; preds = %107
   %114 = load i16, i16* %112, align 8
   %115 = sext i16 %114 to i32
   %116 = bitcast i8* %109 to i16*
   %117 = trunc i32 %115 to i16
-  %NullCheck94 = icmp ne i16* %116, null
-  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+  %NullCheck93 = icmp eq i16* %116, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %118
 
 ; <label>:118                                     ; preds = %113
   store i16 %117, i16* %116, align 8
@@ -881,15 +963,15 @@ entry:
   %120 = getelementptr inbounds i8, i8* %119, i64 6
   %121 = load i8*, i8** %arg1
   %122 = getelementptr inbounds i8, i8* %121, i64 6
-  %NullCheck96 = icmp ne i8* %122, null
-  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+  %NullCheck95 = icmp eq i8* %122, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %123
 
 ; <label>:123                                     ; preds = %118
   %124 = load i8, i8* %122, align 8
   %125 = zext i8 %124 to i32
   %126 = trunc i32 %125 to i8
-  %NullCheck98 = icmp ne i8* %120, null
-  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+  %NullCheck97 = icmp eq i8* %120, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %127
 
 ; <label>:127                                     ; preds = %123
   store i8 %126, i8* %120, align 8
@@ -899,14 +981,14 @@ entry:
   %129 = load i8*, i8** %arg0
   %130 = load i8*, i8** %arg1
   %131 = bitcast i8* %130 to i64*
-  %NullCheck84 = icmp ne i64* %131, null
-  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+  %NullCheck83 = icmp eq i64* %131, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %132
 
 ; <label>:132                                     ; preds = %128
   %133 = load i64, i64* %131, align 8
   %134 = bitcast i8* %129 to i64*
-  %NullCheck86 = icmp ne i64* %134, null
-  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+  %NullCheck85 = icmp eq i64* %134, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %135
 
 ; <label>:135                                     ; preds = %132
   store i64 %133, i64* %134, align 8
@@ -916,14 +998,14 @@ entry:
   %137 = load i8*, i8** %arg0
   %138 = load i8*, i8** %arg1
   %139 = bitcast i8* %138 to i64*
-  %NullCheck76 = icmp ne i64* %139, null
-  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+  %NullCheck75 = icmp eq i64* %139, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %140
 
 ; <label>:140                                     ; preds = %136
   %141 = load i64, i64* %139, align 8
   %142 = bitcast i8* %137 to i64*
-  %NullCheck78 = icmp ne i64* %142, null
-  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+  %NullCheck77 = icmp eq i64* %142, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %143
 
 ; <label>:143                                     ; preds = %140
   store i64 %141, i64* %142, align 8
@@ -931,15 +1013,15 @@ entry:
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %NullCheck80 = icmp ne i8* %147, null
-  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+  %NullCheck79 = icmp eq i8* %147, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %148
 
 ; <label>:148                                     ; preds = %143
   %149 = load i8, i8* %147, align 8
   %150 = zext i8 %149 to i32
   %151 = trunc i32 %150 to i8
-  %NullCheck82 = icmp ne i8* %145, null
-  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+  %NullCheck81 = icmp eq i8* %145, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %152
 
 ; <label>:152                                     ; preds = %148
   store i8 %151, i8* %145, align 8
@@ -949,14 +1031,14 @@ entry:
   %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
   %156 = bitcast i8* %155 to i64*
-  %NullCheck68 = icmp ne i64* %156, null
-  br i1 %NullCheck68, label %157, label %ThrowNullRef67
+  %NullCheck67 = icmp eq i64* %156, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %157
 
 ; <label>:157                                     ; preds = %153
   %158 = load i64, i64* %156, align 8
   %159 = bitcast i8* %154 to i64*
-  %NullCheck70 = icmp ne i64* %159, null
-  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+  %NullCheck69 = icmp eq i64* %159, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %160
 
 ; <label>:160                                     ; preds = %157
   store i64 %158, i64* %159, align 8
@@ -965,16 +1047,16 @@ entry:
   %163 = load i8*, i8** %arg1
   %164 = getelementptr inbounds i8, i8* %163, i64 8
   %165 = bitcast i8* %164 to i16*
-  %NullCheck72 = icmp ne i16* %165, null
-  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+  %NullCheck71 = icmp eq i16* %165, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %166
 
 ; <label>:166                                     ; preds = %160
   %167 = load i16, i16* %165, align 8
   %168 = sext i16 %167 to i32
   %169 = bitcast i8* %162 to i16*
   %170 = trunc i32 %168 to i16
-  %NullCheck74 = icmp ne i16* %169, null
-  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+  %NullCheck73 = icmp eq i16* %169, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %171
 
 ; <label>:171                                     ; preds = %166
   store i16 %170, i16* %169, align 8
@@ -984,14 +1066,14 @@ entry:
   %173 = load i8*, i8** %arg0
   %174 = load i8*, i8** %arg1
   %175 = bitcast i8* %174 to i64*
-  %NullCheck56 = icmp ne i64* %175, null
-  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+  %NullCheck55 = icmp eq i64* %175, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %176
 
 ; <label>:176                                     ; preds = %172
   %177 = load i64, i64* %175, align 8
   %178 = bitcast i8* %173 to i64*
-  %NullCheck58 = icmp ne i64* %178, null
-  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+  %NullCheck57 = icmp eq i64* %178, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %179
 
 ; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
@@ -1000,16 +1082,16 @@ entry:
   %182 = load i8*, i8** %arg1
   %183 = getelementptr inbounds i8, i8* %182, i64 8
   %184 = bitcast i8* %183 to i16*
-  %NullCheck60 = icmp ne i16* %184, null
-  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+  %NullCheck59 = icmp eq i16* %184, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %185
 
 ; <label>:185                                     ; preds = %179
   %186 = load i16, i16* %184, align 8
   %187 = sext i16 %186 to i32
   %188 = bitcast i8* %181 to i16*
   %189 = trunc i32 %187 to i16
-  %NullCheck62 = icmp ne i16* %188, null
-  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+  %NullCheck61 = icmp eq i16* %188, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %190
 
 ; <label>:190                                     ; preds = %185
   store i16 %189, i16* %188, align 8
@@ -1017,15 +1099,15 @@ entry:
   %192 = getelementptr inbounds i8, i8* %191, i64 10
   %193 = load i8*, i8** %arg1
   %194 = getelementptr inbounds i8, i8* %193, i64 10
-  %NullCheck64 = icmp ne i8* %194, null
-  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+  %NullCheck63 = icmp eq i8* %194, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %195
 
 ; <label>:195                                     ; preds = %190
   %196 = load i8, i8* %194, align 8
   %197 = zext i8 %196 to i32
   %198 = trunc i32 %197 to i8
-  %NullCheck66 = icmp ne i8* %192, null
-  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+  %NullCheck65 = icmp eq i8* %192, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %199
 
 ; <label>:199                                     ; preds = %195
   store i8 %198, i8* %192, align 8
@@ -1035,14 +1117,14 @@ entry:
   %201 = load i8*, i8** %arg0
   %202 = load i8*, i8** %arg1
   %203 = bitcast i8* %202 to i64*
-  %NullCheck48 = icmp ne i64* %203, null
-  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+  %NullCheck47 = icmp eq i64* %203, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %204
 
 ; <label>:204                                     ; preds = %200
   %205 = load i64, i64* %203, align 8
   %206 = bitcast i8* %201 to i64*
-  %NullCheck50 = icmp ne i64* %206, null
-  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+  %NullCheck49 = icmp eq i64* %206, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %207
 
 ; <label>:207                                     ; preds = %204
   store i64 %205, i64* %206, align 8
@@ -1051,14 +1133,14 @@ entry:
   %210 = load i8*, i8** %arg1
   %211 = getelementptr inbounds i8, i8* %210, i64 8
   %212 = bitcast i8* %211 to i32*
-  %NullCheck52 = icmp ne i32* %212, null
-  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+  %NullCheck51 = icmp eq i32* %212, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %213
 
 ; <label>:213                                     ; preds = %207
   %214 = load i32, i32* %212, align 8
   %215 = bitcast i8* %209 to i32*
-  %NullCheck54 = icmp ne i32* %215, null
-  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+  %NullCheck53 = icmp eq i32* %215, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %216
 
 ; <label>:216                                     ; preds = %213
   store i32 %214, i32* %215, align 8
@@ -1068,14 +1150,14 @@ entry:
   %218 = load i8*, i8** %arg0
   %219 = load i8*, i8** %arg1
   %220 = bitcast i8* %219 to i64*
-  %NullCheck36 = icmp ne i64* %220, null
-  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64* %220, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %221
 
 ; <label>:221                                     ; preds = %217
   %222 = load i64, i64* %220, align 8
   %223 = bitcast i8* %218 to i64*
-  %NullCheck38 = icmp ne i64* %223, null
-  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+  %NullCheck37 = icmp eq i64* %223, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %224
 
 ; <label>:224                                     ; preds = %221
   store i64 %222, i64* %223, align 8
@@ -1084,14 +1166,14 @@ entry:
   %227 = load i8*, i8** %arg1
   %228 = getelementptr inbounds i8, i8* %227, i64 8
   %229 = bitcast i8* %228 to i32*
-  %NullCheck40 = icmp ne i32* %229, null
-  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i32* %229, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %230
 
 ; <label>:230                                     ; preds = %224
   %231 = load i32, i32* %229, align 8
   %232 = bitcast i8* %226 to i32*
-  %NullCheck42 = icmp ne i32* %232, null
-  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+  %NullCheck41 = icmp eq i32* %232, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %233
 
 ; <label>:233                                     ; preds = %230
   store i32 %231, i32* %232, align 8
@@ -1099,15 +1181,15 @@ entry:
   %235 = getelementptr inbounds i8, i8* %234, i64 12
   %236 = load i8*, i8** %arg1
   %237 = getelementptr inbounds i8, i8* %236, i64 12
-  %NullCheck44 = icmp ne i8* %237, null
-  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i8* %237, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %238
 
 ; <label>:238                                     ; preds = %233
   %239 = load i8, i8* %237, align 8
   %240 = zext i8 %239 to i32
   %241 = trunc i32 %240 to i8
-  %NullCheck46 = icmp ne i8* %235, null
-  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+  %NullCheck45 = icmp eq i8* %235, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %242
 
 ; <label>:242                                     ; preds = %238
   store i8 %241, i8* %235, align 8
@@ -1117,14 +1199,14 @@ entry:
   %244 = load i8*, i8** %arg0
   %245 = load i8*, i8** %arg1
   %246 = bitcast i8* %245 to i64*
-  %NullCheck24 = icmp ne i64* %246, null
-  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64* %246, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %247
 
 ; <label>:247                                     ; preds = %243
   %248 = load i64, i64* %246, align 8
   %249 = bitcast i8* %244 to i64*
-  %NullCheck26 = icmp ne i64* %249, null
-  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64* %249, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %250
 
 ; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
@@ -1133,14 +1215,14 @@ entry:
   %253 = load i8*, i8** %arg1
   %254 = getelementptr inbounds i8, i8* %253, i64 8
   %255 = bitcast i8* %254 to i32*
-  %NullCheck28 = icmp ne i32* %255, null
-  br i1 %NullCheck28, label %256, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i32* %255, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %256
 
 ; <label>:256                                     ; preds = %250
   %257 = load i32, i32* %255, align 8
   %258 = bitcast i8* %252 to i32*
-  %NullCheck30 = icmp ne i32* %258, null
-  br i1 %NullCheck30, label %259, label %ThrowNullRef29
+  %NullCheck29 = icmp eq i32* %258, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %259
 
 ; <label>:259                                     ; preds = %256
   store i32 %257, i32* %258, align 8
@@ -1149,16 +1231,16 @@ entry:
   %262 = load i8*, i8** %arg1
   %263 = getelementptr inbounds i8, i8* %262, i64 12
   %264 = bitcast i8* %263 to i16*
-  %NullCheck32 = icmp ne i16* %264, null
-  br i1 %NullCheck32, label %265, label %ThrowNullRef31
+  %NullCheck31 = icmp eq i16* %264, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %265
 
 ; <label>:265                                     ; preds = %259
   %266 = load i16, i16* %264, align 8
   %267 = sext i16 %266 to i32
   %268 = bitcast i8* %261 to i16*
   %269 = trunc i32 %267 to i16
-  %NullCheck34 = icmp ne i16* %268, null
-  br i1 %NullCheck34, label %270, label %ThrowNullRef33
+  %NullCheck33 = icmp eq i16* %268, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %270
 
 ; <label>:270                                     ; preds = %265
   store i16 %269, i16* %268, align 8
@@ -1168,14 +1250,14 @@ entry:
   %272 = load i8*, i8** %arg0
   %273 = load i8*, i8** %arg1
   %274 = bitcast i8* %273 to i64*
-  %NullCheck8 = icmp ne i64* %274, null
-  br i1 %NullCheck8, label %275, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64* %274, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %275
 
 ; <label>:275                                     ; preds = %271
   %276 = load i64, i64* %274, align 8
   %277 = bitcast i8* %272 to i64*
-  %NullCheck10 = icmp ne i64* %277, null
-  br i1 %NullCheck10, label %278, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %277, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %278
 
 ; <label>:278                                     ; preds = %275
   store i64 %276, i64* %277, align 8
@@ -1184,14 +1266,14 @@ entry:
   %281 = load i8*, i8** %arg1
   %282 = getelementptr inbounds i8, i8* %281, i64 8
   %283 = bitcast i8* %282 to i32*
-  %NullCheck12 = icmp ne i32* %283, null
-  br i1 %NullCheck12, label %284, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i32* %283, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %284
 
 ; <label>:284                                     ; preds = %278
   %285 = load i32, i32* %283, align 8
   %286 = bitcast i8* %280 to i32*
-  %NullCheck14 = icmp ne i32* %286, null
-  br i1 %NullCheck14, label %287, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i32* %286, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %287
 
 ; <label>:287                                     ; preds = %284
   store i32 %285, i32* %286, align 8
@@ -1200,16 +1282,16 @@ entry:
   %290 = load i8*, i8** %arg1
   %291 = getelementptr inbounds i8, i8* %290, i64 12
   %292 = bitcast i8* %291 to i16*
-  %NullCheck16 = icmp ne i16* %292, null
-  br i1 %NullCheck16, label %293, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i16* %292, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %293
 
 ; <label>:293                                     ; preds = %287
   %294 = load i16, i16* %292, align 8
   %295 = sext i16 %294 to i32
   %296 = bitcast i8* %289 to i16*
   %297 = trunc i32 %295 to i16
-  %NullCheck18 = icmp ne i16* %296, null
-  br i1 %NullCheck18, label %298, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i16* %296, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %298
 
 ; <label>:298                                     ; preds = %293
   store i16 %297, i16* %296, align 8
@@ -1217,15 +1299,15 @@ entry:
   %300 = getelementptr inbounds i8, i8* %299, i64 14
   %301 = load i8*, i8** %arg1
   %302 = getelementptr inbounds i8, i8* %301, i64 14
-  %NullCheck20 = icmp ne i8* %302, null
-  br i1 %NullCheck20, label %303, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i8* %302, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %303
 
 ; <label>:303                                     ; preds = %298
   %304 = load i8, i8* %302, align 8
   %305 = zext i8 %304 to i32
   %306 = trunc i32 %305 to i8
-  %NullCheck22 = icmp ne i8* %300, null
-  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i8* %300, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %307
 
 ; <label>:307                                     ; preds = %303
   store i8 %306, i8* %300, align 8
@@ -1235,14 +1317,14 @@ entry:
   %309 = load i8*, i8** %arg0
   %310 = load i8*, i8** %arg1
   %311 = bitcast i8* %310 to i64*
-  %NullCheck = icmp ne i64* %311, null
-  br i1 %NullCheck, label %312, label %ThrowNullRef
+  %NullCheck = icmp eq i64* %311, null
+  br i1 %NullCheck, label %ThrowNullRef, label %312
 
 ; <label>:312                                     ; preds = %308
   %313 = load i64, i64* %311, align 8
   %314 = bitcast i8* %309 to i64*
-  %NullCheck2 = icmp ne i64* %314, null
-  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64* %314, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %315
 
 ; <label>:315                                     ; preds = %312
   store i64 %313, i64* %314, align 8
@@ -1251,14 +1333,14 @@ entry:
   %318 = load i8*, i8** %arg1
   %319 = getelementptr inbounds i8, i8* %318, i64 8
   %320 = bitcast i8* %319 to i64*
-  %NullCheck4 = icmp ne i64* %320, null
-  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64* %320, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %321
 
 ; <label>:321                                     ; preds = %315
   %322 = load i64, i64* %320, align 8
   %323 = bitcast i8* %317 to i64*
-  %NullCheck6 = icmp ne i64* %323, null
-  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64* %323, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %324
 
 ; <label>:324                                     ; preds = %321
   store i64 %322, i64* %323, align 8
@@ -1286,15 +1368,15 @@ entry:
 ; <label>:338                                     ; preds = %333
   %339 = load i8*, i8** %arg0
   %340 = load i8*, i8** %arg1
-  %NullCheck136 = icmp ne i8* %340, null
-  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+  %NullCheck135 = icmp eq i8* %340, null
+  br i1 %NullCheck135, label %ThrowNullRef136, label %341
 
 ; <label>:341                                     ; preds = %338
   %342 = load i8, i8* %340, align 8
   %343 = zext i8 %342 to i32
   %344 = trunc i32 %343 to i8
-  %NullCheck138 = icmp ne i8* %339, null
-  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+  %NullCheck137 = icmp eq i8* %339, null
+  br i1 %NullCheck137, label %ThrowNullRef138, label %345
 
 ; <label>:345                                     ; preds = %341
   store i8 %344, i8* %339, align 8
@@ -1317,16 +1399,16 @@ entry:
   %357 = load i8*, i8** %arg0
   %358 = load i8*, i8** %arg1
   %359 = bitcast i8* %358 to i16*
-  %NullCheck140 = icmp ne i16* %359, null
-  br i1 %NullCheck140, label %360, label %ThrowNullRef139
+  %NullCheck139 = icmp eq i16* %359, null
+  br i1 %NullCheck139, label %ThrowNullRef140, label %360
 
 ; <label>:360                                     ; preds = %356
   %361 = load i16, i16* %359, align 8
   %362 = sext i16 %361 to i32
   %363 = bitcast i8* %357 to i16*
   %364 = trunc i32 %362 to i16
-  %NullCheck142 = icmp ne i16* %363, null
-  br i1 %NullCheck142, label %365, label %ThrowNullRef141
+  %NullCheck141 = icmp eq i16* %363, null
+  br i1 %NullCheck141, label %ThrowNullRef142, label %365
 
 ; <label>:365                                     ; preds = %360
   store i16 %364, i16* %363, align 8
@@ -1352,14 +1434,14 @@ entry:
   %378 = load i8*, i8** %arg0
   %379 = load i8*, i8** %arg1
   %380 = bitcast i8* %379 to i32*
-  %NullCheck144 = icmp ne i32* %380, null
-  br i1 %NullCheck144, label %381, label %ThrowNullRef143
+  %NullCheck143 = icmp eq i32* %380, null
+  br i1 %NullCheck143, label %ThrowNullRef144, label %381
 
 ; <label>:381                                     ; preds = %377
   %382 = load i32, i32* %380, align 8
   %383 = bitcast i8* %378 to i32*
-  %NullCheck146 = icmp ne i32* %383, null
-  br i1 %NullCheck146, label %384, label %ThrowNullRef145
+  %NullCheck145 = icmp eq i32* %383, null
+  br i1 %NullCheck145, label %ThrowNullRef146, label %384
 
 ; <label>:384                                     ; preds = %381
   store i32 %382, i32* %383, align 8
@@ -1384,14 +1466,14 @@ entry:
   %395 = load i8*, i8** %arg0
   %396 = load i8*, i8** %arg1
   %397 = bitcast i8* %396 to i64*
-  %NullCheck164 = icmp ne i64* %397, null
-  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+  %NullCheck163 = icmp eq i64* %397, null
+  br i1 %NullCheck163, label %ThrowNullRef164, label %398
 
 ; <label>:398                                     ; preds = %394
   %399 = load i64, i64* %397, align 8
   %400 = bitcast i8* %395 to i64*
-  %NullCheck166 = icmp ne i64* %400, null
-  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+  %NullCheck165 = icmp eq i64* %400, null
+  br i1 %NullCheck165, label %ThrowNullRef166, label %401
 
 ; <label>:401                                     ; preds = %398
   store i64 %399, i64* %400, align 8
@@ -1400,14 +1482,14 @@ entry:
   %404 = load i8*, i8** %arg1
   %405 = getelementptr inbounds i8, i8* %404, i64 8
   %406 = bitcast i8* %405 to i64*
-  %NullCheck168 = icmp ne i64* %406, null
-  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+  %NullCheck167 = icmp eq i64* %406, null
+  br i1 %NullCheck167, label %ThrowNullRef168, label %407
 
 ; <label>:407                                     ; preds = %401
   %408 = load i64, i64* %406, align 8
   %409 = bitcast i8* %403 to i64*
-  %NullCheck170 = icmp ne i64* %409, null
-  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+  %NullCheck169 = icmp eq i64* %409, null
+  br i1 %NullCheck169, label %ThrowNullRef170, label %410
 
 ; <label>:410                                     ; preds = %407
   store i64 %408, i64* %409, align 8
@@ -1437,14 +1519,14 @@ entry:
   %425 = load i8*, i8** %arg0
   %426 = load i8*, i8** %arg1
   %427 = bitcast i8* %426 to i64*
-  %NullCheck148 = icmp ne i64* %427, null
-  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+  %NullCheck147 = icmp eq i64* %427, null
+  br i1 %NullCheck147, label %ThrowNullRef148, label %428
 
 ; <label>:428                                     ; preds = %424
   %429 = load i64, i64* %427, align 8
   %430 = bitcast i8* %425 to i64*
-  %NullCheck150 = icmp ne i64* %430, null
-  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+  %NullCheck149 = icmp eq i64* %430, null
+  br i1 %NullCheck149, label %ThrowNullRef150, label %431
 
 ; <label>:431                                     ; preds = %428
   store i64 %429, i64* %430, align 8
@@ -1466,14 +1548,14 @@ entry:
   %441 = load i8*, i8** %arg0
   %442 = load i8*, i8** %arg1
   %443 = bitcast i8* %442 to i32*
-  %NullCheck152 = icmp ne i32* %443, null
-  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+  %NullCheck151 = icmp eq i32* %443, null
+  br i1 %NullCheck151, label %ThrowNullRef152, label %444
 
 ; <label>:444                                     ; preds = %440
   %445 = load i32, i32* %443, align 8
   %446 = bitcast i8* %441 to i32*
-  %NullCheck154 = icmp ne i32* %446, null
-  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+  %NullCheck153 = icmp eq i32* %446, null
+  br i1 %NullCheck153, label %ThrowNullRef154, label %447
 
 ; <label>:447                                     ; preds = %444
   store i32 %445, i32* %446, align 8
@@ -1495,16 +1577,16 @@ entry:
   %457 = load i8*, i8** %arg0
   %458 = load i8*, i8** %arg1
   %459 = bitcast i8* %458 to i16*
-  %NullCheck156 = icmp ne i16* %459, null
-  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+  %NullCheck155 = icmp eq i16* %459, null
+  br i1 %NullCheck155, label %ThrowNullRef156, label %460
 
 ; <label>:460                                     ; preds = %456
   %461 = load i16, i16* %459, align 8
   %462 = sext i16 %461 to i32
   %463 = bitcast i8* %457 to i16*
   %464 = trunc i32 %462 to i16
-  %NullCheck158 = icmp ne i16* %463, null
-  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+  %NullCheck157 = icmp eq i16* %463, null
+  br i1 %NullCheck157, label %ThrowNullRef158, label %465
 
 ; <label>:465                                     ; preds = %460
   store i16 %464, i16* %463, align 8
@@ -1525,15 +1607,15 @@ entry:
 ; <label>:474                                     ; preds = %470
   %475 = load i8*, i8** %arg0
   %476 = load i8*, i8** %arg1
-  %NullCheck160 = icmp ne i8* %476, null
-  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+  %NullCheck159 = icmp eq i8* %476, null
+  br i1 %NullCheck159, label %ThrowNullRef160, label %477
 
 ; <label>:477                                     ; preds = %474
   %478 = load i8, i8* %476, align 8
   %479 = zext i8 %478 to i32
   %480 = trunc i32 %479 to i8
-  %NullCheck162 = icmp ne i8* %475, null
-  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+  %NullCheck161 = icmp eq i8* %475, null
+  br i1 %NullCheck161, label %ThrowNullRef162, label %481
 
 ; <label>:481                                     ; preds = %477
   store i8 %480, i8* %475, align 8
@@ -1553,343 +1635,343 @@ ThrowNullRef:                                     ; preds = %308
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %312
+ThrowNullRef2:                                    ; preds = %312
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %315
+ThrowNullRef4:                                    ; preds = %315
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %321
+ThrowNullRef6:                                    ; preds = %321
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %271
+ThrowNullRef8:                                    ; preds = %271
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %275
+ThrowNullRef10:                                   ; preds = %275
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %278
+ThrowNullRef12:                                   ; preds = %278
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %284
+ThrowNullRef14:                                   ; preds = %284
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %287
+ThrowNullRef16:                                   ; preds = %287
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %293
+ThrowNullRef18:                                   ; preds = %293
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %298
+ThrowNullRef20:                                   ; preds = %298
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %303
+ThrowNullRef22:                                   ; preds = %303
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %243
+ThrowNullRef24:                                   ; preds = %243
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %247
+ThrowNullRef26:                                   ; preds = %247
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %250
+ThrowNullRef28:                                   ; preds = %250
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %256
+ThrowNullRef30:                                   ; preds = %256
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %259
+ThrowNullRef32:                                   ; preds = %259
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %265
+ThrowNullRef34:                                   ; preds = %265
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %217
+ThrowNullRef36:                                   ; preds = %217
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %221
+ThrowNullRef38:                                   ; preds = %221
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %224
+ThrowNullRef40:                                   ; preds = %224
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %230
+ThrowNullRef42:                                   ; preds = %230
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %233
+ThrowNullRef44:                                   ; preds = %233
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %238
+ThrowNullRef46:                                   ; preds = %238
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %200
+ThrowNullRef48:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %204
+ThrowNullRef50:                                   ; preds = %204
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %207
+ThrowNullRef52:                                   ; preds = %207
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %213
+ThrowNullRef54:                                   ; preds = %213
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %172
+ThrowNullRef56:                                   ; preds = %172
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %176
+ThrowNullRef58:                                   ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %179
+ThrowNullRef60:                                   ; preds = %179
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %185
+ThrowNullRef62:                                   ; preds = %185
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %190
+ThrowNullRef64:                                   ; preds = %190
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %195
+ThrowNullRef66:                                   ; preds = %195
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %153
+ThrowNullRef68:                                   ; preds = %153
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %157
+ThrowNullRef70:                                   ; preds = %157
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %160
+ThrowNullRef72:                                   ; preds = %160
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %166
+ThrowNullRef74:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %136
+ThrowNullRef76:                                   ; preds = %136
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %140
+ThrowNullRef78:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %143
+ThrowNullRef80:                                   ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %148
+ThrowNullRef82:                                   ; preds = %148
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %128
+ThrowNullRef84:                                   ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %132
+ThrowNullRef86:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %100
+ThrowNullRef88:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %104
+ThrowNullRef90:                                   ; preds = %104
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %107
+ThrowNullRef92:                                   ; preds = %107
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %113
+ThrowNullRef94:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %118
+ThrowNullRef96:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %123
+ThrowNullRef98:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %81
+ThrowNullRef100:                                  ; preds = %81
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef101:                                  ; preds = %85
+ThrowNullRef102:                                  ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef103:                                  ; preds = %88
+ThrowNullRef104:                                  ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef105:                                  ; preds = %94
+ThrowNullRef106:                                  ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef107:                                  ; preds = %64
+ThrowNullRef108:                                  ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef109:                                  ; preds = %68
+ThrowNullRef110:                                  ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef111:                                  ; preds = %71
+ThrowNullRef112:                                  ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef113:                                  ; preds = %76
+ThrowNullRef114:                                  ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef115:                                  ; preds = %56
+ThrowNullRef116:                                  ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef117:                                  ; preds = %60
+ThrowNullRef118:                                  ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef119:                                  ; preds = %37
+ThrowNullRef120:                                  ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef121:                                  ; preds = %41
+ThrowNullRef122:                                  ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef123:                                  ; preds = %46
+ThrowNullRef124:                                  ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef125:                                  ; preds = %51
+ThrowNullRef126:                                  ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef127:                                  ; preds = %27
+ThrowNullRef128:                                  ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef129:                                  ; preds = %31
+ThrowNullRef130:                                  ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef131:                                  ; preds = %19
+ThrowNullRef132:                                  ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef133:                                  ; preds = %22
+ThrowNullRef134:                                  ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef135:                                  ; preds = %338
+ThrowNullRef136:                                  ; preds = %338
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef137:                                  ; preds = %341
+ThrowNullRef138:                                  ; preds = %341
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef139:                                  ; preds = %356
+ThrowNullRef140:                                  ; preds = %356
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef141:                                  ; preds = %360
+ThrowNullRef142:                                  ; preds = %360
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef143:                                  ; preds = %377
+ThrowNullRef144:                                  ; preds = %377
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef145:                                  ; preds = %381
+ThrowNullRef146:                                  ; preds = %381
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef147:                                  ; preds = %424
+ThrowNullRef148:                                  ; preds = %424
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef149:                                  ; preds = %428
+ThrowNullRef150:                                  ; preds = %428
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef151:                                  ; preds = %440
+ThrowNullRef152:                                  ; preds = %440
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef153:                                  ; preds = %444
+ThrowNullRef154:                                  ; preds = %444
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef155:                                  ; preds = %456
+ThrowNullRef156:                                  ; preds = %456
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef157:                                  ; preds = %460
+ThrowNullRef158:                                  ; preds = %460
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef159:                                  ; preds = %474
+ThrowNullRef160:                                  ; preds = %474
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef161:                                  ; preds = %477
+ThrowNullRef162:                                  ; preds = %477
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef163:                                  ; preds = %394
+ThrowNullRef164:                                  ; preds = %394
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef165:                                  ; preds = %398
+ThrowNullRef166:                                  ; preds = %398
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef167:                                  ; preds = %401
+ThrowNullRef168:                                  ; preds = %401
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef169:                                  ; preds = %407
+ThrowNullRef170:                                  ; preds = %407
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1939,8 +2021,8 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
-  br i1 %NullCheck, label %22, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %ThrowNullRef, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
@@ -1948,8 +2030,8 @@ entry:
   store i32 %24, i32* %loc0
   %25 = load i32, i32* %loc0
   %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %26, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %27
 
 ; <label>:27                                      ; preds = %22
   %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
@@ -1971,7 +2053,7 @@ ThrowNullRef:                                     ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1989,8 +2071,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -2022,15 +2104,15 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2048,16 +2130,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
   %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
   store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %15
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
@@ -2072,8 +2154,8 @@ entry:
   %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
   %29 = ptrtoint i16 addrspace(1)* %28 to i64
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %19
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
@@ -2089,19 +2171,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2114,8 +2196,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
@@ -2128,7 +2210,7 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[loadElem]
+Failed to read AppDomain.PrepareDataForSetup[storeElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
@@ -2202,8 +2284,8 @@ entry:
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
-  br i1 %NullCheck24, label %27, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = load i64, i64 addrspace(1)* %26
@@ -2218,8 +2300,8 @@ entry:
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
-  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
   %41 = load i64, i64 addrspace(1)* %39
@@ -2236,8 +2318,8 @@ entry:
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
-  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
   %54 = load i64, i64 addrspace(1)* %52
@@ -2252,8 +2334,8 @@ entry:
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
   %67 = load i64, i64 addrspace(1)* %65
@@ -2270,8 +2352,8 @@ entry:
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
-  br i1 %NullCheck16, label %79, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
   %80 = load i64, i64 addrspace(1)* %78
@@ -2286,8 +2368,8 @@ entry:
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
-  br i1 %NullCheck18, label %92, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
   %93 = load i64, i64 addrspace(1)* %91
@@ -2304,8 +2386,8 @@ entry:
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
-  br i1 %NullCheck12, label %105, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = load i64, i64 addrspace(1)* %104
@@ -2320,8 +2402,8 @@ entry:
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
-  br i1 %NullCheck14, label %118, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
   %119 = load i64, i64 addrspace(1)* %117
@@ -2337,8 +2419,8 @@ entry:
 
 ; <label>:128                                     ; preds = %20
   %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
-  br i1 %NullCheck4, label %130, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %129, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %130
 
 ; <label>:130                                     ; preds = %128
   %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
@@ -2346,8 +2428,8 @@ entry:
   %133 = load i16, i16 addrspace(1)* %132, align 8
   %134 = zext i16 %133 to i32
   %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
-  br i1 %NullCheck6, label %136, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %135, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %136
 
 ; <label>:136                                     ; preds = %130
   %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
@@ -2360,8 +2442,8 @@ entry:
 
 ; <label>:143                                     ; preds = %136
   %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
-  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %144, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %145
 
 ; <label>:145                                     ; preds = %143
   %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
@@ -2369,8 +2451,8 @@ entry:
   %148 = load i16, i16 addrspace(1)* %147, align 8
   %149 = zext i16 %148 to i32
   %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %150, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %151
 
 ; <label>:151                                     ; preds = %145
   %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
@@ -2388,8 +2470,8 @@ entry:
 
 ; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
-  br i1 %NullCheck, label %163, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %ThrowNullRef, label %163
 
 ; <label>:163                                     ; preds = %161
   %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
@@ -2399,8 +2481,8 @@ entry:
 
 ; <label>:167                                     ; preds = %163
   %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
-  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %168, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %169
 
 ; <label>:169                                     ; preds = %167
   %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
@@ -2432,55 +2514,55 @@ ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %167
+ThrowNullRef2:                                    ; preds = %167
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %128
+ThrowNullRef4:                                    ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %130
+ThrowNullRef6:                                    ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %143
+ThrowNullRef8:                                    ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %145
+ThrowNullRef10:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %102
+ThrowNullRef12:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %105
+ThrowNullRef14:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %76
+ThrowNullRef16:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %79
+ThrowNullRef18:                                   ; preds = %79
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %50
+ThrowNullRef20:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %53
+ThrowNullRef22:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %24
+ThrowNullRef24:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %27
+ThrowNullRef26:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2503,15 +2585,15 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2519,16 +2601,16 @@ entry:
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
   store i32 %8, i32* %loc0
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
   %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
   store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
@@ -2546,16 +2628,16 @@ entry:
 
 ; <label>:23                                      ; preds = %64
   %24 = load i16*, i16** %loc3
-  %NullCheck12 = icmp ne i16* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i16* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
   store i32 %27, i32* %loc5
   %28 = load i16*, i16** %loc4
-  %NullCheck14 = icmp ne i16* %28, null
-  br i1 %NullCheck14, label %29, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %28, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = load i16, i16* %28, align 8
@@ -2620,15 +2702,15 @@ entry:
 
 ; <label>:67                                      ; preds = %64
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
-  br i1 %NullCheck8, label %69, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %68, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %69
 
 ; <label>:69                                      ; preds = %67
   %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
   %71 = load i32, i32 addrspace(1)* %70
   %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
-  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %73
 
 ; <label>:73                                      ; preds = %69
   %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
@@ -2645,31 +2727,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %67
+ThrowNullRef8:                                    ; preds = %67
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %69
+ThrowNullRef10:                                   ; preds = %69
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2710,14 +2792,14 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
   %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
@@ -2730,14 +2812,14 @@ entry:
 
 ; <label>:11                                      ; preds = %4
   %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
   %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
@@ -2749,14 +2831,14 @@ entry:
 
 ; <label>:22                                      ; preds = %16
   %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
   %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
-  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
-  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
@@ -2804,23 +2886,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2836,7 +2918,280 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[loadElem]
+Successfully read RuntimeType.IsAssignableFrom
+
+define i8 @RuntimeType.IsAssignableFrom(%System.RuntimeType addrspace(1)* %param0, %System.Type addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.RuntimeType addrspace(1)*
+  %arg1 = alloca %System.Type addrspace(1)*
+  %loc0 = alloca %System.RuntimeType addrspace(1)*
+  %loc1 = alloca %"System.Type[]" addrspace(1)*
+  %loc2 = alloca i32
+  store %System.RuntimeType addrspace(1)* %param0, %System.RuntimeType addrspace(1)** %this
+  store %System.Type addrspace(1)* %param1, %System.Type addrspace(1)** %arg1
+  %0 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %1 = icmp ne %System.Type addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i8 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %5 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %6 = bitcast %System.Type addrspace(1)* %4 to %System.Object addrspace(1)*
+  %7 = bitcast %System.RuntimeType addrspace(1)* %5 to %System.Object addrspace(1)*
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %6, %System.Object addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %3
+  ret i8 1
+
+; <label>:12                                      ; preds = %3
+  %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 152
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 32
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
+  %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
+  %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
+  store %System.RuntimeType addrspace(1)* %25, %System.RuntimeType addrspace(1)** %loc0
+  %26 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %27 = icmp eq %System.RuntimeType addrspace(1)* %26, null
+  br i1 %27, label %34, label %28
+
+; <label>:28                                      ; preds = %15
+  %29 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %30 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)*)*)(%System.RuntimeType addrspace(1)* %29, %System.RuntimeType addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+; <label>:34                                      ; preds = %15
+  %35 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %36 = call %System.Reflection.Emit.TypeBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Reflection.Emit.TypeBuilder addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %35)
+  %37 = icmp eq %System.Reflection.Emit.TypeBuilder addrspace(1)* %36, null
+  br i1 %37, label %139, label %38
+
+; <label>:38                                      ; preds = %34
+  %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %42
+
+; <label>:42                                      ; preds = %38
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 152
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 40
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
+  %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
+  %53 = zext i8 %52 to i32
+  %54 = icmp eq i32 %53, 0
+  br i1 %54, label %56, label %55
+
+; <label>:55                                      ; preds = %42
+  ret i8 1
+
+; <label>:56                                      ; preds = %42
+  %57 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %58 = bitcast %System.RuntimeType addrspace(1)* %57 to %System.Type addrspace(1)*
+  %59 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %58)
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %64 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.Type addrspace(1)* %63, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = bitcast %System.RuntimeType addrspace(1)* %64 to %System.Type addrspace(1)*
+  %67 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %63, %System.Type addrspace(1)* %66)
+  %68 = zext i8 %67 to i32
+  %69 = trunc i32 %68 to i8
+  ret i8 %69
+
+; <label>:70                                      ; preds = %56
+  %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
+  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %73
+
+; <label>:73                                      ; preds = %70
+  %74 = load i64, i64 addrspace(1)* %72
+  %75 = add i64 %74, 128
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = add i64 %77, 0
+  %79 = inttoptr i64 %78 to i64*
+  %80 = load i64, i64* %79
+  %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
+  %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
+  %83 = call i8 %82(%System.Type addrspace(1)* %81)
+  %84 = zext i8 %83 to i32
+  %85 = icmp eq i32 %84, 0
+  br i1 %85, label %139, label %86
+
+; <label>:86                                      ; preds = %73
+  %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
+  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %89
+
+; <label>:89                                      ; preds = %86
+  %90 = load i64, i64 addrspace(1)* %88
+  %91 = add i64 %90, 128
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = add i64 %93, 24
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
+  %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
+  %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
+  store %"System.Type[]" addrspace(1)* %99, %"System.Type[]" addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %129
+
+; <label>:100                                     ; preds = %132
+  %101 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %102 = load i32, i32* %loc2
+  %NullCheck11 = icmp eq %"System.Type[]" addrspace(1)* %101, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %103
+
+; <label>:103                                     ; preds = %100
+  %104 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 1
+  %105 = load i32, i32 addrspace(1)* %104
+  %106 = zext i32 %105 to i64
+  %107 = zext i32 %102 to i64
+  %BoundsCheck = icmp uge i64 %107, %106
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %108
+
+; <label>:108                                     ; preds = %103
+  %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
+  %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
+  %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
+  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %113
+
+; <label>:113                                     ; preds = %108
+  %114 = load i64, i64 addrspace(1)* %112
+  %115 = add i64 %114, 152
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = add i64 %117, 56
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
+  %123 = zext i8 %122 to i32
+  %124 = icmp ne i32 %123, 0
+  br i1 %124, label %126, label %125
+
+; <label>:125                                     ; preds = %113
+  ret i8 0
+
+; <label>:126                                     ; preds = %113
+  %127 = load i32, i32* %loc2
+  %128 = add i32 %127, 1
+  store i32 %128, i32* %loc2
+  br label %129
+
+; <label>:129                                     ; preds = %89, %126
+  %130 = load i32, i32* %loc2
+  %131 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %NullCheck9 = icmp eq %"System.Type[]" addrspace(1)* %131, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %132
+
+; <label>:132                                     ; preds = %129
+  %133 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %131, i32 0, i32 1
+  %134 = load i32, i32 addrspace(1)* %133
+  %135 = zext i32 %134 to i64
+  %136 = trunc i64 %135 to i32
+  %137 = icmp slt i32 %130, %136
+  br i1 %137, label %100, label %138
+
+; <label>:138                                     ; preds = %132
+  ret i8 1
+
+; <label>:139                                     ; preds = %34, %73
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %129
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %103
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -2893,7 +3248,7 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElem]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -2904,8 +3259,8 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -2997,8 +3352,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
@@ -3059,8 +3414,8 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -3087,8 +3442,8 @@ entry:
 
 ; <label>:17                                      ; preds = %5, %11
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
@@ -3097,8 +3452,8 @@ entry:
 
 ; <label>:22                                      ; preds = %1, %11
   %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
@@ -3109,11 +3464,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %17
+ThrowNullRef2:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %22
+ThrowNullRef4:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3167,15 +3522,15 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
   %15 = load i32, i32 addrspace(1)* %14
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
@@ -3198,7 +3553,7 @@ ThrowNullRef:                                     ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef2:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3232,8 +3587,8 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
@@ -3312,8 +3667,8 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -3327,8 +3682,8 @@ entry:
 ; <label>:5                                       ; preds = %43
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %7 = load i32, i32* %loc1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck6, label %8, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
@@ -3366,8 +3721,8 @@ entry:
 ; <label>:32                                      ; preds = %21, %25
   %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
   %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
-  br i1 %NullCheck8, label %35, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = trunc i32 %34 to i16
@@ -3380,8 +3735,8 @@ entry:
 ; <label>:40                                      ; preds = %1, %35
   %41 = load i32, i32* %loc1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
-  br i1 %NullCheck2, label %43, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %42, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
@@ -3392,8 +3747,8 @@ entry:
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
   %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
-  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
   %51 = load i64, i64 addrspace(1)* %49
@@ -3412,19 +3767,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %40
+ThrowNullRef2:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %47
+ThrowNullRef4:                                    ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %5
+ThrowNullRef6:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %32
+ThrowNullRef8:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3467,8 +3822,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
@@ -3492,11 +3847,391 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(i16* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store i16* %param0, i16** %arg0
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load i32, i32* %arg3
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %42, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %37, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg2
+  %13 = load i32, i32* %arg3
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %37, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %24 = load i32, i32* %arg2
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load i16*, i16** %arg0
+  %35 = load i32, i32* %arg3
+  %36 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %36, i16* %34, i32 %35)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:37                                      ; preds = %5, %16
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %39)
+  %41 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41, %System.String addrspace(1)* %38, %System.String addrspace(1)* %40)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41) #0
+  unreachable
+
+; <label>:42                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
-Failed to read StringBuilder.ToString[loadElemA]
+Successfully read StringBuilder.ToString
+
+define %System.String addrspace(1)* @StringBuilder.ToString(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i16*
+  %loc3 = alloca %"System.Char[]" addrspace(1)*
+  %loc4 = alloca i32
+  %loc5 = alloca i32
+  %loc6 = alloca i16 addrspace(1)*
+  %loc7 = alloca %System.String addrspace(1)*
+  %loc8 = alloca %"System.Char[]" addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %0)
+  %2 = icmp ne i32 %1, 0
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %4
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %6)
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %7)
+  store %System.String addrspace(1)* %8, %System.String addrspace(1)** %loc0
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.Text.StringBuilder addrspace(1)* %9, %System.Text.StringBuilder addrspace(1)** %loc1
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  store %System.String addrspace(1)* %10, %System.String addrspace(1)** %loc7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc7
+  %12 = ptrtoint %System.String addrspace(1)* %11 to i64
+  %13 = icmp eq i64 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %5
+  %15 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %16 = sext i32 %15 to i64
+  %17 = add i64 %12, %16
+  br label %18
+
+; <label>:18                                      ; preds = %5, %14
+  %19 = phi i64 [ %12, %5 ], [ %17, %14 ]
+  %20 = inttoptr i64 %19 to i16*
+  store i16* %20, i16** %loc2
+  br label %21
+
+; <label>:21                                      ; preds = %98, %18
+  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %22, null
+  br i1 %NullCheck, label %ThrowNullRef, label %23
+
+; <label>:23                                      ; preds = %21
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 3
+  %25 = load i32, i32 addrspace(1)* %24, align 8
+  %26 = icmp sle i32 %25, 0
+  br i1 %26, label %96, label %27
+
+; <label>:27                                      ; preds = %23
+  %28 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %28, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %29
+
+; <label>:29                                      ; preds = %27
+  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %28, i32 0, i32 1
+  %31 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %30, align 8
+  store %"System.Char[]" addrspace(1)* %31, %"System.Char[]" addrspace(1)** %loc3
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %33
+
+; <label>:33                                      ; preds = %29
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  store i32 %35, i32* %loc4
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  %39 = load i32, i32 addrspace(1)* %38, align 8
+  store i32 %39, i32* %loc5
+  %40 = load i32, i32* %loc5
+  %41 = load i32, i32* %loc4
+  %42 = add i32 %40, %41
+  %43 = zext i32 %42 to i64
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %45
+
+; <label>:45                                      ; preds = %37
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = sext i32 %47 to i64
+  %49 = icmp sgt i64 %43, %48
+  br i1 %49, label %91, label %50
+
+; <label>:50                                      ; preds = %45
+  %51 = load i32, i32* %loc5
+  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %52, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %53
+
+; <label>:53                                      ; preds = %50
+  %54 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %52, i32 0, i32 1
+  %55 = load i32, i32 addrspace(1)* %54
+  %56 = zext i32 %55 to i64
+  %57 = trunc i64 %56 to i32
+  %58 = icmp ugt i32 %51, %57
+  br i1 %58, label %91, label %59
+
+; <label>:59                                      ; preds = %53
+  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  store %"System.Char[]" addrspace(1)* %60, %"System.Char[]" addrspace(1)** %loc8
+  %61 = icmp eq %"System.Char[]" addrspace(1)* %60, null
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %63, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %64
+
+; <label>:64                                      ; preds = %62
+  %65 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %63, i32 0, i32 1
+  %66 = load i32, i32 addrspace(1)* %65
+  %67 = zext i32 %66 to i64
+  %68 = trunc i64 %67 to i32
+  %69 = icmp ne i32 %68, 0
+  br i1 %69, label %71, label %70
+
+; <label>:70                                      ; preds = %59, %64
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:71                                      ; preds = %64
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %73
+
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %BoundsCheck = icmp uge i64 0, %76
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %77
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %78, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:79                                      ; preds = %70, %77
+  %80 = load i16*, i16** %loc2
+  %81 = load i32, i32* %loc4
+  %82 = sext i32 %81 to i64
+  %83 = mul i64 %82, 2
+  %84 = bitcast i16* %80 to i8*
+  %85 = getelementptr inbounds i8, i8* %84, i64 %83
+  %86 = load i16 addrspace(1)*, i16 addrspace(1)** %loc6
+  %87 = ptrtoint i16 addrspace(1)* %86 to i64
+  %88 = load i32, i32* %loc5
+  %89 = bitcast i8* %85 to i16*
+  %90 = inttoptr i64 %87 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %89, i16* %90, i32 %88)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %96
+
+; <label>:91                                      ; preds = %45, %53
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %94 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %93)
+  %95 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95, %System.String addrspace(1)* %92, %System.String addrspace(1)* %94)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95) #0
+  unreachable
+
+; <label>:96                                      ; preds = %23, %79
+  %97 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %97, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %98
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %97, i32 0, i32 2
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  store %System.Text.StringBuilder addrspace(1)* %100, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %102 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %102, label %21, label %103
+
+; <label>:103                                     ; preds = %98
+  store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc7
+  %104 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  ret %System.String addrspace(1)* %104
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method StringBuilder::get_Length using LLILCJit
+Successfully read StringBuilder.get_Length
+
+define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
+Successfully read RuntimeHelpers.get_OffsetToStringData
+
+define i32 @RuntimeHelpers.get_OffsetToStringData() {
+entry:
+  ret i32 12
+}
+
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
 Successfully read CultureData.CreateCultureData
 
@@ -3514,23 +4249,23 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
   store i8 %4, i8 addrspace(1)* %6
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
@@ -3549,11 +4284,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3566,50 +4301,50 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
   store i32 -1, i32 addrspace(1)* %2
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
   store i32 -1, i32 addrspace(1)* %8
   %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
   store i32 -1, i32 addrspace(1)* %14
   %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
   store i32 -1, i32 addrspace(1)* %17
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
@@ -3623,27 +4358,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3675,7 +4410,136 @@ Failed to read Dictionary`2.Insert[non-const derefAddress]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
 Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
-Failed to read HashHelpers.GetPrime[loadElem]
+Successfully read HashHelpers.GetPrime
+
+define i32 @HashHelpers.GetPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %6, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5, %System.String addrspace(1)* %4)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5) #0
+  unreachable
+
+; <label>:6                                       ; preds = %entry
+  store i32 0, i32* %loc0
+  br label %29
+
+; <label>:7                                       ; preds = %35
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 1296
+  %10 = addrspacecast i8 addrspace(1)* %9 to %"System.Int32[]" addrspace(1)**
+  %11 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %10
+  %12 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Int32[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = zext i32 %15 to i64
+  %17 = zext i32 %12 to i64
+  %BoundsCheck = icmp uge i64 %17, %16
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 3, i32 %12
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  store i32 %20, i32* %loc1
+  %21 = load i32, i32* %loc1
+  %22 = load i32, i32* %arg0
+  %23 = icmp slt i32 %21, %22
+  br i1 %23, label %26, label %24
+
+; <label>:24                                      ; preds = %18
+  %25 = load i32, i32* %loc1
+  ret i32 %25
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %loc0
+  %28 = add i32 %27, 1
+  store i32 %28, i32* %loc0
+  br label %29
+
+; <label>:29                                      ; preds = %6, %26
+  %30 = load i32, i32* %loc0
+  %31 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %32 = getelementptr inbounds i8, i8 addrspace(1)* %31, i64 1296
+  %33 = addrspacecast i8 addrspace(1)* %32 to %"System.Int32[]" addrspace(1)**
+  %34 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %33
+  %NullCheck = icmp eq %"System.Int32[]" addrspace(1)* %34, null
+  br i1 %NullCheck, label %ThrowNullRef, label %35
+
+; <label>:35                                      ; preds = %29
+  %36 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %34, i32 0, i32 1
+  %37 = load i32, i32 addrspace(1)* %36
+  %38 = zext i32 %37 to i64
+  %39 = trunc i64 %38 to i32
+  %40 = icmp slt i32 %30, %39
+  br i1 %40, label %7, label %41
+
+; <label>:41                                      ; preds = %35
+  %42 = load i32, i32* %arg0
+  %43 = or i32 %42, 1
+  store i32 %43, i32* %loc2
+  br label %59
+
+; <label>:44                                      ; preds = %59
+  %45 = load i32, i32* %loc2
+  %46 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %45)
+  %47 = zext i8 %46 to i32
+  %48 = icmp eq i32 %47, 0
+  br i1 %48, label %56, label %49
+
+; <label>:49                                      ; preds = %44
+  %50 = load i32, i32* %loc2
+  %51 = sub i32 %50, 1
+  %52 = srem i32 %51, 101
+  %53 = icmp eq i32 %52, 0
+  br i1 %53, label %56, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = load i32, i32* %loc2
+  ret i32 %55
+
+; <label>:56                                      ; preds = %44, %49
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %57, 2
+  store i32 %58, i32* %loc2
+  br label %59
+
+; <label>:59                                      ; preds = %41, %56
+  %60 = load i32, i32* %loc2
+  %61 = icmp slt i32 %60, 2147483647
+  br i1 %61, label %44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load i32, i32* %arg0
+  ret i32 %63
+
+ThrowNullRef:                                     ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
 Successfully read GenericEqualityComparer`1.GetHashCode
 
@@ -3694,14 +4558,14 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
   %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load i64, i64 addrspace(1)* %7
@@ -3720,7 +4584,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3750,8 +4614,8 @@ entry:
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
@@ -3796,8 +4660,8 @@ entry:
   %35 = bitcast i16* %34 to i8*
   %36 = getelementptr inbounds i8, i8* %35, i64 2
   %37 = bitcast i8* %36 to i16*
-  %NullCheck4 = icmp ne i16* %37, null
-  br i1 %NullCheck4, label %38, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %37, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %38
 
 ; <label>:38                                      ; preds = %27
   %39 = load i16, i16* %37, align 8
@@ -3824,8 +4688,8 @@ entry:
 
 ; <label>:54                                      ; preds = %22, %43
   %55 = load i16*, i16** %loc4
-  %NullCheck2 = icmp ne i16* %55, null
-  br i1 %NullCheck2, label %56, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i16* %55, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %56
 
 ; <label>:56                                      ; preds = %54
   %57 = load i16, i16* %55, align 8
@@ -3850,11 +4714,11 @@ ThrowNullRef:                                     ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %54
+ThrowNullRef2:                                    ; preds = %54
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %27
+ThrowNullRef4:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3871,8 +4735,8 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -3907,8 +4771,8 @@ entry:
 
 ; <label>:26                                      ; preds = %19
   %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
-  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %28
 
 ; <label>:28                                      ; preds = %26
   %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
@@ -3920,7 +4784,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3972,8 +4836,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
@@ -3984,26 +4848,26 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
-  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
@@ -4014,8 +4878,8 @@ entry:
 ; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
@@ -4024,8 +4888,8 @@ entry:
 
 ; <label>:25                                      ; preds = %1, %16, %23
   %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
-  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
@@ -4036,27 +4900,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %20
+ThrowNullRef10:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4069,8 +4933,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -4081,8 +4945,8 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
@@ -4091,8 +4955,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1, %8
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
@@ -4103,11 +4967,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4128,24 +4992,24 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   store i32 %3, i32* %loc0
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
   %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
   store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck4, label %9, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
@@ -4164,15 +5028,15 @@ entry:
 ; <label>:18                                      ; preds = %70
   %19 = load i16*, i16** %loc3
   %20 = bitcast i16* %19 to i64*
-  %NullCheck10 = icmp ne i64* %20, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %20, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = load i64, i64* %20, align 8
   %23 = load i16*, i16** %loc4
   %24 = bitcast i16* %23 to i64*
-  %NullCheck12 = icmp ne i64* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = load i64, i64* %24, align 8
@@ -4188,8 +5052,8 @@ entry:
   %31 = bitcast i16* %30 to i8*
   %32 = getelementptr inbounds i8, i8* %31, i64 8
   %33 = bitcast i8* %32 to i64*
-  %NullCheck14 = icmp ne i64* %33, null
-  br i1 %NullCheck14, label %34, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = load i64, i64* %33, align 8
@@ -4197,8 +5061,8 @@ entry:
   %37 = bitcast i16* %36 to i8*
   %38 = getelementptr inbounds i8, i8* %37, i64 8
   %39 = bitcast i8* %38 to i64*
-  %NullCheck16 = icmp ne i64* %39, null
-  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %40
 
 ; <label>:40                                      ; preds = %34
   %41 = load i64, i64* %39, align 8
@@ -4214,8 +5078,8 @@ entry:
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %NullCheck18 = icmp ne i64* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = load i64, i64* %48, align 8
@@ -4223,8 +5087,8 @@ entry:
   %52 = bitcast i16* %51 to i8*
   %53 = getelementptr inbounds i8, i8* %52, i64 16
   %54 = bitcast i8* %53 to i64*
-  %NullCheck20 = icmp ne i64* %54, null
-  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64* %54, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %55
 
 ; <label>:55                                      ; preds = %49
   %56 = load i64, i64* %54, align 8
@@ -4262,15 +5126,15 @@ entry:
 ; <label>:74                                      ; preds = %95
   %75 = load i16*, i16** %loc3
   %76 = bitcast i16* %75 to i32*
-  %NullCheck6 = icmp ne i32* %76, null
-  br i1 %NullCheck6, label %77, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32* %76, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %77
 
 ; <label>:77                                      ; preds = %74
   %78 = load i32, i32* %76, align 8
   %79 = load i16*, i16** %loc4
   %80 = bitcast i16* %79 to i32*
-  %NullCheck8 = icmp ne i32* %80, null
-  br i1 %NullCheck8, label %81, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i32* %80, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %81
 
 ; <label>:81                                      ; preds = %77
   %82 = load i32, i32* %80, align 8
@@ -4318,43 +5182,43 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %74
+ThrowNullRef6:                                    ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %77
+ThrowNullRef8:                                    ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %29
+ThrowNullRef14:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %34
+ThrowNullRef16:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4376,8 +5240,8 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load i64, i64 addrspace(1)* %4
@@ -4389,8 +5253,8 @@ entry:
   %12 = load i64, i64* %11
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %5
   %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
@@ -4399,8 +5263,8 @@ entry:
   %18 = load i8, i8* %arg2
   %19 = zext i8 %18 to i32
   %20 = trunc i32 %19 to i8
-  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %15
   %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
@@ -4411,11 +5275,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4442,8 +5306,8 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
@@ -4466,16 +5330,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
   %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = load i64, i64 addrspace(1)* %19
@@ -4500,8 +5364,8 @@ entry:
 ; <label>:35                                      ; preds = %30
   %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
@@ -4514,8 +5378,8 @@ entry:
 
 ; <label>:42                                      ; preds = %1, %38
   %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
-  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
@@ -4526,19 +5390,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %35
+ThrowNullRef2:                                    ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %42
+ThrowNullRef8:                                    ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4551,14 +5415,14 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
@@ -4570,7 +5434,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4583,8 +5447,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
@@ -4613,51 +5477,51 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
   %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
   %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
   %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
   %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
-  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
   store i64 %21, i64 addrspace(1)* %23
   %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %25 = load i64, i64* %loc0
-  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
@@ -4668,27 +5532,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %22
+ThrowNullRef12:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4701,8 +5565,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
@@ -4713,19 +5577,19 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
@@ -4734,8 +5598,8 @@ entry:
 
 ; <label>:15                                      ; preds = %1, %13
   %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
@@ -4746,19 +5610,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %15
+ThrowNullRef8:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4771,8 +5635,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -4831,8 +5695,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
@@ -4882,8 +5746,8 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
-  br i1 %NullCheck, label %17, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %ThrowNullRef, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
@@ -4894,15 +5758,15 @@ entry:
 
 ; <label>:22                                      ; preds = %17
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
-  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
   %26 = load i32, i32 addrspace(1)* %25
   %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
-  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %27, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
@@ -4925,8 +5789,8 @@ entry:
 ; <label>:40                                      ; preds = %17
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
-  br i1 %NullCheck6, label %43, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %41, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
@@ -4938,34 +5802,17 @@ ThrowNullRef:                                     ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %24
+ThrowNullRef4:                                    ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %40
+ThrowNullRef6:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
-}
-
-INFO:  jitting method Object::ReferenceEquals using LLILCJit
-Successfully read Object.ReferenceEquals
-
-define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
-entry:
-  %arg0 = alloca %System.Object addrspace(1)*
-  %arg1 = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
-  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
-  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = icmp eq %System.Object addrspace(1)* %0, %1
-  %3 = sext i1 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
 }
 
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
@@ -4978,21 +5825,21 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
   %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
-  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
@@ -5007,28 +5854,28 @@ entry:
 ; <label>:13                                      ; preds = %8, %12
   %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
   %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
   %21 = load i32, i32 addrspace(1)* %20, align 8
   %22 = add i32 %21, 1
-  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
   store i32 %22, i32 addrspace(1)* %24
   %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
@@ -5039,27 +5886,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5077,7 +5924,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::Setup using LLILCJit
-Failed to read AppDomain.Setup[loadElem]
+Failed to read AppDomain.Setup[unbox]
 INFO:  jitting method Thread::GetDomain using LLILCJit
 Successfully read Thread.GetDomain
 
@@ -5108,8 +5955,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
@@ -5122,14 +5969,14 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
   %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
@@ -5141,11 +5988,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5173,8 +6020,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -5189,7 +6036,328 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
 Failed to read KeyCollection.System.Collections.Generic.IEnumerable<TKey>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Successfully read Enumerator.MoveNext
+
+define i8 @Enumerator.MoveNext(%"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.RuntimeTypeHandle* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*
+  %"$TypeArg" = alloca %System.RuntimeTypeHandle*
+  store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
+  %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 8
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %76, label %12
+
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
+  br label %76
+
+; <label>:13                                      ; preds = %85
+  %14 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck19 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %15
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, i32 0, i32 0
+  %17 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %16, align 8
+  %NullCheck21 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, i32 0, i32 2
+  %20 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %19, align 8
+  %21 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck23 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %22
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, i32 0, i32 2
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %NullCheck25 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 3, i32 %24
+  %NullCheck27 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %32
+
+; <label>:32                                      ; preds = %30
+  %33 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, i32 0, i32 2
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = icmp slt i32 %34, 0
+  br i1 %35, label %68, label %36
+
+; <label>:36                                      ; preds = %32
+  %37 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %38 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck29 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %39
+
+; <label>:39                                      ; preds = %36
+  %40 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, i32 0, i32 0
+  %41 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %40, align 8
+  %NullCheck31 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, i32 0, i32 2
+  %44 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %43, align 8
+  %45 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck33 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, i32 0, i32 2
+  %48 = load i32, i32 addrspace(1)* %47, align 8
+  %NullCheck35 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %49
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = zext i32 %51 to i64
+  %53 = zext i32 %48 to i64
+  %BoundsCheck37 = icmp uge i64 %53, %52
+  br i1 %BoundsCheck37, label %ThrowIndexOutOfRange38, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 3, i32 %48
+  %NullCheck39 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %56
+
+; <label>:56                                      ; preds = %54
+  %57 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, i32 0, i32 0
+  %58 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck41 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %59
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %60, %System.__Canon addrspace(1)* %58)
+  %61 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck43 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  %64 = load i32, i32 addrspace(1)* %63, align 8
+  %65 = add i32 %64, 1
+  %NullCheck45 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  store i32 %65, i32 addrspace(1)* %67
+  ret i8 1
+
+; <label>:68                                      ; preds = %32
+  %69 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck47 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %73 = add i32 %72, 1
+  %NullCheck49 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %74
+
+; <label>:74                                      ; preds = %70
+  %75 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  store i32 %73, i32 addrspace(1)* %75
+  br label %76
+
+; <label>:76                                      ; preds = %8, %12, %74
+  %77 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %78
+
+; <label>:78                                      ; preds = %76
+  %79 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, i32 0, i32 2
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck7 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %82
+
+; <label>:82                                      ; preds = %78
+  %83 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, i32 0, i32 0
+  %84 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %83, align 8
+  %NullCheck9 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %85
+
+; <label>:85                                      ; preds = %82
+  %86 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, i32 0, i32 7
+  %87 = load i32, i32 addrspace(1)* %86, align 8
+  %88 = icmp ult i32 %80, %87
+  br i1 %88, label %13, label %89
+
+; <label>:89                                      ; preds = %85
+  %90 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %91 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck11 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %92
+
+; <label>:92                                      ; preds = %89
+  %93 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, i32 0, i32 0
+  %94 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck13 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %95
+
+; <label>:95                                      ; preds = %92
+  %96 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, i32 0, i32 7
+  %97 = load i32, i32 addrspace(1)* %96, align 8
+  %98 = add i32 %97, 1
+  %NullCheck15 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %99
+
+; <label>:99                                      ; preds = %95
+  %100 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, i32 0, i32 2
+  store i32 %98, i32 addrspace(1)* %100
+  %101 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck17 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %102
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %103, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %92
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef22:                                   ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef24:                                   ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef26:                                   ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef28:                                   ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef30:                                   ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef32:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef34:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef36:                                   ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange38:                           ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef40:                                   ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef42:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef44:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef46:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef48:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef50:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -5200,8 +6368,8 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -5232,9 +6400,9 @@ Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
 Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
-Failed to read String.MakeSeparatorList[loadElemA]
+Failed to read String.MakeSeparatorList[storeElem]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
-Failed to read String.InternalSplitKeepEmptyEntries[loadElem]
+Failed to read String.InternalSplitKeepEmptyEntries[storeElem]
 INFO:  jitting method Path::IsRelative using LLILCJit
 Successfully read Path.IsRelative
 
@@ -5243,8 +6411,8 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -5254,8 +6422,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
@@ -5271,8 +6439,8 @@ entry:
 
 ; <label>:17                                      ; preds = %7
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
@@ -5288,8 +6456,8 @@ entry:
 
 ; <label>:29                                      ; preds = %19
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %31
 
 ; <label>:31                                      ; preds = %29
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
@@ -5300,8 +6468,8 @@ entry:
 
 ; <label>:36                                      ; preds = %31
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
-  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %37, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
@@ -5312,8 +6480,8 @@ entry:
 
 ; <label>:43                                      ; preds = %31, %38
   %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
-  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %45
 
 ; <label>:45                                      ; preds = %43
   %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
@@ -5324,8 +6492,8 @@ entry:
 
 ; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %50
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
@@ -5336,8 +6504,8 @@ entry:
 
 ; <label>:57                                      ; preds = %1, %7, %19, %45, %52
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
-  br i1 %NullCheck14, label %59, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %59
 
 ; <label>:59                                      ; preds = %57
   %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
@@ -5347,8 +6515,8 @@ entry:
 
 ; <label>:63                                      ; preds = %59
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
@@ -5359,8 +6527,8 @@ entry:
 
 ; <label>:70                                      ; preds = %65
   %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
-  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.String addrspace(1)* %71, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %72
 
 ; <label>:72                                      ; preds = %70
   %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
@@ -5379,39 +6547,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %17
+ThrowNullRef4:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %29
+ThrowNullRef6:                                    ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %36
+ThrowNullRef8:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %43
+ThrowNullRef10:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %50
+ThrowNullRef12:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %57
+ThrowNullRef14:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %63
+ThrowNullRef16:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %70
+ThrowNullRef18:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5419,7 +6587,293 @@ ThrowNullRef17:                                   ; preds = %70
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
-Failed to read String.TrimHelper[loadElem]
+Successfully read String.TrimHelper
+
+define %System.String addrspace(1)* @String.TrimHelper(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i16
+  %loc4 = alloca i32
+  %loc5 = alloca i16
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = sub i32 %3, 1
+  store i32 %4, i32* %loc0
+  store i32 0, i32* %loc1
+  %5 = load i32, i32* %arg2
+  %6 = icmp eq i32 %5, 1
+  br i1 %6, label %62, label %7
+
+; <label>:7                                       ; preds = %1
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:8                                       ; preds = %58
+  store i32 0, i32* %loc2
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load i32, i32* %loc1
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2, i32 %10
+  %13 = load i16, i16 addrspace(1)* %12
+  %14 = zext i16 %13 to i32
+  %15 = trunc i32 %14 to i16
+  store i16 %15, i16* %loc3
+  store i32 0, i32* %loc2
+  br label %34
+
+; <label>:16                                      ; preds = %37
+  %17 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %18 = load i32, i32* %loc2
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %17, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %19
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = zext i32 %18 to i64
+  %BoundsCheck = icmp uge i64 %23, %22
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %24
+
+; <label>:24                                      ; preds = %19
+  %25 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 3, i32 %18
+  %26 = load i16, i16 addrspace(1)* %25, align 8
+  %27 = zext i16 %26 to i32
+  %28 = load i16, i16* %loc3
+  %29 = zext i16 %28 to i32
+  %30 = icmp eq i32 %27, %29
+  br i1 %30, label %43, label %31
+
+; <label>:31                                      ; preds = %24
+  %32 = load i32, i32* %loc2
+  %33 = add i32 %32, 1
+  store i32 %33, i32* %loc2
+  br label %34
+
+; <label>:34                                      ; preds = %11, %31
+  %35 = load i32, i32* %loc2
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = icmp slt i32 %35, %41
+  br i1 %42, label %16, label %43
+
+; <label>:43                                      ; preds = %24, %37
+  %44 = load i32, i32* %loc2
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %45, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp eq i32 %44, %50
+  br i1 %51, label %62, label %52
+
+; <label>:52                                      ; preds = %46
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %7, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %57, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %58
+
+; <label>:58                                      ; preds = %55
+  %59 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %60 = load i32, i32 addrspace(1)* %59
+  %61 = icmp slt i32 %56, %60
+  br i1 %61, label %8, label %62
+
+; <label>:62                                      ; preds = %1, %46, %58
+  %63 = load i32, i32* %arg2
+  %64 = icmp eq i32 %63, 0
+  br i1 %64, label %122, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %66, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %67
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %66, i32 0, i32 1
+  %69 = load i32, i32 addrspace(1)* %68
+  %70 = sub i32 %69, 1
+  store i32 %70, i32* %loc0
+  br label %118
+
+; <label>:71                                      ; preds = %118
+  store i32 0, i32* %loc4
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %73 = load i32, i32* %loc0
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %74
+
+; <label>:74                                      ; preds = %71
+  %75 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 2, i32 %73
+  %76 = load i16, i16 addrspace(1)* %75
+  %77 = zext i16 %76 to i32
+  %78 = trunc i32 %77 to i16
+  store i16 %78, i16* %loc5
+  store i32 0, i32* %loc4
+  br label %97
+
+; <label>:79                                      ; preds = %100
+  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %81 = load i32, i32* %loc4
+  %NullCheck19 = icmp eq %"System.Char[]" addrspace(1)* %80, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
+
+; <label>:82                                      ; preds = %79
+  %83 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 1
+  %84 = load i32, i32 addrspace(1)* %83
+  %85 = zext i32 %84 to i64
+  %86 = zext i32 %81 to i64
+  %BoundsCheck21 = icmp uge i64 %86, %85
+  br i1 %BoundsCheck21, label %ThrowIndexOutOfRange22, label %87
+
+; <label>:87                                      ; preds = %82
+  %88 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 3, i32 %81
+  %89 = load i16, i16 addrspace(1)* %88, align 8
+  %90 = zext i16 %89 to i32
+  %91 = load i16, i16* %loc5
+  %92 = zext i16 %91 to i32
+  %93 = icmp eq i32 %90, %92
+  br i1 %93, label %106, label %94
+
+; <label>:94                                      ; preds = %87
+  %95 = load i32, i32* %loc4
+  %96 = add i32 %95, 1
+  store i32 %96, i32* %loc4
+  br label %97
+
+; <label>:97                                      ; preds = %74, %94
+  %98 = load i32, i32* %loc4
+  %99 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck15 = icmp eq %"System.Char[]" addrspace(1)* %99, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %100
+
+; <label>:100                                     ; preds = %97
+  %101 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %99, i32 0, i32 1
+  %102 = load i32, i32 addrspace(1)* %101
+  %103 = zext i32 %102 to i64
+  %104 = trunc i64 %103 to i32
+  %105 = icmp slt i32 %98, %104
+  br i1 %105, label %79, label %106
+
+; <label>:106                                     ; preds = %87, %100
+  %107 = load i32, i32* %loc4
+  %108 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck17 = icmp eq %"System.Char[]" addrspace(1)* %108, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %109
+
+; <label>:109                                     ; preds = %106
+  %110 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %108, i32 0, i32 1
+  %111 = load i32, i32 addrspace(1)* %110
+  %112 = zext i32 %111 to i64
+  %113 = trunc i64 %112 to i32
+  %114 = icmp eq i32 %107, %113
+  br i1 %114, label %122, label %115
+
+; <label>:115                                     ; preds = %109
+  %116 = load i32, i32* %loc0
+  %117 = sub i32 %116, 1
+  store i32 %117, i32* %loc0
+  br label %118
+
+; <label>:118                                     ; preds = %67, %115
+  %119 = load i32, i32* %loc0
+  %120 = load i32, i32* %loc1
+  %121 = icmp sge i32 %119, %120
+  br i1 %121, label %71, label %122
+
+; <label>:122                                     ; preds = %62, %109, %118
+  %123 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %124 = load i32, i32* %loc1
+  %125 = load i32, i32* %loc0
+  %126 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %123, i32 %124, i32 %125)
+  ret %System.String addrspace(1)* %126
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %97
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange22:                           ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
 Successfully read String.CreateTrimmedString
 
@@ -5439,8 +6893,8 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
@@ -5535,8 +6989,8 @@ entry:
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i64 2872
   %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
   %8 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %7
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %3
   %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
@@ -5553,8 +7007,8 @@ entry:
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 2864
   %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
   %21 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %20
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
-  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %22
 
 ; <label>:22                                      ; preds = %16
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
@@ -5569,7 +7023,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %16
+ThrowNullRef2:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5586,8 +7040,8 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5613,8 +7067,8 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
@@ -5632,8 +7086,8 @@ entry:
 
 ; <label>:12                                      ; preds = %4
   %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
@@ -5644,8 +7098,8 @@ entry:
 
 ; <label>:19                                      ; preds = %14
   %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %19
   %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
@@ -5660,21 +7114,21 @@ entry:
   %31 = zext i16 %30 to i32
   %32 = bitcast i8* %29 to i16*
   %33 = trunc i32 %31 to i16
-  %NullCheck6 = icmp ne i16* %32, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i16* %32, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %21
   store i16 %33, i16* %32, align 8
   %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %36
 
 ; <label>:36                                      ; preds = %34
   %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
   %38 = load i32, i32 addrspace(1)* %37, align 8
   %39 = add i32 %38, 1
-  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %40
 
 ; <label>:40                                      ; preds = %36
   %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
@@ -5683,16 +7137,16 @@ entry:
 
 ; <label>:42                                      ; preds = %14
   %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
-  br i1 %NullCheck12, label %44, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
   %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
   %47 = load i16, i16* %arg1
   %48 = zext i16 %47 to i32
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = trunc i32 %48 to i16
@@ -5703,31 +7157,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %19
+ThrowNullRef4:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %21
+ThrowNullRef6:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %36
+ThrowNullRef10:                                   ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %42
+ThrowNullRef12:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %44
+ThrowNullRef14:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5740,8 +7194,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -5752,8 +7206,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
@@ -5762,14 +7216,14 @@ entry:
 
 ; <label>:11                                      ; preds = %1
   %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
@@ -5779,15 +7233,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5808,8 +7262,8 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5822,8 +7276,8 @@ entry:
 
 ; <label>:8                                       ; preds = %3
   %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
@@ -5842,15 +7296,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
-  br i1 %NullCheck4, label %22, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
   %24 = load i16*, i16* addrspace(1)* %23, align 8
   %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %25, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
@@ -5859,8 +7313,8 @@ entry:
   store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
@@ -5874,8 +7328,8 @@ entry:
 
 ; <label>:37                                      ; preds = %65
   %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %37
   %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
@@ -5886,16 +7340,16 @@ entry:
   %45 = bitcast i16* %41 to i8*
   %46 = getelementptr inbounds i8, i8* %45, i64 %44
   %47 = bitcast i8* %46 to i16*
-  %NullCheck14 = icmp ne i16* %47, null
-  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %47, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %48
 
 ; <label>:48                                      ; preds = %39
   %49 = load i16, i16* %47, align 8
   %50 = zext i16 %49 to i32
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %52 = load i32, i32* %loc1
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %53
 
 ; <label>:53                                      ; preds = %48
   %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
@@ -5916,8 +7370,8 @@ entry:
 ; <label>:62                                      ; preds = %36, %59
   %63 = load i32, i32* %loc1
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck10, label %65, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %65
 
 ; <label>:65                                      ; preds = %62
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
@@ -5936,15 +7390,15 @@ entry:
 
 ; <label>:74                                      ; preds = %70
   %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
-  br i1 %NullCheck18, label %76, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %76
 
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
   %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
-  br i1 %NullCheck20, label %80, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
   %81 = load i64, i64 addrspace(1)* %79
@@ -5958,8 +7412,8 @@ entry:
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
   %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
-  br i1 %NullCheck22, label %92, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.String addrspace(1)* %90, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %92
 
 ; <label>:92                                      ; preds = %80
   %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
@@ -5969,15 +7423,15 @@ entry:
 
 ; <label>:96                                      ; preds = %70
   %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
-  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %98
 
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
   %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
-  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
   %103 = load i64, i64 addrspace(1)* %101
@@ -5991,8 +7445,8 @@ entry:
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
   %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
-  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.String addrspace(1)* %112, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %114
 
 ; <label>:114                                     ; preds = %102
   %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
@@ -6004,59 +7458,59 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %20
+ThrowNullRef4:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %22
+ThrowNullRef6:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %26
+ThrowNullRef8:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %62
+ThrowNullRef10:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %48
+ThrowNullRef16:                                   ; preds = %48
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %74
+ThrowNullRef18:                                   ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %76
+ThrowNullRef20:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %80
+ThrowNullRef22:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %96
+ThrowNullRef24:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %98
+ThrowNullRef26:                                   ; preds = %98
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %102
+ThrowNullRef28:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6069,15 +7523,15 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
   %3 = load i16*, i16* addrspace(1)* %2, align 8
   %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
@@ -6087,8 +7541,8 @@ entry:
   %10 = bitcast i16* %3 to i8*
   %11 = getelementptr inbounds i8, i8* %10, i64 %9
   %12 = bitcast i8* %11 to i16*
-  %NullCheck4 = icmp ne i16* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %5
   store i16 0, i16* %12, align 8
@@ -6098,11 +7552,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6119,8 +7573,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -6131,8 +7585,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
@@ -6144,15 +7598,15 @@ entry:
 
 ; <label>:14                                      ; preds = %1
   %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
   %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
   %21 = load i64, i64 addrspace(1)* %19
@@ -6171,15 +7625,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %14
+ThrowNullRef4:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %16
+ThrowNullRef6:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6302,14 +7756,6 @@ entry:
   ret %System.String addrspace(1)* %57
 }
 
-INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
-Successfully read RuntimeHelpers.get_OffsetToStringData
-
-define i32 @RuntimeHelpers.get_OffsetToStringData() {
-entry:
-  ret i32 12
-}
-
 INFO:  jitting method String::Equals using LLILCJit
 Successfully read String.Equals
 
@@ -6381,8 +7827,8 @@ entry:
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
-  br i1 %NullCheck24, label %29, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
   %30 = load i64, i64 addrspace(1)* %28
@@ -6397,8 +7843,8 @@ entry:
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
-  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
   %43 = load i64, i64 addrspace(1)* %41
@@ -6418,8 +7864,8 @@ entry:
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
   %59 = load i64, i64 addrspace(1)* %57
@@ -6434,8 +7880,8 @@ entry:
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck22, label %71, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
   %72 = load i64, i64 addrspace(1)* %70
@@ -6455,8 +7901,8 @@ entry:
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
-  br i1 %NullCheck16, label %87, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = load i64, i64 addrspace(1)* %86
@@ -6471,8 +7917,8 @@ entry:
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck18, label %100, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
   %101 = load i64, i64 addrspace(1)* %99
@@ -6492,8 +7938,8 @@ entry:
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
-  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
   %117 = load i64, i64 addrspace(1)* %115
@@ -6508,8 +7954,8 @@ entry:
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
-  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
   %130 = load i64, i64 addrspace(1)* %128
@@ -6528,15 +7974,15 @@ entry:
 
 ; <label>:142                                     ; preds = %22
   %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
-  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %143, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %144
 
 ; <label>:144                                     ; preds = %142
   %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
   %146 = load i32, i32 addrspace(1)* %145
   %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
-  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %147, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %148
 
 ; <label>:148                                     ; preds = %144
   %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
@@ -6557,15 +8003,15 @@ entry:
 
 ; <label>:159                                     ; preds = %22
   %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
-  br i1 %NullCheck, label %161, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %ThrowNullRef, label %161
 
 ; <label>:161                                     ; preds = %159
   %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
   %163 = load i32, i32 addrspace(1)* %162
   %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
-  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %164, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %165
 
 ; <label>:165                                     ; preds = %161
   %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
@@ -6578,8 +8024,8 @@ entry:
 
 ; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
-  br i1 %NullCheck4, label %172, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %171, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %172
 
 ; <label>:172                                     ; preds = %170
   %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
@@ -6589,8 +8035,8 @@ entry:
 
 ; <label>:176                                     ; preds = %172
   %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
-  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %177, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %178
 
 ; <label>:178                                     ; preds = %176
   %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
@@ -6629,55 +8075,55 @@ ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %161
+ThrowNullRef2:                                    ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %170
+ThrowNullRef4:                                    ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %176
+ThrowNullRef6:                                    ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %142
+ThrowNullRef8:                                    ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %144
+ThrowNullRef10:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %113
+ThrowNullRef12:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %116
+ThrowNullRef14:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %84
+ThrowNullRef16:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %87
+ThrowNullRef18:                                   ; preds = %87
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %55
+ThrowNullRef20:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %58
+ThrowNullRef22:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %26
+ThrowNullRef24:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %29
+ThrowNullRef26:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,8 +8161,8 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck, label %14, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %ThrowNullRef, label %14
 
 ; <label>:14                                      ; preds = %8
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
@@ -6760,8 +8206,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
@@ -6770,14 +8216,14 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32, i32* %loc0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %10
   %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
   %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
@@ -6790,15 +8236,15 @@ entry:
 ; <label>:25                                      ; preds = %19
   %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
-  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
   %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
@@ -6807,8 +8253,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %37 = load i32, i32* %loc0
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %38, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %38
 
 ; <label>:38                                      ; preds = %32
   %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
@@ -6817,14 +8263,14 @@ entry:
 
 ; <label>:40                                      ; preds = %19
   %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %40
   %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
   %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
-  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
-  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
@@ -6832,8 +8278,8 @@ entry:
   %48 = zext i32 %47 to i64
   %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
-  br i1 %NullCheck16, label %51, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %51
 
 ; <label>:51                                      ; preds = %45
   %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
@@ -6847,15 +8293,15 @@ entry:
 ; <label>:57                                      ; preds = %51
   %58 = load i16*, i16** %arg1
   %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
-  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %60
 
 ; <label>:60                                      ; preds = %57
   %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
   %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
-  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %64
 
 ; <label>:64                                      ; preds = %60
   %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
@@ -6864,22 +8310,22 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
   %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
-  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %70
 
 ; <label>:70                                      ; preds = %64
   %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
   %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
-  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
-  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
   %75 = load i32, i32 addrspace(1)* %74
   %76 = zext i32 %75 to i64
   %77 = trunc i64 %76 to i32
-  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
-  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %78
 
 ; <label>:78                                      ; preds = %73
   %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
@@ -6901,8 +8347,8 @@ entry:
   %90 = bitcast i16* %86 to i8*
   %91 = getelementptr inbounds i8, i8* %90, i64 %89
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %93
 
 ; <label>:93                                      ; preds = %80
   %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
@@ -6912,8 +8358,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %99 = load i32, i32* %loc2
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %100
 
 ; <label>:100                                     ; preds = %93
   %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
@@ -6928,63 +8374,63 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %25
+ThrowNullRef6:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %32
+ThrowNullRef10:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %40
+ThrowNullRef12:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %45
+ThrowNullRef16:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %57
+ThrowNullRef18:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %60
+ThrowNullRef20:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %64
+ThrowNullRef22:                                   ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %70
+ThrowNullRef24:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %73
+ThrowNullRef26:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %80
+ThrowNullRef28:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %93
+ThrowNullRef30:                                   ; preds = %93
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7004,8 +8450,8 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
@@ -7033,43 +8479,43 @@ entry:
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %14
   %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
   %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   %28 = load i32, i32 addrspace(1)* %27, align 8
   %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
-  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %30
 
 ; <label>:30                                      ; preds = %26
   %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
   %32 = load i32, i32 addrspace(1)* %31, align 8
   %33 = add i32 %28, %32
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %34
 
 ; <label>:34                                      ; preds = %30
   %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   store i32 %33, i32 addrspace(1)* %35
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
   store i32 0, i32 addrspace(1)* %38
   %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %40
 
 ; <label>:40                                      ; preds = %37
   %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
@@ -7082,8 +8528,8 @@ entry:
 
 ; <label>:47                                      ; preds = %40
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
@@ -7098,8 +8544,8 @@ entry:
   %54 = load i32, i32* %loc0
   %55 = sext i32 %54 to i64
   %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
-  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %57
 
 ; <label>:57                                      ; preds = %52
   %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
@@ -7110,68 +8556,35 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %14
+ThrowNullRef2:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %23
+ThrowNullRef4:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %26
+ThrowNullRef6:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %30
+ThrowNullRef8:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %34
+ThrowNullRef10:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %47
+ThrowNullRef14:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %52
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-}
-
-INFO:  jitting method StringBuilder::get_Length using LLILCJit
-Successfully read StringBuilder.get_Length
-
-define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.StringBuilder addrspace(1)*
-  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
-  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
-
-; <label>:1                                       ; preds = %entry
-  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %3 = load i32, i32 addrspace(1)* %2, align 8
-  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
-
-; <label>:5                                       ; preds = %1
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = add i32 %3, %7
-  ret i32 %8
-
-ThrowNullRef:                                     ; preds = %entry
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef16:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7213,70 +8626,70 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
   %6 = load i32, i32 addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
   store i32 %6, i32 addrspace(1)* %8
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
   %13 = load i32, i32 addrspace(1)* %12, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
   store i32 %13, i32 addrspace(1)* %15
   %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
-  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %18
 
 ; <label>:18                                      ; preds = %14
   %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
   %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
   %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
   %34 = load i32, i32 addrspace(1)* %33, align 8
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
-  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
@@ -7287,39 +8700,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %28
+ThrowNullRef16:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %32
+ThrowNullRef18:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7455,13 +8868,13 @@ entry:
 ; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
@@ -7477,16 +8890,16 @@ entry:
 
 ; <label>:18                                      ; preds = %15
   %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
   store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
   %22 = load i32, i32* %loc0
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %24
 
 ; <label>:24                                      ; preds = %20
   %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
@@ -7498,13 +8911,13 @@ entry:
 ; <label>:28                                      ; preds = %15, %24
   %29 = load i32, i32* %arg1
   %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %31
   %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
@@ -7517,20 +8930,20 @@ entry:
   %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
-  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
   %46 = load i32, i32 addrspace(1)* %45, align 8
   %47 = sub i32 %40, %46
-  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
-  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i32 addrspace(1)* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %48
 
 ; <label>:48                                      ; preds = %44
   store i32 %47, i32 addrspace(1)* %39, align 8
@@ -7538,21 +8951,21 @@ entry:
 
 ; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
-  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %51
 
 ; <label>:51                                      ; preds = %49
   %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %53
 
 ; <label>:53                                      ; preds = %51
   %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
   %55 = load i32, i32 addrspace(1)* %54, align 8
   %56 = load i32, i32* %arg2
   %57 = sub i32 %55, %56
-  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %58
 
 ; <label>:58                                      ; preds = %53
   %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
@@ -7562,13 +8975,13 @@ entry:
 ; <label>:60                                      ; preds = %33, %58
   %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
   %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
-  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %63
 
 ; <label>:63                                      ; preds = %60
   %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
-  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
-  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
@@ -7578,15 +8991,15 @@ entry:
 
 ; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
-  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i32 addrspace(1)* %69, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %70
 
 ; <label>:70                                      ; preds = %68
   %71 = load i32, i32 addrspace(1)* %69, align 8
   store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
-  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
@@ -7596,8 +9009,8 @@ entry:
   store i32 %77, i32* %loc4
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
-  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %80
 
 ; <label>:80                                      ; preds = %73
   %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
@@ -7607,71 +9020,71 @@ entry:
 ; <label>:83                                      ; preds = %80
   store i32 0, i32* %loc3
   %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
-  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
-  br i1 %NullCheck26, label %88, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i32 addrspace(1)* %87, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %88
 
 ; <label>:88                                      ; preds = %85
   %89 = load i32, i32 addrspace(1)* %87, align 8
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
-  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %90
 
 ; <label>:90                                      ; preds = %88
   %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
   store i32 %89, i32 addrspace(1)* %91
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
-  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
-  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %96
 
 ; <label>:96                                      ; preds = %94
   %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
-  br i1 %NullCheck34, label %100, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %100
 
 ; <label>:100                                     ; preds = %96
   %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
-  br i1 %NullCheck36, label %102, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %102
 
 ; <label>:102                                     ; preds = %100
   %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
   %104 = load i32, i32 addrspace(1)* %103, align 8
   %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
-  br i1 %NullCheck38, label %106, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %106
 
 ; <label>:106                                     ; preds = %102
   %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
-  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
-  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %108
 
 ; <label>:108                                     ; preds = %106
   %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
   %110 = load i32, i32 addrspace(1)* %109, align 8
   %111 = add i32 %104, %110
-  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %112
 
 ; <label>:112                                     ; preds = %108
   %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
   store i32 %111, i32 addrspace(1)* %113
   %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
-  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i32 addrspace(1)* %114, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %115
 
 ; <label>:115                                     ; preds = %112
   %116 = load i32, i32 addrspace(1)* %114, align 8
@@ -7681,19 +9094,19 @@ entry:
 ; <label>:118                                     ; preds = %115
   %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
-  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %121
 
 ; <label>:121                                     ; preds = %118
   %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
-  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
-  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %123
 
 ; <label>:123                                     ; preds = %121
   %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
   %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
-  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
-  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %126
 
 ; <label>:126                                     ; preds = %123
   %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
@@ -7705,8 +9118,8 @@ entry:
 
 ; <label>:130                                     ; preds = %80, %115, %126
   %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %132
 
 ; <label>:132                                     ; preds = %130
   %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7715,8 +9128,8 @@ entry:
   %136 = load i32, i32* %loc3
   %137 = sub i32 %135, %136
   %138 = sub i32 %134, %137
-  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %139
 
 ; <label>:139                                     ; preds = %132
   %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7728,16 +9141,16 @@ entry:
 
 ; <label>:144                                     ; preds = %139
   %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
-  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %146
 
 ; <label>:146                                     ; preds = %144
   %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
   %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
   %149 = load i32, i32* %loc2
   %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
-  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %151
 
 ; <label>:151                                     ; preds = %146
   %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
@@ -7754,145 +9167,249 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %18
+ThrowNullRef4:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %31
+ThrowNullRef10:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %44
+ThrowNullRef16:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %68
+ThrowNullRef18:                                   ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %70
+ThrowNullRef20:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %73
+ThrowNullRef22:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %83
+ThrowNullRef24:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %85
+ThrowNullRef26:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %88
+ThrowNullRef28:                                   ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %90
+ThrowNullRef30:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %94
+ThrowNullRef32:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %96
+ThrowNullRef34:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %100
+ThrowNullRef36:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %102
+ThrowNullRef38:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %106
+ThrowNullRef40:                                   ; preds = %106
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %108
+ThrowNullRef42:                                   ; preds = %108
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %112
+ThrowNullRef44:                                   ; preds = %112
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %118
+ThrowNullRef46:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %121
+ThrowNullRef48:                                   ; preds = %121
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %123
+ThrowNullRef50:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %130
+ThrowNullRef52:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %132
+ThrowNullRef54:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %144
+ThrowNullRef56:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %146
+ThrowNullRef58:                                   ; preds = %146
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %60
+ThrowNullRef60:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %63
+ThrowNullRef62:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %49
+ThrowNullRef64:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %51
+ThrowNullRef66:                                   ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %53
+ThrowNullRef68:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(%"System.Char[]" addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %arg0 = alloca %"System.Char[]" addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store %"System.Char[]" addrspace(1)* %param0, %"System.Char[]" addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load i32, i32* %arg4
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %43, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %38, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg1
+  %13 = load i32, i32* %arg4
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %38, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %24 = load i32, i32* %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %35 = load i32, i32* %arg3
+  %36 = load i32, i32* %arg4
+  %37 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %37, %"System.Char[]" addrspace(1)* %34, i32 %35, i32 %36)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:38                                      ; preds = %5, %16
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Successfully read Buffer._Memmove
 
@@ -7914,7 +9431,7 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[loadElem]
+Failed to read AppDomain.SetDataHelper[storeElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -7923,8 +9440,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
@@ -7934,8 +9451,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
@@ -7947,15 +9464,15 @@ entry:
   %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
   %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
@@ -7966,15 +9483,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7992,7 +9509,79 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
-Failed to read Dictionary`2.TryGetValue[loadElemA]
+Successfully read Dictionary`2.TryGetValue
+
+define i8 @"Dictionary`2.TryGetValue"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)* addrspace(1)* %param2) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  %arg2 = alloca %System.__Canon addrspace(1)* addrspace(1)*
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  store %System.__Canon addrspace(1)* addrspace(1)* %param2, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  store i32 %2, i32* %loc0
+  %3 = load i32, i32* %loc0
+  %4 = icmp slt i32 %3, 0
+  br i1 %4, label %22, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 2
+  %10 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %9, align 8
+  %11 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = zext i32 %11 to i64
+  %BoundsCheck = icmp uge i64 %16, %15
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 3, i32 %11
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %20, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %6, %System.__Canon addrspace(1)* %21)
+  ret i8 1
+
+; <label>:22                                      ; preds = %entry
+  %23 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %23, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -8058,8 +9647,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
@@ -8091,8 +9680,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
@@ -8171,15 +9760,15 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck, label %19, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %ThrowNullRef, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
   %21 = load i32, i32 addrspace(1)* %20
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
@@ -8202,7 +9791,7 @@ ThrowNullRef:                                     ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %19
+ThrowNullRef2:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8248,8 +9837,8 @@ entry:
   %0 = alloca %System.AppDomainHandle
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %1 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %1, i32 0, i32 15
@@ -8269,8 +9858,8 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
@@ -8286,7 +9875,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -8299,8 +9888,8 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -8327,8 +9916,8 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
@@ -8352,8 +9941,8 @@ entry:
   %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
   store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
@@ -8363,8 +9952,8 @@ entry:
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
@@ -8374,8 +9963,8 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %9
   %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
@@ -8384,8 +9973,8 @@ entry:
 
 ; <label>:18                                      ; preds = %3, %16
   %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
@@ -8397,15 +9986,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %18
+ThrowNullRef6:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8418,8 +10007,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
@@ -8453,15 +10042,15 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
@@ -8473,7 +10062,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8481,7 +10070,7 @@ ThrowNullRef1:                                    ; preds = %1
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
 Failed to read Dictionary`2.System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
@@ -8506,8 +10095,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
@@ -8524,8 +10113,8 @@ entry:
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -8544,7 +10133,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8577,8 +10166,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = load i64, i64* %arg2
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = trunc i32 %3 to i8
@@ -8634,46 +10223,46 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
   %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
-  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
-  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
-  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
@@ -8684,27 +10273,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %20
+ThrowNullRef12:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8717,8 +10306,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -8756,22 +10345,22 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
   %9 = load i64, i64 addrspace(1)* %8, align 8
   %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
   %13 = load i64, i64 addrspace(1)* %12, align 8
   %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %11
   %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
@@ -8788,11 +10377,11 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8882,8 +10471,8 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
@@ -8900,8 +10489,8 @@ entry:
 ; <label>:8                                       ; preds = %1
   %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
   %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
@@ -8911,15 +10500,15 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
   %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
   %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
-  br i1 %NullCheck6, label %21, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
@@ -8946,15 +10535,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8992,15 +10581,15 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
   store i8 %3, i8 addrspace(1)* %5
   %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
@@ -9011,7 +10600,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9027,8 +10616,8 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -9041,8 +10630,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
@@ -9058,7 +10647,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9080,8 +10669,8 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
@@ -9096,8 +10685,8 @@ entry:
 ; <label>:12                                      ; preds = %6
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
@@ -9112,8 +10701,8 @@ entry:
 ; <label>:21                                      ; preds = %15
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
@@ -9128,8 +10717,8 @@ entry:
 ; <label>:30                                      ; preds = %24
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %31, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
@@ -9144,8 +10733,8 @@ entry:
 ; <label>:39                                      ; preds = %33
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
-  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %40, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %42
 
 ; <label>:42                                      ; preds = %39
   %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
@@ -9164,19 +10753,19 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %21
+ThrowNullRef4:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %30
+ThrowNullRef6:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %39
+ThrowNullRef8:                                    ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9243,8 +10832,8 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
@@ -9264,57 +10853,57 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
   store i8 0, i8 addrspace(1)* %2
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
   store i8 0, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
   store i8 0, i8 addrspace(1)* %17
   %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
   store i8 0, i8 addrspace(1)* %20
   %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
-  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
@@ -9325,31 +10914,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %19
+ThrowNullRef14:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9367,8 +10956,8 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
@@ -9380,8 +10969,8 @@ entry:
 
 ; <label>:9                                       ; preds = %4
   %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %9
   %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
@@ -9395,7 +10984,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef2:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9420,8 +11009,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
@@ -9512,8 +11101,8 @@ entry:
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
@@ -9524,8 +11113,8 @@ entry:
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = load i64, i64 addrspace(1)* %12
@@ -9537,8 +11126,8 @@ entry:
   %20 = load i64, i64* %19
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
-  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %13
   %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
@@ -9555,8 +11144,8 @@ entry:
 ; <label>:30                                      ; preds = %25
   %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %32 = load i32, i32* %arg2
-  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
-  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
@@ -9570,15 +11159,15 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %30
+ThrowNullRef2:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9622,87 +11211,87 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
   %10 = load i8, i8 addrspace(1)* %9, align 8
   %11 = zext i8 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %8
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
   store i8 %12, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
   %19 = load i8, i8 addrspace(1)* %18, align 8
   %20 = zext i8 %19 to i32
   %21 = trunc i32 %20 to i8
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
   store i8 %21, i8 addrspace(1)* %23
   %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
   %28 = load i8, i8 addrspace(1)* %27, align 8
   %29 = zext i8 %28 to i32
   %30 = trunc i32 %29 to i8
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
-  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %31
 
 ; <label>:31                                      ; preds = %26
   %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
   store i8 %30, i8 addrspace(1)* %32
   %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
-  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
-  br i1 %NullCheck14, label %40, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %40
 
 ; <label>:40                                      ; preds = %35
   %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
   store i8 %39, i8 addrspace(1)* %41
   %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
-  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %44
 
 ; <label>:44                                      ; preds = %40
   %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
   %46 = load i8, i8 addrspace(1)* %45, align 8
   %47 = zext i8 %46 to i32
   %48 = trunc i32 %47 to i8
-  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
   store i8 %48, i8 addrspace(1)* %50
   %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
-  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
@@ -9713,29 +11302,29 @@ entry:
 ; <label>:56                                      ; preds = %52
   %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
-  br i1 %NullCheck22, label %59, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
   %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
   %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
-  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
-  br i1 %NullCheck24, label %63, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
   %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
-  br i1 %NullCheck26, label %66, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
   %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
-  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
-  br i1 %NullCheck28, label %69, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %69
 
 ; <label>:69                                      ; preds = %66
   %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
@@ -9744,15 +11333,15 @@ entry:
 
 ; <label>:71                                      ; preds = %105
   %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
-  br i1 %NullCheck34, label %73, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %73
 
 ; <label>:73                                      ; preds = %71
   %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
   %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
   %76 = load i32, i32* %loc0
-  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
-  br i1 %NullCheck36, label %77, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
@@ -9766,8 +11355,8 @@ entry:
 
 ; <label>:83                                      ; preds = %77
   %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
-  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
@@ -9775,14 +11364,14 @@ entry:
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
   %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
-  br i1 %NullCheck40, label %91, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
 ; <label>:91                                      ; preds = %85
   %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
   %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
-  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck42, label %94, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %94
 
 ; <label>:94                                      ; preds = %91
   %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
@@ -9798,14 +11387,14 @@ entry:
 ; <label>:99                                      ; preds = %69, %96
   %100 = load i32, i32* %loc0
   %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
-  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %102
 
 ; <label>:102                                     ; preds = %99
   %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
   %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
-  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
-  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
@@ -9819,87 +11408,87 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %26
+ThrowNullRef10:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %31
+ThrowNullRef12:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %35
+ThrowNullRef14:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %40
+ThrowNullRef16:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %56
+ThrowNullRef22:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %59
+ThrowNullRef24:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %63
+ThrowNullRef26:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %66
+ThrowNullRef28:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %102
+ThrowNullRef32:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %71
+ThrowNullRef34:                                   ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %73
+ThrowNullRef36:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %83
+ThrowNullRef38:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %85
+ThrowNullRef40:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %91
+ThrowNullRef42:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9943,15 +11532,15 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
   %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
@@ -9961,28 +11550,28 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
   %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %12
   %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
   %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
   %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
-  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
@@ -9993,23 +11582,23 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %12
+ThrowNullRef6:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10031,15 +11620,15 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
   %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = load i64, i64 addrspace(1)* %7
@@ -10077,13 +11666,13 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[loadElem]
+Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -10111,8 +11700,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueGtFP.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueGtFP.error.txt
@@ -25,8 +25,8 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
@@ -40,8 +40,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
   %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
@@ -75,7 +75,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -90,8 +90,8 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %NullCheck = icmp ne i8 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = load i8, i8 addrspace(1)* %0, align 8
@@ -125,8 +125,8 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
@@ -159,8 +159,8 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -184,8 +184,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
   store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
@@ -195,8 +195,8 @@ entry:
 ; <label>:4                                       ; preds = %1
   %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
   %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
@@ -206,8 +206,8 @@ entry:
   %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
@@ -221,14 +221,14 @@ entry:
 
 ; <label>:17                                      ; preds = %14
   %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
   %21 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
@@ -238,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -249,8 +249,8 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
@@ -261,27 +261,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %30
+ThrowNullRef10:                                   ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -301,7 +301,89 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
-Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
+Successfully read AppDomainSetup.GetUnsecureApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.GetUnsecureApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %NullCheck = icmp eq %"System.String[]" addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %BoundsCheck = icmp uge i64 0, %5
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %6
+
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 3, i32 0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
+  ret %System.String addrspace(1)* %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_Value using LLILCJit
+Successfully read AppDomainSetup.get_Value
+
+define %"System.String[]" addrspace(1)* @AppDomainSetup.get_Value(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.String[]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 18)
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.String[]" addrspace(1)* addrspace(1)*, %"System.String[]" addrspace(1)*)*)(%"System.String[]" addrspace(1)* addrspace(1)* %9, %"System.String[]" addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %11, i32 0, i32 1
+  %14 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %13, align 8
+  ret %"System.String[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -319,8 +401,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -368,16 +450,16 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
   %5 = load i32, i32 addrspace(1)* %4
   %6 = sub i32 %5, 1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -389,7 +471,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -421,8 +503,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
@@ -456,8 +538,8 @@ entry:
 ; <label>:27                                      ; preds = %19
   %28 = load i32, i32* %arg1
   %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
-  br i1 %NullCheck2, label %30, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %29, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %30
 
 ; <label>:30                                      ; preds = %27
   %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
@@ -493,8 +575,8 @@ entry:
 ; <label>:49                                      ; preds = %46
   %50 = load i32, i32* %arg2
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck4, label %52, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
@@ -517,11 +599,11 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %27
+ThrowNullRef2:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %49
+ThrowNullRef4:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -544,16 +626,16 @@ entry:
   %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %0)
   store %System.String addrspace(1)* %1, %System.String addrspace(1)** %loc0
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 2
   %5 = bitcast [0 x i16] addrspace(1)* %4 to i16 addrspace(1)*
   store i16 addrspace(1)* %5, i16 addrspace(1)** %loc1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %3
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2
@@ -580,7 +662,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -691,15 +773,15 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %NullCheck132 = icmp ne i8* %21, null
-  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+  %NullCheck131 = icmp eq i8* %21, null
+  br i1 %NullCheck131, label %ThrowNullRef132, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = load i8, i8* %21, align 8
   %24 = zext i8 %23 to i32
   %25 = trunc i32 %24 to i8
-  %NullCheck134 = icmp ne i8* %20, null
-  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+  %NullCheck133 = icmp eq i8* %20, null
+  br i1 %NullCheck133, label %ThrowNullRef134, label %26
 
 ; <label>:26                                      ; preds = %22
   store i8 %25, i8* %20, align 8
@@ -709,16 +791,16 @@ entry:
   %28 = load i8*, i8** %arg0
   %29 = load i8*, i8** %arg1
   %30 = bitcast i8* %29 to i16*
-  %NullCheck128 = icmp ne i16* %30, null
-  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+  %NullCheck127 = icmp eq i16* %30, null
+  br i1 %NullCheck127, label %ThrowNullRef128, label %31
 
 ; <label>:31                                      ; preds = %27
   %32 = load i16, i16* %30, align 8
   %33 = sext i16 %32 to i32
   %34 = bitcast i8* %28 to i16*
   %35 = trunc i32 %33 to i16
-  %NullCheck130 = icmp ne i16* %34, null
-  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+  %NullCheck129 = icmp eq i16* %34, null
+  br i1 %NullCheck129, label %ThrowNullRef130, label %36
 
 ; <label>:36                                      ; preds = %31
   store i16 %35, i16* %34, align 8
@@ -728,16 +810,16 @@ entry:
   %38 = load i8*, i8** %arg0
   %39 = load i8*, i8** %arg1
   %40 = bitcast i8* %39 to i16*
-  %NullCheck120 = icmp ne i16* %40, null
-  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+  %NullCheck119 = icmp eq i16* %40, null
+  br i1 %NullCheck119, label %ThrowNullRef120, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i16, i16* %40, align 8
   %43 = sext i16 %42 to i32
   %44 = bitcast i8* %38 to i16*
   %45 = trunc i32 %43 to i16
-  %NullCheck122 = icmp ne i16* %44, null
-  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+  %NullCheck121 = icmp eq i16* %44, null
+  br i1 %NullCheck121, label %ThrowNullRef122, label %46
 
 ; <label>:46                                      ; preds = %41
   store i16 %45, i16* %44, align 8
@@ -745,15 +827,15 @@ entry:
   %48 = getelementptr inbounds i8, i8* %47, i64 2
   %49 = load i8*, i8** %arg1
   %50 = getelementptr inbounds i8, i8* %49, i64 2
-  %NullCheck124 = icmp ne i8* %50, null
-  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+  %NullCheck123 = icmp eq i8* %50, null
+  br i1 %NullCheck123, label %ThrowNullRef124, label %51
 
 ; <label>:51                                      ; preds = %46
   %52 = load i8, i8* %50, align 8
   %53 = zext i8 %52 to i32
   %54 = trunc i32 %53 to i8
-  %NullCheck126 = icmp ne i8* %48, null
-  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+  %NullCheck125 = icmp eq i8* %48, null
+  br i1 %NullCheck125, label %ThrowNullRef126, label %55
 
 ; <label>:55                                      ; preds = %51
   store i8 %54, i8* %48, align 8
@@ -763,14 +845,14 @@ entry:
   %57 = load i8*, i8** %arg0
   %58 = load i8*, i8** %arg1
   %59 = bitcast i8* %58 to i32*
-  %NullCheck116 = icmp ne i32* %59, null
-  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+  %NullCheck115 = icmp eq i32* %59, null
+  br i1 %NullCheck115, label %ThrowNullRef116, label %60
 
 ; <label>:60                                      ; preds = %56
   %61 = load i32, i32* %59, align 8
   %62 = bitcast i8* %57 to i32*
-  %NullCheck118 = icmp ne i32* %62, null
-  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+  %NullCheck117 = icmp eq i32* %62, null
+  br i1 %NullCheck117, label %ThrowNullRef118, label %63
 
 ; <label>:63                                      ; preds = %60
   store i32 %61, i32* %62, align 8
@@ -780,14 +862,14 @@ entry:
   %65 = load i8*, i8** %arg0
   %66 = load i8*, i8** %arg1
   %67 = bitcast i8* %66 to i32*
-  %NullCheck108 = icmp ne i32* %67, null
-  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+  %NullCheck107 = icmp eq i32* %67, null
+  br i1 %NullCheck107, label %ThrowNullRef108, label %68
 
 ; <label>:68                                      ; preds = %64
   %69 = load i32, i32* %67, align 8
   %70 = bitcast i8* %65 to i32*
-  %NullCheck110 = icmp ne i32* %70, null
-  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+  %NullCheck109 = icmp eq i32* %70, null
+  br i1 %NullCheck109, label %ThrowNullRef110, label %71
 
 ; <label>:71                                      ; preds = %68
   store i32 %69, i32* %70, align 8
@@ -795,15 +877,15 @@ entry:
   %73 = getelementptr inbounds i8, i8* %72, i64 4
   %74 = load i8*, i8** %arg1
   %75 = getelementptr inbounds i8, i8* %74, i64 4
-  %NullCheck112 = icmp ne i8* %75, null
-  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+  %NullCheck111 = icmp eq i8* %75, null
+  br i1 %NullCheck111, label %ThrowNullRef112, label %76
 
 ; <label>:76                                      ; preds = %71
   %77 = load i8, i8* %75, align 8
   %78 = zext i8 %77 to i32
   %79 = trunc i32 %78 to i8
-  %NullCheck114 = icmp ne i8* %73, null
-  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+  %NullCheck113 = icmp eq i8* %73, null
+  br i1 %NullCheck113, label %ThrowNullRef114, label %80
 
 ; <label>:80                                      ; preds = %76
   store i8 %79, i8* %73, align 8
@@ -813,14 +895,14 @@ entry:
   %82 = load i8*, i8** %arg0
   %83 = load i8*, i8** %arg1
   %84 = bitcast i8* %83 to i32*
-  %NullCheck100 = icmp ne i32* %84, null
-  br i1 %NullCheck100, label %85, label %ThrowNullRef99
+  %NullCheck99 = icmp eq i32* %84, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %85
 
 ; <label>:85                                      ; preds = %81
   %86 = load i32, i32* %84, align 8
   %87 = bitcast i8* %82 to i32*
-  %NullCheck102 = icmp ne i32* %87, null
-  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+  %NullCheck101 = icmp eq i32* %87, null
+  br i1 %NullCheck101, label %ThrowNullRef102, label %88
 
 ; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
@@ -829,16 +911,16 @@ entry:
   %91 = load i8*, i8** %arg1
   %92 = getelementptr inbounds i8, i8* %91, i64 4
   %93 = bitcast i8* %92 to i16*
-  %NullCheck104 = icmp ne i16* %93, null
-  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+  %NullCheck103 = icmp eq i16* %93, null
+  br i1 %NullCheck103, label %ThrowNullRef104, label %94
 
 ; <label>:94                                      ; preds = %88
   %95 = load i16, i16* %93, align 8
   %96 = sext i16 %95 to i32
   %97 = bitcast i8* %90 to i16*
   %98 = trunc i32 %96 to i16
-  %NullCheck106 = icmp ne i16* %97, null
-  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+  %NullCheck105 = icmp eq i16* %97, null
+  br i1 %NullCheck105, label %ThrowNullRef106, label %99
 
 ; <label>:99                                      ; preds = %94
   store i16 %98, i16* %97, align 8
@@ -848,14 +930,14 @@ entry:
   %101 = load i8*, i8** %arg0
   %102 = load i8*, i8** %arg1
   %103 = bitcast i8* %102 to i32*
-  %NullCheck88 = icmp ne i32* %103, null
-  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+  %NullCheck87 = icmp eq i32* %103, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %104
 
 ; <label>:104                                     ; preds = %100
   %105 = load i32, i32* %103, align 8
   %106 = bitcast i8* %101 to i32*
-  %NullCheck90 = icmp ne i32* %106, null
-  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+  %NullCheck89 = icmp eq i32* %106, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %107
 
 ; <label>:107                                     ; preds = %104
   store i32 %105, i32* %106, align 8
@@ -864,16 +946,16 @@ entry:
   %110 = load i8*, i8** %arg1
   %111 = getelementptr inbounds i8, i8* %110, i64 4
   %112 = bitcast i8* %111 to i16*
-  %NullCheck92 = icmp ne i16* %112, null
-  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+  %NullCheck91 = icmp eq i16* %112, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %113
 
 ; <label>:113                                     ; preds = %107
   %114 = load i16, i16* %112, align 8
   %115 = sext i16 %114 to i32
   %116 = bitcast i8* %109 to i16*
   %117 = trunc i32 %115 to i16
-  %NullCheck94 = icmp ne i16* %116, null
-  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+  %NullCheck93 = icmp eq i16* %116, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %118
 
 ; <label>:118                                     ; preds = %113
   store i16 %117, i16* %116, align 8
@@ -881,15 +963,15 @@ entry:
   %120 = getelementptr inbounds i8, i8* %119, i64 6
   %121 = load i8*, i8** %arg1
   %122 = getelementptr inbounds i8, i8* %121, i64 6
-  %NullCheck96 = icmp ne i8* %122, null
-  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+  %NullCheck95 = icmp eq i8* %122, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %123
 
 ; <label>:123                                     ; preds = %118
   %124 = load i8, i8* %122, align 8
   %125 = zext i8 %124 to i32
   %126 = trunc i32 %125 to i8
-  %NullCheck98 = icmp ne i8* %120, null
-  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+  %NullCheck97 = icmp eq i8* %120, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %127
 
 ; <label>:127                                     ; preds = %123
   store i8 %126, i8* %120, align 8
@@ -899,14 +981,14 @@ entry:
   %129 = load i8*, i8** %arg0
   %130 = load i8*, i8** %arg1
   %131 = bitcast i8* %130 to i64*
-  %NullCheck84 = icmp ne i64* %131, null
-  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+  %NullCheck83 = icmp eq i64* %131, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %132
 
 ; <label>:132                                     ; preds = %128
   %133 = load i64, i64* %131, align 8
   %134 = bitcast i8* %129 to i64*
-  %NullCheck86 = icmp ne i64* %134, null
-  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+  %NullCheck85 = icmp eq i64* %134, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %135
 
 ; <label>:135                                     ; preds = %132
   store i64 %133, i64* %134, align 8
@@ -916,14 +998,14 @@ entry:
   %137 = load i8*, i8** %arg0
   %138 = load i8*, i8** %arg1
   %139 = bitcast i8* %138 to i64*
-  %NullCheck76 = icmp ne i64* %139, null
-  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+  %NullCheck75 = icmp eq i64* %139, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %140
 
 ; <label>:140                                     ; preds = %136
   %141 = load i64, i64* %139, align 8
   %142 = bitcast i8* %137 to i64*
-  %NullCheck78 = icmp ne i64* %142, null
-  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+  %NullCheck77 = icmp eq i64* %142, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %143
 
 ; <label>:143                                     ; preds = %140
   store i64 %141, i64* %142, align 8
@@ -931,15 +1013,15 @@ entry:
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %NullCheck80 = icmp ne i8* %147, null
-  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+  %NullCheck79 = icmp eq i8* %147, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %148
 
 ; <label>:148                                     ; preds = %143
   %149 = load i8, i8* %147, align 8
   %150 = zext i8 %149 to i32
   %151 = trunc i32 %150 to i8
-  %NullCheck82 = icmp ne i8* %145, null
-  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+  %NullCheck81 = icmp eq i8* %145, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %152
 
 ; <label>:152                                     ; preds = %148
   store i8 %151, i8* %145, align 8
@@ -949,14 +1031,14 @@ entry:
   %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
   %156 = bitcast i8* %155 to i64*
-  %NullCheck68 = icmp ne i64* %156, null
-  br i1 %NullCheck68, label %157, label %ThrowNullRef67
+  %NullCheck67 = icmp eq i64* %156, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %157
 
 ; <label>:157                                     ; preds = %153
   %158 = load i64, i64* %156, align 8
   %159 = bitcast i8* %154 to i64*
-  %NullCheck70 = icmp ne i64* %159, null
-  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+  %NullCheck69 = icmp eq i64* %159, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %160
 
 ; <label>:160                                     ; preds = %157
   store i64 %158, i64* %159, align 8
@@ -965,16 +1047,16 @@ entry:
   %163 = load i8*, i8** %arg1
   %164 = getelementptr inbounds i8, i8* %163, i64 8
   %165 = bitcast i8* %164 to i16*
-  %NullCheck72 = icmp ne i16* %165, null
-  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+  %NullCheck71 = icmp eq i16* %165, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %166
 
 ; <label>:166                                     ; preds = %160
   %167 = load i16, i16* %165, align 8
   %168 = sext i16 %167 to i32
   %169 = bitcast i8* %162 to i16*
   %170 = trunc i32 %168 to i16
-  %NullCheck74 = icmp ne i16* %169, null
-  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+  %NullCheck73 = icmp eq i16* %169, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %171
 
 ; <label>:171                                     ; preds = %166
   store i16 %170, i16* %169, align 8
@@ -984,14 +1066,14 @@ entry:
   %173 = load i8*, i8** %arg0
   %174 = load i8*, i8** %arg1
   %175 = bitcast i8* %174 to i64*
-  %NullCheck56 = icmp ne i64* %175, null
-  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+  %NullCheck55 = icmp eq i64* %175, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %176
 
 ; <label>:176                                     ; preds = %172
   %177 = load i64, i64* %175, align 8
   %178 = bitcast i8* %173 to i64*
-  %NullCheck58 = icmp ne i64* %178, null
-  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+  %NullCheck57 = icmp eq i64* %178, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %179
 
 ; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
@@ -1000,16 +1082,16 @@ entry:
   %182 = load i8*, i8** %arg1
   %183 = getelementptr inbounds i8, i8* %182, i64 8
   %184 = bitcast i8* %183 to i16*
-  %NullCheck60 = icmp ne i16* %184, null
-  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+  %NullCheck59 = icmp eq i16* %184, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %185
 
 ; <label>:185                                     ; preds = %179
   %186 = load i16, i16* %184, align 8
   %187 = sext i16 %186 to i32
   %188 = bitcast i8* %181 to i16*
   %189 = trunc i32 %187 to i16
-  %NullCheck62 = icmp ne i16* %188, null
-  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+  %NullCheck61 = icmp eq i16* %188, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %190
 
 ; <label>:190                                     ; preds = %185
   store i16 %189, i16* %188, align 8
@@ -1017,15 +1099,15 @@ entry:
   %192 = getelementptr inbounds i8, i8* %191, i64 10
   %193 = load i8*, i8** %arg1
   %194 = getelementptr inbounds i8, i8* %193, i64 10
-  %NullCheck64 = icmp ne i8* %194, null
-  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+  %NullCheck63 = icmp eq i8* %194, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %195
 
 ; <label>:195                                     ; preds = %190
   %196 = load i8, i8* %194, align 8
   %197 = zext i8 %196 to i32
   %198 = trunc i32 %197 to i8
-  %NullCheck66 = icmp ne i8* %192, null
-  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+  %NullCheck65 = icmp eq i8* %192, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %199
 
 ; <label>:199                                     ; preds = %195
   store i8 %198, i8* %192, align 8
@@ -1035,14 +1117,14 @@ entry:
   %201 = load i8*, i8** %arg0
   %202 = load i8*, i8** %arg1
   %203 = bitcast i8* %202 to i64*
-  %NullCheck48 = icmp ne i64* %203, null
-  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+  %NullCheck47 = icmp eq i64* %203, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %204
 
 ; <label>:204                                     ; preds = %200
   %205 = load i64, i64* %203, align 8
   %206 = bitcast i8* %201 to i64*
-  %NullCheck50 = icmp ne i64* %206, null
-  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+  %NullCheck49 = icmp eq i64* %206, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %207
 
 ; <label>:207                                     ; preds = %204
   store i64 %205, i64* %206, align 8
@@ -1051,14 +1133,14 @@ entry:
   %210 = load i8*, i8** %arg1
   %211 = getelementptr inbounds i8, i8* %210, i64 8
   %212 = bitcast i8* %211 to i32*
-  %NullCheck52 = icmp ne i32* %212, null
-  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+  %NullCheck51 = icmp eq i32* %212, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %213
 
 ; <label>:213                                     ; preds = %207
   %214 = load i32, i32* %212, align 8
   %215 = bitcast i8* %209 to i32*
-  %NullCheck54 = icmp ne i32* %215, null
-  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+  %NullCheck53 = icmp eq i32* %215, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %216
 
 ; <label>:216                                     ; preds = %213
   store i32 %214, i32* %215, align 8
@@ -1068,14 +1150,14 @@ entry:
   %218 = load i8*, i8** %arg0
   %219 = load i8*, i8** %arg1
   %220 = bitcast i8* %219 to i64*
-  %NullCheck36 = icmp ne i64* %220, null
-  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64* %220, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %221
 
 ; <label>:221                                     ; preds = %217
   %222 = load i64, i64* %220, align 8
   %223 = bitcast i8* %218 to i64*
-  %NullCheck38 = icmp ne i64* %223, null
-  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+  %NullCheck37 = icmp eq i64* %223, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %224
 
 ; <label>:224                                     ; preds = %221
   store i64 %222, i64* %223, align 8
@@ -1084,14 +1166,14 @@ entry:
   %227 = load i8*, i8** %arg1
   %228 = getelementptr inbounds i8, i8* %227, i64 8
   %229 = bitcast i8* %228 to i32*
-  %NullCheck40 = icmp ne i32* %229, null
-  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i32* %229, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %230
 
 ; <label>:230                                     ; preds = %224
   %231 = load i32, i32* %229, align 8
   %232 = bitcast i8* %226 to i32*
-  %NullCheck42 = icmp ne i32* %232, null
-  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+  %NullCheck41 = icmp eq i32* %232, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %233
 
 ; <label>:233                                     ; preds = %230
   store i32 %231, i32* %232, align 8
@@ -1099,15 +1181,15 @@ entry:
   %235 = getelementptr inbounds i8, i8* %234, i64 12
   %236 = load i8*, i8** %arg1
   %237 = getelementptr inbounds i8, i8* %236, i64 12
-  %NullCheck44 = icmp ne i8* %237, null
-  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i8* %237, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %238
 
 ; <label>:238                                     ; preds = %233
   %239 = load i8, i8* %237, align 8
   %240 = zext i8 %239 to i32
   %241 = trunc i32 %240 to i8
-  %NullCheck46 = icmp ne i8* %235, null
-  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+  %NullCheck45 = icmp eq i8* %235, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %242
 
 ; <label>:242                                     ; preds = %238
   store i8 %241, i8* %235, align 8
@@ -1117,14 +1199,14 @@ entry:
   %244 = load i8*, i8** %arg0
   %245 = load i8*, i8** %arg1
   %246 = bitcast i8* %245 to i64*
-  %NullCheck24 = icmp ne i64* %246, null
-  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64* %246, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %247
 
 ; <label>:247                                     ; preds = %243
   %248 = load i64, i64* %246, align 8
   %249 = bitcast i8* %244 to i64*
-  %NullCheck26 = icmp ne i64* %249, null
-  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64* %249, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %250
 
 ; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
@@ -1133,14 +1215,14 @@ entry:
   %253 = load i8*, i8** %arg1
   %254 = getelementptr inbounds i8, i8* %253, i64 8
   %255 = bitcast i8* %254 to i32*
-  %NullCheck28 = icmp ne i32* %255, null
-  br i1 %NullCheck28, label %256, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i32* %255, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %256
 
 ; <label>:256                                     ; preds = %250
   %257 = load i32, i32* %255, align 8
   %258 = bitcast i8* %252 to i32*
-  %NullCheck30 = icmp ne i32* %258, null
-  br i1 %NullCheck30, label %259, label %ThrowNullRef29
+  %NullCheck29 = icmp eq i32* %258, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %259
 
 ; <label>:259                                     ; preds = %256
   store i32 %257, i32* %258, align 8
@@ -1149,16 +1231,16 @@ entry:
   %262 = load i8*, i8** %arg1
   %263 = getelementptr inbounds i8, i8* %262, i64 12
   %264 = bitcast i8* %263 to i16*
-  %NullCheck32 = icmp ne i16* %264, null
-  br i1 %NullCheck32, label %265, label %ThrowNullRef31
+  %NullCheck31 = icmp eq i16* %264, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %265
 
 ; <label>:265                                     ; preds = %259
   %266 = load i16, i16* %264, align 8
   %267 = sext i16 %266 to i32
   %268 = bitcast i8* %261 to i16*
   %269 = trunc i32 %267 to i16
-  %NullCheck34 = icmp ne i16* %268, null
-  br i1 %NullCheck34, label %270, label %ThrowNullRef33
+  %NullCheck33 = icmp eq i16* %268, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %270
 
 ; <label>:270                                     ; preds = %265
   store i16 %269, i16* %268, align 8
@@ -1168,14 +1250,14 @@ entry:
   %272 = load i8*, i8** %arg0
   %273 = load i8*, i8** %arg1
   %274 = bitcast i8* %273 to i64*
-  %NullCheck8 = icmp ne i64* %274, null
-  br i1 %NullCheck8, label %275, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64* %274, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %275
 
 ; <label>:275                                     ; preds = %271
   %276 = load i64, i64* %274, align 8
   %277 = bitcast i8* %272 to i64*
-  %NullCheck10 = icmp ne i64* %277, null
-  br i1 %NullCheck10, label %278, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %277, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %278
 
 ; <label>:278                                     ; preds = %275
   store i64 %276, i64* %277, align 8
@@ -1184,14 +1266,14 @@ entry:
   %281 = load i8*, i8** %arg1
   %282 = getelementptr inbounds i8, i8* %281, i64 8
   %283 = bitcast i8* %282 to i32*
-  %NullCheck12 = icmp ne i32* %283, null
-  br i1 %NullCheck12, label %284, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i32* %283, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %284
 
 ; <label>:284                                     ; preds = %278
   %285 = load i32, i32* %283, align 8
   %286 = bitcast i8* %280 to i32*
-  %NullCheck14 = icmp ne i32* %286, null
-  br i1 %NullCheck14, label %287, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i32* %286, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %287
 
 ; <label>:287                                     ; preds = %284
   store i32 %285, i32* %286, align 8
@@ -1200,16 +1282,16 @@ entry:
   %290 = load i8*, i8** %arg1
   %291 = getelementptr inbounds i8, i8* %290, i64 12
   %292 = bitcast i8* %291 to i16*
-  %NullCheck16 = icmp ne i16* %292, null
-  br i1 %NullCheck16, label %293, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i16* %292, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %293
 
 ; <label>:293                                     ; preds = %287
   %294 = load i16, i16* %292, align 8
   %295 = sext i16 %294 to i32
   %296 = bitcast i8* %289 to i16*
   %297 = trunc i32 %295 to i16
-  %NullCheck18 = icmp ne i16* %296, null
-  br i1 %NullCheck18, label %298, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i16* %296, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %298
 
 ; <label>:298                                     ; preds = %293
   store i16 %297, i16* %296, align 8
@@ -1217,15 +1299,15 @@ entry:
   %300 = getelementptr inbounds i8, i8* %299, i64 14
   %301 = load i8*, i8** %arg1
   %302 = getelementptr inbounds i8, i8* %301, i64 14
-  %NullCheck20 = icmp ne i8* %302, null
-  br i1 %NullCheck20, label %303, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i8* %302, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %303
 
 ; <label>:303                                     ; preds = %298
   %304 = load i8, i8* %302, align 8
   %305 = zext i8 %304 to i32
   %306 = trunc i32 %305 to i8
-  %NullCheck22 = icmp ne i8* %300, null
-  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i8* %300, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %307
 
 ; <label>:307                                     ; preds = %303
   store i8 %306, i8* %300, align 8
@@ -1235,14 +1317,14 @@ entry:
   %309 = load i8*, i8** %arg0
   %310 = load i8*, i8** %arg1
   %311 = bitcast i8* %310 to i64*
-  %NullCheck = icmp ne i64* %311, null
-  br i1 %NullCheck, label %312, label %ThrowNullRef
+  %NullCheck = icmp eq i64* %311, null
+  br i1 %NullCheck, label %ThrowNullRef, label %312
 
 ; <label>:312                                     ; preds = %308
   %313 = load i64, i64* %311, align 8
   %314 = bitcast i8* %309 to i64*
-  %NullCheck2 = icmp ne i64* %314, null
-  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64* %314, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %315
 
 ; <label>:315                                     ; preds = %312
   store i64 %313, i64* %314, align 8
@@ -1251,14 +1333,14 @@ entry:
   %318 = load i8*, i8** %arg1
   %319 = getelementptr inbounds i8, i8* %318, i64 8
   %320 = bitcast i8* %319 to i64*
-  %NullCheck4 = icmp ne i64* %320, null
-  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64* %320, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %321
 
 ; <label>:321                                     ; preds = %315
   %322 = load i64, i64* %320, align 8
   %323 = bitcast i8* %317 to i64*
-  %NullCheck6 = icmp ne i64* %323, null
-  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64* %323, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %324
 
 ; <label>:324                                     ; preds = %321
   store i64 %322, i64* %323, align 8
@@ -1286,15 +1368,15 @@ entry:
 ; <label>:338                                     ; preds = %333
   %339 = load i8*, i8** %arg0
   %340 = load i8*, i8** %arg1
-  %NullCheck136 = icmp ne i8* %340, null
-  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+  %NullCheck135 = icmp eq i8* %340, null
+  br i1 %NullCheck135, label %ThrowNullRef136, label %341
 
 ; <label>:341                                     ; preds = %338
   %342 = load i8, i8* %340, align 8
   %343 = zext i8 %342 to i32
   %344 = trunc i32 %343 to i8
-  %NullCheck138 = icmp ne i8* %339, null
-  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+  %NullCheck137 = icmp eq i8* %339, null
+  br i1 %NullCheck137, label %ThrowNullRef138, label %345
 
 ; <label>:345                                     ; preds = %341
   store i8 %344, i8* %339, align 8
@@ -1317,16 +1399,16 @@ entry:
   %357 = load i8*, i8** %arg0
   %358 = load i8*, i8** %arg1
   %359 = bitcast i8* %358 to i16*
-  %NullCheck140 = icmp ne i16* %359, null
-  br i1 %NullCheck140, label %360, label %ThrowNullRef139
+  %NullCheck139 = icmp eq i16* %359, null
+  br i1 %NullCheck139, label %ThrowNullRef140, label %360
 
 ; <label>:360                                     ; preds = %356
   %361 = load i16, i16* %359, align 8
   %362 = sext i16 %361 to i32
   %363 = bitcast i8* %357 to i16*
   %364 = trunc i32 %362 to i16
-  %NullCheck142 = icmp ne i16* %363, null
-  br i1 %NullCheck142, label %365, label %ThrowNullRef141
+  %NullCheck141 = icmp eq i16* %363, null
+  br i1 %NullCheck141, label %ThrowNullRef142, label %365
 
 ; <label>:365                                     ; preds = %360
   store i16 %364, i16* %363, align 8
@@ -1352,14 +1434,14 @@ entry:
   %378 = load i8*, i8** %arg0
   %379 = load i8*, i8** %arg1
   %380 = bitcast i8* %379 to i32*
-  %NullCheck144 = icmp ne i32* %380, null
-  br i1 %NullCheck144, label %381, label %ThrowNullRef143
+  %NullCheck143 = icmp eq i32* %380, null
+  br i1 %NullCheck143, label %ThrowNullRef144, label %381
 
 ; <label>:381                                     ; preds = %377
   %382 = load i32, i32* %380, align 8
   %383 = bitcast i8* %378 to i32*
-  %NullCheck146 = icmp ne i32* %383, null
-  br i1 %NullCheck146, label %384, label %ThrowNullRef145
+  %NullCheck145 = icmp eq i32* %383, null
+  br i1 %NullCheck145, label %ThrowNullRef146, label %384
 
 ; <label>:384                                     ; preds = %381
   store i32 %382, i32* %383, align 8
@@ -1384,14 +1466,14 @@ entry:
   %395 = load i8*, i8** %arg0
   %396 = load i8*, i8** %arg1
   %397 = bitcast i8* %396 to i64*
-  %NullCheck164 = icmp ne i64* %397, null
-  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+  %NullCheck163 = icmp eq i64* %397, null
+  br i1 %NullCheck163, label %ThrowNullRef164, label %398
 
 ; <label>:398                                     ; preds = %394
   %399 = load i64, i64* %397, align 8
   %400 = bitcast i8* %395 to i64*
-  %NullCheck166 = icmp ne i64* %400, null
-  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+  %NullCheck165 = icmp eq i64* %400, null
+  br i1 %NullCheck165, label %ThrowNullRef166, label %401
 
 ; <label>:401                                     ; preds = %398
   store i64 %399, i64* %400, align 8
@@ -1400,14 +1482,14 @@ entry:
   %404 = load i8*, i8** %arg1
   %405 = getelementptr inbounds i8, i8* %404, i64 8
   %406 = bitcast i8* %405 to i64*
-  %NullCheck168 = icmp ne i64* %406, null
-  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+  %NullCheck167 = icmp eq i64* %406, null
+  br i1 %NullCheck167, label %ThrowNullRef168, label %407
 
 ; <label>:407                                     ; preds = %401
   %408 = load i64, i64* %406, align 8
   %409 = bitcast i8* %403 to i64*
-  %NullCheck170 = icmp ne i64* %409, null
-  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+  %NullCheck169 = icmp eq i64* %409, null
+  br i1 %NullCheck169, label %ThrowNullRef170, label %410
 
 ; <label>:410                                     ; preds = %407
   store i64 %408, i64* %409, align 8
@@ -1437,14 +1519,14 @@ entry:
   %425 = load i8*, i8** %arg0
   %426 = load i8*, i8** %arg1
   %427 = bitcast i8* %426 to i64*
-  %NullCheck148 = icmp ne i64* %427, null
-  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+  %NullCheck147 = icmp eq i64* %427, null
+  br i1 %NullCheck147, label %ThrowNullRef148, label %428
 
 ; <label>:428                                     ; preds = %424
   %429 = load i64, i64* %427, align 8
   %430 = bitcast i8* %425 to i64*
-  %NullCheck150 = icmp ne i64* %430, null
-  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+  %NullCheck149 = icmp eq i64* %430, null
+  br i1 %NullCheck149, label %ThrowNullRef150, label %431
 
 ; <label>:431                                     ; preds = %428
   store i64 %429, i64* %430, align 8
@@ -1466,14 +1548,14 @@ entry:
   %441 = load i8*, i8** %arg0
   %442 = load i8*, i8** %arg1
   %443 = bitcast i8* %442 to i32*
-  %NullCheck152 = icmp ne i32* %443, null
-  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+  %NullCheck151 = icmp eq i32* %443, null
+  br i1 %NullCheck151, label %ThrowNullRef152, label %444
 
 ; <label>:444                                     ; preds = %440
   %445 = load i32, i32* %443, align 8
   %446 = bitcast i8* %441 to i32*
-  %NullCheck154 = icmp ne i32* %446, null
-  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+  %NullCheck153 = icmp eq i32* %446, null
+  br i1 %NullCheck153, label %ThrowNullRef154, label %447
 
 ; <label>:447                                     ; preds = %444
   store i32 %445, i32* %446, align 8
@@ -1495,16 +1577,16 @@ entry:
   %457 = load i8*, i8** %arg0
   %458 = load i8*, i8** %arg1
   %459 = bitcast i8* %458 to i16*
-  %NullCheck156 = icmp ne i16* %459, null
-  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+  %NullCheck155 = icmp eq i16* %459, null
+  br i1 %NullCheck155, label %ThrowNullRef156, label %460
 
 ; <label>:460                                     ; preds = %456
   %461 = load i16, i16* %459, align 8
   %462 = sext i16 %461 to i32
   %463 = bitcast i8* %457 to i16*
   %464 = trunc i32 %462 to i16
-  %NullCheck158 = icmp ne i16* %463, null
-  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+  %NullCheck157 = icmp eq i16* %463, null
+  br i1 %NullCheck157, label %ThrowNullRef158, label %465
 
 ; <label>:465                                     ; preds = %460
   store i16 %464, i16* %463, align 8
@@ -1525,15 +1607,15 @@ entry:
 ; <label>:474                                     ; preds = %470
   %475 = load i8*, i8** %arg0
   %476 = load i8*, i8** %arg1
-  %NullCheck160 = icmp ne i8* %476, null
-  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+  %NullCheck159 = icmp eq i8* %476, null
+  br i1 %NullCheck159, label %ThrowNullRef160, label %477
 
 ; <label>:477                                     ; preds = %474
   %478 = load i8, i8* %476, align 8
   %479 = zext i8 %478 to i32
   %480 = trunc i32 %479 to i8
-  %NullCheck162 = icmp ne i8* %475, null
-  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+  %NullCheck161 = icmp eq i8* %475, null
+  br i1 %NullCheck161, label %ThrowNullRef162, label %481
 
 ; <label>:481                                     ; preds = %477
   store i8 %480, i8* %475, align 8
@@ -1553,343 +1635,343 @@ ThrowNullRef:                                     ; preds = %308
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %312
+ThrowNullRef2:                                    ; preds = %312
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %315
+ThrowNullRef4:                                    ; preds = %315
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %321
+ThrowNullRef6:                                    ; preds = %321
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %271
+ThrowNullRef8:                                    ; preds = %271
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %275
+ThrowNullRef10:                                   ; preds = %275
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %278
+ThrowNullRef12:                                   ; preds = %278
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %284
+ThrowNullRef14:                                   ; preds = %284
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %287
+ThrowNullRef16:                                   ; preds = %287
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %293
+ThrowNullRef18:                                   ; preds = %293
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %298
+ThrowNullRef20:                                   ; preds = %298
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %303
+ThrowNullRef22:                                   ; preds = %303
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %243
+ThrowNullRef24:                                   ; preds = %243
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %247
+ThrowNullRef26:                                   ; preds = %247
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %250
+ThrowNullRef28:                                   ; preds = %250
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %256
+ThrowNullRef30:                                   ; preds = %256
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %259
+ThrowNullRef32:                                   ; preds = %259
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %265
+ThrowNullRef34:                                   ; preds = %265
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %217
+ThrowNullRef36:                                   ; preds = %217
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %221
+ThrowNullRef38:                                   ; preds = %221
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %224
+ThrowNullRef40:                                   ; preds = %224
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %230
+ThrowNullRef42:                                   ; preds = %230
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %233
+ThrowNullRef44:                                   ; preds = %233
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %238
+ThrowNullRef46:                                   ; preds = %238
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %200
+ThrowNullRef48:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %204
+ThrowNullRef50:                                   ; preds = %204
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %207
+ThrowNullRef52:                                   ; preds = %207
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %213
+ThrowNullRef54:                                   ; preds = %213
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %172
+ThrowNullRef56:                                   ; preds = %172
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %176
+ThrowNullRef58:                                   ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %179
+ThrowNullRef60:                                   ; preds = %179
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %185
+ThrowNullRef62:                                   ; preds = %185
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %190
+ThrowNullRef64:                                   ; preds = %190
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %195
+ThrowNullRef66:                                   ; preds = %195
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %153
+ThrowNullRef68:                                   ; preds = %153
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %157
+ThrowNullRef70:                                   ; preds = %157
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %160
+ThrowNullRef72:                                   ; preds = %160
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %166
+ThrowNullRef74:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %136
+ThrowNullRef76:                                   ; preds = %136
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %140
+ThrowNullRef78:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %143
+ThrowNullRef80:                                   ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %148
+ThrowNullRef82:                                   ; preds = %148
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %128
+ThrowNullRef84:                                   ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %132
+ThrowNullRef86:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %100
+ThrowNullRef88:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %104
+ThrowNullRef90:                                   ; preds = %104
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %107
+ThrowNullRef92:                                   ; preds = %107
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %113
+ThrowNullRef94:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %118
+ThrowNullRef96:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %123
+ThrowNullRef98:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %81
+ThrowNullRef100:                                  ; preds = %81
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef101:                                  ; preds = %85
+ThrowNullRef102:                                  ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef103:                                  ; preds = %88
+ThrowNullRef104:                                  ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef105:                                  ; preds = %94
+ThrowNullRef106:                                  ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef107:                                  ; preds = %64
+ThrowNullRef108:                                  ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef109:                                  ; preds = %68
+ThrowNullRef110:                                  ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef111:                                  ; preds = %71
+ThrowNullRef112:                                  ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef113:                                  ; preds = %76
+ThrowNullRef114:                                  ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef115:                                  ; preds = %56
+ThrowNullRef116:                                  ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef117:                                  ; preds = %60
+ThrowNullRef118:                                  ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef119:                                  ; preds = %37
+ThrowNullRef120:                                  ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef121:                                  ; preds = %41
+ThrowNullRef122:                                  ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef123:                                  ; preds = %46
+ThrowNullRef124:                                  ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef125:                                  ; preds = %51
+ThrowNullRef126:                                  ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef127:                                  ; preds = %27
+ThrowNullRef128:                                  ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef129:                                  ; preds = %31
+ThrowNullRef130:                                  ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef131:                                  ; preds = %19
+ThrowNullRef132:                                  ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef133:                                  ; preds = %22
+ThrowNullRef134:                                  ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef135:                                  ; preds = %338
+ThrowNullRef136:                                  ; preds = %338
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef137:                                  ; preds = %341
+ThrowNullRef138:                                  ; preds = %341
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef139:                                  ; preds = %356
+ThrowNullRef140:                                  ; preds = %356
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef141:                                  ; preds = %360
+ThrowNullRef142:                                  ; preds = %360
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef143:                                  ; preds = %377
+ThrowNullRef144:                                  ; preds = %377
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef145:                                  ; preds = %381
+ThrowNullRef146:                                  ; preds = %381
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef147:                                  ; preds = %424
+ThrowNullRef148:                                  ; preds = %424
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef149:                                  ; preds = %428
+ThrowNullRef150:                                  ; preds = %428
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef151:                                  ; preds = %440
+ThrowNullRef152:                                  ; preds = %440
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef153:                                  ; preds = %444
+ThrowNullRef154:                                  ; preds = %444
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef155:                                  ; preds = %456
+ThrowNullRef156:                                  ; preds = %456
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef157:                                  ; preds = %460
+ThrowNullRef158:                                  ; preds = %460
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef159:                                  ; preds = %474
+ThrowNullRef160:                                  ; preds = %474
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef161:                                  ; preds = %477
+ThrowNullRef162:                                  ; preds = %477
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef163:                                  ; preds = %394
+ThrowNullRef164:                                  ; preds = %394
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef165:                                  ; preds = %398
+ThrowNullRef166:                                  ; preds = %398
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef167:                                  ; preds = %401
+ThrowNullRef168:                                  ; preds = %401
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef169:                                  ; preds = %407
+ThrowNullRef170:                                  ; preds = %407
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1939,8 +2021,8 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
-  br i1 %NullCheck, label %22, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %ThrowNullRef, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
@@ -1948,8 +2030,8 @@ entry:
   store i32 %24, i32* %loc0
   %25 = load i32, i32* %loc0
   %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %26, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %27
 
 ; <label>:27                                      ; preds = %22
   %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
@@ -1971,7 +2053,7 @@ ThrowNullRef:                                     ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1989,8 +2071,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -2022,15 +2104,15 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2048,16 +2130,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
   %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
   store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %15
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
@@ -2072,8 +2154,8 @@ entry:
   %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
   %29 = ptrtoint i16 addrspace(1)* %28 to i64
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %19
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
@@ -2089,19 +2171,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2114,8 +2196,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
@@ -2128,7 +2210,7 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[loadElem]
+Failed to read AppDomain.PrepareDataForSetup[storeElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
@@ -2202,8 +2284,8 @@ entry:
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
-  br i1 %NullCheck24, label %27, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = load i64, i64 addrspace(1)* %26
@@ -2218,8 +2300,8 @@ entry:
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
-  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
   %41 = load i64, i64 addrspace(1)* %39
@@ -2236,8 +2318,8 @@ entry:
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
-  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
   %54 = load i64, i64 addrspace(1)* %52
@@ -2252,8 +2334,8 @@ entry:
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
   %67 = load i64, i64 addrspace(1)* %65
@@ -2270,8 +2352,8 @@ entry:
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
-  br i1 %NullCheck16, label %79, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
   %80 = load i64, i64 addrspace(1)* %78
@@ -2286,8 +2368,8 @@ entry:
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
-  br i1 %NullCheck18, label %92, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
   %93 = load i64, i64 addrspace(1)* %91
@@ -2304,8 +2386,8 @@ entry:
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
-  br i1 %NullCheck12, label %105, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = load i64, i64 addrspace(1)* %104
@@ -2320,8 +2402,8 @@ entry:
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
-  br i1 %NullCheck14, label %118, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
   %119 = load i64, i64 addrspace(1)* %117
@@ -2337,8 +2419,8 @@ entry:
 
 ; <label>:128                                     ; preds = %20
   %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
-  br i1 %NullCheck4, label %130, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %129, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %130
 
 ; <label>:130                                     ; preds = %128
   %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
@@ -2346,8 +2428,8 @@ entry:
   %133 = load i16, i16 addrspace(1)* %132, align 8
   %134 = zext i16 %133 to i32
   %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
-  br i1 %NullCheck6, label %136, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %135, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %136
 
 ; <label>:136                                     ; preds = %130
   %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
@@ -2360,8 +2442,8 @@ entry:
 
 ; <label>:143                                     ; preds = %136
   %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
-  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %144, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %145
 
 ; <label>:145                                     ; preds = %143
   %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
@@ -2369,8 +2451,8 @@ entry:
   %148 = load i16, i16 addrspace(1)* %147, align 8
   %149 = zext i16 %148 to i32
   %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %150, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %151
 
 ; <label>:151                                     ; preds = %145
   %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
@@ -2388,8 +2470,8 @@ entry:
 
 ; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
-  br i1 %NullCheck, label %163, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %ThrowNullRef, label %163
 
 ; <label>:163                                     ; preds = %161
   %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
@@ -2399,8 +2481,8 @@ entry:
 
 ; <label>:167                                     ; preds = %163
   %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
-  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %168, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %169
 
 ; <label>:169                                     ; preds = %167
   %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
@@ -2432,55 +2514,55 @@ ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %167
+ThrowNullRef2:                                    ; preds = %167
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %128
+ThrowNullRef4:                                    ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %130
+ThrowNullRef6:                                    ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %143
+ThrowNullRef8:                                    ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %145
+ThrowNullRef10:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %102
+ThrowNullRef12:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %105
+ThrowNullRef14:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %76
+ThrowNullRef16:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %79
+ThrowNullRef18:                                   ; preds = %79
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %50
+ThrowNullRef20:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %53
+ThrowNullRef22:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %24
+ThrowNullRef24:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %27
+ThrowNullRef26:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2503,15 +2585,15 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2519,16 +2601,16 @@ entry:
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
   store i32 %8, i32* %loc0
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
   %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
   store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
@@ -2546,16 +2628,16 @@ entry:
 
 ; <label>:23                                      ; preds = %64
   %24 = load i16*, i16** %loc3
-  %NullCheck12 = icmp ne i16* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i16* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
   store i32 %27, i32* %loc5
   %28 = load i16*, i16** %loc4
-  %NullCheck14 = icmp ne i16* %28, null
-  br i1 %NullCheck14, label %29, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %28, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = load i16, i16* %28, align 8
@@ -2620,15 +2702,15 @@ entry:
 
 ; <label>:67                                      ; preds = %64
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
-  br i1 %NullCheck8, label %69, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %68, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %69
 
 ; <label>:69                                      ; preds = %67
   %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
   %71 = load i32, i32 addrspace(1)* %70
   %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
-  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %73
 
 ; <label>:73                                      ; preds = %69
   %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
@@ -2645,31 +2727,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %67
+ThrowNullRef8:                                    ; preds = %67
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %69
+ThrowNullRef10:                                   ; preds = %69
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2710,14 +2792,14 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
   %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
@@ -2730,14 +2812,14 @@ entry:
 
 ; <label>:11                                      ; preds = %4
   %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
   %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
@@ -2749,14 +2831,14 @@ entry:
 
 ; <label>:22                                      ; preds = %16
   %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
   %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
-  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
-  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
@@ -2804,23 +2886,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2836,7 +2918,280 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[loadElem]
+Successfully read RuntimeType.IsAssignableFrom
+
+define i8 @RuntimeType.IsAssignableFrom(%System.RuntimeType addrspace(1)* %param0, %System.Type addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.RuntimeType addrspace(1)*
+  %arg1 = alloca %System.Type addrspace(1)*
+  %loc0 = alloca %System.RuntimeType addrspace(1)*
+  %loc1 = alloca %"System.Type[]" addrspace(1)*
+  %loc2 = alloca i32
+  store %System.RuntimeType addrspace(1)* %param0, %System.RuntimeType addrspace(1)** %this
+  store %System.Type addrspace(1)* %param1, %System.Type addrspace(1)** %arg1
+  %0 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %1 = icmp ne %System.Type addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i8 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %5 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %6 = bitcast %System.Type addrspace(1)* %4 to %System.Object addrspace(1)*
+  %7 = bitcast %System.RuntimeType addrspace(1)* %5 to %System.Object addrspace(1)*
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %6, %System.Object addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %3
+  ret i8 1
+
+; <label>:12                                      ; preds = %3
+  %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 152
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 32
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
+  %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
+  %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
+  store %System.RuntimeType addrspace(1)* %25, %System.RuntimeType addrspace(1)** %loc0
+  %26 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %27 = icmp eq %System.RuntimeType addrspace(1)* %26, null
+  br i1 %27, label %34, label %28
+
+; <label>:28                                      ; preds = %15
+  %29 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %30 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)*)*)(%System.RuntimeType addrspace(1)* %29, %System.RuntimeType addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+; <label>:34                                      ; preds = %15
+  %35 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %36 = call %System.Reflection.Emit.TypeBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Reflection.Emit.TypeBuilder addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %35)
+  %37 = icmp eq %System.Reflection.Emit.TypeBuilder addrspace(1)* %36, null
+  br i1 %37, label %139, label %38
+
+; <label>:38                                      ; preds = %34
+  %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %42
+
+; <label>:42                                      ; preds = %38
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 152
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 40
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
+  %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
+  %53 = zext i8 %52 to i32
+  %54 = icmp eq i32 %53, 0
+  br i1 %54, label %56, label %55
+
+; <label>:55                                      ; preds = %42
+  ret i8 1
+
+; <label>:56                                      ; preds = %42
+  %57 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %58 = bitcast %System.RuntimeType addrspace(1)* %57 to %System.Type addrspace(1)*
+  %59 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %58)
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %64 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.Type addrspace(1)* %63, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = bitcast %System.RuntimeType addrspace(1)* %64 to %System.Type addrspace(1)*
+  %67 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %63, %System.Type addrspace(1)* %66)
+  %68 = zext i8 %67 to i32
+  %69 = trunc i32 %68 to i8
+  ret i8 %69
+
+; <label>:70                                      ; preds = %56
+  %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
+  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %73
+
+; <label>:73                                      ; preds = %70
+  %74 = load i64, i64 addrspace(1)* %72
+  %75 = add i64 %74, 128
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = add i64 %77, 0
+  %79 = inttoptr i64 %78 to i64*
+  %80 = load i64, i64* %79
+  %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
+  %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
+  %83 = call i8 %82(%System.Type addrspace(1)* %81)
+  %84 = zext i8 %83 to i32
+  %85 = icmp eq i32 %84, 0
+  br i1 %85, label %139, label %86
+
+; <label>:86                                      ; preds = %73
+  %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
+  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %89
+
+; <label>:89                                      ; preds = %86
+  %90 = load i64, i64 addrspace(1)* %88
+  %91 = add i64 %90, 128
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = add i64 %93, 24
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
+  %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
+  %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
+  store %"System.Type[]" addrspace(1)* %99, %"System.Type[]" addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %129
+
+; <label>:100                                     ; preds = %132
+  %101 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %102 = load i32, i32* %loc2
+  %NullCheck11 = icmp eq %"System.Type[]" addrspace(1)* %101, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %103
+
+; <label>:103                                     ; preds = %100
+  %104 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 1
+  %105 = load i32, i32 addrspace(1)* %104
+  %106 = zext i32 %105 to i64
+  %107 = zext i32 %102 to i64
+  %BoundsCheck = icmp uge i64 %107, %106
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %108
+
+; <label>:108                                     ; preds = %103
+  %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
+  %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
+  %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
+  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %113
+
+; <label>:113                                     ; preds = %108
+  %114 = load i64, i64 addrspace(1)* %112
+  %115 = add i64 %114, 152
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = add i64 %117, 56
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
+  %123 = zext i8 %122 to i32
+  %124 = icmp ne i32 %123, 0
+  br i1 %124, label %126, label %125
+
+; <label>:125                                     ; preds = %113
+  ret i8 0
+
+; <label>:126                                     ; preds = %113
+  %127 = load i32, i32* %loc2
+  %128 = add i32 %127, 1
+  store i32 %128, i32* %loc2
+  br label %129
+
+; <label>:129                                     ; preds = %89, %126
+  %130 = load i32, i32* %loc2
+  %131 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %NullCheck9 = icmp eq %"System.Type[]" addrspace(1)* %131, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %132
+
+; <label>:132                                     ; preds = %129
+  %133 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %131, i32 0, i32 1
+  %134 = load i32, i32 addrspace(1)* %133
+  %135 = zext i32 %134 to i64
+  %136 = trunc i64 %135 to i32
+  %137 = icmp slt i32 %130, %136
+  br i1 %137, label %100, label %138
+
+; <label>:138                                     ; preds = %132
+  ret i8 1
+
+; <label>:139                                     ; preds = %34, %73
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %129
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %103
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -2893,7 +3248,7 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElem]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -2904,8 +3259,8 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -2997,8 +3352,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
@@ -3059,8 +3414,8 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -3087,8 +3442,8 @@ entry:
 
 ; <label>:17                                      ; preds = %5, %11
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
@@ -3097,8 +3452,8 @@ entry:
 
 ; <label>:22                                      ; preds = %1, %11
   %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
@@ -3109,11 +3464,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %17
+ThrowNullRef2:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %22
+ThrowNullRef4:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3167,15 +3522,15 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
   %15 = load i32, i32 addrspace(1)* %14
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
@@ -3198,7 +3553,7 @@ ThrowNullRef:                                     ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef2:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3232,8 +3587,8 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
@@ -3312,8 +3667,8 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -3327,8 +3682,8 @@ entry:
 ; <label>:5                                       ; preds = %43
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %7 = load i32, i32* %loc1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck6, label %8, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
@@ -3366,8 +3721,8 @@ entry:
 ; <label>:32                                      ; preds = %21, %25
   %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
   %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
-  br i1 %NullCheck8, label %35, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = trunc i32 %34 to i16
@@ -3380,8 +3735,8 @@ entry:
 ; <label>:40                                      ; preds = %1, %35
   %41 = load i32, i32* %loc1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
-  br i1 %NullCheck2, label %43, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %42, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
@@ -3392,8 +3747,8 @@ entry:
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
   %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
-  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
   %51 = load i64, i64 addrspace(1)* %49
@@ -3412,19 +3767,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %40
+ThrowNullRef2:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %47
+ThrowNullRef4:                                    ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %5
+ThrowNullRef6:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %32
+ThrowNullRef8:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3467,8 +3822,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
@@ -3492,11 +3847,391 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(i16* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store i16* %param0, i16** %arg0
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load i32, i32* %arg3
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %42, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %37, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg2
+  %13 = load i32, i32* %arg3
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %37, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %24 = load i32, i32* %arg2
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load i16*, i16** %arg0
+  %35 = load i32, i32* %arg3
+  %36 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %36, i16* %34, i32 %35)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:37                                      ; preds = %5, %16
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %39)
+  %41 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41, %System.String addrspace(1)* %38, %System.String addrspace(1)* %40)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41) #0
+  unreachable
+
+; <label>:42                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
-Failed to read StringBuilder.ToString[loadElemA]
+Successfully read StringBuilder.ToString
+
+define %System.String addrspace(1)* @StringBuilder.ToString(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i16*
+  %loc3 = alloca %"System.Char[]" addrspace(1)*
+  %loc4 = alloca i32
+  %loc5 = alloca i32
+  %loc6 = alloca i16 addrspace(1)*
+  %loc7 = alloca %System.String addrspace(1)*
+  %loc8 = alloca %"System.Char[]" addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %0)
+  %2 = icmp ne i32 %1, 0
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %4
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %6)
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %7)
+  store %System.String addrspace(1)* %8, %System.String addrspace(1)** %loc0
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.Text.StringBuilder addrspace(1)* %9, %System.Text.StringBuilder addrspace(1)** %loc1
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  store %System.String addrspace(1)* %10, %System.String addrspace(1)** %loc7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc7
+  %12 = ptrtoint %System.String addrspace(1)* %11 to i64
+  %13 = icmp eq i64 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %5
+  %15 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %16 = sext i32 %15 to i64
+  %17 = add i64 %12, %16
+  br label %18
+
+; <label>:18                                      ; preds = %5, %14
+  %19 = phi i64 [ %12, %5 ], [ %17, %14 ]
+  %20 = inttoptr i64 %19 to i16*
+  store i16* %20, i16** %loc2
+  br label %21
+
+; <label>:21                                      ; preds = %98, %18
+  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %22, null
+  br i1 %NullCheck, label %ThrowNullRef, label %23
+
+; <label>:23                                      ; preds = %21
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 3
+  %25 = load i32, i32 addrspace(1)* %24, align 8
+  %26 = icmp sle i32 %25, 0
+  br i1 %26, label %96, label %27
+
+; <label>:27                                      ; preds = %23
+  %28 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %28, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %29
+
+; <label>:29                                      ; preds = %27
+  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %28, i32 0, i32 1
+  %31 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %30, align 8
+  store %"System.Char[]" addrspace(1)* %31, %"System.Char[]" addrspace(1)** %loc3
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %33
+
+; <label>:33                                      ; preds = %29
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  store i32 %35, i32* %loc4
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  %39 = load i32, i32 addrspace(1)* %38, align 8
+  store i32 %39, i32* %loc5
+  %40 = load i32, i32* %loc5
+  %41 = load i32, i32* %loc4
+  %42 = add i32 %40, %41
+  %43 = zext i32 %42 to i64
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %45
+
+; <label>:45                                      ; preds = %37
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = sext i32 %47 to i64
+  %49 = icmp sgt i64 %43, %48
+  br i1 %49, label %91, label %50
+
+; <label>:50                                      ; preds = %45
+  %51 = load i32, i32* %loc5
+  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %52, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %53
+
+; <label>:53                                      ; preds = %50
+  %54 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %52, i32 0, i32 1
+  %55 = load i32, i32 addrspace(1)* %54
+  %56 = zext i32 %55 to i64
+  %57 = trunc i64 %56 to i32
+  %58 = icmp ugt i32 %51, %57
+  br i1 %58, label %91, label %59
+
+; <label>:59                                      ; preds = %53
+  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  store %"System.Char[]" addrspace(1)* %60, %"System.Char[]" addrspace(1)** %loc8
+  %61 = icmp eq %"System.Char[]" addrspace(1)* %60, null
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %63, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %64
+
+; <label>:64                                      ; preds = %62
+  %65 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %63, i32 0, i32 1
+  %66 = load i32, i32 addrspace(1)* %65
+  %67 = zext i32 %66 to i64
+  %68 = trunc i64 %67 to i32
+  %69 = icmp ne i32 %68, 0
+  br i1 %69, label %71, label %70
+
+; <label>:70                                      ; preds = %59, %64
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:71                                      ; preds = %64
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %73
+
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %BoundsCheck = icmp uge i64 0, %76
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %77
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %78, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:79                                      ; preds = %70, %77
+  %80 = load i16*, i16** %loc2
+  %81 = load i32, i32* %loc4
+  %82 = sext i32 %81 to i64
+  %83 = mul i64 %82, 2
+  %84 = bitcast i16* %80 to i8*
+  %85 = getelementptr inbounds i8, i8* %84, i64 %83
+  %86 = load i16 addrspace(1)*, i16 addrspace(1)** %loc6
+  %87 = ptrtoint i16 addrspace(1)* %86 to i64
+  %88 = load i32, i32* %loc5
+  %89 = bitcast i8* %85 to i16*
+  %90 = inttoptr i64 %87 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %89, i16* %90, i32 %88)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %96
+
+; <label>:91                                      ; preds = %45, %53
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %94 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %93)
+  %95 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95, %System.String addrspace(1)* %92, %System.String addrspace(1)* %94)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95) #0
+  unreachable
+
+; <label>:96                                      ; preds = %23, %79
+  %97 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %97, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %98
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %97, i32 0, i32 2
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  store %System.Text.StringBuilder addrspace(1)* %100, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %102 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %102, label %21, label %103
+
+; <label>:103                                     ; preds = %98
+  store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc7
+  %104 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  ret %System.String addrspace(1)* %104
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method StringBuilder::get_Length using LLILCJit
+Successfully read StringBuilder.get_Length
+
+define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
+Successfully read RuntimeHelpers.get_OffsetToStringData
+
+define i32 @RuntimeHelpers.get_OffsetToStringData() {
+entry:
+  ret i32 12
+}
+
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
 Successfully read CultureData.CreateCultureData
 
@@ -3514,23 +4249,23 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
   store i8 %4, i8 addrspace(1)* %6
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
@@ -3549,11 +4284,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3566,50 +4301,50 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
   store i32 -1, i32 addrspace(1)* %2
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
   store i32 -1, i32 addrspace(1)* %8
   %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
   store i32 -1, i32 addrspace(1)* %14
   %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
   store i32 -1, i32 addrspace(1)* %17
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
@@ -3623,27 +4358,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3675,7 +4410,136 @@ Failed to read Dictionary`2.Insert[non-const derefAddress]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
 Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
-Failed to read HashHelpers.GetPrime[loadElem]
+Successfully read HashHelpers.GetPrime
+
+define i32 @HashHelpers.GetPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %6, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5, %System.String addrspace(1)* %4)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5) #0
+  unreachable
+
+; <label>:6                                       ; preds = %entry
+  store i32 0, i32* %loc0
+  br label %29
+
+; <label>:7                                       ; preds = %35
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 1296
+  %10 = addrspacecast i8 addrspace(1)* %9 to %"System.Int32[]" addrspace(1)**
+  %11 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %10
+  %12 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Int32[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = zext i32 %15 to i64
+  %17 = zext i32 %12 to i64
+  %BoundsCheck = icmp uge i64 %17, %16
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 3, i32 %12
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  store i32 %20, i32* %loc1
+  %21 = load i32, i32* %loc1
+  %22 = load i32, i32* %arg0
+  %23 = icmp slt i32 %21, %22
+  br i1 %23, label %26, label %24
+
+; <label>:24                                      ; preds = %18
+  %25 = load i32, i32* %loc1
+  ret i32 %25
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %loc0
+  %28 = add i32 %27, 1
+  store i32 %28, i32* %loc0
+  br label %29
+
+; <label>:29                                      ; preds = %6, %26
+  %30 = load i32, i32* %loc0
+  %31 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %32 = getelementptr inbounds i8, i8 addrspace(1)* %31, i64 1296
+  %33 = addrspacecast i8 addrspace(1)* %32 to %"System.Int32[]" addrspace(1)**
+  %34 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %33
+  %NullCheck = icmp eq %"System.Int32[]" addrspace(1)* %34, null
+  br i1 %NullCheck, label %ThrowNullRef, label %35
+
+; <label>:35                                      ; preds = %29
+  %36 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %34, i32 0, i32 1
+  %37 = load i32, i32 addrspace(1)* %36
+  %38 = zext i32 %37 to i64
+  %39 = trunc i64 %38 to i32
+  %40 = icmp slt i32 %30, %39
+  br i1 %40, label %7, label %41
+
+; <label>:41                                      ; preds = %35
+  %42 = load i32, i32* %arg0
+  %43 = or i32 %42, 1
+  store i32 %43, i32* %loc2
+  br label %59
+
+; <label>:44                                      ; preds = %59
+  %45 = load i32, i32* %loc2
+  %46 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %45)
+  %47 = zext i8 %46 to i32
+  %48 = icmp eq i32 %47, 0
+  br i1 %48, label %56, label %49
+
+; <label>:49                                      ; preds = %44
+  %50 = load i32, i32* %loc2
+  %51 = sub i32 %50, 1
+  %52 = srem i32 %51, 101
+  %53 = icmp eq i32 %52, 0
+  br i1 %53, label %56, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = load i32, i32* %loc2
+  ret i32 %55
+
+; <label>:56                                      ; preds = %44, %49
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %57, 2
+  store i32 %58, i32* %loc2
+  br label %59
+
+; <label>:59                                      ; preds = %41, %56
+  %60 = load i32, i32* %loc2
+  %61 = icmp slt i32 %60, 2147483647
+  br i1 %61, label %44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load i32, i32* %arg0
+  ret i32 %63
+
+ThrowNullRef:                                     ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
 Successfully read GenericEqualityComparer`1.GetHashCode
 
@@ -3694,14 +4558,14 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
   %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load i64, i64 addrspace(1)* %7
@@ -3720,7 +4584,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3750,8 +4614,8 @@ entry:
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
@@ -3796,8 +4660,8 @@ entry:
   %35 = bitcast i16* %34 to i8*
   %36 = getelementptr inbounds i8, i8* %35, i64 2
   %37 = bitcast i8* %36 to i16*
-  %NullCheck4 = icmp ne i16* %37, null
-  br i1 %NullCheck4, label %38, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %37, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %38
 
 ; <label>:38                                      ; preds = %27
   %39 = load i16, i16* %37, align 8
@@ -3824,8 +4688,8 @@ entry:
 
 ; <label>:54                                      ; preds = %22, %43
   %55 = load i16*, i16** %loc4
-  %NullCheck2 = icmp ne i16* %55, null
-  br i1 %NullCheck2, label %56, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i16* %55, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %56
 
 ; <label>:56                                      ; preds = %54
   %57 = load i16, i16* %55, align 8
@@ -3850,11 +4714,11 @@ ThrowNullRef:                                     ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %54
+ThrowNullRef2:                                    ; preds = %54
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %27
+ThrowNullRef4:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3871,8 +4735,8 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -3907,8 +4771,8 @@ entry:
 
 ; <label>:26                                      ; preds = %19
   %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
-  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %28
 
 ; <label>:28                                      ; preds = %26
   %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
@@ -3920,7 +4784,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3972,8 +4836,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
@@ -3984,26 +4848,26 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
-  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
@@ -4014,8 +4878,8 @@ entry:
 ; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
@@ -4024,8 +4888,8 @@ entry:
 
 ; <label>:25                                      ; preds = %1, %16, %23
   %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
-  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
@@ -4036,27 +4900,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %20
+ThrowNullRef10:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4069,8 +4933,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -4081,8 +4945,8 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
@@ -4091,8 +4955,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1, %8
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
@@ -4103,11 +4967,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4128,24 +4992,24 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   store i32 %3, i32* %loc0
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
   %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
   store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck4, label %9, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
@@ -4164,15 +5028,15 @@ entry:
 ; <label>:18                                      ; preds = %70
   %19 = load i16*, i16** %loc3
   %20 = bitcast i16* %19 to i64*
-  %NullCheck10 = icmp ne i64* %20, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %20, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = load i64, i64* %20, align 8
   %23 = load i16*, i16** %loc4
   %24 = bitcast i16* %23 to i64*
-  %NullCheck12 = icmp ne i64* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = load i64, i64* %24, align 8
@@ -4188,8 +5052,8 @@ entry:
   %31 = bitcast i16* %30 to i8*
   %32 = getelementptr inbounds i8, i8* %31, i64 8
   %33 = bitcast i8* %32 to i64*
-  %NullCheck14 = icmp ne i64* %33, null
-  br i1 %NullCheck14, label %34, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = load i64, i64* %33, align 8
@@ -4197,8 +5061,8 @@ entry:
   %37 = bitcast i16* %36 to i8*
   %38 = getelementptr inbounds i8, i8* %37, i64 8
   %39 = bitcast i8* %38 to i64*
-  %NullCheck16 = icmp ne i64* %39, null
-  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %40
 
 ; <label>:40                                      ; preds = %34
   %41 = load i64, i64* %39, align 8
@@ -4214,8 +5078,8 @@ entry:
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %NullCheck18 = icmp ne i64* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = load i64, i64* %48, align 8
@@ -4223,8 +5087,8 @@ entry:
   %52 = bitcast i16* %51 to i8*
   %53 = getelementptr inbounds i8, i8* %52, i64 16
   %54 = bitcast i8* %53 to i64*
-  %NullCheck20 = icmp ne i64* %54, null
-  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64* %54, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %55
 
 ; <label>:55                                      ; preds = %49
   %56 = load i64, i64* %54, align 8
@@ -4262,15 +5126,15 @@ entry:
 ; <label>:74                                      ; preds = %95
   %75 = load i16*, i16** %loc3
   %76 = bitcast i16* %75 to i32*
-  %NullCheck6 = icmp ne i32* %76, null
-  br i1 %NullCheck6, label %77, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32* %76, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %77
 
 ; <label>:77                                      ; preds = %74
   %78 = load i32, i32* %76, align 8
   %79 = load i16*, i16** %loc4
   %80 = bitcast i16* %79 to i32*
-  %NullCheck8 = icmp ne i32* %80, null
-  br i1 %NullCheck8, label %81, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i32* %80, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %81
 
 ; <label>:81                                      ; preds = %77
   %82 = load i32, i32* %80, align 8
@@ -4318,43 +5182,43 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %74
+ThrowNullRef6:                                    ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %77
+ThrowNullRef8:                                    ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %29
+ThrowNullRef14:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %34
+ThrowNullRef16:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4376,8 +5240,8 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load i64, i64 addrspace(1)* %4
@@ -4389,8 +5253,8 @@ entry:
   %12 = load i64, i64* %11
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %5
   %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
@@ -4399,8 +5263,8 @@ entry:
   %18 = load i8, i8* %arg2
   %19 = zext i8 %18 to i32
   %20 = trunc i32 %19 to i8
-  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %15
   %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
@@ -4411,11 +5275,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4442,8 +5306,8 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
@@ -4466,16 +5330,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
   %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = load i64, i64 addrspace(1)* %19
@@ -4500,8 +5364,8 @@ entry:
 ; <label>:35                                      ; preds = %30
   %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
@@ -4514,8 +5378,8 @@ entry:
 
 ; <label>:42                                      ; preds = %1, %38
   %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
-  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
@@ -4526,19 +5390,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %35
+ThrowNullRef2:                                    ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %42
+ThrowNullRef8:                                    ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4551,14 +5415,14 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
@@ -4570,7 +5434,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4583,8 +5447,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
@@ -4613,51 +5477,51 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
   %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
   %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
   %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
   %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
-  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
   store i64 %21, i64 addrspace(1)* %23
   %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %25 = load i64, i64* %loc0
-  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
@@ -4668,27 +5532,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %22
+ThrowNullRef12:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4701,8 +5565,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
@@ -4713,19 +5577,19 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
@@ -4734,8 +5598,8 @@ entry:
 
 ; <label>:15                                      ; preds = %1, %13
   %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
@@ -4746,19 +5610,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %15
+ThrowNullRef8:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4771,8 +5635,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -4831,8 +5695,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
@@ -4882,8 +5746,8 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
-  br i1 %NullCheck, label %17, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %ThrowNullRef, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
@@ -4894,15 +5758,15 @@ entry:
 
 ; <label>:22                                      ; preds = %17
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
-  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
   %26 = load i32, i32 addrspace(1)* %25
   %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
-  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %27, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
@@ -4925,8 +5789,8 @@ entry:
 ; <label>:40                                      ; preds = %17
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
-  br i1 %NullCheck6, label %43, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %41, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
@@ -4938,34 +5802,17 @@ ThrowNullRef:                                     ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %24
+ThrowNullRef4:                                    ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %40
+ThrowNullRef6:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
-}
-
-INFO:  jitting method Object::ReferenceEquals using LLILCJit
-Successfully read Object.ReferenceEquals
-
-define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
-entry:
-  %arg0 = alloca %System.Object addrspace(1)*
-  %arg1 = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
-  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
-  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = icmp eq %System.Object addrspace(1)* %0, %1
-  %3 = sext i1 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
 }
 
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
@@ -4978,21 +5825,21 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
   %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
-  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
@@ -5007,28 +5854,28 @@ entry:
 ; <label>:13                                      ; preds = %8, %12
   %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
   %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
   %21 = load i32, i32 addrspace(1)* %20, align 8
   %22 = add i32 %21, 1
-  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
   store i32 %22, i32 addrspace(1)* %24
   %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
@@ -5039,27 +5886,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5077,7 +5924,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::Setup using LLILCJit
-Failed to read AppDomain.Setup[loadElem]
+Failed to read AppDomain.Setup[unbox]
 INFO:  jitting method Thread::GetDomain using LLILCJit
 Successfully read Thread.GetDomain
 
@@ -5108,8 +5955,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
@@ -5122,14 +5969,14 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
   %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
@@ -5141,11 +5988,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5173,8 +6020,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -5189,7 +6036,328 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
 Failed to read KeyCollection.System.Collections.Generic.IEnumerable<TKey>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Successfully read Enumerator.MoveNext
+
+define i8 @Enumerator.MoveNext(%"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.RuntimeTypeHandle* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*
+  %"$TypeArg" = alloca %System.RuntimeTypeHandle*
+  store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
+  %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 8
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %76, label %12
+
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
+  br label %76
+
+; <label>:13                                      ; preds = %85
+  %14 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck19 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %15
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, i32 0, i32 0
+  %17 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %16, align 8
+  %NullCheck21 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, i32 0, i32 2
+  %20 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %19, align 8
+  %21 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck23 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %22
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, i32 0, i32 2
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %NullCheck25 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 3, i32 %24
+  %NullCheck27 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %32
+
+; <label>:32                                      ; preds = %30
+  %33 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, i32 0, i32 2
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = icmp slt i32 %34, 0
+  br i1 %35, label %68, label %36
+
+; <label>:36                                      ; preds = %32
+  %37 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %38 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck29 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %39
+
+; <label>:39                                      ; preds = %36
+  %40 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, i32 0, i32 0
+  %41 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %40, align 8
+  %NullCheck31 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, i32 0, i32 2
+  %44 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %43, align 8
+  %45 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck33 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, i32 0, i32 2
+  %48 = load i32, i32 addrspace(1)* %47, align 8
+  %NullCheck35 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %49
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = zext i32 %51 to i64
+  %53 = zext i32 %48 to i64
+  %BoundsCheck37 = icmp uge i64 %53, %52
+  br i1 %BoundsCheck37, label %ThrowIndexOutOfRange38, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 3, i32 %48
+  %NullCheck39 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %56
+
+; <label>:56                                      ; preds = %54
+  %57 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, i32 0, i32 0
+  %58 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck41 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %59
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %60, %System.__Canon addrspace(1)* %58)
+  %61 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck43 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  %64 = load i32, i32 addrspace(1)* %63, align 8
+  %65 = add i32 %64, 1
+  %NullCheck45 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  store i32 %65, i32 addrspace(1)* %67
+  ret i8 1
+
+; <label>:68                                      ; preds = %32
+  %69 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck47 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %73 = add i32 %72, 1
+  %NullCheck49 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %74
+
+; <label>:74                                      ; preds = %70
+  %75 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  store i32 %73, i32 addrspace(1)* %75
+  br label %76
+
+; <label>:76                                      ; preds = %8, %12, %74
+  %77 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %78
+
+; <label>:78                                      ; preds = %76
+  %79 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, i32 0, i32 2
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck7 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %82
+
+; <label>:82                                      ; preds = %78
+  %83 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, i32 0, i32 0
+  %84 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %83, align 8
+  %NullCheck9 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %85
+
+; <label>:85                                      ; preds = %82
+  %86 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, i32 0, i32 7
+  %87 = load i32, i32 addrspace(1)* %86, align 8
+  %88 = icmp ult i32 %80, %87
+  br i1 %88, label %13, label %89
+
+; <label>:89                                      ; preds = %85
+  %90 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %91 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck11 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %92
+
+; <label>:92                                      ; preds = %89
+  %93 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, i32 0, i32 0
+  %94 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck13 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %95
+
+; <label>:95                                      ; preds = %92
+  %96 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, i32 0, i32 7
+  %97 = load i32, i32 addrspace(1)* %96, align 8
+  %98 = add i32 %97, 1
+  %NullCheck15 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %99
+
+; <label>:99                                      ; preds = %95
+  %100 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, i32 0, i32 2
+  store i32 %98, i32 addrspace(1)* %100
+  %101 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck17 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %102
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %103, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %92
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef22:                                   ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef24:                                   ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef26:                                   ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef28:                                   ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef30:                                   ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef32:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef34:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef36:                                   ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange38:                           ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef40:                                   ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef42:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef44:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef46:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef48:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef50:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -5200,8 +6368,8 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -5232,9 +6400,9 @@ Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
 Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
-Failed to read String.MakeSeparatorList[loadElemA]
+Failed to read String.MakeSeparatorList[storeElem]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
-Failed to read String.InternalSplitKeepEmptyEntries[loadElem]
+Failed to read String.InternalSplitKeepEmptyEntries[storeElem]
 INFO:  jitting method Path::IsRelative using LLILCJit
 Successfully read Path.IsRelative
 
@@ -5243,8 +6411,8 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -5254,8 +6422,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
@@ -5271,8 +6439,8 @@ entry:
 
 ; <label>:17                                      ; preds = %7
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
@@ -5288,8 +6456,8 @@ entry:
 
 ; <label>:29                                      ; preds = %19
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %31
 
 ; <label>:31                                      ; preds = %29
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
@@ -5300,8 +6468,8 @@ entry:
 
 ; <label>:36                                      ; preds = %31
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
-  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %37, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
@@ -5312,8 +6480,8 @@ entry:
 
 ; <label>:43                                      ; preds = %31, %38
   %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
-  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %45
 
 ; <label>:45                                      ; preds = %43
   %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
@@ -5324,8 +6492,8 @@ entry:
 
 ; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %50
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
@@ -5336,8 +6504,8 @@ entry:
 
 ; <label>:57                                      ; preds = %1, %7, %19, %45, %52
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
-  br i1 %NullCheck14, label %59, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %59
 
 ; <label>:59                                      ; preds = %57
   %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
@@ -5347,8 +6515,8 @@ entry:
 
 ; <label>:63                                      ; preds = %59
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
@@ -5359,8 +6527,8 @@ entry:
 
 ; <label>:70                                      ; preds = %65
   %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
-  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.String addrspace(1)* %71, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %72
 
 ; <label>:72                                      ; preds = %70
   %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
@@ -5379,39 +6547,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %17
+ThrowNullRef4:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %29
+ThrowNullRef6:                                    ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %36
+ThrowNullRef8:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %43
+ThrowNullRef10:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %50
+ThrowNullRef12:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %57
+ThrowNullRef14:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %63
+ThrowNullRef16:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %70
+ThrowNullRef18:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5419,7 +6587,293 @@ ThrowNullRef17:                                   ; preds = %70
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
-Failed to read String.TrimHelper[loadElem]
+Successfully read String.TrimHelper
+
+define %System.String addrspace(1)* @String.TrimHelper(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i16
+  %loc4 = alloca i32
+  %loc5 = alloca i16
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = sub i32 %3, 1
+  store i32 %4, i32* %loc0
+  store i32 0, i32* %loc1
+  %5 = load i32, i32* %arg2
+  %6 = icmp eq i32 %5, 1
+  br i1 %6, label %62, label %7
+
+; <label>:7                                       ; preds = %1
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:8                                       ; preds = %58
+  store i32 0, i32* %loc2
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load i32, i32* %loc1
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2, i32 %10
+  %13 = load i16, i16 addrspace(1)* %12
+  %14 = zext i16 %13 to i32
+  %15 = trunc i32 %14 to i16
+  store i16 %15, i16* %loc3
+  store i32 0, i32* %loc2
+  br label %34
+
+; <label>:16                                      ; preds = %37
+  %17 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %18 = load i32, i32* %loc2
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %17, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %19
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = zext i32 %18 to i64
+  %BoundsCheck = icmp uge i64 %23, %22
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %24
+
+; <label>:24                                      ; preds = %19
+  %25 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 3, i32 %18
+  %26 = load i16, i16 addrspace(1)* %25, align 8
+  %27 = zext i16 %26 to i32
+  %28 = load i16, i16* %loc3
+  %29 = zext i16 %28 to i32
+  %30 = icmp eq i32 %27, %29
+  br i1 %30, label %43, label %31
+
+; <label>:31                                      ; preds = %24
+  %32 = load i32, i32* %loc2
+  %33 = add i32 %32, 1
+  store i32 %33, i32* %loc2
+  br label %34
+
+; <label>:34                                      ; preds = %11, %31
+  %35 = load i32, i32* %loc2
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = icmp slt i32 %35, %41
+  br i1 %42, label %16, label %43
+
+; <label>:43                                      ; preds = %24, %37
+  %44 = load i32, i32* %loc2
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %45, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp eq i32 %44, %50
+  br i1 %51, label %62, label %52
+
+; <label>:52                                      ; preds = %46
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %7, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %57, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %58
+
+; <label>:58                                      ; preds = %55
+  %59 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %60 = load i32, i32 addrspace(1)* %59
+  %61 = icmp slt i32 %56, %60
+  br i1 %61, label %8, label %62
+
+; <label>:62                                      ; preds = %1, %46, %58
+  %63 = load i32, i32* %arg2
+  %64 = icmp eq i32 %63, 0
+  br i1 %64, label %122, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %66, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %67
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %66, i32 0, i32 1
+  %69 = load i32, i32 addrspace(1)* %68
+  %70 = sub i32 %69, 1
+  store i32 %70, i32* %loc0
+  br label %118
+
+; <label>:71                                      ; preds = %118
+  store i32 0, i32* %loc4
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %73 = load i32, i32* %loc0
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %74
+
+; <label>:74                                      ; preds = %71
+  %75 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 2, i32 %73
+  %76 = load i16, i16 addrspace(1)* %75
+  %77 = zext i16 %76 to i32
+  %78 = trunc i32 %77 to i16
+  store i16 %78, i16* %loc5
+  store i32 0, i32* %loc4
+  br label %97
+
+; <label>:79                                      ; preds = %100
+  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %81 = load i32, i32* %loc4
+  %NullCheck19 = icmp eq %"System.Char[]" addrspace(1)* %80, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
+
+; <label>:82                                      ; preds = %79
+  %83 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 1
+  %84 = load i32, i32 addrspace(1)* %83
+  %85 = zext i32 %84 to i64
+  %86 = zext i32 %81 to i64
+  %BoundsCheck21 = icmp uge i64 %86, %85
+  br i1 %BoundsCheck21, label %ThrowIndexOutOfRange22, label %87
+
+; <label>:87                                      ; preds = %82
+  %88 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 3, i32 %81
+  %89 = load i16, i16 addrspace(1)* %88, align 8
+  %90 = zext i16 %89 to i32
+  %91 = load i16, i16* %loc5
+  %92 = zext i16 %91 to i32
+  %93 = icmp eq i32 %90, %92
+  br i1 %93, label %106, label %94
+
+; <label>:94                                      ; preds = %87
+  %95 = load i32, i32* %loc4
+  %96 = add i32 %95, 1
+  store i32 %96, i32* %loc4
+  br label %97
+
+; <label>:97                                      ; preds = %74, %94
+  %98 = load i32, i32* %loc4
+  %99 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck15 = icmp eq %"System.Char[]" addrspace(1)* %99, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %100
+
+; <label>:100                                     ; preds = %97
+  %101 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %99, i32 0, i32 1
+  %102 = load i32, i32 addrspace(1)* %101
+  %103 = zext i32 %102 to i64
+  %104 = trunc i64 %103 to i32
+  %105 = icmp slt i32 %98, %104
+  br i1 %105, label %79, label %106
+
+; <label>:106                                     ; preds = %87, %100
+  %107 = load i32, i32* %loc4
+  %108 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck17 = icmp eq %"System.Char[]" addrspace(1)* %108, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %109
+
+; <label>:109                                     ; preds = %106
+  %110 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %108, i32 0, i32 1
+  %111 = load i32, i32 addrspace(1)* %110
+  %112 = zext i32 %111 to i64
+  %113 = trunc i64 %112 to i32
+  %114 = icmp eq i32 %107, %113
+  br i1 %114, label %122, label %115
+
+; <label>:115                                     ; preds = %109
+  %116 = load i32, i32* %loc0
+  %117 = sub i32 %116, 1
+  store i32 %117, i32* %loc0
+  br label %118
+
+; <label>:118                                     ; preds = %67, %115
+  %119 = load i32, i32* %loc0
+  %120 = load i32, i32* %loc1
+  %121 = icmp sge i32 %119, %120
+  br i1 %121, label %71, label %122
+
+; <label>:122                                     ; preds = %62, %109, %118
+  %123 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %124 = load i32, i32* %loc1
+  %125 = load i32, i32* %loc0
+  %126 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %123, i32 %124, i32 %125)
+  ret %System.String addrspace(1)* %126
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %97
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange22:                           ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
 Successfully read String.CreateTrimmedString
 
@@ -5439,8 +6893,8 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
@@ -5535,8 +6989,8 @@ entry:
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i64 2872
   %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
   %8 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %7
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %3
   %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
@@ -5553,8 +7007,8 @@ entry:
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 2864
   %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
   %21 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %20
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
-  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %22
 
 ; <label>:22                                      ; preds = %16
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
@@ -5569,7 +7023,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %16
+ThrowNullRef2:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5586,8 +7040,8 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5613,8 +7067,8 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
@@ -5632,8 +7086,8 @@ entry:
 
 ; <label>:12                                      ; preds = %4
   %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
@@ -5644,8 +7098,8 @@ entry:
 
 ; <label>:19                                      ; preds = %14
   %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %19
   %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
@@ -5660,21 +7114,21 @@ entry:
   %31 = zext i16 %30 to i32
   %32 = bitcast i8* %29 to i16*
   %33 = trunc i32 %31 to i16
-  %NullCheck6 = icmp ne i16* %32, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i16* %32, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %21
   store i16 %33, i16* %32, align 8
   %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %36
 
 ; <label>:36                                      ; preds = %34
   %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
   %38 = load i32, i32 addrspace(1)* %37, align 8
   %39 = add i32 %38, 1
-  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %40
 
 ; <label>:40                                      ; preds = %36
   %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
@@ -5683,16 +7137,16 @@ entry:
 
 ; <label>:42                                      ; preds = %14
   %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
-  br i1 %NullCheck12, label %44, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
   %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
   %47 = load i16, i16* %arg1
   %48 = zext i16 %47 to i32
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = trunc i32 %48 to i16
@@ -5703,31 +7157,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %19
+ThrowNullRef4:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %21
+ThrowNullRef6:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %36
+ThrowNullRef10:                                   ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %42
+ThrowNullRef12:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %44
+ThrowNullRef14:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5740,8 +7194,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -5752,8 +7206,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
@@ -5762,14 +7216,14 @@ entry:
 
 ; <label>:11                                      ; preds = %1
   %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
@@ -5779,15 +7233,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5808,8 +7262,8 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5822,8 +7276,8 @@ entry:
 
 ; <label>:8                                       ; preds = %3
   %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
@@ -5842,15 +7296,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
-  br i1 %NullCheck4, label %22, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
   %24 = load i16*, i16* addrspace(1)* %23, align 8
   %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %25, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
@@ -5859,8 +7313,8 @@ entry:
   store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
@@ -5874,8 +7328,8 @@ entry:
 
 ; <label>:37                                      ; preds = %65
   %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %37
   %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
@@ -5886,16 +7340,16 @@ entry:
   %45 = bitcast i16* %41 to i8*
   %46 = getelementptr inbounds i8, i8* %45, i64 %44
   %47 = bitcast i8* %46 to i16*
-  %NullCheck14 = icmp ne i16* %47, null
-  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %47, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %48
 
 ; <label>:48                                      ; preds = %39
   %49 = load i16, i16* %47, align 8
   %50 = zext i16 %49 to i32
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %52 = load i32, i32* %loc1
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %53
 
 ; <label>:53                                      ; preds = %48
   %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
@@ -5916,8 +7370,8 @@ entry:
 ; <label>:62                                      ; preds = %36, %59
   %63 = load i32, i32* %loc1
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck10, label %65, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %65
 
 ; <label>:65                                      ; preds = %62
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
@@ -5936,15 +7390,15 @@ entry:
 
 ; <label>:74                                      ; preds = %70
   %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
-  br i1 %NullCheck18, label %76, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %76
 
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
   %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
-  br i1 %NullCheck20, label %80, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
   %81 = load i64, i64 addrspace(1)* %79
@@ -5958,8 +7412,8 @@ entry:
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
   %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
-  br i1 %NullCheck22, label %92, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.String addrspace(1)* %90, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %92
 
 ; <label>:92                                      ; preds = %80
   %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
@@ -5969,15 +7423,15 @@ entry:
 
 ; <label>:96                                      ; preds = %70
   %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
-  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %98
 
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
   %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
-  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
   %103 = load i64, i64 addrspace(1)* %101
@@ -5991,8 +7445,8 @@ entry:
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
   %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
-  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.String addrspace(1)* %112, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %114
 
 ; <label>:114                                     ; preds = %102
   %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
@@ -6004,59 +7458,59 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %20
+ThrowNullRef4:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %22
+ThrowNullRef6:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %26
+ThrowNullRef8:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %62
+ThrowNullRef10:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %48
+ThrowNullRef16:                                   ; preds = %48
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %74
+ThrowNullRef18:                                   ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %76
+ThrowNullRef20:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %80
+ThrowNullRef22:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %96
+ThrowNullRef24:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %98
+ThrowNullRef26:                                   ; preds = %98
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %102
+ThrowNullRef28:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6069,15 +7523,15 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
   %3 = load i16*, i16* addrspace(1)* %2, align 8
   %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
@@ -6087,8 +7541,8 @@ entry:
   %10 = bitcast i16* %3 to i8*
   %11 = getelementptr inbounds i8, i8* %10, i64 %9
   %12 = bitcast i8* %11 to i16*
-  %NullCheck4 = icmp ne i16* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %5
   store i16 0, i16* %12, align 8
@@ -6098,11 +7552,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6119,8 +7573,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -6131,8 +7585,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
@@ -6144,15 +7598,15 @@ entry:
 
 ; <label>:14                                      ; preds = %1
   %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
   %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
   %21 = load i64, i64 addrspace(1)* %19
@@ -6171,15 +7625,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %14
+ThrowNullRef4:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %16
+ThrowNullRef6:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6302,14 +7756,6 @@ entry:
   ret %System.String addrspace(1)* %57
 }
 
-INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
-Successfully read RuntimeHelpers.get_OffsetToStringData
-
-define i32 @RuntimeHelpers.get_OffsetToStringData() {
-entry:
-  ret i32 12
-}
-
 INFO:  jitting method String::Equals using LLILCJit
 Successfully read String.Equals
 
@@ -6381,8 +7827,8 @@ entry:
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
-  br i1 %NullCheck24, label %29, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
   %30 = load i64, i64 addrspace(1)* %28
@@ -6397,8 +7843,8 @@ entry:
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
-  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
   %43 = load i64, i64 addrspace(1)* %41
@@ -6418,8 +7864,8 @@ entry:
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
   %59 = load i64, i64 addrspace(1)* %57
@@ -6434,8 +7880,8 @@ entry:
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck22, label %71, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
   %72 = load i64, i64 addrspace(1)* %70
@@ -6455,8 +7901,8 @@ entry:
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
-  br i1 %NullCheck16, label %87, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = load i64, i64 addrspace(1)* %86
@@ -6471,8 +7917,8 @@ entry:
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck18, label %100, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
   %101 = load i64, i64 addrspace(1)* %99
@@ -6492,8 +7938,8 @@ entry:
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
-  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
   %117 = load i64, i64 addrspace(1)* %115
@@ -6508,8 +7954,8 @@ entry:
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
-  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
   %130 = load i64, i64 addrspace(1)* %128
@@ -6528,15 +7974,15 @@ entry:
 
 ; <label>:142                                     ; preds = %22
   %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
-  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %143, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %144
 
 ; <label>:144                                     ; preds = %142
   %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
   %146 = load i32, i32 addrspace(1)* %145
   %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
-  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %147, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %148
 
 ; <label>:148                                     ; preds = %144
   %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
@@ -6557,15 +8003,15 @@ entry:
 
 ; <label>:159                                     ; preds = %22
   %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
-  br i1 %NullCheck, label %161, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %ThrowNullRef, label %161
 
 ; <label>:161                                     ; preds = %159
   %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
   %163 = load i32, i32 addrspace(1)* %162
   %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
-  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %164, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %165
 
 ; <label>:165                                     ; preds = %161
   %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
@@ -6578,8 +8024,8 @@ entry:
 
 ; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
-  br i1 %NullCheck4, label %172, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %171, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %172
 
 ; <label>:172                                     ; preds = %170
   %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
@@ -6589,8 +8035,8 @@ entry:
 
 ; <label>:176                                     ; preds = %172
   %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
-  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %177, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %178
 
 ; <label>:178                                     ; preds = %176
   %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
@@ -6629,55 +8075,55 @@ ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %161
+ThrowNullRef2:                                    ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %170
+ThrowNullRef4:                                    ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %176
+ThrowNullRef6:                                    ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %142
+ThrowNullRef8:                                    ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %144
+ThrowNullRef10:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %113
+ThrowNullRef12:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %116
+ThrowNullRef14:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %84
+ThrowNullRef16:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %87
+ThrowNullRef18:                                   ; preds = %87
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %55
+ThrowNullRef20:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %58
+ThrowNullRef22:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %26
+ThrowNullRef24:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %29
+ThrowNullRef26:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,8 +8161,8 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck, label %14, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %ThrowNullRef, label %14
 
 ; <label>:14                                      ; preds = %8
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
@@ -6760,8 +8206,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
@@ -6770,14 +8216,14 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32, i32* %loc0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %10
   %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
   %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
@@ -6790,15 +8236,15 @@ entry:
 ; <label>:25                                      ; preds = %19
   %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
-  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
   %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
@@ -6807,8 +8253,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %37 = load i32, i32* %loc0
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %38, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %38
 
 ; <label>:38                                      ; preds = %32
   %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
@@ -6817,14 +8263,14 @@ entry:
 
 ; <label>:40                                      ; preds = %19
   %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %40
   %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
   %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
-  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
-  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
@@ -6832,8 +8278,8 @@ entry:
   %48 = zext i32 %47 to i64
   %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
-  br i1 %NullCheck16, label %51, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %51
 
 ; <label>:51                                      ; preds = %45
   %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
@@ -6847,15 +8293,15 @@ entry:
 ; <label>:57                                      ; preds = %51
   %58 = load i16*, i16** %arg1
   %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
-  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %60
 
 ; <label>:60                                      ; preds = %57
   %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
   %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
-  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %64
 
 ; <label>:64                                      ; preds = %60
   %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
@@ -6864,22 +8310,22 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
   %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
-  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %70
 
 ; <label>:70                                      ; preds = %64
   %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
   %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
-  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
-  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
   %75 = load i32, i32 addrspace(1)* %74
   %76 = zext i32 %75 to i64
   %77 = trunc i64 %76 to i32
-  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
-  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %78
 
 ; <label>:78                                      ; preds = %73
   %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
@@ -6901,8 +8347,8 @@ entry:
   %90 = bitcast i16* %86 to i8*
   %91 = getelementptr inbounds i8, i8* %90, i64 %89
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %93
 
 ; <label>:93                                      ; preds = %80
   %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
@@ -6912,8 +8358,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %99 = load i32, i32* %loc2
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %100
 
 ; <label>:100                                     ; preds = %93
   %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
@@ -6928,63 +8374,63 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %25
+ThrowNullRef6:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %32
+ThrowNullRef10:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %40
+ThrowNullRef12:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %45
+ThrowNullRef16:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %57
+ThrowNullRef18:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %60
+ThrowNullRef20:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %64
+ThrowNullRef22:                                   ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %70
+ThrowNullRef24:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %73
+ThrowNullRef26:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %80
+ThrowNullRef28:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %93
+ThrowNullRef30:                                   ; preds = %93
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7004,8 +8450,8 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
@@ -7033,43 +8479,43 @@ entry:
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %14
   %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
   %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   %28 = load i32, i32 addrspace(1)* %27, align 8
   %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
-  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %30
 
 ; <label>:30                                      ; preds = %26
   %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
   %32 = load i32, i32 addrspace(1)* %31, align 8
   %33 = add i32 %28, %32
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %34
 
 ; <label>:34                                      ; preds = %30
   %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   store i32 %33, i32 addrspace(1)* %35
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
   store i32 0, i32 addrspace(1)* %38
   %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %40
 
 ; <label>:40                                      ; preds = %37
   %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
@@ -7082,8 +8528,8 @@ entry:
 
 ; <label>:47                                      ; preds = %40
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
@@ -7098,8 +8544,8 @@ entry:
   %54 = load i32, i32* %loc0
   %55 = sext i32 %54 to i64
   %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
-  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %57
 
 ; <label>:57                                      ; preds = %52
   %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
@@ -7110,68 +8556,35 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %14
+ThrowNullRef2:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %23
+ThrowNullRef4:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %26
+ThrowNullRef6:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %30
+ThrowNullRef8:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %34
+ThrowNullRef10:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %47
+ThrowNullRef14:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %52
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-}
-
-INFO:  jitting method StringBuilder::get_Length using LLILCJit
-Successfully read StringBuilder.get_Length
-
-define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.StringBuilder addrspace(1)*
-  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
-  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
-
-; <label>:1                                       ; preds = %entry
-  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %3 = load i32, i32 addrspace(1)* %2, align 8
-  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
-
-; <label>:5                                       ; preds = %1
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = add i32 %3, %7
-  ret i32 %8
-
-ThrowNullRef:                                     ; preds = %entry
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef16:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7213,70 +8626,70 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
   %6 = load i32, i32 addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
   store i32 %6, i32 addrspace(1)* %8
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
   %13 = load i32, i32 addrspace(1)* %12, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
   store i32 %13, i32 addrspace(1)* %15
   %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
-  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %18
 
 ; <label>:18                                      ; preds = %14
   %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
   %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
   %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
   %34 = load i32, i32 addrspace(1)* %33, align 8
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
-  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
@@ -7287,39 +8700,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %28
+ThrowNullRef16:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %32
+ThrowNullRef18:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7455,13 +8868,13 @@ entry:
 ; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
@@ -7477,16 +8890,16 @@ entry:
 
 ; <label>:18                                      ; preds = %15
   %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
   store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
   %22 = load i32, i32* %loc0
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %24
 
 ; <label>:24                                      ; preds = %20
   %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
@@ -7498,13 +8911,13 @@ entry:
 ; <label>:28                                      ; preds = %15, %24
   %29 = load i32, i32* %arg1
   %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %31
   %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
@@ -7517,20 +8930,20 @@ entry:
   %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
-  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
   %46 = load i32, i32 addrspace(1)* %45, align 8
   %47 = sub i32 %40, %46
-  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
-  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i32 addrspace(1)* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %48
 
 ; <label>:48                                      ; preds = %44
   store i32 %47, i32 addrspace(1)* %39, align 8
@@ -7538,21 +8951,21 @@ entry:
 
 ; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
-  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %51
 
 ; <label>:51                                      ; preds = %49
   %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %53
 
 ; <label>:53                                      ; preds = %51
   %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
   %55 = load i32, i32 addrspace(1)* %54, align 8
   %56 = load i32, i32* %arg2
   %57 = sub i32 %55, %56
-  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %58
 
 ; <label>:58                                      ; preds = %53
   %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
@@ -7562,13 +8975,13 @@ entry:
 ; <label>:60                                      ; preds = %33, %58
   %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
   %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
-  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %63
 
 ; <label>:63                                      ; preds = %60
   %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
-  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
-  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
@@ -7578,15 +8991,15 @@ entry:
 
 ; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
-  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i32 addrspace(1)* %69, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %70
 
 ; <label>:70                                      ; preds = %68
   %71 = load i32, i32 addrspace(1)* %69, align 8
   store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
-  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
@@ -7596,8 +9009,8 @@ entry:
   store i32 %77, i32* %loc4
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
-  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %80
 
 ; <label>:80                                      ; preds = %73
   %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
@@ -7607,71 +9020,71 @@ entry:
 ; <label>:83                                      ; preds = %80
   store i32 0, i32* %loc3
   %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
-  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
-  br i1 %NullCheck26, label %88, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i32 addrspace(1)* %87, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %88
 
 ; <label>:88                                      ; preds = %85
   %89 = load i32, i32 addrspace(1)* %87, align 8
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
-  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %90
 
 ; <label>:90                                      ; preds = %88
   %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
   store i32 %89, i32 addrspace(1)* %91
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
-  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
-  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %96
 
 ; <label>:96                                      ; preds = %94
   %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
-  br i1 %NullCheck34, label %100, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %100
 
 ; <label>:100                                     ; preds = %96
   %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
-  br i1 %NullCheck36, label %102, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %102
 
 ; <label>:102                                     ; preds = %100
   %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
   %104 = load i32, i32 addrspace(1)* %103, align 8
   %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
-  br i1 %NullCheck38, label %106, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %106
 
 ; <label>:106                                     ; preds = %102
   %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
-  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
-  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %108
 
 ; <label>:108                                     ; preds = %106
   %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
   %110 = load i32, i32 addrspace(1)* %109, align 8
   %111 = add i32 %104, %110
-  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %112
 
 ; <label>:112                                     ; preds = %108
   %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
   store i32 %111, i32 addrspace(1)* %113
   %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
-  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i32 addrspace(1)* %114, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %115
 
 ; <label>:115                                     ; preds = %112
   %116 = load i32, i32 addrspace(1)* %114, align 8
@@ -7681,19 +9094,19 @@ entry:
 ; <label>:118                                     ; preds = %115
   %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
-  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %121
 
 ; <label>:121                                     ; preds = %118
   %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
-  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
-  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %123
 
 ; <label>:123                                     ; preds = %121
   %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
   %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
-  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
-  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %126
 
 ; <label>:126                                     ; preds = %123
   %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
@@ -7705,8 +9118,8 @@ entry:
 
 ; <label>:130                                     ; preds = %80, %115, %126
   %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %132
 
 ; <label>:132                                     ; preds = %130
   %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7715,8 +9128,8 @@ entry:
   %136 = load i32, i32* %loc3
   %137 = sub i32 %135, %136
   %138 = sub i32 %134, %137
-  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %139
 
 ; <label>:139                                     ; preds = %132
   %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7728,16 +9141,16 @@ entry:
 
 ; <label>:144                                     ; preds = %139
   %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
-  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %146
 
 ; <label>:146                                     ; preds = %144
   %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
   %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
   %149 = load i32, i32* %loc2
   %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
-  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %151
 
 ; <label>:151                                     ; preds = %146
   %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
@@ -7754,145 +9167,249 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %18
+ThrowNullRef4:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %31
+ThrowNullRef10:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %44
+ThrowNullRef16:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %68
+ThrowNullRef18:                                   ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %70
+ThrowNullRef20:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %73
+ThrowNullRef22:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %83
+ThrowNullRef24:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %85
+ThrowNullRef26:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %88
+ThrowNullRef28:                                   ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %90
+ThrowNullRef30:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %94
+ThrowNullRef32:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %96
+ThrowNullRef34:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %100
+ThrowNullRef36:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %102
+ThrowNullRef38:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %106
+ThrowNullRef40:                                   ; preds = %106
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %108
+ThrowNullRef42:                                   ; preds = %108
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %112
+ThrowNullRef44:                                   ; preds = %112
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %118
+ThrowNullRef46:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %121
+ThrowNullRef48:                                   ; preds = %121
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %123
+ThrowNullRef50:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %130
+ThrowNullRef52:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %132
+ThrowNullRef54:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %144
+ThrowNullRef56:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %146
+ThrowNullRef58:                                   ; preds = %146
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %60
+ThrowNullRef60:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %63
+ThrowNullRef62:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %49
+ThrowNullRef64:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %51
+ThrowNullRef66:                                   ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %53
+ThrowNullRef68:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(%"System.Char[]" addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %arg0 = alloca %"System.Char[]" addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store %"System.Char[]" addrspace(1)* %param0, %"System.Char[]" addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load i32, i32* %arg4
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %43, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %38, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg1
+  %13 = load i32, i32* %arg4
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %38, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %24 = load i32, i32* %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %35 = load i32, i32* %arg3
+  %36 = load i32, i32* %arg4
+  %37 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %37, %"System.Char[]" addrspace(1)* %34, i32 %35, i32 %36)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:38                                      ; preds = %5, %16
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Successfully read Buffer._Memmove
 
@@ -7914,7 +9431,7 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[loadElem]
+Failed to read AppDomain.SetDataHelper[storeElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -7923,8 +9440,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
@@ -7934,8 +9451,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
@@ -7947,15 +9464,15 @@ entry:
   %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
   %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
@@ -7966,15 +9483,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7992,7 +9509,79 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
-Failed to read Dictionary`2.TryGetValue[loadElemA]
+Successfully read Dictionary`2.TryGetValue
+
+define i8 @"Dictionary`2.TryGetValue"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)* addrspace(1)* %param2) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  %arg2 = alloca %System.__Canon addrspace(1)* addrspace(1)*
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  store %System.__Canon addrspace(1)* addrspace(1)* %param2, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  store i32 %2, i32* %loc0
+  %3 = load i32, i32* %loc0
+  %4 = icmp slt i32 %3, 0
+  br i1 %4, label %22, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 2
+  %10 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %9, align 8
+  %11 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = zext i32 %11 to i64
+  %BoundsCheck = icmp uge i64 %16, %15
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 3, i32 %11
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %20, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %6, %System.__Canon addrspace(1)* %21)
+  ret i8 1
+
+; <label>:22                                      ; preds = %entry
+  %23 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %23, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -8058,8 +9647,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
@@ -8091,8 +9680,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
@@ -8171,15 +9760,15 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck, label %19, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %ThrowNullRef, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
   %21 = load i32, i32 addrspace(1)* %20
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
@@ -8202,7 +9791,7 @@ ThrowNullRef:                                     ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %19
+ThrowNullRef2:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8248,8 +9837,8 @@ entry:
   %0 = alloca %System.AppDomainHandle
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %1 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %1, i32 0, i32 15
@@ -8269,8 +9858,8 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
@@ -8286,7 +9875,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -8299,8 +9888,8 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -8327,8 +9916,8 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
@@ -8352,8 +9941,8 @@ entry:
   %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
   store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
@@ -8363,8 +9952,8 @@ entry:
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
@@ -8374,8 +9963,8 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %9
   %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
@@ -8384,8 +9973,8 @@ entry:
 
 ; <label>:18                                      ; preds = %3, %16
   %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
@@ -8397,15 +9986,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %18
+ThrowNullRef6:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8418,8 +10007,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
@@ -8453,15 +10042,15 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
@@ -8473,7 +10062,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8481,7 +10070,7 @@ ThrowNullRef1:                                    ; preds = %1
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
 Failed to read Dictionary`2.System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
@@ -8506,8 +10095,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
@@ -8524,8 +10113,8 @@ entry:
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -8544,7 +10133,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8577,8 +10166,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = load i64, i64* %arg2
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = trunc i32 %3 to i8
@@ -8634,46 +10223,46 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
   %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
-  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
-  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
-  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
@@ -8684,27 +10273,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %20
+ThrowNullRef12:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8717,8 +10306,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -8756,22 +10345,22 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
   %9 = load i64, i64 addrspace(1)* %8, align 8
   %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
   %13 = load i64, i64 addrspace(1)* %12, align 8
   %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %11
   %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
@@ -8788,11 +10377,11 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8882,8 +10471,8 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
@@ -8900,8 +10489,8 @@ entry:
 ; <label>:8                                       ; preds = %1
   %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
   %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
@@ -8911,15 +10500,15 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
   %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
   %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
-  br i1 %NullCheck6, label %21, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
@@ -8946,15 +10535,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8992,15 +10581,15 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
   store i8 %3, i8 addrspace(1)* %5
   %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
@@ -9011,7 +10600,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9027,8 +10616,8 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -9041,8 +10630,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
@@ -9058,7 +10647,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9080,8 +10669,8 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
@@ -9096,8 +10685,8 @@ entry:
 ; <label>:12                                      ; preds = %6
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
@@ -9112,8 +10701,8 @@ entry:
 ; <label>:21                                      ; preds = %15
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
@@ -9128,8 +10717,8 @@ entry:
 ; <label>:30                                      ; preds = %24
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %31, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
@@ -9144,8 +10733,8 @@ entry:
 ; <label>:39                                      ; preds = %33
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
-  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %40, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %42
 
 ; <label>:42                                      ; preds = %39
   %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
@@ -9164,19 +10753,19 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %21
+ThrowNullRef4:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %30
+ThrowNullRef6:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %39
+ThrowNullRef8:                                    ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9243,8 +10832,8 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
@@ -9264,57 +10853,57 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
   store i8 0, i8 addrspace(1)* %2
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
   store i8 0, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
   store i8 0, i8 addrspace(1)* %17
   %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
   store i8 0, i8 addrspace(1)* %20
   %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
-  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
@@ -9325,31 +10914,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %19
+ThrowNullRef14:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9367,8 +10956,8 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
@@ -9380,8 +10969,8 @@ entry:
 
 ; <label>:9                                       ; preds = %4
   %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %9
   %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
@@ -9395,7 +10984,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef2:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9420,8 +11009,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
@@ -9512,8 +11101,8 @@ entry:
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
@@ -9524,8 +11113,8 @@ entry:
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = load i64, i64 addrspace(1)* %12
@@ -9537,8 +11126,8 @@ entry:
   %20 = load i64, i64* %19
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
-  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %13
   %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
@@ -9555,8 +11144,8 @@ entry:
 ; <label>:30                                      ; preds = %25
   %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %32 = load i32, i32* %arg2
-  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
-  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
@@ -9570,15 +11159,15 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %30
+ThrowNullRef2:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9622,87 +11211,87 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
   %10 = load i8, i8 addrspace(1)* %9, align 8
   %11 = zext i8 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %8
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
   store i8 %12, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
   %19 = load i8, i8 addrspace(1)* %18, align 8
   %20 = zext i8 %19 to i32
   %21 = trunc i32 %20 to i8
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
   store i8 %21, i8 addrspace(1)* %23
   %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
   %28 = load i8, i8 addrspace(1)* %27, align 8
   %29 = zext i8 %28 to i32
   %30 = trunc i32 %29 to i8
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
-  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %31
 
 ; <label>:31                                      ; preds = %26
   %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
   store i8 %30, i8 addrspace(1)* %32
   %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
-  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
-  br i1 %NullCheck14, label %40, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %40
 
 ; <label>:40                                      ; preds = %35
   %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
   store i8 %39, i8 addrspace(1)* %41
   %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
-  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %44
 
 ; <label>:44                                      ; preds = %40
   %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
   %46 = load i8, i8 addrspace(1)* %45, align 8
   %47 = zext i8 %46 to i32
   %48 = trunc i32 %47 to i8
-  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
   store i8 %48, i8 addrspace(1)* %50
   %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
-  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
@@ -9713,29 +11302,29 @@ entry:
 ; <label>:56                                      ; preds = %52
   %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
-  br i1 %NullCheck22, label %59, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
   %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
   %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
-  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
-  br i1 %NullCheck24, label %63, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
   %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
-  br i1 %NullCheck26, label %66, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
   %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
-  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
-  br i1 %NullCheck28, label %69, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %69
 
 ; <label>:69                                      ; preds = %66
   %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
@@ -9744,15 +11333,15 @@ entry:
 
 ; <label>:71                                      ; preds = %105
   %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
-  br i1 %NullCheck34, label %73, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %73
 
 ; <label>:73                                      ; preds = %71
   %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
   %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
   %76 = load i32, i32* %loc0
-  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
-  br i1 %NullCheck36, label %77, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
@@ -9766,8 +11355,8 @@ entry:
 
 ; <label>:83                                      ; preds = %77
   %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
-  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
@@ -9775,14 +11364,14 @@ entry:
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
   %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
-  br i1 %NullCheck40, label %91, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
 ; <label>:91                                      ; preds = %85
   %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
   %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
-  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck42, label %94, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %94
 
 ; <label>:94                                      ; preds = %91
   %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
@@ -9798,14 +11387,14 @@ entry:
 ; <label>:99                                      ; preds = %69, %96
   %100 = load i32, i32* %loc0
   %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
-  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %102
 
 ; <label>:102                                     ; preds = %99
   %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
   %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
-  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
-  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
@@ -9819,87 +11408,87 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %26
+ThrowNullRef10:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %31
+ThrowNullRef12:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %35
+ThrowNullRef14:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %40
+ThrowNullRef16:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %56
+ThrowNullRef22:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %59
+ThrowNullRef24:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %63
+ThrowNullRef26:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %66
+ThrowNullRef28:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %102
+ThrowNullRef32:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %71
+ThrowNullRef34:                                   ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %73
+ThrowNullRef36:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %83
+ThrowNullRef38:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %85
+ThrowNullRef40:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %91
+ThrowNullRef42:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9943,15 +11532,15 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
   %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
@@ -9961,28 +11550,28 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
   %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %12
   %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
   %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
   %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
-  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
@@ -9993,23 +11582,23 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %12
+ThrowNullRef6:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10031,15 +11620,15 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
   %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = load i64, i64 addrspace(1)* %7
@@ -10077,13 +11666,13 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[loadElem]
+Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -10111,8 +11700,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueGtInt1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueGtInt1.error.txt
@@ -25,8 +25,8 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
@@ -40,8 +40,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
   %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
@@ -75,7 +75,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -90,8 +90,8 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %NullCheck = icmp ne i8 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = load i8, i8 addrspace(1)* %0, align 8
@@ -125,8 +125,8 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
@@ -159,8 +159,8 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -184,8 +184,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
   store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
@@ -195,8 +195,8 @@ entry:
 ; <label>:4                                       ; preds = %1
   %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
   %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
@@ -206,8 +206,8 @@ entry:
   %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
@@ -221,14 +221,14 @@ entry:
 
 ; <label>:17                                      ; preds = %14
   %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
   %21 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
@@ -238,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -249,8 +249,8 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
@@ -261,27 +261,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %30
+ThrowNullRef10:                                   ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -301,7 +301,89 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
-Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
+Successfully read AppDomainSetup.GetUnsecureApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.GetUnsecureApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %NullCheck = icmp eq %"System.String[]" addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %BoundsCheck = icmp uge i64 0, %5
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %6
+
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 3, i32 0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
+  ret %System.String addrspace(1)* %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_Value using LLILCJit
+Successfully read AppDomainSetup.get_Value
+
+define %"System.String[]" addrspace(1)* @AppDomainSetup.get_Value(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.String[]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 18)
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.String[]" addrspace(1)* addrspace(1)*, %"System.String[]" addrspace(1)*)*)(%"System.String[]" addrspace(1)* addrspace(1)* %9, %"System.String[]" addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %11, i32 0, i32 1
+  %14 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %13, align 8
+  ret %"System.String[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -319,8 +401,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -368,16 +450,16 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
   %5 = load i32, i32 addrspace(1)* %4
   %6 = sub i32 %5, 1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -389,7 +471,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -421,8 +503,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
@@ -456,8 +538,8 @@ entry:
 ; <label>:27                                      ; preds = %19
   %28 = load i32, i32* %arg1
   %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
-  br i1 %NullCheck2, label %30, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %29, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %30
 
 ; <label>:30                                      ; preds = %27
   %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
@@ -493,8 +575,8 @@ entry:
 ; <label>:49                                      ; preds = %46
   %50 = load i32, i32* %arg2
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck4, label %52, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
@@ -517,11 +599,11 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %27
+ThrowNullRef2:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %49
+ThrowNullRef4:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -544,16 +626,16 @@ entry:
   %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %0)
   store %System.String addrspace(1)* %1, %System.String addrspace(1)** %loc0
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 2
   %5 = bitcast [0 x i16] addrspace(1)* %4 to i16 addrspace(1)*
   store i16 addrspace(1)* %5, i16 addrspace(1)** %loc1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %3
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2
@@ -580,7 +662,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -691,15 +773,15 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %NullCheck132 = icmp ne i8* %21, null
-  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+  %NullCheck131 = icmp eq i8* %21, null
+  br i1 %NullCheck131, label %ThrowNullRef132, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = load i8, i8* %21, align 8
   %24 = zext i8 %23 to i32
   %25 = trunc i32 %24 to i8
-  %NullCheck134 = icmp ne i8* %20, null
-  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+  %NullCheck133 = icmp eq i8* %20, null
+  br i1 %NullCheck133, label %ThrowNullRef134, label %26
 
 ; <label>:26                                      ; preds = %22
   store i8 %25, i8* %20, align 8
@@ -709,16 +791,16 @@ entry:
   %28 = load i8*, i8** %arg0
   %29 = load i8*, i8** %arg1
   %30 = bitcast i8* %29 to i16*
-  %NullCheck128 = icmp ne i16* %30, null
-  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+  %NullCheck127 = icmp eq i16* %30, null
+  br i1 %NullCheck127, label %ThrowNullRef128, label %31
 
 ; <label>:31                                      ; preds = %27
   %32 = load i16, i16* %30, align 8
   %33 = sext i16 %32 to i32
   %34 = bitcast i8* %28 to i16*
   %35 = trunc i32 %33 to i16
-  %NullCheck130 = icmp ne i16* %34, null
-  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+  %NullCheck129 = icmp eq i16* %34, null
+  br i1 %NullCheck129, label %ThrowNullRef130, label %36
 
 ; <label>:36                                      ; preds = %31
   store i16 %35, i16* %34, align 8
@@ -728,16 +810,16 @@ entry:
   %38 = load i8*, i8** %arg0
   %39 = load i8*, i8** %arg1
   %40 = bitcast i8* %39 to i16*
-  %NullCheck120 = icmp ne i16* %40, null
-  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+  %NullCheck119 = icmp eq i16* %40, null
+  br i1 %NullCheck119, label %ThrowNullRef120, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i16, i16* %40, align 8
   %43 = sext i16 %42 to i32
   %44 = bitcast i8* %38 to i16*
   %45 = trunc i32 %43 to i16
-  %NullCheck122 = icmp ne i16* %44, null
-  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+  %NullCheck121 = icmp eq i16* %44, null
+  br i1 %NullCheck121, label %ThrowNullRef122, label %46
 
 ; <label>:46                                      ; preds = %41
   store i16 %45, i16* %44, align 8
@@ -745,15 +827,15 @@ entry:
   %48 = getelementptr inbounds i8, i8* %47, i64 2
   %49 = load i8*, i8** %arg1
   %50 = getelementptr inbounds i8, i8* %49, i64 2
-  %NullCheck124 = icmp ne i8* %50, null
-  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+  %NullCheck123 = icmp eq i8* %50, null
+  br i1 %NullCheck123, label %ThrowNullRef124, label %51
 
 ; <label>:51                                      ; preds = %46
   %52 = load i8, i8* %50, align 8
   %53 = zext i8 %52 to i32
   %54 = trunc i32 %53 to i8
-  %NullCheck126 = icmp ne i8* %48, null
-  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+  %NullCheck125 = icmp eq i8* %48, null
+  br i1 %NullCheck125, label %ThrowNullRef126, label %55
 
 ; <label>:55                                      ; preds = %51
   store i8 %54, i8* %48, align 8
@@ -763,14 +845,14 @@ entry:
   %57 = load i8*, i8** %arg0
   %58 = load i8*, i8** %arg1
   %59 = bitcast i8* %58 to i32*
-  %NullCheck116 = icmp ne i32* %59, null
-  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+  %NullCheck115 = icmp eq i32* %59, null
+  br i1 %NullCheck115, label %ThrowNullRef116, label %60
 
 ; <label>:60                                      ; preds = %56
   %61 = load i32, i32* %59, align 8
   %62 = bitcast i8* %57 to i32*
-  %NullCheck118 = icmp ne i32* %62, null
-  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+  %NullCheck117 = icmp eq i32* %62, null
+  br i1 %NullCheck117, label %ThrowNullRef118, label %63
 
 ; <label>:63                                      ; preds = %60
   store i32 %61, i32* %62, align 8
@@ -780,14 +862,14 @@ entry:
   %65 = load i8*, i8** %arg0
   %66 = load i8*, i8** %arg1
   %67 = bitcast i8* %66 to i32*
-  %NullCheck108 = icmp ne i32* %67, null
-  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+  %NullCheck107 = icmp eq i32* %67, null
+  br i1 %NullCheck107, label %ThrowNullRef108, label %68
 
 ; <label>:68                                      ; preds = %64
   %69 = load i32, i32* %67, align 8
   %70 = bitcast i8* %65 to i32*
-  %NullCheck110 = icmp ne i32* %70, null
-  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+  %NullCheck109 = icmp eq i32* %70, null
+  br i1 %NullCheck109, label %ThrowNullRef110, label %71
 
 ; <label>:71                                      ; preds = %68
   store i32 %69, i32* %70, align 8
@@ -795,15 +877,15 @@ entry:
   %73 = getelementptr inbounds i8, i8* %72, i64 4
   %74 = load i8*, i8** %arg1
   %75 = getelementptr inbounds i8, i8* %74, i64 4
-  %NullCheck112 = icmp ne i8* %75, null
-  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+  %NullCheck111 = icmp eq i8* %75, null
+  br i1 %NullCheck111, label %ThrowNullRef112, label %76
 
 ; <label>:76                                      ; preds = %71
   %77 = load i8, i8* %75, align 8
   %78 = zext i8 %77 to i32
   %79 = trunc i32 %78 to i8
-  %NullCheck114 = icmp ne i8* %73, null
-  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+  %NullCheck113 = icmp eq i8* %73, null
+  br i1 %NullCheck113, label %ThrowNullRef114, label %80
 
 ; <label>:80                                      ; preds = %76
   store i8 %79, i8* %73, align 8
@@ -813,14 +895,14 @@ entry:
   %82 = load i8*, i8** %arg0
   %83 = load i8*, i8** %arg1
   %84 = bitcast i8* %83 to i32*
-  %NullCheck100 = icmp ne i32* %84, null
-  br i1 %NullCheck100, label %85, label %ThrowNullRef99
+  %NullCheck99 = icmp eq i32* %84, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %85
 
 ; <label>:85                                      ; preds = %81
   %86 = load i32, i32* %84, align 8
   %87 = bitcast i8* %82 to i32*
-  %NullCheck102 = icmp ne i32* %87, null
-  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+  %NullCheck101 = icmp eq i32* %87, null
+  br i1 %NullCheck101, label %ThrowNullRef102, label %88
 
 ; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
@@ -829,16 +911,16 @@ entry:
   %91 = load i8*, i8** %arg1
   %92 = getelementptr inbounds i8, i8* %91, i64 4
   %93 = bitcast i8* %92 to i16*
-  %NullCheck104 = icmp ne i16* %93, null
-  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+  %NullCheck103 = icmp eq i16* %93, null
+  br i1 %NullCheck103, label %ThrowNullRef104, label %94
 
 ; <label>:94                                      ; preds = %88
   %95 = load i16, i16* %93, align 8
   %96 = sext i16 %95 to i32
   %97 = bitcast i8* %90 to i16*
   %98 = trunc i32 %96 to i16
-  %NullCheck106 = icmp ne i16* %97, null
-  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+  %NullCheck105 = icmp eq i16* %97, null
+  br i1 %NullCheck105, label %ThrowNullRef106, label %99
 
 ; <label>:99                                      ; preds = %94
   store i16 %98, i16* %97, align 8
@@ -848,14 +930,14 @@ entry:
   %101 = load i8*, i8** %arg0
   %102 = load i8*, i8** %arg1
   %103 = bitcast i8* %102 to i32*
-  %NullCheck88 = icmp ne i32* %103, null
-  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+  %NullCheck87 = icmp eq i32* %103, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %104
 
 ; <label>:104                                     ; preds = %100
   %105 = load i32, i32* %103, align 8
   %106 = bitcast i8* %101 to i32*
-  %NullCheck90 = icmp ne i32* %106, null
-  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+  %NullCheck89 = icmp eq i32* %106, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %107
 
 ; <label>:107                                     ; preds = %104
   store i32 %105, i32* %106, align 8
@@ -864,16 +946,16 @@ entry:
   %110 = load i8*, i8** %arg1
   %111 = getelementptr inbounds i8, i8* %110, i64 4
   %112 = bitcast i8* %111 to i16*
-  %NullCheck92 = icmp ne i16* %112, null
-  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+  %NullCheck91 = icmp eq i16* %112, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %113
 
 ; <label>:113                                     ; preds = %107
   %114 = load i16, i16* %112, align 8
   %115 = sext i16 %114 to i32
   %116 = bitcast i8* %109 to i16*
   %117 = trunc i32 %115 to i16
-  %NullCheck94 = icmp ne i16* %116, null
-  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+  %NullCheck93 = icmp eq i16* %116, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %118
 
 ; <label>:118                                     ; preds = %113
   store i16 %117, i16* %116, align 8
@@ -881,15 +963,15 @@ entry:
   %120 = getelementptr inbounds i8, i8* %119, i64 6
   %121 = load i8*, i8** %arg1
   %122 = getelementptr inbounds i8, i8* %121, i64 6
-  %NullCheck96 = icmp ne i8* %122, null
-  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+  %NullCheck95 = icmp eq i8* %122, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %123
 
 ; <label>:123                                     ; preds = %118
   %124 = load i8, i8* %122, align 8
   %125 = zext i8 %124 to i32
   %126 = trunc i32 %125 to i8
-  %NullCheck98 = icmp ne i8* %120, null
-  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+  %NullCheck97 = icmp eq i8* %120, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %127
 
 ; <label>:127                                     ; preds = %123
   store i8 %126, i8* %120, align 8
@@ -899,14 +981,14 @@ entry:
   %129 = load i8*, i8** %arg0
   %130 = load i8*, i8** %arg1
   %131 = bitcast i8* %130 to i64*
-  %NullCheck84 = icmp ne i64* %131, null
-  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+  %NullCheck83 = icmp eq i64* %131, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %132
 
 ; <label>:132                                     ; preds = %128
   %133 = load i64, i64* %131, align 8
   %134 = bitcast i8* %129 to i64*
-  %NullCheck86 = icmp ne i64* %134, null
-  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+  %NullCheck85 = icmp eq i64* %134, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %135
 
 ; <label>:135                                     ; preds = %132
   store i64 %133, i64* %134, align 8
@@ -916,14 +998,14 @@ entry:
   %137 = load i8*, i8** %arg0
   %138 = load i8*, i8** %arg1
   %139 = bitcast i8* %138 to i64*
-  %NullCheck76 = icmp ne i64* %139, null
-  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+  %NullCheck75 = icmp eq i64* %139, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %140
 
 ; <label>:140                                     ; preds = %136
   %141 = load i64, i64* %139, align 8
   %142 = bitcast i8* %137 to i64*
-  %NullCheck78 = icmp ne i64* %142, null
-  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+  %NullCheck77 = icmp eq i64* %142, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %143
 
 ; <label>:143                                     ; preds = %140
   store i64 %141, i64* %142, align 8
@@ -931,15 +1013,15 @@ entry:
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %NullCheck80 = icmp ne i8* %147, null
-  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+  %NullCheck79 = icmp eq i8* %147, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %148
 
 ; <label>:148                                     ; preds = %143
   %149 = load i8, i8* %147, align 8
   %150 = zext i8 %149 to i32
   %151 = trunc i32 %150 to i8
-  %NullCheck82 = icmp ne i8* %145, null
-  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+  %NullCheck81 = icmp eq i8* %145, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %152
 
 ; <label>:152                                     ; preds = %148
   store i8 %151, i8* %145, align 8
@@ -949,14 +1031,14 @@ entry:
   %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
   %156 = bitcast i8* %155 to i64*
-  %NullCheck68 = icmp ne i64* %156, null
-  br i1 %NullCheck68, label %157, label %ThrowNullRef67
+  %NullCheck67 = icmp eq i64* %156, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %157
 
 ; <label>:157                                     ; preds = %153
   %158 = load i64, i64* %156, align 8
   %159 = bitcast i8* %154 to i64*
-  %NullCheck70 = icmp ne i64* %159, null
-  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+  %NullCheck69 = icmp eq i64* %159, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %160
 
 ; <label>:160                                     ; preds = %157
   store i64 %158, i64* %159, align 8
@@ -965,16 +1047,16 @@ entry:
   %163 = load i8*, i8** %arg1
   %164 = getelementptr inbounds i8, i8* %163, i64 8
   %165 = bitcast i8* %164 to i16*
-  %NullCheck72 = icmp ne i16* %165, null
-  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+  %NullCheck71 = icmp eq i16* %165, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %166
 
 ; <label>:166                                     ; preds = %160
   %167 = load i16, i16* %165, align 8
   %168 = sext i16 %167 to i32
   %169 = bitcast i8* %162 to i16*
   %170 = trunc i32 %168 to i16
-  %NullCheck74 = icmp ne i16* %169, null
-  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+  %NullCheck73 = icmp eq i16* %169, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %171
 
 ; <label>:171                                     ; preds = %166
   store i16 %170, i16* %169, align 8
@@ -984,14 +1066,14 @@ entry:
   %173 = load i8*, i8** %arg0
   %174 = load i8*, i8** %arg1
   %175 = bitcast i8* %174 to i64*
-  %NullCheck56 = icmp ne i64* %175, null
-  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+  %NullCheck55 = icmp eq i64* %175, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %176
 
 ; <label>:176                                     ; preds = %172
   %177 = load i64, i64* %175, align 8
   %178 = bitcast i8* %173 to i64*
-  %NullCheck58 = icmp ne i64* %178, null
-  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+  %NullCheck57 = icmp eq i64* %178, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %179
 
 ; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
@@ -1000,16 +1082,16 @@ entry:
   %182 = load i8*, i8** %arg1
   %183 = getelementptr inbounds i8, i8* %182, i64 8
   %184 = bitcast i8* %183 to i16*
-  %NullCheck60 = icmp ne i16* %184, null
-  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+  %NullCheck59 = icmp eq i16* %184, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %185
 
 ; <label>:185                                     ; preds = %179
   %186 = load i16, i16* %184, align 8
   %187 = sext i16 %186 to i32
   %188 = bitcast i8* %181 to i16*
   %189 = trunc i32 %187 to i16
-  %NullCheck62 = icmp ne i16* %188, null
-  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+  %NullCheck61 = icmp eq i16* %188, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %190
 
 ; <label>:190                                     ; preds = %185
   store i16 %189, i16* %188, align 8
@@ -1017,15 +1099,15 @@ entry:
   %192 = getelementptr inbounds i8, i8* %191, i64 10
   %193 = load i8*, i8** %arg1
   %194 = getelementptr inbounds i8, i8* %193, i64 10
-  %NullCheck64 = icmp ne i8* %194, null
-  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+  %NullCheck63 = icmp eq i8* %194, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %195
 
 ; <label>:195                                     ; preds = %190
   %196 = load i8, i8* %194, align 8
   %197 = zext i8 %196 to i32
   %198 = trunc i32 %197 to i8
-  %NullCheck66 = icmp ne i8* %192, null
-  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+  %NullCheck65 = icmp eq i8* %192, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %199
 
 ; <label>:199                                     ; preds = %195
   store i8 %198, i8* %192, align 8
@@ -1035,14 +1117,14 @@ entry:
   %201 = load i8*, i8** %arg0
   %202 = load i8*, i8** %arg1
   %203 = bitcast i8* %202 to i64*
-  %NullCheck48 = icmp ne i64* %203, null
-  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+  %NullCheck47 = icmp eq i64* %203, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %204
 
 ; <label>:204                                     ; preds = %200
   %205 = load i64, i64* %203, align 8
   %206 = bitcast i8* %201 to i64*
-  %NullCheck50 = icmp ne i64* %206, null
-  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+  %NullCheck49 = icmp eq i64* %206, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %207
 
 ; <label>:207                                     ; preds = %204
   store i64 %205, i64* %206, align 8
@@ -1051,14 +1133,14 @@ entry:
   %210 = load i8*, i8** %arg1
   %211 = getelementptr inbounds i8, i8* %210, i64 8
   %212 = bitcast i8* %211 to i32*
-  %NullCheck52 = icmp ne i32* %212, null
-  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+  %NullCheck51 = icmp eq i32* %212, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %213
 
 ; <label>:213                                     ; preds = %207
   %214 = load i32, i32* %212, align 8
   %215 = bitcast i8* %209 to i32*
-  %NullCheck54 = icmp ne i32* %215, null
-  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+  %NullCheck53 = icmp eq i32* %215, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %216
 
 ; <label>:216                                     ; preds = %213
   store i32 %214, i32* %215, align 8
@@ -1068,14 +1150,14 @@ entry:
   %218 = load i8*, i8** %arg0
   %219 = load i8*, i8** %arg1
   %220 = bitcast i8* %219 to i64*
-  %NullCheck36 = icmp ne i64* %220, null
-  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64* %220, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %221
 
 ; <label>:221                                     ; preds = %217
   %222 = load i64, i64* %220, align 8
   %223 = bitcast i8* %218 to i64*
-  %NullCheck38 = icmp ne i64* %223, null
-  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+  %NullCheck37 = icmp eq i64* %223, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %224
 
 ; <label>:224                                     ; preds = %221
   store i64 %222, i64* %223, align 8
@@ -1084,14 +1166,14 @@ entry:
   %227 = load i8*, i8** %arg1
   %228 = getelementptr inbounds i8, i8* %227, i64 8
   %229 = bitcast i8* %228 to i32*
-  %NullCheck40 = icmp ne i32* %229, null
-  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i32* %229, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %230
 
 ; <label>:230                                     ; preds = %224
   %231 = load i32, i32* %229, align 8
   %232 = bitcast i8* %226 to i32*
-  %NullCheck42 = icmp ne i32* %232, null
-  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+  %NullCheck41 = icmp eq i32* %232, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %233
 
 ; <label>:233                                     ; preds = %230
   store i32 %231, i32* %232, align 8
@@ -1099,15 +1181,15 @@ entry:
   %235 = getelementptr inbounds i8, i8* %234, i64 12
   %236 = load i8*, i8** %arg1
   %237 = getelementptr inbounds i8, i8* %236, i64 12
-  %NullCheck44 = icmp ne i8* %237, null
-  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i8* %237, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %238
 
 ; <label>:238                                     ; preds = %233
   %239 = load i8, i8* %237, align 8
   %240 = zext i8 %239 to i32
   %241 = trunc i32 %240 to i8
-  %NullCheck46 = icmp ne i8* %235, null
-  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+  %NullCheck45 = icmp eq i8* %235, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %242
 
 ; <label>:242                                     ; preds = %238
   store i8 %241, i8* %235, align 8
@@ -1117,14 +1199,14 @@ entry:
   %244 = load i8*, i8** %arg0
   %245 = load i8*, i8** %arg1
   %246 = bitcast i8* %245 to i64*
-  %NullCheck24 = icmp ne i64* %246, null
-  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64* %246, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %247
 
 ; <label>:247                                     ; preds = %243
   %248 = load i64, i64* %246, align 8
   %249 = bitcast i8* %244 to i64*
-  %NullCheck26 = icmp ne i64* %249, null
-  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64* %249, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %250
 
 ; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
@@ -1133,14 +1215,14 @@ entry:
   %253 = load i8*, i8** %arg1
   %254 = getelementptr inbounds i8, i8* %253, i64 8
   %255 = bitcast i8* %254 to i32*
-  %NullCheck28 = icmp ne i32* %255, null
-  br i1 %NullCheck28, label %256, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i32* %255, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %256
 
 ; <label>:256                                     ; preds = %250
   %257 = load i32, i32* %255, align 8
   %258 = bitcast i8* %252 to i32*
-  %NullCheck30 = icmp ne i32* %258, null
-  br i1 %NullCheck30, label %259, label %ThrowNullRef29
+  %NullCheck29 = icmp eq i32* %258, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %259
 
 ; <label>:259                                     ; preds = %256
   store i32 %257, i32* %258, align 8
@@ -1149,16 +1231,16 @@ entry:
   %262 = load i8*, i8** %arg1
   %263 = getelementptr inbounds i8, i8* %262, i64 12
   %264 = bitcast i8* %263 to i16*
-  %NullCheck32 = icmp ne i16* %264, null
-  br i1 %NullCheck32, label %265, label %ThrowNullRef31
+  %NullCheck31 = icmp eq i16* %264, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %265
 
 ; <label>:265                                     ; preds = %259
   %266 = load i16, i16* %264, align 8
   %267 = sext i16 %266 to i32
   %268 = bitcast i8* %261 to i16*
   %269 = trunc i32 %267 to i16
-  %NullCheck34 = icmp ne i16* %268, null
-  br i1 %NullCheck34, label %270, label %ThrowNullRef33
+  %NullCheck33 = icmp eq i16* %268, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %270
 
 ; <label>:270                                     ; preds = %265
   store i16 %269, i16* %268, align 8
@@ -1168,14 +1250,14 @@ entry:
   %272 = load i8*, i8** %arg0
   %273 = load i8*, i8** %arg1
   %274 = bitcast i8* %273 to i64*
-  %NullCheck8 = icmp ne i64* %274, null
-  br i1 %NullCheck8, label %275, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64* %274, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %275
 
 ; <label>:275                                     ; preds = %271
   %276 = load i64, i64* %274, align 8
   %277 = bitcast i8* %272 to i64*
-  %NullCheck10 = icmp ne i64* %277, null
-  br i1 %NullCheck10, label %278, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %277, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %278
 
 ; <label>:278                                     ; preds = %275
   store i64 %276, i64* %277, align 8
@@ -1184,14 +1266,14 @@ entry:
   %281 = load i8*, i8** %arg1
   %282 = getelementptr inbounds i8, i8* %281, i64 8
   %283 = bitcast i8* %282 to i32*
-  %NullCheck12 = icmp ne i32* %283, null
-  br i1 %NullCheck12, label %284, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i32* %283, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %284
 
 ; <label>:284                                     ; preds = %278
   %285 = load i32, i32* %283, align 8
   %286 = bitcast i8* %280 to i32*
-  %NullCheck14 = icmp ne i32* %286, null
-  br i1 %NullCheck14, label %287, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i32* %286, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %287
 
 ; <label>:287                                     ; preds = %284
   store i32 %285, i32* %286, align 8
@@ -1200,16 +1282,16 @@ entry:
   %290 = load i8*, i8** %arg1
   %291 = getelementptr inbounds i8, i8* %290, i64 12
   %292 = bitcast i8* %291 to i16*
-  %NullCheck16 = icmp ne i16* %292, null
-  br i1 %NullCheck16, label %293, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i16* %292, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %293
 
 ; <label>:293                                     ; preds = %287
   %294 = load i16, i16* %292, align 8
   %295 = sext i16 %294 to i32
   %296 = bitcast i8* %289 to i16*
   %297 = trunc i32 %295 to i16
-  %NullCheck18 = icmp ne i16* %296, null
-  br i1 %NullCheck18, label %298, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i16* %296, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %298
 
 ; <label>:298                                     ; preds = %293
   store i16 %297, i16* %296, align 8
@@ -1217,15 +1299,15 @@ entry:
   %300 = getelementptr inbounds i8, i8* %299, i64 14
   %301 = load i8*, i8** %arg1
   %302 = getelementptr inbounds i8, i8* %301, i64 14
-  %NullCheck20 = icmp ne i8* %302, null
-  br i1 %NullCheck20, label %303, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i8* %302, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %303
 
 ; <label>:303                                     ; preds = %298
   %304 = load i8, i8* %302, align 8
   %305 = zext i8 %304 to i32
   %306 = trunc i32 %305 to i8
-  %NullCheck22 = icmp ne i8* %300, null
-  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i8* %300, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %307
 
 ; <label>:307                                     ; preds = %303
   store i8 %306, i8* %300, align 8
@@ -1235,14 +1317,14 @@ entry:
   %309 = load i8*, i8** %arg0
   %310 = load i8*, i8** %arg1
   %311 = bitcast i8* %310 to i64*
-  %NullCheck = icmp ne i64* %311, null
-  br i1 %NullCheck, label %312, label %ThrowNullRef
+  %NullCheck = icmp eq i64* %311, null
+  br i1 %NullCheck, label %ThrowNullRef, label %312
 
 ; <label>:312                                     ; preds = %308
   %313 = load i64, i64* %311, align 8
   %314 = bitcast i8* %309 to i64*
-  %NullCheck2 = icmp ne i64* %314, null
-  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64* %314, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %315
 
 ; <label>:315                                     ; preds = %312
   store i64 %313, i64* %314, align 8
@@ -1251,14 +1333,14 @@ entry:
   %318 = load i8*, i8** %arg1
   %319 = getelementptr inbounds i8, i8* %318, i64 8
   %320 = bitcast i8* %319 to i64*
-  %NullCheck4 = icmp ne i64* %320, null
-  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64* %320, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %321
 
 ; <label>:321                                     ; preds = %315
   %322 = load i64, i64* %320, align 8
   %323 = bitcast i8* %317 to i64*
-  %NullCheck6 = icmp ne i64* %323, null
-  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64* %323, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %324
 
 ; <label>:324                                     ; preds = %321
   store i64 %322, i64* %323, align 8
@@ -1286,15 +1368,15 @@ entry:
 ; <label>:338                                     ; preds = %333
   %339 = load i8*, i8** %arg0
   %340 = load i8*, i8** %arg1
-  %NullCheck136 = icmp ne i8* %340, null
-  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+  %NullCheck135 = icmp eq i8* %340, null
+  br i1 %NullCheck135, label %ThrowNullRef136, label %341
 
 ; <label>:341                                     ; preds = %338
   %342 = load i8, i8* %340, align 8
   %343 = zext i8 %342 to i32
   %344 = trunc i32 %343 to i8
-  %NullCheck138 = icmp ne i8* %339, null
-  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+  %NullCheck137 = icmp eq i8* %339, null
+  br i1 %NullCheck137, label %ThrowNullRef138, label %345
 
 ; <label>:345                                     ; preds = %341
   store i8 %344, i8* %339, align 8
@@ -1317,16 +1399,16 @@ entry:
   %357 = load i8*, i8** %arg0
   %358 = load i8*, i8** %arg1
   %359 = bitcast i8* %358 to i16*
-  %NullCheck140 = icmp ne i16* %359, null
-  br i1 %NullCheck140, label %360, label %ThrowNullRef139
+  %NullCheck139 = icmp eq i16* %359, null
+  br i1 %NullCheck139, label %ThrowNullRef140, label %360
 
 ; <label>:360                                     ; preds = %356
   %361 = load i16, i16* %359, align 8
   %362 = sext i16 %361 to i32
   %363 = bitcast i8* %357 to i16*
   %364 = trunc i32 %362 to i16
-  %NullCheck142 = icmp ne i16* %363, null
-  br i1 %NullCheck142, label %365, label %ThrowNullRef141
+  %NullCheck141 = icmp eq i16* %363, null
+  br i1 %NullCheck141, label %ThrowNullRef142, label %365
 
 ; <label>:365                                     ; preds = %360
   store i16 %364, i16* %363, align 8
@@ -1352,14 +1434,14 @@ entry:
   %378 = load i8*, i8** %arg0
   %379 = load i8*, i8** %arg1
   %380 = bitcast i8* %379 to i32*
-  %NullCheck144 = icmp ne i32* %380, null
-  br i1 %NullCheck144, label %381, label %ThrowNullRef143
+  %NullCheck143 = icmp eq i32* %380, null
+  br i1 %NullCheck143, label %ThrowNullRef144, label %381
 
 ; <label>:381                                     ; preds = %377
   %382 = load i32, i32* %380, align 8
   %383 = bitcast i8* %378 to i32*
-  %NullCheck146 = icmp ne i32* %383, null
-  br i1 %NullCheck146, label %384, label %ThrowNullRef145
+  %NullCheck145 = icmp eq i32* %383, null
+  br i1 %NullCheck145, label %ThrowNullRef146, label %384
 
 ; <label>:384                                     ; preds = %381
   store i32 %382, i32* %383, align 8
@@ -1384,14 +1466,14 @@ entry:
   %395 = load i8*, i8** %arg0
   %396 = load i8*, i8** %arg1
   %397 = bitcast i8* %396 to i64*
-  %NullCheck164 = icmp ne i64* %397, null
-  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+  %NullCheck163 = icmp eq i64* %397, null
+  br i1 %NullCheck163, label %ThrowNullRef164, label %398
 
 ; <label>:398                                     ; preds = %394
   %399 = load i64, i64* %397, align 8
   %400 = bitcast i8* %395 to i64*
-  %NullCheck166 = icmp ne i64* %400, null
-  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+  %NullCheck165 = icmp eq i64* %400, null
+  br i1 %NullCheck165, label %ThrowNullRef166, label %401
 
 ; <label>:401                                     ; preds = %398
   store i64 %399, i64* %400, align 8
@@ -1400,14 +1482,14 @@ entry:
   %404 = load i8*, i8** %arg1
   %405 = getelementptr inbounds i8, i8* %404, i64 8
   %406 = bitcast i8* %405 to i64*
-  %NullCheck168 = icmp ne i64* %406, null
-  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+  %NullCheck167 = icmp eq i64* %406, null
+  br i1 %NullCheck167, label %ThrowNullRef168, label %407
 
 ; <label>:407                                     ; preds = %401
   %408 = load i64, i64* %406, align 8
   %409 = bitcast i8* %403 to i64*
-  %NullCheck170 = icmp ne i64* %409, null
-  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+  %NullCheck169 = icmp eq i64* %409, null
+  br i1 %NullCheck169, label %ThrowNullRef170, label %410
 
 ; <label>:410                                     ; preds = %407
   store i64 %408, i64* %409, align 8
@@ -1437,14 +1519,14 @@ entry:
   %425 = load i8*, i8** %arg0
   %426 = load i8*, i8** %arg1
   %427 = bitcast i8* %426 to i64*
-  %NullCheck148 = icmp ne i64* %427, null
-  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+  %NullCheck147 = icmp eq i64* %427, null
+  br i1 %NullCheck147, label %ThrowNullRef148, label %428
 
 ; <label>:428                                     ; preds = %424
   %429 = load i64, i64* %427, align 8
   %430 = bitcast i8* %425 to i64*
-  %NullCheck150 = icmp ne i64* %430, null
-  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+  %NullCheck149 = icmp eq i64* %430, null
+  br i1 %NullCheck149, label %ThrowNullRef150, label %431
 
 ; <label>:431                                     ; preds = %428
   store i64 %429, i64* %430, align 8
@@ -1466,14 +1548,14 @@ entry:
   %441 = load i8*, i8** %arg0
   %442 = load i8*, i8** %arg1
   %443 = bitcast i8* %442 to i32*
-  %NullCheck152 = icmp ne i32* %443, null
-  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+  %NullCheck151 = icmp eq i32* %443, null
+  br i1 %NullCheck151, label %ThrowNullRef152, label %444
 
 ; <label>:444                                     ; preds = %440
   %445 = load i32, i32* %443, align 8
   %446 = bitcast i8* %441 to i32*
-  %NullCheck154 = icmp ne i32* %446, null
-  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+  %NullCheck153 = icmp eq i32* %446, null
+  br i1 %NullCheck153, label %ThrowNullRef154, label %447
 
 ; <label>:447                                     ; preds = %444
   store i32 %445, i32* %446, align 8
@@ -1495,16 +1577,16 @@ entry:
   %457 = load i8*, i8** %arg0
   %458 = load i8*, i8** %arg1
   %459 = bitcast i8* %458 to i16*
-  %NullCheck156 = icmp ne i16* %459, null
-  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+  %NullCheck155 = icmp eq i16* %459, null
+  br i1 %NullCheck155, label %ThrowNullRef156, label %460
 
 ; <label>:460                                     ; preds = %456
   %461 = load i16, i16* %459, align 8
   %462 = sext i16 %461 to i32
   %463 = bitcast i8* %457 to i16*
   %464 = trunc i32 %462 to i16
-  %NullCheck158 = icmp ne i16* %463, null
-  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+  %NullCheck157 = icmp eq i16* %463, null
+  br i1 %NullCheck157, label %ThrowNullRef158, label %465
 
 ; <label>:465                                     ; preds = %460
   store i16 %464, i16* %463, align 8
@@ -1525,15 +1607,15 @@ entry:
 ; <label>:474                                     ; preds = %470
   %475 = load i8*, i8** %arg0
   %476 = load i8*, i8** %arg1
-  %NullCheck160 = icmp ne i8* %476, null
-  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+  %NullCheck159 = icmp eq i8* %476, null
+  br i1 %NullCheck159, label %ThrowNullRef160, label %477
 
 ; <label>:477                                     ; preds = %474
   %478 = load i8, i8* %476, align 8
   %479 = zext i8 %478 to i32
   %480 = trunc i32 %479 to i8
-  %NullCheck162 = icmp ne i8* %475, null
-  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+  %NullCheck161 = icmp eq i8* %475, null
+  br i1 %NullCheck161, label %ThrowNullRef162, label %481
 
 ; <label>:481                                     ; preds = %477
   store i8 %480, i8* %475, align 8
@@ -1553,343 +1635,343 @@ ThrowNullRef:                                     ; preds = %308
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %312
+ThrowNullRef2:                                    ; preds = %312
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %315
+ThrowNullRef4:                                    ; preds = %315
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %321
+ThrowNullRef6:                                    ; preds = %321
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %271
+ThrowNullRef8:                                    ; preds = %271
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %275
+ThrowNullRef10:                                   ; preds = %275
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %278
+ThrowNullRef12:                                   ; preds = %278
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %284
+ThrowNullRef14:                                   ; preds = %284
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %287
+ThrowNullRef16:                                   ; preds = %287
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %293
+ThrowNullRef18:                                   ; preds = %293
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %298
+ThrowNullRef20:                                   ; preds = %298
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %303
+ThrowNullRef22:                                   ; preds = %303
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %243
+ThrowNullRef24:                                   ; preds = %243
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %247
+ThrowNullRef26:                                   ; preds = %247
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %250
+ThrowNullRef28:                                   ; preds = %250
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %256
+ThrowNullRef30:                                   ; preds = %256
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %259
+ThrowNullRef32:                                   ; preds = %259
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %265
+ThrowNullRef34:                                   ; preds = %265
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %217
+ThrowNullRef36:                                   ; preds = %217
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %221
+ThrowNullRef38:                                   ; preds = %221
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %224
+ThrowNullRef40:                                   ; preds = %224
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %230
+ThrowNullRef42:                                   ; preds = %230
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %233
+ThrowNullRef44:                                   ; preds = %233
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %238
+ThrowNullRef46:                                   ; preds = %238
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %200
+ThrowNullRef48:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %204
+ThrowNullRef50:                                   ; preds = %204
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %207
+ThrowNullRef52:                                   ; preds = %207
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %213
+ThrowNullRef54:                                   ; preds = %213
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %172
+ThrowNullRef56:                                   ; preds = %172
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %176
+ThrowNullRef58:                                   ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %179
+ThrowNullRef60:                                   ; preds = %179
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %185
+ThrowNullRef62:                                   ; preds = %185
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %190
+ThrowNullRef64:                                   ; preds = %190
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %195
+ThrowNullRef66:                                   ; preds = %195
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %153
+ThrowNullRef68:                                   ; preds = %153
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %157
+ThrowNullRef70:                                   ; preds = %157
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %160
+ThrowNullRef72:                                   ; preds = %160
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %166
+ThrowNullRef74:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %136
+ThrowNullRef76:                                   ; preds = %136
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %140
+ThrowNullRef78:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %143
+ThrowNullRef80:                                   ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %148
+ThrowNullRef82:                                   ; preds = %148
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %128
+ThrowNullRef84:                                   ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %132
+ThrowNullRef86:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %100
+ThrowNullRef88:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %104
+ThrowNullRef90:                                   ; preds = %104
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %107
+ThrowNullRef92:                                   ; preds = %107
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %113
+ThrowNullRef94:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %118
+ThrowNullRef96:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %123
+ThrowNullRef98:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %81
+ThrowNullRef100:                                  ; preds = %81
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef101:                                  ; preds = %85
+ThrowNullRef102:                                  ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef103:                                  ; preds = %88
+ThrowNullRef104:                                  ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef105:                                  ; preds = %94
+ThrowNullRef106:                                  ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef107:                                  ; preds = %64
+ThrowNullRef108:                                  ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef109:                                  ; preds = %68
+ThrowNullRef110:                                  ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef111:                                  ; preds = %71
+ThrowNullRef112:                                  ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef113:                                  ; preds = %76
+ThrowNullRef114:                                  ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef115:                                  ; preds = %56
+ThrowNullRef116:                                  ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef117:                                  ; preds = %60
+ThrowNullRef118:                                  ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef119:                                  ; preds = %37
+ThrowNullRef120:                                  ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef121:                                  ; preds = %41
+ThrowNullRef122:                                  ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef123:                                  ; preds = %46
+ThrowNullRef124:                                  ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef125:                                  ; preds = %51
+ThrowNullRef126:                                  ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef127:                                  ; preds = %27
+ThrowNullRef128:                                  ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef129:                                  ; preds = %31
+ThrowNullRef130:                                  ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef131:                                  ; preds = %19
+ThrowNullRef132:                                  ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef133:                                  ; preds = %22
+ThrowNullRef134:                                  ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef135:                                  ; preds = %338
+ThrowNullRef136:                                  ; preds = %338
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef137:                                  ; preds = %341
+ThrowNullRef138:                                  ; preds = %341
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef139:                                  ; preds = %356
+ThrowNullRef140:                                  ; preds = %356
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef141:                                  ; preds = %360
+ThrowNullRef142:                                  ; preds = %360
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef143:                                  ; preds = %377
+ThrowNullRef144:                                  ; preds = %377
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef145:                                  ; preds = %381
+ThrowNullRef146:                                  ; preds = %381
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef147:                                  ; preds = %424
+ThrowNullRef148:                                  ; preds = %424
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef149:                                  ; preds = %428
+ThrowNullRef150:                                  ; preds = %428
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef151:                                  ; preds = %440
+ThrowNullRef152:                                  ; preds = %440
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef153:                                  ; preds = %444
+ThrowNullRef154:                                  ; preds = %444
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef155:                                  ; preds = %456
+ThrowNullRef156:                                  ; preds = %456
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef157:                                  ; preds = %460
+ThrowNullRef158:                                  ; preds = %460
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef159:                                  ; preds = %474
+ThrowNullRef160:                                  ; preds = %474
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef161:                                  ; preds = %477
+ThrowNullRef162:                                  ; preds = %477
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef163:                                  ; preds = %394
+ThrowNullRef164:                                  ; preds = %394
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef165:                                  ; preds = %398
+ThrowNullRef166:                                  ; preds = %398
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef167:                                  ; preds = %401
+ThrowNullRef168:                                  ; preds = %401
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef169:                                  ; preds = %407
+ThrowNullRef170:                                  ; preds = %407
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1939,8 +2021,8 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
-  br i1 %NullCheck, label %22, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %ThrowNullRef, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
@@ -1948,8 +2030,8 @@ entry:
   store i32 %24, i32* %loc0
   %25 = load i32, i32* %loc0
   %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %26, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %27
 
 ; <label>:27                                      ; preds = %22
   %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
@@ -1971,7 +2053,7 @@ ThrowNullRef:                                     ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1989,8 +2071,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -2022,15 +2104,15 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2048,16 +2130,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
   %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
   store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %15
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
@@ -2072,8 +2154,8 @@ entry:
   %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
   %29 = ptrtoint i16 addrspace(1)* %28 to i64
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %19
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
@@ -2089,19 +2171,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2114,8 +2196,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
@@ -2128,7 +2210,7 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[loadElem]
+Failed to read AppDomain.PrepareDataForSetup[storeElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
@@ -2202,8 +2284,8 @@ entry:
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
-  br i1 %NullCheck24, label %27, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = load i64, i64 addrspace(1)* %26
@@ -2218,8 +2300,8 @@ entry:
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
-  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
   %41 = load i64, i64 addrspace(1)* %39
@@ -2236,8 +2318,8 @@ entry:
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
-  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
   %54 = load i64, i64 addrspace(1)* %52
@@ -2252,8 +2334,8 @@ entry:
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
   %67 = load i64, i64 addrspace(1)* %65
@@ -2270,8 +2352,8 @@ entry:
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
-  br i1 %NullCheck16, label %79, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
   %80 = load i64, i64 addrspace(1)* %78
@@ -2286,8 +2368,8 @@ entry:
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
-  br i1 %NullCheck18, label %92, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
   %93 = load i64, i64 addrspace(1)* %91
@@ -2304,8 +2386,8 @@ entry:
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
-  br i1 %NullCheck12, label %105, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = load i64, i64 addrspace(1)* %104
@@ -2320,8 +2402,8 @@ entry:
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
-  br i1 %NullCheck14, label %118, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
   %119 = load i64, i64 addrspace(1)* %117
@@ -2337,8 +2419,8 @@ entry:
 
 ; <label>:128                                     ; preds = %20
   %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
-  br i1 %NullCheck4, label %130, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %129, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %130
 
 ; <label>:130                                     ; preds = %128
   %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
@@ -2346,8 +2428,8 @@ entry:
   %133 = load i16, i16 addrspace(1)* %132, align 8
   %134 = zext i16 %133 to i32
   %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
-  br i1 %NullCheck6, label %136, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %135, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %136
 
 ; <label>:136                                     ; preds = %130
   %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
@@ -2360,8 +2442,8 @@ entry:
 
 ; <label>:143                                     ; preds = %136
   %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
-  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %144, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %145
 
 ; <label>:145                                     ; preds = %143
   %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
@@ -2369,8 +2451,8 @@ entry:
   %148 = load i16, i16 addrspace(1)* %147, align 8
   %149 = zext i16 %148 to i32
   %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %150, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %151
 
 ; <label>:151                                     ; preds = %145
   %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
@@ -2388,8 +2470,8 @@ entry:
 
 ; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
-  br i1 %NullCheck, label %163, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %ThrowNullRef, label %163
 
 ; <label>:163                                     ; preds = %161
   %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
@@ -2399,8 +2481,8 @@ entry:
 
 ; <label>:167                                     ; preds = %163
   %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
-  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %168, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %169
 
 ; <label>:169                                     ; preds = %167
   %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
@@ -2432,55 +2514,55 @@ ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %167
+ThrowNullRef2:                                    ; preds = %167
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %128
+ThrowNullRef4:                                    ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %130
+ThrowNullRef6:                                    ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %143
+ThrowNullRef8:                                    ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %145
+ThrowNullRef10:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %102
+ThrowNullRef12:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %105
+ThrowNullRef14:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %76
+ThrowNullRef16:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %79
+ThrowNullRef18:                                   ; preds = %79
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %50
+ThrowNullRef20:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %53
+ThrowNullRef22:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %24
+ThrowNullRef24:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %27
+ThrowNullRef26:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2503,15 +2585,15 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2519,16 +2601,16 @@ entry:
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
   store i32 %8, i32* %loc0
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
   %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
   store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
@@ -2546,16 +2628,16 @@ entry:
 
 ; <label>:23                                      ; preds = %64
   %24 = load i16*, i16** %loc3
-  %NullCheck12 = icmp ne i16* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i16* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
   store i32 %27, i32* %loc5
   %28 = load i16*, i16** %loc4
-  %NullCheck14 = icmp ne i16* %28, null
-  br i1 %NullCheck14, label %29, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %28, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = load i16, i16* %28, align 8
@@ -2620,15 +2702,15 @@ entry:
 
 ; <label>:67                                      ; preds = %64
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
-  br i1 %NullCheck8, label %69, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %68, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %69
 
 ; <label>:69                                      ; preds = %67
   %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
   %71 = load i32, i32 addrspace(1)* %70
   %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
-  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %73
 
 ; <label>:73                                      ; preds = %69
   %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
@@ -2645,31 +2727,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %67
+ThrowNullRef8:                                    ; preds = %67
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %69
+ThrowNullRef10:                                   ; preds = %69
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2710,14 +2792,14 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
   %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
@@ -2730,14 +2812,14 @@ entry:
 
 ; <label>:11                                      ; preds = %4
   %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
   %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
@@ -2749,14 +2831,14 @@ entry:
 
 ; <label>:22                                      ; preds = %16
   %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
   %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
-  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
-  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
@@ -2804,23 +2886,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2836,7 +2918,280 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[loadElem]
+Successfully read RuntimeType.IsAssignableFrom
+
+define i8 @RuntimeType.IsAssignableFrom(%System.RuntimeType addrspace(1)* %param0, %System.Type addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.RuntimeType addrspace(1)*
+  %arg1 = alloca %System.Type addrspace(1)*
+  %loc0 = alloca %System.RuntimeType addrspace(1)*
+  %loc1 = alloca %"System.Type[]" addrspace(1)*
+  %loc2 = alloca i32
+  store %System.RuntimeType addrspace(1)* %param0, %System.RuntimeType addrspace(1)** %this
+  store %System.Type addrspace(1)* %param1, %System.Type addrspace(1)** %arg1
+  %0 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %1 = icmp ne %System.Type addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i8 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %5 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %6 = bitcast %System.Type addrspace(1)* %4 to %System.Object addrspace(1)*
+  %7 = bitcast %System.RuntimeType addrspace(1)* %5 to %System.Object addrspace(1)*
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %6, %System.Object addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %3
+  ret i8 1
+
+; <label>:12                                      ; preds = %3
+  %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 152
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 32
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
+  %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
+  %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
+  store %System.RuntimeType addrspace(1)* %25, %System.RuntimeType addrspace(1)** %loc0
+  %26 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %27 = icmp eq %System.RuntimeType addrspace(1)* %26, null
+  br i1 %27, label %34, label %28
+
+; <label>:28                                      ; preds = %15
+  %29 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %30 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)*)*)(%System.RuntimeType addrspace(1)* %29, %System.RuntimeType addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+; <label>:34                                      ; preds = %15
+  %35 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %36 = call %System.Reflection.Emit.TypeBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Reflection.Emit.TypeBuilder addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %35)
+  %37 = icmp eq %System.Reflection.Emit.TypeBuilder addrspace(1)* %36, null
+  br i1 %37, label %139, label %38
+
+; <label>:38                                      ; preds = %34
+  %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %42
+
+; <label>:42                                      ; preds = %38
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 152
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 40
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
+  %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
+  %53 = zext i8 %52 to i32
+  %54 = icmp eq i32 %53, 0
+  br i1 %54, label %56, label %55
+
+; <label>:55                                      ; preds = %42
+  ret i8 1
+
+; <label>:56                                      ; preds = %42
+  %57 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %58 = bitcast %System.RuntimeType addrspace(1)* %57 to %System.Type addrspace(1)*
+  %59 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %58)
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %64 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.Type addrspace(1)* %63, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = bitcast %System.RuntimeType addrspace(1)* %64 to %System.Type addrspace(1)*
+  %67 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %63, %System.Type addrspace(1)* %66)
+  %68 = zext i8 %67 to i32
+  %69 = trunc i32 %68 to i8
+  ret i8 %69
+
+; <label>:70                                      ; preds = %56
+  %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
+  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %73
+
+; <label>:73                                      ; preds = %70
+  %74 = load i64, i64 addrspace(1)* %72
+  %75 = add i64 %74, 128
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = add i64 %77, 0
+  %79 = inttoptr i64 %78 to i64*
+  %80 = load i64, i64* %79
+  %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
+  %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
+  %83 = call i8 %82(%System.Type addrspace(1)* %81)
+  %84 = zext i8 %83 to i32
+  %85 = icmp eq i32 %84, 0
+  br i1 %85, label %139, label %86
+
+; <label>:86                                      ; preds = %73
+  %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
+  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %89
+
+; <label>:89                                      ; preds = %86
+  %90 = load i64, i64 addrspace(1)* %88
+  %91 = add i64 %90, 128
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = add i64 %93, 24
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
+  %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
+  %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
+  store %"System.Type[]" addrspace(1)* %99, %"System.Type[]" addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %129
+
+; <label>:100                                     ; preds = %132
+  %101 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %102 = load i32, i32* %loc2
+  %NullCheck11 = icmp eq %"System.Type[]" addrspace(1)* %101, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %103
+
+; <label>:103                                     ; preds = %100
+  %104 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 1
+  %105 = load i32, i32 addrspace(1)* %104
+  %106 = zext i32 %105 to i64
+  %107 = zext i32 %102 to i64
+  %BoundsCheck = icmp uge i64 %107, %106
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %108
+
+; <label>:108                                     ; preds = %103
+  %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
+  %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
+  %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
+  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %113
+
+; <label>:113                                     ; preds = %108
+  %114 = load i64, i64 addrspace(1)* %112
+  %115 = add i64 %114, 152
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = add i64 %117, 56
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
+  %123 = zext i8 %122 to i32
+  %124 = icmp ne i32 %123, 0
+  br i1 %124, label %126, label %125
+
+; <label>:125                                     ; preds = %113
+  ret i8 0
+
+; <label>:126                                     ; preds = %113
+  %127 = load i32, i32* %loc2
+  %128 = add i32 %127, 1
+  store i32 %128, i32* %loc2
+  br label %129
+
+; <label>:129                                     ; preds = %89, %126
+  %130 = load i32, i32* %loc2
+  %131 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %NullCheck9 = icmp eq %"System.Type[]" addrspace(1)* %131, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %132
+
+; <label>:132                                     ; preds = %129
+  %133 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %131, i32 0, i32 1
+  %134 = load i32, i32 addrspace(1)* %133
+  %135 = zext i32 %134 to i64
+  %136 = trunc i64 %135 to i32
+  %137 = icmp slt i32 %130, %136
+  br i1 %137, label %100, label %138
+
+; <label>:138                                     ; preds = %132
+  ret i8 1
+
+; <label>:139                                     ; preds = %34, %73
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %129
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %103
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -2893,7 +3248,7 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElem]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -2904,8 +3259,8 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -2997,8 +3352,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
@@ -3059,8 +3414,8 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -3087,8 +3442,8 @@ entry:
 
 ; <label>:17                                      ; preds = %5, %11
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
@@ -3097,8 +3452,8 @@ entry:
 
 ; <label>:22                                      ; preds = %1, %11
   %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
@@ -3109,11 +3464,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %17
+ThrowNullRef2:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %22
+ThrowNullRef4:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3167,15 +3522,15 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
   %15 = load i32, i32 addrspace(1)* %14
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
@@ -3198,7 +3553,7 @@ ThrowNullRef:                                     ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef2:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3232,8 +3587,8 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
@@ -3312,8 +3667,8 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -3327,8 +3682,8 @@ entry:
 ; <label>:5                                       ; preds = %43
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %7 = load i32, i32* %loc1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck6, label %8, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
@@ -3366,8 +3721,8 @@ entry:
 ; <label>:32                                      ; preds = %21, %25
   %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
   %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
-  br i1 %NullCheck8, label %35, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = trunc i32 %34 to i16
@@ -3380,8 +3735,8 @@ entry:
 ; <label>:40                                      ; preds = %1, %35
   %41 = load i32, i32* %loc1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
-  br i1 %NullCheck2, label %43, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %42, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
@@ -3392,8 +3747,8 @@ entry:
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
   %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
-  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
   %51 = load i64, i64 addrspace(1)* %49
@@ -3412,19 +3767,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %40
+ThrowNullRef2:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %47
+ThrowNullRef4:                                    ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %5
+ThrowNullRef6:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %32
+ThrowNullRef8:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3467,8 +3822,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
@@ -3492,11 +3847,391 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(i16* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store i16* %param0, i16** %arg0
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load i32, i32* %arg3
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %42, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %37, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg2
+  %13 = load i32, i32* %arg3
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %37, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %24 = load i32, i32* %arg2
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load i16*, i16** %arg0
+  %35 = load i32, i32* %arg3
+  %36 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %36, i16* %34, i32 %35)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:37                                      ; preds = %5, %16
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %39)
+  %41 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41, %System.String addrspace(1)* %38, %System.String addrspace(1)* %40)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41) #0
+  unreachable
+
+; <label>:42                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
-Failed to read StringBuilder.ToString[loadElemA]
+Successfully read StringBuilder.ToString
+
+define %System.String addrspace(1)* @StringBuilder.ToString(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i16*
+  %loc3 = alloca %"System.Char[]" addrspace(1)*
+  %loc4 = alloca i32
+  %loc5 = alloca i32
+  %loc6 = alloca i16 addrspace(1)*
+  %loc7 = alloca %System.String addrspace(1)*
+  %loc8 = alloca %"System.Char[]" addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %0)
+  %2 = icmp ne i32 %1, 0
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %4
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %6)
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %7)
+  store %System.String addrspace(1)* %8, %System.String addrspace(1)** %loc0
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.Text.StringBuilder addrspace(1)* %9, %System.Text.StringBuilder addrspace(1)** %loc1
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  store %System.String addrspace(1)* %10, %System.String addrspace(1)** %loc7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc7
+  %12 = ptrtoint %System.String addrspace(1)* %11 to i64
+  %13 = icmp eq i64 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %5
+  %15 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %16 = sext i32 %15 to i64
+  %17 = add i64 %12, %16
+  br label %18
+
+; <label>:18                                      ; preds = %5, %14
+  %19 = phi i64 [ %12, %5 ], [ %17, %14 ]
+  %20 = inttoptr i64 %19 to i16*
+  store i16* %20, i16** %loc2
+  br label %21
+
+; <label>:21                                      ; preds = %98, %18
+  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %22, null
+  br i1 %NullCheck, label %ThrowNullRef, label %23
+
+; <label>:23                                      ; preds = %21
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 3
+  %25 = load i32, i32 addrspace(1)* %24, align 8
+  %26 = icmp sle i32 %25, 0
+  br i1 %26, label %96, label %27
+
+; <label>:27                                      ; preds = %23
+  %28 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %28, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %29
+
+; <label>:29                                      ; preds = %27
+  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %28, i32 0, i32 1
+  %31 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %30, align 8
+  store %"System.Char[]" addrspace(1)* %31, %"System.Char[]" addrspace(1)** %loc3
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %33
+
+; <label>:33                                      ; preds = %29
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  store i32 %35, i32* %loc4
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  %39 = load i32, i32 addrspace(1)* %38, align 8
+  store i32 %39, i32* %loc5
+  %40 = load i32, i32* %loc5
+  %41 = load i32, i32* %loc4
+  %42 = add i32 %40, %41
+  %43 = zext i32 %42 to i64
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %45
+
+; <label>:45                                      ; preds = %37
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = sext i32 %47 to i64
+  %49 = icmp sgt i64 %43, %48
+  br i1 %49, label %91, label %50
+
+; <label>:50                                      ; preds = %45
+  %51 = load i32, i32* %loc5
+  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %52, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %53
+
+; <label>:53                                      ; preds = %50
+  %54 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %52, i32 0, i32 1
+  %55 = load i32, i32 addrspace(1)* %54
+  %56 = zext i32 %55 to i64
+  %57 = trunc i64 %56 to i32
+  %58 = icmp ugt i32 %51, %57
+  br i1 %58, label %91, label %59
+
+; <label>:59                                      ; preds = %53
+  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  store %"System.Char[]" addrspace(1)* %60, %"System.Char[]" addrspace(1)** %loc8
+  %61 = icmp eq %"System.Char[]" addrspace(1)* %60, null
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %63, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %64
+
+; <label>:64                                      ; preds = %62
+  %65 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %63, i32 0, i32 1
+  %66 = load i32, i32 addrspace(1)* %65
+  %67 = zext i32 %66 to i64
+  %68 = trunc i64 %67 to i32
+  %69 = icmp ne i32 %68, 0
+  br i1 %69, label %71, label %70
+
+; <label>:70                                      ; preds = %59, %64
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:71                                      ; preds = %64
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %73
+
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %BoundsCheck = icmp uge i64 0, %76
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %77
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %78, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:79                                      ; preds = %70, %77
+  %80 = load i16*, i16** %loc2
+  %81 = load i32, i32* %loc4
+  %82 = sext i32 %81 to i64
+  %83 = mul i64 %82, 2
+  %84 = bitcast i16* %80 to i8*
+  %85 = getelementptr inbounds i8, i8* %84, i64 %83
+  %86 = load i16 addrspace(1)*, i16 addrspace(1)** %loc6
+  %87 = ptrtoint i16 addrspace(1)* %86 to i64
+  %88 = load i32, i32* %loc5
+  %89 = bitcast i8* %85 to i16*
+  %90 = inttoptr i64 %87 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %89, i16* %90, i32 %88)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %96
+
+; <label>:91                                      ; preds = %45, %53
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %94 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %93)
+  %95 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95, %System.String addrspace(1)* %92, %System.String addrspace(1)* %94)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95) #0
+  unreachable
+
+; <label>:96                                      ; preds = %23, %79
+  %97 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %97, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %98
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %97, i32 0, i32 2
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  store %System.Text.StringBuilder addrspace(1)* %100, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %102 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %102, label %21, label %103
+
+; <label>:103                                     ; preds = %98
+  store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc7
+  %104 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  ret %System.String addrspace(1)* %104
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method StringBuilder::get_Length using LLILCJit
+Successfully read StringBuilder.get_Length
+
+define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
+Successfully read RuntimeHelpers.get_OffsetToStringData
+
+define i32 @RuntimeHelpers.get_OffsetToStringData() {
+entry:
+  ret i32 12
+}
+
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
 Successfully read CultureData.CreateCultureData
 
@@ -3514,23 +4249,23 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
   store i8 %4, i8 addrspace(1)* %6
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
@@ -3549,11 +4284,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3566,50 +4301,50 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
   store i32 -1, i32 addrspace(1)* %2
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
   store i32 -1, i32 addrspace(1)* %8
   %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
   store i32 -1, i32 addrspace(1)* %14
   %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
   store i32 -1, i32 addrspace(1)* %17
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
@@ -3623,27 +4358,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3675,7 +4410,136 @@ Failed to read Dictionary`2.Insert[non-const derefAddress]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
 Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
-Failed to read HashHelpers.GetPrime[loadElem]
+Successfully read HashHelpers.GetPrime
+
+define i32 @HashHelpers.GetPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %6, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5, %System.String addrspace(1)* %4)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5) #0
+  unreachable
+
+; <label>:6                                       ; preds = %entry
+  store i32 0, i32* %loc0
+  br label %29
+
+; <label>:7                                       ; preds = %35
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 1296
+  %10 = addrspacecast i8 addrspace(1)* %9 to %"System.Int32[]" addrspace(1)**
+  %11 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %10
+  %12 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Int32[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = zext i32 %15 to i64
+  %17 = zext i32 %12 to i64
+  %BoundsCheck = icmp uge i64 %17, %16
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 3, i32 %12
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  store i32 %20, i32* %loc1
+  %21 = load i32, i32* %loc1
+  %22 = load i32, i32* %arg0
+  %23 = icmp slt i32 %21, %22
+  br i1 %23, label %26, label %24
+
+; <label>:24                                      ; preds = %18
+  %25 = load i32, i32* %loc1
+  ret i32 %25
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %loc0
+  %28 = add i32 %27, 1
+  store i32 %28, i32* %loc0
+  br label %29
+
+; <label>:29                                      ; preds = %6, %26
+  %30 = load i32, i32* %loc0
+  %31 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %32 = getelementptr inbounds i8, i8 addrspace(1)* %31, i64 1296
+  %33 = addrspacecast i8 addrspace(1)* %32 to %"System.Int32[]" addrspace(1)**
+  %34 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %33
+  %NullCheck = icmp eq %"System.Int32[]" addrspace(1)* %34, null
+  br i1 %NullCheck, label %ThrowNullRef, label %35
+
+; <label>:35                                      ; preds = %29
+  %36 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %34, i32 0, i32 1
+  %37 = load i32, i32 addrspace(1)* %36
+  %38 = zext i32 %37 to i64
+  %39 = trunc i64 %38 to i32
+  %40 = icmp slt i32 %30, %39
+  br i1 %40, label %7, label %41
+
+; <label>:41                                      ; preds = %35
+  %42 = load i32, i32* %arg0
+  %43 = or i32 %42, 1
+  store i32 %43, i32* %loc2
+  br label %59
+
+; <label>:44                                      ; preds = %59
+  %45 = load i32, i32* %loc2
+  %46 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %45)
+  %47 = zext i8 %46 to i32
+  %48 = icmp eq i32 %47, 0
+  br i1 %48, label %56, label %49
+
+; <label>:49                                      ; preds = %44
+  %50 = load i32, i32* %loc2
+  %51 = sub i32 %50, 1
+  %52 = srem i32 %51, 101
+  %53 = icmp eq i32 %52, 0
+  br i1 %53, label %56, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = load i32, i32* %loc2
+  ret i32 %55
+
+; <label>:56                                      ; preds = %44, %49
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %57, 2
+  store i32 %58, i32* %loc2
+  br label %59
+
+; <label>:59                                      ; preds = %41, %56
+  %60 = load i32, i32* %loc2
+  %61 = icmp slt i32 %60, 2147483647
+  br i1 %61, label %44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load i32, i32* %arg0
+  ret i32 %63
+
+ThrowNullRef:                                     ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
 Successfully read GenericEqualityComparer`1.GetHashCode
 
@@ -3694,14 +4558,14 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
   %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load i64, i64 addrspace(1)* %7
@@ -3720,7 +4584,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3750,8 +4614,8 @@ entry:
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
@@ -3796,8 +4660,8 @@ entry:
   %35 = bitcast i16* %34 to i8*
   %36 = getelementptr inbounds i8, i8* %35, i64 2
   %37 = bitcast i8* %36 to i16*
-  %NullCheck4 = icmp ne i16* %37, null
-  br i1 %NullCheck4, label %38, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %37, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %38
 
 ; <label>:38                                      ; preds = %27
   %39 = load i16, i16* %37, align 8
@@ -3824,8 +4688,8 @@ entry:
 
 ; <label>:54                                      ; preds = %22, %43
   %55 = load i16*, i16** %loc4
-  %NullCheck2 = icmp ne i16* %55, null
-  br i1 %NullCheck2, label %56, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i16* %55, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %56
 
 ; <label>:56                                      ; preds = %54
   %57 = load i16, i16* %55, align 8
@@ -3850,11 +4714,11 @@ ThrowNullRef:                                     ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %54
+ThrowNullRef2:                                    ; preds = %54
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %27
+ThrowNullRef4:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3871,8 +4735,8 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -3907,8 +4771,8 @@ entry:
 
 ; <label>:26                                      ; preds = %19
   %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
-  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %28
 
 ; <label>:28                                      ; preds = %26
   %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
@@ -3920,7 +4784,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3972,8 +4836,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
@@ -3984,26 +4848,26 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
-  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
@@ -4014,8 +4878,8 @@ entry:
 ; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
@@ -4024,8 +4888,8 @@ entry:
 
 ; <label>:25                                      ; preds = %1, %16, %23
   %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
-  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
@@ -4036,27 +4900,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %20
+ThrowNullRef10:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4069,8 +4933,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -4081,8 +4945,8 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
@@ -4091,8 +4955,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1, %8
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
@@ -4103,11 +4967,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4128,24 +4992,24 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   store i32 %3, i32* %loc0
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
   %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
   store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck4, label %9, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
@@ -4164,15 +5028,15 @@ entry:
 ; <label>:18                                      ; preds = %70
   %19 = load i16*, i16** %loc3
   %20 = bitcast i16* %19 to i64*
-  %NullCheck10 = icmp ne i64* %20, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %20, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = load i64, i64* %20, align 8
   %23 = load i16*, i16** %loc4
   %24 = bitcast i16* %23 to i64*
-  %NullCheck12 = icmp ne i64* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = load i64, i64* %24, align 8
@@ -4188,8 +5052,8 @@ entry:
   %31 = bitcast i16* %30 to i8*
   %32 = getelementptr inbounds i8, i8* %31, i64 8
   %33 = bitcast i8* %32 to i64*
-  %NullCheck14 = icmp ne i64* %33, null
-  br i1 %NullCheck14, label %34, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = load i64, i64* %33, align 8
@@ -4197,8 +5061,8 @@ entry:
   %37 = bitcast i16* %36 to i8*
   %38 = getelementptr inbounds i8, i8* %37, i64 8
   %39 = bitcast i8* %38 to i64*
-  %NullCheck16 = icmp ne i64* %39, null
-  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %40
 
 ; <label>:40                                      ; preds = %34
   %41 = load i64, i64* %39, align 8
@@ -4214,8 +5078,8 @@ entry:
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %NullCheck18 = icmp ne i64* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = load i64, i64* %48, align 8
@@ -4223,8 +5087,8 @@ entry:
   %52 = bitcast i16* %51 to i8*
   %53 = getelementptr inbounds i8, i8* %52, i64 16
   %54 = bitcast i8* %53 to i64*
-  %NullCheck20 = icmp ne i64* %54, null
-  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64* %54, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %55
 
 ; <label>:55                                      ; preds = %49
   %56 = load i64, i64* %54, align 8
@@ -4262,15 +5126,15 @@ entry:
 ; <label>:74                                      ; preds = %95
   %75 = load i16*, i16** %loc3
   %76 = bitcast i16* %75 to i32*
-  %NullCheck6 = icmp ne i32* %76, null
-  br i1 %NullCheck6, label %77, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32* %76, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %77
 
 ; <label>:77                                      ; preds = %74
   %78 = load i32, i32* %76, align 8
   %79 = load i16*, i16** %loc4
   %80 = bitcast i16* %79 to i32*
-  %NullCheck8 = icmp ne i32* %80, null
-  br i1 %NullCheck8, label %81, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i32* %80, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %81
 
 ; <label>:81                                      ; preds = %77
   %82 = load i32, i32* %80, align 8
@@ -4318,43 +5182,43 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %74
+ThrowNullRef6:                                    ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %77
+ThrowNullRef8:                                    ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %29
+ThrowNullRef14:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %34
+ThrowNullRef16:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4376,8 +5240,8 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load i64, i64 addrspace(1)* %4
@@ -4389,8 +5253,8 @@ entry:
   %12 = load i64, i64* %11
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %5
   %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
@@ -4399,8 +5263,8 @@ entry:
   %18 = load i8, i8* %arg2
   %19 = zext i8 %18 to i32
   %20 = trunc i32 %19 to i8
-  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %15
   %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
@@ -4411,11 +5275,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4442,8 +5306,8 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
@@ -4466,16 +5330,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
   %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = load i64, i64 addrspace(1)* %19
@@ -4500,8 +5364,8 @@ entry:
 ; <label>:35                                      ; preds = %30
   %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
@@ -4514,8 +5378,8 @@ entry:
 
 ; <label>:42                                      ; preds = %1, %38
   %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
-  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
@@ -4526,19 +5390,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %35
+ThrowNullRef2:                                    ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %42
+ThrowNullRef8:                                    ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4551,14 +5415,14 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
@@ -4570,7 +5434,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4583,8 +5447,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
@@ -4613,51 +5477,51 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
   %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
   %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
   %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
   %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
-  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
   store i64 %21, i64 addrspace(1)* %23
   %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %25 = load i64, i64* %loc0
-  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
@@ -4668,27 +5532,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %22
+ThrowNullRef12:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4701,8 +5565,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
@@ -4713,19 +5577,19 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
@@ -4734,8 +5598,8 @@ entry:
 
 ; <label>:15                                      ; preds = %1, %13
   %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
@@ -4746,19 +5610,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %15
+ThrowNullRef8:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4771,8 +5635,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -4831,8 +5695,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
@@ -4882,8 +5746,8 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
-  br i1 %NullCheck, label %17, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %ThrowNullRef, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
@@ -4894,15 +5758,15 @@ entry:
 
 ; <label>:22                                      ; preds = %17
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
-  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
   %26 = load i32, i32 addrspace(1)* %25
   %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
-  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %27, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
@@ -4925,8 +5789,8 @@ entry:
 ; <label>:40                                      ; preds = %17
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
-  br i1 %NullCheck6, label %43, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %41, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
@@ -4938,34 +5802,17 @@ ThrowNullRef:                                     ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %24
+ThrowNullRef4:                                    ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %40
+ThrowNullRef6:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
-}
-
-INFO:  jitting method Object::ReferenceEquals using LLILCJit
-Successfully read Object.ReferenceEquals
-
-define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
-entry:
-  %arg0 = alloca %System.Object addrspace(1)*
-  %arg1 = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
-  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
-  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = icmp eq %System.Object addrspace(1)* %0, %1
-  %3 = sext i1 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
 }
 
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
@@ -4978,21 +5825,21 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
   %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
-  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
@@ -5007,28 +5854,28 @@ entry:
 ; <label>:13                                      ; preds = %8, %12
   %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
   %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
   %21 = load i32, i32 addrspace(1)* %20, align 8
   %22 = add i32 %21, 1
-  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
   store i32 %22, i32 addrspace(1)* %24
   %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
@@ -5039,27 +5886,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5077,7 +5924,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::Setup using LLILCJit
-Failed to read AppDomain.Setup[loadElem]
+Failed to read AppDomain.Setup[unbox]
 INFO:  jitting method Thread::GetDomain using LLILCJit
 Successfully read Thread.GetDomain
 
@@ -5108,8 +5955,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
@@ -5122,14 +5969,14 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
   %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
@@ -5141,11 +5988,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5173,8 +6020,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -5189,7 +6036,328 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
 Failed to read KeyCollection.System.Collections.Generic.IEnumerable<TKey>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Successfully read Enumerator.MoveNext
+
+define i8 @Enumerator.MoveNext(%"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.RuntimeTypeHandle* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*
+  %"$TypeArg" = alloca %System.RuntimeTypeHandle*
+  store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
+  %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 8
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %76, label %12
+
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
+  br label %76
+
+; <label>:13                                      ; preds = %85
+  %14 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck19 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %15
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, i32 0, i32 0
+  %17 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %16, align 8
+  %NullCheck21 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, i32 0, i32 2
+  %20 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %19, align 8
+  %21 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck23 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %22
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, i32 0, i32 2
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %NullCheck25 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 3, i32 %24
+  %NullCheck27 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %32
+
+; <label>:32                                      ; preds = %30
+  %33 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, i32 0, i32 2
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = icmp slt i32 %34, 0
+  br i1 %35, label %68, label %36
+
+; <label>:36                                      ; preds = %32
+  %37 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %38 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck29 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %39
+
+; <label>:39                                      ; preds = %36
+  %40 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, i32 0, i32 0
+  %41 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %40, align 8
+  %NullCheck31 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, i32 0, i32 2
+  %44 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %43, align 8
+  %45 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck33 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, i32 0, i32 2
+  %48 = load i32, i32 addrspace(1)* %47, align 8
+  %NullCheck35 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %49
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = zext i32 %51 to i64
+  %53 = zext i32 %48 to i64
+  %BoundsCheck37 = icmp uge i64 %53, %52
+  br i1 %BoundsCheck37, label %ThrowIndexOutOfRange38, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 3, i32 %48
+  %NullCheck39 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %56
+
+; <label>:56                                      ; preds = %54
+  %57 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, i32 0, i32 0
+  %58 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck41 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %59
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %60, %System.__Canon addrspace(1)* %58)
+  %61 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck43 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  %64 = load i32, i32 addrspace(1)* %63, align 8
+  %65 = add i32 %64, 1
+  %NullCheck45 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  store i32 %65, i32 addrspace(1)* %67
+  ret i8 1
+
+; <label>:68                                      ; preds = %32
+  %69 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck47 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %73 = add i32 %72, 1
+  %NullCheck49 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %74
+
+; <label>:74                                      ; preds = %70
+  %75 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  store i32 %73, i32 addrspace(1)* %75
+  br label %76
+
+; <label>:76                                      ; preds = %8, %12, %74
+  %77 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %78
+
+; <label>:78                                      ; preds = %76
+  %79 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, i32 0, i32 2
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck7 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %82
+
+; <label>:82                                      ; preds = %78
+  %83 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, i32 0, i32 0
+  %84 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %83, align 8
+  %NullCheck9 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %85
+
+; <label>:85                                      ; preds = %82
+  %86 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, i32 0, i32 7
+  %87 = load i32, i32 addrspace(1)* %86, align 8
+  %88 = icmp ult i32 %80, %87
+  br i1 %88, label %13, label %89
+
+; <label>:89                                      ; preds = %85
+  %90 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %91 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck11 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %92
+
+; <label>:92                                      ; preds = %89
+  %93 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, i32 0, i32 0
+  %94 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck13 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %95
+
+; <label>:95                                      ; preds = %92
+  %96 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, i32 0, i32 7
+  %97 = load i32, i32 addrspace(1)* %96, align 8
+  %98 = add i32 %97, 1
+  %NullCheck15 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %99
+
+; <label>:99                                      ; preds = %95
+  %100 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, i32 0, i32 2
+  store i32 %98, i32 addrspace(1)* %100
+  %101 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck17 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %102
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %103, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %92
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef22:                                   ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef24:                                   ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef26:                                   ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef28:                                   ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef30:                                   ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef32:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef34:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef36:                                   ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange38:                           ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef40:                                   ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef42:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef44:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef46:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef48:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef50:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -5200,8 +6368,8 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -5232,9 +6400,9 @@ Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
 Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
-Failed to read String.MakeSeparatorList[loadElemA]
+Failed to read String.MakeSeparatorList[storeElem]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
-Failed to read String.InternalSplitKeepEmptyEntries[loadElem]
+Failed to read String.InternalSplitKeepEmptyEntries[storeElem]
 INFO:  jitting method Path::IsRelative using LLILCJit
 Successfully read Path.IsRelative
 
@@ -5243,8 +6411,8 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -5254,8 +6422,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
@@ -5271,8 +6439,8 @@ entry:
 
 ; <label>:17                                      ; preds = %7
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
@@ -5288,8 +6456,8 @@ entry:
 
 ; <label>:29                                      ; preds = %19
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %31
 
 ; <label>:31                                      ; preds = %29
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
@@ -5300,8 +6468,8 @@ entry:
 
 ; <label>:36                                      ; preds = %31
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
-  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %37, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
@@ -5312,8 +6480,8 @@ entry:
 
 ; <label>:43                                      ; preds = %31, %38
   %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
-  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %45
 
 ; <label>:45                                      ; preds = %43
   %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
@@ -5324,8 +6492,8 @@ entry:
 
 ; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %50
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
@@ -5336,8 +6504,8 @@ entry:
 
 ; <label>:57                                      ; preds = %1, %7, %19, %45, %52
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
-  br i1 %NullCheck14, label %59, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %59
 
 ; <label>:59                                      ; preds = %57
   %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
@@ -5347,8 +6515,8 @@ entry:
 
 ; <label>:63                                      ; preds = %59
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
@@ -5359,8 +6527,8 @@ entry:
 
 ; <label>:70                                      ; preds = %65
   %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
-  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.String addrspace(1)* %71, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %72
 
 ; <label>:72                                      ; preds = %70
   %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
@@ -5379,39 +6547,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %17
+ThrowNullRef4:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %29
+ThrowNullRef6:                                    ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %36
+ThrowNullRef8:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %43
+ThrowNullRef10:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %50
+ThrowNullRef12:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %57
+ThrowNullRef14:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %63
+ThrowNullRef16:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %70
+ThrowNullRef18:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5419,7 +6587,293 @@ ThrowNullRef17:                                   ; preds = %70
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
-Failed to read String.TrimHelper[loadElem]
+Successfully read String.TrimHelper
+
+define %System.String addrspace(1)* @String.TrimHelper(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i16
+  %loc4 = alloca i32
+  %loc5 = alloca i16
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = sub i32 %3, 1
+  store i32 %4, i32* %loc0
+  store i32 0, i32* %loc1
+  %5 = load i32, i32* %arg2
+  %6 = icmp eq i32 %5, 1
+  br i1 %6, label %62, label %7
+
+; <label>:7                                       ; preds = %1
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:8                                       ; preds = %58
+  store i32 0, i32* %loc2
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load i32, i32* %loc1
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2, i32 %10
+  %13 = load i16, i16 addrspace(1)* %12
+  %14 = zext i16 %13 to i32
+  %15 = trunc i32 %14 to i16
+  store i16 %15, i16* %loc3
+  store i32 0, i32* %loc2
+  br label %34
+
+; <label>:16                                      ; preds = %37
+  %17 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %18 = load i32, i32* %loc2
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %17, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %19
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = zext i32 %18 to i64
+  %BoundsCheck = icmp uge i64 %23, %22
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %24
+
+; <label>:24                                      ; preds = %19
+  %25 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 3, i32 %18
+  %26 = load i16, i16 addrspace(1)* %25, align 8
+  %27 = zext i16 %26 to i32
+  %28 = load i16, i16* %loc3
+  %29 = zext i16 %28 to i32
+  %30 = icmp eq i32 %27, %29
+  br i1 %30, label %43, label %31
+
+; <label>:31                                      ; preds = %24
+  %32 = load i32, i32* %loc2
+  %33 = add i32 %32, 1
+  store i32 %33, i32* %loc2
+  br label %34
+
+; <label>:34                                      ; preds = %11, %31
+  %35 = load i32, i32* %loc2
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = icmp slt i32 %35, %41
+  br i1 %42, label %16, label %43
+
+; <label>:43                                      ; preds = %24, %37
+  %44 = load i32, i32* %loc2
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %45, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp eq i32 %44, %50
+  br i1 %51, label %62, label %52
+
+; <label>:52                                      ; preds = %46
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %7, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %57, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %58
+
+; <label>:58                                      ; preds = %55
+  %59 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %60 = load i32, i32 addrspace(1)* %59
+  %61 = icmp slt i32 %56, %60
+  br i1 %61, label %8, label %62
+
+; <label>:62                                      ; preds = %1, %46, %58
+  %63 = load i32, i32* %arg2
+  %64 = icmp eq i32 %63, 0
+  br i1 %64, label %122, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %66, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %67
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %66, i32 0, i32 1
+  %69 = load i32, i32 addrspace(1)* %68
+  %70 = sub i32 %69, 1
+  store i32 %70, i32* %loc0
+  br label %118
+
+; <label>:71                                      ; preds = %118
+  store i32 0, i32* %loc4
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %73 = load i32, i32* %loc0
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %74
+
+; <label>:74                                      ; preds = %71
+  %75 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 2, i32 %73
+  %76 = load i16, i16 addrspace(1)* %75
+  %77 = zext i16 %76 to i32
+  %78 = trunc i32 %77 to i16
+  store i16 %78, i16* %loc5
+  store i32 0, i32* %loc4
+  br label %97
+
+; <label>:79                                      ; preds = %100
+  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %81 = load i32, i32* %loc4
+  %NullCheck19 = icmp eq %"System.Char[]" addrspace(1)* %80, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
+
+; <label>:82                                      ; preds = %79
+  %83 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 1
+  %84 = load i32, i32 addrspace(1)* %83
+  %85 = zext i32 %84 to i64
+  %86 = zext i32 %81 to i64
+  %BoundsCheck21 = icmp uge i64 %86, %85
+  br i1 %BoundsCheck21, label %ThrowIndexOutOfRange22, label %87
+
+; <label>:87                                      ; preds = %82
+  %88 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 3, i32 %81
+  %89 = load i16, i16 addrspace(1)* %88, align 8
+  %90 = zext i16 %89 to i32
+  %91 = load i16, i16* %loc5
+  %92 = zext i16 %91 to i32
+  %93 = icmp eq i32 %90, %92
+  br i1 %93, label %106, label %94
+
+; <label>:94                                      ; preds = %87
+  %95 = load i32, i32* %loc4
+  %96 = add i32 %95, 1
+  store i32 %96, i32* %loc4
+  br label %97
+
+; <label>:97                                      ; preds = %74, %94
+  %98 = load i32, i32* %loc4
+  %99 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck15 = icmp eq %"System.Char[]" addrspace(1)* %99, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %100
+
+; <label>:100                                     ; preds = %97
+  %101 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %99, i32 0, i32 1
+  %102 = load i32, i32 addrspace(1)* %101
+  %103 = zext i32 %102 to i64
+  %104 = trunc i64 %103 to i32
+  %105 = icmp slt i32 %98, %104
+  br i1 %105, label %79, label %106
+
+; <label>:106                                     ; preds = %87, %100
+  %107 = load i32, i32* %loc4
+  %108 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck17 = icmp eq %"System.Char[]" addrspace(1)* %108, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %109
+
+; <label>:109                                     ; preds = %106
+  %110 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %108, i32 0, i32 1
+  %111 = load i32, i32 addrspace(1)* %110
+  %112 = zext i32 %111 to i64
+  %113 = trunc i64 %112 to i32
+  %114 = icmp eq i32 %107, %113
+  br i1 %114, label %122, label %115
+
+; <label>:115                                     ; preds = %109
+  %116 = load i32, i32* %loc0
+  %117 = sub i32 %116, 1
+  store i32 %117, i32* %loc0
+  br label %118
+
+; <label>:118                                     ; preds = %67, %115
+  %119 = load i32, i32* %loc0
+  %120 = load i32, i32* %loc1
+  %121 = icmp sge i32 %119, %120
+  br i1 %121, label %71, label %122
+
+; <label>:122                                     ; preds = %62, %109, %118
+  %123 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %124 = load i32, i32* %loc1
+  %125 = load i32, i32* %loc0
+  %126 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %123, i32 %124, i32 %125)
+  ret %System.String addrspace(1)* %126
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %97
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange22:                           ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
 Successfully read String.CreateTrimmedString
 
@@ -5439,8 +6893,8 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
@@ -5535,8 +6989,8 @@ entry:
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i64 2872
   %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
   %8 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %7
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %3
   %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
@@ -5553,8 +7007,8 @@ entry:
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 2864
   %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
   %21 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %20
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
-  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %22
 
 ; <label>:22                                      ; preds = %16
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
@@ -5569,7 +7023,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %16
+ThrowNullRef2:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5586,8 +7040,8 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5613,8 +7067,8 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
@@ -5632,8 +7086,8 @@ entry:
 
 ; <label>:12                                      ; preds = %4
   %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
@@ -5644,8 +7098,8 @@ entry:
 
 ; <label>:19                                      ; preds = %14
   %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %19
   %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
@@ -5660,21 +7114,21 @@ entry:
   %31 = zext i16 %30 to i32
   %32 = bitcast i8* %29 to i16*
   %33 = trunc i32 %31 to i16
-  %NullCheck6 = icmp ne i16* %32, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i16* %32, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %21
   store i16 %33, i16* %32, align 8
   %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %36
 
 ; <label>:36                                      ; preds = %34
   %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
   %38 = load i32, i32 addrspace(1)* %37, align 8
   %39 = add i32 %38, 1
-  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %40
 
 ; <label>:40                                      ; preds = %36
   %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
@@ -5683,16 +7137,16 @@ entry:
 
 ; <label>:42                                      ; preds = %14
   %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
-  br i1 %NullCheck12, label %44, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
   %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
   %47 = load i16, i16* %arg1
   %48 = zext i16 %47 to i32
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = trunc i32 %48 to i16
@@ -5703,31 +7157,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %19
+ThrowNullRef4:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %21
+ThrowNullRef6:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %36
+ThrowNullRef10:                                   ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %42
+ThrowNullRef12:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %44
+ThrowNullRef14:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5740,8 +7194,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -5752,8 +7206,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
@@ -5762,14 +7216,14 @@ entry:
 
 ; <label>:11                                      ; preds = %1
   %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
@@ -5779,15 +7233,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5808,8 +7262,8 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5822,8 +7276,8 @@ entry:
 
 ; <label>:8                                       ; preds = %3
   %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
@@ -5842,15 +7296,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
-  br i1 %NullCheck4, label %22, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
   %24 = load i16*, i16* addrspace(1)* %23, align 8
   %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %25, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
@@ -5859,8 +7313,8 @@ entry:
   store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
@@ -5874,8 +7328,8 @@ entry:
 
 ; <label>:37                                      ; preds = %65
   %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %37
   %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
@@ -5886,16 +7340,16 @@ entry:
   %45 = bitcast i16* %41 to i8*
   %46 = getelementptr inbounds i8, i8* %45, i64 %44
   %47 = bitcast i8* %46 to i16*
-  %NullCheck14 = icmp ne i16* %47, null
-  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %47, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %48
 
 ; <label>:48                                      ; preds = %39
   %49 = load i16, i16* %47, align 8
   %50 = zext i16 %49 to i32
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %52 = load i32, i32* %loc1
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %53
 
 ; <label>:53                                      ; preds = %48
   %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
@@ -5916,8 +7370,8 @@ entry:
 ; <label>:62                                      ; preds = %36, %59
   %63 = load i32, i32* %loc1
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck10, label %65, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %65
 
 ; <label>:65                                      ; preds = %62
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
@@ -5936,15 +7390,15 @@ entry:
 
 ; <label>:74                                      ; preds = %70
   %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
-  br i1 %NullCheck18, label %76, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %76
 
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
   %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
-  br i1 %NullCheck20, label %80, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
   %81 = load i64, i64 addrspace(1)* %79
@@ -5958,8 +7412,8 @@ entry:
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
   %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
-  br i1 %NullCheck22, label %92, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.String addrspace(1)* %90, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %92
 
 ; <label>:92                                      ; preds = %80
   %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
@@ -5969,15 +7423,15 @@ entry:
 
 ; <label>:96                                      ; preds = %70
   %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
-  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %98
 
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
   %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
-  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
   %103 = load i64, i64 addrspace(1)* %101
@@ -5991,8 +7445,8 @@ entry:
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
   %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
-  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.String addrspace(1)* %112, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %114
 
 ; <label>:114                                     ; preds = %102
   %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
@@ -6004,59 +7458,59 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %20
+ThrowNullRef4:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %22
+ThrowNullRef6:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %26
+ThrowNullRef8:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %62
+ThrowNullRef10:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %48
+ThrowNullRef16:                                   ; preds = %48
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %74
+ThrowNullRef18:                                   ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %76
+ThrowNullRef20:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %80
+ThrowNullRef22:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %96
+ThrowNullRef24:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %98
+ThrowNullRef26:                                   ; preds = %98
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %102
+ThrowNullRef28:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6069,15 +7523,15 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
   %3 = load i16*, i16* addrspace(1)* %2, align 8
   %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
@@ -6087,8 +7541,8 @@ entry:
   %10 = bitcast i16* %3 to i8*
   %11 = getelementptr inbounds i8, i8* %10, i64 %9
   %12 = bitcast i8* %11 to i16*
-  %NullCheck4 = icmp ne i16* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %5
   store i16 0, i16* %12, align 8
@@ -6098,11 +7552,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6119,8 +7573,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -6131,8 +7585,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
@@ -6144,15 +7598,15 @@ entry:
 
 ; <label>:14                                      ; preds = %1
   %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
   %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
   %21 = load i64, i64 addrspace(1)* %19
@@ -6171,15 +7625,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %14
+ThrowNullRef4:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %16
+ThrowNullRef6:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6302,14 +7756,6 @@ entry:
   ret %System.String addrspace(1)* %57
 }
 
-INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
-Successfully read RuntimeHelpers.get_OffsetToStringData
-
-define i32 @RuntimeHelpers.get_OffsetToStringData() {
-entry:
-  ret i32 12
-}
-
 INFO:  jitting method String::Equals using LLILCJit
 Successfully read String.Equals
 
@@ -6381,8 +7827,8 @@ entry:
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
-  br i1 %NullCheck24, label %29, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
   %30 = load i64, i64 addrspace(1)* %28
@@ -6397,8 +7843,8 @@ entry:
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
-  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
   %43 = load i64, i64 addrspace(1)* %41
@@ -6418,8 +7864,8 @@ entry:
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
   %59 = load i64, i64 addrspace(1)* %57
@@ -6434,8 +7880,8 @@ entry:
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck22, label %71, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
   %72 = load i64, i64 addrspace(1)* %70
@@ -6455,8 +7901,8 @@ entry:
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
-  br i1 %NullCheck16, label %87, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = load i64, i64 addrspace(1)* %86
@@ -6471,8 +7917,8 @@ entry:
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck18, label %100, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
   %101 = load i64, i64 addrspace(1)* %99
@@ -6492,8 +7938,8 @@ entry:
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
-  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
   %117 = load i64, i64 addrspace(1)* %115
@@ -6508,8 +7954,8 @@ entry:
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
-  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
   %130 = load i64, i64 addrspace(1)* %128
@@ -6528,15 +7974,15 @@ entry:
 
 ; <label>:142                                     ; preds = %22
   %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
-  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %143, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %144
 
 ; <label>:144                                     ; preds = %142
   %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
   %146 = load i32, i32 addrspace(1)* %145
   %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
-  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %147, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %148
 
 ; <label>:148                                     ; preds = %144
   %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
@@ -6557,15 +8003,15 @@ entry:
 
 ; <label>:159                                     ; preds = %22
   %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
-  br i1 %NullCheck, label %161, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %ThrowNullRef, label %161
 
 ; <label>:161                                     ; preds = %159
   %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
   %163 = load i32, i32 addrspace(1)* %162
   %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
-  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %164, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %165
 
 ; <label>:165                                     ; preds = %161
   %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
@@ -6578,8 +8024,8 @@ entry:
 
 ; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
-  br i1 %NullCheck4, label %172, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %171, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %172
 
 ; <label>:172                                     ; preds = %170
   %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
@@ -6589,8 +8035,8 @@ entry:
 
 ; <label>:176                                     ; preds = %172
   %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
-  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %177, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %178
 
 ; <label>:178                                     ; preds = %176
   %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
@@ -6629,55 +8075,55 @@ ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %161
+ThrowNullRef2:                                    ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %170
+ThrowNullRef4:                                    ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %176
+ThrowNullRef6:                                    ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %142
+ThrowNullRef8:                                    ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %144
+ThrowNullRef10:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %113
+ThrowNullRef12:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %116
+ThrowNullRef14:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %84
+ThrowNullRef16:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %87
+ThrowNullRef18:                                   ; preds = %87
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %55
+ThrowNullRef20:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %58
+ThrowNullRef22:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %26
+ThrowNullRef24:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %29
+ThrowNullRef26:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,8 +8161,8 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck, label %14, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %ThrowNullRef, label %14
 
 ; <label>:14                                      ; preds = %8
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
@@ -6760,8 +8206,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
@@ -6770,14 +8216,14 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32, i32* %loc0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %10
   %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
   %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
@@ -6790,15 +8236,15 @@ entry:
 ; <label>:25                                      ; preds = %19
   %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
-  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
   %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
@@ -6807,8 +8253,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %37 = load i32, i32* %loc0
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %38, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %38
 
 ; <label>:38                                      ; preds = %32
   %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
@@ -6817,14 +8263,14 @@ entry:
 
 ; <label>:40                                      ; preds = %19
   %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %40
   %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
   %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
-  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
-  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
@@ -6832,8 +8278,8 @@ entry:
   %48 = zext i32 %47 to i64
   %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
-  br i1 %NullCheck16, label %51, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %51
 
 ; <label>:51                                      ; preds = %45
   %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
@@ -6847,15 +8293,15 @@ entry:
 ; <label>:57                                      ; preds = %51
   %58 = load i16*, i16** %arg1
   %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
-  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %60
 
 ; <label>:60                                      ; preds = %57
   %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
   %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
-  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %64
 
 ; <label>:64                                      ; preds = %60
   %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
@@ -6864,22 +8310,22 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
   %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
-  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %70
 
 ; <label>:70                                      ; preds = %64
   %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
   %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
-  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
-  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
   %75 = load i32, i32 addrspace(1)* %74
   %76 = zext i32 %75 to i64
   %77 = trunc i64 %76 to i32
-  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
-  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %78
 
 ; <label>:78                                      ; preds = %73
   %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
@@ -6901,8 +8347,8 @@ entry:
   %90 = bitcast i16* %86 to i8*
   %91 = getelementptr inbounds i8, i8* %90, i64 %89
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %93
 
 ; <label>:93                                      ; preds = %80
   %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
@@ -6912,8 +8358,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %99 = load i32, i32* %loc2
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %100
 
 ; <label>:100                                     ; preds = %93
   %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
@@ -6928,63 +8374,63 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %25
+ThrowNullRef6:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %32
+ThrowNullRef10:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %40
+ThrowNullRef12:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %45
+ThrowNullRef16:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %57
+ThrowNullRef18:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %60
+ThrowNullRef20:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %64
+ThrowNullRef22:                                   ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %70
+ThrowNullRef24:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %73
+ThrowNullRef26:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %80
+ThrowNullRef28:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %93
+ThrowNullRef30:                                   ; preds = %93
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7004,8 +8450,8 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
@@ -7033,43 +8479,43 @@ entry:
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %14
   %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
   %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   %28 = load i32, i32 addrspace(1)* %27, align 8
   %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
-  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %30
 
 ; <label>:30                                      ; preds = %26
   %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
   %32 = load i32, i32 addrspace(1)* %31, align 8
   %33 = add i32 %28, %32
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %34
 
 ; <label>:34                                      ; preds = %30
   %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   store i32 %33, i32 addrspace(1)* %35
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
   store i32 0, i32 addrspace(1)* %38
   %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %40
 
 ; <label>:40                                      ; preds = %37
   %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
@@ -7082,8 +8528,8 @@ entry:
 
 ; <label>:47                                      ; preds = %40
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
@@ -7098,8 +8544,8 @@ entry:
   %54 = load i32, i32* %loc0
   %55 = sext i32 %54 to i64
   %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
-  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %57
 
 ; <label>:57                                      ; preds = %52
   %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
@@ -7110,68 +8556,35 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %14
+ThrowNullRef2:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %23
+ThrowNullRef4:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %26
+ThrowNullRef6:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %30
+ThrowNullRef8:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %34
+ThrowNullRef10:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %47
+ThrowNullRef14:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %52
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-}
-
-INFO:  jitting method StringBuilder::get_Length using LLILCJit
-Successfully read StringBuilder.get_Length
-
-define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.StringBuilder addrspace(1)*
-  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
-  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
-
-; <label>:1                                       ; preds = %entry
-  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %3 = load i32, i32 addrspace(1)* %2, align 8
-  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
-
-; <label>:5                                       ; preds = %1
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = add i32 %3, %7
-  ret i32 %8
-
-ThrowNullRef:                                     ; preds = %entry
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef16:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7213,70 +8626,70 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
   %6 = load i32, i32 addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
   store i32 %6, i32 addrspace(1)* %8
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
   %13 = load i32, i32 addrspace(1)* %12, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
   store i32 %13, i32 addrspace(1)* %15
   %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
-  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %18
 
 ; <label>:18                                      ; preds = %14
   %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
   %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
   %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
   %34 = load i32, i32 addrspace(1)* %33, align 8
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
-  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
@@ -7287,39 +8700,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %28
+ThrowNullRef16:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %32
+ThrowNullRef18:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7455,13 +8868,13 @@ entry:
 ; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
@@ -7477,16 +8890,16 @@ entry:
 
 ; <label>:18                                      ; preds = %15
   %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
   store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
   %22 = load i32, i32* %loc0
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %24
 
 ; <label>:24                                      ; preds = %20
   %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
@@ -7498,13 +8911,13 @@ entry:
 ; <label>:28                                      ; preds = %15, %24
   %29 = load i32, i32* %arg1
   %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %31
   %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
@@ -7517,20 +8930,20 @@ entry:
   %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
-  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
   %46 = load i32, i32 addrspace(1)* %45, align 8
   %47 = sub i32 %40, %46
-  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
-  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i32 addrspace(1)* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %48
 
 ; <label>:48                                      ; preds = %44
   store i32 %47, i32 addrspace(1)* %39, align 8
@@ -7538,21 +8951,21 @@ entry:
 
 ; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
-  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %51
 
 ; <label>:51                                      ; preds = %49
   %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %53
 
 ; <label>:53                                      ; preds = %51
   %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
   %55 = load i32, i32 addrspace(1)* %54, align 8
   %56 = load i32, i32* %arg2
   %57 = sub i32 %55, %56
-  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %58
 
 ; <label>:58                                      ; preds = %53
   %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
@@ -7562,13 +8975,13 @@ entry:
 ; <label>:60                                      ; preds = %33, %58
   %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
   %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
-  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %63
 
 ; <label>:63                                      ; preds = %60
   %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
-  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
-  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
@@ -7578,15 +8991,15 @@ entry:
 
 ; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
-  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i32 addrspace(1)* %69, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %70
 
 ; <label>:70                                      ; preds = %68
   %71 = load i32, i32 addrspace(1)* %69, align 8
   store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
-  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
@@ -7596,8 +9009,8 @@ entry:
   store i32 %77, i32* %loc4
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
-  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %80
 
 ; <label>:80                                      ; preds = %73
   %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
@@ -7607,71 +9020,71 @@ entry:
 ; <label>:83                                      ; preds = %80
   store i32 0, i32* %loc3
   %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
-  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
-  br i1 %NullCheck26, label %88, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i32 addrspace(1)* %87, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %88
 
 ; <label>:88                                      ; preds = %85
   %89 = load i32, i32 addrspace(1)* %87, align 8
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
-  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %90
 
 ; <label>:90                                      ; preds = %88
   %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
   store i32 %89, i32 addrspace(1)* %91
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
-  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
-  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %96
 
 ; <label>:96                                      ; preds = %94
   %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
-  br i1 %NullCheck34, label %100, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %100
 
 ; <label>:100                                     ; preds = %96
   %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
-  br i1 %NullCheck36, label %102, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %102
 
 ; <label>:102                                     ; preds = %100
   %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
   %104 = load i32, i32 addrspace(1)* %103, align 8
   %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
-  br i1 %NullCheck38, label %106, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %106
 
 ; <label>:106                                     ; preds = %102
   %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
-  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
-  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %108
 
 ; <label>:108                                     ; preds = %106
   %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
   %110 = load i32, i32 addrspace(1)* %109, align 8
   %111 = add i32 %104, %110
-  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %112
 
 ; <label>:112                                     ; preds = %108
   %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
   store i32 %111, i32 addrspace(1)* %113
   %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
-  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i32 addrspace(1)* %114, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %115
 
 ; <label>:115                                     ; preds = %112
   %116 = load i32, i32 addrspace(1)* %114, align 8
@@ -7681,19 +9094,19 @@ entry:
 ; <label>:118                                     ; preds = %115
   %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
-  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %121
 
 ; <label>:121                                     ; preds = %118
   %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
-  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
-  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %123
 
 ; <label>:123                                     ; preds = %121
   %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
   %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
-  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
-  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %126
 
 ; <label>:126                                     ; preds = %123
   %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
@@ -7705,8 +9118,8 @@ entry:
 
 ; <label>:130                                     ; preds = %80, %115, %126
   %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %132
 
 ; <label>:132                                     ; preds = %130
   %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7715,8 +9128,8 @@ entry:
   %136 = load i32, i32* %loc3
   %137 = sub i32 %135, %136
   %138 = sub i32 %134, %137
-  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %139
 
 ; <label>:139                                     ; preds = %132
   %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7728,16 +9141,16 @@ entry:
 
 ; <label>:144                                     ; preds = %139
   %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
-  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %146
 
 ; <label>:146                                     ; preds = %144
   %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
   %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
   %149 = load i32, i32* %loc2
   %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
-  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %151
 
 ; <label>:151                                     ; preds = %146
   %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
@@ -7754,145 +9167,249 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %18
+ThrowNullRef4:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %31
+ThrowNullRef10:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %44
+ThrowNullRef16:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %68
+ThrowNullRef18:                                   ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %70
+ThrowNullRef20:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %73
+ThrowNullRef22:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %83
+ThrowNullRef24:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %85
+ThrowNullRef26:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %88
+ThrowNullRef28:                                   ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %90
+ThrowNullRef30:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %94
+ThrowNullRef32:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %96
+ThrowNullRef34:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %100
+ThrowNullRef36:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %102
+ThrowNullRef38:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %106
+ThrowNullRef40:                                   ; preds = %106
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %108
+ThrowNullRef42:                                   ; preds = %108
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %112
+ThrowNullRef44:                                   ; preds = %112
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %118
+ThrowNullRef46:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %121
+ThrowNullRef48:                                   ; preds = %121
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %123
+ThrowNullRef50:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %130
+ThrowNullRef52:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %132
+ThrowNullRef54:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %144
+ThrowNullRef56:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %146
+ThrowNullRef58:                                   ; preds = %146
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %60
+ThrowNullRef60:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %63
+ThrowNullRef62:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %49
+ThrowNullRef64:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %51
+ThrowNullRef66:                                   ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %53
+ThrowNullRef68:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(%"System.Char[]" addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %arg0 = alloca %"System.Char[]" addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store %"System.Char[]" addrspace(1)* %param0, %"System.Char[]" addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load i32, i32* %arg4
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %43, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %38, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg1
+  %13 = load i32, i32* %arg4
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %38, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %24 = load i32, i32* %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %35 = load i32, i32* %arg3
+  %36 = load i32, i32* %arg4
+  %37 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %37, %"System.Char[]" addrspace(1)* %34, i32 %35, i32 %36)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:38                                      ; preds = %5, %16
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Successfully read Buffer._Memmove
 
@@ -7914,7 +9431,7 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[loadElem]
+Failed to read AppDomain.SetDataHelper[storeElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -7923,8 +9440,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
@@ -7934,8 +9451,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
@@ -7947,15 +9464,15 @@ entry:
   %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
   %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
@@ -7966,15 +9483,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7992,7 +9509,79 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
-Failed to read Dictionary`2.TryGetValue[loadElemA]
+Successfully read Dictionary`2.TryGetValue
+
+define i8 @"Dictionary`2.TryGetValue"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)* addrspace(1)* %param2) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  %arg2 = alloca %System.__Canon addrspace(1)* addrspace(1)*
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  store %System.__Canon addrspace(1)* addrspace(1)* %param2, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  store i32 %2, i32* %loc0
+  %3 = load i32, i32* %loc0
+  %4 = icmp slt i32 %3, 0
+  br i1 %4, label %22, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 2
+  %10 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %9, align 8
+  %11 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = zext i32 %11 to i64
+  %BoundsCheck = icmp uge i64 %16, %15
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 3, i32 %11
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %20, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %6, %System.__Canon addrspace(1)* %21)
+  ret i8 1
+
+; <label>:22                                      ; preds = %entry
+  %23 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %23, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -8058,8 +9647,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
@@ -8091,8 +9680,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
@@ -8171,15 +9760,15 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck, label %19, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %ThrowNullRef, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
   %21 = load i32, i32 addrspace(1)* %20
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
@@ -8202,7 +9791,7 @@ ThrowNullRef:                                     ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %19
+ThrowNullRef2:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8248,8 +9837,8 @@ entry:
   %0 = alloca %System.AppDomainHandle
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %1 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %1, i32 0, i32 15
@@ -8269,8 +9858,8 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
@@ -8286,7 +9875,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -8299,8 +9888,8 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -8327,8 +9916,8 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
@@ -8352,8 +9941,8 @@ entry:
   %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
   store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
@@ -8363,8 +9952,8 @@ entry:
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
@@ -8374,8 +9963,8 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %9
   %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
@@ -8384,8 +9973,8 @@ entry:
 
 ; <label>:18                                      ; preds = %3, %16
   %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
@@ -8397,15 +9986,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %18
+ThrowNullRef6:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8418,8 +10007,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
@@ -8453,15 +10042,15 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
@@ -8473,7 +10062,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8481,7 +10070,7 @@ ThrowNullRef1:                                    ; preds = %1
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
 Failed to read Dictionary`2.System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
@@ -8506,8 +10095,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
@@ -8524,8 +10113,8 @@ entry:
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -8544,7 +10133,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8577,8 +10166,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = load i64, i64* %arg2
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = trunc i32 %3 to i8
@@ -8634,46 +10223,46 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
   %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
-  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
-  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
-  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
@@ -8684,27 +10273,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %20
+ThrowNullRef12:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8717,8 +10306,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -8756,22 +10345,22 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
   %9 = load i64, i64 addrspace(1)* %8, align 8
   %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
   %13 = load i64, i64 addrspace(1)* %12, align 8
   %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %11
   %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
@@ -8788,11 +10377,11 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8882,8 +10471,8 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
@@ -8900,8 +10489,8 @@ entry:
 ; <label>:8                                       ; preds = %1
   %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
   %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
@@ -8911,15 +10500,15 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
   %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
   %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
-  br i1 %NullCheck6, label %21, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
@@ -8946,15 +10535,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8992,15 +10581,15 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
   store i8 %3, i8 addrspace(1)* %5
   %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
@@ -9011,7 +10600,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9027,8 +10616,8 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -9041,8 +10630,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
@@ -9058,7 +10647,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9080,8 +10669,8 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
@@ -9096,8 +10685,8 @@ entry:
 ; <label>:12                                      ; preds = %6
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
@@ -9112,8 +10701,8 @@ entry:
 ; <label>:21                                      ; preds = %15
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
@@ -9128,8 +10717,8 @@ entry:
 ; <label>:30                                      ; preds = %24
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %31, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
@@ -9144,8 +10733,8 @@ entry:
 ; <label>:39                                      ; preds = %33
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
-  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %40, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %42
 
 ; <label>:42                                      ; preds = %39
   %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
@@ -9164,19 +10753,19 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %21
+ThrowNullRef4:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %30
+ThrowNullRef6:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %39
+ThrowNullRef8:                                    ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9243,8 +10832,8 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
@@ -9264,57 +10853,57 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
   store i8 0, i8 addrspace(1)* %2
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
   store i8 0, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
   store i8 0, i8 addrspace(1)* %17
   %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
   store i8 0, i8 addrspace(1)* %20
   %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
-  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
@@ -9325,31 +10914,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %19
+ThrowNullRef14:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9367,8 +10956,8 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
@@ -9380,8 +10969,8 @@ entry:
 
 ; <label>:9                                       ; preds = %4
   %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %9
   %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
@@ -9395,7 +10984,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef2:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9420,8 +11009,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
@@ -9512,8 +11101,8 @@ entry:
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
@@ -9524,8 +11113,8 @@ entry:
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = load i64, i64 addrspace(1)* %12
@@ -9537,8 +11126,8 @@ entry:
   %20 = load i64, i64* %19
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
-  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %13
   %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
@@ -9555,8 +11144,8 @@ entry:
 ; <label>:30                                      ; preds = %25
   %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %32 = load i32, i32* %arg2
-  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
-  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
@@ -9570,15 +11159,15 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %30
+ThrowNullRef2:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9622,87 +11211,87 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
   %10 = load i8, i8 addrspace(1)* %9, align 8
   %11 = zext i8 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %8
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
   store i8 %12, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
   %19 = load i8, i8 addrspace(1)* %18, align 8
   %20 = zext i8 %19 to i32
   %21 = trunc i32 %20 to i8
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
   store i8 %21, i8 addrspace(1)* %23
   %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
   %28 = load i8, i8 addrspace(1)* %27, align 8
   %29 = zext i8 %28 to i32
   %30 = trunc i32 %29 to i8
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
-  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %31
 
 ; <label>:31                                      ; preds = %26
   %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
   store i8 %30, i8 addrspace(1)* %32
   %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
-  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
-  br i1 %NullCheck14, label %40, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %40
 
 ; <label>:40                                      ; preds = %35
   %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
   store i8 %39, i8 addrspace(1)* %41
   %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
-  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %44
 
 ; <label>:44                                      ; preds = %40
   %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
   %46 = load i8, i8 addrspace(1)* %45, align 8
   %47 = zext i8 %46 to i32
   %48 = trunc i32 %47 to i8
-  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
   store i8 %48, i8 addrspace(1)* %50
   %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
-  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
@@ -9713,29 +11302,29 @@ entry:
 ; <label>:56                                      ; preds = %52
   %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
-  br i1 %NullCheck22, label %59, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
   %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
   %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
-  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
-  br i1 %NullCheck24, label %63, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
   %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
-  br i1 %NullCheck26, label %66, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
   %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
-  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
-  br i1 %NullCheck28, label %69, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %69
 
 ; <label>:69                                      ; preds = %66
   %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
@@ -9744,15 +11333,15 @@ entry:
 
 ; <label>:71                                      ; preds = %105
   %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
-  br i1 %NullCheck34, label %73, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %73
 
 ; <label>:73                                      ; preds = %71
   %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
   %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
   %76 = load i32, i32* %loc0
-  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
-  br i1 %NullCheck36, label %77, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
@@ -9766,8 +11355,8 @@ entry:
 
 ; <label>:83                                      ; preds = %77
   %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
-  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
@@ -9775,14 +11364,14 @@ entry:
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
   %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
-  br i1 %NullCheck40, label %91, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
 ; <label>:91                                      ; preds = %85
   %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
   %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
-  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck42, label %94, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %94
 
 ; <label>:94                                      ; preds = %91
   %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
@@ -9798,14 +11387,14 @@ entry:
 ; <label>:99                                      ; preds = %69, %96
   %100 = load i32, i32* %loc0
   %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
-  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %102
 
 ; <label>:102                                     ; preds = %99
   %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
   %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
-  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
-  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
@@ -9819,87 +11408,87 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %26
+ThrowNullRef10:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %31
+ThrowNullRef12:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %35
+ThrowNullRef14:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %40
+ThrowNullRef16:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %56
+ThrowNullRef22:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %59
+ThrowNullRef24:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %63
+ThrowNullRef26:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %66
+ThrowNullRef28:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %102
+ThrowNullRef32:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %71
+ThrowNullRef34:                                   ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %73
+ThrowNullRef36:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %83
+ThrowNullRef38:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %85
+ThrowNullRef40:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %91
+ThrowNullRef42:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9943,15 +11532,15 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
   %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
@@ -9961,28 +11550,28 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
   %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %12
   %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
   %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
   %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
-  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
@@ -9993,23 +11582,23 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %12
+ThrowNullRef6:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10031,15 +11620,15 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
   %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = load i64, i64 addrspace(1)* %7
@@ -10077,13 +11666,13 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[loadElem]
+Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -10111,8 +11700,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueLeDbl.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueLeDbl.error.txt
@@ -25,8 +25,8 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
@@ -40,8 +40,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
   %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
@@ -75,7 +75,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -90,8 +90,8 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %NullCheck = icmp ne i8 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = load i8, i8 addrspace(1)* %0, align 8
@@ -125,8 +125,8 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
@@ -159,8 +159,8 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -184,8 +184,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
   store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
@@ -195,8 +195,8 @@ entry:
 ; <label>:4                                       ; preds = %1
   %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
   %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
@@ -206,8 +206,8 @@ entry:
   %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
@@ -221,14 +221,14 @@ entry:
 
 ; <label>:17                                      ; preds = %14
   %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
   %21 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
@@ -238,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -249,8 +249,8 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
@@ -261,27 +261,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %30
+ThrowNullRef10:                                   ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -301,7 +301,89 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
-Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
+Successfully read AppDomainSetup.GetUnsecureApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.GetUnsecureApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %NullCheck = icmp eq %"System.String[]" addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %BoundsCheck = icmp uge i64 0, %5
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %6
+
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 3, i32 0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
+  ret %System.String addrspace(1)* %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_Value using LLILCJit
+Successfully read AppDomainSetup.get_Value
+
+define %"System.String[]" addrspace(1)* @AppDomainSetup.get_Value(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.String[]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 18)
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.String[]" addrspace(1)* addrspace(1)*, %"System.String[]" addrspace(1)*)*)(%"System.String[]" addrspace(1)* addrspace(1)* %9, %"System.String[]" addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %11, i32 0, i32 1
+  %14 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %13, align 8
+  ret %"System.String[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -319,8 +401,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -368,16 +450,16 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
   %5 = load i32, i32 addrspace(1)* %4
   %6 = sub i32 %5, 1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -389,7 +471,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -421,8 +503,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
@@ -456,8 +538,8 @@ entry:
 ; <label>:27                                      ; preds = %19
   %28 = load i32, i32* %arg1
   %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
-  br i1 %NullCheck2, label %30, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %29, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %30
 
 ; <label>:30                                      ; preds = %27
   %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
@@ -493,8 +575,8 @@ entry:
 ; <label>:49                                      ; preds = %46
   %50 = load i32, i32* %arg2
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck4, label %52, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
@@ -517,11 +599,11 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %27
+ThrowNullRef2:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %49
+ThrowNullRef4:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -544,16 +626,16 @@ entry:
   %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %0)
   store %System.String addrspace(1)* %1, %System.String addrspace(1)** %loc0
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 2
   %5 = bitcast [0 x i16] addrspace(1)* %4 to i16 addrspace(1)*
   store i16 addrspace(1)* %5, i16 addrspace(1)** %loc1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %3
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2
@@ -580,7 +662,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -691,15 +773,15 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %NullCheck132 = icmp ne i8* %21, null
-  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+  %NullCheck131 = icmp eq i8* %21, null
+  br i1 %NullCheck131, label %ThrowNullRef132, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = load i8, i8* %21, align 8
   %24 = zext i8 %23 to i32
   %25 = trunc i32 %24 to i8
-  %NullCheck134 = icmp ne i8* %20, null
-  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+  %NullCheck133 = icmp eq i8* %20, null
+  br i1 %NullCheck133, label %ThrowNullRef134, label %26
 
 ; <label>:26                                      ; preds = %22
   store i8 %25, i8* %20, align 8
@@ -709,16 +791,16 @@ entry:
   %28 = load i8*, i8** %arg0
   %29 = load i8*, i8** %arg1
   %30 = bitcast i8* %29 to i16*
-  %NullCheck128 = icmp ne i16* %30, null
-  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+  %NullCheck127 = icmp eq i16* %30, null
+  br i1 %NullCheck127, label %ThrowNullRef128, label %31
 
 ; <label>:31                                      ; preds = %27
   %32 = load i16, i16* %30, align 8
   %33 = sext i16 %32 to i32
   %34 = bitcast i8* %28 to i16*
   %35 = trunc i32 %33 to i16
-  %NullCheck130 = icmp ne i16* %34, null
-  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+  %NullCheck129 = icmp eq i16* %34, null
+  br i1 %NullCheck129, label %ThrowNullRef130, label %36
 
 ; <label>:36                                      ; preds = %31
   store i16 %35, i16* %34, align 8
@@ -728,16 +810,16 @@ entry:
   %38 = load i8*, i8** %arg0
   %39 = load i8*, i8** %arg1
   %40 = bitcast i8* %39 to i16*
-  %NullCheck120 = icmp ne i16* %40, null
-  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+  %NullCheck119 = icmp eq i16* %40, null
+  br i1 %NullCheck119, label %ThrowNullRef120, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i16, i16* %40, align 8
   %43 = sext i16 %42 to i32
   %44 = bitcast i8* %38 to i16*
   %45 = trunc i32 %43 to i16
-  %NullCheck122 = icmp ne i16* %44, null
-  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+  %NullCheck121 = icmp eq i16* %44, null
+  br i1 %NullCheck121, label %ThrowNullRef122, label %46
 
 ; <label>:46                                      ; preds = %41
   store i16 %45, i16* %44, align 8
@@ -745,15 +827,15 @@ entry:
   %48 = getelementptr inbounds i8, i8* %47, i64 2
   %49 = load i8*, i8** %arg1
   %50 = getelementptr inbounds i8, i8* %49, i64 2
-  %NullCheck124 = icmp ne i8* %50, null
-  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+  %NullCheck123 = icmp eq i8* %50, null
+  br i1 %NullCheck123, label %ThrowNullRef124, label %51
 
 ; <label>:51                                      ; preds = %46
   %52 = load i8, i8* %50, align 8
   %53 = zext i8 %52 to i32
   %54 = trunc i32 %53 to i8
-  %NullCheck126 = icmp ne i8* %48, null
-  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+  %NullCheck125 = icmp eq i8* %48, null
+  br i1 %NullCheck125, label %ThrowNullRef126, label %55
 
 ; <label>:55                                      ; preds = %51
   store i8 %54, i8* %48, align 8
@@ -763,14 +845,14 @@ entry:
   %57 = load i8*, i8** %arg0
   %58 = load i8*, i8** %arg1
   %59 = bitcast i8* %58 to i32*
-  %NullCheck116 = icmp ne i32* %59, null
-  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+  %NullCheck115 = icmp eq i32* %59, null
+  br i1 %NullCheck115, label %ThrowNullRef116, label %60
 
 ; <label>:60                                      ; preds = %56
   %61 = load i32, i32* %59, align 8
   %62 = bitcast i8* %57 to i32*
-  %NullCheck118 = icmp ne i32* %62, null
-  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+  %NullCheck117 = icmp eq i32* %62, null
+  br i1 %NullCheck117, label %ThrowNullRef118, label %63
 
 ; <label>:63                                      ; preds = %60
   store i32 %61, i32* %62, align 8
@@ -780,14 +862,14 @@ entry:
   %65 = load i8*, i8** %arg0
   %66 = load i8*, i8** %arg1
   %67 = bitcast i8* %66 to i32*
-  %NullCheck108 = icmp ne i32* %67, null
-  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+  %NullCheck107 = icmp eq i32* %67, null
+  br i1 %NullCheck107, label %ThrowNullRef108, label %68
 
 ; <label>:68                                      ; preds = %64
   %69 = load i32, i32* %67, align 8
   %70 = bitcast i8* %65 to i32*
-  %NullCheck110 = icmp ne i32* %70, null
-  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+  %NullCheck109 = icmp eq i32* %70, null
+  br i1 %NullCheck109, label %ThrowNullRef110, label %71
 
 ; <label>:71                                      ; preds = %68
   store i32 %69, i32* %70, align 8
@@ -795,15 +877,15 @@ entry:
   %73 = getelementptr inbounds i8, i8* %72, i64 4
   %74 = load i8*, i8** %arg1
   %75 = getelementptr inbounds i8, i8* %74, i64 4
-  %NullCheck112 = icmp ne i8* %75, null
-  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+  %NullCheck111 = icmp eq i8* %75, null
+  br i1 %NullCheck111, label %ThrowNullRef112, label %76
 
 ; <label>:76                                      ; preds = %71
   %77 = load i8, i8* %75, align 8
   %78 = zext i8 %77 to i32
   %79 = trunc i32 %78 to i8
-  %NullCheck114 = icmp ne i8* %73, null
-  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+  %NullCheck113 = icmp eq i8* %73, null
+  br i1 %NullCheck113, label %ThrowNullRef114, label %80
 
 ; <label>:80                                      ; preds = %76
   store i8 %79, i8* %73, align 8
@@ -813,14 +895,14 @@ entry:
   %82 = load i8*, i8** %arg0
   %83 = load i8*, i8** %arg1
   %84 = bitcast i8* %83 to i32*
-  %NullCheck100 = icmp ne i32* %84, null
-  br i1 %NullCheck100, label %85, label %ThrowNullRef99
+  %NullCheck99 = icmp eq i32* %84, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %85
 
 ; <label>:85                                      ; preds = %81
   %86 = load i32, i32* %84, align 8
   %87 = bitcast i8* %82 to i32*
-  %NullCheck102 = icmp ne i32* %87, null
-  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+  %NullCheck101 = icmp eq i32* %87, null
+  br i1 %NullCheck101, label %ThrowNullRef102, label %88
 
 ; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
@@ -829,16 +911,16 @@ entry:
   %91 = load i8*, i8** %arg1
   %92 = getelementptr inbounds i8, i8* %91, i64 4
   %93 = bitcast i8* %92 to i16*
-  %NullCheck104 = icmp ne i16* %93, null
-  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+  %NullCheck103 = icmp eq i16* %93, null
+  br i1 %NullCheck103, label %ThrowNullRef104, label %94
 
 ; <label>:94                                      ; preds = %88
   %95 = load i16, i16* %93, align 8
   %96 = sext i16 %95 to i32
   %97 = bitcast i8* %90 to i16*
   %98 = trunc i32 %96 to i16
-  %NullCheck106 = icmp ne i16* %97, null
-  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+  %NullCheck105 = icmp eq i16* %97, null
+  br i1 %NullCheck105, label %ThrowNullRef106, label %99
 
 ; <label>:99                                      ; preds = %94
   store i16 %98, i16* %97, align 8
@@ -848,14 +930,14 @@ entry:
   %101 = load i8*, i8** %arg0
   %102 = load i8*, i8** %arg1
   %103 = bitcast i8* %102 to i32*
-  %NullCheck88 = icmp ne i32* %103, null
-  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+  %NullCheck87 = icmp eq i32* %103, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %104
 
 ; <label>:104                                     ; preds = %100
   %105 = load i32, i32* %103, align 8
   %106 = bitcast i8* %101 to i32*
-  %NullCheck90 = icmp ne i32* %106, null
-  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+  %NullCheck89 = icmp eq i32* %106, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %107
 
 ; <label>:107                                     ; preds = %104
   store i32 %105, i32* %106, align 8
@@ -864,16 +946,16 @@ entry:
   %110 = load i8*, i8** %arg1
   %111 = getelementptr inbounds i8, i8* %110, i64 4
   %112 = bitcast i8* %111 to i16*
-  %NullCheck92 = icmp ne i16* %112, null
-  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+  %NullCheck91 = icmp eq i16* %112, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %113
 
 ; <label>:113                                     ; preds = %107
   %114 = load i16, i16* %112, align 8
   %115 = sext i16 %114 to i32
   %116 = bitcast i8* %109 to i16*
   %117 = trunc i32 %115 to i16
-  %NullCheck94 = icmp ne i16* %116, null
-  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+  %NullCheck93 = icmp eq i16* %116, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %118
 
 ; <label>:118                                     ; preds = %113
   store i16 %117, i16* %116, align 8
@@ -881,15 +963,15 @@ entry:
   %120 = getelementptr inbounds i8, i8* %119, i64 6
   %121 = load i8*, i8** %arg1
   %122 = getelementptr inbounds i8, i8* %121, i64 6
-  %NullCheck96 = icmp ne i8* %122, null
-  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+  %NullCheck95 = icmp eq i8* %122, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %123
 
 ; <label>:123                                     ; preds = %118
   %124 = load i8, i8* %122, align 8
   %125 = zext i8 %124 to i32
   %126 = trunc i32 %125 to i8
-  %NullCheck98 = icmp ne i8* %120, null
-  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+  %NullCheck97 = icmp eq i8* %120, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %127
 
 ; <label>:127                                     ; preds = %123
   store i8 %126, i8* %120, align 8
@@ -899,14 +981,14 @@ entry:
   %129 = load i8*, i8** %arg0
   %130 = load i8*, i8** %arg1
   %131 = bitcast i8* %130 to i64*
-  %NullCheck84 = icmp ne i64* %131, null
-  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+  %NullCheck83 = icmp eq i64* %131, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %132
 
 ; <label>:132                                     ; preds = %128
   %133 = load i64, i64* %131, align 8
   %134 = bitcast i8* %129 to i64*
-  %NullCheck86 = icmp ne i64* %134, null
-  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+  %NullCheck85 = icmp eq i64* %134, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %135
 
 ; <label>:135                                     ; preds = %132
   store i64 %133, i64* %134, align 8
@@ -916,14 +998,14 @@ entry:
   %137 = load i8*, i8** %arg0
   %138 = load i8*, i8** %arg1
   %139 = bitcast i8* %138 to i64*
-  %NullCheck76 = icmp ne i64* %139, null
-  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+  %NullCheck75 = icmp eq i64* %139, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %140
 
 ; <label>:140                                     ; preds = %136
   %141 = load i64, i64* %139, align 8
   %142 = bitcast i8* %137 to i64*
-  %NullCheck78 = icmp ne i64* %142, null
-  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+  %NullCheck77 = icmp eq i64* %142, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %143
 
 ; <label>:143                                     ; preds = %140
   store i64 %141, i64* %142, align 8
@@ -931,15 +1013,15 @@ entry:
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %NullCheck80 = icmp ne i8* %147, null
-  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+  %NullCheck79 = icmp eq i8* %147, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %148
 
 ; <label>:148                                     ; preds = %143
   %149 = load i8, i8* %147, align 8
   %150 = zext i8 %149 to i32
   %151 = trunc i32 %150 to i8
-  %NullCheck82 = icmp ne i8* %145, null
-  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+  %NullCheck81 = icmp eq i8* %145, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %152
 
 ; <label>:152                                     ; preds = %148
   store i8 %151, i8* %145, align 8
@@ -949,14 +1031,14 @@ entry:
   %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
   %156 = bitcast i8* %155 to i64*
-  %NullCheck68 = icmp ne i64* %156, null
-  br i1 %NullCheck68, label %157, label %ThrowNullRef67
+  %NullCheck67 = icmp eq i64* %156, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %157
 
 ; <label>:157                                     ; preds = %153
   %158 = load i64, i64* %156, align 8
   %159 = bitcast i8* %154 to i64*
-  %NullCheck70 = icmp ne i64* %159, null
-  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+  %NullCheck69 = icmp eq i64* %159, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %160
 
 ; <label>:160                                     ; preds = %157
   store i64 %158, i64* %159, align 8
@@ -965,16 +1047,16 @@ entry:
   %163 = load i8*, i8** %arg1
   %164 = getelementptr inbounds i8, i8* %163, i64 8
   %165 = bitcast i8* %164 to i16*
-  %NullCheck72 = icmp ne i16* %165, null
-  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+  %NullCheck71 = icmp eq i16* %165, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %166
 
 ; <label>:166                                     ; preds = %160
   %167 = load i16, i16* %165, align 8
   %168 = sext i16 %167 to i32
   %169 = bitcast i8* %162 to i16*
   %170 = trunc i32 %168 to i16
-  %NullCheck74 = icmp ne i16* %169, null
-  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+  %NullCheck73 = icmp eq i16* %169, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %171
 
 ; <label>:171                                     ; preds = %166
   store i16 %170, i16* %169, align 8
@@ -984,14 +1066,14 @@ entry:
   %173 = load i8*, i8** %arg0
   %174 = load i8*, i8** %arg1
   %175 = bitcast i8* %174 to i64*
-  %NullCheck56 = icmp ne i64* %175, null
-  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+  %NullCheck55 = icmp eq i64* %175, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %176
 
 ; <label>:176                                     ; preds = %172
   %177 = load i64, i64* %175, align 8
   %178 = bitcast i8* %173 to i64*
-  %NullCheck58 = icmp ne i64* %178, null
-  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+  %NullCheck57 = icmp eq i64* %178, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %179
 
 ; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
@@ -1000,16 +1082,16 @@ entry:
   %182 = load i8*, i8** %arg1
   %183 = getelementptr inbounds i8, i8* %182, i64 8
   %184 = bitcast i8* %183 to i16*
-  %NullCheck60 = icmp ne i16* %184, null
-  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+  %NullCheck59 = icmp eq i16* %184, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %185
 
 ; <label>:185                                     ; preds = %179
   %186 = load i16, i16* %184, align 8
   %187 = sext i16 %186 to i32
   %188 = bitcast i8* %181 to i16*
   %189 = trunc i32 %187 to i16
-  %NullCheck62 = icmp ne i16* %188, null
-  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+  %NullCheck61 = icmp eq i16* %188, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %190
 
 ; <label>:190                                     ; preds = %185
   store i16 %189, i16* %188, align 8
@@ -1017,15 +1099,15 @@ entry:
   %192 = getelementptr inbounds i8, i8* %191, i64 10
   %193 = load i8*, i8** %arg1
   %194 = getelementptr inbounds i8, i8* %193, i64 10
-  %NullCheck64 = icmp ne i8* %194, null
-  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+  %NullCheck63 = icmp eq i8* %194, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %195
 
 ; <label>:195                                     ; preds = %190
   %196 = load i8, i8* %194, align 8
   %197 = zext i8 %196 to i32
   %198 = trunc i32 %197 to i8
-  %NullCheck66 = icmp ne i8* %192, null
-  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+  %NullCheck65 = icmp eq i8* %192, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %199
 
 ; <label>:199                                     ; preds = %195
   store i8 %198, i8* %192, align 8
@@ -1035,14 +1117,14 @@ entry:
   %201 = load i8*, i8** %arg0
   %202 = load i8*, i8** %arg1
   %203 = bitcast i8* %202 to i64*
-  %NullCheck48 = icmp ne i64* %203, null
-  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+  %NullCheck47 = icmp eq i64* %203, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %204
 
 ; <label>:204                                     ; preds = %200
   %205 = load i64, i64* %203, align 8
   %206 = bitcast i8* %201 to i64*
-  %NullCheck50 = icmp ne i64* %206, null
-  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+  %NullCheck49 = icmp eq i64* %206, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %207
 
 ; <label>:207                                     ; preds = %204
   store i64 %205, i64* %206, align 8
@@ -1051,14 +1133,14 @@ entry:
   %210 = load i8*, i8** %arg1
   %211 = getelementptr inbounds i8, i8* %210, i64 8
   %212 = bitcast i8* %211 to i32*
-  %NullCheck52 = icmp ne i32* %212, null
-  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+  %NullCheck51 = icmp eq i32* %212, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %213
 
 ; <label>:213                                     ; preds = %207
   %214 = load i32, i32* %212, align 8
   %215 = bitcast i8* %209 to i32*
-  %NullCheck54 = icmp ne i32* %215, null
-  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+  %NullCheck53 = icmp eq i32* %215, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %216
 
 ; <label>:216                                     ; preds = %213
   store i32 %214, i32* %215, align 8
@@ -1068,14 +1150,14 @@ entry:
   %218 = load i8*, i8** %arg0
   %219 = load i8*, i8** %arg1
   %220 = bitcast i8* %219 to i64*
-  %NullCheck36 = icmp ne i64* %220, null
-  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64* %220, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %221
 
 ; <label>:221                                     ; preds = %217
   %222 = load i64, i64* %220, align 8
   %223 = bitcast i8* %218 to i64*
-  %NullCheck38 = icmp ne i64* %223, null
-  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+  %NullCheck37 = icmp eq i64* %223, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %224
 
 ; <label>:224                                     ; preds = %221
   store i64 %222, i64* %223, align 8
@@ -1084,14 +1166,14 @@ entry:
   %227 = load i8*, i8** %arg1
   %228 = getelementptr inbounds i8, i8* %227, i64 8
   %229 = bitcast i8* %228 to i32*
-  %NullCheck40 = icmp ne i32* %229, null
-  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i32* %229, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %230
 
 ; <label>:230                                     ; preds = %224
   %231 = load i32, i32* %229, align 8
   %232 = bitcast i8* %226 to i32*
-  %NullCheck42 = icmp ne i32* %232, null
-  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+  %NullCheck41 = icmp eq i32* %232, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %233
 
 ; <label>:233                                     ; preds = %230
   store i32 %231, i32* %232, align 8
@@ -1099,15 +1181,15 @@ entry:
   %235 = getelementptr inbounds i8, i8* %234, i64 12
   %236 = load i8*, i8** %arg1
   %237 = getelementptr inbounds i8, i8* %236, i64 12
-  %NullCheck44 = icmp ne i8* %237, null
-  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i8* %237, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %238
 
 ; <label>:238                                     ; preds = %233
   %239 = load i8, i8* %237, align 8
   %240 = zext i8 %239 to i32
   %241 = trunc i32 %240 to i8
-  %NullCheck46 = icmp ne i8* %235, null
-  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+  %NullCheck45 = icmp eq i8* %235, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %242
 
 ; <label>:242                                     ; preds = %238
   store i8 %241, i8* %235, align 8
@@ -1117,14 +1199,14 @@ entry:
   %244 = load i8*, i8** %arg0
   %245 = load i8*, i8** %arg1
   %246 = bitcast i8* %245 to i64*
-  %NullCheck24 = icmp ne i64* %246, null
-  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64* %246, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %247
 
 ; <label>:247                                     ; preds = %243
   %248 = load i64, i64* %246, align 8
   %249 = bitcast i8* %244 to i64*
-  %NullCheck26 = icmp ne i64* %249, null
-  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64* %249, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %250
 
 ; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
@@ -1133,14 +1215,14 @@ entry:
   %253 = load i8*, i8** %arg1
   %254 = getelementptr inbounds i8, i8* %253, i64 8
   %255 = bitcast i8* %254 to i32*
-  %NullCheck28 = icmp ne i32* %255, null
-  br i1 %NullCheck28, label %256, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i32* %255, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %256
 
 ; <label>:256                                     ; preds = %250
   %257 = load i32, i32* %255, align 8
   %258 = bitcast i8* %252 to i32*
-  %NullCheck30 = icmp ne i32* %258, null
-  br i1 %NullCheck30, label %259, label %ThrowNullRef29
+  %NullCheck29 = icmp eq i32* %258, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %259
 
 ; <label>:259                                     ; preds = %256
   store i32 %257, i32* %258, align 8
@@ -1149,16 +1231,16 @@ entry:
   %262 = load i8*, i8** %arg1
   %263 = getelementptr inbounds i8, i8* %262, i64 12
   %264 = bitcast i8* %263 to i16*
-  %NullCheck32 = icmp ne i16* %264, null
-  br i1 %NullCheck32, label %265, label %ThrowNullRef31
+  %NullCheck31 = icmp eq i16* %264, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %265
 
 ; <label>:265                                     ; preds = %259
   %266 = load i16, i16* %264, align 8
   %267 = sext i16 %266 to i32
   %268 = bitcast i8* %261 to i16*
   %269 = trunc i32 %267 to i16
-  %NullCheck34 = icmp ne i16* %268, null
-  br i1 %NullCheck34, label %270, label %ThrowNullRef33
+  %NullCheck33 = icmp eq i16* %268, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %270
 
 ; <label>:270                                     ; preds = %265
   store i16 %269, i16* %268, align 8
@@ -1168,14 +1250,14 @@ entry:
   %272 = load i8*, i8** %arg0
   %273 = load i8*, i8** %arg1
   %274 = bitcast i8* %273 to i64*
-  %NullCheck8 = icmp ne i64* %274, null
-  br i1 %NullCheck8, label %275, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64* %274, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %275
 
 ; <label>:275                                     ; preds = %271
   %276 = load i64, i64* %274, align 8
   %277 = bitcast i8* %272 to i64*
-  %NullCheck10 = icmp ne i64* %277, null
-  br i1 %NullCheck10, label %278, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %277, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %278
 
 ; <label>:278                                     ; preds = %275
   store i64 %276, i64* %277, align 8
@@ -1184,14 +1266,14 @@ entry:
   %281 = load i8*, i8** %arg1
   %282 = getelementptr inbounds i8, i8* %281, i64 8
   %283 = bitcast i8* %282 to i32*
-  %NullCheck12 = icmp ne i32* %283, null
-  br i1 %NullCheck12, label %284, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i32* %283, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %284
 
 ; <label>:284                                     ; preds = %278
   %285 = load i32, i32* %283, align 8
   %286 = bitcast i8* %280 to i32*
-  %NullCheck14 = icmp ne i32* %286, null
-  br i1 %NullCheck14, label %287, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i32* %286, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %287
 
 ; <label>:287                                     ; preds = %284
   store i32 %285, i32* %286, align 8
@@ -1200,16 +1282,16 @@ entry:
   %290 = load i8*, i8** %arg1
   %291 = getelementptr inbounds i8, i8* %290, i64 12
   %292 = bitcast i8* %291 to i16*
-  %NullCheck16 = icmp ne i16* %292, null
-  br i1 %NullCheck16, label %293, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i16* %292, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %293
 
 ; <label>:293                                     ; preds = %287
   %294 = load i16, i16* %292, align 8
   %295 = sext i16 %294 to i32
   %296 = bitcast i8* %289 to i16*
   %297 = trunc i32 %295 to i16
-  %NullCheck18 = icmp ne i16* %296, null
-  br i1 %NullCheck18, label %298, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i16* %296, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %298
 
 ; <label>:298                                     ; preds = %293
   store i16 %297, i16* %296, align 8
@@ -1217,15 +1299,15 @@ entry:
   %300 = getelementptr inbounds i8, i8* %299, i64 14
   %301 = load i8*, i8** %arg1
   %302 = getelementptr inbounds i8, i8* %301, i64 14
-  %NullCheck20 = icmp ne i8* %302, null
-  br i1 %NullCheck20, label %303, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i8* %302, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %303
 
 ; <label>:303                                     ; preds = %298
   %304 = load i8, i8* %302, align 8
   %305 = zext i8 %304 to i32
   %306 = trunc i32 %305 to i8
-  %NullCheck22 = icmp ne i8* %300, null
-  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i8* %300, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %307
 
 ; <label>:307                                     ; preds = %303
   store i8 %306, i8* %300, align 8
@@ -1235,14 +1317,14 @@ entry:
   %309 = load i8*, i8** %arg0
   %310 = load i8*, i8** %arg1
   %311 = bitcast i8* %310 to i64*
-  %NullCheck = icmp ne i64* %311, null
-  br i1 %NullCheck, label %312, label %ThrowNullRef
+  %NullCheck = icmp eq i64* %311, null
+  br i1 %NullCheck, label %ThrowNullRef, label %312
 
 ; <label>:312                                     ; preds = %308
   %313 = load i64, i64* %311, align 8
   %314 = bitcast i8* %309 to i64*
-  %NullCheck2 = icmp ne i64* %314, null
-  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64* %314, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %315
 
 ; <label>:315                                     ; preds = %312
   store i64 %313, i64* %314, align 8
@@ -1251,14 +1333,14 @@ entry:
   %318 = load i8*, i8** %arg1
   %319 = getelementptr inbounds i8, i8* %318, i64 8
   %320 = bitcast i8* %319 to i64*
-  %NullCheck4 = icmp ne i64* %320, null
-  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64* %320, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %321
 
 ; <label>:321                                     ; preds = %315
   %322 = load i64, i64* %320, align 8
   %323 = bitcast i8* %317 to i64*
-  %NullCheck6 = icmp ne i64* %323, null
-  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64* %323, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %324
 
 ; <label>:324                                     ; preds = %321
   store i64 %322, i64* %323, align 8
@@ -1286,15 +1368,15 @@ entry:
 ; <label>:338                                     ; preds = %333
   %339 = load i8*, i8** %arg0
   %340 = load i8*, i8** %arg1
-  %NullCheck136 = icmp ne i8* %340, null
-  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+  %NullCheck135 = icmp eq i8* %340, null
+  br i1 %NullCheck135, label %ThrowNullRef136, label %341
 
 ; <label>:341                                     ; preds = %338
   %342 = load i8, i8* %340, align 8
   %343 = zext i8 %342 to i32
   %344 = trunc i32 %343 to i8
-  %NullCheck138 = icmp ne i8* %339, null
-  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+  %NullCheck137 = icmp eq i8* %339, null
+  br i1 %NullCheck137, label %ThrowNullRef138, label %345
 
 ; <label>:345                                     ; preds = %341
   store i8 %344, i8* %339, align 8
@@ -1317,16 +1399,16 @@ entry:
   %357 = load i8*, i8** %arg0
   %358 = load i8*, i8** %arg1
   %359 = bitcast i8* %358 to i16*
-  %NullCheck140 = icmp ne i16* %359, null
-  br i1 %NullCheck140, label %360, label %ThrowNullRef139
+  %NullCheck139 = icmp eq i16* %359, null
+  br i1 %NullCheck139, label %ThrowNullRef140, label %360
 
 ; <label>:360                                     ; preds = %356
   %361 = load i16, i16* %359, align 8
   %362 = sext i16 %361 to i32
   %363 = bitcast i8* %357 to i16*
   %364 = trunc i32 %362 to i16
-  %NullCheck142 = icmp ne i16* %363, null
-  br i1 %NullCheck142, label %365, label %ThrowNullRef141
+  %NullCheck141 = icmp eq i16* %363, null
+  br i1 %NullCheck141, label %ThrowNullRef142, label %365
 
 ; <label>:365                                     ; preds = %360
   store i16 %364, i16* %363, align 8
@@ -1352,14 +1434,14 @@ entry:
   %378 = load i8*, i8** %arg0
   %379 = load i8*, i8** %arg1
   %380 = bitcast i8* %379 to i32*
-  %NullCheck144 = icmp ne i32* %380, null
-  br i1 %NullCheck144, label %381, label %ThrowNullRef143
+  %NullCheck143 = icmp eq i32* %380, null
+  br i1 %NullCheck143, label %ThrowNullRef144, label %381
 
 ; <label>:381                                     ; preds = %377
   %382 = load i32, i32* %380, align 8
   %383 = bitcast i8* %378 to i32*
-  %NullCheck146 = icmp ne i32* %383, null
-  br i1 %NullCheck146, label %384, label %ThrowNullRef145
+  %NullCheck145 = icmp eq i32* %383, null
+  br i1 %NullCheck145, label %ThrowNullRef146, label %384
 
 ; <label>:384                                     ; preds = %381
   store i32 %382, i32* %383, align 8
@@ -1384,14 +1466,14 @@ entry:
   %395 = load i8*, i8** %arg0
   %396 = load i8*, i8** %arg1
   %397 = bitcast i8* %396 to i64*
-  %NullCheck164 = icmp ne i64* %397, null
-  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+  %NullCheck163 = icmp eq i64* %397, null
+  br i1 %NullCheck163, label %ThrowNullRef164, label %398
 
 ; <label>:398                                     ; preds = %394
   %399 = load i64, i64* %397, align 8
   %400 = bitcast i8* %395 to i64*
-  %NullCheck166 = icmp ne i64* %400, null
-  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+  %NullCheck165 = icmp eq i64* %400, null
+  br i1 %NullCheck165, label %ThrowNullRef166, label %401
 
 ; <label>:401                                     ; preds = %398
   store i64 %399, i64* %400, align 8
@@ -1400,14 +1482,14 @@ entry:
   %404 = load i8*, i8** %arg1
   %405 = getelementptr inbounds i8, i8* %404, i64 8
   %406 = bitcast i8* %405 to i64*
-  %NullCheck168 = icmp ne i64* %406, null
-  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+  %NullCheck167 = icmp eq i64* %406, null
+  br i1 %NullCheck167, label %ThrowNullRef168, label %407
 
 ; <label>:407                                     ; preds = %401
   %408 = load i64, i64* %406, align 8
   %409 = bitcast i8* %403 to i64*
-  %NullCheck170 = icmp ne i64* %409, null
-  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+  %NullCheck169 = icmp eq i64* %409, null
+  br i1 %NullCheck169, label %ThrowNullRef170, label %410
 
 ; <label>:410                                     ; preds = %407
   store i64 %408, i64* %409, align 8
@@ -1437,14 +1519,14 @@ entry:
   %425 = load i8*, i8** %arg0
   %426 = load i8*, i8** %arg1
   %427 = bitcast i8* %426 to i64*
-  %NullCheck148 = icmp ne i64* %427, null
-  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+  %NullCheck147 = icmp eq i64* %427, null
+  br i1 %NullCheck147, label %ThrowNullRef148, label %428
 
 ; <label>:428                                     ; preds = %424
   %429 = load i64, i64* %427, align 8
   %430 = bitcast i8* %425 to i64*
-  %NullCheck150 = icmp ne i64* %430, null
-  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+  %NullCheck149 = icmp eq i64* %430, null
+  br i1 %NullCheck149, label %ThrowNullRef150, label %431
 
 ; <label>:431                                     ; preds = %428
   store i64 %429, i64* %430, align 8
@@ -1466,14 +1548,14 @@ entry:
   %441 = load i8*, i8** %arg0
   %442 = load i8*, i8** %arg1
   %443 = bitcast i8* %442 to i32*
-  %NullCheck152 = icmp ne i32* %443, null
-  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+  %NullCheck151 = icmp eq i32* %443, null
+  br i1 %NullCheck151, label %ThrowNullRef152, label %444
 
 ; <label>:444                                     ; preds = %440
   %445 = load i32, i32* %443, align 8
   %446 = bitcast i8* %441 to i32*
-  %NullCheck154 = icmp ne i32* %446, null
-  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+  %NullCheck153 = icmp eq i32* %446, null
+  br i1 %NullCheck153, label %ThrowNullRef154, label %447
 
 ; <label>:447                                     ; preds = %444
   store i32 %445, i32* %446, align 8
@@ -1495,16 +1577,16 @@ entry:
   %457 = load i8*, i8** %arg0
   %458 = load i8*, i8** %arg1
   %459 = bitcast i8* %458 to i16*
-  %NullCheck156 = icmp ne i16* %459, null
-  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+  %NullCheck155 = icmp eq i16* %459, null
+  br i1 %NullCheck155, label %ThrowNullRef156, label %460
 
 ; <label>:460                                     ; preds = %456
   %461 = load i16, i16* %459, align 8
   %462 = sext i16 %461 to i32
   %463 = bitcast i8* %457 to i16*
   %464 = trunc i32 %462 to i16
-  %NullCheck158 = icmp ne i16* %463, null
-  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+  %NullCheck157 = icmp eq i16* %463, null
+  br i1 %NullCheck157, label %ThrowNullRef158, label %465
 
 ; <label>:465                                     ; preds = %460
   store i16 %464, i16* %463, align 8
@@ -1525,15 +1607,15 @@ entry:
 ; <label>:474                                     ; preds = %470
   %475 = load i8*, i8** %arg0
   %476 = load i8*, i8** %arg1
-  %NullCheck160 = icmp ne i8* %476, null
-  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+  %NullCheck159 = icmp eq i8* %476, null
+  br i1 %NullCheck159, label %ThrowNullRef160, label %477
 
 ; <label>:477                                     ; preds = %474
   %478 = load i8, i8* %476, align 8
   %479 = zext i8 %478 to i32
   %480 = trunc i32 %479 to i8
-  %NullCheck162 = icmp ne i8* %475, null
-  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+  %NullCheck161 = icmp eq i8* %475, null
+  br i1 %NullCheck161, label %ThrowNullRef162, label %481
 
 ; <label>:481                                     ; preds = %477
   store i8 %480, i8* %475, align 8
@@ -1553,343 +1635,343 @@ ThrowNullRef:                                     ; preds = %308
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %312
+ThrowNullRef2:                                    ; preds = %312
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %315
+ThrowNullRef4:                                    ; preds = %315
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %321
+ThrowNullRef6:                                    ; preds = %321
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %271
+ThrowNullRef8:                                    ; preds = %271
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %275
+ThrowNullRef10:                                   ; preds = %275
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %278
+ThrowNullRef12:                                   ; preds = %278
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %284
+ThrowNullRef14:                                   ; preds = %284
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %287
+ThrowNullRef16:                                   ; preds = %287
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %293
+ThrowNullRef18:                                   ; preds = %293
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %298
+ThrowNullRef20:                                   ; preds = %298
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %303
+ThrowNullRef22:                                   ; preds = %303
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %243
+ThrowNullRef24:                                   ; preds = %243
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %247
+ThrowNullRef26:                                   ; preds = %247
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %250
+ThrowNullRef28:                                   ; preds = %250
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %256
+ThrowNullRef30:                                   ; preds = %256
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %259
+ThrowNullRef32:                                   ; preds = %259
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %265
+ThrowNullRef34:                                   ; preds = %265
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %217
+ThrowNullRef36:                                   ; preds = %217
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %221
+ThrowNullRef38:                                   ; preds = %221
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %224
+ThrowNullRef40:                                   ; preds = %224
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %230
+ThrowNullRef42:                                   ; preds = %230
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %233
+ThrowNullRef44:                                   ; preds = %233
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %238
+ThrowNullRef46:                                   ; preds = %238
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %200
+ThrowNullRef48:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %204
+ThrowNullRef50:                                   ; preds = %204
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %207
+ThrowNullRef52:                                   ; preds = %207
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %213
+ThrowNullRef54:                                   ; preds = %213
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %172
+ThrowNullRef56:                                   ; preds = %172
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %176
+ThrowNullRef58:                                   ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %179
+ThrowNullRef60:                                   ; preds = %179
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %185
+ThrowNullRef62:                                   ; preds = %185
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %190
+ThrowNullRef64:                                   ; preds = %190
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %195
+ThrowNullRef66:                                   ; preds = %195
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %153
+ThrowNullRef68:                                   ; preds = %153
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %157
+ThrowNullRef70:                                   ; preds = %157
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %160
+ThrowNullRef72:                                   ; preds = %160
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %166
+ThrowNullRef74:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %136
+ThrowNullRef76:                                   ; preds = %136
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %140
+ThrowNullRef78:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %143
+ThrowNullRef80:                                   ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %148
+ThrowNullRef82:                                   ; preds = %148
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %128
+ThrowNullRef84:                                   ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %132
+ThrowNullRef86:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %100
+ThrowNullRef88:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %104
+ThrowNullRef90:                                   ; preds = %104
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %107
+ThrowNullRef92:                                   ; preds = %107
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %113
+ThrowNullRef94:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %118
+ThrowNullRef96:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %123
+ThrowNullRef98:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %81
+ThrowNullRef100:                                  ; preds = %81
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef101:                                  ; preds = %85
+ThrowNullRef102:                                  ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef103:                                  ; preds = %88
+ThrowNullRef104:                                  ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef105:                                  ; preds = %94
+ThrowNullRef106:                                  ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef107:                                  ; preds = %64
+ThrowNullRef108:                                  ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef109:                                  ; preds = %68
+ThrowNullRef110:                                  ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef111:                                  ; preds = %71
+ThrowNullRef112:                                  ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef113:                                  ; preds = %76
+ThrowNullRef114:                                  ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef115:                                  ; preds = %56
+ThrowNullRef116:                                  ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef117:                                  ; preds = %60
+ThrowNullRef118:                                  ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef119:                                  ; preds = %37
+ThrowNullRef120:                                  ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef121:                                  ; preds = %41
+ThrowNullRef122:                                  ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef123:                                  ; preds = %46
+ThrowNullRef124:                                  ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef125:                                  ; preds = %51
+ThrowNullRef126:                                  ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef127:                                  ; preds = %27
+ThrowNullRef128:                                  ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef129:                                  ; preds = %31
+ThrowNullRef130:                                  ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef131:                                  ; preds = %19
+ThrowNullRef132:                                  ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef133:                                  ; preds = %22
+ThrowNullRef134:                                  ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef135:                                  ; preds = %338
+ThrowNullRef136:                                  ; preds = %338
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef137:                                  ; preds = %341
+ThrowNullRef138:                                  ; preds = %341
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef139:                                  ; preds = %356
+ThrowNullRef140:                                  ; preds = %356
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef141:                                  ; preds = %360
+ThrowNullRef142:                                  ; preds = %360
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef143:                                  ; preds = %377
+ThrowNullRef144:                                  ; preds = %377
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef145:                                  ; preds = %381
+ThrowNullRef146:                                  ; preds = %381
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef147:                                  ; preds = %424
+ThrowNullRef148:                                  ; preds = %424
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef149:                                  ; preds = %428
+ThrowNullRef150:                                  ; preds = %428
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef151:                                  ; preds = %440
+ThrowNullRef152:                                  ; preds = %440
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef153:                                  ; preds = %444
+ThrowNullRef154:                                  ; preds = %444
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef155:                                  ; preds = %456
+ThrowNullRef156:                                  ; preds = %456
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef157:                                  ; preds = %460
+ThrowNullRef158:                                  ; preds = %460
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef159:                                  ; preds = %474
+ThrowNullRef160:                                  ; preds = %474
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef161:                                  ; preds = %477
+ThrowNullRef162:                                  ; preds = %477
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef163:                                  ; preds = %394
+ThrowNullRef164:                                  ; preds = %394
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef165:                                  ; preds = %398
+ThrowNullRef166:                                  ; preds = %398
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef167:                                  ; preds = %401
+ThrowNullRef168:                                  ; preds = %401
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef169:                                  ; preds = %407
+ThrowNullRef170:                                  ; preds = %407
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1939,8 +2021,8 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
-  br i1 %NullCheck, label %22, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %ThrowNullRef, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
@@ -1948,8 +2030,8 @@ entry:
   store i32 %24, i32* %loc0
   %25 = load i32, i32* %loc0
   %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %26, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %27
 
 ; <label>:27                                      ; preds = %22
   %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
@@ -1971,7 +2053,7 @@ ThrowNullRef:                                     ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1989,8 +2071,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -2022,15 +2104,15 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2048,16 +2130,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
   %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
   store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %15
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
@@ -2072,8 +2154,8 @@ entry:
   %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
   %29 = ptrtoint i16 addrspace(1)* %28 to i64
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %19
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
@@ -2089,19 +2171,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2114,8 +2196,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
@@ -2128,7 +2210,7 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[loadElem]
+Failed to read AppDomain.PrepareDataForSetup[storeElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
@@ -2202,8 +2284,8 @@ entry:
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
-  br i1 %NullCheck24, label %27, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = load i64, i64 addrspace(1)* %26
@@ -2218,8 +2300,8 @@ entry:
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
-  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
   %41 = load i64, i64 addrspace(1)* %39
@@ -2236,8 +2318,8 @@ entry:
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
-  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
   %54 = load i64, i64 addrspace(1)* %52
@@ -2252,8 +2334,8 @@ entry:
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
   %67 = load i64, i64 addrspace(1)* %65
@@ -2270,8 +2352,8 @@ entry:
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
-  br i1 %NullCheck16, label %79, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
   %80 = load i64, i64 addrspace(1)* %78
@@ -2286,8 +2368,8 @@ entry:
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
-  br i1 %NullCheck18, label %92, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
   %93 = load i64, i64 addrspace(1)* %91
@@ -2304,8 +2386,8 @@ entry:
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
-  br i1 %NullCheck12, label %105, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = load i64, i64 addrspace(1)* %104
@@ -2320,8 +2402,8 @@ entry:
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
-  br i1 %NullCheck14, label %118, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
   %119 = load i64, i64 addrspace(1)* %117
@@ -2337,8 +2419,8 @@ entry:
 
 ; <label>:128                                     ; preds = %20
   %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
-  br i1 %NullCheck4, label %130, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %129, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %130
 
 ; <label>:130                                     ; preds = %128
   %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
@@ -2346,8 +2428,8 @@ entry:
   %133 = load i16, i16 addrspace(1)* %132, align 8
   %134 = zext i16 %133 to i32
   %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
-  br i1 %NullCheck6, label %136, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %135, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %136
 
 ; <label>:136                                     ; preds = %130
   %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
@@ -2360,8 +2442,8 @@ entry:
 
 ; <label>:143                                     ; preds = %136
   %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
-  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %144, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %145
 
 ; <label>:145                                     ; preds = %143
   %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
@@ -2369,8 +2451,8 @@ entry:
   %148 = load i16, i16 addrspace(1)* %147, align 8
   %149 = zext i16 %148 to i32
   %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %150, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %151
 
 ; <label>:151                                     ; preds = %145
   %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
@@ -2388,8 +2470,8 @@ entry:
 
 ; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
-  br i1 %NullCheck, label %163, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %ThrowNullRef, label %163
 
 ; <label>:163                                     ; preds = %161
   %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
@@ -2399,8 +2481,8 @@ entry:
 
 ; <label>:167                                     ; preds = %163
   %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
-  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %168, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %169
 
 ; <label>:169                                     ; preds = %167
   %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
@@ -2432,55 +2514,55 @@ ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %167
+ThrowNullRef2:                                    ; preds = %167
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %128
+ThrowNullRef4:                                    ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %130
+ThrowNullRef6:                                    ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %143
+ThrowNullRef8:                                    ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %145
+ThrowNullRef10:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %102
+ThrowNullRef12:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %105
+ThrowNullRef14:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %76
+ThrowNullRef16:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %79
+ThrowNullRef18:                                   ; preds = %79
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %50
+ThrowNullRef20:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %53
+ThrowNullRef22:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %24
+ThrowNullRef24:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %27
+ThrowNullRef26:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2503,15 +2585,15 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2519,16 +2601,16 @@ entry:
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
   store i32 %8, i32* %loc0
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
   %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
   store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
@@ -2546,16 +2628,16 @@ entry:
 
 ; <label>:23                                      ; preds = %64
   %24 = load i16*, i16** %loc3
-  %NullCheck12 = icmp ne i16* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i16* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
   store i32 %27, i32* %loc5
   %28 = load i16*, i16** %loc4
-  %NullCheck14 = icmp ne i16* %28, null
-  br i1 %NullCheck14, label %29, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %28, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = load i16, i16* %28, align 8
@@ -2620,15 +2702,15 @@ entry:
 
 ; <label>:67                                      ; preds = %64
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
-  br i1 %NullCheck8, label %69, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %68, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %69
 
 ; <label>:69                                      ; preds = %67
   %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
   %71 = load i32, i32 addrspace(1)* %70
   %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
-  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %73
 
 ; <label>:73                                      ; preds = %69
   %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
@@ -2645,31 +2727,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %67
+ThrowNullRef8:                                    ; preds = %67
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %69
+ThrowNullRef10:                                   ; preds = %69
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2710,14 +2792,14 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
   %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
@@ -2730,14 +2812,14 @@ entry:
 
 ; <label>:11                                      ; preds = %4
   %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
   %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
@@ -2749,14 +2831,14 @@ entry:
 
 ; <label>:22                                      ; preds = %16
   %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
   %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
-  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
-  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
@@ -2804,23 +2886,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2836,7 +2918,280 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[loadElem]
+Successfully read RuntimeType.IsAssignableFrom
+
+define i8 @RuntimeType.IsAssignableFrom(%System.RuntimeType addrspace(1)* %param0, %System.Type addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.RuntimeType addrspace(1)*
+  %arg1 = alloca %System.Type addrspace(1)*
+  %loc0 = alloca %System.RuntimeType addrspace(1)*
+  %loc1 = alloca %"System.Type[]" addrspace(1)*
+  %loc2 = alloca i32
+  store %System.RuntimeType addrspace(1)* %param0, %System.RuntimeType addrspace(1)** %this
+  store %System.Type addrspace(1)* %param1, %System.Type addrspace(1)** %arg1
+  %0 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %1 = icmp ne %System.Type addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i8 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %5 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %6 = bitcast %System.Type addrspace(1)* %4 to %System.Object addrspace(1)*
+  %7 = bitcast %System.RuntimeType addrspace(1)* %5 to %System.Object addrspace(1)*
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %6, %System.Object addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %3
+  ret i8 1
+
+; <label>:12                                      ; preds = %3
+  %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 152
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 32
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
+  %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
+  %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
+  store %System.RuntimeType addrspace(1)* %25, %System.RuntimeType addrspace(1)** %loc0
+  %26 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %27 = icmp eq %System.RuntimeType addrspace(1)* %26, null
+  br i1 %27, label %34, label %28
+
+; <label>:28                                      ; preds = %15
+  %29 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %30 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)*)*)(%System.RuntimeType addrspace(1)* %29, %System.RuntimeType addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+; <label>:34                                      ; preds = %15
+  %35 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %36 = call %System.Reflection.Emit.TypeBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Reflection.Emit.TypeBuilder addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %35)
+  %37 = icmp eq %System.Reflection.Emit.TypeBuilder addrspace(1)* %36, null
+  br i1 %37, label %139, label %38
+
+; <label>:38                                      ; preds = %34
+  %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %42
+
+; <label>:42                                      ; preds = %38
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 152
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 40
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
+  %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
+  %53 = zext i8 %52 to i32
+  %54 = icmp eq i32 %53, 0
+  br i1 %54, label %56, label %55
+
+; <label>:55                                      ; preds = %42
+  ret i8 1
+
+; <label>:56                                      ; preds = %42
+  %57 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %58 = bitcast %System.RuntimeType addrspace(1)* %57 to %System.Type addrspace(1)*
+  %59 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %58)
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %64 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.Type addrspace(1)* %63, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = bitcast %System.RuntimeType addrspace(1)* %64 to %System.Type addrspace(1)*
+  %67 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %63, %System.Type addrspace(1)* %66)
+  %68 = zext i8 %67 to i32
+  %69 = trunc i32 %68 to i8
+  ret i8 %69
+
+; <label>:70                                      ; preds = %56
+  %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
+  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %73
+
+; <label>:73                                      ; preds = %70
+  %74 = load i64, i64 addrspace(1)* %72
+  %75 = add i64 %74, 128
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = add i64 %77, 0
+  %79 = inttoptr i64 %78 to i64*
+  %80 = load i64, i64* %79
+  %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
+  %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
+  %83 = call i8 %82(%System.Type addrspace(1)* %81)
+  %84 = zext i8 %83 to i32
+  %85 = icmp eq i32 %84, 0
+  br i1 %85, label %139, label %86
+
+; <label>:86                                      ; preds = %73
+  %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
+  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %89
+
+; <label>:89                                      ; preds = %86
+  %90 = load i64, i64 addrspace(1)* %88
+  %91 = add i64 %90, 128
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = add i64 %93, 24
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
+  %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
+  %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
+  store %"System.Type[]" addrspace(1)* %99, %"System.Type[]" addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %129
+
+; <label>:100                                     ; preds = %132
+  %101 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %102 = load i32, i32* %loc2
+  %NullCheck11 = icmp eq %"System.Type[]" addrspace(1)* %101, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %103
+
+; <label>:103                                     ; preds = %100
+  %104 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 1
+  %105 = load i32, i32 addrspace(1)* %104
+  %106 = zext i32 %105 to i64
+  %107 = zext i32 %102 to i64
+  %BoundsCheck = icmp uge i64 %107, %106
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %108
+
+; <label>:108                                     ; preds = %103
+  %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
+  %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
+  %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
+  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %113
+
+; <label>:113                                     ; preds = %108
+  %114 = load i64, i64 addrspace(1)* %112
+  %115 = add i64 %114, 152
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = add i64 %117, 56
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
+  %123 = zext i8 %122 to i32
+  %124 = icmp ne i32 %123, 0
+  br i1 %124, label %126, label %125
+
+; <label>:125                                     ; preds = %113
+  ret i8 0
+
+; <label>:126                                     ; preds = %113
+  %127 = load i32, i32* %loc2
+  %128 = add i32 %127, 1
+  store i32 %128, i32* %loc2
+  br label %129
+
+; <label>:129                                     ; preds = %89, %126
+  %130 = load i32, i32* %loc2
+  %131 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %NullCheck9 = icmp eq %"System.Type[]" addrspace(1)* %131, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %132
+
+; <label>:132                                     ; preds = %129
+  %133 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %131, i32 0, i32 1
+  %134 = load i32, i32 addrspace(1)* %133
+  %135 = zext i32 %134 to i64
+  %136 = trunc i64 %135 to i32
+  %137 = icmp slt i32 %130, %136
+  br i1 %137, label %100, label %138
+
+; <label>:138                                     ; preds = %132
+  ret i8 1
+
+; <label>:139                                     ; preds = %34, %73
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %129
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %103
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -2893,7 +3248,7 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElem]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -2904,8 +3259,8 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -2997,8 +3352,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
@@ -3059,8 +3414,8 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -3087,8 +3442,8 @@ entry:
 
 ; <label>:17                                      ; preds = %5, %11
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
@@ -3097,8 +3452,8 @@ entry:
 
 ; <label>:22                                      ; preds = %1, %11
   %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
@@ -3109,11 +3464,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %17
+ThrowNullRef2:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %22
+ThrowNullRef4:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3167,15 +3522,15 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
   %15 = load i32, i32 addrspace(1)* %14
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
@@ -3198,7 +3553,7 @@ ThrowNullRef:                                     ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef2:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3232,8 +3587,8 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
@@ -3312,8 +3667,8 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -3327,8 +3682,8 @@ entry:
 ; <label>:5                                       ; preds = %43
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %7 = load i32, i32* %loc1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck6, label %8, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
@@ -3366,8 +3721,8 @@ entry:
 ; <label>:32                                      ; preds = %21, %25
   %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
   %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
-  br i1 %NullCheck8, label %35, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = trunc i32 %34 to i16
@@ -3380,8 +3735,8 @@ entry:
 ; <label>:40                                      ; preds = %1, %35
   %41 = load i32, i32* %loc1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
-  br i1 %NullCheck2, label %43, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %42, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
@@ -3392,8 +3747,8 @@ entry:
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
   %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
-  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
   %51 = load i64, i64 addrspace(1)* %49
@@ -3412,19 +3767,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %40
+ThrowNullRef2:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %47
+ThrowNullRef4:                                    ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %5
+ThrowNullRef6:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %32
+ThrowNullRef8:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3467,8 +3822,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
@@ -3492,11 +3847,391 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(i16* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store i16* %param0, i16** %arg0
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load i32, i32* %arg3
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %42, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %37, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg2
+  %13 = load i32, i32* %arg3
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %37, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %24 = load i32, i32* %arg2
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load i16*, i16** %arg0
+  %35 = load i32, i32* %arg3
+  %36 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %36, i16* %34, i32 %35)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:37                                      ; preds = %5, %16
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %39)
+  %41 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41, %System.String addrspace(1)* %38, %System.String addrspace(1)* %40)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41) #0
+  unreachable
+
+; <label>:42                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
-Failed to read StringBuilder.ToString[loadElemA]
+Successfully read StringBuilder.ToString
+
+define %System.String addrspace(1)* @StringBuilder.ToString(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i16*
+  %loc3 = alloca %"System.Char[]" addrspace(1)*
+  %loc4 = alloca i32
+  %loc5 = alloca i32
+  %loc6 = alloca i16 addrspace(1)*
+  %loc7 = alloca %System.String addrspace(1)*
+  %loc8 = alloca %"System.Char[]" addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %0)
+  %2 = icmp ne i32 %1, 0
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %4
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %6)
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %7)
+  store %System.String addrspace(1)* %8, %System.String addrspace(1)** %loc0
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.Text.StringBuilder addrspace(1)* %9, %System.Text.StringBuilder addrspace(1)** %loc1
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  store %System.String addrspace(1)* %10, %System.String addrspace(1)** %loc7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc7
+  %12 = ptrtoint %System.String addrspace(1)* %11 to i64
+  %13 = icmp eq i64 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %5
+  %15 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %16 = sext i32 %15 to i64
+  %17 = add i64 %12, %16
+  br label %18
+
+; <label>:18                                      ; preds = %5, %14
+  %19 = phi i64 [ %12, %5 ], [ %17, %14 ]
+  %20 = inttoptr i64 %19 to i16*
+  store i16* %20, i16** %loc2
+  br label %21
+
+; <label>:21                                      ; preds = %98, %18
+  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %22, null
+  br i1 %NullCheck, label %ThrowNullRef, label %23
+
+; <label>:23                                      ; preds = %21
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 3
+  %25 = load i32, i32 addrspace(1)* %24, align 8
+  %26 = icmp sle i32 %25, 0
+  br i1 %26, label %96, label %27
+
+; <label>:27                                      ; preds = %23
+  %28 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %28, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %29
+
+; <label>:29                                      ; preds = %27
+  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %28, i32 0, i32 1
+  %31 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %30, align 8
+  store %"System.Char[]" addrspace(1)* %31, %"System.Char[]" addrspace(1)** %loc3
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %33
+
+; <label>:33                                      ; preds = %29
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  store i32 %35, i32* %loc4
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  %39 = load i32, i32 addrspace(1)* %38, align 8
+  store i32 %39, i32* %loc5
+  %40 = load i32, i32* %loc5
+  %41 = load i32, i32* %loc4
+  %42 = add i32 %40, %41
+  %43 = zext i32 %42 to i64
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %45
+
+; <label>:45                                      ; preds = %37
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = sext i32 %47 to i64
+  %49 = icmp sgt i64 %43, %48
+  br i1 %49, label %91, label %50
+
+; <label>:50                                      ; preds = %45
+  %51 = load i32, i32* %loc5
+  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %52, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %53
+
+; <label>:53                                      ; preds = %50
+  %54 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %52, i32 0, i32 1
+  %55 = load i32, i32 addrspace(1)* %54
+  %56 = zext i32 %55 to i64
+  %57 = trunc i64 %56 to i32
+  %58 = icmp ugt i32 %51, %57
+  br i1 %58, label %91, label %59
+
+; <label>:59                                      ; preds = %53
+  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  store %"System.Char[]" addrspace(1)* %60, %"System.Char[]" addrspace(1)** %loc8
+  %61 = icmp eq %"System.Char[]" addrspace(1)* %60, null
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %63, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %64
+
+; <label>:64                                      ; preds = %62
+  %65 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %63, i32 0, i32 1
+  %66 = load i32, i32 addrspace(1)* %65
+  %67 = zext i32 %66 to i64
+  %68 = trunc i64 %67 to i32
+  %69 = icmp ne i32 %68, 0
+  br i1 %69, label %71, label %70
+
+; <label>:70                                      ; preds = %59, %64
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:71                                      ; preds = %64
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %73
+
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %BoundsCheck = icmp uge i64 0, %76
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %77
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %78, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:79                                      ; preds = %70, %77
+  %80 = load i16*, i16** %loc2
+  %81 = load i32, i32* %loc4
+  %82 = sext i32 %81 to i64
+  %83 = mul i64 %82, 2
+  %84 = bitcast i16* %80 to i8*
+  %85 = getelementptr inbounds i8, i8* %84, i64 %83
+  %86 = load i16 addrspace(1)*, i16 addrspace(1)** %loc6
+  %87 = ptrtoint i16 addrspace(1)* %86 to i64
+  %88 = load i32, i32* %loc5
+  %89 = bitcast i8* %85 to i16*
+  %90 = inttoptr i64 %87 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %89, i16* %90, i32 %88)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %96
+
+; <label>:91                                      ; preds = %45, %53
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %94 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %93)
+  %95 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95, %System.String addrspace(1)* %92, %System.String addrspace(1)* %94)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95) #0
+  unreachable
+
+; <label>:96                                      ; preds = %23, %79
+  %97 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %97, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %98
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %97, i32 0, i32 2
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  store %System.Text.StringBuilder addrspace(1)* %100, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %102 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %102, label %21, label %103
+
+; <label>:103                                     ; preds = %98
+  store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc7
+  %104 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  ret %System.String addrspace(1)* %104
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method StringBuilder::get_Length using LLILCJit
+Successfully read StringBuilder.get_Length
+
+define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
+Successfully read RuntimeHelpers.get_OffsetToStringData
+
+define i32 @RuntimeHelpers.get_OffsetToStringData() {
+entry:
+  ret i32 12
+}
+
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
 Successfully read CultureData.CreateCultureData
 
@@ -3514,23 +4249,23 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
   store i8 %4, i8 addrspace(1)* %6
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
@@ -3549,11 +4284,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3566,50 +4301,50 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
   store i32 -1, i32 addrspace(1)* %2
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
   store i32 -1, i32 addrspace(1)* %8
   %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
   store i32 -1, i32 addrspace(1)* %14
   %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
   store i32 -1, i32 addrspace(1)* %17
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
@@ -3623,27 +4358,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3675,7 +4410,136 @@ Failed to read Dictionary`2.Insert[non-const derefAddress]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
 Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
-Failed to read HashHelpers.GetPrime[loadElem]
+Successfully read HashHelpers.GetPrime
+
+define i32 @HashHelpers.GetPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %6, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5, %System.String addrspace(1)* %4)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5) #0
+  unreachable
+
+; <label>:6                                       ; preds = %entry
+  store i32 0, i32* %loc0
+  br label %29
+
+; <label>:7                                       ; preds = %35
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 1296
+  %10 = addrspacecast i8 addrspace(1)* %9 to %"System.Int32[]" addrspace(1)**
+  %11 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %10
+  %12 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Int32[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = zext i32 %15 to i64
+  %17 = zext i32 %12 to i64
+  %BoundsCheck = icmp uge i64 %17, %16
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 3, i32 %12
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  store i32 %20, i32* %loc1
+  %21 = load i32, i32* %loc1
+  %22 = load i32, i32* %arg0
+  %23 = icmp slt i32 %21, %22
+  br i1 %23, label %26, label %24
+
+; <label>:24                                      ; preds = %18
+  %25 = load i32, i32* %loc1
+  ret i32 %25
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %loc0
+  %28 = add i32 %27, 1
+  store i32 %28, i32* %loc0
+  br label %29
+
+; <label>:29                                      ; preds = %6, %26
+  %30 = load i32, i32* %loc0
+  %31 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %32 = getelementptr inbounds i8, i8 addrspace(1)* %31, i64 1296
+  %33 = addrspacecast i8 addrspace(1)* %32 to %"System.Int32[]" addrspace(1)**
+  %34 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %33
+  %NullCheck = icmp eq %"System.Int32[]" addrspace(1)* %34, null
+  br i1 %NullCheck, label %ThrowNullRef, label %35
+
+; <label>:35                                      ; preds = %29
+  %36 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %34, i32 0, i32 1
+  %37 = load i32, i32 addrspace(1)* %36
+  %38 = zext i32 %37 to i64
+  %39 = trunc i64 %38 to i32
+  %40 = icmp slt i32 %30, %39
+  br i1 %40, label %7, label %41
+
+; <label>:41                                      ; preds = %35
+  %42 = load i32, i32* %arg0
+  %43 = or i32 %42, 1
+  store i32 %43, i32* %loc2
+  br label %59
+
+; <label>:44                                      ; preds = %59
+  %45 = load i32, i32* %loc2
+  %46 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %45)
+  %47 = zext i8 %46 to i32
+  %48 = icmp eq i32 %47, 0
+  br i1 %48, label %56, label %49
+
+; <label>:49                                      ; preds = %44
+  %50 = load i32, i32* %loc2
+  %51 = sub i32 %50, 1
+  %52 = srem i32 %51, 101
+  %53 = icmp eq i32 %52, 0
+  br i1 %53, label %56, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = load i32, i32* %loc2
+  ret i32 %55
+
+; <label>:56                                      ; preds = %44, %49
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %57, 2
+  store i32 %58, i32* %loc2
+  br label %59
+
+; <label>:59                                      ; preds = %41, %56
+  %60 = load i32, i32* %loc2
+  %61 = icmp slt i32 %60, 2147483647
+  br i1 %61, label %44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load i32, i32* %arg0
+  ret i32 %63
+
+ThrowNullRef:                                     ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
 Successfully read GenericEqualityComparer`1.GetHashCode
 
@@ -3694,14 +4558,14 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
   %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load i64, i64 addrspace(1)* %7
@@ -3720,7 +4584,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3750,8 +4614,8 @@ entry:
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
@@ -3796,8 +4660,8 @@ entry:
   %35 = bitcast i16* %34 to i8*
   %36 = getelementptr inbounds i8, i8* %35, i64 2
   %37 = bitcast i8* %36 to i16*
-  %NullCheck4 = icmp ne i16* %37, null
-  br i1 %NullCheck4, label %38, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %37, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %38
 
 ; <label>:38                                      ; preds = %27
   %39 = load i16, i16* %37, align 8
@@ -3824,8 +4688,8 @@ entry:
 
 ; <label>:54                                      ; preds = %22, %43
   %55 = load i16*, i16** %loc4
-  %NullCheck2 = icmp ne i16* %55, null
-  br i1 %NullCheck2, label %56, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i16* %55, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %56
 
 ; <label>:56                                      ; preds = %54
   %57 = load i16, i16* %55, align 8
@@ -3850,11 +4714,11 @@ ThrowNullRef:                                     ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %54
+ThrowNullRef2:                                    ; preds = %54
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %27
+ThrowNullRef4:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3871,8 +4735,8 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -3907,8 +4771,8 @@ entry:
 
 ; <label>:26                                      ; preds = %19
   %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
-  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %28
 
 ; <label>:28                                      ; preds = %26
   %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
@@ -3920,7 +4784,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3972,8 +4836,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
@@ -3984,26 +4848,26 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
-  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
@@ -4014,8 +4878,8 @@ entry:
 ; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
@@ -4024,8 +4888,8 @@ entry:
 
 ; <label>:25                                      ; preds = %1, %16, %23
   %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
-  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
@@ -4036,27 +4900,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %20
+ThrowNullRef10:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4069,8 +4933,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -4081,8 +4945,8 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
@@ -4091,8 +4955,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1, %8
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
@@ -4103,11 +4967,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4128,24 +4992,24 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   store i32 %3, i32* %loc0
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
   %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
   store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck4, label %9, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
@@ -4164,15 +5028,15 @@ entry:
 ; <label>:18                                      ; preds = %70
   %19 = load i16*, i16** %loc3
   %20 = bitcast i16* %19 to i64*
-  %NullCheck10 = icmp ne i64* %20, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %20, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = load i64, i64* %20, align 8
   %23 = load i16*, i16** %loc4
   %24 = bitcast i16* %23 to i64*
-  %NullCheck12 = icmp ne i64* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = load i64, i64* %24, align 8
@@ -4188,8 +5052,8 @@ entry:
   %31 = bitcast i16* %30 to i8*
   %32 = getelementptr inbounds i8, i8* %31, i64 8
   %33 = bitcast i8* %32 to i64*
-  %NullCheck14 = icmp ne i64* %33, null
-  br i1 %NullCheck14, label %34, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = load i64, i64* %33, align 8
@@ -4197,8 +5061,8 @@ entry:
   %37 = bitcast i16* %36 to i8*
   %38 = getelementptr inbounds i8, i8* %37, i64 8
   %39 = bitcast i8* %38 to i64*
-  %NullCheck16 = icmp ne i64* %39, null
-  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %40
 
 ; <label>:40                                      ; preds = %34
   %41 = load i64, i64* %39, align 8
@@ -4214,8 +5078,8 @@ entry:
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %NullCheck18 = icmp ne i64* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = load i64, i64* %48, align 8
@@ -4223,8 +5087,8 @@ entry:
   %52 = bitcast i16* %51 to i8*
   %53 = getelementptr inbounds i8, i8* %52, i64 16
   %54 = bitcast i8* %53 to i64*
-  %NullCheck20 = icmp ne i64* %54, null
-  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64* %54, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %55
 
 ; <label>:55                                      ; preds = %49
   %56 = load i64, i64* %54, align 8
@@ -4262,15 +5126,15 @@ entry:
 ; <label>:74                                      ; preds = %95
   %75 = load i16*, i16** %loc3
   %76 = bitcast i16* %75 to i32*
-  %NullCheck6 = icmp ne i32* %76, null
-  br i1 %NullCheck6, label %77, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32* %76, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %77
 
 ; <label>:77                                      ; preds = %74
   %78 = load i32, i32* %76, align 8
   %79 = load i16*, i16** %loc4
   %80 = bitcast i16* %79 to i32*
-  %NullCheck8 = icmp ne i32* %80, null
-  br i1 %NullCheck8, label %81, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i32* %80, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %81
 
 ; <label>:81                                      ; preds = %77
   %82 = load i32, i32* %80, align 8
@@ -4318,43 +5182,43 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %74
+ThrowNullRef6:                                    ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %77
+ThrowNullRef8:                                    ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %29
+ThrowNullRef14:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %34
+ThrowNullRef16:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4376,8 +5240,8 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load i64, i64 addrspace(1)* %4
@@ -4389,8 +5253,8 @@ entry:
   %12 = load i64, i64* %11
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %5
   %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
@@ -4399,8 +5263,8 @@ entry:
   %18 = load i8, i8* %arg2
   %19 = zext i8 %18 to i32
   %20 = trunc i32 %19 to i8
-  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %15
   %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
@@ -4411,11 +5275,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4442,8 +5306,8 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
@@ -4466,16 +5330,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
   %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = load i64, i64 addrspace(1)* %19
@@ -4500,8 +5364,8 @@ entry:
 ; <label>:35                                      ; preds = %30
   %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
@@ -4514,8 +5378,8 @@ entry:
 
 ; <label>:42                                      ; preds = %1, %38
   %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
-  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
@@ -4526,19 +5390,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %35
+ThrowNullRef2:                                    ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %42
+ThrowNullRef8:                                    ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4551,14 +5415,14 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
@@ -4570,7 +5434,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4583,8 +5447,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
@@ -4613,51 +5477,51 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
   %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
   %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
   %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
   %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
-  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
   store i64 %21, i64 addrspace(1)* %23
   %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %25 = load i64, i64* %loc0
-  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
@@ -4668,27 +5532,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %22
+ThrowNullRef12:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4701,8 +5565,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
@@ -4713,19 +5577,19 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
@@ -4734,8 +5598,8 @@ entry:
 
 ; <label>:15                                      ; preds = %1, %13
   %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
@@ -4746,19 +5610,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %15
+ThrowNullRef8:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4771,8 +5635,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -4831,8 +5695,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
@@ -4882,8 +5746,8 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
-  br i1 %NullCheck, label %17, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %ThrowNullRef, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
@@ -4894,15 +5758,15 @@ entry:
 
 ; <label>:22                                      ; preds = %17
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
-  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
   %26 = load i32, i32 addrspace(1)* %25
   %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
-  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %27, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
@@ -4925,8 +5789,8 @@ entry:
 ; <label>:40                                      ; preds = %17
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
-  br i1 %NullCheck6, label %43, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %41, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
@@ -4938,34 +5802,17 @@ ThrowNullRef:                                     ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %24
+ThrowNullRef4:                                    ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %40
+ThrowNullRef6:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
-}
-
-INFO:  jitting method Object::ReferenceEquals using LLILCJit
-Successfully read Object.ReferenceEquals
-
-define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
-entry:
-  %arg0 = alloca %System.Object addrspace(1)*
-  %arg1 = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
-  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
-  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = icmp eq %System.Object addrspace(1)* %0, %1
-  %3 = sext i1 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
 }
 
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
@@ -4978,21 +5825,21 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
   %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
-  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
@@ -5007,28 +5854,28 @@ entry:
 ; <label>:13                                      ; preds = %8, %12
   %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
   %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
   %21 = load i32, i32 addrspace(1)* %20, align 8
   %22 = add i32 %21, 1
-  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
   store i32 %22, i32 addrspace(1)* %24
   %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
@@ -5039,27 +5886,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5077,7 +5924,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::Setup using LLILCJit
-Failed to read AppDomain.Setup[loadElem]
+Failed to read AppDomain.Setup[unbox]
 INFO:  jitting method Thread::GetDomain using LLILCJit
 Successfully read Thread.GetDomain
 
@@ -5108,8 +5955,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
@@ -5122,14 +5969,14 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
   %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
@@ -5141,11 +5988,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5173,8 +6020,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -5189,7 +6036,328 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
 Failed to read KeyCollection.System.Collections.Generic.IEnumerable<TKey>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Successfully read Enumerator.MoveNext
+
+define i8 @Enumerator.MoveNext(%"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.RuntimeTypeHandle* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*
+  %"$TypeArg" = alloca %System.RuntimeTypeHandle*
+  store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
+  %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 8
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %76, label %12
+
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
+  br label %76
+
+; <label>:13                                      ; preds = %85
+  %14 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck19 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %15
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, i32 0, i32 0
+  %17 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %16, align 8
+  %NullCheck21 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, i32 0, i32 2
+  %20 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %19, align 8
+  %21 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck23 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %22
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, i32 0, i32 2
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %NullCheck25 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 3, i32 %24
+  %NullCheck27 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %32
+
+; <label>:32                                      ; preds = %30
+  %33 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, i32 0, i32 2
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = icmp slt i32 %34, 0
+  br i1 %35, label %68, label %36
+
+; <label>:36                                      ; preds = %32
+  %37 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %38 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck29 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %39
+
+; <label>:39                                      ; preds = %36
+  %40 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, i32 0, i32 0
+  %41 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %40, align 8
+  %NullCheck31 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, i32 0, i32 2
+  %44 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %43, align 8
+  %45 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck33 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, i32 0, i32 2
+  %48 = load i32, i32 addrspace(1)* %47, align 8
+  %NullCheck35 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %49
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = zext i32 %51 to i64
+  %53 = zext i32 %48 to i64
+  %BoundsCheck37 = icmp uge i64 %53, %52
+  br i1 %BoundsCheck37, label %ThrowIndexOutOfRange38, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 3, i32 %48
+  %NullCheck39 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %56
+
+; <label>:56                                      ; preds = %54
+  %57 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, i32 0, i32 0
+  %58 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck41 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %59
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %60, %System.__Canon addrspace(1)* %58)
+  %61 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck43 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  %64 = load i32, i32 addrspace(1)* %63, align 8
+  %65 = add i32 %64, 1
+  %NullCheck45 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  store i32 %65, i32 addrspace(1)* %67
+  ret i8 1
+
+; <label>:68                                      ; preds = %32
+  %69 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck47 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %73 = add i32 %72, 1
+  %NullCheck49 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %74
+
+; <label>:74                                      ; preds = %70
+  %75 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  store i32 %73, i32 addrspace(1)* %75
+  br label %76
+
+; <label>:76                                      ; preds = %8, %12, %74
+  %77 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %78
+
+; <label>:78                                      ; preds = %76
+  %79 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, i32 0, i32 2
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck7 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %82
+
+; <label>:82                                      ; preds = %78
+  %83 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, i32 0, i32 0
+  %84 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %83, align 8
+  %NullCheck9 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %85
+
+; <label>:85                                      ; preds = %82
+  %86 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, i32 0, i32 7
+  %87 = load i32, i32 addrspace(1)* %86, align 8
+  %88 = icmp ult i32 %80, %87
+  br i1 %88, label %13, label %89
+
+; <label>:89                                      ; preds = %85
+  %90 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %91 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck11 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %92
+
+; <label>:92                                      ; preds = %89
+  %93 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, i32 0, i32 0
+  %94 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck13 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %95
+
+; <label>:95                                      ; preds = %92
+  %96 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, i32 0, i32 7
+  %97 = load i32, i32 addrspace(1)* %96, align 8
+  %98 = add i32 %97, 1
+  %NullCheck15 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %99
+
+; <label>:99                                      ; preds = %95
+  %100 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, i32 0, i32 2
+  store i32 %98, i32 addrspace(1)* %100
+  %101 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck17 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %102
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %103, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %92
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef22:                                   ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef24:                                   ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef26:                                   ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef28:                                   ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef30:                                   ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef32:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef34:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef36:                                   ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange38:                           ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef40:                                   ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef42:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef44:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef46:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef48:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef50:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -5200,8 +6368,8 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -5232,9 +6400,9 @@ Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
 Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
-Failed to read String.MakeSeparatorList[loadElemA]
+Failed to read String.MakeSeparatorList[storeElem]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
-Failed to read String.InternalSplitKeepEmptyEntries[loadElem]
+Failed to read String.InternalSplitKeepEmptyEntries[storeElem]
 INFO:  jitting method Path::IsRelative using LLILCJit
 Successfully read Path.IsRelative
 
@@ -5243,8 +6411,8 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -5254,8 +6422,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
@@ -5271,8 +6439,8 @@ entry:
 
 ; <label>:17                                      ; preds = %7
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
@@ -5288,8 +6456,8 @@ entry:
 
 ; <label>:29                                      ; preds = %19
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %31
 
 ; <label>:31                                      ; preds = %29
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
@@ -5300,8 +6468,8 @@ entry:
 
 ; <label>:36                                      ; preds = %31
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
-  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %37, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
@@ -5312,8 +6480,8 @@ entry:
 
 ; <label>:43                                      ; preds = %31, %38
   %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
-  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %45
 
 ; <label>:45                                      ; preds = %43
   %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
@@ -5324,8 +6492,8 @@ entry:
 
 ; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %50
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
@@ -5336,8 +6504,8 @@ entry:
 
 ; <label>:57                                      ; preds = %1, %7, %19, %45, %52
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
-  br i1 %NullCheck14, label %59, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %59
 
 ; <label>:59                                      ; preds = %57
   %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
@@ -5347,8 +6515,8 @@ entry:
 
 ; <label>:63                                      ; preds = %59
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
@@ -5359,8 +6527,8 @@ entry:
 
 ; <label>:70                                      ; preds = %65
   %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
-  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.String addrspace(1)* %71, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %72
 
 ; <label>:72                                      ; preds = %70
   %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
@@ -5379,39 +6547,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %17
+ThrowNullRef4:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %29
+ThrowNullRef6:                                    ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %36
+ThrowNullRef8:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %43
+ThrowNullRef10:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %50
+ThrowNullRef12:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %57
+ThrowNullRef14:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %63
+ThrowNullRef16:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %70
+ThrowNullRef18:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5419,7 +6587,293 @@ ThrowNullRef17:                                   ; preds = %70
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
-Failed to read String.TrimHelper[loadElem]
+Successfully read String.TrimHelper
+
+define %System.String addrspace(1)* @String.TrimHelper(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i16
+  %loc4 = alloca i32
+  %loc5 = alloca i16
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = sub i32 %3, 1
+  store i32 %4, i32* %loc0
+  store i32 0, i32* %loc1
+  %5 = load i32, i32* %arg2
+  %6 = icmp eq i32 %5, 1
+  br i1 %6, label %62, label %7
+
+; <label>:7                                       ; preds = %1
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:8                                       ; preds = %58
+  store i32 0, i32* %loc2
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load i32, i32* %loc1
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2, i32 %10
+  %13 = load i16, i16 addrspace(1)* %12
+  %14 = zext i16 %13 to i32
+  %15 = trunc i32 %14 to i16
+  store i16 %15, i16* %loc3
+  store i32 0, i32* %loc2
+  br label %34
+
+; <label>:16                                      ; preds = %37
+  %17 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %18 = load i32, i32* %loc2
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %17, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %19
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = zext i32 %18 to i64
+  %BoundsCheck = icmp uge i64 %23, %22
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %24
+
+; <label>:24                                      ; preds = %19
+  %25 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 3, i32 %18
+  %26 = load i16, i16 addrspace(1)* %25, align 8
+  %27 = zext i16 %26 to i32
+  %28 = load i16, i16* %loc3
+  %29 = zext i16 %28 to i32
+  %30 = icmp eq i32 %27, %29
+  br i1 %30, label %43, label %31
+
+; <label>:31                                      ; preds = %24
+  %32 = load i32, i32* %loc2
+  %33 = add i32 %32, 1
+  store i32 %33, i32* %loc2
+  br label %34
+
+; <label>:34                                      ; preds = %11, %31
+  %35 = load i32, i32* %loc2
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = icmp slt i32 %35, %41
+  br i1 %42, label %16, label %43
+
+; <label>:43                                      ; preds = %24, %37
+  %44 = load i32, i32* %loc2
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %45, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp eq i32 %44, %50
+  br i1 %51, label %62, label %52
+
+; <label>:52                                      ; preds = %46
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %7, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %57, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %58
+
+; <label>:58                                      ; preds = %55
+  %59 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %60 = load i32, i32 addrspace(1)* %59
+  %61 = icmp slt i32 %56, %60
+  br i1 %61, label %8, label %62
+
+; <label>:62                                      ; preds = %1, %46, %58
+  %63 = load i32, i32* %arg2
+  %64 = icmp eq i32 %63, 0
+  br i1 %64, label %122, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %66, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %67
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %66, i32 0, i32 1
+  %69 = load i32, i32 addrspace(1)* %68
+  %70 = sub i32 %69, 1
+  store i32 %70, i32* %loc0
+  br label %118
+
+; <label>:71                                      ; preds = %118
+  store i32 0, i32* %loc4
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %73 = load i32, i32* %loc0
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %74
+
+; <label>:74                                      ; preds = %71
+  %75 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 2, i32 %73
+  %76 = load i16, i16 addrspace(1)* %75
+  %77 = zext i16 %76 to i32
+  %78 = trunc i32 %77 to i16
+  store i16 %78, i16* %loc5
+  store i32 0, i32* %loc4
+  br label %97
+
+; <label>:79                                      ; preds = %100
+  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %81 = load i32, i32* %loc4
+  %NullCheck19 = icmp eq %"System.Char[]" addrspace(1)* %80, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
+
+; <label>:82                                      ; preds = %79
+  %83 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 1
+  %84 = load i32, i32 addrspace(1)* %83
+  %85 = zext i32 %84 to i64
+  %86 = zext i32 %81 to i64
+  %BoundsCheck21 = icmp uge i64 %86, %85
+  br i1 %BoundsCheck21, label %ThrowIndexOutOfRange22, label %87
+
+; <label>:87                                      ; preds = %82
+  %88 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 3, i32 %81
+  %89 = load i16, i16 addrspace(1)* %88, align 8
+  %90 = zext i16 %89 to i32
+  %91 = load i16, i16* %loc5
+  %92 = zext i16 %91 to i32
+  %93 = icmp eq i32 %90, %92
+  br i1 %93, label %106, label %94
+
+; <label>:94                                      ; preds = %87
+  %95 = load i32, i32* %loc4
+  %96 = add i32 %95, 1
+  store i32 %96, i32* %loc4
+  br label %97
+
+; <label>:97                                      ; preds = %74, %94
+  %98 = load i32, i32* %loc4
+  %99 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck15 = icmp eq %"System.Char[]" addrspace(1)* %99, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %100
+
+; <label>:100                                     ; preds = %97
+  %101 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %99, i32 0, i32 1
+  %102 = load i32, i32 addrspace(1)* %101
+  %103 = zext i32 %102 to i64
+  %104 = trunc i64 %103 to i32
+  %105 = icmp slt i32 %98, %104
+  br i1 %105, label %79, label %106
+
+; <label>:106                                     ; preds = %87, %100
+  %107 = load i32, i32* %loc4
+  %108 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck17 = icmp eq %"System.Char[]" addrspace(1)* %108, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %109
+
+; <label>:109                                     ; preds = %106
+  %110 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %108, i32 0, i32 1
+  %111 = load i32, i32 addrspace(1)* %110
+  %112 = zext i32 %111 to i64
+  %113 = trunc i64 %112 to i32
+  %114 = icmp eq i32 %107, %113
+  br i1 %114, label %122, label %115
+
+; <label>:115                                     ; preds = %109
+  %116 = load i32, i32* %loc0
+  %117 = sub i32 %116, 1
+  store i32 %117, i32* %loc0
+  br label %118
+
+; <label>:118                                     ; preds = %67, %115
+  %119 = load i32, i32* %loc0
+  %120 = load i32, i32* %loc1
+  %121 = icmp sge i32 %119, %120
+  br i1 %121, label %71, label %122
+
+; <label>:122                                     ; preds = %62, %109, %118
+  %123 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %124 = load i32, i32* %loc1
+  %125 = load i32, i32* %loc0
+  %126 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %123, i32 %124, i32 %125)
+  ret %System.String addrspace(1)* %126
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %97
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange22:                           ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
 Successfully read String.CreateTrimmedString
 
@@ -5439,8 +6893,8 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
@@ -5535,8 +6989,8 @@ entry:
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i64 2872
   %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
   %8 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %7
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %3
   %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
@@ -5553,8 +7007,8 @@ entry:
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 2864
   %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
   %21 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %20
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
-  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %22
 
 ; <label>:22                                      ; preds = %16
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
@@ -5569,7 +7023,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %16
+ThrowNullRef2:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5586,8 +7040,8 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5613,8 +7067,8 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
@@ -5632,8 +7086,8 @@ entry:
 
 ; <label>:12                                      ; preds = %4
   %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
@@ -5644,8 +7098,8 @@ entry:
 
 ; <label>:19                                      ; preds = %14
   %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %19
   %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
@@ -5660,21 +7114,21 @@ entry:
   %31 = zext i16 %30 to i32
   %32 = bitcast i8* %29 to i16*
   %33 = trunc i32 %31 to i16
-  %NullCheck6 = icmp ne i16* %32, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i16* %32, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %21
   store i16 %33, i16* %32, align 8
   %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %36
 
 ; <label>:36                                      ; preds = %34
   %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
   %38 = load i32, i32 addrspace(1)* %37, align 8
   %39 = add i32 %38, 1
-  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %40
 
 ; <label>:40                                      ; preds = %36
   %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
@@ -5683,16 +7137,16 @@ entry:
 
 ; <label>:42                                      ; preds = %14
   %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
-  br i1 %NullCheck12, label %44, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
   %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
   %47 = load i16, i16* %arg1
   %48 = zext i16 %47 to i32
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = trunc i32 %48 to i16
@@ -5703,31 +7157,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %19
+ThrowNullRef4:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %21
+ThrowNullRef6:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %36
+ThrowNullRef10:                                   ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %42
+ThrowNullRef12:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %44
+ThrowNullRef14:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5740,8 +7194,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -5752,8 +7206,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
@@ -5762,14 +7216,14 @@ entry:
 
 ; <label>:11                                      ; preds = %1
   %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
@@ -5779,15 +7233,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5808,8 +7262,8 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5822,8 +7276,8 @@ entry:
 
 ; <label>:8                                       ; preds = %3
   %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
@@ -5842,15 +7296,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
-  br i1 %NullCheck4, label %22, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
   %24 = load i16*, i16* addrspace(1)* %23, align 8
   %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %25, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
@@ -5859,8 +7313,8 @@ entry:
   store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
@@ -5874,8 +7328,8 @@ entry:
 
 ; <label>:37                                      ; preds = %65
   %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %37
   %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
@@ -5886,16 +7340,16 @@ entry:
   %45 = bitcast i16* %41 to i8*
   %46 = getelementptr inbounds i8, i8* %45, i64 %44
   %47 = bitcast i8* %46 to i16*
-  %NullCheck14 = icmp ne i16* %47, null
-  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %47, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %48
 
 ; <label>:48                                      ; preds = %39
   %49 = load i16, i16* %47, align 8
   %50 = zext i16 %49 to i32
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %52 = load i32, i32* %loc1
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %53
 
 ; <label>:53                                      ; preds = %48
   %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
@@ -5916,8 +7370,8 @@ entry:
 ; <label>:62                                      ; preds = %36, %59
   %63 = load i32, i32* %loc1
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck10, label %65, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %65
 
 ; <label>:65                                      ; preds = %62
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
@@ -5936,15 +7390,15 @@ entry:
 
 ; <label>:74                                      ; preds = %70
   %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
-  br i1 %NullCheck18, label %76, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %76
 
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
   %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
-  br i1 %NullCheck20, label %80, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
   %81 = load i64, i64 addrspace(1)* %79
@@ -5958,8 +7412,8 @@ entry:
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
   %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
-  br i1 %NullCheck22, label %92, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.String addrspace(1)* %90, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %92
 
 ; <label>:92                                      ; preds = %80
   %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
@@ -5969,15 +7423,15 @@ entry:
 
 ; <label>:96                                      ; preds = %70
   %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
-  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %98
 
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
   %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
-  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
   %103 = load i64, i64 addrspace(1)* %101
@@ -5991,8 +7445,8 @@ entry:
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
   %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
-  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.String addrspace(1)* %112, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %114
 
 ; <label>:114                                     ; preds = %102
   %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
@@ -6004,59 +7458,59 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %20
+ThrowNullRef4:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %22
+ThrowNullRef6:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %26
+ThrowNullRef8:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %62
+ThrowNullRef10:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %48
+ThrowNullRef16:                                   ; preds = %48
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %74
+ThrowNullRef18:                                   ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %76
+ThrowNullRef20:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %80
+ThrowNullRef22:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %96
+ThrowNullRef24:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %98
+ThrowNullRef26:                                   ; preds = %98
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %102
+ThrowNullRef28:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6069,15 +7523,15 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
   %3 = load i16*, i16* addrspace(1)* %2, align 8
   %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
@@ -6087,8 +7541,8 @@ entry:
   %10 = bitcast i16* %3 to i8*
   %11 = getelementptr inbounds i8, i8* %10, i64 %9
   %12 = bitcast i8* %11 to i16*
-  %NullCheck4 = icmp ne i16* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %5
   store i16 0, i16* %12, align 8
@@ -6098,11 +7552,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6119,8 +7573,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -6131,8 +7585,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
@@ -6144,15 +7598,15 @@ entry:
 
 ; <label>:14                                      ; preds = %1
   %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
   %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
   %21 = load i64, i64 addrspace(1)* %19
@@ -6171,15 +7625,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %14
+ThrowNullRef4:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %16
+ThrowNullRef6:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6302,14 +7756,6 @@ entry:
   ret %System.String addrspace(1)* %57
 }
 
-INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
-Successfully read RuntimeHelpers.get_OffsetToStringData
-
-define i32 @RuntimeHelpers.get_OffsetToStringData() {
-entry:
-  ret i32 12
-}
-
 INFO:  jitting method String::Equals using LLILCJit
 Successfully read String.Equals
 
@@ -6381,8 +7827,8 @@ entry:
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
-  br i1 %NullCheck24, label %29, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
   %30 = load i64, i64 addrspace(1)* %28
@@ -6397,8 +7843,8 @@ entry:
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
-  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
   %43 = load i64, i64 addrspace(1)* %41
@@ -6418,8 +7864,8 @@ entry:
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
   %59 = load i64, i64 addrspace(1)* %57
@@ -6434,8 +7880,8 @@ entry:
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck22, label %71, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
   %72 = load i64, i64 addrspace(1)* %70
@@ -6455,8 +7901,8 @@ entry:
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
-  br i1 %NullCheck16, label %87, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = load i64, i64 addrspace(1)* %86
@@ -6471,8 +7917,8 @@ entry:
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck18, label %100, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
   %101 = load i64, i64 addrspace(1)* %99
@@ -6492,8 +7938,8 @@ entry:
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
-  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
   %117 = load i64, i64 addrspace(1)* %115
@@ -6508,8 +7954,8 @@ entry:
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
-  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
   %130 = load i64, i64 addrspace(1)* %128
@@ -6528,15 +7974,15 @@ entry:
 
 ; <label>:142                                     ; preds = %22
   %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
-  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %143, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %144
 
 ; <label>:144                                     ; preds = %142
   %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
   %146 = load i32, i32 addrspace(1)* %145
   %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
-  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %147, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %148
 
 ; <label>:148                                     ; preds = %144
   %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
@@ -6557,15 +8003,15 @@ entry:
 
 ; <label>:159                                     ; preds = %22
   %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
-  br i1 %NullCheck, label %161, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %ThrowNullRef, label %161
 
 ; <label>:161                                     ; preds = %159
   %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
   %163 = load i32, i32 addrspace(1)* %162
   %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
-  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %164, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %165
 
 ; <label>:165                                     ; preds = %161
   %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
@@ -6578,8 +8024,8 @@ entry:
 
 ; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
-  br i1 %NullCheck4, label %172, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %171, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %172
 
 ; <label>:172                                     ; preds = %170
   %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
@@ -6589,8 +8035,8 @@ entry:
 
 ; <label>:176                                     ; preds = %172
   %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
-  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %177, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %178
 
 ; <label>:178                                     ; preds = %176
   %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
@@ -6629,55 +8075,55 @@ ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %161
+ThrowNullRef2:                                    ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %170
+ThrowNullRef4:                                    ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %176
+ThrowNullRef6:                                    ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %142
+ThrowNullRef8:                                    ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %144
+ThrowNullRef10:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %113
+ThrowNullRef12:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %116
+ThrowNullRef14:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %84
+ThrowNullRef16:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %87
+ThrowNullRef18:                                   ; preds = %87
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %55
+ThrowNullRef20:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %58
+ThrowNullRef22:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %26
+ThrowNullRef24:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %29
+ThrowNullRef26:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,8 +8161,8 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck, label %14, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %ThrowNullRef, label %14
 
 ; <label>:14                                      ; preds = %8
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
@@ -6760,8 +8206,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
@@ -6770,14 +8216,14 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32, i32* %loc0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %10
   %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
   %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
@@ -6790,15 +8236,15 @@ entry:
 ; <label>:25                                      ; preds = %19
   %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
-  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
   %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
@@ -6807,8 +8253,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %37 = load i32, i32* %loc0
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %38, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %38
 
 ; <label>:38                                      ; preds = %32
   %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
@@ -6817,14 +8263,14 @@ entry:
 
 ; <label>:40                                      ; preds = %19
   %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %40
   %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
   %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
-  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
-  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
@@ -6832,8 +8278,8 @@ entry:
   %48 = zext i32 %47 to i64
   %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
-  br i1 %NullCheck16, label %51, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %51
 
 ; <label>:51                                      ; preds = %45
   %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
@@ -6847,15 +8293,15 @@ entry:
 ; <label>:57                                      ; preds = %51
   %58 = load i16*, i16** %arg1
   %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
-  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %60
 
 ; <label>:60                                      ; preds = %57
   %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
   %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
-  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %64
 
 ; <label>:64                                      ; preds = %60
   %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
@@ -6864,22 +8310,22 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
   %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
-  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %70
 
 ; <label>:70                                      ; preds = %64
   %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
   %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
-  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
-  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
   %75 = load i32, i32 addrspace(1)* %74
   %76 = zext i32 %75 to i64
   %77 = trunc i64 %76 to i32
-  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
-  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %78
 
 ; <label>:78                                      ; preds = %73
   %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
@@ -6901,8 +8347,8 @@ entry:
   %90 = bitcast i16* %86 to i8*
   %91 = getelementptr inbounds i8, i8* %90, i64 %89
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %93
 
 ; <label>:93                                      ; preds = %80
   %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
@@ -6912,8 +8358,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %99 = load i32, i32* %loc2
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %100
 
 ; <label>:100                                     ; preds = %93
   %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
@@ -6928,63 +8374,63 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %25
+ThrowNullRef6:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %32
+ThrowNullRef10:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %40
+ThrowNullRef12:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %45
+ThrowNullRef16:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %57
+ThrowNullRef18:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %60
+ThrowNullRef20:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %64
+ThrowNullRef22:                                   ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %70
+ThrowNullRef24:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %73
+ThrowNullRef26:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %80
+ThrowNullRef28:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %93
+ThrowNullRef30:                                   ; preds = %93
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7004,8 +8450,8 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
@@ -7033,43 +8479,43 @@ entry:
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %14
   %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
   %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   %28 = load i32, i32 addrspace(1)* %27, align 8
   %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
-  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %30
 
 ; <label>:30                                      ; preds = %26
   %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
   %32 = load i32, i32 addrspace(1)* %31, align 8
   %33 = add i32 %28, %32
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %34
 
 ; <label>:34                                      ; preds = %30
   %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   store i32 %33, i32 addrspace(1)* %35
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
   store i32 0, i32 addrspace(1)* %38
   %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %40
 
 ; <label>:40                                      ; preds = %37
   %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
@@ -7082,8 +8528,8 @@ entry:
 
 ; <label>:47                                      ; preds = %40
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
@@ -7098,8 +8544,8 @@ entry:
   %54 = load i32, i32* %loc0
   %55 = sext i32 %54 to i64
   %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
-  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %57
 
 ; <label>:57                                      ; preds = %52
   %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
@@ -7110,68 +8556,35 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %14
+ThrowNullRef2:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %23
+ThrowNullRef4:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %26
+ThrowNullRef6:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %30
+ThrowNullRef8:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %34
+ThrowNullRef10:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %47
+ThrowNullRef14:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %52
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-}
-
-INFO:  jitting method StringBuilder::get_Length using LLILCJit
-Successfully read StringBuilder.get_Length
-
-define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.StringBuilder addrspace(1)*
-  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
-  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
-
-; <label>:1                                       ; preds = %entry
-  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %3 = load i32, i32 addrspace(1)* %2, align 8
-  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
-
-; <label>:5                                       ; preds = %1
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = add i32 %3, %7
-  ret i32 %8
-
-ThrowNullRef:                                     ; preds = %entry
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef16:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7213,70 +8626,70 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
   %6 = load i32, i32 addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
   store i32 %6, i32 addrspace(1)* %8
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
   %13 = load i32, i32 addrspace(1)* %12, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
   store i32 %13, i32 addrspace(1)* %15
   %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
-  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %18
 
 ; <label>:18                                      ; preds = %14
   %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
   %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
   %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
   %34 = load i32, i32 addrspace(1)* %33, align 8
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
-  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
@@ -7287,39 +8700,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %28
+ThrowNullRef16:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %32
+ThrowNullRef18:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7455,13 +8868,13 @@ entry:
 ; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
@@ -7477,16 +8890,16 @@ entry:
 
 ; <label>:18                                      ; preds = %15
   %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
   store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
   %22 = load i32, i32* %loc0
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %24
 
 ; <label>:24                                      ; preds = %20
   %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
@@ -7498,13 +8911,13 @@ entry:
 ; <label>:28                                      ; preds = %15, %24
   %29 = load i32, i32* %arg1
   %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %31
   %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
@@ -7517,20 +8930,20 @@ entry:
   %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
-  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
   %46 = load i32, i32 addrspace(1)* %45, align 8
   %47 = sub i32 %40, %46
-  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
-  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i32 addrspace(1)* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %48
 
 ; <label>:48                                      ; preds = %44
   store i32 %47, i32 addrspace(1)* %39, align 8
@@ -7538,21 +8951,21 @@ entry:
 
 ; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
-  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %51
 
 ; <label>:51                                      ; preds = %49
   %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %53
 
 ; <label>:53                                      ; preds = %51
   %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
   %55 = load i32, i32 addrspace(1)* %54, align 8
   %56 = load i32, i32* %arg2
   %57 = sub i32 %55, %56
-  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %58
 
 ; <label>:58                                      ; preds = %53
   %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
@@ -7562,13 +8975,13 @@ entry:
 ; <label>:60                                      ; preds = %33, %58
   %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
   %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
-  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %63
 
 ; <label>:63                                      ; preds = %60
   %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
-  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
-  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
@@ -7578,15 +8991,15 @@ entry:
 
 ; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
-  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i32 addrspace(1)* %69, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %70
 
 ; <label>:70                                      ; preds = %68
   %71 = load i32, i32 addrspace(1)* %69, align 8
   store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
-  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
@@ -7596,8 +9009,8 @@ entry:
   store i32 %77, i32* %loc4
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
-  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %80
 
 ; <label>:80                                      ; preds = %73
   %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
@@ -7607,71 +9020,71 @@ entry:
 ; <label>:83                                      ; preds = %80
   store i32 0, i32* %loc3
   %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
-  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
-  br i1 %NullCheck26, label %88, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i32 addrspace(1)* %87, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %88
 
 ; <label>:88                                      ; preds = %85
   %89 = load i32, i32 addrspace(1)* %87, align 8
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
-  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %90
 
 ; <label>:90                                      ; preds = %88
   %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
   store i32 %89, i32 addrspace(1)* %91
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
-  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
-  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %96
 
 ; <label>:96                                      ; preds = %94
   %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
-  br i1 %NullCheck34, label %100, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %100
 
 ; <label>:100                                     ; preds = %96
   %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
-  br i1 %NullCheck36, label %102, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %102
 
 ; <label>:102                                     ; preds = %100
   %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
   %104 = load i32, i32 addrspace(1)* %103, align 8
   %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
-  br i1 %NullCheck38, label %106, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %106
 
 ; <label>:106                                     ; preds = %102
   %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
-  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
-  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %108
 
 ; <label>:108                                     ; preds = %106
   %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
   %110 = load i32, i32 addrspace(1)* %109, align 8
   %111 = add i32 %104, %110
-  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %112
 
 ; <label>:112                                     ; preds = %108
   %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
   store i32 %111, i32 addrspace(1)* %113
   %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
-  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i32 addrspace(1)* %114, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %115
 
 ; <label>:115                                     ; preds = %112
   %116 = load i32, i32 addrspace(1)* %114, align 8
@@ -7681,19 +9094,19 @@ entry:
 ; <label>:118                                     ; preds = %115
   %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
-  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %121
 
 ; <label>:121                                     ; preds = %118
   %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
-  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
-  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %123
 
 ; <label>:123                                     ; preds = %121
   %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
   %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
-  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
-  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %126
 
 ; <label>:126                                     ; preds = %123
   %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
@@ -7705,8 +9118,8 @@ entry:
 
 ; <label>:130                                     ; preds = %80, %115, %126
   %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %132
 
 ; <label>:132                                     ; preds = %130
   %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7715,8 +9128,8 @@ entry:
   %136 = load i32, i32* %loc3
   %137 = sub i32 %135, %136
   %138 = sub i32 %134, %137
-  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %139
 
 ; <label>:139                                     ; preds = %132
   %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7728,16 +9141,16 @@ entry:
 
 ; <label>:144                                     ; preds = %139
   %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
-  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %146
 
 ; <label>:146                                     ; preds = %144
   %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
   %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
   %149 = load i32, i32* %loc2
   %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
-  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %151
 
 ; <label>:151                                     ; preds = %146
   %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
@@ -7754,145 +9167,249 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %18
+ThrowNullRef4:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %31
+ThrowNullRef10:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %44
+ThrowNullRef16:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %68
+ThrowNullRef18:                                   ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %70
+ThrowNullRef20:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %73
+ThrowNullRef22:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %83
+ThrowNullRef24:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %85
+ThrowNullRef26:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %88
+ThrowNullRef28:                                   ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %90
+ThrowNullRef30:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %94
+ThrowNullRef32:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %96
+ThrowNullRef34:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %100
+ThrowNullRef36:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %102
+ThrowNullRef38:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %106
+ThrowNullRef40:                                   ; preds = %106
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %108
+ThrowNullRef42:                                   ; preds = %108
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %112
+ThrowNullRef44:                                   ; preds = %112
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %118
+ThrowNullRef46:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %121
+ThrowNullRef48:                                   ; preds = %121
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %123
+ThrowNullRef50:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %130
+ThrowNullRef52:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %132
+ThrowNullRef54:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %144
+ThrowNullRef56:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %146
+ThrowNullRef58:                                   ; preds = %146
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %60
+ThrowNullRef60:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %63
+ThrowNullRef62:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %49
+ThrowNullRef64:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %51
+ThrowNullRef66:                                   ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %53
+ThrowNullRef68:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(%"System.Char[]" addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %arg0 = alloca %"System.Char[]" addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store %"System.Char[]" addrspace(1)* %param0, %"System.Char[]" addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load i32, i32* %arg4
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %43, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %38, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg1
+  %13 = load i32, i32* %arg4
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %38, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %24 = load i32, i32* %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %35 = load i32, i32* %arg3
+  %36 = load i32, i32* %arg4
+  %37 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %37, %"System.Char[]" addrspace(1)* %34, i32 %35, i32 %36)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:38                                      ; preds = %5, %16
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Successfully read Buffer._Memmove
 
@@ -7914,7 +9431,7 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[loadElem]
+Failed to read AppDomain.SetDataHelper[storeElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -7923,8 +9440,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
@@ -7934,8 +9451,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
@@ -7947,15 +9464,15 @@ entry:
   %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
   %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
@@ -7966,15 +9483,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7992,7 +9509,79 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
-Failed to read Dictionary`2.TryGetValue[loadElemA]
+Successfully read Dictionary`2.TryGetValue
+
+define i8 @"Dictionary`2.TryGetValue"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)* addrspace(1)* %param2) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  %arg2 = alloca %System.__Canon addrspace(1)* addrspace(1)*
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  store %System.__Canon addrspace(1)* addrspace(1)* %param2, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  store i32 %2, i32* %loc0
+  %3 = load i32, i32* %loc0
+  %4 = icmp slt i32 %3, 0
+  br i1 %4, label %22, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 2
+  %10 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %9, align 8
+  %11 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = zext i32 %11 to i64
+  %BoundsCheck = icmp uge i64 %16, %15
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 3, i32 %11
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %20, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %6, %System.__Canon addrspace(1)* %21)
+  ret i8 1
+
+; <label>:22                                      ; preds = %entry
+  %23 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %23, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -8058,8 +9647,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
@@ -8091,8 +9680,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
@@ -8171,15 +9760,15 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck, label %19, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %ThrowNullRef, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
   %21 = load i32, i32 addrspace(1)* %20
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
@@ -8202,7 +9791,7 @@ ThrowNullRef:                                     ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %19
+ThrowNullRef2:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8248,8 +9837,8 @@ entry:
   %0 = alloca %System.AppDomainHandle
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %1 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %1, i32 0, i32 15
@@ -8269,8 +9858,8 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
@@ -8286,7 +9875,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -8299,8 +9888,8 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -8327,8 +9916,8 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
@@ -8352,8 +9941,8 @@ entry:
   %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
   store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
@@ -8363,8 +9952,8 @@ entry:
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
@@ -8374,8 +9963,8 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %9
   %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
@@ -8384,8 +9973,8 @@ entry:
 
 ; <label>:18                                      ; preds = %3, %16
   %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
@@ -8397,15 +9986,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %18
+ThrowNullRef6:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8418,8 +10007,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
@@ -8453,15 +10042,15 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
@@ -8473,7 +10062,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8481,7 +10070,7 @@ ThrowNullRef1:                                    ; preds = %1
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
 Failed to read Dictionary`2.System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
@@ -8506,8 +10095,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
@@ -8524,8 +10113,8 @@ entry:
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -8544,7 +10133,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8577,8 +10166,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = load i64, i64* %arg2
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = trunc i32 %3 to i8
@@ -8634,46 +10223,46 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
   %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
-  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
-  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
-  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
@@ -8684,27 +10273,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %20
+ThrowNullRef12:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8717,8 +10306,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -8756,22 +10345,22 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
   %9 = load i64, i64 addrspace(1)* %8, align 8
   %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
   %13 = load i64, i64 addrspace(1)* %12, align 8
   %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %11
   %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
@@ -8788,11 +10377,11 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8882,8 +10471,8 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
@@ -8900,8 +10489,8 @@ entry:
 ; <label>:8                                       ; preds = %1
   %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
   %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
@@ -8911,15 +10500,15 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
   %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
   %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
-  br i1 %NullCheck6, label %21, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
@@ -8946,15 +10535,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8992,15 +10581,15 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
   store i8 %3, i8 addrspace(1)* %5
   %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
@@ -9011,7 +10600,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9027,8 +10616,8 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -9041,8 +10630,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
@@ -9058,7 +10647,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9080,8 +10669,8 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
@@ -9096,8 +10685,8 @@ entry:
 ; <label>:12                                      ; preds = %6
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
@@ -9112,8 +10701,8 @@ entry:
 ; <label>:21                                      ; preds = %15
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
@@ -9128,8 +10717,8 @@ entry:
 ; <label>:30                                      ; preds = %24
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %31, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
@@ -9144,8 +10733,8 @@ entry:
 ; <label>:39                                      ; preds = %33
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
-  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %40, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %42
 
 ; <label>:42                                      ; preds = %39
   %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
@@ -9164,19 +10753,19 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %21
+ThrowNullRef4:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %30
+ThrowNullRef6:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %39
+ThrowNullRef8:                                    ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9243,8 +10832,8 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
@@ -9264,57 +10853,57 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
   store i8 0, i8 addrspace(1)* %2
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
   store i8 0, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
   store i8 0, i8 addrspace(1)* %17
   %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
   store i8 0, i8 addrspace(1)* %20
   %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
-  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
@@ -9325,31 +10914,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %19
+ThrowNullRef14:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9367,8 +10956,8 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
@@ -9380,8 +10969,8 @@ entry:
 
 ; <label>:9                                       ; preds = %4
   %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %9
   %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
@@ -9395,7 +10984,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef2:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9420,8 +11009,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
@@ -9512,8 +11101,8 @@ entry:
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
@@ -9524,8 +11113,8 @@ entry:
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = load i64, i64 addrspace(1)* %12
@@ -9537,8 +11126,8 @@ entry:
   %20 = load i64, i64* %19
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
-  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %13
   %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
@@ -9555,8 +11144,8 @@ entry:
 ; <label>:30                                      ; preds = %25
   %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %32 = load i32, i32* %arg2
-  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
-  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
@@ -9570,15 +11159,15 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %30
+ThrowNullRef2:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9622,87 +11211,87 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
   %10 = load i8, i8 addrspace(1)* %9, align 8
   %11 = zext i8 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %8
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
   store i8 %12, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
   %19 = load i8, i8 addrspace(1)* %18, align 8
   %20 = zext i8 %19 to i32
   %21 = trunc i32 %20 to i8
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
   store i8 %21, i8 addrspace(1)* %23
   %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
   %28 = load i8, i8 addrspace(1)* %27, align 8
   %29 = zext i8 %28 to i32
   %30 = trunc i32 %29 to i8
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
-  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %31
 
 ; <label>:31                                      ; preds = %26
   %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
   store i8 %30, i8 addrspace(1)* %32
   %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
-  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
-  br i1 %NullCheck14, label %40, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %40
 
 ; <label>:40                                      ; preds = %35
   %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
   store i8 %39, i8 addrspace(1)* %41
   %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
-  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %44
 
 ; <label>:44                                      ; preds = %40
   %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
   %46 = load i8, i8 addrspace(1)* %45, align 8
   %47 = zext i8 %46 to i32
   %48 = trunc i32 %47 to i8
-  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
   store i8 %48, i8 addrspace(1)* %50
   %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
-  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
@@ -9713,29 +11302,29 @@ entry:
 ; <label>:56                                      ; preds = %52
   %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
-  br i1 %NullCheck22, label %59, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
   %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
   %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
-  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
-  br i1 %NullCheck24, label %63, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
   %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
-  br i1 %NullCheck26, label %66, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
   %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
-  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
-  br i1 %NullCheck28, label %69, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %69
 
 ; <label>:69                                      ; preds = %66
   %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
@@ -9744,15 +11333,15 @@ entry:
 
 ; <label>:71                                      ; preds = %105
   %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
-  br i1 %NullCheck34, label %73, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %73
 
 ; <label>:73                                      ; preds = %71
   %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
   %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
   %76 = load i32, i32* %loc0
-  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
-  br i1 %NullCheck36, label %77, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
@@ -9766,8 +11355,8 @@ entry:
 
 ; <label>:83                                      ; preds = %77
   %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
-  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
@@ -9775,14 +11364,14 @@ entry:
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
   %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
-  br i1 %NullCheck40, label %91, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
 ; <label>:91                                      ; preds = %85
   %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
   %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
-  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck42, label %94, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %94
 
 ; <label>:94                                      ; preds = %91
   %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
@@ -9798,14 +11387,14 @@ entry:
 ; <label>:99                                      ; preds = %69, %96
   %100 = load i32, i32* %loc0
   %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
-  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %102
 
 ; <label>:102                                     ; preds = %99
   %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
   %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
-  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
-  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
@@ -9819,87 +11408,87 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %26
+ThrowNullRef10:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %31
+ThrowNullRef12:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %35
+ThrowNullRef14:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %40
+ThrowNullRef16:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %56
+ThrowNullRef22:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %59
+ThrowNullRef24:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %63
+ThrowNullRef26:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %66
+ThrowNullRef28:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %102
+ThrowNullRef32:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %71
+ThrowNullRef34:                                   ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %73
+ThrowNullRef36:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %83
+ThrowNullRef38:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %85
+ThrowNullRef40:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %91
+ThrowNullRef42:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9943,15 +11532,15 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
   %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
@@ -9961,28 +11550,28 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
   %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %12
   %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
   %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
   %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
-  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
@@ -9993,23 +11582,23 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %12
+ThrowNullRef6:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10031,15 +11620,15 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
   %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = load i64, i64 addrspace(1)* %7
@@ -10077,13 +11666,13 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[loadElem]
+Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -10111,8 +11700,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueLeFP.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueLeFP.error.txt
@@ -25,8 +25,8 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
@@ -40,8 +40,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
   %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
@@ -75,7 +75,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -90,8 +90,8 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %NullCheck = icmp ne i8 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = load i8, i8 addrspace(1)* %0, align 8
@@ -125,8 +125,8 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
@@ -159,8 +159,8 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -184,8 +184,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
   store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
@@ -195,8 +195,8 @@ entry:
 ; <label>:4                                       ; preds = %1
   %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
   %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
@@ -206,8 +206,8 @@ entry:
   %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
@@ -221,14 +221,14 @@ entry:
 
 ; <label>:17                                      ; preds = %14
   %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
   %21 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
@@ -238,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -249,8 +249,8 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
@@ -261,27 +261,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %30
+ThrowNullRef10:                                   ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -301,7 +301,89 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
-Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
+Successfully read AppDomainSetup.GetUnsecureApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.GetUnsecureApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %NullCheck = icmp eq %"System.String[]" addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %BoundsCheck = icmp uge i64 0, %5
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %6
+
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 3, i32 0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
+  ret %System.String addrspace(1)* %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_Value using LLILCJit
+Successfully read AppDomainSetup.get_Value
+
+define %"System.String[]" addrspace(1)* @AppDomainSetup.get_Value(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.String[]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 18)
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.String[]" addrspace(1)* addrspace(1)*, %"System.String[]" addrspace(1)*)*)(%"System.String[]" addrspace(1)* addrspace(1)* %9, %"System.String[]" addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %11, i32 0, i32 1
+  %14 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %13, align 8
+  ret %"System.String[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -319,8 +401,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -368,16 +450,16 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
   %5 = load i32, i32 addrspace(1)* %4
   %6 = sub i32 %5, 1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -389,7 +471,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -421,8 +503,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
@@ -456,8 +538,8 @@ entry:
 ; <label>:27                                      ; preds = %19
   %28 = load i32, i32* %arg1
   %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
-  br i1 %NullCheck2, label %30, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %29, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %30
 
 ; <label>:30                                      ; preds = %27
   %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
@@ -493,8 +575,8 @@ entry:
 ; <label>:49                                      ; preds = %46
   %50 = load i32, i32* %arg2
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck4, label %52, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
@@ -517,11 +599,11 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %27
+ThrowNullRef2:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %49
+ThrowNullRef4:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -544,16 +626,16 @@ entry:
   %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %0)
   store %System.String addrspace(1)* %1, %System.String addrspace(1)** %loc0
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 2
   %5 = bitcast [0 x i16] addrspace(1)* %4 to i16 addrspace(1)*
   store i16 addrspace(1)* %5, i16 addrspace(1)** %loc1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %3
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2
@@ -580,7 +662,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -691,15 +773,15 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %NullCheck132 = icmp ne i8* %21, null
-  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+  %NullCheck131 = icmp eq i8* %21, null
+  br i1 %NullCheck131, label %ThrowNullRef132, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = load i8, i8* %21, align 8
   %24 = zext i8 %23 to i32
   %25 = trunc i32 %24 to i8
-  %NullCheck134 = icmp ne i8* %20, null
-  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+  %NullCheck133 = icmp eq i8* %20, null
+  br i1 %NullCheck133, label %ThrowNullRef134, label %26
 
 ; <label>:26                                      ; preds = %22
   store i8 %25, i8* %20, align 8
@@ -709,16 +791,16 @@ entry:
   %28 = load i8*, i8** %arg0
   %29 = load i8*, i8** %arg1
   %30 = bitcast i8* %29 to i16*
-  %NullCheck128 = icmp ne i16* %30, null
-  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+  %NullCheck127 = icmp eq i16* %30, null
+  br i1 %NullCheck127, label %ThrowNullRef128, label %31
 
 ; <label>:31                                      ; preds = %27
   %32 = load i16, i16* %30, align 8
   %33 = sext i16 %32 to i32
   %34 = bitcast i8* %28 to i16*
   %35 = trunc i32 %33 to i16
-  %NullCheck130 = icmp ne i16* %34, null
-  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+  %NullCheck129 = icmp eq i16* %34, null
+  br i1 %NullCheck129, label %ThrowNullRef130, label %36
 
 ; <label>:36                                      ; preds = %31
   store i16 %35, i16* %34, align 8
@@ -728,16 +810,16 @@ entry:
   %38 = load i8*, i8** %arg0
   %39 = load i8*, i8** %arg1
   %40 = bitcast i8* %39 to i16*
-  %NullCheck120 = icmp ne i16* %40, null
-  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+  %NullCheck119 = icmp eq i16* %40, null
+  br i1 %NullCheck119, label %ThrowNullRef120, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i16, i16* %40, align 8
   %43 = sext i16 %42 to i32
   %44 = bitcast i8* %38 to i16*
   %45 = trunc i32 %43 to i16
-  %NullCheck122 = icmp ne i16* %44, null
-  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+  %NullCheck121 = icmp eq i16* %44, null
+  br i1 %NullCheck121, label %ThrowNullRef122, label %46
 
 ; <label>:46                                      ; preds = %41
   store i16 %45, i16* %44, align 8
@@ -745,15 +827,15 @@ entry:
   %48 = getelementptr inbounds i8, i8* %47, i64 2
   %49 = load i8*, i8** %arg1
   %50 = getelementptr inbounds i8, i8* %49, i64 2
-  %NullCheck124 = icmp ne i8* %50, null
-  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+  %NullCheck123 = icmp eq i8* %50, null
+  br i1 %NullCheck123, label %ThrowNullRef124, label %51
 
 ; <label>:51                                      ; preds = %46
   %52 = load i8, i8* %50, align 8
   %53 = zext i8 %52 to i32
   %54 = trunc i32 %53 to i8
-  %NullCheck126 = icmp ne i8* %48, null
-  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+  %NullCheck125 = icmp eq i8* %48, null
+  br i1 %NullCheck125, label %ThrowNullRef126, label %55
 
 ; <label>:55                                      ; preds = %51
   store i8 %54, i8* %48, align 8
@@ -763,14 +845,14 @@ entry:
   %57 = load i8*, i8** %arg0
   %58 = load i8*, i8** %arg1
   %59 = bitcast i8* %58 to i32*
-  %NullCheck116 = icmp ne i32* %59, null
-  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+  %NullCheck115 = icmp eq i32* %59, null
+  br i1 %NullCheck115, label %ThrowNullRef116, label %60
 
 ; <label>:60                                      ; preds = %56
   %61 = load i32, i32* %59, align 8
   %62 = bitcast i8* %57 to i32*
-  %NullCheck118 = icmp ne i32* %62, null
-  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+  %NullCheck117 = icmp eq i32* %62, null
+  br i1 %NullCheck117, label %ThrowNullRef118, label %63
 
 ; <label>:63                                      ; preds = %60
   store i32 %61, i32* %62, align 8
@@ -780,14 +862,14 @@ entry:
   %65 = load i8*, i8** %arg0
   %66 = load i8*, i8** %arg1
   %67 = bitcast i8* %66 to i32*
-  %NullCheck108 = icmp ne i32* %67, null
-  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+  %NullCheck107 = icmp eq i32* %67, null
+  br i1 %NullCheck107, label %ThrowNullRef108, label %68
 
 ; <label>:68                                      ; preds = %64
   %69 = load i32, i32* %67, align 8
   %70 = bitcast i8* %65 to i32*
-  %NullCheck110 = icmp ne i32* %70, null
-  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+  %NullCheck109 = icmp eq i32* %70, null
+  br i1 %NullCheck109, label %ThrowNullRef110, label %71
 
 ; <label>:71                                      ; preds = %68
   store i32 %69, i32* %70, align 8
@@ -795,15 +877,15 @@ entry:
   %73 = getelementptr inbounds i8, i8* %72, i64 4
   %74 = load i8*, i8** %arg1
   %75 = getelementptr inbounds i8, i8* %74, i64 4
-  %NullCheck112 = icmp ne i8* %75, null
-  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+  %NullCheck111 = icmp eq i8* %75, null
+  br i1 %NullCheck111, label %ThrowNullRef112, label %76
 
 ; <label>:76                                      ; preds = %71
   %77 = load i8, i8* %75, align 8
   %78 = zext i8 %77 to i32
   %79 = trunc i32 %78 to i8
-  %NullCheck114 = icmp ne i8* %73, null
-  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+  %NullCheck113 = icmp eq i8* %73, null
+  br i1 %NullCheck113, label %ThrowNullRef114, label %80
 
 ; <label>:80                                      ; preds = %76
   store i8 %79, i8* %73, align 8
@@ -813,14 +895,14 @@ entry:
   %82 = load i8*, i8** %arg0
   %83 = load i8*, i8** %arg1
   %84 = bitcast i8* %83 to i32*
-  %NullCheck100 = icmp ne i32* %84, null
-  br i1 %NullCheck100, label %85, label %ThrowNullRef99
+  %NullCheck99 = icmp eq i32* %84, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %85
 
 ; <label>:85                                      ; preds = %81
   %86 = load i32, i32* %84, align 8
   %87 = bitcast i8* %82 to i32*
-  %NullCheck102 = icmp ne i32* %87, null
-  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+  %NullCheck101 = icmp eq i32* %87, null
+  br i1 %NullCheck101, label %ThrowNullRef102, label %88
 
 ; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
@@ -829,16 +911,16 @@ entry:
   %91 = load i8*, i8** %arg1
   %92 = getelementptr inbounds i8, i8* %91, i64 4
   %93 = bitcast i8* %92 to i16*
-  %NullCheck104 = icmp ne i16* %93, null
-  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+  %NullCheck103 = icmp eq i16* %93, null
+  br i1 %NullCheck103, label %ThrowNullRef104, label %94
 
 ; <label>:94                                      ; preds = %88
   %95 = load i16, i16* %93, align 8
   %96 = sext i16 %95 to i32
   %97 = bitcast i8* %90 to i16*
   %98 = trunc i32 %96 to i16
-  %NullCheck106 = icmp ne i16* %97, null
-  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+  %NullCheck105 = icmp eq i16* %97, null
+  br i1 %NullCheck105, label %ThrowNullRef106, label %99
 
 ; <label>:99                                      ; preds = %94
   store i16 %98, i16* %97, align 8
@@ -848,14 +930,14 @@ entry:
   %101 = load i8*, i8** %arg0
   %102 = load i8*, i8** %arg1
   %103 = bitcast i8* %102 to i32*
-  %NullCheck88 = icmp ne i32* %103, null
-  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+  %NullCheck87 = icmp eq i32* %103, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %104
 
 ; <label>:104                                     ; preds = %100
   %105 = load i32, i32* %103, align 8
   %106 = bitcast i8* %101 to i32*
-  %NullCheck90 = icmp ne i32* %106, null
-  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+  %NullCheck89 = icmp eq i32* %106, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %107
 
 ; <label>:107                                     ; preds = %104
   store i32 %105, i32* %106, align 8
@@ -864,16 +946,16 @@ entry:
   %110 = load i8*, i8** %arg1
   %111 = getelementptr inbounds i8, i8* %110, i64 4
   %112 = bitcast i8* %111 to i16*
-  %NullCheck92 = icmp ne i16* %112, null
-  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+  %NullCheck91 = icmp eq i16* %112, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %113
 
 ; <label>:113                                     ; preds = %107
   %114 = load i16, i16* %112, align 8
   %115 = sext i16 %114 to i32
   %116 = bitcast i8* %109 to i16*
   %117 = trunc i32 %115 to i16
-  %NullCheck94 = icmp ne i16* %116, null
-  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+  %NullCheck93 = icmp eq i16* %116, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %118
 
 ; <label>:118                                     ; preds = %113
   store i16 %117, i16* %116, align 8
@@ -881,15 +963,15 @@ entry:
   %120 = getelementptr inbounds i8, i8* %119, i64 6
   %121 = load i8*, i8** %arg1
   %122 = getelementptr inbounds i8, i8* %121, i64 6
-  %NullCheck96 = icmp ne i8* %122, null
-  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+  %NullCheck95 = icmp eq i8* %122, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %123
 
 ; <label>:123                                     ; preds = %118
   %124 = load i8, i8* %122, align 8
   %125 = zext i8 %124 to i32
   %126 = trunc i32 %125 to i8
-  %NullCheck98 = icmp ne i8* %120, null
-  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+  %NullCheck97 = icmp eq i8* %120, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %127
 
 ; <label>:127                                     ; preds = %123
   store i8 %126, i8* %120, align 8
@@ -899,14 +981,14 @@ entry:
   %129 = load i8*, i8** %arg0
   %130 = load i8*, i8** %arg1
   %131 = bitcast i8* %130 to i64*
-  %NullCheck84 = icmp ne i64* %131, null
-  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+  %NullCheck83 = icmp eq i64* %131, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %132
 
 ; <label>:132                                     ; preds = %128
   %133 = load i64, i64* %131, align 8
   %134 = bitcast i8* %129 to i64*
-  %NullCheck86 = icmp ne i64* %134, null
-  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+  %NullCheck85 = icmp eq i64* %134, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %135
 
 ; <label>:135                                     ; preds = %132
   store i64 %133, i64* %134, align 8
@@ -916,14 +998,14 @@ entry:
   %137 = load i8*, i8** %arg0
   %138 = load i8*, i8** %arg1
   %139 = bitcast i8* %138 to i64*
-  %NullCheck76 = icmp ne i64* %139, null
-  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+  %NullCheck75 = icmp eq i64* %139, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %140
 
 ; <label>:140                                     ; preds = %136
   %141 = load i64, i64* %139, align 8
   %142 = bitcast i8* %137 to i64*
-  %NullCheck78 = icmp ne i64* %142, null
-  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+  %NullCheck77 = icmp eq i64* %142, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %143
 
 ; <label>:143                                     ; preds = %140
   store i64 %141, i64* %142, align 8
@@ -931,15 +1013,15 @@ entry:
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %NullCheck80 = icmp ne i8* %147, null
-  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+  %NullCheck79 = icmp eq i8* %147, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %148
 
 ; <label>:148                                     ; preds = %143
   %149 = load i8, i8* %147, align 8
   %150 = zext i8 %149 to i32
   %151 = trunc i32 %150 to i8
-  %NullCheck82 = icmp ne i8* %145, null
-  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+  %NullCheck81 = icmp eq i8* %145, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %152
 
 ; <label>:152                                     ; preds = %148
   store i8 %151, i8* %145, align 8
@@ -949,14 +1031,14 @@ entry:
   %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
   %156 = bitcast i8* %155 to i64*
-  %NullCheck68 = icmp ne i64* %156, null
-  br i1 %NullCheck68, label %157, label %ThrowNullRef67
+  %NullCheck67 = icmp eq i64* %156, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %157
 
 ; <label>:157                                     ; preds = %153
   %158 = load i64, i64* %156, align 8
   %159 = bitcast i8* %154 to i64*
-  %NullCheck70 = icmp ne i64* %159, null
-  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+  %NullCheck69 = icmp eq i64* %159, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %160
 
 ; <label>:160                                     ; preds = %157
   store i64 %158, i64* %159, align 8
@@ -965,16 +1047,16 @@ entry:
   %163 = load i8*, i8** %arg1
   %164 = getelementptr inbounds i8, i8* %163, i64 8
   %165 = bitcast i8* %164 to i16*
-  %NullCheck72 = icmp ne i16* %165, null
-  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+  %NullCheck71 = icmp eq i16* %165, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %166
 
 ; <label>:166                                     ; preds = %160
   %167 = load i16, i16* %165, align 8
   %168 = sext i16 %167 to i32
   %169 = bitcast i8* %162 to i16*
   %170 = trunc i32 %168 to i16
-  %NullCheck74 = icmp ne i16* %169, null
-  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+  %NullCheck73 = icmp eq i16* %169, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %171
 
 ; <label>:171                                     ; preds = %166
   store i16 %170, i16* %169, align 8
@@ -984,14 +1066,14 @@ entry:
   %173 = load i8*, i8** %arg0
   %174 = load i8*, i8** %arg1
   %175 = bitcast i8* %174 to i64*
-  %NullCheck56 = icmp ne i64* %175, null
-  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+  %NullCheck55 = icmp eq i64* %175, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %176
 
 ; <label>:176                                     ; preds = %172
   %177 = load i64, i64* %175, align 8
   %178 = bitcast i8* %173 to i64*
-  %NullCheck58 = icmp ne i64* %178, null
-  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+  %NullCheck57 = icmp eq i64* %178, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %179
 
 ; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
@@ -1000,16 +1082,16 @@ entry:
   %182 = load i8*, i8** %arg1
   %183 = getelementptr inbounds i8, i8* %182, i64 8
   %184 = bitcast i8* %183 to i16*
-  %NullCheck60 = icmp ne i16* %184, null
-  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+  %NullCheck59 = icmp eq i16* %184, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %185
 
 ; <label>:185                                     ; preds = %179
   %186 = load i16, i16* %184, align 8
   %187 = sext i16 %186 to i32
   %188 = bitcast i8* %181 to i16*
   %189 = trunc i32 %187 to i16
-  %NullCheck62 = icmp ne i16* %188, null
-  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+  %NullCheck61 = icmp eq i16* %188, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %190
 
 ; <label>:190                                     ; preds = %185
   store i16 %189, i16* %188, align 8
@@ -1017,15 +1099,15 @@ entry:
   %192 = getelementptr inbounds i8, i8* %191, i64 10
   %193 = load i8*, i8** %arg1
   %194 = getelementptr inbounds i8, i8* %193, i64 10
-  %NullCheck64 = icmp ne i8* %194, null
-  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+  %NullCheck63 = icmp eq i8* %194, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %195
 
 ; <label>:195                                     ; preds = %190
   %196 = load i8, i8* %194, align 8
   %197 = zext i8 %196 to i32
   %198 = trunc i32 %197 to i8
-  %NullCheck66 = icmp ne i8* %192, null
-  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+  %NullCheck65 = icmp eq i8* %192, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %199
 
 ; <label>:199                                     ; preds = %195
   store i8 %198, i8* %192, align 8
@@ -1035,14 +1117,14 @@ entry:
   %201 = load i8*, i8** %arg0
   %202 = load i8*, i8** %arg1
   %203 = bitcast i8* %202 to i64*
-  %NullCheck48 = icmp ne i64* %203, null
-  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+  %NullCheck47 = icmp eq i64* %203, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %204
 
 ; <label>:204                                     ; preds = %200
   %205 = load i64, i64* %203, align 8
   %206 = bitcast i8* %201 to i64*
-  %NullCheck50 = icmp ne i64* %206, null
-  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+  %NullCheck49 = icmp eq i64* %206, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %207
 
 ; <label>:207                                     ; preds = %204
   store i64 %205, i64* %206, align 8
@@ -1051,14 +1133,14 @@ entry:
   %210 = load i8*, i8** %arg1
   %211 = getelementptr inbounds i8, i8* %210, i64 8
   %212 = bitcast i8* %211 to i32*
-  %NullCheck52 = icmp ne i32* %212, null
-  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+  %NullCheck51 = icmp eq i32* %212, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %213
 
 ; <label>:213                                     ; preds = %207
   %214 = load i32, i32* %212, align 8
   %215 = bitcast i8* %209 to i32*
-  %NullCheck54 = icmp ne i32* %215, null
-  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+  %NullCheck53 = icmp eq i32* %215, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %216
 
 ; <label>:216                                     ; preds = %213
   store i32 %214, i32* %215, align 8
@@ -1068,14 +1150,14 @@ entry:
   %218 = load i8*, i8** %arg0
   %219 = load i8*, i8** %arg1
   %220 = bitcast i8* %219 to i64*
-  %NullCheck36 = icmp ne i64* %220, null
-  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64* %220, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %221
 
 ; <label>:221                                     ; preds = %217
   %222 = load i64, i64* %220, align 8
   %223 = bitcast i8* %218 to i64*
-  %NullCheck38 = icmp ne i64* %223, null
-  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+  %NullCheck37 = icmp eq i64* %223, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %224
 
 ; <label>:224                                     ; preds = %221
   store i64 %222, i64* %223, align 8
@@ -1084,14 +1166,14 @@ entry:
   %227 = load i8*, i8** %arg1
   %228 = getelementptr inbounds i8, i8* %227, i64 8
   %229 = bitcast i8* %228 to i32*
-  %NullCheck40 = icmp ne i32* %229, null
-  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i32* %229, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %230
 
 ; <label>:230                                     ; preds = %224
   %231 = load i32, i32* %229, align 8
   %232 = bitcast i8* %226 to i32*
-  %NullCheck42 = icmp ne i32* %232, null
-  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+  %NullCheck41 = icmp eq i32* %232, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %233
 
 ; <label>:233                                     ; preds = %230
   store i32 %231, i32* %232, align 8
@@ -1099,15 +1181,15 @@ entry:
   %235 = getelementptr inbounds i8, i8* %234, i64 12
   %236 = load i8*, i8** %arg1
   %237 = getelementptr inbounds i8, i8* %236, i64 12
-  %NullCheck44 = icmp ne i8* %237, null
-  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i8* %237, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %238
 
 ; <label>:238                                     ; preds = %233
   %239 = load i8, i8* %237, align 8
   %240 = zext i8 %239 to i32
   %241 = trunc i32 %240 to i8
-  %NullCheck46 = icmp ne i8* %235, null
-  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+  %NullCheck45 = icmp eq i8* %235, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %242
 
 ; <label>:242                                     ; preds = %238
   store i8 %241, i8* %235, align 8
@@ -1117,14 +1199,14 @@ entry:
   %244 = load i8*, i8** %arg0
   %245 = load i8*, i8** %arg1
   %246 = bitcast i8* %245 to i64*
-  %NullCheck24 = icmp ne i64* %246, null
-  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64* %246, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %247
 
 ; <label>:247                                     ; preds = %243
   %248 = load i64, i64* %246, align 8
   %249 = bitcast i8* %244 to i64*
-  %NullCheck26 = icmp ne i64* %249, null
-  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64* %249, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %250
 
 ; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
@@ -1133,14 +1215,14 @@ entry:
   %253 = load i8*, i8** %arg1
   %254 = getelementptr inbounds i8, i8* %253, i64 8
   %255 = bitcast i8* %254 to i32*
-  %NullCheck28 = icmp ne i32* %255, null
-  br i1 %NullCheck28, label %256, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i32* %255, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %256
 
 ; <label>:256                                     ; preds = %250
   %257 = load i32, i32* %255, align 8
   %258 = bitcast i8* %252 to i32*
-  %NullCheck30 = icmp ne i32* %258, null
-  br i1 %NullCheck30, label %259, label %ThrowNullRef29
+  %NullCheck29 = icmp eq i32* %258, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %259
 
 ; <label>:259                                     ; preds = %256
   store i32 %257, i32* %258, align 8
@@ -1149,16 +1231,16 @@ entry:
   %262 = load i8*, i8** %arg1
   %263 = getelementptr inbounds i8, i8* %262, i64 12
   %264 = bitcast i8* %263 to i16*
-  %NullCheck32 = icmp ne i16* %264, null
-  br i1 %NullCheck32, label %265, label %ThrowNullRef31
+  %NullCheck31 = icmp eq i16* %264, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %265
 
 ; <label>:265                                     ; preds = %259
   %266 = load i16, i16* %264, align 8
   %267 = sext i16 %266 to i32
   %268 = bitcast i8* %261 to i16*
   %269 = trunc i32 %267 to i16
-  %NullCheck34 = icmp ne i16* %268, null
-  br i1 %NullCheck34, label %270, label %ThrowNullRef33
+  %NullCheck33 = icmp eq i16* %268, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %270
 
 ; <label>:270                                     ; preds = %265
   store i16 %269, i16* %268, align 8
@@ -1168,14 +1250,14 @@ entry:
   %272 = load i8*, i8** %arg0
   %273 = load i8*, i8** %arg1
   %274 = bitcast i8* %273 to i64*
-  %NullCheck8 = icmp ne i64* %274, null
-  br i1 %NullCheck8, label %275, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64* %274, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %275
 
 ; <label>:275                                     ; preds = %271
   %276 = load i64, i64* %274, align 8
   %277 = bitcast i8* %272 to i64*
-  %NullCheck10 = icmp ne i64* %277, null
-  br i1 %NullCheck10, label %278, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %277, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %278
 
 ; <label>:278                                     ; preds = %275
   store i64 %276, i64* %277, align 8
@@ -1184,14 +1266,14 @@ entry:
   %281 = load i8*, i8** %arg1
   %282 = getelementptr inbounds i8, i8* %281, i64 8
   %283 = bitcast i8* %282 to i32*
-  %NullCheck12 = icmp ne i32* %283, null
-  br i1 %NullCheck12, label %284, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i32* %283, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %284
 
 ; <label>:284                                     ; preds = %278
   %285 = load i32, i32* %283, align 8
   %286 = bitcast i8* %280 to i32*
-  %NullCheck14 = icmp ne i32* %286, null
-  br i1 %NullCheck14, label %287, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i32* %286, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %287
 
 ; <label>:287                                     ; preds = %284
   store i32 %285, i32* %286, align 8
@@ -1200,16 +1282,16 @@ entry:
   %290 = load i8*, i8** %arg1
   %291 = getelementptr inbounds i8, i8* %290, i64 12
   %292 = bitcast i8* %291 to i16*
-  %NullCheck16 = icmp ne i16* %292, null
-  br i1 %NullCheck16, label %293, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i16* %292, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %293
 
 ; <label>:293                                     ; preds = %287
   %294 = load i16, i16* %292, align 8
   %295 = sext i16 %294 to i32
   %296 = bitcast i8* %289 to i16*
   %297 = trunc i32 %295 to i16
-  %NullCheck18 = icmp ne i16* %296, null
-  br i1 %NullCheck18, label %298, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i16* %296, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %298
 
 ; <label>:298                                     ; preds = %293
   store i16 %297, i16* %296, align 8
@@ -1217,15 +1299,15 @@ entry:
   %300 = getelementptr inbounds i8, i8* %299, i64 14
   %301 = load i8*, i8** %arg1
   %302 = getelementptr inbounds i8, i8* %301, i64 14
-  %NullCheck20 = icmp ne i8* %302, null
-  br i1 %NullCheck20, label %303, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i8* %302, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %303
 
 ; <label>:303                                     ; preds = %298
   %304 = load i8, i8* %302, align 8
   %305 = zext i8 %304 to i32
   %306 = trunc i32 %305 to i8
-  %NullCheck22 = icmp ne i8* %300, null
-  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i8* %300, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %307
 
 ; <label>:307                                     ; preds = %303
   store i8 %306, i8* %300, align 8
@@ -1235,14 +1317,14 @@ entry:
   %309 = load i8*, i8** %arg0
   %310 = load i8*, i8** %arg1
   %311 = bitcast i8* %310 to i64*
-  %NullCheck = icmp ne i64* %311, null
-  br i1 %NullCheck, label %312, label %ThrowNullRef
+  %NullCheck = icmp eq i64* %311, null
+  br i1 %NullCheck, label %ThrowNullRef, label %312
 
 ; <label>:312                                     ; preds = %308
   %313 = load i64, i64* %311, align 8
   %314 = bitcast i8* %309 to i64*
-  %NullCheck2 = icmp ne i64* %314, null
-  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64* %314, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %315
 
 ; <label>:315                                     ; preds = %312
   store i64 %313, i64* %314, align 8
@@ -1251,14 +1333,14 @@ entry:
   %318 = load i8*, i8** %arg1
   %319 = getelementptr inbounds i8, i8* %318, i64 8
   %320 = bitcast i8* %319 to i64*
-  %NullCheck4 = icmp ne i64* %320, null
-  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64* %320, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %321
 
 ; <label>:321                                     ; preds = %315
   %322 = load i64, i64* %320, align 8
   %323 = bitcast i8* %317 to i64*
-  %NullCheck6 = icmp ne i64* %323, null
-  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64* %323, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %324
 
 ; <label>:324                                     ; preds = %321
   store i64 %322, i64* %323, align 8
@@ -1286,15 +1368,15 @@ entry:
 ; <label>:338                                     ; preds = %333
   %339 = load i8*, i8** %arg0
   %340 = load i8*, i8** %arg1
-  %NullCheck136 = icmp ne i8* %340, null
-  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+  %NullCheck135 = icmp eq i8* %340, null
+  br i1 %NullCheck135, label %ThrowNullRef136, label %341
 
 ; <label>:341                                     ; preds = %338
   %342 = load i8, i8* %340, align 8
   %343 = zext i8 %342 to i32
   %344 = trunc i32 %343 to i8
-  %NullCheck138 = icmp ne i8* %339, null
-  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+  %NullCheck137 = icmp eq i8* %339, null
+  br i1 %NullCheck137, label %ThrowNullRef138, label %345
 
 ; <label>:345                                     ; preds = %341
   store i8 %344, i8* %339, align 8
@@ -1317,16 +1399,16 @@ entry:
   %357 = load i8*, i8** %arg0
   %358 = load i8*, i8** %arg1
   %359 = bitcast i8* %358 to i16*
-  %NullCheck140 = icmp ne i16* %359, null
-  br i1 %NullCheck140, label %360, label %ThrowNullRef139
+  %NullCheck139 = icmp eq i16* %359, null
+  br i1 %NullCheck139, label %ThrowNullRef140, label %360
 
 ; <label>:360                                     ; preds = %356
   %361 = load i16, i16* %359, align 8
   %362 = sext i16 %361 to i32
   %363 = bitcast i8* %357 to i16*
   %364 = trunc i32 %362 to i16
-  %NullCheck142 = icmp ne i16* %363, null
-  br i1 %NullCheck142, label %365, label %ThrowNullRef141
+  %NullCheck141 = icmp eq i16* %363, null
+  br i1 %NullCheck141, label %ThrowNullRef142, label %365
 
 ; <label>:365                                     ; preds = %360
   store i16 %364, i16* %363, align 8
@@ -1352,14 +1434,14 @@ entry:
   %378 = load i8*, i8** %arg0
   %379 = load i8*, i8** %arg1
   %380 = bitcast i8* %379 to i32*
-  %NullCheck144 = icmp ne i32* %380, null
-  br i1 %NullCheck144, label %381, label %ThrowNullRef143
+  %NullCheck143 = icmp eq i32* %380, null
+  br i1 %NullCheck143, label %ThrowNullRef144, label %381
 
 ; <label>:381                                     ; preds = %377
   %382 = load i32, i32* %380, align 8
   %383 = bitcast i8* %378 to i32*
-  %NullCheck146 = icmp ne i32* %383, null
-  br i1 %NullCheck146, label %384, label %ThrowNullRef145
+  %NullCheck145 = icmp eq i32* %383, null
+  br i1 %NullCheck145, label %ThrowNullRef146, label %384
 
 ; <label>:384                                     ; preds = %381
   store i32 %382, i32* %383, align 8
@@ -1384,14 +1466,14 @@ entry:
   %395 = load i8*, i8** %arg0
   %396 = load i8*, i8** %arg1
   %397 = bitcast i8* %396 to i64*
-  %NullCheck164 = icmp ne i64* %397, null
-  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+  %NullCheck163 = icmp eq i64* %397, null
+  br i1 %NullCheck163, label %ThrowNullRef164, label %398
 
 ; <label>:398                                     ; preds = %394
   %399 = load i64, i64* %397, align 8
   %400 = bitcast i8* %395 to i64*
-  %NullCheck166 = icmp ne i64* %400, null
-  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+  %NullCheck165 = icmp eq i64* %400, null
+  br i1 %NullCheck165, label %ThrowNullRef166, label %401
 
 ; <label>:401                                     ; preds = %398
   store i64 %399, i64* %400, align 8
@@ -1400,14 +1482,14 @@ entry:
   %404 = load i8*, i8** %arg1
   %405 = getelementptr inbounds i8, i8* %404, i64 8
   %406 = bitcast i8* %405 to i64*
-  %NullCheck168 = icmp ne i64* %406, null
-  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+  %NullCheck167 = icmp eq i64* %406, null
+  br i1 %NullCheck167, label %ThrowNullRef168, label %407
 
 ; <label>:407                                     ; preds = %401
   %408 = load i64, i64* %406, align 8
   %409 = bitcast i8* %403 to i64*
-  %NullCheck170 = icmp ne i64* %409, null
-  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+  %NullCheck169 = icmp eq i64* %409, null
+  br i1 %NullCheck169, label %ThrowNullRef170, label %410
 
 ; <label>:410                                     ; preds = %407
   store i64 %408, i64* %409, align 8
@@ -1437,14 +1519,14 @@ entry:
   %425 = load i8*, i8** %arg0
   %426 = load i8*, i8** %arg1
   %427 = bitcast i8* %426 to i64*
-  %NullCheck148 = icmp ne i64* %427, null
-  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+  %NullCheck147 = icmp eq i64* %427, null
+  br i1 %NullCheck147, label %ThrowNullRef148, label %428
 
 ; <label>:428                                     ; preds = %424
   %429 = load i64, i64* %427, align 8
   %430 = bitcast i8* %425 to i64*
-  %NullCheck150 = icmp ne i64* %430, null
-  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+  %NullCheck149 = icmp eq i64* %430, null
+  br i1 %NullCheck149, label %ThrowNullRef150, label %431
 
 ; <label>:431                                     ; preds = %428
   store i64 %429, i64* %430, align 8
@@ -1466,14 +1548,14 @@ entry:
   %441 = load i8*, i8** %arg0
   %442 = load i8*, i8** %arg1
   %443 = bitcast i8* %442 to i32*
-  %NullCheck152 = icmp ne i32* %443, null
-  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+  %NullCheck151 = icmp eq i32* %443, null
+  br i1 %NullCheck151, label %ThrowNullRef152, label %444
 
 ; <label>:444                                     ; preds = %440
   %445 = load i32, i32* %443, align 8
   %446 = bitcast i8* %441 to i32*
-  %NullCheck154 = icmp ne i32* %446, null
-  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+  %NullCheck153 = icmp eq i32* %446, null
+  br i1 %NullCheck153, label %ThrowNullRef154, label %447
 
 ; <label>:447                                     ; preds = %444
   store i32 %445, i32* %446, align 8
@@ -1495,16 +1577,16 @@ entry:
   %457 = load i8*, i8** %arg0
   %458 = load i8*, i8** %arg1
   %459 = bitcast i8* %458 to i16*
-  %NullCheck156 = icmp ne i16* %459, null
-  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+  %NullCheck155 = icmp eq i16* %459, null
+  br i1 %NullCheck155, label %ThrowNullRef156, label %460
 
 ; <label>:460                                     ; preds = %456
   %461 = load i16, i16* %459, align 8
   %462 = sext i16 %461 to i32
   %463 = bitcast i8* %457 to i16*
   %464 = trunc i32 %462 to i16
-  %NullCheck158 = icmp ne i16* %463, null
-  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+  %NullCheck157 = icmp eq i16* %463, null
+  br i1 %NullCheck157, label %ThrowNullRef158, label %465
 
 ; <label>:465                                     ; preds = %460
   store i16 %464, i16* %463, align 8
@@ -1525,15 +1607,15 @@ entry:
 ; <label>:474                                     ; preds = %470
   %475 = load i8*, i8** %arg0
   %476 = load i8*, i8** %arg1
-  %NullCheck160 = icmp ne i8* %476, null
-  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+  %NullCheck159 = icmp eq i8* %476, null
+  br i1 %NullCheck159, label %ThrowNullRef160, label %477
 
 ; <label>:477                                     ; preds = %474
   %478 = load i8, i8* %476, align 8
   %479 = zext i8 %478 to i32
   %480 = trunc i32 %479 to i8
-  %NullCheck162 = icmp ne i8* %475, null
-  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+  %NullCheck161 = icmp eq i8* %475, null
+  br i1 %NullCheck161, label %ThrowNullRef162, label %481
 
 ; <label>:481                                     ; preds = %477
   store i8 %480, i8* %475, align 8
@@ -1553,343 +1635,343 @@ ThrowNullRef:                                     ; preds = %308
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %312
+ThrowNullRef2:                                    ; preds = %312
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %315
+ThrowNullRef4:                                    ; preds = %315
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %321
+ThrowNullRef6:                                    ; preds = %321
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %271
+ThrowNullRef8:                                    ; preds = %271
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %275
+ThrowNullRef10:                                   ; preds = %275
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %278
+ThrowNullRef12:                                   ; preds = %278
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %284
+ThrowNullRef14:                                   ; preds = %284
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %287
+ThrowNullRef16:                                   ; preds = %287
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %293
+ThrowNullRef18:                                   ; preds = %293
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %298
+ThrowNullRef20:                                   ; preds = %298
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %303
+ThrowNullRef22:                                   ; preds = %303
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %243
+ThrowNullRef24:                                   ; preds = %243
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %247
+ThrowNullRef26:                                   ; preds = %247
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %250
+ThrowNullRef28:                                   ; preds = %250
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %256
+ThrowNullRef30:                                   ; preds = %256
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %259
+ThrowNullRef32:                                   ; preds = %259
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %265
+ThrowNullRef34:                                   ; preds = %265
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %217
+ThrowNullRef36:                                   ; preds = %217
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %221
+ThrowNullRef38:                                   ; preds = %221
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %224
+ThrowNullRef40:                                   ; preds = %224
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %230
+ThrowNullRef42:                                   ; preds = %230
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %233
+ThrowNullRef44:                                   ; preds = %233
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %238
+ThrowNullRef46:                                   ; preds = %238
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %200
+ThrowNullRef48:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %204
+ThrowNullRef50:                                   ; preds = %204
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %207
+ThrowNullRef52:                                   ; preds = %207
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %213
+ThrowNullRef54:                                   ; preds = %213
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %172
+ThrowNullRef56:                                   ; preds = %172
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %176
+ThrowNullRef58:                                   ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %179
+ThrowNullRef60:                                   ; preds = %179
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %185
+ThrowNullRef62:                                   ; preds = %185
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %190
+ThrowNullRef64:                                   ; preds = %190
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %195
+ThrowNullRef66:                                   ; preds = %195
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %153
+ThrowNullRef68:                                   ; preds = %153
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %157
+ThrowNullRef70:                                   ; preds = %157
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %160
+ThrowNullRef72:                                   ; preds = %160
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %166
+ThrowNullRef74:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %136
+ThrowNullRef76:                                   ; preds = %136
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %140
+ThrowNullRef78:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %143
+ThrowNullRef80:                                   ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %148
+ThrowNullRef82:                                   ; preds = %148
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %128
+ThrowNullRef84:                                   ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %132
+ThrowNullRef86:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %100
+ThrowNullRef88:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %104
+ThrowNullRef90:                                   ; preds = %104
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %107
+ThrowNullRef92:                                   ; preds = %107
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %113
+ThrowNullRef94:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %118
+ThrowNullRef96:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %123
+ThrowNullRef98:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %81
+ThrowNullRef100:                                  ; preds = %81
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef101:                                  ; preds = %85
+ThrowNullRef102:                                  ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef103:                                  ; preds = %88
+ThrowNullRef104:                                  ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef105:                                  ; preds = %94
+ThrowNullRef106:                                  ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef107:                                  ; preds = %64
+ThrowNullRef108:                                  ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef109:                                  ; preds = %68
+ThrowNullRef110:                                  ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef111:                                  ; preds = %71
+ThrowNullRef112:                                  ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef113:                                  ; preds = %76
+ThrowNullRef114:                                  ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef115:                                  ; preds = %56
+ThrowNullRef116:                                  ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef117:                                  ; preds = %60
+ThrowNullRef118:                                  ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef119:                                  ; preds = %37
+ThrowNullRef120:                                  ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef121:                                  ; preds = %41
+ThrowNullRef122:                                  ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef123:                                  ; preds = %46
+ThrowNullRef124:                                  ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef125:                                  ; preds = %51
+ThrowNullRef126:                                  ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef127:                                  ; preds = %27
+ThrowNullRef128:                                  ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef129:                                  ; preds = %31
+ThrowNullRef130:                                  ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef131:                                  ; preds = %19
+ThrowNullRef132:                                  ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef133:                                  ; preds = %22
+ThrowNullRef134:                                  ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef135:                                  ; preds = %338
+ThrowNullRef136:                                  ; preds = %338
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef137:                                  ; preds = %341
+ThrowNullRef138:                                  ; preds = %341
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef139:                                  ; preds = %356
+ThrowNullRef140:                                  ; preds = %356
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef141:                                  ; preds = %360
+ThrowNullRef142:                                  ; preds = %360
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef143:                                  ; preds = %377
+ThrowNullRef144:                                  ; preds = %377
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef145:                                  ; preds = %381
+ThrowNullRef146:                                  ; preds = %381
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef147:                                  ; preds = %424
+ThrowNullRef148:                                  ; preds = %424
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef149:                                  ; preds = %428
+ThrowNullRef150:                                  ; preds = %428
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef151:                                  ; preds = %440
+ThrowNullRef152:                                  ; preds = %440
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef153:                                  ; preds = %444
+ThrowNullRef154:                                  ; preds = %444
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef155:                                  ; preds = %456
+ThrowNullRef156:                                  ; preds = %456
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef157:                                  ; preds = %460
+ThrowNullRef158:                                  ; preds = %460
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef159:                                  ; preds = %474
+ThrowNullRef160:                                  ; preds = %474
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef161:                                  ; preds = %477
+ThrowNullRef162:                                  ; preds = %477
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef163:                                  ; preds = %394
+ThrowNullRef164:                                  ; preds = %394
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef165:                                  ; preds = %398
+ThrowNullRef166:                                  ; preds = %398
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef167:                                  ; preds = %401
+ThrowNullRef168:                                  ; preds = %401
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef169:                                  ; preds = %407
+ThrowNullRef170:                                  ; preds = %407
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1939,8 +2021,8 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
-  br i1 %NullCheck, label %22, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %ThrowNullRef, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
@@ -1948,8 +2030,8 @@ entry:
   store i32 %24, i32* %loc0
   %25 = load i32, i32* %loc0
   %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %26, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %27
 
 ; <label>:27                                      ; preds = %22
   %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
@@ -1971,7 +2053,7 @@ ThrowNullRef:                                     ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1989,8 +2071,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -2022,15 +2104,15 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2048,16 +2130,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
   %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
   store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %15
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
@@ -2072,8 +2154,8 @@ entry:
   %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
   %29 = ptrtoint i16 addrspace(1)* %28 to i64
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %19
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
@@ -2089,19 +2171,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2114,8 +2196,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
@@ -2128,7 +2210,7 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[loadElem]
+Failed to read AppDomain.PrepareDataForSetup[storeElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
@@ -2202,8 +2284,8 @@ entry:
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
-  br i1 %NullCheck24, label %27, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = load i64, i64 addrspace(1)* %26
@@ -2218,8 +2300,8 @@ entry:
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
-  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
   %41 = load i64, i64 addrspace(1)* %39
@@ -2236,8 +2318,8 @@ entry:
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
-  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
   %54 = load i64, i64 addrspace(1)* %52
@@ -2252,8 +2334,8 @@ entry:
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
   %67 = load i64, i64 addrspace(1)* %65
@@ -2270,8 +2352,8 @@ entry:
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
-  br i1 %NullCheck16, label %79, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
   %80 = load i64, i64 addrspace(1)* %78
@@ -2286,8 +2368,8 @@ entry:
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
-  br i1 %NullCheck18, label %92, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
   %93 = load i64, i64 addrspace(1)* %91
@@ -2304,8 +2386,8 @@ entry:
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
-  br i1 %NullCheck12, label %105, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = load i64, i64 addrspace(1)* %104
@@ -2320,8 +2402,8 @@ entry:
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
-  br i1 %NullCheck14, label %118, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
   %119 = load i64, i64 addrspace(1)* %117
@@ -2337,8 +2419,8 @@ entry:
 
 ; <label>:128                                     ; preds = %20
   %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
-  br i1 %NullCheck4, label %130, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %129, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %130
 
 ; <label>:130                                     ; preds = %128
   %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
@@ -2346,8 +2428,8 @@ entry:
   %133 = load i16, i16 addrspace(1)* %132, align 8
   %134 = zext i16 %133 to i32
   %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
-  br i1 %NullCheck6, label %136, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %135, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %136
 
 ; <label>:136                                     ; preds = %130
   %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
@@ -2360,8 +2442,8 @@ entry:
 
 ; <label>:143                                     ; preds = %136
   %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
-  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %144, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %145
 
 ; <label>:145                                     ; preds = %143
   %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
@@ -2369,8 +2451,8 @@ entry:
   %148 = load i16, i16 addrspace(1)* %147, align 8
   %149 = zext i16 %148 to i32
   %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %150, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %151
 
 ; <label>:151                                     ; preds = %145
   %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
@@ -2388,8 +2470,8 @@ entry:
 
 ; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
-  br i1 %NullCheck, label %163, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %ThrowNullRef, label %163
 
 ; <label>:163                                     ; preds = %161
   %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
@@ -2399,8 +2481,8 @@ entry:
 
 ; <label>:167                                     ; preds = %163
   %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
-  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %168, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %169
 
 ; <label>:169                                     ; preds = %167
   %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
@@ -2432,55 +2514,55 @@ ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %167
+ThrowNullRef2:                                    ; preds = %167
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %128
+ThrowNullRef4:                                    ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %130
+ThrowNullRef6:                                    ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %143
+ThrowNullRef8:                                    ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %145
+ThrowNullRef10:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %102
+ThrowNullRef12:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %105
+ThrowNullRef14:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %76
+ThrowNullRef16:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %79
+ThrowNullRef18:                                   ; preds = %79
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %50
+ThrowNullRef20:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %53
+ThrowNullRef22:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %24
+ThrowNullRef24:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %27
+ThrowNullRef26:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2503,15 +2585,15 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2519,16 +2601,16 @@ entry:
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
   store i32 %8, i32* %loc0
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
   %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
   store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
@@ -2546,16 +2628,16 @@ entry:
 
 ; <label>:23                                      ; preds = %64
   %24 = load i16*, i16** %loc3
-  %NullCheck12 = icmp ne i16* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i16* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
   store i32 %27, i32* %loc5
   %28 = load i16*, i16** %loc4
-  %NullCheck14 = icmp ne i16* %28, null
-  br i1 %NullCheck14, label %29, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %28, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = load i16, i16* %28, align 8
@@ -2620,15 +2702,15 @@ entry:
 
 ; <label>:67                                      ; preds = %64
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
-  br i1 %NullCheck8, label %69, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %68, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %69
 
 ; <label>:69                                      ; preds = %67
   %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
   %71 = load i32, i32 addrspace(1)* %70
   %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
-  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %73
 
 ; <label>:73                                      ; preds = %69
   %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
@@ -2645,31 +2727,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %67
+ThrowNullRef8:                                    ; preds = %67
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %69
+ThrowNullRef10:                                   ; preds = %69
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2710,14 +2792,14 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
   %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
@@ -2730,14 +2812,14 @@ entry:
 
 ; <label>:11                                      ; preds = %4
   %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
   %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
@@ -2749,14 +2831,14 @@ entry:
 
 ; <label>:22                                      ; preds = %16
   %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
   %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
-  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
-  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
@@ -2804,23 +2886,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2836,7 +2918,280 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[loadElem]
+Successfully read RuntimeType.IsAssignableFrom
+
+define i8 @RuntimeType.IsAssignableFrom(%System.RuntimeType addrspace(1)* %param0, %System.Type addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.RuntimeType addrspace(1)*
+  %arg1 = alloca %System.Type addrspace(1)*
+  %loc0 = alloca %System.RuntimeType addrspace(1)*
+  %loc1 = alloca %"System.Type[]" addrspace(1)*
+  %loc2 = alloca i32
+  store %System.RuntimeType addrspace(1)* %param0, %System.RuntimeType addrspace(1)** %this
+  store %System.Type addrspace(1)* %param1, %System.Type addrspace(1)** %arg1
+  %0 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %1 = icmp ne %System.Type addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i8 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %5 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %6 = bitcast %System.Type addrspace(1)* %4 to %System.Object addrspace(1)*
+  %7 = bitcast %System.RuntimeType addrspace(1)* %5 to %System.Object addrspace(1)*
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %6, %System.Object addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %3
+  ret i8 1
+
+; <label>:12                                      ; preds = %3
+  %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 152
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 32
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
+  %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
+  %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
+  store %System.RuntimeType addrspace(1)* %25, %System.RuntimeType addrspace(1)** %loc0
+  %26 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %27 = icmp eq %System.RuntimeType addrspace(1)* %26, null
+  br i1 %27, label %34, label %28
+
+; <label>:28                                      ; preds = %15
+  %29 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %30 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)*)*)(%System.RuntimeType addrspace(1)* %29, %System.RuntimeType addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+; <label>:34                                      ; preds = %15
+  %35 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %36 = call %System.Reflection.Emit.TypeBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Reflection.Emit.TypeBuilder addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %35)
+  %37 = icmp eq %System.Reflection.Emit.TypeBuilder addrspace(1)* %36, null
+  br i1 %37, label %139, label %38
+
+; <label>:38                                      ; preds = %34
+  %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %42
+
+; <label>:42                                      ; preds = %38
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 152
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 40
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
+  %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
+  %53 = zext i8 %52 to i32
+  %54 = icmp eq i32 %53, 0
+  br i1 %54, label %56, label %55
+
+; <label>:55                                      ; preds = %42
+  ret i8 1
+
+; <label>:56                                      ; preds = %42
+  %57 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %58 = bitcast %System.RuntimeType addrspace(1)* %57 to %System.Type addrspace(1)*
+  %59 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %58)
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %64 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.Type addrspace(1)* %63, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = bitcast %System.RuntimeType addrspace(1)* %64 to %System.Type addrspace(1)*
+  %67 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %63, %System.Type addrspace(1)* %66)
+  %68 = zext i8 %67 to i32
+  %69 = trunc i32 %68 to i8
+  ret i8 %69
+
+; <label>:70                                      ; preds = %56
+  %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
+  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %73
+
+; <label>:73                                      ; preds = %70
+  %74 = load i64, i64 addrspace(1)* %72
+  %75 = add i64 %74, 128
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = add i64 %77, 0
+  %79 = inttoptr i64 %78 to i64*
+  %80 = load i64, i64* %79
+  %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
+  %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
+  %83 = call i8 %82(%System.Type addrspace(1)* %81)
+  %84 = zext i8 %83 to i32
+  %85 = icmp eq i32 %84, 0
+  br i1 %85, label %139, label %86
+
+; <label>:86                                      ; preds = %73
+  %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
+  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %89
+
+; <label>:89                                      ; preds = %86
+  %90 = load i64, i64 addrspace(1)* %88
+  %91 = add i64 %90, 128
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = add i64 %93, 24
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
+  %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
+  %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
+  store %"System.Type[]" addrspace(1)* %99, %"System.Type[]" addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %129
+
+; <label>:100                                     ; preds = %132
+  %101 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %102 = load i32, i32* %loc2
+  %NullCheck11 = icmp eq %"System.Type[]" addrspace(1)* %101, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %103
+
+; <label>:103                                     ; preds = %100
+  %104 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 1
+  %105 = load i32, i32 addrspace(1)* %104
+  %106 = zext i32 %105 to i64
+  %107 = zext i32 %102 to i64
+  %BoundsCheck = icmp uge i64 %107, %106
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %108
+
+; <label>:108                                     ; preds = %103
+  %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
+  %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
+  %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
+  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %113
+
+; <label>:113                                     ; preds = %108
+  %114 = load i64, i64 addrspace(1)* %112
+  %115 = add i64 %114, 152
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = add i64 %117, 56
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
+  %123 = zext i8 %122 to i32
+  %124 = icmp ne i32 %123, 0
+  br i1 %124, label %126, label %125
+
+; <label>:125                                     ; preds = %113
+  ret i8 0
+
+; <label>:126                                     ; preds = %113
+  %127 = load i32, i32* %loc2
+  %128 = add i32 %127, 1
+  store i32 %128, i32* %loc2
+  br label %129
+
+; <label>:129                                     ; preds = %89, %126
+  %130 = load i32, i32* %loc2
+  %131 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %NullCheck9 = icmp eq %"System.Type[]" addrspace(1)* %131, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %132
+
+; <label>:132                                     ; preds = %129
+  %133 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %131, i32 0, i32 1
+  %134 = load i32, i32 addrspace(1)* %133
+  %135 = zext i32 %134 to i64
+  %136 = trunc i64 %135 to i32
+  %137 = icmp slt i32 %130, %136
+  br i1 %137, label %100, label %138
+
+; <label>:138                                     ; preds = %132
+  ret i8 1
+
+; <label>:139                                     ; preds = %34, %73
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %129
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %103
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -2893,7 +3248,7 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElem]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -2904,8 +3259,8 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -2997,8 +3352,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
@@ -3059,8 +3414,8 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -3087,8 +3442,8 @@ entry:
 
 ; <label>:17                                      ; preds = %5, %11
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
@@ -3097,8 +3452,8 @@ entry:
 
 ; <label>:22                                      ; preds = %1, %11
   %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
@@ -3109,11 +3464,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %17
+ThrowNullRef2:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %22
+ThrowNullRef4:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3167,15 +3522,15 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
   %15 = load i32, i32 addrspace(1)* %14
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
@@ -3198,7 +3553,7 @@ ThrowNullRef:                                     ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef2:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3232,8 +3587,8 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
@@ -3312,8 +3667,8 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -3327,8 +3682,8 @@ entry:
 ; <label>:5                                       ; preds = %43
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %7 = load i32, i32* %loc1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck6, label %8, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
@@ -3366,8 +3721,8 @@ entry:
 ; <label>:32                                      ; preds = %21, %25
   %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
   %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
-  br i1 %NullCheck8, label %35, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = trunc i32 %34 to i16
@@ -3380,8 +3735,8 @@ entry:
 ; <label>:40                                      ; preds = %1, %35
   %41 = load i32, i32* %loc1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
-  br i1 %NullCheck2, label %43, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %42, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
@@ -3392,8 +3747,8 @@ entry:
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
   %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
-  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
   %51 = load i64, i64 addrspace(1)* %49
@@ -3412,19 +3767,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %40
+ThrowNullRef2:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %47
+ThrowNullRef4:                                    ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %5
+ThrowNullRef6:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %32
+ThrowNullRef8:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3467,8 +3822,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
@@ -3492,11 +3847,391 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(i16* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store i16* %param0, i16** %arg0
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load i32, i32* %arg3
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %42, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %37, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg2
+  %13 = load i32, i32* %arg3
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %37, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %24 = load i32, i32* %arg2
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load i16*, i16** %arg0
+  %35 = load i32, i32* %arg3
+  %36 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %36, i16* %34, i32 %35)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:37                                      ; preds = %5, %16
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %39)
+  %41 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41, %System.String addrspace(1)* %38, %System.String addrspace(1)* %40)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41) #0
+  unreachable
+
+; <label>:42                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
-Failed to read StringBuilder.ToString[loadElemA]
+Successfully read StringBuilder.ToString
+
+define %System.String addrspace(1)* @StringBuilder.ToString(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i16*
+  %loc3 = alloca %"System.Char[]" addrspace(1)*
+  %loc4 = alloca i32
+  %loc5 = alloca i32
+  %loc6 = alloca i16 addrspace(1)*
+  %loc7 = alloca %System.String addrspace(1)*
+  %loc8 = alloca %"System.Char[]" addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %0)
+  %2 = icmp ne i32 %1, 0
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %4
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %6)
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %7)
+  store %System.String addrspace(1)* %8, %System.String addrspace(1)** %loc0
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.Text.StringBuilder addrspace(1)* %9, %System.Text.StringBuilder addrspace(1)** %loc1
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  store %System.String addrspace(1)* %10, %System.String addrspace(1)** %loc7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc7
+  %12 = ptrtoint %System.String addrspace(1)* %11 to i64
+  %13 = icmp eq i64 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %5
+  %15 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %16 = sext i32 %15 to i64
+  %17 = add i64 %12, %16
+  br label %18
+
+; <label>:18                                      ; preds = %5, %14
+  %19 = phi i64 [ %12, %5 ], [ %17, %14 ]
+  %20 = inttoptr i64 %19 to i16*
+  store i16* %20, i16** %loc2
+  br label %21
+
+; <label>:21                                      ; preds = %98, %18
+  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %22, null
+  br i1 %NullCheck, label %ThrowNullRef, label %23
+
+; <label>:23                                      ; preds = %21
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 3
+  %25 = load i32, i32 addrspace(1)* %24, align 8
+  %26 = icmp sle i32 %25, 0
+  br i1 %26, label %96, label %27
+
+; <label>:27                                      ; preds = %23
+  %28 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %28, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %29
+
+; <label>:29                                      ; preds = %27
+  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %28, i32 0, i32 1
+  %31 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %30, align 8
+  store %"System.Char[]" addrspace(1)* %31, %"System.Char[]" addrspace(1)** %loc3
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %33
+
+; <label>:33                                      ; preds = %29
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  store i32 %35, i32* %loc4
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  %39 = load i32, i32 addrspace(1)* %38, align 8
+  store i32 %39, i32* %loc5
+  %40 = load i32, i32* %loc5
+  %41 = load i32, i32* %loc4
+  %42 = add i32 %40, %41
+  %43 = zext i32 %42 to i64
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %45
+
+; <label>:45                                      ; preds = %37
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = sext i32 %47 to i64
+  %49 = icmp sgt i64 %43, %48
+  br i1 %49, label %91, label %50
+
+; <label>:50                                      ; preds = %45
+  %51 = load i32, i32* %loc5
+  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %52, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %53
+
+; <label>:53                                      ; preds = %50
+  %54 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %52, i32 0, i32 1
+  %55 = load i32, i32 addrspace(1)* %54
+  %56 = zext i32 %55 to i64
+  %57 = trunc i64 %56 to i32
+  %58 = icmp ugt i32 %51, %57
+  br i1 %58, label %91, label %59
+
+; <label>:59                                      ; preds = %53
+  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  store %"System.Char[]" addrspace(1)* %60, %"System.Char[]" addrspace(1)** %loc8
+  %61 = icmp eq %"System.Char[]" addrspace(1)* %60, null
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %63, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %64
+
+; <label>:64                                      ; preds = %62
+  %65 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %63, i32 0, i32 1
+  %66 = load i32, i32 addrspace(1)* %65
+  %67 = zext i32 %66 to i64
+  %68 = trunc i64 %67 to i32
+  %69 = icmp ne i32 %68, 0
+  br i1 %69, label %71, label %70
+
+; <label>:70                                      ; preds = %59, %64
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:71                                      ; preds = %64
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %73
+
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %BoundsCheck = icmp uge i64 0, %76
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %77
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %78, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:79                                      ; preds = %70, %77
+  %80 = load i16*, i16** %loc2
+  %81 = load i32, i32* %loc4
+  %82 = sext i32 %81 to i64
+  %83 = mul i64 %82, 2
+  %84 = bitcast i16* %80 to i8*
+  %85 = getelementptr inbounds i8, i8* %84, i64 %83
+  %86 = load i16 addrspace(1)*, i16 addrspace(1)** %loc6
+  %87 = ptrtoint i16 addrspace(1)* %86 to i64
+  %88 = load i32, i32* %loc5
+  %89 = bitcast i8* %85 to i16*
+  %90 = inttoptr i64 %87 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %89, i16* %90, i32 %88)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %96
+
+; <label>:91                                      ; preds = %45, %53
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %94 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %93)
+  %95 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95, %System.String addrspace(1)* %92, %System.String addrspace(1)* %94)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95) #0
+  unreachable
+
+; <label>:96                                      ; preds = %23, %79
+  %97 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %97, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %98
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %97, i32 0, i32 2
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  store %System.Text.StringBuilder addrspace(1)* %100, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %102 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %102, label %21, label %103
+
+; <label>:103                                     ; preds = %98
+  store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc7
+  %104 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  ret %System.String addrspace(1)* %104
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method StringBuilder::get_Length using LLILCJit
+Successfully read StringBuilder.get_Length
+
+define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
+Successfully read RuntimeHelpers.get_OffsetToStringData
+
+define i32 @RuntimeHelpers.get_OffsetToStringData() {
+entry:
+  ret i32 12
+}
+
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
 Successfully read CultureData.CreateCultureData
 
@@ -3514,23 +4249,23 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
   store i8 %4, i8 addrspace(1)* %6
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
@@ -3549,11 +4284,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3566,50 +4301,50 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
   store i32 -1, i32 addrspace(1)* %2
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
   store i32 -1, i32 addrspace(1)* %8
   %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
   store i32 -1, i32 addrspace(1)* %14
   %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
   store i32 -1, i32 addrspace(1)* %17
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
@@ -3623,27 +4358,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3675,7 +4410,136 @@ Failed to read Dictionary`2.Insert[non-const derefAddress]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
 Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
-Failed to read HashHelpers.GetPrime[loadElem]
+Successfully read HashHelpers.GetPrime
+
+define i32 @HashHelpers.GetPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %6, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5, %System.String addrspace(1)* %4)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5) #0
+  unreachable
+
+; <label>:6                                       ; preds = %entry
+  store i32 0, i32* %loc0
+  br label %29
+
+; <label>:7                                       ; preds = %35
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 1296
+  %10 = addrspacecast i8 addrspace(1)* %9 to %"System.Int32[]" addrspace(1)**
+  %11 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %10
+  %12 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Int32[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = zext i32 %15 to i64
+  %17 = zext i32 %12 to i64
+  %BoundsCheck = icmp uge i64 %17, %16
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 3, i32 %12
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  store i32 %20, i32* %loc1
+  %21 = load i32, i32* %loc1
+  %22 = load i32, i32* %arg0
+  %23 = icmp slt i32 %21, %22
+  br i1 %23, label %26, label %24
+
+; <label>:24                                      ; preds = %18
+  %25 = load i32, i32* %loc1
+  ret i32 %25
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %loc0
+  %28 = add i32 %27, 1
+  store i32 %28, i32* %loc0
+  br label %29
+
+; <label>:29                                      ; preds = %6, %26
+  %30 = load i32, i32* %loc0
+  %31 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %32 = getelementptr inbounds i8, i8 addrspace(1)* %31, i64 1296
+  %33 = addrspacecast i8 addrspace(1)* %32 to %"System.Int32[]" addrspace(1)**
+  %34 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %33
+  %NullCheck = icmp eq %"System.Int32[]" addrspace(1)* %34, null
+  br i1 %NullCheck, label %ThrowNullRef, label %35
+
+; <label>:35                                      ; preds = %29
+  %36 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %34, i32 0, i32 1
+  %37 = load i32, i32 addrspace(1)* %36
+  %38 = zext i32 %37 to i64
+  %39 = trunc i64 %38 to i32
+  %40 = icmp slt i32 %30, %39
+  br i1 %40, label %7, label %41
+
+; <label>:41                                      ; preds = %35
+  %42 = load i32, i32* %arg0
+  %43 = or i32 %42, 1
+  store i32 %43, i32* %loc2
+  br label %59
+
+; <label>:44                                      ; preds = %59
+  %45 = load i32, i32* %loc2
+  %46 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %45)
+  %47 = zext i8 %46 to i32
+  %48 = icmp eq i32 %47, 0
+  br i1 %48, label %56, label %49
+
+; <label>:49                                      ; preds = %44
+  %50 = load i32, i32* %loc2
+  %51 = sub i32 %50, 1
+  %52 = srem i32 %51, 101
+  %53 = icmp eq i32 %52, 0
+  br i1 %53, label %56, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = load i32, i32* %loc2
+  ret i32 %55
+
+; <label>:56                                      ; preds = %44, %49
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %57, 2
+  store i32 %58, i32* %loc2
+  br label %59
+
+; <label>:59                                      ; preds = %41, %56
+  %60 = load i32, i32* %loc2
+  %61 = icmp slt i32 %60, 2147483647
+  br i1 %61, label %44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load i32, i32* %arg0
+  ret i32 %63
+
+ThrowNullRef:                                     ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
 Successfully read GenericEqualityComparer`1.GetHashCode
 
@@ -3694,14 +4558,14 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
   %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load i64, i64 addrspace(1)* %7
@@ -3720,7 +4584,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3750,8 +4614,8 @@ entry:
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
@@ -3796,8 +4660,8 @@ entry:
   %35 = bitcast i16* %34 to i8*
   %36 = getelementptr inbounds i8, i8* %35, i64 2
   %37 = bitcast i8* %36 to i16*
-  %NullCheck4 = icmp ne i16* %37, null
-  br i1 %NullCheck4, label %38, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %37, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %38
 
 ; <label>:38                                      ; preds = %27
   %39 = load i16, i16* %37, align 8
@@ -3824,8 +4688,8 @@ entry:
 
 ; <label>:54                                      ; preds = %22, %43
   %55 = load i16*, i16** %loc4
-  %NullCheck2 = icmp ne i16* %55, null
-  br i1 %NullCheck2, label %56, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i16* %55, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %56
 
 ; <label>:56                                      ; preds = %54
   %57 = load i16, i16* %55, align 8
@@ -3850,11 +4714,11 @@ ThrowNullRef:                                     ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %54
+ThrowNullRef2:                                    ; preds = %54
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %27
+ThrowNullRef4:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3871,8 +4735,8 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -3907,8 +4771,8 @@ entry:
 
 ; <label>:26                                      ; preds = %19
   %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
-  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %28
 
 ; <label>:28                                      ; preds = %26
   %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
@@ -3920,7 +4784,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3972,8 +4836,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
@@ -3984,26 +4848,26 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
-  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
@@ -4014,8 +4878,8 @@ entry:
 ; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
@@ -4024,8 +4888,8 @@ entry:
 
 ; <label>:25                                      ; preds = %1, %16, %23
   %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
-  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
@@ -4036,27 +4900,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %20
+ThrowNullRef10:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4069,8 +4933,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -4081,8 +4945,8 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
@@ -4091,8 +4955,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1, %8
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
@@ -4103,11 +4967,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4128,24 +4992,24 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   store i32 %3, i32* %loc0
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
   %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
   store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck4, label %9, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
@@ -4164,15 +5028,15 @@ entry:
 ; <label>:18                                      ; preds = %70
   %19 = load i16*, i16** %loc3
   %20 = bitcast i16* %19 to i64*
-  %NullCheck10 = icmp ne i64* %20, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %20, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = load i64, i64* %20, align 8
   %23 = load i16*, i16** %loc4
   %24 = bitcast i16* %23 to i64*
-  %NullCheck12 = icmp ne i64* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = load i64, i64* %24, align 8
@@ -4188,8 +5052,8 @@ entry:
   %31 = bitcast i16* %30 to i8*
   %32 = getelementptr inbounds i8, i8* %31, i64 8
   %33 = bitcast i8* %32 to i64*
-  %NullCheck14 = icmp ne i64* %33, null
-  br i1 %NullCheck14, label %34, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = load i64, i64* %33, align 8
@@ -4197,8 +5061,8 @@ entry:
   %37 = bitcast i16* %36 to i8*
   %38 = getelementptr inbounds i8, i8* %37, i64 8
   %39 = bitcast i8* %38 to i64*
-  %NullCheck16 = icmp ne i64* %39, null
-  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %40
 
 ; <label>:40                                      ; preds = %34
   %41 = load i64, i64* %39, align 8
@@ -4214,8 +5078,8 @@ entry:
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %NullCheck18 = icmp ne i64* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = load i64, i64* %48, align 8
@@ -4223,8 +5087,8 @@ entry:
   %52 = bitcast i16* %51 to i8*
   %53 = getelementptr inbounds i8, i8* %52, i64 16
   %54 = bitcast i8* %53 to i64*
-  %NullCheck20 = icmp ne i64* %54, null
-  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64* %54, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %55
 
 ; <label>:55                                      ; preds = %49
   %56 = load i64, i64* %54, align 8
@@ -4262,15 +5126,15 @@ entry:
 ; <label>:74                                      ; preds = %95
   %75 = load i16*, i16** %loc3
   %76 = bitcast i16* %75 to i32*
-  %NullCheck6 = icmp ne i32* %76, null
-  br i1 %NullCheck6, label %77, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32* %76, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %77
 
 ; <label>:77                                      ; preds = %74
   %78 = load i32, i32* %76, align 8
   %79 = load i16*, i16** %loc4
   %80 = bitcast i16* %79 to i32*
-  %NullCheck8 = icmp ne i32* %80, null
-  br i1 %NullCheck8, label %81, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i32* %80, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %81
 
 ; <label>:81                                      ; preds = %77
   %82 = load i32, i32* %80, align 8
@@ -4318,43 +5182,43 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %74
+ThrowNullRef6:                                    ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %77
+ThrowNullRef8:                                    ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %29
+ThrowNullRef14:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %34
+ThrowNullRef16:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4376,8 +5240,8 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load i64, i64 addrspace(1)* %4
@@ -4389,8 +5253,8 @@ entry:
   %12 = load i64, i64* %11
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %5
   %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
@@ -4399,8 +5263,8 @@ entry:
   %18 = load i8, i8* %arg2
   %19 = zext i8 %18 to i32
   %20 = trunc i32 %19 to i8
-  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %15
   %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
@@ -4411,11 +5275,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4442,8 +5306,8 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
@@ -4466,16 +5330,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
   %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = load i64, i64 addrspace(1)* %19
@@ -4500,8 +5364,8 @@ entry:
 ; <label>:35                                      ; preds = %30
   %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
@@ -4514,8 +5378,8 @@ entry:
 
 ; <label>:42                                      ; preds = %1, %38
   %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
-  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
@@ -4526,19 +5390,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %35
+ThrowNullRef2:                                    ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %42
+ThrowNullRef8:                                    ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4551,14 +5415,14 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
@@ -4570,7 +5434,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4583,8 +5447,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
@@ -4613,51 +5477,51 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
   %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
   %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
   %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
   %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
-  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
   store i64 %21, i64 addrspace(1)* %23
   %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %25 = load i64, i64* %loc0
-  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
@@ -4668,27 +5532,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %22
+ThrowNullRef12:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4701,8 +5565,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
@@ -4713,19 +5577,19 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
@@ -4734,8 +5598,8 @@ entry:
 
 ; <label>:15                                      ; preds = %1, %13
   %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
@@ -4746,19 +5610,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %15
+ThrowNullRef8:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4771,8 +5635,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -4831,8 +5695,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
@@ -4882,8 +5746,8 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
-  br i1 %NullCheck, label %17, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %ThrowNullRef, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
@@ -4894,15 +5758,15 @@ entry:
 
 ; <label>:22                                      ; preds = %17
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
-  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
   %26 = load i32, i32 addrspace(1)* %25
   %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
-  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %27, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
@@ -4925,8 +5789,8 @@ entry:
 ; <label>:40                                      ; preds = %17
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
-  br i1 %NullCheck6, label %43, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %41, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
@@ -4938,34 +5802,17 @@ ThrowNullRef:                                     ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %24
+ThrowNullRef4:                                    ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %40
+ThrowNullRef6:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
-}
-
-INFO:  jitting method Object::ReferenceEquals using LLILCJit
-Successfully read Object.ReferenceEquals
-
-define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
-entry:
-  %arg0 = alloca %System.Object addrspace(1)*
-  %arg1 = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
-  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
-  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = icmp eq %System.Object addrspace(1)* %0, %1
-  %3 = sext i1 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
 }
 
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
@@ -4978,21 +5825,21 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
   %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
-  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
@@ -5007,28 +5854,28 @@ entry:
 ; <label>:13                                      ; preds = %8, %12
   %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
   %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
   %21 = load i32, i32 addrspace(1)* %20, align 8
   %22 = add i32 %21, 1
-  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
   store i32 %22, i32 addrspace(1)* %24
   %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
@@ -5039,27 +5886,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5077,7 +5924,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::Setup using LLILCJit
-Failed to read AppDomain.Setup[loadElem]
+Failed to read AppDomain.Setup[unbox]
 INFO:  jitting method Thread::GetDomain using LLILCJit
 Successfully read Thread.GetDomain
 
@@ -5108,8 +5955,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
@@ -5122,14 +5969,14 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
   %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
@@ -5141,11 +5988,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5173,8 +6020,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -5189,7 +6036,328 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
 Failed to read KeyCollection.System.Collections.Generic.IEnumerable<TKey>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Successfully read Enumerator.MoveNext
+
+define i8 @Enumerator.MoveNext(%"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.RuntimeTypeHandle* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*
+  %"$TypeArg" = alloca %System.RuntimeTypeHandle*
+  store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
+  %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 8
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %76, label %12
+
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
+  br label %76
+
+; <label>:13                                      ; preds = %85
+  %14 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck19 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %15
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, i32 0, i32 0
+  %17 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %16, align 8
+  %NullCheck21 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, i32 0, i32 2
+  %20 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %19, align 8
+  %21 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck23 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %22
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, i32 0, i32 2
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %NullCheck25 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 3, i32 %24
+  %NullCheck27 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %32
+
+; <label>:32                                      ; preds = %30
+  %33 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, i32 0, i32 2
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = icmp slt i32 %34, 0
+  br i1 %35, label %68, label %36
+
+; <label>:36                                      ; preds = %32
+  %37 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %38 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck29 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %39
+
+; <label>:39                                      ; preds = %36
+  %40 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, i32 0, i32 0
+  %41 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %40, align 8
+  %NullCheck31 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, i32 0, i32 2
+  %44 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %43, align 8
+  %45 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck33 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, i32 0, i32 2
+  %48 = load i32, i32 addrspace(1)* %47, align 8
+  %NullCheck35 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %49
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = zext i32 %51 to i64
+  %53 = zext i32 %48 to i64
+  %BoundsCheck37 = icmp uge i64 %53, %52
+  br i1 %BoundsCheck37, label %ThrowIndexOutOfRange38, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 3, i32 %48
+  %NullCheck39 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %56
+
+; <label>:56                                      ; preds = %54
+  %57 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, i32 0, i32 0
+  %58 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck41 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %59
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %60, %System.__Canon addrspace(1)* %58)
+  %61 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck43 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  %64 = load i32, i32 addrspace(1)* %63, align 8
+  %65 = add i32 %64, 1
+  %NullCheck45 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  store i32 %65, i32 addrspace(1)* %67
+  ret i8 1
+
+; <label>:68                                      ; preds = %32
+  %69 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck47 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %73 = add i32 %72, 1
+  %NullCheck49 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %74
+
+; <label>:74                                      ; preds = %70
+  %75 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  store i32 %73, i32 addrspace(1)* %75
+  br label %76
+
+; <label>:76                                      ; preds = %8, %12, %74
+  %77 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %78
+
+; <label>:78                                      ; preds = %76
+  %79 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, i32 0, i32 2
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck7 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %82
+
+; <label>:82                                      ; preds = %78
+  %83 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, i32 0, i32 0
+  %84 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %83, align 8
+  %NullCheck9 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %85
+
+; <label>:85                                      ; preds = %82
+  %86 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, i32 0, i32 7
+  %87 = load i32, i32 addrspace(1)* %86, align 8
+  %88 = icmp ult i32 %80, %87
+  br i1 %88, label %13, label %89
+
+; <label>:89                                      ; preds = %85
+  %90 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %91 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck11 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %92
+
+; <label>:92                                      ; preds = %89
+  %93 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, i32 0, i32 0
+  %94 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck13 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %95
+
+; <label>:95                                      ; preds = %92
+  %96 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, i32 0, i32 7
+  %97 = load i32, i32 addrspace(1)* %96, align 8
+  %98 = add i32 %97, 1
+  %NullCheck15 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %99
+
+; <label>:99                                      ; preds = %95
+  %100 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, i32 0, i32 2
+  store i32 %98, i32 addrspace(1)* %100
+  %101 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck17 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %102
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %103, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %92
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef22:                                   ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef24:                                   ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef26:                                   ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef28:                                   ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef30:                                   ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef32:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef34:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef36:                                   ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange38:                           ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef40:                                   ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef42:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef44:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef46:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef48:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef50:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -5200,8 +6368,8 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -5232,9 +6400,9 @@ Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
 Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
-Failed to read String.MakeSeparatorList[loadElemA]
+Failed to read String.MakeSeparatorList[storeElem]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
-Failed to read String.InternalSplitKeepEmptyEntries[loadElem]
+Failed to read String.InternalSplitKeepEmptyEntries[storeElem]
 INFO:  jitting method Path::IsRelative using LLILCJit
 Successfully read Path.IsRelative
 
@@ -5243,8 +6411,8 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -5254,8 +6422,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
@@ -5271,8 +6439,8 @@ entry:
 
 ; <label>:17                                      ; preds = %7
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
@@ -5288,8 +6456,8 @@ entry:
 
 ; <label>:29                                      ; preds = %19
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %31
 
 ; <label>:31                                      ; preds = %29
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
@@ -5300,8 +6468,8 @@ entry:
 
 ; <label>:36                                      ; preds = %31
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
-  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %37, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
@@ -5312,8 +6480,8 @@ entry:
 
 ; <label>:43                                      ; preds = %31, %38
   %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
-  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %45
 
 ; <label>:45                                      ; preds = %43
   %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
@@ -5324,8 +6492,8 @@ entry:
 
 ; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %50
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
@@ -5336,8 +6504,8 @@ entry:
 
 ; <label>:57                                      ; preds = %1, %7, %19, %45, %52
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
-  br i1 %NullCheck14, label %59, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %59
 
 ; <label>:59                                      ; preds = %57
   %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
@@ -5347,8 +6515,8 @@ entry:
 
 ; <label>:63                                      ; preds = %59
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
@@ -5359,8 +6527,8 @@ entry:
 
 ; <label>:70                                      ; preds = %65
   %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
-  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.String addrspace(1)* %71, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %72
 
 ; <label>:72                                      ; preds = %70
   %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
@@ -5379,39 +6547,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %17
+ThrowNullRef4:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %29
+ThrowNullRef6:                                    ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %36
+ThrowNullRef8:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %43
+ThrowNullRef10:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %50
+ThrowNullRef12:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %57
+ThrowNullRef14:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %63
+ThrowNullRef16:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %70
+ThrowNullRef18:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5419,7 +6587,293 @@ ThrowNullRef17:                                   ; preds = %70
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
-Failed to read String.TrimHelper[loadElem]
+Successfully read String.TrimHelper
+
+define %System.String addrspace(1)* @String.TrimHelper(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i16
+  %loc4 = alloca i32
+  %loc5 = alloca i16
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = sub i32 %3, 1
+  store i32 %4, i32* %loc0
+  store i32 0, i32* %loc1
+  %5 = load i32, i32* %arg2
+  %6 = icmp eq i32 %5, 1
+  br i1 %6, label %62, label %7
+
+; <label>:7                                       ; preds = %1
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:8                                       ; preds = %58
+  store i32 0, i32* %loc2
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load i32, i32* %loc1
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2, i32 %10
+  %13 = load i16, i16 addrspace(1)* %12
+  %14 = zext i16 %13 to i32
+  %15 = trunc i32 %14 to i16
+  store i16 %15, i16* %loc3
+  store i32 0, i32* %loc2
+  br label %34
+
+; <label>:16                                      ; preds = %37
+  %17 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %18 = load i32, i32* %loc2
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %17, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %19
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = zext i32 %18 to i64
+  %BoundsCheck = icmp uge i64 %23, %22
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %24
+
+; <label>:24                                      ; preds = %19
+  %25 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 3, i32 %18
+  %26 = load i16, i16 addrspace(1)* %25, align 8
+  %27 = zext i16 %26 to i32
+  %28 = load i16, i16* %loc3
+  %29 = zext i16 %28 to i32
+  %30 = icmp eq i32 %27, %29
+  br i1 %30, label %43, label %31
+
+; <label>:31                                      ; preds = %24
+  %32 = load i32, i32* %loc2
+  %33 = add i32 %32, 1
+  store i32 %33, i32* %loc2
+  br label %34
+
+; <label>:34                                      ; preds = %11, %31
+  %35 = load i32, i32* %loc2
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = icmp slt i32 %35, %41
+  br i1 %42, label %16, label %43
+
+; <label>:43                                      ; preds = %24, %37
+  %44 = load i32, i32* %loc2
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %45, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp eq i32 %44, %50
+  br i1 %51, label %62, label %52
+
+; <label>:52                                      ; preds = %46
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %7, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %57, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %58
+
+; <label>:58                                      ; preds = %55
+  %59 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %60 = load i32, i32 addrspace(1)* %59
+  %61 = icmp slt i32 %56, %60
+  br i1 %61, label %8, label %62
+
+; <label>:62                                      ; preds = %1, %46, %58
+  %63 = load i32, i32* %arg2
+  %64 = icmp eq i32 %63, 0
+  br i1 %64, label %122, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %66, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %67
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %66, i32 0, i32 1
+  %69 = load i32, i32 addrspace(1)* %68
+  %70 = sub i32 %69, 1
+  store i32 %70, i32* %loc0
+  br label %118
+
+; <label>:71                                      ; preds = %118
+  store i32 0, i32* %loc4
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %73 = load i32, i32* %loc0
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %74
+
+; <label>:74                                      ; preds = %71
+  %75 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 2, i32 %73
+  %76 = load i16, i16 addrspace(1)* %75
+  %77 = zext i16 %76 to i32
+  %78 = trunc i32 %77 to i16
+  store i16 %78, i16* %loc5
+  store i32 0, i32* %loc4
+  br label %97
+
+; <label>:79                                      ; preds = %100
+  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %81 = load i32, i32* %loc4
+  %NullCheck19 = icmp eq %"System.Char[]" addrspace(1)* %80, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
+
+; <label>:82                                      ; preds = %79
+  %83 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 1
+  %84 = load i32, i32 addrspace(1)* %83
+  %85 = zext i32 %84 to i64
+  %86 = zext i32 %81 to i64
+  %BoundsCheck21 = icmp uge i64 %86, %85
+  br i1 %BoundsCheck21, label %ThrowIndexOutOfRange22, label %87
+
+; <label>:87                                      ; preds = %82
+  %88 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 3, i32 %81
+  %89 = load i16, i16 addrspace(1)* %88, align 8
+  %90 = zext i16 %89 to i32
+  %91 = load i16, i16* %loc5
+  %92 = zext i16 %91 to i32
+  %93 = icmp eq i32 %90, %92
+  br i1 %93, label %106, label %94
+
+; <label>:94                                      ; preds = %87
+  %95 = load i32, i32* %loc4
+  %96 = add i32 %95, 1
+  store i32 %96, i32* %loc4
+  br label %97
+
+; <label>:97                                      ; preds = %74, %94
+  %98 = load i32, i32* %loc4
+  %99 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck15 = icmp eq %"System.Char[]" addrspace(1)* %99, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %100
+
+; <label>:100                                     ; preds = %97
+  %101 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %99, i32 0, i32 1
+  %102 = load i32, i32 addrspace(1)* %101
+  %103 = zext i32 %102 to i64
+  %104 = trunc i64 %103 to i32
+  %105 = icmp slt i32 %98, %104
+  br i1 %105, label %79, label %106
+
+; <label>:106                                     ; preds = %87, %100
+  %107 = load i32, i32* %loc4
+  %108 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck17 = icmp eq %"System.Char[]" addrspace(1)* %108, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %109
+
+; <label>:109                                     ; preds = %106
+  %110 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %108, i32 0, i32 1
+  %111 = load i32, i32 addrspace(1)* %110
+  %112 = zext i32 %111 to i64
+  %113 = trunc i64 %112 to i32
+  %114 = icmp eq i32 %107, %113
+  br i1 %114, label %122, label %115
+
+; <label>:115                                     ; preds = %109
+  %116 = load i32, i32* %loc0
+  %117 = sub i32 %116, 1
+  store i32 %117, i32* %loc0
+  br label %118
+
+; <label>:118                                     ; preds = %67, %115
+  %119 = load i32, i32* %loc0
+  %120 = load i32, i32* %loc1
+  %121 = icmp sge i32 %119, %120
+  br i1 %121, label %71, label %122
+
+; <label>:122                                     ; preds = %62, %109, %118
+  %123 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %124 = load i32, i32* %loc1
+  %125 = load i32, i32* %loc0
+  %126 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %123, i32 %124, i32 %125)
+  ret %System.String addrspace(1)* %126
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %97
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange22:                           ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
 Successfully read String.CreateTrimmedString
 
@@ -5439,8 +6893,8 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
@@ -5535,8 +6989,8 @@ entry:
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i64 2872
   %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
   %8 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %7
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %3
   %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
@@ -5553,8 +7007,8 @@ entry:
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 2864
   %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
   %21 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %20
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
-  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %22
 
 ; <label>:22                                      ; preds = %16
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
@@ -5569,7 +7023,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %16
+ThrowNullRef2:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5586,8 +7040,8 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5613,8 +7067,8 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
@@ -5632,8 +7086,8 @@ entry:
 
 ; <label>:12                                      ; preds = %4
   %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
@@ -5644,8 +7098,8 @@ entry:
 
 ; <label>:19                                      ; preds = %14
   %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %19
   %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
@@ -5660,21 +7114,21 @@ entry:
   %31 = zext i16 %30 to i32
   %32 = bitcast i8* %29 to i16*
   %33 = trunc i32 %31 to i16
-  %NullCheck6 = icmp ne i16* %32, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i16* %32, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %21
   store i16 %33, i16* %32, align 8
   %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %36
 
 ; <label>:36                                      ; preds = %34
   %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
   %38 = load i32, i32 addrspace(1)* %37, align 8
   %39 = add i32 %38, 1
-  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %40
 
 ; <label>:40                                      ; preds = %36
   %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
@@ -5683,16 +7137,16 @@ entry:
 
 ; <label>:42                                      ; preds = %14
   %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
-  br i1 %NullCheck12, label %44, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
   %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
   %47 = load i16, i16* %arg1
   %48 = zext i16 %47 to i32
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = trunc i32 %48 to i16
@@ -5703,31 +7157,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %19
+ThrowNullRef4:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %21
+ThrowNullRef6:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %36
+ThrowNullRef10:                                   ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %42
+ThrowNullRef12:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %44
+ThrowNullRef14:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5740,8 +7194,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -5752,8 +7206,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
@@ -5762,14 +7216,14 @@ entry:
 
 ; <label>:11                                      ; preds = %1
   %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
@@ -5779,15 +7233,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5808,8 +7262,8 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5822,8 +7276,8 @@ entry:
 
 ; <label>:8                                       ; preds = %3
   %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
@@ -5842,15 +7296,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
-  br i1 %NullCheck4, label %22, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
   %24 = load i16*, i16* addrspace(1)* %23, align 8
   %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %25, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
@@ -5859,8 +7313,8 @@ entry:
   store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
@@ -5874,8 +7328,8 @@ entry:
 
 ; <label>:37                                      ; preds = %65
   %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %37
   %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
@@ -5886,16 +7340,16 @@ entry:
   %45 = bitcast i16* %41 to i8*
   %46 = getelementptr inbounds i8, i8* %45, i64 %44
   %47 = bitcast i8* %46 to i16*
-  %NullCheck14 = icmp ne i16* %47, null
-  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %47, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %48
 
 ; <label>:48                                      ; preds = %39
   %49 = load i16, i16* %47, align 8
   %50 = zext i16 %49 to i32
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %52 = load i32, i32* %loc1
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %53
 
 ; <label>:53                                      ; preds = %48
   %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
@@ -5916,8 +7370,8 @@ entry:
 ; <label>:62                                      ; preds = %36, %59
   %63 = load i32, i32* %loc1
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck10, label %65, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %65
 
 ; <label>:65                                      ; preds = %62
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
@@ -5936,15 +7390,15 @@ entry:
 
 ; <label>:74                                      ; preds = %70
   %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
-  br i1 %NullCheck18, label %76, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %76
 
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
   %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
-  br i1 %NullCheck20, label %80, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
   %81 = load i64, i64 addrspace(1)* %79
@@ -5958,8 +7412,8 @@ entry:
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
   %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
-  br i1 %NullCheck22, label %92, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.String addrspace(1)* %90, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %92
 
 ; <label>:92                                      ; preds = %80
   %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
@@ -5969,15 +7423,15 @@ entry:
 
 ; <label>:96                                      ; preds = %70
   %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
-  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %98
 
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
   %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
-  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
   %103 = load i64, i64 addrspace(1)* %101
@@ -5991,8 +7445,8 @@ entry:
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
   %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
-  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.String addrspace(1)* %112, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %114
 
 ; <label>:114                                     ; preds = %102
   %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
@@ -6004,59 +7458,59 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %20
+ThrowNullRef4:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %22
+ThrowNullRef6:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %26
+ThrowNullRef8:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %62
+ThrowNullRef10:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %48
+ThrowNullRef16:                                   ; preds = %48
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %74
+ThrowNullRef18:                                   ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %76
+ThrowNullRef20:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %80
+ThrowNullRef22:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %96
+ThrowNullRef24:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %98
+ThrowNullRef26:                                   ; preds = %98
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %102
+ThrowNullRef28:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6069,15 +7523,15 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
   %3 = load i16*, i16* addrspace(1)* %2, align 8
   %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
@@ -6087,8 +7541,8 @@ entry:
   %10 = bitcast i16* %3 to i8*
   %11 = getelementptr inbounds i8, i8* %10, i64 %9
   %12 = bitcast i8* %11 to i16*
-  %NullCheck4 = icmp ne i16* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %5
   store i16 0, i16* %12, align 8
@@ -6098,11 +7552,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6119,8 +7573,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -6131,8 +7585,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
@@ -6144,15 +7598,15 @@ entry:
 
 ; <label>:14                                      ; preds = %1
   %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
   %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
   %21 = load i64, i64 addrspace(1)* %19
@@ -6171,15 +7625,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %14
+ThrowNullRef4:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %16
+ThrowNullRef6:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6302,14 +7756,6 @@ entry:
   ret %System.String addrspace(1)* %57
 }
 
-INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
-Successfully read RuntimeHelpers.get_OffsetToStringData
-
-define i32 @RuntimeHelpers.get_OffsetToStringData() {
-entry:
-  ret i32 12
-}
-
 INFO:  jitting method String::Equals using LLILCJit
 Successfully read String.Equals
 
@@ -6381,8 +7827,8 @@ entry:
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
-  br i1 %NullCheck24, label %29, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
   %30 = load i64, i64 addrspace(1)* %28
@@ -6397,8 +7843,8 @@ entry:
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
-  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
   %43 = load i64, i64 addrspace(1)* %41
@@ -6418,8 +7864,8 @@ entry:
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
   %59 = load i64, i64 addrspace(1)* %57
@@ -6434,8 +7880,8 @@ entry:
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck22, label %71, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
   %72 = load i64, i64 addrspace(1)* %70
@@ -6455,8 +7901,8 @@ entry:
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
-  br i1 %NullCheck16, label %87, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = load i64, i64 addrspace(1)* %86
@@ -6471,8 +7917,8 @@ entry:
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck18, label %100, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
   %101 = load i64, i64 addrspace(1)* %99
@@ -6492,8 +7938,8 @@ entry:
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
-  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
   %117 = load i64, i64 addrspace(1)* %115
@@ -6508,8 +7954,8 @@ entry:
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
-  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
   %130 = load i64, i64 addrspace(1)* %128
@@ -6528,15 +7974,15 @@ entry:
 
 ; <label>:142                                     ; preds = %22
   %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
-  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %143, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %144
 
 ; <label>:144                                     ; preds = %142
   %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
   %146 = load i32, i32 addrspace(1)* %145
   %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
-  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %147, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %148
 
 ; <label>:148                                     ; preds = %144
   %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
@@ -6557,15 +8003,15 @@ entry:
 
 ; <label>:159                                     ; preds = %22
   %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
-  br i1 %NullCheck, label %161, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %ThrowNullRef, label %161
 
 ; <label>:161                                     ; preds = %159
   %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
   %163 = load i32, i32 addrspace(1)* %162
   %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
-  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %164, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %165
 
 ; <label>:165                                     ; preds = %161
   %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
@@ -6578,8 +8024,8 @@ entry:
 
 ; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
-  br i1 %NullCheck4, label %172, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %171, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %172
 
 ; <label>:172                                     ; preds = %170
   %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
@@ -6589,8 +8035,8 @@ entry:
 
 ; <label>:176                                     ; preds = %172
   %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
-  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %177, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %178
 
 ; <label>:178                                     ; preds = %176
   %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
@@ -6629,55 +8075,55 @@ ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %161
+ThrowNullRef2:                                    ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %170
+ThrowNullRef4:                                    ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %176
+ThrowNullRef6:                                    ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %142
+ThrowNullRef8:                                    ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %144
+ThrowNullRef10:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %113
+ThrowNullRef12:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %116
+ThrowNullRef14:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %84
+ThrowNullRef16:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %87
+ThrowNullRef18:                                   ; preds = %87
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %55
+ThrowNullRef20:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %58
+ThrowNullRef22:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %26
+ThrowNullRef24:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %29
+ThrowNullRef26:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,8 +8161,8 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck, label %14, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %ThrowNullRef, label %14
 
 ; <label>:14                                      ; preds = %8
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
@@ -6760,8 +8206,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
@@ -6770,14 +8216,14 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32, i32* %loc0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %10
   %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
   %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
@@ -6790,15 +8236,15 @@ entry:
 ; <label>:25                                      ; preds = %19
   %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
-  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
   %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
@@ -6807,8 +8253,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %37 = load i32, i32* %loc0
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %38, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %38
 
 ; <label>:38                                      ; preds = %32
   %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
@@ -6817,14 +8263,14 @@ entry:
 
 ; <label>:40                                      ; preds = %19
   %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %40
   %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
   %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
-  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
-  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
@@ -6832,8 +8278,8 @@ entry:
   %48 = zext i32 %47 to i64
   %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
-  br i1 %NullCheck16, label %51, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %51
 
 ; <label>:51                                      ; preds = %45
   %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
@@ -6847,15 +8293,15 @@ entry:
 ; <label>:57                                      ; preds = %51
   %58 = load i16*, i16** %arg1
   %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
-  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %60
 
 ; <label>:60                                      ; preds = %57
   %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
   %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
-  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %64
 
 ; <label>:64                                      ; preds = %60
   %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
@@ -6864,22 +8310,22 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
   %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
-  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %70
 
 ; <label>:70                                      ; preds = %64
   %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
   %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
-  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
-  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
   %75 = load i32, i32 addrspace(1)* %74
   %76 = zext i32 %75 to i64
   %77 = trunc i64 %76 to i32
-  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
-  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %78
 
 ; <label>:78                                      ; preds = %73
   %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
@@ -6901,8 +8347,8 @@ entry:
   %90 = bitcast i16* %86 to i8*
   %91 = getelementptr inbounds i8, i8* %90, i64 %89
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %93
 
 ; <label>:93                                      ; preds = %80
   %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
@@ -6912,8 +8358,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %99 = load i32, i32* %loc2
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %100
 
 ; <label>:100                                     ; preds = %93
   %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
@@ -6928,63 +8374,63 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %25
+ThrowNullRef6:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %32
+ThrowNullRef10:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %40
+ThrowNullRef12:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %45
+ThrowNullRef16:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %57
+ThrowNullRef18:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %60
+ThrowNullRef20:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %64
+ThrowNullRef22:                                   ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %70
+ThrowNullRef24:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %73
+ThrowNullRef26:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %80
+ThrowNullRef28:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %93
+ThrowNullRef30:                                   ; preds = %93
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7004,8 +8450,8 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
@@ -7033,43 +8479,43 @@ entry:
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %14
   %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
   %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   %28 = load i32, i32 addrspace(1)* %27, align 8
   %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
-  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %30
 
 ; <label>:30                                      ; preds = %26
   %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
   %32 = load i32, i32 addrspace(1)* %31, align 8
   %33 = add i32 %28, %32
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %34
 
 ; <label>:34                                      ; preds = %30
   %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   store i32 %33, i32 addrspace(1)* %35
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
   store i32 0, i32 addrspace(1)* %38
   %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %40
 
 ; <label>:40                                      ; preds = %37
   %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
@@ -7082,8 +8528,8 @@ entry:
 
 ; <label>:47                                      ; preds = %40
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
@@ -7098,8 +8544,8 @@ entry:
   %54 = load i32, i32* %loc0
   %55 = sext i32 %54 to i64
   %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
-  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %57
 
 ; <label>:57                                      ; preds = %52
   %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
@@ -7110,68 +8556,35 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %14
+ThrowNullRef2:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %23
+ThrowNullRef4:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %26
+ThrowNullRef6:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %30
+ThrowNullRef8:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %34
+ThrowNullRef10:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %47
+ThrowNullRef14:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %52
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-}
-
-INFO:  jitting method StringBuilder::get_Length using LLILCJit
-Successfully read StringBuilder.get_Length
-
-define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.StringBuilder addrspace(1)*
-  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
-  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
-
-; <label>:1                                       ; preds = %entry
-  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %3 = load i32, i32 addrspace(1)* %2, align 8
-  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
-
-; <label>:5                                       ; preds = %1
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = add i32 %3, %7
-  ret i32 %8
-
-ThrowNullRef:                                     ; preds = %entry
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef16:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7213,70 +8626,70 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
   %6 = load i32, i32 addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
   store i32 %6, i32 addrspace(1)* %8
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
   %13 = load i32, i32 addrspace(1)* %12, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
   store i32 %13, i32 addrspace(1)* %15
   %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
-  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %18
 
 ; <label>:18                                      ; preds = %14
   %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
   %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
   %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
   %34 = load i32, i32 addrspace(1)* %33, align 8
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
-  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
@@ -7287,39 +8700,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %28
+ThrowNullRef16:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %32
+ThrowNullRef18:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7455,13 +8868,13 @@ entry:
 ; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
@@ -7477,16 +8890,16 @@ entry:
 
 ; <label>:18                                      ; preds = %15
   %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
   store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
   %22 = load i32, i32* %loc0
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %24
 
 ; <label>:24                                      ; preds = %20
   %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
@@ -7498,13 +8911,13 @@ entry:
 ; <label>:28                                      ; preds = %15, %24
   %29 = load i32, i32* %arg1
   %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %31
   %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
@@ -7517,20 +8930,20 @@ entry:
   %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
-  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
   %46 = load i32, i32 addrspace(1)* %45, align 8
   %47 = sub i32 %40, %46
-  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
-  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i32 addrspace(1)* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %48
 
 ; <label>:48                                      ; preds = %44
   store i32 %47, i32 addrspace(1)* %39, align 8
@@ -7538,21 +8951,21 @@ entry:
 
 ; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
-  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %51
 
 ; <label>:51                                      ; preds = %49
   %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %53
 
 ; <label>:53                                      ; preds = %51
   %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
   %55 = load i32, i32 addrspace(1)* %54, align 8
   %56 = load i32, i32* %arg2
   %57 = sub i32 %55, %56
-  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %58
 
 ; <label>:58                                      ; preds = %53
   %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
@@ -7562,13 +8975,13 @@ entry:
 ; <label>:60                                      ; preds = %33, %58
   %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
   %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
-  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %63
 
 ; <label>:63                                      ; preds = %60
   %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
-  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
-  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
@@ -7578,15 +8991,15 @@ entry:
 
 ; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
-  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i32 addrspace(1)* %69, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %70
 
 ; <label>:70                                      ; preds = %68
   %71 = load i32, i32 addrspace(1)* %69, align 8
   store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
-  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
@@ -7596,8 +9009,8 @@ entry:
   store i32 %77, i32* %loc4
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
-  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %80
 
 ; <label>:80                                      ; preds = %73
   %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
@@ -7607,71 +9020,71 @@ entry:
 ; <label>:83                                      ; preds = %80
   store i32 0, i32* %loc3
   %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
-  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
-  br i1 %NullCheck26, label %88, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i32 addrspace(1)* %87, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %88
 
 ; <label>:88                                      ; preds = %85
   %89 = load i32, i32 addrspace(1)* %87, align 8
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
-  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %90
 
 ; <label>:90                                      ; preds = %88
   %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
   store i32 %89, i32 addrspace(1)* %91
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
-  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
-  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %96
 
 ; <label>:96                                      ; preds = %94
   %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
-  br i1 %NullCheck34, label %100, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %100
 
 ; <label>:100                                     ; preds = %96
   %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
-  br i1 %NullCheck36, label %102, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %102
 
 ; <label>:102                                     ; preds = %100
   %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
   %104 = load i32, i32 addrspace(1)* %103, align 8
   %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
-  br i1 %NullCheck38, label %106, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %106
 
 ; <label>:106                                     ; preds = %102
   %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
-  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
-  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %108
 
 ; <label>:108                                     ; preds = %106
   %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
   %110 = load i32, i32 addrspace(1)* %109, align 8
   %111 = add i32 %104, %110
-  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %112
 
 ; <label>:112                                     ; preds = %108
   %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
   store i32 %111, i32 addrspace(1)* %113
   %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
-  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i32 addrspace(1)* %114, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %115
 
 ; <label>:115                                     ; preds = %112
   %116 = load i32, i32 addrspace(1)* %114, align 8
@@ -7681,19 +9094,19 @@ entry:
 ; <label>:118                                     ; preds = %115
   %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
-  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %121
 
 ; <label>:121                                     ; preds = %118
   %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
-  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
-  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %123
 
 ; <label>:123                                     ; preds = %121
   %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
   %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
-  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
-  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %126
 
 ; <label>:126                                     ; preds = %123
   %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
@@ -7705,8 +9118,8 @@ entry:
 
 ; <label>:130                                     ; preds = %80, %115, %126
   %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %132
 
 ; <label>:132                                     ; preds = %130
   %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7715,8 +9128,8 @@ entry:
   %136 = load i32, i32* %loc3
   %137 = sub i32 %135, %136
   %138 = sub i32 %134, %137
-  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %139
 
 ; <label>:139                                     ; preds = %132
   %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7728,16 +9141,16 @@ entry:
 
 ; <label>:144                                     ; preds = %139
   %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
-  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %146
 
 ; <label>:146                                     ; preds = %144
   %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
   %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
   %149 = load i32, i32* %loc2
   %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
-  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %151
 
 ; <label>:151                                     ; preds = %146
   %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
@@ -7754,145 +9167,249 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %18
+ThrowNullRef4:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %31
+ThrowNullRef10:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %44
+ThrowNullRef16:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %68
+ThrowNullRef18:                                   ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %70
+ThrowNullRef20:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %73
+ThrowNullRef22:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %83
+ThrowNullRef24:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %85
+ThrowNullRef26:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %88
+ThrowNullRef28:                                   ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %90
+ThrowNullRef30:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %94
+ThrowNullRef32:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %96
+ThrowNullRef34:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %100
+ThrowNullRef36:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %102
+ThrowNullRef38:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %106
+ThrowNullRef40:                                   ; preds = %106
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %108
+ThrowNullRef42:                                   ; preds = %108
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %112
+ThrowNullRef44:                                   ; preds = %112
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %118
+ThrowNullRef46:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %121
+ThrowNullRef48:                                   ; preds = %121
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %123
+ThrowNullRef50:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %130
+ThrowNullRef52:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %132
+ThrowNullRef54:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %144
+ThrowNullRef56:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %146
+ThrowNullRef58:                                   ; preds = %146
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %60
+ThrowNullRef60:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %63
+ThrowNullRef62:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %49
+ThrowNullRef64:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %51
+ThrowNullRef66:                                   ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %53
+ThrowNullRef68:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(%"System.Char[]" addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %arg0 = alloca %"System.Char[]" addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store %"System.Char[]" addrspace(1)* %param0, %"System.Char[]" addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load i32, i32* %arg4
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %43, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %38, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg1
+  %13 = load i32, i32* %arg4
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %38, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %24 = load i32, i32* %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %35 = load i32, i32* %arg3
+  %36 = load i32, i32* %arg4
+  %37 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %37, %"System.Char[]" addrspace(1)* %34, i32 %35, i32 %36)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:38                                      ; preds = %5, %16
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Successfully read Buffer._Memmove
 
@@ -7914,7 +9431,7 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[loadElem]
+Failed to read AppDomain.SetDataHelper[storeElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -7923,8 +9440,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
@@ -7934,8 +9451,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
@@ -7947,15 +9464,15 @@ entry:
   %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
   %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
@@ -7966,15 +9483,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7992,7 +9509,79 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
-Failed to read Dictionary`2.TryGetValue[loadElemA]
+Successfully read Dictionary`2.TryGetValue
+
+define i8 @"Dictionary`2.TryGetValue"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)* addrspace(1)* %param2) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  %arg2 = alloca %System.__Canon addrspace(1)* addrspace(1)*
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  store %System.__Canon addrspace(1)* addrspace(1)* %param2, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  store i32 %2, i32* %loc0
+  %3 = load i32, i32* %loc0
+  %4 = icmp slt i32 %3, 0
+  br i1 %4, label %22, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 2
+  %10 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %9, align 8
+  %11 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = zext i32 %11 to i64
+  %BoundsCheck = icmp uge i64 %16, %15
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 3, i32 %11
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %20, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %6, %System.__Canon addrspace(1)* %21)
+  ret i8 1
+
+; <label>:22                                      ; preds = %entry
+  %23 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %23, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -8058,8 +9647,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
@@ -8091,8 +9680,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
@@ -8171,15 +9760,15 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck, label %19, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %ThrowNullRef, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
   %21 = load i32, i32 addrspace(1)* %20
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
@@ -8202,7 +9791,7 @@ ThrowNullRef:                                     ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %19
+ThrowNullRef2:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8248,8 +9837,8 @@ entry:
   %0 = alloca %System.AppDomainHandle
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %1 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %1, i32 0, i32 15
@@ -8269,8 +9858,8 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
@@ -8286,7 +9875,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -8299,8 +9888,8 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -8327,8 +9916,8 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
@@ -8352,8 +9941,8 @@ entry:
   %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
   store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
@@ -8363,8 +9952,8 @@ entry:
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
@@ -8374,8 +9963,8 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %9
   %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
@@ -8384,8 +9973,8 @@ entry:
 
 ; <label>:18                                      ; preds = %3, %16
   %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
@@ -8397,15 +9986,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %18
+ThrowNullRef6:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8418,8 +10007,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
@@ -8453,15 +10042,15 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
@@ -8473,7 +10062,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8481,7 +10070,7 @@ ThrowNullRef1:                                    ; preds = %1
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
 Failed to read Dictionary`2.System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
@@ -8506,8 +10095,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
@@ -8524,8 +10113,8 @@ entry:
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -8544,7 +10133,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8577,8 +10166,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = load i64, i64* %arg2
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = trunc i32 %3 to i8
@@ -8634,46 +10223,46 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
   %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
-  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
-  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
-  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
@@ -8684,27 +10273,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %20
+ThrowNullRef12:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8717,8 +10306,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -8756,22 +10345,22 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
   %9 = load i64, i64 addrspace(1)* %8, align 8
   %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
   %13 = load i64, i64 addrspace(1)* %12, align 8
   %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %11
   %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
@@ -8788,11 +10377,11 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8882,8 +10471,8 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
@@ -8900,8 +10489,8 @@ entry:
 ; <label>:8                                       ; preds = %1
   %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
   %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
@@ -8911,15 +10500,15 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
   %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
   %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
-  br i1 %NullCheck6, label %21, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
@@ -8946,15 +10535,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8992,15 +10581,15 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
   store i8 %3, i8 addrspace(1)* %5
   %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
@@ -9011,7 +10600,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9027,8 +10616,8 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -9041,8 +10630,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
@@ -9058,7 +10647,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9080,8 +10669,8 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
@@ -9096,8 +10685,8 @@ entry:
 ; <label>:12                                      ; preds = %6
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
@@ -9112,8 +10701,8 @@ entry:
 ; <label>:21                                      ; preds = %15
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
@@ -9128,8 +10717,8 @@ entry:
 ; <label>:30                                      ; preds = %24
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %31, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
@@ -9144,8 +10733,8 @@ entry:
 ; <label>:39                                      ; preds = %33
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
-  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %40, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %42
 
 ; <label>:42                                      ; preds = %39
   %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
@@ -9164,19 +10753,19 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %21
+ThrowNullRef4:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %30
+ThrowNullRef6:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %39
+ThrowNullRef8:                                    ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9243,8 +10832,8 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
@@ -9264,57 +10853,57 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
   store i8 0, i8 addrspace(1)* %2
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
   store i8 0, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
   store i8 0, i8 addrspace(1)* %17
   %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
   store i8 0, i8 addrspace(1)* %20
   %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
-  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
@@ -9325,31 +10914,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %19
+ThrowNullRef14:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9367,8 +10956,8 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
@@ -9380,8 +10969,8 @@ entry:
 
 ; <label>:9                                       ; preds = %4
   %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %9
   %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
@@ -9395,7 +10984,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef2:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9420,8 +11009,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
@@ -9512,8 +11101,8 @@ entry:
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
@@ -9524,8 +11113,8 @@ entry:
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = load i64, i64 addrspace(1)* %12
@@ -9537,8 +11126,8 @@ entry:
   %20 = load i64, i64* %19
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
-  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %13
   %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
@@ -9555,8 +11144,8 @@ entry:
 ; <label>:30                                      ; preds = %25
   %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %32 = load i32, i32* %arg2
-  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
-  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
@@ -9570,15 +11159,15 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %30
+ThrowNullRef2:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9622,87 +11211,87 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
   %10 = load i8, i8 addrspace(1)* %9, align 8
   %11 = zext i8 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %8
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
   store i8 %12, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
   %19 = load i8, i8 addrspace(1)* %18, align 8
   %20 = zext i8 %19 to i32
   %21 = trunc i32 %20 to i8
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
   store i8 %21, i8 addrspace(1)* %23
   %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
   %28 = load i8, i8 addrspace(1)* %27, align 8
   %29 = zext i8 %28 to i32
   %30 = trunc i32 %29 to i8
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
-  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %31
 
 ; <label>:31                                      ; preds = %26
   %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
   store i8 %30, i8 addrspace(1)* %32
   %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
-  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
-  br i1 %NullCheck14, label %40, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %40
 
 ; <label>:40                                      ; preds = %35
   %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
   store i8 %39, i8 addrspace(1)* %41
   %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
-  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %44
 
 ; <label>:44                                      ; preds = %40
   %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
   %46 = load i8, i8 addrspace(1)* %45, align 8
   %47 = zext i8 %46 to i32
   %48 = trunc i32 %47 to i8
-  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
   store i8 %48, i8 addrspace(1)* %50
   %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
-  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
@@ -9713,29 +11302,29 @@ entry:
 ; <label>:56                                      ; preds = %52
   %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
-  br i1 %NullCheck22, label %59, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
   %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
   %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
-  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
-  br i1 %NullCheck24, label %63, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
   %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
-  br i1 %NullCheck26, label %66, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
   %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
-  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
-  br i1 %NullCheck28, label %69, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %69
 
 ; <label>:69                                      ; preds = %66
   %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
@@ -9744,15 +11333,15 @@ entry:
 
 ; <label>:71                                      ; preds = %105
   %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
-  br i1 %NullCheck34, label %73, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %73
 
 ; <label>:73                                      ; preds = %71
   %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
   %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
   %76 = load i32, i32* %loc0
-  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
-  br i1 %NullCheck36, label %77, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
@@ -9766,8 +11355,8 @@ entry:
 
 ; <label>:83                                      ; preds = %77
   %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
-  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
@@ -9775,14 +11364,14 @@ entry:
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
   %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
-  br i1 %NullCheck40, label %91, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
 ; <label>:91                                      ; preds = %85
   %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
   %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
-  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck42, label %94, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %94
 
 ; <label>:94                                      ; preds = %91
   %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
@@ -9798,14 +11387,14 @@ entry:
 ; <label>:99                                      ; preds = %69, %96
   %100 = load i32, i32* %loc0
   %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
-  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %102
 
 ; <label>:102                                     ; preds = %99
   %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
   %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
-  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
-  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
@@ -9819,87 +11408,87 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %26
+ThrowNullRef10:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %31
+ThrowNullRef12:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %35
+ThrowNullRef14:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %40
+ThrowNullRef16:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %56
+ThrowNullRef22:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %59
+ThrowNullRef24:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %63
+ThrowNullRef26:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %66
+ThrowNullRef28:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %102
+ThrowNullRef32:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %71
+ThrowNullRef34:                                   ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %73
+ThrowNullRef36:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %83
+ThrowNullRef38:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %85
+ThrowNullRef40:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %91
+ThrowNullRef42:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9943,15 +11532,15 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
   %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
@@ -9961,28 +11550,28 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
   %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %12
   %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
   %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
   %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
-  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
@@ -9993,23 +11582,23 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %12
+ThrowNullRef6:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10031,15 +11620,15 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
   %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = load i64, i64 addrspace(1)* %7
@@ -10077,13 +11666,13 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[loadElem]
+Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -10111,8 +11700,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueLeInt1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueLeInt1.error.txt
@@ -25,8 +25,8 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
@@ -40,8 +40,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
   %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
@@ -75,7 +75,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -90,8 +90,8 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %NullCheck = icmp ne i8 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = load i8, i8 addrspace(1)* %0, align 8
@@ -125,8 +125,8 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
@@ -159,8 +159,8 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -184,8 +184,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
   store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
@@ -195,8 +195,8 @@ entry:
 ; <label>:4                                       ; preds = %1
   %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
   %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
@@ -206,8 +206,8 @@ entry:
   %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
@@ -221,14 +221,14 @@ entry:
 
 ; <label>:17                                      ; preds = %14
   %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
   %21 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
@@ -238,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -249,8 +249,8 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
@@ -261,27 +261,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %30
+ThrowNullRef10:                                   ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -301,7 +301,89 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
-Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
+Successfully read AppDomainSetup.GetUnsecureApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.GetUnsecureApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %NullCheck = icmp eq %"System.String[]" addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %BoundsCheck = icmp uge i64 0, %5
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %6
+
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 3, i32 0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
+  ret %System.String addrspace(1)* %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_Value using LLILCJit
+Successfully read AppDomainSetup.get_Value
+
+define %"System.String[]" addrspace(1)* @AppDomainSetup.get_Value(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.String[]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 18)
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.String[]" addrspace(1)* addrspace(1)*, %"System.String[]" addrspace(1)*)*)(%"System.String[]" addrspace(1)* addrspace(1)* %9, %"System.String[]" addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %11, i32 0, i32 1
+  %14 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %13, align 8
+  ret %"System.String[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -319,8 +401,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -368,16 +450,16 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
   %5 = load i32, i32 addrspace(1)* %4
   %6 = sub i32 %5, 1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -389,7 +471,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -421,8 +503,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
@@ -456,8 +538,8 @@ entry:
 ; <label>:27                                      ; preds = %19
   %28 = load i32, i32* %arg1
   %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
-  br i1 %NullCheck2, label %30, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %29, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %30
 
 ; <label>:30                                      ; preds = %27
   %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
@@ -493,8 +575,8 @@ entry:
 ; <label>:49                                      ; preds = %46
   %50 = load i32, i32* %arg2
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck4, label %52, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
@@ -517,11 +599,11 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %27
+ThrowNullRef2:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %49
+ThrowNullRef4:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -544,16 +626,16 @@ entry:
   %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %0)
   store %System.String addrspace(1)* %1, %System.String addrspace(1)** %loc0
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 2
   %5 = bitcast [0 x i16] addrspace(1)* %4 to i16 addrspace(1)*
   store i16 addrspace(1)* %5, i16 addrspace(1)** %loc1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %3
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2
@@ -580,7 +662,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -691,15 +773,15 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %NullCheck132 = icmp ne i8* %21, null
-  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+  %NullCheck131 = icmp eq i8* %21, null
+  br i1 %NullCheck131, label %ThrowNullRef132, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = load i8, i8* %21, align 8
   %24 = zext i8 %23 to i32
   %25 = trunc i32 %24 to i8
-  %NullCheck134 = icmp ne i8* %20, null
-  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+  %NullCheck133 = icmp eq i8* %20, null
+  br i1 %NullCheck133, label %ThrowNullRef134, label %26
 
 ; <label>:26                                      ; preds = %22
   store i8 %25, i8* %20, align 8
@@ -709,16 +791,16 @@ entry:
   %28 = load i8*, i8** %arg0
   %29 = load i8*, i8** %arg1
   %30 = bitcast i8* %29 to i16*
-  %NullCheck128 = icmp ne i16* %30, null
-  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+  %NullCheck127 = icmp eq i16* %30, null
+  br i1 %NullCheck127, label %ThrowNullRef128, label %31
 
 ; <label>:31                                      ; preds = %27
   %32 = load i16, i16* %30, align 8
   %33 = sext i16 %32 to i32
   %34 = bitcast i8* %28 to i16*
   %35 = trunc i32 %33 to i16
-  %NullCheck130 = icmp ne i16* %34, null
-  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+  %NullCheck129 = icmp eq i16* %34, null
+  br i1 %NullCheck129, label %ThrowNullRef130, label %36
 
 ; <label>:36                                      ; preds = %31
   store i16 %35, i16* %34, align 8
@@ -728,16 +810,16 @@ entry:
   %38 = load i8*, i8** %arg0
   %39 = load i8*, i8** %arg1
   %40 = bitcast i8* %39 to i16*
-  %NullCheck120 = icmp ne i16* %40, null
-  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+  %NullCheck119 = icmp eq i16* %40, null
+  br i1 %NullCheck119, label %ThrowNullRef120, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i16, i16* %40, align 8
   %43 = sext i16 %42 to i32
   %44 = bitcast i8* %38 to i16*
   %45 = trunc i32 %43 to i16
-  %NullCheck122 = icmp ne i16* %44, null
-  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+  %NullCheck121 = icmp eq i16* %44, null
+  br i1 %NullCheck121, label %ThrowNullRef122, label %46
 
 ; <label>:46                                      ; preds = %41
   store i16 %45, i16* %44, align 8
@@ -745,15 +827,15 @@ entry:
   %48 = getelementptr inbounds i8, i8* %47, i64 2
   %49 = load i8*, i8** %arg1
   %50 = getelementptr inbounds i8, i8* %49, i64 2
-  %NullCheck124 = icmp ne i8* %50, null
-  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+  %NullCheck123 = icmp eq i8* %50, null
+  br i1 %NullCheck123, label %ThrowNullRef124, label %51
 
 ; <label>:51                                      ; preds = %46
   %52 = load i8, i8* %50, align 8
   %53 = zext i8 %52 to i32
   %54 = trunc i32 %53 to i8
-  %NullCheck126 = icmp ne i8* %48, null
-  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+  %NullCheck125 = icmp eq i8* %48, null
+  br i1 %NullCheck125, label %ThrowNullRef126, label %55
 
 ; <label>:55                                      ; preds = %51
   store i8 %54, i8* %48, align 8
@@ -763,14 +845,14 @@ entry:
   %57 = load i8*, i8** %arg0
   %58 = load i8*, i8** %arg1
   %59 = bitcast i8* %58 to i32*
-  %NullCheck116 = icmp ne i32* %59, null
-  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+  %NullCheck115 = icmp eq i32* %59, null
+  br i1 %NullCheck115, label %ThrowNullRef116, label %60
 
 ; <label>:60                                      ; preds = %56
   %61 = load i32, i32* %59, align 8
   %62 = bitcast i8* %57 to i32*
-  %NullCheck118 = icmp ne i32* %62, null
-  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+  %NullCheck117 = icmp eq i32* %62, null
+  br i1 %NullCheck117, label %ThrowNullRef118, label %63
 
 ; <label>:63                                      ; preds = %60
   store i32 %61, i32* %62, align 8
@@ -780,14 +862,14 @@ entry:
   %65 = load i8*, i8** %arg0
   %66 = load i8*, i8** %arg1
   %67 = bitcast i8* %66 to i32*
-  %NullCheck108 = icmp ne i32* %67, null
-  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+  %NullCheck107 = icmp eq i32* %67, null
+  br i1 %NullCheck107, label %ThrowNullRef108, label %68
 
 ; <label>:68                                      ; preds = %64
   %69 = load i32, i32* %67, align 8
   %70 = bitcast i8* %65 to i32*
-  %NullCheck110 = icmp ne i32* %70, null
-  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+  %NullCheck109 = icmp eq i32* %70, null
+  br i1 %NullCheck109, label %ThrowNullRef110, label %71
 
 ; <label>:71                                      ; preds = %68
   store i32 %69, i32* %70, align 8
@@ -795,15 +877,15 @@ entry:
   %73 = getelementptr inbounds i8, i8* %72, i64 4
   %74 = load i8*, i8** %arg1
   %75 = getelementptr inbounds i8, i8* %74, i64 4
-  %NullCheck112 = icmp ne i8* %75, null
-  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+  %NullCheck111 = icmp eq i8* %75, null
+  br i1 %NullCheck111, label %ThrowNullRef112, label %76
 
 ; <label>:76                                      ; preds = %71
   %77 = load i8, i8* %75, align 8
   %78 = zext i8 %77 to i32
   %79 = trunc i32 %78 to i8
-  %NullCheck114 = icmp ne i8* %73, null
-  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+  %NullCheck113 = icmp eq i8* %73, null
+  br i1 %NullCheck113, label %ThrowNullRef114, label %80
 
 ; <label>:80                                      ; preds = %76
   store i8 %79, i8* %73, align 8
@@ -813,14 +895,14 @@ entry:
   %82 = load i8*, i8** %arg0
   %83 = load i8*, i8** %arg1
   %84 = bitcast i8* %83 to i32*
-  %NullCheck100 = icmp ne i32* %84, null
-  br i1 %NullCheck100, label %85, label %ThrowNullRef99
+  %NullCheck99 = icmp eq i32* %84, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %85
 
 ; <label>:85                                      ; preds = %81
   %86 = load i32, i32* %84, align 8
   %87 = bitcast i8* %82 to i32*
-  %NullCheck102 = icmp ne i32* %87, null
-  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+  %NullCheck101 = icmp eq i32* %87, null
+  br i1 %NullCheck101, label %ThrowNullRef102, label %88
 
 ; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
@@ -829,16 +911,16 @@ entry:
   %91 = load i8*, i8** %arg1
   %92 = getelementptr inbounds i8, i8* %91, i64 4
   %93 = bitcast i8* %92 to i16*
-  %NullCheck104 = icmp ne i16* %93, null
-  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+  %NullCheck103 = icmp eq i16* %93, null
+  br i1 %NullCheck103, label %ThrowNullRef104, label %94
 
 ; <label>:94                                      ; preds = %88
   %95 = load i16, i16* %93, align 8
   %96 = sext i16 %95 to i32
   %97 = bitcast i8* %90 to i16*
   %98 = trunc i32 %96 to i16
-  %NullCheck106 = icmp ne i16* %97, null
-  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+  %NullCheck105 = icmp eq i16* %97, null
+  br i1 %NullCheck105, label %ThrowNullRef106, label %99
 
 ; <label>:99                                      ; preds = %94
   store i16 %98, i16* %97, align 8
@@ -848,14 +930,14 @@ entry:
   %101 = load i8*, i8** %arg0
   %102 = load i8*, i8** %arg1
   %103 = bitcast i8* %102 to i32*
-  %NullCheck88 = icmp ne i32* %103, null
-  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+  %NullCheck87 = icmp eq i32* %103, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %104
 
 ; <label>:104                                     ; preds = %100
   %105 = load i32, i32* %103, align 8
   %106 = bitcast i8* %101 to i32*
-  %NullCheck90 = icmp ne i32* %106, null
-  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+  %NullCheck89 = icmp eq i32* %106, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %107
 
 ; <label>:107                                     ; preds = %104
   store i32 %105, i32* %106, align 8
@@ -864,16 +946,16 @@ entry:
   %110 = load i8*, i8** %arg1
   %111 = getelementptr inbounds i8, i8* %110, i64 4
   %112 = bitcast i8* %111 to i16*
-  %NullCheck92 = icmp ne i16* %112, null
-  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+  %NullCheck91 = icmp eq i16* %112, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %113
 
 ; <label>:113                                     ; preds = %107
   %114 = load i16, i16* %112, align 8
   %115 = sext i16 %114 to i32
   %116 = bitcast i8* %109 to i16*
   %117 = trunc i32 %115 to i16
-  %NullCheck94 = icmp ne i16* %116, null
-  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+  %NullCheck93 = icmp eq i16* %116, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %118
 
 ; <label>:118                                     ; preds = %113
   store i16 %117, i16* %116, align 8
@@ -881,15 +963,15 @@ entry:
   %120 = getelementptr inbounds i8, i8* %119, i64 6
   %121 = load i8*, i8** %arg1
   %122 = getelementptr inbounds i8, i8* %121, i64 6
-  %NullCheck96 = icmp ne i8* %122, null
-  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+  %NullCheck95 = icmp eq i8* %122, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %123
 
 ; <label>:123                                     ; preds = %118
   %124 = load i8, i8* %122, align 8
   %125 = zext i8 %124 to i32
   %126 = trunc i32 %125 to i8
-  %NullCheck98 = icmp ne i8* %120, null
-  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+  %NullCheck97 = icmp eq i8* %120, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %127
 
 ; <label>:127                                     ; preds = %123
   store i8 %126, i8* %120, align 8
@@ -899,14 +981,14 @@ entry:
   %129 = load i8*, i8** %arg0
   %130 = load i8*, i8** %arg1
   %131 = bitcast i8* %130 to i64*
-  %NullCheck84 = icmp ne i64* %131, null
-  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+  %NullCheck83 = icmp eq i64* %131, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %132
 
 ; <label>:132                                     ; preds = %128
   %133 = load i64, i64* %131, align 8
   %134 = bitcast i8* %129 to i64*
-  %NullCheck86 = icmp ne i64* %134, null
-  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+  %NullCheck85 = icmp eq i64* %134, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %135
 
 ; <label>:135                                     ; preds = %132
   store i64 %133, i64* %134, align 8
@@ -916,14 +998,14 @@ entry:
   %137 = load i8*, i8** %arg0
   %138 = load i8*, i8** %arg1
   %139 = bitcast i8* %138 to i64*
-  %NullCheck76 = icmp ne i64* %139, null
-  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+  %NullCheck75 = icmp eq i64* %139, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %140
 
 ; <label>:140                                     ; preds = %136
   %141 = load i64, i64* %139, align 8
   %142 = bitcast i8* %137 to i64*
-  %NullCheck78 = icmp ne i64* %142, null
-  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+  %NullCheck77 = icmp eq i64* %142, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %143
 
 ; <label>:143                                     ; preds = %140
   store i64 %141, i64* %142, align 8
@@ -931,15 +1013,15 @@ entry:
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %NullCheck80 = icmp ne i8* %147, null
-  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+  %NullCheck79 = icmp eq i8* %147, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %148
 
 ; <label>:148                                     ; preds = %143
   %149 = load i8, i8* %147, align 8
   %150 = zext i8 %149 to i32
   %151 = trunc i32 %150 to i8
-  %NullCheck82 = icmp ne i8* %145, null
-  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+  %NullCheck81 = icmp eq i8* %145, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %152
 
 ; <label>:152                                     ; preds = %148
   store i8 %151, i8* %145, align 8
@@ -949,14 +1031,14 @@ entry:
   %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
   %156 = bitcast i8* %155 to i64*
-  %NullCheck68 = icmp ne i64* %156, null
-  br i1 %NullCheck68, label %157, label %ThrowNullRef67
+  %NullCheck67 = icmp eq i64* %156, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %157
 
 ; <label>:157                                     ; preds = %153
   %158 = load i64, i64* %156, align 8
   %159 = bitcast i8* %154 to i64*
-  %NullCheck70 = icmp ne i64* %159, null
-  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+  %NullCheck69 = icmp eq i64* %159, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %160
 
 ; <label>:160                                     ; preds = %157
   store i64 %158, i64* %159, align 8
@@ -965,16 +1047,16 @@ entry:
   %163 = load i8*, i8** %arg1
   %164 = getelementptr inbounds i8, i8* %163, i64 8
   %165 = bitcast i8* %164 to i16*
-  %NullCheck72 = icmp ne i16* %165, null
-  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+  %NullCheck71 = icmp eq i16* %165, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %166
 
 ; <label>:166                                     ; preds = %160
   %167 = load i16, i16* %165, align 8
   %168 = sext i16 %167 to i32
   %169 = bitcast i8* %162 to i16*
   %170 = trunc i32 %168 to i16
-  %NullCheck74 = icmp ne i16* %169, null
-  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+  %NullCheck73 = icmp eq i16* %169, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %171
 
 ; <label>:171                                     ; preds = %166
   store i16 %170, i16* %169, align 8
@@ -984,14 +1066,14 @@ entry:
   %173 = load i8*, i8** %arg0
   %174 = load i8*, i8** %arg1
   %175 = bitcast i8* %174 to i64*
-  %NullCheck56 = icmp ne i64* %175, null
-  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+  %NullCheck55 = icmp eq i64* %175, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %176
 
 ; <label>:176                                     ; preds = %172
   %177 = load i64, i64* %175, align 8
   %178 = bitcast i8* %173 to i64*
-  %NullCheck58 = icmp ne i64* %178, null
-  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+  %NullCheck57 = icmp eq i64* %178, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %179
 
 ; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
@@ -1000,16 +1082,16 @@ entry:
   %182 = load i8*, i8** %arg1
   %183 = getelementptr inbounds i8, i8* %182, i64 8
   %184 = bitcast i8* %183 to i16*
-  %NullCheck60 = icmp ne i16* %184, null
-  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+  %NullCheck59 = icmp eq i16* %184, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %185
 
 ; <label>:185                                     ; preds = %179
   %186 = load i16, i16* %184, align 8
   %187 = sext i16 %186 to i32
   %188 = bitcast i8* %181 to i16*
   %189 = trunc i32 %187 to i16
-  %NullCheck62 = icmp ne i16* %188, null
-  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+  %NullCheck61 = icmp eq i16* %188, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %190
 
 ; <label>:190                                     ; preds = %185
   store i16 %189, i16* %188, align 8
@@ -1017,15 +1099,15 @@ entry:
   %192 = getelementptr inbounds i8, i8* %191, i64 10
   %193 = load i8*, i8** %arg1
   %194 = getelementptr inbounds i8, i8* %193, i64 10
-  %NullCheck64 = icmp ne i8* %194, null
-  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+  %NullCheck63 = icmp eq i8* %194, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %195
 
 ; <label>:195                                     ; preds = %190
   %196 = load i8, i8* %194, align 8
   %197 = zext i8 %196 to i32
   %198 = trunc i32 %197 to i8
-  %NullCheck66 = icmp ne i8* %192, null
-  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+  %NullCheck65 = icmp eq i8* %192, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %199
 
 ; <label>:199                                     ; preds = %195
   store i8 %198, i8* %192, align 8
@@ -1035,14 +1117,14 @@ entry:
   %201 = load i8*, i8** %arg0
   %202 = load i8*, i8** %arg1
   %203 = bitcast i8* %202 to i64*
-  %NullCheck48 = icmp ne i64* %203, null
-  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+  %NullCheck47 = icmp eq i64* %203, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %204
 
 ; <label>:204                                     ; preds = %200
   %205 = load i64, i64* %203, align 8
   %206 = bitcast i8* %201 to i64*
-  %NullCheck50 = icmp ne i64* %206, null
-  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+  %NullCheck49 = icmp eq i64* %206, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %207
 
 ; <label>:207                                     ; preds = %204
   store i64 %205, i64* %206, align 8
@@ -1051,14 +1133,14 @@ entry:
   %210 = load i8*, i8** %arg1
   %211 = getelementptr inbounds i8, i8* %210, i64 8
   %212 = bitcast i8* %211 to i32*
-  %NullCheck52 = icmp ne i32* %212, null
-  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+  %NullCheck51 = icmp eq i32* %212, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %213
 
 ; <label>:213                                     ; preds = %207
   %214 = load i32, i32* %212, align 8
   %215 = bitcast i8* %209 to i32*
-  %NullCheck54 = icmp ne i32* %215, null
-  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+  %NullCheck53 = icmp eq i32* %215, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %216
 
 ; <label>:216                                     ; preds = %213
   store i32 %214, i32* %215, align 8
@@ -1068,14 +1150,14 @@ entry:
   %218 = load i8*, i8** %arg0
   %219 = load i8*, i8** %arg1
   %220 = bitcast i8* %219 to i64*
-  %NullCheck36 = icmp ne i64* %220, null
-  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64* %220, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %221
 
 ; <label>:221                                     ; preds = %217
   %222 = load i64, i64* %220, align 8
   %223 = bitcast i8* %218 to i64*
-  %NullCheck38 = icmp ne i64* %223, null
-  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+  %NullCheck37 = icmp eq i64* %223, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %224
 
 ; <label>:224                                     ; preds = %221
   store i64 %222, i64* %223, align 8
@@ -1084,14 +1166,14 @@ entry:
   %227 = load i8*, i8** %arg1
   %228 = getelementptr inbounds i8, i8* %227, i64 8
   %229 = bitcast i8* %228 to i32*
-  %NullCheck40 = icmp ne i32* %229, null
-  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i32* %229, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %230
 
 ; <label>:230                                     ; preds = %224
   %231 = load i32, i32* %229, align 8
   %232 = bitcast i8* %226 to i32*
-  %NullCheck42 = icmp ne i32* %232, null
-  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+  %NullCheck41 = icmp eq i32* %232, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %233
 
 ; <label>:233                                     ; preds = %230
   store i32 %231, i32* %232, align 8
@@ -1099,15 +1181,15 @@ entry:
   %235 = getelementptr inbounds i8, i8* %234, i64 12
   %236 = load i8*, i8** %arg1
   %237 = getelementptr inbounds i8, i8* %236, i64 12
-  %NullCheck44 = icmp ne i8* %237, null
-  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i8* %237, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %238
 
 ; <label>:238                                     ; preds = %233
   %239 = load i8, i8* %237, align 8
   %240 = zext i8 %239 to i32
   %241 = trunc i32 %240 to i8
-  %NullCheck46 = icmp ne i8* %235, null
-  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+  %NullCheck45 = icmp eq i8* %235, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %242
 
 ; <label>:242                                     ; preds = %238
   store i8 %241, i8* %235, align 8
@@ -1117,14 +1199,14 @@ entry:
   %244 = load i8*, i8** %arg0
   %245 = load i8*, i8** %arg1
   %246 = bitcast i8* %245 to i64*
-  %NullCheck24 = icmp ne i64* %246, null
-  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64* %246, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %247
 
 ; <label>:247                                     ; preds = %243
   %248 = load i64, i64* %246, align 8
   %249 = bitcast i8* %244 to i64*
-  %NullCheck26 = icmp ne i64* %249, null
-  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64* %249, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %250
 
 ; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
@@ -1133,14 +1215,14 @@ entry:
   %253 = load i8*, i8** %arg1
   %254 = getelementptr inbounds i8, i8* %253, i64 8
   %255 = bitcast i8* %254 to i32*
-  %NullCheck28 = icmp ne i32* %255, null
-  br i1 %NullCheck28, label %256, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i32* %255, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %256
 
 ; <label>:256                                     ; preds = %250
   %257 = load i32, i32* %255, align 8
   %258 = bitcast i8* %252 to i32*
-  %NullCheck30 = icmp ne i32* %258, null
-  br i1 %NullCheck30, label %259, label %ThrowNullRef29
+  %NullCheck29 = icmp eq i32* %258, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %259
 
 ; <label>:259                                     ; preds = %256
   store i32 %257, i32* %258, align 8
@@ -1149,16 +1231,16 @@ entry:
   %262 = load i8*, i8** %arg1
   %263 = getelementptr inbounds i8, i8* %262, i64 12
   %264 = bitcast i8* %263 to i16*
-  %NullCheck32 = icmp ne i16* %264, null
-  br i1 %NullCheck32, label %265, label %ThrowNullRef31
+  %NullCheck31 = icmp eq i16* %264, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %265
 
 ; <label>:265                                     ; preds = %259
   %266 = load i16, i16* %264, align 8
   %267 = sext i16 %266 to i32
   %268 = bitcast i8* %261 to i16*
   %269 = trunc i32 %267 to i16
-  %NullCheck34 = icmp ne i16* %268, null
-  br i1 %NullCheck34, label %270, label %ThrowNullRef33
+  %NullCheck33 = icmp eq i16* %268, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %270
 
 ; <label>:270                                     ; preds = %265
   store i16 %269, i16* %268, align 8
@@ -1168,14 +1250,14 @@ entry:
   %272 = load i8*, i8** %arg0
   %273 = load i8*, i8** %arg1
   %274 = bitcast i8* %273 to i64*
-  %NullCheck8 = icmp ne i64* %274, null
-  br i1 %NullCheck8, label %275, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64* %274, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %275
 
 ; <label>:275                                     ; preds = %271
   %276 = load i64, i64* %274, align 8
   %277 = bitcast i8* %272 to i64*
-  %NullCheck10 = icmp ne i64* %277, null
-  br i1 %NullCheck10, label %278, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %277, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %278
 
 ; <label>:278                                     ; preds = %275
   store i64 %276, i64* %277, align 8
@@ -1184,14 +1266,14 @@ entry:
   %281 = load i8*, i8** %arg1
   %282 = getelementptr inbounds i8, i8* %281, i64 8
   %283 = bitcast i8* %282 to i32*
-  %NullCheck12 = icmp ne i32* %283, null
-  br i1 %NullCheck12, label %284, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i32* %283, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %284
 
 ; <label>:284                                     ; preds = %278
   %285 = load i32, i32* %283, align 8
   %286 = bitcast i8* %280 to i32*
-  %NullCheck14 = icmp ne i32* %286, null
-  br i1 %NullCheck14, label %287, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i32* %286, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %287
 
 ; <label>:287                                     ; preds = %284
   store i32 %285, i32* %286, align 8
@@ -1200,16 +1282,16 @@ entry:
   %290 = load i8*, i8** %arg1
   %291 = getelementptr inbounds i8, i8* %290, i64 12
   %292 = bitcast i8* %291 to i16*
-  %NullCheck16 = icmp ne i16* %292, null
-  br i1 %NullCheck16, label %293, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i16* %292, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %293
 
 ; <label>:293                                     ; preds = %287
   %294 = load i16, i16* %292, align 8
   %295 = sext i16 %294 to i32
   %296 = bitcast i8* %289 to i16*
   %297 = trunc i32 %295 to i16
-  %NullCheck18 = icmp ne i16* %296, null
-  br i1 %NullCheck18, label %298, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i16* %296, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %298
 
 ; <label>:298                                     ; preds = %293
   store i16 %297, i16* %296, align 8
@@ -1217,15 +1299,15 @@ entry:
   %300 = getelementptr inbounds i8, i8* %299, i64 14
   %301 = load i8*, i8** %arg1
   %302 = getelementptr inbounds i8, i8* %301, i64 14
-  %NullCheck20 = icmp ne i8* %302, null
-  br i1 %NullCheck20, label %303, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i8* %302, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %303
 
 ; <label>:303                                     ; preds = %298
   %304 = load i8, i8* %302, align 8
   %305 = zext i8 %304 to i32
   %306 = trunc i32 %305 to i8
-  %NullCheck22 = icmp ne i8* %300, null
-  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i8* %300, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %307
 
 ; <label>:307                                     ; preds = %303
   store i8 %306, i8* %300, align 8
@@ -1235,14 +1317,14 @@ entry:
   %309 = load i8*, i8** %arg0
   %310 = load i8*, i8** %arg1
   %311 = bitcast i8* %310 to i64*
-  %NullCheck = icmp ne i64* %311, null
-  br i1 %NullCheck, label %312, label %ThrowNullRef
+  %NullCheck = icmp eq i64* %311, null
+  br i1 %NullCheck, label %ThrowNullRef, label %312
 
 ; <label>:312                                     ; preds = %308
   %313 = load i64, i64* %311, align 8
   %314 = bitcast i8* %309 to i64*
-  %NullCheck2 = icmp ne i64* %314, null
-  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64* %314, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %315
 
 ; <label>:315                                     ; preds = %312
   store i64 %313, i64* %314, align 8
@@ -1251,14 +1333,14 @@ entry:
   %318 = load i8*, i8** %arg1
   %319 = getelementptr inbounds i8, i8* %318, i64 8
   %320 = bitcast i8* %319 to i64*
-  %NullCheck4 = icmp ne i64* %320, null
-  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64* %320, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %321
 
 ; <label>:321                                     ; preds = %315
   %322 = load i64, i64* %320, align 8
   %323 = bitcast i8* %317 to i64*
-  %NullCheck6 = icmp ne i64* %323, null
-  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64* %323, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %324
 
 ; <label>:324                                     ; preds = %321
   store i64 %322, i64* %323, align 8
@@ -1286,15 +1368,15 @@ entry:
 ; <label>:338                                     ; preds = %333
   %339 = load i8*, i8** %arg0
   %340 = load i8*, i8** %arg1
-  %NullCheck136 = icmp ne i8* %340, null
-  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+  %NullCheck135 = icmp eq i8* %340, null
+  br i1 %NullCheck135, label %ThrowNullRef136, label %341
 
 ; <label>:341                                     ; preds = %338
   %342 = load i8, i8* %340, align 8
   %343 = zext i8 %342 to i32
   %344 = trunc i32 %343 to i8
-  %NullCheck138 = icmp ne i8* %339, null
-  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+  %NullCheck137 = icmp eq i8* %339, null
+  br i1 %NullCheck137, label %ThrowNullRef138, label %345
 
 ; <label>:345                                     ; preds = %341
   store i8 %344, i8* %339, align 8
@@ -1317,16 +1399,16 @@ entry:
   %357 = load i8*, i8** %arg0
   %358 = load i8*, i8** %arg1
   %359 = bitcast i8* %358 to i16*
-  %NullCheck140 = icmp ne i16* %359, null
-  br i1 %NullCheck140, label %360, label %ThrowNullRef139
+  %NullCheck139 = icmp eq i16* %359, null
+  br i1 %NullCheck139, label %ThrowNullRef140, label %360
 
 ; <label>:360                                     ; preds = %356
   %361 = load i16, i16* %359, align 8
   %362 = sext i16 %361 to i32
   %363 = bitcast i8* %357 to i16*
   %364 = trunc i32 %362 to i16
-  %NullCheck142 = icmp ne i16* %363, null
-  br i1 %NullCheck142, label %365, label %ThrowNullRef141
+  %NullCheck141 = icmp eq i16* %363, null
+  br i1 %NullCheck141, label %ThrowNullRef142, label %365
 
 ; <label>:365                                     ; preds = %360
   store i16 %364, i16* %363, align 8
@@ -1352,14 +1434,14 @@ entry:
   %378 = load i8*, i8** %arg0
   %379 = load i8*, i8** %arg1
   %380 = bitcast i8* %379 to i32*
-  %NullCheck144 = icmp ne i32* %380, null
-  br i1 %NullCheck144, label %381, label %ThrowNullRef143
+  %NullCheck143 = icmp eq i32* %380, null
+  br i1 %NullCheck143, label %ThrowNullRef144, label %381
 
 ; <label>:381                                     ; preds = %377
   %382 = load i32, i32* %380, align 8
   %383 = bitcast i8* %378 to i32*
-  %NullCheck146 = icmp ne i32* %383, null
-  br i1 %NullCheck146, label %384, label %ThrowNullRef145
+  %NullCheck145 = icmp eq i32* %383, null
+  br i1 %NullCheck145, label %ThrowNullRef146, label %384
 
 ; <label>:384                                     ; preds = %381
   store i32 %382, i32* %383, align 8
@@ -1384,14 +1466,14 @@ entry:
   %395 = load i8*, i8** %arg0
   %396 = load i8*, i8** %arg1
   %397 = bitcast i8* %396 to i64*
-  %NullCheck164 = icmp ne i64* %397, null
-  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+  %NullCheck163 = icmp eq i64* %397, null
+  br i1 %NullCheck163, label %ThrowNullRef164, label %398
 
 ; <label>:398                                     ; preds = %394
   %399 = load i64, i64* %397, align 8
   %400 = bitcast i8* %395 to i64*
-  %NullCheck166 = icmp ne i64* %400, null
-  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+  %NullCheck165 = icmp eq i64* %400, null
+  br i1 %NullCheck165, label %ThrowNullRef166, label %401
 
 ; <label>:401                                     ; preds = %398
   store i64 %399, i64* %400, align 8
@@ -1400,14 +1482,14 @@ entry:
   %404 = load i8*, i8** %arg1
   %405 = getelementptr inbounds i8, i8* %404, i64 8
   %406 = bitcast i8* %405 to i64*
-  %NullCheck168 = icmp ne i64* %406, null
-  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+  %NullCheck167 = icmp eq i64* %406, null
+  br i1 %NullCheck167, label %ThrowNullRef168, label %407
 
 ; <label>:407                                     ; preds = %401
   %408 = load i64, i64* %406, align 8
   %409 = bitcast i8* %403 to i64*
-  %NullCheck170 = icmp ne i64* %409, null
-  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+  %NullCheck169 = icmp eq i64* %409, null
+  br i1 %NullCheck169, label %ThrowNullRef170, label %410
 
 ; <label>:410                                     ; preds = %407
   store i64 %408, i64* %409, align 8
@@ -1437,14 +1519,14 @@ entry:
   %425 = load i8*, i8** %arg0
   %426 = load i8*, i8** %arg1
   %427 = bitcast i8* %426 to i64*
-  %NullCheck148 = icmp ne i64* %427, null
-  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+  %NullCheck147 = icmp eq i64* %427, null
+  br i1 %NullCheck147, label %ThrowNullRef148, label %428
 
 ; <label>:428                                     ; preds = %424
   %429 = load i64, i64* %427, align 8
   %430 = bitcast i8* %425 to i64*
-  %NullCheck150 = icmp ne i64* %430, null
-  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+  %NullCheck149 = icmp eq i64* %430, null
+  br i1 %NullCheck149, label %ThrowNullRef150, label %431
 
 ; <label>:431                                     ; preds = %428
   store i64 %429, i64* %430, align 8
@@ -1466,14 +1548,14 @@ entry:
   %441 = load i8*, i8** %arg0
   %442 = load i8*, i8** %arg1
   %443 = bitcast i8* %442 to i32*
-  %NullCheck152 = icmp ne i32* %443, null
-  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+  %NullCheck151 = icmp eq i32* %443, null
+  br i1 %NullCheck151, label %ThrowNullRef152, label %444
 
 ; <label>:444                                     ; preds = %440
   %445 = load i32, i32* %443, align 8
   %446 = bitcast i8* %441 to i32*
-  %NullCheck154 = icmp ne i32* %446, null
-  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+  %NullCheck153 = icmp eq i32* %446, null
+  br i1 %NullCheck153, label %ThrowNullRef154, label %447
 
 ; <label>:447                                     ; preds = %444
   store i32 %445, i32* %446, align 8
@@ -1495,16 +1577,16 @@ entry:
   %457 = load i8*, i8** %arg0
   %458 = load i8*, i8** %arg1
   %459 = bitcast i8* %458 to i16*
-  %NullCheck156 = icmp ne i16* %459, null
-  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+  %NullCheck155 = icmp eq i16* %459, null
+  br i1 %NullCheck155, label %ThrowNullRef156, label %460
 
 ; <label>:460                                     ; preds = %456
   %461 = load i16, i16* %459, align 8
   %462 = sext i16 %461 to i32
   %463 = bitcast i8* %457 to i16*
   %464 = trunc i32 %462 to i16
-  %NullCheck158 = icmp ne i16* %463, null
-  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+  %NullCheck157 = icmp eq i16* %463, null
+  br i1 %NullCheck157, label %ThrowNullRef158, label %465
 
 ; <label>:465                                     ; preds = %460
   store i16 %464, i16* %463, align 8
@@ -1525,15 +1607,15 @@ entry:
 ; <label>:474                                     ; preds = %470
   %475 = load i8*, i8** %arg0
   %476 = load i8*, i8** %arg1
-  %NullCheck160 = icmp ne i8* %476, null
-  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+  %NullCheck159 = icmp eq i8* %476, null
+  br i1 %NullCheck159, label %ThrowNullRef160, label %477
 
 ; <label>:477                                     ; preds = %474
   %478 = load i8, i8* %476, align 8
   %479 = zext i8 %478 to i32
   %480 = trunc i32 %479 to i8
-  %NullCheck162 = icmp ne i8* %475, null
-  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+  %NullCheck161 = icmp eq i8* %475, null
+  br i1 %NullCheck161, label %ThrowNullRef162, label %481
 
 ; <label>:481                                     ; preds = %477
   store i8 %480, i8* %475, align 8
@@ -1553,343 +1635,343 @@ ThrowNullRef:                                     ; preds = %308
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %312
+ThrowNullRef2:                                    ; preds = %312
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %315
+ThrowNullRef4:                                    ; preds = %315
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %321
+ThrowNullRef6:                                    ; preds = %321
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %271
+ThrowNullRef8:                                    ; preds = %271
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %275
+ThrowNullRef10:                                   ; preds = %275
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %278
+ThrowNullRef12:                                   ; preds = %278
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %284
+ThrowNullRef14:                                   ; preds = %284
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %287
+ThrowNullRef16:                                   ; preds = %287
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %293
+ThrowNullRef18:                                   ; preds = %293
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %298
+ThrowNullRef20:                                   ; preds = %298
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %303
+ThrowNullRef22:                                   ; preds = %303
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %243
+ThrowNullRef24:                                   ; preds = %243
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %247
+ThrowNullRef26:                                   ; preds = %247
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %250
+ThrowNullRef28:                                   ; preds = %250
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %256
+ThrowNullRef30:                                   ; preds = %256
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %259
+ThrowNullRef32:                                   ; preds = %259
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %265
+ThrowNullRef34:                                   ; preds = %265
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %217
+ThrowNullRef36:                                   ; preds = %217
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %221
+ThrowNullRef38:                                   ; preds = %221
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %224
+ThrowNullRef40:                                   ; preds = %224
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %230
+ThrowNullRef42:                                   ; preds = %230
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %233
+ThrowNullRef44:                                   ; preds = %233
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %238
+ThrowNullRef46:                                   ; preds = %238
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %200
+ThrowNullRef48:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %204
+ThrowNullRef50:                                   ; preds = %204
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %207
+ThrowNullRef52:                                   ; preds = %207
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %213
+ThrowNullRef54:                                   ; preds = %213
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %172
+ThrowNullRef56:                                   ; preds = %172
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %176
+ThrowNullRef58:                                   ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %179
+ThrowNullRef60:                                   ; preds = %179
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %185
+ThrowNullRef62:                                   ; preds = %185
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %190
+ThrowNullRef64:                                   ; preds = %190
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %195
+ThrowNullRef66:                                   ; preds = %195
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %153
+ThrowNullRef68:                                   ; preds = %153
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %157
+ThrowNullRef70:                                   ; preds = %157
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %160
+ThrowNullRef72:                                   ; preds = %160
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %166
+ThrowNullRef74:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %136
+ThrowNullRef76:                                   ; preds = %136
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %140
+ThrowNullRef78:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %143
+ThrowNullRef80:                                   ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %148
+ThrowNullRef82:                                   ; preds = %148
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %128
+ThrowNullRef84:                                   ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %132
+ThrowNullRef86:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %100
+ThrowNullRef88:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %104
+ThrowNullRef90:                                   ; preds = %104
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %107
+ThrowNullRef92:                                   ; preds = %107
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %113
+ThrowNullRef94:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %118
+ThrowNullRef96:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %123
+ThrowNullRef98:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %81
+ThrowNullRef100:                                  ; preds = %81
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef101:                                  ; preds = %85
+ThrowNullRef102:                                  ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef103:                                  ; preds = %88
+ThrowNullRef104:                                  ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef105:                                  ; preds = %94
+ThrowNullRef106:                                  ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef107:                                  ; preds = %64
+ThrowNullRef108:                                  ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef109:                                  ; preds = %68
+ThrowNullRef110:                                  ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef111:                                  ; preds = %71
+ThrowNullRef112:                                  ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef113:                                  ; preds = %76
+ThrowNullRef114:                                  ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef115:                                  ; preds = %56
+ThrowNullRef116:                                  ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef117:                                  ; preds = %60
+ThrowNullRef118:                                  ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef119:                                  ; preds = %37
+ThrowNullRef120:                                  ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef121:                                  ; preds = %41
+ThrowNullRef122:                                  ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef123:                                  ; preds = %46
+ThrowNullRef124:                                  ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef125:                                  ; preds = %51
+ThrowNullRef126:                                  ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef127:                                  ; preds = %27
+ThrowNullRef128:                                  ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef129:                                  ; preds = %31
+ThrowNullRef130:                                  ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef131:                                  ; preds = %19
+ThrowNullRef132:                                  ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef133:                                  ; preds = %22
+ThrowNullRef134:                                  ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef135:                                  ; preds = %338
+ThrowNullRef136:                                  ; preds = %338
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef137:                                  ; preds = %341
+ThrowNullRef138:                                  ; preds = %341
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef139:                                  ; preds = %356
+ThrowNullRef140:                                  ; preds = %356
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef141:                                  ; preds = %360
+ThrowNullRef142:                                  ; preds = %360
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef143:                                  ; preds = %377
+ThrowNullRef144:                                  ; preds = %377
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef145:                                  ; preds = %381
+ThrowNullRef146:                                  ; preds = %381
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef147:                                  ; preds = %424
+ThrowNullRef148:                                  ; preds = %424
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef149:                                  ; preds = %428
+ThrowNullRef150:                                  ; preds = %428
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef151:                                  ; preds = %440
+ThrowNullRef152:                                  ; preds = %440
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef153:                                  ; preds = %444
+ThrowNullRef154:                                  ; preds = %444
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef155:                                  ; preds = %456
+ThrowNullRef156:                                  ; preds = %456
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef157:                                  ; preds = %460
+ThrowNullRef158:                                  ; preds = %460
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef159:                                  ; preds = %474
+ThrowNullRef160:                                  ; preds = %474
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef161:                                  ; preds = %477
+ThrowNullRef162:                                  ; preds = %477
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef163:                                  ; preds = %394
+ThrowNullRef164:                                  ; preds = %394
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef165:                                  ; preds = %398
+ThrowNullRef166:                                  ; preds = %398
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef167:                                  ; preds = %401
+ThrowNullRef168:                                  ; preds = %401
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef169:                                  ; preds = %407
+ThrowNullRef170:                                  ; preds = %407
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1939,8 +2021,8 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
-  br i1 %NullCheck, label %22, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %ThrowNullRef, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
@@ -1948,8 +2030,8 @@ entry:
   store i32 %24, i32* %loc0
   %25 = load i32, i32* %loc0
   %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %26, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %27
 
 ; <label>:27                                      ; preds = %22
   %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
@@ -1971,7 +2053,7 @@ ThrowNullRef:                                     ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1989,8 +2071,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -2022,15 +2104,15 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2048,16 +2130,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
   %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
   store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %15
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
@@ -2072,8 +2154,8 @@ entry:
   %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
   %29 = ptrtoint i16 addrspace(1)* %28 to i64
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %19
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
@@ -2089,19 +2171,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2114,8 +2196,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
@@ -2128,7 +2210,7 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[loadElem]
+Failed to read AppDomain.PrepareDataForSetup[storeElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
@@ -2202,8 +2284,8 @@ entry:
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
-  br i1 %NullCheck24, label %27, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = load i64, i64 addrspace(1)* %26
@@ -2218,8 +2300,8 @@ entry:
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
-  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
   %41 = load i64, i64 addrspace(1)* %39
@@ -2236,8 +2318,8 @@ entry:
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
-  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
   %54 = load i64, i64 addrspace(1)* %52
@@ -2252,8 +2334,8 @@ entry:
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
   %67 = load i64, i64 addrspace(1)* %65
@@ -2270,8 +2352,8 @@ entry:
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
-  br i1 %NullCheck16, label %79, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
   %80 = load i64, i64 addrspace(1)* %78
@@ -2286,8 +2368,8 @@ entry:
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
-  br i1 %NullCheck18, label %92, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
   %93 = load i64, i64 addrspace(1)* %91
@@ -2304,8 +2386,8 @@ entry:
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
-  br i1 %NullCheck12, label %105, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = load i64, i64 addrspace(1)* %104
@@ -2320,8 +2402,8 @@ entry:
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
-  br i1 %NullCheck14, label %118, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
   %119 = load i64, i64 addrspace(1)* %117
@@ -2337,8 +2419,8 @@ entry:
 
 ; <label>:128                                     ; preds = %20
   %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
-  br i1 %NullCheck4, label %130, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %129, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %130
 
 ; <label>:130                                     ; preds = %128
   %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
@@ -2346,8 +2428,8 @@ entry:
   %133 = load i16, i16 addrspace(1)* %132, align 8
   %134 = zext i16 %133 to i32
   %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
-  br i1 %NullCheck6, label %136, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %135, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %136
 
 ; <label>:136                                     ; preds = %130
   %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
@@ -2360,8 +2442,8 @@ entry:
 
 ; <label>:143                                     ; preds = %136
   %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
-  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %144, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %145
 
 ; <label>:145                                     ; preds = %143
   %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
@@ -2369,8 +2451,8 @@ entry:
   %148 = load i16, i16 addrspace(1)* %147, align 8
   %149 = zext i16 %148 to i32
   %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %150, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %151
 
 ; <label>:151                                     ; preds = %145
   %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
@@ -2388,8 +2470,8 @@ entry:
 
 ; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
-  br i1 %NullCheck, label %163, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %ThrowNullRef, label %163
 
 ; <label>:163                                     ; preds = %161
   %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
@@ -2399,8 +2481,8 @@ entry:
 
 ; <label>:167                                     ; preds = %163
   %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
-  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %168, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %169
 
 ; <label>:169                                     ; preds = %167
   %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
@@ -2432,55 +2514,55 @@ ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %167
+ThrowNullRef2:                                    ; preds = %167
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %128
+ThrowNullRef4:                                    ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %130
+ThrowNullRef6:                                    ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %143
+ThrowNullRef8:                                    ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %145
+ThrowNullRef10:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %102
+ThrowNullRef12:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %105
+ThrowNullRef14:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %76
+ThrowNullRef16:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %79
+ThrowNullRef18:                                   ; preds = %79
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %50
+ThrowNullRef20:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %53
+ThrowNullRef22:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %24
+ThrowNullRef24:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %27
+ThrowNullRef26:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2503,15 +2585,15 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2519,16 +2601,16 @@ entry:
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
   store i32 %8, i32* %loc0
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
   %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
   store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
@@ -2546,16 +2628,16 @@ entry:
 
 ; <label>:23                                      ; preds = %64
   %24 = load i16*, i16** %loc3
-  %NullCheck12 = icmp ne i16* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i16* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
   store i32 %27, i32* %loc5
   %28 = load i16*, i16** %loc4
-  %NullCheck14 = icmp ne i16* %28, null
-  br i1 %NullCheck14, label %29, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %28, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = load i16, i16* %28, align 8
@@ -2620,15 +2702,15 @@ entry:
 
 ; <label>:67                                      ; preds = %64
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
-  br i1 %NullCheck8, label %69, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %68, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %69
 
 ; <label>:69                                      ; preds = %67
   %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
   %71 = load i32, i32 addrspace(1)* %70
   %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
-  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %73
 
 ; <label>:73                                      ; preds = %69
   %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
@@ -2645,31 +2727,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %67
+ThrowNullRef8:                                    ; preds = %67
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %69
+ThrowNullRef10:                                   ; preds = %69
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2710,14 +2792,14 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
   %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
@@ -2730,14 +2812,14 @@ entry:
 
 ; <label>:11                                      ; preds = %4
   %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
   %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
@@ -2749,14 +2831,14 @@ entry:
 
 ; <label>:22                                      ; preds = %16
   %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
   %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
-  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
-  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
@@ -2804,23 +2886,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2836,7 +2918,280 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[loadElem]
+Successfully read RuntimeType.IsAssignableFrom
+
+define i8 @RuntimeType.IsAssignableFrom(%System.RuntimeType addrspace(1)* %param0, %System.Type addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.RuntimeType addrspace(1)*
+  %arg1 = alloca %System.Type addrspace(1)*
+  %loc0 = alloca %System.RuntimeType addrspace(1)*
+  %loc1 = alloca %"System.Type[]" addrspace(1)*
+  %loc2 = alloca i32
+  store %System.RuntimeType addrspace(1)* %param0, %System.RuntimeType addrspace(1)** %this
+  store %System.Type addrspace(1)* %param1, %System.Type addrspace(1)** %arg1
+  %0 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %1 = icmp ne %System.Type addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i8 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %5 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %6 = bitcast %System.Type addrspace(1)* %4 to %System.Object addrspace(1)*
+  %7 = bitcast %System.RuntimeType addrspace(1)* %5 to %System.Object addrspace(1)*
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %6, %System.Object addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %3
+  ret i8 1
+
+; <label>:12                                      ; preds = %3
+  %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 152
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 32
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
+  %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
+  %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
+  store %System.RuntimeType addrspace(1)* %25, %System.RuntimeType addrspace(1)** %loc0
+  %26 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %27 = icmp eq %System.RuntimeType addrspace(1)* %26, null
+  br i1 %27, label %34, label %28
+
+; <label>:28                                      ; preds = %15
+  %29 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %30 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)*)*)(%System.RuntimeType addrspace(1)* %29, %System.RuntimeType addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+; <label>:34                                      ; preds = %15
+  %35 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %36 = call %System.Reflection.Emit.TypeBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Reflection.Emit.TypeBuilder addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %35)
+  %37 = icmp eq %System.Reflection.Emit.TypeBuilder addrspace(1)* %36, null
+  br i1 %37, label %139, label %38
+
+; <label>:38                                      ; preds = %34
+  %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %42
+
+; <label>:42                                      ; preds = %38
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 152
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 40
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
+  %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
+  %53 = zext i8 %52 to i32
+  %54 = icmp eq i32 %53, 0
+  br i1 %54, label %56, label %55
+
+; <label>:55                                      ; preds = %42
+  ret i8 1
+
+; <label>:56                                      ; preds = %42
+  %57 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %58 = bitcast %System.RuntimeType addrspace(1)* %57 to %System.Type addrspace(1)*
+  %59 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %58)
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %64 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.Type addrspace(1)* %63, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = bitcast %System.RuntimeType addrspace(1)* %64 to %System.Type addrspace(1)*
+  %67 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %63, %System.Type addrspace(1)* %66)
+  %68 = zext i8 %67 to i32
+  %69 = trunc i32 %68 to i8
+  ret i8 %69
+
+; <label>:70                                      ; preds = %56
+  %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
+  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %73
+
+; <label>:73                                      ; preds = %70
+  %74 = load i64, i64 addrspace(1)* %72
+  %75 = add i64 %74, 128
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = add i64 %77, 0
+  %79 = inttoptr i64 %78 to i64*
+  %80 = load i64, i64* %79
+  %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
+  %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
+  %83 = call i8 %82(%System.Type addrspace(1)* %81)
+  %84 = zext i8 %83 to i32
+  %85 = icmp eq i32 %84, 0
+  br i1 %85, label %139, label %86
+
+; <label>:86                                      ; preds = %73
+  %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
+  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %89
+
+; <label>:89                                      ; preds = %86
+  %90 = load i64, i64 addrspace(1)* %88
+  %91 = add i64 %90, 128
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = add i64 %93, 24
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
+  %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
+  %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
+  store %"System.Type[]" addrspace(1)* %99, %"System.Type[]" addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %129
+
+; <label>:100                                     ; preds = %132
+  %101 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %102 = load i32, i32* %loc2
+  %NullCheck11 = icmp eq %"System.Type[]" addrspace(1)* %101, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %103
+
+; <label>:103                                     ; preds = %100
+  %104 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 1
+  %105 = load i32, i32 addrspace(1)* %104
+  %106 = zext i32 %105 to i64
+  %107 = zext i32 %102 to i64
+  %BoundsCheck = icmp uge i64 %107, %106
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %108
+
+; <label>:108                                     ; preds = %103
+  %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
+  %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
+  %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
+  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %113
+
+; <label>:113                                     ; preds = %108
+  %114 = load i64, i64 addrspace(1)* %112
+  %115 = add i64 %114, 152
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = add i64 %117, 56
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
+  %123 = zext i8 %122 to i32
+  %124 = icmp ne i32 %123, 0
+  br i1 %124, label %126, label %125
+
+; <label>:125                                     ; preds = %113
+  ret i8 0
+
+; <label>:126                                     ; preds = %113
+  %127 = load i32, i32* %loc2
+  %128 = add i32 %127, 1
+  store i32 %128, i32* %loc2
+  br label %129
+
+; <label>:129                                     ; preds = %89, %126
+  %130 = load i32, i32* %loc2
+  %131 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %NullCheck9 = icmp eq %"System.Type[]" addrspace(1)* %131, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %132
+
+; <label>:132                                     ; preds = %129
+  %133 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %131, i32 0, i32 1
+  %134 = load i32, i32 addrspace(1)* %133
+  %135 = zext i32 %134 to i64
+  %136 = trunc i64 %135 to i32
+  %137 = icmp slt i32 %130, %136
+  br i1 %137, label %100, label %138
+
+; <label>:138                                     ; preds = %132
+  ret i8 1
+
+; <label>:139                                     ; preds = %34, %73
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %129
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %103
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -2893,7 +3248,7 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElem]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -2904,8 +3259,8 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -2997,8 +3352,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
@@ -3059,8 +3414,8 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -3087,8 +3442,8 @@ entry:
 
 ; <label>:17                                      ; preds = %5, %11
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
@@ -3097,8 +3452,8 @@ entry:
 
 ; <label>:22                                      ; preds = %1, %11
   %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
@@ -3109,11 +3464,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %17
+ThrowNullRef2:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %22
+ThrowNullRef4:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3167,15 +3522,15 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
   %15 = load i32, i32 addrspace(1)* %14
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
@@ -3198,7 +3553,7 @@ ThrowNullRef:                                     ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef2:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3232,8 +3587,8 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
@@ -3312,8 +3667,8 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -3327,8 +3682,8 @@ entry:
 ; <label>:5                                       ; preds = %43
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %7 = load i32, i32* %loc1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck6, label %8, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
@@ -3366,8 +3721,8 @@ entry:
 ; <label>:32                                      ; preds = %21, %25
   %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
   %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
-  br i1 %NullCheck8, label %35, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = trunc i32 %34 to i16
@@ -3380,8 +3735,8 @@ entry:
 ; <label>:40                                      ; preds = %1, %35
   %41 = load i32, i32* %loc1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
-  br i1 %NullCheck2, label %43, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %42, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
@@ -3392,8 +3747,8 @@ entry:
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
   %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
-  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
   %51 = load i64, i64 addrspace(1)* %49
@@ -3412,19 +3767,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %40
+ThrowNullRef2:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %47
+ThrowNullRef4:                                    ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %5
+ThrowNullRef6:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %32
+ThrowNullRef8:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3467,8 +3822,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
@@ -3492,11 +3847,391 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(i16* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store i16* %param0, i16** %arg0
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load i32, i32* %arg3
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %42, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %37, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg2
+  %13 = load i32, i32* %arg3
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %37, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %24 = load i32, i32* %arg2
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load i16*, i16** %arg0
+  %35 = load i32, i32* %arg3
+  %36 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %36, i16* %34, i32 %35)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:37                                      ; preds = %5, %16
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %39)
+  %41 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41, %System.String addrspace(1)* %38, %System.String addrspace(1)* %40)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41) #0
+  unreachable
+
+; <label>:42                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
-Failed to read StringBuilder.ToString[loadElemA]
+Successfully read StringBuilder.ToString
+
+define %System.String addrspace(1)* @StringBuilder.ToString(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i16*
+  %loc3 = alloca %"System.Char[]" addrspace(1)*
+  %loc4 = alloca i32
+  %loc5 = alloca i32
+  %loc6 = alloca i16 addrspace(1)*
+  %loc7 = alloca %System.String addrspace(1)*
+  %loc8 = alloca %"System.Char[]" addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %0)
+  %2 = icmp ne i32 %1, 0
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %4
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %6)
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %7)
+  store %System.String addrspace(1)* %8, %System.String addrspace(1)** %loc0
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.Text.StringBuilder addrspace(1)* %9, %System.Text.StringBuilder addrspace(1)** %loc1
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  store %System.String addrspace(1)* %10, %System.String addrspace(1)** %loc7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc7
+  %12 = ptrtoint %System.String addrspace(1)* %11 to i64
+  %13 = icmp eq i64 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %5
+  %15 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %16 = sext i32 %15 to i64
+  %17 = add i64 %12, %16
+  br label %18
+
+; <label>:18                                      ; preds = %5, %14
+  %19 = phi i64 [ %12, %5 ], [ %17, %14 ]
+  %20 = inttoptr i64 %19 to i16*
+  store i16* %20, i16** %loc2
+  br label %21
+
+; <label>:21                                      ; preds = %98, %18
+  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %22, null
+  br i1 %NullCheck, label %ThrowNullRef, label %23
+
+; <label>:23                                      ; preds = %21
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 3
+  %25 = load i32, i32 addrspace(1)* %24, align 8
+  %26 = icmp sle i32 %25, 0
+  br i1 %26, label %96, label %27
+
+; <label>:27                                      ; preds = %23
+  %28 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %28, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %29
+
+; <label>:29                                      ; preds = %27
+  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %28, i32 0, i32 1
+  %31 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %30, align 8
+  store %"System.Char[]" addrspace(1)* %31, %"System.Char[]" addrspace(1)** %loc3
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %33
+
+; <label>:33                                      ; preds = %29
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  store i32 %35, i32* %loc4
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  %39 = load i32, i32 addrspace(1)* %38, align 8
+  store i32 %39, i32* %loc5
+  %40 = load i32, i32* %loc5
+  %41 = load i32, i32* %loc4
+  %42 = add i32 %40, %41
+  %43 = zext i32 %42 to i64
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %45
+
+; <label>:45                                      ; preds = %37
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = sext i32 %47 to i64
+  %49 = icmp sgt i64 %43, %48
+  br i1 %49, label %91, label %50
+
+; <label>:50                                      ; preds = %45
+  %51 = load i32, i32* %loc5
+  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %52, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %53
+
+; <label>:53                                      ; preds = %50
+  %54 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %52, i32 0, i32 1
+  %55 = load i32, i32 addrspace(1)* %54
+  %56 = zext i32 %55 to i64
+  %57 = trunc i64 %56 to i32
+  %58 = icmp ugt i32 %51, %57
+  br i1 %58, label %91, label %59
+
+; <label>:59                                      ; preds = %53
+  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  store %"System.Char[]" addrspace(1)* %60, %"System.Char[]" addrspace(1)** %loc8
+  %61 = icmp eq %"System.Char[]" addrspace(1)* %60, null
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %63, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %64
+
+; <label>:64                                      ; preds = %62
+  %65 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %63, i32 0, i32 1
+  %66 = load i32, i32 addrspace(1)* %65
+  %67 = zext i32 %66 to i64
+  %68 = trunc i64 %67 to i32
+  %69 = icmp ne i32 %68, 0
+  br i1 %69, label %71, label %70
+
+; <label>:70                                      ; preds = %59, %64
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:71                                      ; preds = %64
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %73
+
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %BoundsCheck = icmp uge i64 0, %76
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %77
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %78, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:79                                      ; preds = %70, %77
+  %80 = load i16*, i16** %loc2
+  %81 = load i32, i32* %loc4
+  %82 = sext i32 %81 to i64
+  %83 = mul i64 %82, 2
+  %84 = bitcast i16* %80 to i8*
+  %85 = getelementptr inbounds i8, i8* %84, i64 %83
+  %86 = load i16 addrspace(1)*, i16 addrspace(1)** %loc6
+  %87 = ptrtoint i16 addrspace(1)* %86 to i64
+  %88 = load i32, i32* %loc5
+  %89 = bitcast i8* %85 to i16*
+  %90 = inttoptr i64 %87 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %89, i16* %90, i32 %88)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %96
+
+; <label>:91                                      ; preds = %45, %53
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %94 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %93)
+  %95 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95, %System.String addrspace(1)* %92, %System.String addrspace(1)* %94)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95) #0
+  unreachable
+
+; <label>:96                                      ; preds = %23, %79
+  %97 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %97, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %98
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %97, i32 0, i32 2
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  store %System.Text.StringBuilder addrspace(1)* %100, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %102 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %102, label %21, label %103
+
+; <label>:103                                     ; preds = %98
+  store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc7
+  %104 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  ret %System.String addrspace(1)* %104
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method StringBuilder::get_Length using LLILCJit
+Successfully read StringBuilder.get_Length
+
+define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
+Successfully read RuntimeHelpers.get_OffsetToStringData
+
+define i32 @RuntimeHelpers.get_OffsetToStringData() {
+entry:
+  ret i32 12
+}
+
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
 Successfully read CultureData.CreateCultureData
 
@@ -3514,23 +4249,23 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
   store i8 %4, i8 addrspace(1)* %6
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
@@ -3549,11 +4284,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3566,50 +4301,50 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
   store i32 -1, i32 addrspace(1)* %2
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
   store i32 -1, i32 addrspace(1)* %8
   %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
   store i32 -1, i32 addrspace(1)* %14
   %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
   store i32 -1, i32 addrspace(1)* %17
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
@@ -3623,27 +4358,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3675,7 +4410,136 @@ Failed to read Dictionary`2.Insert[non-const derefAddress]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
 Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
-Failed to read HashHelpers.GetPrime[loadElem]
+Successfully read HashHelpers.GetPrime
+
+define i32 @HashHelpers.GetPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %6, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5, %System.String addrspace(1)* %4)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5) #0
+  unreachable
+
+; <label>:6                                       ; preds = %entry
+  store i32 0, i32* %loc0
+  br label %29
+
+; <label>:7                                       ; preds = %35
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 1296
+  %10 = addrspacecast i8 addrspace(1)* %9 to %"System.Int32[]" addrspace(1)**
+  %11 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %10
+  %12 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Int32[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = zext i32 %15 to i64
+  %17 = zext i32 %12 to i64
+  %BoundsCheck = icmp uge i64 %17, %16
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 3, i32 %12
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  store i32 %20, i32* %loc1
+  %21 = load i32, i32* %loc1
+  %22 = load i32, i32* %arg0
+  %23 = icmp slt i32 %21, %22
+  br i1 %23, label %26, label %24
+
+; <label>:24                                      ; preds = %18
+  %25 = load i32, i32* %loc1
+  ret i32 %25
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %loc0
+  %28 = add i32 %27, 1
+  store i32 %28, i32* %loc0
+  br label %29
+
+; <label>:29                                      ; preds = %6, %26
+  %30 = load i32, i32* %loc0
+  %31 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %32 = getelementptr inbounds i8, i8 addrspace(1)* %31, i64 1296
+  %33 = addrspacecast i8 addrspace(1)* %32 to %"System.Int32[]" addrspace(1)**
+  %34 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %33
+  %NullCheck = icmp eq %"System.Int32[]" addrspace(1)* %34, null
+  br i1 %NullCheck, label %ThrowNullRef, label %35
+
+; <label>:35                                      ; preds = %29
+  %36 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %34, i32 0, i32 1
+  %37 = load i32, i32 addrspace(1)* %36
+  %38 = zext i32 %37 to i64
+  %39 = trunc i64 %38 to i32
+  %40 = icmp slt i32 %30, %39
+  br i1 %40, label %7, label %41
+
+; <label>:41                                      ; preds = %35
+  %42 = load i32, i32* %arg0
+  %43 = or i32 %42, 1
+  store i32 %43, i32* %loc2
+  br label %59
+
+; <label>:44                                      ; preds = %59
+  %45 = load i32, i32* %loc2
+  %46 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %45)
+  %47 = zext i8 %46 to i32
+  %48 = icmp eq i32 %47, 0
+  br i1 %48, label %56, label %49
+
+; <label>:49                                      ; preds = %44
+  %50 = load i32, i32* %loc2
+  %51 = sub i32 %50, 1
+  %52 = srem i32 %51, 101
+  %53 = icmp eq i32 %52, 0
+  br i1 %53, label %56, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = load i32, i32* %loc2
+  ret i32 %55
+
+; <label>:56                                      ; preds = %44, %49
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %57, 2
+  store i32 %58, i32* %loc2
+  br label %59
+
+; <label>:59                                      ; preds = %41, %56
+  %60 = load i32, i32* %loc2
+  %61 = icmp slt i32 %60, 2147483647
+  br i1 %61, label %44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load i32, i32* %arg0
+  ret i32 %63
+
+ThrowNullRef:                                     ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
 Successfully read GenericEqualityComparer`1.GetHashCode
 
@@ -3694,14 +4558,14 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
   %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load i64, i64 addrspace(1)* %7
@@ -3720,7 +4584,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3750,8 +4614,8 @@ entry:
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
@@ -3796,8 +4660,8 @@ entry:
   %35 = bitcast i16* %34 to i8*
   %36 = getelementptr inbounds i8, i8* %35, i64 2
   %37 = bitcast i8* %36 to i16*
-  %NullCheck4 = icmp ne i16* %37, null
-  br i1 %NullCheck4, label %38, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %37, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %38
 
 ; <label>:38                                      ; preds = %27
   %39 = load i16, i16* %37, align 8
@@ -3824,8 +4688,8 @@ entry:
 
 ; <label>:54                                      ; preds = %22, %43
   %55 = load i16*, i16** %loc4
-  %NullCheck2 = icmp ne i16* %55, null
-  br i1 %NullCheck2, label %56, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i16* %55, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %56
 
 ; <label>:56                                      ; preds = %54
   %57 = load i16, i16* %55, align 8
@@ -3850,11 +4714,11 @@ ThrowNullRef:                                     ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %54
+ThrowNullRef2:                                    ; preds = %54
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %27
+ThrowNullRef4:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3871,8 +4735,8 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -3907,8 +4771,8 @@ entry:
 
 ; <label>:26                                      ; preds = %19
   %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
-  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %28
 
 ; <label>:28                                      ; preds = %26
   %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
@@ -3920,7 +4784,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3972,8 +4836,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
@@ -3984,26 +4848,26 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
-  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
@@ -4014,8 +4878,8 @@ entry:
 ; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
@@ -4024,8 +4888,8 @@ entry:
 
 ; <label>:25                                      ; preds = %1, %16, %23
   %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
-  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
@@ -4036,27 +4900,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %20
+ThrowNullRef10:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4069,8 +4933,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -4081,8 +4945,8 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
@@ -4091,8 +4955,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1, %8
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
@@ -4103,11 +4967,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4128,24 +4992,24 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   store i32 %3, i32* %loc0
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
   %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
   store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck4, label %9, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
@@ -4164,15 +5028,15 @@ entry:
 ; <label>:18                                      ; preds = %70
   %19 = load i16*, i16** %loc3
   %20 = bitcast i16* %19 to i64*
-  %NullCheck10 = icmp ne i64* %20, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %20, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = load i64, i64* %20, align 8
   %23 = load i16*, i16** %loc4
   %24 = bitcast i16* %23 to i64*
-  %NullCheck12 = icmp ne i64* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = load i64, i64* %24, align 8
@@ -4188,8 +5052,8 @@ entry:
   %31 = bitcast i16* %30 to i8*
   %32 = getelementptr inbounds i8, i8* %31, i64 8
   %33 = bitcast i8* %32 to i64*
-  %NullCheck14 = icmp ne i64* %33, null
-  br i1 %NullCheck14, label %34, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = load i64, i64* %33, align 8
@@ -4197,8 +5061,8 @@ entry:
   %37 = bitcast i16* %36 to i8*
   %38 = getelementptr inbounds i8, i8* %37, i64 8
   %39 = bitcast i8* %38 to i64*
-  %NullCheck16 = icmp ne i64* %39, null
-  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %40
 
 ; <label>:40                                      ; preds = %34
   %41 = load i64, i64* %39, align 8
@@ -4214,8 +5078,8 @@ entry:
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %NullCheck18 = icmp ne i64* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = load i64, i64* %48, align 8
@@ -4223,8 +5087,8 @@ entry:
   %52 = bitcast i16* %51 to i8*
   %53 = getelementptr inbounds i8, i8* %52, i64 16
   %54 = bitcast i8* %53 to i64*
-  %NullCheck20 = icmp ne i64* %54, null
-  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64* %54, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %55
 
 ; <label>:55                                      ; preds = %49
   %56 = load i64, i64* %54, align 8
@@ -4262,15 +5126,15 @@ entry:
 ; <label>:74                                      ; preds = %95
   %75 = load i16*, i16** %loc3
   %76 = bitcast i16* %75 to i32*
-  %NullCheck6 = icmp ne i32* %76, null
-  br i1 %NullCheck6, label %77, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32* %76, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %77
 
 ; <label>:77                                      ; preds = %74
   %78 = load i32, i32* %76, align 8
   %79 = load i16*, i16** %loc4
   %80 = bitcast i16* %79 to i32*
-  %NullCheck8 = icmp ne i32* %80, null
-  br i1 %NullCheck8, label %81, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i32* %80, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %81
 
 ; <label>:81                                      ; preds = %77
   %82 = load i32, i32* %80, align 8
@@ -4318,43 +5182,43 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %74
+ThrowNullRef6:                                    ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %77
+ThrowNullRef8:                                    ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %29
+ThrowNullRef14:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %34
+ThrowNullRef16:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4376,8 +5240,8 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load i64, i64 addrspace(1)* %4
@@ -4389,8 +5253,8 @@ entry:
   %12 = load i64, i64* %11
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %5
   %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
@@ -4399,8 +5263,8 @@ entry:
   %18 = load i8, i8* %arg2
   %19 = zext i8 %18 to i32
   %20 = trunc i32 %19 to i8
-  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %15
   %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
@@ -4411,11 +5275,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4442,8 +5306,8 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
@@ -4466,16 +5330,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
   %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = load i64, i64 addrspace(1)* %19
@@ -4500,8 +5364,8 @@ entry:
 ; <label>:35                                      ; preds = %30
   %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
@@ -4514,8 +5378,8 @@ entry:
 
 ; <label>:42                                      ; preds = %1, %38
   %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
-  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
@@ -4526,19 +5390,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %35
+ThrowNullRef2:                                    ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %42
+ThrowNullRef8:                                    ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4551,14 +5415,14 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
@@ -4570,7 +5434,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4583,8 +5447,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
@@ -4613,51 +5477,51 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
   %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
   %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
   %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
   %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
-  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
   store i64 %21, i64 addrspace(1)* %23
   %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %25 = load i64, i64* %loc0
-  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
@@ -4668,27 +5532,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %22
+ThrowNullRef12:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4701,8 +5565,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
@@ -4713,19 +5577,19 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
@@ -4734,8 +5598,8 @@ entry:
 
 ; <label>:15                                      ; preds = %1, %13
   %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
@@ -4746,19 +5610,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %15
+ThrowNullRef8:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4771,8 +5635,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -4831,8 +5695,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
@@ -4882,8 +5746,8 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
-  br i1 %NullCheck, label %17, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %ThrowNullRef, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
@@ -4894,15 +5758,15 @@ entry:
 
 ; <label>:22                                      ; preds = %17
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
-  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
   %26 = load i32, i32 addrspace(1)* %25
   %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
-  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %27, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
@@ -4925,8 +5789,8 @@ entry:
 ; <label>:40                                      ; preds = %17
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
-  br i1 %NullCheck6, label %43, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %41, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
@@ -4938,34 +5802,17 @@ ThrowNullRef:                                     ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %24
+ThrowNullRef4:                                    ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %40
+ThrowNullRef6:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
-}
-
-INFO:  jitting method Object::ReferenceEquals using LLILCJit
-Successfully read Object.ReferenceEquals
-
-define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
-entry:
-  %arg0 = alloca %System.Object addrspace(1)*
-  %arg1 = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
-  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
-  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = icmp eq %System.Object addrspace(1)* %0, %1
-  %3 = sext i1 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
 }
 
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
@@ -4978,21 +5825,21 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
   %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
-  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
@@ -5007,28 +5854,28 @@ entry:
 ; <label>:13                                      ; preds = %8, %12
   %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
   %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
   %21 = load i32, i32 addrspace(1)* %20, align 8
   %22 = add i32 %21, 1
-  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
   store i32 %22, i32 addrspace(1)* %24
   %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
@@ -5039,27 +5886,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5077,7 +5924,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::Setup using LLILCJit
-Failed to read AppDomain.Setup[loadElem]
+Failed to read AppDomain.Setup[unbox]
 INFO:  jitting method Thread::GetDomain using LLILCJit
 Successfully read Thread.GetDomain
 
@@ -5108,8 +5955,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
@@ -5122,14 +5969,14 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
   %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
@@ -5141,11 +5988,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5173,8 +6020,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -5189,7 +6036,328 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
 Failed to read KeyCollection.System.Collections.Generic.IEnumerable<TKey>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Successfully read Enumerator.MoveNext
+
+define i8 @Enumerator.MoveNext(%"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.RuntimeTypeHandle* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*
+  %"$TypeArg" = alloca %System.RuntimeTypeHandle*
+  store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
+  %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 8
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %76, label %12
+
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
+  br label %76
+
+; <label>:13                                      ; preds = %85
+  %14 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck19 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %15
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, i32 0, i32 0
+  %17 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %16, align 8
+  %NullCheck21 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, i32 0, i32 2
+  %20 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %19, align 8
+  %21 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck23 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %22
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, i32 0, i32 2
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %NullCheck25 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 3, i32 %24
+  %NullCheck27 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %32
+
+; <label>:32                                      ; preds = %30
+  %33 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, i32 0, i32 2
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = icmp slt i32 %34, 0
+  br i1 %35, label %68, label %36
+
+; <label>:36                                      ; preds = %32
+  %37 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %38 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck29 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %39
+
+; <label>:39                                      ; preds = %36
+  %40 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, i32 0, i32 0
+  %41 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %40, align 8
+  %NullCheck31 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, i32 0, i32 2
+  %44 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %43, align 8
+  %45 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck33 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, i32 0, i32 2
+  %48 = load i32, i32 addrspace(1)* %47, align 8
+  %NullCheck35 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %49
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = zext i32 %51 to i64
+  %53 = zext i32 %48 to i64
+  %BoundsCheck37 = icmp uge i64 %53, %52
+  br i1 %BoundsCheck37, label %ThrowIndexOutOfRange38, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 3, i32 %48
+  %NullCheck39 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %56
+
+; <label>:56                                      ; preds = %54
+  %57 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, i32 0, i32 0
+  %58 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck41 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %59
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %60, %System.__Canon addrspace(1)* %58)
+  %61 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck43 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  %64 = load i32, i32 addrspace(1)* %63, align 8
+  %65 = add i32 %64, 1
+  %NullCheck45 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  store i32 %65, i32 addrspace(1)* %67
+  ret i8 1
+
+; <label>:68                                      ; preds = %32
+  %69 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck47 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %73 = add i32 %72, 1
+  %NullCheck49 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %74
+
+; <label>:74                                      ; preds = %70
+  %75 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  store i32 %73, i32 addrspace(1)* %75
+  br label %76
+
+; <label>:76                                      ; preds = %8, %12, %74
+  %77 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %78
+
+; <label>:78                                      ; preds = %76
+  %79 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, i32 0, i32 2
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck7 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %82
+
+; <label>:82                                      ; preds = %78
+  %83 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, i32 0, i32 0
+  %84 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %83, align 8
+  %NullCheck9 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %85
+
+; <label>:85                                      ; preds = %82
+  %86 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, i32 0, i32 7
+  %87 = load i32, i32 addrspace(1)* %86, align 8
+  %88 = icmp ult i32 %80, %87
+  br i1 %88, label %13, label %89
+
+; <label>:89                                      ; preds = %85
+  %90 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %91 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck11 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %92
+
+; <label>:92                                      ; preds = %89
+  %93 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, i32 0, i32 0
+  %94 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck13 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %95
+
+; <label>:95                                      ; preds = %92
+  %96 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, i32 0, i32 7
+  %97 = load i32, i32 addrspace(1)* %96, align 8
+  %98 = add i32 %97, 1
+  %NullCheck15 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %99
+
+; <label>:99                                      ; preds = %95
+  %100 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, i32 0, i32 2
+  store i32 %98, i32 addrspace(1)* %100
+  %101 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck17 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %102
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %103, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %92
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef22:                                   ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef24:                                   ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef26:                                   ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef28:                                   ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef30:                                   ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef32:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef34:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef36:                                   ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange38:                           ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef40:                                   ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef42:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef44:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef46:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef48:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef50:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -5200,8 +6368,8 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -5232,9 +6400,9 @@ Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
 Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
-Failed to read String.MakeSeparatorList[loadElemA]
+Failed to read String.MakeSeparatorList[storeElem]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
-Failed to read String.InternalSplitKeepEmptyEntries[loadElem]
+Failed to read String.InternalSplitKeepEmptyEntries[storeElem]
 INFO:  jitting method Path::IsRelative using LLILCJit
 Successfully read Path.IsRelative
 
@@ -5243,8 +6411,8 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -5254,8 +6422,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
@@ -5271,8 +6439,8 @@ entry:
 
 ; <label>:17                                      ; preds = %7
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
@@ -5288,8 +6456,8 @@ entry:
 
 ; <label>:29                                      ; preds = %19
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %31
 
 ; <label>:31                                      ; preds = %29
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
@@ -5300,8 +6468,8 @@ entry:
 
 ; <label>:36                                      ; preds = %31
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
-  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %37, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
@@ -5312,8 +6480,8 @@ entry:
 
 ; <label>:43                                      ; preds = %31, %38
   %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
-  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %45
 
 ; <label>:45                                      ; preds = %43
   %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
@@ -5324,8 +6492,8 @@ entry:
 
 ; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %50
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
@@ -5336,8 +6504,8 @@ entry:
 
 ; <label>:57                                      ; preds = %1, %7, %19, %45, %52
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
-  br i1 %NullCheck14, label %59, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %59
 
 ; <label>:59                                      ; preds = %57
   %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
@@ -5347,8 +6515,8 @@ entry:
 
 ; <label>:63                                      ; preds = %59
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
@@ -5359,8 +6527,8 @@ entry:
 
 ; <label>:70                                      ; preds = %65
   %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
-  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.String addrspace(1)* %71, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %72
 
 ; <label>:72                                      ; preds = %70
   %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
@@ -5379,39 +6547,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %17
+ThrowNullRef4:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %29
+ThrowNullRef6:                                    ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %36
+ThrowNullRef8:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %43
+ThrowNullRef10:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %50
+ThrowNullRef12:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %57
+ThrowNullRef14:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %63
+ThrowNullRef16:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %70
+ThrowNullRef18:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5419,7 +6587,293 @@ ThrowNullRef17:                                   ; preds = %70
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
-Failed to read String.TrimHelper[loadElem]
+Successfully read String.TrimHelper
+
+define %System.String addrspace(1)* @String.TrimHelper(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i16
+  %loc4 = alloca i32
+  %loc5 = alloca i16
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = sub i32 %3, 1
+  store i32 %4, i32* %loc0
+  store i32 0, i32* %loc1
+  %5 = load i32, i32* %arg2
+  %6 = icmp eq i32 %5, 1
+  br i1 %6, label %62, label %7
+
+; <label>:7                                       ; preds = %1
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:8                                       ; preds = %58
+  store i32 0, i32* %loc2
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load i32, i32* %loc1
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2, i32 %10
+  %13 = load i16, i16 addrspace(1)* %12
+  %14 = zext i16 %13 to i32
+  %15 = trunc i32 %14 to i16
+  store i16 %15, i16* %loc3
+  store i32 0, i32* %loc2
+  br label %34
+
+; <label>:16                                      ; preds = %37
+  %17 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %18 = load i32, i32* %loc2
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %17, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %19
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = zext i32 %18 to i64
+  %BoundsCheck = icmp uge i64 %23, %22
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %24
+
+; <label>:24                                      ; preds = %19
+  %25 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 3, i32 %18
+  %26 = load i16, i16 addrspace(1)* %25, align 8
+  %27 = zext i16 %26 to i32
+  %28 = load i16, i16* %loc3
+  %29 = zext i16 %28 to i32
+  %30 = icmp eq i32 %27, %29
+  br i1 %30, label %43, label %31
+
+; <label>:31                                      ; preds = %24
+  %32 = load i32, i32* %loc2
+  %33 = add i32 %32, 1
+  store i32 %33, i32* %loc2
+  br label %34
+
+; <label>:34                                      ; preds = %11, %31
+  %35 = load i32, i32* %loc2
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = icmp slt i32 %35, %41
+  br i1 %42, label %16, label %43
+
+; <label>:43                                      ; preds = %24, %37
+  %44 = load i32, i32* %loc2
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %45, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp eq i32 %44, %50
+  br i1 %51, label %62, label %52
+
+; <label>:52                                      ; preds = %46
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %7, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %57, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %58
+
+; <label>:58                                      ; preds = %55
+  %59 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %60 = load i32, i32 addrspace(1)* %59
+  %61 = icmp slt i32 %56, %60
+  br i1 %61, label %8, label %62
+
+; <label>:62                                      ; preds = %1, %46, %58
+  %63 = load i32, i32* %arg2
+  %64 = icmp eq i32 %63, 0
+  br i1 %64, label %122, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %66, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %67
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %66, i32 0, i32 1
+  %69 = load i32, i32 addrspace(1)* %68
+  %70 = sub i32 %69, 1
+  store i32 %70, i32* %loc0
+  br label %118
+
+; <label>:71                                      ; preds = %118
+  store i32 0, i32* %loc4
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %73 = load i32, i32* %loc0
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %74
+
+; <label>:74                                      ; preds = %71
+  %75 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 2, i32 %73
+  %76 = load i16, i16 addrspace(1)* %75
+  %77 = zext i16 %76 to i32
+  %78 = trunc i32 %77 to i16
+  store i16 %78, i16* %loc5
+  store i32 0, i32* %loc4
+  br label %97
+
+; <label>:79                                      ; preds = %100
+  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %81 = load i32, i32* %loc4
+  %NullCheck19 = icmp eq %"System.Char[]" addrspace(1)* %80, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
+
+; <label>:82                                      ; preds = %79
+  %83 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 1
+  %84 = load i32, i32 addrspace(1)* %83
+  %85 = zext i32 %84 to i64
+  %86 = zext i32 %81 to i64
+  %BoundsCheck21 = icmp uge i64 %86, %85
+  br i1 %BoundsCheck21, label %ThrowIndexOutOfRange22, label %87
+
+; <label>:87                                      ; preds = %82
+  %88 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 3, i32 %81
+  %89 = load i16, i16 addrspace(1)* %88, align 8
+  %90 = zext i16 %89 to i32
+  %91 = load i16, i16* %loc5
+  %92 = zext i16 %91 to i32
+  %93 = icmp eq i32 %90, %92
+  br i1 %93, label %106, label %94
+
+; <label>:94                                      ; preds = %87
+  %95 = load i32, i32* %loc4
+  %96 = add i32 %95, 1
+  store i32 %96, i32* %loc4
+  br label %97
+
+; <label>:97                                      ; preds = %74, %94
+  %98 = load i32, i32* %loc4
+  %99 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck15 = icmp eq %"System.Char[]" addrspace(1)* %99, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %100
+
+; <label>:100                                     ; preds = %97
+  %101 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %99, i32 0, i32 1
+  %102 = load i32, i32 addrspace(1)* %101
+  %103 = zext i32 %102 to i64
+  %104 = trunc i64 %103 to i32
+  %105 = icmp slt i32 %98, %104
+  br i1 %105, label %79, label %106
+
+; <label>:106                                     ; preds = %87, %100
+  %107 = load i32, i32* %loc4
+  %108 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck17 = icmp eq %"System.Char[]" addrspace(1)* %108, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %109
+
+; <label>:109                                     ; preds = %106
+  %110 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %108, i32 0, i32 1
+  %111 = load i32, i32 addrspace(1)* %110
+  %112 = zext i32 %111 to i64
+  %113 = trunc i64 %112 to i32
+  %114 = icmp eq i32 %107, %113
+  br i1 %114, label %122, label %115
+
+; <label>:115                                     ; preds = %109
+  %116 = load i32, i32* %loc0
+  %117 = sub i32 %116, 1
+  store i32 %117, i32* %loc0
+  br label %118
+
+; <label>:118                                     ; preds = %67, %115
+  %119 = load i32, i32* %loc0
+  %120 = load i32, i32* %loc1
+  %121 = icmp sge i32 %119, %120
+  br i1 %121, label %71, label %122
+
+; <label>:122                                     ; preds = %62, %109, %118
+  %123 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %124 = load i32, i32* %loc1
+  %125 = load i32, i32* %loc0
+  %126 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %123, i32 %124, i32 %125)
+  ret %System.String addrspace(1)* %126
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %97
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange22:                           ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
 Successfully read String.CreateTrimmedString
 
@@ -5439,8 +6893,8 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
@@ -5535,8 +6989,8 @@ entry:
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i64 2872
   %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
   %8 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %7
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %3
   %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
@@ -5553,8 +7007,8 @@ entry:
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 2864
   %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
   %21 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %20
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
-  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %22
 
 ; <label>:22                                      ; preds = %16
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
@@ -5569,7 +7023,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %16
+ThrowNullRef2:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5586,8 +7040,8 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5613,8 +7067,8 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
@@ -5632,8 +7086,8 @@ entry:
 
 ; <label>:12                                      ; preds = %4
   %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
@@ -5644,8 +7098,8 @@ entry:
 
 ; <label>:19                                      ; preds = %14
   %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %19
   %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
@@ -5660,21 +7114,21 @@ entry:
   %31 = zext i16 %30 to i32
   %32 = bitcast i8* %29 to i16*
   %33 = trunc i32 %31 to i16
-  %NullCheck6 = icmp ne i16* %32, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i16* %32, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %21
   store i16 %33, i16* %32, align 8
   %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %36
 
 ; <label>:36                                      ; preds = %34
   %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
   %38 = load i32, i32 addrspace(1)* %37, align 8
   %39 = add i32 %38, 1
-  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %40
 
 ; <label>:40                                      ; preds = %36
   %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
@@ -5683,16 +7137,16 @@ entry:
 
 ; <label>:42                                      ; preds = %14
   %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
-  br i1 %NullCheck12, label %44, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
   %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
   %47 = load i16, i16* %arg1
   %48 = zext i16 %47 to i32
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = trunc i32 %48 to i16
@@ -5703,31 +7157,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %19
+ThrowNullRef4:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %21
+ThrowNullRef6:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %36
+ThrowNullRef10:                                   ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %42
+ThrowNullRef12:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %44
+ThrowNullRef14:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5740,8 +7194,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -5752,8 +7206,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
@@ -5762,14 +7216,14 @@ entry:
 
 ; <label>:11                                      ; preds = %1
   %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
@@ -5779,15 +7233,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5808,8 +7262,8 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5822,8 +7276,8 @@ entry:
 
 ; <label>:8                                       ; preds = %3
   %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
@@ -5842,15 +7296,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
-  br i1 %NullCheck4, label %22, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
   %24 = load i16*, i16* addrspace(1)* %23, align 8
   %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %25, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
@@ -5859,8 +7313,8 @@ entry:
   store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
@@ -5874,8 +7328,8 @@ entry:
 
 ; <label>:37                                      ; preds = %65
   %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %37
   %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
@@ -5886,16 +7340,16 @@ entry:
   %45 = bitcast i16* %41 to i8*
   %46 = getelementptr inbounds i8, i8* %45, i64 %44
   %47 = bitcast i8* %46 to i16*
-  %NullCheck14 = icmp ne i16* %47, null
-  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %47, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %48
 
 ; <label>:48                                      ; preds = %39
   %49 = load i16, i16* %47, align 8
   %50 = zext i16 %49 to i32
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %52 = load i32, i32* %loc1
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %53
 
 ; <label>:53                                      ; preds = %48
   %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
@@ -5916,8 +7370,8 @@ entry:
 ; <label>:62                                      ; preds = %36, %59
   %63 = load i32, i32* %loc1
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck10, label %65, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %65
 
 ; <label>:65                                      ; preds = %62
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
@@ -5936,15 +7390,15 @@ entry:
 
 ; <label>:74                                      ; preds = %70
   %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
-  br i1 %NullCheck18, label %76, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %76
 
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
   %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
-  br i1 %NullCheck20, label %80, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
   %81 = load i64, i64 addrspace(1)* %79
@@ -5958,8 +7412,8 @@ entry:
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
   %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
-  br i1 %NullCheck22, label %92, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.String addrspace(1)* %90, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %92
 
 ; <label>:92                                      ; preds = %80
   %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
@@ -5969,15 +7423,15 @@ entry:
 
 ; <label>:96                                      ; preds = %70
   %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
-  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %98
 
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
   %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
-  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
   %103 = load i64, i64 addrspace(1)* %101
@@ -5991,8 +7445,8 @@ entry:
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
   %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
-  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.String addrspace(1)* %112, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %114
 
 ; <label>:114                                     ; preds = %102
   %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
@@ -6004,59 +7458,59 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %20
+ThrowNullRef4:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %22
+ThrowNullRef6:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %26
+ThrowNullRef8:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %62
+ThrowNullRef10:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %48
+ThrowNullRef16:                                   ; preds = %48
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %74
+ThrowNullRef18:                                   ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %76
+ThrowNullRef20:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %80
+ThrowNullRef22:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %96
+ThrowNullRef24:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %98
+ThrowNullRef26:                                   ; preds = %98
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %102
+ThrowNullRef28:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6069,15 +7523,15 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
   %3 = load i16*, i16* addrspace(1)* %2, align 8
   %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
@@ -6087,8 +7541,8 @@ entry:
   %10 = bitcast i16* %3 to i8*
   %11 = getelementptr inbounds i8, i8* %10, i64 %9
   %12 = bitcast i8* %11 to i16*
-  %NullCheck4 = icmp ne i16* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %5
   store i16 0, i16* %12, align 8
@@ -6098,11 +7552,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6119,8 +7573,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -6131,8 +7585,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
@@ -6144,15 +7598,15 @@ entry:
 
 ; <label>:14                                      ; preds = %1
   %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
   %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
   %21 = load i64, i64 addrspace(1)* %19
@@ -6171,15 +7625,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %14
+ThrowNullRef4:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %16
+ThrowNullRef6:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6302,14 +7756,6 @@ entry:
   ret %System.String addrspace(1)* %57
 }
 
-INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
-Successfully read RuntimeHelpers.get_OffsetToStringData
-
-define i32 @RuntimeHelpers.get_OffsetToStringData() {
-entry:
-  ret i32 12
-}
-
 INFO:  jitting method String::Equals using LLILCJit
 Successfully read String.Equals
 
@@ -6381,8 +7827,8 @@ entry:
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
-  br i1 %NullCheck24, label %29, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
   %30 = load i64, i64 addrspace(1)* %28
@@ -6397,8 +7843,8 @@ entry:
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
-  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
   %43 = load i64, i64 addrspace(1)* %41
@@ -6418,8 +7864,8 @@ entry:
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
   %59 = load i64, i64 addrspace(1)* %57
@@ -6434,8 +7880,8 @@ entry:
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck22, label %71, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
   %72 = load i64, i64 addrspace(1)* %70
@@ -6455,8 +7901,8 @@ entry:
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
-  br i1 %NullCheck16, label %87, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = load i64, i64 addrspace(1)* %86
@@ -6471,8 +7917,8 @@ entry:
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck18, label %100, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
   %101 = load i64, i64 addrspace(1)* %99
@@ -6492,8 +7938,8 @@ entry:
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
-  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
   %117 = load i64, i64 addrspace(1)* %115
@@ -6508,8 +7954,8 @@ entry:
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
-  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
   %130 = load i64, i64 addrspace(1)* %128
@@ -6528,15 +7974,15 @@ entry:
 
 ; <label>:142                                     ; preds = %22
   %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
-  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %143, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %144
 
 ; <label>:144                                     ; preds = %142
   %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
   %146 = load i32, i32 addrspace(1)* %145
   %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
-  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %147, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %148
 
 ; <label>:148                                     ; preds = %144
   %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
@@ -6557,15 +8003,15 @@ entry:
 
 ; <label>:159                                     ; preds = %22
   %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
-  br i1 %NullCheck, label %161, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %ThrowNullRef, label %161
 
 ; <label>:161                                     ; preds = %159
   %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
   %163 = load i32, i32 addrspace(1)* %162
   %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
-  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %164, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %165
 
 ; <label>:165                                     ; preds = %161
   %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
@@ -6578,8 +8024,8 @@ entry:
 
 ; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
-  br i1 %NullCheck4, label %172, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %171, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %172
 
 ; <label>:172                                     ; preds = %170
   %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
@@ -6589,8 +8035,8 @@ entry:
 
 ; <label>:176                                     ; preds = %172
   %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
-  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %177, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %178
 
 ; <label>:178                                     ; preds = %176
   %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
@@ -6629,55 +8075,55 @@ ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %161
+ThrowNullRef2:                                    ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %170
+ThrowNullRef4:                                    ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %176
+ThrowNullRef6:                                    ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %142
+ThrowNullRef8:                                    ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %144
+ThrowNullRef10:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %113
+ThrowNullRef12:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %116
+ThrowNullRef14:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %84
+ThrowNullRef16:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %87
+ThrowNullRef18:                                   ; preds = %87
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %55
+ThrowNullRef20:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %58
+ThrowNullRef22:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %26
+ThrowNullRef24:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %29
+ThrowNullRef26:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,8 +8161,8 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck, label %14, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %ThrowNullRef, label %14
 
 ; <label>:14                                      ; preds = %8
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
@@ -6760,8 +8206,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
@@ -6770,14 +8216,14 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32, i32* %loc0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %10
   %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
   %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
@@ -6790,15 +8236,15 @@ entry:
 ; <label>:25                                      ; preds = %19
   %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
-  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
   %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
@@ -6807,8 +8253,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %37 = load i32, i32* %loc0
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %38, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %38
 
 ; <label>:38                                      ; preds = %32
   %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
@@ -6817,14 +8263,14 @@ entry:
 
 ; <label>:40                                      ; preds = %19
   %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %40
   %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
   %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
-  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
-  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
@@ -6832,8 +8278,8 @@ entry:
   %48 = zext i32 %47 to i64
   %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
-  br i1 %NullCheck16, label %51, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %51
 
 ; <label>:51                                      ; preds = %45
   %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
@@ -6847,15 +8293,15 @@ entry:
 ; <label>:57                                      ; preds = %51
   %58 = load i16*, i16** %arg1
   %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
-  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %60
 
 ; <label>:60                                      ; preds = %57
   %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
   %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
-  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %64
 
 ; <label>:64                                      ; preds = %60
   %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
@@ -6864,22 +8310,22 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
   %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
-  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %70
 
 ; <label>:70                                      ; preds = %64
   %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
   %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
-  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
-  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
   %75 = load i32, i32 addrspace(1)* %74
   %76 = zext i32 %75 to i64
   %77 = trunc i64 %76 to i32
-  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
-  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %78
 
 ; <label>:78                                      ; preds = %73
   %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
@@ -6901,8 +8347,8 @@ entry:
   %90 = bitcast i16* %86 to i8*
   %91 = getelementptr inbounds i8, i8* %90, i64 %89
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %93
 
 ; <label>:93                                      ; preds = %80
   %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
@@ -6912,8 +8358,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %99 = load i32, i32* %loc2
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %100
 
 ; <label>:100                                     ; preds = %93
   %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
@@ -6928,63 +8374,63 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %25
+ThrowNullRef6:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %32
+ThrowNullRef10:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %40
+ThrowNullRef12:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %45
+ThrowNullRef16:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %57
+ThrowNullRef18:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %60
+ThrowNullRef20:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %64
+ThrowNullRef22:                                   ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %70
+ThrowNullRef24:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %73
+ThrowNullRef26:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %80
+ThrowNullRef28:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %93
+ThrowNullRef30:                                   ; preds = %93
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7004,8 +8450,8 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
@@ -7033,43 +8479,43 @@ entry:
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %14
   %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
   %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   %28 = load i32, i32 addrspace(1)* %27, align 8
   %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
-  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %30
 
 ; <label>:30                                      ; preds = %26
   %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
   %32 = load i32, i32 addrspace(1)* %31, align 8
   %33 = add i32 %28, %32
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %34
 
 ; <label>:34                                      ; preds = %30
   %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   store i32 %33, i32 addrspace(1)* %35
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
   store i32 0, i32 addrspace(1)* %38
   %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %40
 
 ; <label>:40                                      ; preds = %37
   %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
@@ -7082,8 +8528,8 @@ entry:
 
 ; <label>:47                                      ; preds = %40
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
@@ -7098,8 +8544,8 @@ entry:
   %54 = load i32, i32* %loc0
   %55 = sext i32 %54 to i64
   %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
-  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %57
 
 ; <label>:57                                      ; preds = %52
   %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
@@ -7110,68 +8556,35 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %14
+ThrowNullRef2:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %23
+ThrowNullRef4:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %26
+ThrowNullRef6:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %30
+ThrowNullRef8:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %34
+ThrowNullRef10:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %47
+ThrowNullRef14:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %52
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-}
-
-INFO:  jitting method StringBuilder::get_Length using LLILCJit
-Successfully read StringBuilder.get_Length
-
-define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.StringBuilder addrspace(1)*
-  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
-  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
-
-; <label>:1                                       ; preds = %entry
-  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %3 = load i32, i32 addrspace(1)* %2, align 8
-  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
-
-; <label>:5                                       ; preds = %1
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = add i32 %3, %7
-  ret i32 %8
-
-ThrowNullRef:                                     ; preds = %entry
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef16:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7213,70 +8626,70 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
   %6 = load i32, i32 addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
   store i32 %6, i32 addrspace(1)* %8
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
   %13 = load i32, i32 addrspace(1)* %12, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
   store i32 %13, i32 addrspace(1)* %15
   %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
-  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %18
 
 ; <label>:18                                      ; preds = %14
   %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
   %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
   %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
   %34 = load i32, i32 addrspace(1)* %33, align 8
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
-  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
@@ -7287,39 +8700,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %28
+ThrowNullRef16:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %32
+ThrowNullRef18:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7455,13 +8868,13 @@ entry:
 ; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
@@ -7477,16 +8890,16 @@ entry:
 
 ; <label>:18                                      ; preds = %15
   %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
   store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
   %22 = load i32, i32* %loc0
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %24
 
 ; <label>:24                                      ; preds = %20
   %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
@@ -7498,13 +8911,13 @@ entry:
 ; <label>:28                                      ; preds = %15, %24
   %29 = load i32, i32* %arg1
   %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %31
   %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
@@ -7517,20 +8930,20 @@ entry:
   %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
-  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
   %46 = load i32, i32 addrspace(1)* %45, align 8
   %47 = sub i32 %40, %46
-  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
-  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i32 addrspace(1)* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %48
 
 ; <label>:48                                      ; preds = %44
   store i32 %47, i32 addrspace(1)* %39, align 8
@@ -7538,21 +8951,21 @@ entry:
 
 ; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
-  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %51
 
 ; <label>:51                                      ; preds = %49
   %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %53
 
 ; <label>:53                                      ; preds = %51
   %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
   %55 = load i32, i32 addrspace(1)* %54, align 8
   %56 = load i32, i32* %arg2
   %57 = sub i32 %55, %56
-  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %58
 
 ; <label>:58                                      ; preds = %53
   %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
@@ -7562,13 +8975,13 @@ entry:
 ; <label>:60                                      ; preds = %33, %58
   %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
   %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
-  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %63
 
 ; <label>:63                                      ; preds = %60
   %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
-  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
-  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
@@ -7578,15 +8991,15 @@ entry:
 
 ; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
-  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i32 addrspace(1)* %69, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %70
 
 ; <label>:70                                      ; preds = %68
   %71 = load i32, i32 addrspace(1)* %69, align 8
   store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
-  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
@@ -7596,8 +9009,8 @@ entry:
   store i32 %77, i32* %loc4
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
-  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %80
 
 ; <label>:80                                      ; preds = %73
   %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
@@ -7607,71 +9020,71 @@ entry:
 ; <label>:83                                      ; preds = %80
   store i32 0, i32* %loc3
   %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
-  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
-  br i1 %NullCheck26, label %88, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i32 addrspace(1)* %87, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %88
 
 ; <label>:88                                      ; preds = %85
   %89 = load i32, i32 addrspace(1)* %87, align 8
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
-  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %90
 
 ; <label>:90                                      ; preds = %88
   %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
   store i32 %89, i32 addrspace(1)* %91
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
-  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
-  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %96
 
 ; <label>:96                                      ; preds = %94
   %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
-  br i1 %NullCheck34, label %100, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %100
 
 ; <label>:100                                     ; preds = %96
   %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
-  br i1 %NullCheck36, label %102, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %102
 
 ; <label>:102                                     ; preds = %100
   %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
   %104 = load i32, i32 addrspace(1)* %103, align 8
   %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
-  br i1 %NullCheck38, label %106, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %106
 
 ; <label>:106                                     ; preds = %102
   %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
-  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
-  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %108
 
 ; <label>:108                                     ; preds = %106
   %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
   %110 = load i32, i32 addrspace(1)* %109, align 8
   %111 = add i32 %104, %110
-  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %112
 
 ; <label>:112                                     ; preds = %108
   %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
   store i32 %111, i32 addrspace(1)* %113
   %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
-  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i32 addrspace(1)* %114, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %115
 
 ; <label>:115                                     ; preds = %112
   %116 = load i32, i32 addrspace(1)* %114, align 8
@@ -7681,19 +9094,19 @@ entry:
 ; <label>:118                                     ; preds = %115
   %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
-  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %121
 
 ; <label>:121                                     ; preds = %118
   %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
-  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
-  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %123
 
 ; <label>:123                                     ; preds = %121
   %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
   %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
-  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
-  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %126
 
 ; <label>:126                                     ; preds = %123
   %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
@@ -7705,8 +9118,8 @@ entry:
 
 ; <label>:130                                     ; preds = %80, %115, %126
   %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %132
 
 ; <label>:132                                     ; preds = %130
   %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7715,8 +9128,8 @@ entry:
   %136 = load i32, i32* %loc3
   %137 = sub i32 %135, %136
   %138 = sub i32 %134, %137
-  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %139
 
 ; <label>:139                                     ; preds = %132
   %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7728,16 +9141,16 @@ entry:
 
 ; <label>:144                                     ; preds = %139
   %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
-  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %146
 
 ; <label>:146                                     ; preds = %144
   %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
   %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
   %149 = load i32, i32* %loc2
   %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
-  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %151
 
 ; <label>:151                                     ; preds = %146
   %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
@@ -7754,145 +9167,249 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %18
+ThrowNullRef4:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %31
+ThrowNullRef10:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %44
+ThrowNullRef16:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %68
+ThrowNullRef18:                                   ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %70
+ThrowNullRef20:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %73
+ThrowNullRef22:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %83
+ThrowNullRef24:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %85
+ThrowNullRef26:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %88
+ThrowNullRef28:                                   ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %90
+ThrowNullRef30:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %94
+ThrowNullRef32:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %96
+ThrowNullRef34:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %100
+ThrowNullRef36:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %102
+ThrowNullRef38:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %106
+ThrowNullRef40:                                   ; preds = %106
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %108
+ThrowNullRef42:                                   ; preds = %108
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %112
+ThrowNullRef44:                                   ; preds = %112
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %118
+ThrowNullRef46:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %121
+ThrowNullRef48:                                   ; preds = %121
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %123
+ThrowNullRef50:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %130
+ThrowNullRef52:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %132
+ThrowNullRef54:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %144
+ThrowNullRef56:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %146
+ThrowNullRef58:                                   ; preds = %146
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %60
+ThrowNullRef60:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %63
+ThrowNullRef62:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %49
+ThrowNullRef64:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %51
+ThrowNullRef66:                                   ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %53
+ThrowNullRef68:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(%"System.Char[]" addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %arg0 = alloca %"System.Char[]" addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store %"System.Char[]" addrspace(1)* %param0, %"System.Char[]" addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load i32, i32* %arg4
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %43, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %38, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg1
+  %13 = load i32, i32* %arg4
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %38, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %24 = load i32, i32* %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %35 = load i32, i32* %arg3
+  %36 = load i32, i32* %arg4
+  %37 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %37, %"System.Char[]" addrspace(1)* %34, i32 %35, i32 %36)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:38                                      ; preds = %5, %16
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Successfully read Buffer._Memmove
 
@@ -7914,7 +9431,7 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[loadElem]
+Failed to read AppDomain.SetDataHelper[storeElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -7923,8 +9440,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
@@ -7934,8 +9451,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
@@ -7947,15 +9464,15 @@ entry:
   %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
   %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
@@ -7966,15 +9483,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7992,7 +9509,79 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
-Failed to read Dictionary`2.TryGetValue[loadElemA]
+Successfully read Dictionary`2.TryGetValue
+
+define i8 @"Dictionary`2.TryGetValue"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)* addrspace(1)* %param2) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  %arg2 = alloca %System.__Canon addrspace(1)* addrspace(1)*
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  store %System.__Canon addrspace(1)* addrspace(1)* %param2, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  store i32 %2, i32* %loc0
+  %3 = load i32, i32* %loc0
+  %4 = icmp slt i32 %3, 0
+  br i1 %4, label %22, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 2
+  %10 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %9, align 8
+  %11 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = zext i32 %11 to i64
+  %BoundsCheck = icmp uge i64 %16, %15
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 3, i32 %11
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %20, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %6, %System.__Canon addrspace(1)* %21)
+  ret i8 1
+
+; <label>:22                                      ; preds = %entry
+  %23 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %23, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -8058,8 +9647,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
@@ -8091,8 +9680,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
@@ -8171,15 +9760,15 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck, label %19, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %ThrowNullRef, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
   %21 = load i32, i32 addrspace(1)* %20
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
@@ -8202,7 +9791,7 @@ ThrowNullRef:                                     ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %19
+ThrowNullRef2:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8248,8 +9837,8 @@ entry:
   %0 = alloca %System.AppDomainHandle
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %1 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %1, i32 0, i32 15
@@ -8269,8 +9858,8 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
@@ -8286,7 +9875,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -8299,8 +9888,8 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -8327,8 +9916,8 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
@@ -8352,8 +9941,8 @@ entry:
   %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
   store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
@@ -8363,8 +9952,8 @@ entry:
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
@@ -8374,8 +9963,8 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %9
   %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
@@ -8384,8 +9973,8 @@ entry:
 
 ; <label>:18                                      ; preds = %3, %16
   %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
@@ -8397,15 +9986,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %18
+ThrowNullRef6:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8418,8 +10007,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
@@ -8453,15 +10042,15 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
@@ -8473,7 +10062,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8481,7 +10070,7 @@ ThrowNullRef1:                                    ; preds = %1
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
 Failed to read Dictionary`2.System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
@@ -8506,8 +10095,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
@@ -8524,8 +10113,8 @@ entry:
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -8544,7 +10133,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8577,8 +10166,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = load i64, i64* %arg2
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = trunc i32 %3 to i8
@@ -8634,46 +10223,46 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
   %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
-  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
-  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
-  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
@@ -8684,27 +10273,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %20
+ThrowNullRef12:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8717,8 +10306,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -8756,22 +10345,22 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
   %9 = load i64, i64 addrspace(1)* %8, align 8
   %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
   %13 = load i64, i64 addrspace(1)* %12, align 8
   %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %11
   %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
@@ -8788,11 +10377,11 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8882,8 +10471,8 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
@@ -8900,8 +10489,8 @@ entry:
 ; <label>:8                                       ; preds = %1
   %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
   %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
@@ -8911,15 +10500,15 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
   %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
   %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
-  br i1 %NullCheck6, label %21, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
@@ -8946,15 +10535,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8992,15 +10581,15 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
   store i8 %3, i8 addrspace(1)* %5
   %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
@@ -9011,7 +10600,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9027,8 +10616,8 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -9041,8 +10630,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
@@ -9058,7 +10647,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9080,8 +10669,8 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
@@ -9096,8 +10685,8 @@ entry:
 ; <label>:12                                      ; preds = %6
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
@@ -9112,8 +10701,8 @@ entry:
 ; <label>:21                                      ; preds = %15
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
@@ -9128,8 +10717,8 @@ entry:
 ; <label>:30                                      ; preds = %24
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %31, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
@@ -9144,8 +10733,8 @@ entry:
 ; <label>:39                                      ; preds = %33
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
-  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %40, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %42
 
 ; <label>:42                                      ; preds = %39
   %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
@@ -9164,19 +10753,19 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %21
+ThrowNullRef4:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %30
+ThrowNullRef6:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %39
+ThrowNullRef8:                                    ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9243,8 +10832,8 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
@@ -9264,57 +10853,57 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
   store i8 0, i8 addrspace(1)* %2
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
   store i8 0, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
   store i8 0, i8 addrspace(1)* %17
   %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
   store i8 0, i8 addrspace(1)* %20
   %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
-  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
@@ -9325,31 +10914,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %19
+ThrowNullRef14:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9367,8 +10956,8 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
@@ -9380,8 +10969,8 @@ entry:
 
 ; <label>:9                                       ; preds = %4
   %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %9
   %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
@@ -9395,7 +10984,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef2:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9420,8 +11009,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
@@ -9512,8 +11101,8 @@ entry:
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
@@ -9524,8 +11113,8 @@ entry:
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = load i64, i64 addrspace(1)* %12
@@ -9537,8 +11126,8 @@ entry:
   %20 = load i64, i64* %19
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
-  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %13
   %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
@@ -9555,8 +11144,8 @@ entry:
 ; <label>:30                                      ; preds = %25
   %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %32 = load i32, i32* %arg2
-  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
-  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
@@ -9570,15 +11159,15 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %30
+ThrowNullRef2:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9622,87 +11211,87 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
   %10 = load i8, i8 addrspace(1)* %9, align 8
   %11 = zext i8 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %8
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
   store i8 %12, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
   %19 = load i8, i8 addrspace(1)* %18, align 8
   %20 = zext i8 %19 to i32
   %21 = trunc i32 %20 to i8
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
   store i8 %21, i8 addrspace(1)* %23
   %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
   %28 = load i8, i8 addrspace(1)* %27, align 8
   %29 = zext i8 %28 to i32
   %30 = trunc i32 %29 to i8
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
-  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %31
 
 ; <label>:31                                      ; preds = %26
   %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
   store i8 %30, i8 addrspace(1)* %32
   %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
-  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
-  br i1 %NullCheck14, label %40, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %40
 
 ; <label>:40                                      ; preds = %35
   %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
   store i8 %39, i8 addrspace(1)* %41
   %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
-  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %44
 
 ; <label>:44                                      ; preds = %40
   %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
   %46 = load i8, i8 addrspace(1)* %45, align 8
   %47 = zext i8 %46 to i32
   %48 = trunc i32 %47 to i8
-  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
   store i8 %48, i8 addrspace(1)* %50
   %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
-  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
@@ -9713,29 +11302,29 @@ entry:
 ; <label>:56                                      ; preds = %52
   %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
-  br i1 %NullCheck22, label %59, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
   %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
   %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
-  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
-  br i1 %NullCheck24, label %63, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
   %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
-  br i1 %NullCheck26, label %66, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
   %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
-  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
-  br i1 %NullCheck28, label %69, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %69
 
 ; <label>:69                                      ; preds = %66
   %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
@@ -9744,15 +11333,15 @@ entry:
 
 ; <label>:71                                      ; preds = %105
   %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
-  br i1 %NullCheck34, label %73, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %73
 
 ; <label>:73                                      ; preds = %71
   %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
   %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
   %76 = load i32, i32* %loc0
-  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
-  br i1 %NullCheck36, label %77, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
@@ -9766,8 +11355,8 @@ entry:
 
 ; <label>:83                                      ; preds = %77
   %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
-  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
@@ -9775,14 +11364,14 @@ entry:
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
   %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
-  br i1 %NullCheck40, label %91, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
 ; <label>:91                                      ; preds = %85
   %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
   %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
-  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck42, label %94, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %94
 
 ; <label>:94                                      ; preds = %91
   %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
@@ -9798,14 +11387,14 @@ entry:
 ; <label>:99                                      ; preds = %69, %96
   %100 = load i32, i32* %loc0
   %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
-  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %102
 
 ; <label>:102                                     ; preds = %99
   %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
   %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
-  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
-  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
@@ -9819,87 +11408,87 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %26
+ThrowNullRef10:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %31
+ThrowNullRef12:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %35
+ThrowNullRef14:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %40
+ThrowNullRef16:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %56
+ThrowNullRef22:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %59
+ThrowNullRef24:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %63
+ThrowNullRef26:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %66
+ThrowNullRef28:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %102
+ThrowNullRef32:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %71
+ThrowNullRef34:                                   ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %73
+ThrowNullRef36:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %83
+ThrowNullRef38:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %85
+ThrowNullRef40:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %91
+ThrowNullRef42:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9943,15 +11532,15 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
   %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
@@ -9961,28 +11550,28 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
   %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %12
   %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
   %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
   %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
-  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
@@ -9993,23 +11582,23 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %12
+ThrowNullRef6:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10031,15 +11620,15 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
   %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = load i64, i64 addrspace(1)* %7
@@ -10077,13 +11666,13 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[loadElem]
+Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -10111,8 +11700,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueLtDbl.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueLtDbl.error.txt
@@ -25,8 +25,8 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
@@ -40,8 +40,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
   %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
@@ -75,7 +75,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -90,8 +90,8 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %NullCheck = icmp ne i8 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = load i8, i8 addrspace(1)* %0, align 8
@@ -125,8 +125,8 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
@@ -159,8 +159,8 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -184,8 +184,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
   store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
@@ -195,8 +195,8 @@ entry:
 ; <label>:4                                       ; preds = %1
   %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
   %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
@@ -206,8 +206,8 @@ entry:
   %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
@@ -221,14 +221,14 @@ entry:
 
 ; <label>:17                                      ; preds = %14
   %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
   %21 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
@@ -238,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -249,8 +249,8 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
@@ -261,27 +261,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %30
+ThrowNullRef10:                                   ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -301,7 +301,89 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
-Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
+Successfully read AppDomainSetup.GetUnsecureApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.GetUnsecureApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %NullCheck = icmp eq %"System.String[]" addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %BoundsCheck = icmp uge i64 0, %5
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %6
+
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 3, i32 0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
+  ret %System.String addrspace(1)* %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_Value using LLILCJit
+Successfully read AppDomainSetup.get_Value
+
+define %"System.String[]" addrspace(1)* @AppDomainSetup.get_Value(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.String[]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 18)
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.String[]" addrspace(1)* addrspace(1)*, %"System.String[]" addrspace(1)*)*)(%"System.String[]" addrspace(1)* addrspace(1)* %9, %"System.String[]" addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %11, i32 0, i32 1
+  %14 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %13, align 8
+  ret %"System.String[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -319,8 +401,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -368,16 +450,16 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
   %5 = load i32, i32 addrspace(1)* %4
   %6 = sub i32 %5, 1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -389,7 +471,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -421,8 +503,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
@@ -456,8 +538,8 @@ entry:
 ; <label>:27                                      ; preds = %19
   %28 = load i32, i32* %arg1
   %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
-  br i1 %NullCheck2, label %30, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %29, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %30
 
 ; <label>:30                                      ; preds = %27
   %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
@@ -493,8 +575,8 @@ entry:
 ; <label>:49                                      ; preds = %46
   %50 = load i32, i32* %arg2
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck4, label %52, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
@@ -517,11 +599,11 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %27
+ThrowNullRef2:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %49
+ThrowNullRef4:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -544,16 +626,16 @@ entry:
   %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %0)
   store %System.String addrspace(1)* %1, %System.String addrspace(1)** %loc0
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 2
   %5 = bitcast [0 x i16] addrspace(1)* %4 to i16 addrspace(1)*
   store i16 addrspace(1)* %5, i16 addrspace(1)** %loc1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %3
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2
@@ -580,7 +662,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -691,15 +773,15 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %NullCheck132 = icmp ne i8* %21, null
-  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+  %NullCheck131 = icmp eq i8* %21, null
+  br i1 %NullCheck131, label %ThrowNullRef132, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = load i8, i8* %21, align 8
   %24 = zext i8 %23 to i32
   %25 = trunc i32 %24 to i8
-  %NullCheck134 = icmp ne i8* %20, null
-  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+  %NullCheck133 = icmp eq i8* %20, null
+  br i1 %NullCheck133, label %ThrowNullRef134, label %26
 
 ; <label>:26                                      ; preds = %22
   store i8 %25, i8* %20, align 8
@@ -709,16 +791,16 @@ entry:
   %28 = load i8*, i8** %arg0
   %29 = load i8*, i8** %arg1
   %30 = bitcast i8* %29 to i16*
-  %NullCheck128 = icmp ne i16* %30, null
-  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+  %NullCheck127 = icmp eq i16* %30, null
+  br i1 %NullCheck127, label %ThrowNullRef128, label %31
 
 ; <label>:31                                      ; preds = %27
   %32 = load i16, i16* %30, align 8
   %33 = sext i16 %32 to i32
   %34 = bitcast i8* %28 to i16*
   %35 = trunc i32 %33 to i16
-  %NullCheck130 = icmp ne i16* %34, null
-  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+  %NullCheck129 = icmp eq i16* %34, null
+  br i1 %NullCheck129, label %ThrowNullRef130, label %36
 
 ; <label>:36                                      ; preds = %31
   store i16 %35, i16* %34, align 8
@@ -728,16 +810,16 @@ entry:
   %38 = load i8*, i8** %arg0
   %39 = load i8*, i8** %arg1
   %40 = bitcast i8* %39 to i16*
-  %NullCheck120 = icmp ne i16* %40, null
-  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+  %NullCheck119 = icmp eq i16* %40, null
+  br i1 %NullCheck119, label %ThrowNullRef120, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i16, i16* %40, align 8
   %43 = sext i16 %42 to i32
   %44 = bitcast i8* %38 to i16*
   %45 = trunc i32 %43 to i16
-  %NullCheck122 = icmp ne i16* %44, null
-  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+  %NullCheck121 = icmp eq i16* %44, null
+  br i1 %NullCheck121, label %ThrowNullRef122, label %46
 
 ; <label>:46                                      ; preds = %41
   store i16 %45, i16* %44, align 8
@@ -745,15 +827,15 @@ entry:
   %48 = getelementptr inbounds i8, i8* %47, i64 2
   %49 = load i8*, i8** %arg1
   %50 = getelementptr inbounds i8, i8* %49, i64 2
-  %NullCheck124 = icmp ne i8* %50, null
-  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+  %NullCheck123 = icmp eq i8* %50, null
+  br i1 %NullCheck123, label %ThrowNullRef124, label %51
 
 ; <label>:51                                      ; preds = %46
   %52 = load i8, i8* %50, align 8
   %53 = zext i8 %52 to i32
   %54 = trunc i32 %53 to i8
-  %NullCheck126 = icmp ne i8* %48, null
-  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+  %NullCheck125 = icmp eq i8* %48, null
+  br i1 %NullCheck125, label %ThrowNullRef126, label %55
 
 ; <label>:55                                      ; preds = %51
   store i8 %54, i8* %48, align 8
@@ -763,14 +845,14 @@ entry:
   %57 = load i8*, i8** %arg0
   %58 = load i8*, i8** %arg1
   %59 = bitcast i8* %58 to i32*
-  %NullCheck116 = icmp ne i32* %59, null
-  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+  %NullCheck115 = icmp eq i32* %59, null
+  br i1 %NullCheck115, label %ThrowNullRef116, label %60
 
 ; <label>:60                                      ; preds = %56
   %61 = load i32, i32* %59, align 8
   %62 = bitcast i8* %57 to i32*
-  %NullCheck118 = icmp ne i32* %62, null
-  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+  %NullCheck117 = icmp eq i32* %62, null
+  br i1 %NullCheck117, label %ThrowNullRef118, label %63
 
 ; <label>:63                                      ; preds = %60
   store i32 %61, i32* %62, align 8
@@ -780,14 +862,14 @@ entry:
   %65 = load i8*, i8** %arg0
   %66 = load i8*, i8** %arg1
   %67 = bitcast i8* %66 to i32*
-  %NullCheck108 = icmp ne i32* %67, null
-  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+  %NullCheck107 = icmp eq i32* %67, null
+  br i1 %NullCheck107, label %ThrowNullRef108, label %68
 
 ; <label>:68                                      ; preds = %64
   %69 = load i32, i32* %67, align 8
   %70 = bitcast i8* %65 to i32*
-  %NullCheck110 = icmp ne i32* %70, null
-  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+  %NullCheck109 = icmp eq i32* %70, null
+  br i1 %NullCheck109, label %ThrowNullRef110, label %71
 
 ; <label>:71                                      ; preds = %68
   store i32 %69, i32* %70, align 8
@@ -795,15 +877,15 @@ entry:
   %73 = getelementptr inbounds i8, i8* %72, i64 4
   %74 = load i8*, i8** %arg1
   %75 = getelementptr inbounds i8, i8* %74, i64 4
-  %NullCheck112 = icmp ne i8* %75, null
-  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+  %NullCheck111 = icmp eq i8* %75, null
+  br i1 %NullCheck111, label %ThrowNullRef112, label %76
 
 ; <label>:76                                      ; preds = %71
   %77 = load i8, i8* %75, align 8
   %78 = zext i8 %77 to i32
   %79 = trunc i32 %78 to i8
-  %NullCheck114 = icmp ne i8* %73, null
-  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+  %NullCheck113 = icmp eq i8* %73, null
+  br i1 %NullCheck113, label %ThrowNullRef114, label %80
 
 ; <label>:80                                      ; preds = %76
   store i8 %79, i8* %73, align 8
@@ -813,14 +895,14 @@ entry:
   %82 = load i8*, i8** %arg0
   %83 = load i8*, i8** %arg1
   %84 = bitcast i8* %83 to i32*
-  %NullCheck100 = icmp ne i32* %84, null
-  br i1 %NullCheck100, label %85, label %ThrowNullRef99
+  %NullCheck99 = icmp eq i32* %84, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %85
 
 ; <label>:85                                      ; preds = %81
   %86 = load i32, i32* %84, align 8
   %87 = bitcast i8* %82 to i32*
-  %NullCheck102 = icmp ne i32* %87, null
-  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+  %NullCheck101 = icmp eq i32* %87, null
+  br i1 %NullCheck101, label %ThrowNullRef102, label %88
 
 ; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
@@ -829,16 +911,16 @@ entry:
   %91 = load i8*, i8** %arg1
   %92 = getelementptr inbounds i8, i8* %91, i64 4
   %93 = bitcast i8* %92 to i16*
-  %NullCheck104 = icmp ne i16* %93, null
-  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+  %NullCheck103 = icmp eq i16* %93, null
+  br i1 %NullCheck103, label %ThrowNullRef104, label %94
 
 ; <label>:94                                      ; preds = %88
   %95 = load i16, i16* %93, align 8
   %96 = sext i16 %95 to i32
   %97 = bitcast i8* %90 to i16*
   %98 = trunc i32 %96 to i16
-  %NullCheck106 = icmp ne i16* %97, null
-  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+  %NullCheck105 = icmp eq i16* %97, null
+  br i1 %NullCheck105, label %ThrowNullRef106, label %99
 
 ; <label>:99                                      ; preds = %94
   store i16 %98, i16* %97, align 8
@@ -848,14 +930,14 @@ entry:
   %101 = load i8*, i8** %arg0
   %102 = load i8*, i8** %arg1
   %103 = bitcast i8* %102 to i32*
-  %NullCheck88 = icmp ne i32* %103, null
-  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+  %NullCheck87 = icmp eq i32* %103, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %104
 
 ; <label>:104                                     ; preds = %100
   %105 = load i32, i32* %103, align 8
   %106 = bitcast i8* %101 to i32*
-  %NullCheck90 = icmp ne i32* %106, null
-  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+  %NullCheck89 = icmp eq i32* %106, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %107
 
 ; <label>:107                                     ; preds = %104
   store i32 %105, i32* %106, align 8
@@ -864,16 +946,16 @@ entry:
   %110 = load i8*, i8** %arg1
   %111 = getelementptr inbounds i8, i8* %110, i64 4
   %112 = bitcast i8* %111 to i16*
-  %NullCheck92 = icmp ne i16* %112, null
-  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+  %NullCheck91 = icmp eq i16* %112, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %113
 
 ; <label>:113                                     ; preds = %107
   %114 = load i16, i16* %112, align 8
   %115 = sext i16 %114 to i32
   %116 = bitcast i8* %109 to i16*
   %117 = trunc i32 %115 to i16
-  %NullCheck94 = icmp ne i16* %116, null
-  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+  %NullCheck93 = icmp eq i16* %116, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %118
 
 ; <label>:118                                     ; preds = %113
   store i16 %117, i16* %116, align 8
@@ -881,15 +963,15 @@ entry:
   %120 = getelementptr inbounds i8, i8* %119, i64 6
   %121 = load i8*, i8** %arg1
   %122 = getelementptr inbounds i8, i8* %121, i64 6
-  %NullCheck96 = icmp ne i8* %122, null
-  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+  %NullCheck95 = icmp eq i8* %122, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %123
 
 ; <label>:123                                     ; preds = %118
   %124 = load i8, i8* %122, align 8
   %125 = zext i8 %124 to i32
   %126 = trunc i32 %125 to i8
-  %NullCheck98 = icmp ne i8* %120, null
-  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+  %NullCheck97 = icmp eq i8* %120, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %127
 
 ; <label>:127                                     ; preds = %123
   store i8 %126, i8* %120, align 8
@@ -899,14 +981,14 @@ entry:
   %129 = load i8*, i8** %arg0
   %130 = load i8*, i8** %arg1
   %131 = bitcast i8* %130 to i64*
-  %NullCheck84 = icmp ne i64* %131, null
-  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+  %NullCheck83 = icmp eq i64* %131, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %132
 
 ; <label>:132                                     ; preds = %128
   %133 = load i64, i64* %131, align 8
   %134 = bitcast i8* %129 to i64*
-  %NullCheck86 = icmp ne i64* %134, null
-  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+  %NullCheck85 = icmp eq i64* %134, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %135
 
 ; <label>:135                                     ; preds = %132
   store i64 %133, i64* %134, align 8
@@ -916,14 +998,14 @@ entry:
   %137 = load i8*, i8** %arg0
   %138 = load i8*, i8** %arg1
   %139 = bitcast i8* %138 to i64*
-  %NullCheck76 = icmp ne i64* %139, null
-  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+  %NullCheck75 = icmp eq i64* %139, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %140
 
 ; <label>:140                                     ; preds = %136
   %141 = load i64, i64* %139, align 8
   %142 = bitcast i8* %137 to i64*
-  %NullCheck78 = icmp ne i64* %142, null
-  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+  %NullCheck77 = icmp eq i64* %142, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %143
 
 ; <label>:143                                     ; preds = %140
   store i64 %141, i64* %142, align 8
@@ -931,15 +1013,15 @@ entry:
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %NullCheck80 = icmp ne i8* %147, null
-  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+  %NullCheck79 = icmp eq i8* %147, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %148
 
 ; <label>:148                                     ; preds = %143
   %149 = load i8, i8* %147, align 8
   %150 = zext i8 %149 to i32
   %151 = trunc i32 %150 to i8
-  %NullCheck82 = icmp ne i8* %145, null
-  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+  %NullCheck81 = icmp eq i8* %145, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %152
 
 ; <label>:152                                     ; preds = %148
   store i8 %151, i8* %145, align 8
@@ -949,14 +1031,14 @@ entry:
   %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
   %156 = bitcast i8* %155 to i64*
-  %NullCheck68 = icmp ne i64* %156, null
-  br i1 %NullCheck68, label %157, label %ThrowNullRef67
+  %NullCheck67 = icmp eq i64* %156, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %157
 
 ; <label>:157                                     ; preds = %153
   %158 = load i64, i64* %156, align 8
   %159 = bitcast i8* %154 to i64*
-  %NullCheck70 = icmp ne i64* %159, null
-  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+  %NullCheck69 = icmp eq i64* %159, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %160
 
 ; <label>:160                                     ; preds = %157
   store i64 %158, i64* %159, align 8
@@ -965,16 +1047,16 @@ entry:
   %163 = load i8*, i8** %arg1
   %164 = getelementptr inbounds i8, i8* %163, i64 8
   %165 = bitcast i8* %164 to i16*
-  %NullCheck72 = icmp ne i16* %165, null
-  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+  %NullCheck71 = icmp eq i16* %165, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %166
 
 ; <label>:166                                     ; preds = %160
   %167 = load i16, i16* %165, align 8
   %168 = sext i16 %167 to i32
   %169 = bitcast i8* %162 to i16*
   %170 = trunc i32 %168 to i16
-  %NullCheck74 = icmp ne i16* %169, null
-  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+  %NullCheck73 = icmp eq i16* %169, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %171
 
 ; <label>:171                                     ; preds = %166
   store i16 %170, i16* %169, align 8
@@ -984,14 +1066,14 @@ entry:
   %173 = load i8*, i8** %arg0
   %174 = load i8*, i8** %arg1
   %175 = bitcast i8* %174 to i64*
-  %NullCheck56 = icmp ne i64* %175, null
-  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+  %NullCheck55 = icmp eq i64* %175, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %176
 
 ; <label>:176                                     ; preds = %172
   %177 = load i64, i64* %175, align 8
   %178 = bitcast i8* %173 to i64*
-  %NullCheck58 = icmp ne i64* %178, null
-  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+  %NullCheck57 = icmp eq i64* %178, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %179
 
 ; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
@@ -1000,16 +1082,16 @@ entry:
   %182 = load i8*, i8** %arg1
   %183 = getelementptr inbounds i8, i8* %182, i64 8
   %184 = bitcast i8* %183 to i16*
-  %NullCheck60 = icmp ne i16* %184, null
-  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+  %NullCheck59 = icmp eq i16* %184, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %185
 
 ; <label>:185                                     ; preds = %179
   %186 = load i16, i16* %184, align 8
   %187 = sext i16 %186 to i32
   %188 = bitcast i8* %181 to i16*
   %189 = trunc i32 %187 to i16
-  %NullCheck62 = icmp ne i16* %188, null
-  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+  %NullCheck61 = icmp eq i16* %188, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %190
 
 ; <label>:190                                     ; preds = %185
   store i16 %189, i16* %188, align 8
@@ -1017,15 +1099,15 @@ entry:
   %192 = getelementptr inbounds i8, i8* %191, i64 10
   %193 = load i8*, i8** %arg1
   %194 = getelementptr inbounds i8, i8* %193, i64 10
-  %NullCheck64 = icmp ne i8* %194, null
-  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+  %NullCheck63 = icmp eq i8* %194, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %195
 
 ; <label>:195                                     ; preds = %190
   %196 = load i8, i8* %194, align 8
   %197 = zext i8 %196 to i32
   %198 = trunc i32 %197 to i8
-  %NullCheck66 = icmp ne i8* %192, null
-  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+  %NullCheck65 = icmp eq i8* %192, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %199
 
 ; <label>:199                                     ; preds = %195
   store i8 %198, i8* %192, align 8
@@ -1035,14 +1117,14 @@ entry:
   %201 = load i8*, i8** %arg0
   %202 = load i8*, i8** %arg1
   %203 = bitcast i8* %202 to i64*
-  %NullCheck48 = icmp ne i64* %203, null
-  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+  %NullCheck47 = icmp eq i64* %203, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %204
 
 ; <label>:204                                     ; preds = %200
   %205 = load i64, i64* %203, align 8
   %206 = bitcast i8* %201 to i64*
-  %NullCheck50 = icmp ne i64* %206, null
-  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+  %NullCheck49 = icmp eq i64* %206, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %207
 
 ; <label>:207                                     ; preds = %204
   store i64 %205, i64* %206, align 8
@@ -1051,14 +1133,14 @@ entry:
   %210 = load i8*, i8** %arg1
   %211 = getelementptr inbounds i8, i8* %210, i64 8
   %212 = bitcast i8* %211 to i32*
-  %NullCheck52 = icmp ne i32* %212, null
-  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+  %NullCheck51 = icmp eq i32* %212, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %213
 
 ; <label>:213                                     ; preds = %207
   %214 = load i32, i32* %212, align 8
   %215 = bitcast i8* %209 to i32*
-  %NullCheck54 = icmp ne i32* %215, null
-  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+  %NullCheck53 = icmp eq i32* %215, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %216
 
 ; <label>:216                                     ; preds = %213
   store i32 %214, i32* %215, align 8
@@ -1068,14 +1150,14 @@ entry:
   %218 = load i8*, i8** %arg0
   %219 = load i8*, i8** %arg1
   %220 = bitcast i8* %219 to i64*
-  %NullCheck36 = icmp ne i64* %220, null
-  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64* %220, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %221
 
 ; <label>:221                                     ; preds = %217
   %222 = load i64, i64* %220, align 8
   %223 = bitcast i8* %218 to i64*
-  %NullCheck38 = icmp ne i64* %223, null
-  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+  %NullCheck37 = icmp eq i64* %223, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %224
 
 ; <label>:224                                     ; preds = %221
   store i64 %222, i64* %223, align 8
@@ -1084,14 +1166,14 @@ entry:
   %227 = load i8*, i8** %arg1
   %228 = getelementptr inbounds i8, i8* %227, i64 8
   %229 = bitcast i8* %228 to i32*
-  %NullCheck40 = icmp ne i32* %229, null
-  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i32* %229, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %230
 
 ; <label>:230                                     ; preds = %224
   %231 = load i32, i32* %229, align 8
   %232 = bitcast i8* %226 to i32*
-  %NullCheck42 = icmp ne i32* %232, null
-  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+  %NullCheck41 = icmp eq i32* %232, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %233
 
 ; <label>:233                                     ; preds = %230
   store i32 %231, i32* %232, align 8
@@ -1099,15 +1181,15 @@ entry:
   %235 = getelementptr inbounds i8, i8* %234, i64 12
   %236 = load i8*, i8** %arg1
   %237 = getelementptr inbounds i8, i8* %236, i64 12
-  %NullCheck44 = icmp ne i8* %237, null
-  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i8* %237, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %238
 
 ; <label>:238                                     ; preds = %233
   %239 = load i8, i8* %237, align 8
   %240 = zext i8 %239 to i32
   %241 = trunc i32 %240 to i8
-  %NullCheck46 = icmp ne i8* %235, null
-  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+  %NullCheck45 = icmp eq i8* %235, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %242
 
 ; <label>:242                                     ; preds = %238
   store i8 %241, i8* %235, align 8
@@ -1117,14 +1199,14 @@ entry:
   %244 = load i8*, i8** %arg0
   %245 = load i8*, i8** %arg1
   %246 = bitcast i8* %245 to i64*
-  %NullCheck24 = icmp ne i64* %246, null
-  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64* %246, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %247
 
 ; <label>:247                                     ; preds = %243
   %248 = load i64, i64* %246, align 8
   %249 = bitcast i8* %244 to i64*
-  %NullCheck26 = icmp ne i64* %249, null
-  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64* %249, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %250
 
 ; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
@@ -1133,14 +1215,14 @@ entry:
   %253 = load i8*, i8** %arg1
   %254 = getelementptr inbounds i8, i8* %253, i64 8
   %255 = bitcast i8* %254 to i32*
-  %NullCheck28 = icmp ne i32* %255, null
-  br i1 %NullCheck28, label %256, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i32* %255, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %256
 
 ; <label>:256                                     ; preds = %250
   %257 = load i32, i32* %255, align 8
   %258 = bitcast i8* %252 to i32*
-  %NullCheck30 = icmp ne i32* %258, null
-  br i1 %NullCheck30, label %259, label %ThrowNullRef29
+  %NullCheck29 = icmp eq i32* %258, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %259
 
 ; <label>:259                                     ; preds = %256
   store i32 %257, i32* %258, align 8
@@ -1149,16 +1231,16 @@ entry:
   %262 = load i8*, i8** %arg1
   %263 = getelementptr inbounds i8, i8* %262, i64 12
   %264 = bitcast i8* %263 to i16*
-  %NullCheck32 = icmp ne i16* %264, null
-  br i1 %NullCheck32, label %265, label %ThrowNullRef31
+  %NullCheck31 = icmp eq i16* %264, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %265
 
 ; <label>:265                                     ; preds = %259
   %266 = load i16, i16* %264, align 8
   %267 = sext i16 %266 to i32
   %268 = bitcast i8* %261 to i16*
   %269 = trunc i32 %267 to i16
-  %NullCheck34 = icmp ne i16* %268, null
-  br i1 %NullCheck34, label %270, label %ThrowNullRef33
+  %NullCheck33 = icmp eq i16* %268, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %270
 
 ; <label>:270                                     ; preds = %265
   store i16 %269, i16* %268, align 8
@@ -1168,14 +1250,14 @@ entry:
   %272 = load i8*, i8** %arg0
   %273 = load i8*, i8** %arg1
   %274 = bitcast i8* %273 to i64*
-  %NullCheck8 = icmp ne i64* %274, null
-  br i1 %NullCheck8, label %275, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64* %274, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %275
 
 ; <label>:275                                     ; preds = %271
   %276 = load i64, i64* %274, align 8
   %277 = bitcast i8* %272 to i64*
-  %NullCheck10 = icmp ne i64* %277, null
-  br i1 %NullCheck10, label %278, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %277, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %278
 
 ; <label>:278                                     ; preds = %275
   store i64 %276, i64* %277, align 8
@@ -1184,14 +1266,14 @@ entry:
   %281 = load i8*, i8** %arg1
   %282 = getelementptr inbounds i8, i8* %281, i64 8
   %283 = bitcast i8* %282 to i32*
-  %NullCheck12 = icmp ne i32* %283, null
-  br i1 %NullCheck12, label %284, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i32* %283, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %284
 
 ; <label>:284                                     ; preds = %278
   %285 = load i32, i32* %283, align 8
   %286 = bitcast i8* %280 to i32*
-  %NullCheck14 = icmp ne i32* %286, null
-  br i1 %NullCheck14, label %287, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i32* %286, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %287
 
 ; <label>:287                                     ; preds = %284
   store i32 %285, i32* %286, align 8
@@ -1200,16 +1282,16 @@ entry:
   %290 = load i8*, i8** %arg1
   %291 = getelementptr inbounds i8, i8* %290, i64 12
   %292 = bitcast i8* %291 to i16*
-  %NullCheck16 = icmp ne i16* %292, null
-  br i1 %NullCheck16, label %293, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i16* %292, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %293
 
 ; <label>:293                                     ; preds = %287
   %294 = load i16, i16* %292, align 8
   %295 = sext i16 %294 to i32
   %296 = bitcast i8* %289 to i16*
   %297 = trunc i32 %295 to i16
-  %NullCheck18 = icmp ne i16* %296, null
-  br i1 %NullCheck18, label %298, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i16* %296, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %298
 
 ; <label>:298                                     ; preds = %293
   store i16 %297, i16* %296, align 8
@@ -1217,15 +1299,15 @@ entry:
   %300 = getelementptr inbounds i8, i8* %299, i64 14
   %301 = load i8*, i8** %arg1
   %302 = getelementptr inbounds i8, i8* %301, i64 14
-  %NullCheck20 = icmp ne i8* %302, null
-  br i1 %NullCheck20, label %303, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i8* %302, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %303
 
 ; <label>:303                                     ; preds = %298
   %304 = load i8, i8* %302, align 8
   %305 = zext i8 %304 to i32
   %306 = trunc i32 %305 to i8
-  %NullCheck22 = icmp ne i8* %300, null
-  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i8* %300, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %307
 
 ; <label>:307                                     ; preds = %303
   store i8 %306, i8* %300, align 8
@@ -1235,14 +1317,14 @@ entry:
   %309 = load i8*, i8** %arg0
   %310 = load i8*, i8** %arg1
   %311 = bitcast i8* %310 to i64*
-  %NullCheck = icmp ne i64* %311, null
-  br i1 %NullCheck, label %312, label %ThrowNullRef
+  %NullCheck = icmp eq i64* %311, null
+  br i1 %NullCheck, label %ThrowNullRef, label %312
 
 ; <label>:312                                     ; preds = %308
   %313 = load i64, i64* %311, align 8
   %314 = bitcast i8* %309 to i64*
-  %NullCheck2 = icmp ne i64* %314, null
-  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64* %314, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %315
 
 ; <label>:315                                     ; preds = %312
   store i64 %313, i64* %314, align 8
@@ -1251,14 +1333,14 @@ entry:
   %318 = load i8*, i8** %arg1
   %319 = getelementptr inbounds i8, i8* %318, i64 8
   %320 = bitcast i8* %319 to i64*
-  %NullCheck4 = icmp ne i64* %320, null
-  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64* %320, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %321
 
 ; <label>:321                                     ; preds = %315
   %322 = load i64, i64* %320, align 8
   %323 = bitcast i8* %317 to i64*
-  %NullCheck6 = icmp ne i64* %323, null
-  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64* %323, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %324
 
 ; <label>:324                                     ; preds = %321
   store i64 %322, i64* %323, align 8
@@ -1286,15 +1368,15 @@ entry:
 ; <label>:338                                     ; preds = %333
   %339 = load i8*, i8** %arg0
   %340 = load i8*, i8** %arg1
-  %NullCheck136 = icmp ne i8* %340, null
-  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+  %NullCheck135 = icmp eq i8* %340, null
+  br i1 %NullCheck135, label %ThrowNullRef136, label %341
 
 ; <label>:341                                     ; preds = %338
   %342 = load i8, i8* %340, align 8
   %343 = zext i8 %342 to i32
   %344 = trunc i32 %343 to i8
-  %NullCheck138 = icmp ne i8* %339, null
-  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+  %NullCheck137 = icmp eq i8* %339, null
+  br i1 %NullCheck137, label %ThrowNullRef138, label %345
 
 ; <label>:345                                     ; preds = %341
   store i8 %344, i8* %339, align 8
@@ -1317,16 +1399,16 @@ entry:
   %357 = load i8*, i8** %arg0
   %358 = load i8*, i8** %arg1
   %359 = bitcast i8* %358 to i16*
-  %NullCheck140 = icmp ne i16* %359, null
-  br i1 %NullCheck140, label %360, label %ThrowNullRef139
+  %NullCheck139 = icmp eq i16* %359, null
+  br i1 %NullCheck139, label %ThrowNullRef140, label %360
 
 ; <label>:360                                     ; preds = %356
   %361 = load i16, i16* %359, align 8
   %362 = sext i16 %361 to i32
   %363 = bitcast i8* %357 to i16*
   %364 = trunc i32 %362 to i16
-  %NullCheck142 = icmp ne i16* %363, null
-  br i1 %NullCheck142, label %365, label %ThrowNullRef141
+  %NullCheck141 = icmp eq i16* %363, null
+  br i1 %NullCheck141, label %ThrowNullRef142, label %365
 
 ; <label>:365                                     ; preds = %360
   store i16 %364, i16* %363, align 8
@@ -1352,14 +1434,14 @@ entry:
   %378 = load i8*, i8** %arg0
   %379 = load i8*, i8** %arg1
   %380 = bitcast i8* %379 to i32*
-  %NullCheck144 = icmp ne i32* %380, null
-  br i1 %NullCheck144, label %381, label %ThrowNullRef143
+  %NullCheck143 = icmp eq i32* %380, null
+  br i1 %NullCheck143, label %ThrowNullRef144, label %381
 
 ; <label>:381                                     ; preds = %377
   %382 = load i32, i32* %380, align 8
   %383 = bitcast i8* %378 to i32*
-  %NullCheck146 = icmp ne i32* %383, null
-  br i1 %NullCheck146, label %384, label %ThrowNullRef145
+  %NullCheck145 = icmp eq i32* %383, null
+  br i1 %NullCheck145, label %ThrowNullRef146, label %384
 
 ; <label>:384                                     ; preds = %381
   store i32 %382, i32* %383, align 8
@@ -1384,14 +1466,14 @@ entry:
   %395 = load i8*, i8** %arg0
   %396 = load i8*, i8** %arg1
   %397 = bitcast i8* %396 to i64*
-  %NullCheck164 = icmp ne i64* %397, null
-  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+  %NullCheck163 = icmp eq i64* %397, null
+  br i1 %NullCheck163, label %ThrowNullRef164, label %398
 
 ; <label>:398                                     ; preds = %394
   %399 = load i64, i64* %397, align 8
   %400 = bitcast i8* %395 to i64*
-  %NullCheck166 = icmp ne i64* %400, null
-  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+  %NullCheck165 = icmp eq i64* %400, null
+  br i1 %NullCheck165, label %ThrowNullRef166, label %401
 
 ; <label>:401                                     ; preds = %398
   store i64 %399, i64* %400, align 8
@@ -1400,14 +1482,14 @@ entry:
   %404 = load i8*, i8** %arg1
   %405 = getelementptr inbounds i8, i8* %404, i64 8
   %406 = bitcast i8* %405 to i64*
-  %NullCheck168 = icmp ne i64* %406, null
-  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+  %NullCheck167 = icmp eq i64* %406, null
+  br i1 %NullCheck167, label %ThrowNullRef168, label %407
 
 ; <label>:407                                     ; preds = %401
   %408 = load i64, i64* %406, align 8
   %409 = bitcast i8* %403 to i64*
-  %NullCheck170 = icmp ne i64* %409, null
-  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+  %NullCheck169 = icmp eq i64* %409, null
+  br i1 %NullCheck169, label %ThrowNullRef170, label %410
 
 ; <label>:410                                     ; preds = %407
   store i64 %408, i64* %409, align 8
@@ -1437,14 +1519,14 @@ entry:
   %425 = load i8*, i8** %arg0
   %426 = load i8*, i8** %arg1
   %427 = bitcast i8* %426 to i64*
-  %NullCheck148 = icmp ne i64* %427, null
-  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+  %NullCheck147 = icmp eq i64* %427, null
+  br i1 %NullCheck147, label %ThrowNullRef148, label %428
 
 ; <label>:428                                     ; preds = %424
   %429 = load i64, i64* %427, align 8
   %430 = bitcast i8* %425 to i64*
-  %NullCheck150 = icmp ne i64* %430, null
-  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+  %NullCheck149 = icmp eq i64* %430, null
+  br i1 %NullCheck149, label %ThrowNullRef150, label %431
 
 ; <label>:431                                     ; preds = %428
   store i64 %429, i64* %430, align 8
@@ -1466,14 +1548,14 @@ entry:
   %441 = load i8*, i8** %arg0
   %442 = load i8*, i8** %arg1
   %443 = bitcast i8* %442 to i32*
-  %NullCheck152 = icmp ne i32* %443, null
-  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+  %NullCheck151 = icmp eq i32* %443, null
+  br i1 %NullCheck151, label %ThrowNullRef152, label %444
 
 ; <label>:444                                     ; preds = %440
   %445 = load i32, i32* %443, align 8
   %446 = bitcast i8* %441 to i32*
-  %NullCheck154 = icmp ne i32* %446, null
-  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+  %NullCheck153 = icmp eq i32* %446, null
+  br i1 %NullCheck153, label %ThrowNullRef154, label %447
 
 ; <label>:447                                     ; preds = %444
   store i32 %445, i32* %446, align 8
@@ -1495,16 +1577,16 @@ entry:
   %457 = load i8*, i8** %arg0
   %458 = load i8*, i8** %arg1
   %459 = bitcast i8* %458 to i16*
-  %NullCheck156 = icmp ne i16* %459, null
-  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+  %NullCheck155 = icmp eq i16* %459, null
+  br i1 %NullCheck155, label %ThrowNullRef156, label %460
 
 ; <label>:460                                     ; preds = %456
   %461 = load i16, i16* %459, align 8
   %462 = sext i16 %461 to i32
   %463 = bitcast i8* %457 to i16*
   %464 = trunc i32 %462 to i16
-  %NullCheck158 = icmp ne i16* %463, null
-  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+  %NullCheck157 = icmp eq i16* %463, null
+  br i1 %NullCheck157, label %ThrowNullRef158, label %465
 
 ; <label>:465                                     ; preds = %460
   store i16 %464, i16* %463, align 8
@@ -1525,15 +1607,15 @@ entry:
 ; <label>:474                                     ; preds = %470
   %475 = load i8*, i8** %arg0
   %476 = load i8*, i8** %arg1
-  %NullCheck160 = icmp ne i8* %476, null
-  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+  %NullCheck159 = icmp eq i8* %476, null
+  br i1 %NullCheck159, label %ThrowNullRef160, label %477
 
 ; <label>:477                                     ; preds = %474
   %478 = load i8, i8* %476, align 8
   %479 = zext i8 %478 to i32
   %480 = trunc i32 %479 to i8
-  %NullCheck162 = icmp ne i8* %475, null
-  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+  %NullCheck161 = icmp eq i8* %475, null
+  br i1 %NullCheck161, label %ThrowNullRef162, label %481
 
 ; <label>:481                                     ; preds = %477
   store i8 %480, i8* %475, align 8
@@ -1553,343 +1635,343 @@ ThrowNullRef:                                     ; preds = %308
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %312
+ThrowNullRef2:                                    ; preds = %312
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %315
+ThrowNullRef4:                                    ; preds = %315
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %321
+ThrowNullRef6:                                    ; preds = %321
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %271
+ThrowNullRef8:                                    ; preds = %271
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %275
+ThrowNullRef10:                                   ; preds = %275
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %278
+ThrowNullRef12:                                   ; preds = %278
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %284
+ThrowNullRef14:                                   ; preds = %284
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %287
+ThrowNullRef16:                                   ; preds = %287
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %293
+ThrowNullRef18:                                   ; preds = %293
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %298
+ThrowNullRef20:                                   ; preds = %298
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %303
+ThrowNullRef22:                                   ; preds = %303
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %243
+ThrowNullRef24:                                   ; preds = %243
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %247
+ThrowNullRef26:                                   ; preds = %247
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %250
+ThrowNullRef28:                                   ; preds = %250
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %256
+ThrowNullRef30:                                   ; preds = %256
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %259
+ThrowNullRef32:                                   ; preds = %259
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %265
+ThrowNullRef34:                                   ; preds = %265
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %217
+ThrowNullRef36:                                   ; preds = %217
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %221
+ThrowNullRef38:                                   ; preds = %221
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %224
+ThrowNullRef40:                                   ; preds = %224
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %230
+ThrowNullRef42:                                   ; preds = %230
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %233
+ThrowNullRef44:                                   ; preds = %233
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %238
+ThrowNullRef46:                                   ; preds = %238
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %200
+ThrowNullRef48:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %204
+ThrowNullRef50:                                   ; preds = %204
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %207
+ThrowNullRef52:                                   ; preds = %207
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %213
+ThrowNullRef54:                                   ; preds = %213
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %172
+ThrowNullRef56:                                   ; preds = %172
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %176
+ThrowNullRef58:                                   ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %179
+ThrowNullRef60:                                   ; preds = %179
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %185
+ThrowNullRef62:                                   ; preds = %185
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %190
+ThrowNullRef64:                                   ; preds = %190
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %195
+ThrowNullRef66:                                   ; preds = %195
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %153
+ThrowNullRef68:                                   ; preds = %153
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %157
+ThrowNullRef70:                                   ; preds = %157
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %160
+ThrowNullRef72:                                   ; preds = %160
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %166
+ThrowNullRef74:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %136
+ThrowNullRef76:                                   ; preds = %136
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %140
+ThrowNullRef78:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %143
+ThrowNullRef80:                                   ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %148
+ThrowNullRef82:                                   ; preds = %148
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %128
+ThrowNullRef84:                                   ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %132
+ThrowNullRef86:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %100
+ThrowNullRef88:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %104
+ThrowNullRef90:                                   ; preds = %104
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %107
+ThrowNullRef92:                                   ; preds = %107
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %113
+ThrowNullRef94:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %118
+ThrowNullRef96:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %123
+ThrowNullRef98:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %81
+ThrowNullRef100:                                  ; preds = %81
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef101:                                  ; preds = %85
+ThrowNullRef102:                                  ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef103:                                  ; preds = %88
+ThrowNullRef104:                                  ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef105:                                  ; preds = %94
+ThrowNullRef106:                                  ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef107:                                  ; preds = %64
+ThrowNullRef108:                                  ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef109:                                  ; preds = %68
+ThrowNullRef110:                                  ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef111:                                  ; preds = %71
+ThrowNullRef112:                                  ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef113:                                  ; preds = %76
+ThrowNullRef114:                                  ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef115:                                  ; preds = %56
+ThrowNullRef116:                                  ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef117:                                  ; preds = %60
+ThrowNullRef118:                                  ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef119:                                  ; preds = %37
+ThrowNullRef120:                                  ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef121:                                  ; preds = %41
+ThrowNullRef122:                                  ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef123:                                  ; preds = %46
+ThrowNullRef124:                                  ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef125:                                  ; preds = %51
+ThrowNullRef126:                                  ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef127:                                  ; preds = %27
+ThrowNullRef128:                                  ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef129:                                  ; preds = %31
+ThrowNullRef130:                                  ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef131:                                  ; preds = %19
+ThrowNullRef132:                                  ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef133:                                  ; preds = %22
+ThrowNullRef134:                                  ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef135:                                  ; preds = %338
+ThrowNullRef136:                                  ; preds = %338
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef137:                                  ; preds = %341
+ThrowNullRef138:                                  ; preds = %341
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef139:                                  ; preds = %356
+ThrowNullRef140:                                  ; preds = %356
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef141:                                  ; preds = %360
+ThrowNullRef142:                                  ; preds = %360
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef143:                                  ; preds = %377
+ThrowNullRef144:                                  ; preds = %377
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef145:                                  ; preds = %381
+ThrowNullRef146:                                  ; preds = %381
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef147:                                  ; preds = %424
+ThrowNullRef148:                                  ; preds = %424
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef149:                                  ; preds = %428
+ThrowNullRef150:                                  ; preds = %428
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef151:                                  ; preds = %440
+ThrowNullRef152:                                  ; preds = %440
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef153:                                  ; preds = %444
+ThrowNullRef154:                                  ; preds = %444
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef155:                                  ; preds = %456
+ThrowNullRef156:                                  ; preds = %456
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef157:                                  ; preds = %460
+ThrowNullRef158:                                  ; preds = %460
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef159:                                  ; preds = %474
+ThrowNullRef160:                                  ; preds = %474
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef161:                                  ; preds = %477
+ThrowNullRef162:                                  ; preds = %477
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef163:                                  ; preds = %394
+ThrowNullRef164:                                  ; preds = %394
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef165:                                  ; preds = %398
+ThrowNullRef166:                                  ; preds = %398
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef167:                                  ; preds = %401
+ThrowNullRef168:                                  ; preds = %401
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef169:                                  ; preds = %407
+ThrowNullRef170:                                  ; preds = %407
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1939,8 +2021,8 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
-  br i1 %NullCheck, label %22, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %ThrowNullRef, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
@@ -1948,8 +2030,8 @@ entry:
   store i32 %24, i32* %loc0
   %25 = load i32, i32* %loc0
   %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %26, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %27
 
 ; <label>:27                                      ; preds = %22
   %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
@@ -1971,7 +2053,7 @@ ThrowNullRef:                                     ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1989,8 +2071,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -2022,15 +2104,15 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2048,16 +2130,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
   %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
   store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %15
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
@@ -2072,8 +2154,8 @@ entry:
   %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
   %29 = ptrtoint i16 addrspace(1)* %28 to i64
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %19
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
@@ -2089,19 +2171,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2114,8 +2196,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
@@ -2128,7 +2210,7 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[loadElem]
+Failed to read AppDomain.PrepareDataForSetup[storeElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
@@ -2202,8 +2284,8 @@ entry:
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
-  br i1 %NullCheck24, label %27, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = load i64, i64 addrspace(1)* %26
@@ -2218,8 +2300,8 @@ entry:
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
-  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
   %41 = load i64, i64 addrspace(1)* %39
@@ -2236,8 +2318,8 @@ entry:
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
-  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
   %54 = load i64, i64 addrspace(1)* %52
@@ -2252,8 +2334,8 @@ entry:
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
   %67 = load i64, i64 addrspace(1)* %65
@@ -2270,8 +2352,8 @@ entry:
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
-  br i1 %NullCheck16, label %79, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
   %80 = load i64, i64 addrspace(1)* %78
@@ -2286,8 +2368,8 @@ entry:
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
-  br i1 %NullCheck18, label %92, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
   %93 = load i64, i64 addrspace(1)* %91
@@ -2304,8 +2386,8 @@ entry:
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
-  br i1 %NullCheck12, label %105, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = load i64, i64 addrspace(1)* %104
@@ -2320,8 +2402,8 @@ entry:
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
-  br i1 %NullCheck14, label %118, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
   %119 = load i64, i64 addrspace(1)* %117
@@ -2337,8 +2419,8 @@ entry:
 
 ; <label>:128                                     ; preds = %20
   %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
-  br i1 %NullCheck4, label %130, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %129, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %130
 
 ; <label>:130                                     ; preds = %128
   %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
@@ -2346,8 +2428,8 @@ entry:
   %133 = load i16, i16 addrspace(1)* %132, align 8
   %134 = zext i16 %133 to i32
   %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
-  br i1 %NullCheck6, label %136, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %135, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %136
 
 ; <label>:136                                     ; preds = %130
   %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
@@ -2360,8 +2442,8 @@ entry:
 
 ; <label>:143                                     ; preds = %136
   %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
-  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %144, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %145
 
 ; <label>:145                                     ; preds = %143
   %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
@@ -2369,8 +2451,8 @@ entry:
   %148 = load i16, i16 addrspace(1)* %147, align 8
   %149 = zext i16 %148 to i32
   %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %150, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %151
 
 ; <label>:151                                     ; preds = %145
   %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
@@ -2388,8 +2470,8 @@ entry:
 
 ; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
-  br i1 %NullCheck, label %163, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %ThrowNullRef, label %163
 
 ; <label>:163                                     ; preds = %161
   %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
@@ -2399,8 +2481,8 @@ entry:
 
 ; <label>:167                                     ; preds = %163
   %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
-  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %168, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %169
 
 ; <label>:169                                     ; preds = %167
   %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
@@ -2432,55 +2514,55 @@ ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %167
+ThrowNullRef2:                                    ; preds = %167
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %128
+ThrowNullRef4:                                    ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %130
+ThrowNullRef6:                                    ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %143
+ThrowNullRef8:                                    ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %145
+ThrowNullRef10:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %102
+ThrowNullRef12:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %105
+ThrowNullRef14:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %76
+ThrowNullRef16:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %79
+ThrowNullRef18:                                   ; preds = %79
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %50
+ThrowNullRef20:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %53
+ThrowNullRef22:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %24
+ThrowNullRef24:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %27
+ThrowNullRef26:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2503,15 +2585,15 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2519,16 +2601,16 @@ entry:
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
   store i32 %8, i32* %loc0
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
   %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
   store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
@@ -2546,16 +2628,16 @@ entry:
 
 ; <label>:23                                      ; preds = %64
   %24 = load i16*, i16** %loc3
-  %NullCheck12 = icmp ne i16* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i16* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
   store i32 %27, i32* %loc5
   %28 = load i16*, i16** %loc4
-  %NullCheck14 = icmp ne i16* %28, null
-  br i1 %NullCheck14, label %29, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %28, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = load i16, i16* %28, align 8
@@ -2620,15 +2702,15 @@ entry:
 
 ; <label>:67                                      ; preds = %64
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
-  br i1 %NullCheck8, label %69, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %68, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %69
 
 ; <label>:69                                      ; preds = %67
   %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
   %71 = load i32, i32 addrspace(1)* %70
   %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
-  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %73
 
 ; <label>:73                                      ; preds = %69
   %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
@@ -2645,31 +2727,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %67
+ThrowNullRef8:                                    ; preds = %67
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %69
+ThrowNullRef10:                                   ; preds = %69
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2710,14 +2792,14 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
   %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
@@ -2730,14 +2812,14 @@ entry:
 
 ; <label>:11                                      ; preds = %4
   %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
   %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
@@ -2749,14 +2831,14 @@ entry:
 
 ; <label>:22                                      ; preds = %16
   %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
   %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
-  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
-  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
@@ -2804,23 +2886,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2836,7 +2918,280 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[loadElem]
+Successfully read RuntimeType.IsAssignableFrom
+
+define i8 @RuntimeType.IsAssignableFrom(%System.RuntimeType addrspace(1)* %param0, %System.Type addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.RuntimeType addrspace(1)*
+  %arg1 = alloca %System.Type addrspace(1)*
+  %loc0 = alloca %System.RuntimeType addrspace(1)*
+  %loc1 = alloca %"System.Type[]" addrspace(1)*
+  %loc2 = alloca i32
+  store %System.RuntimeType addrspace(1)* %param0, %System.RuntimeType addrspace(1)** %this
+  store %System.Type addrspace(1)* %param1, %System.Type addrspace(1)** %arg1
+  %0 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %1 = icmp ne %System.Type addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i8 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %5 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %6 = bitcast %System.Type addrspace(1)* %4 to %System.Object addrspace(1)*
+  %7 = bitcast %System.RuntimeType addrspace(1)* %5 to %System.Object addrspace(1)*
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %6, %System.Object addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %3
+  ret i8 1
+
+; <label>:12                                      ; preds = %3
+  %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 152
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 32
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
+  %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
+  %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
+  store %System.RuntimeType addrspace(1)* %25, %System.RuntimeType addrspace(1)** %loc0
+  %26 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %27 = icmp eq %System.RuntimeType addrspace(1)* %26, null
+  br i1 %27, label %34, label %28
+
+; <label>:28                                      ; preds = %15
+  %29 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %30 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)*)*)(%System.RuntimeType addrspace(1)* %29, %System.RuntimeType addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+; <label>:34                                      ; preds = %15
+  %35 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %36 = call %System.Reflection.Emit.TypeBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Reflection.Emit.TypeBuilder addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %35)
+  %37 = icmp eq %System.Reflection.Emit.TypeBuilder addrspace(1)* %36, null
+  br i1 %37, label %139, label %38
+
+; <label>:38                                      ; preds = %34
+  %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %42
+
+; <label>:42                                      ; preds = %38
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 152
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 40
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
+  %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
+  %53 = zext i8 %52 to i32
+  %54 = icmp eq i32 %53, 0
+  br i1 %54, label %56, label %55
+
+; <label>:55                                      ; preds = %42
+  ret i8 1
+
+; <label>:56                                      ; preds = %42
+  %57 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %58 = bitcast %System.RuntimeType addrspace(1)* %57 to %System.Type addrspace(1)*
+  %59 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %58)
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %64 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.Type addrspace(1)* %63, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = bitcast %System.RuntimeType addrspace(1)* %64 to %System.Type addrspace(1)*
+  %67 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %63, %System.Type addrspace(1)* %66)
+  %68 = zext i8 %67 to i32
+  %69 = trunc i32 %68 to i8
+  ret i8 %69
+
+; <label>:70                                      ; preds = %56
+  %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
+  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %73
+
+; <label>:73                                      ; preds = %70
+  %74 = load i64, i64 addrspace(1)* %72
+  %75 = add i64 %74, 128
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = add i64 %77, 0
+  %79 = inttoptr i64 %78 to i64*
+  %80 = load i64, i64* %79
+  %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
+  %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
+  %83 = call i8 %82(%System.Type addrspace(1)* %81)
+  %84 = zext i8 %83 to i32
+  %85 = icmp eq i32 %84, 0
+  br i1 %85, label %139, label %86
+
+; <label>:86                                      ; preds = %73
+  %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
+  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %89
+
+; <label>:89                                      ; preds = %86
+  %90 = load i64, i64 addrspace(1)* %88
+  %91 = add i64 %90, 128
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = add i64 %93, 24
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
+  %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
+  %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
+  store %"System.Type[]" addrspace(1)* %99, %"System.Type[]" addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %129
+
+; <label>:100                                     ; preds = %132
+  %101 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %102 = load i32, i32* %loc2
+  %NullCheck11 = icmp eq %"System.Type[]" addrspace(1)* %101, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %103
+
+; <label>:103                                     ; preds = %100
+  %104 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 1
+  %105 = load i32, i32 addrspace(1)* %104
+  %106 = zext i32 %105 to i64
+  %107 = zext i32 %102 to i64
+  %BoundsCheck = icmp uge i64 %107, %106
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %108
+
+; <label>:108                                     ; preds = %103
+  %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
+  %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
+  %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
+  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %113
+
+; <label>:113                                     ; preds = %108
+  %114 = load i64, i64 addrspace(1)* %112
+  %115 = add i64 %114, 152
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = add i64 %117, 56
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
+  %123 = zext i8 %122 to i32
+  %124 = icmp ne i32 %123, 0
+  br i1 %124, label %126, label %125
+
+; <label>:125                                     ; preds = %113
+  ret i8 0
+
+; <label>:126                                     ; preds = %113
+  %127 = load i32, i32* %loc2
+  %128 = add i32 %127, 1
+  store i32 %128, i32* %loc2
+  br label %129
+
+; <label>:129                                     ; preds = %89, %126
+  %130 = load i32, i32* %loc2
+  %131 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %NullCheck9 = icmp eq %"System.Type[]" addrspace(1)* %131, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %132
+
+; <label>:132                                     ; preds = %129
+  %133 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %131, i32 0, i32 1
+  %134 = load i32, i32 addrspace(1)* %133
+  %135 = zext i32 %134 to i64
+  %136 = trunc i64 %135 to i32
+  %137 = icmp slt i32 %130, %136
+  br i1 %137, label %100, label %138
+
+; <label>:138                                     ; preds = %132
+  ret i8 1
+
+; <label>:139                                     ; preds = %34, %73
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %129
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %103
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -2893,7 +3248,7 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElem]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -2904,8 +3259,8 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -2997,8 +3352,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
@@ -3059,8 +3414,8 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -3087,8 +3442,8 @@ entry:
 
 ; <label>:17                                      ; preds = %5, %11
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
@@ -3097,8 +3452,8 @@ entry:
 
 ; <label>:22                                      ; preds = %1, %11
   %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
@@ -3109,11 +3464,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %17
+ThrowNullRef2:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %22
+ThrowNullRef4:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3167,15 +3522,15 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
   %15 = load i32, i32 addrspace(1)* %14
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
@@ -3198,7 +3553,7 @@ ThrowNullRef:                                     ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef2:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3232,8 +3587,8 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
@@ -3312,8 +3667,8 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -3327,8 +3682,8 @@ entry:
 ; <label>:5                                       ; preds = %43
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %7 = load i32, i32* %loc1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck6, label %8, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
@@ -3366,8 +3721,8 @@ entry:
 ; <label>:32                                      ; preds = %21, %25
   %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
   %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
-  br i1 %NullCheck8, label %35, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = trunc i32 %34 to i16
@@ -3380,8 +3735,8 @@ entry:
 ; <label>:40                                      ; preds = %1, %35
   %41 = load i32, i32* %loc1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
-  br i1 %NullCheck2, label %43, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %42, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
@@ -3392,8 +3747,8 @@ entry:
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
   %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
-  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
   %51 = load i64, i64 addrspace(1)* %49
@@ -3412,19 +3767,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %40
+ThrowNullRef2:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %47
+ThrowNullRef4:                                    ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %5
+ThrowNullRef6:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %32
+ThrowNullRef8:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3467,8 +3822,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
@@ -3492,11 +3847,391 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(i16* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store i16* %param0, i16** %arg0
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load i32, i32* %arg3
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %42, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %37, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg2
+  %13 = load i32, i32* %arg3
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %37, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %24 = load i32, i32* %arg2
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load i16*, i16** %arg0
+  %35 = load i32, i32* %arg3
+  %36 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %36, i16* %34, i32 %35)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:37                                      ; preds = %5, %16
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %39)
+  %41 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41, %System.String addrspace(1)* %38, %System.String addrspace(1)* %40)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41) #0
+  unreachable
+
+; <label>:42                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
-Failed to read StringBuilder.ToString[loadElemA]
+Successfully read StringBuilder.ToString
+
+define %System.String addrspace(1)* @StringBuilder.ToString(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i16*
+  %loc3 = alloca %"System.Char[]" addrspace(1)*
+  %loc4 = alloca i32
+  %loc5 = alloca i32
+  %loc6 = alloca i16 addrspace(1)*
+  %loc7 = alloca %System.String addrspace(1)*
+  %loc8 = alloca %"System.Char[]" addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %0)
+  %2 = icmp ne i32 %1, 0
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %4
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %6)
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %7)
+  store %System.String addrspace(1)* %8, %System.String addrspace(1)** %loc0
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.Text.StringBuilder addrspace(1)* %9, %System.Text.StringBuilder addrspace(1)** %loc1
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  store %System.String addrspace(1)* %10, %System.String addrspace(1)** %loc7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc7
+  %12 = ptrtoint %System.String addrspace(1)* %11 to i64
+  %13 = icmp eq i64 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %5
+  %15 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %16 = sext i32 %15 to i64
+  %17 = add i64 %12, %16
+  br label %18
+
+; <label>:18                                      ; preds = %5, %14
+  %19 = phi i64 [ %12, %5 ], [ %17, %14 ]
+  %20 = inttoptr i64 %19 to i16*
+  store i16* %20, i16** %loc2
+  br label %21
+
+; <label>:21                                      ; preds = %98, %18
+  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %22, null
+  br i1 %NullCheck, label %ThrowNullRef, label %23
+
+; <label>:23                                      ; preds = %21
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 3
+  %25 = load i32, i32 addrspace(1)* %24, align 8
+  %26 = icmp sle i32 %25, 0
+  br i1 %26, label %96, label %27
+
+; <label>:27                                      ; preds = %23
+  %28 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %28, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %29
+
+; <label>:29                                      ; preds = %27
+  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %28, i32 0, i32 1
+  %31 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %30, align 8
+  store %"System.Char[]" addrspace(1)* %31, %"System.Char[]" addrspace(1)** %loc3
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %33
+
+; <label>:33                                      ; preds = %29
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  store i32 %35, i32* %loc4
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  %39 = load i32, i32 addrspace(1)* %38, align 8
+  store i32 %39, i32* %loc5
+  %40 = load i32, i32* %loc5
+  %41 = load i32, i32* %loc4
+  %42 = add i32 %40, %41
+  %43 = zext i32 %42 to i64
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %45
+
+; <label>:45                                      ; preds = %37
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = sext i32 %47 to i64
+  %49 = icmp sgt i64 %43, %48
+  br i1 %49, label %91, label %50
+
+; <label>:50                                      ; preds = %45
+  %51 = load i32, i32* %loc5
+  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %52, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %53
+
+; <label>:53                                      ; preds = %50
+  %54 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %52, i32 0, i32 1
+  %55 = load i32, i32 addrspace(1)* %54
+  %56 = zext i32 %55 to i64
+  %57 = trunc i64 %56 to i32
+  %58 = icmp ugt i32 %51, %57
+  br i1 %58, label %91, label %59
+
+; <label>:59                                      ; preds = %53
+  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  store %"System.Char[]" addrspace(1)* %60, %"System.Char[]" addrspace(1)** %loc8
+  %61 = icmp eq %"System.Char[]" addrspace(1)* %60, null
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %63, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %64
+
+; <label>:64                                      ; preds = %62
+  %65 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %63, i32 0, i32 1
+  %66 = load i32, i32 addrspace(1)* %65
+  %67 = zext i32 %66 to i64
+  %68 = trunc i64 %67 to i32
+  %69 = icmp ne i32 %68, 0
+  br i1 %69, label %71, label %70
+
+; <label>:70                                      ; preds = %59, %64
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:71                                      ; preds = %64
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %73
+
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %BoundsCheck = icmp uge i64 0, %76
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %77
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %78, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:79                                      ; preds = %70, %77
+  %80 = load i16*, i16** %loc2
+  %81 = load i32, i32* %loc4
+  %82 = sext i32 %81 to i64
+  %83 = mul i64 %82, 2
+  %84 = bitcast i16* %80 to i8*
+  %85 = getelementptr inbounds i8, i8* %84, i64 %83
+  %86 = load i16 addrspace(1)*, i16 addrspace(1)** %loc6
+  %87 = ptrtoint i16 addrspace(1)* %86 to i64
+  %88 = load i32, i32* %loc5
+  %89 = bitcast i8* %85 to i16*
+  %90 = inttoptr i64 %87 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %89, i16* %90, i32 %88)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %96
+
+; <label>:91                                      ; preds = %45, %53
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %94 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %93)
+  %95 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95, %System.String addrspace(1)* %92, %System.String addrspace(1)* %94)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95) #0
+  unreachable
+
+; <label>:96                                      ; preds = %23, %79
+  %97 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %97, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %98
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %97, i32 0, i32 2
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  store %System.Text.StringBuilder addrspace(1)* %100, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %102 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %102, label %21, label %103
+
+; <label>:103                                     ; preds = %98
+  store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc7
+  %104 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  ret %System.String addrspace(1)* %104
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method StringBuilder::get_Length using LLILCJit
+Successfully read StringBuilder.get_Length
+
+define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
+Successfully read RuntimeHelpers.get_OffsetToStringData
+
+define i32 @RuntimeHelpers.get_OffsetToStringData() {
+entry:
+  ret i32 12
+}
+
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
 Successfully read CultureData.CreateCultureData
 
@@ -3514,23 +4249,23 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
   store i8 %4, i8 addrspace(1)* %6
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
@@ -3549,11 +4284,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3566,50 +4301,50 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
   store i32 -1, i32 addrspace(1)* %2
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
   store i32 -1, i32 addrspace(1)* %8
   %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
   store i32 -1, i32 addrspace(1)* %14
   %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
   store i32 -1, i32 addrspace(1)* %17
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
@@ -3623,27 +4358,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3675,7 +4410,136 @@ Failed to read Dictionary`2.Insert[non-const derefAddress]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
 Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
-Failed to read HashHelpers.GetPrime[loadElem]
+Successfully read HashHelpers.GetPrime
+
+define i32 @HashHelpers.GetPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %6, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5, %System.String addrspace(1)* %4)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5) #0
+  unreachable
+
+; <label>:6                                       ; preds = %entry
+  store i32 0, i32* %loc0
+  br label %29
+
+; <label>:7                                       ; preds = %35
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 1296
+  %10 = addrspacecast i8 addrspace(1)* %9 to %"System.Int32[]" addrspace(1)**
+  %11 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %10
+  %12 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Int32[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = zext i32 %15 to i64
+  %17 = zext i32 %12 to i64
+  %BoundsCheck = icmp uge i64 %17, %16
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 3, i32 %12
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  store i32 %20, i32* %loc1
+  %21 = load i32, i32* %loc1
+  %22 = load i32, i32* %arg0
+  %23 = icmp slt i32 %21, %22
+  br i1 %23, label %26, label %24
+
+; <label>:24                                      ; preds = %18
+  %25 = load i32, i32* %loc1
+  ret i32 %25
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %loc0
+  %28 = add i32 %27, 1
+  store i32 %28, i32* %loc0
+  br label %29
+
+; <label>:29                                      ; preds = %6, %26
+  %30 = load i32, i32* %loc0
+  %31 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %32 = getelementptr inbounds i8, i8 addrspace(1)* %31, i64 1296
+  %33 = addrspacecast i8 addrspace(1)* %32 to %"System.Int32[]" addrspace(1)**
+  %34 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %33
+  %NullCheck = icmp eq %"System.Int32[]" addrspace(1)* %34, null
+  br i1 %NullCheck, label %ThrowNullRef, label %35
+
+; <label>:35                                      ; preds = %29
+  %36 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %34, i32 0, i32 1
+  %37 = load i32, i32 addrspace(1)* %36
+  %38 = zext i32 %37 to i64
+  %39 = trunc i64 %38 to i32
+  %40 = icmp slt i32 %30, %39
+  br i1 %40, label %7, label %41
+
+; <label>:41                                      ; preds = %35
+  %42 = load i32, i32* %arg0
+  %43 = or i32 %42, 1
+  store i32 %43, i32* %loc2
+  br label %59
+
+; <label>:44                                      ; preds = %59
+  %45 = load i32, i32* %loc2
+  %46 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %45)
+  %47 = zext i8 %46 to i32
+  %48 = icmp eq i32 %47, 0
+  br i1 %48, label %56, label %49
+
+; <label>:49                                      ; preds = %44
+  %50 = load i32, i32* %loc2
+  %51 = sub i32 %50, 1
+  %52 = srem i32 %51, 101
+  %53 = icmp eq i32 %52, 0
+  br i1 %53, label %56, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = load i32, i32* %loc2
+  ret i32 %55
+
+; <label>:56                                      ; preds = %44, %49
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %57, 2
+  store i32 %58, i32* %loc2
+  br label %59
+
+; <label>:59                                      ; preds = %41, %56
+  %60 = load i32, i32* %loc2
+  %61 = icmp slt i32 %60, 2147483647
+  br i1 %61, label %44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load i32, i32* %arg0
+  ret i32 %63
+
+ThrowNullRef:                                     ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
 Successfully read GenericEqualityComparer`1.GetHashCode
 
@@ -3694,14 +4558,14 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
   %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load i64, i64 addrspace(1)* %7
@@ -3720,7 +4584,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3750,8 +4614,8 @@ entry:
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
@@ -3796,8 +4660,8 @@ entry:
   %35 = bitcast i16* %34 to i8*
   %36 = getelementptr inbounds i8, i8* %35, i64 2
   %37 = bitcast i8* %36 to i16*
-  %NullCheck4 = icmp ne i16* %37, null
-  br i1 %NullCheck4, label %38, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %37, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %38
 
 ; <label>:38                                      ; preds = %27
   %39 = load i16, i16* %37, align 8
@@ -3824,8 +4688,8 @@ entry:
 
 ; <label>:54                                      ; preds = %22, %43
   %55 = load i16*, i16** %loc4
-  %NullCheck2 = icmp ne i16* %55, null
-  br i1 %NullCheck2, label %56, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i16* %55, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %56
 
 ; <label>:56                                      ; preds = %54
   %57 = load i16, i16* %55, align 8
@@ -3850,11 +4714,11 @@ ThrowNullRef:                                     ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %54
+ThrowNullRef2:                                    ; preds = %54
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %27
+ThrowNullRef4:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3871,8 +4735,8 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -3907,8 +4771,8 @@ entry:
 
 ; <label>:26                                      ; preds = %19
   %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
-  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %28
 
 ; <label>:28                                      ; preds = %26
   %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
@@ -3920,7 +4784,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3972,8 +4836,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
@@ -3984,26 +4848,26 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
-  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
@@ -4014,8 +4878,8 @@ entry:
 ; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
@@ -4024,8 +4888,8 @@ entry:
 
 ; <label>:25                                      ; preds = %1, %16, %23
   %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
-  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
@@ -4036,27 +4900,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %20
+ThrowNullRef10:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4069,8 +4933,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -4081,8 +4945,8 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
@@ -4091,8 +4955,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1, %8
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
@@ -4103,11 +4967,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4128,24 +4992,24 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   store i32 %3, i32* %loc0
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
   %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
   store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck4, label %9, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
@@ -4164,15 +5028,15 @@ entry:
 ; <label>:18                                      ; preds = %70
   %19 = load i16*, i16** %loc3
   %20 = bitcast i16* %19 to i64*
-  %NullCheck10 = icmp ne i64* %20, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %20, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = load i64, i64* %20, align 8
   %23 = load i16*, i16** %loc4
   %24 = bitcast i16* %23 to i64*
-  %NullCheck12 = icmp ne i64* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = load i64, i64* %24, align 8
@@ -4188,8 +5052,8 @@ entry:
   %31 = bitcast i16* %30 to i8*
   %32 = getelementptr inbounds i8, i8* %31, i64 8
   %33 = bitcast i8* %32 to i64*
-  %NullCheck14 = icmp ne i64* %33, null
-  br i1 %NullCheck14, label %34, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = load i64, i64* %33, align 8
@@ -4197,8 +5061,8 @@ entry:
   %37 = bitcast i16* %36 to i8*
   %38 = getelementptr inbounds i8, i8* %37, i64 8
   %39 = bitcast i8* %38 to i64*
-  %NullCheck16 = icmp ne i64* %39, null
-  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %40
 
 ; <label>:40                                      ; preds = %34
   %41 = load i64, i64* %39, align 8
@@ -4214,8 +5078,8 @@ entry:
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %NullCheck18 = icmp ne i64* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = load i64, i64* %48, align 8
@@ -4223,8 +5087,8 @@ entry:
   %52 = bitcast i16* %51 to i8*
   %53 = getelementptr inbounds i8, i8* %52, i64 16
   %54 = bitcast i8* %53 to i64*
-  %NullCheck20 = icmp ne i64* %54, null
-  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64* %54, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %55
 
 ; <label>:55                                      ; preds = %49
   %56 = load i64, i64* %54, align 8
@@ -4262,15 +5126,15 @@ entry:
 ; <label>:74                                      ; preds = %95
   %75 = load i16*, i16** %loc3
   %76 = bitcast i16* %75 to i32*
-  %NullCheck6 = icmp ne i32* %76, null
-  br i1 %NullCheck6, label %77, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32* %76, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %77
 
 ; <label>:77                                      ; preds = %74
   %78 = load i32, i32* %76, align 8
   %79 = load i16*, i16** %loc4
   %80 = bitcast i16* %79 to i32*
-  %NullCheck8 = icmp ne i32* %80, null
-  br i1 %NullCheck8, label %81, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i32* %80, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %81
 
 ; <label>:81                                      ; preds = %77
   %82 = load i32, i32* %80, align 8
@@ -4318,43 +5182,43 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %74
+ThrowNullRef6:                                    ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %77
+ThrowNullRef8:                                    ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %29
+ThrowNullRef14:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %34
+ThrowNullRef16:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4376,8 +5240,8 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load i64, i64 addrspace(1)* %4
@@ -4389,8 +5253,8 @@ entry:
   %12 = load i64, i64* %11
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %5
   %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
@@ -4399,8 +5263,8 @@ entry:
   %18 = load i8, i8* %arg2
   %19 = zext i8 %18 to i32
   %20 = trunc i32 %19 to i8
-  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %15
   %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
@@ -4411,11 +5275,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4442,8 +5306,8 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
@@ -4466,16 +5330,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
   %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = load i64, i64 addrspace(1)* %19
@@ -4500,8 +5364,8 @@ entry:
 ; <label>:35                                      ; preds = %30
   %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
@@ -4514,8 +5378,8 @@ entry:
 
 ; <label>:42                                      ; preds = %1, %38
   %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
-  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
@@ -4526,19 +5390,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %35
+ThrowNullRef2:                                    ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %42
+ThrowNullRef8:                                    ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4551,14 +5415,14 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
@@ -4570,7 +5434,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4583,8 +5447,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
@@ -4613,51 +5477,51 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
   %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
   %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
   %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
   %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
-  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
   store i64 %21, i64 addrspace(1)* %23
   %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %25 = load i64, i64* %loc0
-  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
@@ -4668,27 +5532,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %22
+ThrowNullRef12:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4701,8 +5565,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
@@ -4713,19 +5577,19 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
@@ -4734,8 +5598,8 @@ entry:
 
 ; <label>:15                                      ; preds = %1, %13
   %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
@@ -4746,19 +5610,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %15
+ThrowNullRef8:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4771,8 +5635,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -4831,8 +5695,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
@@ -4882,8 +5746,8 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
-  br i1 %NullCheck, label %17, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %ThrowNullRef, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
@@ -4894,15 +5758,15 @@ entry:
 
 ; <label>:22                                      ; preds = %17
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
-  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
   %26 = load i32, i32 addrspace(1)* %25
   %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
-  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %27, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
@@ -4925,8 +5789,8 @@ entry:
 ; <label>:40                                      ; preds = %17
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
-  br i1 %NullCheck6, label %43, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %41, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
@@ -4938,34 +5802,17 @@ ThrowNullRef:                                     ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %24
+ThrowNullRef4:                                    ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %40
+ThrowNullRef6:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
-}
-
-INFO:  jitting method Object::ReferenceEquals using LLILCJit
-Successfully read Object.ReferenceEquals
-
-define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
-entry:
-  %arg0 = alloca %System.Object addrspace(1)*
-  %arg1 = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
-  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
-  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = icmp eq %System.Object addrspace(1)* %0, %1
-  %3 = sext i1 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
 }
 
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
@@ -4978,21 +5825,21 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
   %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
-  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
@@ -5007,28 +5854,28 @@ entry:
 ; <label>:13                                      ; preds = %8, %12
   %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
   %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
   %21 = load i32, i32 addrspace(1)* %20, align 8
   %22 = add i32 %21, 1
-  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
   store i32 %22, i32 addrspace(1)* %24
   %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
@@ -5039,27 +5886,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5077,7 +5924,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::Setup using LLILCJit
-Failed to read AppDomain.Setup[loadElem]
+Failed to read AppDomain.Setup[unbox]
 INFO:  jitting method Thread::GetDomain using LLILCJit
 Successfully read Thread.GetDomain
 
@@ -5108,8 +5955,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
@@ -5122,14 +5969,14 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
   %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
@@ -5141,11 +5988,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5173,8 +6020,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -5189,7 +6036,328 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
 Failed to read KeyCollection.System.Collections.Generic.IEnumerable<TKey>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Successfully read Enumerator.MoveNext
+
+define i8 @Enumerator.MoveNext(%"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.RuntimeTypeHandle* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*
+  %"$TypeArg" = alloca %System.RuntimeTypeHandle*
+  store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
+  %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 8
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %76, label %12
+
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
+  br label %76
+
+; <label>:13                                      ; preds = %85
+  %14 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck19 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %15
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, i32 0, i32 0
+  %17 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %16, align 8
+  %NullCheck21 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, i32 0, i32 2
+  %20 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %19, align 8
+  %21 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck23 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %22
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, i32 0, i32 2
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %NullCheck25 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 3, i32 %24
+  %NullCheck27 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %32
+
+; <label>:32                                      ; preds = %30
+  %33 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, i32 0, i32 2
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = icmp slt i32 %34, 0
+  br i1 %35, label %68, label %36
+
+; <label>:36                                      ; preds = %32
+  %37 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %38 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck29 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %39
+
+; <label>:39                                      ; preds = %36
+  %40 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, i32 0, i32 0
+  %41 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %40, align 8
+  %NullCheck31 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, i32 0, i32 2
+  %44 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %43, align 8
+  %45 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck33 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, i32 0, i32 2
+  %48 = load i32, i32 addrspace(1)* %47, align 8
+  %NullCheck35 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %49
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = zext i32 %51 to i64
+  %53 = zext i32 %48 to i64
+  %BoundsCheck37 = icmp uge i64 %53, %52
+  br i1 %BoundsCheck37, label %ThrowIndexOutOfRange38, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 3, i32 %48
+  %NullCheck39 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %56
+
+; <label>:56                                      ; preds = %54
+  %57 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, i32 0, i32 0
+  %58 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck41 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %59
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %60, %System.__Canon addrspace(1)* %58)
+  %61 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck43 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  %64 = load i32, i32 addrspace(1)* %63, align 8
+  %65 = add i32 %64, 1
+  %NullCheck45 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  store i32 %65, i32 addrspace(1)* %67
+  ret i8 1
+
+; <label>:68                                      ; preds = %32
+  %69 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck47 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %73 = add i32 %72, 1
+  %NullCheck49 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %74
+
+; <label>:74                                      ; preds = %70
+  %75 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  store i32 %73, i32 addrspace(1)* %75
+  br label %76
+
+; <label>:76                                      ; preds = %8, %12, %74
+  %77 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %78
+
+; <label>:78                                      ; preds = %76
+  %79 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, i32 0, i32 2
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck7 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %82
+
+; <label>:82                                      ; preds = %78
+  %83 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, i32 0, i32 0
+  %84 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %83, align 8
+  %NullCheck9 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %85
+
+; <label>:85                                      ; preds = %82
+  %86 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, i32 0, i32 7
+  %87 = load i32, i32 addrspace(1)* %86, align 8
+  %88 = icmp ult i32 %80, %87
+  br i1 %88, label %13, label %89
+
+; <label>:89                                      ; preds = %85
+  %90 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %91 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck11 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %92
+
+; <label>:92                                      ; preds = %89
+  %93 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, i32 0, i32 0
+  %94 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck13 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %95
+
+; <label>:95                                      ; preds = %92
+  %96 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, i32 0, i32 7
+  %97 = load i32, i32 addrspace(1)* %96, align 8
+  %98 = add i32 %97, 1
+  %NullCheck15 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %99
+
+; <label>:99                                      ; preds = %95
+  %100 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, i32 0, i32 2
+  store i32 %98, i32 addrspace(1)* %100
+  %101 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck17 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %102
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %103, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %92
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef22:                                   ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef24:                                   ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef26:                                   ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef28:                                   ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef30:                                   ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef32:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef34:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef36:                                   ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange38:                           ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef40:                                   ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef42:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef44:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef46:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef48:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef50:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -5200,8 +6368,8 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -5232,9 +6400,9 @@ Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
 Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
-Failed to read String.MakeSeparatorList[loadElemA]
+Failed to read String.MakeSeparatorList[storeElem]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
-Failed to read String.InternalSplitKeepEmptyEntries[loadElem]
+Failed to read String.InternalSplitKeepEmptyEntries[storeElem]
 INFO:  jitting method Path::IsRelative using LLILCJit
 Successfully read Path.IsRelative
 
@@ -5243,8 +6411,8 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -5254,8 +6422,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
@@ -5271,8 +6439,8 @@ entry:
 
 ; <label>:17                                      ; preds = %7
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
@@ -5288,8 +6456,8 @@ entry:
 
 ; <label>:29                                      ; preds = %19
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %31
 
 ; <label>:31                                      ; preds = %29
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
@@ -5300,8 +6468,8 @@ entry:
 
 ; <label>:36                                      ; preds = %31
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
-  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %37, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
@@ -5312,8 +6480,8 @@ entry:
 
 ; <label>:43                                      ; preds = %31, %38
   %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
-  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %45
 
 ; <label>:45                                      ; preds = %43
   %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
@@ -5324,8 +6492,8 @@ entry:
 
 ; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %50
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
@@ -5336,8 +6504,8 @@ entry:
 
 ; <label>:57                                      ; preds = %1, %7, %19, %45, %52
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
-  br i1 %NullCheck14, label %59, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %59
 
 ; <label>:59                                      ; preds = %57
   %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
@@ -5347,8 +6515,8 @@ entry:
 
 ; <label>:63                                      ; preds = %59
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
@@ -5359,8 +6527,8 @@ entry:
 
 ; <label>:70                                      ; preds = %65
   %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
-  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.String addrspace(1)* %71, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %72
 
 ; <label>:72                                      ; preds = %70
   %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
@@ -5379,39 +6547,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %17
+ThrowNullRef4:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %29
+ThrowNullRef6:                                    ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %36
+ThrowNullRef8:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %43
+ThrowNullRef10:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %50
+ThrowNullRef12:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %57
+ThrowNullRef14:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %63
+ThrowNullRef16:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %70
+ThrowNullRef18:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5419,7 +6587,293 @@ ThrowNullRef17:                                   ; preds = %70
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
-Failed to read String.TrimHelper[loadElem]
+Successfully read String.TrimHelper
+
+define %System.String addrspace(1)* @String.TrimHelper(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i16
+  %loc4 = alloca i32
+  %loc5 = alloca i16
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = sub i32 %3, 1
+  store i32 %4, i32* %loc0
+  store i32 0, i32* %loc1
+  %5 = load i32, i32* %arg2
+  %6 = icmp eq i32 %5, 1
+  br i1 %6, label %62, label %7
+
+; <label>:7                                       ; preds = %1
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:8                                       ; preds = %58
+  store i32 0, i32* %loc2
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load i32, i32* %loc1
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2, i32 %10
+  %13 = load i16, i16 addrspace(1)* %12
+  %14 = zext i16 %13 to i32
+  %15 = trunc i32 %14 to i16
+  store i16 %15, i16* %loc3
+  store i32 0, i32* %loc2
+  br label %34
+
+; <label>:16                                      ; preds = %37
+  %17 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %18 = load i32, i32* %loc2
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %17, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %19
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = zext i32 %18 to i64
+  %BoundsCheck = icmp uge i64 %23, %22
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %24
+
+; <label>:24                                      ; preds = %19
+  %25 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 3, i32 %18
+  %26 = load i16, i16 addrspace(1)* %25, align 8
+  %27 = zext i16 %26 to i32
+  %28 = load i16, i16* %loc3
+  %29 = zext i16 %28 to i32
+  %30 = icmp eq i32 %27, %29
+  br i1 %30, label %43, label %31
+
+; <label>:31                                      ; preds = %24
+  %32 = load i32, i32* %loc2
+  %33 = add i32 %32, 1
+  store i32 %33, i32* %loc2
+  br label %34
+
+; <label>:34                                      ; preds = %11, %31
+  %35 = load i32, i32* %loc2
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = icmp slt i32 %35, %41
+  br i1 %42, label %16, label %43
+
+; <label>:43                                      ; preds = %24, %37
+  %44 = load i32, i32* %loc2
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %45, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp eq i32 %44, %50
+  br i1 %51, label %62, label %52
+
+; <label>:52                                      ; preds = %46
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %7, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %57, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %58
+
+; <label>:58                                      ; preds = %55
+  %59 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %60 = load i32, i32 addrspace(1)* %59
+  %61 = icmp slt i32 %56, %60
+  br i1 %61, label %8, label %62
+
+; <label>:62                                      ; preds = %1, %46, %58
+  %63 = load i32, i32* %arg2
+  %64 = icmp eq i32 %63, 0
+  br i1 %64, label %122, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %66, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %67
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %66, i32 0, i32 1
+  %69 = load i32, i32 addrspace(1)* %68
+  %70 = sub i32 %69, 1
+  store i32 %70, i32* %loc0
+  br label %118
+
+; <label>:71                                      ; preds = %118
+  store i32 0, i32* %loc4
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %73 = load i32, i32* %loc0
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %74
+
+; <label>:74                                      ; preds = %71
+  %75 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 2, i32 %73
+  %76 = load i16, i16 addrspace(1)* %75
+  %77 = zext i16 %76 to i32
+  %78 = trunc i32 %77 to i16
+  store i16 %78, i16* %loc5
+  store i32 0, i32* %loc4
+  br label %97
+
+; <label>:79                                      ; preds = %100
+  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %81 = load i32, i32* %loc4
+  %NullCheck19 = icmp eq %"System.Char[]" addrspace(1)* %80, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
+
+; <label>:82                                      ; preds = %79
+  %83 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 1
+  %84 = load i32, i32 addrspace(1)* %83
+  %85 = zext i32 %84 to i64
+  %86 = zext i32 %81 to i64
+  %BoundsCheck21 = icmp uge i64 %86, %85
+  br i1 %BoundsCheck21, label %ThrowIndexOutOfRange22, label %87
+
+; <label>:87                                      ; preds = %82
+  %88 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 3, i32 %81
+  %89 = load i16, i16 addrspace(1)* %88, align 8
+  %90 = zext i16 %89 to i32
+  %91 = load i16, i16* %loc5
+  %92 = zext i16 %91 to i32
+  %93 = icmp eq i32 %90, %92
+  br i1 %93, label %106, label %94
+
+; <label>:94                                      ; preds = %87
+  %95 = load i32, i32* %loc4
+  %96 = add i32 %95, 1
+  store i32 %96, i32* %loc4
+  br label %97
+
+; <label>:97                                      ; preds = %74, %94
+  %98 = load i32, i32* %loc4
+  %99 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck15 = icmp eq %"System.Char[]" addrspace(1)* %99, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %100
+
+; <label>:100                                     ; preds = %97
+  %101 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %99, i32 0, i32 1
+  %102 = load i32, i32 addrspace(1)* %101
+  %103 = zext i32 %102 to i64
+  %104 = trunc i64 %103 to i32
+  %105 = icmp slt i32 %98, %104
+  br i1 %105, label %79, label %106
+
+; <label>:106                                     ; preds = %87, %100
+  %107 = load i32, i32* %loc4
+  %108 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck17 = icmp eq %"System.Char[]" addrspace(1)* %108, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %109
+
+; <label>:109                                     ; preds = %106
+  %110 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %108, i32 0, i32 1
+  %111 = load i32, i32 addrspace(1)* %110
+  %112 = zext i32 %111 to i64
+  %113 = trunc i64 %112 to i32
+  %114 = icmp eq i32 %107, %113
+  br i1 %114, label %122, label %115
+
+; <label>:115                                     ; preds = %109
+  %116 = load i32, i32* %loc0
+  %117 = sub i32 %116, 1
+  store i32 %117, i32* %loc0
+  br label %118
+
+; <label>:118                                     ; preds = %67, %115
+  %119 = load i32, i32* %loc0
+  %120 = load i32, i32* %loc1
+  %121 = icmp sge i32 %119, %120
+  br i1 %121, label %71, label %122
+
+; <label>:122                                     ; preds = %62, %109, %118
+  %123 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %124 = load i32, i32* %loc1
+  %125 = load i32, i32* %loc0
+  %126 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %123, i32 %124, i32 %125)
+  ret %System.String addrspace(1)* %126
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %97
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange22:                           ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
 Successfully read String.CreateTrimmedString
 
@@ -5439,8 +6893,8 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
@@ -5535,8 +6989,8 @@ entry:
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i64 2872
   %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
   %8 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %7
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %3
   %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
@@ -5553,8 +7007,8 @@ entry:
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 2864
   %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
   %21 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %20
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
-  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %22
 
 ; <label>:22                                      ; preds = %16
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
@@ -5569,7 +7023,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %16
+ThrowNullRef2:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5586,8 +7040,8 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5613,8 +7067,8 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
@@ -5632,8 +7086,8 @@ entry:
 
 ; <label>:12                                      ; preds = %4
   %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
@@ -5644,8 +7098,8 @@ entry:
 
 ; <label>:19                                      ; preds = %14
   %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %19
   %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
@@ -5660,21 +7114,21 @@ entry:
   %31 = zext i16 %30 to i32
   %32 = bitcast i8* %29 to i16*
   %33 = trunc i32 %31 to i16
-  %NullCheck6 = icmp ne i16* %32, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i16* %32, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %21
   store i16 %33, i16* %32, align 8
   %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %36
 
 ; <label>:36                                      ; preds = %34
   %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
   %38 = load i32, i32 addrspace(1)* %37, align 8
   %39 = add i32 %38, 1
-  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %40
 
 ; <label>:40                                      ; preds = %36
   %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
@@ -5683,16 +7137,16 @@ entry:
 
 ; <label>:42                                      ; preds = %14
   %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
-  br i1 %NullCheck12, label %44, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
   %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
   %47 = load i16, i16* %arg1
   %48 = zext i16 %47 to i32
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = trunc i32 %48 to i16
@@ -5703,31 +7157,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %19
+ThrowNullRef4:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %21
+ThrowNullRef6:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %36
+ThrowNullRef10:                                   ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %42
+ThrowNullRef12:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %44
+ThrowNullRef14:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5740,8 +7194,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -5752,8 +7206,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
@@ -5762,14 +7216,14 @@ entry:
 
 ; <label>:11                                      ; preds = %1
   %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
@@ -5779,15 +7233,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5808,8 +7262,8 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5822,8 +7276,8 @@ entry:
 
 ; <label>:8                                       ; preds = %3
   %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
@@ -5842,15 +7296,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
-  br i1 %NullCheck4, label %22, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
   %24 = load i16*, i16* addrspace(1)* %23, align 8
   %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %25, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
@@ -5859,8 +7313,8 @@ entry:
   store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
@@ -5874,8 +7328,8 @@ entry:
 
 ; <label>:37                                      ; preds = %65
   %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %37
   %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
@@ -5886,16 +7340,16 @@ entry:
   %45 = bitcast i16* %41 to i8*
   %46 = getelementptr inbounds i8, i8* %45, i64 %44
   %47 = bitcast i8* %46 to i16*
-  %NullCheck14 = icmp ne i16* %47, null
-  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %47, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %48
 
 ; <label>:48                                      ; preds = %39
   %49 = load i16, i16* %47, align 8
   %50 = zext i16 %49 to i32
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %52 = load i32, i32* %loc1
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %53
 
 ; <label>:53                                      ; preds = %48
   %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
@@ -5916,8 +7370,8 @@ entry:
 ; <label>:62                                      ; preds = %36, %59
   %63 = load i32, i32* %loc1
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck10, label %65, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %65
 
 ; <label>:65                                      ; preds = %62
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
@@ -5936,15 +7390,15 @@ entry:
 
 ; <label>:74                                      ; preds = %70
   %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
-  br i1 %NullCheck18, label %76, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %76
 
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
   %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
-  br i1 %NullCheck20, label %80, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
   %81 = load i64, i64 addrspace(1)* %79
@@ -5958,8 +7412,8 @@ entry:
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
   %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
-  br i1 %NullCheck22, label %92, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.String addrspace(1)* %90, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %92
 
 ; <label>:92                                      ; preds = %80
   %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
@@ -5969,15 +7423,15 @@ entry:
 
 ; <label>:96                                      ; preds = %70
   %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
-  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %98
 
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
   %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
-  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
   %103 = load i64, i64 addrspace(1)* %101
@@ -5991,8 +7445,8 @@ entry:
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
   %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
-  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.String addrspace(1)* %112, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %114
 
 ; <label>:114                                     ; preds = %102
   %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
@@ -6004,59 +7458,59 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %20
+ThrowNullRef4:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %22
+ThrowNullRef6:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %26
+ThrowNullRef8:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %62
+ThrowNullRef10:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %48
+ThrowNullRef16:                                   ; preds = %48
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %74
+ThrowNullRef18:                                   ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %76
+ThrowNullRef20:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %80
+ThrowNullRef22:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %96
+ThrowNullRef24:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %98
+ThrowNullRef26:                                   ; preds = %98
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %102
+ThrowNullRef28:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6069,15 +7523,15 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
   %3 = load i16*, i16* addrspace(1)* %2, align 8
   %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
@@ -6087,8 +7541,8 @@ entry:
   %10 = bitcast i16* %3 to i8*
   %11 = getelementptr inbounds i8, i8* %10, i64 %9
   %12 = bitcast i8* %11 to i16*
-  %NullCheck4 = icmp ne i16* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %5
   store i16 0, i16* %12, align 8
@@ -6098,11 +7552,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6119,8 +7573,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -6131,8 +7585,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
@@ -6144,15 +7598,15 @@ entry:
 
 ; <label>:14                                      ; preds = %1
   %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
   %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
   %21 = load i64, i64 addrspace(1)* %19
@@ -6171,15 +7625,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %14
+ThrowNullRef4:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %16
+ThrowNullRef6:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6302,14 +7756,6 @@ entry:
   ret %System.String addrspace(1)* %57
 }
 
-INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
-Successfully read RuntimeHelpers.get_OffsetToStringData
-
-define i32 @RuntimeHelpers.get_OffsetToStringData() {
-entry:
-  ret i32 12
-}
-
 INFO:  jitting method String::Equals using LLILCJit
 Successfully read String.Equals
 
@@ -6381,8 +7827,8 @@ entry:
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
-  br i1 %NullCheck24, label %29, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
   %30 = load i64, i64 addrspace(1)* %28
@@ -6397,8 +7843,8 @@ entry:
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
-  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
   %43 = load i64, i64 addrspace(1)* %41
@@ -6418,8 +7864,8 @@ entry:
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
   %59 = load i64, i64 addrspace(1)* %57
@@ -6434,8 +7880,8 @@ entry:
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck22, label %71, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
   %72 = load i64, i64 addrspace(1)* %70
@@ -6455,8 +7901,8 @@ entry:
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
-  br i1 %NullCheck16, label %87, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = load i64, i64 addrspace(1)* %86
@@ -6471,8 +7917,8 @@ entry:
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck18, label %100, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
   %101 = load i64, i64 addrspace(1)* %99
@@ -6492,8 +7938,8 @@ entry:
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
-  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
   %117 = load i64, i64 addrspace(1)* %115
@@ -6508,8 +7954,8 @@ entry:
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
-  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
   %130 = load i64, i64 addrspace(1)* %128
@@ -6528,15 +7974,15 @@ entry:
 
 ; <label>:142                                     ; preds = %22
   %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
-  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %143, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %144
 
 ; <label>:144                                     ; preds = %142
   %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
   %146 = load i32, i32 addrspace(1)* %145
   %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
-  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %147, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %148
 
 ; <label>:148                                     ; preds = %144
   %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
@@ -6557,15 +8003,15 @@ entry:
 
 ; <label>:159                                     ; preds = %22
   %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
-  br i1 %NullCheck, label %161, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %ThrowNullRef, label %161
 
 ; <label>:161                                     ; preds = %159
   %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
   %163 = load i32, i32 addrspace(1)* %162
   %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
-  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %164, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %165
 
 ; <label>:165                                     ; preds = %161
   %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
@@ -6578,8 +8024,8 @@ entry:
 
 ; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
-  br i1 %NullCheck4, label %172, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %171, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %172
 
 ; <label>:172                                     ; preds = %170
   %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
@@ -6589,8 +8035,8 @@ entry:
 
 ; <label>:176                                     ; preds = %172
   %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
-  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %177, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %178
 
 ; <label>:178                                     ; preds = %176
   %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
@@ -6629,55 +8075,55 @@ ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %161
+ThrowNullRef2:                                    ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %170
+ThrowNullRef4:                                    ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %176
+ThrowNullRef6:                                    ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %142
+ThrowNullRef8:                                    ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %144
+ThrowNullRef10:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %113
+ThrowNullRef12:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %116
+ThrowNullRef14:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %84
+ThrowNullRef16:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %87
+ThrowNullRef18:                                   ; preds = %87
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %55
+ThrowNullRef20:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %58
+ThrowNullRef22:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %26
+ThrowNullRef24:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %29
+ThrowNullRef26:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,8 +8161,8 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck, label %14, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %ThrowNullRef, label %14
 
 ; <label>:14                                      ; preds = %8
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
@@ -6760,8 +8206,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
@@ -6770,14 +8216,14 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32, i32* %loc0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %10
   %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
   %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
@@ -6790,15 +8236,15 @@ entry:
 ; <label>:25                                      ; preds = %19
   %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
-  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
   %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
@@ -6807,8 +8253,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %37 = load i32, i32* %loc0
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %38, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %38
 
 ; <label>:38                                      ; preds = %32
   %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
@@ -6817,14 +8263,14 @@ entry:
 
 ; <label>:40                                      ; preds = %19
   %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %40
   %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
   %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
-  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
-  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
@@ -6832,8 +8278,8 @@ entry:
   %48 = zext i32 %47 to i64
   %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
-  br i1 %NullCheck16, label %51, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %51
 
 ; <label>:51                                      ; preds = %45
   %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
@@ -6847,15 +8293,15 @@ entry:
 ; <label>:57                                      ; preds = %51
   %58 = load i16*, i16** %arg1
   %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
-  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %60
 
 ; <label>:60                                      ; preds = %57
   %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
   %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
-  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %64
 
 ; <label>:64                                      ; preds = %60
   %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
@@ -6864,22 +8310,22 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
   %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
-  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %70
 
 ; <label>:70                                      ; preds = %64
   %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
   %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
-  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
-  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
   %75 = load i32, i32 addrspace(1)* %74
   %76 = zext i32 %75 to i64
   %77 = trunc i64 %76 to i32
-  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
-  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %78
 
 ; <label>:78                                      ; preds = %73
   %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
@@ -6901,8 +8347,8 @@ entry:
   %90 = bitcast i16* %86 to i8*
   %91 = getelementptr inbounds i8, i8* %90, i64 %89
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %93
 
 ; <label>:93                                      ; preds = %80
   %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
@@ -6912,8 +8358,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %99 = load i32, i32* %loc2
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %100
 
 ; <label>:100                                     ; preds = %93
   %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
@@ -6928,63 +8374,63 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %25
+ThrowNullRef6:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %32
+ThrowNullRef10:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %40
+ThrowNullRef12:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %45
+ThrowNullRef16:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %57
+ThrowNullRef18:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %60
+ThrowNullRef20:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %64
+ThrowNullRef22:                                   ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %70
+ThrowNullRef24:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %73
+ThrowNullRef26:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %80
+ThrowNullRef28:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %93
+ThrowNullRef30:                                   ; preds = %93
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7004,8 +8450,8 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
@@ -7033,43 +8479,43 @@ entry:
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %14
   %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
   %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   %28 = load i32, i32 addrspace(1)* %27, align 8
   %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
-  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %30
 
 ; <label>:30                                      ; preds = %26
   %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
   %32 = load i32, i32 addrspace(1)* %31, align 8
   %33 = add i32 %28, %32
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %34
 
 ; <label>:34                                      ; preds = %30
   %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   store i32 %33, i32 addrspace(1)* %35
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
   store i32 0, i32 addrspace(1)* %38
   %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %40
 
 ; <label>:40                                      ; preds = %37
   %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
@@ -7082,8 +8528,8 @@ entry:
 
 ; <label>:47                                      ; preds = %40
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
@@ -7098,8 +8544,8 @@ entry:
   %54 = load i32, i32* %loc0
   %55 = sext i32 %54 to i64
   %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
-  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %57
 
 ; <label>:57                                      ; preds = %52
   %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
@@ -7110,68 +8556,35 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %14
+ThrowNullRef2:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %23
+ThrowNullRef4:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %26
+ThrowNullRef6:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %30
+ThrowNullRef8:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %34
+ThrowNullRef10:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %47
+ThrowNullRef14:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %52
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-}
-
-INFO:  jitting method StringBuilder::get_Length using LLILCJit
-Successfully read StringBuilder.get_Length
-
-define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.StringBuilder addrspace(1)*
-  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
-  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
-
-; <label>:1                                       ; preds = %entry
-  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %3 = load i32, i32 addrspace(1)* %2, align 8
-  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
-
-; <label>:5                                       ; preds = %1
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = add i32 %3, %7
-  ret i32 %8
-
-ThrowNullRef:                                     ; preds = %entry
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef16:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7213,70 +8626,70 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
   %6 = load i32, i32 addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
   store i32 %6, i32 addrspace(1)* %8
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
   %13 = load i32, i32 addrspace(1)* %12, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
   store i32 %13, i32 addrspace(1)* %15
   %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
-  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %18
 
 ; <label>:18                                      ; preds = %14
   %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
   %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
   %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
   %34 = load i32, i32 addrspace(1)* %33, align 8
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
-  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
@@ -7287,39 +8700,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %28
+ThrowNullRef16:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %32
+ThrowNullRef18:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7455,13 +8868,13 @@ entry:
 ; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
@@ -7477,16 +8890,16 @@ entry:
 
 ; <label>:18                                      ; preds = %15
   %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
   store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
   %22 = load i32, i32* %loc0
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %24
 
 ; <label>:24                                      ; preds = %20
   %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
@@ -7498,13 +8911,13 @@ entry:
 ; <label>:28                                      ; preds = %15, %24
   %29 = load i32, i32* %arg1
   %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %31
   %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
@@ -7517,20 +8930,20 @@ entry:
   %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
-  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
   %46 = load i32, i32 addrspace(1)* %45, align 8
   %47 = sub i32 %40, %46
-  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
-  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i32 addrspace(1)* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %48
 
 ; <label>:48                                      ; preds = %44
   store i32 %47, i32 addrspace(1)* %39, align 8
@@ -7538,21 +8951,21 @@ entry:
 
 ; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
-  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %51
 
 ; <label>:51                                      ; preds = %49
   %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %53
 
 ; <label>:53                                      ; preds = %51
   %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
   %55 = load i32, i32 addrspace(1)* %54, align 8
   %56 = load i32, i32* %arg2
   %57 = sub i32 %55, %56
-  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %58
 
 ; <label>:58                                      ; preds = %53
   %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
@@ -7562,13 +8975,13 @@ entry:
 ; <label>:60                                      ; preds = %33, %58
   %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
   %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
-  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %63
 
 ; <label>:63                                      ; preds = %60
   %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
-  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
-  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
@@ -7578,15 +8991,15 @@ entry:
 
 ; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
-  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i32 addrspace(1)* %69, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %70
 
 ; <label>:70                                      ; preds = %68
   %71 = load i32, i32 addrspace(1)* %69, align 8
   store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
-  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
@@ -7596,8 +9009,8 @@ entry:
   store i32 %77, i32* %loc4
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
-  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %80
 
 ; <label>:80                                      ; preds = %73
   %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
@@ -7607,71 +9020,71 @@ entry:
 ; <label>:83                                      ; preds = %80
   store i32 0, i32* %loc3
   %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
-  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
-  br i1 %NullCheck26, label %88, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i32 addrspace(1)* %87, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %88
 
 ; <label>:88                                      ; preds = %85
   %89 = load i32, i32 addrspace(1)* %87, align 8
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
-  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %90
 
 ; <label>:90                                      ; preds = %88
   %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
   store i32 %89, i32 addrspace(1)* %91
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
-  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
-  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %96
 
 ; <label>:96                                      ; preds = %94
   %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
-  br i1 %NullCheck34, label %100, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %100
 
 ; <label>:100                                     ; preds = %96
   %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
-  br i1 %NullCheck36, label %102, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %102
 
 ; <label>:102                                     ; preds = %100
   %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
   %104 = load i32, i32 addrspace(1)* %103, align 8
   %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
-  br i1 %NullCheck38, label %106, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %106
 
 ; <label>:106                                     ; preds = %102
   %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
-  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
-  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %108
 
 ; <label>:108                                     ; preds = %106
   %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
   %110 = load i32, i32 addrspace(1)* %109, align 8
   %111 = add i32 %104, %110
-  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %112
 
 ; <label>:112                                     ; preds = %108
   %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
   store i32 %111, i32 addrspace(1)* %113
   %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
-  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i32 addrspace(1)* %114, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %115
 
 ; <label>:115                                     ; preds = %112
   %116 = load i32, i32 addrspace(1)* %114, align 8
@@ -7681,19 +9094,19 @@ entry:
 ; <label>:118                                     ; preds = %115
   %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
-  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %121
 
 ; <label>:121                                     ; preds = %118
   %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
-  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
-  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %123
 
 ; <label>:123                                     ; preds = %121
   %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
   %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
-  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
-  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %126
 
 ; <label>:126                                     ; preds = %123
   %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
@@ -7705,8 +9118,8 @@ entry:
 
 ; <label>:130                                     ; preds = %80, %115, %126
   %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %132
 
 ; <label>:132                                     ; preds = %130
   %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7715,8 +9128,8 @@ entry:
   %136 = load i32, i32* %loc3
   %137 = sub i32 %135, %136
   %138 = sub i32 %134, %137
-  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %139
 
 ; <label>:139                                     ; preds = %132
   %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7728,16 +9141,16 @@ entry:
 
 ; <label>:144                                     ; preds = %139
   %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
-  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %146
 
 ; <label>:146                                     ; preds = %144
   %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
   %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
   %149 = load i32, i32* %loc2
   %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
-  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %151
 
 ; <label>:151                                     ; preds = %146
   %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
@@ -7754,145 +9167,249 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %18
+ThrowNullRef4:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %31
+ThrowNullRef10:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %44
+ThrowNullRef16:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %68
+ThrowNullRef18:                                   ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %70
+ThrowNullRef20:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %73
+ThrowNullRef22:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %83
+ThrowNullRef24:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %85
+ThrowNullRef26:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %88
+ThrowNullRef28:                                   ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %90
+ThrowNullRef30:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %94
+ThrowNullRef32:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %96
+ThrowNullRef34:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %100
+ThrowNullRef36:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %102
+ThrowNullRef38:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %106
+ThrowNullRef40:                                   ; preds = %106
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %108
+ThrowNullRef42:                                   ; preds = %108
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %112
+ThrowNullRef44:                                   ; preds = %112
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %118
+ThrowNullRef46:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %121
+ThrowNullRef48:                                   ; preds = %121
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %123
+ThrowNullRef50:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %130
+ThrowNullRef52:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %132
+ThrowNullRef54:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %144
+ThrowNullRef56:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %146
+ThrowNullRef58:                                   ; preds = %146
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %60
+ThrowNullRef60:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %63
+ThrowNullRef62:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %49
+ThrowNullRef64:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %51
+ThrowNullRef66:                                   ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %53
+ThrowNullRef68:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(%"System.Char[]" addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %arg0 = alloca %"System.Char[]" addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store %"System.Char[]" addrspace(1)* %param0, %"System.Char[]" addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load i32, i32* %arg4
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %43, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %38, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg1
+  %13 = load i32, i32* %arg4
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %38, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %24 = load i32, i32* %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %35 = load i32, i32* %arg3
+  %36 = load i32, i32* %arg4
+  %37 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %37, %"System.Char[]" addrspace(1)* %34, i32 %35, i32 %36)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:38                                      ; preds = %5, %16
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Successfully read Buffer._Memmove
 
@@ -7914,7 +9431,7 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[loadElem]
+Failed to read AppDomain.SetDataHelper[storeElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -7923,8 +9440,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
@@ -7934,8 +9451,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
@@ -7947,15 +9464,15 @@ entry:
   %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
   %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
@@ -7966,15 +9483,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7992,7 +9509,79 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
-Failed to read Dictionary`2.TryGetValue[loadElemA]
+Successfully read Dictionary`2.TryGetValue
+
+define i8 @"Dictionary`2.TryGetValue"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)* addrspace(1)* %param2) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  %arg2 = alloca %System.__Canon addrspace(1)* addrspace(1)*
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  store %System.__Canon addrspace(1)* addrspace(1)* %param2, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  store i32 %2, i32* %loc0
+  %3 = load i32, i32* %loc0
+  %4 = icmp slt i32 %3, 0
+  br i1 %4, label %22, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 2
+  %10 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %9, align 8
+  %11 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = zext i32 %11 to i64
+  %BoundsCheck = icmp uge i64 %16, %15
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 3, i32 %11
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %20, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %6, %System.__Canon addrspace(1)* %21)
+  ret i8 1
+
+; <label>:22                                      ; preds = %entry
+  %23 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %23, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -8058,8 +9647,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
@@ -8091,8 +9680,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
@@ -8171,15 +9760,15 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck, label %19, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %ThrowNullRef, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
   %21 = load i32, i32 addrspace(1)* %20
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
@@ -8202,7 +9791,7 @@ ThrowNullRef:                                     ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %19
+ThrowNullRef2:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8248,8 +9837,8 @@ entry:
   %0 = alloca %System.AppDomainHandle
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %1 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %1, i32 0, i32 15
@@ -8269,8 +9858,8 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
@@ -8286,7 +9875,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -8299,8 +9888,8 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -8327,8 +9916,8 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
@@ -8352,8 +9941,8 @@ entry:
   %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
   store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
@@ -8363,8 +9952,8 @@ entry:
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
@@ -8374,8 +9963,8 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %9
   %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
@@ -8384,8 +9973,8 @@ entry:
 
 ; <label>:18                                      ; preds = %3, %16
   %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
@@ -8397,15 +9986,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %18
+ThrowNullRef6:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8418,8 +10007,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
@@ -8453,15 +10042,15 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
@@ -8473,7 +10062,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8481,7 +10070,7 @@ ThrowNullRef1:                                    ; preds = %1
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
 Failed to read Dictionary`2.System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
@@ -8506,8 +10095,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
@@ -8524,8 +10113,8 @@ entry:
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -8544,7 +10133,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8577,8 +10166,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = load i64, i64* %arg2
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = trunc i32 %3 to i8
@@ -8634,46 +10223,46 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
   %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
-  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
-  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
-  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
@@ -8684,27 +10273,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %20
+ThrowNullRef12:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8717,8 +10306,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -8756,22 +10345,22 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
   %9 = load i64, i64 addrspace(1)* %8, align 8
   %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
   %13 = load i64, i64 addrspace(1)* %12, align 8
   %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %11
   %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
@@ -8788,11 +10377,11 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8882,8 +10471,8 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
@@ -8900,8 +10489,8 @@ entry:
 ; <label>:8                                       ; preds = %1
   %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
   %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
@@ -8911,15 +10500,15 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
   %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
   %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
-  br i1 %NullCheck6, label %21, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
@@ -8946,15 +10535,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8992,15 +10581,15 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
   store i8 %3, i8 addrspace(1)* %5
   %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
@@ -9011,7 +10600,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9027,8 +10616,8 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -9041,8 +10630,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
@@ -9058,7 +10647,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9080,8 +10669,8 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
@@ -9096,8 +10685,8 @@ entry:
 ; <label>:12                                      ; preds = %6
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
@@ -9112,8 +10701,8 @@ entry:
 ; <label>:21                                      ; preds = %15
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
@@ -9128,8 +10717,8 @@ entry:
 ; <label>:30                                      ; preds = %24
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %31, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
@@ -9144,8 +10733,8 @@ entry:
 ; <label>:39                                      ; preds = %33
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
-  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %40, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %42
 
 ; <label>:42                                      ; preds = %39
   %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
@@ -9164,19 +10753,19 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %21
+ThrowNullRef4:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %30
+ThrowNullRef6:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %39
+ThrowNullRef8:                                    ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9243,8 +10832,8 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
@@ -9264,57 +10853,57 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
   store i8 0, i8 addrspace(1)* %2
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
   store i8 0, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
   store i8 0, i8 addrspace(1)* %17
   %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
   store i8 0, i8 addrspace(1)* %20
   %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
-  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
@@ -9325,31 +10914,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %19
+ThrowNullRef14:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9367,8 +10956,8 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
@@ -9380,8 +10969,8 @@ entry:
 
 ; <label>:9                                       ; preds = %4
   %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %9
   %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
@@ -9395,7 +10984,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef2:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9420,8 +11009,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
@@ -9512,8 +11101,8 @@ entry:
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
@@ -9524,8 +11113,8 @@ entry:
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = load i64, i64 addrspace(1)* %12
@@ -9537,8 +11126,8 @@ entry:
   %20 = load i64, i64* %19
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
-  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %13
   %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
@@ -9555,8 +11144,8 @@ entry:
 ; <label>:30                                      ; preds = %25
   %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %32 = load i32, i32* %arg2
-  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
-  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
@@ -9570,15 +11159,15 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %30
+ThrowNullRef2:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9622,87 +11211,87 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
   %10 = load i8, i8 addrspace(1)* %9, align 8
   %11 = zext i8 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %8
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
   store i8 %12, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
   %19 = load i8, i8 addrspace(1)* %18, align 8
   %20 = zext i8 %19 to i32
   %21 = trunc i32 %20 to i8
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
   store i8 %21, i8 addrspace(1)* %23
   %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
   %28 = load i8, i8 addrspace(1)* %27, align 8
   %29 = zext i8 %28 to i32
   %30 = trunc i32 %29 to i8
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
-  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %31
 
 ; <label>:31                                      ; preds = %26
   %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
   store i8 %30, i8 addrspace(1)* %32
   %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
-  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
-  br i1 %NullCheck14, label %40, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %40
 
 ; <label>:40                                      ; preds = %35
   %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
   store i8 %39, i8 addrspace(1)* %41
   %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
-  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %44
 
 ; <label>:44                                      ; preds = %40
   %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
   %46 = load i8, i8 addrspace(1)* %45, align 8
   %47 = zext i8 %46 to i32
   %48 = trunc i32 %47 to i8
-  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
   store i8 %48, i8 addrspace(1)* %50
   %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
-  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
@@ -9713,29 +11302,29 @@ entry:
 ; <label>:56                                      ; preds = %52
   %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
-  br i1 %NullCheck22, label %59, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
   %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
   %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
-  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
-  br i1 %NullCheck24, label %63, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
   %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
-  br i1 %NullCheck26, label %66, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
   %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
-  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
-  br i1 %NullCheck28, label %69, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %69
 
 ; <label>:69                                      ; preds = %66
   %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
@@ -9744,15 +11333,15 @@ entry:
 
 ; <label>:71                                      ; preds = %105
   %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
-  br i1 %NullCheck34, label %73, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %73
 
 ; <label>:73                                      ; preds = %71
   %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
   %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
   %76 = load i32, i32* %loc0
-  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
-  br i1 %NullCheck36, label %77, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
@@ -9766,8 +11355,8 @@ entry:
 
 ; <label>:83                                      ; preds = %77
   %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
-  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
@@ -9775,14 +11364,14 @@ entry:
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
   %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
-  br i1 %NullCheck40, label %91, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
 ; <label>:91                                      ; preds = %85
   %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
   %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
-  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck42, label %94, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %94
 
 ; <label>:94                                      ; preds = %91
   %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
@@ -9798,14 +11387,14 @@ entry:
 ; <label>:99                                      ; preds = %69, %96
   %100 = load i32, i32* %loc0
   %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
-  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %102
 
 ; <label>:102                                     ; preds = %99
   %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
   %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
-  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
-  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
@@ -9819,87 +11408,87 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %26
+ThrowNullRef10:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %31
+ThrowNullRef12:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %35
+ThrowNullRef14:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %40
+ThrowNullRef16:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %56
+ThrowNullRef22:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %59
+ThrowNullRef24:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %63
+ThrowNullRef26:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %66
+ThrowNullRef28:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %102
+ThrowNullRef32:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %71
+ThrowNullRef34:                                   ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %73
+ThrowNullRef36:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %83
+ThrowNullRef38:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %85
+ThrowNullRef40:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %91
+ThrowNullRef42:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9943,15 +11532,15 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
   %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
@@ -9961,28 +11550,28 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
   %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %12
   %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
   %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
   %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
-  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
@@ -9993,23 +11582,23 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %12
+ThrowNullRef6:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10031,15 +11620,15 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
   %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = load i64, i64 addrspace(1)* %7
@@ -10077,13 +11666,13 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[loadElem]
+Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -10111,8 +11700,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueLtFP.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueLtFP.error.txt
@@ -25,8 +25,8 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
@@ -40,8 +40,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
   %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
@@ -75,7 +75,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -90,8 +90,8 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %NullCheck = icmp ne i8 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = load i8, i8 addrspace(1)* %0, align 8
@@ -125,8 +125,8 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
@@ -159,8 +159,8 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -184,8 +184,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
   store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
@@ -195,8 +195,8 @@ entry:
 ; <label>:4                                       ; preds = %1
   %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
   %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
@@ -206,8 +206,8 @@ entry:
   %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
@@ -221,14 +221,14 @@ entry:
 
 ; <label>:17                                      ; preds = %14
   %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
   %21 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
@@ -238,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -249,8 +249,8 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
@@ -261,27 +261,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %30
+ThrowNullRef10:                                   ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -301,7 +301,89 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
-Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
+Successfully read AppDomainSetup.GetUnsecureApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.GetUnsecureApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %NullCheck = icmp eq %"System.String[]" addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %BoundsCheck = icmp uge i64 0, %5
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %6
+
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 3, i32 0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
+  ret %System.String addrspace(1)* %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_Value using LLILCJit
+Successfully read AppDomainSetup.get_Value
+
+define %"System.String[]" addrspace(1)* @AppDomainSetup.get_Value(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.String[]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 18)
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.String[]" addrspace(1)* addrspace(1)*, %"System.String[]" addrspace(1)*)*)(%"System.String[]" addrspace(1)* addrspace(1)* %9, %"System.String[]" addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %11, i32 0, i32 1
+  %14 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %13, align 8
+  ret %"System.String[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -319,8 +401,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -368,16 +450,16 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
   %5 = load i32, i32 addrspace(1)* %4
   %6 = sub i32 %5, 1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -389,7 +471,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -421,8 +503,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
@@ -456,8 +538,8 @@ entry:
 ; <label>:27                                      ; preds = %19
   %28 = load i32, i32* %arg1
   %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
-  br i1 %NullCheck2, label %30, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %29, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %30
 
 ; <label>:30                                      ; preds = %27
   %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
@@ -493,8 +575,8 @@ entry:
 ; <label>:49                                      ; preds = %46
   %50 = load i32, i32* %arg2
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck4, label %52, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
@@ -517,11 +599,11 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %27
+ThrowNullRef2:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %49
+ThrowNullRef4:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -544,16 +626,16 @@ entry:
   %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %0)
   store %System.String addrspace(1)* %1, %System.String addrspace(1)** %loc0
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 2
   %5 = bitcast [0 x i16] addrspace(1)* %4 to i16 addrspace(1)*
   store i16 addrspace(1)* %5, i16 addrspace(1)** %loc1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %3
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2
@@ -580,7 +662,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -691,15 +773,15 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %NullCheck132 = icmp ne i8* %21, null
-  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+  %NullCheck131 = icmp eq i8* %21, null
+  br i1 %NullCheck131, label %ThrowNullRef132, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = load i8, i8* %21, align 8
   %24 = zext i8 %23 to i32
   %25 = trunc i32 %24 to i8
-  %NullCheck134 = icmp ne i8* %20, null
-  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+  %NullCheck133 = icmp eq i8* %20, null
+  br i1 %NullCheck133, label %ThrowNullRef134, label %26
 
 ; <label>:26                                      ; preds = %22
   store i8 %25, i8* %20, align 8
@@ -709,16 +791,16 @@ entry:
   %28 = load i8*, i8** %arg0
   %29 = load i8*, i8** %arg1
   %30 = bitcast i8* %29 to i16*
-  %NullCheck128 = icmp ne i16* %30, null
-  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+  %NullCheck127 = icmp eq i16* %30, null
+  br i1 %NullCheck127, label %ThrowNullRef128, label %31
 
 ; <label>:31                                      ; preds = %27
   %32 = load i16, i16* %30, align 8
   %33 = sext i16 %32 to i32
   %34 = bitcast i8* %28 to i16*
   %35 = trunc i32 %33 to i16
-  %NullCheck130 = icmp ne i16* %34, null
-  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+  %NullCheck129 = icmp eq i16* %34, null
+  br i1 %NullCheck129, label %ThrowNullRef130, label %36
 
 ; <label>:36                                      ; preds = %31
   store i16 %35, i16* %34, align 8
@@ -728,16 +810,16 @@ entry:
   %38 = load i8*, i8** %arg0
   %39 = load i8*, i8** %arg1
   %40 = bitcast i8* %39 to i16*
-  %NullCheck120 = icmp ne i16* %40, null
-  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+  %NullCheck119 = icmp eq i16* %40, null
+  br i1 %NullCheck119, label %ThrowNullRef120, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i16, i16* %40, align 8
   %43 = sext i16 %42 to i32
   %44 = bitcast i8* %38 to i16*
   %45 = trunc i32 %43 to i16
-  %NullCheck122 = icmp ne i16* %44, null
-  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+  %NullCheck121 = icmp eq i16* %44, null
+  br i1 %NullCheck121, label %ThrowNullRef122, label %46
 
 ; <label>:46                                      ; preds = %41
   store i16 %45, i16* %44, align 8
@@ -745,15 +827,15 @@ entry:
   %48 = getelementptr inbounds i8, i8* %47, i64 2
   %49 = load i8*, i8** %arg1
   %50 = getelementptr inbounds i8, i8* %49, i64 2
-  %NullCheck124 = icmp ne i8* %50, null
-  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+  %NullCheck123 = icmp eq i8* %50, null
+  br i1 %NullCheck123, label %ThrowNullRef124, label %51
 
 ; <label>:51                                      ; preds = %46
   %52 = load i8, i8* %50, align 8
   %53 = zext i8 %52 to i32
   %54 = trunc i32 %53 to i8
-  %NullCheck126 = icmp ne i8* %48, null
-  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+  %NullCheck125 = icmp eq i8* %48, null
+  br i1 %NullCheck125, label %ThrowNullRef126, label %55
 
 ; <label>:55                                      ; preds = %51
   store i8 %54, i8* %48, align 8
@@ -763,14 +845,14 @@ entry:
   %57 = load i8*, i8** %arg0
   %58 = load i8*, i8** %arg1
   %59 = bitcast i8* %58 to i32*
-  %NullCheck116 = icmp ne i32* %59, null
-  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+  %NullCheck115 = icmp eq i32* %59, null
+  br i1 %NullCheck115, label %ThrowNullRef116, label %60
 
 ; <label>:60                                      ; preds = %56
   %61 = load i32, i32* %59, align 8
   %62 = bitcast i8* %57 to i32*
-  %NullCheck118 = icmp ne i32* %62, null
-  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+  %NullCheck117 = icmp eq i32* %62, null
+  br i1 %NullCheck117, label %ThrowNullRef118, label %63
 
 ; <label>:63                                      ; preds = %60
   store i32 %61, i32* %62, align 8
@@ -780,14 +862,14 @@ entry:
   %65 = load i8*, i8** %arg0
   %66 = load i8*, i8** %arg1
   %67 = bitcast i8* %66 to i32*
-  %NullCheck108 = icmp ne i32* %67, null
-  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+  %NullCheck107 = icmp eq i32* %67, null
+  br i1 %NullCheck107, label %ThrowNullRef108, label %68
 
 ; <label>:68                                      ; preds = %64
   %69 = load i32, i32* %67, align 8
   %70 = bitcast i8* %65 to i32*
-  %NullCheck110 = icmp ne i32* %70, null
-  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+  %NullCheck109 = icmp eq i32* %70, null
+  br i1 %NullCheck109, label %ThrowNullRef110, label %71
 
 ; <label>:71                                      ; preds = %68
   store i32 %69, i32* %70, align 8
@@ -795,15 +877,15 @@ entry:
   %73 = getelementptr inbounds i8, i8* %72, i64 4
   %74 = load i8*, i8** %arg1
   %75 = getelementptr inbounds i8, i8* %74, i64 4
-  %NullCheck112 = icmp ne i8* %75, null
-  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+  %NullCheck111 = icmp eq i8* %75, null
+  br i1 %NullCheck111, label %ThrowNullRef112, label %76
 
 ; <label>:76                                      ; preds = %71
   %77 = load i8, i8* %75, align 8
   %78 = zext i8 %77 to i32
   %79 = trunc i32 %78 to i8
-  %NullCheck114 = icmp ne i8* %73, null
-  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+  %NullCheck113 = icmp eq i8* %73, null
+  br i1 %NullCheck113, label %ThrowNullRef114, label %80
 
 ; <label>:80                                      ; preds = %76
   store i8 %79, i8* %73, align 8
@@ -813,14 +895,14 @@ entry:
   %82 = load i8*, i8** %arg0
   %83 = load i8*, i8** %arg1
   %84 = bitcast i8* %83 to i32*
-  %NullCheck100 = icmp ne i32* %84, null
-  br i1 %NullCheck100, label %85, label %ThrowNullRef99
+  %NullCheck99 = icmp eq i32* %84, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %85
 
 ; <label>:85                                      ; preds = %81
   %86 = load i32, i32* %84, align 8
   %87 = bitcast i8* %82 to i32*
-  %NullCheck102 = icmp ne i32* %87, null
-  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+  %NullCheck101 = icmp eq i32* %87, null
+  br i1 %NullCheck101, label %ThrowNullRef102, label %88
 
 ; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
@@ -829,16 +911,16 @@ entry:
   %91 = load i8*, i8** %arg1
   %92 = getelementptr inbounds i8, i8* %91, i64 4
   %93 = bitcast i8* %92 to i16*
-  %NullCheck104 = icmp ne i16* %93, null
-  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+  %NullCheck103 = icmp eq i16* %93, null
+  br i1 %NullCheck103, label %ThrowNullRef104, label %94
 
 ; <label>:94                                      ; preds = %88
   %95 = load i16, i16* %93, align 8
   %96 = sext i16 %95 to i32
   %97 = bitcast i8* %90 to i16*
   %98 = trunc i32 %96 to i16
-  %NullCheck106 = icmp ne i16* %97, null
-  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+  %NullCheck105 = icmp eq i16* %97, null
+  br i1 %NullCheck105, label %ThrowNullRef106, label %99
 
 ; <label>:99                                      ; preds = %94
   store i16 %98, i16* %97, align 8
@@ -848,14 +930,14 @@ entry:
   %101 = load i8*, i8** %arg0
   %102 = load i8*, i8** %arg1
   %103 = bitcast i8* %102 to i32*
-  %NullCheck88 = icmp ne i32* %103, null
-  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+  %NullCheck87 = icmp eq i32* %103, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %104
 
 ; <label>:104                                     ; preds = %100
   %105 = load i32, i32* %103, align 8
   %106 = bitcast i8* %101 to i32*
-  %NullCheck90 = icmp ne i32* %106, null
-  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+  %NullCheck89 = icmp eq i32* %106, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %107
 
 ; <label>:107                                     ; preds = %104
   store i32 %105, i32* %106, align 8
@@ -864,16 +946,16 @@ entry:
   %110 = load i8*, i8** %arg1
   %111 = getelementptr inbounds i8, i8* %110, i64 4
   %112 = bitcast i8* %111 to i16*
-  %NullCheck92 = icmp ne i16* %112, null
-  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+  %NullCheck91 = icmp eq i16* %112, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %113
 
 ; <label>:113                                     ; preds = %107
   %114 = load i16, i16* %112, align 8
   %115 = sext i16 %114 to i32
   %116 = bitcast i8* %109 to i16*
   %117 = trunc i32 %115 to i16
-  %NullCheck94 = icmp ne i16* %116, null
-  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+  %NullCheck93 = icmp eq i16* %116, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %118
 
 ; <label>:118                                     ; preds = %113
   store i16 %117, i16* %116, align 8
@@ -881,15 +963,15 @@ entry:
   %120 = getelementptr inbounds i8, i8* %119, i64 6
   %121 = load i8*, i8** %arg1
   %122 = getelementptr inbounds i8, i8* %121, i64 6
-  %NullCheck96 = icmp ne i8* %122, null
-  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+  %NullCheck95 = icmp eq i8* %122, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %123
 
 ; <label>:123                                     ; preds = %118
   %124 = load i8, i8* %122, align 8
   %125 = zext i8 %124 to i32
   %126 = trunc i32 %125 to i8
-  %NullCheck98 = icmp ne i8* %120, null
-  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+  %NullCheck97 = icmp eq i8* %120, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %127
 
 ; <label>:127                                     ; preds = %123
   store i8 %126, i8* %120, align 8
@@ -899,14 +981,14 @@ entry:
   %129 = load i8*, i8** %arg0
   %130 = load i8*, i8** %arg1
   %131 = bitcast i8* %130 to i64*
-  %NullCheck84 = icmp ne i64* %131, null
-  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+  %NullCheck83 = icmp eq i64* %131, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %132
 
 ; <label>:132                                     ; preds = %128
   %133 = load i64, i64* %131, align 8
   %134 = bitcast i8* %129 to i64*
-  %NullCheck86 = icmp ne i64* %134, null
-  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+  %NullCheck85 = icmp eq i64* %134, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %135
 
 ; <label>:135                                     ; preds = %132
   store i64 %133, i64* %134, align 8
@@ -916,14 +998,14 @@ entry:
   %137 = load i8*, i8** %arg0
   %138 = load i8*, i8** %arg1
   %139 = bitcast i8* %138 to i64*
-  %NullCheck76 = icmp ne i64* %139, null
-  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+  %NullCheck75 = icmp eq i64* %139, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %140
 
 ; <label>:140                                     ; preds = %136
   %141 = load i64, i64* %139, align 8
   %142 = bitcast i8* %137 to i64*
-  %NullCheck78 = icmp ne i64* %142, null
-  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+  %NullCheck77 = icmp eq i64* %142, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %143
 
 ; <label>:143                                     ; preds = %140
   store i64 %141, i64* %142, align 8
@@ -931,15 +1013,15 @@ entry:
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %NullCheck80 = icmp ne i8* %147, null
-  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+  %NullCheck79 = icmp eq i8* %147, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %148
 
 ; <label>:148                                     ; preds = %143
   %149 = load i8, i8* %147, align 8
   %150 = zext i8 %149 to i32
   %151 = trunc i32 %150 to i8
-  %NullCheck82 = icmp ne i8* %145, null
-  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+  %NullCheck81 = icmp eq i8* %145, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %152
 
 ; <label>:152                                     ; preds = %148
   store i8 %151, i8* %145, align 8
@@ -949,14 +1031,14 @@ entry:
   %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
   %156 = bitcast i8* %155 to i64*
-  %NullCheck68 = icmp ne i64* %156, null
-  br i1 %NullCheck68, label %157, label %ThrowNullRef67
+  %NullCheck67 = icmp eq i64* %156, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %157
 
 ; <label>:157                                     ; preds = %153
   %158 = load i64, i64* %156, align 8
   %159 = bitcast i8* %154 to i64*
-  %NullCheck70 = icmp ne i64* %159, null
-  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+  %NullCheck69 = icmp eq i64* %159, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %160
 
 ; <label>:160                                     ; preds = %157
   store i64 %158, i64* %159, align 8
@@ -965,16 +1047,16 @@ entry:
   %163 = load i8*, i8** %arg1
   %164 = getelementptr inbounds i8, i8* %163, i64 8
   %165 = bitcast i8* %164 to i16*
-  %NullCheck72 = icmp ne i16* %165, null
-  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+  %NullCheck71 = icmp eq i16* %165, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %166
 
 ; <label>:166                                     ; preds = %160
   %167 = load i16, i16* %165, align 8
   %168 = sext i16 %167 to i32
   %169 = bitcast i8* %162 to i16*
   %170 = trunc i32 %168 to i16
-  %NullCheck74 = icmp ne i16* %169, null
-  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+  %NullCheck73 = icmp eq i16* %169, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %171
 
 ; <label>:171                                     ; preds = %166
   store i16 %170, i16* %169, align 8
@@ -984,14 +1066,14 @@ entry:
   %173 = load i8*, i8** %arg0
   %174 = load i8*, i8** %arg1
   %175 = bitcast i8* %174 to i64*
-  %NullCheck56 = icmp ne i64* %175, null
-  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+  %NullCheck55 = icmp eq i64* %175, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %176
 
 ; <label>:176                                     ; preds = %172
   %177 = load i64, i64* %175, align 8
   %178 = bitcast i8* %173 to i64*
-  %NullCheck58 = icmp ne i64* %178, null
-  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+  %NullCheck57 = icmp eq i64* %178, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %179
 
 ; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
@@ -1000,16 +1082,16 @@ entry:
   %182 = load i8*, i8** %arg1
   %183 = getelementptr inbounds i8, i8* %182, i64 8
   %184 = bitcast i8* %183 to i16*
-  %NullCheck60 = icmp ne i16* %184, null
-  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+  %NullCheck59 = icmp eq i16* %184, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %185
 
 ; <label>:185                                     ; preds = %179
   %186 = load i16, i16* %184, align 8
   %187 = sext i16 %186 to i32
   %188 = bitcast i8* %181 to i16*
   %189 = trunc i32 %187 to i16
-  %NullCheck62 = icmp ne i16* %188, null
-  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+  %NullCheck61 = icmp eq i16* %188, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %190
 
 ; <label>:190                                     ; preds = %185
   store i16 %189, i16* %188, align 8
@@ -1017,15 +1099,15 @@ entry:
   %192 = getelementptr inbounds i8, i8* %191, i64 10
   %193 = load i8*, i8** %arg1
   %194 = getelementptr inbounds i8, i8* %193, i64 10
-  %NullCheck64 = icmp ne i8* %194, null
-  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+  %NullCheck63 = icmp eq i8* %194, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %195
 
 ; <label>:195                                     ; preds = %190
   %196 = load i8, i8* %194, align 8
   %197 = zext i8 %196 to i32
   %198 = trunc i32 %197 to i8
-  %NullCheck66 = icmp ne i8* %192, null
-  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+  %NullCheck65 = icmp eq i8* %192, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %199
 
 ; <label>:199                                     ; preds = %195
   store i8 %198, i8* %192, align 8
@@ -1035,14 +1117,14 @@ entry:
   %201 = load i8*, i8** %arg0
   %202 = load i8*, i8** %arg1
   %203 = bitcast i8* %202 to i64*
-  %NullCheck48 = icmp ne i64* %203, null
-  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+  %NullCheck47 = icmp eq i64* %203, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %204
 
 ; <label>:204                                     ; preds = %200
   %205 = load i64, i64* %203, align 8
   %206 = bitcast i8* %201 to i64*
-  %NullCheck50 = icmp ne i64* %206, null
-  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+  %NullCheck49 = icmp eq i64* %206, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %207
 
 ; <label>:207                                     ; preds = %204
   store i64 %205, i64* %206, align 8
@@ -1051,14 +1133,14 @@ entry:
   %210 = load i8*, i8** %arg1
   %211 = getelementptr inbounds i8, i8* %210, i64 8
   %212 = bitcast i8* %211 to i32*
-  %NullCheck52 = icmp ne i32* %212, null
-  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+  %NullCheck51 = icmp eq i32* %212, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %213
 
 ; <label>:213                                     ; preds = %207
   %214 = load i32, i32* %212, align 8
   %215 = bitcast i8* %209 to i32*
-  %NullCheck54 = icmp ne i32* %215, null
-  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+  %NullCheck53 = icmp eq i32* %215, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %216
 
 ; <label>:216                                     ; preds = %213
   store i32 %214, i32* %215, align 8
@@ -1068,14 +1150,14 @@ entry:
   %218 = load i8*, i8** %arg0
   %219 = load i8*, i8** %arg1
   %220 = bitcast i8* %219 to i64*
-  %NullCheck36 = icmp ne i64* %220, null
-  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64* %220, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %221
 
 ; <label>:221                                     ; preds = %217
   %222 = load i64, i64* %220, align 8
   %223 = bitcast i8* %218 to i64*
-  %NullCheck38 = icmp ne i64* %223, null
-  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+  %NullCheck37 = icmp eq i64* %223, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %224
 
 ; <label>:224                                     ; preds = %221
   store i64 %222, i64* %223, align 8
@@ -1084,14 +1166,14 @@ entry:
   %227 = load i8*, i8** %arg1
   %228 = getelementptr inbounds i8, i8* %227, i64 8
   %229 = bitcast i8* %228 to i32*
-  %NullCheck40 = icmp ne i32* %229, null
-  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i32* %229, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %230
 
 ; <label>:230                                     ; preds = %224
   %231 = load i32, i32* %229, align 8
   %232 = bitcast i8* %226 to i32*
-  %NullCheck42 = icmp ne i32* %232, null
-  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+  %NullCheck41 = icmp eq i32* %232, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %233
 
 ; <label>:233                                     ; preds = %230
   store i32 %231, i32* %232, align 8
@@ -1099,15 +1181,15 @@ entry:
   %235 = getelementptr inbounds i8, i8* %234, i64 12
   %236 = load i8*, i8** %arg1
   %237 = getelementptr inbounds i8, i8* %236, i64 12
-  %NullCheck44 = icmp ne i8* %237, null
-  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i8* %237, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %238
 
 ; <label>:238                                     ; preds = %233
   %239 = load i8, i8* %237, align 8
   %240 = zext i8 %239 to i32
   %241 = trunc i32 %240 to i8
-  %NullCheck46 = icmp ne i8* %235, null
-  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+  %NullCheck45 = icmp eq i8* %235, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %242
 
 ; <label>:242                                     ; preds = %238
   store i8 %241, i8* %235, align 8
@@ -1117,14 +1199,14 @@ entry:
   %244 = load i8*, i8** %arg0
   %245 = load i8*, i8** %arg1
   %246 = bitcast i8* %245 to i64*
-  %NullCheck24 = icmp ne i64* %246, null
-  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64* %246, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %247
 
 ; <label>:247                                     ; preds = %243
   %248 = load i64, i64* %246, align 8
   %249 = bitcast i8* %244 to i64*
-  %NullCheck26 = icmp ne i64* %249, null
-  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64* %249, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %250
 
 ; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
@@ -1133,14 +1215,14 @@ entry:
   %253 = load i8*, i8** %arg1
   %254 = getelementptr inbounds i8, i8* %253, i64 8
   %255 = bitcast i8* %254 to i32*
-  %NullCheck28 = icmp ne i32* %255, null
-  br i1 %NullCheck28, label %256, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i32* %255, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %256
 
 ; <label>:256                                     ; preds = %250
   %257 = load i32, i32* %255, align 8
   %258 = bitcast i8* %252 to i32*
-  %NullCheck30 = icmp ne i32* %258, null
-  br i1 %NullCheck30, label %259, label %ThrowNullRef29
+  %NullCheck29 = icmp eq i32* %258, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %259
 
 ; <label>:259                                     ; preds = %256
   store i32 %257, i32* %258, align 8
@@ -1149,16 +1231,16 @@ entry:
   %262 = load i8*, i8** %arg1
   %263 = getelementptr inbounds i8, i8* %262, i64 12
   %264 = bitcast i8* %263 to i16*
-  %NullCheck32 = icmp ne i16* %264, null
-  br i1 %NullCheck32, label %265, label %ThrowNullRef31
+  %NullCheck31 = icmp eq i16* %264, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %265
 
 ; <label>:265                                     ; preds = %259
   %266 = load i16, i16* %264, align 8
   %267 = sext i16 %266 to i32
   %268 = bitcast i8* %261 to i16*
   %269 = trunc i32 %267 to i16
-  %NullCheck34 = icmp ne i16* %268, null
-  br i1 %NullCheck34, label %270, label %ThrowNullRef33
+  %NullCheck33 = icmp eq i16* %268, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %270
 
 ; <label>:270                                     ; preds = %265
   store i16 %269, i16* %268, align 8
@@ -1168,14 +1250,14 @@ entry:
   %272 = load i8*, i8** %arg0
   %273 = load i8*, i8** %arg1
   %274 = bitcast i8* %273 to i64*
-  %NullCheck8 = icmp ne i64* %274, null
-  br i1 %NullCheck8, label %275, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64* %274, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %275
 
 ; <label>:275                                     ; preds = %271
   %276 = load i64, i64* %274, align 8
   %277 = bitcast i8* %272 to i64*
-  %NullCheck10 = icmp ne i64* %277, null
-  br i1 %NullCheck10, label %278, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %277, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %278
 
 ; <label>:278                                     ; preds = %275
   store i64 %276, i64* %277, align 8
@@ -1184,14 +1266,14 @@ entry:
   %281 = load i8*, i8** %arg1
   %282 = getelementptr inbounds i8, i8* %281, i64 8
   %283 = bitcast i8* %282 to i32*
-  %NullCheck12 = icmp ne i32* %283, null
-  br i1 %NullCheck12, label %284, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i32* %283, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %284
 
 ; <label>:284                                     ; preds = %278
   %285 = load i32, i32* %283, align 8
   %286 = bitcast i8* %280 to i32*
-  %NullCheck14 = icmp ne i32* %286, null
-  br i1 %NullCheck14, label %287, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i32* %286, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %287
 
 ; <label>:287                                     ; preds = %284
   store i32 %285, i32* %286, align 8
@@ -1200,16 +1282,16 @@ entry:
   %290 = load i8*, i8** %arg1
   %291 = getelementptr inbounds i8, i8* %290, i64 12
   %292 = bitcast i8* %291 to i16*
-  %NullCheck16 = icmp ne i16* %292, null
-  br i1 %NullCheck16, label %293, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i16* %292, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %293
 
 ; <label>:293                                     ; preds = %287
   %294 = load i16, i16* %292, align 8
   %295 = sext i16 %294 to i32
   %296 = bitcast i8* %289 to i16*
   %297 = trunc i32 %295 to i16
-  %NullCheck18 = icmp ne i16* %296, null
-  br i1 %NullCheck18, label %298, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i16* %296, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %298
 
 ; <label>:298                                     ; preds = %293
   store i16 %297, i16* %296, align 8
@@ -1217,15 +1299,15 @@ entry:
   %300 = getelementptr inbounds i8, i8* %299, i64 14
   %301 = load i8*, i8** %arg1
   %302 = getelementptr inbounds i8, i8* %301, i64 14
-  %NullCheck20 = icmp ne i8* %302, null
-  br i1 %NullCheck20, label %303, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i8* %302, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %303
 
 ; <label>:303                                     ; preds = %298
   %304 = load i8, i8* %302, align 8
   %305 = zext i8 %304 to i32
   %306 = trunc i32 %305 to i8
-  %NullCheck22 = icmp ne i8* %300, null
-  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i8* %300, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %307
 
 ; <label>:307                                     ; preds = %303
   store i8 %306, i8* %300, align 8
@@ -1235,14 +1317,14 @@ entry:
   %309 = load i8*, i8** %arg0
   %310 = load i8*, i8** %arg1
   %311 = bitcast i8* %310 to i64*
-  %NullCheck = icmp ne i64* %311, null
-  br i1 %NullCheck, label %312, label %ThrowNullRef
+  %NullCheck = icmp eq i64* %311, null
+  br i1 %NullCheck, label %ThrowNullRef, label %312
 
 ; <label>:312                                     ; preds = %308
   %313 = load i64, i64* %311, align 8
   %314 = bitcast i8* %309 to i64*
-  %NullCheck2 = icmp ne i64* %314, null
-  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64* %314, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %315
 
 ; <label>:315                                     ; preds = %312
   store i64 %313, i64* %314, align 8
@@ -1251,14 +1333,14 @@ entry:
   %318 = load i8*, i8** %arg1
   %319 = getelementptr inbounds i8, i8* %318, i64 8
   %320 = bitcast i8* %319 to i64*
-  %NullCheck4 = icmp ne i64* %320, null
-  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64* %320, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %321
 
 ; <label>:321                                     ; preds = %315
   %322 = load i64, i64* %320, align 8
   %323 = bitcast i8* %317 to i64*
-  %NullCheck6 = icmp ne i64* %323, null
-  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64* %323, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %324
 
 ; <label>:324                                     ; preds = %321
   store i64 %322, i64* %323, align 8
@@ -1286,15 +1368,15 @@ entry:
 ; <label>:338                                     ; preds = %333
   %339 = load i8*, i8** %arg0
   %340 = load i8*, i8** %arg1
-  %NullCheck136 = icmp ne i8* %340, null
-  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+  %NullCheck135 = icmp eq i8* %340, null
+  br i1 %NullCheck135, label %ThrowNullRef136, label %341
 
 ; <label>:341                                     ; preds = %338
   %342 = load i8, i8* %340, align 8
   %343 = zext i8 %342 to i32
   %344 = trunc i32 %343 to i8
-  %NullCheck138 = icmp ne i8* %339, null
-  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+  %NullCheck137 = icmp eq i8* %339, null
+  br i1 %NullCheck137, label %ThrowNullRef138, label %345
 
 ; <label>:345                                     ; preds = %341
   store i8 %344, i8* %339, align 8
@@ -1317,16 +1399,16 @@ entry:
   %357 = load i8*, i8** %arg0
   %358 = load i8*, i8** %arg1
   %359 = bitcast i8* %358 to i16*
-  %NullCheck140 = icmp ne i16* %359, null
-  br i1 %NullCheck140, label %360, label %ThrowNullRef139
+  %NullCheck139 = icmp eq i16* %359, null
+  br i1 %NullCheck139, label %ThrowNullRef140, label %360
 
 ; <label>:360                                     ; preds = %356
   %361 = load i16, i16* %359, align 8
   %362 = sext i16 %361 to i32
   %363 = bitcast i8* %357 to i16*
   %364 = trunc i32 %362 to i16
-  %NullCheck142 = icmp ne i16* %363, null
-  br i1 %NullCheck142, label %365, label %ThrowNullRef141
+  %NullCheck141 = icmp eq i16* %363, null
+  br i1 %NullCheck141, label %ThrowNullRef142, label %365
 
 ; <label>:365                                     ; preds = %360
   store i16 %364, i16* %363, align 8
@@ -1352,14 +1434,14 @@ entry:
   %378 = load i8*, i8** %arg0
   %379 = load i8*, i8** %arg1
   %380 = bitcast i8* %379 to i32*
-  %NullCheck144 = icmp ne i32* %380, null
-  br i1 %NullCheck144, label %381, label %ThrowNullRef143
+  %NullCheck143 = icmp eq i32* %380, null
+  br i1 %NullCheck143, label %ThrowNullRef144, label %381
 
 ; <label>:381                                     ; preds = %377
   %382 = load i32, i32* %380, align 8
   %383 = bitcast i8* %378 to i32*
-  %NullCheck146 = icmp ne i32* %383, null
-  br i1 %NullCheck146, label %384, label %ThrowNullRef145
+  %NullCheck145 = icmp eq i32* %383, null
+  br i1 %NullCheck145, label %ThrowNullRef146, label %384
 
 ; <label>:384                                     ; preds = %381
   store i32 %382, i32* %383, align 8
@@ -1384,14 +1466,14 @@ entry:
   %395 = load i8*, i8** %arg0
   %396 = load i8*, i8** %arg1
   %397 = bitcast i8* %396 to i64*
-  %NullCheck164 = icmp ne i64* %397, null
-  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+  %NullCheck163 = icmp eq i64* %397, null
+  br i1 %NullCheck163, label %ThrowNullRef164, label %398
 
 ; <label>:398                                     ; preds = %394
   %399 = load i64, i64* %397, align 8
   %400 = bitcast i8* %395 to i64*
-  %NullCheck166 = icmp ne i64* %400, null
-  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+  %NullCheck165 = icmp eq i64* %400, null
+  br i1 %NullCheck165, label %ThrowNullRef166, label %401
 
 ; <label>:401                                     ; preds = %398
   store i64 %399, i64* %400, align 8
@@ -1400,14 +1482,14 @@ entry:
   %404 = load i8*, i8** %arg1
   %405 = getelementptr inbounds i8, i8* %404, i64 8
   %406 = bitcast i8* %405 to i64*
-  %NullCheck168 = icmp ne i64* %406, null
-  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+  %NullCheck167 = icmp eq i64* %406, null
+  br i1 %NullCheck167, label %ThrowNullRef168, label %407
 
 ; <label>:407                                     ; preds = %401
   %408 = load i64, i64* %406, align 8
   %409 = bitcast i8* %403 to i64*
-  %NullCheck170 = icmp ne i64* %409, null
-  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+  %NullCheck169 = icmp eq i64* %409, null
+  br i1 %NullCheck169, label %ThrowNullRef170, label %410
 
 ; <label>:410                                     ; preds = %407
   store i64 %408, i64* %409, align 8
@@ -1437,14 +1519,14 @@ entry:
   %425 = load i8*, i8** %arg0
   %426 = load i8*, i8** %arg1
   %427 = bitcast i8* %426 to i64*
-  %NullCheck148 = icmp ne i64* %427, null
-  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+  %NullCheck147 = icmp eq i64* %427, null
+  br i1 %NullCheck147, label %ThrowNullRef148, label %428
 
 ; <label>:428                                     ; preds = %424
   %429 = load i64, i64* %427, align 8
   %430 = bitcast i8* %425 to i64*
-  %NullCheck150 = icmp ne i64* %430, null
-  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+  %NullCheck149 = icmp eq i64* %430, null
+  br i1 %NullCheck149, label %ThrowNullRef150, label %431
 
 ; <label>:431                                     ; preds = %428
   store i64 %429, i64* %430, align 8
@@ -1466,14 +1548,14 @@ entry:
   %441 = load i8*, i8** %arg0
   %442 = load i8*, i8** %arg1
   %443 = bitcast i8* %442 to i32*
-  %NullCheck152 = icmp ne i32* %443, null
-  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+  %NullCheck151 = icmp eq i32* %443, null
+  br i1 %NullCheck151, label %ThrowNullRef152, label %444
 
 ; <label>:444                                     ; preds = %440
   %445 = load i32, i32* %443, align 8
   %446 = bitcast i8* %441 to i32*
-  %NullCheck154 = icmp ne i32* %446, null
-  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+  %NullCheck153 = icmp eq i32* %446, null
+  br i1 %NullCheck153, label %ThrowNullRef154, label %447
 
 ; <label>:447                                     ; preds = %444
   store i32 %445, i32* %446, align 8
@@ -1495,16 +1577,16 @@ entry:
   %457 = load i8*, i8** %arg0
   %458 = load i8*, i8** %arg1
   %459 = bitcast i8* %458 to i16*
-  %NullCheck156 = icmp ne i16* %459, null
-  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+  %NullCheck155 = icmp eq i16* %459, null
+  br i1 %NullCheck155, label %ThrowNullRef156, label %460
 
 ; <label>:460                                     ; preds = %456
   %461 = load i16, i16* %459, align 8
   %462 = sext i16 %461 to i32
   %463 = bitcast i8* %457 to i16*
   %464 = trunc i32 %462 to i16
-  %NullCheck158 = icmp ne i16* %463, null
-  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+  %NullCheck157 = icmp eq i16* %463, null
+  br i1 %NullCheck157, label %ThrowNullRef158, label %465
 
 ; <label>:465                                     ; preds = %460
   store i16 %464, i16* %463, align 8
@@ -1525,15 +1607,15 @@ entry:
 ; <label>:474                                     ; preds = %470
   %475 = load i8*, i8** %arg0
   %476 = load i8*, i8** %arg1
-  %NullCheck160 = icmp ne i8* %476, null
-  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+  %NullCheck159 = icmp eq i8* %476, null
+  br i1 %NullCheck159, label %ThrowNullRef160, label %477
 
 ; <label>:477                                     ; preds = %474
   %478 = load i8, i8* %476, align 8
   %479 = zext i8 %478 to i32
   %480 = trunc i32 %479 to i8
-  %NullCheck162 = icmp ne i8* %475, null
-  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+  %NullCheck161 = icmp eq i8* %475, null
+  br i1 %NullCheck161, label %ThrowNullRef162, label %481
 
 ; <label>:481                                     ; preds = %477
   store i8 %480, i8* %475, align 8
@@ -1553,343 +1635,343 @@ ThrowNullRef:                                     ; preds = %308
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %312
+ThrowNullRef2:                                    ; preds = %312
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %315
+ThrowNullRef4:                                    ; preds = %315
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %321
+ThrowNullRef6:                                    ; preds = %321
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %271
+ThrowNullRef8:                                    ; preds = %271
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %275
+ThrowNullRef10:                                   ; preds = %275
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %278
+ThrowNullRef12:                                   ; preds = %278
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %284
+ThrowNullRef14:                                   ; preds = %284
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %287
+ThrowNullRef16:                                   ; preds = %287
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %293
+ThrowNullRef18:                                   ; preds = %293
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %298
+ThrowNullRef20:                                   ; preds = %298
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %303
+ThrowNullRef22:                                   ; preds = %303
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %243
+ThrowNullRef24:                                   ; preds = %243
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %247
+ThrowNullRef26:                                   ; preds = %247
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %250
+ThrowNullRef28:                                   ; preds = %250
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %256
+ThrowNullRef30:                                   ; preds = %256
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %259
+ThrowNullRef32:                                   ; preds = %259
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %265
+ThrowNullRef34:                                   ; preds = %265
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %217
+ThrowNullRef36:                                   ; preds = %217
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %221
+ThrowNullRef38:                                   ; preds = %221
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %224
+ThrowNullRef40:                                   ; preds = %224
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %230
+ThrowNullRef42:                                   ; preds = %230
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %233
+ThrowNullRef44:                                   ; preds = %233
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %238
+ThrowNullRef46:                                   ; preds = %238
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %200
+ThrowNullRef48:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %204
+ThrowNullRef50:                                   ; preds = %204
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %207
+ThrowNullRef52:                                   ; preds = %207
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %213
+ThrowNullRef54:                                   ; preds = %213
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %172
+ThrowNullRef56:                                   ; preds = %172
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %176
+ThrowNullRef58:                                   ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %179
+ThrowNullRef60:                                   ; preds = %179
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %185
+ThrowNullRef62:                                   ; preds = %185
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %190
+ThrowNullRef64:                                   ; preds = %190
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %195
+ThrowNullRef66:                                   ; preds = %195
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %153
+ThrowNullRef68:                                   ; preds = %153
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %157
+ThrowNullRef70:                                   ; preds = %157
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %160
+ThrowNullRef72:                                   ; preds = %160
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %166
+ThrowNullRef74:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %136
+ThrowNullRef76:                                   ; preds = %136
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %140
+ThrowNullRef78:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %143
+ThrowNullRef80:                                   ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %148
+ThrowNullRef82:                                   ; preds = %148
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %128
+ThrowNullRef84:                                   ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %132
+ThrowNullRef86:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %100
+ThrowNullRef88:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %104
+ThrowNullRef90:                                   ; preds = %104
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %107
+ThrowNullRef92:                                   ; preds = %107
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %113
+ThrowNullRef94:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %118
+ThrowNullRef96:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %123
+ThrowNullRef98:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %81
+ThrowNullRef100:                                  ; preds = %81
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef101:                                  ; preds = %85
+ThrowNullRef102:                                  ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef103:                                  ; preds = %88
+ThrowNullRef104:                                  ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef105:                                  ; preds = %94
+ThrowNullRef106:                                  ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef107:                                  ; preds = %64
+ThrowNullRef108:                                  ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef109:                                  ; preds = %68
+ThrowNullRef110:                                  ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef111:                                  ; preds = %71
+ThrowNullRef112:                                  ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef113:                                  ; preds = %76
+ThrowNullRef114:                                  ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef115:                                  ; preds = %56
+ThrowNullRef116:                                  ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef117:                                  ; preds = %60
+ThrowNullRef118:                                  ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef119:                                  ; preds = %37
+ThrowNullRef120:                                  ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef121:                                  ; preds = %41
+ThrowNullRef122:                                  ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef123:                                  ; preds = %46
+ThrowNullRef124:                                  ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef125:                                  ; preds = %51
+ThrowNullRef126:                                  ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef127:                                  ; preds = %27
+ThrowNullRef128:                                  ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef129:                                  ; preds = %31
+ThrowNullRef130:                                  ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef131:                                  ; preds = %19
+ThrowNullRef132:                                  ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef133:                                  ; preds = %22
+ThrowNullRef134:                                  ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef135:                                  ; preds = %338
+ThrowNullRef136:                                  ; preds = %338
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef137:                                  ; preds = %341
+ThrowNullRef138:                                  ; preds = %341
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef139:                                  ; preds = %356
+ThrowNullRef140:                                  ; preds = %356
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef141:                                  ; preds = %360
+ThrowNullRef142:                                  ; preds = %360
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef143:                                  ; preds = %377
+ThrowNullRef144:                                  ; preds = %377
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef145:                                  ; preds = %381
+ThrowNullRef146:                                  ; preds = %381
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef147:                                  ; preds = %424
+ThrowNullRef148:                                  ; preds = %424
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef149:                                  ; preds = %428
+ThrowNullRef150:                                  ; preds = %428
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef151:                                  ; preds = %440
+ThrowNullRef152:                                  ; preds = %440
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef153:                                  ; preds = %444
+ThrowNullRef154:                                  ; preds = %444
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef155:                                  ; preds = %456
+ThrowNullRef156:                                  ; preds = %456
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef157:                                  ; preds = %460
+ThrowNullRef158:                                  ; preds = %460
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef159:                                  ; preds = %474
+ThrowNullRef160:                                  ; preds = %474
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef161:                                  ; preds = %477
+ThrowNullRef162:                                  ; preds = %477
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef163:                                  ; preds = %394
+ThrowNullRef164:                                  ; preds = %394
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef165:                                  ; preds = %398
+ThrowNullRef166:                                  ; preds = %398
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef167:                                  ; preds = %401
+ThrowNullRef168:                                  ; preds = %401
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef169:                                  ; preds = %407
+ThrowNullRef170:                                  ; preds = %407
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1939,8 +2021,8 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
-  br i1 %NullCheck, label %22, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %ThrowNullRef, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
@@ -1948,8 +2030,8 @@ entry:
   store i32 %24, i32* %loc0
   %25 = load i32, i32* %loc0
   %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %26, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %27
 
 ; <label>:27                                      ; preds = %22
   %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
@@ -1971,7 +2053,7 @@ ThrowNullRef:                                     ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1989,8 +2071,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -2022,15 +2104,15 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2048,16 +2130,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
   %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
   store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %15
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
@@ -2072,8 +2154,8 @@ entry:
   %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
   %29 = ptrtoint i16 addrspace(1)* %28 to i64
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %19
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
@@ -2089,19 +2171,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2114,8 +2196,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
@@ -2128,7 +2210,7 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[loadElem]
+Failed to read AppDomain.PrepareDataForSetup[storeElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
@@ -2202,8 +2284,8 @@ entry:
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
-  br i1 %NullCheck24, label %27, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = load i64, i64 addrspace(1)* %26
@@ -2218,8 +2300,8 @@ entry:
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
-  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
   %41 = load i64, i64 addrspace(1)* %39
@@ -2236,8 +2318,8 @@ entry:
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
-  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
   %54 = load i64, i64 addrspace(1)* %52
@@ -2252,8 +2334,8 @@ entry:
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
   %67 = load i64, i64 addrspace(1)* %65
@@ -2270,8 +2352,8 @@ entry:
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
-  br i1 %NullCheck16, label %79, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
   %80 = load i64, i64 addrspace(1)* %78
@@ -2286,8 +2368,8 @@ entry:
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
-  br i1 %NullCheck18, label %92, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
   %93 = load i64, i64 addrspace(1)* %91
@@ -2304,8 +2386,8 @@ entry:
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
-  br i1 %NullCheck12, label %105, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = load i64, i64 addrspace(1)* %104
@@ -2320,8 +2402,8 @@ entry:
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
-  br i1 %NullCheck14, label %118, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
   %119 = load i64, i64 addrspace(1)* %117
@@ -2337,8 +2419,8 @@ entry:
 
 ; <label>:128                                     ; preds = %20
   %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
-  br i1 %NullCheck4, label %130, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %129, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %130
 
 ; <label>:130                                     ; preds = %128
   %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
@@ -2346,8 +2428,8 @@ entry:
   %133 = load i16, i16 addrspace(1)* %132, align 8
   %134 = zext i16 %133 to i32
   %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
-  br i1 %NullCheck6, label %136, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %135, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %136
 
 ; <label>:136                                     ; preds = %130
   %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
@@ -2360,8 +2442,8 @@ entry:
 
 ; <label>:143                                     ; preds = %136
   %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
-  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %144, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %145
 
 ; <label>:145                                     ; preds = %143
   %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
@@ -2369,8 +2451,8 @@ entry:
   %148 = load i16, i16 addrspace(1)* %147, align 8
   %149 = zext i16 %148 to i32
   %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %150, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %151
 
 ; <label>:151                                     ; preds = %145
   %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
@@ -2388,8 +2470,8 @@ entry:
 
 ; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
-  br i1 %NullCheck, label %163, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %ThrowNullRef, label %163
 
 ; <label>:163                                     ; preds = %161
   %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
@@ -2399,8 +2481,8 @@ entry:
 
 ; <label>:167                                     ; preds = %163
   %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
-  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %168, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %169
 
 ; <label>:169                                     ; preds = %167
   %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
@@ -2432,55 +2514,55 @@ ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %167
+ThrowNullRef2:                                    ; preds = %167
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %128
+ThrowNullRef4:                                    ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %130
+ThrowNullRef6:                                    ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %143
+ThrowNullRef8:                                    ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %145
+ThrowNullRef10:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %102
+ThrowNullRef12:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %105
+ThrowNullRef14:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %76
+ThrowNullRef16:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %79
+ThrowNullRef18:                                   ; preds = %79
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %50
+ThrowNullRef20:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %53
+ThrowNullRef22:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %24
+ThrowNullRef24:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %27
+ThrowNullRef26:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2503,15 +2585,15 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2519,16 +2601,16 @@ entry:
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
   store i32 %8, i32* %loc0
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
   %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
   store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
@@ -2546,16 +2628,16 @@ entry:
 
 ; <label>:23                                      ; preds = %64
   %24 = load i16*, i16** %loc3
-  %NullCheck12 = icmp ne i16* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i16* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
   store i32 %27, i32* %loc5
   %28 = load i16*, i16** %loc4
-  %NullCheck14 = icmp ne i16* %28, null
-  br i1 %NullCheck14, label %29, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %28, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = load i16, i16* %28, align 8
@@ -2620,15 +2702,15 @@ entry:
 
 ; <label>:67                                      ; preds = %64
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
-  br i1 %NullCheck8, label %69, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %68, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %69
 
 ; <label>:69                                      ; preds = %67
   %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
   %71 = load i32, i32 addrspace(1)* %70
   %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
-  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %73
 
 ; <label>:73                                      ; preds = %69
   %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
@@ -2645,31 +2727,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %67
+ThrowNullRef8:                                    ; preds = %67
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %69
+ThrowNullRef10:                                   ; preds = %69
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2710,14 +2792,14 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
   %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
@@ -2730,14 +2812,14 @@ entry:
 
 ; <label>:11                                      ; preds = %4
   %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
   %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
@@ -2749,14 +2831,14 @@ entry:
 
 ; <label>:22                                      ; preds = %16
   %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
   %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
-  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
-  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
@@ -2804,23 +2886,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2836,7 +2918,280 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[loadElem]
+Successfully read RuntimeType.IsAssignableFrom
+
+define i8 @RuntimeType.IsAssignableFrom(%System.RuntimeType addrspace(1)* %param0, %System.Type addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.RuntimeType addrspace(1)*
+  %arg1 = alloca %System.Type addrspace(1)*
+  %loc0 = alloca %System.RuntimeType addrspace(1)*
+  %loc1 = alloca %"System.Type[]" addrspace(1)*
+  %loc2 = alloca i32
+  store %System.RuntimeType addrspace(1)* %param0, %System.RuntimeType addrspace(1)** %this
+  store %System.Type addrspace(1)* %param1, %System.Type addrspace(1)** %arg1
+  %0 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %1 = icmp ne %System.Type addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i8 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %5 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %6 = bitcast %System.Type addrspace(1)* %4 to %System.Object addrspace(1)*
+  %7 = bitcast %System.RuntimeType addrspace(1)* %5 to %System.Object addrspace(1)*
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %6, %System.Object addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %3
+  ret i8 1
+
+; <label>:12                                      ; preds = %3
+  %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 152
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 32
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
+  %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
+  %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
+  store %System.RuntimeType addrspace(1)* %25, %System.RuntimeType addrspace(1)** %loc0
+  %26 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %27 = icmp eq %System.RuntimeType addrspace(1)* %26, null
+  br i1 %27, label %34, label %28
+
+; <label>:28                                      ; preds = %15
+  %29 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %30 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)*)*)(%System.RuntimeType addrspace(1)* %29, %System.RuntimeType addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+; <label>:34                                      ; preds = %15
+  %35 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %36 = call %System.Reflection.Emit.TypeBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Reflection.Emit.TypeBuilder addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %35)
+  %37 = icmp eq %System.Reflection.Emit.TypeBuilder addrspace(1)* %36, null
+  br i1 %37, label %139, label %38
+
+; <label>:38                                      ; preds = %34
+  %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %42
+
+; <label>:42                                      ; preds = %38
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 152
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 40
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
+  %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
+  %53 = zext i8 %52 to i32
+  %54 = icmp eq i32 %53, 0
+  br i1 %54, label %56, label %55
+
+; <label>:55                                      ; preds = %42
+  ret i8 1
+
+; <label>:56                                      ; preds = %42
+  %57 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %58 = bitcast %System.RuntimeType addrspace(1)* %57 to %System.Type addrspace(1)*
+  %59 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %58)
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %64 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.Type addrspace(1)* %63, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = bitcast %System.RuntimeType addrspace(1)* %64 to %System.Type addrspace(1)*
+  %67 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %63, %System.Type addrspace(1)* %66)
+  %68 = zext i8 %67 to i32
+  %69 = trunc i32 %68 to i8
+  ret i8 %69
+
+; <label>:70                                      ; preds = %56
+  %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
+  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %73
+
+; <label>:73                                      ; preds = %70
+  %74 = load i64, i64 addrspace(1)* %72
+  %75 = add i64 %74, 128
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = add i64 %77, 0
+  %79 = inttoptr i64 %78 to i64*
+  %80 = load i64, i64* %79
+  %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
+  %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
+  %83 = call i8 %82(%System.Type addrspace(1)* %81)
+  %84 = zext i8 %83 to i32
+  %85 = icmp eq i32 %84, 0
+  br i1 %85, label %139, label %86
+
+; <label>:86                                      ; preds = %73
+  %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
+  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %89
+
+; <label>:89                                      ; preds = %86
+  %90 = load i64, i64 addrspace(1)* %88
+  %91 = add i64 %90, 128
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = add i64 %93, 24
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
+  %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
+  %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
+  store %"System.Type[]" addrspace(1)* %99, %"System.Type[]" addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %129
+
+; <label>:100                                     ; preds = %132
+  %101 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %102 = load i32, i32* %loc2
+  %NullCheck11 = icmp eq %"System.Type[]" addrspace(1)* %101, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %103
+
+; <label>:103                                     ; preds = %100
+  %104 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 1
+  %105 = load i32, i32 addrspace(1)* %104
+  %106 = zext i32 %105 to i64
+  %107 = zext i32 %102 to i64
+  %BoundsCheck = icmp uge i64 %107, %106
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %108
+
+; <label>:108                                     ; preds = %103
+  %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
+  %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
+  %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
+  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %113
+
+; <label>:113                                     ; preds = %108
+  %114 = load i64, i64 addrspace(1)* %112
+  %115 = add i64 %114, 152
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = add i64 %117, 56
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
+  %123 = zext i8 %122 to i32
+  %124 = icmp ne i32 %123, 0
+  br i1 %124, label %126, label %125
+
+; <label>:125                                     ; preds = %113
+  ret i8 0
+
+; <label>:126                                     ; preds = %113
+  %127 = load i32, i32* %loc2
+  %128 = add i32 %127, 1
+  store i32 %128, i32* %loc2
+  br label %129
+
+; <label>:129                                     ; preds = %89, %126
+  %130 = load i32, i32* %loc2
+  %131 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %NullCheck9 = icmp eq %"System.Type[]" addrspace(1)* %131, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %132
+
+; <label>:132                                     ; preds = %129
+  %133 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %131, i32 0, i32 1
+  %134 = load i32, i32 addrspace(1)* %133
+  %135 = zext i32 %134 to i64
+  %136 = trunc i64 %135 to i32
+  %137 = icmp slt i32 %130, %136
+  br i1 %137, label %100, label %138
+
+; <label>:138                                     ; preds = %132
+  ret i8 1
+
+; <label>:139                                     ; preds = %34, %73
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %129
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %103
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -2893,7 +3248,7 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElem]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -2904,8 +3259,8 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -2997,8 +3352,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
@@ -3059,8 +3414,8 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -3087,8 +3442,8 @@ entry:
 
 ; <label>:17                                      ; preds = %5, %11
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
@@ -3097,8 +3452,8 @@ entry:
 
 ; <label>:22                                      ; preds = %1, %11
   %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
@@ -3109,11 +3464,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %17
+ThrowNullRef2:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %22
+ThrowNullRef4:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3167,15 +3522,15 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
   %15 = load i32, i32 addrspace(1)* %14
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
@@ -3198,7 +3553,7 @@ ThrowNullRef:                                     ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef2:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3232,8 +3587,8 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
@@ -3312,8 +3667,8 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -3327,8 +3682,8 @@ entry:
 ; <label>:5                                       ; preds = %43
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %7 = load i32, i32* %loc1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck6, label %8, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
@@ -3366,8 +3721,8 @@ entry:
 ; <label>:32                                      ; preds = %21, %25
   %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
   %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
-  br i1 %NullCheck8, label %35, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = trunc i32 %34 to i16
@@ -3380,8 +3735,8 @@ entry:
 ; <label>:40                                      ; preds = %1, %35
   %41 = load i32, i32* %loc1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
-  br i1 %NullCheck2, label %43, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %42, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
@@ -3392,8 +3747,8 @@ entry:
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
   %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
-  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
   %51 = load i64, i64 addrspace(1)* %49
@@ -3412,19 +3767,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %40
+ThrowNullRef2:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %47
+ThrowNullRef4:                                    ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %5
+ThrowNullRef6:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %32
+ThrowNullRef8:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3467,8 +3822,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
@@ -3492,11 +3847,391 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(i16* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store i16* %param0, i16** %arg0
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load i32, i32* %arg3
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %42, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %37, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg2
+  %13 = load i32, i32* %arg3
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %37, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %24 = load i32, i32* %arg2
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load i16*, i16** %arg0
+  %35 = load i32, i32* %arg3
+  %36 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %36, i16* %34, i32 %35)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:37                                      ; preds = %5, %16
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %39)
+  %41 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41, %System.String addrspace(1)* %38, %System.String addrspace(1)* %40)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41) #0
+  unreachable
+
+; <label>:42                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
-Failed to read StringBuilder.ToString[loadElemA]
+Successfully read StringBuilder.ToString
+
+define %System.String addrspace(1)* @StringBuilder.ToString(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i16*
+  %loc3 = alloca %"System.Char[]" addrspace(1)*
+  %loc4 = alloca i32
+  %loc5 = alloca i32
+  %loc6 = alloca i16 addrspace(1)*
+  %loc7 = alloca %System.String addrspace(1)*
+  %loc8 = alloca %"System.Char[]" addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %0)
+  %2 = icmp ne i32 %1, 0
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %4
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %6)
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %7)
+  store %System.String addrspace(1)* %8, %System.String addrspace(1)** %loc0
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.Text.StringBuilder addrspace(1)* %9, %System.Text.StringBuilder addrspace(1)** %loc1
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  store %System.String addrspace(1)* %10, %System.String addrspace(1)** %loc7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc7
+  %12 = ptrtoint %System.String addrspace(1)* %11 to i64
+  %13 = icmp eq i64 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %5
+  %15 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %16 = sext i32 %15 to i64
+  %17 = add i64 %12, %16
+  br label %18
+
+; <label>:18                                      ; preds = %5, %14
+  %19 = phi i64 [ %12, %5 ], [ %17, %14 ]
+  %20 = inttoptr i64 %19 to i16*
+  store i16* %20, i16** %loc2
+  br label %21
+
+; <label>:21                                      ; preds = %98, %18
+  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %22, null
+  br i1 %NullCheck, label %ThrowNullRef, label %23
+
+; <label>:23                                      ; preds = %21
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 3
+  %25 = load i32, i32 addrspace(1)* %24, align 8
+  %26 = icmp sle i32 %25, 0
+  br i1 %26, label %96, label %27
+
+; <label>:27                                      ; preds = %23
+  %28 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %28, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %29
+
+; <label>:29                                      ; preds = %27
+  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %28, i32 0, i32 1
+  %31 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %30, align 8
+  store %"System.Char[]" addrspace(1)* %31, %"System.Char[]" addrspace(1)** %loc3
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %33
+
+; <label>:33                                      ; preds = %29
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  store i32 %35, i32* %loc4
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  %39 = load i32, i32 addrspace(1)* %38, align 8
+  store i32 %39, i32* %loc5
+  %40 = load i32, i32* %loc5
+  %41 = load i32, i32* %loc4
+  %42 = add i32 %40, %41
+  %43 = zext i32 %42 to i64
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %45
+
+; <label>:45                                      ; preds = %37
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = sext i32 %47 to i64
+  %49 = icmp sgt i64 %43, %48
+  br i1 %49, label %91, label %50
+
+; <label>:50                                      ; preds = %45
+  %51 = load i32, i32* %loc5
+  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %52, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %53
+
+; <label>:53                                      ; preds = %50
+  %54 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %52, i32 0, i32 1
+  %55 = load i32, i32 addrspace(1)* %54
+  %56 = zext i32 %55 to i64
+  %57 = trunc i64 %56 to i32
+  %58 = icmp ugt i32 %51, %57
+  br i1 %58, label %91, label %59
+
+; <label>:59                                      ; preds = %53
+  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  store %"System.Char[]" addrspace(1)* %60, %"System.Char[]" addrspace(1)** %loc8
+  %61 = icmp eq %"System.Char[]" addrspace(1)* %60, null
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %63, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %64
+
+; <label>:64                                      ; preds = %62
+  %65 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %63, i32 0, i32 1
+  %66 = load i32, i32 addrspace(1)* %65
+  %67 = zext i32 %66 to i64
+  %68 = trunc i64 %67 to i32
+  %69 = icmp ne i32 %68, 0
+  br i1 %69, label %71, label %70
+
+; <label>:70                                      ; preds = %59, %64
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:71                                      ; preds = %64
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %73
+
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %BoundsCheck = icmp uge i64 0, %76
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %77
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %78, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:79                                      ; preds = %70, %77
+  %80 = load i16*, i16** %loc2
+  %81 = load i32, i32* %loc4
+  %82 = sext i32 %81 to i64
+  %83 = mul i64 %82, 2
+  %84 = bitcast i16* %80 to i8*
+  %85 = getelementptr inbounds i8, i8* %84, i64 %83
+  %86 = load i16 addrspace(1)*, i16 addrspace(1)** %loc6
+  %87 = ptrtoint i16 addrspace(1)* %86 to i64
+  %88 = load i32, i32* %loc5
+  %89 = bitcast i8* %85 to i16*
+  %90 = inttoptr i64 %87 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %89, i16* %90, i32 %88)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %96
+
+; <label>:91                                      ; preds = %45, %53
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %94 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %93)
+  %95 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95, %System.String addrspace(1)* %92, %System.String addrspace(1)* %94)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95) #0
+  unreachable
+
+; <label>:96                                      ; preds = %23, %79
+  %97 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %97, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %98
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %97, i32 0, i32 2
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  store %System.Text.StringBuilder addrspace(1)* %100, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %102 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %102, label %21, label %103
+
+; <label>:103                                     ; preds = %98
+  store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc7
+  %104 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  ret %System.String addrspace(1)* %104
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method StringBuilder::get_Length using LLILCJit
+Successfully read StringBuilder.get_Length
+
+define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
+Successfully read RuntimeHelpers.get_OffsetToStringData
+
+define i32 @RuntimeHelpers.get_OffsetToStringData() {
+entry:
+  ret i32 12
+}
+
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
 Successfully read CultureData.CreateCultureData
 
@@ -3514,23 +4249,23 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
   store i8 %4, i8 addrspace(1)* %6
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
@@ -3549,11 +4284,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3566,50 +4301,50 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
   store i32 -1, i32 addrspace(1)* %2
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
   store i32 -1, i32 addrspace(1)* %8
   %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
   store i32 -1, i32 addrspace(1)* %14
   %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
   store i32 -1, i32 addrspace(1)* %17
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
@@ -3623,27 +4358,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3675,7 +4410,136 @@ Failed to read Dictionary`2.Insert[non-const derefAddress]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
 Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
-Failed to read HashHelpers.GetPrime[loadElem]
+Successfully read HashHelpers.GetPrime
+
+define i32 @HashHelpers.GetPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %6, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5, %System.String addrspace(1)* %4)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5) #0
+  unreachable
+
+; <label>:6                                       ; preds = %entry
+  store i32 0, i32* %loc0
+  br label %29
+
+; <label>:7                                       ; preds = %35
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 1296
+  %10 = addrspacecast i8 addrspace(1)* %9 to %"System.Int32[]" addrspace(1)**
+  %11 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %10
+  %12 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Int32[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = zext i32 %15 to i64
+  %17 = zext i32 %12 to i64
+  %BoundsCheck = icmp uge i64 %17, %16
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 3, i32 %12
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  store i32 %20, i32* %loc1
+  %21 = load i32, i32* %loc1
+  %22 = load i32, i32* %arg0
+  %23 = icmp slt i32 %21, %22
+  br i1 %23, label %26, label %24
+
+; <label>:24                                      ; preds = %18
+  %25 = load i32, i32* %loc1
+  ret i32 %25
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %loc0
+  %28 = add i32 %27, 1
+  store i32 %28, i32* %loc0
+  br label %29
+
+; <label>:29                                      ; preds = %6, %26
+  %30 = load i32, i32* %loc0
+  %31 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %32 = getelementptr inbounds i8, i8 addrspace(1)* %31, i64 1296
+  %33 = addrspacecast i8 addrspace(1)* %32 to %"System.Int32[]" addrspace(1)**
+  %34 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %33
+  %NullCheck = icmp eq %"System.Int32[]" addrspace(1)* %34, null
+  br i1 %NullCheck, label %ThrowNullRef, label %35
+
+; <label>:35                                      ; preds = %29
+  %36 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %34, i32 0, i32 1
+  %37 = load i32, i32 addrspace(1)* %36
+  %38 = zext i32 %37 to i64
+  %39 = trunc i64 %38 to i32
+  %40 = icmp slt i32 %30, %39
+  br i1 %40, label %7, label %41
+
+; <label>:41                                      ; preds = %35
+  %42 = load i32, i32* %arg0
+  %43 = or i32 %42, 1
+  store i32 %43, i32* %loc2
+  br label %59
+
+; <label>:44                                      ; preds = %59
+  %45 = load i32, i32* %loc2
+  %46 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %45)
+  %47 = zext i8 %46 to i32
+  %48 = icmp eq i32 %47, 0
+  br i1 %48, label %56, label %49
+
+; <label>:49                                      ; preds = %44
+  %50 = load i32, i32* %loc2
+  %51 = sub i32 %50, 1
+  %52 = srem i32 %51, 101
+  %53 = icmp eq i32 %52, 0
+  br i1 %53, label %56, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = load i32, i32* %loc2
+  ret i32 %55
+
+; <label>:56                                      ; preds = %44, %49
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %57, 2
+  store i32 %58, i32* %loc2
+  br label %59
+
+; <label>:59                                      ; preds = %41, %56
+  %60 = load i32, i32* %loc2
+  %61 = icmp slt i32 %60, 2147483647
+  br i1 %61, label %44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load i32, i32* %arg0
+  ret i32 %63
+
+ThrowNullRef:                                     ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
 Successfully read GenericEqualityComparer`1.GetHashCode
 
@@ -3694,14 +4558,14 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
   %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load i64, i64 addrspace(1)* %7
@@ -3720,7 +4584,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3750,8 +4614,8 @@ entry:
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
@@ -3796,8 +4660,8 @@ entry:
   %35 = bitcast i16* %34 to i8*
   %36 = getelementptr inbounds i8, i8* %35, i64 2
   %37 = bitcast i8* %36 to i16*
-  %NullCheck4 = icmp ne i16* %37, null
-  br i1 %NullCheck4, label %38, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %37, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %38
 
 ; <label>:38                                      ; preds = %27
   %39 = load i16, i16* %37, align 8
@@ -3824,8 +4688,8 @@ entry:
 
 ; <label>:54                                      ; preds = %22, %43
   %55 = load i16*, i16** %loc4
-  %NullCheck2 = icmp ne i16* %55, null
-  br i1 %NullCheck2, label %56, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i16* %55, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %56
 
 ; <label>:56                                      ; preds = %54
   %57 = load i16, i16* %55, align 8
@@ -3850,11 +4714,11 @@ ThrowNullRef:                                     ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %54
+ThrowNullRef2:                                    ; preds = %54
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %27
+ThrowNullRef4:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3871,8 +4735,8 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -3907,8 +4771,8 @@ entry:
 
 ; <label>:26                                      ; preds = %19
   %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
-  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %28
 
 ; <label>:28                                      ; preds = %26
   %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
@@ -3920,7 +4784,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3972,8 +4836,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
@@ -3984,26 +4848,26 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
-  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
@@ -4014,8 +4878,8 @@ entry:
 ; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
@@ -4024,8 +4888,8 @@ entry:
 
 ; <label>:25                                      ; preds = %1, %16, %23
   %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
-  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
@@ -4036,27 +4900,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %20
+ThrowNullRef10:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4069,8 +4933,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -4081,8 +4945,8 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
@@ -4091,8 +4955,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1, %8
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
@@ -4103,11 +4967,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4128,24 +4992,24 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   store i32 %3, i32* %loc0
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
   %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
   store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck4, label %9, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
@@ -4164,15 +5028,15 @@ entry:
 ; <label>:18                                      ; preds = %70
   %19 = load i16*, i16** %loc3
   %20 = bitcast i16* %19 to i64*
-  %NullCheck10 = icmp ne i64* %20, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %20, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = load i64, i64* %20, align 8
   %23 = load i16*, i16** %loc4
   %24 = bitcast i16* %23 to i64*
-  %NullCheck12 = icmp ne i64* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = load i64, i64* %24, align 8
@@ -4188,8 +5052,8 @@ entry:
   %31 = bitcast i16* %30 to i8*
   %32 = getelementptr inbounds i8, i8* %31, i64 8
   %33 = bitcast i8* %32 to i64*
-  %NullCheck14 = icmp ne i64* %33, null
-  br i1 %NullCheck14, label %34, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = load i64, i64* %33, align 8
@@ -4197,8 +5061,8 @@ entry:
   %37 = bitcast i16* %36 to i8*
   %38 = getelementptr inbounds i8, i8* %37, i64 8
   %39 = bitcast i8* %38 to i64*
-  %NullCheck16 = icmp ne i64* %39, null
-  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %40
 
 ; <label>:40                                      ; preds = %34
   %41 = load i64, i64* %39, align 8
@@ -4214,8 +5078,8 @@ entry:
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %NullCheck18 = icmp ne i64* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = load i64, i64* %48, align 8
@@ -4223,8 +5087,8 @@ entry:
   %52 = bitcast i16* %51 to i8*
   %53 = getelementptr inbounds i8, i8* %52, i64 16
   %54 = bitcast i8* %53 to i64*
-  %NullCheck20 = icmp ne i64* %54, null
-  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64* %54, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %55
 
 ; <label>:55                                      ; preds = %49
   %56 = load i64, i64* %54, align 8
@@ -4262,15 +5126,15 @@ entry:
 ; <label>:74                                      ; preds = %95
   %75 = load i16*, i16** %loc3
   %76 = bitcast i16* %75 to i32*
-  %NullCheck6 = icmp ne i32* %76, null
-  br i1 %NullCheck6, label %77, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32* %76, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %77
 
 ; <label>:77                                      ; preds = %74
   %78 = load i32, i32* %76, align 8
   %79 = load i16*, i16** %loc4
   %80 = bitcast i16* %79 to i32*
-  %NullCheck8 = icmp ne i32* %80, null
-  br i1 %NullCheck8, label %81, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i32* %80, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %81
 
 ; <label>:81                                      ; preds = %77
   %82 = load i32, i32* %80, align 8
@@ -4318,43 +5182,43 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %74
+ThrowNullRef6:                                    ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %77
+ThrowNullRef8:                                    ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %29
+ThrowNullRef14:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %34
+ThrowNullRef16:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4376,8 +5240,8 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load i64, i64 addrspace(1)* %4
@@ -4389,8 +5253,8 @@ entry:
   %12 = load i64, i64* %11
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %5
   %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
@@ -4399,8 +5263,8 @@ entry:
   %18 = load i8, i8* %arg2
   %19 = zext i8 %18 to i32
   %20 = trunc i32 %19 to i8
-  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %15
   %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
@@ -4411,11 +5275,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4442,8 +5306,8 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
@@ -4466,16 +5330,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
   %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = load i64, i64 addrspace(1)* %19
@@ -4500,8 +5364,8 @@ entry:
 ; <label>:35                                      ; preds = %30
   %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
@@ -4514,8 +5378,8 @@ entry:
 
 ; <label>:42                                      ; preds = %1, %38
   %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
-  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
@@ -4526,19 +5390,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %35
+ThrowNullRef2:                                    ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %42
+ThrowNullRef8:                                    ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4551,14 +5415,14 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
@@ -4570,7 +5434,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4583,8 +5447,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
@@ -4613,51 +5477,51 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
   %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
   %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
   %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
   %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
-  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
   store i64 %21, i64 addrspace(1)* %23
   %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %25 = load i64, i64* %loc0
-  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
@@ -4668,27 +5532,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %22
+ThrowNullRef12:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4701,8 +5565,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
@@ -4713,19 +5577,19 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
@@ -4734,8 +5598,8 @@ entry:
 
 ; <label>:15                                      ; preds = %1, %13
   %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
@@ -4746,19 +5610,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %15
+ThrowNullRef8:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4771,8 +5635,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -4831,8 +5695,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
@@ -4882,8 +5746,8 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
-  br i1 %NullCheck, label %17, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %ThrowNullRef, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
@@ -4894,15 +5758,15 @@ entry:
 
 ; <label>:22                                      ; preds = %17
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
-  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
   %26 = load i32, i32 addrspace(1)* %25
   %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
-  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %27, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
@@ -4925,8 +5789,8 @@ entry:
 ; <label>:40                                      ; preds = %17
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
-  br i1 %NullCheck6, label %43, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %41, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
@@ -4938,34 +5802,17 @@ ThrowNullRef:                                     ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %24
+ThrowNullRef4:                                    ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %40
+ThrowNullRef6:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
-}
-
-INFO:  jitting method Object::ReferenceEquals using LLILCJit
-Successfully read Object.ReferenceEquals
-
-define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
-entry:
-  %arg0 = alloca %System.Object addrspace(1)*
-  %arg1 = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
-  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
-  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = icmp eq %System.Object addrspace(1)* %0, %1
-  %3 = sext i1 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
 }
 
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
@@ -4978,21 +5825,21 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
   %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
-  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
@@ -5007,28 +5854,28 @@ entry:
 ; <label>:13                                      ; preds = %8, %12
   %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
   %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
   %21 = load i32, i32 addrspace(1)* %20, align 8
   %22 = add i32 %21, 1
-  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
   store i32 %22, i32 addrspace(1)* %24
   %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
@@ -5039,27 +5886,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5077,7 +5924,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::Setup using LLILCJit
-Failed to read AppDomain.Setup[loadElem]
+Failed to read AppDomain.Setup[unbox]
 INFO:  jitting method Thread::GetDomain using LLILCJit
 Successfully read Thread.GetDomain
 
@@ -5108,8 +5955,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
@@ -5122,14 +5969,14 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
   %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
@@ -5141,11 +5988,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5173,8 +6020,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -5189,7 +6036,328 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
 Failed to read KeyCollection.System.Collections.Generic.IEnumerable<TKey>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Successfully read Enumerator.MoveNext
+
+define i8 @Enumerator.MoveNext(%"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.RuntimeTypeHandle* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*
+  %"$TypeArg" = alloca %System.RuntimeTypeHandle*
+  store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
+  %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 8
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %76, label %12
+
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
+  br label %76
+
+; <label>:13                                      ; preds = %85
+  %14 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck19 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %15
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, i32 0, i32 0
+  %17 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %16, align 8
+  %NullCheck21 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, i32 0, i32 2
+  %20 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %19, align 8
+  %21 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck23 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %22
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, i32 0, i32 2
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %NullCheck25 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 3, i32 %24
+  %NullCheck27 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %32
+
+; <label>:32                                      ; preds = %30
+  %33 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, i32 0, i32 2
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = icmp slt i32 %34, 0
+  br i1 %35, label %68, label %36
+
+; <label>:36                                      ; preds = %32
+  %37 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %38 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck29 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %39
+
+; <label>:39                                      ; preds = %36
+  %40 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, i32 0, i32 0
+  %41 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %40, align 8
+  %NullCheck31 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, i32 0, i32 2
+  %44 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %43, align 8
+  %45 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck33 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, i32 0, i32 2
+  %48 = load i32, i32 addrspace(1)* %47, align 8
+  %NullCheck35 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %49
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = zext i32 %51 to i64
+  %53 = zext i32 %48 to i64
+  %BoundsCheck37 = icmp uge i64 %53, %52
+  br i1 %BoundsCheck37, label %ThrowIndexOutOfRange38, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 3, i32 %48
+  %NullCheck39 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %56
+
+; <label>:56                                      ; preds = %54
+  %57 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, i32 0, i32 0
+  %58 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck41 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %59
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %60, %System.__Canon addrspace(1)* %58)
+  %61 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck43 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  %64 = load i32, i32 addrspace(1)* %63, align 8
+  %65 = add i32 %64, 1
+  %NullCheck45 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  store i32 %65, i32 addrspace(1)* %67
+  ret i8 1
+
+; <label>:68                                      ; preds = %32
+  %69 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck47 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %73 = add i32 %72, 1
+  %NullCheck49 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %74
+
+; <label>:74                                      ; preds = %70
+  %75 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  store i32 %73, i32 addrspace(1)* %75
+  br label %76
+
+; <label>:76                                      ; preds = %8, %12, %74
+  %77 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %78
+
+; <label>:78                                      ; preds = %76
+  %79 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, i32 0, i32 2
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck7 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %82
+
+; <label>:82                                      ; preds = %78
+  %83 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, i32 0, i32 0
+  %84 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %83, align 8
+  %NullCheck9 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %85
+
+; <label>:85                                      ; preds = %82
+  %86 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, i32 0, i32 7
+  %87 = load i32, i32 addrspace(1)* %86, align 8
+  %88 = icmp ult i32 %80, %87
+  br i1 %88, label %13, label %89
+
+; <label>:89                                      ; preds = %85
+  %90 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %91 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck11 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %92
+
+; <label>:92                                      ; preds = %89
+  %93 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, i32 0, i32 0
+  %94 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck13 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %95
+
+; <label>:95                                      ; preds = %92
+  %96 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, i32 0, i32 7
+  %97 = load i32, i32 addrspace(1)* %96, align 8
+  %98 = add i32 %97, 1
+  %NullCheck15 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %99
+
+; <label>:99                                      ; preds = %95
+  %100 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, i32 0, i32 2
+  store i32 %98, i32 addrspace(1)* %100
+  %101 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck17 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %102
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %103, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %92
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef22:                                   ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef24:                                   ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef26:                                   ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef28:                                   ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef30:                                   ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef32:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef34:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef36:                                   ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange38:                           ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef40:                                   ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef42:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef44:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef46:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef48:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef50:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -5200,8 +6368,8 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -5232,9 +6400,9 @@ Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
 Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
-Failed to read String.MakeSeparatorList[loadElemA]
+Failed to read String.MakeSeparatorList[storeElem]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
-Failed to read String.InternalSplitKeepEmptyEntries[loadElem]
+Failed to read String.InternalSplitKeepEmptyEntries[storeElem]
 INFO:  jitting method Path::IsRelative using LLILCJit
 Successfully read Path.IsRelative
 
@@ -5243,8 +6411,8 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -5254,8 +6422,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
@@ -5271,8 +6439,8 @@ entry:
 
 ; <label>:17                                      ; preds = %7
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
@@ -5288,8 +6456,8 @@ entry:
 
 ; <label>:29                                      ; preds = %19
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %31
 
 ; <label>:31                                      ; preds = %29
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
@@ -5300,8 +6468,8 @@ entry:
 
 ; <label>:36                                      ; preds = %31
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
-  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %37, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
@@ -5312,8 +6480,8 @@ entry:
 
 ; <label>:43                                      ; preds = %31, %38
   %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
-  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %45
 
 ; <label>:45                                      ; preds = %43
   %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
@@ -5324,8 +6492,8 @@ entry:
 
 ; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %50
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
@@ -5336,8 +6504,8 @@ entry:
 
 ; <label>:57                                      ; preds = %1, %7, %19, %45, %52
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
-  br i1 %NullCheck14, label %59, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %59
 
 ; <label>:59                                      ; preds = %57
   %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
@@ -5347,8 +6515,8 @@ entry:
 
 ; <label>:63                                      ; preds = %59
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
@@ -5359,8 +6527,8 @@ entry:
 
 ; <label>:70                                      ; preds = %65
   %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
-  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.String addrspace(1)* %71, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %72
 
 ; <label>:72                                      ; preds = %70
   %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
@@ -5379,39 +6547,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %17
+ThrowNullRef4:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %29
+ThrowNullRef6:                                    ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %36
+ThrowNullRef8:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %43
+ThrowNullRef10:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %50
+ThrowNullRef12:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %57
+ThrowNullRef14:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %63
+ThrowNullRef16:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %70
+ThrowNullRef18:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5419,7 +6587,293 @@ ThrowNullRef17:                                   ; preds = %70
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
-Failed to read String.TrimHelper[loadElem]
+Successfully read String.TrimHelper
+
+define %System.String addrspace(1)* @String.TrimHelper(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i16
+  %loc4 = alloca i32
+  %loc5 = alloca i16
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = sub i32 %3, 1
+  store i32 %4, i32* %loc0
+  store i32 0, i32* %loc1
+  %5 = load i32, i32* %arg2
+  %6 = icmp eq i32 %5, 1
+  br i1 %6, label %62, label %7
+
+; <label>:7                                       ; preds = %1
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:8                                       ; preds = %58
+  store i32 0, i32* %loc2
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load i32, i32* %loc1
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2, i32 %10
+  %13 = load i16, i16 addrspace(1)* %12
+  %14 = zext i16 %13 to i32
+  %15 = trunc i32 %14 to i16
+  store i16 %15, i16* %loc3
+  store i32 0, i32* %loc2
+  br label %34
+
+; <label>:16                                      ; preds = %37
+  %17 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %18 = load i32, i32* %loc2
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %17, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %19
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = zext i32 %18 to i64
+  %BoundsCheck = icmp uge i64 %23, %22
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %24
+
+; <label>:24                                      ; preds = %19
+  %25 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 3, i32 %18
+  %26 = load i16, i16 addrspace(1)* %25, align 8
+  %27 = zext i16 %26 to i32
+  %28 = load i16, i16* %loc3
+  %29 = zext i16 %28 to i32
+  %30 = icmp eq i32 %27, %29
+  br i1 %30, label %43, label %31
+
+; <label>:31                                      ; preds = %24
+  %32 = load i32, i32* %loc2
+  %33 = add i32 %32, 1
+  store i32 %33, i32* %loc2
+  br label %34
+
+; <label>:34                                      ; preds = %11, %31
+  %35 = load i32, i32* %loc2
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = icmp slt i32 %35, %41
+  br i1 %42, label %16, label %43
+
+; <label>:43                                      ; preds = %24, %37
+  %44 = load i32, i32* %loc2
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %45, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp eq i32 %44, %50
+  br i1 %51, label %62, label %52
+
+; <label>:52                                      ; preds = %46
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %7, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %57, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %58
+
+; <label>:58                                      ; preds = %55
+  %59 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %60 = load i32, i32 addrspace(1)* %59
+  %61 = icmp slt i32 %56, %60
+  br i1 %61, label %8, label %62
+
+; <label>:62                                      ; preds = %1, %46, %58
+  %63 = load i32, i32* %arg2
+  %64 = icmp eq i32 %63, 0
+  br i1 %64, label %122, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %66, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %67
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %66, i32 0, i32 1
+  %69 = load i32, i32 addrspace(1)* %68
+  %70 = sub i32 %69, 1
+  store i32 %70, i32* %loc0
+  br label %118
+
+; <label>:71                                      ; preds = %118
+  store i32 0, i32* %loc4
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %73 = load i32, i32* %loc0
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %74
+
+; <label>:74                                      ; preds = %71
+  %75 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 2, i32 %73
+  %76 = load i16, i16 addrspace(1)* %75
+  %77 = zext i16 %76 to i32
+  %78 = trunc i32 %77 to i16
+  store i16 %78, i16* %loc5
+  store i32 0, i32* %loc4
+  br label %97
+
+; <label>:79                                      ; preds = %100
+  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %81 = load i32, i32* %loc4
+  %NullCheck19 = icmp eq %"System.Char[]" addrspace(1)* %80, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
+
+; <label>:82                                      ; preds = %79
+  %83 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 1
+  %84 = load i32, i32 addrspace(1)* %83
+  %85 = zext i32 %84 to i64
+  %86 = zext i32 %81 to i64
+  %BoundsCheck21 = icmp uge i64 %86, %85
+  br i1 %BoundsCheck21, label %ThrowIndexOutOfRange22, label %87
+
+; <label>:87                                      ; preds = %82
+  %88 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 3, i32 %81
+  %89 = load i16, i16 addrspace(1)* %88, align 8
+  %90 = zext i16 %89 to i32
+  %91 = load i16, i16* %loc5
+  %92 = zext i16 %91 to i32
+  %93 = icmp eq i32 %90, %92
+  br i1 %93, label %106, label %94
+
+; <label>:94                                      ; preds = %87
+  %95 = load i32, i32* %loc4
+  %96 = add i32 %95, 1
+  store i32 %96, i32* %loc4
+  br label %97
+
+; <label>:97                                      ; preds = %74, %94
+  %98 = load i32, i32* %loc4
+  %99 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck15 = icmp eq %"System.Char[]" addrspace(1)* %99, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %100
+
+; <label>:100                                     ; preds = %97
+  %101 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %99, i32 0, i32 1
+  %102 = load i32, i32 addrspace(1)* %101
+  %103 = zext i32 %102 to i64
+  %104 = trunc i64 %103 to i32
+  %105 = icmp slt i32 %98, %104
+  br i1 %105, label %79, label %106
+
+; <label>:106                                     ; preds = %87, %100
+  %107 = load i32, i32* %loc4
+  %108 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck17 = icmp eq %"System.Char[]" addrspace(1)* %108, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %109
+
+; <label>:109                                     ; preds = %106
+  %110 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %108, i32 0, i32 1
+  %111 = load i32, i32 addrspace(1)* %110
+  %112 = zext i32 %111 to i64
+  %113 = trunc i64 %112 to i32
+  %114 = icmp eq i32 %107, %113
+  br i1 %114, label %122, label %115
+
+; <label>:115                                     ; preds = %109
+  %116 = load i32, i32* %loc0
+  %117 = sub i32 %116, 1
+  store i32 %117, i32* %loc0
+  br label %118
+
+; <label>:118                                     ; preds = %67, %115
+  %119 = load i32, i32* %loc0
+  %120 = load i32, i32* %loc1
+  %121 = icmp sge i32 %119, %120
+  br i1 %121, label %71, label %122
+
+; <label>:122                                     ; preds = %62, %109, %118
+  %123 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %124 = load i32, i32* %loc1
+  %125 = load i32, i32* %loc0
+  %126 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %123, i32 %124, i32 %125)
+  ret %System.String addrspace(1)* %126
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %97
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange22:                           ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
 Successfully read String.CreateTrimmedString
 
@@ -5439,8 +6893,8 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
@@ -5535,8 +6989,8 @@ entry:
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i64 2872
   %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
   %8 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %7
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %3
   %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
@@ -5553,8 +7007,8 @@ entry:
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 2864
   %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
   %21 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %20
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
-  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %22
 
 ; <label>:22                                      ; preds = %16
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
@@ -5569,7 +7023,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %16
+ThrowNullRef2:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5586,8 +7040,8 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5613,8 +7067,8 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
@@ -5632,8 +7086,8 @@ entry:
 
 ; <label>:12                                      ; preds = %4
   %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
@@ -5644,8 +7098,8 @@ entry:
 
 ; <label>:19                                      ; preds = %14
   %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %19
   %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
@@ -5660,21 +7114,21 @@ entry:
   %31 = zext i16 %30 to i32
   %32 = bitcast i8* %29 to i16*
   %33 = trunc i32 %31 to i16
-  %NullCheck6 = icmp ne i16* %32, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i16* %32, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %21
   store i16 %33, i16* %32, align 8
   %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %36
 
 ; <label>:36                                      ; preds = %34
   %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
   %38 = load i32, i32 addrspace(1)* %37, align 8
   %39 = add i32 %38, 1
-  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %40
 
 ; <label>:40                                      ; preds = %36
   %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
@@ -5683,16 +7137,16 @@ entry:
 
 ; <label>:42                                      ; preds = %14
   %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
-  br i1 %NullCheck12, label %44, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
   %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
   %47 = load i16, i16* %arg1
   %48 = zext i16 %47 to i32
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = trunc i32 %48 to i16
@@ -5703,31 +7157,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %19
+ThrowNullRef4:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %21
+ThrowNullRef6:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %36
+ThrowNullRef10:                                   ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %42
+ThrowNullRef12:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %44
+ThrowNullRef14:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5740,8 +7194,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -5752,8 +7206,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
@@ -5762,14 +7216,14 @@ entry:
 
 ; <label>:11                                      ; preds = %1
   %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
@@ -5779,15 +7233,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5808,8 +7262,8 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5822,8 +7276,8 @@ entry:
 
 ; <label>:8                                       ; preds = %3
   %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
@@ -5842,15 +7296,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
-  br i1 %NullCheck4, label %22, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
   %24 = load i16*, i16* addrspace(1)* %23, align 8
   %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %25, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
@@ -5859,8 +7313,8 @@ entry:
   store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
@@ -5874,8 +7328,8 @@ entry:
 
 ; <label>:37                                      ; preds = %65
   %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %37
   %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
@@ -5886,16 +7340,16 @@ entry:
   %45 = bitcast i16* %41 to i8*
   %46 = getelementptr inbounds i8, i8* %45, i64 %44
   %47 = bitcast i8* %46 to i16*
-  %NullCheck14 = icmp ne i16* %47, null
-  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %47, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %48
 
 ; <label>:48                                      ; preds = %39
   %49 = load i16, i16* %47, align 8
   %50 = zext i16 %49 to i32
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %52 = load i32, i32* %loc1
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %53
 
 ; <label>:53                                      ; preds = %48
   %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
@@ -5916,8 +7370,8 @@ entry:
 ; <label>:62                                      ; preds = %36, %59
   %63 = load i32, i32* %loc1
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck10, label %65, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %65
 
 ; <label>:65                                      ; preds = %62
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
@@ -5936,15 +7390,15 @@ entry:
 
 ; <label>:74                                      ; preds = %70
   %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
-  br i1 %NullCheck18, label %76, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %76
 
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
   %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
-  br i1 %NullCheck20, label %80, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
   %81 = load i64, i64 addrspace(1)* %79
@@ -5958,8 +7412,8 @@ entry:
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
   %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
-  br i1 %NullCheck22, label %92, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.String addrspace(1)* %90, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %92
 
 ; <label>:92                                      ; preds = %80
   %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
@@ -5969,15 +7423,15 @@ entry:
 
 ; <label>:96                                      ; preds = %70
   %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
-  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %98
 
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
   %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
-  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
   %103 = load i64, i64 addrspace(1)* %101
@@ -5991,8 +7445,8 @@ entry:
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
   %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
-  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.String addrspace(1)* %112, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %114
 
 ; <label>:114                                     ; preds = %102
   %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
@@ -6004,59 +7458,59 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %20
+ThrowNullRef4:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %22
+ThrowNullRef6:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %26
+ThrowNullRef8:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %62
+ThrowNullRef10:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %48
+ThrowNullRef16:                                   ; preds = %48
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %74
+ThrowNullRef18:                                   ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %76
+ThrowNullRef20:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %80
+ThrowNullRef22:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %96
+ThrowNullRef24:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %98
+ThrowNullRef26:                                   ; preds = %98
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %102
+ThrowNullRef28:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6069,15 +7523,15 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
   %3 = load i16*, i16* addrspace(1)* %2, align 8
   %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
@@ -6087,8 +7541,8 @@ entry:
   %10 = bitcast i16* %3 to i8*
   %11 = getelementptr inbounds i8, i8* %10, i64 %9
   %12 = bitcast i8* %11 to i16*
-  %NullCheck4 = icmp ne i16* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %5
   store i16 0, i16* %12, align 8
@@ -6098,11 +7552,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6119,8 +7573,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -6131,8 +7585,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
@@ -6144,15 +7598,15 @@ entry:
 
 ; <label>:14                                      ; preds = %1
   %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
   %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
   %21 = load i64, i64 addrspace(1)* %19
@@ -6171,15 +7625,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %14
+ThrowNullRef4:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %16
+ThrowNullRef6:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6302,14 +7756,6 @@ entry:
   ret %System.String addrspace(1)* %57
 }
 
-INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
-Successfully read RuntimeHelpers.get_OffsetToStringData
-
-define i32 @RuntimeHelpers.get_OffsetToStringData() {
-entry:
-  ret i32 12
-}
-
 INFO:  jitting method String::Equals using LLILCJit
 Successfully read String.Equals
 
@@ -6381,8 +7827,8 @@ entry:
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
-  br i1 %NullCheck24, label %29, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
   %30 = load i64, i64 addrspace(1)* %28
@@ -6397,8 +7843,8 @@ entry:
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
-  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
   %43 = load i64, i64 addrspace(1)* %41
@@ -6418,8 +7864,8 @@ entry:
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
   %59 = load i64, i64 addrspace(1)* %57
@@ -6434,8 +7880,8 @@ entry:
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck22, label %71, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
   %72 = load i64, i64 addrspace(1)* %70
@@ -6455,8 +7901,8 @@ entry:
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
-  br i1 %NullCheck16, label %87, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = load i64, i64 addrspace(1)* %86
@@ -6471,8 +7917,8 @@ entry:
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck18, label %100, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
   %101 = load i64, i64 addrspace(1)* %99
@@ -6492,8 +7938,8 @@ entry:
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
-  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
   %117 = load i64, i64 addrspace(1)* %115
@@ -6508,8 +7954,8 @@ entry:
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
-  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
   %130 = load i64, i64 addrspace(1)* %128
@@ -6528,15 +7974,15 @@ entry:
 
 ; <label>:142                                     ; preds = %22
   %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
-  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %143, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %144
 
 ; <label>:144                                     ; preds = %142
   %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
   %146 = load i32, i32 addrspace(1)* %145
   %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
-  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %147, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %148
 
 ; <label>:148                                     ; preds = %144
   %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
@@ -6557,15 +8003,15 @@ entry:
 
 ; <label>:159                                     ; preds = %22
   %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
-  br i1 %NullCheck, label %161, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %ThrowNullRef, label %161
 
 ; <label>:161                                     ; preds = %159
   %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
   %163 = load i32, i32 addrspace(1)* %162
   %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
-  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %164, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %165
 
 ; <label>:165                                     ; preds = %161
   %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
@@ -6578,8 +8024,8 @@ entry:
 
 ; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
-  br i1 %NullCheck4, label %172, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %171, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %172
 
 ; <label>:172                                     ; preds = %170
   %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
@@ -6589,8 +8035,8 @@ entry:
 
 ; <label>:176                                     ; preds = %172
   %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
-  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %177, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %178
 
 ; <label>:178                                     ; preds = %176
   %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
@@ -6629,55 +8075,55 @@ ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %161
+ThrowNullRef2:                                    ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %170
+ThrowNullRef4:                                    ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %176
+ThrowNullRef6:                                    ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %142
+ThrowNullRef8:                                    ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %144
+ThrowNullRef10:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %113
+ThrowNullRef12:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %116
+ThrowNullRef14:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %84
+ThrowNullRef16:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %87
+ThrowNullRef18:                                   ; preds = %87
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %55
+ThrowNullRef20:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %58
+ThrowNullRef22:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %26
+ThrowNullRef24:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %29
+ThrowNullRef26:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,8 +8161,8 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck, label %14, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %ThrowNullRef, label %14
 
 ; <label>:14                                      ; preds = %8
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
@@ -6760,8 +8206,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
@@ -6770,14 +8216,14 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32, i32* %loc0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %10
   %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
   %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
@@ -6790,15 +8236,15 @@ entry:
 ; <label>:25                                      ; preds = %19
   %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
-  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
   %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
@@ -6807,8 +8253,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %37 = load i32, i32* %loc0
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %38, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %38
 
 ; <label>:38                                      ; preds = %32
   %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
@@ -6817,14 +8263,14 @@ entry:
 
 ; <label>:40                                      ; preds = %19
   %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %40
   %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
   %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
-  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
-  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
@@ -6832,8 +8278,8 @@ entry:
   %48 = zext i32 %47 to i64
   %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
-  br i1 %NullCheck16, label %51, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %51
 
 ; <label>:51                                      ; preds = %45
   %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
@@ -6847,15 +8293,15 @@ entry:
 ; <label>:57                                      ; preds = %51
   %58 = load i16*, i16** %arg1
   %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
-  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %60
 
 ; <label>:60                                      ; preds = %57
   %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
   %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
-  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %64
 
 ; <label>:64                                      ; preds = %60
   %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
@@ -6864,22 +8310,22 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
   %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
-  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %70
 
 ; <label>:70                                      ; preds = %64
   %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
   %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
-  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
-  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
   %75 = load i32, i32 addrspace(1)* %74
   %76 = zext i32 %75 to i64
   %77 = trunc i64 %76 to i32
-  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
-  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %78
 
 ; <label>:78                                      ; preds = %73
   %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
@@ -6901,8 +8347,8 @@ entry:
   %90 = bitcast i16* %86 to i8*
   %91 = getelementptr inbounds i8, i8* %90, i64 %89
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %93
 
 ; <label>:93                                      ; preds = %80
   %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
@@ -6912,8 +8358,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %99 = load i32, i32* %loc2
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %100
 
 ; <label>:100                                     ; preds = %93
   %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
@@ -6928,63 +8374,63 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %25
+ThrowNullRef6:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %32
+ThrowNullRef10:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %40
+ThrowNullRef12:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %45
+ThrowNullRef16:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %57
+ThrowNullRef18:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %60
+ThrowNullRef20:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %64
+ThrowNullRef22:                                   ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %70
+ThrowNullRef24:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %73
+ThrowNullRef26:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %80
+ThrowNullRef28:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %93
+ThrowNullRef30:                                   ; preds = %93
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7004,8 +8450,8 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
@@ -7033,43 +8479,43 @@ entry:
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %14
   %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
   %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   %28 = load i32, i32 addrspace(1)* %27, align 8
   %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
-  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %30
 
 ; <label>:30                                      ; preds = %26
   %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
   %32 = load i32, i32 addrspace(1)* %31, align 8
   %33 = add i32 %28, %32
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %34
 
 ; <label>:34                                      ; preds = %30
   %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   store i32 %33, i32 addrspace(1)* %35
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
   store i32 0, i32 addrspace(1)* %38
   %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %40
 
 ; <label>:40                                      ; preds = %37
   %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
@@ -7082,8 +8528,8 @@ entry:
 
 ; <label>:47                                      ; preds = %40
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
@@ -7098,8 +8544,8 @@ entry:
   %54 = load i32, i32* %loc0
   %55 = sext i32 %54 to i64
   %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
-  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %57
 
 ; <label>:57                                      ; preds = %52
   %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
@@ -7110,68 +8556,35 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %14
+ThrowNullRef2:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %23
+ThrowNullRef4:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %26
+ThrowNullRef6:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %30
+ThrowNullRef8:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %34
+ThrowNullRef10:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %47
+ThrowNullRef14:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %52
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-}
-
-INFO:  jitting method StringBuilder::get_Length using LLILCJit
-Successfully read StringBuilder.get_Length
-
-define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.StringBuilder addrspace(1)*
-  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
-  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
-
-; <label>:1                                       ; preds = %entry
-  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %3 = load i32, i32 addrspace(1)* %2, align 8
-  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
-
-; <label>:5                                       ; preds = %1
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = add i32 %3, %7
-  ret i32 %8
-
-ThrowNullRef:                                     ; preds = %entry
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef16:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7213,70 +8626,70 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
   %6 = load i32, i32 addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
   store i32 %6, i32 addrspace(1)* %8
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
   %13 = load i32, i32 addrspace(1)* %12, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
   store i32 %13, i32 addrspace(1)* %15
   %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
-  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %18
 
 ; <label>:18                                      ; preds = %14
   %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
   %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
   %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
   %34 = load i32, i32 addrspace(1)* %33, align 8
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
-  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
@@ -7287,39 +8700,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %28
+ThrowNullRef16:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %32
+ThrowNullRef18:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7455,13 +8868,13 @@ entry:
 ; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
@@ -7477,16 +8890,16 @@ entry:
 
 ; <label>:18                                      ; preds = %15
   %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
   store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
   %22 = load i32, i32* %loc0
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %24
 
 ; <label>:24                                      ; preds = %20
   %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
@@ -7498,13 +8911,13 @@ entry:
 ; <label>:28                                      ; preds = %15, %24
   %29 = load i32, i32* %arg1
   %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %31
   %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
@@ -7517,20 +8930,20 @@ entry:
   %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
-  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
   %46 = load i32, i32 addrspace(1)* %45, align 8
   %47 = sub i32 %40, %46
-  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
-  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i32 addrspace(1)* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %48
 
 ; <label>:48                                      ; preds = %44
   store i32 %47, i32 addrspace(1)* %39, align 8
@@ -7538,21 +8951,21 @@ entry:
 
 ; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
-  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %51
 
 ; <label>:51                                      ; preds = %49
   %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %53
 
 ; <label>:53                                      ; preds = %51
   %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
   %55 = load i32, i32 addrspace(1)* %54, align 8
   %56 = load i32, i32* %arg2
   %57 = sub i32 %55, %56
-  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %58
 
 ; <label>:58                                      ; preds = %53
   %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
@@ -7562,13 +8975,13 @@ entry:
 ; <label>:60                                      ; preds = %33, %58
   %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
   %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
-  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %63
 
 ; <label>:63                                      ; preds = %60
   %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
-  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
-  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
@@ -7578,15 +8991,15 @@ entry:
 
 ; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
-  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i32 addrspace(1)* %69, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %70
 
 ; <label>:70                                      ; preds = %68
   %71 = load i32, i32 addrspace(1)* %69, align 8
   store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
-  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
@@ -7596,8 +9009,8 @@ entry:
   store i32 %77, i32* %loc4
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
-  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %80
 
 ; <label>:80                                      ; preds = %73
   %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
@@ -7607,71 +9020,71 @@ entry:
 ; <label>:83                                      ; preds = %80
   store i32 0, i32* %loc3
   %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
-  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
-  br i1 %NullCheck26, label %88, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i32 addrspace(1)* %87, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %88
 
 ; <label>:88                                      ; preds = %85
   %89 = load i32, i32 addrspace(1)* %87, align 8
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
-  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %90
 
 ; <label>:90                                      ; preds = %88
   %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
   store i32 %89, i32 addrspace(1)* %91
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
-  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
-  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %96
 
 ; <label>:96                                      ; preds = %94
   %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
-  br i1 %NullCheck34, label %100, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %100
 
 ; <label>:100                                     ; preds = %96
   %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
-  br i1 %NullCheck36, label %102, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %102
 
 ; <label>:102                                     ; preds = %100
   %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
   %104 = load i32, i32 addrspace(1)* %103, align 8
   %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
-  br i1 %NullCheck38, label %106, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %106
 
 ; <label>:106                                     ; preds = %102
   %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
-  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
-  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %108
 
 ; <label>:108                                     ; preds = %106
   %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
   %110 = load i32, i32 addrspace(1)* %109, align 8
   %111 = add i32 %104, %110
-  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %112
 
 ; <label>:112                                     ; preds = %108
   %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
   store i32 %111, i32 addrspace(1)* %113
   %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
-  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i32 addrspace(1)* %114, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %115
 
 ; <label>:115                                     ; preds = %112
   %116 = load i32, i32 addrspace(1)* %114, align 8
@@ -7681,19 +9094,19 @@ entry:
 ; <label>:118                                     ; preds = %115
   %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
-  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %121
 
 ; <label>:121                                     ; preds = %118
   %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
-  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
-  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %123
 
 ; <label>:123                                     ; preds = %121
   %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
   %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
-  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
-  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %126
 
 ; <label>:126                                     ; preds = %123
   %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
@@ -7705,8 +9118,8 @@ entry:
 
 ; <label>:130                                     ; preds = %80, %115, %126
   %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %132
 
 ; <label>:132                                     ; preds = %130
   %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7715,8 +9128,8 @@ entry:
   %136 = load i32, i32* %loc3
   %137 = sub i32 %135, %136
   %138 = sub i32 %134, %137
-  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %139
 
 ; <label>:139                                     ; preds = %132
   %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7728,16 +9141,16 @@ entry:
 
 ; <label>:144                                     ; preds = %139
   %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
-  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %146
 
 ; <label>:146                                     ; preds = %144
   %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
   %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
   %149 = load i32, i32* %loc2
   %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
-  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %151
 
 ; <label>:151                                     ; preds = %146
   %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
@@ -7754,145 +9167,249 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %18
+ThrowNullRef4:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %31
+ThrowNullRef10:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %44
+ThrowNullRef16:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %68
+ThrowNullRef18:                                   ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %70
+ThrowNullRef20:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %73
+ThrowNullRef22:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %83
+ThrowNullRef24:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %85
+ThrowNullRef26:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %88
+ThrowNullRef28:                                   ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %90
+ThrowNullRef30:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %94
+ThrowNullRef32:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %96
+ThrowNullRef34:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %100
+ThrowNullRef36:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %102
+ThrowNullRef38:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %106
+ThrowNullRef40:                                   ; preds = %106
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %108
+ThrowNullRef42:                                   ; preds = %108
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %112
+ThrowNullRef44:                                   ; preds = %112
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %118
+ThrowNullRef46:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %121
+ThrowNullRef48:                                   ; preds = %121
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %123
+ThrowNullRef50:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %130
+ThrowNullRef52:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %132
+ThrowNullRef54:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %144
+ThrowNullRef56:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %146
+ThrowNullRef58:                                   ; preds = %146
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %60
+ThrowNullRef60:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %63
+ThrowNullRef62:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %49
+ThrowNullRef64:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %51
+ThrowNullRef66:                                   ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %53
+ThrowNullRef68:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(%"System.Char[]" addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %arg0 = alloca %"System.Char[]" addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store %"System.Char[]" addrspace(1)* %param0, %"System.Char[]" addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load i32, i32* %arg4
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %43, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %38, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg1
+  %13 = load i32, i32* %arg4
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %38, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %24 = load i32, i32* %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %35 = load i32, i32* %arg3
+  %36 = load i32, i32* %arg4
+  %37 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %37, %"System.Char[]" addrspace(1)* %34, i32 %35, i32 %36)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:38                                      ; preds = %5, %16
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Successfully read Buffer._Memmove
 
@@ -7914,7 +9431,7 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[loadElem]
+Failed to read AppDomain.SetDataHelper[storeElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -7923,8 +9440,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
@@ -7934,8 +9451,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
@@ -7947,15 +9464,15 @@ entry:
   %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
   %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
@@ -7966,15 +9483,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7992,7 +9509,79 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
-Failed to read Dictionary`2.TryGetValue[loadElemA]
+Successfully read Dictionary`2.TryGetValue
+
+define i8 @"Dictionary`2.TryGetValue"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)* addrspace(1)* %param2) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  %arg2 = alloca %System.__Canon addrspace(1)* addrspace(1)*
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  store %System.__Canon addrspace(1)* addrspace(1)* %param2, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  store i32 %2, i32* %loc0
+  %3 = load i32, i32* %loc0
+  %4 = icmp slt i32 %3, 0
+  br i1 %4, label %22, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 2
+  %10 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %9, align 8
+  %11 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = zext i32 %11 to i64
+  %BoundsCheck = icmp uge i64 %16, %15
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 3, i32 %11
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %20, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %6, %System.__Canon addrspace(1)* %21)
+  ret i8 1
+
+; <label>:22                                      ; preds = %entry
+  %23 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %23, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -8058,8 +9647,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
@@ -8091,8 +9680,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
@@ -8171,15 +9760,15 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck, label %19, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %ThrowNullRef, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
   %21 = load i32, i32 addrspace(1)* %20
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
@@ -8202,7 +9791,7 @@ ThrowNullRef:                                     ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %19
+ThrowNullRef2:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8248,8 +9837,8 @@ entry:
   %0 = alloca %System.AppDomainHandle
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %1 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %1, i32 0, i32 15
@@ -8269,8 +9858,8 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
@@ -8286,7 +9875,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -8299,8 +9888,8 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -8327,8 +9916,8 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
@@ -8352,8 +9941,8 @@ entry:
   %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
   store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
@@ -8363,8 +9952,8 @@ entry:
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
@@ -8374,8 +9963,8 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %9
   %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
@@ -8384,8 +9973,8 @@ entry:
 
 ; <label>:18                                      ; preds = %3, %16
   %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
@@ -8397,15 +9986,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %18
+ThrowNullRef6:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8418,8 +10007,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
@@ -8453,15 +10042,15 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
@@ -8473,7 +10062,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8481,7 +10070,7 @@ ThrowNullRef1:                                    ; preds = %1
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
 Failed to read Dictionary`2.System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
@@ -8506,8 +10095,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
@@ -8524,8 +10113,8 @@ entry:
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -8544,7 +10133,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8577,8 +10166,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = load i64, i64* %arg2
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = trunc i32 %3 to i8
@@ -8634,46 +10223,46 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
   %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
-  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
-  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
-  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
@@ -8684,27 +10273,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %20
+ThrowNullRef12:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8717,8 +10306,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -8756,22 +10345,22 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
   %9 = load i64, i64 addrspace(1)* %8, align 8
   %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
   %13 = load i64, i64 addrspace(1)* %12, align 8
   %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %11
   %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
@@ -8788,11 +10377,11 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8882,8 +10471,8 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
@@ -8900,8 +10489,8 @@ entry:
 ; <label>:8                                       ; preds = %1
   %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
   %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
@@ -8911,15 +10500,15 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
   %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
   %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
-  br i1 %NullCheck6, label %21, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
@@ -8946,15 +10535,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8992,15 +10581,15 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
   store i8 %3, i8 addrspace(1)* %5
   %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
@@ -9011,7 +10600,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9027,8 +10616,8 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -9041,8 +10630,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
@@ -9058,7 +10647,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9080,8 +10669,8 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
@@ -9096,8 +10685,8 @@ entry:
 ; <label>:12                                      ; preds = %6
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
@@ -9112,8 +10701,8 @@ entry:
 ; <label>:21                                      ; preds = %15
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
@@ -9128,8 +10717,8 @@ entry:
 ; <label>:30                                      ; preds = %24
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %31, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
@@ -9144,8 +10733,8 @@ entry:
 ; <label>:39                                      ; preds = %33
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
-  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %40, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %42
 
 ; <label>:42                                      ; preds = %39
   %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
@@ -9164,19 +10753,19 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %21
+ThrowNullRef4:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %30
+ThrowNullRef6:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %39
+ThrowNullRef8:                                    ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9243,8 +10832,8 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
@@ -9264,57 +10853,57 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
   store i8 0, i8 addrspace(1)* %2
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
   store i8 0, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
   store i8 0, i8 addrspace(1)* %17
   %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
   store i8 0, i8 addrspace(1)* %20
   %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
-  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
@@ -9325,31 +10914,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %19
+ThrowNullRef14:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9367,8 +10956,8 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
@@ -9380,8 +10969,8 @@ entry:
 
 ; <label>:9                                       ; preds = %4
   %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %9
   %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
@@ -9395,7 +10984,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef2:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9420,8 +11009,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
@@ -9512,8 +11101,8 @@ entry:
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
@@ -9524,8 +11113,8 @@ entry:
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = load i64, i64 addrspace(1)* %12
@@ -9537,8 +11126,8 @@ entry:
   %20 = load i64, i64* %19
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
-  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %13
   %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
@@ -9555,8 +11144,8 @@ entry:
 ; <label>:30                                      ; preds = %25
   %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %32 = load i32, i32* %arg2
-  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
-  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
@@ -9570,15 +11159,15 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %30
+ThrowNullRef2:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9622,87 +11211,87 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
   %10 = load i8, i8 addrspace(1)* %9, align 8
   %11 = zext i8 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %8
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
   store i8 %12, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
   %19 = load i8, i8 addrspace(1)* %18, align 8
   %20 = zext i8 %19 to i32
   %21 = trunc i32 %20 to i8
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
   store i8 %21, i8 addrspace(1)* %23
   %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
   %28 = load i8, i8 addrspace(1)* %27, align 8
   %29 = zext i8 %28 to i32
   %30 = trunc i32 %29 to i8
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
-  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %31
 
 ; <label>:31                                      ; preds = %26
   %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
   store i8 %30, i8 addrspace(1)* %32
   %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
-  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
-  br i1 %NullCheck14, label %40, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %40
 
 ; <label>:40                                      ; preds = %35
   %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
   store i8 %39, i8 addrspace(1)* %41
   %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
-  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %44
 
 ; <label>:44                                      ; preds = %40
   %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
   %46 = load i8, i8 addrspace(1)* %45, align 8
   %47 = zext i8 %46 to i32
   %48 = trunc i32 %47 to i8
-  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
   store i8 %48, i8 addrspace(1)* %50
   %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
-  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
@@ -9713,29 +11302,29 @@ entry:
 ; <label>:56                                      ; preds = %52
   %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
-  br i1 %NullCheck22, label %59, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
   %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
   %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
-  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
-  br i1 %NullCheck24, label %63, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
   %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
-  br i1 %NullCheck26, label %66, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
   %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
-  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
-  br i1 %NullCheck28, label %69, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %69
 
 ; <label>:69                                      ; preds = %66
   %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
@@ -9744,15 +11333,15 @@ entry:
 
 ; <label>:71                                      ; preds = %105
   %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
-  br i1 %NullCheck34, label %73, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %73
 
 ; <label>:73                                      ; preds = %71
   %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
   %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
   %76 = load i32, i32* %loc0
-  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
-  br i1 %NullCheck36, label %77, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
@@ -9766,8 +11355,8 @@ entry:
 
 ; <label>:83                                      ; preds = %77
   %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
-  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
@@ -9775,14 +11364,14 @@ entry:
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
   %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
-  br i1 %NullCheck40, label %91, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
 ; <label>:91                                      ; preds = %85
   %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
   %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
-  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck42, label %94, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %94
 
 ; <label>:94                                      ; preds = %91
   %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
@@ -9798,14 +11387,14 @@ entry:
 ; <label>:99                                      ; preds = %69, %96
   %100 = load i32, i32* %loc0
   %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
-  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %102
 
 ; <label>:102                                     ; preds = %99
   %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
   %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
-  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
-  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
@@ -9819,87 +11408,87 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %26
+ThrowNullRef10:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %31
+ThrowNullRef12:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %35
+ThrowNullRef14:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %40
+ThrowNullRef16:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %56
+ThrowNullRef22:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %59
+ThrowNullRef24:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %63
+ThrowNullRef26:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %66
+ThrowNullRef28:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %102
+ThrowNullRef32:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %71
+ThrowNullRef34:                                   ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %73
+ThrowNullRef36:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %83
+ThrowNullRef38:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %85
+ThrowNullRef40:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %91
+ThrowNullRef42:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9943,15 +11532,15 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
   %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
@@ -9961,28 +11550,28 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
   %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %12
   %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
   %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
   %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
-  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
@@ -9993,23 +11582,23 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %12
+ThrowNullRef6:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10031,15 +11620,15 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
   %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = load i64, i64 addrspace(1)* %7
@@ -10077,13 +11666,13 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[loadElem]
+Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -10111,8 +11700,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueLtInt1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueLtInt1.error.txt
@@ -25,8 +25,8 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
@@ -40,8 +40,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
   %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
@@ -75,7 +75,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -90,8 +90,8 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %NullCheck = icmp ne i8 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = load i8, i8 addrspace(1)* %0, align 8
@@ -125,8 +125,8 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
@@ -159,8 +159,8 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -184,8 +184,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
   store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
@@ -195,8 +195,8 @@ entry:
 ; <label>:4                                       ; preds = %1
   %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
   %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
@@ -206,8 +206,8 @@ entry:
   %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
@@ -221,14 +221,14 @@ entry:
 
 ; <label>:17                                      ; preds = %14
   %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
   %21 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
@@ -238,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -249,8 +249,8 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
@@ -261,27 +261,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %30
+ThrowNullRef10:                                   ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -301,7 +301,89 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
-Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
+Successfully read AppDomainSetup.GetUnsecureApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.GetUnsecureApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %NullCheck = icmp eq %"System.String[]" addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %BoundsCheck = icmp uge i64 0, %5
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %6
+
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 3, i32 0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
+  ret %System.String addrspace(1)* %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_Value using LLILCJit
+Successfully read AppDomainSetup.get_Value
+
+define %"System.String[]" addrspace(1)* @AppDomainSetup.get_Value(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.String[]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 18)
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.String[]" addrspace(1)* addrspace(1)*, %"System.String[]" addrspace(1)*)*)(%"System.String[]" addrspace(1)* addrspace(1)* %9, %"System.String[]" addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %11, i32 0, i32 1
+  %14 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %13, align 8
+  ret %"System.String[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -319,8 +401,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -368,16 +450,16 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
   %5 = load i32, i32 addrspace(1)* %4
   %6 = sub i32 %5, 1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -389,7 +471,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -421,8 +503,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
@@ -456,8 +538,8 @@ entry:
 ; <label>:27                                      ; preds = %19
   %28 = load i32, i32* %arg1
   %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
-  br i1 %NullCheck2, label %30, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %29, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %30
 
 ; <label>:30                                      ; preds = %27
   %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
@@ -493,8 +575,8 @@ entry:
 ; <label>:49                                      ; preds = %46
   %50 = load i32, i32* %arg2
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck4, label %52, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
@@ -517,11 +599,11 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %27
+ThrowNullRef2:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %49
+ThrowNullRef4:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -544,16 +626,16 @@ entry:
   %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %0)
   store %System.String addrspace(1)* %1, %System.String addrspace(1)** %loc0
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 2
   %5 = bitcast [0 x i16] addrspace(1)* %4 to i16 addrspace(1)*
   store i16 addrspace(1)* %5, i16 addrspace(1)** %loc1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %3
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2
@@ -580,7 +662,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -691,15 +773,15 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %NullCheck132 = icmp ne i8* %21, null
-  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+  %NullCheck131 = icmp eq i8* %21, null
+  br i1 %NullCheck131, label %ThrowNullRef132, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = load i8, i8* %21, align 8
   %24 = zext i8 %23 to i32
   %25 = trunc i32 %24 to i8
-  %NullCheck134 = icmp ne i8* %20, null
-  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+  %NullCheck133 = icmp eq i8* %20, null
+  br i1 %NullCheck133, label %ThrowNullRef134, label %26
 
 ; <label>:26                                      ; preds = %22
   store i8 %25, i8* %20, align 8
@@ -709,16 +791,16 @@ entry:
   %28 = load i8*, i8** %arg0
   %29 = load i8*, i8** %arg1
   %30 = bitcast i8* %29 to i16*
-  %NullCheck128 = icmp ne i16* %30, null
-  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+  %NullCheck127 = icmp eq i16* %30, null
+  br i1 %NullCheck127, label %ThrowNullRef128, label %31
 
 ; <label>:31                                      ; preds = %27
   %32 = load i16, i16* %30, align 8
   %33 = sext i16 %32 to i32
   %34 = bitcast i8* %28 to i16*
   %35 = trunc i32 %33 to i16
-  %NullCheck130 = icmp ne i16* %34, null
-  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+  %NullCheck129 = icmp eq i16* %34, null
+  br i1 %NullCheck129, label %ThrowNullRef130, label %36
 
 ; <label>:36                                      ; preds = %31
   store i16 %35, i16* %34, align 8
@@ -728,16 +810,16 @@ entry:
   %38 = load i8*, i8** %arg0
   %39 = load i8*, i8** %arg1
   %40 = bitcast i8* %39 to i16*
-  %NullCheck120 = icmp ne i16* %40, null
-  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+  %NullCheck119 = icmp eq i16* %40, null
+  br i1 %NullCheck119, label %ThrowNullRef120, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i16, i16* %40, align 8
   %43 = sext i16 %42 to i32
   %44 = bitcast i8* %38 to i16*
   %45 = trunc i32 %43 to i16
-  %NullCheck122 = icmp ne i16* %44, null
-  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+  %NullCheck121 = icmp eq i16* %44, null
+  br i1 %NullCheck121, label %ThrowNullRef122, label %46
 
 ; <label>:46                                      ; preds = %41
   store i16 %45, i16* %44, align 8
@@ -745,15 +827,15 @@ entry:
   %48 = getelementptr inbounds i8, i8* %47, i64 2
   %49 = load i8*, i8** %arg1
   %50 = getelementptr inbounds i8, i8* %49, i64 2
-  %NullCheck124 = icmp ne i8* %50, null
-  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+  %NullCheck123 = icmp eq i8* %50, null
+  br i1 %NullCheck123, label %ThrowNullRef124, label %51
 
 ; <label>:51                                      ; preds = %46
   %52 = load i8, i8* %50, align 8
   %53 = zext i8 %52 to i32
   %54 = trunc i32 %53 to i8
-  %NullCheck126 = icmp ne i8* %48, null
-  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+  %NullCheck125 = icmp eq i8* %48, null
+  br i1 %NullCheck125, label %ThrowNullRef126, label %55
 
 ; <label>:55                                      ; preds = %51
   store i8 %54, i8* %48, align 8
@@ -763,14 +845,14 @@ entry:
   %57 = load i8*, i8** %arg0
   %58 = load i8*, i8** %arg1
   %59 = bitcast i8* %58 to i32*
-  %NullCheck116 = icmp ne i32* %59, null
-  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+  %NullCheck115 = icmp eq i32* %59, null
+  br i1 %NullCheck115, label %ThrowNullRef116, label %60
 
 ; <label>:60                                      ; preds = %56
   %61 = load i32, i32* %59, align 8
   %62 = bitcast i8* %57 to i32*
-  %NullCheck118 = icmp ne i32* %62, null
-  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+  %NullCheck117 = icmp eq i32* %62, null
+  br i1 %NullCheck117, label %ThrowNullRef118, label %63
 
 ; <label>:63                                      ; preds = %60
   store i32 %61, i32* %62, align 8
@@ -780,14 +862,14 @@ entry:
   %65 = load i8*, i8** %arg0
   %66 = load i8*, i8** %arg1
   %67 = bitcast i8* %66 to i32*
-  %NullCheck108 = icmp ne i32* %67, null
-  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+  %NullCheck107 = icmp eq i32* %67, null
+  br i1 %NullCheck107, label %ThrowNullRef108, label %68
 
 ; <label>:68                                      ; preds = %64
   %69 = load i32, i32* %67, align 8
   %70 = bitcast i8* %65 to i32*
-  %NullCheck110 = icmp ne i32* %70, null
-  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+  %NullCheck109 = icmp eq i32* %70, null
+  br i1 %NullCheck109, label %ThrowNullRef110, label %71
 
 ; <label>:71                                      ; preds = %68
   store i32 %69, i32* %70, align 8
@@ -795,15 +877,15 @@ entry:
   %73 = getelementptr inbounds i8, i8* %72, i64 4
   %74 = load i8*, i8** %arg1
   %75 = getelementptr inbounds i8, i8* %74, i64 4
-  %NullCheck112 = icmp ne i8* %75, null
-  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+  %NullCheck111 = icmp eq i8* %75, null
+  br i1 %NullCheck111, label %ThrowNullRef112, label %76
 
 ; <label>:76                                      ; preds = %71
   %77 = load i8, i8* %75, align 8
   %78 = zext i8 %77 to i32
   %79 = trunc i32 %78 to i8
-  %NullCheck114 = icmp ne i8* %73, null
-  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+  %NullCheck113 = icmp eq i8* %73, null
+  br i1 %NullCheck113, label %ThrowNullRef114, label %80
 
 ; <label>:80                                      ; preds = %76
   store i8 %79, i8* %73, align 8
@@ -813,14 +895,14 @@ entry:
   %82 = load i8*, i8** %arg0
   %83 = load i8*, i8** %arg1
   %84 = bitcast i8* %83 to i32*
-  %NullCheck100 = icmp ne i32* %84, null
-  br i1 %NullCheck100, label %85, label %ThrowNullRef99
+  %NullCheck99 = icmp eq i32* %84, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %85
 
 ; <label>:85                                      ; preds = %81
   %86 = load i32, i32* %84, align 8
   %87 = bitcast i8* %82 to i32*
-  %NullCheck102 = icmp ne i32* %87, null
-  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+  %NullCheck101 = icmp eq i32* %87, null
+  br i1 %NullCheck101, label %ThrowNullRef102, label %88
 
 ; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
@@ -829,16 +911,16 @@ entry:
   %91 = load i8*, i8** %arg1
   %92 = getelementptr inbounds i8, i8* %91, i64 4
   %93 = bitcast i8* %92 to i16*
-  %NullCheck104 = icmp ne i16* %93, null
-  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+  %NullCheck103 = icmp eq i16* %93, null
+  br i1 %NullCheck103, label %ThrowNullRef104, label %94
 
 ; <label>:94                                      ; preds = %88
   %95 = load i16, i16* %93, align 8
   %96 = sext i16 %95 to i32
   %97 = bitcast i8* %90 to i16*
   %98 = trunc i32 %96 to i16
-  %NullCheck106 = icmp ne i16* %97, null
-  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+  %NullCheck105 = icmp eq i16* %97, null
+  br i1 %NullCheck105, label %ThrowNullRef106, label %99
 
 ; <label>:99                                      ; preds = %94
   store i16 %98, i16* %97, align 8
@@ -848,14 +930,14 @@ entry:
   %101 = load i8*, i8** %arg0
   %102 = load i8*, i8** %arg1
   %103 = bitcast i8* %102 to i32*
-  %NullCheck88 = icmp ne i32* %103, null
-  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+  %NullCheck87 = icmp eq i32* %103, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %104
 
 ; <label>:104                                     ; preds = %100
   %105 = load i32, i32* %103, align 8
   %106 = bitcast i8* %101 to i32*
-  %NullCheck90 = icmp ne i32* %106, null
-  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+  %NullCheck89 = icmp eq i32* %106, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %107
 
 ; <label>:107                                     ; preds = %104
   store i32 %105, i32* %106, align 8
@@ -864,16 +946,16 @@ entry:
   %110 = load i8*, i8** %arg1
   %111 = getelementptr inbounds i8, i8* %110, i64 4
   %112 = bitcast i8* %111 to i16*
-  %NullCheck92 = icmp ne i16* %112, null
-  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+  %NullCheck91 = icmp eq i16* %112, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %113
 
 ; <label>:113                                     ; preds = %107
   %114 = load i16, i16* %112, align 8
   %115 = sext i16 %114 to i32
   %116 = bitcast i8* %109 to i16*
   %117 = trunc i32 %115 to i16
-  %NullCheck94 = icmp ne i16* %116, null
-  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+  %NullCheck93 = icmp eq i16* %116, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %118
 
 ; <label>:118                                     ; preds = %113
   store i16 %117, i16* %116, align 8
@@ -881,15 +963,15 @@ entry:
   %120 = getelementptr inbounds i8, i8* %119, i64 6
   %121 = load i8*, i8** %arg1
   %122 = getelementptr inbounds i8, i8* %121, i64 6
-  %NullCheck96 = icmp ne i8* %122, null
-  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+  %NullCheck95 = icmp eq i8* %122, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %123
 
 ; <label>:123                                     ; preds = %118
   %124 = load i8, i8* %122, align 8
   %125 = zext i8 %124 to i32
   %126 = trunc i32 %125 to i8
-  %NullCheck98 = icmp ne i8* %120, null
-  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+  %NullCheck97 = icmp eq i8* %120, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %127
 
 ; <label>:127                                     ; preds = %123
   store i8 %126, i8* %120, align 8
@@ -899,14 +981,14 @@ entry:
   %129 = load i8*, i8** %arg0
   %130 = load i8*, i8** %arg1
   %131 = bitcast i8* %130 to i64*
-  %NullCheck84 = icmp ne i64* %131, null
-  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+  %NullCheck83 = icmp eq i64* %131, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %132
 
 ; <label>:132                                     ; preds = %128
   %133 = load i64, i64* %131, align 8
   %134 = bitcast i8* %129 to i64*
-  %NullCheck86 = icmp ne i64* %134, null
-  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+  %NullCheck85 = icmp eq i64* %134, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %135
 
 ; <label>:135                                     ; preds = %132
   store i64 %133, i64* %134, align 8
@@ -916,14 +998,14 @@ entry:
   %137 = load i8*, i8** %arg0
   %138 = load i8*, i8** %arg1
   %139 = bitcast i8* %138 to i64*
-  %NullCheck76 = icmp ne i64* %139, null
-  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+  %NullCheck75 = icmp eq i64* %139, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %140
 
 ; <label>:140                                     ; preds = %136
   %141 = load i64, i64* %139, align 8
   %142 = bitcast i8* %137 to i64*
-  %NullCheck78 = icmp ne i64* %142, null
-  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+  %NullCheck77 = icmp eq i64* %142, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %143
 
 ; <label>:143                                     ; preds = %140
   store i64 %141, i64* %142, align 8
@@ -931,15 +1013,15 @@ entry:
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %NullCheck80 = icmp ne i8* %147, null
-  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+  %NullCheck79 = icmp eq i8* %147, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %148
 
 ; <label>:148                                     ; preds = %143
   %149 = load i8, i8* %147, align 8
   %150 = zext i8 %149 to i32
   %151 = trunc i32 %150 to i8
-  %NullCheck82 = icmp ne i8* %145, null
-  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+  %NullCheck81 = icmp eq i8* %145, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %152
 
 ; <label>:152                                     ; preds = %148
   store i8 %151, i8* %145, align 8
@@ -949,14 +1031,14 @@ entry:
   %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
   %156 = bitcast i8* %155 to i64*
-  %NullCheck68 = icmp ne i64* %156, null
-  br i1 %NullCheck68, label %157, label %ThrowNullRef67
+  %NullCheck67 = icmp eq i64* %156, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %157
 
 ; <label>:157                                     ; preds = %153
   %158 = load i64, i64* %156, align 8
   %159 = bitcast i8* %154 to i64*
-  %NullCheck70 = icmp ne i64* %159, null
-  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+  %NullCheck69 = icmp eq i64* %159, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %160
 
 ; <label>:160                                     ; preds = %157
   store i64 %158, i64* %159, align 8
@@ -965,16 +1047,16 @@ entry:
   %163 = load i8*, i8** %arg1
   %164 = getelementptr inbounds i8, i8* %163, i64 8
   %165 = bitcast i8* %164 to i16*
-  %NullCheck72 = icmp ne i16* %165, null
-  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+  %NullCheck71 = icmp eq i16* %165, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %166
 
 ; <label>:166                                     ; preds = %160
   %167 = load i16, i16* %165, align 8
   %168 = sext i16 %167 to i32
   %169 = bitcast i8* %162 to i16*
   %170 = trunc i32 %168 to i16
-  %NullCheck74 = icmp ne i16* %169, null
-  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+  %NullCheck73 = icmp eq i16* %169, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %171
 
 ; <label>:171                                     ; preds = %166
   store i16 %170, i16* %169, align 8
@@ -984,14 +1066,14 @@ entry:
   %173 = load i8*, i8** %arg0
   %174 = load i8*, i8** %arg1
   %175 = bitcast i8* %174 to i64*
-  %NullCheck56 = icmp ne i64* %175, null
-  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+  %NullCheck55 = icmp eq i64* %175, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %176
 
 ; <label>:176                                     ; preds = %172
   %177 = load i64, i64* %175, align 8
   %178 = bitcast i8* %173 to i64*
-  %NullCheck58 = icmp ne i64* %178, null
-  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+  %NullCheck57 = icmp eq i64* %178, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %179
 
 ; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
@@ -1000,16 +1082,16 @@ entry:
   %182 = load i8*, i8** %arg1
   %183 = getelementptr inbounds i8, i8* %182, i64 8
   %184 = bitcast i8* %183 to i16*
-  %NullCheck60 = icmp ne i16* %184, null
-  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+  %NullCheck59 = icmp eq i16* %184, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %185
 
 ; <label>:185                                     ; preds = %179
   %186 = load i16, i16* %184, align 8
   %187 = sext i16 %186 to i32
   %188 = bitcast i8* %181 to i16*
   %189 = trunc i32 %187 to i16
-  %NullCheck62 = icmp ne i16* %188, null
-  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+  %NullCheck61 = icmp eq i16* %188, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %190
 
 ; <label>:190                                     ; preds = %185
   store i16 %189, i16* %188, align 8
@@ -1017,15 +1099,15 @@ entry:
   %192 = getelementptr inbounds i8, i8* %191, i64 10
   %193 = load i8*, i8** %arg1
   %194 = getelementptr inbounds i8, i8* %193, i64 10
-  %NullCheck64 = icmp ne i8* %194, null
-  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+  %NullCheck63 = icmp eq i8* %194, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %195
 
 ; <label>:195                                     ; preds = %190
   %196 = load i8, i8* %194, align 8
   %197 = zext i8 %196 to i32
   %198 = trunc i32 %197 to i8
-  %NullCheck66 = icmp ne i8* %192, null
-  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+  %NullCheck65 = icmp eq i8* %192, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %199
 
 ; <label>:199                                     ; preds = %195
   store i8 %198, i8* %192, align 8
@@ -1035,14 +1117,14 @@ entry:
   %201 = load i8*, i8** %arg0
   %202 = load i8*, i8** %arg1
   %203 = bitcast i8* %202 to i64*
-  %NullCheck48 = icmp ne i64* %203, null
-  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+  %NullCheck47 = icmp eq i64* %203, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %204
 
 ; <label>:204                                     ; preds = %200
   %205 = load i64, i64* %203, align 8
   %206 = bitcast i8* %201 to i64*
-  %NullCheck50 = icmp ne i64* %206, null
-  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+  %NullCheck49 = icmp eq i64* %206, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %207
 
 ; <label>:207                                     ; preds = %204
   store i64 %205, i64* %206, align 8
@@ -1051,14 +1133,14 @@ entry:
   %210 = load i8*, i8** %arg1
   %211 = getelementptr inbounds i8, i8* %210, i64 8
   %212 = bitcast i8* %211 to i32*
-  %NullCheck52 = icmp ne i32* %212, null
-  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+  %NullCheck51 = icmp eq i32* %212, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %213
 
 ; <label>:213                                     ; preds = %207
   %214 = load i32, i32* %212, align 8
   %215 = bitcast i8* %209 to i32*
-  %NullCheck54 = icmp ne i32* %215, null
-  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+  %NullCheck53 = icmp eq i32* %215, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %216
 
 ; <label>:216                                     ; preds = %213
   store i32 %214, i32* %215, align 8
@@ -1068,14 +1150,14 @@ entry:
   %218 = load i8*, i8** %arg0
   %219 = load i8*, i8** %arg1
   %220 = bitcast i8* %219 to i64*
-  %NullCheck36 = icmp ne i64* %220, null
-  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64* %220, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %221
 
 ; <label>:221                                     ; preds = %217
   %222 = load i64, i64* %220, align 8
   %223 = bitcast i8* %218 to i64*
-  %NullCheck38 = icmp ne i64* %223, null
-  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+  %NullCheck37 = icmp eq i64* %223, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %224
 
 ; <label>:224                                     ; preds = %221
   store i64 %222, i64* %223, align 8
@@ -1084,14 +1166,14 @@ entry:
   %227 = load i8*, i8** %arg1
   %228 = getelementptr inbounds i8, i8* %227, i64 8
   %229 = bitcast i8* %228 to i32*
-  %NullCheck40 = icmp ne i32* %229, null
-  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i32* %229, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %230
 
 ; <label>:230                                     ; preds = %224
   %231 = load i32, i32* %229, align 8
   %232 = bitcast i8* %226 to i32*
-  %NullCheck42 = icmp ne i32* %232, null
-  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+  %NullCheck41 = icmp eq i32* %232, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %233
 
 ; <label>:233                                     ; preds = %230
   store i32 %231, i32* %232, align 8
@@ -1099,15 +1181,15 @@ entry:
   %235 = getelementptr inbounds i8, i8* %234, i64 12
   %236 = load i8*, i8** %arg1
   %237 = getelementptr inbounds i8, i8* %236, i64 12
-  %NullCheck44 = icmp ne i8* %237, null
-  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i8* %237, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %238
 
 ; <label>:238                                     ; preds = %233
   %239 = load i8, i8* %237, align 8
   %240 = zext i8 %239 to i32
   %241 = trunc i32 %240 to i8
-  %NullCheck46 = icmp ne i8* %235, null
-  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+  %NullCheck45 = icmp eq i8* %235, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %242
 
 ; <label>:242                                     ; preds = %238
   store i8 %241, i8* %235, align 8
@@ -1117,14 +1199,14 @@ entry:
   %244 = load i8*, i8** %arg0
   %245 = load i8*, i8** %arg1
   %246 = bitcast i8* %245 to i64*
-  %NullCheck24 = icmp ne i64* %246, null
-  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64* %246, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %247
 
 ; <label>:247                                     ; preds = %243
   %248 = load i64, i64* %246, align 8
   %249 = bitcast i8* %244 to i64*
-  %NullCheck26 = icmp ne i64* %249, null
-  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64* %249, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %250
 
 ; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
@@ -1133,14 +1215,14 @@ entry:
   %253 = load i8*, i8** %arg1
   %254 = getelementptr inbounds i8, i8* %253, i64 8
   %255 = bitcast i8* %254 to i32*
-  %NullCheck28 = icmp ne i32* %255, null
-  br i1 %NullCheck28, label %256, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i32* %255, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %256
 
 ; <label>:256                                     ; preds = %250
   %257 = load i32, i32* %255, align 8
   %258 = bitcast i8* %252 to i32*
-  %NullCheck30 = icmp ne i32* %258, null
-  br i1 %NullCheck30, label %259, label %ThrowNullRef29
+  %NullCheck29 = icmp eq i32* %258, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %259
 
 ; <label>:259                                     ; preds = %256
   store i32 %257, i32* %258, align 8
@@ -1149,16 +1231,16 @@ entry:
   %262 = load i8*, i8** %arg1
   %263 = getelementptr inbounds i8, i8* %262, i64 12
   %264 = bitcast i8* %263 to i16*
-  %NullCheck32 = icmp ne i16* %264, null
-  br i1 %NullCheck32, label %265, label %ThrowNullRef31
+  %NullCheck31 = icmp eq i16* %264, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %265
 
 ; <label>:265                                     ; preds = %259
   %266 = load i16, i16* %264, align 8
   %267 = sext i16 %266 to i32
   %268 = bitcast i8* %261 to i16*
   %269 = trunc i32 %267 to i16
-  %NullCheck34 = icmp ne i16* %268, null
-  br i1 %NullCheck34, label %270, label %ThrowNullRef33
+  %NullCheck33 = icmp eq i16* %268, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %270
 
 ; <label>:270                                     ; preds = %265
   store i16 %269, i16* %268, align 8
@@ -1168,14 +1250,14 @@ entry:
   %272 = load i8*, i8** %arg0
   %273 = load i8*, i8** %arg1
   %274 = bitcast i8* %273 to i64*
-  %NullCheck8 = icmp ne i64* %274, null
-  br i1 %NullCheck8, label %275, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64* %274, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %275
 
 ; <label>:275                                     ; preds = %271
   %276 = load i64, i64* %274, align 8
   %277 = bitcast i8* %272 to i64*
-  %NullCheck10 = icmp ne i64* %277, null
-  br i1 %NullCheck10, label %278, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %277, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %278
 
 ; <label>:278                                     ; preds = %275
   store i64 %276, i64* %277, align 8
@@ -1184,14 +1266,14 @@ entry:
   %281 = load i8*, i8** %arg1
   %282 = getelementptr inbounds i8, i8* %281, i64 8
   %283 = bitcast i8* %282 to i32*
-  %NullCheck12 = icmp ne i32* %283, null
-  br i1 %NullCheck12, label %284, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i32* %283, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %284
 
 ; <label>:284                                     ; preds = %278
   %285 = load i32, i32* %283, align 8
   %286 = bitcast i8* %280 to i32*
-  %NullCheck14 = icmp ne i32* %286, null
-  br i1 %NullCheck14, label %287, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i32* %286, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %287
 
 ; <label>:287                                     ; preds = %284
   store i32 %285, i32* %286, align 8
@@ -1200,16 +1282,16 @@ entry:
   %290 = load i8*, i8** %arg1
   %291 = getelementptr inbounds i8, i8* %290, i64 12
   %292 = bitcast i8* %291 to i16*
-  %NullCheck16 = icmp ne i16* %292, null
-  br i1 %NullCheck16, label %293, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i16* %292, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %293
 
 ; <label>:293                                     ; preds = %287
   %294 = load i16, i16* %292, align 8
   %295 = sext i16 %294 to i32
   %296 = bitcast i8* %289 to i16*
   %297 = trunc i32 %295 to i16
-  %NullCheck18 = icmp ne i16* %296, null
-  br i1 %NullCheck18, label %298, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i16* %296, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %298
 
 ; <label>:298                                     ; preds = %293
   store i16 %297, i16* %296, align 8
@@ -1217,15 +1299,15 @@ entry:
   %300 = getelementptr inbounds i8, i8* %299, i64 14
   %301 = load i8*, i8** %arg1
   %302 = getelementptr inbounds i8, i8* %301, i64 14
-  %NullCheck20 = icmp ne i8* %302, null
-  br i1 %NullCheck20, label %303, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i8* %302, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %303
 
 ; <label>:303                                     ; preds = %298
   %304 = load i8, i8* %302, align 8
   %305 = zext i8 %304 to i32
   %306 = trunc i32 %305 to i8
-  %NullCheck22 = icmp ne i8* %300, null
-  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i8* %300, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %307
 
 ; <label>:307                                     ; preds = %303
   store i8 %306, i8* %300, align 8
@@ -1235,14 +1317,14 @@ entry:
   %309 = load i8*, i8** %arg0
   %310 = load i8*, i8** %arg1
   %311 = bitcast i8* %310 to i64*
-  %NullCheck = icmp ne i64* %311, null
-  br i1 %NullCheck, label %312, label %ThrowNullRef
+  %NullCheck = icmp eq i64* %311, null
+  br i1 %NullCheck, label %ThrowNullRef, label %312
 
 ; <label>:312                                     ; preds = %308
   %313 = load i64, i64* %311, align 8
   %314 = bitcast i8* %309 to i64*
-  %NullCheck2 = icmp ne i64* %314, null
-  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64* %314, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %315
 
 ; <label>:315                                     ; preds = %312
   store i64 %313, i64* %314, align 8
@@ -1251,14 +1333,14 @@ entry:
   %318 = load i8*, i8** %arg1
   %319 = getelementptr inbounds i8, i8* %318, i64 8
   %320 = bitcast i8* %319 to i64*
-  %NullCheck4 = icmp ne i64* %320, null
-  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64* %320, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %321
 
 ; <label>:321                                     ; preds = %315
   %322 = load i64, i64* %320, align 8
   %323 = bitcast i8* %317 to i64*
-  %NullCheck6 = icmp ne i64* %323, null
-  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64* %323, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %324
 
 ; <label>:324                                     ; preds = %321
   store i64 %322, i64* %323, align 8
@@ -1286,15 +1368,15 @@ entry:
 ; <label>:338                                     ; preds = %333
   %339 = load i8*, i8** %arg0
   %340 = load i8*, i8** %arg1
-  %NullCheck136 = icmp ne i8* %340, null
-  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+  %NullCheck135 = icmp eq i8* %340, null
+  br i1 %NullCheck135, label %ThrowNullRef136, label %341
 
 ; <label>:341                                     ; preds = %338
   %342 = load i8, i8* %340, align 8
   %343 = zext i8 %342 to i32
   %344 = trunc i32 %343 to i8
-  %NullCheck138 = icmp ne i8* %339, null
-  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+  %NullCheck137 = icmp eq i8* %339, null
+  br i1 %NullCheck137, label %ThrowNullRef138, label %345
 
 ; <label>:345                                     ; preds = %341
   store i8 %344, i8* %339, align 8
@@ -1317,16 +1399,16 @@ entry:
   %357 = load i8*, i8** %arg0
   %358 = load i8*, i8** %arg1
   %359 = bitcast i8* %358 to i16*
-  %NullCheck140 = icmp ne i16* %359, null
-  br i1 %NullCheck140, label %360, label %ThrowNullRef139
+  %NullCheck139 = icmp eq i16* %359, null
+  br i1 %NullCheck139, label %ThrowNullRef140, label %360
 
 ; <label>:360                                     ; preds = %356
   %361 = load i16, i16* %359, align 8
   %362 = sext i16 %361 to i32
   %363 = bitcast i8* %357 to i16*
   %364 = trunc i32 %362 to i16
-  %NullCheck142 = icmp ne i16* %363, null
-  br i1 %NullCheck142, label %365, label %ThrowNullRef141
+  %NullCheck141 = icmp eq i16* %363, null
+  br i1 %NullCheck141, label %ThrowNullRef142, label %365
 
 ; <label>:365                                     ; preds = %360
   store i16 %364, i16* %363, align 8
@@ -1352,14 +1434,14 @@ entry:
   %378 = load i8*, i8** %arg0
   %379 = load i8*, i8** %arg1
   %380 = bitcast i8* %379 to i32*
-  %NullCheck144 = icmp ne i32* %380, null
-  br i1 %NullCheck144, label %381, label %ThrowNullRef143
+  %NullCheck143 = icmp eq i32* %380, null
+  br i1 %NullCheck143, label %ThrowNullRef144, label %381
 
 ; <label>:381                                     ; preds = %377
   %382 = load i32, i32* %380, align 8
   %383 = bitcast i8* %378 to i32*
-  %NullCheck146 = icmp ne i32* %383, null
-  br i1 %NullCheck146, label %384, label %ThrowNullRef145
+  %NullCheck145 = icmp eq i32* %383, null
+  br i1 %NullCheck145, label %ThrowNullRef146, label %384
 
 ; <label>:384                                     ; preds = %381
   store i32 %382, i32* %383, align 8
@@ -1384,14 +1466,14 @@ entry:
   %395 = load i8*, i8** %arg0
   %396 = load i8*, i8** %arg1
   %397 = bitcast i8* %396 to i64*
-  %NullCheck164 = icmp ne i64* %397, null
-  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+  %NullCheck163 = icmp eq i64* %397, null
+  br i1 %NullCheck163, label %ThrowNullRef164, label %398
 
 ; <label>:398                                     ; preds = %394
   %399 = load i64, i64* %397, align 8
   %400 = bitcast i8* %395 to i64*
-  %NullCheck166 = icmp ne i64* %400, null
-  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+  %NullCheck165 = icmp eq i64* %400, null
+  br i1 %NullCheck165, label %ThrowNullRef166, label %401
 
 ; <label>:401                                     ; preds = %398
   store i64 %399, i64* %400, align 8
@@ -1400,14 +1482,14 @@ entry:
   %404 = load i8*, i8** %arg1
   %405 = getelementptr inbounds i8, i8* %404, i64 8
   %406 = bitcast i8* %405 to i64*
-  %NullCheck168 = icmp ne i64* %406, null
-  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+  %NullCheck167 = icmp eq i64* %406, null
+  br i1 %NullCheck167, label %ThrowNullRef168, label %407
 
 ; <label>:407                                     ; preds = %401
   %408 = load i64, i64* %406, align 8
   %409 = bitcast i8* %403 to i64*
-  %NullCheck170 = icmp ne i64* %409, null
-  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+  %NullCheck169 = icmp eq i64* %409, null
+  br i1 %NullCheck169, label %ThrowNullRef170, label %410
 
 ; <label>:410                                     ; preds = %407
   store i64 %408, i64* %409, align 8
@@ -1437,14 +1519,14 @@ entry:
   %425 = load i8*, i8** %arg0
   %426 = load i8*, i8** %arg1
   %427 = bitcast i8* %426 to i64*
-  %NullCheck148 = icmp ne i64* %427, null
-  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+  %NullCheck147 = icmp eq i64* %427, null
+  br i1 %NullCheck147, label %ThrowNullRef148, label %428
 
 ; <label>:428                                     ; preds = %424
   %429 = load i64, i64* %427, align 8
   %430 = bitcast i8* %425 to i64*
-  %NullCheck150 = icmp ne i64* %430, null
-  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+  %NullCheck149 = icmp eq i64* %430, null
+  br i1 %NullCheck149, label %ThrowNullRef150, label %431
 
 ; <label>:431                                     ; preds = %428
   store i64 %429, i64* %430, align 8
@@ -1466,14 +1548,14 @@ entry:
   %441 = load i8*, i8** %arg0
   %442 = load i8*, i8** %arg1
   %443 = bitcast i8* %442 to i32*
-  %NullCheck152 = icmp ne i32* %443, null
-  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+  %NullCheck151 = icmp eq i32* %443, null
+  br i1 %NullCheck151, label %ThrowNullRef152, label %444
 
 ; <label>:444                                     ; preds = %440
   %445 = load i32, i32* %443, align 8
   %446 = bitcast i8* %441 to i32*
-  %NullCheck154 = icmp ne i32* %446, null
-  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+  %NullCheck153 = icmp eq i32* %446, null
+  br i1 %NullCheck153, label %ThrowNullRef154, label %447
 
 ; <label>:447                                     ; preds = %444
   store i32 %445, i32* %446, align 8
@@ -1495,16 +1577,16 @@ entry:
   %457 = load i8*, i8** %arg0
   %458 = load i8*, i8** %arg1
   %459 = bitcast i8* %458 to i16*
-  %NullCheck156 = icmp ne i16* %459, null
-  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+  %NullCheck155 = icmp eq i16* %459, null
+  br i1 %NullCheck155, label %ThrowNullRef156, label %460
 
 ; <label>:460                                     ; preds = %456
   %461 = load i16, i16* %459, align 8
   %462 = sext i16 %461 to i32
   %463 = bitcast i8* %457 to i16*
   %464 = trunc i32 %462 to i16
-  %NullCheck158 = icmp ne i16* %463, null
-  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+  %NullCheck157 = icmp eq i16* %463, null
+  br i1 %NullCheck157, label %ThrowNullRef158, label %465
 
 ; <label>:465                                     ; preds = %460
   store i16 %464, i16* %463, align 8
@@ -1525,15 +1607,15 @@ entry:
 ; <label>:474                                     ; preds = %470
   %475 = load i8*, i8** %arg0
   %476 = load i8*, i8** %arg1
-  %NullCheck160 = icmp ne i8* %476, null
-  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+  %NullCheck159 = icmp eq i8* %476, null
+  br i1 %NullCheck159, label %ThrowNullRef160, label %477
 
 ; <label>:477                                     ; preds = %474
   %478 = load i8, i8* %476, align 8
   %479 = zext i8 %478 to i32
   %480 = trunc i32 %479 to i8
-  %NullCheck162 = icmp ne i8* %475, null
-  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+  %NullCheck161 = icmp eq i8* %475, null
+  br i1 %NullCheck161, label %ThrowNullRef162, label %481
 
 ; <label>:481                                     ; preds = %477
   store i8 %480, i8* %475, align 8
@@ -1553,343 +1635,343 @@ ThrowNullRef:                                     ; preds = %308
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %312
+ThrowNullRef2:                                    ; preds = %312
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %315
+ThrowNullRef4:                                    ; preds = %315
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %321
+ThrowNullRef6:                                    ; preds = %321
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %271
+ThrowNullRef8:                                    ; preds = %271
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %275
+ThrowNullRef10:                                   ; preds = %275
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %278
+ThrowNullRef12:                                   ; preds = %278
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %284
+ThrowNullRef14:                                   ; preds = %284
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %287
+ThrowNullRef16:                                   ; preds = %287
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %293
+ThrowNullRef18:                                   ; preds = %293
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %298
+ThrowNullRef20:                                   ; preds = %298
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %303
+ThrowNullRef22:                                   ; preds = %303
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %243
+ThrowNullRef24:                                   ; preds = %243
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %247
+ThrowNullRef26:                                   ; preds = %247
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %250
+ThrowNullRef28:                                   ; preds = %250
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %256
+ThrowNullRef30:                                   ; preds = %256
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %259
+ThrowNullRef32:                                   ; preds = %259
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %265
+ThrowNullRef34:                                   ; preds = %265
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %217
+ThrowNullRef36:                                   ; preds = %217
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %221
+ThrowNullRef38:                                   ; preds = %221
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %224
+ThrowNullRef40:                                   ; preds = %224
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %230
+ThrowNullRef42:                                   ; preds = %230
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %233
+ThrowNullRef44:                                   ; preds = %233
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %238
+ThrowNullRef46:                                   ; preds = %238
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %200
+ThrowNullRef48:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %204
+ThrowNullRef50:                                   ; preds = %204
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %207
+ThrowNullRef52:                                   ; preds = %207
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %213
+ThrowNullRef54:                                   ; preds = %213
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %172
+ThrowNullRef56:                                   ; preds = %172
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %176
+ThrowNullRef58:                                   ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %179
+ThrowNullRef60:                                   ; preds = %179
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %185
+ThrowNullRef62:                                   ; preds = %185
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %190
+ThrowNullRef64:                                   ; preds = %190
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %195
+ThrowNullRef66:                                   ; preds = %195
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %153
+ThrowNullRef68:                                   ; preds = %153
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %157
+ThrowNullRef70:                                   ; preds = %157
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %160
+ThrowNullRef72:                                   ; preds = %160
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %166
+ThrowNullRef74:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %136
+ThrowNullRef76:                                   ; preds = %136
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %140
+ThrowNullRef78:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %143
+ThrowNullRef80:                                   ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %148
+ThrowNullRef82:                                   ; preds = %148
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %128
+ThrowNullRef84:                                   ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %132
+ThrowNullRef86:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %100
+ThrowNullRef88:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %104
+ThrowNullRef90:                                   ; preds = %104
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %107
+ThrowNullRef92:                                   ; preds = %107
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %113
+ThrowNullRef94:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %118
+ThrowNullRef96:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %123
+ThrowNullRef98:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %81
+ThrowNullRef100:                                  ; preds = %81
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef101:                                  ; preds = %85
+ThrowNullRef102:                                  ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef103:                                  ; preds = %88
+ThrowNullRef104:                                  ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef105:                                  ; preds = %94
+ThrowNullRef106:                                  ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef107:                                  ; preds = %64
+ThrowNullRef108:                                  ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef109:                                  ; preds = %68
+ThrowNullRef110:                                  ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef111:                                  ; preds = %71
+ThrowNullRef112:                                  ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef113:                                  ; preds = %76
+ThrowNullRef114:                                  ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef115:                                  ; preds = %56
+ThrowNullRef116:                                  ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef117:                                  ; preds = %60
+ThrowNullRef118:                                  ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef119:                                  ; preds = %37
+ThrowNullRef120:                                  ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef121:                                  ; preds = %41
+ThrowNullRef122:                                  ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef123:                                  ; preds = %46
+ThrowNullRef124:                                  ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef125:                                  ; preds = %51
+ThrowNullRef126:                                  ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef127:                                  ; preds = %27
+ThrowNullRef128:                                  ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef129:                                  ; preds = %31
+ThrowNullRef130:                                  ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef131:                                  ; preds = %19
+ThrowNullRef132:                                  ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef133:                                  ; preds = %22
+ThrowNullRef134:                                  ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef135:                                  ; preds = %338
+ThrowNullRef136:                                  ; preds = %338
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef137:                                  ; preds = %341
+ThrowNullRef138:                                  ; preds = %341
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef139:                                  ; preds = %356
+ThrowNullRef140:                                  ; preds = %356
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef141:                                  ; preds = %360
+ThrowNullRef142:                                  ; preds = %360
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef143:                                  ; preds = %377
+ThrowNullRef144:                                  ; preds = %377
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef145:                                  ; preds = %381
+ThrowNullRef146:                                  ; preds = %381
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef147:                                  ; preds = %424
+ThrowNullRef148:                                  ; preds = %424
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef149:                                  ; preds = %428
+ThrowNullRef150:                                  ; preds = %428
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef151:                                  ; preds = %440
+ThrowNullRef152:                                  ; preds = %440
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef153:                                  ; preds = %444
+ThrowNullRef154:                                  ; preds = %444
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef155:                                  ; preds = %456
+ThrowNullRef156:                                  ; preds = %456
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef157:                                  ; preds = %460
+ThrowNullRef158:                                  ; preds = %460
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef159:                                  ; preds = %474
+ThrowNullRef160:                                  ; preds = %474
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef161:                                  ; preds = %477
+ThrowNullRef162:                                  ; preds = %477
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef163:                                  ; preds = %394
+ThrowNullRef164:                                  ; preds = %394
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef165:                                  ; preds = %398
+ThrowNullRef166:                                  ; preds = %398
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef167:                                  ; preds = %401
+ThrowNullRef168:                                  ; preds = %401
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef169:                                  ; preds = %407
+ThrowNullRef170:                                  ; preds = %407
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1939,8 +2021,8 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
-  br i1 %NullCheck, label %22, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %ThrowNullRef, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
@@ -1948,8 +2030,8 @@ entry:
   store i32 %24, i32* %loc0
   %25 = load i32, i32* %loc0
   %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %26, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %27
 
 ; <label>:27                                      ; preds = %22
   %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
@@ -1971,7 +2053,7 @@ ThrowNullRef:                                     ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1989,8 +2071,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -2022,15 +2104,15 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2048,16 +2130,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
   %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
   store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %15
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
@@ -2072,8 +2154,8 @@ entry:
   %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
   %29 = ptrtoint i16 addrspace(1)* %28 to i64
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %19
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
@@ -2089,19 +2171,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2114,8 +2196,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
@@ -2128,7 +2210,7 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[loadElem]
+Failed to read AppDomain.PrepareDataForSetup[storeElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
@@ -2202,8 +2284,8 @@ entry:
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
-  br i1 %NullCheck24, label %27, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = load i64, i64 addrspace(1)* %26
@@ -2218,8 +2300,8 @@ entry:
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
-  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
   %41 = load i64, i64 addrspace(1)* %39
@@ -2236,8 +2318,8 @@ entry:
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
-  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
   %54 = load i64, i64 addrspace(1)* %52
@@ -2252,8 +2334,8 @@ entry:
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
   %67 = load i64, i64 addrspace(1)* %65
@@ -2270,8 +2352,8 @@ entry:
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
-  br i1 %NullCheck16, label %79, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
   %80 = load i64, i64 addrspace(1)* %78
@@ -2286,8 +2368,8 @@ entry:
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
-  br i1 %NullCheck18, label %92, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
   %93 = load i64, i64 addrspace(1)* %91
@@ -2304,8 +2386,8 @@ entry:
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
-  br i1 %NullCheck12, label %105, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = load i64, i64 addrspace(1)* %104
@@ -2320,8 +2402,8 @@ entry:
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
-  br i1 %NullCheck14, label %118, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
   %119 = load i64, i64 addrspace(1)* %117
@@ -2337,8 +2419,8 @@ entry:
 
 ; <label>:128                                     ; preds = %20
   %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
-  br i1 %NullCheck4, label %130, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %129, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %130
 
 ; <label>:130                                     ; preds = %128
   %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
@@ -2346,8 +2428,8 @@ entry:
   %133 = load i16, i16 addrspace(1)* %132, align 8
   %134 = zext i16 %133 to i32
   %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
-  br i1 %NullCheck6, label %136, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %135, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %136
 
 ; <label>:136                                     ; preds = %130
   %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
@@ -2360,8 +2442,8 @@ entry:
 
 ; <label>:143                                     ; preds = %136
   %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
-  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %144, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %145
 
 ; <label>:145                                     ; preds = %143
   %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
@@ -2369,8 +2451,8 @@ entry:
   %148 = load i16, i16 addrspace(1)* %147, align 8
   %149 = zext i16 %148 to i32
   %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %150, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %151
 
 ; <label>:151                                     ; preds = %145
   %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
@@ -2388,8 +2470,8 @@ entry:
 
 ; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
-  br i1 %NullCheck, label %163, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %ThrowNullRef, label %163
 
 ; <label>:163                                     ; preds = %161
   %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
@@ -2399,8 +2481,8 @@ entry:
 
 ; <label>:167                                     ; preds = %163
   %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
-  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %168, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %169
 
 ; <label>:169                                     ; preds = %167
   %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
@@ -2432,55 +2514,55 @@ ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %167
+ThrowNullRef2:                                    ; preds = %167
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %128
+ThrowNullRef4:                                    ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %130
+ThrowNullRef6:                                    ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %143
+ThrowNullRef8:                                    ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %145
+ThrowNullRef10:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %102
+ThrowNullRef12:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %105
+ThrowNullRef14:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %76
+ThrowNullRef16:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %79
+ThrowNullRef18:                                   ; preds = %79
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %50
+ThrowNullRef20:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %53
+ThrowNullRef22:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %24
+ThrowNullRef24:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %27
+ThrowNullRef26:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2503,15 +2585,15 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2519,16 +2601,16 @@ entry:
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
   store i32 %8, i32* %loc0
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
   %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
   store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
@@ -2546,16 +2628,16 @@ entry:
 
 ; <label>:23                                      ; preds = %64
   %24 = load i16*, i16** %loc3
-  %NullCheck12 = icmp ne i16* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i16* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
   store i32 %27, i32* %loc5
   %28 = load i16*, i16** %loc4
-  %NullCheck14 = icmp ne i16* %28, null
-  br i1 %NullCheck14, label %29, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %28, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = load i16, i16* %28, align 8
@@ -2620,15 +2702,15 @@ entry:
 
 ; <label>:67                                      ; preds = %64
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
-  br i1 %NullCheck8, label %69, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %68, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %69
 
 ; <label>:69                                      ; preds = %67
   %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
   %71 = load i32, i32 addrspace(1)* %70
   %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
-  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %73
 
 ; <label>:73                                      ; preds = %69
   %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
@@ -2645,31 +2727,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %67
+ThrowNullRef8:                                    ; preds = %67
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %69
+ThrowNullRef10:                                   ; preds = %69
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2710,14 +2792,14 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
   %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
@@ -2730,14 +2812,14 @@ entry:
 
 ; <label>:11                                      ; preds = %4
   %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
   %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
@@ -2749,14 +2831,14 @@ entry:
 
 ; <label>:22                                      ; preds = %16
   %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
   %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
-  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
-  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
@@ -2804,23 +2886,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2836,7 +2918,280 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[loadElem]
+Successfully read RuntimeType.IsAssignableFrom
+
+define i8 @RuntimeType.IsAssignableFrom(%System.RuntimeType addrspace(1)* %param0, %System.Type addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.RuntimeType addrspace(1)*
+  %arg1 = alloca %System.Type addrspace(1)*
+  %loc0 = alloca %System.RuntimeType addrspace(1)*
+  %loc1 = alloca %"System.Type[]" addrspace(1)*
+  %loc2 = alloca i32
+  store %System.RuntimeType addrspace(1)* %param0, %System.RuntimeType addrspace(1)** %this
+  store %System.Type addrspace(1)* %param1, %System.Type addrspace(1)** %arg1
+  %0 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %1 = icmp ne %System.Type addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i8 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %5 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %6 = bitcast %System.Type addrspace(1)* %4 to %System.Object addrspace(1)*
+  %7 = bitcast %System.RuntimeType addrspace(1)* %5 to %System.Object addrspace(1)*
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %6, %System.Object addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %3
+  ret i8 1
+
+; <label>:12                                      ; preds = %3
+  %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 152
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 32
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
+  %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
+  %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
+  store %System.RuntimeType addrspace(1)* %25, %System.RuntimeType addrspace(1)** %loc0
+  %26 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %27 = icmp eq %System.RuntimeType addrspace(1)* %26, null
+  br i1 %27, label %34, label %28
+
+; <label>:28                                      ; preds = %15
+  %29 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %30 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)*)*)(%System.RuntimeType addrspace(1)* %29, %System.RuntimeType addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+; <label>:34                                      ; preds = %15
+  %35 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %36 = call %System.Reflection.Emit.TypeBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Reflection.Emit.TypeBuilder addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %35)
+  %37 = icmp eq %System.Reflection.Emit.TypeBuilder addrspace(1)* %36, null
+  br i1 %37, label %139, label %38
+
+; <label>:38                                      ; preds = %34
+  %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %42
+
+; <label>:42                                      ; preds = %38
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 152
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 40
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
+  %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
+  %53 = zext i8 %52 to i32
+  %54 = icmp eq i32 %53, 0
+  br i1 %54, label %56, label %55
+
+; <label>:55                                      ; preds = %42
+  ret i8 1
+
+; <label>:56                                      ; preds = %42
+  %57 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %58 = bitcast %System.RuntimeType addrspace(1)* %57 to %System.Type addrspace(1)*
+  %59 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %58)
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %64 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.Type addrspace(1)* %63, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = bitcast %System.RuntimeType addrspace(1)* %64 to %System.Type addrspace(1)*
+  %67 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %63, %System.Type addrspace(1)* %66)
+  %68 = zext i8 %67 to i32
+  %69 = trunc i32 %68 to i8
+  ret i8 %69
+
+; <label>:70                                      ; preds = %56
+  %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
+  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %73
+
+; <label>:73                                      ; preds = %70
+  %74 = load i64, i64 addrspace(1)* %72
+  %75 = add i64 %74, 128
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = add i64 %77, 0
+  %79 = inttoptr i64 %78 to i64*
+  %80 = load i64, i64* %79
+  %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
+  %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
+  %83 = call i8 %82(%System.Type addrspace(1)* %81)
+  %84 = zext i8 %83 to i32
+  %85 = icmp eq i32 %84, 0
+  br i1 %85, label %139, label %86
+
+; <label>:86                                      ; preds = %73
+  %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
+  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %89
+
+; <label>:89                                      ; preds = %86
+  %90 = load i64, i64 addrspace(1)* %88
+  %91 = add i64 %90, 128
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = add i64 %93, 24
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
+  %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
+  %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
+  store %"System.Type[]" addrspace(1)* %99, %"System.Type[]" addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %129
+
+; <label>:100                                     ; preds = %132
+  %101 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %102 = load i32, i32* %loc2
+  %NullCheck11 = icmp eq %"System.Type[]" addrspace(1)* %101, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %103
+
+; <label>:103                                     ; preds = %100
+  %104 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 1
+  %105 = load i32, i32 addrspace(1)* %104
+  %106 = zext i32 %105 to i64
+  %107 = zext i32 %102 to i64
+  %BoundsCheck = icmp uge i64 %107, %106
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %108
+
+; <label>:108                                     ; preds = %103
+  %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
+  %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
+  %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
+  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %113
+
+; <label>:113                                     ; preds = %108
+  %114 = load i64, i64 addrspace(1)* %112
+  %115 = add i64 %114, 152
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = add i64 %117, 56
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
+  %123 = zext i8 %122 to i32
+  %124 = icmp ne i32 %123, 0
+  br i1 %124, label %126, label %125
+
+; <label>:125                                     ; preds = %113
+  ret i8 0
+
+; <label>:126                                     ; preds = %113
+  %127 = load i32, i32* %loc2
+  %128 = add i32 %127, 1
+  store i32 %128, i32* %loc2
+  br label %129
+
+; <label>:129                                     ; preds = %89, %126
+  %130 = load i32, i32* %loc2
+  %131 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %NullCheck9 = icmp eq %"System.Type[]" addrspace(1)* %131, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %132
+
+; <label>:132                                     ; preds = %129
+  %133 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %131, i32 0, i32 1
+  %134 = load i32, i32 addrspace(1)* %133
+  %135 = zext i32 %134 to i64
+  %136 = trunc i64 %135 to i32
+  %137 = icmp slt i32 %130, %136
+  br i1 %137, label %100, label %138
+
+; <label>:138                                     ; preds = %132
+  ret i8 1
+
+; <label>:139                                     ; preds = %34, %73
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %129
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %103
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -2893,7 +3248,7 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElem]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -2904,8 +3259,8 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -2997,8 +3352,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
@@ -3059,8 +3414,8 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -3087,8 +3442,8 @@ entry:
 
 ; <label>:17                                      ; preds = %5, %11
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
@@ -3097,8 +3452,8 @@ entry:
 
 ; <label>:22                                      ; preds = %1, %11
   %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
@@ -3109,11 +3464,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %17
+ThrowNullRef2:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %22
+ThrowNullRef4:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3167,15 +3522,15 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
   %15 = load i32, i32 addrspace(1)* %14
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
@@ -3198,7 +3553,7 @@ ThrowNullRef:                                     ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef2:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3232,8 +3587,8 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
@@ -3312,8 +3667,8 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -3327,8 +3682,8 @@ entry:
 ; <label>:5                                       ; preds = %43
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %7 = load i32, i32* %loc1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck6, label %8, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
@@ -3366,8 +3721,8 @@ entry:
 ; <label>:32                                      ; preds = %21, %25
   %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
   %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
-  br i1 %NullCheck8, label %35, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = trunc i32 %34 to i16
@@ -3380,8 +3735,8 @@ entry:
 ; <label>:40                                      ; preds = %1, %35
   %41 = load i32, i32* %loc1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
-  br i1 %NullCheck2, label %43, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %42, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
@@ -3392,8 +3747,8 @@ entry:
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
   %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
-  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
   %51 = load i64, i64 addrspace(1)* %49
@@ -3412,19 +3767,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %40
+ThrowNullRef2:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %47
+ThrowNullRef4:                                    ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %5
+ThrowNullRef6:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %32
+ThrowNullRef8:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3467,8 +3822,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
@@ -3492,11 +3847,391 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(i16* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store i16* %param0, i16** %arg0
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load i32, i32* %arg3
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %42, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %37, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg2
+  %13 = load i32, i32* %arg3
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %37, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %24 = load i32, i32* %arg2
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load i16*, i16** %arg0
+  %35 = load i32, i32* %arg3
+  %36 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %36, i16* %34, i32 %35)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:37                                      ; preds = %5, %16
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %39)
+  %41 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41, %System.String addrspace(1)* %38, %System.String addrspace(1)* %40)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41) #0
+  unreachable
+
+; <label>:42                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
-Failed to read StringBuilder.ToString[loadElemA]
+Successfully read StringBuilder.ToString
+
+define %System.String addrspace(1)* @StringBuilder.ToString(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i16*
+  %loc3 = alloca %"System.Char[]" addrspace(1)*
+  %loc4 = alloca i32
+  %loc5 = alloca i32
+  %loc6 = alloca i16 addrspace(1)*
+  %loc7 = alloca %System.String addrspace(1)*
+  %loc8 = alloca %"System.Char[]" addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %0)
+  %2 = icmp ne i32 %1, 0
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %4
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %6)
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %7)
+  store %System.String addrspace(1)* %8, %System.String addrspace(1)** %loc0
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.Text.StringBuilder addrspace(1)* %9, %System.Text.StringBuilder addrspace(1)** %loc1
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  store %System.String addrspace(1)* %10, %System.String addrspace(1)** %loc7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc7
+  %12 = ptrtoint %System.String addrspace(1)* %11 to i64
+  %13 = icmp eq i64 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %5
+  %15 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %16 = sext i32 %15 to i64
+  %17 = add i64 %12, %16
+  br label %18
+
+; <label>:18                                      ; preds = %5, %14
+  %19 = phi i64 [ %12, %5 ], [ %17, %14 ]
+  %20 = inttoptr i64 %19 to i16*
+  store i16* %20, i16** %loc2
+  br label %21
+
+; <label>:21                                      ; preds = %98, %18
+  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %22, null
+  br i1 %NullCheck, label %ThrowNullRef, label %23
+
+; <label>:23                                      ; preds = %21
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 3
+  %25 = load i32, i32 addrspace(1)* %24, align 8
+  %26 = icmp sle i32 %25, 0
+  br i1 %26, label %96, label %27
+
+; <label>:27                                      ; preds = %23
+  %28 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %28, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %29
+
+; <label>:29                                      ; preds = %27
+  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %28, i32 0, i32 1
+  %31 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %30, align 8
+  store %"System.Char[]" addrspace(1)* %31, %"System.Char[]" addrspace(1)** %loc3
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %33
+
+; <label>:33                                      ; preds = %29
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  store i32 %35, i32* %loc4
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  %39 = load i32, i32 addrspace(1)* %38, align 8
+  store i32 %39, i32* %loc5
+  %40 = load i32, i32* %loc5
+  %41 = load i32, i32* %loc4
+  %42 = add i32 %40, %41
+  %43 = zext i32 %42 to i64
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %45
+
+; <label>:45                                      ; preds = %37
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = sext i32 %47 to i64
+  %49 = icmp sgt i64 %43, %48
+  br i1 %49, label %91, label %50
+
+; <label>:50                                      ; preds = %45
+  %51 = load i32, i32* %loc5
+  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %52, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %53
+
+; <label>:53                                      ; preds = %50
+  %54 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %52, i32 0, i32 1
+  %55 = load i32, i32 addrspace(1)* %54
+  %56 = zext i32 %55 to i64
+  %57 = trunc i64 %56 to i32
+  %58 = icmp ugt i32 %51, %57
+  br i1 %58, label %91, label %59
+
+; <label>:59                                      ; preds = %53
+  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  store %"System.Char[]" addrspace(1)* %60, %"System.Char[]" addrspace(1)** %loc8
+  %61 = icmp eq %"System.Char[]" addrspace(1)* %60, null
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %63, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %64
+
+; <label>:64                                      ; preds = %62
+  %65 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %63, i32 0, i32 1
+  %66 = load i32, i32 addrspace(1)* %65
+  %67 = zext i32 %66 to i64
+  %68 = trunc i64 %67 to i32
+  %69 = icmp ne i32 %68, 0
+  br i1 %69, label %71, label %70
+
+; <label>:70                                      ; preds = %59, %64
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:71                                      ; preds = %64
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %73
+
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %BoundsCheck = icmp uge i64 0, %76
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %77
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %78, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:79                                      ; preds = %70, %77
+  %80 = load i16*, i16** %loc2
+  %81 = load i32, i32* %loc4
+  %82 = sext i32 %81 to i64
+  %83 = mul i64 %82, 2
+  %84 = bitcast i16* %80 to i8*
+  %85 = getelementptr inbounds i8, i8* %84, i64 %83
+  %86 = load i16 addrspace(1)*, i16 addrspace(1)** %loc6
+  %87 = ptrtoint i16 addrspace(1)* %86 to i64
+  %88 = load i32, i32* %loc5
+  %89 = bitcast i8* %85 to i16*
+  %90 = inttoptr i64 %87 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %89, i16* %90, i32 %88)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %96
+
+; <label>:91                                      ; preds = %45, %53
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %94 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %93)
+  %95 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95, %System.String addrspace(1)* %92, %System.String addrspace(1)* %94)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95) #0
+  unreachable
+
+; <label>:96                                      ; preds = %23, %79
+  %97 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %97, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %98
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %97, i32 0, i32 2
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  store %System.Text.StringBuilder addrspace(1)* %100, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %102 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %102, label %21, label %103
+
+; <label>:103                                     ; preds = %98
+  store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc7
+  %104 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  ret %System.String addrspace(1)* %104
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method StringBuilder::get_Length using LLILCJit
+Successfully read StringBuilder.get_Length
+
+define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
+Successfully read RuntimeHelpers.get_OffsetToStringData
+
+define i32 @RuntimeHelpers.get_OffsetToStringData() {
+entry:
+  ret i32 12
+}
+
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
 Successfully read CultureData.CreateCultureData
 
@@ -3514,23 +4249,23 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
   store i8 %4, i8 addrspace(1)* %6
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
@@ -3549,11 +4284,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3566,50 +4301,50 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
   store i32 -1, i32 addrspace(1)* %2
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
   store i32 -1, i32 addrspace(1)* %8
   %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
   store i32 -1, i32 addrspace(1)* %14
   %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
   store i32 -1, i32 addrspace(1)* %17
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
@@ -3623,27 +4358,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3675,7 +4410,136 @@ Failed to read Dictionary`2.Insert[non-const derefAddress]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
 Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
-Failed to read HashHelpers.GetPrime[loadElem]
+Successfully read HashHelpers.GetPrime
+
+define i32 @HashHelpers.GetPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %6, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5, %System.String addrspace(1)* %4)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5) #0
+  unreachable
+
+; <label>:6                                       ; preds = %entry
+  store i32 0, i32* %loc0
+  br label %29
+
+; <label>:7                                       ; preds = %35
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 1296
+  %10 = addrspacecast i8 addrspace(1)* %9 to %"System.Int32[]" addrspace(1)**
+  %11 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %10
+  %12 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Int32[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = zext i32 %15 to i64
+  %17 = zext i32 %12 to i64
+  %BoundsCheck = icmp uge i64 %17, %16
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 3, i32 %12
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  store i32 %20, i32* %loc1
+  %21 = load i32, i32* %loc1
+  %22 = load i32, i32* %arg0
+  %23 = icmp slt i32 %21, %22
+  br i1 %23, label %26, label %24
+
+; <label>:24                                      ; preds = %18
+  %25 = load i32, i32* %loc1
+  ret i32 %25
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %loc0
+  %28 = add i32 %27, 1
+  store i32 %28, i32* %loc0
+  br label %29
+
+; <label>:29                                      ; preds = %6, %26
+  %30 = load i32, i32* %loc0
+  %31 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %32 = getelementptr inbounds i8, i8 addrspace(1)* %31, i64 1296
+  %33 = addrspacecast i8 addrspace(1)* %32 to %"System.Int32[]" addrspace(1)**
+  %34 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %33
+  %NullCheck = icmp eq %"System.Int32[]" addrspace(1)* %34, null
+  br i1 %NullCheck, label %ThrowNullRef, label %35
+
+; <label>:35                                      ; preds = %29
+  %36 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %34, i32 0, i32 1
+  %37 = load i32, i32 addrspace(1)* %36
+  %38 = zext i32 %37 to i64
+  %39 = trunc i64 %38 to i32
+  %40 = icmp slt i32 %30, %39
+  br i1 %40, label %7, label %41
+
+; <label>:41                                      ; preds = %35
+  %42 = load i32, i32* %arg0
+  %43 = or i32 %42, 1
+  store i32 %43, i32* %loc2
+  br label %59
+
+; <label>:44                                      ; preds = %59
+  %45 = load i32, i32* %loc2
+  %46 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %45)
+  %47 = zext i8 %46 to i32
+  %48 = icmp eq i32 %47, 0
+  br i1 %48, label %56, label %49
+
+; <label>:49                                      ; preds = %44
+  %50 = load i32, i32* %loc2
+  %51 = sub i32 %50, 1
+  %52 = srem i32 %51, 101
+  %53 = icmp eq i32 %52, 0
+  br i1 %53, label %56, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = load i32, i32* %loc2
+  ret i32 %55
+
+; <label>:56                                      ; preds = %44, %49
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %57, 2
+  store i32 %58, i32* %loc2
+  br label %59
+
+; <label>:59                                      ; preds = %41, %56
+  %60 = load i32, i32* %loc2
+  %61 = icmp slt i32 %60, 2147483647
+  br i1 %61, label %44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load i32, i32* %arg0
+  ret i32 %63
+
+ThrowNullRef:                                     ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
 Successfully read GenericEqualityComparer`1.GetHashCode
 
@@ -3694,14 +4558,14 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
   %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load i64, i64 addrspace(1)* %7
@@ -3720,7 +4584,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3750,8 +4614,8 @@ entry:
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
@@ -3796,8 +4660,8 @@ entry:
   %35 = bitcast i16* %34 to i8*
   %36 = getelementptr inbounds i8, i8* %35, i64 2
   %37 = bitcast i8* %36 to i16*
-  %NullCheck4 = icmp ne i16* %37, null
-  br i1 %NullCheck4, label %38, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %37, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %38
 
 ; <label>:38                                      ; preds = %27
   %39 = load i16, i16* %37, align 8
@@ -3824,8 +4688,8 @@ entry:
 
 ; <label>:54                                      ; preds = %22, %43
   %55 = load i16*, i16** %loc4
-  %NullCheck2 = icmp ne i16* %55, null
-  br i1 %NullCheck2, label %56, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i16* %55, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %56
 
 ; <label>:56                                      ; preds = %54
   %57 = load i16, i16* %55, align 8
@@ -3850,11 +4714,11 @@ ThrowNullRef:                                     ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %54
+ThrowNullRef2:                                    ; preds = %54
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %27
+ThrowNullRef4:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3871,8 +4735,8 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -3907,8 +4771,8 @@ entry:
 
 ; <label>:26                                      ; preds = %19
   %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
-  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %28
 
 ; <label>:28                                      ; preds = %26
   %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
@@ -3920,7 +4784,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3972,8 +4836,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
@@ -3984,26 +4848,26 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
-  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
@@ -4014,8 +4878,8 @@ entry:
 ; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
@@ -4024,8 +4888,8 @@ entry:
 
 ; <label>:25                                      ; preds = %1, %16, %23
   %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
-  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
@@ -4036,27 +4900,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %20
+ThrowNullRef10:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4069,8 +4933,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -4081,8 +4945,8 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
@@ -4091,8 +4955,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1, %8
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
@@ -4103,11 +4967,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4128,24 +4992,24 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   store i32 %3, i32* %loc0
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
   %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
   store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck4, label %9, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
@@ -4164,15 +5028,15 @@ entry:
 ; <label>:18                                      ; preds = %70
   %19 = load i16*, i16** %loc3
   %20 = bitcast i16* %19 to i64*
-  %NullCheck10 = icmp ne i64* %20, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %20, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = load i64, i64* %20, align 8
   %23 = load i16*, i16** %loc4
   %24 = bitcast i16* %23 to i64*
-  %NullCheck12 = icmp ne i64* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = load i64, i64* %24, align 8
@@ -4188,8 +5052,8 @@ entry:
   %31 = bitcast i16* %30 to i8*
   %32 = getelementptr inbounds i8, i8* %31, i64 8
   %33 = bitcast i8* %32 to i64*
-  %NullCheck14 = icmp ne i64* %33, null
-  br i1 %NullCheck14, label %34, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = load i64, i64* %33, align 8
@@ -4197,8 +5061,8 @@ entry:
   %37 = bitcast i16* %36 to i8*
   %38 = getelementptr inbounds i8, i8* %37, i64 8
   %39 = bitcast i8* %38 to i64*
-  %NullCheck16 = icmp ne i64* %39, null
-  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %40
 
 ; <label>:40                                      ; preds = %34
   %41 = load i64, i64* %39, align 8
@@ -4214,8 +5078,8 @@ entry:
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %NullCheck18 = icmp ne i64* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = load i64, i64* %48, align 8
@@ -4223,8 +5087,8 @@ entry:
   %52 = bitcast i16* %51 to i8*
   %53 = getelementptr inbounds i8, i8* %52, i64 16
   %54 = bitcast i8* %53 to i64*
-  %NullCheck20 = icmp ne i64* %54, null
-  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64* %54, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %55
 
 ; <label>:55                                      ; preds = %49
   %56 = load i64, i64* %54, align 8
@@ -4262,15 +5126,15 @@ entry:
 ; <label>:74                                      ; preds = %95
   %75 = load i16*, i16** %loc3
   %76 = bitcast i16* %75 to i32*
-  %NullCheck6 = icmp ne i32* %76, null
-  br i1 %NullCheck6, label %77, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32* %76, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %77
 
 ; <label>:77                                      ; preds = %74
   %78 = load i32, i32* %76, align 8
   %79 = load i16*, i16** %loc4
   %80 = bitcast i16* %79 to i32*
-  %NullCheck8 = icmp ne i32* %80, null
-  br i1 %NullCheck8, label %81, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i32* %80, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %81
 
 ; <label>:81                                      ; preds = %77
   %82 = load i32, i32* %80, align 8
@@ -4318,43 +5182,43 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %74
+ThrowNullRef6:                                    ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %77
+ThrowNullRef8:                                    ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %29
+ThrowNullRef14:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %34
+ThrowNullRef16:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4376,8 +5240,8 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load i64, i64 addrspace(1)* %4
@@ -4389,8 +5253,8 @@ entry:
   %12 = load i64, i64* %11
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %5
   %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
@@ -4399,8 +5263,8 @@ entry:
   %18 = load i8, i8* %arg2
   %19 = zext i8 %18 to i32
   %20 = trunc i32 %19 to i8
-  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %15
   %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
@@ -4411,11 +5275,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4442,8 +5306,8 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
@@ -4466,16 +5330,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
   %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = load i64, i64 addrspace(1)* %19
@@ -4500,8 +5364,8 @@ entry:
 ; <label>:35                                      ; preds = %30
   %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
@@ -4514,8 +5378,8 @@ entry:
 
 ; <label>:42                                      ; preds = %1, %38
   %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
-  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
@@ -4526,19 +5390,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %35
+ThrowNullRef2:                                    ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %42
+ThrowNullRef8:                                    ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4551,14 +5415,14 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
@@ -4570,7 +5434,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4583,8 +5447,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
@@ -4613,51 +5477,51 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
   %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
   %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
   %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
   %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
-  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
   store i64 %21, i64 addrspace(1)* %23
   %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %25 = load i64, i64* %loc0
-  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
@@ -4668,27 +5532,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %22
+ThrowNullRef12:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4701,8 +5565,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
@@ -4713,19 +5577,19 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
@@ -4734,8 +5598,8 @@ entry:
 
 ; <label>:15                                      ; preds = %1, %13
   %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
@@ -4746,19 +5610,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %15
+ThrowNullRef8:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4771,8 +5635,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -4831,8 +5695,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
@@ -4882,8 +5746,8 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
-  br i1 %NullCheck, label %17, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %ThrowNullRef, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
@@ -4894,15 +5758,15 @@ entry:
 
 ; <label>:22                                      ; preds = %17
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
-  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
   %26 = load i32, i32 addrspace(1)* %25
   %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
-  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %27, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
@@ -4925,8 +5789,8 @@ entry:
 ; <label>:40                                      ; preds = %17
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
-  br i1 %NullCheck6, label %43, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %41, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
@@ -4938,34 +5802,17 @@ ThrowNullRef:                                     ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %24
+ThrowNullRef4:                                    ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %40
+ThrowNullRef6:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
-}
-
-INFO:  jitting method Object::ReferenceEquals using LLILCJit
-Successfully read Object.ReferenceEquals
-
-define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
-entry:
-  %arg0 = alloca %System.Object addrspace(1)*
-  %arg1 = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
-  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
-  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = icmp eq %System.Object addrspace(1)* %0, %1
-  %3 = sext i1 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
 }
 
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
@@ -4978,21 +5825,21 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
   %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
-  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
@@ -5007,28 +5854,28 @@ entry:
 ; <label>:13                                      ; preds = %8, %12
   %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
   %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
   %21 = load i32, i32 addrspace(1)* %20, align 8
   %22 = add i32 %21, 1
-  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
   store i32 %22, i32 addrspace(1)* %24
   %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
@@ -5039,27 +5886,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5077,7 +5924,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::Setup using LLILCJit
-Failed to read AppDomain.Setup[loadElem]
+Failed to read AppDomain.Setup[unbox]
 INFO:  jitting method Thread::GetDomain using LLILCJit
 Successfully read Thread.GetDomain
 
@@ -5108,8 +5955,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
@@ -5122,14 +5969,14 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
   %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
@@ -5141,11 +5988,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5173,8 +6020,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -5189,7 +6036,328 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
 Failed to read KeyCollection.System.Collections.Generic.IEnumerable<TKey>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Successfully read Enumerator.MoveNext
+
+define i8 @Enumerator.MoveNext(%"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.RuntimeTypeHandle* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*
+  %"$TypeArg" = alloca %System.RuntimeTypeHandle*
+  store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
+  %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 8
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %76, label %12
+
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
+  br label %76
+
+; <label>:13                                      ; preds = %85
+  %14 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck19 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %15
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, i32 0, i32 0
+  %17 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %16, align 8
+  %NullCheck21 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, i32 0, i32 2
+  %20 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %19, align 8
+  %21 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck23 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %22
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, i32 0, i32 2
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %NullCheck25 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 3, i32 %24
+  %NullCheck27 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %32
+
+; <label>:32                                      ; preds = %30
+  %33 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, i32 0, i32 2
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = icmp slt i32 %34, 0
+  br i1 %35, label %68, label %36
+
+; <label>:36                                      ; preds = %32
+  %37 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %38 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck29 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %39
+
+; <label>:39                                      ; preds = %36
+  %40 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, i32 0, i32 0
+  %41 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %40, align 8
+  %NullCheck31 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, i32 0, i32 2
+  %44 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %43, align 8
+  %45 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck33 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, i32 0, i32 2
+  %48 = load i32, i32 addrspace(1)* %47, align 8
+  %NullCheck35 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %49
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = zext i32 %51 to i64
+  %53 = zext i32 %48 to i64
+  %BoundsCheck37 = icmp uge i64 %53, %52
+  br i1 %BoundsCheck37, label %ThrowIndexOutOfRange38, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 3, i32 %48
+  %NullCheck39 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %56
+
+; <label>:56                                      ; preds = %54
+  %57 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, i32 0, i32 0
+  %58 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck41 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %59
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %60, %System.__Canon addrspace(1)* %58)
+  %61 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck43 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  %64 = load i32, i32 addrspace(1)* %63, align 8
+  %65 = add i32 %64, 1
+  %NullCheck45 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  store i32 %65, i32 addrspace(1)* %67
+  ret i8 1
+
+; <label>:68                                      ; preds = %32
+  %69 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck47 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %73 = add i32 %72, 1
+  %NullCheck49 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %74
+
+; <label>:74                                      ; preds = %70
+  %75 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  store i32 %73, i32 addrspace(1)* %75
+  br label %76
+
+; <label>:76                                      ; preds = %8, %12, %74
+  %77 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %78
+
+; <label>:78                                      ; preds = %76
+  %79 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, i32 0, i32 2
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck7 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %82
+
+; <label>:82                                      ; preds = %78
+  %83 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, i32 0, i32 0
+  %84 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %83, align 8
+  %NullCheck9 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %85
+
+; <label>:85                                      ; preds = %82
+  %86 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, i32 0, i32 7
+  %87 = load i32, i32 addrspace(1)* %86, align 8
+  %88 = icmp ult i32 %80, %87
+  br i1 %88, label %13, label %89
+
+; <label>:89                                      ; preds = %85
+  %90 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %91 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck11 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %92
+
+; <label>:92                                      ; preds = %89
+  %93 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, i32 0, i32 0
+  %94 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck13 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %95
+
+; <label>:95                                      ; preds = %92
+  %96 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, i32 0, i32 7
+  %97 = load i32, i32 addrspace(1)* %96, align 8
+  %98 = add i32 %97, 1
+  %NullCheck15 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %99
+
+; <label>:99                                      ; preds = %95
+  %100 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, i32 0, i32 2
+  store i32 %98, i32 addrspace(1)* %100
+  %101 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck17 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %102
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %103, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %92
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef22:                                   ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef24:                                   ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef26:                                   ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef28:                                   ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef30:                                   ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef32:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef34:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef36:                                   ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange38:                           ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef40:                                   ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef42:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef44:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef46:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef48:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef50:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -5200,8 +6368,8 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -5232,9 +6400,9 @@ Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
 Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
-Failed to read String.MakeSeparatorList[loadElemA]
+Failed to read String.MakeSeparatorList[storeElem]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
-Failed to read String.InternalSplitKeepEmptyEntries[loadElem]
+Failed to read String.InternalSplitKeepEmptyEntries[storeElem]
 INFO:  jitting method Path::IsRelative using LLILCJit
 Successfully read Path.IsRelative
 
@@ -5243,8 +6411,8 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -5254,8 +6422,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
@@ -5271,8 +6439,8 @@ entry:
 
 ; <label>:17                                      ; preds = %7
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
@@ -5288,8 +6456,8 @@ entry:
 
 ; <label>:29                                      ; preds = %19
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %31
 
 ; <label>:31                                      ; preds = %29
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
@@ -5300,8 +6468,8 @@ entry:
 
 ; <label>:36                                      ; preds = %31
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
-  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %37, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
@@ -5312,8 +6480,8 @@ entry:
 
 ; <label>:43                                      ; preds = %31, %38
   %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
-  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %45
 
 ; <label>:45                                      ; preds = %43
   %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
@@ -5324,8 +6492,8 @@ entry:
 
 ; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %50
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
@@ -5336,8 +6504,8 @@ entry:
 
 ; <label>:57                                      ; preds = %1, %7, %19, %45, %52
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
-  br i1 %NullCheck14, label %59, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %59
 
 ; <label>:59                                      ; preds = %57
   %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
@@ -5347,8 +6515,8 @@ entry:
 
 ; <label>:63                                      ; preds = %59
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
@@ -5359,8 +6527,8 @@ entry:
 
 ; <label>:70                                      ; preds = %65
   %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
-  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.String addrspace(1)* %71, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %72
 
 ; <label>:72                                      ; preds = %70
   %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
@@ -5379,39 +6547,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %17
+ThrowNullRef4:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %29
+ThrowNullRef6:                                    ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %36
+ThrowNullRef8:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %43
+ThrowNullRef10:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %50
+ThrowNullRef12:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %57
+ThrowNullRef14:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %63
+ThrowNullRef16:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %70
+ThrowNullRef18:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5419,7 +6587,293 @@ ThrowNullRef17:                                   ; preds = %70
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
-Failed to read String.TrimHelper[loadElem]
+Successfully read String.TrimHelper
+
+define %System.String addrspace(1)* @String.TrimHelper(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i16
+  %loc4 = alloca i32
+  %loc5 = alloca i16
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = sub i32 %3, 1
+  store i32 %4, i32* %loc0
+  store i32 0, i32* %loc1
+  %5 = load i32, i32* %arg2
+  %6 = icmp eq i32 %5, 1
+  br i1 %6, label %62, label %7
+
+; <label>:7                                       ; preds = %1
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:8                                       ; preds = %58
+  store i32 0, i32* %loc2
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load i32, i32* %loc1
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2, i32 %10
+  %13 = load i16, i16 addrspace(1)* %12
+  %14 = zext i16 %13 to i32
+  %15 = trunc i32 %14 to i16
+  store i16 %15, i16* %loc3
+  store i32 0, i32* %loc2
+  br label %34
+
+; <label>:16                                      ; preds = %37
+  %17 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %18 = load i32, i32* %loc2
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %17, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %19
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = zext i32 %18 to i64
+  %BoundsCheck = icmp uge i64 %23, %22
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %24
+
+; <label>:24                                      ; preds = %19
+  %25 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 3, i32 %18
+  %26 = load i16, i16 addrspace(1)* %25, align 8
+  %27 = zext i16 %26 to i32
+  %28 = load i16, i16* %loc3
+  %29 = zext i16 %28 to i32
+  %30 = icmp eq i32 %27, %29
+  br i1 %30, label %43, label %31
+
+; <label>:31                                      ; preds = %24
+  %32 = load i32, i32* %loc2
+  %33 = add i32 %32, 1
+  store i32 %33, i32* %loc2
+  br label %34
+
+; <label>:34                                      ; preds = %11, %31
+  %35 = load i32, i32* %loc2
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = icmp slt i32 %35, %41
+  br i1 %42, label %16, label %43
+
+; <label>:43                                      ; preds = %24, %37
+  %44 = load i32, i32* %loc2
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %45, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp eq i32 %44, %50
+  br i1 %51, label %62, label %52
+
+; <label>:52                                      ; preds = %46
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %7, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %57, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %58
+
+; <label>:58                                      ; preds = %55
+  %59 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %60 = load i32, i32 addrspace(1)* %59
+  %61 = icmp slt i32 %56, %60
+  br i1 %61, label %8, label %62
+
+; <label>:62                                      ; preds = %1, %46, %58
+  %63 = load i32, i32* %arg2
+  %64 = icmp eq i32 %63, 0
+  br i1 %64, label %122, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %66, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %67
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %66, i32 0, i32 1
+  %69 = load i32, i32 addrspace(1)* %68
+  %70 = sub i32 %69, 1
+  store i32 %70, i32* %loc0
+  br label %118
+
+; <label>:71                                      ; preds = %118
+  store i32 0, i32* %loc4
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %73 = load i32, i32* %loc0
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %74
+
+; <label>:74                                      ; preds = %71
+  %75 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 2, i32 %73
+  %76 = load i16, i16 addrspace(1)* %75
+  %77 = zext i16 %76 to i32
+  %78 = trunc i32 %77 to i16
+  store i16 %78, i16* %loc5
+  store i32 0, i32* %loc4
+  br label %97
+
+; <label>:79                                      ; preds = %100
+  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %81 = load i32, i32* %loc4
+  %NullCheck19 = icmp eq %"System.Char[]" addrspace(1)* %80, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
+
+; <label>:82                                      ; preds = %79
+  %83 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 1
+  %84 = load i32, i32 addrspace(1)* %83
+  %85 = zext i32 %84 to i64
+  %86 = zext i32 %81 to i64
+  %BoundsCheck21 = icmp uge i64 %86, %85
+  br i1 %BoundsCheck21, label %ThrowIndexOutOfRange22, label %87
+
+; <label>:87                                      ; preds = %82
+  %88 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 3, i32 %81
+  %89 = load i16, i16 addrspace(1)* %88, align 8
+  %90 = zext i16 %89 to i32
+  %91 = load i16, i16* %loc5
+  %92 = zext i16 %91 to i32
+  %93 = icmp eq i32 %90, %92
+  br i1 %93, label %106, label %94
+
+; <label>:94                                      ; preds = %87
+  %95 = load i32, i32* %loc4
+  %96 = add i32 %95, 1
+  store i32 %96, i32* %loc4
+  br label %97
+
+; <label>:97                                      ; preds = %74, %94
+  %98 = load i32, i32* %loc4
+  %99 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck15 = icmp eq %"System.Char[]" addrspace(1)* %99, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %100
+
+; <label>:100                                     ; preds = %97
+  %101 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %99, i32 0, i32 1
+  %102 = load i32, i32 addrspace(1)* %101
+  %103 = zext i32 %102 to i64
+  %104 = trunc i64 %103 to i32
+  %105 = icmp slt i32 %98, %104
+  br i1 %105, label %79, label %106
+
+; <label>:106                                     ; preds = %87, %100
+  %107 = load i32, i32* %loc4
+  %108 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck17 = icmp eq %"System.Char[]" addrspace(1)* %108, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %109
+
+; <label>:109                                     ; preds = %106
+  %110 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %108, i32 0, i32 1
+  %111 = load i32, i32 addrspace(1)* %110
+  %112 = zext i32 %111 to i64
+  %113 = trunc i64 %112 to i32
+  %114 = icmp eq i32 %107, %113
+  br i1 %114, label %122, label %115
+
+; <label>:115                                     ; preds = %109
+  %116 = load i32, i32* %loc0
+  %117 = sub i32 %116, 1
+  store i32 %117, i32* %loc0
+  br label %118
+
+; <label>:118                                     ; preds = %67, %115
+  %119 = load i32, i32* %loc0
+  %120 = load i32, i32* %loc1
+  %121 = icmp sge i32 %119, %120
+  br i1 %121, label %71, label %122
+
+; <label>:122                                     ; preds = %62, %109, %118
+  %123 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %124 = load i32, i32* %loc1
+  %125 = load i32, i32* %loc0
+  %126 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %123, i32 %124, i32 %125)
+  ret %System.String addrspace(1)* %126
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %97
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange22:                           ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
 Successfully read String.CreateTrimmedString
 
@@ -5439,8 +6893,8 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
@@ -5535,8 +6989,8 @@ entry:
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i64 2872
   %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
   %8 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %7
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %3
   %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
@@ -5553,8 +7007,8 @@ entry:
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 2864
   %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
   %21 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %20
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
-  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %22
 
 ; <label>:22                                      ; preds = %16
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
@@ -5569,7 +7023,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %16
+ThrowNullRef2:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5586,8 +7040,8 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5613,8 +7067,8 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
@@ -5632,8 +7086,8 @@ entry:
 
 ; <label>:12                                      ; preds = %4
   %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
@@ -5644,8 +7098,8 @@ entry:
 
 ; <label>:19                                      ; preds = %14
   %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %19
   %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
@@ -5660,21 +7114,21 @@ entry:
   %31 = zext i16 %30 to i32
   %32 = bitcast i8* %29 to i16*
   %33 = trunc i32 %31 to i16
-  %NullCheck6 = icmp ne i16* %32, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i16* %32, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %21
   store i16 %33, i16* %32, align 8
   %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %36
 
 ; <label>:36                                      ; preds = %34
   %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
   %38 = load i32, i32 addrspace(1)* %37, align 8
   %39 = add i32 %38, 1
-  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %40
 
 ; <label>:40                                      ; preds = %36
   %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
@@ -5683,16 +7137,16 @@ entry:
 
 ; <label>:42                                      ; preds = %14
   %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
-  br i1 %NullCheck12, label %44, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
   %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
   %47 = load i16, i16* %arg1
   %48 = zext i16 %47 to i32
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = trunc i32 %48 to i16
@@ -5703,31 +7157,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %19
+ThrowNullRef4:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %21
+ThrowNullRef6:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %36
+ThrowNullRef10:                                   ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %42
+ThrowNullRef12:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %44
+ThrowNullRef14:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5740,8 +7194,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -5752,8 +7206,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
@@ -5762,14 +7216,14 @@ entry:
 
 ; <label>:11                                      ; preds = %1
   %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
@@ -5779,15 +7233,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5808,8 +7262,8 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5822,8 +7276,8 @@ entry:
 
 ; <label>:8                                       ; preds = %3
   %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
@@ -5842,15 +7296,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
-  br i1 %NullCheck4, label %22, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
   %24 = load i16*, i16* addrspace(1)* %23, align 8
   %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %25, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
@@ -5859,8 +7313,8 @@ entry:
   store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
@@ -5874,8 +7328,8 @@ entry:
 
 ; <label>:37                                      ; preds = %65
   %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %37
   %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
@@ -5886,16 +7340,16 @@ entry:
   %45 = bitcast i16* %41 to i8*
   %46 = getelementptr inbounds i8, i8* %45, i64 %44
   %47 = bitcast i8* %46 to i16*
-  %NullCheck14 = icmp ne i16* %47, null
-  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %47, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %48
 
 ; <label>:48                                      ; preds = %39
   %49 = load i16, i16* %47, align 8
   %50 = zext i16 %49 to i32
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %52 = load i32, i32* %loc1
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %53
 
 ; <label>:53                                      ; preds = %48
   %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
@@ -5916,8 +7370,8 @@ entry:
 ; <label>:62                                      ; preds = %36, %59
   %63 = load i32, i32* %loc1
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck10, label %65, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %65
 
 ; <label>:65                                      ; preds = %62
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
@@ -5936,15 +7390,15 @@ entry:
 
 ; <label>:74                                      ; preds = %70
   %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
-  br i1 %NullCheck18, label %76, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %76
 
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
   %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
-  br i1 %NullCheck20, label %80, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
   %81 = load i64, i64 addrspace(1)* %79
@@ -5958,8 +7412,8 @@ entry:
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
   %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
-  br i1 %NullCheck22, label %92, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.String addrspace(1)* %90, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %92
 
 ; <label>:92                                      ; preds = %80
   %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
@@ -5969,15 +7423,15 @@ entry:
 
 ; <label>:96                                      ; preds = %70
   %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
-  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %98
 
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
   %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
-  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
   %103 = load i64, i64 addrspace(1)* %101
@@ -5991,8 +7445,8 @@ entry:
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
   %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
-  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.String addrspace(1)* %112, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %114
 
 ; <label>:114                                     ; preds = %102
   %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
@@ -6004,59 +7458,59 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %20
+ThrowNullRef4:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %22
+ThrowNullRef6:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %26
+ThrowNullRef8:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %62
+ThrowNullRef10:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %48
+ThrowNullRef16:                                   ; preds = %48
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %74
+ThrowNullRef18:                                   ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %76
+ThrowNullRef20:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %80
+ThrowNullRef22:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %96
+ThrowNullRef24:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %98
+ThrowNullRef26:                                   ; preds = %98
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %102
+ThrowNullRef28:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6069,15 +7523,15 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
   %3 = load i16*, i16* addrspace(1)* %2, align 8
   %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
@@ -6087,8 +7541,8 @@ entry:
   %10 = bitcast i16* %3 to i8*
   %11 = getelementptr inbounds i8, i8* %10, i64 %9
   %12 = bitcast i8* %11 to i16*
-  %NullCheck4 = icmp ne i16* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %5
   store i16 0, i16* %12, align 8
@@ -6098,11 +7552,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6119,8 +7573,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -6131,8 +7585,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
@@ -6144,15 +7598,15 @@ entry:
 
 ; <label>:14                                      ; preds = %1
   %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
   %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
   %21 = load i64, i64 addrspace(1)* %19
@@ -6171,15 +7625,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %14
+ThrowNullRef4:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %16
+ThrowNullRef6:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6302,14 +7756,6 @@ entry:
   ret %System.String addrspace(1)* %57
 }
 
-INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
-Successfully read RuntimeHelpers.get_OffsetToStringData
-
-define i32 @RuntimeHelpers.get_OffsetToStringData() {
-entry:
-  ret i32 12
-}
-
 INFO:  jitting method String::Equals using LLILCJit
 Successfully read String.Equals
 
@@ -6381,8 +7827,8 @@ entry:
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
-  br i1 %NullCheck24, label %29, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
   %30 = load i64, i64 addrspace(1)* %28
@@ -6397,8 +7843,8 @@ entry:
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
-  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
   %43 = load i64, i64 addrspace(1)* %41
@@ -6418,8 +7864,8 @@ entry:
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
   %59 = load i64, i64 addrspace(1)* %57
@@ -6434,8 +7880,8 @@ entry:
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck22, label %71, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
   %72 = load i64, i64 addrspace(1)* %70
@@ -6455,8 +7901,8 @@ entry:
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
-  br i1 %NullCheck16, label %87, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = load i64, i64 addrspace(1)* %86
@@ -6471,8 +7917,8 @@ entry:
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck18, label %100, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
   %101 = load i64, i64 addrspace(1)* %99
@@ -6492,8 +7938,8 @@ entry:
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
-  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
   %117 = load i64, i64 addrspace(1)* %115
@@ -6508,8 +7954,8 @@ entry:
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
-  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
   %130 = load i64, i64 addrspace(1)* %128
@@ -6528,15 +7974,15 @@ entry:
 
 ; <label>:142                                     ; preds = %22
   %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
-  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %143, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %144
 
 ; <label>:144                                     ; preds = %142
   %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
   %146 = load i32, i32 addrspace(1)* %145
   %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
-  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %147, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %148
 
 ; <label>:148                                     ; preds = %144
   %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
@@ -6557,15 +8003,15 @@ entry:
 
 ; <label>:159                                     ; preds = %22
   %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
-  br i1 %NullCheck, label %161, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %ThrowNullRef, label %161
 
 ; <label>:161                                     ; preds = %159
   %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
   %163 = load i32, i32 addrspace(1)* %162
   %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
-  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %164, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %165
 
 ; <label>:165                                     ; preds = %161
   %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
@@ -6578,8 +8024,8 @@ entry:
 
 ; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
-  br i1 %NullCheck4, label %172, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %171, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %172
 
 ; <label>:172                                     ; preds = %170
   %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
@@ -6589,8 +8035,8 @@ entry:
 
 ; <label>:176                                     ; preds = %172
   %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
-  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %177, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %178
 
 ; <label>:178                                     ; preds = %176
   %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
@@ -6629,55 +8075,55 @@ ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %161
+ThrowNullRef2:                                    ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %170
+ThrowNullRef4:                                    ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %176
+ThrowNullRef6:                                    ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %142
+ThrowNullRef8:                                    ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %144
+ThrowNullRef10:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %113
+ThrowNullRef12:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %116
+ThrowNullRef14:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %84
+ThrowNullRef16:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %87
+ThrowNullRef18:                                   ; preds = %87
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %55
+ThrowNullRef20:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %58
+ThrowNullRef22:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %26
+ThrowNullRef24:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %29
+ThrowNullRef26:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,8 +8161,8 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck, label %14, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %ThrowNullRef, label %14
 
 ; <label>:14                                      ; preds = %8
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
@@ -6760,8 +8206,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
@@ -6770,14 +8216,14 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32, i32* %loc0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %10
   %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
   %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
@@ -6790,15 +8236,15 @@ entry:
 ; <label>:25                                      ; preds = %19
   %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
-  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
   %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
@@ -6807,8 +8253,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %37 = load i32, i32* %loc0
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %38, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %38
 
 ; <label>:38                                      ; preds = %32
   %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
@@ -6817,14 +8263,14 @@ entry:
 
 ; <label>:40                                      ; preds = %19
   %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %40
   %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
   %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
-  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
-  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
@@ -6832,8 +8278,8 @@ entry:
   %48 = zext i32 %47 to i64
   %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
-  br i1 %NullCheck16, label %51, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %51
 
 ; <label>:51                                      ; preds = %45
   %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
@@ -6847,15 +8293,15 @@ entry:
 ; <label>:57                                      ; preds = %51
   %58 = load i16*, i16** %arg1
   %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
-  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %60
 
 ; <label>:60                                      ; preds = %57
   %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
   %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
-  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %64
 
 ; <label>:64                                      ; preds = %60
   %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
@@ -6864,22 +8310,22 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
   %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
-  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %70
 
 ; <label>:70                                      ; preds = %64
   %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
   %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
-  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
-  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
   %75 = load i32, i32 addrspace(1)* %74
   %76 = zext i32 %75 to i64
   %77 = trunc i64 %76 to i32
-  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
-  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %78
 
 ; <label>:78                                      ; preds = %73
   %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
@@ -6901,8 +8347,8 @@ entry:
   %90 = bitcast i16* %86 to i8*
   %91 = getelementptr inbounds i8, i8* %90, i64 %89
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %93
 
 ; <label>:93                                      ; preds = %80
   %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
@@ -6912,8 +8358,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %99 = load i32, i32* %loc2
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %100
 
 ; <label>:100                                     ; preds = %93
   %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
@@ -6928,63 +8374,63 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %25
+ThrowNullRef6:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %32
+ThrowNullRef10:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %40
+ThrowNullRef12:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %45
+ThrowNullRef16:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %57
+ThrowNullRef18:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %60
+ThrowNullRef20:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %64
+ThrowNullRef22:                                   ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %70
+ThrowNullRef24:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %73
+ThrowNullRef26:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %80
+ThrowNullRef28:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %93
+ThrowNullRef30:                                   ; preds = %93
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7004,8 +8450,8 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
@@ -7033,43 +8479,43 @@ entry:
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %14
   %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
   %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   %28 = load i32, i32 addrspace(1)* %27, align 8
   %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
-  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %30
 
 ; <label>:30                                      ; preds = %26
   %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
   %32 = load i32, i32 addrspace(1)* %31, align 8
   %33 = add i32 %28, %32
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %34
 
 ; <label>:34                                      ; preds = %30
   %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   store i32 %33, i32 addrspace(1)* %35
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
   store i32 0, i32 addrspace(1)* %38
   %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %40
 
 ; <label>:40                                      ; preds = %37
   %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
@@ -7082,8 +8528,8 @@ entry:
 
 ; <label>:47                                      ; preds = %40
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
@@ -7098,8 +8544,8 @@ entry:
   %54 = load i32, i32* %loc0
   %55 = sext i32 %54 to i64
   %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
-  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %57
 
 ; <label>:57                                      ; preds = %52
   %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
@@ -7110,68 +8556,35 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %14
+ThrowNullRef2:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %23
+ThrowNullRef4:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %26
+ThrowNullRef6:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %30
+ThrowNullRef8:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %34
+ThrowNullRef10:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %47
+ThrowNullRef14:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %52
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-}
-
-INFO:  jitting method StringBuilder::get_Length using LLILCJit
-Successfully read StringBuilder.get_Length
-
-define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.StringBuilder addrspace(1)*
-  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
-  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
-
-; <label>:1                                       ; preds = %entry
-  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %3 = load i32, i32 addrspace(1)* %2, align 8
-  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
-
-; <label>:5                                       ; preds = %1
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = add i32 %3, %7
-  ret i32 %8
-
-ThrowNullRef:                                     ; preds = %entry
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef16:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7213,70 +8626,70 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
   %6 = load i32, i32 addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
   store i32 %6, i32 addrspace(1)* %8
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
   %13 = load i32, i32 addrspace(1)* %12, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
   store i32 %13, i32 addrspace(1)* %15
   %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
-  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %18
 
 ; <label>:18                                      ; preds = %14
   %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
   %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
   %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
   %34 = load i32, i32 addrspace(1)* %33, align 8
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
-  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
@@ -7287,39 +8700,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %28
+ThrowNullRef16:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %32
+ThrowNullRef18:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7455,13 +8868,13 @@ entry:
 ; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
@@ -7477,16 +8890,16 @@ entry:
 
 ; <label>:18                                      ; preds = %15
   %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
   store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
   %22 = load i32, i32* %loc0
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %24
 
 ; <label>:24                                      ; preds = %20
   %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
@@ -7498,13 +8911,13 @@ entry:
 ; <label>:28                                      ; preds = %15, %24
   %29 = load i32, i32* %arg1
   %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %31
   %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
@@ -7517,20 +8930,20 @@ entry:
   %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
-  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
   %46 = load i32, i32 addrspace(1)* %45, align 8
   %47 = sub i32 %40, %46
-  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
-  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i32 addrspace(1)* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %48
 
 ; <label>:48                                      ; preds = %44
   store i32 %47, i32 addrspace(1)* %39, align 8
@@ -7538,21 +8951,21 @@ entry:
 
 ; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
-  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %51
 
 ; <label>:51                                      ; preds = %49
   %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %53
 
 ; <label>:53                                      ; preds = %51
   %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
   %55 = load i32, i32 addrspace(1)* %54, align 8
   %56 = load i32, i32* %arg2
   %57 = sub i32 %55, %56
-  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %58
 
 ; <label>:58                                      ; preds = %53
   %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
@@ -7562,13 +8975,13 @@ entry:
 ; <label>:60                                      ; preds = %33, %58
   %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
   %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
-  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %63
 
 ; <label>:63                                      ; preds = %60
   %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
-  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
-  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
@@ -7578,15 +8991,15 @@ entry:
 
 ; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
-  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i32 addrspace(1)* %69, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %70
 
 ; <label>:70                                      ; preds = %68
   %71 = load i32, i32 addrspace(1)* %69, align 8
   store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
-  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
@@ -7596,8 +9009,8 @@ entry:
   store i32 %77, i32* %loc4
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
-  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %80
 
 ; <label>:80                                      ; preds = %73
   %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
@@ -7607,71 +9020,71 @@ entry:
 ; <label>:83                                      ; preds = %80
   store i32 0, i32* %loc3
   %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
-  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
-  br i1 %NullCheck26, label %88, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i32 addrspace(1)* %87, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %88
 
 ; <label>:88                                      ; preds = %85
   %89 = load i32, i32 addrspace(1)* %87, align 8
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
-  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %90
 
 ; <label>:90                                      ; preds = %88
   %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
   store i32 %89, i32 addrspace(1)* %91
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
-  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
-  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %96
 
 ; <label>:96                                      ; preds = %94
   %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
-  br i1 %NullCheck34, label %100, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %100
 
 ; <label>:100                                     ; preds = %96
   %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
-  br i1 %NullCheck36, label %102, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %102
 
 ; <label>:102                                     ; preds = %100
   %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
   %104 = load i32, i32 addrspace(1)* %103, align 8
   %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
-  br i1 %NullCheck38, label %106, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %106
 
 ; <label>:106                                     ; preds = %102
   %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
-  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
-  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %108
 
 ; <label>:108                                     ; preds = %106
   %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
   %110 = load i32, i32 addrspace(1)* %109, align 8
   %111 = add i32 %104, %110
-  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %112
 
 ; <label>:112                                     ; preds = %108
   %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
   store i32 %111, i32 addrspace(1)* %113
   %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
-  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i32 addrspace(1)* %114, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %115
 
 ; <label>:115                                     ; preds = %112
   %116 = load i32, i32 addrspace(1)* %114, align 8
@@ -7681,19 +9094,19 @@ entry:
 ; <label>:118                                     ; preds = %115
   %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
-  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %121
 
 ; <label>:121                                     ; preds = %118
   %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
-  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
-  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %123
 
 ; <label>:123                                     ; preds = %121
   %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
   %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
-  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
-  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %126
 
 ; <label>:126                                     ; preds = %123
   %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
@@ -7705,8 +9118,8 @@ entry:
 
 ; <label>:130                                     ; preds = %80, %115, %126
   %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %132
 
 ; <label>:132                                     ; preds = %130
   %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7715,8 +9128,8 @@ entry:
   %136 = load i32, i32* %loc3
   %137 = sub i32 %135, %136
   %138 = sub i32 %134, %137
-  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %139
 
 ; <label>:139                                     ; preds = %132
   %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7728,16 +9141,16 @@ entry:
 
 ; <label>:144                                     ; preds = %139
   %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
-  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %146
 
 ; <label>:146                                     ; preds = %144
   %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
   %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
   %149 = load i32, i32* %loc2
   %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
-  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %151
 
 ; <label>:151                                     ; preds = %146
   %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
@@ -7754,145 +9167,249 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %18
+ThrowNullRef4:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %31
+ThrowNullRef10:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %44
+ThrowNullRef16:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %68
+ThrowNullRef18:                                   ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %70
+ThrowNullRef20:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %73
+ThrowNullRef22:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %83
+ThrowNullRef24:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %85
+ThrowNullRef26:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %88
+ThrowNullRef28:                                   ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %90
+ThrowNullRef30:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %94
+ThrowNullRef32:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %96
+ThrowNullRef34:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %100
+ThrowNullRef36:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %102
+ThrowNullRef38:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %106
+ThrowNullRef40:                                   ; preds = %106
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %108
+ThrowNullRef42:                                   ; preds = %108
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %112
+ThrowNullRef44:                                   ; preds = %112
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %118
+ThrowNullRef46:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %121
+ThrowNullRef48:                                   ; preds = %121
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %123
+ThrowNullRef50:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %130
+ThrowNullRef52:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %132
+ThrowNullRef54:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %144
+ThrowNullRef56:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %146
+ThrowNullRef58:                                   ; preds = %146
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %60
+ThrowNullRef60:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %63
+ThrowNullRef62:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %49
+ThrowNullRef64:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %51
+ThrowNullRef66:                                   ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %53
+ThrowNullRef68:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(%"System.Char[]" addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %arg0 = alloca %"System.Char[]" addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store %"System.Char[]" addrspace(1)* %param0, %"System.Char[]" addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load i32, i32* %arg4
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %43, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %38, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg1
+  %13 = load i32, i32* %arg4
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %38, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %24 = load i32, i32* %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %35 = load i32, i32* %arg3
+  %36 = load i32, i32* %arg4
+  %37 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %37, %"System.Char[]" addrspace(1)* %34, i32 %35, i32 %36)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:38                                      ; preds = %5, %16
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Successfully read Buffer._Memmove
 
@@ -7914,7 +9431,7 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[loadElem]
+Failed to read AppDomain.SetDataHelper[storeElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -7923,8 +9440,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
@@ -7934,8 +9451,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
@@ -7947,15 +9464,15 @@ entry:
   %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
   %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
@@ -7966,15 +9483,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7992,7 +9509,79 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
-Failed to read Dictionary`2.TryGetValue[loadElemA]
+Successfully read Dictionary`2.TryGetValue
+
+define i8 @"Dictionary`2.TryGetValue"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)* addrspace(1)* %param2) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  %arg2 = alloca %System.__Canon addrspace(1)* addrspace(1)*
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  store %System.__Canon addrspace(1)* addrspace(1)* %param2, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  store i32 %2, i32* %loc0
+  %3 = load i32, i32* %loc0
+  %4 = icmp slt i32 %3, 0
+  br i1 %4, label %22, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 2
+  %10 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %9, align 8
+  %11 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = zext i32 %11 to i64
+  %BoundsCheck = icmp uge i64 %16, %15
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 3, i32 %11
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %20, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %6, %System.__Canon addrspace(1)* %21)
+  ret i8 1
+
+; <label>:22                                      ; preds = %entry
+  %23 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %23, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -8058,8 +9647,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
@@ -8091,8 +9680,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
@@ -8171,15 +9760,15 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck, label %19, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %ThrowNullRef, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
   %21 = load i32, i32 addrspace(1)* %20
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
@@ -8202,7 +9791,7 @@ ThrowNullRef:                                     ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %19
+ThrowNullRef2:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8248,8 +9837,8 @@ entry:
   %0 = alloca %System.AppDomainHandle
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %1 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %1, i32 0, i32 15
@@ -8269,8 +9858,8 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
@@ -8286,7 +9875,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -8299,8 +9888,8 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -8327,8 +9916,8 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
@@ -8352,8 +9941,8 @@ entry:
   %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
   store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
@@ -8363,8 +9952,8 @@ entry:
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
@@ -8374,8 +9963,8 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %9
   %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
@@ -8384,8 +9973,8 @@ entry:
 
 ; <label>:18                                      ; preds = %3, %16
   %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
@@ -8397,15 +9986,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %18
+ThrowNullRef6:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8418,8 +10007,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
@@ -8453,15 +10042,15 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
@@ -8473,7 +10062,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8481,7 +10070,7 @@ ThrowNullRef1:                                    ; preds = %1
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
 Failed to read Dictionary`2.System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
@@ -8506,8 +10095,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
@@ -8524,8 +10113,8 @@ entry:
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -8544,7 +10133,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8577,8 +10166,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = load i64, i64* %arg2
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = trunc i32 %3 to i8
@@ -8634,46 +10223,46 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
   %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
-  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
-  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
-  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
@@ -8684,27 +10273,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %20
+ThrowNullRef12:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8717,8 +10306,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -8756,22 +10345,22 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
   %9 = load i64, i64 addrspace(1)* %8, align 8
   %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
   %13 = load i64, i64 addrspace(1)* %12, align 8
   %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %11
   %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
@@ -8788,11 +10377,11 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8882,8 +10471,8 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
@@ -8900,8 +10489,8 @@ entry:
 ; <label>:8                                       ; preds = %1
   %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
   %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
@@ -8911,15 +10500,15 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
   %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
   %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
-  br i1 %NullCheck6, label %21, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
@@ -8946,15 +10535,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8992,15 +10581,15 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
   store i8 %3, i8 addrspace(1)* %5
   %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
@@ -9011,7 +10600,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9027,8 +10616,8 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -9041,8 +10630,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
@@ -9058,7 +10647,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9080,8 +10669,8 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
@@ -9096,8 +10685,8 @@ entry:
 ; <label>:12                                      ; preds = %6
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
@@ -9112,8 +10701,8 @@ entry:
 ; <label>:21                                      ; preds = %15
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
@@ -9128,8 +10717,8 @@ entry:
 ; <label>:30                                      ; preds = %24
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %31, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
@@ -9144,8 +10733,8 @@ entry:
 ; <label>:39                                      ; preds = %33
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
-  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %40, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %42
 
 ; <label>:42                                      ; preds = %39
   %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
@@ -9164,19 +10753,19 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %21
+ThrowNullRef4:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %30
+ThrowNullRef6:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %39
+ThrowNullRef8:                                    ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9243,8 +10832,8 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
@@ -9264,57 +10853,57 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
   store i8 0, i8 addrspace(1)* %2
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
   store i8 0, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
   store i8 0, i8 addrspace(1)* %17
   %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
   store i8 0, i8 addrspace(1)* %20
   %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
-  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
@@ -9325,31 +10914,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %19
+ThrowNullRef14:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9367,8 +10956,8 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
@@ -9380,8 +10969,8 @@ entry:
 
 ; <label>:9                                       ; preds = %4
   %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %9
   %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
@@ -9395,7 +10984,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef2:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9420,8 +11009,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
@@ -9512,8 +11101,8 @@ entry:
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
@@ -9524,8 +11113,8 @@ entry:
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = load i64, i64 addrspace(1)* %12
@@ -9537,8 +11126,8 @@ entry:
   %20 = load i64, i64* %19
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
-  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %13
   %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
@@ -9555,8 +11144,8 @@ entry:
 ; <label>:30                                      ; preds = %25
   %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %32 = load i32, i32* %arg2
-  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
-  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
@@ -9570,15 +11159,15 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %30
+ThrowNullRef2:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9622,87 +11211,87 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
   %10 = load i8, i8 addrspace(1)* %9, align 8
   %11 = zext i8 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %8
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
   store i8 %12, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
   %19 = load i8, i8 addrspace(1)* %18, align 8
   %20 = zext i8 %19 to i32
   %21 = trunc i32 %20 to i8
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
   store i8 %21, i8 addrspace(1)* %23
   %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
   %28 = load i8, i8 addrspace(1)* %27, align 8
   %29 = zext i8 %28 to i32
   %30 = trunc i32 %29 to i8
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
-  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %31
 
 ; <label>:31                                      ; preds = %26
   %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
   store i8 %30, i8 addrspace(1)* %32
   %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
-  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
-  br i1 %NullCheck14, label %40, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %40
 
 ; <label>:40                                      ; preds = %35
   %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
   store i8 %39, i8 addrspace(1)* %41
   %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
-  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %44
 
 ; <label>:44                                      ; preds = %40
   %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
   %46 = load i8, i8 addrspace(1)* %45, align 8
   %47 = zext i8 %46 to i32
   %48 = trunc i32 %47 to i8
-  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
   store i8 %48, i8 addrspace(1)* %50
   %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
-  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
@@ -9713,29 +11302,29 @@ entry:
 ; <label>:56                                      ; preds = %52
   %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
-  br i1 %NullCheck22, label %59, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
   %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
   %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
-  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
-  br i1 %NullCheck24, label %63, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
   %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
-  br i1 %NullCheck26, label %66, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
   %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
-  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
-  br i1 %NullCheck28, label %69, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %69
 
 ; <label>:69                                      ; preds = %66
   %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
@@ -9744,15 +11333,15 @@ entry:
 
 ; <label>:71                                      ; preds = %105
   %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
-  br i1 %NullCheck34, label %73, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %73
 
 ; <label>:73                                      ; preds = %71
   %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
   %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
   %76 = load i32, i32* %loc0
-  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
-  br i1 %NullCheck36, label %77, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
@@ -9766,8 +11355,8 @@ entry:
 
 ; <label>:83                                      ; preds = %77
   %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
-  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
@@ -9775,14 +11364,14 @@ entry:
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
   %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
-  br i1 %NullCheck40, label %91, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
 ; <label>:91                                      ; preds = %85
   %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
   %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
-  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck42, label %94, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %94
 
 ; <label>:94                                      ; preds = %91
   %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
@@ -9798,14 +11387,14 @@ entry:
 ; <label>:99                                      ; preds = %69, %96
   %100 = load i32, i32* %loc0
   %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
-  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %102
 
 ; <label>:102                                     ; preds = %99
   %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
   %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
-  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
-  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
@@ -9819,87 +11408,87 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %26
+ThrowNullRef10:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %31
+ThrowNullRef12:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %35
+ThrowNullRef14:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %40
+ThrowNullRef16:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %56
+ThrowNullRef22:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %59
+ThrowNullRef24:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %63
+ThrowNullRef26:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %66
+ThrowNullRef28:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %102
+ThrowNullRef32:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %71
+ThrowNullRef34:                                   ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %73
+ThrowNullRef36:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %83
+ThrowNullRef38:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %85
+ThrowNullRef40:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %91
+ThrowNullRef42:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9943,15 +11532,15 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
   %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
@@ -9961,28 +11550,28 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
   %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %12
   %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
   %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
   %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
-  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
@@ -9993,23 +11582,23 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %12
+ThrowNullRef6:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10031,15 +11620,15 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
   %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = load i64, i64 addrspace(1)* %7
@@ -10077,13 +11666,13 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[loadElem]
+Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -10111,8 +11700,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueNeDbl.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueNeDbl.error.txt
@@ -25,8 +25,8 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
@@ -40,8 +40,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
   %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
@@ -75,7 +75,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -90,8 +90,8 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %NullCheck = icmp ne i8 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = load i8, i8 addrspace(1)* %0, align 8
@@ -125,8 +125,8 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
@@ -159,8 +159,8 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -184,8 +184,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
   store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
@@ -195,8 +195,8 @@ entry:
 ; <label>:4                                       ; preds = %1
   %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
   %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
@@ -206,8 +206,8 @@ entry:
   %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
@@ -221,14 +221,14 @@ entry:
 
 ; <label>:17                                      ; preds = %14
   %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
   %21 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
@@ -238,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -249,8 +249,8 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
@@ -261,27 +261,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %30
+ThrowNullRef10:                                   ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -301,7 +301,89 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
-Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
+Successfully read AppDomainSetup.GetUnsecureApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.GetUnsecureApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %NullCheck = icmp eq %"System.String[]" addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %BoundsCheck = icmp uge i64 0, %5
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %6
+
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 3, i32 0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
+  ret %System.String addrspace(1)* %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_Value using LLILCJit
+Successfully read AppDomainSetup.get_Value
+
+define %"System.String[]" addrspace(1)* @AppDomainSetup.get_Value(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.String[]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 18)
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.String[]" addrspace(1)* addrspace(1)*, %"System.String[]" addrspace(1)*)*)(%"System.String[]" addrspace(1)* addrspace(1)* %9, %"System.String[]" addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %11, i32 0, i32 1
+  %14 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %13, align 8
+  ret %"System.String[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -319,8 +401,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -368,16 +450,16 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
   %5 = load i32, i32 addrspace(1)* %4
   %6 = sub i32 %5, 1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -389,7 +471,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -421,8 +503,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
@@ -456,8 +538,8 @@ entry:
 ; <label>:27                                      ; preds = %19
   %28 = load i32, i32* %arg1
   %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
-  br i1 %NullCheck2, label %30, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %29, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %30
 
 ; <label>:30                                      ; preds = %27
   %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
@@ -493,8 +575,8 @@ entry:
 ; <label>:49                                      ; preds = %46
   %50 = load i32, i32* %arg2
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck4, label %52, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
@@ -517,11 +599,11 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %27
+ThrowNullRef2:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %49
+ThrowNullRef4:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -544,16 +626,16 @@ entry:
   %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %0)
   store %System.String addrspace(1)* %1, %System.String addrspace(1)** %loc0
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 2
   %5 = bitcast [0 x i16] addrspace(1)* %4 to i16 addrspace(1)*
   store i16 addrspace(1)* %5, i16 addrspace(1)** %loc1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %3
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2
@@ -580,7 +662,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -691,15 +773,15 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %NullCheck132 = icmp ne i8* %21, null
-  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+  %NullCheck131 = icmp eq i8* %21, null
+  br i1 %NullCheck131, label %ThrowNullRef132, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = load i8, i8* %21, align 8
   %24 = zext i8 %23 to i32
   %25 = trunc i32 %24 to i8
-  %NullCheck134 = icmp ne i8* %20, null
-  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+  %NullCheck133 = icmp eq i8* %20, null
+  br i1 %NullCheck133, label %ThrowNullRef134, label %26
 
 ; <label>:26                                      ; preds = %22
   store i8 %25, i8* %20, align 8
@@ -709,16 +791,16 @@ entry:
   %28 = load i8*, i8** %arg0
   %29 = load i8*, i8** %arg1
   %30 = bitcast i8* %29 to i16*
-  %NullCheck128 = icmp ne i16* %30, null
-  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+  %NullCheck127 = icmp eq i16* %30, null
+  br i1 %NullCheck127, label %ThrowNullRef128, label %31
 
 ; <label>:31                                      ; preds = %27
   %32 = load i16, i16* %30, align 8
   %33 = sext i16 %32 to i32
   %34 = bitcast i8* %28 to i16*
   %35 = trunc i32 %33 to i16
-  %NullCheck130 = icmp ne i16* %34, null
-  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+  %NullCheck129 = icmp eq i16* %34, null
+  br i1 %NullCheck129, label %ThrowNullRef130, label %36
 
 ; <label>:36                                      ; preds = %31
   store i16 %35, i16* %34, align 8
@@ -728,16 +810,16 @@ entry:
   %38 = load i8*, i8** %arg0
   %39 = load i8*, i8** %arg1
   %40 = bitcast i8* %39 to i16*
-  %NullCheck120 = icmp ne i16* %40, null
-  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+  %NullCheck119 = icmp eq i16* %40, null
+  br i1 %NullCheck119, label %ThrowNullRef120, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i16, i16* %40, align 8
   %43 = sext i16 %42 to i32
   %44 = bitcast i8* %38 to i16*
   %45 = trunc i32 %43 to i16
-  %NullCheck122 = icmp ne i16* %44, null
-  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+  %NullCheck121 = icmp eq i16* %44, null
+  br i1 %NullCheck121, label %ThrowNullRef122, label %46
 
 ; <label>:46                                      ; preds = %41
   store i16 %45, i16* %44, align 8
@@ -745,15 +827,15 @@ entry:
   %48 = getelementptr inbounds i8, i8* %47, i64 2
   %49 = load i8*, i8** %arg1
   %50 = getelementptr inbounds i8, i8* %49, i64 2
-  %NullCheck124 = icmp ne i8* %50, null
-  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+  %NullCheck123 = icmp eq i8* %50, null
+  br i1 %NullCheck123, label %ThrowNullRef124, label %51
 
 ; <label>:51                                      ; preds = %46
   %52 = load i8, i8* %50, align 8
   %53 = zext i8 %52 to i32
   %54 = trunc i32 %53 to i8
-  %NullCheck126 = icmp ne i8* %48, null
-  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+  %NullCheck125 = icmp eq i8* %48, null
+  br i1 %NullCheck125, label %ThrowNullRef126, label %55
 
 ; <label>:55                                      ; preds = %51
   store i8 %54, i8* %48, align 8
@@ -763,14 +845,14 @@ entry:
   %57 = load i8*, i8** %arg0
   %58 = load i8*, i8** %arg1
   %59 = bitcast i8* %58 to i32*
-  %NullCheck116 = icmp ne i32* %59, null
-  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+  %NullCheck115 = icmp eq i32* %59, null
+  br i1 %NullCheck115, label %ThrowNullRef116, label %60
 
 ; <label>:60                                      ; preds = %56
   %61 = load i32, i32* %59, align 8
   %62 = bitcast i8* %57 to i32*
-  %NullCheck118 = icmp ne i32* %62, null
-  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+  %NullCheck117 = icmp eq i32* %62, null
+  br i1 %NullCheck117, label %ThrowNullRef118, label %63
 
 ; <label>:63                                      ; preds = %60
   store i32 %61, i32* %62, align 8
@@ -780,14 +862,14 @@ entry:
   %65 = load i8*, i8** %arg0
   %66 = load i8*, i8** %arg1
   %67 = bitcast i8* %66 to i32*
-  %NullCheck108 = icmp ne i32* %67, null
-  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+  %NullCheck107 = icmp eq i32* %67, null
+  br i1 %NullCheck107, label %ThrowNullRef108, label %68
 
 ; <label>:68                                      ; preds = %64
   %69 = load i32, i32* %67, align 8
   %70 = bitcast i8* %65 to i32*
-  %NullCheck110 = icmp ne i32* %70, null
-  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+  %NullCheck109 = icmp eq i32* %70, null
+  br i1 %NullCheck109, label %ThrowNullRef110, label %71
 
 ; <label>:71                                      ; preds = %68
   store i32 %69, i32* %70, align 8
@@ -795,15 +877,15 @@ entry:
   %73 = getelementptr inbounds i8, i8* %72, i64 4
   %74 = load i8*, i8** %arg1
   %75 = getelementptr inbounds i8, i8* %74, i64 4
-  %NullCheck112 = icmp ne i8* %75, null
-  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+  %NullCheck111 = icmp eq i8* %75, null
+  br i1 %NullCheck111, label %ThrowNullRef112, label %76
 
 ; <label>:76                                      ; preds = %71
   %77 = load i8, i8* %75, align 8
   %78 = zext i8 %77 to i32
   %79 = trunc i32 %78 to i8
-  %NullCheck114 = icmp ne i8* %73, null
-  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+  %NullCheck113 = icmp eq i8* %73, null
+  br i1 %NullCheck113, label %ThrowNullRef114, label %80
 
 ; <label>:80                                      ; preds = %76
   store i8 %79, i8* %73, align 8
@@ -813,14 +895,14 @@ entry:
   %82 = load i8*, i8** %arg0
   %83 = load i8*, i8** %arg1
   %84 = bitcast i8* %83 to i32*
-  %NullCheck100 = icmp ne i32* %84, null
-  br i1 %NullCheck100, label %85, label %ThrowNullRef99
+  %NullCheck99 = icmp eq i32* %84, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %85
 
 ; <label>:85                                      ; preds = %81
   %86 = load i32, i32* %84, align 8
   %87 = bitcast i8* %82 to i32*
-  %NullCheck102 = icmp ne i32* %87, null
-  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+  %NullCheck101 = icmp eq i32* %87, null
+  br i1 %NullCheck101, label %ThrowNullRef102, label %88
 
 ; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
@@ -829,16 +911,16 @@ entry:
   %91 = load i8*, i8** %arg1
   %92 = getelementptr inbounds i8, i8* %91, i64 4
   %93 = bitcast i8* %92 to i16*
-  %NullCheck104 = icmp ne i16* %93, null
-  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+  %NullCheck103 = icmp eq i16* %93, null
+  br i1 %NullCheck103, label %ThrowNullRef104, label %94
 
 ; <label>:94                                      ; preds = %88
   %95 = load i16, i16* %93, align 8
   %96 = sext i16 %95 to i32
   %97 = bitcast i8* %90 to i16*
   %98 = trunc i32 %96 to i16
-  %NullCheck106 = icmp ne i16* %97, null
-  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+  %NullCheck105 = icmp eq i16* %97, null
+  br i1 %NullCheck105, label %ThrowNullRef106, label %99
 
 ; <label>:99                                      ; preds = %94
   store i16 %98, i16* %97, align 8
@@ -848,14 +930,14 @@ entry:
   %101 = load i8*, i8** %arg0
   %102 = load i8*, i8** %arg1
   %103 = bitcast i8* %102 to i32*
-  %NullCheck88 = icmp ne i32* %103, null
-  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+  %NullCheck87 = icmp eq i32* %103, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %104
 
 ; <label>:104                                     ; preds = %100
   %105 = load i32, i32* %103, align 8
   %106 = bitcast i8* %101 to i32*
-  %NullCheck90 = icmp ne i32* %106, null
-  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+  %NullCheck89 = icmp eq i32* %106, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %107
 
 ; <label>:107                                     ; preds = %104
   store i32 %105, i32* %106, align 8
@@ -864,16 +946,16 @@ entry:
   %110 = load i8*, i8** %arg1
   %111 = getelementptr inbounds i8, i8* %110, i64 4
   %112 = bitcast i8* %111 to i16*
-  %NullCheck92 = icmp ne i16* %112, null
-  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+  %NullCheck91 = icmp eq i16* %112, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %113
 
 ; <label>:113                                     ; preds = %107
   %114 = load i16, i16* %112, align 8
   %115 = sext i16 %114 to i32
   %116 = bitcast i8* %109 to i16*
   %117 = trunc i32 %115 to i16
-  %NullCheck94 = icmp ne i16* %116, null
-  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+  %NullCheck93 = icmp eq i16* %116, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %118
 
 ; <label>:118                                     ; preds = %113
   store i16 %117, i16* %116, align 8
@@ -881,15 +963,15 @@ entry:
   %120 = getelementptr inbounds i8, i8* %119, i64 6
   %121 = load i8*, i8** %arg1
   %122 = getelementptr inbounds i8, i8* %121, i64 6
-  %NullCheck96 = icmp ne i8* %122, null
-  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+  %NullCheck95 = icmp eq i8* %122, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %123
 
 ; <label>:123                                     ; preds = %118
   %124 = load i8, i8* %122, align 8
   %125 = zext i8 %124 to i32
   %126 = trunc i32 %125 to i8
-  %NullCheck98 = icmp ne i8* %120, null
-  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+  %NullCheck97 = icmp eq i8* %120, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %127
 
 ; <label>:127                                     ; preds = %123
   store i8 %126, i8* %120, align 8
@@ -899,14 +981,14 @@ entry:
   %129 = load i8*, i8** %arg0
   %130 = load i8*, i8** %arg1
   %131 = bitcast i8* %130 to i64*
-  %NullCheck84 = icmp ne i64* %131, null
-  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+  %NullCheck83 = icmp eq i64* %131, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %132
 
 ; <label>:132                                     ; preds = %128
   %133 = load i64, i64* %131, align 8
   %134 = bitcast i8* %129 to i64*
-  %NullCheck86 = icmp ne i64* %134, null
-  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+  %NullCheck85 = icmp eq i64* %134, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %135
 
 ; <label>:135                                     ; preds = %132
   store i64 %133, i64* %134, align 8
@@ -916,14 +998,14 @@ entry:
   %137 = load i8*, i8** %arg0
   %138 = load i8*, i8** %arg1
   %139 = bitcast i8* %138 to i64*
-  %NullCheck76 = icmp ne i64* %139, null
-  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+  %NullCheck75 = icmp eq i64* %139, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %140
 
 ; <label>:140                                     ; preds = %136
   %141 = load i64, i64* %139, align 8
   %142 = bitcast i8* %137 to i64*
-  %NullCheck78 = icmp ne i64* %142, null
-  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+  %NullCheck77 = icmp eq i64* %142, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %143
 
 ; <label>:143                                     ; preds = %140
   store i64 %141, i64* %142, align 8
@@ -931,15 +1013,15 @@ entry:
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %NullCheck80 = icmp ne i8* %147, null
-  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+  %NullCheck79 = icmp eq i8* %147, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %148
 
 ; <label>:148                                     ; preds = %143
   %149 = load i8, i8* %147, align 8
   %150 = zext i8 %149 to i32
   %151 = trunc i32 %150 to i8
-  %NullCheck82 = icmp ne i8* %145, null
-  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+  %NullCheck81 = icmp eq i8* %145, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %152
 
 ; <label>:152                                     ; preds = %148
   store i8 %151, i8* %145, align 8
@@ -949,14 +1031,14 @@ entry:
   %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
   %156 = bitcast i8* %155 to i64*
-  %NullCheck68 = icmp ne i64* %156, null
-  br i1 %NullCheck68, label %157, label %ThrowNullRef67
+  %NullCheck67 = icmp eq i64* %156, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %157
 
 ; <label>:157                                     ; preds = %153
   %158 = load i64, i64* %156, align 8
   %159 = bitcast i8* %154 to i64*
-  %NullCheck70 = icmp ne i64* %159, null
-  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+  %NullCheck69 = icmp eq i64* %159, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %160
 
 ; <label>:160                                     ; preds = %157
   store i64 %158, i64* %159, align 8
@@ -965,16 +1047,16 @@ entry:
   %163 = load i8*, i8** %arg1
   %164 = getelementptr inbounds i8, i8* %163, i64 8
   %165 = bitcast i8* %164 to i16*
-  %NullCheck72 = icmp ne i16* %165, null
-  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+  %NullCheck71 = icmp eq i16* %165, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %166
 
 ; <label>:166                                     ; preds = %160
   %167 = load i16, i16* %165, align 8
   %168 = sext i16 %167 to i32
   %169 = bitcast i8* %162 to i16*
   %170 = trunc i32 %168 to i16
-  %NullCheck74 = icmp ne i16* %169, null
-  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+  %NullCheck73 = icmp eq i16* %169, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %171
 
 ; <label>:171                                     ; preds = %166
   store i16 %170, i16* %169, align 8
@@ -984,14 +1066,14 @@ entry:
   %173 = load i8*, i8** %arg0
   %174 = load i8*, i8** %arg1
   %175 = bitcast i8* %174 to i64*
-  %NullCheck56 = icmp ne i64* %175, null
-  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+  %NullCheck55 = icmp eq i64* %175, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %176
 
 ; <label>:176                                     ; preds = %172
   %177 = load i64, i64* %175, align 8
   %178 = bitcast i8* %173 to i64*
-  %NullCheck58 = icmp ne i64* %178, null
-  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+  %NullCheck57 = icmp eq i64* %178, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %179
 
 ; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
@@ -1000,16 +1082,16 @@ entry:
   %182 = load i8*, i8** %arg1
   %183 = getelementptr inbounds i8, i8* %182, i64 8
   %184 = bitcast i8* %183 to i16*
-  %NullCheck60 = icmp ne i16* %184, null
-  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+  %NullCheck59 = icmp eq i16* %184, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %185
 
 ; <label>:185                                     ; preds = %179
   %186 = load i16, i16* %184, align 8
   %187 = sext i16 %186 to i32
   %188 = bitcast i8* %181 to i16*
   %189 = trunc i32 %187 to i16
-  %NullCheck62 = icmp ne i16* %188, null
-  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+  %NullCheck61 = icmp eq i16* %188, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %190
 
 ; <label>:190                                     ; preds = %185
   store i16 %189, i16* %188, align 8
@@ -1017,15 +1099,15 @@ entry:
   %192 = getelementptr inbounds i8, i8* %191, i64 10
   %193 = load i8*, i8** %arg1
   %194 = getelementptr inbounds i8, i8* %193, i64 10
-  %NullCheck64 = icmp ne i8* %194, null
-  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+  %NullCheck63 = icmp eq i8* %194, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %195
 
 ; <label>:195                                     ; preds = %190
   %196 = load i8, i8* %194, align 8
   %197 = zext i8 %196 to i32
   %198 = trunc i32 %197 to i8
-  %NullCheck66 = icmp ne i8* %192, null
-  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+  %NullCheck65 = icmp eq i8* %192, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %199
 
 ; <label>:199                                     ; preds = %195
   store i8 %198, i8* %192, align 8
@@ -1035,14 +1117,14 @@ entry:
   %201 = load i8*, i8** %arg0
   %202 = load i8*, i8** %arg1
   %203 = bitcast i8* %202 to i64*
-  %NullCheck48 = icmp ne i64* %203, null
-  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+  %NullCheck47 = icmp eq i64* %203, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %204
 
 ; <label>:204                                     ; preds = %200
   %205 = load i64, i64* %203, align 8
   %206 = bitcast i8* %201 to i64*
-  %NullCheck50 = icmp ne i64* %206, null
-  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+  %NullCheck49 = icmp eq i64* %206, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %207
 
 ; <label>:207                                     ; preds = %204
   store i64 %205, i64* %206, align 8
@@ -1051,14 +1133,14 @@ entry:
   %210 = load i8*, i8** %arg1
   %211 = getelementptr inbounds i8, i8* %210, i64 8
   %212 = bitcast i8* %211 to i32*
-  %NullCheck52 = icmp ne i32* %212, null
-  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+  %NullCheck51 = icmp eq i32* %212, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %213
 
 ; <label>:213                                     ; preds = %207
   %214 = load i32, i32* %212, align 8
   %215 = bitcast i8* %209 to i32*
-  %NullCheck54 = icmp ne i32* %215, null
-  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+  %NullCheck53 = icmp eq i32* %215, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %216
 
 ; <label>:216                                     ; preds = %213
   store i32 %214, i32* %215, align 8
@@ -1068,14 +1150,14 @@ entry:
   %218 = load i8*, i8** %arg0
   %219 = load i8*, i8** %arg1
   %220 = bitcast i8* %219 to i64*
-  %NullCheck36 = icmp ne i64* %220, null
-  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64* %220, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %221
 
 ; <label>:221                                     ; preds = %217
   %222 = load i64, i64* %220, align 8
   %223 = bitcast i8* %218 to i64*
-  %NullCheck38 = icmp ne i64* %223, null
-  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+  %NullCheck37 = icmp eq i64* %223, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %224
 
 ; <label>:224                                     ; preds = %221
   store i64 %222, i64* %223, align 8
@@ -1084,14 +1166,14 @@ entry:
   %227 = load i8*, i8** %arg1
   %228 = getelementptr inbounds i8, i8* %227, i64 8
   %229 = bitcast i8* %228 to i32*
-  %NullCheck40 = icmp ne i32* %229, null
-  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i32* %229, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %230
 
 ; <label>:230                                     ; preds = %224
   %231 = load i32, i32* %229, align 8
   %232 = bitcast i8* %226 to i32*
-  %NullCheck42 = icmp ne i32* %232, null
-  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+  %NullCheck41 = icmp eq i32* %232, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %233
 
 ; <label>:233                                     ; preds = %230
   store i32 %231, i32* %232, align 8
@@ -1099,15 +1181,15 @@ entry:
   %235 = getelementptr inbounds i8, i8* %234, i64 12
   %236 = load i8*, i8** %arg1
   %237 = getelementptr inbounds i8, i8* %236, i64 12
-  %NullCheck44 = icmp ne i8* %237, null
-  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i8* %237, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %238
 
 ; <label>:238                                     ; preds = %233
   %239 = load i8, i8* %237, align 8
   %240 = zext i8 %239 to i32
   %241 = trunc i32 %240 to i8
-  %NullCheck46 = icmp ne i8* %235, null
-  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+  %NullCheck45 = icmp eq i8* %235, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %242
 
 ; <label>:242                                     ; preds = %238
   store i8 %241, i8* %235, align 8
@@ -1117,14 +1199,14 @@ entry:
   %244 = load i8*, i8** %arg0
   %245 = load i8*, i8** %arg1
   %246 = bitcast i8* %245 to i64*
-  %NullCheck24 = icmp ne i64* %246, null
-  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64* %246, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %247
 
 ; <label>:247                                     ; preds = %243
   %248 = load i64, i64* %246, align 8
   %249 = bitcast i8* %244 to i64*
-  %NullCheck26 = icmp ne i64* %249, null
-  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64* %249, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %250
 
 ; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
@@ -1133,14 +1215,14 @@ entry:
   %253 = load i8*, i8** %arg1
   %254 = getelementptr inbounds i8, i8* %253, i64 8
   %255 = bitcast i8* %254 to i32*
-  %NullCheck28 = icmp ne i32* %255, null
-  br i1 %NullCheck28, label %256, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i32* %255, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %256
 
 ; <label>:256                                     ; preds = %250
   %257 = load i32, i32* %255, align 8
   %258 = bitcast i8* %252 to i32*
-  %NullCheck30 = icmp ne i32* %258, null
-  br i1 %NullCheck30, label %259, label %ThrowNullRef29
+  %NullCheck29 = icmp eq i32* %258, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %259
 
 ; <label>:259                                     ; preds = %256
   store i32 %257, i32* %258, align 8
@@ -1149,16 +1231,16 @@ entry:
   %262 = load i8*, i8** %arg1
   %263 = getelementptr inbounds i8, i8* %262, i64 12
   %264 = bitcast i8* %263 to i16*
-  %NullCheck32 = icmp ne i16* %264, null
-  br i1 %NullCheck32, label %265, label %ThrowNullRef31
+  %NullCheck31 = icmp eq i16* %264, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %265
 
 ; <label>:265                                     ; preds = %259
   %266 = load i16, i16* %264, align 8
   %267 = sext i16 %266 to i32
   %268 = bitcast i8* %261 to i16*
   %269 = trunc i32 %267 to i16
-  %NullCheck34 = icmp ne i16* %268, null
-  br i1 %NullCheck34, label %270, label %ThrowNullRef33
+  %NullCheck33 = icmp eq i16* %268, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %270
 
 ; <label>:270                                     ; preds = %265
   store i16 %269, i16* %268, align 8
@@ -1168,14 +1250,14 @@ entry:
   %272 = load i8*, i8** %arg0
   %273 = load i8*, i8** %arg1
   %274 = bitcast i8* %273 to i64*
-  %NullCheck8 = icmp ne i64* %274, null
-  br i1 %NullCheck8, label %275, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64* %274, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %275
 
 ; <label>:275                                     ; preds = %271
   %276 = load i64, i64* %274, align 8
   %277 = bitcast i8* %272 to i64*
-  %NullCheck10 = icmp ne i64* %277, null
-  br i1 %NullCheck10, label %278, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %277, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %278
 
 ; <label>:278                                     ; preds = %275
   store i64 %276, i64* %277, align 8
@@ -1184,14 +1266,14 @@ entry:
   %281 = load i8*, i8** %arg1
   %282 = getelementptr inbounds i8, i8* %281, i64 8
   %283 = bitcast i8* %282 to i32*
-  %NullCheck12 = icmp ne i32* %283, null
-  br i1 %NullCheck12, label %284, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i32* %283, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %284
 
 ; <label>:284                                     ; preds = %278
   %285 = load i32, i32* %283, align 8
   %286 = bitcast i8* %280 to i32*
-  %NullCheck14 = icmp ne i32* %286, null
-  br i1 %NullCheck14, label %287, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i32* %286, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %287
 
 ; <label>:287                                     ; preds = %284
   store i32 %285, i32* %286, align 8
@@ -1200,16 +1282,16 @@ entry:
   %290 = load i8*, i8** %arg1
   %291 = getelementptr inbounds i8, i8* %290, i64 12
   %292 = bitcast i8* %291 to i16*
-  %NullCheck16 = icmp ne i16* %292, null
-  br i1 %NullCheck16, label %293, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i16* %292, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %293
 
 ; <label>:293                                     ; preds = %287
   %294 = load i16, i16* %292, align 8
   %295 = sext i16 %294 to i32
   %296 = bitcast i8* %289 to i16*
   %297 = trunc i32 %295 to i16
-  %NullCheck18 = icmp ne i16* %296, null
-  br i1 %NullCheck18, label %298, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i16* %296, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %298
 
 ; <label>:298                                     ; preds = %293
   store i16 %297, i16* %296, align 8
@@ -1217,15 +1299,15 @@ entry:
   %300 = getelementptr inbounds i8, i8* %299, i64 14
   %301 = load i8*, i8** %arg1
   %302 = getelementptr inbounds i8, i8* %301, i64 14
-  %NullCheck20 = icmp ne i8* %302, null
-  br i1 %NullCheck20, label %303, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i8* %302, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %303
 
 ; <label>:303                                     ; preds = %298
   %304 = load i8, i8* %302, align 8
   %305 = zext i8 %304 to i32
   %306 = trunc i32 %305 to i8
-  %NullCheck22 = icmp ne i8* %300, null
-  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i8* %300, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %307
 
 ; <label>:307                                     ; preds = %303
   store i8 %306, i8* %300, align 8
@@ -1235,14 +1317,14 @@ entry:
   %309 = load i8*, i8** %arg0
   %310 = load i8*, i8** %arg1
   %311 = bitcast i8* %310 to i64*
-  %NullCheck = icmp ne i64* %311, null
-  br i1 %NullCheck, label %312, label %ThrowNullRef
+  %NullCheck = icmp eq i64* %311, null
+  br i1 %NullCheck, label %ThrowNullRef, label %312
 
 ; <label>:312                                     ; preds = %308
   %313 = load i64, i64* %311, align 8
   %314 = bitcast i8* %309 to i64*
-  %NullCheck2 = icmp ne i64* %314, null
-  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64* %314, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %315
 
 ; <label>:315                                     ; preds = %312
   store i64 %313, i64* %314, align 8
@@ -1251,14 +1333,14 @@ entry:
   %318 = load i8*, i8** %arg1
   %319 = getelementptr inbounds i8, i8* %318, i64 8
   %320 = bitcast i8* %319 to i64*
-  %NullCheck4 = icmp ne i64* %320, null
-  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64* %320, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %321
 
 ; <label>:321                                     ; preds = %315
   %322 = load i64, i64* %320, align 8
   %323 = bitcast i8* %317 to i64*
-  %NullCheck6 = icmp ne i64* %323, null
-  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64* %323, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %324
 
 ; <label>:324                                     ; preds = %321
   store i64 %322, i64* %323, align 8
@@ -1286,15 +1368,15 @@ entry:
 ; <label>:338                                     ; preds = %333
   %339 = load i8*, i8** %arg0
   %340 = load i8*, i8** %arg1
-  %NullCheck136 = icmp ne i8* %340, null
-  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+  %NullCheck135 = icmp eq i8* %340, null
+  br i1 %NullCheck135, label %ThrowNullRef136, label %341
 
 ; <label>:341                                     ; preds = %338
   %342 = load i8, i8* %340, align 8
   %343 = zext i8 %342 to i32
   %344 = trunc i32 %343 to i8
-  %NullCheck138 = icmp ne i8* %339, null
-  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+  %NullCheck137 = icmp eq i8* %339, null
+  br i1 %NullCheck137, label %ThrowNullRef138, label %345
 
 ; <label>:345                                     ; preds = %341
   store i8 %344, i8* %339, align 8
@@ -1317,16 +1399,16 @@ entry:
   %357 = load i8*, i8** %arg0
   %358 = load i8*, i8** %arg1
   %359 = bitcast i8* %358 to i16*
-  %NullCheck140 = icmp ne i16* %359, null
-  br i1 %NullCheck140, label %360, label %ThrowNullRef139
+  %NullCheck139 = icmp eq i16* %359, null
+  br i1 %NullCheck139, label %ThrowNullRef140, label %360
 
 ; <label>:360                                     ; preds = %356
   %361 = load i16, i16* %359, align 8
   %362 = sext i16 %361 to i32
   %363 = bitcast i8* %357 to i16*
   %364 = trunc i32 %362 to i16
-  %NullCheck142 = icmp ne i16* %363, null
-  br i1 %NullCheck142, label %365, label %ThrowNullRef141
+  %NullCheck141 = icmp eq i16* %363, null
+  br i1 %NullCheck141, label %ThrowNullRef142, label %365
 
 ; <label>:365                                     ; preds = %360
   store i16 %364, i16* %363, align 8
@@ -1352,14 +1434,14 @@ entry:
   %378 = load i8*, i8** %arg0
   %379 = load i8*, i8** %arg1
   %380 = bitcast i8* %379 to i32*
-  %NullCheck144 = icmp ne i32* %380, null
-  br i1 %NullCheck144, label %381, label %ThrowNullRef143
+  %NullCheck143 = icmp eq i32* %380, null
+  br i1 %NullCheck143, label %ThrowNullRef144, label %381
 
 ; <label>:381                                     ; preds = %377
   %382 = load i32, i32* %380, align 8
   %383 = bitcast i8* %378 to i32*
-  %NullCheck146 = icmp ne i32* %383, null
-  br i1 %NullCheck146, label %384, label %ThrowNullRef145
+  %NullCheck145 = icmp eq i32* %383, null
+  br i1 %NullCheck145, label %ThrowNullRef146, label %384
 
 ; <label>:384                                     ; preds = %381
   store i32 %382, i32* %383, align 8
@@ -1384,14 +1466,14 @@ entry:
   %395 = load i8*, i8** %arg0
   %396 = load i8*, i8** %arg1
   %397 = bitcast i8* %396 to i64*
-  %NullCheck164 = icmp ne i64* %397, null
-  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+  %NullCheck163 = icmp eq i64* %397, null
+  br i1 %NullCheck163, label %ThrowNullRef164, label %398
 
 ; <label>:398                                     ; preds = %394
   %399 = load i64, i64* %397, align 8
   %400 = bitcast i8* %395 to i64*
-  %NullCheck166 = icmp ne i64* %400, null
-  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+  %NullCheck165 = icmp eq i64* %400, null
+  br i1 %NullCheck165, label %ThrowNullRef166, label %401
 
 ; <label>:401                                     ; preds = %398
   store i64 %399, i64* %400, align 8
@@ -1400,14 +1482,14 @@ entry:
   %404 = load i8*, i8** %arg1
   %405 = getelementptr inbounds i8, i8* %404, i64 8
   %406 = bitcast i8* %405 to i64*
-  %NullCheck168 = icmp ne i64* %406, null
-  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+  %NullCheck167 = icmp eq i64* %406, null
+  br i1 %NullCheck167, label %ThrowNullRef168, label %407
 
 ; <label>:407                                     ; preds = %401
   %408 = load i64, i64* %406, align 8
   %409 = bitcast i8* %403 to i64*
-  %NullCheck170 = icmp ne i64* %409, null
-  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+  %NullCheck169 = icmp eq i64* %409, null
+  br i1 %NullCheck169, label %ThrowNullRef170, label %410
 
 ; <label>:410                                     ; preds = %407
   store i64 %408, i64* %409, align 8
@@ -1437,14 +1519,14 @@ entry:
   %425 = load i8*, i8** %arg0
   %426 = load i8*, i8** %arg1
   %427 = bitcast i8* %426 to i64*
-  %NullCheck148 = icmp ne i64* %427, null
-  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+  %NullCheck147 = icmp eq i64* %427, null
+  br i1 %NullCheck147, label %ThrowNullRef148, label %428
 
 ; <label>:428                                     ; preds = %424
   %429 = load i64, i64* %427, align 8
   %430 = bitcast i8* %425 to i64*
-  %NullCheck150 = icmp ne i64* %430, null
-  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+  %NullCheck149 = icmp eq i64* %430, null
+  br i1 %NullCheck149, label %ThrowNullRef150, label %431
 
 ; <label>:431                                     ; preds = %428
   store i64 %429, i64* %430, align 8
@@ -1466,14 +1548,14 @@ entry:
   %441 = load i8*, i8** %arg0
   %442 = load i8*, i8** %arg1
   %443 = bitcast i8* %442 to i32*
-  %NullCheck152 = icmp ne i32* %443, null
-  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+  %NullCheck151 = icmp eq i32* %443, null
+  br i1 %NullCheck151, label %ThrowNullRef152, label %444
 
 ; <label>:444                                     ; preds = %440
   %445 = load i32, i32* %443, align 8
   %446 = bitcast i8* %441 to i32*
-  %NullCheck154 = icmp ne i32* %446, null
-  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+  %NullCheck153 = icmp eq i32* %446, null
+  br i1 %NullCheck153, label %ThrowNullRef154, label %447
 
 ; <label>:447                                     ; preds = %444
   store i32 %445, i32* %446, align 8
@@ -1495,16 +1577,16 @@ entry:
   %457 = load i8*, i8** %arg0
   %458 = load i8*, i8** %arg1
   %459 = bitcast i8* %458 to i16*
-  %NullCheck156 = icmp ne i16* %459, null
-  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+  %NullCheck155 = icmp eq i16* %459, null
+  br i1 %NullCheck155, label %ThrowNullRef156, label %460
 
 ; <label>:460                                     ; preds = %456
   %461 = load i16, i16* %459, align 8
   %462 = sext i16 %461 to i32
   %463 = bitcast i8* %457 to i16*
   %464 = trunc i32 %462 to i16
-  %NullCheck158 = icmp ne i16* %463, null
-  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+  %NullCheck157 = icmp eq i16* %463, null
+  br i1 %NullCheck157, label %ThrowNullRef158, label %465
 
 ; <label>:465                                     ; preds = %460
   store i16 %464, i16* %463, align 8
@@ -1525,15 +1607,15 @@ entry:
 ; <label>:474                                     ; preds = %470
   %475 = load i8*, i8** %arg0
   %476 = load i8*, i8** %arg1
-  %NullCheck160 = icmp ne i8* %476, null
-  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+  %NullCheck159 = icmp eq i8* %476, null
+  br i1 %NullCheck159, label %ThrowNullRef160, label %477
 
 ; <label>:477                                     ; preds = %474
   %478 = load i8, i8* %476, align 8
   %479 = zext i8 %478 to i32
   %480 = trunc i32 %479 to i8
-  %NullCheck162 = icmp ne i8* %475, null
-  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+  %NullCheck161 = icmp eq i8* %475, null
+  br i1 %NullCheck161, label %ThrowNullRef162, label %481
 
 ; <label>:481                                     ; preds = %477
   store i8 %480, i8* %475, align 8
@@ -1553,343 +1635,343 @@ ThrowNullRef:                                     ; preds = %308
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %312
+ThrowNullRef2:                                    ; preds = %312
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %315
+ThrowNullRef4:                                    ; preds = %315
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %321
+ThrowNullRef6:                                    ; preds = %321
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %271
+ThrowNullRef8:                                    ; preds = %271
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %275
+ThrowNullRef10:                                   ; preds = %275
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %278
+ThrowNullRef12:                                   ; preds = %278
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %284
+ThrowNullRef14:                                   ; preds = %284
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %287
+ThrowNullRef16:                                   ; preds = %287
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %293
+ThrowNullRef18:                                   ; preds = %293
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %298
+ThrowNullRef20:                                   ; preds = %298
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %303
+ThrowNullRef22:                                   ; preds = %303
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %243
+ThrowNullRef24:                                   ; preds = %243
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %247
+ThrowNullRef26:                                   ; preds = %247
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %250
+ThrowNullRef28:                                   ; preds = %250
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %256
+ThrowNullRef30:                                   ; preds = %256
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %259
+ThrowNullRef32:                                   ; preds = %259
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %265
+ThrowNullRef34:                                   ; preds = %265
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %217
+ThrowNullRef36:                                   ; preds = %217
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %221
+ThrowNullRef38:                                   ; preds = %221
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %224
+ThrowNullRef40:                                   ; preds = %224
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %230
+ThrowNullRef42:                                   ; preds = %230
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %233
+ThrowNullRef44:                                   ; preds = %233
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %238
+ThrowNullRef46:                                   ; preds = %238
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %200
+ThrowNullRef48:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %204
+ThrowNullRef50:                                   ; preds = %204
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %207
+ThrowNullRef52:                                   ; preds = %207
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %213
+ThrowNullRef54:                                   ; preds = %213
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %172
+ThrowNullRef56:                                   ; preds = %172
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %176
+ThrowNullRef58:                                   ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %179
+ThrowNullRef60:                                   ; preds = %179
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %185
+ThrowNullRef62:                                   ; preds = %185
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %190
+ThrowNullRef64:                                   ; preds = %190
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %195
+ThrowNullRef66:                                   ; preds = %195
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %153
+ThrowNullRef68:                                   ; preds = %153
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %157
+ThrowNullRef70:                                   ; preds = %157
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %160
+ThrowNullRef72:                                   ; preds = %160
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %166
+ThrowNullRef74:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %136
+ThrowNullRef76:                                   ; preds = %136
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %140
+ThrowNullRef78:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %143
+ThrowNullRef80:                                   ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %148
+ThrowNullRef82:                                   ; preds = %148
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %128
+ThrowNullRef84:                                   ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %132
+ThrowNullRef86:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %100
+ThrowNullRef88:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %104
+ThrowNullRef90:                                   ; preds = %104
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %107
+ThrowNullRef92:                                   ; preds = %107
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %113
+ThrowNullRef94:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %118
+ThrowNullRef96:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %123
+ThrowNullRef98:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %81
+ThrowNullRef100:                                  ; preds = %81
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef101:                                  ; preds = %85
+ThrowNullRef102:                                  ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef103:                                  ; preds = %88
+ThrowNullRef104:                                  ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef105:                                  ; preds = %94
+ThrowNullRef106:                                  ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef107:                                  ; preds = %64
+ThrowNullRef108:                                  ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef109:                                  ; preds = %68
+ThrowNullRef110:                                  ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef111:                                  ; preds = %71
+ThrowNullRef112:                                  ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef113:                                  ; preds = %76
+ThrowNullRef114:                                  ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef115:                                  ; preds = %56
+ThrowNullRef116:                                  ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef117:                                  ; preds = %60
+ThrowNullRef118:                                  ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef119:                                  ; preds = %37
+ThrowNullRef120:                                  ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef121:                                  ; preds = %41
+ThrowNullRef122:                                  ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef123:                                  ; preds = %46
+ThrowNullRef124:                                  ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef125:                                  ; preds = %51
+ThrowNullRef126:                                  ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef127:                                  ; preds = %27
+ThrowNullRef128:                                  ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef129:                                  ; preds = %31
+ThrowNullRef130:                                  ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef131:                                  ; preds = %19
+ThrowNullRef132:                                  ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef133:                                  ; preds = %22
+ThrowNullRef134:                                  ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef135:                                  ; preds = %338
+ThrowNullRef136:                                  ; preds = %338
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef137:                                  ; preds = %341
+ThrowNullRef138:                                  ; preds = %341
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef139:                                  ; preds = %356
+ThrowNullRef140:                                  ; preds = %356
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef141:                                  ; preds = %360
+ThrowNullRef142:                                  ; preds = %360
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef143:                                  ; preds = %377
+ThrowNullRef144:                                  ; preds = %377
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef145:                                  ; preds = %381
+ThrowNullRef146:                                  ; preds = %381
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef147:                                  ; preds = %424
+ThrowNullRef148:                                  ; preds = %424
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef149:                                  ; preds = %428
+ThrowNullRef150:                                  ; preds = %428
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef151:                                  ; preds = %440
+ThrowNullRef152:                                  ; preds = %440
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef153:                                  ; preds = %444
+ThrowNullRef154:                                  ; preds = %444
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef155:                                  ; preds = %456
+ThrowNullRef156:                                  ; preds = %456
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef157:                                  ; preds = %460
+ThrowNullRef158:                                  ; preds = %460
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef159:                                  ; preds = %474
+ThrowNullRef160:                                  ; preds = %474
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef161:                                  ; preds = %477
+ThrowNullRef162:                                  ; preds = %477
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef163:                                  ; preds = %394
+ThrowNullRef164:                                  ; preds = %394
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef165:                                  ; preds = %398
+ThrowNullRef166:                                  ; preds = %398
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef167:                                  ; preds = %401
+ThrowNullRef168:                                  ; preds = %401
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef169:                                  ; preds = %407
+ThrowNullRef170:                                  ; preds = %407
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1939,8 +2021,8 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
-  br i1 %NullCheck, label %22, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %ThrowNullRef, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
@@ -1948,8 +2030,8 @@ entry:
   store i32 %24, i32* %loc0
   %25 = load i32, i32* %loc0
   %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %26, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %27
 
 ; <label>:27                                      ; preds = %22
   %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
@@ -1971,7 +2053,7 @@ ThrowNullRef:                                     ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1989,8 +2071,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -2022,15 +2104,15 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2048,16 +2130,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
   %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
   store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %15
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
@@ -2072,8 +2154,8 @@ entry:
   %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
   %29 = ptrtoint i16 addrspace(1)* %28 to i64
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %19
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
@@ -2089,19 +2171,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2114,8 +2196,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
@@ -2128,7 +2210,7 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[loadElem]
+Failed to read AppDomain.PrepareDataForSetup[storeElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
@@ -2202,8 +2284,8 @@ entry:
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
-  br i1 %NullCheck24, label %27, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = load i64, i64 addrspace(1)* %26
@@ -2218,8 +2300,8 @@ entry:
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
-  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
   %41 = load i64, i64 addrspace(1)* %39
@@ -2236,8 +2318,8 @@ entry:
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
-  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
   %54 = load i64, i64 addrspace(1)* %52
@@ -2252,8 +2334,8 @@ entry:
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
   %67 = load i64, i64 addrspace(1)* %65
@@ -2270,8 +2352,8 @@ entry:
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
-  br i1 %NullCheck16, label %79, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
   %80 = load i64, i64 addrspace(1)* %78
@@ -2286,8 +2368,8 @@ entry:
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
-  br i1 %NullCheck18, label %92, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
   %93 = load i64, i64 addrspace(1)* %91
@@ -2304,8 +2386,8 @@ entry:
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
-  br i1 %NullCheck12, label %105, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = load i64, i64 addrspace(1)* %104
@@ -2320,8 +2402,8 @@ entry:
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
-  br i1 %NullCheck14, label %118, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
   %119 = load i64, i64 addrspace(1)* %117
@@ -2337,8 +2419,8 @@ entry:
 
 ; <label>:128                                     ; preds = %20
   %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
-  br i1 %NullCheck4, label %130, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %129, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %130
 
 ; <label>:130                                     ; preds = %128
   %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
@@ -2346,8 +2428,8 @@ entry:
   %133 = load i16, i16 addrspace(1)* %132, align 8
   %134 = zext i16 %133 to i32
   %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
-  br i1 %NullCheck6, label %136, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %135, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %136
 
 ; <label>:136                                     ; preds = %130
   %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
@@ -2360,8 +2442,8 @@ entry:
 
 ; <label>:143                                     ; preds = %136
   %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
-  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %144, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %145
 
 ; <label>:145                                     ; preds = %143
   %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
@@ -2369,8 +2451,8 @@ entry:
   %148 = load i16, i16 addrspace(1)* %147, align 8
   %149 = zext i16 %148 to i32
   %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %150, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %151
 
 ; <label>:151                                     ; preds = %145
   %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
@@ -2388,8 +2470,8 @@ entry:
 
 ; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
-  br i1 %NullCheck, label %163, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %ThrowNullRef, label %163
 
 ; <label>:163                                     ; preds = %161
   %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
@@ -2399,8 +2481,8 @@ entry:
 
 ; <label>:167                                     ; preds = %163
   %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
-  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %168, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %169
 
 ; <label>:169                                     ; preds = %167
   %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
@@ -2432,55 +2514,55 @@ ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %167
+ThrowNullRef2:                                    ; preds = %167
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %128
+ThrowNullRef4:                                    ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %130
+ThrowNullRef6:                                    ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %143
+ThrowNullRef8:                                    ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %145
+ThrowNullRef10:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %102
+ThrowNullRef12:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %105
+ThrowNullRef14:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %76
+ThrowNullRef16:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %79
+ThrowNullRef18:                                   ; preds = %79
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %50
+ThrowNullRef20:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %53
+ThrowNullRef22:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %24
+ThrowNullRef24:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %27
+ThrowNullRef26:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2503,15 +2585,15 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2519,16 +2601,16 @@ entry:
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
   store i32 %8, i32* %loc0
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
   %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
   store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
@@ -2546,16 +2628,16 @@ entry:
 
 ; <label>:23                                      ; preds = %64
   %24 = load i16*, i16** %loc3
-  %NullCheck12 = icmp ne i16* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i16* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
   store i32 %27, i32* %loc5
   %28 = load i16*, i16** %loc4
-  %NullCheck14 = icmp ne i16* %28, null
-  br i1 %NullCheck14, label %29, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %28, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = load i16, i16* %28, align 8
@@ -2620,15 +2702,15 @@ entry:
 
 ; <label>:67                                      ; preds = %64
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
-  br i1 %NullCheck8, label %69, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %68, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %69
 
 ; <label>:69                                      ; preds = %67
   %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
   %71 = load i32, i32 addrspace(1)* %70
   %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
-  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %73
 
 ; <label>:73                                      ; preds = %69
   %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
@@ -2645,31 +2727,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %67
+ThrowNullRef8:                                    ; preds = %67
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %69
+ThrowNullRef10:                                   ; preds = %69
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2710,14 +2792,14 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
   %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
@@ -2730,14 +2812,14 @@ entry:
 
 ; <label>:11                                      ; preds = %4
   %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
   %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
@@ -2749,14 +2831,14 @@ entry:
 
 ; <label>:22                                      ; preds = %16
   %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
   %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
-  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
-  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
@@ -2804,23 +2886,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2836,7 +2918,280 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[loadElem]
+Successfully read RuntimeType.IsAssignableFrom
+
+define i8 @RuntimeType.IsAssignableFrom(%System.RuntimeType addrspace(1)* %param0, %System.Type addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.RuntimeType addrspace(1)*
+  %arg1 = alloca %System.Type addrspace(1)*
+  %loc0 = alloca %System.RuntimeType addrspace(1)*
+  %loc1 = alloca %"System.Type[]" addrspace(1)*
+  %loc2 = alloca i32
+  store %System.RuntimeType addrspace(1)* %param0, %System.RuntimeType addrspace(1)** %this
+  store %System.Type addrspace(1)* %param1, %System.Type addrspace(1)** %arg1
+  %0 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %1 = icmp ne %System.Type addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i8 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %5 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %6 = bitcast %System.Type addrspace(1)* %4 to %System.Object addrspace(1)*
+  %7 = bitcast %System.RuntimeType addrspace(1)* %5 to %System.Object addrspace(1)*
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %6, %System.Object addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %3
+  ret i8 1
+
+; <label>:12                                      ; preds = %3
+  %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 152
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 32
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
+  %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
+  %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
+  store %System.RuntimeType addrspace(1)* %25, %System.RuntimeType addrspace(1)** %loc0
+  %26 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %27 = icmp eq %System.RuntimeType addrspace(1)* %26, null
+  br i1 %27, label %34, label %28
+
+; <label>:28                                      ; preds = %15
+  %29 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %30 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)*)*)(%System.RuntimeType addrspace(1)* %29, %System.RuntimeType addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+; <label>:34                                      ; preds = %15
+  %35 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %36 = call %System.Reflection.Emit.TypeBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Reflection.Emit.TypeBuilder addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %35)
+  %37 = icmp eq %System.Reflection.Emit.TypeBuilder addrspace(1)* %36, null
+  br i1 %37, label %139, label %38
+
+; <label>:38                                      ; preds = %34
+  %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %42
+
+; <label>:42                                      ; preds = %38
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 152
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 40
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
+  %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
+  %53 = zext i8 %52 to i32
+  %54 = icmp eq i32 %53, 0
+  br i1 %54, label %56, label %55
+
+; <label>:55                                      ; preds = %42
+  ret i8 1
+
+; <label>:56                                      ; preds = %42
+  %57 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %58 = bitcast %System.RuntimeType addrspace(1)* %57 to %System.Type addrspace(1)*
+  %59 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %58)
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %64 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.Type addrspace(1)* %63, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = bitcast %System.RuntimeType addrspace(1)* %64 to %System.Type addrspace(1)*
+  %67 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %63, %System.Type addrspace(1)* %66)
+  %68 = zext i8 %67 to i32
+  %69 = trunc i32 %68 to i8
+  ret i8 %69
+
+; <label>:70                                      ; preds = %56
+  %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
+  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %73
+
+; <label>:73                                      ; preds = %70
+  %74 = load i64, i64 addrspace(1)* %72
+  %75 = add i64 %74, 128
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = add i64 %77, 0
+  %79 = inttoptr i64 %78 to i64*
+  %80 = load i64, i64* %79
+  %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
+  %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
+  %83 = call i8 %82(%System.Type addrspace(1)* %81)
+  %84 = zext i8 %83 to i32
+  %85 = icmp eq i32 %84, 0
+  br i1 %85, label %139, label %86
+
+; <label>:86                                      ; preds = %73
+  %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
+  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %89
+
+; <label>:89                                      ; preds = %86
+  %90 = load i64, i64 addrspace(1)* %88
+  %91 = add i64 %90, 128
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = add i64 %93, 24
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
+  %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
+  %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
+  store %"System.Type[]" addrspace(1)* %99, %"System.Type[]" addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %129
+
+; <label>:100                                     ; preds = %132
+  %101 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %102 = load i32, i32* %loc2
+  %NullCheck11 = icmp eq %"System.Type[]" addrspace(1)* %101, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %103
+
+; <label>:103                                     ; preds = %100
+  %104 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 1
+  %105 = load i32, i32 addrspace(1)* %104
+  %106 = zext i32 %105 to i64
+  %107 = zext i32 %102 to i64
+  %BoundsCheck = icmp uge i64 %107, %106
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %108
+
+; <label>:108                                     ; preds = %103
+  %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
+  %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
+  %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
+  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %113
+
+; <label>:113                                     ; preds = %108
+  %114 = load i64, i64 addrspace(1)* %112
+  %115 = add i64 %114, 152
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = add i64 %117, 56
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
+  %123 = zext i8 %122 to i32
+  %124 = icmp ne i32 %123, 0
+  br i1 %124, label %126, label %125
+
+; <label>:125                                     ; preds = %113
+  ret i8 0
+
+; <label>:126                                     ; preds = %113
+  %127 = load i32, i32* %loc2
+  %128 = add i32 %127, 1
+  store i32 %128, i32* %loc2
+  br label %129
+
+; <label>:129                                     ; preds = %89, %126
+  %130 = load i32, i32* %loc2
+  %131 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %NullCheck9 = icmp eq %"System.Type[]" addrspace(1)* %131, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %132
+
+; <label>:132                                     ; preds = %129
+  %133 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %131, i32 0, i32 1
+  %134 = load i32, i32 addrspace(1)* %133
+  %135 = zext i32 %134 to i64
+  %136 = trunc i64 %135 to i32
+  %137 = icmp slt i32 %130, %136
+  br i1 %137, label %100, label %138
+
+; <label>:138                                     ; preds = %132
+  ret i8 1
+
+; <label>:139                                     ; preds = %34, %73
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %129
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %103
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -2893,7 +3248,7 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElem]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -2904,8 +3259,8 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -2997,8 +3352,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
@@ -3059,8 +3414,8 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -3087,8 +3442,8 @@ entry:
 
 ; <label>:17                                      ; preds = %5, %11
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
@@ -3097,8 +3452,8 @@ entry:
 
 ; <label>:22                                      ; preds = %1, %11
   %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
@@ -3109,11 +3464,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %17
+ThrowNullRef2:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %22
+ThrowNullRef4:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3167,15 +3522,15 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
   %15 = load i32, i32 addrspace(1)* %14
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
@@ -3198,7 +3553,7 @@ ThrowNullRef:                                     ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef2:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3232,8 +3587,8 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
@@ -3312,8 +3667,8 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -3327,8 +3682,8 @@ entry:
 ; <label>:5                                       ; preds = %43
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %7 = load i32, i32* %loc1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck6, label %8, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
@@ -3366,8 +3721,8 @@ entry:
 ; <label>:32                                      ; preds = %21, %25
   %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
   %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
-  br i1 %NullCheck8, label %35, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = trunc i32 %34 to i16
@@ -3380,8 +3735,8 @@ entry:
 ; <label>:40                                      ; preds = %1, %35
   %41 = load i32, i32* %loc1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
-  br i1 %NullCheck2, label %43, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %42, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
@@ -3392,8 +3747,8 @@ entry:
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
   %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
-  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
   %51 = load i64, i64 addrspace(1)* %49
@@ -3412,19 +3767,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %40
+ThrowNullRef2:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %47
+ThrowNullRef4:                                    ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %5
+ThrowNullRef6:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %32
+ThrowNullRef8:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3467,8 +3822,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
@@ -3492,11 +3847,391 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(i16* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store i16* %param0, i16** %arg0
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load i32, i32* %arg3
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %42, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %37, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg2
+  %13 = load i32, i32* %arg3
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %37, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %24 = load i32, i32* %arg2
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load i16*, i16** %arg0
+  %35 = load i32, i32* %arg3
+  %36 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %36, i16* %34, i32 %35)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:37                                      ; preds = %5, %16
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %39)
+  %41 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41, %System.String addrspace(1)* %38, %System.String addrspace(1)* %40)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41) #0
+  unreachable
+
+; <label>:42                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
-Failed to read StringBuilder.ToString[loadElemA]
+Successfully read StringBuilder.ToString
+
+define %System.String addrspace(1)* @StringBuilder.ToString(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i16*
+  %loc3 = alloca %"System.Char[]" addrspace(1)*
+  %loc4 = alloca i32
+  %loc5 = alloca i32
+  %loc6 = alloca i16 addrspace(1)*
+  %loc7 = alloca %System.String addrspace(1)*
+  %loc8 = alloca %"System.Char[]" addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %0)
+  %2 = icmp ne i32 %1, 0
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %4
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %6)
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %7)
+  store %System.String addrspace(1)* %8, %System.String addrspace(1)** %loc0
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.Text.StringBuilder addrspace(1)* %9, %System.Text.StringBuilder addrspace(1)** %loc1
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  store %System.String addrspace(1)* %10, %System.String addrspace(1)** %loc7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc7
+  %12 = ptrtoint %System.String addrspace(1)* %11 to i64
+  %13 = icmp eq i64 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %5
+  %15 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %16 = sext i32 %15 to i64
+  %17 = add i64 %12, %16
+  br label %18
+
+; <label>:18                                      ; preds = %5, %14
+  %19 = phi i64 [ %12, %5 ], [ %17, %14 ]
+  %20 = inttoptr i64 %19 to i16*
+  store i16* %20, i16** %loc2
+  br label %21
+
+; <label>:21                                      ; preds = %98, %18
+  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %22, null
+  br i1 %NullCheck, label %ThrowNullRef, label %23
+
+; <label>:23                                      ; preds = %21
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 3
+  %25 = load i32, i32 addrspace(1)* %24, align 8
+  %26 = icmp sle i32 %25, 0
+  br i1 %26, label %96, label %27
+
+; <label>:27                                      ; preds = %23
+  %28 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %28, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %29
+
+; <label>:29                                      ; preds = %27
+  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %28, i32 0, i32 1
+  %31 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %30, align 8
+  store %"System.Char[]" addrspace(1)* %31, %"System.Char[]" addrspace(1)** %loc3
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %33
+
+; <label>:33                                      ; preds = %29
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  store i32 %35, i32* %loc4
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  %39 = load i32, i32 addrspace(1)* %38, align 8
+  store i32 %39, i32* %loc5
+  %40 = load i32, i32* %loc5
+  %41 = load i32, i32* %loc4
+  %42 = add i32 %40, %41
+  %43 = zext i32 %42 to i64
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %45
+
+; <label>:45                                      ; preds = %37
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = sext i32 %47 to i64
+  %49 = icmp sgt i64 %43, %48
+  br i1 %49, label %91, label %50
+
+; <label>:50                                      ; preds = %45
+  %51 = load i32, i32* %loc5
+  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %52, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %53
+
+; <label>:53                                      ; preds = %50
+  %54 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %52, i32 0, i32 1
+  %55 = load i32, i32 addrspace(1)* %54
+  %56 = zext i32 %55 to i64
+  %57 = trunc i64 %56 to i32
+  %58 = icmp ugt i32 %51, %57
+  br i1 %58, label %91, label %59
+
+; <label>:59                                      ; preds = %53
+  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  store %"System.Char[]" addrspace(1)* %60, %"System.Char[]" addrspace(1)** %loc8
+  %61 = icmp eq %"System.Char[]" addrspace(1)* %60, null
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %63, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %64
+
+; <label>:64                                      ; preds = %62
+  %65 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %63, i32 0, i32 1
+  %66 = load i32, i32 addrspace(1)* %65
+  %67 = zext i32 %66 to i64
+  %68 = trunc i64 %67 to i32
+  %69 = icmp ne i32 %68, 0
+  br i1 %69, label %71, label %70
+
+; <label>:70                                      ; preds = %59, %64
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:71                                      ; preds = %64
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %73
+
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %BoundsCheck = icmp uge i64 0, %76
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %77
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %78, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:79                                      ; preds = %70, %77
+  %80 = load i16*, i16** %loc2
+  %81 = load i32, i32* %loc4
+  %82 = sext i32 %81 to i64
+  %83 = mul i64 %82, 2
+  %84 = bitcast i16* %80 to i8*
+  %85 = getelementptr inbounds i8, i8* %84, i64 %83
+  %86 = load i16 addrspace(1)*, i16 addrspace(1)** %loc6
+  %87 = ptrtoint i16 addrspace(1)* %86 to i64
+  %88 = load i32, i32* %loc5
+  %89 = bitcast i8* %85 to i16*
+  %90 = inttoptr i64 %87 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %89, i16* %90, i32 %88)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %96
+
+; <label>:91                                      ; preds = %45, %53
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %94 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %93)
+  %95 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95, %System.String addrspace(1)* %92, %System.String addrspace(1)* %94)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95) #0
+  unreachable
+
+; <label>:96                                      ; preds = %23, %79
+  %97 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %97, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %98
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %97, i32 0, i32 2
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  store %System.Text.StringBuilder addrspace(1)* %100, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %102 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %102, label %21, label %103
+
+; <label>:103                                     ; preds = %98
+  store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc7
+  %104 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  ret %System.String addrspace(1)* %104
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method StringBuilder::get_Length using LLILCJit
+Successfully read StringBuilder.get_Length
+
+define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
+Successfully read RuntimeHelpers.get_OffsetToStringData
+
+define i32 @RuntimeHelpers.get_OffsetToStringData() {
+entry:
+  ret i32 12
+}
+
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
 Successfully read CultureData.CreateCultureData
 
@@ -3514,23 +4249,23 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
   store i8 %4, i8 addrspace(1)* %6
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
@@ -3549,11 +4284,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3566,50 +4301,50 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
   store i32 -1, i32 addrspace(1)* %2
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
   store i32 -1, i32 addrspace(1)* %8
   %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
   store i32 -1, i32 addrspace(1)* %14
   %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
   store i32 -1, i32 addrspace(1)* %17
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
@@ -3623,27 +4358,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3675,7 +4410,136 @@ Failed to read Dictionary`2.Insert[non-const derefAddress]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
 Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
-Failed to read HashHelpers.GetPrime[loadElem]
+Successfully read HashHelpers.GetPrime
+
+define i32 @HashHelpers.GetPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %6, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5, %System.String addrspace(1)* %4)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5) #0
+  unreachable
+
+; <label>:6                                       ; preds = %entry
+  store i32 0, i32* %loc0
+  br label %29
+
+; <label>:7                                       ; preds = %35
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 1296
+  %10 = addrspacecast i8 addrspace(1)* %9 to %"System.Int32[]" addrspace(1)**
+  %11 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %10
+  %12 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Int32[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = zext i32 %15 to i64
+  %17 = zext i32 %12 to i64
+  %BoundsCheck = icmp uge i64 %17, %16
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 3, i32 %12
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  store i32 %20, i32* %loc1
+  %21 = load i32, i32* %loc1
+  %22 = load i32, i32* %arg0
+  %23 = icmp slt i32 %21, %22
+  br i1 %23, label %26, label %24
+
+; <label>:24                                      ; preds = %18
+  %25 = load i32, i32* %loc1
+  ret i32 %25
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %loc0
+  %28 = add i32 %27, 1
+  store i32 %28, i32* %loc0
+  br label %29
+
+; <label>:29                                      ; preds = %6, %26
+  %30 = load i32, i32* %loc0
+  %31 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %32 = getelementptr inbounds i8, i8 addrspace(1)* %31, i64 1296
+  %33 = addrspacecast i8 addrspace(1)* %32 to %"System.Int32[]" addrspace(1)**
+  %34 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %33
+  %NullCheck = icmp eq %"System.Int32[]" addrspace(1)* %34, null
+  br i1 %NullCheck, label %ThrowNullRef, label %35
+
+; <label>:35                                      ; preds = %29
+  %36 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %34, i32 0, i32 1
+  %37 = load i32, i32 addrspace(1)* %36
+  %38 = zext i32 %37 to i64
+  %39 = trunc i64 %38 to i32
+  %40 = icmp slt i32 %30, %39
+  br i1 %40, label %7, label %41
+
+; <label>:41                                      ; preds = %35
+  %42 = load i32, i32* %arg0
+  %43 = or i32 %42, 1
+  store i32 %43, i32* %loc2
+  br label %59
+
+; <label>:44                                      ; preds = %59
+  %45 = load i32, i32* %loc2
+  %46 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %45)
+  %47 = zext i8 %46 to i32
+  %48 = icmp eq i32 %47, 0
+  br i1 %48, label %56, label %49
+
+; <label>:49                                      ; preds = %44
+  %50 = load i32, i32* %loc2
+  %51 = sub i32 %50, 1
+  %52 = srem i32 %51, 101
+  %53 = icmp eq i32 %52, 0
+  br i1 %53, label %56, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = load i32, i32* %loc2
+  ret i32 %55
+
+; <label>:56                                      ; preds = %44, %49
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %57, 2
+  store i32 %58, i32* %loc2
+  br label %59
+
+; <label>:59                                      ; preds = %41, %56
+  %60 = load i32, i32* %loc2
+  %61 = icmp slt i32 %60, 2147483647
+  br i1 %61, label %44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load i32, i32* %arg0
+  ret i32 %63
+
+ThrowNullRef:                                     ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
 Successfully read GenericEqualityComparer`1.GetHashCode
 
@@ -3694,14 +4558,14 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
   %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load i64, i64 addrspace(1)* %7
@@ -3720,7 +4584,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3750,8 +4614,8 @@ entry:
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
@@ -3796,8 +4660,8 @@ entry:
   %35 = bitcast i16* %34 to i8*
   %36 = getelementptr inbounds i8, i8* %35, i64 2
   %37 = bitcast i8* %36 to i16*
-  %NullCheck4 = icmp ne i16* %37, null
-  br i1 %NullCheck4, label %38, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %37, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %38
 
 ; <label>:38                                      ; preds = %27
   %39 = load i16, i16* %37, align 8
@@ -3824,8 +4688,8 @@ entry:
 
 ; <label>:54                                      ; preds = %22, %43
   %55 = load i16*, i16** %loc4
-  %NullCheck2 = icmp ne i16* %55, null
-  br i1 %NullCheck2, label %56, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i16* %55, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %56
 
 ; <label>:56                                      ; preds = %54
   %57 = load i16, i16* %55, align 8
@@ -3850,11 +4714,11 @@ ThrowNullRef:                                     ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %54
+ThrowNullRef2:                                    ; preds = %54
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %27
+ThrowNullRef4:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3871,8 +4735,8 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -3907,8 +4771,8 @@ entry:
 
 ; <label>:26                                      ; preds = %19
   %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
-  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %28
 
 ; <label>:28                                      ; preds = %26
   %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
@@ -3920,7 +4784,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3972,8 +4836,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
@@ -3984,26 +4848,26 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
-  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
@@ -4014,8 +4878,8 @@ entry:
 ; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
@@ -4024,8 +4888,8 @@ entry:
 
 ; <label>:25                                      ; preds = %1, %16, %23
   %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
-  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
@@ -4036,27 +4900,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %20
+ThrowNullRef10:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4069,8 +4933,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -4081,8 +4945,8 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
@@ -4091,8 +4955,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1, %8
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
@@ -4103,11 +4967,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4128,24 +4992,24 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   store i32 %3, i32* %loc0
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
   %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
   store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck4, label %9, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
@@ -4164,15 +5028,15 @@ entry:
 ; <label>:18                                      ; preds = %70
   %19 = load i16*, i16** %loc3
   %20 = bitcast i16* %19 to i64*
-  %NullCheck10 = icmp ne i64* %20, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %20, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = load i64, i64* %20, align 8
   %23 = load i16*, i16** %loc4
   %24 = bitcast i16* %23 to i64*
-  %NullCheck12 = icmp ne i64* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = load i64, i64* %24, align 8
@@ -4188,8 +5052,8 @@ entry:
   %31 = bitcast i16* %30 to i8*
   %32 = getelementptr inbounds i8, i8* %31, i64 8
   %33 = bitcast i8* %32 to i64*
-  %NullCheck14 = icmp ne i64* %33, null
-  br i1 %NullCheck14, label %34, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = load i64, i64* %33, align 8
@@ -4197,8 +5061,8 @@ entry:
   %37 = bitcast i16* %36 to i8*
   %38 = getelementptr inbounds i8, i8* %37, i64 8
   %39 = bitcast i8* %38 to i64*
-  %NullCheck16 = icmp ne i64* %39, null
-  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %40
 
 ; <label>:40                                      ; preds = %34
   %41 = load i64, i64* %39, align 8
@@ -4214,8 +5078,8 @@ entry:
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %NullCheck18 = icmp ne i64* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = load i64, i64* %48, align 8
@@ -4223,8 +5087,8 @@ entry:
   %52 = bitcast i16* %51 to i8*
   %53 = getelementptr inbounds i8, i8* %52, i64 16
   %54 = bitcast i8* %53 to i64*
-  %NullCheck20 = icmp ne i64* %54, null
-  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64* %54, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %55
 
 ; <label>:55                                      ; preds = %49
   %56 = load i64, i64* %54, align 8
@@ -4262,15 +5126,15 @@ entry:
 ; <label>:74                                      ; preds = %95
   %75 = load i16*, i16** %loc3
   %76 = bitcast i16* %75 to i32*
-  %NullCheck6 = icmp ne i32* %76, null
-  br i1 %NullCheck6, label %77, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32* %76, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %77
 
 ; <label>:77                                      ; preds = %74
   %78 = load i32, i32* %76, align 8
   %79 = load i16*, i16** %loc4
   %80 = bitcast i16* %79 to i32*
-  %NullCheck8 = icmp ne i32* %80, null
-  br i1 %NullCheck8, label %81, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i32* %80, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %81
 
 ; <label>:81                                      ; preds = %77
   %82 = load i32, i32* %80, align 8
@@ -4318,43 +5182,43 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %74
+ThrowNullRef6:                                    ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %77
+ThrowNullRef8:                                    ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %29
+ThrowNullRef14:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %34
+ThrowNullRef16:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4376,8 +5240,8 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load i64, i64 addrspace(1)* %4
@@ -4389,8 +5253,8 @@ entry:
   %12 = load i64, i64* %11
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %5
   %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
@@ -4399,8 +5263,8 @@ entry:
   %18 = load i8, i8* %arg2
   %19 = zext i8 %18 to i32
   %20 = trunc i32 %19 to i8
-  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %15
   %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
@@ -4411,11 +5275,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4442,8 +5306,8 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
@@ -4466,16 +5330,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
   %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = load i64, i64 addrspace(1)* %19
@@ -4500,8 +5364,8 @@ entry:
 ; <label>:35                                      ; preds = %30
   %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
@@ -4514,8 +5378,8 @@ entry:
 
 ; <label>:42                                      ; preds = %1, %38
   %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
-  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
@@ -4526,19 +5390,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %35
+ThrowNullRef2:                                    ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %42
+ThrowNullRef8:                                    ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4551,14 +5415,14 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
@@ -4570,7 +5434,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4583,8 +5447,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
@@ -4613,51 +5477,51 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
   %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
   %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
   %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
   %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
-  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
   store i64 %21, i64 addrspace(1)* %23
   %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %25 = load i64, i64* %loc0
-  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
@@ -4668,27 +5532,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %22
+ThrowNullRef12:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4701,8 +5565,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
@@ -4713,19 +5577,19 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
@@ -4734,8 +5598,8 @@ entry:
 
 ; <label>:15                                      ; preds = %1, %13
   %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
@@ -4746,19 +5610,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %15
+ThrowNullRef8:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4771,8 +5635,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -4831,8 +5695,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
@@ -4882,8 +5746,8 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
-  br i1 %NullCheck, label %17, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %ThrowNullRef, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
@@ -4894,15 +5758,15 @@ entry:
 
 ; <label>:22                                      ; preds = %17
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
-  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
   %26 = load i32, i32 addrspace(1)* %25
   %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
-  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %27, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
@@ -4925,8 +5789,8 @@ entry:
 ; <label>:40                                      ; preds = %17
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
-  br i1 %NullCheck6, label %43, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %41, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
@@ -4938,34 +5802,17 @@ ThrowNullRef:                                     ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %24
+ThrowNullRef4:                                    ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %40
+ThrowNullRef6:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
-}
-
-INFO:  jitting method Object::ReferenceEquals using LLILCJit
-Successfully read Object.ReferenceEquals
-
-define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
-entry:
-  %arg0 = alloca %System.Object addrspace(1)*
-  %arg1 = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
-  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
-  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = icmp eq %System.Object addrspace(1)* %0, %1
-  %3 = sext i1 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
 }
 
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
@@ -4978,21 +5825,21 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
   %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
-  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
@@ -5007,28 +5854,28 @@ entry:
 ; <label>:13                                      ; preds = %8, %12
   %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
   %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
   %21 = load i32, i32 addrspace(1)* %20, align 8
   %22 = add i32 %21, 1
-  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
   store i32 %22, i32 addrspace(1)* %24
   %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
@@ -5039,27 +5886,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5077,7 +5924,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::Setup using LLILCJit
-Failed to read AppDomain.Setup[loadElem]
+Failed to read AppDomain.Setup[unbox]
 INFO:  jitting method Thread::GetDomain using LLILCJit
 Successfully read Thread.GetDomain
 
@@ -5108,8 +5955,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
@@ -5122,14 +5969,14 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
   %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
@@ -5141,11 +5988,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5173,8 +6020,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -5189,7 +6036,328 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
 Failed to read KeyCollection.System.Collections.Generic.IEnumerable<TKey>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Successfully read Enumerator.MoveNext
+
+define i8 @Enumerator.MoveNext(%"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.RuntimeTypeHandle* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*
+  %"$TypeArg" = alloca %System.RuntimeTypeHandle*
+  store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
+  %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 8
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %76, label %12
+
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
+  br label %76
+
+; <label>:13                                      ; preds = %85
+  %14 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck19 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %15
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, i32 0, i32 0
+  %17 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %16, align 8
+  %NullCheck21 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, i32 0, i32 2
+  %20 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %19, align 8
+  %21 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck23 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %22
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, i32 0, i32 2
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %NullCheck25 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 3, i32 %24
+  %NullCheck27 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %32
+
+; <label>:32                                      ; preds = %30
+  %33 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, i32 0, i32 2
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = icmp slt i32 %34, 0
+  br i1 %35, label %68, label %36
+
+; <label>:36                                      ; preds = %32
+  %37 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %38 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck29 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %39
+
+; <label>:39                                      ; preds = %36
+  %40 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, i32 0, i32 0
+  %41 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %40, align 8
+  %NullCheck31 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, i32 0, i32 2
+  %44 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %43, align 8
+  %45 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck33 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, i32 0, i32 2
+  %48 = load i32, i32 addrspace(1)* %47, align 8
+  %NullCheck35 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %49
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = zext i32 %51 to i64
+  %53 = zext i32 %48 to i64
+  %BoundsCheck37 = icmp uge i64 %53, %52
+  br i1 %BoundsCheck37, label %ThrowIndexOutOfRange38, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 3, i32 %48
+  %NullCheck39 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %56
+
+; <label>:56                                      ; preds = %54
+  %57 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, i32 0, i32 0
+  %58 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck41 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %59
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %60, %System.__Canon addrspace(1)* %58)
+  %61 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck43 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  %64 = load i32, i32 addrspace(1)* %63, align 8
+  %65 = add i32 %64, 1
+  %NullCheck45 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  store i32 %65, i32 addrspace(1)* %67
+  ret i8 1
+
+; <label>:68                                      ; preds = %32
+  %69 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck47 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %73 = add i32 %72, 1
+  %NullCheck49 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %74
+
+; <label>:74                                      ; preds = %70
+  %75 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  store i32 %73, i32 addrspace(1)* %75
+  br label %76
+
+; <label>:76                                      ; preds = %8, %12, %74
+  %77 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %78
+
+; <label>:78                                      ; preds = %76
+  %79 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, i32 0, i32 2
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck7 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %82
+
+; <label>:82                                      ; preds = %78
+  %83 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, i32 0, i32 0
+  %84 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %83, align 8
+  %NullCheck9 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %85
+
+; <label>:85                                      ; preds = %82
+  %86 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, i32 0, i32 7
+  %87 = load i32, i32 addrspace(1)* %86, align 8
+  %88 = icmp ult i32 %80, %87
+  br i1 %88, label %13, label %89
+
+; <label>:89                                      ; preds = %85
+  %90 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %91 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck11 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %92
+
+; <label>:92                                      ; preds = %89
+  %93 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, i32 0, i32 0
+  %94 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck13 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %95
+
+; <label>:95                                      ; preds = %92
+  %96 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, i32 0, i32 7
+  %97 = load i32, i32 addrspace(1)* %96, align 8
+  %98 = add i32 %97, 1
+  %NullCheck15 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %99
+
+; <label>:99                                      ; preds = %95
+  %100 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, i32 0, i32 2
+  store i32 %98, i32 addrspace(1)* %100
+  %101 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck17 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %102
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %103, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %92
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef22:                                   ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef24:                                   ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef26:                                   ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef28:                                   ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef30:                                   ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef32:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef34:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef36:                                   ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange38:                           ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef40:                                   ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef42:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef44:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef46:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef48:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef50:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -5200,8 +6368,8 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -5232,9 +6400,9 @@ Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
 Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
-Failed to read String.MakeSeparatorList[loadElemA]
+Failed to read String.MakeSeparatorList[storeElem]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
-Failed to read String.InternalSplitKeepEmptyEntries[loadElem]
+Failed to read String.InternalSplitKeepEmptyEntries[storeElem]
 INFO:  jitting method Path::IsRelative using LLILCJit
 Successfully read Path.IsRelative
 
@@ -5243,8 +6411,8 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -5254,8 +6422,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
@@ -5271,8 +6439,8 @@ entry:
 
 ; <label>:17                                      ; preds = %7
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
@@ -5288,8 +6456,8 @@ entry:
 
 ; <label>:29                                      ; preds = %19
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %31
 
 ; <label>:31                                      ; preds = %29
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
@@ -5300,8 +6468,8 @@ entry:
 
 ; <label>:36                                      ; preds = %31
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
-  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %37, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
@@ -5312,8 +6480,8 @@ entry:
 
 ; <label>:43                                      ; preds = %31, %38
   %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
-  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %45
 
 ; <label>:45                                      ; preds = %43
   %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
@@ -5324,8 +6492,8 @@ entry:
 
 ; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %50
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
@@ -5336,8 +6504,8 @@ entry:
 
 ; <label>:57                                      ; preds = %1, %7, %19, %45, %52
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
-  br i1 %NullCheck14, label %59, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %59
 
 ; <label>:59                                      ; preds = %57
   %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
@@ -5347,8 +6515,8 @@ entry:
 
 ; <label>:63                                      ; preds = %59
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
@@ -5359,8 +6527,8 @@ entry:
 
 ; <label>:70                                      ; preds = %65
   %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
-  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.String addrspace(1)* %71, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %72
 
 ; <label>:72                                      ; preds = %70
   %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
@@ -5379,39 +6547,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %17
+ThrowNullRef4:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %29
+ThrowNullRef6:                                    ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %36
+ThrowNullRef8:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %43
+ThrowNullRef10:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %50
+ThrowNullRef12:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %57
+ThrowNullRef14:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %63
+ThrowNullRef16:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %70
+ThrowNullRef18:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5419,7 +6587,293 @@ ThrowNullRef17:                                   ; preds = %70
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
-Failed to read String.TrimHelper[loadElem]
+Successfully read String.TrimHelper
+
+define %System.String addrspace(1)* @String.TrimHelper(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i16
+  %loc4 = alloca i32
+  %loc5 = alloca i16
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = sub i32 %3, 1
+  store i32 %4, i32* %loc0
+  store i32 0, i32* %loc1
+  %5 = load i32, i32* %arg2
+  %6 = icmp eq i32 %5, 1
+  br i1 %6, label %62, label %7
+
+; <label>:7                                       ; preds = %1
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:8                                       ; preds = %58
+  store i32 0, i32* %loc2
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load i32, i32* %loc1
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2, i32 %10
+  %13 = load i16, i16 addrspace(1)* %12
+  %14 = zext i16 %13 to i32
+  %15 = trunc i32 %14 to i16
+  store i16 %15, i16* %loc3
+  store i32 0, i32* %loc2
+  br label %34
+
+; <label>:16                                      ; preds = %37
+  %17 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %18 = load i32, i32* %loc2
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %17, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %19
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = zext i32 %18 to i64
+  %BoundsCheck = icmp uge i64 %23, %22
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %24
+
+; <label>:24                                      ; preds = %19
+  %25 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 3, i32 %18
+  %26 = load i16, i16 addrspace(1)* %25, align 8
+  %27 = zext i16 %26 to i32
+  %28 = load i16, i16* %loc3
+  %29 = zext i16 %28 to i32
+  %30 = icmp eq i32 %27, %29
+  br i1 %30, label %43, label %31
+
+; <label>:31                                      ; preds = %24
+  %32 = load i32, i32* %loc2
+  %33 = add i32 %32, 1
+  store i32 %33, i32* %loc2
+  br label %34
+
+; <label>:34                                      ; preds = %11, %31
+  %35 = load i32, i32* %loc2
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = icmp slt i32 %35, %41
+  br i1 %42, label %16, label %43
+
+; <label>:43                                      ; preds = %24, %37
+  %44 = load i32, i32* %loc2
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %45, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp eq i32 %44, %50
+  br i1 %51, label %62, label %52
+
+; <label>:52                                      ; preds = %46
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %7, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %57, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %58
+
+; <label>:58                                      ; preds = %55
+  %59 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %60 = load i32, i32 addrspace(1)* %59
+  %61 = icmp slt i32 %56, %60
+  br i1 %61, label %8, label %62
+
+; <label>:62                                      ; preds = %1, %46, %58
+  %63 = load i32, i32* %arg2
+  %64 = icmp eq i32 %63, 0
+  br i1 %64, label %122, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %66, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %67
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %66, i32 0, i32 1
+  %69 = load i32, i32 addrspace(1)* %68
+  %70 = sub i32 %69, 1
+  store i32 %70, i32* %loc0
+  br label %118
+
+; <label>:71                                      ; preds = %118
+  store i32 0, i32* %loc4
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %73 = load i32, i32* %loc0
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %74
+
+; <label>:74                                      ; preds = %71
+  %75 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 2, i32 %73
+  %76 = load i16, i16 addrspace(1)* %75
+  %77 = zext i16 %76 to i32
+  %78 = trunc i32 %77 to i16
+  store i16 %78, i16* %loc5
+  store i32 0, i32* %loc4
+  br label %97
+
+; <label>:79                                      ; preds = %100
+  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %81 = load i32, i32* %loc4
+  %NullCheck19 = icmp eq %"System.Char[]" addrspace(1)* %80, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
+
+; <label>:82                                      ; preds = %79
+  %83 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 1
+  %84 = load i32, i32 addrspace(1)* %83
+  %85 = zext i32 %84 to i64
+  %86 = zext i32 %81 to i64
+  %BoundsCheck21 = icmp uge i64 %86, %85
+  br i1 %BoundsCheck21, label %ThrowIndexOutOfRange22, label %87
+
+; <label>:87                                      ; preds = %82
+  %88 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 3, i32 %81
+  %89 = load i16, i16 addrspace(1)* %88, align 8
+  %90 = zext i16 %89 to i32
+  %91 = load i16, i16* %loc5
+  %92 = zext i16 %91 to i32
+  %93 = icmp eq i32 %90, %92
+  br i1 %93, label %106, label %94
+
+; <label>:94                                      ; preds = %87
+  %95 = load i32, i32* %loc4
+  %96 = add i32 %95, 1
+  store i32 %96, i32* %loc4
+  br label %97
+
+; <label>:97                                      ; preds = %74, %94
+  %98 = load i32, i32* %loc4
+  %99 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck15 = icmp eq %"System.Char[]" addrspace(1)* %99, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %100
+
+; <label>:100                                     ; preds = %97
+  %101 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %99, i32 0, i32 1
+  %102 = load i32, i32 addrspace(1)* %101
+  %103 = zext i32 %102 to i64
+  %104 = trunc i64 %103 to i32
+  %105 = icmp slt i32 %98, %104
+  br i1 %105, label %79, label %106
+
+; <label>:106                                     ; preds = %87, %100
+  %107 = load i32, i32* %loc4
+  %108 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck17 = icmp eq %"System.Char[]" addrspace(1)* %108, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %109
+
+; <label>:109                                     ; preds = %106
+  %110 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %108, i32 0, i32 1
+  %111 = load i32, i32 addrspace(1)* %110
+  %112 = zext i32 %111 to i64
+  %113 = trunc i64 %112 to i32
+  %114 = icmp eq i32 %107, %113
+  br i1 %114, label %122, label %115
+
+; <label>:115                                     ; preds = %109
+  %116 = load i32, i32* %loc0
+  %117 = sub i32 %116, 1
+  store i32 %117, i32* %loc0
+  br label %118
+
+; <label>:118                                     ; preds = %67, %115
+  %119 = load i32, i32* %loc0
+  %120 = load i32, i32* %loc1
+  %121 = icmp sge i32 %119, %120
+  br i1 %121, label %71, label %122
+
+; <label>:122                                     ; preds = %62, %109, %118
+  %123 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %124 = load i32, i32* %loc1
+  %125 = load i32, i32* %loc0
+  %126 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %123, i32 %124, i32 %125)
+  ret %System.String addrspace(1)* %126
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %97
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange22:                           ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
 Successfully read String.CreateTrimmedString
 
@@ -5439,8 +6893,8 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
@@ -5535,8 +6989,8 @@ entry:
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i64 2872
   %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
   %8 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %7
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %3
   %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
@@ -5553,8 +7007,8 @@ entry:
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 2864
   %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
   %21 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %20
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
-  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %22
 
 ; <label>:22                                      ; preds = %16
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
@@ -5569,7 +7023,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %16
+ThrowNullRef2:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5586,8 +7040,8 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5613,8 +7067,8 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
@@ -5632,8 +7086,8 @@ entry:
 
 ; <label>:12                                      ; preds = %4
   %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
@@ -5644,8 +7098,8 @@ entry:
 
 ; <label>:19                                      ; preds = %14
   %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %19
   %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
@@ -5660,21 +7114,21 @@ entry:
   %31 = zext i16 %30 to i32
   %32 = bitcast i8* %29 to i16*
   %33 = trunc i32 %31 to i16
-  %NullCheck6 = icmp ne i16* %32, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i16* %32, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %21
   store i16 %33, i16* %32, align 8
   %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %36
 
 ; <label>:36                                      ; preds = %34
   %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
   %38 = load i32, i32 addrspace(1)* %37, align 8
   %39 = add i32 %38, 1
-  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %40
 
 ; <label>:40                                      ; preds = %36
   %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
@@ -5683,16 +7137,16 @@ entry:
 
 ; <label>:42                                      ; preds = %14
   %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
-  br i1 %NullCheck12, label %44, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
   %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
   %47 = load i16, i16* %arg1
   %48 = zext i16 %47 to i32
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = trunc i32 %48 to i16
@@ -5703,31 +7157,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %19
+ThrowNullRef4:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %21
+ThrowNullRef6:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %36
+ThrowNullRef10:                                   ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %42
+ThrowNullRef12:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %44
+ThrowNullRef14:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5740,8 +7194,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -5752,8 +7206,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
@@ -5762,14 +7216,14 @@ entry:
 
 ; <label>:11                                      ; preds = %1
   %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
@@ -5779,15 +7233,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5808,8 +7262,8 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5822,8 +7276,8 @@ entry:
 
 ; <label>:8                                       ; preds = %3
   %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
@@ -5842,15 +7296,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
-  br i1 %NullCheck4, label %22, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
   %24 = load i16*, i16* addrspace(1)* %23, align 8
   %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %25, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
@@ -5859,8 +7313,8 @@ entry:
   store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
@@ -5874,8 +7328,8 @@ entry:
 
 ; <label>:37                                      ; preds = %65
   %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %37
   %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
@@ -5886,16 +7340,16 @@ entry:
   %45 = bitcast i16* %41 to i8*
   %46 = getelementptr inbounds i8, i8* %45, i64 %44
   %47 = bitcast i8* %46 to i16*
-  %NullCheck14 = icmp ne i16* %47, null
-  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %47, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %48
 
 ; <label>:48                                      ; preds = %39
   %49 = load i16, i16* %47, align 8
   %50 = zext i16 %49 to i32
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %52 = load i32, i32* %loc1
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %53
 
 ; <label>:53                                      ; preds = %48
   %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
@@ -5916,8 +7370,8 @@ entry:
 ; <label>:62                                      ; preds = %36, %59
   %63 = load i32, i32* %loc1
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck10, label %65, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %65
 
 ; <label>:65                                      ; preds = %62
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
@@ -5936,15 +7390,15 @@ entry:
 
 ; <label>:74                                      ; preds = %70
   %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
-  br i1 %NullCheck18, label %76, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %76
 
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
   %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
-  br i1 %NullCheck20, label %80, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
   %81 = load i64, i64 addrspace(1)* %79
@@ -5958,8 +7412,8 @@ entry:
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
   %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
-  br i1 %NullCheck22, label %92, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.String addrspace(1)* %90, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %92
 
 ; <label>:92                                      ; preds = %80
   %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
@@ -5969,15 +7423,15 @@ entry:
 
 ; <label>:96                                      ; preds = %70
   %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
-  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %98
 
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
   %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
-  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
   %103 = load i64, i64 addrspace(1)* %101
@@ -5991,8 +7445,8 @@ entry:
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
   %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
-  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.String addrspace(1)* %112, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %114
 
 ; <label>:114                                     ; preds = %102
   %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
@@ -6004,59 +7458,59 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %20
+ThrowNullRef4:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %22
+ThrowNullRef6:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %26
+ThrowNullRef8:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %62
+ThrowNullRef10:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %48
+ThrowNullRef16:                                   ; preds = %48
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %74
+ThrowNullRef18:                                   ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %76
+ThrowNullRef20:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %80
+ThrowNullRef22:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %96
+ThrowNullRef24:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %98
+ThrowNullRef26:                                   ; preds = %98
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %102
+ThrowNullRef28:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6069,15 +7523,15 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
   %3 = load i16*, i16* addrspace(1)* %2, align 8
   %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
@@ -6087,8 +7541,8 @@ entry:
   %10 = bitcast i16* %3 to i8*
   %11 = getelementptr inbounds i8, i8* %10, i64 %9
   %12 = bitcast i8* %11 to i16*
-  %NullCheck4 = icmp ne i16* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %5
   store i16 0, i16* %12, align 8
@@ -6098,11 +7552,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6119,8 +7573,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -6131,8 +7585,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
@@ -6144,15 +7598,15 @@ entry:
 
 ; <label>:14                                      ; preds = %1
   %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
   %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
   %21 = load i64, i64 addrspace(1)* %19
@@ -6171,15 +7625,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %14
+ThrowNullRef4:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %16
+ThrowNullRef6:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6302,14 +7756,6 @@ entry:
   ret %System.String addrspace(1)* %57
 }
 
-INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
-Successfully read RuntimeHelpers.get_OffsetToStringData
-
-define i32 @RuntimeHelpers.get_OffsetToStringData() {
-entry:
-  ret i32 12
-}
-
 INFO:  jitting method String::Equals using LLILCJit
 Successfully read String.Equals
 
@@ -6381,8 +7827,8 @@ entry:
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
-  br i1 %NullCheck24, label %29, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
   %30 = load i64, i64 addrspace(1)* %28
@@ -6397,8 +7843,8 @@ entry:
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
-  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
   %43 = load i64, i64 addrspace(1)* %41
@@ -6418,8 +7864,8 @@ entry:
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
   %59 = load i64, i64 addrspace(1)* %57
@@ -6434,8 +7880,8 @@ entry:
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck22, label %71, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
   %72 = load i64, i64 addrspace(1)* %70
@@ -6455,8 +7901,8 @@ entry:
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
-  br i1 %NullCheck16, label %87, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = load i64, i64 addrspace(1)* %86
@@ -6471,8 +7917,8 @@ entry:
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck18, label %100, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
   %101 = load i64, i64 addrspace(1)* %99
@@ -6492,8 +7938,8 @@ entry:
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
-  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
   %117 = load i64, i64 addrspace(1)* %115
@@ -6508,8 +7954,8 @@ entry:
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
-  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
   %130 = load i64, i64 addrspace(1)* %128
@@ -6528,15 +7974,15 @@ entry:
 
 ; <label>:142                                     ; preds = %22
   %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
-  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %143, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %144
 
 ; <label>:144                                     ; preds = %142
   %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
   %146 = load i32, i32 addrspace(1)* %145
   %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
-  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %147, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %148
 
 ; <label>:148                                     ; preds = %144
   %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
@@ -6557,15 +8003,15 @@ entry:
 
 ; <label>:159                                     ; preds = %22
   %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
-  br i1 %NullCheck, label %161, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %ThrowNullRef, label %161
 
 ; <label>:161                                     ; preds = %159
   %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
   %163 = load i32, i32 addrspace(1)* %162
   %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
-  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %164, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %165
 
 ; <label>:165                                     ; preds = %161
   %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
@@ -6578,8 +8024,8 @@ entry:
 
 ; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
-  br i1 %NullCheck4, label %172, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %171, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %172
 
 ; <label>:172                                     ; preds = %170
   %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
@@ -6589,8 +8035,8 @@ entry:
 
 ; <label>:176                                     ; preds = %172
   %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
-  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %177, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %178
 
 ; <label>:178                                     ; preds = %176
   %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
@@ -6629,55 +8075,55 @@ ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %161
+ThrowNullRef2:                                    ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %170
+ThrowNullRef4:                                    ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %176
+ThrowNullRef6:                                    ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %142
+ThrowNullRef8:                                    ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %144
+ThrowNullRef10:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %113
+ThrowNullRef12:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %116
+ThrowNullRef14:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %84
+ThrowNullRef16:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %87
+ThrowNullRef18:                                   ; preds = %87
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %55
+ThrowNullRef20:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %58
+ThrowNullRef22:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %26
+ThrowNullRef24:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %29
+ThrowNullRef26:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,8 +8161,8 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck, label %14, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %ThrowNullRef, label %14
 
 ; <label>:14                                      ; preds = %8
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
@@ -6760,8 +8206,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
@@ -6770,14 +8216,14 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32, i32* %loc0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %10
   %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
   %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
@@ -6790,15 +8236,15 @@ entry:
 ; <label>:25                                      ; preds = %19
   %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
-  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
   %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
@@ -6807,8 +8253,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %37 = load i32, i32* %loc0
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %38, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %38
 
 ; <label>:38                                      ; preds = %32
   %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
@@ -6817,14 +8263,14 @@ entry:
 
 ; <label>:40                                      ; preds = %19
   %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %40
   %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
   %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
-  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
-  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
@@ -6832,8 +8278,8 @@ entry:
   %48 = zext i32 %47 to i64
   %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
-  br i1 %NullCheck16, label %51, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %51
 
 ; <label>:51                                      ; preds = %45
   %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
@@ -6847,15 +8293,15 @@ entry:
 ; <label>:57                                      ; preds = %51
   %58 = load i16*, i16** %arg1
   %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
-  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %60
 
 ; <label>:60                                      ; preds = %57
   %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
   %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
-  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %64
 
 ; <label>:64                                      ; preds = %60
   %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
@@ -6864,22 +8310,22 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
   %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
-  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %70
 
 ; <label>:70                                      ; preds = %64
   %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
   %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
-  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
-  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
   %75 = load i32, i32 addrspace(1)* %74
   %76 = zext i32 %75 to i64
   %77 = trunc i64 %76 to i32
-  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
-  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %78
 
 ; <label>:78                                      ; preds = %73
   %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
@@ -6901,8 +8347,8 @@ entry:
   %90 = bitcast i16* %86 to i8*
   %91 = getelementptr inbounds i8, i8* %90, i64 %89
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %93
 
 ; <label>:93                                      ; preds = %80
   %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
@@ -6912,8 +8358,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %99 = load i32, i32* %loc2
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %100
 
 ; <label>:100                                     ; preds = %93
   %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
@@ -6928,63 +8374,63 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %25
+ThrowNullRef6:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %32
+ThrowNullRef10:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %40
+ThrowNullRef12:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %45
+ThrowNullRef16:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %57
+ThrowNullRef18:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %60
+ThrowNullRef20:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %64
+ThrowNullRef22:                                   ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %70
+ThrowNullRef24:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %73
+ThrowNullRef26:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %80
+ThrowNullRef28:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %93
+ThrowNullRef30:                                   ; preds = %93
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7004,8 +8450,8 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
@@ -7033,43 +8479,43 @@ entry:
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %14
   %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
   %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   %28 = load i32, i32 addrspace(1)* %27, align 8
   %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
-  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %30
 
 ; <label>:30                                      ; preds = %26
   %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
   %32 = load i32, i32 addrspace(1)* %31, align 8
   %33 = add i32 %28, %32
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %34
 
 ; <label>:34                                      ; preds = %30
   %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   store i32 %33, i32 addrspace(1)* %35
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
   store i32 0, i32 addrspace(1)* %38
   %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %40
 
 ; <label>:40                                      ; preds = %37
   %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
@@ -7082,8 +8528,8 @@ entry:
 
 ; <label>:47                                      ; preds = %40
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
@@ -7098,8 +8544,8 @@ entry:
   %54 = load i32, i32* %loc0
   %55 = sext i32 %54 to i64
   %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
-  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %57
 
 ; <label>:57                                      ; preds = %52
   %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
@@ -7110,68 +8556,35 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %14
+ThrowNullRef2:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %23
+ThrowNullRef4:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %26
+ThrowNullRef6:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %30
+ThrowNullRef8:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %34
+ThrowNullRef10:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %47
+ThrowNullRef14:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %52
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-}
-
-INFO:  jitting method StringBuilder::get_Length using LLILCJit
-Successfully read StringBuilder.get_Length
-
-define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.StringBuilder addrspace(1)*
-  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
-  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
-
-; <label>:1                                       ; preds = %entry
-  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %3 = load i32, i32 addrspace(1)* %2, align 8
-  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
-
-; <label>:5                                       ; preds = %1
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = add i32 %3, %7
-  ret i32 %8
-
-ThrowNullRef:                                     ; preds = %entry
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef16:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7213,70 +8626,70 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
   %6 = load i32, i32 addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
   store i32 %6, i32 addrspace(1)* %8
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
   %13 = load i32, i32 addrspace(1)* %12, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
   store i32 %13, i32 addrspace(1)* %15
   %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
-  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %18
 
 ; <label>:18                                      ; preds = %14
   %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
   %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
   %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
   %34 = load i32, i32 addrspace(1)* %33, align 8
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
-  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
@@ -7287,39 +8700,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %28
+ThrowNullRef16:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %32
+ThrowNullRef18:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7455,13 +8868,13 @@ entry:
 ; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
@@ -7477,16 +8890,16 @@ entry:
 
 ; <label>:18                                      ; preds = %15
   %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
   store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
   %22 = load i32, i32* %loc0
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %24
 
 ; <label>:24                                      ; preds = %20
   %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
@@ -7498,13 +8911,13 @@ entry:
 ; <label>:28                                      ; preds = %15, %24
   %29 = load i32, i32* %arg1
   %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %31
   %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
@@ -7517,20 +8930,20 @@ entry:
   %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
-  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
   %46 = load i32, i32 addrspace(1)* %45, align 8
   %47 = sub i32 %40, %46
-  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
-  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i32 addrspace(1)* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %48
 
 ; <label>:48                                      ; preds = %44
   store i32 %47, i32 addrspace(1)* %39, align 8
@@ -7538,21 +8951,21 @@ entry:
 
 ; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
-  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %51
 
 ; <label>:51                                      ; preds = %49
   %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %53
 
 ; <label>:53                                      ; preds = %51
   %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
   %55 = load i32, i32 addrspace(1)* %54, align 8
   %56 = load i32, i32* %arg2
   %57 = sub i32 %55, %56
-  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %58
 
 ; <label>:58                                      ; preds = %53
   %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
@@ -7562,13 +8975,13 @@ entry:
 ; <label>:60                                      ; preds = %33, %58
   %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
   %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
-  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %63
 
 ; <label>:63                                      ; preds = %60
   %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
-  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
-  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
@@ -7578,15 +8991,15 @@ entry:
 
 ; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
-  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i32 addrspace(1)* %69, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %70
 
 ; <label>:70                                      ; preds = %68
   %71 = load i32, i32 addrspace(1)* %69, align 8
   store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
-  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
@@ -7596,8 +9009,8 @@ entry:
   store i32 %77, i32* %loc4
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
-  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %80
 
 ; <label>:80                                      ; preds = %73
   %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
@@ -7607,71 +9020,71 @@ entry:
 ; <label>:83                                      ; preds = %80
   store i32 0, i32* %loc3
   %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
-  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
-  br i1 %NullCheck26, label %88, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i32 addrspace(1)* %87, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %88
 
 ; <label>:88                                      ; preds = %85
   %89 = load i32, i32 addrspace(1)* %87, align 8
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
-  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %90
 
 ; <label>:90                                      ; preds = %88
   %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
   store i32 %89, i32 addrspace(1)* %91
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
-  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
-  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %96
 
 ; <label>:96                                      ; preds = %94
   %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
-  br i1 %NullCheck34, label %100, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %100
 
 ; <label>:100                                     ; preds = %96
   %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
-  br i1 %NullCheck36, label %102, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %102
 
 ; <label>:102                                     ; preds = %100
   %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
   %104 = load i32, i32 addrspace(1)* %103, align 8
   %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
-  br i1 %NullCheck38, label %106, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %106
 
 ; <label>:106                                     ; preds = %102
   %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
-  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
-  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %108
 
 ; <label>:108                                     ; preds = %106
   %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
   %110 = load i32, i32 addrspace(1)* %109, align 8
   %111 = add i32 %104, %110
-  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %112
 
 ; <label>:112                                     ; preds = %108
   %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
   store i32 %111, i32 addrspace(1)* %113
   %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
-  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i32 addrspace(1)* %114, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %115
 
 ; <label>:115                                     ; preds = %112
   %116 = load i32, i32 addrspace(1)* %114, align 8
@@ -7681,19 +9094,19 @@ entry:
 ; <label>:118                                     ; preds = %115
   %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
-  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %121
 
 ; <label>:121                                     ; preds = %118
   %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
-  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
-  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %123
 
 ; <label>:123                                     ; preds = %121
   %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
   %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
-  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
-  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %126
 
 ; <label>:126                                     ; preds = %123
   %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
@@ -7705,8 +9118,8 @@ entry:
 
 ; <label>:130                                     ; preds = %80, %115, %126
   %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %132
 
 ; <label>:132                                     ; preds = %130
   %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7715,8 +9128,8 @@ entry:
   %136 = load i32, i32* %loc3
   %137 = sub i32 %135, %136
   %138 = sub i32 %134, %137
-  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %139
 
 ; <label>:139                                     ; preds = %132
   %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7728,16 +9141,16 @@ entry:
 
 ; <label>:144                                     ; preds = %139
   %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
-  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %146
 
 ; <label>:146                                     ; preds = %144
   %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
   %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
   %149 = load i32, i32* %loc2
   %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
-  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %151
 
 ; <label>:151                                     ; preds = %146
   %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
@@ -7754,145 +9167,249 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %18
+ThrowNullRef4:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %31
+ThrowNullRef10:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %44
+ThrowNullRef16:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %68
+ThrowNullRef18:                                   ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %70
+ThrowNullRef20:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %73
+ThrowNullRef22:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %83
+ThrowNullRef24:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %85
+ThrowNullRef26:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %88
+ThrowNullRef28:                                   ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %90
+ThrowNullRef30:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %94
+ThrowNullRef32:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %96
+ThrowNullRef34:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %100
+ThrowNullRef36:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %102
+ThrowNullRef38:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %106
+ThrowNullRef40:                                   ; preds = %106
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %108
+ThrowNullRef42:                                   ; preds = %108
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %112
+ThrowNullRef44:                                   ; preds = %112
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %118
+ThrowNullRef46:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %121
+ThrowNullRef48:                                   ; preds = %121
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %123
+ThrowNullRef50:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %130
+ThrowNullRef52:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %132
+ThrowNullRef54:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %144
+ThrowNullRef56:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %146
+ThrowNullRef58:                                   ; preds = %146
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %60
+ThrowNullRef60:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %63
+ThrowNullRef62:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %49
+ThrowNullRef64:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %51
+ThrowNullRef66:                                   ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %53
+ThrowNullRef68:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(%"System.Char[]" addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %arg0 = alloca %"System.Char[]" addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store %"System.Char[]" addrspace(1)* %param0, %"System.Char[]" addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load i32, i32* %arg4
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %43, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %38, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg1
+  %13 = load i32, i32* %arg4
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %38, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %24 = load i32, i32* %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %35 = load i32, i32* %arg3
+  %36 = load i32, i32* %arg4
+  %37 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %37, %"System.Char[]" addrspace(1)* %34, i32 %35, i32 %36)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:38                                      ; preds = %5, %16
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Successfully read Buffer._Memmove
 
@@ -7914,7 +9431,7 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[loadElem]
+Failed to read AppDomain.SetDataHelper[storeElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -7923,8 +9440,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
@@ -7934,8 +9451,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
@@ -7947,15 +9464,15 @@ entry:
   %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
   %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
@@ -7966,15 +9483,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7992,7 +9509,79 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
-Failed to read Dictionary`2.TryGetValue[loadElemA]
+Successfully read Dictionary`2.TryGetValue
+
+define i8 @"Dictionary`2.TryGetValue"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)* addrspace(1)* %param2) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  %arg2 = alloca %System.__Canon addrspace(1)* addrspace(1)*
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  store %System.__Canon addrspace(1)* addrspace(1)* %param2, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  store i32 %2, i32* %loc0
+  %3 = load i32, i32* %loc0
+  %4 = icmp slt i32 %3, 0
+  br i1 %4, label %22, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 2
+  %10 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %9, align 8
+  %11 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = zext i32 %11 to i64
+  %BoundsCheck = icmp uge i64 %16, %15
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 3, i32 %11
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %20, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %6, %System.__Canon addrspace(1)* %21)
+  ret i8 1
+
+; <label>:22                                      ; preds = %entry
+  %23 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %23, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -8058,8 +9647,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
@@ -8091,8 +9680,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
@@ -8171,15 +9760,15 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck, label %19, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %ThrowNullRef, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
   %21 = load i32, i32 addrspace(1)* %20
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
@@ -8202,7 +9791,7 @@ ThrowNullRef:                                     ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %19
+ThrowNullRef2:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8248,8 +9837,8 @@ entry:
   %0 = alloca %System.AppDomainHandle
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %1 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %1, i32 0, i32 15
@@ -8269,8 +9858,8 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
@@ -8286,7 +9875,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -8299,8 +9888,8 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -8327,8 +9916,8 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
@@ -8352,8 +9941,8 @@ entry:
   %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
   store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
@@ -8363,8 +9952,8 @@ entry:
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
@@ -8374,8 +9963,8 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %9
   %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
@@ -8384,8 +9973,8 @@ entry:
 
 ; <label>:18                                      ; preds = %3, %16
   %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
@@ -8397,15 +9986,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %18
+ThrowNullRef6:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8418,8 +10007,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
@@ -8453,15 +10042,15 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
@@ -8473,7 +10062,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8481,7 +10070,7 @@ ThrowNullRef1:                                    ; preds = %1
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
 Failed to read Dictionary`2.System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
@@ -8506,8 +10095,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
@@ -8524,8 +10113,8 @@ entry:
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -8544,7 +10133,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8577,8 +10166,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = load i64, i64* %arg2
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = trunc i32 %3 to i8
@@ -8634,46 +10223,46 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
   %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
-  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
-  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
-  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
@@ -8684,27 +10273,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %20
+ThrowNullRef12:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8717,8 +10306,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -8756,22 +10345,22 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
   %9 = load i64, i64 addrspace(1)* %8, align 8
   %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
   %13 = load i64, i64 addrspace(1)* %12, align 8
   %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %11
   %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
@@ -8788,11 +10377,11 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8882,8 +10471,8 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
@@ -8900,8 +10489,8 @@ entry:
 ; <label>:8                                       ; preds = %1
   %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
   %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
@@ -8911,15 +10500,15 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
   %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
   %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
-  br i1 %NullCheck6, label %21, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
@@ -8946,15 +10535,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8992,15 +10581,15 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
   store i8 %3, i8 addrspace(1)* %5
   %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
@@ -9011,7 +10600,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9027,8 +10616,8 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -9041,8 +10630,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
@@ -9058,7 +10647,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9080,8 +10669,8 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
@@ -9096,8 +10685,8 @@ entry:
 ; <label>:12                                      ; preds = %6
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
@@ -9112,8 +10701,8 @@ entry:
 ; <label>:21                                      ; preds = %15
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
@@ -9128,8 +10717,8 @@ entry:
 ; <label>:30                                      ; preds = %24
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %31, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
@@ -9144,8 +10733,8 @@ entry:
 ; <label>:39                                      ; preds = %33
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
-  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %40, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %42
 
 ; <label>:42                                      ; preds = %39
   %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
@@ -9164,19 +10753,19 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %21
+ThrowNullRef4:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %30
+ThrowNullRef6:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %39
+ThrowNullRef8:                                    ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9243,8 +10832,8 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
@@ -9264,57 +10853,57 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
   store i8 0, i8 addrspace(1)* %2
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
   store i8 0, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
   store i8 0, i8 addrspace(1)* %17
   %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
   store i8 0, i8 addrspace(1)* %20
   %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
-  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
@@ -9325,31 +10914,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %19
+ThrowNullRef14:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9367,8 +10956,8 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
@@ -9380,8 +10969,8 @@ entry:
 
 ; <label>:9                                       ; preds = %4
   %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %9
   %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
@@ -9395,7 +10984,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef2:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9420,8 +11009,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
@@ -9512,8 +11101,8 @@ entry:
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
@@ -9524,8 +11113,8 @@ entry:
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = load i64, i64 addrspace(1)* %12
@@ -9537,8 +11126,8 @@ entry:
   %20 = load i64, i64* %19
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
-  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %13
   %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
@@ -9555,8 +11144,8 @@ entry:
 ; <label>:30                                      ; preds = %25
   %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %32 = load i32, i32* %arg2
-  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
-  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
@@ -9570,15 +11159,15 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %30
+ThrowNullRef2:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9622,87 +11211,87 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
   %10 = load i8, i8 addrspace(1)* %9, align 8
   %11 = zext i8 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %8
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
   store i8 %12, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
   %19 = load i8, i8 addrspace(1)* %18, align 8
   %20 = zext i8 %19 to i32
   %21 = trunc i32 %20 to i8
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
   store i8 %21, i8 addrspace(1)* %23
   %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
   %28 = load i8, i8 addrspace(1)* %27, align 8
   %29 = zext i8 %28 to i32
   %30 = trunc i32 %29 to i8
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
-  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %31
 
 ; <label>:31                                      ; preds = %26
   %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
   store i8 %30, i8 addrspace(1)* %32
   %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
-  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
-  br i1 %NullCheck14, label %40, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %40
 
 ; <label>:40                                      ; preds = %35
   %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
   store i8 %39, i8 addrspace(1)* %41
   %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
-  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %44
 
 ; <label>:44                                      ; preds = %40
   %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
   %46 = load i8, i8 addrspace(1)* %45, align 8
   %47 = zext i8 %46 to i32
   %48 = trunc i32 %47 to i8
-  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
   store i8 %48, i8 addrspace(1)* %50
   %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
-  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
@@ -9713,29 +11302,29 @@ entry:
 ; <label>:56                                      ; preds = %52
   %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
-  br i1 %NullCheck22, label %59, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
   %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
   %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
-  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
-  br i1 %NullCheck24, label %63, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
   %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
-  br i1 %NullCheck26, label %66, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
   %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
-  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
-  br i1 %NullCheck28, label %69, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %69
 
 ; <label>:69                                      ; preds = %66
   %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
@@ -9744,15 +11333,15 @@ entry:
 
 ; <label>:71                                      ; preds = %105
   %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
-  br i1 %NullCheck34, label %73, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %73
 
 ; <label>:73                                      ; preds = %71
   %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
   %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
   %76 = load i32, i32* %loc0
-  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
-  br i1 %NullCheck36, label %77, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
@@ -9766,8 +11355,8 @@ entry:
 
 ; <label>:83                                      ; preds = %77
   %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
-  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
@@ -9775,14 +11364,14 @@ entry:
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
   %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
-  br i1 %NullCheck40, label %91, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
 ; <label>:91                                      ; preds = %85
   %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
   %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
-  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck42, label %94, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %94
 
 ; <label>:94                                      ; preds = %91
   %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
@@ -9798,14 +11387,14 @@ entry:
 ; <label>:99                                      ; preds = %69, %96
   %100 = load i32, i32* %loc0
   %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
-  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %102
 
 ; <label>:102                                     ; preds = %99
   %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
   %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
-  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
-  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
@@ -9819,87 +11408,87 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %26
+ThrowNullRef10:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %31
+ThrowNullRef12:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %35
+ThrowNullRef14:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %40
+ThrowNullRef16:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %56
+ThrowNullRef22:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %59
+ThrowNullRef24:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %63
+ThrowNullRef26:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %66
+ThrowNullRef28:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %102
+ThrowNullRef32:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %71
+ThrowNullRef34:                                   ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %73
+ThrowNullRef36:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %83
+ThrowNullRef38:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %85
+ThrowNullRef40:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %91
+ThrowNullRef42:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9943,15 +11532,15 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
   %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
@@ -9961,28 +11550,28 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
   %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %12
   %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
   %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
   %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
-  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
@@ -9993,23 +11582,23 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %12
+ThrowNullRef6:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10031,15 +11620,15 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
   %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = load i64, i64 addrspace(1)* %7
@@ -10077,13 +11666,13 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[loadElem]
+Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -10111,8 +11700,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueNeFP.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueNeFP.error.txt
@@ -25,8 +25,8 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
@@ -40,8 +40,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
   %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
@@ -75,7 +75,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -90,8 +90,8 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %NullCheck = icmp ne i8 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = load i8, i8 addrspace(1)* %0, align 8
@@ -125,8 +125,8 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
@@ -159,8 +159,8 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -184,8 +184,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
   store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
@@ -195,8 +195,8 @@ entry:
 ; <label>:4                                       ; preds = %1
   %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
   %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
@@ -206,8 +206,8 @@ entry:
   %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
@@ -221,14 +221,14 @@ entry:
 
 ; <label>:17                                      ; preds = %14
   %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
   %21 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
@@ -238,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -249,8 +249,8 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
@@ -261,27 +261,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %30
+ThrowNullRef10:                                   ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -301,7 +301,89 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
-Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
+Successfully read AppDomainSetup.GetUnsecureApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.GetUnsecureApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %NullCheck = icmp eq %"System.String[]" addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %BoundsCheck = icmp uge i64 0, %5
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %6
+
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 3, i32 0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
+  ret %System.String addrspace(1)* %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_Value using LLILCJit
+Successfully read AppDomainSetup.get_Value
+
+define %"System.String[]" addrspace(1)* @AppDomainSetup.get_Value(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.String[]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 18)
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.String[]" addrspace(1)* addrspace(1)*, %"System.String[]" addrspace(1)*)*)(%"System.String[]" addrspace(1)* addrspace(1)* %9, %"System.String[]" addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %11, i32 0, i32 1
+  %14 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %13, align 8
+  ret %"System.String[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -319,8 +401,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -368,16 +450,16 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
   %5 = load i32, i32 addrspace(1)* %4
   %6 = sub i32 %5, 1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -389,7 +471,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -421,8 +503,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
@@ -456,8 +538,8 @@ entry:
 ; <label>:27                                      ; preds = %19
   %28 = load i32, i32* %arg1
   %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
-  br i1 %NullCheck2, label %30, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %29, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %30
 
 ; <label>:30                                      ; preds = %27
   %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
@@ -493,8 +575,8 @@ entry:
 ; <label>:49                                      ; preds = %46
   %50 = load i32, i32* %arg2
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck4, label %52, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
@@ -517,11 +599,11 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %27
+ThrowNullRef2:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %49
+ThrowNullRef4:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -544,16 +626,16 @@ entry:
   %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %0)
   store %System.String addrspace(1)* %1, %System.String addrspace(1)** %loc0
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 2
   %5 = bitcast [0 x i16] addrspace(1)* %4 to i16 addrspace(1)*
   store i16 addrspace(1)* %5, i16 addrspace(1)** %loc1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %3
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2
@@ -580,7 +662,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -691,15 +773,15 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %NullCheck132 = icmp ne i8* %21, null
-  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+  %NullCheck131 = icmp eq i8* %21, null
+  br i1 %NullCheck131, label %ThrowNullRef132, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = load i8, i8* %21, align 8
   %24 = zext i8 %23 to i32
   %25 = trunc i32 %24 to i8
-  %NullCheck134 = icmp ne i8* %20, null
-  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+  %NullCheck133 = icmp eq i8* %20, null
+  br i1 %NullCheck133, label %ThrowNullRef134, label %26
 
 ; <label>:26                                      ; preds = %22
   store i8 %25, i8* %20, align 8
@@ -709,16 +791,16 @@ entry:
   %28 = load i8*, i8** %arg0
   %29 = load i8*, i8** %arg1
   %30 = bitcast i8* %29 to i16*
-  %NullCheck128 = icmp ne i16* %30, null
-  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+  %NullCheck127 = icmp eq i16* %30, null
+  br i1 %NullCheck127, label %ThrowNullRef128, label %31
 
 ; <label>:31                                      ; preds = %27
   %32 = load i16, i16* %30, align 8
   %33 = sext i16 %32 to i32
   %34 = bitcast i8* %28 to i16*
   %35 = trunc i32 %33 to i16
-  %NullCheck130 = icmp ne i16* %34, null
-  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+  %NullCheck129 = icmp eq i16* %34, null
+  br i1 %NullCheck129, label %ThrowNullRef130, label %36
 
 ; <label>:36                                      ; preds = %31
   store i16 %35, i16* %34, align 8
@@ -728,16 +810,16 @@ entry:
   %38 = load i8*, i8** %arg0
   %39 = load i8*, i8** %arg1
   %40 = bitcast i8* %39 to i16*
-  %NullCheck120 = icmp ne i16* %40, null
-  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+  %NullCheck119 = icmp eq i16* %40, null
+  br i1 %NullCheck119, label %ThrowNullRef120, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i16, i16* %40, align 8
   %43 = sext i16 %42 to i32
   %44 = bitcast i8* %38 to i16*
   %45 = trunc i32 %43 to i16
-  %NullCheck122 = icmp ne i16* %44, null
-  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+  %NullCheck121 = icmp eq i16* %44, null
+  br i1 %NullCheck121, label %ThrowNullRef122, label %46
 
 ; <label>:46                                      ; preds = %41
   store i16 %45, i16* %44, align 8
@@ -745,15 +827,15 @@ entry:
   %48 = getelementptr inbounds i8, i8* %47, i64 2
   %49 = load i8*, i8** %arg1
   %50 = getelementptr inbounds i8, i8* %49, i64 2
-  %NullCheck124 = icmp ne i8* %50, null
-  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+  %NullCheck123 = icmp eq i8* %50, null
+  br i1 %NullCheck123, label %ThrowNullRef124, label %51
 
 ; <label>:51                                      ; preds = %46
   %52 = load i8, i8* %50, align 8
   %53 = zext i8 %52 to i32
   %54 = trunc i32 %53 to i8
-  %NullCheck126 = icmp ne i8* %48, null
-  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+  %NullCheck125 = icmp eq i8* %48, null
+  br i1 %NullCheck125, label %ThrowNullRef126, label %55
 
 ; <label>:55                                      ; preds = %51
   store i8 %54, i8* %48, align 8
@@ -763,14 +845,14 @@ entry:
   %57 = load i8*, i8** %arg0
   %58 = load i8*, i8** %arg1
   %59 = bitcast i8* %58 to i32*
-  %NullCheck116 = icmp ne i32* %59, null
-  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+  %NullCheck115 = icmp eq i32* %59, null
+  br i1 %NullCheck115, label %ThrowNullRef116, label %60
 
 ; <label>:60                                      ; preds = %56
   %61 = load i32, i32* %59, align 8
   %62 = bitcast i8* %57 to i32*
-  %NullCheck118 = icmp ne i32* %62, null
-  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+  %NullCheck117 = icmp eq i32* %62, null
+  br i1 %NullCheck117, label %ThrowNullRef118, label %63
 
 ; <label>:63                                      ; preds = %60
   store i32 %61, i32* %62, align 8
@@ -780,14 +862,14 @@ entry:
   %65 = load i8*, i8** %arg0
   %66 = load i8*, i8** %arg1
   %67 = bitcast i8* %66 to i32*
-  %NullCheck108 = icmp ne i32* %67, null
-  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+  %NullCheck107 = icmp eq i32* %67, null
+  br i1 %NullCheck107, label %ThrowNullRef108, label %68
 
 ; <label>:68                                      ; preds = %64
   %69 = load i32, i32* %67, align 8
   %70 = bitcast i8* %65 to i32*
-  %NullCheck110 = icmp ne i32* %70, null
-  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+  %NullCheck109 = icmp eq i32* %70, null
+  br i1 %NullCheck109, label %ThrowNullRef110, label %71
 
 ; <label>:71                                      ; preds = %68
   store i32 %69, i32* %70, align 8
@@ -795,15 +877,15 @@ entry:
   %73 = getelementptr inbounds i8, i8* %72, i64 4
   %74 = load i8*, i8** %arg1
   %75 = getelementptr inbounds i8, i8* %74, i64 4
-  %NullCheck112 = icmp ne i8* %75, null
-  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+  %NullCheck111 = icmp eq i8* %75, null
+  br i1 %NullCheck111, label %ThrowNullRef112, label %76
 
 ; <label>:76                                      ; preds = %71
   %77 = load i8, i8* %75, align 8
   %78 = zext i8 %77 to i32
   %79 = trunc i32 %78 to i8
-  %NullCheck114 = icmp ne i8* %73, null
-  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+  %NullCheck113 = icmp eq i8* %73, null
+  br i1 %NullCheck113, label %ThrowNullRef114, label %80
 
 ; <label>:80                                      ; preds = %76
   store i8 %79, i8* %73, align 8
@@ -813,14 +895,14 @@ entry:
   %82 = load i8*, i8** %arg0
   %83 = load i8*, i8** %arg1
   %84 = bitcast i8* %83 to i32*
-  %NullCheck100 = icmp ne i32* %84, null
-  br i1 %NullCheck100, label %85, label %ThrowNullRef99
+  %NullCheck99 = icmp eq i32* %84, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %85
 
 ; <label>:85                                      ; preds = %81
   %86 = load i32, i32* %84, align 8
   %87 = bitcast i8* %82 to i32*
-  %NullCheck102 = icmp ne i32* %87, null
-  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+  %NullCheck101 = icmp eq i32* %87, null
+  br i1 %NullCheck101, label %ThrowNullRef102, label %88
 
 ; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
@@ -829,16 +911,16 @@ entry:
   %91 = load i8*, i8** %arg1
   %92 = getelementptr inbounds i8, i8* %91, i64 4
   %93 = bitcast i8* %92 to i16*
-  %NullCheck104 = icmp ne i16* %93, null
-  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+  %NullCheck103 = icmp eq i16* %93, null
+  br i1 %NullCheck103, label %ThrowNullRef104, label %94
 
 ; <label>:94                                      ; preds = %88
   %95 = load i16, i16* %93, align 8
   %96 = sext i16 %95 to i32
   %97 = bitcast i8* %90 to i16*
   %98 = trunc i32 %96 to i16
-  %NullCheck106 = icmp ne i16* %97, null
-  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+  %NullCheck105 = icmp eq i16* %97, null
+  br i1 %NullCheck105, label %ThrowNullRef106, label %99
 
 ; <label>:99                                      ; preds = %94
   store i16 %98, i16* %97, align 8
@@ -848,14 +930,14 @@ entry:
   %101 = load i8*, i8** %arg0
   %102 = load i8*, i8** %arg1
   %103 = bitcast i8* %102 to i32*
-  %NullCheck88 = icmp ne i32* %103, null
-  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+  %NullCheck87 = icmp eq i32* %103, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %104
 
 ; <label>:104                                     ; preds = %100
   %105 = load i32, i32* %103, align 8
   %106 = bitcast i8* %101 to i32*
-  %NullCheck90 = icmp ne i32* %106, null
-  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+  %NullCheck89 = icmp eq i32* %106, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %107
 
 ; <label>:107                                     ; preds = %104
   store i32 %105, i32* %106, align 8
@@ -864,16 +946,16 @@ entry:
   %110 = load i8*, i8** %arg1
   %111 = getelementptr inbounds i8, i8* %110, i64 4
   %112 = bitcast i8* %111 to i16*
-  %NullCheck92 = icmp ne i16* %112, null
-  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+  %NullCheck91 = icmp eq i16* %112, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %113
 
 ; <label>:113                                     ; preds = %107
   %114 = load i16, i16* %112, align 8
   %115 = sext i16 %114 to i32
   %116 = bitcast i8* %109 to i16*
   %117 = trunc i32 %115 to i16
-  %NullCheck94 = icmp ne i16* %116, null
-  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+  %NullCheck93 = icmp eq i16* %116, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %118
 
 ; <label>:118                                     ; preds = %113
   store i16 %117, i16* %116, align 8
@@ -881,15 +963,15 @@ entry:
   %120 = getelementptr inbounds i8, i8* %119, i64 6
   %121 = load i8*, i8** %arg1
   %122 = getelementptr inbounds i8, i8* %121, i64 6
-  %NullCheck96 = icmp ne i8* %122, null
-  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+  %NullCheck95 = icmp eq i8* %122, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %123
 
 ; <label>:123                                     ; preds = %118
   %124 = load i8, i8* %122, align 8
   %125 = zext i8 %124 to i32
   %126 = trunc i32 %125 to i8
-  %NullCheck98 = icmp ne i8* %120, null
-  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+  %NullCheck97 = icmp eq i8* %120, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %127
 
 ; <label>:127                                     ; preds = %123
   store i8 %126, i8* %120, align 8
@@ -899,14 +981,14 @@ entry:
   %129 = load i8*, i8** %arg0
   %130 = load i8*, i8** %arg1
   %131 = bitcast i8* %130 to i64*
-  %NullCheck84 = icmp ne i64* %131, null
-  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+  %NullCheck83 = icmp eq i64* %131, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %132
 
 ; <label>:132                                     ; preds = %128
   %133 = load i64, i64* %131, align 8
   %134 = bitcast i8* %129 to i64*
-  %NullCheck86 = icmp ne i64* %134, null
-  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+  %NullCheck85 = icmp eq i64* %134, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %135
 
 ; <label>:135                                     ; preds = %132
   store i64 %133, i64* %134, align 8
@@ -916,14 +998,14 @@ entry:
   %137 = load i8*, i8** %arg0
   %138 = load i8*, i8** %arg1
   %139 = bitcast i8* %138 to i64*
-  %NullCheck76 = icmp ne i64* %139, null
-  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+  %NullCheck75 = icmp eq i64* %139, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %140
 
 ; <label>:140                                     ; preds = %136
   %141 = load i64, i64* %139, align 8
   %142 = bitcast i8* %137 to i64*
-  %NullCheck78 = icmp ne i64* %142, null
-  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+  %NullCheck77 = icmp eq i64* %142, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %143
 
 ; <label>:143                                     ; preds = %140
   store i64 %141, i64* %142, align 8
@@ -931,15 +1013,15 @@ entry:
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %NullCheck80 = icmp ne i8* %147, null
-  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+  %NullCheck79 = icmp eq i8* %147, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %148
 
 ; <label>:148                                     ; preds = %143
   %149 = load i8, i8* %147, align 8
   %150 = zext i8 %149 to i32
   %151 = trunc i32 %150 to i8
-  %NullCheck82 = icmp ne i8* %145, null
-  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+  %NullCheck81 = icmp eq i8* %145, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %152
 
 ; <label>:152                                     ; preds = %148
   store i8 %151, i8* %145, align 8
@@ -949,14 +1031,14 @@ entry:
   %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
   %156 = bitcast i8* %155 to i64*
-  %NullCheck68 = icmp ne i64* %156, null
-  br i1 %NullCheck68, label %157, label %ThrowNullRef67
+  %NullCheck67 = icmp eq i64* %156, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %157
 
 ; <label>:157                                     ; preds = %153
   %158 = load i64, i64* %156, align 8
   %159 = bitcast i8* %154 to i64*
-  %NullCheck70 = icmp ne i64* %159, null
-  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+  %NullCheck69 = icmp eq i64* %159, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %160
 
 ; <label>:160                                     ; preds = %157
   store i64 %158, i64* %159, align 8
@@ -965,16 +1047,16 @@ entry:
   %163 = load i8*, i8** %arg1
   %164 = getelementptr inbounds i8, i8* %163, i64 8
   %165 = bitcast i8* %164 to i16*
-  %NullCheck72 = icmp ne i16* %165, null
-  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+  %NullCheck71 = icmp eq i16* %165, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %166
 
 ; <label>:166                                     ; preds = %160
   %167 = load i16, i16* %165, align 8
   %168 = sext i16 %167 to i32
   %169 = bitcast i8* %162 to i16*
   %170 = trunc i32 %168 to i16
-  %NullCheck74 = icmp ne i16* %169, null
-  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+  %NullCheck73 = icmp eq i16* %169, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %171
 
 ; <label>:171                                     ; preds = %166
   store i16 %170, i16* %169, align 8
@@ -984,14 +1066,14 @@ entry:
   %173 = load i8*, i8** %arg0
   %174 = load i8*, i8** %arg1
   %175 = bitcast i8* %174 to i64*
-  %NullCheck56 = icmp ne i64* %175, null
-  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+  %NullCheck55 = icmp eq i64* %175, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %176
 
 ; <label>:176                                     ; preds = %172
   %177 = load i64, i64* %175, align 8
   %178 = bitcast i8* %173 to i64*
-  %NullCheck58 = icmp ne i64* %178, null
-  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+  %NullCheck57 = icmp eq i64* %178, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %179
 
 ; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
@@ -1000,16 +1082,16 @@ entry:
   %182 = load i8*, i8** %arg1
   %183 = getelementptr inbounds i8, i8* %182, i64 8
   %184 = bitcast i8* %183 to i16*
-  %NullCheck60 = icmp ne i16* %184, null
-  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+  %NullCheck59 = icmp eq i16* %184, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %185
 
 ; <label>:185                                     ; preds = %179
   %186 = load i16, i16* %184, align 8
   %187 = sext i16 %186 to i32
   %188 = bitcast i8* %181 to i16*
   %189 = trunc i32 %187 to i16
-  %NullCheck62 = icmp ne i16* %188, null
-  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+  %NullCheck61 = icmp eq i16* %188, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %190
 
 ; <label>:190                                     ; preds = %185
   store i16 %189, i16* %188, align 8
@@ -1017,15 +1099,15 @@ entry:
   %192 = getelementptr inbounds i8, i8* %191, i64 10
   %193 = load i8*, i8** %arg1
   %194 = getelementptr inbounds i8, i8* %193, i64 10
-  %NullCheck64 = icmp ne i8* %194, null
-  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+  %NullCheck63 = icmp eq i8* %194, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %195
 
 ; <label>:195                                     ; preds = %190
   %196 = load i8, i8* %194, align 8
   %197 = zext i8 %196 to i32
   %198 = trunc i32 %197 to i8
-  %NullCheck66 = icmp ne i8* %192, null
-  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+  %NullCheck65 = icmp eq i8* %192, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %199
 
 ; <label>:199                                     ; preds = %195
   store i8 %198, i8* %192, align 8
@@ -1035,14 +1117,14 @@ entry:
   %201 = load i8*, i8** %arg0
   %202 = load i8*, i8** %arg1
   %203 = bitcast i8* %202 to i64*
-  %NullCheck48 = icmp ne i64* %203, null
-  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+  %NullCheck47 = icmp eq i64* %203, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %204
 
 ; <label>:204                                     ; preds = %200
   %205 = load i64, i64* %203, align 8
   %206 = bitcast i8* %201 to i64*
-  %NullCheck50 = icmp ne i64* %206, null
-  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+  %NullCheck49 = icmp eq i64* %206, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %207
 
 ; <label>:207                                     ; preds = %204
   store i64 %205, i64* %206, align 8
@@ -1051,14 +1133,14 @@ entry:
   %210 = load i8*, i8** %arg1
   %211 = getelementptr inbounds i8, i8* %210, i64 8
   %212 = bitcast i8* %211 to i32*
-  %NullCheck52 = icmp ne i32* %212, null
-  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+  %NullCheck51 = icmp eq i32* %212, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %213
 
 ; <label>:213                                     ; preds = %207
   %214 = load i32, i32* %212, align 8
   %215 = bitcast i8* %209 to i32*
-  %NullCheck54 = icmp ne i32* %215, null
-  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+  %NullCheck53 = icmp eq i32* %215, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %216
 
 ; <label>:216                                     ; preds = %213
   store i32 %214, i32* %215, align 8
@@ -1068,14 +1150,14 @@ entry:
   %218 = load i8*, i8** %arg0
   %219 = load i8*, i8** %arg1
   %220 = bitcast i8* %219 to i64*
-  %NullCheck36 = icmp ne i64* %220, null
-  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64* %220, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %221
 
 ; <label>:221                                     ; preds = %217
   %222 = load i64, i64* %220, align 8
   %223 = bitcast i8* %218 to i64*
-  %NullCheck38 = icmp ne i64* %223, null
-  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+  %NullCheck37 = icmp eq i64* %223, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %224
 
 ; <label>:224                                     ; preds = %221
   store i64 %222, i64* %223, align 8
@@ -1084,14 +1166,14 @@ entry:
   %227 = load i8*, i8** %arg1
   %228 = getelementptr inbounds i8, i8* %227, i64 8
   %229 = bitcast i8* %228 to i32*
-  %NullCheck40 = icmp ne i32* %229, null
-  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i32* %229, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %230
 
 ; <label>:230                                     ; preds = %224
   %231 = load i32, i32* %229, align 8
   %232 = bitcast i8* %226 to i32*
-  %NullCheck42 = icmp ne i32* %232, null
-  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+  %NullCheck41 = icmp eq i32* %232, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %233
 
 ; <label>:233                                     ; preds = %230
   store i32 %231, i32* %232, align 8
@@ -1099,15 +1181,15 @@ entry:
   %235 = getelementptr inbounds i8, i8* %234, i64 12
   %236 = load i8*, i8** %arg1
   %237 = getelementptr inbounds i8, i8* %236, i64 12
-  %NullCheck44 = icmp ne i8* %237, null
-  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i8* %237, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %238
 
 ; <label>:238                                     ; preds = %233
   %239 = load i8, i8* %237, align 8
   %240 = zext i8 %239 to i32
   %241 = trunc i32 %240 to i8
-  %NullCheck46 = icmp ne i8* %235, null
-  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+  %NullCheck45 = icmp eq i8* %235, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %242
 
 ; <label>:242                                     ; preds = %238
   store i8 %241, i8* %235, align 8
@@ -1117,14 +1199,14 @@ entry:
   %244 = load i8*, i8** %arg0
   %245 = load i8*, i8** %arg1
   %246 = bitcast i8* %245 to i64*
-  %NullCheck24 = icmp ne i64* %246, null
-  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64* %246, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %247
 
 ; <label>:247                                     ; preds = %243
   %248 = load i64, i64* %246, align 8
   %249 = bitcast i8* %244 to i64*
-  %NullCheck26 = icmp ne i64* %249, null
-  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64* %249, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %250
 
 ; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
@@ -1133,14 +1215,14 @@ entry:
   %253 = load i8*, i8** %arg1
   %254 = getelementptr inbounds i8, i8* %253, i64 8
   %255 = bitcast i8* %254 to i32*
-  %NullCheck28 = icmp ne i32* %255, null
-  br i1 %NullCheck28, label %256, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i32* %255, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %256
 
 ; <label>:256                                     ; preds = %250
   %257 = load i32, i32* %255, align 8
   %258 = bitcast i8* %252 to i32*
-  %NullCheck30 = icmp ne i32* %258, null
-  br i1 %NullCheck30, label %259, label %ThrowNullRef29
+  %NullCheck29 = icmp eq i32* %258, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %259
 
 ; <label>:259                                     ; preds = %256
   store i32 %257, i32* %258, align 8
@@ -1149,16 +1231,16 @@ entry:
   %262 = load i8*, i8** %arg1
   %263 = getelementptr inbounds i8, i8* %262, i64 12
   %264 = bitcast i8* %263 to i16*
-  %NullCheck32 = icmp ne i16* %264, null
-  br i1 %NullCheck32, label %265, label %ThrowNullRef31
+  %NullCheck31 = icmp eq i16* %264, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %265
 
 ; <label>:265                                     ; preds = %259
   %266 = load i16, i16* %264, align 8
   %267 = sext i16 %266 to i32
   %268 = bitcast i8* %261 to i16*
   %269 = trunc i32 %267 to i16
-  %NullCheck34 = icmp ne i16* %268, null
-  br i1 %NullCheck34, label %270, label %ThrowNullRef33
+  %NullCheck33 = icmp eq i16* %268, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %270
 
 ; <label>:270                                     ; preds = %265
   store i16 %269, i16* %268, align 8
@@ -1168,14 +1250,14 @@ entry:
   %272 = load i8*, i8** %arg0
   %273 = load i8*, i8** %arg1
   %274 = bitcast i8* %273 to i64*
-  %NullCheck8 = icmp ne i64* %274, null
-  br i1 %NullCheck8, label %275, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64* %274, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %275
 
 ; <label>:275                                     ; preds = %271
   %276 = load i64, i64* %274, align 8
   %277 = bitcast i8* %272 to i64*
-  %NullCheck10 = icmp ne i64* %277, null
-  br i1 %NullCheck10, label %278, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %277, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %278
 
 ; <label>:278                                     ; preds = %275
   store i64 %276, i64* %277, align 8
@@ -1184,14 +1266,14 @@ entry:
   %281 = load i8*, i8** %arg1
   %282 = getelementptr inbounds i8, i8* %281, i64 8
   %283 = bitcast i8* %282 to i32*
-  %NullCheck12 = icmp ne i32* %283, null
-  br i1 %NullCheck12, label %284, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i32* %283, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %284
 
 ; <label>:284                                     ; preds = %278
   %285 = load i32, i32* %283, align 8
   %286 = bitcast i8* %280 to i32*
-  %NullCheck14 = icmp ne i32* %286, null
-  br i1 %NullCheck14, label %287, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i32* %286, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %287
 
 ; <label>:287                                     ; preds = %284
   store i32 %285, i32* %286, align 8
@@ -1200,16 +1282,16 @@ entry:
   %290 = load i8*, i8** %arg1
   %291 = getelementptr inbounds i8, i8* %290, i64 12
   %292 = bitcast i8* %291 to i16*
-  %NullCheck16 = icmp ne i16* %292, null
-  br i1 %NullCheck16, label %293, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i16* %292, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %293
 
 ; <label>:293                                     ; preds = %287
   %294 = load i16, i16* %292, align 8
   %295 = sext i16 %294 to i32
   %296 = bitcast i8* %289 to i16*
   %297 = trunc i32 %295 to i16
-  %NullCheck18 = icmp ne i16* %296, null
-  br i1 %NullCheck18, label %298, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i16* %296, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %298
 
 ; <label>:298                                     ; preds = %293
   store i16 %297, i16* %296, align 8
@@ -1217,15 +1299,15 @@ entry:
   %300 = getelementptr inbounds i8, i8* %299, i64 14
   %301 = load i8*, i8** %arg1
   %302 = getelementptr inbounds i8, i8* %301, i64 14
-  %NullCheck20 = icmp ne i8* %302, null
-  br i1 %NullCheck20, label %303, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i8* %302, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %303
 
 ; <label>:303                                     ; preds = %298
   %304 = load i8, i8* %302, align 8
   %305 = zext i8 %304 to i32
   %306 = trunc i32 %305 to i8
-  %NullCheck22 = icmp ne i8* %300, null
-  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i8* %300, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %307
 
 ; <label>:307                                     ; preds = %303
   store i8 %306, i8* %300, align 8
@@ -1235,14 +1317,14 @@ entry:
   %309 = load i8*, i8** %arg0
   %310 = load i8*, i8** %arg1
   %311 = bitcast i8* %310 to i64*
-  %NullCheck = icmp ne i64* %311, null
-  br i1 %NullCheck, label %312, label %ThrowNullRef
+  %NullCheck = icmp eq i64* %311, null
+  br i1 %NullCheck, label %ThrowNullRef, label %312
 
 ; <label>:312                                     ; preds = %308
   %313 = load i64, i64* %311, align 8
   %314 = bitcast i8* %309 to i64*
-  %NullCheck2 = icmp ne i64* %314, null
-  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64* %314, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %315
 
 ; <label>:315                                     ; preds = %312
   store i64 %313, i64* %314, align 8
@@ -1251,14 +1333,14 @@ entry:
   %318 = load i8*, i8** %arg1
   %319 = getelementptr inbounds i8, i8* %318, i64 8
   %320 = bitcast i8* %319 to i64*
-  %NullCheck4 = icmp ne i64* %320, null
-  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64* %320, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %321
 
 ; <label>:321                                     ; preds = %315
   %322 = load i64, i64* %320, align 8
   %323 = bitcast i8* %317 to i64*
-  %NullCheck6 = icmp ne i64* %323, null
-  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64* %323, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %324
 
 ; <label>:324                                     ; preds = %321
   store i64 %322, i64* %323, align 8
@@ -1286,15 +1368,15 @@ entry:
 ; <label>:338                                     ; preds = %333
   %339 = load i8*, i8** %arg0
   %340 = load i8*, i8** %arg1
-  %NullCheck136 = icmp ne i8* %340, null
-  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+  %NullCheck135 = icmp eq i8* %340, null
+  br i1 %NullCheck135, label %ThrowNullRef136, label %341
 
 ; <label>:341                                     ; preds = %338
   %342 = load i8, i8* %340, align 8
   %343 = zext i8 %342 to i32
   %344 = trunc i32 %343 to i8
-  %NullCheck138 = icmp ne i8* %339, null
-  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+  %NullCheck137 = icmp eq i8* %339, null
+  br i1 %NullCheck137, label %ThrowNullRef138, label %345
 
 ; <label>:345                                     ; preds = %341
   store i8 %344, i8* %339, align 8
@@ -1317,16 +1399,16 @@ entry:
   %357 = load i8*, i8** %arg0
   %358 = load i8*, i8** %arg1
   %359 = bitcast i8* %358 to i16*
-  %NullCheck140 = icmp ne i16* %359, null
-  br i1 %NullCheck140, label %360, label %ThrowNullRef139
+  %NullCheck139 = icmp eq i16* %359, null
+  br i1 %NullCheck139, label %ThrowNullRef140, label %360
 
 ; <label>:360                                     ; preds = %356
   %361 = load i16, i16* %359, align 8
   %362 = sext i16 %361 to i32
   %363 = bitcast i8* %357 to i16*
   %364 = trunc i32 %362 to i16
-  %NullCheck142 = icmp ne i16* %363, null
-  br i1 %NullCheck142, label %365, label %ThrowNullRef141
+  %NullCheck141 = icmp eq i16* %363, null
+  br i1 %NullCheck141, label %ThrowNullRef142, label %365
 
 ; <label>:365                                     ; preds = %360
   store i16 %364, i16* %363, align 8
@@ -1352,14 +1434,14 @@ entry:
   %378 = load i8*, i8** %arg0
   %379 = load i8*, i8** %arg1
   %380 = bitcast i8* %379 to i32*
-  %NullCheck144 = icmp ne i32* %380, null
-  br i1 %NullCheck144, label %381, label %ThrowNullRef143
+  %NullCheck143 = icmp eq i32* %380, null
+  br i1 %NullCheck143, label %ThrowNullRef144, label %381
 
 ; <label>:381                                     ; preds = %377
   %382 = load i32, i32* %380, align 8
   %383 = bitcast i8* %378 to i32*
-  %NullCheck146 = icmp ne i32* %383, null
-  br i1 %NullCheck146, label %384, label %ThrowNullRef145
+  %NullCheck145 = icmp eq i32* %383, null
+  br i1 %NullCheck145, label %ThrowNullRef146, label %384
 
 ; <label>:384                                     ; preds = %381
   store i32 %382, i32* %383, align 8
@@ -1384,14 +1466,14 @@ entry:
   %395 = load i8*, i8** %arg0
   %396 = load i8*, i8** %arg1
   %397 = bitcast i8* %396 to i64*
-  %NullCheck164 = icmp ne i64* %397, null
-  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+  %NullCheck163 = icmp eq i64* %397, null
+  br i1 %NullCheck163, label %ThrowNullRef164, label %398
 
 ; <label>:398                                     ; preds = %394
   %399 = load i64, i64* %397, align 8
   %400 = bitcast i8* %395 to i64*
-  %NullCheck166 = icmp ne i64* %400, null
-  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+  %NullCheck165 = icmp eq i64* %400, null
+  br i1 %NullCheck165, label %ThrowNullRef166, label %401
 
 ; <label>:401                                     ; preds = %398
   store i64 %399, i64* %400, align 8
@@ -1400,14 +1482,14 @@ entry:
   %404 = load i8*, i8** %arg1
   %405 = getelementptr inbounds i8, i8* %404, i64 8
   %406 = bitcast i8* %405 to i64*
-  %NullCheck168 = icmp ne i64* %406, null
-  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+  %NullCheck167 = icmp eq i64* %406, null
+  br i1 %NullCheck167, label %ThrowNullRef168, label %407
 
 ; <label>:407                                     ; preds = %401
   %408 = load i64, i64* %406, align 8
   %409 = bitcast i8* %403 to i64*
-  %NullCheck170 = icmp ne i64* %409, null
-  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+  %NullCheck169 = icmp eq i64* %409, null
+  br i1 %NullCheck169, label %ThrowNullRef170, label %410
 
 ; <label>:410                                     ; preds = %407
   store i64 %408, i64* %409, align 8
@@ -1437,14 +1519,14 @@ entry:
   %425 = load i8*, i8** %arg0
   %426 = load i8*, i8** %arg1
   %427 = bitcast i8* %426 to i64*
-  %NullCheck148 = icmp ne i64* %427, null
-  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+  %NullCheck147 = icmp eq i64* %427, null
+  br i1 %NullCheck147, label %ThrowNullRef148, label %428
 
 ; <label>:428                                     ; preds = %424
   %429 = load i64, i64* %427, align 8
   %430 = bitcast i8* %425 to i64*
-  %NullCheck150 = icmp ne i64* %430, null
-  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+  %NullCheck149 = icmp eq i64* %430, null
+  br i1 %NullCheck149, label %ThrowNullRef150, label %431
 
 ; <label>:431                                     ; preds = %428
   store i64 %429, i64* %430, align 8
@@ -1466,14 +1548,14 @@ entry:
   %441 = load i8*, i8** %arg0
   %442 = load i8*, i8** %arg1
   %443 = bitcast i8* %442 to i32*
-  %NullCheck152 = icmp ne i32* %443, null
-  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+  %NullCheck151 = icmp eq i32* %443, null
+  br i1 %NullCheck151, label %ThrowNullRef152, label %444
 
 ; <label>:444                                     ; preds = %440
   %445 = load i32, i32* %443, align 8
   %446 = bitcast i8* %441 to i32*
-  %NullCheck154 = icmp ne i32* %446, null
-  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+  %NullCheck153 = icmp eq i32* %446, null
+  br i1 %NullCheck153, label %ThrowNullRef154, label %447
 
 ; <label>:447                                     ; preds = %444
   store i32 %445, i32* %446, align 8
@@ -1495,16 +1577,16 @@ entry:
   %457 = load i8*, i8** %arg0
   %458 = load i8*, i8** %arg1
   %459 = bitcast i8* %458 to i16*
-  %NullCheck156 = icmp ne i16* %459, null
-  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+  %NullCheck155 = icmp eq i16* %459, null
+  br i1 %NullCheck155, label %ThrowNullRef156, label %460
 
 ; <label>:460                                     ; preds = %456
   %461 = load i16, i16* %459, align 8
   %462 = sext i16 %461 to i32
   %463 = bitcast i8* %457 to i16*
   %464 = trunc i32 %462 to i16
-  %NullCheck158 = icmp ne i16* %463, null
-  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+  %NullCheck157 = icmp eq i16* %463, null
+  br i1 %NullCheck157, label %ThrowNullRef158, label %465
 
 ; <label>:465                                     ; preds = %460
   store i16 %464, i16* %463, align 8
@@ -1525,15 +1607,15 @@ entry:
 ; <label>:474                                     ; preds = %470
   %475 = load i8*, i8** %arg0
   %476 = load i8*, i8** %arg1
-  %NullCheck160 = icmp ne i8* %476, null
-  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+  %NullCheck159 = icmp eq i8* %476, null
+  br i1 %NullCheck159, label %ThrowNullRef160, label %477
 
 ; <label>:477                                     ; preds = %474
   %478 = load i8, i8* %476, align 8
   %479 = zext i8 %478 to i32
   %480 = trunc i32 %479 to i8
-  %NullCheck162 = icmp ne i8* %475, null
-  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+  %NullCheck161 = icmp eq i8* %475, null
+  br i1 %NullCheck161, label %ThrowNullRef162, label %481
 
 ; <label>:481                                     ; preds = %477
   store i8 %480, i8* %475, align 8
@@ -1553,343 +1635,343 @@ ThrowNullRef:                                     ; preds = %308
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %312
+ThrowNullRef2:                                    ; preds = %312
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %315
+ThrowNullRef4:                                    ; preds = %315
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %321
+ThrowNullRef6:                                    ; preds = %321
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %271
+ThrowNullRef8:                                    ; preds = %271
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %275
+ThrowNullRef10:                                   ; preds = %275
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %278
+ThrowNullRef12:                                   ; preds = %278
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %284
+ThrowNullRef14:                                   ; preds = %284
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %287
+ThrowNullRef16:                                   ; preds = %287
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %293
+ThrowNullRef18:                                   ; preds = %293
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %298
+ThrowNullRef20:                                   ; preds = %298
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %303
+ThrowNullRef22:                                   ; preds = %303
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %243
+ThrowNullRef24:                                   ; preds = %243
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %247
+ThrowNullRef26:                                   ; preds = %247
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %250
+ThrowNullRef28:                                   ; preds = %250
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %256
+ThrowNullRef30:                                   ; preds = %256
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %259
+ThrowNullRef32:                                   ; preds = %259
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %265
+ThrowNullRef34:                                   ; preds = %265
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %217
+ThrowNullRef36:                                   ; preds = %217
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %221
+ThrowNullRef38:                                   ; preds = %221
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %224
+ThrowNullRef40:                                   ; preds = %224
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %230
+ThrowNullRef42:                                   ; preds = %230
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %233
+ThrowNullRef44:                                   ; preds = %233
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %238
+ThrowNullRef46:                                   ; preds = %238
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %200
+ThrowNullRef48:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %204
+ThrowNullRef50:                                   ; preds = %204
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %207
+ThrowNullRef52:                                   ; preds = %207
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %213
+ThrowNullRef54:                                   ; preds = %213
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %172
+ThrowNullRef56:                                   ; preds = %172
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %176
+ThrowNullRef58:                                   ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %179
+ThrowNullRef60:                                   ; preds = %179
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %185
+ThrowNullRef62:                                   ; preds = %185
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %190
+ThrowNullRef64:                                   ; preds = %190
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %195
+ThrowNullRef66:                                   ; preds = %195
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %153
+ThrowNullRef68:                                   ; preds = %153
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %157
+ThrowNullRef70:                                   ; preds = %157
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %160
+ThrowNullRef72:                                   ; preds = %160
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %166
+ThrowNullRef74:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %136
+ThrowNullRef76:                                   ; preds = %136
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %140
+ThrowNullRef78:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %143
+ThrowNullRef80:                                   ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %148
+ThrowNullRef82:                                   ; preds = %148
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %128
+ThrowNullRef84:                                   ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %132
+ThrowNullRef86:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %100
+ThrowNullRef88:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %104
+ThrowNullRef90:                                   ; preds = %104
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %107
+ThrowNullRef92:                                   ; preds = %107
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %113
+ThrowNullRef94:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %118
+ThrowNullRef96:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %123
+ThrowNullRef98:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %81
+ThrowNullRef100:                                  ; preds = %81
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef101:                                  ; preds = %85
+ThrowNullRef102:                                  ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef103:                                  ; preds = %88
+ThrowNullRef104:                                  ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef105:                                  ; preds = %94
+ThrowNullRef106:                                  ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef107:                                  ; preds = %64
+ThrowNullRef108:                                  ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef109:                                  ; preds = %68
+ThrowNullRef110:                                  ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef111:                                  ; preds = %71
+ThrowNullRef112:                                  ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef113:                                  ; preds = %76
+ThrowNullRef114:                                  ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef115:                                  ; preds = %56
+ThrowNullRef116:                                  ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef117:                                  ; preds = %60
+ThrowNullRef118:                                  ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef119:                                  ; preds = %37
+ThrowNullRef120:                                  ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef121:                                  ; preds = %41
+ThrowNullRef122:                                  ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef123:                                  ; preds = %46
+ThrowNullRef124:                                  ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef125:                                  ; preds = %51
+ThrowNullRef126:                                  ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef127:                                  ; preds = %27
+ThrowNullRef128:                                  ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef129:                                  ; preds = %31
+ThrowNullRef130:                                  ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef131:                                  ; preds = %19
+ThrowNullRef132:                                  ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef133:                                  ; preds = %22
+ThrowNullRef134:                                  ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef135:                                  ; preds = %338
+ThrowNullRef136:                                  ; preds = %338
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef137:                                  ; preds = %341
+ThrowNullRef138:                                  ; preds = %341
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef139:                                  ; preds = %356
+ThrowNullRef140:                                  ; preds = %356
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef141:                                  ; preds = %360
+ThrowNullRef142:                                  ; preds = %360
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef143:                                  ; preds = %377
+ThrowNullRef144:                                  ; preds = %377
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef145:                                  ; preds = %381
+ThrowNullRef146:                                  ; preds = %381
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef147:                                  ; preds = %424
+ThrowNullRef148:                                  ; preds = %424
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef149:                                  ; preds = %428
+ThrowNullRef150:                                  ; preds = %428
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef151:                                  ; preds = %440
+ThrowNullRef152:                                  ; preds = %440
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef153:                                  ; preds = %444
+ThrowNullRef154:                                  ; preds = %444
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef155:                                  ; preds = %456
+ThrowNullRef156:                                  ; preds = %456
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef157:                                  ; preds = %460
+ThrowNullRef158:                                  ; preds = %460
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef159:                                  ; preds = %474
+ThrowNullRef160:                                  ; preds = %474
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef161:                                  ; preds = %477
+ThrowNullRef162:                                  ; preds = %477
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef163:                                  ; preds = %394
+ThrowNullRef164:                                  ; preds = %394
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef165:                                  ; preds = %398
+ThrowNullRef166:                                  ; preds = %398
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef167:                                  ; preds = %401
+ThrowNullRef168:                                  ; preds = %401
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef169:                                  ; preds = %407
+ThrowNullRef170:                                  ; preds = %407
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1939,8 +2021,8 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
-  br i1 %NullCheck, label %22, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %ThrowNullRef, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
@@ -1948,8 +2030,8 @@ entry:
   store i32 %24, i32* %loc0
   %25 = load i32, i32* %loc0
   %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %26, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %27
 
 ; <label>:27                                      ; preds = %22
   %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
@@ -1971,7 +2053,7 @@ ThrowNullRef:                                     ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1989,8 +2071,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -2022,15 +2104,15 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2048,16 +2130,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
   %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
   store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %15
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
@@ -2072,8 +2154,8 @@ entry:
   %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
   %29 = ptrtoint i16 addrspace(1)* %28 to i64
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %19
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
@@ -2089,19 +2171,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2114,8 +2196,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
@@ -2128,7 +2210,7 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[loadElem]
+Failed to read AppDomain.PrepareDataForSetup[storeElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
@@ -2202,8 +2284,8 @@ entry:
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
-  br i1 %NullCheck24, label %27, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = load i64, i64 addrspace(1)* %26
@@ -2218,8 +2300,8 @@ entry:
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
-  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
   %41 = load i64, i64 addrspace(1)* %39
@@ -2236,8 +2318,8 @@ entry:
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
-  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
   %54 = load i64, i64 addrspace(1)* %52
@@ -2252,8 +2334,8 @@ entry:
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
   %67 = load i64, i64 addrspace(1)* %65
@@ -2270,8 +2352,8 @@ entry:
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
-  br i1 %NullCheck16, label %79, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
   %80 = load i64, i64 addrspace(1)* %78
@@ -2286,8 +2368,8 @@ entry:
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
-  br i1 %NullCheck18, label %92, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
   %93 = load i64, i64 addrspace(1)* %91
@@ -2304,8 +2386,8 @@ entry:
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
-  br i1 %NullCheck12, label %105, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = load i64, i64 addrspace(1)* %104
@@ -2320,8 +2402,8 @@ entry:
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
-  br i1 %NullCheck14, label %118, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
   %119 = load i64, i64 addrspace(1)* %117
@@ -2337,8 +2419,8 @@ entry:
 
 ; <label>:128                                     ; preds = %20
   %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
-  br i1 %NullCheck4, label %130, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %129, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %130
 
 ; <label>:130                                     ; preds = %128
   %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
@@ -2346,8 +2428,8 @@ entry:
   %133 = load i16, i16 addrspace(1)* %132, align 8
   %134 = zext i16 %133 to i32
   %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
-  br i1 %NullCheck6, label %136, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %135, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %136
 
 ; <label>:136                                     ; preds = %130
   %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
@@ -2360,8 +2442,8 @@ entry:
 
 ; <label>:143                                     ; preds = %136
   %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
-  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %144, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %145
 
 ; <label>:145                                     ; preds = %143
   %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
@@ -2369,8 +2451,8 @@ entry:
   %148 = load i16, i16 addrspace(1)* %147, align 8
   %149 = zext i16 %148 to i32
   %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %150, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %151
 
 ; <label>:151                                     ; preds = %145
   %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
@@ -2388,8 +2470,8 @@ entry:
 
 ; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
-  br i1 %NullCheck, label %163, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %ThrowNullRef, label %163
 
 ; <label>:163                                     ; preds = %161
   %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
@@ -2399,8 +2481,8 @@ entry:
 
 ; <label>:167                                     ; preds = %163
   %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
-  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %168, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %169
 
 ; <label>:169                                     ; preds = %167
   %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
@@ -2432,55 +2514,55 @@ ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %167
+ThrowNullRef2:                                    ; preds = %167
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %128
+ThrowNullRef4:                                    ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %130
+ThrowNullRef6:                                    ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %143
+ThrowNullRef8:                                    ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %145
+ThrowNullRef10:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %102
+ThrowNullRef12:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %105
+ThrowNullRef14:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %76
+ThrowNullRef16:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %79
+ThrowNullRef18:                                   ; preds = %79
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %50
+ThrowNullRef20:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %53
+ThrowNullRef22:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %24
+ThrowNullRef24:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %27
+ThrowNullRef26:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2503,15 +2585,15 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2519,16 +2601,16 @@ entry:
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
   store i32 %8, i32* %loc0
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
   %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
   store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
@@ -2546,16 +2628,16 @@ entry:
 
 ; <label>:23                                      ; preds = %64
   %24 = load i16*, i16** %loc3
-  %NullCheck12 = icmp ne i16* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i16* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
   store i32 %27, i32* %loc5
   %28 = load i16*, i16** %loc4
-  %NullCheck14 = icmp ne i16* %28, null
-  br i1 %NullCheck14, label %29, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %28, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = load i16, i16* %28, align 8
@@ -2620,15 +2702,15 @@ entry:
 
 ; <label>:67                                      ; preds = %64
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
-  br i1 %NullCheck8, label %69, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %68, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %69
 
 ; <label>:69                                      ; preds = %67
   %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
   %71 = load i32, i32 addrspace(1)* %70
   %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
-  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %73
 
 ; <label>:73                                      ; preds = %69
   %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
@@ -2645,31 +2727,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %67
+ThrowNullRef8:                                    ; preds = %67
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %69
+ThrowNullRef10:                                   ; preds = %69
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2710,14 +2792,14 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
   %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
@@ -2730,14 +2812,14 @@ entry:
 
 ; <label>:11                                      ; preds = %4
   %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
   %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
@@ -2749,14 +2831,14 @@ entry:
 
 ; <label>:22                                      ; preds = %16
   %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
   %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
-  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
-  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
@@ -2804,23 +2886,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2836,7 +2918,280 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[loadElem]
+Successfully read RuntimeType.IsAssignableFrom
+
+define i8 @RuntimeType.IsAssignableFrom(%System.RuntimeType addrspace(1)* %param0, %System.Type addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.RuntimeType addrspace(1)*
+  %arg1 = alloca %System.Type addrspace(1)*
+  %loc0 = alloca %System.RuntimeType addrspace(1)*
+  %loc1 = alloca %"System.Type[]" addrspace(1)*
+  %loc2 = alloca i32
+  store %System.RuntimeType addrspace(1)* %param0, %System.RuntimeType addrspace(1)** %this
+  store %System.Type addrspace(1)* %param1, %System.Type addrspace(1)** %arg1
+  %0 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %1 = icmp ne %System.Type addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i8 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %5 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %6 = bitcast %System.Type addrspace(1)* %4 to %System.Object addrspace(1)*
+  %7 = bitcast %System.RuntimeType addrspace(1)* %5 to %System.Object addrspace(1)*
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %6, %System.Object addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %3
+  ret i8 1
+
+; <label>:12                                      ; preds = %3
+  %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 152
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 32
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
+  %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
+  %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
+  store %System.RuntimeType addrspace(1)* %25, %System.RuntimeType addrspace(1)** %loc0
+  %26 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %27 = icmp eq %System.RuntimeType addrspace(1)* %26, null
+  br i1 %27, label %34, label %28
+
+; <label>:28                                      ; preds = %15
+  %29 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %30 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)*)*)(%System.RuntimeType addrspace(1)* %29, %System.RuntimeType addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+; <label>:34                                      ; preds = %15
+  %35 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %36 = call %System.Reflection.Emit.TypeBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Reflection.Emit.TypeBuilder addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %35)
+  %37 = icmp eq %System.Reflection.Emit.TypeBuilder addrspace(1)* %36, null
+  br i1 %37, label %139, label %38
+
+; <label>:38                                      ; preds = %34
+  %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %42
+
+; <label>:42                                      ; preds = %38
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 152
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 40
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
+  %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
+  %53 = zext i8 %52 to i32
+  %54 = icmp eq i32 %53, 0
+  br i1 %54, label %56, label %55
+
+; <label>:55                                      ; preds = %42
+  ret i8 1
+
+; <label>:56                                      ; preds = %42
+  %57 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %58 = bitcast %System.RuntimeType addrspace(1)* %57 to %System.Type addrspace(1)*
+  %59 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %58)
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %64 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.Type addrspace(1)* %63, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = bitcast %System.RuntimeType addrspace(1)* %64 to %System.Type addrspace(1)*
+  %67 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %63, %System.Type addrspace(1)* %66)
+  %68 = zext i8 %67 to i32
+  %69 = trunc i32 %68 to i8
+  ret i8 %69
+
+; <label>:70                                      ; preds = %56
+  %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
+  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %73
+
+; <label>:73                                      ; preds = %70
+  %74 = load i64, i64 addrspace(1)* %72
+  %75 = add i64 %74, 128
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = add i64 %77, 0
+  %79 = inttoptr i64 %78 to i64*
+  %80 = load i64, i64* %79
+  %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
+  %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
+  %83 = call i8 %82(%System.Type addrspace(1)* %81)
+  %84 = zext i8 %83 to i32
+  %85 = icmp eq i32 %84, 0
+  br i1 %85, label %139, label %86
+
+; <label>:86                                      ; preds = %73
+  %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
+  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %89
+
+; <label>:89                                      ; preds = %86
+  %90 = load i64, i64 addrspace(1)* %88
+  %91 = add i64 %90, 128
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = add i64 %93, 24
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
+  %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
+  %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
+  store %"System.Type[]" addrspace(1)* %99, %"System.Type[]" addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %129
+
+; <label>:100                                     ; preds = %132
+  %101 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %102 = load i32, i32* %loc2
+  %NullCheck11 = icmp eq %"System.Type[]" addrspace(1)* %101, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %103
+
+; <label>:103                                     ; preds = %100
+  %104 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 1
+  %105 = load i32, i32 addrspace(1)* %104
+  %106 = zext i32 %105 to i64
+  %107 = zext i32 %102 to i64
+  %BoundsCheck = icmp uge i64 %107, %106
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %108
+
+; <label>:108                                     ; preds = %103
+  %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
+  %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
+  %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
+  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %113
+
+; <label>:113                                     ; preds = %108
+  %114 = load i64, i64 addrspace(1)* %112
+  %115 = add i64 %114, 152
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = add i64 %117, 56
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
+  %123 = zext i8 %122 to i32
+  %124 = icmp ne i32 %123, 0
+  br i1 %124, label %126, label %125
+
+; <label>:125                                     ; preds = %113
+  ret i8 0
+
+; <label>:126                                     ; preds = %113
+  %127 = load i32, i32* %loc2
+  %128 = add i32 %127, 1
+  store i32 %128, i32* %loc2
+  br label %129
+
+; <label>:129                                     ; preds = %89, %126
+  %130 = load i32, i32* %loc2
+  %131 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %NullCheck9 = icmp eq %"System.Type[]" addrspace(1)* %131, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %132
+
+; <label>:132                                     ; preds = %129
+  %133 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %131, i32 0, i32 1
+  %134 = load i32, i32 addrspace(1)* %133
+  %135 = zext i32 %134 to i64
+  %136 = trunc i64 %135 to i32
+  %137 = icmp slt i32 %130, %136
+  br i1 %137, label %100, label %138
+
+; <label>:138                                     ; preds = %132
+  ret i8 1
+
+; <label>:139                                     ; preds = %34, %73
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %129
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %103
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -2893,7 +3248,7 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElem]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -2904,8 +3259,8 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -2997,8 +3352,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
@@ -3059,8 +3414,8 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -3087,8 +3442,8 @@ entry:
 
 ; <label>:17                                      ; preds = %5, %11
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
@@ -3097,8 +3452,8 @@ entry:
 
 ; <label>:22                                      ; preds = %1, %11
   %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
@@ -3109,11 +3464,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %17
+ThrowNullRef2:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %22
+ThrowNullRef4:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3167,15 +3522,15 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
   %15 = load i32, i32 addrspace(1)* %14
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
@@ -3198,7 +3553,7 @@ ThrowNullRef:                                     ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef2:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3232,8 +3587,8 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
@@ -3312,8 +3667,8 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -3327,8 +3682,8 @@ entry:
 ; <label>:5                                       ; preds = %43
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %7 = load i32, i32* %loc1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck6, label %8, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
@@ -3366,8 +3721,8 @@ entry:
 ; <label>:32                                      ; preds = %21, %25
   %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
   %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
-  br i1 %NullCheck8, label %35, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = trunc i32 %34 to i16
@@ -3380,8 +3735,8 @@ entry:
 ; <label>:40                                      ; preds = %1, %35
   %41 = load i32, i32* %loc1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
-  br i1 %NullCheck2, label %43, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %42, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
@@ -3392,8 +3747,8 @@ entry:
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
   %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
-  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
   %51 = load i64, i64 addrspace(1)* %49
@@ -3412,19 +3767,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %40
+ThrowNullRef2:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %47
+ThrowNullRef4:                                    ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %5
+ThrowNullRef6:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %32
+ThrowNullRef8:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3467,8 +3822,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
@@ -3492,11 +3847,391 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(i16* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store i16* %param0, i16** %arg0
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load i32, i32* %arg3
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %42, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %37, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg2
+  %13 = load i32, i32* %arg3
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %37, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %24 = load i32, i32* %arg2
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load i16*, i16** %arg0
+  %35 = load i32, i32* %arg3
+  %36 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %36, i16* %34, i32 %35)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:37                                      ; preds = %5, %16
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %39)
+  %41 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41, %System.String addrspace(1)* %38, %System.String addrspace(1)* %40)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41) #0
+  unreachable
+
+; <label>:42                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
-Failed to read StringBuilder.ToString[loadElemA]
+Successfully read StringBuilder.ToString
+
+define %System.String addrspace(1)* @StringBuilder.ToString(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i16*
+  %loc3 = alloca %"System.Char[]" addrspace(1)*
+  %loc4 = alloca i32
+  %loc5 = alloca i32
+  %loc6 = alloca i16 addrspace(1)*
+  %loc7 = alloca %System.String addrspace(1)*
+  %loc8 = alloca %"System.Char[]" addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %0)
+  %2 = icmp ne i32 %1, 0
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %4
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %6)
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %7)
+  store %System.String addrspace(1)* %8, %System.String addrspace(1)** %loc0
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.Text.StringBuilder addrspace(1)* %9, %System.Text.StringBuilder addrspace(1)** %loc1
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  store %System.String addrspace(1)* %10, %System.String addrspace(1)** %loc7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc7
+  %12 = ptrtoint %System.String addrspace(1)* %11 to i64
+  %13 = icmp eq i64 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %5
+  %15 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %16 = sext i32 %15 to i64
+  %17 = add i64 %12, %16
+  br label %18
+
+; <label>:18                                      ; preds = %5, %14
+  %19 = phi i64 [ %12, %5 ], [ %17, %14 ]
+  %20 = inttoptr i64 %19 to i16*
+  store i16* %20, i16** %loc2
+  br label %21
+
+; <label>:21                                      ; preds = %98, %18
+  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %22, null
+  br i1 %NullCheck, label %ThrowNullRef, label %23
+
+; <label>:23                                      ; preds = %21
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 3
+  %25 = load i32, i32 addrspace(1)* %24, align 8
+  %26 = icmp sle i32 %25, 0
+  br i1 %26, label %96, label %27
+
+; <label>:27                                      ; preds = %23
+  %28 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %28, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %29
+
+; <label>:29                                      ; preds = %27
+  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %28, i32 0, i32 1
+  %31 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %30, align 8
+  store %"System.Char[]" addrspace(1)* %31, %"System.Char[]" addrspace(1)** %loc3
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %33
+
+; <label>:33                                      ; preds = %29
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  store i32 %35, i32* %loc4
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  %39 = load i32, i32 addrspace(1)* %38, align 8
+  store i32 %39, i32* %loc5
+  %40 = load i32, i32* %loc5
+  %41 = load i32, i32* %loc4
+  %42 = add i32 %40, %41
+  %43 = zext i32 %42 to i64
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %45
+
+; <label>:45                                      ; preds = %37
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = sext i32 %47 to i64
+  %49 = icmp sgt i64 %43, %48
+  br i1 %49, label %91, label %50
+
+; <label>:50                                      ; preds = %45
+  %51 = load i32, i32* %loc5
+  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %52, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %53
+
+; <label>:53                                      ; preds = %50
+  %54 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %52, i32 0, i32 1
+  %55 = load i32, i32 addrspace(1)* %54
+  %56 = zext i32 %55 to i64
+  %57 = trunc i64 %56 to i32
+  %58 = icmp ugt i32 %51, %57
+  br i1 %58, label %91, label %59
+
+; <label>:59                                      ; preds = %53
+  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  store %"System.Char[]" addrspace(1)* %60, %"System.Char[]" addrspace(1)** %loc8
+  %61 = icmp eq %"System.Char[]" addrspace(1)* %60, null
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %63, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %64
+
+; <label>:64                                      ; preds = %62
+  %65 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %63, i32 0, i32 1
+  %66 = load i32, i32 addrspace(1)* %65
+  %67 = zext i32 %66 to i64
+  %68 = trunc i64 %67 to i32
+  %69 = icmp ne i32 %68, 0
+  br i1 %69, label %71, label %70
+
+; <label>:70                                      ; preds = %59, %64
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:71                                      ; preds = %64
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %73
+
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %BoundsCheck = icmp uge i64 0, %76
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %77
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %78, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:79                                      ; preds = %70, %77
+  %80 = load i16*, i16** %loc2
+  %81 = load i32, i32* %loc4
+  %82 = sext i32 %81 to i64
+  %83 = mul i64 %82, 2
+  %84 = bitcast i16* %80 to i8*
+  %85 = getelementptr inbounds i8, i8* %84, i64 %83
+  %86 = load i16 addrspace(1)*, i16 addrspace(1)** %loc6
+  %87 = ptrtoint i16 addrspace(1)* %86 to i64
+  %88 = load i32, i32* %loc5
+  %89 = bitcast i8* %85 to i16*
+  %90 = inttoptr i64 %87 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %89, i16* %90, i32 %88)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %96
+
+; <label>:91                                      ; preds = %45, %53
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %94 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %93)
+  %95 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95, %System.String addrspace(1)* %92, %System.String addrspace(1)* %94)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95) #0
+  unreachable
+
+; <label>:96                                      ; preds = %23, %79
+  %97 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %97, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %98
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %97, i32 0, i32 2
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  store %System.Text.StringBuilder addrspace(1)* %100, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %102 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %102, label %21, label %103
+
+; <label>:103                                     ; preds = %98
+  store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc7
+  %104 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  ret %System.String addrspace(1)* %104
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method StringBuilder::get_Length using LLILCJit
+Successfully read StringBuilder.get_Length
+
+define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
+Successfully read RuntimeHelpers.get_OffsetToStringData
+
+define i32 @RuntimeHelpers.get_OffsetToStringData() {
+entry:
+  ret i32 12
+}
+
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
 Successfully read CultureData.CreateCultureData
 
@@ -3514,23 +4249,23 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
   store i8 %4, i8 addrspace(1)* %6
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
@@ -3549,11 +4284,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3566,50 +4301,50 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
   store i32 -1, i32 addrspace(1)* %2
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
   store i32 -1, i32 addrspace(1)* %8
   %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
   store i32 -1, i32 addrspace(1)* %14
   %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
   store i32 -1, i32 addrspace(1)* %17
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
@@ -3623,27 +4358,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3675,7 +4410,136 @@ Failed to read Dictionary`2.Insert[non-const derefAddress]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
 Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
-Failed to read HashHelpers.GetPrime[loadElem]
+Successfully read HashHelpers.GetPrime
+
+define i32 @HashHelpers.GetPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %6, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5, %System.String addrspace(1)* %4)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5) #0
+  unreachable
+
+; <label>:6                                       ; preds = %entry
+  store i32 0, i32* %loc0
+  br label %29
+
+; <label>:7                                       ; preds = %35
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 1296
+  %10 = addrspacecast i8 addrspace(1)* %9 to %"System.Int32[]" addrspace(1)**
+  %11 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %10
+  %12 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Int32[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = zext i32 %15 to i64
+  %17 = zext i32 %12 to i64
+  %BoundsCheck = icmp uge i64 %17, %16
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 3, i32 %12
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  store i32 %20, i32* %loc1
+  %21 = load i32, i32* %loc1
+  %22 = load i32, i32* %arg0
+  %23 = icmp slt i32 %21, %22
+  br i1 %23, label %26, label %24
+
+; <label>:24                                      ; preds = %18
+  %25 = load i32, i32* %loc1
+  ret i32 %25
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %loc0
+  %28 = add i32 %27, 1
+  store i32 %28, i32* %loc0
+  br label %29
+
+; <label>:29                                      ; preds = %6, %26
+  %30 = load i32, i32* %loc0
+  %31 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %32 = getelementptr inbounds i8, i8 addrspace(1)* %31, i64 1296
+  %33 = addrspacecast i8 addrspace(1)* %32 to %"System.Int32[]" addrspace(1)**
+  %34 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %33
+  %NullCheck = icmp eq %"System.Int32[]" addrspace(1)* %34, null
+  br i1 %NullCheck, label %ThrowNullRef, label %35
+
+; <label>:35                                      ; preds = %29
+  %36 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %34, i32 0, i32 1
+  %37 = load i32, i32 addrspace(1)* %36
+  %38 = zext i32 %37 to i64
+  %39 = trunc i64 %38 to i32
+  %40 = icmp slt i32 %30, %39
+  br i1 %40, label %7, label %41
+
+; <label>:41                                      ; preds = %35
+  %42 = load i32, i32* %arg0
+  %43 = or i32 %42, 1
+  store i32 %43, i32* %loc2
+  br label %59
+
+; <label>:44                                      ; preds = %59
+  %45 = load i32, i32* %loc2
+  %46 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %45)
+  %47 = zext i8 %46 to i32
+  %48 = icmp eq i32 %47, 0
+  br i1 %48, label %56, label %49
+
+; <label>:49                                      ; preds = %44
+  %50 = load i32, i32* %loc2
+  %51 = sub i32 %50, 1
+  %52 = srem i32 %51, 101
+  %53 = icmp eq i32 %52, 0
+  br i1 %53, label %56, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = load i32, i32* %loc2
+  ret i32 %55
+
+; <label>:56                                      ; preds = %44, %49
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %57, 2
+  store i32 %58, i32* %loc2
+  br label %59
+
+; <label>:59                                      ; preds = %41, %56
+  %60 = load i32, i32* %loc2
+  %61 = icmp slt i32 %60, 2147483647
+  br i1 %61, label %44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load i32, i32* %arg0
+  ret i32 %63
+
+ThrowNullRef:                                     ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
 Successfully read GenericEqualityComparer`1.GetHashCode
 
@@ -3694,14 +4558,14 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
   %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load i64, i64 addrspace(1)* %7
@@ -3720,7 +4584,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3750,8 +4614,8 @@ entry:
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
@@ -3796,8 +4660,8 @@ entry:
   %35 = bitcast i16* %34 to i8*
   %36 = getelementptr inbounds i8, i8* %35, i64 2
   %37 = bitcast i8* %36 to i16*
-  %NullCheck4 = icmp ne i16* %37, null
-  br i1 %NullCheck4, label %38, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %37, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %38
 
 ; <label>:38                                      ; preds = %27
   %39 = load i16, i16* %37, align 8
@@ -3824,8 +4688,8 @@ entry:
 
 ; <label>:54                                      ; preds = %22, %43
   %55 = load i16*, i16** %loc4
-  %NullCheck2 = icmp ne i16* %55, null
-  br i1 %NullCheck2, label %56, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i16* %55, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %56
 
 ; <label>:56                                      ; preds = %54
   %57 = load i16, i16* %55, align 8
@@ -3850,11 +4714,11 @@ ThrowNullRef:                                     ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %54
+ThrowNullRef2:                                    ; preds = %54
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %27
+ThrowNullRef4:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3871,8 +4735,8 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -3907,8 +4771,8 @@ entry:
 
 ; <label>:26                                      ; preds = %19
   %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
-  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %28
 
 ; <label>:28                                      ; preds = %26
   %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
@@ -3920,7 +4784,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3972,8 +4836,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
@@ -3984,26 +4848,26 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
-  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
@@ -4014,8 +4878,8 @@ entry:
 ; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
@@ -4024,8 +4888,8 @@ entry:
 
 ; <label>:25                                      ; preds = %1, %16, %23
   %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
-  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
@@ -4036,27 +4900,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %20
+ThrowNullRef10:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4069,8 +4933,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -4081,8 +4945,8 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
@@ -4091,8 +4955,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1, %8
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
@@ -4103,11 +4967,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4128,24 +4992,24 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   store i32 %3, i32* %loc0
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
   %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
   store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck4, label %9, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
@@ -4164,15 +5028,15 @@ entry:
 ; <label>:18                                      ; preds = %70
   %19 = load i16*, i16** %loc3
   %20 = bitcast i16* %19 to i64*
-  %NullCheck10 = icmp ne i64* %20, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %20, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = load i64, i64* %20, align 8
   %23 = load i16*, i16** %loc4
   %24 = bitcast i16* %23 to i64*
-  %NullCheck12 = icmp ne i64* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = load i64, i64* %24, align 8
@@ -4188,8 +5052,8 @@ entry:
   %31 = bitcast i16* %30 to i8*
   %32 = getelementptr inbounds i8, i8* %31, i64 8
   %33 = bitcast i8* %32 to i64*
-  %NullCheck14 = icmp ne i64* %33, null
-  br i1 %NullCheck14, label %34, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = load i64, i64* %33, align 8
@@ -4197,8 +5061,8 @@ entry:
   %37 = bitcast i16* %36 to i8*
   %38 = getelementptr inbounds i8, i8* %37, i64 8
   %39 = bitcast i8* %38 to i64*
-  %NullCheck16 = icmp ne i64* %39, null
-  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %40
 
 ; <label>:40                                      ; preds = %34
   %41 = load i64, i64* %39, align 8
@@ -4214,8 +5078,8 @@ entry:
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %NullCheck18 = icmp ne i64* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = load i64, i64* %48, align 8
@@ -4223,8 +5087,8 @@ entry:
   %52 = bitcast i16* %51 to i8*
   %53 = getelementptr inbounds i8, i8* %52, i64 16
   %54 = bitcast i8* %53 to i64*
-  %NullCheck20 = icmp ne i64* %54, null
-  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64* %54, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %55
 
 ; <label>:55                                      ; preds = %49
   %56 = load i64, i64* %54, align 8
@@ -4262,15 +5126,15 @@ entry:
 ; <label>:74                                      ; preds = %95
   %75 = load i16*, i16** %loc3
   %76 = bitcast i16* %75 to i32*
-  %NullCheck6 = icmp ne i32* %76, null
-  br i1 %NullCheck6, label %77, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32* %76, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %77
 
 ; <label>:77                                      ; preds = %74
   %78 = load i32, i32* %76, align 8
   %79 = load i16*, i16** %loc4
   %80 = bitcast i16* %79 to i32*
-  %NullCheck8 = icmp ne i32* %80, null
-  br i1 %NullCheck8, label %81, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i32* %80, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %81
 
 ; <label>:81                                      ; preds = %77
   %82 = load i32, i32* %80, align 8
@@ -4318,43 +5182,43 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %74
+ThrowNullRef6:                                    ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %77
+ThrowNullRef8:                                    ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %29
+ThrowNullRef14:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %34
+ThrowNullRef16:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4376,8 +5240,8 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load i64, i64 addrspace(1)* %4
@@ -4389,8 +5253,8 @@ entry:
   %12 = load i64, i64* %11
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %5
   %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
@@ -4399,8 +5263,8 @@ entry:
   %18 = load i8, i8* %arg2
   %19 = zext i8 %18 to i32
   %20 = trunc i32 %19 to i8
-  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %15
   %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
@@ -4411,11 +5275,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4442,8 +5306,8 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
@@ -4466,16 +5330,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
   %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = load i64, i64 addrspace(1)* %19
@@ -4500,8 +5364,8 @@ entry:
 ; <label>:35                                      ; preds = %30
   %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
@@ -4514,8 +5378,8 @@ entry:
 
 ; <label>:42                                      ; preds = %1, %38
   %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
-  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
@@ -4526,19 +5390,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %35
+ThrowNullRef2:                                    ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %42
+ThrowNullRef8:                                    ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4551,14 +5415,14 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
@@ -4570,7 +5434,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4583,8 +5447,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
@@ -4613,51 +5477,51 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
   %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
   %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
   %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
   %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
-  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
   store i64 %21, i64 addrspace(1)* %23
   %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %25 = load i64, i64* %loc0
-  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
@@ -4668,27 +5532,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %22
+ThrowNullRef12:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4701,8 +5565,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
@@ -4713,19 +5577,19 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
@@ -4734,8 +5598,8 @@ entry:
 
 ; <label>:15                                      ; preds = %1, %13
   %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
@@ -4746,19 +5610,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %15
+ThrowNullRef8:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4771,8 +5635,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -4831,8 +5695,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
@@ -4882,8 +5746,8 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
-  br i1 %NullCheck, label %17, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %ThrowNullRef, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
@@ -4894,15 +5758,15 @@ entry:
 
 ; <label>:22                                      ; preds = %17
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
-  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
   %26 = load i32, i32 addrspace(1)* %25
   %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
-  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %27, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
@@ -4925,8 +5789,8 @@ entry:
 ; <label>:40                                      ; preds = %17
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
-  br i1 %NullCheck6, label %43, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %41, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
@@ -4938,34 +5802,17 @@ ThrowNullRef:                                     ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %24
+ThrowNullRef4:                                    ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %40
+ThrowNullRef6:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
-}
-
-INFO:  jitting method Object::ReferenceEquals using LLILCJit
-Successfully read Object.ReferenceEquals
-
-define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
-entry:
-  %arg0 = alloca %System.Object addrspace(1)*
-  %arg1 = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
-  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
-  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = icmp eq %System.Object addrspace(1)* %0, %1
-  %3 = sext i1 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
 }
 
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
@@ -4978,21 +5825,21 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
   %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
-  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
@@ -5007,28 +5854,28 @@ entry:
 ; <label>:13                                      ; preds = %8, %12
   %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
   %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
   %21 = load i32, i32 addrspace(1)* %20, align 8
   %22 = add i32 %21, 1
-  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
   store i32 %22, i32 addrspace(1)* %24
   %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
@@ -5039,27 +5886,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5077,7 +5924,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::Setup using LLILCJit
-Failed to read AppDomain.Setup[loadElem]
+Failed to read AppDomain.Setup[unbox]
 INFO:  jitting method Thread::GetDomain using LLILCJit
 Successfully read Thread.GetDomain
 
@@ -5108,8 +5955,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
@@ -5122,14 +5969,14 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
   %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
@@ -5141,11 +5988,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5173,8 +6020,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -5189,7 +6036,328 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
 Failed to read KeyCollection.System.Collections.Generic.IEnumerable<TKey>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Successfully read Enumerator.MoveNext
+
+define i8 @Enumerator.MoveNext(%"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.RuntimeTypeHandle* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*
+  %"$TypeArg" = alloca %System.RuntimeTypeHandle*
+  store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
+  %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 8
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %76, label %12
+
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
+  br label %76
+
+; <label>:13                                      ; preds = %85
+  %14 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck19 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %15
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, i32 0, i32 0
+  %17 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %16, align 8
+  %NullCheck21 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, i32 0, i32 2
+  %20 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %19, align 8
+  %21 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck23 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %22
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, i32 0, i32 2
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %NullCheck25 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 3, i32 %24
+  %NullCheck27 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %32
+
+; <label>:32                                      ; preds = %30
+  %33 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, i32 0, i32 2
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = icmp slt i32 %34, 0
+  br i1 %35, label %68, label %36
+
+; <label>:36                                      ; preds = %32
+  %37 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %38 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck29 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %39
+
+; <label>:39                                      ; preds = %36
+  %40 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, i32 0, i32 0
+  %41 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %40, align 8
+  %NullCheck31 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, i32 0, i32 2
+  %44 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %43, align 8
+  %45 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck33 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, i32 0, i32 2
+  %48 = load i32, i32 addrspace(1)* %47, align 8
+  %NullCheck35 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %49
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = zext i32 %51 to i64
+  %53 = zext i32 %48 to i64
+  %BoundsCheck37 = icmp uge i64 %53, %52
+  br i1 %BoundsCheck37, label %ThrowIndexOutOfRange38, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 3, i32 %48
+  %NullCheck39 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %56
+
+; <label>:56                                      ; preds = %54
+  %57 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, i32 0, i32 0
+  %58 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck41 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %59
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %60, %System.__Canon addrspace(1)* %58)
+  %61 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck43 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  %64 = load i32, i32 addrspace(1)* %63, align 8
+  %65 = add i32 %64, 1
+  %NullCheck45 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  store i32 %65, i32 addrspace(1)* %67
+  ret i8 1
+
+; <label>:68                                      ; preds = %32
+  %69 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck47 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %73 = add i32 %72, 1
+  %NullCheck49 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %74
+
+; <label>:74                                      ; preds = %70
+  %75 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  store i32 %73, i32 addrspace(1)* %75
+  br label %76
+
+; <label>:76                                      ; preds = %8, %12, %74
+  %77 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %78
+
+; <label>:78                                      ; preds = %76
+  %79 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, i32 0, i32 2
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck7 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %82
+
+; <label>:82                                      ; preds = %78
+  %83 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, i32 0, i32 0
+  %84 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %83, align 8
+  %NullCheck9 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %85
+
+; <label>:85                                      ; preds = %82
+  %86 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, i32 0, i32 7
+  %87 = load i32, i32 addrspace(1)* %86, align 8
+  %88 = icmp ult i32 %80, %87
+  br i1 %88, label %13, label %89
+
+; <label>:89                                      ; preds = %85
+  %90 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %91 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck11 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %92
+
+; <label>:92                                      ; preds = %89
+  %93 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, i32 0, i32 0
+  %94 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck13 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %95
+
+; <label>:95                                      ; preds = %92
+  %96 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, i32 0, i32 7
+  %97 = load i32, i32 addrspace(1)* %96, align 8
+  %98 = add i32 %97, 1
+  %NullCheck15 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %99
+
+; <label>:99                                      ; preds = %95
+  %100 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, i32 0, i32 2
+  store i32 %98, i32 addrspace(1)* %100
+  %101 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck17 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %102
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %103, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %92
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef22:                                   ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef24:                                   ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef26:                                   ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef28:                                   ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef30:                                   ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef32:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef34:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef36:                                   ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange38:                           ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef40:                                   ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef42:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef44:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef46:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef48:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef50:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -5200,8 +6368,8 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -5232,9 +6400,9 @@ Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
 Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
-Failed to read String.MakeSeparatorList[loadElemA]
+Failed to read String.MakeSeparatorList[storeElem]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
-Failed to read String.InternalSplitKeepEmptyEntries[loadElem]
+Failed to read String.InternalSplitKeepEmptyEntries[storeElem]
 INFO:  jitting method Path::IsRelative using LLILCJit
 Successfully read Path.IsRelative
 
@@ -5243,8 +6411,8 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -5254,8 +6422,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
@@ -5271,8 +6439,8 @@ entry:
 
 ; <label>:17                                      ; preds = %7
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
@@ -5288,8 +6456,8 @@ entry:
 
 ; <label>:29                                      ; preds = %19
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %31
 
 ; <label>:31                                      ; preds = %29
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
@@ -5300,8 +6468,8 @@ entry:
 
 ; <label>:36                                      ; preds = %31
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
-  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %37, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
@@ -5312,8 +6480,8 @@ entry:
 
 ; <label>:43                                      ; preds = %31, %38
   %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
-  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %45
 
 ; <label>:45                                      ; preds = %43
   %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
@@ -5324,8 +6492,8 @@ entry:
 
 ; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %50
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
@@ -5336,8 +6504,8 @@ entry:
 
 ; <label>:57                                      ; preds = %1, %7, %19, %45, %52
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
-  br i1 %NullCheck14, label %59, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %59
 
 ; <label>:59                                      ; preds = %57
   %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
@@ -5347,8 +6515,8 @@ entry:
 
 ; <label>:63                                      ; preds = %59
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
@@ -5359,8 +6527,8 @@ entry:
 
 ; <label>:70                                      ; preds = %65
   %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
-  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.String addrspace(1)* %71, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %72
 
 ; <label>:72                                      ; preds = %70
   %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
@@ -5379,39 +6547,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %17
+ThrowNullRef4:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %29
+ThrowNullRef6:                                    ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %36
+ThrowNullRef8:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %43
+ThrowNullRef10:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %50
+ThrowNullRef12:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %57
+ThrowNullRef14:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %63
+ThrowNullRef16:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %70
+ThrowNullRef18:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5419,7 +6587,293 @@ ThrowNullRef17:                                   ; preds = %70
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
-Failed to read String.TrimHelper[loadElem]
+Successfully read String.TrimHelper
+
+define %System.String addrspace(1)* @String.TrimHelper(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i16
+  %loc4 = alloca i32
+  %loc5 = alloca i16
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = sub i32 %3, 1
+  store i32 %4, i32* %loc0
+  store i32 0, i32* %loc1
+  %5 = load i32, i32* %arg2
+  %6 = icmp eq i32 %5, 1
+  br i1 %6, label %62, label %7
+
+; <label>:7                                       ; preds = %1
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:8                                       ; preds = %58
+  store i32 0, i32* %loc2
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load i32, i32* %loc1
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2, i32 %10
+  %13 = load i16, i16 addrspace(1)* %12
+  %14 = zext i16 %13 to i32
+  %15 = trunc i32 %14 to i16
+  store i16 %15, i16* %loc3
+  store i32 0, i32* %loc2
+  br label %34
+
+; <label>:16                                      ; preds = %37
+  %17 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %18 = load i32, i32* %loc2
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %17, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %19
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = zext i32 %18 to i64
+  %BoundsCheck = icmp uge i64 %23, %22
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %24
+
+; <label>:24                                      ; preds = %19
+  %25 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 3, i32 %18
+  %26 = load i16, i16 addrspace(1)* %25, align 8
+  %27 = zext i16 %26 to i32
+  %28 = load i16, i16* %loc3
+  %29 = zext i16 %28 to i32
+  %30 = icmp eq i32 %27, %29
+  br i1 %30, label %43, label %31
+
+; <label>:31                                      ; preds = %24
+  %32 = load i32, i32* %loc2
+  %33 = add i32 %32, 1
+  store i32 %33, i32* %loc2
+  br label %34
+
+; <label>:34                                      ; preds = %11, %31
+  %35 = load i32, i32* %loc2
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = icmp slt i32 %35, %41
+  br i1 %42, label %16, label %43
+
+; <label>:43                                      ; preds = %24, %37
+  %44 = load i32, i32* %loc2
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %45, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp eq i32 %44, %50
+  br i1 %51, label %62, label %52
+
+; <label>:52                                      ; preds = %46
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %7, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %57, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %58
+
+; <label>:58                                      ; preds = %55
+  %59 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %60 = load i32, i32 addrspace(1)* %59
+  %61 = icmp slt i32 %56, %60
+  br i1 %61, label %8, label %62
+
+; <label>:62                                      ; preds = %1, %46, %58
+  %63 = load i32, i32* %arg2
+  %64 = icmp eq i32 %63, 0
+  br i1 %64, label %122, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %66, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %67
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %66, i32 0, i32 1
+  %69 = load i32, i32 addrspace(1)* %68
+  %70 = sub i32 %69, 1
+  store i32 %70, i32* %loc0
+  br label %118
+
+; <label>:71                                      ; preds = %118
+  store i32 0, i32* %loc4
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %73 = load i32, i32* %loc0
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %74
+
+; <label>:74                                      ; preds = %71
+  %75 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 2, i32 %73
+  %76 = load i16, i16 addrspace(1)* %75
+  %77 = zext i16 %76 to i32
+  %78 = trunc i32 %77 to i16
+  store i16 %78, i16* %loc5
+  store i32 0, i32* %loc4
+  br label %97
+
+; <label>:79                                      ; preds = %100
+  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %81 = load i32, i32* %loc4
+  %NullCheck19 = icmp eq %"System.Char[]" addrspace(1)* %80, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
+
+; <label>:82                                      ; preds = %79
+  %83 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 1
+  %84 = load i32, i32 addrspace(1)* %83
+  %85 = zext i32 %84 to i64
+  %86 = zext i32 %81 to i64
+  %BoundsCheck21 = icmp uge i64 %86, %85
+  br i1 %BoundsCheck21, label %ThrowIndexOutOfRange22, label %87
+
+; <label>:87                                      ; preds = %82
+  %88 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 3, i32 %81
+  %89 = load i16, i16 addrspace(1)* %88, align 8
+  %90 = zext i16 %89 to i32
+  %91 = load i16, i16* %loc5
+  %92 = zext i16 %91 to i32
+  %93 = icmp eq i32 %90, %92
+  br i1 %93, label %106, label %94
+
+; <label>:94                                      ; preds = %87
+  %95 = load i32, i32* %loc4
+  %96 = add i32 %95, 1
+  store i32 %96, i32* %loc4
+  br label %97
+
+; <label>:97                                      ; preds = %74, %94
+  %98 = load i32, i32* %loc4
+  %99 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck15 = icmp eq %"System.Char[]" addrspace(1)* %99, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %100
+
+; <label>:100                                     ; preds = %97
+  %101 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %99, i32 0, i32 1
+  %102 = load i32, i32 addrspace(1)* %101
+  %103 = zext i32 %102 to i64
+  %104 = trunc i64 %103 to i32
+  %105 = icmp slt i32 %98, %104
+  br i1 %105, label %79, label %106
+
+; <label>:106                                     ; preds = %87, %100
+  %107 = load i32, i32* %loc4
+  %108 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck17 = icmp eq %"System.Char[]" addrspace(1)* %108, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %109
+
+; <label>:109                                     ; preds = %106
+  %110 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %108, i32 0, i32 1
+  %111 = load i32, i32 addrspace(1)* %110
+  %112 = zext i32 %111 to i64
+  %113 = trunc i64 %112 to i32
+  %114 = icmp eq i32 %107, %113
+  br i1 %114, label %122, label %115
+
+; <label>:115                                     ; preds = %109
+  %116 = load i32, i32* %loc0
+  %117 = sub i32 %116, 1
+  store i32 %117, i32* %loc0
+  br label %118
+
+; <label>:118                                     ; preds = %67, %115
+  %119 = load i32, i32* %loc0
+  %120 = load i32, i32* %loc1
+  %121 = icmp sge i32 %119, %120
+  br i1 %121, label %71, label %122
+
+; <label>:122                                     ; preds = %62, %109, %118
+  %123 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %124 = load i32, i32* %loc1
+  %125 = load i32, i32* %loc0
+  %126 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %123, i32 %124, i32 %125)
+  ret %System.String addrspace(1)* %126
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %97
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange22:                           ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
 Successfully read String.CreateTrimmedString
 
@@ -5439,8 +6893,8 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
@@ -5535,8 +6989,8 @@ entry:
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i64 2872
   %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
   %8 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %7
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %3
   %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
@@ -5553,8 +7007,8 @@ entry:
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 2864
   %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
   %21 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %20
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
-  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %22
 
 ; <label>:22                                      ; preds = %16
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
@@ -5569,7 +7023,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %16
+ThrowNullRef2:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5586,8 +7040,8 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5613,8 +7067,8 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
@@ -5632,8 +7086,8 @@ entry:
 
 ; <label>:12                                      ; preds = %4
   %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
@@ -5644,8 +7098,8 @@ entry:
 
 ; <label>:19                                      ; preds = %14
   %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %19
   %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
@@ -5660,21 +7114,21 @@ entry:
   %31 = zext i16 %30 to i32
   %32 = bitcast i8* %29 to i16*
   %33 = trunc i32 %31 to i16
-  %NullCheck6 = icmp ne i16* %32, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i16* %32, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %21
   store i16 %33, i16* %32, align 8
   %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %36
 
 ; <label>:36                                      ; preds = %34
   %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
   %38 = load i32, i32 addrspace(1)* %37, align 8
   %39 = add i32 %38, 1
-  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %40
 
 ; <label>:40                                      ; preds = %36
   %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
@@ -5683,16 +7137,16 @@ entry:
 
 ; <label>:42                                      ; preds = %14
   %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
-  br i1 %NullCheck12, label %44, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
   %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
   %47 = load i16, i16* %arg1
   %48 = zext i16 %47 to i32
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = trunc i32 %48 to i16
@@ -5703,31 +7157,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %19
+ThrowNullRef4:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %21
+ThrowNullRef6:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %36
+ThrowNullRef10:                                   ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %42
+ThrowNullRef12:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %44
+ThrowNullRef14:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5740,8 +7194,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -5752,8 +7206,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
@@ -5762,14 +7216,14 @@ entry:
 
 ; <label>:11                                      ; preds = %1
   %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
@@ -5779,15 +7233,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5808,8 +7262,8 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5822,8 +7276,8 @@ entry:
 
 ; <label>:8                                       ; preds = %3
   %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
@@ -5842,15 +7296,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
-  br i1 %NullCheck4, label %22, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
   %24 = load i16*, i16* addrspace(1)* %23, align 8
   %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %25, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
@@ -5859,8 +7313,8 @@ entry:
   store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
@@ -5874,8 +7328,8 @@ entry:
 
 ; <label>:37                                      ; preds = %65
   %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %37
   %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
@@ -5886,16 +7340,16 @@ entry:
   %45 = bitcast i16* %41 to i8*
   %46 = getelementptr inbounds i8, i8* %45, i64 %44
   %47 = bitcast i8* %46 to i16*
-  %NullCheck14 = icmp ne i16* %47, null
-  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %47, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %48
 
 ; <label>:48                                      ; preds = %39
   %49 = load i16, i16* %47, align 8
   %50 = zext i16 %49 to i32
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %52 = load i32, i32* %loc1
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %53
 
 ; <label>:53                                      ; preds = %48
   %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
@@ -5916,8 +7370,8 @@ entry:
 ; <label>:62                                      ; preds = %36, %59
   %63 = load i32, i32* %loc1
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck10, label %65, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %65
 
 ; <label>:65                                      ; preds = %62
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
@@ -5936,15 +7390,15 @@ entry:
 
 ; <label>:74                                      ; preds = %70
   %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
-  br i1 %NullCheck18, label %76, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %76
 
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
   %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
-  br i1 %NullCheck20, label %80, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
   %81 = load i64, i64 addrspace(1)* %79
@@ -5958,8 +7412,8 @@ entry:
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
   %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
-  br i1 %NullCheck22, label %92, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.String addrspace(1)* %90, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %92
 
 ; <label>:92                                      ; preds = %80
   %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
@@ -5969,15 +7423,15 @@ entry:
 
 ; <label>:96                                      ; preds = %70
   %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
-  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %98
 
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
   %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
-  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
   %103 = load i64, i64 addrspace(1)* %101
@@ -5991,8 +7445,8 @@ entry:
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
   %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
-  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.String addrspace(1)* %112, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %114
 
 ; <label>:114                                     ; preds = %102
   %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
@@ -6004,59 +7458,59 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %20
+ThrowNullRef4:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %22
+ThrowNullRef6:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %26
+ThrowNullRef8:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %62
+ThrowNullRef10:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %48
+ThrowNullRef16:                                   ; preds = %48
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %74
+ThrowNullRef18:                                   ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %76
+ThrowNullRef20:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %80
+ThrowNullRef22:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %96
+ThrowNullRef24:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %98
+ThrowNullRef26:                                   ; preds = %98
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %102
+ThrowNullRef28:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6069,15 +7523,15 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
   %3 = load i16*, i16* addrspace(1)* %2, align 8
   %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
@@ -6087,8 +7541,8 @@ entry:
   %10 = bitcast i16* %3 to i8*
   %11 = getelementptr inbounds i8, i8* %10, i64 %9
   %12 = bitcast i8* %11 to i16*
-  %NullCheck4 = icmp ne i16* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %5
   store i16 0, i16* %12, align 8
@@ -6098,11 +7552,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6119,8 +7573,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -6131,8 +7585,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
@@ -6144,15 +7598,15 @@ entry:
 
 ; <label>:14                                      ; preds = %1
   %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
   %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
   %21 = load i64, i64 addrspace(1)* %19
@@ -6171,15 +7625,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %14
+ThrowNullRef4:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %16
+ThrowNullRef6:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6302,14 +7756,6 @@ entry:
   ret %System.String addrspace(1)* %57
 }
 
-INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
-Successfully read RuntimeHelpers.get_OffsetToStringData
-
-define i32 @RuntimeHelpers.get_OffsetToStringData() {
-entry:
-  ret i32 12
-}
-
 INFO:  jitting method String::Equals using LLILCJit
 Successfully read String.Equals
 
@@ -6381,8 +7827,8 @@ entry:
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
-  br i1 %NullCheck24, label %29, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
   %30 = load i64, i64 addrspace(1)* %28
@@ -6397,8 +7843,8 @@ entry:
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
-  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
   %43 = load i64, i64 addrspace(1)* %41
@@ -6418,8 +7864,8 @@ entry:
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
   %59 = load i64, i64 addrspace(1)* %57
@@ -6434,8 +7880,8 @@ entry:
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck22, label %71, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
   %72 = load i64, i64 addrspace(1)* %70
@@ -6455,8 +7901,8 @@ entry:
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
-  br i1 %NullCheck16, label %87, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = load i64, i64 addrspace(1)* %86
@@ -6471,8 +7917,8 @@ entry:
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck18, label %100, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
   %101 = load i64, i64 addrspace(1)* %99
@@ -6492,8 +7938,8 @@ entry:
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
-  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
   %117 = load i64, i64 addrspace(1)* %115
@@ -6508,8 +7954,8 @@ entry:
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
-  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
   %130 = load i64, i64 addrspace(1)* %128
@@ -6528,15 +7974,15 @@ entry:
 
 ; <label>:142                                     ; preds = %22
   %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
-  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %143, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %144
 
 ; <label>:144                                     ; preds = %142
   %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
   %146 = load i32, i32 addrspace(1)* %145
   %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
-  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %147, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %148
 
 ; <label>:148                                     ; preds = %144
   %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
@@ -6557,15 +8003,15 @@ entry:
 
 ; <label>:159                                     ; preds = %22
   %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
-  br i1 %NullCheck, label %161, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %ThrowNullRef, label %161
 
 ; <label>:161                                     ; preds = %159
   %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
   %163 = load i32, i32 addrspace(1)* %162
   %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
-  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %164, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %165
 
 ; <label>:165                                     ; preds = %161
   %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
@@ -6578,8 +8024,8 @@ entry:
 
 ; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
-  br i1 %NullCheck4, label %172, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %171, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %172
 
 ; <label>:172                                     ; preds = %170
   %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
@@ -6589,8 +8035,8 @@ entry:
 
 ; <label>:176                                     ; preds = %172
   %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
-  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %177, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %178
 
 ; <label>:178                                     ; preds = %176
   %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
@@ -6629,55 +8075,55 @@ ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %161
+ThrowNullRef2:                                    ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %170
+ThrowNullRef4:                                    ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %176
+ThrowNullRef6:                                    ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %142
+ThrowNullRef8:                                    ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %144
+ThrowNullRef10:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %113
+ThrowNullRef12:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %116
+ThrowNullRef14:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %84
+ThrowNullRef16:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %87
+ThrowNullRef18:                                   ; preds = %87
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %55
+ThrowNullRef20:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %58
+ThrowNullRef22:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %26
+ThrowNullRef24:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %29
+ThrowNullRef26:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,8 +8161,8 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck, label %14, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %ThrowNullRef, label %14
 
 ; <label>:14                                      ; preds = %8
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
@@ -6760,8 +8206,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
@@ -6770,14 +8216,14 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32, i32* %loc0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %10
   %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
   %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
@@ -6790,15 +8236,15 @@ entry:
 ; <label>:25                                      ; preds = %19
   %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
-  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
   %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
@@ -6807,8 +8253,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %37 = load i32, i32* %loc0
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %38, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %38
 
 ; <label>:38                                      ; preds = %32
   %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
@@ -6817,14 +8263,14 @@ entry:
 
 ; <label>:40                                      ; preds = %19
   %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %40
   %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
   %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
-  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
-  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
@@ -6832,8 +8278,8 @@ entry:
   %48 = zext i32 %47 to i64
   %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
-  br i1 %NullCheck16, label %51, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %51
 
 ; <label>:51                                      ; preds = %45
   %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
@@ -6847,15 +8293,15 @@ entry:
 ; <label>:57                                      ; preds = %51
   %58 = load i16*, i16** %arg1
   %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
-  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %60
 
 ; <label>:60                                      ; preds = %57
   %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
   %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
-  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %64
 
 ; <label>:64                                      ; preds = %60
   %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
@@ -6864,22 +8310,22 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
   %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
-  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %70
 
 ; <label>:70                                      ; preds = %64
   %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
   %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
-  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
-  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
   %75 = load i32, i32 addrspace(1)* %74
   %76 = zext i32 %75 to i64
   %77 = trunc i64 %76 to i32
-  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
-  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %78
 
 ; <label>:78                                      ; preds = %73
   %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
@@ -6901,8 +8347,8 @@ entry:
   %90 = bitcast i16* %86 to i8*
   %91 = getelementptr inbounds i8, i8* %90, i64 %89
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %93
 
 ; <label>:93                                      ; preds = %80
   %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
@@ -6912,8 +8358,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %99 = load i32, i32* %loc2
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %100
 
 ; <label>:100                                     ; preds = %93
   %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
@@ -6928,63 +8374,63 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %25
+ThrowNullRef6:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %32
+ThrowNullRef10:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %40
+ThrowNullRef12:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %45
+ThrowNullRef16:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %57
+ThrowNullRef18:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %60
+ThrowNullRef20:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %64
+ThrowNullRef22:                                   ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %70
+ThrowNullRef24:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %73
+ThrowNullRef26:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %80
+ThrowNullRef28:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %93
+ThrowNullRef30:                                   ; preds = %93
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7004,8 +8450,8 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
@@ -7033,43 +8479,43 @@ entry:
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %14
   %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
   %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   %28 = load i32, i32 addrspace(1)* %27, align 8
   %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
-  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %30
 
 ; <label>:30                                      ; preds = %26
   %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
   %32 = load i32, i32 addrspace(1)* %31, align 8
   %33 = add i32 %28, %32
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %34
 
 ; <label>:34                                      ; preds = %30
   %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   store i32 %33, i32 addrspace(1)* %35
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
   store i32 0, i32 addrspace(1)* %38
   %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %40
 
 ; <label>:40                                      ; preds = %37
   %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
@@ -7082,8 +8528,8 @@ entry:
 
 ; <label>:47                                      ; preds = %40
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
@@ -7098,8 +8544,8 @@ entry:
   %54 = load i32, i32* %loc0
   %55 = sext i32 %54 to i64
   %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
-  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %57
 
 ; <label>:57                                      ; preds = %52
   %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
@@ -7110,68 +8556,35 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %14
+ThrowNullRef2:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %23
+ThrowNullRef4:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %26
+ThrowNullRef6:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %30
+ThrowNullRef8:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %34
+ThrowNullRef10:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %47
+ThrowNullRef14:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %52
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-}
-
-INFO:  jitting method StringBuilder::get_Length using LLILCJit
-Successfully read StringBuilder.get_Length
-
-define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.StringBuilder addrspace(1)*
-  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
-  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
-
-; <label>:1                                       ; preds = %entry
-  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %3 = load i32, i32 addrspace(1)* %2, align 8
-  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
-
-; <label>:5                                       ; preds = %1
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = add i32 %3, %7
-  ret i32 %8
-
-ThrowNullRef:                                     ; preds = %entry
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef16:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7213,70 +8626,70 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
   %6 = load i32, i32 addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
   store i32 %6, i32 addrspace(1)* %8
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
   %13 = load i32, i32 addrspace(1)* %12, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
   store i32 %13, i32 addrspace(1)* %15
   %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
-  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %18
 
 ; <label>:18                                      ; preds = %14
   %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
   %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
   %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
   %34 = load i32, i32 addrspace(1)* %33, align 8
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
-  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
@@ -7287,39 +8700,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %28
+ThrowNullRef16:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %32
+ThrowNullRef18:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7455,13 +8868,13 @@ entry:
 ; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
@@ -7477,16 +8890,16 @@ entry:
 
 ; <label>:18                                      ; preds = %15
   %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
   store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
   %22 = load i32, i32* %loc0
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %24
 
 ; <label>:24                                      ; preds = %20
   %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
@@ -7498,13 +8911,13 @@ entry:
 ; <label>:28                                      ; preds = %15, %24
   %29 = load i32, i32* %arg1
   %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %31
   %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
@@ -7517,20 +8930,20 @@ entry:
   %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
-  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
   %46 = load i32, i32 addrspace(1)* %45, align 8
   %47 = sub i32 %40, %46
-  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
-  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i32 addrspace(1)* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %48
 
 ; <label>:48                                      ; preds = %44
   store i32 %47, i32 addrspace(1)* %39, align 8
@@ -7538,21 +8951,21 @@ entry:
 
 ; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
-  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %51
 
 ; <label>:51                                      ; preds = %49
   %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %53
 
 ; <label>:53                                      ; preds = %51
   %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
   %55 = load i32, i32 addrspace(1)* %54, align 8
   %56 = load i32, i32* %arg2
   %57 = sub i32 %55, %56
-  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %58
 
 ; <label>:58                                      ; preds = %53
   %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
@@ -7562,13 +8975,13 @@ entry:
 ; <label>:60                                      ; preds = %33, %58
   %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
   %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
-  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %63
 
 ; <label>:63                                      ; preds = %60
   %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
-  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
-  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
@@ -7578,15 +8991,15 @@ entry:
 
 ; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
-  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i32 addrspace(1)* %69, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %70
 
 ; <label>:70                                      ; preds = %68
   %71 = load i32, i32 addrspace(1)* %69, align 8
   store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
-  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
@@ -7596,8 +9009,8 @@ entry:
   store i32 %77, i32* %loc4
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
-  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %80
 
 ; <label>:80                                      ; preds = %73
   %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
@@ -7607,71 +9020,71 @@ entry:
 ; <label>:83                                      ; preds = %80
   store i32 0, i32* %loc3
   %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
-  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
-  br i1 %NullCheck26, label %88, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i32 addrspace(1)* %87, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %88
 
 ; <label>:88                                      ; preds = %85
   %89 = load i32, i32 addrspace(1)* %87, align 8
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
-  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %90
 
 ; <label>:90                                      ; preds = %88
   %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
   store i32 %89, i32 addrspace(1)* %91
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
-  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
-  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %96
 
 ; <label>:96                                      ; preds = %94
   %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
-  br i1 %NullCheck34, label %100, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %100
 
 ; <label>:100                                     ; preds = %96
   %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
-  br i1 %NullCheck36, label %102, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %102
 
 ; <label>:102                                     ; preds = %100
   %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
   %104 = load i32, i32 addrspace(1)* %103, align 8
   %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
-  br i1 %NullCheck38, label %106, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %106
 
 ; <label>:106                                     ; preds = %102
   %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
-  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
-  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %108
 
 ; <label>:108                                     ; preds = %106
   %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
   %110 = load i32, i32 addrspace(1)* %109, align 8
   %111 = add i32 %104, %110
-  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %112
 
 ; <label>:112                                     ; preds = %108
   %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
   store i32 %111, i32 addrspace(1)* %113
   %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
-  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i32 addrspace(1)* %114, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %115
 
 ; <label>:115                                     ; preds = %112
   %116 = load i32, i32 addrspace(1)* %114, align 8
@@ -7681,19 +9094,19 @@ entry:
 ; <label>:118                                     ; preds = %115
   %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
-  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %121
 
 ; <label>:121                                     ; preds = %118
   %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
-  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
-  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %123
 
 ; <label>:123                                     ; preds = %121
   %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
   %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
-  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
-  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %126
 
 ; <label>:126                                     ; preds = %123
   %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
@@ -7705,8 +9118,8 @@ entry:
 
 ; <label>:130                                     ; preds = %80, %115, %126
   %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %132
 
 ; <label>:132                                     ; preds = %130
   %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7715,8 +9128,8 @@ entry:
   %136 = load i32, i32* %loc3
   %137 = sub i32 %135, %136
   %138 = sub i32 %134, %137
-  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %139
 
 ; <label>:139                                     ; preds = %132
   %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7728,16 +9141,16 @@ entry:
 
 ; <label>:144                                     ; preds = %139
   %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
-  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %146
 
 ; <label>:146                                     ; preds = %144
   %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
   %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
   %149 = load i32, i32* %loc2
   %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
-  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %151
 
 ; <label>:151                                     ; preds = %146
   %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
@@ -7754,145 +9167,249 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %18
+ThrowNullRef4:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %31
+ThrowNullRef10:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %44
+ThrowNullRef16:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %68
+ThrowNullRef18:                                   ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %70
+ThrowNullRef20:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %73
+ThrowNullRef22:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %83
+ThrowNullRef24:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %85
+ThrowNullRef26:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %88
+ThrowNullRef28:                                   ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %90
+ThrowNullRef30:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %94
+ThrowNullRef32:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %96
+ThrowNullRef34:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %100
+ThrowNullRef36:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %102
+ThrowNullRef38:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %106
+ThrowNullRef40:                                   ; preds = %106
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %108
+ThrowNullRef42:                                   ; preds = %108
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %112
+ThrowNullRef44:                                   ; preds = %112
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %118
+ThrowNullRef46:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %121
+ThrowNullRef48:                                   ; preds = %121
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %123
+ThrowNullRef50:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %130
+ThrowNullRef52:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %132
+ThrowNullRef54:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %144
+ThrowNullRef56:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %146
+ThrowNullRef58:                                   ; preds = %146
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %60
+ThrowNullRef60:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %63
+ThrowNullRef62:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %49
+ThrowNullRef64:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %51
+ThrowNullRef66:                                   ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %53
+ThrowNullRef68:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(%"System.Char[]" addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %arg0 = alloca %"System.Char[]" addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store %"System.Char[]" addrspace(1)* %param0, %"System.Char[]" addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load i32, i32* %arg4
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %43, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %38, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg1
+  %13 = load i32, i32* %arg4
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %38, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %24 = load i32, i32* %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %35 = load i32, i32* %arg3
+  %36 = load i32, i32* %arg4
+  %37 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %37, %"System.Char[]" addrspace(1)* %34, i32 %35, i32 %36)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:38                                      ; preds = %5, %16
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Successfully read Buffer._Memmove
 
@@ -7914,7 +9431,7 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[loadElem]
+Failed to read AppDomain.SetDataHelper[storeElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -7923,8 +9440,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
@@ -7934,8 +9451,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
@@ -7947,15 +9464,15 @@ entry:
   %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
   %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
@@ -7966,15 +9483,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7992,7 +9509,79 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
-Failed to read Dictionary`2.TryGetValue[loadElemA]
+Successfully read Dictionary`2.TryGetValue
+
+define i8 @"Dictionary`2.TryGetValue"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)* addrspace(1)* %param2) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  %arg2 = alloca %System.__Canon addrspace(1)* addrspace(1)*
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  store %System.__Canon addrspace(1)* addrspace(1)* %param2, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  store i32 %2, i32* %loc0
+  %3 = load i32, i32* %loc0
+  %4 = icmp slt i32 %3, 0
+  br i1 %4, label %22, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 2
+  %10 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %9, align 8
+  %11 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = zext i32 %11 to i64
+  %BoundsCheck = icmp uge i64 %16, %15
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 3, i32 %11
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %20, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %6, %System.__Canon addrspace(1)* %21)
+  ret i8 1
+
+; <label>:22                                      ; preds = %entry
+  %23 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %23, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -8058,8 +9647,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
@@ -8091,8 +9680,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
@@ -8171,15 +9760,15 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck, label %19, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %ThrowNullRef, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
   %21 = load i32, i32 addrspace(1)* %20
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
@@ -8202,7 +9791,7 @@ ThrowNullRef:                                     ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %19
+ThrowNullRef2:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8248,8 +9837,8 @@ entry:
   %0 = alloca %System.AppDomainHandle
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %1 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %1, i32 0, i32 15
@@ -8269,8 +9858,8 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
@@ -8286,7 +9875,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -8299,8 +9888,8 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -8327,8 +9916,8 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
@@ -8352,8 +9941,8 @@ entry:
   %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
   store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
@@ -8363,8 +9952,8 @@ entry:
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
@@ -8374,8 +9963,8 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %9
   %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
@@ -8384,8 +9973,8 @@ entry:
 
 ; <label>:18                                      ; preds = %3, %16
   %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
@@ -8397,15 +9986,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %18
+ThrowNullRef6:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8418,8 +10007,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
@@ -8453,15 +10042,15 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
@@ -8473,7 +10062,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8481,7 +10070,7 @@ ThrowNullRef1:                                    ; preds = %1
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
 Failed to read Dictionary`2.System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
@@ -8506,8 +10095,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
@@ -8524,8 +10113,8 @@ entry:
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -8544,7 +10133,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8577,8 +10166,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = load i64, i64* %arg2
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = trunc i32 %3 to i8
@@ -8634,46 +10223,46 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
   %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
-  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
-  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
-  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
@@ -8684,27 +10273,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %20
+ThrowNullRef12:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8717,8 +10306,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -8756,22 +10345,22 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
   %9 = load i64, i64 addrspace(1)* %8, align 8
   %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
   %13 = load i64, i64 addrspace(1)* %12, align 8
   %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %11
   %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
@@ -8788,11 +10377,11 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8882,8 +10471,8 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
@@ -8900,8 +10489,8 @@ entry:
 ; <label>:8                                       ; preds = %1
   %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
   %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
@@ -8911,15 +10500,15 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
   %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
   %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
-  br i1 %NullCheck6, label %21, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
@@ -8946,15 +10535,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8992,15 +10581,15 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
   store i8 %3, i8 addrspace(1)* %5
   %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
@@ -9011,7 +10600,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9027,8 +10616,8 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -9041,8 +10630,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
@@ -9058,7 +10647,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9080,8 +10669,8 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
@@ -9096,8 +10685,8 @@ entry:
 ; <label>:12                                      ; preds = %6
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
@@ -9112,8 +10701,8 @@ entry:
 ; <label>:21                                      ; preds = %15
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
@@ -9128,8 +10717,8 @@ entry:
 ; <label>:30                                      ; preds = %24
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %31, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
@@ -9144,8 +10733,8 @@ entry:
 ; <label>:39                                      ; preds = %33
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
-  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %40, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %42
 
 ; <label>:42                                      ; preds = %39
   %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
@@ -9164,19 +10753,19 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %21
+ThrowNullRef4:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %30
+ThrowNullRef6:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %39
+ThrowNullRef8:                                    ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9243,8 +10832,8 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
@@ -9264,57 +10853,57 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
   store i8 0, i8 addrspace(1)* %2
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
   store i8 0, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
   store i8 0, i8 addrspace(1)* %17
   %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
   store i8 0, i8 addrspace(1)* %20
   %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
-  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
@@ -9325,31 +10914,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %19
+ThrowNullRef14:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9367,8 +10956,8 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
@@ -9380,8 +10969,8 @@ entry:
 
 ; <label>:9                                       ; preds = %4
   %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %9
   %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
@@ -9395,7 +10984,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef2:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9420,8 +11009,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
@@ -9512,8 +11101,8 @@ entry:
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
@@ -9524,8 +11113,8 @@ entry:
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = load i64, i64 addrspace(1)* %12
@@ -9537,8 +11126,8 @@ entry:
   %20 = load i64, i64* %19
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
-  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %13
   %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
@@ -9555,8 +11144,8 @@ entry:
 ; <label>:30                                      ; preds = %25
   %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %32 = load i32, i32* %arg2
-  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
-  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
@@ -9570,15 +11159,15 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %30
+ThrowNullRef2:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9622,87 +11211,87 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
   %10 = load i8, i8 addrspace(1)* %9, align 8
   %11 = zext i8 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %8
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
   store i8 %12, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
   %19 = load i8, i8 addrspace(1)* %18, align 8
   %20 = zext i8 %19 to i32
   %21 = trunc i32 %20 to i8
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
   store i8 %21, i8 addrspace(1)* %23
   %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
   %28 = load i8, i8 addrspace(1)* %27, align 8
   %29 = zext i8 %28 to i32
   %30 = trunc i32 %29 to i8
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
-  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %31
 
 ; <label>:31                                      ; preds = %26
   %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
   store i8 %30, i8 addrspace(1)* %32
   %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
-  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
-  br i1 %NullCheck14, label %40, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %40
 
 ; <label>:40                                      ; preds = %35
   %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
   store i8 %39, i8 addrspace(1)* %41
   %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
-  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %44
 
 ; <label>:44                                      ; preds = %40
   %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
   %46 = load i8, i8 addrspace(1)* %45, align 8
   %47 = zext i8 %46 to i32
   %48 = trunc i32 %47 to i8
-  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
   store i8 %48, i8 addrspace(1)* %50
   %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
-  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
@@ -9713,29 +11302,29 @@ entry:
 ; <label>:56                                      ; preds = %52
   %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
-  br i1 %NullCheck22, label %59, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
   %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
   %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
-  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
-  br i1 %NullCheck24, label %63, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
   %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
-  br i1 %NullCheck26, label %66, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
   %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
-  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
-  br i1 %NullCheck28, label %69, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %69
 
 ; <label>:69                                      ; preds = %66
   %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
@@ -9744,15 +11333,15 @@ entry:
 
 ; <label>:71                                      ; preds = %105
   %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
-  br i1 %NullCheck34, label %73, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %73
 
 ; <label>:73                                      ; preds = %71
   %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
   %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
   %76 = load i32, i32* %loc0
-  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
-  br i1 %NullCheck36, label %77, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
@@ -9766,8 +11355,8 @@ entry:
 
 ; <label>:83                                      ; preds = %77
   %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
-  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
@@ -9775,14 +11364,14 @@ entry:
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
   %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
-  br i1 %NullCheck40, label %91, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
 ; <label>:91                                      ; preds = %85
   %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
   %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
-  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck42, label %94, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %94
 
 ; <label>:94                                      ; preds = %91
   %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
@@ -9798,14 +11387,14 @@ entry:
 ; <label>:99                                      ; preds = %69, %96
   %100 = load i32, i32* %loc0
   %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
-  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %102
 
 ; <label>:102                                     ; preds = %99
   %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
   %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
-  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
-  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
@@ -9819,87 +11408,87 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %26
+ThrowNullRef10:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %31
+ThrowNullRef12:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %35
+ThrowNullRef14:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %40
+ThrowNullRef16:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %56
+ThrowNullRef22:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %59
+ThrowNullRef24:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %63
+ThrowNullRef26:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %66
+ThrowNullRef28:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %102
+ThrowNullRef32:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %71
+ThrowNullRef34:                                   ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %73
+ThrowNullRef36:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %83
+ThrowNullRef38:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %85
+ThrowNullRef40:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %91
+ThrowNullRef42:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9943,15 +11532,15 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
   %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
@@ -9961,28 +11550,28 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
   %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %12
   %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
   %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
   %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
-  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
@@ -9993,23 +11582,23 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %12
+ThrowNullRef6:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10031,15 +11620,15 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
   %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = load i64, i64 addrspace(1)* %7
@@ -10077,13 +11666,13 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[loadElem]
+Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -10111,8 +11700,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueNeInt1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueNeInt1.error.txt
@@ -25,8 +25,8 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
@@ -40,8 +40,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
   %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
@@ -75,7 +75,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -90,8 +90,8 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %NullCheck = icmp ne i8 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = load i8, i8 addrspace(1)* %0, align 8
@@ -125,8 +125,8 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
@@ -159,8 +159,8 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -184,8 +184,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
   store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
@@ -195,8 +195,8 @@ entry:
 ; <label>:4                                       ; preds = %1
   %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
   %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
@@ -206,8 +206,8 @@ entry:
   %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
@@ -221,14 +221,14 @@ entry:
 
 ; <label>:17                                      ; preds = %14
   %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
   %21 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
@@ -238,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -249,8 +249,8 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
@@ -261,27 +261,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %30
+ThrowNullRef10:                                   ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -301,7 +301,89 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
-Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
+Successfully read AppDomainSetup.GetUnsecureApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.GetUnsecureApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %NullCheck = icmp eq %"System.String[]" addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %BoundsCheck = icmp uge i64 0, %5
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %6
+
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 3, i32 0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
+  ret %System.String addrspace(1)* %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_Value using LLILCJit
+Successfully read AppDomainSetup.get_Value
+
+define %"System.String[]" addrspace(1)* @AppDomainSetup.get_Value(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.String[]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 18)
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.String[]" addrspace(1)* addrspace(1)*, %"System.String[]" addrspace(1)*)*)(%"System.String[]" addrspace(1)* addrspace(1)* %9, %"System.String[]" addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %11, i32 0, i32 1
+  %14 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %13, align 8
+  ret %"System.String[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -319,8 +401,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -368,16 +450,16 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
   %5 = load i32, i32 addrspace(1)* %4
   %6 = sub i32 %5, 1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -389,7 +471,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -421,8 +503,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
@@ -456,8 +538,8 @@ entry:
 ; <label>:27                                      ; preds = %19
   %28 = load i32, i32* %arg1
   %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
-  br i1 %NullCheck2, label %30, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %29, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %30
 
 ; <label>:30                                      ; preds = %27
   %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
@@ -493,8 +575,8 @@ entry:
 ; <label>:49                                      ; preds = %46
   %50 = load i32, i32* %arg2
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck4, label %52, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
@@ -517,11 +599,11 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %27
+ThrowNullRef2:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %49
+ThrowNullRef4:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -544,16 +626,16 @@ entry:
   %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %0)
   store %System.String addrspace(1)* %1, %System.String addrspace(1)** %loc0
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 2
   %5 = bitcast [0 x i16] addrspace(1)* %4 to i16 addrspace(1)*
   store i16 addrspace(1)* %5, i16 addrspace(1)** %loc1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %3
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2
@@ -580,7 +662,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -691,15 +773,15 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %NullCheck132 = icmp ne i8* %21, null
-  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+  %NullCheck131 = icmp eq i8* %21, null
+  br i1 %NullCheck131, label %ThrowNullRef132, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = load i8, i8* %21, align 8
   %24 = zext i8 %23 to i32
   %25 = trunc i32 %24 to i8
-  %NullCheck134 = icmp ne i8* %20, null
-  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+  %NullCheck133 = icmp eq i8* %20, null
+  br i1 %NullCheck133, label %ThrowNullRef134, label %26
 
 ; <label>:26                                      ; preds = %22
   store i8 %25, i8* %20, align 8
@@ -709,16 +791,16 @@ entry:
   %28 = load i8*, i8** %arg0
   %29 = load i8*, i8** %arg1
   %30 = bitcast i8* %29 to i16*
-  %NullCheck128 = icmp ne i16* %30, null
-  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+  %NullCheck127 = icmp eq i16* %30, null
+  br i1 %NullCheck127, label %ThrowNullRef128, label %31
 
 ; <label>:31                                      ; preds = %27
   %32 = load i16, i16* %30, align 8
   %33 = sext i16 %32 to i32
   %34 = bitcast i8* %28 to i16*
   %35 = trunc i32 %33 to i16
-  %NullCheck130 = icmp ne i16* %34, null
-  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+  %NullCheck129 = icmp eq i16* %34, null
+  br i1 %NullCheck129, label %ThrowNullRef130, label %36
 
 ; <label>:36                                      ; preds = %31
   store i16 %35, i16* %34, align 8
@@ -728,16 +810,16 @@ entry:
   %38 = load i8*, i8** %arg0
   %39 = load i8*, i8** %arg1
   %40 = bitcast i8* %39 to i16*
-  %NullCheck120 = icmp ne i16* %40, null
-  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+  %NullCheck119 = icmp eq i16* %40, null
+  br i1 %NullCheck119, label %ThrowNullRef120, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i16, i16* %40, align 8
   %43 = sext i16 %42 to i32
   %44 = bitcast i8* %38 to i16*
   %45 = trunc i32 %43 to i16
-  %NullCheck122 = icmp ne i16* %44, null
-  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+  %NullCheck121 = icmp eq i16* %44, null
+  br i1 %NullCheck121, label %ThrowNullRef122, label %46
 
 ; <label>:46                                      ; preds = %41
   store i16 %45, i16* %44, align 8
@@ -745,15 +827,15 @@ entry:
   %48 = getelementptr inbounds i8, i8* %47, i64 2
   %49 = load i8*, i8** %arg1
   %50 = getelementptr inbounds i8, i8* %49, i64 2
-  %NullCheck124 = icmp ne i8* %50, null
-  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+  %NullCheck123 = icmp eq i8* %50, null
+  br i1 %NullCheck123, label %ThrowNullRef124, label %51
 
 ; <label>:51                                      ; preds = %46
   %52 = load i8, i8* %50, align 8
   %53 = zext i8 %52 to i32
   %54 = trunc i32 %53 to i8
-  %NullCheck126 = icmp ne i8* %48, null
-  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+  %NullCheck125 = icmp eq i8* %48, null
+  br i1 %NullCheck125, label %ThrowNullRef126, label %55
 
 ; <label>:55                                      ; preds = %51
   store i8 %54, i8* %48, align 8
@@ -763,14 +845,14 @@ entry:
   %57 = load i8*, i8** %arg0
   %58 = load i8*, i8** %arg1
   %59 = bitcast i8* %58 to i32*
-  %NullCheck116 = icmp ne i32* %59, null
-  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+  %NullCheck115 = icmp eq i32* %59, null
+  br i1 %NullCheck115, label %ThrowNullRef116, label %60
 
 ; <label>:60                                      ; preds = %56
   %61 = load i32, i32* %59, align 8
   %62 = bitcast i8* %57 to i32*
-  %NullCheck118 = icmp ne i32* %62, null
-  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+  %NullCheck117 = icmp eq i32* %62, null
+  br i1 %NullCheck117, label %ThrowNullRef118, label %63
 
 ; <label>:63                                      ; preds = %60
   store i32 %61, i32* %62, align 8
@@ -780,14 +862,14 @@ entry:
   %65 = load i8*, i8** %arg0
   %66 = load i8*, i8** %arg1
   %67 = bitcast i8* %66 to i32*
-  %NullCheck108 = icmp ne i32* %67, null
-  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+  %NullCheck107 = icmp eq i32* %67, null
+  br i1 %NullCheck107, label %ThrowNullRef108, label %68
 
 ; <label>:68                                      ; preds = %64
   %69 = load i32, i32* %67, align 8
   %70 = bitcast i8* %65 to i32*
-  %NullCheck110 = icmp ne i32* %70, null
-  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+  %NullCheck109 = icmp eq i32* %70, null
+  br i1 %NullCheck109, label %ThrowNullRef110, label %71
 
 ; <label>:71                                      ; preds = %68
   store i32 %69, i32* %70, align 8
@@ -795,15 +877,15 @@ entry:
   %73 = getelementptr inbounds i8, i8* %72, i64 4
   %74 = load i8*, i8** %arg1
   %75 = getelementptr inbounds i8, i8* %74, i64 4
-  %NullCheck112 = icmp ne i8* %75, null
-  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+  %NullCheck111 = icmp eq i8* %75, null
+  br i1 %NullCheck111, label %ThrowNullRef112, label %76
 
 ; <label>:76                                      ; preds = %71
   %77 = load i8, i8* %75, align 8
   %78 = zext i8 %77 to i32
   %79 = trunc i32 %78 to i8
-  %NullCheck114 = icmp ne i8* %73, null
-  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+  %NullCheck113 = icmp eq i8* %73, null
+  br i1 %NullCheck113, label %ThrowNullRef114, label %80
 
 ; <label>:80                                      ; preds = %76
   store i8 %79, i8* %73, align 8
@@ -813,14 +895,14 @@ entry:
   %82 = load i8*, i8** %arg0
   %83 = load i8*, i8** %arg1
   %84 = bitcast i8* %83 to i32*
-  %NullCheck100 = icmp ne i32* %84, null
-  br i1 %NullCheck100, label %85, label %ThrowNullRef99
+  %NullCheck99 = icmp eq i32* %84, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %85
 
 ; <label>:85                                      ; preds = %81
   %86 = load i32, i32* %84, align 8
   %87 = bitcast i8* %82 to i32*
-  %NullCheck102 = icmp ne i32* %87, null
-  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+  %NullCheck101 = icmp eq i32* %87, null
+  br i1 %NullCheck101, label %ThrowNullRef102, label %88
 
 ; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
@@ -829,16 +911,16 @@ entry:
   %91 = load i8*, i8** %arg1
   %92 = getelementptr inbounds i8, i8* %91, i64 4
   %93 = bitcast i8* %92 to i16*
-  %NullCheck104 = icmp ne i16* %93, null
-  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+  %NullCheck103 = icmp eq i16* %93, null
+  br i1 %NullCheck103, label %ThrowNullRef104, label %94
 
 ; <label>:94                                      ; preds = %88
   %95 = load i16, i16* %93, align 8
   %96 = sext i16 %95 to i32
   %97 = bitcast i8* %90 to i16*
   %98 = trunc i32 %96 to i16
-  %NullCheck106 = icmp ne i16* %97, null
-  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+  %NullCheck105 = icmp eq i16* %97, null
+  br i1 %NullCheck105, label %ThrowNullRef106, label %99
 
 ; <label>:99                                      ; preds = %94
   store i16 %98, i16* %97, align 8
@@ -848,14 +930,14 @@ entry:
   %101 = load i8*, i8** %arg0
   %102 = load i8*, i8** %arg1
   %103 = bitcast i8* %102 to i32*
-  %NullCheck88 = icmp ne i32* %103, null
-  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+  %NullCheck87 = icmp eq i32* %103, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %104
 
 ; <label>:104                                     ; preds = %100
   %105 = load i32, i32* %103, align 8
   %106 = bitcast i8* %101 to i32*
-  %NullCheck90 = icmp ne i32* %106, null
-  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+  %NullCheck89 = icmp eq i32* %106, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %107
 
 ; <label>:107                                     ; preds = %104
   store i32 %105, i32* %106, align 8
@@ -864,16 +946,16 @@ entry:
   %110 = load i8*, i8** %arg1
   %111 = getelementptr inbounds i8, i8* %110, i64 4
   %112 = bitcast i8* %111 to i16*
-  %NullCheck92 = icmp ne i16* %112, null
-  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+  %NullCheck91 = icmp eq i16* %112, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %113
 
 ; <label>:113                                     ; preds = %107
   %114 = load i16, i16* %112, align 8
   %115 = sext i16 %114 to i32
   %116 = bitcast i8* %109 to i16*
   %117 = trunc i32 %115 to i16
-  %NullCheck94 = icmp ne i16* %116, null
-  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+  %NullCheck93 = icmp eq i16* %116, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %118
 
 ; <label>:118                                     ; preds = %113
   store i16 %117, i16* %116, align 8
@@ -881,15 +963,15 @@ entry:
   %120 = getelementptr inbounds i8, i8* %119, i64 6
   %121 = load i8*, i8** %arg1
   %122 = getelementptr inbounds i8, i8* %121, i64 6
-  %NullCheck96 = icmp ne i8* %122, null
-  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+  %NullCheck95 = icmp eq i8* %122, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %123
 
 ; <label>:123                                     ; preds = %118
   %124 = load i8, i8* %122, align 8
   %125 = zext i8 %124 to i32
   %126 = trunc i32 %125 to i8
-  %NullCheck98 = icmp ne i8* %120, null
-  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+  %NullCheck97 = icmp eq i8* %120, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %127
 
 ; <label>:127                                     ; preds = %123
   store i8 %126, i8* %120, align 8
@@ -899,14 +981,14 @@ entry:
   %129 = load i8*, i8** %arg0
   %130 = load i8*, i8** %arg1
   %131 = bitcast i8* %130 to i64*
-  %NullCheck84 = icmp ne i64* %131, null
-  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+  %NullCheck83 = icmp eq i64* %131, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %132
 
 ; <label>:132                                     ; preds = %128
   %133 = load i64, i64* %131, align 8
   %134 = bitcast i8* %129 to i64*
-  %NullCheck86 = icmp ne i64* %134, null
-  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+  %NullCheck85 = icmp eq i64* %134, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %135
 
 ; <label>:135                                     ; preds = %132
   store i64 %133, i64* %134, align 8
@@ -916,14 +998,14 @@ entry:
   %137 = load i8*, i8** %arg0
   %138 = load i8*, i8** %arg1
   %139 = bitcast i8* %138 to i64*
-  %NullCheck76 = icmp ne i64* %139, null
-  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+  %NullCheck75 = icmp eq i64* %139, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %140
 
 ; <label>:140                                     ; preds = %136
   %141 = load i64, i64* %139, align 8
   %142 = bitcast i8* %137 to i64*
-  %NullCheck78 = icmp ne i64* %142, null
-  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+  %NullCheck77 = icmp eq i64* %142, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %143
 
 ; <label>:143                                     ; preds = %140
   store i64 %141, i64* %142, align 8
@@ -931,15 +1013,15 @@ entry:
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %NullCheck80 = icmp ne i8* %147, null
-  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+  %NullCheck79 = icmp eq i8* %147, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %148
 
 ; <label>:148                                     ; preds = %143
   %149 = load i8, i8* %147, align 8
   %150 = zext i8 %149 to i32
   %151 = trunc i32 %150 to i8
-  %NullCheck82 = icmp ne i8* %145, null
-  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+  %NullCheck81 = icmp eq i8* %145, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %152
 
 ; <label>:152                                     ; preds = %148
   store i8 %151, i8* %145, align 8
@@ -949,14 +1031,14 @@ entry:
   %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
   %156 = bitcast i8* %155 to i64*
-  %NullCheck68 = icmp ne i64* %156, null
-  br i1 %NullCheck68, label %157, label %ThrowNullRef67
+  %NullCheck67 = icmp eq i64* %156, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %157
 
 ; <label>:157                                     ; preds = %153
   %158 = load i64, i64* %156, align 8
   %159 = bitcast i8* %154 to i64*
-  %NullCheck70 = icmp ne i64* %159, null
-  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+  %NullCheck69 = icmp eq i64* %159, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %160
 
 ; <label>:160                                     ; preds = %157
   store i64 %158, i64* %159, align 8
@@ -965,16 +1047,16 @@ entry:
   %163 = load i8*, i8** %arg1
   %164 = getelementptr inbounds i8, i8* %163, i64 8
   %165 = bitcast i8* %164 to i16*
-  %NullCheck72 = icmp ne i16* %165, null
-  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+  %NullCheck71 = icmp eq i16* %165, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %166
 
 ; <label>:166                                     ; preds = %160
   %167 = load i16, i16* %165, align 8
   %168 = sext i16 %167 to i32
   %169 = bitcast i8* %162 to i16*
   %170 = trunc i32 %168 to i16
-  %NullCheck74 = icmp ne i16* %169, null
-  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+  %NullCheck73 = icmp eq i16* %169, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %171
 
 ; <label>:171                                     ; preds = %166
   store i16 %170, i16* %169, align 8
@@ -984,14 +1066,14 @@ entry:
   %173 = load i8*, i8** %arg0
   %174 = load i8*, i8** %arg1
   %175 = bitcast i8* %174 to i64*
-  %NullCheck56 = icmp ne i64* %175, null
-  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+  %NullCheck55 = icmp eq i64* %175, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %176
 
 ; <label>:176                                     ; preds = %172
   %177 = load i64, i64* %175, align 8
   %178 = bitcast i8* %173 to i64*
-  %NullCheck58 = icmp ne i64* %178, null
-  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+  %NullCheck57 = icmp eq i64* %178, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %179
 
 ; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
@@ -1000,16 +1082,16 @@ entry:
   %182 = load i8*, i8** %arg1
   %183 = getelementptr inbounds i8, i8* %182, i64 8
   %184 = bitcast i8* %183 to i16*
-  %NullCheck60 = icmp ne i16* %184, null
-  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+  %NullCheck59 = icmp eq i16* %184, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %185
 
 ; <label>:185                                     ; preds = %179
   %186 = load i16, i16* %184, align 8
   %187 = sext i16 %186 to i32
   %188 = bitcast i8* %181 to i16*
   %189 = trunc i32 %187 to i16
-  %NullCheck62 = icmp ne i16* %188, null
-  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+  %NullCheck61 = icmp eq i16* %188, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %190
 
 ; <label>:190                                     ; preds = %185
   store i16 %189, i16* %188, align 8
@@ -1017,15 +1099,15 @@ entry:
   %192 = getelementptr inbounds i8, i8* %191, i64 10
   %193 = load i8*, i8** %arg1
   %194 = getelementptr inbounds i8, i8* %193, i64 10
-  %NullCheck64 = icmp ne i8* %194, null
-  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+  %NullCheck63 = icmp eq i8* %194, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %195
 
 ; <label>:195                                     ; preds = %190
   %196 = load i8, i8* %194, align 8
   %197 = zext i8 %196 to i32
   %198 = trunc i32 %197 to i8
-  %NullCheck66 = icmp ne i8* %192, null
-  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+  %NullCheck65 = icmp eq i8* %192, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %199
 
 ; <label>:199                                     ; preds = %195
   store i8 %198, i8* %192, align 8
@@ -1035,14 +1117,14 @@ entry:
   %201 = load i8*, i8** %arg0
   %202 = load i8*, i8** %arg1
   %203 = bitcast i8* %202 to i64*
-  %NullCheck48 = icmp ne i64* %203, null
-  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+  %NullCheck47 = icmp eq i64* %203, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %204
 
 ; <label>:204                                     ; preds = %200
   %205 = load i64, i64* %203, align 8
   %206 = bitcast i8* %201 to i64*
-  %NullCheck50 = icmp ne i64* %206, null
-  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+  %NullCheck49 = icmp eq i64* %206, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %207
 
 ; <label>:207                                     ; preds = %204
   store i64 %205, i64* %206, align 8
@@ -1051,14 +1133,14 @@ entry:
   %210 = load i8*, i8** %arg1
   %211 = getelementptr inbounds i8, i8* %210, i64 8
   %212 = bitcast i8* %211 to i32*
-  %NullCheck52 = icmp ne i32* %212, null
-  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+  %NullCheck51 = icmp eq i32* %212, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %213
 
 ; <label>:213                                     ; preds = %207
   %214 = load i32, i32* %212, align 8
   %215 = bitcast i8* %209 to i32*
-  %NullCheck54 = icmp ne i32* %215, null
-  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+  %NullCheck53 = icmp eq i32* %215, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %216
 
 ; <label>:216                                     ; preds = %213
   store i32 %214, i32* %215, align 8
@@ -1068,14 +1150,14 @@ entry:
   %218 = load i8*, i8** %arg0
   %219 = load i8*, i8** %arg1
   %220 = bitcast i8* %219 to i64*
-  %NullCheck36 = icmp ne i64* %220, null
-  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64* %220, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %221
 
 ; <label>:221                                     ; preds = %217
   %222 = load i64, i64* %220, align 8
   %223 = bitcast i8* %218 to i64*
-  %NullCheck38 = icmp ne i64* %223, null
-  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+  %NullCheck37 = icmp eq i64* %223, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %224
 
 ; <label>:224                                     ; preds = %221
   store i64 %222, i64* %223, align 8
@@ -1084,14 +1166,14 @@ entry:
   %227 = load i8*, i8** %arg1
   %228 = getelementptr inbounds i8, i8* %227, i64 8
   %229 = bitcast i8* %228 to i32*
-  %NullCheck40 = icmp ne i32* %229, null
-  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i32* %229, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %230
 
 ; <label>:230                                     ; preds = %224
   %231 = load i32, i32* %229, align 8
   %232 = bitcast i8* %226 to i32*
-  %NullCheck42 = icmp ne i32* %232, null
-  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+  %NullCheck41 = icmp eq i32* %232, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %233
 
 ; <label>:233                                     ; preds = %230
   store i32 %231, i32* %232, align 8
@@ -1099,15 +1181,15 @@ entry:
   %235 = getelementptr inbounds i8, i8* %234, i64 12
   %236 = load i8*, i8** %arg1
   %237 = getelementptr inbounds i8, i8* %236, i64 12
-  %NullCheck44 = icmp ne i8* %237, null
-  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i8* %237, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %238
 
 ; <label>:238                                     ; preds = %233
   %239 = load i8, i8* %237, align 8
   %240 = zext i8 %239 to i32
   %241 = trunc i32 %240 to i8
-  %NullCheck46 = icmp ne i8* %235, null
-  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+  %NullCheck45 = icmp eq i8* %235, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %242
 
 ; <label>:242                                     ; preds = %238
   store i8 %241, i8* %235, align 8
@@ -1117,14 +1199,14 @@ entry:
   %244 = load i8*, i8** %arg0
   %245 = load i8*, i8** %arg1
   %246 = bitcast i8* %245 to i64*
-  %NullCheck24 = icmp ne i64* %246, null
-  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64* %246, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %247
 
 ; <label>:247                                     ; preds = %243
   %248 = load i64, i64* %246, align 8
   %249 = bitcast i8* %244 to i64*
-  %NullCheck26 = icmp ne i64* %249, null
-  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64* %249, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %250
 
 ; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
@@ -1133,14 +1215,14 @@ entry:
   %253 = load i8*, i8** %arg1
   %254 = getelementptr inbounds i8, i8* %253, i64 8
   %255 = bitcast i8* %254 to i32*
-  %NullCheck28 = icmp ne i32* %255, null
-  br i1 %NullCheck28, label %256, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i32* %255, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %256
 
 ; <label>:256                                     ; preds = %250
   %257 = load i32, i32* %255, align 8
   %258 = bitcast i8* %252 to i32*
-  %NullCheck30 = icmp ne i32* %258, null
-  br i1 %NullCheck30, label %259, label %ThrowNullRef29
+  %NullCheck29 = icmp eq i32* %258, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %259
 
 ; <label>:259                                     ; preds = %256
   store i32 %257, i32* %258, align 8
@@ -1149,16 +1231,16 @@ entry:
   %262 = load i8*, i8** %arg1
   %263 = getelementptr inbounds i8, i8* %262, i64 12
   %264 = bitcast i8* %263 to i16*
-  %NullCheck32 = icmp ne i16* %264, null
-  br i1 %NullCheck32, label %265, label %ThrowNullRef31
+  %NullCheck31 = icmp eq i16* %264, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %265
 
 ; <label>:265                                     ; preds = %259
   %266 = load i16, i16* %264, align 8
   %267 = sext i16 %266 to i32
   %268 = bitcast i8* %261 to i16*
   %269 = trunc i32 %267 to i16
-  %NullCheck34 = icmp ne i16* %268, null
-  br i1 %NullCheck34, label %270, label %ThrowNullRef33
+  %NullCheck33 = icmp eq i16* %268, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %270
 
 ; <label>:270                                     ; preds = %265
   store i16 %269, i16* %268, align 8
@@ -1168,14 +1250,14 @@ entry:
   %272 = load i8*, i8** %arg0
   %273 = load i8*, i8** %arg1
   %274 = bitcast i8* %273 to i64*
-  %NullCheck8 = icmp ne i64* %274, null
-  br i1 %NullCheck8, label %275, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64* %274, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %275
 
 ; <label>:275                                     ; preds = %271
   %276 = load i64, i64* %274, align 8
   %277 = bitcast i8* %272 to i64*
-  %NullCheck10 = icmp ne i64* %277, null
-  br i1 %NullCheck10, label %278, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %277, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %278
 
 ; <label>:278                                     ; preds = %275
   store i64 %276, i64* %277, align 8
@@ -1184,14 +1266,14 @@ entry:
   %281 = load i8*, i8** %arg1
   %282 = getelementptr inbounds i8, i8* %281, i64 8
   %283 = bitcast i8* %282 to i32*
-  %NullCheck12 = icmp ne i32* %283, null
-  br i1 %NullCheck12, label %284, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i32* %283, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %284
 
 ; <label>:284                                     ; preds = %278
   %285 = load i32, i32* %283, align 8
   %286 = bitcast i8* %280 to i32*
-  %NullCheck14 = icmp ne i32* %286, null
-  br i1 %NullCheck14, label %287, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i32* %286, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %287
 
 ; <label>:287                                     ; preds = %284
   store i32 %285, i32* %286, align 8
@@ -1200,16 +1282,16 @@ entry:
   %290 = load i8*, i8** %arg1
   %291 = getelementptr inbounds i8, i8* %290, i64 12
   %292 = bitcast i8* %291 to i16*
-  %NullCheck16 = icmp ne i16* %292, null
-  br i1 %NullCheck16, label %293, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i16* %292, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %293
 
 ; <label>:293                                     ; preds = %287
   %294 = load i16, i16* %292, align 8
   %295 = sext i16 %294 to i32
   %296 = bitcast i8* %289 to i16*
   %297 = trunc i32 %295 to i16
-  %NullCheck18 = icmp ne i16* %296, null
-  br i1 %NullCheck18, label %298, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i16* %296, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %298
 
 ; <label>:298                                     ; preds = %293
   store i16 %297, i16* %296, align 8
@@ -1217,15 +1299,15 @@ entry:
   %300 = getelementptr inbounds i8, i8* %299, i64 14
   %301 = load i8*, i8** %arg1
   %302 = getelementptr inbounds i8, i8* %301, i64 14
-  %NullCheck20 = icmp ne i8* %302, null
-  br i1 %NullCheck20, label %303, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i8* %302, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %303
 
 ; <label>:303                                     ; preds = %298
   %304 = load i8, i8* %302, align 8
   %305 = zext i8 %304 to i32
   %306 = trunc i32 %305 to i8
-  %NullCheck22 = icmp ne i8* %300, null
-  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i8* %300, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %307
 
 ; <label>:307                                     ; preds = %303
   store i8 %306, i8* %300, align 8
@@ -1235,14 +1317,14 @@ entry:
   %309 = load i8*, i8** %arg0
   %310 = load i8*, i8** %arg1
   %311 = bitcast i8* %310 to i64*
-  %NullCheck = icmp ne i64* %311, null
-  br i1 %NullCheck, label %312, label %ThrowNullRef
+  %NullCheck = icmp eq i64* %311, null
+  br i1 %NullCheck, label %ThrowNullRef, label %312
 
 ; <label>:312                                     ; preds = %308
   %313 = load i64, i64* %311, align 8
   %314 = bitcast i8* %309 to i64*
-  %NullCheck2 = icmp ne i64* %314, null
-  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64* %314, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %315
 
 ; <label>:315                                     ; preds = %312
   store i64 %313, i64* %314, align 8
@@ -1251,14 +1333,14 @@ entry:
   %318 = load i8*, i8** %arg1
   %319 = getelementptr inbounds i8, i8* %318, i64 8
   %320 = bitcast i8* %319 to i64*
-  %NullCheck4 = icmp ne i64* %320, null
-  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64* %320, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %321
 
 ; <label>:321                                     ; preds = %315
   %322 = load i64, i64* %320, align 8
   %323 = bitcast i8* %317 to i64*
-  %NullCheck6 = icmp ne i64* %323, null
-  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64* %323, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %324
 
 ; <label>:324                                     ; preds = %321
   store i64 %322, i64* %323, align 8
@@ -1286,15 +1368,15 @@ entry:
 ; <label>:338                                     ; preds = %333
   %339 = load i8*, i8** %arg0
   %340 = load i8*, i8** %arg1
-  %NullCheck136 = icmp ne i8* %340, null
-  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+  %NullCheck135 = icmp eq i8* %340, null
+  br i1 %NullCheck135, label %ThrowNullRef136, label %341
 
 ; <label>:341                                     ; preds = %338
   %342 = load i8, i8* %340, align 8
   %343 = zext i8 %342 to i32
   %344 = trunc i32 %343 to i8
-  %NullCheck138 = icmp ne i8* %339, null
-  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+  %NullCheck137 = icmp eq i8* %339, null
+  br i1 %NullCheck137, label %ThrowNullRef138, label %345
 
 ; <label>:345                                     ; preds = %341
   store i8 %344, i8* %339, align 8
@@ -1317,16 +1399,16 @@ entry:
   %357 = load i8*, i8** %arg0
   %358 = load i8*, i8** %arg1
   %359 = bitcast i8* %358 to i16*
-  %NullCheck140 = icmp ne i16* %359, null
-  br i1 %NullCheck140, label %360, label %ThrowNullRef139
+  %NullCheck139 = icmp eq i16* %359, null
+  br i1 %NullCheck139, label %ThrowNullRef140, label %360
 
 ; <label>:360                                     ; preds = %356
   %361 = load i16, i16* %359, align 8
   %362 = sext i16 %361 to i32
   %363 = bitcast i8* %357 to i16*
   %364 = trunc i32 %362 to i16
-  %NullCheck142 = icmp ne i16* %363, null
-  br i1 %NullCheck142, label %365, label %ThrowNullRef141
+  %NullCheck141 = icmp eq i16* %363, null
+  br i1 %NullCheck141, label %ThrowNullRef142, label %365
 
 ; <label>:365                                     ; preds = %360
   store i16 %364, i16* %363, align 8
@@ -1352,14 +1434,14 @@ entry:
   %378 = load i8*, i8** %arg0
   %379 = load i8*, i8** %arg1
   %380 = bitcast i8* %379 to i32*
-  %NullCheck144 = icmp ne i32* %380, null
-  br i1 %NullCheck144, label %381, label %ThrowNullRef143
+  %NullCheck143 = icmp eq i32* %380, null
+  br i1 %NullCheck143, label %ThrowNullRef144, label %381
 
 ; <label>:381                                     ; preds = %377
   %382 = load i32, i32* %380, align 8
   %383 = bitcast i8* %378 to i32*
-  %NullCheck146 = icmp ne i32* %383, null
-  br i1 %NullCheck146, label %384, label %ThrowNullRef145
+  %NullCheck145 = icmp eq i32* %383, null
+  br i1 %NullCheck145, label %ThrowNullRef146, label %384
 
 ; <label>:384                                     ; preds = %381
   store i32 %382, i32* %383, align 8
@@ -1384,14 +1466,14 @@ entry:
   %395 = load i8*, i8** %arg0
   %396 = load i8*, i8** %arg1
   %397 = bitcast i8* %396 to i64*
-  %NullCheck164 = icmp ne i64* %397, null
-  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+  %NullCheck163 = icmp eq i64* %397, null
+  br i1 %NullCheck163, label %ThrowNullRef164, label %398
 
 ; <label>:398                                     ; preds = %394
   %399 = load i64, i64* %397, align 8
   %400 = bitcast i8* %395 to i64*
-  %NullCheck166 = icmp ne i64* %400, null
-  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+  %NullCheck165 = icmp eq i64* %400, null
+  br i1 %NullCheck165, label %ThrowNullRef166, label %401
 
 ; <label>:401                                     ; preds = %398
   store i64 %399, i64* %400, align 8
@@ -1400,14 +1482,14 @@ entry:
   %404 = load i8*, i8** %arg1
   %405 = getelementptr inbounds i8, i8* %404, i64 8
   %406 = bitcast i8* %405 to i64*
-  %NullCheck168 = icmp ne i64* %406, null
-  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+  %NullCheck167 = icmp eq i64* %406, null
+  br i1 %NullCheck167, label %ThrowNullRef168, label %407
 
 ; <label>:407                                     ; preds = %401
   %408 = load i64, i64* %406, align 8
   %409 = bitcast i8* %403 to i64*
-  %NullCheck170 = icmp ne i64* %409, null
-  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+  %NullCheck169 = icmp eq i64* %409, null
+  br i1 %NullCheck169, label %ThrowNullRef170, label %410
 
 ; <label>:410                                     ; preds = %407
   store i64 %408, i64* %409, align 8
@@ -1437,14 +1519,14 @@ entry:
   %425 = load i8*, i8** %arg0
   %426 = load i8*, i8** %arg1
   %427 = bitcast i8* %426 to i64*
-  %NullCheck148 = icmp ne i64* %427, null
-  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+  %NullCheck147 = icmp eq i64* %427, null
+  br i1 %NullCheck147, label %ThrowNullRef148, label %428
 
 ; <label>:428                                     ; preds = %424
   %429 = load i64, i64* %427, align 8
   %430 = bitcast i8* %425 to i64*
-  %NullCheck150 = icmp ne i64* %430, null
-  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+  %NullCheck149 = icmp eq i64* %430, null
+  br i1 %NullCheck149, label %ThrowNullRef150, label %431
 
 ; <label>:431                                     ; preds = %428
   store i64 %429, i64* %430, align 8
@@ -1466,14 +1548,14 @@ entry:
   %441 = load i8*, i8** %arg0
   %442 = load i8*, i8** %arg1
   %443 = bitcast i8* %442 to i32*
-  %NullCheck152 = icmp ne i32* %443, null
-  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+  %NullCheck151 = icmp eq i32* %443, null
+  br i1 %NullCheck151, label %ThrowNullRef152, label %444
 
 ; <label>:444                                     ; preds = %440
   %445 = load i32, i32* %443, align 8
   %446 = bitcast i8* %441 to i32*
-  %NullCheck154 = icmp ne i32* %446, null
-  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+  %NullCheck153 = icmp eq i32* %446, null
+  br i1 %NullCheck153, label %ThrowNullRef154, label %447
 
 ; <label>:447                                     ; preds = %444
   store i32 %445, i32* %446, align 8
@@ -1495,16 +1577,16 @@ entry:
   %457 = load i8*, i8** %arg0
   %458 = load i8*, i8** %arg1
   %459 = bitcast i8* %458 to i16*
-  %NullCheck156 = icmp ne i16* %459, null
-  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+  %NullCheck155 = icmp eq i16* %459, null
+  br i1 %NullCheck155, label %ThrowNullRef156, label %460
 
 ; <label>:460                                     ; preds = %456
   %461 = load i16, i16* %459, align 8
   %462 = sext i16 %461 to i32
   %463 = bitcast i8* %457 to i16*
   %464 = trunc i32 %462 to i16
-  %NullCheck158 = icmp ne i16* %463, null
-  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+  %NullCheck157 = icmp eq i16* %463, null
+  br i1 %NullCheck157, label %ThrowNullRef158, label %465
 
 ; <label>:465                                     ; preds = %460
   store i16 %464, i16* %463, align 8
@@ -1525,15 +1607,15 @@ entry:
 ; <label>:474                                     ; preds = %470
   %475 = load i8*, i8** %arg0
   %476 = load i8*, i8** %arg1
-  %NullCheck160 = icmp ne i8* %476, null
-  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+  %NullCheck159 = icmp eq i8* %476, null
+  br i1 %NullCheck159, label %ThrowNullRef160, label %477
 
 ; <label>:477                                     ; preds = %474
   %478 = load i8, i8* %476, align 8
   %479 = zext i8 %478 to i32
   %480 = trunc i32 %479 to i8
-  %NullCheck162 = icmp ne i8* %475, null
-  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+  %NullCheck161 = icmp eq i8* %475, null
+  br i1 %NullCheck161, label %ThrowNullRef162, label %481
 
 ; <label>:481                                     ; preds = %477
   store i8 %480, i8* %475, align 8
@@ -1553,343 +1635,343 @@ ThrowNullRef:                                     ; preds = %308
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %312
+ThrowNullRef2:                                    ; preds = %312
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %315
+ThrowNullRef4:                                    ; preds = %315
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %321
+ThrowNullRef6:                                    ; preds = %321
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %271
+ThrowNullRef8:                                    ; preds = %271
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %275
+ThrowNullRef10:                                   ; preds = %275
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %278
+ThrowNullRef12:                                   ; preds = %278
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %284
+ThrowNullRef14:                                   ; preds = %284
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %287
+ThrowNullRef16:                                   ; preds = %287
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %293
+ThrowNullRef18:                                   ; preds = %293
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %298
+ThrowNullRef20:                                   ; preds = %298
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %303
+ThrowNullRef22:                                   ; preds = %303
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %243
+ThrowNullRef24:                                   ; preds = %243
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %247
+ThrowNullRef26:                                   ; preds = %247
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %250
+ThrowNullRef28:                                   ; preds = %250
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %256
+ThrowNullRef30:                                   ; preds = %256
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %259
+ThrowNullRef32:                                   ; preds = %259
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %265
+ThrowNullRef34:                                   ; preds = %265
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %217
+ThrowNullRef36:                                   ; preds = %217
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %221
+ThrowNullRef38:                                   ; preds = %221
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %224
+ThrowNullRef40:                                   ; preds = %224
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %230
+ThrowNullRef42:                                   ; preds = %230
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %233
+ThrowNullRef44:                                   ; preds = %233
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %238
+ThrowNullRef46:                                   ; preds = %238
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %200
+ThrowNullRef48:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %204
+ThrowNullRef50:                                   ; preds = %204
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %207
+ThrowNullRef52:                                   ; preds = %207
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %213
+ThrowNullRef54:                                   ; preds = %213
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %172
+ThrowNullRef56:                                   ; preds = %172
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %176
+ThrowNullRef58:                                   ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %179
+ThrowNullRef60:                                   ; preds = %179
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %185
+ThrowNullRef62:                                   ; preds = %185
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %190
+ThrowNullRef64:                                   ; preds = %190
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %195
+ThrowNullRef66:                                   ; preds = %195
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %153
+ThrowNullRef68:                                   ; preds = %153
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %157
+ThrowNullRef70:                                   ; preds = %157
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %160
+ThrowNullRef72:                                   ; preds = %160
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %166
+ThrowNullRef74:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %136
+ThrowNullRef76:                                   ; preds = %136
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %140
+ThrowNullRef78:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %143
+ThrowNullRef80:                                   ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %148
+ThrowNullRef82:                                   ; preds = %148
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %128
+ThrowNullRef84:                                   ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %132
+ThrowNullRef86:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %100
+ThrowNullRef88:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %104
+ThrowNullRef90:                                   ; preds = %104
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %107
+ThrowNullRef92:                                   ; preds = %107
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %113
+ThrowNullRef94:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %118
+ThrowNullRef96:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %123
+ThrowNullRef98:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %81
+ThrowNullRef100:                                  ; preds = %81
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef101:                                  ; preds = %85
+ThrowNullRef102:                                  ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef103:                                  ; preds = %88
+ThrowNullRef104:                                  ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef105:                                  ; preds = %94
+ThrowNullRef106:                                  ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef107:                                  ; preds = %64
+ThrowNullRef108:                                  ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef109:                                  ; preds = %68
+ThrowNullRef110:                                  ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef111:                                  ; preds = %71
+ThrowNullRef112:                                  ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef113:                                  ; preds = %76
+ThrowNullRef114:                                  ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef115:                                  ; preds = %56
+ThrowNullRef116:                                  ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef117:                                  ; preds = %60
+ThrowNullRef118:                                  ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef119:                                  ; preds = %37
+ThrowNullRef120:                                  ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef121:                                  ; preds = %41
+ThrowNullRef122:                                  ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef123:                                  ; preds = %46
+ThrowNullRef124:                                  ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef125:                                  ; preds = %51
+ThrowNullRef126:                                  ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef127:                                  ; preds = %27
+ThrowNullRef128:                                  ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef129:                                  ; preds = %31
+ThrowNullRef130:                                  ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef131:                                  ; preds = %19
+ThrowNullRef132:                                  ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef133:                                  ; preds = %22
+ThrowNullRef134:                                  ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef135:                                  ; preds = %338
+ThrowNullRef136:                                  ; preds = %338
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef137:                                  ; preds = %341
+ThrowNullRef138:                                  ; preds = %341
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef139:                                  ; preds = %356
+ThrowNullRef140:                                  ; preds = %356
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef141:                                  ; preds = %360
+ThrowNullRef142:                                  ; preds = %360
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef143:                                  ; preds = %377
+ThrowNullRef144:                                  ; preds = %377
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef145:                                  ; preds = %381
+ThrowNullRef146:                                  ; preds = %381
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef147:                                  ; preds = %424
+ThrowNullRef148:                                  ; preds = %424
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef149:                                  ; preds = %428
+ThrowNullRef150:                                  ; preds = %428
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef151:                                  ; preds = %440
+ThrowNullRef152:                                  ; preds = %440
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef153:                                  ; preds = %444
+ThrowNullRef154:                                  ; preds = %444
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef155:                                  ; preds = %456
+ThrowNullRef156:                                  ; preds = %456
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef157:                                  ; preds = %460
+ThrowNullRef158:                                  ; preds = %460
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef159:                                  ; preds = %474
+ThrowNullRef160:                                  ; preds = %474
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef161:                                  ; preds = %477
+ThrowNullRef162:                                  ; preds = %477
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef163:                                  ; preds = %394
+ThrowNullRef164:                                  ; preds = %394
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef165:                                  ; preds = %398
+ThrowNullRef166:                                  ; preds = %398
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef167:                                  ; preds = %401
+ThrowNullRef168:                                  ; preds = %401
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef169:                                  ; preds = %407
+ThrowNullRef170:                                  ; preds = %407
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1939,8 +2021,8 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
-  br i1 %NullCheck, label %22, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %ThrowNullRef, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
@@ -1948,8 +2030,8 @@ entry:
   store i32 %24, i32* %loc0
   %25 = load i32, i32* %loc0
   %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %26, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %27
 
 ; <label>:27                                      ; preds = %22
   %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
@@ -1971,7 +2053,7 @@ ThrowNullRef:                                     ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1989,8 +2071,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -2022,15 +2104,15 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2048,16 +2130,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
   %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
   store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %15
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
@@ -2072,8 +2154,8 @@ entry:
   %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
   %29 = ptrtoint i16 addrspace(1)* %28 to i64
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %19
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
@@ -2089,19 +2171,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2114,8 +2196,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
@@ -2128,7 +2210,7 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[loadElem]
+Failed to read AppDomain.PrepareDataForSetup[storeElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
@@ -2202,8 +2284,8 @@ entry:
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
-  br i1 %NullCheck24, label %27, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = load i64, i64 addrspace(1)* %26
@@ -2218,8 +2300,8 @@ entry:
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
-  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
   %41 = load i64, i64 addrspace(1)* %39
@@ -2236,8 +2318,8 @@ entry:
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
-  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
   %54 = load i64, i64 addrspace(1)* %52
@@ -2252,8 +2334,8 @@ entry:
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
   %67 = load i64, i64 addrspace(1)* %65
@@ -2270,8 +2352,8 @@ entry:
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
-  br i1 %NullCheck16, label %79, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
   %80 = load i64, i64 addrspace(1)* %78
@@ -2286,8 +2368,8 @@ entry:
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
-  br i1 %NullCheck18, label %92, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
   %93 = load i64, i64 addrspace(1)* %91
@@ -2304,8 +2386,8 @@ entry:
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
-  br i1 %NullCheck12, label %105, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = load i64, i64 addrspace(1)* %104
@@ -2320,8 +2402,8 @@ entry:
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
-  br i1 %NullCheck14, label %118, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
   %119 = load i64, i64 addrspace(1)* %117
@@ -2337,8 +2419,8 @@ entry:
 
 ; <label>:128                                     ; preds = %20
   %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
-  br i1 %NullCheck4, label %130, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %129, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %130
 
 ; <label>:130                                     ; preds = %128
   %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
@@ -2346,8 +2428,8 @@ entry:
   %133 = load i16, i16 addrspace(1)* %132, align 8
   %134 = zext i16 %133 to i32
   %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
-  br i1 %NullCheck6, label %136, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %135, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %136
 
 ; <label>:136                                     ; preds = %130
   %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
@@ -2360,8 +2442,8 @@ entry:
 
 ; <label>:143                                     ; preds = %136
   %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
-  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %144, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %145
 
 ; <label>:145                                     ; preds = %143
   %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
@@ -2369,8 +2451,8 @@ entry:
   %148 = load i16, i16 addrspace(1)* %147, align 8
   %149 = zext i16 %148 to i32
   %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %150, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %151
 
 ; <label>:151                                     ; preds = %145
   %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
@@ -2388,8 +2470,8 @@ entry:
 
 ; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
-  br i1 %NullCheck, label %163, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %ThrowNullRef, label %163
 
 ; <label>:163                                     ; preds = %161
   %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
@@ -2399,8 +2481,8 @@ entry:
 
 ; <label>:167                                     ; preds = %163
   %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
-  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %168, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %169
 
 ; <label>:169                                     ; preds = %167
   %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
@@ -2432,55 +2514,55 @@ ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %167
+ThrowNullRef2:                                    ; preds = %167
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %128
+ThrowNullRef4:                                    ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %130
+ThrowNullRef6:                                    ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %143
+ThrowNullRef8:                                    ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %145
+ThrowNullRef10:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %102
+ThrowNullRef12:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %105
+ThrowNullRef14:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %76
+ThrowNullRef16:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %79
+ThrowNullRef18:                                   ; preds = %79
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %50
+ThrowNullRef20:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %53
+ThrowNullRef22:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %24
+ThrowNullRef24:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %27
+ThrowNullRef26:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2503,15 +2585,15 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2519,16 +2601,16 @@ entry:
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
   store i32 %8, i32* %loc0
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
   %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
   store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
@@ -2546,16 +2628,16 @@ entry:
 
 ; <label>:23                                      ; preds = %64
   %24 = load i16*, i16** %loc3
-  %NullCheck12 = icmp ne i16* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i16* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
   store i32 %27, i32* %loc5
   %28 = load i16*, i16** %loc4
-  %NullCheck14 = icmp ne i16* %28, null
-  br i1 %NullCheck14, label %29, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %28, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = load i16, i16* %28, align 8
@@ -2620,15 +2702,15 @@ entry:
 
 ; <label>:67                                      ; preds = %64
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
-  br i1 %NullCheck8, label %69, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %68, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %69
 
 ; <label>:69                                      ; preds = %67
   %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
   %71 = load i32, i32 addrspace(1)* %70
   %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
-  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %73
 
 ; <label>:73                                      ; preds = %69
   %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
@@ -2645,31 +2727,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %67
+ThrowNullRef8:                                    ; preds = %67
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %69
+ThrowNullRef10:                                   ; preds = %69
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2710,14 +2792,14 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
   %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
@@ -2730,14 +2812,14 @@ entry:
 
 ; <label>:11                                      ; preds = %4
   %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
   %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
@@ -2749,14 +2831,14 @@ entry:
 
 ; <label>:22                                      ; preds = %16
   %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
   %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
-  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
-  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
@@ -2804,23 +2886,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2836,7 +2918,280 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[loadElem]
+Successfully read RuntimeType.IsAssignableFrom
+
+define i8 @RuntimeType.IsAssignableFrom(%System.RuntimeType addrspace(1)* %param0, %System.Type addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.RuntimeType addrspace(1)*
+  %arg1 = alloca %System.Type addrspace(1)*
+  %loc0 = alloca %System.RuntimeType addrspace(1)*
+  %loc1 = alloca %"System.Type[]" addrspace(1)*
+  %loc2 = alloca i32
+  store %System.RuntimeType addrspace(1)* %param0, %System.RuntimeType addrspace(1)** %this
+  store %System.Type addrspace(1)* %param1, %System.Type addrspace(1)** %arg1
+  %0 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %1 = icmp ne %System.Type addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i8 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %5 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %6 = bitcast %System.Type addrspace(1)* %4 to %System.Object addrspace(1)*
+  %7 = bitcast %System.RuntimeType addrspace(1)* %5 to %System.Object addrspace(1)*
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %6, %System.Object addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %3
+  ret i8 1
+
+; <label>:12                                      ; preds = %3
+  %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 152
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 32
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
+  %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
+  %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
+  store %System.RuntimeType addrspace(1)* %25, %System.RuntimeType addrspace(1)** %loc0
+  %26 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %27 = icmp eq %System.RuntimeType addrspace(1)* %26, null
+  br i1 %27, label %34, label %28
+
+; <label>:28                                      ; preds = %15
+  %29 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %30 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)*)*)(%System.RuntimeType addrspace(1)* %29, %System.RuntimeType addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+; <label>:34                                      ; preds = %15
+  %35 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %36 = call %System.Reflection.Emit.TypeBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Reflection.Emit.TypeBuilder addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %35)
+  %37 = icmp eq %System.Reflection.Emit.TypeBuilder addrspace(1)* %36, null
+  br i1 %37, label %139, label %38
+
+; <label>:38                                      ; preds = %34
+  %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %42
+
+; <label>:42                                      ; preds = %38
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 152
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 40
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
+  %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
+  %53 = zext i8 %52 to i32
+  %54 = icmp eq i32 %53, 0
+  br i1 %54, label %56, label %55
+
+; <label>:55                                      ; preds = %42
+  ret i8 1
+
+; <label>:56                                      ; preds = %42
+  %57 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %58 = bitcast %System.RuntimeType addrspace(1)* %57 to %System.Type addrspace(1)*
+  %59 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %58)
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %64 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.Type addrspace(1)* %63, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = bitcast %System.RuntimeType addrspace(1)* %64 to %System.Type addrspace(1)*
+  %67 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %63, %System.Type addrspace(1)* %66)
+  %68 = zext i8 %67 to i32
+  %69 = trunc i32 %68 to i8
+  ret i8 %69
+
+; <label>:70                                      ; preds = %56
+  %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
+  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %73
+
+; <label>:73                                      ; preds = %70
+  %74 = load i64, i64 addrspace(1)* %72
+  %75 = add i64 %74, 128
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = add i64 %77, 0
+  %79 = inttoptr i64 %78 to i64*
+  %80 = load i64, i64* %79
+  %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
+  %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
+  %83 = call i8 %82(%System.Type addrspace(1)* %81)
+  %84 = zext i8 %83 to i32
+  %85 = icmp eq i32 %84, 0
+  br i1 %85, label %139, label %86
+
+; <label>:86                                      ; preds = %73
+  %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
+  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %89
+
+; <label>:89                                      ; preds = %86
+  %90 = load i64, i64 addrspace(1)* %88
+  %91 = add i64 %90, 128
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = add i64 %93, 24
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
+  %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
+  %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
+  store %"System.Type[]" addrspace(1)* %99, %"System.Type[]" addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %129
+
+; <label>:100                                     ; preds = %132
+  %101 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %102 = load i32, i32* %loc2
+  %NullCheck11 = icmp eq %"System.Type[]" addrspace(1)* %101, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %103
+
+; <label>:103                                     ; preds = %100
+  %104 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 1
+  %105 = load i32, i32 addrspace(1)* %104
+  %106 = zext i32 %105 to i64
+  %107 = zext i32 %102 to i64
+  %BoundsCheck = icmp uge i64 %107, %106
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %108
+
+; <label>:108                                     ; preds = %103
+  %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
+  %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
+  %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
+  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %113
+
+; <label>:113                                     ; preds = %108
+  %114 = load i64, i64 addrspace(1)* %112
+  %115 = add i64 %114, 152
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = add i64 %117, 56
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
+  %123 = zext i8 %122 to i32
+  %124 = icmp ne i32 %123, 0
+  br i1 %124, label %126, label %125
+
+; <label>:125                                     ; preds = %113
+  ret i8 0
+
+; <label>:126                                     ; preds = %113
+  %127 = load i32, i32* %loc2
+  %128 = add i32 %127, 1
+  store i32 %128, i32* %loc2
+  br label %129
+
+; <label>:129                                     ; preds = %89, %126
+  %130 = load i32, i32* %loc2
+  %131 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %NullCheck9 = icmp eq %"System.Type[]" addrspace(1)* %131, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %132
+
+; <label>:132                                     ; preds = %129
+  %133 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %131, i32 0, i32 1
+  %134 = load i32, i32 addrspace(1)* %133
+  %135 = zext i32 %134 to i64
+  %136 = trunc i64 %135 to i32
+  %137 = icmp slt i32 %130, %136
+  br i1 %137, label %100, label %138
+
+; <label>:138                                     ; preds = %132
+  ret i8 1
+
+; <label>:139                                     ; preds = %34, %73
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %129
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %103
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -2893,7 +3248,7 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElem]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -2904,8 +3259,8 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -2997,8 +3352,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
@@ -3059,8 +3414,8 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -3087,8 +3442,8 @@ entry:
 
 ; <label>:17                                      ; preds = %5, %11
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
@@ -3097,8 +3452,8 @@ entry:
 
 ; <label>:22                                      ; preds = %1, %11
   %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
@@ -3109,11 +3464,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %17
+ThrowNullRef2:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %22
+ThrowNullRef4:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3167,15 +3522,15 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
   %15 = load i32, i32 addrspace(1)* %14
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
@@ -3198,7 +3553,7 @@ ThrowNullRef:                                     ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef2:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3232,8 +3587,8 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
@@ -3312,8 +3667,8 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -3327,8 +3682,8 @@ entry:
 ; <label>:5                                       ; preds = %43
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %7 = load i32, i32* %loc1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck6, label %8, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
@@ -3366,8 +3721,8 @@ entry:
 ; <label>:32                                      ; preds = %21, %25
   %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
   %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
-  br i1 %NullCheck8, label %35, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = trunc i32 %34 to i16
@@ -3380,8 +3735,8 @@ entry:
 ; <label>:40                                      ; preds = %1, %35
   %41 = load i32, i32* %loc1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
-  br i1 %NullCheck2, label %43, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %42, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
@@ -3392,8 +3747,8 @@ entry:
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
   %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
-  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
   %51 = load i64, i64 addrspace(1)* %49
@@ -3412,19 +3767,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %40
+ThrowNullRef2:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %47
+ThrowNullRef4:                                    ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %5
+ThrowNullRef6:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %32
+ThrowNullRef8:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3467,8 +3822,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
@@ -3492,11 +3847,391 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(i16* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store i16* %param0, i16** %arg0
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load i32, i32* %arg3
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %42, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %37, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg2
+  %13 = load i32, i32* %arg3
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %37, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %24 = load i32, i32* %arg2
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load i16*, i16** %arg0
+  %35 = load i32, i32* %arg3
+  %36 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %36, i16* %34, i32 %35)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:37                                      ; preds = %5, %16
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %39)
+  %41 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41, %System.String addrspace(1)* %38, %System.String addrspace(1)* %40)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41) #0
+  unreachable
+
+; <label>:42                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
-Failed to read StringBuilder.ToString[loadElemA]
+Successfully read StringBuilder.ToString
+
+define %System.String addrspace(1)* @StringBuilder.ToString(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i16*
+  %loc3 = alloca %"System.Char[]" addrspace(1)*
+  %loc4 = alloca i32
+  %loc5 = alloca i32
+  %loc6 = alloca i16 addrspace(1)*
+  %loc7 = alloca %System.String addrspace(1)*
+  %loc8 = alloca %"System.Char[]" addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %0)
+  %2 = icmp ne i32 %1, 0
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %4
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %6)
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %7)
+  store %System.String addrspace(1)* %8, %System.String addrspace(1)** %loc0
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.Text.StringBuilder addrspace(1)* %9, %System.Text.StringBuilder addrspace(1)** %loc1
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  store %System.String addrspace(1)* %10, %System.String addrspace(1)** %loc7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc7
+  %12 = ptrtoint %System.String addrspace(1)* %11 to i64
+  %13 = icmp eq i64 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %5
+  %15 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %16 = sext i32 %15 to i64
+  %17 = add i64 %12, %16
+  br label %18
+
+; <label>:18                                      ; preds = %5, %14
+  %19 = phi i64 [ %12, %5 ], [ %17, %14 ]
+  %20 = inttoptr i64 %19 to i16*
+  store i16* %20, i16** %loc2
+  br label %21
+
+; <label>:21                                      ; preds = %98, %18
+  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %22, null
+  br i1 %NullCheck, label %ThrowNullRef, label %23
+
+; <label>:23                                      ; preds = %21
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 3
+  %25 = load i32, i32 addrspace(1)* %24, align 8
+  %26 = icmp sle i32 %25, 0
+  br i1 %26, label %96, label %27
+
+; <label>:27                                      ; preds = %23
+  %28 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %28, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %29
+
+; <label>:29                                      ; preds = %27
+  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %28, i32 0, i32 1
+  %31 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %30, align 8
+  store %"System.Char[]" addrspace(1)* %31, %"System.Char[]" addrspace(1)** %loc3
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %33
+
+; <label>:33                                      ; preds = %29
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  store i32 %35, i32* %loc4
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  %39 = load i32, i32 addrspace(1)* %38, align 8
+  store i32 %39, i32* %loc5
+  %40 = load i32, i32* %loc5
+  %41 = load i32, i32* %loc4
+  %42 = add i32 %40, %41
+  %43 = zext i32 %42 to i64
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %45
+
+; <label>:45                                      ; preds = %37
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = sext i32 %47 to i64
+  %49 = icmp sgt i64 %43, %48
+  br i1 %49, label %91, label %50
+
+; <label>:50                                      ; preds = %45
+  %51 = load i32, i32* %loc5
+  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %52, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %53
+
+; <label>:53                                      ; preds = %50
+  %54 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %52, i32 0, i32 1
+  %55 = load i32, i32 addrspace(1)* %54
+  %56 = zext i32 %55 to i64
+  %57 = trunc i64 %56 to i32
+  %58 = icmp ugt i32 %51, %57
+  br i1 %58, label %91, label %59
+
+; <label>:59                                      ; preds = %53
+  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  store %"System.Char[]" addrspace(1)* %60, %"System.Char[]" addrspace(1)** %loc8
+  %61 = icmp eq %"System.Char[]" addrspace(1)* %60, null
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %63, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %64
+
+; <label>:64                                      ; preds = %62
+  %65 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %63, i32 0, i32 1
+  %66 = load i32, i32 addrspace(1)* %65
+  %67 = zext i32 %66 to i64
+  %68 = trunc i64 %67 to i32
+  %69 = icmp ne i32 %68, 0
+  br i1 %69, label %71, label %70
+
+; <label>:70                                      ; preds = %59, %64
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:71                                      ; preds = %64
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %73
+
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %BoundsCheck = icmp uge i64 0, %76
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %77
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %78, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:79                                      ; preds = %70, %77
+  %80 = load i16*, i16** %loc2
+  %81 = load i32, i32* %loc4
+  %82 = sext i32 %81 to i64
+  %83 = mul i64 %82, 2
+  %84 = bitcast i16* %80 to i8*
+  %85 = getelementptr inbounds i8, i8* %84, i64 %83
+  %86 = load i16 addrspace(1)*, i16 addrspace(1)** %loc6
+  %87 = ptrtoint i16 addrspace(1)* %86 to i64
+  %88 = load i32, i32* %loc5
+  %89 = bitcast i8* %85 to i16*
+  %90 = inttoptr i64 %87 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %89, i16* %90, i32 %88)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %96
+
+; <label>:91                                      ; preds = %45, %53
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %94 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %93)
+  %95 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95, %System.String addrspace(1)* %92, %System.String addrspace(1)* %94)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95) #0
+  unreachable
+
+; <label>:96                                      ; preds = %23, %79
+  %97 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %97, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %98
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %97, i32 0, i32 2
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  store %System.Text.StringBuilder addrspace(1)* %100, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %102 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %102, label %21, label %103
+
+; <label>:103                                     ; preds = %98
+  store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc7
+  %104 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  ret %System.String addrspace(1)* %104
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method StringBuilder::get_Length using LLILCJit
+Successfully read StringBuilder.get_Length
+
+define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
+Successfully read RuntimeHelpers.get_OffsetToStringData
+
+define i32 @RuntimeHelpers.get_OffsetToStringData() {
+entry:
+  ret i32 12
+}
+
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
 Successfully read CultureData.CreateCultureData
 
@@ -3514,23 +4249,23 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
   store i8 %4, i8 addrspace(1)* %6
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
@@ -3549,11 +4284,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3566,50 +4301,50 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
   store i32 -1, i32 addrspace(1)* %2
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
   store i32 -1, i32 addrspace(1)* %8
   %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
   store i32 -1, i32 addrspace(1)* %14
   %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
   store i32 -1, i32 addrspace(1)* %17
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
@@ -3623,27 +4358,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3675,7 +4410,136 @@ Failed to read Dictionary`2.Insert[non-const derefAddress]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
 Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
-Failed to read HashHelpers.GetPrime[loadElem]
+Successfully read HashHelpers.GetPrime
+
+define i32 @HashHelpers.GetPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %6, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5, %System.String addrspace(1)* %4)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5) #0
+  unreachable
+
+; <label>:6                                       ; preds = %entry
+  store i32 0, i32* %loc0
+  br label %29
+
+; <label>:7                                       ; preds = %35
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 1296
+  %10 = addrspacecast i8 addrspace(1)* %9 to %"System.Int32[]" addrspace(1)**
+  %11 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %10
+  %12 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Int32[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = zext i32 %15 to i64
+  %17 = zext i32 %12 to i64
+  %BoundsCheck = icmp uge i64 %17, %16
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 3, i32 %12
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  store i32 %20, i32* %loc1
+  %21 = load i32, i32* %loc1
+  %22 = load i32, i32* %arg0
+  %23 = icmp slt i32 %21, %22
+  br i1 %23, label %26, label %24
+
+; <label>:24                                      ; preds = %18
+  %25 = load i32, i32* %loc1
+  ret i32 %25
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %loc0
+  %28 = add i32 %27, 1
+  store i32 %28, i32* %loc0
+  br label %29
+
+; <label>:29                                      ; preds = %6, %26
+  %30 = load i32, i32* %loc0
+  %31 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %32 = getelementptr inbounds i8, i8 addrspace(1)* %31, i64 1296
+  %33 = addrspacecast i8 addrspace(1)* %32 to %"System.Int32[]" addrspace(1)**
+  %34 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %33
+  %NullCheck = icmp eq %"System.Int32[]" addrspace(1)* %34, null
+  br i1 %NullCheck, label %ThrowNullRef, label %35
+
+; <label>:35                                      ; preds = %29
+  %36 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %34, i32 0, i32 1
+  %37 = load i32, i32 addrspace(1)* %36
+  %38 = zext i32 %37 to i64
+  %39 = trunc i64 %38 to i32
+  %40 = icmp slt i32 %30, %39
+  br i1 %40, label %7, label %41
+
+; <label>:41                                      ; preds = %35
+  %42 = load i32, i32* %arg0
+  %43 = or i32 %42, 1
+  store i32 %43, i32* %loc2
+  br label %59
+
+; <label>:44                                      ; preds = %59
+  %45 = load i32, i32* %loc2
+  %46 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %45)
+  %47 = zext i8 %46 to i32
+  %48 = icmp eq i32 %47, 0
+  br i1 %48, label %56, label %49
+
+; <label>:49                                      ; preds = %44
+  %50 = load i32, i32* %loc2
+  %51 = sub i32 %50, 1
+  %52 = srem i32 %51, 101
+  %53 = icmp eq i32 %52, 0
+  br i1 %53, label %56, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = load i32, i32* %loc2
+  ret i32 %55
+
+; <label>:56                                      ; preds = %44, %49
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %57, 2
+  store i32 %58, i32* %loc2
+  br label %59
+
+; <label>:59                                      ; preds = %41, %56
+  %60 = load i32, i32* %loc2
+  %61 = icmp slt i32 %60, 2147483647
+  br i1 %61, label %44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load i32, i32* %arg0
+  ret i32 %63
+
+ThrowNullRef:                                     ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
 Successfully read GenericEqualityComparer`1.GetHashCode
 
@@ -3694,14 +4558,14 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
   %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load i64, i64 addrspace(1)* %7
@@ -3720,7 +4584,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3750,8 +4614,8 @@ entry:
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
@@ -3796,8 +4660,8 @@ entry:
   %35 = bitcast i16* %34 to i8*
   %36 = getelementptr inbounds i8, i8* %35, i64 2
   %37 = bitcast i8* %36 to i16*
-  %NullCheck4 = icmp ne i16* %37, null
-  br i1 %NullCheck4, label %38, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %37, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %38
 
 ; <label>:38                                      ; preds = %27
   %39 = load i16, i16* %37, align 8
@@ -3824,8 +4688,8 @@ entry:
 
 ; <label>:54                                      ; preds = %22, %43
   %55 = load i16*, i16** %loc4
-  %NullCheck2 = icmp ne i16* %55, null
-  br i1 %NullCheck2, label %56, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i16* %55, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %56
 
 ; <label>:56                                      ; preds = %54
   %57 = load i16, i16* %55, align 8
@@ -3850,11 +4714,11 @@ ThrowNullRef:                                     ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %54
+ThrowNullRef2:                                    ; preds = %54
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %27
+ThrowNullRef4:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3871,8 +4735,8 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -3907,8 +4771,8 @@ entry:
 
 ; <label>:26                                      ; preds = %19
   %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
-  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %28
 
 ; <label>:28                                      ; preds = %26
   %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
@@ -3920,7 +4784,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3972,8 +4836,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
@@ -3984,26 +4848,26 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
-  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
@@ -4014,8 +4878,8 @@ entry:
 ; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
@@ -4024,8 +4888,8 @@ entry:
 
 ; <label>:25                                      ; preds = %1, %16, %23
   %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
-  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
@@ -4036,27 +4900,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %20
+ThrowNullRef10:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4069,8 +4933,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -4081,8 +4945,8 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
@@ -4091,8 +4955,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1, %8
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
@@ -4103,11 +4967,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4128,24 +4992,24 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   store i32 %3, i32* %loc0
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
   %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
   store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck4, label %9, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
@@ -4164,15 +5028,15 @@ entry:
 ; <label>:18                                      ; preds = %70
   %19 = load i16*, i16** %loc3
   %20 = bitcast i16* %19 to i64*
-  %NullCheck10 = icmp ne i64* %20, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %20, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = load i64, i64* %20, align 8
   %23 = load i16*, i16** %loc4
   %24 = bitcast i16* %23 to i64*
-  %NullCheck12 = icmp ne i64* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = load i64, i64* %24, align 8
@@ -4188,8 +5052,8 @@ entry:
   %31 = bitcast i16* %30 to i8*
   %32 = getelementptr inbounds i8, i8* %31, i64 8
   %33 = bitcast i8* %32 to i64*
-  %NullCheck14 = icmp ne i64* %33, null
-  br i1 %NullCheck14, label %34, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = load i64, i64* %33, align 8
@@ -4197,8 +5061,8 @@ entry:
   %37 = bitcast i16* %36 to i8*
   %38 = getelementptr inbounds i8, i8* %37, i64 8
   %39 = bitcast i8* %38 to i64*
-  %NullCheck16 = icmp ne i64* %39, null
-  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %40
 
 ; <label>:40                                      ; preds = %34
   %41 = load i64, i64* %39, align 8
@@ -4214,8 +5078,8 @@ entry:
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %NullCheck18 = icmp ne i64* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = load i64, i64* %48, align 8
@@ -4223,8 +5087,8 @@ entry:
   %52 = bitcast i16* %51 to i8*
   %53 = getelementptr inbounds i8, i8* %52, i64 16
   %54 = bitcast i8* %53 to i64*
-  %NullCheck20 = icmp ne i64* %54, null
-  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64* %54, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %55
 
 ; <label>:55                                      ; preds = %49
   %56 = load i64, i64* %54, align 8
@@ -4262,15 +5126,15 @@ entry:
 ; <label>:74                                      ; preds = %95
   %75 = load i16*, i16** %loc3
   %76 = bitcast i16* %75 to i32*
-  %NullCheck6 = icmp ne i32* %76, null
-  br i1 %NullCheck6, label %77, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32* %76, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %77
 
 ; <label>:77                                      ; preds = %74
   %78 = load i32, i32* %76, align 8
   %79 = load i16*, i16** %loc4
   %80 = bitcast i16* %79 to i32*
-  %NullCheck8 = icmp ne i32* %80, null
-  br i1 %NullCheck8, label %81, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i32* %80, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %81
 
 ; <label>:81                                      ; preds = %77
   %82 = load i32, i32* %80, align 8
@@ -4318,43 +5182,43 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %74
+ThrowNullRef6:                                    ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %77
+ThrowNullRef8:                                    ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %29
+ThrowNullRef14:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %34
+ThrowNullRef16:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4376,8 +5240,8 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load i64, i64 addrspace(1)* %4
@@ -4389,8 +5253,8 @@ entry:
   %12 = load i64, i64* %11
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %5
   %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
@@ -4399,8 +5263,8 @@ entry:
   %18 = load i8, i8* %arg2
   %19 = zext i8 %18 to i32
   %20 = trunc i32 %19 to i8
-  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %15
   %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
@@ -4411,11 +5275,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4442,8 +5306,8 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
@@ -4466,16 +5330,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
   %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = load i64, i64 addrspace(1)* %19
@@ -4500,8 +5364,8 @@ entry:
 ; <label>:35                                      ; preds = %30
   %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
@@ -4514,8 +5378,8 @@ entry:
 
 ; <label>:42                                      ; preds = %1, %38
   %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
-  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
@@ -4526,19 +5390,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %35
+ThrowNullRef2:                                    ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %42
+ThrowNullRef8:                                    ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4551,14 +5415,14 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
@@ -4570,7 +5434,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4583,8 +5447,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
@@ -4613,51 +5477,51 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
   %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
   %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
   %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
   %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
-  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
   store i64 %21, i64 addrspace(1)* %23
   %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %25 = load i64, i64* %loc0
-  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
@@ -4668,27 +5532,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %22
+ThrowNullRef12:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4701,8 +5565,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
@@ -4713,19 +5577,19 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
@@ -4734,8 +5598,8 @@ entry:
 
 ; <label>:15                                      ; preds = %1, %13
   %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
@@ -4746,19 +5610,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %15
+ThrowNullRef8:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4771,8 +5635,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -4831,8 +5695,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
@@ -4882,8 +5746,8 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
-  br i1 %NullCheck, label %17, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %ThrowNullRef, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
@@ -4894,15 +5758,15 @@ entry:
 
 ; <label>:22                                      ; preds = %17
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
-  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
   %26 = load i32, i32 addrspace(1)* %25
   %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
-  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %27, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
@@ -4925,8 +5789,8 @@ entry:
 ; <label>:40                                      ; preds = %17
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
-  br i1 %NullCheck6, label %43, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %41, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
@@ -4938,34 +5802,17 @@ ThrowNullRef:                                     ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %24
+ThrowNullRef4:                                    ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %40
+ThrowNullRef6:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
-}
-
-INFO:  jitting method Object::ReferenceEquals using LLILCJit
-Successfully read Object.ReferenceEquals
-
-define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
-entry:
-  %arg0 = alloca %System.Object addrspace(1)*
-  %arg1 = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
-  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
-  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = icmp eq %System.Object addrspace(1)* %0, %1
-  %3 = sext i1 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
 }
 
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
@@ -4978,21 +5825,21 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
   %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
-  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
@@ -5007,28 +5854,28 @@ entry:
 ; <label>:13                                      ; preds = %8, %12
   %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
   %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
   %21 = load i32, i32 addrspace(1)* %20, align 8
   %22 = add i32 %21, 1
-  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
   store i32 %22, i32 addrspace(1)* %24
   %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
@@ -5039,27 +5886,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5077,7 +5924,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::Setup using LLILCJit
-Failed to read AppDomain.Setup[loadElem]
+Failed to read AppDomain.Setup[unbox]
 INFO:  jitting method Thread::GetDomain using LLILCJit
 Successfully read Thread.GetDomain
 
@@ -5108,8 +5955,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
@@ -5122,14 +5969,14 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
   %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
@@ -5141,11 +5988,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5173,8 +6020,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -5189,7 +6036,328 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
 Failed to read KeyCollection.System.Collections.Generic.IEnumerable<TKey>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Successfully read Enumerator.MoveNext
+
+define i8 @Enumerator.MoveNext(%"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.RuntimeTypeHandle* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*
+  %"$TypeArg" = alloca %System.RuntimeTypeHandle*
+  store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
+  %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 8
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %76, label %12
+
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
+  br label %76
+
+; <label>:13                                      ; preds = %85
+  %14 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck19 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %15
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, i32 0, i32 0
+  %17 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %16, align 8
+  %NullCheck21 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, i32 0, i32 2
+  %20 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %19, align 8
+  %21 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck23 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %22
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, i32 0, i32 2
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %NullCheck25 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 3, i32 %24
+  %NullCheck27 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %32
+
+; <label>:32                                      ; preds = %30
+  %33 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, i32 0, i32 2
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = icmp slt i32 %34, 0
+  br i1 %35, label %68, label %36
+
+; <label>:36                                      ; preds = %32
+  %37 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %38 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck29 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %39
+
+; <label>:39                                      ; preds = %36
+  %40 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, i32 0, i32 0
+  %41 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %40, align 8
+  %NullCheck31 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, i32 0, i32 2
+  %44 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %43, align 8
+  %45 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck33 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, i32 0, i32 2
+  %48 = load i32, i32 addrspace(1)* %47, align 8
+  %NullCheck35 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %49
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = zext i32 %51 to i64
+  %53 = zext i32 %48 to i64
+  %BoundsCheck37 = icmp uge i64 %53, %52
+  br i1 %BoundsCheck37, label %ThrowIndexOutOfRange38, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 3, i32 %48
+  %NullCheck39 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %56
+
+; <label>:56                                      ; preds = %54
+  %57 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, i32 0, i32 0
+  %58 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck41 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %59
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %60, %System.__Canon addrspace(1)* %58)
+  %61 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck43 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  %64 = load i32, i32 addrspace(1)* %63, align 8
+  %65 = add i32 %64, 1
+  %NullCheck45 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  store i32 %65, i32 addrspace(1)* %67
+  ret i8 1
+
+; <label>:68                                      ; preds = %32
+  %69 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck47 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %73 = add i32 %72, 1
+  %NullCheck49 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %74
+
+; <label>:74                                      ; preds = %70
+  %75 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  store i32 %73, i32 addrspace(1)* %75
+  br label %76
+
+; <label>:76                                      ; preds = %8, %12, %74
+  %77 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %78
+
+; <label>:78                                      ; preds = %76
+  %79 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, i32 0, i32 2
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck7 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %82
+
+; <label>:82                                      ; preds = %78
+  %83 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, i32 0, i32 0
+  %84 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %83, align 8
+  %NullCheck9 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %85
+
+; <label>:85                                      ; preds = %82
+  %86 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, i32 0, i32 7
+  %87 = load i32, i32 addrspace(1)* %86, align 8
+  %88 = icmp ult i32 %80, %87
+  br i1 %88, label %13, label %89
+
+; <label>:89                                      ; preds = %85
+  %90 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %91 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck11 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %92
+
+; <label>:92                                      ; preds = %89
+  %93 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, i32 0, i32 0
+  %94 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck13 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %95
+
+; <label>:95                                      ; preds = %92
+  %96 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, i32 0, i32 7
+  %97 = load i32, i32 addrspace(1)* %96, align 8
+  %98 = add i32 %97, 1
+  %NullCheck15 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %99
+
+; <label>:99                                      ; preds = %95
+  %100 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, i32 0, i32 2
+  store i32 %98, i32 addrspace(1)* %100
+  %101 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck17 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %102
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %103, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %92
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef22:                                   ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef24:                                   ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef26:                                   ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef28:                                   ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef30:                                   ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef32:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef34:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef36:                                   ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange38:                           ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef40:                                   ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef42:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef44:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef46:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef48:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef50:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -5200,8 +6368,8 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -5232,9 +6400,9 @@ Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
 Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
-Failed to read String.MakeSeparatorList[loadElemA]
+Failed to read String.MakeSeparatorList[storeElem]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
-Failed to read String.InternalSplitKeepEmptyEntries[loadElem]
+Failed to read String.InternalSplitKeepEmptyEntries[storeElem]
 INFO:  jitting method Path::IsRelative using LLILCJit
 Successfully read Path.IsRelative
 
@@ -5243,8 +6411,8 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -5254,8 +6422,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
@@ -5271,8 +6439,8 @@ entry:
 
 ; <label>:17                                      ; preds = %7
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
@@ -5288,8 +6456,8 @@ entry:
 
 ; <label>:29                                      ; preds = %19
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %31
 
 ; <label>:31                                      ; preds = %29
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
@@ -5300,8 +6468,8 @@ entry:
 
 ; <label>:36                                      ; preds = %31
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
-  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %37, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
@@ -5312,8 +6480,8 @@ entry:
 
 ; <label>:43                                      ; preds = %31, %38
   %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
-  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %45
 
 ; <label>:45                                      ; preds = %43
   %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
@@ -5324,8 +6492,8 @@ entry:
 
 ; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %50
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
@@ -5336,8 +6504,8 @@ entry:
 
 ; <label>:57                                      ; preds = %1, %7, %19, %45, %52
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
-  br i1 %NullCheck14, label %59, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %59
 
 ; <label>:59                                      ; preds = %57
   %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
@@ -5347,8 +6515,8 @@ entry:
 
 ; <label>:63                                      ; preds = %59
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
@@ -5359,8 +6527,8 @@ entry:
 
 ; <label>:70                                      ; preds = %65
   %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
-  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.String addrspace(1)* %71, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %72
 
 ; <label>:72                                      ; preds = %70
   %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
@@ -5379,39 +6547,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %17
+ThrowNullRef4:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %29
+ThrowNullRef6:                                    ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %36
+ThrowNullRef8:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %43
+ThrowNullRef10:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %50
+ThrowNullRef12:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %57
+ThrowNullRef14:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %63
+ThrowNullRef16:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %70
+ThrowNullRef18:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5419,7 +6587,293 @@ ThrowNullRef17:                                   ; preds = %70
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
-Failed to read String.TrimHelper[loadElem]
+Successfully read String.TrimHelper
+
+define %System.String addrspace(1)* @String.TrimHelper(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i16
+  %loc4 = alloca i32
+  %loc5 = alloca i16
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = sub i32 %3, 1
+  store i32 %4, i32* %loc0
+  store i32 0, i32* %loc1
+  %5 = load i32, i32* %arg2
+  %6 = icmp eq i32 %5, 1
+  br i1 %6, label %62, label %7
+
+; <label>:7                                       ; preds = %1
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:8                                       ; preds = %58
+  store i32 0, i32* %loc2
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load i32, i32* %loc1
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2, i32 %10
+  %13 = load i16, i16 addrspace(1)* %12
+  %14 = zext i16 %13 to i32
+  %15 = trunc i32 %14 to i16
+  store i16 %15, i16* %loc3
+  store i32 0, i32* %loc2
+  br label %34
+
+; <label>:16                                      ; preds = %37
+  %17 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %18 = load i32, i32* %loc2
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %17, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %19
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = zext i32 %18 to i64
+  %BoundsCheck = icmp uge i64 %23, %22
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %24
+
+; <label>:24                                      ; preds = %19
+  %25 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 3, i32 %18
+  %26 = load i16, i16 addrspace(1)* %25, align 8
+  %27 = zext i16 %26 to i32
+  %28 = load i16, i16* %loc3
+  %29 = zext i16 %28 to i32
+  %30 = icmp eq i32 %27, %29
+  br i1 %30, label %43, label %31
+
+; <label>:31                                      ; preds = %24
+  %32 = load i32, i32* %loc2
+  %33 = add i32 %32, 1
+  store i32 %33, i32* %loc2
+  br label %34
+
+; <label>:34                                      ; preds = %11, %31
+  %35 = load i32, i32* %loc2
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = icmp slt i32 %35, %41
+  br i1 %42, label %16, label %43
+
+; <label>:43                                      ; preds = %24, %37
+  %44 = load i32, i32* %loc2
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %45, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp eq i32 %44, %50
+  br i1 %51, label %62, label %52
+
+; <label>:52                                      ; preds = %46
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %7, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %57, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %58
+
+; <label>:58                                      ; preds = %55
+  %59 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %60 = load i32, i32 addrspace(1)* %59
+  %61 = icmp slt i32 %56, %60
+  br i1 %61, label %8, label %62
+
+; <label>:62                                      ; preds = %1, %46, %58
+  %63 = load i32, i32* %arg2
+  %64 = icmp eq i32 %63, 0
+  br i1 %64, label %122, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %66, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %67
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %66, i32 0, i32 1
+  %69 = load i32, i32 addrspace(1)* %68
+  %70 = sub i32 %69, 1
+  store i32 %70, i32* %loc0
+  br label %118
+
+; <label>:71                                      ; preds = %118
+  store i32 0, i32* %loc4
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %73 = load i32, i32* %loc0
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %74
+
+; <label>:74                                      ; preds = %71
+  %75 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 2, i32 %73
+  %76 = load i16, i16 addrspace(1)* %75
+  %77 = zext i16 %76 to i32
+  %78 = trunc i32 %77 to i16
+  store i16 %78, i16* %loc5
+  store i32 0, i32* %loc4
+  br label %97
+
+; <label>:79                                      ; preds = %100
+  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %81 = load i32, i32* %loc4
+  %NullCheck19 = icmp eq %"System.Char[]" addrspace(1)* %80, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
+
+; <label>:82                                      ; preds = %79
+  %83 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 1
+  %84 = load i32, i32 addrspace(1)* %83
+  %85 = zext i32 %84 to i64
+  %86 = zext i32 %81 to i64
+  %BoundsCheck21 = icmp uge i64 %86, %85
+  br i1 %BoundsCheck21, label %ThrowIndexOutOfRange22, label %87
+
+; <label>:87                                      ; preds = %82
+  %88 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 3, i32 %81
+  %89 = load i16, i16 addrspace(1)* %88, align 8
+  %90 = zext i16 %89 to i32
+  %91 = load i16, i16* %loc5
+  %92 = zext i16 %91 to i32
+  %93 = icmp eq i32 %90, %92
+  br i1 %93, label %106, label %94
+
+; <label>:94                                      ; preds = %87
+  %95 = load i32, i32* %loc4
+  %96 = add i32 %95, 1
+  store i32 %96, i32* %loc4
+  br label %97
+
+; <label>:97                                      ; preds = %74, %94
+  %98 = load i32, i32* %loc4
+  %99 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck15 = icmp eq %"System.Char[]" addrspace(1)* %99, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %100
+
+; <label>:100                                     ; preds = %97
+  %101 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %99, i32 0, i32 1
+  %102 = load i32, i32 addrspace(1)* %101
+  %103 = zext i32 %102 to i64
+  %104 = trunc i64 %103 to i32
+  %105 = icmp slt i32 %98, %104
+  br i1 %105, label %79, label %106
+
+; <label>:106                                     ; preds = %87, %100
+  %107 = load i32, i32* %loc4
+  %108 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck17 = icmp eq %"System.Char[]" addrspace(1)* %108, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %109
+
+; <label>:109                                     ; preds = %106
+  %110 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %108, i32 0, i32 1
+  %111 = load i32, i32 addrspace(1)* %110
+  %112 = zext i32 %111 to i64
+  %113 = trunc i64 %112 to i32
+  %114 = icmp eq i32 %107, %113
+  br i1 %114, label %122, label %115
+
+; <label>:115                                     ; preds = %109
+  %116 = load i32, i32* %loc0
+  %117 = sub i32 %116, 1
+  store i32 %117, i32* %loc0
+  br label %118
+
+; <label>:118                                     ; preds = %67, %115
+  %119 = load i32, i32* %loc0
+  %120 = load i32, i32* %loc1
+  %121 = icmp sge i32 %119, %120
+  br i1 %121, label %71, label %122
+
+; <label>:122                                     ; preds = %62, %109, %118
+  %123 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %124 = load i32, i32* %loc1
+  %125 = load i32, i32* %loc0
+  %126 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %123, i32 %124, i32 %125)
+  ret %System.String addrspace(1)* %126
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %97
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange22:                           ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
 Successfully read String.CreateTrimmedString
 
@@ -5439,8 +6893,8 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
@@ -5535,8 +6989,8 @@ entry:
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i64 2872
   %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
   %8 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %7
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %3
   %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
@@ -5553,8 +7007,8 @@ entry:
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 2864
   %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
   %21 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %20
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
-  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %22
 
 ; <label>:22                                      ; preds = %16
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
@@ -5569,7 +7023,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %16
+ThrowNullRef2:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5586,8 +7040,8 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5613,8 +7067,8 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
@@ -5632,8 +7086,8 @@ entry:
 
 ; <label>:12                                      ; preds = %4
   %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
@@ -5644,8 +7098,8 @@ entry:
 
 ; <label>:19                                      ; preds = %14
   %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %19
   %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
@@ -5660,21 +7114,21 @@ entry:
   %31 = zext i16 %30 to i32
   %32 = bitcast i8* %29 to i16*
   %33 = trunc i32 %31 to i16
-  %NullCheck6 = icmp ne i16* %32, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i16* %32, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %21
   store i16 %33, i16* %32, align 8
   %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %36
 
 ; <label>:36                                      ; preds = %34
   %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
   %38 = load i32, i32 addrspace(1)* %37, align 8
   %39 = add i32 %38, 1
-  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %40
 
 ; <label>:40                                      ; preds = %36
   %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
@@ -5683,16 +7137,16 @@ entry:
 
 ; <label>:42                                      ; preds = %14
   %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
-  br i1 %NullCheck12, label %44, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
   %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
   %47 = load i16, i16* %arg1
   %48 = zext i16 %47 to i32
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = trunc i32 %48 to i16
@@ -5703,31 +7157,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %19
+ThrowNullRef4:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %21
+ThrowNullRef6:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %36
+ThrowNullRef10:                                   ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %42
+ThrowNullRef12:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %44
+ThrowNullRef14:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5740,8 +7194,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -5752,8 +7206,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
@@ -5762,14 +7216,14 @@ entry:
 
 ; <label>:11                                      ; preds = %1
   %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
@@ -5779,15 +7233,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5808,8 +7262,8 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5822,8 +7276,8 @@ entry:
 
 ; <label>:8                                       ; preds = %3
   %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
@@ -5842,15 +7296,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
-  br i1 %NullCheck4, label %22, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
   %24 = load i16*, i16* addrspace(1)* %23, align 8
   %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %25, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
@@ -5859,8 +7313,8 @@ entry:
   store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
@@ -5874,8 +7328,8 @@ entry:
 
 ; <label>:37                                      ; preds = %65
   %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %37
   %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
@@ -5886,16 +7340,16 @@ entry:
   %45 = bitcast i16* %41 to i8*
   %46 = getelementptr inbounds i8, i8* %45, i64 %44
   %47 = bitcast i8* %46 to i16*
-  %NullCheck14 = icmp ne i16* %47, null
-  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %47, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %48
 
 ; <label>:48                                      ; preds = %39
   %49 = load i16, i16* %47, align 8
   %50 = zext i16 %49 to i32
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %52 = load i32, i32* %loc1
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %53
 
 ; <label>:53                                      ; preds = %48
   %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
@@ -5916,8 +7370,8 @@ entry:
 ; <label>:62                                      ; preds = %36, %59
   %63 = load i32, i32* %loc1
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck10, label %65, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %65
 
 ; <label>:65                                      ; preds = %62
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
@@ -5936,15 +7390,15 @@ entry:
 
 ; <label>:74                                      ; preds = %70
   %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
-  br i1 %NullCheck18, label %76, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %76
 
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
   %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
-  br i1 %NullCheck20, label %80, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
   %81 = load i64, i64 addrspace(1)* %79
@@ -5958,8 +7412,8 @@ entry:
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
   %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
-  br i1 %NullCheck22, label %92, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.String addrspace(1)* %90, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %92
 
 ; <label>:92                                      ; preds = %80
   %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
@@ -5969,15 +7423,15 @@ entry:
 
 ; <label>:96                                      ; preds = %70
   %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
-  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %98
 
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
   %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
-  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
   %103 = load i64, i64 addrspace(1)* %101
@@ -5991,8 +7445,8 @@ entry:
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
   %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
-  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.String addrspace(1)* %112, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %114
 
 ; <label>:114                                     ; preds = %102
   %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
@@ -6004,59 +7458,59 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %20
+ThrowNullRef4:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %22
+ThrowNullRef6:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %26
+ThrowNullRef8:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %62
+ThrowNullRef10:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %48
+ThrowNullRef16:                                   ; preds = %48
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %74
+ThrowNullRef18:                                   ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %76
+ThrowNullRef20:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %80
+ThrowNullRef22:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %96
+ThrowNullRef24:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %98
+ThrowNullRef26:                                   ; preds = %98
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %102
+ThrowNullRef28:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6069,15 +7523,15 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
   %3 = load i16*, i16* addrspace(1)* %2, align 8
   %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
@@ -6087,8 +7541,8 @@ entry:
   %10 = bitcast i16* %3 to i8*
   %11 = getelementptr inbounds i8, i8* %10, i64 %9
   %12 = bitcast i8* %11 to i16*
-  %NullCheck4 = icmp ne i16* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %5
   store i16 0, i16* %12, align 8
@@ -6098,11 +7552,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6119,8 +7573,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -6131,8 +7585,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
@@ -6144,15 +7598,15 @@ entry:
 
 ; <label>:14                                      ; preds = %1
   %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
   %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
   %21 = load i64, i64 addrspace(1)* %19
@@ -6171,15 +7625,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %14
+ThrowNullRef4:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %16
+ThrowNullRef6:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6302,14 +7756,6 @@ entry:
   ret %System.String addrspace(1)* %57
 }
 
-INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
-Successfully read RuntimeHelpers.get_OffsetToStringData
-
-define i32 @RuntimeHelpers.get_OffsetToStringData() {
-entry:
-  ret i32 12
-}
-
 INFO:  jitting method String::Equals using LLILCJit
 Successfully read String.Equals
 
@@ -6381,8 +7827,8 @@ entry:
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
-  br i1 %NullCheck24, label %29, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
   %30 = load i64, i64 addrspace(1)* %28
@@ -6397,8 +7843,8 @@ entry:
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
-  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
   %43 = load i64, i64 addrspace(1)* %41
@@ -6418,8 +7864,8 @@ entry:
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
   %59 = load i64, i64 addrspace(1)* %57
@@ -6434,8 +7880,8 @@ entry:
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck22, label %71, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
   %72 = load i64, i64 addrspace(1)* %70
@@ -6455,8 +7901,8 @@ entry:
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
-  br i1 %NullCheck16, label %87, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = load i64, i64 addrspace(1)* %86
@@ -6471,8 +7917,8 @@ entry:
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck18, label %100, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
   %101 = load i64, i64 addrspace(1)* %99
@@ -6492,8 +7938,8 @@ entry:
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
-  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
   %117 = load i64, i64 addrspace(1)* %115
@@ -6508,8 +7954,8 @@ entry:
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
-  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
   %130 = load i64, i64 addrspace(1)* %128
@@ -6528,15 +7974,15 @@ entry:
 
 ; <label>:142                                     ; preds = %22
   %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
-  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %143, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %144
 
 ; <label>:144                                     ; preds = %142
   %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
   %146 = load i32, i32 addrspace(1)* %145
   %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
-  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %147, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %148
 
 ; <label>:148                                     ; preds = %144
   %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
@@ -6557,15 +8003,15 @@ entry:
 
 ; <label>:159                                     ; preds = %22
   %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
-  br i1 %NullCheck, label %161, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %ThrowNullRef, label %161
 
 ; <label>:161                                     ; preds = %159
   %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
   %163 = load i32, i32 addrspace(1)* %162
   %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
-  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %164, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %165
 
 ; <label>:165                                     ; preds = %161
   %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
@@ -6578,8 +8024,8 @@ entry:
 
 ; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
-  br i1 %NullCheck4, label %172, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %171, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %172
 
 ; <label>:172                                     ; preds = %170
   %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
@@ -6589,8 +8035,8 @@ entry:
 
 ; <label>:176                                     ; preds = %172
   %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
-  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %177, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %178
 
 ; <label>:178                                     ; preds = %176
   %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
@@ -6629,55 +8075,55 @@ ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %161
+ThrowNullRef2:                                    ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %170
+ThrowNullRef4:                                    ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %176
+ThrowNullRef6:                                    ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %142
+ThrowNullRef8:                                    ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %144
+ThrowNullRef10:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %113
+ThrowNullRef12:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %116
+ThrowNullRef14:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %84
+ThrowNullRef16:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %87
+ThrowNullRef18:                                   ; preds = %87
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %55
+ThrowNullRef20:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %58
+ThrowNullRef22:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %26
+ThrowNullRef24:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %29
+ThrowNullRef26:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,8 +8161,8 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck, label %14, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %ThrowNullRef, label %14
 
 ; <label>:14                                      ; preds = %8
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
@@ -6760,8 +8206,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
@@ -6770,14 +8216,14 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32, i32* %loc0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %10
   %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
   %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
@@ -6790,15 +8236,15 @@ entry:
 ; <label>:25                                      ; preds = %19
   %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
-  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
   %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
@@ -6807,8 +8253,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %37 = load i32, i32* %loc0
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %38, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %38
 
 ; <label>:38                                      ; preds = %32
   %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
@@ -6817,14 +8263,14 @@ entry:
 
 ; <label>:40                                      ; preds = %19
   %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %40
   %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
   %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
-  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
-  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
@@ -6832,8 +8278,8 @@ entry:
   %48 = zext i32 %47 to i64
   %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
-  br i1 %NullCheck16, label %51, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %51
 
 ; <label>:51                                      ; preds = %45
   %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
@@ -6847,15 +8293,15 @@ entry:
 ; <label>:57                                      ; preds = %51
   %58 = load i16*, i16** %arg1
   %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
-  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %60
 
 ; <label>:60                                      ; preds = %57
   %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
   %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
-  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %64
 
 ; <label>:64                                      ; preds = %60
   %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
@@ -6864,22 +8310,22 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
   %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
-  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %70
 
 ; <label>:70                                      ; preds = %64
   %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
   %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
-  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
-  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
   %75 = load i32, i32 addrspace(1)* %74
   %76 = zext i32 %75 to i64
   %77 = trunc i64 %76 to i32
-  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
-  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %78
 
 ; <label>:78                                      ; preds = %73
   %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
@@ -6901,8 +8347,8 @@ entry:
   %90 = bitcast i16* %86 to i8*
   %91 = getelementptr inbounds i8, i8* %90, i64 %89
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %93
 
 ; <label>:93                                      ; preds = %80
   %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
@@ -6912,8 +8358,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %99 = load i32, i32* %loc2
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %100
 
 ; <label>:100                                     ; preds = %93
   %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
@@ -6928,63 +8374,63 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %25
+ThrowNullRef6:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %32
+ThrowNullRef10:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %40
+ThrowNullRef12:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %45
+ThrowNullRef16:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %57
+ThrowNullRef18:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %60
+ThrowNullRef20:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %64
+ThrowNullRef22:                                   ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %70
+ThrowNullRef24:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %73
+ThrowNullRef26:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %80
+ThrowNullRef28:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %93
+ThrowNullRef30:                                   ; preds = %93
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7004,8 +8450,8 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
@@ -7033,43 +8479,43 @@ entry:
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %14
   %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
   %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   %28 = load i32, i32 addrspace(1)* %27, align 8
   %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
-  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %30
 
 ; <label>:30                                      ; preds = %26
   %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
   %32 = load i32, i32 addrspace(1)* %31, align 8
   %33 = add i32 %28, %32
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %34
 
 ; <label>:34                                      ; preds = %30
   %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   store i32 %33, i32 addrspace(1)* %35
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
   store i32 0, i32 addrspace(1)* %38
   %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %40
 
 ; <label>:40                                      ; preds = %37
   %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
@@ -7082,8 +8528,8 @@ entry:
 
 ; <label>:47                                      ; preds = %40
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
@@ -7098,8 +8544,8 @@ entry:
   %54 = load i32, i32* %loc0
   %55 = sext i32 %54 to i64
   %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
-  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %57
 
 ; <label>:57                                      ; preds = %52
   %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
@@ -7110,68 +8556,35 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %14
+ThrowNullRef2:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %23
+ThrowNullRef4:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %26
+ThrowNullRef6:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %30
+ThrowNullRef8:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %34
+ThrowNullRef10:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %47
+ThrowNullRef14:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %52
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-}
-
-INFO:  jitting method StringBuilder::get_Length using LLILCJit
-Successfully read StringBuilder.get_Length
-
-define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.StringBuilder addrspace(1)*
-  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
-  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
-
-; <label>:1                                       ; preds = %entry
-  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %3 = load i32, i32 addrspace(1)* %2, align 8
-  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
-
-; <label>:5                                       ; preds = %1
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = add i32 %3, %7
-  ret i32 %8
-
-ThrowNullRef:                                     ; preds = %entry
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef16:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7213,70 +8626,70 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
   %6 = load i32, i32 addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
   store i32 %6, i32 addrspace(1)* %8
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
   %13 = load i32, i32 addrspace(1)* %12, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
   store i32 %13, i32 addrspace(1)* %15
   %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
-  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %18
 
 ; <label>:18                                      ; preds = %14
   %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
   %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
   %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
   %34 = load i32, i32 addrspace(1)* %33, align 8
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
-  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
@@ -7287,39 +8700,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %28
+ThrowNullRef16:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %32
+ThrowNullRef18:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7455,13 +8868,13 @@ entry:
 ; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
@@ -7477,16 +8890,16 @@ entry:
 
 ; <label>:18                                      ; preds = %15
   %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
   store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
   %22 = load i32, i32* %loc0
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %24
 
 ; <label>:24                                      ; preds = %20
   %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
@@ -7498,13 +8911,13 @@ entry:
 ; <label>:28                                      ; preds = %15, %24
   %29 = load i32, i32* %arg1
   %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %31
   %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
@@ -7517,20 +8930,20 @@ entry:
   %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
-  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
   %46 = load i32, i32 addrspace(1)* %45, align 8
   %47 = sub i32 %40, %46
-  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
-  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i32 addrspace(1)* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %48
 
 ; <label>:48                                      ; preds = %44
   store i32 %47, i32 addrspace(1)* %39, align 8
@@ -7538,21 +8951,21 @@ entry:
 
 ; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
-  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %51
 
 ; <label>:51                                      ; preds = %49
   %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %53
 
 ; <label>:53                                      ; preds = %51
   %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
   %55 = load i32, i32 addrspace(1)* %54, align 8
   %56 = load i32, i32* %arg2
   %57 = sub i32 %55, %56
-  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %58
 
 ; <label>:58                                      ; preds = %53
   %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
@@ -7562,13 +8975,13 @@ entry:
 ; <label>:60                                      ; preds = %33, %58
   %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
   %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
-  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %63
 
 ; <label>:63                                      ; preds = %60
   %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
-  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
-  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
@@ -7578,15 +8991,15 @@ entry:
 
 ; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
-  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i32 addrspace(1)* %69, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %70
 
 ; <label>:70                                      ; preds = %68
   %71 = load i32, i32 addrspace(1)* %69, align 8
   store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
-  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
@@ -7596,8 +9009,8 @@ entry:
   store i32 %77, i32* %loc4
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
-  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %80
 
 ; <label>:80                                      ; preds = %73
   %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
@@ -7607,71 +9020,71 @@ entry:
 ; <label>:83                                      ; preds = %80
   store i32 0, i32* %loc3
   %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
-  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
-  br i1 %NullCheck26, label %88, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i32 addrspace(1)* %87, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %88
 
 ; <label>:88                                      ; preds = %85
   %89 = load i32, i32 addrspace(1)* %87, align 8
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
-  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %90
 
 ; <label>:90                                      ; preds = %88
   %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
   store i32 %89, i32 addrspace(1)* %91
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
-  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
-  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %96
 
 ; <label>:96                                      ; preds = %94
   %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
-  br i1 %NullCheck34, label %100, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %100
 
 ; <label>:100                                     ; preds = %96
   %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
-  br i1 %NullCheck36, label %102, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %102
 
 ; <label>:102                                     ; preds = %100
   %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
   %104 = load i32, i32 addrspace(1)* %103, align 8
   %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
-  br i1 %NullCheck38, label %106, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %106
 
 ; <label>:106                                     ; preds = %102
   %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
-  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
-  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %108
 
 ; <label>:108                                     ; preds = %106
   %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
   %110 = load i32, i32 addrspace(1)* %109, align 8
   %111 = add i32 %104, %110
-  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %112
 
 ; <label>:112                                     ; preds = %108
   %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
   store i32 %111, i32 addrspace(1)* %113
   %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
-  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i32 addrspace(1)* %114, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %115
 
 ; <label>:115                                     ; preds = %112
   %116 = load i32, i32 addrspace(1)* %114, align 8
@@ -7681,19 +9094,19 @@ entry:
 ; <label>:118                                     ; preds = %115
   %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
-  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %121
 
 ; <label>:121                                     ; preds = %118
   %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
-  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
-  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %123
 
 ; <label>:123                                     ; preds = %121
   %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
   %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
-  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
-  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %126
 
 ; <label>:126                                     ; preds = %123
   %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
@@ -7705,8 +9118,8 @@ entry:
 
 ; <label>:130                                     ; preds = %80, %115, %126
   %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %132
 
 ; <label>:132                                     ; preds = %130
   %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7715,8 +9128,8 @@ entry:
   %136 = load i32, i32* %loc3
   %137 = sub i32 %135, %136
   %138 = sub i32 %134, %137
-  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %139
 
 ; <label>:139                                     ; preds = %132
   %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7728,16 +9141,16 @@ entry:
 
 ; <label>:144                                     ; preds = %139
   %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
-  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %146
 
 ; <label>:146                                     ; preds = %144
   %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
   %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
   %149 = load i32, i32* %loc2
   %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
-  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %151
 
 ; <label>:151                                     ; preds = %146
   %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
@@ -7754,145 +9167,249 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %18
+ThrowNullRef4:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %31
+ThrowNullRef10:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %44
+ThrowNullRef16:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %68
+ThrowNullRef18:                                   ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %70
+ThrowNullRef20:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %73
+ThrowNullRef22:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %83
+ThrowNullRef24:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %85
+ThrowNullRef26:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %88
+ThrowNullRef28:                                   ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %90
+ThrowNullRef30:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %94
+ThrowNullRef32:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %96
+ThrowNullRef34:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %100
+ThrowNullRef36:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %102
+ThrowNullRef38:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %106
+ThrowNullRef40:                                   ; preds = %106
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %108
+ThrowNullRef42:                                   ; preds = %108
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %112
+ThrowNullRef44:                                   ; preds = %112
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %118
+ThrowNullRef46:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %121
+ThrowNullRef48:                                   ; preds = %121
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %123
+ThrowNullRef50:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %130
+ThrowNullRef52:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %132
+ThrowNullRef54:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %144
+ThrowNullRef56:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %146
+ThrowNullRef58:                                   ; preds = %146
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %60
+ThrowNullRef60:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %63
+ThrowNullRef62:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %49
+ThrowNullRef64:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %51
+ThrowNullRef66:                                   ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %53
+ThrowNullRef68:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(%"System.Char[]" addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %arg0 = alloca %"System.Char[]" addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store %"System.Char[]" addrspace(1)* %param0, %"System.Char[]" addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load i32, i32* %arg4
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %43, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %38, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg1
+  %13 = load i32, i32* %arg4
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %38, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %24 = load i32, i32* %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %35 = load i32, i32* %arg3
+  %36 = load i32, i32* %arg4
+  %37 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %37, %"System.Char[]" addrspace(1)* %34, i32 %35, i32 %36)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:38                                      ; preds = %5, %16
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Successfully read Buffer._Memmove
 
@@ -7914,7 +9431,7 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[loadElem]
+Failed to read AppDomain.SetDataHelper[storeElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -7923,8 +9440,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
@@ -7934,8 +9451,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
@@ -7947,15 +9464,15 @@ entry:
   %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
   %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
@@ -7966,15 +9483,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7992,7 +9509,79 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
-Failed to read Dictionary`2.TryGetValue[loadElemA]
+Successfully read Dictionary`2.TryGetValue
+
+define i8 @"Dictionary`2.TryGetValue"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)* addrspace(1)* %param2) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  %arg2 = alloca %System.__Canon addrspace(1)* addrspace(1)*
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  store %System.__Canon addrspace(1)* addrspace(1)* %param2, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  store i32 %2, i32* %loc0
+  %3 = load i32, i32* %loc0
+  %4 = icmp slt i32 %3, 0
+  br i1 %4, label %22, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 2
+  %10 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %9, align 8
+  %11 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = zext i32 %11 to i64
+  %BoundsCheck = icmp uge i64 %16, %15
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 3, i32 %11
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %20, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %6, %System.__Canon addrspace(1)* %21)
+  ret i8 1
+
+; <label>:22                                      ; preds = %entry
+  %23 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %23, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -8058,8 +9647,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
@@ -8091,8 +9680,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
@@ -8171,15 +9760,15 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck, label %19, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %ThrowNullRef, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
   %21 = load i32, i32 addrspace(1)* %20
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
@@ -8202,7 +9791,7 @@ ThrowNullRef:                                     ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %19
+ThrowNullRef2:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8248,8 +9837,8 @@ entry:
   %0 = alloca %System.AppDomainHandle
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %1 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %1, i32 0, i32 15
@@ -8269,8 +9858,8 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
@@ -8286,7 +9875,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -8299,8 +9888,8 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -8327,8 +9916,8 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
@@ -8352,8 +9941,8 @@ entry:
   %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
   store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
@@ -8363,8 +9952,8 @@ entry:
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
@@ -8374,8 +9963,8 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %9
   %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
@@ -8384,8 +9973,8 @@ entry:
 
 ; <label>:18                                      ; preds = %3, %16
   %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
@@ -8397,15 +9986,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %18
+ThrowNullRef6:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8418,8 +10007,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
@@ -8453,15 +10042,15 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
@@ -8473,7 +10062,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8481,7 +10070,7 @@ ThrowNullRef1:                                    ; preds = %1
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
 Failed to read Dictionary`2.System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
@@ -8506,8 +10095,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
@@ -8524,8 +10113,8 @@ entry:
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -8544,7 +10133,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8577,8 +10166,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = load i64, i64* %arg2
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = trunc i32 %3 to i8
@@ -8634,46 +10223,46 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
   %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
-  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
-  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
-  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
@@ -8684,27 +10273,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %20
+ThrowNullRef12:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8717,8 +10306,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -8756,22 +10345,22 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
   %9 = load i64, i64 addrspace(1)* %8, align 8
   %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
   %13 = load i64, i64 addrspace(1)* %12, align 8
   %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %11
   %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
@@ -8788,11 +10377,11 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8882,8 +10471,8 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
@@ -8900,8 +10489,8 @@ entry:
 ; <label>:8                                       ; preds = %1
   %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
   %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
@@ -8911,15 +10500,15 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
   %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
   %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
-  br i1 %NullCheck6, label %21, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
@@ -8946,15 +10535,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8992,15 +10581,15 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
   store i8 %3, i8 addrspace(1)* %5
   %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
@@ -9011,7 +10600,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9027,8 +10616,8 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -9041,8 +10630,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
@@ -9058,7 +10647,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9080,8 +10669,8 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
@@ -9096,8 +10685,8 @@ entry:
 ; <label>:12                                      ; preds = %6
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
@@ -9112,8 +10701,8 @@ entry:
 ; <label>:21                                      ; preds = %15
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
@@ -9128,8 +10717,8 @@ entry:
 ; <label>:30                                      ; preds = %24
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %31, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
@@ -9144,8 +10733,8 @@ entry:
 ; <label>:39                                      ; preds = %33
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
-  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %40, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %42
 
 ; <label>:42                                      ; preds = %39
   %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
@@ -9164,19 +10753,19 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %21
+ThrowNullRef4:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %30
+ThrowNullRef6:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %39
+ThrowNullRef8:                                    ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9243,8 +10832,8 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
@@ -9264,57 +10853,57 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
   store i8 0, i8 addrspace(1)* %2
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
   store i8 0, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
   store i8 0, i8 addrspace(1)* %17
   %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
   store i8 0, i8 addrspace(1)* %20
   %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
-  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
@@ -9325,31 +10914,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %19
+ThrowNullRef14:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9367,8 +10956,8 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
@@ -9380,8 +10969,8 @@ entry:
 
 ; <label>:9                                       ; preds = %4
   %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %9
   %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
@@ -9395,7 +10984,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef2:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9420,8 +11009,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
@@ -9512,8 +11101,8 @@ entry:
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
@@ -9524,8 +11113,8 @@ entry:
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = load i64, i64 addrspace(1)* %12
@@ -9537,8 +11126,8 @@ entry:
   %20 = load i64, i64* %19
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
-  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %13
   %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
@@ -9555,8 +11144,8 @@ entry:
 ; <label>:30                                      ; preds = %25
   %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %32 = load i32, i32* %arg2
-  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
-  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
@@ -9570,15 +11159,15 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %30
+ThrowNullRef2:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9622,87 +11211,87 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
   %10 = load i8, i8 addrspace(1)* %9, align 8
   %11 = zext i8 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %8
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
   store i8 %12, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
   %19 = load i8, i8 addrspace(1)* %18, align 8
   %20 = zext i8 %19 to i32
   %21 = trunc i32 %20 to i8
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
   store i8 %21, i8 addrspace(1)* %23
   %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
   %28 = load i8, i8 addrspace(1)* %27, align 8
   %29 = zext i8 %28 to i32
   %30 = trunc i32 %29 to i8
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
-  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %31
 
 ; <label>:31                                      ; preds = %26
   %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
   store i8 %30, i8 addrspace(1)* %32
   %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
-  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
-  br i1 %NullCheck14, label %40, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %40
 
 ; <label>:40                                      ; preds = %35
   %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
   store i8 %39, i8 addrspace(1)* %41
   %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
-  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %44
 
 ; <label>:44                                      ; preds = %40
   %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
   %46 = load i8, i8 addrspace(1)* %45, align 8
   %47 = zext i8 %46 to i32
   %48 = trunc i32 %47 to i8
-  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
   store i8 %48, i8 addrspace(1)* %50
   %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
-  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
@@ -9713,29 +11302,29 @@ entry:
 ; <label>:56                                      ; preds = %52
   %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
-  br i1 %NullCheck22, label %59, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
   %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
   %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
-  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
-  br i1 %NullCheck24, label %63, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
   %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
-  br i1 %NullCheck26, label %66, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
   %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
-  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
-  br i1 %NullCheck28, label %69, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %69
 
 ; <label>:69                                      ; preds = %66
   %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
@@ -9744,15 +11333,15 @@ entry:
 
 ; <label>:71                                      ; preds = %105
   %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
-  br i1 %NullCheck34, label %73, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %73
 
 ; <label>:73                                      ; preds = %71
   %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
   %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
   %76 = load i32, i32* %loc0
-  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
-  br i1 %NullCheck36, label %77, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
@@ -9766,8 +11355,8 @@ entry:
 
 ; <label>:83                                      ; preds = %77
   %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
-  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
@@ -9775,14 +11364,14 @@ entry:
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
   %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
-  br i1 %NullCheck40, label %91, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
 ; <label>:91                                      ; preds = %85
   %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
   %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
-  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck42, label %94, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %94
 
 ; <label>:94                                      ; preds = %91
   %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
@@ -9798,14 +11387,14 @@ entry:
 ; <label>:99                                      ; preds = %69, %96
   %100 = load i32, i32* %loc0
   %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
-  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %102
 
 ; <label>:102                                     ; preds = %99
   %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
   %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
-  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
-  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
@@ -9819,87 +11408,87 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %26
+ThrowNullRef10:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %31
+ThrowNullRef12:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %35
+ThrowNullRef14:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %40
+ThrowNullRef16:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %56
+ThrowNullRef22:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %59
+ThrowNullRef24:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %63
+ThrowNullRef26:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %66
+ThrowNullRef28:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %102
+ThrowNullRef32:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %71
+ThrowNullRef34:                                   ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %73
+ThrowNullRef36:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %83
+ThrowNullRef38:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %85
+ThrowNullRef40:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %91
+ThrowNullRef42:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9943,15 +11532,15 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
   %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
@@ -9961,28 +11550,28 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
   %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %12
   %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
   %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
   %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
-  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
@@ -9993,23 +11582,23 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %12
+ThrowNullRef6:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10031,15 +11620,15 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
   %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = load i64, i64 addrspace(1)* %7
@@ -10077,13 +11666,13 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[loadElem]
+Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -10111,8 +11700,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Jmp1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Jmp1.error.txt
@@ -25,8 +25,8 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
@@ -40,8 +40,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
   %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
@@ -75,7 +75,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -90,8 +90,8 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %NullCheck = icmp ne i8 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = load i8, i8 addrspace(1)* %0, align 8
@@ -125,8 +125,8 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
@@ -159,8 +159,8 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -184,8 +184,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
   store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
@@ -195,8 +195,8 @@ entry:
 ; <label>:4                                       ; preds = %1
   %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
   %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
@@ -206,8 +206,8 @@ entry:
   %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
@@ -221,14 +221,14 @@ entry:
 
 ; <label>:17                                      ; preds = %14
   %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
   %21 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
@@ -238,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -249,8 +249,8 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
@@ -261,27 +261,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %30
+ThrowNullRef10:                                   ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -301,7 +301,89 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
-Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
+Successfully read AppDomainSetup.GetUnsecureApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.GetUnsecureApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %NullCheck = icmp eq %"System.String[]" addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %BoundsCheck = icmp uge i64 0, %5
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %6
+
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 3, i32 0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
+  ret %System.String addrspace(1)* %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_Value using LLILCJit
+Successfully read AppDomainSetup.get_Value
+
+define %"System.String[]" addrspace(1)* @AppDomainSetup.get_Value(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.String[]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 18)
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.String[]" addrspace(1)* addrspace(1)*, %"System.String[]" addrspace(1)*)*)(%"System.String[]" addrspace(1)* addrspace(1)* %9, %"System.String[]" addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %11, i32 0, i32 1
+  %14 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %13, align 8
+  ret %"System.String[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -319,8 +401,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -368,16 +450,16 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
   %5 = load i32, i32 addrspace(1)* %4
   %6 = sub i32 %5, 1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -389,7 +471,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -421,8 +503,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
@@ -456,8 +538,8 @@ entry:
 ; <label>:27                                      ; preds = %19
   %28 = load i32, i32* %arg1
   %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
-  br i1 %NullCheck2, label %30, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %29, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %30
 
 ; <label>:30                                      ; preds = %27
   %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
@@ -493,8 +575,8 @@ entry:
 ; <label>:49                                      ; preds = %46
   %50 = load i32, i32* %arg2
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck4, label %52, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
@@ -517,11 +599,11 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %27
+ThrowNullRef2:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %49
+ThrowNullRef4:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -544,16 +626,16 @@ entry:
   %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %0)
   store %System.String addrspace(1)* %1, %System.String addrspace(1)** %loc0
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 2
   %5 = bitcast [0 x i16] addrspace(1)* %4 to i16 addrspace(1)*
   store i16 addrspace(1)* %5, i16 addrspace(1)** %loc1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %3
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2
@@ -580,7 +662,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -691,15 +773,15 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %NullCheck132 = icmp ne i8* %21, null
-  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+  %NullCheck131 = icmp eq i8* %21, null
+  br i1 %NullCheck131, label %ThrowNullRef132, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = load i8, i8* %21, align 8
   %24 = zext i8 %23 to i32
   %25 = trunc i32 %24 to i8
-  %NullCheck134 = icmp ne i8* %20, null
-  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+  %NullCheck133 = icmp eq i8* %20, null
+  br i1 %NullCheck133, label %ThrowNullRef134, label %26
 
 ; <label>:26                                      ; preds = %22
   store i8 %25, i8* %20, align 8
@@ -709,16 +791,16 @@ entry:
   %28 = load i8*, i8** %arg0
   %29 = load i8*, i8** %arg1
   %30 = bitcast i8* %29 to i16*
-  %NullCheck128 = icmp ne i16* %30, null
-  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+  %NullCheck127 = icmp eq i16* %30, null
+  br i1 %NullCheck127, label %ThrowNullRef128, label %31
 
 ; <label>:31                                      ; preds = %27
   %32 = load i16, i16* %30, align 8
   %33 = sext i16 %32 to i32
   %34 = bitcast i8* %28 to i16*
   %35 = trunc i32 %33 to i16
-  %NullCheck130 = icmp ne i16* %34, null
-  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+  %NullCheck129 = icmp eq i16* %34, null
+  br i1 %NullCheck129, label %ThrowNullRef130, label %36
 
 ; <label>:36                                      ; preds = %31
   store i16 %35, i16* %34, align 8
@@ -728,16 +810,16 @@ entry:
   %38 = load i8*, i8** %arg0
   %39 = load i8*, i8** %arg1
   %40 = bitcast i8* %39 to i16*
-  %NullCheck120 = icmp ne i16* %40, null
-  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+  %NullCheck119 = icmp eq i16* %40, null
+  br i1 %NullCheck119, label %ThrowNullRef120, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i16, i16* %40, align 8
   %43 = sext i16 %42 to i32
   %44 = bitcast i8* %38 to i16*
   %45 = trunc i32 %43 to i16
-  %NullCheck122 = icmp ne i16* %44, null
-  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+  %NullCheck121 = icmp eq i16* %44, null
+  br i1 %NullCheck121, label %ThrowNullRef122, label %46
 
 ; <label>:46                                      ; preds = %41
   store i16 %45, i16* %44, align 8
@@ -745,15 +827,15 @@ entry:
   %48 = getelementptr inbounds i8, i8* %47, i64 2
   %49 = load i8*, i8** %arg1
   %50 = getelementptr inbounds i8, i8* %49, i64 2
-  %NullCheck124 = icmp ne i8* %50, null
-  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+  %NullCheck123 = icmp eq i8* %50, null
+  br i1 %NullCheck123, label %ThrowNullRef124, label %51
 
 ; <label>:51                                      ; preds = %46
   %52 = load i8, i8* %50, align 8
   %53 = zext i8 %52 to i32
   %54 = trunc i32 %53 to i8
-  %NullCheck126 = icmp ne i8* %48, null
-  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+  %NullCheck125 = icmp eq i8* %48, null
+  br i1 %NullCheck125, label %ThrowNullRef126, label %55
 
 ; <label>:55                                      ; preds = %51
   store i8 %54, i8* %48, align 8
@@ -763,14 +845,14 @@ entry:
   %57 = load i8*, i8** %arg0
   %58 = load i8*, i8** %arg1
   %59 = bitcast i8* %58 to i32*
-  %NullCheck116 = icmp ne i32* %59, null
-  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+  %NullCheck115 = icmp eq i32* %59, null
+  br i1 %NullCheck115, label %ThrowNullRef116, label %60
 
 ; <label>:60                                      ; preds = %56
   %61 = load i32, i32* %59, align 8
   %62 = bitcast i8* %57 to i32*
-  %NullCheck118 = icmp ne i32* %62, null
-  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+  %NullCheck117 = icmp eq i32* %62, null
+  br i1 %NullCheck117, label %ThrowNullRef118, label %63
 
 ; <label>:63                                      ; preds = %60
   store i32 %61, i32* %62, align 8
@@ -780,14 +862,14 @@ entry:
   %65 = load i8*, i8** %arg0
   %66 = load i8*, i8** %arg1
   %67 = bitcast i8* %66 to i32*
-  %NullCheck108 = icmp ne i32* %67, null
-  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+  %NullCheck107 = icmp eq i32* %67, null
+  br i1 %NullCheck107, label %ThrowNullRef108, label %68
 
 ; <label>:68                                      ; preds = %64
   %69 = load i32, i32* %67, align 8
   %70 = bitcast i8* %65 to i32*
-  %NullCheck110 = icmp ne i32* %70, null
-  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+  %NullCheck109 = icmp eq i32* %70, null
+  br i1 %NullCheck109, label %ThrowNullRef110, label %71
 
 ; <label>:71                                      ; preds = %68
   store i32 %69, i32* %70, align 8
@@ -795,15 +877,15 @@ entry:
   %73 = getelementptr inbounds i8, i8* %72, i64 4
   %74 = load i8*, i8** %arg1
   %75 = getelementptr inbounds i8, i8* %74, i64 4
-  %NullCheck112 = icmp ne i8* %75, null
-  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+  %NullCheck111 = icmp eq i8* %75, null
+  br i1 %NullCheck111, label %ThrowNullRef112, label %76
 
 ; <label>:76                                      ; preds = %71
   %77 = load i8, i8* %75, align 8
   %78 = zext i8 %77 to i32
   %79 = trunc i32 %78 to i8
-  %NullCheck114 = icmp ne i8* %73, null
-  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+  %NullCheck113 = icmp eq i8* %73, null
+  br i1 %NullCheck113, label %ThrowNullRef114, label %80
 
 ; <label>:80                                      ; preds = %76
   store i8 %79, i8* %73, align 8
@@ -813,14 +895,14 @@ entry:
   %82 = load i8*, i8** %arg0
   %83 = load i8*, i8** %arg1
   %84 = bitcast i8* %83 to i32*
-  %NullCheck100 = icmp ne i32* %84, null
-  br i1 %NullCheck100, label %85, label %ThrowNullRef99
+  %NullCheck99 = icmp eq i32* %84, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %85
 
 ; <label>:85                                      ; preds = %81
   %86 = load i32, i32* %84, align 8
   %87 = bitcast i8* %82 to i32*
-  %NullCheck102 = icmp ne i32* %87, null
-  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+  %NullCheck101 = icmp eq i32* %87, null
+  br i1 %NullCheck101, label %ThrowNullRef102, label %88
 
 ; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
@@ -829,16 +911,16 @@ entry:
   %91 = load i8*, i8** %arg1
   %92 = getelementptr inbounds i8, i8* %91, i64 4
   %93 = bitcast i8* %92 to i16*
-  %NullCheck104 = icmp ne i16* %93, null
-  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+  %NullCheck103 = icmp eq i16* %93, null
+  br i1 %NullCheck103, label %ThrowNullRef104, label %94
 
 ; <label>:94                                      ; preds = %88
   %95 = load i16, i16* %93, align 8
   %96 = sext i16 %95 to i32
   %97 = bitcast i8* %90 to i16*
   %98 = trunc i32 %96 to i16
-  %NullCheck106 = icmp ne i16* %97, null
-  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+  %NullCheck105 = icmp eq i16* %97, null
+  br i1 %NullCheck105, label %ThrowNullRef106, label %99
 
 ; <label>:99                                      ; preds = %94
   store i16 %98, i16* %97, align 8
@@ -848,14 +930,14 @@ entry:
   %101 = load i8*, i8** %arg0
   %102 = load i8*, i8** %arg1
   %103 = bitcast i8* %102 to i32*
-  %NullCheck88 = icmp ne i32* %103, null
-  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+  %NullCheck87 = icmp eq i32* %103, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %104
 
 ; <label>:104                                     ; preds = %100
   %105 = load i32, i32* %103, align 8
   %106 = bitcast i8* %101 to i32*
-  %NullCheck90 = icmp ne i32* %106, null
-  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+  %NullCheck89 = icmp eq i32* %106, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %107
 
 ; <label>:107                                     ; preds = %104
   store i32 %105, i32* %106, align 8
@@ -864,16 +946,16 @@ entry:
   %110 = load i8*, i8** %arg1
   %111 = getelementptr inbounds i8, i8* %110, i64 4
   %112 = bitcast i8* %111 to i16*
-  %NullCheck92 = icmp ne i16* %112, null
-  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+  %NullCheck91 = icmp eq i16* %112, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %113
 
 ; <label>:113                                     ; preds = %107
   %114 = load i16, i16* %112, align 8
   %115 = sext i16 %114 to i32
   %116 = bitcast i8* %109 to i16*
   %117 = trunc i32 %115 to i16
-  %NullCheck94 = icmp ne i16* %116, null
-  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+  %NullCheck93 = icmp eq i16* %116, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %118
 
 ; <label>:118                                     ; preds = %113
   store i16 %117, i16* %116, align 8
@@ -881,15 +963,15 @@ entry:
   %120 = getelementptr inbounds i8, i8* %119, i64 6
   %121 = load i8*, i8** %arg1
   %122 = getelementptr inbounds i8, i8* %121, i64 6
-  %NullCheck96 = icmp ne i8* %122, null
-  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+  %NullCheck95 = icmp eq i8* %122, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %123
 
 ; <label>:123                                     ; preds = %118
   %124 = load i8, i8* %122, align 8
   %125 = zext i8 %124 to i32
   %126 = trunc i32 %125 to i8
-  %NullCheck98 = icmp ne i8* %120, null
-  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+  %NullCheck97 = icmp eq i8* %120, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %127
 
 ; <label>:127                                     ; preds = %123
   store i8 %126, i8* %120, align 8
@@ -899,14 +981,14 @@ entry:
   %129 = load i8*, i8** %arg0
   %130 = load i8*, i8** %arg1
   %131 = bitcast i8* %130 to i64*
-  %NullCheck84 = icmp ne i64* %131, null
-  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+  %NullCheck83 = icmp eq i64* %131, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %132
 
 ; <label>:132                                     ; preds = %128
   %133 = load i64, i64* %131, align 8
   %134 = bitcast i8* %129 to i64*
-  %NullCheck86 = icmp ne i64* %134, null
-  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+  %NullCheck85 = icmp eq i64* %134, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %135
 
 ; <label>:135                                     ; preds = %132
   store i64 %133, i64* %134, align 8
@@ -916,14 +998,14 @@ entry:
   %137 = load i8*, i8** %arg0
   %138 = load i8*, i8** %arg1
   %139 = bitcast i8* %138 to i64*
-  %NullCheck76 = icmp ne i64* %139, null
-  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+  %NullCheck75 = icmp eq i64* %139, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %140
 
 ; <label>:140                                     ; preds = %136
   %141 = load i64, i64* %139, align 8
   %142 = bitcast i8* %137 to i64*
-  %NullCheck78 = icmp ne i64* %142, null
-  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+  %NullCheck77 = icmp eq i64* %142, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %143
 
 ; <label>:143                                     ; preds = %140
   store i64 %141, i64* %142, align 8
@@ -931,15 +1013,15 @@ entry:
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %NullCheck80 = icmp ne i8* %147, null
-  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+  %NullCheck79 = icmp eq i8* %147, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %148
 
 ; <label>:148                                     ; preds = %143
   %149 = load i8, i8* %147, align 8
   %150 = zext i8 %149 to i32
   %151 = trunc i32 %150 to i8
-  %NullCheck82 = icmp ne i8* %145, null
-  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+  %NullCheck81 = icmp eq i8* %145, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %152
 
 ; <label>:152                                     ; preds = %148
   store i8 %151, i8* %145, align 8
@@ -949,14 +1031,14 @@ entry:
   %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
   %156 = bitcast i8* %155 to i64*
-  %NullCheck68 = icmp ne i64* %156, null
-  br i1 %NullCheck68, label %157, label %ThrowNullRef67
+  %NullCheck67 = icmp eq i64* %156, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %157
 
 ; <label>:157                                     ; preds = %153
   %158 = load i64, i64* %156, align 8
   %159 = bitcast i8* %154 to i64*
-  %NullCheck70 = icmp ne i64* %159, null
-  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+  %NullCheck69 = icmp eq i64* %159, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %160
 
 ; <label>:160                                     ; preds = %157
   store i64 %158, i64* %159, align 8
@@ -965,16 +1047,16 @@ entry:
   %163 = load i8*, i8** %arg1
   %164 = getelementptr inbounds i8, i8* %163, i64 8
   %165 = bitcast i8* %164 to i16*
-  %NullCheck72 = icmp ne i16* %165, null
-  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+  %NullCheck71 = icmp eq i16* %165, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %166
 
 ; <label>:166                                     ; preds = %160
   %167 = load i16, i16* %165, align 8
   %168 = sext i16 %167 to i32
   %169 = bitcast i8* %162 to i16*
   %170 = trunc i32 %168 to i16
-  %NullCheck74 = icmp ne i16* %169, null
-  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+  %NullCheck73 = icmp eq i16* %169, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %171
 
 ; <label>:171                                     ; preds = %166
   store i16 %170, i16* %169, align 8
@@ -984,14 +1066,14 @@ entry:
   %173 = load i8*, i8** %arg0
   %174 = load i8*, i8** %arg1
   %175 = bitcast i8* %174 to i64*
-  %NullCheck56 = icmp ne i64* %175, null
-  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+  %NullCheck55 = icmp eq i64* %175, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %176
 
 ; <label>:176                                     ; preds = %172
   %177 = load i64, i64* %175, align 8
   %178 = bitcast i8* %173 to i64*
-  %NullCheck58 = icmp ne i64* %178, null
-  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+  %NullCheck57 = icmp eq i64* %178, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %179
 
 ; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
@@ -1000,16 +1082,16 @@ entry:
   %182 = load i8*, i8** %arg1
   %183 = getelementptr inbounds i8, i8* %182, i64 8
   %184 = bitcast i8* %183 to i16*
-  %NullCheck60 = icmp ne i16* %184, null
-  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+  %NullCheck59 = icmp eq i16* %184, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %185
 
 ; <label>:185                                     ; preds = %179
   %186 = load i16, i16* %184, align 8
   %187 = sext i16 %186 to i32
   %188 = bitcast i8* %181 to i16*
   %189 = trunc i32 %187 to i16
-  %NullCheck62 = icmp ne i16* %188, null
-  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+  %NullCheck61 = icmp eq i16* %188, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %190
 
 ; <label>:190                                     ; preds = %185
   store i16 %189, i16* %188, align 8
@@ -1017,15 +1099,15 @@ entry:
   %192 = getelementptr inbounds i8, i8* %191, i64 10
   %193 = load i8*, i8** %arg1
   %194 = getelementptr inbounds i8, i8* %193, i64 10
-  %NullCheck64 = icmp ne i8* %194, null
-  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+  %NullCheck63 = icmp eq i8* %194, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %195
 
 ; <label>:195                                     ; preds = %190
   %196 = load i8, i8* %194, align 8
   %197 = zext i8 %196 to i32
   %198 = trunc i32 %197 to i8
-  %NullCheck66 = icmp ne i8* %192, null
-  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+  %NullCheck65 = icmp eq i8* %192, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %199
 
 ; <label>:199                                     ; preds = %195
   store i8 %198, i8* %192, align 8
@@ -1035,14 +1117,14 @@ entry:
   %201 = load i8*, i8** %arg0
   %202 = load i8*, i8** %arg1
   %203 = bitcast i8* %202 to i64*
-  %NullCheck48 = icmp ne i64* %203, null
-  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+  %NullCheck47 = icmp eq i64* %203, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %204
 
 ; <label>:204                                     ; preds = %200
   %205 = load i64, i64* %203, align 8
   %206 = bitcast i8* %201 to i64*
-  %NullCheck50 = icmp ne i64* %206, null
-  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+  %NullCheck49 = icmp eq i64* %206, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %207
 
 ; <label>:207                                     ; preds = %204
   store i64 %205, i64* %206, align 8
@@ -1051,14 +1133,14 @@ entry:
   %210 = load i8*, i8** %arg1
   %211 = getelementptr inbounds i8, i8* %210, i64 8
   %212 = bitcast i8* %211 to i32*
-  %NullCheck52 = icmp ne i32* %212, null
-  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+  %NullCheck51 = icmp eq i32* %212, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %213
 
 ; <label>:213                                     ; preds = %207
   %214 = load i32, i32* %212, align 8
   %215 = bitcast i8* %209 to i32*
-  %NullCheck54 = icmp ne i32* %215, null
-  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+  %NullCheck53 = icmp eq i32* %215, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %216
 
 ; <label>:216                                     ; preds = %213
   store i32 %214, i32* %215, align 8
@@ -1068,14 +1150,14 @@ entry:
   %218 = load i8*, i8** %arg0
   %219 = load i8*, i8** %arg1
   %220 = bitcast i8* %219 to i64*
-  %NullCheck36 = icmp ne i64* %220, null
-  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64* %220, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %221
 
 ; <label>:221                                     ; preds = %217
   %222 = load i64, i64* %220, align 8
   %223 = bitcast i8* %218 to i64*
-  %NullCheck38 = icmp ne i64* %223, null
-  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+  %NullCheck37 = icmp eq i64* %223, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %224
 
 ; <label>:224                                     ; preds = %221
   store i64 %222, i64* %223, align 8
@@ -1084,14 +1166,14 @@ entry:
   %227 = load i8*, i8** %arg1
   %228 = getelementptr inbounds i8, i8* %227, i64 8
   %229 = bitcast i8* %228 to i32*
-  %NullCheck40 = icmp ne i32* %229, null
-  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i32* %229, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %230
 
 ; <label>:230                                     ; preds = %224
   %231 = load i32, i32* %229, align 8
   %232 = bitcast i8* %226 to i32*
-  %NullCheck42 = icmp ne i32* %232, null
-  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+  %NullCheck41 = icmp eq i32* %232, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %233
 
 ; <label>:233                                     ; preds = %230
   store i32 %231, i32* %232, align 8
@@ -1099,15 +1181,15 @@ entry:
   %235 = getelementptr inbounds i8, i8* %234, i64 12
   %236 = load i8*, i8** %arg1
   %237 = getelementptr inbounds i8, i8* %236, i64 12
-  %NullCheck44 = icmp ne i8* %237, null
-  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i8* %237, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %238
 
 ; <label>:238                                     ; preds = %233
   %239 = load i8, i8* %237, align 8
   %240 = zext i8 %239 to i32
   %241 = trunc i32 %240 to i8
-  %NullCheck46 = icmp ne i8* %235, null
-  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+  %NullCheck45 = icmp eq i8* %235, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %242
 
 ; <label>:242                                     ; preds = %238
   store i8 %241, i8* %235, align 8
@@ -1117,14 +1199,14 @@ entry:
   %244 = load i8*, i8** %arg0
   %245 = load i8*, i8** %arg1
   %246 = bitcast i8* %245 to i64*
-  %NullCheck24 = icmp ne i64* %246, null
-  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64* %246, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %247
 
 ; <label>:247                                     ; preds = %243
   %248 = load i64, i64* %246, align 8
   %249 = bitcast i8* %244 to i64*
-  %NullCheck26 = icmp ne i64* %249, null
-  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64* %249, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %250
 
 ; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
@@ -1133,14 +1215,14 @@ entry:
   %253 = load i8*, i8** %arg1
   %254 = getelementptr inbounds i8, i8* %253, i64 8
   %255 = bitcast i8* %254 to i32*
-  %NullCheck28 = icmp ne i32* %255, null
-  br i1 %NullCheck28, label %256, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i32* %255, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %256
 
 ; <label>:256                                     ; preds = %250
   %257 = load i32, i32* %255, align 8
   %258 = bitcast i8* %252 to i32*
-  %NullCheck30 = icmp ne i32* %258, null
-  br i1 %NullCheck30, label %259, label %ThrowNullRef29
+  %NullCheck29 = icmp eq i32* %258, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %259
 
 ; <label>:259                                     ; preds = %256
   store i32 %257, i32* %258, align 8
@@ -1149,16 +1231,16 @@ entry:
   %262 = load i8*, i8** %arg1
   %263 = getelementptr inbounds i8, i8* %262, i64 12
   %264 = bitcast i8* %263 to i16*
-  %NullCheck32 = icmp ne i16* %264, null
-  br i1 %NullCheck32, label %265, label %ThrowNullRef31
+  %NullCheck31 = icmp eq i16* %264, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %265
 
 ; <label>:265                                     ; preds = %259
   %266 = load i16, i16* %264, align 8
   %267 = sext i16 %266 to i32
   %268 = bitcast i8* %261 to i16*
   %269 = trunc i32 %267 to i16
-  %NullCheck34 = icmp ne i16* %268, null
-  br i1 %NullCheck34, label %270, label %ThrowNullRef33
+  %NullCheck33 = icmp eq i16* %268, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %270
 
 ; <label>:270                                     ; preds = %265
   store i16 %269, i16* %268, align 8
@@ -1168,14 +1250,14 @@ entry:
   %272 = load i8*, i8** %arg0
   %273 = load i8*, i8** %arg1
   %274 = bitcast i8* %273 to i64*
-  %NullCheck8 = icmp ne i64* %274, null
-  br i1 %NullCheck8, label %275, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64* %274, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %275
 
 ; <label>:275                                     ; preds = %271
   %276 = load i64, i64* %274, align 8
   %277 = bitcast i8* %272 to i64*
-  %NullCheck10 = icmp ne i64* %277, null
-  br i1 %NullCheck10, label %278, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %277, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %278
 
 ; <label>:278                                     ; preds = %275
   store i64 %276, i64* %277, align 8
@@ -1184,14 +1266,14 @@ entry:
   %281 = load i8*, i8** %arg1
   %282 = getelementptr inbounds i8, i8* %281, i64 8
   %283 = bitcast i8* %282 to i32*
-  %NullCheck12 = icmp ne i32* %283, null
-  br i1 %NullCheck12, label %284, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i32* %283, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %284
 
 ; <label>:284                                     ; preds = %278
   %285 = load i32, i32* %283, align 8
   %286 = bitcast i8* %280 to i32*
-  %NullCheck14 = icmp ne i32* %286, null
-  br i1 %NullCheck14, label %287, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i32* %286, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %287
 
 ; <label>:287                                     ; preds = %284
   store i32 %285, i32* %286, align 8
@@ -1200,16 +1282,16 @@ entry:
   %290 = load i8*, i8** %arg1
   %291 = getelementptr inbounds i8, i8* %290, i64 12
   %292 = bitcast i8* %291 to i16*
-  %NullCheck16 = icmp ne i16* %292, null
-  br i1 %NullCheck16, label %293, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i16* %292, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %293
 
 ; <label>:293                                     ; preds = %287
   %294 = load i16, i16* %292, align 8
   %295 = sext i16 %294 to i32
   %296 = bitcast i8* %289 to i16*
   %297 = trunc i32 %295 to i16
-  %NullCheck18 = icmp ne i16* %296, null
-  br i1 %NullCheck18, label %298, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i16* %296, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %298
 
 ; <label>:298                                     ; preds = %293
   store i16 %297, i16* %296, align 8
@@ -1217,15 +1299,15 @@ entry:
   %300 = getelementptr inbounds i8, i8* %299, i64 14
   %301 = load i8*, i8** %arg1
   %302 = getelementptr inbounds i8, i8* %301, i64 14
-  %NullCheck20 = icmp ne i8* %302, null
-  br i1 %NullCheck20, label %303, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i8* %302, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %303
 
 ; <label>:303                                     ; preds = %298
   %304 = load i8, i8* %302, align 8
   %305 = zext i8 %304 to i32
   %306 = trunc i32 %305 to i8
-  %NullCheck22 = icmp ne i8* %300, null
-  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i8* %300, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %307
 
 ; <label>:307                                     ; preds = %303
   store i8 %306, i8* %300, align 8
@@ -1235,14 +1317,14 @@ entry:
   %309 = load i8*, i8** %arg0
   %310 = load i8*, i8** %arg1
   %311 = bitcast i8* %310 to i64*
-  %NullCheck = icmp ne i64* %311, null
-  br i1 %NullCheck, label %312, label %ThrowNullRef
+  %NullCheck = icmp eq i64* %311, null
+  br i1 %NullCheck, label %ThrowNullRef, label %312
 
 ; <label>:312                                     ; preds = %308
   %313 = load i64, i64* %311, align 8
   %314 = bitcast i8* %309 to i64*
-  %NullCheck2 = icmp ne i64* %314, null
-  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64* %314, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %315
 
 ; <label>:315                                     ; preds = %312
   store i64 %313, i64* %314, align 8
@@ -1251,14 +1333,14 @@ entry:
   %318 = load i8*, i8** %arg1
   %319 = getelementptr inbounds i8, i8* %318, i64 8
   %320 = bitcast i8* %319 to i64*
-  %NullCheck4 = icmp ne i64* %320, null
-  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64* %320, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %321
 
 ; <label>:321                                     ; preds = %315
   %322 = load i64, i64* %320, align 8
   %323 = bitcast i8* %317 to i64*
-  %NullCheck6 = icmp ne i64* %323, null
-  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64* %323, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %324
 
 ; <label>:324                                     ; preds = %321
   store i64 %322, i64* %323, align 8
@@ -1286,15 +1368,15 @@ entry:
 ; <label>:338                                     ; preds = %333
   %339 = load i8*, i8** %arg0
   %340 = load i8*, i8** %arg1
-  %NullCheck136 = icmp ne i8* %340, null
-  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+  %NullCheck135 = icmp eq i8* %340, null
+  br i1 %NullCheck135, label %ThrowNullRef136, label %341
 
 ; <label>:341                                     ; preds = %338
   %342 = load i8, i8* %340, align 8
   %343 = zext i8 %342 to i32
   %344 = trunc i32 %343 to i8
-  %NullCheck138 = icmp ne i8* %339, null
-  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+  %NullCheck137 = icmp eq i8* %339, null
+  br i1 %NullCheck137, label %ThrowNullRef138, label %345
 
 ; <label>:345                                     ; preds = %341
   store i8 %344, i8* %339, align 8
@@ -1317,16 +1399,16 @@ entry:
   %357 = load i8*, i8** %arg0
   %358 = load i8*, i8** %arg1
   %359 = bitcast i8* %358 to i16*
-  %NullCheck140 = icmp ne i16* %359, null
-  br i1 %NullCheck140, label %360, label %ThrowNullRef139
+  %NullCheck139 = icmp eq i16* %359, null
+  br i1 %NullCheck139, label %ThrowNullRef140, label %360
 
 ; <label>:360                                     ; preds = %356
   %361 = load i16, i16* %359, align 8
   %362 = sext i16 %361 to i32
   %363 = bitcast i8* %357 to i16*
   %364 = trunc i32 %362 to i16
-  %NullCheck142 = icmp ne i16* %363, null
-  br i1 %NullCheck142, label %365, label %ThrowNullRef141
+  %NullCheck141 = icmp eq i16* %363, null
+  br i1 %NullCheck141, label %ThrowNullRef142, label %365
 
 ; <label>:365                                     ; preds = %360
   store i16 %364, i16* %363, align 8
@@ -1352,14 +1434,14 @@ entry:
   %378 = load i8*, i8** %arg0
   %379 = load i8*, i8** %arg1
   %380 = bitcast i8* %379 to i32*
-  %NullCheck144 = icmp ne i32* %380, null
-  br i1 %NullCheck144, label %381, label %ThrowNullRef143
+  %NullCheck143 = icmp eq i32* %380, null
+  br i1 %NullCheck143, label %ThrowNullRef144, label %381
 
 ; <label>:381                                     ; preds = %377
   %382 = load i32, i32* %380, align 8
   %383 = bitcast i8* %378 to i32*
-  %NullCheck146 = icmp ne i32* %383, null
-  br i1 %NullCheck146, label %384, label %ThrowNullRef145
+  %NullCheck145 = icmp eq i32* %383, null
+  br i1 %NullCheck145, label %ThrowNullRef146, label %384
 
 ; <label>:384                                     ; preds = %381
   store i32 %382, i32* %383, align 8
@@ -1384,14 +1466,14 @@ entry:
   %395 = load i8*, i8** %arg0
   %396 = load i8*, i8** %arg1
   %397 = bitcast i8* %396 to i64*
-  %NullCheck164 = icmp ne i64* %397, null
-  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+  %NullCheck163 = icmp eq i64* %397, null
+  br i1 %NullCheck163, label %ThrowNullRef164, label %398
 
 ; <label>:398                                     ; preds = %394
   %399 = load i64, i64* %397, align 8
   %400 = bitcast i8* %395 to i64*
-  %NullCheck166 = icmp ne i64* %400, null
-  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+  %NullCheck165 = icmp eq i64* %400, null
+  br i1 %NullCheck165, label %ThrowNullRef166, label %401
 
 ; <label>:401                                     ; preds = %398
   store i64 %399, i64* %400, align 8
@@ -1400,14 +1482,14 @@ entry:
   %404 = load i8*, i8** %arg1
   %405 = getelementptr inbounds i8, i8* %404, i64 8
   %406 = bitcast i8* %405 to i64*
-  %NullCheck168 = icmp ne i64* %406, null
-  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+  %NullCheck167 = icmp eq i64* %406, null
+  br i1 %NullCheck167, label %ThrowNullRef168, label %407
 
 ; <label>:407                                     ; preds = %401
   %408 = load i64, i64* %406, align 8
   %409 = bitcast i8* %403 to i64*
-  %NullCheck170 = icmp ne i64* %409, null
-  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+  %NullCheck169 = icmp eq i64* %409, null
+  br i1 %NullCheck169, label %ThrowNullRef170, label %410
 
 ; <label>:410                                     ; preds = %407
   store i64 %408, i64* %409, align 8
@@ -1437,14 +1519,14 @@ entry:
   %425 = load i8*, i8** %arg0
   %426 = load i8*, i8** %arg1
   %427 = bitcast i8* %426 to i64*
-  %NullCheck148 = icmp ne i64* %427, null
-  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+  %NullCheck147 = icmp eq i64* %427, null
+  br i1 %NullCheck147, label %ThrowNullRef148, label %428
 
 ; <label>:428                                     ; preds = %424
   %429 = load i64, i64* %427, align 8
   %430 = bitcast i8* %425 to i64*
-  %NullCheck150 = icmp ne i64* %430, null
-  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+  %NullCheck149 = icmp eq i64* %430, null
+  br i1 %NullCheck149, label %ThrowNullRef150, label %431
 
 ; <label>:431                                     ; preds = %428
   store i64 %429, i64* %430, align 8
@@ -1466,14 +1548,14 @@ entry:
   %441 = load i8*, i8** %arg0
   %442 = load i8*, i8** %arg1
   %443 = bitcast i8* %442 to i32*
-  %NullCheck152 = icmp ne i32* %443, null
-  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+  %NullCheck151 = icmp eq i32* %443, null
+  br i1 %NullCheck151, label %ThrowNullRef152, label %444
 
 ; <label>:444                                     ; preds = %440
   %445 = load i32, i32* %443, align 8
   %446 = bitcast i8* %441 to i32*
-  %NullCheck154 = icmp ne i32* %446, null
-  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+  %NullCheck153 = icmp eq i32* %446, null
+  br i1 %NullCheck153, label %ThrowNullRef154, label %447
 
 ; <label>:447                                     ; preds = %444
   store i32 %445, i32* %446, align 8
@@ -1495,16 +1577,16 @@ entry:
   %457 = load i8*, i8** %arg0
   %458 = load i8*, i8** %arg1
   %459 = bitcast i8* %458 to i16*
-  %NullCheck156 = icmp ne i16* %459, null
-  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+  %NullCheck155 = icmp eq i16* %459, null
+  br i1 %NullCheck155, label %ThrowNullRef156, label %460
 
 ; <label>:460                                     ; preds = %456
   %461 = load i16, i16* %459, align 8
   %462 = sext i16 %461 to i32
   %463 = bitcast i8* %457 to i16*
   %464 = trunc i32 %462 to i16
-  %NullCheck158 = icmp ne i16* %463, null
-  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+  %NullCheck157 = icmp eq i16* %463, null
+  br i1 %NullCheck157, label %ThrowNullRef158, label %465
 
 ; <label>:465                                     ; preds = %460
   store i16 %464, i16* %463, align 8
@@ -1525,15 +1607,15 @@ entry:
 ; <label>:474                                     ; preds = %470
   %475 = load i8*, i8** %arg0
   %476 = load i8*, i8** %arg1
-  %NullCheck160 = icmp ne i8* %476, null
-  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+  %NullCheck159 = icmp eq i8* %476, null
+  br i1 %NullCheck159, label %ThrowNullRef160, label %477
 
 ; <label>:477                                     ; preds = %474
   %478 = load i8, i8* %476, align 8
   %479 = zext i8 %478 to i32
   %480 = trunc i32 %479 to i8
-  %NullCheck162 = icmp ne i8* %475, null
-  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+  %NullCheck161 = icmp eq i8* %475, null
+  br i1 %NullCheck161, label %ThrowNullRef162, label %481
 
 ; <label>:481                                     ; preds = %477
   store i8 %480, i8* %475, align 8
@@ -1553,343 +1635,343 @@ ThrowNullRef:                                     ; preds = %308
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %312
+ThrowNullRef2:                                    ; preds = %312
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %315
+ThrowNullRef4:                                    ; preds = %315
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %321
+ThrowNullRef6:                                    ; preds = %321
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %271
+ThrowNullRef8:                                    ; preds = %271
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %275
+ThrowNullRef10:                                   ; preds = %275
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %278
+ThrowNullRef12:                                   ; preds = %278
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %284
+ThrowNullRef14:                                   ; preds = %284
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %287
+ThrowNullRef16:                                   ; preds = %287
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %293
+ThrowNullRef18:                                   ; preds = %293
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %298
+ThrowNullRef20:                                   ; preds = %298
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %303
+ThrowNullRef22:                                   ; preds = %303
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %243
+ThrowNullRef24:                                   ; preds = %243
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %247
+ThrowNullRef26:                                   ; preds = %247
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %250
+ThrowNullRef28:                                   ; preds = %250
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %256
+ThrowNullRef30:                                   ; preds = %256
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %259
+ThrowNullRef32:                                   ; preds = %259
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %265
+ThrowNullRef34:                                   ; preds = %265
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %217
+ThrowNullRef36:                                   ; preds = %217
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %221
+ThrowNullRef38:                                   ; preds = %221
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %224
+ThrowNullRef40:                                   ; preds = %224
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %230
+ThrowNullRef42:                                   ; preds = %230
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %233
+ThrowNullRef44:                                   ; preds = %233
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %238
+ThrowNullRef46:                                   ; preds = %238
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %200
+ThrowNullRef48:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %204
+ThrowNullRef50:                                   ; preds = %204
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %207
+ThrowNullRef52:                                   ; preds = %207
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %213
+ThrowNullRef54:                                   ; preds = %213
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %172
+ThrowNullRef56:                                   ; preds = %172
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %176
+ThrowNullRef58:                                   ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %179
+ThrowNullRef60:                                   ; preds = %179
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %185
+ThrowNullRef62:                                   ; preds = %185
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %190
+ThrowNullRef64:                                   ; preds = %190
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %195
+ThrowNullRef66:                                   ; preds = %195
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %153
+ThrowNullRef68:                                   ; preds = %153
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %157
+ThrowNullRef70:                                   ; preds = %157
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %160
+ThrowNullRef72:                                   ; preds = %160
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %166
+ThrowNullRef74:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %136
+ThrowNullRef76:                                   ; preds = %136
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %140
+ThrowNullRef78:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %143
+ThrowNullRef80:                                   ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %148
+ThrowNullRef82:                                   ; preds = %148
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %128
+ThrowNullRef84:                                   ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %132
+ThrowNullRef86:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %100
+ThrowNullRef88:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %104
+ThrowNullRef90:                                   ; preds = %104
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %107
+ThrowNullRef92:                                   ; preds = %107
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %113
+ThrowNullRef94:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %118
+ThrowNullRef96:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %123
+ThrowNullRef98:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %81
+ThrowNullRef100:                                  ; preds = %81
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef101:                                  ; preds = %85
+ThrowNullRef102:                                  ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef103:                                  ; preds = %88
+ThrowNullRef104:                                  ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef105:                                  ; preds = %94
+ThrowNullRef106:                                  ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef107:                                  ; preds = %64
+ThrowNullRef108:                                  ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef109:                                  ; preds = %68
+ThrowNullRef110:                                  ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef111:                                  ; preds = %71
+ThrowNullRef112:                                  ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef113:                                  ; preds = %76
+ThrowNullRef114:                                  ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef115:                                  ; preds = %56
+ThrowNullRef116:                                  ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef117:                                  ; preds = %60
+ThrowNullRef118:                                  ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef119:                                  ; preds = %37
+ThrowNullRef120:                                  ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef121:                                  ; preds = %41
+ThrowNullRef122:                                  ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef123:                                  ; preds = %46
+ThrowNullRef124:                                  ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef125:                                  ; preds = %51
+ThrowNullRef126:                                  ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef127:                                  ; preds = %27
+ThrowNullRef128:                                  ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef129:                                  ; preds = %31
+ThrowNullRef130:                                  ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef131:                                  ; preds = %19
+ThrowNullRef132:                                  ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef133:                                  ; preds = %22
+ThrowNullRef134:                                  ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef135:                                  ; preds = %338
+ThrowNullRef136:                                  ; preds = %338
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef137:                                  ; preds = %341
+ThrowNullRef138:                                  ; preds = %341
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef139:                                  ; preds = %356
+ThrowNullRef140:                                  ; preds = %356
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef141:                                  ; preds = %360
+ThrowNullRef142:                                  ; preds = %360
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef143:                                  ; preds = %377
+ThrowNullRef144:                                  ; preds = %377
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef145:                                  ; preds = %381
+ThrowNullRef146:                                  ; preds = %381
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef147:                                  ; preds = %424
+ThrowNullRef148:                                  ; preds = %424
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef149:                                  ; preds = %428
+ThrowNullRef150:                                  ; preds = %428
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef151:                                  ; preds = %440
+ThrowNullRef152:                                  ; preds = %440
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef153:                                  ; preds = %444
+ThrowNullRef154:                                  ; preds = %444
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef155:                                  ; preds = %456
+ThrowNullRef156:                                  ; preds = %456
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef157:                                  ; preds = %460
+ThrowNullRef158:                                  ; preds = %460
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef159:                                  ; preds = %474
+ThrowNullRef160:                                  ; preds = %474
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef161:                                  ; preds = %477
+ThrowNullRef162:                                  ; preds = %477
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef163:                                  ; preds = %394
+ThrowNullRef164:                                  ; preds = %394
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef165:                                  ; preds = %398
+ThrowNullRef166:                                  ; preds = %398
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef167:                                  ; preds = %401
+ThrowNullRef168:                                  ; preds = %401
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef169:                                  ; preds = %407
+ThrowNullRef170:                                  ; preds = %407
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1939,8 +2021,8 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
-  br i1 %NullCheck, label %22, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %ThrowNullRef, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
@@ -1948,8 +2030,8 @@ entry:
   store i32 %24, i32* %loc0
   %25 = load i32, i32* %loc0
   %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %26, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %27
 
 ; <label>:27                                      ; preds = %22
   %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
@@ -1971,7 +2053,7 @@ ThrowNullRef:                                     ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1989,8 +2071,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -2022,15 +2104,15 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2048,16 +2130,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
   %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
   store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %15
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
@@ -2072,8 +2154,8 @@ entry:
   %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
   %29 = ptrtoint i16 addrspace(1)* %28 to i64
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %19
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
@@ -2089,19 +2171,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2114,8 +2196,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
@@ -2128,7 +2210,7 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[loadElem]
+Failed to read AppDomain.PrepareDataForSetup[storeElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
@@ -2202,8 +2284,8 @@ entry:
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
-  br i1 %NullCheck24, label %27, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = load i64, i64 addrspace(1)* %26
@@ -2218,8 +2300,8 @@ entry:
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
-  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
   %41 = load i64, i64 addrspace(1)* %39
@@ -2236,8 +2318,8 @@ entry:
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
-  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
   %54 = load i64, i64 addrspace(1)* %52
@@ -2252,8 +2334,8 @@ entry:
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
   %67 = load i64, i64 addrspace(1)* %65
@@ -2270,8 +2352,8 @@ entry:
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
-  br i1 %NullCheck16, label %79, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
   %80 = load i64, i64 addrspace(1)* %78
@@ -2286,8 +2368,8 @@ entry:
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
-  br i1 %NullCheck18, label %92, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
   %93 = load i64, i64 addrspace(1)* %91
@@ -2304,8 +2386,8 @@ entry:
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
-  br i1 %NullCheck12, label %105, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = load i64, i64 addrspace(1)* %104
@@ -2320,8 +2402,8 @@ entry:
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
-  br i1 %NullCheck14, label %118, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
   %119 = load i64, i64 addrspace(1)* %117
@@ -2337,8 +2419,8 @@ entry:
 
 ; <label>:128                                     ; preds = %20
   %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
-  br i1 %NullCheck4, label %130, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %129, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %130
 
 ; <label>:130                                     ; preds = %128
   %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
@@ -2346,8 +2428,8 @@ entry:
   %133 = load i16, i16 addrspace(1)* %132, align 8
   %134 = zext i16 %133 to i32
   %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
-  br i1 %NullCheck6, label %136, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %135, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %136
 
 ; <label>:136                                     ; preds = %130
   %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
@@ -2360,8 +2442,8 @@ entry:
 
 ; <label>:143                                     ; preds = %136
   %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
-  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %144, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %145
 
 ; <label>:145                                     ; preds = %143
   %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
@@ -2369,8 +2451,8 @@ entry:
   %148 = load i16, i16 addrspace(1)* %147, align 8
   %149 = zext i16 %148 to i32
   %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %150, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %151
 
 ; <label>:151                                     ; preds = %145
   %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
@@ -2388,8 +2470,8 @@ entry:
 
 ; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
-  br i1 %NullCheck, label %163, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %ThrowNullRef, label %163
 
 ; <label>:163                                     ; preds = %161
   %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
@@ -2399,8 +2481,8 @@ entry:
 
 ; <label>:167                                     ; preds = %163
   %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
-  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %168, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %169
 
 ; <label>:169                                     ; preds = %167
   %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
@@ -2432,55 +2514,55 @@ ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %167
+ThrowNullRef2:                                    ; preds = %167
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %128
+ThrowNullRef4:                                    ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %130
+ThrowNullRef6:                                    ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %143
+ThrowNullRef8:                                    ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %145
+ThrowNullRef10:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %102
+ThrowNullRef12:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %105
+ThrowNullRef14:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %76
+ThrowNullRef16:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %79
+ThrowNullRef18:                                   ; preds = %79
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %50
+ThrowNullRef20:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %53
+ThrowNullRef22:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %24
+ThrowNullRef24:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %27
+ThrowNullRef26:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2503,15 +2585,15 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2519,16 +2601,16 @@ entry:
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
   store i32 %8, i32* %loc0
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
   %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
   store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
@@ -2546,16 +2628,16 @@ entry:
 
 ; <label>:23                                      ; preds = %64
   %24 = load i16*, i16** %loc3
-  %NullCheck12 = icmp ne i16* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i16* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
   store i32 %27, i32* %loc5
   %28 = load i16*, i16** %loc4
-  %NullCheck14 = icmp ne i16* %28, null
-  br i1 %NullCheck14, label %29, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %28, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = load i16, i16* %28, align 8
@@ -2620,15 +2702,15 @@ entry:
 
 ; <label>:67                                      ; preds = %64
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
-  br i1 %NullCheck8, label %69, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %68, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %69
 
 ; <label>:69                                      ; preds = %67
   %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
   %71 = load i32, i32 addrspace(1)* %70
   %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
-  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %73
 
 ; <label>:73                                      ; preds = %69
   %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
@@ -2645,31 +2727,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %67
+ThrowNullRef8:                                    ; preds = %67
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %69
+ThrowNullRef10:                                   ; preds = %69
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2710,14 +2792,14 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
   %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
@@ -2730,14 +2812,14 @@ entry:
 
 ; <label>:11                                      ; preds = %4
   %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
   %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
@@ -2749,14 +2831,14 @@ entry:
 
 ; <label>:22                                      ; preds = %16
   %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
   %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
-  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
-  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
@@ -2804,23 +2886,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2836,7 +2918,280 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[loadElem]
+Successfully read RuntimeType.IsAssignableFrom
+
+define i8 @RuntimeType.IsAssignableFrom(%System.RuntimeType addrspace(1)* %param0, %System.Type addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.RuntimeType addrspace(1)*
+  %arg1 = alloca %System.Type addrspace(1)*
+  %loc0 = alloca %System.RuntimeType addrspace(1)*
+  %loc1 = alloca %"System.Type[]" addrspace(1)*
+  %loc2 = alloca i32
+  store %System.RuntimeType addrspace(1)* %param0, %System.RuntimeType addrspace(1)** %this
+  store %System.Type addrspace(1)* %param1, %System.Type addrspace(1)** %arg1
+  %0 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %1 = icmp ne %System.Type addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i8 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %5 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %6 = bitcast %System.Type addrspace(1)* %4 to %System.Object addrspace(1)*
+  %7 = bitcast %System.RuntimeType addrspace(1)* %5 to %System.Object addrspace(1)*
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %6, %System.Object addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %3
+  ret i8 1
+
+; <label>:12                                      ; preds = %3
+  %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 152
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 32
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
+  %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
+  %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
+  store %System.RuntimeType addrspace(1)* %25, %System.RuntimeType addrspace(1)** %loc0
+  %26 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %27 = icmp eq %System.RuntimeType addrspace(1)* %26, null
+  br i1 %27, label %34, label %28
+
+; <label>:28                                      ; preds = %15
+  %29 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %30 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)*)*)(%System.RuntimeType addrspace(1)* %29, %System.RuntimeType addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+; <label>:34                                      ; preds = %15
+  %35 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %36 = call %System.Reflection.Emit.TypeBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Reflection.Emit.TypeBuilder addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %35)
+  %37 = icmp eq %System.Reflection.Emit.TypeBuilder addrspace(1)* %36, null
+  br i1 %37, label %139, label %38
+
+; <label>:38                                      ; preds = %34
+  %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %42
+
+; <label>:42                                      ; preds = %38
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 152
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 40
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
+  %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
+  %53 = zext i8 %52 to i32
+  %54 = icmp eq i32 %53, 0
+  br i1 %54, label %56, label %55
+
+; <label>:55                                      ; preds = %42
+  ret i8 1
+
+; <label>:56                                      ; preds = %42
+  %57 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %58 = bitcast %System.RuntimeType addrspace(1)* %57 to %System.Type addrspace(1)*
+  %59 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %58)
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %64 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.Type addrspace(1)* %63, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = bitcast %System.RuntimeType addrspace(1)* %64 to %System.Type addrspace(1)*
+  %67 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %63, %System.Type addrspace(1)* %66)
+  %68 = zext i8 %67 to i32
+  %69 = trunc i32 %68 to i8
+  ret i8 %69
+
+; <label>:70                                      ; preds = %56
+  %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
+  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %73
+
+; <label>:73                                      ; preds = %70
+  %74 = load i64, i64 addrspace(1)* %72
+  %75 = add i64 %74, 128
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = add i64 %77, 0
+  %79 = inttoptr i64 %78 to i64*
+  %80 = load i64, i64* %79
+  %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
+  %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
+  %83 = call i8 %82(%System.Type addrspace(1)* %81)
+  %84 = zext i8 %83 to i32
+  %85 = icmp eq i32 %84, 0
+  br i1 %85, label %139, label %86
+
+; <label>:86                                      ; preds = %73
+  %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
+  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %89
+
+; <label>:89                                      ; preds = %86
+  %90 = load i64, i64 addrspace(1)* %88
+  %91 = add i64 %90, 128
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = add i64 %93, 24
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
+  %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
+  %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
+  store %"System.Type[]" addrspace(1)* %99, %"System.Type[]" addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %129
+
+; <label>:100                                     ; preds = %132
+  %101 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %102 = load i32, i32* %loc2
+  %NullCheck11 = icmp eq %"System.Type[]" addrspace(1)* %101, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %103
+
+; <label>:103                                     ; preds = %100
+  %104 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 1
+  %105 = load i32, i32 addrspace(1)* %104
+  %106 = zext i32 %105 to i64
+  %107 = zext i32 %102 to i64
+  %BoundsCheck = icmp uge i64 %107, %106
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %108
+
+; <label>:108                                     ; preds = %103
+  %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
+  %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
+  %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
+  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %113
+
+; <label>:113                                     ; preds = %108
+  %114 = load i64, i64 addrspace(1)* %112
+  %115 = add i64 %114, 152
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = add i64 %117, 56
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
+  %123 = zext i8 %122 to i32
+  %124 = icmp ne i32 %123, 0
+  br i1 %124, label %126, label %125
+
+; <label>:125                                     ; preds = %113
+  ret i8 0
+
+; <label>:126                                     ; preds = %113
+  %127 = load i32, i32* %loc2
+  %128 = add i32 %127, 1
+  store i32 %128, i32* %loc2
+  br label %129
+
+; <label>:129                                     ; preds = %89, %126
+  %130 = load i32, i32* %loc2
+  %131 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %NullCheck9 = icmp eq %"System.Type[]" addrspace(1)* %131, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %132
+
+; <label>:132                                     ; preds = %129
+  %133 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %131, i32 0, i32 1
+  %134 = load i32, i32 addrspace(1)* %133
+  %135 = zext i32 %134 to i64
+  %136 = trunc i64 %135 to i32
+  %137 = icmp slt i32 %130, %136
+  br i1 %137, label %100, label %138
+
+; <label>:138                                     ; preds = %132
+  ret i8 1
+
+; <label>:139                                     ; preds = %34, %73
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %129
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %103
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -2893,7 +3248,7 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElem]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -2904,8 +3259,8 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -2997,8 +3352,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
@@ -3059,8 +3414,8 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -3087,8 +3442,8 @@ entry:
 
 ; <label>:17                                      ; preds = %5, %11
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
@@ -3097,8 +3452,8 @@ entry:
 
 ; <label>:22                                      ; preds = %1, %11
   %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
@@ -3109,11 +3464,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %17
+ThrowNullRef2:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %22
+ThrowNullRef4:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3167,15 +3522,15 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
   %15 = load i32, i32 addrspace(1)* %14
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
@@ -3198,7 +3553,7 @@ ThrowNullRef:                                     ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef2:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3232,8 +3587,8 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
@@ -3312,8 +3667,8 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -3327,8 +3682,8 @@ entry:
 ; <label>:5                                       ; preds = %43
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %7 = load i32, i32* %loc1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck6, label %8, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
@@ -3366,8 +3721,8 @@ entry:
 ; <label>:32                                      ; preds = %21, %25
   %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
   %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
-  br i1 %NullCheck8, label %35, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = trunc i32 %34 to i16
@@ -3380,8 +3735,8 @@ entry:
 ; <label>:40                                      ; preds = %1, %35
   %41 = load i32, i32* %loc1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
-  br i1 %NullCheck2, label %43, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %42, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
@@ -3392,8 +3747,8 @@ entry:
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
   %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
-  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
   %51 = load i64, i64 addrspace(1)* %49
@@ -3412,19 +3767,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %40
+ThrowNullRef2:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %47
+ThrowNullRef4:                                    ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %5
+ThrowNullRef6:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %32
+ThrowNullRef8:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3467,8 +3822,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
@@ -3492,11 +3847,391 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(i16* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store i16* %param0, i16** %arg0
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load i32, i32* %arg3
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %42, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %37, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg2
+  %13 = load i32, i32* %arg3
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %37, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %24 = load i32, i32* %arg2
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load i16*, i16** %arg0
+  %35 = load i32, i32* %arg3
+  %36 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %36, i16* %34, i32 %35)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:37                                      ; preds = %5, %16
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %39)
+  %41 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41, %System.String addrspace(1)* %38, %System.String addrspace(1)* %40)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41) #0
+  unreachable
+
+; <label>:42                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
-Failed to read StringBuilder.ToString[loadElemA]
+Successfully read StringBuilder.ToString
+
+define %System.String addrspace(1)* @StringBuilder.ToString(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i16*
+  %loc3 = alloca %"System.Char[]" addrspace(1)*
+  %loc4 = alloca i32
+  %loc5 = alloca i32
+  %loc6 = alloca i16 addrspace(1)*
+  %loc7 = alloca %System.String addrspace(1)*
+  %loc8 = alloca %"System.Char[]" addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %0)
+  %2 = icmp ne i32 %1, 0
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %4
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %6)
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %7)
+  store %System.String addrspace(1)* %8, %System.String addrspace(1)** %loc0
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.Text.StringBuilder addrspace(1)* %9, %System.Text.StringBuilder addrspace(1)** %loc1
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  store %System.String addrspace(1)* %10, %System.String addrspace(1)** %loc7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc7
+  %12 = ptrtoint %System.String addrspace(1)* %11 to i64
+  %13 = icmp eq i64 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %5
+  %15 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %16 = sext i32 %15 to i64
+  %17 = add i64 %12, %16
+  br label %18
+
+; <label>:18                                      ; preds = %5, %14
+  %19 = phi i64 [ %12, %5 ], [ %17, %14 ]
+  %20 = inttoptr i64 %19 to i16*
+  store i16* %20, i16** %loc2
+  br label %21
+
+; <label>:21                                      ; preds = %98, %18
+  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %22, null
+  br i1 %NullCheck, label %ThrowNullRef, label %23
+
+; <label>:23                                      ; preds = %21
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 3
+  %25 = load i32, i32 addrspace(1)* %24, align 8
+  %26 = icmp sle i32 %25, 0
+  br i1 %26, label %96, label %27
+
+; <label>:27                                      ; preds = %23
+  %28 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %28, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %29
+
+; <label>:29                                      ; preds = %27
+  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %28, i32 0, i32 1
+  %31 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %30, align 8
+  store %"System.Char[]" addrspace(1)* %31, %"System.Char[]" addrspace(1)** %loc3
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %33
+
+; <label>:33                                      ; preds = %29
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  store i32 %35, i32* %loc4
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  %39 = load i32, i32 addrspace(1)* %38, align 8
+  store i32 %39, i32* %loc5
+  %40 = load i32, i32* %loc5
+  %41 = load i32, i32* %loc4
+  %42 = add i32 %40, %41
+  %43 = zext i32 %42 to i64
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %45
+
+; <label>:45                                      ; preds = %37
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = sext i32 %47 to i64
+  %49 = icmp sgt i64 %43, %48
+  br i1 %49, label %91, label %50
+
+; <label>:50                                      ; preds = %45
+  %51 = load i32, i32* %loc5
+  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %52, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %53
+
+; <label>:53                                      ; preds = %50
+  %54 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %52, i32 0, i32 1
+  %55 = load i32, i32 addrspace(1)* %54
+  %56 = zext i32 %55 to i64
+  %57 = trunc i64 %56 to i32
+  %58 = icmp ugt i32 %51, %57
+  br i1 %58, label %91, label %59
+
+; <label>:59                                      ; preds = %53
+  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  store %"System.Char[]" addrspace(1)* %60, %"System.Char[]" addrspace(1)** %loc8
+  %61 = icmp eq %"System.Char[]" addrspace(1)* %60, null
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %63, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %64
+
+; <label>:64                                      ; preds = %62
+  %65 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %63, i32 0, i32 1
+  %66 = load i32, i32 addrspace(1)* %65
+  %67 = zext i32 %66 to i64
+  %68 = trunc i64 %67 to i32
+  %69 = icmp ne i32 %68, 0
+  br i1 %69, label %71, label %70
+
+; <label>:70                                      ; preds = %59, %64
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:71                                      ; preds = %64
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %73
+
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %BoundsCheck = icmp uge i64 0, %76
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %77
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %78, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:79                                      ; preds = %70, %77
+  %80 = load i16*, i16** %loc2
+  %81 = load i32, i32* %loc4
+  %82 = sext i32 %81 to i64
+  %83 = mul i64 %82, 2
+  %84 = bitcast i16* %80 to i8*
+  %85 = getelementptr inbounds i8, i8* %84, i64 %83
+  %86 = load i16 addrspace(1)*, i16 addrspace(1)** %loc6
+  %87 = ptrtoint i16 addrspace(1)* %86 to i64
+  %88 = load i32, i32* %loc5
+  %89 = bitcast i8* %85 to i16*
+  %90 = inttoptr i64 %87 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %89, i16* %90, i32 %88)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %96
+
+; <label>:91                                      ; preds = %45, %53
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %94 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %93)
+  %95 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95, %System.String addrspace(1)* %92, %System.String addrspace(1)* %94)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95) #0
+  unreachable
+
+; <label>:96                                      ; preds = %23, %79
+  %97 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %97, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %98
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %97, i32 0, i32 2
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  store %System.Text.StringBuilder addrspace(1)* %100, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %102 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %102, label %21, label %103
+
+; <label>:103                                     ; preds = %98
+  store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc7
+  %104 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  ret %System.String addrspace(1)* %104
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method StringBuilder::get_Length using LLILCJit
+Successfully read StringBuilder.get_Length
+
+define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
+Successfully read RuntimeHelpers.get_OffsetToStringData
+
+define i32 @RuntimeHelpers.get_OffsetToStringData() {
+entry:
+  ret i32 12
+}
+
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
 Successfully read CultureData.CreateCultureData
 
@@ -3514,23 +4249,23 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
   store i8 %4, i8 addrspace(1)* %6
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
@@ -3549,11 +4284,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3566,50 +4301,50 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
   store i32 -1, i32 addrspace(1)* %2
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
   store i32 -1, i32 addrspace(1)* %8
   %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
   store i32 -1, i32 addrspace(1)* %14
   %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
   store i32 -1, i32 addrspace(1)* %17
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
@@ -3623,27 +4358,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3675,7 +4410,136 @@ Failed to read Dictionary`2.Insert[non-const derefAddress]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
 Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
-Failed to read HashHelpers.GetPrime[loadElem]
+Successfully read HashHelpers.GetPrime
+
+define i32 @HashHelpers.GetPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %6, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5, %System.String addrspace(1)* %4)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5) #0
+  unreachable
+
+; <label>:6                                       ; preds = %entry
+  store i32 0, i32* %loc0
+  br label %29
+
+; <label>:7                                       ; preds = %35
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 1296
+  %10 = addrspacecast i8 addrspace(1)* %9 to %"System.Int32[]" addrspace(1)**
+  %11 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %10
+  %12 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Int32[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = zext i32 %15 to i64
+  %17 = zext i32 %12 to i64
+  %BoundsCheck = icmp uge i64 %17, %16
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 3, i32 %12
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  store i32 %20, i32* %loc1
+  %21 = load i32, i32* %loc1
+  %22 = load i32, i32* %arg0
+  %23 = icmp slt i32 %21, %22
+  br i1 %23, label %26, label %24
+
+; <label>:24                                      ; preds = %18
+  %25 = load i32, i32* %loc1
+  ret i32 %25
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %loc0
+  %28 = add i32 %27, 1
+  store i32 %28, i32* %loc0
+  br label %29
+
+; <label>:29                                      ; preds = %6, %26
+  %30 = load i32, i32* %loc0
+  %31 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %32 = getelementptr inbounds i8, i8 addrspace(1)* %31, i64 1296
+  %33 = addrspacecast i8 addrspace(1)* %32 to %"System.Int32[]" addrspace(1)**
+  %34 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %33
+  %NullCheck = icmp eq %"System.Int32[]" addrspace(1)* %34, null
+  br i1 %NullCheck, label %ThrowNullRef, label %35
+
+; <label>:35                                      ; preds = %29
+  %36 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %34, i32 0, i32 1
+  %37 = load i32, i32 addrspace(1)* %36
+  %38 = zext i32 %37 to i64
+  %39 = trunc i64 %38 to i32
+  %40 = icmp slt i32 %30, %39
+  br i1 %40, label %7, label %41
+
+; <label>:41                                      ; preds = %35
+  %42 = load i32, i32* %arg0
+  %43 = or i32 %42, 1
+  store i32 %43, i32* %loc2
+  br label %59
+
+; <label>:44                                      ; preds = %59
+  %45 = load i32, i32* %loc2
+  %46 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %45)
+  %47 = zext i8 %46 to i32
+  %48 = icmp eq i32 %47, 0
+  br i1 %48, label %56, label %49
+
+; <label>:49                                      ; preds = %44
+  %50 = load i32, i32* %loc2
+  %51 = sub i32 %50, 1
+  %52 = srem i32 %51, 101
+  %53 = icmp eq i32 %52, 0
+  br i1 %53, label %56, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = load i32, i32* %loc2
+  ret i32 %55
+
+; <label>:56                                      ; preds = %44, %49
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %57, 2
+  store i32 %58, i32* %loc2
+  br label %59
+
+; <label>:59                                      ; preds = %41, %56
+  %60 = load i32, i32* %loc2
+  %61 = icmp slt i32 %60, 2147483647
+  br i1 %61, label %44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load i32, i32* %arg0
+  ret i32 %63
+
+ThrowNullRef:                                     ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
 Successfully read GenericEqualityComparer`1.GetHashCode
 
@@ -3694,14 +4558,14 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
   %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load i64, i64 addrspace(1)* %7
@@ -3720,7 +4584,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3750,8 +4614,8 @@ entry:
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
@@ -3796,8 +4660,8 @@ entry:
   %35 = bitcast i16* %34 to i8*
   %36 = getelementptr inbounds i8, i8* %35, i64 2
   %37 = bitcast i8* %36 to i16*
-  %NullCheck4 = icmp ne i16* %37, null
-  br i1 %NullCheck4, label %38, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %37, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %38
 
 ; <label>:38                                      ; preds = %27
   %39 = load i16, i16* %37, align 8
@@ -3824,8 +4688,8 @@ entry:
 
 ; <label>:54                                      ; preds = %22, %43
   %55 = load i16*, i16** %loc4
-  %NullCheck2 = icmp ne i16* %55, null
-  br i1 %NullCheck2, label %56, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i16* %55, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %56
 
 ; <label>:56                                      ; preds = %54
   %57 = load i16, i16* %55, align 8
@@ -3850,11 +4714,11 @@ ThrowNullRef:                                     ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %54
+ThrowNullRef2:                                    ; preds = %54
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %27
+ThrowNullRef4:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3871,8 +4735,8 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -3907,8 +4771,8 @@ entry:
 
 ; <label>:26                                      ; preds = %19
   %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
-  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %28
 
 ; <label>:28                                      ; preds = %26
   %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
@@ -3920,7 +4784,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3972,8 +4836,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
@@ -3984,26 +4848,26 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
-  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
@@ -4014,8 +4878,8 @@ entry:
 ; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
@@ -4024,8 +4888,8 @@ entry:
 
 ; <label>:25                                      ; preds = %1, %16, %23
   %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
-  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
@@ -4036,27 +4900,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %20
+ThrowNullRef10:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4069,8 +4933,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -4081,8 +4945,8 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
@@ -4091,8 +4955,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1, %8
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
@@ -4103,11 +4967,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4128,24 +4992,24 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   store i32 %3, i32* %loc0
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
   %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
   store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck4, label %9, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
@@ -4164,15 +5028,15 @@ entry:
 ; <label>:18                                      ; preds = %70
   %19 = load i16*, i16** %loc3
   %20 = bitcast i16* %19 to i64*
-  %NullCheck10 = icmp ne i64* %20, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %20, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = load i64, i64* %20, align 8
   %23 = load i16*, i16** %loc4
   %24 = bitcast i16* %23 to i64*
-  %NullCheck12 = icmp ne i64* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = load i64, i64* %24, align 8
@@ -4188,8 +5052,8 @@ entry:
   %31 = bitcast i16* %30 to i8*
   %32 = getelementptr inbounds i8, i8* %31, i64 8
   %33 = bitcast i8* %32 to i64*
-  %NullCheck14 = icmp ne i64* %33, null
-  br i1 %NullCheck14, label %34, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = load i64, i64* %33, align 8
@@ -4197,8 +5061,8 @@ entry:
   %37 = bitcast i16* %36 to i8*
   %38 = getelementptr inbounds i8, i8* %37, i64 8
   %39 = bitcast i8* %38 to i64*
-  %NullCheck16 = icmp ne i64* %39, null
-  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %40
 
 ; <label>:40                                      ; preds = %34
   %41 = load i64, i64* %39, align 8
@@ -4214,8 +5078,8 @@ entry:
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %NullCheck18 = icmp ne i64* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = load i64, i64* %48, align 8
@@ -4223,8 +5087,8 @@ entry:
   %52 = bitcast i16* %51 to i8*
   %53 = getelementptr inbounds i8, i8* %52, i64 16
   %54 = bitcast i8* %53 to i64*
-  %NullCheck20 = icmp ne i64* %54, null
-  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64* %54, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %55
 
 ; <label>:55                                      ; preds = %49
   %56 = load i64, i64* %54, align 8
@@ -4262,15 +5126,15 @@ entry:
 ; <label>:74                                      ; preds = %95
   %75 = load i16*, i16** %loc3
   %76 = bitcast i16* %75 to i32*
-  %NullCheck6 = icmp ne i32* %76, null
-  br i1 %NullCheck6, label %77, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32* %76, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %77
 
 ; <label>:77                                      ; preds = %74
   %78 = load i32, i32* %76, align 8
   %79 = load i16*, i16** %loc4
   %80 = bitcast i16* %79 to i32*
-  %NullCheck8 = icmp ne i32* %80, null
-  br i1 %NullCheck8, label %81, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i32* %80, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %81
 
 ; <label>:81                                      ; preds = %77
   %82 = load i32, i32* %80, align 8
@@ -4318,43 +5182,43 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %74
+ThrowNullRef6:                                    ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %77
+ThrowNullRef8:                                    ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %29
+ThrowNullRef14:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %34
+ThrowNullRef16:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4376,8 +5240,8 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load i64, i64 addrspace(1)* %4
@@ -4389,8 +5253,8 @@ entry:
   %12 = load i64, i64* %11
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %5
   %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
@@ -4399,8 +5263,8 @@ entry:
   %18 = load i8, i8* %arg2
   %19 = zext i8 %18 to i32
   %20 = trunc i32 %19 to i8
-  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %15
   %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
@@ -4411,11 +5275,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4442,8 +5306,8 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
@@ -4466,16 +5330,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
   %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = load i64, i64 addrspace(1)* %19
@@ -4500,8 +5364,8 @@ entry:
 ; <label>:35                                      ; preds = %30
   %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
@@ -4514,8 +5378,8 @@ entry:
 
 ; <label>:42                                      ; preds = %1, %38
   %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
-  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
@@ -4526,19 +5390,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %35
+ThrowNullRef2:                                    ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %42
+ThrowNullRef8:                                    ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4551,14 +5415,14 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
@@ -4570,7 +5434,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4583,8 +5447,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
@@ -4613,51 +5477,51 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
   %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
   %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
   %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
   %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
-  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
   store i64 %21, i64 addrspace(1)* %23
   %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %25 = load i64, i64* %loc0
-  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
@@ -4668,27 +5532,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %22
+ThrowNullRef12:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4701,8 +5565,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
@@ -4713,19 +5577,19 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
@@ -4734,8 +5598,8 @@ entry:
 
 ; <label>:15                                      ; preds = %1, %13
   %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
@@ -4746,19 +5610,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %15
+ThrowNullRef8:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4771,8 +5635,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -4831,8 +5695,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
@@ -4882,8 +5746,8 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
-  br i1 %NullCheck, label %17, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %ThrowNullRef, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
@@ -4894,15 +5758,15 @@ entry:
 
 ; <label>:22                                      ; preds = %17
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
-  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
   %26 = load i32, i32 addrspace(1)* %25
   %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
-  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %27, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
@@ -4925,8 +5789,8 @@ entry:
 ; <label>:40                                      ; preds = %17
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
-  br i1 %NullCheck6, label %43, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %41, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
@@ -4938,34 +5802,17 @@ ThrowNullRef:                                     ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %24
+ThrowNullRef4:                                    ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %40
+ThrowNullRef6:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
-}
-
-INFO:  jitting method Object::ReferenceEquals using LLILCJit
-Successfully read Object.ReferenceEquals
-
-define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
-entry:
-  %arg0 = alloca %System.Object addrspace(1)*
-  %arg1 = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
-  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
-  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = icmp eq %System.Object addrspace(1)* %0, %1
-  %3 = sext i1 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
 }
 
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
@@ -4978,21 +5825,21 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
   %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
-  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
@@ -5007,28 +5854,28 @@ entry:
 ; <label>:13                                      ; preds = %8, %12
   %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
   %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
   %21 = load i32, i32 addrspace(1)* %20, align 8
   %22 = add i32 %21, 1
-  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
   store i32 %22, i32 addrspace(1)* %24
   %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
@@ -5039,27 +5886,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5077,7 +5924,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::Setup using LLILCJit
-Failed to read AppDomain.Setup[loadElem]
+Failed to read AppDomain.Setup[unbox]
 INFO:  jitting method Thread::GetDomain using LLILCJit
 Successfully read Thread.GetDomain
 
@@ -5108,8 +5955,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
@@ -5122,14 +5969,14 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
   %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
@@ -5141,11 +5988,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5173,8 +6020,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -5189,7 +6036,328 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
 Failed to read KeyCollection.System.Collections.Generic.IEnumerable<TKey>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Successfully read Enumerator.MoveNext
+
+define i8 @Enumerator.MoveNext(%"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.RuntimeTypeHandle* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*
+  %"$TypeArg" = alloca %System.RuntimeTypeHandle*
+  store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
+  %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 8
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %76, label %12
+
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
+  br label %76
+
+; <label>:13                                      ; preds = %85
+  %14 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck19 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %15
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, i32 0, i32 0
+  %17 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %16, align 8
+  %NullCheck21 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, i32 0, i32 2
+  %20 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %19, align 8
+  %21 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck23 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %22
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, i32 0, i32 2
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %NullCheck25 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 3, i32 %24
+  %NullCheck27 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %32
+
+; <label>:32                                      ; preds = %30
+  %33 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, i32 0, i32 2
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = icmp slt i32 %34, 0
+  br i1 %35, label %68, label %36
+
+; <label>:36                                      ; preds = %32
+  %37 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %38 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck29 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %39
+
+; <label>:39                                      ; preds = %36
+  %40 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, i32 0, i32 0
+  %41 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %40, align 8
+  %NullCheck31 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, i32 0, i32 2
+  %44 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %43, align 8
+  %45 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck33 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, i32 0, i32 2
+  %48 = load i32, i32 addrspace(1)* %47, align 8
+  %NullCheck35 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %49
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = zext i32 %51 to i64
+  %53 = zext i32 %48 to i64
+  %BoundsCheck37 = icmp uge i64 %53, %52
+  br i1 %BoundsCheck37, label %ThrowIndexOutOfRange38, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 3, i32 %48
+  %NullCheck39 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %56
+
+; <label>:56                                      ; preds = %54
+  %57 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, i32 0, i32 0
+  %58 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck41 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %59
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %60, %System.__Canon addrspace(1)* %58)
+  %61 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck43 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  %64 = load i32, i32 addrspace(1)* %63, align 8
+  %65 = add i32 %64, 1
+  %NullCheck45 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  store i32 %65, i32 addrspace(1)* %67
+  ret i8 1
+
+; <label>:68                                      ; preds = %32
+  %69 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck47 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %73 = add i32 %72, 1
+  %NullCheck49 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %74
+
+; <label>:74                                      ; preds = %70
+  %75 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  store i32 %73, i32 addrspace(1)* %75
+  br label %76
+
+; <label>:76                                      ; preds = %8, %12, %74
+  %77 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %78
+
+; <label>:78                                      ; preds = %76
+  %79 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, i32 0, i32 2
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck7 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %82
+
+; <label>:82                                      ; preds = %78
+  %83 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, i32 0, i32 0
+  %84 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %83, align 8
+  %NullCheck9 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %85
+
+; <label>:85                                      ; preds = %82
+  %86 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, i32 0, i32 7
+  %87 = load i32, i32 addrspace(1)* %86, align 8
+  %88 = icmp ult i32 %80, %87
+  br i1 %88, label %13, label %89
+
+; <label>:89                                      ; preds = %85
+  %90 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %91 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck11 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %92
+
+; <label>:92                                      ; preds = %89
+  %93 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, i32 0, i32 0
+  %94 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck13 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %95
+
+; <label>:95                                      ; preds = %92
+  %96 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, i32 0, i32 7
+  %97 = load i32, i32 addrspace(1)* %96, align 8
+  %98 = add i32 %97, 1
+  %NullCheck15 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %99
+
+; <label>:99                                      ; preds = %95
+  %100 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, i32 0, i32 2
+  store i32 %98, i32 addrspace(1)* %100
+  %101 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck17 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %102
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %103, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %92
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef22:                                   ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef24:                                   ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef26:                                   ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef28:                                   ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef30:                                   ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef32:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef34:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef36:                                   ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange38:                           ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef40:                                   ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef42:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef44:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef46:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef48:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef50:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -5200,8 +6368,8 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -5232,9 +6400,9 @@ Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
 Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
-Failed to read String.MakeSeparatorList[loadElemA]
+Failed to read String.MakeSeparatorList[storeElem]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
-Failed to read String.InternalSplitKeepEmptyEntries[loadElem]
+Failed to read String.InternalSplitKeepEmptyEntries[storeElem]
 INFO:  jitting method Path::IsRelative using LLILCJit
 Successfully read Path.IsRelative
 
@@ -5243,8 +6411,8 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -5254,8 +6422,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
@@ -5271,8 +6439,8 @@ entry:
 
 ; <label>:17                                      ; preds = %7
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
@@ -5288,8 +6456,8 @@ entry:
 
 ; <label>:29                                      ; preds = %19
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %31
 
 ; <label>:31                                      ; preds = %29
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
@@ -5300,8 +6468,8 @@ entry:
 
 ; <label>:36                                      ; preds = %31
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
-  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %37, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
@@ -5312,8 +6480,8 @@ entry:
 
 ; <label>:43                                      ; preds = %31, %38
   %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
-  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %45
 
 ; <label>:45                                      ; preds = %43
   %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
@@ -5324,8 +6492,8 @@ entry:
 
 ; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %50
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
@@ -5336,8 +6504,8 @@ entry:
 
 ; <label>:57                                      ; preds = %1, %7, %19, %45, %52
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
-  br i1 %NullCheck14, label %59, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %59
 
 ; <label>:59                                      ; preds = %57
   %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
@@ -5347,8 +6515,8 @@ entry:
 
 ; <label>:63                                      ; preds = %59
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
@@ -5359,8 +6527,8 @@ entry:
 
 ; <label>:70                                      ; preds = %65
   %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
-  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.String addrspace(1)* %71, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %72
 
 ; <label>:72                                      ; preds = %70
   %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
@@ -5379,39 +6547,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %17
+ThrowNullRef4:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %29
+ThrowNullRef6:                                    ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %36
+ThrowNullRef8:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %43
+ThrowNullRef10:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %50
+ThrowNullRef12:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %57
+ThrowNullRef14:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %63
+ThrowNullRef16:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %70
+ThrowNullRef18:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5419,7 +6587,293 @@ ThrowNullRef17:                                   ; preds = %70
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
-Failed to read String.TrimHelper[loadElem]
+Successfully read String.TrimHelper
+
+define %System.String addrspace(1)* @String.TrimHelper(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i16
+  %loc4 = alloca i32
+  %loc5 = alloca i16
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = sub i32 %3, 1
+  store i32 %4, i32* %loc0
+  store i32 0, i32* %loc1
+  %5 = load i32, i32* %arg2
+  %6 = icmp eq i32 %5, 1
+  br i1 %6, label %62, label %7
+
+; <label>:7                                       ; preds = %1
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:8                                       ; preds = %58
+  store i32 0, i32* %loc2
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load i32, i32* %loc1
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2, i32 %10
+  %13 = load i16, i16 addrspace(1)* %12
+  %14 = zext i16 %13 to i32
+  %15 = trunc i32 %14 to i16
+  store i16 %15, i16* %loc3
+  store i32 0, i32* %loc2
+  br label %34
+
+; <label>:16                                      ; preds = %37
+  %17 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %18 = load i32, i32* %loc2
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %17, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %19
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = zext i32 %18 to i64
+  %BoundsCheck = icmp uge i64 %23, %22
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %24
+
+; <label>:24                                      ; preds = %19
+  %25 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 3, i32 %18
+  %26 = load i16, i16 addrspace(1)* %25, align 8
+  %27 = zext i16 %26 to i32
+  %28 = load i16, i16* %loc3
+  %29 = zext i16 %28 to i32
+  %30 = icmp eq i32 %27, %29
+  br i1 %30, label %43, label %31
+
+; <label>:31                                      ; preds = %24
+  %32 = load i32, i32* %loc2
+  %33 = add i32 %32, 1
+  store i32 %33, i32* %loc2
+  br label %34
+
+; <label>:34                                      ; preds = %11, %31
+  %35 = load i32, i32* %loc2
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = icmp slt i32 %35, %41
+  br i1 %42, label %16, label %43
+
+; <label>:43                                      ; preds = %24, %37
+  %44 = load i32, i32* %loc2
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %45, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp eq i32 %44, %50
+  br i1 %51, label %62, label %52
+
+; <label>:52                                      ; preds = %46
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %7, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %57, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %58
+
+; <label>:58                                      ; preds = %55
+  %59 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %60 = load i32, i32 addrspace(1)* %59
+  %61 = icmp slt i32 %56, %60
+  br i1 %61, label %8, label %62
+
+; <label>:62                                      ; preds = %1, %46, %58
+  %63 = load i32, i32* %arg2
+  %64 = icmp eq i32 %63, 0
+  br i1 %64, label %122, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %66, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %67
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %66, i32 0, i32 1
+  %69 = load i32, i32 addrspace(1)* %68
+  %70 = sub i32 %69, 1
+  store i32 %70, i32* %loc0
+  br label %118
+
+; <label>:71                                      ; preds = %118
+  store i32 0, i32* %loc4
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %73 = load i32, i32* %loc0
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %74
+
+; <label>:74                                      ; preds = %71
+  %75 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 2, i32 %73
+  %76 = load i16, i16 addrspace(1)* %75
+  %77 = zext i16 %76 to i32
+  %78 = trunc i32 %77 to i16
+  store i16 %78, i16* %loc5
+  store i32 0, i32* %loc4
+  br label %97
+
+; <label>:79                                      ; preds = %100
+  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %81 = load i32, i32* %loc4
+  %NullCheck19 = icmp eq %"System.Char[]" addrspace(1)* %80, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
+
+; <label>:82                                      ; preds = %79
+  %83 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 1
+  %84 = load i32, i32 addrspace(1)* %83
+  %85 = zext i32 %84 to i64
+  %86 = zext i32 %81 to i64
+  %BoundsCheck21 = icmp uge i64 %86, %85
+  br i1 %BoundsCheck21, label %ThrowIndexOutOfRange22, label %87
+
+; <label>:87                                      ; preds = %82
+  %88 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 3, i32 %81
+  %89 = load i16, i16 addrspace(1)* %88, align 8
+  %90 = zext i16 %89 to i32
+  %91 = load i16, i16* %loc5
+  %92 = zext i16 %91 to i32
+  %93 = icmp eq i32 %90, %92
+  br i1 %93, label %106, label %94
+
+; <label>:94                                      ; preds = %87
+  %95 = load i32, i32* %loc4
+  %96 = add i32 %95, 1
+  store i32 %96, i32* %loc4
+  br label %97
+
+; <label>:97                                      ; preds = %74, %94
+  %98 = load i32, i32* %loc4
+  %99 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck15 = icmp eq %"System.Char[]" addrspace(1)* %99, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %100
+
+; <label>:100                                     ; preds = %97
+  %101 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %99, i32 0, i32 1
+  %102 = load i32, i32 addrspace(1)* %101
+  %103 = zext i32 %102 to i64
+  %104 = trunc i64 %103 to i32
+  %105 = icmp slt i32 %98, %104
+  br i1 %105, label %79, label %106
+
+; <label>:106                                     ; preds = %87, %100
+  %107 = load i32, i32* %loc4
+  %108 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck17 = icmp eq %"System.Char[]" addrspace(1)* %108, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %109
+
+; <label>:109                                     ; preds = %106
+  %110 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %108, i32 0, i32 1
+  %111 = load i32, i32 addrspace(1)* %110
+  %112 = zext i32 %111 to i64
+  %113 = trunc i64 %112 to i32
+  %114 = icmp eq i32 %107, %113
+  br i1 %114, label %122, label %115
+
+; <label>:115                                     ; preds = %109
+  %116 = load i32, i32* %loc0
+  %117 = sub i32 %116, 1
+  store i32 %117, i32* %loc0
+  br label %118
+
+; <label>:118                                     ; preds = %67, %115
+  %119 = load i32, i32* %loc0
+  %120 = load i32, i32* %loc1
+  %121 = icmp sge i32 %119, %120
+  br i1 %121, label %71, label %122
+
+; <label>:122                                     ; preds = %62, %109, %118
+  %123 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %124 = load i32, i32* %loc1
+  %125 = load i32, i32* %loc0
+  %126 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %123, i32 %124, i32 %125)
+  ret %System.String addrspace(1)* %126
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %97
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange22:                           ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
 Successfully read String.CreateTrimmedString
 
@@ -5439,8 +6893,8 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
@@ -5535,8 +6989,8 @@ entry:
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i64 2872
   %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
   %8 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %7
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %3
   %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
@@ -5553,8 +7007,8 @@ entry:
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 2864
   %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
   %21 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %20
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
-  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %22
 
 ; <label>:22                                      ; preds = %16
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
@@ -5569,7 +7023,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %16
+ThrowNullRef2:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5586,8 +7040,8 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5613,8 +7067,8 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
@@ -5632,8 +7086,8 @@ entry:
 
 ; <label>:12                                      ; preds = %4
   %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
@@ -5644,8 +7098,8 @@ entry:
 
 ; <label>:19                                      ; preds = %14
   %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %19
   %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
@@ -5660,21 +7114,21 @@ entry:
   %31 = zext i16 %30 to i32
   %32 = bitcast i8* %29 to i16*
   %33 = trunc i32 %31 to i16
-  %NullCheck6 = icmp ne i16* %32, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i16* %32, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %21
   store i16 %33, i16* %32, align 8
   %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %36
 
 ; <label>:36                                      ; preds = %34
   %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
   %38 = load i32, i32 addrspace(1)* %37, align 8
   %39 = add i32 %38, 1
-  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %40
 
 ; <label>:40                                      ; preds = %36
   %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
@@ -5683,16 +7137,16 @@ entry:
 
 ; <label>:42                                      ; preds = %14
   %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
-  br i1 %NullCheck12, label %44, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
   %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
   %47 = load i16, i16* %arg1
   %48 = zext i16 %47 to i32
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = trunc i32 %48 to i16
@@ -5703,31 +7157,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %19
+ThrowNullRef4:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %21
+ThrowNullRef6:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %36
+ThrowNullRef10:                                   ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %42
+ThrowNullRef12:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %44
+ThrowNullRef14:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5740,8 +7194,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -5752,8 +7206,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
@@ -5762,14 +7216,14 @@ entry:
 
 ; <label>:11                                      ; preds = %1
   %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
@@ -5779,15 +7233,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5808,8 +7262,8 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5822,8 +7276,8 @@ entry:
 
 ; <label>:8                                       ; preds = %3
   %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
@@ -5842,15 +7296,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
-  br i1 %NullCheck4, label %22, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
   %24 = load i16*, i16* addrspace(1)* %23, align 8
   %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %25, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
@@ -5859,8 +7313,8 @@ entry:
   store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
@@ -5874,8 +7328,8 @@ entry:
 
 ; <label>:37                                      ; preds = %65
   %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %37
   %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
@@ -5886,16 +7340,16 @@ entry:
   %45 = bitcast i16* %41 to i8*
   %46 = getelementptr inbounds i8, i8* %45, i64 %44
   %47 = bitcast i8* %46 to i16*
-  %NullCheck14 = icmp ne i16* %47, null
-  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %47, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %48
 
 ; <label>:48                                      ; preds = %39
   %49 = load i16, i16* %47, align 8
   %50 = zext i16 %49 to i32
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %52 = load i32, i32* %loc1
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %53
 
 ; <label>:53                                      ; preds = %48
   %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
@@ -5916,8 +7370,8 @@ entry:
 ; <label>:62                                      ; preds = %36, %59
   %63 = load i32, i32* %loc1
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck10, label %65, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %65
 
 ; <label>:65                                      ; preds = %62
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
@@ -5936,15 +7390,15 @@ entry:
 
 ; <label>:74                                      ; preds = %70
   %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
-  br i1 %NullCheck18, label %76, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %76
 
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
   %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
-  br i1 %NullCheck20, label %80, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
   %81 = load i64, i64 addrspace(1)* %79
@@ -5958,8 +7412,8 @@ entry:
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
   %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
-  br i1 %NullCheck22, label %92, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.String addrspace(1)* %90, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %92
 
 ; <label>:92                                      ; preds = %80
   %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
@@ -5969,15 +7423,15 @@ entry:
 
 ; <label>:96                                      ; preds = %70
   %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
-  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %98
 
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
   %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
-  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
   %103 = load i64, i64 addrspace(1)* %101
@@ -5991,8 +7445,8 @@ entry:
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
   %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
-  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.String addrspace(1)* %112, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %114
 
 ; <label>:114                                     ; preds = %102
   %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
@@ -6004,59 +7458,59 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %20
+ThrowNullRef4:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %22
+ThrowNullRef6:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %26
+ThrowNullRef8:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %62
+ThrowNullRef10:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %48
+ThrowNullRef16:                                   ; preds = %48
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %74
+ThrowNullRef18:                                   ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %76
+ThrowNullRef20:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %80
+ThrowNullRef22:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %96
+ThrowNullRef24:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %98
+ThrowNullRef26:                                   ; preds = %98
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %102
+ThrowNullRef28:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6069,15 +7523,15 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
   %3 = load i16*, i16* addrspace(1)* %2, align 8
   %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
@@ -6087,8 +7541,8 @@ entry:
   %10 = bitcast i16* %3 to i8*
   %11 = getelementptr inbounds i8, i8* %10, i64 %9
   %12 = bitcast i8* %11 to i16*
-  %NullCheck4 = icmp ne i16* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %5
   store i16 0, i16* %12, align 8
@@ -6098,11 +7552,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6119,8 +7573,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -6131,8 +7585,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
@@ -6144,15 +7598,15 @@ entry:
 
 ; <label>:14                                      ; preds = %1
   %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
   %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
   %21 = load i64, i64 addrspace(1)* %19
@@ -6171,15 +7625,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %14
+ThrowNullRef4:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %16
+ThrowNullRef6:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6302,14 +7756,6 @@ entry:
   ret %System.String addrspace(1)* %57
 }
 
-INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
-Successfully read RuntimeHelpers.get_OffsetToStringData
-
-define i32 @RuntimeHelpers.get_OffsetToStringData() {
-entry:
-  ret i32 12
-}
-
 INFO:  jitting method String::Equals using LLILCJit
 Successfully read String.Equals
 
@@ -6381,8 +7827,8 @@ entry:
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
-  br i1 %NullCheck24, label %29, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
   %30 = load i64, i64 addrspace(1)* %28
@@ -6397,8 +7843,8 @@ entry:
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
-  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
   %43 = load i64, i64 addrspace(1)* %41
@@ -6418,8 +7864,8 @@ entry:
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
   %59 = load i64, i64 addrspace(1)* %57
@@ -6434,8 +7880,8 @@ entry:
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck22, label %71, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
   %72 = load i64, i64 addrspace(1)* %70
@@ -6455,8 +7901,8 @@ entry:
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
-  br i1 %NullCheck16, label %87, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = load i64, i64 addrspace(1)* %86
@@ -6471,8 +7917,8 @@ entry:
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck18, label %100, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
   %101 = load i64, i64 addrspace(1)* %99
@@ -6492,8 +7938,8 @@ entry:
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
-  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
   %117 = load i64, i64 addrspace(1)* %115
@@ -6508,8 +7954,8 @@ entry:
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
-  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
   %130 = load i64, i64 addrspace(1)* %128
@@ -6528,15 +7974,15 @@ entry:
 
 ; <label>:142                                     ; preds = %22
   %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
-  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %143, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %144
 
 ; <label>:144                                     ; preds = %142
   %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
   %146 = load i32, i32 addrspace(1)* %145
   %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
-  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %147, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %148
 
 ; <label>:148                                     ; preds = %144
   %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
@@ -6557,15 +8003,15 @@ entry:
 
 ; <label>:159                                     ; preds = %22
   %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
-  br i1 %NullCheck, label %161, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %ThrowNullRef, label %161
 
 ; <label>:161                                     ; preds = %159
   %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
   %163 = load i32, i32 addrspace(1)* %162
   %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
-  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %164, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %165
 
 ; <label>:165                                     ; preds = %161
   %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
@@ -6578,8 +8024,8 @@ entry:
 
 ; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
-  br i1 %NullCheck4, label %172, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %171, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %172
 
 ; <label>:172                                     ; preds = %170
   %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
@@ -6589,8 +8035,8 @@ entry:
 
 ; <label>:176                                     ; preds = %172
   %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
-  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %177, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %178
 
 ; <label>:178                                     ; preds = %176
   %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
@@ -6629,55 +8075,55 @@ ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %161
+ThrowNullRef2:                                    ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %170
+ThrowNullRef4:                                    ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %176
+ThrowNullRef6:                                    ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %142
+ThrowNullRef8:                                    ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %144
+ThrowNullRef10:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %113
+ThrowNullRef12:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %116
+ThrowNullRef14:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %84
+ThrowNullRef16:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %87
+ThrowNullRef18:                                   ; preds = %87
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %55
+ThrowNullRef20:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %58
+ThrowNullRef22:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %26
+ThrowNullRef24:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %29
+ThrowNullRef26:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,8 +8161,8 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck, label %14, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %ThrowNullRef, label %14
 
 ; <label>:14                                      ; preds = %8
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
@@ -6760,8 +8206,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
@@ -6770,14 +8216,14 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32, i32* %loc0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %10
   %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
   %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
@@ -6790,15 +8236,15 @@ entry:
 ; <label>:25                                      ; preds = %19
   %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
-  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
   %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
@@ -6807,8 +8253,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %37 = load i32, i32* %loc0
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %38, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %38
 
 ; <label>:38                                      ; preds = %32
   %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
@@ -6817,14 +8263,14 @@ entry:
 
 ; <label>:40                                      ; preds = %19
   %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %40
   %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
   %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
-  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
-  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
@@ -6832,8 +8278,8 @@ entry:
   %48 = zext i32 %47 to i64
   %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
-  br i1 %NullCheck16, label %51, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %51
 
 ; <label>:51                                      ; preds = %45
   %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
@@ -6847,15 +8293,15 @@ entry:
 ; <label>:57                                      ; preds = %51
   %58 = load i16*, i16** %arg1
   %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
-  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %60
 
 ; <label>:60                                      ; preds = %57
   %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
   %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
-  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %64
 
 ; <label>:64                                      ; preds = %60
   %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
@@ -6864,22 +8310,22 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
   %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
-  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %70
 
 ; <label>:70                                      ; preds = %64
   %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
   %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
-  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
-  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
   %75 = load i32, i32 addrspace(1)* %74
   %76 = zext i32 %75 to i64
   %77 = trunc i64 %76 to i32
-  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
-  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %78
 
 ; <label>:78                                      ; preds = %73
   %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
@@ -6901,8 +8347,8 @@ entry:
   %90 = bitcast i16* %86 to i8*
   %91 = getelementptr inbounds i8, i8* %90, i64 %89
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %93
 
 ; <label>:93                                      ; preds = %80
   %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
@@ -6912,8 +8358,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %99 = load i32, i32* %loc2
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %100
 
 ; <label>:100                                     ; preds = %93
   %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
@@ -6928,63 +8374,63 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %25
+ThrowNullRef6:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %32
+ThrowNullRef10:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %40
+ThrowNullRef12:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %45
+ThrowNullRef16:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %57
+ThrowNullRef18:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %60
+ThrowNullRef20:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %64
+ThrowNullRef22:                                   ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %70
+ThrowNullRef24:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %73
+ThrowNullRef26:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %80
+ThrowNullRef28:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %93
+ThrowNullRef30:                                   ; preds = %93
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7004,8 +8450,8 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
@@ -7033,43 +8479,43 @@ entry:
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %14
   %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
   %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   %28 = load i32, i32 addrspace(1)* %27, align 8
   %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
-  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %30
 
 ; <label>:30                                      ; preds = %26
   %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
   %32 = load i32, i32 addrspace(1)* %31, align 8
   %33 = add i32 %28, %32
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %34
 
 ; <label>:34                                      ; preds = %30
   %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   store i32 %33, i32 addrspace(1)* %35
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
   store i32 0, i32 addrspace(1)* %38
   %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %40
 
 ; <label>:40                                      ; preds = %37
   %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
@@ -7082,8 +8528,8 @@ entry:
 
 ; <label>:47                                      ; preds = %40
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
@@ -7098,8 +8544,8 @@ entry:
   %54 = load i32, i32* %loc0
   %55 = sext i32 %54 to i64
   %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
-  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %57
 
 ; <label>:57                                      ; preds = %52
   %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
@@ -7110,68 +8556,35 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %14
+ThrowNullRef2:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %23
+ThrowNullRef4:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %26
+ThrowNullRef6:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %30
+ThrowNullRef8:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %34
+ThrowNullRef10:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %47
+ThrowNullRef14:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %52
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-}
-
-INFO:  jitting method StringBuilder::get_Length using LLILCJit
-Successfully read StringBuilder.get_Length
-
-define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.StringBuilder addrspace(1)*
-  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
-  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
-
-; <label>:1                                       ; preds = %entry
-  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %3 = load i32, i32 addrspace(1)* %2, align 8
-  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
-
-; <label>:5                                       ; preds = %1
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = add i32 %3, %7
-  ret i32 %8
-
-ThrowNullRef:                                     ; preds = %entry
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef16:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7213,70 +8626,70 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
   %6 = load i32, i32 addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
   store i32 %6, i32 addrspace(1)* %8
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
   %13 = load i32, i32 addrspace(1)* %12, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
   store i32 %13, i32 addrspace(1)* %15
   %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
-  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %18
 
 ; <label>:18                                      ; preds = %14
   %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
   %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
   %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
   %34 = load i32, i32 addrspace(1)* %33, align 8
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
-  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
@@ -7287,39 +8700,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %28
+ThrowNullRef16:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %32
+ThrowNullRef18:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7455,13 +8868,13 @@ entry:
 ; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
@@ -7477,16 +8890,16 @@ entry:
 
 ; <label>:18                                      ; preds = %15
   %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
   store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
   %22 = load i32, i32* %loc0
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %24
 
 ; <label>:24                                      ; preds = %20
   %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
@@ -7498,13 +8911,13 @@ entry:
 ; <label>:28                                      ; preds = %15, %24
   %29 = load i32, i32* %arg1
   %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %31
   %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
@@ -7517,20 +8930,20 @@ entry:
   %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
-  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
   %46 = load i32, i32 addrspace(1)* %45, align 8
   %47 = sub i32 %40, %46
-  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
-  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i32 addrspace(1)* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %48
 
 ; <label>:48                                      ; preds = %44
   store i32 %47, i32 addrspace(1)* %39, align 8
@@ -7538,21 +8951,21 @@ entry:
 
 ; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
-  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %51
 
 ; <label>:51                                      ; preds = %49
   %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %53
 
 ; <label>:53                                      ; preds = %51
   %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
   %55 = load i32, i32 addrspace(1)* %54, align 8
   %56 = load i32, i32* %arg2
   %57 = sub i32 %55, %56
-  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %58
 
 ; <label>:58                                      ; preds = %53
   %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
@@ -7562,13 +8975,13 @@ entry:
 ; <label>:60                                      ; preds = %33, %58
   %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
   %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
-  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %63
 
 ; <label>:63                                      ; preds = %60
   %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
-  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
-  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
@@ -7578,15 +8991,15 @@ entry:
 
 ; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
-  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i32 addrspace(1)* %69, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %70
 
 ; <label>:70                                      ; preds = %68
   %71 = load i32, i32 addrspace(1)* %69, align 8
   store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
-  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
@@ -7596,8 +9009,8 @@ entry:
   store i32 %77, i32* %loc4
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
-  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %80
 
 ; <label>:80                                      ; preds = %73
   %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
@@ -7607,71 +9020,71 @@ entry:
 ; <label>:83                                      ; preds = %80
   store i32 0, i32* %loc3
   %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
-  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
-  br i1 %NullCheck26, label %88, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i32 addrspace(1)* %87, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %88
 
 ; <label>:88                                      ; preds = %85
   %89 = load i32, i32 addrspace(1)* %87, align 8
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
-  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %90
 
 ; <label>:90                                      ; preds = %88
   %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
   store i32 %89, i32 addrspace(1)* %91
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
-  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
-  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %96
 
 ; <label>:96                                      ; preds = %94
   %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
-  br i1 %NullCheck34, label %100, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %100
 
 ; <label>:100                                     ; preds = %96
   %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
-  br i1 %NullCheck36, label %102, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %102
 
 ; <label>:102                                     ; preds = %100
   %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
   %104 = load i32, i32 addrspace(1)* %103, align 8
   %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
-  br i1 %NullCheck38, label %106, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %106
 
 ; <label>:106                                     ; preds = %102
   %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
-  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
-  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %108
 
 ; <label>:108                                     ; preds = %106
   %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
   %110 = load i32, i32 addrspace(1)* %109, align 8
   %111 = add i32 %104, %110
-  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %112
 
 ; <label>:112                                     ; preds = %108
   %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
   store i32 %111, i32 addrspace(1)* %113
   %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
-  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i32 addrspace(1)* %114, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %115
 
 ; <label>:115                                     ; preds = %112
   %116 = load i32, i32 addrspace(1)* %114, align 8
@@ -7681,19 +9094,19 @@ entry:
 ; <label>:118                                     ; preds = %115
   %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
-  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %121
 
 ; <label>:121                                     ; preds = %118
   %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
-  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
-  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %123
 
 ; <label>:123                                     ; preds = %121
   %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
   %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
-  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
-  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %126
 
 ; <label>:126                                     ; preds = %123
   %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
@@ -7705,8 +9118,8 @@ entry:
 
 ; <label>:130                                     ; preds = %80, %115, %126
   %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %132
 
 ; <label>:132                                     ; preds = %130
   %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7715,8 +9128,8 @@ entry:
   %136 = load i32, i32* %loc3
   %137 = sub i32 %135, %136
   %138 = sub i32 %134, %137
-  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %139
 
 ; <label>:139                                     ; preds = %132
   %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7728,16 +9141,16 @@ entry:
 
 ; <label>:144                                     ; preds = %139
   %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
-  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %146
 
 ; <label>:146                                     ; preds = %144
   %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
   %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
   %149 = load i32, i32* %loc2
   %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
-  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %151
 
 ; <label>:151                                     ; preds = %146
   %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
@@ -7754,145 +9167,249 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %18
+ThrowNullRef4:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %31
+ThrowNullRef10:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %44
+ThrowNullRef16:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %68
+ThrowNullRef18:                                   ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %70
+ThrowNullRef20:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %73
+ThrowNullRef22:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %83
+ThrowNullRef24:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %85
+ThrowNullRef26:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %88
+ThrowNullRef28:                                   ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %90
+ThrowNullRef30:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %94
+ThrowNullRef32:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %96
+ThrowNullRef34:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %100
+ThrowNullRef36:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %102
+ThrowNullRef38:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %106
+ThrowNullRef40:                                   ; preds = %106
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %108
+ThrowNullRef42:                                   ; preds = %108
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %112
+ThrowNullRef44:                                   ; preds = %112
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %118
+ThrowNullRef46:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %121
+ThrowNullRef48:                                   ; preds = %121
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %123
+ThrowNullRef50:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %130
+ThrowNullRef52:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %132
+ThrowNullRef54:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %144
+ThrowNullRef56:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %146
+ThrowNullRef58:                                   ; preds = %146
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %60
+ThrowNullRef60:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %63
+ThrowNullRef62:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %49
+ThrowNullRef64:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %51
+ThrowNullRef66:                                   ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %53
+ThrowNullRef68:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(%"System.Char[]" addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %arg0 = alloca %"System.Char[]" addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store %"System.Char[]" addrspace(1)* %param0, %"System.Char[]" addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load i32, i32* %arg4
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %43, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %38, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg1
+  %13 = load i32, i32* %arg4
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %38, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %24 = load i32, i32* %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %35 = load i32, i32* %arg3
+  %36 = load i32, i32* %arg4
+  %37 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %37, %"System.Char[]" addrspace(1)* %34, i32 %35, i32 %36)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:38                                      ; preds = %5, %16
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Successfully read Buffer._Memmove
 
@@ -7914,7 +9431,7 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[loadElem]
+Failed to read AppDomain.SetDataHelper[storeElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -7923,8 +9440,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
@@ -7934,8 +9451,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
@@ -7947,15 +9464,15 @@ entry:
   %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
   %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
@@ -7966,15 +9483,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7992,7 +9509,79 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
-Failed to read Dictionary`2.TryGetValue[loadElemA]
+Successfully read Dictionary`2.TryGetValue
+
+define i8 @"Dictionary`2.TryGetValue"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)* addrspace(1)* %param2) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  %arg2 = alloca %System.__Canon addrspace(1)* addrspace(1)*
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  store %System.__Canon addrspace(1)* addrspace(1)* %param2, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  store i32 %2, i32* %loc0
+  %3 = load i32, i32* %loc0
+  %4 = icmp slt i32 %3, 0
+  br i1 %4, label %22, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 2
+  %10 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %9, align 8
+  %11 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = zext i32 %11 to i64
+  %BoundsCheck = icmp uge i64 %16, %15
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 3, i32 %11
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %20, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %6, %System.__Canon addrspace(1)* %21)
+  ret i8 1
+
+; <label>:22                                      ; preds = %entry
+  %23 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %23, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -8058,8 +9647,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
@@ -8091,8 +9680,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
@@ -8171,15 +9760,15 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck, label %19, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %ThrowNullRef, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
   %21 = load i32, i32 addrspace(1)* %20
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
@@ -8202,7 +9791,7 @@ ThrowNullRef:                                     ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %19
+ThrowNullRef2:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8248,8 +9837,8 @@ entry:
   %0 = alloca %System.AppDomainHandle
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %1 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %1, i32 0, i32 15
@@ -8269,8 +9858,8 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
@@ -8286,7 +9875,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -8299,8 +9888,8 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -8327,8 +9916,8 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
@@ -8352,8 +9941,8 @@ entry:
   %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
   store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
@@ -8363,8 +9952,8 @@ entry:
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
@@ -8374,8 +9963,8 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %9
   %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
@@ -8384,8 +9973,8 @@ entry:
 
 ; <label>:18                                      ; preds = %3, %16
   %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
@@ -8397,15 +9986,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %18
+ThrowNullRef6:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8418,8 +10007,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
@@ -8453,15 +10042,15 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
@@ -8473,7 +10062,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8481,7 +10070,7 @@ ThrowNullRef1:                                    ; preds = %1
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
 Failed to read Dictionary`2.System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
@@ -8506,8 +10095,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
@@ -8524,8 +10113,8 @@ entry:
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -8544,7 +10133,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8577,8 +10166,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = load i64, i64* %arg2
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = trunc i32 %3 to i8
@@ -8634,46 +10223,46 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
   %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
-  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
-  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
-  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
@@ -8684,27 +10273,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %20
+ThrowNullRef12:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8717,8 +10306,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -8756,22 +10345,22 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
   %9 = load i64, i64 addrspace(1)* %8, align 8
   %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
   %13 = load i64, i64 addrspace(1)* %12, align 8
   %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %11
   %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
@@ -8788,11 +10377,11 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8882,8 +10471,8 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
@@ -8900,8 +10489,8 @@ entry:
 ; <label>:8                                       ; preds = %1
   %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
   %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
@@ -8911,15 +10500,15 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
   %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
   %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
-  br i1 %NullCheck6, label %21, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
@@ -8946,15 +10535,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8992,15 +10581,15 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
   store i8 %3, i8 addrspace(1)* %5
   %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
@@ -9011,7 +10600,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9027,8 +10616,8 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -9041,8 +10630,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
@@ -9058,7 +10647,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9080,8 +10669,8 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
@@ -9096,8 +10685,8 @@ entry:
 ; <label>:12                                      ; preds = %6
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
@@ -9112,8 +10701,8 @@ entry:
 ; <label>:21                                      ; preds = %15
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
@@ -9128,8 +10717,8 @@ entry:
 ; <label>:30                                      ; preds = %24
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %31, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
@@ -9144,8 +10733,8 @@ entry:
 ; <label>:39                                      ; preds = %33
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
-  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %40, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %42
 
 ; <label>:42                                      ; preds = %39
   %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
@@ -9164,19 +10753,19 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %21
+ThrowNullRef4:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %30
+ThrowNullRef6:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %39
+ThrowNullRef8:                                    ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9243,8 +10832,8 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
@@ -9264,57 +10853,57 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
   store i8 0, i8 addrspace(1)* %2
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
   store i8 0, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
   store i8 0, i8 addrspace(1)* %17
   %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
   store i8 0, i8 addrspace(1)* %20
   %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
-  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
@@ -9325,31 +10914,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %19
+ThrowNullRef14:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9367,8 +10956,8 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
@@ -9380,8 +10969,8 @@ entry:
 
 ; <label>:9                                       ; preds = %4
   %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %9
   %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
@@ -9395,7 +10984,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef2:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9420,8 +11009,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
@@ -9512,8 +11101,8 @@ entry:
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
@@ -9524,8 +11113,8 @@ entry:
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = load i64, i64 addrspace(1)* %12
@@ -9537,8 +11126,8 @@ entry:
   %20 = load i64, i64* %19
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
-  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %13
   %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
@@ -9555,8 +11144,8 @@ entry:
 ; <label>:30                                      ; preds = %25
   %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %32 = load i32, i32* %arg2
-  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
-  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
@@ -9570,15 +11159,15 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %30
+ThrowNullRef2:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9622,87 +11211,87 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
   %10 = load i8, i8 addrspace(1)* %9, align 8
   %11 = zext i8 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %8
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
   store i8 %12, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
   %19 = load i8, i8 addrspace(1)* %18, align 8
   %20 = zext i8 %19 to i32
   %21 = trunc i32 %20 to i8
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
   store i8 %21, i8 addrspace(1)* %23
   %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
   %28 = load i8, i8 addrspace(1)* %27, align 8
   %29 = zext i8 %28 to i32
   %30 = trunc i32 %29 to i8
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
-  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %31
 
 ; <label>:31                                      ; preds = %26
   %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
   store i8 %30, i8 addrspace(1)* %32
   %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
-  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
-  br i1 %NullCheck14, label %40, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %40
 
 ; <label>:40                                      ; preds = %35
   %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
   store i8 %39, i8 addrspace(1)* %41
   %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
-  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %44
 
 ; <label>:44                                      ; preds = %40
   %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
   %46 = load i8, i8 addrspace(1)* %45, align 8
   %47 = zext i8 %46 to i32
   %48 = trunc i32 %47 to i8
-  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
   store i8 %48, i8 addrspace(1)* %50
   %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
-  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
@@ -9713,29 +11302,29 @@ entry:
 ; <label>:56                                      ; preds = %52
   %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
-  br i1 %NullCheck22, label %59, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
   %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
   %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
-  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
-  br i1 %NullCheck24, label %63, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
   %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
-  br i1 %NullCheck26, label %66, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
   %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
-  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
-  br i1 %NullCheck28, label %69, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %69
 
 ; <label>:69                                      ; preds = %66
   %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
@@ -9744,15 +11333,15 @@ entry:
 
 ; <label>:71                                      ; preds = %105
   %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
-  br i1 %NullCheck34, label %73, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %73
 
 ; <label>:73                                      ; preds = %71
   %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
   %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
   %76 = load i32, i32* %loc0
-  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
-  br i1 %NullCheck36, label %77, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
@@ -9766,8 +11355,8 @@ entry:
 
 ; <label>:83                                      ; preds = %77
   %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
-  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
@@ -9775,14 +11364,14 @@ entry:
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
   %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
-  br i1 %NullCheck40, label %91, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
 ; <label>:91                                      ; preds = %85
   %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
   %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
-  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck42, label %94, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %94
 
 ; <label>:94                                      ; preds = %91
   %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
@@ -9798,14 +11387,14 @@ entry:
 ; <label>:99                                      ; preds = %69, %96
   %100 = load i32, i32* %loc0
   %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
-  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %102
 
 ; <label>:102                                     ; preds = %99
   %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
   %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
-  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
-  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
@@ -9819,87 +11408,87 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %26
+ThrowNullRef10:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %31
+ThrowNullRef12:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %35
+ThrowNullRef14:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %40
+ThrowNullRef16:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %56
+ThrowNullRef22:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %59
+ThrowNullRef24:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %63
+ThrowNullRef26:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %66
+ThrowNullRef28:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %102
+ThrowNullRef32:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %71
+ThrowNullRef34:                                   ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %73
+ThrowNullRef36:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %83
+ThrowNullRef38:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %85
+ThrowNullRef40:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %91
+ThrowNullRef42:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9943,15 +11532,15 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
   %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
@@ -9961,28 +11550,28 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
   %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %12
   %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
   %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
   %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
-  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
@@ -9993,23 +11582,23 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %12
+ThrowNullRef6:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10031,15 +11620,15 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
   %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = load i64, i64 addrspace(1)* %7
@@ -10077,13 +11666,13 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[loadElem]
+Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -10111,8 +11700,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Le1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Le1.error.txt
@@ -25,8 +25,8 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
@@ -40,8 +40,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
   %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
@@ -75,7 +75,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -90,8 +90,8 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %NullCheck = icmp ne i8 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = load i8, i8 addrspace(1)* %0, align 8
@@ -125,8 +125,8 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
@@ -159,8 +159,8 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -184,8 +184,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
   store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
@@ -195,8 +195,8 @@ entry:
 ; <label>:4                                       ; preds = %1
   %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
   %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
@@ -206,8 +206,8 @@ entry:
   %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
@@ -221,14 +221,14 @@ entry:
 
 ; <label>:17                                      ; preds = %14
   %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
   %21 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
@@ -238,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -249,8 +249,8 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
@@ -261,27 +261,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %30
+ThrowNullRef10:                                   ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -301,7 +301,89 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
-Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
+Successfully read AppDomainSetup.GetUnsecureApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.GetUnsecureApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %NullCheck = icmp eq %"System.String[]" addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %BoundsCheck = icmp uge i64 0, %5
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %6
+
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 3, i32 0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
+  ret %System.String addrspace(1)* %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_Value using LLILCJit
+Successfully read AppDomainSetup.get_Value
+
+define %"System.String[]" addrspace(1)* @AppDomainSetup.get_Value(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.String[]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 18)
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.String[]" addrspace(1)* addrspace(1)*, %"System.String[]" addrspace(1)*)*)(%"System.String[]" addrspace(1)* addrspace(1)* %9, %"System.String[]" addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %11, i32 0, i32 1
+  %14 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %13, align 8
+  ret %"System.String[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -319,8 +401,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -368,16 +450,16 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
   %5 = load i32, i32 addrspace(1)* %4
   %6 = sub i32 %5, 1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -389,7 +471,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -421,8 +503,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
@@ -456,8 +538,8 @@ entry:
 ; <label>:27                                      ; preds = %19
   %28 = load i32, i32* %arg1
   %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
-  br i1 %NullCheck2, label %30, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %29, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %30
 
 ; <label>:30                                      ; preds = %27
   %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
@@ -493,8 +575,8 @@ entry:
 ; <label>:49                                      ; preds = %46
   %50 = load i32, i32* %arg2
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck4, label %52, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
@@ -517,11 +599,11 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %27
+ThrowNullRef2:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %49
+ThrowNullRef4:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -544,16 +626,16 @@ entry:
   %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %0)
   store %System.String addrspace(1)* %1, %System.String addrspace(1)** %loc0
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 2
   %5 = bitcast [0 x i16] addrspace(1)* %4 to i16 addrspace(1)*
   store i16 addrspace(1)* %5, i16 addrspace(1)** %loc1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %3
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2
@@ -580,7 +662,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -691,15 +773,15 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %NullCheck132 = icmp ne i8* %21, null
-  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+  %NullCheck131 = icmp eq i8* %21, null
+  br i1 %NullCheck131, label %ThrowNullRef132, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = load i8, i8* %21, align 8
   %24 = zext i8 %23 to i32
   %25 = trunc i32 %24 to i8
-  %NullCheck134 = icmp ne i8* %20, null
-  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+  %NullCheck133 = icmp eq i8* %20, null
+  br i1 %NullCheck133, label %ThrowNullRef134, label %26
 
 ; <label>:26                                      ; preds = %22
   store i8 %25, i8* %20, align 8
@@ -709,16 +791,16 @@ entry:
   %28 = load i8*, i8** %arg0
   %29 = load i8*, i8** %arg1
   %30 = bitcast i8* %29 to i16*
-  %NullCheck128 = icmp ne i16* %30, null
-  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+  %NullCheck127 = icmp eq i16* %30, null
+  br i1 %NullCheck127, label %ThrowNullRef128, label %31
 
 ; <label>:31                                      ; preds = %27
   %32 = load i16, i16* %30, align 8
   %33 = sext i16 %32 to i32
   %34 = bitcast i8* %28 to i16*
   %35 = trunc i32 %33 to i16
-  %NullCheck130 = icmp ne i16* %34, null
-  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+  %NullCheck129 = icmp eq i16* %34, null
+  br i1 %NullCheck129, label %ThrowNullRef130, label %36
 
 ; <label>:36                                      ; preds = %31
   store i16 %35, i16* %34, align 8
@@ -728,16 +810,16 @@ entry:
   %38 = load i8*, i8** %arg0
   %39 = load i8*, i8** %arg1
   %40 = bitcast i8* %39 to i16*
-  %NullCheck120 = icmp ne i16* %40, null
-  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+  %NullCheck119 = icmp eq i16* %40, null
+  br i1 %NullCheck119, label %ThrowNullRef120, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i16, i16* %40, align 8
   %43 = sext i16 %42 to i32
   %44 = bitcast i8* %38 to i16*
   %45 = trunc i32 %43 to i16
-  %NullCheck122 = icmp ne i16* %44, null
-  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+  %NullCheck121 = icmp eq i16* %44, null
+  br i1 %NullCheck121, label %ThrowNullRef122, label %46
 
 ; <label>:46                                      ; preds = %41
   store i16 %45, i16* %44, align 8
@@ -745,15 +827,15 @@ entry:
   %48 = getelementptr inbounds i8, i8* %47, i64 2
   %49 = load i8*, i8** %arg1
   %50 = getelementptr inbounds i8, i8* %49, i64 2
-  %NullCheck124 = icmp ne i8* %50, null
-  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+  %NullCheck123 = icmp eq i8* %50, null
+  br i1 %NullCheck123, label %ThrowNullRef124, label %51
 
 ; <label>:51                                      ; preds = %46
   %52 = load i8, i8* %50, align 8
   %53 = zext i8 %52 to i32
   %54 = trunc i32 %53 to i8
-  %NullCheck126 = icmp ne i8* %48, null
-  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+  %NullCheck125 = icmp eq i8* %48, null
+  br i1 %NullCheck125, label %ThrowNullRef126, label %55
 
 ; <label>:55                                      ; preds = %51
   store i8 %54, i8* %48, align 8
@@ -763,14 +845,14 @@ entry:
   %57 = load i8*, i8** %arg0
   %58 = load i8*, i8** %arg1
   %59 = bitcast i8* %58 to i32*
-  %NullCheck116 = icmp ne i32* %59, null
-  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+  %NullCheck115 = icmp eq i32* %59, null
+  br i1 %NullCheck115, label %ThrowNullRef116, label %60
 
 ; <label>:60                                      ; preds = %56
   %61 = load i32, i32* %59, align 8
   %62 = bitcast i8* %57 to i32*
-  %NullCheck118 = icmp ne i32* %62, null
-  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+  %NullCheck117 = icmp eq i32* %62, null
+  br i1 %NullCheck117, label %ThrowNullRef118, label %63
 
 ; <label>:63                                      ; preds = %60
   store i32 %61, i32* %62, align 8
@@ -780,14 +862,14 @@ entry:
   %65 = load i8*, i8** %arg0
   %66 = load i8*, i8** %arg1
   %67 = bitcast i8* %66 to i32*
-  %NullCheck108 = icmp ne i32* %67, null
-  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+  %NullCheck107 = icmp eq i32* %67, null
+  br i1 %NullCheck107, label %ThrowNullRef108, label %68
 
 ; <label>:68                                      ; preds = %64
   %69 = load i32, i32* %67, align 8
   %70 = bitcast i8* %65 to i32*
-  %NullCheck110 = icmp ne i32* %70, null
-  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+  %NullCheck109 = icmp eq i32* %70, null
+  br i1 %NullCheck109, label %ThrowNullRef110, label %71
 
 ; <label>:71                                      ; preds = %68
   store i32 %69, i32* %70, align 8
@@ -795,15 +877,15 @@ entry:
   %73 = getelementptr inbounds i8, i8* %72, i64 4
   %74 = load i8*, i8** %arg1
   %75 = getelementptr inbounds i8, i8* %74, i64 4
-  %NullCheck112 = icmp ne i8* %75, null
-  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+  %NullCheck111 = icmp eq i8* %75, null
+  br i1 %NullCheck111, label %ThrowNullRef112, label %76
 
 ; <label>:76                                      ; preds = %71
   %77 = load i8, i8* %75, align 8
   %78 = zext i8 %77 to i32
   %79 = trunc i32 %78 to i8
-  %NullCheck114 = icmp ne i8* %73, null
-  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+  %NullCheck113 = icmp eq i8* %73, null
+  br i1 %NullCheck113, label %ThrowNullRef114, label %80
 
 ; <label>:80                                      ; preds = %76
   store i8 %79, i8* %73, align 8
@@ -813,14 +895,14 @@ entry:
   %82 = load i8*, i8** %arg0
   %83 = load i8*, i8** %arg1
   %84 = bitcast i8* %83 to i32*
-  %NullCheck100 = icmp ne i32* %84, null
-  br i1 %NullCheck100, label %85, label %ThrowNullRef99
+  %NullCheck99 = icmp eq i32* %84, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %85
 
 ; <label>:85                                      ; preds = %81
   %86 = load i32, i32* %84, align 8
   %87 = bitcast i8* %82 to i32*
-  %NullCheck102 = icmp ne i32* %87, null
-  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+  %NullCheck101 = icmp eq i32* %87, null
+  br i1 %NullCheck101, label %ThrowNullRef102, label %88
 
 ; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
@@ -829,16 +911,16 @@ entry:
   %91 = load i8*, i8** %arg1
   %92 = getelementptr inbounds i8, i8* %91, i64 4
   %93 = bitcast i8* %92 to i16*
-  %NullCheck104 = icmp ne i16* %93, null
-  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+  %NullCheck103 = icmp eq i16* %93, null
+  br i1 %NullCheck103, label %ThrowNullRef104, label %94
 
 ; <label>:94                                      ; preds = %88
   %95 = load i16, i16* %93, align 8
   %96 = sext i16 %95 to i32
   %97 = bitcast i8* %90 to i16*
   %98 = trunc i32 %96 to i16
-  %NullCheck106 = icmp ne i16* %97, null
-  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+  %NullCheck105 = icmp eq i16* %97, null
+  br i1 %NullCheck105, label %ThrowNullRef106, label %99
 
 ; <label>:99                                      ; preds = %94
   store i16 %98, i16* %97, align 8
@@ -848,14 +930,14 @@ entry:
   %101 = load i8*, i8** %arg0
   %102 = load i8*, i8** %arg1
   %103 = bitcast i8* %102 to i32*
-  %NullCheck88 = icmp ne i32* %103, null
-  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+  %NullCheck87 = icmp eq i32* %103, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %104
 
 ; <label>:104                                     ; preds = %100
   %105 = load i32, i32* %103, align 8
   %106 = bitcast i8* %101 to i32*
-  %NullCheck90 = icmp ne i32* %106, null
-  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+  %NullCheck89 = icmp eq i32* %106, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %107
 
 ; <label>:107                                     ; preds = %104
   store i32 %105, i32* %106, align 8
@@ -864,16 +946,16 @@ entry:
   %110 = load i8*, i8** %arg1
   %111 = getelementptr inbounds i8, i8* %110, i64 4
   %112 = bitcast i8* %111 to i16*
-  %NullCheck92 = icmp ne i16* %112, null
-  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+  %NullCheck91 = icmp eq i16* %112, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %113
 
 ; <label>:113                                     ; preds = %107
   %114 = load i16, i16* %112, align 8
   %115 = sext i16 %114 to i32
   %116 = bitcast i8* %109 to i16*
   %117 = trunc i32 %115 to i16
-  %NullCheck94 = icmp ne i16* %116, null
-  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+  %NullCheck93 = icmp eq i16* %116, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %118
 
 ; <label>:118                                     ; preds = %113
   store i16 %117, i16* %116, align 8
@@ -881,15 +963,15 @@ entry:
   %120 = getelementptr inbounds i8, i8* %119, i64 6
   %121 = load i8*, i8** %arg1
   %122 = getelementptr inbounds i8, i8* %121, i64 6
-  %NullCheck96 = icmp ne i8* %122, null
-  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+  %NullCheck95 = icmp eq i8* %122, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %123
 
 ; <label>:123                                     ; preds = %118
   %124 = load i8, i8* %122, align 8
   %125 = zext i8 %124 to i32
   %126 = trunc i32 %125 to i8
-  %NullCheck98 = icmp ne i8* %120, null
-  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+  %NullCheck97 = icmp eq i8* %120, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %127
 
 ; <label>:127                                     ; preds = %123
   store i8 %126, i8* %120, align 8
@@ -899,14 +981,14 @@ entry:
   %129 = load i8*, i8** %arg0
   %130 = load i8*, i8** %arg1
   %131 = bitcast i8* %130 to i64*
-  %NullCheck84 = icmp ne i64* %131, null
-  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+  %NullCheck83 = icmp eq i64* %131, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %132
 
 ; <label>:132                                     ; preds = %128
   %133 = load i64, i64* %131, align 8
   %134 = bitcast i8* %129 to i64*
-  %NullCheck86 = icmp ne i64* %134, null
-  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+  %NullCheck85 = icmp eq i64* %134, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %135
 
 ; <label>:135                                     ; preds = %132
   store i64 %133, i64* %134, align 8
@@ -916,14 +998,14 @@ entry:
   %137 = load i8*, i8** %arg0
   %138 = load i8*, i8** %arg1
   %139 = bitcast i8* %138 to i64*
-  %NullCheck76 = icmp ne i64* %139, null
-  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+  %NullCheck75 = icmp eq i64* %139, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %140
 
 ; <label>:140                                     ; preds = %136
   %141 = load i64, i64* %139, align 8
   %142 = bitcast i8* %137 to i64*
-  %NullCheck78 = icmp ne i64* %142, null
-  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+  %NullCheck77 = icmp eq i64* %142, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %143
 
 ; <label>:143                                     ; preds = %140
   store i64 %141, i64* %142, align 8
@@ -931,15 +1013,15 @@ entry:
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %NullCheck80 = icmp ne i8* %147, null
-  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+  %NullCheck79 = icmp eq i8* %147, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %148
 
 ; <label>:148                                     ; preds = %143
   %149 = load i8, i8* %147, align 8
   %150 = zext i8 %149 to i32
   %151 = trunc i32 %150 to i8
-  %NullCheck82 = icmp ne i8* %145, null
-  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+  %NullCheck81 = icmp eq i8* %145, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %152
 
 ; <label>:152                                     ; preds = %148
   store i8 %151, i8* %145, align 8
@@ -949,14 +1031,14 @@ entry:
   %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
   %156 = bitcast i8* %155 to i64*
-  %NullCheck68 = icmp ne i64* %156, null
-  br i1 %NullCheck68, label %157, label %ThrowNullRef67
+  %NullCheck67 = icmp eq i64* %156, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %157
 
 ; <label>:157                                     ; preds = %153
   %158 = load i64, i64* %156, align 8
   %159 = bitcast i8* %154 to i64*
-  %NullCheck70 = icmp ne i64* %159, null
-  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+  %NullCheck69 = icmp eq i64* %159, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %160
 
 ; <label>:160                                     ; preds = %157
   store i64 %158, i64* %159, align 8
@@ -965,16 +1047,16 @@ entry:
   %163 = load i8*, i8** %arg1
   %164 = getelementptr inbounds i8, i8* %163, i64 8
   %165 = bitcast i8* %164 to i16*
-  %NullCheck72 = icmp ne i16* %165, null
-  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+  %NullCheck71 = icmp eq i16* %165, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %166
 
 ; <label>:166                                     ; preds = %160
   %167 = load i16, i16* %165, align 8
   %168 = sext i16 %167 to i32
   %169 = bitcast i8* %162 to i16*
   %170 = trunc i32 %168 to i16
-  %NullCheck74 = icmp ne i16* %169, null
-  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+  %NullCheck73 = icmp eq i16* %169, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %171
 
 ; <label>:171                                     ; preds = %166
   store i16 %170, i16* %169, align 8
@@ -984,14 +1066,14 @@ entry:
   %173 = load i8*, i8** %arg0
   %174 = load i8*, i8** %arg1
   %175 = bitcast i8* %174 to i64*
-  %NullCheck56 = icmp ne i64* %175, null
-  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+  %NullCheck55 = icmp eq i64* %175, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %176
 
 ; <label>:176                                     ; preds = %172
   %177 = load i64, i64* %175, align 8
   %178 = bitcast i8* %173 to i64*
-  %NullCheck58 = icmp ne i64* %178, null
-  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+  %NullCheck57 = icmp eq i64* %178, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %179
 
 ; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
@@ -1000,16 +1082,16 @@ entry:
   %182 = load i8*, i8** %arg1
   %183 = getelementptr inbounds i8, i8* %182, i64 8
   %184 = bitcast i8* %183 to i16*
-  %NullCheck60 = icmp ne i16* %184, null
-  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+  %NullCheck59 = icmp eq i16* %184, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %185
 
 ; <label>:185                                     ; preds = %179
   %186 = load i16, i16* %184, align 8
   %187 = sext i16 %186 to i32
   %188 = bitcast i8* %181 to i16*
   %189 = trunc i32 %187 to i16
-  %NullCheck62 = icmp ne i16* %188, null
-  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+  %NullCheck61 = icmp eq i16* %188, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %190
 
 ; <label>:190                                     ; preds = %185
   store i16 %189, i16* %188, align 8
@@ -1017,15 +1099,15 @@ entry:
   %192 = getelementptr inbounds i8, i8* %191, i64 10
   %193 = load i8*, i8** %arg1
   %194 = getelementptr inbounds i8, i8* %193, i64 10
-  %NullCheck64 = icmp ne i8* %194, null
-  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+  %NullCheck63 = icmp eq i8* %194, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %195
 
 ; <label>:195                                     ; preds = %190
   %196 = load i8, i8* %194, align 8
   %197 = zext i8 %196 to i32
   %198 = trunc i32 %197 to i8
-  %NullCheck66 = icmp ne i8* %192, null
-  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+  %NullCheck65 = icmp eq i8* %192, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %199
 
 ; <label>:199                                     ; preds = %195
   store i8 %198, i8* %192, align 8
@@ -1035,14 +1117,14 @@ entry:
   %201 = load i8*, i8** %arg0
   %202 = load i8*, i8** %arg1
   %203 = bitcast i8* %202 to i64*
-  %NullCheck48 = icmp ne i64* %203, null
-  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+  %NullCheck47 = icmp eq i64* %203, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %204
 
 ; <label>:204                                     ; preds = %200
   %205 = load i64, i64* %203, align 8
   %206 = bitcast i8* %201 to i64*
-  %NullCheck50 = icmp ne i64* %206, null
-  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+  %NullCheck49 = icmp eq i64* %206, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %207
 
 ; <label>:207                                     ; preds = %204
   store i64 %205, i64* %206, align 8
@@ -1051,14 +1133,14 @@ entry:
   %210 = load i8*, i8** %arg1
   %211 = getelementptr inbounds i8, i8* %210, i64 8
   %212 = bitcast i8* %211 to i32*
-  %NullCheck52 = icmp ne i32* %212, null
-  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+  %NullCheck51 = icmp eq i32* %212, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %213
 
 ; <label>:213                                     ; preds = %207
   %214 = load i32, i32* %212, align 8
   %215 = bitcast i8* %209 to i32*
-  %NullCheck54 = icmp ne i32* %215, null
-  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+  %NullCheck53 = icmp eq i32* %215, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %216
 
 ; <label>:216                                     ; preds = %213
   store i32 %214, i32* %215, align 8
@@ -1068,14 +1150,14 @@ entry:
   %218 = load i8*, i8** %arg0
   %219 = load i8*, i8** %arg1
   %220 = bitcast i8* %219 to i64*
-  %NullCheck36 = icmp ne i64* %220, null
-  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64* %220, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %221
 
 ; <label>:221                                     ; preds = %217
   %222 = load i64, i64* %220, align 8
   %223 = bitcast i8* %218 to i64*
-  %NullCheck38 = icmp ne i64* %223, null
-  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+  %NullCheck37 = icmp eq i64* %223, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %224
 
 ; <label>:224                                     ; preds = %221
   store i64 %222, i64* %223, align 8
@@ -1084,14 +1166,14 @@ entry:
   %227 = load i8*, i8** %arg1
   %228 = getelementptr inbounds i8, i8* %227, i64 8
   %229 = bitcast i8* %228 to i32*
-  %NullCheck40 = icmp ne i32* %229, null
-  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i32* %229, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %230
 
 ; <label>:230                                     ; preds = %224
   %231 = load i32, i32* %229, align 8
   %232 = bitcast i8* %226 to i32*
-  %NullCheck42 = icmp ne i32* %232, null
-  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+  %NullCheck41 = icmp eq i32* %232, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %233
 
 ; <label>:233                                     ; preds = %230
   store i32 %231, i32* %232, align 8
@@ -1099,15 +1181,15 @@ entry:
   %235 = getelementptr inbounds i8, i8* %234, i64 12
   %236 = load i8*, i8** %arg1
   %237 = getelementptr inbounds i8, i8* %236, i64 12
-  %NullCheck44 = icmp ne i8* %237, null
-  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i8* %237, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %238
 
 ; <label>:238                                     ; preds = %233
   %239 = load i8, i8* %237, align 8
   %240 = zext i8 %239 to i32
   %241 = trunc i32 %240 to i8
-  %NullCheck46 = icmp ne i8* %235, null
-  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+  %NullCheck45 = icmp eq i8* %235, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %242
 
 ; <label>:242                                     ; preds = %238
   store i8 %241, i8* %235, align 8
@@ -1117,14 +1199,14 @@ entry:
   %244 = load i8*, i8** %arg0
   %245 = load i8*, i8** %arg1
   %246 = bitcast i8* %245 to i64*
-  %NullCheck24 = icmp ne i64* %246, null
-  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64* %246, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %247
 
 ; <label>:247                                     ; preds = %243
   %248 = load i64, i64* %246, align 8
   %249 = bitcast i8* %244 to i64*
-  %NullCheck26 = icmp ne i64* %249, null
-  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64* %249, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %250
 
 ; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
@@ -1133,14 +1215,14 @@ entry:
   %253 = load i8*, i8** %arg1
   %254 = getelementptr inbounds i8, i8* %253, i64 8
   %255 = bitcast i8* %254 to i32*
-  %NullCheck28 = icmp ne i32* %255, null
-  br i1 %NullCheck28, label %256, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i32* %255, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %256
 
 ; <label>:256                                     ; preds = %250
   %257 = load i32, i32* %255, align 8
   %258 = bitcast i8* %252 to i32*
-  %NullCheck30 = icmp ne i32* %258, null
-  br i1 %NullCheck30, label %259, label %ThrowNullRef29
+  %NullCheck29 = icmp eq i32* %258, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %259
 
 ; <label>:259                                     ; preds = %256
   store i32 %257, i32* %258, align 8
@@ -1149,16 +1231,16 @@ entry:
   %262 = load i8*, i8** %arg1
   %263 = getelementptr inbounds i8, i8* %262, i64 12
   %264 = bitcast i8* %263 to i16*
-  %NullCheck32 = icmp ne i16* %264, null
-  br i1 %NullCheck32, label %265, label %ThrowNullRef31
+  %NullCheck31 = icmp eq i16* %264, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %265
 
 ; <label>:265                                     ; preds = %259
   %266 = load i16, i16* %264, align 8
   %267 = sext i16 %266 to i32
   %268 = bitcast i8* %261 to i16*
   %269 = trunc i32 %267 to i16
-  %NullCheck34 = icmp ne i16* %268, null
-  br i1 %NullCheck34, label %270, label %ThrowNullRef33
+  %NullCheck33 = icmp eq i16* %268, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %270
 
 ; <label>:270                                     ; preds = %265
   store i16 %269, i16* %268, align 8
@@ -1168,14 +1250,14 @@ entry:
   %272 = load i8*, i8** %arg0
   %273 = load i8*, i8** %arg1
   %274 = bitcast i8* %273 to i64*
-  %NullCheck8 = icmp ne i64* %274, null
-  br i1 %NullCheck8, label %275, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64* %274, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %275
 
 ; <label>:275                                     ; preds = %271
   %276 = load i64, i64* %274, align 8
   %277 = bitcast i8* %272 to i64*
-  %NullCheck10 = icmp ne i64* %277, null
-  br i1 %NullCheck10, label %278, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %277, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %278
 
 ; <label>:278                                     ; preds = %275
   store i64 %276, i64* %277, align 8
@@ -1184,14 +1266,14 @@ entry:
   %281 = load i8*, i8** %arg1
   %282 = getelementptr inbounds i8, i8* %281, i64 8
   %283 = bitcast i8* %282 to i32*
-  %NullCheck12 = icmp ne i32* %283, null
-  br i1 %NullCheck12, label %284, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i32* %283, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %284
 
 ; <label>:284                                     ; preds = %278
   %285 = load i32, i32* %283, align 8
   %286 = bitcast i8* %280 to i32*
-  %NullCheck14 = icmp ne i32* %286, null
-  br i1 %NullCheck14, label %287, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i32* %286, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %287
 
 ; <label>:287                                     ; preds = %284
   store i32 %285, i32* %286, align 8
@@ -1200,16 +1282,16 @@ entry:
   %290 = load i8*, i8** %arg1
   %291 = getelementptr inbounds i8, i8* %290, i64 12
   %292 = bitcast i8* %291 to i16*
-  %NullCheck16 = icmp ne i16* %292, null
-  br i1 %NullCheck16, label %293, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i16* %292, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %293
 
 ; <label>:293                                     ; preds = %287
   %294 = load i16, i16* %292, align 8
   %295 = sext i16 %294 to i32
   %296 = bitcast i8* %289 to i16*
   %297 = trunc i32 %295 to i16
-  %NullCheck18 = icmp ne i16* %296, null
-  br i1 %NullCheck18, label %298, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i16* %296, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %298
 
 ; <label>:298                                     ; preds = %293
   store i16 %297, i16* %296, align 8
@@ -1217,15 +1299,15 @@ entry:
   %300 = getelementptr inbounds i8, i8* %299, i64 14
   %301 = load i8*, i8** %arg1
   %302 = getelementptr inbounds i8, i8* %301, i64 14
-  %NullCheck20 = icmp ne i8* %302, null
-  br i1 %NullCheck20, label %303, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i8* %302, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %303
 
 ; <label>:303                                     ; preds = %298
   %304 = load i8, i8* %302, align 8
   %305 = zext i8 %304 to i32
   %306 = trunc i32 %305 to i8
-  %NullCheck22 = icmp ne i8* %300, null
-  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i8* %300, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %307
 
 ; <label>:307                                     ; preds = %303
   store i8 %306, i8* %300, align 8
@@ -1235,14 +1317,14 @@ entry:
   %309 = load i8*, i8** %arg0
   %310 = load i8*, i8** %arg1
   %311 = bitcast i8* %310 to i64*
-  %NullCheck = icmp ne i64* %311, null
-  br i1 %NullCheck, label %312, label %ThrowNullRef
+  %NullCheck = icmp eq i64* %311, null
+  br i1 %NullCheck, label %ThrowNullRef, label %312
 
 ; <label>:312                                     ; preds = %308
   %313 = load i64, i64* %311, align 8
   %314 = bitcast i8* %309 to i64*
-  %NullCheck2 = icmp ne i64* %314, null
-  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64* %314, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %315
 
 ; <label>:315                                     ; preds = %312
   store i64 %313, i64* %314, align 8
@@ -1251,14 +1333,14 @@ entry:
   %318 = load i8*, i8** %arg1
   %319 = getelementptr inbounds i8, i8* %318, i64 8
   %320 = bitcast i8* %319 to i64*
-  %NullCheck4 = icmp ne i64* %320, null
-  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64* %320, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %321
 
 ; <label>:321                                     ; preds = %315
   %322 = load i64, i64* %320, align 8
   %323 = bitcast i8* %317 to i64*
-  %NullCheck6 = icmp ne i64* %323, null
-  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64* %323, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %324
 
 ; <label>:324                                     ; preds = %321
   store i64 %322, i64* %323, align 8
@@ -1286,15 +1368,15 @@ entry:
 ; <label>:338                                     ; preds = %333
   %339 = load i8*, i8** %arg0
   %340 = load i8*, i8** %arg1
-  %NullCheck136 = icmp ne i8* %340, null
-  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+  %NullCheck135 = icmp eq i8* %340, null
+  br i1 %NullCheck135, label %ThrowNullRef136, label %341
 
 ; <label>:341                                     ; preds = %338
   %342 = load i8, i8* %340, align 8
   %343 = zext i8 %342 to i32
   %344 = trunc i32 %343 to i8
-  %NullCheck138 = icmp ne i8* %339, null
-  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+  %NullCheck137 = icmp eq i8* %339, null
+  br i1 %NullCheck137, label %ThrowNullRef138, label %345
 
 ; <label>:345                                     ; preds = %341
   store i8 %344, i8* %339, align 8
@@ -1317,16 +1399,16 @@ entry:
   %357 = load i8*, i8** %arg0
   %358 = load i8*, i8** %arg1
   %359 = bitcast i8* %358 to i16*
-  %NullCheck140 = icmp ne i16* %359, null
-  br i1 %NullCheck140, label %360, label %ThrowNullRef139
+  %NullCheck139 = icmp eq i16* %359, null
+  br i1 %NullCheck139, label %ThrowNullRef140, label %360
 
 ; <label>:360                                     ; preds = %356
   %361 = load i16, i16* %359, align 8
   %362 = sext i16 %361 to i32
   %363 = bitcast i8* %357 to i16*
   %364 = trunc i32 %362 to i16
-  %NullCheck142 = icmp ne i16* %363, null
-  br i1 %NullCheck142, label %365, label %ThrowNullRef141
+  %NullCheck141 = icmp eq i16* %363, null
+  br i1 %NullCheck141, label %ThrowNullRef142, label %365
 
 ; <label>:365                                     ; preds = %360
   store i16 %364, i16* %363, align 8
@@ -1352,14 +1434,14 @@ entry:
   %378 = load i8*, i8** %arg0
   %379 = load i8*, i8** %arg1
   %380 = bitcast i8* %379 to i32*
-  %NullCheck144 = icmp ne i32* %380, null
-  br i1 %NullCheck144, label %381, label %ThrowNullRef143
+  %NullCheck143 = icmp eq i32* %380, null
+  br i1 %NullCheck143, label %ThrowNullRef144, label %381
 
 ; <label>:381                                     ; preds = %377
   %382 = load i32, i32* %380, align 8
   %383 = bitcast i8* %378 to i32*
-  %NullCheck146 = icmp ne i32* %383, null
-  br i1 %NullCheck146, label %384, label %ThrowNullRef145
+  %NullCheck145 = icmp eq i32* %383, null
+  br i1 %NullCheck145, label %ThrowNullRef146, label %384
 
 ; <label>:384                                     ; preds = %381
   store i32 %382, i32* %383, align 8
@@ -1384,14 +1466,14 @@ entry:
   %395 = load i8*, i8** %arg0
   %396 = load i8*, i8** %arg1
   %397 = bitcast i8* %396 to i64*
-  %NullCheck164 = icmp ne i64* %397, null
-  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+  %NullCheck163 = icmp eq i64* %397, null
+  br i1 %NullCheck163, label %ThrowNullRef164, label %398
 
 ; <label>:398                                     ; preds = %394
   %399 = load i64, i64* %397, align 8
   %400 = bitcast i8* %395 to i64*
-  %NullCheck166 = icmp ne i64* %400, null
-  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+  %NullCheck165 = icmp eq i64* %400, null
+  br i1 %NullCheck165, label %ThrowNullRef166, label %401
 
 ; <label>:401                                     ; preds = %398
   store i64 %399, i64* %400, align 8
@@ -1400,14 +1482,14 @@ entry:
   %404 = load i8*, i8** %arg1
   %405 = getelementptr inbounds i8, i8* %404, i64 8
   %406 = bitcast i8* %405 to i64*
-  %NullCheck168 = icmp ne i64* %406, null
-  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+  %NullCheck167 = icmp eq i64* %406, null
+  br i1 %NullCheck167, label %ThrowNullRef168, label %407
 
 ; <label>:407                                     ; preds = %401
   %408 = load i64, i64* %406, align 8
   %409 = bitcast i8* %403 to i64*
-  %NullCheck170 = icmp ne i64* %409, null
-  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+  %NullCheck169 = icmp eq i64* %409, null
+  br i1 %NullCheck169, label %ThrowNullRef170, label %410
 
 ; <label>:410                                     ; preds = %407
   store i64 %408, i64* %409, align 8
@@ -1437,14 +1519,14 @@ entry:
   %425 = load i8*, i8** %arg0
   %426 = load i8*, i8** %arg1
   %427 = bitcast i8* %426 to i64*
-  %NullCheck148 = icmp ne i64* %427, null
-  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+  %NullCheck147 = icmp eq i64* %427, null
+  br i1 %NullCheck147, label %ThrowNullRef148, label %428
 
 ; <label>:428                                     ; preds = %424
   %429 = load i64, i64* %427, align 8
   %430 = bitcast i8* %425 to i64*
-  %NullCheck150 = icmp ne i64* %430, null
-  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+  %NullCheck149 = icmp eq i64* %430, null
+  br i1 %NullCheck149, label %ThrowNullRef150, label %431
 
 ; <label>:431                                     ; preds = %428
   store i64 %429, i64* %430, align 8
@@ -1466,14 +1548,14 @@ entry:
   %441 = load i8*, i8** %arg0
   %442 = load i8*, i8** %arg1
   %443 = bitcast i8* %442 to i32*
-  %NullCheck152 = icmp ne i32* %443, null
-  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+  %NullCheck151 = icmp eq i32* %443, null
+  br i1 %NullCheck151, label %ThrowNullRef152, label %444
 
 ; <label>:444                                     ; preds = %440
   %445 = load i32, i32* %443, align 8
   %446 = bitcast i8* %441 to i32*
-  %NullCheck154 = icmp ne i32* %446, null
-  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+  %NullCheck153 = icmp eq i32* %446, null
+  br i1 %NullCheck153, label %ThrowNullRef154, label %447
 
 ; <label>:447                                     ; preds = %444
   store i32 %445, i32* %446, align 8
@@ -1495,16 +1577,16 @@ entry:
   %457 = load i8*, i8** %arg0
   %458 = load i8*, i8** %arg1
   %459 = bitcast i8* %458 to i16*
-  %NullCheck156 = icmp ne i16* %459, null
-  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+  %NullCheck155 = icmp eq i16* %459, null
+  br i1 %NullCheck155, label %ThrowNullRef156, label %460
 
 ; <label>:460                                     ; preds = %456
   %461 = load i16, i16* %459, align 8
   %462 = sext i16 %461 to i32
   %463 = bitcast i8* %457 to i16*
   %464 = trunc i32 %462 to i16
-  %NullCheck158 = icmp ne i16* %463, null
-  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+  %NullCheck157 = icmp eq i16* %463, null
+  br i1 %NullCheck157, label %ThrowNullRef158, label %465
 
 ; <label>:465                                     ; preds = %460
   store i16 %464, i16* %463, align 8
@@ -1525,15 +1607,15 @@ entry:
 ; <label>:474                                     ; preds = %470
   %475 = load i8*, i8** %arg0
   %476 = load i8*, i8** %arg1
-  %NullCheck160 = icmp ne i8* %476, null
-  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+  %NullCheck159 = icmp eq i8* %476, null
+  br i1 %NullCheck159, label %ThrowNullRef160, label %477
 
 ; <label>:477                                     ; preds = %474
   %478 = load i8, i8* %476, align 8
   %479 = zext i8 %478 to i32
   %480 = trunc i32 %479 to i8
-  %NullCheck162 = icmp ne i8* %475, null
-  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+  %NullCheck161 = icmp eq i8* %475, null
+  br i1 %NullCheck161, label %ThrowNullRef162, label %481
 
 ; <label>:481                                     ; preds = %477
   store i8 %480, i8* %475, align 8
@@ -1553,343 +1635,343 @@ ThrowNullRef:                                     ; preds = %308
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %312
+ThrowNullRef2:                                    ; preds = %312
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %315
+ThrowNullRef4:                                    ; preds = %315
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %321
+ThrowNullRef6:                                    ; preds = %321
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %271
+ThrowNullRef8:                                    ; preds = %271
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %275
+ThrowNullRef10:                                   ; preds = %275
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %278
+ThrowNullRef12:                                   ; preds = %278
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %284
+ThrowNullRef14:                                   ; preds = %284
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %287
+ThrowNullRef16:                                   ; preds = %287
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %293
+ThrowNullRef18:                                   ; preds = %293
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %298
+ThrowNullRef20:                                   ; preds = %298
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %303
+ThrowNullRef22:                                   ; preds = %303
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %243
+ThrowNullRef24:                                   ; preds = %243
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %247
+ThrowNullRef26:                                   ; preds = %247
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %250
+ThrowNullRef28:                                   ; preds = %250
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %256
+ThrowNullRef30:                                   ; preds = %256
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %259
+ThrowNullRef32:                                   ; preds = %259
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %265
+ThrowNullRef34:                                   ; preds = %265
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %217
+ThrowNullRef36:                                   ; preds = %217
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %221
+ThrowNullRef38:                                   ; preds = %221
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %224
+ThrowNullRef40:                                   ; preds = %224
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %230
+ThrowNullRef42:                                   ; preds = %230
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %233
+ThrowNullRef44:                                   ; preds = %233
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %238
+ThrowNullRef46:                                   ; preds = %238
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %200
+ThrowNullRef48:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %204
+ThrowNullRef50:                                   ; preds = %204
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %207
+ThrowNullRef52:                                   ; preds = %207
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %213
+ThrowNullRef54:                                   ; preds = %213
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %172
+ThrowNullRef56:                                   ; preds = %172
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %176
+ThrowNullRef58:                                   ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %179
+ThrowNullRef60:                                   ; preds = %179
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %185
+ThrowNullRef62:                                   ; preds = %185
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %190
+ThrowNullRef64:                                   ; preds = %190
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %195
+ThrowNullRef66:                                   ; preds = %195
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %153
+ThrowNullRef68:                                   ; preds = %153
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %157
+ThrowNullRef70:                                   ; preds = %157
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %160
+ThrowNullRef72:                                   ; preds = %160
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %166
+ThrowNullRef74:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %136
+ThrowNullRef76:                                   ; preds = %136
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %140
+ThrowNullRef78:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %143
+ThrowNullRef80:                                   ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %148
+ThrowNullRef82:                                   ; preds = %148
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %128
+ThrowNullRef84:                                   ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %132
+ThrowNullRef86:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %100
+ThrowNullRef88:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %104
+ThrowNullRef90:                                   ; preds = %104
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %107
+ThrowNullRef92:                                   ; preds = %107
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %113
+ThrowNullRef94:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %118
+ThrowNullRef96:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %123
+ThrowNullRef98:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %81
+ThrowNullRef100:                                  ; preds = %81
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef101:                                  ; preds = %85
+ThrowNullRef102:                                  ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef103:                                  ; preds = %88
+ThrowNullRef104:                                  ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef105:                                  ; preds = %94
+ThrowNullRef106:                                  ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef107:                                  ; preds = %64
+ThrowNullRef108:                                  ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef109:                                  ; preds = %68
+ThrowNullRef110:                                  ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef111:                                  ; preds = %71
+ThrowNullRef112:                                  ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef113:                                  ; preds = %76
+ThrowNullRef114:                                  ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef115:                                  ; preds = %56
+ThrowNullRef116:                                  ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef117:                                  ; preds = %60
+ThrowNullRef118:                                  ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef119:                                  ; preds = %37
+ThrowNullRef120:                                  ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef121:                                  ; preds = %41
+ThrowNullRef122:                                  ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef123:                                  ; preds = %46
+ThrowNullRef124:                                  ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef125:                                  ; preds = %51
+ThrowNullRef126:                                  ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef127:                                  ; preds = %27
+ThrowNullRef128:                                  ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef129:                                  ; preds = %31
+ThrowNullRef130:                                  ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef131:                                  ; preds = %19
+ThrowNullRef132:                                  ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef133:                                  ; preds = %22
+ThrowNullRef134:                                  ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef135:                                  ; preds = %338
+ThrowNullRef136:                                  ; preds = %338
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef137:                                  ; preds = %341
+ThrowNullRef138:                                  ; preds = %341
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef139:                                  ; preds = %356
+ThrowNullRef140:                                  ; preds = %356
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef141:                                  ; preds = %360
+ThrowNullRef142:                                  ; preds = %360
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef143:                                  ; preds = %377
+ThrowNullRef144:                                  ; preds = %377
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef145:                                  ; preds = %381
+ThrowNullRef146:                                  ; preds = %381
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef147:                                  ; preds = %424
+ThrowNullRef148:                                  ; preds = %424
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef149:                                  ; preds = %428
+ThrowNullRef150:                                  ; preds = %428
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef151:                                  ; preds = %440
+ThrowNullRef152:                                  ; preds = %440
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef153:                                  ; preds = %444
+ThrowNullRef154:                                  ; preds = %444
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef155:                                  ; preds = %456
+ThrowNullRef156:                                  ; preds = %456
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef157:                                  ; preds = %460
+ThrowNullRef158:                                  ; preds = %460
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef159:                                  ; preds = %474
+ThrowNullRef160:                                  ; preds = %474
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef161:                                  ; preds = %477
+ThrowNullRef162:                                  ; preds = %477
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef163:                                  ; preds = %394
+ThrowNullRef164:                                  ; preds = %394
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef165:                                  ; preds = %398
+ThrowNullRef166:                                  ; preds = %398
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef167:                                  ; preds = %401
+ThrowNullRef168:                                  ; preds = %401
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef169:                                  ; preds = %407
+ThrowNullRef170:                                  ; preds = %407
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1939,8 +2021,8 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
-  br i1 %NullCheck, label %22, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %ThrowNullRef, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
@@ -1948,8 +2030,8 @@ entry:
   store i32 %24, i32* %loc0
   %25 = load i32, i32* %loc0
   %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %26, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %27
 
 ; <label>:27                                      ; preds = %22
   %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
@@ -1971,7 +2053,7 @@ ThrowNullRef:                                     ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1989,8 +2071,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -2022,15 +2104,15 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2048,16 +2130,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
   %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
   store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %15
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
@@ -2072,8 +2154,8 @@ entry:
   %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
   %29 = ptrtoint i16 addrspace(1)* %28 to i64
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %19
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
@@ -2089,19 +2171,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2114,8 +2196,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
@@ -2128,7 +2210,7 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[loadElem]
+Failed to read AppDomain.PrepareDataForSetup[storeElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
@@ -2202,8 +2284,8 @@ entry:
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
-  br i1 %NullCheck24, label %27, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = load i64, i64 addrspace(1)* %26
@@ -2218,8 +2300,8 @@ entry:
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
-  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
   %41 = load i64, i64 addrspace(1)* %39
@@ -2236,8 +2318,8 @@ entry:
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
-  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
   %54 = load i64, i64 addrspace(1)* %52
@@ -2252,8 +2334,8 @@ entry:
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
   %67 = load i64, i64 addrspace(1)* %65
@@ -2270,8 +2352,8 @@ entry:
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
-  br i1 %NullCheck16, label %79, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
   %80 = load i64, i64 addrspace(1)* %78
@@ -2286,8 +2368,8 @@ entry:
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
-  br i1 %NullCheck18, label %92, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
   %93 = load i64, i64 addrspace(1)* %91
@@ -2304,8 +2386,8 @@ entry:
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
-  br i1 %NullCheck12, label %105, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = load i64, i64 addrspace(1)* %104
@@ -2320,8 +2402,8 @@ entry:
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
-  br i1 %NullCheck14, label %118, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
   %119 = load i64, i64 addrspace(1)* %117
@@ -2337,8 +2419,8 @@ entry:
 
 ; <label>:128                                     ; preds = %20
   %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
-  br i1 %NullCheck4, label %130, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %129, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %130
 
 ; <label>:130                                     ; preds = %128
   %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
@@ -2346,8 +2428,8 @@ entry:
   %133 = load i16, i16 addrspace(1)* %132, align 8
   %134 = zext i16 %133 to i32
   %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
-  br i1 %NullCheck6, label %136, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %135, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %136
 
 ; <label>:136                                     ; preds = %130
   %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
@@ -2360,8 +2442,8 @@ entry:
 
 ; <label>:143                                     ; preds = %136
   %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
-  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %144, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %145
 
 ; <label>:145                                     ; preds = %143
   %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
@@ -2369,8 +2451,8 @@ entry:
   %148 = load i16, i16 addrspace(1)* %147, align 8
   %149 = zext i16 %148 to i32
   %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %150, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %151
 
 ; <label>:151                                     ; preds = %145
   %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
@@ -2388,8 +2470,8 @@ entry:
 
 ; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
-  br i1 %NullCheck, label %163, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %ThrowNullRef, label %163
 
 ; <label>:163                                     ; preds = %161
   %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
@@ -2399,8 +2481,8 @@ entry:
 
 ; <label>:167                                     ; preds = %163
   %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
-  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %168, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %169
 
 ; <label>:169                                     ; preds = %167
   %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
@@ -2432,55 +2514,55 @@ ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %167
+ThrowNullRef2:                                    ; preds = %167
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %128
+ThrowNullRef4:                                    ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %130
+ThrowNullRef6:                                    ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %143
+ThrowNullRef8:                                    ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %145
+ThrowNullRef10:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %102
+ThrowNullRef12:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %105
+ThrowNullRef14:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %76
+ThrowNullRef16:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %79
+ThrowNullRef18:                                   ; preds = %79
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %50
+ThrowNullRef20:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %53
+ThrowNullRef22:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %24
+ThrowNullRef24:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %27
+ThrowNullRef26:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2503,15 +2585,15 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2519,16 +2601,16 @@ entry:
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
   store i32 %8, i32* %loc0
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
   %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
   store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
@@ -2546,16 +2628,16 @@ entry:
 
 ; <label>:23                                      ; preds = %64
   %24 = load i16*, i16** %loc3
-  %NullCheck12 = icmp ne i16* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i16* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
   store i32 %27, i32* %loc5
   %28 = load i16*, i16** %loc4
-  %NullCheck14 = icmp ne i16* %28, null
-  br i1 %NullCheck14, label %29, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %28, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = load i16, i16* %28, align 8
@@ -2620,15 +2702,15 @@ entry:
 
 ; <label>:67                                      ; preds = %64
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
-  br i1 %NullCheck8, label %69, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %68, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %69
 
 ; <label>:69                                      ; preds = %67
   %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
   %71 = load i32, i32 addrspace(1)* %70
   %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
-  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %73
 
 ; <label>:73                                      ; preds = %69
   %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
@@ -2645,31 +2727,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %67
+ThrowNullRef8:                                    ; preds = %67
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %69
+ThrowNullRef10:                                   ; preds = %69
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2710,14 +2792,14 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
   %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
@@ -2730,14 +2812,14 @@ entry:
 
 ; <label>:11                                      ; preds = %4
   %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
   %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
@@ -2749,14 +2831,14 @@ entry:
 
 ; <label>:22                                      ; preds = %16
   %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
   %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
-  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
-  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
@@ -2804,23 +2886,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2836,7 +2918,280 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[loadElem]
+Successfully read RuntimeType.IsAssignableFrom
+
+define i8 @RuntimeType.IsAssignableFrom(%System.RuntimeType addrspace(1)* %param0, %System.Type addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.RuntimeType addrspace(1)*
+  %arg1 = alloca %System.Type addrspace(1)*
+  %loc0 = alloca %System.RuntimeType addrspace(1)*
+  %loc1 = alloca %"System.Type[]" addrspace(1)*
+  %loc2 = alloca i32
+  store %System.RuntimeType addrspace(1)* %param0, %System.RuntimeType addrspace(1)** %this
+  store %System.Type addrspace(1)* %param1, %System.Type addrspace(1)** %arg1
+  %0 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %1 = icmp ne %System.Type addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i8 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %5 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %6 = bitcast %System.Type addrspace(1)* %4 to %System.Object addrspace(1)*
+  %7 = bitcast %System.RuntimeType addrspace(1)* %5 to %System.Object addrspace(1)*
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %6, %System.Object addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %3
+  ret i8 1
+
+; <label>:12                                      ; preds = %3
+  %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 152
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 32
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
+  %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
+  %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
+  store %System.RuntimeType addrspace(1)* %25, %System.RuntimeType addrspace(1)** %loc0
+  %26 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %27 = icmp eq %System.RuntimeType addrspace(1)* %26, null
+  br i1 %27, label %34, label %28
+
+; <label>:28                                      ; preds = %15
+  %29 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %30 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)*)*)(%System.RuntimeType addrspace(1)* %29, %System.RuntimeType addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+; <label>:34                                      ; preds = %15
+  %35 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %36 = call %System.Reflection.Emit.TypeBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Reflection.Emit.TypeBuilder addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %35)
+  %37 = icmp eq %System.Reflection.Emit.TypeBuilder addrspace(1)* %36, null
+  br i1 %37, label %139, label %38
+
+; <label>:38                                      ; preds = %34
+  %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %42
+
+; <label>:42                                      ; preds = %38
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 152
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 40
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
+  %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
+  %53 = zext i8 %52 to i32
+  %54 = icmp eq i32 %53, 0
+  br i1 %54, label %56, label %55
+
+; <label>:55                                      ; preds = %42
+  ret i8 1
+
+; <label>:56                                      ; preds = %42
+  %57 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %58 = bitcast %System.RuntimeType addrspace(1)* %57 to %System.Type addrspace(1)*
+  %59 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %58)
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %64 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.Type addrspace(1)* %63, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = bitcast %System.RuntimeType addrspace(1)* %64 to %System.Type addrspace(1)*
+  %67 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %63, %System.Type addrspace(1)* %66)
+  %68 = zext i8 %67 to i32
+  %69 = trunc i32 %68 to i8
+  ret i8 %69
+
+; <label>:70                                      ; preds = %56
+  %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
+  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %73
+
+; <label>:73                                      ; preds = %70
+  %74 = load i64, i64 addrspace(1)* %72
+  %75 = add i64 %74, 128
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = add i64 %77, 0
+  %79 = inttoptr i64 %78 to i64*
+  %80 = load i64, i64* %79
+  %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
+  %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
+  %83 = call i8 %82(%System.Type addrspace(1)* %81)
+  %84 = zext i8 %83 to i32
+  %85 = icmp eq i32 %84, 0
+  br i1 %85, label %139, label %86
+
+; <label>:86                                      ; preds = %73
+  %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
+  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %89
+
+; <label>:89                                      ; preds = %86
+  %90 = load i64, i64 addrspace(1)* %88
+  %91 = add i64 %90, 128
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = add i64 %93, 24
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
+  %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
+  %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
+  store %"System.Type[]" addrspace(1)* %99, %"System.Type[]" addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %129
+
+; <label>:100                                     ; preds = %132
+  %101 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %102 = load i32, i32* %loc2
+  %NullCheck11 = icmp eq %"System.Type[]" addrspace(1)* %101, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %103
+
+; <label>:103                                     ; preds = %100
+  %104 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 1
+  %105 = load i32, i32 addrspace(1)* %104
+  %106 = zext i32 %105 to i64
+  %107 = zext i32 %102 to i64
+  %BoundsCheck = icmp uge i64 %107, %106
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %108
+
+; <label>:108                                     ; preds = %103
+  %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
+  %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
+  %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
+  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %113
+
+; <label>:113                                     ; preds = %108
+  %114 = load i64, i64 addrspace(1)* %112
+  %115 = add i64 %114, 152
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = add i64 %117, 56
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
+  %123 = zext i8 %122 to i32
+  %124 = icmp ne i32 %123, 0
+  br i1 %124, label %126, label %125
+
+; <label>:125                                     ; preds = %113
+  ret i8 0
+
+; <label>:126                                     ; preds = %113
+  %127 = load i32, i32* %loc2
+  %128 = add i32 %127, 1
+  store i32 %128, i32* %loc2
+  br label %129
+
+; <label>:129                                     ; preds = %89, %126
+  %130 = load i32, i32* %loc2
+  %131 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %NullCheck9 = icmp eq %"System.Type[]" addrspace(1)* %131, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %132
+
+; <label>:132                                     ; preds = %129
+  %133 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %131, i32 0, i32 1
+  %134 = load i32, i32 addrspace(1)* %133
+  %135 = zext i32 %134 to i64
+  %136 = trunc i64 %135 to i32
+  %137 = icmp slt i32 %130, %136
+  br i1 %137, label %100, label %138
+
+; <label>:138                                     ; preds = %132
+  ret i8 1
+
+; <label>:139                                     ; preds = %34, %73
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %129
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %103
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -2893,7 +3248,7 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElem]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -2904,8 +3259,8 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -2997,8 +3352,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
@@ -3059,8 +3414,8 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -3087,8 +3442,8 @@ entry:
 
 ; <label>:17                                      ; preds = %5, %11
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
@@ -3097,8 +3452,8 @@ entry:
 
 ; <label>:22                                      ; preds = %1, %11
   %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
@@ -3109,11 +3464,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %17
+ThrowNullRef2:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %22
+ThrowNullRef4:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3167,15 +3522,15 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
   %15 = load i32, i32 addrspace(1)* %14
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
@@ -3198,7 +3553,7 @@ ThrowNullRef:                                     ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef2:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3232,8 +3587,8 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
@@ -3312,8 +3667,8 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -3327,8 +3682,8 @@ entry:
 ; <label>:5                                       ; preds = %43
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %7 = load i32, i32* %loc1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck6, label %8, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
@@ -3366,8 +3721,8 @@ entry:
 ; <label>:32                                      ; preds = %21, %25
   %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
   %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
-  br i1 %NullCheck8, label %35, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = trunc i32 %34 to i16
@@ -3380,8 +3735,8 @@ entry:
 ; <label>:40                                      ; preds = %1, %35
   %41 = load i32, i32* %loc1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
-  br i1 %NullCheck2, label %43, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %42, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
@@ -3392,8 +3747,8 @@ entry:
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
   %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
-  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
   %51 = load i64, i64 addrspace(1)* %49
@@ -3412,19 +3767,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %40
+ThrowNullRef2:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %47
+ThrowNullRef4:                                    ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %5
+ThrowNullRef6:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %32
+ThrowNullRef8:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3467,8 +3822,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
@@ -3492,11 +3847,391 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(i16* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store i16* %param0, i16** %arg0
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load i32, i32* %arg3
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %42, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %37, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg2
+  %13 = load i32, i32* %arg3
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %37, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %24 = load i32, i32* %arg2
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load i16*, i16** %arg0
+  %35 = load i32, i32* %arg3
+  %36 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %36, i16* %34, i32 %35)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:37                                      ; preds = %5, %16
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %39)
+  %41 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41, %System.String addrspace(1)* %38, %System.String addrspace(1)* %40)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41) #0
+  unreachable
+
+; <label>:42                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
-Failed to read StringBuilder.ToString[loadElemA]
+Successfully read StringBuilder.ToString
+
+define %System.String addrspace(1)* @StringBuilder.ToString(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i16*
+  %loc3 = alloca %"System.Char[]" addrspace(1)*
+  %loc4 = alloca i32
+  %loc5 = alloca i32
+  %loc6 = alloca i16 addrspace(1)*
+  %loc7 = alloca %System.String addrspace(1)*
+  %loc8 = alloca %"System.Char[]" addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %0)
+  %2 = icmp ne i32 %1, 0
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %4
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %6)
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %7)
+  store %System.String addrspace(1)* %8, %System.String addrspace(1)** %loc0
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.Text.StringBuilder addrspace(1)* %9, %System.Text.StringBuilder addrspace(1)** %loc1
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  store %System.String addrspace(1)* %10, %System.String addrspace(1)** %loc7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc7
+  %12 = ptrtoint %System.String addrspace(1)* %11 to i64
+  %13 = icmp eq i64 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %5
+  %15 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %16 = sext i32 %15 to i64
+  %17 = add i64 %12, %16
+  br label %18
+
+; <label>:18                                      ; preds = %5, %14
+  %19 = phi i64 [ %12, %5 ], [ %17, %14 ]
+  %20 = inttoptr i64 %19 to i16*
+  store i16* %20, i16** %loc2
+  br label %21
+
+; <label>:21                                      ; preds = %98, %18
+  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %22, null
+  br i1 %NullCheck, label %ThrowNullRef, label %23
+
+; <label>:23                                      ; preds = %21
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 3
+  %25 = load i32, i32 addrspace(1)* %24, align 8
+  %26 = icmp sle i32 %25, 0
+  br i1 %26, label %96, label %27
+
+; <label>:27                                      ; preds = %23
+  %28 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %28, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %29
+
+; <label>:29                                      ; preds = %27
+  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %28, i32 0, i32 1
+  %31 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %30, align 8
+  store %"System.Char[]" addrspace(1)* %31, %"System.Char[]" addrspace(1)** %loc3
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %33
+
+; <label>:33                                      ; preds = %29
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  store i32 %35, i32* %loc4
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  %39 = load i32, i32 addrspace(1)* %38, align 8
+  store i32 %39, i32* %loc5
+  %40 = load i32, i32* %loc5
+  %41 = load i32, i32* %loc4
+  %42 = add i32 %40, %41
+  %43 = zext i32 %42 to i64
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %45
+
+; <label>:45                                      ; preds = %37
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = sext i32 %47 to i64
+  %49 = icmp sgt i64 %43, %48
+  br i1 %49, label %91, label %50
+
+; <label>:50                                      ; preds = %45
+  %51 = load i32, i32* %loc5
+  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %52, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %53
+
+; <label>:53                                      ; preds = %50
+  %54 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %52, i32 0, i32 1
+  %55 = load i32, i32 addrspace(1)* %54
+  %56 = zext i32 %55 to i64
+  %57 = trunc i64 %56 to i32
+  %58 = icmp ugt i32 %51, %57
+  br i1 %58, label %91, label %59
+
+; <label>:59                                      ; preds = %53
+  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  store %"System.Char[]" addrspace(1)* %60, %"System.Char[]" addrspace(1)** %loc8
+  %61 = icmp eq %"System.Char[]" addrspace(1)* %60, null
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %63, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %64
+
+; <label>:64                                      ; preds = %62
+  %65 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %63, i32 0, i32 1
+  %66 = load i32, i32 addrspace(1)* %65
+  %67 = zext i32 %66 to i64
+  %68 = trunc i64 %67 to i32
+  %69 = icmp ne i32 %68, 0
+  br i1 %69, label %71, label %70
+
+; <label>:70                                      ; preds = %59, %64
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:71                                      ; preds = %64
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %73
+
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %BoundsCheck = icmp uge i64 0, %76
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %77
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %78, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:79                                      ; preds = %70, %77
+  %80 = load i16*, i16** %loc2
+  %81 = load i32, i32* %loc4
+  %82 = sext i32 %81 to i64
+  %83 = mul i64 %82, 2
+  %84 = bitcast i16* %80 to i8*
+  %85 = getelementptr inbounds i8, i8* %84, i64 %83
+  %86 = load i16 addrspace(1)*, i16 addrspace(1)** %loc6
+  %87 = ptrtoint i16 addrspace(1)* %86 to i64
+  %88 = load i32, i32* %loc5
+  %89 = bitcast i8* %85 to i16*
+  %90 = inttoptr i64 %87 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %89, i16* %90, i32 %88)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %96
+
+; <label>:91                                      ; preds = %45, %53
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %94 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %93)
+  %95 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95, %System.String addrspace(1)* %92, %System.String addrspace(1)* %94)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95) #0
+  unreachable
+
+; <label>:96                                      ; preds = %23, %79
+  %97 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %97, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %98
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %97, i32 0, i32 2
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  store %System.Text.StringBuilder addrspace(1)* %100, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %102 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %102, label %21, label %103
+
+; <label>:103                                     ; preds = %98
+  store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc7
+  %104 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  ret %System.String addrspace(1)* %104
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method StringBuilder::get_Length using LLILCJit
+Successfully read StringBuilder.get_Length
+
+define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
+Successfully read RuntimeHelpers.get_OffsetToStringData
+
+define i32 @RuntimeHelpers.get_OffsetToStringData() {
+entry:
+  ret i32 12
+}
+
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
 Successfully read CultureData.CreateCultureData
 
@@ -3514,23 +4249,23 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
   store i8 %4, i8 addrspace(1)* %6
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
@@ -3549,11 +4284,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3566,50 +4301,50 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
   store i32 -1, i32 addrspace(1)* %2
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
   store i32 -1, i32 addrspace(1)* %8
   %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
   store i32 -1, i32 addrspace(1)* %14
   %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
   store i32 -1, i32 addrspace(1)* %17
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
@@ -3623,27 +4358,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3675,7 +4410,136 @@ Failed to read Dictionary`2.Insert[non-const derefAddress]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
 Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
-Failed to read HashHelpers.GetPrime[loadElem]
+Successfully read HashHelpers.GetPrime
+
+define i32 @HashHelpers.GetPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %6, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5, %System.String addrspace(1)* %4)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5) #0
+  unreachable
+
+; <label>:6                                       ; preds = %entry
+  store i32 0, i32* %loc0
+  br label %29
+
+; <label>:7                                       ; preds = %35
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 1296
+  %10 = addrspacecast i8 addrspace(1)* %9 to %"System.Int32[]" addrspace(1)**
+  %11 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %10
+  %12 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Int32[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = zext i32 %15 to i64
+  %17 = zext i32 %12 to i64
+  %BoundsCheck = icmp uge i64 %17, %16
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 3, i32 %12
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  store i32 %20, i32* %loc1
+  %21 = load i32, i32* %loc1
+  %22 = load i32, i32* %arg0
+  %23 = icmp slt i32 %21, %22
+  br i1 %23, label %26, label %24
+
+; <label>:24                                      ; preds = %18
+  %25 = load i32, i32* %loc1
+  ret i32 %25
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %loc0
+  %28 = add i32 %27, 1
+  store i32 %28, i32* %loc0
+  br label %29
+
+; <label>:29                                      ; preds = %6, %26
+  %30 = load i32, i32* %loc0
+  %31 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %32 = getelementptr inbounds i8, i8 addrspace(1)* %31, i64 1296
+  %33 = addrspacecast i8 addrspace(1)* %32 to %"System.Int32[]" addrspace(1)**
+  %34 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %33
+  %NullCheck = icmp eq %"System.Int32[]" addrspace(1)* %34, null
+  br i1 %NullCheck, label %ThrowNullRef, label %35
+
+; <label>:35                                      ; preds = %29
+  %36 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %34, i32 0, i32 1
+  %37 = load i32, i32 addrspace(1)* %36
+  %38 = zext i32 %37 to i64
+  %39 = trunc i64 %38 to i32
+  %40 = icmp slt i32 %30, %39
+  br i1 %40, label %7, label %41
+
+; <label>:41                                      ; preds = %35
+  %42 = load i32, i32* %arg0
+  %43 = or i32 %42, 1
+  store i32 %43, i32* %loc2
+  br label %59
+
+; <label>:44                                      ; preds = %59
+  %45 = load i32, i32* %loc2
+  %46 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %45)
+  %47 = zext i8 %46 to i32
+  %48 = icmp eq i32 %47, 0
+  br i1 %48, label %56, label %49
+
+; <label>:49                                      ; preds = %44
+  %50 = load i32, i32* %loc2
+  %51 = sub i32 %50, 1
+  %52 = srem i32 %51, 101
+  %53 = icmp eq i32 %52, 0
+  br i1 %53, label %56, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = load i32, i32* %loc2
+  ret i32 %55
+
+; <label>:56                                      ; preds = %44, %49
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %57, 2
+  store i32 %58, i32* %loc2
+  br label %59
+
+; <label>:59                                      ; preds = %41, %56
+  %60 = load i32, i32* %loc2
+  %61 = icmp slt i32 %60, 2147483647
+  br i1 %61, label %44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load i32, i32* %arg0
+  ret i32 %63
+
+ThrowNullRef:                                     ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
 Successfully read GenericEqualityComparer`1.GetHashCode
 
@@ -3694,14 +4558,14 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
   %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load i64, i64 addrspace(1)* %7
@@ -3720,7 +4584,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3750,8 +4614,8 @@ entry:
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
@@ -3796,8 +4660,8 @@ entry:
   %35 = bitcast i16* %34 to i8*
   %36 = getelementptr inbounds i8, i8* %35, i64 2
   %37 = bitcast i8* %36 to i16*
-  %NullCheck4 = icmp ne i16* %37, null
-  br i1 %NullCheck4, label %38, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %37, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %38
 
 ; <label>:38                                      ; preds = %27
   %39 = load i16, i16* %37, align 8
@@ -3824,8 +4688,8 @@ entry:
 
 ; <label>:54                                      ; preds = %22, %43
   %55 = load i16*, i16** %loc4
-  %NullCheck2 = icmp ne i16* %55, null
-  br i1 %NullCheck2, label %56, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i16* %55, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %56
 
 ; <label>:56                                      ; preds = %54
   %57 = load i16, i16* %55, align 8
@@ -3850,11 +4714,11 @@ ThrowNullRef:                                     ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %54
+ThrowNullRef2:                                    ; preds = %54
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %27
+ThrowNullRef4:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3871,8 +4735,8 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -3907,8 +4771,8 @@ entry:
 
 ; <label>:26                                      ; preds = %19
   %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
-  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %28
 
 ; <label>:28                                      ; preds = %26
   %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
@@ -3920,7 +4784,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3972,8 +4836,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
@@ -3984,26 +4848,26 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
-  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
@@ -4014,8 +4878,8 @@ entry:
 ; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
@@ -4024,8 +4888,8 @@ entry:
 
 ; <label>:25                                      ; preds = %1, %16, %23
   %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
-  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
@@ -4036,27 +4900,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %20
+ThrowNullRef10:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4069,8 +4933,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -4081,8 +4945,8 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
@@ -4091,8 +4955,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1, %8
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
@@ -4103,11 +4967,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4128,24 +4992,24 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   store i32 %3, i32* %loc0
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
   %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
   store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck4, label %9, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
@@ -4164,15 +5028,15 @@ entry:
 ; <label>:18                                      ; preds = %70
   %19 = load i16*, i16** %loc3
   %20 = bitcast i16* %19 to i64*
-  %NullCheck10 = icmp ne i64* %20, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %20, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = load i64, i64* %20, align 8
   %23 = load i16*, i16** %loc4
   %24 = bitcast i16* %23 to i64*
-  %NullCheck12 = icmp ne i64* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = load i64, i64* %24, align 8
@@ -4188,8 +5052,8 @@ entry:
   %31 = bitcast i16* %30 to i8*
   %32 = getelementptr inbounds i8, i8* %31, i64 8
   %33 = bitcast i8* %32 to i64*
-  %NullCheck14 = icmp ne i64* %33, null
-  br i1 %NullCheck14, label %34, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = load i64, i64* %33, align 8
@@ -4197,8 +5061,8 @@ entry:
   %37 = bitcast i16* %36 to i8*
   %38 = getelementptr inbounds i8, i8* %37, i64 8
   %39 = bitcast i8* %38 to i64*
-  %NullCheck16 = icmp ne i64* %39, null
-  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %40
 
 ; <label>:40                                      ; preds = %34
   %41 = load i64, i64* %39, align 8
@@ -4214,8 +5078,8 @@ entry:
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %NullCheck18 = icmp ne i64* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = load i64, i64* %48, align 8
@@ -4223,8 +5087,8 @@ entry:
   %52 = bitcast i16* %51 to i8*
   %53 = getelementptr inbounds i8, i8* %52, i64 16
   %54 = bitcast i8* %53 to i64*
-  %NullCheck20 = icmp ne i64* %54, null
-  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64* %54, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %55
 
 ; <label>:55                                      ; preds = %49
   %56 = load i64, i64* %54, align 8
@@ -4262,15 +5126,15 @@ entry:
 ; <label>:74                                      ; preds = %95
   %75 = load i16*, i16** %loc3
   %76 = bitcast i16* %75 to i32*
-  %NullCheck6 = icmp ne i32* %76, null
-  br i1 %NullCheck6, label %77, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32* %76, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %77
 
 ; <label>:77                                      ; preds = %74
   %78 = load i32, i32* %76, align 8
   %79 = load i16*, i16** %loc4
   %80 = bitcast i16* %79 to i32*
-  %NullCheck8 = icmp ne i32* %80, null
-  br i1 %NullCheck8, label %81, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i32* %80, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %81
 
 ; <label>:81                                      ; preds = %77
   %82 = load i32, i32* %80, align 8
@@ -4318,43 +5182,43 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %74
+ThrowNullRef6:                                    ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %77
+ThrowNullRef8:                                    ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %29
+ThrowNullRef14:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %34
+ThrowNullRef16:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4376,8 +5240,8 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load i64, i64 addrspace(1)* %4
@@ -4389,8 +5253,8 @@ entry:
   %12 = load i64, i64* %11
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %5
   %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
@@ -4399,8 +5263,8 @@ entry:
   %18 = load i8, i8* %arg2
   %19 = zext i8 %18 to i32
   %20 = trunc i32 %19 to i8
-  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %15
   %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
@@ -4411,11 +5275,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4442,8 +5306,8 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
@@ -4466,16 +5330,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
   %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = load i64, i64 addrspace(1)* %19
@@ -4500,8 +5364,8 @@ entry:
 ; <label>:35                                      ; preds = %30
   %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
@@ -4514,8 +5378,8 @@ entry:
 
 ; <label>:42                                      ; preds = %1, %38
   %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
-  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
@@ -4526,19 +5390,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %35
+ThrowNullRef2:                                    ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %42
+ThrowNullRef8:                                    ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4551,14 +5415,14 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
@@ -4570,7 +5434,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4583,8 +5447,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
@@ -4613,51 +5477,51 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
   %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
   %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
   %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
   %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
-  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
   store i64 %21, i64 addrspace(1)* %23
   %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %25 = load i64, i64* %loc0
-  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
@@ -4668,27 +5532,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %22
+ThrowNullRef12:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4701,8 +5565,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
@@ -4713,19 +5577,19 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
@@ -4734,8 +5598,8 @@ entry:
 
 ; <label>:15                                      ; preds = %1, %13
   %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
@@ -4746,19 +5610,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %15
+ThrowNullRef8:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4771,8 +5635,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -4831,8 +5695,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
@@ -4882,8 +5746,8 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
-  br i1 %NullCheck, label %17, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %ThrowNullRef, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
@@ -4894,15 +5758,15 @@ entry:
 
 ; <label>:22                                      ; preds = %17
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
-  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
   %26 = load i32, i32 addrspace(1)* %25
   %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
-  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %27, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
@@ -4925,8 +5789,8 @@ entry:
 ; <label>:40                                      ; preds = %17
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
-  br i1 %NullCheck6, label %43, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %41, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
@@ -4938,34 +5802,17 @@ ThrowNullRef:                                     ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %24
+ThrowNullRef4:                                    ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %40
+ThrowNullRef6:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
-}
-
-INFO:  jitting method Object::ReferenceEquals using LLILCJit
-Successfully read Object.ReferenceEquals
-
-define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
-entry:
-  %arg0 = alloca %System.Object addrspace(1)*
-  %arg1 = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
-  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
-  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = icmp eq %System.Object addrspace(1)* %0, %1
-  %3 = sext i1 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
 }
 
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
@@ -4978,21 +5825,21 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
   %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
-  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
@@ -5007,28 +5854,28 @@ entry:
 ; <label>:13                                      ; preds = %8, %12
   %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
   %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
   %21 = load i32, i32 addrspace(1)* %20, align 8
   %22 = add i32 %21, 1
-  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
   store i32 %22, i32 addrspace(1)* %24
   %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
@@ -5039,27 +5886,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5077,7 +5924,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::Setup using LLILCJit
-Failed to read AppDomain.Setup[loadElem]
+Failed to read AppDomain.Setup[unbox]
 INFO:  jitting method Thread::GetDomain using LLILCJit
 Successfully read Thread.GetDomain
 
@@ -5108,8 +5955,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
@@ -5122,14 +5969,14 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
   %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
@@ -5141,11 +5988,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5173,8 +6020,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -5189,7 +6036,328 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
 Failed to read KeyCollection.System.Collections.Generic.IEnumerable<TKey>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Successfully read Enumerator.MoveNext
+
+define i8 @Enumerator.MoveNext(%"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.RuntimeTypeHandle* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*
+  %"$TypeArg" = alloca %System.RuntimeTypeHandle*
+  store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
+  %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 8
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %76, label %12
+
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
+  br label %76
+
+; <label>:13                                      ; preds = %85
+  %14 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck19 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %15
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, i32 0, i32 0
+  %17 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %16, align 8
+  %NullCheck21 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, i32 0, i32 2
+  %20 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %19, align 8
+  %21 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck23 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %22
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, i32 0, i32 2
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %NullCheck25 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 3, i32 %24
+  %NullCheck27 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %32
+
+; <label>:32                                      ; preds = %30
+  %33 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, i32 0, i32 2
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = icmp slt i32 %34, 0
+  br i1 %35, label %68, label %36
+
+; <label>:36                                      ; preds = %32
+  %37 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %38 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck29 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %39
+
+; <label>:39                                      ; preds = %36
+  %40 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, i32 0, i32 0
+  %41 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %40, align 8
+  %NullCheck31 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, i32 0, i32 2
+  %44 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %43, align 8
+  %45 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck33 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, i32 0, i32 2
+  %48 = load i32, i32 addrspace(1)* %47, align 8
+  %NullCheck35 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %49
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = zext i32 %51 to i64
+  %53 = zext i32 %48 to i64
+  %BoundsCheck37 = icmp uge i64 %53, %52
+  br i1 %BoundsCheck37, label %ThrowIndexOutOfRange38, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 3, i32 %48
+  %NullCheck39 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %56
+
+; <label>:56                                      ; preds = %54
+  %57 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, i32 0, i32 0
+  %58 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck41 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %59
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %60, %System.__Canon addrspace(1)* %58)
+  %61 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck43 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  %64 = load i32, i32 addrspace(1)* %63, align 8
+  %65 = add i32 %64, 1
+  %NullCheck45 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  store i32 %65, i32 addrspace(1)* %67
+  ret i8 1
+
+; <label>:68                                      ; preds = %32
+  %69 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck47 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %73 = add i32 %72, 1
+  %NullCheck49 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %74
+
+; <label>:74                                      ; preds = %70
+  %75 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  store i32 %73, i32 addrspace(1)* %75
+  br label %76
+
+; <label>:76                                      ; preds = %8, %12, %74
+  %77 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %78
+
+; <label>:78                                      ; preds = %76
+  %79 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, i32 0, i32 2
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck7 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %82
+
+; <label>:82                                      ; preds = %78
+  %83 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, i32 0, i32 0
+  %84 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %83, align 8
+  %NullCheck9 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %85
+
+; <label>:85                                      ; preds = %82
+  %86 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, i32 0, i32 7
+  %87 = load i32, i32 addrspace(1)* %86, align 8
+  %88 = icmp ult i32 %80, %87
+  br i1 %88, label %13, label %89
+
+; <label>:89                                      ; preds = %85
+  %90 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %91 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck11 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %92
+
+; <label>:92                                      ; preds = %89
+  %93 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, i32 0, i32 0
+  %94 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck13 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %95
+
+; <label>:95                                      ; preds = %92
+  %96 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, i32 0, i32 7
+  %97 = load i32, i32 addrspace(1)* %96, align 8
+  %98 = add i32 %97, 1
+  %NullCheck15 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %99
+
+; <label>:99                                      ; preds = %95
+  %100 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, i32 0, i32 2
+  store i32 %98, i32 addrspace(1)* %100
+  %101 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck17 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %102
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %103, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %92
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef22:                                   ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef24:                                   ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef26:                                   ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef28:                                   ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef30:                                   ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef32:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef34:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef36:                                   ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange38:                           ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef40:                                   ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef42:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef44:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef46:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef48:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef50:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -5200,8 +6368,8 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -5232,9 +6400,9 @@ Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
 Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
-Failed to read String.MakeSeparatorList[loadElemA]
+Failed to read String.MakeSeparatorList[storeElem]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
-Failed to read String.InternalSplitKeepEmptyEntries[loadElem]
+Failed to read String.InternalSplitKeepEmptyEntries[storeElem]
 INFO:  jitting method Path::IsRelative using LLILCJit
 Successfully read Path.IsRelative
 
@@ -5243,8 +6411,8 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -5254,8 +6422,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
@@ -5271,8 +6439,8 @@ entry:
 
 ; <label>:17                                      ; preds = %7
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
@@ -5288,8 +6456,8 @@ entry:
 
 ; <label>:29                                      ; preds = %19
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %31
 
 ; <label>:31                                      ; preds = %29
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
@@ -5300,8 +6468,8 @@ entry:
 
 ; <label>:36                                      ; preds = %31
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
-  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %37, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
@@ -5312,8 +6480,8 @@ entry:
 
 ; <label>:43                                      ; preds = %31, %38
   %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
-  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %45
 
 ; <label>:45                                      ; preds = %43
   %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
@@ -5324,8 +6492,8 @@ entry:
 
 ; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %50
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
@@ -5336,8 +6504,8 @@ entry:
 
 ; <label>:57                                      ; preds = %1, %7, %19, %45, %52
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
-  br i1 %NullCheck14, label %59, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %59
 
 ; <label>:59                                      ; preds = %57
   %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
@@ -5347,8 +6515,8 @@ entry:
 
 ; <label>:63                                      ; preds = %59
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
@@ -5359,8 +6527,8 @@ entry:
 
 ; <label>:70                                      ; preds = %65
   %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
-  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.String addrspace(1)* %71, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %72
 
 ; <label>:72                                      ; preds = %70
   %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
@@ -5379,39 +6547,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %17
+ThrowNullRef4:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %29
+ThrowNullRef6:                                    ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %36
+ThrowNullRef8:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %43
+ThrowNullRef10:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %50
+ThrowNullRef12:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %57
+ThrowNullRef14:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %63
+ThrowNullRef16:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %70
+ThrowNullRef18:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5419,7 +6587,293 @@ ThrowNullRef17:                                   ; preds = %70
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
-Failed to read String.TrimHelper[loadElem]
+Successfully read String.TrimHelper
+
+define %System.String addrspace(1)* @String.TrimHelper(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i16
+  %loc4 = alloca i32
+  %loc5 = alloca i16
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = sub i32 %3, 1
+  store i32 %4, i32* %loc0
+  store i32 0, i32* %loc1
+  %5 = load i32, i32* %arg2
+  %6 = icmp eq i32 %5, 1
+  br i1 %6, label %62, label %7
+
+; <label>:7                                       ; preds = %1
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:8                                       ; preds = %58
+  store i32 0, i32* %loc2
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load i32, i32* %loc1
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2, i32 %10
+  %13 = load i16, i16 addrspace(1)* %12
+  %14 = zext i16 %13 to i32
+  %15 = trunc i32 %14 to i16
+  store i16 %15, i16* %loc3
+  store i32 0, i32* %loc2
+  br label %34
+
+; <label>:16                                      ; preds = %37
+  %17 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %18 = load i32, i32* %loc2
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %17, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %19
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = zext i32 %18 to i64
+  %BoundsCheck = icmp uge i64 %23, %22
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %24
+
+; <label>:24                                      ; preds = %19
+  %25 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 3, i32 %18
+  %26 = load i16, i16 addrspace(1)* %25, align 8
+  %27 = zext i16 %26 to i32
+  %28 = load i16, i16* %loc3
+  %29 = zext i16 %28 to i32
+  %30 = icmp eq i32 %27, %29
+  br i1 %30, label %43, label %31
+
+; <label>:31                                      ; preds = %24
+  %32 = load i32, i32* %loc2
+  %33 = add i32 %32, 1
+  store i32 %33, i32* %loc2
+  br label %34
+
+; <label>:34                                      ; preds = %11, %31
+  %35 = load i32, i32* %loc2
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = icmp slt i32 %35, %41
+  br i1 %42, label %16, label %43
+
+; <label>:43                                      ; preds = %24, %37
+  %44 = load i32, i32* %loc2
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %45, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp eq i32 %44, %50
+  br i1 %51, label %62, label %52
+
+; <label>:52                                      ; preds = %46
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %7, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %57, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %58
+
+; <label>:58                                      ; preds = %55
+  %59 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %60 = load i32, i32 addrspace(1)* %59
+  %61 = icmp slt i32 %56, %60
+  br i1 %61, label %8, label %62
+
+; <label>:62                                      ; preds = %1, %46, %58
+  %63 = load i32, i32* %arg2
+  %64 = icmp eq i32 %63, 0
+  br i1 %64, label %122, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %66, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %67
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %66, i32 0, i32 1
+  %69 = load i32, i32 addrspace(1)* %68
+  %70 = sub i32 %69, 1
+  store i32 %70, i32* %loc0
+  br label %118
+
+; <label>:71                                      ; preds = %118
+  store i32 0, i32* %loc4
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %73 = load i32, i32* %loc0
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %74
+
+; <label>:74                                      ; preds = %71
+  %75 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 2, i32 %73
+  %76 = load i16, i16 addrspace(1)* %75
+  %77 = zext i16 %76 to i32
+  %78 = trunc i32 %77 to i16
+  store i16 %78, i16* %loc5
+  store i32 0, i32* %loc4
+  br label %97
+
+; <label>:79                                      ; preds = %100
+  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %81 = load i32, i32* %loc4
+  %NullCheck19 = icmp eq %"System.Char[]" addrspace(1)* %80, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
+
+; <label>:82                                      ; preds = %79
+  %83 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 1
+  %84 = load i32, i32 addrspace(1)* %83
+  %85 = zext i32 %84 to i64
+  %86 = zext i32 %81 to i64
+  %BoundsCheck21 = icmp uge i64 %86, %85
+  br i1 %BoundsCheck21, label %ThrowIndexOutOfRange22, label %87
+
+; <label>:87                                      ; preds = %82
+  %88 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 3, i32 %81
+  %89 = load i16, i16 addrspace(1)* %88, align 8
+  %90 = zext i16 %89 to i32
+  %91 = load i16, i16* %loc5
+  %92 = zext i16 %91 to i32
+  %93 = icmp eq i32 %90, %92
+  br i1 %93, label %106, label %94
+
+; <label>:94                                      ; preds = %87
+  %95 = load i32, i32* %loc4
+  %96 = add i32 %95, 1
+  store i32 %96, i32* %loc4
+  br label %97
+
+; <label>:97                                      ; preds = %74, %94
+  %98 = load i32, i32* %loc4
+  %99 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck15 = icmp eq %"System.Char[]" addrspace(1)* %99, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %100
+
+; <label>:100                                     ; preds = %97
+  %101 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %99, i32 0, i32 1
+  %102 = load i32, i32 addrspace(1)* %101
+  %103 = zext i32 %102 to i64
+  %104 = trunc i64 %103 to i32
+  %105 = icmp slt i32 %98, %104
+  br i1 %105, label %79, label %106
+
+; <label>:106                                     ; preds = %87, %100
+  %107 = load i32, i32* %loc4
+  %108 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck17 = icmp eq %"System.Char[]" addrspace(1)* %108, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %109
+
+; <label>:109                                     ; preds = %106
+  %110 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %108, i32 0, i32 1
+  %111 = load i32, i32 addrspace(1)* %110
+  %112 = zext i32 %111 to i64
+  %113 = trunc i64 %112 to i32
+  %114 = icmp eq i32 %107, %113
+  br i1 %114, label %122, label %115
+
+; <label>:115                                     ; preds = %109
+  %116 = load i32, i32* %loc0
+  %117 = sub i32 %116, 1
+  store i32 %117, i32* %loc0
+  br label %118
+
+; <label>:118                                     ; preds = %67, %115
+  %119 = load i32, i32* %loc0
+  %120 = load i32, i32* %loc1
+  %121 = icmp sge i32 %119, %120
+  br i1 %121, label %71, label %122
+
+; <label>:122                                     ; preds = %62, %109, %118
+  %123 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %124 = load i32, i32* %loc1
+  %125 = load i32, i32* %loc0
+  %126 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %123, i32 %124, i32 %125)
+  ret %System.String addrspace(1)* %126
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %97
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange22:                           ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
 Successfully read String.CreateTrimmedString
 
@@ -5439,8 +6893,8 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
@@ -5535,8 +6989,8 @@ entry:
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i64 2872
   %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
   %8 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %7
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %3
   %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
@@ -5553,8 +7007,8 @@ entry:
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 2864
   %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
   %21 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %20
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
-  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %22
 
 ; <label>:22                                      ; preds = %16
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
@@ -5569,7 +7023,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %16
+ThrowNullRef2:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5586,8 +7040,8 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5613,8 +7067,8 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
@@ -5632,8 +7086,8 @@ entry:
 
 ; <label>:12                                      ; preds = %4
   %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
@@ -5644,8 +7098,8 @@ entry:
 
 ; <label>:19                                      ; preds = %14
   %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %19
   %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
@@ -5660,21 +7114,21 @@ entry:
   %31 = zext i16 %30 to i32
   %32 = bitcast i8* %29 to i16*
   %33 = trunc i32 %31 to i16
-  %NullCheck6 = icmp ne i16* %32, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i16* %32, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %21
   store i16 %33, i16* %32, align 8
   %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %36
 
 ; <label>:36                                      ; preds = %34
   %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
   %38 = load i32, i32 addrspace(1)* %37, align 8
   %39 = add i32 %38, 1
-  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %40
 
 ; <label>:40                                      ; preds = %36
   %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
@@ -5683,16 +7137,16 @@ entry:
 
 ; <label>:42                                      ; preds = %14
   %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
-  br i1 %NullCheck12, label %44, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
   %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
   %47 = load i16, i16* %arg1
   %48 = zext i16 %47 to i32
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = trunc i32 %48 to i16
@@ -5703,31 +7157,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %19
+ThrowNullRef4:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %21
+ThrowNullRef6:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %36
+ThrowNullRef10:                                   ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %42
+ThrowNullRef12:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %44
+ThrowNullRef14:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5740,8 +7194,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -5752,8 +7206,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
@@ -5762,14 +7216,14 @@ entry:
 
 ; <label>:11                                      ; preds = %1
   %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
@@ -5779,15 +7233,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5808,8 +7262,8 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5822,8 +7276,8 @@ entry:
 
 ; <label>:8                                       ; preds = %3
   %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
@@ -5842,15 +7296,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
-  br i1 %NullCheck4, label %22, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
   %24 = load i16*, i16* addrspace(1)* %23, align 8
   %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %25, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
@@ -5859,8 +7313,8 @@ entry:
   store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
@@ -5874,8 +7328,8 @@ entry:
 
 ; <label>:37                                      ; preds = %65
   %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %37
   %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
@@ -5886,16 +7340,16 @@ entry:
   %45 = bitcast i16* %41 to i8*
   %46 = getelementptr inbounds i8, i8* %45, i64 %44
   %47 = bitcast i8* %46 to i16*
-  %NullCheck14 = icmp ne i16* %47, null
-  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %47, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %48
 
 ; <label>:48                                      ; preds = %39
   %49 = load i16, i16* %47, align 8
   %50 = zext i16 %49 to i32
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %52 = load i32, i32* %loc1
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %53
 
 ; <label>:53                                      ; preds = %48
   %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
@@ -5916,8 +7370,8 @@ entry:
 ; <label>:62                                      ; preds = %36, %59
   %63 = load i32, i32* %loc1
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck10, label %65, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %65
 
 ; <label>:65                                      ; preds = %62
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
@@ -5936,15 +7390,15 @@ entry:
 
 ; <label>:74                                      ; preds = %70
   %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
-  br i1 %NullCheck18, label %76, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %76
 
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
   %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
-  br i1 %NullCheck20, label %80, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
   %81 = load i64, i64 addrspace(1)* %79
@@ -5958,8 +7412,8 @@ entry:
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
   %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
-  br i1 %NullCheck22, label %92, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.String addrspace(1)* %90, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %92
 
 ; <label>:92                                      ; preds = %80
   %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
@@ -5969,15 +7423,15 @@ entry:
 
 ; <label>:96                                      ; preds = %70
   %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
-  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %98
 
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
   %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
-  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
   %103 = load i64, i64 addrspace(1)* %101
@@ -5991,8 +7445,8 @@ entry:
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
   %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
-  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.String addrspace(1)* %112, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %114
 
 ; <label>:114                                     ; preds = %102
   %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
@@ -6004,59 +7458,59 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %20
+ThrowNullRef4:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %22
+ThrowNullRef6:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %26
+ThrowNullRef8:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %62
+ThrowNullRef10:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %48
+ThrowNullRef16:                                   ; preds = %48
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %74
+ThrowNullRef18:                                   ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %76
+ThrowNullRef20:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %80
+ThrowNullRef22:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %96
+ThrowNullRef24:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %98
+ThrowNullRef26:                                   ; preds = %98
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %102
+ThrowNullRef28:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6069,15 +7523,15 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
   %3 = load i16*, i16* addrspace(1)* %2, align 8
   %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
@@ -6087,8 +7541,8 @@ entry:
   %10 = bitcast i16* %3 to i8*
   %11 = getelementptr inbounds i8, i8* %10, i64 %9
   %12 = bitcast i8* %11 to i16*
-  %NullCheck4 = icmp ne i16* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %5
   store i16 0, i16* %12, align 8
@@ -6098,11 +7552,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6119,8 +7573,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -6131,8 +7585,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
@@ -6144,15 +7598,15 @@ entry:
 
 ; <label>:14                                      ; preds = %1
   %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
   %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
   %21 = load i64, i64 addrspace(1)* %19
@@ -6171,15 +7625,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %14
+ThrowNullRef4:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %16
+ThrowNullRef6:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6302,14 +7756,6 @@ entry:
   ret %System.String addrspace(1)* %57
 }
 
-INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
-Successfully read RuntimeHelpers.get_OffsetToStringData
-
-define i32 @RuntimeHelpers.get_OffsetToStringData() {
-entry:
-  ret i32 12
-}
-
 INFO:  jitting method String::Equals using LLILCJit
 Successfully read String.Equals
 
@@ -6381,8 +7827,8 @@ entry:
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
-  br i1 %NullCheck24, label %29, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
   %30 = load i64, i64 addrspace(1)* %28
@@ -6397,8 +7843,8 @@ entry:
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
-  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
   %43 = load i64, i64 addrspace(1)* %41
@@ -6418,8 +7864,8 @@ entry:
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
   %59 = load i64, i64 addrspace(1)* %57
@@ -6434,8 +7880,8 @@ entry:
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck22, label %71, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
   %72 = load i64, i64 addrspace(1)* %70
@@ -6455,8 +7901,8 @@ entry:
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
-  br i1 %NullCheck16, label %87, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = load i64, i64 addrspace(1)* %86
@@ -6471,8 +7917,8 @@ entry:
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck18, label %100, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
   %101 = load i64, i64 addrspace(1)* %99
@@ -6492,8 +7938,8 @@ entry:
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
-  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
   %117 = load i64, i64 addrspace(1)* %115
@@ -6508,8 +7954,8 @@ entry:
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
-  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
   %130 = load i64, i64 addrspace(1)* %128
@@ -6528,15 +7974,15 @@ entry:
 
 ; <label>:142                                     ; preds = %22
   %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
-  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %143, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %144
 
 ; <label>:144                                     ; preds = %142
   %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
   %146 = load i32, i32 addrspace(1)* %145
   %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
-  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %147, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %148
 
 ; <label>:148                                     ; preds = %144
   %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
@@ -6557,15 +8003,15 @@ entry:
 
 ; <label>:159                                     ; preds = %22
   %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
-  br i1 %NullCheck, label %161, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %ThrowNullRef, label %161
 
 ; <label>:161                                     ; preds = %159
   %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
   %163 = load i32, i32 addrspace(1)* %162
   %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
-  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %164, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %165
 
 ; <label>:165                                     ; preds = %161
   %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
@@ -6578,8 +8024,8 @@ entry:
 
 ; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
-  br i1 %NullCheck4, label %172, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %171, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %172
 
 ; <label>:172                                     ; preds = %170
   %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
@@ -6589,8 +8035,8 @@ entry:
 
 ; <label>:176                                     ; preds = %172
   %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
-  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %177, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %178
 
 ; <label>:178                                     ; preds = %176
   %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
@@ -6629,55 +8075,55 @@ ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %161
+ThrowNullRef2:                                    ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %170
+ThrowNullRef4:                                    ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %176
+ThrowNullRef6:                                    ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %142
+ThrowNullRef8:                                    ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %144
+ThrowNullRef10:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %113
+ThrowNullRef12:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %116
+ThrowNullRef14:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %84
+ThrowNullRef16:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %87
+ThrowNullRef18:                                   ; preds = %87
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %55
+ThrowNullRef20:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %58
+ThrowNullRef22:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %26
+ThrowNullRef24:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %29
+ThrowNullRef26:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,8 +8161,8 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck, label %14, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %ThrowNullRef, label %14
 
 ; <label>:14                                      ; preds = %8
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
@@ -6760,8 +8206,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
@@ -6770,14 +8216,14 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32, i32* %loc0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %10
   %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
   %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
@@ -6790,15 +8236,15 @@ entry:
 ; <label>:25                                      ; preds = %19
   %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
-  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
   %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
@@ -6807,8 +8253,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %37 = load i32, i32* %loc0
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %38, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %38
 
 ; <label>:38                                      ; preds = %32
   %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
@@ -6817,14 +8263,14 @@ entry:
 
 ; <label>:40                                      ; preds = %19
   %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %40
   %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
   %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
-  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
-  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
@@ -6832,8 +8278,8 @@ entry:
   %48 = zext i32 %47 to i64
   %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
-  br i1 %NullCheck16, label %51, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %51
 
 ; <label>:51                                      ; preds = %45
   %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
@@ -6847,15 +8293,15 @@ entry:
 ; <label>:57                                      ; preds = %51
   %58 = load i16*, i16** %arg1
   %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
-  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %60
 
 ; <label>:60                                      ; preds = %57
   %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
   %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
-  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %64
 
 ; <label>:64                                      ; preds = %60
   %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
@@ -6864,22 +8310,22 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
   %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
-  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %70
 
 ; <label>:70                                      ; preds = %64
   %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
   %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
-  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
-  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
   %75 = load i32, i32 addrspace(1)* %74
   %76 = zext i32 %75 to i64
   %77 = trunc i64 %76 to i32
-  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
-  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %78
 
 ; <label>:78                                      ; preds = %73
   %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
@@ -6901,8 +8347,8 @@ entry:
   %90 = bitcast i16* %86 to i8*
   %91 = getelementptr inbounds i8, i8* %90, i64 %89
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %93
 
 ; <label>:93                                      ; preds = %80
   %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
@@ -6912,8 +8358,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %99 = load i32, i32* %loc2
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %100
 
 ; <label>:100                                     ; preds = %93
   %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
@@ -6928,63 +8374,63 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %25
+ThrowNullRef6:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %32
+ThrowNullRef10:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %40
+ThrowNullRef12:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %45
+ThrowNullRef16:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %57
+ThrowNullRef18:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %60
+ThrowNullRef20:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %64
+ThrowNullRef22:                                   ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %70
+ThrowNullRef24:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %73
+ThrowNullRef26:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %80
+ThrowNullRef28:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %93
+ThrowNullRef30:                                   ; preds = %93
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7004,8 +8450,8 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
@@ -7033,43 +8479,43 @@ entry:
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %14
   %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
   %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   %28 = load i32, i32 addrspace(1)* %27, align 8
   %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
-  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %30
 
 ; <label>:30                                      ; preds = %26
   %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
   %32 = load i32, i32 addrspace(1)* %31, align 8
   %33 = add i32 %28, %32
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %34
 
 ; <label>:34                                      ; preds = %30
   %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   store i32 %33, i32 addrspace(1)* %35
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
   store i32 0, i32 addrspace(1)* %38
   %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %40
 
 ; <label>:40                                      ; preds = %37
   %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
@@ -7082,8 +8528,8 @@ entry:
 
 ; <label>:47                                      ; preds = %40
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
@@ -7098,8 +8544,8 @@ entry:
   %54 = load i32, i32* %loc0
   %55 = sext i32 %54 to i64
   %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
-  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %57
 
 ; <label>:57                                      ; preds = %52
   %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
@@ -7110,68 +8556,35 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %14
+ThrowNullRef2:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %23
+ThrowNullRef4:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %26
+ThrowNullRef6:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %30
+ThrowNullRef8:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %34
+ThrowNullRef10:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %47
+ThrowNullRef14:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %52
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-}
-
-INFO:  jitting method StringBuilder::get_Length using LLILCJit
-Successfully read StringBuilder.get_Length
-
-define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.StringBuilder addrspace(1)*
-  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
-  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
-
-; <label>:1                                       ; preds = %entry
-  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %3 = load i32, i32 addrspace(1)* %2, align 8
-  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
-
-; <label>:5                                       ; preds = %1
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = add i32 %3, %7
-  ret i32 %8
-
-ThrowNullRef:                                     ; preds = %entry
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef16:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7213,70 +8626,70 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
   %6 = load i32, i32 addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
   store i32 %6, i32 addrspace(1)* %8
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
   %13 = load i32, i32 addrspace(1)* %12, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
   store i32 %13, i32 addrspace(1)* %15
   %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
-  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %18
 
 ; <label>:18                                      ; preds = %14
   %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
   %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
   %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
   %34 = load i32, i32 addrspace(1)* %33, align 8
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
-  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
@@ -7287,39 +8700,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %28
+ThrowNullRef16:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %32
+ThrowNullRef18:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7455,13 +8868,13 @@ entry:
 ; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
@@ -7477,16 +8890,16 @@ entry:
 
 ; <label>:18                                      ; preds = %15
   %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
   store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
   %22 = load i32, i32* %loc0
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %24
 
 ; <label>:24                                      ; preds = %20
   %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
@@ -7498,13 +8911,13 @@ entry:
 ; <label>:28                                      ; preds = %15, %24
   %29 = load i32, i32* %arg1
   %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %31
   %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
@@ -7517,20 +8930,20 @@ entry:
   %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
-  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
   %46 = load i32, i32 addrspace(1)* %45, align 8
   %47 = sub i32 %40, %46
-  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
-  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i32 addrspace(1)* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %48
 
 ; <label>:48                                      ; preds = %44
   store i32 %47, i32 addrspace(1)* %39, align 8
@@ -7538,21 +8951,21 @@ entry:
 
 ; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
-  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %51
 
 ; <label>:51                                      ; preds = %49
   %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %53
 
 ; <label>:53                                      ; preds = %51
   %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
   %55 = load i32, i32 addrspace(1)* %54, align 8
   %56 = load i32, i32* %arg2
   %57 = sub i32 %55, %56
-  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %58
 
 ; <label>:58                                      ; preds = %53
   %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
@@ -7562,13 +8975,13 @@ entry:
 ; <label>:60                                      ; preds = %33, %58
   %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
   %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
-  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %63
 
 ; <label>:63                                      ; preds = %60
   %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
-  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
-  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
@@ -7578,15 +8991,15 @@ entry:
 
 ; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
-  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i32 addrspace(1)* %69, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %70
 
 ; <label>:70                                      ; preds = %68
   %71 = load i32, i32 addrspace(1)* %69, align 8
   store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
-  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
@@ -7596,8 +9009,8 @@ entry:
   store i32 %77, i32* %loc4
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
-  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %80
 
 ; <label>:80                                      ; preds = %73
   %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
@@ -7607,71 +9020,71 @@ entry:
 ; <label>:83                                      ; preds = %80
   store i32 0, i32* %loc3
   %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
-  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
-  br i1 %NullCheck26, label %88, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i32 addrspace(1)* %87, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %88
 
 ; <label>:88                                      ; preds = %85
   %89 = load i32, i32 addrspace(1)* %87, align 8
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
-  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %90
 
 ; <label>:90                                      ; preds = %88
   %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
   store i32 %89, i32 addrspace(1)* %91
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
-  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
-  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %96
 
 ; <label>:96                                      ; preds = %94
   %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
-  br i1 %NullCheck34, label %100, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %100
 
 ; <label>:100                                     ; preds = %96
   %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
-  br i1 %NullCheck36, label %102, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %102
 
 ; <label>:102                                     ; preds = %100
   %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
   %104 = load i32, i32 addrspace(1)* %103, align 8
   %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
-  br i1 %NullCheck38, label %106, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %106
 
 ; <label>:106                                     ; preds = %102
   %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
-  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
-  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %108
 
 ; <label>:108                                     ; preds = %106
   %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
   %110 = load i32, i32 addrspace(1)* %109, align 8
   %111 = add i32 %104, %110
-  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %112
 
 ; <label>:112                                     ; preds = %108
   %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
   store i32 %111, i32 addrspace(1)* %113
   %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
-  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i32 addrspace(1)* %114, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %115
 
 ; <label>:115                                     ; preds = %112
   %116 = load i32, i32 addrspace(1)* %114, align 8
@@ -7681,19 +9094,19 @@ entry:
 ; <label>:118                                     ; preds = %115
   %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
-  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %121
 
 ; <label>:121                                     ; preds = %118
   %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
-  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
-  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %123
 
 ; <label>:123                                     ; preds = %121
   %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
   %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
-  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
-  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %126
 
 ; <label>:126                                     ; preds = %123
   %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
@@ -7705,8 +9118,8 @@ entry:
 
 ; <label>:130                                     ; preds = %80, %115, %126
   %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %132
 
 ; <label>:132                                     ; preds = %130
   %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7715,8 +9128,8 @@ entry:
   %136 = load i32, i32* %loc3
   %137 = sub i32 %135, %136
   %138 = sub i32 %134, %137
-  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %139
 
 ; <label>:139                                     ; preds = %132
   %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7728,16 +9141,16 @@ entry:
 
 ; <label>:144                                     ; preds = %139
   %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
-  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %146
 
 ; <label>:146                                     ; preds = %144
   %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
   %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
   %149 = load i32, i32* %loc2
   %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
-  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %151
 
 ; <label>:151                                     ; preds = %146
   %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
@@ -7754,145 +9167,249 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %18
+ThrowNullRef4:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %31
+ThrowNullRef10:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %44
+ThrowNullRef16:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %68
+ThrowNullRef18:                                   ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %70
+ThrowNullRef20:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %73
+ThrowNullRef22:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %83
+ThrowNullRef24:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %85
+ThrowNullRef26:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %88
+ThrowNullRef28:                                   ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %90
+ThrowNullRef30:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %94
+ThrowNullRef32:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %96
+ThrowNullRef34:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %100
+ThrowNullRef36:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %102
+ThrowNullRef38:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %106
+ThrowNullRef40:                                   ; preds = %106
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %108
+ThrowNullRef42:                                   ; preds = %108
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %112
+ThrowNullRef44:                                   ; preds = %112
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %118
+ThrowNullRef46:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %121
+ThrowNullRef48:                                   ; preds = %121
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %123
+ThrowNullRef50:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %130
+ThrowNullRef52:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %132
+ThrowNullRef54:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %144
+ThrowNullRef56:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %146
+ThrowNullRef58:                                   ; preds = %146
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %60
+ThrowNullRef60:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %63
+ThrowNullRef62:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %49
+ThrowNullRef64:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %51
+ThrowNullRef66:                                   ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %53
+ThrowNullRef68:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(%"System.Char[]" addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %arg0 = alloca %"System.Char[]" addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store %"System.Char[]" addrspace(1)* %param0, %"System.Char[]" addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load i32, i32* %arg4
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %43, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %38, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg1
+  %13 = load i32, i32* %arg4
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %38, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %24 = load i32, i32* %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %35 = load i32, i32* %arg3
+  %36 = load i32, i32* %arg4
+  %37 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %37, %"System.Char[]" addrspace(1)* %34, i32 %35, i32 %36)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:38                                      ; preds = %5, %16
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Successfully read Buffer._Memmove
 
@@ -7914,7 +9431,7 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[loadElem]
+Failed to read AppDomain.SetDataHelper[storeElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -7923,8 +9440,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
@@ -7934,8 +9451,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
@@ -7947,15 +9464,15 @@ entry:
   %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
   %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
@@ -7966,15 +9483,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7992,7 +9509,79 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
-Failed to read Dictionary`2.TryGetValue[loadElemA]
+Successfully read Dictionary`2.TryGetValue
+
+define i8 @"Dictionary`2.TryGetValue"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)* addrspace(1)* %param2) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  %arg2 = alloca %System.__Canon addrspace(1)* addrspace(1)*
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  store %System.__Canon addrspace(1)* addrspace(1)* %param2, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  store i32 %2, i32* %loc0
+  %3 = load i32, i32* %loc0
+  %4 = icmp slt i32 %3, 0
+  br i1 %4, label %22, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 2
+  %10 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %9, align 8
+  %11 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = zext i32 %11 to i64
+  %BoundsCheck = icmp uge i64 %16, %15
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 3, i32 %11
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %20, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %6, %System.__Canon addrspace(1)* %21)
+  ret i8 1
+
+; <label>:22                                      ; preds = %entry
+  %23 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %23, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -8058,8 +9647,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
@@ -8091,8 +9680,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
@@ -8171,15 +9760,15 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck, label %19, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %ThrowNullRef, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
   %21 = load i32, i32 addrspace(1)* %20
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
@@ -8202,7 +9791,7 @@ ThrowNullRef:                                     ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %19
+ThrowNullRef2:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8248,8 +9837,8 @@ entry:
   %0 = alloca %System.AppDomainHandle
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %1 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %1, i32 0, i32 15
@@ -8269,8 +9858,8 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
@@ -8286,7 +9875,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -8299,8 +9888,8 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -8327,8 +9916,8 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
@@ -8352,8 +9941,8 @@ entry:
   %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
   store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
@@ -8363,8 +9952,8 @@ entry:
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
@@ -8374,8 +9963,8 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %9
   %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
@@ -8384,8 +9973,8 @@ entry:
 
 ; <label>:18                                      ; preds = %3, %16
   %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
@@ -8397,15 +9986,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %18
+ThrowNullRef6:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8418,8 +10007,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
@@ -8453,15 +10042,15 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
@@ -8473,7 +10062,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8481,7 +10070,7 @@ ThrowNullRef1:                                    ; preds = %1
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
 Failed to read Dictionary`2.System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
@@ -8506,8 +10095,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
@@ -8524,8 +10113,8 @@ entry:
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -8544,7 +10133,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8577,8 +10166,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = load i64, i64* %arg2
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = trunc i32 %3 to i8
@@ -8634,46 +10223,46 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
   %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
-  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
-  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
-  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
@@ -8684,27 +10273,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %20
+ThrowNullRef12:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8717,8 +10306,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -8756,22 +10345,22 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
   %9 = load i64, i64 addrspace(1)* %8, align 8
   %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
   %13 = load i64, i64 addrspace(1)* %12, align 8
   %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %11
   %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
@@ -8788,11 +10377,11 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8882,8 +10471,8 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
@@ -8900,8 +10489,8 @@ entry:
 ; <label>:8                                       ; preds = %1
   %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
   %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
@@ -8911,15 +10500,15 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
   %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
   %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
-  br i1 %NullCheck6, label %21, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
@@ -8946,15 +10535,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8992,15 +10581,15 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
   store i8 %3, i8 addrspace(1)* %5
   %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
@@ -9011,7 +10600,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9027,8 +10616,8 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -9041,8 +10630,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
@@ -9058,7 +10647,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9080,8 +10669,8 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
@@ -9096,8 +10685,8 @@ entry:
 ; <label>:12                                      ; preds = %6
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
@@ -9112,8 +10701,8 @@ entry:
 ; <label>:21                                      ; preds = %15
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
@@ -9128,8 +10717,8 @@ entry:
 ; <label>:30                                      ; preds = %24
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %31, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
@@ -9144,8 +10733,8 @@ entry:
 ; <label>:39                                      ; preds = %33
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
-  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %40, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %42
 
 ; <label>:42                                      ; preds = %39
   %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
@@ -9164,19 +10753,19 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %21
+ThrowNullRef4:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %30
+ThrowNullRef6:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %39
+ThrowNullRef8:                                    ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9243,8 +10832,8 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
@@ -9264,57 +10853,57 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
   store i8 0, i8 addrspace(1)* %2
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
   store i8 0, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
   store i8 0, i8 addrspace(1)* %17
   %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
   store i8 0, i8 addrspace(1)* %20
   %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
-  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
@@ -9325,31 +10914,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %19
+ThrowNullRef14:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9367,8 +10956,8 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
@@ -9380,8 +10969,8 @@ entry:
 
 ; <label>:9                                       ; preds = %4
   %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %9
   %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
@@ -9395,7 +10984,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef2:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9420,8 +11009,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
@@ -9512,8 +11101,8 @@ entry:
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
@@ -9524,8 +11113,8 @@ entry:
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = load i64, i64 addrspace(1)* %12
@@ -9537,8 +11126,8 @@ entry:
   %20 = load i64, i64* %19
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
-  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %13
   %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
@@ -9555,8 +11144,8 @@ entry:
 ; <label>:30                                      ; preds = %25
   %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %32 = load i32, i32* %arg2
-  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
-  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
@@ -9570,15 +11159,15 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %30
+ThrowNullRef2:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9622,87 +11211,87 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
   %10 = load i8, i8 addrspace(1)* %9, align 8
   %11 = zext i8 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %8
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
   store i8 %12, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
   %19 = load i8, i8 addrspace(1)* %18, align 8
   %20 = zext i8 %19 to i32
   %21 = trunc i32 %20 to i8
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
   store i8 %21, i8 addrspace(1)* %23
   %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
   %28 = load i8, i8 addrspace(1)* %27, align 8
   %29 = zext i8 %28 to i32
   %30 = trunc i32 %29 to i8
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
-  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %31
 
 ; <label>:31                                      ; preds = %26
   %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
   store i8 %30, i8 addrspace(1)* %32
   %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
-  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
-  br i1 %NullCheck14, label %40, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %40
 
 ; <label>:40                                      ; preds = %35
   %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
   store i8 %39, i8 addrspace(1)* %41
   %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
-  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %44
 
 ; <label>:44                                      ; preds = %40
   %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
   %46 = load i8, i8 addrspace(1)* %45, align 8
   %47 = zext i8 %46 to i32
   %48 = trunc i32 %47 to i8
-  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
   store i8 %48, i8 addrspace(1)* %50
   %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
-  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
@@ -9713,29 +11302,29 @@ entry:
 ; <label>:56                                      ; preds = %52
   %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
-  br i1 %NullCheck22, label %59, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
   %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
   %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
-  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
-  br i1 %NullCheck24, label %63, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
   %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
-  br i1 %NullCheck26, label %66, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
   %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
-  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
-  br i1 %NullCheck28, label %69, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %69
 
 ; <label>:69                                      ; preds = %66
   %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
@@ -9744,15 +11333,15 @@ entry:
 
 ; <label>:71                                      ; preds = %105
   %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
-  br i1 %NullCheck34, label %73, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %73
 
 ; <label>:73                                      ; preds = %71
   %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
   %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
   %76 = load i32, i32* %loc0
-  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
-  br i1 %NullCheck36, label %77, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
@@ -9766,8 +11355,8 @@ entry:
 
 ; <label>:83                                      ; preds = %77
   %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
-  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
@@ -9775,14 +11364,14 @@ entry:
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
   %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
-  br i1 %NullCheck40, label %91, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
 ; <label>:91                                      ; preds = %85
   %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
   %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
-  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck42, label %94, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %94
 
 ; <label>:94                                      ; preds = %91
   %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
@@ -9798,14 +11387,14 @@ entry:
 ; <label>:99                                      ; preds = %69, %96
   %100 = load i32, i32* %loc0
   %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
-  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %102
 
 ; <label>:102                                     ; preds = %99
   %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
   %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
-  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
-  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
@@ -9819,87 +11408,87 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %26
+ThrowNullRef10:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %31
+ThrowNullRef12:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %35
+ThrowNullRef14:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %40
+ThrowNullRef16:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %56
+ThrowNullRef22:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %59
+ThrowNullRef24:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %63
+ThrowNullRef26:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %66
+ThrowNullRef28:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %102
+ThrowNullRef32:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %71
+ThrowNullRef34:                                   ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %73
+ThrowNullRef36:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %83
+ThrowNullRef38:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %85
+ThrowNullRef40:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %91
+ThrowNullRef42:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9943,15 +11532,15 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
   %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
@@ -9961,28 +11550,28 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
   %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %12
   %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
   %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
   %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
-  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
@@ -9993,23 +11582,23 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %12
+ThrowNullRef6:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10031,15 +11620,15 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
   %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = load i64, i64 addrspace(1)* %7
@@ -10077,13 +11666,13 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[loadElem]
+Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -10111,8 +11700,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1

--- a/test/BaseLine/JIT/CodeGenBringUpTests/LeftShift.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/LeftShift.error.txt
@@ -25,8 +25,8 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
@@ -40,8 +40,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
   %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
@@ -75,7 +75,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -90,8 +90,8 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %NullCheck = icmp ne i8 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = load i8, i8 addrspace(1)* %0, align 8
@@ -125,8 +125,8 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
@@ -159,8 +159,8 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -184,8 +184,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
   store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
@@ -195,8 +195,8 @@ entry:
 ; <label>:4                                       ; preds = %1
   %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
   %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
@@ -206,8 +206,8 @@ entry:
   %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
@@ -221,14 +221,14 @@ entry:
 
 ; <label>:17                                      ; preds = %14
   %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
   %21 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
@@ -238,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -249,8 +249,8 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
@@ -261,27 +261,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %30
+ThrowNullRef10:                                   ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -301,7 +301,89 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
-Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
+Successfully read AppDomainSetup.GetUnsecureApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.GetUnsecureApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %NullCheck = icmp eq %"System.String[]" addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %BoundsCheck = icmp uge i64 0, %5
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %6
+
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 3, i32 0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
+  ret %System.String addrspace(1)* %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_Value using LLILCJit
+Successfully read AppDomainSetup.get_Value
+
+define %"System.String[]" addrspace(1)* @AppDomainSetup.get_Value(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.String[]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 18)
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.String[]" addrspace(1)* addrspace(1)*, %"System.String[]" addrspace(1)*)*)(%"System.String[]" addrspace(1)* addrspace(1)* %9, %"System.String[]" addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %11, i32 0, i32 1
+  %14 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %13, align 8
+  ret %"System.String[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -319,8 +401,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -368,16 +450,16 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
   %5 = load i32, i32 addrspace(1)* %4
   %6 = sub i32 %5, 1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -389,7 +471,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -421,8 +503,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
@@ -456,8 +538,8 @@ entry:
 ; <label>:27                                      ; preds = %19
   %28 = load i32, i32* %arg1
   %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
-  br i1 %NullCheck2, label %30, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %29, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %30
 
 ; <label>:30                                      ; preds = %27
   %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
@@ -493,8 +575,8 @@ entry:
 ; <label>:49                                      ; preds = %46
   %50 = load i32, i32* %arg2
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck4, label %52, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
@@ -517,11 +599,11 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %27
+ThrowNullRef2:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %49
+ThrowNullRef4:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -544,16 +626,16 @@ entry:
   %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %0)
   store %System.String addrspace(1)* %1, %System.String addrspace(1)** %loc0
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 2
   %5 = bitcast [0 x i16] addrspace(1)* %4 to i16 addrspace(1)*
   store i16 addrspace(1)* %5, i16 addrspace(1)** %loc1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %3
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2
@@ -580,7 +662,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -691,15 +773,15 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %NullCheck132 = icmp ne i8* %21, null
-  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+  %NullCheck131 = icmp eq i8* %21, null
+  br i1 %NullCheck131, label %ThrowNullRef132, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = load i8, i8* %21, align 8
   %24 = zext i8 %23 to i32
   %25 = trunc i32 %24 to i8
-  %NullCheck134 = icmp ne i8* %20, null
-  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+  %NullCheck133 = icmp eq i8* %20, null
+  br i1 %NullCheck133, label %ThrowNullRef134, label %26
 
 ; <label>:26                                      ; preds = %22
   store i8 %25, i8* %20, align 8
@@ -709,16 +791,16 @@ entry:
   %28 = load i8*, i8** %arg0
   %29 = load i8*, i8** %arg1
   %30 = bitcast i8* %29 to i16*
-  %NullCheck128 = icmp ne i16* %30, null
-  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+  %NullCheck127 = icmp eq i16* %30, null
+  br i1 %NullCheck127, label %ThrowNullRef128, label %31
 
 ; <label>:31                                      ; preds = %27
   %32 = load i16, i16* %30, align 8
   %33 = sext i16 %32 to i32
   %34 = bitcast i8* %28 to i16*
   %35 = trunc i32 %33 to i16
-  %NullCheck130 = icmp ne i16* %34, null
-  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+  %NullCheck129 = icmp eq i16* %34, null
+  br i1 %NullCheck129, label %ThrowNullRef130, label %36
 
 ; <label>:36                                      ; preds = %31
   store i16 %35, i16* %34, align 8
@@ -728,16 +810,16 @@ entry:
   %38 = load i8*, i8** %arg0
   %39 = load i8*, i8** %arg1
   %40 = bitcast i8* %39 to i16*
-  %NullCheck120 = icmp ne i16* %40, null
-  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+  %NullCheck119 = icmp eq i16* %40, null
+  br i1 %NullCheck119, label %ThrowNullRef120, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i16, i16* %40, align 8
   %43 = sext i16 %42 to i32
   %44 = bitcast i8* %38 to i16*
   %45 = trunc i32 %43 to i16
-  %NullCheck122 = icmp ne i16* %44, null
-  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+  %NullCheck121 = icmp eq i16* %44, null
+  br i1 %NullCheck121, label %ThrowNullRef122, label %46
 
 ; <label>:46                                      ; preds = %41
   store i16 %45, i16* %44, align 8
@@ -745,15 +827,15 @@ entry:
   %48 = getelementptr inbounds i8, i8* %47, i64 2
   %49 = load i8*, i8** %arg1
   %50 = getelementptr inbounds i8, i8* %49, i64 2
-  %NullCheck124 = icmp ne i8* %50, null
-  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+  %NullCheck123 = icmp eq i8* %50, null
+  br i1 %NullCheck123, label %ThrowNullRef124, label %51
 
 ; <label>:51                                      ; preds = %46
   %52 = load i8, i8* %50, align 8
   %53 = zext i8 %52 to i32
   %54 = trunc i32 %53 to i8
-  %NullCheck126 = icmp ne i8* %48, null
-  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+  %NullCheck125 = icmp eq i8* %48, null
+  br i1 %NullCheck125, label %ThrowNullRef126, label %55
 
 ; <label>:55                                      ; preds = %51
   store i8 %54, i8* %48, align 8
@@ -763,14 +845,14 @@ entry:
   %57 = load i8*, i8** %arg0
   %58 = load i8*, i8** %arg1
   %59 = bitcast i8* %58 to i32*
-  %NullCheck116 = icmp ne i32* %59, null
-  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+  %NullCheck115 = icmp eq i32* %59, null
+  br i1 %NullCheck115, label %ThrowNullRef116, label %60
 
 ; <label>:60                                      ; preds = %56
   %61 = load i32, i32* %59, align 8
   %62 = bitcast i8* %57 to i32*
-  %NullCheck118 = icmp ne i32* %62, null
-  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+  %NullCheck117 = icmp eq i32* %62, null
+  br i1 %NullCheck117, label %ThrowNullRef118, label %63
 
 ; <label>:63                                      ; preds = %60
   store i32 %61, i32* %62, align 8
@@ -780,14 +862,14 @@ entry:
   %65 = load i8*, i8** %arg0
   %66 = load i8*, i8** %arg1
   %67 = bitcast i8* %66 to i32*
-  %NullCheck108 = icmp ne i32* %67, null
-  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+  %NullCheck107 = icmp eq i32* %67, null
+  br i1 %NullCheck107, label %ThrowNullRef108, label %68
 
 ; <label>:68                                      ; preds = %64
   %69 = load i32, i32* %67, align 8
   %70 = bitcast i8* %65 to i32*
-  %NullCheck110 = icmp ne i32* %70, null
-  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+  %NullCheck109 = icmp eq i32* %70, null
+  br i1 %NullCheck109, label %ThrowNullRef110, label %71
 
 ; <label>:71                                      ; preds = %68
   store i32 %69, i32* %70, align 8
@@ -795,15 +877,15 @@ entry:
   %73 = getelementptr inbounds i8, i8* %72, i64 4
   %74 = load i8*, i8** %arg1
   %75 = getelementptr inbounds i8, i8* %74, i64 4
-  %NullCheck112 = icmp ne i8* %75, null
-  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+  %NullCheck111 = icmp eq i8* %75, null
+  br i1 %NullCheck111, label %ThrowNullRef112, label %76
 
 ; <label>:76                                      ; preds = %71
   %77 = load i8, i8* %75, align 8
   %78 = zext i8 %77 to i32
   %79 = trunc i32 %78 to i8
-  %NullCheck114 = icmp ne i8* %73, null
-  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+  %NullCheck113 = icmp eq i8* %73, null
+  br i1 %NullCheck113, label %ThrowNullRef114, label %80
 
 ; <label>:80                                      ; preds = %76
   store i8 %79, i8* %73, align 8
@@ -813,14 +895,14 @@ entry:
   %82 = load i8*, i8** %arg0
   %83 = load i8*, i8** %arg1
   %84 = bitcast i8* %83 to i32*
-  %NullCheck100 = icmp ne i32* %84, null
-  br i1 %NullCheck100, label %85, label %ThrowNullRef99
+  %NullCheck99 = icmp eq i32* %84, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %85
 
 ; <label>:85                                      ; preds = %81
   %86 = load i32, i32* %84, align 8
   %87 = bitcast i8* %82 to i32*
-  %NullCheck102 = icmp ne i32* %87, null
-  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+  %NullCheck101 = icmp eq i32* %87, null
+  br i1 %NullCheck101, label %ThrowNullRef102, label %88
 
 ; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
@@ -829,16 +911,16 @@ entry:
   %91 = load i8*, i8** %arg1
   %92 = getelementptr inbounds i8, i8* %91, i64 4
   %93 = bitcast i8* %92 to i16*
-  %NullCheck104 = icmp ne i16* %93, null
-  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+  %NullCheck103 = icmp eq i16* %93, null
+  br i1 %NullCheck103, label %ThrowNullRef104, label %94
 
 ; <label>:94                                      ; preds = %88
   %95 = load i16, i16* %93, align 8
   %96 = sext i16 %95 to i32
   %97 = bitcast i8* %90 to i16*
   %98 = trunc i32 %96 to i16
-  %NullCheck106 = icmp ne i16* %97, null
-  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+  %NullCheck105 = icmp eq i16* %97, null
+  br i1 %NullCheck105, label %ThrowNullRef106, label %99
 
 ; <label>:99                                      ; preds = %94
   store i16 %98, i16* %97, align 8
@@ -848,14 +930,14 @@ entry:
   %101 = load i8*, i8** %arg0
   %102 = load i8*, i8** %arg1
   %103 = bitcast i8* %102 to i32*
-  %NullCheck88 = icmp ne i32* %103, null
-  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+  %NullCheck87 = icmp eq i32* %103, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %104
 
 ; <label>:104                                     ; preds = %100
   %105 = load i32, i32* %103, align 8
   %106 = bitcast i8* %101 to i32*
-  %NullCheck90 = icmp ne i32* %106, null
-  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+  %NullCheck89 = icmp eq i32* %106, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %107
 
 ; <label>:107                                     ; preds = %104
   store i32 %105, i32* %106, align 8
@@ -864,16 +946,16 @@ entry:
   %110 = load i8*, i8** %arg1
   %111 = getelementptr inbounds i8, i8* %110, i64 4
   %112 = bitcast i8* %111 to i16*
-  %NullCheck92 = icmp ne i16* %112, null
-  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+  %NullCheck91 = icmp eq i16* %112, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %113
 
 ; <label>:113                                     ; preds = %107
   %114 = load i16, i16* %112, align 8
   %115 = sext i16 %114 to i32
   %116 = bitcast i8* %109 to i16*
   %117 = trunc i32 %115 to i16
-  %NullCheck94 = icmp ne i16* %116, null
-  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+  %NullCheck93 = icmp eq i16* %116, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %118
 
 ; <label>:118                                     ; preds = %113
   store i16 %117, i16* %116, align 8
@@ -881,15 +963,15 @@ entry:
   %120 = getelementptr inbounds i8, i8* %119, i64 6
   %121 = load i8*, i8** %arg1
   %122 = getelementptr inbounds i8, i8* %121, i64 6
-  %NullCheck96 = icmp ne i8* %122, null
-  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+  %NullCheck95 = icmp eq i8* %122, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %123
 
 ; <label>:123                                     ; preds = %118
   %124 = load i8, i8* %122, align 8
   %125 = zext i8 %124 to i32
   %126 = trunc i32 %125 to i8
-  %NullCheck98 = icmp ne i8* %120, null
-  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+  %NullCheck97 = icmp eq i8* %120, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %127
 
 ; <label>:127                                     ; preds = %123
   store i8 %126, i8* %120, align 8
@@ -899,14 +981,14 @@ entry:
   %129 = load i8*, i8** %arg0
   %130 = load i8*, i8** %arg1
   %131 = bitcast i8* %130 to i64*
-  %NullCheck84 = icmp ne i64* %131, null
-  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+  %NullCheck83 = icmp eq i64* %131, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %132
 
 ; <label>:132                                     ; preds = %128
   %133 = load i64, i64* %131, align 8
   %134 = bitcast i8* %129 to i64*
-  %NullCheck86 = icmp ne i64* %134, null
-  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+  %NullCheck85 = icmp eq i64* %134, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %135
 
 ; <label>:135                                     ; preds = %132
   store i64 %133, i64* %134, align 8
@@ -916,14 +998,14 @@ entry:
   %137 = load i8*, i8** %arg0
   %138 = load i8*, i8** %arg1
   %139 = bitcast i8* %138 to i64*
-  %NullCheck76 = icmp ne i64* %139, null
-  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+  %NullCheck75 = icmp eq i64* %139, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %140
 
 ; <label>:140                                     ; preds = %136
   %141 = load i64, i64* %139, align 8
   %142 = bitcast i8* %137 to i64*
-  %NullCheck78 = icmp ne i64* %142, null
-  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+  %NullCheck77 = icmp eq i64* %142, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %143
 
 ; <label>:143                                     ; preds = %140
   store i64 %141, i64* %142, align 8
@@ -931,15 +1013,15 @@ entry:
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %NullCheck80 = icmp ne i8* %147, null
-  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+  %NullCheck79 = icmp eq i8* %147, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %148
 
 ; <label>:148                                     ; preds = %143
   %149 = load i8, i8* %147, align 8
   %150 = zext i8 %149 to i32
   %151 = trunc i32 %150 to i8
-  %NullCheck82 = icmp ne i8* %145, null
-  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+  %NullCheck81 = icmp eq i8* %145, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %152
 
 ; <label>:152                                     ; preds = %148
   store i8 %151, i8* %145, align 8
@@ -949,14 +1031,14 @@ entry:
   %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
   %156 = bitcast i8* %155 to i64*
-  %NullCheck68 = icmp ne i64* %156, null
-  br i1 %NullCheck68, label %157, label %ThrowNullRef67
+  %NullCheck67 = icmp eq i64* %156, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %157
 
 ; <label>:157                                     ; preds = %153
   %158 = load i64, i64* %156, align 8
   %159 = bitcast i8* %154 to i64*
-  %NullCheck70 = icmp ne i64* %159, null
-  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+  %NullCheck69 = icmp eq i64* %159, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %160
 
 ; <label>:160                                     ; preds = %157
   store i64 %158, i64* %159, align 8
@@ -965,16 +1047,16 @@ entry:
   %163 = load i8*, i8** %arg1
   %164 = getelementptr inbounds i8, i8* %163, i64 8
   %165 = bitcast i8* %164 to i16*
-  %NullCheck72 = icmp ne i16* %165, null
-  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+  %NullCheck71 = icmp eq i16* %165, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %166
 
 ; <label>:166                                     ; preds = %160
   %167 = load i16, i16* %165, align 8
   %168 = sext i16 %167 to i32
   %169 = bitcast i8* %162 to i16*
   %170 = trunc i32 %168 to i16
-  %NullCheck74 = icmp ne i16* %169, null
-  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+  %NullCheck73 = icmp eq i16* %169, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %171
 
 ; <label>:171                                     ; preds = %166
   store i16 %170, i16* %169, align 8
@@ -984,14 +1066,14 @@ entry:
   %173 = load i8*, i8** %arg0
   %174 = load i8*, i8** %arg1
   %175 = bitcast i8* %174 to i64*
-  %NullCheck56 = icmp ne i64* %175, null
-  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+  %NullCheck55 = icmp eq i64* %175, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %176
 
 ; <label>:176                                     ; preds = %172
   %177 = load i64, i64* %175, align 8
   %178 = bitcast i8* %173 to i64*
-  %NullCheck58 = icmp ne i64* %178, null
-  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+  %NullCheck57 = icmp eq i64* %178, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %179
 
 ; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
@@ -1000,16 +1082,16 @@ entry:
   %182 = load i8*, i8** %arg1
   %183 = getelementptr inbounds i8, i8* %182, i64 8
   %184 = bitcast i8* %183 to i16*
-  %NullCheck60 = icmp ne i16* %184, null
-  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+  %NullCheck59 = icmp eq i16* %184, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %185
 
 ; <label>:185                                     ; preds = %179
   %186 = load i16, i16* %184, align 8
   %187 = sext i16 %186 to i32
   %188 = bitcast i8* %181 to i16*
   %189 = trunc i32 %187 to i16
-  %NullCheck62 = icmp ne i16* %188, null
-  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+  %NullCheck61 = icmp eq i16* %188, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %190
 
 ; <label>:190                                     ; preds = %185
   store i16 %189, i16* %188, align 8
@@ -1017,15 +1099,15 @@ entry:
   %192 = getelementptr inbounds i8, i8* %191, i64 10
   %193 = load i8*, i8** %arg1
   %194 = getelementptr inbounds i8, i8* %193, i64 10
-  %NullCheck64 = icmp ne i8* %194, null
-  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+  %NullCheck63 = icmp eq i8* %194, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %195
 
 ; <label>:195                                     ; preds = %190
   %196 = load i8, i8* %194, align 8
   %197 = zext i8 %196 to i32
   %198 = trunc i32 %197 to i8
-  %NullCheck66 = icmp ne i8* %192, null
-  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+  %NullCheck65 = icmp eq i8* %192, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %199
 
 ; <label>:199                                     ; preds = %195
   store i8 %198, i8* %192, align 8
@@ -1035,14 +1117,14 @@ entry:
   %201 = load i8*, i8** %arg0
   %202 = load i8*, i8** %arg1
   %203 = bitcast i8* %202 to i64*
-  %NullCheck48 = icmp ne i64* %203, null
-  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+  %NullCheck47 = icmp eq i64* %203, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %204
 
 ; <label>:204                                     ; preds = %200
   %205 = load i64, i64* %203, align 8
   %206 = bitcast i8* %201 to i64*
-  %NullCheck50 = icmp ne i64* %206, null
-  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+  %NullCheck49 = icmp eq i64* %206, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %207
 
 ; <label>:207                                     ; preds = %204
   store i64 %205, i64* %206, align 8
@@ -1051,14 +1133,14 @@ entry:
   %210 = load i8*, i8** %arg1
   %211 = getelementptr inbounds i8, i8* %210, i64 8
   %212 = bitcast i8* %211 to i32*
-  %NullCheck52 = icmp ne i32* %212, null
-  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+  %NullCheck51 = icmp eq i32* %212, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %213
 
 ; <label>:213                                     ; preds = %207
   %214 = load i32, i32* %212, align 8
   %215 = bitcast i8* %209 to i32*
-  %NullCheck54 = icmp ne i32* %215, null
-  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+  %NullCheck53 = icmp eq i32* %215, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %216
 
 ; <label>:216                                     ; preds = %213
   store i32 %214, i32* %215, align 8
@@ -1068,14 +1150,14 @@ entry:
   %218 = load i8*, i8** %arg0
   %219 = load i8*, i8** %arg1
   %220 = bitcast i8* %219 to i64*
-  %NullCheck36 = icmp ne i64* %220, null
-  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64* %220, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %221
 
 ; <label>:221                                     ; preds = %217
   %222 = load i64, i64* %220, align 8
   %223 = bitcast i8* %218 to i64*
-  %NullCheck38 = icmp ne i64* %223, null
-  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+  %NullCheck37 = icmp eq i64* %223, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %224
 
 ; <label>:224                                     ; preds = %221
   store i64 %222, i64* %223, align 8
@@ -1084,14 +1166,14 @@ entry:
   %227 = load i8*, i8** %arg1
   %228 = getelementptr inbounds i8, i8* %227, i64 8
   %229 = bitcast i8* %228 to i32*
-  %NullCheck40 = icmp ne i32* %229, null
-  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i32* %229, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %230
 
 ; <label>:230                                     ; preds = %224
   %231 = load i32, i32* %229, align 8
   %232 = bitcast i8* %226 to i32*
-  %NullCheck42 = icmp ne i32* %232, null
-  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+  %NullCheck41 = icmp eq i32* %232, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %233
 
 ; <label>:233                                     ; preds = %230
   store i32 %231, i32* %232, align 8
@@ -1099,15 +1181,15 @@ entry:
   %235 = getelementptr inbounds i8, i8* %234, i64 12
   %236 = load i8*, i8** %arg1
   %237 = getelementptr inbounds i8, i8* %236, i64 12
-  %NullCheck44 = icmp ne i8* %237, null
-  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i8* %237, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %238
 
 ; <label>:238                                     ; preds = %233
   %239 = load i8, i8* %237, align 8
   %240 = zext i8 %239 to i32
   %241 = trunc i32 %240 to i8
-  %NullCheck46 = icmp ne i8* %235, null
-  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+  %NullCheck45 = icmp eq i8* %235, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %242
 
 ; <label>:242                                     ; preds = %238
   store i8 %241, i8* %235, align 8
@@ -1117,14 +1199,14 @@ entry:
   %244 = load i8*, i8** %arg0
   %245 = load i8*, i8** %arg1
   %246 = bitcast i8* %245 to i64*
-  %NullCheck24 = icmp ne i64* %246, null
-  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64* %246, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %247
 
 ; <label>:247                                     ; preds = %243
   %248 = load i64, i64* %246, align 8
   %249 = bitcast i8* %244 to i64*
-  %NullCheck26 = icmp ne i64* %249, null
-  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64* %249, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %250
 
 ; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
@@ -1133,14 +1215,14 @@ entry:
   %253 = load i8*, i8** %arg1
   %254 = getelementptr inbounds i8, i8* %253, i64 8
   %255 = bitcast i8* %254 to i32*
-  %NullCheck28 = icmp ne i32* %255, null
-  br i1 %NullCheck28, label %256, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i32* %255, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %256
 
 ; <label>:256                                     ; preds = %250
   %257 = load i32, i32* %255, align 8
   %258 = bitcast i8* %252 to i32*
-  %NullCheck30 = icmp ne i32* %258, null
-  br i1 %NullCheck30, label %259, label %ThrowNullRef29
+  %NullCheck29 = icmp eq i32* %258, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %259
 
 ; <label>:259                                     ; preds = %256
   store i32 %257, i32* %258, align 8
@@ -1149,16 +1231,16 @@ entry:
   %262 = load i8*, i8** %arg1
   %263 = getelementptr inbounds i8, i8* %262, i64 12
   %264 = bitcast i8* %263 to i16*
-  %NullCheck32 = icmp ne i16* %264, null
-  br i1 %NullCheck32, label %265, label %ThrowNullRef31
+  %NullCheck31 = icmp eq i16* %264, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %265
 
 ; <label>:265                                     ; preds = %259
   %266 = load i16, i16* %264, align 8
   %267 = sext i16 %266 to i32
   %268 = bitcast i8* %261 to i16*
   %269 = trunc i32 %267 to i16
-  %NullCheck34 = icmp ne i16* %268, null
-  br i1 %NullCheck34, label %270, label %ThrowNullRef33
+  %NullCheck33 = icmp eq i16* %268, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %270
 
 ; <label>:270                                     ; preds = %265
   store i16 %269, i16* %268, align 8
@@ -1168,14 +1250,14 @@ entry:
   %272 = load i8*, i8** %arg0
   %273 = load i8*, i8** %arg1
   %274 = bitcast i8* %273 to i64*
-  %NullCheck8 = icmp ne i64* %274, null
-  br i1 %NullCheck8, label %275, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64* %274, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %275
 
 ; <label>:275                                     ; preds = %271
   %276 = load i64, i64* %274, align 8
   %277 = bitcast i8* %272 to i64*
-  %NullCheck10 = icmp ne i64* %277, null
-  br i1 %NullCheck10, label %278, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %277, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %278
 
 ; <label>:278                                     ; preds = %275
   store i64 %276, i64* %277, align 8
@@ -1184,14 +1266,14 @@ entry:
   %281 = load i8*, i8** %arg1
   %282 = getelementptr inbounds i8, i8* %281, i64 8
   %283 = bitcast i8* %282 to i32*
-  %NullCheck12 = icmp ne i32* %283, null
-  br i1 %NullCheck12, label %284, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i32* %283, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %284
 
 ; <label>:284                                     ; preds = %278
   %285 = load i32, i32* %283, align 8
   %286 = bitcast i8* %280 to i32*
-  %NullCheck14 = icmp ne i32* %286, null
-  br i1 %NullCheck14, label %287, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i32* %286, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %287
 
 ; <label>:287                                     ; preds = %284
   store i32 %285, i32* %286, align 8
@@ -1200,16 +1282,16 @@ entry:
   %290 = load i8*, i8** %arg1
   %291 = getelementptr inbounds i8, i8* %290, i64 12
   %292 = bitcast i8* %291 to i16*
-  %NullCheck16 = icmp ne i16* %292, null
-  br i1 %NullCheck16, label %293, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i16* %292, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %293
 
 ; <label>:293                                     ; preds = %287
   %294 = load i16, i16* %292, align 8
   %295 = sext i16 %294 to i32
   %296 = bitcast i8* %289 to i16*
   %297 = trunc i32 %295 to i16
-  %NullCheck18 = icmp ne i16* %296, null
-  br i1 %NullCheck18, label %298, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i16* %296, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %298
 
 ; <label>:298                                     ; preds = %293
   store i16 %297, i16* %296, align 8
@@ -1217,15 +1299,15 @@ entry:
   %300 = getelementptr inbounds i8, i8* %299, i64 14
   %301 = load i8*, i8** %arg1
   %302 = getelementptr inbounds i8, i8* %301, i64 14
-  %NullCheck20 = icmp ne i8* %302, null
-  br i1 %NullCheck20, label %303, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i8* %302, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %303
 
 ; <label>:303                                     ; preds = %298
   %304 = load i8, i8* %302, align 8
   %305 = zext i8 %304 to i32
   %306 = trunc i32 %305 to i8
-  %NullCheck22 = icmp ne i8* %300, null
-  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i8* %300, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %307
 
 ; <label>:307                                     ; preds = %303
   store i8 %306, i8* %300, align 8
@@ -1235,14 +1317,14 @@ entry:
   %309 = load i8*, i8** %arg0
   %310 = load i8*, i8** %arg1
   %311 = bitcast i8* %310 to i64*
-  %NullCheck = icmp ne i64* %311, null
-  br i1 %NullCheck, label %312, label %ThrowNullRef
+  %NullCheck = icmp eq i64* %311, null
+  br i1 %NullCheck, label %ThrowNullRef, label %312
 
 ; <label>:312                                     ; preds = %308
   %313 = load i64, i64* %311, align 8
   %314 = bitcast i8* %309 to i64*
-  %NullCheck2 = icmp ne i64* %314, null
-  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64* %314, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %315
 
 ; <label>:315                                     ; preds = %312
   store i64 %313, i64* %314, align 8
@@ -1251,14 +1333,14 @@ entry:
   %318 = load i8*, i8** %arg1
   %319 = getelementptr inbounds i8, i8* %318, i64 8
   %320 = bitcast i8* %319 to i64*
-  %NullCheck4 = icmp ne i64* %320, null
-  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64* %320, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %321
 
 ; <label>:321                                     ; preds = %315
   %322 = load i64, i64* %320, align 8
   %323 = bitcast i8* %317 to i64*
-  %NullCheck6 = icmp ne i64* %323, null
-  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64* %323, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %324
 
 ; <label>:324                                     ; preds = %321
   store i64 %322, i64* %323, align 8
@@ -1286,15 +1368,15 @@ entry:
 ; <label>:338                                     ; preds = %333
   %339 = load i8*, i8** %arg0
   %340 = load i8*, i8** %arg1
-  %NullCheck136 = icmp ne i8* %340, null
-  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+  %NullCheck135 = icmp eq i8* %340, null
+  br i1 %NullCheck135, label %ThrowNullRef136, label %341
 
 ; <label>:341                                     ; preds = %338
   %342 = load i8, i8* %340, align 8
   %343 = zext i8 %342 to i32
   %344 = trunc i32 %343 to i8
-  %NullCheck138 = icmp ne i8* %339, null
-  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+  %NullCheck137 = icmp eq i8* %339, null
+  br i1 %NullCheck137, label %ThrowNullRef138, label %345
 
 ; <label>:345                                     ; preds = %341
   store i8 %344, i8* %339, align 8
@@ -1317,16 +1399,16 @@ entry:
   %357 = load i8*, i8** %arg0
   %358 = load i8*, i8** %arg1
   %359 = bitcast i8* %358 to i16*
-  %NullCheck140 = icmp ne i16* %359, null
-  br i1 %NullCheck140, label %360, label %ThrowNullRef139
+  %NullCheck139 = icmp eq i16* %359, null
+  br i1 %NullCheck139, label %ThrowNullRef140, label %360
 
 ; <label>:360                                     ; preds = %356
   %361 = load i16, i16* %359, align 8
   %362 = sext i16 %361 to i32
   %363 = bitcast i8* %357 to i16*
   %364 = trunc i32 %362 to i16
-  %NullCheck142 = icmp ne i16* %363, null
-  br i1 %NullCheck142, label %365, label %ThrowNullRef141
+  %NullCheck141 = icmp eq i16* %363, null
+  br i1 %NullCheck141, label %ThrowNullRef142, label %365
 
 ; <label>:365                                     ; preds = %360
   store i16 %364, i16* %363, align 8
@@ -1352,14 +1434,14 @@ entry:
   %378 = load i8*, i8** %arg0
   %379 = load i8*, i8** %arg1
   %380 = bitcast i8* %379 to i32*
-  %NullCheck144 = icmp ne i32* %380, null
-  br i1 %NullCheck144, label %381, label %ThrowNullRef143
+  %NullCheck143 = icmp eq i32* %380, null
+  br i1 %NullCheck143, label %ThrowNullRef144, label %381
 
 ; <label>:381                                     ; preds = %377
   %382 = load i32, i32* %380, align 8
   %383 = bitcast i8* %378 to i32*
-  %NullCheck146 = icmp ne i32* %383, null
-  br i1 %NullCheck146, label %384, label %ThrowNullRef145
+  %NullCheck145 = icmp eq i32* %383, null
+  br i1 %NullCheck145, label %ThrowNullRef146, label %384
 
 ; <label>:384                                     ; preds = %381
   store i32 %382, i32* %383, align 8
@@ -1384,14 +1466,14 @@ entry:
   %395 = load i8*, i8** %arg0
   %396 = load i8*, i8** %arg1
   %397 = bitcast i8* %396 to i64*
-  %NullCheck164 = icmp ne i64* %397, null
-  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+  %NullCheck163 = icmp eq i64* %397, null
+  br i1 %NullCheck163, label %ThrowNullRef164, label %398
 
 ; <label>:398                                     ; preds = %394
   %399 = load i64, i64* %397, align 8
   %400 = bitcast i8* %395 to i64*
-  %NullCheck166 = icmp ne i64* %400, null
-  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+  %NullCheck165 = icmp eq i64* %400, null
+  br i1 %NullCheck165, label %ThrowNullRef166, label %401
 
 ; <label>:401                                     ; preds = %398
   store i64 %399, i64* %400, align 8
@@ -1400,14 +1482,14 @@ entry:
   %404 = load i8*, i8** %arg1
   %405 = getelementptr inbounds i8, i8* %404, i64 8
   %406 = bitcast i8* %405 to i64*
-  %NullCheck168 = icmp ne i64* %406, null
-  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+  %NullCheck167 = icmp eq i64* %406, null
+  br i1 %NullCheck167, label %ThrowNullRef168, label %407
 
 ; <label>:407                                     ; preds = %401
   %408 = load i64, i64* %406, align 8
   %409 = bitcast i8* %403 to i64*
-  %NullCheck170 = icmp ne i64* %409, null
-  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+  %NullCheck169 = icmp eq i64* %409, null
+  br i1 %NullCheck169, label %ThrowNullRef170, label %410
 
 ; <label>:410                                     ; preds = %407
   store i64 %408, i64* %409, align 8
@@ -1437,14 +1519,14 @@ entry:
   %425 = load i8*, i8** %arg0
   %426 = load i8*, i8** %arg1
   %427 = bitcast i8* %426 to i64*
-  %NullCheck148 = icmp ne i64* %427, null
-  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+  %NullCheck147 = icmp eq i64* %427, null
+  br i1 %NullCheck147, label %ThrowNullRef148, label %428
 
 ; <label>:428                                     ; preds = %424
   %429 = load i64, i64* %427, align 8
   %430 = bitcast i8* %425 to i64*
-  %NullCheck150 = icmp ne i64* %430, null
-  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+  %NullCheck149 = icmp eq i64* %430, null
+  br i1 %NullCheck149, label %ThrowNullRef150, label %431
 
 ; <label>:431                                     ; preds = %428
   store i64 %429, i64* %430, align 8
@@ -1466,14 +1548,14 @@ entry:
   %441 = load i8*, i8** %arg0
   %442 = load i8*, i8** %arg1
   %443 = bitcast i8* %442 to i32*
-  %NullCheck152 = icmp ne i32* %443, null
-  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+  %NullCheck151 = icmp eq i32* %443, null
+  br i1 %NullCheck151, label %ThrowNullRef152, label %444
 
 ; <label>:444                                     ; preds = %440
   %445 = load i32, i32* %443, align 8
   %446 = bitcast i8* %441 to i32*
-  %NullCheck154 = icmp ne i32* %446, null
-  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+  %NullCheck153 = icmp eq i32* %446, null
+  br i1 %NullCheck153, label %ThrowNullRef154, label %447
 
 ; <label>:447                                     ; preds = %444
   store i32 %445, i32* %446, align 8
@@ -1495,16 +1577,16 @@ entry:
   %457 = load i8*, i8** %arg0
   %458 = load i8*, i8** %arg1
   %459 = bitcast i8* %458 to i16*
-  %NullCheck156 = icmp ne i16* %459, null
-  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+  %NullCheck155 = icmp eq i16* %459, null
+  br i1 %NullCheck155, label %ThrowNullRef156, label %460
 
 ; <label>:460                                     ; preds = %456
   %461 = load i16, i16* %459, align 8
   %462 = sext i16 %461 to i32
   %463 = bitcast i8* %457 to i16*
   %464 = trunc i32 %462 to i16
-  %NullCheck158 = icmp ne i16* %463, null
-  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+  %NullCheck157 = icmp eq i16* %463, null
+  br i1 %NullCheck157, label %ThrowNullRef158, label %465
 
 ; <label>:465                                     ; preds = %460
   store i16 %464, i16* %463, align 8
@@ -1525,15 +1607,15 @@ entry:
 ; <label>:474                                     ; preds = %470
   %475 = load i8*, i8** %arg0
   %476 = load i8*, i8** %arg1
-  %NullCheck160 = icmp ne i8* %476, null
-  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+  %NullCheck159 = icmp eq i8* %476, null
+  br i1 %NullCheck159, label %ThrowNullRef160, label %477
 
 ; <label>:477                                     ; preds = %474
   %478 = load i8, i8* %476, align 8
   %479 = zext i8 %478 to i32
   %480 = trunc i32 %479 to i8
-  %NullCheck162 = icmp ne i8* %475, null
-  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+  %NullCheck161 = icmp eq i8* %475, null
+  br i1 %NullCheck161, label %ThrowNullRef162, label %481
 
 ; <label>:481                                     ; preds = %477
   store i8 %480, i8* %475, align 8
@@ -1553,343 +1635,343 @@ ThrowNullRef:                                     ; preds = %308
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %312
+ThrowNullRef2:                                    ; preds = %312
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %315
+ThrowNullRef4:                                    ; preds = %315
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %321
+ThrowNullRef6:                                    ; preds = %321
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %271
+ThrowNullRef8:                                    ; preds = %271
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %275
+ThrowNullRef10:                                   ; preds = %275
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %278
+ThrowNullRef12:                                   ; preds = %278
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %284
+ThrowNullRef14:                                   ; preds = %284
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %287
+ThrowNullRef16:                                   ; preds = %287
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %293
+ThrowNullRef18:                                   ; preds = %293
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %298
+ThrowNullRef20:                                   ; preds = %298
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %303
+ThrowNullRef22:                                   ; preds = %303
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %243
+ThrowNullRef24:                                   ; preds = %243
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %247
+ThrowNullRef26:                                   ; preds = %247
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %250
+ThrowNullRef28:                                   ; preds = %250
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %256
+ThrowNullRef30:                                   ; preds = %256
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %259
+ThrowNullRef32:                                   ; preds = %259
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %265
+ThrowNullRef34:                                   ; preds = %265
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %217
+ThrowNullRef36:                                   ; preds = %217
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %221
+ThrowNullRef38:                                   ; preds = %221
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %224
+ThrowNullRef40:                                   ; preds = %224
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %230
+ThrowNullRef42:                                   ; preds = %230
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %233
+ThrowNullRef44:                                   ; preds = %233
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %238
+ThrowNullRef46:                                   ; preds = %238
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %200
+ThrowNullRef48:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %204
+ThrowNullRef50:                                   ; preds = %204
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %207
+ThrowNullRef52:                                   ; preds = %207
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %213
+ThrowNullRef54:                                   ; preds = %213
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %172
+ThrowNullRef56:                                   ; preds = %172
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %176
+ThrowNullRef58:                                   ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %179
+ThrowNullRef60:                                   ; preds = %179
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %185
+ThrowNullRef62:                                   ; preds = %185
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %190
+ThrowNullRef64:                                   ; preds = %190
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %195
+ThrowNullRef66:                                   ; preds = %195
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %153
+ThrowNullRef68:                                   ; preds = %153
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %157
+ThrowNullRef70:                                   ; preds = %157
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %160
+ThrowNullRef72:                                   ; preds = %160
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %166
+ThrowNullRef74:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %136
+ThrowNullRef76:                                   ; preds = %136
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %140
+ThrowNullRef78:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %143
+ThrowNullRef80:                                   ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %148
+ThrowNullRef82:                                   ; preds = %148
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %128
+ThrowNullRef84:                                   ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %132
+ThrowNullRef86:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %100
+ThrowNullRef88:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %104
+ThrowNullRef90:                                   ; preds = %104
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %107
+ThrowNullRef92:                                   ; preds = %107
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %113
+ThrowNullRef94:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %118
+ThrowNullRef96:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %123
+ThrowNullRef98:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %81
+ThrowNullRef100:                                  ; preds = %81
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef101:                                  ; preds = %85
+ThrowNullRef102:                                  ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef103:                                  ; preds = %88
+ThrowNullRef104:                                  ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef105:                                  ; preds = %94
+ThrowNullRef106:                                  ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef107:                                  ; preds = %64
+ThrowNullRef108:                                  ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef109:                                  ; preds = %68
+ThrowNullRef110:                                  ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef111:                                  ; preds = %71
+ThrowNullRef112:                                  ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef113:                                  ; preds = %76
+ThrowNullRef114:                                  ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef115:                                  ; preds = %56
+ThrowNullRef116:                                  ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef117:                                  ; preds = %60
+ThrowNullRef118:                                  ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef119:                                  ; preds = %37
+ThrowNullRef120:                                  ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef121:                                  ; preds = %41
+ThrowNullRef122:                                  ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef123:                                  ; preds = %46
+ThrowNullRef124:                                  ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef125:                                  ; preds = %51
+ThrowNullRef126:                                  ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef127:                                  ; preds = %27
+ThrowNullRef128:                                  ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef129:                                  ; preds = %31
+ThrowNullRef130:                                  ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef131:                                  ; preds = %19
+ThrowNullRef132:                                  ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef133:                                  ; preds = %22
+ThrowNullRef134:                                  ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef135:                                  ; preds = %338
+ThrowNullRef136:                                  ; preds = %338
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef137:                                  ; preds = %341
+ThrowNullRef138:                                  ; preds = %341
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef139:                                  ; preds = %356
+ThrowNullRef140:                                  ; preds = %356
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef141:                                  ; preds = %360
+ThrowNullRef142:                                  ; preds = %360
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef143:                                  ; preds = %377
+ThrowNullRef144:                                  ; preds = %377
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef145:                                  ; preds = %381
+ThrowNullRef146:                                  ; preds = %381
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef147:                                  ; preds = %424
+ThrowNullRef148:                                  ; preds = %424
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef149:                                  ; preds = %428
+ThrowNullRef150:                                  ; preds = %428
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef151:                                  ; preds = %440
+ThrowNullRef152:                                  ; preds = %440
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef153:                                  ; preds = %444
+ThrowNullRef154:                                  ; preds = %444
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef155:                                  ; preds = %456
+ThrowNullRef156:                                  ; preds = %456
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef157:                                  ; preds = %460
+ThrowNullRef158:                                  ; preds = %460
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef159:                                  ; preds = %474
+ThrowNullRef160:                                  ; preds = %474
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef161:                                  ; preds = %477
+ThrowNullRef162:                                  ; preds = %477
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef163:                                  ; preds = %394
+ThrowNullRef164:                                  ; preds = %394
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef165:                                  ; preds = %398
+ThrowNullRef166:                                  ; preds = %398
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef167:                                  ; preds = %401
+ThrowNullRef168:                                  ; preds = %401
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef169:                                  ; preds = %407
+ThrowNullRef170:                                  ; preds = %407
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1939,8 +2021,8 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
-  br i1 %NullCheck, label %22, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %ThrowNullRef, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
@@ -1948,8 +2030,8 @@ entry:
   store i32 %24, i32* %loc0
   %25 = load i32, i32* %loc0
   %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %26, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %27
 
 ; <label>:27                                      ; preds = %22
   %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
@@ -1971,7 +2053,7 @@ ThrowNullRef:                                     ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1989,8 +2071,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -2022,15 +2104,15 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2048,16 +2130,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
   %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
   store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %15
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
@@ -2072,8 +2154,8 @@ entry:
   %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
   %29 = ptrtoint i16 addrspace(1)* %28 to i64
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %19
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
@@ -2089,19 +2171,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2114,8 +2196,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
@@ -2128,7 +2210,7 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[loadElem]
+Failed to read AppDomain.PrepareDataForSetup[storeElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
@@ -2202,8 +2284,8 @@ entry:
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
-  br i1 %NullCheck24, label %27, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = load i64, i64 addrspace(1)* %26
@@ -2218,8 +2300,8 @@ entry:
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
-  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
   %41 = load i64, i64 addrspace(1)* %39
@@ -2236,8 +2318,8 @@ entry:
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
-  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
   %54 = load i64, i64 addrspace(1)* %52
@@ -2252,8 +2334,8 @@ entry:
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
   %67 = load i64, i64 addrspace(1)* %65
@@ -2270,8 +2352,8 @@ entry:
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
-  br i1 %NullCheck16, label %79, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
   %80 = load i64, i64 addrspace(1)* %78
@@ -2286,8 +2368,8 @@ entry:
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
-  br i1 %NullCheck18, label %92, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
   %93 = load i64, i64 addrspace(1)* %91
@@ -2304,8 +2386,8 @@ entry:
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
-  br i1 %NullCheck12, label %105, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = load i64, i64 addrspace(1)* %104
@@ -2320,8 +2402,8 @@ entry:
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
-  br i1 %NullCheck14, label %118, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
   %119 = load i64, i64 addrspace(1)* %117
@@ -2337,8 +2419,8 @@ entry:
 
 ; <label>:128                                     ; preds = %20
   %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
-  br i1 %NullCheck4, label %130, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %129, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %130
 
 ; <label>:130                                     ; preds = %128
   %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
@@ -2346,8 +2428,8 @@ entry:
   %133 = load i16, i16 addrspace(1)* %132, align 8
   %134 = zext i16 %133 to i32
   %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
-  br i1 %NullCheck6, label %136, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %135, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %136
 
 ; <label>:136                                     ; preds = %130
   %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
@@ -2360,8 +2442,8 @@ entry:
 
 ; <label>:143                                     ; preds = %136
   %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
-  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %144, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %145
 
 ; <label>:145                                     ; preds = %143
   %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
@@ -2369,8 +2451,8 @@ entry:
   %148 = load i16, i16 addrspace(1)* %147, align 8
   %149 = zext i16 %148 to i32
   %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %150, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %151
 
 ; <label>:151                                     ; preds = %145
   %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
@@ -2388,8 +2470,8 @@ entry:
 
 ; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
-  br i1 %NullCheck, label %163, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %ThrowNullRef, label %163
 
 ; <label>:163                                     ; preds = %161
   %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
@@ -2399,8 +2481,8 @@ entry:
 
 ; <label>:167                                     ; preds = %163
   %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
-  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %168, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %169
 
 ; <label>:169                                     ; preds = %167
   %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
@@ -2432,55 +2514,55 @@ ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %167
+ThrowNullRef2:                                    ; preds = %167
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %128
+ThrowNullRef4:                                    ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %130
+ThrowNullRef6:                                    ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %143
+ThrowNullRef8:                                    ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %145
+ThrowNullRef10:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %102
+ThrowNullRef12:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %105
+ThrowNullRef14:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %76
+ThrowNullRef16:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %79
+ThrowNullRef18:                                   ; preds = %79
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %50
+ThrowNullRef20:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %53
+ThrowNullRef22:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %24
+ThrowNullRef24:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %27
+ThrowNullRef26:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2503,15 +2585,15 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2519,16 +2601,16 @@ entry:
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
   store i32 %8, i32* %loc0
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
   %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
   store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
@@ -2546,16 +2628,16 @@ entry:
 
 ; <label>:23                                      ; preds = %64
   %24 = load i16*, i16** %loc3
-  %NullCheck12 = icmp ne i16* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i16* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
   store i32 %27, i32* %loc5
   %28 = load i16*, i16** %loc4
-  %NullCheck14 = icmp ne i16* %28, null
-  br i1 %NullCheck14, label %29, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %28, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = load i16, i16* %28, align 8
@@ -2620,15 +2702,15 @@ entry:
 
 ; <label>:67                                      ; preds = %64
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
-  br i1 %NullCheck8, label %69, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %68, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %69
 
 ; <label>:69                                      ; preds = %67
   %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
   %71 = load i32, i32 addrspace(1)* %70
   %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
-  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %73
 
 ; <label>:73                                      ; preds = %69
   %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
@@ -2645,31 +2727,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %67
+ThrowNullRef8:                                    ; preds = %67
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %69
+ThrowNullRef10:                                   ; preds = %69
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2710,14 +2792,14 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
   %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
@@ -2730,14 +2812,14 @@ entry:
 
 ; <label>:11                                      ; preds = %4
   %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
   %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
@@ -2749,14 +2831,14 @@ entry:
 
 ; <label>:22                                      ; preds = %16
   %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
   %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
-  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
-  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
@@ -2804,23 +2886,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2836,7 +2918,280 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[loadElem]
+Successfully read RuntimeType.IsAssignableFrom
+
+define i8 @RuntimeType.IsAssignableFrom(%System.RuntimeType addrspace(1)* %param0, %System.Type addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.RuntimeType addrspace(1)*
+  %arg1 = alloca %System.Type addrspace(1)*
+  %loc0 = alloca %System.RuntimeType addrspace(1)*
+  %loc1 = alloca %"System.Type[]" addrspace(1)*
+  %loc2 = alloca i32
+  store %System.RuntimeType addrspace(1)* %param0, %System.RuntimeType addrspace(1)** %this
+  store %System.Type addrspace(1)* %param1, %System.Type addrspace(1)** %arg1
+  %0 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %1 = icmp ne %System.Type addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i8 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %5 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %6 = bitcast %System.Type addrspace(1)* %4 to %System.Object addrspace(1)*
+  %7 = bitcast %System.RuntimeType addrspace(1)* %5 to %System.Object addrspace(1)*
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %6, %System.Object addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %3
+  ret i8 1
+
+; <label>:12                                      ; preds = %3
+  %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 152
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 32
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
+  %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
+  %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
+  store %System.RuntimeType addrspace(1)* %25, %System.RuntimeType addrspace(1)** %loc0
+  %26 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %27 = icmp eq %System.RuntimeType addrspace(1)* %26, null
+  br i1 %27, label %34, label %28
+
+; <label>:28                                      ; preds = %15
+  %29 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %30 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)*)*)(%System.RuntimeType addrspace(1)* %29, %System.RuntimeType addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+; <label>:34                                      ; preds = %15
+  %35 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %36 = call %System.Reflection.Emit.TypeBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Reflection.Emit.TypeBuilder addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %35)
+  %37 = icmp eq %System.Reflection.Emit.TypeBuilder addrspace(1)* %36, null
+  br i1 %37, label %139, label %38
+
+; <label>:38                                      ; preds = %34
+  %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %42
+
+; <label>:42                                      ; preds = %38
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 152
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 40
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
+  %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
+  %53 = zext i8 %52 to i32
+  %54 = icmp eq i32 %53, 0
+  br i1 %54, label %56, label %55
+
+; <label>:55                                      ; preds = %42
+  ret i8 1
+
+; <label>:56                                      ; preds = %42
+  %57 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %58 = bitcast %System.RuntimeType addrspace(1)* %57 to %System.Type addrspace(1)*
+  %59 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %58)
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %64 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.Type addrspace(1)* %63, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = bitcast %System.RuntimeType addrspace(1)* %64 to %System.Type addrspace(1)*
+  %67 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %63, %System.Type addrspace(1)* %66)
+  %68 = zext i8 %67 to i32
+  %69 = trunc i32 %68 to i8
+  ret i8 %69
+
+; <label>:70                                      ; preds = %56
+  %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
+  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %73
+
+; <label>:73                                      ; preds = %70
+  %74 = load i64, i64 addrspace(1)* %72
+  %75 = add i64 %74, 128
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = add i64 %77, 0
+  %79 = inttoptr i64 %78 to i64*
+  %80 = load i64, i64* %79
+  %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
+  %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
+  %83 = call i8 %82(%System.Type addrspace(1)* %81)
+  %84 = zext i8 %83 to i32
+  %85 = icmp eq i32 %84, 0
+  br i1 %85, label %139, label %86
+
+; <label>:86                                      ; preds = %73
+  %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
+  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %89
+
+; <label>:89                                      ; preds = %86
+  %90 = load i64, i64 addrspace(1)* %88
+  %91 = add i64 %90, 128
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = add i64 %93, 24
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
+  %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
+  %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
+  store %"System.Type[]" addrspace(1)* %99, %"System.Type[]" addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %129
+
+; <label>:100                                     ; preds = %132
+  %101 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %102 = load i32, i32* %loc2
+  %NullCheck11 = icmp eq %"System.Type[]" addrspace(1)* %101, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %103
+
+; <label>:103                                     ; preds = %100
+  %104 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 1
+  %105 = load i32, i32 addrspace(1)* %104
+  %106 = zext i32 %105 to i64
+  %107 = zext i32 %102 to i64
+  %BoundsCheck = icmp uge i64 %107, %106
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %108
+
+; <label>:108                                     ; preds = %103
+  %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
+  %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
+  %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
+  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %113
+
+; <label>:113                                     ; preds = %108
+  %114 = load i64, i64 addrspace(1)* %112
+  %115 = add i64 %114, 152
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = add i64 %117, 56
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
+  %123 = zext i8 %122 to i32
+  %124 = icmp ne i32 %123, 0
+  br i1 %124, label %126, label %125
+
+; <label>:125                                     ; preds = %113
+  ret i8 0
+
+; <label>:126                                     ; preds = %113
+  %127 = load i32, i32* %loc2
+  %128 = add i32 %127, 1
+  store i32 %128, i32* %loc2
+  br label %129
+
+; <label>:129                                     ; preds = %89, %126
+  %130 = load i32, i32* %loc2
+  %131 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %NullCheck9 = icmp eq %"System.Type[]" addrspace(1)* %131, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %132
+
+; <label>:132                                     ; preds = %129
+  %133 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %131, i32 0, i32 1
+  %134 = load i32, i32 addrspace(1)* %133
+  %135 = zext i32 %134 to i64
+  %136 = trunc i64 %135 to i32
+  %137 = icmp slt i32 %130, %136
+  br i1 %137, label %100, label %138
+
+; <label>:138                                     ; preds = %132
+  ret i8 1
+
+; <label>:139                                     ; preds = %34, %73
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %129
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %103
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -2893,7 +3248,7 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElem]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -2904,8 +3259,8 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -2997,8 +3352,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
@@ -3059,8 +3414,8 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -3087,8 +3442,8 @@ entry:
 
 ; <label>:17                                      ; preds = %5, %11
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
@@ -3097,8 +3452,8 @@ entry:
 
 ; <label>:22                                      ; preds = %1, %11
   %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
@@ -3109,11 +3464,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %17
+ThrowNullRef2:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %22
+ThrowNullRef4:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3167,15 +3522,15 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
   %15 = load i32, i32 addrspace(1)* %14
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
@@ -3198,7 +3553,7 @@ ThrowNullRef:                                     ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef2:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3232,8 +3587,8 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
@@ -3312,8 +3667,8 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -3327,8 +3682,8 @@ entry:
 ; <label>:5                                       ; preds = %43
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %7 = load i32, i32* %loc1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck6, label %8, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
@@ -3366,8 +3721,8 @@ entry:
 ; <label>:32                                      ; preds = %21, %25
   %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
   %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
-  br i1 %NullCheck8, label %35, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = trunc i32 %34 to i16
@@ -3380,8 +3735,8 @@ entry:
 ; <label>:40                                      ; preds = %1, %35
   %41 = load i32, i32* %loc1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
-  br i1 %NullCheck2, label %43, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %42, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
@@ -3392,8 +3747,8 @@ entry:
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
   %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
-  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
   %51 = load i64, i64 addrspace(1)* %49
@@ -3412,19 +3767,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %40
+ThrowNullRef2:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %47
+ThrowNullRef4:                                    ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %5
+ThrowNullRef6:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %32
+ThrowNullRef8:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3467,8 +3822,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
@@ -3492,11 +3847,391 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(i16* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store i16* %param0, i16** %arg0
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load i32, i32* %arg3
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %42, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %37, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg2
+  %13 = load i32, i32* %arg3
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %37, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %24 = load i32, i32* %arg2
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load i16*, i16** %arg0
+  %35 = load i32, i32* %arg3
+  %36 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %36, i16* %34, i32 %35)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:37                                      ; preds = %5, %16
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %39)
+  %41 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41, %System.String addrspace(1)* %38, %System.String addrspace(1)* %40)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41) #0
+  unreachable
+
+; <label>:42                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
-Failed to read StringBuilder.ToString[loadElemA]
+Successfully read StringBuilder.ToString
+
+define %System.String addrspace(1)* @StringBuilder.ToString(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i16*
+  %loc3 = alloca %"System.Char[]" addrspace(1)*
+  %loc4 = alloca i32
+  %loc5 = alloca i32
+  %loc6 = alloca i16 addrspace(1)*
+  %loc7 = alloca %System.String addrspace(1)*
+  %loc8 = alloca %"System.Char[]" addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %0)
+  %2 = icmp ne i32 %1, 0
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %4
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %6)
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %7)
+  store %System.String addrspace(1)* %8, %System.String addrspace(1)** %loc0
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.Text.StringBuilder addrspace(1)* %9, %System.Text.StringBuilder addrspace(1)** %loc1
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  store %System.String addrspace(1)* %10, %System.String addrspace(1)** %loc7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc7
+  %12 = ptrtoint %System.String addrspace(1)* %11 to i64
+  %13 = icmp eq i64 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %5
+  %15 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %16 = sext i32 %15 to i64
+  %17 = add i64 %12, %16
+  br label %18
+
+; <label>:18                                      ; preds = %5, %14
+  %19 = phi i64 [ %12, %5 ], [ %17, %14 ]
+  %20 = inttoptr i64 %19 to i16*
+  store i16* %20, i16** %loc2
+  br label %21
+
+; <label>:21                                      ; preds = %98, %18
+  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %22, null
+  br i1 %NullCheck, label %ThrowNullRef, label %23
+
+; <label>:23                                      ; preds = %21
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 3
+  %25 = load i32, i32 addrspace(1)* %24, align 8
+  %26 = icmp sle i32 %25, 0
+  br i1 %26, label %96, label %27
+
+; <label>:27                                      ; preds = %23
+  %28 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %28, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %29
+
+; <label>:29                                      ; preds = %27
+  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %28, i32 0, i32 1
+  %31 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %30, align 8
+  store %"System.Char[]" addrspace(1)* %31, %"System.Char[]" addrspace(1)** %loc3
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %33
+
+; <label>:33                                      ; preds = %29
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  store i32 %35, i32* %loc4
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  %39 = load i32, i32 addrspace(1)* %38, align 8
+  store i32 %39, i32* %loc5
+  %40 = load i32, i32* %loc5
+  %41 = load i32, i32* %loc4
+  %42 = add i32 %40, %41
+  %43 = zext i32 %42 to i64
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %45
+
+; <label>:45                                      ; preds = %37
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = sext i32 %47 to i64
+  %49 = icmp sgt i64 %43, %48
+  br i1 %49, label %91, label %50
+
+; <label>:50                                      ; preds = %45
+  %51 = load i32, i32* %loc5
+  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %52, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %53
+
+; <label>:53                                      ; preds = %50
+  %54 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %52, i32 0, i32 1
+  %55 = load i32, i32 addrspace(1)* %54
+  %56 = zext i32 %55 to i64
+  %57 = trunc i64 %56 to i32
+  %58 = icmp ugt i32 %51, %57
+  br i1 %58, label %91, label %59
+
+; <label>:59                                      ; preds = %53
+  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  store %"System.Char[]" addrspace(1)* %60, %"System.Char[]" addrspace(1)** %loc8
+  %61 = icmp eq %"System.Char[]" addrspace(1)* %60, null
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %63, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %64
+
+; <label>:64                                      ; preds = %62
+  %65 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %63, i32 0, i32 1
+  %66 = load i32, i32 addrspace(1)* %65
+  %67 = zext i32 %66 to i64
+  %68 = trunc i64 %67 to i32
+  %69 = icmp ne i32 %68, 0
+  br i1 %69, label %71, label %70
+
+; <label>:70                                      ; preds = %59, %64
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:71                                      ; preds = %64
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %73
+
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %BoundsCheck = icmp uge i64 0, %76
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %77
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %78, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:79                                      ; preds = %70, %77
+  %80 = load i16*, i16** %loc2
+  %81 = load i32, i32* %loc4
+  %82 = sext i32 %81 to i64
+  %83 = mul i64 %82, 2
+  %84 = bitcast i16* %80 to i8*
+  %85 = getelementptr inbounds i8, i8* %84, i64 %83
+  %86 = load i16 addrspace(1)*, i16 addrspace(1)** %loc6
+  %87 = ptrtoint i16 addrspace(1)* %86 to i64
+  %88 = load i32, i32* %loc5
+  %89 = bitcast i8* %85 to i16*
+  %90 = inttoptr i64 %87 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %89, i16* %90, i32 %88)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %96
+
+; <label>:91                                      ; preds = %45, %53
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %94 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %93)
+  %95 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95, %System.String addrspace(1)* %92, %System.String addrspace(1)* %94)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95) #0
+  unreachable
+
+; <label>:96                                      ; preds = %23, %79
+  %97 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %97, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %98
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %97, i32 0, i32 2
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  store %System.Text.StringBuilder addrspace(1)* %100, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %102 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %102, label %21, label %103
+
+; <label>:103                                     ; preds = %98
+  store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc7
+  %104 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  ret %System.String addrspace(1)* %104
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method StringBuilder::get_Length using LLILCJit
+Successfully read StringBuilder.get_Length
+
+define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
+Successfully read RuntimeHelpers.get_OffsetToStringData
+
+define i32 @RuntimeHelpers.get_OffsetToStringData() {
+entry:
+  ret i32 12
+}
+
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
 Successfully read CultureData.CreateCultureData
 
@@ -3514,23 +4249,23 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
   store i8 %4, i8 addrspace(1)* %6
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
@@ -3549,11 +4284,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3566,50 +4301,50 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
   store i32 -1, i32 addrspace(1)* %2
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
   store i32 -1, i32 addrspace(1)* %8
   %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
   store i32 -1, i32 addrspace(1)* %14
   %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
   store i32 -1, i32 addrspace(1)* %17
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
@@ -3623,27 +4358,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3675,7 +4410,136 @@ Failed to read Dictionary`2.Insert[non-const derefAddress]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
 Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
-Failed to read HashHelpers.GetPrime[loadElem]
+Successfully read HashHelpers.GetPrime
+
+define i32 @HashHelpers.GetPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %6, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5, %System.String addrspace(1)* %4)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5) #0
+  unreachable
+
+; <label>:6                                       ; preds = %entry
+  store i32 0, i32* %loc0
+  br label %29
+
+; <label>:7                                       ; preds = %35
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 1296
+  %10 = addrspacecast i8 addrspace(1)* %9 to %"System.Int32[]" addrspace(1)**
+  %11 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %10
+  %12 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Int32[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = zext i32 %15 to i64
+  %17 = zext i32 %12 to i64
+  %BoundsCheck = icmp uge i64 %17, %16
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 3, i32 %12
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  store i32 %20, i32* %loc1
+  %21 = load i32, i32* %loc1
+  %22 = load i32, i32* %arg0
+  %23 = icmp slt i32 %21, %22
+  br i1 %23, label %26, label %24
+
+; <label>:24                                      ; preds = %18
+  %25 = load i32, i32* %loc1
+  ret i32 %25
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %loc0
+  %28 = add i32 %27, 1
+  store i32 %28, i32* %loc0
+  br label %29
+
+; <label>:29                                      ; preds = %6, %26
+  %30 = load i32, i32* %loc0
+  %31 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %32 = getelementptr inbounds i8, i8 addrspace(1)* %31, i64 1296
+  %33 = addrspacecast i8 addrspace(1)* %32 to %"System.Int32[]" addrspace(1)**
+  %34 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %33
+  %NullCheck = icmp eq %"System.Int32[]" addrspace(1)* %34, null
+  br i1 %NullCheck, label %ThrowNullRef, label %35
+
+; <label>:35                                      ; preds = %29
+  %36 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %34, i32 0, i32 1
+  %37 = load i32, i32 addrspace(1)* %36
+  %38 = zext i32 %37 to i64
+  %39 = trunc i64 %38 to i32
+  %40 = icmp slt i32 %30, %39
+  br i1 %40, label %7, label %41
+
+; <label>:41                                      ; preds = %35
+  %42 = load i32, i32* %arg0
+  %43 = or i32 %42, 1
+  store i32 %43, i32* %loc2
+  br label %59
+
+; <label>:44                                      ; preds = %59
+  %45 = load i32, i32* %loc2
+  %46 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %45)
+  %47 = zext i8 %46 to i32
+  %48 = icmp eq i32 %47, 0
+  br i1 %48, label %56, label %49
+
+; <label>:49                                      ; preds = %44
+  %50 = load i32, i32* %loc2
+  %51 = sub i32 %50, 1
+  %52 = srem i32 %51, 101
+  %53 = icmp eq i32 %52, 0
+  br i1 %53, label %56, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = load i32, i32* %loc2
+  ret i32 %55
+
+; <label>:56                                      ; preds = %44, %49
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %57, 2
+  store i32 %58, i32* %loc2
+  br label %59
+
+; <label>:59                                      ; preds = %41, %56
+  %60 = load i32, i32* %loc2
+  %61 = icmp slt i32 %60, 2147483647
+  br i1 %61, label %44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load i32, i32* %arg0
+  ret i32 %63
+
+ThrowNullRef:                                     ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
 Successfully read GenericEqualityComparer`1.GetHashCode
 
@@ -3694,14 +4558,14 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
   %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load i64, i64 addrspace(1)* %7
@@ -3720,7 +4584,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3750,8 +4614,8 @@ entry:
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
@@ -3796,8 +4660,8 @@ entry:
   %35 = bitcast i16* %34 to i8*
   %36 = getelementptr inbounds i8, i8* %35, i64 2
   %37 = bitcast i8* %36 to i16*
-  %NullCheck4 = icmp ne i16* %37, null
-  br i1 %NullCheck4, label %38, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %37, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %38
 
 ; <label>:38                                      ; preds = %27
   %39 = load i16, i16* %37, align 8
@@ -3824,8 +4688,8 @@ entry:
 
 ; <label>:54                                      ; preds = %22, %43
   %55 = load i16*, i16** %loc4
-  %NullCheck2 = icmp ne i16* %55, null
-  br i1 %NullCheck2, label %56, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i16* %55, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %56
 
 ; <label>:56                                      ; preds = %54
   %57 = load i16, i16* %55, align 8
@@ -3850,11 +4714,11 @@ ThrowNullRef:                                     ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %54
+ThrowNullRef2:                                    ; preds = %54
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %27
+ThrowNullRef4:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3871,8 +4735,8 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -3907,8 +4771,8 @@ entry:
 
 ; <label>:26                                      ; preds = %19
   %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
-  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %28
 
 ; <label>:28                                      ; preds = %26
   %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
@@ -3920,7 +4784,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3972,8 +4836,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
@@ -3984,26 +4848,26 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
-  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
@@ -4014,8 +4878,8 @@ entry:
 ; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
@@ -4024,8 +4888,8 @@ entry:
 
 ; <label>:25                                      ; preds = %1, %16, %23
   %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
-  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
@@ -4036,27 +4900,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %20
+ThrowNullRef10:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4069,8 +4933,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -4081,8 +4945,8 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
@@ -4091,8 +4955,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1, %8
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
@@ -4103,11 +4967,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4128,24 +4992,24 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   store i32 %3, i32* %loc0
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
   %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
   store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck4, label %9, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
@@ -4164,15 +5028,15 @@ entry:
 ; <label>:18                                      ; preds = %70
   %19 = load i16*, i16** %loc3
   %20 = bitcast i16* %19 to i64*
-  %NullCheck10 = icmp ne i64* %20, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %20, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = load i64, i64* %20, align 8
   %23 = load i16*, i16** %loc4
   %24 = bitcast i16* %23 to i64*
-  %NullCheck12 = icmp ne i64* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = load i64, i64* %24, align 8
@@ -4188,8 +5052,8 @@ entry:
   %31 = bitcast i16* %30 to i8*
   %32 = getelementptr inbounds i8, i8* %31, i64 8
   %33 = bitcast i8* %32 to i64*
-  %NullCheck14 = icmp ne i64* %33, null
-  br i1 %NullCheck14, label %34, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = load i64, i64* %33, align 8
@@ -4197,8 +5061,8 @@ entry:
   %37 = bitcast i16* %36 to i8*
   %38 = getelementptr inbounds i8, i8* %37, i64 8
   %39 = bitcast i8* %38 to i64*
-  %NullCheck16 = icmp ne i64* %39, null
-  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %40
 
 ; <label>:40                                      ; preds = %34
   %41 = load i64, i64* %39, align 8
@@ -4214,8 +5078,8 @@ entry:
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %NullCheck18 = icmp ne i64* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = load i64, i64* %48, align 8
@@ -4223,8 +5087,8 @@ entry:
   %52 = bitcast i16* %51 to i8*
   %53 = getelementptr inbounds i8, i8* %52, i64 16
   %54 = bitcast i8* %53 to i64*
-  %NullCheck20 = icmp ne i64* %54, null
-  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64* %54, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %55
 
 ; <label>:55                                      ; preds = %49
   %56 = load i64, i64* %54, align 8
@@ -4262,15 +5126,15 @@ entry:
 ; <label>:74                                      ; preds = %95
   %75 = load i16*, i16** %loc3
   %76 = bitcast i16* %75 to i32*
-  %NullCheck6 = icmp ne i32* %76, null
-  br i1 %NullCheck6, label %77, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32* %76, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %77
 
 ; <label>:77                                      ; preds = %74
   %78 = load i32, i32* %76, align 8
   %79 = load i16*, i16** %loc4
   %80 = bitcast i16* %79 to i32*
-  %NullCheck8 = icmp ne i32* %80, null
-  br i1 %NullCheck8, label %81, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i32* %80, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %81
 
 ; <label>:81                                      ; preds = %77
   %82 = load i32, i32* %80, align 8
@@ -4318,43 +5182,43 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %74
+ThrowNullRef6:                                    ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %77
+ThrowNullRef8:                                    ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %29
+ThrowNullRef14:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %34
+ThrowNullRef16:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4376,8 +5240,8 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load i64, i64 addrspace(1)* %4
@@ -4389,8 +5253,8 @@ entry:
   %12 = load i64, i64* %11
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %5
   %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
@@ -4399,8 +5263,8 @@ entry:
   %18 = load i8, i8* %arg2
   %19 = zext i8 %18 to i32
   %20 = trunc i32 %19 to i8
-  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %15
   %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
@@ -4411,11 +5275,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4442,8 +5306,8 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
@@ -4466,16 +5330,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
   %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = load i64, i64 addrspace(1)* %19
@@ -4500,8 +5364,8 @@ entry:
 ; <label>:35                                      ; preds = %30
   %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
@@ -4514,8 +5378,8 @@ entry:
 
 ; <label>:42                                      ; preds = %1, %38
   %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
-  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
@@ -4526,19 +5390,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %35
+ThrowNullRef2:                                    ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %42
+ThrowNullRef8:                                    ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4551,14 +5415,14 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
@@ -4570,7 +5434,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4583,8 +5447,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
@@ -4613,51 +5477,51 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
   %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
   %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
   %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
   %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
-  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
   store i64 %21, i64 addrspace(1)* %23
   %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %25 = load i64, i64* %loc0
-  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
@@ -4668,27 +5532,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %22
+ThrowNullRef12:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4701,8 +5565,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
@@ -4713,19 +5577,19 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
@@ -4734,8 +5598,8 @@ entry:
 
 ; <label>:15                                      ; preds = %1, %13
   %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
@@ -4746,19 +5610,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %15
+ThrowNullRef8:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4771,8 +5635,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -4831,8 +5695,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
@@ -4882,8 +5746,8 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
-  br i1 %NullCheck, label %17, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %ThrowNullRef, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
@@ -4894,15 +5758,15 @@ entry:
 
 ; <label>:22                                      ; preds = %17
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
-  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
   %26 = load i32, i32 addrspace(1)* %25
   %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
-  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %27, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
@@ -4925,8 +5789,8 @@ entry:
 ; <label>:40                                      ; preds = %17
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
-  br i1 %NullCheck6, label %43, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %41, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
@@ -4938,34 +5802,17 @@ ThrowNullRef:                                     ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %24
+ThrowNullRef4:                                    ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %40
+ThrowNullRef6:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
-}
-
-INFO:  jitting method Object::ReferenceEquals using LLILCJit
-Successfully read Object.ReferenceEquals
-
-define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
-entry:
-  %arg0 = alloca %System.Object addrspace(1)*
-  %arg1 = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
-  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
-  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = icmp eq %System.Object addrspace(1)* %0, %1
-  %3 = sext i1 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
 }
 
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
@@ -4978,21 +5825,21 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
   %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
-  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
@@ -5007,28 +5854,28 @@ entry:
 ; <label>:13                                      ; preds = %8, %12
   %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
   %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
   %21 = load i32, i32 addrspace(1)* %20, align 8
   %22 = add i32 %21, 1
-  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
   store i32 %22, i32 addrspace(1)* %24
   %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
@@ -5039,27 +5886,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5077,7 +5924,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::Setup using LLILCJit
-Failed to read AppDomain.Setup[loadElem]
+Failed to read AppDomain.Setup[unbox]
 INFO:  jitting method Thread::GetDomain using LLILCJit
 Successfully read Thread.GetDomain
 
@@ -5108,8 +5955,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
@@ -5122,14 +5969,14 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
   %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
@@ -5141,11 +5988,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5173,8 +6020,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -5189,7 +6036,328 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
 Failed to read KeyCollection.System.Collections.Generic.IEnumerable<TKey>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Successfully read Enumerator.MoveNext
+
+define i8 @Enumerator.MoveNext(%"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.RuntimeTypeHandle* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*
+  %"$TypeArg" = alloca %System.RuntimeTypeHandle*
+  store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
+  %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 8
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %76, label %12
+
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
+  br label %76
+
+; <label>:13                                      ; preds = %85
+  %14 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck19 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %15
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, i32 0, i32 0
+  %17 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %16, align 8
+  %NullCheck21 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, i32 0, i32 2
+  %20 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %19, align 8
+  %21 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck23 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %22
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, i32 0, i32 2
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %NullCheck25 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 3, i32 %24
+  %NullCheck27 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %32
+
+; <label>:32                                      ; preds = %30
+  %33 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, i32 0, i32 2
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = icmp slt i32 %34, 0
+  br i1 %35, label %68, label %36
+
+; <label>:36                                      ; preds = %32
+  %37 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %38 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck29 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %39
+
+; <label>:39                                      ; preds = %36
+  %40 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, i32 0, i32 0
+  %41 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %40, align 8
+  %NullCheck31 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, i32 0, i32 2
+  %44 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %43, align 8
+  %45 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck33 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, i32 0, i32 2
+  %48 = load i32, i32 addrspace(1)* %47, align 8
+  %NullCheck35 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %49
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = zext i32 %51 to i64
+  %53 = zext i32 %48 to i64
+  %BoundsCheck37 = icmp uge i64 %53, %52
+  br i1 %BoundsCheck37, label %ThrowIndexOutOfRange38, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 3, i32 %48
+  %NullCheck39 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %56
+
+; <label>:56                                      ; preds = %54
+  %57 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, i32 0, i32 0
+  %58 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck41 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %59
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %60, %System.__Canon addrspace(1)* %58)
+  %61 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck43 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  %64 = load i32, i32 addrspace(1)* %63, align 8
+  %65 = add i32 %64, 1
+  %NullCheck45 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  store i32 %65, i32 addrspace(1)* %67
+  ret i8 1
+
+; <label>:68                                      ; preds = %32
+  %69 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck47 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %73 = add i32 %72, 1
+  %NullCheck49 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %74
+
+; <label>:74                                      ; preds = %70
+  %75 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  store i32 %73, i32 addrspace(1)* %75
+  br label %76
+
+; <label>:76                                      ; preds = %8, %12, %74
+  %77 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %78
+
+; <label>:78                                      ; preds = %76
+  %79 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, i32 0, i32 2
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck7 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %82
+
+; <label>:82                                      ; preds = %78
+  %83 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, i32 0, i32 0
+  %84 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %83, align 8
+  %NullCheck9 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %85
+
+; <label>:85                                      ; preds = %82
+  %86 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, i32 0, i32 7
+  %87 = load i32, i32 addrspace(1)* %86, align 8
+  %88 = icmp ult i32 %80, %87
+  br i1 %88, label %13, label %89
+
+; <label>:89                                      ; preds = %85
+  %90 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %91 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck11 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %92
+
+; <label>:92                                      ; preds = %89
+  %93 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, i32 0, i32 0
+  %94 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck13 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %95
+
+; <label>:95                                      ; preds = %92
+  %96 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, i32 0, i32 7
+  %97 = load i32, i32 addrspace(1)* %96, align 8
+  %98 = add i32 %97, 1
+  %NullCheck15 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %99
+
+; <label>:99                                      ; preds = %95
+  %100 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, i32 0, i32 2
+  store i32 %98, i32 addrspace(1)* %100
+  %101 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck17 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %102
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %103, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %92
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef22:                                   ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef24:                                   ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef26:                                   ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef28:                                   ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef30:                                   ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef32:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef34:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef36:                                   ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange38:                           ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef40:                                   ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef42:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef44:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef46:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef48:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef50:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -5200,8 +6368,8 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -5232,9 +6400,9 @@ Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
 Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
-Failed to read String.MakeSeparatorList[loadElemA]
+Failed to read String.MakeSeparatorList[storeElem]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
-Failed to read String.InternalSplitKeepEmptyEntries[loadElem]
+Failed to read String.InternalSplitKeepEmptyEntries[storeElem]
 INFO:  jitting method Path::IsRelative using LLILCJit
 Successfully read Path.IsRelative
 
@@ -5243,8 +6411,8 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -5254,8 +6422,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
@@ -5271,8 +6439,8 @@ entry:
 
 ; <label>:17                                      ; preds = %7
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
@@ -5288,8 +6456,8 @@ entry:
 
 ; <label>:29                                      ; preds = %19
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %31
 
 ; <label>:31                                      ; preds = %29
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
@@ -5300,8 +6468,8 @@ entry:
 
 ; <label>:36                                      ; preds = %31
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
-  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %37, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
@@ -5312,8 +6480,8 @@ entry:
 
 ; <label>:43                                      ; preds = %31, %38
   %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
-  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %45
 
 ; <label>:45                                      ; preds = %43
   %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
@@ -5324,8 +6492,8 @@ entry:
 
 ; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %50
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
@@ -5336,8 +6504,8 @@ entry:
 
 ; <label>:57                                      ; preds = %1, %7, %19, %45, %52
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
-  br i1 %NullCheck14, label %59, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %59
 
 ; <label>:59                                      ; preds = %57
   %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
@@ -5347,8 +6515,8 @@ entry:
 
 ; <label>:63                                      ; preds = %59
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
@@ -5359,8 +6527,8 @@ entry:
 
 ; <label>:70                                      ; preds = %65
   %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
-  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.String addrspace(1)* %71, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %72
 
 ; <label>:72                                      ; preds = %70
   %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
@@ -5379,39 +6547,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %17
+ThrowNullRef4:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %29
+ThrowNullRef6:                                    ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %36
+ThrowNullRef8:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %43
+ThrowNullRef10:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %50
+ThrowNullRef12:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %57
+ThrowNullRef14:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %63
+ThrowNullRef16:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %70
+ThrowNullRef18:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5419,7 +6587,293 @@ ThrowNullRef17:                                   ; preds = %70
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
-Failed to read String.TrimHelper[loadElem]
+Successfully read String.TrimHelper
+
+define %System.String addrspace(1)* @String.TrimHelper(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i16
+  %loc4 = alloca i32
+  %loc5 = alloca i16
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = sub i32 %3, 1
+  store i32 %4, i32* %loc0
+  store i32 0, i32* %loc1
+  %5 = load i32, i32* %arg2
+  %6 = icmp eq i32 %5, 1
+  br i1 %6, label %62, label %7
+
+; <label>:7                                       ; preds = %1
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:8                                       ; preds = %58
+  store i32 0, i32* %loc2
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load i32, i32* %loc1
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2, i32 %10
+  %13 = load i16, i16 addrspace(1)* %12
+  %14 = zext i16 %13 to i32
+  %15 = trunc i32 %14 to i16
+  store i16 %15, i16* %loc3
+  store i32 0, i32* %loc2
+  br label %34
+
+; <label>:16                                      ; preds = %37
+  %17 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %18 = load i32, i32* %loc2
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %17, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %19
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = zext i32 %18 to i64
+  %BoundsCheck = icmp uge i64 %23, %22
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %24
+
+; <label>:24                                      ; preds = %19
+  %25 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 3, i32 %18
+  %26 = load i16, i16 addrspace(1)* %25, align 8
+  %27 = zext i16 %26 to i32
+  %28 = load i16, i16* %loc3
+  %29 = zext i16 %28 to i32
+  %30 = icmp eq i32 %27, %29
+  br i1 %30, label %43, label %31
+
+; <label>:31                                      ; preds = %24
+  %32 = load i32, i32* %loc2
+  %33 = add i32 %32, 1
+  store i32 %33, i32* %loc2
+  br label %34
+
+; <label>:34                                      ; preds = %11, %31
+  %35 = load i32, i32* %loc2
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = icmp slt i32 %35, %41
+  br i1 %42, label %16, label %43
+
+; <label>:43                                      ; preds = %24, %37
+  %44 = load i32, i32* %loc2
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %45, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp eq i32 %44, %50
+  br i1 %51, label %62, label %52
+
+; <label>:52                                      ; preds = %46
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %7, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %57, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %58
+
+; <label>:58                                      ; preds = %55
+  %59 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %60 = load i32, i32 addrspace(1)* %59
+  %61 = icmp slt i32 %56, %60
+  br i1 %61, label %8, label %62
+
+; <label>:62                                      ; preds = %1, %46, %58
+  %63 = load i32, i32* %arg2
+  %64 = icmp eq i32 %63, 0
+  br i1 %64, label %122, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %66, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %67
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %66, i32 0, i32 1
+  %69 = load i32, i32 addrspace(1)* %68
+  %70 = sub i32 %69, 1
+  store i32 %70, i32* %loc0
+  br label %118
+
+; <label>:71                                      ; preds = %118
+  store i32 0, i32* %loc4
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %73 = load i32, i32* %loc0
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %74
+
+; <label>:74                                      ; preds = %71
+  %75 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 2, i32 %73
+  %76 = load i16, i16 addrspace(1)* %75
+  %77 = zext i16 %76 to i32
+  %78 = trunc i32 %77 to i16
+  store i16 %78, i16* %loc5
+  store i32 0, i32* %loc4
+  br label %97
+
+; <label>:79                                      ; preds = %100
+  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %81 = load i32, i32* %loc4
+  %NullCheck19 = icmp eq %"System.Char[]" addrspace(1)* %80, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
+
+; <label>:82                                      ; preds = %79
+  %83 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 1
+  %84 = load i32, i32 addrspace(1)* %83
+  %85 = zext i32 %84 to i64
+  %86 = zext i32 %81 to i64
+  %BoundsCheck21 = icmp uge i64 %86, %85
+  br i1 %BoundsCheck21, label %ThrowIndexOutOfRange22, label %87
+
+; <label>:87                                      ; preds = %82
+  %88 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 3, i32 %81
+  %89 = load i16, i16 addrspace(1)* %88, align 8
+  %90 = zext i16 %89 to i32
+  %91 = load i16, i16* %loc5
+  %92 = zext i16 %91 to i32
+  %93 = icmp eq i32 %90, %92
+  br i1 %93, label %106, label %94
+
+; <label>:94                                      ; preds = %87
+  %95 = load i32, i32* %loc4
+  %96 = add i32 %95, 1
+  store i32 %96, i32* %loc4
+  br label %97
+
+; <label>:97                                      ; preds = %74, %94
+  %98 = load i32, i32* %loc4
+  %99 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck15 = icmp eq %"System.Char[]" addrspace(1)* %99, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %100
+
+; <label>:100                                     ; preds = %97
+  %101 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %99, i32 0, i32 1
+  %102 = load i32, i32 addrspace(1)* %101
+  %103 = zext i32 %102 to i64
+  %104 = trunc i64 %103 to i32
+  %105 = icmp slt i32 %98, %104
+  br i1 %105, label %79, label %106
+
+; <label>:106                                     ; preds = %87, %100
+  %107 = load i32, i32* %loc4
+  %108 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck17 = icmp eq %"System.Char[]" addrspace(1)* %108, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %109
+
+; <label>:109                                     ; preds = %106
+  %110 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %108, i32 0, i32 1
+  %111 = load i32, i32 addrspace(1)* %110
+  %112 = zext i32 %111 to i64
+  %113 = trunc i64 %112 to i32
+  %114 = icmp eq i32 %107, %113
+  br i1 %114, label %122, label %115
+
+; <label>:115                                     ; preds = %109
+  %116 = load i32, i32* %loc0
+  %117 = sub i32 %116, 1
+  store i32 %117, i32* %loc0
+  br label %118
+
+; <label>:118                                     ; preds = %67, %115
+  %119 = load i32, i32* %loc0
+  %120 = load i32, i32* %loc1
+  %121 = icmp sge i32 %119, %120
+  br i1 %121, label %71, label %122
+
+; <label>:122                                     ; preds = %62, %109, %118
+  %123 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %124 = load i32, i32* %loc1
+  %125 = load i32, i32* %loc0
+  %126 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %123, i32 %124, i32 %125)
+  ret %System.String addrspace(1)* %126
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %97
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange22:                           ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
 Successfully read String.CreateTrimmedString
 
@@ -5439,8 +6893,8 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
@@ -5535,8 +6989,8 @@ entry:
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i64 2872
   %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
   %8 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %7
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %3
   %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
@@ -5553,8 +7007,8 @@ entry:
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 2864
   %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
   %21 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %20
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
-  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %22
 
 ; <label>:22                                      ; preds = %16
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
@@ -5569,7 +7023,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %16
+ThrowNullRef2:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5586,8 +7040,8 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5613,8 +7067,8 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
@@ -5632,8 +7086,8 @@ entry:
 
 ; <label>:12                                      ; preds = %4
   %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
@@ -5644,8 +7098,8 @@ entry:
 
 ; <label>:19                                      ; preds = %14
   %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %19
   %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
@@ -5660,21 +7114,21 @@ entry:
   %31 = zext i16 %30 to i32
   %32 = bitcast i8* %29 to i16*
   %33 = trunc i32 %31 to i16
-  %NullCheck6 = icmp ne i16* %32, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i16* %32, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %21
   store i16 %33, i16* %32, align 8
   %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %36
 
 ; <label>:36                                      ; preds = %34
   %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
   %38 = load i32, i32 addrspace(1)* %37, align 8
   %39 = add i32 %38, 1
-  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %40
 
 ; <label>:40                                      ; preds = %36
   %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
@@ -5683,16 +7137,16 @@ entry:
 
 ; <label>:42                                      ; preds = %14
   %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
-  br i1 %NullCheck12, label %44, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
   %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
   %47 = load i16, i16* %arg1
   %48 = zext i16 %47 to i32
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = trunc i32 %48 to i16
@@ -5703,31 +7157,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %19
+ThrowNullRef4:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %21
+ThrowNullRef6:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %36
+ThrowNullRef10:                                   ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %42
+ThrowNullRef12:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %44
+ThrowNullRef14:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5740,8 +7194,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -5752,8 +7206,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
@@ -5762,14 +7216,14 @@ entry:
 
 ; <label>:11                                      ; preds = %1
   %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
@@ -5779,15 +7233,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5808,8 +7262,8 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5822,8 +7276,8 @@ entry:
 
 ; <label>:8                                       ; preds = %3
   %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
@@ -5842,15 +7296,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
-  br i1 %NullCheck4, label %22, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
   %24 = load i16*, i16* addrspace(1)* %23, align 8
   %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %25, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
@@ -5859,8 +7313,8 @@ entry:
   store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
@@ -5874,8 +7328,8 @@ entry:
 
 ; <label>:37                                      ; preds = %65
   %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %37
   %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
@@ -5886,16 +7340,16 @@ entry:
   %45 = bitcast i16* %41 to i8*
   %46 = getelementptr inbounds i8, i8* %45, i64 %44
   %47 = bitcast i8* %46 to i16*
-  %NullCheck14 = icmp ne i16* %47, null
-  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %47, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %48
 
 ; <label>:48                                      ; preds = %39
   %49 = load i16, i16* %47, align 8
   %50 = zext i16 %49 to i32
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %52 = load i32, i32* %loc1
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %53
 
 ; <label>:53                                      ; preds = %48
   %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
@@ -5916,8 +7370,8 @@ entry:
 ; <label>:62                                      ; preds = %36, %59
   %63 = load i32, i32* %loc1
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck10, label %65, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %65
 
 ; <label>:65                                      ; preds = %62
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
@@ -5936,15 +7390,15 @@ entry:
 
 ; <label>:74                                      ; preds = %70
   %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
-  br i1 %NullCheck18, label %76, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %76
 
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
   %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
-  br i1 %NullCheck20, label %80, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
   %81 = load i64, i64 addrspace(1)* %79
@@ -5958,8 +7412,8 @@ entry:
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
   %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
-  br i1 %NullCheck22, label %92, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.String addrspace(1)* %90, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %92
 
 ; <label>:92                                      ; preds = %80
   %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
@@ -5969,15 +7423,15 @@ entry:
 
 ; <label>:96                                      ; preds = %70
   %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
-  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %98
 
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
   %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
-  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
   %103 = load i64, i64 addrspace(1)* %101
@@ -5991,8 +7445,8 @@ entry:
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
   %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
-  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.String addrspace(1)* %112, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %114
 
 ; <label>:114                                     ; preds = %102
   %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
@@ -6004,59 +7458,59 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %20
+ThrowNullRef4:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %22
+ThrowNullRef6:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %26
+ThrowNullRef8:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %62
+ThrowNullRef10:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %48
+ThrowNullRef16:                                   ; preds = %48
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %74
+ThrowNullRef18:                                   ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %76
+ThrowNullRef20:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %80
+ThrowNullRef22:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %96
+ThrowNullRef24:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %98
+ThrowNullRef26:                                   ; preds = %98
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %102
+ThrowNullRef28:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6069,15 +7523,15 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
   %3 = load i16*, i16* addrspace(1)* %2, align 8
   %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
@@ -6087,8 +7541,8 @@ entry:
   %10 = bitcast i16* %3 to i8*
   %11 = getelementptr inbounds i8, i8* %10, i64 %9
   %12 = bitcast i8* %11 to i16*
-  %NullCheck4 = icmp ne i16* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %5
   store i16 0, i16* %12, align 8
@@ -6098,11 +7552,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6119,8 +7573,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -6131,8 +7585,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
@@ -6144,15 +7598,15 @@ entry:
 
 ; <label>:14                                      ; preds = %1
   %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
   %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
   %21 = load i64, i64 addrspace(1)* %19
@@ -6171,15 +7625,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %14
+ThrowNullRef4:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %16
+ThrowNullRef6:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6302,14 +7756,6 @@ entry:
   ret %System.String addrspace(1)* %57
 }
 
-INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
-Successfully read RuntimeHelpers.get_OffsetToStringData
-
-define i32 @RuntimeHelpers.get_OffsetToStringData() {
-entry:
-  ret i32 12
-}
-
 INFO:  jitting method String::Equals using LLILCJit
 Successfully read String.Equals
 
@@ -6381,8 +7827,8 @@ entry:
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
-  br i1 %NullCheck24, label %29, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
   %30 = load i64, i64 addrspace(1)* %28
@@ -6397,8 +7843,8 @@ entry:
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
-  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
   %43 = load i64, i64 addrspace(1)* %41
@@ -6418,8 +7864,8 @@ entry:
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
   %59 = load i64, i64 addrspace(1)* %57
@@ -6434,8 +7880,8 @@ entry:
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck22, label %71, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
   %72 = load i64, i64 addrspace(1)* %70
@@ -6455,8 +7901,8 @@ entry:
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
-  br i1 %NullCheck16, label %87, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = load i64, i64 addrspace(1)* %86
@@ -6471,8 +7917,8 @@ entry:
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck18, label %100, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
   %101 = load i64, i64 addrspace(1)* %99
@@ -6492,8 +7938,8 @@ entry:
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
-  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
   %117 = load i64, i64 addrspace(1)* %115
@@ -6508,8 +7954,8 @@ entry:
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
-  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
   %130 = load i64, i64 addrspace(1)* %128
@@ -6528,15 +7974,15 @@ entry:
 
 ; <label>:142                                     ; preds = %22
   %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
-  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %143, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %144
 
 ; <label>:144                                     ; preds = %142
   %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
   %146 = load i32, i32 addrspace(1)* %145
   %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
-  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %147, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %148
 
 ; <label>:148                                     ; preds = %144
   %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
@@ -6557,15 +8003,15 @@ entry:
 
 ; <label>:159                                     ; preds = %22
   %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
-  br i1 %NullCheck, label %161, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %ThrowNullRef, label %161
 
 ; <label>:161                                     ; preds = %159
   %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
   %163 = load i32, i32 addrspace(1)* %162
   %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
-  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %164, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %165
 
 ; <label>:165                                     ; preds = %161
   %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
@@ -6578,8 +8024,8 @@ entry:
 
 ; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
-  br i1 %NullCheck4, label %172, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %171, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %172
 
 ; <label>:172                                     ; preds = %170
   %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
@@ -6589,8 +8035,8 @@ entry:
 
 ; <label>:176                                     ; preds = %172
   %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
-  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %177, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %178
 
 ; <label>:178                                     ; preds = %176
   %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
@@ -6629,55 +8075,55 @@ ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %161
+ThrowNullRef2:                                    ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %170
+ThrowNullRef4:                                    ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %176
+ThrowNullRef6:                                    ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %142
+ThrowNullRef8:                                    ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %144
+ThrowNullRef10:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %113
+ThrowNullRef12:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %116
+ThrowNullRef14:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %84
+ThrowNullRef16:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %87
+ThrowNullRef18:                                   ; preds = %87
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %55
+ThrowNullRef20:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %58
+ThrowNullRef22:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %26
+ThrowNullRef24:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %29
+ThrowNullRef26:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,8 +8161,8 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck, label %14, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %ThrowNullRef, label %14
 
 ; <label>:14                                      ; preds = %8
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
@@ -6760,8 +8206,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
@@ -6770,14 +8216,14 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32, i32* %loc0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %10
   %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
   %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
@@ -6790,15 +8236,15 @@ entry:
 ; <label>:25                                      ; preds = %19
   %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
-  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
   %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
@@ -6807,8 +8253,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %37 = load i32, i32* %loc0
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %38, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %38
 
 ; <label>:38                                      ; preds = %32
   %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
@@ -6817,14 +8263,14 @@ entry:
 
 ; <label>:40                                      ; preds = %19
   %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %40
   %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
   %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
-  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
-  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
@@ -6832,8 +8278,8 @@ entry:
   %48 = zext i32 %47 to i64
   %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
-  br i1 %NullCheck16, label %51, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %51
 
 ; <label>:51                                      ; preds = %45
   %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
@@ -6847,15 +8293,15 @@ entry:
 ; <label>:57                                      ; preds = %51
   %58 = load i16*, i16** %arg1
   %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
-  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %60
 
 ; <label>:60                                      ; preds = %57
   %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
   %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
-  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %64
 
 ; <label>:64                                      ; preds = %60
   %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
@@ -6864,22 +8310,22 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
   %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
-  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %70
 
 ; <label>:70                                      ; preds = %64
   %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
   %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
-  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
-  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
   %75 = load i32, i32 addrspace(1)* %74
   %76 = zext i32 %75 to i64
   %77 = trunc i64 %76 to i32
-  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
-  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %78
 
 ; <label>:78                                      ; preds = %73
   %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
@@ -6901,8 +8347,8 @@ entry:
   %90 = bitcast i16* %86 to i8*
   %91 = getelementptr inbounds i8, i8* %90, i64 %89
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %93
 
 ; <label>:93                                      ; preds = %80
   %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
@@ -6912,8 +8358,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %99 = load i32, i32* %loc2
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %100
 
 ; <label>:100                                     ; preds = %93
   %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
@@ -6928,63 +8374,63 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %25
+ThrowNullRef6:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %32
+ThrowNullRef10:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %40
+ThrowNullRef12:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %45
+ThrowNullRef16:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %57
+ThrowNullRef18:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %60
+ThrowNullRef20:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %64
+ThrowNullRef22:                                   ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %70
+ThrowNullRef24:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %73
+ThrowNullRef26:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %80
+ThrowNullRef28:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %93
+ThrowNullRef30:                                   ; preds = %93
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7004,8 +8450,8 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
@@ -7033,43 +8479,43 @@ entry:
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %14
   %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
   %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   %28 = load i32, i32 addrspace(1)* %27, align 8
   %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
-  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %30
 
 ; <label>:30                                      ; preds = %26
   %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
   %32 = load i32, i32 addrspace(1)* %31, align 8
   %33 = add i32 %28, %32
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %34
 
 ; <label>:34                                      ; preds = %30
   %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   store i32 %33, i32 addrspace(1)* %35
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
   store i32 0, i32 addrspace(1)* %38
   %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %40
 
 ; <label>:40                                      ; preds = %37
   %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
@@ -7082,8 +8528,8 @@ entry:
 
 ; <label>:47                                      ; preds = %40
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
@@ -7098,8 +8544,8 @@ entry:
   %54 = load i32, i32* %loc0
   %55 = sext i32 %54 to i64
   %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
-  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %57
 
 ; <label>:57                                      ; preds = %52
   %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
@@ -7110,68 +8556,35 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %14
+ThrowNullRef2:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %23
+ThrowNullRef4:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %26
+ThrowNullRef6:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %30
+ThrowNullRef8:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %34
+ThrowNullRef10:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %47
+ThrowNullRef14:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %52
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-}
-
-INFO:  jitting method StringBuilder::get_Length using LLILCJit
-Successfully read StringBuilder.get_Length
-
-define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.StringBuilder addrspace(1)*
-  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
-  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
-
-; <label>:1                                       ; preds = %entry
-  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %3 = load i32, i32 addrspace(1)* %2, align 8
-  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
-
-; <label>:5                                       ; preds = %1
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = add i32 %3, %7
-  ret i32 %8
-
-ThrowNullRef:                                     ; preds = %entry
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef16:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7213,70 +8626,70 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
   %6 = load i32, i32 addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
   store i32 %6, i32 addrspace(1)* %8
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
   %13 = load i32, i32 addrspace(1)* %12, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
   store i32 %13, i32 addrspace(1)* %15
   %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
-  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %18
 
 ; <label>:18                                      ; preds = %14
   %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
   %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
   %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
   %34 = load i32, i32 addrspace(1)* %33, align 8
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
-  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
@@ -7287,39 +8700,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %28
+ThrowNullRef16:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %32
+ThrowNullRef18:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7455,13 +8868,13 @@ entry:
 ; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
@@ -7477,16 +8890,16 @@ entry:
 
 ; <label>:18                                      ; preds = %15
   %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
   store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
   %22 = load i32, i32* %loc0
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %24
 
 ; <label>:24                                      ; preds = %20
   %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
@@ -7498,13 +8911,13 @@ entry:
 ; <label>:28                                      ; preds = %15, %24
   %29 = load i32, i32* %arg1
   %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %31
   %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
@@ -7517,20 +8930,20 @@ entry:
   %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
-  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
   %46 = load i32, i32 addrspace(1)* %45, align 8
   %47 = sub i32 %40, %46
-  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
-  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i32 addrspace(1)* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %48
 
 ; <label>:48                                      ; preds = %44
   store i32 %47, i32 addrspace(1)* %39, align 8
@@ -7538,21 +8951,21 @@ entry:
 
 ; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
-  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %51
 
 ; <label>:51                                      ; preds = %49
   %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %53
 
 ; <label>:53                                      ; preds = %51
   %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
   %55 = load i32, i32 addrspace(1)* %54, align 8
   %56 = load i32, i32* %arg2
   %57 = sub i32 %55, %56
-  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %58
 
 ; <label>:58                                      ; preds = %53
   %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
@@ -7562,13 +8975,13 @@ entry:
 ; <label>:60                                      ; preds = %33, %58
   %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
   %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
-  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %63
 
 ; <label>:63                                      ; preds = %60
   %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
-  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
-  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
@@ -7578,15 +8991,15 @@ entry:
 
 ; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
-  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i32 addrspace(1)* %69, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %70
 
 ; <label>:70                                      ; preds = %68
   %71 = load i32, i32 addrspace(1)* %69, align 8
   store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
-  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
@@ -7596,8 +9009,8 @@ entry:
   store i32 %77, i32* %loc4
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
-  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %80
 
 ; <label>:80                                      ; preds = %73
   %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
@@ -7607,71 +9020,71 @@ entry:
 ; <label>:83                                      ; preds = %80
   store i32 0, i32* %loc3
   %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
-  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
-  br i1 %NullCheck26, label %88, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i32 addrspace(1)* %87, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %88
 
 ; <label>:88                                      ; preds = %85
   %89 = load i32, i32 addrspace(1)* %87, align 8
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
-  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %90
 
 ; <label>:90                                      ; preds = %88
   %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
   store i32 %89, i32 addrspace(1)* %91
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
-  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
-  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %96
 
 ; <label>:96                                      ; preds = %94
   %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
-  br i1 %NullCheck34, label %100, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %100
 
 ; <label>:100                                     ; preds = %96
   %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
-  br i1 %NullCheck36, label %102, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %102
 
 ; <label>:102                                     ; preds = %100
   %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
   %104 = load i32, i32 addrspace(1)* %103, align 8
   %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
-  br i1 %NullCheck38, label %106, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %106
 
 ; <label>:106                                     ; preds = %102
   %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
-  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
-  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %108
 
 ; <label>:108                                     ; preds = %106
   %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
   %110 = load i32, i32 addrspace(1)* %109, align 8
   %111 = add i32 %104, %110
-  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %112
 
 ; <label>:112                                     ; preds = %108
   %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
   store i32 %111, i32 addrspace(1)* %113
   %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
-  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i32 addrspace(1)* %114, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %115
 
 ; <label>:115                                     ; preds = %112
   %116 = load i32, i32 addrspace(1)* %114, align 8
@@ -7681,19 +9094,19 @@ entry:
 ; <label>:118                                     ; preds = %115
   %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
-  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %121
 
 ; <label>:121                                     ; preds = %118
   %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
-  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
-  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %123
 
 ; <label>:123                                     ; preds = %121
   %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
   %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
-  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
-  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %126
 
 ; <label>:126                                     ; preds = %123
   %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
@@ -7705,8 +9118,8 @@ entry:
 
 ; <label>:130                                     ; preds = %80, %115, %126
   %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %132
 
 ; <label>:132                                     ; preds = %130
   %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7715,8 +9128,8 @@ entry:
   %136 = load i32, i32* %loc3
   %137 = sub i32 %135, %136
   %138 = sub i32 %134, %137
-  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %139
 
 ; <label>:139                                     ; preds = %132
   %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7728,16 +9141,16 @@ entry:
 
 ; <label>:144                                     ; preds = %139
   %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
-  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %146
 
 ; <label>:146                                     ; preds = %144
   %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
   %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
   %149 = load i32, i32* %loc2
   %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
-  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %151
 
 ; <label>:151                                     ; preds = %146
   %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
@@ -7754,145 +9167,249 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %18
+ThrowNullRef4:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %31
+ThrowNullRef10:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %44
+ThrowNullRef16:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %68
+ThrowNullRef18:                                   ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %70
+ThrowNullRef20:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %73
+ThrowNullRef22:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %83
+ThrowNullRef24:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %85
+ThrowNullRef26:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %88
+ThrowNullRef28:                                   ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %90
+ThrowNullRef30:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %94
+ThrowNullRef32:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %96
+ThrowNullRef34:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %100
+ThrowNullRef36:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %102
+ThrowNullRef38:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %106
+ThrowNullRef40:                                   ; preds = %106
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %108
+ThrowNullRef42:                                   ; preds = %108
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %112
+ThrowNullRef44:                                   ; preds = %112
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %118
+ThrowNullRef46:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %121
+ThrowNullRef48:                                   ; preds = %121
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %123
+ThrowNullRef50:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %130
+ThrowNullRef52:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %132
+ThrowNullRef54:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %144
+ThrowNullRef56:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %146
+ThrowNullRef58:                                   ; preds = %146
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %60
+ThrowNullRef60:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %63
+ThrowNullRef62:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %49
+ThrowNullRef64:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %51
+ThrowNullRef66:                                   ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %53
+ThrowNullRef68:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(%"System.Char[]" addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %arg0 = alloca %"System.Char[]" addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store %"System.Char[]" addrspace(1)* %param0, %"System.Char[]" addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load i32, i32* %arg4
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %43, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %38, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg1
+  %13 = load i32, i32* %arg4
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %38, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %24 = load i32, i32* %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %35 = load i32, i32* %arg3
+  %36 = load i32, i32* %arg4
+  %37 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %37, %"System.Char[]" addrspace(1)* %34, i32 %35, i32 %36)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:38                                      ; preds = %5, %16
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Successfully read Buffer._Memmove
 
@@ -7914,7 +9431,7 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[loadElem]
+Failed to read AppDomain.SetDataHelper[storeElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -7923,8 +9440,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
@@ -7934,8 +9451,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
@@ -7947,15 +9464,15 @@ entry:
   %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
   %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
@@ -7966,15 +9483,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7992,7 +9509,79 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
-Failed to read Dictionary`2.TryGetValue[loadElemA]
+Successfully read Dictionary`2.TryGetValue
+
+define i8 @"Dictionary`2.TryGetValue"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)* addrspace(1)* %param2) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  %arg2 = alloca %System.__Canon addrspace(1)* addrspace(1)*
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  store %System.__Canon addrspace(1)* addrspace(1)* %param2, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  store i32 %2, i32* %loc0
+  %3 = load i32, i32* %loc0
+  %4 = icmp slt i32 %3, 0
+  br i1 %4, label %22, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 2
+  %10 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %9, align 8
+  %11 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = zext i32 %11 to i64
+  %BoundsCheck = icmp uge i64 %16, %15
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 3, i32 %11
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %20, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %6, %System.__Canon addrspace(1)* %21)
+  ret i8 1
+
+; <label>:22                                      ; preds = %entry
+  %23 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %23, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -8058,8 +9647,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
@@ -8091,8 +9680,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
@@ -8171,15 +9760,15 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck, label %19, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %ThrowNullRef, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
   %21 = load i32, i32 addrspace(1)* %20
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
@@ -8202,7 +9791,7 @@ ThrowNullRef:                                     ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %19
+ThrowNullRef2:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8248,8 +9837,8 @@ entry:
   %0 = alloca %System.AppDomainHandle
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %1 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %1, i32 0, i32 15
@@ -8269,8 +9858,8 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
@@ -8286,7 +9875,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -8299,8 +9888,8 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -8327,8 +9916,8 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
@@ -8352,8 +9941,8 @@ entry:
   %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
   store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
@@ -8363,8 +9952,8 @@ entry:
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
@@ -8374,8 +9963,8 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %9
   %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
@@ -8384,8 +9973,8 @@ entry:
 
 ; <label>:18                                      ; preds = %3, %16
   %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
@@ -8397,15 +9986,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %18
+ThrowNullRef6:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8418,8 +10007,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
@@ -8453,15 +10042,15 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
@@ -8473,7 +10062,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8481,7 +10070,7 @@ ThrowNullRef1:                                    ; preds = %1
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
 Failed to read Dictionary`2.System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
@@ -8506,8 +10095,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
@@ -8524,8 +10113,8 @@ entry:
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -8544,7 +10133,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8577,8 +10166,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = load i64, i64* %arg2
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = trunc i32 %3 to i8
@@ -8634,46 +10223,46 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
   %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
-  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
-  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
-  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
@@ -8684,27 +10273,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %20
+ThrowNullRef12:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8717,8 +10306,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -8756,22 +10345,22 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
   %9 = load i64, i64 addrspace(1)* %8, align 8
   %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
   %13 = load i64, i64 addrspace(1)* %12, align 8
   %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %11
   %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
@@ -8788,11 +10377,11 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8882,8 +10471,8 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
@@ -8900,8 +10489,8 @@ entry:
 ; <label>:8                                       ; preds = %1
   %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
   %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
@@ -8911,15 +10500,15 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
   %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
   %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
-  br i1 %NullCheck6, label %21, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
@@ -8946,15 +10535,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8992,15 +10581,15 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
   store i8 %3, i8 addrspace(1)* %5
   %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
@@ -9011,7 +10600,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9027,8 +10616,8 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -9041,8 +10630,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
@@ -9058,7 +10647,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9080,8 +10669,8 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
@@ -9096,8 +10685,8 @@ entry:
 ; <label>:12                                      ; preds = %6
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
@@ -9112,8 +10701,8 @@ entry:
 ; <label>:21                                      ; preds = %15
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
@@ -9128,8 +10717,8 @@ entry:
 ; <label>:30                                      ; preds = %24
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %31, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
@@ -9144,8 +10733,8 @@ entry:
 ; <label>:39                                      ; preds = %33
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
-  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %40, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %42
 
 ; <label>:42                                      ; preds = %39
   %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
@@ -9164,19 +10753,19 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %21
+ThrowNullRef4:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %30
+ThrowNullRef6:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %39
+ThrowNullRef8:                                    ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9243,8 +10832,8 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
@@ -9264,57 +10853,57 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
   store i8 0, i8 addrspace(1)* %2
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
   store i8 0, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
   store i8 0, i8 addrspace(1)* %17
   %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
   store i8 0, i8 addrspace(1)* %20
   %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
-  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
@@ -9325,31 +10914,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %19
+ThrowNullRef14:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9367,8 +10956,8 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
@@ -9380,8 +10969,8 @@ entry:
 
 ; <label>:9                                       ; preds = %4
   %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %9
   %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
@@ -9395,7 +10984,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef2:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9420,8 +11009,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
@@ -9512,8 +11101,8 @@ entry:
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
@@ -9524,8 +11113,8 @@ entry:
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = load i64, i64 addrspace(1)* %12
@@ -9537,8 +11126,8 @@ entry:
   %20 = load i64, i64* %19
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
-  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %13
   %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
@@ -9555,8 +11144,8 @@ entry:
 ; <label>:30                                      ; preds = %25
   %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %32 = load i32, i32* %arg2
-  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
-  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
@@ -9570,15 +11159,15 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %30
+ThrowNullRef2:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9622,87 +11211,87 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
   %10 = load i8, i8 addrspace(1)* %9, align 8
   %11 = zext i8 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %8
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
   store i8 %12, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
   %19 = load i8, i8 addrspace(1)* %18, align 8
   %20 = zext i8 %19 to i32
   %21 = trunc i32 %20 to i8
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
   store i8 %21, i8 addrspace(1)* %23
   %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
   %28 = load i8, i8 addrspace(1)* %27, align 8
   %29 = zext i8 %28 to i32
   %30 = trunc i32 %29 to i8
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
-  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %31
 
 ; <label>:31                                      ; preds = %26
   %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
   store i8 %30, i8 addrspace(1)* %32
   %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
-  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
-  br i1 %NullCheck14, label %40, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %40
 
 ; <label>:40                                      ; preds = %35
   %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
   store i8 %39, i8 addrspace(1)* %41
   %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
-  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %44
 
 ; <label>:44                                      ; preds = %40
   %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
   %46 = load i8, i8 addrspace(1)* %45, align 8
   %47 = zext i8 %46 to i32
   %48 = trunc i32 %47 to i8
-  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
   store i8 %48, i8 addrspace(1)* %50
   %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
-  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
@@ -9713,29 +11302,29 @@ entry:
 ; <label>:56                                      ; preds = %52
   %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
-  br i1 %NullCheck22, label %59, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
   %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
   %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
-  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
-  br i1 %NullCheck24, label %63, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
   %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
-  br i1 %NullCheck26, label %66, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
   %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
-  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
-  br i1 %NullCheck28, label %69, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %69
 
 ; <label>:69                                      ; preds = %66
   %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
@@ -9744,15 +11333,15 @@ entry:
 
 ; <label>:71                                      ; preds = %105
   %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
-  br i1 %NullCheck34, label %73, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %73
 
 ; <label>:73                                      ; preds = %71
   %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
   %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
   %76 = load i32, i32* %loc0
-  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
-  br i1 %NullCheck36, label %77, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
@@ -9766,8 +11355,8 @@ entry:
 
 ; <label>:83                                      ; preds = %77
   %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
-  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
@@ -9775,14 +11364,14 @@ entry:
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
   %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
-  br i1 %NullCheck40, label %91, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
 ; <label>:91                                      ; preds = %85
   %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
   %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
-  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck42, label %94, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %94
 
 ; <label>:94                                      ; preds = %91
   %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
@@ -9798,14 +11387,14 @@ entry:
 ; <label>:99                                      ; preds = %69, %96
   %100 = load i32, i32* %loc0
   %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
-  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %102
 
 ; <label>:102                                     ; preds = %99
   %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
   %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
-  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
-  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
@@ -9819,87 +11408,87 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %26
+ThrowNullRef10:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %31
+ThrowNullRef12:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %35
+ThrowNullRef14:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %40
+ThrowNullRef16:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %56
+ThrowNullRef22:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %59
+ThrowNullRef24:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %63
+ThrowNullRef26:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %66
+ThrowNullRef28:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %102
+ThrowNullRef32:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %71
+ThrowNullRef34:                                   ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %73
+ThrowNullRef36:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %83
+ThrowNullRef38:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %85
+ThrowNullRef40:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %91
+ThrowNullRef42:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9943,15 +11532,15 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
   %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
@@ -9961,28 +11550,28 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
   %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %12
   %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
   %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
   %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
-  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
@@ -9993,23 +11582,23 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %12
+ThrowNullRef6:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10031,15 +11620,15 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
   %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = load i64, i64 addrspace(1)* %7
@@ -10077,13 +11666,13 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[loadElem]
+Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -10111,8 +11700,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1

--- a/test/BaseLine/JIT/CodeGenBringUpTests/LngConv.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/LngConv.error.txt
@@ -25,8 +25,8 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
@@ -40,8 +40,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
   %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
@@ -75,7 +75,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -90,8 +90,8 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %NullCheck = icmp ne i8 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = load i8, i8 addrspace(1)* %0, align 8
@@ -125,8 +125,8 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
@@ -159,8 +159,8 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -184,8 +184,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
   store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
@@ -195,8 +195,8 @@ entry:
 ; <label>:4                                       ; preds = %1
   %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
   %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
@@ -206,8 +206,8 @@ entry:
   %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
@@ -221,14 +221,14 @@ entry:
 
 ; <label>:17                                      ; preds = %14
   %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
   %21 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
@@ -238,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -249,8 +249,8 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
@@ -261,27 +261,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %30
+ThrowNullRef10:                                   ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -301,7 +301,89 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
-Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
+Successfully read AppDomainSetup.GetUnsecureApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.GetUnsecureApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %NullCheck = icmp eq %"System.String[]" addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %BoundsCheck = icmp uge i64 0, %5
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %6
+
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 3, i32 0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
+  ret %System.String addrspace(1)* %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_Value using LLILCJit
+Successfully read AppDomainSetup.get_Value
+
+define %"System.String[]" addrspace(1)* @AppDomainSetup.get_Value(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.String[]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 18)
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.String[]" addrspace(1)* addrspace(1)*, %"System.String[]" addrspace(1)*)*)(%"System.String[]" addrspace(1)* addrspace(1)* %9, %"System.String[]" addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %11, i32 0, i32 1
+  %14 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %13, align 8
+  ret %"System.String[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -319,8 +401,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -368,16 +450,16 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
   %5 = load i32, i32 addrspace(1)* %4
   %6 = sub i32 %5, 1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -389,7 +471,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -421,8 +503,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
@@ -456,8 +538,8 @@ entry:
 ; <label>:27                                      ; preds = %19
   %28 = load i32, i32* %arg1
   %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
-  br i1 %NullCheck2, label %30, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %29, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %30
 
 ; <label>:30                                      ; preds = %27
   %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
@@ -493,8 +575,8 @@ entry:
 ; <label>:49                                      ; preds = %46
   %50 = load i32, i32* %arg2
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck4, label %52, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
@@ -517,11 +599,11 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %27
+ThrowNullRef2:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %49
+ThrowNullRef4:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -544,16 +626,16 @@ entry:
   %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %0)
   store %System.String addrspace(1)* %1, %System.String addrspace(1)** %loc0
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 2
   %5 = bitcast [0 x i16] addrspace(1)* %4 to i16 addrspace(1)*
   store i16 addrspace(1)* %5, i16 addrspace(1)** %loc1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %3
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2
@@ -580,7 +662,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -691,15 +773,15 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %NullCheck132 = icmp ne i8* %21, null
-  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+  %NullCheck131 = icmp eq i8* %21, null
+  br i1 %NullCheck131, label %ThrowNullRef132, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = load i8, i8* %21, align 8
   %24 = zext i8 %23 to i32
   %25 = trunc i32 %24 to i8
-  %NullCheck134 = icmp ne i8* %20, null
-  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+  %NullCheck133 = icmp eq i8* %20, null
+  br i1 %NullCheck133, label %ThrowNullRef134, label %26
 
 ; <label>:26                                      ; preds = %22
   store i8 %25, i8* %20, align 8
@@ -709,16 +791,16 @@ entry:
   %28 = load i8*, i8** %arg0
   %29 = load i8*, i8** %arg1
   %30 = bitcast i8* %29 to i16*
-  %NullCheck128 = icmp ne i16* %30, null
-  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+  %NullCheck127 = icmp eq i16* %30, null
+  br i1 %NullCheck127, label %ThrowNullRef128, label %31
 
 ; <label>:31                                      ; preds = %27
   %32 = load i16, i16* %30, align 8
   %33 = sext i16 %32 to i32
   %34 = bitcast i8* %28 to i16*
   %35 = trunc i32 %33 to i16
-  %NullCheck130 = icmp ne i16* %34, null
-  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+  %NullCheck129 = icmp eq i16* %34, null
+  br i1 %NullCheck129, label %ThrowNullRef130, label %36
 
 ; <label>:36                                      ; preds = %31
   store i16 %35, i16* %34, align 8
@@ -728,16 +810,16 @@ entry:
   %38 = load i8*, i8** %arg0
   %39 = load i8*, i8** %arg1
   %40 = bitcast i8* %39 to i16*
-  %NullCheck120 = icmp ne i16* %40, null
-  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+  %NullCheck119 = icmp eq i16* %40, null
+  br i1 %NullCheck119, label %ThrowNullRef120, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i16, i16* %40, align 8
   %43 = sext i16 %42 to i32
   %44 = bitcast i8* %38 to i16*
   %45 = trunc i32 %43 to i16
-  %NullCheck122 = icmp ne i16* %44, null
-  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+  %NullCheck121 = icmp eq i16* %44, null
+  br i1 %NullCheck121, label %ThrowNullRef122, label %46
 
 ; <label>:46                                      ; preds = %41
   store i16 %45, i16* %44, align 8
@@ -745,15 +827,15 @@ entry:
   %48 = getelementptr inbounds i8, i8* %47, i64 2
   %49 = load i8*, i8** %arg1
   %50 = getelementptr inbounds i8, i8* %49, i64 2
-  %NullCheck124 = icmp ne i8* %50, null
-  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+  %NullCheck123 = icmp eq i8* %50, null
+  br i1 %NullCheck123, label %ThrowNullRef124, label %51
 
 ; <label>:51                                      ; preds = %46
   %52 = load i8, i8* %50, align 8
   %53 = zext i8 %52 to i32
   %54 = trunc i32 %53 to i8
-  %NullCheck126 = icmp ne i8* %48, null
-  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+  %NullCheck125 = icmp eq i8* %48, null
+  br i1 %NullCheck125, label %ThrowNullRef126, label %55
 
 ; <label>:55                                      ; preds = %51
   store i8 %54, i8* %48, align 8
@@ -763,14 +845,14 @@ entry:
   %57 = load i8*, i8** %arg0
   %58 = load i8*, i8** %arg1
   %59 = bitcast i8* %58 to i32*
-  %NullCheck116 = icmp ne i32* %59, null
-  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+  %NullCheck115 = icmp eq i32* %59, null
+  br i1 %NullCheck115, label %ThrowNullRef116, label %60
 
 ; <label>:60                                      ; preds = %56
   %61 = load i32, i32* %59, align 8
   %62 = bitcast i8* %57 to i32*
-  %NullCheck118 = icmp ne i32* %62, null
-  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+  %NullCheck117 = icmp eq i32* %62, null
+  br i1 %NullCheck117, label %ThrowNullRef118, label %63
 
 ; <label>:63                                      ; preds = %60
   store i32 %61, i32* %62, align 8
@@ -780,14 +862,14 @@ entry:
   %65 = load i8*, i8** %arg0
   %66 = load i8*, i8** %arg1
   %67 = bitcast i8* %66 to i32*
-  %NullCheck108 = icmp ne i32* %67, null
-  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+  %NullCheck107 = icmp eq i32* %67, null
+  br i1 %NullCheck107, label %ThrowNullRef108, label %68
 
 ; <label>:68                                      ; preds = %64
   %69 = load i32, i32* %67, align 8
   %70 = bitcast i8* %65 to i32*
-  %NullCheck110 = icmp ne i32* %70, null
-  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+  %NullCheck109 = icmp eq i32* %70, null
+  br i1 %NullCheck109, label %ThrowNullRef110, label %71
 
 ; <label>:71                                      ; preds = %68
   store i32 %69, i32* %70, align 8
@@ -795,15 +877,15 @@ entry:
   %73 = getelementptr inbounds i8, i8* %72, i64 4
   %74 = load i8*, i8** %arg1
   %75 = getelementptr inbounds i8, i8* %74, i64 4
-  %NullCheck112 = icmp ne i8* %75, null
-  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+  %NullCheck111 = icmp eq i8* %75, null
+  br i1 %NullCheck111, label %ThrowNullRef112, label %76
 
 ; <label>:76                                      ; preds = %71
   %77 = load i8, i8* %75, align 8
   %78 = zext i8 %77 to i32
   %79 = trunc i32 %78 to i8
-  %NullCheck114 = icmp ne i8* %73, null
-  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+  %NullCheck113 = icmp eq i8* %73, null
+  br i1 %NullCheck113, label %ThrowNullRef114, label %80
 
 ; <label>:80                                      ; preds = %76
   store i8 %79, i8* %73, align 8
@@ -813,14 +895,14 @@ entry:
   %82 = load i8*, i8** %arg0
   %83 = load i8*, i8** %arg1
   %84 = bitcast i8* %83 to i32*
-  %NullCheck100 = icmp ne i32* %84, null
-  br i1 %NullCheck100, label %85, label %ThrowNullRef99
+  %NullCheck99 = icmp eq i32* %84, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %85
 
 ; <label>:85                                      ; preds = %81
   %86 = load i32, i32* %84, align 8
   %87 = bitcast i8* %82 to i32*
-  %NullCheck102 = icmp ne i32* %87, null
-  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+  %NullCheck101 = icmp eq i32* %87, null
+  br i1 %NullCheck101, label %ThrowNullRef102, label %88
 
 ; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
@@ -829,16 +911,16 @@ entry:
   %91 = load i8*, i8** %arg1
   %92 = getelementptr inbounds i8, i8* %91, i64 4
   %93 = bitcast i8* %92 to i16*
-  %NullCheck104 = icmp ne i16* %93, null
-  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+  %NullCheck103 = icmp eq i16* %93, null
+  br i1 %NullCheck103, label %ThrowNullRef104, label %94
 
 ; <label>:94                                      ; preds = %88
   %95 = load i16, i16* %93, align 8
   %96 = sext i16 %95 to i32
   %97 = bitcast i8* %90 to i16*
   %98 = trunc i32 %96 to i16
-  %NullCheck106 = icmp ne i16* %97, null
-  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+  %NullCheck105 = icmp eq i16* %97, null
+  br i1 %NullCheck105, label %ThrowNullRef106, label %99
 
 ; <label>:99                                      ; preds = %94
   store i16 %98, i16* %97, align 8
@@ -848,14 +930,14 @@ entry:
   %101 = load i8*, i8** %arg0
   %102 = load i8*, i8** %arg1
   %103 = bitcast i8* %102 to i32*
-  %NullCheck88 = icmp ne i32* %103, null
-  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+  %NullCheck87 = icmp eq i32* %103, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %104
 
 ; <label>:104                                     ; preds = %100
   %105 = load i32, i32* %103, align 8
   %106 = bitcast i8* %101 to i32*
-  %NullCheck90 = icmp ne i32* %106, null
-  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+  %NullCheck89 = icmp eq i32* %106, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %107
 
 ; <label>:107                                     ; preds = %104
   store i32 %105, i32* %106, align 8
@@ -864,16 +946,16 @@ entry:
   %110 = load i8*, i8** %arg1
   %111 = getelementptr inbounds i8, i8* %110, i64 4
   %112 = bitcast i8* %111 to i16*
-  %NullCheck92 = icmp ne i16* %112, null
-  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+  %NullCheck91 = icmp eq i16* %112, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %113
 
 ; <label>:113                                     ; preds = %107
   %114 = load i16, i16* %112, align 8
   %115 = sext i16 %114 to i32
   %116 = bitcast i8* %109 to i16*
   %117 = trunc i32 %115 to i16
-  %NullCheck94 = icmp ne i16* %116, null
-  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+  %NullCheck93 = icmp eq i16* %116, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %118
 
 ; <label>:118                                     ; preds = %113
   store i16 %117, i16* %116, align 8
@@ -881,15 +963,15 @@ entry:
   %120 = getelementptr inbounds i8, i8* %119, i64 6
   %121 = load i8*, i8** %arg1
   %122 = getelementptr inbounds i8, i8* %121, i64 6
-  %NullCheck96 = icmp ne i8* %122, null
-  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+  %NullCheck95 = icmp eq i8* %122, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %123
 
 ; <label>:123                                     ; preds = %118
   %124 = load i8, i8* %122, align 8
   %125 = zext i8 %124 to i32
   %126 = trunc i32 %125 to i8
-  %NullCheck98 = icmp ne i8* %120, null
-  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+  %NullCheck97 = icmp eq i8* %120, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %127
 
 ; <label>:127                                     ; preds = %123
   store i8 %126, i8* %120, align 8
@@ -899,14 +981,14 @@ entry:
   %129 = load i8*, i8** %arg0
   %130 = load i8*, i8** %arg1
   %131 = bitcast i8* %130 to i64*
-  %NullCheck84 = icmp ne i64* %131, null
-  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+  %NullCheck83 = icmp eq i64* %131, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %132
 
 ; <label>:132                                     ; preds = %128
   %133 = load i64, i64* %131, align 8
   %134 = bitcast i8* %129 to i64*
-  %NullCheck86 = icmp ne i64* %134, null
-  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+  %NullCheck85 = icmp eq i64* %134, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %135
 
 ; <label>:135                                     ; preds = %132
   store i64 %133, i64* %134, align 8
@@ -916,14 +998,14 @@ entry:
   %137 = load i8*, i8** %arg0
   %138 = load i8*, i8** %arg1
   %139 = bitcast i8* %138 to i64*
-  %NullCheck76 = icmp ne i64* %139, null
-  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+  %NullCheck75 = icmp eq i64* %139, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %140
 
 ; <label>:140                                     ; preds = %136
   %141 = load i64, i64* %139, align 8
   %142 = bitcast i8* %137 to i64*
-  %NullCheck78 = icmp ne i64* %142, null
-  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+  %NullCheck77 = icmp eq i64* %142, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %143
 
 ; <label>:143                                     ; preds = %140
   store i64 %141, i64* %142, align 8
@@ -931,15 +1013,15 @@ entry:
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %NullCheck80 = icmp ne i8* %147, null
-  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+  %NullCheck79 = icmp eq i8* %147, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %148
 
 ; <label>:148                                     ; preds = %143
   %149 = load i8, i8* %147, align 8
   %150 = zext i8 %149 to i32
   %151 = trunc i32 %150 to i8
-  %NullCheck82 = icmp ne i8* %145, null
-  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+  %NullCheck81 = icmp eq i8* %145, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %152
 
 ; <label>:152                                     ; preds = %148
   store i8 %151, i8* %145, align 8
@@ -949,14 +1031,14 @@ entry:
   %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
   %156 = bitcast i8* %155 to i64*
-  %NullCheck68 = icmp ne i64* %156, null
-  br i1 %NullCheck68, label %157, label %ThrowNullRef67
+  %NullCheck67 = icmp eq i64* %156, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %157
 
 ; <label>:157                                     ; preds = %153
   %158 = load i64, i64* %156, align 8
   %159 = bitcast i8* %154 to i64*
-  %NullCheck70 = icmp ne i64* %159, null
-  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+  %NullCheck69 = icmp eq i64* %159, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %160
 
 ; <label>:160                                     ; preds = %157
   store i64 %158, i64* %159, align 8
@@ -965,16 +1047,16 @@ entry:
   %163 = load i8*, i8** %arg1
   %164 = getelementptr inbounds i8, i8* %163, i64 8
   %165 = bitcast i8* %164 to i16*
-  %NullCheck72 = icmp ne i16* %165, null
-  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+  %NullCheck71 = icmp eq i16* %165, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %166
 
 ; <label>:166                                     ; preds = %160
   %167 = load i16, i16* %165, align 8
   %168 = sext i16 %167 to i32
   %169 = bitcast i8* %162 to i16*
   %170 = trunc i32 %168 to i16
-  %NullCheck74 = icmp ne i16* %169, null
-  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+  %NullCheck73 = icmp eq i16* %169, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %171
 
 ; <label>:171                                     ; preds = %166
   store i16 %170, i16* %169, align 8
@@ -984,14 +1066,14 @@ entry:
   %173 = load i8*, i8** %arg0
   %174 = load i8*, i8** %arg1
   %175 = bitcast i8* %174 to i64*
-  %NullCheck56 = icmp ne i64* %175, null
-  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+  %NullCheck55 = icmp eq i64* %175, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %176
 
 ; <label>:176                                     ; preds = %172
   %177 = load i64, i64* %175, align 8
   %178 = bitcast i8* %173 to i64*
-  %NullCheck58 = icmp ne i64* %178, null
-  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+  %NullCheck57 = icmp eq i64* %178, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %179
 
 ; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
@@ -1000,16 +1082,16 @@ entry:
   %182 = load i8*, i8** %arg1
   %183 = getelementptr inbounds i8, i8* %182, i64 8
   %184 = bitcast i8* %183 to i16*
-  %NullCheck60 = icmp ne i16* %184, null
-  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+  %NullCheck59 = icmp eq i16* %184, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %185
 
 ; <label>:185                                     ; preds = %179
   %186 = load i16, i16* %184, align 8
   %187 = sext i16 %186 to i32
   %188 = bitcast i8* %181 to i16*
   %189 = trunc i32 %187 to i16
-  %NullCheck62 = icmp ne i16* %188, null
-  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+  %NullCheck61 = icmp eq i16* %188, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %190
 
 ; <label>:190                                     ; preds = %185
   store i16 %189, i16* %188, align 8
@@ -1017,15 +1099,15 @@ entry:
   %192 = getelementptr inbounds i8, i8* %191, i64 10
   %193 = load i8*, i8** %arg1
   %194 = getelementptr inbounds i8, i8* %193, i64 10
-  %NullCheck64 = icmp ne i8* %194, null
-  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+  %NullCheck63 = icmp eq i8* %194, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %195
 
 ; <label>:195                                     ; preds = %190
   %196 = load i8, i8* %194, align 8
   %197 = zext i8 %196 to i32
   %198 = trunc i32 %197 to i8
-  %NullCheck66 = icmp ne i8* %192, null
-  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+  %NullCheck65 = icmp eq i8* %192, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %199
 
 ; <label>:199                                     ; preds = %195
   store i8 %198, i8* %192, align 8
@@ -1035,14 +1117,14 @@ entry:
   %201 = load i8*, i8** %arg0
   %202 = load i8*, i8** %arg1
   %203 = bitcast i8* %202 to i64*
-  %NullCheck48 = icmp ne i64* %203, null
-  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+  %NullCheck47 = icmp eq i64* %203, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %204
 
 ; <label>:204                                     ; preds = %200
   %205 = load i64, i64* %203, align 8
   %206 = bitcast i8* %201 to i64*
-  %NullCheck50 = icmp ne i64* %206, null
-  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+  %NullCheck49 = icmp eq i64* %206, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %207
 
 ; <label>:207                                     ; preds = %204
   store i64 %205, i64* %206, align 8
@@ -1051,14 +1133,14 @@ entry:
   %210 = load i8*, i8** %arg1
   %211 = getelementptr inbounds i8, i8* %210, i64 8
   %212 = bitcast i8* %211 to i32*
-  %NullCheck52 = icmp ne i32* %212, null
-  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+  %NullCheck51 = icmp eq i32* %212, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %213
 
 ; <label>:213                                     ; preds = %207
   %214 = load i32, i32* %212, align 8
   %215 = bitcast i8* %209 to i32*
-  %NullCheck54 = icmp ne i32* %215, null
-  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+  %NullCheck53 = icmp eq i32* %215, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %216
 
 ; <label>:216                                     ; preds = %213
   store i32 %214, i32* %215, align 8
@@ -1068,14 +1150,14 @@ entry:
   %218 = load i8*, i8** %arg0
   %219 = load i8*, i8** %arg1
   %220 = bitcast i8* %219 to i64*
-  %NullCheck36 = icmp ne i64* %220, null
-  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64* %220, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %221
 
 ; <label>:221                                     ; preds = %217
   %222 = load i64, i64* %220, align 8
   %223 = bitcast i8* %218 to i64*
-  %NullCheck38 = icmp ne i64* %223, null
-  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+  %NullCheck37 = icmp eq i64* %223, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %224
 
 ; <label>:224                                     ; preds = %221
   store i64 %222, i64* %223, align 8
@@ -1084,14 +1166,14 @@ entry:
   %227 = load i8*, i8** %arg1
   %228 = getelementptr inbounds i8, i8* %227, i64 8
   %229 = bitcast i8* %228 to i32*
-  %NullCheck40 = icmp ne i32* %229, null
-  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i32* %229, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %230
 
 ; <label>:230                                     ; preds = %224
   %231 = load i32, i32* %229, align 8
   %232 = bitcast i8* %226 to i32*
-  %NullCheck42 = icmp ne i32* %232, null
-  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+  %NullCheck41 = icmp eq i32* %232, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %233
 
 ; <label>:233                                     ; preds = %230
   store i32 %231, i32* %232, align 8
@@ -1099,15 +1181,15 @@ entry:
   %235 = getelementptr inbounds i8, i8* %234, i64 12
   %236 = load i8*, i8** %arg1
   %237 = getelementptr inbounds i8, i8* %236, i64 12
-  %NullCheck44 = icmp ne i8* %237, null
-  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i8* %237, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %238
 
 ; <label>:238                                     ; preds = %233
   %239 = load i8, i8* %237, align 8
   %240 = zext i8 %239 to i32
   %241 = trunc i32 %240 to i8
-  %NullCheck46 = icmp ne i8* %235, null
-  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+  %NullCheck45 = icmp eq i8* %235, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %242
 
 ; <label>:242                                     ; preds = %238
   store i8 %241, i8* %235, align 8
@@ -1117,14 +1199,14 @@ entry:
   %244 = load i8*, i8** %arg0
   %245 = load i8*, i8** %arg1
   %246 = bitcast i8* %245 to i64*
-  %NullCheck24 = icmp ne i64* %246, null
-  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64* %246, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %247
 
 ; <label>:247                                     ; preds = %243
   %248 = load i64, i64* %246, align 8
   %249 = bitcast i8* %244 to i64*
-  %NullCheck26 = icmp ne i64* %249, null
-  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64* %249, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %250
 
 ; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
@@ -1133,14 +1215,14 @@ entry:
   %253 = load i8*, i8** %arg1
   %254 = getelementptr inbounds i8, i8* %253, i64 8
   %255 = bitcast i8* %254 to i32*
-  %NullCheck28 = icmp ne i32* %255, null
-  br i1 %NullCheck28, label %256, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i32* %255, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %256
 
 ; <label>:256                                     ; preds = %250
   %257 = load i32, i32* %255, align 8
   %258 = bitcast i8* %252 to i32*
-  %NullCheck30 = icmp ne i32* %258, null
-  br i1 %NullCheck30, label %259, label %ThrowNullRef29
+  %NullCheck29 = icmp eq i32* %258, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %259
 
 ; <label>:259                                     ; preds = %256
   store i32 %257, i32* %258, align 8
@@ -1149,16 +1231,16 @@ entry:
   %262 = load i8*, i8** %arg1
   %263 = getelementptr inbounds i8, i8* %262, i64 12
   %264 = bitcast i8* %263 to i16*
-  %NullCheck32 = icmp ne i16* %264, null
-  br i1 %NullCheck32, label %265, label %ThrowNullRef31
+  %NullCheck31 = icmp eq i16* %264, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %265
 
 ; <label>:265                                     ; preds = %259
   %266 = load i16, i16* %264, align 8
   %267 = sext i16 %266 to i32
   %268 = bitcast i8* %261 to i16*
   %269 = trunc i32 %267 to i16
-  %NullCheck34 = icmp ne i16* %268, null
-  br i1 %NullCheck34, label %270, label %ThrowNullRef33
+  %NullCheck33 = icmp eq i16* %268, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %270
 
 ; <label>:270                                     ; preds = %265
   store i16 %269, i16* %268, align 8
@@ -1168,14 +1250,14 @@ entry:
   %272 = load i8*, i8** %arg0
   %273 = load i8*, i8** %arg1
   %274 = bitcast i8* %273 to i64*
-  %NullCheck8 = icmp ne i64* %274, null
-  br i1 %NullCheck8, label %275, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64* %274, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %275
 
 ; <label>:275                                     ; preds = %271
   %276 = load i64, i64* %274, align 8
   %277 = bitcast i8* %272 to i64*
-  %NullCheck10 = icmp ne i64* %277, null
-  br i1 %NullCheck10, label %278, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %277, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %278
 
 ; <label>:278                                     ; preds = %275
   store i64 %276, i64* %277, align 8
@@ -1184,14 +1266,14 @@ entry:
   %281 = load i8*, i8** %arg1
   %282 = getelementptr inbounds i8, i8* %281, i64 8
   %283 = bitcast i8* %282 to i32*
-  %NullCheck12 = icmp ne i32* %283, null
-  br i1 %NullCheck12, label %284, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i32* %283, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %284
 
 ; <label>:284                                     ; preds = %278
   %285 = load i32, i32* %283, align 8
   %286 = bitcast i8* %280 to i32*
-  %NullCheck14 = icmp ne i32* %286, null
-  br i1 %NullCheck14, label %287, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i32* %286, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %287
 
 ; <label>:287                                     ; preds = %284
   store i32 %285, i32* %286, align 8
@@ -1200,16 +1282,16 @@ entry:
   %290 = load i8*, i8** %arg1
   %291 = getelementptr inbounds i8, i8* %290, i64 12
   %292 = bitcast i8* %291 to i16*
-  %NullCheck16 = icmp ne i16* %292, null
-  br i1 %NullCheck16, label %293, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i16* %292, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %293
 
 ; <label>:293                                     ; preds = %287
   %294 = load i16, i16* %292, align 8
   %295 = sext i16 %294 to i32
   %296 = bitcast i8* %289 to i16*
   %297 = trunc i32 %295 to i16
-  %NullCheck18 = icmp ne i16* %296, null
-  br i1 %NullCheck18, label %298, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i16* %296, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %298
 
 ; <label>:298                                     ; preds = %293
   store i16 %297, i16* %296, align 8
@@ -1217,15 +1299,15 @@ entry:
   %300 = getelementptr inbounds i8, i8* %299, i64 14
   %301 = load i8*, i8** %arg1
   %302 = getelementptr inbounds i8, i8* %301, i64 14
-  %NullCheck20 = icmp ne i8* %302, null
-  br i1 %NullCheck20, label %303, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i8* %302, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %303
 
 ; <label>:303                                     ; preds = %298
   %304 = load i8, i8* %302, align 8
   %305 = zext i8 %304 to i32
   %306 = trunc i32 %305 to i8
-  %NullCheck22 = icmp ne i8* %300, null
-  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i8* %300, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %307
 
 ; <label>:307                                     ; preds = %303
   store i8 %306, i8* %300, align 8
@@ -1235,14 +1317,14 @@ entry:
   %309 = load i8*, i8** %arg0
   %310 = load i8*, i8** %arg1
   %311 = bitcast i8* %310 to i64*
-  %NullCheck = icmp ne i64* %311, null
-  br i1 %NullCheck, label %312, label %ThrowNullRef
+  %NullCheck = icmp eq i64* %311, null
+  br i1 %NullCheck, label %ThrowNullRef, label %312
 
 ; <label>:312                                     ; preds = %308
   %313 = load i64, i64* %311, align 8
   %314 = bitcast i8* %309 to i64*
-  %NullCheck2 = icmp ne i64* %314, null
-  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64* %314, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %315
 
 ; <label>:315                                     ; preds = %312
   store i64 %313, i64* %314, align 8
@@ -1251,14 +1333,14 @@ entry:
   %318 = load i8*, i8** %arg1
   %319 = getelementptr inbounds i8, i8* %318, i64 8
   %320 = bitcast i8* %319 to i64*
-  %NullCheck4 = icmp ne i64* %320, null
-  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64* %320, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %321
 
 ; <label>:321                                     ; preds = %315
   %322 = load i64, i64* %320, align 8
   %323 = bitcast i8* %317 to i64*
-  %NullCheck6 = icmp ne i64* %323, null
-  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64* %323, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %324
 
 ; <label>:324                                     ; preds = %321
   store i64 %322, i64* %323, align 8
@@ -1286,15 +1368,15 @@ entry:
 ; <label>:338                                     ; preds = %333
   %339 = load i8*, i8** %arg0
   %340 = load i8*, i8** %arg1
-  %NullCheck136 = icmp ne i8* %340, null
-  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+  %NullCheck135 = icmp eq i8* %340, null
+  br i1 %NullCheck135, label %ThrowNullRef136, label %341
 
 ; <label>:341                                     ; preds = %338
   %342 = load i8, i8* %340, align 8
   %343 = zext i8 %342 to i32
   %344 = trunc i32 %343 to i8
-  %NullCheck138 = icmp ne i8* %339, null
-  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+  %NullCheck137 = icmp eq i8* %339, null
+  br i1 %NullCheck137, label %ThrowNullRef138, label %345
 
 ; <label>:345                                     ; preds = %341
   store i8 %344, i8* %339, align 8
@@ -1317,16 +1399,16 @@ entry:
   %357 = load i8*, i8** %arg0
   %358 = load i8*, i8** %arg1
   %359 = bitcast i8* %358 to i16*
-  %NullCheck140 = icmp ne i16* %359, null
-  br i1 %NullCheck140, label %360, label %ThrowNullRef139
+  %NullCheck139 = icmp eq i16* %359, null
+  br i1 %NullCheck139, label %ThrowNullRef140, label %360
 
 ; <label>:360                                     ; preds = %356
   %361 = load i16, i16* %359, align 8
   %362 = sext i16 %361 to i32
   %363 = bitcast i8* %357 to i16*
   %364 = trunc i32 %362 to i16
-  %NullCheck142 = icmp ne i16* %363, null
-  br i1 %NullCheck142, label %365, label %ThrowNullRef141
+  %NullCheck141 = icmp eq i16* %363, null
+  br i1 %NullCheck141, label %ThrowNullRef142, label %365
 
 ; <label>:365                                     ; preds = %360
   store i16 %364, i16* %363, align 8
@@ -1352,14 +1434,14 @@ entry:
   %378 = load i8*, i8** %arg0
   %379 = load i8*, i8** %arg1
   %380 = bitcast i8* %379 to i32*
-  %NullCheck144 = icmp ne i32* %380, null
-  br i1 %NullCheck144, label %381, label %ThrowNullRef143
+  %NullCheck143 = icmp eq i32* %380, null
+  br i1 %NullCheck143, label %ThrowNullRef144, label %381
 
 ; <label>:381                                     ; preds = %377
   %382 = load i32, i32* %380, align 8
   %383 = bitcast i8* %378 to i32*
-  %NullCheck146 = icmp ne i32* %383, null
-  br i1 %NullCheck146, label %384, label %ThrowNullRef145
+  %NullCheck145 = icmp eq i32* %383, null
+  br i1 %NullCheck145, label %ThrowNullRef146, label %384
 
 ; <label>:384                                     ; preds = %381
   store i32 %382, i32* %383, align 8
@@ -1384,14 +1466,14 @@ entry:
   %395 = load i8*, i8** %arg0
   %396 = load i8*, i8** %arg1
   %397 = bitcast i8* %396 to i64*
-  %NullCheck164 = icmp ne i64* %397, null
-  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+  %NullCheck163 = icmp eq i64* %397, null
+  br i1 %NullCheck163, label %ThrowNullRef164, label %398
 
 ; <label>:398                                     ; preds = %394
   %399 = load i64, i64* %397, align 8
   %400 = bitcast i8* %395 to i64*
-  %NullCheck166 = icmp ne i64* %400, null
-  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+  %NullCheck165 = icmp eq i64* %400, null
+  br i1 %NullCheck165, label %ThrowNullRef166, label %401
 
 ; <label>:401                                     ; preds = %398
   store i64 %399, i64* %400, align 8
@@ -1400,14 +1482,14 @@ entry:
   %404 = load i8*, i8** %arg1
   %405 = getelementptr inbounds i8, i8* %404, i64 8
   %406 = bitcast i8* %405 to i64*
-  %NullCheck168 = icmp ne i64* %406, null
-  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+  %NullCheck167 = icmp eq i64* %406, null
+  br i1 %NullCheck167, label %ThrowNullRef168, label %407
 
 ; <label>:407                                     ; preds = %401
   %408 = load i64, i64* %406, align 8
   %409 = bitcast i8* %403 to i64*
-  %NullCheck170 = icmp ne i64* %409, null
-  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+  %NullCheck169 = icmp eq i64* %409, null
+  br i1 %NullCheck169, label %ThrowNullRef170, label %410
 
 ; <label>:410                                     ; preds = %407
   store i64 %408, i64* %409, align 8
@@ -1437,14 +1519,14 @@ entry:
   %425 = load i8*, i8** %arg0
   %426 = load i8*, i8** %arg1
   %427 = bitcast i8* %426 to i64*
-  %NullCheck148 = icmp ne i64* %427, null
-  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+  %NullCheck147 = icmp eq i64* %427, null
+  br i1 %NullCheck147, label %ThrowNullRef148, label %428
 
 ; <label>:428                                     ; preds = %424
   %429 = load i64, i64* %427, align 8
   %430 = bitcast i8* %425 to i64*
-  %NullCheck150 = icmp ne i64* %430, null
-  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+  %NullCheck149 = icmp eq i64* %430, null
+  br i1 %NullCheck149, label %ThrowNullRef150, label %431
 
 ; <label>:431                                     ; preds = %428
   store i64 %429, i64* %430, align 8
@@ -1466,14 +1548,14 @@ entry:
   %441 = load i8*, i8** %arg0
   %442 = load i8*, i8** %arg1
   %443 = bitcast i8* %442 to i32*
-  %NullCheck152 = icmp ne i32* %443, null
-  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+  %NullCheck151 = icmp eq i32* %443, null
+  br i1 %NullCheck151, label %ThrowNullRef152, label %444
 
 ; <label>:444                                     ; preds = %440
   %445 = load i32, i32* %443, align 8
   %446 = bitcast i8* %441 to i32*
-  %NullCheck154 = icmp ne i32* %446, null
-  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+  %NullCheck153 = icmp eq i32* %446, null
+  br i1 %NullCheck153, label %ThrowNullRef154, label %447
 
 ; <label>:447                                     ; preds = %444
   store i32 %445, i32* %446, align 8
@@ -1495,16 +1577,16 @@ entry:
   %457 = load i8*, i8** %arg0
   %458 = load i8*, i8** %arg1
   %459 = bitcast i8* %458 to i16*
-  %NullCheck156 = icmp ne i16* %459, null
-  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+  %NullCheck155 = icmp eq i16* %459, null
+  br i1 %NullCheck155, label %ThrowNullRef156, label %460
 
 ; <label>:460                                     ; preds = %456
   %461 = load i16, i16* %459, align 8
   %462 = sext i16 %461 to i32
   %463 = bitcast i8* %457 to i16*
   %464 = trunc i32 %462 to i16
-  %NullCheck158 = icmp ne i16* %463, null
-  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+  %NullCheck157 = icmp eq i16* %463, null
+  br i1 %NullCheck157, label %ThrowNullRef158, label %465
 
 ; <label>:465                                     ; preds = %460
   store i16 %464, i16* %463, align 8
@@ -1525,15 +1607,15 @@ entry:
 ; <label>:474                                     ; preds = %470
   %475 = load i8*, i8** %arg0
   %476 = load i8*, i8** %arg1
-  %NullCheck160 = icmp ne i8* %476, null
-  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+  %NullCheck159 = icmp eq i8* %476, null
+  br i1 %NullCheck159, label %ThrowNullRef160, label %477
 
 ; <label>:477                                     ; preds = %474
   %478 = load i8, i8* %476, align 8
   %479 = zext i8 %478 to i32
   %480 = trunc i32 %479 to i8
-  %NullCheck162 = icmp ne i8* %475, null
-  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+  %NullCheck161 = icmp eq i8* %475, null
+  br i1 %NullCheck161, label %ThrowNullRef162, label %481
 
 ; <label>:481                                     ; preds = %477
   store i8 %480, i8* %475, align 8
@@ -1553,343 +1635,343 @@ ThrowNullRef:                                     ; preds = %308
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %312
+ThrowNullRef2:                                    ; preds = %312
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %315
+ThrowNullRef4:                                    ; preds = %315
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %321
+ThrowNullRef6:                                    ; preds = %321
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %271
+ThrowNullRef8:                                    ; preds = %271
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %275
+ThrowNullRef10:                                   ; preds = %275
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %278
+ThrowNullRef12:                                   ; preds = %278
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %284
+ThrowNullRef14:                                   ; preds = %284
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %287
+ThrowNullRef16:                                   ; preds = %287
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %293
+ThrowNullRef18:                                   ; preds = %293
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %298
+ThrowNullRef20:                                   ; preds = %298
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %303
+ThrowNullRef22:                                   ; preds = %303
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %243
+ThrowNullRef24:                                   ; preds = %243
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %247
+ThrowNullRef26:                                   ; preds = %247
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %250
+ThrowNullRef28:                                   ; preds = %250
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %256
+ThrowNullRef30:                                   ; preds = %256
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %259
+ThrowNullRef32:                                   ; preds = %259
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %265
+ThrowNullRef34:                                   ; preds = %265
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %217
+ThrowNullRef36:                                   ; preds = %217
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %221
+ThrowNullRef38:                                   ; preds = %221
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %224
+ThrowNullRef40:                                   ; preds = %224
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %230
+ThrowNullRef42:                                   ; preds = %230
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %233
+ThrowNullRef44:                                   ; preds = %233
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %238
+ThrowNullRef46:                                   ; preds = %238
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %200
+ThrowNullRef48:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %204
+ThrowNullRef50:                                   ; preds = %204
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %207
+ThrowNullRef52:                                   ; preds = %207
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %213
+ThrowNullRef54:                                   ; preds = %213
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %172
+ThrowNullRef56:                                   ; preds = %172
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %176
+ThrowNullRef58:                                   ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %179
+ThrowNullRef60:                                   ; preds = %179
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %185
+ThrowNullRef62:                                   ; preds = %185
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %190
+ThrowNullRef64:                                   ; preds = %190
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %195
+ThrowNullRef66:                                   ; preds = %195
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %153
+ThrowNullRef68:                                   ; preds = %153
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %157
+ThrowNullRef70:                                   ; preds = %157
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %160
+ThrowNullRef72:                                   ; preds = %160
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %166
+ThrowNullRef74:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %136
+ThrowNullRef76:                                   ; preds = %136
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %140
+ThrowNullRef78:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %143
+ThrowNullRef80:                                   ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %148
+ThrowNullRef82:                                   ; preds = %148
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %128
+ThrowNullRef84:                                   ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %132
+ThrowNullRef86:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %100
+ThrowNullRef88:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %104
+ThrowNullRef90:                                   ; preds = %104
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %107
+ThrowNullRef92:                                   ; preds = %107
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %113
+ThrowNullRef94:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %118
+ThrowNullRef96:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %123
+ThrowNullRef98:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %81
+ThrowNullRef100:                                  ; preds = %81
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef101:                                  ; preds = %85
+ThrowNullRef102:                                  ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef103:                                  ; preds = %88
+ThrowNullRef104:                                  ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef105:                                  ; preds = %94
+ThrowNullRef106:                                  ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef107:                                  ; preds = %64
+ThrowNullRef108:                                  ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef109:                                  ; preds = %68
+ThrowNullRef110:                                  ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef111:                                  ; preds = %71
+ThrowNullRef112:                                  ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef113:                                  ; preds = %76
+ThrowNullRef114:                                  ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef115:                                  ; preds = %56
+ThrowNullRef116:                                  ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef117:                                  ; preds = %60
+ThrowNullRef118:                                  ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef119:                                  ; preds = %37
+ThrowNullRef120:                                  ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef121:                                  ; preds = %41
+ThrowNullRef122:                                  ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef123:                                  ; preds = %46
+ThrowNullRef124:                                  ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef125:                                  ; preds = %51
+ThrowNullRef126:                                  ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef127:                                  ; preds = %27
+ThrowNullRef128:                                  ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef129:                                  ; preds = %31
+ThrowNullRef130:                                  ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef131:                                  ; preds = %19
+ThrowNullRef132:                                  ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef133:                                  ; preds = %22
+ThrowNullRef134:                                  ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef135:                                  ; preds = %338
+ThrowNullRef136:                                  ; preds = %338
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef137:                                  ; preds = %341
+ThrowNullRef138:                                  ; preds = %341
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef139:                                  ; preds = %356
+ThrowNullRef140:                                  ; preds = %356
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef141:                                  ; preds = %360
+ThrowNullRef142:                                  ; preds = %360
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef143:                                  ; preds = %377
+ThrowNullRef144:                                  ; preds = %377
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef145:                                  ; preds = %381
+ThrowNullRef146:                                  ; preds = %381
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef147:                                  ; preds = %424
+ThrowNullRef148:                                  ; preds = %424
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef149:                                  ; preds = %428
+ThrowNullRef150:                                  ; preds = %428
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef151:                                  ; preds = %440
+ThrowNullRef152:                                  ; preds = %440
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef153:                                  ; preds = %444
+ThrowNullRef154:                                  ; preds = %444
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef155:                                  ; preds = %456
+ThrowNullRef156:                                  ; preds = %456
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef157:                                  ; preds = %460
+ThrowNullRef158:                                  ; preds = %460
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef159:                                  ; preds = %474
+ThrowNullRef160:                                  ; preds = %474
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef161:                                  ; preds = %477
+ThrowNullRef162:                                  ; preds = %477
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef163:                                  ; preds = %394
+ThrowNullRef164:                                  ; preds = %394
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef165:                                  ; preds = %398
+ThrowNullRef166:                                  ; preds = %398
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef167:                                  ; preds = %401
+ThrowNullRef168:                                  ; preds = %401
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef169:                                  ; preds = %407
+ThrowNullRef170:                                  ; preds = %407
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1939,8 +2021,8 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
-  br i1 %NullCheck, label %22, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %ThrowNullRef, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
@@ -1948,8 +2030,8 @@ entry:
   store i32 %24, i32* %loc0
   %25 = load i32, i32* %loc0
   %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %26, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %27
 
 ; <label>:27                                      ; preds = %22
   %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
@@ -1971,7 +2053,7 @@ ThrowNullRef:                                     ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1989,8 +2071,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -2022,15 +2104,15 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2048,16 +2130,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
   %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
   store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %15
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
@@ -2072,8 +2154,8 @@ entry:
   %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
   %29 = ptrtoint i16 addrspace(1)* %28 to i64
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %19
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
@@ -2089,19 +2171,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2114,8 +2196,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
@@ -2128,7 +2210,7 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[loadElem]
+Failed to read AppDomain.PrepareDataForSetup[storeElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
@@ -2202,8 +2284,8 @@ entry:
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
-  br i1 %NullCheck24, label %27, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = load i64, i64 addrspace(1)* %26
@@ -2218,8 +2300,8 @@ entry:
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
-  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
   %41 = load i64, i64 addrspace(1)* %39
@@ -2236,8 +2318,8 @@ entry:
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
-  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
   %54 = load i64, i64 addrspace(1)* %52
@@ -2252,8 +2334,8 @@ entry:
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
   %67 = load i64, i64 addrspace(1)* %65
@@ -2270,8 +2352,8 @@ entry:
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
-  br i1 %NullCheck16, label %79, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
   %80 = load i64, i64 addrspace(1)* %78
@@ -2286,8 +2368,8 @@ entry:
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
-  br i1 %NullCheck18, label %92, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
   %93 = load i64, i64 addrspace(1)* %91
@@ -2304,8 +2386,8 @@ entry:
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
-  br i1 %NullCheck12, label %105, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = load i64, i64 addrspace(1)* %104
@@ -2320,8 +2402,8 @@ entry:
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
-  br i1 %NullCheck14, label %118, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
   %119 = load i64, i64 addrspace(1)* %117
@@ -2337,8 +2419,8 @@ entry:
 
 ; <label>:128                                     ; preds = %20
   %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
-  br i1 %NullCheck4, label %130, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %129, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %130
 
 ; <label>:130                                     ; preds = %128
   %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
@@ -2346,8 +2428,8 @@ entry:
   %133 = load i16, i16 addrspace(1)* %132, align 8
   %134 = zext i16 %133 to i32
   %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
-  br i1 %NullCheck6, label %136, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %135, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %136
 
 ; <label>:136                                     ; preds = %130
   %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
@@ -2360,8 +2442,8 @@ entry:
 
 ; <label>:143                                     ; preds = %136
   %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
-  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %144, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %145
 
 ; <label>:145                                     ; preds = %143
   %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
@@ -2369,8 +2451,8 @@ entry:
   %148 = load i16, i16 addrspace(1)* %147, align 8
   %149 = zext i16 %148 to i32
   %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %150, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %151
 
 ; <label>:151                                     ; preds = %145
   %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
@@ -2388,8 +2470,8 @@ entry:
 
 ; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
-  br i1 %NullCheck, label %163, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %ThrowNullRef, label %163
 
 ; <label>:163                                     ; preds = %161
   %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
@@ -2399,8 +2481,8 @@ entry:
 
 ; <label>:167                                     ; preds = %163
   %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
-  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %168, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %169
 
 ; <label>:169                                     ; preds = %167
   %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
@@ -2432,55 +2514,55 @@ ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %167
+ThrowNullRef2:                                    ; preds = %167
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %128
+ThrowNullRef4:                                    ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %130
+ThrowNullRef6:                                    ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %143
+ThrowNullRef8:                                    ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %145
+ThrowNullRef10:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %102
+ThrowNullRef12:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %105
+ThrowNullRef14:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %76
+ThrowNullRef16:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %79
+ThrowNullRef18:                                   ; preds = %79
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %50
+ThrowNullRef20:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %53
+ThrowNullRef22:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %24
+ThrowNullRef24:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %27
+ThrowNullRef26:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2503,15 +2585,15 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2519,16 +2601,16 @@ entry:
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
   store i32 %8, i32* %loc0
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
   %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
   store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
@@ -2546,16 +2628,16 @@ entry:
 
 ; <label>:23                                      ; preds = %64
   %24 = load i16*, i16** %loc3
-  %NullCheck12 = icmp ne i16* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i16* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
   store i32 %27, i32* %loc5
   %28 = load i16*, i16** %loc4
-  %NullCheck14 = icmp ne i16* %28, null
-  br i1 %NullCheck14, label %29, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %28, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = load i16, i16* %28, align 8
@@ -2620,15 +2702,15 @@ entry:
 
 ; <label>:67                                      ; preds = %64
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
-  br i1 %NullCheck8, label %69, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %68, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %69
 
 ; <label>:69                                      ; preds = %67
   %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
   %71 = load i32, i32 addrspace(1)* %70
   %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
-  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %73
 
 ; <label>:73                                      ; preds = %69
   %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
@@ -2645,31 +2727,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %67
+ThrowNullRef8:                                    ; preds = %67
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %69
+ThrowNullRef10:                                   ; preds = %69
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2710,14 +2792,14 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
   %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
@@ -2730,14 +2812,14 @@ entry:
 
 ; <label>:11                                      ; preds = %4
   %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
   %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
@@ -2749,14 +2831,14 @@ entry:
 
 ; <label>:22                                      ; preds = %16
   %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
   %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
-  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
-  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
@@ -2804,23 +2886,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2836,7 +2918,280 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[loadElem]
+Successfully read RuntimeType.IsAssignableFrom
+
+define i8 @RuntimeType.IsAssignableFrom(%System.RuntimeType addrspace(1)* %param0, %System.Type addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.RuntimeType addrspace(1)*
+  %arg1 = alloca %System.Type addrspace(1)*
+  %loc0 = alloca %System.RuntimeType addrspace(1)*
+  %loc1 = alloca %"System.Type[]" addrspace(1)*
+  %loc2 = alloca i32
+  store %System.RuntimeType addrspace(1)* %param0, %System.RuntimeType addrspace(1)** %this
+  store %System.Type addrspace(1)* %param1, %System.Type addrspace(1)** %arg1
+  %0 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %1 = icmp ne %System.Type addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i8 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %5 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %6 = bitcast %System.Type addrspace(1)* %4 to %System.Object addrspace(1)*
+  %7 = bitcast %System.RuntimeType addrspace(1)* %5 to %System.Object addrspace(1)*
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %6, %System.Object addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %3
+  ret i8 1
+
+; <label>:12                                      ; preds = %3
+  %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 152
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 32
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
+  %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
+  %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
+  store %System.RuntimeType addrspace(1)* %25, %System.RuntimeType addrspace(1)** %loc0
+  %26 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %27 = icmp eq %System.RuntimeType addrspace(1)* %26, null
+  br i1 %27, label %34, label %28
+
+; <label>:28                                      ; preds = %15
+  %29 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %30 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)*)*)(%System.RuntimeType addrspace(1)* %29, %System.RuntimeType addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+; <label>:34                                      ; preds = %15
+  %35 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %36 = call %System.Reflection.Emit.TypeBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Reflection.Emit.TypeBuilder addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %35)
+  %37 = icmp eq %System.Reflection.Emit.TypeBuilder addrspace(1)* %36, null
+  br i1 %37, label %139, label %38
+
+; <label>:38                                      ; preds = %34
+  %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %42
+
+; <label>:42                                      ; preds = %38
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 152
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 40
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
+  %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
+  %53 = zext i8 %52 to i32
+  %54 = icmp eq i32 %53, 0
+  br i1 %54, label %56, label %55
+
+; <label>:55                                      ; preds = %42
+  ret i8 1
+
+; <label>:56                                      ; preds = %42
+  %57 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %58 = bitcast %System.RuntimeType addrspace(1)* %57 to %System.Type addrspace(1)*
+  %59 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %58)
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %64 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.Type addrspace(1)* %63, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = bitcast %System.RuntimeType addrspace(1)* %64 to %System.Type addrspace(1)*
+  %67 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %63, %System.Type addrspace(1)* %66)
+  %68 = zext i8 %67 to i32
+  %69 = trunc i32 %68 to i8
+  ret i8 %69
+
+; <label>:70                                      ; preds = %56
+  %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
+  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %73
+
+; <label>:73                                      ; preds = %70
+  %74 = load i64, i64 addrspace(1)* %72
+  %75 = add i64 %74, 128
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = add i64 %77, 0
+  %79 = inttoptr i64 %78 to i64*
+  %80 = load i64, i64* %79
+  %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
+  %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
+  %83 = call i8 %82(%System.Type addrspace(1)* %81)
+  %84 = zext i8 %83 to i32
+  %85 = icmp eq i32 %84, 0
+  br i1 %85, label %139, label %86
+
+; <label>:86                                      ; preds = %73
+  %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
+  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %89
+
+; <label>:89                                      ; preds = %86
+  %90 = load i64, i64 addrspace(1)* %88
+  %91 = add i64 %90, 128
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = add i64 %93, 24
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
+  %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
+  %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
+  store %"System.Type[]" addrspace(1)* %99, %"System.Type[]" addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %129
+
+; <label>:100                                     ; preds = %132
+  %101 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %102 = load i32, i32* %loc2
+  %NullCheck11 = icmp eq %"System.Type[]" addrspace(1)* %101, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %103
+
+; <label>:103                                     ; preds = %100
+  %104 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 1
+  %105 = load i32, i32 addrspace(1)* %104
+  %106 = zext i32 %105 to i64
+  %107 = zext i32 %102 to i64
+  %BoundsCheck = icmp uge i64 %107, %106
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %108
+
+; <label>:108                                     ; preds = %103
+  %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
+  %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
+  %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
+  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %113
+
+; <label>:113                                     ; preds = %108
+  %114 = load i64, i64 addrspace(1)* %112
+  %115 = add i64 %114, 152
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = add i64 %117, 56
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
+  %123 = zext i8 %122 to i32
+  %124 = icmp ne i32 %123, 0
+  br i1 %124, label %126, label %125
+
+; <label>:125                                     ; preds = %113
+  ret i8 0
+
+; <label>:126                                     ; preds = %113
+  %127 = load i32, i32* %loc2
+  %128 = add i32 %127, 1
+  store i32 %128, i32* %loc2
+  br label %129
+
+; <label>:129                                     ; preds = %89, %126
+  %130 = load i32, i32* %loc2
+  %131 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %NullCheck9 = icmp eq %"System.Type[]" addrspace(1)* %131, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %132
+
+; <label>:132                                     ; preds = %129
+  %133 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %131, i32 0, i32 1
+  %134 = load i32, i32 addrspace(1)* %133
+  %135 = zext i32 %134 to i64
+  %136 = trunc i64 %135 to i32
+  %137 = icmp slt i32 %130, %136
+  br i1 %137, label %100, label %138
+
+; <label>:138                                     ; preds = %132
+  ret i8 1
+
+; <label>:139                                     ; preds = %34, %73
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %129
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %103
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -2893,7 +3248,7 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElem]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -2904,8 +3259,8 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -2997,8 +3352,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
@@ -3059,8 +3414,8 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -3087,8 +3442,8 @@ entry:
 
 ; <label>:17                                      ; preds = %5, %11
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
@@ -3097,8 +3452,8 @@ entry:
 
 ; <label>:22                                      ; preds = %1, %11
   %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
@@ -3109,11 +3464,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %17
+ThrowNullRef2:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %22
+ThrowNullRef4:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3167,15 +3522,15 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
   %15 = load i32, i32 addrspace(1)* %14
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
@@ -3198,7 +3553,7 @@ ThrowNullRef:                                     ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef2:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3232,8 +3587,8 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
@@ -3312,8 +3667,8 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -3327,8 +3682,8 @@ entry:
 ; <label>:5                                       ; preds = %43
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %7 = load i32, i32* %loc1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck6, label %8, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
@@ -3366,8 +3721,8 @@ entry:
 ; <label>:32                                      ; preds = %21, %25
   %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
   %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
-  br i1 %NullCheck8, label %35, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = trunc i32 %34 to i16
@@ -3380,8 +3735,8 @@ entry:
 ; <label>:40                                      ; preds = %1, %35
   %41 = load i32, i32* %loc1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
-  br i1 %NullCheck2, label %43, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %42, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
@@ -3392,8 +3747,8 @@ entry:
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
   %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
-  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
   %51 = load i64, i64 addrspace(1)* %49
@@ -3412,19 +3767,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %40
+ThrowNullRef2:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %47
+ThrowNullRef4:                                    ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %5
+ThrowNullRef6:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %32
+ThrowNullRef8:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3467,8 +3822,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
@@ -3492,11 +3847,391 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(i16* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store i16* %param0, i16** %arg0
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load i32, i32* %arg3
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %42, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %37, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg2
+  %13 = load i32, i32* %arg3
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %37, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %24 = load i32, i32* %arg2
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load i16*, i16** %arg0
+  %35 = load i32, i32* %arg3
+  %36 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %36, i16* %34, i32 %35)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:37                                      ; preds = %5, %16
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %39)
+  %41 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41, %System.String addrspace(1)* %38, %System.String addrspace(1)* %40)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41) #0
+  unreachable
+
+; <label>:42                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
-Failed to read StringBuilder.ToString[loadElemA]
+Successfully read StringBuilder.ToString
+
+define %System.String addrspace(1)* @StringBuilder.ToString(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i16*
+  %loc3 = alloca %"System.Char[]" addrspace(1)*
+  %loc4 = alloca i32
+  %loc5 = alloca i32
+  %loc6 = alloca i16 addrspace(1)*
+  %loc7 = alloca %System.String addrspace(1)*
+  %loc8 = alloca %"System.Char[]" addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %0)
+  %2 = icmp ne i32 %1, 0
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %4
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %6)
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %7)
+  store %System.String addrspace(1)* %8, %System.String addrspace(1)** %loc0
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.Text.StringBuilder addrspace(1)* %9, %System.Text.StringBuilder addrspace(1)** %loc1
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  store %System.String addrspace(1)* %10, %System.String addrspace(1)** %loc7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc7
+  %12 = ptrtoint %System.String addrspace(1)* %11 to i64
+  %13 = icmp eq i64 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %5
+  %15 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %16 = sext i32 %15 to i64
+  %17 = add i64 %12, %16
+  br label %18
+
+; <label>:18                                      ; preds = %5, %14
+  %19 = phi i64 [ %12, %5 ], [ %17, %14 ]
+  %20 = inttoptr i64 %19 to i16*
+  store i16* %20, i16** %loc2
+  br label %21
+
+; <label>:21                                      ; preds = %98, %18
+  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %22, null
+  br i1 %NullCheck, label %ThrowNullRef, label %23
+
+; <label>:23                                      ; preds = %21
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 3
+  %25 = load i32, i32 addrspace(1)* %24, align 8
+  %26 = icmp sle i32 %25, 0
+  br i1 %26, label %96, label %27
+
+; <label>:27                                      ; preds = %23
+  %28 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %28, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %29
+
+; <label>:29                                      ; preds = %27
+  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %28, i32 0, i32 1
+  %31 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %30, align 8
+  store %"System.Char[]" addrspace(1)* %31, %"System.Char[]" addrspace(1)** %loc3
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %33
+
+; <label>:33                                      ; preds = %29
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  store i32 %35, i32* %loc4
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  %39 = load i32, i32 addrspace(1)* %38, align 8
+  store i32 %39, i32* %loc5
+  %40 = load i32, i32* %loc5
+  %41 = load i32, i32* %loc4
+  %42 = add i32 %40, %41
+  %43 = zext i32 %42 to i64
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %45
+
+; <label>:45                                      ; preds = %37
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = sext i32 %47 to i64
+  %49 = icmp sgt i64 %43, %48
+  br i1 %49, label %91, label %50
+
+; <label>:50                                      ; preds = %45
+  %51 = load i32, i32* %loc5
+  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %52, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %53
+
+; <label>:53                                      ; preds = %50
+  %54 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %52, i32 0, i32 1
+  %55 = load i32, i32 addrspace(1)* %54
+  %56 = zext i32 %55 to i64
+  %57 = trunc i64 %56 to i32
+  %58 = icmp ugt i32 %51, %57
+  br i1 %58, label %91, label %59
+
+; <label>:59                                      ; preds = %53
+  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  store %"System.Char[]" addrspace(1)* %60, %"System.Char[]" addrspace(1)** %loc8
+  %61 = icmp eq %"System.Char[]" addrspace(1)* %60, null
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %63, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %64
+
+; <label>:64                                      ; preds = %62
+  %65 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %63, i32 0, i32 1
+  %66 = load i32, i32 addrspace(1)* %65
+  %67 = zext i32 %66 to i64
+  %68 = trunc i64 %67 to i32
+  %69 = icmp ne i32 %68, 0
+  br i1 %69, label %71, label %70
+
+; <label>:70                                      ; preds = %59, %64
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:71                                      ; preds = %64
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %73
+
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %BoundsCheck = icmp uge i64 0, %76
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %77
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %78, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:79                                      ; preds = %70, %77
+  %80 = load i16*, i16** %loc2
+  %81 = load i32, i32* %loc4
+  %82 = sext i32 %81 to i64
+  %83 = mul i64 %82, 2
+  %84 = bitcast i16* %80 to i8*
+  %85 = getelementptr inbounds i8, i8* %84, i64 %83
+  %86 = load i16 addrspace(1)*, i16 addrspace(1)** %loc6
+  %87 = ptrtoint i16 addrspace(1)* %86 to i64
+  %88 = load i32, i32* %loc5
+  %89 = bitcast i8* %85 to i16*
+  %90 = inttoptr i64 %87 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %89, i16* %90, i32 %88)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %96
+
+; <label>:91                                      ; preds = %45, %53
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %94 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %93)
+  %95 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95, %System.String addrspace(1)* %92, %System.String addrspace(1)* %94)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95) #0
+  unreachable
+
+; <label>:96                                      ; preds = %23, %79
+  %97 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %97, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %98
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %97, i32 0, i32 2
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  store %System.Text.StringBuilder addrspace(1)* %100, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %102 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %102, label %21, label %103
+
+; <label>:103                                     ; preds = %98
+  store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc7
+  %104 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  ret %System.String addrspace(1)* %104
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method StringBuilder::get_Length using LLILCJit
+Successfully read StringBuilder.get_Length
+
+define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
+Successfully read RuntimeHelpers.get_OffsetToStringData
+
+define i32 @RuntimeHelpers.get_OffsetToStringData() {
+entry:
+  ret i32 12
+}
+
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
 Successfully read CultureData.CreateCultureData
 
@@ -3514,23 +4249,23 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
   store i8 %4, i8 addrspace(1)* %6
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
@@ -3549,11 +4284,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3566,50 +4301,50 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
   store i32 -1, i32 addrspace(1)* %2
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
   store i32 -1, i32 addrspace(1)* %8
   %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
   store i32 -1, i32 addrspace(1)* %14
   %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
   store i32 -1, i32 addrspace(1)* %17
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
@@ -3623,27 +4358,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3675,7 +4410,136 @@ Failed to read Dictionary`2.Insert[non-const derefAddress]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
 Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
-Failed to read HashHelpers.GetPrime[loadElem]
+Successfully read HashHelpers.GetPrime
+
+define i32 @HashHelpers.GetPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %6, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5, %System.String addrspace(1)* %4)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5) #0
+  unreachable
+
+; <label>:6                                       ; preds = %entry
+  store i32 0, i32* %loc0
+  br label %29
+
+; <label>:7                                       ; preds = %35
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 1296
+  %10 = addrspacecast i8 addrspace(1)* %9 to %"System.Int32[]" addrspace(1)**
+  %11 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %10
+  %12 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Int32[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = zext i32 %15 to i64
+  %17 = zext i32 %12 to i64
+  %BoundsCheck = icmp uge i64 %17, %16
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 3, i32 %12
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  store i32 %20, i32* %loc1
+  %21 = load i32, i32* %loc1
+  %22 = load i32, i32* %arg0
+  %23 = icmp slt i32 %21, %22
+  br i1 %23, label %26, label %24
+
+; <label>:24                                      ; preds = %18
+  %25 = load i32, i32* %loc1
+  ret i32 %25
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %loc0
+  %28 = add i32 %27, 1
+  store i32 %28, i32* %loc0
+  br label %29
+
+; <label>:29                                      ; preds = %6, %26
+  %30 = load i32, i32* %loc0
+  %31 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %32 = getelementptr inbounds i8, i8 addrspace(1)* %31, i64 1296
+  %33 = addrspacecast i8 addrspace(1)* %32 to %"System.Int32[]" addrspace(1)**
+  %34 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %33
+  %NullCheck = icmp eq %"System.Int32[]" addrspace(1)* %34, null
+  br i1 %NullCheck, label %ThrowNullRef, label %35
+
+; <label>:35                                      ; preds = %29
+  %36 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %34, i32 0, i32 1
+  %37 = load i32, i32 addrspace(1)* %36
+  %38 = zext i32 %37 to i64
+  %39 = trunc i64 %38 to i32
+  %40 = icmp slt i32 %30, %39
+  br i1 %40, label %7, label %41
+
+; <label>:41                                      ; preds = %35
+  %42 = load i32, i32* %arg0
+  %43 = or i32 %42, 1
+  store i32 %43, i32* %loc2
+  br label %59
+
+; <label>:44                                      ; preds = %59
+  %45 = load i32, i32* %loc2
+  %46 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %45)
+  %47 = zext i8 %46 to i32
+  %48 = icmp eq i32 %47, 0
+  br i1 %48, label %56, label %49
+
+; <label>:49                                      ; preds = %44
+  %50 = load i32, i32* %loc2
+  %51 = sub i32 %50, 1
+  %52 = srem i32 %51, 101
+  %53 = icmp eq i32 %52, 0
+  br i1 %53, label %56, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = load i32, i32* %loc2
+  ret i32 %55
+
+; <label>:56                                      ; preds = %44, %49
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %57, 2
+  store i32 %58, i32* %loc2
+  br label %59
+
+; <label>:59                                      ; preds = %41, %56
+  %60 = load i32, i32* %loc2
+  %61 = icmp slt i32 %60, 2147483647
+  br i1 %61, label %44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load i32, i32* %arg0
+  ret i32 %63
+
+ThrowNullRef:                                     ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
 Successfully read GenericEqualityComparer`1.GetHashCode
 
@@ -3694,14 +4558,14 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
   %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load i64, i64 addrspace(1)* %7
@@ -3720,7 +4584,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3750,8 +4614,8 @@ entry:
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
@@ -3796,8 +4660,8 @@ entry:
   %35 = bitcast i16* %34 to i8*
   %36 = getelementptr inbounds i8, i8* %35, i64 2
   %37 = bitcast i8* %36 to i16*
-  %NullCheck4 = icmp ne i16* %37, null
-  br i1 %NullCheck4, label %38, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %37, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %38
 
 ; <label>:38                                      ; preds = %27
   %39 = load i16, i16* %37, align 8
@@ -3824,8 +4688,8 @@ entry:
 
 ; <label>:54                                      ; preds = %22, %43
   %55 = load i16*, i16** %loc4
-  %NullCheck2 = icmp ne i16* %55, null
-  br i1 %NullCheck2, label %56, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i16* %55, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %56
 
 ; <label>:56                                      ; preds = %54
   %57 = load i16, i16* %55, align 8
@@ -3850,11 +4714,11 @@ ThrowNullRef:                                     ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %54
+ThrowNullRef2:                                    ; preds = %54
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %27
+ThrowNullRef4:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3871,8 +4735,8 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -3907,8 +4771,8 @@ entry:
 
 ; <label>:26                                      ; preds = %19
   %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
-  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %28
 
 ; <label>:28                                      ; preds = %26
   %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
@@ -3920,7 +4784,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3972,8 +4836,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
@@ -3984,26 +4848,26 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
-  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
@@ -4014,8 +4878,8 @@ entry:
 ; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
@@ -4024,8 +4888,8 @@ entry:
 
 ; <label>:25                                      ; preds = %1, %16, %23
   %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
-  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
@@ -4036,27 +4900,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %20
+ThrowNullRef10:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4069,8 +4933,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -4081,8 +4945,8 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
@@ -4091,8 +4955,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1, %8
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
@@ -4103,11 +4967,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4128,24 +4992,24 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   store i32 %3, i32* %loc0
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
   %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
   store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck4, label %9, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
@@ -4164,15 +5028,15 @@ entry:
 ; <label>:18                                      ; preds = %70
   %19 = load i16*, i16** %loc3
   %20 = bitcast i16* %19 to i64*
-  %NullCheck10 = icmp ne i64* %20, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %20, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = load i64, i64* %20, align 8
   %23 = load i16*, i16** %loc4
   %24 = bitcast i16* %23 to i64*
-  %NullCheck12 = icmp ne i64* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = load i64, i64* %24, align 8
@@ -4188,8 +5052,8 @@ entry:
   %31 = bitcast i16* %30 to i8*
   %32 = getelementptr inbounds i8, i8* %31, i64 8
   %33 = bitcast i8* %32 to i64*
-  %NullCheck14 = icmp ne i64* %33, null
-  br i1 %NullCheck14, label %34, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = load i64, i64* %33, align 8
@@ -4197,8 +5061,8 @@ entry:
   %37 = bitcast i16* %36 to i8*
   %38 = getelementptr inbounds i8, i8* %37, i64 8
   %39 = bitcast i8* %38 to i64*
-  %NullCheck16 = icmp ne i64* %39, null
-  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %40
 
 ; <label>:40                                      ; preds = %34
   %41 = load i64, i64* %39, align 8
@@ -4214,8 +5078,8 @@ entry:
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %NullCheck18 = icmp ne i64* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = load i64, i64* %48, align 8
@@ -4223,8 +5087,8 @@ entry:
   %52 = bitcast i16* %51 to i8*
   %53 = getelementptr inbounds i8, i8* %52, i64 16
   %54 = bitcast i8* %53 to i64*
-  %NullCheck20 = icmp ne i64* %54, null
-  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64* %54, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %55
 
 ; <label>:55                                      ; preds = %49
   %56 = load i64, i64* %54, align 8
@@ -4262,15 +5126,15 @@ entry:
 ; <label>:74                                      ; preds = %95
   %75 = load i16*, i16** %loc3
   %76 = bitcast i16* %75 to i32*
-  %NullCheck6 = icmp ne i32* %76, null
-  br i1 %NullCheck6, label %77, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32* %76, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %77
 
 ; <label>:77                                      ; preds = %74
   %78 = load i32, i32* %76, align 8
   %79 = load i16*, i16** %loc4
   %80 = bitcast i16* %79 to i32*
-  %NullCheck8 = icmp ne i32* %80, null
-  br i1 %NullCheck8, label %81, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i32* %80, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %81
 
 ; <label>:81                                      ; preds = %77
   %82 = load i32, i32* %80, align 8
@@ -4318,43 +5182,43 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %74
+ThrowNullRef6:                                    ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %77
+ThrowNullRef8:                                    ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %29
+ThrowNullRef14:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %34
+ThrowNullRef16:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4376,8 +5240,8 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load i64, i64 addrspace(1)* %4
@@ -4389,8 +5253,8 @@ entry:
   %12 = load i64, i64* %11
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %5
   %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
@@ -4399,8 +5263,8 @@ entry:
   %18 = load i8, i8* %arg2
   %19 = zext i8 %18 to i32
   %20 = trunc i32 %19 to i8
-  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %15
   %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
@@ -4411,11 +5275,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4442,8 +5306,8 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
@@ -4466,16 +5330,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
   %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = load i64, i64 addrspace(1)* %19
@@ -4500,8 +5364,8 @@ entry:
 ; <label>:35                                      ; preds = %30
   %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
@@ -4514,8 +5378,8 @@ entry:
 
 ; <label>:42                                      ; preds = %1, %38
   %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
-  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
@@ -4526,19 +5390,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %35
+ThrowNullRef2:                                    ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %42
+ThrowNullRef8:                                    ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4551,14 +5415,14 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
@@ -4570,7 +5434,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4583,8 +5447,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
@@ -4613,51 +5477,51 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
   %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
   %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
   %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
   %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
-  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
   store i64 %21, i64 addrspace(1)* %23
   %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %25 = load i64, i64* %loc0
-  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
@@ -4668,27 +5532,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %22
+ThrowNullRef12:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4701,8 +5565,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
@@ -4713,19 +5577,19 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
@@ -4734,8 +5598,8 @@ entry:
 
 ; <label>:15                                      ; preds = %1, %13
   %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
@@ -4746,19 +5610,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %15
+ThrowNullRef8:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4771,8 +5635,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -4831,8 +5695,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
@@ -4882,8 +5746,8 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
-  br i1 %NullCheck, label %17, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %ThrowNullRef, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
@@ -4894,15 +5758,15 @@ entry:
 
 ; <label>:22                                      ; preds = %17
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
-  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
   %26 = load i32, i32 addrspace(1)* %25
   %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
-  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %27, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
@@ -4925,8 +5789,8 @@ entry:
 ; <label>:40                                      ; preds = %17
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
-  br i1 %NullCheck6, label %43, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %41, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
@@ -4938,34 +5802,17 @@ ThrowNullRef:                                     ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %24
+ThrowNullRef4:                                    ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %40
+ThrowNullRef6:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
-}
-
-INFO:  jitting method Object::ReferenceEquals using LLILCJit
-Successfully read Object.ReferenceEquals
-
-define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
-entry:
-  %arg0 = alloca %System.Object addrspace(1)*
-  %arg1 = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
-  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
-  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = icmp eq %System.Object addrspace(1)* %0, %1
-  %3 = sext i1 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
 }
 
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
@@ -4978,21 +5825,21 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
   %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
-  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
@@ -5007,28 +5854,28 @@ entry:
 ; <label>:13                                      ; preds = %8, %12
   %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
   %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
   %21 = load i32, i32 addrspace(1)* %20, align 8
   %22 = add i32 %21, 1
-  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
   store i32 %22, i32 addrspace(1)* %24
   %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
@@ -5039,27 +5886,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5077,7 +5924,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::Setup using LLILCJit
-Failed to read AppDomain.Setup[loadElem]
+Failed to read AppDomain.Setup[unbox]
 INFO:  jitting method Thread::GetDomain using LLILCJit
 Successfully read Thread.GetDomain
 
@@ -5108,8 +5955,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
@@ -5122,14 +5969,14 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
   %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
@@ -5141,11 +5988,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5173,8 +6020,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -5189,7 +6036,328 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
 Failed to read KeyCollection.System.Collections.Generic.IEnumerable<TKey>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Successfully read Enumerator.MoveNext
+
+define i8 @Enumerator.MoveNext(%"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.RuntimeTypeHandle* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*
+  %"$TypeArg" = alloca %System.RuntimeTypeHandle*
+  store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
+  %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 8
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %76, label %12
+
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
+  br label %76
+
+; <label>:13                                      ; preds = %85
+  %14 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck19 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %15
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, i32 0, i32 0
+  %17 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %16, align 8
+  %NullCheck21 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, i32 0, i32 2
+  %20 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %19, align 8
+  %21 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck23 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %22
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, i32 0, i32 2
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %NullCheck25 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 3, i32 %24
+  %NullCheck27 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %32
+
+; <label>:32                                      ; preds = %30
+  %33 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, i32 0, i32 2
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = icmp slt i32 %34, 0
+  br i1 %35, label %68, label %36
+
+; <label>:36                                      ; preds = %32
+  %37 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %38 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck29 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %39
+
+; <label>:39                                      ; preds = %36
+  %40 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, i32 0, i32 0
+  %41 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %40, align 8
+  %NullCheck31 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, i32 0, i32 2
+  %44 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %43, align 8
+  %45 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck33 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, i32 0, i32 2
+  %48 = load i32, i32 addrspace(1)* %47, align 8
+  %NullCheck35 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %49
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = zext i32 %51 to i64
+  %53 = zext i32 %48 to i64
+  %BoundsCheck37 = icmp uge i64 %53, %52
+  br i1 %BoundsCheck37, label %ThrowIndexOutOfRange38, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 3, i32 %48
+  %NullCheck39 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %56
+
+; <label>:56                                      ; preds = %54
+  %57 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, i32 0, i32 0
+  %58 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck41 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %59
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %60, %System.__Canon addrspace(1)* %58)
+  %61 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck43 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  %64 = load i32, i32 addrspace(1)* %63, align 8
+  %65 = add i32 %64, 1
+  %NullCheck45 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  store i32 %65, i32 addrspace(1)* %67
+  ret i8 1
+
+; <label>:68                                      ; preds = %32
+  %69 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck47 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %73 = add i32 %72, 1
+  %NullCheck49 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %74
+
+; <label>:74                                      ; preds = %70
+  %75 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  store i32 %73, i32 addrspace(1)* %75
+  br label %76
+
+; <label>:76                                      ; preds = %8, %12, %74
+  %77 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %78
+
+; <label>:78                                      ; preds = %76
+  %79 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, i32 0, i32 2
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck7 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %82
+
+; <label>:82                                      ; preds = %78
+  %83 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, i32 0, i32 0
+  %84 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %83, align 8
+  %NullCheck9 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %85
+
+; <label>:85                                      ; preds = %82
+  %86 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, i32 0, i32 7
+  %87 = load i32, i32 addrspace(1)* %86, align 8
+  %88 = icmp ult i32 %80, %87
+  br i1 %88, label %13, label %89
+
+; <label>:89                                      ; preds = %85
+  %90 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %91 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck11 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %92
+
+; <label>:92                                      ; preds = %89
+  %93 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, i32 0, i32 0
+  %94 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck13 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %95
+
+; <label>:95                                      ; preds = %92
+  %96 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, i32 0, i32 7
+  %97 = load i32, i32 addrspace(1)* %96, align 8
+  %98 = add i32 %97, 1
+  %NullCheck15 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %99
+
+; <label>:99                                      ; preds = %95
+  %100 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, i32 0, i32 2
+  store i32 %98, i32 addrspace(1)* %100
+  %101 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck17 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %102
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %103, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %92
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef22:                                   ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef24:                                   ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef26:                                   ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef28:                                   ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef30:                                   ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef32:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef34:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef36:                                   ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange38:                           ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef40:                                   ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef42:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef44:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef46:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef48:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef50:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -5200,8 +6368,8 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -5232,9 +6400,9 @@ Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
 Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
-Failed to read String.MakeSeparatorList[loadElemA]
+Failed to read String.MakeSeparatorList[storeElem]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
-Failed to read String.InternalSplitKeepEmptyEntries[loadElem]
+Failed to read String.InternalSplitKeepEmptyEntries[storeElem]
 INFO:  jitting method Path::IsRelative using LLILCJit
 Successfully read Path.IsRelative
 
@@ -5243,8 +6411,8 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -5254,8 +6422,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
@@ -5271,8 +6439,8 @@ entry:
 
 ; <label>:17                                      ; preds = %7
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
@@ -5288,8 +6456,8 @@ entry:
 
 ; <label>:29                                      ; preds = %19
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %31
 
 ; <label>:31                                      ; preds = %29
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
@@ -5300,8 +6468,8 @@ entry:
 
 ; <label>:36                                      ; preds = %31
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
-  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %37, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
@@ -5312,8 +6480,8 @@ entry:
 
 ; <label>:43                                      ; preds = %31, %38
   %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
-  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %45
 
 ; <label>:45                                      ; preds = %43
   %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
@@ -5324,8 +6492,8 @@ entry:
 
 ; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %50
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
@@ -5336,8 +6504,8 @@ entry:
 
 ; <label>:57                                      ; preds = %1, %7, %19, %45, %52
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
-  br i1 %NullCheck14, label %59, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %59
 
 ; <label>:59                                      ; preds = %57
   %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
@@ -5347,8 +6515,8 @@ entry:
 
 ; <label>:63                                      ; preds = %59
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
@@ -5359,8 +6527,8 @@ entry:
 
 ; <label>:70                                      ; preds = %65
   %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
-  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.String addrspace(1)* %71, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %72
 
 ; <label>:72                                      ; preds = %70
   %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
@@ -5379,39 +6547,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %17
+ThrowNullRef4:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %29
+ThrowNullRef6:                                    ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %36
+ThrowNullRef8:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %43
+ThrowNullRef10:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %50
+ThrowNullRef12:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %57
+ThrowNullRef14:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %63
+ThrowNullRef16:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %70
+ThrowNullRef18:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5419,7 +6587,293 @@ ThrowNullRef17:                                   ; preds = %70
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
-Failed to read String.TrimHelper[loadElem]
+Successfully read String.TrimHelper
+
+define %System.String addrspace(1)* @String.TrimHelper(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i16
+  %loc4 = alloca i32
+  %loc5 = alloca i16
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = sub i32 %3, 1
+  store i32 %4, i32* %loc0
+  store i32 0, i32* %loc1
+  %5 = load i32, i32* %arg2
+  %6 = icmp eq i32 %5, 1
+  br i1 %6, label %62, label %7
+
+; <label>:7                                       ; preds = %1
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:8                                       ; preds = %58
+  store i32 0, i32* %loc2
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load i32, i32* %loc1
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2, i32 %10
+  %13 = load i16, i16 addrspace(1)* %12
+  %14 = zext i16 %13 to i32
+  %15 = trunc i32 %14 to i16
+  store i16 %15, i16* %loc3
+  store i32 0, i32* %loc2
+  br label %34
+
+; <label>:16                                      ; preds = %37
+  %17 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %18 = load i32, i32* %loc2
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %17, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %19
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = zext i32 %18 to i64
+  %BoundsCheck = icmp uge i64 %23, %22
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %24
+
+; <label>:24                                      ; preds = %19
+  %25 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 3, i32 %18
+  %26 = load i16, i16 addrspace(1)* %25, align 8
+  %27 = zext i16 %26 to i32
+  %28 = load i16, i16* %loc3
+  %29 = zext i16 %28 to i32
+  %30 = icmp eq i32 %27, %29
+  br i1 %30, label %43, label %31
+
+; <label>:31                                      ; preds = %24
+  %32 = load i32, i32* %loc2
+  %33 = add i32 %32, 1
+  store i32 %33, i32* %loc2
+  br label %34
+
+; <label>:34                                      ; preds = %11, %31
+  %35 = load i32, i32* %loc2
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = icmp slt i32 %35, %41
+  br i1 %42, label %16, label %43
+
+; <label>:43                                      ; preds = %24, %37
+  %44 = load i32, i32* %loc2
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %45, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp eq i32 %44, %50
+  br i1 %51, label %62, label %52
+
+; <label>:52                                      ; preds = %46
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %7, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %57, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %58
+
+; <label>:58                                      ; preds = %55
+  %59 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %60 = load i32, i32 addrspace(1)* %59
+  %61 = icmp slt i32 %56, %60
+  br i1 %61, label %8, label %62
+
+; <label>:62                                      ; preds = %1, %46, %58
+  %63 = load i32, i32* %arg2
+  %64 = icmp eq i32 %63, 0
+  br i1 %64, label %122, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %66, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %67
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %66, i32 0, i32 1
+  %69 = load i32, i32 addrspace(1)* %68
+  %70 = sub i32 %69, 1
+  store i32 %70, i32* %loc0
+  br label %118
+
+; <label>:71                                      ; preds = %118
+  store i32 0, i32* %loc4
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %73 = load i32, i32* %loc0
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %74
+
+; <label>:74                                      ; preds = %71
+  %75 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 2, i32 %73
+  %76 = load i16, i16 addrspace(1)* %75
+  %77 = zext i16 %76 to i32
+  %78 = trunc i32 %77 to i16
+  store i16 %78, i16* %loc5
+  store i32 0, i32* %loc4
+  br label %97
+
+; <label>:79                                      ; preds = %100
+  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %81 = load i32, i32* %loc4
+  %NullCheck19 = icmp eq %"System.Char[]" addrspace(1)* %80, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
+
+; <label>:82                                      ; preds = %79
+  %83 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 1
+  %84 = load i32, i32 addrspace(1)* %83
+  %85 = zext i32 %84 to i64
+  %86 = zext i32 %81 to i64
+  %BoundsCheck21 = icmp uge i64 %86, %85
+  br i1 %BoundsCheck21, label %ThrowIndexOutOfRange22, label %87
+
+; <label>:87                                      ; preds = %82
+  %88 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 3, i32 %81
+  %89 = load i16, i16 addrspace(1)* %88, align 8
+  %90 = zext i16 %89 to i32
+  %91 = load i16, i16* %loc5
+  %92 = zext i16 %91 to i32
+  %93 = icmp eq i32 %90, %92
+  br i1 %93, label %106, label %94
+
+; <label>:94                                      ; preds = %87
+  %95 = load i32, i32* %loc4
+  %96 = add i32 %95, 1
+  store i32 %96, i32* %loc4
+  br label %97
+
+; <label>:97                                      ; preds = %74, %94
+  %98 = load i32, i32* %loc4
+  %99 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck15 = icmp eq %"System.Char[]" addrspace(1)* %99, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %100
+
+; <label>:100                                     ; preds = %97
+  %101 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %99, i32 0, i32 1
+  %102 = load i32, i32 addrspace(1)* %101
+  %103 = zext i32 %102 to i64
+  %104 = trunc i64 %103 to i32
+  %105 = icmp slt i32 %98, %104
+  br i1 %105, label %79, label %106
+
+; <label>:106                                     ; preds = %87, %100
+  %107 = load i32, i32* %loc4
+  %108 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck17 = icmp eq %"System.Char[]" addrspace(1)* %108, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %109
+
+; <label>:109                                     ; preds = %106
+  %110 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %108, i32 0, i32 1
+  %111 = load i32, i32 addrspace(1)* %110
+  %112 = zext i32 %111 to i64
+  %113 = trunc i64 %112 to i32
+  %114 = icmp eq i32 %107, %113
+  br i1 %114, label %122, label %115
+
+; <label>:115                                     ; preds = %109
+  %116 = load i32, i32* %loc0
+  %117 = sub i32 %116, 1
+  store i32 %117, i32* %loc0
+  br label %118
+
+; <label>:118                                     ; preds = %67, %115
+  %119 = load i32, i32* %loc0
+  %120 = load i32, i32* %loc1
+  %121 = icmp sge i32 %119, %120
+  br i1 %121, label %71, label %122
+
+; <label>:122                                     ; preds = %62, %109, %118
+  %123 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %124 = load i32, i32* %loc1
+  %125 = load i32, i32* %loc0
+  %126 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %123, i32 %124, i32 %125)
+  ret %System.String addrspace(1)* %126
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %97
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange22:                           ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
 Successfully read String.CreateTrimmedString
 
@@ -5439,8 +6893,8 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
@@ -5535,8 +6989,8 @@ entry:
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i64 2872
   %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
   %8 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %7
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %3
   %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
@@ -5553,8 +7007,8 @@ entry:
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 2864
   %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
   %21 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %20
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
-  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %22
 
 ; <label>:22                                      ; preds = %16
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
@@ -5569,7 +7023,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %16
+ThrowNullRef2:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5586,8 +7040,8 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5613,8 +7067,8 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
@@ -5632,8 +7086,8 @@ entry:
 
 ; <label>:12                                      ; preds = %4
   %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
@@ -5644,8 +7098,8 @@ entry:
 
 ; <label>:19                                      ; preds = %14
   %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %19
   %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
@@ -5660,21 +7114,21 @@ entry:
   %31 = zext i16 %30 to i32
   %32 = bitcast i8* %29 to i16*
   %33 = trunc i32 %31 to i16
-  %NullCheck6 = icmp ne i16* %32, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i16* %32, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %21
   store i16 %33, i16* %32, align 8
   %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %36
 
 ; <label>:36                                      ; preds = %34
   %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
   %38 = load i32, i32 addrspace(1)* %37, align 8
   %39 = add i32 %38, 1
-  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %40
 
 ; <label>:40                                      ; preds = %36
   %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
@@ -5683,16 +7137,16 @@ entry:
 
 ; <label>:42                                      ; preds = %14
   %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
-  br i1 %NullCheck12, label %44, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
   %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
   %47 = load i16, i16* %arg1
   %48 = zext i16 %47 to i32
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = trunc i32 %48 to i16
@@ -5703,31 +7157,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %19
+ThrowNullRef4:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %21
+ThrowNullRef6:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %36
+ThrowNullRef10:                                   ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %42
+ThrowNullRef12:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %44
+ThrowNullRef14:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5740,8 +7194,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -5752,8 +7206,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
@@ -5762,14 +7216,14 @@ entry:
 
 ; <label>:11                                      ; preds = %1
   %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
@@ -5779,15 +7233,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5808,8 +7262,8 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5822,8 +7276,8 @@ entry:
 
 ; <label>:8                                       ; preds = %3
   %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
@@ -5842,15 +7296,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
-  br i1 %NullCheck4, label %22, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
   %24 = load i16*, i16* addrspace(1)* %23, align 8
   %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %25, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
@@ -5859,8 +7313,8 @@ entry:
   store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
@@ -5874,8 +7328,8 @@ entry:
 
 ; <label>:37                                      ; preds = %65
   %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %37
   %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
@@ -5886,16 +7340,16 @@ entry:
   %45 = bitcast i16* %41 to i8*
   %46 = getelementptr inbounds i8, i8* %45, i64 %44
   %47 = bitcast i8* %46 to i16*
-  %NullCheck14 = icmp ne i16* %47, null
-  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %47, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %48
 
 ; <label>:48                                      ; preds = %39
   %49 = load i16, i16* %47, align 8
   %50 = zext i16 %49 to i32
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %52 = load i32, i32* %loc1
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %53
 
 ; <label>:53                                      ; preds = %48
   %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
@@ -5916,8 +7370,8 @@ entry:
 ; <label>:62                                      ; preds = %36, %59
   %63 = load i32, i32* %loc1
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck10, label %65, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %65
 
 ; <label>:65                                      ; preds = %62
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
@@ -5936,15 +7390,15 @@ entry:
 
 ; <label>:74                                      ; preds = %70
   %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
-  br i1 %NullCheck18, label %76, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %76
 
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
   %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
-  br i1 %NullCheck20, label %80, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
   %81 = load i64, i64 addrspace(1)* %79
@@ -5958,8 +7412,8 @@ entry:
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
   %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
-  br i1 %NullCheck22, label %92, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.String addrspace(1)* %90, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %92
 
 ; <label>:92                                      ; preds = %80
   %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
@@ -5969,15 +7423,15 @@ entry:
 
 ; <label>:96                                      ; preds = %70
   %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
-  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %98
 
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
   %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
-  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
   %103 = load i64, i64 addrspace(1)* %101
@@ -5991,8 +7445,8 @@ entry:
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
   %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
-  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.String addrspace(1)* %112, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %114
 
 ; <label>:114                                     ; preds = %102
   %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
@@ -6004,59 +7458,59 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %20
+ThrowNullRef4:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %22
+ThrowNullRef6:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %26
+ThrowNullRef8:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %62
+ThrowNullRef10:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %48
+ThrowNullRef16:                                   ; preds = %48
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %74
+ThrowNullRef18:                                   ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %76
+ThrowNullRef20:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %80
+ThrowNullRef22:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %96
+ThrowNullRef24:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %98
+ThrowNullRef26:                                   ; preds = %98
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %102
+ThrowNullRef28:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6069,15 +7523,15 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
   %3 = load i16*, i16* addrspace(1)* %2, align 8
   %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
@@ -6087,8 +7541,8 @@ entry:
   %10 = bitcast i16* %3 to i8*
   %11 = getelementptr inbounds i8, i8* %10, i64 %9
   %12 = bitcast i8* %11 to i16*
-  %NullCheck4 = icmp ne i16* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %5
   store i16 0, i16* %12, align 8
@@ -6098,11 +7552,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6119,8 +7573,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -6131,8 +7585,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
@@ -6144,15 +7598,15 @@ entry:
 
 ; <label>:14                                      ; preds = %1
   %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
   %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
   %21 = load i64, i64 addrspace(1)* %19
@@ -6171,15 +7625,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %14
+ThrowNullRef4:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %16
+ThrowNullRef6:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6302,14 +7756,6 @@ entry:
   ret %System.String addrspace(1)* %57
 }
 
-INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
-Successfully read RuntimeHelpers.get_OffsetToStringData
-
-define i32 @RuntimeHelpers.get_OffsetToStringData() {
-entry:
-  ret i32 12
-}
-
 INFO:  jitting method String::Equals using LLILCJit
 Successfully read String.Equals
 
@@ -6381,8 +7827,8 @@ entry:
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
-  br i1 %NullCheck24, label %29, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
   %30 = load i64, i64 addrspace(1)* %28
@@ -6397,8 +7843,8 @@ entry:
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
-  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
   %43 = load i64, i64 addrspace(1)* %41
@@ -6418,8 +7864,8 @@ entry:
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
   %59 = load i64, i64 addrspace(1)* %57
@@ -6434,8 +7880,8 @@ entry:
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck22, label %71, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
   %72 = load i64, i64 addrspace(1)* %70
@@ -6455,8 +7901,8 @@ entry:
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
-  br i1 %NullCheck16, label %87, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = load i64, i64 addrspace(1)* %86
@@ -6471,8 +7917,8 @@ entry:
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck18, label %100, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
   %101 = load i64, i64 addrspace(1)* %99
@@ -6492,8 +7938,8 @@ entry:
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
-  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
   %117 = load i64, i64 addrspace(1)* %115
@@ -6508,8 +7954,8 @@ entry:
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
-  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
   %130 = load i64, i64 addrspace(1)* %128
@@ -6528,15 +7974,15 @@ entry:
 
 ; <label>:142                                     ; preds = %22
   %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
-  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %143, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %144
 
 ; <label>:144                                     ; preds = %142
   %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
   %146 = load i32, i32 addrspace(1)* %145
   %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
-  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %147, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %148
 
 ; <label>:148                                     ; preds = %144
   %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
@@ -6557,15 +8003,15 @@ entry:
 
 ; <label>:159                                     ; preds = %22
   %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
-  br i1 %NullCheck, label %161, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %ThrowNullRef, label %161
 
 ; <label>:161                                     ; preds = %159
   %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
   %163 = load i32, i32 addrspace(1)* %162
   %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
-  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %164, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %165
 
 ; <label>:165                                     ; preds = %161
   %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
@@ -6578,8 +8024,8 @@ entry:
 
 ; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
-  br i1 %NullCheck4, label %172, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %171, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %172
 
 ; <label>:172                                     ; preds = %170
   %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
@@ -6589,8 +8035,8 @@ entry:
 
 ; <label>:176                                     ; preds = %172
   %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
-  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %177, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %178
 
 ; <label>:178                                     ; preds = %176
   %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
@@ -6629,55 +8075,55 @@ ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %161
+ThrowNullRef2:                                    ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %170
+ThrowNullRef4:                                    ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %176
+ThrowNullRef6:                                    ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %142
+ThrowNullRef8:                                    ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %144
+ThrowNullRef10:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %113
+ThrowNullRef12:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %116
+ThrowNullRef14:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %84
+ThrowNullRef16:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %87
+ThrowNullRef18:                                   ; preds = %87
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %55
+ThrowNullRef20:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %58
+ThrowNullRef22:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %26
+ThrowNullRef24:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %29
+ThrowNullRef26:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,8 +8161,8 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck, label %14, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %ThrowNullRef, label %14
 
 ; <label>:14                                      ; preds = %8
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
@@ -6760,8 +8206,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
@@ -6770,14 +8216,14 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32, i32* %loc0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %10
   %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
   %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
@@ -6790,15 +8236,15 @@ entry:
 ; <label>:25                                      ; preds = %19
   %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
-  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
   %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
@@ -6807,8 +8253,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %37 = load i32, i32* %loc0
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %38, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %38
 
 ; <label>:38                                      ; preds = %32
   %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
@@ -6817,14 +8263,14 @@ entry:
 
 ; <label>:40                                      ; preds = %19
   %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %40
   %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
   %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
-  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
-  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
@@ -6832,8 +8278,8 @@ entry:
   %48 = zext i32 %47 to i64
   %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
-  br i1 %NullCheck16, label %51, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %51
 
 ; <label>:51                                      ; preds = %45
   %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
@@ -6847,15 +8293,15 @@ entry:
 ; <label>:57                                      ; preds = %51
   %58 = load i16*, i16** %arg1
   %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
-  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %60
 
 ; <label>:60                                      ; preds = %57
   %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
   %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
-  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %64
 
 ; <label>:64                                      ; preds = %60
   %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
@@ -6864,22 +8310,22 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
   %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
-  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %70
 
 ; <label>:70                                      ; preds = %64
   %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
   %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
-  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
-  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
   %75 = load i32, i32 addrspace(1)* %74
   %76 = zext i32 %75 to i64
   %77 = trunc i64 %76 to i32
-  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
-  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %78
 
 ; <label>:78                                      ; preds = %73
   %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
@@ -6901,8 +8347,8 @@ entry:
   %90 = bitcast i16* %86 to i8*
   %91 = getelementptr inbounds i8, i8* %90, i64 %89
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %93
 
 ; <label>:93                                      ; preds = %80
   %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
@@ -6912,8 +8358,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %99 = load i32, i32* %loc2
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %100
 
 ; <label>:100                                     ; preds = %93
   %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
@@ -6928,63 +8374,63 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %25
+ThrowNullRef6:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %32
+ThrowNullRef10:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %40
+ThrowNullRef12:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %45
+ThrowNullRef16:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %57
+ThrowNullRef18:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %60
+ThrowNullRef20:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %64
+ThrowNullRef22:                                   ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %70
+ThrowNullRef24:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %73
+ThrowNullRef26:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %80
+ThrowNullRef28:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %93
+ThrowNullRef30:                                   ; preds = %93
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7004,8 +8450,8 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
@@ -7033,43 +8479,43 @@ entry:
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %14
   %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
   %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   %28 = load i32, i32 addrspace(1)* %27, align 8
   %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
-  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %30
 
 ; <label>:30                                      ; preds = %26
   %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
   %32 = load i32, i32 addrspace(1)* %31, align 8
   %33 = add i32 %28, %32
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %34
 
 ; <label>:34                                      ; preds = %30
   %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   store i32 %33, i32 addrspace(1)* %35
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
   store i32 0, i32 addrspace(1)* %38
   %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %40
 
 ; <label>:40                                      ; preds = %37
   %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
@@ -7082,8 +8528,8 @@ entry:
 
 ; <label>:47                                      ; preds = %40
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
@@ -7098,8 +8544,8 @@ entry:
   %54 = load i32, i32* %loc0
   %55 = sext i32 %54 to i64
   %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
-  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %57
 
 ; <label>:57                                      ; preds = %52
   %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
@@ -7110,68 +8556,35 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %14
+ThrowNullRef2:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %23
+ThrowNullRef4:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %26
+ThrowNullRef6:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %30
+ThrowNullRef8:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %34
+ThrowNullRef10:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %47
+ThrowNullRef14:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %52
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-}
-
-INFO:  jitting method StringBuilder::get_Length using LLILCJit
-Successfully read StringBuilder.get_Length
-
-define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.StringBuilder addrspace(1)*
-  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
-  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
-
-; <label>:1                                       ; preds = %entry
-  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %3 = load i32, i32 addrspace(1)* %2, align 8
-  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
-
-; <label>:5                                       ; preds = %1
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = add i32 %3, %7
-  ret i32 %8
-
-ThrowNullRef:                                     ; preds = %entry
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef16:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7213,70 +8626,70 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
   %6 = load i32, i32 addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
   store i32 %6, i32 addrspace(1)* %8
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
   %13 = load i32, i32 addrspace(1)* %12, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
   store i32 %13, i32 addrspace(1)* %15
   %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
-  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %18
 
 ; <label>:18                                      ; preds = %14
   %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
   %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
   %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
   %34 = load i32, i32 addrspace(1)* %33, align 8
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
-  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
@@ -7287,39 +8700,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %28
+ThrowNullRef16:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %32
+ThrowNullRef18:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7455,13 +8868,13 @@ entry:
 ; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
@@ -7477,16 +8890,16 @@ entry:
 
 ; <label>:18                                      ; preds = %15
   %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
   store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
   %22 = load i32, i32* %loc0
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %24
 
 ; <label>:24                                      ; preds = %20
   %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
@@ -7498,13 +8911,13 @@ entry:
 ; <label>:28                                      ; preds = %15, %24
   %29 = load i32, i32* %arg1
   %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %31
   %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
@@ -7517,20 +8930,20 @@ entry:
   %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
-  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
   %46 = load i32, i32 addrspace(1)* %45, align 8
   %47 = sub i32 %40, %46
-  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
-  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i32 addrspace(1)* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %48
 
 ; <label>:48                                      ; preds = %44
   store i32 %47, i32 addrspace(1)* %39, align 8
@@ -7538,21 +8951,21 @@ entry:
 
 ; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
-  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %51
 
 ; <label>:51                                      ; preds = %49
   %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %53
 
 ; <label>:53                                      ; preds = %51
   %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
   %55 = load i32, i32 addrspace(1)* %54, align 8
   %56 = load i32, i32* %arg2
   %57 = sub i32 %55, %56
-  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %58
 
 ; <label>:58                                      ; preds = %53
   %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
@@ -7562,13 +8975,13 @@ entry:
 ; <label>:60                                      ; preds = %33, %58
   %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
   %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
-  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %63
 
 ; <label>:63                                      ; preds = %60
   %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
-  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
-  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
@@ -7578,15 +8991,15 @@ entry:
 
 ; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
-  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i32 addrspace(1)* %69, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %70
 
 ; <label>:70                                      ; preds = %68
   %71 = load i32, i32 addrspace(1)* %69, align 8
   store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
-  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
@@ -7596,8 +9009,8 @@ entry:
   store i32 %77, i32* %loc4
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
-  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %80
 
 ; <label>:80                                      ; preds = %73
   %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
@@ -7607,71 +9020,71 @@ entry:
 ; <label>:83                                      ; preds = %80
   store i32 0, i32* %loc3
   %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
-  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
-  br i1 %NullCheck26, label %88, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i32 addrspace(1)* %87, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %88
 
 ; <label>:88                                      ; preds = %85
   %89 = load i32, i32 addrspace(1)* %87, align 8
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
-  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %90
 
 ; <label>:90                                      ; preds = %88
   %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
   store i32 %89, i32 addrspace(1)* %91
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
-  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
-  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %96
 
 ; <label>:96                                      ; preds = %94
   %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
-  br i1 %NullCheck34, label %100, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %100
 
 ; <label>:100                                     ; preds = %96
   %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
-  br i1 %NullCheck36, label %102, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %102
 
 ; <label>:102                                     ; preds = %100
   %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
   %104 = load i32, i32 addrspace(1)* %103, align 8
   %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
-  br i1 %NullCheck38, label %106, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %106
 
 ; <label>:106                                     ; preds = %102
   %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
-  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
-  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %108
 
 ; <label>:108                                     ; preds = %106
   %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
   %110 = load i32, i32 addrspace(1)* %109, align 8
   %111 = add i32 %104, %110
-  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %112
 
 ; <label>:112                                     ; preds = %108
   %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
   store i32 %111, i32 addrspace(1)* %113
   %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
-  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i32 addrspace(1)* %114, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %115
 
 ; <label>:115                                     ; preds = %112
   %116 = load i32, i32 addrspace(1)* %114, align 8
@@ -7681,19 +9094,19 @@ entry:
 ; <label>:118                                     ; preds = %115
   %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
-  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %121
 
 ; <label>:121                                     ; preds = %118
   %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
-  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
-  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %123
 
 ; <label>:123                                     ; preds = %121
   %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
   %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
-  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
-  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %126
 
 ; <label>:126                                     ; preds = %123
   %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
@@ -7705,8 +9118,8 @@ entry:
 
 ; <label>:130                                     ; preds = %80, %115, %126
   %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %132
 
 ; <label>:132                                     ; preds = %130
   %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7715,8 +9128,8 @@ entry:
   %136 = load i32, i32* %loc3
   %137 = sub i32 %135, %136
   %138 = sub i32 %134, %137
-  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %139
 
 ; <label>:139                                     ; preds = %132
   %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7728,16 +9141,16 @@ entry:
 
 ; <label>:144                                     ; preds = %139
   %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
-  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %146
 
 ; <label>:146                                     ; preds = %144
   %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
   %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
   %149 = load i32, i32* %loc2
   %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
-  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %151
 
 ; <label>:151                                     ; preds = %146
   %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
@@ -7754,145 +9167,249 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %18
+ThrowNullRef4:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %31
+ThrowNullRef10:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %44
+ThrowNullRef16:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %68
+ThrowNullRef18:                                   ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %70
+ThrowNullRef20:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %73
+ThrowNullRef22:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %83
+ThrowNullRef24:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %85
+ThrowNullRef26:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %88
+ThrowNullRef28:                                   ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %90
+ThrowNullRef30:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %94
+ThrowNullRef32:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %96
+ThrowNullRef34:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %100
+ThrowNullRef36:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %102
+ThrowNullRef38:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %106
+ThrowNullRef40:                                   ; preds = %106
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %108
+ThrowNullRef42:                                   ; preds = %108
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %112
+ThrowNullRef44:                                   ; preds = %112
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %118
+ThrowNullRef46:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %121
+ThrowNullRef48:                                   ; preds = %121
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %123
+ThrowNullRef50:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %130
+ThrowNullRef52:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %132
+ThrowNullRef54:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %144
+ThrowNullRef56:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %146
+ThrowNullRef58:                                   ; preds = %146
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %60
+ThrowNullRef60:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %63
+ThrowNullRef62:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %49
+ThrowNullRef64:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %51
+ThrowNullRef66:                                   ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %53
+ThrowNullRef68:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(%"System.Char[]" addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %arg0 = alloca %"System.Char[]" addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store %"System.Char[]" addrspace(1)* %param0, %"System.Char[]" addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load i32, i32* %arg4
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %43, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %38, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg1
+  %13 = load i32, i32* %arg4
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %38, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %24 = load i32, i32* %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %35 = load i32, i32* %arg3
+  %36 = load i32, i32* %arg4
+  %37 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %37, %"System.Char[]" addrspace(1)* %34, i32 %35, i32 %36)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:38                                      ; preds = %5, %16
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Successfully read Buffer._Memmove
 
@@ -7914,7 +9431,7 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[loadElem]
+Failed to read AppDomain.SetDataHelper[storeElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -7923,8 +9440,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
@@ -7934,8 +9451,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
@@ -7947,15 +9464,15 @@ entry:
   %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
   %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
@@ -7966,15 +9483,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7992,7 +9509,79 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
-Failed to read Dictionary`2.TryGetValue[loadElemA]
+Successfully read Dictionary`2.TryGetValue
+
+define i8 @"Dictionary`2.TryGetValue"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)* addrspace(1)* %param2) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  %arg2 = alloca %System.__Canon addrspace(1)* addrspace(1)*
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  store %System.__Canon addrspace(1)* addrspace(1)* %param2, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  store i32 %2, i32* %loc0
+  %3 = load i32, i32* %loc0
+  %4 = icmp slt i32 %3, 0
+  br i1 %4, label %22, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 2
+  %10 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %9, align 8
+  %11 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = zext i32 %11 to i64
+  %BoundsCheck = icmp uge i64 %16, %15
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 3, i32 %11
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %20, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %6, %System.__Canon addrspace(1)* %21)
+  ret i8 1
+
+; <label>:22                                      ; preds = %entry
+  %23 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %23, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -8058,8 +9647,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
@@ -8091,8 +9680,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
@@ -8171,15 +9760,15 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck, label %19, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %ThrowNullRef, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
   %21 = load i32, i32 addrspace(1)* %20
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
@@ -8202,7 +9791,7 @@ ThrowNullRef:                                     ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %19
+ThrowNullRef2:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8248,8 +9837,8 @@ entry:
   %0 = alloca %System.AppDomainHandle
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %1 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %1, i32 0, i32 15
@@ -8269,8 +9858,8 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
@@ -8286,7 +9875,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -8299,8 +9888,8 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -8327,8 +9916,8 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
@@ -8352,8 +9941,8 @@ entry:
   %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
   store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
@@ -8363,8 +9952,8 @@ entry:
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
@@ -8374,8 +9963,8 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %9
   %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
@@ -8384,8 +9973,8 @@ entry:
 
 ; <label>:18                                      ; preds = %3, %16
   %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
@@ -8397,15 +9986,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %18
+ThrowNullRef6:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8418,8 +10007,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
@@ -8453,15 +10042,15 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
@@ -8473,7 +10062,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8481,7 +10070,7 @@ ThrowNullRef1:                                    ; preds = %1
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
 Failed to read Dictionary`2.System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
@@ -8506,8 +10095,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
@@ -8524,8 +10113,8 @@ entry:
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -8544,7 +10133,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8577,8 +10166,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = load i64, i64* %arg2
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = trunc i32 %3 to i8
@@ -8634,46 +10223,46 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
   %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
-  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
-  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
-  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
@@ -8684,27 +10273,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %20
+ThrowNullRef12:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8717,8 +10306,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -8756,22 +10345,22 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
   %9 = load i64, i64 addrspace(1)* %8, align 8
   %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
   %13 = load i64, i64 addrspace(1)* %12, align 8
   %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %11
   %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
@@ -8788,11 +10377,11 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8882,8 +10471,8 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
@@ -8900,8 +10489,8 @@ entry:
 ; <label>:8                                       ; preds = %1
   %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
   %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
@@ -8911,15 +10500,15 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
   %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
   %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
-  br i1 %NullCheck6, label %21, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
@@ -8946,15 +10535,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8992,15 +10581,15 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
   store i8 %3, i8 addrspace(1)* %5
   %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
@@ -9011,7 +10600,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9027,8 +10616,8 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -9041,8 +10630,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
@@ -9058,7 +10647,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9080,8 +10669,8 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
@@ -9096,8 +10685,8 @@ entry:
 ; <label>:12                                      ; preds = %6
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
@@ -9112,8 +10701,8 @@ entry:
 ; <label>:21                                      ; preds = %15
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
@@ -9128,8 +10717,8 @@ entry:
 ; <label>:30                                      ; preds = %24
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %31, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
@@ -9144,8 +10733,8 @@ entry:
 ; <label>:39                                      ; preds = %33
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
-  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %40, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %42
 
 ; <label>:42                                      ; preds = %39
   %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
@@ -9164,19 +10753,19 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %21
+ThrowNullRef4:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %30
+ThrowNullRef6:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %39
+ThrowNullRef8:                                    ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9243,8 +10832,8 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
@@ -9264,57 +10853,57 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
   store i8 0, i8 addrspace(1)* %2
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
   store i8 0, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
   store i8 0, i8 addrspace(1)* %17
   %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
   store i8 0, i8 addrspace(1)* %20
   %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
-  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
@@ -9325,31 +10914,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %19
+ThrowNullRef14:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9367,8 +10956,8 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
@@ -9380,8 +10969,8 @@ entry:
 
 ; <label>:9                                       ; preds = %4
   %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %9
   %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
@@ -9395,7 +10984,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef2:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9420,8 +11009,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
@@ -9512,8 +11101,8 @@ entry:
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
@@ -9524,8 +11113,8 @@ entry:
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = load i64, i64 addrspace(1)* %12
@@ -9537,8 +11126,8 @@ entry:
   %20 = load i64, i64* %19
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
-  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %13
   %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
@@ -9555,8 +11144,8 @@ entry:
 ; <label>:30                                      ; preds = %25
   %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %32 = load i32, i32* %arg2
-  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
-  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
@@ -9570,15 +11159,15 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %30
+ThrowNullRef2:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9622,87 +11211,87 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
   %10 = load i8, i8 addrspace(1)* %9, align 8
   %11 = zext i8 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %8
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
   store i8 %12, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
   %19 = load i8, i8 addrspace(1)* %18, align 8
   %20 = zext i8 %19 to i32
   %21 = trunc i32 %20 to i8
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
   store i8 %21, i8 addrspace(1)* %23
   %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
   %28 = load i8, i8 addrspace(1)* %27, align 8
   %29 = zext i8 %28 to i32
   %30 = trunc i32 %29 to i8
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
-  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %31
 
 ; <label>:31                                      ; preds = %26
   %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
   store i8 %30, i8 addrspace(1)* %32
   %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
-  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
-  br i1 %NullCheck14, label %40, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %40
 
 ; <label>:40                                      ; preds = %35
   %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
   store i8 %39, i8 addrspace(1)* %41
   %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
-  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %44
 
 ; <label>:44                                      ; preds = %40
   %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
   %46 = load i8, i8 addrspace(1)* %45, align 8
   %47 = zext i8 %46 to i32
   %48 = trunc i32 %47 to i8
-  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
   store i8 %48, i8 addrspace(1)* %50
   %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
-  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
@@ -9713,29 +11302,29 @@ entry:
 ; <label>:56                                      ; preds = %52
   %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
-  br i1 %NullCheck22, label %59, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
   %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
   %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
-  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
-  br i1 %NullCheck24, label %63, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
   %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
-  br i1 %NullCheck26, label %66, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
   %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
-  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
-  br i1 %NullCheck28, label %69, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %69
 
 ; <label>:69                                      ; preds = %66
   %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
@@ -9744,15 +11333,15 @@ entry:
 
 ; <label>:71                                      ; preds = %105
   %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
-  br i1 %NullCheck34, label %73, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %73
 
 ; <label>:73                                      ; preds = %71
   %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
   %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
   %76 = load i32, i32* %loc0
-  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
-  br i1 %NullCheck36, label %77, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
@@ -9766,8 +11355,8 @@ entry:
 
 ; <label>:83                                      ; preds = %77
   %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
-  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
@@ -9775,14 +11364,14 @@ entry:
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
   %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
-  br i1 %NullCheck40, label %91, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
 ; <label>:91                                      ; preds = %85
   %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
   %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
-  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck42, label %94, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %94
 
 ; <label>:94                                      ; preds = %91
   %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
@@ -9798,14 +11387,14 @@ entry:
 ; <label>:99                                      ; preds = %69, %96
   %100 = load i32, i32* %loc0
   %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
-  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %102
 
 ; <label>:102                                     ; preds = %99
   %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
   %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
-  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
-  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
@@ -9819,87 +11408,87 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %26
+ThrowNullRef10:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %31
+ThrowNullRef12:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %35
+ThrowNullRef14:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %40
+ThrowNullRef16:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %56
+ThrowNullRef22:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %59
+ThrowNullRef24:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %63
+ThrowNullRef26:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %66
+ThrowNullRef28:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %102
+ThrowNullRef32:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %71
+ThrowNullRef34:                                   ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %73
+ThrowNullRef36:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %83
+ThrowNullRef38:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %85
+ThrowNullRef40:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %91
+ThrowNullRef42:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9943,15 +11532,15 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
   %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
@@ -9961,28 +11550,28 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
   %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %12
   %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
   %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
   %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
-  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
@@ -9993,23 +11582,23 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %12
+ThrowNullRef6:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10031,15 +11620,15 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
   %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = load i64, i64 addrspace(1)* %7
@@ -10077,13 +11666,13 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[loadElem]
+Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -10111,8 +11700,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -10313,8 +11902,8 @@ entry:
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
   %1 = load i64, i64* %arg1
   %2 = inttoptr i64 %1 to i16*
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -10338,8 +11927,8 @@ entry:
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load i32, i32* %arg0
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -10473,8 +12062,8 @@ entry:
   store i64 %param0, i64* %arg0
   store i64 %param1, i64* %arg1
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
@@ -10482,8 +12071,8 @@ entry:
   %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
   %5 = load i16*, i16* addrspace(1)* %4, align 8
   %6 = addrspacecast i64* %arg1 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = bitcast i64 addrspace(1)* %6 to i8 addrspace(1)*
@@ -10499,7 +12088,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10533,8 +12122,8 @@ entry:
   %1 = load i32, i32* %arg1
   %2 = sext i32 %1 to i64
   %3 = inttoptr i64 %2 to i16*
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -10587,8 +12176,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, i32)*)(%System.IO.ConsoleStream addrspace(1)* %2, i32 %1)
   %3 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %4 = load i64, i64* %arg1
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
@@ -10599,8 +12188,8 @@ entry:
   %10 = icmp eq i32 %9, 3
   %11 = sext i1 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %5
   %14 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, i32 0, i32 5
@@ -10611,7 +12200,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10634,8 +12223,8 @@ entry:
   %5 = icmp eq i32 %4, 1
   %6 = sext i1 %5 to i32
   %7 = trunc i32 %6 to i8
-  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %2, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.ConsoleStream addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
@@ -10646,8 +12235,8 @@ entry:
   %13 = icmp eq i32 %12, 2
   %14 = sext i1 %13 to i32
   %15 = trunc i32 %14 to i8
-  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %10, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.ConsoleStream addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %8
   %17 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %10, i32 0, i32 4
@@ -10658,7 +12247,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10697,8 +12286,8 @@ entry:
   %arg0 = alloca i64
   store i64 %param0, i64* %arg0
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
@@ -10733,8 +12322,8 @@ entry:
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
   %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = load i64, i64 addrspace(1)* %7
@@ -10838,7 +12427,127 @@ entry:
 INFO:  jitting method Encoding::GetEncoding using LLILCJit
 Failed to read Encoding.GetEncoding[convertToHelperArgumentType]
 INFO:  jitting method EncodingProvider::GetEncodingFromProvider using LLILCJit
-Failed to read EncodingProvider.GetEncodingFromProvider[loadElem]
+Successfully read EncodingProvider.GetEncodingFromProvider
+
+define %System.Text.Encoding addrspace(1)* @EncodingProvider.GetEncodingFromProvider(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca %"System.Text.EncodingProvider[]" addrspace(1)*
+  %loc1 = alloca %System.Text.EncodingProvider addrspace(1)*
+  %loc2 = alloca %System.Text.Encoding addrspace(1)*
+  %loc3 = alloca %System.Text.Encoding addrspace(1)*
+  %loc4 = alloca %"System.Text.EncodingProvider[]" addrspace(1)*
+  %loc5 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1059)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2392
+  %2 = addrspacecast i8 addrspace(1)* %1 to %"System.Text.EncodingProvider[]" addrspace(1)**
+  %3 = load volatile %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %2
+  %4 = icmp ne %"System.Text.EncodingProvider[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %entry
+  ret %System.Text.Encoding addrspace(1)* null
+
+; <label>:6                                       ; preds = %entry
+  %7 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1059)
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i64 2392
+  %9 = addrspacecast i8 addrspace(1)* %8 to %"System.Text.EncodingProvider[]" addrspace(1)**
+  %10 = load volatile %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %9
+  store %"System.Text.EncodingProvider[]" addrspace(1)* %10, %"System.Text.EncodingProvider[]" addrspace(1)** %loc0
+  %11 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc0
+  store %"System.Text.EncodingProvider[]" addrspace(1)* %11, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  store i32 0, i32* %loc5
+  br label %43
+
+; <label>:12                                      ; preds = %46
+  %13 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  %14 = load i32, i32* %loc5
+  %NullCheck1 = icmp eq %"System.Text.EncodingProvider[]" addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %13, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = zext i32 %17 to i64
+  %19 = zext i32 %14 to i64
+  %BoundsCheck = icmp uge i64 %19, %18
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %20
+
+; <label>:20                                      ; preds = %15
+  %21 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %13, i32 0, i32 3, i32 %14
+  %22 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)* addrspace(1)* %21, align 8
+  store %System.Text.EncodingProvider addrspace(1)* %22, %System.Text.EncodingProvider addrspace(1)** %loc1
+  %23 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)** %loc1
+  %24 = load i32, i32* %arg0
+  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i64 addrspace(1)*
+  %NullCheck3 = icmp eq i64 addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
+
+; <label>:26                                      ; preds = %20
+  %27 = load i64, i64 addrspace(1)* %25
+  %28 = add i64 %27, 64
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 40
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Text.Encoding addrspace(1)* (%System.Text.EncodingProvider addrspace(1)*, i32)*
+  %35 = call %System.Text.Encoding addrspace(1)* %34(%System.Text.EncodingProvider addrspace(1)* %23, i32 %24)
+  store %System.Text.Encoding addrspace(1)* %35, %System.Text.Encoding addrspace(1)** %loc2
+  %36 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc2
+  %37 = icmp eq %System.Text.Encoding addrspace(1)* %36, null
+  br i1 %37, label %40, label %38
+
+; <label>:38                                      ; preds = %26
+  %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc2
+  store %System.Text.Encoding addrspace(1)* %39, %System.Text.Encoding addrspace(1)** %loc3
+  br label %53
+
+; <label>:40                                      ; preds = %26
+  %41 = load i32, i32* %loc5
+  %42 = add i32 %41, 1
+  store i32 %42, i32* %loc5
+  br label %43
+
+; <label>:43                                      ; preds = %6, %40
+  %44 = load i32, i32* %loc5
+  %45 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  %NullCheck = icmp eq %"System.Text.EncodingProvider[]" addrspace(1)* %45, null
+  br i1 %NullCheck, label %ThrowNullRef, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp slt i32 %44, %50
+  br i1 %51, label %12, label %52
+
+; <label>:52                                      ; preds = %46
+  ret %System.Text.Encoding addrspace(1)* null
+
+; <label>:53                                      ; preds = %38
+  %54 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc3
+  ret %System.Text.Encoding addrspace(1)* %54
+
+ThrowNullRef:                                     ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method EncodingProvider::.cctor using LLILCJit
 Successfully read EncodingProvider..cctor
 
@@ -10857,7 +12566,7 @@ Failed to read Encoding.get_InternalSyncObject[Call HasTypeArg]
 INFO:  jitting method Hashtable::.ctor using LLILCJit
 Failed to read Hashtable..ctor[Volatile store]
 INFO:  jitting method Hashtable::get_Item using LLILCJit
-Failed to read Hashtable.get_Item[loadElemA]
+Failed to read Hashtable.get_Item[loadNonPrimitiveObj]
 INFO:  jitting method Hashtable::InitHash using LLILCJit
 Successfully read Hashtable.InitHash
 
@@ -10877,8 +12586,8 @@ entry:
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -10894,15 +12603,15 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
   %15 = load i32, i32* %loc0
-  %NullCheck2 = icmp ne i32 addrspace(1)* %14, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i32 addrspace(1)* %14, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %3
   store i32 %15, i32 addrspace(1)* %14, align 8
   %17 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %18 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %NullCheck4 = icmp ne i32 addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i32 addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = load i32, i32 addrspace(1)* %18, align 8
@@ -10911,8 +12620,8 @@ entry:
   %23 = sub i32 %22, 1
   %24 = urem i32 %21, %23
   %25 = add i32 1, %24
-  %NullCheck6 = icmp ne i32 addrspace(1)* %17, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32 addrspace(1)* %17, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %19
   store i32 %25, i32 addrspace(1)* %17, align 8
@@ -10923,15 +12632,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %19
+ThrowNullRef6:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10946,8 +12655,8 @@ entry:
   store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
   store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %NullCheck = icmp ne %System.Collections.Hashtable addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Collections.Hashtable addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
@@ -10957,16 +12666,16 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Collections.Hashtable addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Collections.Hashtable addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
   %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck4 = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %9, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
   %13 = inttoptr i64 %11 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
@@ -10976,8 +12685,8 @@ entry:
 ; <label>:15                                      ; preds = %1
   %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -10995,15 +12704,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11017,8 +12726,8 @@ entry:
   store %System.Int32 addrspace(1)* %param0, %System.Int32 addrspace(1)** %this
   %0 = load %System.Int32 addrspace(1)*, %System.Int32 addrspace(1)** %this
   %1 = bitcast %System.Int32 addrspace(1)* %0 to i32 addrspace(1)*
-  %NullCheck = icmp ne i32 addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq i32 addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load i32, i32 addrspace(1)* %1, align 8
@@ -11094,8 +12803,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.UTF8Encoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
@@ -11104,15 +12813,15 @@ entry:
   %9 = load i8, i8* %arg2
   %10 = zext i8 %9 to i32
   %11 = trunc i32 %10 to i8
-  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %8, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %6
   %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %8, i32 0, i32 8
   store i8 %11, i8 addrspace(1)* %13
   %14 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %14, i32 0, i32 8
@@ -11124,8 +12833,8 @@ entry:
 ; <label>:20                                      ; preds = %15
   %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %22, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %22, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = load i64, i64 addrspace(1)* %22
@@ -11147,15 +12856,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %12
+ThrowNullRef4:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11170,8 +12879,8 @@ entry:
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
@@ -11193,16 +12902,16 @@ entry:
 ; <label>:10                                      ; preds = %1
   %11 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
   %12 = load i32, i32* %arg1
-  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %11, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.Encoding addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
   store i32 %12, i32 addrspace(1)* %14
   %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
   %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = load i64, i64 addrspace(1)* %16
@@ -11220,11 +12929,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11237,8 +12946,8 @@ entry:
   %this = alloca %System.Text.UTF8Encoding addrspace(1)*
   store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
   %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.UTF8Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
@@ -11250,16 +12959,16 @@ entry:
 ; <label>:6                                       ; preds = %1
   %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %8 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %10, %System.Text.EncoderFallback addrspace(1)* %8)
   %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %12 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
-  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %11, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %11, i32 0, i32 3
@@ -11272,8 +12981,8 @@ entry:
   %18 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %18, %System.String addrspace(1)* %17)
   %19 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %18 to %System.Text.EncoderFallback addrspace(1)*
-  %NullCheck6 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %16, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %16, i32 0, i32 2
@@ -11283,8 +12992,8 @@ entry:
   %24 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %24, %System.String addrspace(1)* %23)
   %25 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %24 to %System.Text.DecoderFallback addrspace(1)*
-  %NullCheck8 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %22, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %22, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %20
   %27 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %22, i32 0, i32 3
@@ -11295,19 +13004,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %20
+ThrowNullRef8:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11337,8 +13046,8 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load i32, i32* %arg1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -11356,8 +13065,8 @@ entry:
 ; <label>:15                                      ; preds = %8
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %17 = load i32, i32* %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 %17
@@ -11373,7 +13082,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11425,7 +13134,7 @@ entry:
 }
 
 INFO:  jitting method Hashtable::Insert using LLILCJit
-Failed to read Hashtable.Insert[loadElemA]
+Failed to read Hashtable.Insert[storeElem]
 INFO:  jitting method ConsoleEncoding::.ctor using LLILCJit
 Successfully read ConsoleEncoding..ctor
 
@@ -11440,8 +13149,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %1)
   %2 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
@@ -11477,8 +13186,8 @@ entry:
   %2 = call %System.Text.InternalEncoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalEncoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %1)
   %3 = bitcast %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2 to %System.Text.EncoderFallback addrspace(1)*
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
@@ -11488,8 +13197,8 @@ entry:
   %8 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %7)
   %9 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %8 to %System.Text.DecoderFallback addrspace(1)*
-  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %6, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.Encoding addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %4
   %11 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %6, i32 0, i32 3
@@ -11500,7 +13209,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11519,15 +13228,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* %1)
   %2 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   %6 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, i32 0, i32 1
@@ -11538,7 +13247,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11566,8 +13275,8 @@ entry:
   store %System.Text.InternalDecoderBestFitFallback addrspace(1)* %param0, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
   %0 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
@@ -11577,15 +13286,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %4)
   %5 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %6)
   %9 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, i32 0, i32 1
@@ -11596,11 +13305,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11668,8 +13377,8 @@ entry:
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
   %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = load i64, i64 addrspace(1)* %19
@@ -11733,8 +13442,8 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.ConsoleStream addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
@@ -11765,31 +13474,31 @@ entry:
   store i8 %param4, i8* %arg4
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %3, %System.IO.Stream addrspace(1)* %1)
   %4 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %4, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
   %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %4, i32 0, i32 4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %5)
   %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %6
   %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
   %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
   %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = load i64, i64 addrspace(1)* %13
@@ -11801,8 +13510,8 @@ entry:
   %21 = load i64, i64* %20
   %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %8, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %8, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %14
   %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 5
@@ -11820,24 +13529,24 @@ entry:
   %31 = load i32, i32* %arg3
   %32 = sext i32 %31 to i64
   %33 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %32)
-  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %30, null
-  br i1 %NullCheck10, label %34, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.StreamWriter addrspace(1)* %30, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %35, %"System.Char[]" addrspace(1)* %33)
   %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %37, null
-  br i1 %NullCheck12, label %38, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.StreamWriter addrspace(1)* %37, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %38
 
 ; <label>:38                                      ; preds = %34
   %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
   %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
   %41 = load i32, i32* %arg3
   %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %42, null
-  br i1 %NullCheck14, label %43, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %42, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
   %44 = load i64, i64 addrspace(1)* %42
@@ -11851,30 +13560,30 @@ entry:
   %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
   %53 = sext i32 %52 to i64
   %54 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %53)
-  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
-  br i1 %NullCheck16, label %55, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %55
 
 ; <label>:55                                      ; preds = %43
   %56 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %56, %"System.Byte[]" addrspace(1)* %54)
   %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %58 = load i32, i32* %arg3
-  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %57, null
-  br i1 %NullCheck18, label %59, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.StreamWriter addrspace(1)* %57, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %59
 
 ; <label>:59                                      ; preds = %55
   %60 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 10
   store i32 %58, i32 addrspace(1)* %60
   %61 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %61, null
-  br i1 %NullCheck20, label %62, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.IO.StreamWriter addrspace(1)* %61, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %62
 
 ; <label>:62                                      ; preds = %59
   %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
   %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
   %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
   %67 = load i64, i64 addrspace(1)* %65
@@ -11892,15 +13601,15 @@ entry:
 
 ; <label>:78                                      ; preds = %66
   %79 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %79, null
-  br i1 %NullCheck24, label %80, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.StreamWriter addrspace(1)* %79, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %80
 
 ; <label>:80                                      ; preds = %78
   %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
   %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
   %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %83, null
-  br i1 %NullCheck26, label %84, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %83, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
   %85 = load i64, i64 addrspace(1)* %83
@@ -11917,8 +13626,8 @@ entry:
 
 ; <label>:95                                      ; preds = %84
   %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.IO.StreamWriter addrspace(1)* %96, null
-  br i1 %NullCheck28, label %97, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.IO.StreamWriter addrspace(1)* %96, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %97
 
 ; <label>:97                                      ; preds = %95
   %98 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 12
@@ -11932,8 +13641,8 @@ entry:
   %103 = icmp eq i32 %102, 0
   %104 = sext i1 %103 to i32
   %105 = trunc i32 %104 to i8
-  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %100, null
-  br i1 %NullCheck30, label %106, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.IO.StreamWriter addrspace(1)* %100, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %106
 
 ; <label>:106                                     ; preds = %99
   %107 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %100, i32 0, i32 13
@@ -11944,63 +13653,63 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %6
+ThrowNullRef4:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %29
+ThrowNullRef10:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %34
+ThrowNullRef12:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %38
+ThrowNullRef14:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %43
+ThrowNullRef16:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %55
+ThrowNullRef18:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %59
+ThrowNullRef20:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %62
+ThrowNullRef22:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %78
+ThrowNullRef24:                                   ; preds = %78
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %80
+ThrowNullRef26:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %95
+ThrowNullRef28:                                   ; preds = %95
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12013,15 +13722,15 @@ entry:
   %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = load i64, i64 addrspace(1)* %4
@@ -12039,7 +13748,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12089,35 +13798,35 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
   %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderNLS addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %7 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.EncoderNLS addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Text.Encoding addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.Encoding addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Text.EncoderNLS addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.EncoderNLS addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
   %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck8 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = load i64, i64 addrspace(1)* %16
@@ -12136,19 +13845,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12174,8 +13883,8 @@ entry:
   %this = alloca %System.Text.Encoding addrspace(1)*
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
@@ -12195,15 +13904,15 @@ entry:
   %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
   store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
   %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
   store i32 0, i32 addrspace(1)* %2
   %3 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, i32 0, i32 2
@@ -12213,15 +13922,15 @@ entry:
 
 ; <label>:8                                       ; preds = %4
   %9 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
   %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
   %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = load i64, i64 addrspace(1)* %13
@@ -12242,15 +13951,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12265,16 +13974,16 @@ entry:
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = load i32, i32* %arg1
   %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
   %7 = load i64, i64 addrspace(1)* %5
@@ -12292,7 +14001,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12329,8 +14038,8 @@ entry:
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
   %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
   %16 = load i64, i64 addrspace(1)* %14
@@ -12351,8 +14060,8 @@ entry:
   %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
   %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
   %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %31, null
-  br i1 %NullCheck2, label %32, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = load i64, i64 addrspace(1)* %31
@@ -12395,7 +14104,7 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12408,14 +14117,14 @@ entry:
   %this = alloca %System.Text.EncoderReplacementFallback addrspace(1)*
   store %System.Text.EncoderReplacementFallback addrspace(1)* %param0, %System.Text.EncoderReplacementFallback addrspace(1)** %this
   %0 = load %System.Text.EncoderReplacementFallback addrspace(1)*, %System.Text.EncoderReplacementFallback addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -12426,7 +14135,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12456,8 +14165,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
@@ -12489,8 +14198,8 @@ entry:
   %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
   store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
@@ -12502,8 +14211,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Threading.Tasks.Task addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %7)
@@ -12526,7 +14235,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12545,8 +14254,8 @@ entry:
   store i8 %param1, i8* %arg1
   store i8 %param2, i8* %arg2
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
@@ -12560,8 +14269,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1, %5
   %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 9
@@ -12592,8 +14301,8 @@ entry:
 
 ; <label>:25                                      ; preds = %8, %20
   %26 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %26, null
-  br i1 %NullCheck4, label %27, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %26, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %26, i32 0, i32 12
@@ -12604,22 +14313,22 @@ entry:
 
 ; <label>:32                                      ; preds = %27
   %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %33, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.IO.StreamWriter addrspace(1)* %33, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %32
   %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 12
   store i8 1, i8 addrspace(1)* %35
   %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
-  br i1 %NullCheck8, label %37, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
   %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
   %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck10 = icmp ne i64 addrspace(1)* %40, null
-  br i1 %NullCheck10, label %41, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64 addrspace(1)* %40, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i64, i64 addrspace(1)* %40
@@ -12633,8 +14342,8 @@ entry:
   %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
   store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
   %51 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %NullCheck12 = icmp ne %"System.Byte[]" addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Byte[]" addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %41
   %53 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %51, i32 0, i32 1
@@ -12646,16 +14355,16 @@ entry:
 
 ; <label>:58                                      ; preds = %52
   %59 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %59, null
-  br i1 %NullCheck14, label %60, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.IO.StreamWriter addrspace(1)* %59, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %60
 
 ; <label>:60                                      ; preds = %58
   %61 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %59, i32 0, i32 3
   %62 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
   %64 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %NullCheck16 = icmp ne %"System.Byte[]" addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %"System.Byte[]" addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %60
   %66 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %64, i32 0, i32 1
@@ -12663,8 +14372,8 @@ entry:
   %68 = zext i32 %67 to i64
   %69 = trunc i64 %68 to i32
   %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck18, label %71, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
   %72 = load i64, i64 addrspace(1)* %70
@@ -12680,29 +14389,29 @@ entry:
 
 ; <label>:80                                      ; preds = %27, %52, %71
   %81 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %81, null
-  br i1 %NullCheck20, label %82, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.IO.StreamWriter addrspace(1)* %81, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
 
 ; <label>:82                                      ; preds = %80
   %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %81, i32 0, i32 5
   %84 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %83, align 8
   %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.IO.StreamWriter addrspace(1)* %85, null
-  br i1 %NullCheck22, label %86, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.IO.StreamWriter addrspace(1)* %85, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %86
 
 ; <label>:86                                      ; preds = %82
   %87 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 7
   %88 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %87, align 8
   %89 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %89, null
-  br i1 %NullCheck24, label %90, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.StreamWriter addrspace(1)* %89, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %90
 
 ; <label>:90                                      ; preds = %86
   %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %89, i32 0, i32 9
   %92 = load i32, i32 addrspace(1)* %91, align 8
   %93 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.IO.StreamWriter addrspace(1)* %93, null
-  br i1 %NullCheck26, label %94, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.IO.StreamWriter addrspace(1)* %93, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %93, i32 0, i32 6
@@ -12710,8 +14419,8 @@ entry:
   %97 = load i8, i8* %arg2
   %98 = zext i8 %97 to i32
   %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
-  %NullCheck28 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck28, label %100, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
   %101 = load i64, i64 addrspace(1)* %99
@@ -12726,8 +14435,8 @@ entry:
   %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
   store i32 %110, i32* %loc1
   %111 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %111, null
-  br i1 %NullCheck30, label %112, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.IO.StreamWriter addrspace(1)* %111, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %112
 
 ; <label>:112                                     ; preds = %100
   %113 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %111, i32 0, i32 9
@@ -12738,23 +14447,23 @@ entry:
 
 ; <label>:116                                     ; preds = %112
   %117 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck32 = icmp ne %System.IO.StreamWriter addrspace(1)* %117, null
-  br i1 %NullCheck32, label %118, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.IO.StreamWriter addrspace(1)* %117, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %118
 
 ; <label>:118                                     ; preds = %116
   %119 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %117, i32 0, i32 3
   %120 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %119, align 8
   %121 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.IO.StreamWriter addrspace(1)* %121, null
-  br i1 %NullCheck34, label %122, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.IO.StreamWriter addrspace(1)* %121, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %122
 
 ; <label>:122                                     ; preds = %118
   %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
   %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
   %125 = load i32, i32* %loc1
   %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
-  %NullCheck36 = icmp ne i64 addrspace(1)* %126, null
-  br i1 %NullCheck36, label %127, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64 addrspace(1)* %126, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
   %128 = load i64, i64 addrspace(1)* %126
@@ -12776,15 +14485,15 @@ entry:
 
 ; <label>:140                                     ; preds = %136
   %141 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.IO.StreamWriter addrspace(1)* %141, null
-  br i1 %NullCheck38, label %142, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.IO.StreamWriter addrspace(1)* %141, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %142
 
 ; <label>:142                                     ; preds = %140
   %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
   %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
   %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
-  %NullCheck40 = icmp ne i64 addrspace(1)* %145, null
-  br i1 %NullCheck40, label %146, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i64 addrspace(1)* %145, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
   %147 = load i64, i64 addrspace(1)* %145
@@ -12805,83 +14514,83 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %25
+ThrowNullRef4:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %32
+ThrowNullRef6:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %37
+ThrowNullRef10:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %41
+ThrowNullRef12:                                   ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %58
+ThrowNullRef14:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %60
+ThrowNullRef16:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %65
+ThrowNullRef18:                                   ; preds = %65
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %80
+ThrowNullRef20:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %82
+ThrowNullRef22:                                   ; preds = %82
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %86
+ThrowNullRef24:                                   ; preds = %86
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %90
+ThrowNullRef26:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %94
+ThrowNullRef28:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %100
+ThrowNullRef30:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %116
+ThrowNullRef32:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %118
+ThrowNullRef34:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %122
+ThrowNullRef36:                                   ; preds = %122
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %140
+ThrowNullRef38:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %142
+ThrowNullRef40:                                   ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12948,8 +14657,8 @@ entry:
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %1 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
-  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
@@ -12957,8 +14666,8 @@ entry:
   %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
   %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
   %8 = load i64, i64 addrspace(1)* %6
@@ -12974,8 +14683,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %17, %System.IFormatProvider addrspace(1)* %16)
   %18 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %19 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %18, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.SyncTextWriter addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %7
   %21 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %18, i32 0, i32 4
@@ -12986,11 +14695,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13003,8 +14712,8 @@ entry:
   %this = alloca %System.IO.TextWriter addrspace(1)*
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.TextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
@@ -13014,8 +14723,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.Threading.Thread addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Threading.Thread addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %6)
@@ -13024,8 +14733,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1
   %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.TextWriter addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.TextWriter addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %11, i32 0, i32 2
@@ -13036,11 +14745,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13237,8 +14946,8 @@ entry:
   store i32 %param1, i32* %arg1
   store i8 0, i8* %loc1
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
@@ -13248,16 +14957,16 @@ entry:
   %5 = addrspacecast i8* %loc1 to i8 addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %4, i8 addrspace(1)* %5)
   %6 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.SyncTextWriter addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
   %10 = load i32, i32* %arg1
   %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
   %13 = load i64, i64 addrspace(1)* %11
@@ -13292,11 +15001,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13313,8 +15022,8 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load i32, i32* %arg1
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -13328,8 +15037,8 @@ entry:
   call void %11(%System.IO.TextWriter addrspace(1)* %0, i32 %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
   %15 = load i64, i64 addrspace(1)* %13
@@ -13347,7 +15056,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13365,8 +15074,8 @@ entry:
   %1 = addrspacecast i32* %arg1 to i32 addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -13381,8 +15090,8 @@ entry:
   %14 = bitcast i32 addrspace(1)* %1 to %System.UInt32 addrspace(1)*
   %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.UInt32 addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.UInt32 addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
   %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
   %18 = load i64, i64 addrspace(1)* %16
@@ -13400,7 +15109,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13416,8 +15125,8 @@ entry:
   store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
   %0 = load %System.UInt32 addrspace(1)*, %System.UInt32 addrspace(1)** %this
   %1 = bitcast %System.UInt32 addrspace(1)* %0 to i32 addrspace(1)*
-  %NullCheck = icmp ne i32 addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq i32 addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load i32, i32 addrspace(1)* %1, align 8
@@ -13442,8 +15151,8 @@ entry:
   %loc0 = alloca %System.Globalization.NumberFormatInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 3
@@ -13453,8 +15162,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
@@ -13464,24 +15173,24 @@ entry:
   store %System.Globalization.NumberFormatInfo addrspace(1)* %10, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
   %11 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %7
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
   %15 = load i8, i8 addrspace(1)* %14, align 8
   %16 = zext i8 %15 to i32
   %17 = trunc i32 %16 to i8
-  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %11, null
-  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %11, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %13
   %19 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %11, i32 0, i32 29
   store i8 %17, i8 addrspace(1)* %19
   %20 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %21 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %20, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %20, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %18
   %23 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %20, i32 0, i32 3
@@ -13490,8 +15199,8 @@ entry:
 
 ; <label>:24                                      ; preds = %1, %22
   %25 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %25, null
-  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %25, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %26
 
 ; <label>:26                                      ; preds = %24
   %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %25, i32 0, i32 3
@@ -13502,23 +15211,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %18
+ThrowNullRef8:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13543,168 +15252,168 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 18
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %8, align 8
-  %NullCheck2 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %5, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %5, i32 0, i32 4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %9)
   %12 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 19
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %15, align 8
-  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %12, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %12, i32 0, i32 5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %16)
   %19 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %20 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %20, null
-  br i1 %NullCheck8, label %21, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %20, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %20, i32 0, i32 23
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  %NullCheck10 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %19, null
-  br i1 %NullCheck10, label %24, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %19, i32 0, i32 7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %25, %System.String addrspace(1)* %23)
   %26 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %27 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %27, i32 0, i32 22
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %29, align 8
-  %NullCheck14 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %26, null
-  br i1 %NullCheck14, label %31, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %26, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %26, i32 0, i32 6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %32, %System.String addrspace(1)* %30)
   %33 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %34 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Globalization.CultureData addrspace(1)* %34, null
-  br i1 %NullCheck16, label %35, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Globalization.CultureData addrspace(1)* %34, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %34, i32 0, i32 51
   %37 = load i32, i32 addrspace(1)* %36, align 8
-  %NullCheck18 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %33, null
-  br i1 %NullCheck18, label %38, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %33, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %33, i32 0, i32 21
   store i32 %37, i32 addrspace(1)* %39
   %40 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %41 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Globalization.CultureData addrspace(1)* %41, null
-  br i1 %NullCheck20, label %42, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Globalization.CultureData addrspace(1)* %41, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %41, i32 0, i32 52
   %44 = load i32, i32 addrspace(1)* %43, align 8
-  %NullCheck22 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %40, null
-  br i1 %NullCheck22, label %45, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %40, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %40, i32 0, i32 25
   store i32 %44, i32 addrspace(1)* %46
   %47 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %48 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.Globalization.CultureData addrspace(1)* %48, null
-  br i1 %NullCheck24, label %49, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Globalization.CultureData addrspace(1)* %48, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %49
 
 ; <label>:49                                      ; preds = %45
   %50 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %48, i32 0, i32 29
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck26 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %47, null
-  br i1 %NullCheck26, label %52, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %47, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %47, i32 0, i32 10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %53, %System.String addrspace(1)* %51)
   %54 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %55 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Globalization.CultureData addrspace(1)* %55, null
-  br i1 %NullCheck28, label %56, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Globalization.CultureData addrspace(1)* %55, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %56
 
 ; <label>:56                                      ; preds = %52
   %57 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %55, i32 0, i32 35
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %57, align 8
-  %NullCheck30 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %54, null
-  br i1 %NullCheck30, label %59, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %54, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %54, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %60, %System.String addrspace(1)* %58)
   %61 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %62 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck32 = icmp ne %System.Globalization.CultureData addrspace(1)* %62, null
-  br i1 %NullCheck32, label %63, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Globalization.CultureData addrspace(1)* %62, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %62, i32 0, i32 34
   %65 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %64, align 8
-  %NullCheck34 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %61, null
-  br i1 %NullCheck34, label %66, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %61, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %61, i32 0, i32 9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %67, %System.String addrspace(1)* %65)
   %68 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %69 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck36 = icmp ne %System.Globalization.CultureData addrspace(1)* %69, null
-  br i1 %NullCheck36, label %70, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Globalization.CultureData addrspace(1)* %69, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %70
 
 ; <label>:70                                      ; preds = %66
   %71 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %69, i32 0, i32 55
   %72 = load i32, i32 addrspace(1)* %71, align 8
-  %NullCheck38 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %68, null
-  br i1 %NullCheck38, label %73, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %68, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %68, i32 0, i32 22
   store i32 %72, i32 addrspace(1)* %74
   %75 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %76 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck40 = icmp ne %System.Globalization.CultureData addrspace(1)* %76, null
-  br i1 %NullCheck40, label %77, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Globalization.CultureData addrspace(1)* %76, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %76, i32 0, i32 57
   %79 = load i32, i32 addrspace(1)* %78, align 8
-  %NullCheck42 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %75, null
-  br i1 %NullCheck42, label %80, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %75, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %80
 
 ; <label>:80                                      ; preds = %77
   %81 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %75, i32 0, i32 24
   store i32 %79, i32 addrspace(1)* %81
   %82 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %83 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck44 = icmp ne %System.Globalization.CultureData addrspace(1)* %83, null
-  br i1 %NullCheck44, label %84, label %ThrowNullRef43
+  %NullCheck43 = icmp eq %System.Globalization.CultureData addrspace(1)* %83, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %84
 
 ; <label>:84                                      ; preds = %80
   %85 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %83, i32 0, i32 56
   %86 = load i32, i32 addrspace(1)* %85, align 8
-  %NullCheck46 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %82, null
-  br i1 %NullCheck46, label %87, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %82, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %82, i32 0, i32 23
@@ -13713,8 +15422,8 @@ entry:
 
 ; <label>:89                                      ; preds = %entry
   %90 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck100 = icmp ne %System.Globalization.CultureData addrspace(1)* %90, null
-  br i1 %NullCheck100, label %91, label %ThrowNullRef99
+  %NullCheck99 = icmp eq %System.Globalization.CultureData addrspace(1)* %90, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %91
 
 ; <label>:91                                      ; preds = %89
   %92 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %90, i32 0, i32 2
@@ -13732,8 +15441,8 @@ entry:
   %102 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %103 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %104 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %103)
-  %NullCheck48 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %102, null
-  br i1 %NullCheck48, label %105, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %102, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %105
 
 ; <label>:105                                     ; preds = %101
   %106 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %102, i32 0, i32 1
@@ -13741,8 +15450,8 @@ entry:
   %107 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %108 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %109 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %108)
-  %NullCheck50 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %107, null
-  br i1 %NullCheck50, label %110, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %107, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %110
 
 ; <label>:110                                     ; preds = %105
   %111 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %107, i32 0, i32 2
@@ -13750,8 +15459,8 @@ entry:
   %112 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %113 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %114 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %113)
-  %NullCheck52 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %112, null
-  br i1 %NullCheck52, label %115, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %112, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %115
 
 ; <label>:115                                     ; preds = %110
   %116 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %112, i32 0, i32 27
@@ -13759,8 +15468,8 @@ entry:
   %117 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %118 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %119 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %118)
-  %NullCheck54 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %117, null
-  br i1 %NullCheck54, label %120, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %117, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %120
 
 ; <label>:120                                     ; preds = %115
   %121 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %117, i32 0, i32 26
@@ -13768,8 +15477,8 @@ entry:
   %122 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %123 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %124 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %123)
-  %NullCheck56 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %122, null
-  br i1 %NullCheck56, label %125, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %122, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %125
 
 ; <label>:125                                     ; preds = %120
   %126 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %122, i32 0, i32 17
@@ -13777,8 +15486,8 @@ entry:
   %127 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %128 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %129 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %128)
-  %NullCheck58 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %127, null
-  br i1 %NullCheck58, label %130, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %127, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %130
 
 ; <label>:130                                     ; preds = %125
   %131 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %127, i32 0, i32 18
@@ -13786,8 +15495,8 @@ entry:
   %132 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %133 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %134 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %133)
-  %NullCheck60 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %132, null
-  br i1 %NullCheck60, label %135, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %132, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %135
 
 ; <label>:135                                     ; preds = %130
   %136 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %132, i32 0, i32 14
@@ -13795,8 +15504,8 @@ entry:
   %137 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %138 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %139 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %138)
-  %NullCheck62 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %137, null
-  br i1 %NullCheck62, label %140, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %137, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %140
 
 ; <label>:140                                     ; preds = %135
   %141 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %137, i32 0, i32 13
@@ -13804,71 +15513,71 @@ entry:
   %142 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %143 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %144 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %143)
-  %NullCheck64 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %142, null
-  br i1 %NullCheck64, label %145, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %142, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %145
 
 ; <label>:145                                     ; preds = %140
   %146 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %142, i32 0, i32 12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %146, %System.String addrspace(1)* %144)
   %147 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %148 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck66 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %148, null
-  br i1 %NullCheck66, label %149, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %148, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %149
 
 ; <label>:149                                     ; preds = %145
   %150 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %148, i32 0, i32 21
   %151 = load i32, i32 addrspace(1)* %150, align 8
-  %NullCheck68 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %147, null
-  br i1 %NullCheck68, label %152, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %147, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %152
 
 ; <label>:152                                     ; preds = %149
   %153 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %147, i32 0, i32 28
   store i32 %151, i32 addrspace(1)* %153
   %154 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %155 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck70 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %155, null
-  br i1 %NullCheck70, label %156, label %ThrowNullRef69
+  %NullCheck69 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %155, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %156
 
 ; <label>:156                                     ; preds = %152
   %157 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %155, i32 0, i32 6
   %158 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %157, align 8
-  %NullCheck72 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %154, null
-  br i1 %NullCheck72, label %159, label %ThrowNullRef71
+  %NullCheck71 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %154, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %159
 
 ; <label>:159                                     ; preds = %156
   %160 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %154, i32 0, i32 15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %160, %System.String addrspace(1)* %158)
   %161 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %162 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck74 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %162, null
-  br i1 %NullCheck74, label %163, label %ThrowNullRef73
+  %NullCheck73 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %162, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %163
 
 ; <label>:163                                     ; preds = %159
   %164 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %162, i32 0, i32 1
   %165 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %164, align 8
-  %NullCheck76 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %161, null
-  br i1 %NullCheck76, label %166, label %ThrowNullRef75
+  %NullCheck75 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %161, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %166
 
 ; <label>:166                                     ; preds = %163
   %167 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %161, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %167, %"System.Int32[]" addrspace(1)* %165)
   %168 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %169 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck78 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %169, null
-  br i1 %NullCheck78, label %170, label %ThrowNullRef77
+  %NullCheck77 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %169, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %170
 
 ; <label>:170                                     ; preds = %166
   %171 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %169, i32 0, i32 7
   %172 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %171, align 8
-  %NullCheck80 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %168, null
-  br i1 %NullCheck80, label %173, label %ThrowNullRef79
+  %NullCheck79 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %168, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %173
 
 ; <label>:173                                     ; preds = %170
   %174 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %168, i32 0, i32 16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %174, %System.String addrspace(1)* %172)
   %175 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck82 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %175, null
-  br i1 %NullCheck82, label %176, label %ThrowNullRef81
+  %NullCheck81 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %175, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %176
 
 ; <label>:176                                     ; preds = %173
   %177 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %175, i32 0, i32 4
@@ -13878,14 +15587,14 @@ entry:
 
 ; <label>:180                                     ; preds = %176
   %181 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck84 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %181, null
-  br i1 %NullCheck84, label %182, label %ThrowNullRef83
+  %NullCheck83 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %181, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %182
 
 ; <label>:182                                     ; preds = %180
   %183 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %181, i32 0, i32 4
   %184 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %183, align 8
-  %NullCheck86 = icmp ne %System.String addrspace(1)* %184, null
-  br i1 %NullCheck86, label %185, label %ThrowNullRef85
+  %NullCheck85 = icmp eq %System.String addrspace(1)* %184, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %185
 
 ; <label>:185                                     ; preds = %182
   %186 = getelementptr inbounds %System.String, %System.String addrspace(1)* %184, i32 0, i32 1
@@ -13896,8 +15605,8 @@ entry:
 ; <label>:189                                     ; preds = %176, %185
   %190 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck98 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %190, null
-  br i1 %NullCheck98, label %192, label %ThrowNullRef97
+  %NullCheck97 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %190, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %192
 
 ; <label>:192                                     ; preds = %189
   %193 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %190, i32 0, i32 4
@@ -13906,8 +15615,8 @@ entry:
 
 ; <label>:194                                     ; preds = %185, %192
   %195 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck88 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %195, null
-  br i1 %NullCheck88, label %196, label %ThrowNullRef87
+  %NullCheck87 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %195, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %196
 
 ; <label>:196                                     ; preds = %194
   %197 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %195, i32 0, i32 9
@@ -13917,14 +15626,14 @@ entry:
 
 ; <label>:200                                     ; preds = %196
   %201 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck90 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %201, null
-  br i1 %NullCheck90, label %202, label %ThrowNullRef89
+  %NullCheck89 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %201, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %202
 
 ; <label>:202                                     ; preds = %200
   %203 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %201, i32 0, i32 9
   %204 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %203, align 8
-  %NullCheck92 = icmp ne %System.String addrspace(1)* %204, null
-  br i1 %NullCheck92, label %205, label %ThrowNullRef91
+  %NullCheck91 = icmp eq %System.String addrspace(1)* %204, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %205
 
 ; <label>:205                                     ; preds = %202
   %206 = getelementptr inbounds %System.String, %System.String addrspace(1)* %204, i32 0, i32 1
@@ -13935,14 +15644,14 @@ entry:
 ; <label>:209                                     ; preds = %196, %205
   %210 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %211 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck94 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %211, null
-  br i1 %NullCheck94, label %212, label %ThrowNullRef93
+  %NullCheck93 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %211, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %212
 
 ; <label>:212                                     ; preds = %209
   %213 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %211, i32 0, i32 6
   %214 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %213, align 8
-  %NullCheck96 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %210, null
-  br i1 %NullCheck96, label %215, label %ThrowNullRef95
+  %NullCheck95 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %210, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %215
 
 ; <label>:215                                     ; preds = %212
   %216 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %210, i32 0, i32 9
@@ -13956,203 +15665,203 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %17
+ThrowNullRef8:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %21
+ThrowNullRef10:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %24
+ThrowNullRef12:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %28
+ThrowNullRef14:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %31
+ThrowNullRef16:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %35
+ThrowNullRef18:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %38
+ThrowNullRef20:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %42
+ThrowNullRef22:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %45
+ThrowNullRef24:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %49
+ThrowNullRef26:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %52
+ThrowNullRef28:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %56
+ThrowNullRef30:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %59
+ThrowNullRef32:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %63
+ThrowNullRef34:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %66
+ThrowNullRef36:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %70
+ThrowNullRef38:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %73
+ThrowNullRef40:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %77
+ThrowNullRef42:                                   ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %80
+ThrowNullRef44:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %84
+ThrowNullRef46:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %101
+ThrowNullRef48:                                   ; preds = %101
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %105
+ThrowNullRef50:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %110
+ThrowNullRef52:                                   ; preds = %110
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %115
+ThrowNullRef54:                                   ; preds = %115
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %120
+ThrowNullRef56:                                   ; preds = %120
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %125
+ThrowNullRef58:                                   ; preds = %125
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %130
+ThrowNullRef60:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %135
+ThrowNullRef62:                                   ; preds = %135
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %140
+ThrowNullRef64:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %145
+ThrowNullRef66:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %149
+ThrowNullRef68:                                   ; preds = %149
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %152
+ThrowNullRef70:                                   ; preds = %152
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %156
+ThrowNullRef72:                                   ; preds = %156
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %159
+ThrowNullRef74:                                   ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %163
+ThrowNullRef76:                                   ; preds = %163
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %166
+ThrowNullRef78:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %170
+ThrowNullRef80:                                   ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %173
+ThrowNullRef82:                                   ; preds = %173
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %180
+ThrowNullRef84:                                   ; preds = %180
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %182
+ThrowNullRef86:                                   ; preds = %182
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %194
+ThrowNullRef88:                                   ; preds = %194
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %200
+ThrowNullRef90:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %202
+ThrowNullRef92:                                   ; preds = %202
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %209
+ThrowNullRef94:                                   ; preds = %209
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %212
+ThrowNullRef96:                                   ; preds = %212
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %189
+ThrowNullRef98:                                   ; preds = %189
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %89
+ThrowNullRef100:                                  ; preds = %89
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14180,8 +15889,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 21
@@ -14194,8 +15903,8 @@ entry:
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 16)
   %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 21
@@ -14204,8 +15913,8 @@ entry:
 
 ; <label>:12                                      ; preds = %1, %10
   %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 21
@@ -14216,11 +15925,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %12
+ThrowNullRef4:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14236,8 +15945,8 @@ entry:
   store i32 %param1, i32* %arg1
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %1 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
@@ -14304,8 +16013,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 33
@@ -14318,8 +16027,8 @@ entry:
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 24)
   %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 33
@@ -14328,8 +16037,8 @@ entry:
 
 ; <label>:12                                      ; preds = %1, %10
   %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 33
@@ -14340,11 +16049,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %12
+ThrowNullRef4:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14357,8 +16066,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 53
@@ -14370,8 +16079,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 116)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 53
@@ -14380,8 +16089,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 53
@@ -14392,11 +16101,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14425,8 +16134,8 @@ entry:
 
 ; <label>:7                                       ; preds = %entry, %4
   %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %7
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 2
@@ -14450,8 +16159,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 54
@@ -14463,8 +16172,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 117)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
@@ -14473,8 +16182,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 54
@@ -14485,11 +16194,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14502,8 +16211,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 27
@@ -14515,8 +16224,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 118)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 27
@@ -14525,8 +16234,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 27
@@ -14537,11 +16246,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14554,8 +16263,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 28
@@ -14567,8 +16276,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 119)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 28
@@ -14577,8 +16286,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 28
@@ -14589,11 +16298,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14606,8 +16315,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 26
@@ -14619,8 +16328,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 107)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 26
@@ -14629,8 +16338,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 26
@@ -14641,11 +16350,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14658,8 +16367,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 25
@@ -14671,8 +16380,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 106)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 25
@@ -14681,8 +16390,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 25
@@ -14693,11 +16402,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14710,8 +16419,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 24
@@ -14723,8 +16432,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 105)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 24
@@ -14733,8 +16442,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 24
@@ -14745,11 +16454,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14774,8 +16483,8 @@ entry:
   %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %3)
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %2
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -14786,15 +16495,15 @@ entry:
 
 ; <label>:8                                       ; preds = %62
   %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 9
   %12 = load i32, i32 addrspace(1)* %11, align 8
   %13 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.IO.StreamWriter addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %13, i32 0, i32 10
@@ -14809,15 +16518,15 @@ entry:
 
 ; <label>:20                                      ; preds = %14, %18
   %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
   %24 = load i32, i32 addrspace(1)* %23, align 8
   %25 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %25, null
-  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.StreamWriter addrspace(1)* %25, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %25, i32 0, i32 9
@@ -14838,36 +16547,36 @@ entry:
   %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %37 = load i32, i32* %loc1
   %38 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.StreamWriter addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %35
   %40 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %38, i32 0, i32 7
   %41 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %40, align 8
   %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
-  br i1 %NullCheck14, label %43, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %39
   %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 9
   %45 = load i32, i32 addrspace(1)* %44, align 8
   %46 = load i32, i32* %loc2
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %36, null
-  br i1 %NullCheck16, label %47, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %36, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %47
 
 ; <label>:47                                      ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %36, i32 %37, %"System.Char[]" addrspace(1)* %41, i32 %45, i32 %46)
   %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
   %51 = load i32, i32 addrspace(1)* %50, align 8
   %52 = load i32, i32* %loc2
   %53 = add i32 %51, %52
-  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
-  br i1 %NullCheck20, label %54, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %54
 
 ; <label>:54                                      ; preds = %49
   %55 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
@@ -14889,8 +16598,8 @@ entry:
 
 ; <label>:65                                      ; preds = %62
   %66 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %66, null
-  br i1 %NullCheck2, label %67, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %66, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %67
 
 ; <label>:67                                      ; preds = %65
   %68 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %66, i32 0, i32 11
@@ -14911,49 +16620,259 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %65
+ThrowNullRef2:                                    ; preds = %65
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %20
+ThrowNullRef8:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %22
+ThrowNullRef10:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %35
+ThrowNullRef12:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %43
+ThrowNullRef16:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %47
+ThrowNullRef18:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method String::CopyTo using LLILCJit
-Failed to read String.CopyTo[loadElemA]
+Successfully read String.CopyTo
+
+define void @String.CopyTo(%System.String addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  %loc1 = alloca i16 addrspace(1)*
+  %loc2 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %1 = icmp ne %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg4
+  %7 = icmp sge i32 %6, 0
+  br i1 %7, label %13, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  unreachable
+
+; <label>:13                                      ; preds = %5
+  %14 = load i32, i32* %arg1
+  %15 = icmp sge i32 %14, 0
+  br i1 %15, label %21, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %18)
+  %20 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %20, %System.String addrspace(1)* %17, %System.String addrspace(1)* %19)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %20) #0
+  unreachable
+
+; <label>:21                                      ; preds = %13
+  %22 = load i32, i32* %arg4
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck, label %ThrowNullRef, label %24
+
+; <label>:24                                      ; preds = %21
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load i32, i32* %arg1
+  %28 = sub i32 %26, %27
+  %29 = icmp sle i32 %22, %28
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34, %System.String addrspace(1)* %31, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %24
+  %36 = load i32, i32* %arg3
+  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %37, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
+
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
+  %40 = load i32, i32 addrspace(1)* %39
+  %41 = zext i32 %40 to i64
+  %42 = trunc i64 %41 to i32
+  %43 = load i32, i32* %arg4
+  %44 = sub i32 %42, %43
+  %45 = icmp sgt i32 %36, %44
+  br i1 %45, label %49, label %46
+
+; <label>:46                                      ; preds = %38
+  %47 = load i32, i32* %arg3
+  %48 = icmp sge i32 %47, 0
+  br i1 %48, label %54, label %49
+
+; <label>:49                                      ; preds = %38, %46
+  %50 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %52 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %51)
+  %53 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53, %System.String addrspace(1)* %50, %System.String addrspace(1)* %52)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53) #0
+  unreachable
+
+; <label>:54                                      ; preds = %46
+  %55 = load i32, i32* %arg4
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %97, label %57
+
+; <label>:57                                      ; preds = %54
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %59
+
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 2
+  %61 = bitcast [0 x i16] addrspace(1)* %60 to i16 addrspace(1)*
+  store i16 addrspace(1)* %61, i16 addrspace(1)** %loc0
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  store %"System.Char[]" addrspace(1)* %62, %"System.Char[]" addrspace(1)** %loc2
+  %63 = icmp eq %"System.Char[]" addrspace(1)* %62, null
+  br i1 %63, label %72, label %64
+
+; <label>:64                                      ; preds = %59
+  %65 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc2
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %65, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %66
+
+; <label>:66                                      ; preds = %64
+  %67 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %65, i32 0, i32 1
+  %68 = load i32, i32 addrspace(1)* %67
+  %69 = zext i32 %68 to i64
+  %70 = trunc i64 %69 to i32
+  %71 = icmp ne i32 %70, 0
+  br i1 %71, label %73, label %72
+
+; <label>:72                                      ; preds = %59, %66
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  br label %81
+
+; <label>:73                                      ; preds = %66
+  %74 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc2
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %74, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %75
+
+; <label>:75                                      ; preds = %73
+  %76 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %74, i32 0, i32 1
+  %77 = load i32, i32 addrspace(1)* %76
+  %78 = zext i32 %77 to i64
+  %BoundsCheck = icmp uge i64 0, %78
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %79
+
+; <label>:79                                      ; preds = %75
+  %80 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %74, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %80, i16 addrspace(1)** %loc1
+  br label %81
+
+; <label>:81                                      ; preds = %72, %79
+  %82 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %83 = ptrtoint i16 addrspace(1)* %82 to i64
+  %84 = load i32, i32* %arg3
+  %85 = sext i32 %84 to i64
+  %86 = mul i64 %85, 2
+  %87 = add i64 %83, %86
+  %88 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %89 = ptrtoint i16 addrspace(1)* %88 to i64
+  %90 = load i32, i32* %arg1
+  %91 = sext i32 %90 to i64
+  %92 = mul i64 %91, 2
+  %93 = add i64 %89, %92
+  %94 = load i32, i32* %arg4
+  %95 = inttoptr i64 %87 to i16*
+  %96 = inttoptr i64 %93 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %95, i16* %96, i32 %94)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  br label %97
+
+; <label>:97                                      ; preds = %54, %81
+  ret void
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
 Successfully read ConsoleEncoding.GetPreamble
 
@@ -14990,7 +16909,365 @@ entry:
 }
 
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[loadElemA]
+Successfully read EncoderNLS.GetBytes
+
+define i32 @EncoderNLS.GetBytes(%System.Text.EncoderNLS addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3, %"System.Byte[]" addrspace(1)* %param4, i32 %param5, i8 %param6) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %arg4 = alloca %"System.Byte[]" addrspace(1)*
+  %arg5 = alloca i32
+  %arg6 = alloca i8
+  %loc0 = alloca i32
+  %loc1 = alloca i16 addrspace(1)*
+  %loc2 = alloca i8 addrspace(1)*
+  %loc3 = alloca i32
+  %loc4 = alloca %"System.Char[]" addrspace(1)*
+  %loc5 = alloca %"System.Byte[]" addrspace(1)*
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  store %"System.Byte[]" addrspace(1)* %param4, %"System.Byte[]" addrspace(1)** %arg4
+  store i32 %param5, i32* %arg5
+  store i8 %param6, i8* %arg6
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %1 = icmp eq %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %17, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %7 = icmp eq %"System.Char[]" addrspace(1)* %6, null
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %12
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %12
+
+; <label>:12                                      ; preds = %8, %10
+  %13 = phi %System.String addrspace(1)* [ %9, %8 ], [ %11, %10 ]
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %14)
+  %16 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16, %System.String addrspace(1)* %13, %System.String addrspace(1)* %15)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16) #0
+  unreachable
+
+; <label>:17                                      ; preds = %2
+  %18 = load i32, i32* %arg2
+  %19 = icmp slt i32 %18, 0
+  br i1 %19, label %23, label %20
+
+; <label>:20                                      ; preds = %17
+  %21 = load i32, i32* %arg3
+  %22 = icmp sge i32 %21, 0
+  br i1 %22, label %35, label %23
+
+; <label>:23                                      ; preds = %17, %20
+  %24 = load i32, i32* %arg2
+  %25 = icmp slt i32 %24, 0
+  br i1 %25, label %28, label %26
+
+; <label>:26                                      ; preds = %23
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %30
+
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %30
+
+; <label>:30                                      ; preds = %26, %28
+  %31 = phi %System.String addrspace(1)* [ %27, %26 ], [ %29, %28 ]
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34, %System.String addrspace(1)* %31, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %20
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck, label %ThrowNullRef, label %37
+
+; <label>:37                                      ; preds = %35
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = load i32, i32* %arg2
+  %43 = sub i32 %41, %42
+  %44 = load i32, i32* %arg3
+  %45 = icmp sge i32 %43, %44
+  br i1 %45, label %51, label %46
+
+; <label>:46                                      ; preds = %37
+  %47 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %48 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %49 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %48)
+  %50 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %50, %System.String addrspace(1)* %47, %System.String addrspace(1)* %49)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %50) #0
+  unreachable
+
+; <label>:51                                      ; preds = %37
+  %52 = load i32, i32* %arg5
+  %53 = icmp slt i32 %52, 0
+  br i1 %53, label %63, label %54
+
+; <label>:54                                      ; preds = %51
+  %55 = load i32, i32* %arg5
+  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck1 = icmp eq %"System.Byte[]" addrspace(1)* %56, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %57
+
+; <label>:57                                      ; preds = %54
+  %58 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = zext i32 %59 to i64
+  %61 = trunc i64 %60 to i32
+  %62 = icmp sle i32 %55, %61
+  br i1 %62, label %68, label %63
+
+; <label>:63                                      ; preds = %51, %57
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %66 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %65)
+  %67 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %67, %System.String addrspace(1)* %64, %System.String addrspace(1)* %66)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %67) #0
+  unreachable
+
+; <label>:68                                      ; preds = %57
+  %69 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %69, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %69, i32 0, i32 1
+  %72 = load i32, i32 addrspace(1)* %71
+  %73 = zext i32 %72 to i64
+  %74 = trunc i64 %73 to i32
+  %75 = icmp ne i32 %74, 0
+  br i1 %75, label %78, label %76
+
+; <label>:76                                      ; preds = %70
+  %77 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1)
+  store %"System.Char[]" addrspace(1)* %77, %"System.Char[]" addrspace(1)** %arg1
+  br label %78
+
+; <label>:78                                      ; preds = %70, %76
+  %79 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck5 = icmp eq %"System.Byte[]" addrspace(1)* %79, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %80
+
+; <label>:80                                      ; preds = %78
+  %81 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %79, i32 0, i32 1
+  %82 = load i32, i32 addrspace(1)* %81
+  %83 = zext i32 %82 to i64
+  %84 = trunc i64 %83 to i32
+  %85 = load i32, i32* %arg5
+  %86 = sub i32 %84, %85
+  store i32 %86, i32* %loc0
+  %87 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck7 = icmp eq %"System.Byte[]" addrspace(1)* %87, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %88
+
+; <label>:88                                      ; preds = %80
+  %89 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %87, i32 0, i32 1
+  %90 = load i32, i32 addrspace(1)* %89
+  %91 = zext i32 %90 to i64
+  %92 = trunc i64 %91 to i32
+  %93 = icmp ne i32 %92, 0
+  br i1 %93, label %96, label %94
+
+; <label>:94                                      ; preds = %88
+  %95 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1)
+  store %"System.Byte[]" addrspace(1)* %95, %"System.Byte[]" addrspace(1)** %arg4
+  br label %96
+
+; <label>:96                                      ; preds = %88, %94
+  %97 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  store %"System.Char[]" addrspace(1)* %97, %"System.Char[]" addrspace(1)** %loc4
+  %98 = icmp eq %"System.Char[]" addrspace(1)* %97, null
+  br i1 %98, label %107, label %99
+
+; <label>:99                                      ; preds = %96
+  %100 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc4
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %100, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %101
+
+; <label>:101                                     ; preds = %99
+  %102 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %100, i32 0, i32 1
+  %103 = load i32, i32 addrspace(1)* %102
+  %104 = zext i32 %103 to i64
+  %105 = trunc i64 %104 to i32
+  %106 = icmp ne i32 %105, 0
+  br i1 %106, label %108, label %107
+
+; <label>:107                                     ; preds = %96, %101
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  br label %116
+
+; <label>:108                                     ; preds = %101
+  %109 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc4
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %109, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %110
+
+; <label>:110                                     ; preds = %108
+  %111 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %109, i32 0, i32 1
+  %112 = load i32, i32 addrspace(1)* %111
+  %113 = zext i32 %112 to i64
+  %BoundsCheck = icmp uge i64 0, %113
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %114
+
+; <label>:114                                     ; preds = %110
+  %115 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %109, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %115, i16 addrspace(1)** %loc1
+  br label %116
+
+; <label>:116                                     ; preds = %107, %114
+  %117 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  store %"System.Byte[]" addrspace(1)* %117, %"System.Byte[]" addrspace(1)** %loc5
+  %118 = icmp eq %"System.Byte[]" addrspace(1)* %117, null
+  br i1 %118, label %127, label %119
+
+; <label>:119                                     ; preds = %116
+  %120 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc5
+  %NullCheck13 = icmp eq %"System.Byte[]" addrspace(1)* %120, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %121
+
+; <label>:121                                     ; preds = %119
+  %122 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %120, i32 0, i32 1
+  %123 = load i32, i32 addrspace(1)* %122
+  %124 = zext i32 %123 to i64
+  %125 = trunc i64 %124 to i32
+  %126 = icmp ne i32 %125, 0
+  br i1 %126, label %128, label %127
+
+; <label>:127                                     ; preds = %116, %121
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc2
+  br label %136
+
+; <label>:128                                     ; preds = %121
+  %129 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc5
+  %NullCheck15 = icmp eq %"System.Byte[]" addrspace(1)* %129, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %130
+
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %129, i32 0, i32 1
+  %132 = load i32, i32 addrspace(1)* %131
+  %133 = zext i32 %132 to i64
+  %BoundsCheck17 = icmp uge i64 0, %133
+  br i1 %BoundsCheck17, label %ThrowIndexOutOfRange18, label %134
+
+; <label>:134                                     ; preds = %130
+  %135 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %129, i32 0, i32 3, i32 0
+  store i8 addrspace(1)* %135, i8 addrspace(1)** %loc2
+  br label %136
+
+; <label>:136                                     ; preds = %127, %134
+  %137 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %138 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %139 = ptrtoint i16 addrspace(1)* %138 to i64
+  %140 = load i32, i32* %arg2
+  %141 = sext i32 %140 to i64
+  %142 = mul i64 %141, 2
+  %143 = add i64 %139, %142
+  %144 = load i32, i32* %arg3
+  %145 = load i8 addrspace(1)*, i8 addrspace(1)** %loc2
+  %146 = ptrtoint i8 addrspace(1)* %145 to i64
+  %147 = load i32, i32* %arg5
+  %148 = sext i32 %147 to i64
+  %149 = add i64 %146, %148
+  %150 = load i32, i32* %loc0
+  %151 = load i8, i8* %arg6
+  %152 = zext i8 %151 to i32
+  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i64 addrspace(1)*
+  %NullCheck19 = icmp eq i64 addrspace(1)* %153, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %154
+
+; <label>:154                                     ; preds = %136
+  %155 = load i64, i64 addrspace(1)* %153
+  %156 = add i64 %155, 72
+  %157 = inttoptr i64 %156 to i64*
+  %158 = load i64, i64* %157
+  %159 = add i64 %158, 0
+  %160 = inttoptr i64 %159 to i64*
+  %161 = load i64, i64* %160
+  %162 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to %System.Text.Encoder addrspace(1)*
+  %163 = inttoptr i64 %143 to i16*
+  %164 = inttoptr i64 %149 to i8*
+  %165 = trunc i32 %152 to i8
+  %166 = inttoptr i64 %161 to i32 (%System.Text.Encoder addrspace(1)*, i16*, i32, i8*, i32, i8)*
+  %167 = call i32 %166(%System.Text.Encoder addrspace(1)* %162, i16* %163, i32 %144, i8* %164, i32 %150, i8 %165)
+  store i32 %167, i32* %loc3
+  br label %168
+
+; <label>:168                                     ; preds = %154
+  %169 = load i32, i32* %loc3
+  ret i32 %169
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %110
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %119
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange18:                           ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
 Successfully read EncoderNLS.GetBytes
 
@@ -15079,22 +17356,22 @@ entry:
   %40 = load i8, i8* %arg5
   %41 = zext i8 %40 to i32
   %42 = trunc i32 %41 to i8
-  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %39, null
-  br i1 %NullCheck, label %43, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderNLS addrspace(1)* %39, null
+  br i1 %NullCheck, label %ThrowNullRef, label %43
 
 ; <label>:43                                      ; preds = %38
   %44 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
   store i8 %42, i8 addrspace(1)* %44
   %45 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %45, null
-  br i1 %NullCheck2, label %46, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.EncoderNLS addrspace(1)* %45, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %46
 
 ; <label>:46                                      ; preds = %43
   %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %45, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %47
   %48 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.EncoderNLS addrspace(1)* %48, null
-  br i1 %NullCheck4, label %49, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.EncoderNLS addrspace(1)* %48, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %49
 
 ; <label>:49                                      ; preds = %46
   %50 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %48, i32 0, i32 3
@@ -15105,8 +17382,8 @@ entry:
   %55 = load i32, i32* %arg4
   %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck6, label %58, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
   %59 = load i64, i64 addrspace(1)* %57
@@ -15124,15 +17401,15 @@ ThrowNullRef:                                     ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %43
+ThrowNullRef2:                                    ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %46
+ThrowNullRef4:                                    ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %49
+ThrowNullRef6:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -15160,8 +17437,8 @@ entry:
   %4 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0 to %System.IO.ConsoleStream addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*)(%System.IO.ConsoleStream addrspace(1)* %4, %"System.Byte[]" addrspace(1)* %1, i32 %2, i32 %3)
   %5 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
@@ -15246,8 +17523,8 @@ entry:
 
 ; <label>:22                                      ; preds = %8
   %23 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %23, null
-  br i1 %NullCheck, label %24, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Byte[]" addrspace(1)* %23, null
+  br i1 %NullCheck, label %ThrowNullRef, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
@@ -15269,8 +17546,8 @@ entry:
 
 ; <label>:36                                      ; preds = %24
   %37 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %37, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.ConsoleStream addrspace(1)* %37, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %37, i32 0, i32 4
@@ -15291,13 +17568,138 @@ ThrowNullRef:                                     ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %36
+ThrowNullRef2:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
-Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
+Successfully read WindowsConsoleStream.WriteFileNative
+
+define i32 @WindowsConsoleStream.WriteFileNative(i64 %param0, %"System.Byte[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i64
+  %arg1 = alloca %"System.Byte[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i8 addrspace(1)*
+  %loc2 = alloca %"System.Byte[]" addrspace(1)*
+  %loc3 = alloca i32
+  store i64 %param0, i64* %arg0
+  store %"System.Byte[]" addrspace(1)* %param1, %"System.Byte[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Byte[]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = zext i32 %3 to i64
+  %5 = icmp ne i64 %4, 0
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %1
+  ret i32 0
+
+; <label>:7                                       ; preds = %1
+  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  store %"System.Byte[]" addrspace(1)* %8, %"System.Byte[]" addrspace(1)** %loc2
+  %9 = icmp eq %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %9, label %18, label %10
+
+; <label>:10                                      ; preds = %7
+  %11 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc2
+  %NullCheck1 = icmp eq %"System.Byte[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %11, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp ne i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %7, %12
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc1
+  br label %27
+
+; <label>:19                                      ; preds = %12
+  %20 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc2
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %20, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %BoundsCheck = icmp uge i64 0, %24
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %25
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %20, i32 0, i32 3, i32 0
+  store i8 addrspace(1)* %26, i8 addrspace(1)** %loc1
+  br label %27
+
+; <label>:27                                      ; preds = %18, %25
+  %28 = load i64, i64* %arg0
+  %29 = load i8 addrspace(1)*, i8 addrspace(1)** %loc1
+  %30 = ptrtoint i8 addrspace(1)* %29 to i64
+  %31 = load i32, i32* %arg2
+  %32 = sext i32 %31 to i64
+  %33 = add i64 %30, %32
+  %34 = load i32, i32* %arg3
+  %35 = addrspacecast i32* %loc3 to i32 addrspace(1)*
+  %36 = inttoptr i64 %33 to i8*
+  %37 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i8*, i32, i32 addrspace(1)*, i64)*)(i64 %28, i8* %36, i32 %34, i32 addrspace(1)* %35, i64 0)
+  %38 = icmp ugt i32 %37, 0
+  %39 = sext i1 %38 to i32
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc1
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %42, label %41
+
+; <label>:41                                      ; preds = %27
+  ret i32 0
+
+; <label>:42                                      ; preds = %27
+  %43 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  store i32 %43, i32* %loc0
+  %44 = load i32, i32* %loc0
+  %45 = icmp eq i32 %44, 232
+  br i1 %45, label %49, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = load i32, i32* %loc0
+  %48 = icmp ne i32 %47, 109
+  br i1 %48, label %50, label %49
+
+; <label>:49                                      ; preds = %42, %46
+  ret i32 0
+
+; <label>:50                                      ; preds = %46
+  %51 = load i32, i32* %loc0
+  ret i32 %51
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
 Successfully read WindowsConsoleStream.Flush
 
@@ -15306,8 +17708,8 @@ entry:
   %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
   store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
@@ -15342,8 +17744,8 @@ entry:
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
   %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load i64, i64 addrspace(1)* %1
@@ -15382,15 +17784,15 @@ entry:
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.TextWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
   %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %3, align 8
   %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
   %7 = load i64, i64 addrspace(1)* %5
@@ -15408,7 +17810,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -15437,8 +17839,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %4)
   store i32 0, i32* %loc0
   %5 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Char[]" addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
@@ -15450,15 +17852,15 @@ entry:
 
 ; <label>:11                                      ; preds = %69
   %12 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %12, i32 0, i32 9
   %15 = load i32, i32 addrspace(1)* %14, align 8
   %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.IO.StreamWriter addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %16, i32 0, i32 10
@@ -15473,15 +17875,15 @@ entry:
 
 ; <label>:23                                      ; preds = %17, %21
   %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %24, null
-  br i1 %NullCheck8, label %25, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %24, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 10
   %27 = load i32, i32 addrspace(1)* %26, align 8
   %28 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %28, null
-  br i1 %NullCheck10, label %29, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.StreamWriter addrspace(1)* %28, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %28, i32 0, i32 9
@@ -15503,15 +17905,15 @@ entry:
   %40 = load i32, i32* %loc0
   %41 = mul i32 %40, 2
   %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
-  br i1 %NullCheck12, label %43, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %43
 
 ; <label>:43                                      ; preds = %38
   %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 7
   %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %44, align 8
   %46 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %46, null
-  br i1 %NullCheck14, label %47, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.IO.StreamWriter addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %47
 
 ; <label>:47                                      ; preds = %43
   %48 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %46, i32 0, i32 9
@@ -15523,16 +17925,16 @@ entry:
   %54 = bitcast %"System.Char[]" addrspace(1)* %45 to %System.Array addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %53, i32 %41, %System.Array addrspace(1)* %54, i32 %50, i32 %52)
   %55 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
-  br i1 %NullCheck16, label %56, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %56
 
 ; <label>:56                                      ; preds = %47
   %57 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
   %58 = load i32, i32 addrspace(1)* %57, align 8
   %59 = load i32, i32* %loc2
   %60 = add i32 %58, %59
-  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
-  br i1 %NullCheck18, label %61, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %61
 
 ; <label>:61                                      ; preds = %56
   %62 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
@@ -15554,8 +17956,8 @@ entry:
 
 ; <label>:72                                      ; preds = %69
   %73 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %73, null
-  br i1 %NullCheck2, label %74, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %73, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %74
 
 ; <label>:74                                      ; preds = %72
   %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %73, i32 0, i32 11
@@ -15576,39 +17978,39 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %72
+ThrowNullRef2:                                    ; preds = %72
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %23
+ThrowNullRef8:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef10:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %43
+ThrowNullRef14:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %47
+ThrowNullRef16:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %56
+ThrowNullRef18:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -15627,8 +18029,8 @@ entry:
   %1 = load i64, i64* %arg0
   %2 = trunc i64 %1 to i32
   store i32 %2, i32* %loc0
-  %NullCheck = icmp ne i32 addrspace(1)* %0, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i32 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   store i32 %2, i32 addrspace(1)* %0, align 8
@@ -15650,8 +18052,8 @@ entry:
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load i32, i32* %arg0
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -15683,8 +18085,8 @@ entry:
   store i32 %param1, i32* %arg1
   store i8 0, i8* %loc1
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
@@ -15694,16 +18096,16 @@ entry:
   %5 = addrspacecast i8* %loc1 to i8 addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %4, i8 addrspace(1)* %5)
   %6 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.SyncTextWriter addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
   %10 = load i32, i32* %arg1
   %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
   %13 = load i64, i64 addrspace(1)* %11
@@ -15738,11 +18140,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -15759,8 +18161,8 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load i32, i32* %arg1
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -15774,8 +18176,8 @@ entry:
   call void %11(%System.IO.TextWriter addrspace(1)* %0, i32 %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
   %15 = load i64, i64 addrspace(1)* %13
@@ -15793,7 +18195,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -15811,8 +18213,8 @@ entry:
   %1 = addrspacecast i32* %arg1 to i32 addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -15827,8 +18229,8 @@ entry:
   %14 = bitcast i32 addrspace(1)* %1 to %System.Int32 addrspace(1)*
   %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Int32 addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Int32 addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
   %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
   %18 = load i64, i64 addrspace(1)* %16
@@ -15846,7 +18248,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -15862,8 +18264,8 @@ entry:
   store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
   %0 = load %System.Int32 addrspace(1)*, %System.Int32 addrspace(1)** %this
   %1 = bitcast %System.Int32 addrspace(1)* %0 to i32 addrspace(1)*
-  %NullCheck = icmp ne i32 addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq i32 addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load i32, i32 addrspace(1)* %1, align 8
@@ -15891,8 +18293,8 @@ entry:
   %1 = load i64, i64* %arg0
   %2 = trunc i64 %1 to i32
   store i32 %2, i32* %loc0
-  %NullCheck = icmp ne i32 addrspace(1)* %0, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i32 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   store i32 %2, i32 addrspace(1)* %0, align 8
@@ -15921,8 +18323,8 @@ entry:
   %4 = trunc i32 %3 to i16
   store i16 %4, i16* %loc0
   %5 = trunc i32 %3 to i16
-  %NullCheck = icmp ne i16 addrspace(1)* %0, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq i16 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   store i16 %5, i16 addrspace(1)* %0, align 8
@@ -15953,8 +18355,8 @@ entry:
   %4 = trunc i32 %3 to i16
   store i16 %4, i16* %loc0
   %5 = trunc i32 %3 to i16
-  %NullCheck = icmp ne i16 addrspace(1)* %0, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq i16 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   store i16 %5, i16 addrspace(1)* %0, align 8
@@ -15985,8 +18387,8 @@ entry:
   %4 = trunc i32 %3 to i8
   store i8 %4, i8* %loc0
   %5 = trunc i32 %3 to i8
-  %NullCheck = icmp ne i8 addrspace(1)* %0, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   store i8 %5, i8 addrspace(1)* %0, align 8
@@ -16017,8 +18419,8 @@ entry:
   %4 = trunc i32 %3 to i8
   store i8 %4, i8* %loc0
   %5 = trunc i32 %3 to i8
-  %NullCheck = icmp ne i8 addrspace(1)* %0, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   store i8 %5, i8 addrspace(1)* %0, align 8

--- a/test/BaseLine/JIT/CodeGenBringUpTests/LongArgsAndReturn.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/LongArgsAndReturn.error.txt
@@ -25,8 +25,8 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
@@ -40,8 +40,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
   %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
@@ -75,7 +75,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -90,8 +90,8 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %NullCheck = icmp ne i8 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = load i8, i8 addrspace(1)* %0, align 8
@@ -125,8 +125,8 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
@@ -159,8 +159,8 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -184,8 +184,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
   store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
@@ -195,8 +195,8 @@ entry:
 ; <label>:4                                       ; preds = %1
   %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
   %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
@@ -206,8 +206,8 @@ entry:
   %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
@@ -221,14 +221,14 @@ entry:
 
 ; <label>:17                                      ; preds = %14
   %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
   %21 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
@@ -238,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -249,8 +249,8 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
@@ -261,27 +261,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %30
+ThrowNullRef10:                                   ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -301,7 +301,89 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
-Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
+Successfully read AppDomainSetup.GetUnsecureApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.GetUnsecureApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %NullCheck = icmp eq %"System.String[]" addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %BoundsCheck = icmp uge i64 0, %5
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %6
+
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 3, i32 0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
+  ret %System.String addrspace(1)* %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_Value using LLILCJit
+Successfully read AppDomainSetup.get_Value
+
+define %"System.String[]" addrspace(1)* @AppDomainSetup.get_Value(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.String[]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 18)
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.String[]" addrspace(1)* addrspace(1)*, %"System.String[]" addrspace(1)*)*)(%"System.String[]" addrspace(1)* addrspace(1)* %9, %"System.String[]" addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %11, i32 0, i32 1
+  %14 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %13, align 8
+  ret %"System.String[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -319,8 +401,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -368,16 +450,16 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
   %5 = load i32, i32 addrspace(1)* %4
   %6 = sub i32 %5, 1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -389,7 +471,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -421,8 +503,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
@@ -456,8 +538,8 @@ entry:
 ; <label>:27                                      ; preds = %19
   %28 = load i32, i32* %arg1
   %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
-  br i1 %NullCheck2, label %30, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %29, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %30
 
 ; <label>:30                                      ; preds = %27
   %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
@@ -493,8 +575,8 @@ entry:
 ; <label>:49                                      ; preds = %46
   %50 = load i32, i32* %arg2
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck4, label %52, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
@@ -517,11 +599,11 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %27
+ThrowNullRef2:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %49
+ThrowNullRef4:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -544,16 +626,16 @@ entry:
   %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %0)
   store %System.String addrspace(1)* %1, %System.String addrspace(1)** %loc0
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 2
   %5 = bitcast [0 x i16] addrspace(1)* %4 to i16 addrspace(1)*
   store i16 addrspace(1)* %5, i16 addrspace(1)** %loc1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %3
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2
@@ -580,7 +662,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -691,15 +773,15 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %NullCheck132 = icmp ne i8* %21, null
-  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+  %NullCheck131 = icmp eq i8* %21, null
+  br i1 %NullCheck131, label %ThrowNullRef132, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = load i8, i8* %21, align 8
   %24 = zext i8 %23 to i32
   %25 = trunc i32 %24 to i8
-  %NullCheck134 = icmp ne i8* %20, null
-  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+  %NullCheck133 = icmp eq i8* %20, null
+  br i1 %NullCheck133, label %ThrowNullRef134, label %26
 
 ; <label>:26                                      ; preds = %22
   store i8 %25, i8* %20, align 8
@@ -709,16 +791,16 @@ entry:
   %28 = load i8*, i8** %arg0
   %29 = load i8*, i8** %arg1
   %30 = bitcast i8* %29 to i16*
-  %NullCheck128 = icmp ne i16* %30, null
-  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+  %NullCheck127 = icmp eq i16* %30, null
+  br i1 %NullCheck127, label %ThrowNullRef128, label %31
 
 ; <label>:31                                      ; preds = %27
   %32 = load i16, i16* %30, align 8
   %33 = sext i16 %32 to i32
   %34 = bitcast i8* %28 to i16*
   %35 = trunc i32 %33 to i16
-  %NullCheck130 = icmp ne i16* %34, null
-  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+  %NullCheck129 = icmp eq i16* %34, null
+  br i1 %NullCheck129, label %ThrowNullRef130, label %36
 
 ; <label>:36                                      ; preds = %31
   store i16 %35, i16* %34, align 8
@@ -728,16 +810,16 @@ entry:
   %38 = load i8*, i8** %arg0
   %39 = load i8*, i8** %arg1
   %40 = bitcast i8* %39 to i16*
-  %NullCheck120 = icmp ne i16* %40, null
-  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+  %NullCheck119 = icmp eq i16* %40, null
+  br i1 %NullCheck119, label %ThrowNullRef120, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i16, i16* %40, align 8
   %43 = sext i16 %42 to i32
   %44 = bitcast i8* %38 to i16*
   %45 = trunc i32 %43 to i16
-  %NullCheck122 = icmp ne i16* %44, null
-  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+  %NullCheck121 = icmp eq i16* %44, null
+  br i1 %NullCheck121, label %ThrowNullRef122, label %46
 
 ; <label>:46                                      ; preds = %41
   store i16 %45, i16* %44, align 8
@@ -745,15 +827,15 @@ entry:
   %48 = getelementptr inbounds i8, i8* %47, i64 2
   %49 = load i8*, i8** %arg1
   %50 = getelementptr inbounds i8, i8* %49, i64 2
-  %NullCheck124 = icmp ne i8* %50, null
-  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+  %NullCheck123 = icmp eq i8* %50, null
+  br i1 %NullCheck123, label %ThrowNullRef124, label %51
 
 ; <label>:51                                      ; preds = %46
   %52 = load i8, i8* %50, align 8
   %53 = zext i8 %52 to i32
   %54 = trunc i32 %53 to i8
-  %NullCheck126 = icmp ne i8* %48, null
-  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+  %NullCheck125 = icmp eq i8* %48, null
+  br i1 %NullCheck125, label %ThrowNullRef126, label %55
 
 ; <label>:55                                      ; preds = %51
   store i8 %54, i8* %48, align 8
@@ -763,14 +845,14 @@ entry:
   %57 = load i8*, i8** %arg0
   %58 = load i8*, i8** %arg1
   %59 = bitcast i8* %58 to i32*
-  %NullCheck116 = icmp ne i32* %59, null
-  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+  %NullCheck115 = icmp eq i32* %59, null
+  br i1 %NullCheck115, label %ThrowNullRef116, label %60
 
 ; <label>:60                                      ; preds = %56
   %61 = load i32, i32* %59, align 8
   %62 = bitcast i8* %57 to i32*
-  %NullCheck118 = icmp ne i32* %62, null
-  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+  %NullCheck117 = icmp eq i32* %62, null
+  br i1 %NullCheck117, label %ThrowNullRef118, label %63
 
 ; <label>:63                                      ; preds = %60
   store i32 %61, i32* %62, align 8
@@ -780,14 +862,14 @@ entry:
   %65 = load i8*, i8** %arg0
   %66 = load i8*, i8** %arg1
   %67 = bitcast i8* %66 to i32*
-  %NullCheck108 = icmp ne i32* %67, null
-  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+  %NullCheck107 = icmp eq i32* %67, null
+  br i1 %NullCheck107, label %ThrowNullRef108, label %68
 
 ; <label>:68                                      ; preds = %64
   %69 = load i32, i32* %67, align 8
   %70 = bitcast i8* %65 to i32*
-  %NullCheck110 = icmp ne i32* %70, null
-  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+  %NullCheck109 = icmp eq i32* %70, null
+  br i1 %NullCheck109, label %ThrowNullRef110, label %71
 
 ; <label>:71                                      ; preds = %68
   store i32 %69, i32* %70, align 8
@@ -795,15 +877,15 @@ entry:
   %73 = getelementptr inbounds i8, i8* %72, i64 4
   %74 = load i8*, i8** %arg1
   %75 = getelementptr inbounds i8, i8* %74, i64 4
-  %NullCheck112 = icmp ne i8* %75, null
-  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+  %NullCheck111 = icmp eq i8* %75, null
+  br i1 %NullCheck111, label %ThrowNullRef112, label %76
 
 ; <label>:76                                      ; preds = %71
   %77 = load i8, i8* %75, align 8
   %78 = zext i8 %77 to i32
   %79 = trunc i32 %78 to i8
-  %NullCheck114 = icmp ne i8* %73, null
-  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+  %NullCheck113 = icmp eq i8* %73, null
+  br i1 %NullCheck113, label %ThrowNullRef114, label %80
 
 ; <label>:80                                      ; preds = %76
   store i8 %79, i8* %73, align 8
@@ -813,14 +895,14 @@ entry:
   %82 = load i8*, i8** %arg0
   %83 = load i8*, i8** %arg1
   %84 = bitcast i8* %83 to i32*
-  %NullCheck100 = icmp ne i32* %84, null
-  br i1 %NullCheck100, label %85, label %ThrowNullRef99
+  %NullCheck99 = icmp eq i32* %84, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %85
 
 ; <label>:85                                      ; preds = %81
   %86 = load i32, i32* %84, align 8
   %87 = bitcast i8* %82 to i32*
-  %NullCheck102 = icmp ne i32* %87, null
-  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+  %NullCheck101 = icmp eq i32* %87, null
+  br i1 %NullCheck101, label %ThrowNullRef102, label %88
 
 ; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
@@ -829,16 +911,16 @@ entry:
   %91 = load i8*, i8** %arg1
   %92 = getelementptr inbounds i8, i8* %91, i64 4
   %93 = bitcast i8* %92 to i16*
-  %NullCheck104 = icmp ne i16* %93, null
-  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+  %NullCheck103 = icmp eq i16* %93, null
+  br i1 %NullCheck103, label %ThrowNullRef104, label %94
 
 ; <label>:94                                      ; preds = %88
   %95 = load i16, i16* %93, align 8
   %96 = sext i16 %95 to i32
   %97 = bitcast i8* %90 to i16*
   %98 = trunc i32 %96 to i16
-  %NullCheck106 = icmp ne i16* %97, null
-  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+  %NullCheck105 = icmp eq i16* %97, null
+  br i1 %NullCheck105, label %ThrowNullRef106, label %99
 
 ; <label>:99                                      ; preds = %94
   store i16 %98, i16* %97, align 8
@@ -848,14 +930,14 @@ entry:
   %101 = load i8*, i8** %arg0
   %102 = load i8*, i8** %arg1
   %103 = bitcast i8* %102 to i32*
-  %NullCheck88 = icmp ne i32* %103, null
-  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+  %NullCheck87 = icmp eq i32* %103, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %104
 
 ; <label>:104                                     ; preds = %100
   %105 = load i32, i32* %103, align 8
   %106 = bitcast i8* %101 to i32*
-  %NullCheck90 = icmp ne i32* %106, null
-  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+  %NullCheck89 = icmp eq i32* %106, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %107
 
 ; <label>:107                                     ; preds = %104
   store i32 %105, i32* %106, align 8
@@ -864,16 +946,16 @@ entry:
   %110 = load i8*, i8** %arg1
   %111 = getelementptr inbounds i8, i8* %110, i64 4
   %112 = bitcast i8* %111 to i16*
-  %NullCheck92 = icmp ne i16* %112, null
-  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+  %NullCheck91 = icmp eq i16* %112, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %113
 
 ; <label>:113                                     ; preds = %107
   %114 = load i16, i16* %112, align 8
   %115 = sext i16 %114 to i32
   %116 = bitcast i8* %109 to i16*
   %117 = trunc i32 %115 to i16
-  %NullCheck94 = icmp ne i16* %116, null
-  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+  %NullCheck93 = icmp eq i16* %116, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %118
 
 ; <label>:118                                     ; preds = %113
   store i16 %117, i16* %116, align 8
@@ -881,15 +963,15 @@ entry:
   %120 = getelementptr inbounds i8, i8* %119, i64 6
   %121 = load i8*, i8** %arg1
   %122 = getelementptr inbounds i8, i8* %121, i64 6
-  %NullCheck96 = icmp ne i8* %122, null
-  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+  %NullCheck95 = icmp eq i8* %122, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %123
 
 ; <label>:123                                     ; preds = %118
   %124 = load i8, i8* %122, align 8
   %125 = zext i8 %124 to i32
   %126 = trunc i32 %125 to i8
-  %NullCheck98 = icmp ne i8* %120, null
-  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+  %NullCheck97 = icmp eq i8* %120, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %127
 
 ; <label>:127                                     ; preds = %123
   store i8 %126, i8* %120, align 8
@@ -899,14 +981,14 @@ entry:
   %129 = load i8*, i8** %arg0
   %130 = load i8*, i8** %arg1
   %131 = bitcast i8* %130 to i64*
-  %NullCheck84 = icmp ne i64* %131, null
-  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+  %NullCheck83 = icmp eq i64* %131, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %132
 
 ; <label>:132                                     ; preds = %128
   %133 = load i64, i64* %131, align 8
   %134 = bitcast i8* %129 to i64*
-  %NullCheck86 = icmp ne i64* %134, null
-  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+  %NullCheck85 = icmp eq i64* %134, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %135
 
 ; <label>:135                                     ; preds = %132
   store i64 %133, i64* %134, align 8
@@ -916,14 +998,14 @@ entry:
   %137 = load i8*, i8** %arg0
   %138 = load i8*, i8** %arg1
   %139 = bitcast i8* %138 to i64*
-  %NullCheck76 = icmp ne i64* %139, null
-  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+  %NullCheck75 = icmp eq i64* %139, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %140
 
 ; <label>:140                                     ; preds = %136
   %141 = load i64, i64* %139, align 8
   %142 = bitcast i8* %137 to i64*
-  %NullCheck78 = icmp ne i64* %142, null
-  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+  %NullCheck77 = icmp eq i64* %142, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %143
 
 ; <label>:143                                     ; preds = %140
   store i64 %141, i64* %142, align 8
@@ -931,15 +1013,15 @@ entry:
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %NullCheck80 = icmp ne i8* %147, null
-  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+  %NullCheck79 = icmp eq i8* %147, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %148
 
 ; <label>:148                                     ; preds = %143
   %149 = load i8, i8* %147, align 8
   %150 = zext i8 %149 to i32
   %151 = trunc i32 %150 to i8
-  %NullCheck82 = icmp ne i8* %145, null
-  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+  %NullCheck81 = icmp eq i8* %145, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %152
 
 ; <label>:152                                     ; preds = %148
   store i8 %151, i8* %145, align 8
@@ -949,14 +1031,14 @@ entry:
   %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
   %156 = bitcast i8* %155 to i64*
-  %NullCheck68 = icmp ne i64* %156, null
-  br i1 %NullCheck68, label %157, label %ThrowNullRef67
+  %NullCheck67 = icmp eq i64* %156, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %157
 
 ; <label>:157                                     ; preds = %153
   %158 = load i64, i64* %156, align 8
   %159 = bitcast i8* %154 to i64*
-  %NullCheck70 = icmp ne i64* %159, null
-  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+  %NullCheck69 = icmp eq i64* %159, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %160
 
 ; <label>:160                                     ; preds = %157
   store i64 %158, i64* %159, align 8
@@ -965,16 +1047,16 @@ entry:
   %163 = load i8*, i8** %arg1
   %164 = getelementptr inbounds i8, i8* %163, i64 8
   %165 = bitcast i8* %164 to i16*
-  %NullCheck72 = icmp ne i16* %165, null
-  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+  %NullCheck71 = icmp eq i16* %165, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %166
 
 ; <label>:166                                     ; preds = %160
   %167 = load i16, i16* %165, align 8
   %168 = sext i16 %167 to i32
   %169 = bitcast i8* %162 to i16*
   %170 = trunc i32 %168 to i16
-  %NullCheck74 = icmp ne i16* %169, null
-  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+  %NullCheck73 = icmp eq i16* %169, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %171
 
 ; <label>:171                                     ; preds = %166
   store i16 %170, i16* %169, align 8
@@ -984,14 +1066,14 @@ entry:
   %173 = load i8*, i8** %arg0
   %174 = load i8*, i8** %arg1
   %175 = bitcast i8* %174 to i64*
-  %NullCheck56 = icmp ne i64* %175, null
-  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+  %NullCheck55 = icmp eq i64* %175, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %176
 
 ; <label>:176                                     ; preds = %172
   %177 = load i64, i64* %175, align 8
   %178 = bitcast i8* %173 to i64*
-  %NullCheck58 = icmp ne i64* %178, null
-  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+  %NullCheck57 = icmp eq i64* %178, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %179
 
 ; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
@@ -1000,16 +1082,16 @@ entry:
   %182 = load i8*, i8** %arg1
   %183 = getelementptr inbounds i8, i8* %182, i64 8
   %184 = bitcast i8* %183 to i16*
-  %NullCheck60 = icmp ne i16* %184, null
-  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+  %NullCheck59 = icmp eq i16* %184, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %185
 
 ; <label>:185                                     ; preds = %179
   %186 = load i16, i16* %184, align 8
   %187 = sext i16 %186 to i32
   %188 = bitcast i8* %181 to i16*
   %189 = trunc i32 %187 to i16
-  %NullCheck62 = icmp ne i16* %188, null
-  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+  %NullCheck61 = icmp eq i16* %188, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %190
 
 ; <label>:190                                     ; preds = %185
   store i16 %189, i16* %188, align 8
@@ -1017,15 +1099,15 @@ entry:
   %192 = getelementptr inbounds i8, i8* %191, i64 10
   %193 = load i8*, i8** %arg1
   %194 = getelementptr inbounds i8, i8* %193, i64 10
-  %NullCheck64 = icmp ne i8* %194, null
-  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+  %NullCheck63 = icmp eq i8* %194, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %195
 
 ; <label>:195                                     ; preds = %190
   %196 = load i8, i8* %194, align 8
   %197 = zext i8 %196 to i32
   %198 = trunc i32 %197 to i8
-  %NullCheck66 = icmp ne i8* %192, null
-  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+  %NullCheck65 = icmp eq i8* %192, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %199
 
 ; <label>:199                                     ; preds = %195
   store i8 %198, i8* %192, align 8
@@ -1035,14 +1117,14 @@ entry:
   %201 = load i8*, i8** %arg0
   %202 = load i8*, i8** %arg1
   %203 = bitcast i8* %202 to i64*
-  %NullCheck48 = icmp ne i64* %203, null
-  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+  %NullCheck47 = icmp eq i64* %203, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %204
 
 ; <label>:204                                     ; preds = %200
   %205 = load i64, i64* %203, align 8
   %206 = bitcast i8* %201 to i64*
-  %NullCheck50 = icmp ne i64* %206, null
-  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+  %NullCheck49 = icmp eq i64* %206, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %207
 
 ; <label>:207                                     ; preds = %204
   store i64 %205, i64* %206, align 8
@@ -1051,14 +1133,14 @@ entry:
   %210 = load i8*, i8** %arg1
   %211 = getelementptr inbounds i8, i8* %210, i64 8
   %212 = bitcast i8* %211 to i32*
-  %NullCheck52 = icmp ne i32* %212, null
-  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+  %NullCheck51 = icmp eq i32* %212, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %213
 
 ; <label>:213                                     ; preds = %207
   %214 = load i32, i32* %212, align 8
   %215 = bitcast i8* %209 to i32*
-  %NullCheck54 = icmp ne i32* %215, null
-  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+  %NullCheck53 = icmp eq i32* %215, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %216
 
 ; <label>:216                                     ; preds = %213
   store i32 %214, i32* %215, align 8
@@ -1068,14 +1150,14 @@ entry:
   %218 = load i8*, i8** %arg0
   %219 = load i8*, i8** %arg1
   %220 = bitcast i8* %219 to i64*
-  %NullCheck36 = icmp ne i64* %220, null
-  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64* %220, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %221
 
 ; <label>:221                                     ; preds = %217
   %222 = load i64, i64* %220, align 8
   %223 = bitcast i8* %218 to i64*
-  %NullCheck38 = icmp ne i64* %223, null
-  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+  %NullCheck37 = icmp eq i64* %223, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %224
 
 ; <label>:224                                     ; preds = %221
   store i64 %222, i64* %223, align 8
@@ -1084,14 +1166,14 @@ entry:
   %227 = load i8*, i8** %arg1
   %228 = getelementptr inbounds i8, i8* %227, i64 8
   %229 = bitcast i8* %228 to i32*
-  %NullCheck40 = icmp ne i32* %229, null
-  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i32* %229, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %230
 
 ; <label>:230                                     ; preds = %224
   %231 = load i32, i32* %229, align 8
   %232 = bitcast i8* %226 to i32*
-  %NullCheck42 = icmp ne i32* %232, null
-  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+  %NullCheck41 = icmp eq i32* %232, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %233
 
 ; <label>:233                                     ; preds = %230
   store i32 %231, i32* %232, align 8
@@ -1099,15 +1181,15 @@ entry:
   %235 = getelementptr inbounds i8, i8* %234, i64 12
   %236 = load i8*, i8** %arg1
   %237 = getelementptr inbounds i8, i8* %236, i64 12
-  %NullCheck44 = icmp ne i8* %237, null
-  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i8* %237, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %238
 
 ; <label>:238                                     ; preds = %233
   %239 = load i8, i8* %237, align 8
   %240 = zext i8 %239 to i32
   %241 = trunc i32 %240 to i8
-  %NullCheck46 = icmp ne i8* %235, null
-  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+  %NullCheck45 = icmp eq i8* %235, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %242
 
 ; <label>:242                                     ; preds = %238
   store i8 %241, i8* %235, align 8
@@ -1117,14 +1199,14 @@ entry:
   %244 = load i8*, i8** %arg0
   %245 = load i8*, i8** %arg1
   %246 = bitcast i8* %245 to i64*
-  %NullCheck24 = icmp ne i64* %246, null
-  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64* %246, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %247
 
 ; <label>:247                                     ; preds = %243
   %248 = load i64, i64* %246, align 8
   %249 = bitcast i8* %244 to i64*
-  %NullCheck26 = icmp ne i64* %249, null
-  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64* %249, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %250
 
 ; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
@@ -1133,14 +1215,14 @@ entry:
   %253 = load i8*, i8** %arg1
   %254 = getelementptr inbounds i8, i8* %253, i64 8
   %255 = bitcast i8* %254 to i32*
-  %NullCheck28 = icmp ne i32* %255, null
-  br i1 %NullCheck28, label %256, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i32* %255, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %256
 
 ; <label>:256                                     ; preds = %250
   %257 = load i32, i32* %255, align 8
   %258 = bitcast i8* %252 to i32*
-  %NullCheck30 = icmp ne i32* %258, null
-  br i1 %NullCheck30, label %259, label %ThrowNullRef29
+  %NullCheck29 = icmp eq i32* %258, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %259
 
 ; <label>:259                                     ; preds = %256
   store i32 %257, i32* %258, align 8
@@ -1149,16 +1231,16 @@ entry:
   %262 = load i8*, i8** %arg1
   %263 = getelementptr inbounds i8, i8* %262, i64 12
   %264 = bitcast i8* %263 to i16*
-  %NullCheck32 = icmp ne i16* %264, null
-  br i1 %NullCheck32, label %265, label %ThrowNullRef31
+  %NullCheck31 = icmp eq i16* %264, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %265
 
 ; <label>:265                                     ; preds = %259
   %266 = load i16, i16* %264, align 8
   %267 = sext i16 %266 to i32
   %268 = bitcast i8* %261 to i16*
   %269 = trunc i32 %267 to i16
-  %NullCheck34 = icmp ne i16* %268, null
-  br i1 %NullCheck34, label %270, label %ThrowNullRef33
+  %NullCheck33 = icmp eq i16* %268, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %270
 
 ; <label>:270                                     ; preds = %265
   store i16 %269, i16* %268, align 8
@@ -1168,14 +1250,14 @@ entry:
   %272 = load i8*, i8** %arg0
   %273 = load i8*, i8** %arg1
   %274 = bitcast i8* %273 to i64*
-  %NullCheck8 = icmp ne i64* %274, null
-  br i1 %NullCheck8, label %275, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64* %274, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %275
 
 ; <label>:275                                     ; preds = %271
   %276 = load i64, i64* %274, align 8
   %277 = bitcast i8* %272 to i64*
-  %NullCheck10 = icmp ne i64* %277, null
-  br i1 %NullCheck10, label %278, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %277, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %278
 
 ; <label>:278                                     ; preds = %275
   store i64 %276, i64* %277, align 8
@@ -1184,14 +1266,14 @@ entry:
   %281 = load i8*, i8** %arg1
   %282 = getelementptr inbounds i8, i8* %281, i64 8
   %283 = bitcast i8* %282 to i32*
-  %NullCheck12 = icmp ne i32* %283, null
-  br i1 %NullCheck12, label %284, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i32* %283, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %284
 
 ; <label>:284                                     ; preds = %278
   %285 = load i32, i32* %283, align 8
   %286 = bitcast i8* %280 to i32*
-  %NullCheck14 = icmp ne i32* %286, null
-  br i1 %NullCheck14, label %287, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i32* %286, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %287
 
 ; <label>:287                                     ; preds = %284
   store i32 %285, i32* %286, align 8
@@ -1200,16 +1282,16 @@ entry:
   %290 = load i8*, i8** %arg1
   %291 = getelementptr inbounds i8, i8* %290, i64 12
   %292 = bitcast i8* %291 to i16*
-  %NullCheck16 = icmp ne i16* %292, null
-  br i1 %NullCheck16, label %293, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i16* %292, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %293
 
 ; <label>:293                                     ; preds = %287
   %294 = load i16, i16* %292, align 8
   %295 = sext i16 %294 to i32
   %296 = bitcast i8* %289 to i16*
   %297 = trunc i32 %295 to i16
-  %NullCheck18 = icmp ne i16* %296, null
-  br i1 %NullCheck18, label %298, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i16* %296, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %298
 
 ; <label>:298                                     ; preds = %293
   store i16 %297, i16* %296, align 8
@@ -1217,15 +1299,15 @@ entry:
   %300 = getelementptr inbounds i8, i8* %299, i64 14
   %301 = load i8*, i8** %arg1
   %302 = getelementptr inbounds i8, i8* %301, i64 14
-  %NullCheck20 = icmp ne i8* %302, null
-  br i1 %NullCheck20, label %303, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i8* %302, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %303
 
 ; <label>:303                                     ; preds = %298
   %304 = load i8, i8* %302, align 8
   %305 = zext i8 %304 to i32
   %306 = trunc i32 %305 to i8
-  %NullCheck22 = icmp ne i8* %300, null
-  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i8* %300, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %307
 
 ; <label>:307                                     ; preds = %303
   store i8 %306, i8* %300, align 8
@@ -1235,14 +1317,14 @@ entry:
   %309 = load i8*, i8** %arg0
   %310 = load i8*, i8** %arg1
   %311 = bitcast i8* %310 to i64*
-  %NullCheck = icmp ne i64* %311, null
-  br i1 %NullCheck, label %312, label %ThrowNullRef
+  %NullCheck = icmp eq i64* %311, null
+  br i1 %NullCheck, label %ThrowNullRef, label %312
 
 ; <label>:312                                     ; preds = %308
   %313 = load i64, i64* %311, align 8
   %314 = bitcast i8* %309 to i64*
-  %NullCheck2 = icmp ne i64* %314, null
-  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64* %314, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %315
 
 ; <label>:315                                     ; preds = %312
   store i64 %313, i64* %314, align 8
@@ -1251,14 +1333,14 @@ entry:
   %318 = load i8*, i8** %arg1
   %319 = getelementptr inbounds i8, i8* %318, i64 8
   %320 = bitcast i8* %319 to i64*
-  %NullCheck4 = icmp ne i64* %320, null
-  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64* %320, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %321
 
 ; <label>:321                                     ; preds = %315
   %322 = load i64, i64* %320, align 8
   %323 = bitcast i8* %317 to i64*
-  %NullCheck6 = icmp ne i64* %323, null
-  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64* %323, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %324
 
 ; <label>:324                                     ; preds = %321
   store i64 %322, i64* %323, align 8
@@ -1286,15 +1368,15 @@ entry:
 ; <label>:338                                     ; preds = %333
   %339 = load i8*, i8** %arg0
   %340 = load i8*, i8** %arg1
-  %NullCheck136 = icmp ne i8* %340, null
-  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+  %NullCheck135 = icmp eq i8* %340, null
+  br i1 %NullCheck135, label %ThrowNullRef136, label %341
 
 ; <label>:341                                     ; preds = %338
   %342 = load i8, i8* %340, align 8
   %343 = zext i8 %342 to i32
   %344 = trunc i32 %343 to i8
-  %NullCheck138 = icmp ne i8* %339, null
-  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+  %NullCheck137 = icmp eq i8* %339, null
+  br i1 %NullCheck137, label %ThrowNullRef138, label %345
 
 ; <label>:345                                     ; preds = %341
   store i8 %344, i8* %339, align 8
@@ -1317,16 +1399,16 @@ entry:
   %357 = load i8*, i8** %arg0
   %358 = load i8*, i8** %arg1
   %359 = bitcast i8* %358 to i16*
-  %NullCheck140 = icmp ne i16* %359, null
-  br i1 %NullCheck140, label %360, label %ThrowNullRef139
+  %NullCheck139 = icmp eq i16* %359, null
+  br i1 %NullCheck139, label %ThrowNullRef140, label %360
 
 ; <label>:360                                     ; preds = %356
   %361 = load i16, i16* %359, align 8
   %362 = sext i16 %361 to i32
   %363 = bitcast i8* %357 to i16*
   %364 = trunc i32 %362 to i16
-  %NullCheck142 = icmp ne i16* %363, null
-  br i1 %NullCheck142, label %365, label %ThrowNullRef141
+  %NullCheck141 = icmp eq i16* %363, null
+  br i1 %NullCheck141, label %ThrowNullRef142, label %365
 
 ; <label>:365                                     ; preds = %360
   store i16 %364, i16* %363, align 8
@@ -1352,14 +1434,14 @@ entry:
   %378 = load i8*, i8** %arg0
   %379 = load i8*, i8** %arg1
   %380 = bitcast i8* %379 to i32*
-  %NullCheck144 = icmp ne i32* %380, null
-  br i1 %NullCheck144, label %381, label %ThrowNullRef143
+  %NullCheck143 = icmp eq i32* %380, null
+  br i1 %NullCheck143, label %ThrowNullRef144, label %381
 
 ; <label>:381                                     ; preds = %377
   %382 = load i32, i32* %380, align 8
   %383 = bitcast i8* %378 to i32*
-  %NullCheck146 = icmp ne i32* %383, null
-  br i1 %NullCheck146, label %384, label %ThrowNullRef145
+  %NullCheck145 = icmp eq i32* %383, null
+  br i1 %NullCheck145, label %ThrowNullRef146, label %384
 
 ; <label>:384                                     ; preds = %381
   store i32 %382, i32* %383, align 8
@@ -1384,14 +1466,14 @@ entry:
   %395 = load i8*, i8** %arg0
   %396 = load i8*, i8** %arg1
   %397 = bitcast i8* %396 to i64*
-  %NullCheck164 = icmp ne i64* %397, null
-  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+  %NullCheck163 = icmp eq i64* %397, null
+  br i1 %NullCheck163, label %ThrowNullRef164, label %398
 
 ; <label>:398                                     ; preds = %394
   %399 = load i64, i64* %397, align 8
   %400 = bitcast i8* %395 to i64*
-  %NullCheck166 = icmp ne i64* %400, null
-  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+  %NullCheck165 = icmp eq i64* %400, null
+  br i1 %NullCheck165, label %ThrowNullRef166, label %401
 
 ; <label>:401                                     ; preds = %398
   store i64 %399, i64* %400, align 8
@@ -1400,14 +1482,14 @@ entry:
   %404 = load i8*, i8** %arg1
   %405 = getelementptr inbounds i8, i8* %404, i64 8
   %406 = bitcast i8* %405 to i64*
-  %NullCheck168 = icmp ne i64* %406, null
-  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+  %NullCheck167 = icmp eq i64* %406, null
+  br i1 %NullCheck167, label %ThrowNullRef168, label %407
 
 ; <label>:407                                     ; preds = %401
   %408 = load i64, i64* %406, align 8
   %409 = bitcast i8* %403 to i64*
-  %NullCheck170 = icmp ne i64* %409, null
-  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+  %NullCheck169 = icmp eq i64* %409, null
+  br i1 %NullCheck169, label %ThrowNullRef170, label %410
 
 ; <label>:410                                     ; preds = %407
   store i64 %408, i64* %409, align 8
@@ -1437,14 +1519,14 @@ entry:
   %425 = load i8*, i8** %arg0
   %426 = load i8*, i8** %arg1
   %427 = bitcast i8* %426 to i64*
-  %NullCheck148 = icmp ne i64* %427, null
-  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+  %NullCheck147 = icmp eq i64* %427, null
+  br i1 %NullCheck147, label %ThrowNullRef148, label %428
 
 ; <label>:428                                     ; preds = %424
   %429 = load i64, i64* %427, align 8
   %430 = bitcast i8* %425 to i64*
-  %NullCheck150 = icmp ne i64* %430, null
-  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+  %NullCheck149 = icmp eq i64* %430, null
+  br i1 %NullCheck149, label %ThrowNullRef150, label %431
 
 ; <label>:431                                     ; preds = %428
   store i64 %429, i64* %430, align 8
@@ -1466,14 +1548,14 @@ entry:
   %441 = load i8*, i8** %arg0
   %442 = load i8*, i8** %arg1
   %443 = bitcast i8* %442 to i32*
-  %NullCheck152 = icmp ne i32* %443, null
-  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+  %NullCheck151 = icmp eq i32* %443, null
+  br i1 %NullCheck151, label %ThrowNullRef152, label %444
 
 ; <label>:444                                     ; preds = %440
   %445 = load i32, i32* %443, align 8
   %446 = bitcast i8* %441 to i32*
-  %NullCheck154 = icmp ne i32* %446, null
-  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+  %NullCheck153 = icmp eq i32* %446, null
+  br i1 %NullCheck153, label %ThrowNullRef154, label %447
 
 ; <label>:447                                     ; preds = %444
   store i32 %445, i32* %446, align 8
@@ -1495,16 +1577,16 @@ entry:
   %457 = load i8*, i8** %arg0
   %458 = load i8*, i8** %arg1
   %459 = bitcast i8* %458 to i16*
-  %NullCheck156 = icmp ne i16* %459, null
-  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+  %NullCheck155 = icmp eq i16* %459, null
+  br i1 %NullCheck155, label %ThrowNullRef156, label %460
 
 ; <label>:460                                     ; preds = %456
   %461 = load i16, i16* %459, align 8
   %462 = sext i16 %461 to i32
   %463 = bitcast i8* %457 to i16*
   %464 = trunc i32 %462 to i16
-  %NullCheck158 = icmp ne i16* %463, null
-  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+  %NullCheck157 = icmp eq i16* %463, null
+  br i1 %NullCheck157, label %ThrowNullRef158, label %465
 
 ; <label>:465                                     ; preds = %460
   store i16 %464, i16* %463, align 8
@@ -1525,15 +1607,15 @@ entry:
 ; <label>:474                                     ; preds = %470
   %475 = load i8*, i8** %arg0
   %476 = load i8*, i8** %arg1
-  %NullCheck160 = icmp ne i8* %476, null
-  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+  %NullCheck159 = icmp eq i8* %476, null
+  br i1 %NullCheck159, label %ThrowNullRef160, label %477
 
 ; <label>:477                                     ; preds = %474
   %478 = load i8, i8* %476, align 8
   %479 = zext i8 %478 to i32
   %480 = trunc i32 %479 to i8
-  %NullCheck162 = icmp ne i8* %475, null
-  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+  %NullCheck161 = icmp eq i8* %475, null
+  br i1 %NullCheck161, label %ThrowNullRef162, label %481
 
 ; <label>:481                                     ; preds = %477
   store i8 %480, i8* %475, align 8
@@ -1553,343 +1635,343 @@ ThrowNullRef:                                     ; preds = %308
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %312
+ThrowNullRef2:                                    ; preds = %312
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %315
+ThrowNullRef4:                                    ; preds = %315
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %321
+ThrowNullRef6:                                    ; preds = %321
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %271
+ThrowNullRef8:                                    ; preds = %271
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %275
+ThrowNullRef10:                                   ; preds = %275
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %278
+ThrowNullRef12:                                   ; preds = %278
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %284
+ThrowNullRef14:                                   ; preds = %284
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %287
+ThrowNullRef16:                                   ; preds = %287
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %293
+ThrowNullRef18:                                   ; preds = %293
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %298
+ThrowNullRef20:                                   ; preds = %298
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %303
+ThrowNullRef22:                                   ; preds = %303
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %243
+ThrowNullRef24:                                   ; preds = %243
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %247
+ThrowNullRef26:                                   ; preds = %247
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %250
+ThrowNullRef28:                                   ; preds = %250
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %256
+ThrowNullRef30:                                   ; preds = %256
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %259
+ThrowNullRef32:                                   ; preds = %259
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %265
+ThrowNullRef34:                                   ; preds = %265
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %217
+ThrowNullRef36:                                   ; preds = %217
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %221
+ThrowNullRef38:                                   ; preds = %221
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %224
+ThrowNullRef40:                                   ; preds = %224
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %230
+ThrowNullRef42:                                   ; preds = %230
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %233
+ThrowNullRef44:                                   ; preds = %233
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %238
+ThrowNullRef46:                                   ; preds = %238
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %200
+ThrowNullRef48:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %204
+ThrowNullRef50:                                   ; preds = %204
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %207
+ThrowNullRef52:                                   ; preds = %207
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %213
+ThrowNullRef54:                                   ; preds = %213
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %172
+ThrowNullRef56:                                   ; preds = %172
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %176
+ThrowNullRef58:                                   ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %179
+ThrowNullRef60:                                   ; preds = %179
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %185
+ThrowNullRef62:                                   ; preds = %185
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %190
+ThrowNullRef64:                                   ; preds = %190
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %195
+ThrowNullRef66:                                   ; preds = %195
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %153
+ThrowNullRef68:                                   ; preds = %153
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %157
+ThrowNullRef70:                                   ; preds = %157
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %160
+ThrowNullRef72:                                   ; preds = %160
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %166
+ThrowNullRef74:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %136
+ThrowNullRef76:                                   ; preds = %136
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %140
+ThrowNullRef78:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %143
+ThrowNullRef80:                                   ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %148
+ThrowNullRef82:                                   ; preds = %148
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %128
+ThrowNullRef84:                                   ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %132
+ThrowNullRef86:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %100
+ThrowNullRef88:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %104
+ThrowNullRef90:                                   ; preds = %104
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %107
+ThrowNullRef92:                                   ; preds = %107
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %113
+ThrowNullRef94:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %118
+ThrowNullRef96:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %123
+ThrowNullRef98:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %81
+ThrowNullRef100:                                  ; preds = %81
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef101:                                  ; preds = %85
+ThrowNullRef102:                                  ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef103:                                  ; preds = %88
+ThrowNullRef104:                                  ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef105:                                  ; preds = %94
+ThrowNullRef106:                                  ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef107:                                  ; preds = %64
+ThrowNullRef108:                                  ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef109:                                  ; preds = %68
+ThrowNullRef110:                                  ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef111:                                  ; preds = %71
+ThrowNullRef112:                                  ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef113:                                  ; preds = %76
+ThrowNullRef114:                                  ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef115:                                  ; preds = %56
+ThrowNullRef116:                                  ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef117:                                  ; preds = %60
+ThrowNullRef118:                                  ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef119:                                  ; preds = %37
+ThrowNullRef120:                                  ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef121:                                  ; preds = %41
+ThrowNullRef122:                                  ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef123:                                  ; preds = %46
+ThrowNullRef124:                                  ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef125:                                  ; preds = %51
+ThrowNullRef126:                                  ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef127:                                  ; preds = %27
+ThrowNullRef128:                                  ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef129:                                  ; preds = %31
+ThrowNullRef130:                                  ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef131:                                  ; preds = %19
+ThrowNullRef132:                                  ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef133:                                  ; preds = %22
+ThrowNullRef134:                                  ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef135:                                  ; preds = %338
+ThrowNullRef136:                                  ; preds = %338
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef137:                                  ; preds = %341
+ThrowNullRef138:                                  ; preds = %341
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef139:                                  ; preds = %356
+ThrowNullRef140:                                  ; preds = %356
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef141:                                  ; preds = %360
+ThrowNullRef142:                                  ; preds = %360
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef143:                                  ; preds = %377
+ThrowNullRef144:                                  ; preds = %377
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef145:                                  ; preds = %381
+ThrowNullRef146:                                  ; preds = %381
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef147:                                  ; preds = %424
+ThrowNullRef148:                                  ; preds = %424
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef149:                                  ; preds = %428
+ThrowNullRef150:                                  ; preds = %428
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef151:                                  ; preds = %440
+ThrowNullRef152:                                  ; preds = %440
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef153:                                  ; preds = %444
+ThrowNullRef154:                                  ; preds = %444
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef155:                                  ; preds = %456
+ThrowNullRef156:                                  ; preds = %456
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef157:                                  ; preds = %460
+ThrowNullRef158:                                  ; preds = %460
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef159:                                  ; preds = %474
+ThrowNullRef160:                                  ; preds = %474
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef161:                                  ; preds = %477
+ThrowNullRef162:                                  ; preds = %477
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef163:                                  ; preds = %394
+ThrowNullRef164:                                  ; preds = %394
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef165:                                  ; preds = %398
+ThrowNullRef166:                                  ; preds = %398
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef167:                                  ; preds = %401
+ThrowNullRef168:                                  ; preds = %401
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef169:                                  ; preds = %407
+ThrowNullRef170:                                  ; preds = %407
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1939,8 +2021,8 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
-  br i1 %NullCheck, label %22, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %ThrowNullRef, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
@@ -1948,8 +2030,8 @@ entry:
   store i32 %24, i32* %loc0
   %25 = load i32, i32* %loc0
   %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %26, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %27
 
 ; <label>:27                                      ; preds = %22
   %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
@@ -1971,7 +2053,7 @@ ThrowNullRef:                                     ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1989,8 +2071,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -2022,15 +2104,15 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2048,16 +2130,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
   %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
   store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %15
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
@@ -2072,8 +2154,8 @@ entry:
   %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
   %29 = ptrtoint i16 addrspace(1)* %28 to i64
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %19
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
@@ -2089,19 +2171,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2114,8 +2196,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
@@ -2128,7 +2210,7 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[loadElem]
+Failed to read AppDomain.PrepareDataForSetup[storeElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
@@ -2202,8 +2284,8 @@ entry:
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
-  br i1 %NullCheck24, label %27, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = load i64, i64 addrspace(1)* %26
@@ -2218,8 +2300,8 @@ entry:
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
-  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
   %41 = load i64, i64 addrspace(1)* %39
@@ -2236,8 +2318,8 @@ entry:
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
-  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
   %54 = load i64, i64 addrspace(1)* %52
@@ -2252,8 +2334,8 @@ entry:
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
   %67 = load i64, i64 addrspace(1)* %65
@@ -2270,8 +2352,8 @@ entry:
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
-  br i1 %NullCheck16, label %79, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
   %80 = load i64, i64 addrspace(1)* %78
@@ -2286,8 +2368,8 @@ entry:
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
-  br i1 %NullCheck18, label %92, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
   %93 = load i64, i64 addrspace(1)* %91
@@ -2304,8 +2386,8 @@ entry:
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
-  br i1 %NullCheck12, label %105, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = load i64, i64 addrspace(1)* %104
@@ -2320,8 +2402,8 @@ entry:
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
-  br i1 %NullCheck14, label %118, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
   %119 = load i64, i64 addrspace(1)* %117
@@ -2337,8 +2419,8 @@ entry:
 
 ; <label>:128                                     ; preds = %20
   %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
-  br i1 %NullCheck4, label %130, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %129, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %130
 
 ; <label>:130                                     ; preds = %128
   %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
@@ -2346,8 +2428,8 @@ entry:
   %133 = load i16, i16 addrspace(1)* %132, align 8
   %134 = zext i16 %133 to i32
   %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
-  br i1 %NullCheck6, label %136, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %135, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %136
 
 ; <label>:136                                     ; preds = %130
   %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
@@ -2360,8 +2442,8 @@ entry:
 
 ; <label>:143                                     ; preds = %136
   %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
-  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %144, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %145
 
 ; <label>:145                                     ; preds = %143
   %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
@@ -2369,8 +2451,8 @@ entry:
   %148 = load i16, i16 addrspace(1)* %147, align 8
   %149 = zext i16 %148 to i32
   %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %150, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %151
 
 ; <label>:151                                     ; preds = %145
   %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
@@ -2388,8 +2470,8 @@ entry:
 
 ; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
-  br i1 %NullCheck, label %163, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %ThrowNullRef, label %163
 
 ; <label>:163                                     ; preds = %161
   %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
@@ -2399,8 +2481,8 @@ entry:
 
 ; <label>:167                                     ; preds = %163
   %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
-  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %168, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %169
 
 ; <label>:169                                     ; preds = %167
   %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
@@ -2432,55 +2514,55 @@ ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %167
+ThrowNullRef2:                                    ; preds = %167
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %128
+ThrowNullRef4:                                    ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %130
+ThrowNullRef6:                                    ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %143
+ThrowNullRef8:                                    ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %145
+ThrowNullRef10:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %102
+ThrowNullRef12:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %105
+ThrowNullRef14:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %76
+ThrowNullRef16:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %79
+ThrowNullRef18:                                   ; preds = %79
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %50
+ThrowNullRef20:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %53
+ThrowNullRef22:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %24
+ThrowNullRef24:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %27
+ThrowNullRef26:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2503,15 +2585,15 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2519,16 +2601,16 @@ entry:
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
   store i32 %8, i32* %loc0
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
   %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
   store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
@@ -2546,16 +2628,16 @@ entry:
 
 ; <label>:23                                      ; preds = %64
   %24 = load i16*, i16** %loc3
-  %NullCheck12 = icmp ne i16* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i16* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
   store i32 %27, i32* %loc5
   %28 = load i16*, i16** %loc4
-  %NullCheck14 = icmp ne i16* %28, null
-  br i1 %NullCheck14, label %29, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %28, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = load i16, i16* %28, align 8
@@ -2620,15 +2702,15 @@ entry:
 
 ; <label>:67                                      ; preds = %64
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
-  br i1 %NullCheck8, label %69, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %68, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %69
 
 ; <label>:69                                      ; preds = %67
   %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
   %71 = load i32, i32 addrspace(1)* %70
   %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
-  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %73
 
 ; <label>:73                                      ; preds = %69
   %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
@@ -2645,31 +2727,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %67
+ThrowNullRef8:                                    ; preds = %67
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %69
+ThrowNullRef10:                                   ; preds = %69
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2710,14 +2792,14 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
   %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
@@ -2730,14 +2812,14 @@ entry:
 
 ; <label>:11                                      ; preds = %4
   %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
   %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
@@ -2749,14 +2831,14 @@ entry:
 
 ; <label>:22                                      ; preds = %16
   %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
   %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
-  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
-  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
@@ -2804,23 +2886,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2836,7 +2918,280 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[loadElem]
+Successfully read RuntimeType.IsAssignableFrom
+
+define i8 @RuntimeType.IsAssignableFrom(%System.RuntimeType addrspace(1)* %param0, %System.Type addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.RuntimeType addrspace(1)*
+  %arg1 = alloca %System.Type addrspace(1)*
+  %loc0 = alloca %System.RuntimeType addrspace(1)*
+  %loc1 = alloca %"System.Type[]" addrspace(1)*
+  %loc2 = alloca i32
+  store %System.RuntimeType addrspace(1)* %param0, %System.RuntimeType addrspace(1)** %this
+  store %System.Type addrspace(1)* %param1, %System.Type addrspace(1)** %arg1
+  %0 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %1 = icmp ne %System.Type addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i8 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %5 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %6 = bitcast %System.Type addrspace(1)* %4 to %System.Object addrspace(1)*
+  %7 = bitcast %System.RuntimeType addrspace(1)* %5 to %System.Object addrspace(1)*
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %6, %System.Object addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %3
+  ret i8 1
+
+; <label>:12                                      ; preds = %3
+  %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 152
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 32
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
+  %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
+  %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
+  store %System.RuntimeType addrspace(1)* %25, %System.RuntimeType addrspace(1)** %loc0
+  %26 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %27 = icmp eq %System.RuntimeType addrspace(1)* %26, null
+  br i1 %27, label %34, label %28
+
+; <label>:28                                      ; preds = %15
+  %29 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %30 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)*)*)(%System.RuntimeType addrspace(1)* %29, %System.RuntimeType addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+; <label>:34                                      ; preds = %15
+  %35 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %36 = call %System.Reflection.Emit.TypeBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Reflection.Emit.TypeBuilder addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %35)
+  %37 = icmp eq %System.Reflection.Emit.TypeBuilder addrspace(1)* %36, null
+  br i1 %37, label %139, label %38
+
+; <label>:38                                      ; preds = %34
+  %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %42
+
+; <label>:42                                      ; preds = %38
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 152
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 40
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
+  %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
+  %53 = zext i8 %52 to i32
+  %54 = icmp eq i32 %53, 0
+  br i1 %54, label %56, label %55
+
+; <label>:55                                      ; preds = %42
+  ret i8 1
+
+; <label>:56                                      ; preds = %42
+  %57 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %58 = bitcast %System.RuntimeType addrspace(1)* %57 to %System.Type addrspace(1)*
+  %59 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %58)
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %64 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.Type addrspace(1)* %63, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = bitcast %System.RuntimeType addrspace(1)* %64 to %System.Type addrspace(1)*
+  %67 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %63, %System.Type addrspace(1)* %66)
+  %68 = zext i8 %67 to i32
+  %69 = trunc i32 %68 to i8
+  ret i8 %69
+
+; <label>:70                                      ; preds = %56
+  %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
+  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %73
+
+; <label>:73                                      ; preds = %70
+  %74 = load i64, i64 addrspace(1)* %72
+  %75 = add i64 %74, 128
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = add i64 %77, 0
+  %79 = inttoptr i64 %78 to i64*
+  %80 = load i64, i64* %79
+  %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
+  %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
+  %83 = call i8 %82(%System.Type addrspace(1)* %81)
+  %84 = zext i8 %83 to i32
+  %85 = icmp eq i32 %84, 0
+  br i1 %85, label %139, label %86
+
+; <label>:86                                      ; preds = %73
+  %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
+  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %89
+
+; <label>:89                                      ; preds = %86
+  %90 = load i64, i64 addrspace(1)* %88
+  %91 = add i64 %90, 128
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = add i64 %93, 24
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
+  %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
+  %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
+  store %"System.Type[]" addrspace(1)* %99, %"System.Type[]" addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %129
+
+; <label>:100                                     ; preds = %132
+  %101 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %102 = load i32, i32* %loc2
+  %NullCheck11 = icmp eq %"System.Type[]" addrspace(1)* %101, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %103
+
+; <label>:103                                     ; preds = %100
+  %104 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 1
+  %105 = load i32, i32 addrspace(1)* %104
+  %106 = zext i32 %105 to i64
+  %107 = zext i32 %102 to i64
+  %BoundsCheck = icmp uge i64 %107, %106
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %108
+
+; <label>:108                                     ; preds = %103
+  %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
+  %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
+  %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
+  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %113
+
+; <label>:113                                     ; preds = %108
+  %114 = load i64, i64 addrspace(1)* %112
+  %115 = add i64 %114, 152
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = add i64 %117, 56
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
+  %123 = zext i8 %122 to i32
+  %124 = icmp ne i32 %123, 0
+  br i1 %124, label %126, label %125
+
+; <label>:125                                     ; preds = %113
+  ret i8 0
+
+; <label>:126                                     ; preds = %113
+  %127 = load i32, i32* %loc2
+  %128 = add i32 %127, 1
+  store i32 %128, i32* %loc2
+  br label %129
+
+; <label>:129                                     ; preds = %89, %126
+  %130 = load i32, i32* %loc2
+  %131 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %NullCheck9 = icmp eq %"System.Type[]" addrspace(1)* %131, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %132
+
+; <label>:132                                     ; preds = %129
+  %133 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %131, i32 0, i32 1
+  %134 = load i32, i32 addrspace(1)* %133
+  %135 = zext i32 %134 to i64
+  %136 = trunc i64 %135 to i32
+  %137 = icmp slt i32 %130, %136
+  br i1 %137, label %100, label %138
+
+; <label>:138                                     ; preds = %132
+  ret i8 1
+
+; <label>:139                                     ; preds = %34, %73
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %129
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %103
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -2893,7 +3248,7 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElem]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -2904,8 +3259,8 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -2997,8 +3352,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
@@ -3059,8 +3414,8 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -3087,8 +3442,8 @@ entry:
 
 ; <label>:17                                      ; preds = %5, %11
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
@@ -3097,8 +3452,8 @@ entry:
 
 ; <label>:22                                      ; preds = %1, %11
   %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
@@ -3109,11 +3464,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %17
+ThrowNullRef2:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %22
+ThrowNullRef4:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3167,15 +3522,15 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
   %15 = load i32, i32 addrspace(1)* %14
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
@@ -3198,7 +3553,7 @@ ThrowNullRef:                                     ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef2:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3232,8 +3587,8 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
@@ -3312,8 +3667,8 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -3327,8 +3682,8 @@ entry:
 ; <label>:5                                       ; preds = %43
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %7 = load i32, i32* %loc1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck6, label %8, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
@@ -3366,8 +3721,8 @@ entry:
 ; <label>:32                                      ; preds = %21, %25
   %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
   %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
-  br i1 %NullCheck8, label %35, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = trunc i32 %34 to i16
@@ -3380,8 +3735,8 @@ entry:
 ; <label>:40                                      ; preds = %1, %35
   %41 = load i32, i32* %loc1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
-  br i1 %NullCheck2, label %43, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %42, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
@@ -3392,8 +3747,8 @@ entry:
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
   %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
-  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
   %51 = load i64, i64 addrspace(1)* %49
@@ -3412,19 +3767,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %40
+ThrowNullRef2:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %47
+ThrowNullRef4:                                    ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %5
+ThrowNullRef6:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %32
+ThrowNullRef8:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3467,8 +3822,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
@@ -3492,11 +3847,391 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(i16* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store i16* %param0, i16** %arg0
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load i32, i32* %arg3
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %42, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %37, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg2
+  %13 = load i32, i32* %arg3
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %37, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %24 = load i32, i32* %arg2
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load i16*, i16** %arg0
+  %35 = load i32, i32* %arg3
+  %36 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %36, i16* %34, i32 %35)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:37                                      ; preds = %5, %16
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %39)
+  %41 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41, %System.String addrspace(1)* %38, %System.String addrspace(1)* %40)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41) #0
+  unreachable
+
+; <label>:42                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
-Failed to read StringBuilder.ToString[loadElemA]
+Successfully read StringBuilder.ToString
+
+define %System.String addrspace(1)* @StringBuilder.ToString(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i16*
+  %loc3 = alloca %"System.Char[]" addrspace(1)*
+  %loc4 = alloca i32
+  %loc5 = alloca i32
+  %loc6 = alloca i16 addrspace(1)*
+  %loc7 = alloca %System.String addrspace(1)*
+  %loc8 = alloca %"System.Char[]" addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %0)
+  %2 = icmp ne i32 %1, 0
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %4
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %6)
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %7)
+  store %System.String addrspace(1)* %8, %System.String addrspace(1)** %loc0
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.Text.StringBuilder addrspace(1)* %9, %System.Text.StringBuilder addrspace(1)** %loc1
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  store %System.String addrspace(1)* %10, %System.String addrspace(1)** %loc7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc7
+  %12 = ptrtoint %System.String addrspace(1)* %11 to i64
+  %13 = icmp eq i64 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %5
+  %15 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %16 = sext i32 %15 to i64
+  %17 = add i64 %12, %16
+  br label %18
+
+; <label>:18                                      ; preds = %5, %14
+  %19 = phi i64 [ %12, %5 ], [ %17, %14 ]
+  %20 = inttoptr i64 %19 to i16*
+  store i16* %20, i16** %loc2
+  br label %21
+
+; <label>:21                                      ; preds = %98, %18
+  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %22, null
+  br i1 %NullCheck, label %ThrowNullRef, label %23
+
+; <label>:23                                      ; preds = %21
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 3
+  %25 = load i32, i32 addrspace(1)* %24, align 8
+  %26 = icmp sle i32 %25, 0
+  br i1 %26, label %96, label %27
+
+; <label>:27                                      ; preds = %23
+  %28 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %28, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %29
+
+; <label>:29                                      ; preds = %27
+  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %28, i32 0, i32 1
+  %31 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %30, align 8
+  store %"System.Char[]" addrspace(1)* %31, %"System.Char[]" addrspace(1)** %loc3
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %33
+
+; <label>:33                                      ; preds = %29
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  store i32 %35, i32* %loc4
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  %39 = load i32, i32 addrspace(1)* %38, align 8
+  store i32 %39, i32* %loc5
+  %40 = load i32, i32* %loc5
+  %41 = load i32, i32* %loc4
+  %42 = add i32 %40, %41
+  %43 = zext i32 %42 to i64
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %45
+
+; <label>:45                                      ; preds = %37
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = sext i32 %47 to i64
+  %49 = icmp sgt i64 %43, %48
+  br i1 %49, label %91, label %50
+
+; <label>:50                                      ; preds = %45
+  %51 = load i32, i32* %loc5
+  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %52, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %53
+
+; <label>:53                                      ; preds = %50
+  %54 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %52, i32 0, i32 1
+  %55 = load i32, i32 addrspace(1)* %54
+  %56 = zext i32 %55 to i64
+  %57 = trunc i64 %56 to i32
+  %58 = icmp ugt i32 %51, %57
+  br i1 %58, label %91, label %59
+
+; <label>:59                                      ; preds = %53
+  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  store %"System.Char[]" addrspace(1)* %60, %"System.Char[]" addrspace(1)** %loc8
+  %61 = icmp eq %"System.Char[]" addrspace(1)* %60, null
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %63, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %64
+
+; <label>:64                                      ; preds = %62
+  %65 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %63, i32 0, i32 1
+  %66 = load i32, i32 addrspace(1)* %65
+  %67 = zext i32 %66 to i64
+  %68 = trunc i64 %67 to i32
+  %69 = icmp ne i32 %68, 0
+  br i1 %69, label %71, label %70
+
+; <label>:70                                      ; preds = %59, %64
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:71                                      ; preds = %64
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %73
+
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %BoundsCheck = icmp uge i64 0, %76
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %77
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %78, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:79                                      ; preds = %70, %77
+  %80 = load i16*, i16** %loc2
+  %81 = load i32, i32* %loc4
+  %82 = sext i32 %81 to i64
+  %83 = mul i64 %82, 2
+  %84 = bitcast i16* %80 to i8*
+  %85 = getelementptr inbounds i8, i8* %84, i64 %83
+  %86 = load i16 addrspace(1)*, i16 addrspace(1)** %loc6
+  %87 = ptrtoint i16 addrspace(1)* %86 to i64
+  %88 = load i32, i32* %loc5
+  %89 = bitcast i8* %85 to i16*
+  %90 = inttoptr i64 %87 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %89, i16* %90, i32 %88)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %96
+
+; <label>:91                                      ; preds = %45, %53
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %94 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %93)
+  %95 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95, %System.String addrspace(1)* %92, %System.String addrspace(1)* %94)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95) #0
+  unreachable
+
+; <label>:96                                      ; preds = %23, %79
+  %97 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %97, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %98
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %97, i32 0, i32 2
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  store %System.Text.StringBuilder addrspace(1)* %100, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %102 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %102, label %21, label %103
+
+; <label>:103                                     ; preds = %98
+  store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc7
+  %104 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  ret %System.String addrspace(1)* %104
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method StringBuilder::get_Length using LLILCJit
+Successfully read StringBuilder.get_Length
+
+define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
+Successfully read RuntimeHelpers.get_OffsetToStringData
+
+define i32 @RuntimeHelpers.get_OffsetToStringData() {
+entry:
+  ret i32 12
+}
+
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
 Successfully read CultureData.CreateCultureData
 
@@ -3514,23 +4249,23 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
   store i8 %4, i8 addrspace(1)* %6
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
@@ -3549,11 +4284,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3566,50 +4301,50 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
   store i32 -1, i32 addrspace(1)* %2
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
   store i32 -1, i32 addrspace(1)* %8
   %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
   store i32 -1, i32 addrspace(1)* %14
   %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
   store i32 -1, i32 addrspace(1)* %17
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
@@ -3623,27 +4358,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3675,7 +4410,136 @@ Failed to read Dictionary`2.Insert[non-const derefAddress]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
 Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
-Failed to read HashHelpers.GetPrime[loadElem]
+Successfully read HashHelpers.GetPrime
+
+define i32 @HashHelpers.GetPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %6, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5, %System.String addrspace(1)* %4)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5) #0
+  unreachable
+
+; <label>:6                                       ; preds = %entry
+  store i32 0, i32* %loc0
+  br label %29
+
+; <label>:7                                       ; preds = %35
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 1296
+  %10 = addrspacecast i8 addrspace(1)* %9 to %"System.Int32[]" addrspace(1)**
+  %11 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %10
+  %12 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Int32[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = zext i32 %15 to i64
+  %17 = zext i32 %12 to i64
+  %BoundsCheck = icmp uge i64 %17, %16
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 3, i32 %12
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  store i32 %20, i32* %loc1
+  %21 = load i32, i32* %loc1
+  %22 = load i32, i32* %arg0
+  %23 = icmp slt i32 %21, %22
+  br i1 %23, label %26, label %24
+
+; <label>:24                                      ; preds = %18
+  %25 = load i32, i32* %loc1
+  ret i32 %25
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %loc0
+  %28 = add i32 %27, 1
+  store i32 %28, i32* %loc0
+  br label %29
+
+; <label>:29                                      ; preds = %6, %26
+  %30 = load i32, i32* %loc0
+  %31 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %32 = getelementptr inbounds i8, i8 addrspace(1)* %31, i64 1296
+  %33 = addrspacecast i8 addrspace(1)* %32 to %"System.Int32[]" addrspace(1)**
+  %34 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %33
+  %NullCheck = icmp eq %"System.Int32[]" addrspace(1)* %34, null
+  br i1 %NullCheck, label %ThrowNullRef, label %35
+
+; <label>:35                                      ; preds = %29
+  %36 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %34, i32 0, i32 1
+  %37 = load i32, i32 addrspace(1)* %36
+  %38 = zext i32 %37 to i64
+  %39 = trunc i64 %38 to i32
+  %40 = icmp slt i32 %30, %39
+  br i1 %40, label %7, label %41
+
+; <label>:41                                      ; preds = %35
+  %42 = load i32, i32* %arg0
+  %43 = or i32 %42, 1
+  store i32 %43, i32* %loc2
+  br label %59
+
+; <label>:44                                      ; preds = %59
+  %45 = load i32, i32* %loc2
+  %46 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %45)
+  %47 = zext i8 %46 to i32
+  %48 = icmp eq i32 %47, 0
+  br i1 %48, label %56, label %49
+
+; <label>:49                                      ; preds = %44
+  %50 = load i32, i32* %loc2
+  %51 = sub i32 %50, 1
+  %52 = srem i32 %51, 101
+  %53 = icmp eq i32 %52, 0
+  br i1 %53, label %56, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = load i32, i32* %loc2
+  ret i32 %55
+
+; <label>:56                                      ; preds = %44, %49
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %57, 2
+  store i32 %58, i32* %loc2
+  br label %59
+
+; <label>:59                                      ; preds = %41, %56
+  %60 = load i32, i32* %loc2
+  %61 = icmp slt i32 %60, 2147483647
+  br i1 %61, label %44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load i32, i32* %arg0
+  ret i32 %63
+
+ThrowNullRef:                                     ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
 Successfully read GenericEqualityComparer`1.GetHashCode
 
@@ -3694,14 +4558,14 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
   %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load i64, i64 addrspace(1)* %7
@@ -3720,7 +4584,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3750,8 +4614,8 @@ entry:
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
@@ -3796,8 +4660,8 @@ entry:
   %35 = bitcast i16* %34 to i8*
   %36 = getelementptr inbounds i8, i8* %35, i64 2
   %37 = bitcast i8* %36 to i16*
-  %NullCheck4 = icmp ne i16* %37, null
-  br i1 %NullCheck4, label %38, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %37, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %38
 
 ; <label>:38                                      ; preds = %27
   %39 = load i16, i16* %37, align 8
@@ -3824,8 +4688,8 @@ entry:
 
 ; <label>:54                                      ; preds = %22, %43
   %55 = load i16*, i16** %loc4
-  %NullCheck2 = icmp ne i16* %55, null
-  br i1 %NullCheck2, label %56, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i16* %55, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %56
 
 ; <label>:56                                      ; preds = %54
   %57 = load i16, i16* %55, align 8
@@ -3850,11 +4714,11 @@ ThrowNullRef:                                     ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %54
+ThrowNullRef2:                                    ; preds = %54
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %27
+ThrowNullRef4:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3871,8 +4735,8 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -3907,8 +4771,8 @@ entry:
 
 ; <label>:26                                      ; preds = %19
   %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
-  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %28
 
 ; <label>:28                                      ; preds = %26
   %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
@@ -3920,7 +4784,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3972,8 +4836,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
@@ -3984,26 +4848,26 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
-  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
@@ -4014,8 +4878,8 @@ entry:
 ; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
@@ -4024,8 +4888,8 @@ entry:
 
 ; <label>:25                                      ; preds = %1, %16, %23
   %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
-  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
@@ -4036,27 +4900,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %20
+ThrowNullRef10:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4069,8 +4933,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -4081,8 +4945,8 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
@@ -4091,8 +4955,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1, %8
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
@@ -4103,11 +4967,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4128,24 +4992,24 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   store i32 %3, i32* %loc0
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
   %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
   store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck4, label %9, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
@@ -4164,15 +5028,15 @@ entry:
 ; <label>:18                                      ; preds = %70
   %19 = load i16*, i16** %loc3
   %20 = bitcast i16* %19 to i64*
-  %NullCheck10 = icmp ne i64* %20, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %20, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = load i64, i64* %20, align 8
   %23 = load i16*, i16** %loc4
   %24 = bitcast i16* %23 to i64*
-  %NullCheck12 = icmp ne i64* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = load i64, i64* %24, align 8
@@ -4188,8 +5052,8 @@ entry:
   %31 = bitcast i16* %30 to i8*
   %32 = getelementptr inbounds i8, i8* %31, i64 8
   %33 = bitcast i8* %32 to i64*
-  %NullCheck14 = icmp ne i64* %33, null
-  br i1 %NullCheck14, label %34, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = load i64, i64* %33, align 8
@@ -4197,8 +5061,8 @@ entry:
   %37 = bitcast i16* %36 to i8*
   %38 = getelementptr inbounds i8, i8* %37, i64 8
   %39 = bitcast i8* %38 to i64*
-  %NullCheck16 = icmp ne i64* %39, null
-  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %40
 
 ; <label>:40                                      ; preds = %34
   %41 = load i64, i64* %39, align 8
@@ -4214,8 +5078,8 @@ entry:
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %NullCheck18 = icmp ne i64* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = load i64, i64* %48, align 8
@@ -4223,8 +5087,8 @@ entry:
   %52 = bitcast i16* %51 to i8*
   %53 = getelementptr inbounds i8, i8* %52, i64 16
   %54 = bitcast i8* %53 to i64*
-  %NullCheck20 = icmp ne i64* %54, null
-  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64* %54, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %55
 
 ; <label>:55                                      ; preds = %49
   %56 = load i64, i64* %54, align 8
@@ -4262,15 +5126,15 @@ entry:
 ; <label>:74                                      ; preds = %95
   %75 = load i16*, i16** %loc3
   %76 = bitcast i16* %75 to i32*
-  %NullCheck6 = icmp ne i32* %76, null
-  br i1 %NullCheck6, label %77, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32* %76, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %77
 
 ; <label>:77                                      ; preds = %74
   %78 = load i32, i32* %76, align 8
   %79 = load i16*, i16** %loc4
   %80 = bitcast i16* %79 to i32*
-  %NullCheck8 = icmp ne i32* %80, null
-  br i1 %NullCheck8, label %81, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i32* %80, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %81
 
 ; <label>:81                                      ; preds = %77
   %82 = load i32, i32* %80, align 8
@@ -4318,43 +5182,43 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %74
+ThrowNullRef6:                                    ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %77
+ThrowNullRef8:                                    ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %29
+ThrowNullRef14:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %34
+ThrowNullRef16:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4376,8 +5240,8 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load i64, i64 addrspace(1)* %4
@@ -4389,8 +5253,8 @@ entry:
   %12 = load i64, i64* %11
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %5
   %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
@@ -4399,8 +5263,8 @@ entry:
   %18 = load i8, i8* %arg2
   %19 = zext i8 %18 to i32
   %20 = trunc i32 %19 to i8
-  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %15
   %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
@@ -4411,11 +5275,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4442,8 +5306,8 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
@@ -4466,16 +5330,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
   %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = load i64, i64 addrspace(1)* %19
@@ -4500,8 +5364,8 @@ entry:
 ; <label>:35                                      ; preds = %30
   %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
@@ -4514,8 +5378,8 @@ entry:
 
 ; <label>:42                                      ; preds = %1, %38
   %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
-  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
@@ -4526,19 +5390,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %35
+ThrowNullRef2:                                    ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %42
+ThrowNullRef8:                                    ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4551,14 +5415,14 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
@@ -4570,7 +5434,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4583,8 +5447,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
@@ -4613,51 +5477,51 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
   %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
   %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
   %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
   %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
-  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
   store i64 %21, i64 addrspace(1)* %23
   %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %25 = load i64, i64* %loc0
-  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
@@ -4668,27 +5532,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %22
+ThrowNullRef12:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4701,8 +5565,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
@@ -4713,19 +5577,19 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
@@ -4734,8 +5598,8 @@ entry:
 
 ; <label>:15                                      ; preds = %1, %13
   %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
@@ -4746,19 +5610,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %15
+ThrowNullRef8:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4771,8 +5635,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -4831,8 +5695,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
@@ -4882,8 +5746,8 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
-  br i1 %NullCheck, label %17, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %ThrowNullRef, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
@@ -4894,15 +5758,15 @@ entry:
 
 ; <label>:22                                      ; preds = %17
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
-  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
   %26 = load i32, i32 addrspace(1)* %25
   %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
-  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %27, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
@@ -4925,8 +5789,8 @@ entry:
 ; <label>:40                                      ; preds = %17
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
-  br i1 %NullCheck6, label %43, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %41, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
@@ -4938,34 +5802,17 @@ ThrowNullRef:                                     ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %24
+ThrowNullRef4:                                    ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %40
+ThrowNullRef6:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
-}
-
-INFO:  jitting method Object::ReferenceEquals using LLILCJit
-Successfully read Object.ReferenceEquals
-
-define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
-entry:
-  %arg0 = alloca %System.Object addrspace(1)*
-  %arg1 = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
-  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
-  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = icmp eq %System.Object addrspace(1)* %0, %1
-  %3 = sext i1 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
 }
 
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
@@ -4978,21 +5825,21 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
   %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
-  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
@@ -5007,28 +5854,28 @@ entry:
 ; <label>:13                                      ; preds = %8, %12
   %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
   %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
   %21 = load i32, i32 addrspace(1)* %20, align 8
   %22 = add i32 %21, 1
-  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
   store i32 %22, i32 addrspace(1)* %24
   %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
@@ -5039,27 +5886,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5077,7 +5924,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::Setup using LLILCJit
-Failed to read AppDomain.Setup[loadElem]
+Failed to read AppDomain.Setup[unbox]
 INFO:  jitting method Thread::GetDomain using LLILCJit
 Successfully read Thread.GetDomain
 
@@ -5108,8 +5955,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
@@ -5122,14 +5969,14 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
   %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
@@ -5141,11 +5988,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5173,8 +6020,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -5189,7 +6036,328 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
 Failed to read KeyCollection.System.Collections.Generic.IEnumerable<TKey>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Successfully read Enumerator.MoveNext
+
+define i8 @Enumerator.MoveNext(%"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.RuntimeTypeHandle* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*
+  %"$TypeArg" = alloca %System.RuntimeTypeHandle*
+  store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
+  %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 8
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %76, label %12
+
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
+  br label %76
+
+; <label>:13                                      ; preds = %85
+  %14 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck19 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %15
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, i32 0, i32 0
+  %17 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %16, align 8
+  %NullCheck21 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, i32 0, i32 2
+  %20 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %19, align 8
+  %21 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck23 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %22
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, i32 0, i32 2
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %NullCheck25 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 3, i32 %24
+  %NullCheck27 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %32
+
+; <label>:32                                      ; preds = %30
+  %33 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, i32 0, i32 2
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = icmp slt i32 %34, 0
+  br i1 %35, label %68, label %36
+
+; <label>:36                                      ; preds = %32
+  %37 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %38 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck29 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %39
+
+; <label>:39                                      ; preds = %36
+  %40 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, i32 0, i32 0
+  %41 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %40, align 8
+  %NullCheck31 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, i32 0, i32 2
+  %44 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %43, align 8
+  %45 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck33 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, i32 0, i32 2
+  %48 = load i32, i32 addrspace(1)* %47, align 8
+  %NullCheck35 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %49
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = zext i32 %51 to i64
+  %53 = zext i32 %48 to i64
+  %BoundsCheck37 = icmp uge i64 %53, %52
+  br i1 %BoundsCheck37, label %ThrowIndexOutOfRange38, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 3, i32 %48
+  %NullCheck39 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %56
+
+; <label>:56                                      ; preds = %54
+  %57 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, i32 0, i32 0
+  %58 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck41 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %59
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %60, %System.__Canon addrspace(1)* %58)
+  %61 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck43 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  %64 = load i32, i32 addrspace(1)* %63, align 8
+  %65 = add i32 %64, 1
+  %NullCheck45 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  store i32 %65, i32 addrspace(1)* %67
+  ret i8 1
+
+; <label>:68                                      ; preds = %32
+  %69 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck47 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %73 = add i32 %72, 1
+  %NullCheck49 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %74
+
+; <label>:74                                      ; preds = %70
+  %75 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  store i32 %73, i32 addrspace(1)* %75
+  br label %76
+
+; <label>:76                                      ; preds = %8, %12, %74
+  %77 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %78
+
+; <label>:78                                      ; preds = %76
+  %79 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, i32 0, i32 2
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck7 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %82
+
+; <label>:82                                      ; preds = %78
+  %83 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, i32 0, i32 0
+  %84 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %83, align 8
+  %NullCheck9 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %85
+
+; <label>:85                                      ; preds = %82
+  %86 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, i32 0, i32 7
+  %87 = load i32, i32 addrspace(1)* %86, align 8
+  %88 = icmp ult i32 %80, %87
+  br i1 %88, label %13, label %89
+
+; <label>:89                                      ; preds = %85
+  %90 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %91 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck11 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %92
+
+; <label>:92                                      ; preds = %89
+  %93 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, i32 0, i32 0
+  %94 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck13 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %95
+
+; <label>:95                                      ; preds = %92
+  %96 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, i32 0, i32 7
+  %97 = load i32, i32 addrspace(1)* %96, align 8
+  %98 = add i32 %97, 1
+  %NullCheck15 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %99
+
+; <label>:99                                      ; preds = %95
+  %100 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, i32 0, i32 2
+  store i32 %98, i32 addrspace(1)* %100
+  %101 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck17 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %102
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %103, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %92
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef22:                                   ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef24:                                   ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef26:                                   ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef28:                                   ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef30:                                   ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef32:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef34:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef36:                                   ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange38:                           ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef40:                                   ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef42:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef44:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef46:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef48:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef50:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -5200,8 +6368,8 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -5232,9 +6400,9 @@ Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
 Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
-Failed to read String.MakeSeparatorList[loadElemA]
+Failed to read String.MakeSeparatorList[storeElem]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
-Failed to read String.InternalSplitKeepEmptyEntries[loadElem]
+Failed to read String.InternalSplitKeepEmptyEntries[storeElem]
 INFO:  jitting method Path::IsRelative using LLILCJit
 Successfully read Path.IsRelative
 
@@ -5243,8 +6411,8 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -5254,8 +6422,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
@@ -5271,8 +6439,8 @@ entry:
 
 ; <label>:17                                      ; preds = %7
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
@@ -5288,8 +6456,8 @@ entry:
 
 ; <label>:29                                      ; preds = %19
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %31
 
 ; <label>:31                                      ; preds = %29
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
@@ -5300,8 +6468,8 @@ entry:
 
 ; <label>:36                                      ; preds = %31
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
-  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %37, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
@@ -5312,8 +6480,8 @@ entry:
 
 ; <label>:43                                      ; preds = %31, %38
   %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
-  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %45
 
 ; <label>:45                                      ; preds = %43
   %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
@@ -5324,8 +6492,8 @@ entry:
 
 ; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %50
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
@@ -5336,8 +6504,8 @@ entry:
 
 ; <label>:57                                      ; preds = %1, %7, %19, %45, %52
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
-  br i1 %NullCheck14, label %59, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %59
 
 ; <label>:59                                      ; preds = %57
   %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
@@ -5347,8 +6515,8 @@ entry:
 
 ; <label>:63                                      ; preds = %59
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
@@ -5359,8 +6527,8 @@ entry:
 
 ; <label>:70                                      ; preds = %65
   %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
-  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.String addrspace(1)* %71, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %72
 
 ; <label>:72                                      ; preds = %70
   %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
@@ -5379,39 +6547,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %17
+ThrowNullRef4:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %29
+ThrowNullRef6:                                    ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %36
+ThrowNullRef8:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %43
+ThrowNullRef10:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %50
+ThrowNullRef12:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %57
+ThrowNullRef14:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %63
+ThrowNullRef16:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %70
+ThrowNullRef18:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5419,7 +6587,293 @@ ThrowNullRef17:                                   ; preds = %70
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
-Failed to read String.TrimHelper[loadElem]
+Successfully read String.TrimHelper
+
+define %System.String addrspace(1)* @String.TrimHelper(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i16
+  %loc4 = alloca i32
+  %loc5 = alloca i16
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = sub i32 %3, 1
+  store i32 %4, i32* %loc0
+  store i32 0, i32* %loc1
+  %5 = load i32, i32* %arg2
+  %6 = icmp eq i32 %5, 1
+  br i1 %6, label %62, label %7
+
+; <label>:7                                       ; preds = %1
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:8                                       ; preds = %58
+  store i32 0, i32* %loc2
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load i32, i32* %loc1
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2, i32 %10
+  %13 = load i16, i16 addrspace(1)* %12
+  %14 = zext i16 %13 to i32
+  %15 = trunc i32 %14 to i16
+  store i16 %15, i16* %loc3
+  store i32 0, i32* %loc2
+  br label %34
+
+; <label>:16                                      ; preds = %37
+  %17 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %18 = load i32, i32* %loc2
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %17, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %19
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = zext i32 %18 to i64
+  %BoundsCheck = icmp uge i64 %23, %22
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %24
+
+; <label>:24                                      ; preds = %19
+  %25 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 3, i32 %18
+  %26 = load i16, i16 addrspace(1)* %25, align 8
+  %27 = zext i16 %26 to i32
+  %28 = load i16, i16* %loc3
+  %29 = zext i16 %28 to i32
+  %30 = icmp eq i32 %27, %29
+  br i1 %30, label %43, label %31
+
+; <label>:31                                      ; preds = %24
+  %32 = load i32, i32* %loc2
+  %33 = add i32 %32, 1
+  store i32 %33, i32* %loc2
+  br label %34
+
+; <label>:34                                      ; preds = %11, %31
+  %35 = load i32, i32* %loc2
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = icmp slt i32 %35, %41
+  br i1 %42, label %16, label %43
+
+; <label>:43                                      ; preds = %24, %37
+  %44 = load i32, i32* %loc2
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %45, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp eq i32 %44, %50
+  br i1 %51, label %62, label %52
+
+; <label>:52                                      ; preds = %46
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %7, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %57, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %58
+
+; <label>:58                                      ; preds = %55
+  %59 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %60 = load i32, i32 addrspace(1)* %59
+  %61 = icmp slt i32 %56, %60
+  br i1 %61, label %8, label %62
+
+; <label>:62                                      ; preds = %1, %46, %58
+  %63 = load i32, i32* %arg2
+  %64 = icmp eq i32 %63, 0
+  br i1 %64, label %122, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %66, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %67
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %66, i32 0, i32 1
+  %69 = load i32, i32 addrspace(1)* %68
+  %70 = sub i32 %69, 1
+  store i32 %70, i32* %loc0
+  br label %118
+
+; <label>:71                                      ; preds = %118
+  store i32 0, i32* %loc4
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %73 = load i32, i32* %loc0
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %74
+
+; <label>:74                                      ; preds = %71
+  %75 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 2, i32 %73
+  %76 = load i16, i16 addrspace(1)* %75
+  %77 = zext i16 %76 to i32
+  %78 = trunc i32 %77 to i16
+  store i16 %78, i16* %loc5
+  store i32 0, i32* %loc4
+  br label %97
+
+; <label>:79                                      ; preds = %100
+  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %81 = load i32, i32* %loc4
+  %NullCheck19 = icmp eq %"System.Char[]" addrspace(1)* %80, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
+
+; <label>:82                                      ; preds = %79
+  %83 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 1
+  %84 = load i32, i32 addrspace(1)* %83
+  %85 = zext i32 %84 to i64
+  %86 = zext i32 %81 to i64
+  %BoundsCheck21 = icmp uge i64 %86, %85
+  br i1 %BoundsCheck21, label %ThrowIndexOutOfRange22, label %87
+
+; <label>:87                                      ; preds = %82
+  %88 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 3, i32 %81
+  %89 = load i16, i16 addrspace(1)* %88, align 8
+  %90 = zext i16 %89 to i32
+  %91 = load i16, i16* %loc5
+  %92 = zext i16 %91 to i32
+  %93 = icmp eq i32 %90, %92
+  br i1 %93, label %106, label %94
+
+; <label>:94                                      ; preds = %87
+  %95 = load i32, i32* %loc4
+  %96 = add i32 %95, 1
+  store i32 %96, i32* %loc4
+  br label %97
+
+; <label>:97                                      ; preds = %74, %94
+  %98 = load i32, i32* %loc4
+  %99 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck15 = icmp eq %"System.Char[]" addrspace(1)* %99, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %100
+
+; <label>:100                                     ; preds = %97
+  %101 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %99, i32 0, i32 1
+  %102 = load i32, i32 addrspace(1)* %101
+  %103 = zext i32 %102 to i64
+  %104 = trunc i64 %103 to i32
+  %105 = icmp slt i32 %98, %104
+  br i1 %105, label %79, label %106
+
+; <label>:106                                     ; preds = %87, %100
+  %107 = load i32, i32* %loc4
+  %108 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck17 = icmp eq %"System.Char[]" addrspace(1)* %108, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %109
+
+; <label>:109                                     ; preds = %106
+  %110 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %108, i32 0, i32 1
+  %111 = load i32, i32 addrspace(1)* %110
+  %112 = zext i32 %111 to i64
+  %113 = trunc i64 %112 to i32
+  %114 = icmp eq i32 %107, %113
+  br i1 %114, label %122, label %115
+
+; <label>:115                                     ; preds = %109
+  %116 = load i32, i32* %loc0
+  %117 = sub i32 %116, 1
+  store i32 %117, i32* %loc0
+  br label %118
+
+; <label>:118                                     ; preds = %67, %115
+  %119 = load i32, i32* %loc0
+  %120 = load i32, i32* %loc1
+  %121 = icmp sge i32 %119, %120
+  br i1 %121, label %71, label %122
+
+; <label>:122                                     ; preds = %62, %109, %118
+  %123 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %124 = load i32, i32* %loc1
+  %125 = load i32, i32* %loc0
+  %126 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %123, i32 %124, i32 %125)
+  ret %System.String addrspace(1)* %126
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %97
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange22:                           ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
 Successfully read String.CreateTrimmedString
 
@@ -5439,8 +6893,8 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
@@ -5535,8 +6989,8 @@ entry:
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i64 2872
   %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
   %8 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %7
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %3
   %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
@@ -5553,8 +7007,8 @@ entry:
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 2864
   %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
   %21 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %20
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
-  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %22
 
 ; <label>:22                                      ; preds = %16
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
@@ -5569,7 +7023,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %16
+ThrowNullRef2:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5586,8 +7040,8 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5613,8 +7067,8 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
@@ -5632,8 +7086,8 @@ entry:
 
 ; <label>:12                                      ; preds = %4
   %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
@@ -5644,8 +7098,8 @@ entry:
 
 ; <label>:19                                      ; preds = %14
   %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %19
   %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
@@ -5660,21 +7114,21 @@ entry:
   %31 = zext i16 %30 to i32
   %32 = bitcast i8* %29 to i16*
   %33 = trunc i32 %31 to i16
-  %NullCheck6 = icmp ne i16* %32, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i16* %32, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %21
   store i16 %33, i16* %32, align 8
   %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %36
 
 ; <label>:36                                      ; preds = %34
   %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
   %38 = load i32, i32 addrspace(1)* %37, align 8
   %39 = add i32 %38, 1
-  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %40
 
 ; <label>:40                                      ; preds = %36
   %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
@@ -5683,16 +7137,16 @@ entry:
 
 ; <label>:42                                      ; preds = %14
   %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
-  br i1 %NullCheck12, label %44, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
   %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
   %47 = load i16, i16* %arg1
   %48 = zext i16 %47 to i32
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = trunc i32 %48 to i16
@@ -5703,31 +7157,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %19
+ThrowNullRef4:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %21
+ThrowNullRef6:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %36
+ThrowNullRef10:                                   ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %42
+ThrowNullRef12:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %44
+ThrowNullRef14:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5740,8 +7194,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -5752,8 +7206,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
@@ -5762,14 +7216,14 @@ entry:
 
 ; <label>:11                                      ; preds = %1
   %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
@@ -5779,15 +7233,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5808,8 +7262,8 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5822,8 +7276,8 @@ entry:
 
 ; <label>:8                                       ; preds = %3
   %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
@@ -5842,15 +7296,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
-  br i1 %NullCheck4, label %22, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
   %24 = load i16*, i16* addrspace(1)* %23, align 8
   %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %25, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
@@ -5859,8 +7313,8 @@ entry:
   store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
@@ -5874,8 +7328,8 @@ entry:
 
 ; <label>:37                                      ; preds = %65
   %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %37
   %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
@@ -5886,16 +7340,16 @@ entry:
   %45 = bitcast i16* %41 to i8*
   %46 = getelementptr inbounds i8, i8* %45, i64 %44
   %47 = bitcast i8* %46 to i16*
-  %NullCheck14 = icmp ne i16* %47, null
-  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %47, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %48
 
 ; <label>:48                                      ; preds = %39
   %49 = load i16, i16* %47, align 8
   %50 = zext i16 %49 to i32
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %52 = load i32, i32* %loc1
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %53
 
 ; <label>:53                                      ; preds = %48
   %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
@@ -5916,8 +7370,8 @@ entry:
 ; <label>:62                                      ; preds = %36, %59
   %63 = load i32, i32* %loc1
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck10, label %65, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %65
 
 ; <label>:65                                      ; preds = %62
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
@@ -5936,15 +7390,15 @@ entry:
 
 ; <label>:74                                      ; preds = %70
   %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
-  br i1 %NullCheck18, label %76, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %76
 
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
   %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
-  br i1 %NullCheck20, label %80, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
   %81 = load i64, i64 addrspace(1)* %79
@@ -5958,8 +7412,8 @@ entry:
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
   %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
-  br i1 %NullCheck22, label %92, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.String addrspace(1)* %90, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %92
 
 ; <label>:92                                      ; preds = %80
   %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
@@ -5969,15 +7423,15 @@ entry:
 
 ; <label>:96                                      ; preds = %70
   %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
-  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %98
 
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
   %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
-  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
   %103 = load i64, i64 addrspace(1)* %101
@@ -5991,8 +7445,8 @@ entry:
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
   %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
-  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.String addrspace(1)* %112, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %114
 
 ; <label>:114                                     ; preds = %102
   %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
@@ -6004,59 +7458,59 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %20
+ThrowNullRef4:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %22
+ThrowNullRef6:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %26
+ThrowNullRef8:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %62
+ThrowNullRef10:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %48
+ThrowNullRef16:                                   ; preds = %48
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %74
+ThrowNullRef18:                                   ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %76
+ThrowNullRef20:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %80
+ThrowNullRef22:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %96
+ThrowNullRef24:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %98
+ThrowNullRef26:                                   ; preds = %98
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %102
+ThrowNullRef28:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6069,15 +7523,15 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
   %3 = load i16*, i16* addrspace(1)* %2, align 8
   %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
@@ -6087,8 +7541,8 @@ entry:
   %10 = bitcast i16* %3 to i8*
   %11 = getelementptr inbounds i8, i8* %10, i64 %9
   %12 = bitcast i8* %11 to i16*
-  %NullCheck4 = icmp ne i16* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %5
   store i16 0, i16* %12, align 8
@@ -6098,11 +7552,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6119,8 +7573,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -6131,8 +7585,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
@@ -6144,15 +7598,15 @@ entry:
 
 ; <label>:14                                      ; preds = %1
   %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
   %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
   %21 = load i64, i64 addrspace(1)* %19
@@ -6171,15 +7625,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %14
+ThrowNullRef4:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %16
+ThrowNullRef6:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6302,14 +7756,6 @@ entry:
   ret %System.String addrspace(1)* %57
 }
 
-INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
-Successfully read RuntimeHelpers.get_OffsetToStringData
-
-define i32 @RuntimeHelpers.get_OffsetToStringData() {
-entry:
-  ret i32 12
-}
-
 INFO:  jitting method String::Equals using LLILCJit
 Successfully read String.Equals
 
@@ -6381,8 +7827,8 @@ entry:
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
-  br i1 %NullCheck24, label %29, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
   %30 = load i64, i64 addrspace(1)* %28
@@ -6397,8 +7843,8 @@ entry:
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
-  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
   %43 = load i64, i64 addrspace(1)* %41
@@ -6418,8 +7864,8 @@ entry:
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
   %59 = load i64, i64 addrspace(1)* %57
@@ -6434,8 +7880,8 @@ entry:
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck22, label %71, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
   %72 = load i64, i64 addrspace(1)* %70
@@ -6455,8 +7901,8 @@ entry:
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
-  br i1 %NullCheck16, label %87, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = load i64, i64 addrspace(1)* %86
@@ -6471,8 +7917,8 @@ entry:
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck18, label %100, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
   %101 = load i64, i64 addrspace(1)* %99
@@ -6492,8 +7938,8 @@ entry:
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
-  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
   %117 = load i64, i64 addrspace(1)* %115
@@ -6508,8 +7954,8 @@ entry:
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
-  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
   %130 = load i64, i64 addrspace(1)* %128
@@ -6528,15 +7974,15 @@ entry:
 
 ; <label>:142                                     ; preds = %22
   %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
-  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %143, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %144
 
 ; <label>:144                                     ; preds = %142
   %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
   %146 = load i32, i32 addrspace(1)* %145
   %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
-  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %147, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %148
 
 ; <label>:148                                     ; preds = %144
   %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
@@ -6557,15 +8003,15 @@ entry:
 
 ; <label>:159                                     ; preds = %22
   %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
-  br i1 %NullCheck, label %161, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %ThrowNullRef, label %161
 
 ; <label>:161                                     ; preds = %159
   %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
   %163 = load i32, i32 addrspace(1)* %162
   %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
-  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %164, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %165
 
 ; <label>:165                                     ; preds = %161
   %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
@@ -6578,8 +8024,8 @@ entry:
 
 ; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
-  br i1 %NullCheck4, label %172, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %171, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %172
 
 ; <label>:172                                     ; preds = %170
   %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
@@ -6589,8 +8035,8 @@ entry:
 
 ; <label>:176                                     ; preds = %172
   %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
-  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %177, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %178
 
 ; <label>:178                                     ; preds = %176
   %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
@@ -6629,55 +8075,55 @@ ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %161
+ThrowNullRef2:                                    ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %170
+ThrowNullRef4:                                    ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %176
+ThrowNullRef6:                                    ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %142
+ThrowNullRef8:                                    ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %144
+ThrowNullRef10:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %113
+ThrowNullRef12:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %116
+ThrowNullRef14:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %84
+ThrowNullRef16:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %87
+ThrowNullRef18:                                   ; preds = %87
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %55
+ThrowNullRef20:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %58
+ThrowNullRef22:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %26
+ThrowNullRef24:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %29
+ThrowNullRef26:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,8 +8161,8 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck, label %14, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %ThrowNullRef, label %14
 
 ; <label>:14                                      ; preds = %8
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
@@ -6760,8 +8206,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
@@ -6770,14 +8216,14 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32, i32* %loc0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %10
   %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
   %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
@@ -6790,15 +8236,15 @@ entry:
 ; <label>:25                                      ; preds = %19
   %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
-  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
   %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
@@ -6807,8 +8253,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %37 = load i32, i32* %loc0
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %38, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %38
 
 ; <label>:38                                      ; preds = %32
   %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
@@ -6817,14 +8263,14 @@ entry:
 
 ; <label>:40                                      ; preds = %19
   %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %40
   %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
   %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
-  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
-  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
@@ -6832,8 +8278,8 @@ entry:
   %48 = zext i32 %47 to i64
   %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
-  br i1 %NullCheck16, label %51, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %51
 
 ; <label>:51                                      ; preds = %45
   %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
@@ -6847,15 +8293,15 @@ entry:
 ; <label>:57                                      ; preds = %51
   %58 = load i16*, i16** %arg1
   %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
-  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %60
 
 ; <label>:60                                      ; preds = %57
   %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
   %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
-  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %64
 
 ; <label>:64                                      ; preds = %60
   %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
@@ -6864,22 +8310,22 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
   %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
-  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %70
 
 ; <label>:70                                      ; preds = %64
   %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
   %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
-  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
-  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
   %75 = load i32, i32 addrspace(1)* %74
   %76 = zext i32 %75 to i64
   %77 = trunc i64 %76 to i32
-  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
-  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %78
 
 ; <label>:78                                      ; preds = %73
   %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
@@ -6901,8 +8347,8 @@ entry:
   %90 = bitcast i16* %86 to i8*
   %91 = getelementptr inbounds i8, i8* %90, i64 %89
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %93
 
 ; <label>:93                                      ; preds = %80
   %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
@@ -6912,8 +8358,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %99 = load i32, i32* %loc2
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %100
 
 ; <label>:100                                     ; preds = %93
   %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
@@ -6928,63 +8374,63 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %25
+ThrowNullRef6:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %32
+ThrowNullRef10:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %40
+ThrowNullRef12:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %45
+ThrowNullRef16:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %57
+ThrowNullRef18:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %60
+ThrowNullRef20:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %64
+ThrowNullRef22:                                   ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %70
+ThrowNullRef24:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %73
+ThrowNullRef26:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %80
+ThrowNullRef28:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %93
+ThrowNullRef30:                                   ; preds = %93
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7004,8 +8450,8 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
@@ -7033,43 +8479,43 @@ entry:
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %14
   %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
   %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   %28 = load i32, i32 addrspace(1)* %27, align 8
   %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
-  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %30
 
 ; <label>:30                                      ; preds = %26
   %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
   %32 = load i32, i32 addrspace(1)* %31, align 8
   %33 = add i32 %28, %32
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %34
 
 ; <label>:34                                      ; preds = %30
   %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   store i32 %33, i32 addrspace(1)* %35
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
   store i32 0, i32 addrspace(1)* %38
   %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %40
 
 ; <label>:40                                      ; preds = %37
   %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
@@ -7082,8 +8528,8 @@ entry:
 
 ; <label>:47                                      ; preds = %40
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
@@ -7098,8 +8544,8 @@ entry:
   %54 = load i32, i32* %loc0
   %55 = sext i32 %54 to i64
   %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
-  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %57
 
 ; <label>:57                                      ; preds = %52
   %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
@@ -7110,68 +8556,35 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %14
+ThrowNullRef2:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %23
+ThrowNullRef4:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %26
+ThrowNullRef6:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %30
+ThrowNullRef8:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %34
+ThrowNullRef10:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %47
+ThrowNullRef14:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %52
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-}
-
-INFO:  jitting method StringBuilder::get_Length using LLILCJit
-Successfully read StringBuilder.get_Length
-
-define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.StringBuilder addrspace(1)*
-  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
-  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
-
-; <label>:1                                       ; preds = %entry
-  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %3 = load i32, i32 addrspace(1)* %2, align 8
-  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
-
-; <label>:5                                       ; preds = %1
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = add i32 %3, %7
-  ret i32 %8
-
-ThrowNullRef:                                     ; preds = %entry
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef16:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7213,70 +8626,70 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
   %6 = load i32, i32 addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
   store i32 %6, i32 addrspace(1)* %8
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
   %13 = load i32, i32 addrspace(1)* %12, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
   store i32 %13, i32 addrspace(1)* %15
   %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
-  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %18
 
 ; <label>:18                                      ; preds = %14
   %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
   %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
   %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
   %34 = load i32, i32 addrspace(1)* %33, align 8
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
-  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
@@ -7287,39 +8700,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %28
+ThrowNullRef16:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %32
+ThrowNullRef18:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7455,13 +8868,13 @@ entry:
 ; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
@@ -7477,16 +8890,16 @@ entry:
 
 ; <label>:18                                      ; preds = %15
   %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
   store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
   %22 = load i32, i32* %loc0
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %24
 
 ; <label>:24                                      ; preds = %20
   %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
@@ -7498,13 +8911,13 @@ entry:
 ; <label>:28                                      ; preds = %15, %24
   %29 = load i32, i32* %arg1
   %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %31
   %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
@@ -7517,20 +8930,20 @@ entry:
   %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
-  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
   %46 = load i32, i32 addrspace(1)* %45, align 8
   %47 = sub i32 %40, %46
-  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
-  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i32 addrspace(1)* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %48
 
 ; <label>:48                                      ; preds = %44
   store i32 %47, i32 addrspace(1)* %39, align 8
@@ -7538,21 +8951,21 @@ entry:
 
 ; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
-  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %51
 
 ; <label>:51                                      ; preds = %49
   %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %53
 
 ; <label>:53                                      ; preds = %51
   %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
   %55 = load i32, i32 addrspace(1)* %54, align 8
   %56 = load i32, i32* %arg2
   %57 = sub i32 %55, %56
-  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %58
 
 ; <label>:58                                      ; preds = %53
   %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
@@ -7562,13 +8975,13 @@ entry:
 ; <label>:60                                      ; preds = %33, %58
   %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
   %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
-  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %63
 
 ; <label>:63                                      ; preds = %60
   %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
-  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
-  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
@@ -7578,15 +8991,15 @@ entry:
 
 ; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
-  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i32 addrspace(1)* %69, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %70
 
 ; <label>:70                                      ; preds = %68
   %71 = load i32, i32 addrspace(1)* %69, align 8
   store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
-  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
@@ -7596,8 +9009,8 @@ entry:
   store i32 %77, i32* %loc4
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
-  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %80
 
 ; <label>:80                                      ; preds = %73
   %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
@@ -7607,71 +9020,71 @@ entry:
 ; <label>:83                                      ; preds = %80
   store i32 0, i32* %loc3
   %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
-  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
-  br i1 %NullCheck26, label %88, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i32 addrspace(1)* %87, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %88
 
 ; <label>:88                                      ; preds = %85
   %89 = load i32, i32 addrspace(1)* %87, align 8
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
-  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %90
 
 ; <label>:90                                      ; preds = %88
   %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
   store i32 %89, i32 addrspace(1)* %91
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
-  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
-  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %96
 
 ; <label>:96                                      ; preds = %94
   %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
-  br i1 %NullCheck34, label %100, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %100
 
 ; <label>:100                                     ; preds = %96
   %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
-  br i1 %NullCheck36, label %102, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %102
 
 ; <label>:102                                     ; preds = %100
   %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
   %104 = load i32, i32 addrspace(1)* %103, align 8
   %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
-  br i1 %NullCheck38, label %106, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %106
 
 ; <label>:106                                     ; preds = %102
   %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
-  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
-  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %108
 
 ; <label>:108                                     ; preds = %106
   %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
   %110 = load i32, i32 addrspace(1)* %109, align 8
   %111 = add i32 %104, %110
-  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %112
 
 ; <label>:112                                     ; preds = %108
   %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
   store i32 %111, i32 addrspace(1)* %113
   %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
-  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i32 addrspace(1)* %114, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %115
 
 ; <label>:115                                     ; preds = %112
   %116 = load i32, i32 addrspace(1)* %114, align 8
@@ -7681,19 +9094,19 @@ entry:
 ; <label>:118                                     ; preds = %115
   %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
-  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %121
 
 ; <label>:121                                     ; preds = %118
   %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
-  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
-  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %123
 
 ; <label>:123                                     ; preds = %121
   %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
   %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
-  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
-  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %126
 
 ; <label>:126                                     ; preds = %123
   %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
@@ -7705,8 +9118,8 @@ entry:
 
 ; <label>:130                                     ; preds = %80, %115, %126
   %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %132
 
 ; <label>:132                                     ; preds = %130
   %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7715,8 +9128,8 @@ entry:
   %136 = load i32, i32* %loc3
   %137 = sub i32 %135, %136
   %138 = sub i32 %134, %137
-  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %139
 
 ; <label>:139                                     ; preds = %132
   %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7728,16 +9141,16 @@ entry:
 
 ; <label>:144                                     ; preds = %139
   %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
-  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %146
 
 ; <label>:146                                     ; preds = %144
   %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
   %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
   %149 = load i32, i32* %loc2
   %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
-  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %151
 
 ; <label>:151                                     ; preds = %146
   %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
@@ -7754,145 +9167,249 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %18
+ThrowNullRef4:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %31
+ThrowNullRef10:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %44
+ThrowNullRef16:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %68
+ThrowNullRef18:                                   ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %70
+ThrowNullRef20:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %73
+ThrowNullRef22:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %83
+ThrowNullRef24:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %85
+ThrowNullRef26:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %88
+ThrowNullRef28:                                   ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %90
+ThrowNullRef30:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %94
+ThrowNullRef32:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %96
+ThrowNullRef34:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %100
+ThrowNullRef36:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %102
+ThrowNullRef38:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %106
+ThrowNullRef40:                                   ; preds = %106
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %108
+ThrowNullRef42:                                   ; preds = %108
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %112
+ThrowNullRef44:                                   ; preds = %112
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %118
+ThrowNullRef46:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %121
+ThrowNullRef48:                                   ; preds = %121
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %123
+ThrowNullRef50:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %130
+ThrowNullRef52:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %132
+ThrowNullRef54:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %144
+ThrowNullRef56:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %146
+ThrowNullRef58:                                   ; preds = %146
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %60
+ThrowNullRef60:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %63
+ThrowNullRef62:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %49
+ThrowNullRef64:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %51
+ThrowNullRef66:                                   ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %53
+ThrowNullRef68:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(%"System.Char[]" addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %arg0 = alloca %"System.Char[]" addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store %"System.Char[]" addrspace(1)* %param0, %"System.Char[]" addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load i32, i32* %arg4
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %43, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %38, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg1
+  %13 = load i32, i32* %arg4
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %38, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %24 = load i32, i32* %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %35 = load i32, i32* %arg3
+  %36 = load i32, i32* %arg4
+  %37 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %37, %"System.Char[]" addrspace(1)* %34, i32 %35, i32 %36)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:38                                      ; preds = %5, %16
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Successfully read Buffer._Memmove
 
@@ -7914,7 +9431,7 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[loadElem]
+Failed to read AppDomain.SetDataHelper[storeElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -7923,8 +9440,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
@@ -7934,8 +9451,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
@@ -7947,15 +9464,15 @@ entry:
   %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
   %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
@@ -7966,15 +9483,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7992,7 +9509,79 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
-Failed to read Dictionary`2.TryGetValue[loadElemA]
+Successfully read Dictionary`2.TryGetValue
+
+define i8 @"Dictionary`2.TryGetValue"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)* addrspace(1)* %param2) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  %arg2 = alloca %System.__Canon addrspace(1)* addrspace(1)*
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  store %System.__Canon addrspace(1)* addrspace(1)* %param2, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  store i32 %2, i32* %loc0
+  %3 = load i32, i32* %loc0
+  %4 = icmp slt i32 %3, 0
+  br i1 %4, label %22, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 2
+  %10 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %9, align 8
+  %11 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = zext i32 %11 to i64
+  %BoundsCheck = icmp uge i64 %16, %15
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 3, i32 %11
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %20, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %6, %System.__Canon addrspace(1)* %21)
+  ret i8 1
+
+; <label>:22                                      ; preds = %entry
+  %23 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %23, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -8058,8 +9647,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
@@ -8091,8 +9680,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
@@ -8171,15 +9760,15 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck, label %19, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %ThrowNullRef, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
   %21 = load i32, i32 addrspace(1)* %20
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
@@ -8202,7 +9791,7 @@ ThrowNullRef:                                     ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %19
+ThrowNullRef2:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8248,8 +9837,8 @@ entry:
   %0 = alloca %System.AppDomainHandle
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %1 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %1, i32 0, i32 15
@@ -8269,8 +9858,8 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
@@ -8286,7 +9875,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -8299,8 +9888,8 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -8327,8 +9916,8 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
@@ -8352,8 +9941,8 @@ entry:
   %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
   store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
@@ -8363,8 +9952,8 @@ entry:
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
@@ -8374,8 +9963,8 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %9
   %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
@@ -8384,8 +9973,8 @@ entry:
 
 ; <label>:18                                      ; preds = %3, %16
   %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
@@ -8397,15 +9986,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %18
+ThrowNullRef6:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8418,8 +10007,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
@@ -8453,15 +10042,15 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
@@ -8473,7 +10062,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8481,7 +10070,7 @@ ThrowNullRef1:                                    ; preds = %1
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
 Failed to read Dictionary`2.System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
@@ -8506,8 +10095,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
@@ -8524,8 +10113,8 @@ entry:
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -8544,7 +10133,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8577,8 +10166,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = load i64, i64* %arg2
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = trunc i32 %3 to i8
@@ -8634,46 +10223,46 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
   %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
-  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
-  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
-  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
@@ -8684,27 +10273,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %20
+ThrowNullRef12:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8717,8 +10306,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -8756,22 +10345,22 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
   %9 = load i64, i64 addrspace(1)* %8, align 8
   %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
   %13 = load i64, i64 addrspace(1)* %12, align 8
   %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %11
   %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
@@ -8788,11 +10377,11 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8882,8 +10471,8 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
@@ -8900,8 +10489,8 @@ entry:
 ; <label>:8                                       ; preds = %1
   %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
   %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
@@ -8911,15 +10500,15 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
   %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
   %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
-  br i1 %NullCheck6, label %21, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
@@ -8946,15 +10535,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8992,15 +10581,15 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
   store i8 %3, i8 addrspace(1)* %5
   %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
@@ -9011,7 +10600,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9027,8 +10616,8 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -9041,8 +10630,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
@@ -9058,7 +10647,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9080,8 +10669,8 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
@@ -9096,8 +10685,8 @@ entry:
 ; <label>:12                                      ; preds = %6
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
@@ -9112,8 +10701,8 @@ entry:
 ; <label>:21                                      ; preds = %15
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
@@ -9128,8 +10717,8 @@ entry:
 ; <label>:30                                      ; preds = %24
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %31, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
@@ -9144,8 +10733,8 @@ entry:
 ; <label>:39                                      ; preds = %33
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
-  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %40, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %42
 
 ; <label>:42                                      ; preds = %39
   %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
@@ -9164,19 +10753,19 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %21
+ThrowNullRef4:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %30
+ThrowNullRef6:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %39
+ThrowNullRef8:                                    ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9243,8 +10832,8 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
@@ -9264,57 +10853,57 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
   store i8 0, i8 addrspace(1)* %2
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
   store i8 0, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
   store i8 0, i8 addrspace(1)* %17
   %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
   store i8 0, i8 addrspace(1)* %20
   %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
-  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
@@ -9325,31 +10914,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %19
+ThrowNullRef14:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9367,8 +10956,8 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
@@ -9380,8 +10969,8 @@ entry:
 
 ; <label>:9                                       ; preds = %4
   %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %9
   %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
@@ -9395,7 +10984,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef2:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9420,8 +11009,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
@@ -9512,8 +11101,8 @@ entry:
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
@@ -9524,8 +11113,8 @@ entry:
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = load i64, i64 addrspace(1)* %12
@@ -9537,8 +11126,8 @@ entry:
   %20 = load i64, i64* %19
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
-  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %13
   %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
@@ -9555,8 +11144,8 @@ entry:
 ; <label>:30                                      ; preds = %25
   %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %32 = load i32, i32* %arg2
-  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
-  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
@@ -9570,15 +11159,15 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %30
+ThrowNullRef2:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9622,87 +11211,87 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
   %10 = load i8, i8 addrspace(1)* %9, align 8
   %11 = zext i8 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %8
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
   store i8 %12, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
   %19 = load i8, i8 addrspace(1)* %18, align 8
   %20 = zext i8 %19 to i32
   %21 = trunc i32 %20 to i8
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
   store i8 %21, i8 addrspace(1)* %23
   %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
   %28 = load i8, i8 addrspace(1)* %27, align 8
   %29 = zext i8 %28 to i32
   %30 = trunc i32 %29 to i8
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
-  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %31
 
 ; <label>:31                                      ; preds = %26
   %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
   store i8 %30, i8 addrspace(1)* %32
   %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
-  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
-  br i1 %NullCheck14, label %40, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %40
 
 ; <label>:40                                      ; preds = %35
   %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
   store i8 %39, i8 addrspace(1)* %41
   %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
-  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %44
 
 ; <label>:44                                      ; preds = %40
   %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
   %46 = load i8, i8 addrspace(1)* %45, align 8
   %47 = zext i8 %46 to i32
   %48 = trunc i32 %47 to i8
-  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
   store i8 %48, i8 addrspace(1)* %50
   %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
-  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
@@ -9713,29 +11302,29 @@ entry:
 ; <label>:56                                      ; preds = %52
   %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
-  br i1 %NullCheck22, label %59, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
   %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
   %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
-  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
-  br i1 %NullCheck24, label %63, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
   %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
-  br i1 %NullCheck26, label %66, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
   %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
-  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
-  br i1 %NullCheck28, label %69, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %69
 
 ; <label>:69                                      ; preds = %66
   %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
@@ -9744,15 +11333,15 @@ entry:
 
 ; <label>:71                                      ; preds = %105
   %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
-  br i1 %NullCheck34, label %73, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %73
 
 ; <label>:73                                      ; preds = %71
   %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
   %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
   %76 = load i32, i32* %loc0
-  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
-  br i1 %NullCheck36, label %77, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
@@ -9766,8 +11355,8 @@ entry:
 
 ; <label>:83                                      ; preds = %77
   %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
-  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
@@ -9775,14 +11364,14 @@ entry:
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
   %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
-  br i1 %NullCheck40, label %91, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
 ; <label>:91                                      ; preds = %85
   %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
   %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
-  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck42, label %94, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %94
 
 ; <label>:94                                      ; preds = %91
   %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
@@ -9798,14 +11387,14 @@ entry:
 ; <label>:99                                      ; preds = %69, %96
   %100 = load i32, i32* %loc0
   %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
-  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %102
 
 ; <label>:102                                     ; preds = %99
   %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
   %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
-  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
-  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
@@ -9819,87 +11408,87 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %26
+ThrowNullRef10:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %31
+ThrowNullRef12:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %35
+ThrowNullRef14:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %40
+ThrowNullRef16:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %56
+ThrowNullRef22:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %59
+ThrowNullRef24:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %63
+ThrowNullRef26:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %66
+ThrowNullRef28:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %102
+ThrowNullRef32:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %71
+ThrowNullRef34:                                   ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %73
+ThrowNullRef36:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %83
+ThrowNullRef38:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %85
+ThrowNullRef40:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %91
+ThrowNullRef42:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9943,15 +11532,15 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
   %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
@@ -9961,28 +11550,28 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
   %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %12
   %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
   %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
   %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
-  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
@@ -9993,23 +11582,23 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %12
+ThrowNullRef6:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10031,15 +11620,15 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
   %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = load i64, i64 addrspace(1)* %7
@@ -10077,13 +11666,13 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[loadElem]
+Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -10111,8 +11700,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Lt1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Lt1.error.txt
@@ -25,8 +25,8 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
@@ -40,8 +40,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
   %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
@@ -75,7 +75,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -90,8 +90,8 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %NullCheck = icmp ne i8 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = load i8, i8 addrspace(1)* %0, align 8
@@ -125,8 +125,8 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
@@ -159,8 +159,8 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -184,8 +184,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
   store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
@@ -195,8 +195,8 @@ entry:
 ; <label>:4                                       ; preds = %1
   %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
   %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
@@ -206,8 +206,8 @@ entry:
   %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
@@ -221,14 +221,14 @@ entry:
 
 ; <label>:17                                      ; preds = %14
   %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
   %21 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
@@ -238,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -249,8 +249,8 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
@@ -261,27 +261,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %30
+ThrowNullRef10:                                   ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -301,7 +301,89 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
-Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
+Successfully read AppDomainSetup.GetUnsecureApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.GetUnsecureApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %NullCheck = icmp eq %"System.String[]" addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %BoundsCheck = icmp uge i64 0, %5
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %6
+
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 3, i32 0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
+  ret %System.String addrspace(1)* %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_Value using LLILCJit
+Successfully read AppDomainSetup.get_Value
+
+define %"System.String[]" addrspace(1)* @AppDomainSetup.get_Value(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.String[]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 18)
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.String[]" addrspace(1)* addrspace(1)*, %"System.String[]" addrspace(1)*)*)(%"System.String[]" addrspace(1)* addrspace(1)* %9, %"System.String[]" addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %11, i32 0, i32 1
+  %14 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %13, align 8
+  ret %"System.String[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -319,8 +401,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -368,16 +450,16 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
   %5 = load i32, i32 addrspace(1)* %4
   %6 = sub i32 %5, 1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -389,7 +471,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -421,8 +503,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
@@ -456,8 +538,8 @@ entry:
 ; <label>:27                                      ; preds = %19
   %28 = load i32, i32* %arg1
   %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
-  br i1 %NullCheck2, label %30, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %29, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %30
 
 ; <label>:30                                      ; preds = %27
   %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
@@ -493,8 +575,8 @@ entry:
 ; <label>:49                                      ; preds = %46
   %50 = load i32, i32* %arg2
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck4, label %52, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
@@ -517,11 +599,11 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %27
+ThrowNullRef2:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %49
+ThrowNullRef4:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -544,16 +626,16 @@ entry:
   %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %0)
   store %System.String addrspace(1)* %1, %System.String addrspace(1)** %loc0
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 2
   %5 = bitcast [0 x i16] addrspace(1)* %4 to i16 addrspace(1)*
   store i16 addrspace(1)* %5, i16 addrspace(1)** %loc1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %3
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2
@@ -580,7 +662,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -691,15 +773,15 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %NullCheck132 = icmp ne i8* %21, null
-  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+  %NullCheck131 = icmp eq i8* %21, null
+  br i1 %NullCheck131, label %ThrowNullRef132, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = load i8, i8* %21, align 8
   %24 = zext i8 %23 to i32
   %25 = trunc i32 %24 to i8
-  %NullCheck134 = icmp ne i8* %20, null
-  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+  %NullCheck133 = icmp eq i8* %20, null
+  br i1 %NullCheck133, label %ThrowNullRef134, label %26
 
 ; <label>:26                                      ; preds = %22
   store i8 %25, i8* %20, align 8
@@ -709,16 +791,16 @@ entry:
   %28 = load i8*, i8** %arg0
   %29 = load i8*, i8** %arg1
   %30 = bitcast i8* %29 to i16*
-  %NullCheck128 = icmp ne i16* %30, null
-  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+  %NullCheck127 = icmp eq i16* %30, null
+  br i1 %NullCheck127, label %ThrowNullRef128, label %31
 
 ; <label>:31                                      ; preds = %27
   %32 = load i16, i16* %30, align 8
   %33 = sext i16 %32 to i32
   %34 = bitcast i8* %28 to i16*
   %35 = trunc i32 %33 to i16
-  %NullCheck130 = icmp ne i16* %34, null
-  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+  %NullCheck129 = icmp eq i16* %34, null
+  br i1 %NullCheck129, label %ThrowNullRef130, label %36
 
 ; <label>:36                                      ; preds = %31
   store i16 %35, i16* %34, align 8
@@ -728,16 +810,16 @@ entry:
   %38 = load i8*, i8** %arg0
   %39 = load i8*, i8** %arg1
   %40 = bitcast i8* %39 to i16*
-  %NullCheck120 = icmp ne i16* %40, null
-  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+  %NullCheck119 = icmp eq i16* %40, null
+  br i1 %NullCheck119, label %ThrowNullRef120, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i16, i16* %40, align 8
   %43 = sext i16 %42 to i32
   %44 = bitcast i8* %38 to i16*
   %45 = trunc i32 %43 to i16
-  %NullCheck122 = icmp ne i16* %44, null
-  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+  %NullCheck121 = icmp eq i16* %44, null
+  br i1 %NullCheck121, label %ThrowNullRef122, label %46
 
 ; <label>:46                                      ; preds = %41
   store i16 %45, i16* %44, align 8
@@ -745,15 +827,15 @@ entry:
   %48 = getelementptr inbounds i8, i8* %47, i64 2
   %49 = load i8*, i8** %arg1
   %50 = getelementptr inbounds i8, i8* %49, i64 2
-  %NullCheck124 = icmp ne i8* %50, null
-  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+  %NullCheck123 = icmp eq i8* %50, null
+  br i1 %NullCheck123, label %ThrowNullRef124, label %51
 
 ; <label>:51                                      ; preds = %46
   %52 = load i8, i8* %50, align 8
   %53 = zext i8 %52 to i32
   %54 = trunc i32 %53 to i8
-  %NullCheck126 = icmp ne i8* %48, null
-  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+  %NullCheck125 = icmp eq i8* %48, null
+  br i1 %NullCheck125, label %ThrowNullRef126, label %55
 
 ; <label>:55                                      ; preds = %51
   store i8 %54, i8* %48, align 8
@@ -763,14 +845,14 @@ entry:
   %57 = load i8*, i8** %arg0
   %58 = load i8*, i8** %arg1
   %59 = bitcast i8* %58 to i32*
-  %NullCheck116 = icmp ne i32* %59, null
-  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+  %NullCheck115 = icmp eq i32* %59, null
+  br i1 %NullCheck115, label %ThrowNullRef116, label %60
 
 ; <label>:60                                      ; preds = %56
   %61 = load i32, i32* %59, align 8
   %62 = bitcast i8* %57 to i32*
-  %NullCheck118 = icmp ne i32* %62, null
-  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+  %NullCheck117 = icmp eq i32* %62, null
+  br i1 %NullCheck117, label %ThrowNullRef118, label %63
 
 ; <label>:63                                      ; preds = %60
   store i32 %61, i32* %62, align 8
@@ -780,14 +862,14 @@ entry:
   %65 = load i8*, i8** %arg0
   %66 = load i8*, i8** %arg1
   %67 = bitcast i8* %66 to i32*
-  %NullCheck108 = icmp ne i32* %67, null
-  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+  %NullCheck107 = icmp eq i32* %67, null
+  br i1 %NullCheck107, label %ThrowNullRef108, label %68
 
 ; <label>:68                                      ; preds = %64
   %69 = load i32, i32* %67, align 8
   %70 = bitcast i8* %65 to i32*
-  %NullCheck110 = icmp ne i32* %70, null
-  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+  %NullCheck109 = icmp eq i32* %70, null
+  br i1 %NullCheck109, label %ThrowNullRef110, label %71
 
 ; <label>:71                                      ; preds = %68
   store i32 %69, i32* %70, align 8
@@ -795,15 +877,15 @@ entry:
   %73 = getelementptr inbounds i8, i8* %72, i64 4
   %74 = load i8*, i8** %arg1
   %75 = getelementptr inbounds i8, i8* %74, i64 4
-  %NullCheck112 = icmp ne i8* %75, null
-  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+  %NullCheck111 = icmp eq i8* %75, null
+  br i1 %NullCheck111, label %ThrowNullRef112, label %76
 
 ; <label>:76                                      ; preds = %71
   %77 = load i8, i8* %75, align 8
   %78 = zext i8 %77 to i32
   %79 = trunc i32 %78 to i8
-  %NullCheck114 = icmp ne i8* %73, null
-  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+  %NullCheck113 = icmp eq i8* %73, null
+  br i1 %NullCheck113, label %ThrowNullRef114, label %80
 
 ; <label>:80                                      ; preds = %76
   store i8 %79, i8* %73, align 8
@@ -813,14 +895,14 @@ entry:
   %82 = load i8*, i8** %arg0
   %83 = load i8*, i8** %arg1
   %84 = bitcast i8* %83 to i32*
-  %NullCheck100 = icmp ne i32* %84, null
-  br i1 %NullCheck100, label %85, label %ThrowNullRef99
+  %NullCheck99 = icmp eq i32* %84, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %85
 
 ; <label>:85                                      ; preds = %81
   %86 = load i32, i32* %84, align 8
   %87 = bitcast i8* %82 to i32*
-  %NullCheck102 = icmp ne i32* %87, null
-  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+  %NullCheck101 = icmp eq i32* %87, null
+  br i1 %NullCheck101, label %ThrowNullRef102, label %88
 
 ; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
@@ -829,16 +911,16 @@ entry:
   %91 = load i8*, i8** %arg1
   %92 = getelementptr inbounds i8, i8* %91, i64 4
   %93 = bitcast i8* %92 to i16*
-  %NullCheck104 = icmp ne i16* %93, null
-  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+  %NullCheck103 = icmp eq i16* %93, null
+  br i1 %NullCheck103, label %ThrowNullRef104, label %94
 
 ; <label>:94                                      ; preds = %88
   %95 = load i16, i16* %93, align 8
   %96 = sext i16 %95 to i32
   %97 = bitcast i8* %90 to i16*
   %98 = trunc i32 %96 to i16
-  %NullCheck106 = icmp ne i16* %97, null
-  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+  %NullCheck105 = icmp eq i16* %97, null
+  br i1 %NullCheck105, label %ThrowNullRef106, label %99
 
 ; <label>:99                                      ; preds = %94
   store i16 %98, i16* %97, align 8
@@ -848,14 +930,14 @@ entry:
   %101 = load i8*, i8** %arg0
   %102 = load i8*, i8** %arg1
   %103 = bitcast i8* %102 to i32*
-  %NullCheck88 = icmp ne i32* %103, null
-  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+  %NullCheck87 = icmp eq i32* %103, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %104
 
 ; <label>:104                                     ; preds = %100
   %105 = load i32, i32* %103, align 8
   %106 = bitcast i8* %101 to i32*
-  %NullCheck90 = icmp ne i32* %106, null
-  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+  %NullCheck89 = icmp eq i32* %106, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %107
 
 ; <label>:107                                     ; preds = %104
   store i32 %105, i32* %106, align 8
@@ -864,16 +946,16 @@ entry:
   %110 = load i8*, i8** %arg1
   %111 = getelementptr inbounds i8, i8* %110, i64 4
   %112 = bitcast i8* %111 to i16*
-  %NullCheck92 = icmp ne i16* %112, null
-  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+  %NullCheck91 = icmp eq i16* %112, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %113
 
 ; <label>:113                                     ; preds = %107
   %114 = load i16, i16* %112, align 8
   %115 = sext i16 %114 to i32
   %116 = bitcast i8* %109 to i16*
   %117 = trunc i32 %115 to i16
-  %NullCheck94 = icmp ne i16* %116, null
-  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+  %NullCheck93 = icmp eq i16* %116, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %118
 
 ; <label>:118                                     ; preds = %113
   store i16 %117, i16* %116, align 8
@@ -881,15 +963,15 @@ entry:
   %120 = getelementptr inbounds i8, i8* %119, i64 6
   %121 = load i8*, i8** %arg1
   %122 = getelementptr inbounds i8, i8* %121, i64 6
-  %NullCheck96 = icmp ne i8* %122, null
-  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+  %NullCheck95 = icmp eq i8* %122, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %123
 
 ; <label>:123                                     ; preds = %118
   %124 = load i8, i8* %122, align 8
   %125 = zext i8 %124 to i32
   %126 = trunc i32 %125 to i8
-  %NullCheck98 = icmp ne i8* %120, null
-  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+  %NullCheck97 = icmp eq i8* %120, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %127
 
 ; <label>:127                                     ; preds = %123
   store i8 %126, i8* %120, align 8
@@ -899,14 +981,14 @@ entry:
   %129 = load i8*, i8** %arg0
   %130 = load i8*, i8** %arg1
   %131 = bitcast i8* %130 to i64*
-  %NullCheck84 = icmp ne i64* %131, null
-  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+  %NullCheck83 = icmp eq i64* %131, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %132
 
 ; <label>:132                                     ; preds = %128
   %133 = load i64, i64* %131, align 8
   %134 = bitcast i8* %129 to i64*
-  %NullCheck86 = icmp ne i64* %134, null
-  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+  %NullCheck85 = icmp eq i64* %134, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %135
 
 ; <label>:135                                     ; preds = %132
   store i64 %133, i64* %134, align 8
@@ -916,14 +998,14 @@ entry:
   %137 = load i8*, i8** %arg0
   %138 = load i8*, i8** %arg1
   %139 = bitcast i8* %138 to i64*
-  %NullCheck76 = icmp ne i64* %139, null
-  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+  %NullCheck75 = icmp eq i64* %139, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %140
 
 ; <label>:140                                     ; preds = %136
   %141 = load i64, i64* %139, align 8
   %142 = bitcast i8* %137 to i64*
-  %NullCheck78 = icmp ne i64* %142, null
-  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+  %NullCheck77 = icmp eq i64* %142, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %143
 
 ; <label>:143                                     ; preds = %140
   store i64 %141, i64* %142, align 8
@@ -931,15 +1013,15 @@ entry:
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %NullCheck80 = icmp ne i8* %147, null
-  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+  %NullCheck79 = icmp eq i8* %147, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %148
 
 ; <label>:148                                     ; preds = %143
   %149 = load i8, i8* %147, align 8
   %150 = zext i8 %149 to i32
   %151 = trunc i32 %150 to i8
-  %NullCheck82 = icmp ne i8* %145, null
-  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+  %NullCheck81 = icmp eq i8* %145, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %152
 
 ; <label>:152                                     ; preds = %148
   store i8 %151, i8* %145, align 8
@@ -949,14 +1031,14 @@ entry:
   %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
   %156 = bitcast i8* %155 to i64*
-  %NullCheck68 = icmp ne i64* %156, null
-  br i1 %NullCheck68, label %157, label %ThrowNullRef67
+  %NullCheck67 = icmp eq i64* %156, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %157
 
 ; <label>:157                                     ; preds = %153
   %158 = load i64, i64* %156, align 8
   %159 = bitcast i8* %154 to i64*
-  %NullCheck70 = icmp ne i64* %159, null
-  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+  %NullCheck69 = icmp eq i64* %159, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %160
 
 ; <label>:160                                     ; preds = %157
   store i64 %158, i64* %159, align 8
@@ -965,16 +1047,16 @@ entry:
   %163 = load i8*, i8** %arg1
   %164 = getelementptr inbounds i8, i8* %163, i64 8
   %165 = bitcast i8* %164 to i16*
-  %NullCheck72 = icmp ne i16* %165, null
-  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+  %NullCheck71 = icmp eq i16* %165, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %166
 
 ; <label>:166                                     ; preds = %160
   %167 = load i16, i16* %165, align 8
   %168 = sext i16 %167 to i32
   %169 = bitcast i8* %162 to i16*
   %170 = trunc i32 %168 to i16
-  %NullCheck74 = icmp ne i16* %169, null
-  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+  %NullCheck73 = icmp eq i16* %169, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %171
 
 ; <label>:171                                     ; preds = %166
   store i16 %170, i16* %169, align 8
@@ -984,14 +1066,14 @@ entry:
   %173 = load i8*, i8** %arg0
   %174 = load i8*, i8** %arg1
   %175 = bitcast i8* %174 to i64*
-  %NullCheck56 = icmp ne i64* %175, null
-  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+  %NullCheck55 = icmp eq i64* %175, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %176
 
 ; <label>:176                                     ; preds = %172
   %177 = load i64, i64* %175, align 8
   %178 = bitcast i8* %173 to i64*
-  %NullCheck58 = icmp ne i64* %178, null
-  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+  %NullCheck57 = icmp eq i64* %178, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %179
 
 ; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
@@ -1000,16 +1082,16 @@ entry:
   %182 = load i8*, i8** %arg1
   %183 = getelementptr inbounds i8, i8* %182, i64 8
   %184 = bitcast i8* %183 to i16*
-  %NullCheck60 = icmp ne i16* %184, null
-  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+  %NullCheck59 = icmp eq i16* %184, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %185
 
 ; <label>:185                                     ; preds = %179
   %186 = load i16, i16* %184, align 8
   %187 = sext i16 %186 to i32
   %188 = bitcast i8* %181 to i16*
   %189 = trunc i32 %187 to i16
-  %NullCheck62 = icmp ne i16* %188, null
-  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+  %NullCheck61 = icmp eq i16* %188, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %190
 
 ; <label>:190                                     ; preds = %185
   store i16 %189, i16* %188, align 8
@@ -1017,15 +1099,15 @@ entry:
   %192 = getelementptr inbounds i8, i8* %191, i64 10
   %193 = load i8*, i8** %arg1
   %194 = getelementptr inbounds i8, i8* %193, i64 10
-  %NullCheck64 = icmp ne i8* %194, null
-  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+  %NullCheck63 = icmp eq i8* %194, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %195
 
 ; <label>:195                                     ; preds = %190
   %196 = load i8, i8* %194, align 8
   %197 = zext i8 %196 to i32
   %198 = trunc i32 %197 to i8
-  %NullCheck66 = icmp ne i8* %192, null
-  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+  %NullCheck65 = icmp eq i8* %192, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %199
 
 ; <label>:199                                     ; preds = %195
   store i8 %198, i8* %192, align 8
@@ -1035,14 +1117,14 @@ entry:
   %201 = load i8*, i8** %arg0
   %202 = load i8*, i8** %arg1
   %203 = bitcast i8* %202 to i64*
-  %NullCheck48 = icmp ne i64* %203, null
-  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+  %NullCheck47 = icmp eq i64* %203, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %204
 
 ; <label>:204                                     ; preds = %200
   %205 = load i64, i64* %203, align 8
   %206 = bitcast i8* %201 to i64*
-  %NullCheck50 = icmp ne i64* %206, null
-  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+  %NullCheck49 = icmp eq i64* %206, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %207
 
 ; <label>:207                                     ; preds = %204
   store i64 %205, i64* %206, align 8
@@ -1051,14 +1133,14 @@ entry:
   %210 = load i8*, i8** %arg1
   %211 = getelementptr inbounds i8, i8* %210, i64 8
   %212 = bitcast i8* %211 to i32*
-  %NullCheck52 = icmp ne i32* %212, null
-  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+  %NullCheck51 = icmp eq i32* %212, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %213
 
 ; <label>:213                                     ; preds = %207
   %214 = load i32, i32* %212, align 8
   %215 = bitcast i8* %209 to i32*
-  %NullCheck54 = icmp ne i32* %215, null
-  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+  %NullCheck53 = icmp eq i32* %215, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %216
 
 ; <label>:216                                     ; preds = %213
   store i32 %214, i32* %215, align 8
@@ -1068,14 +1150,14 @@ entry:
   %218 = load i8*, i8** %arg0
   %219 = load i8*, i8** %arg1
   %220 = bitcast i8* %219 to i64*
-  %NullCheck36 = icmp ne i64* %220, null
-  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64* %220, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %221
 
 ; <label>:221                                     ; preds = %217
   %222 = load i64, i64* %220, align 8
   %223 = bitcast i8* %218 to i64*
-  %NullCheck38 = icmp ne i64* %223, null
-  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+  %NullCheck37 = icmp eq i64* %223, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %224
 
 ; <label>:224                                     ; preds = %221
   store i64 %222, i64* %223, align 8
@@ -1084,14 +1166,14 @@ entry:
   %227 = load i8*, i8** %arg1
   %228 = getelementptr inbounds i8, i8* %227, i64 8
   %229 = bitcast i8* %228 to i32*
-  %NullCheck40 = icmp ne i32* %229, null
-  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i32* %229, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %230
 
 ; <label>:230                                     ; preds = %224
   %231 = load i32, i32* %229, align 8
   %232 = bitcast i8* %226 to i32*
-  %NullCheck42 = icmp ne i32* %232, null
-  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+  %NullCheck41 = icmp eq i32* %232, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %233
 
 ; <label>:233                                     ; preds = %230
   store i32 %231, i32* %232, align 8
@@ -1099,15 +1181,15 @@ entry:
   %235 = getelementptr inbounds i8, i8* %234, i64 12
   %236 = load i8*, i8** %arg1
   %237 = getelementptr inbounds i8, i8* %236, i64 12
-  %NullCheck44 = icmp ne i8* %237, null
-  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i8* %237, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %238
 
 ; <label>:238                                     ; preds = %233
   %239 = load i8, i8* %237, align 8
   %240 = zext i8 %239 to i32
   %241 = trunc i32 %240 to i8
-  %NullCheck46 = icmp ne i8* %235, null
-  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+  %NullCheck45 = icmp eq i8* %235, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %242
 
 ; <label>:242                                     ; preds = %238
   store i8 %241, i8* %235, align 8
@@ -1117,14 +1199,14 @@ entry:
   %244 = load i8*, i8** %arg0
   %245 = load i8*, i8** %arg1
   %246 = bitcast i8* %245 to i64*
-  %NullCheck24 = icmp ne i64* %246, null
-  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64* %246, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %247
 
 ; <label>:247                                     ; preds = %243
   %248 = load i64, i64* %246, align 8
   %249 = bitcast i8* %244 to i64*
-  %NullCheck26 = icmp ne i64* %249, null
-  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64* %249, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %250
 
 ; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
@@ -1133,14 +1215,14 @@ entry:
   %253 = load i8*, i8** %arg1
   %254 = getelementptr inbounds i8, i8* %253, i64 8
   %255 = bitcast i8* %254 to i32*
-  %NullCheck28 = icmp ne i32* %255, null
-  br i1 %NullCheck28, label %256, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i32* %255, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %256
 
 ; <label>:256                                     ; preds = %250
   %257 = load i32, i32* %255, align 8
   %258 = bitcast i8* %252 to i32*
-  %NullCheck30 = icmp ne i32* %258, null
-  br i1 %NullCheck30, label %259, label %ThrowNullRef29
+  %NullCheck29 = icmp eq i32* %258, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %259
 
 ; <label>:259                                     ; preds = %256
   store i32 %257, i32* %258, align 8
@@ -1149,16 +1231,16 @@ entry:
   %262 = load i8*, i8** %arg1
   %263 = getelementptr inbounds i8, i8* %262, i64 12
   %264 = bitcast i8* %263 to i16*
-  %NullCheck32 = icmp ne i16* %264, null
-  br i1 %NullCheck32, label %265, label %ThrowNullRef31
+  %NullCheck31 = icmp eq i16* %264, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %265
 
 ; <label>:265                                     ; preds = %259
   %266 = load i16, i16* %264, align 8
   %267 = sext i16 %266 to i32
   %268 = bitcast i8* %261 to i16*
   %269 = trunc i32 %267 to i16
-  %NullCheck34 = icmp ne i16* %268, null
-  br i1 %NullCheck34, label %270, label %ThrowNullRef33
+  %NullCheck33 = icmp eq i16* %268, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %270
 
 ; <label>:270                                     ; preds = %265
   store i16 %269, i16* %268, align 8
@@ -1168,14 +1250,14 @@ entry:
   %272 = load i8*, i8** %arg0
   %273 = load i8*, i8** %arg1
   %274 = bitcast i8* %273 to i64*
-  %NullCheck8 = icmp ne i64* %274, null
-  br i1 %NullCheck8, label %275, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64* %274, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %275
 
 ; <label>:275                                     ; preds = %271
   %276 = load i64, i64* %274, align 8
   %277 = bitcast i8* %272 to i64*
-  %NullCheck10 = icmp ne i64* %277, null
-  br i1 %NullCheck10, label %278, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %277, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %278
 
 ; <label>:278                                     ; preds = %275
   store i64 %276, i64* %277, align 8
@@ -1184,14 +1266,14 @@ entry:
   %281 = load i8*, i8** %arg1
   %282 = getelementptr inbounds i8, i8* %281, i64 8
   %283 = bitcast i8* %282 to i32*
-  %NullCheck12 = icmp ne i32* %283, null
-  br i1 %NullCheck12, label %284, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i32* %283, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %284
 
 ; <label>:284                                     ; preds = %278
   %285 = load i32, i32* %283, align 8
   %286 = bitcast i8* %280 to i32*
-  %NullCheck14 = icmp ne i32* %286, null
-  br i1 %NullCheck14, label %287, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i32* %286, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %287
 
 ; <label>:287                                     ; preds = %284
   store i32 %285, i32* %286, align 8
@@ -1200,16 +1282,16 @@ entry:
   %290 = load i8*, i8** %arg1
   %291 = getelementptr inbounds i8, i8* %290, i64 12
   %292 = bitcast i8* %291 to i16*
-  %NullCheck16 = icmp ne i16* %292, null
-  br i1 %NullCheck16, label %293, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i16* %292, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %293
 
 ; <label>:293                                     ; preds = %287
   %294 = load i16, i16* %292, align 8
   %295 = sext i16 %294 to i32
   %296 = bitcast i8* %289 to i16*
   %297 = trunc i32 %295 to i16
-  %NullCheck18 = icmp ne i16* %296, null
-  br i1 %NullCheck18, label %298, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i16* %296, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %298
 
 ; <label>:298                                     ; preds = %293
   store i16 %297, i16* %296, align 8
@@ -1217,15 +1299,15 @@ entry:
   %300 = getelementptr inbounds i8, i8* %299, i64 14
   %301 = load i8*, i8** %arg1
   %302 = getelementptr inbounds i8, i8* %301, i64 14
-  %NullCheck20 = icmp ne i8* %302, null
-  br i1 %NullCheck20, label %303, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i8* %302, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %303
 
 ; <label>:303                                     ; preds = %298
   %304 = load i8, i8* %302, align 8
   %305 = zext i8 %304 to i32
   %306 = trunc i32 %305 to i8
-  %NullCheck22 = icmp ne i8* %300, null
-  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i8* %300, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %307
 
 ; <label>:307                                     ; preds = %303
   store i8 %306, i8* %300, align 8
@@ -1235,14 +1317,14 @@ entry:
   %309 = load i8*, i8** %arg0
   %310 = load i8*, i8** %arg1
   %311 = bitcast i8* %310 to i64*
-  %NullCheck = icmp ne i64* %311, null
-  br i1 %NullCheck, label %312, label %ThrowNullRef
+  %NullCheck = icmp eq i64* %311, null
+  br i1 %NullCheck, label %ThrowNullRef, label %312
 
 ; <label>:312                                     ; preds = %308
   %313 = load i64, i64* %311, align 8
   %314 = bitcast i8* %309 to i64*
-  %NullCheck2 = icmp ne i64* %314, null
-  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64* %314, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %315
 
 ; <label>:315                                     ; preds = %312
   store i64 %313, i64* %314, align 8
@@ -1251,14 +1333,14 @@ entry:
   %318 = load i8*, i8** %arg1
   %319 = getelementptr inbounds i8, i8* %318, i64 8
   %320 = bitcast i8* %319 to i64*
-  %NullCheck4 = icmp ne i64* %320, null
-  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64* %320, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %321
 
 ; <label>:321                                     ; preds = %315
   %322 = load i64, i64* %320, align 8
   %323 = bitcast i8* %317 to i64*
-  %NullCheck6 = icmp ne i64* %323, null
-  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64* %323, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %324
 
 ; <label>:324                                     ; preds = %321
   store i64 %322, i64* %323, align 8
@@ -1286,15 +1368,15 @@ entry:
 ; <label>:338                                     ; preds = %333
   %339 = load i8*, i8** %arg0
   %340 = load i8*, i8** %arg1
-  %NullCheck136 = icmp ne i8* %340, null
-  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+  %NullCheck135 = icmp eq i8* %340, null
+  br i1 %NullCheck135, label %ThrowNullRef136, label %341
 
 ; <label>:341                                     ; preds = %338
   %342 = load i8, i8* %340, align 8
   %343 = zext i8 %342 to i32
   %344 = trunc i32 %343 to i8
-  %NullCheck138 = icmp ne i8* %339, null
-  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+  %NullCheck137 = icmp eq i8* %339, null
+  br i1 %NullCheck137, label %ThrowNullRef138, label %345
 
 ; <label>:345                                     ; preds = %341
   store i8 %344, i8* %339, align 8
@@ -1317,16 +1399,16 @@ entry:
   %357 = load i8*, i8** %arg0
   %358 = load i8*, i8** %arg1
   %359 = bitcast i8* %358 to i16*
-  %NullCheck140 = icmp ne i16* %359, null
-  br i1 %NullCheck140, label %360, label %ThrowNullRef139
+  %NullCheck139 = icmp eq i16* %359, null
+  br i1 %NullCheck139, label %ThrowNullRef140, label %360
 
 ; <label>:360                                     ; preds = %356
   %361 = load i16, i16* %359, align 8
   %362 = sext i16 %361 to i32
   %363 = bitcast i8* %357 to i16*
   %364 = trunc i32 %362 to i16
-  %NullCheck142 = icmp ne i16* %363, null
-  br i1 %NullCheck142, label %365, label %ThrowNullRef141
+  %NullCheck141 = icmp eq i16* %363, null
+  br i1 %NullCheck141, label %ThrowNullRef142, label %365
 
 ; <label>:365                                     ; preds = %360
   store i16 %364, i16* %363, align 8
@@ -1352,14 +1434,14 @@ entry:
   %378 = load i8*, i8** %arg0
   %379 = load i8*, i8** %arg1
   %380 = bitcast i8* %379 to i32*
-  %NullCheck144 = icmp ne i32* %380, null
-  br i1 %NullCheck144, label %381, label %ThrowNullRef143
+  %NullCheck143 = icmp eq i32* %380, null
+  br i1 %NullCheck143, label %ThrowNullRef144, label %381
 
 ; <label>:381                                     ; preds = %377
   %382 = load i32, i32* %380, align 8
   %383 = bitcast i8* %378 to i32*
-  %NullCheck146 = icmp ne i32* %383, null
-  br i1 %NullCheck146, label %384, label %ThrowNullRef145
+  %NullCheck145 = icmp eq i32* %383, null
+  br i1 %NullCheck145, label %ThrowNullRef146, label %384
 
 ; <label>:384                                     ; preds = %381
   store i32 %382, i32* %383, align 8
@@ -1384,14 +1466,14 @@ entry:
   %395 = load i8*, i8** %arg0
   %396 = load i8*, i8** %arg1
   %397 = bitcast i8* %396 to i64*
-  %NullCheck164 = icmp ne i64* %397, null
-  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+  %NullCheck163 = icmp eq i64* %397, null
+  br i1 %NullCheck163, label %ThrowNullRef164, label %398
 
 ; <label>:398                                     ; preds = %394
   %399 = load i64, i64* %397, align 8
   %400 = bitcast i8* %395 to i64*
-  %NullCheck166 = icmp ne i64* %400, null
-  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+  %NullCheck165 = icmp eq i64* %400, null
+  br i1 %NullCheck165, label %ThrowNullRef166, label %401
 
 ; <label>:401                                     ; preds = %398
   store i64 %399, i64* %400, align 8
@@ -1400,14 +1482,14 @@ entry:
   %404 = load i8*, i8** %arg1
   %405 = getelementptr inbounds i8, i8* %404, i64 8
   %406 = bitcast i8* %405 to i64*
-  %NullCheck168 = icmp ne i64* %406, null
-  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+  %NullCheck167 = icmp eq i64* %406, null
+  br i1 %NullCheck167, label %ThrowNullRef168, label %407
 
 ; <label>:407                                     ; preds = %401
   %408 = load i64, i64* %406, align 8
   %409 = bitcast i8* %403 to i64*
-  %NullCheck170 = icmp ne i64* %409, null
-  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+  %NullCheck169 = icmp eq i64* %409, null
+  br i1 %NullCheck169, label %ThrowNullRef170, label %410
 
 ; <label>:410                                     ; preds = %407
   store i64 %408, i64* %409, align 8
@@ -1437,14 +1519,14 @@ entry:
   %425 = load i8*, i8** %arg0
   %426 = load i8*, i8** %arg1
   %427 = bitcast i8* %426 to i64*
-  %NullCheck148 = icmp ne i64* %427, null
-  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+  %NullCheck147 = icmp eq i64* %427, null
+  br i1 %NullCheck147, label %ThrowNullRef148, label %428
 
 ; <label>:428                                     ; preds = %424
   %429 = load i64, i64* %427, align 8
   %430 = bitcast i8* %425 to i64*
-  %NullCheck150 = icmp ne i64* %430, null
-  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+  %NullCheck149 = icmp eq i64* %430, null
+  br i1 %NullCheck149, label %ThrowNullRef150, label %431
 
 ; <label>:431                                     ; preds = %428
   store i64 %429, i64* %430, align 8
@@ -1466,14 +1548,14 @@ entry:
   %441 = load i8*, i8** %arg0
   %442 = load i8*, i8** %arg1
   %443 = bitcast i8* %442 to i32*
-  %NullCheck152 = icmp ne i32* %443, null
-  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+  %NullCheck151 = icmp eq i32* %443, null
+  br i1 %NullCheck151, label %ThrowNullRef152, label %444
 
 ; <label>:444                                     ; preds = %440
   %445 = load i32, i32* %443, align 8
   %446 = bitcast i8* %441 to i32*
-  %NullCheck154 = icmp ne i32* %446, null
-  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+  %NullCheck153 = icmp eq i32* %446, null
+  br i1 %NullCheck153, label %ThrowNullRef154, label %447
 
 ; <label>:447                                     ; preds = %444
   store i32 %445, i32* %446, align 8
@@ -1495,16 +1577,16 @@ entry:
   %457 = load i8*, i8** %arg0
   %458 = load i8*, i8** %arg1
   %459 = bitcast i8* %458 to i16*
-  %NullCheck156 = icmp ne i16* %459, null
-  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+  %NullCheck155 = icmp eq i16* %459, null
+  br i1 %NullCheck155, label %ThrowNullRef156, label %460
 
 ; <label>:460                                     ; preds = %456
   %461 = load i16, i16* %459, align 8
   %462 = sext i16 %461 to i32
   %463 = bitcast i8* %457 to i16*
   %464 = trunc i32 %462 to i16
-  %NullCheck158 = icmp ne i16* %463, null
-  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+  %NullCheck157 = icmp eq i16* %463, null
+  br i1 %NullCheck157, label %ThrowNullRef158, label %465
 
 ; <label>:465                                     ; preds = %460
   store i16 %464, i16* %463, align 8
@@ -1525,15 +1607,15 @@ entry:
 ; <label>:474                                     ; preds = %470
   %475 = load i8*, i8** %arg0
   %476 = load i8*, i8** %arg1
-  %NullCheck160 = icmp ne i8* %476, null
-  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+  %NullCheck159 = icmp eq i8* %476, null
+  br i1 %NullCheck159, label %ThrowNullRef160, label %477
 
 ; <label>:477                                     ; preds = %474
   %478 = load i8, i8* %476, align 8
   %479 = zext i8 %478 to i32
   %480 = trunc i32 %479 to i8
-  %NullCheck162 = icmp ne i8* %475, null
-  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+  %NullCheck161 = icmp eq i8* %475, null
+  br i1 %NullCheck161, label %ThrowNullRef162, label %481
 
 ; <label>:481                                     ; preds = %477
   store i8 %480, i8* %475, align 8
@@ -1553,343 +1635,343 @@ ThrowNullRef:                                     ; preds = %308
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %312
+ThrowNullRef2:                                    ; preds = %312
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %315
+ThrowNullRef4:                                    ; preds = %315
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %321
+ThrowNullRef6:                                    ; preds = %321
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %271
+ThrowNullRef8:                                    ; preds = %271
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %275
+ThrowNullRef10:                                   ; preds = %275
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %278
+ThrowNullRef12:                                   ; preds = %278
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %284
+ThrowNullRef14:                                   ; preds = %284
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %287
+ThrowNullRef16:                                   ; preds = %287
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %293
+ThrowNullRef18:                                   ; preds = %293
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %298
+ThrowNullRef20:                                   ; preds = %298
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %303
+ThrowNullRef22:                                   ; preds = %303
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %243
+ThrowNullRef24:                                   ; preds = %243
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %247
+ThrowNullRef26:                                   ; preds = %247
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %250
+ThrowNullRef28:                                   ; preds = %250
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %256
+ThrowNullRef30:                                   ; preds = %256
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %259
+ThrowNullRef32:                                   ; preds = %259
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %265
+ThrowNullRef34:                                   ; preds = %265
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %217
+ThrowNullRef36:                                   ; preds = %217
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %221
+ThrowNullRef38:                                   ; preds = %221
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %224
+ThrowNullRef40:                                   ; preds = %224
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %230
+ThrowNullRef42:                                   ; preds = %230
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %233
+ThrowNullRef44:                                   ; preds = %233
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %238
+ThrowNullRef46:                                   ; preds = %238
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %200
+ThrowNullRef48:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %204
+ThrowNullRef50:                                   ; preds = %204
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %207
+ThrowNullRef52:                                   ; preds = %207
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %213
+ThrowNullRef54:                                   ; preds = %213
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %172
+ThrowNullRef56:                                   ; preds = %172
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %176
+ThrowNullRef58:                                   ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %179
+ThrowNullRef60:                                   ; preds = %179
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %185
+ThrowNullRef62:                                   ; preds = %185
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %190
+ThrowNullRef64:                                   ; preds = %190
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %195
+ThrowNullRef66:                                   ; preds = %195
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %153
+ThrowNullRef68:                                   ; preds = %153
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %157
+ThrowNullRef70:                                   ; preds = %157
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %160
+ThrowNullRef72:                                   ; preds = %160
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %166
+ThrowNullRef74:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %136
+ThrowNullRef76:                                   ; preds = %136
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %140
+ThrowNullRef78:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %143
+ThrowNullRef80:                                   ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %148
+ThrowNullRef82:                                   ; preds = %148
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %128
+ThrowNullRef84:                                   ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %132
+ThrowNullRef86:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %100
+ThrowNullRef88:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %104
+ThrowNullRef90:                                   ; preds = %104
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %107
+ThrowNullRef92:                                   ; preds = %107
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %113
+ThrowNullRef94:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %118
+ThrowNullRef96:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %123
+ThrowNullRef98:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %81
+ThrowNullRef100:                                  ; preds = %81
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef101:                                  ; preds = %85
+ThrowNullRef102:                                  ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef103:                                  ; preds = %88
+ThrowNullRef104:                                  ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef105:                                  ; preds = %94
+ThrowNullRef106:                                  ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef107:                                  ; preds = %64
+ThrowNullRef108:                                  ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef109:                                  ; preds = %68
+ThrowNullRef110:                                  ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef111:                                  ; preds = %71
+ThrowNullRef112:                                  ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef113:                                  ; preds = %76
+ThrowNullRef114:                                  ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef115:                                  ; preds = %56
+ThrowNullRef116:                                  ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef117:                                  ; preds = %60
+ThrowNullRef118:                                  ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef119:                                  ; preds = %37
+ThrowNullRef120:                                  ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef121:                                  ; preds = %41
+ThrowNullRef122:                                  ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef123:                                  ; preds = %46
+ThrowNullRef124:                                  ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef125:                                  ; preds = %51
+ThrowNullRef126:                                  ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef127:                                  ; preds = %27
+ThrowNullRef128:                                  ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef129:                                  ; preds = %31
+ThrowNullRef130:                                  ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef131:                                  ; preds = %19
+ThrowNullRef132:                                  ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef133:                                  ; preds = %22
+ThrowNullRef134:                                  ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef135:                                  ; preds = %338
+ThrowNullRef136:                                  ; preds = %338
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef137:                                  ; preds = %341
+ThrowNullRef138:                                  ; preds = %341
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef139:                                  ; preds = %356
+ThrowNullRef140:                                  ; preds = %356
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef141:                                  ; preds = %360
+ThrowNullRef142:                                  ; preds = %360
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef143:                                  ; preds = %377
+ThrowNullRef144:                                  ; preds = %377
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef145:                                  ; preds = %381
+ThrowNullRef146:                                  ; preds = %381
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef147:                                  ; preds = %424
+ThrowNullRef148:                                  ; preds = %424
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef149:                                  ; preds = %428
+ThrowNullRef150:                                  ; preds = %428
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef151:                                  ; preds = %440
+ThrowNullRef152:                                  ; preds = %440
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef153:                                  ; preds = %444
+ThrowNullRef154:                                  ; preds = %444
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef155:                                  ; preds = %456
+ThrowNullRef156:                                  ; preds = %456
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef157:                                  ; preds = %460
+ThrowNullRef158:                                  ; preds = %460
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef159:                                  ; preds = %474
+ThrowNullRef160:                                  ; preds = %474
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef161:                                  ; preds = %477
+ThrowNullRef162:                                  ; preds = %477
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef163:                                  ; preds = %394
+ThrowNullRef164:                                  ; preds = %394
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef165:                                  ; preds = %398
+ThrowNullRef166:                                  ; preds = %398
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef167:                                  ; preds = %401
+ThrowNullRef168:                                  ; preds = %401
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef169:                                  ; preds = %407
+ThrowNullRef170:                                  ; preds = %407
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1939,8 +2021,8 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
-  br i1 %NullCheck, label %22, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %ThrowNullRef, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
@@ -1948,8 +2030,8 @@ entry:
   store i32 %24, i32* %loc0
   %25 = load i32, i32* %loc0
   %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %26, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %27
 
 ; <label>:27                                      ; preds = %22
   %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
@@ -1971,7 +2053,7 @@ ThrowNullRef:                                     ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1989,8 +2071,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -2022,15 +2104,15 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2048,16 +2130,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
   %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
   store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %15
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
@@ -2072,8 +2154,8 @@ entry:
   %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
   %29 = ptrtoint i16 addrspace(1)* %28 to i64
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %19
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
@@ -2089,19 +2171,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2114,8 +2196,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
@@ -2128,7 +2210,7 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[loadElem]
+Failed to read AppDomain.PrepareDataForSetup[storeElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
@@ -2202,8 +2284,8 @@ entry:
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
-  br i1 %NullCheck24, label %27, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = load i64, i64 addrspace(1)* %26
@@ -2218,8 +2300,8 @@ entry:
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
-  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
   %41 = load i64, i64 addrspace(1)* %39
@@ -2236,8 +2318,8 @@ entry:
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
-  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
   %54 = load i64, i64 addrspace(1)* %52
@@ -2252,8 +2334,8 @@ entry:
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
   %67 = load i64, i64 addrspace(1)* %65
@@ -2270,8 +2352,8 @@ entry:
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
-  br i1 %NullCheck16, label %79, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
   %80 = load i64, i64 addrspace(1)* %78
@@ -2286,8 +2368,8 @@ entry:
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
-  br i1 %NullCheck18, label %92, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
   %93 = load i64, i64 addrspace(1)* %91
@@ -2304,8 +2386,8 @@ entry:
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
-  br i1 %NullCheck12, label %105, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = load i64, i64 addrspace(1)* %104
@@ -2320,8 +2402,8 @@ entry:
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
-  br i1 %NullCheck14, label %118, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
   %119 = load i64, i64 addrspace(1)* %117
@@ -2337,8 +2419,8 @@ entry:
 
 ; <label>:128                                     ; preds = %20
   %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
-  br i1 %NullCheck4, label %130, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %129, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %130
 
 ; <label>:130                                     ; preds = %128
   %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
@@ -2346,8 +2428,8 @@ entry:
   %133 = load i16, i16 addrspace(1)* %132, align 8
   %134 = zext i16 %133 to i32
   %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
-  br i1 %NullCheck6, label %136, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %135, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %136
 
 ; <label>:136                                     ; preds = %130
   %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
@@ -2360,8 +2442,8 @@ entry:
 
 ; <label>:143                                     ; preds = %136
   %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
-  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %144, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %145
 
 ; <label>:145                                     ; preds = %143
   %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
@@ -2369,8 +2451,8 @@ entry:
   %148 = load i16, i16 addrspace(1)* %147, align 8
   %149 = zext i16 %148 to i32
   %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %150, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %151
 
 ; <label>:151                                     ; preds = %145
   %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
@@ -2388,8 +2470,8 @@ entry:
 
 ; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
-  br i1 %NullCheck, label %163, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %ThrowNullRef, label %163
 
 ; <label>:163                                     ; preds = %161
   %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
@@ -2399,8 +2481,8 @@ entry:
 
 ; <label>:167                                     ; preds = %163
   %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
-  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %168, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %169
 
 ; <label>:169                                     ; preds = %167
   %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
@@ -2432,55 +2514,55 @@ ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %167
+ThrowNullRef2:                                    ; preds = %167
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %128
+ThrowNullRef4:                                    ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %130
+ThrowNullRef6:                                    ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %143
+ThrowNullRef8:                                    ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %145
+ThrowNullRef10:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %102
+ThrowNullRef12:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %105
+ThrowNullRef14:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %76
+ThrowNullRef16:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %79
+ThrowNullRef18:                                   ; preds = %79
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %50
+ThrowNullRef20:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %53
+ThrowNullRef22:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %24
+ThrowNullRef24:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %27
+ThrowNullRef26:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2503,15 +2585,15 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2519,16 +2601,16 @@ entry:
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
   store i32 %8, i32* %loc0
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
   %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
   store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
@@ -2546,16 +2628,16 @@ entry:
 
 ; <label>:23                                      ; preds = %64
   %24 = load i16*, i16** %loc3
-  %NullCheck12 = icmp ne i16* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i16* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
   store i32 %27, i32* %loc5
   %28 = load i16*, i16** %loc4
-  %NullCheck14 = icmp ne i16* %28, null
-  br i1 %NullCheck14, label %29, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %28, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = load i16, i16* %28, align 8
@@ -2620,15 +2702,15 @@ entry:
 
 ; <label>:67                                      ; preds = %64
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
-  br i1 %NullCheck8, label %69, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %68, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %69
 
 ; <label>:69                                      ; preds = %67
   %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
   %71 = load i32, i32 addrspace(1)* %70
   %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
-  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %73
 
 ; <label>:73                                      ; preds = %69
   %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
@@ -2645,31 +2727,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %67
+ThrowNullRef8:                                    ; preds = %67
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %69
+ThrowNullRef10:                                   ; preds = %69
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2710,14 +2792,14 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
   %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
@@ -2730,14 +2812,14 @@ entry:
 
 ; <label>:11                                      ; preds = %4
   %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
   %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
@@ -2749,14 +2831,14 @@ entry:
 
 ; <label>:22                                      ; preds = %16
   %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
   %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
-  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
-  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
@@ -2804,23 +2886,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2836,7 +2918,280 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[loadElem]
+Successfully read RuntimeType.IsAssignableFrom
+
+define i8 @RuntimeType.IsAssignableFrom(%System.RuntimeType addrspace(1)* %param0, %System.Type addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.RuntimeType addrspace(1)*
+  %arg1 = alloca %System.Type addrspace(1)*
+  %loc0 = alloca %System.RuntimeType addrspace(1)*
+  %loc1 = alloca %"System.Type[]" addrspace(1)*
+  %loc2 = alloca i32
+  store %System.RuntimeType addrspace(1)* %param0, %System.RuntimeType addrspace(1)** %this
+  store %System.Type addrspace(1)* %param1, %System.Type addrspace(1)** %arg1
+  %0 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %1 = icmp ne %System.Type addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i8 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %5 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %6 = bitcast %System.Type addrspace(1)* %4 to %System.Object addrspace(1)*
+  %7 = bitcast %System.RuntimeType addrspace(1)* %5 to %System.Object addrspace(1)*
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %6, %System.Object addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %3
+  ret i8 1
+
+; <label>:12                                      ; preds = %3
+  %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 152
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 32
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
+  %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
+  %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
+  store %System.RuntimeType addrspace(1)* %25, %System.RuntimeType addrspace(1)** %loc0
+  %26 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %27 = icmp eq %System.RuntimeType addrspace(1)* %26, null
+  br i1 %27, label %34, label %28
+
+; <label>:28                                      ; preds = %15
+  %29 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %30 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)*)*)(%System.RuntimeType addrspace(1)* %29, %System.RuntimeType addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+; <label>:34                                      ; preds = %15
+  %35 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %36 = call %System.Reflection.Emit.TypeBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Reflection.Emit.TypeBuilder addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %35)
+  %37 = icmp eq %System.Reflection.Emit.TypeBuilder addrspace(1)* %36, null
+  br i1 %37, label %139, label %38
+
+; <label>:38                                      ; preds = %34
+  %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %42
+
+; <label>:42                                      ; preds = %38
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 152
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 40
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
+  %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
+  %53 = zext i8 %52 to i32
+  %54 = icmp eq i32 %53, 0
+  br i1 %54, label %56, label %55
+
+; <label>:55                                      ; preds = %42
+  ret i8 1
+
+; <label>:56                                      ; preds = %42
+  %57 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %58 = bitcast %System.RuntimeType addrspace(1)* %57 to %System.Type addrspace(1)*
+  %59 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %58)
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %64 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.Type addrspace(1)* %63, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = bitcast %System.RuntimeType addrspace(1)* %64 to %System.Type addrspace(1)*
+  %67 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %63, %System.Type addrspace(1)* %66)
+  %68 = zext i8 %67 to i32
+  %69 = trunc i32 %68 to i8
+  ret i8 %69
+
+; <label>:70                                      ; preds = %56
+  %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
+  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %73
+
+; <label>:73                                      ; preds = %70
+  %74 = load i64, i64 addrspace(1)* %72
+  %75 = add i64 %74, 128
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = add i64 %77, 0
+  %79 = inttoptr i64 %78 to i64*
+  %80 = load i64, i64* %79
+  %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
+  %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
+  %83 = call i8 %82(%System.Type addrspace(1)* %81)
+  %84 = zext i8 %83 to i32
+  %85 = icmp eq i32 %84, 0
+  br i1 %85, label %139, label %86
+
+; <label>:86                                      ; preds = %73
+  %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
+  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %89
+
+; <label>:89                                      ; preds = %86
+  %90 = load i64, i64 addrspace(1)* %88
+  %91 = add i64 %90, 128
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = add i64 %93, 24
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
+  %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
+  %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
+  store %"System.Type[]" addrspace(1)* %99, %"System.Type[]" addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %129
+
+; <label>:100                                     ; preds = %132
+  %101 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %102 = load i32, i32* %loc2
+  %NullCheck11 = icmp eq %"System.Type[]" addrspace(1)* %101, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %103
+
+; <label>:103                                     ; preds = %100
+  %104 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 1
+  %105 = load i32, i32 addrspace(1)* %104
+  %106 = zext i32 %105 to i64
+  %107 = zext i32 %102 to i64
+  %BoundsCheck = icmp uge i64 %107, %106
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %108
+
+; <label>:108                                     ; preds = %103
+  %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
+  %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
+  %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
+  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %113
+
+; <label>:113                                     ; preds = %108
+  %114 = load i64, i64 addrspace(1)* %112
+  %115 = add i64 %114, 152
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = add i64 %117, 56
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
+  %123 = zext i8 %122 to i32
+  %124 = icmp ne i32 %123, 0
+  br i1 %124, label %126, label %125
+
+; <label>:125                                     ; preds = %113
+  ret i8 0
+
+; <label>:126                                     ; preds = %113
+  %127 = load i32, i32* %loc2
+  %128 = add i32 %127, 1
+  store i32 %128, i32* %loc2
+  br label %129
+
+; <label>:129                                     ; preds = %89, %126
+  %130 = load i32, i32* %loc2
+  %131 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %NullCheck9 = icmp eq %"System.Type[]" addrspace(1)* %131, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %132
+
+; <label>:132                                     ; preds = %129
+  %133 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %131, i32 0, i32 1
+  %134 = load i32, i32 addrspace(1)* %133
+  %135 = zext i32 %134 to i64
+  %136 = trunc i64 %135 to i32
+  %137 = icmp slt i32 %130, %136
+  br i1 %137, label %100, label %138
+
+; <label>:138                                     ; preds = %132
+  ret i8 1
+
+; <label>:139                                     ; preds = %34, %73
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %129
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %103
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -2893,7 +3248,7 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElem]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -2904,8 +3259,8 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -2997,8 +3352,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
@@ -3059,8 +3414,8 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -3087,8 +3442,8 @@ entry:
 
 ; <label>:17                                      ; preds = %5, %11
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
@@ -3097,8 +3452,8 @@ entry:
 
 ; <label>:22                                      ; preds = %1, %11
   %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
@@ -3109,11 +3464,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %17
+ThrowNullRef2:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %22
+ThrowNullRef4:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3167,15 +3522,15 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
   %15 = load i32, i32 addrspace(1)* %14
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
@@ -3198,7 +3553,7 @@ ThrowNullRef:                                     ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef2:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3232,8 +3587,8 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
@@ -3312,8 +3667,8 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -3327,8 +3682,8 @@ entry:
 ; <label>:5                                       ; preds = %43
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %7 = load i32, i32* %loc1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck6, label %8, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
@@ -3366,8 +3721,8 @@ entry:
 ; <label>:32                                      ; preds = %21, %25
   %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
   %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
-  br i1 %NullCheck8, label %35, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = trunc i32 %34 to i16
@@ -3380,8 +3735,8 @@ entry:
 ; <label>:40                                      ; preds = %1, %35
   %41 = load i32, i32* %loc1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
-  br i1 %NullCheck2, label %43, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %42, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
@@ -3392,8 +3747,8 @@ entry:
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
   %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
-  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
   %51 = load i64, i64 addrspace(1)* %49
@@ -3412,19 +3767,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %40
+ThrowNullRef2:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %47
+ThrowNullRef4:                                    ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %5
+ThrowNullRef6:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %32
+ThrowNullRef8:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3467,8 +3822,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
@@ -3492,11 +3847,391 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(i16* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store i16* %param0, i16** %arg0
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load i32, i32* %arg3
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %42, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %37, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg2
+  %13 = load i32, i32* %arg3
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %37, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %24 = load i32, i32* %arg2
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load i16*, i16** %arg0
+  %35 = load i32, i32* %arg3
+  %36 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %36, i16* %34, i32 %35)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:37                                      ; preds = %5, %16
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %39)
+  %41 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41, %System.String addrspace(1)* %38, %System.String addrspace(1)* %40)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41) #0
+  unreachable
+
+; <label>:42                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
-Failed to read StringBuilder.ToString[loadElemA]
+Successfully read StringBuilder.ToString
+
+define %System.String addrspace(1)* @StringBuilder.ToString(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i16*
+  %loc3 = alloca %"System.Char[]" addrspace(1)*
+  %loc4 = alloca i32
+  %loc5 = alloca i32
+  %loc6 = alloca i16 addrspace(1)*
+  %loc7 = alloca %System.String addrspace(1)*
+  %loc8 = alloca %"System.Char[]" addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %0)
+  %2 = icmp ne i32 %1, 0
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %4
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %6)
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %7)
+  store %System.String addrspace(1)* %8, %System.String addrspace(1)** %loc0
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.Text.StringBuilder addrspace(1)* %9, %System.Text.StringBuilder addrspace(1)** %loc1
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  store %System.String addrspace(1)* %10, %System.String addrspace(1)** %loc7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc7
+  %12 = ptrtoint %System.String addrspace(1)* %11 to i64
+  %13 = icmp eq i64 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %5
+  %15 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %16 = sext i32 %15 to i64
+  %17 = add i64 %12, %16
+  br label %18
+
+; <label>:18                                      ; preds = %5, %14
+  %19 = phi i64 [ %12, %5 ], [ %17, %14 ]
+  %20 = inttoptr i64 %19 to i16*
+  store i16* %20, i16** %loc2
+  br label %21
+
+; <label>:21                                      ; preds = %98, %18
+  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %22, null
+  br i1 %NullCheck, label %ThrowNullRef, label %23
+
+; <label>:23                                      ; preds = %21
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 3
+  %25 = load i32, i32 addrspace(1)* %24, align 8
+  %26 = icmp sle i32 %25, 0
+  br i1 %26, label %96, label %27
+
+; <label>:27                                      ; preds = %23
+  %28 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %28, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %29
+
+; <label>:29                                      ; preds = %27
+  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %28, i32 0, i32 1
+  %31 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %30, align 8
+  store %"System.Char[]" addrspace(1)* %31, %"System.Char[]" addrspace(1)** %loc3
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %33
+
+; <label>:33                                      ; preds = %29
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  store i32 %35, i32* %loc4
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  %39 = load i32, i32 addrspace(1)* %38, align 8
+  store i32 %39, i32* %loc5
+  %40 = load i32, i32* %loc5
+  %41 = load i32, i32* %loc4
+  %42 = add i32 %40, %41
+  %43 = zext i32 %42 to i64
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %45
+
+; <label>:45                                      ; preds = %37
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = sext i32 %47 to i64
+  %49 = icmp sgt i64 %43, %48
+  br i1 %49, label %91, label %50
+
+; <label>:50                                      ; preds = %45
+  %51 = load i32, i32* %loc5
+  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %52, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %53
+
+; <label>:53                                      ; preds = %50
+  %54 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %52, i32 0, i32 1
+  %55 = load i32, i32 addrspace(1)* %54
+  %56 = zext i32 %55 to i64
+  %57 = trunc i64 %56 to i32
+  %58 = icmp ugt i32 %51, %57
+  br i1 %58, label %91, label %59
+
+; <label>:59                                      ; preds = %53
+  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  store %"System.Char[]" addrspace(1)* %60, %"System.Char[]" addrspace(1)** %loc8
+  %61 = icmp eq %"System.Char[]" addrspace(1)* %60, null
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %63, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %64
+
+; <label>:64                                      ; preds = %62
+  %65 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %63, i32 0, i32 1
+  %66 = load i32, i32 addrspace(1)* %65
+  %67 = zext i32 %66 to i64
+  %68 = trunc i64 %67 to i32
+  %69 = icmp ne i32 %68, 0
+  br i1 %69, label %71, label %70
+
+; <label>:70                                      ; preds = %59, %64
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:71                                      ; preds = %64
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %73
+
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %BoundsCheck = icmp uge i64 0, %76
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %77
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %78, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:79                                      ; preds = %70, %77
+  %80 = load i16*, i16** %loc2
+  %81 = load i32, i32* %loc4
+  %82 = sext i32 %81 to i64
+  %83 = mul i64 %82, 2
+  %84 = bitcast i16* %80 to i8*
+  %85 = getelementptr inbounds i8, i8* %84, i64 %83
+  %86 = load i16 addrspace(1)*, i16 addrspace(1)** %loc6
+  %87 = ptrtoint i16 addrspace(1)* %86 to i64
+  %88 = load i32, i32* %loc5
+  %89 = bitcast i8* %85 to i16*
+  %90 = inttoptr i64 %87 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %89, i16* %90, i32 %88)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %96
+
+; <label>:91                                      ; preds = %45, %53
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %94 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %93)
+  %95 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95, %System.String addrspace(1)* %92, %System.String addrspace(1)* %94)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95) #0
+  unreachable
+
+; <label>:96                                      ; preds = %23, %79
+  %97 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %97, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %98
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %97, i32 0, i32 2
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  store %System.Text.StringBuilder addrspace(1)* %100, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %102 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %102, label %21, label %103
+
+; <label>:103                                     ; preds = %98
+  store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc7
+  %104 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  ret %System.String addrspace(1)* %104
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method StringBuilder::get_Length using LLILCJit
+Successfully read StringBuilder.get_Length
+
+define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
+Successfully read RuntimeHelpers.get_OffsetToStringData
+
+define i32 @RuntimeHelpers.get_OffsetToStringData() {
+entry:
+  ret i32 12
+}
+
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
 Successfully read CultureData.CreateCultureData
 
@@ -3514,23 +4249,23 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
   store i8 %4, i8 addrspace(1)* %6
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
@@ -3549,11 +4284,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3566,50 +4301,50 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
   store i32 -1, i32 addrspace(1)* %2
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
   store i32 -1, i32 addrspace(1)* %8
   %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
   store i32 -1, i32 addrspace(1)* %14
   %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
   store i32 -1, i32 addrspace(1)* %17
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
@@ -3623,27 +4358,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3675,7 +4410,136 @@ Failed to read Dictionary`2.Insert[non-const derefAddress]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
 Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
-Failed to read HashHelpers.GetPrime[loadElem]
+Successfully read HashHelpers.GetPrime
+
+define i32 @HashHelpers.GetPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %6, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5, %System.String addrspace(1)* %4)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5) #0
+  unreachable
+
+; <label>:6                                       ; preds = %entry
+  store i32 0, i32* %loc0
+  br label %29
+
+; <label>:7                                       ; preds = %35
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 1296
+  %10 = addrspacecast i8 addrspace(1)* %9 to %"System.Int32[]" addrspace(1)**
+  %11 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %10
+  %12 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Int32[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = zext i32 %15 to i64
+  %17 = zext i32 %12 to i64
+  %BoundsCheck = icmp uge i64 %17, %16
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 3, i32 %12
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  store i32 %20, i32* %loc1
+  %21 = load i32, i32* %loc1
+  %22 = load i32, i32* %arg0
+  %23 = icmp slt i32 %21, %22
+  br i1 %23, label %26, label %24
+
+; <label>:24                                      ; preds = %18
+  %25 = load i32, i32* %loc1
+  ret i32 %25
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %loc0
+  %28 = add i32 %27, 1
+  store i32 %28, i32* %loc0
+  br label %29
+
+; <label>:29                                      ; preds = %6, %26
+  %30 = load i32, i32* %loc0
+  %31 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %32 = getelementptr inbounds i8, i8 addrspace(1)* %31, i64 1296
+  %33 = addrspacecast i8 addrspace(1)* %32 to %"System.Int32[]" addrspace(1)**
+  %34 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %33
+  %NullCheck = icmp eq %"System.Int32[]" addrspace(1)* %34, null
+  br i1 %NullCheck, label %ThrowNullRef, label %35
+
+; <label>:35                                      ; preds = %29
+  %36 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %34, i32 0, i32 1
+  %37 = load i32, i32 addrspace(1)* %36
+  %38 = zext i32 %37 to i64
+  %39 = trunc i64 %38 to i32
+  %40 = icmp slt i32 %30, %39
+  br i1 %40, label %7, label %41
+
+; <label>:41                                      ; preds = %35
+  %42 = load i32, i32* %arg0
+  %43 = or i32 %42, 1
+  store i32 %43, i32* %loc2
+  br label %59
+
+; <label>:44                                      ; preds = %59
+  %45 = load i32, i32* %loc2
+  %46 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %45)
+  %47 = zext i8 %46 to i32
+  %48 = icmp eq i32 %47, 0
+  br i1 %48, label %56, label %49
+
+; <label>:49                                      ; preds = %44
+  %50 = load i32, i32* %loc2
+  %51 = sub i32 %50, 1
+  %52 = srem i32 %51, 101
+  %53 = icmp eq i32 %52, 0
+  br i1 %53, label %56, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = load i32, i32* %loc2
+  ret i32 %55
+
+; <label>:56                                      ; preds = %44, %49
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %57, 2
+  store i32 %58, i32* %loc2
+  br label %59
+
+; <label>:59                                      ; preds = %41, %56
+  %60 = load i32, i32* %loc2
+  %61 = icmp slt i32 %60, 2147483647
+  br i1 %61, label %44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load i32, i32* %arg0
+  ret i32 %63
+
+ThrowNullRef:                                     ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
 Successfully read GenericEqualityComparer`1.GetHashCode
 
@@ -3694,14 +4558,14 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
   %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load i64, i64 addrspace(1)* %7
@@ -3720,7 +4584,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3750,8 +4614,8 @@ entry:
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
@@ -3796,8 +4660,8 @@ entry:
   %35 = bitcast i16* %34 to i8*
   %36 = getelementptr inbounds i8, i8* %35, i64 2
   %37 = bitcast i8* %36 to i16*
-  %NullCheck4 = icmp ne i16* %37, null
-  br i1 %NullCheck4, label %38, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %37, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %38
 
 ; <label>:38                                      ; preds = %27
   %39 = load i16, i16* %37, align 8
@@ -3824,8 +4688,8 @@ entry:
 
 ; <label>:54                                      ; preds = %22, %43
   %55 = load i16*, i16** %loc4
-  %NullCheck2 = icmp ne i16* %55, null
-  br i1 %NullCheck2, label %56, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i16* %55, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %56
 
 ; <label>:56                                      ; preds = %54
   %57 = load i16, i16* %55, align 8
@@ -3850,11 +4714,11 @@ ThrowNullRef:                                     ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %54
+ThrowNullRef2:                                    ; preds = %54
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %27
+ThrowNullRef4:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3871,8 +4735,8 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -3907,8 +4771,8 @@ entry:
 
 ; <label>:26                                      ; preds = %19
   %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
-  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %28
 
 ; <label>:28                                      ; preds = %26
   %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
@@ -3920,7 +4784,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3972,8 +4836,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
@@ -3984,26 +4848,26 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
-  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
@@ -4014,8 +4878,8 @@ entry:
 ; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
@@ -4024,8 +4888,8 @@ entry:
 
 ; <label>:25                                      ; preds = %1, %16, %23
   %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
-  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
@@ -4036,27 +4900,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %20
+ThrowNullRef10:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4069,8 +4933,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -4081,8 +4945,8 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
@@ -4091,8 +4955,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1, %8
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
@@ -4103,11 +4967,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4128,24 +4992,24 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   store i32 %3, i32* %loc0
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
   %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
   store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck4, label %9, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
@@ -4164,15 +5028,15 @@ entry:
 ; <label>:18                                      ; preds = %70
   %19 = load i16*, i16** %loc3
   %20 = bitcast i16* %19 to i64*
-  %NullCheck10 = icmp ne i64* %20, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %20, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = load i64, i64* %20, align 8
   %23 = load i16*, i16** %loc4
   %24 = bitcast i16* %23 to i64*
-  %NullCheck12 = icmp ne i64* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = load i64, i64* %24, align 8
@@ -4188,8 +5052,8 @@ entry:
   %31 = bitcast i16* %30 to i8*
   %32 = getelementptr inbounds i8, i8* %31, i64 8
   %33 = bitcast i8* %32 to i64*
-  %NullCheck14 = icmp ne i64* %33, null
-  br i1 %NullCheck14, label %34, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = load i64, i64* %33, align 8
@@ -4197,8 +5061,8 @@ entry:
   %37 = bitcast i16* %36 to i8*
   %38 = getelementptr inbounds i8, i8* %37, i64 8
   %39 = bitcast i8* %38 to i64*
-  %NullCheck16 = icmp ne i64* %39, null
-  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %40
 
 ; <label>:40                                      ; preds = %34
   %41 = load i64, i64* %39, align 8
@@ -4214,8 +5078,8 @@ entry:
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %NullCheck18 = icmp ne i64* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = load i64, i64* %48, align 8
@@ -4223,8 +5087,8 @@ entry:
   %52 = bitcast i16* %51 to i8*
   %53 = getelementptr inbounds i8, i8* %52, i64 16
   %54 = bitcast i8* %53 to i64*
-  %NullCheck20 = icmp ne i64* %54, null
-  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64* %54, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %55
 
 ; <label>:55                                      ; preds = %49
   %56 = load i64, i64* %54, align 8
@@ -4262,15 +5126,15 @@ entry:
 ; <label>:74                                      ; preds = %95
   %75 = load i16*, i16** %loc3
   %76 = bitcast i16* %75 to i32*
-  %NullCheck6 = icmp ne i32* %76, null
-  br i1 %NullCheck6, label %77, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32* %76, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %77
 
 ; <label>:77                                      ; preds = %74
   %78 = load i32, i32* %76, align 8
   %79 = load i16*, i16** %loc4
   %80 = bitcast i16* %79 to i32*
-  %NullCheck8 = icmp ne i32* %80, null
-  br i1 %NullCheck8, label %81, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i32* %80, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %81
 
 ; <label>:81                                      ; preds = %77
   %82 = load i32, i32* %80, align 8
@@ -4318,43 +5182,43 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %74
+ThrowNullRef6:                                    ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %77
+ThrowNullRef8:                                    ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %29
+ThrowNullRef14:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %34
+ThrowNullRef16:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4376,8 +5240,8 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load i64, i64 addrspace(1)* %4
@@ -4389,8 +5253,8 @@ entry:
   %12 = load i64, i64* %11
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %5
   %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
@@ -4399,8 +5263,8 @@ entry:
   %18 = load i8, i8* %arg2
   %19 = zext i8 %18 to i32
   %20 = trunc i32 %19 to i8
-  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %15
   %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
@@ -4411,11 +5275,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4442,8 +5306,8 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
@@ -4466,16 +5330,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
   %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = load i64, i64 addrspace(1)* %19
@@ -4500,8 +5364,8 @@ entry:
 ; <label>:35                                      ; preds = %30
   %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
@@ -4514,8 +5378,8 @@ entry:
 
 ; <label>:42                                      ; preds = %1, %38
   %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
-  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
@@ -4526,19 +5390,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %35
+ThrowNullRef2:                                    ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %42
+ThrowNullRef8:                                    ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4551,14 +5415,14 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
@@ -4570,7 +5434,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4583,8 +5447,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
@@ -4613,51 +5477,51 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
   %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
   %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
   %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
   %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
-  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
   store i64 %21, i64 addrspace(1)* %23
   %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %25 = load i64, i64* %loc0
-  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
@@ -4668,27 +5532,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %22
+ThrowNullRef12:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4701,8 +5565,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
@@ -4713,19 +5577,19 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
@@ -4734,8 +5598,8 @@ entry:
 
 ; <label>:15                                      ; preds = %1, %13
   %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
@@ -4746,19 +5610,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %15
+ThrowNullRef8:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4771,8 +5635,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -4831,8 +5695,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
@@ -4882,8 +5746,8 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
-  br i1 %NullCheck, label %17, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %ThrowNullRef, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
@@ -4894,15 +5758,15 @@ entry:
 
 ; <label>:22                                      ; preds = %17
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
-  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
   %26 = load i32, i32 addrspace(1)* %25
   %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
-  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %27, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
@@ -4925,8 +5789,8 @@ entry:
 ; <label>:40                                      ; preds = %17
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
-  br i1 %NullCheck6, label %43, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %41, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
@@ -4938,34 +5802,17 @@ ThrowNullRef:                                     ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %24
+ThrowNullRef4:                                    ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %40
+ThrowNullRef6:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
-}
-
-INFO:  jitting method Object::ReferenceEquals using LLILCJit
-Successfully read Object.ReferenceEquals
-
-define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
-entry:
-  %arg0 = alloca %System.Object addrspace(1)*
-  %arg1 = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
-  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
-  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = icmp eq %System.Object addrspace(1)* %0, %1
-  %3 = sext i1 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
 }
 
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
@@ -4978,21 +5825,21 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
   %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
-  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
@@ -5007,28 +5854,28 @@ entry:
 ; <label>:13                                      ; preds = %8, %12
   %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
   %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
   %21 = load i32, i32 addrspace(1)* %20, align 8
   %22 = add i32 %21, 1
-  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
   store i32 %22, i32 addrspace(1)* %24
   %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
@@ -5039,27 +5886,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5077,7 +5924,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::Setup using LLILCJit
-Failed to read AppDomain.Setup[loadElem]
+Failed to read AppDomain.Setup[unbox]
 INFO:  jitting method Thread::GetDomain using LLILCJit
 Successfully read Thread.GetDomain
 
@@ -5108,8 +5955,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
@@ -5122,14 +5969,14 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
   %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
@@ -5141,11 +5988,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5173,8 +6020,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -5189,7 +6036,328 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
 Failed to read KeyCollection.System.Collections.Generic.IEnumerable<TKey>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Successfully read Enumerator.MoveNext
+
+define i8 @Enumerator.MoveNext(%"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.RuntimeTypeHandle* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*
+  %"$TypeArg" = alloca %System.RuntimeTypeHandle*
+  store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
+  %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 8
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %76, label %12
+
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
+  br label %76
+
+; <label>:13                                      ; preds = %85
+  %14 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck19 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %15
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, i32 0, i32 0
+  %17 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %16, align 8
+  %NullCheck21 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, i32 0, i32 2
+  %20 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %19, align 8
+  %21 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck23 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %22
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, i32 0, i32 2
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %NullCheck25 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 3, i32 %24
+  %NullCheck27 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %32
+
+; <label>:32                                      ; preds = %30
+  %33 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, i32 0, i32 2
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = icmp slt i32 %34, 0
+  br i1 %35, label %68, label %36
+
+; <label>:36                                      ; preds = %32
+  %37 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %38 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck29 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %39
+
+; <label>:39                                      ; preds = %36
+  %40 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, i32 0, i32 0
+  %41 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %40, align 8
+  %NullCheck31 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, i32 0, i32 2
+  %44 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %43, align 8
+  %45 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck33 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, i32 0, i32 2
+  %48 = load i32, i32 addrspace(1)* %47, align 8
+  %NullCheck35 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %49
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = zext i32 %51 to i64
+  %53 = zext i32 %48 to i64
+  %BoundsCheck37 = icmp uge i64 %53, %52
+  br i1 %BoundsCheck37, label %ThrowIndexOutOfRange38, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 3, i32 %48
+  %NullCheck39 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %56
+
+; <label>:56                                      ; preds = %54
+  %57 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, i32 0, i32 0
+  %58 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck41 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %59
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %60, %System.__Canon addrspace(1)* %58)
+  %61 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck43 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  %64 = load i32, i32 addrspace(1)* %63, align 8
+  %65 = add i32 %64, 1
+  %NullCheck45 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  store i32 %65, i32 addrspace(1)* %67
+  ret i8 1
+
+; <label>:68                                      ; preds = %32
+  %69 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck47 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %73 = add i32 %72, 1
+  %NullCheck49 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %74
+
+; <label>:74                                      ; preds = %70
+  %75 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  store i32 %73, i32 addrspace(1)* %75
+  br label %76
+
+; <label>:76                                      ; preds = %8, %12, %74
+  %77 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %78
+
+; <label>:78                                      ; preds = %76
+  %79 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, i32 0, i32 2
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck7 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %82
+
+; <label>:82                                      ; preds = %78
+  %83 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, i32 0, i32 0
+  %84 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %83, align 8
+  %NullCheck9 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %85
+
+; <label>:85                                      ; preds = %82
+  %86 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, i32 0, i32 7
+  %87 = load i32, i32 addrspace(1)* %86, align 8
+  %88 = icmp ult i32 %80, %87
+  br i1 %88, label %13, label %89
+
+; <label>:89                                      ; preds = %85
+  %90 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %91 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck11 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %92
+
+; <label>:92                                      ; preds = %89
+  %93 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, i32 0, i32 0
+  %94 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck13 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %95
+
+; <label>:95                                      ; preds = %92
+  %96 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, i32 0, i32 7
+  %97 = load i32, i32 addrspace(1)* %96, align 8
+  %98 = add i32 %97, 1
+  %NullCheck15 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %99
+
+; <label>:99                                      ; preds = %95
+  %100 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, i32 0, i32 2
+  store i32 %98, i32 addrspace(1)* %100
+  %101 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck17 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %102
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %103, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %92
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef22:                                   ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef24:                                   ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef26:                                   ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef28:                                   ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef30:                                   ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef32:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef34:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef36:                                   ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange38:                           ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef40:                                   ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef42:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef44:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef46:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef48:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef50:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -5200,8 +6368,8 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -5232,9 +6400,9 @@ Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
 Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
-Failed to read String.MakeSeparatorList[loadElemA]
+Failed to read String.MakeSeparatorList[storeElem]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
-Failed to read String.InternalSplitKeepEmptyEntries[loadElem]
+Failed to read String.InternalSplitKeepEmptyEntries[storeElem]
 INFO:  jitting method Path::IsRelative using LLILCJit
 Successfully read Path.IsRelative
 
@@ -5243,8 +6411,8 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -5254,8 +6422,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
@@ -5271,8 +6439,8 @@ entry:
 
 ; <label>:17                                      ; preds = %7
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
@@ -5288,8 +6456,8 @@ entry:
 
 ; <label>:29                                      ; preds = %19
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %31
 
 ; <label>:31                                      ; preds = %29
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
@@ -5300,8 +6468,8 @@ entry:
 
 ; <label>:36                                      ; preds = %31
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
-  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %37, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
@@ -5312,8 +6480,8 @@ entry:
 
 ; <label>:43                                      ; preds = %31, %38
   %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
-  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %45
 
 ; <label>:45                                      ; preds = %43
   %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
@@ -5324,8 +6492,8 @@ entry:
 
 ; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %50
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
@@ -5336,8 +6504,8 @@ entry:
 
 ; <label>:57                                      ; preds = %1, %7, %19, %45, %52
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
-  br i1 %NullCheck14, label %59, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %59
 
 ; <label>:59                                      ; preds = %57
   %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
@@ -5347,8 +6515,8 @@ entry:
 
 ; <label>:63                                      ; preds = %59
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
@@ -5359,8 +6527,8 @@ entry:
 
 ; <label>:70                                      ; preds = %65
   %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
-  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.String addrspace(1)* %71, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %72
 
 ; <label>:72                                      ; preds = %70
   %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
@@ -5379,39 +6547,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %17
+ThrowNullRef4:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %29
+ThrowNullRef6:                                    ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %36
+ThrowNullRef8:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %43
+ThrowNullRef10:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %50
+ThrowNullRef12:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %57
+ThrowNullRef14:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %63
+ThrowNullRef16:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %70
+ThrowNullRef18:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5419,7 +6587,293 @@ ThrowNullRef17:                                   ; preds = %70
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
-Failed to read String.TrimHelper[loadElem]
+Successfully read String.TrimHelper
+
+define %System.String addrspace(1)* @String.TrimHelper(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i16
+  %loc4 = alloca i32
+  %loc5 = alloca i16
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = sub i32 %3, 1
+  store i32 %4, i32* %loc0
+  store i32 0, i32* %loc1
+  %5 = load i32, i32* %arg2
+  %6 = icmp eq i32 %5, 1
+  br i1 %6, label %62, label %7
+
+; <label>:7                                       ; preds = %1
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:8                                       ; preds = %58
+  store i32 0, i32* %loc2
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load i32, i32* %loc1
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2, i32 %10
+  %13 = load i16, i16 addrspace(1)* %12
+  %14 = zext i16 %13 to i32
+  %15 = trunc i32 %14 to i16
+  store i16 %15, i16* %loc3
+  store i32 0, i32* %loc2
+  br label %34
+
+; <label>:16                                      ; preds = %37
+  %17 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %18 = load i32, i32* %loc2
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %17, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %19
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = zext i32 %18 to i64
+  %BoundsCheck = icmp uge i64 %23, %22
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %24
+
+; <label>:24                                      ; preds = %19
+  %25 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 3, i32 %18
+  %26 = load i16, i16 addrspace(1)* %25, align 8
+  %27 = zext i16 %26 to i32
+  %28 = load i16, i16* %loc3
+  %29 = zext i16 %28 to i32
+  %30 = icmp eq i32 %27, %29
+  br i1 %30, label %43, label %31
+
+; <label>:31                                      ; preds = %24
+  %32 = load i32, i32* %loc2
+  %33 = add i32 %32, 1
+  store i32 %33, i32* %loc2
+  br label %34
+
+; <label>:34                                      ; preds = %11, %31
+  %35 = load i32, i32* %loc2
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = icmp slt i32 %35, %41
+  br i1 %42, label %16, label %43
+
+; <label>:43                                      ; preds = %24, %37
+  %44 = load i32, i32* %loc2
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %45, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp eq i32 %44, %50
+  br i1 %51, label %62, label %52
+
+; <label>:52                                      ; preds = %46
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %7, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %57, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %58
+
+; <label>:58                                      ; preds = %55
+  %59 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %60 = load i32, i32 addrspace(1)* %59
+  %61 = icmp slt i32 %56, %60
+  br i1 %61, label %8, label %62
+
+; <label>:62                                      ; preds = %1, %46, %58
+  %63 = load i32, i32* %arg2
+  %64 = icmp eq i32 %63, 0
+  br i1 %64, label %122, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %66, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %67
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %66, i32 0, i32 1
+  %69 = load i32, i32 addrspace(1)* %68
+  %70 = sub i32 %69, 1
+  store i32 %70, i32* %loc0
+  br label %118
+
+; <label>:71                                      ; preds = %118
+  store i32 0, i32* %loc4
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %73 = load i32, i32* %loc0
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %74
+
+; <label>:74                                      ; preds = %71
+  %75 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 2, i32 %73
+  %76 = load i16, i16 addrspace(1)* %75
+  %77 = zext i16 %76 to i32
+  %78 = trunc i32 %77 to i16
+  store i16 %78, i16* %loc5
+  store i32 0, i32* %loc4
+  br label %97
+
+; <label>:79                                      ; preds = %100
+  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %81 = load i32, i32* %loc4
+  %NullCheck19 = icmp eq %"System.Char[]" addrspace(1)* %80, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
+
+; <label>:82                                      ; preds = %79
+  %83 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 1
+  %84 = load i32, i32 addrspace(1)* %83
+  %85 = zext i32 %84 to i64
+  %86 = zext i32 %81 to i64
+  %BoundsCheck21 = icmp uge i64 %86, %85
+  br i1 %BoundsCheck21, label %ThrowIndexOutOfRange22, label %87
+
+; <label>:87                                      ; preds = %82
+  %88 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 3, i32 %81
+  %89 = load i16, i16 addrspace(1)* %88, align 8
+  %90 = zext i16 %89 to i32
+  %91 = load i16, i16* %loc5
+  %92 = zext i16 %91 to i32
+  %93 = icmp eq i32 %90, %92
+  br i1 %93, label %106, label %94
+
+; <label>:94                                      ; preds = %87
+  %95 = load i32, i32* %loc4
+  %96 = add i32 %95, 1
+  store i32 %96, i32* %loc4
+  br label %97
+
+; <label>:97                                      ; preds = %74, %94
+  %98 = load i32, i32* %loc4
+  %99 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck15 = icmp eq %"System.Char[]" addrspace(1)* %99, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %100
+
+; <label>:100                                     ; preds = %97
+  %101 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %99, i32 0, i32 1
+  %102 = load i32, i32 addrspace(1)* %101
+  %103 = zext i32 %102 to i64
+  %104 = trunc i64 %103 to i32
+  %105 = icmp slt i32 %98, %104
+  br i1 %105, label %79, label %106
+
+; <label>:106                                     ; preds = %87, %100
+  %107 = load i32, i32* %loc4
+  %108 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck17 = icmp eq %"System.Char[]" addrspace(1)* %108, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %109
+
+; <label>:109                                     ; preds = %106
+  %110 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %108, i32 0, i32 1
+  %111 = load i32, i32 addrspace(1)* %110
+  %112 = zext i32 %111 to i64
+  %113 = trunc i64 %112 to i32
+  %114 = icmp eq i32 %107, %113
+  br i1 %114, label %122, label %115
+
+; <label>:115                                     ; preds = %109
+  %116 = load i32, i32* %loc0
+  %117 = sub i32 %116, 1
+  store i32 %117, i32* %loc0
+  br label %118
+
+; <label>:118                                     ; preds = %67, %115
+  %119 = load i32, i32* %loc0
+  %120 = load i32, i32* %loc1
+  %121 = icmp sge i32 %119, %120
+  br i1 %121, label %71, label %122
+
+; <label>:122                                     ; preds = %62, %109, %118
+  %123 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %124 = load i32, i32* %loc1
+  %125 = load i32, i32* %loc0
+  %126 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %123, i32 %124, i32 %125)
+  ret %System.String addrspace(1)* %126
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %97
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange22:                           ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
 Successfully read String.CreateTrimmedString
 
@@ -5439,8 +6893,8 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
@@ -5535,8 +6989,8 @@ entry:
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i64 2872
   %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
   %8 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %7
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %3
   %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
@@ -5553,8 +7007,8 @@ entry:
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 2864
   %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
   %21 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %20
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
-  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %22
 
 ; <label>:22                                      ; preds = %16
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
@@ -5569,7 +7023,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %16
+ThrowNullRef2:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5586,8 +7040,8 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5613,8 +7067,8 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
@@ -5632,8 +7086,8 @@ entry:
 
 ; <label>:12                                      ; preds = %4
   %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
@@ -5644,8 +7098,8 @@ entry:
 
 ; <label>:19                                      ; preds = %14
   %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %19
   %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
@@ -5660,21 +7114,21 @@ entry:
   %31 = zext i16 %30 to i32
   %32 = bitcast i8* %29 to i16*
   %33 = trunc i32 %31 to i16
-  %NullCheck6 = icmp ne i16* %32, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i16* %32, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %21
   store i16 %33, i16* %32, align 8
   %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %36
 
 ; <label>:36                                      ; preds = %34
   %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
   %38 = load i32, i32 addrspace(1)* %37, align 8
   %39 = add i32 %38, 1
-  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %40
 
 ; <label>:40                                      ; preds = %36
   %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
@@ -5683,16 +7137,16 @@ entry:
 
 ; <label>:42                                      ; preds = %14
   %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
-  br i1 %NullCheck12, label %44, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
   %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
   %47 = load i16, i16* %arg1
   %48 = zext i16 %47 to i32
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = trunc i32 %48 to i16
@@ -5703,31 +7157,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %19
+ThrowNullRef4:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %21
+ThrowNullRef6:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %36
+ThrowNullRef10:                                   ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %42
+ThrowNullRef12:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %44
+ThrowNullRef14:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5740,8 +7194,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -5752,8 +7206,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
@@ -5762,14 +7216,14 @@ entry:
 
 ; <label>:11                                      ; preds = %1
   %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
@@ -5779,15 +7233,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5808,8 +7262,8 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5822,8 +7276,8 @@ entry:
 
 ; <label>:8                                       ; preds = %3
   %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
@@ -5842,15 +7296,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
-  br i1 %NullCheck4, label %22, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
   %24 = load i16*, i16* addrspace(1)* %23, align 8
   %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %25, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
@@ -5859,8 +7313,8 @@ entry:
   store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
@@ -5874,8 +7328,8 @@ entry:
 
 ; <label>:37                                      ; preds = %65
   %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %37
   %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
@@ -5886,16 +7340,16 @@ entry:
   %45 = bitcast i16* %41 to i8*
   %46 = getelementptr inbounds i8, i8* %45, i64 %44
   %47 = bitcast i8* %46 to i16*
-  %NullCheck14 = icmp ne i16* %47, null
-  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %47, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %48
 
 ; <label>:48                                      ; preds = %39
   %49 = load i16, i16* %47, align 8
   %50 = zext i16 %49 to i32
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %52 = load i32, i32* %loc1
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %53
 
 ; <label>:53                                      ; preds = %48
   %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
@@ -5916,8 +7370,8 @@ entry:
 ; <label>:62                                      ; preds = %36, %59
   %63 = load i32, i32* %loc1
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck10, label %65, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %65
 
 ; <label>:65                                      ; preds = %62
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
@@ -5936,15 +7390,15 @@ entry:
 
 ; <label>:74                                      ; preds = %70
   %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
-  br i1 %NullCheck18, label %76, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %76
 
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
   %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
-  br i1 %NullCheck20, label %80, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
   %81 = load i64, i64 addrspace(1)* %79
@@ -5958,8 +7412,8 @@ entry:
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
   %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
-  br i1 %NullCheck22, label %92, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.String addrspace(1)* %90, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %92
 
 ; <label>:92                                      ; preds = %80
   %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
@@ -5969,15 +7423,15 @@ entry:
 
 ; <label>:96                                      ; preds = %70
   %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
-  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %98
 
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
   %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
-  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
   %103 = load i64, i64 addrspace(1)* %101
@@ -5991,8 +7445,8 @@ entry:
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
   %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
-  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.String addrspace(1)* %112, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %114
 
 ; <label>:114                                     ; preds = %102
   %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
@@ -6004,59 +7458,59 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %20
+ThrowNullRef4:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %22
+ThrowNullRef6:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %26
+ThrowNullRef8:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %62
+ThrowNullRef10:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %48
+ThrowNullRef16:                                   ; preds = %48
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %74
+ThrowNullRef18:                                   ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %76
+ThrowNullRef20:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %80
+ThrowNullRef22:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %96
+ThrowNullRef24:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %98
+ThrowNullRef26:                                   ; preds = %98
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %102
+ThrowNullRef28:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6069,15 +7523,15 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
   %3 = load i16*, i16* addrspace(1)* %2, align 8
   %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
@@ -6087,8 +7541,8 @@ entry:
   %10 = bitcast i16* %3 to i8*
   %11 = getelementptr inbounds i8, i8* %10, i64 %9
   %12 = bitcast i8* %11 to i16*
-  %NullCheck4 = icmp ne i16* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %5
   store i16 0, i16* %12, align 8
@@ -6098,11 +7552,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6119,8 +7573,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -6131,8 +7585,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
@@ -6144,15 +7598,15 @@ entry:
 
 ; <label>:14                                      ; preds = %1
   %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
   %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
   %21 = load i64, i64 addrspace(1)* %19
@@ -6171,15 +7625,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %14
+ThrowNullRef4:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %16
+ThrowNullRef6:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6302,14 +7756,6 @@ entry:
   ret %System.String addrspace(1)* %57
 }
 
-INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
-Successfully read RuntimeHelpers.get_OffsetToStringData
-
-define i32 @RuntimeHelpers.get_OffsetToStringData() {
-entry:
-  ret i32 12
-}
-
 INFO:  jitting method String::Equals using LLILCJit
 Successfully read String.Equals
 
@@ -6381,8 +7827,8 @@ entry:
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
-  br i1 %NullCheck24, label %29, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
   %30 = load i64, i64 addrspace(1)* %28
@@ -6397,8 +7843,8 @@ entry:
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
-  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
   %43 = load i64, i64 addrspace(1)* %41
@@ -6418,8 +7864,8 @@ entry:
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
   %59 = load i64, i64 addrspace(1)* %57
@@ -6434,8 +7880,8 @@ entry:
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck22, label %71, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
   %72 = load i64, i64 addrspace(1)* %70
@@ -6455,8 +7901,8 @@ entry:
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
-  br i1 %NullCheck16, label %87, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = load i64, i64 addrspace(1)* %86
@@ -6471,8 +7917,8 @@ entry:
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck18, label %100, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
   %101 = load i64, i64 addrspace(1)* %99
@@ -6492,8 +7938,8 @@ entry:
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
-  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
   %117 = load i64, i64 addrspace(1)* %115
@@ -6508,8 +7954,8 @@ entry:
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
-  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
   %130 = load i64, i64 addrspace(1)* %128
@@ -6528,15 +7974,15 @@ entry:
 
 ; <label>:142                                     ; preds = %22
   %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
-  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %143, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %144
 
 ; <label>:144                                     ; preds = %142
   %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
   %146 = load i32, i32 addrspace(1)* %145
   %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
-  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %147, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %148
 
 ; <label>:148                                     ; preds = %144
   %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
@@ -6557,15 +8003,15 @@ entry:
 
 ; <label>:159                                     ; preds = %22
   %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
-  br i1 %NullCheck, label %161, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %ThrowNullRef, label %161
 
 ; <label>:161                                     ; preds = %159
   %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
   %163 = load i32, i32 addrspace(1)* %162
   %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
-  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %164, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %165
 
 ; <label>:165                                     ; preds = %161
   %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
@@ -6578,8 +8024,8 @@ entry:
 
 ; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
-  br i1 %NullCheck4, label %172, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %171, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %172
 
 ; <label>:172                                     ; preds = %170
   %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
@@ -6589,8 +8035,8 @@ entry:
 
 ; <label>:176                                     ; preds = %172
   %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
-  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %177, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %178
 
 ; <label>:178                                     ; preds = %176
   %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
@@ -6629,55 +8075,55 @@ ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %161
+ThrowNullRef2:                                    ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %170
+ThrowNullRef4:                                    ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %176
+ThrowNullRef6:                                    ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %142
+ThrowNullRef8:                                    ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %144
+ThrowNullRef10:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %113
+ThrowNullRef12:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %116
+ThrowNullRef14:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %84
+ThrowNullRef16:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %87
+ThrowNullRef18:                                   ; preds = %87
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %55
+ThrowNullRef20:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %58
+ThrowNullRef22:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %26
+ThrowNullRef24:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %29
+ThrowNullRef26:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,8 +8161,8 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck, label %14, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %ThrowNullRef, label %14
 
 ; <label>:14                                      ; preds = %8
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
@@ -6760,8 +8206,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
@@ -6770,14 +8216,14 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32, i32* %loc0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %10
   %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
   %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
@@ -6790,15 +8236,15 @@ entry:
 ; <label>:25                                      ; preds = %19
   %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
-  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
   %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
@@ -6807,8 +8253,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %37 = load i32, i32* %loc0
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %38, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %38
 
 ; <label>:38                                      ; preds = %32
   %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
@@ -6817,14 +8263,14 @@ entry:
 
 ; <label>:40                                      ; preds = %19
   %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %40
   %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
   %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
-  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
-  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
@@ -6832,8 +8278,8 @@ entry:
   %48 = zext i32 %47 to i64
   %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
-  br i1 %NullCheck16, label %51, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %51
 
 ; <label>:51                                      ; preds = %45
   %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
@@ -6847,15 +8293,15 @@ entry:
 ; <label>:57                                      ; preds = %51
   %58 = load i16*, i16** %arg1
   %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
-  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %60
 
 ; <label>:60                                      ; preds = %57
   %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
   %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
-  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %64
 
 ; <label>:64                                      ; preds = %60
   %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
@@ -6864,22 +8310,22 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
   %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
-  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %70
 
 ; <label>:70                                      ; preds = %64
   %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
   %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
-  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
-  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
   %75 = load i32, i32 addrspace(1)* %74
   %76 = zext i32 %75 to i64
   %77 = trunc i64 %76 to i32
-  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
-  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %78
 
 ; <label>:78                                      ; preds = %73
   %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
@@ -6901,8 +8347,8 @@ entry:
   %90 = bitcast i16* %86 to i8*
   %91 = getelementptr inbounds i8, i8* %90, i64 %89
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %93
 
 ; <label>:93                                      ; preds = %80
   %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
@@ -6912,8 +8358,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %99 = load i32, i32* %loc2
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %100
 
 ; <label>:100                                     ; preds = %93
   %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
@@ -6928,63 +8374,63 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %25
+ThrowNullRef6:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %32
+ThrowNullRef10:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %40
+ThrowNullRef12:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %45
+ThrowNullRef16:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %57
+ThrowNullRef18:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %60
+ThrowNullRef20:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %64
+ThrowNullRef22:                                   ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %70
+ThrowNullRef24:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %73
+ThrowNullRef26:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %80
+ThrowNullRef28:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %93
+ThrowNullRef30:                                   ; preds = %93
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7004,8 +8450,8 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
@@ -7033,43 +8479,43 @@ entry:
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %14
   %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
   %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   %28 = load i32, i32 addrspace(1)* %27, align 8
   %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
-  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %30
 
 ; <label>:30                                      ; preds = %26
   %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
   %32 = load i32, i32 addrspace(1)* %31, align 8
   %33 = add i32 %28, %32
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %34
 
 ; <label>:34                                      ; preds = %30
   %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   store i32 %33, i32 addrspace(1)* %35
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
   store i32 0, i32 addrspace(1)* %38
   %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %40
 
 ; <label>:40                                      ; preds = %37
   %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
@@ -7082,8 +8528,8 @@ entry:
 
 ; <label>:47                                      ; preds = %40
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
@@ -7098,8 +8544,8 @@ entry:
   %54 = load i32, i32* %loc0
   %55 = sext i32 %54 to i64
   %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
-  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %57
 
 ; <label>:57                                      ; preds = %52
   %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
@@ -7110,68 +8556,35 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %14
+ThrowNullRef2:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %23
+ThrowNullRef4:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %26
+ThrowNullRef6:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %30
+ThrowNullRef8:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %34
+ThrowNullRef10:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %47
+ThrowNullRef14:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %52
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-}
-
-INFO:  jitting method StringBuilder::get_Length using LLILCJit
-Successfully read StringBuilder.get_Length
-
-define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.StringBuilder addrspace(1)*
-  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
-  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
-
-; <label>:1                                       ; preds = %entry
-  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %3 = load i32, i32 addrspace(1)* %2, align 8
-  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
-
-; <label>:5                                       ; preds = %1
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = add i32 %3, %7
-  ret i32 %8
-
-ThrowNullRef:                                     ; preds = %entry
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef16:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7213,70 +8626,70 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
   %6 = load i32, i32 addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
   store i32 %6, i32 addrspace(1)* %8
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
   %13 = load i32, i32 addrspace(1)* %12, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
   store i32 %13, i32 addrspace(1)* %15
   %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
-  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %18
 
 ; <label>:18                                      ; preds = %14
   %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
   %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
   %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
   %34 = load i32, i32 addrspace(1)* %33, align 8
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
-  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
@@ -7287,39 +8700,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %28
+ThrowNullRef16:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %32
+ThrowNullRef18:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7455,13 +8868,13 @@ entry:
 ; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
@@ -7477,16 +8890,16 @@ entry:
 
 ; <label>:18                                      ; preds = %15
   %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
   store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
   %22 = load i32, i32* %loc0
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %24
 
 ; <label>:24                                      ; preds = %20
   %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
@@ -7498,13 +8911,13 @@ entry:
 ; <label>:28                                      ; preds = %15, %24
   %29 = load i32, i32* %arg1
   %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %31
   %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
@@ -7517,20 +8930,20 @@ entry:
   %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
-  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
   %46 = load i32, i32 addrspace(1)* %45, align 8
   %47 = sub i32 %40, %46
-  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
-  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i32 addrspace(1)* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %48
 
 ; <label>:48                                      ; preds = %44
   store i32 %47, i32 addrspace(1)* %39, align 8
@@ -7538,21 +8951,21 @@ entry:
 
 ; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
-  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %51
 
 ; <label>:51                                      ; preds = %49
   %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %53
 
 ; <label>:53                                      ; preds = %51
   %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
   %55 = load i32, i32 addrspace(1)* %54, align 8
   %56 = load i32, i32* %arg2
   %57 = sub i32 %55, %56
-  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %58
 
 ; <label>:58                                      ; preds = %53
   %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
@@ -7562,13 +8975,13 @@ entry:
 ; <label>:60                                      ; preds = %33, %58
   %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
   %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
-  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %63
 
 ; <label>:63                                      ; preds = %60
   %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
-  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
-  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
@@ -7578,15 +8991,15 @@ entry:
 
 ; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
-  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i32 addrspace(1)* %69, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %70
 
 ; <label>:70                                      ; preds = %68
   %71 = load i32, i32 addrspace(1)* %69, align 8
   store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
-  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
@@ -7596,8 +9009,8 @@ entry:
   store i32 %77, i32* %loc4
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
-  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %80
 
 ; <label>:80                                      ; preds = %73
   %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
@@ -7607,71 +9020,71 @@ entry:
 ; <label>:83                                      ; preds = %80
   store i32 0, i32* %loc3
   %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
-  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
-  br i1 %NullCheck26, label %88, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i32 addrspace(1)* %87, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %88
 
 ; <label>:88                                      ; preds = %85
   %89 = load i32, i32 addrspace(1)* %87, align 8
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
-  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %90
 
 ; <label>:90                                      ; preds = %88
   %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
   store i32 %89, i32 addrspace(1)* %91
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
-  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
-  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %96
 
 ; <label>:96                                      ; preds = %94
   %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
-  br i1 %NullCheck34, label %100, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %100
 
 ; <label>:100                                     ; preds = %96
   %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
-  br i1 %NullCheck36, label %102, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %102
 
 ; <label>:102                                     ; preds = %100
   %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
   %104 = load i32, i32 addrspace(1)* %103, align 8
   %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
-  br i1 %NullCheck38, label %106, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %106
 
 ; <label>:106                                     ; preds = %102
   %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
-  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
-  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %108
 
 ; <label>:108                                     ; preds = %106
   %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
   %110 = load i32, i32 addrspace(1)* %109, align 8
   %111 = add i32 %104, %110
-  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %112
 
 ; <label>:112                                     ; preds = %108
   %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
   store i32 %111, i32 addrspace(1)* %113
   %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
-  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i32 addrspace(1)* %114, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %115
 
 ; <label>:115                                     ; preds = %112
   %116 = load i32, i32 addrspace(1)* %114, align 8
@@ -7681,19 +9094,19 @@ entry:
 ; <label>:118                                     ; preds = %115
   %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
-  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %121
 
 ; <label>:121                                     ; preds = %118
   %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
-  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
-  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %123
 
 ; <label>:123                                     ; preds = %121
   %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
   %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
-  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
-  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %126
 
 ; <label>:126                                     ; preds = %123
   %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
@@ -7705,8 +9118,8 @@ entry:
 
 ; <label>:130                                     ; preds = %80, %115, %126
   %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %132
 
 ; <label>:132                                     ; preds = %130
   %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7715,8 +9128,8 @@ entry:
   %136 = load i32, i32* %loc3
   %137 = sub i32 %135, %136
   %138 = sub i32 %134, %137
-  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %139
 
 ; <label>:139                                     ; preds = %132
   %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7728,16 +9141,16 @@ entry:
 
 ; <label>:144                                     ; preds = %139
   %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
-  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %146
 
 ; <label>:146                                     ; preds = %144
   %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
   %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
   %149 = load i32, i32* %loc2
   %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
-  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %151
 
 ; <label>:151                                     ; preds = %146
   %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
@@ -7754,145 +9167,249 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %18
+ThrowNullRef4:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %31
+ThrowNullRef10:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %44
+ThrowNullRef16:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %68
+ThrowNullRef18:                                   ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %70
+ThrowNullRef20:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %73
+ThrowNullRef22:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %83
+ThrowNullRef24:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %85
+ThrowNullRef26:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %88
+ThrowNullRef28:                                   ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %90
+ThrowNullRef30:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %94
+ThrowNullRef32:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %96
+ThrowNullRef34:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %100
+ThrowNullRef36:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %102
+ThrowNullRef38:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %106
+ThrowNullRef40:                                   ; preds = %106
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %108
+ThrowNullRef42:                                   ; preds = %108
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %112
+ThrowNullRef44:                                   ; preds = %112
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %118
+ThrowNullRef46:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %121
+ThrowNullRef48:                                   ; preds = %121
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %123
+ThrowNullRef50:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %130
+ThrowNullRef52:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %132
+ThrowNullRef54:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %144
+ThrowNullRef56:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %146
+ThrowNullRef58:                                   ; preds = %146
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %60
+ThrowNullRef60:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %63
+ThrowNullRef62:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %49
+ThrowNullRef64:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %51
+ThrowNullRef66:                                   ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %53
+ThrowNullRef68:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(%"System.Char[]" addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %arg0 = alloca %"System.Char[]" addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store %"System.Char[]" addrspace(1)* %param0, %"System.Char[]" addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load i32, i32* %arg4
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %43, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %38, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg1
+  %13 = load i32, i32* %arg4
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %38, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %24 = load i32, i32* %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %35 = load i32, i32* %arg3
+  %36 = load i32, i32* %arg4
+  %37 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %37, %"System.Char[]" addrspace(1)* %34, i32 %35, i32 %36)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:38                                      ; preds = %5, %16
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Successfully read Buffer._Memmove
 
@@ -7914,7 +9431,7 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[loadElem]
+Failed to read AppDomain.SetDataHelper[storeElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -7923,8 +9440,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
@@ -7934,8 +9451,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
@@ -7947,15 +9464,15 @@ entry:
   %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
   %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
@@ -7966,15 +9483,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7992,7 +9509,79 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
-Failed to read Dictionary`2.TryGetValue[loadElemA]
+Successfully read Dictionary`2.TryGetValue
+
+define i8 @"Dictionary`2.TryGetValue"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)* addrspace(1)* %param2) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  %arg2 = alloca %System.__Canon addrspace(1)* addrspace(1)*
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  store %System.__Canon addrspace(1)* addrspace(1)* %param2, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  store i32 %2, i32* %loc0
+  %3 = load i32, i32* %loc0
+  %4 = icmp slt i32 %3, 0
+  br i1 %4, label %22, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 2
+  %10 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %9, align 8
+  %11 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = zext i32 %11 to i64
+  %BoundsCheck = icmp uge i64 %16, %15
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 3, i32 %11
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %20, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %6, %System.__Canon addrspace(1)* %21)
+  ret i8 1
+
+; <label>:22                                      ; preds = %entry
+  %23 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %23, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -8058,8 +9647,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
@@ -8091,8 +9680,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
@@ -8171,15 +9760,15 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck, label %19, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %ThrowNullRef, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
   %21 = load i32, i32 addrspace(1)* %20
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
@@ -8202,7 +9791,7 @@ ThrowNullRef:                                     ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %19
+ThrowNullRef2:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8248,8 +9837,8 @@ entry:
   %0 = alloca %System.AppDomainHandle
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %1 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %1, i32 0, i32 15
@@ -8269,8 +9858,8 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
@@ -8286,7 +9875,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -8299,8 +9888,8 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -8327,8 +9916,8 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
@@ -8352,8 +9941,8 @@ entry:
   %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
   store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
@@ -8363,8 +9952,8 @@ entry:
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
@@ -8374,8 +9963,8 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %9
   %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
@@ -8384,8 +9973,8 @@ entry:
 
 ; <label>:18                                      ; preds = %3, %16
   %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
@@ -8397,15 +9986,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %18
+ThrowNullRef6:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8418,8 +10007,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
@@ -8453,15 +10042,15 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
@@ -8473,7 +10062,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8481,7 +10070,7 @@ ThrowNullRef1:                                    ; preds = %1
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
 Failed to read Dictionary`2.System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
@@ -8506,8 +10095,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
@@ -8524,8 +10113,8 @@ entry:
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -8544,7 +10133,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8577,8 +10166,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = load i64, i64* %arg2
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = trunc i32 %3 to i8
@@ -8634,46 +10223,46 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
   %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
-  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
-  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
-  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
@@ -8684,27 +10273,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %20
+ThrowNullRef12:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8717,8 +10306,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -8756,22 +10345,22 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
   %9 = load i64, i64 addrspace(1)* %8, align 8
   %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
   %13 = load i64, i64 addrspace(1)* %12, align 8
   %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %11
   %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
@@ -8788,11 +10377,11 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8882,8 +10471,8 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
@@ -8900,8 +10489,8 @@ entry:
 ; <label>:8                                       ; preds = %1
   %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
   %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
@@ -8911,15 +10500,15 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
   %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
   %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
-  br i1 %NullCheck6, label %21, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
@@ -8946,15 +10535,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8992,15 +10581,15 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
   store i8 %3, i8 addrspace(1)* %5
   %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
@@ -9011,7 +10600,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9027,8 +10616,8 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -9041,8 +10630,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
@@ -9058,7 +10647,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9080,8 +10669,8 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
@@ -9096,8 +10685,8 @@ entry:
 ; <label>:12                                      ; preds = %6
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
@@ -9112,8 +10701,8 @@ entry:
 ; <label>:21                                      ; preds = %15
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
@@ -9128,8 +10717,8 @@ entry:
 ; <label>:30                                      ; preds = %24
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %31, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
@@ -9144,8 +10733,8 @@ entry:
 ; <label>:39                                      ; preds = %33
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
-  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %40, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %42
 
 ; <label>:42                                      ; preds = %39
   %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
@@ -9164,19 +10753,19 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %21
+ThrowNullRef4:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %30
+ThrowNullRef6:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %39
+ThrowNullRef8:                                    ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9243,8 +10832,8 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
@@ -9264,57 +10853,57 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
   store i8 0, i8 addrspace(1)* %2
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
   store i8 0, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
   store i8 0, i8 addrspace(1)* %17
   %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
   store i8 0, i8 addrspace(1)* %20
   %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
-  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
@@ -9325,31 +10914,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %19
+ThrowNullRef14:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9367,8 +10956,8 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
@@ -9380,8 +10969,8 @@ entry:
 
 ; <label>:9                                       ; preds = %4
   %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %9
   %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
@@ -9395,7 +10984,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef2:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9420,8 +11009,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
@@ -9512,8 +11101,8 @@ entry:
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
@@ -9524,8 +11113,8 @@ entry:
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = load i64, i64 addrspace(1)* %12
@@ -9537,8 +11126,8 @@ entry:
   %20 = load i64, i64* %19
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
-  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %13
   %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
@@ -9555,8 +11144,8 @@ entry:
 ; <label>:30                                      ; preds = %25
   %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %32 = load i32, i32* %arg2
-  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
-  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
@@ -9570,15 +11159,15 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %30
+ThrowNullRef2:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9622,87 +11211,87 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
   %10 = load i8, i8 addrspace(1)* %9, align 8
   %11 = zext i8 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %8
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
   store i8 %12, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
   %19 = load i8, i8 addrspace(1)* %18, align 8
   %20 = zext i8 %19 to i32
   %21 = trunc i32 %20 to i8
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
   store i8 %21, i8 addrspace(1)* %23
   %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
   %28 = load i8, i8 addrspace(1)* %27, align 8
   %29 = zext i8 %28 to i32
   %30 = trunc i32 %29 to i8
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
-  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %31
 
 ; <label>:31                                      ; preds = %26
   %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
   store i8 %30, i8 addrspace(1)* %32
   %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
-  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
-  br i1 %NullCheck14, label %40, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %40
 
 ; <label>:40                                      ; preds = %35
   %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
   store i8 %39, i8 addrspace(1)* %41
   %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
-  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %44
 
 ; <label>:44                                      ; preds = %40
   %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
   %46 = load i8, i8 addrspace(1)* %45, align 8
   %47 = zext i8 %46 to i32
   %48 = trunc i32 %47 to i8
-  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
   store i8 %48, i8 addrspace(1)* %50
   %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
-  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
@@ -9713,29 +11302,29 @@ entry:
 ; <label>:56                                      ; preds = %52
   %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
-  br i1 %NullCheck22, label %59, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
   %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
   %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
-  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
-  br i1 %NullCheck24, label %63, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
   %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
-  br i1 %NullCheck26, label %66, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
   %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
-  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
-  br i1 %NullCheck28, label %69, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %69
 
 ; <label>:69                                      ; preds = %66
   %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
@@ -9744,15 +11333,15 @@ entry:
 
 ; <label>:71                                      ; preds = %105
   %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
-  br i1 %NullCheck34, label %73, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %73
 
 ; <label>:73                                      ; preds = %71
   %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
   %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
   %76 = load i32, i32* %loc0
-  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
-  br i1 %NullCheck36, label %77, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
@@ -9766,8 +11355,8 @@ entry:
 
 ; <label>:83                                      ; preds = %77
   %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
-  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
@@ -9775,14 +11364,14 @@ entry:
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
   %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
-  br i1 %NullCheck40, label %91, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
 ; <label>:91                                      ; preds = %85
   %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
   %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
-  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck42, label %94, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %94
 
 ; <label>:94                                      ; preds = %91
   %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
@@ -9798,14 +11387,14 @@ entry:
 ; <label>:99                                      ; preds = %69, %96
   %100 = load i32, i32* %loc0
   %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
-  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %102
 
 ; <label>:102                                     ; preds = %99
   %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
   %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
-  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
-  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
@@ -9819,87 +11408,87 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %26
+ThrowNullRef10:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %31
+ThrowNullRef12:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %35
+ThrowNullRef14:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %40
+ThrowNullRef16:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %56
+ThrowNullRef22:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %59
+ThrowNullRef24:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %63
+ThrowNullRef26:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %66
+ThrowNullRef28:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %102
+ThrowNullRef32:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %71
+ThrowNullRef34:                                   ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %73
+ThrowNullRef36:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %83
+ThrowNullRef38:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %85
+ThrowNullRef40:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %91
+ThrowNullRef42:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9943,15 +11532,15 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
   %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
@@ -9961,28 +11550,28 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
   %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %12
   %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
   %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
   %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
-  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
@@ -9993,23 +11582,23 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %12
+ThrowNullRef6:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10031,15 +11620,15 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
   %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = load i64, i64 addrspace(1)* %7
@@ -10077,13 +11666,13 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[loadElem]
+Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -10111,8 +11700,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Ne1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Ne1.error.txt
@@ -25,8 +25,8 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
@@ -40,8 +40,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
   %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
@@ -75,7 +75,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -90,8 +90,8 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %NullCheck = icmp ne i8 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = load i8, i8 addrspace(1)* %0, align 8
@@ -125,8 +125,8 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
@@ -159,8 +159,8 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -184,8 +184,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
   store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
@@ -195,8 +195,8 @@ entry:
 ; <label>:4                                       ; preds = %1
   %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
   %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
@@ -206,8 +206,8 @@ entry:
   %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
@@ -221,14 +221,14 @@ entry:
 
 ; <label>:17                                      ; preds = %14
   %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
   %21 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
@@ -238,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -249,8 +249,8 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
@@ -261,27 +261,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %30
+ThrowNullRef10:                                   ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -301,7 +301,89 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
-Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
+Successfully read AppDomainSetup.GetUnsecureApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.GetUnsecureApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %NullCheck = icmp eq %"System.String[]" addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %BoundsCheck = icmp uge i64 0, %5
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %6
+
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 3, i32 0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
+  ret %System.String addrspace(1)* %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_Value using LLILCJit
+Successfully read AppDomainSetup.get_Value
+
+define %"System.String[]" addrspace(1)* @AppDomainSetup.get_Value(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.String[]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 18)
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.String[]" addrspace(1)* addrspace(1)*, %"System.String[]" addrspace(1)*)*)(%"System.String[]" addrspace(1)* addrspace(1)* %9, %"System.String[]" addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %11, i32 0, i32 1
+  %14 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %13, align 8
+  ret %"System.String[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -319,8 +401,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -368,16 +450,16 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
   %5 = load i32, i32 addrspace(1)* %4
   %6 = sub i32 %5, 1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -389,7 +471,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -421,8 +503,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
@@ -456,8 +538,8 @@ entry:
 ; <label>:27                                      ; preds = %19
   %28 = load i32, i32* %arg1
   %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
-  br i1 %NullCheck2, label %30, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %29, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %30
 
 ; <label>:30                                      ; preds = %27
   %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
@@ -493,8 +575,8 @@ entry:
 ; <label>:49                                      ; preds = %46
   %50 = load i32, i32* %arg2
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck4, label %52, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
@@ -517,11 +599,11 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %27
+ThrowNullRef2:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %49
+ThrowNullRef4:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -544,16 +626,16 @@ entry:
   %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %0)
   store %System.String addrspace(1)* %1, %System.String addrspace(1)** %loc0
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 2
   %5 = bitcast [0 x i16] addrspace(1)* %4 to i16 addrspace(1)*
   store i16 addrspace(1)* %5, i16 addrspace(1)** %loc1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %3
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2
@@ -580,7 +662,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -691,15 +773,15 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %NullCheck132 = icmp ne i8* %21, null
-  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+  %NullCheck131 = icmp eq i8* %21, null
+  br i1 %NullCheck131, label %ThrowNullRef132, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = load i8, i8* %21, align 8
   %24 = zext i8 %23 to i32
   %25 = trunc i32 %24 to i8
-  %NullCheck134 = icmp ne i8* %20, null
-  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+  %NullCheck133 = icmp eq i8* %20, null
+  br i1 %NullCheck133, label %ThrowNullRef134, label %26
 
 ; <label>:26                                      ; preds = %22
   store i8 %25, i8* %20, align 8
@@ -709,16 +791,16 @@ entry:
   %28 = load i8*, i8** %arg0
   %29 = load i8*, i8** %arg1
   %30 = bitcast i8* %29 to i16*
-  %NullCheck128 = icmp ne i16* %30, null
-  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+  %NullCheck127 = icmp eq i16* %30, null
+  br i1 %NullCheck127, label %ThrowNullRef128, label %31
 
 ; <label>:31                                      ; preds = %27
   %32 = load i16, i16* %30, align 8
   %33 = sext i16 %32 to i32
   %34 = bitcast i8* %28 to i16*
   %35 = trunc i32 %33 to i16
-  %NullCheck130 = icmp ne i16* %34, null
-  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+  %NullCheck129 = icmp eq i16* %34, null
+  br i1 %NullCheck129, label %ThrowNullRef130, label %36
 
 ; <label>:36                                      ; preds = %31
   store i16 %35, i16* %34, align 8
@@ -728,16 +810,16 @@ entry:
   %38 = load i8*, i8** %arg0
   %39 = load i8*, i8** %arg1
   %40 = bitcast i8* %39 to i16*
-  %NullCheck120 = icmp ne i16* %40, null
-  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+  %NullCheck119 = icmp eq i16* %40, null
+  br i1 %NullCheck119, label %ThrowNullRef120, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i16, i16* %40, align 8
   %43 = sext i16 %42 to i32
   %44 = bitcast i8* %38 to i16*
   %45 = trunc i32 %43 to i16
-  %NullCheck122 = icmp ne i16* %44, null
-  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+  %NullCheck121 = icmp eq i16* %44, null
+  br i1 %NullCheck121, label %ThrowNullRef122, label %46
 
 ; <label>:46                                      ; preds = %41
   store i16 %45, i16* %44, align 8
@@ -745,15 +827,15 @@ entry:
   %48 = getelementptr inbounds i8, i8* %47, i64 2
   %49 = load i8*, i8** %arg1
   %50 = getelementptr inbounds i8, i8* %49, i64 2
-  %NullCheck124 = icmp ne i8* %50, null
-  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+  %NullCheck123 = icmp eq i8* %50, null
+  br i1 %NullCheck123, label %ThrowNullRef124, label %51
 
 ; <label>:51                                      ; preds = %46
   %52 = load i8, i8* %50, align 8
   %53 = zext i8 %52 to i32
   %54 = trunc i32 %53 to i8
-  %NullCheck126 = icmp ne i8* %48, null
-  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+  %NullCheck125 = icmp eq i8* %48, null
+  br i1 %NullCheck125, label %ThrowNullRef126, label %55
 
 ; <label>:55                                      ; preds = %51
   store i8 %54, i8* %48, align 8
@@ -763,14 +845,14 @@ entry:
   %57 = load i8*, i8** %arg0
   %58 = load i8*, i8** %arg1
   %59 = bitcast i8* %58 to i32*
-  %NullCheck116 = icmp ne i32* %59, null
-  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+  %NullCheck115 = icmp eq i32* %59, null
+  br i1 %NullCheck115, label %ThrowNullRef116, label %60
 
 ; <label>:60                                      ; preds = %56
   %61 = load i32, i32* %59, align 8
   %62 = bitcast i8* %57 to i32*
-  %NullCheck118 = icmp ne i32* %62, null
-  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+  %NullCheck117 = icmp eq i32* %62, null
+  br i1 %NullCheck117, label %ThrowNullRef118, label %63
 
 ; <label>:63                                      ; preds = %60
   store i32 %61, i32* %62, align 8
@@ -780,14 +862,14 @@ entry:
   %65 = load i8*, i8** %arg0
   %66 = load i8*, i8** %arg1
   %67 = bitcast i8* %66 to i32*
-  %NullCheck108 = icmp ne i32* %67, null
-  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+  %NullCheck107 = icmp eq i32* %67, null
+  br i1 %NullCheck107, label %ThrowNullRef108, label %68
 
 ; <label>:68                                      ; preds = %64
   %69 = load i32, i32* %67, align 8
   %70 = bitcast i8* %65 to i32*
-  %NullCheck110 = icmp ne i32* %70, null
-  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+  %NullCheck109 = icmp eq i32* %70, null
+  br i1 %NullCheck109, label %ThrowNullRef110, label %71
 
 ; <label>:71                                      ; preds = %68
   store i32 %69, i32* %70, align 8
@@ -795,15 +877,15 @@ entry:
   %73 = getelementptr inbounds i8, i8* %72, i64 4
   %74 = load i8*, i8** %arg1
   %75 = getelementptr inbounds i8, i8* %74, i64 4
-  %NullCheck112 = icmp ne i8* %75, null
-  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+  %NullCheck111 = icmp eq i8* %75, null
+  br i1 %NullCheck111, label %ThrowNullRef112, label %76
 
 ; <label>:76                                      ; preds = %71
   %77 = load i8, i8* %75, align 8
   %78 = zext i8 %77 to i32
   %79 = trunc i32 %78 to i8
-  %NullCheck114 = icmp ne i8* %73, null
-  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+  %NullCheck113 = icmp eq i8* %73, null
+  br i1 %NullCheck113, label %ThrowNullRef114, label %80
 
 ; <label>:80                                      ; preds = %76
   store i8 %79, i8* %73, align 8
@@ -813,14 +895,14 @@ entry:
   %82 = load i8*, i8** %arg0
   %83 = load i8*, i8** %arg1
   %84 = bitcast i8* %83 to i32*
-  %NullCheck100 = icmp ne i32* %84, null
-  br i1 %NullCheck100, label %85, label %ThrowNullRef99
+  %NullCheck99 = icmp eq i32* %84, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %85
 
 ; <label>:85                                      ; preds = %81
   %86 = load i32, i32* %84, align 8
   %87 = bitcast i8* %82 to i32*
-  %NullCheck102 = icmp ne i32* %87, null
-  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+  %NullCheck101 = icmp eq i32* %87, null
+  br i1 %NullCheck101, label %ThrowNullRef102, label %88
 
 ; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
@@ -829,16 +911,16 @@ entry:
   %91 = load i8*, i8** %arg1
   %92 = getelementptr inbounds i8, i8* %91, i64 4
   %93 = bitcast i8* %92 to i16*
-  %NullCheck104 = icmp ne i16* %93, null
-  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+  %NullCheck103 = icmp eq i16* %93, null
+  br i1 %NullCheck103, label %ThrowNullRef104, label %94
 
 ; <label>:94                                      ; preds = %88
   %95 = load i16, i16* %93, align 8
   %96 = sext i16 %95 to i32
   %97 = bitcast i8* %90 to i16*
   %98 = trunc i32 %96 to i16
-  %NullCheck106 = icmp ne i16* %97, null
-  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+  %NullCheck105 = icmp eq i16* %97, null
+  br i1 %NullCheck105, label %ThrowNullRef106, label %99
 
 ; <label>:99                                      ; preds = %94
   store i16 %98, i16* %97, align 8
@@ -848,14 +930,14 @@ entry:
   %101 = load i8*, i8** %arg0
   %102 = load i8*, i8** %arg1
   %103 = bitcast i8* %102 to i32*
-  %NullCheck88 = icmp ne i32* %103, null
-  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+  %NullCheck87 = icmp eq i32* %103, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %104
 
 ; <label>:104                                     ; preds = %100
   %105 = load i32, i32* %103, align 8
   %106 = bitcast i8* %101 to i32*
-  %NullCheck90 = icmp ne i32* %106, null
-  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+  %NullCheck89 = icmp eq i32* %106, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %107
 
 ; <label>:107                                     ; preds = %104
   store i32 %105, i32* %106, align 8
@@ -864,16 +946,16 @@ entry:
   %110 = load i8*, i8** %arg1
   %111 = getelementptr inbounds i8, i8* %110, i64 4
   %112 = bitcast i8* %111 to i16*
-  %NullCheck92 = icmp ne i16* %112, null
-  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+  %NullCheck91 = icmp eq i16* %112, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %113
 
 ; <label>:113                                     ; preds = %107
   %114 = load i16, i16* %112, align 8
   %115 = sext i16 %114 to i32
   %116 = bitcast i8* %109 to i16*
   %117 = trunc i32 %115 to i16
-  %NullCheck94 = icmp ne i16* %116, null
-  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+  %NullCheck93 = icmp eq i16* %116, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %118
 
 ; <label>:118                                     ; preds = %113
   store i16 %117, i16* %116, align 8
@@ -881,15 +963,15 @@ entry:
   %120 = getelementptr inbounds i8, i8* %119, i64 6
   %121 = load i8*, i8** %arg1
   %122 = getelementptr inbounds i8, i8* %121, i64 6
-  %NullCheck96 = icmp ne i8* %122, null
-  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+  %NullCheck95 = icmp eq i8* %122, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %123
 
 ; <label>:123                                     ; preds = %118
   %124 = load i8, i8* %122, align 8
   %125 = zext i8 %124 to i32
   %126 = trunc i32 %125 to i8
-  %NullCheck98 = icmp ne i8* %120, null
-  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+  %NullCheck97 = icmp eq i8* %120, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %127
 
 ; <label>:127                                     ; preds = %123
   store i8 %126, i8* %120, align 8
@@ -899,14 +981,14 @@ entry:
   %129 = load i8*, i8** %arg0
   %130 = load i8*, i8** %arg1
   %131 = bitcast i8* %130 to i64*
-  %NullCheck84 = icmp ne i64* %131, null
-  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+  %NullCheck83 = icmp eq i64* %131, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %132
 
 ; <label>:132                                     ; preds = %128
   %133 = load i64, i64* %131, align 8
   %134 = bitcast i8* %129 to i64*
-  %NullCheck86 = icmp ne i64* %134, null
-  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+  %NullCheck85 = icmp eq i64* %134, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %135
 
 ; <label>:135                                     ; preds = %132
   store i64 %133, i64* %134, align 8
@@ -916,14 +998,14 @@ entry:
   %137 = load i8*, i8** %arg0
   %138 = load i8*, i8** %arg1
   %139 = bitcast i8* %138 to i64*
-  %NullCheck76 = icmp ne i64* %139, null
-  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+  %NullCheck75 = icmp eq i64* %139, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %140
 
 ; <label>:140                                     ; preds = %136
   %141 = load i64, i64* %139, align 8
   %142 = bitcast i8* %137 to i64*
-  %NullCheck78 = icmp ne i64* %142, null
-  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+  %NullCheck77 = icmp eq i64* %142, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %143
 
 ; <label>:143                                     ; preds = %140
   store i64 %141, i64* %142, align 8
@@ -931,15 +1013,15 @@ entry:
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %NullCheck80 = icmp ne i8* %147, null
-  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+  %NullCheck79 = icmp eq i8* %147, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %148
 
 ; <label>:148                                     ; preds = %143
   %149 = load i8, i8* %147, align 8
   %150 = zext i8 %149 to i32
   %151 = trunc i32 %150 to i8
-  %NullCheck82 = icmp ne i8* %145, null
-  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+  %NullCheck81 = icmp eq i8* %145, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %152
 
 ; <label>:152                                     ; preds = %148
   store i8 %151, i8* %145, align 8
@@ -949,14 +1031,14 @@ entry:
   %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
   %156 = bitcast i8* %155 to i64*
-  %NullCheck68 = icmp ne i64* %156, null
-  br i1 %NullCheck68, label %157, label %ThrowNullRef67
+  %NullCheck67 = icmp eq i64* %156, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %157
 
 ; <label>:157                                     ; preds = %153
   %158 = load i64, i64* %156, align 8
   %159 = bitcast i8* %154 to i64*
-  %NullCheck70 = icmp ne i64* %159, null
-  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+  %NullCheck69 = icmp eq i64* %159, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %160
 
 ; <label>:160                                     ; preds = %157
   store i64 %158, i64* %159, align 8
@@ -965,16 +1047,16 @@ entry:
   %163 = load i8*, i8** %arg1
   %164 = getelementptr inbounds i8, i8* %163, i64 8
   %165 = bitcast i8* %164 to i16*
-  %NullCheck72 = icmp ne i16* %165, null
-  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+  %NullCheck71 = icmp eq i16* %165, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %166
 
 ; <label>:166                                     ; preds = %160
   %167 = load i16, i16* %165, align 8
   %168 = sext i16 %167 to i32
   %169 = bitcast i8* %162 to i16*
   %170 = trunc i32 %168 to i16
-  %NullCheck74 = icmp ne i16* %169, null
-  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+  %NullCheck73 = icmp eq i16* %169, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %171
 
 ; <label>:171                                     ; preds = %166
   store i16 %170, i16* %169, align 8
@@ -984,14 +1066,14 @@ entry:
   %173 = load i8*, i8** %arg0
   %174 = load i8*, i8** %arg1
   %175 = bitcast i8* %174 to i64*
-  %NullCheck56 = icmp ne i64* %175, null
-  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+  %NullCheck55 = icmp eq i64* %175, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %176
 
 ; <label>:176                                     ; preds = %172
   %177 = load i64, i64* %175, align 8
   %178 = bitcast i8* %173 to i64*
-  %NullCheck58 = icmp ne i64* %178, null
-  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+  %NullCheck57 = icmp eq i64* %178, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %179
 
 ; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
@@ -1000,16 +1082,16 @@ entry:
   %182 = load i8*, i8** %arg1
   %183 = getelementptr inbounds i8, i8* %182, i64 8
   %184 = bitcast i8* %183 to i16*
-  %NullCheck60 = icmp ne i16* %184, null
-  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+  %NullCheck59 = icmp eq i16* %184, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %185
 
 ; <label>:185                                     ; preds = %179
   %186 = load i16, i16* %184, align 8
   %187 = sext i16 %186 to i32
   %188 = bitcast i8* %181 to i16*
   %189 = trunc i32 %187 to i16
-  %NullCheck62 = icmp ne i16* %188, null
-  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+  %NullCheck61 = icmp eq i16* %188, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %190
 
 ; <label>:190                                     ; preds = %185
   store i16 %189, i16* %188, align 8
@@ -1017,15 +1099,15 @@ entry:
   %192 = getelementptr inbounds i8, i8* %191, i64 10
   %193 = load i8*, i8** %arg1
   %194 = getelementptr inbounds i8, i8* %193, i64 10
-  %NullCheck64 = icmp ne i8* %194, null
-  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+  %NullCheck63 = icmp eq i8* %194, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %195
 
 ; <label>:195                                     ; preds = %190
   %196 = load i8, i8* %194, align 8
   %197 = zext i8 %196 to i32
   %198 = trunc i32 %197 to i8
-  %NullCheck66 = icmp ne i8* %192, null
-  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+  %NullCheck65 = icmp eq i8* %192, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %199
 
 ; <label>:199                                     ; preds = %195
   store i8 %198, i8* %192, align 8
@@ -1035,14 +1117,14 @@ entry:
   %201 = load i8*, i8** %arg0
   %202 = load i8*, i8** %arg1
   %203 = bitcast i8* %202 to i64*
-  %NullCheck48 = icmp ne i64* %203, null
-  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+  %NullCheck47 = icmp eq i64* %203, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %204
 
 ; <label>:204                                     ; preds = %200
   %205 = load i64, i64* %203, align 8
   %206 = bitcast i8* %201 to i64*
-  %NullCheck50 = icmp ne i64* %206, null
-  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+  %NullCheck49 = icmp eq i64* %206, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %207
 
 ; <label>:207                                     ; preds = %204
   store i64 %205, i64* %206, align 8
@@ -1051,14 +1133,14 @@ entry:
   %210 = load i8*, i8** %arg1
   %211 = getelementptr inbounds i8, i8* %210, i64 8
   %212 = bitcast i8* %211 to i32*
-  %NullCheck52 = icmp ne i32* %212, null
-  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+  %NullCheck51 = icmp eq i32* %212, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %213
 
 ; <label>:213                                     ; preds = %207
   %214 = load i32, i32* %212, align 8
   %215 = bitcast i8* %209 to i32*
-  %NullCheck54 = icmp ne i32* %215, null
-  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+  %NullCheck53 = icmp eq i32* %215, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %216
 
 ; <label>:216                                     ; preds = %213
   store i32 %214, i32* %215, align 8
@@ -1068,14 +1150,14 @@ entry:
   %218 = load i8*, i8** %arg0
   %219 = load i8*, i8** %arg1
   %220 = bitcast i8* %219 to i64*
-  %NullCheck36 = icmp ne i64* %220, null
-  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64* %220, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %221
 
 ; <label>:221                                     ; preds = %217
   %222 = load i64, i64* %220, align 8
   %223 = bitcast i8* %218 to i64*
-  %NullCheck38 = icmp ne i64* %223, null
-  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+  %NullCheck37 = icmp eq i64* %223, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %224
 
 ; <label>:224                                     ; preds = %221
   store i64 %222, i64* %223, align 8
@@ -1084,14 +1166,14 @@ entry:
   %227 = load i8*, i8** %arg1
   %228 = getelementptr inbounds i8, i8* %227, i64 8
   %229 = bitcast i8* %228 to i32*
-  %NullCheck40 = icmp ne i32* %229, null
-  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i32* %229, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %230
 
 ; <label>:230                                     ; preds = %224
   %231 = load i32, i32* %229, align 8
   %232 = bitcast i8* %226 to i32*
-  %NullCheck42 = icmp ne i32* %232, null
-  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+  %NullCheck41 = icmp eq i32* %232, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %233
 
 ; <label>:233                                     ; preds = %230
   store i32 %231, i32* %232, align 8
@@ -1099,15 +1181,15 @@ entry:
   %235 = getelementptr inbounds i8, i8* %234, i64 12
   %236 = load i8*, i8** %arg1
   %237 = getelementptr inbounds i8, i8* %236, i64 12
-  %NullCheck44 = icmp ne i8* %237, null
-  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i8* %237, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %238
 
 ; <label>:238                                     ; preds = %233
   %239 = load i8, i8* %237, align 8
   %240 = zext i8 %239 to i32
   %241 = trunc i32 %240 to i8
-  %NullCheck46 = icmp ne i8* %235, null
-  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+  %NullCheck45 = icmp eq i8* %235, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %242
 
 ; <label>:242                                     ; preds = %238
   store i8 %241, i8* %235, align 8
@@ -1117,14 +1199,14 @@ entry:
   %244 = load i8*, i8** %arg0
   %245 = load i8*, i8** %arg1
   %246 = bitcast i8* %245 to i64*
-  %NullCheck24 = icmp ne i64* %246, null
-  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64* %246, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %247
 
 ; <label>:247                                     ; preds = %243
   %248 = load i64, i64* %246, align 8
   %249 = bitcast i8* %244 to i64*
-  %NullCheck26 = icmp ne i64* %249, null
-  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64* %249, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %250
 
 ; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
@@ -1133,14 +1215,14 @@ entry:
   %253 = load i8*, i8** %arg1
   %254 = getelementptr inbounds i8, i8* %253, i64 8
   %255 = bitcast i8* %254 to i32*
-  %NullCheck28 = icmp ne i32* %255, null
-  br i1 %NullCheck28, label %256, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i32* %255, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %256
 
 ; <label>:256                                     ; preds = %250
   %257 = load i32, i32* %255, align 8
   %258 = bitcast i8* %252 to i32*
-  %NullCheck30 = icmp ne i32* %258, null
-  br i1 %NullCheck30, label %259, label %ThrowNullRef29
+  %NullCheck29 = icmp eq i32* %258, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %259
 
 ; <label>:259                                     ; preds = %256
   store i32 %257, i32* %258, align 8
@@ -1149,16 +1231,16 @@ entry:
   %262 = load i8*, i8** %arg1
   %263 = getelementptr inbounds i8, i8* %262, i64 12
   %264 = bitcast i8* %263 to i16*
-  %NullCheck32 = icmp ne i16* %264, null
-  br i1 %NullCheck32, label %265, label %ThrowNullRef31
+  %NullCheck31 = icmp eq i16* %264, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %265
 
 ; <label>:265                                     ; preds = %259
   %266 = load i16, i16* %264, align 8
   %267 = sext i16 %266 to i32
   %268 = bitcast i8* %261 to i16*
   %269 = trunc i32 %267 to i16
-  %NullCheck34 = icmp ne i16* %268, null
-  br i1 %NullCheck34, label %270, label %ThrowNullRef33
+  %NullCheck33 = icmp eq i16* %268, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %270
 
 ; <label>:270                                     ; preds = %265
   store i16 %269, i16* %268, align 8
@@ -1168,14 +1250,14 @@ entry:
   %272 = load i8*, i8** %arg0
   %273 = load i8*, i8** %arg1
   %274 = bitcast i8* %273 to i64*
-  %NullCheck8 = icmp ne i64* %274, null
-  br i1 %NullCheck8, label %275, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64* %274, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %275
 
 ; <label>:275                                     ; preds = %271
   %276 = load i64, i64* %274, align 8
   %277 = bitcast i8* %272 to i64*
-  %NullCheck10 = icmp ne i64* %277, null
-  br i1 %NullCheck10, label %278, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %277, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %278
 
 ; <label>:278                                     ; preds = %275
   store i64 %276, i64* %277, align 8
@@ -1184,14 +1266,14 @@ entry:
   %281 = load i8*, i8** %arg1
   %282 = getelementptr inbounds i8, i8* %281, i64 8
   %283 = bitcast i8* %282 to i32*
-  %NullCheck12 = icmp ne i32* %283, null
-  br i1 %NullCheck12, label %284, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i32* %283, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %284
 
 ; <label>:284                                     ; preds = %278
   %285 = load i32, i32* %283, align 8
   %286 = bitcast i8* %280 to i32*
-  %NullCheck14 = icmp ne i32* %286, null
-  br i1 %NullCheck14, label %287, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i32* %286, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %287
 
 ; <label>:287                                     ; preds = %284
   store i32 %285, i32* %286, align 8
@@ -1200,16 +1282,16 @@ entry:
   %290 = load i8*, i8** %arg1
   %291 = getelementptr inbounds i8, i8* %290, i64 12
   %292 = bitcast i8* %291 to i16*
-  %NullCheck16 = icmp ne i16* %292, null
-  br i1 %NullCheck16, label %293, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i16* %292, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %293
 
 ; <label>:293                                     ; preds = %287
   %294 = load i16, i16* %292, align 8
   %295 = sext i16 %294 to i32
   %296 = bitcast i8* %289 to i16*
   %297 = trunc i32 %295 to i16
-  %NullCheck18 = icmp ne i16* %296, null
-  br i1 %NullCheck18, label %298, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i16* %296, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %298
 
 ; <label>:298                                     ; preds = %293
   store i16 %297, i16* %296, align 8
@@ -1217,15 +1299,15 @@ entry:
   %300 = getelementptr inbounds i8, i8* %299, i64 14
   %301 = load i8*, i8** %arg1
   %302 = getelementptr inbounds i8, i8* %301, i64 14
-  %NullCheck20 = icmp ne i8* %302, null
-  br i1 %NullCheck20, label %303, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i8* %302, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %303
 
 ; <label>:303                                     ; preds = %298
   %304 = load i8, i8* %302, align 8
   %305 = zext i8 %304 to i32
   %306 = trunc i32 %305 to i8
-  %NullCheck22 = icmp ne i8* %300, null
-  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i8* %300, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %307
 
 ; <label>:307                                     ; preds = %303
   store i8 %306, i8* %300, align 8
@@ -1235,14 +1317,14 @@ entry:
   %309 = load i8*, i8** %arg0
   %310 = load i8*, i8** %arg1
   %311 = bitcast i8* %310 to i64*
-  %NullCheck = icmp ne i64* %311, null
-  br i1 %NullCheck, label %312, label %ThrowNullRef
+  %NullCheck = icmp eq i64* %311, null
+  br i1 %NullCheck, label %ThrowNullRef, label %312
 
 ; <label>:312                                     ; preds = %308
   %313 = load i64, i64* %311, align 8
   %314 = bitcast i8* %309 to i64*
-  %NullCheck2 = icmp ne i64* %314, null
-  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64* %314, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %315
 
 ; <label>:315                                     ; preds = %312
   store i64 %313, i64* %314, align 8
@@ -1251,14 +1333,14 @@ entry:
   %318 = load i8*, i8** %arg1
   %319 = getelementptr inbounds i8, i8* %318, i64 8
   %320 = bitcast i8* %319 to i64*
-  %NullCheck4 = icmp ne i64* %320, null
-  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64* %320, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %321
 
 ; <label>:321                                     ; preds = %315
   %322 = load i64, i64* %320, align 8
   %323 = bitcast i8* %317 to i64*
-  %NullCheck6 = icmp ne i64* %323, null
-  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64* %323, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %324
 
 ; <label>:324                                     ; preds = %321
   store i64 %322, i64* %323, align 8
@@ -1286,15 +1368,15 @@ entry:
 ; <label>:338                                     ; preds = %333
   %339 = load i8*, i8** %arg0
   %340 = load i8*, i8** %arg1
-  %NullCheck136 = icmp ne i8* %340, null
-  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+  %NullCheck135 = icmp eq i8* %340, null
+  br i1 %NullCheck135, label %ThrowNullRef136, label %341
 
 ; <label>:341                                     ; preds = %338
   %342 = load i8, i8* %340, align 8
   %343 = zext i8 %342 to i32
   %344 = trunc i32 %343 to i8
-  %NullCheck138 = icmp ne i8* %339, null
-  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+  %NullCheck137 = icmp eq i8* %339, null
+  br i1 %NullCheck137, label %ThrowNullRef138, label %345
 
 ; <label>:345                                     ; preds = %341
   store i8 %344, i8* %339, align 8
@@ -1317,16 +1399,16 @@ entry:
   %357 = load i8*, i8** %arg0
   %358 = load i8*, i8** %arg1
   %359 = bitcast i8* %358 to i16*
-  %NullCheck140 = icmp ne i16* %359, null
-  br i1 %NullCheck140, label %360, label %ThrowNullRef139
+  %NullCheck139 = icmp eq i16* %359, null
+  br i1 %NullCheck139, label %ThrowNullRef140, label %360
 
 ; <label>:360                                     ; preds = %356
   %361 = load i16, i16* %359, align 8
   %362 = sext i16 %361 to i32
   %363 = bitcast i8* %357 to i16*
   %364 = trunc i32 %362 to i16
-  %NullCheck142 = icmp ne i16* %363, null
-  br i1 %NullCheck142, label %365, label %ThrowNullRef141
+  %NullCheck141 = icmp eq i16* %363, null
+  br i1 %NullCheck141, label %ThrowNullRef142, label %365
 
 ; <label>:365                                     ; preds = %360
   store i16 %364, i16* %363, align 8
@@ -1352,14 +1434,14 @@ entry:
   %378 = load i8*, i8** %arg0
   %379 = load i8*, i8** %arg1
   %380 = bitcast i8* %379 to i32*
-  %NullCheck144 = icmp ne i32* %380, null
-  br i1 %NullCheck144, label %381, label %ThrowNullRef143
+  %NullCheck143 = icmp eq i32* %380, null
+  br i1 %NullCheck143, label %ThrowNullRef144, label %381
 
 ; <label>:381                                     ; preds = %377
   %382 = load i32, i32* %380, align 8
   %383 = bitcast i8* %378 to i32*
-  %NullCheck146 = icmp ne i32* %383, null
-  br i1 %NullCheck146, label %384, label %ThrowNullRef145
+  %NullCheck145 = icmp eq i32* %383, null
+  br i1 %NullCheck145, label %ThrowNullRef146, label %384
 
 ; <label>:384                                     ; preds = %381
   store i32 %382, i32* %383, align 8
@@ -1384,14 +1466,14 @@ entry:
   %395 = load i8*, i8** %arg0
   %396 = load i8*, i8** %arg1
   %397 = bitcast i8* %396 to i64*
-  %NullCheck164 = icmp ne i64* %397, null
-  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+  %NullCheck163 = icmp eq i64* %397, null
+  br i1 %NullCheck163, label %ThrowNullRef164, label %398
 
 ; <label>:398                                     ; preds = %394
   %399 = load i64, i64* %397, align 8
   %400 = bitcast i8* %395 to i64*
-  %NullCheck166 = icmp ne i64* %400, null
-  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+  %NullCheck165 = icmp eq i64* %400, null
+  br i1 %NullCheck165, label %ThrowNullRef166, label %401
 
 ; <label>:401                                     ; preds = %398
   store i64 %399, i64* %400, align 8
@@ -1400,14 +1482,14 @@ entry:
   %404 = load i8*, i8** %arg1
   %405 = getelementptr inbounds i8, i8* %404, i64 8
   %406 = bitcast i8* %405 to i64*
-  %NullCheck168 = icmp ne i64* %406, null
-  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+  %NullCheck167 = icmp eq i64* %406, null
+  br i1 %NullCheck167, label %ThrowNullRef168, label %407
 
 ; <label>:407                                     ; preds = %401
   %408 = load i64, i64* %406, align 8
   %409 = bitcast i8* %403 to i64*
-  %NullCheck170 = icmp ne i64* %409, null
-  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+  %NullCheck169 = icmp eq i64* %409, null
+  br i1 %NullCheck169, label %ThrowNullRef170, label %410
 
 ; <label>:410                                     ; preds = %407
   store i64 %408, i64* %409, align 8
@@ -1437,14 +1519,14 @@ entry:
   %425 = load i8*, i8** %arg0
   %426 = load i8*, i8** %arg1
   %427 = bitcast i8* %426 to i64*
-  %NullCheck148 = icmp ne i64* %427, null
-  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+  %NullCheck147 = icmp eq i64* %427, null
+  br i1 %NullCheck147, label %ThrowNullRef148, label %428
 
 ; <label>:428                                     ; preds = %424
   %429 = load i64, i64* %427, align 8
   %430 = bitcast i8* %425 to i64*
-  %NullCheck150 = icmp ne i64* %430, null
-  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+  %NullCheck149 = icmp eq i64* %430, null
+  br i1 %NullCheck149, label %ThrowNullRef150, label %431
 
 ; <label>:431                                     ; preds = %428
   store i64 %429, i64* %430, align 8
@@ -1466,14 +1548,14 @@ entry:
   %441 = load i8*, i8** %arg0
   %442 = load i8*, i8** %arg1
   %443 = bitcast i8* %442 to i32*
-  %NullCheck152 = icmp ne i32* %443, null
-  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+  %NullCheck151 = icmp eq i32* %443, null
+  br i1 %NullCheck151, label %ThrowNullRef152, label %444
 
 ; <label>:444                                     ; preds = %440
   %445 = load i32, i32* %443, align 8
   %446 = bitcast i8* %441 to i32*
-  %NullCheck154 = icmp ne i32* %446, null
-  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+  %NullCheck153 = icmp eq i32* %446, null
+  br i1 %NullCheck153, label %ThrowNullRef154, label %447
 
 ; <label>:447                                     ; preds = %444
   store i32 %445, i32* %446, align 8
@@ -1495,16 +1577,16 @@ entry:
   %457 = load i8*, i8** %arg0
   %458 = load i8*, i8** %arg1
   %459 = bitcast i8* %458 to i16*
-  %NullCheck156 = icmp ne i16* %459, null
-  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+  %NullCheck155 = icmp eq i16* %459, null
+  br i1 %NullCheck155, label %ThrowNullRef156, label %460
 
 ; <label>:460                                     ; preds = %456
   %461 = load i16, i16* %459, align 8
   %462 = sext i16 %461 to i32
   %463 = bitcast i8* %457 to i16*
   %464 = trunc i32 %462 to i16
-  %NullCheck158 = icmp ne i16* %463, null
-  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+  %NullCheck157 = icmp eq i16* %463, null
+  br i1 %NullCheck157, label %ThrowNullRef158, label %465
 
 ; <label>:465                                     ; preds = %460
   store i16 %464, i16* %463, align 8
@@ -1525,15 +1607,15 @@ entry:
 ; <label>:474                                     ; preds = %470
   %475 = load i8*, i8** %arg0
   %476 = load i8*, i8** %arg1
-  %NullCheck160 = icmp ne i8* %476, null
-  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+  %NullCheck159 = icmp eq i8* %476, null
+  br i1 %NullCheck159, label %ThrowNullRef160, label %477
 
 ; <label>:477                                     ; preds = %474
   %478 = load i8, i8* %476, align 8
   %479 = zext i8 %478 to i32
   %480 = trunc i32 %479 to i8
-  %NullCheck162 = icmp ne i8* %475, null
-  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+  %NullCheck161 = icmp eq i8* %475, null
+  br i1 %NullCheck161, label %ThrowNullRef162, label %481
 
 ; <label>:481                                     ; preds = %477
   store i8 %480, i8* %475, align 8
@@ -1553,343 +1635,343 @@ ThrowNullRef:                                     ; preds = %308
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %312
+ThrowNullRef2:                                    ; preds = %312
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %315
+ThrowNullRef4:                                    ; preds = %315
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %321
+ThrowNullRef6:                                    ; preds = %321
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %271
+ThrowNullRef8:                                    ; preds = %271
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %275
+ThrowNullRef10:                                   ; preds = %275
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %278
+ThrowNullRef12:                                   ; preds = %278
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %284
+ThrowNullRef14:                                   ; preds = %284
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %287
+ThrowNullRef16:                                   ; preds = %287
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %293
+ThrowNullRef18:                                   ; preds = %293
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %298
+ThrowNullRef20:                                   ; preds = %298
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %303
+ThrowNullRef22:                                   ; preds = %303
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %243
+ThrowNullRef24:                                   ; preds = %243
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %247
+ThrowNullRef26:                                   ; preds = %247
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %250
+ThrowNullRef28:                                   ; preds = %250
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %256
+ThrowNullRef30:                                   ; preds = %256
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %259
+ThrowNullRef32:                                   ; preds = %259
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %265
+ThrowNullRef34:                                   ; preds = %265
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %217
+ThrowNullRef36:                                   ; preds = %217
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %221
+ThrowNullRef38:                                   ; preds = %221
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %224
+ThrowNullRef40:                                   ; preds = %224
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %230
+ThrowNullRef42:                                   ; preds = %230
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %233
+ThrowNullRef44:                                   ; preds = %233
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %238
+ThrowNullRef46:                                   ; preds = %238
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %200
+ThrowNullRef48:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %204
+ThrowNullRef50:                                   ; preds = %204
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %207
+ThrowNullRef52:                                   ; preds = %207
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %213
+ThrowNullRef54:                                   ; preds = %213
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %172
+ThrowNullRef56:                                   ; preds = %172
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %176
+ThrowNullRef58:                                   ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %179
+ThrowNullRef60:                                   ; preds = %179
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %185
+ThrowNullRef62:                                   ; preds = %185
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %190
+ThrowNullRef64:                                   ; preds = %190
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %195
+ThrowNullRef66:                                   ; preds = %195
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %153
+ThrowNullRef68:                                   ; preds = %153
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %157
+ThrowNullRef70:                                   ; preds = %157
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %160
+ThrowNullRef72:                                   ; preds = %160
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %166
+ThrowNullRef74:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %136
+ThrowNullRef76:                                   ; preds = %136
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %140
+ThrowNullRef78:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %143
+ThrowNullRef80:                                   ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %148
+ThrowNullRef82:                                   ; preds = %148
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %128
+ThrowNullRef84:                                   ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %132
+ThrowNullRef86:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %100
+ThrowNullRef88:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %104
+ThrowNullRef90:                                   ; preds = %104
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %107
+ThrowNullRef92:                                   ; preds = %107
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %113
+ThrowNullRef94:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %118
+ThrowNullRef96:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %123
+ThrowNullRef98:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %81
+ThrowNullRef100:                                  ; preds = %81
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef101:                                  ; preds = %85
+ThrowNullRef102:                                  ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef103:                                  ; preds = %88
+ThrowNullRef104:                                  ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef105:                                  ; preds = %94
+ThrowNullRef106:                                  ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef107:                                  ; preds = %64
+ThrowNullRef108:                                  ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef109:                                  ; preds = %68
+ThrowNullRef110:                                  ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef111:                                  ; preds = %71
+ThrowNullRef112:                                  ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef113:                                  ; preds = %76
+ThrowNullRef114:                                  ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef115:                                  ; preds = %56
+ThrowNullRef116:                                  ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef117:                                  ; preds = %60
+ThrowNullRef118:                                  ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef119:                                  ; preds = %37
+ThrowNullRef120:                                  ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef121:                                  ; preds = %41
+ThrowNullRef122:                                  ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef123:                                  ; preds = %46
+ThrowNullRef124:                                  ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef125:                                  ; preds = %51
+ThrowNullRef126:                                  ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef127:                                  ; preds = %27
+ThrowNullRef128:                                  ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef129:                                  ; preds = %31
+ThrowNullRef130:                                  ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef131:                                  ; preds = %19
+ThrowNullRef132:                                  ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef133:                                  ; preds = %22
+ThrowNullRef134:                                  ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef135:                                  ; preds = %338
+ThrowNullRef136:                                  ; preds = %338
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef137:                                  ; preds = %341
+ThrowNullRef138:                                  ; preds = %341
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef139:                                  ; preds = %356
+ThrowNullRef140:                                  ; preds = %356
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef141:                                  ; preds = %360
+ThrowNullRef142:                                  ; preds = %360
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef143:                                  ; preds = %377
+ThrowNullRef144:                                  ; preds = %377
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef145:                                  ; preds = %381
+ThrowNullRef146:                                  ; preds = %381
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef147:                                  ; preds = %424
+ThrowNullRef148:                                  ; preds = %424
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef149:                                  ; preds = %428
+ThrowNullRef150:                                  ; preds = %428
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef151:                                  ; preds = %440
+ThrowNullRef152:                                  ; preds = %440
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef153:                                  ; preds = %444
+ThrowNullRef154:                                  ; preds = %444
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef155:                                  ; preds = %456
+ThrowNullRef156:                                  ; preds = %456
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef157:                                  ; preds = %460
+ThrowNullRef158:                                  ; preds = %460
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef159:                                  ; preds = %474
+ThrowNullRef160:                                  ; preds = %474
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef161:                                  ; preds = %477
+ThrowNullRef162:                                  ; preds = %477
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef163:                                  ; preds = %394
+ThrowNullRef164:                                  ; preds = %394
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef165:                                  ; preds = %398
+ThrowNullRef166:                                  ; preds = %398
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef167:                                  ; preds = %401
+ThrowNullRef168:                                  ; preds = %401
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef169:                                  ; preds = %407
+ThrowNullRef170:                                  ; preds = %407
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1939,8 +2021,8 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
-  br i1 %NullCheck, label %22, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %ThrowNullRef, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
@@ -1948,8 +2030,8 @@ entry:
   store i32 %24, i32* %loc0
   %25 = load i32, i32* %loc0
   %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %26, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %27
 
 ; <label>:27                                      ; preds = %22
   %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
@@ -1971,7 +2053,7 @@ ThrowNullRef:                                     ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1989,8 +2071,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -2022,15 +2104,15 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2048,16 +2130,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
   %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
   store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %15
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
@@ -2072,8 +2154,8 @@ entry:
   %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
   %29 = ptrtoint i16 addrspace(1)* %28 to i64
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %19
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
@@ -2089,19 +2171,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2114,8 +2196,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
@@ -2128,7 +2210,7 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[loadElem]
+Failed to read AppDomain.PrepareDataForSetup[storeElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
@@ -2202,8 +2284,8 @@ entry:
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
-  br i1 %NullCheck24, label %27, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = load i64, i64 addrspace(1)* %26
@@ -2218,8 +2300,8 @@ entry:
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
-  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
   %41 = load i64, i64 addrspace(1)* %39
@@ -2236,8 +2318,8 @@ entry:
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
-  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
   %54 = load i64, i64 addrspace(1)* %52
@@ -2252,8 +2334,8 @@ entry:
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
   %67 = load i64, i64 addrspace(1)* %65
@@ -2270,8 +2352,8 @@ entry:
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
-  br i1 %NullCheck16, label %79, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
   %80 = load i64, i64 addrspace(1)* %78
@@ -2286,8 +2368,8 @@ entry:
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
-  br i1 %NullCheck18, label %92, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
   %93 = load i64, i64 addrspace(1)* %91
@@ -2304,8 +2386,8 @@ entry:
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
-  br i1 %NullCheck12, label %105, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = load i64, i64 addrspace(1)* %104
@@ -2320,8 +2402,8 @@ entry:
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
-  br i1 %NullCheck14, label %118, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
   %119 = load i64, i64 addrspace(1)* %117
@@ -2337,8 +2419,8 @@ entry:
 
 ; <label>:128                                     ; preds = %20
   %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
-  br i1 %NullCheck4, label %130, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %129, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %130
 
 ; <label>:130                                     ; preds = %128
   %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
@@ -2346,8 +2428,8 @@ entry:
   %133 = load i16, i16 addrspace(1)* %132, align 8
   %134 = zext i16 %133 to i32
   %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
-  br i1 %NullCheck6, label %136, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %135, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %136
 
 ; <label>:136                                     ; preds = %130
   %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
@@ -2360,8 +2442,8 @@ entry:
 
 ; <label>:143                                     ; preds = %136
   %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
-  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %144, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %145
 
 ; <label>:145                                     ; preds = %143
   %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
@@ -2369,8 +2451,8 @@ entry:
   %148 = load i16, i16 addrspace(1)* %147, align 8
   %149 = zext i16 %148 to i32
   %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %150, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %151
 
 ; <label>:151                                     ; preds = %145
   %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
@@ -2388,8 +2470,8 @@ entry:
 
 ; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
-  br i1 %NullCheck, label %163, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %ThrowNullRef, label %163
 
 ; <label>:163                                     ; preds = %161
   %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
@@ -2399,8 +2481,8 @@ entry:
 
 ; <label>:167                                     ; preds = %163
   %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
-  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %168, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %169
 
 ; <label>:169                                     ; preds = %167
   %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
@@ -2432,55 +2514,55 @@ ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %167
+ThrowNullRef2:                                    ; preds = %167
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %128
+ThrowNullRef4:                                    ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %130
+ThrowNullRef6:                                    ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %143
+ThrowNullRef8:                                    ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %145
+ThrowNullRef10:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %102
+ThrowNullRef12:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %105
+ThrowNullRef14:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %76
+ThrowNullRef16:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %79
+ThrowNullRef18:                                   ; preds = %79
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %50
+ThrowNullRef20:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %53
+ThrowNullRef22:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %24
+ThrowNullRef24:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %27
+ThrowNullRef26:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2503,15 +2585,15 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2519,16 +2601,16 @@ entry:
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
   store i32 %8, i32* %loc0
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
   %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
   store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
@@ -2546,16 +2628,16 @@ entry:
 
 ; <label>:23                                      ; preds = %64
   %24 = load i16*, i16** %loc3
-  %NullCheck12 = icmp ne i16* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i16* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
   store i32 %27, i32* %loc5
   %28 = load i16*, i16** %loc4
-  %NullCheck14 = icmp ne i16* %28, null
-  br i1 %NullCheck14, label %29, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %28, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = load i16, i16* %28, align 8
@@ -2620,15 +2702,15 @@ entry:
 
 ; <label>:67                                      ; preds = %64
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
-  br i1 %NullCheck8, label %69, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %68, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %69
 
 ; <label>:69                                      ; preds = %67
   %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
   %71 = load i32, i32 addrspace(1)* %70
   %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
-  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %73
 
 ; <label>:73                                      ; preds = %69
   %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
@@ -2645,31 +2727,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %67
+ThrowNullRef8:                                    ; preds = %67
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %69
+ThrowNullRef10:                                   ; preds = %69
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2710,14 +2792,14 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
   %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
@@ -2730,14 +2812,14 @@ entry:
 
 ; <label>:11                                      ; preds = %4
   %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
   %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
@@ -2749,14 +2831,14 @@ entry:
 
 ; <label>:22                                      ; preds = %16
   %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
   %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
-  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
-  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
@@ -2804,23 +2886,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2836,7 +2918,280 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[loadElem]
+Successfully read RuntimeType.IsAssignableFrom
+
+define i8 @RuntimeType.IsAssignableFrom(%System.RuntimeType addrspace(1)* %param0, %System.Type addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.RuntimeType addrspace(1)*
+  %arg1 = alloca %System.Type addrspace(1)*
+  %loc0 = alloca %System.RuntimeType addrspace(1)*
+  %loc1 = alloca %"System.Type[]" addrspace(1)*
+  %loc2 = alloca i32
+  store %System.RuntimeType addrspace(1)* %param0, %System.RuntimeType addrspace(1)** %this
+  store %System.Type addrspace(1)* %param1, %System.Type addrspace(1)** %arg1
+  %0 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %1 = icmp ne %System.Type addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i8 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %5 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %6 = bitcast %System.Type addrspace(1)* %4 to %System.Object addrspace(1)*
+  %7 = bitcast %System.RuntimeType addrspace(1)* %5 to %System.Object addrspace(1)*
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %6, %System.Object addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %3
+  ret i8 1
+
+; <label>:12                                      ; preds = %3
+  %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 152
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 32
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
+  %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
+  %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
+  store %System.RuntimeType addrspace(1)* %25, %System.RuntimeType addrspace(1)** %loc0
+  %26 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %27 = icmp eq %System.RuntimeType addrspace(1)* %26, null
+  br i1 %27, label %34, label %28
+
+; <label>:28                                      ; preds = %15
+  %29 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %30 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)*)*)(%System.RuntimeType addrspace(1)* %29, %System.RuntimeType addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+; <label>:34                                      ; preds = %15
+  %35 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %36 = call %System.Reflection.Emit.TypeBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Reflection.Emit.TypeBuilder addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %35)
+  %37 = icmp eq %System.Reflection.Emit.TypeBuilder addrspace(1)* %36, null
+  br i1 %37, label %139, label %38
+
+; <label>:38                                      ; preds = %34
+  %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %42
+
+; <label>:42                                      ; preds = %38
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 152
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 40
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
+  %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
+  %53 = zext i8 %52 to i32
+  %54 = icmp eq i32 %53, 0
+  br i1 %54, label %56, label %55
+
+; <label>:55                                      ; preds = %42
+  ret i8 1
+
+; <label>:56                                      ; preds = %42
+  %57 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %58 = bitcast %System.RuntimeType addrspace(1)* %57 to %System.Type addrspace(1)*
+  %59 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %58)
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %64 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.Type addrspace(1)* %63, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = bitcast %System.RuntimeType addrspace(1)* %64 to %System.Type addrspace(1)*
+  %67 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %63, %System.Type addrspace(1)* %66)
+  %68 = zext i8 %67 to i32
+  %69 = trunc i32 %68 to i8
+  ret i8 %69
+
+; <label>:70                                      ; preds = %56
+  %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
+  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %73
+
+; <label>:73                                      ; preds = %70
+  %74 = load i64, i64 addrspace(1)* %72
+  %75 = add i64 %74, 128
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = add i64 %77, 0
+  %79 = inttoptr i64 %78 to i64*
+  %80 = load i64, i64* %79
+  %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
+  %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
+  %83 = call i8 %82(%System.Type addrspace(1)* %81)
+  %84 = zext i8 %83 to i32
+  %85 = icmp eq i32 %84, 0
+  br i1 %85, label %139, label %86
+
+; <label>:86                                      ; preds = %73
+  %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
+  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %89
+
+; <label>:89                                      ; preds = %86
+  %90 = load i64, i64 addrspace(1)* %88
+  %91 = add i64 %90, 128
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = add i64 %93, 24
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
+  %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
+  %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
+  store %"System.Type[]" addrspace(1)* %99, %"System.Type[]" addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %129
+
+; <label>:100                                     ; preds = %132
+  %101 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %102 = load i32, i32* %loc2
+  %NullCheck11 = icmp eq %"System.Type[]" addrspace(1)* %101, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %103
+
+; <label>:103                                     ; preds = %100
+  %104 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 1
+  %105 = load i32, i32 addrspace(1)* %104
+  %106 = zext i32 %105 to i64
+  %107 = zext i32 %102 to i64
+  %BoundsCheck = icmp uge i64 %107, %106
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %108
+
+; <label>:108                                     ; preds = %103
+  %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
+  %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
+  %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
+  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %113
+
+; <label>:113                                     ; preds = %108
+  %114 = load i64, i64 addrspace(1)* %112
+  %115 = add i64 %114, 152
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = add i64 %117, 56
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
+  %123 = zext i8 %122 to i32
+  %124 = icmp ne i32 %123, 0
+  br i1 %124, label %126, label %125
+
+; <label>:125                                     ; preds = %113
+  ret i8 0
+
+; <label>:126                                     ; preds = %113
+  %127 = load i32, i32* %loc2
+  %128 = add i32 %127, 1
+  store i32 %128, i32* %loc2
+  br label %129
+
+; <label>:129                                     ; preds = %89, %126
+  %130 = load i32, i32* %loc2
+  %131 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %NullCheck9 = icmp eq %"System.Type[]" addrspace(1)* %131, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %132
+
+; <label>:132                                     ; preds = %129
+  %133 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %131, i32 0, i32 1
+  %134 = load i32, i32 addrspace(1)* %133
+  %135 = zext i32 %134 to i64
+  %136 = trunc i64 %135 to i32
+  %137 = icmp slt i32 %130, %136
+  br i1 %137, label %100, label %138
+
+; <label>:138                                     ; preds = %132
+  ret i8 1
+
+; <label>:139                                     ; preds = %34, %73
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %129
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %103
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -2893,7 +3248,7 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElem]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -2904,8 +3259,8 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -2997,8 +3352,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
@@ -3059,8 +3414,8 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -3087,8 +3442,8 @@ entry:
 
 ; <label>:17                                      ; preds = %5, %11
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
@@ -3097,8 +3452,8 @@ entry:
 
 ; <label>:22                                      ; preds = %1, %11
   %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
@@ -3109,11 +3464,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %17
+ThrowNullRef2:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %22
+ThrowNullRef4:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3167,15 +3522,15 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
   %15 = load i32, i32 addrspace(1)* %14
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
@@ -3198,7 +3553,7 @@ ThrowNullRef:                                     ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef2:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3232,8 +3587,8 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
@@ -3312,8 +3667,8 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -3327,8 +3682,8 @@ entry:
 ; <label>:5                                       ; preds = %43
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %7 = load i32, i32* %loc1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck6, label %8, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
@@ -3366,8 +3721,8 @@ entry:
 ; <label>:32                                      ; preds = %21, %25
   %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
   %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
-  br i1 %NullCheck8, label %35, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = trunc i32 %34 to i16
@@ -3380,8 +3735,8 @@ entry:
 ; <label>:40                                      ; preds = %1, %35
   %41 = load i32, i32* %loc1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
-  br i1 %NullCheck2, label %43, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %42, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
@@ -3392,8 +3747,8 @@ entry:
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
   %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
-  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
   %51 = load i64, i64 addrspace(1)* %49
@@ -3412,19 +3767,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %40
+ThrowNullRef2:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %47
+ThrowNullRef4:                                    ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %5
+ThrowNullRef6:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %32
+ThrowNullRef8:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3467,8 +3822,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
@@ -3492,11 +3847,391 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(i16* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store i16* %param0, i16** %arg0
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load i32, i32* %arg3
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %42, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %37, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg2
+  %13 = load i32, i32* %arg3
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %37, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %24 = load i32, i32* %arg2
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load i16*, i16** %arg0
+  %35 = load i32, i32* %arg3
+  %36 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %36, i16* %34, i32 %35)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:37                                      ; preds = %5, %16
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %39)
+  %41 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41, %System.String addrspace(1)* %38, %System.String addrspace(1)* %40)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41) #0
+  unreachable
+
+; <label>:42                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
-Failed to read StringBuilder.ToString[loadElemA]
+Successfully read StringBuilder.ToString
+
+define %System.String addrspace(1)* @StringBuilder.ToString(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i16*
+  %loc3 = alloca %"System.Char[]" addrspace(1)*
+  %loc4 = alloca i32
+  %loc5 = alloca i32
+  %loc6 = alloca i16 addrspace(1)*
+  %loc7 = alloca %System.String addrspace(1)*
+  %loc8 = alloca %"System.Char[]" addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %0)
+  %2 = icmp ne i32 %1, 0
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %4
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %6)
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %7)
+  store %System.String addrspace(1)* %8, %System.String addrspace(1)** %loc0
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.Text.StringBuilder addrspace(1)* %9, %System.Text.StringBuilder addrspace(1)** %loc1
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  store %System.String addrspace(1)* %10, %System.String addrspace(1)** %loc7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc7
+  %12 = ptrtoint %System.String addrspace(1)* %11 to i64
+  %13 = icmp eq i64 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %5
+  %15 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %16 = sext i32 %15 to i64
+  %17 = add i64 %12, %16
+  br label %18
+
+; <label>:18                                      ; preds = %5, %14
+  %19 = phi i64 [ %12, %5 ], [ %17, %14 ]
+  %20 = inttoptr i64 %19 to i16*
+  store i16* %20, i16** %loc2
+  br label %21
+
+; <label>:21                                      ; preds = %98, %18
+  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %22, null
+  br i1 %NullCheck, label %ThrowNullRef, label %23
+
+; <label>:23                                      ; preds = %21
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 3
+  %25 = load i32, i32 addrspace(1)* %24, align 8
+  %26 = icmp sle i32 %25, 0
+  br i1 %26, label %96, label %27
+
+; <label>:27                                      ; preds = %23
+  %28 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %28, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %29
+
+; <label>:29                                      ; preds = %27
+  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %28, i32 0, i32 1
+  %31 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %30, align 8
+  store %"System.Char[]" addrspace(1)* %31, %"System.Char[]" addrspace(1)** %loc3
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %33
+
+; <label>:33                                      ; preds = %29
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  store i32 %35, i32* %loc4
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  %39 = load i32, i32 addrspace(1)* %38, align 8
+  store i32 %39, i32* %loc5
+  %40 = load i32, i32* %loc5
+  %41 = load i32, i32* %loc4
+  %42 = add i32 %40, %41
+  %43 = zext i32 %42 to i64
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %45
+
+; <label>:45                                      ; preds = %37
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = sext i32 %47 to i64
+  %49 = icmp sgt i64 %43, %48
+  br i1 %49, label %91, label %50
+
+; <label>:50                                      ; preds = %45
+  %51 = load i32, i32* %loc5
+  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %52, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %53
+
+; <label>:53                                      ; preds = %50
+  %54 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %52, i32 0, i32 1
+  %55 = load i32, i32 addrspace(1)* %54
+  %56 = zext i32 %55 to i64
+  %57 = trunc i64 %56 to i32
+  %58 = icmp ugt i32 %51, %57
+  br i1 %58, label %91, label %59
+
+; <label>:59                                      ; preds = %53
+  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  store %"System.Char[]" addrspace(1)* %60, %"System.Char[]" addrspace(1)** %loc8
+  %61 = icmp eq %"System.Char[]" addrspace(1)* %60, null
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %63, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %64
+
+; <label>:64                                      ; preds = %62
+  %65 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %63, i32 0, i32 1
+  %66 = load i32, i32 addrspace(1)* %65
+  %67 = zext i32 %66 to i64
+  %68 = trunc i64 %67 to i32
+  %69 = icmp ne i32 %68, 0
+  br i1 %69, label %71, label %70
+
+; <label>:70                                      ; preds = %59, %64
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:71                                      ; preds = %64
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %73
+
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %BoundsCheck = icmp uge i64 0, %76
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %77
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %78, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:79                                      ; preds = %70, %77
+  %80 = load i16*, i16** %loc2
+  %81 = load i32, i32* %loc4
+  %82 = sext i32 %81 to i64
+  %83 = mul i64 %82, 2
+  %84 = bitcast i16* %80 to i8*
+  %85 = getelementptr inbounds i8, i8* %84, i64 %83
+  %86 = load i16 addrspace(1)*, i16 addrspace(1)** %loc6
+  %87 = ptrtoint i16 addrspace(1)* %86 to i64
+  %88 = load i32, i32* %loc5
+  %89 = bitcast i8* %85 to i16*
+  %90 = inttoptr i64 %87 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %89, i16* %90, i32 %88)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %96
+
+; <label>:91                                      ; preds = %45, %53
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %94 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %93)
+  %95 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95, %System.String addrspace(1)* %92, %System.String addrspace(1)* %94)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95) #0
+  unreachable
+
+; <label>:96                                      ; preds = %23, %79
+  %97 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %97, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %98
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %97, i32 0, i32 2
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  store %System.Text.StringBuilder addrspace(1)* %100, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %102 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %102, label %21, label %103
+
+; <label>:103                                     ; preds = %98
+  store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc7
+  %104 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  ret %System.String addrspace(1)* %104
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method StringBuilder::get_Length using LLILCJit
+Successfully read StringBuilder.get_Length
+
+define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
+Successfully read RuntimeHelpers.get_OffsetToStringData
+
+define i32 @RuntimeHelpers.get_OffsetToStringData() {
+entry:
+  ret i32 12
+}
+
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
 Successfully read CultureData.CreateCultureData
 
@@ -3514,23 +4249,23 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
   store i8 %4, i8 addrspace(1)* %6
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
@@ -3549,11 +4284,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3566,50 +4301,50 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
   store i32 -1, i32 addrspace(1)* %2
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
   store i32 -1, i32 addrspace(1)* %8
   %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
   store i32 -1, i32 addrspace(1)* %14
   %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
   store i32 -1, i32 addrspace(1)* %17
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
@@ -3623,27 +4358,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3675,7 +4410,136 @@ Failed to read Dictionary`2.Insert[non-const derefAddress]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
 Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
-Failed to read HashHelpers.GetPrime[loadElem]
+Successfully read HashHelpers.GetPrime
+
+define i32 @HashHelpers.GetPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %6, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5, %System.String addrspace(1)* %4)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5) #0
+  unreachable
+
+; <label>:6                                       ; preds = %entry
+  store i32 0, i32* %loc0
+  br label %29
+
+; <label>:7                                       ; preds = %35
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 1296
+  %10 = addrspacecast i8 addrspace(1)* %9 to %"System.Int32[]" addrspace(1)**
+  %11 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %10
+  %12 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Int32[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = zext i32 %15 to i64
+  %17 = zext i32 %12 to i64
+  %BoundsCheck = icmp uge i64 %17, %16
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 3, i32 %12
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  store i32 %20, i32* %loc1
+  %21 = load i32, i32* %loc1
+  %22 = load i32, i32* %arg0
+  %23 = icmp slt i32 %21, %22
+  br i1 %23, label %26, label %24
+
+; <label>:24                                      ; preds = %18
+  %25 = load i32, i32* %loc1
+  ret i32 %25
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %loc0
+  %28 = add i32 %27, 1
+  store i32 %28, i32* %loc0
+  br label %29
+
+; <label>:29                                      ; preds = %6, %26
+  %30 = load i32, i32* %loc0
+  %31 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %32 = getelementptr inbounds i8, i8 addrspace(1)* %31, i64 1296
+  %33 = addrspacecast i8 addrspace(1)* %32 to %"System.Int32[]" addrspace(1)**
+  %34 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %33
+  %NullCheck = icmp eq %"System.Int32[]" addrspace(1)* %34, null
+  br i1 %NullCheck, label %ThrowNullRef, label %35
+
+; <label>:35                                      ; preds = %29
+  %36 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %34, i32 0, i32 1
+  %37 = load i32, i32 addrspace(1)* %36
+  %38 = zext i32 %37 to i64
+  %39 = trunc i64 %38 to i32
+  %40 = icmp slt i32 %30, %39
+  br i1 %40, label %7, label %41
+
+; <label>:41                                      ; preds = %35
+  %42 = load i32, i32* %arg0
+  %43 = or i32 %42, 1
+  store i32 %43, i32* %loc2
+  br label %59
+
+; <label>:44                                      ; preds = %59
+  %45 = load i32, i32* %loc2
+  %46 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %45)
+  %47 = zext i8 %46 to i32
+  %48 = icmp eq i32 %47, 0
+  br i1 %48, label %56, label %49
+
+; <label>:49                                      ; preds = %44
+  %50 = load i32, i32* %loc2
+  %51 = sub i32 %50, 1
+  %52 = srem i32 %51, 101
+  %53 = icmp eq i32 %52, 0
+  br i1 %53, label %56, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = load i32, i32* %loc2
+  ret i32 %55
+
+; <label>:56                                      ; preds = %44, %49
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %57, 2
+  store i32 %58, i32* %loc2
+  br label %59
+
+; <label>:59                                      ; preds = %41, %56
+  %60 = load i32, i32* %loc2
+  %61 = icmp slt i32 %60, 2147483647
+  br i1 %61, label %44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load i32, i32* %arg0
+  ret i32 %63
+
+ThrowNullRef:                                     ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
 Successfully read GenericEqualityComparer`1.GetHashCode
 
@@ -3694,14 +4558,14 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
   %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load i64, i64 addrspace(1)* %7
@@ -3720,7 +4584,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3750,8 +4614,8 @@ entry:
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
@@ -3796,8 +4660,8 @@ entry:
   %35 = bitcast i16* %34 to i8*
   %36 = getelementptr inbounds i8, i8* %35, i64 2
   %37 = bitcast i8* %36 to i16*
-  %NullCheck4 = icmp ne i16* %37, null
-  br i1 %NullCheck4, label %38, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %37, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %38
 
 ; <label>:38                                      ; preds = %27
   %39 = load i16, i16* %37, align 8
@@ -3824,8 +4688,8 @@ entry:
 
 ; <label>:54                                      ; preds = %22, %43
   %55 = load i16*, i16** %loc4
-  %NullCheck2 = icmp ne i16* %55, null
-  br i1 %NullCheck2, label %56, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i16* %55, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %56
 
 ; <label>:56                                      ; preds = %54
   %57 = load i16, i16* %55, align 8
@@ -3850,11 +4714,11 @@ ThrowNullRef:                                     ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %54
+ThrowNullRef2:                                    ; preds = %54
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %27
+ThrowNullRef4:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3871,8 +4735,8 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -3907,8 +4771,8 @@ entry:
 
 ; <label>:26                                      ; preds = %19
   %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
-  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %28
 
 ; <label>:28                                      ; preds = %26
   %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
@@ -3920,7 +4784,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3972,8 +4836,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
@@ -3984,26 +4848,26 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
-  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
@@ -4014,8 +4878,8 @@ entry:
 ; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
@@ -4024,8 +4888,8 @@ entry:
 
 ; <label>:25                                      ; preds = %1, %16, %23
   %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
-  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
@@ -4036,27 +4900,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %20
+ThrowNullRef10:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4069,8 +4933,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -4081,8 +4945,8 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
@@ -4091,8 +4955,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1, %8
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
@@ -4103,11 +4967,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4128,24 +4992,24 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   store i32 %3, i32* %loc0
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
   %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
   store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck4, label %9, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
@@ -4164,15 +5028,15 @@ entry:
 ; <label>:18                                      ; preds = %70
   %19 = load i16*, i16** %loc3
   %20 = bitcast i16* %19 to i64*
-  %NullCheck10 = icmp ne i64* %20, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %20, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = load i64, i64* %20, align 8
   %23 = load i16*, i16** %loc4
   %24 = bitcast i16* %23 to i64*
-  %NullCheck12 = icmp ne i64* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = load i64, i64* %24, align 8
@@ -4188,8 +5052,8 @@ entry:
   %31 = bitcast i16* %30 to i8*
   %32 = getelementptr inbounds i8, i8* %31, i64 8
   %33 = bitcast i8* %32 to i64*
-  %NullCheck14 = icmp ne i64* %33, null
-  br i1 %NullCheck14, label %34, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = load i64, i64* %33, align 8
@@ -4197,8 +5061,8 @@ entry:
   %37 = bitcast i16* %36 to i8*
   %38 = getelementptr inbounds i8, i8* %37, i64 8
   %39 = bitcast i8* %38 to i64*
-  %NullCheck16 = icmp ne i64* %39, null
-  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %40
 
 ; <label>:40                                      ; preds = %34
   %41 = load i64, i64* %39, align 8
@@ -4214,8 +5078,8 @@ entry:
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %NullCheck18 = icmp ne i64* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = load i64, i64* %48, align 8
@@ -4223,8 +5087,8 @@ entry:
   %52 = bitcast i16* %51 to i8*
   %53 = getelementptr inbounds i8, i8* %52, i64 16
   %54 = bitcast i8* %53 to i64*
-  %NullCheck20 = icmp ne i64* %54, null
-  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64* %54, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %55
 
 ; <label>:55                                      ; preds = %49
   %56 = load i64, i64* %54, align 8
@@ -4262,15 +5126,15 @@ entry:
 ; <label>:74                                      ; preds = %95
   %75 = load i16*, i16** %loc3
   %76 = bitcast i16* %75 to i32*
-  %NullCheck6 = icmp ne i32* %76, null
-  br i1 %NullCheck6, label %77, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32* %76, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %77
 
 ; <label>:77                                      ; preds = %74
   %78 = load i32, i32* %76, align 8
   %79 = load i16*, i16** %loc4
   %80 = bitcast i16* %79 to i32*
-  %NullCheck8 = icmp ne i32* %80, null
-  br i1 %NullCheck8, label %81, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i32* %80, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %81
 
 ; <label>:81                                      ; preds = %77
   %82 = load i32, i32* %80, align 8
@@ -4318,43 +5182,43 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %74
+ThrowNullRef6:                                    ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %77
+ThrowNullRef8:                                    ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %29
+ThrowNullRef14:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %34
+ThrowNullRef16:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4376,8 +5240,8 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load i64, i64 addrspace(1)* %4
@@ -4389,8 +5253,8 @@ entry:
   %12 = load i64, i64* %11
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %5
   %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
@@ -4399,8 +5263,8 @@ entry:
   %18 = load i8, i8* %arg2
   %19 = zext i8 %18 to i32
   %20 = trunc i32 %19 to i8
-  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %15
   %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
@@ -4411,11 +5275,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4442,8 +5306,8 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
@@ -4466,16 +5330,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
   %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = load i64, i64 addrspace(1)* %19
@@ -4500,8 +5364,8 @@ entry:
 ; <label>:35                                      ; preds = %30
   %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
@@ -4514,8 +5378,8 @@ entry:
 
 ; <label>:42                                      ; preds = %1, %38
   %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
-  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
@@ -4526,19 +5390,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %35
+ThrowNullRef2:                                    ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %42
+ThrowNullRef8:                                    ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4551,14 +5415,14 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
@@ -4570,7 +5434,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4583,8 +5447,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
@@ -4613,51 +5477,51 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
   %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
   %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
   %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
   %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
-  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
   store i64 %21, i64 addrspace(1)* %23
   %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %25 = load i64, i64* %loc0
-  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
@@ -4668,27 +5532,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %22
+ThrowNullRef12:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4701,8 +5565,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
@@ -4713,19 +5577,19 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
@@ -4734,8 +5598,8 @@ entry:
 
 ; <label>:15                                      ; preds = %1, %13
   %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
@@ -4746,19 +5610,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %15
+ThrowNullRef8:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4771,8 +5635,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -4831,8 +5695,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
@@ -4882,8 +5746,8 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
-  br i1 %NullCheck, label %17, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %ThrowNullRef, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
@@ -4894,15 +5758,15 @@ entry:
 
 ; <label>:22                                      ; preds = %17
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
-  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
   %26 = load i32, i32 addrspace(1)* %25
   %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
-  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %27, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
@@ -4925,8 +5789,8 @@ entry:
 ; <label>:40                                      ; preds = %17
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
-  br i1 %NullCheck6, label %43, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %41, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
@@ -4938,34 +5802,17 @@ ThrowNullRef:                                     ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %24
+ThrowNullRef4:                                    ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %40
+ThrowNullRef6:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
-}
-
-INFO:  jitting method Object::ReferenceEquals using LLILCJit
-Successfully read Object.ReferenceEquals
-
-define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
-entry:
-  %arg0 = alloca %System.Object addrspace(1)*
-  %arg1 = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
-  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
-  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = icmp eq %System.Object addrspace(1)* %0, %1
-  %3 = sext i1 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
 }
 
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
@@ -4978,21 +5825,21 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
   %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
-  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
@@ -5007,28 +5854,28 @@ entry:
 ; <label>:13                                      ; preds = %8, %12
   %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
   %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
   %21 = load i32, i32 addrspace(1)* %20, align 8
   %22 = add i32 %21, 1
-  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
   store i32 %22, i32 addrspace(1)* %24
   %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
@@ -5039,27 +5886,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5077,7 +5924,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::Setup using LLILCJit
-Failed to read AppDomain.Setup[loadElem]
+Failed to read AppDomain.Setup[unbox]
 INFO:  jitting method Thread::GetDomain using LLILCJit
 Successfully read Thread.GetDomain
 
@@ -5108,8 +5955,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
@@ -5122,14 +5969,14 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
   %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
@@ -5141,11 +5988,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5173,8 +6020,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -5189,7 +6036,328 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
 Failed to read KeyCollection.System.Collections.Generic.IEnumerable<TKey>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Successfully read Enumerator.MoveNext
+
+define i8 @Enumerator.MoveNext(%"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.RuntimeTypeHandle* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*
+  %"$TypeArg" = alloca %System.RuntimeTypeHandle*
+  store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
+  %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 8
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %76, label %12
+
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
+  br label %76
+
+; <label>:13                                      ; preds = %85
+  %14 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck19 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %15
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, i32 0, i32 0
+  %17 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %16, align 8
+  %NullCheck21 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, i32 0, i32 2
+  %20 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %19, align 8
+  %21 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck23 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %22
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, i32 0, i32 2
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %NullCheck25 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 3, i32 %24
+  %NullCheck27 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %32
+
+; <label>:32                                      ; preds = %30
+  %33 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, i32 0, i32 2
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = icmp slt i32 %34, 0
+  br i1 %35, label %68, label %36
+
+; <label>:36                                      ; preds = %32
+  %37 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %38 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck29 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %39
+
+; <label>:39                                      ; preds = %36
+  %40 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, i32 0, i32 0
+  %41 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %40, align 8
+  %NullCheck31 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, i32 0, i32 2
+  %44 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %43, align 8
+  %45 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck33 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, i32 0, i32 2
+  %48 = load i32, i32 addrspace(1)* %47, align 8
+  %NullCheck35 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %49
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = zext i32 %51 to i64
+  %53 = zext i32 %48 to i64
+  %BoundsCheck37 = icmp uge i64 %53, %52
+  br i1 %BoundsCheck37, label %ThrowIndexOutOfRange38, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 3, i32 %48
+  %NullCheck39 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %56
+
+; <label>:56                                      ; preds = %54
+  %57 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, i32 0, i32 0
+  %58 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck41 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %59
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %60, %System.__Canon addrspace(1)* %58)
+  %61 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck43 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  %64 = load i32, i32 addrspace(1)* %63, align 8
+  %65 = add i32 %64, 1
+  %NullCheck45 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  store i32 %65, i32 addrspace(1)* %67
+  ret i8 1
+
+; <label>:68                                      ; preds = %32
+  %69 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck47 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %73 = add i32 %72, 1
+  %NullCheck49 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %74
+
+; <label>:74                                      ; preds = %70
+  %75 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  store i32 %73, i32 addrspace(1)* %75
+  br label %76
+
+; <label>:76                                      ; preds = %8, %12, %74
+  %77 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %78
+
+; <label>:78                                      ; preds = %76
+  %79 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, i32 0, i32 2
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck7 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %82
+
+; <label>:82                                      ; preds = %78
+  %83 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, i32 0, i32 0
+  %84 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %83, align 8
+  %NullCheck9 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %85
+
+; <label>:85                                      ; preds = %82
+  %86 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, i32 0, i32 7
+  %87 = load i32, i32 addrspace(1)* %86, align 8
+  %88 = icmp ult i32 %80, %87
+  br i1 %88, label %13, label %89
+
+; <label>:89                                      ; preds = %85
+  %90 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %91 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck11 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %92
+
+; <label>:92                                      ; preds = %89
+  %93 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, i32 0, i32 0
+  %94 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck13 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %95
+
+; <label>:95                                      ; preds = %92
+  %96 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, i32 0, i32 7
+  %97 = load i32, i32 addrspace(1)* %96, align 8
+  %98 = add i32 %97, 1
+  %NullCheck15 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %99
+
+; <label>:99                                      ; preds = %95
+  %100 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, i32 0, i32 2
+  store i32 %98, i32 addrspace(1)* %100
+  %101 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck17 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %102
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %103, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %92
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef22:                                   ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef24:                                   ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef26:                                   ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef28:                                   ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef30:                                   ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef32:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef34:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef36:                                   ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange38:                           ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef40:                                   ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef42:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef44:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef46:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef48:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef50:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -5200,8 +6368,8 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -5232,9 +6400,9 @@ Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
 Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
-Failed to read String.MakeSeparatorList[loadElemA]
+Failed to read String.MakeSeparatorList[storeElem]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
-Failed to read String.InternalSplitKeepEmptyEntries[loadElem]
+Failed to read String.InternalSplitKeepEmptyEntries[storeElem]
 INFO:  jitting method Path::IsRelative using LLILCJit
 Successfully read Path.IsRelative
 
@@ -5243,8 +6411,8 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -5254,8 +6422,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
@@ -5271,8 +6439,8 @@ entry:
 
 ; <label>:17                                      ; preds = %7
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
@@ -5288,8 +6456,8 @@ entry:
 
 ; <label>:29                                      ; preds = %19
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %31
 
 ; <label>:31                                      ; preds = %29
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
@@ -5300,8 +6468,8 @@ entry:
 
 ; <label>:36                                      ; preds = %31
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
-  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %37, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
@@ -5312,8 +6480,8 @@ entry:
 
 ; <label>:43                                      ; preds = %31, %38
   %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
-  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %45
 
 ; <label>:45                                      ; preds = %43
   %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
@@ -5324,8 +6492,8 @@ entry:
 
 ; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %50
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
@@ -5336,8 +6504,8 @@ entry:
 
 ; <label>:57                                      ; preds = %1, %7, %19, %45, %52
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
-  br i1 %NullCheck14, label %59, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %59
 
 ; <label>:59                                      ; preds = %57
   %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
@@ -5347,8 +6515,8 @@ entry:
 
 ; <label>:63                                      ; preds = %59
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
@@ -5359,8 +6527,8 @@ entry:
 
 ; <label>:70                                      ; preds = %65
   %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
-  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.String addrspace(1)* %71, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %72
 
 ; <label>:72                                      ; preds = %70
   %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
@@ -5379,39 +6547,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %17
+ThrowNullRef4:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %29
+ThrowNullRef6:                                    ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %36
+ThrowNullRef8:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %43
+ThrowNullRef10:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %50
+ThrowNullRef12:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %57
+ThrowNullRef14:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %63
+ThrowNullRef16:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %70
+ThrowNullRef18:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5419,7 +6587,293 @@ ThrowNullRef17:                                   ; preds = %70
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
-Failed to read String.TrimHelper[loadElem]
+Successfully read String.TrimHelper
+
+define %System.String addrspace(1)* @String.TrimHelper(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i16
+  %loc4 = alloca i32
+  %loc5 = alloca i16
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = sub i32 %3, 1
+  store i32 %4, i32* %loc0
+  store i32 0, i32* %loc1
+  %5 = load i32, i32* %arg2
+  %6 = icmp eq i32 %5, 1
+  br i1 %6, label %62, label %7
+
+; <label>:7                                       ; preds = %1
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:8                                       ; preds = %58
+  store i32 0, i32* %loc2
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load i32, i32* %loc1
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2, i32 %10
+  %13 = load i16, i16 addrspace(1)* %12
+  %14 = zext i16 %13 to i32
+  %15 = trunc i32 %14 to i16
+  store i16 %15, i16* %loc3
+  store i32 0, i32* %loc2
+  br label %34
+
+; <label>:16                                      ; preds = %37
+  %17 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %18 = load i32, i32* %loc2
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %17, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %19
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = zext i32 %18 to i64
+  %BoundsCheck = icmp uge i64 %23, %22
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %24
+
+; <label>:24                                      ; preds = %19
+  %25 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 3, i32 %18
+  %26 = load i16, i16 addrspace(1)* %25, align 8
+  %27 = zext i16 %26 to i32
+  %28 = load i16, i16* %loc3
+  %29 = zext i16 %28 to i32
+  %30 = icmp eq i32 %27, %29
+  br i1 %30, label %43, label %31
+
+; <label>:31                                      ; preds = %24
+  %32 = load i32, i32* %loc2
+  %33 = add i32 %32, 1
+  store i32 %33, i32* %loc2
+  br label %34
+
+; <label>:34                                      ; preds = %11, %31
+  %35 = load i32, i32* %loc2
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = icmp slt i32 %35, %41
+  br i1 %42, label %16, label %43
+
+; <label>:43                                      ; preds = %24, %37
+  %44 = load i32, i32* %loc2
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %45, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp eq i32 %44, %50
+  br i1 %51, label %62, label %52
+
+; <label>:52                                      ; preds = %46
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %7, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %57, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %58
+
+; <label>:58                                      ; preds = %55
+  %59 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %60 = load i32, i32 addrspace(1)* %59
+  %61 = icmp slt i32 %56, %60
+  br i1 %61, label %8, label %62
+
+; <label>:62                                      ; preds = %1, %46, %58
+  %63 = load i32, i32* %arg2
+  %64 = icmp eq i32 %63, 0
+  br i1 %64, label %122, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %66, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %67
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %66, i32 0, i32 1
+  %69 = load i32, i32 addrspace(1)* %68
+  %70 = sub i32 %69, 1
+  store i32 %70, i32* %loc0
+  br label %118
+
+; <label>:71                                      ; preds = %118
+  store i32 0, i32* %loc4
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %73 = load i32, i32* %loc0
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %74
+
+; <label>:74                                      ; preds = %71
+  %75 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 2, i32 %73
+  %76 = load i16, i16 addrspace(1)* %75
+  %77 = zext i16 %76 to i32
+  %78 = trunc i32 %77 to i16
+  store i16 %78, i16* %loc5
+  store i32 0, i32* %loc4
+  br label %97
+
+; <label>:79                                      ; preds = %100
+  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %81 = load i32, i32* %loc4
+  %NullCheck19 = icmp eq %"System.Char[]" addrspace(1)* %80, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
+
+; <label>:82                                      ; preds = %79
+  %83 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 1
+  %84 = load i32, i32 addrspace(1)* %83
+  %85 = zext i32 %84 to i64
+  %86 = zext i32 %81 to i64
+  %BoundsCheck21 = icmp uge i64 %86, %85
+  br i1 %BoundsCheck21, label %ThrowIndexOutOfRange22, label %87
+
+; <label>:87                                      ; preds = %82
+  %88 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 3, i32 %81
+  %89 = load i16, i16 addrspace(1)* %88, align 8
+  %90 = zext i16 %89 to i32
+  %91 = load i16, i16* %loc5
+  %92 = zext i16 %91 to i32
+  %93 = icmp eq i32 %90, %92
+  br i1 %93, label %106, label %94
+
+; <label>:94                                      ; preds = %87
+  %95 = load i32, i32* %loc4
+  %96 = add i32 %95, 1
+  store i32 %96, i32* %loc4
+  br label %97
+
+; <label>:97                                      ; preds = %74, %94
+  %98 = load i32, i32* %loc4
+  %99 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck15 = icmp eq %"System.Char[]" addrspace(1)* %99, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %100
+
+; <label>:100                                     ; preds = %97
+  %101 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %99, i32 0, i32 1
+  %102 = load i32, i32 addrspace(1)* %101
+  %103 = zext i32 %102 to i64
+  %104 = trunc i64 %103 to i32
+  %105 = icmp slt i32 %98, %104
+  br i1 %105, label %79, label %106
+
+; <label>:106                                     ; preds = %87, %100
+  %107 = load i32, i32* %loc4
+  %108 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck17 = icmp eq %"System.Char[]" addrspace(1)* %108, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %109
+
+; <label>:109                                     ; preds = %106
+  %110 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %108, i32 0, i32 1
+  %111 = load i32, i32 addrspace(1)* %110
+  %112 = zext i32 %111 to i64
+  %113 = trunc i64 %112 to i32
+  %114 = icmp eq i32 %107, %113
+  br i1 %114, label %122, label %115
+
+; <label>:115                                     ; preds = %109
+  %116 = load i32, i32* %loc0
+  %117 = sub i32 %116, 1
+  store i32 %117, i32* %loc0
+  br label %118
+
+; <label>:118                                     ; preds = %67, %115
+  %119 = load i32, i32* %loc0
+  %120 = load i32, i32* %loc1
+  %121 = icmp sge i32 %119, %120
+  br i1 %121, label %71, label %122
+
+; <label>:122                                     ; preds = %62, %109, %118
+  %123 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %124 = load i32, i32* %loc1
+  %125 = load i32, i32* %loc0
+  %126 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %123, i32 %124, i32 %125)
+  ret %System.String addrspace(1)* %126
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %97
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange22:                           ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
 Successfully read String.CreateTrimmedString
 
@@ -5439,8 +6893,8 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
@@ -5535,8 +6989,8 @@ entry:
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i64 2872
   %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
   %8 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %7
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %3
   %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
@@ -5553,8 +7007,8 @@ entry:
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 2864
   %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
   %21 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %20
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
-  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %22
 
 ; <label>:22                                      ; preds = %16
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
@@ -5569,7 +7023,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %16
+ThrowNullRef2:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5586,8 +7040,8 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5613,8 +7067,8 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
@@ -5632,8 +7086,8 @@ entry:
 
 ; <label>:12                                      ; preds = %4
   %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
@@ -5644,8 +7098,8 @@ entry:
 
 ; <label>:19                                      ; preds = %14
   %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %19
   %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
@@ -5660,21 +7114,21 @@ entry:
   %31 = zext i16 %30 to i32
   %32 = bitcast i8* %29 to i16*
   %33 = trunc i32 %31 to i16
-  %NullCheck6 = icmp ne i16* %32, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i16* %32, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %21
   store i16 %33, i16* %32, align 8
   %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %36
 
 ; <label>:36                                      ; preds = %34
   %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
   %38 = load i32, i32 addrspace(1)* %37, align 8
   %39 = add i32 %38, 1
-  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %40
 
 ; <label>:40                                      ; preds = %36
   %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
@@ -5683,16 +7137,16 @@ entry:
 
 ; <label>:42                                      ; preds = %14
   %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
-  br i1 %NullCheck12, label %44, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
   %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
   %47 = load i16, i16* %arg1
   %48 = zext i16 %47 to i32
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = trunc i32 %48 to i16
@@ -5703,31 +7157,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %19
+ThrowNullRef4:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %21
+ThrowNullRef6:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %36
+ThrowNullRef10:                                   ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %42
+ThrowNullRef12:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %44
+ThrowNullRef14:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5740,8 +7194,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -5752,8 +7206,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
@@ -5762,14 +7216,14 @@ entry:
 
 ; <label>:11                                      ; preds = %1
   %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
@@ -5779,15 +7233,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5808,8 +7262,8 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5822,8 +7276,8 @@ entry:
 
 ; <label>:8                                       ; preds = %3
   %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
@@ -5842,15 +7296,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
-  br i1 %NullCheck4, label %22, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
   %24 = load i16*, i16* addrspace(1)* %23, align 8
   %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %25, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
@@ -5859,8 +7313,8 @@ entry:
   store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
@@ -5874,8 +7328,8 @@ entry:
 
 ; <label>:37                                      ; preds = %65
   %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %37
   %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
@@ -5886,16 +7340,16 @@ entry:
   %45 = bitcast i16* %41 to i8*
   %46 = getelementptr inbounds i8, i8* %45, i64 %44
   %47 = bitcast i8* %46 to i16*
-  %NullCheck14 = icmp ne i16* %47, null
-  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %47, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %48
 
 ; <label>:48                                      ; preds = %39
   %49 = load i16, i16* %47, align 8
   %50 = zext i16 %49 to i32
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %52 = load i32, i32* %loc1
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %53
 
 ; <label>:53                                      ; preds = %48
   %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
@@ -5916,8 +7370,8 @@ entry:
 ; <label>:62                                      ; preds = %36, %59
   %63 = load i32, i32* %loc1
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck10, label %65, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %65
 
 ; <label>:65                                      ; preds = %62
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
@@ -5936,15 +7390,15 @@ entry:
 
 ; <label>:74                                      ; preds = %70
   %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
-  br i1 %NullCheck18, label %76, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %76
 
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
   %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
-  br i1 %NullCheck20, label %80, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
   %81 = load i64, i64 addrspace(1)* %79
@@ -5958,8 +7412,8 @@ entry:
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
   %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
-  br i1 %NullCheck22, label %92, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.String addrspace(1)* %90, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %92
 
 ; <label>:92                                      ; preds = %80
   %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
@@ -5969,15 +7423,15 @@ entry:
 
 ; <label>:96                                      ; preds = %70
   %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
-  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %98
 
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
   %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
-  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
   %103 = load i64, i64 addrspace(1)* %101
@@ -5991,8 +7445,8 @@ entry:
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
   %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
-  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.String addrspace(1)* %112, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %114
 
 ; <label>:114                                     ; preds = %102
   %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
@@ -6004,59 +7458,59 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %20
+ThrowNullRef4:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %22
+ThrowNullRef6:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %26
+ThrowNullRef8:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %62
+ThrowNullRef10:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %48
+ThrowNullRef16:                                   ; preds = %48
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %74
+ThrowNullRef18:                                   ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %76
+ThrowNullRef20:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %80
+ThrowNullRef22:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %96
+ThrowNullRef24:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %98
+ThrowNullRef26:                                   ; preds = %98
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %102
+ThrowNullRef28:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6069,15 +7523,15 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
   %3 = load i16*, i16* addrspace(1)* %2, align 8
   %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
@@ -6087,8 +7541,8 @@ entry:
   %10 = bitcast i16* %3 to i8*
   %11 = getelementptr inbounds i8, i8* %10, i64 %9
   %12 = bitcast i8* %11 to i16*
-  %NullCheck4 = icmp ne i16* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %5
   store i16 0, i16* %12, align 8
@@ -6098,11 +7552,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6119,8 +7573,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -6131,8 +7585,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
@@ -6144,15 +7598,15 @@ entry:
 
 ; <label>:14                                      ; preds = %1
   %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
   %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
   %21 = load i64, i64 addrspace(1)* %19
@@ -6171,15 +7625,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %14
+ThrowNullRef4:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %16
+ThrowNullRef6:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6302,14 +7756,6 @@ entry:
   ret %System.String addrspace(1)* %57
 }
 
-INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
-Successfully read RuntimeHelpers.get_OffsetToStringData
-
-define i32 @RuntimeHelpers.get_OffsetToStringData() {
-entry:
-  ret i32 12
-}
-
 INFO:  jitting method String::Equals using LLILCJit
 Successfully read String.Equals
 
@@ -6381,8 +7827,8 @@ entry:
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
-  br i1 %NullCheck24, label %29, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
   %30 = load i64, i64 addrspace(1)* %28
@@ -6397,8 +7843,8 @@ entry:
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
-  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
   %43 = load i64, i64 addrspace(1)* %41
@@ -6418,8 +7864,8 @@ entry:
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
   %59 = load i64, i64 addrspace(1)* %57
@@ -6434,8 +7880,8 @@ entry:
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck22, label %71, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
   %72 = load i64, i64 addrspace(1)* %70
@@ -6455,8 +7901,8 @@ entry:
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
-  br i1 %NullCheck16, label %87, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = load i64, i64 addrspace(1)* %86
@@ -6471,8 +7917,8 @@ entry:
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck18, label %100, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
   %101 = load i64, i64 addrspace(1)* %99
@@ -6492,8 +7938,8 @@ entry:
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
-  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
   %117 = load i64, i64 addrspace(1)* %115
@@ -6508,8 +7954,8 @@ entry:
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
-  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
   %130 = load i64, i64 addrspace(1)* %128
@@ -6528,15 +7974,15 @@ entry:
 
 ; <label>:142                                     ; preds = %22
   %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
-  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %143, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %144
 
 ; <label>:144                                     ; preds = %142
   %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
   %146 = load i32, i32 addrspace(1)* %145
   %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
-  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %147, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %148
 
 ; <label>:148                                     ; preds = %144
   %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
@@ -6557,15 +8003,15 @@ entry:
 
 ; <label>:159                                     ; preds = %22
   %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
-  br i1 %NullCheck, label %161, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %ThrowNullRef, label %161
 
 ; <label>:161                                     ; preds = %159
   %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
   %163 = load i32, i32 addrspace(1)* %162
   %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
-  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %164, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %165
 
 ; <label>:165                                     ; preds = %161
   %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
@@ -6578,8 +8024,8 @@ entry:
 
 ; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
-  br i1 %NullCheck4, label %172, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %171, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %172
 
 ; <label>:172                                     ; preds = %170
   %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
@@ -6589,8 +8035,8 @@ entry:
 
 ; <label>:176                                     ; preds = %172
   %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
-  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %177, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %178
 
 ; <label>:178                                     ; preds = %176
   %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
@@ -6629,55 +8075,55 @@ ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %161
+ThrowNullRef2:                                    ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %170
+ThrowNullRef4:                                    ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %176
+ThrowNullRef6:                                    ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %142
+ThrowNullRef8:                                    ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %144
+ThrowNullRef10:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %113
+ThrowNullRef12:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %116
+ThrowNullRef14:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %84
+ThrowNullRef16:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %87
+ThrowNullRef18:                                   ; preds = %87
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %55
+ThrowNullRef20:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %58
+ThrowNullRef22:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %26
+ThrowNullRef24:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %29
+ThrowNullRef26:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,8 +8161,8 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck, label %14, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %ThrowNullRef, label %14
 
 ; <label>:14                                      ; preds = %8
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
@@ -6760,8 +8206,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
@@ -6770,14 +8216,14 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32, i32* %loc0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %10
   %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
   %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
@@ -6790,15 +8236,15 @@ entry:
 ; <label>:25                                      ; preds = %19
   %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
-  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
   %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
@@ -6807,8 +8253,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %37 = load i32, i32* %loc0
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %38, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %38
 
 ; <label>:38                                      ; preds = %32
   %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
@@ -6817,14 +8263,14 @@ entry:
 
 ; <label>:40                                      ; preds = %19
   %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %40
   %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
   %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
-  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
-  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
@@ -6832,8 +8278,8 @@ entry:
   %48 = zext i32 %47 to i64
   %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
-  br i1 %NullCheck16, label %51, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %51
 
 ; <label>:51                                      ; preds = %45
   %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
@@ -6847,15 +8293,15 @@ entry:
 ; <label>:57                                      ; preds = %51
   %58 = load i16*, i16** %arg1
   %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
-  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %60
 
 ; <label>:60                                      ; preds = %57
   %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
   %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
-  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %64
 
 ; <label>:64                                      ; preds = %60
   %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
@@ -6864,22 +8310,22 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
   %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
-  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %70
 
 ; <label>:70                                      ; preds = %64
   %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
   %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
-  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
-  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
   %75 = load i32, i32 addrspace(1)* %74
   %76 = zext i32 %75 to i64
   %77 = trunc i64 %76 to i32
-  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
-  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %78
 
 ; <label>:78                                      ; preds = %73
   %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
@@ -6901,8 +8347,8 @@ entry:
   %90 = bitcast i16* %86 to i8*
   %91 = getelementptr inbounds i8, i8* %90, i64 %89
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %93
 
 ; <label>:93                                      ; preds = %80
   %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
@@ -6912,8 +8358,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %99 = load i32, i32* %loc2
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %100
 
 ; <label>:100                                     ; preds = %93
   %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
@@ -6928,63 +8374,63 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %25
+ThrowNullRef6:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %32
+ThrowNullRef10:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %40
+ThrowNullRef12:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %45
+ThrowNullRef16:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %57
+ThrowNullRef18:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %60
+ThrowNullRef20:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %64
+ThrowNullRef22:                                   ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %70
+ThrowNullRef24:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %73
+ThrowNullRef26:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %80
+ThrowNullRef28:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %93
+ThrowNullRef30:                                   ; preds = %93
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7004,8 +8450,8 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
@@ -7033,43 +8479,43 @@ entry:
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %14
   %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
   %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   %28 = load i32, i32 addrspace(1)* %27, align 8
   %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
-  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %30
 
 ; <label>:30                                      ; preds = %26
   %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
   %32 = load i32, i32 addrspace(1)* %31, align 8
   %33 = add i32 %28, %32
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %34
 
 ; <label>:34                                      ; preds = %30
   %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   store i32 %33, i32 addrspace(1)* %35
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
   store i32 0, i32 addrspace(1)* %38
   %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %40
 
 ; <label>:40                                      ; preds = %37
   %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
@@ -7082,8 +8528,8 @@ entry:
 
 ; <label>:47                                      ; preds = %40
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
@@ -7098,8 +8544,8 @@ entry:
   %54 = load i32, i32* %loc0
   %55 = sext i32 %54 to i64
   %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
-  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %57
 
 ; <label>:57                                      ; preds = %52
   %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
@@ -7110,68 +8556,35 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %14
+ThrowNullRef2:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %23
+ThrowNullRef4:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %26
+ThrowNullRef6:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %30
+ThrowNullRef8:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %34
+ThrowNullRef10:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %47
+ThrowNullRef14:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %52
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-}
-
-INFO:  jitting method StringBuilder::get_Length using LLILCJit
-Successfully read StringBuilder.get_Length
-
-define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.StringBuilder addrspace(1)*
-  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
-  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
-
-; <label>:1                                       ; preds = %entry
-  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %3 = load i32, i32 addrspace(1)* %2, align 8
-  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
-
-; <label>:5                                       ; preds = %1
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = add i32 %3, %7
-  ret i32 %8
-
-ThrowNullRef:                                     ; preds = %entry
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef16:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7213,70 +8626,70 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
   %6 = load i32, i32 addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
   store i32 %6, i32 addrspace(1)* %8
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
   %13 = load i32, i32 addrspace(1)* %12, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
   store i32 %13, i32 addrspace(1)* %15
   %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
-  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %18
 
 ; <label>:18                                      ; preds = %14
   %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
   %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
   %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
   %34 = load i32, i32 addrspace(1)* %33, align 8
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
-  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
@@ -7287,39 +8700,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %28
+ThrowNullRef16:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %32
+ThrowNullRef18:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7455,13 +8868,13 @@ entry:
 ; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
@@ -7477,16 +8890,16 @@ entry:
 
 ; <label>:18                                      ; preds = %15
   %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
   store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
   %22 = load i32, i32* %loc0
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %24
 
 ; <label>:24                                      ; preds = %20
   %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
@@ -7498,13 +8911,13 @@ entry:
 ; <label>:28                                      ; preds = %15, %24
   %29 = load i32, i32* %arg1
   %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %31
   %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
@@ -7517,20 +8930,20 @@ entry:
   %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
-  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
   %46 = load i32, i32 addrspace(1)* %45, align 8
   %47 = sub i32 %40, %46
-  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
-  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i32 addrspace(1)* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %48
 
 ; <label>:48                                      ; preds = %44
   store i32 %47, i32 addrspace(1)* %39, align 8
@@ -7538,21 +8951,21 @@ entry:
 
 ; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
-  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %51
 
 ; <label>:51                                      ; preds = %49
   %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %53
 
 ; <label>:53                                      ; preds = %51
   %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
   %55 = load i32, i32 addrspace(1)* %54, align 8
   %56 = load i32, i32* %arg2
   %57 = sub i32 %55, %56
-  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %58
 
 ; <label>:58                                      ; preds = %53
   %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
@@ -7562,13 +8975,13 @@ entry:
 ; <label>:60                                      ; preds = %33, %58
   %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
   %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
-  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %63
 
 ; <label>:63                                      ; preds = %60
   %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
-  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
-  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
@@ -7578,15 +8991,15 @@ entry:
 
 ; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
-  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i32 addrspace(1)* %69, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %70
 
 ; <label>:70                                      ; preds = %68
   %71 = load i32, i32 addrspace(1)* %69, align 8
   store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
-  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
@@ -7596,8 +9009,8 @@ entry:
   store i32 %77, i32* %loc4
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
-  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %80
 
 ; <label>:80                                      ; preds = %73
   %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
@@ -7607,71 +9020,71 @@ entry:
 ; <label>:83                                      ; preds = %80
   store i32 0, i32* %loc3
   %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
-  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
-  br i1 %NullCheck26, label %88, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i32 addrspace(1)* %87, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %88
 
 ; <label>:88                                      ; preds = %85
   %89 = load i32, i32 addrspace(1)* %87, align 8
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
-  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %90
 
 ; <label>:90                                      ; preds = %88
   %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
   store i32 %89, i32 addrspace(1)* %91
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
-  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
-  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %96
 
 ; <label>:96                                      ; preds = %94
   %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
-  br i1 %NullCheck34, label %100, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %100
 
 ; <label>:100                                     ; preds = %96
   %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
-  br i1 %NullCheck36, label %102, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %102
 
 ; <label>:102                                     ; preds = %100
   %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
   %104 = load i32, i32 addrspace(1)* %103, align 8
   %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
-  br i1 %NullCheck38, label %106, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %106
 
 ; <label>:106                                     ; preds = %102
   %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
-  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
-  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %108
 
 ; <label>:108                                     ; preds = %106
   %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
   %110 = load i32, i32 addrspace(1)* %109, align 8
   %111 = add i32 %104, %110
-  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %112
 
 ; <label>:112                                     ; preds = %108
   %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
   store i32 %111, i32 addrspace(1)* %113
   %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
-  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i32 addrspace(1)* %114, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %115
 
 ; <label>:115                                     ; preds = %112
   %116 = load i32, i32 addrspace(1)* %114, align 8
@@ -7681,19 +9094,19 @@ entry:
 ; <label>:118                                     ; preds = %115
   %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
-  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %121
 
 ; <label>:121                                     ; preds = %118
   %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
-  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
-  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %123
 
 ; <label>:123                                     ; preds = %121
   %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
   %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
-  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
-  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %126
 
 ; <label>:126                                     ; preds = %123
   %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
@@ -7705,8 +9118,8 @@ entry:
 
 ; <label>:130                                     ; preds = %80, %115, %126
   %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %132
 
 ; <label>:132                                     ; preds = %130
   %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7715,8 +9128,8 @@ entry:
   %136 = load i32, i32* %loc3
   %137 = sub i32 %135, %136
   %138 = sub i32 %134, %137
-  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %139
 
 ; <label>:139                                     ; preds = %132
   %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7728,16 +9141,16 @@ entry:
 
 ; <label>:144                                     ; preds = %139
   %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
-  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %146
 
 ; <label>:146                                     ; preds = %144
   %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
   %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
   %149 = load i32, i32* %loc2
   %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
-  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %151
 
 ; <label>:151                                     ; preds = %146
   %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
@@ -7754,145 +9167,249 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %18
+ThrowNullRef4:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %31
+ThrowNullRef10:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %44
+ThrowNullRef16:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %68
+ThrowNullRef18:                                   ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %70
+ThrowNullRef20:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %73
+ThrowNullRef22:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %83
+ThrowNullRef24:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %85
+ThrowNullRef26:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %88
+ThrowNullRef28:                                   ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %90
+ThrowNullRef30:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %94
+ThrowNullRef32:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %96
+ThrowNullRef34:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %100
+ThrowNullRef36:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %102
+ThrowNullRef38:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %106
+ThrowNullRef40:                                   ; preds = %106
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %108
+ThrowNullRef42:                                   ; preds = %108
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %112
+ThrowNullRef44:                                   ; preds = %112
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %118
+ThrowNullRef46:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %121
+ThrowNullRef48:                                   ; preds = %121
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %123
+ThrowNullRef50:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %130
+ThrowNullRef52:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %132
+ThrowNullRef54:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %144
+ThrowNullRef56:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %146
+ThrowNullRef58:                                   ; preds = %146
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %60
+ThrowNullRef60:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %63
+ThrowNullRef62:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %49
+ThrowNullRef64:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %51
+ThrowNullRef66:                                   ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %53
+ThrowNullRef68:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(%"System.Char[]" addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %arg0 = alloca %"System.Char[]" addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store %"System.Char[]" addrspace(1)* %param0, %"System.Char[]" addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load i32, i32* %arg4
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %43, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %38, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg1
+  %13 = load i32, i32* %arg4
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %38, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %24 = load i32, i32* %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %35 = load i32, i32* %arg3
+  %36 = load i32, i32* %arg4
+  %37 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %37, %"System.Char[]" addrspace(1)* %34, i32 %35, i32 %36)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:38                                      ; preds = %5, %16
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Successfully read Buffer._Memmove
 
@@ -7914,7 +9431,7 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[loadElem]
+Failed to read AppDomain.SetDataHelper[storeElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -7923,8 +9440,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
@@ -7934,8 +9451,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
@@ -7947,15 +9464,15 @@ entry:
   %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
   %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
@@ -7966,15 +9483,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7992,7 +9509,79 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
-Failed to read Dictionary`2.TryGetValue[loadElemA]
+Successfully read Dictionary`2.TryGetValue
+
+define i8 @"Dictionary`2.TryGetValue"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)* addrspace(1)* %param2) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  %arg2 = alloca %System.__Canon addrspace(1)* addrspace(1)*
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  store %System.__Canon addrspace(1)* addrspace(1)* %param2, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  store i32 %2, i32* %loc0
+  %3 = load i32, i32* %loc0
+  %4 = icmp slt i32 %3, 0
+  br i1 %4, label %22, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 2
+  %10 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %9, align 8
+  %11 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = zext i32 %11 to i64
+  %BoundsCheck = icmp uge i64 %16, %15
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 3, i32 %11
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %20, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %6, %System.__Canon addrspace(1)* %21)
+  ret i8 1
+
+; <label>:22                                      ; preds = %entry
+  %23 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %23, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -8058,8 +9647,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
@@ -8091,8 +9680,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
@@ -8171,15 +9760,15 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck, label %19, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %ThrowNullRef, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
   %21 = load i32, i32 addrspace(1)* %20
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
@@ -8202,7 +9791,7 @@ ThrowNullRef:                                     ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %19
+ThrowNullRef2:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8248,8 +9837,8 @@ entry:
   %0 = alloca %System.AppDomainHandle
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %1 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %1, i32 0, i32 15
@@ -8269,8 +9858,8 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
@@ -8286,7 +9875,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -8299,8 +9888,8 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -8327,8 +9916,8 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
@@ -8352,8 +9941,8 @@ entry:
   %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
   store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
@@ -8363,8 +9952,8 @@ entry:
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
@@ -8374,8 +9963,8 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %9
   %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
@@ -8384,8 +9973,8 @@ entry:
 
 ; <label>:18                                      ; preds = %3, %16
   %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
@@ -8397,15 +9986,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %18
+ThrowNullRef6:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8418,8 +10007,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
@@ -8453,15 +10042,15 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
@@ -8473,7 +10062,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8481,7 +10070,7 @@ ThrowNullRef1:                                    ; preds = %1
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
 Failed to read Dictionary`2.System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
@@ -8506,8 +10095,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
@@ -8524,8 +10113,8 @@ entry:
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -8544,7 +10133,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8577,8 +10166,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = load i64, i64* %arg2
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = trunc i32 %3 to i8
@@ -8634,46 +10223,46 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
   %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
-  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
-  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
-  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
@@ -8684,27 +10273,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %20
+ThrowNullRef12:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8717,8 +10306,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -8756,22 +10345,22 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
   %9 = load i64, i64 addrspace(1)* %8, align 8
   %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
   %13 = load i64, i64 addrspace(1)* %12, align 8
   %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %11
   %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
@@ -8788,11 +10377,11 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8882,8 +10471,8 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
@@ -8900,8 +10489,8 @@ entry:
 ; <label>:8                                       ; preds = %1
   %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
   %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
@@ -8911,15 +10500,15 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
   %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
   %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
-  br i1 %NullCheck6, label %21, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
@@ -8946,15 +10535,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8992,15 +10581,15 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
   store i8 %3, i8 addrspace(1)* %5
   %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
@@ -9011,7 +10600,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9027,8 +10616,8 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -9041,8 +10630,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
@@ -9058,7 +10647,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9080,8 +10669,8 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
@@ -9096,8 +10685,8 @@ entry:
 ; <label>:12                                      ; preds = %6
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
@@ -9112,8 +10701,8 @@ entry:
 ; <label>:21                                      ; preds = %15
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
@@ -9128,8 +10717,8 @@ entry:
 ; <label>:30                                      ; preds = %24
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %31, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
@@ -9144,8 +10733,8 @@ entry:
 ; <label>:39                                      ; preds = %33
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
-  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %40, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %42
 
 ; <label>:42                                      ; preds = %39
   %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
@@ -9164,19 +10753,19 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %21
+ThrowNullRef4:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %30
+ThrowNullRef6:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %39
+ThrowNullRef8:                                    ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9243,8 +10832,8 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
@@ -9264,57 +10853,57 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
   store i8 0, i8 addrspace(1)* %2
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
   store i8 0, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
   store i8 0, i8 addrspace(1)* %17
   %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
   store i8 0, i8 addrspace(1)* %20
   %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
-  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
@@ -9325,31 +10914,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %19
+ThrowNullRef14:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9367,8 +10956,8 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
@@ -9380,8 +10969,8 @@ entry:
 
 ; <label>:9                                       ; preds = %4
   %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %9
   %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
@@ -9395,7 +10984,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef2:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9420,8 +11009,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
@@ -9512,8 +11101,8 @@ entry:
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
@@ -9524,8 +11113,8 @@ entry:
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = load i64, i64 addrspace(1)* %12
@@ -9537,8 +11126,8 @@ entry:
   %20 = load i64, i64* %19
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
-  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %13
   %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
@@ -9555,8 +11144,8 @@ entry:
 ; <label>:30                                      ; preds = %25
   %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %32 = load i32, i32* %arg2
-  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
-  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
@@ -9570,15 +11159,15 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %30
+ThrowNullRef2:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9622,87 +11211,87 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
   %10 = load i8, i8 addrspace(1)* %9, align 8
   %11 = zext i8 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %8
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
   store i8 %12, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
   %19 = load i8, i8 addrspace(1)* %18, align 8
   %20 = zext i8 %19 to i32
   %21 = trunc i32 %20 to i8
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
   store i8 %21, i8 addrspace(1)* %23
   %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
   %28 = load i8, i8 addrspace(1)* %27, align 8
   %29 = zext i8 %28 to i32
   %30 = trunc i32 %29 to i8
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
-  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %31
 
 ; <label>:31                                      ; preds = %26
   %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
   store i8 %30, i8 addrspace(1)* %32
   %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
-  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
-  br i1 %NullCheck14, label %40, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %40
 
 ; <label>:40                                      ; preds = %35
   %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
   store i8 %39, i8 addrspace(1)* %41
   %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
-  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %44
 
 ; <label>:44                                      ; preds = %40
   %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
   %46 = load i8, i8 addrspace(1)* %45, align 8
   %47 = zext i8 %46 to i32
   %48 = trunc i32 %47 to i8
-  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
   store i8 %48, i8 addrspace(1)* %50
   %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
-  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
@@ -9713,29 +11302,29 @@ entry:
 ; <label>:56                                      ; preds = %52
   %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
-  br i1 %NullCheck22, label %59, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
   %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
   %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
-  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
-  br i1 %NullCheck24, label %63, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
   %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
-  br i1 %NullCheck26, label %66, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
   %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
-  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
-  br i1 %NullCheck28, label %69, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %69
 
 ; <label>:69                                      ; preds = %66
   %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
@@ -9744,15 +11333,15 @@ entry:
 
 ; <label>:71                                      ; preds = %105
   %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
-  br i1 %NullCheck34, label %73, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %73
 
 ; <label>:73                                      ; preds = %71
   %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
   %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
   %76 = load i32, i32* %loc0
-  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
-  br i1 %NullCheck36, label %77, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
@@ -9766,8 +11355,8 @@ entry:
 
 ; <label>:83                                      ; preds = %77
   %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
-  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
@@ -9775,14 +11364,14 @@ entry:
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
   %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
-  br i1 %NullCheck40, label %91, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
 ; <label>:91                                      ; preds = %85
   %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
   %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
-  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck42, label %94, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %94
 
 ; <label>:94                                      ; preds = %91
   %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
@@ -9798,14 +11387,14 @@ entry:
 ; <label>:99                                      ; preds = %69, %96
   %100 = load i32, i32* %loc0
   %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
-  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %102
 
 ; <label>:102                                     ; preds = %99
   %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
   %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
-  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
-  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
@@ -9819,87 +11408,87 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %26
+ThrowNullRef10:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %31
+ThrowNullRef12:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %35
+ThrowNullRef14:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %40
+ThrowNullRef16:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %56
+ThrowNullRef22:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %59
+ThrowNullRef24:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %63
+ThrowNullRef26:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %66
+ThrowNullRef28:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %102
+ThrowNullRef32:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %71
+ThrowNullRef34:                                   ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %73
+ThrowNullRef36:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %83
+ThrowNullRef38:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %85
+ThrowNullRef40:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %91
+ThrowNullRef42:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9943,15 +11532,15 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
   %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
@@ -9961,28 +11550,28 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
   %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %12
   %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
   %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
   %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
-  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
@@ -9993,23 +11582,23 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %12
+ThrowNullRef6:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10031,15 +11620,15 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
   %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = load i64, i64 addrspace(1)* %7
@@ -10077,13 +11666,13 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[loadElem]
+Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -10111,8 +11700,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1

--- a/test/BaseLine/JIT/CodeGenBringUpTests/NegRMW.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/NegRMW.error.txt
@@ -25,8 +25,8 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
@@ -40,8 +40,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
   %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
@@ -75,7 +75,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -90,8 +90,8 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %NullCheck = icmp ne i8 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = load i8, i8 addrspace(1)* %0, align 8
@@ -125,8 +125,8 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
@@ -159,8 +159,8 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -184,8 +184,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
   store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
@@ -195,8 +195,8 @@ entry:
 ; <label>:4                                       ; preds = %1
   %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
   %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
@@ -206,8 +206,8 @@ entry:
   %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
@@ -221,14 +221,14 @@ entry:
 
 ; <label>:17                                      ; preds = %14
   %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
   %21 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
@@ -238,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -249,8 +249,8 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
@@ -261,27 +261,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %30
+ThrowNullRef10:                                   ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -301,7 +301,89 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
-Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
+Successfully read AppDomainSetup.GetUnsecureApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.GetUnsecureApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %NullCheck = icmp eq %"System.String[]" addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %BoundsCheck = icmp uge i64 0, %5
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %6
+
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 3, i32 0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
+  ret %System.String addrspace(1)* %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_Value using LLILCJit
+Successfully read AppDomainSetup.get_Value
+
+define %"System.String[]" addrspace(1)* @AppDomainSetup.get_Value(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.String[]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 18)
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.String[]" addrspace(1)* addrspace(1)*, %"System.String[]" addrspace(1)*)*)(%"System.String[]" addrspace(1)* addrspace(1)* %9, %"System.String[]" addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %11, i32 0, i32 1
+  %14 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %13, align 8
+  ret %"System.String[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -319,8 +401,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -368,16 +450,16 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
   %5 = load i32, i32 addrspace(1)* %4
   %6 = sub i32 %5, 1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -389,7 +471,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -421,8 +503,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
@@ -456,8 +538,8 @@ entry:
 ; <label>:27                                      ; preds = %19
   %28 = load i32, i32* %arg1
   %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
-  br i1 %NullCheck2, label %30, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %29, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %30
 
 ; <label>:30                                      ; preds = %27
   %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
@@ -493,8 +575,8 @@ entry:
 ; <label>:49                                      ; preds = %46
   %50 = load i32, i32* %arg2
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck4, label %52, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
@@ -517,11 +599,11 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %27
+ThrowNullRef2:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %49
+ThrowNullRef4:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -544,16 +626,16 @@ entry:
   %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %0)
   store %System.String addrspace(1)* %1, %System.String addrspace(1)** %loc0
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 2
   %5 = bitcast [0 x i16] addrspace(1)* %4 to i16 addrspace(1)*
   store i16 addrspace(1)* %5, i16 addrspace(1)** %loc1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %3
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2
@@ -580,7 +662,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -691,15 +773,15 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %NullCheck132 = icmp ne i8* %21, null
-  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+  %NullCheck131 = icmp eq i8* %21, null
+  br i1 %NullCheck131, label %ThrowNullRef132, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = load i8, i8* %21, align 8
   %24 = zext i8 %23 to i32
   %25 = trunc i32 %24 to i8
-  %NullCheck134 = icmp ne i8* %20, null
-  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+  %NullCheck133 = icmp eq i8* %20, null
+  br i1 %NullCheck133, label %ThrowNullRef134, label %26
 
 ; <label>:26                                      ; preds = %22
   store i8 %25, i8* %20, align 8
@@ -709,16 +791,16 @@ entry:
   %28 = load i8*, i8** %arg0
   %29 = load i8*, i8** %arg1
   %30 = bitcast i8* %29 to i16*
-  %NullCheck128 = icmp ne i16* %30, null
-  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+  %NullCheck127 = icmp eq i16* %30, null
+  br i1 %NullCheck127, label %ThrowNullRef128, label %31
 
 ; <label>:31                                      ; preds = %27
   %32 = load i16, i16* %30, align 8
   %33 = sext i16 %32 to i32
   %34 = bitcast i8* %28 to i16*
   %35 = trunc i32 %33 to i16
-  %NullCheck130 = icmp ne i16* %34, null
-  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+  %NullCheck129 = icmp eq i16* %34, null
+  br i1 %NullCheck129, label %ThrowNullRef130, label %36
 
 ; <label>:36                                      ; preds = %31
   store i16 %35, i16* %34, align 8
@@ -728,16 +810,16 @@ entry:
   %38 = load i8*, i8** %arg0
   %39 = load i8*, i8** %arg1
   %40 = bitcast i8* %39 to i16*
-  %NullCheck120 = icmp ne i16* %40, null
-  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+  %NullCheck119 = icmp eq i16* %40, null
+  br i1 %NullCheck119, label %ThrowNullRef120, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i16, i16* %40, align 8
   %43 = sext i16 %42 to i32
   %44 = bitcast i8* %38 to i16*
   %45 = trunc i32 %43 to i16
-  %NullCheck122 = icmp ne i16* %44, null
-  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+  %NullCheck121 = icmp eq i16* %44, null
+  br i1 %NullCheck121, label %ThrowNullRef122, label %46
 
 ; <label>:46                                      ; preds = %41
   store i16 %45, i16* %44, align 8
@@ -745,15 +827,15 @@ entry:
   %48 = getelementptr inbounds i8, i8* %47, i64 2
   %49 = load i8*, i8** %arg1
   %50 = getelementptr inbounds i8, i8* %49, i64 2
-  %NullCheck124 = icmp ne i8* %50, null
-  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+  %NullCheck123 = icmp eq i8* %50, null
+  br i1 %NullCheck123, label %ThrowNullRef124, label %51
 
 ; <label>:51                                      ; preds = %46
   %52 = load i8, i8* %50, align 8
   %53 = zext i8 %52 to i32
   %54 = trunc i32 %53 to i8
-  %NullCheck126 = icmp ne i8* %48, null
-  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+  %NullCheck125 = icmp eq i8* %48, null
+  br i1 %NullCheck125, label %ThrowNullRef126, label %55
 
 ; <label>:55                                      ; preds = %51
   store i8 %54, i8* %48, align 8
@@ -763,14 +845,14 @@ entry:
   %57 = load i8*, i8** %arg0
   %58 = load i8*, i8** %arg1
   %59 = bitcast i8* %58 to i32*
-  %NullCheck116 = icmp ne i32* %59, null
-  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+  %NullCheck115 = icmp eq i32* %59, null
+  br i1 %NullCheck115, label %ThrowNullRef116, label %60
 
 ; <label>:60                                      ; preds = %56
   %61 = load i32, i32* %59, align 8
   %62 = bitcast i8* %57 to i32*
-  %NullCheck118 = icmp ne i32* %62, null
-  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+  %NullCheck117 = icmp eq i32* %62, null
+  br i1 %NullCheck117, label %ThrowNullRef118, label %63
 
 ; <label>:63                                      ; preds = %60
   store i32 %61, i32* %62, align 8
@@ -780,14 +862,14 @@ entry:
   %65 = load i8*, i8** %arg0
   %66 = load i8*, i8** %arg1
   %67 = bitcast i8* %66 to i32*
-  %NullCheck108 = icmp ne i32* %67, null
-  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+  %NullCheck107 = icmp eq i32* %67, null
+  br i1 %NullCheck107, label %ThrowNullRef108, label %68
 
 ; <label>:68                                      ; preds = %64
   %69 = load i32, i32* %67, align 8
   %70 = bitcast i8* %65 to i32*
-  %NullCheck110 = icmp ne i32* %70, null
-  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+  %NullCheck109 = icmp eq i32* %70, null
+  br i1 %NullCheck109, label %ThrowNullRef110, label %71
 
 ; <label>:71                                      ; preds = %68
   store i32 %69, i32* %70, align 8
@@ -795,15 +877,15 @@ entry:
   %73 = getelementptr inbounds i8, i8* %72, i64 4
   %74 = load i8*, i8** %arg1
   %75 = getelementptr inbounds i8, i8* %74, i64 4
-  %NullCheck112 = icmp ne i8* %75, null
-  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+  %NullCheck111 = icmp eq i8* %75, null
+  br i1 %NullCheck111, label %ThrowNullRef112, label %76
 
 ; <label>:76                                      ; preds = %71
   %77 = load i8, i8* %75, align 8
   %78 = zext i8 %77 to i32
   %79 = trunc i32 %78 to i8
-  %NullCheck114 = icmp ne i8* %73, null
-  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+  %NullCheck113 = icmp eq i8* %73, null
+  br i1 %NullCheck113, label %ThrowNullRef114, label %80
 
 ; <label>:80                                      ; preds = %76
   store i8 %79, i8* %73, align 8
@@ -813,14 +895,14 @@ entry:
   %82 = load i8*, i8** %arg0
   %83 = load i8*, i8** %arg1
   %84 = bitcast i8* %83 to i32*
-  %NullCheck100 = icmp ne i32* %84, null
-  br i1 %NullCheck100, label %85, label %ThrowNullRef99
+  %NullCheck99 = icmp eq i32* %84, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %85
 
 ; <label>:85                                      ; preds = %81
   %86 = load i32, i32* %84, align 8
   %87 = bitcast i8* %82 to i32*
-  %NullCheck102 = icmp ne i32* %87, null
-  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+  %NullCheck101 = icmp eq i32* %87, null
+  br i1 %NullCheck101, label %ThrowNullRef102, label %88
 
 ; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
@@ -829,16 +911,16 @@ entry:
   %91 = load i8*, i8** %arg1
   %92 = getelementptr inbounds i8, i8* %91, i64 4
   %93 = bitcast i8* %92 to i16*
-  %NullCheck104 = icmp ne i16* %93, null
-  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+  %NullCheck103 = icmp eq i16* %93, null
+  br i1 %NullCheck103, label %ThrowNullRef104, label %94
 
 ; <label>:94                                      ; preds = %88
   %95 = load i16, i16* %93, align 8
   %96 = sext i16 %95 to i32
   %97 = bitcast i8* %90 to i16*
   %98 = trunc i32 %96 to i16
-  %NullCheck106 = icmp ne i16* %97, null
-  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+  %NullCheck105 = icmp eq i16* %97, null
+  br i1 %NullCheck105, label %ThrowNullRef106, label %99
 
 ; <label>:99                                      ; preds = %94
   store i16 %98, i16* %97, align 8
@@ -848,14 +930,14 @@ entry:
   %101 = load i8*, i8** %arg0
   %102 = load i8*, i8** %arg1
   %103 = bitcast i8* %102 to i32*
-  %NullCheck88 = icmp ne i32* %103, null
-  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+  %NullCheck87 = icmp eq i32* %103, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %104
 
 ; <label>:104                                     ; preds = %100
   %105 = load i32, i32* %103, align 8
   %106 = bitcast i8* %101 to i32*
-  %NullCheck90 = icmp ne i32* %106, null
-  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+  %NullCheck89 = icmp eq i32* %106, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %107
 
 ; <label>:107                                     ; preds = %104
   store i32 %105, i32* %106, align 8
@@ -864,16 +946,16 @@ entry:
   %110 = load i8*, i8** %arg1
   %111 = getelementptr inbounds i8, i8* %110, i64 4
   %112 = bitcast i8* %111 to i16*
-  %NullCheck92 = icmp ne i16* %112, null
-  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+  %NullCheck91 = icmp eq i16* %112, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %113
 
 ; <label>:113                                     ; preds = %107
   %114 = load i16, i16* %112, align 8
   %115 = sext i16 %114 to i32
   %116 = bitcast i8* %109 to i16*
   %117 = trunc i32 %115 to i16
-  %NullCheck94 = icmp ne i16* %116, null
-  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+  %NullCheck93 = icmp eq i16* %116, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %118
 
 ; <label>:118                                     ; preds = %113
   store i16 %117, i16* %116, align 8
@@ -881,15 +963,15 @@ entry:
   %120 = getelementptr inbounds i8, i8* %119, i64 6
   %121 = load i8*, i8** %arg1
   %122 = getelementptr inbounds i8, i8* %121, i64 6
-  %NullCheck96 = icmp ne i8* %122, null
-  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+  %NullCheck95 = icmp eq i8* %122, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %123
 
 ; <label>:123                                     ; preds = %118
   %124 = load i8, i8* %122, align 8
   %125 = zext i8 %124 to i32
   %126 = trunc i32 %125 to i8
-  %NullCheck98 = icmp ne i8* %120, null
-  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+  %NullCheck97 = icmp eq i8* %120, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %127
 
 ; <label>:127                                     ; preds = %123
   store i8 %126, i8* %120, align 8
@@ -899,14 +981,14 @@ entry:
   %129 = load i8*, i8** %arg0
   %130 = load i8*, i8** %arg1
   %131 = bitcast i8* %130 to i64*
-  %NullCheck84 = icmp ne i64* %131, null
-  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+  %NullCheck83 = icmp eq i64* %131, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %132
 
 ; <label>:132                                     ; preds = %128
   %133 = load i64, i64* %131, align 8
   %134 = bitcast i8* %129 to i64*
-  %NullCheck86 = icmp ne i64* %134, null
-  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+  %NullCheck85 = icmp eq i64* %134, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %135
 
 ; <label>:135                                     ; preds = %132
   store i64 %133, i64* %134, align 8
@@ -916,14 +998,14 @@ entry:
   %137 = load i8*, i8** %arg0
   %138 = load i8*, i8** %arg1
   %139 = bitcast i8* %138 to i64*
-  %NullCheck76 = icmp ne i64* %139, null
-  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+  %NullCheck75 = icmp eq i64* %139, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %140
 
 ; <label>:140                                     ; preds = %136
   %141 = load i64, i64* %139, align 8
   %142 = bitcast i8* %137 to i64*
-  %NullCheck78 = icmp ne i64* %142, null
-  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+  %NullCheck77 = icmp eq i64* %142, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %143
 
 ; <label>:143                                     ; preds = %140
   store i64 %141, i64* %142, align 8
@@ -931,15 +1013,15 @@ entry:
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %NullCheck80 = icmp ne i8* %147, null
-  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+  %NullCheck79 = icmp eq i8* %147, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %148
 
 ; <label>:148                                     ; preds = %143
   %149 = load i8, i8* %147, align 8
   %150 = zext i8 %149 to i32
   %151 = trunc i32 %150 to i8
-  %NullCheck82 = icmp ne i8* %145, null
-  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+  %NullCheck81 = icmp eq i8* %145, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %152
 
 ; <label>:152                                     ; preds = %148
   store i8 %151, i8* %145, align 8
@@ -949,14 +1031,14 @@ entry:
   %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
   %156 = bitcast i8* %155 to i64*
-  %NullCheck68 = icmp ne i64* %156, null
-  br i1 %NullCheck68, label %157, label %ThrowNullRef67
+  %NullCheck67 = icmp eq i64* %156, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %157
 
 ; <label>:157                                     ; preds = %153
   %158 = load i64, i64* %156, align 8
   %159 = bitcast i8* %154 to i64*
-  %NullCheck70 = icmp ne i64* %159, null
-  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+  %NullCheck69 = icmp eq i64* %159, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %160
 
 ; <label>:160                                     ; preds = %157
   store i64 %158, i64* %159, align 8
@@ -965,16 +1047,16 @@ entry:
   %163 = load i8*, i8** %arg1
   %164 = getelementptr inbounds i8, i8* %163, i64 8
   %165 = bitcast i8* %164 to i16*
-  %NullCheck72 = icmp ne i16* %165, null
-  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+  %NullCheck71 = icmp eq i16* %165, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %166
 
 ; <label>:166                                     ; preds = %160
   %167 = load i16, i16* %165, align 8
   %168 = sext i16 %167 to i32
   %169 = bitcast i8* %162 to i16*
   %170 = trunc i32 %168 to i16
-  %NullCheck74 = icmp ne i16* %169, null
-  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+  %NullCheck73 = icmp eq i16* %169, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %171
 
 ; <label>:171                                     ; preds = %166
   store i16 %170, i16* %169, align 8
@@ -984,14 +1066,14 @@ entry:
   %173 = load i8*, i8** %arg0
   %174 = load i8*, i8** %arg1
   %175 = bitcast i8* %174 to i64*
-  %NullCheck56 = icmp ne i64* %175, null
-  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+  %NullCheck55 = icmp eq i64* %175, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %176
 
 ; <label>:176                                     ; preds = %172
   %177 = load i64, i64* %175, align 8
   %178 = bitcast i8* %173 to i64*
-  %NullCheck58 = icmp ne i64* %178, null
-  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+  %NullCheck57 = icmp eq i64* %178, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %179
 
 ; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
@@ -1000,16 +1082,16 @@ entry:
   %182 = load i8*, i8** %arg1
   %183 = getelementptr inbounds i8, i8* %182, i64 8
   %184 = bitcast i8* %183 to i16*
-  %NullCheck60 = icmp ne i16* %184, null
-  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+  %NullCheck59 = icmp eq i16* %184, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %185
 
 ; <label>:185                                     ; preds = %179
   %186 = load i16, i16* %184, align 8
   %187 = sext i16 %186 to i32
   %188 = bitcast i8* %181 to i16*
   %189 = trunc i32 %187 to i16
-  %NullCheck62 = icmp ne i16* %188, null
-  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+  %NullCheck61 = icmp eq i16* %188, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %190
 
 ; <label>:190                                     ; preds = %185
   store i16 %189, i16* %188, align 8
@@ -1017,15 +1099,15 @@ entry:
   %192 = getelementptr inbounds i8, i8* %191, i64 10
   %193 = load i8*, i8** %arg1
   %194 = getelementptr inbounds i8, i8* %193, i64 10
-  %NullCheck64 = icmp ne i8* %194, null
-  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+  %NullCheck63 = icmp eq i8* %194, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %195
 
 ; <label>:195                                     ; preds = %190
   %196 = load i8, i8* %194, align 8
   %197 = zext i8 %196 to i32
   %198 = trunc i32 %197 to i8
-  %NullCheck66 = icmp ne i8* %192, null
-  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+  %NullCheck65 = icmp eq i8* %192, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %199
 
 ; <label>:199                                     ; preds = %195
   store i8 %198, i8* %192, align 8
@@ -1035,14 +1117,14 @@ entry:
   %201 = load i8*, i8** %arg0
   %202 = load i8*, i8** %arg1
   %203 = bitcast i8* %202 to i64*
-  %NullCheck48 = icmp ne i64* %203, null
-  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+  %NullCheck47 = icmp eq i64* %203, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %204
 
 ; <label>:204                                     ; preds = %200
   %205 = load i64, i64* %203, align 8
   %206 = bitcast i8* %201 to i64*
-  %NullCheck50 = icmp ne i64* %206, null
-  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+  %NullCheck49 = icmp eq i64* %206, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %207
 
 ; <label>:207                                     ; preds = %204
   store i64 %205, i64* %206, align 8
@@ -1051,14 +1133,14 @@ entry:
   %210 = load i8*, i8** %arg1
   %211 = getelementptr inbounds i8, i8* %210, i64 8
   %212 = bitcast i8* %211 to i32*
-  %NullCheck52 = icmp ne i32* %212, null
-  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+  %NullCheck51 = icmp eq i32* %212, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %213
 
 ; <label>:213                                     ; preds = %207
   %214 = load i32, i32* %212, align 8
   %215 = bitcast i8* %209 to i32*
-  %NullCheck54 = icmp ne i32* %215, null
-  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+  %NullCheck53 = icmp eq i32* %215, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %216
 
 ; <label>:216                                     ; preds = %213
   store i32 %214, i32* %215, align 8
@@ -1068,14 +1150,14 @@ entry:
   %218 = load i8*, i8** %arg0
   %219 = load i8*, i8** %arg1
   %220 = bitcast i8* %219 to i64*
-  %NullCheck36 = icmp ne i64* %220, null
-  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64* %220, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %221
 
 ; <label>:221                                     ; preds = %217
   %222 = load i64, i64* %220, align 8
   %223 = bitcast i8* %218 to i64*
-  %NullCheck38 = icmp ne i64* %223, null
-  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+  %NullCheck37 = icmp eq i64* %223, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %224
 
 ; <label>:224                                     ; preds = %221
   store i64 %222, i64* %223, align 8
@@ -1084,14 +1166,14 @@ entry:
   %227 = load i8*, i8** %arg1
   %228 = getelementptr inbounds i8, i8* %227, i64 8
   %229 = bitcast i8* %228 to i32*
-  %NullCheck40 = icmp ne i32* %229, null
-  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i32* %229, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %230
 
 ; <label>:230                                     ; preds = %224
   %231 = load i32, i32* %229, align 8
   %232 = bitcast i8* %226 to i32*
-  %NullCheck42 = icmp ne i32* %232, null
-  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+  %NullCheck41 = icmp eq i32* %232, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %233
 
 ; <label>:233                                     ; preds = %230
   store i32 %231, i32* %232, align 8
@@ -1099,15 +1181,15 @@ entry:
   %235 = getelementptr inbounds i8, i8* %234, i64 12
   %236 = load i8*, i8** %arg1
   %237 = getelementptr inbounds i8, i8* %236, i64 12
-  %NullCheck44 = icmp ne i8* %237, null
-  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i8* %237, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %238
 
 ; <label>:238                                     ; preds = %233
   %239 = load i8, i8* %237, align 8
   %240 = zext i8 %239 to i32
   %241 = trunc i32 %240 to i8
-  %NullCheck46 = icmp ne i8* %235, null
-  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+  %NullCheck45 = icmp eq i8* %235, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %242
 
 ; <label>:242                                     ; preds = %238
   store i8 %241, i8* %235, align 8
@@ -1117,14 +1199,14 @@ entry:
   %244 = load i8*, i8** %arg0
   %245 = load i8*, i8** %arg1
   %246 = bitcast i8* %245 to i64*
-  %NullCheck24 = icmp ne i64* %246, null
-  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64* %246, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %247
 
 ; <label>:247                                     ; preds = %243
   %248 = load i64, i64* %246, align 8
   %249 = bitcast i8* %244 to i64*
-  %NullCheck26 = icmp ne i64* %249, null
-  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64* %249, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %250
 
 ; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
@@ -1133,14 +1215,14 @@ entry:
   %253 = load i8*, i8** %arg1
   %254 = getelementptr inbounds i8, i8* %253, i64 8
   %255 = bitcast i8* %254 to i32*
-  %NullCheck28 = icmp ne i32* %255, null
-  br i1 %NullCheck28, label %256, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i32* %255, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %256
 
 ; <label>:256                                     ; preds = %250
   %257 = load i32, i32* %255, align 8
   %258 = bitcast i8* %252 to i32*
-  %NullCheck30 = icmp ne i32* %258, null
-  br i1 %NullCheck30, label %259, label %ThrowNullRef29
+  %NullCheck29 = icmp eq i32* %258, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %259
 
 ; <label>:259                                     ; preds = %256
   store i32 %257, i32* %258, align 8
@@ -1149,16 +1231,16 @@ entry:
   %262 = load i8*, i8** %arg1
   %263 = getelementptr inbounds i8, i8* %262, i64 12
   %264 = bitcast i8* %263 to i16*
-  %NullCheck32 = icmp ne i16* %264, null
-  br i1 %NullCheck32, label %265, label %ThrowNullRef31
+  %NullCheck31 = icmp eq i16* %264, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %265
 
 ; <label>:265                                     ; preds = %259
   %266 = load i16, i16* %264, align 8
   %267 = sext i16 %266 to i32
   %268 = bitcast i8* %261 to i16*
   %269 = trunc i32 %267 to i16
-  %NullCheck34 = icmp ne i16* %268, null
-  br i1 %NullCheck34, label %270, label %ThrowNullRef33
+  %NullCheck33 = icmp eq i16* %268, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %270
 
 ; <label>:270                                     ; preds = %265
   store i16 %269, i16* %268, align 8
@@ -1168,14 +1250,14 @@ entry:
   %272 = load i8*, i8** %arg0
   %273 = load i8*, i8** %arg1
   %274 = bitcast i8* %273 to i64*
-  %NullCheck8 = icmp ne i64* %274, null
-  br i1 %NullCheck8, label %275, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64* %274, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %275
 
 ; <label>:275                                     ; preds = %271
   %276 = load i64, i64* %274, align 8
   %277 = bitcast i8* %272 to i64*
-  %NullCheck10 = icmp ne i64* %277, null
-  br i1 %NullCheck10, label %278, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %277, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %278
 
 ; <label>:278                                     ; preds = %275
   store i64 %276, i64* %277, align 8
@@ -1184,14 +1266,14 @@ entry:
   %281 = load i8*, i8** %arg1
   %282 = getelementptr inbounds i8, i8* %281, i64 8
   %283 = bitcast i8* %282 to i32*
-  %NullCheck12 = icmp ne i32* %283, null
-  br i1 %NullCheck12, label %284, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i32* %283, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %284
 
 ; <label>:284                                     ; preds = %278
   %285 = load i32, i32* %283, align 8
   %286 = bitcast i8* %280 to i32*
-  %NullCheck14 = icmp ne i32* %286, null
-  br i1 %NullCheck14, label %287, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i32* %286, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %287
 
 ; <label>:287                                     ; preds = %284
   store i32 %285, i32* %286, align 8
@@ -1200,16 +1282,16 @@ entry:
   %290 = load i8*, i8** %arg1
   %291 = getelementptr inbounds i8, i8* %290, i64 12
   %292 = bitcast i8* %291 to i16*
-  %NullCheck16 = icmp ne i16* %292, null
-  br i1 %NullCheck16, label %293, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i16* %292, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %293
 
 ; <label>:293                                     ; preds = %287
   %294 = load i16, i16* %292, align 8
   %295 = sext i16 %294 to i32
   %296 = bitcast i8* %289 to i16*
   %297 = trunc i32 %295 to i16
-  %NullCheck18 = icmp ne i16* %296, null
-  br i1 %NullCheck18, label %298, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i16* %296, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %298
 
 ; <label>:298                                     ; preds = %293
   store i16 %297, i16* %296, align 8
@@ -1217,15 +1299,15 @@ entry:
   %300 = getelementptr inbounds i8, i8* %299, i64 14
   %301 = load i8*, i8** %arg1
   %302 = getelementptr inbounds i8, i8* %301, i64 14
-  %NullCheck20 = icmp ne i8* %302, null
-  br i1 %NullCheck20, label %303, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i8* %302, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %303
 
 ; <label>:303                                     ; preds = %298
   %304 = load i8, i8* %302, align 8
   %305 = zext i8 %304 to i32
   %306 = trunc i32 %305 to i8
-  %NullCheck22 = icmp ne i8* %300, null
-  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i8* %300, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %307
 
 ; <label>:307                                     ; preds = %303
   store i8 %306, i8* %300, align 8
@@ -1235,14 +1317,14 @@ entry:
   %309 = load i8*, i8** %arg0
   %310 = load i8*, i8** %arg1
   %311 = bitcast i8* %310 to i64*
-  %NullCheck = icmp ne i64* %311, null
-  br i1 %NullCheck, label %312, label %ThrowNullRef
+  %NullCheck = icmp eq i64* %311, null
+  br i1 %NullCheck, label %ThrowNullRef, label %312
 
 ; <label>:312                                     ; preds = %308
   %313 = load i64, i64* %311, align 8
   %314 = bitcast i8* %309 to i64*
-  %NullCheck2 = icmp ne i64* %314, null
-  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64* %314, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %315
 
 ; <label>:315                                     ; preds = %312
   store i64 %313, i64* %314, align 8
@@ -1251,14 +1333,14 @@ entry:
   %318 = load i8*, i8** %arg1
   %319 = getelementptr inbounds i8, i8* %318, i64 8
   %320 = bitcast i8* %319 to i64*
-  %NullCheck4 = icmp ne i64* %320, null
-  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64* %320, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %321
 
 ; <label>:321                                     ; preds = %315
   %322 = load i64, i64* %320, align 8
   %323 = bitcast i8* %317 to i64*
-  %NullCheck6 = icmp ne i64* %323, null
-  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64* %323, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %324
 
 ; <label>:324                                     ; preds = %321
   store i64 %322, i64* %323, align 8
@@ -1286,15 +1368,15 @@ entry:
 ; <label>:338                                     ; preds = %333
   %339 = load i8*, i8** %arg0
   %340 = load i8*, i8** %arg1
-  %NullCheck136 = icmp ne i8* %340, null
-  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+  %NullCheck135 = icmp eq i8* %340, null
+  br i1 %NullCheck135, label %ThrowNullRef136, label %341
 
 ; <label>:341                                     ; preds = %338
   %342 = load i8, i8* %340, align 8
   %343 = zext i8 %342 to i32
   %344 = trunc i32 %343 to i8
-  %NullCheck138 = icmp ne i8* %339, null
-  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+  %NullCheck137 = icmp eq i8* %339, null
+  br i1 %NullCheck137, label %ThrowNullRef138, label %345
 
 ; <label>:345                                     ; preds = %341
   store i8 %344, i8* %339, align 8
@@ -1317,16 +1399,16 @@ entry:
   %357 = load i8*, i8** %arg0
   %358 = load i8*, i8** %arg1
   %359 = bitcast i8* %358 to i16*
-  %NullCheck140 = icmp ne i16* %359, null
-  br i1 %NullCheck140, label %360, label %ThrowNullRef139
+  %NullCheck139 = icmp eq i16* %359, null
+  br i1 %NullCheck139, label %ThrowNullRef140, label %360
 
 ; <label>:360                                     ; preds = %356
   %361 = load i16, i16* %359, align 8
   %362 = sext i16 %361 to i32
   %363 = bitcast i8* %357 to i16*
   %364 = trunc i32 %362 to i16
-  %NullCheck142 = icmp ne i16* %363, null
-  br i1 %NullCheck142, label %365, label %ThrowNullRef141
+  %NullCheck141 = icmp eq i16* %363, null
+  br i1 %NullCheck141, label %ThrowNullRef142, label %365
 
 ; <label>:365                                     ; preds = %360
   store i16 %364, i16* %363, align 8
@@ -1352,14 +1434,14 @@ entry:
   %378 = load i8*, i8** %arg0
   %379 = load i8*, i8** %arg1
   %380 = bitcast i8* %379 to i32*
-  %NullCheck144 = icmp ne i32* %380, null
-  br i1 %NullCheck144, label %381, label %ThrowNullRef143
+  %NullCheck143 = icmp eq i32* %380, null
+  br i1 %NullCheck143, label %ThrowNullRef144, label %381
 
 ; <label>:381                                     ; preds = %377
   %382 = load i32, i32* %380, align 8
   %383 = bitcast i8* %378 to i32*
-  %NullCheck146 = icmp ne i32* %383, null
-  br i1 %NullCheck146, label %384, label %ThrowNullRef145
+  %NullCheck145 = icmp eq i32* %383, null
+  br i1 %NullCheck145, label %ThrowNullRef146, label %384
 
 ; <label>:384                                     ; preds = %381
   store i32 %382, i32* %383, align 8
@@ -1384,14 +1466,14 @@ entry:
   %395 = load i8*, i8** %arg0
   %396 = load i8*, i8** %arg1
   %397 = bitcast i8* %396 to i64*
-  %NullCheck164 = icmp ne i64* %397, null
-  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+  %NullCheck163 = icmp eq i64* %397, null
+  br i1 %NullCheck163, label %ThrowNullRef164, label %398
 
 ; <label>:398                                     ; preds = %394
   %399 = load i64, i64* %397, align 8
   %400 = bitcast i8* %395 to i64*
-  %NullCheck166 = icmp ne i64* %400, null
-  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+  %NullCheck165 = icmp eq i64* %400, null
+  br i1 %NullCheck165, label %ThrowNullRef166, label %401
 
 ; <label>:401                                     ; preds = %398
   store i64 %399, i64* %400, align 8
@@ -1400,14 +1482,14 @@ entry:
   %404 = load i8*, i8** %arg1
   %405 = getelementptr inbounds i8, i8* %404, i64 8
   %406 = bitcast i8* %405 to i64*
-  %NullCheck168 = icmp ne i64* %406, null
-  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+  %NullCheck167 = icmp eq i64* %406, null
+  br i1 %NullCheck167, label %ThrowNullRef168, label %407
 
 ; <label>:407                                     ; preds = %401
   %408 = load i64, i64* %406, align 8
   %409 = bitcast i8* %403 to i64*
-  %NullCheck170 = icmp ne i64* %409, null
-  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+  %NullCheck169 = icmp eq i64* %409, null
+  br i1 %NullCheck169, label %ThrowNullRef170, label %410
 
 ; <label>:410                                     ; preds = %407
   store i64 %408, i64* %409, align 8
@@ -1437,14 +1519,14 @@ entry:
   %425 = load i8*, i8** %arg0
   %426 = load i8*, i8** %arg1
   %427 = bitcast i8* %426 to i64*
-  %NullCheck148 = icmp ne i64* %427, null
-  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+  %NullCheck147 = icmp eq i64* %427, null
+  br i1 %NullCheck147, label %ThrowNullRef148, label %428
 
 ; <label>:428                                     ; preds = %424
   %429 = load i64, i64* %427, align 8
   %430 = bitcast i8* %425 to i64*
-  %NullCheck150 = icmp ne i64* %430, null
-  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+  %NullCheck149 = icmp eq i64* %430, null
+  br i1 %NullCheck149, label %ThrowNullRef150, label %431
 
 ; <label>:431                                     ; preds = %428
   store i64 %429, i64* %430, align 8
@@ -1466,14 +1548,14 @@ entry:
   %441 = load i8*, i8** %arg0
   %442 = load i8*, i8** %arg1
   %443 = bitcast i8* %442 to i32*
-  %NullCheck152 = icmp ne i32* %443, null
-  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+  %NullCheck151 = icmp eq i32* %443, null
+  br i1 %NullCheck151, label %ThrowNullRef152, label %444
 
 ; <label>:444                                     ; preds = %440
   %445 = load i32, i32* %443, align 8
   %446 = bitcast i8* %441 to i32*
-  %NullCheck154 = icmp ne i32* %446, null
-  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+  %NullCheck153 = icmp eq i32* %446, null
+  br i1 %NullCheck153, label %ThrowNullRef154, label %447
 
 ; <label>:447                                     ; preds = %444
   store i32 %445, i32* %446, align 8
@@ -1495,16 +1577,16 @@ entry:
   %457 = load i8*, i8** %arg0
   %458 = load i8*, i8** %arg1
   %459 = bitcast i8* %458 to i16*
-  %NullCheck156 = icmp ne i16* %459, null
-  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+  %NullCheck155 = icmp eq i16* %459, null
+  br i1 %NullCheck155, label %ThrowNullRef156, label %460
 
 ; <label>:460                                     ; preds = %456
   %461 = load i16, i16* %459, align 8
   %462 = sext i16 %461 to i32
   %463 = bitcast i8* %457 to i16*
   %464 = trunc i32 %462 to i16
-  %NullCheck158 = icmp ne i16* %463, null
-  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+  %NullCheck157 = icmp eq i16* %463, null
+  br i1 %NullCheck157, label %ThrowNullRef158, label %465
 
 ; <label>:465                                     ; preds = %460
   store i16 %464, i16* %463, align 8
@@ -1525,15 +1607,15 @@ entry:
 ; <label>:474                                     ; preds = %470
   %475 = load i8*, i8** %arg0
   %476 = load i8*, i8** %arg1
-  %NullCheck160 = icmp ne i8* %476, null
-  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+  %NullCheck159 = icmp eq i8* %476, null
+  br i1 %NullCheck159, label %ThrowNullRef160, label %477
 
 ; <label>:477                                     ; preds = %474
   %478 = load i8, i8* %476, align 8
   %479 = zext i8 %478 to i32
   %480 = trunc i32 %479 to i8
-  %NullCheck162 = icmp ne i8* %475, null
-  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+  %NullCheck161 = icmp eq i8* %475, null
+  br i1 %NullCheck161, label %ThrowNullRef162, label %481
 
 ; <label>:481                                     ; preds = %477
   store i8 %480, i8* %475, align 8
@@ -1553,343 +1635,343 @@ ThrowNullRef:                                     ; preds = %308
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %312
+ThrowNullRef2:                                    ; preds = %312
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %315
+ThrowNullRef4:                                    ; preds = %315
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %321
+ThrowNullRef6:                                    ; preds = %321
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %271
+ThrowNullRef8:                                    ; preds = %271
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %275
+ThrowNullRef10:                                   ; preds = %275
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %278
+ThrowNullRef12:                                   ; preds = %278
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %284
+ThrowNullRef14:                                   ; preds = %284
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %287
+ThrowNullRef16:                                   ; preds = %287
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %293
+ThrowNullRef18:                                   ; preds = %293
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %298
+ThrowNullRef20:                                   ; preds = %298
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %303
+ThrowNullRef22:                                   ; preds = %303
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %243
+ThrowNullRef24:                                   ; preds = %243
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %247
+ThrowNullRef26:                                   ; preds = %247
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %250
+ThrowNullRef28:                                   ; preds = %250
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %256
+ThrowNullRef30:                                   ; preds = %256
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %259
+ThrowNullRef32:                                   ; preds = %259
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %265
+ThrowNullRef34:                                   ; preds = %265
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %217
+ThrowNullRef36:                                   ; preds = %217
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %221
+ThrowNullRef38:                                   ; preds = %221
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %224
+ThrowNullRef40:                                   ; preds = %224
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %230
+ThrowNullRef42:                                   ; preds = %230
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %233
+ThrowNullRef44:                                   ; preds = %233
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %238
+ThrowNullRef46:                                   ; preds = %238
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %200
+ThrowNullRef48:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %204
+ThrowNullRef50:                                   ; preds = %204
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %207
+ThrowNullRef52:                                   ; preds = %207
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %213
+ThrowNullRef54:                                   ; preds = %213
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %172
+ThrowNullRef56:                                   ; preds = %172
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %176
+ThrowNullRef58:                                   ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %179
+ThrowNullRef60:                                   ; preds = %179
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %185
+ThrowNullRef62:                                   ; preds = %185
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %190
+ThrowNullRef64:                                   ; preds = %190
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %195
+ThrowNullRef66:                                   ; preds = %195
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %153
+ThrowNullRef68:                                   ; preds = %153
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %157
+ThrowNullRef70:                                   ; preds = %157
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %160
+ThrowNullRef72:                                   ; preds = %160
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %166
+ThrowNullRef74:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %136
+ThrowNullRef76:                                   ; preds = %136
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %140
+ThrowNullRef78:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %143
+ThrowNullRef80:                                   ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %148
+ThrowNullRef82:                                   ; preds = %148
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %128
+ThrowNullRef84:                                   ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %132
+ThrowNullRef86:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %100
+ThrowNullRef88:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %104
+ThrowNullRef90:                                   ; preds = %104
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %107
+ThrowNullRef92:                                   ; preds = %107
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %113
+ThrowNullRef94:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %118
+ThrowNullRef96:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %123
+ThrowNullRef98:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %81
+ThrowNullRef100:                                  ; preds = %81
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef101:                                  ; preds = %85
+ThrowNullRef102:                                  ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef103:                                  ; preds = %88
+ThrowNullRef104:                                  ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef105:                                  ; preds = %94
+ThrowNullRef106:                                  ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef107:                                  ; preds = %64
+ThrowNullRef108:                                  ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef109:                                  ; preds = %68
+ThrowNullRef110:                                  ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef111:                                  ; preds = %71
+ThrowNullRef112:                                  ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef113:                                  ; preds = %76
+ThrowNullRef114:                                  ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef115:                                  ; preds = %56
+ThrowNullRef116:                                  ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef117:                                  ; preds = %60
+ThrowNullRef118:                                  ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef119:                                  ; preds = %37
+ThrowNullRef120:                                  ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef121:                                  ; preds = %41
+ThrowNullRef122:                                  ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef123:                                  ; preds = %46
+ThrowNullRef124:                                  ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef125:                                  ; preds = %51
+ThrowNullRef126:                                  ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef127:                                  ; preds = %27
+ThrowNullRef128:                                  ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef129:                                  ; preds = %31
+ThrowNullRef130:                                  ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef131:                                  ; preds = %19
+ThrowNullRef132:                                  ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef133:                                  ; preds = %22
+ThrowNullRef134:                                  ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef135:                                  ; preds = %338
+ThrowNullRef136:                                  ; preds = %338
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef137:                                  ; preds = %341
+ThrowNullRef138:                                  ; preds = %341
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef139:                                  ; preds = %356
+ThrowNullRef140:                                  ; preds = %356
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef141:                                  ; preds = %360
+ThrowNullRef142:                                  ; preds = %360
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef143:                                  ; preds = %377
+ThrowNullRef144:                                  ; preds = %377
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef145:                                  ; preds = %381
+ThrowNullRef146:                                  ; preds = %381
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef147:                                  ; preds = %424
+ThrowNullRef148:                                  ; preds = %424
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef149:                                  ; preds = %428
+ThrowNullRef150:                                  ; preds = %428
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef151:                                  ; preds = %440
+ThrowNullRef152:                                  ; preds = %440
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef153:                                  ; preds = %444
+ThrowNullRef154:                                  ; preds = %444
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef155:                                  ; preds = %456
+ThrowNullRef156:                                  ; preds = %456
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef157:                                  ; preds = %460
+ThrowNullRef158:                                  ; preds = %460
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef159:                                  ; preds = %474
+ThrowNullRef160:                                  ; preds = %474
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef161:                                  ; preds = %477
+ThrowNullRef162:                                  ; preds = %477
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef163:                                  ; preds = %394
+ThrowNullRef164:                                  ; preds = %394
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef165:                                  ; preds = %398
+ThrowNullRef166:                                  ; preds = %398
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef167:                                  ; preds = %401
+ThrowNullRef168:                                  ; preds = %401
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef169:                                  ; preds = %407
+ThrowNullRef170:                                  ; preds = %407
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1939,8 +2021,8 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
-  br i1 %NullCheck, label %22, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %ThrowNullRef, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
@@ -1948,8 +2030,8 @@ entry:
   store i32 %24, i32* %loc0
   %25 = load i32, i32* %loc0
   %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %26, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %27
 
 ; <label>:27                                      ; preds = %22
   %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
@@ -1971,7 +2053,7 @@ ThrowNullRef:                                     ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1989,8 +2071,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -2022,15 +2104,15 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2048,16 +2130,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
   %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
   store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %15
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
@@ -2072,8 +2154,8 @@ entry:
   %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
   %29 = ptrtoint i16 addrspace(1)* %28 to i64
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %19
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
@@ -2089,19 +2171,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2114,8 +2196,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
@@ -2128,7 +2210,7 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[loadElem]
+Failed to read AppDomain.PrepareDataForSetup[storeElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
@@ -2202,8 +2284,8 @@ entry:
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
-  br i1 %NullCheck24, label %27, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = load i64, i64 addrspace(1)* %26
@@ -2218,8 +2300,8 @@ entry:
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
-  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
   %41 = load i64, i64 addrspace(1)* %39
@@ -2236,8 +2318,8 @@ entry:
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
-  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
   %54 = load i64, i64 addrspace(1)* %52
@@ -2252,8 +2334,8 @@ entry:
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
   %67 = load i64, i64 addrspace(1)* %65
@@ -2270,8 +2352,8 @@ entry:
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
-  br i1 %NullCheck16, label %79, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
   %80 = load i64, i64 addrspace(1)* %78
@@ -2286,8 +2368,8 @@ entry:
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
-  br i1 %NullCheck18, label %92, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
   %93 = load i64, i64 addrspace(1)* %91
@@ -2304,8 +2386,8 @@ entry:
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
-  br i1 %NullCheck12, label %105, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = load i64, i64 addrspace(1)* %104
@@ -2320,8 +2402,8 @@ entry:
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
-  br i1 %NullCheck14, label %118, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
   %119 = load i64, i64 addrspace(1)* %117
@@ -2337,8 +2419,8 @@ entry:
 
 ; <label>:128                                     ; preds = %20
   %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
-  br i1 %NullCheck4, label %130, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %129, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %130
 
 ; <label>:130                                     ; preds = %128
   %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
@@ -2346,8 +2428,8 @@ entry:
   %133 = load i16, i16 addrspace(1)* %132, align 8
   %134 = zext i16 %133 to i32
   %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
-  br i1 %NullCheck6, label %136, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %135, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %136
 
 ; <label>:136                                     ; preds = %130
   %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
@@ -2360,8 +2442,8 @@ entry:
 
 ; <label>:143                                     ; preds = %136
   %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
-  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %144, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %145
 
 ; <label>:145                                     ; preds = %143
   %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
@@ -2369,8 +2451,8 @@ entry:
   %148 = load i16, i16 addrspace(1)* %147, align 8
   %149 = zext i16 %148 to i32
   %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %150, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %151
 
 ; <label>:151                                     ; preds = %145
   %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
@@ -2388,8 +2470,8 @@ entry:
 
 ; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
-  br i1 %NullCheck, label %163, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %ThrowNullRef, label %163
 
 ; <label>:163                                     ; preds = %161
   %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
@@ -2399,8 +2481,8 @@ entry:
 
 ; <label>:167                                     ; preds = %163
   %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
-  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %168, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %169
 
 ; <label>:169                                     ; preds = %167
   %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
@@ -2432,55 +2514,55 @@ ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %167
+ThrowNullRef2:                                    ; preds = %167
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %128
+ThrowNullRef4:                                    ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %130
+ThrowNullRef6:                                    ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %143
+ThrowNullRef8:                                    ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %145
+ThrowNullRef10:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %102
+ThrowNullRef12:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %105
+ThrowNullRef14:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %76
+ThrowNullRef16:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %79
+ThrowNullRef18:                                   ; preds = %79
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %50
+ThrowNullRef20:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %53
+ThrowNullRef22:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %24
+ThrowNullRef24:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %27
+ThrowNullRef26:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2503,15 +2585,15 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2519,16 +2601,16 @@ entry:
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
   store i32 %8, i32* %loc0
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
   %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
   store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
@@ -2546,16 +2628,16 @@ entry:
 
 ; <label>:23                                      ; preds = %64
   %24 = load i16*, i16** %loc3
-  %NullCheck12 = icmp ne i16* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i16* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
   store i32 %27, i32* %loc5
   %28 = load i16*, i16** %loc4
-  %NullCheck14 = icmp ne i16* %28, null
-  br i1 %NullCheck14, label %29, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %28, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = load i16, i16* %28, align 8
@@ -2620,15 +2702,15 @@ entry:
 
 ; <label>:67                                      ; preds = %64
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
-  br i1 %NullCheck8, label %69, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %68, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %69
 
 ; <label>:69                                      ; preds = %67
   %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
   %71 = load i32, i32 addrspace(1)* %70
   %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
-  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %73
 
 ; <label>:73                                      ; preds = %69
   %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
@@ -2645,31 +2727,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %67
+ThrowNullRef8:                                    ; preds = %67
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %69
+ThrowNullRef10:                                   ; preds = %69
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2710,14 +2792,14 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
   %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
@@ -2730,14 +2812,14 @@ entry:
 
 ; <label>:11                                      ; preds = %4
   %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
   %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
@@ -2749,14 +2831,14 @@ entry:
 
 ; <label>:22                                      ; preds = %16
   %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
   %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
-  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
-  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
@@ -2804,23 +2886,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2836,7 +2918,280 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[loadElem]
+Successfully read RuntimeType.IsAssignableFrom
+
+define i8 @RuntimeType.IsAssignableFrom(%System.RuntimeType addrspace(1)* %param0, %System.Type addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.RuntimeType addrspace(1)*
+  %arg1 = alloca %System.Type addrspace(1)*
+  %loc0 = alloca %System.RuntimeType addrspace(1)*
+  %loc1 = alloca %"System.Type[]" addrspace(1)*
+  %loc2 = alloca i32
+  store %System.RuntimeType addrspace(1)* %param0, %System.RuntimeType addrspace(1)** %this
+  store %System.Type addrspace(1)* %param1, %System.Type addrspace(1)** %arg1
+  %0 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %1 = icmp ne %System.Type addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i8 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %5 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %6 = bitcast %System.Type addrspace(1)* %4 to %System.Object addrspace(1)*
+  %7 = bitcast %System.RuntimeType addrspace(1)* %5 to %System.Object addrspace(1)*
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %6, %System.Object addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %3
+  ret i8 1
+
+; <label>:12                                      ; preds = %3
+  %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 152
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 32
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
+  %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
+  %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
+  store %System.RuntimeType addrspace(1)* %25, %System.RuntimeType addrspace(1)** %loc0
+  %26 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %27 = icmp eq %System.RuntimeType addrspace(1)* %26, null
+  br i1 %27, label %34, label %28
+
+; <label>:28                                      ; preds = %15
+  %29 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %30 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)*)*)(%System.RuntimeType addrspace(1)* %29, %System.RuntimeType addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+; <label>:34                                      ; preds = %15
+  %35 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %36 = call %System.Reflection.Emit.TypeBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Reflection.Emit.TypeBuilder addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %35)
+  %37 = icmp eq %System.Reflection.Emit.TypeBuilder addrspace(1)* %36, null
+  br i1 %37, label %139, label %38
+
+; <label>:38                                      ; preds = %34
+  %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %42
+
+; <label>:42                                      ; preds = %38
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 152
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 40
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
+  %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
+  %53 = zext i8 %52 to i32
+  %54 = icmp eq i32 %53, 0
+  br i1 %54, label %56, label %55
+
+; <label>:55                                      ; preds = %42
+  ret i8 1
+
+; <label>:56                                      ; preds = %42
+  %57 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %58 = bitcast %System.RuntimeType addrspace(1)* %57 to %System.Type addrspace(1)*
+  %59 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %58)
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %64 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.Type addrspace(1)* %63, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = bitcast %System.RuntimeType addrspace(1)* %64 to %System.Type addrspace(1)*
+  %67 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %63, %System.Type addrspace(1)* %66)
+  %68 = zext i8 %67 to i32
+  %69 = trunc i32 %68 to i8
+  ret i8 %69
+
+; <label>:70                                      ; preds = %56
+  %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
+  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %73
+
+; <label>:73                                      ; preds = %70
+  %74 = load i64, i64 addrspace(1)* %72
+  %75 = add i64 %74, 128
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = add i64 %77, 0
+  %79 = inttoptr i64 %78 to i64*
+  %80 = load i64, i64* %79
+  %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
+  %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
+  %83 = call i8 %82(%System.Type addrspace(1)* %81)
+  %84 = zext i8 %83 to i32
+  %85 = icmp eq i32 %84, 0
+  br i1 %85, label %139, label %86
+
+; <label>:86                                      ; preds = %73
+  %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
+  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %89
+
+; <label>:89                                      ; preds = %86
+  %90 = load i64, i64 addrspace(1)* %88
+  %91 = add i64 %90, 128
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = add i64 %93, 24
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
+  %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
+  %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
+  store %"System.Type[]" addrspace(1)* %99, %"System.Type[]" addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %129
+
+; <label>:100                                     ; preds = %132
+  %101 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %102 = load i32, i32* %loc2
+  %NullCheck11 = icmp eq %"System.Type[]" addrspace(1)* %101, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %103
+
+; <label>:103                                     ; preds = %100
+  %104 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 1
+  %105 = load i32, i32 addrspace(1)* %104
+  %106 = zext i32 %105 to i64
+  %107 = zext i32 %102 to i64
+  %BoundsCheck = icmp uge i64 %107, %106
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %108
+
+; <label>:108                                     ; preds = %103
+  %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
+  %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
+  %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
+  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %113
+
+; <label>:113                                     ; preds = %108
+  %114 = load i64, i64 addrspace(1)* %112
+  %115 = add i64 %114, 152
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = add i64 %117, 56
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
+  %123 = zext i8 %122 to i32
+  %124 = icmp ne i32 %123, 0
+  br i1 %124, label %126, label %125
+
+; <label>:125                                     ; preds = %113
+  ret i8 0
+
+; <label>:126                                     ; preds = %113
+  %127 = load i32, i32* %loc2
+  %128 = add i32 %127, 1
+  store i32 %128, i32* %loc2
+  br label %129
+
+; <label>:129                                     ; preds = %89, %126
+  %130 = load i32, i32* %loc2
+  %131 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %NullCheck9 = icmp eq %"System.Type[]" addrspace(1)* %131, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %132
+
+; <label>:132                                     ; preds = %129
+  %133 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %131, i32 0, i32 1
+  %134 = load i32, i32 addrspace(1)* %133
+  %135 = zext i32 %134 to i64
+  %136 = trunc i64 %135 to i32
+  %137 = icmp slt i32 %130, %136
+  br i1 %137, label %100, label %138
+
+; <label>:138                                     ; preds = %132
+  ret i8 1
+
+; <label>:139                                     ; preds = %34, %73
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %129
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %103
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -2893,7 +3248,7 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElem]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -2904,8 +3259,8 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -2997,8 +3352,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
@@ -3059,8 +3414,8 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -3087,8 +3442,8 @@ entry:
 
 ; <label>:17                                      ; preds = %5, %11
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
@@ -3097,8 +3452,8 @@ entry:
 
 ; <label>:22                                      ; preds = %1, %11
   %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
@@ -3109,11 +3464,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %17
+ThrowNullRef2:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %22
+ThrowNullRef4:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3167,15 +3522,15 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
   %15 = load i32, i32 addrspace(1)* %14
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
@@ -3198,7 +3553,7 @@ ThrowNullRef:                                     ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef2:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3232,8 +3587,8 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
@@ -3312,8 +3667,8 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -3327,8 +3682,8 @@ entry:
 ; <label>:5                                       ; preds = %43
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %7 = load i32, i32* %loc1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck6, label %8, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
@@ -3366,8 +3721,8 @@ entry:
 ; <label>:32                                      ; preds = %21, %25
   %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
   %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
-  br i1 %NullCheck8, label %35, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = trunc i32 %34 to i16
@@ -3380,8 +3735,8 @@ entry:
 ; <label>:40                                      ; preds = %1, %35
   %41 = load i32, i32* %loc1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
-  br i1 %NullCheck2, label %43, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %42, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
@@ -3392,8 +3747,8 @@ entry:
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
   %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
-  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
   %51 = load i64, i64 addrspace(1)* %49
@@ -3412,19 +3767,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %40
+ThrowNullRef2:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %47
+ThrowNullRef4:                                    ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %5
+ThrowNullRef6:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %32
+ThrowNullRef8:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3467,8 +3822,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
@@ -3492,11 +3847,391 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(i16* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store i16* %param0, i16** %arg0
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load i32, i32* %arg3
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %42, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %37, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg2
+  %13 = load i32, i32* %arg3
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %37, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %24 = load i32, i32* %arg2
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load i16*, i16** %arg0
+  %35 = load i32, i32* %arg3
+  %36 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %36, i16* %34, i32 %35)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:37                                      ; preds = %5, %16
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %39)
+  %41 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41, %System.String addrspace(1)* %38, %System.String addrspace(1)* %40)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41) #0
+  unreachable
+
+; <label>:42                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
-Failed to read StringBuilder.ToString[loadElemA]
+Successfully read StringBuilder.ToString
+
+define %System.String addrspace(1)* @StringBuilder.ToString(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i16*
+  %loc3 = alloca %"System.Char[]" addrspace(1)*
+  %loc4 = alloca i32
+  %loc5 = alloca i32
+  %loc6 = alloca i16 addrspace(1)*
+  %loc7 = alloca %System.String addrspace(1)*
+  %loc8 = alloca %"System.Char[]" addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %0)
+  %2 = icmp ne i32 %1, 0
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %4
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %6)
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %7)
+  store %System.String addrspace(1)* %8, %System.String addrspace(1)** %loc0
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.Text.StringBuilder addrspace(1)* %9, %System.Text.StringBuilder addrspace(1)** %loc1
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  store %System.String addrspace(1)* %10, %System.String addrspace(1)** %loc7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc7
+  %12 = ptrtoint %System.String addrspace(1)* %11 to i64
+  %13 = icmp eq i64 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %5
+  %15 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %16 = sext i32 %15 to i64
+  %17 = add i64 %12, %16
+  br label %18
+
+; <label>:18                                      ; preds = %5, %14
+  %19 = phi i64 [ %12, %5 ], [ %17, %14 ]
+  %20 = inttoptr i64 %19 to i16*
+  store i16* %20, i16** %loc2
+  br label %21
+
+; <label>:21                                      ; preds = %98, %18
+  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %22, null
+  br i1 %NullCheck, label %ThrowNullRef, label %23
+
+; <label>:23                                      ; preds = %21
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 3
+  %25 = load i32, i32 addrspace(1)* %24, align 8
+  %26 = icmp sle i32 %25, 0
+  br i1 %26, label %96, label %27
+
+; <label>:27                                      ; preds = %23
+  %28 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %28, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %29
+
+; <label>:29                                      ; preds = %27
+  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %28, i32 0, i32 1
+  %31 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %30, align 8
+  store %"System.Char[]" addrspace(1)* %31, %"System.Char[]" addrspace(1)** %loc3
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %33
+
+; <label>:33                                      ; preds = %29
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  store i32 %35, i32* %loc4
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  %39 = load i32, i32 addrspace(1)* %38, align 8
+  store i32 %39, i32* %loc5
+  %40 = load i32, i32* %loc5
+  %41 = load i32, i32* %loc4
+  %42 = add i32 %40, %41
+  %43 = zext i32 %42 to i64
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %45
+
+; <label>:45                                      ; preds = %37
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = sext i32 %47 to i64
+  %49 = icmp sgt i64 %43, %48
+  br i1 %49, label %91, label %50
+
+; <label>:50                                      ; preds = %45
+  %51 = load i32, i32* %loc5
+  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %52, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %53
+
+; <label>:53                                      ; preds = %50
+  %54 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %52, i32 0, i32 1
+  %55 = load i32, i32 addrspace(1)* %54
+  %56 = zext i32 %55 to i64
+  %57 = trunc i64 %56 to i32
+  %58 = icmp ugt i32 %51, %57
+  br i1 %58, label %91, label %59
+
+; <label>:59                                      ; preds = %53
+  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  store %"System.Char[]" addrspace(1)* %60, %"System.Char[]" addrspace(1)** %loc8
+  %61 = icmp eq %"System.Char[]" addrspace(1)* %60, null
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %63, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %64
+
+; <label>:64                                      ; preds = %62
+  %65 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %63, i32 0, i32 1
+  %66 = load i32, i32 addrspace(1)* %65
+  %67 = zext i32 %66 to i64
+  %68 = trunc i64 %67 to i32
+  %69 = icmp ne i32 %68, 0
+  br i1 %69, label %71, label %70
+
+; <label>:70                                      ; preds = %59, %64
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:71                                      ; preds = %64
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %73
+
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %BoundsCheck = icmp uge i64 0, %76
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %77
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %78, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:79                                      ; preds = %70, %77
+  %80 = load i16*, i16** %loc2
+  %81 = load i32, i32* %loc4
+  %82 = sext i32 %81 to i64
+  %83 = mul i64 %82, 2
+  %84 = bitcast i16* %80 to i8*
+  %85 = getelementptr inbounds i8, i8* %84, i64 %83
+  %86 = load i16 addrspace(1)*, i16 addrspace(1)** %loc6
+  %87 = ptrtoint i16 addrspace(1)* %86 to i64
+  %88 = load i32, i32* %loc5
+  %89 = bitcast i8* %85 to i16*
+  %90 = inttoptr i64 %87 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %89, i16* %90, i32 %88)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %96
+
+; <label>:91                                      ; preds = %45, %53
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %94 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %93)
+  %95 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95, %System.String addrspace(1)* %92, %System.String addrspace(1)* %94)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95) #0
+  unreachable
+
+; <label>:96                                      ; preds = %23, %79
+  %97 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %97, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %98
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %97, i32 0, i32 2
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  store %System.Text.StringBuilder addrspace(1)* %100, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %102 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %102, label %21, label %103
+
+; <label>:103                                     ; preds = %98
+  store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc7
+  %104 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  ret %System.String addrspace(1)* %104
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method StringBuilder::get_Length using LLILCJit
+Successfully read StringBuilder.get_Length
+
+define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
+Successfully read RuntimeHelpers.get_OffsetToStringData
+
+define i32 @RuntimeHelpers.get_OffsetToStringData() {
+entry:
+  ret i32 12
+}
+
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
 Successfully read CultureData.CreateCultureData
 
@@ -3514,23 +4249,23 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
   store i8 %4, i8 addrspace(1)* %6
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
@@ -3549,11 +4284,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3566,50 +4301,50 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
   store i32 -1, i32 addrspace(1)* %2
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
   store i32 -1, i32 addrspace(1)* %8
   %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
   store i32 -1, i32 addrspace(1)* %14
   %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
   store i32 -1, i32 addrspace(1)* %17
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
@@ -3623,27 +4358,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3675,7 +4410,136 @@ Failed to read Dictionary`2.Insert[non-const derefAddress]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
 Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
-Failed to read HashHelpers.GetPrime[loadElem]
+Successfully read HashHelpers.GetPrime
+
+define i32 @HashHelpers.GetPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %6, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5, %System.String addrspace(1)* %4)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5) #0
+  unreachable
+
+; <label>:6                                       ; preds = %entry
+  store i32 0, i32* %loc0
+  br label %29
+
+; <label>:7                                       ; preds = %35
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 1296
+  %10 = addrspacecast i8 addrspace(1)* %9 to %"System.Int32[]" addrspace(1)**
+  %11 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %10
+  %12 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Int32[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = zext i32 %15 to i64
+  %17 = zext i32 %12 to i64
+  %BoundsCheck = icmp uge i64 %17, %16
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 3, i32 %12
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  store i32 %20, i32* %loc1
+  %21 = load i32, i32* %loc1
+  %22 = load i32, i32* %arg0
+  %23 = icmp slt i32 %21, %22
+  br i1 %23, label %26, label %24
+
+; <label>:24                                      ; preds = %18
+  %25 = load i32, i32* %loc1
+  ret i32 %25
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %loc0
+  %28 = add i32 %27, 1
+  store i32 %28, i32* %loc0
+  br label %29
+
+; <label>:29                                      ; preds = %6, %26
+  %30 = load i32, i32* %loc0
+  %31 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %32 = getelementptr inbounds i8, i8 addrspace(1)* %31, i64 1296
+  %33 = addrspacecast i8 addrspace(1)* %32 to %"System.Int32[]" addrspace(1)**
+  %34 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %33
+  %NullCheck = icmp eq %"System.Int32[]" addrspace(1)* %34, null
+  br i1 %NullCheck, label %ThrowNullRef, label %35
+
+; <label>:35                                      ; preds = %29
+  %36 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %34, i32 0, i32 1
+  %37 = load i32, i32 addrspace(1)* %36
+  %38 = zext i32 %37 to i64
+  %39 = trunc i64 %38 to i32
+  %40 = icmp slt i32 %30, %39
+  br i1 %40, label %7, label %41
+
+; <label>:41                                      ; preds = %35
+  %42 = load i32, i32* %arg0
+  %43 = or i32 %42, 1
+  store i32 %43, i32* %loc2
+  br label %59
+
+; <label>:44                                      ; preds = %59
+  %45 = load i32, i32* %loc2
+  %46 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %45)
+  %47 = zext i8 %46 to i32
+  %48 = icmp eq i32 %47, 0
+  br i1 %48, label %56, label %49
+
+; <label>:49                                      ; preds = %44
+  %50 = load i32, i32* %loc2
+  %51 = sub i32 %50, 1
+  %52 = srem i32 %51, 101
+  %53 = icmp eq i32 %52, 0
+  br i1 %53, label %56, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = load i32, i32* %loc2
+  ret i32 %55
+
+; <label>:56                                      ; preds = %44, %49
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %57, 2
+  store i32 %58, i32* %loc2
+  br label %59
+
+; <label>:59                                      ; preds = %41, %56
+  %60 = load i32, i32* %loc2
+  %61 = icmp slt i32 %60, 2147483647
+  br i1 %61, label %44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load i32, i32* %arg0
+  ret i32 %63
+
+ThrowNullRef:                                     ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
 Successfully read GenericEqualityComparer`1.GetHashCode
 
@@ -3694,14 +4558,14 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
   %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load i64, i64 addrspace(1)* %7
@@ -3720,7 +4584,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3750,8 +4614,8 @@ entry:
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
@@ -3796,8 +4660,8 @@ entry:
   %35 = bitcast i16* %34 to i8*
   %36 = getelementptr inbounds i8, i8* %35, i64 2
   %37 = bitcast i8* %36 to i16*
-  %NullCheck4 = icmp ne i16* %37, null
-  br i1 %NullCheck4, label %38, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %37, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %38
 
 ; <label>:38                                      ; preds = %27
   %39 = load i16, i16* %37, align 8
@@ -3824,8 +4688,8 @@ entry:
 
 ; <label>:54                                      ; preds = %22, %43
   %55 = load i16*, i16** %loc4
-  %NullCheck2 = icmp ne i16* %55, null
-  br i1 %NullCheck2, label %56, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i16* %55, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %56
 
 ; <label>:56                                      ; preds = %54
   %57 = load i16, i16* %55, align 8
@@ -3850,11 +4714,11 @@ ThrowNullRef:                                     ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %54
+ThrowNullRef2:                                    ; preds = %54
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %27
+ThrowNullRef4:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3871,8 +4735,8 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -3907,8 +4771,8 @@ entry:
 
 ; <label>:26                                      ; preds = %19
   %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
-  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %28
 
 ; <label>:28                                      ; preds = %26
   %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
@@ -3920,7 +4784,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3972,8 +4836,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
@@ -3984,26 +4848,26 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
-  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
@@ -4014,8 +4878,8 @@ entry:
 ; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
@@ -4024,8 +4888,8 @@ entry:
 
 ; <label>:25                                      ; preds = %1, %16, %23
   %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
-  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
@@ -4036,27 +4900,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %20
+ThrowNullRef10:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4069,8 +4933,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -4081,8 +4945,8 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
@@ -4091,8 +4955,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1, %8
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
@@ -4103,11 +4967,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4128,24 +4992,24 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   store i32 %3, i32* %loc0
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
   %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
   store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck4, label %9, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
@@ -4164,15 +5028,15 @@ entry:
 ; <label>:18                                      ; preds = %70
   %19 = load i16*, i16** %loc3
   %20 = bitcast i16* %19 to i64*
-  %NullCheck10 = icmp ne i64* %20, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %20, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = load i64, i64* %20, align 8
   %23 = load i16*, i16** %loc4
   %24 = bitcast i16* %23 to i64*
-  %NullCheck12 = icmp ne i64* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = load i64, i64* %24, align 8
@@ -4188,8 +5052,8 @@ entry:
   %31 = bitcast i16* %30 to i8*
   %32 = getelementptr inbounds i8, i8* %31, i64 8
   %33 = bitcast i8* %32 to i64*
-  %NullCheck14 = icmp ne i64* %33, null
-  br i1 %NullCheck14, label %34, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = load i64, i64* %33, align 8
@@ -4197,8 +5061,8 @@ entry:
   %37 = bitcast i16* %36 to i8*
   %38 = getelementptr inbounds i8, i8* %37, i64 8
   %39 = bitcast i8* %38 to i64*
-  %NullCheck16 = icmp ne i64* %39, null
-  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %40
 
 ; <label>:40                                      ; preds = %34
   %41 = load i64, i64* %39, align 8
@@ -4214,8 +5078,8 @@ entry:
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %NullCheck18 = icmp ne i64* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = load i64, i64* %48, align 8
@@ -4223,8 +5087,8 @@ entry:
   %52 = bitcast i16* %51 to i8*
   %53 = getelementptr inbounds i8, i8* %52, i64 16
   %54 = bitcast i8* %53 to i64*
-  %NullCheck20 = icmp ne i64* %54, null
-  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64* %54, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %55
 
 ; <label>:55                                      ; preds = %49
   %56 = load i64, i64* %54, align 8
@@ -4262,15 +5126,15 @@ entry:
 ; <label>:74                                      ; preds = %95
   %75 = load i16*, i16** %loc3
   %76 = bitcast i16* %75 to i32*
-  %NullCheck6 = icmp ne i32* %76, null
-  br i1 %NullCheck6, label %77, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32* %76, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %77
 
 ; <label>:77                                      ; preds = %74
   %78 = load i32, i32* %76, align 8
   %79 = load i16*, i16** %loc4
   %80 = bitcast i16* %79 to i32*
-  %NullCheck8 = icmp ne i32* %80, null
-  br i1 %NullCheck8, label %81, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i32* %80, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %81
 
 ; <label>:81                                      ; preds = %77
   %82 = load i32, i32* %80, align 8
@@ -4318,43 +5182,43 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %74
+ThrowNullRef6:                                    ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %77
+ThrowNullRef8:                                    ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %29
+ThrowNullRef14:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %34
+ThrowNullRef16:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4376,8 +5240,8 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load i64, i64 addrspace(1)* %4
@@ -4389,8 +5253,8 @@ entry:
   %12 = load i64, i64* %11
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %5
   %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
@@ -4399,8 +5263,8 @@ entry:
   %18 = load i8, i8* %arg2
   %19 = zext i8 %18 to i32
   %20 = trunc i32 %19 to i8
-  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %15
   %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
@@ -4411,11 +5275,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4442,8 +5306,8 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
@@ -4466,16 +5330,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
   %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = load i64, i64 addrspace(1)* %19
@@ -4500,8 +5364,8 @@ entry:
 ; <label>:35                                      ; preds = %30
   %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
@@ -4514,8 +5378,8 @@ entry:
 
 ; <label>:42                                      ; preds = %1, %38
   %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
-  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
@@ -4526,19 +5390,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %35
+ThrowNullRef2:                                    ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %42
+ThrowNullRef8:                                    ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4551,14 +5415,14 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
@@ -4570,7 +5434,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4583,8 +5447,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
@@ -4613,51 +5477,51 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
   %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
   %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
   %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
   %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
-  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
   store i64 %21, i64 addrspace(1)* %23
   %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %25 = load i64, i64* %loc0
-  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
@@ -4668,27 +5532,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %22
+ThrowNullRef12:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4701,8 +5565,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
@@ -4713,19 +5577,19 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
@@ -4734,8 +5598,8 @@ entry:
 
 ; <label>:15                                      ; preds = %1, %13
   %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
@@ -4746,19 +5610,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %15
+ThrowNullRef8:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4771,8 +5635,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -4831,8 +5695,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
@@ -4882,8 +5746,8 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
-  br i1 %NullCheck, label %17, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %ThrowNullRef, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
@@ -4894,15 +5758,15 @@ entry:
 
 ; <label>:22                                      ; preds = %17
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
-  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
   %26 = load i32, i32 addrspace(1)* %25
   %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
-  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %27, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
@@ -4925,8 +5789,8 @@ entry:
 ; <label>:40                                      ; preds = %17
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
-  br i1 %NullCheck6, label %43, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %41, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
@@ -4938,34 +5802,17 @@ ThrowNullRef:                                     ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %24
+ThrowNullRef4:                                    ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %40
+ThrowNullRef6:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
-}
-
-INFO:  jitting method Object::ReferenceEquals using LLILCJit
-Successfully read Object.ReferenceEquals
-
-define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
-entry:
-  %arg0 = alloca %System.Object addrspace(1)*
-  %arg1 = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
-  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
-  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = icmp eq %System.Object addrspace(1)* %0, %1
-  %3 = sext i1 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
 }
 
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
@@ -4978,21 +5825,21 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
   %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
-  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
@@ -5007,28 +5854,28 @@ entry:
 ; <label>:13                                      ; preds = %8, %12
   %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
   %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
   %21 = load i32, i32 addrspace(1)* %20, align 8
   %22 = add i32 %21, 1
-  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
   store i32 %22, i32 addrspace(1)* %24
   %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
@@ -5039,27 +5886,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5077,7 +5924,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::Setup using LLILCJit
-Failed to read AppDomain.Setup[loadElem]
+Failed to read AppDomain.Setup[unbox]
 INFO:  jitting method Thread::GetDomain using LLILCJit
 Successfully read Thread.GetDomain
 
@@ -5108,8 +5955,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
@@ -5122,14 +5969,14 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
   %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
@@ -5141,11 +5988,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5173,8 +6020,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -5189,7 +6036,328 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
 Failed to read KeyCollection.System.Collections.Generic.IEnumerable<TKey>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Successfully read Enumerator.MoveNext
+
+define i8 @Enumerator.MoveNext(%"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.RuntimeTypeHandle* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*
+  %"$TypeArg" = alloca %System.RuntimeTypeHandle*
+  store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
+  %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 8
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %76, label %12
+
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
+  br label %76
+
+; <label>:13                                      ; preds = %85
+  %14 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck19 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %15
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, i32 0, i32 0
+  %17 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %16, align 8
+  %NullCheck21 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, i32 0, i32 2
+  %20 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %19, align 8
+  %21 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck23 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %22
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, i32 0, i32 2
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %NullCheck25 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 3, i32 %24
+  %NullCheck27 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %32
+
+; <label>:32                                      ; preds = %30
+  %33 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, i32 0, i32 2
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = icmp slt i32 %34, 0
+  br i1 %35, label %68, label %36
+
+; <label>:36                                      ; preds = %32
+  %37 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %38 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck29 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %39
+
+; <label>:39                                      ; preds = %36
+  %40 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, i32 0, i32 0
+  %41 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %40, align 8
+  %NullCheck31 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, i32 0, i32 2
+  %44 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %43, align 8
+  %45 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck33 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, i32 0, i32 2
+  %48 = load i32, i32 addrspace(1)* %47, align 8
+  %NullCheck35 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %49
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = zext i32 %51 to i64
+  %53 = zext i32 %48 to i64
+  %BoundsCheck37 = icmp uge i64 %53, %52
+  br i1 %BoundsCheck37, label %ThrowIndexOutOfRange38, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 3, i32 %48
+  %NullCheck39 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %56
+
+; <label>:56                                      ; preds = %54
+  %57 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, i32 0, i32 0
+  %58 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck41 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %59
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %60, %System.__Canon addrspace(1)* %58)
+  %61 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck43 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  %64 = load i32, i32 addrspace(1)* %63, align 8
+  %65 = add i32 %64, 1
+  %NullCheck45 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  store i32 %65, i32 addrspace(1)* %67
+  ret i8 1
+
+; <label>:68                                      ; preds = %32
+  %69 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck47 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %73 = add i32 %72, 1
+  %NullCheck49 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %74
+
+; <label>:74                                      ; preds = %70
+  %75 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  store i32 %73, i32 addrspace(1)* %75
+  br label %76
+
+; <label>:76                                      ; preds = %8, %12, %74
+  %77 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %78
+
+; <label>:78                                      ; preds = %76
+  %79 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, i32 0, i32 2
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck7 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %82
+
+; <label>:82                                      ; preds = %78
+  %83 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, i32 0, i32 0
+  %84 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %83, align 8
+  %NullCheck9 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %85
+
+; <label>:85                                      ; preds = %82
+  %86 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, i32 0, i32 7
+  %87 = load i32, i32 addrspace(1)* %86, align 8
+  %88 = icmp ult i32 %80, %87
+  br i1 %88, label %13, label %89
+
+; <label>:89                                      ; preds = %85
+  %90 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %91 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck11 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %92
+
+; <label>:92                                      ; preds = %89
+  %93 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, i32 0, i32 0
+  %94 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck13 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %95
+
+; <label>:95                                      ; preds = %92
+  %96 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, i32 0, i32 7
+  %97 = load i32, i32 addrspace(1)* %96, align 8
+  %98 = add i32 %97, 1
+  %NullCheck15 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %99
+
+; <label>:99                                      ; preds = %95
+  %100 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, i32 0, i32 2
+  store i32 %98, i32 addrspace(1)* %100
+  %101 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck17 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %102
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %103, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %92
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef22:                                   ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef24:                                   ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef26:                                   ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef28:                                   ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef30:                                   ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef32:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef34:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef36:                                   ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange38:                           ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef40:                                   ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef42:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef44:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef46:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef48:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef50:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -5200,8 +6368,8 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -5232,9 +6400,9 @@ Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
 Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
-Failed to read String.MakeSeparatorList[loadElemA]
+Failed to read String.MakeSeparatorList[storeElem]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
-Failed to read String.InternalSplitKeepEmptyEntries[loadElem]
+Failed to read String.InternalSplitKeepEmptyEntries[storeElem]
 INFO:  jitting method Path::IsRelative using LLILCJit
 Successfully read Path.IsRelative
 
@@ -5243,8 +6411,8 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -5254,8 +6422,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
@@ -5271,8 +6439,8 @@ entry:
 
 ; <label>:17                                      ; preds = %7
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
@@ -5288,8 +6456,8 @@ entry:
 
 ; <label>:29                                      ; preds = %19
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %31
 
 ; <label>:31                                      ; preds = %29
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
@@ -5300,8 +6468,8 @@ entry:
 
 ; <label>:36                                      ; preds = %31
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
-  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %37, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
@@ -5312,8 +6480,8 @@ entry:
 
 ; <label>:43                                      ; preds = %31, %38
   %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
-  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %45
 
 ; <label>:45                                      ; preds = %43
   %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
@@ -5324,8 +6492,8 @@ entry:
 
 ; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %50
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
@@ -5336,8 +6504,8 @@ entry:
 
 ; <label>:57                                      ; preds = %1, %7, %19, %45, %52
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
-  br i1 %NullCheck14, label %59, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %59
 
 ; <label>:59                                      ; preds = %57
   %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
@@ -5347,8 +6515,8 @@ entry:
 
 ; <label>:63                                      ; preds = %59
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
@@ -5359,8 +6527,8 @@ entry:
 
 ; <label>:70                                      ; preds = %65
   %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
-  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.String addrspace(1)* %71, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %72
 
 ; <label>:72                                      ; preds = %70
   %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
@@ -5379,39 +6547,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %17
+ThrowNullRef4:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %29
+ThrowNullRef6:                                    ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %36
+ThrowNullRef8:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %43
+ThrowNullRef10:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %50
+ThrowNullRef12:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %57
+ThrowNullRef14:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %63
+ThrowNullRef16:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %70
+ThrowNullRef18:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5419,7 +6587,293 @@ ThrowNullRef17:                                   ; preds = %70
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
-Failed to read String.TrimHelper[loadElem]
+Successfully read String.TrimHelper
+
+define %System.String addrspace(1)* @String.TrimHelper(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i16
+  %loc4 = alloca i32
+  %loc5 = alloca i16
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = sub i32 %3, 1
+  store i32 %4, i32* %loc0
+  store i32 0, i32* %loc1
+  %5 = load i32, i32* %arg2
+  %6 = icmp eq i32 %5, 1
+  br i1 %6, label %62, label %7
+
+; <label>:7                                       ; preds = %1
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:8                                       ; preds = %58
+  store i32 0, i32* %loc2
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load i32, i32* %loc1
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2, i32 %10
+  %13 = load i16, i16 addrspace(1)* %12
+  %14 = zext i16 %13 to i32
+  %15 = trunc i32 %14 to i16
+  store i16 %15, i16* %loc3
+  store i32 0, i32* %loc2
+  br label %34
+
+; <label>:16                                      ; preds = %37
+  %17 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %18 = load i32, i32* %loc2
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %17, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %19
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = zext i32 %18 to i64
+  %BoundsCheck = icmp uge i64 %23, %22
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %24
+
+; <label>:24                                      ; preds = %19
+  %25 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 3, i32 %18
+  %26 = load i16, i16 addrspace(1)* %25, align 8
+  %27 = zext i16 %26 to i32
+  %28 = load i16, i16* %loc3
+  %29 = zext i16 %28 to i32
+  %30 = icmp eq i32 %27, %29
+  br i1 %30, label %43, label %31
+
+; <label>:31                                      ; preds = %24
+  %32 = load i32, i32* %loc2
+  %33 = add i32 %32, 1
+  store i32 %33, i32* %loc2
+  br label %34
+
+; <label>:34                                      ; preds = %11, %31
+  %35 = load i32, i32* %loc2
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = icmp slt i32 %35, %41
+  br i1 %42, label %16, label %43
+
+; <label>:43                                      ; preds = %24, %37
+  %44 = load i32, i32* %loc2
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %45, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp eq i32 %44, %50
+  br i1 %51, label %62, label %52
+
+; <label>:52                                      ; preds = %46
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %7, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %57, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %58
+
+; <label>:58                                      ; preds = %55
+  %59 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %60 = load i32, i32 addrspace(1)* %59
+  %61 = icmp slt i32 %56, %60
+  br i1 %61, label %8, label %62
+
+; <label>:62                                      ; preds = %1, %46, %58
+  %63 = load i32, i32* %arg2
+  %64 = icmp eq i32 %63, 0
+  br i1 %64, label %122, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %66, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %67
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %66, i32 0, i32 1
+  %69 = load i32, i32 addrspace(1)* %68
+  %70 = sub i32 %69, 1
+  store i32 %70, i32* %loc0
+  br label %118
+
+; <label>:71                                      ; preds = %118
+  store i32 0, i32* %loc4
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %73 = load i32, i32* %loc0
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %74
+
+; <label>:74                                      ; preds = %71
+  %75 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 2, i32 %73
+  %76 = load i16, i16 addrspace(1)* %75
+  %77 = zext i16 %76 to i32
+  %78 = trunc i32 %77 to i16
+  store i16 %78, i16* %loc5
+  store i32 0, i32* %loc4
+  br label %97
+
+; <label>:79                                      ; preds = %100
+  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %81 = load i32, i32* %loc4
+  %NullCheck19 = icmp eq %"System.Char[]" addrspace(1)* %80, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
+
+; <label>:82                                      ; preds = %79
+  %83 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 1
+  %84 = load i32, i32 addrspace(1)* %83
+  %85 = zext i32 %84 to i64
+  %86 = zext i32 %81 to i64
+  %BoundsCheck21 = icmp uge i64 %86, %85
+  br i1 %BoundsCheck21, label %ThrowIndexOutOfRange22, label %87
+
+; <label>:87                                      ; preds = %82
+  %88 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 3, i32 %81
+  %89 = load i16, i16 addrspace(1)* %88, align 8
+  %90 = zext i16 %89 to i32
+  %91 = load i16, i16* %loc5
+  %92 = zext i16 %91 to i32
+  %93 = icmp eq i32 %90, %92
+  br i1 %93, label %106, label %94
+
+; <label>:94                                      ; preds = %87
+  %95 = load i32, i32* %loc4
+  %96 = add i32 %95, 1
+  store i32 %96, i32* %loc4
+  br label %97
+
+; <label>:97                                      ; preds = %74, %94
+  %98 = load i32, i32* %loc4
+  %99 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck15 = icmp eq %"System.Char[]" addrspace(1)* %99, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %100
+
+; <label>:100                                     ; preds = %97
+  %101 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %99, i32 0, i32 1
+  %102 = load i32, i32 addrspace(1)* %101
+  %103 = zext i32 %102 to i64
+  %104 = trunc i64 %103 to i32
+  %105 = icmp slt i32 %98, %104
+  br i1 %105, label %79, label %106
+
+; <label>:106                                     ; preds = %87, %100
+  %107 = load i32, i32* %loc4
+  %108 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck17 = icmp eq %"System.Char[]" addrspace(1)* %108, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %109
+
+; <label>:109                                     ; preds = %106
+  %110 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %108, i32 0, i32 1
+  %111 = load i32, i32 addrspace(1)* %110
+  %112 = zext i32 %111 to i64
+  %113 = trunc i64 %112 to i32
+  %114 = icmp eq i32 %107, %113
+  br i1 %114, label %122, label %115
+
+; <label>:115                                     ; preds = %109
+  %116 = load i32, i32* %loc0
+  %117 = sub i32 %116, 1
+  store i32 %117, i32* %loc0
+  br label %118
+
+; <label>:118                                     ; preds = %67, %115
+  %119 = load i32, i32* %loc0
+  %120 = load i32, i32* %loc1
+  %121 = icmp sge i32 %119, %120
+  br i1 %121, label %71, label %122
+
+; <label>:122                                     ; preds = %62, %109, %118
+  %123 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %124 = load i32, i32* %loc1
+  %125 = load i32, i32* %loc0
+  %126 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %123, i32 %124, i32 %125)
+  ret %System.String addrspace(1)* %126
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %97
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange22:                           ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
 Successfully read String.CreateTrimmedString
 
@@ -5439,8 +6893,8 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
@@ -5535,8 +6989,8 @@ entry:
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i64 2872
   %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
   %8 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %7
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %3
   %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
@@ -5553,8 +7007,8 @@ entry:
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 2864
   %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
   %21 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %20
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
-  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %22
 
 ; <label>:22                                      ; preds = %16
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
@@ -5569,7 +7023,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %16
+ThrowNullRef2:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5586,8 +7040,8 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5613,8 +7067,8 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
@@ -5632,8 +7086,8 @@ entry:
 
 ; <label>:12                                      ; preds = %4
   %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
@@ -5644,8 +7098,8 @@ entry:
 
 ; <label>:19                                      ; preds = %14
   %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %19
   %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
@@ -5660,21 +7114,21 @@ entry:
   %31 = zext i16 %30 to i32
   %32 = bitcast i8* %29 to i16*
   %33 = trunc i32 %31 to i16
-  %NullCheck6 = icmp ne i16* %32, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i16* %32, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %21
   store i16 %33, i16* %32, align 8
   %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %36
 
 ; <label>:36                                      ; preds = %34
   %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
   %38 = load i32, i32 addrspace(1)* %37, align 8
   %39 = add i32 %38, 1
-  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %40
 
 ; <label>:40                                      ; preds = %36
   %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
@@ -5683,16 +7137,16 @@ entry:
 
 ; <label>:42                                      ; preds = %14
   %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
-  br i1 %NullCheck12, label %44, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
   %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
   %47 = load i16, i16* %arg1
   %48 = zext i16 %47 to i32
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = trunc i32 %48 to i16
@@ -5703,31 +7157,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %19
+ThrowNullRef4:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %21
+ThrowNullRef6:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %36
+ThrowNullRef10:                                   ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %42
+ThrowNullRef12:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %44
+ThrowNullRef14:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5740,8 +7194,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -5752,8 +7206,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
@@ -5762,14 +7216,14 @@ entry:
 
 ; <label>:11                                      ; preds = %1
   %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
@@ -5779,15 +7233,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5808,8 +7262,8 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5822,8 +7276,8 @@ entry:
 
 ; <label>:8                                       ; preds = %3
   %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
@@ -5842,15 +7296,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
-  br i1 %NullCheck4, label %22, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
   %24 = load i16*, i16* addrspace(1)* %23, align 8
   %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %25, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
@@ -5859,8 +7313,8 @@ entry:
   store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
@@ -5874,8 +7328,8 @@ entry:
 
 ; <label>:37                                      ; preds = %65
   %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %37
   %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
@@ -5886,16 +7340,16 @@ entry:
   %45 = bitcast i16* %41 to i8*
   %46 = getelementptr inbounds i8, i8* %45, i64 %44
   %47 = bitcast i8* %46 to i16*
-  %NullCheck14 = icmp ne i16* %47, null
-  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %47, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %48
 
 ; <label>:48                                      ; preds = %39
   %49 = load i16, i16* %47, align 8
   %50 = zext i16 %49 to i32
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %52 = load i32, i32* %loc1
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %53
 
 ; <label>:53                                      ; preds = %48
   %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
@@ -5916,8 +7370,8 @@ entry:
 ; <label>:62                                      ; preds = %36, %59
   %63 = load i32, i32* %loc1
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck10, label %65, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %65
 
 ; <label>:65                                      ; preds = %62
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
@@ -5936,15 +7390,15 @@ entry:
 
 ; <label>:74                                      ; preds = %70
   %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
-  br i1 %NullCheck18, label %76, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %76
 
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
   %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
-  br i1 %NullCheck20, label %80, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
   %81 = load i64, i64 addrspace(1)* %79
@@ -5958,8 +7412,8 @@ entry:
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
   %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
-  br i1 %NullCheck22, label %92, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.String addrspace(1)* %90, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %92
 
 ; <label>:92                                      ; preds = %80
   %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
@@ -5969,15 +7423,15 @@ entry:
 
 ; <label>:96                                      ; preds = %70
   %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
-  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %98
 
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
   %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
-  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
   %103 = load i64, i64 addrspace(1)* %101
@@ -5991,8 +7445,8 @@ entry:
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
   %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
-  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.String addrspace(1)* %112, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %114
 
 ; <label>:114                                     ; preds = %102
   %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
@@ -6004,59 +7458,59 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %20
+ThrowNullRef4:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %22
+ThrowNullRef6:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %26
+ThrowNullRef8:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %62
+ThrowNullRef10:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %48
+ThrowNullRef16:                                   ; preds = %48
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %74
+ThrowNullRef18:                                   ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %76
+ThrowNullRef20:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %80
+ThrowNullRef22:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %96
+ThrowNullRef24:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %98
+ThrowNullRef26:                                   ; preds = %98
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %102
+ThrowNullRef28:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6069,15 +7523,15 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
   %3 = load i16*, i16* addrspace(1)* %2, align 8
   %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
@@ -6087,8 +7541,8 @@ entry:
   %10 = bitcast i16* %3 to i8*
   %11 = getelementptr inbounds i8, i8* %10, i64 %9
   %12 = bitcast i8* %11 to i16*
-  %NullCheck4 = icmp ne i16* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %5
   store i16 0, i16* %12, align 8
@@ -6098,11 +7552,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6119,8 +7573,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -6131,8 +7585,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
@@ -6144,15 +7598,15 @@ entry:
 
 ; <label>:14                                      ; preds = %1
   %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
   %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
   %21 = load i64, i64 addrspace(1)* %19
@@ -6171,15 +7625,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %14
+ThrowNullRef4:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %16
+ThrowNullRef6:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6302,14 +7756,6 @@ entry:
   ret %System.String addrspace(1)* %57
 }
 
-INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
-Successfully read RuntimeHelpers.get_OffsetToStringData
-
-define i32 @RuntimeHelpers.get_OffsetToStringData() {
-entry:
-  ret i32 12
-}
-
 INFO:  jitting method String::Equals using LLILCJit
 Successfully read String.Equals
 
@@ -6381,8 +7827,8 @@ entry:
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
-  br i1 %NullCheck24, label %29, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
   %30 = load i64, i64 addrspace(1)* %28
@@ -6397,8 +7843,8 @@ entry:
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
-  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
   %43 = load i64, i64 addrspace(1)* %41
@@ -6418,8 +7864,8 @@ entry:
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
   %59 = load i64, i64 addrspace(1)* %57
@@ -6434,8 +7880,8 @@ entry:
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck22, label %71, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
   %72 = load i64, i64 addrspace(1)* %70
@@ -6455,8 +7901,8 @@ entry:
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
-  br i1 %NullCheck16, label %87, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = load i64, i64 addrspace(1)* %86
@@ -6471,8 +7917,8 @@ entry:
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck18, label %100, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
   %101 = load i64, i64 addrspace(1)* %99
@@ -6492,8 +7938,8 @@ entry:
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
-  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
   %117 = load i64, i64 addrspace(1)* %115
@@ -6508,8 +7954,8 @@ entry:
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
-  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
   %130 = load i64, i64 addrspace(1)* %128
@@ -6528,15 +7974,15 @@ entry:
 
 ; <label>:142                                     ; preds = %22
   %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
-  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %143, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %144
 
 ; <label>:144                                     ; preds = %142
   %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
   %146 = load i32, i32 addrspace(1)* %145
   %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
-  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %147, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %148
 
 ; <label>:148                                     ; preds = %144
   %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
@@ -6557,15 +8003,15 @@ entry:
 
 ; <label>:159                                     ; preds = %22
   %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
-  br i1 %NullCheck, label %161, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %ThrowNullRef, label %161
 
 ; <label>:161                                     ; preds = %159
   %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
   %163 = load i32, i32 addrspace(1)* %162
   %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
-  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %164, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %165
 
 ; <label>:165                                     ; preds = %161
   %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
@@ -6578,8 +8024,8 @@ entry:
 
 ; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
-  br i1 %NullCheck4, label %172, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %171, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %172
 
 ; <label>:172                                     ; preds = %170
   %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
@@ -6589,8 +8035,8 @@ entry:
 
 ; <label>:176                                     ; preds = %172
   %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
-  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %177, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %178
 
 ; <label>:178                                     ; preds = %176
   %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
@@ -6629,55 +8075,55 @@ ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %161
+ThrowNullRef2:                                    ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %170
+ThrowNullRef4:                                    ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %176
+ThrowNullRef6:                                    ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %142
+ThrowNullRef8:                                    ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %144
+ThrowNullRef10:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %113
+ThrowNullRef12:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %116
+ThrowNullRef14:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %84
+ThrowNullRef16:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %87
+ThrowNullRef18:                                   ; preds = %87
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %55
+ThrowNullRef20:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %58
+ThrowNullRef22:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %26
+ThrowNullRef24:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %29
+ThrowNullRef26:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,8 +8161,8 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck, label %14, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %ThrowNullRef, label %14
 
 ; <label>:14                                      ; preds = %8
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
@@ -6760,8 +8206,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
@@ -6770,14 +8216,14 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32, i32* %loc0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %10
   %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
   %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
@@ -6790,15 +8236,15 @@ entry:
 ; <label>:25                                      ; preds = %19
   %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
-  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
   %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
@@ -6807,8 +8253,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %37 = load i32, i32* %loc0
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %38, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %38
 
 ; <label>:38                                      ; preds = %32
   %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
@@ -6817,14 +8263,14 @@ entry:
 
 ; <label>:40                                      ; preds = %19
   %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %40
   %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
   %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
-  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
-  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
@@ -6832,8 +8278,8 @@ entry:
   %48 = zext i32 %47 to i64
   %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
-  br i1 %NullCheck16, label %51, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %51
 
 ; <label>:51                                      ; preds = %45
   %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
@@ -6847,15 +8293,15 @@ entry:
 ; <label>:57                                      ; preds = %51
   %58 = load i16*, i16** %arg1
   %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
-  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %60
 
 ; <label>:60                                      ; preds = %57
   %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
   %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
-  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %64
 
 ; <label>:64                                      ; preds = %60
   %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
@@ -6864,22 +8310,22 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
   %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
-  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %70
 
 ; <label>:70                                      ; preds = %64
   %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
   %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
-  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
-  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
   %75 = load i32, i32 addrspace(1)* %74
   %76 = zext i32 %75 to i64
   %77 = trunc i64 %76 to i32
-  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
-  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %78
 
 ; <label>:78                                      ; preds = %73
   %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
@@ -6901,8 +8347,8 @@ entry:
   %90 = bitcast i16* %86 to i8*
   %91 = getelementptr inbounds i8, i8* %90, i64 %89
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %93
 
 ; <label>:93                                      ; preds = %80
   %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
@@ -6912,8 +8358,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %99 = load i32, i32* %loc2
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %100
 
 ; <label>:100                                     ; preds = %93
   %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
@@ -6928,63 +8374,63 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %25
+ThrowNullRef6:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %32
+ThrowNullRef10:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %40
+ThrowNullRef12:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %45
+ThrowNullRef16:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %57
+ThrowNullRef18:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %60
+ThrowNullRef20:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %64
+ThrowNullRef22:                                   ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %70
+ThrowNullRef24:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %73
+ThrowNullRef26:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %80
+ThrowNullRef28:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %93
+ThrowNullRef30:                                   ; preds = %93
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7004,8 +8450,8 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
@@ -7033,43 +8479,43 @@ entry:
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %14
   %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
   %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   %28 = load i32, i32 addrspace(1)* %27, align 8
   %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
-  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %30
 
 ; <label>:30                                      ; preds = %26
   %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
   %32 = load i32, i32 addrspace(1)* %31, align 8
   %33 = add i32 %28, %32
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %34
 
 ; <label>:34                                      ; preds = %30
   %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   store i32 %33, i32 addrspace(1)* %35
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
   store i32 0, i32 addrspace(1)* %38
   %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %40
 
 ; <label>:40                                      ; preds = %37
   %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
@@ -7082,8 +8528,8 @@ entry:
 
 ; <label>:47                                      ; preds = %40
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
@@ -7098,8 +8544,8 @@ entry:
   %54 = load i32, i32* %loc0
   %55 = sext i32 %54 to i64
   %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
-  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %57
 
 ; <label>:57                                      ; preds = %52
   %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
@@ -7110,68 +8556,35 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %14
+ThrowNullRef2:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %23
+ThrowNullRef4:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %26
+ThrowNullRef6:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %30
+ThrowNullRef8:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %34
+ThrowNullRef10:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %47
+ThrowNullRef14:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %52
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-}
-
-INFO:  jitting method StringBuilder::get_Length using LLILCJit
-Successfully read StringBuilder.get_Length
-
-define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.StringBuilder addrspace(1)*
-  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
-  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
-
-; <label>:1                                       ; preds = %entry
-  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %3 = load i32, i32 addrspace(1)* %2, align 8
-  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
-
-; <label>:5                                       ; preds = %1
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = add i32 %3, %7
-  ret i32 %8
-
-ThrowNullRef:                                     ; preds = %entry
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef16:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7213,70 +8626,70 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
   %6 = load i32, i32 addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
   store i32 %6, i32 addrspace(1)* %8
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
   %13 = load i32, i32 addrspace(1)* %12, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
   store i32 %13, i32 addrspace(1)* %15
   %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
-  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %18
 
 ; <label>:18                                      ; preds = %14
   %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
   %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
   %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
   %34 = load i32, i32 addrspace(1)* %33, align 8
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
-  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
@@ -7287,39 +8700,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %28
+ThrowNullRef16:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %32
+ThrowNullRef18:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7455,13 +8868,13 @@ entry:
 ; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
@@ -7477,16 +8890,16 @@ entry:
 
 ; <label>:18                                      ; preds = %15
   %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
   store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
   %22 = load i32, i32* %loc0
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %24
 
 ; <label>:24                                      ; preds = %20
   %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
@@ -7498,13 +8911,13 @@ entry:
 ; <label>:28                                      ; preds = %15, %24
   %29 = load i32, i32* %arg1
   %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %31
   %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
@@ -7517,20 +8930,20 @@ entry:
   %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
-  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
   %46 = load i32, i32 addrspace(1)* %45, align 8
   %47 = sub i32 %40, %46
-  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
-  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i32 addrspace(1)* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %48
 
 ; <label>:48                                      ; preds = %44
   store i32 %47, i32 addrspace(1)* %39, align 8
@@ -7538,21 +8951,21 @@ entry:
 
 ; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
-  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %51
 
 ; <label>:51                                      ; preds = %49
   %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %53
 
 ; <label>:53                                      ; preds = %51
   %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
   %55 = load i32, i32 addrspace(1)* %54, align 8
   %56 = load i32, i32* %arg2
   %57 = sub i32 %55, %56
-  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %58
 
 ; <label>:58                                      ; preds = %53
   %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
@@ -7562,13 +8975,13 @@ entry:
 ; <label>:60                                      ; preds = %33, %58
   %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
   %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
-  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %63
 
 ; <label>:63                                      ; preds = %60
   %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
-  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
-  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
@@ -7578,15 +8991,15 @@ entry:
 
 ; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
-  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i32 addrspace(1)* %69, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %70
 
 ; <label>:70                                      ; preds = %68
   %71 = load i32, i32 addrspace(1)* %69, align 8
   store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
-  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
@@ -7596,8 +9009,8 @@ entry:
   store i32 %77, i32* %loc4
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
-  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %80
 
 ; <label>:80                                      ; preds = %73
   %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
@@ -7607,71 +9020,71 @@ entry:
 ; <label>:83                                      ; preds = %80
   store i32 0, i32* %loc3
   %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
-  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
-  br i1 %NullCheck26, label %88, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i32 addrspace(1)* %87, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %88
 
 ; <label>:88                                      ; preds = %85
   %89 = load i32, i32 addrspace(1)* %87, align 8
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
-  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %90
 
 ; <label>:90                                      ; preds = %88
   %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
   store i32 %89, i32 addrspace(1)* %91
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
-  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
-  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %96
 
 ; <label>:96                                      ; preds = %94
   %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
-  br i1 %NullCheck34, label %100, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %100
 
 ; <label>:100                                     ; preds = %96
   %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
-  br i1 %NullCheck36, label %102, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %102
 
 ; <label>:102                                     ; preds = %100
   %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
   %104 = load i32, i32 addrspace(1)* %103, align 8
   %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
-  br i1 %NullCheck38, label %106, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %106
 
 ; <label>:106                                     ; preds = %102
   %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
-  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
-  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %108
 
 ; <label>:108                                     ; preds = %106
   %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
   %110 = load i32, i32 addrspace(1)* %109, align 8
   %111 = add i32 %104, %110
-  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %112
 
 ; <label>:112                                     ; preds = %108
   %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
   store i32 %111, i32 addrspace(1)* %113
   %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
-  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i32 addrspace(1)* %114, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %115
 
 ; <label>:115                                     ; preds = %112
   %116 = load i32, i32 addrspace(1)* %114, align 8
@@ -7681,19 +9094,19 @@ entry:
 ; <label>:118                                     ; preds = %115
   %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
-  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %121
 
 ; <label>:121                                     ; preds = %118
   %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
-  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
-  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %123
 
 ; <label>:123                                     ; preds = %121
   %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
   %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
-  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
-  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %126
 
 ; <label>:126                                     ; preds = %123
   %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
@@ -7705,8 +9118,8 @@ entry:
 
 ; <label>:130                                     ; preds = %80, %115, %126
   %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %132
 
 ; <label>:132                                     ; preds = %130
   %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7715,8 +9128,8 @@ entry:
   %136 = load i32, i32* %loc3
   %137 = sub i32 %135, %136
   %138 = sub i32 %134, %137
-  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %139
 
 ; <label>:139                                     ; preds = %132
   %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7728,16 +9141,16 @@ entry:
 
 ; <label>:144                                     ; preds = %139
   %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
-  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %146
 
 ; <label>:146                                     ; preds = %144
   %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
   %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
   %149 = load i32, i32* %loc2
   %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
-  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %151
 
 ; <label>:151                                     ; preds = %146
   %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
@@ -7754,145 +9167,249 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %18
+ThrowNullRef4:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %31
+ThrowNullRef10:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %44
+ThrowNullRef16:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %68
+ThrowNullRef18:                                   ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %70
+ThrowNullRef20:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %73
+ThrowNullRef22:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %83
+ThrowNullRef24:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %85
+ThrowNullRef26:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %88
+ThrowNullRef28:                                   ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %90
+ThrowNullRef30:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %94
+ThrowNullRef32:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %96
+ThrowNullRef34:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %100
+ThrowNullRef36:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %102
+ThrowNullRef38:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %106
+ThrowNullRef40:                                   ; preds = %106
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %108
+ThrowNullRef42:                                   ; preds = %108
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %112
+ThrowNullRef44:                                   ; preds = %112
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %118
+ThrowNullRef46:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %121
+ThrowNullRef48:                                   ; preds = %121
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %123
+ThrowNullRef50:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %130
+ThrowNullRef52:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %132
+ThrowNullRef54:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %144
+ThrowNullRef56:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %146
+ThrowNullRef58:                                   ; preds = %146
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %60
+ThrowNullRef60:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %63
+ThrowNullRef62:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %49
+ThrowNullRef64:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %51
+ThrowNullRef66:                                   ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %53
+ThrowNullRef68:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(%"System.Char[]" addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %arg0 = alloca %"System.Char[]" addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store %"System.Char[]" addrspace(1)* %param0, %"System.Char[]" addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load i32, i32* %arg4
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %43, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %38, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg1
+  %13 = load i32, i32* %arg4
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %38, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %24 = load i32, i32* %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %35 = load i32, i32* %arg3
+  %36 = load i32, i32* %arg4
+  %37 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %37, %"System.Char[]" addrspace(1)* %34, i32 %35, i32 %36)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:38                                      ; preds = %5, %16
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Successfully read Buffer._Memmove
 
@@ -7914,7 +9431,7 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[loadElem]
+Failed to read AppDomain.SetDataHelper[storeElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -7923,8 +9440,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
@@ -7934,8 +9451,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
@@ -7947,15 +9464,15 @@ entry:
   %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
   %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
@@ -7966,15 +9483,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7992,7 +9509,79 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
-Failed to read Dictionary`2.TryGetValue[loadElemA]
+Successfully read Dictionary`2.TryGetValue
+
+define i8 @"Dictionary`2.TryGetValue"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)* addrspace(1)* %param2) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  %arg2 = alloca %System.__Canon addrspace(1)* addrspace(1)*
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  store %System.__Canon addrspace(1)* addrspace(1)* %param2, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  store i32 %2, i32* %loc0
+  %3 = load i32, i32* %loc0
+  %4 = icmp slt i32 %3, 0
+  br i1 %4, label %22, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 2
+  %10 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %9, align 8
+  %11 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = zext i32 %11 to i64
+  %BoundsCheck = icmp uge i64 %16, %15
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 3, i32 %11
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %20, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %6, %System.__Canon addrspace(1)* %21)
+  ret i8 1
+
+; <label>:22                                      ; preds = %entry
+  %23 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %23, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -8058,8 +9647,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
@@ -8091,8 +9680,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
@@ -8171,15 +9760,15 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck, label %19, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %ThrowNullRef, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
   %21 = load i32, i32 addrspace(1)* %20
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
@@ -8202,7 +9791,7 @@ ThrowNullRef:                                     ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %19
+ThrowNullRef2:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8248,8 +9837,8 @@ entry:
   %0 = alloca %System.AppDomainHandle
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %1 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %1, i32 0, i32 15
@@ -8269,8 +9858,8 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
@@ -8286,7 +9875,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -8299,8 +9888,8 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -8327,8 +9916,8 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
@@ -8352,8 +9941,8 @@ entry:
   %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
   store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
@@ -8363,8 +9952,8 @@ entry:
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
@@ -8374,8 +9963,8 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %9
   %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
@@ -8384,8 +9973,8 @@ entry:
 
 ; <label>:18                                      ; preds = %3, %16
   %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
@@ -8397,15 +9986,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %18
+ThrowNullRef6:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8418,8 +10007,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
@@ -8453,15 +10042,15 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
@@ -8473,7 +10062,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8481,7 +10070,7 @@ ThrowNullRef1:                                    ; preds = %1
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
 Failed to read Dictionary`2.System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
@@ -8506,8 +10095,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
@@ -8524,8 +10113,8 @@ entry:
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -8544,7 +10133,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8577,8 +10166,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = load i64, i64* %arg2
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = trunc i32 %3 to i8
@@ -8634,46 +10223,46 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
   %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
-  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
-  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
-  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
@@ -8684,27 +10273,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %20
+ThrowNullRef12:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8717,8 +10306,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -8756,22 +10345,22 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
   %9 = load i64, i64 addrspace(1)* %8, align 8
   %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
   %13 = load i64, i64 addrspace(1)* %12, align 8
   %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %11
   %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
@@ -8788,11 +10377,11 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8882,8 +10471,8 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
@@ -8900,8 +10489,8 @@ entry:
 ; <label>:8                                       ; preds = %1
   %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
   %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
@@ -8911,15 +10500,15 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
   %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
   %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
-  br i1 %NullCheck6, label %21, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
@@ -8946,15 +10535,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8992,15 +10581,15 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
   store i8 %3, i8 addrspace(1)* %5
   %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
@@ -9011,7 +10600,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9027,8 +10616,8 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -9041,8 +10630,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
@@ -9058,7 +10647,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9080,8 +10669,8 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
@@ -9096,8 +10685,8 @@ entry:
 ; <label>:12                                      ; preds = %6
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
@@ -9112,8 +10701,8 @@ entry:
 ; <label>:21                                      ; preds = %15
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
@@ -9128,8 +10717,8 @@ entry:
 ; <label>:30                                      ; preds = %24
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %31, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
@@ -9144,8 +10733,8 @@ entry:
 ; <label>:39                                      ; preds = %33
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
-  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %40, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %42
 
 ; <label>:42                                      ; preds = %39
   %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
@@ -9164,19 +10753,19 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %21
+ThrowNullRef4:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %30
+ThrowNullRef6:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %39
+ThrowNullRef8:                                    ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9243,8 +10832,8 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
@@ -9264,57 +10853,57 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
   store i8 0, i8 addrspace(1)* %2
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
   store i8 0, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
   store i8 0, i8 addrspace(1)* %17
   %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
   store i8 0, i8 addrspace(1)* %20
   %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
-  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
@@ -9325,31 +10914,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %19
+ThrowNullRef14:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9367,8 +10956,8 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
@@ -9380,8 +10969,8 @@ entry:
 
 ; <label>:9                                       ; preds = %4
   %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %9
   %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
@@ -9395,7 +10984,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef2:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9420,8 +11009,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
@@ -9512,8 +11101,8 @@ entry:
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
@@ -9524,8 +11113,8 @@ entry:
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = load i64, i64 addrspace(1)* %12
@@ -9537,8 +11126,8 @@ entry:
   %20 = load i64, i64* %19
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
-  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %13
   %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
@@ -9555,8 +11144,8 @@ entry:
 ; <label>:30                                      ; preds = %25
   %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %32 = load i32, i32* %arg2
-  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
-  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
@@ -9570,15 +11159,15 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %30
+ThrowNullRef2:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9622,87 +11211,87 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
   %10 = load i8, i8 addrspace(1)* %9, align 8
   %11 = zext i8 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %8
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
   store i8 %12, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
   %19 = load i8, i8 addrspace(1)* %18, align 8
   %20 = zext i8 %19 to i32
   %21 = trunc i32 %20 to i8
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
   store i8 %21, i8 addrspace(1)* %23
   %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
   %28 = load i8, i8 addrspace(1)* %27, align 8
   %29 = zext i8 %28 to i32
   %30 = trunc i32 %29 to i8
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
-  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %31
 
 ; <label>:31                                      ; preds = %26
   %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
   store i8 %30, i8 addrspace(1)* %32
   %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
-  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
-  br i1 %NullCheck14, label %40, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %40
 
 ; <label>:40                                      ; preds = %35
   %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
   store i8 %39, i8 addrspace(1)* %41
   %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
-  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %44
 
 ; <label>:44                                      ; preds = %40
   %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
   %46 = load i8, i8 addrspace(1)* %45, align 8
   %47 = zext i8 %46 to i32
   %48 = trunc i32 %47 to i8
-  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
   store i8 %48, i8 addrspace(1)* %50
   %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
-  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
@@ -9713,29 +11302,29 @@ entry:
 ; <label>:56                                      ; preds = %52
   %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
-  br i1 %NullCheck22, label %59, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
   %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
   %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
-  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
-  br i1 %NullCheck24, label %63, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
   %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
-  br i1 %NullCheck26, label %66, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
   %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
-  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
-  br i1 %NullCheck28, label %69, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %69
 
 ; <label>:69                                      ; preds = %66
   %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
@@ -9744,15 +11333,15 @@ entry:
 
 ; <label>:71                                      ; preds = %105
   %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
-  br i1 %NullCheck34, label %73, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %73
 
 ; <label>:73                                      ; preds = %71
   %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
   %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
   %76 = load i32, i32* %loc0
-  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
-  br i1 %NullCheck36, label %77, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
@@ -9766,8 +11355,8 @@ entry:
 
 ; <label>:83                                      ; preds = %77
   %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
-  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
@@ -9775,14 +11364,14 @@ entry:
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
   %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
-  br i1 %NullCheck40, label %91, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
 ; <label>:91                                      ; preds = %85
   %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
   %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
-  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck42, label %94, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %94
 
 ; <label>:94                                      ; preds = %91
   %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
@@ -9798,14 +11387,14 @@ entry:
 ; <label>:99                                      ; preds = %69, %96
   %100 = load i32, i32* %loc0
   %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
-  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %102
 
 ; <label>:102                                     ; preds = %99
   %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
   %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
-  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
-  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
@@ -9819,87 +11408,87 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %26
+ThrowNullRef10:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %31
+ThrowNullRef12:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %35
+ThrowNullRef14:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %40
+ThrowNullRef16:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %56
+ThrowNullRef22:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %59
+ThrowNullRef24:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %63
+ThrowNullRef26:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %66
+ThrowNullRef28:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %102
+ThrowNullRef32:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %71
+ThrowNullRef34:                                   ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %73
+ThrowNullRef36:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %83
+ThrowNullRef38:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %85
+ThrowNullRef40:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %91
+ThrowNullRef42:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9943,15 +11532,15 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
   %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
@@ -9961,28 +11550,28 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
   %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %12
   %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
   %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
   %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
-  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
@@ -9993,23 +11582,23 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %12
+ThrowNullRef6:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10031,15 +11620,15 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
   %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = load i64, i64 addrspace(1)* %7
@@ -10077,13 +11666,13 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[loadElem]
+Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -10111,8 +11700,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -10180,14 +11769,14 @@ entry:
   store i32 addrspace(1)* %param0, i32 addrspace(1)** %arg0
   %0 = load i32 addrspace(1)*, i32 addrspace(1)** %arg0
   %1 = load i32 addrspace(1)*, i32 addrspace(1)** %arg0
-  %NullCheck = icmp ne i32 addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq i32 addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load i32, i32 addrspace(1)* %1, align 8
   %4 = sub i32 0, %3
-  %NullCheck2 = icmp ne i32 addrspace(1)* %0, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i32 addrspace(1)* %0, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %2
   store i32 %4, i32 addrspace(1)* %0, align 8
@@ -10197,7 +11786,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }

--- a/test/BaseLine/JIT/CodeGenBringUpTests/NestedCall.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/NestedCall.error.txt
@@ -25,8 +25,8 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
@@ -40,8 +40,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
   %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
@@ -75,7 +75,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -90,8 +90,8 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %NullCheck = icmp ne i8 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = load i8, i8 addrspace(1)* %0, align 8
@@ -125,8 +125,8 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
@@ -159,8 +159,8 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -184,8 +184,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
   store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
@@ -195,8 +195,8 @@ entry:
 ; <label>:4                                       ; preds = %1
   %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
   %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
@@ -206,8 +206,8 @@ entry:
   %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
@@ -221,14 +221,14 @@ entry:
 
 ; <label>:17                                      ; preds = %14
   %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
   %21 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
@@ -238,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -249,8 +249,8 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
@@ -261,27 +261,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %30
+ThrowNullRef10:                                   ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -301,7 +301,89 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
-Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
+Successfully read AppDomainSetup.GetUnsecureApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.GetUnsecureApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %NullCheck = icmp eq %"System.String[]" addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %BoundsCheck = icmp uge i64 0, %5
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %6
+
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 3, i32 0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
+  ret %System.String addrspace(1)* %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_Value using LLILCJit
+Successfully read AppDomainSetup.get_Value
+
+define %"System.String[]" addrspace(1)* @AppDomainSetup.get_Value(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.String[]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 18)
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.String[]" addrspace(1)* addrspace(1)*, %"System.String[]" addrspace(1)*)*)(%"System.String[]" addrspace(1)* addrspace(1)* %9, %"System.String[]" addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %11, i32 0, i32 1
+  %14 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %13, align 8
+  ret %"System.String[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -319,8 +401,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -368,16 +450,16 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
   %5 = load i32, i32 addrspace(1)* %4
   %6 = sub i32 %5, 1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -389,7 +471,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -421,8 +503,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
@@ -456,8 +538,8 @@ entry:
 ; <label>:27                                      ; preds = %19
   %28 = load i32, i32* %arg1
   %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
-  br i1 %NullCheck2, label %30, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %29, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %30
 
 ; <label>:30                                      ; preds = %27
   %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
@@ -493,8 +575,8 @@ entry:
 ; <label>:49                                      ; preds = %46
   %50 = load i32, i32* %arg2
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck4, label %52, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
@@ -517,11 +599,11 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %27
+ThrowNullRef2:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %49
+ThrowNullRef4:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -544,16 +626,16 @@ entry:
   %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %0)
   store %System.String addrspace(1)* %1, %System.String addrspace(1)** %loc0
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 2
   %5 = bitcast [0 x i16] addrspace(1)* %4 to i16 addrspace(1)*
   store i16 addrspace(1)* %5, i16 addrspace(1)** %loc1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %3
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2
@@ -580,7 +662,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -691,15 +773,15 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %NullCheck132 = icmp ne i8* %21, null
-  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+  %NullCheck131 = icmp eq i8* %21, null
+  br i1 %NullCheck131, label %ThrowNullRef132, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = load i8, i8* %21, align 8
   %24 = zext i8 %23 to i32
   %25 = trunc i32 %24 to i8
-  %NullCheck134 = icmp ne i8* %20, null
-  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+  %NullCheck133 = icmp eq i8* %20, null
+  br i1 %NullCheck133, label %ThrowNullRef134, label %26
 
 ; <label>:26                                      ; preds = %22
   store i8 %25, i8* %20, align 8
@@ -709,16 +791,16 @@ entry:
   %28 = load i8*, i8** %arg0
   %29 = load i8*, i8** %arg1
   %30 = bitcast i8* %29 to i16*
-  %NullCheck128 = icmp ne i16* %30, null
-  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+  %NullCheck127 = icmp eq i16* %30, null
+  br i1 %NullCheck127, label %ThrowNullRef128, label %31
 
 ; <label>:31                                      ; preds = %27
   %32 = load i16, i16* %30, align 8
   %33 = sext i16 %32 to i32
   %34 = bitcast i8* %28 to i16*
   %35 = trunc i32 %33 to i16
-  %NullCheck130 = icmp ne i16* %34, null
-  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+  %NullCheck129 = icmp eq i16* %34, null
+  br i1 %NullCheck129, label %ThrowNullRef130, label %36
 
 ; <label>:36                                      ; preds = %31
   store i16 %35, i16* %34, align 8
@@ -728,16 +810,16 @@ entry:
   %38 = load i8*, i8** %arg0
   %39 = load i8*, i8** %arg1
   %40 = bitcast i8* %39 to i16*
-  %NullCheck120 = icmp ne i16* %40, null
-  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+  %NullCheck119 = icmp eq i16* %40, null
+  br i1 %NullCheck119, label %ThrowNullRef120, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i16, i16* %40, align 8
   %43 = sext i16 %42 to i32
   %44 = bitcast i8* %38 to i16*
   %45 = trunc i32 %43 to i16
-  %NullCheck122 = icmp ne i16* %44, null
-  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+  %NullCheck121 = icmp eq i16* %44, null
+  br i1 %NullCheck121, label %ThrowNullRef122, label %46
 
 ; <label>:46                                      ; preds = %41
   store i16 %45, i16* %44, align 8
@@ -745,15 +827,15 @@ entry:
   %48 = getelementptr inbounds i8, i8* %47, i64 2
   %49 = load i8*, i8** %arg1
   %50 = getelementptr inbounds i8, i8* %49, i64 2
-  %NullCheck124 = icmp ne i8* %50, null
-  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+  %NullCheck123 = icmp eq i8* %50, null
+  br i1 %NullCheck123, label %ThrowNullRef124, label %51
 
 ; <label>:51                                      ; preds = %46
   %52 = load i8, i8* %50, align 8
   %53 = zext i8 %52 to i32
   %54 = trunc i32 %53 to i8
-  %NullCheck126 = icmp ne i8* %48, null
-  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+  %NullCheck125 = icmp eq i8* %48, null
+  br i1 %NullCheck125, label %ThrowNullRef126, label %55
 
 ; <label>:55                                      ; preds = %51
   store i8 %54, i8* %48, align 8
@@ -763,14 +845,14 @@ entry:
   %57 = load i8*, i8** %arg0
   %58 = load i8*, i8** %arg1
   %59 = bitcast i8* %58 to i32*
-  %NullCheck116 = icmp ne i32* %59, null
-  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+  %NullCheck115 = icmp eq i32* %59, null
+  br i1 %NullCheck115, label %ThrowNullRef116, label %60
 
 ; <label>:60                                      ; preds = %56
   %61 = load i32, i32* %59, align 8
   %62 = bitcast i8* %57 to i32*
-  %NullCheck118 = icmp ne i32* %62, null
-  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+  %NullCheck117 = icmp eq i32* %62, null
+  br i1 %NullCheck117, label %ThrowNullRef118, label %63
 
 ; <label>:63                                      ; preds = %60
   store i32 %61, i32* %62, align 8
@@ -780,14 +862,14 @@ entry:
   %65 = load i8*, i8** %arg0
   %66 = load i8*, i8** %arg1
   %67 = bitcast i8* %66 to i32*
-  %NullCheck108 = icmp ne i32* %67, null
-  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+  %NullCheck107 = icmp eq i32* %67, null
+  br i1 %NullCheck107, label %ThrowNullRef108, label %68
 
 ; <label>:68                                      ; preds = %64
   %69 = load i32, i32* %67, align 8
   %70 = bitcast i8* %65 to i32*
-  %NullCheck110 = icmp ne i32* %70, null
-  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+  %NullCheck109 = icmp eq i32* %70, null
+  br i1 %NullCheck109, label %ThrowNullRef110, label %71
 
 ; <label>:71                                      ; preds = %68
   store i32 %69, i32* %70, align 8
@@ -795,15 +877,15 @@ entry:
   %73 = getelementptr inbounds i8, i8* %72, i64 4
   %74 = load i8*, i8** %arg1
   %75 = getelementptr inbounds i8, i8* %74, i64 4
-  %NullCheck112 = icmp ne i8* %75, null
-  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+  %NullCheck111 = icmp eq i8* %75, null
+  br i1 %NullCheck111, label %ThrowNullRef112, label %76
 
 ; <label>:76                                      ; preds = %71
   %77 = load i8, i8* %75, align 8
   %78 = zext i8 %77 to i32
   %79 = trunc i32 %78 to i8
-  %NullCheck114 = icmp ne i8* %73, null
-  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+  %NullCheck113 = icmp eq i8* %73, null
+  br i1 %NullCheck113, label %ThrowNullRef114, label %80
 
 ; <label>:80                                      ; preds = %76
   store i8 %79, i8* %73, align 8
@@ -813,14 +895,14 @@ entry:
   %82 = load i8*, i8** %arg0
   %83 = load i8*, i8** %arg1
   %84 = bitcast i8* %83 to i32*
-  %NullCheck100 = icmp ne i32* %84, null
-  br i1 %NullCheck100, label %85, label %ThrowNullRef99
+  %NullCheck99 = icmp eq i32* %84, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %85
 
 ; <label>:85                                      ; preds = %81
   %86 = load i32, i32* %84, align 8
   %87 = bitcast i8* %82 to i32*
-  %NullCheck102 = icmp ne i32* %87, null
-  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+  %NullCheck101 = icmp eq i32* %87, null
+  br i1 %NullCheck101, label %ThrowNullRef102, label %88
 
 ; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
@@ -829,16 +911,16 @@ entry:
   %91 = load i8*, i8** %arg1
   %92 = getelementptr inbounds i8, i8* %91, i64 4
   %93 = bitcast i8* %92 to i16*
-  %NullCheck104 = icmp ne i16* %93, null
-  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+  %NullCheck103 = icmp eq i16* %93, null
+  br i1 %NullCheck103, label %ThrowNullRef104, label %94
 
 ; <label>:94                                      ; preds = %88
   %95 = load i16, i16* %93, align 8
   %96 = sext i16 %95 to i32
   %97 = bitcast i8* %90 to i16*
   %98 = trunc i32 %96 to i16
-  %NullCheck106 = icmp ne i16* %97, null
-  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+  %NullCheck105 = icmp eq i16* %97, null
+  br i1 %NullCheck105, label %ThrowNullRef106, label %99
 
 ; <label>:99                                      ; preds = %94
   store i16 %98, i16* %97, align 8
@@ -848,14 +930,14 @@ entry:
   %101 = load i8*, i8** %arg0
   %102 = load i8*, i8** %arg1
   %103 = bitcast i8* %102 to i32*
-  %NullCheck88 = icmp ne i32* %103, null
-  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+  %NullCheck87 = icmp eq i32* %103, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %104
 
 ; <label>:104                                     ; preds = %100
   %105 = load i32, i32* %103, align 8
   %106 = bitcast i8* %101 to i32*
-  %NullCheck90 = icmp ne i32* %106, null
-  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+  %NullCheck89 = icmp eq i32* %106, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %107
 
 ; <label>:107                                     ; preds = %104
   store i32 %105, i32* %106, align 8
@@ -864,16 +946,16 @@ entry:
   %110 = load i8*, i8** %arg1
   %111 = getelementptr inbounds i8, i8* %110, i64 4
   %112 = bitcast i8* %111 to i16*
-  %NullCheck92 = icmp ne i16* %112, null
-  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+  %NullCheck91 = icmp eq i16* %112, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %113
 
 ; <label>:113                                     ; preds = %107
   %114 = load i16, i16* %112, align 8
   %115 = sext i16 %114 to i32
   %116 = bitcast i8* %109 to i16*
   %117 = trunc i32 %115 to i16
-  %NullCheck94 = icmp ne i16* %116, null
-  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+  %NullCheck93 = icmp eq i16* %116, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %118
 
 ; <label>:118                                     ; preds = %113
   store i16 %117, i16* %116, align 8
@@ -881,15 +963,15 @@ entry:
   %120 = getelementptr inbounds i8, i8* %119, i64 6
   %121 = load i8*, i8** %arg1
   %122 = getelementptr inbounds i8, i8* %121, i64 6
-  %NullCheck96 = icmp ne i8* %122, null
-  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+  %NullCheck95 = icmp eq i8* %122, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %123
 
 ; <label>:123                                     ; preds = %118
   %124 = load i8, i8* %122, align 8
   %125 = zext i8 %124 to i32
   %126 = trunc i32 %125 to i8
-  %NullCheck98 = icmp ne i8* %120, null
-  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+  %NullCheck97 = icmp eq i8* %120, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %127
 
 ; <label>:127                                     ; preds = %123
   store i8 %126, i8* %120, align 8
@@ -899,14 +981,14 @@ entry:
   %129 = load i8*, i8** %arg0
   %130 = load i8*, i8** %arg1
   %131 = bitcast i8* %130 to i64*
-  %NullCheck84 = icmp ne i64* %131, null
-  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+  %NullCheck83 = icmp eq i64* %131, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %132
 
 ; <label>:132                                     ; preds = %128
   %133 = load i64, i64* %131, align 8
   %134 = bitcast i8* %129 to i64*
-  %NullCheck86 = icmp ne i64* %134, null
-  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+  %NullCheck85 = icmp eq i64* %134, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %135
 
 ; <label>:135                                     ; preds = %132
   store i64 %133, i64* %134, align 8
@@ -916,14 +998,14 @@ entry:
   %137 = load i8*, i8** %arg0
   %138 = load i8*, i8** %arg1
   %139 = bitcast i8* %138 to i64*
-  %NullCheck76 = icmp ne i64* %139, null
-  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+  %NullCheck75 = icmp eq i64* %139, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %140
 
 ; <label>:140                                     ; preds = %136
   %141 = load i64, i64* %139, align 8
   %142 = bitcast i8* %137 to i64*
-  %NullCheck78 = icmp ne i64* %142, null
-  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+  %NullCheck77 = icmp eq i64* %142, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %143
 
 ; <label>:143                                     ; preds = %140
   store i64 %141, i64* %142, align 8
@@ -931,15 +1013,15 @@ entry:
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %NullCheck80 = icmp ne i8* %147, null
-  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+  %NullCheck79 = icmp eq i8* %147, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %148
 
 ; <label>:148                                     ; preds = %143
   %149 = load i8, i8* %147, align 8
   %150 = zext i8 %149 to i32
   %151 = trunc i32 %150 to i8
-  %NullCheck82 = icmp ne i8* %145, null
-  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+  %NullCheck81 = icmp eq i8* %145, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %152
 
 ; <label>:152                                     ; preds = %148
   store i8 %151, i8* %145, align 8
@@ -949,14 +1031,14 @@ entry:
   %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
   %156 = bitcast i8* %155 to i64*
-  %NullCheck68 = icmp ne i64* %156, null
-  br i1 %NullCheck68, label %157, label %ThrowNullRef67
+  %NullCheck67 = icmp eq i64* %156, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %157
 
 ; <label>:157                                     ; preds = %153
   %158 = load i64, i64* %156, align 8
   %159 = bitcast i8* %154 to i64*
-  %NullCheck70 = icmp ne i64* %159, null
-  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+  %NullCheck69 = icmp eq i64* %159, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %160
 
 ; <label>:160                                     ; preds = %157
   store i64 %158, i64* %159, align 8
@@ -965,16 +1047,16 @@ entry:
   %163 = load i8*, i8** %arg1
   %164 = getelementptr inbounds i8, i8* %163, i64 8
   %165 = bitcast i8* %164 to i16*
-  %NullCheck72 = icmp ne i16* %165, null
-  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+  %NullCheck71 = icmp eq i16* %165, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %166
 
 ; <label>:166                                     ; preds = %160
   %167 = load i16, i16* %165, align 8
   %168 = sext i16 %167 to i32
   %169 = bitcast i8* %162 to i16*
   %170 = trunc i32 %168 to i16
-  %NullCheck74 = icmp ne i16* %169, null
-  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+  %NullCheck73 = icmp eq i16* %169, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %171
 
 ; <label>:171                                     ; preds = %166
   store i16 %170, i16* %169, align 8
@@ -984,14 +1066,14 @@ entry:
   %173 = load i8*, i8** %arg0
   %174 = load i8*, i8** %arg1
   %175 = bitcast i8* %174 to i64*
-  %NullCheck56 = icmp ne i64* %175, null
-  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+  %NullCheck55 = icmp eq i64* %175, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %176
 
 ; <label>:176                                     ; preds = %172
   %177 = load i64, i64* %175, align 8
   %178 = bitcast i8* %173 to i64*
-  %NullCheck58 = icmp ne i64* %178, null
-  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+  %NullCheck57 = icmp eq i64* %178, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %179
 
 ; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
@@ -1000,16 +1082,16 @@ entry:
   %182 = load i8*, i8** %arg1
   %183 = getelementptr inbounds i8, i8* %182, i64 8
   %184 = bitcast i8* %183 to i16*
-  %NullCheck60 = icmp ne i16* %184, null
-  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+  %NullCheck59 = icmp eq i16* %184, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %185
 
 ; <label>:185                                     ; preds = %179
   %186 = load i16, i16* %184, align 8
   %187 = sext i16 %186 to i32
   %188 = bitcast i8* %181 to i16*
   %189 = trunc i32 %187 to i16
-  %NullCheck62 = icmp ne i16* %188, null
-  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+  %NullCheck61 = icmp eq i16* %188, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %190
 
 ; <label>:190                                     ; preds = %185
   store i16 %189, i16* %188, align 8
@@ -1017,15 +1099,15 @@ entry:
   %192 = getelementptr inbounds i8, i8* %191, i64 10
   %193 = load i8*, i8** %arg1
   %194 = getelementptr inbounds i8, i8* %193, i64 10
-  %NullCheck64 = icmp ne i8* %194, null
-  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+  %NullCheck63 = icmp eq i8* %194, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %195
 
 ; <label>:195                                     ; preds = %190
   %196 = load i8, i8* %194, align 8
   %197 = zext i8 %196 to i32
   %198 = trunc i32 %197 to i8
-  %NullCheck66 = icmp ne i8* %192, null
-  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+  %NullCheck65 = icmp eq i8* %192, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %199
 
 ; <label>:199                                     ; preds = %195
   store i8 %198, i8* %192, align 8
@@ -1035,14 +1117,14 @@ entry:
   %201 = load i8*, i8** %arg0
   %202 = load i8*, i8** %arg1
   %203 = bitcast i8* %202 to i64*
-  %NullCheck48 = icmp ne i64* %203, null
-  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+  %NullCheck47 = icmp eq i64* %203, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %204
 
 ; <label>:204                                     ; preds = %200
   %205 = load i64, i64* %203, align 8
   %206 = bitcast i8* %201 to i64*
-  %NullCheck50 = icmp ne i64* %206, null
-  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+  %NullCheck49 = icmp eq i64* %206, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %207
 
 ; <label>:207                                     ; preds = %204
   store i64 %205, i64* %206, align 8
@@ -1051,14 +1133,14 @@ entry:
   %210 = load i8*, i8** %arg1
   %211 = getelementptr inbounds i8, i8* %210, i64 8
   %212 = bitcast i8* %211 to i32*
-  %NullCheck52 = icmp ne i32* %212, null
-  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+  %NullCheck51 = icmp eq i32* %212, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %213
 
 ; <label>:213                                     ; preds = %207
   %214 = load i32, i32* %212, align 8
   %215 = bitcast i8* %209 to i32*
-  %NullCheck54 = icmp ne i32* %215, null
-  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+  %NullCheck53 = icmp eq i32* %215, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %216
 
 ; <label>:216                                     ; preds = %213
   store i32 %214, i32* %215, align 8
@@ -1068,14 +1150,14 @@ entry:
   %218 = load i8*, i8** %arg0
   %219 = load i8*, i8** %arg1
   %220 = bitcast i8* %219 to i64*
-  %NullCheck36 = icmp ne i64* %220, null
-  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64* %220, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %221
 
 ; <label>:221                                     ; preds = %217
   %222 = load i64, i64* %220, align 8
   %223 = bitcast i8* %218 to i64*
-  %NullCheck38 = icmp ne i64* %223, null
-  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+  %NullCheck37 = icmp eq i64* %223, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %224
 
 ; <label>:224                                     ; preds = %221
   store i64 %222, i64* %223, align 8
@@ -1084,14 +1166,14 @@ entry:
   %227 = load i8*, i8** %arg1
   %228 = getelementptr inbounds i8, i8* %227, i64 8
   %229 = bitcast i8* %228 to i32*
-  %NullCheck40 = icmp ne i32* %229, null
-  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i32* %229, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %230
 
 ; <label>:230                                     ; preds = %224
   %231 = load i32, i32* %229, align 8
   %232 = bitcast i8* %226 to i32*
-  %NullCheck42 = icmp ne i32* %232, null
-  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+  %NullCheck41 = icmp eq i32* %232, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %233
 
 ; <label>:233                                     ; preds = %230
   store i32 %231, i32* %232, align 8
@@ -1099,15 +1181,15 @@ entry:
   %235 = getelementptr inbounds i8, i8* %234, i64 12
   %236 = load i8*, i8** %arg1
   %237 = getelementptr inbounds i8, i8* %236, i64 12
-  %NullCheck44 = icmp ne i8* %237, null
-  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i8* %237, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %238
 
 ; <label>:238                                     ; preds = %233
   %239 = load i8, i8* %237, align 8
   %240 = zext i8 %239 to i32
   %241 = trunc i32 %240 to i8
-  %NullCheck46 = icmp ne i8* %235, null
-  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+  %NullCheck45 = icmp eq i8* %235, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %242
 
 ; <label>:242                                     ; preds = %238
   store i8 %241, i8* %235, align 8
@@ -1117,14 +1199,14 @@ entry:
   %244 = load i8*, i8** %arg0
   %245 = load i8*, i8** %arg1
   %246 = bitcast i8* %245 to i64*
-  %NullCheck24 = icmp ne i64* %246, null
-  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64* %246, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %247
 
 ; <label>:247                                     ; preds = %243
   %248 = load i64, i64* %246, align 8
   %249 = bitcast i8* %244 to i64*
-  %NullCheck26 = icmp ne i64* %249, null
-  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64* %249, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %250
 
 ; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
@@ -1133,14 +1215,14 @@ entry:
   %253 = load i8*, i8** %arg1
   %254 = getelementptr inbounds i8, i8* %253, i64 8
   %255 = bitcast i8* %254 to i32*
-  %NullCheck28 = icmp ne i32* %255, null
-  br i1 %NullCheck28, label %256, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i32* %255, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %256
 
 ; <label>:256                                     ; preds = %250
   %257 = load i32, i32* %255, align 8
   %258 = bitcast i8* %252 to i32*
-  %NullCheck30 = icmp ne i32* %258, null
-  br i1 %NullCheck30, label %259, label %ThrowNullRef29
+  %NullCheck29 = icmp eq i32* %258, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %259
 
 ; <label>:259                                     ; preds = %256
   store i32 %257, i32* %258, align 8
@@ -1149,16 +1231,16 @@ entry:
   %262 = load i8*, i8** %arg1
   %263 = getelementptr inbounds i8, i8* %262, i64 12
   %264 = bitcast i8* %263 to i16*
-  %NullCheck32 = icmp ne i16* %264, null
-  br i1 %NullCheck32, label %265, label %ThrowNullRef31
+  %NullCheck31 = icmp eq i16* %264, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %265
 
 ; <label>:265                                     ; preds = %259
   %266 = load i16, i16* %264, align 8
   %267 = sext i16 %266 to i32
   %268 = bitcast i8* %261 to i16*
   %269 = trunc i32 %267 to i16
-  %NullCheck34 = icmp ne i16* %268, null
-  br i1 %NullCheck34, label %270, label %ThrowNullRef33
+  %NullCheck33 = icmp eq i16* %268, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %270
 
 ; <label>:270                                     ; preds = %265
   store i16 %269, i16* %268, align 8
@@ -1168,14 +1250,14 @@ entry:
   %272 = load i8*, i8** %arg0
   %273 = load i8*, i8** %arg1
   %274 = bitcast i8* %273 to i64*
-  %NullCheck8 = icmp ne i64* %274, null
-  br i1 %NullCheck8, label %275, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64* %274, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %275
 
 ; <label>:275                                     ; preds = %271
   %276 = load i64, i64* %274, align 8
   %277 = bitcast i8* %272 to i64*
-  %NullCheck10 = icmp ne i64* %277, null
-  br i1 %NullCheck10, label %278, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %277, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %278
 
 ; <label>:278                                     ; preds = %275
   store i64 %276, i64* %277, align 8
@@ -1184,14 +1266,14 @@ entry:
   %281 = load i8*, i8** %arg1
   %282 = getelementptr inbounds i8, i8* %281, i64 8
   %283 = bitcast i8* %282 to i32*
-  %NullCheck12 = icmp ne i32* %283, null
-  br i1 %NullCheck12, label %284, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i32* %283, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %284
 
 ; <label>:284                                     ; preds = %278
   %285 = load i32, i32* %283, align 8
   %286 = bitcast i8* %280 to i32*
-  %NullCheck14 = icmp ne i32* %286, null
-  br i1 %NullCheck14, label %287, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i32* %286, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %287
 
 ; <label>:287                                     ; preds = %284
   store i32 %285, i32* %286, align 8
@@ -1200,16 +1282,16 @@ entry:
   %290 = load i8*, i8** %arg1
   %291 = getelementptr inbounds i8, i8* %290, i64 12
   %292 = bitcast i8* %291 to i16*
-  %NullCheck16 = icmp ne i16* %292, null
-  br i1 %NullCheck16, label %293, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i16* %292, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %293
 
 ; <label>:293                                     ; preds = %287
   %294 = load i16, i16* %292, align 8
   %295 = sext i16 %294 to i32
   %296 = bitcast i8* %289 to i16*
   %297 = trunc i32 %295 to i16
-  %NullCheck18 = icmp ne i16* %296, null
-  br i1 %NullCheck18, label %298, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i16* %296, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %298
 
 ; <label>:298                                     ; preds = %293
   store i16 %297, i16* %296, align 8
@@ -1217,15 +1299,15 @@ entry:
   %300 = getelementptr inbounds i8, i8* %299, i64 14
   %301 = load i8*, i8** %arg1
   %302 = getelementptr inbounds i8, i8* %301, i64 14
-  %NullCheck20 = icmp ne i8* %302, null
-  br i1 %NullCheck20, label %303, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i8* %302, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %303
 
 ; <label>:303                                     ; preds = %298
   %304 = load i8, i8* %302, align 8
   %305 = zext i8 %304 to i32
   %306 = trunc i32 %305 to i8
-  %NullCheck22 = icmp ne i8* %300, null
-  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i8* %300, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %307
 
 ; <label>:307                                     ; preds = %303
   store i8 %306, i8* %300, align 8
@@ -1235,14 +1317,14 @@ entry:
   %309 = load i8*, i8** %arg0
   %310 = load i8*, i8** %arg1
   %311 = bitcast i8* %310 to i64*
-  %NullCheck = icmp ne i64* %311, null
-  br i1 %NullCheck, label %312, label %ThrowNullRef
+  %NullCheck = icmp eq i64* %311, null
+  br i1 %NullCheck, label %ThrowNullRef, label %312
 
 ; <label>:312                                     ; preds = %308
   %313 = load i64, i64* %311, align 8
   %314 = bitcast i8* %309 to i64*
-  %NullCheck2 = icmp ne i64* %314, null
-  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64* %314, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %315
 
 ; <label>:315                                     ; preds = %312
   store i64 %313, i64* %314, align 8
@@ -1251,14 +1333,14 @@ entry:
   %318 = load i8*, i8** %arg1
   %319 = getelementptr inbounds i8, i8* %318, i64 8
   %320 = bitcast i8* %319 to i64*
-  %NullCheck4 = icmp ne i64* %320, null
-  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64* %320, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %321
 
 ; <label>:321                                     ; preds = %315
   %322 = load i64, i64* %320, align 8
   %323 = bitcast i8* %317 to i64*
-  %NullCheck6 = icmp ne i64* %323, null
-  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64* %323, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %324
 
 ; <label>:324                                     ; preds = %321
   store i64 %322, i64* %323, align 8
@@ -1286,15 +1368,15 @@ entry:
 ; <label>:338                                     ; preds = %333
   %339 = load i8*, i8** %arg0
   %340 = load i8*, i8** %arg1
-  %NullCheck136 = icmp ne i8* %340, null
-  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+  %NullCheck135 = icmp eq i8* %340, null
+  br i1 %NullCheck135, label %ThrowNullRef136, label %341
 
 ; <label>:341                                     ; preds = %338
   %342 = load i8, i8* %340, align 8
   %343 = zext i8 %342 to i32
   %344 = trunc i32 %343 to i8
-  %NullCheck138 = icmp ne i8* %339, null
-  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+  %NullCheck137 = icmp eq i8* %339, null
+  br i1 %NullCheck137, label %ThrowNullRef138, label %345
 
 ; <label>:345                                     ; preds = %341
   store i8 %344, i8* %339, align 8
@@ -1317,16 +1399,16 @@ entry:
   %357 = load i8*, i8** %arg0
   %358 = load i8*, i8** %arg1
   %359 = bitcast i8* %358 to i16*
-  %NullCheck140 = icmp ne i16* %359, null
-  br i1 %NullCheck140, label %360, label %ThrowNullRef139
+  %NullCheck139 = icmp eq i16* %359, null
+  br i1 %NullCheck139, label %ThrowNullRef140, label %360
 
 ; <label>:360                                     ; preds = %356
   %361 = load i16, i16* %359, align 8
   %362 = sext i16 %361 to i32
   %363 = bitcast i8* %357 to i16*
   %364 = trunc i32 %362 to i16
-  %NullCheck142 = icmp ne i16* %363, null
-  br i1 %NullCheck142, label %365, label %ThrowNullRef141
+  %NullCheck141 = icmp eq i16* %363, null
+  br i1 %NullCheck141, label %ThrowNullRef142, label %365
 
 ; <label>:365                                     ; preds = %360
   store i16 %364, i16* %363, align 8
@@ -1352,14 +1434,14 @@ entry:
   %378 = load i8*, i8** %arg0
   %379 = load i8*, i8** %arg1
   %380 = bitcast i8* %379 to i32*
-  %NullCheck144 = icmp ne i32* %380, null
-  br i1 %NullCheck144, label %381, label %ThrowNullRef143
+  %NullCheck143 = icmp eq i32* %380, null
+  br i1 %NullCheck143, label %ThrowNullRef144, label %381
 
 ; <label>:381                                     ; preds = %377
   %382 = load i32, i32* %380, align 8
   %383 = bitcast i8* %378 to i32*
-  %NullCheck146 = icmp ne i32* %383, null
-  br i1 %NullCheck146, label %384, label %ThrowNullRef145
+  %NullCheck145 = icmp eq i32* %383, null
+  br i1 %NullCheck145, label %ThrowNullRef146, label %384
 
 ; <label>:384                                     ; preds = %381
   store i32 %382, i32* %383, align 8
@@ -1384,14 +1466,14 @@ entry:
   %395 = load i8*, i8** %arg0
   %396 = load i8*, i8** %arg1
   %397 = bitcast i8* %396 to i64*
-  %NullCheck164 = icmp ne i64* %397, null
-  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+  %NullCheck163 = icmp eq i64* %397, null
+  br i1 %NullCheck163, label %ThrowNullRef164, label %398
 
 ; <label>:398                                     ; preds = %394
   %399 = load i64, i64* %397, align 8
   %400 = bitcast i8* %395 to i64*
-  %NullCheck166 = icmp ne i64* %400, null
-  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+  %NullCheck165 = icmp eq i64* %400, null
+  br i1 %NullCheck165, label %ThrowNullRef166, label %401
 
 ; <label>:401                                     ; preds = %398
   store i64 %399, i64* %400, align 8
@@ -1400,14 +1482,14 @@ entry:
   %404 = load i8*, i8** %arg1
   %405 = getelementptr inbounds i8, i8* %404, i64 8
   %406 = bitcast i8* %405 to i64*
-  %NullCheck168 = icmp ne i64* %406, null
-  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+  %NullCheck167 = icmp eq i64* %406, null
+  br i1 %NullCheck167, label %ThrowNullRef168, label %407
 
 ; <label>:407                                     ; preds = %401
   %408 = load i64, i64* %406, align 8
   %409 = bitcast i8* %403 to i64*
-  %NullCheck170 = icmp ne i64* %409, null
-  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+  %NullCheck169 = icmp eq i64* %409, null
+  br i1 %NullCheck169, label %ThrowNullRef170, label %410
 
 ; <label>:410                                     ; preds = %407
   store i64 %408, i64* %409, align 8
@@ -1437,14 +1519,14 @@ entry:
   %425 = load i8*, i8** %arg0
   %426 = load i8*, i8** %arg1
   %427 = bitcast i8* %426 to i64*
-  %NullCheck148 = icmp ne i64* %427, null
-  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+  %NullCheck147 = icmp eq i64* %427, null
+  br i1 %NullCheck147, label %ThrowNullRef148, label %428
 
 ; <label>:428                                     ; preds = %424
   %429 = load i64, i64* %427, align 8
   %430 = bitcast i8* %425 to i64*
-  %NullCheck150 = icmp ne i64* %430, null
-  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+  %NullCheck149 = icmp eq i64* %430, null
+  br i1 %NullCheck149, label %ThrowNullRef150, label %431
 
 ; <label>:431                                     ; preds = %428
   store i64 %429, i64* %430, align 8
@@ -1466,14 +1548,14 @@ entry:
   %441 = load i8*, i8** %arg0
   %442 = load i8*, i8** %arg1
   %443 = bitcast i8* %442 to i32*
-  %NullCheck152 = icmp ne i32* %443, null
-  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+  %NullCheck151 = icmp eq i32* %443, null
+  br i1 %NullCheck151, label %ThrowNullRef152, label %444
 
 ; <label>:444                                     ; preds = %440
   %445 = load i32, i32* %443, align 8
   %446 = bitcast i8* %441 to i32*
-  %NullCheck154 = icmp ne i32* %446, null
-  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+  %NullCheck153 = icmp eq i32* %446, null
+  br i1 %NullCheck153, label %ThrowNullRef154, label %447
 
 ; <label>:447                                     ; preds = %444
   store i32 %445, i32* %446, align 8
@@ -1495,16 +1577,16 @@ entry:
   %457 = load i8*, i8** %arg0
   %458 = load i8*, i8** %arg1
   %459 = bitcast i8* %458 to i16*
-  %NullCheck156 = icmp ne i16* %459, null
-  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+  %NullCheck155 = icmp eq i16* %459, null
+  br i1 %NullCheck155, label %ThrowNullRef156, label %460
 
 ; <label>:460                                     ; preds = %456
   %461 = load i16, i16* %459, align 8
   %462 = sext i16 %461 to i32
   %463 = bitcast i8* %457 to i16*
   %464 = trunc i32 %462 to i16
-  %NullCheck158 = icmp ne i16* %463, null
-  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+  %NullCheck157 = icmp eq i16* %463, null
+  br i1 %NullCheck157, label %ThrowNullRef158, label %465
 
 ; <label>:465                                     ; preds = %460
   store i16 %464, i16* %463, align 8
@@ -1525,15 +1607,15 @@ entry:
 ; <label>:474                                     ; preds = %470
   %475 = load i8*, i8** %arg0
   %476 = load i8*, i8** %arg1
-  %NullCheck160 = icmp ne i8* %476, null
-  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+  %NullCheck159 = icmp eq i8* %476, null
+  br i1 %NullCheck159, label %ThrowNullRef160, label %477
 
 ; <label>:477                                     ; preds = %474
   %478 = load i8, i8* %476, align 8
   %479 = zext i8 %478 to i32
   %480 = trunc i32 %479 to i8
-  %NullCheck162 = icmp ne i8* %475, null
-  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+  %NullCheck161 = icmp eq i8* %475, null
+  br i1 %NullCheck161, label %ThrowNullRef162, label %481
 
 ; <label>:481                                     ; preds = %477
   store i8 %480, i8* %475, align 8
@@ -1553,343 +1635,343 @@ ThrowNullRef:                                     ; preds = %308
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %312
+ThrowNullRef2:                                    ; preds = %312
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %315
+ThrowNullRef4:                                    ; preds = %315
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %321
+ThrowNullRef6:                                    ; preds = %321
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %271
+ThrowNullRef8:                                    ; preds = %271
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %275
+ThrowNullRef10:                                   ; preds = %275
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %278
+ThrowNullRef12:                                   ; preds = %278
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %284
+ThrowNullRef14:                                   ; preds = %284
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %287
+ThrowNullRef16:                                   ; preds = %287
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %293
+ThrowNullRef18:                                   ; preds = %293
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %298
+ThrowNullRef20:                                   ; preds = %298
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %303
+ThrowNullRef22:                                   ; preds = %303
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %243
+ThrowNullRef24:                                   ; preds = %243
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %247
+ThrowNullRef26:                                   ; preds = %247
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %250
+ThrowNullRef28:                                   ; preds = %250
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %256
+ThrowNullRef30:                                   ; preds = %256
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %259
+ThrowNullRef32:                                   ; preds = %259
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %265
+ThrowNullRef34:                                   ; preds = %265
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %217
+ThrowNullRef36:                                   ; preds = %217
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %221
+ThrowNullRef38:                                   ; preds = %221
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %224
+ThrowNullRef40:                                   ; preds = %224
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %230
+ThrowNullRef42:                                   ; preds = %230
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %233
+ThrowNullRef44:                                   ; preds = %233
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %238
+ThrowNullRef46:                                   ; preds = %238
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %200
+ThrowNullRef48:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %204
+ThrowNullRef50:                                   ; preds = %204
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %207
+ThrowNullRef52:                                   ; preds = %207
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %213
+ThrowNullRef54:                                   ; preds = %213
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %172
+ThrowNullRef56:                                   ; preds = %172
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %176
+ThrowNullRef58:                                   ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %179
+ThrowNullRef60:                                   ; preds = %179
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %185
+ThrowNullRef62:                                   ; preds = %185
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %190
+ThrowNullRef64:                                   ; preds = %190
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %195
+ThrowNullRef66:                                   ; preds = %195
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %153
+ThrowNullRef68:                                   ; preds = %153
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %157
+ThrowNullRef70:                                   ; preds = %157
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %160
+ThrowNullRef72:                                   ; preds = %160
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %166
+ThrowNullRef74:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %136
+ThrowNullRef76:                                   ; preds = %136
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %140
+ThrowNullRef78:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %143
+ThrowNullRef80:                                   ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %148
+ThrowNullRef82:                                   ; preds = %148
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %128
+ThrowNullRef84:                                   ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %132
+ThrowNullRef86:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %100
+ThrowNullRef88:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %104
+ThrowNullRef90:                                   ; preds = %104
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %107
+ThrowNullRef92:                                   ; preds = %107
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %113
+ThrowNullRef94:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %118
+ThrowNullRef96:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %123
+ThrowNullRef98:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %81
+ThrowNullRef100:                                  ; preds = %81
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef101:                                  ; preds = %85
+ThrowNullRef102:                                  ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef103:                                  ; preds = %88
+ThrowNullRef104:                                  ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef105:                                  ; preds = %94
+ThrowNullRef106:                                  ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef107:                                  ; preds = %64
+ThrowNullRef108:                                  ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef109:                                  ; preds = %68
+ThrowNullRef110:                                  ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef111:                                  ; preds = %71
+ThrowNullRef112:                                  ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef113:                                  ; preds = %76
+ThrowNullRef114:                                  ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef115:                                  ; preds = %56
+ThrowNullRef116:                                  ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef117:                                  ; preds = %60
+ThrowNullRef118:                                  ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef119:                                  ; preds = %37
+ThrowNullRef120:                                  ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef121:                                  ; preds = %41
+ThrowNullRef122:                                  ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef123:                                  ; preds = %46
+ThrowNullRef124:                                  ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef125:                                  ; preds = %51
+ThrowNullRef126:                                  ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef127:                                  ; preds = %27
+ThrowNullRef128:                                  ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef129:                                  ; preds = %31
+ThrowNullRef130:                                  ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef131:                                  ; preds = %19
+ThrowNullRef132:                                  ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef133:                                  ; preds = %22
+ThrowNullRef134:                                  ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef135:                                  ; preds = %338
+ThrowNullRef136:                                  ; preds = %338
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef137:                                  ; preds = %341
+ThrowNullRef138:                                  ; preds = %341
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef139:                                  ; preds = %356
+ThrowNullRef140:                                  ; preds = %356
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef141:                                  ; preds = %360
+ThrowNullRef142:                                  ; preds = %360
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef143:                                  ; preds = %377
+ThrowNullRef144:                                  ; preds = %377
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef145:                                  ; preds = %381
+ThrowNullRef146:                                  ; preds = %381
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef147:                                  ; preds = %424
+ThrowNullRef148:                                  ; preds = %424
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef149:                                  ; preds = %428
+ThrowNullRef150:                                  ; preds = %428
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef151:                                  ; preds = %440
+ThrowNullRef152:                                  ; preds = %440
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef153:                                  ; preds = %444
+ThrowNullRef154:                                  ; preds = %444
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef155:                                  ; preds = %456
+ThrowNullRef156:                                  ; preds = %456
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef157:                                  ; preds = %460
+ThrowNullRef158:                                  ; preds = %460
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef159:                                  ; preds = %474
+ThrowNullRef160:                                  ; preds = %474
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef161:                                  ; preds = %477
+ThrowNullRef162:                                  ; preds = %477
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef163:                                  ; preds = %394
+ThrowNullRef164:                                  ; preds = %394
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef165:                                  ; preds = %398
+ThrowNullRef166:                                  ; preds = %398
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef167:                                  ; preds = %401
+ThrowNullRef168:                                  ; preds = %401
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef169:                                  ; preds = %407
+ThrowNullRef170:                                  ; preds = %407
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1939,8 +2021,8 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
-  br i1 %NullCheck, label %22, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %ThrowNullRef, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
@@ -1948,8 +2030,8 @@ entry:
   store i32 %24, i32* %loc0
   %25 = load i32, i32* %loc0
   %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %26, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %27
 
 ; <label>:27                                      ; preds = %22
   %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
@@ -1971,7 +2053,7 @@ ThrowNullRef:                                     ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1989,8 +2071,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -2022,15 +2104,15 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2048,16 +2130,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
   %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
   store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %15
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
@@ -2072,8 +2154,8 @@ entry:
   %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
   %29 = ptrtoint i16 addrspace(1)* %28 to i64
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %19
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
@@ -2089,19 +2171,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2114,8 +2196,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
@@ -2128,7 +2210,7 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[loadElem]
+Failed to read AppDomain.PrepareDataForSetup[storeElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
@@ -2202,8 +2284,8 @@ entry:
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
-  br i1 %NullCheck24, label %27, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = load i64, i64 addrspace(1)* %26
@@ -2218,8 +2300,8 @@ entry:
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
-  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
   %41 = load i64, i64 addrspace(1)* %39
@@ -2236,8 +2318,8 @@ entry:
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
-  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
   %54 = load i64, i64 addrspace(1)* %52
@@ -2252,8 +2334,8 @@ entry:
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
   %67 = load i64, i64 addrspace(1)* %65
@@ -2270,8 +2352,8 @@ entry:
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
-  br i1 %NullCheck16, label %79, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
   %80 = load i64, i64 addrspace(1)* %78
@@ -2286,8 +2368,8 @@ entry:
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
-  br i1 %NullCheck18, label %92, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
   %93 = load i64, i64 addrspace(1)* %91
@@ -2304,8 +2386,8 @@ entry:
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
-  br i1 %NullCheck12, label %105, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = load i64, i64 addrspace(1)* %104
@@ -2320,8 +2402,8 @@ entry:
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
-  br i1 %NullCheck14, label %118, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
   %119 = load i64, i64 addrspace(1)* %117
@@ -2337,8 +2419,8 @@ entry:
 
 ; <label>:128                                     ; preds = %20
   %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
-  br i1 %NullCheck4, label %130, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %129, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %130
 
 ; <label>:130                                     ; preds = %128
   %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
@@ -2346,8 +2428,8 @@ entry:
   %133 = load i16, i16 addrspace(1)* %132, align 8
   %134 = zext i16 %133 to i32
   %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
-  br i1 %NullCheck6, label %136, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %135, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %136
 
 ; <label>:136                                     ; preds = %130
   %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
@@ -2360,8 +2442,8 @@ entry:
 
 ; <label>:143                                     ; preds = %136
   %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
-  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %144, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %145
 
 ; <label>:145                                     ; preds = %143
   %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
@@ -2369,8 +2451,8 @@ entry:
   %148 = load i16, i16 addrspace(1)* %147, align 8
   %149 = zext i16 %148 to i32
   %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %150, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %151
 
 ; <label>:151                                     ; preds = %145
   %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
@@ -2388,8 +2470,8 @@ entry:
 
 ; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
-  br i1 %NullCheck, label %163, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %ThrowNullRef, label %163
 
 ; <label>:163                                     ; preds = %161
   %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
@@ -2399,8 +2481,8 @@ entry:
 
 ; <label>:167                                     ; preds = %163
   %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
-  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %168, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %169
 
 ; <label>:169                                     ; preds = %167
   %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
@@ -2432,55 +2514,55 @@ ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %167
+ThrowNullRef2:                                    ; preds = %167
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %128
+ThrowNullRef4:                                    ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %130
+ThrowNullRef6:                                    ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %143
+ThrowNullRef8:                                    ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %145
+ThrowNullRef10:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %102
+ThrowNullRef12:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %105
+ThrowNullRef14:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %76
+ThrowNullRef16:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %79
+ThrowNullRef18:                                   ; preds = %79
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %50
+ThrowNullRef20:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %53
+ThrowNullRef22:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %24
+ThrowNullRef24:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %27
+ThrowNullRef26:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2503,15 +2585,15 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2519,16 +2601,16 @@ entry:
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
   store i32 %8, i32* %loc0
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
   %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
   store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
@@ -2546,16 +2628,16 @@ entry:
 
 ; <label>:23                                      ; preds = %64
   %24 = load i16*, i16** %loc3
-  %NullCheck12 = icmp ne i16* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i16* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
   store i32 %27, i32* %loc5
   %28 = load i16*, i16** %loc4
-  %NullCheck14 = icmp ne i16* %28, null
-  br i1 %NullCheck14, label %29, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %28, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = load i16, i16* %28, align 8
@@ -2620,15 +2702,15 @@ entry:
 
 ; <label>:67                                      ; preds = %64
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
-  br i1 %NullCheck8, label %69, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %68, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %69
 
 ; <label>:69                                      ; preds = %67
   %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
   %71 = load i32, i32 addrspace(1)* %70
   %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
-  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %73
 
 ; <label>:73                                      ; preds = %69
   %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
@@ -2645,31 +2727,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %67
+ThrowNullRef8:                                    ; preds = %67
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %69
+ThrowNullRef10:                                   ; preds = %69
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2710,14 +2792,14 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
   %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
@@ -2730,14 +2812,14 @@ entry:
 
 ; <label>:11                                      ; preds = %4
   %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
   %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
@@ -2749,14 +2831,14 @@ entry:
 
 ; <label>:22                                      ; preds = %16
   %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
   %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
-  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
-  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
@@ -2804,23 +2886,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2836,7 +2918,280 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[loadElem]
+Successfully read RuntimeType.IsAssignableFrom
+
+define i8 @RuntimeType.IsAssignableFrom(%System.RuntimeType addrspace(1)* %param0, %System.Type addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.RuntimeType addrspace(1)*
+  %arg1 = alloca %System.Type addrspace(1)*
+  %loc0 = alloca %System.RuntimeType addrspace(1)*
+  %loc1 = alloca %"System.Type[]" addrspace(1)*
+  %loc2 = alloca i32
+  store %System.RuntimeType addrspace(1)* %param0, %System.RuntimeType addrspace(1)** %this
+  store %System.Type addrspace(1)* %param1, %System.Type addrspace(1)** %arg1
+  %0 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %1 = icmp ne %System.Type addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i8 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %5 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %6 = bitcast %System.Type addrspace(1)* %4 to %System.Object addrspace(1)*
+  %7 = bitcast %System.RuntimeType addrspace(1)* %5 to %System.Object addrspace(1)*
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %6, %System.Object addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %3
+  ret i8 1
+
+; <label>:12                                      ; preds = %3
+  %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 152
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 32
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
+  %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
+  %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
+  store %System.RuntimeType addrspace(1)* %25, %System.RuntimeType addrspace(1)** %loc0
+  %26 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %27 = icmp eq %System.RuntimeType addrspace(1)* %26, null
+  br i1 %27, label %34, label %28
+
+; <label>:28                                      ; preds = %15
+  %29 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %30 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)*)*)(%System.RuntimeType addrspace(1)* %29, %System.RuntimeType addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+; <label>:34                                      ; preds = %15
+  %35 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %36 = call %System.Reflection.Emit.TypeBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Reflection.Emit.TypeBuilder addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %35)
+  %37 = icmp eq %System.Reflection.Emit.TypeBuilder addrspace(1)* %36, null
+  br i1 %37, label %139, label %38
+
+; <label>:38                                      ; preds = %34
+  %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %42
+
+; <label>:42                                      ; preds = %38
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 152
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 40
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
+  %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
+  %53 = zext i8 %52 to i32
+  %54 = icmp eq i32 %53, 0
+  br i1 %54, label %56, label %55
+
+; <label>:55                                      ; preds = %42
+  ret i8 1
+
+; <label>:56                                      ; preds = %42
+  %57 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %58 = bitcast %System.RuntimeType addrspace(1)* %57 to %System.Type addrspace(1)*
+  %59 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %58)
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %64 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.Type addrspace(1)* %63, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = bitcast %System.RuntimeType addrspace(1)* %64 to %System.Type addrspace(1)*
+  %67 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %63, %System.Type addrspace(1)* %66)
+  %68 = zext i8 %67 to i32
+  %69 = trunc i32 %68 to i8
+  ret i8 %69
+
+; <label>:70                                      ; preds = %56
+  %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
+  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %73
+
+; <label>:73                                      ; preds = %70
+  %74 = load i64, i64 addrspace(1)* %72
+  %75 = add i64 %74, 128
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = add i64 %77, 0
+  %79 = inttoptr i64 %78 to i64*
+  %80 = load i64, i64* %79
+  %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
+  %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
+  %83 = call i8 %82(%System.Type addrspace(1)* %81)
+  %84 = zext i8 %83 to i32
+  %85 = icmp eq i32 %84, 0
+  br i1 %85, label %139, label %86
+
+; <label>:86                                      ; preds = %73
+  %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
+  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %89
+
+; <label>:89                                      ; preds = %86
+  %90 = load i64, i64 addrspace(1)* %88
+  %91 = add i64 %90, 128
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = add i64 %93, 24
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
+  %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
+  %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
+  store %"System.Type[]" addrspace(1)* %99, %"System.Type[]" addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %129
+
+; <label>:100                                     ; preds = %132
+  %101 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %102 = load i32, i32* %loc2
+  %NullCheck11 = icmp eq %"System.Type[]" addrspace(1)* %101, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %103
+
+; <label>:103                                     ; preds = %100
+  %104 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 1
+  %105 = load i32, i32 addrspace(1)* %104
+  %106 = zext i32 %105 to i64
+  %107 = zext i32 %102 to i64
+  %BoundsCheck = icmp uge i64 %107, %106
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %108
+
+; <label>:108                                     ; preds = %103
+  %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
+  %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
+  %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
+  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %113
+
+; <label>:113                                     ; preds = %108
+  %114 = load i64, i64 addrspace(1)* %112
+  %115 = add i64 %114, 152
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = add i64 %117, 56
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
+  %123 = zext i8 %122 to i32
+  %124 = icmp ne i32 %123, 0
+  br i1 %124, label %126, label %125
+
+; <label>:125                                     ; preds = %113
+  ret i8 0
+
+; <label>:126                                     ; preds = %113
+  %127 = load i32, i32* %loc2
+  %128 = add i32 %127, 1
+  store i32 %128, i32* %loc2
+  br label %129
+
+; <label>:129                                     ; preds = %89, %126
+  %130 = load i32, i32* %loc2
+  %131 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %NullCheck9 = icmp eq %"System.Type[]" addrspace(1)* %131, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %132
+
+; <label>:132                                     ; preds = %129
+  %133 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %131, i32 0, i32 1
+  %134 = load i32, i32 addrspace(1)* %133
+  %135 = zext i32 %134 to i64
+  %136 = trunc i64 %135 to i32
+  %137 = icmp slt i32 %130, %136
+  br i1 %137, label %100, label %138
+
+; <label>:138                                     ; preds = %132
+  ret i8 1
+
+; <label>:139                                     ; preds = %34, %73
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %129
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %103
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -2893,7 +3248,7 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElem]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -2904,8 +3259,8 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -2997,8 +3352,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
@@ -3059,8 +3414,8 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -3087,8 +3442,8 @@ entry:
 
 ; <label>:17                                      ; preds = %5, %11
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
@@ -3097,8 +3452,8 @@ entry:
 
 ; <label>:22                                      ; preds = %1, %11
   %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
@@ -3109,11 +3464,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %17
+ThrowNullRef2:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %22
+ThrowNullRef4:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3167,15 +3522,15 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
   %15 = load i32, i32 addrspace(1)* %14
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
@@ -3198,7 +3553,7 @@ ThrowNullRef:                                     ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef2:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3232,8 +3587,8 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
@@ -3312,8 +3667,8 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -3327,8 +3682,8 @@ entry:
 ; <label>:5                                       ; preds = %43
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %7 = load i32, i32* %loc1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck6, label %8, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
@@ -3366,8 +3721,8 @@ entry:
 ; <label>:32                                      ; preds = %21, %25
   %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
   %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
-  br i1 %NullCheck8, label %35, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = trunc i32 %34 to i16
@@ -3380,8 +3735,8 @@ entry:
 ; <label>:40                                      ; preds = %1, %35
   %41 = load i32, i32* %loc1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
-  br i1 %NullCheck2, label %43, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %42, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
@@ -3392,8 +3747,8 @@ entry:
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
   %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
-  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
   %51 = load i64, i64 addrspace(1)* %49
@@ -3412,19 +3767,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %40
+ThrowNullRef2:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %47
+ThrowNullRef4:                                    ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %5
+ThrowNullRef6:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %32
+ThrowNullRef8:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3467,8 +3822,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
@@ -3492,11 +3847,391 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(i16* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store i16* %param0, i16** %arg0
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load i32, i32* %arg3
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %42, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %37, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg2
+  %13 = load i32, i32* %arg3
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %37, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %24 = load i32, i32* %arg2
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load i16*, i16** %arg0
+  %35 = load i32, i32* %arg3
+  %36 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %36, i16* %34, i32 %35)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:37                                      ; preds = %5, %16
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %39)
+  %41 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41, %System.String addrspace(1)* %38, %System.String addrspace(1)* %40)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41) #0
+  unreachable
+
+; <label>:42                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
-Failed to read StringBuilder.ToString[loadElemA]
+Successfully read StringBuilder.ToString
+
+define %System.String addrspace(1)* @StringBuilder.ToString(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i16*
+  %loc3 = alloca %"System.Char[]" addrspace(1)*
+  %loc4 = alloca i32
+  %loc5 = alloca i32
+  %loc6 = alloca i16 addrspace(1)*
+  %loc7 = alloca %System.String addrspace(1)*
+  %loc8 = alloca %"System.Char[]" addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %0)
+  %2 = icmp ne i32 %1, 0
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %4
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %6)
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %7)
+  store %System.String addrspace(1)* %8, %System.String addrspace(1)** %loc0
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.Text.StringBuilder addrspace(1)* %9, %System.Text.StringBuilder addrspace(1)** %loc1
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  store %System.String addrspace(1)* %10, %System.String addrspace(1)** %loc7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc7
+  %12 = ptrtoint %System.String addrspace(1)* %11 to i64
+  %13 = icmp eq i64 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %5
+  %15 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %16 = sext i32 %15 to i64
+  %17 = add i64 %12, %16
+  br label %18
+
+; <label>:18                                      ; preds = %5, %14
+  %19 = phi i64 [ %12, %5 ], [ %17, %14 ]
+  %20 = inttoptr i64 %19 to i16*
+  store i16* %20, i16** %loc2
+  br label %21
+
+; <label>:21                                      ; preds = %98, %18
+  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %22, null
+  br i1 %NullCheck, label %ThrowNullRef, label %23
+
+; <label>:23                                      ; preds = %21
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 3
+  %25 = load i32, i32 addrspace(1)* %24, align 8
+  %26 = icmp sle i32 %25, 0
+  br i1 %26, label %96, label %27
+
+; <label>:27                                      ; preds = %23
+  %28 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %28, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %29
+
+; <label>:29                                      ; preds = %27
+  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %28, i32 0, i32 1
+  %31 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %30, align 8
+  store %"System.Char[]" addrspace(1)* %31, %"System.Char[]" addrspace(1)** %loc3
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %33
+
+; <label>:33                                      ; preds = %29
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  store i32 %35, i32* %loc4
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  %39 = load i32, i32 addrspace(1)* %38, align 8
+  store i32 %39, i32* %loc5
+  %40 = load i32, i32* %loc5
+  %41 = load i32, i32* %loc4
+  %42 = add i32 %40, %41
+  %43 = zext i32 %42 to i64
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %45
+
+; <label>:45                                      ; preds = %37
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = sext i32 %47 to i64
+  %49 = icmp sgt i64 %43, %48
+  br i1 %49, label %91, label %50
+
+; <label>:50                                      ; preds = %45
+  %51 = load i32, i32* %loc5
+  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %52, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %53
+
+; <label>:53                                      ; preds = %50
+  %54 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %52, i32 0, i32 1
+  %55 = load i32, i32 addrspace(1)* %54
+  %56 = zext i32 %55 to i64
+  %57 = trunc i64 %56 to i32
+  %58 = icmp ugt i32 %51, %57
+  br i1 %58, label %91, label %59
+
+; <label>:59                                      ; preds = %53
+  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  store %"System.Char[]" addrspace(1)* %60, %"System.Char[]" addrspace(1)** %loc8
+  %61 = icmp eq %"System.Char[]" addrspace(1)* %60, null
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %63, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %64
+
+; <label>:64                                      ; preds = %62
+  %65 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %63, i32 0, i32 1
+  %66 = load i32, i32 addrspace(1)* %65
+  %67 = zext i32 %66 to i64
+  %68 = trunc i64 %67 to i32
+  %69 = icmp ne i32 %68, 0
+  br i1 %69, label %71, label %70
+
+; <label>:70                                      ; preds = %59, %64
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:71                                      ; preds = %64
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %73
+
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %BoundsCheck = icmp uge i64 0, %76
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %77
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %78, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:79                                      ; preds = %70, %77
+  %80 = load i16*, i16** %loc2
+  %81 = load i32, i32* %loc4
+  %82 = sext i32 %81 to i64
+  %83 = mul i64 %82, 2
+  %84 = bitcast i16* %80 to i8*
+  %85 = getelementptr inbounds i8, i8* %84, i64 %83
+  %86 = load i16 addrspace(1)*, i16 addrspace(1)** %loc6
+  %87 = ptrtoint i16 addrspace(1)* %86 to i64
+  %88 = load i32, i32* %loc5
+  %89 = bitcast i8* %85 to i16*
+  %90 = inttoptr i64 %87 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %89, i16* %90, i32 %88)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %96
+
+; <label>:91                                      ; preds = %45, %53
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %94 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %93)
+  %95 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95, %System.String addrspace(1)* %92, %System.String addrspace(1)* %94)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95) #0
+  unreachable
+
+; <label>:96                                      ; preds = %23, %79
+  %97 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %97, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %98
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %97, i32 0, i32 2
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  store %System.Text.StringBuilder addrspace(1)* %100, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %102 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %102, label %21, label %103
+
+; <label>:103                                     ; preds = %98
+  store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc7
+  %104 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  ret %System.String addrspace(1)* %104
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method StringBuilder::get_Length using LLILCJit
+Successfully read StringBuilder.get_Length
+
+define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
+Successfully read RuntimeHelpers.get_OffsetToStringData
+
+define i32 @RuntimeHelpers.get_OffsetToStringData() {
+entry:
+  ret i32 12
+}
+
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
 Successfully read CultureData.CreateCultureData
 
@@ -3514,23 +4249,23 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
   store i8 %4, i8 addrspace(1)* %6
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
@@ -3549,11 +4284,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3566,50 +4301,50 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
   store i32 -1, i32 addrspace(1)* %2
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
   store i32 -1, i32 addrspace(1)* %8
   %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
   store i32 -1, i32 addrspace(1)* %14
   %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
   store i32 -1, i32 addrspace(1)* %17
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
@@ -3623,27 +4358,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3675,7 +4410,136 @@ Failed to read Dictionary`2.Insert[non-const derefAddress]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
 Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
-Failed to read HashHelpers.GetPrime[loadElem]
+Successfully read HashHelpers.GetPrime
+
+define i32 @HashHelpers.GetPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %6, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5, %System.String addrspace(1)* %4)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5) #0
+  unreachable
+
+; <label>:6                                       ; preds = %entry
+  store i32 0, i32* %loc0
+  br label %29
+
+; <label>:7                                       ; preds = %35
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 1296
+  %10 = addrspacecast i8 addrspace(1)* %9 to %"System.Int32[]" addrspace(1)**
+  %11 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %10
+  %12 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Int32[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = zext i32 %15 to i64
+  %17 = zext i32 %12 to i64
+  %BoundsCheck = icmp uge i64 %17, %16
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 3, i32 %12
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  store i32 %20, i32* %loc1
+  %21 = load i32, i32* %loc1
+  %22 = load i32, i32* %arg0
+  %23 = icmp slt i32 %21, %22
+  br i1 %23, label %26, label %24
+
+; <label>:24                                      ; preds = %18
+  %25 = load i32, i32* %loc1
+  ret i32 %25
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %loc0
+  %28 = add i32 %27, 1
+  store i32 %28, i32* %loc0
+  br label %29
+
+; <label>:29                                      ; preds = %6, %26
+  %30 = load i32, i32* %loc0
+  %31 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %32 = getelementptr inbounds i8, i8 addrspace(1)* %31, i64 1296
+  %33 = addrspacecast i8 addrspace(1)* %32 to %"System.Int32[]" addrspace(1)**
+  %34 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %33
+  %NullCheck = icmp eq %"System.Int32[]" addrspace(1)* %34, null
+  br i1 %NullCheck, label %ThrowNullRef, label %35
+
+; <label>:35                                      ; preds = %29
+  %36 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %34, i32 0, i32 1
+  %37 = load i32, i32 addrspace(1)* %36
+  %38 = zext i32 %37 to i64
+  %39 = trunc i64 %38 to i32
+  %40 = icmp slt i32 %30, %39
+  br i1 %40, label %7, label %41
+
+; <label>:41                                      ; preds = %35
+  %42 = load i32, i32* %arg0
+  %43 = or i32 %42, 1
+  store i32 %43, i32* %loc2
+  br label %59
+
+; <label>:44                                      ; preds = %59
+  %45 = load i32, i32* %loc2
+  %46 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %45)
+  %47 = zext i8 %46 to i32
+  %48 = icmp eq i32 %47, 0
+  br i1 %48, label %56, label %49
+
+; <label>:49                                      ; preds = %44
+  %50 = load i32, i32* %loc2
+  %51 = sub i32 %50, 1
+  %52 = srem i32 %51, 101
+  %53 = icmp eq i32 %52, 0
+  br i1 %53, label %56, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = load i32, i32* %loc2
+  ret i32 %55
+
+; <label>:56                                      ; preds = %44, %49
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %57, 2
+  store i32 %58, i32* %loc2
+  br label %59
+
+; <label>:59                                      ; preds = %41, %56
+  %60 = load i32, i32* %loc2
+  %61 = icmp slt i32 %60, 2147483647
+  br i1 %61, label %44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load i32, i32* %arg0
+  ret i32 %63
+
+ThrowNullRef:                                     ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
 Successfully read GenericEqualityComparer`1.GetHashCode
 
@@ -3694,14 +4558,14 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
   %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load i64, i64 addrspace(1)* %7
@@ -3720,7 +4584,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3750,8 +4614,8 @@ entry:
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
@@ -3796,8 +4660,8 @@ entry:
   %35 = bitcast i16* %34 to i8*
   %36 = getelementptr inbounds i8, i8* %35, i64 2
   %37 = bitcast i8* %36 to i16*
-  %NullCheck4 = icmp ne i16* %37, null
-  br i1 %NullCheck4, label %38, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %37, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %38
 
 ; <label>:38                                      ; preds = %27
   %39 = load i16, i16* %37, align 8
@@ -3824,8 +4688,8 @@ entry:
 
 ; <label>:54                                      ; preds = %22, %43
   %55 = load i16*, i16** %loc4
-  %NullCheck2 = icmp ne i16* %55, null
-  br i1 %NullCheck2, label %56, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i16* %55, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %56
 
 ; <label>:56                                      ; preds = %54
   %57 = load i16, i16* %55, align 8
@@ -3850,11 +4714,11 @@ ThrowNullRef:                                     ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %54
+ThrowNullRef2:                                    ; preds = %54
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %27
+ThrowNullRef4:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3871,8 +4735,8 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -3907,8 +4771,8 @@ entry:
 
 ; <label>:26                                      ; preds = %19
   %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
-  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %28
 
 ; <label>:28                                      ; preds = %26
   %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
@@ -3920,7 +4784,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3972,8 +4836,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
@@ -3984,26 +4848,26 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
-  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
@@ -4014,8 +4878,8 @@ entry:
 ; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
@@ -4024,8 +4888,8 @@ entry:
 
 ; <label>:25                                      ; preds = %1, %16, %23
   %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
-  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
@@ -4036,27 +4900,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %20
+ThrowNullRef10:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4069,8 +4933,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -4081,8 +4945,8 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
@@ -4091,8 +4955,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1, %8
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
@@ -4103,11 +4967,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4128,24 +4992,24 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   store i32 %3, i32* %loc0
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
   %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
   store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck4, label %9, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
@@ -4164,15 +5028,15 @@ entry:
 ; <label>:18                                      ; preds = %70
   %19 = load i16*, i16** %loc3
   %20 = bitcast i16* %19 to i64*
-  %NullCheck10 = icmp ne i64* %20, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %20, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = load i64, i64* %20, align 8
   %23 = load i16*, i16** %loc4
   %24 = bitcast i16* %23 to i64*
-  %NullCheck12 = icmp ne i64* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = load i64, i64* %24, align 8
@@ -4188,8 +5052,8 @@ entry:
   %31 = bitcast i16* %30 to i8*
   %32 = getelementptr inbounds i8, i8* %31, i64 8
   %33 = bitcast i8* %32 to i64*
-  %NullCheck14 = icmp ne i64* %33, null
-  br i1 %NullCheck14, label %34, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = load i64, i64* %33, align 8
@@ -4197,8 +5061,8 @@ entry:
   %37 = bitcast i16* %36 to i8*
   %38 = getelementptr inbounds i8, i8* %37, i64 8
   %39 = bitcast i8* %38 to i64*
-  %NullCheck16 = icmp ne i64* %39, null
-  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %40
 
 ; <label>:40                                      ; preds = %34
   %41 = load i64, i64* %39, align 8
@@ -4214,8 +5078,8 @@ entry:
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %NullCheck18 = icmp ne i64* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = load i64, i64* %48, align 8
@@ -4223,8 +5087,8 @@ entry:
   %52 = bitcast i16* %51 to i8*
   %53 = getelementptr inbounds i8, i8* %52, i64 16
   %54 = bitcast i8* %53 to i64*
-  %NullCheck20 = icmp ne i64* %54, null
-  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64* %54, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %55
 
 ; <label>:55                                      ; preds = %49
   %56 = load i64, i64* %54, align 8
@@ -4262,15 +5126,15 @@ entry:
 ; <label>:74                                      ; preds = %95
   %75 = load i16*, i16** %loc3
   %76 = bitcast i16* %75 to i32*
-  %NullCheck6 = icmp ne i32* %76, null
-  br i1 %NullCheck6, label %77, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32* %76, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %77
 
 ; <label>:77                                      ; preds = %74
   %78 = load i32, i32* %76, align 8
   %79 = load i16*, i16** %loc4
   %80 = bitcast i16* %79 to i32*
-  %NullCheck8 = icmp ne i32* %80, null
-  br i1 %NullCheck8, label %81, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i32* %80, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %81
 
 ; <label>:81                                      ; preds = %77
   %82 = load i32, i32* %80, align 8
@@ -4318,43 +5182,43 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %74
+ThrowNullRef6:                                    ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %77
+ThrowNullRef8:                                    ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %29
+ThrowNullRef14:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %34
+ThrowNullRef16:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4376,8 +5240,8 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load i64, i64 addrspace(1)* %4
@@ -4389,8 +5253,8 @@ entry:
   %12 = load i64, i64* %11
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %5
   %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
@@ -4399,8 +5263,8 @@ entry:
   %18 = load i8, i8* %arg2
   %19 = zext i8 %18 to i32
   %20 = trunc i32 %19 to i8
-  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %15
   %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
@@ -4411,11 +5275,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4442,8 +5306,8 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
@@ -4466,16 +5330,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
   %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = load i64, i64 addrspace(1)* %19
@@ -4500,8 +5364,8 @@ entry:
 ; <label>:35                                      ; preds = %30
   %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
@@ -4514,8 +5378,8 @@ entry:
 
 ; <label>:42                                      ; preds = %1, %38
   %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
-  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
@@ -4526,19 +5390,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %35
+ThrowNullRef2:                                    ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %42
+ThrowNullRef8:                                    ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4551,14 +5415,14 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
@@ -4570,7 +5434,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4583,8 +5447,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
@@ -4613,51 +5477,51 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
   %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
   %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
   %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
   %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
-  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
   store i64 %21, i64 addrspace(1)* %23
   %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %25 = load i64, i64* %loc0
-  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
@@ -4668,27 +5532,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %22
+ThrowNullRef12:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4701,8 +5565,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
@@ -4713,19 +5577,19 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
@@ -4734,8 +5598,8 @@ entry:
 
 ; <label>:15                                      ; preds = %1, %13
   %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
@@ -4746,19 +5610,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %15
+ThrowNullRef8:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4771,8 +5635,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -4831,8 +5695,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
@@ -4882,8 +5746,8 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
-  br i1 %NullCheck, label %17, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %ThrowNullRef, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
@@ -4894,15 +5758,15 @@ entry:
 
 ; <label>:22                                      ; preds = %17
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
-  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
   %26 = load i32, i32 addrspace(1)* %25
   %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
-  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %27, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
@@ -4925,8 +5789,8 @@ entry:
 ; <label>:40                                      ; preds = %17
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
-  br i1 %NullCheck6, label %43, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %41, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
@@ -4938,34 +5802,17 @@ ThrowNullRef:                                     ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %24
+ThrowNullRef4:                                    ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %40
+ThrowNullRef6:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
-}
-
-INFO:  jitting method Object::ReferenceEquals using LLILCJit
-Successfully read Object.ReferenceEquals
-
-define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
-entry:
-  %arg0 = alloca %System.Object addrspace(1)*
-  %arg1 = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
-  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
-  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = icmp eq %System.Object addrspace(1)* %0, %1
-  %3 = sext i1 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
 }
 
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
@@ -4978,21 +5825,21 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
   %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
-  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
@@ -5007,28 +5854,28 @@ entry:
 ; <label>:13                                      ; preds = %8, %12
   %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
   %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
   %21 = load i32, i32 addrspace(1)* %20, align 8
   %22 = add i32 %21, 1
-  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
   store i32 %22, i32 addrspace(1)* %24
   %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
@@ -5039,27 +5886,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5077,7 +5924,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::Setup using LLILCJit
-Failed to read AppDomain.Setup[loadElem]
+Failed to read AppDomain.Setup[unbox]
 INFO:  jitting method Thread::GetDomain using LLILCJit
 Successfully read Thread.GetDomain
 
@@ -5108,8 +5955,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
@@ -5122,14 +5969,14 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
   %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
@@ -5141,11 +5988,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5173,8 +6020,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -5189,7 +6036,328 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
 Failed to read KeyCollection.System.Collections.Generic.IEnumerable<TKey>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Successfully read Enumerator.MoveNext
+
+define i8 @Enumerator.MoveNext(%"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.RuntimeTypeHandle* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*
+  %"$TypeArg" = alloca %System.RuntimeTypeHandle*
+  store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
+  %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 8
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %76, label %12
+
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
+  br label %76
+
+; <label>:13                                      ; preds = %85
+  %14 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck19 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %15
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, i32 0, i32 0
+  %17 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %16, align 8
+  %NullCheck21 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, i32 0, i32 2
+  %20 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %19, align 8
+  %21 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck23 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %22
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, i32 0, i32 2
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %NullCheck25 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 3, i32 %24
+  %NullCheck27 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %32
+
+; <label>:32                                      ; preds = %30
+  %33 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, i32 0, i32 2
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = icmp slt i32 %34, 0
+  br i1 %35, label %68, label %36
+
+; <label>:36                                      ; preds = %32
+  %37 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %38 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck29 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %39
+
+; <label>:39                                      ; preds = %36
+  %40 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, i32 0, i32 0
+  %41 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %40, align 8
+  %NullCheck31 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, i32 0, i32 2
+  %44 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %43, align 8
+  %45 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck33 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, i32 0, i32 2
+  %48 = load i32, i32 addrspace(1)* %47, align 8
+  %NullCheck35 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %49
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = zext i32 %51 to i64
+  %53 = zext i32 %48 to i64
+  %BoundsCheck37 = icmp uge i64 %53, %52
+  br i1 %BoundsCheck37, label %ThrowIndexOutOfRange38, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 3, i32 %48
+  %NullCheck39 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %56
+
+; <label>:56                                      ; preds = %54
+  %57 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, i32 0, i32 0
+  %58 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck41 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %59
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %60, %System.__Canon addrspace(1)* %58)
+  %61 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck43 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  %64 = load i32, i32 addrspace(1)* %63, align 8
+  %65 = add i32 %64, 1
+  %NullCheck45 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  store i32 %65, i32 addrspace(1)* %67
+  ret i8 1
+
+; <label>:68                                      ; preds = %32
+  %69 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck47 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %73 = add i32 %72, 1
+  %NullCheck49 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %74
+
+; <label>:74                                      ; preds = %70
+  %75 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  store i32 %73, i32 addrspace(1)* %75
+  br label %76
+
+; <label>:76                                      ; preds = %8, %12, %74
+  %77 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %78
+
+; <label>:78                                      ; preds = %76
+  %79 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, i32 0, i32 2
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck7 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %82
+
+; <label>:82                                      ; preds = %78
+  %83 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, i32 0, i32 0
+  %84 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %83, align 8
+  %NullCheck9 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %85
+
+; <label>:85                                      ; preds = %82
+  %86 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, i32 0, i32 7
+  %87 = load i32, i32 addrspace(1)* %86, align 8
+  %88 = icmp ult i32 %80, %87
+  br i1 %88, label %13, label %89
+
+; <label>:89                                      ; preds = %85
+  %90 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %91 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck11 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %92
+
+; <label>:92                                      ; preds = %89
+  %93 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, i32 0, i32 0
+  %94 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck13 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %95
+
+; <label>:95                                      ; preds = %92
+  %96 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, i32 0, i32 7
+  %97 = load i32, i32 addrspace(1)* %96, align 8
+  %98 = add i32 %97, 1
+  %NullCheck15 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %99
+
+; <label>:99                                      ; preds = %95
+  %100 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, i32 0, i32 2
+  store i32 %98, i32 addrspace(1)* %100
+  %101 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck17 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %102
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %103, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %92
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef22:                                   ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef24:                                   ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef26:                                   ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef28:                                   ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef30:                                   ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef32:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef34:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef36:                                   ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange38:                           ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef40:                                   ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef42:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef44:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef46:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef48:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef50:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -5200,8 +6368,8 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -5232,9 +6400,9 @@ Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
 Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
-Failed to read String.MakeSeparatorList[loadElemA]
+Failed to read String.MakeSeparatorList[storeElem]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
-Failed to read String.InternalSplitKeepEmptyEntries[loadElem]
+Failed to read String.InternalSplitKeepEmptyEntries[storeElem]
 INFO:  jitting method Path::IsRelative using LLILCJit
 Successfully read Path.IsRelative
 
@@ -5243,8 +6411,8 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -5254,8 +6422,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
@@ -5271,8 +6439,8 @@ entry:
 
 ; <label>:17                                      ; preds = %7
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
@@ -5288,8 +6456,8 @@ entry:
 
 ; <label>:29                                      ; preds = %19
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %31
 
 ; <label>:31                                      ; preds = %29
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
@@ -5300,8 +6468,8 @@ entry:
 
 ; <label>:36                                      ; preds = %31
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
-  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %37, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
@@ -5312,8 +6480,8 @@ entry:
 
 ; <label>:43                                      ; preds = %31, %38
   %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
-  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %45
 
 ; <label>:45                                      ; preds = %43
   %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
@@ -5324,8 +6492,8 @@ entry:
 
 ; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %50
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
@@ -5336,8 +6504,8 @@ entry:
 
 ; <label>:57                                      ; preds = %1, %7, %19, %45, %52
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
-  br i1 %NullCheck14, label %59, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %59
 
 ; <label>:59                                      ; preds = %57
   %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
@@ -5347,8 +6515,8 @@ entry:
 
 ; <label>:63                                      ; preds = %59
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
@@ -5359,8 +6527,8 @@ entry:
 
 ; <label>:70                                      ; preds = %65
   %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
-  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.String addrspace(1)* %71, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %72
 
 ; <label>:72                                      ; preds = %70
   %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
@@ -5379,39 +6547,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %17
+ThrowNullRef4:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %29
+ThrowNullRef6:                                    ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %36
+ThrowNullRef8:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %43
+ThrowNullRef10:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %50
+ThrowNullRef12:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %57
+ThrowNullRef14:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %63
+ThrowNullRef16:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %70
+ThrowNullRef18:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5419,7 +6587,293 @@ ThrowNullRef17:                                   ; preds = %70
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
-Failed to read String.TrimHelper[loadElem]
+Successfully read String.TrimHelper
+
+define %System.String addrspace(1)* @String.TrimHelper(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i16
+  %loc4 = alloca i32
+  %loc5 = alloca i16
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = sub i32 %3, 1
+  store i32 %4, i32* %loc0
+  store i32 0, i32* %loc1
+  %5 = load i32, i32* %arg2
+  %6 = icmp eq i32 %5, 1
+  br i1 %6, label %62, label %7
+
+; <label>:7                                       ; preds = %1
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:8                                       ; preds = %58
+  store i32 0, i32* %loc2
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load i32, i32* %loc1
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2, i32 %10
+  %13 = load i16, i16 addrspace(1)* %12
+  %14 = zext i16 %13 to i32
+  %15 = trunc i32 %14 to i16
+  store i16 %15, i16* %loc3
+  store i32 0, i32* %loc2
+  br label %34
+
+; <label>:16                                      ; preds = %37
+  %17 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %18 = load i32, i32* %loc2
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %17, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %19
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = zext i32 %18 to i64
+  %BoundsCheck = icmp uge i64 %23, %22
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %24
+
+; <label>:24                                      ; preds = %19
+  %25 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 3, i32 %18
+  %26 = load i16, i16 addrspace(1)* %25, align 8
+  %27 = zext i16 %26 to i32
+  %28 = load i16, i16* %loc3
+  %29 = zext i16 %28 to i32
+  %30 = icmp eq i32 %27, %29
+  br i1 %30, label %43, label %31
+
+; <label>:31                                      ; preds = %24
+  %32 = load i32, i32* %loc2
+  %33 = add i32 %32, 1
+  store i32 %33, i32* %loc2
+  br label %34
+
+; <label>:34                                      ; preds = %11, %31
+  %35 = load i32, i32* %loc2
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = icmp slt i32 %35, %41
+  br i1 %42, label %16, label %43
+
+; <label>:43                                      ; preds = %24, %37
+  %44 = load i32, i32* %loc2
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %45, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp eq i32 %44, %50
+  br i1 %51, label %62, label %52
+
+; <label>:52                                      ; preds = %46
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %7, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %57, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %58
+
+; <label>:58                                      ; preds = %55
+  %59 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %60 = load i32, i32 addrspace(1)* %59
+  %61 = icmp slt i32 %56, %60
+  br i1 %61, label %8, label %62
+
+; <label>:62                                      ; preds = %1, %46, %58
+  %63 = load i32, i32* %arg2
+  %64 = icmp eq i32 %63, 0
+  br i1 %64, label %122, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %66, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %67
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %66, i32 0, i32 1
+  %69 = load i32, i32 addrspace(1)* %68
+  %70 = sub i32 %69, 1
+  store i32 %70, i32* %loc0
+  br label %118
+
+; <label>:71                                      ; preds = %118
+  store i32 0, i32* %loc4
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %73 = load i32, i32* %loc0
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %74
+
+; <label>:74                                      ; preds = %71
+  %75 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 2, i32 %73
+  %76 = load i16, i16 addrspace(1)* %75
+  %77 = zext i16 %76 to i32
+  %78 = trunc i32 %77 to i16
+  store i16 %78, i16* %loc5
+  store i32 0, i32* %loc4
+  br label %97
+
+; <label>:79                                      ; preds = %100
+  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %81 = load i32, i32* %loc4
+  %NullCheck19 = icmp eq %"System.Char[]" addrspace(1)* %80, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
+
+; <label>:82                                      ; preds = %79
+  %83 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 1
+  %84 = load i32, i32 addrspace(1)* %83
+  %85 = zext i32 %84 to i64
+  %86 = zext i32 %81 to i64
+  %BoundsCheck21 = icmp uge i64 %86, %85
+  br i1 %BoundsCheck21, label %ThrowIndexOutOfRange22, label %87
+
+; <label>:87                                      ; preds = %82
+  %88 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 3, i32 %81
+  %89 = load i16, i16 addrspace(1)* %88, align 8
+  %90 = zext i16 %89 to i32
+  %91 = load i16, i16* %loc5
+  %92 = zext i16 %91 to i32
+  %93 = icmp eq i32 %90, %92
+  br i1 %93, label %106, label %94
+
+; <label>:94                                      ; preds = %87
+  %95 = load i32, i32* %loc4
+  %96 = add i32 %95, 1
+  store i32 %96, i32* %loc4
+  br label %97
+
+; <label>:97                                      ; preds = %74, %94
+  %98 = load i32, i32* %loc4
+  %99 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck15 = icmp eq %"System.Char[]" addrspace(1)* %99, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %100
+
+; <label>:100                                     ; preds = %97
+  %101 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %99, i32 0, i32 1
+  %102 = load i32, i32 addrspace(1)* %101
+  %103 = zext i32 %102 to i64
+  %104 = trunc i64 %103 to i32
+  %105 = icmp slt i32 %98, %104
+  br i1 %105, label %79, label %106
+
+; <label>:106                                     ; preds = %87, %100
+  %107 = load i32, i32* %loc4
+  %108 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck17 = icmp eq %"System.Char[]" addrspace(1)* %108, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %109
+
+; <label>:109                                     ; preds = %106
+  %110 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %108, i32 0, i32 1
+  %111 = load i32, i32 addrspace(1)* %110
+  %112 = zext i32 %111 to i64
+  %113 = trunc i64 %112 to i32
+  %114 = icmp eq i32 %107, %113
+  br i1 %114, label %122, label %115
+
+; <label>:115                                     ; preds = %109
+  %116 = load i32, i32* %loc0
+  %117 = sub i32 %116, 1
+  store i32 %117, i32* %loc0
+  br label %118
+
+; <label>:118                                     ; preds = %67, %115
+  %119 = load i32, i32* %loc0
+  %120 = load i32, i32* %loc1
+  %121 = icmp sge i32 %119, %120
+  br i1 %121, label %71, label %122
+
+; <label>:122                                     ; preds = %62, %109, %118
+  %123 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %124 = load i32, i32* %loc1
+  %125 = load i32, i32* %loc0
+  %126 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %123, i32 %124, i32 %125)
+  ret %System.String addrspace(1)* %126
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %97
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange22:                           ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
 Successfully read String.CreateTrimmedString
 
@@ -5439,8 +6893,8 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
@@ -5535,8 +6989,8 @@ entry:
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i64 2872
   %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
   %8 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %7
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %3
   %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
@@ -5553,8 +7007,8 @@ entry:
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 2864
   %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
   %21 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %20
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
-  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %22
 
 ; <label>:22                                      ; preds = %16
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
@@ -5569,7 +7023,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %16
+ThrowNullRef2:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5586,8 +7040,8 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5613,8 +7067,8 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
@@ -5632,8 +7086,8 @@ entry:
 
 ; <label>:12                                      ; preds = %4
   %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
@@ -5644,8 +7098,8 @@ entry:
 
 ; <label>:19                                      ; preds = %14
   %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %19
   %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
@@ -5660,21 +7114,21 @@ entry:
   %31 = zext i16 %30 to i32
   %32 = bitcast i8* %29 to i16*
   %33 = trunc i32 %31 to i16
-  %NullCheck6 = icmp ne i16* %32, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i16* %32, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %21
   store i16 %33, i16* %32, align 8
   %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %36
 
 ; <label>:36                                      ; preds = %34
   %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
   %38 = load i32, i32 addrspace(1)* %37, align 8
   %39 = add i32 %38, 1
-  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %40
 
 ; <label>:40                                      ; preds = %36
   %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
@@ -5683,16 +7137,16 @@ entry:
 
 ; <label>:42                                      ; preds = %14
   %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
-  br i1 %NullCheck12, label %44, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
   %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
   %47 = load i16, i16* %arg1
   %48 = zext i16 %47 to i32
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = trunc i32 %48 to i16
@@ -5703,31 +7157,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %19
+ThrowNullRef4:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %21
+ThrowNullRef6:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %36
+ThrowNullRef10:                                   ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %42
+ThrowNullRef12:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %44
+ThrowNullRef14:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5740,8 +7194,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -5752,8 +7206,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
@@ -5762,14 +7216,14 @@ entry:
 
 ; <label>:11                                      ; preds = %1
   %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
@@ -5779,15 +7233,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5808,8 +7262,8 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5822,8 +7276,8 @@ entry:
 
 ; <label>:8                                       ; preds = %3
   %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
@@ -5842,15 +7296,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
-  br i1 %NullCheck4, label %22, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
   %24 = load i16*, i16* addrspace(1)* %23, align 8
   %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %25, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
@@ -5859,8 +7313,8 @@ entry:
   store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
@@ -5874,8 +7328,8 @@ entry:
 
 ; <label>:37                                      ; preds = %65
   %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %37
   %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
@@ -5886,16 +7340,16 @@ entry:
   %45 = bitcast i16* %41 to i8*
   %46 = getelementptr inbounds i8, i8* %45, i64 %44
   %47 = bitcast i8* %46 to i16*
-  %NullCheck14 = icmp ne i16* %47, null
-  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %47, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %48
 
 ; <label>:48                                      ; preds = %39
   %49 = load i16, i16* %47, align 8
   %50 = zext i16 %49 to i32
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %52 = load i32, i32* %loc1
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %53
 
 ; <label>:53                                      ; preds = %48
   %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
@@ -5916,8 +7370,8 @@ entry:
 ; <label>:62                                      ; preds = %36, %59
   %63 = load i32, i32* %loc1
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck10, label %65, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %65
 
 ; <label>:65                                      ; preds = %62
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
@@ -5936,15 +7390,15 @@ entry:
 
 ; <label>:74                                      ; preds = %70
   %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
-  br i1 %NullCheck18, label %76, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %76
 
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
   %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
-  br i1 %NullCheck20, label %80, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
   %81 = load i64, i64 addrspace(1)* %79
@@ -5958,8 +7412,8 @@ entry:
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
   %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
-  br i1 %NullCheck22, label %92, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.String addrspace(1)* %90, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %92
 
 ; <label>:92                                      ; preds = %80
   %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
@@ -5969,15 +7423,15 @@ entry:
 
 ; <label>:96                                      ; preds = %70
   %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
-  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %98
 
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
   %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
-  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
   %103 = load i64, i64 addrspace(1)* %101
@@ -5991,8 +7445,8 @@ entry:
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
   %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
-  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.String addrspace(1)* %112, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %114
 
 ; <label>:114                                     ; preds = %102
   %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
@@ -6004,59 +7458,59 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %20
+ThrowNullRef4:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %22
+ThrowNullRef6:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %26
+ThrowNullRef8:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %62
+ThrowNullRef10:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %48
+ThrowNullRef16:                                   ; preds = %48
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %74
+ThrowNullRef18:                                   ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %76
+ThrowNullRef20:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %80
+ThrowNullRef22:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %96
+ThrowNullRef24:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %98
+ThrowNullRef26:                                   ; preds = %98
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %102
+ThrowNullRef28:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6069,15 +7523,15 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
   %3 = load i16*, i16* addrspace(1)* %2, align 8
   %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
@@ -6087,8 +7541,8 @@ entry:
   %10 = bitcast i16* %3 to i8*
   %11 = getelementptr inbounds i8, i8* %10, i64 %9
   %12 = bitcast i8* %11 to i16*
-  %NullCheck4 = icmp ne i16* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %5
   store i16 0, i16* %12, align 8
@@ -6098,11 +7552,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6119,8 +7573,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -6131,8 +7585,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
@@ -6144,15 +7598,15 @@ entry:
 
 ; <label>:14                                      ; preds = %1
   %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
   %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
   %21 = load i64, i64 addrspace(1)* %19
@@ -6171,15 +7625,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %14
+ThrowNullRef4:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %16
+ThrowNullRef6:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6302,14 +7756,6 @@ entry:
   ret %System.String addrspace(1)* %57
 }
 
-INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
-Successfully read RuntimeHelpers.get_OffsetToStringData
-
-define i32 @RuntimeHelpers.get_OffsetToStringData() {
-entry:
-  ret i32 12
-}
-
 INFO:  jitting method String::Equals using LLILCJit
 Successfully read String.Equals
 
@@ -6381,8 +7827,8 @@ entry:
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
-  br i1 %NullCheck24, label %29, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
   %30 = load i64, i64 addrspace(1)* %28
@@ -6397,8 +7843,8 @@ entry:
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
-  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
   %43 = load i64, i64 addrspace(1)* %41
@@ -6418,8 +7864,8 @@ entry:
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
   %59 = load i64, i64 addrspace(1)* %57
@@ -6434,8 +7880,8 @@ entry:
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck22, label %71, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
   %72 = load i64, i64 addrspace(1)* %70
@@ -6455,8 +7901,8 @@ entry:
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
-  br i1 %NullCheck16, label %87, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = load i64, i64 addrspace(1)* %86
@@ -6471,8 +7917,8 @@ entry:
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck18, label %100, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
   %101 = load i64, i64 addrspace(1)* %99
@@ -6492,8 +7938,8 @@ entry:
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
-  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
   %117 = load i64, i64 addrspace(1)* %115
@@ -6508,8 +7954,8 @@ entry:
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
-  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
   %130 = load i64, i64 addrspace(1)* %128
@@ -6528,15 +7974,15 @@ entry:
 
 ; <label>:142                                     ; preds = %22
   %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
-  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %143, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %144
 
 ; <label>:144                                     ; preds = %142
   %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
   %146 = load i32, i32 addrspace(1)* %145
   %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
-  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %147, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %148
 
 ; <label>:148                                     ; preds = %144
   %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
@@ -6557,15 +8003,15 @@ entry:
 
 ; <label>:159                                     ; preds = %22
   %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
-  br i1 %NullCheck, label %161, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %ThrowNullRef, label %161
 
 ; <label>:161                                     ; preds = %159
   %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
   %163 = load i32, i32 addrspace(1)* %162
   %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
-  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %164, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %165
 
 ; <label>:165                                     ; preds = %161
   %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
@@ -6578,8 +8024,8 @@ entry:
 
 ; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
-  br i1 %NullCheck4, label %172, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %171, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %172
 
 ; <label>:172                                     ; preds = %170
   %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
@@ -6589,8 +8035,8 @@ entry:
 
 ; <label>:176                                     ; preds = %172
   %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
-  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %177, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %178
 
 ; <label>:178                                     ; preds = %176
   %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
@@ -6629,55 +8075,55 @@ ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %161
+ThrowNullRef2:                                    ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %170
+ThrowNullRef4:                                    ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %176
+ThrowNullRef6:                                    ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %142
+ThrowNullRef8:                                    ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %144
+ThrowNullRef10:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %113
+ThrowNullRef12:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %116
+ThrowNullRef14:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %84
+ThrowNullRef16:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %87
+ThrowNullRef18:                                   ; preds = %87
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %55
+ThrowNullRef20:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %58
+ThrowNullRef22:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %26
+ThrowNullRef24:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %29
+ThrowNullRef26:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,8 +8161,8 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck, label %14, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %ThrowNullRef, label %14
 
 ; <label>:14                                      ; preds = %8
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
@@ -6760,8 +8206,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
@@ -6770,14 +8216,14 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32, i32* %loc0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %10
   %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
   %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
@@ -6790,15 +8236,15 @@ entry:
 ; <label>:25                                      ; preds = %19
   %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
-  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
   %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
@@ -6807,8 +8253,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %37 = load i32, i32* %loc0
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %38, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %38
 
 ; <label>:38                                      ; preds = %32
   %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
@@ -6817,14 +8263,14 @@ entry:
 
 ; <label>:40                                      ; preds = %19
   %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %40
   %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
   %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
-  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
-  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
@@ -6832,8 +8278,8 @@ entry:
   %48 = zext i32 %47 to i64
   %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
-  br i1 %NullCheck16, label %51, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %51
 
 ; <label>:51                                      ; preds = %45
   %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
@@ -6847,15 +8293,15 @@ entry:
 ; <label>:57                                      ; preds = %51
   %58 = load i16*, i16** %arg1
   %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
-  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %60
 
 ; <label>:60                                      ; preds = %57
   %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
   %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
-  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %64
 
 ; <label>:64                                      ; preds = %60
   %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
@@ -6864,22 +8310,22 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
   %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
-  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %70
 
 ; <label>:70                                      ; preds = %64
   %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
   %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
-  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
-  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
   %75 = load i32, i32 addrspace(1)* %74
   %76 = zext i32 %75 to i64
   %77 = trunc i64 %76 to i32
-  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
-  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %78
 
 ; <label>:78                                      ; preds = %73
   %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
@@ -6901,8 +8347,8 @@ entry:
   %90 = bitcast i16* %86 to i8*
   %91 = getelementptr inbounds i8, i8* %90, i64 %89
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %93
 
 ; <label>:93                                      ; preds = %80
   %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
@@ -6912,8 +8358,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %99 = load i32, i32* %loc2
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %100
 
 ; <label>:100                                     ; preds = %93
   %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
@@ -6928,63 +8374,63 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %25
+ThrowNullRef6:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %32
+ThrowNullRef10:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %40
+ThrowNullRef12:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %45
+ThrowNullRef16:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %57
+ThrowNullRef18:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %60
+ThrowNullRef20:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %64
+ThrowNullRef22:                                   ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %70
+ThrowNullRef24:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %73
+ThrowNullRef26:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %80
+ThrowNullRef28:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %93
+ThrowNullRef30:                                   ; preds = %93
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7004,8 +8450,8 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
@@ -7033,43 +8479,43 @@ entry:
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %14
   %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
   %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   %28 = load i32, i32 addrspace(1)* %27, align 8
   %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
-  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %30
 
 ; <label>:30                                      ; preds = %26
   %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
   %32 = load i32, i32 addrspace(1)* %31, align 8
   %33 = add i32 %28, %32
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %34
 
 ; <label>:34                                      ; preds = %30
   %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   store i32 %33, i32 addrspace(1)* %35
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
   store i32 0, i32 addrspace(1)* %38
   %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %40
 
 ; <label>:40                                      ; preds = %37
   %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
@@ -7082,8 +8528,8 @@ entry:
 
 ; <label>:47                                      ; preds = %40
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
@@ -7098,8 +8544,8 @@ entry:
   %54 = load i32, i32* %loc0
   %55 = sext i32 %54 to i64
   %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
-  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %57
 
 ; <label>:57                                      ; preds = %52
   %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
@@ -7110,68 +8556,35 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %14
+ThrowNullRef2:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %23
+ThrowNullRef4:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %26
+ThrowNullRef6:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %30
+ThrowNullRef8:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %34
+ThrowNullRef10:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %47
+ThrowNullRef14:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %52
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-}
-
-INFO:  jitting method StringBuilder::get_Length using LLILCJit
-Successfully read StringBuilder.get_Length
-
-define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.StringBuilder addrspace(1)*
-  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
-  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
-
-; <label>:1                                       ; preds = %entry
-  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %3 = load i32, i32 addrspace(1)* %2, align 8
-  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
-
-; <label>:5                                       ; preds = %1
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = add i32 %3, %7
-  ret i32 %8
-
-ThrowNullRef:                                     ; preds = %entry
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef16:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7213,70 +8626,70 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
   %6 = load i32, i32 addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
   store i32 %6, i32 addrspace(1)* %8
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
   %13 = load i32, i32 addrspace(1)* %12, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
   store i32 %13, i32 addrspace(1)* %15
   %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
-  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %18
 
 ; <label>:18                                      ; preds = %14
   %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
   %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
   %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
   %34 = load i32, i32 addrspace(1)* %33, align 8
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
-  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
@@ -7287,39 +8700,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %28
+ThrowNullRef16:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %32
+ThrowNullRef18:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7455,13 +8868,13 @@ entry:
 ; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
@@ -7477,16 +8890,16 @@ entry:
 
 ; <label>:18                                      ; preds = %15
   %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
   store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
   %22 = load i32, i32* %loc0
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %24
 
 ; <label>:24                                      ; preds = %20
   %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
@@ -7498,13 +8911,13 @@ entry:
 ; <label>:28                                      ; preds = %15, %24
   %29 = load i32, i32* %arg1
   %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %31
   %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
@@ -7517,20 +8930,20 @@ entry:
   %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
-  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
   %46 = load i32, i32 addrspace(1)* %45, align 8
   %47 = sub i32 %40, %46
-  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
-  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i32 addrspace(1)* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %48
 
 ; <label>:48                                      ; preds = %44
   store i32 %47, i32 addrspace(1)* %39, align 8
@@ -7538,21 +8951,21 @@ entry:
 
 ; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
-  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %51
 
 ; <label>:51                                      ; preds = %49
   %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %53
 
 ; <label>:53                                      ; preds = %51
   %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
   %55 = load i32, i32 addrspace(1)* %54, align 8
   %56 = load i32, i32* %arg2
   %57 = sub i32 %55, %56
-  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %58
 
 ; <label>:58                                      ; preds = %53
   %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
@@ -7562,13 +8975,13 @@ entry:
 ; <label>:60                                      ; preds = %33, %58
   %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
   %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
-  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %63
 
 ; <label>:63                                      ; preds = %60
   %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
-  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
-  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
@@ -7578,15 +8991,15 @@ entry:
 
 ; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
-  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i32 addrspace(1)* %69, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %70
 
 ; <label>:70                                      ; preds = %68
   %71 = load i32, i32 addrspace(1)* %69, align 8
   store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
-  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
@@ -7596,8 +9009,8 @@ entry:
   store i32 %77, i32* %loc4
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
-  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %80
 
 ; <label>:80                                      ; preds = %73
   %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
@@ -7607,71 +9020,71 @@ entry:
 ; <label>:83                                      ; preds = %80
   store i32 0, i32* %loc3
   %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
-  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
-  br i1 %NullCheck26, label %88, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i32 addrspace(1)* %87, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %88
 
 ; <label>:88                                      ; preds = %85
   %89 = load i32, i32 addrspace(1)* %87, align 8
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
-  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %90
 
 ; <label>:90                                      ; preds = %88
   %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
   store i32 %89, i32 addrspace(1)* %91
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
-  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
-  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %96
 
 ; <label>:96                                      ; preds = %94
   %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
-  br i1 %NullCheck34, label %100, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %100
 
 ; <label>:100                                     ; preds = %96
   %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
-  br i1 %NullCheck36, label %102, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %102
 
 ; <label>:102                                     ; preds = %100
   %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
   %104 = load i32, i32 addrspace(1)* %103, align 8
   %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
-  br i1 %NullCheck38, label %106, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %106
 
 ; <label>:106                                     ; preds = %102
   %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
-  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
-  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %108
 
 ; <label>:108                                     ; preds = %106
   %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
   %110 = load i32, i32 addrspace(1)* %109, align 8
   %111 = add i32 %104, %110
-  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %112
 
 ; <label>:112                                     ; preds = %108
   %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
   store i32 %111, i32 addrspace(1)* %113
   %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
-  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i32 addrspace(1)* %114, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %115
 
 ; <label>:115                                     ; preds = %112
   %116 = load i32, i32 addrspace(1)* %114, align 8
@@ -7681,19 +9094,19 @@ entry:
 ; <label>:118                                     ; preds = %115
   %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
-  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %121
 
 ; <label>:121                                     ; preds = %118
   %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
-  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
-  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %123
 
 ; <label>:123                                     ; preds = %121
   %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
   %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
-  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
-  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %126
 
 ; <label>:126                                     ; preds = %123
   %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
@@ -7705,8 +9118,8 @@ entry:
 
 ; <label>:130                                     ; preds = %80, %115, %126
   %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %132
 
 ; <label>:132                                     ; preds = %130
   %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7715,8 +9128,8 @@ entry:
   %136 = load i32, i32* %loc3
   %137 = sub i32 %135, %136
   %138 = sub i32 %134, %137
-  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %139
 
 ; <label>:139                                     ; preds = %132
   %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7728,16 +9141,16 @@ entry:
 
 ; <label>:144                                     ; preds = %139
   %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
-  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %146
 
 ; <label>:146                                     ; preds = %144
   %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
   %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
   %149 = load i32, i32* %loc2
   %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
-  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %151
 
 ; <label>:151                                     ; preds = %146
   %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
@@ -7754,145 +9167,249 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %18
+ThrowNullRef4:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %31
+ThrowNullRef10:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %44
+ThrowNullRef16:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %68
+ThrowNullRef18:                                   ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %70
+ThrowNullRef20:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %73
+ThrowNullRef22:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %83
+ThrowNullRef24:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %85
+ThrowNullRef26:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %88
+ThrowNullRef28:                                   ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %90
+ThrowNullRef30:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %94
+ThrowNullRef32:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %96
+ThrowNullRef34:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %100
+ThrowNullRef36:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %102
+ThrowNullRef38:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %106
+ThrowNullRef40:                                   ; preds = %106
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %108
+ThrowNullRef42:                                   ; preds = %108
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %112
+ThrowNullRef44:                                   ; preds = %112
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %118
+ThrowNullRef46:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %121
+ThrowNullRef48:                                   ; preds = %121
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %123
+ThrowNullRef50:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %130
+ThrowNullRef52:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %132
+ThrowNullRef54:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %144
+ThrowNullRef56:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %146
+ThrowNullRef58:                                   ; preds = %146
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %60
+ThrowNullRef60:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %63
+ThrowNullRef62:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %49
+ThrowNullRef64:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %51
+ThrowNullRef66:                                   ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %53
+ThrowNullRef68:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(%"System.Char[]" addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %arg0 = alloca %"System.Char[]" addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store %"System.Char[]" addrspace(1)* %param0, %"System.Char[]" addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load i32, i32* %arg4
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %43, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %38, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg1
+  %13 = load i32, i32* %arg4
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %38, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %24 = load i32, i32* %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %35 = load i32, i32* %arg3
+  %36 = load i32, i32* %arg4
+  %37 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %37, %"System.Char[]" addrspace(1)* %34, i32 %35, i32 %36)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:38                                      ; preds = %5, %16
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Successfully read Buffer._Memmove
 
@@ -7914,7 +9431,7 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[loadElem]
+Failed to read AppDomain.SetDataHelper[storeElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -7923,8 +9440,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
@@ -7934,8 +9451,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
@@ -7947,15 +9464,15 @@ entry:
   %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
   %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
@@ -7966,15 +9483,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7992,7 +9509,79 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
-Failed to read Dictionary`2.TryGetValue[loadElemA]
+Successfully read Dictionary`2.TryGetValue
+
+define i8 @"Dictionary`2.TryGetValue"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)* addrspace(1)* %param2) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  %arg2 = alloca %System.__Canon addrspace(1)* addrspace(1)*
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  store %System.__Canon addrspace(1)* addrspace(1)* %param2, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  store i32 %2, i32* %loc0
+  %3 = load i32, i32* %loc0
+  %4 = icmp slt i32 %3, 0
+  br i1 %4, label %22, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 2
+  %10 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %9, align 8
+  %11 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = zext i32 %11 to i64
+  %BoundsCheck = icmp uge i64 %16, %15
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 3, i32 %11
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %20, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %6, %System.__Canon addrspace(1)* %21)
+  ret i8 1
+
+; <label>:22                                      ; preds = %entry
+  %23 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %23, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -8058,8 +9647,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
@@ -8091,8 +9680,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
@@ -8171,15 +9760,15 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck, label %19, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %ThrowNullRef, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
   %21 = load i32, i32 addrspace(1)* %20
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
@@ -8202,7 +9791,7 @@ ThrowNullRef:                                     ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %19
+ThrowNullRef2:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8248,8 +9837,8 @@ entry:
   %0 = alloca %System.AppDomainHandle
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %1 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %1, i32 0, i32 15
@@ -8269,8 +9858,8 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
@@ -8286,7 +9875,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -8299,8 +9888,8 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -8327,8 +9916,8 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
@@ -8352,8 +9941,8 @@ entry:
   %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
   store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
@@ -8363,8 +9952,8 @@ entry:
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
@@ -8374,8 +9963,8 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %9
   %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
@@ -8384,8 +9973,8 @@ entry:
 
 ; <label>:18                                      ; preds = %3, %16
   %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
@@ -8397,15 +9986,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %18
+ThrowNullRef6:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8418,8 +10007,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
@@ -8453,15 +10042,15 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
@@ -8473,7 +10062,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8481,7 +10070,7 @@ ThrowNullRef1:                                    ; preds = %1
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
 Failed to read Dictionary`2.System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
@@ -8506,8 +10095,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
@@ -8524,8 +10113,8 @@ entry:
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -8544,7 +10133,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8577,8 +10166,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = load i64, i64* %arg2
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = trunc i32 %3 to i8
@@ -8634,46 +10223,46 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
   %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
-  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
-  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
-  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
@@ -8684,27 +10273,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %20
+ThrowNullRef12:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8717,8 +10306,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -8756,22 +10345,22 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
   %9 = load i64, i64 addrspace(1)* %8, align 8
   %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
   %13 = load i64, i64 addrspace(1)* %12, align 8
   %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %11
   %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
@@ -8788,11 +10377,11 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8882,8 +10471,8 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
@@ -8900,8 +10489,8 @@ entry:
 ; <label>:8                                       ; preds = %1
   %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
   %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
@@ -8911,15 +10500,15 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
   %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
   %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
-  br i1 %NullCheck6, label %21, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
@@ -8946,15 +10535,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8992,15 +10581,15 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
   store i8 %3, i8 addrspace(1)* %5
   %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
@@ -9011,7 +10600,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9027,8 +10616,8 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -9041,8 +10630,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
@@ -9058,7 +10647,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9080,8 +10669,8 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
@@ -9096,8 +10685,8 @@ entry:
 ; <label>:12                                      ; preds = %6
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
@@ -9112,8 +10701,8 @@ entry:
 ; <label>:21                                      ; preds = %15
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
@@ -9128,8 +10717,8 @@ entry:
 ; <label>:30                                      ; preds = %24
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %31, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
@@ -9144,8 +10733,8 @@ entry:
 ; <label>:39                                      ; preds = %33
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
-  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %40, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %42
 
 ; <label>:42                                      ; preds = %39
   %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
@@ -9164,19 +10753,19 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %21
+ThrowNullRef4:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %30
+ThrowNullRef6:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %39
+ThrowNullRef8:                                    ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9243,8 +10832,8 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
@@ -9264,57 +10853,57 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
   store i8 0, i8 addrspace(1)* %2
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
   store i8 0, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
   store i8 0, i8 addrspace(1)* %17
   %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
   store i8 0, i8 addrspace(1)* %20
   %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
-  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
@@ -9325,31 +10914,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %19
+ThrowNullRef14:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9367,8 +10956,8 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
@@ -9380,8 +10969,8 @@ entry:
 
 ; <label>:9                                       ; preds = %4
   %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %9
   %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
@@ -9395,7 +10984,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef2:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9420,8 +11009,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
@@ -9512,8 +11101,8 @@ entry:
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
@@ -9524,8 +11113,8 @@ entry:
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = load i64, i64 addrspace(1)* %12
@@ -9537,8 +11126,8 @@ entry:
   %20 = load i64, i64* %19
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
-  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %13
   %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
@@ -9555,8 +11144,8 @@ entry:
 ; <label>:30                                      ; preds = %25
   %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %32 = load i32, i32* %arg2
-  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
-  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
@@ -9570,15 +11159,15 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %30
+ThrowNullRef2:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9622,87 +11211,87 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
   %10 = load i8, i8 addrspace(1)* %9, align 8
   %11 = zext i8 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %8
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
   store i8 %12, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
   %19 = load i8, i8 addrspace(1)* %18, align 8
   %20 = zext i8 %19 to i32
   %21 = trunc i32 %20 to i8
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
   store i8 %21, i8 addrspace(1)* %23
   %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
   %28 = load i8, i8 addrspace(1)* %27, align 8
   %29 = zext i8 %28 to i32
   %30 = trunc i32 %29 to i8
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
-  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %31
 
 ; <label>:31                                      ; preds = %26
   %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
   store i8 %30, i8 addrspace(1)* %32
   %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
-  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
-  br i1 %NullCheck14, label %40, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %40
 
 ; <label>:40                                      ; preds = %35
   %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
   store i8 %39, i8 addrspace(1)* %41
   %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
-  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %44
 
 ; <label>:44                                      ; preds = %40
   %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
   %46 = load i8, i8 addrspace(1)* %45, align 8
   %47 = zext i8 %46 to i32
   %48 = trunc i32 %47 to i8
-  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
   store i8 %48, i8 addrspace(1)* %50
   %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
-  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
@@ -9713,29 +11302,29 @@ entry:
 ; <label>:56                                      ; preds = %52
   %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
-  br i1 %NullCheck22, label %59, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
   %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
   %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
-  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
-  br i1 %NullCheck24, label %63, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
   %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
-  br i1 %NullCheck26, label %66, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
   %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
-  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
-  br i1 %NullCheck28, label %69, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %69
 
 ; <label>:69                                      ; preds = %66
   %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
@@ -9744,15 +11333,15 @@ entry:
 
 ; <label>:71                                      ; preds = %105
   %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
-  br i1 %NullCheck34, label %73, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %73
 
 ; <label>:73                                      ; preds = %71
   %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
   %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
   %76 = load i32, i32* %loc0
-  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
-  br i1 %NullCheck36, label %77, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
@@ -9766,8 +11355,8 @@ entry:
 
 ; <label>:83                                      ; preds = %77
   %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
-  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
@@ -9775,14 +11364,14 @@ entry:
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
   %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
-  br i1 %NullCheck40, label %91, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
 ; <label>:91                                      ; preds = %85
   %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
   %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
-  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck42, label %94, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %94
 
 ; <label>:94                                      ; preds = %91
   %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
@@ -9798,14 +11387,14 @@ entry:
 ; <label>:99                                      ; preds = %69, %96
   %100 = load i32, i32* %loc0
   %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
-  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %102
 
 ; <label>:102                                     ; preds = %99
   %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
   %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
-  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
-  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
@@ -9819,87 +11408,87 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %26
+ThrowNullRef10:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %31
+ThrowNullRef12:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %35
+ThrowNullRef14:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %40
+ThrowNullRef16:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %56
+ThrowNullRef22:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %59
+ThrowNullRef24:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %63
+ThrowNullRef26:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %66
+ThrowNullRef28:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %102
+ThrowNullRef32:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %71
+ThrowNullRef34:                                   ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %73
+ThrowNullRef36:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %83
+ThrowNullRef38:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %85
+ThrowNullRef40:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %91
+ThrowNullRef42:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9943,15 +11532,15 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
   %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
@@ -9961,28 +11550,28 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
   %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %12
   %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
   %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
   %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
-  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
@@ -9993,23 +11582,23 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %12
+ThrowNullRef6:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10031,15 +11620,15 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
   %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = load i64, i64 addrspace(1)* %7
@@ -10077,13 +11666,13 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[loadElem]
+Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -10111,8 +11700,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1

--- a/test/BaseLine/JIT/CodeGenBringUpTests/NotAndNeg.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/NotAndNeg.error.txt
@@ -25,8 +25,8 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
@@ -40,8 +40,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
   %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
@@ -75,7 +75,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -90,8 +90,8 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %NullCheck = icmp ne i8 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = load i8, i8 addrspace(1)* %0, align 8
@@ -125,8 +125,8 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
@@ -159,8 +159,8 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -184,8 +184,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
   store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
@@ -195,8 +195,8 @@ entry:
 ; <label>:4                                       ; preds = %1
   %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
   %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
@@ -206,8 +206,8 @@ entry:
   %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
@@ -221,14 +221,14 @@ entry:
 
 ; <label>:17                                      ; preds = %14
   %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
   %21 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
@@ -238,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -249,8 +249,8 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
@@ -261,27 +261,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %30
+ThrowNullRef10:                                   ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -301,7 +301,89 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
-Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
+Successfully read AppDomainSetup.GetUnsecureApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.GetUnsecureApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %NullCheck = icmp eq %"System.String[]" addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %BoundsCheck = icmp uge i64 0, %5
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %6
+
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 3, i32 0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
+  ret %System.String addrspace(1)* %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_Value using LLILCJit
+Successfully read AppDomainSetup.get_Value
+
+define %"System.String[]" addrspace(1)* @AppDomainSetup.get_Value(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.String[]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 18)
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.String[]" addrspace(1)* addrspace(1)*, %"System.String[]" addrspace(1)*)*)(%"System.String[]" addrspace(1)* addrspace(1)* %9, %"System.String[]" addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %11, i32 0, i32 1
+  %14 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %13, align 8
+  ret %"System.String[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -319,8 +401,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -368,16 +450,16 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
   %5 = load i32, i32 addrspace(1)* %4
   %6 = sub i32 %5, 1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -389,7 +471,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -421,8 +503,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
@@ -456,8 +538,8 @@ entry:
 ; <label>:27                                      ; preds = %19
   %28 = load i32, i32* %arg1
   %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
-  br i1 %NullCheck2, label %30, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %29, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %30
 
 ; <label>:30                                      ; preds = %27
   %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
@@ -493,8 +575,8 @@ entry:
 ; <label>:49                                      ; preds = %46
   %50 = load i32, i32* %arg2
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck4, label %52, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
@@ -517,11 +599,11 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %27
+ThrowNullRef2:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %49
+ThrowNullRef4:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -544,16 +626,16 @@ entry:
   %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %0)
   store %System.String addrspace(1)* %1, %System.String addrspace(1)** %loc0
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 2
   %5 = bitcast [0 x i16] addrspace(1)* %4 to i16 addrspace(1)*
   store i16 addrspace(1)* %5, i16 addrspace(1)** %loc1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %3
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2
@@ -580,7 +662,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -691,15 +773,15 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %NullCheck132 = icmp ne i8* %21, null
-  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+  %NullCheck131 = icmp eq i8* %21, null
+  br i1 %NullCheck131, label %ThrowNullRef132, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = load i8, i8* %21, align 8
   %24 = zext i8 %23 to i32
   %25 = trunc i32 %24 to i8
-  %NullCheck134 = icmp ne i8* %20, null
-  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+  %NullCheck133 = icmp eq i8* %20, null
+  br i1 %NullCheck133, label %ThrowNullRef134, label %26
 
 ; <label>:26                                      ; preds = %22
   store i8 %25, i8* %20, align 8
@@ -709,16 +791,16 @@ entry:
   %28 = load i8*, i8** %arg0
   %29 = load i8*, i8** %arg1
   %30 = bitcast i8* %29 to i16*
-  %NullCheck128 = icmp ne i16* %30, null
-  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+  %NullCheck127 = icmp eq i16* %30, null
+  br i1 %NullCheck127, label %ThrowNullRef128, label %31
 
 ; <label>:31                                      ; preds = %27
   %32 = load i16, i16* %30, align 8
   %33 = sext i16 %32 to i32
   %34 = bitcast i8* %28 to i16*
   %35 = trunc i32 %33 to i16
-  %NullCheck130 = icmp ne i16* %34, null
-  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+  %NullCheck129 = icmp eq i16* %34, null
+  br i1 %NullCheck129, label %ThrowNullRef130, label %36
 
 ; <label>:36                                      ; preds = %31
   store i16 %35, i16* %34, align 8
@@ -728,16 +810,16 @@ entry:
   %38 = load i8*, i8** %arg0
   %39 = load i8*, i8** %arg1
   %40 = bitcast i8* %39 to i16*
-  %NullCheck120 = icmp ne i16* %40, null
-  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+  %NullCheck119 = icmp eq i16* %40, null
+  br i1 %NullCheck119, label %ThrowNullRef120, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i16, i16* %40, align 8
   %43 = sext i16 %42 to i32
   %44 = bitcast i8* %38 to i16*
   %45 = trunc i32 %43 to i16
-  %NullCheck122 = icmp ne i16* %44, null
-  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+  %NullCheck121 = icmp eq i16* %44, null
+  br i1 %NullCheck121, label %ThrowNullRef122, label %46
 
 ; <label>:46                                      ; preds = %41
   store i16 %45, i16* %44, align 8
@@ -745,15 +827,15 @@ entry:
   %48 = getelementptr inbounds i8, i8* %47, i64 2
   %49 = load i8*, i8** %arg1
   %50 = getelementptr inbounds i8, i8* %49, i64 2
-  %NullCheck124 = icmp ne i8* %50, null
-  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+  %NullCheck123 = icmp eq i8* %50, null
+  br i1 %NullCheck123, label %ThrowNullRef124, label %51
 
 ; <label>:51                                      ; preds = %46
   %52 = load i8, i8* %50, align 8
   %53 = zext i8 %52 to i32
   %54 = trunc i32 %53 to i8
-  %NullCheck126 = icmp ne i8* %48, null
-  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+  %NullCheck125 = icmp eq i8* %48, null
+  br i1 %NullCheck125, label %ThrowNullRef126, label %55
 
 ; <label>:55                                      ; preds = %51
   store i8 %54, i8* %48, align 8
@@ -763,14 +845,14 @@ entry:
   %57 = load i8*, i8** %arg0
   %58 = load i8*, i8** %arg1
   %59 = bitcast i8* %58 to i32*
-  %NullCheck116 = icmp ne i32* %59, null
-  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+  %NullCheck115 = icmp eq i32* %59, null
+  br i1 %NullCheck115, label %ThrowNullRef116, label %60
 
 ; <label>:60                                      ; preds = %56
   %61 = load i32, i32* %59, align 8
   %62 = bitcast i8* %57 to i32*
-  %NullCheck118 = icmp ne i32* %62, null
-  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+  %NullCheck117 = icmp eq i32* %62, null
+  br i1 %NullCheck117, label %ThrowNullRef118, label %63
 
 ; <label>:63                                      ; preds = %60
   store i32 %61, i32* %62, align 8
@@ -780,14 +862,14 @@ entry:
   %65 = load i8*, i8** %arg0
   %66 = load i8*, i8** %arg1
   %67 = bitcast i8* %66 to i32*
-  %NullCheck108 = icmp ne i32* %67, null
-  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+  %NullCheck107 = icmp eq i32* %67, null
+  br i1 %NullCheck107, label %ThrowNullRef108, label %68
 
 ; <label>:68                                      ; preds = %64
   %69 = load i32, i32* %67, align 8
   %70 = bitcast i8* %65 to i32*
-  %NullCheck110 = icmp ne i32* %70, null
-  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+  %NullCheck109 = icmp eq i32* %70, null
+  br i1 %NullCheck109, label %ThrowNullRef110, label %71
 
 ; <label>:71                                      ; preds = %68
   store i32 %69, i32* %70, align 8
@@ -795,15 +877,15 @@ entry:
   %73 = getelementptr inbounds i8, i8* %72, i64 4
   %74 = load i8*, i8** %arg1
   %75 = getelementptr inbounds i8, i8* %74, i64 4
-  %NullCheck112 = icmp ne i8* %75, null
-  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+  %NullCheck111 = icmp eq i8* %75, null
+  br i1 %NullCheck111, label %ThrowNullRef112, label %76
 
 ; <label>:76                                      ; preds = %71
   %77 = load i8, i8* %75, align 8
   %78 = zext i8 %77 to i32
   %79 = trunc i32 %78 to i8
-  %NullCheck114 = icmp ne i8* %73, null
-  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+  %NullCheck113 = icmp eq i8* %73, null
+  br i1 %NullCheck113, label %ThrowNullRef114, label %80
 
 ; <label>:80                                      ; preds = %76
   store i8 %79, i8* %73, align 8
@@ -813,14 +895,14 @@ entry:
   %82 = load i8*, i8** %arg0
   %83 = load i8*, i8** %arg1
   %84 = bitcast i8* %83 to i32*
-  %NullCheck100 = icmp ne i32* %84, null
-  br i1 %NullCheck100, label %85, label %ThrowNullRef99
+  %NullCheck99 = icmp eq i32* %84, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %85
 
 ; <label>:85                                      ; preds = %81
   %86 = load i32, i32* %84, align 8
   %87 = bitcast i8* %82 to i32*
-  %NullCheck102 = icmp ne i32* %87, null
-  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+  %NullCheck101 = icmp eq i32* %87, null
+  br i1 %NullCheck101, label %ThrowNullRef102, label %88
 
 ; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
@@ -829,16 +911,16 @@ entry:
   %91 = load i8*, i8** %arg1
   %92 = getelementptr inbounds i8, i8* %91, i64 4
   %93 = bitcast i8* %92 to i16*
-  %NullCheck104 = icmp ne i16* %93, null
-  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+  %NullCheck103 = icmp eq i16* %93, null
+  br i1 %NullCheck103, label %ThrowNullRef104, label %94
 
 ; <label>:94                                      ; preds = %88
   %95 = load i16, i16* %93, align 8
   %96 = sext i16 %95 to i32
   %97 = bitcast i8* %90 to i16*
   %98 = trunc i32 %96 to i16
-  %NullCheck106 = icmp ne i16* %97, null
-  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+  %NullCheck105 = icmp eq i16* %97, null
+  br i1 %NullCheck105, label %ThrowNullRef106, label %99
 
 ; <label>:99                                      ; preds = %94
   store i16 %98, i16* %97, align 8
@@ -848,14 +930,14 @@ entry:
   %101 = load i8*, i8** %arg0
   %102 = load i8*, i8** %arg1
   %103 = bitcast i8* %102 to i32*
-  %NullCheck88 = icmp ne i32* %103, null
-  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+  %NullCheck87 = icmp eq i32* %103, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %104
 
 ; <label>:104                                     ; preds = %100
   %105 = load i32, i32* %103, align 8
   %106 = bitcast i8* %101 to i32*
-  %NullCheck90 = icmp ne i32* %106, null
-  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+  %NullCheck89 = icmp eq i32* %106, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %107
 
 ; <label>:107                                     ; preds = %104
   store i32 %105, i32* %106, align 8
@@ -864,16 +946,16 @@ entry:
   %110 = load i8*, i8** %arg1
   %111 = getelementptr inbounds i8, i8* %110, i64 4
   %112 = bitcast i8* %111 to i16*
-  %NullCheck92 = icmp ne i16* %112, null
-  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+  %NullCheck91 = icmp eq i16* %112, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %113
 
 ; <label>:113                                     ; preds = %107
   %114 = load i16, i16* %112, align 8
   %115 = sext i16 %114 to i32
   %116 = bitcast i8* %109 to i16*
   %117 = trunc i32 %115 to i16
-  %NullCheck94 = icmp ne i16* %116, null
-  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+  %NullCheck93 = icmp eq i16* %116, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %118
 
 ; <label>:118                                     ; preds = %113
   store i16 %117, i16* %116, align 8
@@ -881,15 +963,15 @@ entry:
   %120 = getelementptr inbounds i8, i8* %119, i64 6
   %121 = load i8*, i8** %arg1
   %122 = getelementptr inbounds i8, i8* %121, i64 6
-  %NullCheck96 = icmp ne i8* %122, null
-  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+  %NullCheck95 = icmp eq i8* %122, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %123
 
 ; <label>:123                                     ; preds = %118
   %124 = load i8, i8* %122, align 8
   %125 = zext i8 %124 to i32
   %126 = trunc i32 %125 to i8
-  %NullCheck98 = icmp ne i8* %120, null
-  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+  %NullCheck97 = icmp eq i8* %120, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %127
 
 ; <label>:127                                     ; preds = %123
   store i8 %126, i8* %120, align 8
@@ -899,14 +981,14 @@ entry:
   %129 = load i8*, i8** %arg0
   %130 = load i8*, i8** %arg1
   %131 = bitcast i8* %130 to i64*
-  %NullCheck84 = icmp ne i64* %131, null
-  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+  %NullCheck83 = icmp eq i64* %131, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %132
 
 ; <label>:132                                     ; preds = %128
   %133 = load i64, i64* %131, align 8
   %134 = bitcast i8* %129 to i64*
-  %NullCheck86 = icmp ne i64* %134, null
-  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+  %NullCheck85 = icmp eq i64* %134, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %135
 
 ; <label>:135                                     ; preds = %132
   store i64 %133, i64* %134, align 8
@@ -916,14 +998,14 @@ entry:
   %137 = load i8*, i8** %arg0
   %138 = load i8*, i8** %arg1
   %139 = bitcast i8* %138 to i64*
-  %NullCheck76 = icmp ne i64* %139, null
-  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+  %NullCheck75 = icmp eq i64* %139, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %140
 
 ; <label>:140                                     ; preds = %136
   %141 = load i64, i64* %139, align 8
   %142 = bitcast i8* %137 to i64*
-  %NullCheck78 = icmp ne i64* %142, null
-  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+  %NullCheck77 = icmp eq i64* %142, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %143
 
 ; <label>:143                                     ; preds = %140
   store i64 %141, i64* %142, align 8
@@ -931,15 +1013,15 @@ entry:
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %NullCheck80 = icmp ne i8* %147, null
-  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+  %NullCheck79 = icmp eq i8* %147, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %148
 
 ; <label>:148                                     ; preds = %143
   %149 = load i8, i8* %147, align 8
   %150 = zext i8 %149 to i32
   %151 = trunc i32 %150 to i8
-  %NullCheck82 = icmp ne i8* %145, null
-  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+  %NullCheck81 = icmp eq i8* %145, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %152
 
 ; <label>:152                                     ; preds = %148
   store i8 %151, i8* %145, align 8
@@ -949,14 +1031,14 @@ entry:
   %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
   %156 = bitcast i8* %155 to i64*
-  %NullCheck68 = icmp ne i64* %156, null
-  br i1 %NullCheck68, label %157, label %ThrowNullRef67
+  %NullCheck67 = icmp eq i64* %156, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %157
 
 ; <label>:157                                     ; preds = %153
   %158 = load i64, i64* %156, align 8
   %159 = bitcast i8* %154 to i64*
-  %NullCheck70 = icmp ne i64* %159, null
-  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+  %NullCheck69 = icmp eq i64* %159, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %160
 
 ; <label>:160                                     ; preds = %157
   store i64 %158, i64* %159, align 8
@@ -965,16 +1047,16 @@ entry:
   %163 = load i8*, i8** %arg1
   %164 = getelementptr inbounds i8, i8* %163, i64 8
   %165 = bitcast i8* %164 to i16*
-  %NullCheck72 = icmp ne i16* %165, null
-  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+  %NullCheck71 = icmp eq i16* %165, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %166
 
 ; <label>:166                                     ; preds = %160
   %167 = load i16, i16* %165, align 8
   %168 = sext i16 %167 to i32
   %169 = bitcast i8* %162 to i16*
   %170 = trunc i32 %168 to i16
-  %NullCheck74 = icmp ne i16* %169, null
-  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+  %NullCheck73 = icmp eq i16* %169, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %171
 
 ; <label>:171                                     ; preds = %166
   store i16 %170, i16* %169, align 8
@@ -984,14 +1066,14 @@ entry:
   %173 = load i8*, i8** %arg0
   %174 = load i8*, i8** %arg1
   %175 = bitcast i8* %174 to i64*
-  %NullCheck56 = icmp ne i64* %175, null
-  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+  %NullCheck55 = icmp eq i64* %175, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %176
 
 ; <label>:176                                     ; preds = %172
   %177 = load i64, i64* %175, align 8
   %178 = bitcast i8* %173 to i64*
-  %NullCheck58 = icmp ne i64* %178, null
-  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+  %NullCheck57 = icmp eq i64* %178, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %179
 
 ; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
@@ -1000,16 +1082,16 @@ entry:
   %182 = load i8*, i8** %arg1
   %183 = getelementptr inbounds i8, i8* %182, i64 8
   %184 = bitcast i8* %183 to i16*
-  %NullCheck60 = icmp ne i16* %184, null
-  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+  %NullCheck59 = icmp eq i16* %184, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %185
 
 ; <label>:185                                     ; preds = %179
   %186 = load i16, i16* %184, align 8
   %187 = sext i16 %186 to i32
   %188 = bitcast i8* %181 to i16*
   %189 = trunc i32 %187 to i16
-  %NullCheck62 = icmp ne i16* %188, null
-  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+  %NullCheck61 = icmp eq i16* %188, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %190
 
 ; <label>:190                                     ; preds = %185
   store i16 %189, i16* %188, align 8
@@ -1017,15 +1099,15 @@ entry:
   %192 = getelementptr inbounds i8, i8* %191, i64 10
   %193 = load i8*, i8** %arg1
   %194 = getelementptr inbounds i8, i8* %193, i64 10
-  %NullCheck64 = icmp ne i8* %194, null
-  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+  %NullCheck63 = icmp eq i8* %194, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %195
 
 ; <label>:195                                     ; preds = %190
   %196 = load i8, i8* %194, align 8
   %197 = zext i8 %196 to i32
   %198 = trunc i32 %197 to i8
-  %NullCheck66 = icmp ne i8* %192, null
-  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+  %NullCheck65 = icmp eq i8* %192, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %199
 
 ; <label>:199                                     ; preds = %195
   store i8 %198, i8* %192, align 8
@@ -1035,14 +1117,14 @@ entry:
   %201 = load i8*, i8** %arg0
   %202 = load i8*, i8** %arg1
   %203 = bitcast i8* %202 to i64*
-  %NullCheck48 = icmp ne i64* %203, null
-  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+  %NullCheck47 = icmp eq i64* %203, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %204
 
 ; <label>:204                                     ; preds = %200
   %205 = load i64, i64* %203, align 8
   %206 = bitcast i8* %201 to i64*
-  %NullCheck50 = icmp ne i64* %206, null
-  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+  %NullCheck49 = icmp eq i64* %206, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %207
 
 ; <label>:207                                     ; preds = %204
   store i64 %205, i64* %206, align 8
@@ -1051,14 +1133,14 @@ entry:
   %210 = load i8*, i8** %arg1
   %211 = getelementptr inbounds i8, i8* %210, i64 8
   %212 = bitcast i8* %211 to i32*
-  %NullCheck52 = icmp ne i32* %212, null
-  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+  %NullCheck51 = icmp eq i32* %212, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %213
 
 ; <label>:213                                     ; preds = %207
   %214 = load i32, i32* %212, align 8
   %215 = bitcast i8* %209 to i32*
-  %NullCheck54 = icmp ne i32* %215, null
-  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+  %NullCheck53 = icmp eq i32* %215, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %216
 
 ; <label>:216                                     ; preds = %213
   store i32 %214, i32* %215, align 8
@@ -1068,14 +1150,14 @@ entry:
   %218 = load i8*, i8** %arg0
   %219 = load i8*, i8** %arg1
   %220 = bitcast i8* %219 to i64*
-  %NullCheck36 = icmp ne i64* %220, null
-  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64* %220, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %221
 
 ; <label>:221                                     ; preds = %217
   %222 = load i64, i64* %220, align 8
   %223 = bitcast i8* %218 to i64*
-  %NullCheck38 = icmp ne i64* %223, null
-  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+  %NullCheck37 = icmp eq i64* %223, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %224
 
 ; <label>:224                                     ; preds = %221
   store i64 %222, i64* %223, align 8
@@ -1084,14 +1166,14 @@ entry:
   %227 = load i8*, i8** %arg1
   %228 = getelementptr inbounds i8, i8* %227, i64 8
   %229 = bitcast i8* %228 to i32*
-  %NullCheck40 = icmp ne i32* %229, null
-  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i32* %229, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %230
 
 ; <label>:230                                     ; preds = %224
   %231 = load i32, i32* %229, align 8
   %232 = bitcast i8* %226 to i32*
-  %NullCheck42 = icmp ne i32* %232, null
-  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+  %NullCheck41 = icmp eq i32* %232, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %233
 
 ; <label>:233                                     ; preds = %230
   store i32 %231, i32* %232, align 8
@@ -1099,15 +1181,15 @@ entry:
   %235 = getelementptr inbounds i8, i8* %234, i64 12
   %236 = load i8*, i8** %arg1
   %237 = getelementptr inbounds i8, i8* %236, i64 12
-  %NullCheck44 = icmp ne i8* %237, null
-  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i8* %237, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %238
 
 ; <label>:238                                     ; preds = %233
   %239 = load i8, i8* %237, align 8
   %240 = zext i8 %239 to i32
   %241 = trunc i32 %240 to i8
-  %NullCheck46 = icmp ne i8* %235, null
-  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+  %NullCheck45 = icmp eq i8* %235, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %242
 
 ; <label>:242                                     ; preds = %238
   store i8 %241, i8* %235, align 8
@@ -1117,14 +1199,14 @@ entry:
   %244 = load i8*, i8** %arg0
   %245 = load i8*, i8** %arg1
   %246 = bitcast i8* %245 to i64*
-  %NullCheck24 = icmp ne i64* %246, null
-  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64* %246, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %247
 
 ; <label>:247                                     ; preds = %243
   %248 = load i64, i64* %246, align 8
   %249 = bitcast i8* %244 to i64*
-  %NullCheck26 = icmp ne i64* %249, null
-  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64* %249, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %250
 
 ; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
@@ -1133,14 +1215,14 @@ entry:
   %253 = load i8*, i8** %arg1
   %254 = getelementptr inbounds i8, i8* %253, i64 8
   %255 = bitcast i8* %254 to i32*
-  %NullCheck28 = icmp ne i32* %255, null
-  br i1 %NullCheck28, label %256, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i32* %255, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %256
 
 ; <label>:256                                     ; preds = %250
   %257 = load i32, i32* %255, align 8
   %258 = bitcast i8* %252 to i32*
-  %NullCheck30 = icmp ne i32* %258, null
-  br i1 %NullCheck30, label %259, label %ThrowNullRef29
+  %NullCheck29 = icmp eq i32* %258, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %259
 
 ; <label>:259                                     ; preds = %256
   store i32 %257, i32* %258, align 8
@@ -1149,16 +1231,16 @@ entry:
   %262 = load i8*, i8** %arg1
   %263 = getelementptr inbounds i8, i8* %262, i64 12
   %264 = bitcast i8* %263 to i16*
-  %NullCheck32 = icmp ne i16* %264, null
-  br i1 %NullCheck32, label %265, label %ThrowNullRef31
+  %NullCheck31 = icmp eq i16* %264, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %265
 
 ; <label>:265                                     ; preds = %259
   %266 = load i16, i16* %264, align 8
   %267 = sext i16 %266 to i32
   %268 = bitcast i8* %261 to i16*
   %269 = trunc i32 %267 to i16
-  %NullCheck34 = icmp ne i16* %268, null
-  br i1 %NullCheck34, label %270, label %ThrowNullRef33
+  %NullCheck33 = icmp eq i16* %268, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %270
 
 ; <label>:270                                     ; preds = %265
   store i16 %269, i16* %268, align 8
@@ -1168,14 +1250,14 @@ entry:
   %272 = load i8*, i8** %arg0
   %273 = load i8*, i8** %arg1
   %274 = bitcast i8* %273 to i64*
-  %NullCheck8 = icmp ne i64* %274, null
-  br i1 %NullCheck8, label %275, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64* %274, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %275
 
 ; <label>:275                                     ; preds = %271
   %276 = load i64, i64* %274, align 8
   %277 = bitcast i8* %272 to i64*
-  %NullCheck10 = icmp ne i64* %277, null
-  br i1 %NullCheck10, label %278, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %277, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %278
 
 ; <label>:278                                     ; preds = %275
   store i64 %276, i64* %277, align 8
@@ -1184,14 +1266,14 @@ entry:
   %281 = load i8*, i8** %arg1
   %282 = getelementptr inbounds i8, i8* %281, i64 8
   %283 = bitcast i8* %282 to i32*
-  %NullCheck12 = icmp ne i32* %283, null
-  br i1 %NullCheck12, label %284, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i32* %283, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %284
 
 ; <label>:284                                     ; preds = %278
   %285 = load i32, i32* %283, align 8
   %286 = bitcast i8* %280 to i32*
-  %NullCheck14 = icmp ne i32* %286, null
-  br i1 %NullCheck14, label %287, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i32* %286, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %287
 
 ; <label>:287                                     ; preds = %284
   store i32 %285, i32* %286, align 8
@@ -1200,16 +1282,16 @@ entry:
   %290 = load i8*, i8** %arg1
   %291 = getelementptr inbounds i8, i8* %290, i64 12
   %292 = bitcast i8* %291 to i16*
-  %NullCheck16 = icmp ne i16* %292, null
-  br i1 %NullCheck16, label %293, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i16* %292, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %293
 
 ; <label>:293                                     ; preds = %287
   %294 = load i16, i16* %292, align 8
   %295 = sext i16 %294 to i32
   %296 = bitcast i8* %289 to i16*
   %297 = trunc i32 %295 to i16
-  %NullCheck18 = icmp ne i16* %296, null
-  br i1 %NullCheck18, label %298, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i16* %296, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %298
 
 ; <label>:298                                     ; preds = %293
   store i16 %297, i16* %296, align 8
@@ -1217,15 +1299,15 @@ entry:
   %300 = getelementptr inbounds i8, i8* %299, i64 14
   %301 = load i8*, i8** %arg1
   %302 = getelementptr inbounds i8, i8* %301, i64 14
-  %NullCheck20 = icmp ne i8* %302, null
-  br i1 %NullCheck20, label %303, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i8* %302, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %303
 
 ; <label>:303                                     ; preds = %298
   %304 = load i8, i8* %302, align 8
   %305 = zext i8 %304 to i32
   %306 = trunc i32 %305 to i8
-  %NullCheck22 = icmp ne i8* %300, null
-  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i8* %300, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %307
 
 ; <label>:307                                     ; preds = %303
   store i8 %306, i8* %300, align 8
@@ -1235,14 +1317,14 @@ entry:
   %309 = load i8*, i8** %arg0
   %310 = load i8*, i8** %arg1
   %311 = bitcast i8* %310 to i64*
-  %NullCheck = icmp ne i64* %311, null
-  br i1 %NullCheck, label %312, label %ThrowNullRef
+  %NullCheck = icmp eq i64* %311, null
+  br i1 %NullCheck, label %ThrowNullRef, label %312
 
 ; <label>:312                                     ; preds = %308
   %313 = load i64, i64* %311, align 8
   %314 = bitcast i8* %309 to i64*
-  %NullCheck2 = icmp ne i64* %314, null
-  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64* %314, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %315
 
 ; <label>:315                                     ; preds = %312
   store i64 %313, i64* %314, align 8
@@ -1251,14 +1333,14 @@ entry:
   %318 = load i8*, i8** %arg1
   %319 = getelementptr inbounds i8, i8* %318, i64 8
   %320 = bitcast i8* %319 to i64*
-  %NullCheck4 = icmp ne i64* %320, null
-  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64* %320, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %321
 
 ; <label>:321                                     ; preds = %315
   %322 = load i64, i64* %320, align 8
   %323 = bitcast i8* %317 to i64*
-  %NullCheck6 = icmp ne i64* %323, null
-  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64* %323, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %324
 
 ; <label>:324                                     ; preds = %321
   store i64 %322, i64* %323, align 8
@@ -1286,15 +1368,15 @@ entry:
 ; <label>:338                                     ; preds = %333
   %339 = load i8*, i8** %arg0
   %340 = load i8*, i8** %arg1
-  %NullCheck136 = icmp ne i8* %340, null
-  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+  %NullCheck135 = icmp eq i8* %340, null
+  br i1 %NullCheck135, label %ThrowNullRef136, label %341
 
 ; <label>:341                                     ; preds = %338
   %342 = load i8, i8* %340, align 8
   %343 = zext i8 %342 to i32
   %344 = trunc i32 %343 to i8
-  %NullCheck138 = icmp ne i8* %339, null
-  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+  %NullCheck137 = icmp eq i8* %339, null
+  br i1 %NullCheck137, label %ThrowNullRef138, label %345
 
 ; <label>:345                                     ; preds = %341
   store i8 %344, i8* %339, align 8
@@ -1317,16 +1399,16 @@ entry:
   %357 = load i8*, i8** %arg0
   %358 = load i8*, i8** %arg1
   %359 = bitcast i8* %358 to i16*
-  %NullCheck140 = icmp ne i16* %359, null
-  br i1 %NullCheck140, label %360, label %ThrowNullRef139
+  %NullCheck139 = icmp eq i16* %359, null
+  br i1 %NullCheck139, label %ThrowNullRef140, label %360
 
 ; <label>:360                                     ; preds = %356
   %361 = load i16, i16* %359, align 8
   %362 = sext i16 %361 to i32
   %363 = bitcast i8* %357 to i16*
   %364 = trunc i32 %362 to i16
-  %NullCheck142 = icmp ne i16* %363, null
-  br i1 %NullCheck142, label %365, label %ThrowNullRef141
+  %NullCheck141 = icmp eq i16* %363, null
+  br i1 %NullCheck141, label %ThrowNullRef142, label %365
 
 ; <label>:365                                     ; preds = %360
   store i16 %364, i16* %363, align 8
@@ -1352,14 +1434,14 @@ entry:
   %378 = load i8*, i8** %arg0
   %379 = load i8*, i8** %arg1
   %380 = bitcast i8* %379 to i32*
-  %NullCheck144 = icmp ne i32* %380, null
-  br i1 %NullCheck144, label %381, label %ThrowNullRef143
+  %NullCheck143 = icmp eq i32* %380, null
+  br i1 %NullCheck143, label %ThrowNullRef144, label %381
 
 ; <label>:381                                     ; preds = %377
   %382 = load i32, i32* %380, align 8
   %383 = bitcast i8* %378 to i32*
-  %NullCheck146 = icmp ne i32* %383, null
-  br i1 %NullCheck146, label %384, label %ThrowNullRef145
+  %NullCheck145 = icmp eq i32* %383, null
+  br i1 %NullCheck145, label %ThrowNullRef146, label %384
 
 ; <label>:384                                     ; preds = %381
   store i32 %382, i32* %383, align 8
@@ -1384,14 +1466,14 @@ entry:
   %395 = load i8*, i8** %arg0
   %396 = load i8*, i8** %arg1
   %397 = bitcast i8* %396 to i64*
-  %NullCheck164 = icmp ne i64* %397, null
-  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+  %NullCheck163 = icmp eq i64* %397, null
+  br i1 %NullCheck163, label %ThrowNullRef164, label %398
 
 ; <label>:398                                     ; preds = %394
   %399 = load i64, i64* %397, align 8
   %400 = bitcast i8* %395 to i64*
-  %NullCheck166 = icmp ne i64* %400, null
-  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+  %NullCheck165 = icmp eq i64* %400, null
+  br i1 %NullCheck165, label %ThrowNullRef166, label %401
 
 ; <label>:401                                     ; preds = %398
   store i64 %399, i64* %400, align 8
@@ -1400,14 +1482,14 @@ entry:
   %404 = load i8*, i8** %arg1
   %405 = getelementptr inbounds i8, i8* %404, i64 8
   %406 = bitcast i8* %405 to i64*
-  %NullCheck168 = icmp ne i64* %406, null
-  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+  %NullCheck167 = icmp eq i64* %406, null
+  br i1 %NullCheck167, label %ThrowNullRef168, label %407
 
 ; <label>:407                                     ; preds = %401
   %408 = load i64, i64* %406, align 8
   %409 = bitcast i8* %403 to i64*
-  %NullCheck170 = icmp ne i64* %409, null
-  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+  %NullCheck169 = icmp eq i64* %409, null
+  br i1 %NullCheck169, label %ThrowNullRef170, label %410
 
 ; <label>:410                                     ; preds = %407
   store i64 %408, i64* %409, align 8
@@ -1437,14 +1519,14 @@ entry:
   %425 = load i8*, i8** %arg0
   %426 = load i8*, i8** %arg1
   %427 = bitcast i8* %426 to i64*
-  %NullCheck148 = icmp ne i64* %427, null
-  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+  %NullCheck147 = icmp eq i64* %427, null
+  br i1 %NullCheck147, label %ThrowNullRef148, label %428
 
 ; <label>:428                                     ; preds = %424
   %429 = load i64, i64* %427, align 8
   %430 = bitcast i8* %425 to i64*
-  %NullCheck150 = icmp ne i64* %430, null
-  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+  %NullCheck149 = icmp eq i64* %430, null
+  br i1 %NullCheck149, label %ThrowNullRef150, label %431
 
 ; <label>:431                                     ; preds = %428
   store i64 %429, i64* %430, align 8
@@ -1466,14 +1548,14 @@ entry:
   %441 = load i8*, i8** %arg0
   %442 = load i8*, i8** %arg1
   %443 = bitcast i8* %442 to i32*
-  %NullCheck152 = icmp ne i32* %443, null
-  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+  %NullCheck151 = icmp eq i32* %443, null
+  br i1 %NullCheck151, label %ThrowNullRef152, label %444
 
 ; <label>:444                                     ; preds = %440
   %445 = load i32, i32* %443, align 8
   %446 = bitcast i8* %441 to i32*
-  %NullCheck154 = icmp ne i32* %446, null
-  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+  %NullCheck153 = icmp eq i32* %446, null
+  br i1 %NullCheck153, label %ThrowNullRef154, label %447
 
 ; <label>:447                                     ; preds = %444
   store i32 %445, i32* %446, align 8
@@ -1495,16 +1577,16 @@ entry:
   %457 = load i8*, i8** %arg0
   %458 = load i8*, i8** %arg1
   %459 = bitcast i8* %458 to i16*
-  %NullCheck156 = icmp ne i16* %459, null
-  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+  %NullCheck155 = icmp eq i16* %459, null
+  br i1 %NullCheck155, label %ThrowNullRef156, label %460
 
 ; <label>:460                                     ; preds = %456
   %461 = load i16, i16* %459, align 8
   %462 = sext i16 %461 to i32
   %463 = bitcast i8* %457 to i16*
   %464 = trunc i32 %462 to i16
-  %NullCheck158 = icmp ne i16* %463, null
-  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+  %NullCheck157 = icmp eq i16* %463, null
+  br i1 %NullCheck157, label %ThrowNullRef158, label %465
 
 ; <label>:465                                     ; preds = %460
   store i16 %464, i16* %463, align 8
@@ -1525,15 +1607,15 @@ entry:
 ; <label>:474                                     ; preds = %470
   %475 = load i8*, i8** %arg0
   %476 = load i8*, i8** %arg1
-  %NullCheck160 = icmp ne i8* %476, null
-  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+  %NullCheck159 = icmp eq i8* %476, null
+  br i1 %NullCheck159, label %ThrowNullRef160, label %477
 
 ; <label>:477                                     ; preds = %474
   %478 = load i8, i8* %476, align 8
   %479 = zext i8 %478 to i32
   %480 = trunc i32 %479 to i8
-  %NullCheck162 = icmp ne i8* %475, null
-  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+  %NullCheck161 = icmp eq i8* %475, null
+  br i1 %NullCheck161, label %ThrowNullRef162, label %481
 
 ; <label>:481                                     ; preds = %477
   store i8 %480, i8* %475, align 8
@@ -1553,343 +1635,343 @@ ThrowNullRef:                                     ; preds = %308
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %312
+ThrowNullRef2:                                    ; preds = %312
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %315
+ThrowNullRef4:                                    ; preds = %315
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %321
+ThrowNullRef6:                                    ; preds = %321
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %271
+ThrowNullRef8:                                    ; preds = %271
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %275
+ThrowNullRef10:                                   ; preds = %275
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %278
+ThrowNullRef12:                                   ; preds = %278
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %284
+ThrowNullRef14:                                   ; preds = %284
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %287
+ThrowNullRef16:                                   ; preds = %287
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %293
+ThrowNullRef18:                                   ; preds = %293
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %298
+ThrowNullRef20:                                   ; preds = %298
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %303
+ThrowNullRef22:                                   ; preds = %303
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %243
+ThrowNullRef24:                                   ; preds = %243
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %247
+ThrowNullRef26:                                   ; preds = %247
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %250
+ThrowNullRef28:                                   ; preds = %250
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %256
+ThrowNullRef30:                                   ; preds = %256
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %259
+ThrowNullRef32:                                   ; preds = %259
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %265
+ThrowNullRef34:                                   ; preds = %265
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %217
+ThrowNullRef36:                                   ; preds = %217
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %221
+ThrowNullRef38:                                   ; preds = %221
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %224
+ThrowNullRef40:                                   ; preds = %224
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %230
+ThrowNullRef42:                                   ; preds = %230
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %233
+ThrowNullRef44:                                   ; preds = %233
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %238
+ThrowNullRef46:                                   ; preds = %238
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %200
+ThrowNullRef48:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %204
+ThrowNullRef50:                                   ; preds = %204
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %207
+ThrowNullRef52:                                   ; preds = %207
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %213
+ThrowNullRef54:                                   ; preds = %213
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %172
+ThrowNullRef56:                                   ; preds = %172
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %176
+ThrowNullRef58:                                   ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %179
+ThrowNullRef60:                                   ; preds = %179
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %185
+ThrowNullRef62:                                   ; preds = %185
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %190
+ThrowNullRef64:                                   ; preds = %190
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %195
+ThrowNullRef66:                                   ; preds = %195
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %153
+ThrowNullRef68:                                   ; preds = %153
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %157
+ThrowNullRef70:                                   ; preds = %157
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %160
+ThrowNullRef72:                                   ; preds = %160
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %166
+ThrowNullRef74:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %136
+ThrowNullRef76:                                   ; preds = %136
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %140
+ThrowNullRef78:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %143
+ThrowNullRef80:                                   ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %148
+ThrowNullRef82:                                   ; preds = %148
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %128
+ThrowNullRef84:                                   ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %132
+ThrowNullRef86:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %100
+ThrowNullRef88:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %104
+ThrowNullRef90:                                   ; preds = %104
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %107
+ThrowNullRef92:                                   ; preds = %107
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %113
+ThrowNullRef94:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %118
+ThrowNullRef96:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %123
+ThrowNullRef98:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %81
+ThrowNullRef100:                                  ; preds = %81
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef101:                                  ; preds = %85
+ThrowNullRef102:                                  ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef103:                                  ; preds = %88
+ThrowNullRef104:                                  ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef105:                                  ; preds = %94
+ThrowNullRef106:                                  ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef107:                                  ; preds = %64
+ThrowNullRef108:                                  ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef109:                                  ; preds = %68
+ThrowNullRef110:                                  ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef111:                                  ; preds = %71
+ThrowNullRef112:                                  ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef113:                                  ; preds = %76
+ThrowNullRef114:                                  ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef115:                                  ; preds = %56
+ThrowNullRef116:                                  ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef117:                                  ; preds = %60
+ThrowNullRef118:                                  ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef119:                                  ; preds = %37
+ThrowNullRef120:                                  ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef121:                                  ; preds = %41
+ThrowNullRef122:                                  ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef123:                                  ; preds = %46
+ThrowNullRef124:                                  ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef125:                                  ; preds = %51
+ThrowNullRef126:                                  ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef127:                                  ; preds = %27
+ThrowNullRef128:                                  ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef129:                                  ; preds = %31
+ThrowNullRef130:                                  ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef131:                                  ; preds = %19
+ThrowNullRef132:                                  ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef133:                                  ; preds = %22
+ThrowNullRef134:                                  ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef135:                                  ; preds = %338
+ThrowNullRef136:                                  ; preds = %338
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef137:                                  ; preds = %341
+ThrowNullRef138:                                  ; preds = %341
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef139:                                  ; preds = %356
+ThrowNullRef140:                                  ; preds = %356
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef141:                                  ; preds = %360
+ThrowNullRef142:                                  ; preds = %360
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef143:                                  ; preds = %377
+ThrowNullRef144:                                  ; preds = %377
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef145:                                  ; preds = %381
+ThrowNullRef146:                                  ; preds = %381
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef147:                                  ; preds = %424
+ThrowNullRef148:                                  ; preds = %424
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef149:                                  ; preds = %428
+ThrowNullRef150:                                  ; preds = %428
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef151:                                  ; preds = %440
+ThrowNullRef152:                                  ; preds = %440
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef153:                                  ; preds = %444
+ThrowNullRef154:                                  ; preds = %444
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef155:                                  ; preds = %456
+ThrowNullRef156:                                  ; preds = %456
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef157:                                  ; preds = %460
+ThrowNullRef158:                                  ; preds = %460
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef159:                                  ; preds = %474
+ThrowNullRef160:                                  ; preds = %474
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef161:                                  ; preds = %477
+ThrowNullRef162:                                  ; preds = %477
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef163:                                  ; preds = %394
+ThrowNullRef164:                                  ; preds = %394
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef165:                                  ; preds = %398
+ThrowNullRef166:                                  ; preds = %398
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef167:                                  ; preds = %401
+ThrowNullRef168:                                  ; preds = %401
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef169:                                  ; preds = %407
+ThrowNullRef170:                                  ; preds = %407
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1939,8 +2021,8 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
-  br i1 %NullCheck, label %22, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %ThrowNullRef, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
@@ -1948,8 +2030,8 @@ entry:
   store i32 %24, i32* %loc0
   %25 = load i32, i32* %loc0
   %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %26, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %27
 
 ; <label>:27                                      ; preds = %22
   %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
@@ -1971,7 +2053,7 @@ ThrowNullRef:                                     ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1989,8 +2071,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -2022,15 +2104,15 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2048,16 +2130,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
   %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
   store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %15
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
@@ -2072,8 +2154,8 @@ entry:
   %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
   %29 = ptrtoint i16 addrspace(1)* %28 to i64
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %19
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
@@ -2089,19 +2171,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2114,8 +2196,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
@@ -2128,7 +2210,7 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[loadElem]
+Failed to read AppDomain.PrepareDataForSetup[storeElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
@@ -2202,8 +2284,8 @@ entry:
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
-  br i1 %NullCheck24, label %27, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = load i64, i64 addrspace(1)* %26
@@ -2218,8 +2300,8 @@ entry:
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
-  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
   %41 = load i64, i64 addrspace(1)* %39
@@ -2236,8 +2318,8 @@ entry:
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
-  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
   %54 = load i64, i64 addrspace(1)* %52
@@ -2252,8 +2334,8 @@ entry:
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
   %67 = load i64, i64 addrspace(1)* %65
@@ -2270,8 +2352,8 @@ entry:
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
-  br i1 %NullCheck16, label %79, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
   %80 = load i64, i64 addrspace(1)* %78
@@ -2286,8 +2368,8 @@ entry:
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
-  br i1 %NullCheck18, label %92, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
   %93 = load i64, i64 addrspace(1)* %91
@@ -2304,8 +2386,8 @@ entry:
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
-  br i1 %NullCheck12, label %105, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = load i64, i64 addrspace(1)* %104
@@ -2320,8 +2402,8 @@ entry:
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
-  br i1 %NullCheck14, label %118, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
   %119 = load i64, i64 addrspace(1)* %117
@@ -2337,8 +2419,8 @@ entry:
 
 ; <label>:128                                     ; preds = %20
   %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
-  br i1 %NullCheck4, label %130, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %129, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %130
 
 ; <label>:130                                     ; preds = %128
   %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
@@ -2346,8 +2428,8 @@ entry:
   %133 = load i16, i16 addrspace(1)* %132, align 8
   %134 = zext i16 %133 to i32
   %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
-  br i1 %NullCheck6, label %136, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %135, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %136
 
 ; <label>:136                                     ; preds = %130
   %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
@@ -2360,8 +2442,8 @@ entry:
 
 ; <label>:143                                     ; preds = %136
   %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
-  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %144, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %145
 
 ; <label>:145                                     ; preds = %143
   %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
@@ -2369,8 +2451,8 @@ entry:
   %148 = load i16, i16 addrspace(1)* %147, align 8
   %149 = zext i16 %148 to i32
   %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %150, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %151
 
 ; <label>:151                                     ; preds = %145
   %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
@@ -2388,8 +2470,8 @@ entry:
 
 ; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
-  br i1 %NullCheck, label %163, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %ThrowNullRef, label %163
 
 ; <label>:163                                     ; preds = %161
   %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
@@ -2399,8 +2481,8 @@ entry:
 
 ; <label>:167                                     ; preds = %163
   %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
-  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %168, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %169
 
 ; <label>:169                                     ; preds = %167
   %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
@@ -2432,55 +2514,55 @@ ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %167
+ThrowNullRef2:                                    ; preds = %167
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %128
+ThrowNullRef4:                                    ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %130
+ThrowNullRef6:                                    ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %143
+ThrowNullRef8:                                    ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %145
+ThrowNullRef10:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %102
+ThrowNullRef12:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %105
+ThrowNullRef14:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %76
+ThrowNullRef16:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %79
+ThrowNullRef18:                                   ; preds = %79
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %50
+ThrowNullRef20:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %53
+ThrowNullRef22:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %24
+ThrowNullRef24:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %27
+ThrowNullRef26:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2503,15 +2585,15 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2519,16 +2601,16 @@ entry:
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
   store i32 %8, i32* %loc0
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
   %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
   store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
@@ -2546,16 +2628,16 @@ entry:
 
 ; <label>:23                                      ; preds = %64
   %24 = load i16*, i16** %loc3
-  %NullCheck12 = icmp ne i16* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i16* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
   store i32 %27, i32* %loc5
   %28 = load i16*, i16** %loc4
-  %NullCheck14 = icmp ne i16* %28, null
-  br i1 %NullCheck14, label %29, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %28, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = load i16, i16* %28, align 8
@@ -2620,15 +2702,15 @@ entry:
 
 ; <label>:67                                      ; preds = %64
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
-  br i1 %NullCheck8, label %69, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %68, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %69
 
 ; <label>:69                                      ; preds = %67
   %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
   %71 = load i32, i32 addrspace(1)* %70
   %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
-  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %73
 
 ; <label>:73                                      ; preds = %69
   %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
@@ -2645,31 +2727,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %67
+ThrowNullRef8:                                    ; preds = %67
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %69
+ThrowNullRef10:                                   ; preds = %69
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2710,14 +2792,14 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
   %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
@@ -2730,14 +2812,14 @@ entry:
 
 ; <label>:11                                      ; preds = %4
   %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
   %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
@@ -2749,14 +2831,14 @@ entry:
 
 ; <label>:22                                      ; preds = %16
   %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
   %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
-  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
-  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
@@ -2804,23 +2886,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2836,7 +2918,280 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[loadElem]
+Successfully read RuntimeType.IsAssignableFrom
+
+define i8 @RuntimeType.IsAssignableFrom(%System.RuntimeType addrspace(1)* %param0, %System.Type addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.RuntimeType addrspace(1)*
+  %arg1 = alloca %System.Type addrspace(1)*
+  %loc0 = alloca %System.RuntimeType addrspace(1)*
+  %loc1 = alloca %"System.Type[]" addrspace(1)*
+  %loc2 = alloca i32
+  store %System.RuntimeType addrspace(1)* %param0, %System.RuntimeType addrspace(1)** %this
+  store %System.Type addrspace(1)* %param1, %System.Type addrspace(1)** %arg1
+  %0 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %1 = icmp ne %System.Type addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i8 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %5 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %6 = bitcast %System.Type addrspace(1)* %4 to %System.Object addrspace(1)*
+  %7 = bitcast %System.RuntimeType addrspace(1)* %5 to %System.Object addrspace(1)*
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %6, %System.Object addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %3
+  ret i8 1
+
+; <label>:12                                      ; preds = %3
+  %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 152
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 32
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
+  %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
+  %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
+  store %System.RuntimeType addrspace(1)* %25, %System.RuntimeType addrspace(1)** %loc0
+  %26 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %27 = icmp eq %System.RuntimeType addrspace(1)* %26, null
+  br i1 %27, label %34, label %28
+
+; <label>:28                                      ; preds = %15
+  %29 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %30 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)*)*)(%System.RuntimeType addrspace(1)* %29, %System.RuntimeType addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+; <label>:34                                      ; preds = %15
+  %35 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %36 = call %System.Reflection.Emit.TypeBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Reflection.Emit.TypeBuilder addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %35)
+  %37 = icmp eq %System.Reflection.Emit.TypeBuilder addrspace(1)* %36, null
+  br i1 %37, label %139, label %38
+
+; <label>:38                                      ; preds = %34
+  %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %42
+
+; <label>:42                                      ; preds = %38
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 152
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 40
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
+  %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
+  %53 = zext i8 %52 to i32
+  %54 = icmp eq i32 %53, 0
+  br i1 %54, label %56, label %55
+
+; <label>:55                                      ; preds = %42
+  ret i8 1
+
+; <label>:56                                      ; preds = %42
+  %57 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %58 = bitcast %System.RuntimeType addrspace(1)* %57 to %System.Type addrspace(1)*
+  %59 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %58)
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %64 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.Type addrspace(1)* %63, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = bitcast %System.RuntimeType addrspace(1)* %64 to %System.Type addrspace(1)*
+  %67 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %63, %System.Type addrspace(1)* %66)
+  %68 = zext i8 %67 to i32
+  %69 = trunc i32 %68 to i8
+  ret i8 %69
+
+; <label>:70                                      ; preds = %56
+  %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
+  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %73
+
+; <label>:73                                      ; preds = %70
+  %74 = load i64, i64 addrspace(1)* %72
+  %75 = add i64 %74, 128
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = add i64 %77, 0
+  %79 = inttoptr i64 %78 to i64*
+  %80 = load i64, i64* %79
+  %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
+  %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
+  %83 = call i8 %82(%System.Type addrspace(1)* %81)
+  %84 = zext i8 %83 to i32
+  %85 = icmp eq i32 %84, 0
+  br i1 %85, label %139, label %86
+
+; <label>:86                                      ; preds = %73
+  %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
+  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %89
+
+; <label>:89                                      ; preds = %86
+  %90 = load i64, i64 addrspace(1)* %88
+  %91 = add i64 %90, 128
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = add i64 %93, 24
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
+  %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
+  %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
+  store %"System.Type[]" addrspace(1)* %99, %"System.Type[]" addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %129
+
+; <label>:100                                     ; preds = %132
+  %101 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %102 = load i32, i32* %loc2
+  %NullCheck11 = icmp eq %"System.Type[]" addrspace(1)* %101, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %103
+
+; <label>:103                                     ; preds = %100
+  %104 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 1
+  %105 = load i32, i32 addrspace(1)* %104
+  %106 = zext i32 %105 to i64
+  %107 = zext i32 %102 to i64
+  %BoundsCheck = icmp uge i64 %107, %106
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %108
+
+; <label>:108                                     ; preds = %103
+  %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
+  %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
+  %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
+  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %113
+
+; <label>:113                                     ; preds = %108
+  %114 = load i64, i64 addrspace(1)* %112
+  %115 = add i64 %114, 152
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = add i64 %117, 56
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
+  %123 = zext i8 %122 to i32
+  %124 = icmp ne i32 %123, 0
+  br i1 %124, label %126, label %125
+
+; <label>:125                                     ; preds = %113
+  ret i8 0
+
+; <label>:126                                     ; preds = %113
+  %127 = load i32, i32* %loc2
+  %128 = add i32 %127, 1
+  store i32 %128, i32* %loc2
+  br label %129
+
+; <label>:129                                     ; preds = %89, %126
+  %130 = load i32, i32* %loc2
+  %131 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %NullCheck9 = icmp eq %"System.Type[]" addrspace(1)* %131, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %132
+
+; <label>:132                                     ; preds = %129
+  %133 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %131, i32 0, i32 1
+  %134 = load i32, i32 addrspace(1)* %133
+  %135 = zext i32 %134 to i64
+  %136 = trunc i64 %135 to i32
+  %137 = icmp slt i32 %130, %136
+  br i1 %137, label %100, label %138
+
+; <label>:138                                     ; preds = %132
+  ret i8 1
+
+; <label>:139                                     ; preds = %34, %73
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %129
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %103
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -2893,7 +3248,7 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElem]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -2904,8 +3259,8 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -2997,8 +3352,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
@@ -3059,8 +3414,8 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -3087,8 +3442,8 @@ entry:
 
 ; <label>:17                                      ; preds = %5, %11
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
@@ -3097,8 +3452,8 @@ entry:
 
 ; <label>:22                                      ; preds = %1, %11
   %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
@@ -3109,11 +3464,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %17
+ThrowNullRef2:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %22
+ThrowNullRef4:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3167,15 +3522,15 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
   %15 = load i32, i32 addrspace(1)* %14
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
@@ -3198,7 +3553,7 @@ ThrowNullRef:                                     ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef2:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3232,8 +3587,8 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
@@ -3312,8 +3667,8 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -3327,8 +3682,8 @@ entry:
 ; <label>:5                                       ; preds = %43
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %7 = load i32, i32* %loc1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck6, label %8, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
@@ -3366,8 +3721,8 @@ entry:
 ; <label>:32                                      ; preds = %21, %25
   %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
   %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
-  br i1 %NullCheck8, label %35, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = trunc i32 %34 to i16
@@ -3380,8 +3735,8 @@ entry:
 ; <label>:40                                      ; preds = %1, %35
   %41 = load i32, i32* %loc1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
-  br i1 %NullCheck2, label %43, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %42, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
@@ -3392,8 +3747,8 @@ entry:
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
   %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
-  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
   %51 = load i64, i64 addrspace(1)* %49
@@ -3412,19 +3767,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %40
+ThrowNullRef2:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %47
+ThrowNullRef4:                                    ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %5
+ThrowNullRef6:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %32
+ThrowNullRef8:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3467,8 +3822,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
@@ -3492,11 +3847,391 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(i16* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store i16* %param0, i16** %arg0
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load i32, i32* %arg3
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %42, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %37, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg2
+  %13 = load i32, i32* %arg3
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %37, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %24 = load i32, i32* %arg2
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load i16*, i16** %arg0
+  %35 = load i32, i32* %arg3
+  %36 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %36, i16* %34, i32 %35)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:37                                      ; preds = %5, %16
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %39)
+  %41 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41, %System.String addrspace(1)* %38, %System.String addrspace(1)* %40)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41) #0
+  unreachable
+
+; <label>:42                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
-Failed to read StringBuilder.ToString[loadElemA]
+Successfully read StringBuilder.ToString
+
+define %System.String addrspace(1)* @StringBuilder.ToString(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i16*
+  %loc3 = alloca %"System.Char[]" addrspace(1)*
+  %loc4 = alloca i32
+  %loc5 = alloca i32
+  %loc6 = alloca i16 addrspace(1)*
+  %loc7 = alloca %System.String addrspace(1)*
+  %loc8 = alloca %"System.Char[]" addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %0)
+  %2 = icmp ne i32 %1, 0
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %4
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %6)
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %7)
+  store %System.String addrspace(1)* %8, %System.String addrspace(1)** %loc0
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.Text.StringBuilder addrspace(1)* %9, %System.Text.StringBuilder addrspace(1)** %loc1
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  store %System.String addrspace(1)* %10, %System.String addrspace(1)** %loc7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc7
+  %12 = ptrtoint %System.String addrspace(1)* %11 to i64
+  %13 = icmp eq i64 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %5
+  %15 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %16 = sext i32 %15 to i64
+  %17 = add i64 %12, %16
+  br label %18
+
+; <label>:18                                      ; preds = %5, %14
+  %19 = phi i64 [ %12, %5 ], [ %17, %14 ]
+  %20 = inttoptr i64 %19 to i16*
+  store i16* %20, i16** %loc2
+  br label %21
+
+; <label>:21                                      ; preds = %98, %18
+  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %22, null
+  br i1 %NullCheck, label %ThrowNullRef, label %23
+
+; <label>:23                                      ; preds = %21
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 3
+  %25 = load i32, i32 addrspace(1)* %24, align 8
+  %26 = icmp sle i32 %25, 0
+  br i1 %26, label %96, label %27
+
+; <label>:27                                      ; preds = %23
+  %28 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %28, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %29
+
+; <label>:29                                      ; preds = %27
+  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %28, i32 0, i32 1
+  %31 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %30, align 8
+  store %"System.Char[]" addrspace(1)* %31, %"System.Char[]" addrspace(1)** %loc3
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %33
+
+; <label>:33                                      ; preds = %29
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  store i32 %35, i32* %loc4
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  %39 = load i32, i32 addrspace(1)* %38, align 8
+  store i32 %39, i32* %loc5
+  %40 = load i32, i32* %loc5
+  %41 = load i32, i32* %loc4
+  %42 = add i32 %40, %41
+  %43 = zext i32 %42 to i64
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %45
+
+; <label>:45                                      ; preds = %37
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = sext i32 %47 to i64
+  %49 = icmp sgt i64 %43, %48
+  br i1 %49, label %91, label %50
+
+; <label>:50                                      ; preds = %45
+  %51 = load i32, i32* %loc5
+  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %52, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %53
+
+; <label>:53                                      ; preds = %50
+  %54 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %52, i32 0, i32 1
+  %55 = load i32, i32 addrspace(1)* %54
+  %56 = zext i32 %55 to i64
+  %57 = trunc i64 %56 to i32
+  %58 = icmp ugt i32 %51, %57
+  br i1 %58, label %91, label %59
+
+; <label>:59                                      ; preds = %53
+  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  store %"System.Char[]" addrspace(1)* %60, %"System.Char[]" addrspace(1)** %loc8
+  %61 = icmp eq %"System.Char[]" addrspace(1)* %60, null
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %63, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %64
+
+; <label>:64                                      ; preds = %62
+  %65 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %63, i32 0, i32 1
+  %66 = load i32, i32 addrspace(1)* %65
+  %67 = zext i32 %66 to i64
+  %68 = trunc i64 %67 to i32
+  %69 = icmp ne i32 %68, 0
+  br i1 %69, label %71, label %70
+
+; <label>:70                                      ; preds = %59, %64
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:71                                      ; preds = %64
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %73
+
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %BoundsCheck = icmp uge i64 0, %76
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %77
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %78, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:79                                      ; preds = %70, %77
+  %80 = load i16*, i16** %loc2
+  %81 = load i32, i32* %loc4
+  %82 = sext i32 %81 to i64
+  %83 = mul i64 %82, 2
+  %84 = bitcast i16* %80 to i8*
+  %85 = getelementptr inbounds i8, i8* %84, i64 %83
+  %86 = load i16 addrspace(1)*, i16 addrspace(1)** %loc6
+  %87 = ptrtoint i16 addrspace(1)* %86 to i64
+  %88 = load i32, i32* %loc5
+  %89 = bitcast i8* %85 to i16*
+  %90 = inttoptr i64 %87 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %89, i16* %90, i32 %88)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %96
+
+; <label>:91                                      ; preds = %45, %53
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %94 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %93)
+  %95 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95, %System.String addrspace(1)* %92, %System.String addrspace(1)* %94)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95) #0
+  unreachable
+
+; <label>:96                                      ; preds = %23, %79
+  %97 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %97, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %98
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %97, i32 0, i32 2
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  store %System.Text.StringBuilder addrspace(1)* %100, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %102 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %102, label %21, label %103
+
+; <label>:103                                     ; preds = %98
+  store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc7
+  %104 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  ret %System.String addrspace(1)* %104
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method StringBuilder::get_Length using LLILCJit
+Successfully read StringBuilder.get_Length
+
+define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
+Successfully read RuntimeHelpers.get_OffsetToStringData
+
+define i32 @RuntimeHelpers.get_OffsetToStringData() {
+entry:
+  ret i32 12
+}
+
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
 Successfully read CultureData.CreateCultureData
 
@@ -3514,23 +4249,23 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
   store i8 %4, i8 addrspace(1)* %6
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
@@ -3549,11 +4284,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3566,50 +4301,50 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
   store i32 -1, i32 addrspace(1)* %2
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
   store i32 -1, i32 addrspace(1)* %8
   %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
   store i32 -1, i32 addrspace(1)* %14
   %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
   store i32 -1, i32 addrspace(1)* %17
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
@@ -3623,27 +4358,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3675,7 +4410,136 @@ Failed to read Dictionary`2.Insert[non-const derefAddress]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
 Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
-Failed to read HashHelpers.GetPrime[loadElem]
+Successfully read HashHelpers.GetPrime
+
+define i32 @HashHelpers.GetPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %6, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5, %System.String addrspace(1)* %4)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5) #0
+  unreachable
+
+; <label>:6                                       ; preds = %entry
+  store i32 0, i32* %loc0
+  br label %29
+
+; <label>:7                                       ; preds = %35
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 1296
+  %10 = addrspacecast i8 addrspace(1)* %9 to %"System.Int32[]" addrspace(1)**
+  %11 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %10
+  %12 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Int32[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = zext i32 %15 to i64
+  %17 = zext i32 %12 to i64
+  %BoundsCheck = icmp uge i64 %17, %16
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 3, i32 %12
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  store i32 %20, i32* %loc1
+  %21 = load i32, i32* %loc1
+  %22 = load i32, i32* %arg0
+  %23 = icmp slt i32 %21, %22
+  br i1 %23, label %26, label %24
+
+; <label>:24                                      ; preds = %18
+  %25 = load i32, i32* %loc1
+  ret i32 %25
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %loc0
+  %28 = add i32 %27, 1
+  store i32 %28, i32* %loc0
+  br label %29
+
+; <label>:29                                      ; preds = %6, %26
+  %30 = load i32, i32* %loc0
+  %31 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %32 = getelementptr inbounds i8, i8 addrspace(1)* %31, i64 1296
+  %33 = addrspacecast i8 addrspace(1)* %32 to %"System.Int32[]" addrspace(1)**
+  %34 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %33
+  %NullCheck = icmp eq %"System.Int32[]" addrspace(1)* %34, null
+  br i1 %NullCheck, label %ThrowNullRef, label %35
+
+; <label>:35                                      ; preds = %29
+  %36 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %34, i32 0, i32 1
+  %37 = load i32, i32 addrspace(1)* %36
+  %38 = zext i32 %37 to i64
+  %39 = trunc i64 %38 to i32
+  %40 = icmp slt i32 %30, %39
+  br i1 %40, label %7, label %41
+
+; <label>:41                                      ; preds = %35
+  %42 = load i32, i32* %arg0
+  %43 = or i32 %42, 1
+  store i32 %43, i32* %loc2
+  br label %59
+
+; <label>:44                                      ; preds = %59
+  %45 = load i32, i32* %loc2
+  %46 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %45)
+  %47 = zext i8 %46 to i32
+  %48 = icmp eq i32 %47, 0
+  br i1 %48, label %56, label %49
+
+; <label>:49                                      ; preds = %44
+  %50 = load i32, i32* %loc2
+  %51 = sub i32 %50, 1
+  %52 = srem i32 %51, 101
+  %53 = icmp eq i32 %52, 0
+  br i1 %53, label %56, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = load i32, i32* %loc2
+  ret i32 %55
+
+; <label>:56                                      ; preds = %44, %49
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %57, 2
+  store i32 %58, i32* %loc2
+  br label %59
+
+; <label>:59                                      ; preds = %41, %56
+  %60 = load i32, i32* %loc2
+  %61 = icmp slt i32 %60, 2147483647
+  br i1 %61, label %44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load i32, i32* %arg0
+  ret i32 %63
+
+ThrowNullRef:                                     ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
 Successfully read GenericEqualityComparer`1.GetHashCode
 
@@ -3694,14 +4558,14 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
   %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load i64, i64 addrspace(1)* %7
@@ -3720,7 +4584,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3750,8 +4614,8 @@ entry:
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
@@ -3796,8 +4660,8 @@ entry:
   %35 = bitcast i16* %34 to i8*
   %36 = getelementptr inbounds i8, i8* %35, i64 2
   %37 = bitcast i8* %36 to i16*
-  %NullCheck4 = icmp ne i16* %37, null
-  br i1 %NullCheck4, label %38, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %37, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %38
 
 ; <label>:38                                      ; preds = %27
   %39 = load i16, i16* %37, align 8
@@ -3824,8 +4688,8 @@ entry:
 
 ; <label>:54                                      ; preds = %22, %43
   %55 = load i16*, i16** %loc4
-  %NullCheck2 = icmp ne i16* %55, null
-  br i1 %NullCheck2, label %56, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i16* %55, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %56
 
 ; <label>:56                                      ; preds = %54
   %57 = load i16, i16* %55, align 8
@@ -3850,11 +4714,11 @@ ThrowNullRef:                                     ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %54
+ThrowNullRef2:                                    ; preds = %54
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %27
+ThrowNullRef4:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3871,8 +4735,8 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -3907,8 +4771,8 @@ entry:
 
 ; <label>:26                                      ; preds = %19
   %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
-  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %28
 
 ; <label>:28                                      ; preds = %26
   %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
@@ -3920,7 +4784,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3972,8 +4836,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
@@ -3984,26 +4848,26 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
-  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
@@ -4014,8 +4878,8 @@ entry:
 ; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
@@ -4024,8 +4888,8 @@ entry:
 
 ; <label>:25                                      ; preds = %1, %16, %23
   %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
-  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
@@ -4036,27 +4900,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %20
+ThrowNullRef10:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4069,8 +4933,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -4081,8 +4945,8 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
@@ -4091,8 +4955,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1, %8
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
@@ -4103,11 +4967,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4128,24 +4992,24 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   store i32 %3, i32* %loc0
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
   %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
   store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck4, label %9, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
@@ -4164,15 +5028,15 @@ entry:
 ; <label>:18                                      ; preds = %70
   %19 = load i16*, i16** %loc3
   %20 = bitcast i16* %19 to i64*
-  %NullCheck10 = icmp ne i64* %20, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %20, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = load i64, i64* %20, align 8
   %23 = load i16*, i16** %loc4
   %24 = bitcast i16* %23 to i64*
-  %NullCheck12 = icmp ne i64* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = load i64, i64* %24, align 8
@@ -4188,8 +5052,8 @@ entry:
   %31 = bitcast i16* %30 to i8*
   %32 = getelementptr inbounds i8, i8* %31, i64 8
   %33 = bitcast i8* %32 to i64*
-  %NullCheck14 = icmp ne i64* %33, null
-  br i1 %NullCheck14, label %34, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = load i64, i64* %33, align 8
@@ -4197,8 +5061,8 @@ entry:
   %37 = bitcast i16* %36 to i8*
   %38 = getelementptr inbounds i8, i8* %37, i64 8
   %39 = bitcast i8* %38 to i64*
-  %NullCheck16 = icmp ne i64* %39, null
-  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %40
 
 ; <label>:40                                      ; preds = %34
   %41 = load i64, i64* %39, align 8
@@ -4214,8 +5078,8 @@ entry:
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %NullCheck18 = icmp ne i64* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = load i64, i64* %48, align 8
@@ -4223,8 +5087,8 @@ entry:
   %52 = bitcast i16* %51 to i8*
   %53 = getelementptr inbounds i8, i8* %52, i64 16
   %54 = bitcast i8* %53 to i64*
-  %NullCheck20 = icmp ne i64* %54, null
-  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64* %54, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %55
 
 ; <label>:55                                      ; preds = %49
   %56 = load i64, i64* %54, align 8
@@ -4262,15 +5126,15 @@ entry:
 ; <label>:74                                      ; preds = %95
   %75 = load i16*, i16** %loc3
   %76 = bitcast i16* %75 to i32*
-  %NullCheck6 = icmp ne i32* %76, null
-  br i1 %NullCheck6, label %77, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32* %76, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %77
 
 ; <label>:77                                      ; preds = %74
   %78 = load i32, i32* %76, align 8
   %79 = load i16*, i16** %loc4
   %80 = bitcast i16* %79 to i32*
-  %NullCheck8 = icmp ne i32* %80, null
-  br i1 %NullCheck8, label %81, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i32* %80, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %81
 
 ; <label>:81                                      ; preds = %77
   %82 = load i32, i32* %80, align 8
@@ -4318,43 +5182,43 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %74
+ThrowNullRef6:                                    ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %77
+ThrowNullRef8:                                    ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %29
+ThrowNullRef14:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %34
+ThrowNullRef16:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4376,8 +5240,8 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load i64, i64 addrspace(1)* %4
@@ -4389,8 +5253,8 @@ entry:
   %12 = load i64, i64* %11
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %5
   %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
@@ -4399,8 +5263,8 @@ entry:
   %18 = load i8, i8* %arg2
   %19 = zext i8 %18 to i32
   %20 = trunc i32 %19 to i8
-  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %15
   %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
@@ -4411,11 +5275,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4442,8 +5306,8 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
@@ -4466,16 +5330,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
   %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = load i64, i64 addrspace(1)* %19
@@ -4500,8 +5364,8 @@ entry:
 ; <label>:35                                      ; preds = %30
   %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
@@ -4514,8 +5378,8 @@ entry:
 
 ; <label>:42                                      ; preds = %1, %38
   %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
-  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
@@ -4526,19 +5390,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %35
+ThrowNullRef2:                                    ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %42
+ThrowNullRef8:                                    ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4551,14 +5415,14 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
@@ -4570,7 +5434,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4583,8 +5447,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
@@ -4613,51 +5477,51 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
   %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
   %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
   %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
   %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
-  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
   store i64 %21, i64 addrspace(1)* %23
   %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %25 = load i64, i64* %loc0
-  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
@@ -4668,27 +5532,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %22
+ThrowNullRef12:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4701,8 +5565,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
@@ -4713,19 +5577,19 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
@@ -4734,8 +5598,8 @@ entry:
 
 ; <label>:15                                      ; preds = %1, %13
   %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
@@ -4746,19 +5610,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %15
+ThrowNullRef8:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4771,8 +5635,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -4831,8 +5695,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
@@ -4882,8 +5746,8 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
-  br i1 %NullCheck, label %17, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %ThrowNullRef, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
@@ -4894,15 +5758,15 @@ entry:
 
 ; <label>:22                                      ; preds = %17
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
-  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
   %26 = load i32, i32 addrspace(1)* %25
   %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
-  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %27, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
@@ -4925,8 +5789,8 @@ entry:
 ; <label>:40                                      ; preds = %17
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
-  br i1 %NullCheck6, label %43, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %41, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
@@ -4938,34 +5802,17 @@ ThrowNullRef:                                     ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %24
+ThrowNullRef4:                                    ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %40
+ThrowNullRef6:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
-}
-
-INFO:  jitting method Object::ReferenceEquals using LLILCJit
-Successfully read Object.ReferenceEquals
-
-define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
-entry:
-  %arg0 = alloca %System.Object addrspace(1)*
-  %arg1 = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
-  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
-  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = icmp eq %System.Object addrspace(1)* %0, %1
-  %3 = sext i1 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
 }
 
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
@@ -4978,21 +5825,21 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
   %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
-  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
@@ -5007,28 +5854,28 @@ entry:
 ; <label>:13                                      ; preds = %8, %12
   %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
   %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
   %21 = load i32, i32 addrspace(1)* %20, align 8
   %22 = add i32 %21, 1
-  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
   store i32 %22, i32 addrspace(1)* %24
   %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
@@ -5039,27 +5886,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5077,7 +5924,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::Setup using LLILCJit
-Failed to read AppDomain.Setup[loadElem]
+Failed to read AppDomain.Setup[unbox]
 INFO:  jitting method Thread::GetDomain using LLILCJit
 Successfully read Thread.GetDomain
 
@@ -5108,8 +5955,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
@@ -5122,14 +5969,14 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
   %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
@@ -5141,11 +5988,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5173,8 +6020,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -5189,7 +6036,328 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
 Failed to read KeyCollection.System.Collections.Generic.IEnumerable<TKey>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Successfully read Enumerator.MoveNext
+
+define i8 @Enumerator.MoveNext(%"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.RuntimeTypeHandle* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*
+  %"$TypeArg" = alloca %System.RuntimeTypeHandle*
+  store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
+  %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 8
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %76, label %12
+
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
+  br label %76
+
+; <label>:13                                      ; preds = %85
+  %14 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck19 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %15
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, i32 0, i32 0
+  %17 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %16, align 8
+  %NullCheck21 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, i32 0, i32 2
+  %20 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %19, align 8
+  %21 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck23 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %22
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, i32 0, i32 2
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %NullCheck25 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 3, i32 %24
+  %NullCheck27 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %32
+
+; <label>:32                                      ; preds = %30
+  %33 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, i32 0, i32 2
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = icmp slt i32 %34, 0
+  br i1 %35, label %68, label %36
+
+; <label>:36                                      ; preds = %32
+  %37 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %38 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck29 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %39
+
+; <label>:39                                      ; preds = %36
+  %40 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, i32 0, i32 0
+  %41 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %40, align 8
+  %NullCheck31 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, i32 0, i32 2
+  %44 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %43, align 8
+  %45 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck33 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, i32 0, i32 2
+  %48 = load i32, i32 addrspace(1)* %47, align 8
+  %NullCheck35 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %49
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = zext i32 %51 to i64
+  %53 = zext i32 %48 to i64
+  %BoundsCheck37 = icmp uge i64 %53, %52
+  br i1 %BoundsCheck37, label %ThrowIndexOutOfRange38, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 3, i32 %48
+  %NullCheck39 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %56
+
+; <label>:56                                      ; preds = %54
+  %57 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, i32 0, i32 0
+  %58 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck41 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %59
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %60, %System.__Canon addrspace(1)* %58)
+  %61 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck43 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  %64 = load i32, i32 addrspace(1)* %63, align 8
+  %65 = add i32 %64, 1
+  %NullCheck45 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  store i32 %65, i32 addrspace(1)* %67
+  ret i8 1
+
+; <label>:68                                      ; preds = %32
+  %69 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck47 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %73 = add i32 %72, 1
+  %NullCheck49 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %74
+
+; <label>:74                                      ; preds = %70
+  %75 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  store i32 %73, i32 addrspace(1)* %75
+  br label %76
+
+; <label>:76                                      ; preds = %8, %12, %74
+  %77 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %78
+
+; <label>:78                                      ; preds = %76
+  %79 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, i32 0, i32 2
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck7 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %82
+
+; <label>:82                                      ; preds = %78
+  %83 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, i32 0, i32 0
+  %84 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %83, align 8
+  %NullCheck9 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %85
+
+; <label>:85                                      ; preds = %82
+  %86 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, i32 0, i32 7
+  %87 = load i32, i32 addrspace(1)* %86, align 8
+  %88 = icmp ult i32 %80, %87
+  br i1 %88, label %13, label %89
+
+; <label>:89                                      ; preds = %85
+  %90 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %91 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck11 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %92
+
+; <label>:92                                      ; preds = %89
+  %93 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, i32 0, i32 0
+  %94 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck13 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %95
+
+; <label>:95                                      ; preds = %92
+  %96 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, i32 0, i32 7
+  %97 = load i32, i32 addrspace(1)* %96, align 8
+  %98 = add i32 %97, 1
+  %NullCheck15 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %99
+
+; <label>:99                                      ; preds = %95
+  %100 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, i32 0, i32 2
+  store i32 %98, i32 addrspace(1)* %100
+  %101 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck17 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %102
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %103, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %92
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef22:                                   ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef24:                                   ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef26:                                   ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef28:                                   ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef30:                                   ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef32:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef34:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef36:                                   ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange38:                           ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef40:                                   ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef42:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef44:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef46:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef48:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef50:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -5200,8 +6368,8 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -5232,9 +6400,9 @@ Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
 Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
-Failed to read String.MakeSeparatorList[loadElemA]
+Failed to read String.MakeSeparatorList[storeElem]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
-Failed to read String.InternalSplitKeepEmptyEntries[loadElem]
+Failed to read String.InternalSplitKeepEmptyEntries[storeElem]
 INFO:  jitting method Path::IsRelative using LLILCJit
 Successfully read Path.IsRelative
 
@@ -5243,8 +6411,8 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -5254,8 +6422,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
@@ -5271,8 +6439,8 @@ entry:
 
 ; <label>:17                                      ; preds = %7
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
@@ -5288,8 +6456,8 @@ entry:
 
 ; <label>:29                                      ; preds = %19
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %31
 
 ; <label>:31                                      ; preds = %29
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
@@ -5300,8 +6468,8 @@ entry:
 
 ; <label>:36                                      ; preds = %31
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
-  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %37, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
@@ -5312,8 +6480,8 @@ entry:
 
 ; <label>:43                                      ; preds = %31, %38
   %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
-  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %45
 
 ; <label>:45                                      ; preds = %43
   %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
@@ -5324,8 +6492,8 @@ entry:
 
 ; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %50
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
@@ -5336,8 +6504,8 @@ entry:
 
 ; <label>:57                                      ; preds = %1, %7, %19, %45, %52
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
-  br i1 %NullCheck14, label %59, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %59
 
 ; <label>:59                                      ; preds = %57
   %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
@@ -5347,8 +6515,8 @@ entry:
 
 ; <label>:63                                      ; preds = %59
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
@@ -5359,8 +6527,8 @@ entry:
 
 ; <label>:70                                      ; preds = %65
   %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
-  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.String addrspace(1)* %71, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %72
 
 ; <label>:72                                      ; preds = %70
   %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
@@ -5379,39 +6547,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %17
+ThrowNullRef4:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %29
+ThrowNullRef6:                                    ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %36
+ThrowNullRef8:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %43
+ThrowNullRef10:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %50
+ThrowNullRef12:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %57
+ThrowNullRef14:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %63
+ThrowNullRef16:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %70
+ThrowNullRef18:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5419,7 +6587,293 @@ ThrowNullRef17:                                   ; preds = %70
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
-Failed to read String.TrimHelper[loadElem]
+Successfully read String.TrimHelper
+
+define %System.String addrspace(1)* @String.TrimHelper(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i16
+  %loc4 = alloca i32
+  %loc5 = alloca i16
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = sub i32 %3, 1
+  store i32 %4, i32* %loc0
+  store i32 0, i32* %loc1
+  %5 = load i32, i32* %arg2
+  %6 = icmp eq i32 %5, 1
+  br i1 %6, label %62, label %7
+
+; <label>:7                                       ; preds = %1
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:8                                       ; preds = %58
+  store i32 0, i32* %loc2
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load i32, i32* %loc1
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2, i32 %10
+  %13 = load i16, i16 addrspace(1)* %12
+  %14 = zext i16 %13 to i32
+  %15 = trunc i32 %14 to i16
+  store i16 %15, i16* %loc3
+  store i32 0, i32* %loc2
+  br label %34
+
+; <label>:16                                      ; preds = %37
+  %17 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %18 = load i32, i32* %loc2
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %17, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %19
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = zext i32 %18 to i64
+  %BoundsCheck = icmp uge i64 %23, %22
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %24
+
+; <label>:24                                      ; preds = %19
+  %25 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 3, i32 %18
+  %26 = load i16, i16 addrspace(1)* %25, align 8
+  %27 = zext i16 %26 to i32
+  %28 = load i16, i16* %loc3
+  %29 = zext i16 %28 to i32
+  %30 = icmp eq i32 %27, %29
+  br i1 %30, label %43, label %31
+
+; <label>:31                                      ; preds = %24
+  %32 = load i32, i32* %loc2
+  %33 = add i32 %32, 1
+  store i32 %33, i32* %loc2
+  br label %34
+
+; <label>:34                                      ; preds = %11, %31
+  %35 = load i32, i32* %loc2
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = icmp slt i32 %35, %41
+  br i1 %42, label %16, label %43
+
+; <label>:43                                      ; preds = %24, %37
+  %44 = load i32, i32* %loc2
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %45, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp eq i32 %44, %50
+  br i1 %51, label %62, label %52
+
+; <label>:52                                      ; preds = %46
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %7, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %57, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %58
+
+; <label>:58                                      ; preds = %55
+  %59 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %60 = load i32, i32 addrspace(1)* %59
+  %61 = icmp slt i32 %56, %60
+  br i1 %61, label %8, label %62
+
+; <label>:62                                      ; preds = %1, %46, %58
+  %63 = load i32, i32* %arg2
+  %64 = icmp eq i32 %63, 0
+  br i1 %64, label %122, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %66, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %67
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %66, i32 0, i32 1
+  %69 = load i32, i32 addrspace(1)* %68
+  %70 = sub i32 %69, 1
+  store i32 %70, i32* %loc0
+  br label %118
+
+; <label>:71                                      ; preds = %118
+  store i32 0, i32* %loc4
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %73 = load i32, i32* %loc0
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %74
+
+; <label>:74                                      ; preds = %71
+  %75 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 2, i32 %73
+  %76 = load i16, i16 addrspace(1)* %75
+  %77 = zext i16 %76 to i32
+  %78 = trunc i32 %77 to i16
+  store i16 %78, i16* %loc5
+  store i32 0, i32* %loc4
+  br label %97
+
+; <label>:79                                      ; preds = %100
+  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %81 = load i32, i32* %loc4
+  %NullCheck19 = icmp eq %"System.Char[]" addrspace(1)* %80, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
+
+; <label>:82                                      ; preds = %79
+  %83 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 1
+  %84 = load i32, i32 addrspace(1)* %83
+  %85 = zext i32 %84 to i64
+  %86 = zext i32 %81 to i64
+  %BoundsCheck21 = icmp uge i64 %86, %85
+  br i1 %BoundsCheck21, label %ThrowIndexOutOfRange22, label %87
+
+; <label>:87                                      ; preds = %82
+  %88 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 3, i32 %81
+  %89 = load i16, i16 addrspace(1)* %88, align 8
+  %90 = zext i16 %89 to i32
+  %91 = load i16, i16* %loc5
+  %92 = zext i16 %91 to i32
+  %93 = icmp eq i32 %90, %92
+  br i1 %93, label %106, label %94
+
+; <label>:94                                      ; preds = %87
+  %95 = load i32, i32* %loc4
+  %96 = add i32 %95, 1
+  store i32 %96, i32* %loc4
+  br label %97
+
+; <label>:97                                      ; preds = %74, %94
+  %98 = load i32, i32* %loc4
+  %99 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck15 = icmp eq %"System.Char[]" addrspace(1)* %99, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %100
+
+; <label>:100                                     ; preds = %97
+  %101 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %99, i32 0, i32 1
+  %102 = load i32, i32 addrspace(1)* %101
+  %103 = zext i32 %102 to i64
+  %104 = trunc i64 %103 to i32
+  %105 = icmp slt i32 %98, %104
+  br i1 %105, label %79, label %106
+
+; <label>:106                                     ; preds = %87, %100
+  %107 = load i32, i32* %loc4
+  %108 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck17 = icmp eq %"System.Char[]" addrspace(1)* %108, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %109
+
+; <label>:109                                     ; preds = %106
+  %110 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %108, i32 0, i32 1
+  %111 = load i32, i32 addrspace(1)* %110
+  %112 = zext i32 %111 to i64
+  %113 = trunc i64 %112 to i32
+  %114 = icmp eq i32 %107, %113
+  br i1 %114, label %122, label %115
+
+; <label>:115                                     ; preds = %109
+  %116 = load i32, i32* %loc0
+  %117 = sub i32 %116, 1
+  store i32 %117, i32* %loc0
+  br label %118
+
+; <label>:118                                     ; preds = %67, %115
+  %119 = load i32, i32* %loc0
+  %120 = load i32, i32* %loc1
+  %121 = icmp sge i32 %119, %120
+  br i1 %121, label %71, label %122
+
+; <label>:122                                     ; preds = %62, %109, %118
+  %123 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %124 = load i32, i32* %loc1
+  %125 = load i32, i32* %loc0
+  %126 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %123, i32 %124, i32 %125)
+  ret %System.String addrspace(1)* %126
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %97
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange22:                           ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
 Successfully read String.CreateTrimmedString
 
@@ -5439,8 +6893,8 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
@@ -5535,8 +6989,8 @@ entry:
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i64 2872
   %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
   %8 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %7
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %3
   %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
@@ -5553,8 +7007,8 @@ entry:
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 2864
   %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
   %21 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %20
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
-  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %22
 
 ; <label>:22                                      ; preds = %16
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
@@ -5569,7 +7023,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %16
+ThrowNullRef2:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5586,8 +7040,8 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5613,8 +7067,8 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
@@ -5632,8 +7086,8 @@ entry:
 
 ; <label>:12                                      ; preds = %4
   %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
@@ -5644,8 +7098,8 @@ entry:
 
 ; <label>:19                                      ; preds = %14
   %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %19
   %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
@@ -5660,21 +7114,21 @@ entry:
   %31 = zext i16 %30 to i32
   %32 = bitcast i8* %29 to i16*
   %33 = trunc i32 %31 to i16
-  %NullCheck6 = icmp ne i16* %32, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i16* %32, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %21
   store i16 %33, i16* %32, align 8
   %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %36
 
 ; <label>:36                                      ; preds = %34
   %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
   %38 = load i32, i32 addrspace(1)* %37, align 8
   %39 = add i32 %38, 1
-  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %40
 
 ; <label>:40                                      ; preds = %36
   %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
@@ -5683,16 +7137,16 @@ entry:
 
 ; <label>:42                                      ; preds = %14
   %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
-  br i1 %NullCheck12, label %44, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
   %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
   %47 = load i16, i16* %arg1
   %48 = zext i16 %47 to i32
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = trunc i32 %48 to i16
@@ -5703,31 +7157,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %19
+ThrowNullRef4:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %21
+ThrowNullRef6:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %36
+ThrowNullRef10:                                   ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %42
+ThrowNullRef12:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %44
+ThrowNullRef14:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5740,8 +7194,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -5752,8 +7206,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
@@ -5762,14 +7216,14 @@ entry:
 
 ; <label>:11                                      ; preds = %1
   %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
@@ -5779,15 +7233,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5808,8 +7262,8 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5822,8 +7276,8 @@ entry:
 
 ; <label>:8                                       ; preds = %3
   %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
@@ -5842,15 +7296,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
-  br i1 %NullCheck4, label %22, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
   %24 = load i16*, i16* addrspace(1)* %23, align 8
   %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %25, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
@@ -5859,8 +7313,8 @@ entry:
   store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
@@ -5874,8 +7328,8 @@ entry:
 
 ; <label>:37                                      ; preds = %65
   %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %37
   %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
@@ -5886,16 +7340,16 @@ entry:
   %45 = bitcast i16* %41 to i8*
   %46 = getelementptr inbounds i8, i8* %45, i64 %44
   %47 = bitcast i8* %46 to i16*
-  %NullCheck14 = icmp ne i16* %47, null
-  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %47, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %48
 
 ; <label>:48                                      ; preds = %39
   %49 = load i16, i16* %47, align 8
   %50 = zext i16 %49 to i32
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %52 = load i32, i32* %loc1
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %53
 
 ; <label>:53                                      ; preds = %48
   %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
@@ -5916,8 +7370,8 @@ entry:
 ; <label>:62                                      ; preds = %36, %59
   %63 = load i32, i32* %loc1
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck10, label %65, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %65
 
 ; <label>:65                                      ; preds = %62
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
@@ -5936,15 +7390,15 @@ entry:
 
 ; <label>:74                                      ; preds = %70
   %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
-  br i1 %NullCheck18, label %76, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %76
 
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
   %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
-  br i1 %NullCheck20, label %80, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
   %81 = load i64, i64 addrspace(1)* %79
@@ -5958,8 +7412,8 @@ entry:
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
   %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
-  br i1 %NullCheck22, label %92, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.String addrspace(1)* %90, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %92
 
 ; <label>:92                                      ; preds = %80
   %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
@@ -5969,15 +7423,15 @@ entry:
 
 ; <label>:96                                      ; preds = %70
   %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
-  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %98
 
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
   %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
-  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
   %103 = load i64, i64 addrspace(1)* %101
@@ -5991,8 +7445,8 @@ entry:
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
   %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
-  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.String addrspace(1)* %112, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %114
 
 ; <label>:114                                     ; preds = %102
   %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
@@ -6004,59 +7458,59 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %20
+ThrowNullRef4:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %22
+ThrowNullRef6:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %26
+ThrowNullRef8:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %62
+ThrowNullRef10:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %48
+ThrowNullRef16:                                   ; preds = %48
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %74
+ThrowNullRef18:                                   ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %76
+ThrowNullRef20:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %80
+ThrowNullRef22:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %96
+ThrowNullRef24:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %98
+ThrowNullRef26:                                   ; preds = %98
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %102
+ThrowNullRef28:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6069,15 +7523,15 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
   %3 = load i16*, i16* addrspace(1)* %2, align 8
   %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
@@ -6087,8 +7541,8 @@ entry:
   %10 = bitcast i16* %3 to i8*
   %11 = getelementptr inbounds i8, i8* %10, i64 %9
   %12 = bitcast i8* %11 to i16*
-  %NullCheck4 = icmp ne i16* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %5
   store i16 0, i16* %12, align 8
@@ -6098,11 +7552,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6119,8 +7573,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -6131,8 +7585,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
@@ -6144,15 +7598,15 @@ entry:
 
 ; <label>:14                                      ; preds = %1
   %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
   %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
   %21 = load i64, i64 addrspace(1)* %19
@@ -6171,15 +7625,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %14
+ThrowNullRef4:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %16
+ThrowNullRef6:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6302,14 +7756,6 @@ entry:
   ret %System.String addrspace(1)* %57
 }
 
-INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
-Successfully read RuntimeHelpers.get_OffsetToStringData
-
-define i32 @RuntimeHelpers.get_OffsetToStringData() {
-entry:
-  ret i32 12
-}
-
 INFO:  jitting method String::Equals using LLILCJit
 Successfully read String.Equals
 
@@ -6381,8 +7827,8 @@ entry:
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
-  br i1 %NullCheck24, label %29, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
   %30 = load i64, i64 addrspace(1)* %28
@@ -6397,8 +7843,8 @@ entry:
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
-  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
   %43 = load i64, i64 addrspace(1)* %41
@@ -6418,8 +7864,8 @@ entry:
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
   %59 = load i64, i64 addrspace(1)* %57
@@ -6434,8 +7880,8 @@ entry:
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck22, label %71, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
   %72 = load i64, i64 addrspace(1)* %70
@@ -6455,8 +7901,8 @@ entry:
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
-  br i1 %NullCheck16, label %87, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = load i64, i64 addrspace(1)* %86
@@ -6471,8 +7917,8 @@ entry:
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck18, label %100, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
   %101 = load i64, i64 addrspace(1)* %99
@@ -6492,8 +7938,8 @@ entry:
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
-  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
   %117 = load i64, i64 addrspace(1)* %115
@@ -6508,8 +7954,8 @@ entry:
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
-  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
   %130 = load i64, i64 addrspace(1)* %128
@@ -6528,15 +7974,15 @@ entry:
 
 ; <label>:142                                     ; preds = %22
   %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
-  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %143, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %144
 
 ; <label>:144                                     ; preds = %142
   %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
   %146 = load i32, i32 addrspace(1)* %145
   %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
-  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %147, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %148
 
 ; <label>:148                                     ; preds = %144
   %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
@@ -6557,15 +8003,15 @@ entry:
 
 ; <label>:159                                     ; preds = %22
   %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
-  br i1 %NullCheck, label %161, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %ThrowNullRef, label %161
 
 ; <label>:161                                     ; preds = %159
   %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
   %163 = load i32, i32 addrspace(1)* %162
   %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
-  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %164, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %165
 
 ; <label>:165                                     ; preds = %161
   %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
@@ -6578,8 +8024,8 @@ entry:
 
 ; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
-  br i1 %NullCheck4, label %172, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %171, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %172
 
 ; <label>:172                                     ; preds = %170
   %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
@@ -6589,8 +8035,8 @@ entry:
 
 ; <label>:176                                     ; preds = %172
   %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
-  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %177, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %178
 
 ; <label>:178                                     ; preds = %176
   %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
@@ -6629,55 +8075,55 @@ ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %161
+ThrowNullRef2:                                    ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %170
+ThrowNullRef4:                                    ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %176
+ThrowNullRef6:                                    ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %142
+ThrowNullRef8:                                    ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %144
+ThrowNullRef10:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %113
+ThrowNullRef12:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %116
+ThrowNullRef14:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %84
+ThrowNullRef16:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %87
+ThrowNullRef18:                                   ; preds = %87
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %55
+ThrowNullRef20:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %58
+ThrowNullRef22:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %26
+ThrowNullRef24:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %29
+ThrowNullRef26:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,8 +8161,8 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck, label %14, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %ThrowNullRef, label %14
 
 ; <label>:14                                      ; preds = %8
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
@@ -6760,8 +8206,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
@@ -6770,14 +8216,14 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32, i32* %loc0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %10
   %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
   %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
@@ -6790,15 +8236,15 @@ entry:
 ; <label>:25                                      ; preds = %19
   %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
-  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
   %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
@@ -6807,8 +8253,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %37 = load i32, i32* %loc0
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %38, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %38
 
 ; <label>:38                                      ; preds = %32
   %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
@@ -6817,14 +8263,14 @@ entry:
 
 ; <label>:40                                      ; preds = %19
   %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %40
   %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
   %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
-  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
-  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
@@ -6832,8 +8278,8 @@ entry:
   %48 = zext i32 %47 to i64
   %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
-  br i1 %NullCheck16, label %51, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %51
 
 ; <label>:51                                      ; preds = %45
   %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
@@ -6847,15 +8293,15 @@ entry:
 ; <label>:57                                      ; preds = %51
   %58 = load i16*, i16** %arg1
   %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
-  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %60
 
 ; <label>:60                                      ; preds = %57
   %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
   %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
-  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %64
 
 ; <label>:64                                      ; preds = %60
   %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
@@ -6864,22 +8310,22 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
   %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
-  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %70
 
 ; <label>:70                                      ; preds = %64
   %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
   %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
-  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
-  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
   %75 = load i32, i32 addrspace(1)* %74
   %76 = zext i32 %75 to i64
   %77 = trunc i64 %76 to i32
-  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
-  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %78
 
 ; <label>:78                                      ; preds = %73
   %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
@@ -6901,8 +8347,8 @@ entry:
   %90 = bitcast i16* %86 to i8*
   %91 = getelementptr inbounds i8, i8* %90, i64 %89
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %93
 
 ; <label>:93                                      ; preds = %80
   %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
@@ -6912,8 +8358,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %99 = load i32, i32* %loc2
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %100
 
 ; <label>:100                                     ; preds = %93
   %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
@@ -6928,63 +8374,63 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %25
+ThrowNullRef6:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %32
+ThrowNullRef10:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %40
+ThrowNullRef12:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %45
+ThrowNullRef16:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %57
+ThrowNullRef18:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %60
+ThrowNullRef20:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %64
+ThrowNullRef22:                                   ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %70
+ThrowNullRef24:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %73
+ThrowNullRef26:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %80
+ThrowNullRef28:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %93
+ThrowNullRef30:                                   ; preds = %93
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7004,8 +8450,8 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
@@ -7033,43 +8479,43 @@ entry:
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %14
   %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
   %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   %28 = load i32, i32 addrspace(1)* %27, align 8
   %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
-  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %30
 
 ; <label>:30                                      ; preds = %26
   %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
   %32 = load i32, i32 addrspace(1)* %31, align 8
   %33 = add i32 %28, %32
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %34
 
 ; <label>:34                                      ; preds = %30
   %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   store i32 %33, i32 addrspace(1)* %35
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
   store i32 0, i32 addrspace(1)* %38
   %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %40
 
 ; <label>:40                                      ; preds = %37
   %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
@@ -7082,8 +8528,8 @@ entry:
 
 ; <label>:47                                      ; preds = %40
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
@@ -7098,8 +8544,8 @@ entry:
   %54 = load i32, i32* %loc0
   %55 = sext i32 %54 to i64
   %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
-  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %57
 
 ; <label>:57                                      ; preds = %52
   %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
@@ -7110,68 +8556,35 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %14
+ThrowNullRef2:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %23
+ThrowNullRef4:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %26
+ThrowNullRef6:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %30
+ThrowNullRef8:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %34
+ThrowNullRef10:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %47
+ThrowNullRef14:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %52
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-}
-
-INFO:  jitting method StringBuilder::get_Length using LLILCJit
-Successfully read StringBuilder.get_Length
-
-define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.StringBuilder addrspace(1)*
-  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
-  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
-
-; <label>:1                                       ; preds = %entry
-  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %3 = load i32, i32 addrspace(1)* %2, align 8
-  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
-
-; <label>:5                                       ; preds = %1
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = add i32 %3, %7
-  ret i32 %8
-
-ThrowNullRef:                                     ; preds = %entry
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef16:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7213,70 +8626,70 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
   %6 = load i32, i32 addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
   store i32 %6, i32 addrspace(1)* %8
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
   %13 = load i32, i32 addrspace(1)* %12, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
   store i32 %13, i32 addrspace(1)* %15
   %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
-  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %18
 
 ; <label>:18                                      ; preds = %14
   %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
   %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
   %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
   %34 = load i32, i32 addrspace(1)* %33, align 8
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
-  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
@@ -7287,39 +8700,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %28
+ThrowNullRef16:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %32
+ThrowNullRef18:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7455,13 +8868,13 @@ entry:
 ; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
@@ -7477,16 +8890,16 @@ entry:
 
 ; <label>:18                                      ; preds = %15
   %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
   store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
   %22 = load i32, i32* %loc0
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %24
 
 ; <label>:24                                      ; preds = %20
   %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
@@ -7498,13 +8911,13 @@ entry:
 ; <label>:28                                      ; preds = %15, %24
   %29 = load i32, i32* %arg1
   %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %31
   %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
@@ -7517,20 +8930,20 @@ entry:
   %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
-  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
   %46 = load i32, i32 addrspace(1)* %45, align 8
   %47 = sub i32 %40, %46
-  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
-  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i32 addrspace(1)* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %48
 
 ; <label>:48                                      ; preds = %44
   store i32 %47, i32 addrspace(1)* %39, align 8
@@ -7538,21 +8951,21 @@ entry:
 
 ; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
-  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %51
 
 ; <label>:51                                      ; preds = %49
   %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %53
 
 ; <label>:53                                      ; preds = %51
   %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
   %55 = load i32, i32 addrspace(1)* %54, align 8
   %56 = load i32, i32* %arg2
   %57 = sub i32 %55, %56
-  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %58
 
 ; <label>:58                                      ; preds = %53
   %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
@@ -7562,13 +8975,13 @@ entry:
 ; <label>:60                                      ; preds = %33, %58
   %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
   %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
-  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %63
 
 ; <label>:63                                      ; preds = %60
   %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
-  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
-  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
@@ -7578,15 +8991,15 @@ entry:
 
 ; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
-  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i32 addrspace(1)* %69, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %70
 
 ; <label>:70                                      ; preds = %68
   %71 = load i32, i32 addrspace(1)* %69, align 8
   store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
-  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
@@ -7596,8 +9009,8 @@ entry:
   store i32 %77, i32* %loc4
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
-  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %80
 
 ; <label>:80                                      ; preds = %73
   %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
@@ -7607,71 +9020,71 @@ entry:
 ; <label>:83                                      ; preds = %80
   store i32 0, i32* %loc3
   %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
-  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
-  br i1 %NullCheck26, label %88, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i32 addrspace(1)* %87, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %88
 
 ; <label>:88                                      ; preds = %85
   %89 = load i32, i32 addrspace(1)* %87, align 8
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
-  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %90
 
 ; <label>:90                                      ; preds = %88
   %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
   store i32 %89, i32 addrspace(1)* %91
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
-  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
-  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %96
 
 ; <label>:96                                      ; preds = %94
   %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
-  br i1 %NullCheck34, label %100, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %100
 
 ; <label>:100                                     ; preds = %96
   %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
-  br i1 %NullCheck36, label %102, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %102
 
 ; <label>:102                                     ; preds = %100
   %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
   %104 = load i32, i32 addrspace(1)* %103, align 8
   %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
-  br i1 %NullCheck38, label %106, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %106
 
 ; <label>:106                                     ; preds = %102
   %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
-  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
-  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %108
 
 ; <label>:108                                     ; preds = %106
   %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
   %110 = load i32, i32 addrspace(1)* %109, align 8
   %111 = add i32 %104, %110
-  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %112
 
 ; <label>:112                                     ; preds = %108
   %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
   store i32 %111, i32 addrspace(1)* %113
   %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
-  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i32 addrspace(1)* %114, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %115
 
 ; <label>:115                                     ; preds = %112
   %116 = load i32, i32 addrspace(1)* %114, align 8
@@ -7681,19 +9094,19 @@ entry:
 ; <label>:118                                     ; preds = %115
   %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
-  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %121
 
 ; <label>:121                                     ; preds = %118
   %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
-  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
-  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %123
 
 ; <label>:123                                     ; preds = %121
   %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
   %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
-  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
-  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %126
 
 ; <label>:126                                     ; preds = %123
   %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
@@ -7705,8 +9118,8 @@ entry:
 
 ; <label>:130                                     ; preds = %80, %115, %126
   %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %132
 
 ; <label>:132                                     ; preds = %130
   %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7715,8 +9128,8 @@ entry:
   %136 = load i32, i32* %loc3
   %137 = sub i32 %135, %136
   %138 = sub i32 %134, %137
-  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %139
 
 ; <label>:139                                     ; preds = %132
   %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7728,16 +9141,16 @@ entry:
 
 ; <label>:144                                     ; preds = %139
   %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
-  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %146
 
 ; <label>:146                                     ; preds = %144
   %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
   %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
   %149 = load i32, i32* %loc2
   %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
-  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %151
 
 ; <label>:151                                     ; preds = %146
   %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
@@ -7754,145 +9167,249 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %18
+ThrowNullRef4:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %31
+ThrowNullRef10:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %44
+ThrowNullRef16:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %68
+ThrowNullRef18:                                   ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %70
+ThrowNullRef20:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %73
+ThrowNullRef22:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %83
+ThrowNullRef24:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %85
+ThrowNullRef26:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %88
+ThrowNullRef28:                                   ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %90
+ThrowNullRef30:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %94
+ThrowNullRef32:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %96
+ThrowNullRef34:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %100
+ThrowNullRef36:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %102
+ThrowNullRef38:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %106
+ThrowNullRef40:                                   ; preds = %106
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %108
+ThrowNullRef42:                                   ; preds = %108
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %112
+ThrowNullRef44:                                   ; preds = %112
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %118
+ThrowNullRef46:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %121
+ThrowNullRef48:                                   ; preds = %121
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %123
+ThrowNullRef50:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %130
+ThrowNullRef52:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %132
+ThrowNullRef54:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %144
+ThrowNullRef56:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %146
+ThrowNullRef58:                                   ; preds = %146
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %60
+ThrowNullRef60:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %63
+ThrowNullRef62:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %49
+ThrowNullRef64:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %51
+ThrowNullRef66:                                   ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %53
+ThrowNullRef68:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(%"System.Char[]" addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %arg0 = alloca %"System.Char[]" addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store %"System.Char[]" addrspace(1)* %param0, %"System.Char[]" addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load i32, i32* %arg4
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %43, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %38, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg1
+  %13 = load i32, i32* %arg4
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %38, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %24 = load i32, i32* %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %35 = load i32, i32* %arg3
+  %36 = load i32, i32* %arg4
+  %37 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %37, %"System.Char[]" addrspace(1)* %34, i32 %35, i32 %36)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:38                                      ; preds = %5, %16
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Successfully read Buffer._Memmove
 
@@ -7914,7 +9431,7 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[loadElem]
+Failed to read AppDomain.SetDataHelper[storeElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -7923,8 +9440,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
@@ -7934,8 +9451,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
@@ -7947,15 +9464,15 @@ entry:
   %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
   %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
@@ -7966,15 +9483,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7992,7 +9509,79 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
-Failed to read Dictionary`2.TryGetValue[loadElemA]
+Successfully read Dictionary`2.TryGetValue
+
+define i8 @"Dictionary`2.TryGetValue"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)* addrspace(1)* %param2) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  %arg2 = alloca %System.__Canon addrspace(1)* addrspace(1)*
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  store %System.__Canon addrspace(1)* addrspace(1)* %param2, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  store i32 %2, i32* %loc0
+  %3 = load i32, i32* %loc0
+  %4 = icmp slt i32 %3, 0
+  br i1 %4, label %22, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 2
+  %10 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %9, align 8
+  %11 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = zext i32 %11 to i64
+  %BoundsCheck = icmp uge i64 %16, %15
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 3, i32 %11
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %20, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %6, %System.__Canon addrspace(1)* %21)
+  ret i8 1
+
+; <label>:22                                      ; preds = %entry
+  %23 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %23, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -8058,8 +9647,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
@@ -8091,8 +9680,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
@@ -8171,15 +9760,15 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck, label %19, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %ThrowNullRef, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
   %21 = load i32, i32 addrspace(1)* %20
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
@@ -8202,7 +9791,7 @@ ThrowNullRef:                                     ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %19
+ThrowNullRef2:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8248,8 +9837,8 @@ entry:
   %0 = alloca %System.AppDomainHandle
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %1 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %1, i32 0, i32 15
@@ -8269,8 +9858,8 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
@@ -8286,7 +9875,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -8299,8 +9888,8 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -8327,8 +9916,8 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
@@ -8352,8 +9941,8 @@ entry:
   %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
   store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
@@ -8363,8 +9952,8 @@ entry:
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
@@ -8374,8 +9963,8 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %9
   %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
@@ -8384,8 +9973,8 @@ entry:
 
 ; <label>:18                                      ; preds = %3, %16
   %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
@@ -8397,15 +9986,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %18
+ThrowNullRef6:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8418,8 +10007,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
@@ -8453,15 +10042,15 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
@@ -8473,7 +10062,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8481,7 +10070,7 @@ ThrowNullRef1:                                    ; preds = %1
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
 Failed to read Dictionary`2.System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
@@ -8506,8 +10095,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
@@ -8524,8 +10113,8 @@ entry:
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -8544,7 +10133,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8577,8 +10166,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = load i64, i64* %arg2
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = trunc i32 %3 to i8
@@ -8634,46 +10223,46 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
   %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
-  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
-  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
-  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
@@ -8684,27 +10273,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %20
+ThrowNullRef12:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8717,8 +10306,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -8756,22 +10345,22 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
   %9 = load i64, i64 addrspace(1)* %8, align 8
   %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
   %13 = load i64, i64 addrspace(1)* %12, align 8
   %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %11
   %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
@@ -8788,11 +10377,11 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8882,8 +10471,8 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
@@ -8900,8 +10489,8 @@ entry:
 ; <label>:8                                       ; preds = %1
   %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
   %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
@@ -8911,15 +10500,15 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
   %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
   %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
-  br i1 %NullCheck6, label %21, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
@@ -8946,15 +10535,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8992,15 +10581,15 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
   store i8 %3, i8 addrspace(1)* %5
   %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
@@ -9011,7 +10600,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9027,8 +10616,8 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -9041,8 +10630,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
@@ -9058,7 +10647,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9080,8 +10669,8 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
@@ -9096,8 +10685,8 @@ entry:
 ; <label>:12                                      ; preds = %6
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
@@ -9112,8 +10701,8 @@ entry:
 ; <label>:21                                      ; preds = %15
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
@@ -9128,8 +10717,8 @@ entry:
 ; <label>:30                                      ; preds = %24
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %31, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
@@ -9144,8 +10733,8 @@ entry:
 ; <label>:39                                      ; preds = %33
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
-  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %40, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %42
 
 ; <label>:42                                      ; preds = %39
   %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
@@ -9164,19 +10753,19 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %21
+ThrowNullRef4:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %30
+ThrowNullRef6:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %39
+ThrowNullRef8:                                    ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9243,8 +10832,8 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
@@ -9264,57 +10853,57 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
   store i8 0, i8 addrspace(1)* %2
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
   store i8 0, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
   store i8 0, i8 addrspace(1)* %17
   %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
   store i8 0, i8 addrspace(1)* %20
   %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
-  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
@@ -9325,31 +10914,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %19
+ThrowNullRef14:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9367,8 +10956,8 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
@@ -9380,8 +10969,8 @@ entry:
 
 ; <label>:9                                       ; preds = %4
   %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %9
   %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
@@ -9395,7 +10984,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef2:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9420,8 +11009,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
@@ -9512,8 +11101,8 @@ entry:
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
@@ -9524,8 +11113,8 @@ entry:
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = load i64, i64 addrspace(1)* %12
@@ -9537,8 +11126,8 @@ entry:
   %20 = load i64, i64* %19
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
-  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %13
   %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
@@ -9555,8 +11144,8 @@ entry:
 ; <label>:30                                      ; preds = %25
   %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %32 = load i32, i32* %arg2
-  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
-  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
@@ -9570,15 +11159,15 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %30
+ThrowNullRef2:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9622,87 +11211,87 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
   %10 = load i8, i8 addrspace(1)* %9, align 8
   %11 = zext i8 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %8
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
   store i8 %12, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
   %19 = load i8, i8 addrspace(1)* %18, align 8
   %20 = zext i8 %19 to i32
   %21 = trunc i32 %20 to i8
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
   store i8 %21, i8 addrspace(1)* %23
   %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
   %28 = load i8, i8 addrspace(1)* %27, align 8
   %29 = zext i8 %28 to i32
   %30 = trunc i32 %29 to i8
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
-  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %31
 
 ; <label>:31                                      ; preds = %26
   %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
   store i8 %30, i8 addrspace(1)* %32
   %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
-  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
-  br i1 %NullCheck14, label %40, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %40
 
 ; <label>:40                                      ; preds = %35
   %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
   store i8 %39, i8 addrspace(1)* %41
   %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
-  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %44
 
 ; <label>:44                                      ; preds = %40
   %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
   %46 = load i8, i8 addrspace(1)* %45, align 8
   %47 = zext i8 %46 to i32
   %48 = trunc i32 %47 to i8
-  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
   store i8 %48, i8 addrspace(1)* %50
   %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
-  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
@@ -9713,29 +11302,29 @@ entry:
 ; <label>:56                                      ; preds = %52
   %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
-  br i1 %NullCheck22, label %59, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
   %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
   %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
-  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
-  br i1 %NullCheck24, label %63, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
   %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
-  br i1 %NullCheck26, label %66, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
   %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
-  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
-  br i1 %NullCheck28, label %69, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %69
 
 ; <label>:69                                      ; preds = %66
   %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
@@ -9744,15 +11333,15 @@ entry:
 
 ; <label>:71                                      ; preds = %105
   %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
-  br i1 %NullCheck34, label %73, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %73
 
 ; <label>:73                                      ; preds = %71
   %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
   %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
   %76 = load i32, i32* %loc0
-  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
-  br i1 %NullCheck36, label %77, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
@@ -9766,8 +11355,8 @@ entry:
 
 ; <label>:83                                      ; preds = %77
   %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
-  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
@@ -9775,14 +11364,14 @@ entry:
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
   %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
-  br i1 %NullCheck40, label %91, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
 ; <label>:91                                      ; preds = %85
   %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
   %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
-  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck42, label %94, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %94
 
 ; <label>:94                                      ; preds = %91
   %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
@@ -9798,14 +11387,14 @@ entry:
 ; <label>:99                                      ; preds = %69, %96
   %100 = load i32, i32* %loc0
   %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
-  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %102
 
 ; <label>:102                                     ; preds = %99
   %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
   %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
-  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
-  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
@@ -9819,87 +11408,87 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %26
+ThrowNullRef10:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %31
+ThrowNullRef12:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %35
+ThrowNullRef14:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %40
+ThrowNullRef16:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %56
+ThrowNullRef22:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %59
+ThrowNullRef24:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %63
+ThrowNullRef26:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %66
+ThrowNullRef28:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %102
+ThrowNullRef32:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %71
+ThrowNullRef34:                                   ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %73
+ThrowNullRef36:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %83
+ThrowNullRef38:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %85
+ThrowNullRef40:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %91
+ThrowNullRef42:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9943,15 +11532,15 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
   %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
@@ -9961,28 +11550,28 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
   %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %12
   %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
   %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
   %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
-  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
@@ -9993,23 +11582,23 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %12
+ThrowNullRef6:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10031,15 +11620,15 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
   %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = load i64, i64 addrspace(1)* %7
@@ -10077,13 +11666,13 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[loadElem]
+Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -10111,8 +11700,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1

--- a/test/BaseLine/JIT/CodeGenBringUpTests/NotRMW.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/NotRMW.error.txt
@@ -25,8 +25,8 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
@@ -40,8 +40,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
   %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
@@ -75,7 +75,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -90,8 +90,8 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %NullCheck = icmp ne i8 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = load i8, i8 addrspace(1)* %0, align 8
@@ -125,8 +125,8 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
@@ -159,8 +159,8 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -184,8 +184,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
   store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
@@ -195,8 +195,8 @@ entry:
 ; <label>:4                                       ; preds = %1
   %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
   %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
@@ -206,8 +206,8 @@ entry:
   %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
@@ -221,14 +221,14 @@ entry:
 
 ; <label>:17                                      ; preds = %14
   %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
   %21 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
@@ -238,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -249,8 +249,8 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
@@ -261,27 +261,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %30
+ThrowNullRef10:                                   ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -301,7 +301,89 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
-Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
+Successfully read AppDomainSetup.GetUnsecureApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.GetUnsecureApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %NullCheck = icmp eq %"System.String[]" addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %BoundsCheck = icmp uge i64 0, %5
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %6
+
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 3, i32 0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
+  ret %System.String addrspace(1)* %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_Value using LLILCJit
+Successfully read AppDomainSetup.get_Value
+
+define %"System.String[]" addrspace(1)* @AppDomainSetup.get_Value(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.String[]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 18)
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.String[]" addrspace(1)* addrspace(1)*, %"System.String[]" addrspace(1)*)*)(%"System.String[]" addrspace(1)* addrspace(1)* %9, %"System.String[]" addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %11, i32 0, i32 1
+  %14 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %13, align 8
+  ret %"System.String[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -319,8 +401,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -368,16 +450,16 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
   %5 = load i32, i32 addrspace(1)* %4
   %6 = sub i32 %5, 1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -389,7 +471,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -421,8 +503,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
@@ -456,8 +538,8 @@ entry:
 ; <label>:27                                      ; preds = %19
   %28 = load i32, i32* %arg1
   %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
-  br i1 %NullCheck2, label %30, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %29, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %30
 
 ; <label>:30                                      ; preds = %27
   %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
@@ -493,8 +575,8 @@ entry:
 ; <label>:49                                      ; preds = %46
   %50 = load i32, i32* %arg2
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck4, label %52, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
@@ -517,11 +599,11 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %27
+ThrowNullRef2:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %49
+ThrowNullRef4:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -544,16 +626,16 @@ entry:
   %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %0)
   store %System.String addrspace(1)* %1, %System.String addrspace(1)** %loc0
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 2
   %5 = bitcast [0 x i16] addrspace(1)* %4 to i16 addrspace(1)*
   store i16 addrspace(1)* %5, i16 addrspace(1)** %loc1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %3
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2
@@ -580,7 +662,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -691,15 +773,15 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %NullCheck132 = icmp ne i8* %21, null
-  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+  %NullCheck131 = icmp eq i8* %21, null
+  br i1 %NullCheck131, label %ThrowNullRef132, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = load i8, i8* %21, align 8
   %24 = zext i8 %23 to i32
   %25 = trunc i32 %24 to i8
-  %NullCheck134 = icmp ne i8* %20, null
-  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+  %NullCheck133 = icmp eq i8* %20, null
+  br i1 %NullCheck133, label %ThrowNullRef134, label %26
 
 ; <label>:26                                      ; preds = %22
   store i8 %25, i8* %20, align 8
@@ -709,16 +791,16 @@ entry:
   %28 = load i8*, i8** %arg0
   %29 = load i8*, i8** %arg1
   %30 = bitcast i8* %29 to i16*
-  %NullCheck128 = icmp ne i16* %30, null
-  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+  %NullCheck127 = icmp eq i16* %30, null
+  br i1 %NullCheck127, label %ThrowNullRef128, label %31
 
 ; <label>:31                                      ; preds = %27
   %32 = load i16, i16* %30, align 8
   %33 = sext i16 %32 to i32
   %34 = bitcast i8* %28 to i16*
   %35 = trunc i32 %33 to i16
-  %NullCheck130 = icmp ne i16* %34, null
-  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+  %NullCheck129 = icmp eq i16* %34, null
+  br i1 %NullCheck129, label %ThrowNullRef130, label %36
 
 ; <label>:36                                      ; preds = %31
   store i16 %35, i16* %34, align 8
@@ -728,16 +810,16 @@ entry:
   %38 = load i8*, i8** %arg0
   %39 = load i8*, i8** %arg1
   %40 = bitcast i8* %39 to i16*
-  %NullCheck120 = icmp ne i16* %40, null
-  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+  %NullCheck119 = icmp eq i16* %40, null
+  br i1 %NullCheck119, label %ThrowNullRef120, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i16, i16* %40, align 8
   %43 = sext i16 %42 to i32
   %44 = bitcast i8* %38 to i16*
   %45 = trunc i32 %43 to i16
-  %NullCheck122 = icmp ne i16* %44, null
-  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+  %NullCheck121 = icmp eq i16* %44, null
+  br i1 %NullCheck121, label %ThrowNullRef122, label %46
 
 ; <label>:46                                      ; preds = %41
   store i16 %45, i16* %44, align 8
@@ -745,15 +827,15 @@ entry:
   %48 = getelementptr inbounds i8, i8* %47, i64 2
   %49 = load i8*, i8** %arg1
   %50 = getelementptr inbounds i8, i8* %49, i64 2
-  %NullCheck124 = icmp ne i8* %50, null
-  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+  %NullCheck123 = icmp eq i8* %50, null
+  br i1 %NullCheck123, label %ThrowNullRef124, label %51
 
 ; <label>:51                                      ; preds = %46
   %52 = load i8, i8* %50, align 8
   %53 = zext i8 %52 to i32
   %54 = trunc i32 %53 to i8
-  %NullCheck126 = icmp ne i8* %48, null
-  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+  %NullCheck125 = icmp eq i8* %48, null
+  br i1 %NullCheck125, label %ThrowNullRef126, label %55
 
 ; <label>:55                                      ; preds = %51
   store i8 %54, i8* %48, align 8
@@ -763,14 +845,14 @@ entry:
   %57 = load i8*, i8** %arg0
   %58 = load i8*, i8** %arg1
   %59 = bitcast i8* %58 to i32*
-  %NullCheck116 = icmp ne i32* %59, null
-  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+  %NullCheck115 = icmp eq i32* %59, null
+  br i1 %NullCheck115, label %ThrowNullRef116, label %60
 
 ; <label>:60                                      ; preds = %56
   %61 = load i32, i32* %59, align 8
   %62 = bitcast i8* %57 to i32*
-  %NullCheck118 = icmp ne i32* %62, null
-  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+  %NullCheck117 = icmp eq i32* %62, null
+  br i1 %NullCheck117, label %ThrowNullRef118, label %63
 
 ; <label>:63                                      ; preds = %60
   store i32 %61, i32* %62, align 8
@@ -780,14 +862,14 @@ entry:
   %65 = load i8*, i8** %arg0
   %66 = load i8*, i8** %arg1
   %67 = bitcast i8* %66 to i32*
-  %NullCheck108 = icmp ne i32* %67, null
-  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+  %NullCheck107 = icmp eq i32* %67, null
+  br i1 %NullCheck107, label %ThrowNullRef108, label %68
 
 ; <label>:68                                      ; preds = %64
   %69 = load i32, i32* %67, align 8
   %70 = bitcast i8* %65 to i32*
-  %NullCheck110 = icmp ne i32* %70, null
-  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+  %NullCheck109 = icmp eq i32* %70, null
+  br i1 %NullCheck109, label %ThrowNullRef110, label %71
 
 ; <label>:71                                      ; preds = %68
   store i32 %69, i32* %70, align 8
@@ -795,15 +877,15 @@ entry:
   %73 = getelementptr inbounds i8, i8* %72, i64 4
   %74 = load i8*, i8** %arg1
   %75 = getelementptr inbounds i8, i8* %74, i64 4
-  %NullCheck112 = icmp ne i8* %75, null
-  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+  %NullCheck111 = icmp eq i8* %75, null
+  br i1 %NullCheck111, label %ThrowNullRef112, label %76
 
 ; <label>:76                                      ; preds = %71
   %77 = load i8, i8* %75, align 8
   %78 = zext i8 %77 to i32
   %79 = trunc i32 %78 to i8
-  %NullCheck114 = icmp ne i8* %73, null
-  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+  %NullCheck113 = icmp eq i8* %73, null
+  br i1 %NullCheck113, label %ThrowNullRef114, label %80
 
 ; <label>:80                                      ; preds = %76
   store i8 %79, i8* %73, align 8
@@ -813,14 +895,14 @@ entry:
   %82 = load i8*, i8** %arg0
   %83 = load i8*, i8** %arg1
   %84 = bitcast i8* %83 to i32*
-  %NullCheck100 = icmp ne i32* %84, null
-  br i1 %NullCheck100, label %85, label %ThrowNullRef99
+  %NullCheck99 = icmp eq i32* %84, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %85
 
 ; <label>:85                                      ; preds = %81
   %86 = load i32, i32* %84, align 8
   %87 = bitcast i8* %82 to i32*
-  %NullCheck102 = icmp ne i32* %87, null
-  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+  %NullCheck101 = icmp eq i32* %87, null
+  br i1 %NullCheck101, label %ThrowNullRef102, label %88
 
 ; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
@@ -829,16 +911,16 @@ entry:
   %91 = load i8*, i8** %arg1
   %92 = getelementptr inbounds i8, i8* %91, i64 4
   %93 = bitcast i8* %92 to i16*
-  %NullCheck104 = icmp ne i16* %93, null
-  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+  %NullCheck103 = icmp eq i16* %93, null
+  br i1 %NullCheck103, label %ThrowNullRef104, label %94
 
 ; <label>:94                                      ; preds = %88
   %95 = load i16, i16* %93, align 8
   %96 = sext i16 %95 to i32
   %97 = bitcast i8* %90 to i16*
   %98 = trunc i32 %96 to i16
-  %NullCheck106 = icmp ne i16* %97, null
-  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+  %NullCheck105 = icmp eq i16* %97, null
+  br i1 %NullCheck105, label %ThrowNullRef106, label %99
 
 ; <label>:99                                      ; preds = %94
   store i16 %98, i16* %97, align 8
@@ -848,14 +930,14 @@ entry:
   %101 = load i8*, i8** %arg0
   %102 = load i8*, i8** %arg1
   %103 = bitcast i8* %102 to i32*
-  %NullCheck88 = icmp ne i32* %103, null
-  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+  %NullCheck87 = icmp eq i32* %103, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %104
 
 ; <label>:104                                     ; preds = %100
   %105 = load i32, i32* %103, align 8
   %106 = bitcast i8* %101 to i32*
-  %NullCheck90 = icmp ne i32* %106, null
-  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+  %NullCheck89 = icmp eq i32* %106, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %107
 
 ; <label>:107                                     ; preds = %104
   store i32 %105, i32* %106, align 8
@@ -864,16 +946,16 @@ entry:
   %110 = load i8*, i8** %arg1
   %111 = getelementptr inbounds i8, i8* %110, i64 4
   %112 = bitcast i8* %111 to i16*
-  %NullCheck92 = icmp ne i16* %112, null
-  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+  %NullCheck91 = icmp eq i16* %112, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %113
 
 ; <label>:113                                     ; preds = %107
   %114 = load i16, i16* %112, align 8
   %115 = sext i16 %114 to i32
   %116 = bitcast i8* %109 to i16*
   %117 = trunc i32 %115 to i16
-  %NullCheck94 = icmp ne i16* %116, null
-  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+  %NullCheck93 = icmp eq i16* %116, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %118
 
 ; <label>:118                                     ; preds = %113
   store i16 %117, i16* %116, align 8
@@ -881,15 +963,15 @@ entry:
   %120 = getelementptr inbounds i8, i8* %119, i64 6
   %121 = load i8*, i8** %arg1
   %122 = getelementptr inbounds i8, i8* %121, i64 6
-  %NullCheck96 = icmp ne i8* %122, null
-  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+  %NullCheck95 = icmp eq i8* %122, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %123
 
 ; <label>:123                                     ; preds = %118
   %124 = load i8, i8* %122, align 8
   %125 = zext i8 %124 to i32
   %126 = trunc i32 %125 to i8
-  %NullCheck98 = icmp ne i8* %120, null
-  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+  %NullCheck97 = icmp eq i8* %120, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %127
 
 ; <label>:127                                     ; preds = %123
   store i8 %126, i8* %120, align 8
@@ -899,14 +981,14 @@ entry:
   %129 = load i8*, i8** %arg0
   %130 = load i8*, i8** %arg1
   %131 = bitcast i8* %130 to i64*
-  %NullCheck84 = icmp ne i64* %131, null
-  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+  %NullCheck83 = icmp eq i64* %131, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %132
 
 ; <label>:132                                     ; preds = %128
   %133 = load i64, i64* %131, align 8
   %134 = bitcast i8* %129 to i64*
-  %NullCheck86 = icmp ne i64* %134, null
-  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+  %NullCheck85 = icmp eq i64* %134, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %135
 
 ; <label>:135                                     ; preds = %132
   store i64 %133, i64* %134, align 8
@@ -916,14 +998,14 @@ entry:
   %137 = load i8*, i8** %arg0
   %138 = load i8*, i8** %arg1
   %139 = bitcast i8* %138 to i64*
-  %NullCheck76 = icmp ne i64* %139, null
-  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+  %NullCheck75 = icmp eq i64* %139, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %140
 
 ; <label>:140                                     ; preds = %136
   %141 = load i64, i64* %139, align 8
   %142 = bitcast i8* %137 to i64*
-  %NullCheck78 = icmp ne i64* %142, null
-  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+  %NullCheck77 = icmp eq i64* %142, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %143
 
 ; <label>:143                                     ; preds = %140
   store i64 %141, i64* %142, align 8
@@ -931,15 +1013,15 @@ entry:
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %NullCheck80 = icmp ne i8* %147, null
-  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+  %NullCheck79 = icmp eq i8* %147, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %148
 
 ; <label>:148                                     ; preds = %143
   %149 = load i8, i8* %147, align 8
   %150 = zext i8 %149 to i32
   %151 = trunc i32 %150 to i8
-  %NullCheck82 = icmp ne i8* %145, null
-  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+  %NullCheck81 = icmp eq i8* %145, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %152
 
 ; <label>:152                                     ; preds = %148
   store i8 %151, i8* %145, align 8
@@ -949,14 +1031,14 @@ entry:
   %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
   %156 = bitcast i8* %155 to i64*
-  %NullCheck68 = icmp ne i64* %156, null
-  br i1 %NullCheck68, label %157, label %ThrowNullRef67
+  %NullCheck67 = icmp eq i64* %156, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %157
 
 ; <label>:157                                     ; preds = %153
   %158 = load i64, i64* %156, align 8
   %159 = bitcast i8* %154 to i64*
-  %NullCheck70 = icmp ne i64* %159, null
-  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+  %NullCheck69 = icmp eq i64* %159, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %160
 
 ; <label>:160                                     ; preds = %157
   store i64 %158, i64* %159, align 8
@@ -965,16 +1047,16 @@ entry:
   %163 = load i8*, i8** %arg1
   %164 = getelementptr inbounds i8, i8* %163, i64 8
   %165 = bitcast i8* %164 to i16*
-  %NullCheck72 = icmp ne i16* %165, null
-  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+  %NullCheck71 = icmp eq i16* %165, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %166
 
 ; <label>:166                                     ; preds = %160
   %167 = load i16, i16* %165, align 8
   %168 = sext i16 %167 to i32
   %169 = bitcast i8* %162 to i16*
   %170 = trunc i32 %168 to i16
-  %NullCheck74 = icmp ne i16* %169, null
-  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+  %NullCheck73 = icmp eq i16* %169, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %171
 
 ; <label>:171                                     ; preds = %166
   store i16 %170, i16* %169, align 8
@@ -984,14 +1066,14 @@ entry:
   %173 = load i8*, i8** %arg0
   %174 = load i8*, i8** %arg1
   %175 = bitcast i8* %174 to i64*
-  %NullCheck56 = icmp ne i64* %175, null
-  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+  %NullCheck55 = icmp eq i64* %175, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %176
 
 ; <label>:176                                     ; preds = %172
   %177 = load i64, i64* %175, align 8
   %178 = bitcast i8* %173 to i64*
-  %NullCheck58 = icmp ne i64* %178, null
-  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+  %NullCheck57 = icmp eq i64* %178, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %179
 
 ; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
@@ -1000,16 +1082,16 @@ entry:
   %182 = load i8*, i8** %arg1
   %183 = getelementptr inbounds i8, i8* %182, i64 8
   %184 = bitcast i8* %183 to i16*
-  %NullCheck60 = icmp ne i16* %184, null
-  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+  %NullCheck59 = icmp eq i16* %184, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %185
 
 ; <label>:185                                     ; preds = %179
   %186 = load i16, i16* %184, align 8
   %187 = sext i16 %186 to i32
   %188 = bitcast i8* %181 to i16*
   %189 = trunc i32 %187 to i16
-  %NullCheck62 = icmp ne i16* %188, null
-  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+  %NullCheck61 = icmp eq i16* %188, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %190
 
 ; <label>:190                                     ; preds = %185
   store i16 %189, i16* %188, align 8
@@ -1017,15 +1099,15 @@ entry:
   %192 = getelementptr inbounds i8, i8* %191, i64 10
   %193 = load i8*, i8** %arg1
   %194 = getelementptr inbounds i8, i8* %193, i64 10
-  %NullCheck64 = icmp ne i8* %194, null
-  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+  %NullCheck63 = icmp eq i8* %194, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %195
 
 ; <label>:195                                     ; preds = %190
   %196 = load i8, i8* %194, align 8
   %197 = zext i8 %196 to i32
   %198 = trunc i32 %197 to i8
-  %NullCheck66 = icmp ne i8* %192, null
-  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+  %NullCheck65 = icmp eq i8* %192, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %199
 
 ; <label>:199                                     ; preds = %195
   store i8 %198, i8* %192, align 8
@@ -1035,14 +1117,14 @@ entry:
   %201 = load i8*, i8** %arg0
   %202 = load i8*, i8** %arg1
   %203 = bitcast i8* %202 to i64*
-  %NullCheck48 = icmp ne i64* %203, null
-  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+  %NullCheck47 = icmp eq i64* %203, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %204
 
 ; <label>:204                                     ; preds = %200
   %205 = load i64, i64* %203, align 8
   %206 = bitcast i8* %201 to i64*
-  %NullCheck50 = icmp ne i64* %206, null
-  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+  %NullCheck49 = icmp eq i64* %206, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %207
 
 ; <label>:207                                     ; preds = %204
   store i64 %205, i64* %206, align 8
@@ -1051,14 +1133,14 @@ entry:
   %210 = load i8*, i8** %arg1
   %211 = getelementptr inbounds i8, i8* %210, i64 8
   %212 = bitcast i8* %211 to i32*
-  %NullCheck52 = icmp ne i32* %212, null
-  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+  %NullCheck51 = icmp eq i32* %212, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %213
 
 ; <label>:213                                     ; preds = %207
   %214 = load i32, i32* %212, align 8
   %215 = bitcast i8* %209 to i32*
-  %NullCheck54 = icmp ne i32* %215, null
-  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+  %NullCheck53 = icmp eq i32* %215, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %216
 
 ; <label>:216                                     ; preds = %213
   store i32 %214, i32* %215, align 8
@@ -1068,14 +1150,14 @@ entry:
   %218 = load i8*, i8** %arg0
   %219 = load i8*, i8** %arg1
   %220 = bitcast i8* %219 to i64*
-  %NullCheck36 = icmp ne i64* %220, null
-  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64* %220, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %221
 
 ; <label>:221                                     ; preds = %217
   %222 = load i64, i64* %220, align 8
   %223 = bitcast i8* %218 to i64*
-  %NullCheck38 = icmp ne i64* %223, null
-  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+  %NullCheck37 = icmp eq i64* %223, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %224
 
 ; <label>:224                                     ; preds = %221
   store i64 %222, i64* %223, align 8
@@ -1084,14 +1166,14 @@ entry:
   %227 = load i8*, i8** %arg1
   %228 = getelementptr inbounds i8, i8* %227, i64 8
   %229 = bitcast i8* %228 to i32*
-  %NullCheck40 = icmp ne i32* %229, null
-  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i32* %229, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %230
 
 ; <label>:230                                     ; preds = %224
   %231 = load i32, i32* %229, align 8
   %232 = bitcast i8* %226 to i32*
-  %NullCheck42 = icmp ne i32* %232, null
-  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+  %NullCheck41 = icmp eq i32* %232, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %233
 
 ; <label>:233                                     ; preds = %230
   store i32 %231, i32* %232, align 8
@@ -1099,15 +1181,15 @@ entry:
   %235 = getelementptr inbounds i8, i8* %234, i64 12
   %236 = load i8*, i8** %arg1
   %237 = getelementptr inbounds i8, i8* %236, i64 12
-  %NullCheck44 = icmp ne i8* %237, null
-  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i8* %237, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %238
 
 ; <label>:238                                     ; preds = %233
   %239 = load i8, i8* %237, align 8
   %240 = zext i8 %239 to i32
   %241 = trunc i32 %240 to i8
-  %NullCheck46 = icmp ne i8* %235, null
-  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+  %NullCheck45 = icmp eq i8* %235, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %242
 
 ; <label>:242                                     ; preds = %238
   store i8 %241, i8* %235, align 8
@@ -1117,14 +1199,14 @@ entry:
   %244 = load i8*, i8** %arg0
   %245 = load i8*, i8** %arg1
   %246 = bitcast i8* %245 to i64*
-  %NullCheck24 = icmp ne i64* %246, null
-  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64* %246, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %247
 
 ; <label>:247                                     ; preds = %243
   %248 = load i64, i64* %246, align 8
   %249 = bitcast i8* %244 to i64*
-  %NullCheck26 = icmp ne i64* %249, null
-  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64* %249, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %250
 
 ; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
@@ -1133,14 +1215,14 @@ entry:
   %253 = load i8*, i8** %arg1
   %254 = getelementptr inbounds i8, i8* %253, i64 8
   %255 = bitcast i8* %254 to i32*
-  %NullCheck28 = icmp ne i32* %255, null
-  br i1 %NullCheck28, label %256, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i32* %255, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %256
 
 ; <label>:256                                     ; preds = %250
   %257 = load i32, i32* %255, align 8
   %258 = bitcast i8* %252 to i32*
-  %NullCheck30 = icmp ne i32* %258, null
-  br i1 %NullCheck30, label %259, label %ThrowNullRef29
+  %NullCheck29 = icmp eq i32* %258, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %259
 
 ; <label>:259                                     ; preds = %256
   store i32 %257, i32* %258, align 8
@@ -1149,16 +1231,16 @@ entry:
   %262 = load i8*, i8** %arg1
   %263 = getelementptr inbounds i8, i8* %262, i64 12
   %264 = bitcast i8* %263 to i16*
-  %NullCheck32 = icmp ne i16* %264, null
-  br i1 %NullCheck32, label %265, label %ThrowNullRef31
+  %NullCheck31 = icmp eq i16* %264, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %265
 
 ; <label>:265                                     ; preds = %259
   %266 = load i16, i16* %264, align 8
   %267 = sext i16 %266 to i32
   %268 = bitcast i8* %261 to i16*
   %269 = trunc i32 %267 to i16
-  %NullCheck34 = icmp ne i16* %268, null
-  br i1 %NullCheck34, label %270, label %ThrowNullRef33
+  %NullCheck33 = icmp eq i16* %268, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %270
 
 ; <label>:270                                     ; preds = %265
   store i16 %269, i16* %268, align 8
@@ -1168,14 +1250,14 @@ entry:
   %272 = load i8*, i8** %arg0
   %273 = load i8*, i8** %arg1
   %274 = bitcast i8* %273 to i64*
-  %NullCheck8 = icmp ne i64* %274, null
-  br i1 %NullCheck8, label %275, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64* %274, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %275
 
 ; <label>:275                                     ; preds = %271
   %276 = load i64, i64* %274, align 8
   %277 = bitcast i8* %272 to i64*
-  %NullCheck10 = icmp ne i64* %277, null
-  br i1 %NullCheck10, label %278, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %277, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %278
 
 ; <label>:278                                     ; preds = %275
   store i64 %276, i64* %277, align 8
@@ -1184,14 +1266,14 @@ entry:
   %281 = load i8*, i8** %arg1
   %282 = getelementptr inbounds i8, i8* %281, i64 8
   %283 = bitcast i8* %282 to i32*
-  %NullCheck12 = icmp ne i32* %283, null
-  br i1 %NullCheck12, label %284, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i32* %283, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %284
 
 ; <label>:284                                     ; preds = %278
   %285 = load i32, i32* %283, align 8
   %286 = bitcast i8* %280 to i32*
-  %NullCheck14 = icmp ne i32* %286, null
-  br i1 %NullCheck14, label %287, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i32* %286, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %287
 
 ; <label>:287                                     ; preds = %284
   store i32 %285, i32* %286, align 8
@@ -1200,16 +1282,16 @@ entry:
   %290 = load i8*, i8** %arg1
   %291 = getelementptr inbounds i8, i8* %290, i64 12
   %292 = bitcast i8* %291 to i16*
-  %NullCheck16 = icmp ne i16* %292, null
-  br i1 %NullCheck16, label %293, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i16* %292, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %293
 
 ; <label>:293                                     ; preds = %287
   %294 = load i16, i16* %292, align 8
   %295 = sext i16 %294 to i32
   %296 = bitcast i8* %289 to i16*
   %297 = trunc i32 %295 to i16
-  %NullCheck18 = icmp ne i16* %296, null
-  br i1 %NullCheck18, label %298, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i16* %296, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %298
 
 ; <label>:298                                     ; preds = %293
   store i16 %297, i16* %296, align 8
@@ -1217,15 +1299,15 @@ entry:
   %300 = getelementptr inbounds i8, i8* %299, i64 14
   %301 = load i8*, i8** %arg1
   %302 = getelementptr inbounds i8, i8* %301, i64 14
-  %NullCheck20 = icmp ne i8* %302, null
-  br i1 %NullCheck20, label %303, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i8* %302, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %303
 
 ; <label>:303                                     ; preds = %298
   %304 = load i8, i8* %302, align 8
   %305 = zext i8 %304 to i32
   %306 = trunc i32 %305 to i8
-  %NullCheck22 = icmp ne i8* %300, null
-  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i8* %300, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %307
 
 ; <label>:307                                     ; preds = %303
   store i8 %306, i8* %300, align 8
@@ -1235,14 +1317,14 @@ entry:
   %309 = load i8*, i8** %arg0
   %310 = load i8*, i8** %arg1
   %311 = bitcast i8* %310 to i64*
-  %NullCheck = icmp ne i64* %311, null
-  br i1 %NullCheck, label %312, label %ThrowNullRef
+  %NullCheck = icmp eq i64* %311, null
+  br i1 %NullCheck, label %ThrowNullRef, label %312
 
 ; <label>:312                                     ; preds = %308
   %313 = load i64, i64* %311, align 8
   %314 = bitcast i8* %309 to i64*
-  %NullCheck2 = icmp ne i64* %314, null
-  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64* %314, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %315
 
 ; <label>:315                                     ; preds = %312
   store i64 %313, i64* %314, align 8
@@ -1251,14 +1333,14 @@ entry:
   %318 = load i8*, i8** %arg1
   %319 = getelementptr inbounds i8, i8* %318, i64 8
   %320 = bitcast i8* %319 to i64*
-  %NullCheck4 = icmp ne i64* %320, null
-  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64* %320, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %321
 
 ; <label>:321                                     ; preds = %315
   %322 = load i64, i64* %320, align 8
   %323 = bitcast i8* %317 to i64*
-  %NullCheck6 = icmp ne i64* %323, null
-  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64* %323, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %324
 
 ; <label>:324                                     ; preds = %321
   store i64 %322, i64* %323, align 8
@@ -1286,15 +1368,15 @@ entry:
 ; <label>:338                                     ; preds = %333
   %339 = load i8*, i8** %arg0
   %340 = load i8*, i8** %arg1
-  %NullCheck136 = icmp ne i8* %340, null
-  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+  %NullCheck135 = icmp eq i8* %340, null
+  br i1 %NullCheck135, label %ThrowNullRef136, label %341
 
 ; <label>:341                                     ; preds = %338
   %342 = load i8, i8* %340, align 8
   %343 = zext i8 %342 to i32
   %344 = trunc i32 %343 to i8
-  %NullCheck138 = icmp ne i8* %339, null
-  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+  %NullCheck137 = icmp eq i8* %339, null
+  br i1 %NullCheck137, label %ThrowNullRef138, label %345
 
 ; <label>:345                                     ; preds = %341
   store i8 %344, i8* %339, align 8
@@ -1317,16 +1399,16 @@ entry:
   %357 = load i8*, i8** %arg0
   %358 = load i8*, i8** %arg1
   %359 = bitcast i8* %358 to i16*
-  %NullCheck140 = icmp ne i16* %359, null
-  br i1 %NullCheck140, label %360, label %ThrowNullRef139
+  %NullCheck139 = icmp eq i16* %359, null
+  br i1 %NullCheck139, label %ThrowNullRef140, label %360
 
 ; <label>:360                                     ; preds = %356
   %361 = load i16, i16* %359, align 8
   %362 = sext i16 %361 to i32
   %363 = bitcast i8* %357 to i16*
   %364 = trunc i32 %362 to i16
-  %NullCheck142 = icmp ne i16* %363, null
-  br i1 %NullCheck142, label %365, label %ThrowNullRef141
+  %NullCheck141 = icmp eq i16* %363, null
+  br i1 %NullCheck141, label %ThrowNullRef142, label %365
 
 ; <label>:365                                     ; preds = %360
   store i16 %364, i16* %363, align 8
@@ -1352,14 +1434,14 @@ entry:
   %378 = load i8*, i8** %arg0
   %379 = load i8*, i8** %arg1
   %380 = bitcast i8* %379 to i32*
-  %NullCheck144 = icmp ne i32* %380, null
-  br i1 %NullCheck144, label %381, label %ThrowNullRef143
+  %NullCheck143 = icmp eq i32* %380, null
+  br i1 %NullCheck143, label %ThrowNullRef144, label %381
 
 ; <label>:381                                     ; preds = %377
   %382 = load i32, i32* %380, align 8
   %383 = bitcast i8* %378 to i32*
-  %NullCheck146 = icmp ne i32* %383, null
-  br i1 %NullCheck146, label %384, label %ThrowNullRef145
+  %NullCheck145 = icmp eq i32* %383, null
+  br i1 %NullCheck145, label %ThrowNullRef146, label %384
 
 ; <label>:384                                     ; preds = %381
   store i32 %382, i32* %383, align 8
@@ -1384,14 +1466,14 @@ entry:
   %395 = load i8*, i8** %arg0
   %396 = load i8*, i8** %arg1
   %397 = bitcast i8* %396 to i64*
-  %NullCheck164 = icmp ne i64* %397, null
-  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+  %NullCheck163 = icmp eq i64* %397, null
+  br i1 %NullCheck163, label %ThrowNullRef164, label %398
 
 ; <label>:398                                     ; preds = %394
   %399 = load i64, i64* %397, align 8
   %400 = bitcast i8* %395 to i64*
-  %NullCheck166 = icmp ne i64* %400, null
-  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+  %NullCheck165 = icmp eq i64* %400, null
+  br i1 %NullCheck165, label %ThrowNullRef166, label %401
 
 ; <label>:401                                     ; preds = %398
   store i64 %399, i64* %400, align 8
@@ -1400,14 +1482,14 @@ entry:
   %404 = load i8*, i8** %arg1
   %405 = getelementptr inbounds i8, i8* %404, i64 8
   %406 = bitcast i8* %405 to i64*
-  %NullCheck168 = icmp ne i64* %406, null
-  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+  %NullCheck167 = icmp eq i64* %406, null
+  br i1 %NullCheck167, label %ThrowNullRef168, label %407
 
 ; <label>:407                                     ; preds = %401
   %408 = load i64, i64* %406, align 8
   %409 = bitcast i8* %403 to i64*
-  %NullCheck170 = icmp ne i64* %409, null
-  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+  %NullCheck169 = icmp eq i64* %409, null
+  br i1 %NullCheck169, label %ThrowNullRef170, label %410
 
 ; <label>:410                                     ; preds = %407
   store i64 %408, i64* %409, align 8
@@ -1437,14 +1519,14 @@ entry:
   %425 = load i8*, i8** %arg0
   %426 = load i8*, i8** %arg1
   %427 = bitcast i8* %426 to i64*
-  %NullCheck148 = icmp ne i64* %427, null
-  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+  %NullCheck147 = icmp eq i64* %427, null
+  br i1 %NullCheck147, label %ThrowNullRef148, label %428
 
 ; <label>:428                                     ; preds = %424
   %429 = load i64, i64* %427, align 8
   %430 = bitcast i8* %425 to i64*
-  %NullCheck150 = icmp ne i64* %430, null
-  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+  %NullCheck149 = icmp eq i64* %430, null
+  br i1 %NullCheck149, label %ThrowNullRef150, label %431
 
 ; <label>:431                                     ; preds = %428
   store i64 %429, i64* %430, align 8
@@ -1466,14 +1548,14 @@ entry:
   %441 = load i8*, i8** %arg0
   %442 = load i8*, i8** %arg1
   %443 = bitcast i8* %442 to i32*
-  %NullCheck152 = icmp ne i32* %443, null
-  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+  %NullCheck151 = icmp eq i32* %443, null
+  br i1 %NullCheck151, label %ThrowNullRef152, label %444
 
 ; <label>:444                                     ; preds = %440
   %445 = load i32, i32* %443, align 8
   %446 = bitcast i8* %441 to i32*
-  %NullCheck154 = icmp ne i32* %446, null
-  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+  %NullCheck153 = icmp eq i32* %446, null
+  br i1 %NullCheck153, label %ThrowNullRef154, label %447
 
 ; <label>:447                                     ; preds = %444
   store i32 %445, i32* %446, align 8
@@ -1495,16 +1577,16 @@ entry:
   %457 = load i8*, i8** %arg0
   %458 = load i8*, i8** %arg1
   %459 = bitcast i8* %458 to i16*
-  %NullCheck156 = icmp ne i16* %459, null
-  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+  %NullCheck155 = icmp eq i16* %459, null
+  br i1 %NullCheck155, label %ThrowNullRef156, label %460
 
 ; <label>:460                                     ; preds = %456
   %461 = load i16, i16* %459, align 8
   %462 = sext i16 %461 to i32
   %463 = bitcast i8* %457 to i16*
   %464 = trunc i32 %462 to i16
-  %NullCheck158 = icmp ne i16* %463, null
-  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+  %NullCheck157 = icmp eq i16* %463, null
+  br i1 %NullCheck157, label %ThrowNullRef158, label %465
 
 ; <label>:465                                     ; preds = %460
   store i16 %464, i16* %463, align 8
@@ -1525,15 +1607,15 @@ entry:
 ; <label>:474                                     ; preds = %470
   %475 = load i8*, i8** %arg0
   %476 = load i8*, i8** %arg1
-  %NullCheck160 = icmp ne i8* %476, null
-  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+  %NullCheck159 = icmp eq i8* %476, null
+  br i1 %NullCheck159, label %ThrowNullRef160, label %477
 
 ; <label>:477                                     ; preds = %474
   %478 = load i8, i8* %476, align 8
   %479 = zext i8 %478 to i32
   %480 = trunc i32 %479 to i8
-  %NullCheck162 = icmp ne i8* %475, null
-  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+  %NullCheck161 = icmp eq i8* %475, null
+  br i1 %NullCheck161, label %ThrowNullRef162, label %481
 
 ; <label>:481                                     ; preds = %477
   store i8 %480, i8* %475, align 8
@@ -1553,343 +1635,343 @@ ThrowNullRef:                                     ; preds = %308
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %312
+ThrowNullRef2:                                    ; preds = %312
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %315
+ThrowNullRef4:                                    ; preds = %315
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %321
+ThrowNullRef6:                                    ; preds = %321
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %271
+ThrowNullRef8:                                    ; preds = %271
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %275
+ThrowNullRef10:                                   ; preds = %275
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %278
+ThrowNullRef12:                                   ; preds = %278
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %284
+ThrowNullRef14:                                   ; preds = %284
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %287
+ThrowNullRef16:                                   ; preds = %287
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %293
+ThrowNullRef18:                                   ; preds = %293
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %298
+ThrowNullRef20:                                   ; preds = %298
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %303
+ThrowNullRef22:                                   ; preds = %303
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %243
+ThrowNullRef24:                                   ; preds = %243
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %247
+ThrowNullRef26:                                   ; preds = %247
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %250
+ThrowNullRef28:                                   ; preds = %250
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %256
+ThrowNullRef30:                                   ; preds = %256
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %259
+ThrowNullRef32:                                   ; preds = %259
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %265
+ThrowNullRef34:                                   ; preds = %265
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %217
+ThrowNullRef36:                                   ; preds = %217
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %221
+ThrowNullRef38:                                   ; preds = %221
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %224
+ThrowNullRef40:                                   ; preds = %224
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %230
+ThrowNullRef42:                                   ; preds = %230
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %233
+ThrowNullRef44:                                   ; preds = %233
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %238
+ThrowNullRef46:                                   ; preds = %238
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %200
+ThrowNullRef48:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %204
+ThrowNullRef50:                                   ; preds = %204
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %207
+ThrowNullRef52:                                   ; preds = %207
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %213
+ThrowNullRef54:                                   ; preds = %213
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %172
+ThrowNullRef56:                                   ; preds = %172
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %176
+ThrowNullRef58:                                   ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %179
+ThrowNullRef60:                                   ; preds = %179
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %185
+ThrowNullRef62:                                   ; preds = %185
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %190
+ThrowNullRef64:                                   ; preds = %190
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %195
+ThrowNullRef66:                                   ; preds = %195
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %153
+ThrowNullRef68:                                   ; preds = %153
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %157
+ThrowNullRef70:                                   ; preds = %157
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %160
+ThrowNullRef72:                                   ; preds = %160
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %166
+ThrowNullRef74:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %136
+ThrowNullRef76:                                   ; preds = %136
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %140
+ThrowNullRef78:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %143
+ThrowNullRef80:                                   ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %148
+ThrowNullRef82:                                   ; preds = %148
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %128
+ThrowNullRef84:                                   ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %132
+ThrowNullRef86:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %100
+ThrowNullRef88:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %104
+ThrowNullRef90:                                   ; preds = %104
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %107
+ThrowNullRef92:                                   ; preds = %107
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %113
+ThrowNullRef94:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %118
+ThrowNullRef96:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %123
+ThrowNullRef98:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %81
+ThrowNullRef100:                                  ; preds = %81
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef101:                                  ; preds = %85
+ThrowNullRef102:                                  ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef103:                                  ; preds = %88
+ThrowNullRef104:                                  ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef105:                                  ; preds = %94
+ThrowNullRef106:                                  ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef107:                                  ; preds = %64
+ThrowNullRef108:                                  ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef109:                                  ; preds = %68
+ThrowNullRef110:                                  ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef111:                                  ; preds = %71
+ThrowNullRef112:                                  ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef113:                                  ; preds = %76
+ThrowNullRef114:                                  ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef115:                                  ; preds = %56
+ThrowNullRef116:                                  ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef117:                                  ; preds = %60
+ThrowNullRef118:                                  ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef119:                                  ; preds = %37
+ThrowNullRef120:                                  ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef121:                                  ; preds = %41
+ThrowNullRef122:                                  ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef123:                                  ; preds = %46
+ThrowNullRef124:                                  ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef125:                                  ; preds = %51
+ThrowNullRef126:                                  ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef127:                                  ; preds = %27
+ThrowNullRef128:                                  ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef129:                                  ; preds = %31
+ThrowNullRef130:                                  ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef131:                                  ; preds = %19
+ThrowNullRef132:                                  ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef133:                                  ; preds = %22
+ThrowNullRef134:                                  ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef135:                                  ; preds = %338
+ThrowNullRef136:                                  ; preds = %338
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef137:                                  ; preds = %341
+ThrowNullRef138:                                  ; preds = %341
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef139:                                  ; preds = %356
+ThrowNullRef140:                                  ; preds = %356
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef141:                                  ; preds = %360
+ThrowNullRef142:                                  ; preds = %360
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef143:                                  ; preds = %377
+ThrowNullRef144:                                  ; preds = %377
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef145:                                  ; preds = %381
+ThrowNullRef146:                                  ; preds = %381
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef147:                                  ; preds = %424
+ThrowNullRef148:                                  ; preds = %424
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef149:                                  ; preds = %428
+ThrowNullRef150:                                  ; preds = %428
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef151:                                  ; preds = %440
+ThrowNullRef152:                                  ; preds = %440
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef153:                                  ; preds = %444
+ThrowNullRef154:                                  ; preds = %444
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef155:                                  ; preds = %456
+ThrowNullRef156:                                  ; preds = %456
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef157:                                  ; preds = %460
+ThrowNullRef158:                                  ; preds = %460
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef159:                                  ; preds = %474
+ThrowNullRef160:                                  ; preds = %474
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef161:                                  ; preds = %477
+ThrowNullRef162:                                  ; preds = %477
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef163:                                  ; preds = %394
+ThrowNullRef164:                                  ; preds = %394
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef165:                                  ; preds = %398
+ThrowNullRef166:                                  ; preds = %398
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef167:                                  ; preds = %401
+ThrowNullRef168:                                  ; preds = %401
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef169:                                  ; preds = %407
+ThrowNullRef170:                                  ; preds = %407
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1939,8 +2021,8 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
-  br i1 %NullCheck, label %22, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %ThrowNullRef, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
@@ -1948,8 +2030,8 @@ entry:
   store i32 %24, i32* %loc0
   %25 = load i32, i32* %loc0
   %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %26, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %27
 
 ; <label>:27                                      ; preds = %22
   %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
@@ -1971,7 +2053,7 @@ ThrowNullRef:                                     ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1989,8 +2071,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -2022,15 +2104,15 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2048,16 +2130,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
   %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
   store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %15
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
@@ -2072,8 +2154,8 @@ entry:
   %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
   %29 = ptrtoint i16 addrspace(1)* %28 to i64
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %19
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
@@ -2089,19 +2171,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2114,8 +2196,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
@@ -2128,7 +2210,7 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[loadElem]
+Failed to read AppDomain.PrepareDataForSetup[storeElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
@@ -2202,8 +2284,8 @@ entry:
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
-  br i1 %NullCheck24, label %27, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = load i64, i64 addrspace(1)* %26
@@ -2218,8 +2300,8 @@ entry:
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
-  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
   %41 = load i64, i64 addrspace(1)* %39
@@ -2236,8 +2318,8 @@ entry:
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
-  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
   %54 = load i64, i64 addrspace(1)* %52
@@ -2252,8 +2334,8 @@ entry:
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
   %67 = load i64, i64 addrspace(1)* %65
@@ -2270,8 +2352,8 @@ entry:
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
-  br i1 %NullCheck16, label %79, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
   %80 = load i64, i64 addrspace(1)* %78
@@ -2286,8 +2368,8 @@ entry:
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
-  br i1 %NullCheck18, label %92, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
   %93 = load i64, i64 addrspace(1)* %91
@@ -2304,8 +2386,8 @@ entry:
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
-  br i1 %NullCheck12, label %105, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = load i64, i64 addrspace(1)* %104
@@ -2320,8 +2402,8 @@ entry:
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
-  br i1 %NullCheck14, label %118, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
   %119 = load i64, i64 addrspace(1)* %117
@@ -2337,8 +2419,8 @@ entry:
 
 ; <label>:128                                     ; preds = %20
   %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
-  br i1 %NullCheck4, label %130, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %129, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %130
 
 ; <label>:130                                     ; preds = %128
   %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
@@ -2346,8 +2428,8 @@ entry:
   %133 = load i16, i16 addrspace(1)* %132, align 8
   %134 = zext i16 %133 to i32
   %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
-  br i1 %NullCheck6, label %136, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %135, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %136
 
 ; <label>:136                                     ; preds = %130
   %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
@@ -2360,8 +2442,8 @@ entry:
 
 ; <label>:143                                     ; preds = %136
   %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
-  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %144, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %145
 
 ; <label>:145                                     ; preds = %143
   %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
@@ -2369,8 +2451,8 @@ entry:
   %148 = load i16, i16 addrspace(1)* %147, align 8
   %149 = zext i16 %148 to i32
   %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %150, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %151
 
 ; <label>:151                                     ; preds = %145
   %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
@@ -2388,8 +2470,8 @@ entry:
 
 ; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
-  br i1 %NullCheck, label %163, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %ThrowNullRef, label %163
 
 ; <label>:163                                     ; preds = %161
   %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
@@ -2399,8 +2481,8 @@ entry:
 
 ; <label>:167                                     ; preds = %163
   %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
-  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %168, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %169
 
 ; <label>:169                                     ; preds = %167
   %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
@@ -2432,55 +2514,55 @@ ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %167
+ThrowNullRef2:                                    ; preds = %167
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %128
+ThrowNullRef4:                                    ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %130
+ThrowNullRef6:                                    ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %143
+ThrowNullRef8:                                    ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %145
+ThrowNullRef10:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %102
+ThrowNullRef12:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %105
+ThrowNullRef14:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %76
+ThrowNullRef16:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %79
+ThrowNullRef18:                                   ; preds = %79
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %50
+ThrowNullRef20:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %53
+ThrowNullRef22:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %24
+ThrowNullRef24:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %27
+ThrowNullRef26:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2503,15 +2585,15 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2519,16 +2601,16 @@ entry:
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
   store i32 %8, i32* %loc0
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
   %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
   store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
@@ -2546,16 +2628,16 @@ entry:
 
 ; <label>:23                                      ; preds = %64
   %24 = load i16*, i16** %loc3
-  %NullCheck12 = icmp ne i16* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i16* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
   store i32 %27, i32* %loc5
   %28 = load i16*, i16** %loc4
-  %NullCheck14 = icmp ne i16* %28, null
-  br i1 %NullCheck14, label %29, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %28, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = load i16, i16* %28, align 8
@@ -2620,15 +2702,15 @@ entry:
 
 ; <label>:67                                      ; preds = %64
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
-  br i1 %NullCheck8, label %69, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %68, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %69
 
 ; <label>:69                                      ; preds = %67
   %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
   %71 = load i32, i32 addrspace(1)* %70
   %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
-  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %73
 
 ; <label>:73                                      ; preds = %69
   %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
@@ -2645,31 +2727,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %67
+ThrowNullRef8:                                    ; preds = %67
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %69
+ThrowNullRef10:                                   ; preds = %69
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2710,14 +2792,14 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
   %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
@@ -2730,14 +2812,14 @@ entry:
 
 ; <label>:11                                      ; preds = %4
   %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
   %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
@@ -2749,14 +2831,14 @@ entry:
 
 ; <label>:22                                      ; preds = %16
   %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
   %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
-  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
-  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
@@ -2804,23 +2886,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2836,7 +2918,280 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[loadElem]
+Successfully read RuntimeType.IsAssignableFrom
+
+define i8 @RuntimeType.IsAssignableFrom(%System.RuntimeType addrspace(1)* %param0, %System.Type addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.RuntimeType addrspace(1)*
+  %arg1 = alloca %System.Type addrspace(1)*
+  %loc0 = alloca %System.RuntimeType addrspace(1)*
+  %loc1 = alloca %"System.Type[]" addrspace(1)*
+  %loc2 = alloca i32
+  store %System.RuntimeType addrspace(1)* %param0, %System.RuntimeType addrspace(1)** %this
+  store %System.Type addrspace(1)* %param1, %System.Type addrspace(1)** %arg1
+  %0 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %1 = icmp ne %System.Type addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i8 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %5 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %6 = bitcast %System.Type addrspace(1)* %4 to %System.Object addrspace(1)*
+  %7 = bitcast %System.RuntimeType addrspace(1)* %5 to %System.Object addrspace(1)*
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %6, %System.Object addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %3
+  ret i8 1
+
+; <label>:12                                      ; preds = %3
+  %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 152
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 32
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
+  %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
+  %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
+  store %System.RuntimeType addrspace(1)* %25, %System.RuntimeType addrspace(1)** %loc0
+  %26 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %27 = icmp eq %System.RuntimeType addrspace(1)* %26, null
+  br i1 %27, label %34, label %28
+
+; <label>:28                                      ; preds = %15
+  %29 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %30 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)*)*)(%System.RuntimeType addrspace(1)* %29, %System.RuntimeType addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+; <label>:34                                      ; preds = %15
+  %35 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %36 = call %System.Reflection.Emit.TypeBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Reflection.Emit.TypeBuilder addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %35)
+  %37 = icmp eq %System.Reflection.Emit.TypeBuilder addrspace(1)* %36, null
+  br i1 %37, label %139, label %38
+
+; <label>:38                                      ; preds = %34
+  %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %42
+
+; <label>:42                                      ; preds = %38
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 152
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 40
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
+  %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
+  %53 = zext i8 %52 to i32
+  %54 = icmp eq i32 %53, 0
+  br i1 %54, label %56, label %55
+
+; <label>:55                                      ; preds = %42
+  ret i8 1
+
+; <label>:56                                      ; preds = %42
+  %57 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %58 = bitcast %System.RuntimeType addrspace(1)* %57 to %System.Type addrspace(1)*
+  %59 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %58)
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %64 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.Type addrspace(1)* %63, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = bitcast %System.RuntimeType addrspace(1)* %64 to %System.Type addrspace(1)*
+  %67 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %63, %System.Type addrspace(1)* %66)
+  %68 = zext i8 %67 to i32
+  %69 = trunc i32 %68 to i8
+  ret i8 %69
+
+; <label>:70                                      ; preds = %56
+  %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
+  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %73
+
+; <label>:73                                      ; preds = %70
+  %74 = load i64, i64 addrspace(1)* %72
+  %75 = add i64 %74, 128
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = add i64 %77, 0
+  %79 = inttoptr i64 %78 to i64*
+  %80 = load i64, i64* %79
+  %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
+  %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
+  %83 = call i8 %82(%System.Type addrspace(1)* %81)
+  %84 = zext i8 %83 to i32
+  %85 = icmp eq i32 %84, 0
+  br i1 %85, label %139, label %86
+
+; <label>:86                                      ; preds = %73
+  %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
+  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %89
+
+; <label>:89                                      ; preds = %86
+  %90 = load i64, i64 addrspace(1)* %88
+  %91 = add i64 %90, 128
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = add i64 %93, 24
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
+  %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
+  %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
+  store %"System.Type[]" addrspace(1)* %99, %"System.Type[]" addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %129
+
+; <label>:100                                     ; preds = %132
+  %101 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %102 = load i32, i32* %loc2
+  %NullCheck11 = icmp eq %"System.Type[]" addrspace(1)* %101, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %103
+
+; <label>:103                                     ; preds = %100
+  %104 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 1
+  %105 = load i32, i32 addrspace(1)* %104
+  %106 = zext i32 %105 to i64
+  %107 = zext i32 %102 to i64
+  %BoundsCheck = icmp uge i64 %107, %106
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %108
+
+; <label>:108                                     ; preds = %103
+  %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
+  %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
+  %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
+  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %113
+
+; <label>:113                                     ; preds = %108
+  %114 = load i64, i64 addrspace(1)* %112
+  %115 = add i64 %114, 152
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = add i64 %117, 56
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
+  %123 = zext i8 %122 to i32
+  %124 = icmp ne i32 %123, 0
+  br i1 %124, label %126, label %125
+
+; <label>:125                                     ; preds = %113
+  ret i8 0
+
+; <label>:126                                     ; preds = %113
+  %127 = load i32, i32* %loc2
+  %128 = add i32 %127, 1
+  store i32 %128, i32* %loc2
+  br label %129
+
+; <label>:129                                     ; preds = %89, %126
+  %130 = load i32, i32* %loc2
+  %131 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %NullCheck9 = icmp eq %"System.Type[]" addrspace(1)* %131, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %132
+
+; <label>:132                                     ; preds = %129
+  %133 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %131, i32 0, i32 1
+  %134 = load i32, i32 addrspace(1)* %133
+  %135 = zext i32 %134 to i64
+  %136 = trunc i64 %135 to i32
+  %137 = icmp slt i32 %130, %136
+  br i1 %137, label %100, label %138
+
+; <label>:138                                     ; preds = %132
+  ret i8 1
+
+; <label>:139                                     ; preds = %34, %73
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %129
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %103
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -2893,7 +3248,7 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElem]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -2904,8 +3259,8 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -2997,8 +3352,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
@@ -3059,8 +3414,8 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -3087,8 +3442,8 @@ entry:
 
 ; <label>:17                                      ; preds = %5, %11
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
@@ -3097,8 +3452,8 @@ entry:
 
 ; <label>:22                                      ; preds = %1, %11
   %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
@@ -3109,11 +3464,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %17
+ThrowNullRef2:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %22
+ThrowNullRef4:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3167,15 +3522,15 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
   %15 = load i32, i32 addrspace(1)* %14
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
@@ -3198,7 +3553,7 @@ ThrowNullRef:                                     ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef2:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3232,8 +3587,8 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
@@ -3312,8 +3667,8 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -3327,8 +3682,8 @@ entry:
 ; <label>:5                                       ; preds = %43
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %7 = load i32, i32* %loc1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck6, label %8, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
@@ -3366,8 +3721,8 @@ entry:
 ; <label>:32                                      ; preds = %21, %25
   %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
   %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
-  br i1 %NullCheck8, label %35, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = trunc i32 %34 to i16
@@ -3380,8 +3735,8 @@ entry:
 ; <label>:40                                      ; preds = %1, %35
   %41 = load i32, i32* %loc1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
-  br i1 %NullCheck2, label %43, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %42, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
@@ -3392,8 +3747,8 @@ entry:
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
   %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
-  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
   %51 = load i64, i64 addrspace(1)* %49
@@ -3412,19 +3767,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %40
+ThrowNullRef2:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %47
+ThrowNullRef4:                                    ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %5
+ThrowNullRef6:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %32
+ThrowNullRef8:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3467,8 +3822,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
@@ -3492,11 +3847,391 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(i16* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store i16* %param0, i16** %arg0
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load i32, i32* %arg3
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %42, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %37, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg2
+  %13 = load i32, i32* %arg3
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %37, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %24 = load i32, i32* %arg2
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load i16*, i16** %arg0
+  %35 = load i32, i32* %arg3
+  %36 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %36, i16* %34, i32 %35)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:37                                      ; preds = %5, %16
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %39)
+  %41 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41, %System.String addrspace(1)* %38, %System.String addrspace(1)* %40)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41) #0
+  unreachable
+
+; <label>:42                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
-Failed to read StringBuilder.ToString[loadElemA]
+Successfully read StringBuilder.ToString
+
+define %System.String addrspace(1)* @StringBuilder.ToString(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i16*
+  %loc3 = alloca %"System.Char[]" addrspace(1)*
+  %loc4 = alloca i32
+  %loc5 = alloca i32
+  %loc6 = alloca i16 addrspace(1)*
+  %loc7 = alloca %System.String addrspace(1)*
+  %loc8 = alloca %"System.Char[]" addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %0)
+  %2 = icmp ne i32 %1, 0
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %4
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %6)
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %7)
+  store %System.String addrspace(1)* %8, %System.String addrspace(1)** %loc0
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.Text.StringBuilder addrspace(1)* %9, %System.Text.StringBuilder addrspace(1)** %loc1
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  store %System.String addrspace(1)* %10, %System.String addrspace(1)** %loc7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc7
+  %12 = ptrtoint %System.String addrspace(1)* %11 to i64
+  %13 = icmp eq i64 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %5
+  %15 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %16 = sext i32 %15 to i64
+  %17 = add i64 %12, %16
+  br label %18
+
+; <label>:18                                      ; preds = %5, %14
+  %19 = phi i64 [ %12, %5 ], [ %17, %14 ]
+  %20 = inttoptr i64 %19 to i16*
+  store i16* %20, i16** %loc2
+  br label %21
+
+; <label>:21                                      ; preds = %98, %18
+  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %22, null
+  br i1 %NullCheck, label %ThrowNullRef, label %23
+
+; <label>:23                                      ; preds = %21
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 3
+  %25 = load i32, i32 addrspace(1)* %24, align 8
+  %26 = icmp sle i32 %25, 0
+  br i1 %26, label %96, label %27
+
+; <label>:27                                      ; preds = %23
+  %28 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %28, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %29
+
+; <label>:29                                      ; preds = %27
+  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %28, i32 0, i32 1
+  %31 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %30, align 8
+  store %"System.Char[]" addrspace(1)* %31, %"System.Char[]" addrspace(1)** %loc3
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %33
+
+; <label>:33                                      ; preds = %29
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  store i32 %35, i32* %loc4
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  %39 = load i32, i32 addrspace(1)* %38, align 8
+  store i32 %39, i32* %loc5
+  %40 = load i32, i32* %loc5
+  %41 = load i32, i32* %loc4
+  %42 = add i32 %40, %41
+  %43 = zext i32 %42 to i64
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %45
+
+; <label>:45                                      ; preds = %37
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = sext i32 %47 to i64
+  %49 = icmp sgt i64 %43, %48
+  br i1 %49, label %91, label %50
+
+; <label>:50                                      ; preds = %45
+  %51 = load i32, i32* %loc5
+  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %52, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %53
+
+; <label>:53                                      ; preds = %50
+  %54 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %52, i32 0, i32 1
+  %55 = load i32, i32 addrspace(1)* %54
+  %56 = zext i32 %55 to i64
+  %57 = trunc i64 %56 to i32
+  %58 = icmp ugt i32 %51, %57
+  br i1 %58, label %91, label %59
+
+; <label>:59                                      ; preds = %53
+  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  store %"System.Char[]" addrspace(1)* %60, %"System.Char[]" addrspace(1)** %loc8
+  %61 = icmp eq %"System.Char[]" addrspace(1)* %60, null
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %63, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %64
+
+; <label>:64                                      ; preds = %62
+  %65 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %63, i32 0, i32 1
+  %66 = load i32, i32 addrspace(1)* %65
+  %67 = zext i32 %66 to i64
+  %68 = trunc i64 %67 to i32
+  %69 = icmp ne i32 %68, 0
+  br i1 %69, label %71, label %70
+
+; <label>:70                                      ; preds = %59, %64
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:71                                      ; preds = %64
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %73
+
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %BoundsCheck = icmp uge i64 0, %76
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %77
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %78, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:79                                      ; preds = %70, %77
+  %80 = load i16*, i16** %loc2
+  %81 = load i32, i32* %loc4
+  %82 = sext i32 %81 to i64
+  %83 = mul i64 %82, 2
+  %84 = bitcast i16* %80 to i8*
+  %85 = getelementptr inbounds i8, i8* %84, i64 %83
+  %86 = load i16 addrspace(1)*, i16 addrspace(1)** %loc6
+  %87 = ptrtoint i16 addrspace(1)* %86 to i64
+  %88 = load i32, i32* %loc5
+  %89 = bitcast i8* %85 to i16*
+  %90 = inttoptr i64 %87 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %89, i16* %90, i32 %88)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %96
+
+; <label>:91                                      ; preds = %45, %53
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %94 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %93)
+  %95 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95, %System.String addrspace(1)* %92, %System.String addrspace(1)* %94)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95) #0
+  unreachable
+
+; <label>:96                                      ; preds = %23, %79
+  %97 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %97, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %98
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %97, i32 0, i32 2
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  store %System.Text.StringBuilder addrspace(1)* %100, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %102 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %102, label %21, label %103
+
+; <label>:103                                     ; preds = %98
+  store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc7
+  %104 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  ret %System.String addrspace(1)* %104
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method StringBuilder::get_Length using LLILCJit
+Successfully read StringBuilder.get_Length
+
+define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
+Successfully read RuntimeHelpers.get_OffsetToStringData
+
+define i32 @RuntimeHelpers.get_OffsetToStringData() {
+entry:
+  ret i32 12
+}
+
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
 Successfully read CultureData.CreateCultureData
 
@@ -3514,23 +4249,23 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
   store i8 %4, i8 addrspace(1)* %6
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
@@ -3549,11 +4284,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3566,50 +4301,50 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
   store i32 -1, i32 addrspace(1)* %2
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
   store i32 -1, i32 addrspace(1)* %8
   %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
   store i32 -1, i32 addrspace(1)* %14
   %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
   store i32 -1, i32 addrspace(1)* %17
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
@@ -3623,27 +4358,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3675,7 +4410,136 @@ Failed to read Dictionary`2.Insert[non-const derefAddress]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
 Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
-Failed to read HashHelpers.GetPrime[loadElem]
+Successfully read HashHelpers.GetPrime
+
+define i32 @HashHelpers.GetPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %6, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5, %System.String addrspace(1)* %4)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5) #0
+  unreachable
+
+; <label>:6                                       ; preds = %entry
+  store i32 0, i32* %loc0
+  br label %29
+
+; <label>:7                                       ; preds = %35
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 1296
+  %10 = addrspacecast i8 addrspace(1)* %9 to %"System.Int32[]" addrspace(1)**
+  %11 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %10
+  %12 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Int32[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = zext i32 %15 to i64
+  %17 = zext i32 %12 to i64
+  %BoundsCheck = icmp uge i64 %17, %16
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 3, i32 %12
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  store i32 %20, i32* %loc1
+  %21 = load i32, i32* %loc1
+  %22 = load i32, i32* %arg0
+  %23 = icmp slt i32 %21, %22
+  br i1 %23, label %26, label %24
+
+; <label>:24                                      ; preds = %18
+  %25 = load i32, i32* %loc1
+  ret i32 %25
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %loc0
+  %28 = add i32 %27, 1
+  store i32 %28, i32* %loc0
+  br label %29
+
+; <label>:29                                      ; preds = %6, %26
+  %30 = load i32, i32* %loc0
+  %31 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %32 = getelementptr inbounds i8, i8 addrspace(1)* %31, i64 1296
+  %33 = addrspacecast i8 addrspace(1)* %32 to %"System.Int32[]" addrspace(1)**
+  %34 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %33
+  %NullCheck = icmp eq %"System.Int32[]" addrspace(1)* %34, null
+  br i1 %NullCheck, label %ThrowNullRef, label %35
+
+; <label>:35                                      ; preds = %29
+  %36 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %34, i32 0, i32 1
+  %37 = load i32, i32 addrspace(1)* %36
+  %38 = zext i32 %37 to i64
+  %39 = trunc i64 %38 to i32
+  %40 = icmp slt i32 %30, %39
+  br i1 %40, label %7, label %41
+
+; <label>:41                                      ; preds = %35
+  %42 = load i32, i32* %arg0
+  %43 = or i32 %42, 1
+  store i32 %43, i32* %loc2
+  br label %59
+
+; <label>:44                                      ; preds = %59
+  %45 = load i32, i32* %loc2
+  %46 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %45)
+  %47 = zext i8 %46 to i32
+  %48 = icmp eq i32 %47, 0
+  br i1 %48, label %56, label %49
+
+; <label>:49                                      ; preds = %44
+  %50 = load i32, i32* %loc2
+  %51 = sub i32 %50, 1
+  %52 = srem i32 %51, 101
+  %53 = icmp eq i32 %52, 0
+  br i1 %53, label %56, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = load i32, i32* %loc2
+  ret i32 %55
+
+; <label>:56                                      ; preds = %44, %49
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %57, 2
+  store i32 %58, i32* %loc2
+  br label %59
+
+; <label>:59                                      ; preds = %41, %56
+  %60 = load i32, i32* %loc2
+  %61 = icmp slt i32 %60, 2147483647
+  br i1 %61, label %44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load i32, i32* %arg0
+  ret i32 %63
+
+ThrowNullRef:                                     ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
 Successfully read GenericEqualityComparer`1.GetHashCode
 
@@ -3694,14 +4558,14 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
   %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load i64, i64 addrspace(1)* %7
@@ -3720,7 +4584,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3750,8 +4614,8 @@ entry:
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
@@ -3796,8 +4660,8 @@ entry:
   %35 = bitcast i16* %34 to i8*
   %36 = getelementptr inbounds i8, i8* %35, i64 2
   %37 = bitcast i8* %36 to i16*
-  %NullCheck4 = icmp ne i16* %37, null
-  br i1 %NullCheck4, label %38, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %37, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %38
 
 ; <label>:38                                      ; preds = %27
   %39 = load i16, i16* %37, align 8
@@ -3824,8 +4688,8 @@ entry:
 
 ; <label>:54                                      ; preds = %22, %43
   %55 = load i16*, i16** %loc4
-  %NullCheck2 = icmp ne i16* %55, null
-  br i1 %NullCheck2, label %56, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i16* %55, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %56
 
 ; <label>:56                                      ; preds = %54
   %57 = load i16, i16* %55, align 8
@@ -3850,11 +4714,11 @@ ThrowNullRef:                                     ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %54
+ThrowNullRef2:                                    ; preds = %54
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %27
+ThrowNullRef4:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3871,8 +4735,8 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -3907,8 +4771,8 @@ entry:
 
 ; <label>:26                                      ; preds = %19
   %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
-  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %28
 
 ; <label>:28                                      ; preds = %26
   %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
@@ -3920,7 +4784,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3972,8 +4836,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
@@ -3984,26 +4848,26 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
-  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
@@ -4014,8 +4878,8 @@ entry:
 ; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
@@ -4024,8 +4888,8 @@ entry:
 
 ; <label>:25                                      ; preds = %1, %16, %23
   %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
-  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
@@ -4036,27 +4900,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %20
+ThrowNullRef10:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4069,8 +4933,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -4081,8 +4945,8 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
@@ -4091,8 +4955,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1, %8
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
@@ -4103,11 +4967,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4128,24 +4992,24 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   store i32 %3, i32* %loc0
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
   %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
   store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck4, label %9, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
@@ -4164,15 +5028,15 @@ entry:
 ; <label>:18                                      ; preds = %70
   %19 = load i16*, i16** %loc3
   %20 = bitcast i16* %19 to i64*
-  %NullCheck10 = icmp ne i64* %20, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %20, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = load i64, i64* %20, align 8
   %23 = load i16*, i16** %loc4
   %24 = bitcast i16* %23 to i64*
-  %NullCheck12 = icmp ne i64* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = load i64, i64* %24, align 8
@@ -4188,8 +5052,8 @@ entry:
   %31 = bitcast i16* %30 to i8*
   %32 = getelementptr inbounds i8, i8* %31, i64 8
   %33 = bitcast i8* %32 to i64*
-  %NullCheck14 = icmp ne i64* %33, null
-  br i1 %NullCheck14, label %34, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = load i64, i64* %33, align 8
@@ -4197,8 +5061,8 @@ entry:
   %37 = bitcast i16* %36 to i8*
   %38 = getelementptr inbounds i8, i8* %37, i64 8
   %39 = bitcast i8* %38 to i64*
-  %NullCheck16 = icmp ne i64* %39, null
-  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %40
 
 ; <label>:40                                      ; preds = %34
   %41 = load i64, i64* %39, align 8
@@ -4214,8 +5078,8 @@ entry:
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %NullCheck18 = icmp ne i64* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = load i64, i64* %48, align 8
@@ -4223,8 +5087,8 @@ entry:
   %52 = bitcast i16* %51 to i8*
   %53 = getelementptr inbounds i8, i8* %52, i64 16
   %54 = bitcast i8* %53 to i64*
-  %NullCheck20 = icmp ne i64* %54, null
-  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64* %54, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %55
 
 ; <label>:55                                      ; preds = %49
   %56 = load i64, i64* %54, align 8
@@ -4262,15 +5126,15 @@ entry:
 ; <label>:74                                      ; preds = %95
   %75 = load i16*, i16** %loc3
   %76 = bitcast i16* %75 to i32*
-  %NullCheck6 = icmp ne i32* %76, null
-  br i1 %NullCheck6, label %77, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32* %76, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %77
 
 ; <label>:77                                      ; preds = %74
   %78 = load i32, i32* %76, align 8
   %79 = load i16*, i16** %loc4
   %80 = bitcast i16* %79 to i32*
-  %NullCheck8 = icmp ne i32* %80, null
-  br i1 %NullCheck8, label %81, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i32* %80, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %81
 
 ; <label>:81                                      ; preds = %77
   %82 = load i32, i32* %80, align 8
@@ -4318,43 +5182,43 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %74
+ThrowNullRef6:                                    ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %77
+ThrowNullRef8:                                    ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %29
+ThrowNullRef14:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %34
+ThrowNullRef16:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4376,8 +5240,8 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load i64, i64 addrspace(1)* %4
@@ -4389,8 +5253,8 @@ entry:
   %12 = load i64, i64* %11
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %5
   %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
@@ -4399,8 +5263,8 @@ entry:
   %18 = load i8, i8* %arg2
   %19 = zext i8 %18 to i32
   %20 = trunc i32 %19 to i8
-  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %15
   %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
@@ -4411,11 +5275,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4442,8 +5306,8 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
@@ -4466,16 +5330,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
   %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = load i64, i64 addrspace(1)* %19
@@ -4500,8 +5364,8 @@ entry:
 ; <label>:35                                      ; preds = %30
   %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
@@ -4514,8 +5378,8 @@ entry:
 
 ; <label>:42                                      ; preds = %1, %38
   %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
-  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
@@ -4526,19 +5390,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %35
+ThrowNullRef2:                                    ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %42
+ThrowNullRef8:                                    ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4551,14 +5415,14 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
@@ -4570,7 +5434,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4583,8 +5447,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
@@ -4613,51 +5477,51 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
   %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
   %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
   %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
   %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
-  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
   store i64 %21, i64 addrspace(1)* %23
   %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %25 = load i64, i64* %loc0
-  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
@@ -4668,27 +5532,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %22
+ThrowNullRef12:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4701,8 +5565,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
@@ -4713,19 +5577,19 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
@@ -4734,8 +5598,8 @@ entry:
 
 ; <label>:15                                      ; preds = %1, %13
   %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
@@ -4746,19 +5610,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %15
+ThrowNullRef8:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4771,8 +5635,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -4831,8 +5695,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
@@ -4882,8 +5746,8 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
-  br i1 %NullCheck, label %17, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %ThrowNullRef, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
@@ -4894,15 +5758,15 @@ entry:
 
 ; <label>:22                                      ; preds = %17
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
-  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
   %26 = load i32, i32 addrspace(1)* %25
   %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
-  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %27, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
@@ -4925,8 +5789,8 @@ entry:
 ; <label>:40                                      ; preds = %17
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
-  br i1 %NullCheck6, label %43, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %41, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
@@ -4938,34 +5802,17 @@ ThrowNullRef:                                     ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %24
+ThrowNullRef4:                                    ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %40
+ThrowNullRef6:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
-}
-
-INFO:  jitting method Object::ReferenceEquals using LLILCJit
-Successfully read Object.ReferenceEquals
-
-define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
-entry:
-  %arg0 = alloca %System.Object addrspace(1)*
-  %arg1 = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
-  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
-  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = icmp eq %System.Object addrspace(1)* %0, %1
-  %3 = sext i1 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
 }
 
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
@@ -4978,21 +5825,21 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
   %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
-  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
@@ -5007,28 +5854,28 @@ entry:
 ; <label>:13                                      ; preds = %8, %12
   %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
   %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
   %21 = load i32, i32 addrspace(1)* %20, align 8
   %22 = add i32 %21, 1
-  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
   store i32 %22, i32 addrspace(1)* %24
   %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
@@ -5039,27 +5886,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5077,7 +5924,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::Setup using LLILCJit
-Failed to read AppDomain.Setup[loadElem]
+Failed to read AppDomain.Setup[unbox]
 INFO:  jitting method Thread::GetDomain using LLILCJit
 Successfully read Thread.GetDomain
 
@@ -5108,8 +5955,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
@@ -5122,14 +5969,14 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
   %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
@@ -5141,11 +5988,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5173,8 +6020,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -5189,7 +6036,328 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
 Failed to read KeyCollection.System.Collections.Generic.IEnumerable<TKey>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Successfully read Enumerator.MoveNext
+
+define i8 @Enumerator.MoveNext(%"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.RuntimeTypeHandle* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*
+  %"$TypeArg" = alloca %System.RuntimeTypeHandle*
+  store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
+  %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 8
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %76, label %12
+
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
+  br label %76
+
+; <label>:13                                      ; preds = %85
+  %14 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck19 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %15
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, i32 0, i32 0
+  %17 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %16, align 8
+  %NullCheck21 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, i32 0, i32 2
+  %20 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %19, align 8
+  %21 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck23 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %22
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, i32 0, i32 2
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %NullCheck25 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 3, i32 %24
+  %NullCheck27 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %32
+
+; <label>:32                                      ; preds = %30
+  %33 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, i32 0, i32 2
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = icmp slt i32 %34, 0
+  br i1 %35, label %68, label %36
+
+; <label>:36                                      ; preds = %32
+  %37 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %38 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck29 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %39
+
+; <label>:39                                      ; preds = %36
+  %40 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, i32 0, i32 0
+  %41 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %40, align 8
+  %NullCheck31 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, i32 0, i32 2
+  %44 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %43, align 8
+  %45 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck33 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, i32 0, i32 2
+  %48 = load i32, i32 addrspace(1)* %47, align 8
+  %NullCheck35 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %49
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = zext i32 %51 to i64
+  %53 = zext i32 %48 to i64
+  %BoundsCheck37 = icmp uge i64 %53, %52
+  br i1 %BoundsCheck37, label %ThrowIndexOutOfRange38, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 3, i32 %48
+  %NullCheck39 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %56
+
+; <label>:56                                      ; preds = %54
+  %57 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, i32 0, i32 0
+  %58 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck41 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %59
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %60, %System.__Canon addrspace(1)* %58)
+  %61 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck43 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  %64 = load i32, i32 addrspace(1)* %63, align 8
+  %65 = add i32 %64, 1
+  %NullCheck45 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  store i32 %65, i32 addrspace(1)* %67
+  ret i8 1
+
+; <label>:68                                      ; preds = %32
+  %69 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck47 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %73 = add i32 %72, 1
+  %NullCheck49 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %74
+
+; <label>:74                                      ; preds = %70
+  %75 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  store i32 %73, i32 addrspace(1)* %75
+  br label %76
+
+; <label>:76                                      ; preds = %8, %12, %74
+  %77 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %78
+
+; <label>:78                                      ; preds = %76
+  %79 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, i32 0, i32 2
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck7 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %82
+
+; <label>:82                                      ; preds = %78
+  %83 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, i32 0, i32 0
+  %84 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %83, align 8
+  %NullCheck9 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %85
+
+; <label>:85                                      ; preds = %82
+  %86 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, i32 0, i32 7
+  %87 = load i32, i32 addrspace(1)* %86, align 8
+  %88 = icmp ult i32 %80, %87
+  br i1 %88, label %13, label %89
+
+; <label>:89                                      ; preds = %85
+  %90 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %91 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck11 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %92
+
+; <label>:92                                      ; preds = %89
+  %93 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, i32 0, i32 0
+  %94 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck13 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %95
+
+; <label>:95                                      ; preds = %92
+  %96 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, i32 0, i32 7
+  %97 = load i32, i32 addrspace(1)* %96, align 8
+  %98 = add i32 %97, 1
+  %NullCheck15 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %99
+
+; <label>:99                                      ; preds = %95
+  %100 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, i32 0, i32 2
+  store i32 %98, i32 addrspace(1)* %100
+  %101 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck17 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %102
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %103, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %92
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef22:                                   ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef24:                                   ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef26:                                   ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef28:                                   ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef30:                                   ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef32:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef34:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef36:                                   ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange38:                           ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef40:                                   ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef42:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef44:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef46:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef48:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef50:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -5200,8 +6368,8 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -5232,9 +6400,9 @@ Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
 Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
-Failed to read String.MakeSeparatorList[loadElemA]
+Failed to read String.MakeSeparatorList[storeElem]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
-Failed to read String.InternalSplitKeepEmptyEntries[loadElem]
+Failed to read String.InternalSplitKeepEmptyEntries[storeElem]
 INFO:  jitting method Path::IsRelative using LLILCJit
 Successfully read Path.IsRelative
 
@@ -5243,8 +6411,8 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -5254,8 +6422,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
@@ -5271,8 +6439,8 @@ entry:
 
 ; <label>:17                                      ; preds = %7
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
@@ -5288,8 +6456,8 @@ entry:
 
 ; <label>:29                                      ; preds = %19
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %31
 
 ; <label>:31                                      ; preds = %29
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
@@ -5300,8 +6468,8 @@ entry:
 
 ; <label>:36                                      ; preds = %31
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
-  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %37, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
@@ -5312,8 +6480,8 @@ entry:
 
 ; <label>:43                                      ; preds = %31, %38
   %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
-  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %45
 
 ; <label>:45                                      ; preds = %43
   %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
@@ -5324,8 +6492,8 @@ entry:
 
 ; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %50
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
@@ -5336,8 +6504,8 @@ entry:
 
 ; <label>:57                                      ; preds = %1, %7, %19, %45, %52
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
-  br i1 %NullCheck14, label %59, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %59
 
 ; <label>:59                                      ; preds = %57
   %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
@@ -5347,8 +6515,8 @@ entry:
 
 ; <label>:63                                      ; preds = %59
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
@@ -5359,8 +6527,8 @@ entry:
 
 ; <label>:70                                      ; preds = %65
   %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
-  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.String addrspace(1)* %71, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %72
 
 ; <label>:72                                      ; preds = %70
   %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
@@ -5379,39 +6547,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %17
+ThrowNullRef4:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %29
+ThrowNullRef6:                                    ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %36
+ThrowNullRef8:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %43
+ThrowNullRef10:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %50
+ThrowNullRef12:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %57
+ThrowNullRef14:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %63
+ThrowNullRef16:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %70
+ThrowNullRef18:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5419,7 +6587,293 @@ ThrowNullRef17:                                   ; preds = %70
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
-Failed to read String.TrimHelper[loadElem]
+Successfully read String.TrimHelper
+
+define %System.String addrspace(1)* @String.TrimHelper(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i16
+  %loc4 = alloca i32
+  %loc5 = alloca i16
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = sub i32 %3, 1
+  store i32 %4, i32* %loc0
+  store i32 0, i32* %loc1
+  %5 = load i32, i32* %arg2
+  %6 = icmp eq i32 %5, 1
+  br i1 %6, label %62, label %7
+
+; <label>:7                                       ; preds = %1
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:8                                       ; preds = %58
+  store i32 0, i32* %loc2
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load i32, i32* %loc1
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2, i32 %10
+  %13 = load i16, i16 addrspace(1)* %12
+  %14 = zext i16 %13 to i32
+  %15 = trunc i32 %14 to i16
+  store i16 %15, i16* %loc3
+  store i32 0, i32* %loc2
+  br label %34
+
+; <label>:16                                      ; preds = %37
+  %17 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %18 = load i32, i32* %loc2
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %17, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %19
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = zext i32 %18 to i64
+  %BoundsCheck = icmp uge i64 %23, %22
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %24
+
+; <label>:24                                      ; preds = %19
+  %25 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 3, i32 %18
+  %26 = load i16, i16 addrspace(1)* %25, align 8
+  %27 = zext i16 %26 to i32
+  %28 = load i16, i16* %loc3
+  %29 = zext i16 %28 to i32
+  %30 = icmp eq i32 %27, %29
+  br i1 %30, label %43, label %31
+
+; <label>:31                                      ; preds = %24
+  %32 = load i32, i32* %loc2
+  %33 = add i32 %32, 1
+  store i32 %33, i32* %loc2
+  br label %34
+
+; <label>:34                                      ; preds = %11, %31
+  %35 = load i32, i32* %loc2
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = icmp slt i32 %35, %41
+  br i1 %42, label %16, label %43
+
+; <label>:43                                      ; preds = %24, %37
+  %44 = load i32, i32* %loc2
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %45, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp eq i32 %44, %50
+  br i1 %51, label %62, label %52
+
+; <label>:52                                      ; preds = %46
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %7, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %57, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %58
+
+; <label>:58                                      ; preds = %55
+  %59 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %60 = load i32, i32 addrspace(1)* %59
+  %61 = icmp slt i32 %56, %60
+  br i1 %61, label %8, label %62
+
+; <label>:62                                      ; preds = %1, %46, %58
+  %63 = load i32, i32* %arg2
+  %64 = icmp eq i32 %63, 0
+  br i1 %64, label %122, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %66, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %67
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %66, i32 0, i32 1
+  %69 = load i32, i32 addrspace(1)* %68
+  %70 = sub i32 %69, 1
+  store i32 %70, i32* %loc0
+  br label %118
+
+; <label>:71                                      ; preds = %118
+  store i32 0, i32* %loc4
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %73 = load i32, i32* %loc0
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %74
+
+; <label>:74                                      ; preds = %71
+  %75 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 2, i32 %73
+  %76 = load i16, i16 addrspace(1)* %75
+  %77 = zext i16 %76 to i32
+  %78 = trunc i32 %77 to i16
+  store i16 %78, i16* %loc5
+  store i32 0, i32* %loc4
+  br label %97
+
+; <label>:79                                      ; preds = %100
+  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %81 = load i32, i32* %loc4
+  %NullCheck19 = icmp eq %"System.Char[]" addrspace(1)* %80, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
+
+; <label>:82                                      ; preds = %79
+  %83 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 1
+  %84 = load i32, i32 addrspace(1)* %83
+  %85 = zext i32 %84 to i64
+  %86 = zext i32 %81 to i64
+  %BoundsCheck21 = icmp uge i64 %86, %85
+  br i1 %BoundsCheck21, label %ThrowIndexOutOfRange22, label %87
+
+; <label>:87                                      ; preds = %82
+  %88 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 3, i32 %81
+  %89 = load i16, i16 addrspace(1)* %88, align 8
+  %90 = zext i16 %89 to i32
+  %91 = load i16, i16* %loc5
+  %92 = zext i16 %91 to i32
+  %93 = icmp eq i32 %90, %92
+  br i1 %93, label %106, label %94
+
+; <label>:94                                      ; preds = %87
+  %95 = load i32, i32* %loc4
+  %96 = add i32 %95, 1
+  store i32 %96, i32* %loc4
+  br label %97
+
+; <label>:97                                      ; preds = %74, %94
+  %98 = load i32, i32* %loc4
+  %99 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck15 = icmp eq %"System.Char[]" addrspace(1)* %99, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %100
+
+; <label>:100                                     ; preds = %97
+  %101 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %99, i32 0, i32 1
+  %102 = load i32, i32 addrspace(1)* %101
+  %103 = zext i32 %102 to i64
+  %104 = trunc i64 %103 to i32
+  %105 = icmp slt i32 %98, %104
+  br i1 %105, label %79, label %106
+
+; <label>:106                                     ; preds = %87, %100
+  %107 = load i32, i32* %loc4
+  %108 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck17 = icmp eq %"System.Char[]" addrspace(1)* %108, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %109
+
+; <label>:109                                     ; preds = %106
+  %110 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %108, i32 0, i32 1
+  %111 = load i32, i32 addrspace(1)* %110
+  %112 = zext i32 %111 to i64
+  %113 = trunc i64 %112 to i32
+  %114 = icmp eq i32 %107, %113
+  br i1 %114, label %122, label %115
+
+; <label>:115                                     ; preds = %109
+  %116 = load i32, i32* %loc0
+  %117 = sub i32 %116, 1
+  store i32 %117, i32* %loc0
+  br label %118
+
+; <label>:118                                     ; preds = %67, %115
+  %119 = load i32, i32* %loc0
+  %120 = load i32, i32* %loc1
+  %121 = icmp sge i32 %119, %120
+  br i1 %121, label %71, label %122
+
+; <label>:122                                     ; preds = %62, %109, %118
+  %123 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %124 = load i32, i32* %loc1
+  %125 = load i32, i32* %loc0
+  %126 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %123, i32 %124, i32 %125)
+  ret %System.String addrspace(1)* %126
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %97
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange22:                           ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
 Successfully read String.CreateTrimmedString
 
@@ -5439,8 +6893,8 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
@@ -5535,8 +6989,8 @@ entry:
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i64 2872
   %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
   %8 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %7
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %3
   %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
@@ -5553,8 +7007,8 @@ entry:
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 2864
   %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
   %21 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %20
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
-  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %22
 
 ; <label>:22                                      ; preds = %16
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
@@ -5569,7 +7023,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %16
+ThrowNullRef2:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5586,8 +7040,8 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5613,8 +7067,8 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
@@ -5632,8 +7086,8 @@ entry:
 
 ; <label>:12                                      ; preds = %4
   %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
@@ -5644,8 +7098,8 @@ entry:
 
 ; <label>:19                                      ; preds = %14
   %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %19
   %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
@@ -5660,21 +7114,21 @@ entry:
   %31 = zext i16 %30 to i32
   %32 = bitcast i8* %29 to i16*
   %33 = trunc i32 %31 to i16
-  %NullCheck6 = icmp ne i16* %32, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i16* %32, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %21
   store i16 %33, i16* %32, align 8
   %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %36
 
 ; <label>:36                                      ; preds = %34
   %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
   %38 = load i32, i32 addrspace(1)* %37, align 8
   %39 = add i32 %38, 1
-  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %40
 
 ; <label>:40                                      ; preds = %36
   %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
@@ -5683,16 +7137,16 @@ entry:
 
 ; <label>:42                                      ; preds = %14
   %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
-  br i1 %NullCheck12, label %44, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
   %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
   %47 = load i16, i16* %arg1
   %48 = zext i16 %47 to i32
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = trunc i32 %48 to i16
@@ -5703,31 +7157,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %19
+ThrowNullRef4:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %21
+ThrowNullRef6:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %36
+ThrowNullRef10:                                   ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %42
+ThrowNullRef12:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %44
+ThrowNullRef14:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5740,8 +7194,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -5752,8 +7206,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
@@ -5762,14 +7216,14 @@ entry:
 
 ; <label>:11                                      ; preds = %1
   %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
@@ -5779,15 +7233,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5808,8 +7262,8 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5822,8 +7276,8 @@ entry:
 
 ; <label>:8                                       ; preds = %3
   %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
@@ -5842,15 +7296,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
-  br i1 %NullCheck4, label %22, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
   %24 = load i16*, i16* addrspace(1)* %23, align 8
   %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %25, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
@@ -5859,8 +7313,8 @@ entry:
   store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
@@ -5874,8 +7328,8 @@ entry:
 
 ; <label>:37                                      ; preds = %65
   %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %37
   %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
@@ -5886,16 +7340,16 @@ entry:
   %45 = bitcast i16* %41 to i8*
   %46 = getelementptr inbounds i8, i8* %45, i64 %44
   %47 = bitcast i8* %46 to i16*
-  %NullCheck14 = icmp ne i16* %47, null
-  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %47, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %48
 
 ; <label>:48                                      ; preds = %39
   %49 = load i16, i16* %47, align 8
   %50 = zext i16 %49 to i32
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %52 = load i32, i32* %loc1
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %53
 
 ; <label>:53                                      ; preds = %48
   %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
@@ -5916,8 +7370,8 @@ entry:
 ; <label>:62                                      ; preds = %36, %59
   %63 = load i32, i32* %loc1
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck10, label %65, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %65
 
 ; <label>:65                                      ; preds = %62
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
@@ -5936,15 +7390,15 @@ entry:
 
 ; <label>:74                                      ; preds = %70
   %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
-  br i1 %NullCheck18, label %76, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %76
 
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
   %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
-  br i1 %NullCheck20, label %80, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
   %81 = load i64, i64 addrspace(1)* %79
@@ -5958,8 +7412,8 @@ entry:
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
   %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
-  br i1 %NullCheck22, label %92, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.String addrspace(1)* %90, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %92
 
 ; <label>:92                                      ; preds = %80
   %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
@@ -5969,15 +7423,15 @@ entry:
 
 ; <label>:96                                      ; preds = %70
   %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
-  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %98
 
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
   %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
-  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
   %103 = load i64, i64 addrspace(1)* %101
@@ -5991,8 +7445,8 @@ entry:
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
   %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
-  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.String addrspace(1)* %112, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %114
 
 ; <label>:114                                     ; preds = %102
   %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
@@ -6004,59 +7458,59 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %20
+ThrowNullRef4:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %22
+ThrowNullRef6:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %26
+ThrowNullRef8:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %62
+ThrowNullRef10:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %48
+ThrowNullRef16:                                   ; preds = %48
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %74
+ThrowNullRef18:                                   ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %76
+ThrowNullRef20:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %80
+ThrowNullRef22:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %96
+ThrowNullRef24:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %98
+ThrowNullRef26:                                   ; preds = %98
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %102
+ThrowNullRef28:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6069,15 +7523,15 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
   %3 = load i16*, i16* addrspace(1)* %2, align 8
   %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
@@ -6087,8 +7541,8 @@ entry:
   %10 = bitcast i16* %3 to i8*
   %11 = getelementptr inbounds i8, i8* %10, i64 %9
   %12 = bitcast i8* %11 to i16*
-  %NullCheck4 = icmp ne i16* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %5
   store i16 0, i16* %12, align 8
@@ -6098,11 +7552,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6119,8 +7573,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -6131,8 +7585,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
@@ -6144,15 +7598,15 @@ entry:
 
 ; <label>:14                                      ; preds = %1
   %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
   %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
   %21 = load i64, i64 addrspace(1)* %19
@@ -6171,15 +7625,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %14
+ThrowNullRef4:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %16
+ThrowNullRef6:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6302,14 +7756,6 @@ entry:
   ret %System.String addrspace(1)* %57
 }
 
-INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
-Successfully read RuntimeHelpers.get_OffsetToStringData
-
-define i32 @RuntimeHelpers.get_OffsetToStringData() {
-entry:
-  ret i32 12
-}
-
 INFO:  jitting method String::Equals using LLILCJit
 Successfully read String.Equals
 
@@ -6381,8 +7827,8 @@ entry:
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
-  br i1 %NullCheck24, label %29, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
   %30 = load i64, i64 addrspace(1)* %28
@@ -6397,8 +7843,8 @@ entry:
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
-  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
   %43 = load i64, i64 addrspace(1)* %41
@@ -6418,8 +7864,8 @@ entry:
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
   %59 = load i64, i64 addrspace(1)* %57
@@ -6434,8 +7880,8 @@ entry:
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck22, label %71, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
   %72 = load i64, i64 addrspace(1)* %70
@@ -6455,8 +7901,8 @@ entry:
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
-  br i1 %NullCheck16, label %87, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = load i64, i64 addrspace(1)* %86
@@ -6471,8 +7917,8 @@ entry:
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck18, label %100, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
   %101 = load i64, i64 addrspace(1)* %99
@@ -6492,8 +7938,8 @@ entry:
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
-  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
   %117 = load i64, i64 addrspace(1)* %115
@@ -6508,8 +7954,8 @@ entry:
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
-  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
   %130 = load i64, i64 addrspace(1)* %128
@@ -6528,15 +7974,15 @@ entry:
 
 ; <label>:142                                     ; preds = %22
   %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
-  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %143, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %144
 
 ; <label>:144                                     ; preds = %142
   %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
   %146 = load i32, i32 addrspace(1)* %145
   %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
-  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %147, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %148
 
 ; <label>:148                                     ; preds = %144
   %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
@@ -6557,15 +8003,15 @@ entry:
 
 ; <label>:159                                     ; preds = %22
   %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
-  br i1 %NullCheck, label %161, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %ThrowNullRef, label %161
 
 ; <label>:161                                     ; preds = %159
   %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
   %163 = load i32, i32 addrspace(1)* %162
   %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
-  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %164, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %165
 
 ; <label>:165                                     ; preds = %161
   %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
@@ -6578,8 +8024,8 @@ entry:
 
 ; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
-  br i1 %NullCheck4, label %172, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %171, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %172
 
 ; <label>:172                                     ; preds = %170
   %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
@@ -6589,8 +8035,8 @@ entry:
 
 ; <label>:176                                     ; preds = %172
   %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
-  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %177, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %178
 
 ; <label>:178                                     ; preds = %176
   %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
@@ -6629,55 +8075,55 @@ ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %161
+ThrowNullRef2:                                    ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %170
+ThrowNullRef4:                                    ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %176
+ThrowNullRef6:                                    ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %142
+ThrowNullRef8:                                    ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %144
+ThrowNullRef10:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %113
+ThrowNullRef12:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %116
+ThrowNullRef14:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %84
+ThrowNullRef16:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %87
+ThrowNullRef18:                                   ; preds = %87
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %55
+ThrowNullRef20:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %58
+ThrowNullRef22:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %26
+ThrowNullRef24:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %29
+ThrowNullRef26:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,8 +8161,8 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck, label %14, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %ThrowNullRef, label %14
 
 ; <label>:14                                      ; preds = %8
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
@@ -6760,8 +8206,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
@@ -6770,14 +8216,14 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32, i32* %loc0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %10
   %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
   %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
@@ -6790,15 +8236,15 @@ entry:
 ; <label>:25                                      ; preds = %19
   %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
-  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
   %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
@@ -6807,8 +8253,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %37 = load i32, i32* %loc0
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %38, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %38
 
 ; <label>:38                                      ; preds = %32
   %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
@@ -6817,14 +8263,14 @@ entry:
 
 ; <label>:40                                      ; preds = %19
   %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %40
   %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
   %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
-  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
-  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
@@ -6832,8 +8278,8 @@ entry:
   %48 = zext i32 %47 to i64
   %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
-  br i1 %NullCheck16, label %51, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %51
 
 ; <label>:51                                      ; preds = %45
   %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
@@ -6847,15 +8293,15 @@ entry:
 ; <label>:57                                      ; preds = %51
   %58 = load i16*, i16** %arg1
   %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
-  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %60
 
 ; <label>:60                                      ; preds = %57
   %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
   %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
-  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %64
 
 ; <label>:64                                      ; preds = %60
   %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
@@ -6864,22 +8310,22 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
   %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
-  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %70
 
 ; <label>:70                                      ; preds = %64
   %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
   %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
-  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
-  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
   %75 = load i32, i32 addrspace(1)* %74
   %76 = zext i32 %75 to i64
   %77 = trunc i64 %76 to i32
-  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
-  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %78
 
 ; <label>:78                                      ; preds = %73
   %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
@@ -6901,8 +8347,8 @@ entry:
   %90 = bitcast i16* %86 to i8*
   %91 = getelementptr inbounds i8, i8* %90, i64 %89
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %93
 
 ; <label>:93                                      ; preds = %80
   %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
@@ -6912,8 +8358,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %99 = load i32, i32* %loc2
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %100
 
 ; <label>:100                                     ; preds = %93
   %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
@@ -6928,63 +8374,63 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %25
+ThrowNullRef6:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %32
+ThrowNullRef10:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %40
+ThrowNullRef12:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %45
+ThrowNullRef16:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %57
+ThrowNullRef18:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %60
+ThrowNullRef20:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %64
+ThrowNullRef22:                                   ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %70
+ThrowNullRef24:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %73
+ThrowNullRef26:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %80
+ThrowNullRef28:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %93
+ThrowNullRef30:                                   ; preds = %93
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7004,8 +8450,8 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
@@ -7033,43 +8479,43 @@ entry:
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %14
   %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
   %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   %28 = load i32, i32 addrspace(1)* %27, align 8
   %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
-  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %30
 
 ; <label>:30                                      ; preds = %26
   %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
   %32 = load i32, i32 addrspace(1)* %31, align 8
   %33 = add i32 %28, %32
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %34
 
 ; <label>:34                                      ; preds = %30
   %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   store i32 %33, i32 addrspace(1)* %35
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
   store i32 0, i32 addrspace(1)* %38
   %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %40
 
 ; <label>:40                                      ; preds = %37
   %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
@@ -7082,8 +8528,8 @@ entry:
 
 ; <label>:47                                      ; preds = %40
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
@@ -7098,8 +8544,8 @@ entry:
   %54 = load i32, i32* %loc0
   %55 = sext i32 %54 to i64
   %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
-  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %57
 
 ; <label>:57                                      ; preds = %52
   %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
@@ -7110,68 +8556,35 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %14
+ThrowNullRef2:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %23
+ThrowNullRef4:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %26
+ThrowNullRef6:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %30
+ThrowNullRef8:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %34
+ThrowNullRef10:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %47
+ThrowNullRef14:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %52
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-}
-
-INFO:  jitting method StringBuilder::get_Length using LLILCJit
-Successfully read StringBuilder.get_Length
-
-define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.StringBuilder addrspace(1)*
-  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
-  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
-
-; <label>:1                                       ; preds = %entry
-  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %3 = load i32, i32 addrspace(1)* %2, align 8
-  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
-
-; <label>:5                                       ; preds = %1
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = add i32 %3, %7
-  ret i32 %8
-
-ThrowNullRef:                                     ; preds = %entry
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef16:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7213,70 +8626,70 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
   %6 = load i32, i32 addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
   store i32 %6, i32 addrspace(1)* %8
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
   %13 = load i32, i32 addrspace(1)* %12, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
   store i32 %13, i32 addrspace(1)* %15
   %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
-  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %18
 
 ; <label>:18                                      ; preds = %14
   %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
   %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
   %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
   %34 = load i32, i32 addrspace(1)* %33, align 8
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
-  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
@@ -7287,39 +8700,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %28
+ThrowNullRef16:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %32
+ThrowNullRef18:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7455,13 +8868,13 @@ entry:
 ; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
@@ -7477,16 +8890,16 @@ entry:
 
 ; <label>:18                                      ; preds = %15
   %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
   store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
   %22 = load i32, i32* %loc0
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %24
 
 ; <label>:24                                      ; preds = %20
   %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
@@ -7498,13 +8911,13 @@ entry:
 ; <label>:28                                      ; preds = %15, %24
   %29 = load i32, i32* %arg1
   %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %31
   %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
@@ -7517,20 +8930,20 @@ entry:
   %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
-  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
   %46 = load i32, i32 addrspace(1)* %45, align 8
   %47 = sub i32 %40, %46
-  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
-  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i32 addrspace(1)* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %48
 
 ; <label>:48                                      ; preds = %44
   store i32 %47, i32 addrspace(1)* %39, align 8
@@ -7538,21 +8951,21 @@ entry:
 
 ; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
-  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %51
 
 ; <label>:51                                      ; preds = %49
   %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %53
 
 ; <label>:53                                      ; preds = %51
   %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
   %55 = load i32, i32 addrspace(1)* %54, align 8
   %56 = load i32, i32* %arg2
   %57 = sub i32 %55, %56
-  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %58
 
 ; <label>:58                                      ; preds = %53
   %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
@@ -7562,13 +8975,13 @@ entry:
 ; <label>:60                                      ; preds = %33, %58
   %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
   %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
-  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %63
 
 ; <label>:63                                      ; preds = %60
   %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
-  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
-  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
@@ -7578,15 +8991,15 @@ entry:
 
 ; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
-  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i32 addrspace(1)* %69, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %70
 
 ; <label>:70                                      ; preds = %68
   %71 = load i32, i32 addrspace(1)* %69, align 8
   store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
-  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
@@ -7596,8 +9009,8 @@ entry:
   store i32 %77, i32* %loc4
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
-  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %80
 
 ; <label>:80                                      ; preds = %73
   %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
@@ -7607,71 +9020,71 @@ entry:
 ; <label>:83                                      ; preds = %80
   store i32 0, i32* %loc3
   %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
-  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
-  br i1 %NullCheck26, label %88, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i32 addrspace(1)* %87, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %88
 
 ; <label>:88                                      ; preds = %85
   %89 = load i32, i32 addrspace(1)* %87, align 8
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
-  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %90
 
 ; <label>:90                                      ; preds = %88
   %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
   store i32 %89, i32 addrspace(1)* %91
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
-  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
-  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %96
 
 ; <label>:96                                      ; preds = %94
   %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
-  br i1 %NullCheck34, label %100, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %100
 
 ; <label>:100                                     ; preds = %96
   %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
-  br i1 %NullCheck36, label %102, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %102
 
 ; <label>:102                                     ; preds = %100
   %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
   %104 = load i32, i32 addrspace(1)* %103, align 8
   %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
-  br i1 %NullCheck38, label %106, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %106
 
 ; <label>:106                                     ; preds = %102
   %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
-  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
-  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %108
 
 ; <label>:108                                     ; preds = %106
   %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
   %110 = load i32, i32 addrspace(1)* %109, align 8
   %111 = add i32 %104, %110
-  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %112
 
 ; <label>:112                                     ; preds = %108
   %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
   store i32 %111, i32 addrspace(1)* %113
   %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
-  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i32 addrspace(1)* %114, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %115
 
 ; <label>:115                                     ; preds = %112
   %116 = load i32, i32 addrspace(1)* %114, align 8
@@ -7681,19 +9094,19 @@ entry:
 ; <label>:118                                     ; preds = %115
   %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
-  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %121
 
 ; <label>:121                                     ; preds = %118
   %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
-  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
-  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %123
 
 ; <label>:123                                     ; preds = %121
   %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
   %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
-  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
-  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %126
 
 ; <label>:126                                     ; preds = %123
   %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
@@ -7705,8 +9118,8 @@ entry:
 
 ; <label>:130                                     ; preds = %80, %115, %126
   %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %132
 
 ; <label>:132                                     ; preds = %130
   %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7715,8 +9128,8 @@ entry:
   %136 = load i32, i32* %loc3
   %137 = sub i32 %135, %136
   %138 = sub i32 %134, %137
-  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %139
 
 ; <label>:139                                     ; preds = %132
   %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7728,16 +9141,16 @@ entry:
 
 ; <label>:144                                     ; preds = %139
   %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
-  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %146
 
 ; <label>:146                                     ; preds = %144
   %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
   %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
   %149 = load i32, i32* %loc2
   %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
-  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %151
 
 ; <label>:151                                     ; preds = %146
   %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
@@ -7754,145 +9167,249 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %18
+ThrowNullRef4:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %31
+ThrowNullRef10:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %44
+ThrowNullRef16:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %68
+ThrowNullRef18:                                   ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %70
+ThrowNullRef20:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %73
+ThrowNullRef22:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %83
+ThrowNullRef24:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %85
+ThrowNullRef26:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %88
+ThrowNullRef28:                                   ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %90
+ThrowNullRef30:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %94
+ThrowNullRef32:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %96
+ThrowNullRef34:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %100
+ThrowNullRef36:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %102
+ThrowNullRef38:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %106
+ThrowNullRef40:                                   ; preds = %106
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %108
+ThrowNullRef42:                                   ; preds = %108
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %112
+ThrowNullRef44:                                   ; preds = %112
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %118
+ThrowNullRef46:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %121
+ThrowNullRef48:                                   ; preds = %121
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %123
+ThrowNullRef50:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %130
+ThrowNullRef52:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %132
+ThrowNullRef54:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %144
+ThrowNullRef56:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %146
+ThrowNullRef58:                                   ; preds = %146
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %60
+ThrowNullRef60:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %63
+ThrowNullRef62:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %49
+ThrowNullRef64:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %51
+ThrowNullRef66:                                   ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %53
+ThrowNullRef68:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(%"System.Char[]" addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %arg0 = alloca %"System.Char[]" addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store %"System.Char[]" addrspace(1)* %param0, %"System.Char[]" addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load i32, i32* %arg4
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %43, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %38, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg1
+  %13 = load i32, i32* %arg4
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %38, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %24 = load i32, i32* %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %35 = load i32, i32* %arg3
+  %36 = load i32, i32* %arg4
+  %37 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %37, %"System.Char[]" addrspace(1)* %34, i32 %35, i32 %36)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:38                                      ; preds = %5, %16
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Successfully read Buffer._Memmove
 
@@ -7914,7 +9431,7 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[loadElem]
+Failed to read AppDomain.SetDataHelper[storeElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -7923,8 +9440,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
@@ -7934,8 +9451,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
@@ -7947,15 +9464,15 @@ entry:
   %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
   %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
@@ -7966,15 +9483,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7992,7 +9509,79 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
-Failed to read Dictionary`2.TryGetValue[loadElemA]
+Successfully read Dictionary`2.TryGetValue
+
+define i8 @"Dictionary`2.TryGetValue"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)* addrspace(1)* %param2) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  %arg2 = alloca %System.__Canon addrspace(1)* addrspace(1)*
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  store %System.__Canon addrspace(1)* addrspace(1)* %param2, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  store i32 %2, i32* %loc0
+  %3 = load i32, i32* %loc0
+  %4 = icmp slt i32 %3, 0
+  br i1 %4, label %22, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 2
+  %10 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %9, align 8
+  %11 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = zext i32 %11 to i64
+  %BoundsCheck = icmp uge i64 %16, %15
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 3, i32 %11
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %20, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %6, %System.__Canon addrspace(1)* %21)
+  ret i8 1
+
+; <label>:22                                      ; preds = %entry
+  %23 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %23, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -8058,8 +9647,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
@@ -8091,8 +9680,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
@@ -8171,15 +9760,15 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck, label %19, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %ThrowNullRef, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
   %21 = load i32, i32 addrspace(1)* %20
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
@@ -8202,7 +9791,7 @@ ThrowNullRef:                                     ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %19
+ThrowNullRef2:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8248,8 +9837,8 @@ entry:
   %0 = alloca %System.AppDomainHandle
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %1 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %1, i32 0, i32 15
@@ -8269,8 +9858,8 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
@@ -8286,7 +9875,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -8299,8 +9888,8 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -8327,8 +9916,8 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
@@ -8352,8 +9941,8 @@ entry:
   %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
   store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
@@ -8363,8 +9952,8 @@ entry:
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
@@ -8374,8 +9963,8 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %9
   %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
@@ -8384,8 +9973,8 @@ entry:
 
 ; <label>:18                                      ; preds = %3, %16
   %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
@@ -8397,15 +9986,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %18
+ThrowNullRef6:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8418,8 +10007,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
@@ -8453,15 +10042,15 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
@@ -8473,7 +10062,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8481,7 +10070,7 @@ ThrowNullRef1:                                    ; preds = %1
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
 Failed to read Dictionary`2.System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
@@ -8506,8 +10095,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
@@ -8524,8 +10113,8 @@ entry:
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -8544,7 +10133,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8577,8 +10166,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = load i64, i64* %arg2
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = trunc i32 %3 to i8
@@ -8634,46 +10223,46 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
   %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
-  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
-  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
-  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
@@ -8684,27 +10273,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %20
+ThrowNullRef12:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8717,8 +10306,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -8756,22 +10345,22 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
   %9 = load i64, i64 addrspace(1)* %8, align 8
   %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
   %13 = load i64, i64 addrspace(1)* %12, align 8
   %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %11
   %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
@@ -8788,11 +10377,11 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8882,8 +10471,8 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
@@ -8900,8 +10489,8 @@ entry:
 ; <label>:8                                       ; preds = %1
   %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
   %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
@@ -8911,15 +10500,15 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
   %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
   %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
-  br i1 %NullCheck6, label %21, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
@@ -8946,15 +10535,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8992,15 +10581,15 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
   store i8 %3, i8 addrspace(1)* %5
   %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
@@ -9011,7 +10600,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9027,8 +10616,8 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -9041,8 +10630,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
@@ -9058,7 +10647,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9080,8 +10669,8 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
@@ -9096,8 +10685,8 @@ entry:
 ; <label>:12                                      ; preds = %6
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
@@ -9112,8 +10701,8 @@ entry:
 ; <label>:21                                      ; preds = %15
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
@@ -9128,8 +10717,8 @@ entry:
 ; <label>:30                                      ; preds = %24
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %31, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
@@ -9144,8 +10733,8 @@ entry:
 ; <label>:39                                      ; preds = %33
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
-  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %40, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %42
 
 ; <label>:42                                      ; preds = %39
   %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
@@ -9164,19 +10753,19 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %21
+ThrowNullRef4:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %30
+ThrowNullRef6:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %39
+ThrowNullRef8:                                    ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9243,8 +10832,8 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
@@ -9264,57 +10853,57 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
   store i8 0, i8 addrspace(1)* %2
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
   store i8 0, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
   store i8 0, i8 addrspace(1)* %17
   %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
   store i8 0, i8 addrspace(1)* %20
   %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
-  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
@@ -9325,31 +10914,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %19
+ThrowNullRef14:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9367,8 +10956,8 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
@@ -9380,8 +10969,8 @@ entry:
 
 ; <label>:9                                       ; preds = %4
   %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %9
   %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
@@ -9395,7 +10984,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef2:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9420,8 +11009,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
@@ -9512,8 +11101,8 @@ entry:
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
@@ -9524,8 +11113,8 @@ entry:
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = load i64, i64 addrspace(1)* %12
@@ -9537,8 +11126,8 @@ entry:
   %20 = load i64, i64* %19
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
-  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %13
   %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
@@ -9555,8 +11144,8 @@ entry:
 ; <label>:30                                      ; preds = %25
   %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %32 = load i32, i32* %arg2
-  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
-  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
@@ -9570,15 +11159,15 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %30
+ThrowNullRef2:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9622,87 +11211,87 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
   %10 = load i8, i8 addrspace(1)* %9, align 8
   %11 = zext i8 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %8
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
   store i8 %12, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
   %19 = load i8, i8 addrspace(1)* %18, align 8
   %20 = zext i8 %19 to i32
   %21 = trunc i32 %20 to i8
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
   store i8 %21, i8 addrspace(1)* %23
   %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
   %28 = load i8, i8 addrspace(1)* %27, align 8
   %29 = zext i8 %28 to i32
   %30 = trunc i32 %29 to i8
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
-  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %31
 
 ; <label>:31                                      ; preds = %26
   %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
   store i8 %30, i8 addrspace(1)* %32
   %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
-  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
-  br i1 %NullCheck14, label %40, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %40
 
 ; <label>:40                                      ; preds = %35
   %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
   store i8 %39, i8 addrspace(1)* %41
   %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
-  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %44
 
 ; <label>:44                                      ; preds = %40
   %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
   %46 = load i8, i8 addrspace(1)* %45, align 8
   %47 = zext i8 %46 to i32
   %48 = trunc i32 %47 to i8
-  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
   store i8 %48, i8 addrspace(1)* %50
   %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
-  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
@@ -9713,29 +11302,29 @@ entry:
 ; <label>:56                                      ; preds = %52
   %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
-  br i1 %NullCheck22, label %59, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
   %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
   %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
-  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
-  br i1 %NullCheck24, label %63, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
   %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
-  br i1 %NullCheck26, label %66, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
   %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
-  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
-  br i1 %NullCheck28, label %69, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %69
 
 ; <label>:69                                      ; preds = %66
   %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
@@ -9744,15 +11333,15 @@ entry:
 
 ; <label>:71                                      ; preds = %105
   %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
-  br i1 %NullCheck34, label %73, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %73
 
 ; <label>:73                                      ; preds = %71
   %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
   %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
   %76 = load i32, i32* %loc0
-  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
-  br i1 %NullCheck36, label %77, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
@@ -9766,8 +11355,8 @@ entry:
 
 ; <label>:83                                      ; preds = %77
   %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
-  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
@@ -9775,14 +11364,14 @@ entry:
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
   %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
-  br i1 %NullCheck40, label %91, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
 ; <label>:91                                      ; preds = %85
   %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
   %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
-  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck42, label %94, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %94
 
 ; <label>:94                                      ; preds = %91
   %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
@@ -9798,14 +11387,14 @@ entry:
 ; <label>:99                                      ; preds = %69, %96
   %100 = load i32, i32* %loc0
   %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
-  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %102
 
 ; <label>:102                                     ; preds = %99
   %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
   %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
-  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
-  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
@@ -9819,87 +11408,87 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %26
+ThrowNullRef10:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %31
+ThrowNullRef12:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %35
+ThrowNullRef14:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %40
+ThrowNullRef16:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %56
+ThrowNullRef22:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %59
+ThrowNullRef24:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %63
+ThrowNullRef26:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %66
+ThrowNullRef28:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %102
+ThrowNullRef32:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %71
+ThrowNullRef34:                                   ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %73
+ThrowNullRef36:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %83
+ThrowNullRef38:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %85
+ThrowNullRef40:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %91
+ThrowNullRef42:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9943,15 +11532,15 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
   %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
@@ -9961,28 +11550,28 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
   %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %12
   %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
   %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
   %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
-  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
@@ -9993,23 +11582,23 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %12
+ThrowNullRef6:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10031,15 +11620,15 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
   %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = load i64, i64 addrspace(1)* %7
@@ -10077,13 +11666,13 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[loadElem]
+Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -10111,8 +11700,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -10180,14 +11769,14 @@ entry:
   store i32 addrspace(1)* %param0, i32 addrspace(1)** %arg0
   %0 = load i32 addrspace(1)*, i32 addrspace(1)** %arg0
   %1 = load i32 addrspace(1)*, i32 addrspace(1)** %arg0
-  %NullCheck = icmp ne i32 addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq i32 addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load i32, i32 addrspace(1)* %1, align 8
   %4 = xor i32 %3, -1
-  %NullCheck2 = icmp ne i32 addrspace(1)* %0, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i32 addrspace(1)* %0, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %2
   store i32 %4, i32 addrspace(1)* %0, align 8
@@ -10197,7 +11786,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }

--- a/test/BaseLine/JIT/CodeGenBringUpTests/ObjAlloc.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/ObjAlloc.error.txt
@@ -25,8 +25,8 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
@@ -40,8 +40,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
   %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
@@ -75,7 +75,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -90,8 +90,8 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %NullCheck = icmp ne i8 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = load i8, i8 addrspace(1)* %0, align 8
@@ -125,8 +125,8 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
@@ -159,8 +159,8 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -184,8 +184,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
   store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
@@ -195,8 +195,8 @@ entry:
 ; <label>:4                                       ; preds = %1
   %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
   %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
@@ -206,8 +206,8 @@ entry:
   %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
@@ -221,14 +221,14 @@ entry:
 
 ; <label>:17                                      ; preds = %14
   %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
   %21 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
@@ -238,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -249,8 +249,8 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
@@ -261,27 +261,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %30
+ThrowNullRef10:                                   ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -301,7 +301,89 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
-Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
+Successfully read AppDomainSetup.GetUnsecureApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.GetUnsecureApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %NullCheck = icmp eq %"System.String[]" addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %BoundsCheck = icmp uge i64 0, %5
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %6
+
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 3, i32 0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
+  ret %System.String addrspace(1)* %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_Value using LLILCJit
+Successfully read AppDomainSetup.get_Value
+
+define %"System.String[]" addrspace(1)* @AppDomainSetup.get_Value(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.String[]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 18)
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.String[]" addrspace(1)* addrspace(1)*, %"System.String[]" addrspace(1)*)*)(%"System.String[]" addrspace(1)* addrspace(1)* %9, %"System.String[]" addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %11, i32 0, i32 1
+  %14 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %13, align 8
+  ret %"System.String[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -319,8 +401,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -368,16 +450,16 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
   %5 = load i32, i32 addrspace(1)* %4
   %6 = sub i32 %5, 1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -389,7 +471,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -421,8 +503,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
@@ -456,8 +538,8 @@ entry:
 ; <label>:27                                      ; preds = %19
   %28 = load i32, i32* %arg1
   %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
-  br i1 %NullCheck2, label %30, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %29, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %30
 
 ; <label>:30                                      ; preds = %27
   %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
@@ -493,8 +575,8 @@ entry:
 ; <label>:49                                      ; preds = %46
   %50 = load i32, i32* %arg2
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck4, label %52, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
@@ -517,11 +599,11 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %27
+ThrowNullRef2:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %49
+ThrowNullRef4:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -544,16 +626,16 @@ entry:
   %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %0)
   store %System.String addrspace(1)* %1, %System.String addrspace(1)** %loc0
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 2
   %5 = bitcast [0 x i16] addrspace(1)* %4 to i16 addrspace(1)*
   store i16 addrspace(1)* %5, i16 addrspace(1)** %loc1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %3
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2
@@ -580,7 +662,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -691,15 +773,15 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %NullCheck132 = icmp ne i8* %21, null
-  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+  %NullCheck131 = icmp eq i8* %21, null
+  br i1 %NullCheck131, label %ThrowNullRef132, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = load i8, i8* %21, align 8
   %24 = zext i8 %23 to i32
   %25 = trunc i32 %24 to i8
-  %NullCheck134 = icmp ne i8* %20, null
-  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+  %NullCheck133 = icmp eq i8* %20, null
+  br i1 %NullCheck133, label %ThrowNullRef134, label %26
 
 ; <label>:26                                      ; preds = %22
   store i8 %25, i8* %20, align 8
@@ -709,16 +791,16 @@ entry:
   %28 = load i8*, i8** %arg0
   %29 = load i8*, i8** %arg1
   %30 = bitcast i8* %29 to i16*
-  %NullCheck128 = icmp ne i16* %30, null
-  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+  %NullCheck127 = icmp eq i16* %30, null
+  br i1 %NullCheck127, label %ThrowNullRef128, label %31
 
 ; <label>:31                                      ; preds = %27
   %32 = load i16, i16* %30, align 8
   %33 = sext i16 %32 to i32
   %34 = bitcast i8* %28 to i16*
   %35 = trunc i32 %33 to i16
-  %NullCheck130 = icmp ne i16* %34, null
-  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+  %NullCheck129 = icmp eq i16* %34, null
+  br i1 %NullCheck129, label %ThrowNullRef130, label %36
 
 ; <label>:36                                      ; preds = %31
   store i16 %35, i16* %34, align 8
@@ -728,16 +810,16 @@ entry:
   %38 = load i8*, i8** %arg0
   %39 = load i8*, i8** %arg1
   %40 = bitcast i8* %39 to i16*
-  %NullCheck120 = icmp ne i16* %40, null
-  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+  %NullCheck119 = icmp eq i16* %40, null
+  br i1 %NullCheck119, label %ThrowNullRef120, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i16, i16* %40, align 8
   %43 = sext i16 %42 to i32
   %44 = bitcast i8* %38 to i16*
   %45 = trunc i32 %43 to i16
-  %NullCheck122 = icmp ne i16* %44, null
-  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+  %NullCheck121 = icmp eq i16* %44, null
+  br i1 %NullCheck121, label %ThrowNullRef122, label %46
 
 ; <label>:46                                      ; preds = %41
   store i16 %45, i16* %44, align 8
@@ -745,15 +827,15 @@ entry:
   %48 = getelementptr inbounds i8, i8* %47, i64 2
   %49 = load i8*, i8** %arg1
   %50 = getelementptr inbounds i8, i8* %49, i64 2
-  %NullCheck124 = icmp ne i8* %50, null
-  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+  %NullCheck123 = icmp eq i8* %50, null
+  br i1 %NullCheck123, label %ThrowNullRef124, label %51
 
 ; <label>:51                                      ; preds = %46
   %52 = load i8, i8* %50, align 8
   %53 = zext i8 %52 to i32
   %54 = trunc i32 %53 to i8
-  %NullCheck126 = icmp ne i8* %48, null
-  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+  %NullCheck125 = icmp eq i8* %48, null
+  br i1 %NullCheck125, label %ThrowNullRef126, label %55
 
 ; <label>:55                                      ; preds = %51
   store i8 %54, i8* %48, align 8
@@ -763,14 +845,14 @@ entry:
   %57 = load i8*, i8** %arg0
   %58 = load i8*, i8** %arg1
   %59 = bitcast i8* %58 to i32*
-  %NullCheck116 = icmp ne i32* %59, null
-  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+  %NullCheck115 = icmp eq i32* %59, null
+  br i1 %NullCheck115, label %ThrowNullRef116, label %60
 
 ; <label>:60                                      ; preds = %56
   %61 = load i32, i32* %59, align 8
   %62 = bitcast i8* %57 to i32*
-  %NullCheck118 = icmp ne i32* %62, null
-  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+  %NullCheck117 = icmp eq i32* %62, null
+  br i1 %NullCheck117, label %ThrowNullRef118, label %63
 
 ; <label>:63                                      ; preds = %60
   store i32 %61, i32* %62, align 8
@@ -780,14 +862,14 @@ entry:
   %65 = load i8*, i8** %arg0
   %66 = load i8*, i8** %arg1
   %67 = bitcast i8* %66 to i32*
-  %NullCheck108 = icmp ne i32* %67, null
-  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+  %NullCheck107 = icmp eq i32* %67, null
+  br i1 %NullCheck107, label %ThrowNullRef108, label %68
 
 ; <label>:68                                      ; preds = %64
   %69 = load i32, i32* %67, align 8
   %70 = bitcast i8* %65 to i32*
-  %NullCheck110 = icmp ne i32* %70, null
-  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+  %NullCheck109 = icmp eq i32* %70, null
+  br i1 %NullCheck109, label %ThrowNullRef110, label %71
 
 ; <label>:71                                      ; preds = %68
   store i32 %69, i32* %70, align 8
@@ -795,15 +877,15 @@ entry:
   %73 = getelementptr inbounds i8, i8* %72, i64 4
   %74 = load i8*, i8** %arg1
   %75 = getelementptr inbounds i8, i8* %74, i64 4
-  %NullCheck112 = icmp ne i8* %75, null
-  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+  %NullCheck111 = icmp eq i8* %75, null
+  br i1 %NullCheck111, label %ThrowNullRef112, label %76
 
 ; <label>:76                                      ; preds = %71
   %77 = load i8, i8* %75, align 8
   %78 = zext i8 %77 to i32
   %79 = trunc i32 %78 to i8
-  %NullCheck114 = icmp ne i8* %73, null
-  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+  %NullCheck113 = icmp eq i8* %73, null
+  br i1 %NullCheck113, label %ThrowNullRef114, label %80
 
 ; <label>:80                                      ; preds = %76
   store i8 %79, i8* %73, align 8
@@ -813,14 +895,14 @@ entry:
   %82 = load i8*, i8** %arg0
   %83 = load i8*, i8** %arg1
   %84 = bitcast i8* %83 to i32*
-  %NullCheck100 = icmp ne i32* %84, null
-  br i1 %NullCheck100, label %85, label %ThrowNullRef99
+  %NullCheck99 = icmp eq i32* %84, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %85
 
 ; <label>:85                                      ; preds = %81
   %86 = load i32, i32* %84, align 8
   %87 = bitcast i8* %82 to i32*
-  %NullCheck102 = icmp ne i32* %87, null
-  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+  %NullCheck101 = icmp eq i32* %87, null
+  br i1 %NullCheck101, label %ThrowNullRef102, label %88
 
 ; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
@@ -829,16 +911,16 @@ entry:
   %91 = load i8*, i8** %arg1
   %92 = getelementptr inbounds i8, i8* %91, i64 4
   %93 = bitcast i8* %92 to i16*
-  %NullCheck104 = icmp ne i16* %93, null
-  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+  %NullCheck103 = icmp eq i16* %93, null
+  br i1 %NullCheck103, label %ThrowNullRef104, label %94
 
 ; <label>:94                                      ; preds = %88
   %95 = load i16, i16* %93, align 8
   %96 = sext i16 %95 to i32
   %97 = bitcast i8* %90 to i16*
   %98 = trunc i32 %96 to i16
-  %NullCheck106 = icmp ne i16* %97, null
-  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+  %NullCheck105 = icmp eq i16* %97, null
+  br i1 %NullCheck105, label %ThrowNullRef106, label %99
 
 ; <label>:99                                      ; preds = %94
   store i16 %98, i16* %97, align 8
@@ -848,14 +930,14 @@ entry:
   %101 = load i8*, i8** %arg0
   %102 = load i8*, i8** %arg1
   %103 = bitcast i8* %102 to i32*
-  %NullCheck88 = icmp ne i32* %103, null
-  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+  %NullCheck87 = icmp eq i32* %103, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %104
 
 ; <label>:104                                     ; preds = %100
   %105 = load i32, i32* %103, align 8
   %106 = bitcast i8* %101 to i32*
-  %NullCheck90 = icmp ne i32* %106, null
-  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+  %NullCheck89 = icmp eq i32* %106, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %107
 
 ; <label>:107                                     ; preds = %104
   store i32 %105, i32* %106, align 8
@@ -864,16 +946,16 @@ entry:
   %110 = load i8*, i8** %arg1
   %111 = getelementptr inbounds i8, i8* %110, i64 4
   %112 = bitcast i8* %111 to i16*
-  %NullCheck92 = icmp ne i16* %112, null
-  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+  %NullCheck91 = icmp eq i16* %112, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %113
 
 ; <label>:113                                     ; preds = %107
   %114 = load i16, i16* %112, align 8
   %115 = sext i16 %114 to i32
   %116 = bitcast i8* %109 to i16*
   %117 = trunc i32 %115 to i16
-  %NullCheck94 = icmp ne i16* %116, null
-  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+  %NullCheck93 = icmp eq i16* %116, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %118
 
 ; <label>:118                                     ; preds = %113
   store i16 %117, i16* %116, align 8
@@ -881,15 +963,15 @@ entry:
   %120 = getelementptr inbounds i8, i8* %119, i64 6
   %121 = load i8*, i8** %arg1
   %122 = getelementptr inbounds i8, i8* %121, i64 6
-  %NullCheck96 = icmp ne i8* %122, null
-  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+  %NullCheck95 = icmp eq i8* %122, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %123
 
 ; <label>:123                                     ; preds = %118
   %124 = load i8, i8* %122, align 8
   %125 = zext i8 %124 to i32
   %126 = trunc i32 %125 to i8
-  %NullCheck98 = icmp ne i8* %120, null
-  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+  %NullCheck97 = icmp eq i8* %120, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %127
 
 ; <label>:127                                     ; preds = %123
   store i8 %126, i8* %120, align 8
@@ -899,14 +981,14 @@ entry:
   %129 = load i8*, i8** %arg0
   %130 = load i8*, i8** %arg1
   %131 = bitcast i8* %130 to i64*
-  %NullCheck84 = icmp ne i64* %131, null
-  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+  %NullCheck83 = icmp eq i64* %131, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %132
 
 ; <label>:132                                     ; preds = %128
   %133 = load i64, i64* %131, align 8
   %134 = bitcast i8* %129 to i64*
-  %NullCheck86 = icmp ne i64* %134, null
-  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+  %NullCheck85 = icmp eq i64* %134, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %135
 
 ; <label>:135                                     ; preds = %132
   store i64 %133, i64* %134, align 8
@@ -916,14 +998,14 @@ entry:
   %137 = load i8*, i8** %arg0
   %138 = load i8*, i8** %arg1
   %139 = bitcast i8* %138 to i64*
-  %NullCheck76 = icmp ne i64* %139, null
-  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+  %NullCheck75 = icmp eq i64* %139, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %140
 
 ; <label>:140                                     ; preds = %136
   %141 = load i64, i64* %139, align 8
   %142 = bitcast i8* %137 to i64*
-  %NullCheck78 = icmp ne i64* %142, null
-  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+  %NullCheck77 = icmp eq i64* %142, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %143
 
 ; <label>:143                                     ; preds = %140
   store i64 %141, i64* %142, align 8
@@ -931,15 +1013,15 @@ entry:
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %NullCheck80 = icmp ne i8* %147, null
-  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+  %NullCheck79 = icmp eq i8* %147, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %148
 
 ; <label>:148                                     ; preds = %143
   %149 = load i8, i8* %147, align 8
   %150 = zext i8 %149 to i32
   %151 = trunc i32 %150 to i8
-  %NullCheck82 = icmp ne i8* %145, null
-  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+  %NullCheck81 = icmp eq i8* %145, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %152
 
 ; <label>:152                                     ; preds = %148
   store i8 %151, i8* %145, align 8
@@ -949,14 +1031,14 @@ entry:
   %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
   %156 = bitcast i8* %155 to i64*
-  %NullCheck68 = icmp ne i64* %156, null
-  br i1 %NullCheck68, label %157, label %ThrowNullRef67
+  %NullCheck67 = icmp eq i64* %156, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %157
 
 ; <label>:157                                     ; preds = %153
   %158 = load i64, i64* %156, align 8
   %159 = bitcast i8* %154 to i64*
-  %NullCheck70 = icmp ne i64* %159, null
-  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+  %NullCheck69 = icmp eq i64* %159, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %160
 
 ; <label>:160                                     ; preds = %157
   store i64 %158, i64* %159, align 8
@@ -965,16 +1047,16 @@ entry:
   %163 = load i8*, i8** %arg1
   %164 = getelementptr inbounds i8, i8* %163, i64 8
   %165 = bitcast i8* %164 to i16*
-  %NullCheck72 = icmp ne i16* %165, null
-  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+  %NullCheck71 = icmp eq i16* %165, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %166
 
 ; <label>:166                                     ; preds = %160
   %167 = load i16, i16* %165, align 8
   %168 = sext i16 %167 to i32
   %169 = bitcast i8* %162 to i16*
   %170 = trunc i32 %168 to i16
-  %NullCheck74 = icmp ne i16* %169, null
-  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+  %NullCheck73 = icmp eq i16* %169, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %171
 
 ; <label>:171                                     ; preds = %166
   store i16 %170, i16* %169, align 8
@@ -984,14 +1066,14 @@ entry:
   %173 = load i8*, i8** %arg0
   %174 = load i8*, i8** %arg1
   %175 = bitcast i8* %174 to i64*
-  %NullCheck56 = icmp ne i64* %175, null
-  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+  %NullCheck55 = icmp eq i64* %175, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %176
 
 ; <label>:176                                     ; preds = %172
   %177 = load i64, i64* %175, align 8
   %178 = bitcast i8* %173 to i64*
-  %NullCheck58 = icmp ne i64* %178, null
-  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+  %NullCheck57 = icmp eq i64* %178, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %179
 
 ; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
@@ -1000,16 +1082,16 @@ entry:
   %182 = load i8*, i8** %arg1
   %183 = getelementptr inbounds i8, i8* %182, i64 8
   %184 = bitcast i8* %183 to i16*
-  %NullCheck60 = icmp ne i16* %184, null
-  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+  %NullCheck59 = icmp eq i16* %184, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %185
 
 ; <label>:185                                     ; preds = %179
   %186 = load i16, i16* %184, align 8
   %187 = sext i16 %186 to i32
   %188 = bitcast i8* %181 to i16*
   %189 = trunc i32 %187 to i16
-  %NullCheck62 = icmp ne i16* %188, null
-  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+  %NullCheck61 = icmp eq i16* %188, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %190
 
 ; <label>:190                                     ; preds = %185
   store i16 %189, i16* %188, align 8
@@ -1017,15 +1099,15 @@ entry:
   %192 = getelementptr inbounds i8, i8* %191, i64 10
   %193 = load i8*, i8** %arg1
   %194 = getelementptr inbounds i8, i8* %193, i64 10
-  %NullCheck64 = icmp ne i8* %194, null
-  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+  %NullCheck63 = icmp eq i8* %194, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %195
 
 ; <label>:195                                     ; preds = %190
   %196 = load i8, i8* %194, align 8
   %197 = zext i8 %196 to i32
   %198 = trunc i32 %197 to i8
-  %NullCheck66 = icmp ne i8* %192, null
-  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+  %NullCheck65 = icmp eq i8* %192, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %199
 
 ; <label>:199                                     ; preds = %195
   store i8 %198, i8* %192, align 8
@@ -1035,14 +1117,14 @@ entry:
   %201 = load i8*, i8** %arg0
   %202 = load i8*, i8** %arg1
   %203 = bitcast i8* %202 to i64*
-  %NullCheck48 = icmp ne i64* %203, null
-  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+  %NullCheck47 = icmp eq i64* %203, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %204
 
 ; <label>:204                                     ; preds = %200
   %205 = load i64, i64* %203, align 8
   %206 = bitcast i8* %201 to i64*
-  %NullCheck50 = icmp ne i64* %206, null
-  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+  %NullCheck49 = icmp eq i64* %206, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %207
 
 ; <label>:207                                     ; preds = %204
   store i64 %205, i64* %206, align 8
@@ -1051,14 +1133,14 @@ entry:
   %210 = load i8*, i8** %arg1
   %211 = getelementptr inbounds i8, i8* %210, i64 8
   %212 = bitcast i8* %211 to i32*
-  %NullCheck52 = icmp ne i32* %212, null
-  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+  %NullCheck51 = icmp eq i32* %212, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %213
 
 ; <label>:213                                     ; preds = %207
   %214 = load i32, i32* %212, align 8
   %215 = bitcast i8* %209 to i32*
-  %NullCheck54 = icmp ne i32* %215, null
-  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+  %NullCheck53 = icmp eq i32* %215, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %216
 
 ; <label>:216                                     ; preds = %213
   store i32 %214, i32* %215, align 8
@@ -1068,14 +1150,14 @@ entry:
   %218 = load i8*, i8** %arg0
   %219 = load i8*, i8** %arg1
   %220 = bitcast i8* %219 to i64*
-  %NullCheck36 = icmp ne i64* %220, null
-  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64* %220, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %221
 
 ; <label>:221                                     ; preds = %217
   %222 = load i64, i64* %220, align 8
   %223 = bitcast i8* %218 to i64*
-  %NullCheck38 = icmp ne i64* %223, null
-  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+  %NullCheck37 = icmp eq i64* %223, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %224
 
 ; <label>:224                                     ; preds = %221
   store i64 %222, i64* %223, align 8
@@ -1084,14 +1166,14 @@ entry:
   %227 = load i8*, i8** %arg1
   %228 = getelementptr inbounds i8, i8* %227, i64 8
   %229 = bitcast i8* %228 to i32*
-  %NullCheck40 = icmp ne i32* %229, null
-  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i32* %229, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %230
 
 ; <label>:230                                     ; preds = %224
   %231 = load i32, i32* %229, align 8
   %232 = bitcast i8* %226 to i32*
-  %NullCheck42 = icmp ne i32* %232, null
-  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+  %NullCheck41 = icmp eq i32* %232, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %233
 
 ; <label>:233                                     ; preds = %230
   store i32 %231, i32* %232, align 8
@@ -1099,15 +1181,15 @@ entry:
   %235 = getelementptr inbounds i8, i8* %234, i64 12
   %236 = load i8*, i8** %arg1
   %237 = getelementptr inbounds i8, i8* %236, i64 12
-  %NullCheck44 = icmp ne i8* %237, null
-  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i8* %237, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %238
 
 ; <label>:238                                     ; preds = %233
   %239 = load i8, i8* %237, align 8
   %240 = zext i8 %239 to i32
   %241 = trunc i32 %240 to i8
-  %NullCheck46 = icmp ne i8* %235, null
-  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+  %NullCheck45 = icmp eq i8* %235, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %242
 
 ; <label>:242                                     ; preds = %238
   store i8 %241, i8* %235, align 8
@@ -1117,14 +1199,14 @@ entry:
   %244 = load i8*, i8** %arg0
   %245 = load i8*, i8** %arg1
   %246 = bitcast i8* %245 to i64*
-  %NullCheck24 = icmp ne i64* %246, null
-  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64* %246, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %247
 
 ; <label>:247                                     ; preds = %243
   %248 = load i64, i64* %246, align 8
   %249 = bitcast i8* %244 to i64*
-  %NullCheck26 = icmp ne i64* %249, null
-  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64* %249, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %250
 
 ; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
@@ -1133,14 +1215,14 @@ entry:
   %253 = load i8*, i8** %arg1
   %254 = getelementptr inbounds i8, i8* %253, i64 8
   %255 = bitcast i8* %254 to i32*
-  %NullCheck28 = icmp ne i32* %255, null
-  br i1 %NullCheck28, label %256, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i32* %255, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %256
 
 ; <label>:256                                     ; preds = %250
   %257 = load i32, i32* %255, align 8
   %258 = bitcast i8* %252 to i32*
-  %NullCheck30 = icmp ne i32* %258, null
-  br i1 %NullCheck30, label %259, label %ThrowNullRef29
+  %NullCheck29 = icmp eq i32* %258, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %259
 
 ; <label>:259                                     ; preds = %256
   store i32 %257, i32* %258, align 8
@@ -1149,16 +1231,16 @@ entry:
   %262 = load i8*, i8** %arg1
   %263 = getelementptr inbounds i8, i8* %262, i64 12
   %264 = bitcast i8* %263 to i16*
-  %NullCheck32 = icmp ne i16* %264, null
-  br i1 %NullCheck32, label %265, label %ThrowNullRef31
+  %NullCheck31 = icmp eq i16* %264, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %265
 
 ; <label>:265                                     ; preds = %259
   %266 = load i16, i16* %264, align 8
   %267 = sext i16 %266 to i32
   %268 = bitcast i8* %261 to i16*
   %269 = trunc i32 %267 to i16
-  %NullCheck34 = icmp ne i16* %268, null
-  br i1 %NullCheck34, label %270, label %ThrowNullRef33
+  %NullCheck33 = icmp eq i16* %268, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %270
 
 ; <label>:270                                     ; preds = %265
   store i16 %269, i16* %268, align 8
@@ -1168,14 +1250,14 @@ entry:
   %272 = load i8*, i8** %arg0
   %273 = load i8*, i8** %arg1
   %274 = bitcast i8* %273 to i64*
-  %NullCheck8 = icmp ne i64* %274, null
-  br i1 %NullCheck8, label %275, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64* %274, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %275
 
 ; <label>:275                                     ; preds = %271
   %276 = load i64, i64* %274, align 8
   %277 = bitcast i8* %272 to i64*
-  %NullCheck10 = icmp ne i64* %277, null
-  br i1 %NullCheck10, label %278, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %277, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %278
 
 ; <label>:278                                     ; preds = %275
   store i64 %276, i64* %277, align 8
@@ -1184,14 +1266,14 @@ entry:
   %281 = load i8*, i8** %arg1
   %282 = getelementptr inbounds i8, i8* %281, i64 8
   %283 = bitcast i8* %282 to i32*
-  %NullCheck12 = icmp ne i32* %283, null
-  br i1 %NullCheck12, label %284, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i32* %283, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %284
 
 ; <label>:284                                     ; preds = %278
   %285 = load i32, i32* %283, align 8
   %286 = bitcast i8* %280 to i32*
-  %NullCheck14 = icmp ne i32* %286, null
-  br i1 %NullCheck14, label %287, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i32* %286, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %287
 
 ; <label>:287                                     ; preds = %284
   store i32 %285, i32* %286, align 8
@@ -1200,16 +1282,16 @@ entry:
   %290 = load i8*, i8** %arg1
   %291 = getelementptr inbounds i8, i8* %290, i64 12
   %292 = bitcast i8* %291 to i16*
-  %NullCheck16 = icmp ne i16* %292, null
-  br i1 %NullCheck16, label %293, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i16* %292, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %293
 
 ; <label>:293                                     ; preds = %287
   %294 = load i16, i16* %292, align 8
   %295 = sext i16 %294 to i32
   %296 = bitcast i8* %289 to i16*
   %297 = trunc i32 %295 to i16
-  %NullCheck18 = icmp ne i16* %296, null
-  br i1 %NullCheck18, label %298, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i16* %296, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %298
 
 ; <label>:298                                     ; preds = %293
   store i16 %297, i16* %296, align 8
@@ -1217,15 +1299,15 @@ entry:
   %300 = getelementptr inbounds i8, i8* %299, i64 14
   %301 = load i8*, i8** %arg1
   %302 = getelementptr inbounds i8, i8* %301, i64 14
-  %NullCheck20 = icmp ne i8* %302, null
-  br i1 %NullCheck20, label %303, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i8* %302, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %303
 
 ; <label>:303                                     ; preds = %298
   %304 = load i8, i8* %302, align 8
   %305 = zext i8 %304 to i32
   %306 = trunc i32 %305 to i8
-  %NullCheck22 = icmp ne i8* %300, null
-  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i8* %300, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %307
 
 ; <label>:307                                     ; preds = %303
   store i8 %306, i8* %300, align 8
@@ -1235,14 +1317,14 @@ entry:
   %309 = load i8*, i8** %arg0
   %310 = load i8*, i8** %arg1
   %311 = bitcast i8* %310 to i64*
-  %NullCheck = icmp ne i64* %311, null
-  br i1 %NullCheck, label %312, label %ThrowNullRef
+  %NullCheck = icmp eq i64* %311, null
+  br i1 %NullCheck, label %ThrowNullRef, label %312
 
 ; <label>:312                                     ; preds = %308
   %313 = load i64, i64* %311, align 8
   %314 = bitcast i8* %309 to i64*
-  %NullCheck2 = icmp ne i64* %314, null
-  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64* %314, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %315
 
 ; <label>:315                                     ; preds = %312
   store i64 %313, i64* %314, align 8
@@ -1251,14 +1333,14 @@ entry:
   %318 = load i8*, i8** %arg1
   %319 = getelementptr inbounds i8, i8* %318, i64 8
   %320 = bitcast i8* %319 to i64*
-  %NullCheck4 = icmp ne i64* %320, null
-  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64* %320, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %321
 
 ; <label>:321                                     ; preds = %315
   %322 = load i64, i64* %320, align 8
   %323 = bitcast i8* %317 to i64*
-  %NullCheck6 = icmp ne i64* %323, null
-  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64* %323, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %324
 
 ; <label>:324                                     ; preds = %321
   store i64 %322, i64* %323, align 8
@@ -1286,15 +1368,15 @@ entry:
 ; <label>:338                                     ; preds = %333
   %339 = load i8*, i8** %arg0
   %340 = load i8*, i8** %arg1
-  %NullCheck136 = icmp ne i8* %340, null
-  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+  %NullCheck135 = icmp eq i8* %340, null
+  br i1 %NullCheck135, label %ThrowNullRef136, label %341
 
 ; <label>:341                                     ; preds = %338
   %342 = load i8, i8* %340, align 8
   %343 = zext i8 %342 to i32
   %344 = trunc i32 %343 to i8
-  %NullCheck138 = icmp ne i8* %339, null
-  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+  %NullCheck137 = icmp eq i8* %339, null
+  br i1 %NullCheck137, label %ThrowNullRef138, label %345
 
 ; <label>:345                                     ; preds = %341
   store i8 %344, i8* %339, align 8
@@ -1317,16 +1399,16 @@ entry:
   %357 = load i8*, i8** %arg0
   %358 = load i8*, i8** %arg1
   %359 = bitcast i8* %358 to i16*
-  %NullCheck140 = icmp ne i16* %359, null
-  br i1 %NullCheck140, label %360, label %ThrowNullRef139
+  %NullCheck139 = icmp eq i16* %359, null
+  br i1 %NullCheck139, label %ThrowNullRef140, label %360
 
 ; <label>:360                                     ; preds = %356
   %361 = load i16, i16* %359, align 8
   %362 = sext i16 %361 to i32
   %363 = bitcast i8* %357 to i16*
   %364 = trunc i32 %362 to i16
-  %NullCheck142 = icmp ne i16* %363, null
-  br i1 %NullCheck142, label %365, label %ThrowNullRef141
+  %NullCheck141 = icmp eq i16* %363, null
+  br i1 %NullCheck141, label %ThrowNullRef142, label %365
 
 ; <label>:365                                     ; preds = %360
   store i16 %364, i16* %363, align 8
@@ -1352,14 +1434,14 @@ entry:
   %378 = load i8*, i8** %arg0
   %379 = load i8*, i8** %arg1
   %380 = bitcast i8* %379 to i32*
-  %NullCheck144 = icmp ne i32* %380, null
-  br i1 %NullCheck144, label %381, label %ThrowNullRef143
+  %NullCheck143 = icmp eq i32* %380, null
+  br i1 %NullCheck143, label %ThrowNullRef144, label %381
 
 ; <label>:381                                     ; preds = %377
   %382 = load i32, i32* %380, align 8
   %383 = bitcast i8* %378 to i32*
-  %NullCheck146 = icmp ne i32* %383, null
-  br i1 %NullCheck146, label %384, label %ThrowNullRef145
+  %NullCheck145 = icmp eq i32* %383, null
+  br i1 %NullCheck145, label %ThrowNullRef146, label %384
 
 ; <label>:384                                     ; preds = %381
   store i32 %382, i32* %383, align 8
@@ -1384,14 +1466,14 @@ entry:
   %395 = load i8*, i8** %arg0
   %396 = load i8*, i8** %arg1
   %397 = bitcast i8* %396 to i64*
-  %NullCheck164 = icmp ne i64* %397, null
-  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+  %NullCheck163 = icmp eq i64* %397, null
+  br i1 %NullCheck163, label %ThrowNullRef164, label %398
 
 ; <label>:398                                     ; preds = %394
   %399 = load i64, i64* %397, align 8
   %400 = bitcast i8* %395 to i64*
-  %NullCheck166 = icmp ne i64* %400, null
-  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+  %NullCheck165 = icmp eq i64* %400, null
+  br i1 %NullCheck165, label %ThrowNullRef166, label %401
 
 ; <label>:401                                     ; preds = %398
   store i64 %399, i64* %400, align 8
@@ -1400,14 +1482,14 @@ entry:
   %404 = load i8*, i8** %arg1
   %405 = getelementptr inbounds i8, i8* %404, i64 8
   %406 = bitcast i8* %405 to i64*
-  %NullCheck168 = icmp ne i64* %406, null
-  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+  %NullCheck167 = icmp eq i64* %406, null
+  br i1 %NullCheck167, label %ThrowNullRef168, label %407
 
 ; <label>:407                                     ; preds = %401
   %408 = load i64, i64* %406, align 8
   %409 = bitcast i8* %403 to i64*
-  %NullCheck170 = icmp ne i64* %409, null
-  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+  %NullCheck169 = icmp eq i64* %409, null
+  br i1 %NullCheck169, label %ThrowNullRef170, label %410
 
 ; <label>:410                                     ; preds = %407
   store i64 %408, i64* %409, align 8
@@ -1437,14 +1519,14 @@ entry:
   %425 = load i8*, i8** %arg0
   %426 = load i8*, i8** %arg1
   %427 = bitcast i8* %426 to i64*
-  %NullCheck148 = icmp ne i64* %427, null
-  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+  %NullCheck147 = icmp eq i64* %427, null
+  br i1 %NullCheck147, label %ThrowNullRef148, label %428
 
 ; <label>:428                                     ; preds = %424
   %429 = load i64, i64* %427, align 8
   %430 = bitcast i8* %425 to i64*
-  %NullCheck150 = icmp ne i64* %430, null
-  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+  %NullCheck149 = icmp eq i64* %430, null
+  br i1 %NullCheck149, label %ThrowNullRef150, label %431
 
 ; <label>:431                                     ; preds = %428
   store i64 %429, i64* %430, align 8
@@ -1466,14 +1548,14 @@ entry:
   %441 = load i8*, i8** %arg0
   %442 = load i8*, i8** %arg1
   %443 = bitcast i8* %442 to i32*
-  %NullCheck152 = icmp ne i32* %443, null
-  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+  %NullCheck151 = icmp eq i32* %443, null
+  br i1 %NullCheck151, label %ThrowNullRef152, label %444
 
 ; <label>:444                                     ; preds = %440
   %445 = load i32, i32* %443, align 8
   %446 = bitcast i8* %441 to i32*
-  %NullCheck154 = icmp ne i32* %446, null
-  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+  %NullCheck153 = icmp eq i32* %446, null
+  br i1 %NullCheck153, label %ThrowNullRef154, label %447
 
 ; <label>:447                                     ; preds = %444
   store i32 %445, i32* %446, align 8
@@ -1495,16 +1577,16 @@ entry:
   %457 = load i8*, i8** %arg0
   %458 = load i8*, i8** %arg1
   %459 = bitcast i8* %458 to i16*
-  %NullCheck156 = icmp ne i16* %459, null
-  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+  %NullCheck155 = icmp eq i16* %459, null
+  br i1 %NullCheck155, label %ThrowNullRef156, label %460
 
 ; <label>:460                                     ; preds = %456
   %461 = load i16, i16* %459, align 8
   %462 = sext i16 %461 to i32
   %463 = bitcast i8* %457 to i16*
   %464 = trunc i32 %462 to i16
-  %NullCheck158 = icmp ne i16* %463, null
-  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+  %NullCheck157 = icmp eq i16* %463, null
+  br i1 %NullCheck157, label %ThrowNullRef158, label %465
 
 ; <label>:465                                     ; preds = %460
   store i16 %464, i16* %463, align 8
@@ -1525,15 +1607,15 @@ entry:
 ; <label>:474                                     ; preds = %470
   %475 = load i8*, i8** %arg0
   %476 = load i8*, i8** %arg1
-  %NullCheck160 = icmp ne i8* %476, null
-  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+  %NullCheck159 = icmp eq i8* %476, null
+  br i1 %NullCheck159, label %ThrowNullRef160, label %477
 
 ; <label>:477                                     ; preds = %474
   %478 = load i8, i8* %476, align 8
   %479 = zext i8 %478 to i32
   %480 = trunc i32 %479 to i8
-  %NullCheck162 = icmp ne i8* %475, null
-  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+  %NullCheck161 = icmp eq i8* %475, null
+  br i1 %NullCheck161, label %ThrowNullRef162, label %481
 
 ; <label>:481                                     ; preds = %477
   store i8 %480, i8* %475, align 8
@@ -1553,343 +1635,343 @@ ThrowNullRef:                                     ; preds = %308
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %312
+ThrowNullRef2:                                    ; preds = %312
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %315
+ThrowNullRef4:                                    ; preds = %315
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %321
+ThrowNullRef6:                                    ; preds = %321
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %271
+ThrowNullRef8:                                    ; preds = %271
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %275
+ThrowNullRef10:                                   ; preds = %275
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %278
+ThrowNullRef12:                                   ; preds = %278
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %284
+ThrowNullRef14:                                   ; preds = %284
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %287
+ThrowNullRef16:                                   ; preds = %287
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %293
+ThrowNullRef18:                                   ; preds = %293
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %298
+ThrowNullRef20:                                   ; preds = %298
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %303
+ThrowNullRef22:                                   ; preds = %303
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %243
+ThrowNullRef24:                                   ; preds = %243
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %247
+ThrowNullRef26:                                   ; preds = %247
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %250
+ThrowNullRef28:                                   ; preds = %250
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %256
+ThrowNullRef30:                                   ; preds = %256
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %259
+ThrowNullRef32:                                   ; preds = %259
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %265
+ThrowNullRef34:                                   ; preds = %265
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %217
+ThrowNullRef36:                                   ; preds = %217
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %221
+ThrowNullRef38:                                   ; preds = %221
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %224
+ThrowNullRef40:                                   ; preds = %224
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %230
+ThrowNullRef42:                                   ; preds = %230
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %233
+ThrowNullRef44:                                   ; preds = %233
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %238
+ThrowNullRef46:                                   ; preds = %238
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %200
+ThrowNullRef48:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %204
+ThrowNullRef50:                                   ; preds = %204
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %207
+ThrowNullRef52:                                   ; preds = %207
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %213
+ThrowNullRef54:                                   ; preds = %213
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %172
+ThrowNullRef56:                                   ; preds = %172
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %176
+ThrowNullRef58:                                   ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %179
+ThrowNullRef60:                                   ; preds = %179
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %185
+ThrowNullRef62:                                   ; preds = %185
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %190
+ThrowNullRef64:                                   ; preds = %190
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %195
+ThrowNullRef66:                                   ; preds = %195
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %153
+ThrowNullRef68:                                   ; preds = %153
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %157
+ThrowNullRef70:                                   ; preds = %157
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %160
+ThrowNullRef72:                                   ; preds = %160
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %166
+ThrowNullRef74:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %136
+ThrowNullRef76:                                   ; preds = %136
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %140
+ThrowNullRef78:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %143
+ThrowNullRef80:                                   ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %148
+ThrowNullRef82:                                   ; preds = %148
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %128
+ThrowNullRef84:                                   ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %132
+ThrowNullRef86:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %100
+ThrowNullRef88:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %104
+ThrowNullRef90:                                   ; preds = %104
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %107
+ThrowNullRef92:                                   ; preds = %107
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %113
+ThrowNullRef94:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %118
+ThrowNullRef96:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %123
+ThrowNullRef98:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %81
+ThrowNullRef100:                                  ; preds = %81
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef101:                                  ; preds = %85
+ThrowNullRef102:                                  ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef103:                                  ; preds = %88
+ThrowNullRef104:                                  ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef105:                                  ; preds = %94
+ThrowNullRef106:                                  ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef107:                                  ; preds = %64
+ThrowNullRef108:                                  ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef109:                                  ; preds = %68
+ThrowNullRef110:                                  ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef111:                                  ; preds = %71
+ThrowNullRef112:                                  ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef113:                                  ; preds = %76
+ThrowNullRef114:                                  ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef115:                                  ; preds = %56
+ThrowNullRef116:                                  ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef117:                                  ; preds = %60
+ThrowNullRef118:                                  ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef119:                                  ; preds = %37
+ThrowNullRef120:                                  ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef121:                                  ; preds = %41
+ThrowNullRef122:                                  ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef123:                                  ; preds = %46
+ThrowNullRef124:                                  ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef125:                                  ; preds = %51
+ThrowNullRef126:                                  ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef127:                                  ; preds = %27
+ThrowNullRef128:                                  ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef129:                                  ; preds = %31
+ThrowNullRef130:                                  ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef131:                                  ; preds = %19
+ThrowNullRef132:                                  ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef133:                                  ; preds = %22
+ThrowNullRef134:                                  ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef135:                                  ; preds = %338
+ThrowNullRef136:                                  ; preds = %338
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef137:                                  ; preds = %341
+ThrowNullRef138:                                  ; preds = %341
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef139:                                  ; preds = %356
+ThrowNullRef140:                                  ; preds = %356
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef141:                                  ; preds = %360
+ThrowNullRef142:                                  ; preds = %360
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef143:                                  ; preds = %377
+ThrowNullRef144:                                  ; preds = %377
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef145:                                  ; preds = %381
+ThrowNullRef146:                                  ; preds = %381
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef147:                                  ; preds = %424
+ThrowNullRef148:                                  ; preds = %424
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef149:                                  ; preds = %428
+ThrowNullRef150:                                  ; preds = %428
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef151:                                  ; preds = %440
+ThrowNullRef152:                                  ; preds = %440
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef153:                                  ; preds = %444
+ThrowNullRef154:                                  ; preds = %444
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef155:                                  ; preds = %456
+ThrowNullRef156:                                  ; preds = %456
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef157:                                  ; preds = %460
+ThrowNullRef158:                                  ; preds = %460
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef159:                                  ; preds = %474
+ThrowNullRef160:                                  ; preds = %474
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef161:                                  ; preds = %477
+ThrowNullRef162:                                  ; preds = %477
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef163:                                  ; preds = %394
+ThrowNullRef164:                                  ; preds = %394
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef165:                                  ; preds = %398
+ThrowNullRef166:                                  ; preds = %398
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef167:                                  ; preds = %401
+ThrowNullRef168:                                  ; preds = %401
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef169:                                  ; preds = %407
+ThrowNullRef170:                                  ; preds = %407
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1939,8 +2021,8 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
-  br i1 %NullCheck, label %22, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %ThrowNullRef, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
@@ -1948,8 +2030,8 @@ entry:
   store i32 %24, i32* %loc0
   %25 = load i32, i32* %loc0
   %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %26, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %27
 
 ; <label>:27                                      ; preds = %22
   %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
@@ -1971,7 +2053,7 @@ ThrowNullRef:                                     ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1989,8 +2071,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -2022,15 +2104,15 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2048,16 +2130,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
   %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
   store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %15
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
@@ -2072,8 +2154,8 @@ entry:
   %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
   %29 = ptrtoint i16 addrspace(1)* %28 to i64
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %19
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
@@ -2089,19 +2171,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2114,8 +2196,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
@@ -2128,7 +2210,7 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[loadElem]
+Failed to read AppDomain.PrepareDataForSetup[storeElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
@@ -2202,8 +2284,8 @@ entry:
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
-  br i1 %NullCheck24, label %27, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = load i64, i64 addrspace(1)* %26
@@ -2218,8 +2300,8 @@ entry:
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
-  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
   %41 = load i64, i64 addrspace(1)* %39
@@ -2236,8 +2318,8 @@ entry:
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
-  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
   %54 = load i64, i64 addrspace(1)* %52
@@ -2252,8 +2334,8 @@ entry:
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
   %67 = load i64, i64 addrspace(1)* %65
@@ -2270,8 +2352,8 @@ entry:
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
-  br i1 %NullCheck16, label %79, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
   %80 = load i64, i64 addrspace(1)* %78
@@ -2286,8 +2368,8 @@ entry:
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
-  br i1 %NullCheck18, label %92, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
   %93 = load i64, i64 addrspace(1)* %91
@@ -2304,8 +2386,8 @@ entry:
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
-  br i1 %NullCheck12, label %105, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = load i64, i64 addrspace(1)* %104
@@ -2320,8 +2402,8 @@ entry:
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
-  br i1 %NullCheck14, label %118, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
   %119 = load i64, i64 addrspace(1)* %117
@@ -2337,8 +2419,8 @@ entry:
 
 ; <label>:128                                     ; preds = %20
   %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
-  br i1 %NullCheck4, label %130, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %129, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %130
 
 ; <label>:130                                     ; preds = %128
   %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
@@ -2346,8 +2428,8 @@ entry:
   %133 = load i16, i16 addrspace(1)* %132, align 8
   %134 = zext i16 %133 to i32
   %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
-  br i1 %NullCheck6, label %136, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %135, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %136
 
 ; <label>:136                                     ; preds = %130
   %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
@@ -2360,8 +2442,8 @@ entry:
 
 ; <label>:143                                     ; preds = %136
   %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
-  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %144, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %145
 
 ; <label>:145                                     ; preds = %143
   %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
@@ -2369,8 +2451,8 @@ entry:
   %148 = load i16, i16 addrspace(1)* %147, align 8
   %149 = zext i16 %148 to i32
   %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %150, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %151
 
 ; <label>:151                                     ; preds = %145
   %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
@@ -2388,8 +2470,8 @@ entry:
 
 ; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
-  br i1 %NullCheck, label %163, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %ThrowNullRef, label %163
 
 ; <label>:163                                     ; preds = %161
   %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
@@ -2399,8 +2481,8 @@ entry:
 
 ; <label>:167                                     ; preds = %163
   %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
-  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %168, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %169
 
 ; <label>:169                                     ; preds = %167
   %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
@@ -2432,55 +2514,55 @@ ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %167
+ThrowNullRef2:                                    ; preds = %167
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %128
+ThrowNullRef4:                                    ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %130
+ThrowNullRef6:                                    ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %143
+ThrowNullRef8:                                    ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %145
+ThrowNullRef10:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %102
+ThrowNullRef12:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %105
+ThrowNullRef14:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %76
+ThrowNullRef16:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %79
+ThrowNullRef18:                                   ; preds = %79
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %50
+ThrowNullRef20:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %53
+ThrowNullRef22:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %24
+ThrowNullRef24:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %27
+ThrowNullRef26:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2503,15 +2585,15 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2519,16 +2601,16 @@ entry:
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
   store i32 %8, i32* %loc0
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
   %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
   store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
@@ -2546,16 +2628,16 @@ entry:
 
 ; <label>:23                                      ; preds = %64
   %24 = load i16*, i16** %loc3
-  %NullCheck12 = icmp ne i16* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i16* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
   store i32 %27, i32* %loc5
   %28 = load i16*, i16** %loc4
-  %NullCheck14 = icmp ne i16* %28, null
-  br i1 %NullCheck14, label %29, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %28, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = load i16, i16* %28, align 8
@@ -2620,15 +2702,15 @@ entry:
 
 ; <label>:67                                      ; preds = %64
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
-  br i1 %NullCheck8, label %69, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %68, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %69
 
 ; <label>:69                                      ; preds = %67
   %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
   %71 = load i32, i32 addrspace(1)* %70
   %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
-  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %73
 
 ; <label>:73                                      ; preds = %69
   %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
@@ -2645,31 +2727,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %67
+ThrowNullRef8:                                    ; preds = %67
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %69
+ThrowNullRef10:                                   ; preds = %69
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2710,14 +2792,14 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
   %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
@@ -2730,14 +2812,14 @@ entry:
 
 ; <label>:11                                      ; preds = %4
   %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
   %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
@@ -2749,14 +2831,14 @@ entry:
 
 ; <label>:22                                      ; preds = %16
   %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
   %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
-  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
-  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
@@ -2804,23 +2886,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2836,7 +2918,280 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[loadElem]
+Successfully read RuntimeType.IsAssignableFrom
+
+define i8 @RuntimeType.IsAssignableFrom(%System.RuntimeType addrspace(1)* %param0, %System.Type addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.RuntimeType addrspace(1)*
+  %arg1 = alloca %System.Type addrspace(1)*
+  %loc0 = alloca %System.RuntimeType addrspace(1)*
+  %loc1 = alloca %"System.Type[]" addrspace(1)*
+  %loc2 = alloca i32
+  store %System.RuntimeType addrspace(1)* %param0, %System.RuntimeType addrspace(1)** %this
+  store %System.Type addrspace(1)* %param1, %System.Type addrspace(1)** %arg1
+  %0 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %1 = icmp ne %System.Type addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i8 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %5 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %6 = bitcast %System.Type addrspace(1)* %4 to %System.Object addrspace(1)*
+  %7 = bitcast %System.RuntimeType addrspace(1)* %5 to %System.Object addrspace(1)*
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %6, %System.Object addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %3
+  ret i8 1
+
+; <label>:12                                      ; preds = %3
+  %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 152
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 32
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
+  %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
+  %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
+  store %System.RuntimeType addrspace(1)* %25, %System.RuntimeType addrspace(1)** %loc0
+  %26 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %27 = icmp eq %System.RuntimeType addrspace(1)* %26, null
+  br i1 %27, label %34, label %28
+
+; <label>:28                                      ; preds = %15
+  %29 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %30 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)*)*)(%System.RuntimeType addrspace(1)* %29, %System.RuntimeType addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+; <label>:34                                      ; preds = %15
+  %35 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %36 = call %System.Reflection.Emit.TypeBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Reflection.Emit.TypeBuilder addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %35)
+  %37 = icmp eq %System.Reflection.Emit.TypeBuilder addrspace(1)* %36, null
+  br i1 %37, label %139, label %38
+
+; <label>:38                                      ; preds = %34
+  %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %42
+
+; <label>:42                                      ; preds = %38
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 152
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 40
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
+  %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
+  %53 = zext i8 %52 to i32
+  %54 = icmp eq i32 %53, 0
+  br i1 %54, label %56, label %55
+
+; <label>:55                                      ; preds = %42
+  ret i8 1
+
+; <label>:56                                      ; preds = %42
+  %57 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %58 = bitcast %System.RuntimeType addrspace(1)* %57 to %System.Type addrspace(1)*
+  %59 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %58)
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %64 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.Type addrspace(1)* %63, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = bitcast %System.RuntimeType addrspace(1)* %64 to %System.Type addrspace(1)*
+  %67 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %63, %System.Type addrspace(1)* %66)
+  %68 = zext i8 %67 to i32
+  %69 = trunc i32 %68 to i8
+  ret i8 %69
+
+; <label>:70                                      ; preds = %56
+  %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
+  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %73
+
+; <label>:73                                      ; preds = %70
+  %74 = load i64, i64 addrspace(1)* %72
+  %75 = add i64 %74, 128
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = add i64 %77, 0
+  %79 = inttoptr i64 %78 to i64*
+  %80 = load i64, i64* %79
+  %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
+  %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
+  %83 = call i8 %82(%System.Type addrspace(1)* %81)
+  %84 = zext i8 %83 to i32
+  %85 = icmp eq i32 %84, 0
+  br i1 %85, label %139, label %86
+
+; <label>:86                                      ; preds = %73
+  %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
+  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %89
+
+; <label>:89                                      ; preds = %86
+  %90 = load i64, i64 addrspace(1)* %88
+  %91 = add i64 %90, 128
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = add i64 %93, 24
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
+  %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
+  %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
+  store %"System.Type[]" addrspace(1)* %99, %"System.Type[]" addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %129
+
+; <label>:100                                     ; preds = %132
+  %101 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %102 = load i32, i32* %loc2
+  %NullCheck11 = icmp eq %"System.Type[]" addrspace(1)* %101, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %103
+
+; <label>:103                                     ; preds = %100
+  %104 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 1
+  %105 = load i32, i32 addrspace(1)* %104
+  %106 = zext i32 %105 to i64
+  %107 = zext i32 %102 to i64
+  %BoundsCheck = icmp uge i64 %107, %106
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %108
+
+; <label>:108                                     ; preds = %103
+  %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
+  %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
+  %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
+  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %113
+
+; <label>:113                                     ; preds = %108
+  %114 = load i64, i64 addrspace(1)* %112
+  %115 = add i64 %114, 152
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = add i64 %117, 56
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
+  %123 = zext i8 %122 to i32
+  %124 = icmp ne i32 %123, 0
+  br i1 %124, label %126, label %125
+
+; <label>:125                                     ; preds = %113
+  ret i8 0
+
+; <label>:126                                     ; preds = %113
+  %127 = load i32, i32* %loc2
+  %128 = add i32 %127, 1
+  store i32 %128, i32* %loc2
+  br label %129
+
+; <label>:129                                     ; preds = %89, %126
+  %130 = load i32, i32* %loc2
+  %131 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %NullCheck9 = icmp eq %"System.Type[]" addrspace(1)* %131, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %132
+
+; <label>:132                                     ; preds = %129
+  %133 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %131, i32 0, i32 1
+  %134 = load i32, i32 addrspace(1)* %133
+  %135 = zext i32 %134 to i64
+  %136 = trunc i64 %135 to i32
+  %137 = icmp slt i32 %130, %136
+  br i1 %137, label %100, label %138
+
+; <label>:138                                     ; preds = %132
+  ret i8 1
+
+; <label>:139                                     ; preds = %34, %73
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %129
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %103
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -2893,7 +3248,7 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElem]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -2904,8 +3259,8 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -2997,8 +3352,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
@@ -3059,8 +3414,8 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -3087,8 +3442,8 @@ entry:
 
 ; <label>:17                                      ; preds = %5, %11
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
@@ -3097,8 +3452,8 @@ entry:
 
 ; <label>:22                                      ; preds = %1, %11
   %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
@@ -3109,11 +3464,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %17
+ThrowNullRef2:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %22
+ThrowNullRef4:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3167,15 +3522,15 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
   %15 = load i32, i32 addrspace(1)* %14
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
@@ -3198,7 +3553,7 @@ ThrowNullRef:                                     ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef2:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3232,8 +3587,8 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
@@ -3312,8 +3667,8 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -3327,8 +3682,8 @@ entry:
 ; <label>:5                                       ; preds = %43
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %7 = load i32, i32* %loc1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck6, label %8, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
@@ -3366,8 +3721,8 @@ entry:
 ; <label>:32                                      ; preds = %21, %25
   %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
   %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
-  br i1 %NullCheck8, label %35, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = trunc i32 %34 to i16
@@ -3380,8 +3735,8 @@ entry:
 ; <label>:40                                      ; preds = %1, %35
   %41 = load i32, i32* %loc1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
-  br i1 %NullCheck2, label %43, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %42, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
@@ -3392,8 +3747,8 @@ entry:
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
   %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
-  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
   %51 = load i64, i64 addrspace(1)* %49
@@ -3412,19 +3767,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %40
+ThrowNullRef2:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %47
+ThrowNullRef4:                                    ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %5
+ThrowNullRef6:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %32
+ThrowNullRef8:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3467,8 +3822,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
@@ -3492,11 +3847,391 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(i16* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store i16* %param0, i16** %arg0
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load i32, i32* %arg3
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %42, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %37, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg2
+  %13 = load i32, i32* %arg3
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %37, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %24 = load i32, i32* %arg2
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load i16*, i16** %arg0
+  %35 = load i32, i32* %arg3
+  %36 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %36, i16* %34, i32 %35)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:37                                      ; preds = %5, %16
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %39)
+  %41 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41, %System.String addrspace(1)* %38, %System.String addrspace(1)* %40)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41) #0
+  unreachable
+
+; <label>:42                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
-Failed to read StringBuilder.ToString[loadElemA]
+Successfully read StringBuilder.ToString
+
+define %System.String addrspace(1)* @StringBuilder.ToString(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i16*
+  %loc3 = alloca %"System.Char[]" addrspace(1)*
+  %loc4 = alloca i32
+  %loc5 = alloca i32
+  %loc6 = alloca i16 addrspace(1)*
+  %loc7 = alloca %System.String addrspace(1)*
+  %loc8 = alloca %"System.Char[]" addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %0)
+  %2 = icmp ne i32 %1, 0
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %4
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %6)
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %7)
+  store %System.String addrspace(1)* %8, %System.String addrspace(1)** %loc0
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.Text.StringBuilder addrspace(1)* %9, %System.Text.StringBuilder addrspace(1)** %loc1
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  store %System.String addrspace(1)* %10, %System.String addrspace(1)** %loc7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc7
+  %12 = ptrtoint %System.String addrspace(1)* %11 to i64
+  %13 = icmp eq i64 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %5
+  %15 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %16 = sext i32 %15 to i64
+  %17 = add i64 %12, %16
+  br label %18
+
+; <label>:18                                      ; preds = %5, %14
+  %19 = phi i64 [ %12, %5 ], [ %17, %14 ]
+  %20 = inttoptr i64 %19 to i16*
+  store i16* %20, i16** %loc2
+  br label %21
+
+; <label>:21                                      ; preds = %98, %18
+  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %22, null
+  br i1 %NullCheck, label %ThrowNullRef, label %23
+
+; <label>:23                                      ; preds = %21
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 3
+  %25 = load i32, i32 addrspace(1)* %24, align 8
+  %26 = icmp sle i32 %25, 0
+  br i1 %26, label %96, label %27
+
+; <label>:27                                      ; preds = %23
+  %28 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %28, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %29
+
+; <label>:29                                      ; preds = %27
+  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %28, i32 0, i32 1
+  %31 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %30, align 8
+  store %"System.Char[]" addrspace(1)* %31, %"System.Char[]" addrspace(1)** %loc3
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %33
+
+; <label>:33                                      ; preds = %29
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  store i32 %35, i32* %loc4
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  %39 = load i32, i32 addrspace(1)* %38, align 8
+  store i32 %39, i32* %loc5
+  %40 = load i32, i32* %loc5
+  %41 = load i32, i32* %loc4
+  %42 = add i32 %40, %41
+  %43 = zext i32 %42 to i64
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %45
+
+; <label>:45                                      ; preds = %37
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = sext i32 %47 to i64
+  %49 = icmp sgt i64 %43, %48
+  br i1 %49, label %91, label %50
+
+; <label>:50                                      ; preds = %45
+  %51 = load i32, i32* %loc5
+  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %52, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %53
+
+; <label>:53                                      ; preds = %50
+  %54 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %52, i32 0, i32 1
+  %55 = load i32, i32 addrspace(1)* %54
+  %56 = zext i32 %55 to i64
+  %57 = trunc i64 %56 to i32
+  %58 = icmp ugt i32 %51, %57
+  br i1 %58, label %91, label %59
+
+; <label>:59                                      ; preds = %53
+  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  store %"System.Char[]" addrspace(1)* %60, %"System.Char[]" addrspace(1)** %loc8
+  %61 = icmp eq %"System.Char[]" addrspace(1)* %60, null
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %63, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %64
+
+; <label>:64                                      ; preds = %62
+  %65 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %63, i32 0, i32 1
+  %66 = load i32, i32 addrspace(1)* %65
+  %67 = zext i32 %66 to i64
+  %68 = trunc i64 %67 to i32
+  %69 = icmp ne i32 %68, 0
+  br i1 %69, label %71, label %70
+
+; <label>:70                                      ; preds = %59, %64
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:71                                      ; preds = %64
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %73
+
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %BoundsCheck = icmp uge i64 0, %76
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %77
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %78, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:79                                      ; preds = %70, %77
+  %80 = load i16*, i16** %loc2
+  %81 = load i32, i32* %loc4
+  %82 = sext i32 %81 to i64
+  %83 = mul i64 %82, 2
+  %84 = bitcast i16* %80 to i8*
+  %85 = getelementptr inbounds i8, i8* %84, i64 %83
+  %86 = load i16 addrspace(1)*, i16 addrspace(1)** %loc6
+  %87 = ptrtoint i16 addrspace(1)* %86 to i64
+  %88 = load i32, i32* %loc5
+  %89 = bitcast i8* %85 to i16*
+  %90 = inttoptr i64 %87 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %89, i16* %90, i32 %88)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %96
+
+; <label>:91                                      ; preds = %45, %53
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %94 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %93)
+  %95 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95, %System.String addrspace(1)* %92, %System.String addrspace(1)* %94)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95) #0
+  unreachable
+
+; <label>:96                                      ; preds = %23, %79
+  %97 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %97, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %98
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %97, i32 0, i32 2
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  store %System.Text.StringBuilder addrspace(1)* %100, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %102 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %102, label %21, label %103
+
+; <label>:103                                     ; preds = %98
+  store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc7
+  %104 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  ret %System.String addrspace(1)* %104
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method StringBuilder::get_Length using LLILCJit
+Successfully read StringBuilder.get_Length
+
+define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
+Successfully read RuntimeHelpers.get_OffsetToStringData
+
+define i32 @RuntimeHelpers.get_OffsetToStringData() {
+entry:
+  ret i32 12
+}
+
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
 Successfully read CultureData.CreateCultureData
 
@@ -3514,23 +4249,23 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
   store i8 %4, i8 addrspace(1)* %6
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
@@ -3549,11 +4284,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3566,50 +4301,50 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
   store i32 -1, i32 addrspace(1)* %2
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
   store i32 -1, i32 addrspace(1)* %8
   %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
   store i32 -1, i32 addrspace(1)* %14
   %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
   store i32 -1, i32 addrspace(1)* %17
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
@@ -3623,27 +4358,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3675,7 +4410,136 @@ Failed to read Dictionary`2.Insert[non-const derefAddress]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
 Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
-Failed to read HashHelpers.GetPrime[loadElem]
+Successfully read HashHelpers.GetPrime
+
+define i32 @HashHelpers.GetPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %6, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5, %System.String addrspace(1)* %4)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5) #0
+  unreachable
+
+; <label>:6                                       ; preds = %entry
+  store i32 0, i32* %loc0
+  br label %29
+
+; <label>:7                                       ; preds = %35
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 1296
+  %10 = addrspacecast i8 addrspace(1)* %9 to %"System.Int32[]" addrspace(1)**
+  %11 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %10
+  %12 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Int32[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = zext i32 %15 to i64
+  %17 = zext i32 %12 to i64
+  %BoundsCheck = icmp uge i64 %17, %16
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 3, i32 %12
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  store i32 %20, i32* %loc1
+  %21 = load i32, i32* %loc1
+  %22 = load i32, i32* %arg0
+  %23 = icmp slt i32 %21, %22
+  br i1 %23, label %26, label %24
+
+; <label>:24                                      ; preds = %18
+  %25 = load i32, i32* %loc1
+  ret i32 %25
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %loc0
+  %28 = add i32 %27, 1
+  store i32 %28, i32* %loc0
+  br label %29
+
+; <label>:29                                      ; preds = %6, %26
+  %30 = load i32, i32* %loc0
+  %31 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %32 = getelementptr inbounds i8, i8 addrspace(1)* %31, i64 1296
+  %33 = addrspacecast i8 addrspace(1)* %32 to %"System.Int32[]" addrspace(1)**
+  %34 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %33
+  %NullCheck = icmp eq %"System.Int32[]" addrspace(1)* %34, null
+  br i1 %NullCheck, label %ThrowNullRef, label %35
+
+; <label>:35                                      ; preds = %29
+  %36 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %34, i32 0, i32 1
+  %37 = load i32, i32 addrspace(1)* %36
+  %38 = zext i32 %37 to i64
+  %39 = trunc i64 %38 to i32
+  %40 = icmp slt i32 %30, %39
+  br i1 %40, label %7, label %41
+
+; <label>:41                                      ; preds = %35
+  %42 = load i32, i32* %arg0
+  %43 = or i32 %42, 1
+  store i32 %43, i32* %loc2
+  br label %59
+
+; <label>:44                                      ; preds = %59
+  %45 = load i32, i32* %loc2
+  %46 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %45)
+  %47 = zext i8 %46 to i32
+  %48 = icmp eq i32 %47, 0
+  br i1 %48, label %56, label %49
+
+; <label>:49                                      ; preds = %44
+  %50 = load i32, i32* %loc2
+  %51 = sub i32 %50, 1
+  %52 = srem i32 %51, 101
+  %53 = icmp eq i32 %52, 0
+  br i1 %53, label %56, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = load i32, i32* %loc2
+  ret i32 %55
+
+; <label>:56                                      ; preds = %44, %49
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %57, 2
+  store i32 %58, i32* %loc2
+  br label %59
+
+; <label>:59                                      ; preds = %41, %56
+  %60 = load i32, i32* %loc2
+  %61 = icmp slt i32 %60, 2147483647
+  br i1 %61, label %44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load i32, i32* %arg0
+  ret i32 %63
+
+ThrowNullRef:                                     ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
 Successfully read GenericEqualityComparer`1.GetHashCode
 
@@ -3694,14 +4558,14 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
   %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load i64, i64 addrspace(1)* %7
@@ -3720,7 +4584,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3750,8 +4614,8 @@ entry:
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
@@ -3796,8 +4660,8 @@ entry:
   %35 = bitcast i16* %34 to i8*
   %36 = getelementptr inbounds i8, i8* %35, i64 2
   %37 = bitcast i8* %36 to i16*
-  %NullCheck4 = icmp ne i16* %37, null
-  br i1 %NullCheck4, label %38, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %37, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %38
 
 ; <label>:38                                      ; preds = %27
   %39 = load i16, i16* %37, align 8
@@ -3824,8 +4688,8 @@ entry:
 
 ; <label>:54                                      ; preds = %22, %43
   %55 = load i16*, i16** %loc4
-  %NullCheck2 = icmp ne i16* %55, null
-  br i1 %NullCheck2, label %56, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i16* %55, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %56
 
 ; <label>:56                                      ; preds = %54
   %57 = load i16, i16* %55, align 8
@@ -3850,11 +4714,11 @@ ThrowNullRef:                                     ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %54
+ThrowNullRef2:                                    ; preds = %54
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %27
+ThrowNullRef4:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3871,8 +4735,8 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -3907,8 +4771,8 @@ entry:
 
 ; <label>:26                                      ; preds = %19
   %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
-  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %28
 
 ; <label>:28                                      ; preds = %26
   %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
@@ -3920,7 +4784,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3972,8 +4836,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
@@ -3984,26 +4848,26 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
-  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
@@ -4014,8 +4878,8 @@ entry:
 ; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
@@ -4024,8 +4888,8 @@ entry:
 
 ; <label>:25                                      ; preds = %1, %16, %23
   %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
-  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
@@ -4036,27 +4900,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %20
+ThrowNullRef10:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4069,8 +4933,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -4081,8 +4945,8 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
@@ -4091,8 +4955,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1, %8
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
@@ -4103,11 +4967,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4128,24 +4992,24 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   store i32 %3, i32* %loc0
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
   %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
   store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck4, label %9, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
@@ -4164,15 +5028,15 @@ entry:
 ; <label>:18                                      ; preds = %70
   %19 = load i16*, i16** %loc3
   %20 = bitcast i16* %19 to i64*
-  %NullCheck10 = icmp ne i64* %20, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %20, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = load i64, i64* %20, align 8
   %23 = load i16*, i16** %loc4
   %24 = bitcast i16* %23 to i64*
-  %NullCheck12 = icmp ne i64* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = load i64, i64* %24, align 8
@@ -4188,8 +5052,8 @@ entry:
   %31 = bitcast i16* %30 to i8*
   %32 = getelementptr inbounds i8, i8* %31, i64 8
   %33 = bitcast i8* %32 to i64*
-  %NullCheck14 = icmp ne i64* %33, null
-  br i1 %NullCheck14, label %34, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = load i64, i64* %33, align 8
@@ -4197,8 +5061,8 @@ entry:
   %37 = bitcast i16* %36 to i8*
   %38 = getelementptr inbounds i8, i8* %37, i64 8
   %39 = bitcast i8* %38 to i64*
-  %NullCheck16 = icmp ne i64* %39, null
-  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %40
 
 ; <label>:40                                      ; preds = %34
   %41 = load i64, i64* %39, align 8
@@ -4214,8 +5078,8 @@ entry:
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %NullCheck18 = icmp ne i64* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = load i64, i64* %48, align 8
@@ -4223,8 +5087,8 @@ entry:
   %52 = bitcast i16* %51 to i8*
   %53 = getelementptr inbounds i8, i8* %52, i64 16
   %54 = bitcast i8* %53 to i64*
-  %NullCheck20 = icmp ne i64* %54, null
-  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64* %54, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %55
 
 ; <label>:55                                      ; preds = %49
   %56 = load i64, i64* %54, align 8
@@ -4262,15 +5126,15 @@ entry:
 ; <label>:74                                      ; preds = %95
   %75 = load i16*, i16** %loc3
   %76 = bitcast i16* %75 to i32*
-  %NullCheck6 = icmp ne i32* %76, null
-  br i1 %NullCheck6, label %77, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32* %76, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %77
 
 ; <label>:77                                      ; preds = %74
   %78 = load i32, i32* %76, align 8
   %79 = load i16*, i16** %loc4
   %80 = bitcast i16* %79 to i32*
-  %NullCheck8 = icmp ne i32* %80, null
-  br i1 %NullCheck8, label %81, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i32* %80, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %81
 
 ; <label>:81                                      ; preds = %77
   %82 = load i32, i32* %80, align 8
@@ -4318,43 +5182,43 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %74
+ThrowNullRef6:                                    ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %77
+ThrowNullRef8:                                    ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %29
+ThrowNullRef14:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %34
+ThrowNullRef16:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4376,8 +5240,8 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load i64, i64 addrspace(1)* %4
@@ -4389,8 +5253,8 @@ entry:
   %12 = load i64, i64* %11
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %5
   %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
@@ -4399,8 +5263,8 @@ entry:
   %18 = load i8, i8* %arg2
   %19 = zext i8 %18 to i32
   %20 = trunc i32 %19 to i8
-  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %15
   %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
@@ -4411,11 +5275,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4442,8 +5306,8 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
@@ -4466,16 +5330,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
   %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = load i64, i64 addrspace(1)* %19
@@ -4500,8 +5364,8 @@ entry:
 ; <label>:35                                      ; preds = %30
   %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
@@ -4514,8 +5378,8 @@ entry:
 
 ; <label>:42                                      ; preds = %1, %38
   %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
-  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
@@ -4526,19 +5390,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %35
+ThrowNullRef2:                                    ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %42
+ThrowNullRef8:                                    ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4551,14 +5415,14 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
@@ -4570,7 +5434,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4583,8 +5447,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
@@ -4613,51 +5477,51 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
   %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
   %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
   %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
   %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
-  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
   store i64 %21, i64 addrspace(1)* %23
   %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %25 = load i64, i64* %loc0
-  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
@@ -4668,27 +5532,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %22
+ThrowNullRef12:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4701,8 +5565,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
@@ -4713,19 +5577,19 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
@@ -4734,8 +5598,8 @@ entry:
 
 ; <label>:15                                      ; preds = %1, %13
   %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
@@ -4746,19 +5610,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %15
+ThrowNullRef8:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4771,8 +5635,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -4831,8 +5695,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
@@ -4882,8 +5746,8 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
-  br i1 %NullCheck, label %17, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %ThrowNullRef, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
@@ -4894,15 +5758,15 @@ entry:
 
 ; <label>:22                                      ; preds = %17
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
-  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
   %26 = load i32, i32 addrspace(1)* %25
   %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
-  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %27, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
@@ -4925,8 +5789,8 @@ entry:
 ; <label>:40                                      ; preds = %17
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
-  br i1 %NullCheck6, label %43, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %41, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
@@ -4938,34 +5802,17 @@ ThrowNullRef:                                     ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %24
+ThrowNullRef4:                                    ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %40
+ThrowNullRef6:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
-}
-
-INFO:  jitting method Object::ReferenceEquals using LLILCJit
-Successfully read Object.ReferenceEquals
-
-define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
-entry:
-  %arg0 = alloca %System.Object addrspace(1)*
-  %arg1 = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
-  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
-  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = icmp eq %System.Object addrspace(1)* %0, %1
-  %3 = sext i1 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
 }
 
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
@@ -4978,21 +5825,21 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
   %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
-  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
@@ -5007,28 +5854,28 @@ entry:
 ; <label>:13                                      ; preds = %8, %12
   %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
   %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
   %21 = load i32, i32 addrspace(1)* %20, align 8
   %22 = add i32 %21, 1
-  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
   store i32 %22, i32 addrspace(1)* %24
   %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
@@ -5039,27 +5886,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5077,7 +5924,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::Setup using LLILCJit
-Failed to read AppDomain.Setup[loadElem]
+Failed to read AppDomain.Setup[unbox]
 INFO:  jitting method Thread::GetDomain using LLILCJit
 Successfully read Thread.GetDomain
 
@@ -5108,8 +5955,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
@@ -5122,14 +5969,14 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
   %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
@@ -5141,11 +5988,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5173,8 +6020,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -5189,7 +6036,328 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
 Failed to read KeyCollection.System.Collections.Generic.IEnumerable<TKey>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Successfully read Enumerator.MoveNext
+
+define i8 @Enumerator.MoveNext(%"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.RuntimeTypeHandle* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*
+  %"$TypeArg" = alloca %System.RuntimeTypeHandle*
+  store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
+  %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 8
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %76, label %12
+
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
+  br label %76
+
+; <label>:13                                      ; preds = %85
+  %14 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck19 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %15
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, i32 0, i32 0
+  %17 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %16, align 8
+  %NullCheck21 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, i32 0, i32 2
+  %20 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %19, align 8
+  %21 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck23 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %22
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, i32 0, i32 2
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %NullCheck25 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 3, i32 %24
+  %NullCheck27 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %32
+
+; <label>:32                                      ; preds = %30
+  %33 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, i32 0, i32 2
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = icmp slt i32 %34, 0
+  br i1 %35, label %68, label %36
+
+; <label>:36                                      ; preds = %32
+  %37 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %38 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck29 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %39
+
+; <label>:39                                      ; preds = %36
+  %40 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, i32 0, i32 0
+  %41 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %40, align 8
+  %NullCheck31 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, i32 0, i32 2
+  %44 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %43, align 8
+  %45 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck33 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, i32 0, i32 2
+  %48 = load i32, i32 addrspace(1)* %47, align 8
+  %NullCheck35 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %49
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = zext i32 %51 to i64
+  %53 = zext i32 %48 to i64
+  %BoundsCheck37 = icmp uge i64 %53, %52
+  br i1 %BoundsCheck37, label %ThrowIndexOutOfRange38, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 3, i32 %48
+  %NullCheck39 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %56
+
+; <label>:56                                      ; preds = %54
+  %57 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, i32 0, i32 0
+  %58 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck41 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %59
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %60, %System.__Canon addrspace(1)* %58)
+  %61 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck43 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  %64 = load i32, i32 addrspace(1)* %63, align 8
+  %65 = add i32 %64, 1
+  %NullCheck45 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  store i32 %65, i32 addrspace(1)* %67
+  ret i8 1
+
+; <label>:68                                      ; preds = %32
+  %69 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck47 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %73 = add i32 %72, 1
+  %NullCheck49 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %74
+
+; <label>:74                                      ; preds = %70
+  %75 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  store i32 %73, i32 addrspace(1)* %75
+  br label %76
+
+; <label>:76                                      ; preds = %8, %12, %74
+  %77 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %78
+
+; <label>:78                                      ; preds = %76
+  %79 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, i32 0, i32 2
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck7 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %82
+
+; <label>:82                                      ; preds = %78
+  %83 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, i32 0, i32 0
+  %84 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %83, align 8
+  %NullCheck9 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %85
+
+; <label>:85                                      ; preds = %82
+  %86 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, i32 0, i32 7
+  %87 = load i32, i32 addrspace(1)* %86, align 8
+  %88 = icmp ult i32 %80, %87
+  br i1 %88, label %13, label %89
+
+; <label>:89                                      ; preds = %85
+  %90 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %91 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck11 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %92
+
+; <label>:92                                      ; preds = %89
+  %93 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, i32 0, i32 0
+  %94 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck13 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %95
+
+; <label>:95                                      ; preds = %92
+  %96 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, i32 0, i32 7
+  %97 = load i32, i32 addrspace(1)* %96, align 8
+  %98 = add i32 %97, 1
+  %NullCheck15 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %99
+
+; <label>:99                                      ; preds = %95
+  %100 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, i32 0, i32 2
+  store i32 %98, i32 addrspace(1)* %100
+  %101 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck17 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %102
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %103, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %92
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef22:                                   ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef24:                                   ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef26:                                   ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef28:                                   ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef30:                                   ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef32:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef34:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef36:                                   ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange38:                           ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef40:                                   ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef42:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef44:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef46:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef48:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef50:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -5200,8 +6368,8 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -5232,9 +6400,9 @@ Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
 Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
-Failed to read String.MakeSeparatorList[loadElemA]
+Failed to read String.MakeSeparatorList[storeElem]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
-Failed to read String.InternalSplitKeepEmptyEntries[loadElem]
+Failed to read String.InternalSplitKeepEmptyEntries[storeElem]
 INFO:  jitting method Path::IsRelative using LLILCJit
 Successfully read Path.IsRelative
 
@@ -5243,8 +6411,8 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -5254,8 +6422,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
@@ -5271,8 +6439,8 @@ entry:
 
 ; <label>:17                                      ; preds = %7
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
@@ -5288,8 +6456,8 @@ entry:
 
 ; <label>:29                                      ; preds = %19
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %31
 
 ; <label>:31                                      ; preds = %29
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
@@ -5300,8 +6468,8 @@ entry:
 
 ; <label>:36                                      ; preds = %31
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
-  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %37, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
@@ -5312,8 +6480,8 @@ entry:
 
 ; <label>:43                                      ; preds = %31, %38
   %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
-  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %45
 
 ; <label>:45                                      ; preds = %43
   %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
@@ -5324,8 +6492,8 @@ entry:
 
 ; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %50
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
@@ -5336,8 +6504,8 @@ entry:
 
 ; <label>:57                                      ; preds = %1, %7, %19, %45, %52
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
-  br i1 %NullCheck14, label %59, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %59
 
 ; <label>:59                                      ; preds = %57
   %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
@@ -5347,8 +6515,8 @@ entry:
 
 ; <label>:63                                      ; preds = %59
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
@@ -5359,8 +6527,8 @@ entry:
 
 ; <label>:70                                      ; preds = %65
   %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
-  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.String addrspace(1)* %71, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %72
 
 ; <label>:72                                      ; preds = %70
   %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
@@ -5379,39 +6547,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %17
+ThrowNullRef4:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %29
+ThrowNullRef6:                                    ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %36
+ThrowNullRef8:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %43
+ThrowNullRef10:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %50
+ThrowNullRef12:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %57
+ThrowNullRef14:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %63
+ThrowNullRef16:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %70
+ThrowNullRef18:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5419,7 +6587,293 @@ ThrowNullRef17:                                   ; preds = %70
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
-Failed to read String.TrimHelper[loadElem]
+Successfully read String.TrimHelper
+
+define %System.String addrspace(1)* @String.TrimHelper(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i16
+  %loc4 = alloca i32
+  %loc5 = alloca i16
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = sub i32 %3, 1
+  store i32 %4, i32* %loc0
+  store i32 0, i32* %loc1
+  %5 = load i32, i32* %arg2
+  %6 = icmp eq i32 %5, 1
+  br i1 %6, label %62, label %7
+
+; <label>:7                                       ; preds = %1
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:8                                       ; preds = %58
+  store i32 0, i32* %loc2
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load i32, i32* %loc1
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2, i32 %10
+  %13 = load i16, i16 addrspace(1)* %12
+  %14 = zext i16 %13 to i32
+  %15 = trunc i32 %14 to i16
+  store i16 %15, i16* %loc3
+  store i32 0, i32* %loc2
+  br label %34
+
+; <label>:16                                      ; preds = %37
+  %17 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %18 = load i32, i32* %loc2
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %17, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %19
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = zext i32 %18 to i64
+  %BoundsCheck = icmp uge i64 %23, %22
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %24
+
+; <label>:24                                      ; preds = %19
+  %25 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 3, i32 %18
+  %26 = load i16, i16 addrspace(1)* %25, align 8
+  %27 = zext i16 %26 to i32
+  %28 = load i16, i16* %loc3
+  %29 = zext i16 %28 to i32
+  %30 = icmp eq i32 %27, %29
+  br i1 %30, label %43, label %31
+
+; <label>:31                                      ; preds = %24
+  %32 = load i32, i32* %loc2
+  %33 = add i32 %32, 1
+  store i32 %33, i32* %loc2
+  br label %34
+
+; <label>:34                                      ; preds = %11, %31
+  %35 = load i32, i32* %loc2
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = icmp slt i32 %35, %41
+  br i1 %42, label %16, label %43
+
+; <label>:43                                      ; preds = %24, %37
+  %44 = load i32, i32* %loc2
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %45, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp eq i32 %44, %50
+  br i1 %51, label %62, label %52
+
+; <label>:52                                      ; preds = %46
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %7, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %57, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %58
+
+; <label>:58                                      ; preds = %55
+  %59 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %60 = load i32, i32 addrspace(1)* %59
+  %61 = icmp slt i32 %56, %60
+  br i1 %61, label %8, label %62
+
+; <label>:62                                      ; preds = %1, %46, %58
+  %63 = load i32, i32* %arg2
+  %64 = icmp eq i32 %63, 0
+  br i1 %64, label %122, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %66, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %67
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %66, i32 0, i32 1
+  %69 = load i32, i32 addrspace(1)* %68
+  %70 = sub i32 %69, 1
+  store i32 %70, i32* %loc0
+  br label %118
+
+; <label>:71                                      ; preds = %118
+  store i32 0, i32* %loc4
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %73 = load i32, i32* %loc0
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %74
+
+; <label>:74                                      ; preds = %71
+  %75 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 2, i32 %73
+  %76 = load i16, i16 addrspace(1)* %75
+  %77 = zext i16 %76 to i32
+  %78 = trunc i32 %77 to i16
+  store i16 %78, i16* %loc5
+  store i32 0, i32* %loc4
+  br label %97
+
+; <label>:79                                      ; preds = %100
+  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %81 = load i32, i32* %loc4
+  %NullCheck19 = icmp eq %"System.Char[]" addrspace(1)* %80, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
+
+; <label>:82                                      ; preds = %79
+  %83 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 1
+  %84 = load i32, i32 addrspace(1)* %83
+  %85 = zext i32 %84 to i64
+  %86 = zext i32 %81 to i64
+  %BoundsCheck21 = icmp uge i64 %86, %85
+  br i1 %BoundsCheck21, label %ThrowIndexOutOfRange22, label %87
+
+; <label>:87                                      ; preds = %82
+  %88 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 3, i32 %81
+  %89 = load i16, i16 addrspace(1)* %88, align 8
+  %90 = zext i16 %89 to i32
+  %91 = load i16, i16* %loc5
+  %92 = zext i16 %91 to i32
+  %93 = icmp eq i32 %90, %92
+  br i1 %93, label %106, label %94
+
+; <label>:94                                      ; preds = %87
+  %95 = load i32, i32* %loc4
+  %96 = add i32 %95, 1
+  store i32 %96, i32* %loc4
+  br label %97
+
+; <label>:97                                      ; preds = %74, %94
+  %98 = load i32, i32* %loc4
+  %99 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck15 = icmp eq %"System.Char[]" addrspace(1)* %99, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %100
+
+; <label>:100                                     ; preds = %97
+  %101 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %99, i32 0, i32 1
+  %102 = load i32, i32 addrspace(1)* %101
+  %103 = zext i32 %102 to i64
+  %104 = trunc i64 %103 to i32
+  %105 = icmp slt i32 %98, %104
+  br i1 %105, label %79, label %106
+
+; <label>:106                                     ; preds = %87, %100
+  %107 = load i32, i32* %loc4
+  %108 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck17 = icmp eq %"System.Char[]" addrspace(1)* %108, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %109
+
+; <label>:109                                     ; preds = %106
+  %110 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %108, i32 0, i32 1
+  %111 = load i32, i32 addrspace(1)* %110
+  %112 = zext i32 %111 to i64
+  %113 = trunc i64 %112 to i32
+  %114 = icmp eq i32 %107, %113
+  br i1 %114, label %122, label %115
+
+; <label>:115                                     ; preds = %109
+  %116 = load i32, i32* %loc0
+  %117 = sub i32 %116, 1
+  store i32 %117, i32* %loc0
+  br label %118
+
+; <label>:118                                     ; preds = %67, %115
+  %119 = load i32, i32* %loc0
+  %120 = load i32, i32* %loc1
+  %121 = icmp sge i32 %119, %120
+  br i1 %121, label %71, label %122
+
+; <label>:122                                     ; preds = %62, %109, %118
+  %123 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %124 = load i32, i32* %loc1
+  %125 = load i32, i32* %loc0
+  %126 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %123, i32 %124, i32 %125)
+  ret %System.String addrspace(1)* %126
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %97
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange22:                           ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
 Successfully read String.CreateTrimmedString
 
@@ -5439,8 +6893,8 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
@@ -5535,8 +6989,8 @@ entry:
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i64 2872
   %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
   %8 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %7
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %3
   %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
@@ -5553,8 +7007,8 @@ entry:
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 2864
   %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
   %21 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %20
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
-  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %22
 
 ; <label>:22                                      ; preds = %16
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
@@ -5569,7 +7023,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %16
+ThrowNullRef2:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5586,8 +7040,8 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5613,8 +7067,8 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
@@ -5632,8 +7086,8 @@ entry:
 
 ; <label>:12                                      ; preds = %4
   %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
@@ -5644,8 +7098,8 @@ entry:
 
 ; <label>:19                                      ; preds = %14
   %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %19
   %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
@@ -5660,21 +7114,21 @@ entry:
   %31 = zext i16 %30 to i32
   %32 = bitcast i8* %29 to i16*
   %33 = trunc i32 %31 to i16
-  %NullCheck6 = icmp ne i16* %32, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i16* %32, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %21
   store i16 %33, i16* %32, align 8
   %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %36
 
 ; <label>:36                                      ; preds = %34
   %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
   %38 = load i32, i32 addrspace(1)* %37, align 8
   %39 = add i32 %38, 1
-  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %40
 
 ; <label>:40                                      ; preds = %36
   %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
@@ -5683,16 +7137,16 @@ entry:
 
 ; <label>:42                                      ; preds = %14
   %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
-  br i1 %NullCheck12, label %44, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
   %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
   %47 = load i16, i16* %arg1
   %48 = zext i16 %47 to i32
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = trunc i32 %48 to i16
@@ -5703,31 +7157,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %19
+ThrowNullRef4:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %21
+ThrowNullRef6:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %36
+ThrowNullRef10:                                   ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %42
+ThrowNullRef12:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %44
+ThrowNullRef14:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5740,8 +7194,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -5752,8 +7206,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
@@ -5762,14 +7216,14 @@ entry:
 
 ; <label>:11                                      ; preds = %1
   %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
@@ -5779,15 +7233,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5808,8 +7262,8 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5822,8 +7276,8 @@ entry:
 
 ; <label>:8                                       ; preds = %3
   %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
@@ -5842,15 +7296,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
-  br i1 %NullCheck4, label %22, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
   %24 = load i16*, i16* addrspace(1)* %23, align 8
   %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %25, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
@@ -5859,8 +7313,8 @@ entry:
   store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
@@ -5874,8 +7328,8 @@ entry:
 
 ; <label>:37                                      ; preds = %65
   %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %37
   %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
@@ -5886,16 +7340,16 @@ entry:
   %45 = bitcast i16* %41 to i8*
   %46 = getelementptr inbounds i8, i8* %45, i64 %44
   %47 = bitcast i8* %46 to i16*
-  %NullCheck14 = icmp ne i16* %47, null
-  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %47, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %48
 
 ; <label>:48                                      ; preds = %39
   %49 = load i16, i16* %47, align 8
   %50 = zext i16 %49 to i32
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %52 = load i32, i32* %loc1
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %53
 
 ; <label>:53                                      ; preds = %48
   %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
@@ -5916,8 +7370,8 @@ entry:
 ; <label>:62                                      ; preds = %36, %59
   %63 = load i32, i32* %loc1
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck10, label %65, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %65
 
 ; <label>:65                                      ; preds = %62
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
@@ -5936,15 +7390,15 @@ entry:
 
 ; <label>:74                                      ; preds = %70
   %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
-  br i1 %NullCheck18, label %76, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %76
 
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
   %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
-  br i1 %NullCheck20, label %80, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
   %81 = load i64, i64 addrspace(1)* %79
@@ -5958,8 +7412,8 @@ entry:
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
   %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
-  br i1 %NullCheck22, label %92, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.String addrspace(1)* %90, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %92
 
 ; <label>:92                                      ; preds = %80
   %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
@@ -5969,15 +7423,15 @@ entry:
 
 ; <label>:96                                      ; preds = %70
   %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
-  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %98
 
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
   %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
-  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
   %103 = load i64, i64 addrspace(1)* %101
@@ -5991,8 +7445,8 @@ entry:
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
   %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
-  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.String addrspace(1)* %112, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %114
 
 ; <label>:114                                     ; preds = %102
   %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
@@ -6004,59 +7458,59 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %20
+ThrowNullRef4:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %22
+ThrowNullRef6:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %26
+ThrowNullRef8:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %62
+ThrowNullRef10:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %48
+ThrowNullRef16:                                   ; preds = %48
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %74
+ThrowNullRef18:                                   ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %76
+ThrowNullRef20:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %80
+ThrowNullRef22:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %96
+ThrowNullRef24:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %98
+ThrowNullRef26:                                   ; preds = %98
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %102
+ThrowNullRef28:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6069,15 +7523,15 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
   %3 = load i16*, i16* addrspace(1)* %2, align 8
   %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
@@ -6087,8 +7541,8 @@ entry:
   %10 = bitcast i16* %3 to i8*
   %11 = getelementptr inbounds i8, i8* %10, i64 %9
   %12 = bitcast i8* %11 to i16*
-  %NullCheck4 = icmp ne i16* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %5
   store i16 0, i16* %12, align 8
@@ -6098,11 +7552,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6119,8 +7573,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -6131,8 +7585,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
@@ -6144,15 +7598,15 @@ entry:
 
 ; <label>:14                                      ; preds = %1
   %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
   %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
   %21 = load i64, i64 addrspace(1)* %19
@@ -6171,15 +7625,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %14
+ThrowNullRef4:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %16
+ThrowNullRef6:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6302,14 +7756,6 @@ entry:
   ret %System.String addrspace(1)* %57
 }
 
-INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
-Successfully read RuntimeHelpers.get_OffsetToStringData
-
-define i32 @RuntimeHelpers.get_OffsetToStringData() {
-entry:
-  ret i32 12
-}
-
 INFO:  jitting method String::Equals using LLILCJit
 Successfully read String.Equals
 
@@ -6381,8 +7827,8 @@ entry:
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
-  br i1 %NullCheck24, label %29, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
   %30 = load i64, i64 addrspace(1)* %28
@@ -6397,8 +7843,8 @@ entry:
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
-  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
   %43 = load i64, i64 addrspace(1)* %41
@@ -6418,8 +7864,8 @@ entry:
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
   %59 = load i64, i64 addrspace(1)* %57
@@ -6434,8 +7880,8 @@ entry:
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck22, label %71, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
   %72 = load i64, i64 addrspace(1)* %70
@@ -6455,8 +7901,8 @@ entry:
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
-  br i1 %NullCheck16, label %87, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = load i64, i64 addrspace(1)* %86
@@ -6471,8 +7917,8 @@ entry:
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck18, label %100, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
   %101 = load i64, i64 addrspace(1)* %99
@@ -6492,8 +7938,8 @@ entry:
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
-  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
   %117 = load i64, i64 addrspace(1)* %115
@@ -6508,8 +7954,8 @@ entry:
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
-  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
   %130 = load i64, i64 addrspace(1)* %128
@@ -6528,15 +7974,15 @@ entry:
 
 ; <label>:142                                     ; preds = %22
   %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
-  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %143, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %144
 
 ; <label>:144                                     ; preds = %142
   %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
   %146 = load i32, i32 addrspace(1)* %145
   %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
-  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %147, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %148
 
 ; <label>:148                                     ; preds = %144
   %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
@@ -6557,15 +8003,15 @@ entry:
 
 ; <label>:159                                     ; preds = %22
   %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
-  br i1 %NullCheck, label %161, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %ThrowNullRef, label %161
 
 ; <label>:161                                     ; preds = %159
   %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
   %163 = load i32, i32 addrspace(1)* %162
   %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
-  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %164, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %165
 
 ; <label>:165                                     ; preds = %161
   %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
@@ -6578,8 +8024,8 @@ entry:
 
 ; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
-  br i1 %NullCheck4, label %172, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %171, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %172
 
 ; <label>:172                                     ; preds = %170
   %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
@@ -6589,8 +8035,8 @@ entry:
 
 ; <label>:176                                     ; preds = %172
   %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
-  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %177, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %178
 
 ; <label>:178                                     ; preds = %176
   %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
@@ -6629,55 +8075,55 @@ ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %161
+ThrowNullRef2:                                    ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %170
+ThrowNullRef4:                                    ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %176
+ThrowNullRef6:                                    ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %142
+ThrowNullRef8:                                    ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %144
+ThrowNullRef10:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %113
+ThrowNullRef12:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %116
+ThrowNullRef14:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %84
+ThrowNullRef16:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %87
+ThrowNullRef18:                                   ; preds = %87
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %55
+ThrowNullRef20:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %58
+ThrowNullRef22:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %26
+ThrowNullRef24:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %29
+ThrowNullRef26:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,8 +8161,8 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck, label %14, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %ThrowNullRef, label %14
 
 ; <label>:14                                      ; preds = %8
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
@@ -6760,8 +8206,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
@@ -6770,14 +8216,14 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32, i32* %loc0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %10
   %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
   %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
@@ -6790,15 +8236,15 @@ entry:
 ; <label>:25                                      ; preds = %19
   %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
-  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
   %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
@@ -6807,8 +8253,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %37 = load i32, i32* %loc0
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %38, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %38
 
 ; <label>:38                                      ; preds = %32
   %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
@@ -6817,14 +8263,14 @@ entry:
 
 ; <label>:40                                      ; preds = %19
   %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %40
   %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
   %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
-  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
-  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
@@ -6832,8 +8278,8 @@ entry:
   %48 = zext i32 %47 to i64
   %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
-  br i1 %NullCheck16, label %51, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %51
 
 ; <label>:51                                      ; preds = %45
   %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
@@ -6847,15 +8293,15 @@ entry:
 ; <label>:57                                      ; preds = %51
   %58 = load i16*, i16** %arg1
   %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
-  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %60
 
 ; <label>:60                                      ; preds = %57
   %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
   %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
-  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %64
 
 ; <label>:64                                      ; preds = %60
   %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
@@ -6864,22 +8310,22 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
   %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
-  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %70
 
 ; <label>:70                                      ; preds = %64
   %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
   %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
-  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
-  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
   %75 = load i32, i32 addrspace(1)* %74
   %76 = zext i32 %75 to i64
   %77 = trunc i64 %76 to i32
-  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
-  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %78
 
 ; <label>:78                                      ; preds = %73
   %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
@@ -6901,8 +8347,8 @@ entry:
   %90 = bitcast i16* %86 to i8*
   %91 = getelementptr inbounds i8, i8* %90, i64 %89
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %93
 
 ; <label>:93                                      ; preds = %80
   %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
@@ -6912,8 +8358,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %99 = load i32, i32* %loc2
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %100
 
 ; <label>:100                                     ; preds = %93
   %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
@@ -6928,63 +8374,63 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %25
+ThrowNullRef6:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %32
+ThrowNullRef10:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %40
+ThrowNullRef12:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %45
+ThrowNullRef16:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %57
+ThrowNullRef18:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %60
+ThrowNullRef20:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %64
+ThrowNullRef22:                                   ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %70
+ThrowNullRef24:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %73
+ThrowNullRef26:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %80
+ThrowNullRef28:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %93
+ThrowNullRef30:                                   ; preds = %93
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7004,8 +8450,8 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
@@ -7033,43 +8479,43 @@ entry:
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %14
   %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
   %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   %28 = load i32, i32 addrspace(1)* %27, align 8
   %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
-  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %30
 
 ; <label>:30                                      ; preds = %26
   %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
   %32 = load i32, i32 addrspace(1)* %31, align 8
   %33 = add i32 %28, %32
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %34
 
 ; <label>:34                                      ; preds = %30
   %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   store i32 %33, i32 addrspace(1)* %35
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
   store i32 0, i32 addrspace(1)* %38
   %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %40
 
 ; <label>:40                                      ; preds = %37
   %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
@@ -7082,8 +8528,8 @@ entry:
 
 ; <label>:47                                      ; preds = %40
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
@@ -7098,8 +8544,8 @@ entry:
   %54 = load i32, i32* %loc0
   %55 = sext i32 %54 to i64
   %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
-  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %57
 
 ; <label>:57                                      ; preds = %52
   %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
@@ -7110,68 +8556,35 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %14
+ThrowNullRef2:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %23
+ThrowNullRef4:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %26
+ThrowNullRef6:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %30
+ThrowNullRef8:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %34
+ThrowNullRef10:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %47
+ThrowNullRef14:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %52
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-}
-
-INFO:  jitting method StringBuilder::get_Length using LLILCJit
-Successfully read StringBuilder.get_Length
-
-define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.StringBuilder addrspace(1)*
-  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
-  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
-
-; <label>:1                                       ; preds = %entry
-  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %3 = load i32, i32 addrspace(1)* %2, align 8
-  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
-
-; <label>:5                                       ; preds = %1
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = add i32 %3, %7
-  ret i32 %8
-
-ThrowNullRef:                                     ; preds = %entry
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef16:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7213,70 +8626,70 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
   %6 = load i32, i32 addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
   store i32 %6, i32 addrspace(1)* %8
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
   %13 = load i32, i32 addrspace(1)* %12, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
   store i32 %13, i32 addrspace(1)* %15
   %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
-  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %18
 
 ; <label>:18                                      ; preds = %14
   %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
   %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
   %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
   %34 = load i32, i32 addrspace(1)* %33, align 8
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
-  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
@@ -7287,39 +8700,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %28
+ThrowNullRef16:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %32
+ThrowNullRef18:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7455,13 +8868,13 @@ entry:
 ; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
@@ -7477,16 +8890,16 @@ entry:
 
 ; <label>:18                                      ; preds = %15
   %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
   store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
   %22 = load i32, i32* %loc0
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %24
 
 ; <label>:24                                      ; preds = %20
   %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
@@ -7498,13 +8911,13 @@ entry:
 ; <label>:28                                      ; preds = %15, %24
   %29 = load i32, i32* %arg1
   %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %31
   %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
@@ -7517,20 +8930,20 @@ entry:
   %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
-  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
   %46 = load i32, i32 addrspace(1)* %45, align 8
   %47 = sub i32 %40, %46
-  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
-  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i32 addrspace(1)* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %48
 
 ; <label>:48                                      ; preds = %44
   store i32 %47, i32 addrspace(1)* %39, align 8
@@ -7538,21 +8951,21 @@ entry:
 
 ; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
-  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %51
 
 ; <label>:51                                      ; preds = %49
   %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %53
 
 ; <label>:53                                      ; preds = %51
   %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
   %55 = load i32, i32 addrspace(1)* %54, align 8
   %56 = load i32, i32* %arg2
   %57 = sub i32 %55, %56
-  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %58
 
 ; <label>:58                                      ; preds = %53
   %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
@@ -7562,13 +8975,13 @@ entry:
 ; <label>:60                                      ; preds = %33, %58
   %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
   %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
-  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %63
 
 ; <label>:63                                      ; preds = %60
   %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
-  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
-  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
@@ -7578,15 +8991,15 @@ entry:
 
 ; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
-  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i32 addrspace(1)* %69, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %70
 
 ; <label>:70                                      ; preds = %68
   %71 = load i32, i32 addrspace(1)* %69, align 8
   store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
-  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
@@ -7596,8 +9009,8 @@ entry:
   store i32 %77, i32* %loc4
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
-  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %80
 
 ; <label>:80                                      ; preds = %73
   %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
@@ -7607,71 +9020,71 @@ entry:
 ; <label>:83                                      ; preds = %80
   store i32 0, i32* %loc3
   %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
-  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
-  br i1 %NullCheck26, label %88, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i32 addrspace(1)* %87, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %88
 
 ; <label>:88                                      ; preds = %85
   %89 = load i32, i32 addrspace(1)* %87, align 8
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
-  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %90
 
 ; <label>:90                                      ; preds = %88
   %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
   store i32 %89, i32 addrspace(1)* %91
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
-  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
-  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %96
 
 ; <label>:96                                      ; preds = %94
   %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
-  br i1 %NullCheck34, label %100, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %100
 
 ; <label>:100                                     ; preds = %96
   %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
-  br i1 %NullCheck36, label %102, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %102
 
 ; <label>:102                                     ; preds = %100
   %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
   %104 = load i32, i32 addrspace(1)* %103, align 8
   %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
-  br i1 %NullCheck38, label %106, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %106
 
 ; <label>:106                                     ; preds = %102
   %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
-  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
-  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %108
 
 ; <label>:108                                     ; preds = %106
   %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
   %110 = load i32, i32 addrspace(1)* %109, align 8
   %111 = add i32 %104, %110
-  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %112
 
 ; <label>:112                                     ; preds = %108
   %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
   store i32 %111, i32 addrspace(1)* %113
   %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
-  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i32 addrspace(1)* %114, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %115
 
 ; <label>:115                                     ; preds = %112
   %116 = load i32, i32 addrspace(1)* %114, align 8
@@ -7681,19 +9094,19 @@ entry:
 ; <label>:118                                     ; preds = %115
   %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
-  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %121
 
 ; <label>:121                                     ; preds = %118
   %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
-  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
-  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %123
 
 ; <label>:123                                     ; preds = %121
   %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
   %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
-  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
-  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %126
 
 ; <label>:126                                     ; preds = %123
   %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
@@ -7705,8 +9118,8 @@ entry:
 
 ; <label>:130                                     ; preds = %80, %115, %126
   %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %132
 
 ; <label>:132                                     ; preds = %130
   %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7715,8 +9128,8 @@ entry:
   %136 = load i32, i32* %loc3
   %137 = sub i32 %135, %136
   %138 = sub i32 %134, %137
-  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %139
 
 ; <label>:139                                     ; preds = %132
   %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7728,16 +9141,16 @@ entry:
 
 ; <label>:144                                     ; preds = %139
   %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
-  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %146
 
 ; <label>:146                                     ; preds = %144
   %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
   %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
   %149 = load i32, i32* %loc2
   %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
-  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %151
 
 ; <label>:151                                     ; preds = %146
   %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
@@ -7754,145 +9167,249 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %18
+ThrowNullRef4:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %31
+ThrowNullRef10:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %44
+ThrowNullRef16:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %68
+ThrowNullRef18:                                   ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %70
+ThrowNullRef20:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %73
+ThrowNullRef22:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %83
+ThrowNullRef24:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %85
+ThrowNullRef26:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %88
+ThrowNullRef28:                                   ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %90
+ThrowNullRef30:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %94
+ThrowNullRef32:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %96
+ThrowNullRef34:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %100
+ThrowNullRef36:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %102
+ThrowNullRef38:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %106
+ThrowNullRef40:                                   ; preds = %106
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %108
+ThrowNullRef42:                                   ; preds = %108
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %112
+ThrowNullRef44:                                   ; preds = %112
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %118
+ThrowNullRef46:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %121
+ThrowNullRef48:                                   ; preds = %121
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %123
+ThrowNullRef50:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %130
+ThrowNullRef52:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %132
+ThrowNullRef54:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %144
+ThrowNullRef56:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %146
+ThrowNullRef58:                                   ; preds = %146
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %60
+ThrowNullRef60:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %63
+ThrowNullRef62:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %49
+ThrowNullRef64:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %51
+ThrowNullRef66:                                   ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %53
+ThrowNullRef68:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(%"System.Char[]" addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %arg0 = alloca %"System.Char[]" addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store %"System.Char[]" addrspace(1)* %param0, %"System.Char[]" addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load i32, i32* %arg4
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %43, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %38, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg1
+  %13 = load i32, i32* %arg4
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %38, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %24 = load i32, i32* %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %35 = load i32, i32* %arg3
+  %36 = load i32, i32* %arg4
+  %37 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %37, %"System.Char[]" addrspace(1)* %34, i32 %35, i32 %36)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:38                                      ; preds = %5, %16
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Successfully read Buffer._Memmove
 
@@ -7914,7 +9431,7 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[loadElem]
+Failed to read AppDomain.SetDataHelper[storeElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -7923,8 +9440,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
@@ -7934,8 +9451,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
@@ -7947,15 +9464,15 @@ entry:
   %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
   %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
@@ -7966,15 +9483,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7992,7 +9509,79 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
-Failed to read Dictionary`2.TryGetValue[loadElemA]
+Successfully read Dictionary`2.TryGetValue
+
+define i8 @"Dictionary`2.TryGetValue"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)* addrspace(1)* %param2) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  %arg2 = alloca %System.__Canon addrspace(1)* addrspace(1)*
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  store %System.__Canon addrspace(1)* addrspace(1)* %param2, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  store i32 %2, i32* %loc0
+  %3 = load i32, i32* %loc0
+  %4 = icmp slt i32 %3, 0
+  br i1 %4, label %22, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 2
+  %10 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %9, align 8
+  %11 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = zext i32 %11 to i64
+  %BoundsCheck = icmp uge i64 %16, %15
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 3, i32 %11
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %20, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %6, %System.__Canon addrspace(1)* %21)
+  ret i8 1
+
+; <label>:22                                      ; preds = %entry
+  %23 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %23, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -8058,8 +9647,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
@@ -8091,8 +9680,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
@@ -8171,15 +9760,15 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck, label %19, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %ThrowNullRef, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
   %21 = load i32, i32 addrspace(1)* %20
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
@@ -8202,7 +9791,7 @@ ThrowNullRef:                                     ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %19
+ThrowNullRef2:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8248,8 +9837,8 @@ entry:
   %0 = alloca %System.AppDomainHandle
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %1 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %1, i32 0, i32 15
@@ -8269,8 +9858,8 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
@@ -8286,7 +9875,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -8299,8 +9888,8 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -8327,8 +9916,8 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
@@ -8352,8 +9941,8 @@ entry:
   %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
   store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
@@ -8363,8 +9952,8 @@ entry:
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
@@ -8374,8 +9963,8 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %9
   %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
@@ -8384,8 +9973,8 @@ entry:
 
 ; <label>:18                                      ; preds = %3, %16
   %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
@@ -8397,15 +9986,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %18
+ThrowNullRef6:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8418,8 +10007,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
@@ -8453,15 +10042,15 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
@@ -8473,7 +10062,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8481,7 +10070,7 @@ ThrowNullRef1:                                    ; preds = %1
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
 Failed to read Dictionary`2.System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
@@ -8506,8 +10095,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
@@ -8524,8 +10113,8 @@ entry:
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -8544,7 +10133,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8577,8 +10166,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = load i64, i64* %arg2
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = trunc i32 %3 to i8
@@ -8634,46 +10223,46 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
   %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
-  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
-  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
-  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
@@ -8684,27 +10273,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %20
+ThrowNullRef12:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8717,8 +10306,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -8756,22 +10345,22 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
   %9 = load i64, i64 addrspace(1)* %8, align 8
   %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
   %13 = load i64, i64 addrspace(1)* %12, align 8
   %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %11
   %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
@@ -8788,11 +10377,11 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8882,8 +10471,8 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
@@ -8900,8 +10489,8 @@ entry:
 ; <label>:8                                       ; preds = %1
   %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
   %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
@@ -8911,15 +10500,15 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
   %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
   %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
-  br i1 %NullCheck6, label %21, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
@@ -8946,15 +10535,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8992,15 +10581,15 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
   store i8 %3, i8 addrspace(1)* %5
   %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
@@ -9011,7 +10600,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9027,8 +10616,8 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -9041,8 +10630,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
@@ -9058,7 +10647,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9080,8 +10669,8 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
@@ -9096,8 +10685,8 @@ entry:
 ; <label>:12                                      ; preds = %6
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
@@ -9112,8 +10701,8 @@ entry:
 ; <label>:21                                      ; preds = %15
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
@@ -9128,8 +10717,8 @@ entry:
 ; <label>:30                                      ; preds = %24
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %31, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
@@ -9144,8 +10733,8 @@ entry:
 ; <label>:39                                      ; preds = %33
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
-  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %40, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %42
 
 ; <label>:42                                      ; preds = %39
   %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
@@ -9164,19 +10753,19 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %21
+ThrowNullRef4:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %30
+ThrowNullRef6:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %39
+ThrowNullRef8:                                    ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9243,8 +10832,8 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
@@ -9264,57 +10853,57 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
   store i8 0, i8 addrspace(1)* %2
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
   store i8 0, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
   store i8 0, i8 addrspace(1)* %17
   %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
   store i8 0, i8 addrspace(1)* %20
   %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
-  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
@@ -9325,31 +10914,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %19
+ThrowNullRef14:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9367,8 +10956,8 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
@@ -9380,8 +10969,8 @@ entry:
 
 ; <label>:9                                       ; preds = %4
   %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %9
   %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
@@ -9395,7 +10984,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef2:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9420,8 +11009,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
@@ -9512,8 +11101,8 @@ entry:
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
@@ -9524,8 +11113,8 @@ entry:
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = load i64, i64 addrspace(1)* %12
@@ -9537,8 +11126,8 @@ entry:
   %20 = load i64, i64* %19
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
-  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %13
   %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
@@ -9555,8 +11144,8 @@ entry:
 ; <label>:30                                      ; preds = %25
   %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %32 = load i32, i32* %arg2
-  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
-  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
@@ -9570,15 +11159,15 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %30
+ThrowNullRef2:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9622,87 +11211,87 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
   %10 = load i8, i8 addrspace(1)* %9, align 8
   %11 = zext i8 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %8
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
   store i8 %12, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
   %19 = load i8, i8 addrspace(1)* %18, align 8
   %20 = zext i8 %19 to i32
   %21 = trunc i32 %20 to i8
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
   store i8 %21, i8 addrspace(1)* %23
   %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
   %28 = load i8, i8 addrspace(1)* %27, align 8
   %29 = zext i8 %28 to i32
   %30 = trunc i32 %29 to i8
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
-  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %31
 
 ; <label>:31                                      ; preds = %26
   %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
   store i8 %30, i8 addrspace(1)* %32
   %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
-  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
-  br i1 %NullCheck14, label %40, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %40
 
 ; <label>:40                                      ; preds = %35
   %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
   store i8 %39, i8 addrspace(1)* %41
   %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
-  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %44
 
 ; <label>:44                                      ; preds = %40
   %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
   %46 = load i8, i8 addrspace(1)* %45, align 8
   %47 = zext i8 %46 to i32
   %48 = trunc i32 %47 to i8
-  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
   store i8 %48, i8 addrspace(1)* %50
   %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
-  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
@@ -9713,29 +11302,29 @@ entry:
 ; <label>:56                                      ; preds = %52
   %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
-  br i1 %NullCheck22, label %59, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
   %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
   %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
-  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
-  br i1 %NullCheck24, label %63, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
   %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
-  br i1 %NullCheck26, label %66, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
   %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
-  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
-  br i1 %NullCheck28, label %69, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %69
 
 ; <label>:69                                      ; preds = %66
   %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
@@ -9744,15 +11333,15 @@ entry:
 
 ; <label>:71                                      ; preds = %105
   %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
-  br i1 %NullCheck34, label %73, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %73
 
 ; <label>:73                                      ; preds = %71
   %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
   %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
   %76 = load i32, i32* %loc0
-  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
-  br i1 %NullCheck36, label %77, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
@@ -9766,8 +11355,8 @@ entry:
 
 ; <label>:83                                      ; preds = %77
   %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
-  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
@@ -9775,14 +11364,14 @@ entry:
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
   %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
-  br i1 %NullCheck40, label %91, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
 ; <label>:91                                      ; preds = %85
   %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
   %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
-  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck42, label %94, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %94
 
 ; <label>:94                                      ; preds = %91
   %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
@@ -9798,14 +11387,14 @@ entry:
 ; <label>:99                                      ; preds = %69, %96
   %100 = load i32, i32* %loc0
   %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
-  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %102
 
 ; <label>:102                                     ; preds = %99
   %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
   %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
-  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
-  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
@@ -9819,87 +11408,87 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %26
+ThrowNullRef10:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %31
+ThrowNullRef12:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %35
+ThrowNullRef14:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %40
+ThrowNullRef16:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %56
+ThrowNullRef22:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %59
+ThrowNullRef24:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %63
+ThrowNullRef26:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %66
+ThrowNullRef28:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %102
+ThrowNullRef32:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %71
+ThrowNullRef34:                                   ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %73
+ThrowNullRef36:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %83
+ThrowNullRef38:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %85
+ThrowNullRef40:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %91
+ThrowNullRef42:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9943,15 +11532,15 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
   %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
@@ -9961,28 +11550,28 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
   %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %12
   %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
   %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
   %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
-  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
@@ -9993,23 +11582,23 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %12
+ThrowNullRef6:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10031,15 +11620,15 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
   %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = load i64, i64 addrspace(1)* %7
@@ -10077,13 +11666,13 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[loadElem]
+Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -10111,8 +11700,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -10186,8 +11775,8 @@ entry:
   store %Point addrspace(1)* %1, %Point addrspace(1)** %loc1
   %2 = load %Point addrspace(1)*, %Point addrspace(1)** %loc0
   %3 = load %Point addrspace(1)*, %Point addrspace(1)** %loc1
-  %NullCheck = icmp ne %Point addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %Point addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%Point addrspace(1)*, %Point addrspace(1)*)*)(%Point addrspace(1)* %2, %Point addrspace(1)* %3)
@@ -10225,16 +11814,16 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %Point addrspace(1)*, %Point addrspace(1)** %this
   %3 = load i32, i32* %arg1
-  %NullCheck = icmp ne %Point addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %Point addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %Point, %Point addrspace(1)* %2, i32 0, i32 1
   store i32 %3, i32 addrspace(1)* %5
   %6 = load %Point addrspace(1)*, %Point addrspace(1)** %this
   %7 = load i32, i32* %arg2
-  %NullCheck2 = icmp ne %Point addrspace(1)* %6, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %Point addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %Point, %Point addrspace(1)* %6, i32 0, i32 2
@@ -10245,7 +11834,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10260,30 +11849,30 @@ entry:
   store %Point addrspace(1)* %param0, %Point addrspace(1)** %this
   store %Point addrspace(1)* %param1, %Point addrspace(1)** %arg1
   %0 = load %Point addrspace(1)*, %Point addrspace(1)** %this
-  %NullCheck = icmp ne %Point addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %Point addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %Point, %Point addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %Point addrspace(1)*, %Point addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %Point addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %Point addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %Point, %Point addrspace(1)* %4, i32 0, i32 1
   %7 = load i32, i32 addrspace(1)* %6, align 8
   %8 = sub i32 %3, %7
   %9 = load %Point addrspace(1)*, %Point addrspace(1)** %this
-  %NullCheck4 = icmp ne %Point addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %Point addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %Point, %Point addrspace(1)* %9, i32 0, i32 1
   %12 = load i32, i32 addrspace(1)* %11, align 8
   %13 = load %Point addrspace(1)*, %Point addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %Point addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %Point addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %Point, %Point addrspace(1)* %13, i32 0, i32 1
@@ -10291,30 +11880,30 @@ entry:
   %17 = sub i32 %12, %16
   %18 = mul i32 %8, %17
   %19 = load %Point addrspace(1)*, %Point addrspace(1)** %this
-  %NullCheck8 = icmp ne %Point addrspace(1)* %19, null
-  br i1 %NullCheck8, label %20, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %Point addrspace(1)* %19, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %20
 
 ; <label>:20                                      ; preds = %14
   %21 = getelementptr inbounds %Point, %Point addrspace(1)* %19, i32 0, i32 2
   %22 = load i32, i32 addrspace(1)* %21, align 8
   %23 = load %Point addrspace(1)*, %Point addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %Point addrspace(1)* %23, null
-  br i1 %NullCheck10, label %24, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %Point addrspace(1)* %23, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %24
 
 ; <label>:24                                      ; preds = %20
   %25 = getelementptr inbounds %Point, %Point addrspace(1)* %23, i32 0, i32 2
   %26 = load i32, i32 addrspace(1)* %25, align 8
   %27 = sub i32 %22, %26
   %28 = load %Point addrspace(1)*, %Point addrspace(1)** %this
-  %NullCheck12 = icmp ne %Point addrspace(1)* %28, null
-  br i1 %NullCheck12, label %29, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %Point addrspace(1)* %28, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %29
 
 ; <label>:29                                      ; preds = %24
   %30 = getelementptr inbounds %Point, %Point addrspace(1)* %28, i32 0, i32 2
   %31 = load i32, i32 addrspace(1)* %30, align 8
   %32 = load %Point addrspace(1)*, %Point addrspace(1)** %arg1
-  %NullCheck14 = icmp ne %Point addrspace(1)* %32, null
-  br i1 %NullCheck14, label %33, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %Point addrspace(1)* %32, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %33
 
 ; <label>:33                                      ; preds = %29
   %34 = getelementptr inbounds %Point, %Point addrspace(1)* %32, i32 0, i32 2
@@ -10328,31 +11917,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %20
+ThrowNullRef10:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %24
+ThrowNullRef12:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %29
+ThrowNullRef14:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }

--- a/test/BaseLine/JIT/CodeGenBringUpTests/OpMembersOfStructLocal.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/OpMembersOfStructLocal.error.txt
@@ -25,8 +25,8 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
@@ -40,8 +40,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
   %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
@@ -75,7 +75,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -90,8 +90,8 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %NullCheck = icmp ne i8 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = load i8, i8 addrspace(1)* %0, align 8
@@ -125,8 +125,8 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
@@ -159,8 +159,8 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -184,8 +184,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
   store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
@@ -195,8 +195,8 @@ entry:
 ; <label>:4                                       ; preds = %1
   %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
   %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
@@ -206,8 +206,8 @@ entry:
   %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
@@ -221,14 +221,14 @@ entry:
 
 ; <label>:17                                      ; preds = %14
   %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
   %21 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
@@ -238,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -249,8 +249,8 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
@@ -261,27 +261,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %30
+ThrowNullRef10:                                   ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -301,7 +301,89 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
-Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
+Successfully read AppDomainSetup.GetUnsecureApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.GetUnsecureApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %NullCheck = icmp eq %"System.String[]" addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %BoundsCheck = icmp uge i64 0, %5
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %6
+
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 3, i32 0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
+  ret %System.String addrspace(1)* %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_Value using LLILCJit
+Successfully read AppDomainSetup.get_Value
+
+define %"System.String[]" addrspace(1)* @AppDomainSetup.get_Value(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.String[]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 18)
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.String[]" addrspace(1)* addrspace(1)*, %"System.String[]" addrspace(1)*)*)(%"System.String[]" addrspace(1)* addrspace(1)* %9, %"System.String[]" addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %11, i32 0, i32 1
+  %14 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %13, align 8
+  ret %"System.String[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -319,8 +401,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -368,16 +450,16 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
   %5 = load i32, i32 addrspace(1)* %4
   %6 = sub i32 %5, 1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -389,7 +471,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -421,8 +503,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
@@ -456,8 +538,8 @@ entry:
 ; <label>:27                                      ; preds = %19
   %28 = load i32, i32* %arg1
   %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
-  br i1 %NullCheck2, label %30, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %29, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %30
 
 ; <label>:30                                      ; preds = %27
   %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
@@ -493,8 +575,8 @@ entry:
 ; <label>:49                                      ; preds = %46
   %50 = load i32, i32* %arg2
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck4, label %52, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
@@ -517,11 +599,11 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %27
+ThrowNullRef2:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %49
+ThrowNullRef4:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -544,16 +626,16 @@ entry:
   %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %0)
   store %System.String addrspace(1)* %1, %System.String addrspace(1)** %loc0
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 2
   %5 = bitcast [0 x i16] addrspace(1)* %4 to i16 addrspace(1)*
   store i16 addrspace(1)* %5, i16 addrspace(1)** %loc1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %3
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2
@@ -580,7 +662,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -691,15 +773,15 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %NullCheck132 = icmp ne i8* %21, null
-  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+  %NullCheck131 = icmp eq i8* %21, null
+  br i1 %NullCheck131, label %ThrowNullRef132, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = load i8, i8* %21, align 8
   %24 = zext i8 %23 to i32
   %25 = trunc i32 %24 to i8
-  %NullCheck134 = icmp ne i8* %20, null
-  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+  %NullCheck133 = icmp eq i8* %20, null
+  br i1 %NullCheck133, label %ThrowNullRef134, label %26
 
 ; <label>:26                                      ; preds = %22
   store i8 %25, i8* %20, align 8
@@ -709,16 +791,16 @@ entry:
   %28 = load i8*, i8** %arg0
   %29 = load i8*, i8** %arg1
   %30 = bitcast i8* %29 to i16*
-  %NullCheck128 = icmp ne i16* %30, null
-  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+  %NullCheck127 = icmp eq i16* %30, null
+  br i1 %NullCheck127, label %ThrowNullRef128, label %31
 
 ; <label>:31                                      ; preds = %27
   %32 = load i16, i16* %30, align 8
   %33 = sext i16 %32 to i32
   %34 = bitcast i8* %28 to i16*
   %35 = trunc i32 %33 to i16
-  %NullCheck130 = icmp ne i16* %34, null
-  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+  %NullCheck129 = icmp eq i16* %34, null
+  br i1 %NullCheck129, label %ThrowNullRef130, label %36
 
 ; <label>:36                                      ; preds = %31
   store i16 %35, i16* %34, align 8
@@ -728,16 +810,16 @@ entry:
   %38 = load i8*, i8** %arg0
   %39 = load i8*, i8** %arg1
   %40 = bitcast i8* %39 to i16*
-  %NullCheck120 = icmp ne i16* %40, null
-  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+  %NullCheck119 = icmp eq i16* %40, null
+  br i1 %NullCheck119, label %ThrowNullRef120, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i16, i16* %40, align 8
   %43 = sext i16 %42 to i32
   %44 = bitcast i8* %38 to i16*
   %45 = trunc i32 %43 to i16
-  %NullCheck122 = icmp ne i16* %44, null
-  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+  %NullCheck121 = icmp eq i16* %44, null
+  br i1 %NullCheck121, label %ThrowNullRef122, label %46
 
 ; <label>:46                                      ; preds = %41
   store i16 %45, i16* %44, align 8
@@ -745,15 +827,15 @@ entry:
   %48 = getelementptr inbounds i8, i8* %47, i64 2
   %49 = load i8*, i8** %arg1
   %50 = getelementptr inbounds i8, i8* %49, i64 2
-  %NullCheck124 = icmp ne i8* %50, null
-  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+  %NullCheck123 = icmp eq i8* %50, null
+  br i1 %NullCheck123, label %ThrowNullRef124, label %51
 
 ; <label>:51                                      ; preds = %46
   %52 = load i8, i8* %50, align 8
   %53 = zext i8 %52 to i32
   %54 = trunc i32 %53 to i8
-  %NullCheck126 = icmp ne i8* %48, null
-  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+  %NullCheck125 = icmp eq i8* %48, null
+  br i1 %NullCheck125, label %ThrowNullRef126, label %55
 
 ; <label>:55                                      ; preds = %51
   store i8 %54, i8* %48, align 8
@@ -763,14 +845,14 @@ entry:
   %57 = load i8*, i8** %arg0
   %58 = load i8*, i8** %arg1
   %59 = bitcast i8* %58 to i32*
-  %NullCheck116 = icmp ne i32* %59, null
-  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+  %NullCheck115 = icmp eq i32* %59, null
+  br i1 %NullCheck115, label %ThrowNullRef116, label %60
 
 ; <label>:60                                      ; preds = %56
   %61 = load i32, i32* %59, align 8
   %62 = bitcast i8* %57 to i32*
-  %NullCheck118 = icmp ne i32* %62, null
-  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+  %NullCheck117 = icmp eq i32* %62, null
+  br i1 %NullCheck117, label %ThrowNullRef118, label %63
 
 ; <label>:63                                      ; preds = %60
   store i32 %61, i32* %62, align 8
@@ -780,14 +862,14 @@ entry:
   %65 = load i8*, i8** %arg0
   %66 = load i8*, i8** %arg1
   %67 = bitcast i8* %66 to i32*
-  %NullCheck108 = icmp ne i32* %67, null
-  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+  %NullCheck107 = icmp eq i32* %67, null
+  br i1 %NullCheck107, label %ThrowNullRef108, label %68
 
 ; <label>:68                                      ; preds = %64
   %69 = load i32, i32* %67, align 8
   %70 = bitcast i8* %65 to i32*
-  %NullCheck110 = icmp ne i32* %70, null
-  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+  %NullCheck109 = icmp eq i32* %70, null
+  br i1 %NullCheck109, label %ThrowNullRef110, label %71
 
 ; <label>:71                                      ; preds = %68
   store i32 %69, i32* %70, align 8
@@ -795,15 +877,15 @@ entry:
   %73 = getelementptr inbounds i8, i8* %72, i64 4
   %74 = load i8*, i8** %arg1
   %75 = getelementptr inbounds i8, i8* %74, i64 4
-  %NullCheck112 = icmp ne i8* %75, null
-  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+  %NullCheck111 = icmp eq i8* %75, null
+  br i1 %NullCheck111, label %ThrowNullRef112, label %76
 
 ; <label>:76                                      ; preds = %71
   %77 = load i8, i8* %75, align 8
   %78 = zext i8 %77 to i32
   %79 = trunc i32 %78 to i8
-  %NullCheck114 = icmp ne i8* %73, null
-  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+  %NullCheck113 = icmp eq i8* %73, null
+  br i1 %NullCheck113, label %ThrowNullRef114, label %80
 
 ; <label>:80                                      ; preds = %76
   store i8 %79, i8* %73, align 8
@@ -813,14 +895,14 @@ entry:
   %82 = load i8*, i8** %arg0
   %83 = load i8*, i8** %arg1
   %84 = bitcast i8* %83 to i32*
-  %NullCheck100 = icmp ne i32* %84, null
-  br i1 %NullCheck100, label %85, label %ThrowNullRef99
+  %NullCheck99 = icmp eq i32* %84, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %85
 
 ; <label>:85                                      ; preds = %81
   %86 = load i32, i32* %84, align 8
   %87 = bitcast i8* %82 to i32*
-  %NullCheck102 = icmp ne i32* %87, null
-  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+  %NullCheck101 = icmp eq i32* %87, null
+  br i1 %NullCheck101, label %ThrowNullRef102, label %88
 
 ; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
@@ -829,16 +911,16 @@ entry:
   %91 = load i8*, i8** %arg1
   %92 = getelementptr inbounds i8, i8* %91, i64 4
   %93 = bitcast i8* %92 to i16*
-  %NullCheck104 = icmp ne i16* %93, null
-  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+  %NullCheck103 = icmp eq i16* %93, null
+  br i1 %NullCheck103, label %ThrowNullRef104, label %94
 
 ; <label>:94                                      ; preds = %88
   %95 = load i16, i16* %93, align 8
   %96 = sext i16 %95 to i32
   %97 = bitcast i8* %90 to i16*
   %98 = trunc i32 %96 to i16
-  %NullCheck106 = icmp ne i16* %97, null
-  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+  %NullCheck105 = icmp eq i16* %97, null
+  br i1 %NullCheck105, label %ThrowNullRef106, label %99
 
 ; <label>:99                                      ; preds = %94
   store i16 %98, i16* %97, align 8
@@ -848,14 +930,14 @@ entry:
   %101 = load i8*, i8** %arg0
   %102 = load i8*, i8** %arg1
   %103 = bitcast i8* %102 to i32*
-  %NullCheck88 = icmp ne i32* %103, null
-  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+  %NullCheck87 = icmp eq i32* %103, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %104
 
 ; <label>:104                                     ; preds = %100
   %105 = load i32, i32* %103, align 8
   %106 = bitcast i8* %101 to i32*
-  %NullCheck90 = icmp ne i32* %106, null
-  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+  %NullCheck89 = icmp eq i32* %106, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %107
 
 ; <label>:107                                     ; preds = %104
   store i32 %105, i32* %106, align 8
@@ -864,16 +946,16 @@ entry:
   %110 = load i8*, i8** %arg1
   %111 = getelementptr inbounds i8, i8* %110, i64 4
   %112 = bitcast i8* %111 to i16*
-  %NullCheck92 = icmp ne i16* %112, null
-  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+  %NullCheck91 = icmp eq i16* %112, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %113
 
 ; <label>:113                                     ; preds = %107
   %114 = load i16, i16* %112, align 8
   %115 = sext i16 %114 to i32
   %116 = bitcast i8* %109 to i16*
   %117 = trunc i32 %115 to i16
-  %NullCheck94 = icmp ne i16* %116, null
-  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+  %NullCheck93 = icmp eq i16* %116, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %118
 
 ; <label>:118                                     ; preds = %113
   store i16 %117, i16* %116, align 8
@@ -881,15 +963,15 @@ entry:
   %120 = getelementptr inbounds i8, i8* %119, i64 6
   %121 = load i8*, i8** %arg1
   %122 = getelementptr inbounds i8, i8* %121, i64 6
-  %NullCheck96 = icmp ne i8* %122, null
-  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+  %NullCheck95 = icmp eq i8* %122, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %123
 
 ; <label>:123                                     ; preds = %118
   %124 = load i8, i8* %122, align 8
   %125 = zext i8 %124 to i32
   %126 = trunc i32 %125 to i8
-  %NullCheck98 = icmp ne i8* %120, null
-  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+  %NullCheck97 = icmp eq i8* %120, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %127
 
 ; <label>:127                                     ; preds = %123
   store i8 %126, i8* %120, align 8
@@ -899,14 +981,14 @@ entry:
   %129 = load i8*, i8** %arg0
   %130 = load i8*, i8** %arg1
   %131 = bitcast i8* %130 to i64*
-  %NullCheck84 = icmp ne i64* %131, null
-  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+  %NullCheck83 = icmp eq i64* %131, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %132
 
 ; <label>:132                                     ; preds = %128
   %133 = load i64, i64* %131, align 8
   %134 = bitcast i8* %129 to i64*
-  %NullCheck86 = icmp ne i64* %134, null
-  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+  %NullCheck85 = icmp eq i64* %134, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %135
 
 ; <label>:135                                     ; preds = %132
   store i64 %133, i64* %134, align 8
@@ -916,14 +998,14 @@ entry:
   %137 = load i8*, i8** %arg0
   %138 = load i8*, i8** %arg1
   %139 = bitcast i8* %138 to i64*
-  %NullCheck76 = icmp ne i64* %139, null
-  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+  %NullCheck75 = icmp eq i64* %139, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %140
 
 ; <label>:140                                     ; preds = %136
   %141 = load i64, i64* %139, align 8
   %142 = bitcast i8* %137 to i64*
-  %NullCheck78 = icmp ne i64* %142, null
-  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+  %NullCheck77 = icmp eq i64* %142, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %143
 
 ; <label>:143                                     ; preds = %140
   store i64 %141, i64* %142, align 8
@@ -931,15 +1013,15 @@ entry:
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %NullCheck80 = icmp ne i8* %147, null
-  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+  %NullCheck79 = icmp eq i8* %147, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %148
 
 ; <label>:148                                     ; preds = %143
   %149 = load i8, i8* %147, align 8
   %150 = zext i8 %149 to i32
   %151 = trunc i32 %150 to i8
-  %NullCheck82 = icmp ne i8* %145, null
-  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+  %NullCheck81 = icmp eq i8* %145, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %152
 
 ; <label>:152                                     ; preds = %148
   store i8 %151, i8* %145, align 8
@@ -949,14 +1031,14 @@ entry:
   %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
   %156 = bitcast i8* %155 to i64*
-  %NullCheck68 = icmp ne i64* %156, null
-  br i1 %NullCheck68, label %157, label %ThrowNullRef67
+  %NullCheck67 = icmp eq i64* %156, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %157
 
 ; <label>:157                                     ; preds = %153
   %158 = load i64, i64* %156, align 8
   %159 = bitcast i8* %154 to i64*
-  %NullCheck70 = icmp ne i64* %159, null
-  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+  %NullCheck69 = icmp eq i64* %159, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %160
 
 ; <label>:160                                     ; preds = %157
   store i64 %158, i64* %159, align 8
@@ -965,16 +1047,16 @@ entry:
   %163 = load i8*, i8** %arg1
   %164 = getelementptr inbounds i8, i8* %163, i64 8
   %165 = bitcast i8* %164 to i16*
-  %NullCheck72 = icmp ne i16* %165, null
-  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+  %NullCheck71 = icmp eq i16* %165, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %166
 
 ; <label>:166                                     ; preds = %160
   %167 = load i16, i16* %165, align 8
   %168 = sext i16 %167 to i32
   %169 = bitcast i8* %162 to i16*
   %170 = trunc i32 %168 to i16
-  %NullCheck74 = icmp ne i16* %169, null
-  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+  %NullCheck73 = icmp eq i16* %169, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %171
 
 ; <label>:171                                     ; preds = %166
   store i16 %170, i16* %169, align 8
@@ -984,14 +1066,14 @@ entry:
   %173 = load i8*, i8** %arg0
   %174 = load i8*, i8** %arg1
   %175 = bitcast i8* %174 to i64*
-  %NullCheck56 = icmp ne i64* %175, null
-  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+  %NullCheck55 = icmp eq i64* %175, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %176
 
 ; <label>:176                                     ; preds = %172
   %177 = load i64, i64* %175, align 8
   %178 = bitcast i8* %173 to i64*
-  %NullCheck58 = icmp ne i64* %178, null
-  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+  %NullCheck57 = icmp eq i64* %178, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %179
 
 ; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
@@ -1000,16 +1082,16 @@ entry:
   %182 = load i8*, i8** %arg1
   %183 = getelementptr inbounds i8, i8* %182, i64 8
   %184 = bitcast i8* %183 to i16*
-  %NullCheck60 = icmp ne i16* %184, null
-  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+  %NullCheck59 = icmp eq i16* %184, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %185
 
 ; <label>:185                                     ; preds = %179
   %186 = load i16, i16* %184, align 8
   %187 = sext i16 %186 to i32
   %188 = bitcast i8* %181 to i16*
   %189 = trunc i32 %187 to i16
-  %NullCheck62 = icmp ne i16* %188, null
-  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+  %NullCheck61 = icmp eq i16* %188, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %190
 
 ; <label>:190                                     ; preds = %185
   store i16 %189, i16* %188, align 8
@@ -1017,15 +1099,15 @@ entry:
   %192 = getelementptr inbounds i8, i8* %191, i64 10
   %193 = load i8*, i8** %arg1
   %194 = getelementptr inbounds i8, i8* %193, i64 10
-  %NullCheck64 = icmp ne i8* %194, null
-  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+  %NullCheck63 = icmp eq i8* %194, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %195
 
 ; <label>:195                                     ; preds = %190
   %196 = load i8, i8* %194, align 8
   %197 = zext i8 %196 to i32
   %198 = trunc i32 %197 to i8
-  %NullCheck66 = icmp ne i8* %192, null
-  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+  %NullCheck65 = icmp eq i8* %192, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %199
 
 ; <label>:199                                     ; preds = %195
   store i8 %198, i8* %192, align 8
@@ -1035,14 +1117,14 @@ entry:
   %201 = load i8*, i8** %arg0
   %202 = load i8*, i8** %arg1
   %203 = bitcast i8* %202 to i64*
-  %NullCheck48 = icmp ne i64* %203, null
-  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+  %NullCheck47 = icmp eq i64* %203, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %204
 
 ; <label>:204                                     ; preds = %200
   %205 = load i64, i64* %203, align 8
   %206 = bitcast i8* %201 to i64*
-  %NullCheck50 = icmp ne i64* %206, null
-  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+  %NullCheck49 = icmp eq i64* %206, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %207
 
 ; <label>:207                                     ; preds = %204
   store i64 %205, i64* %206, align 8
@@ -1051,14 +1133,14 @@ entry:
   %210 = load i8*, i8** %arg1
   %211 = getelementptr inbounds i8, i8* %210, i64 8
   %212 = bitcast i8* %211 to i32*
-  %NullCheck52 = icmp ne i32* %212, null
-  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+  %NullCheck51 = icmp eq i32* %212, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %213
 
 ; <label>:213                                     ; preds = %207
   %214 = load i32, i32* %212, align 8
   %215 = bitcast i8* %209 to i32*
-  %NullCheck54 = icmp ne i32* %215, null
-  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+  %NullCheck53 = icmp eq i32* %215, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %216
 
 ; <label>:216                                     ; preds = %213
   store i32 %214, i32* %215, align 8
@@ -1068,14 +1150,14 @@ entry:
   %218 = load i8*, i8** %arg0
   %219 = load i8*, i8** %arg1
   %220 = bitcast i8* %219 to i64*
-  %NullCheck36 = icmp ne i64* %220, null
-  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64* %220, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %221
 
 ; <label>:221                                     ; preds = %217
   %222 = load i64, i64* %220, align 8
   %223 = bitcast i8* %218 to i64*
-  %NullCheck38 = icmp ne i64* %223, null
-  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+  %NullCheck37 = icmp eq i64* %223, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %224
 
 ; <label>:224                                     ; preds = %221
   store i64 %222, i64* %223, align 8
@@ -1084,14 +1166,14 @@ entry:
   %227 = load i8*, i8** %arg1
   %228 = getelementptr inbounds i8, i8* %227, i64 8
   %229 = bitcast i8* %228 to i32*
-  %NullCheck40 = icmp ne i32* %229, null
-  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i32* %229, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %230
 
 ; <label>:230                                     ; preds = %224
   %231 = load i32, i32* %229, align 8
   %232 = bitcast i8* %226 to i32*
-  %NullCheck42 = icmp ne i32* %232, null
-  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+  %NullCheck41 = icmp eq i32* %232, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %233
 
 ; <label>:233                                     ; preds = %230
   store i32 %231, i32* %232, align 8
@@ -1099,15 +1181,15 @@ entry:
   %235 = getelementptr inbounds i8, i8* %234, i64 12
   %236 = load i8*, i8** %arg1
   %237 = getelementptr inbounds i8, i8* %236, i64 12
-  %NullCheck44 = icmp ne i8* %237, null
-  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i8* %237, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %238
 
 ; <label>:238                                     ; preds = %233
   %239 = load i8, i8* %237, align 8
   %240 = zext i8 %239 to i32
   %241 = trunc i32 %240 to i8
-  %NullCheck46 = icmp ne i8* %235, null
-  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+  %NullCheck45 = icmp eq i8* %235, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %242
 
 ; <label>:242                                     ; preds = %238
   store i8 %241, i8* %235, align 8
@@ -1117,14 +1199,14 @@ entry:
   %244 = load i8*, i8** %arg0
   %245 = load i8*, i8** %arg1
   %246 = bitcast i8* %245 to i64*
-  %NullCheck24 = icmp ne i64* %246, null
-  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64* %246, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %247
 
 ; <label>:247                                     ; preds = %243
   %248 = load i64, i64* %246, align 8
   %249 = bitcast i8* %244 to i64*
-  %NullCheck26 = icmp ne i64* %249, null
-  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64* %249, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %250
 
 ; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
@@ -1133,14 +1215,14 @@ entry:
   %253 = load i8*, i8** %arg1
   %254 = getelementptr inbounds i8, i8* %253, i64 8
   %255 = bitcast i8* %254 to i32*
-  %NullCheck28 = icmp ne i32* %255, null
-  br i1 %NullCheck28, label %256, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i32* %255, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %256
 
 ; <label>:256                                     ; preds = %250
   %257 = load i32, i32* %255, align 8
   %258 = bitcast i8* %252 to i32*
-  %NullCheck30 = icmp ne i32* %258, null
-  br i1 %NullCheck30, label %259, label %ThrowNullRef29
+  %NullCheck29 = icmp eq i32* %258, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %259
 
 ; <label>:259                                     ; preds = %256
   store i32 %257, i32* %258, align 8
@@ -1149,16 +1231,16 @@ entry:
   %262 = load i8*, i8** %arg1
   %263 = getelementptr inbounds i8, i8* %262, i64 12
   %264 = bitcast i8* %263 to i16*
-  %NullCheck32 = icmp ne i16* %264, null
-  br i1 %NullCheck32, label %265, label %ThrowNullRef31
+  %NullCheck31 = icmp eq i16* %264, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %265
 
 ; <label>:265                                     ; preds = %259
   %266 = load i16, i16* %264, align 8
   %267 = sext i16 %266 to i32
   %268 = bitcast i8* %261 to i16*
   %269 = trunc i32 %267 to i16
-  %NullCheck34 = icmp ne i16* %268, null
-  br i1 %NullCheck34, label %270, label %ThrowNullRef33
+  %NullCheck33 = icmp eq i16* %268, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %270
 
 ; <label>:270                                     ; preds = %265
   store i16 %269, i16* %268, align 8
@@ -1168,14 +1250,14 @@ entry:
   %272 = load i8*, i8** %arg0
   %273 = load i8*, i8** %arg1
   %274 = bitcast i8* %273 to i64*
-  %NullCheck8 = icmp ne i64* %274, null
-  br i1 %NullCheck8, label %275, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64* %274, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %275
 
 ; <label>:275                                     ; preds = %271
   %276 = load i64, i64* %274, align 8
   %277 = bitcast i8* %272 to i64*
-  %NullCheck10 = icmp ne i64* %277, null
-  br i1 %NullCheck10, label %278, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %277, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %278
 
 ; <label>:278                                     ; preds = %275
   store i64 %276, i64* %277, align 8
@@ -1184,14 +1266,14 @@ entry:
   %281 = load i8*, i8** %arg1
   %282 = getelementptr inbounds i8, i8* %281, i64 8
   %283 = bitcast i8* %282 to i32*
-  %NullCheck12 = icmp ne i32* %283, null
-  br i1 %NullCheck12, label %284, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i32* %283, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %284
 
 ; <label>:284                                     ; preds = %278
   %285 = load i32, i32* %283, align 8
   %286 = bitcast i8* %280 to i32*
-  %NullCheck14 = icmp ne i32* %286, null
-  br i1 %NullCheck14, label %287, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i32* %286, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %287
 
 ; <label>:287                                     ; preds = %284
   store i32 %285, i32* %286, align 8
@@ -1200,16 +1282,16 @@ entry:
   %290 = load i8*, i8** %arg1
   %291 = getelementptr inbounds i8, i8* %290, i64 12
   %292 = bitcast i8* %291 to i16*
-  %NullCheck16 = icmp ne i16* %292, null
-  br i1 %NullCheck16, label %293, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i16* %292, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %293
 
 ; <label>:293                                     ; preds = %287
   %294 = load i16, i16* %292, align 8
   %295 = sext i16 %294 to i32
   %296 = bitcast i8* %289 to i16*
   %297 = trunc i32 %295 to i16
-  %NullCheck18 = icmp ne i16* %296, null
-  br i1 %NullCheck18, label %298, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i16* %296, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %298
 
 ; <label>:298                                     ; preds = %293
   store i16 %297, i16* %296, align 8
@@ -1217,15 +1299,15 @@ entry:
   %300 = getelementptr inbounds i8, i8* %299, i64 14
   %301 = load i8*, i8** %arg1
   %302 = getelementptr inbounds i8, i8* %301, i64 14
-  %NullCheck20 = icmp ne i8* %302, null
-  br i1 %NullCheck20, label %303, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i8* %302, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %303
 
 ; <label>:303                                     ; preds = %298
   %304 = load i8, i8* %302, align 8
   %305 = zext i8 %304 to i32
   %306 = trunc i32 %305 to i8
-  %NullCheck22 = icmp ne i8* %300, null
-  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i8* %300, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %307
 
 ; <label>:307                                     ; preds = %303
   store i8 %306, i8* %300, align 8
@@ -1235,14 +1317,14 @@ entry:
   %309 = load i8*, i8** %arg0
   %310 = load i8*, i8** %arg1
   %311 = bitcast i8* %310 to i64*
-  %NullCheck = icmp ne i64* %311, null
-  br i1 %NullCheck, label %312, label %ThrowNullRef
+  %NullCheck = icmp eq i64* %311, null
+  br i1 %NullCheck, label %ThrowNullRef, label %312
 
 ; <label>:312                                     ; preds = %308
   %313 = load i64, i64* %311, align 8
   %314 = bitcast i8* %309 to i64*
-  %NullCheck2 = icmp ne i64* %314, null
-  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64* %314, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %315
 
 ; <label>:315                                     ; preds = %312
   store i64 %313, i64* %314, align 8
@@ -1251,14 +1333,14 @@ entry:
   %318 = load i8*, i8** %arg1
   %319 = getelementptr inbounds i8, i8* %318, i64 8
   %320 = bitcast i8* %319 to i64*
-  %NullCheck4 = icmp ne i64* %320, null
-  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64* %320, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %321
 
 ; <label>:321                                     ; preds = %315
   %322 = load i64, i64* %320, align 8
   %323 = bitcast i8* %317 to i64*
-  %NullCheck6 = icmp ne i64* %323, null
-  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64* %323, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %324
 
 ; <label>:324                                     ; preds = %321
   store i64 %322, i64* %323, align 8
@@ -1286,15 +1368,15 @@ entry:
 ; <label>:338                                     ; preds = %333
   %339 = load i8*, i8** %arg0
   %340 = load i8*, i8** %arg1
-  %NullCheck136 = icmp ne i8* %340, null
-  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+  %NullCheck135 = icmp eq i8* %340, null
+  br i1 %NullCheck135, label %ThrowNullRef136, label %341
 
 ; <label>:341                                     ; preds = %338
   %342 = load i8, i8* %340, align 8
   %343 = zext i8 %342 to i32
   %344 = trunc i32 %343 to i8
-  %NullCheck138 = icmp ne i8* %339, null
-  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+  %NullCheck137 = icmp eq i8* %339, null
+  br i1 %NullCheck137, label %ThrowNullRef138, label %345
 
 ; <label>:345                                     ; preds = %341
   store i8 %344, i8* %339, align 8
@@ -1317,16 +1399,16 @@ entry:
   %357 = load i8*, i8** %arg0
   %358 = load i8*, i8** %arg1
   %359 = bitcast i8* %358 to i16*
-  %NullCheck140 = icmp ne i16* %359, null
-  br i1 %NullCheck140, label %360, label %ThrowNullRef139
+  %NullCheck139 = icmp eq i16* %359, null
+  br i1 %NullCheck139, label %ThrowNullRef140, label %360
 
 ; <label>:360                                     ; preds = %356
   %361 = load i16, i16* %359, align 8
   %362 = sext i16 %361 to i32
   %363 = bitcast i8* %357 to i16*
   %364 = trunc i32 %362 to i16
-  %NullCheck142 = icmp ne i16* %363, null
-  br i1 %NullCheck142, label %365, label %ThrowNullRef141
+  %NullCheck141 = icmp eq i16* %363, null
+  br i1 %NullCheck141, label %ThrowNullRef142, label %365
 
 ; <label>:365                                     ; preds = %360
   store i16 %364, i16* %363, align 8
@@ -1352,14 +1434,14 @@ entry:
   %378 = load i8*, i8** %arg0
   %379 = load i8*, i8** %arg1
   %380 = bitcast i8* %379 to i32*
-  %NullCheck144 = icmp ne i32* %380, null
-  br i1 %NullCheck144, label %381, label %ThrowNullRef143
+  %NullCheck143 = icmp eq i32* %380, null
+  br i1 %NullCheck143, label %ThrowNullRef144, label %381
 
 ; <label>:381                                     ; preds = %377
   %382 = load i32, i32* %380, align 8
   %383 = bitcast i8* %378 to i32*
-  %NullCheck146 = icmp ne i32* %383, null
-  br i1 %NullCheck146, label %384, label %ThrowNullRef145
+  %NullCheck145 = icmp eq i32* %383, null
+  br i1 %NullCheck145, label %ThrowNullRef146, label %384
 
 ; <label>:384                                     ; preds = %381
   store i32 %382, i32* %383, align 8
@@ -1384,14 +1466,14 @@ entry:
   %395 = load i8*, i8** %arg0
   %396 = load i8*, i8** %arg1
   %397 = bitcast i8* %396 to i64*
-  %NullCheck164 = icmp ne i64* %397, null
-  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+  %NullCheck163 = icmp eq i64* %397, null
+  br i1 %NullCheck163, label %ThrowNullRef164, label %398
 
 ; <label>:398                                     ; preds = %394
   %399 = load i64, i64* %397, align 8
   %400 = bitcast i8* %395 to i64*
-  %NullCheck166 = icmp ne i64* %400, null
-  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+  %NullCheck165 = icmp eq i64* %400, null
+  br i1 %NullCheck165, label %ThrowNullRef166, label %401
 
 ; <label>:401                                     ; preds = %398
   store i64 %399, i64* %400, align 8
@@ -1400,14 +1482,14 @@ entry:
   %404 = load i8*, i8** %arg1
   %405 = getelementptr inbounds i8, i8* %404, i64 8
   %406 = bitcast i8* %405 to i64*
-  %NullCheck168 = icmp ne i64* %406, null
-  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+  %NullCheck167 = icmp eq i64* %406, null
+  br i1 %NullCheck167, label %ThrowNullRef168, label %407
 
 ; <label>:407                                     ; preds = %401
   %408 = load i64, i64* %406, align 8
   %409 = bitcast i8* %403 to i64*
-  %NullCheck170 = icmp ne i64* %409, null
-  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+  %NullCheck169 = icmp eq i64* %409, null
+  br i1 %NullCheck169, label %ThrowNullRef170, label %410
 
 ; <label>:410                                     ; preds = %407
   store i64 %408, i64* %409, align 8
@@ -1437,14 +1519,14 @@ entry:
   %425 = load i8*, i8** %arg0
   %426 = load i8*, i8** %arg1
   %427 = bitcast i8* %426 to i64*
-  %NullCheck148 = icmp ne i64* %427, null
-  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+  %NullCheck147 = icmp eq i64* %427, null
+  br i1 %NullCheck147, label %ThrowNullRef148, label %428
 
 ; <label>:428                                     ; preds = %424
   %429 = load i64, i64* %427, align 8
   %430 = bitcast i8* %425 to i64*
-  %NullCheck150 = icmp ne i64* %430, null
-  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+  %NullCheck149 = icmp eq i64* %430, null
+  br i1 %NullCheck149, label %ThrowNullRef150, label %431
 
 ; <label>:431                                     ; preds = %428
   store i64 %429, i64* %430, align 8
@@ -1466,14 +1548,14 @@ entry:
   %441 = load i8*, i8** %arg0
   %442 = load i8*, i8** %arg1
   %443 = bitcast i8* %442 to i32*
-  %NullCheck152 = icmp ne i32* %443, null
-  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+  %NullCheck151 = icmp eq i32* %443, null
+  br i1 %NullCheck151, label %ThrowNullRef152, label %444
 
 ; <label>:444                                     ; preds = %440
   %445 = load i32, i32* %443, align 8
   %446 = bitcast i8* %441 to i32*
-  %NullCheck154 = icmp ne i32* %446, null
-  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+  %NullCheck153 = icmp eq i32* %446, null
+  br i1 %NullCheck153, label %ThrowNullRef154, label %447
 
 ; <label>:447                                     ; preds = %444
   store i32 %445, i32* %446, align 8
@@ -1495,16 +1577,16 @@ entry:
   %457 = load i8*, i8** %arg0
   %458 = load i8*, i8** %arg1
   %459 = bitcast i8* %458 to i16*
-  %NullCheck156 = icmp ne i16* %459, null
-  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+  %NullCheck155 = icmp eq i16* %459, null
+  br i1 %NullCheck155, label %ThrowNullRef156, label %460
 
 ; <label>:460                                     ; preds = %456
   %461 = load i16, i16* %459, align 8
   %462 = sext i16 %461 to i32
   %463 = bitcast i8* %457 to i16*
   %464 = trunc i32 %462 to i16
-  %NullCheck158 = icmp ne i16* %463, null
-  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+  %NullCheck157 = icmp eq i16* %463, null
+  br i1 %NullCheck157, label %ThrowNullRef158, label %465
 
 ; <label>:465                                     ; preds = %460
   store i16 %464, i16* %463, align 8
@@ -1525,15 +1607,15 @@ entry:
 ; <label>:474                                     ; preds = %470
   %475 = load i8*, i8** %arg0
   %476 = load i8*, i8** %arg1
-  %NullCheck160 = icmp ne i8* %476, null
-  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+  %NullCheck159 = icmp eq i8* %476, null
+  br i1 %NullCheck159, label %ThrowNullRef160, label %477
 
 ; <label>:477                                     ; preds = %474
   %478 = load i8, i8* %476, align 8
   %479 = zext i8 %478 to i32
   %480 = trunc i32 %479 to i8
-  %NullCheck162 = icmp ne i8* %475, null
-  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+  %NullCheck161 = icmp eq i8* %475, null
+  br i1 %NullCheck161, label %ThrowNullRef162, label %481
 
 ; <label>:481                                     ; preds = %477
   store i8 %480, i8* %475, align 8
@@ -1553,343 +1635,343 @@ ThrowNullRef:                                     ; preds = %308
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %312
+ThrowNullRef2:                                    ; preds = %312
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %315
+ThrowNullRef4:                                    ; preds = %315
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %321
+ThrowNullRef6:                                    ; preds = %321
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %271
+ThrowNullRef8:                                    ; preds = %271
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %275
+ThrowNullRef10:                                   ; preds = %275
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %278
+ThrowNullRef12:                                   ; preds = %278
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %284
+ThrowNullRef14:                                   ; preds = %284
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %287
+ThrowNullRef16:                                   ; preds = %287
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %293
+ThrowNullRef18:                                   ; preds = %293
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %298
+ThrowNullRef20:                                   ; preds = %298
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %303
+ThrowNullRef22:                                   ; preds = %303
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %243
+ThrowNullRef24:                                   ; preds = %243
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %247
+ThrowNullRef26:                                   ; preds = %247
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %250
+ThrowNullRef28:                                   ; preds = %250
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %256
+ThrowNullRef30:                                   ; preds = %256
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %259
+ThrowNullRef32:                                   ; preds = %259
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %265
+ThrowNullRef34:                                   ; preds = %265
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %217
+ThrowNullRef36:                                   ; preds = %217
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %221
+ThrowNullRef38:                                   ; preds = %221
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %224
+ThrowNullRef40:                                   ; preds = %224
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %230
+ThrowNullRef42:                                   ; preds = %230
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %233
+ThrowNullRef44:                                   ; preds = %233
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %238
+ThrowNullRef46:                                   ; preds = %238
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %200
+ThrowNullRef48:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %204
+ThrowNullRef50:                                   ; preds = %204
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %207
+ThrowNullRef52:                                   ; preds = %207
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %213
+ThrowNullRef54:                                   ; preds = %213
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %172
+ThrowNullRef56:                                   ; preds = %172
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %176
+ThrowNullRef58:                                   ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %179
+ThrowNullRef60:                                   ; preds = %179
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %185
+ThrowNullRef62:                                   ; preds = %185
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %190
+ThrowNullRef64:                                   ; preds = %190
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %195
+ThrowNullRef66:                                   ; preds = %195
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %153
+ThrowNullRef68:                                   ; preds = %153
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %157
+ThrowNullRef70:                                   ; preds = %157
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %160
+ThrowNullRef72:                                   ; preds = %160
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %166
+ThrowNullRef74:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %136
+ThrowNullRef76:                                   ; preds = %136
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %140
+ThrowNullRef78:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %143
+ThrowNullRef80:                                   ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %148
+ThrowNullRef82:                                   ; preds = %148
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %128
+ThrowNullRef84:                                   ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %132
+ThrowNullRef86:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %100
+ThrowNullRef88:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %104
+ThrowNullRef90:                                   ; preds = %104
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %107
+ThrowNullRef92:                                   ; preds = %107
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %113
+ThrowNullRef94:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %118
+ThrowNullRef96:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %123
+ThrowNullRef98:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %81
+ThrowNullRef100:                                  ; preds = %81
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef101:                                  ; preds = %85
+ThrowNullRef102:                                  ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef103:                                  ; preds = %88
+ThrowNullRef104:                                  ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef105:                                  ; preds = %94
+ThrowNullRef106:                                  ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef107:                                  ; preds = %64
+ThrowNullRef108:                                  ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef109:                                  ; preds = %68
+ThrowNullRef110:                                  ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef111:                                  ; preds = %71
+ThrowNullRef112:                                  ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef113:                                  ; preds = %76
+ThrowNullRef114:                                  ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef115:                                  ; preds = %56
+ThrowNullRef116:                                  ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef117:                                  ; preds = %60
+ThrowNullRef118:                                  ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef119:                                  ; preds = %37
+ThrowNullRef120:                                  ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef121:                                  ; preds = %41
+ThrowNullRef122:                                  ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef123:                                  ; preds = %46
+ThrowNullRef124:                                  ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef125:                                  ; preds = %51
+ThrowNullRef126:                                  ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef127:                                  ; preds = %27
+ThrowNullRef128:                                  ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef129:                                  ; preds = %31
+ThrowNullRef130:                                  ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef131:                                  ; preds = %19
+ThrowNullRef132:                                  ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef133:                                  ; preds = %22
+ThrowNullRef134:                                  ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef135:                                  ; preds = %338
+ThrowNullRef136:                                  ; preds = %338
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef137:                                  ; preds = %341
+ThrowNullRef138:                                  ; preds = %341
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef139:                                  ; preds = %356
+ThrowNullRef140:                                  ; preds = %356
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef141:                                  ; preds = %360
+ThrowNullRef142:                                  ; preds = %360
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef143:                                  ; preds = %377
+ThrowNullRef144:                                  ; preds = %377
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef145:                                  ; preds = %381
+ThrowNullRef146:                                  ; preds = %381
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef147:                                  ; preds = %424
+ThrowNullRef148:                                  ; preds = %424
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef149:                                  ; preds = %428
+ThrowNullRef150:                                  ; preds = %428
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef151:                                  ; preds = %440
+ThrowNullRef152:                                  ; preds = %440
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef153:                                  ; preds = %444
+ThrowNullRef154:                                  ; preds = %444
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef155:                                  ; preds = %456
+ThrowNullRef156:                                  ; preds = %456
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef157:                                  ; preds = %460
+ThrowNullRef158:                                  ; preds = %460
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef159:                                  ; preds = %474
+ThrowNullRef160:                                  ; preds = %474
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef161:                                  ; preds = %477
+ThrowNullRef162:                                  ; preds = %477
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef163:                                  ; preds = %394
+ThrowNullRef164:                                  ; preds = %394
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef165:                                  ; preds = %398
+ThrowNullRef166:                                  ; preds = %398
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef167:                                  ; preds = %401
+ThrowNullRef168:                                  ; preds = %401
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef169:                                  ; preds = %407
+ThrowNullRef170:                                  ; preds = %407
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1939,8 +2021,8 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
-  br i1 %NullCheck, label %22, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %ThrowNullRef, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
@@ -1948,8 +2030,8 @@ entry:
   store i32 %24, i32* %loc0
   %25 = load i32, i32* %loc0
   %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %26, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %27
 
 ; <label>:27                                      ; preds = %22
   %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
@@ -1971,7 +2053,7 @@ ThrowNullRef:                                     ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1989,8 +2071,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -2022,15 +2104,15 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2048,16 +2130,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
   %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
   store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %15
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
@@ -2072,8 +2154,8 @@ entry:
   %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
   %29 = ptrtoint i16 addrspace(1)* %28 to i64
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %19
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
@@ -2089,19 +2171,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2114,8 +2196,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
@@ -2128,7 +2210,7 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[loadElem]
+Failed to read AppDomain.PrepareDataForSetup[storeElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
@@ -2202,8 +2284,8 @@ entry:
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
-  br i1 %NullCheck24, label %27, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = load i64, i64 addrspace(1)* %26
@@ -2218,8 +2300,8 @@ entry:
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
-  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
   %41 = load i64, i64 addrspace(1)* %39
@@ -2236,8 +2318,8 @@ entry:
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
-  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
   %54 = load i64, i64 addrspace(1)* %52
@@ -2252,8 +2334,8 @@ entry:
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
   %67 = load i64, i64 addrspace(1)* %65
@@ -2270,8 +2352,8 @@ entry:
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
-  br i1 %NullCheck16, label %79, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
   %80 = load i64, i64 addrspace(1)* %78
@@ -2286,8 +2368,8 @@ entry:
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
-  br i1 %NullCheck18, label %92, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
   %93 = load i64, i64 addrspace(1)* %91
@@ -2304,8 +2386,8 @@ entry:
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
-  br i1 %NullCheck12, label %105, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = load i64, i64 addrspace(1)* %104
@@ -2320,8 +2402,8 @@ entry:
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
-  br i1 %NullCheck14, label %118, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
   %119 = load i64, i64 addrspace(1)* %117
@@ -2337,8 +2419,8 @@ entry:
 
 ; <label>:128                                     ; preds = %20
   %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
-  br i1 %NullCheck4, label %130, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %129, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %130
 
 ; <label>:130                                     ; preds = %128
   %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
@@ -2346,8 +2428,8 @@ entry:
   %133 = load i16, i16 addrspace(1)* %132, align 8
   %134 = zext i16 %133 to i32
   %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
-  br i1 %NullCheck6, label %136, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %135, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %136
 
 ; <label>:136                                     ; preds = %130
   %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
@@ -2360,8 +2442,8 @@ entry:
 
 ; <label>:143                                     ; preds = %136
   %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
-  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %144, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %145
 
 ; <label>:145                                     ; preds = %143
   %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
@@ -2369,8 +2451,8 @@ entry:
   %148 = load i16, i16 addrspace(1)* %147, align 8
   %149 = zext i16 %148 to i32
   %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %150, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %151
 
 ; <label>:151                                     ; preds = %145
   %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
@@ -2388,8 +2470,8 @@ entry:
 
 ; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
-  br i1 %NullCheck, label %163, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %ThrowNullRef, label %163
 
 ; <label>:163                                     ; preds = %161
   %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
@@ -2399,8 +2481,8 @@ entry:
 
 ; <label>:167                                     ; preds = %163
   %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
-  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %168, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %169
 
 ; <label>:169                                     ; preds = %167
   %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
@@ -2432,55 +2514,55 @@ ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %167
+ThrowNullRef2:                                    ; preds = %167
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %128
+ThrowNullRef4:                                    ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %130
+ThrowNullRef6:                                    ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %143
+ThrowNullRef8:                                    ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %145
+ThrowNullRef10:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %102
+ThrowNullRef12:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %105
+ThrowNullRef14:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %76
+ThrowNullRef16:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %79
+ThrowNullRef18:                                   ; preds = %79
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %50
+ThrowNullRef20:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %53
+ThrowNullRef22:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %24
+ThrowNullRef24:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %27
+ThrowNullRef26:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2503,15 +2585,15 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2519,16 +2601,16 @@ entry:
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
   store i32 %8, i32* %loc0
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
   %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
   store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
@@ -2546,16 +2628,16 @@ entry:
 
 ; <label>:23                                      ; preds = %64
   %24 = load i16*, i16** %loc3
-  %NullCheck12 = icmp ne i16* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i16* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
   store i32 %27, i32* %loc5
   %28 = load i16*, i16** %loc4
-  %NullCheck14 = icmp ne i16* %28, null
-  br i1 %NullCheck14, label %29, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %28, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = load i16, i16* %28, align 8
@@ -2620,15 +2702,15 @@ entry:
 
 ; <label>:67                                      ; preds = %64
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
-  br i1 %NullCheck8, label %69, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %68, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %69
 
 ; <label>:69                                      ; preds = %67
   %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
   %71 = load i32, i32 addrspace(1)* %70
   %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
-  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %73
 
 ; <label>:73                                      ; preds = %69
   %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
@@ -2645,31 +2727,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %67
+ThrowNullRef8:                                    ; preds = %67
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %69
+ThrowNullRef10:                                   ; preds = %69
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2710,14 +2792,14 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
   %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
@@ -2730,14 +2812,14 @@ entry:
 
 ; <label>:11                                      ; preds = %4
   %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
   %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
@@ -2749,14 +2831,14 @@ entry:
 
 ; <label>:22                                      ; preds = %16
   %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
   %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
-  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
-  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
@@ -2804,23 +2886,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2836,7 +2918,280 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[loadElem]
+Successfully read RuntimeType.IsAssignableFrom
+
+define i8 @RuntimeType.IsAssignableFrom(%System.RuntimeType addrspace(1)* %param0, %System.Type addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.RuntimeType addrspace(1)*
+  %arg1 = alloca %System.Type addrspace(1)*
+  %loc0 = alloca %System.RuntimeType addrspace(1)*
+  %loc1 = alloca %"System.Type[]" addrspace(1)*
+  %loc2 = alloca i32
+  store %System.RuntimeType addrspace(1)* %param0, %System.RuntimeType addrspace(1)** %this
+  store %System.Type addrspace(1)* %param1, %System.Type addrspace(1)** %arg1
+  %0 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %1 = icmp ne %System.Type addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i8 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %5 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %6 = bitcast %System.Type addrspace(1)* %4 to %System.Object addrspace(1)*
+  %7 = bitcast %System.RuntimeType addrspace(1)* %5 to %System.Object addrspace(1)*
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %6, %System.Object addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %3
+  ret i8 1
+
+; <label>:12                                      ; preds = %3
+  %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 152
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 32
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
+  %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
+  %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
+  store %System.RuntimeType addrspace(1)* %25, %System.RuntimeType addrspace(1)** %loc0
+  %26 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %27 = icmp eq %System.RuntimeType addrspace(1)* %26, null
+  br i1 %27, label %34, label %28
+
+; <label>:28                                      ; preds = %15
+  %29 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %30 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)*)*)(%System.RuntimeType addrspace(1)* %29, %System.RuntimeType addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+; <label>:34                                      ; preds = %15
+  %35 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %36 = call %System.Reflection.Emit.TypeBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Reflection.Emit.TypeBuilder addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %35)
+  %37 = icmp eq %System.Reflection.Emit.TypeBuilder addrspace(1)* %36, null
+  br i1 %37, label %139, label %38
+
+; <label>:38                                      ; preds = %34
+  %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %42
+
+; <label>:42                                      ; preds = %38
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 152
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 40
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
+  %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
+  %53 = zext i8 %52 to i32
+  %54 = icmp eq i32 %53, 0
+  br i1 %54, label %56, label %55
+
+; <label>:55                                      ; preds = %42
+  ret i8 1
+
+; <label>:56                                      ; preds = %42
+  %57 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %58 = bitcast %System.RuntimeType addrspace(1)* %57 to %System.Type addrspace(1)*
+  %59 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %58)
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %64 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.Type addrspace(1)* %63, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = bitcast %System.RuntimeType addrspace(1)* %64 to %System.Type addrspace(1)*
+  %67 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %63, %System.Type addrspace(1)* %66)
+  %68 = zext i8 %67 to i32
+  %69 = trunc i32 %68 to i8
+  ret i8 %69
+
+; <label>:70                                      ; preds = %56
+  %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
+  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %73
+
+; <label>:73                                      ; preds = %70
+  %74 = load i64, i64 addrspace(1)* %72
+  %75 = add i64 %74, 128
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = add i64 %77, 0
+  %79 = inttoptr i64 %78 to i64*
+  %80 = load i64, i64* %79
+  %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
+  %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
+  %83 = call i8 %82(%System.Type addrspace(1)* %81)
+  %84 = zext i8 %83 to i32
+  %85 = icmp eq i32 %84, 0
+  br i1 %85, label %139, label %86
+
+; <label>:86                                      ; preds = %73
+  %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
+  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %89
+
+; <label>:89                                      ; preds = %86
+  %90 = load i64, i64 addrspace(1)* %88
+  %91 = add i64 %90, 128
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = add i64 %93, 24
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
+  %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
+  %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
+  store %"System.Type[]" addrspace(1)* %99, %"System.Type[]" addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %129
+
+; <label>:100                                     ; preds = %132
+  %101 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %102 = load i32, i32* %loc2
+  %NullCheck11 = icmp eq %"System.Type[]" addrspace(1)* %101, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %103
+
+; <label>:103                                     ; preds = %100
+  %104 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 1
+  %105 = load i32, i32 addrspace(1)* %104
+  %106 = zext i32 %105 to i64
+  %107 = zext i32 %102 to i64
+  %BoundsCheck = icmp uge i64 %107, %106
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %108
+
+; <label>:108                                     ; preds = %103
+  %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
+  %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
+  %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
+  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %113
+
+; <label>:113                                     ; preds = %108
+  %114 = load i64, i64 addrspace(1)* %112
+  %115 = add i64 %114, 152
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = add i64 %117, 56
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
+  %123 = zext i8 %122 to i32
+  %124 = icmp ne i32 %123, 0
+  br i1 %124, label %126, label %125
+
+; <label>:125                                     ; preds = %113
+  ret i8 0
+
+; <label>:126                                     ; preds = %113
+  %127 = load i32, i32* %loc2
+  %128 = add i32 %127, 1
+  store i32 %128, i32* %loc2
+  br label %129
+
+; <label>:129                                     ; preds = %89, %126
+  %130 = load i32, i32* %loc2
+  %131 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %NullCheck9 = icmp eq %"System.Type[]" addrspace(1)* %131, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %132
+
+; <label>:132                                     ; preds = %129
+  %133 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %131, i32 0, i32 1
+  %134 = load i32, i32 addrspace(1)* %133
+  %135 = zext i32 %134 to i64
+  %136 = trunc i64 %135 to i32
+  %137 = icmp slt i32 %130, %136
+  br i1 %137, label %100, label %138
+
+; <label>:138                                     ; preds = %132
+  ret i8 1
+
+; <label>:139                                     ; preds = %34, %73
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %129
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %103
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -2893,7 +3248,7 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElem]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -2904,8 +3259,8 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -2997,8 +3352,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
@@ -3059,8 +3414,8 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -3087,8 +3442,8 @@ entry:
 
 ; <label>:17                                      ; preds = %5, %11
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
@@ -3097,8 +3452,8 @@ entry:
 
 ; <label>:22                                      ; preds = %1, %11
   %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
@@ -3109,11 +3464,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %17
+ThrowNullRef2:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %22
+ThrowNullRef4:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3167,15 +3522,15 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
   %15 = load i32, i32 addrspace(1)* %14
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
@@ -3198,7 +3553,7 @@ ThrowNullRef:                                     ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef2:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3232,8 +3587,8 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
@@ -3312,8 +3667,8 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -3327,8 +3682,8 @@ entry:
 ; <label>:5                                       ; preds = %43
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %7 = load i32, i32* %loc1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck6, label %8, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
@@ -3366,8 +3721,8 @@ entry:
 ; <label>:32                                      ; preds = %21, %25
   %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
   %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
-  br i1 %NullCheck8, label %35, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = trunc i32 %34 to i16
@@ -3380,8 +3735,8 @@ entry:
 ; <label>:40                                      ; preds = %1, %35
   %41 = load i32, i32* %loc1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
-  br i1 %NullCheck2, label %43, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %42, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
@@ -3392,8 +3747,8 @@ entry:
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
   %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
-  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
   %51 = load i64, i64 addrspace(1)* %49
@@ -3412,19 +3767,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %40
+ThrowNullRef2:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %47
+ThrowNullRef4:                                    ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %5
+ThrowNullRef6:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %32
+ThrowNullRef8:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3467,8 +3822,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
@@ -3492,11 +3847,391 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(i16* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store i16* %param0, i16** %arg0
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load i32, i32* %arg3
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %42, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %37, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg2
+  %13 = load i32, i32* %arg3
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %37, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %24 = load i32, i32* %arg2
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load i16*, i16** %arg0
+  %35 = load i32, i32* %arg3
+  %36 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %36, i16* %34, i32 %35)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:37                                      ; preds = %5, %16
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %39)
+  %41 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41, %System.String addrspace(1)* %38, %System.String addrspace(1)* %40)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41) #0
+  unreachable
+
+; <label>:42                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
-Failed to read StringBuilder.ToString[loadElemA]
+Successfully read StringBuilder.ToString
+
+define %System.String addrspace(1)* @StringBuilder.ToString(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i16*
+  %loc3 = alloca %"System.Char[]" addrspace(1)*
+  %loc4 = alloca i32
+  %loc5 = alloca i32
+  %loc6 = alloca i16 addrspace(1)*
+  %loc7 = alloca %System.String addrspace(1)*
+  %loc8 = alloca %"System.Char[]" addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %0)
+  %2 = icmp ne i32 %1, 0
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %4
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %6)
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %7)
+  store %System.String addrspace(1)* %8, %System.String addrspace(1)** %loc0
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.Text.StringBuilder addrspace(1)* %9, %System.Text.StringBuilder addrspace(1)** %loc1
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  store %System.String addrspace(1)* %10, %System.String addrspace(1)** %loc7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc7
+  %12 = ptrtoint %System.String addrspace(1)* %11 to i64
+  %13 = icmp eq i64 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %5
+  %15 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %16 = sext i32 %15 to i64
+  %17 = add i64 %12, %16
+  br label %18
+
+; <label>:18                                      ; preds = %5, %14
+  %19 = phi i64 [ %12, %5 ], [ %17, %14 ]
+  %20 = inttoptr i64 %19 to i16*
+  store i16* %20, i16** %loc2
+  br label %21
+
+; <label>:21                                      ; preds = %98, %18
+  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %22, null
+  br i1 %NullCheck, label %ThrowNullRef, label %23
+
+; <label>:23                                      ; preds = %21
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 3
+  %25 = load i32, i32 addrspace(1)* %24, align 8
+  %26 = icmp sle i32 %25, 0
+  br i1 %26, label %96, label %27
+
+; <label>:27                                      ; preds = %23
+  %28 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %28, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %29
+
+; <label>:29                                      ; preds = %27
+  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %28, i32 0, i32 1
+  %31 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %30, align 8
+  store %"System.Char[]" addrspace(1)* %31, %"System.Char[]" addrspace(1)** %loc3
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %33
+
+; <label>:33                                      ; preds = %29
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  store i32 %35, i32* %loc4
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  %39 = load i32, i32 addrspace(1)* %38, align 8
+  store i32 %39, i32* %loc5
+  %40 = load i32, i32* %loc5
+  %41 = load i32, i32* %loc4
+  %42 = add i32 %40, %41
+  %43 = zext i32 %42 to i64
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %45
+
+; <label>:45                                      ; preds = %37
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = sext i32 %47 to i64
+  %49 = icmp sgt i64 %43, %48
+  br i1 %49, label %91, label %50
+
+; <label>:50                                      ; preds = %45
+  %51 = load i32, i32* %loc5
+  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %52, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %53
+
+; <label>:53                                      ; preds = %50
+  %54 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %52, i32 0, i32 1
+  %55 = load i32, i32 addrspace(1)* %54
+  %56 = zext i32 %55 to i64
+  %57 = trunc i64 %56 to i32
+  %58 = icmp ugt i32 %51, %57
+  br i1 %58, label %91, label %59
+
+; <label>:59                                      ; preds = %53
+  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  store %"System.Char[]" addrspace(1)* %60, %"System.Char[]" addrspace(1)** %loc8
+  %61 = icmp eq %"System.Char[]" addrspace(1)* %60, null
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %63, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %64
+
+; <label>:64                                      ; preds = %62
+  %65 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %63, i32 0, i32 1
+  %66 = load i32, i32 addrspace(1)* %65
+  %67 = zext i32 %66 to i64
+  %68 = trunc i64 %67 to i32
+  %69 = icmp ne i32 %68, 0
+  br i1 %69, label %71, label %70
+
+; <label>:70                                      ; preds = %59, %64
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:71                                      ; preds = %64
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %73
+
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %BoundsCheck = icmp uge i64 0, %76
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %77
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %78, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:79                                      ; preds = %70, %77
+  %80 = load i16*, i16** %loc2
+  %81 = load i32, i32* %loc4
+  %82 = sext i32 %81 to i64
+  %83 = mul i64 %82, 2
+  %84 = bitcast i16* %80 to i8*
+  %85 = getelementptr inbounds i8, i8* %84, i64 %83
+  %86 = load i16 addrspace(1)*, i16 addrspace(1)** %loc6
+  %87 = ptrtoint i16 addrspace(1)* %86 to i64
+  %88 = load i32, i32* %loc5
+  %89 = bitcast i8* %85 to i16*
+  %90 = inttoptr i64 %87 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %89, i16* %90, i32 %88)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %96
+
+; <label>:91                                      ; preds = %45, %53
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %94 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %93)
+  %95 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95, %System.String addrspace(1)* %92, %System.String addrspace(1)* %94)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95) #0
+  unreachable
+
+; <label>:96                                      ; preds = %23, %79
+  %97 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %97, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %98
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %97, i32 0, i32 2
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  store %System.Text.StringBuilder addrspace(1)* %100, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %102 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %102, label %21, label %103
+
+; <label>:103                                     ; preds = %98
+  store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc7
+  %104 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  ret %System.String addrspace(1)* %104
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method StringBuilder::get_Length using LLILCJit
+Successfully read StringBuilder.get_Length
+
+define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
+Successfully read RuntimeHelpers.get_OffsetToStringData
+
+define i32 @RuntimeHelpers.get_OffsetToStringData() {
+entry:
+  ret i32 12
+}
+
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
 Successfully read CultureData.CreateCultureData
 
@@ -3514,23 +4249,23 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
   store i8 %4, i8 addrspace(1)* %6
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
@@ -3549,11 +4284,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3566,50 +4301,50 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
   store i32 -1, i32 addrspace(1)* %2
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
   store i32 -1, i32 addrspace(1)* %8
   %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
   store i32 -1, i32 addrspace(1)* %14
   %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
   store i32 -1, i32 addrspace(1)* %17
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
@@ -3623,27 +4358,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3675,7 +4410,136 @@ Failed to read Dictionary`2.Insert[non-const derefAddress]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
 Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
-Failed to read HashHelpers.GetPrime[loadElem]
+Successfully read HashHelpers.GetPrime
+
+define i32 @HashHelpers.GetPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %6, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5, %System.String addrspace(1)* %4)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5) #0
+  unreachable
+
+; <label>:6                                       ; preds = %entry
+  store i32 0, i32* %loc0
+  br label %29
+
+; <label>:7                                       ; preds = %35
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 1296
+  %10 = addrspacecast i8 addrspace(1)* %9 to %"System.Int32[]" addrspace(1)**
+  %11 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %10
+  %12 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Int32[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = zext i32 %15 to i64
+  %17 = zext i32 %12 to i64
+  %BoundsCheck = icmp uge i64 %17, %16
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 3, i32 %12
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  store i32 %20, i32* %loc1
+  %21 = load i32, i32* %loc1
+  %22 = load i32, i32* %arg0
+  %23 = icmp slt i32 %21, %22
+  br i1 %23, label %26, label %24
+
+; <label>:24                                      ; preds = %18
+  %25 = load i32, i32* %loc1
+  ret i32 %25
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %loc0
+  %28 = add i32 %27, 1
+  store i32 %28, i32* %loc0
+  br label %29
+
+; <label>:29                                      ; preds = %6, %26
+  %30 = load i32, i32* %loc0
+  %31 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %32 = getelementptr inbounds i8, i8 addrspace(1)* %31, i64 1296
+  %33 = addrspacecast i8 addrspace(1)* %32 to %"System.Int32[]" addrspace(1)**
+  %34 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %33
+  %NullCheck = icmp eq %"System.Int32[]" addrspace(1)* %34, null
+  br i1 %NullCheck, label %ThrowNullRef, label %35
+
+; <label>:35                                      ; preds = %29
+  %36 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %34, i32 0, i32 1
+  %37 = load i32, i32 addrspace(1)* %36
+  %38 = zext i32 %37 to i64
+  %39 = trunc i64 %38 to i32
+  %40 = icmp slt i32 %30, %39
+  br i1 %40, label %7, label %41
+
+; <label>:41                                      ; preds = %35
+  %42 = load i32, i32* %arg0
+  %43 = or i32 %42, 1
+  store i32 %43, i32* %loc2
+  br label %59
+
+; <label>:44                                      ; preds = %59
+  %45 = load i32, i32* %loc2
+  %46 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %45)
+  %47 = zext i8 %46 to i32
+  %48 = icmp eq i32 %47, 0
+  br i1 %48, label %56, label %49
+
+; <label>:49                                      ; preds = %44
+  %50 = load i32, i32* %loc2
+  %51 = sub i32 %50, 1
+  %52 = srem i32 %51, 101
+  %53 = icmp eq i32 %52, 0
+  br i1 %53, label %56, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = load i32, i32* %loc2
+  ret i32 %55
+
+; <label>:56                                      ; preds = %44, %49
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %57, 2
+  store i32 %58, i32* %loc2
+  br label %59
+
+; <label>:59                                      ; preds = %41, %56
+  %60 = load i32, i32* %loc2
+  %61 = icmp slt i32 %60, 2147483647
+  br i1 %61, label %44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load i32, i32* %arg0
+  ret i32 %63
+
+ThrowNullRef:                                     ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
 Successfully read GenericEqualityComparer`1.GetHashCode
 
@@ -3694,14 +4558,14 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
   %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load i64, i64 addrspace(1)* %7
@@ -3720,7 +4584,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3750,8 +4614,8 @@ entry:
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
@@ -3796,8 +4660,8 @@ entry:
   %35 = bitcast i16* %34 to i8*
   %36 = getelementptr inbounds i8, i8* %35, i64 2
   %37 = bitcast i8* %36 to i16*
-  %NullCheck4 = icmp ne i16* %37, null
-  br i1 %NullCheck4, label %38, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %37, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %38
 
 ; <label>:38                                      ; preds = %27
   %39 = load i16, i16* %37, align 8
@@ -3824,8 +4688,8 @@ entry:
 
 ; <label>:54                                      ; preds = %22, %43
   %55 = load i16*, i16** %loc4
-  %NullCheck2 = icmp ne i16* %55, null
-  br i1 %NullCheck2, label %56, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i16* %55, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %56
 
 ; <label>:56                                      ; preds = %54
   %57 = load i16, i16* %55, align 8
@@ -3850,11 +4714,11 @@ ThrowNullRef:                                     ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %54
+ThrowNullRef2:                                    ; preds = %54
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %27
+ThrowNullRef4:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3871,8 +4735,8 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -3907,8 +4771,8 @@ entry:
 
 ; <label>:26                                      ; preds = %19
   %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
-  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %28
 
 ; <label>:28                                      ; preds = %26
   %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
@@ -3920,7 +4784,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3972,8 +4836,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
@@ -3984,26 +4848,26 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
-  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
@@ -4014,8 +4878,8 @@ entry:
 ; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
@@ -4024,8 +4888,8 @@ entry:
 
 ; <label>:25                                      ; preds = %1, %16, %23
   %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
-  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
@@ -4036,27 +4900,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %20
+ThrowNullRef10:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4069,8 +4933,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -4081,8 +4945,8 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
@@ -4091,8 +4955,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1, %8
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
@@ -4103,11 +4967,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4128,24 +4992,24 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   store i32 %3, i32* %loc0
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
   %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
   store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck4, label %9, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
@@ -4164,15 +5028,15 @@ entry:
 ; <label>:18                                      ; preds = %70
   %19 = load i16*, i16** %loc3
   %20 = bitcast i16* %19 to i64*
-  %NullCheck10 = icmp ne i64* %20, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %20, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = load i64, i64* %20, align 8
   %23 = load i16*, i16** %loc4
   %24 = bitcast i16* %23 to i64*
-  %NullCheck12 = icmp ne i64* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = load i64, i64* %24, align 8
@@ -4188,8 +5052,8 @@ entry:
   %31 = bitcast i16* %30 to i8*
   %32 = getelementptr inbounds i8, i8* %31, i64 8
   %33 = bitcast i8* %32 to i64*
-  %NullCheck14 = icmp ne i64* %33, null
-  br i1 %NullCheck14, label %34, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = load i64, i64* %33, align 8
@@ -4197,8 +5061,8 @@ entry:
   %37 = bitcast i16* %36 to i8*
   %38 = getelementptr inbounds i8, i8* %37, i64 8
   %39 = bitcast i8* %38 to i64*
-  %NullCheck16 = icmp ne i64* %39, null
-  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %40
 
 ; <label>:40                                      ; preds = %34
   %41 = load i64, i64* %39, align 8
@@ -4214,8 +5078,8 @@ entry:
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %NullCheck18 = icmp ne i64* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = load i64, i64* %48, align 8
@@ -4223,8 +5087,8 @@ entry:
   %52 = bitcast i16* %51 to i8*
   %53 = getelementptr inbounds i8, i8* %52, i64 16
   %54 = bitcast i8* %53 to i64*
-  %NullCheck20 = icmp ne i64* %54, null
-  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64* %54, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %55
 
 ; <label>:55                                      ; preds = %49
   %56 = load i64, i64* %54, align 8
@@ -4262,15 +5126,15 @@ entry:
 ; <label>:74                                      ; preds = %95
   %75 = load i16*, i16** %loc3
   %76 = bitcast i16* %75 to i32*
-  %NullCheck6 = icmp ne i32* %76, null
-  br i1 %NullCheck6, label %77, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32* %76, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %77
 
 ; <label>:77                                      ; preds = %74
   %78 = load i32, i32* %76, align 8
   %79 = load i16*, i16** %loc4
   %80 = bitcast i16* %79 to i32*
-  %NullCheck8 = icmp ne i32* %80, null
-  br i1 %NullCheck8, label %81, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i32* %80, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %81
 
 ; <label>:81                                      ; preds = %77
   %82 = load i32, i32* %80, align 8
@@ -4318,43 +5182,43 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %74
+ThrowNullRef6:                                    ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %77
+ThrowNullRef8:                                    ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %29
+ThrowNullRef14:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %34
+ThrowNullRef16:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4376,8 +5240,8 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load i64, i64 addrspace(1)* %4
@@ -4389,8 +5253,8 @@ entry:
   %12 = load i64, i64* %11
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %5
   %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
@@ -4399,8 +5263,8 @@ entry:
   %18 = load i8, i8* %arg2
   %19 = zext i8 %18 to i32
   %20 = trunc i32 %19 to i8
-  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %15
   %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
@@ -4411,11 +5275,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4442,8 +5306,8 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
@@ -4466,16 +5330,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
   %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = load i64, i64 addrspace(1)* %19
@@ -4500,8 +5364,8 @@ entry:
 ; <label>:35                                      ; preds = %30
   %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
@@ -4514,8 +5378,8 @@ entry:
 
 ; <label>:42                                      ; preds = %1, %38
   %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
-  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
@@ -4526,19 +5390,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %35
+ThrowNullRef2:                                    ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %42
+ThrowNullRef8:                                    ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4551,14 +5415,14 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
@@ -4570,7 +5434,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4583,8 +5447,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
@@ -4613,51 +5477,51 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
   %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
   %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
   %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
   %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
-  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
   store i64 %21, i64 addrspace(1)* %23
   %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %25 = load i64, i64* %loc0
-  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
@@ -4668,27 +5532,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %22
+ThrowNullRef12:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4701,8 +5565,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
@@ -4713,19 +5577,19 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
@@ -4734,8 +5598,8 @@ entry:
 
 ; <label>:15                                      ; preds = %1, %13
   %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
@@ -4746,19 +5610,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %15
+ThrowNullRef8:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4771,8 +5635,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -4831,8 +5695,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
@@ -4882,8 +5746,8 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
-  br i1 %NullCheck, label %17, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %ThrowNullRef, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
@@ -4894,15 +5758,15 @@ entry:
 
 ; <label>:22                                      ; preds = %17
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
-  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
   %26 = load i32, i32 addrspace(1)* %25
   %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
-  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %27, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
@@ -4925,8 +5789,8 @@ entry:
 ; <label>:40                                      ; preds = %17
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
-  br i1 %NullCheck6, label %43, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %41, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
@@ -4938,34 +5802,17 @@ ThrowNullRef:                                     ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %24
+ThrowNullRef4:                                    ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %40
+ThrowNullRef6:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
-}
-
-INFO:  jitting method Object::ReferenceEquals using LLILCJit
-Successfully read Object.ReferenceEquals
-
-define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
-entry:
-  %arg0 = alloca %System.Object addrspace(1)*
-  %arg1 = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
-  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
-  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = icmp eq %System.Object addrspace(1)* %0, %1
-  %3 = sext i1 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
 }
 
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
@@ -4978,21 +5825,21 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
   %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
-  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
@@ -5007,28 +5854,28 @@ entry:
 ; <label>:13                                      ; preds = %8, %12
   %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
   %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
   %21 = load i32, i32 addrspace(1)* %20, align 8
   %22 = add i32 %21, 1
-  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
   store i32 %22, i32 addrspace(1)* %24
   %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
@@ -5039,27 +5886,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5077,7 +5924,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::Setup using LLILCJit
-Failed to read AppDomain.Setup[loadElem]
+Failed to read AppDomain.Setup[unbox]
 INFO:  jitting method Thread::GetDomain using LLILCJit
 Successfully read Thread.GetDomain
 
@@ -5108,8 +5955,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
@@ -5122,14 +5969,14 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
   %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
@@ -5141,11 +5988,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5173,8 +6020,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -5189,7 +6036,328 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
 Failed to read KeyCollection.System.Collections.Generic.IEnumerable<TKey>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Successfully read Enumerator.MoveNext
+
+define i8 @Enumerator.MoveNext(%"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.RuntimeTypeHandle* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*
+  %"$TypeArg" = alloca %System.RuntimeTypeHandle*
+  store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
+  %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 8
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %76, label %12
+
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
+  br label %76
+
+; <label>:13                                      ; preds = %85
+  %14 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck19 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %15
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, i32 0, i32 0
+  %17 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %16, align 8
+  %NullCheck21 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, i32 0, i32 2
+  %20 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %19, align 8
+  %21 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck23 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %22
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, i32 0, i32 2
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %NullCheck25 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 3, i32 %24
+  %NullCheck27 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %32
+
+; <label>:32                                      ; preds = %30
+  %33 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, i32 0, i32 2
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = icmp slt i32 %34, 0
+  br i1 %35, label %68, label %36
+
+; <label>:36                                      ; preds = %32
+  %37 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %38 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck29 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %39
+
+; <label>:39                                      ; preds = %36
+  %40 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, i32 0, i32 0
+  %41 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %40, align 8
+  %NullCheck31 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, i32 0, i32 2
+  %44 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %43, align 8
+  %45 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck33 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, i32 0, i32 2
+  %48 = load i32, i32 addrspace(1)* %47, align 8
+  %NullCheck35 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %49
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = zext i32 %51 to i64
+  %53 = zext i32 %48 to i64
+  %BoundsCheck37 = icmp uge i64 %53, %52
+  br i1 %BoundsCheck37, label %ThrowIndexOutOfRange38, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 3, i32 %48
+  %NullCheck39 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %56
+
+; <label>:56                                      ; preds = %54
+  %57 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, i32 0, i32 0
+  %58 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck41 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %59
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %60, %System.__Canon addrspace(1)* %58)
+  %61 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck43 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  %64 = load i32, i32 addrspace(1)* %63, align 8
+  %65 = add i32 %64, 1
+  %NullCheck45 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  store i32 %65, i32 addrspace(1)* %67
+  ret i8 1
+
+; <label>:68                                      ; preds = %32
+  %69 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck47 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %73 = add i32 %72, 1
+  %NullCheck49 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %74
+
+; <label>:74                                      ; preds = %70
+  %75 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  store i32 %73, i32 addrspace(1)* %75
+  br label %76
+
+; <label>:76                                      ; preds = %8, %12, %74
+  %77 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %78
+
+; <label>:78                                      ; preds = %76
+  %79 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, i32 0, i32 2
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck7 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %82
+
+; <label>:82                                      ; preds = %78
+  %83 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, i32 0, i32 0
+  %84 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %83, align 8
+  %NullCheck9 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %85
+
+; <label>:85                                      ; preds = %82
+  %86 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, i32 0, i32 7
+  %87 = load i32, i32 addrspace(1)* %86, align 8
+  %88 = icmp ult i32 %80, %87
+  br i1 %88, label %13, label %89
+
+; <label>:89                                      ; preds = %85
+  %90 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %91 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck11 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %92
+
+; <label>:92                                      ; preds = %89
+  %93 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, i32 0, i32 0
+  %94 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck13 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %95
+
+; <label>:95                                      ; preds = %92
+  %96 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, i32 0, i32 7
+  %97 = load i32, i32 addrspace(1)* %96, align 8
+  %98 = add i32 %97, 1
+  %NullCheck15 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %99
+
+; <label>:99                                      ; preds = %95
+  %100 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, i32 0, i32 2
+  store i32 %98, i32 addrspace(1)* %100
+  %101 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck17 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %102
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %103, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %92
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef22:                                   ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef24:                                   ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef26:                                   ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef28:                                   ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef30:                                   ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef32:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef34:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef36:                                   ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange38:                           ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef40:                                   ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef42:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef44:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef46:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef48:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef50:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -5200,8 +6368,8 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -5232,9 +6400,9 @@ Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
 Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
-Failed to read String.MakeSeparatorList[loadElemA]
+Failed to read String.MakeSeparatorList[storeElem]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
-Failed to read String.InternalSplitKeepEmptyEntries[loadElem]
+Failed to read String.InternalSplitKeepEmptyEntries[storeElem]
 INFO:  jitting method Path::IsRelative using LLILCJit
 Successfully read Path.IsRelative
 
@@ -5243,8 +6411,8 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -5254,8 +6422,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
@@ -5271,8 +6439,8 @@ entry:
 
 ; <label>:17                                      ; preds = %7
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
@@ -5288,8 +6456,8 @@ entry:
 
 ; <label>:29                                      ; preds = %19
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %31
 
 ; <label>:31                                      ; preds = %29
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
@@ -5300,8 +6468,8 @@ entry:
 
 ; <label>:36                                      ; preds = %31
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
-  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %37, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
@@ -5312,8 +6480,8 @@ entry:
 
 ; <label>:43                                      ; preds = %31, %38
   %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
-  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %45
 
 ; <label>:45                                      ; preds = %43
   %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
@@ -5324,8 +6492,8 @@ entry:
 
 ; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %50
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
@@ -5336,8 +6504,8 @@ entry:
 
 ; <label>:57                                      ; preds = %1, %7, %19, %45, %52
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
-  br i1 %NullCheck14, label %59, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %59
 
 ; <label>:59                                      ; preds = %57
   %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
@@ -5347,8 +6515,8 @@ entry:
 
 ; <label>:63                                      ; preds = %59
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
@@ -5359,8 +6527,8 @@ entry:
 
 ; <label>:70                                      ; preds = %65
   %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
-  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.String addrspace(1)* %71, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %72
 
 ; <label>:72                                      ; preds = %70
   %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
@@ -5379,39 +6547,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %17
+ThrowNullRef4:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %29
+ThrowNullRef6:                                    ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %36
+ThrowNullRef8:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %43
+ThrowNullRef10:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %50
+ThrowNullRef12:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %57
+ThrowNullRef14:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %63
+ThrowNullRef16:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %70
+ThrowNullRef18:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5419,7 +6587,293 @@ ThrowNullRef17:                                   ; preds = %70
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
-Failed to read String.TrimHelper[loadElem]
+Successfully read String.TrimHelper
+
+define %System.String addrspace(1)* @String.TrimHelper(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i16
+  %loc4 = alloca i32
+  %loc5 = alloca i16
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = sub i32 %3, 1
+  store i32 %4, i32* %loc0
+  store i32 0, i32* %loc1
+  %5 = load i32, i32* %arg2
+  %6 = icmp eq i32 %5, 1
+  br i1 %6, label %62, label %7
+
+; <label>:7                                       ; preds = %1
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:8                                       ; preds = %58
+  store i32 0, i32* %loc2
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load i32, i32* %loc1
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2, i32 %10
+  %13 = load i16, i16 addrspace(1)* %12
+  %14 = zext i16 %13 to i32
+  %15 = trunc i32 %14 to i16
+  store i16 %15, i16* %loc3
+  store i32 0, i32* %loc2
+  br label %34
+
+; <label>:16                                      ; preds = %37
+  %17 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %18 = load i32, i32* %loc2
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %17, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %19
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = zext i32 %18 to i64
+  %BoundsCheck = icmp uge i64 %23, %22
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %24
+
+; <label>:24                                      ; preds = %19
+  %25 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 3, i32 %18
+  %26 = load i16, i16 addrspace(1)* %25, align 8
+  %27 = zext i16 %26 to i32
+  %28 = load i16, i16* %loc3
+  %29 = zext i16 %28 to i32
+  %30 = icmp eq i32 %27, %29
+  br i1 %30, label %43, label %31
+
+; <label>:31                                      ; preds = %24
+  %32 = load i32, i32* %loc2
+  %33 = add i32 %32, 1
+  store i32 %33, i32* %loc2
+  br label %34
+
+; <label>:34                                      ; preds = %11, %31
+  %35 = load i32, i32* %loc2
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = icmp slt i32 %35, %41
+  br i1 %42, label %16, label %43
+
+; <label>:43                                      ; preds = %24, %37
+  %44 = load i32, i32* %loc2
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %45, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp eq i32 %44, %50
+  br i1 %51, label %62, label %52
+
+; <label>:52                                      ; preds = %46
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %7, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %57, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %58
+
+; <label>:58                                      ; preds = %55
+  %59 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %60 = load i32, i32 addrspace(1)* %59
+  %61 = icmp slt i32 %56, %60
+  br i1 %61, label %8, label %62
+
+; <label>:62                                      ; preds = %1, %46, %58
+  %63 = load i32, i32* %arg2
+  %64 = icmp eq i32 %63, 0
+  br i1 %64, label %122, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %66, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %67
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %66, i32 0, i32 1
+  %69 = load i32, i32 addrspace(1)* %68
+  %70 = sub i32 %69, 1
+  store i32 %70, i32* %loc0
+  br label %118
+
+; <label>:71                                      ; preds = %118
+  store i32 0, i32* %loc4
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %73 = load i32, i32* %loc0
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %74
+
+; <label>:74                                      ; preds = %71
+  %75 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 2, i32 %73
+  %76 = load i16, i16 addrspace(1)* %75
+  %77 = zext i16 %76 to i32
+  %78 = trunc i32 %77 to i16
+  store i16 %78, i16* %loc5
+  store i32 0, i32* %loc4
+  br label %97
+
+; <label>:79                                      ; preds = %100
+  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %81 = load i32, i32* %loc4
+  %NullCheck19 = icmp eq %"System.Char[]" addrspace(1)* %80, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
+
+; <label>:82                                      ; preds = %79
+  %83 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 1
+  %84 = load i32, i32 addrspace(1)* %83
+  %85 = zext i32 %84 to i64
+  %86 = zext i32 %81 to i64
+  %BoundsCheck21 = icmp uge i64 %86, %85
+  br i1 %BoundsCheck21, label %ThrowIndexOutOfRange22, label %87
+
+; <label>:87                                      ; preds = %82
+  %88 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 3, i32 %81
+  %89 = load i16, i16 addrspace(1)* %88, align 8
+  %90 = zext i16 %89 to i32
+  %91 = load i16, i16* %loc5
+  %92 = zext i16 %91 to i32
+  %93 = icmp eq i32 %90, %92
+  br i1 %93, label %106, label %94
+
+; <label>:94                                      ; preds = %87
+  %95 = load i32, i32* %loc4
+  %96 = add i32 %95, 1
+  store i32 %96, i32* %loc4
+  br label %97
+
+; <label>:97                                      ; preds = %74, %94
+  %98 = load i32, i32* %loc4
+  %99 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck15 = icmp eq %"System.Char[]" addrspace(1)* %99, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %100
+
+; <label>:100                                     ; preds = %97
+  %101 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %99, i32 0, i32 1
+  %102 = load i32, i32 addrspace(1)* %101
+  %103 = zext i32 %102 to i64
+  %104 = trunc i64 %103 to i32
+  %105 = icmp slt i32 %98, %104
+  br i1 %105, label %79, label %106
+
+; <label>:106                                     ; preds = %87, %100
+  %107 = load i32, i32* %loc4
+  %108 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck17 = icmp eq %"System.Char[]" addrspace(1)* %108, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %109
+
+; <label>:109                                     ; preds = %106
+  %110 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %108, i32 0, i32 1
+  %111 = load i32, i32 addrspace(1)* %110
+  %112 = zext i32 %111 to i64
+  %113 = trunc i64 %112 to i32
+  %114 = icmp eq i32 %107, %113
+  br i1 %114, label %122, label %115
+
+; <label>:115                                     ; preds = %109
+  %116 = load i32, i32* %loc0
+  %117 = sub i32 %116, 1
+  store i32 %117, i32* %loc0
+  br label %118
+
+; <label>:118                                     ; preds = %67, %115
+  %119 = load i32, i32* %loc0
+  %120 = load i32, i32* %loc1
+  %121 = icmp sge i32 %119, %120
+  br i1 %121, label %71, label %122
+
+; <label>:122                                     ; preds = %62, %109, %118
+  %123 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %124 = load i32, i32* %loc1
+  %125 = load i32, i32* %loc0
+  %126 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %123, i32 %124, i32 %125)
+  ret %System.String addrspace(1)* %126
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %97
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange22:                           ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
 Successfully read String.CreateTrimmedString
 
@@ -5439,8 +6893,8 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
@@ -5535,8 +6989,8 @@ entry:
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i64 2872
   %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
   %8 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %7
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %3
   %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
@@ -5553,8 +7007,8 @@ entry:
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 2864
   %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
   %21 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %20
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
-  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %22
 
 ; <label>:22                                      ; preds = %16
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
@@ -5569,7 +7023,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %16
+ThrowNullRef2:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5586,8 +7040,8 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5613,8 +7067,8 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
@@ -5632,8 +7086,8 @@ entry:
 
 ; <label>:12                                      ; preds = %4
   %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
@@ -5644,8 +7098,8 @@ entry:
 
 ; <label>:19                                      ; preds = %14
   %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %19
   %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
@@ -5660,21 +7114,21 @@ entry:
   %31 = zext i16 %30 to i32
   %32 = bitcast i8* %29 to i16*
   %33 = trunc i32 %31 to i16
-  %NullCheck6 = icmp ne i16* %32, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i16* %32, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %21
   store i16 %33, i16* %32, align 8
   %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %36
 
 ; <label>:36                                      ; preds = %34
   %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
   %38 = load i32, i32 addrspace(1)* %37, align 8
   %39 = add i32 %38, 1
-  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %40
 
 ; <label>:40                                      ; preds = %36
   %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
@@ -5683,16 +7137,16 @@ entry:
 
 ; <label>:42                                      ; preds = %14
   %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
-  br i1 %NullCheck12, label %44, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
   %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
   %47 = load i16, i16* %arg1
   %48 = zext i16 %47 to i32
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = trunc i32 %48 to i16
@@ -5703,31 +7157,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %19
+ThrowNullRef4:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %21
+ThrowNullRef6:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %36
+ThrowNullRef10:                                   ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %42
+ThrowNullRef12:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %44
+ThrowNullRef14:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5740,8 +7194,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -5752,8 +7206,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
@@ -5762,14 +7216,14 @@ entry:
 
 ; <label>:11                                      ; preds = %1
   %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
@@ -5779,15 +7233,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5808,8 +7262,8 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5822,8 +7276,8 @@ entry:
 
 ; <label>:8                                       ; preds = %3
   %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
@@ -5842,15 +7296,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
-  br i1 %NullCheck4, label %22, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
   %24 = load i16*, i16* addrspace(1)* %23, align 8
   %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %25, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
@@ -5859,8 +7313,8 @@ entry:
   store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
@@ -5874,8 +7328,8 @@ entry:
 
 ; <label>:37                                      ; preds = %65
   %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %37
   %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
@@ -5886,16 +7340,16 @@ entry:
   %45 = bitcast i16* %41 to i8*
   %46 = getelementptr inbounds i8, i8* %45, i64 %44
   %47 = bitcast i8* %46 to i16*
-  %NullCheck14 = icmp ne i16* %47, null
-  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %47, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %48
 
 ; <label>:48                                      ; preds = %39
   %49 = load i16, i16* %47, align 8
   %50 = zext i16 %49 to i32
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %52 = load i32, i32* %loc1
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %53
 
 ; <label>:53                                      ; preds = %48
   %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
@@ -5916,8 +7370,8 @@ entry:
 ; <label>:62                                      ; preds = %36, %59
   %63 = load i32, i32* %loc1
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck10, label %65, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %65
 
 ; <label>:65                                      ; preds = %62
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
@@ -5936,15 +7390,15 @@ entry:
 
 ; <label>:74                                      ; preds = %70
   %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
-  br i1 %NullCheck18, label %76, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %76
 
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
   %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
-  br i1 %NullCheck20, label %80, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
   %81 = load i64, i64 addrspace(1)* %79
@@ -5958,8 +7412,8 @@ entry:
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
   %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
-  br i1 %NullCheck22, label %92, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.String addrspace(1)* %90, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %92
 
 ; <label>:92                                      ; preds = %80
   %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
@@ -5969,15 +7423,15 @@ entry:
 
 ; <label>:96                                      ; preds = %70
   %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
-  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %98
 
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
   %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
-  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
   %103 = load i64, i64 addrspace(1)* %101
@@ -5991,8 +7445,8 @@ entry:
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
   %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
-  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.String addrspace(1)* %112, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %114
 
 ; <label>:114                                     ; preds = %102
   %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
@@ -6004,59 +7458,59 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %20
+ThrowNullRef4:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %22
+ThrowNullRef6:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %26
+ThrowNullRef8:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %62
+ThrowNullRef10:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %48
+ThrowNullRef16:                                   ; preds = %48
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %74
+ThrowNullRef18:                                   ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %76
+ThrowNullRef20:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %80
+ThrowNullRef22:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %96
+ThrowNullRef24:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %98
+ThrowNullRef26:                                   ; preds = %98
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %102
+ThrowNullRef28:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6069,15 +7523,15 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
   %3 = load i16*, i16* addrspace(1)* %2, align 8
   %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
@@ -6087,8 +7541,8 @@ entry:
   %10 = bitcast i16* %3 to i8*
   %11 = getelementptr inbounds i8, i8* %10, i64 %9
   %12 = bitcast i8* %11 to i16*
-  %NullCheck4 = icmp ne i16* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %5
   store i16 0, i16* %12, align 8
@@ -6098,11 +7552,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6119,8 +7573,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -6131,8 +7585,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
@@ -6144,15 +7598,15 @@ entry:
 
 ; <label>:14                                      ; preds = %1
   %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
   %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
   %21 = load i64, i64 addrspace(1)* %19
@@ -6171,15 +7625,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %14
+ThrowNullRef4:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %16
+ThrowNullRef6:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6302,14 +7756,6 @@ entry:
   ret %System.String addrspace(1)* %57
 }
 
-INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
-Successfully read RuntimeHelpers.get_OffsetToStringData
-
-define i32 @RuntimeHelpers.get_OffsetToStringData() {
-entry:
-  ret i32 12
-}
-
 INFO:  jitting method String::Equals using LLILCJit
 Successfully read String.Equals
 
@@ -6381,8 +7827,8 @@ entry:
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
-  br i1 %NullCheck24, label %29, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
   %30 = load i64, i64 addrspace(1)* %28
@@ -6397,8 +7843,8 @@ entry:
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
-  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
   %43 = load i64, i64 addrspace(1)* %41
@@ -6418,8 +7864,8 @@ entry:
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
   %59 = load i64, i64 addrspace(1)* %57
@@ -6434,8 +7880,8 @@ entry:
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck22, label %71, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
   %72 = load i64, i64 addrspace(1)* %70
@@ -6455,8 +7901,8 @@ entry:
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
-  br i1 %NullCheck16, label %87, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = load i64, i64 addrspace(1)* %86
@@ -6471,8 +7917,8 @@ entry:
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck18, label %100, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
   %101 = load i64, i64 addrspace(1)* %99
@@ -6492,8 +7938,8 @@ entry:
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
-  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
   %117 = load i64, i64 addrspace(1)* %115
@@ -6508,8 +7954,8 @@ entry:
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
-  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
   %130 = load i64, i64 addrspace(1)* %128
@@ -6528,15 +7974,15 @@ entry:
 
 ; <label>:142                                     ; preds = %22
   %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
-  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %143, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %144
 
 ; <label>:144                                     ; preds = %142
   %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
   %146 = load i32, i32 addrspace(1)* %145
   %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
-  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %147, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %148
 
 ; <label>:148                                     ; preds = %144
   %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
@@ -6557,15 +8003,15 @@ entry:
 
 ; <label>:159                                     ; preds = %22
   %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
-  br i1 %NullCheck, label %161, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %ThrowNullRef, label %161
 
 ; <label>:161                                     ; preds = %159
   %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
   %163 = load i32, i32 addrspace(1)* %162
   %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
-  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %164, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %165
 
 ; <label>:165                                     ; preds = %161
   %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
@@ -6578,8 +8024,8 @@ entry:
 
 ; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
-  br i1 %NullCheck4, label %172, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %171, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %172
 
 ; <label>:172                                     ; preds = %170
   %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
@@ -6589,8 +8035,8 @@ entry:
 
 ; <label>:176                                     ; preds = %172
   %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
-  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %177, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %178
 
 ; <label>:178                                     ; preds = %176
   %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
@@ -6629,55 +8075,55 @@ ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %161
+ThrowNullRef2:                                    ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %170
+ThrowNullRef4:                                    ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %176
+ThrowNullRef6:                                    ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %142
+ThrowNullRef8:                                    ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %144
+ThrowNullRef10:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %113
+ThrowNullRef12:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %116
+ThrowNullRef14:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %84
+ThrowNullRef16:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %87
+ThrowNullRef18:                                   ; preds = %87
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %55
+ThrowNullRef20:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %58
+ThrowNullRef22:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %26
+ThrowNullRef24:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %29
+ThrowNullRef26:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,8 +8161,8 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck, label %14, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %ThrowNullRef, label %14
 
 ; <label>:14                                      ; preds = %8
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
@@ -6760,8 +8206,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
@@ -6770,14 +8216,14 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32, i32* %loc0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %10
   %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
   %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
@@ -6790,15 +8236,15 @@ entry:
 ; <label>:25                                      ; preds = %19
   %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
-  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
   %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
@@ -6807,8 +8253,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %37 = load i32, i32* %loc0
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %38, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %38
 
 ; <label>:38                                      ; preds = %32
   %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
@@ -6817,14 +8263,14 @@ entry:
 
 ; <label>:40                                      ; preds = %19
   %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %40
   %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
   %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
-  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
-  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
@@ -6832,8 +8278,8 @@ entry:
   %48 = zext i32 %47 to i64
   %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
-  br i1 %NullCheck16, label %51, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %51
 
 ; <label>:51                                      ; preds = %45
   %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
@@ -6847,15 +8293,15 @@ entry:
 ; <label>:57                                      ; preds = %51
   %58 = load i16*, i16** %arg1
   %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
-  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %60
 
 ; <label>:60                                      ; preds = %57
   %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
   %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
-  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %64
 
 ; <label>:64                                      ; preds = %60
   %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
@@ -6864,22 +8310,22 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
   %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
-  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %70
 
 ; <label>:70                                      ; preds = %64
   %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
   %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
-  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
-  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
   %75 = load i32, i32 addrspace(1)* %74
   %76 = zext i32 %75 to i64
   %77 = trunc i64 %76 to i32
-  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
-  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %78
 
 ; <label>:78                                      ; preds = %73
   %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
@@ -6901,8 +8347,8 @@ entry:
   %90 = bitcast i16* %86 to i8*
   %91 = getelementptr inbounds i8, i8* %90, i64 %89
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %93
 
 ; <label>:93                                      ; preds = %80
   %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
@@ -6912,8 +8358,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %99 = load i32, i32* %loc2
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %100
 
 ; <label>:100                                     ; preds = %93
   %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
@@ -6928,63 +8374,63 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %25
+ThrowNullRef6:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %32
+ThrowNullRef10:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %40
+ThrowNullRef12:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %45
+ThrowNullRef16:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %57
+ThrowNullRef18:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %60
+ThrowNullRef20:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %64
+ThrowNullRef22:                                   ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %70
+ThrowNullRef24:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %73
+ThrowNullRef26:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %80
+ThrowNullRef28:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %93
+ThrowNullRef30:                                   ; preds = %93
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7004,8 +8450,8 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
@@ -7033,43 +8479,43 @@ entry:
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %14
   %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
   %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   %28 = load i32, i32 addrspace(1)* %27, align 8
   %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
-  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %30
 
 ; <label>:30                                      ; preds = %26
   %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
   %32 = load i32, i32 addrspace(1)* %31, align 8
   %33 = add i32 %28, %32
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %34
 
 ; <label>:34                                      ; preds = %30
   %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   store i32 %33, i32 addrspace(1)* %35
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
   store i32 0, i32 addrspace(1)* %38
   %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %40
 
 ; <label>:40                                      ; preds = %37
   %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
@@ -7082,8 +8528,8 @@ entry:
 
 ; <label>:47                                      ; preds = %40
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
@@ -7098,8 +8544,8 @@ entry:
   %54 = load i32, i32* %loc0
   %55 = sext i32 %54 to i64
   %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
-  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %57
 
 ; <label>:57                                      ; preds = %52
   %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
@@ -7110,68 +8556,35 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %14
+ThrowNullRef2:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %23
+ThrowNullRef4:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %26
+ThrowNullRef6:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %30
+ThrowNullRef8:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %34
+ThrowNullRef10:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %47
+ThrowNullRef14:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %52
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-}
-
-INFO:  jitting method StringBuilder::get_Length using LLILCJit
-Successfully read StringBuilder.get_Length
-
-define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.StringBuilder addrspace(1)*
-  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
-  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
-
-; <label>:1                                       ; preds = %entry
-  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %3 = load i32, i32 addrspace(1)* %2, align 8
-  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
-
-; <label>:5                                       ; preds = %1
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = add i32 %3, %7
-  ret i32 %8
-
-ThrowNullRef:                                     ; preds = %entry
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef16:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7213,70 +8626,70 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
   %6 = load i32, i32 addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
   store i32 %6, i32 addrspace(1)* %8
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
   %13 = load i32, i32 addrspace(1)* %12, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
   store i32 %13, i32 addrspace(1)* %15
   %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
-  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %18
 
 ; <label>:18                                      ; preds = %14
   %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
   %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
   %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
   %34 = load i32, i32 addrspace(1)* %33, align 8
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
-  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
@@ -7287,39 +8700,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %28
+ThrowNullRef16:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %32
+ThrowNullRef18:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7455,13 +8868,13 @@ entry:
 ; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
@@ -7477,16 +8890,16 @@ entry:
 
 ; <label>:18                                      ; preds = %15
   %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
   store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
   %22 = load i32, i32* %loc0
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %24
 
 ; <label>:24                                      ; preds = %20
   %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
@@ -7498,13 +8911,13 @@ entry:
 ; <label>:28                                      ; preds = %15, %24
   %29 = load i32, i32* %arg1
   %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %31
   %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
@@ -7517,20 +8930,20 @@ entry:
   %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
-  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
   %46 = load i32, i32 addrspace(1)* %45, align 8
   %47 = sub i32 %40, %46
-  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
-  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i32 addrspace(1)* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %48
 
 ; <label>:48                                      ; preds = %44
   store i32 %47, i32 addrspace(1)* %39, align 8
@@ -7538,21 +8951,21 @@ entry:
 
 ; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
-  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %51
 
 ; <label>:51                                      ; preds = %49
   %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %53
 
 ; <label>:53                                      ; preds = %51
   %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
   %55 = load i32, i32 addrspace(1)* %54, align 8
   %56 = load i32, i32* %arg2
   %57 = sub i32 %55, %56
-  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %58
 
 ; <label>:58                                      ; preds = %53
   %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
@@ -7562,13 +8975,13 @@ entry:
 ; <label>:60                                      ; preds = %33, %58
   %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
   %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
-  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %63
 
 ; <label>:63                                      ; preds = %60
   %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
-  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
-  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
@@ -7578,15 +8991,15 @@ entry:
 
 ; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
-  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i32 addrspace(1)* %69, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %70
 
 ; <label>:70                                      ; preds = %68
   %71 = load i32, i32 addrspace(1)* %69, align 8
   store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
-  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
@@ -7596,8 +9009,8 @@ entry:
   store i32 %77, i32* %loc4
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
-  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %80
 
 ; <label>:80                                      ; preds = %73
   %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
@@ -7607,71 +9020,71 @@ entry:
 ; <label>:83                                      ; preds = %80
   store i32 0, i32* %loc3
   %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
-  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
-  br i1 %NullCheck26, label %88, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i32 addrspace(1)* %87, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %88
 
 ; <label>:88                                      ; preds = %85
   %89 = load i32, i32 addrspace(1)* %87, align 8
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
-  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %90
 
 ; <label>:90                                      ; preds = %88
   %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
   store i32 %89, i32 addrspace(1)* %91
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
-  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
-  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %96
 
 ; <label>:96                                      ; preds = %94
   %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
-  br i1 %NullCheck34, label %100, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %100
 
 ; <label>:100                                     ; preds = %96
   %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
-  br i1 %NullCheck36, label %102, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %102
 
 ; <label>:102                                     ; preds = %100
   %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
   %104 = load i32, i32 addrspace(1)* %103, align 8
   %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
-  br i1 %NullCheck38, label %106, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %106
 
 ; <label>:106                                     ; preds = %102
   %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
-  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
-  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %108
 
 ; <label>:108                                     ; preds = %106
   %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
   %110 = load i32, i32 addrspace(1)* %109, align 8
   %111 = add i32 %104, %110
-  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %112
 
 ; <label>:112                                     ; preds = %108
   %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
   store i32 %111, i32 addrspace(1)* %113
   %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
-  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i32 addrspace(1)* %114, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %115
 
 ; <label>:115                                     ; preds = %112
   %116 = load i32, i32 addrspace(1)* %114, align 8
@@ -7681,19 +9094,19 @@ entry:
 ; <label>:118                                     ; preds = %115
   %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
-  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %121
 
 ; <label>:121                                     ; preds = %118
   %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
-  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
-  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %123
 
 ; <label>:123                                     ; preds = %121
   %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
   %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
-  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
-  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %126
 
 ; <label>:126                                     ; preds = %123
   %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
@@ -7705,8 +9118,8 @@ entry:
 
 ; <label>:130                                     ; preds = %80, %115, %126
   %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %132
 
 ; <label>:132                                     ; preds = %130
   %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7715,8 +9128,8 @@ entry:
   %136 = load i32, i32* %loc3
   %137 = sub i32 %135, %136
   %138 = sub i32 %134, %137
-  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %139
 
 ; <label>:139                                     ; preds = %132
   %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7728,16 +9141,16 @@ entry:
 
 ; <label>:144                                     ; preds = %139
   %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
-  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %146
 
 ; <label>:146                                     ; preds = %144
   %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
   %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
   %149 = load i32, i32* %loc2
   %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
-  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %151
 
 ; <label>:151                                     ; preds = %146
   %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
@@ -7754,145 +9167,249 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %18
+ThrowNullRef4:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %31
+ThrowNullRef10:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %44
+ThrowNullRef16:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %68
+ThrowNullRef18:                                   ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %70
+ThrowNullRef20:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %73
+ThrowNullRef22:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %83
+ThrowNullRef24:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %85
+ThrowNullRef26:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %88
+ThrowNullRef28:                                   ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %90
+ThrowNullRef30:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %94
+ThrowNullRef32:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %96
+ThrowNullRef34:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %100
+ThrowNullRef36:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %102
+ThrowNullRef38:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %106
+ThrowNullRef40:                                   ; preds = %106
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %108
+ThrowNullRef42:                                   ; preds = %108
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %112
+ThrowNullRef44:                                   ; preds = %112
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %118
+ThrowNullRef46:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %121
+ThrowNullRef48:                                   ; preds = %121
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %123
+ThrowNullRef50:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %130
+ThrowNullRef52:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %132
+ThrowNullRef54:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %144
+ThrowNullRef56:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %146
+ThrowNullRef58:                                   ; preds = %146
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %60
+ThrowNullRef60:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %63
+ThrowNullRef62:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %49
+ThrowNullRef64:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %51
+ThrowNullRef66:                                   ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %53
+ThrowNullRef68:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(%"System.Char[]" addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %arg0 = alloca %"System.Char[]" addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store %"System.Char[]" addrspace(1)* %param0, %"System.Char[]" addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load i32, i32* %arg4
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %43, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %38, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg1
+  %13 = load i32, i32* %arg4
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %38, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %24 = load i32, i32* %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %35 = load i32, i32* %arg3
+  %36 = load i32, i32* %arg4
+  %37 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %37, %"System.Char[]" addrspace(1)* %34, i32 %35, i32 %36)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:38                                      ; preds = %5, %16
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Successfully read Buffer._Memmove
 
@@ -7914,7 +9431,7 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[loadElem]
+Failed to read AppDomain.SetDataHelper[storeElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -7923,8 +9440,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
@@ -7934,8 +9451,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
@@ -7947,15 +9464,15 @@ entry:
   %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
   %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
@@ -7966,15 +9483,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7992,7 +9509,79 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
-Failed to read Dictionary`2.TryGetValue[loadElemA]
+Successfully read Dictionary`2.TryGetValue
+
+define i8 @"Dictionary`2.TryGetValue"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)* addrspace(1)* %param2) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  %arg2 = alloca %System.__Canon addrspace(1)* addrspace(1)*
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  store %System.__Canon addrspace(1)* addrspace(1)* %param2, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  store i32 %2, i32* %loc0
+  %3 = load i32, i32* %loc0
+  %4 = icmp slt i32 %3, 0
+  br i1 %4, label %22, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 2
+  %10 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %9, align 8
+  %11 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = zext i32 %11 to i64
+  %BoundsCheck = icmp uge i64 %16, %15
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 3, i32 %11
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %20, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %6, %System.__Canon addrspace(1)* %21)
+  ret i8 1
+
+; <label>:22                                      ; preds = %entry
+  %23 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %23, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -8058,8 +9647,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
@@ -8091,8 +9680,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
@@ -8171,15 +9760,15 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck, label %19, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %ThrowNullRef, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
   %21 = load i32, i32 addrspace(1)* %20
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
@@ -8202,7 +9791,7 @@ ThrowNullRef:                                     ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %19
+ThrowNullRef2:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8248,8 +9837,8 @@ entry:
   %0 = alloca %System.AppDomainHandle
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %1 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %1, i32 0, i32 15
@@ -8269,8 +9858,8 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
@@ -8286,7 +9875,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -8299,8 +9888,8 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -8327,8 +9916,8 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
@@ -8352,8 +9941,8 @@ entry:
   %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
   store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
@@ -8363,8 +9952,8 @@ entry:
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
@@ -8374,8 +9963,8 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %9
   %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
@@ -8384,8 +9973,8 @@ entry:
 
 ; <label>:18                                      ; preds = %3, %16
   %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
@@ -8397,15 +9986,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %18
+ThrowNullRef6:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8418,8 +10007,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
@@ -8453,15 +10042,15 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
@@ -8473,7 +10062,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8481,7 +10070,7 @@ ThrowNullRef1:                                    ; preds = %1
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
 Failed to read Dictionary`2.System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
@@ -8506,8 +10095,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
@@ -8524,8 +10113,8 @@ entry:
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -8544,7 +10133,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8577,8 +10166,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = load i64, i64* %arg2
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = trunc i32 %3 to i8
@@ -8634,46 +10223,46 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
   %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
-  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
-  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
-  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
@@ -8684,27 +10273,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %20
+ThrowNullRef12:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8717,8 +10306,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -8756,22 +10345,22 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
   %9 = load i64, i64 addrspace(1)* %8, align 8
   %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
   %13 = load i64, i64 addrspace(1)* %12, align 8
   %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %11
   %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
@@ -8788,11 +10377,11 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8882,8 +10471,8 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
@@ -8900,8 +10489,8 @@ entry:
 ; <label>:8                                       ; preds = %1
   %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
   %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
@@ -8911,15 +10500,15 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
   %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
   %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
-  br i1 %NullCheck6, label %21, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
@@ -8946,15 +10535,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8992,15 +10581,15 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
   store i8 %3, i8 addrspace(1)* %5
   %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
@@ -9011,7 +10600,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9027,8 +10616,8 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -9041,8 +10630,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
@@ -9058,7 +10647,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9080,8 +10669,8 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
@@ -9096,8 +10685,8 @@ entry:
 ; <label>:12                                      ; preds = %6
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
@@ -9112,8 +10701,8 @@ entry:
 ; <label>:21                                      ; preds = %15
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
@@ -9128,8 +10717,8 @@ entry:
 ; <label>:30                                      ; preds = %24
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %31, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
@@ -9144,8 +10733,8 @@ entry:
 ; <label>:39                                      ; preds = %33
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
-  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %40, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %42
 
 ; <label>:42                                      ; preds = %39
   %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
@@ -9164,19 +10753,19 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %21
+ThrowNullRef4:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %30
+ThrowNullRef6:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %39
+ThrowNullRef8:                                    ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9243,8 +10832,8 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
@@ -9264,57 +10853,57 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
   store i8 0, i8 addrspace(1)* %2
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
   store i8 0, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
   store i8 0, i8 addrspace(1)* %17
   %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
   store i8 0, i8 addrspace(1)* %20
   %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
-  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
@@ -9325,31 +10914,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %19
+ThrowNullRef14:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9367,8 +10956,8 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
@@ -9380,8 +10969,8 @@ entry:
 
 ; <label>:9                                       ; preds = %4
   %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %9
   %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
@@ -9395,7 +10984,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef2:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9420,8 +11009,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
@@ -9512,8 +11101,8 @@ entry:
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
@@ -9524,8 +11113,8 @@ entry:
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = load i64, i64 addrspace(1)* %12
@@ -9537,8 +11126,8 @@ entry:
   %20 = load i64, i64* %19
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
-  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %13
   %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
@@ -9555,8 +11144,8 @@ entry:
 ; <label>:30                                      ; preds = %25
   %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %32 = load i32, i32* %arg2
-  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
-  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
@@ -9570,15 +11159,15 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %30
+ThrowNullRef2:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9622,87 +11211,87 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
   %10 = load i8, i8 addrspace(1)* %9, align 8
   %11 = zext i8 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %8
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
   store i8 %12, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
   %19 = load i8, i8 addrspace(1)* %18, align 8
   %20 = zext i8 %19 to i32
   %21 = trunc i32 %20 to i8
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
   store i8 %21, i8 addrspace(1)* %23
   %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
   %28 = load i8, i8 addrspace(1)* %27, align 8
   %29 = zext i8 %28 to i32
   %30 = trunc i32 %29 to i8
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
-  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %31
 
 ; <label>:31                                      ; preds = %26
   %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
   store i8 %30, i8 addrspace(1)* %32
   %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
-  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
-  br i1 %NullCheck14, label %40, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %40
 
 ; <label>:40                                      ; preds = %35
   %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
   store i8 %39, i8 addrspace(1)* %41
   %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
-  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %44
 
 ; <label>:44                                      ; preds = %40
   %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
   %46 = load i8, i8 addrspace(1)* %45, align 8
   %47 = zext i8 %46 to i32
   %48 = trunc i32 %47 to i8
-  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
   store i8 %48, i8 addrspace(1)* %50
   %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
-  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
@@ -9713,29 +11302,29 @@ entry:
 ; <label>:56                                      ; preds = %52
   %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
-  br i1 %NullCheck22, label %59, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
   %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
   %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
-  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
-  br i1 %NullCheck24, label %63, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
   %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
-  br i1 %NullCheck26, label %66, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
   %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
-  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
-  br i1 %NullCheck28, label %69, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %69
 
 ; <label>:69                                      ; preds = %66
   %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
@@ -9744,15 +11333,15 @@ entry:
 
 ; <label>:71                                      ; preds = %105
   %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
-  br i1 %NullCheck34, label %73, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %73
 
 ; <label>:73                                      ; preds = %71
   %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
   %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
   %76 = load i32, i32* %loc0
-  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
-  br i1 %NullCheck36, label %77, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
@@ -9766,8 +11355,8 @@ entry:
 
 ; <label>:83                                      ; preds = %77
   %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
-  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
@@ -9775,14 +11364,14 @@ entry:
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
   %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
-  br i1 %NullCheck40, label %91, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
 ; <label>:91                                      ; preds = %85
   %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
   %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
-  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck42, label %94, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %94
 
 ; <label>:94                                      ; preds = %91
   %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
@@ -9798,14 +11387,14 @@ entry:
 ; <label>:99                                      ; preds = %69, %96
   %100 = load i32, i32* %loc0
   %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
-  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %102
 
 ; <label>:102                                     ; preds = %99
   %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
   %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
-  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
-  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
@@ -9819,87 +11408,87 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %26
+ThrowNullRef10:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %31
+ThrowNullRef12:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %35
+ThrowNullRef14:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %40
+ThrowNullRef16:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %56
+ThrowNullRef22:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %59
+ThrowNullRef24:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %63
+ThrowNullRef26:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %66
+ThrowNullRef28:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %102
+ThrowNullRef32:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %71
+ThrowNullRef34:                                   ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %73
+ThrowNullRef36:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %83
+ThrowNullRef38:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %85
+ThrowNullRef40:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %91
+ThrowNullRef42:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9943,15 +11532,15 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
   %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
@@ -9961,28 +11550,28 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
   %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %12
   %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
   %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
   %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
-  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
@@ -9993,23 +11582,23 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %12
+ThrowNullRef6:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10031,15 +11620,15 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
   %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = load i64, i64 addrspace(1)* %7
@@ -10077,13 +11666,13 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[loadElem]
+Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -10111,8 +11700,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -10187,88 +11776,88 @@ entry:
   %0 = addrspacecast %Point* %loc0 to %Point addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%Point addrspace(1)*, i32, i32, i32)*)(%Point addrspace(1)* %0, i32 10, i32 20, i32 30)
   %1 = addrspacecast %Point* %loc1 to %Point addrspace(1)*
-  %NullCheck = icmp ne %Point addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %Point addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %Point, %Point addrspace(1)* %1, i32 0, i32 0
   store i32 0, i32 addrspace(1)* %3
   %4 = addrspacecast %Point* %loc1 to %Point addrspace(1)*
-  %NullCheck2 = icmp ne %Point addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %Point addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %2
   %6 = getelementptr inbounds %Point, %Point addrspace(1)* %4, i32 0, i32 1
   store i32 0, i32 addrspace(1)* %6
   %7 = addrspacecast %Point* %loc1 to %Point addrspace(1)*
-  %NullCheck4 = icmp ne %Point addrspace(1)* %7, null
-  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %Point addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %Point, %Point addrspace(1)* %7, i32 0, i32 2
   store i32 0, i32 addrspace(1)* %9
   %10 = addrspacecast %Point* %loc2 to %Point addrspace(1)*
   %11 = addrspacecast %Point* %loc0 to %Point addrspace(1)*
-  %NullCheck6 = icmp ne %Point addrspace(1)* %11, null
-  br i1 %NullCheck6, label %12, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %Point addrspace(1)* %11, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %12
 
 ; <label>:12                                      ; preds = %8
   %13 = getelementptr inbounds %Point, %Point addrspace(1)* %11, i32 0, i32 0
   %14 = load i32, i32 addrspace(1)* %13, align 8
   %15 = add i32 %14, 5
-  %NullCheck8 = icmp ne %Point addrspace(1)* %10, null
-  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %Point addrspace(1)* %10, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %16
 
 ; <label>:16                                      ; preds = %12
   %17 = getelementptr inbounds %Point, %Point addrspace(1)* %10, i32 0, i32 0
   store i32 %15, i32 addrspace(1)* %17
   %18 = addrspacecast %Point* %loc2 to %Point addrspace(1)*
   %19 = addrspacecast %Point* %loc0 to %Point addrspace(1)*
-  %NullCheck10 = icmp ne %Point addrspace(1)* %19, null
-  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %Point addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %20
 
 ; <label>:20                                      ; preds = %16
   %21 = getelementptr inbounds %Point, %Point addrspace(1)* %19, i32 0, i32 1
   %22 = load i32, i32 addrspace(1)* %21, align 8
   %23 = addrspacecast %Point* %loc1 to %Point addrspace(1)*
-  %NullCheck12 = icmp ne %Point addrspace(1)* %23, null
-  br i1 %NullCheck12, label %24, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %Point addrspace(1)* %23, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %24
 
 ; <label>:24                                      ; preds = %20
   %25 = getelementptr inbounds %Point, %Point addrspace(1)* %23, i32 0, i32 1
   %26 = load i32, i32 addrspace(1)* %25, align 8
   %27 = add i32 %22, %26
-  %NullCheck14 = icmp ne %Point addrspace(1)* %18, null
-  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %Point addrspace(1)* %18, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %Point, %Point addrspace(1)* %18, i32 0, i32 1
   store i32 %27, i32 addrspace(1)* %29
   %30 = addrspacecast %Point* %loc2 to %Point addrspace(1)*
   %31 = addrspacecast %Point* %loc0 to %Point addrspace(1)*
-  %NullCheck16 = icmp ne %Point addrspace(1)* %31, null
-  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %Point addrspace(1)* %31, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %Point, %Point addrspace(1)* %31, i32 0, i32 2
   %34 = load i32, i32 addrspace(1)* %33, align 8
   %35 = addrspacecast %Point* %loc1 to %Point addrspace(1)*
-  %NullCheck18 = icmp ne %Point addrspace(1)* %35, null
-  br i1 %NullCheck18, label %36, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %Point addrspace(1)* %35, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %36
 
 ; <label>:36                                      ; preds = %32
   %37 = getelementptr inbounds %Point, %Point addrspace(1)* %35, i32 0, i32 2
   %38 = load i32, i32 addrspace(1)* %37, align 8
   %39 = mul i32 %34, %38
-  %NullCheck20 = icmp ne %Point addrspace(1)* %30, null
-  br i1 %NullCheck20, label %40, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %Point addrspace(1)* %30, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %40
 
 ; <label>:40                                      ; preds = %36
   %41 = getelementptr inbounds %Point, %Point addrspace(1)* %30, i32 0, i32 2
   store i32 %39, i32 addrspace(1)* %41
   %42 = addrspacecast %Point* %loc2 to %Point addrspace(1)*
-  %NullCheck22 = icmp ne %Point addrspace(1)* %42, null
-  br i1 %NullCheck22, label %43, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %Point addrspace(1)* %42, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = getelementptr inbounds %Point, %Point addrspace(1)* %42, i32 0, i32 0
@@ -10278,8 +11867,8 @@ entry:
 
 ; <label>:47                                      ; preds = %43
   %48 = addrspacecast %Point* %loc2 to %Point addrspace(1)*
-  %NullCheck24 = icmp ne %Point addrspace(1)* %48, null
-  br i1 %NullCheck24, label %49, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %Point addrspace(1)* %48, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %Point, %Point addrspace(1)* %48, i32 0, i32 1
@@ -10289,8 +11878,8 @@ entry:
 
 ; <label>:53                                      ; preds = %49
   %54 = addrspacecast %Point* %loc2 to %Point addrspace(1)*
-  %NullCheck26 = icmp ne %Point addrspace(1)* %54, null
-  br i1 %NullCheck26, label %55, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %Point addrspace(1)* %54, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %55
 
 ; <label>:55                                      ; preds = %53
   %56 = getelementptr inbounds %Point, %Point addrspace(1)* %54, i32 0, i32 2
@@ -10316,15 +11905,15 @@ entry:
 
 ; <label>:68                                      ; preds = %61
   %69 = addrspacecast %Point* %loc0 to %Point addrspace(1)*
-  %NullCheck28 = icmp ne %Point addrspace(1)* %69, null
-  br i1 %NullCheck28, label %70, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %Point addrspace(1)* %69, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %70
 
 ; <label>:70                                      ; preds = %68
   %71 = getelementptr inbounds %Point, %Point addrspace(1)* %69, i32 0, i32 0
   %72 = load i32, i32 addrspace(1)* %71, align 8
   %73 = addrspacecast %Point* %loc1 to %Point addrspace(1)*
-  %NullCheck30 = icmp ne %Point addrspace(1)* %73, null
-  br i1 %NullCheck30, label %74, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %Point addrspace(1)* %73, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %74
 
 ; <label>:74                                      ; preds = %70
   %75 = getelementptr inbounds %Point, %Point addrspace(1)* %73, i32 0, i32 0
@@ -10332,15 +11921,15 @@ entry:
   %77 = add i32 %72, %76
   store i32 %77, i32* %loc4
   %78 = addrspacecast %Point* %loc0 to %Point addrspace(1)*
-  %NullCheck32 = icmp ne %Point addrspace(1)* %78, null
-  br i1 %NullCheck32, label %79, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %Point addrspace(1)* %78, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %79
 
 ; <label>:79                                      ; preds = %74
   %80 = getelementptr inbounds %Point, %Point addrspace(1)* %78, i32 0, i32 1
   %81 = load i32, i32 addrspace(1)* %80, align 8
   %82 = addrspacecast %Point* %loc1 to %Point addrspace(1)*
-  %NullCheck34 = icmp ne %Point addrspace(1)* %82, null
-  br i1 %NullCheck34, label %83, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %Point addrspace(1)* %82, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %83
 
 ; <label>:83                                      ; preds = %79
   %84 = getelementptr inbounds %Point, %Point addrspace(1)* %82, i32 0, i32 1
@@ -10348,8 +11937,8 @@ entry:
   %86 = mul i32 %81, %85
   store i32 %86, i32* %loc5
   %87 = addrspacecast %Point* %loc0 to %Point addrspace(1)*
-  %NullCheck36 = icmp ne %Point addrspace(1)* %87, null
-  br i1 %NullCheck36, label %88, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %Point addrspace(1)* %87, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %88
 
 ; <label>:88                                      ; preds = %83
   %89 = getelementptr inbounds %Point, %Point addrspace(1)* %87, i32 0, i32 2
@@ -10357,8 +11946,8 @@ entry:
   store i32 %90, i32* %loc6
   %91 = load i32, i32* %loc4
   %92 = addrspacecast %Point* %loc0 to %Point addrspace(1)*
-  %NullCheck38 = icmp ne %Point addrspace(1)* %92, null
-  br i1 %NullCheck38, label %93, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %Point addrspace(1)* %92, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %93
 
 ; <label>:93                                      ; preds = %88
   %94 = getelementptr inbounds %Point, %Point addrspace(1)* %92, i32 0, i32 0
@@ -10369,8 +11958,8 @@ entry:
 ; <label>:97                                      ; preds = %93
   %98 = load i32, i32* %loc5
   %99 = addrspacecast %Point* %loc1 to %Point addrspace(1)*
-  %NullCheck40 = icmp ne %Point addrspace(1)* %99, null
-  br i1 %NullCheck40, label %100, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %Point addrspace(1)* %99, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %100
 
 ; <label>:100                                     ; preds = %97
   %101 = getelementptr inbounds %Point, %Point addrspace(1)* %99, i32 0, i32 1
@@ -10397,8 +11986,8 @@ entry:
 ; <label>:113                                     ; preds = %106
   %114 = load i32, i32* %loc4
   %115 = addrspacecast %Point* %loc0 to %Point addrspace(1)*
-  %NullCheck42 = icmp ne %Point addrspace(1)* %115, null
-  br i1 %NullCheck42, label %116, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %Point addrspace(1)* %115, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %116
 
 ; <label>:116                                     ; preds = %113
   %117 = getelementptr inbounds %Point, %Point addrspace(1)* %115, i32 0, i32 0
@@ -10415,8 +12004,8 @@ entry:
 ; <label>:123                                     ; preds = %116
   %124 = load i32, i32* %loc5
   %125 = addrspacecast %Point* %loc0 to %Point addrspace(1)*
-  %NullCheck44 = icmp ne %Point addrspace(1)* %125, null
-  br i1 %NullCheck44, label %126, label %ThrowNullRef43
+  %NullCheck43 = icmp eq %Point addrspace(1)* %125, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %126
 
 ; <label>:126                                     ; preds = %123
   %127 = getelementptr inbounds %Point, %Point addrspace(1)* %125, i32 0, i32 1
@@ -10433,8 +12022,8 @@ entry:
 ; <label>:133                                     ; preds = %126
   %134 = load i32, i32* %loc6
   %135 = addrspacecast %Point* %loc0 to %Point addrspace(1)*
-  %NullCheck46 = icmp ne %Point addrspace(1)* %135, null
-  br i1 %NullCheck46, label %136, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %Point addrspace(1)* %135, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %136
 
 ; <label>:136                                     ; preds = %133
   %137 = getelementptr inbounds %Point, %Point addrspace(1)* %135, i32 0, i32 0
@@ -10442,50 +12031,50 @@ entry:
   %139 = sdiv i32 %134, %138
   store i32 %139, i32* %loc6
   %140 = addrspacecast %Point* %loc0 to %Point addrspace(1)*
-  %NullCheck48 = icmp ne %Point addrspace(1)* %140, null
-  br i1 %NullCheck48, label %141, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %Point addrspace(1)* %140, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %141
 
 ; <label>:141                                     ; preds = %136
   %142 = getelementptr inbounds %Point, %Point addrspace(1)* %140, i32 0, i32 0
   %143 = load i32, i32 addrspace(1)* %142, align 8
   %144 = add i32 %143, 10
-  %NullCheck50 = icmp ne %Point addrspace(1)* %140, null
-  br i1 %NullCheck50, label %145, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %Point addrspace(1)* %140, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %145
 
 ; <label>:145                                     ; preds = %141
   %146 = getelementptr inbounds %Point, %Point addrspace(1)* %140, i32 0, i32 0
   store i32 %144, i32 addrspace(1)* %146
   %147 = addrspacecast %Point* %loc0 to %Point addrspace(1)*
-  %NullCheck52 = icmp ne %Point addrspace(1)* %147, null
-  br i1 %NullCheck52, label %148, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %Point addrspace(1)* %147, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %148
 
 ; <label>:148                                     ; preds = %145
   %149 = getelementptr inbounds %Point, %Point addrspace(1)* %147, i32 0, i32 1
   %150 = load i32, i32 addrspace(1)* %149, align 8
   %151 = mul i32 %150, 3
-  %NullCheck54 = icmp ne %Point addrspace(1)* %147, null
-  br i1 %NullCheck54, label %152, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %Point addrspace(1)* %147, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %152
 
 ; <label>:152                                     ; preds = %148
   %153 = getelementptr inbounds %Point, %Point addrspace(1)* %147, i32 0, i32 1
   store i32 %151, i32 addrspace(1)* %153
   %154 = addrspacecast %Point* %loc0 to %Point addrspace(1)*
-  %NullCheck56 = icmp ne %Point addrspace(1)* %154, null
-  br i1 %NullCheck56, label %155, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %Point addrspace(1)* %154, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %155
 
 ; <label>:155                                     ; preds = %152
   %156 = getelementptr inbounds %Point, %Point addrspace(1)* %154, i32 0, i32 2
   %157 = load i32, i32 addrspace(1)* %156, align 8
   %158 = sdiv i32 %157, 5
-  %NullCheck58 = icmp ne %Point addrspace(1)* %154, null
-  br i1 %NullCheck58, label %159, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %Point addrspace(1)* %154, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %159
 
 ; <label>:159                                     ; preds = %155
   %160 = getelementptr inbounds %Point, %Point addrspace(1)* %154, i32 0, i32 2
   store i32 %158, i32 addrspace(1)* %160
   %161 = addrspacecast %Point* %loc0 to %Point addrspace(1)*
-  %NullCheck60 = icmp ne %Point addrspace(1)* %161, null
-  br i1 %NullCheck60, label %162, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %Point addrspace(1)* %161, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %162
 
 ; <label>:162                                     ; preds = %159
   %163 = getelementptr inbounds %Point, %Point addrspace(1)* %161, i32 0, i32 0
@@ -10498,8 +12087,8 @@ entry:
 
 ; <label>:167                                     ; preds = %162
   %168 = addrspacecast %Point* %loc0 to %Point addrspace(1)*
-  %NullCheck62 = icmp ne %Point addrspace(1)* %168, null
-  br i1 %NullCheck62, label %169, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %Point addrspace(1)* %168, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %169
 
 ; <label>:169                                     ; preds = %167
   %170 = getelementptr inbounds %Point, %Point addrspace(1)* %168, i32 0, i32 1
@@ -10512,8 +12101,8 @@ entry:
 
 ; <label>:174                                     ; preds = %169
   %175 = addrspacecast %Point* %loc0 to %Point addrspace(1)*
-  %NullCheck64 = icmp ne %Point addrspace(1)* %175, null
-  br i1 %NullCheck64, label %176, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %Point addrspace(1)* %175, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %176
 
 ; <label>:176                                     ; preds = %174
   %177 = getelementptr inbounds %Point, %Point addrspace(1)* %175, i32 0, i32 2
@@ -10528,88 +12117,88 @@ entry:
   %182 = addrspacecast %PointFlt* %loc7 to %PointFlt addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%PointFlt addrspace(1)*, float, float, float)*)(%PointFlt addrspace(1)* %182, float 1.000000e+01, float 2.000000e+01, float 3.000000e+01)
   %183 = addrspacecast %PointFlt* %loc8 to %PointFlt addrspace(1)*
-  %NullCheck66 = icmp ne %PointFlt addrspace(1)* %183, null
-  br i1 %NullCheck66, label %184, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %PointFlt addrspace(1)* %183, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %184
 
 ; <label>:184                                     ; preds = %181
   %185 = getelementptr inbounds %PointFlt, %PointFlt addrspace(1)* %183, i32 0, i32 0
   store float 0.000000e+00, float addrspace(1)* %185
   %186 = addrspacecast %PointFlt* %loc8 to %PointFlt addrspace(1)*
-  %NullCheck68 = icmp ne %PointFlt addrspace(1)* %186, null
-  br i1 %NullCheck68, label %187, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %PointFlt addrspace(1)* %186, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %187
 
 ; <label>:187                                     ; preds = %184
   %188 = getelementptr inbounds %PointFlt, %PointFlt addrspace(1)* %186, i32 0, i32 1
   store float 0.000000e+00, float addrspace(1)* %188
   %189 = addrspacecast %PointFlt* %loc8 to %PointFlt addrspace(1)*
-  %NullCheck70 = icmp ne %PointFlt addrspace(1)* %189, null
-  br i1 %NullCheck70, label %190, label %ThrowNullRef69
+  %NullCheck69 = icmp eq %PointFlt addrspace(1)* %189, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %190
 
 ; <label>:190                                     ; preds = %187
   %191 = getelementptr inbounds %PointFlt, %PointFlt addrspace(1)* %189, i32 0, i32 2
   store float 0.000000e+00, float addrspace(1)* %191
   %192 = addrspacecast %PointFlt* %loc9 to %PointFlt addrspace(1)*
   %193 = addrspacecast %PointFlt* %loc7 to %PointFlt addrspace(1)*
-  %NullCheck72 = icmp ne %PointFlt addrspace(1)* %193, null
-  br i1 %NullCheck72, label %194, label %ThrowNullRef71
+  %NullCheck71 = icmp eq %PointFlt addrspace(1)* %193, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %194
 
 ; <label>:194                                     ; preds = %190
   %195 = getelementptr inbounds %PointFlt, %PointFlt addrspace(1)* %193, i32 0, i32 0
   %196 = load float, float addrspace(1)* %195, align 8
   %197 = fadd float %196, 5.000000e+00
-  %NullCheck74 = icmp ne %PointFlt addrspace(1)* %192, null
-  br i1 %NullCheck74, label %198, label %ThrowNullRef73
+  %NullCheck73 = icmp eq %PointFlt addrspace(1)* %192, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %198
 
 ; <label>:198                                     ; preds = %194
   %199 = getelementptr inbounds %PointFlt, %PointFlt addrspace(1)* %192, i32 0, i32 0
   store float %197, float addrspace(1)* %199
   %200 = addrspacecast %PointFlt* %loc9 to %PointFlt addrspace(1)*
   %201 = addrspacecast %PointFlt* %loc7 to %PointFlt addrspace(1)*
-  %NullCheck76 = icmp ne %PointFlt addrspace(1)* %201, null
-  br i1 %NullCheck76, label %202, label %ThrowNullRef75
+  %NullCheck75 = icmp eq %PointFlt addrspace(1)* %201, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %202
 
 ; <label>:202                                     ; preds = %198
   %203 = getelementptr inbounds %PointFlt, %PointFlt addrspace(1)* %201, i32 0, i32 1
   %204 = load float, float addrspace(1)* %203, align 8
   %205 = addrspacecast %PointFlt* %loc8 to %PointFlt addrspace(1)*
-  %NullCheck78 = icmp ne %PointFlt addrspace(1)* %205, null
-  br i1 %NullCheck78, label %206, label %ThrowNullRef77
+  %NullCheck77 = icmp eq %PointFlt addrspace(1)* %205, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %206
 
 ; <label>:206                                     ; preds = %202
   %207 = getelementptr inbounds %PointFlt, %PointFlt addrspace(1)* %205, i32 0, i32 1
   %208 = load float, float addrspace(1)* %207, align 8
   %209 = fadd float %204, %208
-  %NullCheck80 = icmp ne %PointFlt addrspace(1)* %200, null
-  br i1 %NullCheck80, label %210, label %ThrowNullRef79
+  %NullCheck79 = icmp eq %PointFlt addrspace(1)* %200, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %210
 
 ; <label>:210                                     ; preds = %206
   %211 = getelementptr inbounds %PointFlt, %PointFlt addrspace(1)* %200, i32 0, i32 1
   store float %209, float addrspace(1)* %211
   %212 = addrspacecast %PointFlt* %loc9 to %PointFlt addrspace(1)*
   %213 = addrspacecast %PointFlt* %loc7 to %PointFlt addrspace(1)*
-  %NullCheck82 = icmp ne %PointFlt addrspace(1)* %213, null
-  br i1 %NullCheck82, label %214, label %ThrowNullRef81
+  %NullCheck81 = icmp eq %PointFlt addrspace(1)* %213, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %214
 
 ; <label>:214                                     ; preds = %210
   %215 = getelementptr inbounds %PointFlt, %PointFlt addrspace(1)* %213, i32 0, i32 2
   %216 = load float, float addrspace(1)* %215, align 8
   %217 = addrspacecast %PointFlt* %loc8 to %PointFlt addrspace(1)*
-  %NullCheck84 = icmp ne %PointFlt addrspace(1)* %217, null
-  br i1 %NullCheck84, label %218, label %ThrowNullRef83
+  %NullCheck83 = icmp eq %PointFlt addrspace(1)* %217, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %218
 
 ; <label>:218                                     ; preds = %214
   %219 = getelementptr inbounds %PointFlt, %PointFlt addrspace(1)* %217, i32 0, i32 2
   %220 = load float, float addrspace(1)* %219, align 8
   %221 = fmul float %216, %220
-  %NullCheck86 = icmp ne %PointFlt addrspace(1)* %212, null
-  br i1 %NullCheck86, label %222, label %ThrowNullRef85
+  %NullCheck85 = icmp eq %PointFlt addrspace(1)* %212, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %222
 
 ; <label>:222                                     ; preds = %218
   %223 = getelementptr inbounds %PointFlt, %PointFlt addrspace(1)* %212, i32 0, i32 2
   store float %221, float addrspace(1)* %223
   %224 = addrspacecast %PointFlt* %loc9 to %PointFlt addrspace(1)*
-  %NullCheck88 = icmp ne %PointFlt addrspace(1)* %224, null
-  br i1 %NullCheck88, label %225, label %ThrowNullRef87
+  %NullCheck87 = icmp eq %PointFlt addrspace(1)* %224, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %225
 
 ; <label>:225                                     ; preds = %222
   %226 = getelementptr inbounds %PointFlt, %PointFlt addrspace(1)* %224, i32 0, i32 0
@@ -10621,8 +12210,8 @@ entry:
 
 ; <label>:231                                     ; preds = %225
   %232 = addrspacecast %PointFlt* %loc9 to %PointFlt addrspace(1)*
-  %NullCheck90 = icmp ne %PointFlt addrspace(1)* %232, null
-  br i1 %NullCheck90, label %233, label %ThrowNullRef89
+  %NullCheck89 = icmp eq %PointFlt addrspace(1)* %232, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %233
 
 ; <label>:233                                     ; preds = %231
   %234 = getelementptr inbounds %PointFlt, %PointFlt addrspace(1)* %232, i32 0, i32 1
@@ -10634,8 +12223,8 @@ entry:
 
 ; <label>:239                                     ; preds = %233
   %240 = addrspacecast %PointFlt* %loc9 to %PointFlt addrspace(1)*
-  %NullCheck92 = icmp ne %PointFlt addrspace(1)* %240, null
-  br i1 %NullCheck92, label %241, label %ThrowNullRef91
+  %NullCheck91 = icmp eq %PointFlt addrspace(1)* %240, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %241
 
 ; <label>:241                                     ; preds = %239
   %242 = getelementptr inbounds %PointFlt, %PointFlt addrspace(1)* %240, i32 0, i32 2
@@ -10661,15 +12250,15 @@ entry:
 
 ; <label>:254                                     ; preds = %247
   %255 = addrspacecast %PointFlt* %loc7 to %PointFlt addrspace(1)*
-  %NullCheck94 = icmp ne %PointFlt addrspace(1)* %255, null
-  br i1 %NullCheck94, label %256, label %ThrowNullRef93
+  %NullCheck93 = icmp eq %PointFlt addrspace(1)* %255, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %256
 
 ; <label>:256                                     ; preds = %254
   %257 = getelementptr inbounds %PointFlt, %PointFlt addrspace(1)* %255, i32 0, i32 0
   %258 = load float, float addrspace(1)* %257, align 8
   %259 = addrspacecast %PointFlt* %loc8 to %PointFlt addrspace(1)*
-  %NullCheck96 = icmp ne %PointFlt addrspace(1)* %259, null
-  br i1 %NullCheck96, label %260, label %ThrowNullRef95
+  %NullCheck95 = icmp eq %PointFlt addrspace(1)* %259, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %260
 
 ; <label>:260                                     ; preds = %256
   %261 = getelementptr inbounds %PointFlt, %PointFlt addrspace(1)* %259, i32 0, i32 0
@@ -10677,15 +12266,15 @@ entry:
   %263 = fadd float %258, %262
   store float %263, float* %loc10
   %264 = addrspacecast %PointFlt* %loc7 to %PointFlt addrspace(1)*
-  %NullCheck98 = icmp ne %PointFlt addrspace(1)* %264, null
-  br i1 %NullCheck98, label %265, label %ThrowNullRef97
+  %NullCheck97 = icmp eq %PointFlt addrspace(1)* %264, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %265
 
 ; <label>:265                                     ; preds = %260
   %266 = getelementptr inbounds %PointFlt, %PointFlt addrspace(1)* %264, i32 0, i32 1
   %267 = load float, float addrspace(1)* %266, align 8
   %268 = addrspacecast %PointFlt* %loc8 to %PointFlt addrspace(1)*
-  %NullCheck100 = icmp ne %PointFlt addrspace(1)* %268, null
-  br i1 %NullCheck100, label %269, label %ThrowNullRef99
+  %NullCheck99 = icmp eq %PointFlt addrspace(1)* %268, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %269
 
 ; <label>:269                                     ; preds = %265
   %270 = getelementptr inbounds %PointFlt, %PointFlt addrspace(1)* %268, i32 0, i32 1
@@ -10693,8 +12282,8 @@ entry:
   %272 = fmul float %267, %271
   store float %272, float* %loc11
   %273 = addrspacecast %PointFlt* %loc7 to %PointFlt addrspace(1)*
-  %NullCheck102 = icmp ne %PointFlt addrspace(1)* %273, null
-  br i1 %NullCheck102, label %274, label %ThrowNullRef101
+  %NullCheck101 = icmp eq %PointFlt addrspace(1)* %273, null
+  br i1 %NullCheck101, label %ThrowNullRef102, label %274
 
 ; <label>:274                                     ; preds = %269
   %275 = getelementptr inbounds %PointFlt, %PointFlt addrspace(1)* %273, i32 0, i32 2
@@ -10702,8 +12291,8 @@ entry:
   store float %276, float* %loc12
   %277 = load float, float* %loc10
   %278 = addrspacecast %PointFlt* %loc7 to %PointFlt addrspace(1)*
-  %NullCheck104 = icmp ne %PointFlt addrspace(1)* %278, null
-  br i1 %NullCheck104, label %279, label %ThrowNullRef103
+  %NullCheck103 = icmp eq %PointFlt addrspace(1)* %278, null
+  br i1 %NullCheck103, label %ThrowNullRef104, label %279
 
 ; <label>:279                                     ; preds = %274
   %280 = getelementptr inbounds %PointFlt, %PointFlt addrspace(1)* %278, i32 0, i32 0
@@ -10716,8 +12305,8 @@ entry:
 ; <label>:285                                     ; preds = %279
   %286 = load float, float* %loc11
   %287 = addrspacecast %PointFlt* %loc8 to %PointFlt addrspace(1)*
-  %NullCheck106 = icmp ne %PointFlt addrspace(1)* %287, null
-  br i1 %NullCheck106, label %288, label %ThrowNullRef105
+  %NullCheck105 = icmp eq %PointFlt addrspace(1)* %287, null
+  br i1 %NullCheck105, label %ThrowNullRef106, label %288
 
 ; <label>:288                                     ; preds = %285
   %289 = getelementptr inbounds %PointFlt, %PointFlt addrspace(1)* %287, i32 0, i32 1
@@ -10744,8 +12333,8 @@ entry:
 ; <label>:301                                     ; preds = %294
   %302 = load float, float* %loc10
   %303 = addrspacecast %PointFlt* %loc7 to %PointFlt addrspace(1)*
-  %NullCheck108 = icmp ne %PointFlt addrspace(1)* %303, null
-  br i1 %NullCheck108, label %304, label %ThrowNullRef107
+  %NullCheck107 = icmp eq %PointFlt addrspace(1)* %303, null
+  br i1 %NullCheck107, label %ThrowNullRef108, label %304
 
 ; <label>:304                                     ; preds = %301
   %305 = getelementptr inbounds %PointFlt, %PointFlt addrspace(1)* %303, i32 0, i32 0
@@ -10764,8 +12353,8 @@ entry:
 ; <label>:313                                     ; preds = %304
   %314 = load float, float* %loc11
   %315 = addrspacecast %PointFlt* %loc7 to %PointFlt addrspace(1)*
-  %NullCheck110 = icmp ne %PointFlt addrspace(1)* %315, null
-  br i1 %NullCheck110, label %316, label %ThrowNullRef109
+  %NullCheck109 = icmp eq %PointFlt addrspace(1)* %315, null
+  br i1 %NullCheck109, label %ThrowNullRef110, label %316
 
 ; <label>:316                                     ; preds = %313
   %317 = getelementptr inbounds %PointFlt, %PointFlt addrspace(1)* %315, i32 0, i32 1
@@ -10784,8 +12373,8 @@ entry:
 ; <label>:325                                     ; preds = %316
   %326 = load float, float* %loc12
   %327 = addrspacecast %PointFlt* %loc7 to %PointFlt addrspace(1)*
-  %NullCheck112 = icmp ne %PointFlt addrspace(1)* %327, null
-  br i1 %NullCheck112, label %328, label %ThrowNullRef111
+  %NullCheck111 = icmp eq %PointFlt addrspace(1)* %327, null
+  br i1 %NullCheck111, label %ThrowNullRef112, label %328
 
 ; <label>:328                                     ; preds = %325
   %329 = getelementptr inbounds %PointFlt, %PointFlt addrspace(1)* %327, i32 0, i32 0
@@ -10793,50 +12382,50 @@ entry:
   %331 = fdiv float %326, %330
   store float %331, float* %loc12
   %332 = addrspacecast %PointFlt* %loc7 to %PointFlt addrspace(1)*
-  %NullCheck114 = icmp ne %PointFlt addrspace(1)* %332, null
-  br i1 %NullCheck114, label %333, label %ThrowNullRef113
+  %NullCheck113 = icmp eq %PointFlt addrspace(1)* %332, null
+  br i1 %NullCheck113, label %ThrowNullRef114, label %333
 
 ; <label>:333                                     ; preds = %328
   %334 = getelementptr inbounds %PointFlt, %PointFlt addrspace(1)* %332, i32 0, i32 0
   %335 = load float, float addrspace(1)* %334, align 8
   %336 = fadd float %335, 1.000000e+01
-  %NullCheck116 = icmp ne %PointFlt addrspace(1)* %332, null
-  br i1 %NullCheck116, label %337, label %ThrowNullRef115
+  %NullCheck115 = icmp eq %PointFlt addrspace(1)* %332, null
+  br i1 %NullCheck115, label %ThrowNullRef116, label %337
 
 ; <label>:337                                     ; preds = %333
   %338 = getelementptr inbounds %PointFlt, %PointFlt addrspace(1)* %332, i32 0, i32 0
   store float %336, float addrspace(1)* %338
   %339 = addrspacecast %PointFlt* %loc7 to %PointFlt addrspace(1)*
-  %NullCheck118 = icmp ne %PointFlt addrspace(1)* %339, null
-  br i1 %NullCheck118, label %340, label %ThrowNullRef117
+  %NullCheck117 = icmp eq %PointFlt addrspace(1)* %339, null
+  br i1 %NullCheck117, label %ThrowNullRef118, label %340
 
 ; <label>:340                                     ; preds = %337
   %341 = getelementptr inbounds %PointFlt, %PointFlt addrspace(1)* %339, i32 0, i32 1
   %342 = load float, float addrspace(1)* %341, align 8
   %343 = fmul float %342, 3.000000e+00
-  %NullCheck120 = icmp ne %PointFlt addrspace(1)* %339, null
-  br i1 %NullCheck120, label %344, label %ThrowNullRef119
+  %NullCheck119 = icmp eq %PointFlt addrspace(1)* %339, null
+  br i1 %NullCheck119, label %ThrowNullRef120, label %344
 
 ; <label>:344                                     ; preds = %340
   %345 = getelementptr inbounds %PointFlt, %PointFlt addrspace(1)* %339, i32 0, i32 1
   store float %343, float addrspace(1)* %345
   %346 = addrspacecast %PointFlt* %loc7 to %PointFlt addrspace(1)*
-  %NullCheck122 = icmp ne %PointFlt addrspace(1)* %346, null
-  br i1 %NullCheck122, label %347, label %ThrowNullRef121
+  %NullCheck121 = icmp eq %PointFlt addrspace(1)* %346, null
+  br i1 %NullCheck121, label %ThrowNullRef122, label %347
 
 ; <label>:347                                     ; preds = %344
   %348 = getelementptr inbounds %PointFlt, %PointFlt addrspace(1)* %346, i32 0, i32 2
   %349 = load float, float addrspace(1)* %348, align 8
   %350 = fdiv float %349, 5.000000e+00
-  %NullCheck124 = icmp ne %PointFlt addrspace(1)* %346, null
-  br i1 %NullCheck124, label %351, label %ThrowNullRef123
+  %NullCheck123 = icmp eq %PointFlt addrspace(1)* %346, null
+  br i1 %NullCheck123, label %ThrowNullRef124, label %351
 
 ; <label>:351                                     ; preds = %347
   %352 = getelementptr inbounds %PointFlt, %PointFlt addrspace(1)* %346, i32 0, i32 2
   store float %350, float addrspace(1)* %352
   %353 = addrspacecast %PointFlt* %loc7 to %PointFlt addrspace(1)*
-  %NullCheck126 = icmp ne %PointFlt addrspace(1)* %353, null
-  br i1 %NullCheck126, label %354, label %ThrowNullRef125
+  %NullCheck125 = icmp eq %PointFlt addrspace(1)* %353, null
+  br i1 %NullCheck125, label %ThrowNullRef126, label %354
 
 ; <label>:354                                     ; preds = %351
   %355 = getelementptr inbounds %PointFlt, %PointFlt addrspace(1)* %353, i32 0, i32 0
@@ -10851,8 +12440,8 @@ entry:
 
 ; <label>:361                                     ; preds = %354
   %362 = addrspacecast %PointFlt* %loc7 to %PointFlt addrspace(1)*
-  %NullCheck128 = icmp ne %PointFlt addrspace(1)* %362, null
-  br i1 %NullCheck128, label %363, label %ThrowNullRef127
+  %NullCheck127 = icmp eq %PointFlt addrspace(1)* %362, null
+  br i1 %NullCheck127, label %ThrowNullRef128, label %363
 
 ; <label>:363                                     ; preds = %361
   %364 = getelementptr inbounds %PointFlt, %PointFlt addrspace(1)* %362, i32 0, i32 1
@@ -10867,8 +12456,8 @@ entry:
 
 ; <label>:370                                     ; preds = %363
   %371 = addrspacecast %PointFlt* %loc7 to %PointFlt addrspace(1)*
-  %NullCheck130 = icmp ne %PointFlt addrspace(1)* %371, null
-  br i1 %NullCheck130, label %372, label %ThrowNullRef129
+  %NullCheck129 = icmp eq %PointFlt addrspace(1)* %371, null
+  br i1 %NullCheck129, label %ThrowNullRef130, label %372
 
 ; <label>:372                                     ; preds = %370
   %373 = getelementptr inbounds %PointFlt, %PointFlt addrspace(1)* %371, i32 0, i32 2
@@ -10885,88 +12474,88 @@ entry:
   %380 = addrspacecast %PointDbl* %loc13 to %PointDbl addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%PointDbl addrspace(1)*, double, double, double)*)(%PointDbl addrspace(1)* %380, double 1.000000e+01, double 2.000000e+01, double 3.000000e+01)
   %381 = addrspacecast %PointDbl* %loc14 to %PointDbl addrspace(1)*
-  %NullCheck132 = icmp ne %PointDbl addrspace(1)* %381, null
-  br i1 %NullCheck132, label %382, label %ThrowNullRef131
+  %NullCheck131 = icmp eq %PointDbl addrspace(1)* %381, null
+  br i1 %NullCheck131, label %ThrowNullRef132, label %382
 
 ; <label>:382                                     ; preds = %379
   %383 = getelementptr inbounds %PointDbl, %PointDbl addrspace(1)* %381, i32 0, i32 0
   store double 0.000000e+00, double addrspace(1)* %383
   %384 = addrspacecast %PointDbl* %loc14 to %PointDbl addrspace(1)*
-  %NullCheck134 = icmp ne %PointDbl addrspace(1)* %384, null
-  br i1 %NullCheck134, label %385, label %ThrowNullRef133
+  %NullCheck133 = icmp eq %PointDbl addrspace(1)* %384, null
+  br i1 %NullCheck133, label %ThrowNullRef134, label %385
 
 ; <label>:385                                     ; preds = %382
   %386 = getelementptr inbounds %PointDbl, %PointDbl addrspace(1)* %384, i32 0, i32 1
   store double 0.000000e+00, double addrspace(1)* %386
   %387 = addrspacecast %PointDbl* %loc14 to %PointDbl addrspace(1)*
-  %NullCheck136 = icmp ne %PointDbl addrspace(1)* %387, null
-  br i1 %NullCheck136, label %388, label %ThrowNullRef135
+  %NullCheck135 = icmp eq %PointDbl addrspace(1)* %387, null
+  br i1 %NullCheck135, label %ThrowNullRef136, label %388
 
 ; <label>:388                                     ; preds = %385
   %389 = getelementptr inbounds %PointDbl, %PointDbl addrspace(1)* %387, i32 0, i32 2
   store double 0.000000e+00, double addrspace(1)* %389
   %390 = addrspacecast %PointDbl* %loc15 to %PointDbl addrspace(1)*
   %391 = addrspacecast %PointDbl* %loc13 to %PointDbl addrspace(1)*
-  %NullCheck138 = icmp ne %PointDbl addrspace(1)* %391, null
-  br i1 %NullCheck138, label %392, label %ThrowNullRef137
+  %NullCheck137 = icmp eq %PointDbl addrspace(1)* %391, null
+  br i1 %NullCheck137, label %ThrowNullRef138, label %392
 
 ; <label>:392                                     ; preds = %388
   %393 = getelementptr inbounds %PointDbl, %PointDbl addrspace(1)* %391, i32 0, i32 0
   %394 = load double, double addrspace(1)* %393, align 8
   %395 = fadd double %394, 5.000000e+00
-  %NullCheck140 = icmp ne %PointDbl addrspace(1)* %390, null
-  br i1 %NullCheck140, label %396, label %ThrowNullRef139
+  %NullCheck139 = icmp eq %PointDbl addrspace(1)* %390, null
+  br i1 %NullCheck139, label %ThrowNullRef140, label %396
 
 ; <label>:396                                     ; preds = %392
   %397 = getelementptr inbounds %PointDbl, %PointDbl addrspace(1)* %390, i32 0, i32 0
   store double %395, double addrspace(1)* %397
   %398 = addrspacecast %PointDbl* %loc15 to %PointDbl addrspace(1)*
   %399 = addrspacecast %PointDbl* %loc13 to %PointDbl addrspace(1)*
-  %NullCheck142 = icmp ne %PointDbl addrspace(1)* %399, null
-  br i1 %NullCheck142, label %400, label %ThrowNullRef141
+  %NullCheck141 = icmp eq %PointDbl addrspace(1)* %399, null
+  br i1 %NullCheck141, label %ThrowNullRef142, label %400
 
 ; <label>:400                                     ; preds = %396
   %401 = getelementptr inbounds %PointDbl, %PointDbl addrspace(1)* %399, i32 0, i32 1
   %402 = load double, double addrspace(1)* %401, align 8
   %403 = addrspacecast %PointDbl* %loc14 to %PointDbl addrspace(1)*
-  %NullCheck144 = icmp ne %PointDbl addrspace(1)* %403, null
-  br i1 %NullCheck144, label %404, label %ThrowNullRef143
+  %NullCheck143 = icmp eq %PointDbl addrspace(1)* %403, null
+  br i1 %NullCheck143, label %ThrowNullRef144, label %404
 
 ; <label>:404                                     ; preds = %400
   %405 = getelementptr inbounds %PointDbl, %PointDbl addrspace(1)* %403, i32 0, i32 1
   %406 = load double, double addrspace(1)* %405, align 8
   %407 = fadd double %402, %406
-  %NullCheck146 = icmp ne %PointDbl addrspace(1)* %398, null
-  br i1 %NullCheck146, label %408, label %ThrowNullRef145
+  %NullCheck145 = icmp eq %PointDbl addrspace(1)* %398, null
+  br i1 %NullCheck145, label %ThrowNullRef146, label %408
 
 ; <label>:408                                     ; preds = %404
   %409 = getelementptr inbounds %PointDbl, %PointDbl addrspace(1)* %398, i32 0, i32 1
   store double %407, double addrspace(1)* %409
   %410 = addrspacecast %PointDbl* %loc15 to %PointDbl addrspace(1)*
   %411 = addrspacecast %PointDbl* %loc13 to %PointDbl addrspace(1)*
-  %NullCheck148 = icmp ne %PointDbl addrspace(1)* %411, null
-  br i1 %NullCheck148, label %412, label %ThrowNullRef147
+  %NullCheck147 = icmp eq %PointDbl addrspace(1)* %411, null
+  br i1 %NullCheck147, label %ThrowNullRef148, label %412
 
 ; <label>:412                                     ; preds = %408
   %413 = getelementptr inbounds %PointDbl, %PointDbl addrspace(1)* %411, i32 0, i32 2
   %414 = load double, double addrspace(1)* %413, align 8
   %415 = addrspacecast %PointDbl* %loc14 to %PointDbl addrspace(1)*
-  %NullCheck150 = icmp ne %PointDbl addrspace(1)* %415, null
-  br i1 %NullCheck150, label %416, label %ThrowNullRef149
+  %NullCheck149 = icmp eq %PointDbl addrspace(1)* %415, null
+  br i1 %NullCheck149, label %ThrowNullRef150, label %416
 
 ; <label>:416                                     ; preds = %412
   %417 = getelementptr inbounds %PointDbl, %PointDbl addrspace(1)* %415, i32 0, i32 2
   %418 = load double, double addrspace(1)* %417, align 8
   %419 = fmul double %414, %418
-  %NullCheck152 = icmp ne %PointDbl addrspace(1)* %410, null
-  br i1 %NullCheck152, label %420, label %ThrowNullRef151
+  %NullCheck151 = icmp eq %PointDbl addrspace(1)* %410, null
+  br i1 %NullCheck151, label %ThrowNullRef152, label %420
 
 ; <label>:420                                     ; preds = %416
   %421 = getelementptr inbounds %PointDbl, %PointDbl addrspace(1)* %410, i32 0, i32 2
   store double %419, double addrspace(1)* %421
   %422 = addrspacecast %PointDbl* %loc15 to %PointDbl addrspace(1)*
-  %NullCheck154 = icmp ne %PointDbl addrspace(1)* %422, null
-  br i1 %NullCheck154, label %423, label %ThrowNullRef153
+  %NullCheck153 = icmp eq %PointDbl addrspace(1)* %422, null
+  br i1 %NullCheck153, label %ThrowNullRef154, label %423
 
 ; <label>:423                                     ; preds = %420
   %424 = getelementptr inbounds %PointDbl, %PointDbl addrspace(1)* %422, i32 0, i32 0
@@ -10978,8 +12567,8 @@ entry:
 
 ; <label>:429                                     ; preds = %423
   %430 = addrspacecast %PointDbl* %loc15 to %PointDbl addrspace(1)*
-  %NullCheck156 = icmp ne %PointDbl addrspace(1)* %430, null
-  br i1 %NullCheck156, label %431, label %ThrowNullRef155
+  %NullCheck155 = icmp eq %PointDbl addrspace(1)* %430, null
+  br i1 %NullCheck155, label %ThrowNullRef156, label %431
 
 ; <label>:431                                     ; preds = %429
   %432 = getelementptr inbounds %PointDbl, %PointDbl addrspace(1)* %430, i32 0, i32 1
@@ -10991,8 +12580,8 @@ entry:
 
 ; <label>:437                                     ; preds = %431
   %438 = addrspacecast %PointDbl* %loc15 to %PointDbl addrspace(1)*
-  %NullCheck158 = icmp ne %PointDbl addrspace(1)* %438, null
-  br i1 %NullCheck158, label %439, label %ThrowNullRef157
+  %NullCheck157 = icmp eq %PointDbl addrspace(1)* %438, null
+  br i1 %NullCheck157, label %ThrowNullRef158, label %439
 
 ; <label>:439                                     ; preds = %437
   %440 = getelementptr inbounds %PointDbl, %PointDbl addrspace(1)* %438, i32 0, i32 2
@@ -11018,15 +12607,15 @@ entry:
 
 ; <label>:452                                     ; preds = %445
   %453 = addrspacecast %PointDbl* %loc13 to %PointDbl addrspace(1)*
-  %NullCheck160 = icmp ne %PointDbl addrspace(1)* %453, null
-  br i1 %NullCheck160, label %454, label %ThrowNullRef159
+  %NullCheck159 = icmp eq %PointDbl addrspace(1)* %453, null
+  br i1 %NullCheck159, label %ThrowNullRef160, label %454
 
 ; <label>:454                                     ; preds = %452
   %455 = getelementptr inbounds %PointDbl, %PointDbl addrspace(1)* %453, i32 0, i32 0
   %456 = load double, double addrspace(1)* %455, align 8
   %457 = addrspacecast %PointDbl* %loc14 to %PointDbl addrspace(1)*
-  %NullCheck162 = icmp ne %PointDbl addrspace(1)* %457, null
-  br i1 %NullCheck162, label %458, label %ThrowNullRef161
+  %NullCheck161 = icmp eq %PointDbl addrspace(1)* %457, null
+  br i1 %NullCheck161, label %ThrowNullRef162, label %458
 
 ; <label>:458                                     ; preds = %454
   %459 = getelementptr inbounds %PointDbl, %PointDbl addrspace(1)* %457, i32 0, i32 0
@@ -11034,15 +12623,15 @@ entry:
   %461 = fadd double %456, %460
   store double %461, double* %loc16
   %462 = addrspacecast %PointDbl* %loc13 to %PointDbl addrspace(1)*
-  %NullCheck164 = icmp ne %PointDbl addrspace(1)* %462, null
-  br i1 %NullCheck164, label %463, label %ThrowNullRef163
+  %NullCheck163 = icmp eq %PointDbl addrspace(1)* %462, null
+  br i1 %NullCheck163, label %ThrowNullRef164, label %463
 
 ; <label>:463                                     ; preds = %458
   %464 = getelementptr inbounds %PointDbl, %PointDbl addrspace(1)* %462, i32 0, i32 1
   %465 = load double, double addrspace(1)* %464, align 8
   %466 = addrspacecast %PointDbl* %loc14 to %PointDbl addrspace(1)*
-  %NullCheck166 = icmp ne %PointDbl addrspace(1)* %466, null
-  br i1 %NullCheck166, label %467, label %ThrowNullRef165
+  %NullCheck165 = icmp eq %PointDbl addrspace(1)* %466, null
+  br i1 %NullCheck165, label %ThrowNullRef166, label %467
 
 ; <label>:467                                     ; preds = %463
   %468 = getelementptr inbounds %PointDbl, %PointDbl addrspace(1)* %466, i32 0, i32 1
@@ -11050,8 +12639,8 @@ entry:
   %470 = fmul double %465, %469
   store double %470, double* %loc17
   %471 = addrspacecast %PointDbl* %loc13 to %PointDbl addrspace(1)*
-  %NullCheck168 = icmp ne %PointDbl addrspace(1)* %471, null
-  br i1 %NullCheck168, label %472, label %ThrowNullRef167
+  %NullCheck167 = icmp eq %PointDbl addrspace(1)* %471, null
+  br i1 %NullCheck167, label %ThrowNullRef168, label %472
 
 ; <label>:472                                     ; preds = %467
   %473 = getelementptr inbounds %PointDbl, %PointDbl addrspace(1)* %471, i32 0, i32 2
@@ -11059,8 +12648,8 @@ entry:
   store double %474, double* %loc18
   %475 = load double, double* %loc16
   %476 = addrspacecast %PointDbl* %loc13 to %PointDbl addrspace(1)*
-  %NullCheck170 = icmp ne %PointDbl addrspace(1)* %476, null
-  br i1 %NullCheck170, label %477, label %ThrowNullRef169
+  %NullCheck169 = icmp eq %PointDbl addrspace(1)* %476, null
+  br i1 %NullCheck169, label %ThrowNullRef170, label %477
 
 ; <label>:477                                     ; preds = %472
   %478 = getelementptr inbounds %PointDbl, %PointDbl addrspace(1)* %476, i32 0, i32 0
@@ -11073,8 +12662,8 @@ entry:
 ; <label>:483                                     ; preds = %477
   %484 = load double, double* %loc17
   %485 = addrspacecast %PointDbl* %loc14 to %PointDbl addrspace(1)*
-  %NullCheck172 = icmp ne %PointDbl addrspace(1)* %485, null
-  br i1 %NullCheck172, label %486, label %ThrowNullRef171
+  %NullCheck171 = icmp eq %PointDbl addrspace(1)* %485, null
+  br i1 %NullCheck171, label %ThrowNullRef172, label %486
 
 ; <label>:486                                     ; preds = %483
   %487 = getelementptr inbounds %PointDbl, %PointDbl addrspace(1)* %485, i32 0, i32 1
@@ -11101,8 +12690,8 @@ entry:
 ; <label>:499                                     ; preds = %492
   %500 = load double, double* %loc16
   %501 = addrspacecast %PointDbl* %loc13 to %PointDbl addrspace(1)*
-  %NullCheck174 = icmp ne %PointDbl addrspace(1)* %501, null
-  br i1 %NullCheck174, label %502, label %ThrowNullRef173
+  %NullCheck173 = icmp eq %PointDbl addrspace(1)* %501, null
+  br i1 %NullCheck173, label %ThrowNullRef174, label %502
 
 ; <label>:502                                     ; preds = %499
   %503 = getelementptr inbounds %PointDbl, %PointDbl addrspace(1)* %501, i32 0, i32 0
@@ -11121,8 +12710,8 @@ entry:
 ; <label>:511                                     ; preds = %502
   %512 = load double, double* %loc17
   %513 = addrspacecast %PointDbl* %loc13 to %PointDbl addrspace(1)*
-  %NullCheck176 = icmp ne %PointDbl addrspace(1)* %513, null
-  br i1 %NullCheck176, label %514, label %ThrowNullRef175
+  %NullCheck175 = icmp eq %PointDbl addrspace(1)* %513, null
+  br i1 %NullCheck175, label %ThrowNullRef176, label %514
 
 ; <label>:514                                     ; preds = %511
   %515 = getelementptr inbounds %PointDbl, %PointDbl addrspace(1)* %513, i32 0, i32 1
@@ -11141,8 +12730,8 @@ entry:
 ; <label>:523                                     ; preds = %514
   %524 = load double, double* %loc18
   %525 = addrspacecast %PointDbl* %loc13 to %PointDbl addrspace(1)*
-  %NullCheck178 = icmp ne %PointDbl addrspace(1)* %525, null
-  br i1 %NullCheck178, label %526, label %ThrowNullRef177
+  %NullCheck177 = icmp eq %PointDbl addrspace(1)* %525, null
+  br i1 %NullCheck177, label %ThrowNullRef178, label %526
 
 ; <label>:526                                     ; preds = %523
   %527 = getelementptr inbounds %PointDbl, %PointDbl addrspace(1)* %525, i32 0, i32 0
@@ -11150,50 +12739,50 @@ entry:
   %529 = fdiv double %524, %528
   store double %529, double* %loc18
   %530 = addrspacecast %PointDbl* %loc13 to %PointDbl addrspace(1)*
-  %NullCheck180 = icmp ne %PointDbl addrspace(1)* %530, null
-  br i1 %NullCheck180, label %531, label %ThrowNullRef179
+  %NullCheck179 = icmp eq %PointDbl addrspace(1)* %530, null
+  br i1 %NullCheck179, label %ThrowNullRef180, label %531
 
 ; <label>:531                                     ; preds = %526
   %532 = getelementptr inbounds %PointDbl, %PointDbl addrspace(1)* %530, i32 0, i32 0
   %533 = load double, double addrspace(1)* %532, align 8
   %534 = fadd double %533, 1.000000e+01
-  %NullCheck182 = icmp ne %PointDbl addrspace(1)* %530, null
-  br i1 %NullCheck182, label %535, label %ThrowNullRef181
+  %NullCheck181 = icmp eq %PointDbl addrspace(1)* %530, null
+  br i1 %NullCheck181, label %ThrowNullRef182, label %535
 
 ; <label>:535                                     ; preds = %531
   %536 = getelementptr inbounds %PointDbl, %PointDbl addrspace(1)* %530, i32 0, i32 0
   store double %534, double addrspace(1)* %536
   %537 = addrspacecast %PointDbl* %loc13 to %PointDbl addrspace(1)*
-  %NullCheck184 = icmp ne %PointDbl addrspace(1)* %537, null
-  br i1 %NullCheck184, label %538, label %ThrowNullRef183
+  %NullCheck183 = icmp eq %PointDbl addrspace(1)* %537, null
+  br i1 %NullCheck183, label %ThrowNullRef184, label %538
 
 ; <label>:538                                     ; preds = %535
   %539 = getelementptr inbounds %PointDbl, %PointDbl addrspace(1)* %537, i32 0, i32 1
   %540 = load double, double addrspace(1)* %539, align 8
   %541 = fmul double %540, 3.000000e+00
-  %NullCheck186 = icmp ne %PointDbl addrspace(1)* %537, null
-  br i1 %NullCheck186, label %542, label %ThrowNullRef185
+  %NullCheck185 = icmp eq %PointDbl addrspace(1)* %537, null
+  br i1 %NullCheck185, label %ThrowNullRef186, label %542
 
 ; <label>:542                                     ; preds = %538
   %543 = getelementptr inbounds %PointDbl, %PointDbl addrspace(1)* %537, i32 0, i32 1
   store double %541, double addrspace(1)* %543
   %544 = addrspacecast %PointDbl* %loc13 to %PointDbl addrspace(1)*
-  %NullCheck188 = icmp ne %PointDbl addrspace(1)* %544, null
-  br i1 %NullCheck188, label %545, label %ThrowNullRef187
+  %NullCheck187 = icmp eq %PointDbl addrspace(1)* %544, null
+  br i1 %NullCheck187, label %ThrowNullRef188, label %545
 
 ; <label>:545                                     ; preds = %542
   %546 = getelementptr inbounds %PointDbl, %PointDbl addrspace(1)* %544, i32 0, i32 2
   %547 = load double, double addrspace(1)* %546, align 8
   %548 = fdiv double %547, 5.000000e+00
-  %NullCheck190 = icmp ne %PointDbl addrspace(1)* %544, null
-  br i1 %NullCheck190, label %549, label %ThrowNullRef189
+  %NullCheck189 = icmp eq %PointDbl addrspace(1)* %544, null
+  br i1 %NullCheck189, label %ThrowNullRef190, label %549
 
 ; <label>:549                                     ; preds = %545
   %550 = getelementptr inbounds %PointDbl, %PointDbl addrspace(1)* %544, i32 0, i32 2
   store double %548, double addrspace(1)* %550
   %551 = addrspacecast %PointDbl* %loc13 to %PointDbl addrspace(1)*
-  %NullCheck192 = icmp ne %PointDbl addrspace(1)* %551, null
-  br i1 %NullCheck192, label %552, label %ThrowNullRef191
+  %NullCheck191 = icmp eq %PointDbl addrspace(1)* %551, null
+  br i1 %NullCheck191, label %ThrowNullRef192, label %552
 
 ; <label>:552                                     ; preds = %549
   %553 = getelementptr inbounds %PointDbl, %PointDbl addrspace(1)* %551, i32 0, i32 0
@@ -11208,8 +12797,8 @@ entry:
 
 ; <label>:559                                     ; preds = %552
   %560 = addrspacecast %PointDbl* %loc13 to %PointDbl addrspace(1)*
-  %NullCheck194 = icmp ne %PointDbl addrspace(1)* %560, null
-  br i1 %NullCheck194, label %561, label %ThrowNullRef193
+  %NullCheck193 = icmp eq %PointDbl addrspace(1)* %560, null
+  br i1 %NullCheck193, label %ThrowNullRef194, label %561
 
 ; <label>:561                                     ; preds = %559
   %562 = getelementptr inbounds %PointDbl, %PointDbl addrspace(1)* %560, i32 0, i32 1
@@ -11224,8 +12813,8 @@ entry:
 
 ; <label>:568                                     ; preds = %561
   %569 = addrspacecast %PointDbl* %loc13 to %PointDbl addrspace(1)*
-  %NullCheck196 = icmp ne %PointDbl addrspace(1)* %569, null
-  br i1 %NullCheck196, label %570, label %ThrowNullRef195
+  %NullCheck195 = icmp eq %PointDbl addrspace(1)* %569, null
+  br i1 %NullCheck195, label %ThrowNullRef196, label %570
 
 ; <label>:570                                     ; preds = %568
   %571 = getelementptr inbounds %PointDbl, %PointDbl addrspace(1)* %569, i32 0, i32 2
@@ -11245,395 +12834,395 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %8
+ThrowNullRef6:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %12
+ThrowNullRef8:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %16
+ThrowNullRef10:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %20
+ThrowNullRef12:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %24
+ThrowNullRef14:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %28
+ThrowNullRef16:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %32
+ThrowNullRef18:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %36
+ThrowNullRef20:                                   ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %40
+ThrowNullRef22:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %47
+ThrowNullRef24:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %53
+ThrowNullRef26:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %68
+ThrowNullRef28:                                   ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %70
+ThrowNullRef30:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %74
+ThrowNullRef32:                                   ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %79
+ThrowNullRef34:                                   ; preds = %79
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %83
+ThrowNullRef36:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %88
+ThrowNullRef38:                                   ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %97
+ThrowNullRef40:                                   ; preds = %97
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %113
+ThrowNullRef42:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %123
+ThrowNullRef44:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %133
+ThrowNullRef46:                                   ; preds = %133
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %136
+ThrowNullRef48:                                   ; preds = %136
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %141
+ThrowNullRef50:                                   ; preds = %141
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %145
+ThrowNullRef52:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %148
+ThrowNullRef54:                                   ; preds = %148
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %152
+ThrowNullRef56:                                   ; preds = %152
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %155
+ThrowNullRef58:                                   ; preds = %155
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %159
+ThrowNullRef60:                                   ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %167
+ThrowNullRef62:                                   ; preds = %167
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %174
+ThrowNullRef64:                                   ; preds = %174
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %181
+ThrowNullRef66:                                   ; preds = %181
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %184
+ThrowNullRef68:                                   ; preds = %184
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %187
+ThrowNullRef70:                                   ; preds = %187
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %190
+ThrowNullRef72:                                   ; preds = %190
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %194
+ThrowNullRef74:                                   ; preds = %194
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %198
+ThrowNullRef76:                                   ; preds = %198
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %202
+ThrowNullRef78:                                   ; preds = %202
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %206
+ThrowNullRef80:                                   ; preds = %206
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %210
+ThrowNullRef82:                                   ; preds = %210
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %214
+ThrowNullRef84:                                   ; preds = %214
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %218
+ThrowNullRef86:                                   ; preds = %218
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %222
+ThrowNullRef88:                                   ; preds = %222
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %231
+ThrowNullRef90:                                   ; preds = %231
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %239
+ThrowNullRef92:                                   ; preds = %239
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %254
+ThrowNullRef94:                                   ; preds = %254
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %256
+ThrowNullRef96:                                   ; preds = %256
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %260
+ThrowNullRef98:                                   ; preds = %260
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %265
+ThrowNullRef100:                                  ; preds = %265
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef101:                                  ; preds = %269
+ThrowNullRef102:                                  ; preds = %269
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef103:                                  ; preds = %274
+ThrowNullRef104:                                  ; preds = %274
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef105:                                  ; preds = %285
+ThrowNullRef106:                                  ; preds = %285
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef107:                                  ; preds = %301
+ThrowNullRef108:                                  ; preds = %301
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef109:                                  ; preds = %313
+ThrowNullRef110:                                  ; preds = %313
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef111:                                  ; preds = %325
+ThrowNullRef112:                                  ; preds = %325
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef113:                                  ; preds = %328
+ThrowNullRef114:                                  ; preds = %328
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef115:                                  ; preds = %333
+ThrowNullRef116:                                  ; preds = %333
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef117:                                  ; preds = %337
+ThrowNullRef118:                                  ; preds = %337
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef119:                                  ; preds = %340
+ThrowNullRef120:                                  ; preds = %340
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef121:                                  ; preds = %344
+ThrowNullRef122:                                  ; preds = %344
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef123:                                  ; preds = %347
+ThrowNullRef124:                                  ; preds = %347
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef125:                                  ; preds = %351
+ThrowNullRef126:                                  ; preds = %351
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef127:                                  ; preds = %361
+ThrowNullRef128:                                  ; preds = %361
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef129:                                  ; preds = %370
+ThrowNullRef130:                                  ; preds = %370
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef131:                                  ; preds = %379
+ThrowNullRef132:                                  ; preds = %379
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef133:                                  ; preds = %382
+ThrowNullRef134:                                  ; preds = %382
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef135:                                  ; preds = %385
+ThrowNullRef136:                                  ; preds = %385
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef137:                                  ; preds = %388
+ThrowNullRef138:                                  ; preds = %388
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef139:                                  ; preds = %392
+ThrowNullRef140:                                  ; preds = %392
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef141:                                  ; preds = %396
+ThrowNullRef142:                                  ; preds = %396
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef143:                                  ; preds = %400
+ThrowNullRef144:                                  ; preds = %400
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef145:                                  ; preds = %404
+ThrowNullRef146:                                  ; preds = %404
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef147:                                  ; preds = %408
+ThrowNullRef148:                                  ; preds = %408
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef149:                                  ; preds = %412
+ThrowNullRef150:                                  ; preds = %412
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef151:                                  ; preds = %416
+ThrowNullRef152:                                  ; preds = %416
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef153:                                  ; preds = %420
+ThrowNullRef154:                                  ; preds = %420
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef155:                                  ; preds = %429
+ThrowNullRef156:                                  ; preds = %429
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef157:                                  ; preds = %437
+ThrowNullRef158:                                  ; preds = %437
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef159:                                  ; preds = %452
+ThrowNullRef160:                                  ; preds = %452
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef161:                                  ; preds = %454
+ThrowNullRef162:                                  ; preds = %454
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef163:                                  ; preds = %458
+ThrowNullRef164:                                  ; preds = %458
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef165:                                  ; preds = %463
+ThrowNullRef166:                                  ; preds = %463
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef167:                                  ; preds = %467
+ThrowNullRef168:                                  ; preds = %467
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef169:                                  ; preds = %472
+ThrowNullRef170:                                  ; preds = %472
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef171:                                  ; preds = %483
+ThrowNullRef172:                                  ; preds = %483
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef173:                                  ; preds = %499
+ThrowNullRef174:                                  ; preds = %499
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef175:                                  ; preds = %511
+ThrowNullRef176:                                  ; preds = %511
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef177:                                  ; preds = %523
+ThrowNullRef178:                                  ; preds = %523
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef179:                                  ; preds = %526
+ThrowNullRef180:                                  ; preds = %526
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef181:                                  ; preds = %531
+ThrowNullRef182:                                  ; preds = %531
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef183:                                  ; preds = %535
+ThrowNullRef184:                                  ; preds = %535
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef185:                                  ; preds = %538
+ThrowNullRef186:                                  ; preds = %538
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef187:                                  ; preds = %542
+ThrowNullRef188:                                  ; preds = %542
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef189:                                  ; preds = %545
+ThrowNullRef190:                                  ; preds = %545
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef191:                                  ; preds = %549
+ThrowNullRef192:                                  ; preds = %549
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef193:                                  ; preds = %559
+ThrowNullRef194:                                  ; preds = %559
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef195:                                  ; preds = %568
+ThrowNullRef196:                                  ; preds = %568
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11653,24 +13242,24 @@ entry:
   store i32 %param3, i32* %arg3
   %0 = load %Point addrspace(1)*, %Point addrspace(1)** %this
   %1 = load i32, i32* %arg1
-  %NullCheck = icmp ne %Point addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %Point addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %Point, %Point addrspace(1)* %0, i32 0, i32 0
   store i32 %1, i32 addrspace(1)* %3
   %4 = load %Point addrspace(1)*, %Point addrspace(1)** %this
   %5 = load i32, i32* %arg2
-  %NullCheck2 = icmp ne %Point addrspace(1)* %4, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %Point addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
   %7 = getelementptr inbounds %Point, %Point addrspace(1)* %4, i32 0, i32 1
   store i32 %5, i32 addrspace(1)* %7
   %8 = load %Point addrspace(1)*, %Point addrspace(1)** %this
   %9 = load i32, i32* %arg3
-  %NullCheck4 = icmp ne %Point addrspace(1)* %8, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %Point addrspace(1)* %8, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %6
   %11 = getelementptr inbounds %Point, %Point addrspace(1)* %8, i32 0, i32 2
@@ -11681,11 +13270,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %6
+ThrowNullRef4:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11705,24 +13294,24 @@ entry:
   store float %param3, float* %arg3
   %0 = load %PointFlt addrspace(1)*, %PointFlt addrspace(1)** %this
   %1 = load float, float* %arg1
-  %NullCheck = icmp ne %PointFlt addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %PointFlt addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %PointFlt, %PointFlt addrspace(1)* %0, i32 0, i32 0
   store float %1, float addrspace(1)* %3
   %4 = load %PointFlt addrspace(1)*, %PointFlt addrspace(1)** %this
   %5 = load float, float* %arg2
-  %NullCheck2 = icmp ne %PointFlt addrspace(1)* %4, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %PointFlt addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
   %7 = getelementptr inbounds %PointFlt, %PointFlt addrspace(1)* %4, i32 0, i32 1
   store float %5, float addrspace(1)* %7
   %8 = load %PointFlt addrspace(1)*, %PointFlt addrspace(1)** %this
   %9 = load float, float* %arg3
-  %NullCheck4 = icmp ne %PointFlt addrspace(1)* %8, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %PointFlt addrspace(1)* %8, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %6
   %11 = getelementptr inbounds %PointFlt, %PointFlt addrspace(1)* %8, i32 0, i32 2
@@ -11733,11 +13322,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %6
+ThrowNullRef4:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11759,24 +13348,24 @@ entry:
   store double %param3, double* %arg3
   %0 = load %PointDbl addrspace(1)*, %PointDbl addrspace(1)** %this
   %1 = load double, double* %arg1
-  %NullCheck = icmp ne %PointDbl addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %PointDbl addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %PointDbl, %PointDbl addrspace(1)* %0, i32 0, i32 0
   store double %1, double addrspace(1)* %3
   %4 = load %PointDbl addrspace(1)*, %PointDbl addrspace(1)** %this
   %5 = load double, double* %arg2
-  %NullCheck2 = icmp ne %PointDbl addrspace(1)* %4, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %PointDbl addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
   %7 = getelementptr inbounds %PointDbl, %PointDbl addrspace(1)* %4, i32 0, i32 1
   store double %5, double addrspace(1)* %7
   %8 = load %PointDbl addrspace(1)*, %PointDbl addrspace(1)** %this
   %9 = load double, double* %arg3
-  %NullCheck4 = icmp ne %PointDbl addrspace(1)* %8, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %PointDbl addrspace(1)* %8, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %6
   %11 = getelementptr inbounds %PointDbl, %PointDbl addrspace(1)* %8, i32 0, i32 2
@@ -11787,11 +13376,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %6
+ThrowNullRef4:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Or1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Or1.error.txt
@@ -25,8 +25,8 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
@@ -40,8 +40,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
   %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
@@ -75,7 +75,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -90,8 +90,8 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %NullCheck = icmp ne i8 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = load i8, i8 addrspace(1)* %0, align 8
@@ -125,8 +125,8 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
@@ -159,8 +159,8 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -184,8 +184,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
   store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
@@ -195,8 +195,8 @@ entry:
 ; <label>:4                                       ; preds = %1
   %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
   %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
@@ -206,8 +206,8 @@ entry:
   %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
@@ -221,14 +221,14 @@ entry:
 
 ; <label>:17                                      ; preds = %14
   %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
   %21 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
@@ -238,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -249,8 +249,8 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
@@ -261,27 +261,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %30
+ThrowNullRef10:                                   ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -301,7 +301,89 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
-Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
+Successfully read AppDomainSetup.GetUnsecureApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.GetUnsecureApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %NullCheck = icmp eq %"System.String[]" addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %BoundsCheck = icmp uge i64 0, %5
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %6
+
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 3, i32 0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
+  ret %System.String addrspace(1)* %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_Value using LLILCJit
+Successfully read AppDomainSetup.get_Value
+
+define %"System.String[]" addrspace(1)* @AppDomainSetup.get_Value(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.String[]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 18)
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.String[]" addrspace(1)* addrspace(1)*, %"System.String[]" addrspace(1)*)*)(%"System.String[]" addrspace(1)* addrspace(1)* %9, %"System.String[]" addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %11, i32 0, i32 1
+  %14 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %13, align 8
+  ret %"System.String[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -319,8 +401,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -368,16 +450,16 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
   %5 = load i32, i32 addrspace(1)* %4
   %6 = sub i32 %5, 1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -389,7 +471,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -421,8 +503,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
@@ -456,8 +538,8 @@ entry:
 ; <label>:27                                      ; preds = %19
   %28 = load i32, i32* %arg1
   %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
-  br i1 %NullCheck2, label %30, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %29, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %30
 
 ; <label>:30                                      ; preds = %27
   %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
@@ -493,8 +575,8 @@ entry:
 ; <label>:49                                      ; preds = %46
   %50 = load i32, i32* %arg2
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck4, label %52, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
@@ -517,11 +599,11 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %27
+ThrowNullRef2:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %49
+ThrowNullRef4:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -544,16 +626,16 @@ entry:
   %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %0)
   store %System.String addrspace(1)* %1, %System.String addrspace(1)** %loc0
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 2
   %5 = bitcast [0 x i16] addrspace(1)* %4 to i16 addrspace(1)*
   store i16 addrspace(1)* %5, i16 addrspace(1)** %loc1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %3
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2
@@ -580,7 +662,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -691,15 +773,15 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %NullCheck132 = icmp ne i8* %21, null
-  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+  %NullCheck131 = icmp eq i8* %21, null
+  br i1 %NullCheck131, label %ThrowNullRef132, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = load i8, i8* %21, align 8
   %24 = zext i8 %23 to i32
   %25 = trunc i32 %24 to i8
-  %NullCheck134 = icmp ne i8* %20, null
-  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+  %NullCheck133 = icmp eq i8* %20, null
+  br i1 %NullCheck133, label %ThrowNullRef134, label %26
 
 ; <label>:26                                      ; preds = %22
   store i8 %25, i8* %20, align 8
@@ -709,16 +791,16 @@ entry:
   %28 = load i8*, i8** %arg0
   %29 = load i8*, i8** %arg1
   %30 = bitcast i8* %29 to i16*
-  %NullCheck128 = icmp ne i16* %30, null
-  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+  %NullCheck127 = icmp eq i16* %30, null
+  br i1 %NullCheck127, label %ThrowNullRef128, label %31
 
 ; <label>:31                                      ; preds = %27
   %32 = load i16, i16* %30, align 8
   %33 = sext i16 %32 to i32
   %34 = bitcast i8* %28 to i16*
   %35 = trunc i32 %33 to i16
-  %NullCheck130 = icmp ne i16* %34, null
-  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+  %NullCheck129 = icmp eq i16* %34, null
+  br i1 %NullCheck129, label %ThrowNullRef130, label %36
 
 ; <label>:36                                      ; preds = %31
   store i16 %35, i16* %34, align 8
@@ -728,16 +810,16 @@ entry:
   %38 = load i8*, i8** %arg0
   %39 = load i8*, i8** %arg1
   %40 = bitcast i8* %39 to i16*
-  %NullCheck120 = icmp ne i16* %40, null
-  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+  %NullCheck119 = icmp eq i16* %40, null
+  br i1 %NullCheck119, label %ThrowNullRef120, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i16, i16* %40, align 8
   %43 = sext i16 %42 to i32
   %44 = bitcast i8* %38 to i16*
   %45 = trunc i32 %43 to i16
-  %NullCheck122 = icmp ne i16* %44, null
-  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+  %NullCheck121 = icmp eq i16* %44, null
+  br i1 %NullCheck121, label %ThrowNullRef122, label %46
 
 ; <label>:46                                      ; preds = %41
   store i16 %45, i16* %44, align 8
@@ -745,15 +827,15 @@ entry:
   %48 = getelementptr inbounds i8, i8* %47, i64 2
   %49 = load i8*, i8** %arg1
   %50 = getelementptr inbounds i8, i8* %49, i64 2
-  %NullCheck124 = icmp ne i8* %50, null
-  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+  %NullCheck123 = icmp eq i8* %50, null
+  br i1 %NullCheck123, label %ThrowNullRef124, label %51
 
 ; <label>:51                                      ; preds = %46
   %52 = load i8, i8* %50, align 8
   %53 = zext i8 %52 to i32
   %54 = trunc i32 %53 to i8
-  %NullCheck126 = icmp ne i8* %48, null
-  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+  %NullCheck125 = icmp eq i8* %48, null
+  br i1 %NullCheck125, label %ThrowNullRef126, label %55
 
 ; <label>:55                                      ; preds = %51
   store i8 %54, i8* %48, align 8
@@ -763,14 +845,14 @@ entry:
   %57 = load i8*, i8** %arg0
   %58 = load i8*, i8** %arg1
   %59 = bitcast i8* %58 to i32*
-  %NullCheck116 = icmp ne i32* %59, null
-  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+  %NullCheck115 = icmp eq i32* %59, null
+  br i1 %NullCheck115, label %ThrowNullRef116, label %60
 
 ; <label>:60                                      ; preds = %56
   %61 = load i32, i32* %59, align 8
   %62 = bitcast i8* %57 to i32*
-  %NullCheck118 = icmp ne i32* %62, null
-  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+  %NullCheck117 = icmp eq i32* %62, null
+  br i1 %NullCheck117, label %ThrowNullRef118, label %63
 
 ; <label>:63                                      ; preds = %60
   store i32 %61, i32* %62, align 8
@@ -780,14 +862,14 @@ entry:
   %65 = load i8*, i8** %arg0
   %66 = load i8*, i8** %arg1
   %67 = bitcast i8* %66 to i32*
-  %NullCheck108 = icmp ne i32* %67, null
-  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+  %NullCheck107 = icmp eq i32* %67, null
+  br i1 %NullCheck107, label %ThrowNullRef108, label %68
 
 ; <label>:68                                      ; preds = %64
   %69 = load i32, i32* %67, align 8
   %70 = bitcast i8* %65 to i32*
-  %NullCheck110 = icmp ne i32* %70, null
-  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+  %NullCheck109 = icmp eq i32* %70, null
+  br i1 %NullCheck109, label %ThrowNullRef110, label %71
 
 ; <label>:71                                      ; preds = %68
   store i32 %69, i32* %70, align 8
@@ -795,15 +877,15 @@ entry:
   %73 = getelementptr inbounds i8, i8* %72, i64 4
   %74 = load i8*, i8** %arg1
   %75 = getelementptr inbounds i8, i8* %74, i64 4
-  %NullCheck112 = icmp ne i8* %75, null
-  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+  %NullCheck111 = icmp eq i8* %75, null
+  br i1 %NullCheck111, label %ThrowNullRef112, label %76
 
 ; <label>:76                                      ; preds = %71
   %77 = load i8, i8* %75, align 8
   %78 = zext i8 %77 to i32
   %79 = trunc i32 %78 to i8
-  %NullCheck114 = icmp ne i8* %73, null
-  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+  %NullCheck113 = icmp eq i8* %73, null
+  br i1 %NullCheck113, label %ThrowNullRef114, label %80
 
 ; <label>:80                                      ; preds = %76
   store i8 %79, i8* %73, align 8
@@ -813,14 +895,14 @@ entry:
   %82 = load i8*, i8** %arg0
   %83 = load i8*, i8** %arg1
   %84 = bitcast i8* %83 to i32*
-  %NullCheck100 = icmp ne i32* %84, null
-  br i1 %NullCheck100, label %85, label %ThrowNullRef99
+  %NullCheck99 = icmp eq i32* %84, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %85
 
 ; <label>:85                                      ; preds = %81
   %86 = load i32, i32* %84, align 8
   %87 = bitcast i8* %82 to i32*
-  %NullCheck102 = icmp ne i32* %87, null
-  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+  %NullCheck101 = icmp eq i32* %87, null
+  br i1 %NullCheck101, label %ThrowNullRef102, label %88
 
 ; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
@@ -829,16 +911,16 @@ entry:
   %91 = load i8*, i8** %arg1
   %92 = getelementptr inbounds i8, i8* %91, i64 4
   %93 = bitcast i8* %92 to i16*
-  %NullCheck104 = icmp ne i16* %93, null
-  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+  %NullCheck103 = icmp eq i16* %93, null
+  br i1 %NullCheck103, label %ThrowNullRef104, label %94
 
 ; <label>:94                                      ; preds = %88
   %95 = load i16, i16* %93, align 8
   %96 = sext i16 %95 to i32
   %97 = bitcast i8* %90 to i16*
   %98 = trunc i32 %96 to i16
-  %NullCheck106 = icmp ne i16* %97, null
-  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+  %NullCheck105 = icmp eq i16* %97, null
+  br i1 %NullCheck105, label %ThrowNullRef106, label %99
 
 ; <label>:99                                      ; preds = %94
   store i16 %98, i16* %97, align 8
@@ -848,14 +930,14 @@ entry:
   %101 = load i8*, i8** %arg0
   %102 = load i8*, i8** %arg1
   %103 = bitcast i8* %102 to i32*
-  %NullCheck88 = icmp ne i32* %103, null
-  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+  %NullCheck87 = icmp eq i32* %103, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %104
 
 ; <label>:104                                     ; preds = %100
   %105 = load i32, i32* %103, align 8
   %106 = bitcast i8* %101 to i32*
-  %NullCheck90 = icmp ne i32* %106, null
-  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+  %NullCheck89 = icmp eq i32* %106, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %107
 
 ; <label>:107                                     ; preds = %104
   store i32 %105, i32* %106, align 8
@@ -864,16 +946,16 @@ entry:
   %110 = load i8*, i8** %arg1
   %111 = getelementptr inbounds i8, i8* %110, i64 4
   %112 = bitcast i8* %111 to i16*
-  %NullCheck92 = icmp ne i16* %112, null
-  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+  %NullCheck91 = icmp eq i16* %112, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %113
 
 ; <label>:113                                     ; preds = %107
   %114 = load i16, i16* %112, align 8
   %115 = sext i16 %114 to i32
   %116 = bitcast i8* %109 to i16*
   %117 = trunc i32 %115 to i16
-  %NullCheck94 = icmp ne i16* %116, null
-  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+  %NullCheck93 = icmp eq i16* %116, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %118
 
 ; <label>:118                                     ; preds = %113
   store i16 %117, i16* %116, align 8
@@ -881,15 +963,15 @@ entry:
   %120 = getelementptr inbounds i8, i8* %119, i64 6
   %121 = load i8*, i8** %arg1
   %122 = getelementptr inbounds i8, i8* %121, i64 6
-  %NullCheck96 = icmp ne i8* %122, null
-  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+  %NullCheck95 = icmp eq i8* %122, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %123
 
 ; <label>:123                                     ; preds = %118
   %124 = load i8, i8* %122, align 8
   %125 = zext i8 %124 to i32
   %126 = trunc i32 %125 to i8
-  %NullCheck98 = icmp ne i8* %120, null
-  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+  %NullCheck97 = icmp eq i8* %120, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %127
 
 ; <label>:127                                     ; preds = %123
   store i8 %126, i8* %120, align 8
@@ -899,14 +981,14 @@ entry:
   %129 = load i8*, i8** %arg0
   %130 = load i8*, i8** %arg1
   %131 = bitcast i8* %130 to i64*
-  %NullCheck84 = icmp ne i64* %131, null
-  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+  %NullCheck83 = icmp eq i64* %131, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %132
 
 ; <label>:132                                     ; preds = %128
   %133 = load i64, i64* %131, align 8
   %134 = bitcast i8* %129 to i64*
-  %NullCheck86 = icmp ne i64* %134, null
-  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+  %NullCheck85 = icmp eq i64* %134, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %135
 
 ; <label>:135                                     ; preds = %132
   store i64 %133, i64* %134, align 8
@@ -916,14 +998,14 @@ entry:
   %137 = load i8*, i8** %arg0
   %138 = load i8*, i8** %arg1
   %139 = bitcast i8* %138 to i64*
-  %NullCheck76 = icmp ne i64* %139, null
-  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+  %NullCheck75 = icmp eq i64* %139, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %140
 
 ; <label>:140                                     ; preds = %136
   %141 = load i64, i64* %139, align 8
   %142 = bitcast i8* %137 to i64*
-  %NullCheck78 = icmp ne i64* %142, null
-  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+  %NullCheck77 = icmp eq i64* %142, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %143
 
 ; <label>:143                                     ; preds = %140
   store i64 %141, i64* %142, align 8
@@ -931,15 +1013,15 @@ entry:
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %NullCheck80 = icmp ne i8* %147, null
-  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+  %NullCheck79 = icmp eq i8* %147, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %148
 
 ; <label>:148                                     ; preds = %143
   %149 = load i8, i8* %147, align 8
   %150 = zext i8 %149 to i32
   %151 = trunc i32 %150 to i8
-  %NullCheck82 = icmp ne i8* %145, null
-  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+  %NullCheck81 = icmp eq i8* %145, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %152
 
 ; <label>:152                                     ; preds = %148
   store i8 %151, i8* %145, align 8
@@ -949,14 +1031,14 @@ entry:
   %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
   %156 = bitcast i8* %155 to i64*
-  %NullCheck68 = icmp ne i64* %156, null
-  br i1 %NullCheck68, label %157, label %ThrowNullRef67
+  %NullCheck67 = icmp eq i64* %156, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %157
 
 ; <label>:157                                     ; preds = %153
   %158 = load i64, i64* %156, align 8
   %159 = bitcast i8* %154 to i64*
-  %NullCheck70 = icmp ne i64* %159, null
-  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+  %NullCheck69 = icmp eq i64* %159, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %160
 
 ; <label>:160                                     ; preds = %157
   store i64 %158, i64* %159, align 8
@@ -965,16 +1047,16 @@ entry:
   %163 = load i8*, i8** %arg1
   %164 = getelementptr inbounds i8, i8* %163, i64 8
   %165 = bitcast i8* %164 to i16*
-  %NullCheck72 = icmp ne i16* %165, null
-  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+  %NullCheck71 = icmp eq i16* %165, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %166
 
 ; <label>:166                                     ; preds = %160
   %167 = load i16, i16* %165, align 8
   %168 = sext i16 %167 to i32
   %169 = bitcast i8* %162 to i16*
   %170 = trunc i32 %168 to i16
-  %NullCheck74 = icmp ne i16* %169, null
-  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+  %NullCheck73 = icmp eq i16* %169, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %171
 
 ; <label>:171                                     ; preds = %166
   store i16 %170, i16* %169, align 8
@@ -984,14 +1066,14 @@ entry:
   %173 = load i8*, i8** %arg0
   %174 = load i8*, i8** %arg1
   %175 = bitcast i8* %174 to i64*
-  %NullCheck56 = icmp ne i64* %175, null
-  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+  %NullCheck55 = icmp eq i64* %175, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %176
 
 ; <label>:176                                     ; preds = %172
   %177 = load i64, i64* %175, align 8
   %178 = bitcast i8* %173 to i64*
-  %NullCheck58 = icmp ne i64* %178, null
-  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+  %NullCheck57 = icmp eq i64* %178, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %179
 
 ; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
@@ -1000,16 +1082,16 @@ entry:
   %182 = load i8*, i8** %arg1
   %183 = getelementptr inbounds i8, i8* %182, i64 8
   %184 = bitcast i8* %183 to i16*
-  %NullCheck60 = icmp ne i16* %184, null
-  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+  %NullCheck59 = icmp eq i16* %184, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %185
 
 ; <label>:185                                     ; preds = %179
   %186 = load i16, i16* %184, align 8
   %187 = sext i16 %186 to i32
   %188 = bitcast i8* %181 to i16*
   %189 = trunc i32 %187 to i16
-  %NullCheck62 = icmp ne i16* %188, null
-  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+  %NullCheck61 = icmp eq i16* %188, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %190
 
 ; <label>:190                                     ; preds = %185
   store i16 %189, i16* %188, align 8
@@ -1017,15 +1099,15 @@ entry:
   %192 = getelementptr inbounds i8, i8* %191, i64 10
   %193 = load i8*, i8** %arg1
   %194 = getelementptr inbounds i8, i8* %193, i64 10
-  %NullCheck64 = icmp ne i8* %194, null
-  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+  %NullCheck63 = icmp eq i8* %194, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %195
 
 ; <label>:195                                     ; preds = %190
   %196 = load i8, i8* %194, align 8
   %197 = zext i8 %196 to i32
   %198 = trunc i32 %197 to i8
-  %NullCheck66 = icmp ne i8* %192, null
-  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+  %NullCheck65 = icmp eq i8* %192, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %199
 
 ; <label>:199                                     ; preds = %195
   store i8 %198, i8* %192, align 8
@@ -1035,14 +1117,14 @@ entry:
   %201 = load i8*, i8** %arg0
   %202 = load i8*, i8** %arg1
   %203 = bitcast i8* %202 to i64*
-  %NullCheck48 = icmp ne i64* %203, null
-  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+  %NullCheck47 = icmp eq i64* %203, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %204
 
 ; <label>:204                                     ; preds = %200
   %205 = load i64, i64* %203, align 8
   %206 = bitcast i8* %201 to i64*
-  %NullCheck50 = icmp ne i64* %206, null
-  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+  %NullCheck49 = icmp eq i64* %206, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %207
 
 ; <label>:207                                     ; preds = %204
   store i64 %205, i64* %206, align 8
@@ -1051,14 +1133,14 @@ entry:
   %210 = load i8*, i8** %arg1
   %211 = getelementptr inbounds i8, i8* %210, i64 8
   %212 = bitcast i8* %211 to i32*
-  %NullCheck52 = icmp ne i32* %212, null
-  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+  %NullCheck51 = icmp eq i32* %212, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %213
 
 ; <label>:213                                     ; preds = %207
   %214 = load i32, i32* %212, align 8
   %215 = bitcast i8* %209 to i32*
-  %NullCheck54 = icmp ne i32* %215, null
-  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+  %NullCheck53 = icmp eq i32* %215, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %216
 
 ; <label>:216                                     ; preds = %213
   store i32 %214, i32* %215, align 8
@@ -1068,14 +1150,14 @@ entry:
   %218 = load i8*, i8** %arg0
   %219 = load i8*, i8** %arg1
   %220 = bitcast i8* %219 to i64*
-  %NullCheck36 = icmp ne i64* %220, null
-  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64* %220, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %221
 
 ; <label>:221                                     ; preds = %217
   %222 = load i64, i64* %220, align 8
   %223 = bitcast i8* %218 to i64*
-  %NullCheck38 = icmp ne i64* %223, null
-  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+  %NullCheck37 = icmp eq i64* %223, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %224
 
 ; <label>:224                                     ; preds = %221
   store i64 %222, i64* %223, align 8
@@ -1084,14 +1166,14 @@ entry:
   %227 = load i8*, i8** %arg1
   %228 = getelementptr inbounds i8, i8* %227, i64 8
   %229 = bitcast i8* %228 to i32*
-  %NullCheck40 = icmp ne i32* %229, null
-  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i32* %229, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %230
 
 ; <label>:230                                     ; preds = %224
   %231 = load i32, i32* %229, align 8
   %232 = bitcast i8* %226 to i32*
-  %NullCheck42 = icmp ne i32* %232, null
-  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+  %NullCheck41 = icmp eq i32* %232, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %233
 
 ; <label>:233                                     ; preds = %230
   store i32 %231, i32* %232, align 8
@@ -1099,15 +1181,15 @@ entry:
   %235 = getelementptr inbounds i8, i8* %234, i64 12
   %236 = load i8*, i8** %arg1
   %237 = getelementptr inbounds i8, i8* %236, i64 12
-  %NullCheck44 = icmp ne i8* %237, null
-  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i8* %237, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %238
 
 ; <label>:238                                     ; preds = %233
   %239 = load i8, i8* %237, align 8
   %240 = zext i8 %239 to i32
   %241 = trunc i32 %240 to i8
-  %NullCheck46 = icmp ne i8* %235, null
-  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+  %NullCheck45 = icmp eq i8* %235, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %242
 
 ; <label>:242                                     ; preds = %238
   store i8 %241, i8* %235, align 8
@@ -1117,14 +1199,14 @@ entry:
   %244 = load i8*, i8** %arg0
   %245 = load i8*, i8** %arg1
   %246 = bitcast i8* %245 to i64*
-  %NullCheck24 = icmp ne i64* %246, null
-  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64* %246, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %247
 
 ; <label>:247                                     ; preds = %243
   %248 = load i64, i64* %246, align 8
   %249 = bitcast i8* %244 to i64*
-  %NullCheck26 = icmp ne i64* %249, null
-  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64* %249, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %250
 
 ; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
@@ -1133,14 +1215,14 @@ entry:
   %253 = load i8*, i8** %arg1
   %254 = getelementptr inbounds i8, i8* %253, i64 8
   %255 = bitcast i8* %254 to i32*
-  %NullCheck28 = icmp ne i32* %255, null
-  br i1 %NullCheck28, label %256, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i32* %255, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %256
 
 ; <label>:256                                     ; preds = %250
   %257 = load i32, i32* %255, align 8
   %258 = bitcast i8* %252 to i32*
-  %NullCheck30 = icmp ne i32* %258, null
-  br i1 %NullCheck30, label %259, label %ThrowNullRef29
+  %NullCheck29 = icmp eq i32* %258, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %259
 
 ; <label>:259                                     ; preds = %256
   store i32 %257, i32* %258, align 8
@@ -1149,16 +1231,16 @@ entry:
   %262 = load i8*, i8** %arg1
   %263 = getelementptr inbounds i8, i8* %262, i64 12
   %264 = bitcast i8* %263 to i16*
-  %NullCheck32 = icmp ne i16* %264, null
-  br i1 %NullCheck32, label %265, label %ThrowNullRef31
+  %NullCheck31 = icmp eq i16* %264, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %265
 
 ; <label>:265                                     ; preds = %259
   %266 = load i16, i16* %264, align 8
   %267 = sext i16 %266 to i32
   %268 = bitcast i8* %261 to i16*
   %269 = trunc i32 %267 to i16
-  %NullCheck34 = icmp ne i16* %268, null
-  br i1 %NullCheck34, label %270, label %ThrowNullRef33
+  %NullCheck33 = icmp eq i16* %268, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %270
 
 ; <label>:270                                     ; preds = %265
   store i16 %269, i16* %268, align 8
@@ -1168,14 +1250,14 @@ entry:
   %272 = load i8*, i8** %arg0
   %273 = load i8*, i8** %arg1
   %274 = bitcast i8* %273 to i64*
-  %NullCheck8 = icmp ne i64* %274, null
-  br i1 %NullCheck8, label %275, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64* %274, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %275
 
 ; <label>:275                                     ; preds = %271
   %276 = load i64, i64* %274, align 8
   %277 = bitcast i8* %272 to i64*
-  %NullCheck10 = icmp ne i64* %277, null
-  br i1 %NullCheck10, label %278, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %277, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %278
 
 ; <label>:278                                     ; preds = %275
   store i64 %276, i64* %277, align 8
@@ -1184,14 +1266,14 @@ entry:
   %281 = load i8*, i8** %arg1
   %282 = getelementptr inbounds i8, i8* %281, i64 8
   %283 = bitcast i8* %282 to i32*
-  %NullCheck12 = icmp ne i32* %283, null
-  br i1 %NullCheck12, label %284, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i32* %283, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %284
 
 ; <label>:284                                     ; preds = %278
   %285 = load i32, i32* %283, align 8
   %286 = bitcast i8* %280 to i32*
-  %NullCheck14 = icmp ne i32* %286, null
-  br i1 %NullCheck14, label %287, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i32* %286, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %287
 
 ; <label>:287                                     ; preds = %284
   store i32 %285, i32* %286, align 8
@@ -1200,16 +1282,16 @@ entry:
   %290 = load i8*, i8** %arg1
   %291 = getelementptr inbounds i8, i8* %290, i64 12
   %292 = bitcast i8* %291 to i16*
-  %NullCheck16 = icmp ne i16* %292, null
-  br i1 %NullCheck16, label %293, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i16* %292, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %293
 
 ; <label>:293                                     ; preds = %287
   %294 = load i16, i16* %292, align 8
   %295 = sext i16 %294 to i32
   %296 = bitcast i8* %289 to i16*
   %297 = trunc i32 %295 to i16
-  %NullCheck18 = icmp ne i16* %296, null
-  br i1 %NullCheck18, label %298, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i16* %296, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %298
 
 ; <label>:298                                     ; preds = %293
   store i16 %297, i16* %296, align 8
@@ -1217,15 +1299,15 @@ entry:
   %300 = getelementptr inbounds i8, i8* %299, i64 14
   %301 = load i8*, i8** %arg1
   %302 = getelementptr inbounds i8, i8* %301, i64 14
-  %NullCheck20 = icmp ne i8* %302, null
-  br i1 %NullCheck20, label %303, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i8* %302, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %303
 
 ; <label>:303                                     ; preds = %298
   %304 = load i8, i8* %302, align 8
   %305 = zext i8 %304 to i32
   %306 = trunc i32 %305 to i8
-  %NullCheck22 = icmp ne i8* %300, null
-  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i8* %300, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %307
 
 ; <label>:307                                     ; preds = %303
   store i8 %306, i8* %300, align 8
@@ -1235,14 +1317,14 @@ entry:
   %309 = load i8*, i8** %arg0
   %310 = load i8*, i8** %arg1
   %311 = bitcast i8* %310 to i64*
-  %NullCheck = icmp ne i64* %311, null
-  br i1 %NullCheck, label %312, label %ThrowNullRef
+  %NullCheck = icmp eq i64* %311, null
+  br i1 %NullCheck, label %ThrowNullRef, label %312
 
 ; <label>:312                                     ; preds = %308
   %313 = load i64, i64* %311, align 8
   %314 = bitcast i8* %309 to i64*
-  %NullCheck2 = icmp ne i64* %314, null
-  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64* %314, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %315
 
 ; <label>:315                                     ; preds = %312
   store i64 %313, i64* %314, align 8
@@ -1251,14 +1333,14 @@ entry:
   %318 = load i8*, i8** %arg1
   %319 = getelementptr inbounds i8, i8* %318, i64 8
   %320 = bitcast i8* %319 to i64*
-  %NullCheck4 = icmp ne i64* %320, null
-  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64* %320, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %321
 
 ; <label>:321                                     ; preds = %315
   %322 = load i64, i64* %320, align 8
   %323 = bitcast i8* %317 to i64*
-  %NullCheck6 = icmp ne i64* %323, null
-  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64* %323, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %324
 
 ; <label>:324                                     ; preds = %321
   store i64 %322, i64* %323, align 8
@@ -1286,15 +1368,15 @@ entry:
 ; <label>:338                                     ; preds = %333
   %339 = load i8*, i8** %arg0
   %340 = load i8*, i8** %arg1
-  %NullCheck136 = icmp ne i8* %340, null
-  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+  %NullCheck135 = icmp eq i8* %340, null
+  br i1 %NullCheck135, label %ThrowNullRef136, label %341
 
 ; <label>:341                                     ; preds = %338
   %342 = load i8, i8* %340, align 8
   %343 = zext i8 %342 to i32
   %344 = trunc i32 %343 to i8
-  %NullCheck138 = icmp ne i8* %339, null
-  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+  %NullCheck137 = icmp eq i8* %339, null
+  br i1 %NullCheck137, label %ThrowNullRef138, label %345
 
 ; <label>:345                                     ; preds = %341
   store i8 %344, i8* %339, align 8
@@ -1317,16 +1399,16 @@ entry:
   %357 = load i8*, i8** %arg0
   %358 = load i8*, i8** %arg1
   %359 = bitcast i8* %358 to i16*
-  %NullCheck140 = icmp ne i16* %359, null
-  br i1 %NullCheck140, label %360, label %ThrowNullRef139
+  %NullCheck139 = icmp eq i16* %359, null
+  br i1 %NullCheck139, label %ThrowNullRef140, label %360
 
 ; <label>:360                                     ; preds = %356
   %361 = load i16, i16* %359, align 8
   %362 = sext i16 %361 to i32
   %363 = bitcast i8* %357 to i16*
   %364 = trunc i32 %362 to i16
-  %NullCheck142 = icmp ne i16* %363, null
-  br i1 %NullCheck142, label %365, label %ThrowNullRef141
+  %NullCheck141 = icmp eq i16* %363, null
+  br i1 %NullCheck141, label %ThrowNullRef142, label %365
 
 ; <label>:365                                     ; preds = %360
   store i16 %364, i16* %363, align 8
@@ -1352,14 +1434,14 @@ entry:
   %378 = load i8*, i8** %arg0
   %379 = load i8*, i8** %arg1
   %380 = bitcast i8* %379 to i32*
-  %NullCheck144 = icmp ne i32* %380, null
-  br i1 %NullCheck144, label %381, label %ThrowNullRef143
+  %NullCheck143 = icmp eq i32* %380, null
+  br i1 %NullCheck143, label %ThrowNullRef144, label %381
 
 ; <label>:381                                     ; preds = %377
   %382 = load i32, i32* %380, align 8
   %383 = bitcast i8* %378 to i32*
-  %NullCheck146 = icmp ne i32* %383, null
-  br i1 %NullCheck146, label %384, label %ThrowNullRef145
+  %NullCheck145 = icmp eq i32* %383, null
+  br i1 %NullCheck145, label %ThrowNullRef146, label %384
 
 ; <label>:384                                     ; preds = %381
   store i32 %382, i32* %383, align 8
@@ -1384,14 +1466,14 @@ entry:
   %395 = load i8*, i8** %arg0
   %396 = load i8*, i8** %arg1
   %397 = bitcast i8* %396 to i64*
-  %NullCheck164 = icmp ne i64* %397, null
-  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+  %NullCheck163 = icmp eq i64* %397, null
+  br i1 %NullCheck163, label %ThrowNullRef164, label %398
 
 ; <label>:398                                     ; preds = %394
   %399 = load i64, i64* %397, align 8
   %400 = bitcast i8* %395 to i64*
-  %NullCheck166 = icmp ne i64* %400, null
-  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+  %NullCheck165 = icmp eq i64* %400, null
+  br i1 %NullCheck165, label %ThrowNullRef166, label %401
 
 ; <label>:401                                     ; preds = %398
   store i64 %399, i64* %400, align 8
@@ -1400,14 +1482,14 @@ entry:
   %404 = load i8*, i8** %arg1
   %405 = getelementptr inbounds i8, i8* %404, i64 8
   %406 = bitcast i8* %405 to i64*
-  %NullCheck168 = icmp ne i64* %406, null
-  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+  %NullCheck167 = icmp eq i64* %406, null
+  br i1 %NullCheck167, label %ThrowNullRef168, label %407
 
 ; <label>:407                                     ; preds = %401
   %408 = load i64, i64* %406, align 8
   %409 = bitcast i8* %403 to i64*
-  %NullCheck170 = icmp ne i64* %409, null
-  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+  %NullCheck169 = icmp eq i64* %409, null
+  br i1 %NullCheck169, label %ThrowNullRef170, label %410
 
 ; <label>:410                                     ; preds = %407
   store i64 %408, i64* %409, align 8
@@ -1437,14 +1519,14 @@ entry:
   %425 = load i8*, i8** %arg0
   %426 = load i8*, i8** %arg1
   %427 = bitcast i8* %426 to i64*
-  %NullCheck148 = icmp ne i64* %427, null
-  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+  %NullCheck147 = icmp eq i64* %427, null
+  br i1 %NullCheck147, label %ThrowNullRef148, label %428
 
 ; <label>:428                                     ; preds = %424
   %429 = load i64, i64* %427, align 8
   %430 = bitcast i8* %425 to i64*
-  %NullCheck150 = icmp ne i64* %430, null
-  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+  %NullCheck149 = icmp eq i64* %430, null
+  br i1 %NullCheck149, label %ThrowNullRef150, label %431
 
 ; <label>:431                                     ; preds = %428
   store i64 %429, i64* %430, align 8
@@ -1466,14 +1548,14 @@ entry:
   %441 = load i8*, i8** %arg0
   %442 = load i8*, i8** %arg1
   %443 = bitcast i8* %442 to i32*
-  %NullCheck152 = icmp ne i32* %443, null
-  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+  %NullCheck151 = icmp eq i32* %443, null
+  br i1 %NullCheck151, label %ThrowNullRef152, label %444
 
 ; <label>:444                                     ; preds = %440
   %445 = load i32, i32* %443, align 8
   %446 = bitcast i8* %441 to i32*
-  %NullCheck154 = icmp ne i32* %446, null
-  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+  %NullCheck153 = icmp eq i32* %446, null
+  br i1 %NullCheck153, label %ThrowNullRef154, label %447
 
 ; <label>:447                                     ; preds = %444
   store i32 %445, i32* %446, align 8
@@ -1495,16 +1577,16 @@ entry:
   %457 = load i8*, i8** %arg0
   %458 = load i8*, i8** %arg1
   %459 = bitcast i8* %458 to i16*
-  %NullCheck156 = icmp ne i16* %459, null
-  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+  %NullCheck155 = icmp eq i16* %459, null
+  br i1 %NullCheck155, label %ThrowNullRef156, label %460
 
 ; <label>:460                                     ; preds = %456
   %461 = load i16, i16* %459, align 8
   %462 = sext i16 %461 to i32
   %463 = bitcast i8* %457 to i16*
   %464 = trunc i32 %462 to i16
-  %NullCheck158 = icmp ne i16* %463, null
-  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+  %NullCheck157 = icmp eq i16* %463, null
+  br i1 %NullCheck157, label %ThrowNullRef158, label %465
 
 ; <label>:465                                     ; preds = %460
   store i16 %464, i16* %463, align 8
@@ -1525,15 +1607,15 @@ entry:
 ; <label>:474                                     ; preds = %470
   %475 = load i8*, i8** %arg0
   %476 = load i8*, i8** %arg1
-  %NullCheck160 = icmp ne i8* %476, null
-  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+  %NullCheck159 = icmp eq i8* %476, null
+  br i1 %NullCheck159, label %ThrowNullRef160, label %477
 
 ; <label>:477                                     ; preds = %474
   %478 = load i8, i8* %476, align 8
   %479 = zext i8 %478 to i32
   %480 = trunc i32 %479 to i8
-  %NullCheck162 = icmp ne i8* %475, null
-  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+  %NullCheck161 = icmp eq i8* %475, null
+  br i1 %NullCheck161, label %ThrowNullRef162, label %481
 
 ; <label>:481                                     ; preds = %477
   store i8 %480, i8* %475, align 8
@@ -1553,343 +1635,343 @@ ThrowNullRef:                                     ; preds = %308
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %312
+ThrowNullRef2:                                    ; preds = %312
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %315
+ThrowNullRef4:                                    ; preds = %315
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %321
+ThrowNullRef6:                                    ; preds = %321
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %271
+ThrowNullRef8:                                    ; preds = %271
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %275
+ThrowNullRef10:                                   ; preds = %275
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %278
+ThrowNullRef12:                                   ; preds = %278
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %284
+ThrowNullRef14:                                   ; preds = %284
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %287
+ThrowNullRef16:                                   ; preds = %287
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %293
+ThrowNullRef18:                                   ; preds = %293
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %298
+ThrowNullRef20:                                   ; preds = %298
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %303
+ThrowNullRef22:                                   ; preds = %303
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %243
+ThrowNullRef24:                                   ; preds = %243
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %247
+ThrowNullRef26:                                   ; preds = %247
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %250
+ThrowNullRef28:                                   ; preds = %250
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %256
+ThrowNullRef30:                                   ; preds = %256
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %259
+ThrowNullRef32:                                   ; preds = %259
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %265
+ThrowNullRef34:                                   ; preds = %265
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %217
+ThrowNullRef36:                                   ; preds = %217
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %221
+ThrowNullRef38:                                   ; preds = %221
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %224
+ThrowNullRef40:                                   ; preds = %224
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %230
+ThrowNullRef42:                                   ; preds = %230
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %233
+ThrowNullRef44:                                   ; preds = %233
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %238
+ThrowNullRef46:                                   ; preds = %238
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %200
+ThrowNullRef48:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %204
+ThrowNullRef50:                                   ; preds = %204
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %207
+ThrowNullRef52:                                   ; preds = %207
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %213
+ThrowNullRef54:                                   ; preds = %213
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %172
+ThrowNullRef56:                                   ; preds = %172
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %176
+ThrowNullRef58:                                   ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %179
+ThrowNullRef60:                                   ; preds = %179
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %185
+ThrowNullRef62:                                   ; preds = %185
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %190
+ThrowNullRef64:                                   ; preds = %190
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %195
+ThrowNullRef66:                                   ; preds = %195
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %153
+ThrowNullRef68:                                   ; preds = %153
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %157
+ThrowNullRef70:                                   ; preds = %157
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %160
+ThrowNullRef72:                                   ; preds = %160
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %166
+ThrowNullRef74:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %136
+ThrowNullRef76:                                   ; preds = %136
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %140
+ThrowNullRef78:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %143
+ThrowNullRef80:                                   ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %148
+ThrowNullRef82:                                   ; preds = %148
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %128
+ThrowNullRef84:                                   ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %132
+ThrowNullRef86:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %100
+ThrowNullRef88:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %104
+ThrowNullRef90:                                   ; preds = %104
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %107
+ThrowNullRef92:                                   ; preds = %107
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %113
+ThrowNullRef94:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %118
+ThrowNullRef96:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %123
+ThrowNullRef98:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %81
+ThrowNullRef100:                                  ; preds = %81
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef101:                                  ; preds = %85
+ThrowNullRef102:                                  ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef103:                                  ; preds = %88
+ThrowNullRef104:                                  ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef105:                                  ; preds = %94
+ThrowNullRef106:                                  ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef107:                                  ; preds = %64
+ThrowNullRef108:                                  ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef109:                                  ; preds = %68
+ThrowNullRef110:                                  ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef111:                                  ; preds = %71
+ThrowNullRef112:                                  ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef113:                                  ; preds = %76
+ThrowNullRef114:                                  ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef115:                                  ; preds = %56
+ThrowNullRef116:                                  ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef117:                                  ; preds = %60
+ThrowNullRef118:                                  ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef119:                                  ; preds = %37
+ThrowNullRef120:                                  ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef121:                                  ; preds = %41
+ThrowNullRef122:                                  ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef123:                                  ; preds = %46
+ThrowNullRef124:                                  ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef125:                                  ; preds = %51
+ThrowNullRef126:                                  ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef127:                                  ; preds = %27
+ThrowNullRef128:                                  ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef129:                                  ; preds = %31
+ThrowNullRef130:                                  ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef131:                                  ; preds = %19
+ThrowNullRef132:                                  ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef133:                                  ; preds = %22
+ThrowNullRef134:                                  ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef135:                                  ; preds = %338
+ThrowNullRef136:                                  ; preds = %338
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef137:                                  ; preds = %341
+ThrowNullRef138:                                  ; preds = %341
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef139:                                  ; preds = %356
+ThrowNullRef140:                                  ; preds = %356
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef141:                                  ; preds = %360
+ThrowNullRef142:                                  ; preds = %360
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef143:                                  ; preds = %377
+ThrowNullRef144:                                  ; preds = %377
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef145:                                  ; preds = %381
+ThrowNullRef146:                                  ; preds = %381
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef147:                                  ; preds = %424
+ThrowNullRef148:                                  ; preds = %424
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef149:                                  ; preds = %428
+ThrowNullRef150:                                  ; preds = %428
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef151:                                  ; preds = %440
+ThrowNullRef152:                                  ; preds = %440
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef153:                                  ; preds = %444
+ThrowNullRef154:                                  ; preds = %444
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef155:                                  ; preds = %456
+ThrowNullRef156:                                  ; preds = %456
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef157:                                  ; preds = %460
+ThrowNullRef158:                                  ; preds = %460
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef159:                                  ; preds = %474
+ThrowNullRef160:                                  ; preds = %474
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef161:                                  ; preds = %477
+ThrowNullRef162:                                  ; preds = %477
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef163:                                  ; preds = %394
+ThrowNullRef164:                                  ; preds = %394
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef165:                                  ; preds = %398
+ThrowNullRef166:                                  ; preds = %398
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef167:                                  ; preds = %401
+ThrowNullRef168:                                  ; preds = %401
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef169:                                  ; preds = %407
+ThrowNullRef170:                                  ; preds = %407
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1939,8 +2021,8 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
-  br i1 %NullCheck, label %22, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %ThrowNullRef, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
@@ -1948,8 +2030,8 @@ entry:
   store i32 %24, i32* %loc0
   %25 = load i32, i32* %loc0
   %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %26, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %27
 
 ; <label>:27                                      ; preds = %22
   %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
@@ -1971,7 +2053,7 @@ ThrowNullRef:                                     ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1989,8 +2071,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -2022,15 +2104,15 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2048,16 +2130,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
   %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
   store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %15
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
@@ -2072,8 +2154,8 @@ entry:
   %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
   %29 = ptrtoint i16 addrspace(1)* %28 to i64
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %19
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
@@ -2089,19 +2171,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2114,8 +2196,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
@@ -2128,7 +2210,7 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[loadElem]
+Failed to read AppDomain.PrepareDataForSetup[storeElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
@@ -2202,8 +2284,8 @@ entry:
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
-  br i1 %NullCheck24, label %27, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = load i64, i64 addrspace(1)* %26
@@ -2218,8 +2300,8 @@ entry:
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
-  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
   %41 = load i64, i64 addrspace(1)* %39
@@ -2236,8 +2318,8 @@ entry:
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
-  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
   %54 = load i64, i64 addrspace(1)* %52
@@ -2252,8 +2334,8 @@ entry:
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
   %67 = load i64, i64 addrspace(1)* %65
@@ -2270,8 +2352,8 @@ entry:
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
-  br i1 %NullCheck16, label %79, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
   %80 = load i64, i64 addrspace(1)* %78
@@ -2286,8 +2368,8 @@ entry:
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
-  br i1 %NullCheck18, label %92, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
   %93 = load i64, i64 addrspace(1)* %91
@@ -2304,8 +2386,8 @@ entry:
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
-  br i1 %NullCheck12, label %105, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = load i64, i64 addrspace(1)* %104
@@ -2320,8 +2402,8 @@ entry:
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
-  br i1 %NullCheck14, label %118, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
   %119 = load i64, i64 addrspace(1)* %117
@@ -2337,8 +2419,8 @@ entry:
 
 ; <label>:128                                     ; preds = %20
   %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
-  br i1 %NullCheck4, label %130, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %129, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %130
 
 ; <label>:130                                     ; preds = %128
   %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
@@ -2346,8 +2428,8 @@ entry:
   %133 = load i16, i16 addrspace(1)* %132, align 8
   %134 = zext i16 %133 to i32
   %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
-  br i1 %NullCheck6, label %136, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %135, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %136
 
 ; <label>:136                                     ; preds = %130
   %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
@@ -2360,8 +2442,8 @@ entry:
 
 ; <label>:143                                     ; preds = %136
   %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
-  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %144, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %145
 
 ; <label>:145                                     ; preds = %143
   %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
@@ -2369,8 +2451,8 @@ entry:
   %148 = load i16, i16 addrspace(1)* %147, align 8
   %149 = zext i16 %148 to i32
   %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %150, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %151
 
 ; <label>:151                                     ; preds = %145
   %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
@@ -2388,8 +2470,8 @@ entry:
 
 ; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
-  br i1 %NullCheck, label %163, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %ThrowNullRef, label %163
 
 ; <label>:163                                     ; preds = %161
   %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
@@ -2399,8 +2481,8 @@ entry:
 
 ; <label>:167                                     ; preds = %163
   %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
-  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %168, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %169
 
 ; <label>:169                                     ; preds = %167
   %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
@@ -2432,55 +2514,55 @@ ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %167
+ThrowNullRef2:                                    ; preds = %167
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %128
+ThrowNullRef4:                                    ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %130
+ThrowNullRef6:                                    ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %143
+ThrowNullRef8:                                    ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %145
+ThrowNullRef10:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %102
+ThrowNullRef12:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %105
+ThrowNullRef14:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %76
+ThrowNullRef16:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %79
+ThrowNullRef18:                                   ; preds = %79
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %50
+ThrowNullRef20:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %53
+ThrowNullRef22:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %24
+ThrowNullRef24:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %27
+ThrowNullRef26:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2503,15 +2585,15 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2519,16 +2601,16 @@ entry:
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
   store i32 %8, i32* %loc0
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
   %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
   store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
@@ -2546,16 +2628,16 @@ entry:
 
 ; <label>:23                                      ; preds = %64
   %24 = load i16*, i16** %loc3
-  %NullCheck12 = icmp ne i16* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i16* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
   store i32 %27, i32* %loc5
   %28 = load i16*, i16** %loc4
-  %NullCheck14 = icmp ne i16* %28, null
-  br i1 %NullCheck14, label %29, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %28, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = load i16, i16* %28, align 8
@@ -2620,15 +2702,15 @@ entry:
 
 ; <label>:67                                      ; preds = %64
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
-  br i1 %NullCheck8, label %69, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %68, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %69
 
 ; <label>:69                                      ; preds = %67
   %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
   %71 = load i32, i32 addrspace(1)* %70
   %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
-  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %73
 
 ; <label>:73                                      ; preds = %69
   %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
@@ -2645,31 +2727,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %67
+ThrowNullRef8:                                    ; preds = %67
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %69
+ThrowNullRef10:                                   ; preds = %69
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2710,14 +2792,14 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
   %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
@@ -2730,14 +2812,14 @@ entry:
 
 ; <label>:11                                      ; preds = %4
   %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
   %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
@@ -2749,14 +2831,14 @@ entry:
 
 ; <label>:22                                      ; preds = %16
   %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
   %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
-  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
-  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
@@ -2804,23 +2886,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2836,7 +2918,280 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[loadElem]
+Successfully read RuntimeType.IsAssignableFrom
+
+define i8 @RuntimeType.IsAssignableFrom(%System.RuntimeType addrspace(1)* %param0, %System.Type addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.RuntimeType addrspace(1)*
+  %arg1 = alloca %System.Type addrspace(1)*
+  %loc0 = alloca %System.RuntimeType addrspace(1)*
+  %loc1 = alloca %"System.Type[]" addrspace(1)*
+  %loc2 = alloca i32
+  store %System.RuntimeType addrspace(1)* %param0, %System.RuntimeType addrspace(1)** %this
+  store %System.Type addrspace(1)* %param1, %System.Type addrspace(1)** %arg1
+  %0 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %1 = icmp ne %System.Type addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i8 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %5 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %6 = bitcast %System.Type addrspace(1)* %4 to %System.Object addrspace(1)*
+  %7 = bitcast %System.RuntimeType addrspace(1)* %5 to %System.Object addrspace(1)*
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %6, %System.Object addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %3
+  ret i8 1
+
+; <label>:12                                      ; preds = %3
+  %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 152
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 32
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
+  %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
+  %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
+  store %System.RuntimeType addrspace(1)* %25, %System.RuntimeType addrspace(1)** %loc0
+  %26 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %27 = icmp eq %System.RuntimeType addrspace(1)* %26, null
+  br i1 %27, label %34, label %28
+
+; <label>:28                                      ; preds = %15
+  %29 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %30 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)*)*)(%System.RuntimeType addrspace(1)* %29, %System.RuntimeType addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+; <label>:34                                      ; preds = %15
+  %35 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %36 = call %System.Reflection.Emit.TypeBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Reflection.Emit.TypeBuilder addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %35)
+  %37 = icmp eq %System.Reflection.Emit.TypeBuilder addrspace(1)* %36, null
+  br i1 %37, label %139, label %38
+
+; <label>:38                                      ; preds = %34
+  %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %42
+
+; <label>:42                                      ; preds = %38
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 152
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 40
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
+  %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
+  %53 = zext i8 %52 to i32
+  %54 = icmp eq i32 %53, 0
+  br i1 %54, label %56, label %55
+
+; <label>:55                                      ; preds = %42
+  ret i8 1
+
+; <label>:56                                      ; preds = %42
+  %57 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %58 = bitcast %System.RuntimeType addrspace(1)* %57 to %System.Type addrspace(1)*
+  %59 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %58)
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %64 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.Type addrspace(1)* %63, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = bitcast %System.RuntimeType addrspace(1)* %64 to %System.Type addrspace(1)*
+  %67 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %63, %System.Type addrspace(1)* %66)
+  %68 = zext i8 %67 to i32
+  %69 = trunc i32 %68 to i8
+  ret i8 %69
+
+; <label>:70                                      ; preds = %56
+  %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
+  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %73
+
+; <label>:73                                      ; preds = %70
+  %74 = load i64, i64 addrspace(1)* %72
+  %75 = add i64 %74, 128
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = add i64 %77, 0
+  %79 = inttoptr i64 %78 to i64*
+  %80 = load i64, i64* %79
+  %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
+  %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
+  %83 = call i8 %82(%System.Type addrspace(1)* %81)
+  %84 = zext i8 %83 to i32
+  %85 = icmp eq i32 %84, 0
+  br i1 %85, label %139, label %86
+
+; <label>:86                                      ; preds = %73
+  %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
+  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %89
+
+; <label>:89                                      ; preds = %86
+  %90 = load i64, i64 addrspace(1)* %88
+  %91 = add i64 %90, 128
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = add i64 %93, 24
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
+  %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
+  %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
+  store %"System.Type[]" addrspace(1)* %99, %"System.Type[]" addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %129
+
+; <label>:100                                     ; preds = %132
+  %101 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %102 = load i32, i32* %loc2
+  %NullCheck11 = icmp eq %"System.Type[]" addrspace(1)* %101, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %103
+
+; <label>:103                                     ; preds = %100
+  %104 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 1
+  %105 = load i32, i32 addrspace(1)* %104
+  %106 = zext i32 %105 to i64
+  %107 = zext i32 %102 to i64
+  %BoundsCheck = icmp uge i64 %107, %106
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %108
+
+; <label>:108                                     ; preds = %103
+  %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
+  %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
+  %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
+  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %113
+
+; <label>:113                                     ; preds = %108
+  %114 = load i64, i64 addrspace(1)* %112
+  %115 = add i64 %114, 152
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = add i64 %117, 56
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
+  %123 = zext i8 %122 to i32
+  %124 = icmp ne i32 %123, 0
+  br i1 %124, label %126, label %125
+
+; <label>:125                                     ; preds = %113
+  ret i8 0
+
+; <label>:126                                     ; preds = %113
+  %127 = load i32, i32* %loc2
+  %128 = add i32 %127, 1
+  store i32 %128, i32* %loc2
+  br label %129
+
+; <label>:129                                     ; preds = %89, %126
+  %130 = load i32, i32* %loc2
+  %131 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %NullCheck9 = icmp eq %"System.Type[]" addrspace(1)* %131, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %132
+
+; <label>:132                                     ; preds = %129
+  %133 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %131, i32 0, i32 1
+  %134 = load i32, i32 addrspace(1)* %133
+  %135 = zext i32 %134 to i64
+  %136 = trunc i64 %135 to i32
+  %137 = icmp slt i32 %130, %136
+  br i1 %137, label %100, label %138
+
+; <label>:138                                     ; preds = %132
+  ret i8 1
+
+; <label>:139                                     ; preds = %34, %73
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %129
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %103
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -2893,7 +3248,7 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElem]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -2904,8 +3259,8 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -2997,8 +3352,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
@@ -3059,8 +3414,8 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -3087,8 +3442,8 @@ entry:
 
 ; <label>:17                                      ; preds = %5, %11
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
@@ -3097,8 +3452,8 @@ entry:
 
 ; <label>:22                                      ; preds = %1, %11
   %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
@@ -3109,11 +3464,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %17
+ThrowNullRef2:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %22
+ThrowNullRef4:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3167,15 +3522,15 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
   %15 = load i32, i32 addrspace(1)* %14
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
@@ -3198,7 +3553,7 @@ ThrowNullRef:                                     ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef2:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3232,8 +3587,8 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
@@ -3312,8 +3667,8 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -3327,8 +3682,8 @@ entry:
 ; <label>:5                                       ; preds = %43
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %7 = load i32, i32* %loc1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck6, label %8, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
@@ -3366,8 +3721,8 @@ entry:
 ; <label>:32                                      ; preds = %21, %25
   %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
   %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
-  br i1 %NullCheck8, label %35, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = trunc i32 %34 to i16
@@ -3380,8 +3735,8 @@ entry:
 ; <label>:40                                      ; preds = %1, %35
   %41 = load i32, i32* %loc1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
-  br i1 %NullCheck2, label %43, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %42, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
@@ -3392,8 +3747,8 @@ entry:
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
   %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
-  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
   %51 = load i64, i64 addrspace(1)* %49
@@ -3412,19 +3767,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %40
+ThrowNullRef2:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %47
+ThrowNullRef4:                                    ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %5
+ThrowNullRef6:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %32
+ThrowNullRef8:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3467,8 +3822,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
@@ -3492,11 +3847,391 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(i16* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store i16* %param0, i16** %arg0
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load i32, i32* %arg3
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %42, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %37, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg2
+  %13 = load i32, i32* %arg3
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %37, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %24 = load i32, i32* %arg2
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load i16*, i16** %arg0
+  %35 = load i32, i32* %arg3
+  %36 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %36, i16* %34, i32 %35)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:37                                      ; preds = %5, %16
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %39)
+  %41 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41, %System.String addrspace(1)* %38, %System.String addrspace(1)* %40)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41) #0
+  unreachable
+
+; <label>:42                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
-Failed to read StringBuilder.ToString[loadElemA]
+Successfully read StringBuilder.ToString
+
+define %System.String addrspace(1)* @StringBuilder.ToString(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i16*
+  %loc3 = alloca %"System.Char[]" addrspace(1)*
+  %loc4 = alloca i32
+  %loc5 = alloca i32
+  %loc6 = alloca i16 addrspace(1)*
+  %loc7 = alloca %System.String addrspace(1)*
+  %loc8 = alloca %"System.Char[]" addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %0)
+  %2 = icmp ne i32 %1, 0
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %4
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %6)
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %7)
+  store %System.String addrspace(1)* %8, %System.String addrspace(1)** %loc0
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.Text.StringBuilder addrspace(1)* %9, %System.Text.StringBuilder addrspace(1)** %loc1
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  store %System.String addrspace(1)* %10, %System.String addrspace(1)** %loc7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc7
+  %12 = ptrtoint %System.String addrspace(1)* %11 to i64
+  %13 = icmp eq i64 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %5
+  %15 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %16 = sext i32 %15 to i64
+  %17 = add i64 %12, %16
+  br label %18
+
+; <label>:18                                      ; preds = %5, %14
+  %19 = phi i64 [ %12, %5 ], [ %17, %14 ]
+  %20 = inttoptr i64 %19 to i16*
+  store i16* %20, i16** %loc2
+  br label %21
+
+; <label>:21                                      ; preds = %98, %18
+  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %22, null
+  br i1 %NullCheck, label %ThrowNullRef, label %23
+
+; <label>:23                                      ; preds = %21
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 3
+  %25 = load i32, i32 addrspace(1)* %24, align 8
+  %26 = icmp sle i32 %25, 0
+  br i1 %26, label %96, label %27
+
+; <label>:27                                      ; preds = %23
+  %28 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %28, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %29
+
+; <label>:29                                      ; preds = %27
+  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %28, i32 0, i32 1
+  %31 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %30, align 8
+  store %"System.Char[]" addrspace(1)* %31, %"System.Char[]" addrspace(1)** %loc3
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %33
+
+; <label>:33                                      ; preds = %29
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  store i32 %35, i32* %loc4
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  %39 = load i32, i32 addrspace(1)* %38, align 8
+  store i32 %39, i32* %loc5
+  %40 = load i32, i32* %loc5
+  %41 = load i32, i32* %loc4
+  %42 = add i32 %40, %41
+  %43 = zext i32 %42 to i64
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %45
+
+; <label>:45                                      ; preds = %37
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = sext i32 %47 to i64
+  %49 = icmp sgt i64 %43, %48
+  br i1 %49, label %91, label %50
+
+; <label>:50                                      ; preds = %45
+  %51 = load i32, i32* %loc5
+  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %52, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %53
+
+; <label>:53                                      ; preds = %50
+  %54 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %52, i32 0, i32 1
+  %55 = load i32, i32 addrspace(1)* %54
+  %56 = zext i32 %55 to i64
+  %57 = trunc i64 %56 to i32
+  %58 = icmp ugt i32 %51, %57
+  br i1 %58, label %91, label %59
+
+; <label>:59                                      ; preds = %53
+  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  store %"System.Char[]" addrspace(1)* %60, %"System.Char[]" addrspace(1)** %loc8
+  %61 = icmp eq %"System.Char[]" addrspace(1)* %60, null
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %63, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %64
+
+; <label>:64                                      ; preds = %62
+  %65 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %63, i32 0, i32 1
+  %66 = load i32, i32 addrspace(1)* %65
+  %67 = zext i32 %66 to i64
+  %68 = trunc i64 %67 to i32
+  %69 = icmp ne i32 %68, 0
+  br i1 %69, label %71, label %70
+
+; <label>:70                                      ; preds = %59, %64
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:71                                      ; preds = %64
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %73
+
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %BoundsCheck = icmp uge i64 0, %76
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %77
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %78, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:79                                      ; preds = %70, %77
+  %80 = load i16*, i16** %loc2
+  %81 = load i32, i32* %loc4
+  %82 = sext i32 %81 to i64
+  %83 = mul i64 %82, 2
+  %84 = bitcast i16* %80 to i8*
+  %85 = getelementptr inbounds i8, i8* %84, i64 %83
+  %86 = load i16 addrspace(1)*, i16 addrspace(1)** %loc6
+  %87 = ptrtoint i16 addrspace(1)* %86 to i64
+  %88 = load i32, i32* %loc5
+  %89 = bitcast i8* %85 to i16*
+  %90 = inttoptr i64 %87 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %89, i16* %90, i32 %88)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %96
+
+; <label>:91                                      ; preds = %45, %53
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %94 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %93)
+  %95 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95, %System.String addrspace(1)* %92, %System.String addrspace(1)* %94)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95) #0
+  unreachable
+
+; <label>:96                                      ; preds = %23, %79
+  %97 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %97, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %98
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %97, i32 0, i32 2
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  store %System.Text.StringBuilder addrspace(1)* %100, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %102 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %102, label %21, label %103
+
+; <label>:103                                     ; preds = %98
+  store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc7
+  %104 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  ret %System.String addrspace(1)* %104
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method StringBuilder::get_Length using LLILCJit
+Successfully read StringBuilder.get_Length
+
+define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
+Successfully read RuntimeHelpers.get_OffsetToStringData
+
+define i32 @RuntimeHelpers.get_OffsetToStringData() {
+entry:
+  ret i32 12
+}
+
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
 Successfully read CultureData.CreateCultureData
 
@@ -3514,23 +4249,23 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
   store i8 %4, i8 addrspace(1)* %6
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
@@ -3549,11 +4284,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3566,50 +4301,50 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
   store i32 -1, i32 addrspace(1)* %2
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
   store i32 -1, i32 addrspace(1)* %8
   %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
   store i32 -1, i32 addrspace(1)* %14
   %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
   store i32 -1, i32 addrspace(1)* %17
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
@@ -3623,27 +4358,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3675,7 +4410,136 @@ Failed to read Dictionary`2.Insert[non-const derefAddress]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
 Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
-Failed to read HashHelpers.GetPrime[loadElem]
+Successfully read HashHelpers.GetPrime
+
+define i32 @HashHelpers.GetPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %6, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5, %System.String addrspace(1)* %4)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5) #0
+  unreachable
+
+; <label>:6                                       ; preds = %entry
+  store i32 0, i32* %loc0
+  br label %29
+
+; <label>:7                                       ; preds = %35
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 1296
+  %10 = addrspacecast i8 addrspace(1)* %9 to %"System.Int32[]" addrspace(1)**
+  %11 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %10
+  %12 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Int32[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = zext i32 %15 to i64
+  %17 = zext i32 %12 to i64
+  %BoundsCheck = icmp uge i64 %17, %16
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 3, i32 %12
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  store i32 %20, i32* %loc1
+  %21 = load i32, i32* %loc1
+  %22 = load i32, i32* %arg0
+  %23 = icmp slt i32 %21, %22
+  br i1 %23, label %26, label %24
+
+; <label>:24                                      ; preds = %18
+  %25 = load i32, i32* %loc1
+  ret i32 %25
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %loc0
+  %28 = add i32 %27, 1
+  store i32 %28, i32* %loc0
+  br label %29
+
+; <label>:29                                      ; preds = %6, %26
+  %30 = load i32, i32* %loc0
+  %31 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %32 = getelementptr inbounds i8, i8 addrspace(1)* %31, i64 1296
+  %33 = addrspacecast i8 addrspace(1)* %32 to %"System.Int32[]" addrspace(1)**
+  %34 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %33
+  %NullCheck = icmp eq %"System.Int32[]" addrspace(1)* %34, null
+  br i1 %NullCheck, label %ThrowNullRef, label %35
+
+; <label>:35                                      ; preds = %29
+  %36 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %34, i32 0, i32 1
+  %37 = load i32, i32 addrspace(1)* %36
+  %38 = zext i32 %37 to i64
+  %39 = trunc i64 %38 to i32
+  %40 = icmp slt i32 %30, %39
+  br i1 %40, label %7, label %41
+
+; <label>:41                                      ; preds = %35
+  %42 = load i32, i32* %arg0
+  %43 = or i32 %42, 1
+  store i32 %43, i32* %loc2
+  br label %59
+
+; <label>:44                                      ; preds = %59
+  %45 = load i32, i32* %loc2
+  %46 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %45)
+  %47 = zext i8 %46 to i32
+  %48 = icmp eq i32 %47, 0
+  br i1 %48, label %56, label %49
+
+; <label>:49                                      ; preds = %44
+  %50 = load i32, i32* %loc2
+  %51 = sub i32 %50, 1
+  %52 = srem i32 %51, 101
+  %53 = icmp eq i32 %52, 0
+  br i1 %53, label %56, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = load i32, i32* %loc2
+  ret i32 %55
+
+; <label>:56                                      ; preds = %44, %49
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %57, 2
+  store i32 %58, i32* %loc2
+  br label %59
+
+; <label>:59                                      ; preds = %41, %56
+  %60 = load i32, i32* %loc2
+  %61 = icmp slt i32 %60, 2147483647
+  br i1 %61, label %44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load i32, i32* %arg0
+  ret i32 %63
+
+ThrowNullRef:                                     ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
 Successfully read GenericEqualityComparer`1.GetHashCode
 
@@ -3694,14 +4558,14 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
   %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load i64, i64 addrspace(1)* %7
@@ -3720,7 +4584,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3750,8 +4614,8 @@ entry:
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
@@ -3796,8 +4660,8 @@ entry:
   %35 = bitcast i16* %34 to i8*
   %36 = getelementptr inbounds i8, i8* %35, i64 2
   %37 = bitcast i8* %36 to i16*
-  %NullCheck4 = icmp ne i16* %37, null
-  br i1 %NullCheck4, label %38, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %37, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %38
 
 ; <label>:38                                      ; preds = %27
   %39 = load i16, i16* %37, align 8
@@ -3824,8 +4688,8 @@ entry:
 
 ; <label>:54                                      ; preds = %22, %43
   %55 = load i16*, i16** %loc4
-  %NullCheck2 = icmp ne i16* %55, null
-  br i1 %NullCheck2, label %56, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i16* %55, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %56
 
 ; <label>:56                                      ; preds = %54
   %57 = load i16, i16* %55, align 8
@@ -3850,11 +4714,11 @@ ThrowNullRef:                                     ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %54
+ThrowNullRef2:                                    ; preds = %54
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %27
+ThrowNullRef4:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3871,8 +4735,8 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -3907,8 +4771,8 @@ entry:
 
 ; <label>:26                                      ; preds = %19
   %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
-  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %28
 
 ; <label>:28                                      ; preds = %26
   %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
@@ -3920,7 +4784,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3972,8 +4836,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
@@ -3984,26 +4848,26 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
-  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
@@ -4014,8 +4878,8 @@ entry:
 ; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
@@ -4024,8 +4888,8 @@ entry:
 
 ; <label>:25                                      ; preds = %1, %16, %23
   %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
-  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
@@ -4036,27 +4900,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %20
+ThrowNullRef10:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4069,8 +4933,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -4081,8 +4945,8 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
@@ -4091,8 +4955,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1, %8
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
@@ -4103,11 +4967,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4128,24 +4992,24 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   store i32 %3, i32* %loc0
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
   %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
   store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck4, label %9, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
@@ -4164,15 +5028,15 @@ entry:
 ; <label>:18                                      ; preds = %70
   %19 = load i16*, i16** %loc3
   %20 = bitcast i16* %19 to i64*
-  %NullCheck10 = icmp ne i64* %20, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %20, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = load i64, i64* %20, align 8
   %23 = load i16*, i16** %loc4
   %24 = bitcast i16* %23 to i64*
-  %NullCheck12 = icmp ne i64* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = load i64, i64* %24, align 8
@@ -4188,8 +5052,8 @@ entry:
   %31 = bitcast i16* %30 to i8*
   %32 = getelementptr inbounds i8, i8* %31, i64 8
   %33 = bitcast i8* %32 to i64*
-  %NullCheck14 = icmp ne i64* %33, null
-  br i1 %NullCheck14, label %34, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = load i64, i64* %33, align 8
@@ -4197,8 +5061,8 @@ entry:
   %37 = bitcast i16* %36 to i8*
   %38 = getelementptr inbounds i8, i8* %37, i64 8
   %39 = bitcast i8* %38 to i64*
-  %NullCheck16 = icmp ne i64* %39, null
-  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %40
 
 ; <label>:40                                      ; preds = %34
   %41 = load i64, i64* %39, align 8
@@ -4214,8 +5078,8 @@ entry:
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %NullCheck18 = icmp ne i64* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = load i64, i64* %48, align 8
@@ -4223,8 +5087,8 @@ entry:
   %52 = bitcast i16* %51 to i8*
   %53 = getelementptr inbounds i8, i8* %52, i64 16
   %54 = bitcast i8* %53 to i64*
-  %NullCheck20 = icmp ne i64* %54, null
-  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64* %54, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %55
 
 ; <label>:55                                      ; preds = %49
   %56 = load i64, i64* %54, align 8
@@ -4262,15 +5126,15 @@ entry:
 ; <label>:74                                      ; preds = %95
   %75 = load i16*, i16** %loc3
   %76 = bitcast i16* %75 to i32*
-  %NullCheck6 = icmp ne i32* %76, null
-  br i1 %NullCheck6, label %77, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32* %76, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %77
 
 ; <label>:77                                      ; preds = %74
   %78 = load i32, i32* %76, align 8
   %79 = load i16*, i16** %loc4
   %80 = bitcast i16* %79 to i32*
-  %NullCheck8 = icmp ne i32* %80, null
-  br i1 %NullCheck8, label %81, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i32* %80, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %81
 
 ; <label>:81                                      ; preds = %77
   %82 = load i32, i32* %80, align 8
@@ -4318,43 +5182,43 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %74
+ThrowNullRef6:                                    ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %77
+ThrowNullRef8:                                    ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %29
+ThrowNullRef14:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %34
+ThrowNullRef16:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4376,8 +5240,8 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load i64, i64 addrspace(1)* %4
@@ -4389,8 +5253,8 @@ entry:
   %12 = load i64, i64* %11
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %5
   %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
@@ -4399,8 +5263,8 @@ entry:
   %18 = load i8, i8* %arg2
   %19 = zext i8 %18 to i32
   %20 = trunc i32 %19 to i8
-  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %15
   %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
@@ -4411,11 +5275,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4442,8 +5306,8 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
@@ -4466,16 +5330,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
   %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = load i64, i64 addrspace(1)* %19
@@ -4500,8 +5364,8 @@ entry:
 ; <label>:35                                      ; preds = %30
   %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
@@ -4514,8 +5378,8 @@ entry:
 
 ; <label>:42                                      ; preds = %1, %38
   %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
-  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
@@ -4526,19 +5390,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %35
+ThrowNullRef2:                                    ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %42
+ThrowNullRef8:                                    ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4551,14 +5415,14 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
@@ -4570,7 +5434,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4583,8 +5447,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
@@ -4613,51 +5477,51 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
   %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
   %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
   %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
   %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
-  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
   store i64 %21, i64 addrspace(1)* %23
   %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %25 = load i64, i64* %loc0
-  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
@@ -4668,27 +5532,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %22
+ThrowNullRef12:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4701,8 +5565,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
@@ -4713,19 +5577,19 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
@@ -4734,8 +5598,8 @@ entry:
 
 ; <label>:15                                      ; preds = %1, %13
   %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
@@ -4746,19 +5610,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %15
+ThrowNullRef8:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4771,8 +5635,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -4831,8 +5695,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
@@ -4882,8 +5746,8 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
-  br i1 %NullCheck, label %17, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %ThrowNullRef, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
@@ -4894,15 +5758,15 @@ entry:
 
 ; <label>:22                                      ; preds = %17
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
-  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
   %26 = load i32, i32 addrspace(1)* %25
   %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
-  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %27, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
@@ -4925,8 +5789,8 @@ entry:
 ; <label>:40                                      ; preds = %17
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
-  br i1 %NullCheck6, label %43, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %41, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
@@ -4938,34 +5802,17 @@ ThrowNullRef:                                     ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %24
+ThrowNullRef4:                                    ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %40
+ThrowNullRef6:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
-}
-
-INFO:  jitting method Object::ReferenceEquals using LLILCJit
-Successfully read Object.ReferenceEquals
-
-define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
-entry:
-  %arg0 = alloca %System.Object addrspace(1)*
-  %arg1 = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
-  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
-  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = icmp eq %System.Object addrspace(1)* %0, %1
-  %3 = sext i1 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
 }
 
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
@@ -4978,21 +5825,21 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
   %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
-  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
@@ -5007,28 +5854,28 @@ entry:
 ; <label>:13                                      ; preds = %8, %12
   %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
   %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
   %21 = load i32, i32 addrspace(1)* %20, align 8
   %22 = add i32 %21, 1
-  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
   store i32 %22, i32 addrspace(1)* %24
   %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
@@ -5039,27 +5886,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5077,7 +5924,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::Setup using LLILCJit
-Failed to read AppDomain.Setup[loadElem]
+Failed to read AppDomain.Setup[unbox]
 INFO:  jitting method Thread::GetDomain using LLILCJit
 Successfully read Thread.GetDomain
 
@@ -5108,8 +5955,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
@@ -5122,14 +5969,14 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
   %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
@@ -5141,11 +5988,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5173,8 +6020,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -5189,7 +6036,328 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
 Failed to read KeyCollection.System.Collections.Generic.IEnumerable<TKey>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Successfully read Enumerator.MoveNext
+
+define i8 @Enumerator.MoveNext(%"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.RuntimeTypeHandle* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*
+  %"$TypeArg" = alloca %System.RuntimeTypeHandle*
+  store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
+  %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 8
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %76, label %12
+
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
+  br label %76
+
+; <label>:13                                      ; preds = %85
+  %14 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck19 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %15
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, i32 0, i32 0
+  %17 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %16, align 8
+  %NullCheck21 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, i32 0, i32 2
+  %20 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %19, align 8
+  %21 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck23 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %22
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, i32 0, i32 2
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %NullCheck25 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 3, i32 %24
+  %NullCheck27 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %32
+
+; <label>:32                                      ; preds = %30
+  %33 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, i32 0, i32 2
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = icmp slt i32 %34, 0
+  br i1 %35, label %68, label %36
+
+; <label>:36                                      ; preds = %32
+  %37 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %38 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck29 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %39
+
+; <label>:39                                      ; preds = %36
+  %40 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, i32 0, i32 0
+  %41 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %40, align 8
+  %NullCheck31 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, i32 0, i32 2
+  %44 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %43, align 8
+  %45 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck33 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, i32 0, i32 2
+  %48 = load i32, i32 addrspace(1)* %47, align 8
+  %NullCheck35 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %49
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = zext i32 %51 to i64
+  %53 = zext i32 %48 to i64
+  %BoundsCheck37 = icmp uge i64 %53, %52
+  br i1 %BoundsCheck37, label %ThrowIndexOutOfRange38, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 3, i32 %48
+  %NullCheck39 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %56
+
+; <label>:56                                      ; preds = %54
+  %57 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, i32 0, i32 0
+  %58 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck41 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %59
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %60, %System.__Canon addrspace(1)* %58)
+  %61 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck43 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  %64 = load i32, i32 addrspace(1)* %63, align 8
+  %65 = add i32 %64, 1
+  %NullCheck45 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  store i32 %65, i32 addrspace(1)* %67
+  ret i8 1
+
+; <label>:68                                      ; preds = %32
+  %69 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck47 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %73 = add i32 %72, 1
+  %NullCheck49 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %74
+
+; <label>:74                                      ; preds = %70
+  %75 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  store i32 %73, i32 addrspace(1)* %75
+  br label %76
+
+; <label>:76                                      ; preds = %8, %12, %74
+  %77 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %78
+
+; <label>:78                                      ; preds = %76
+  %79 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, i32 0, i32 2
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck7 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %82
+
+; <label>:82                                      ; preds = %78
+  %83 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, i32 0, i32 0
+  %84 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %83, align 8
+  %NullCheck9 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %85
+
+; <label>:85                                      ; preds = %82
+  %86 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, i32 0, i32 7
+  %87 = load i32, i32 addrspace(1)* %86, align 8
+  %88 = icmp ult i32 %80, %87
+  br i1 %88, label %13, label %89
+
+; <label>:89                                      ; preds = %85
+  %90 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %91 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck11 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %92
+
+; <label>:92                                      ; preds = %89
+  %93 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, i32 0, i32 0
+  %94 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck13 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %95
+
+; <label>:95                                      ; preds = %92
+  %96 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, i32 0, i32 7
+  %97 = load i32, i32 addrspace(1)* %96, align 8
+  %98 = add i32 %97, 1
+  %NullCheck15 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %99
+
+; <label>:99                                      ; preds = %95
+  %100 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, i32 0, i32 2
+  store i32 %98, i32 addrspace(1)* %100
+  %101 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck17 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %102
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %103, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %92
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef22:                                   ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef24:                                   ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef26:                                   ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef28:                                   ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef30:                                   ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef32:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef34:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef36:                                   ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange38:                           ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef40:                                   ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef42:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef44:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef46:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef48:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef50:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -5200,8 +6368,8 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -5232,9 +6400,9 @@ Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
 Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
-Failed to read String.MakeSeparatorList[loadElemA]
+Failed to read String.MakeSeparatorList[storeElem]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
-Failed to read String.InternalSplitKeepEmptyEntries[loadElem]
+Failed to read String.InternalSplitKeepEmptyEntries[storeElem]
 INFO:  jitting method Path::IsRelative using LLILCJit
 Successfully read Path.IsRelative
 
@@ -5243,8 +6411,8 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -5254,8 +6422,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
@@ -5271,8 +6439,8 @@ entry:
 
 ; <label>:17                                      ; preds = %7
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
@@ -5288,8 +6456,8 @@ entry:
 
 ; <label>:29                                      ; preds = %19
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %31
 
 ; <label>:31                                      ; preds = %29
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
@@ -5300,8 +6468,8 @@ entry:
 
 ; <label>:36                                      ; preds = %31
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
-  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %37, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
@@ -5312,8 +6480,8 @@ entry:
 
 ; <label>:43                                      ; preds = %31, %38
   %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
-  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %45
 
 ; <label>:45                                      ; preds = %43
   %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
@@ -5324,8 +6492,8 @@ entry:
 
 ; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %50
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
@@ -5336,8 +6504,8 @@ entry:
 
 ; <label>:57                                      ; preds = %1, %7, %19, %45, %52
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
-  br i1 %NullCheck14, label %59, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %59
 
 ; <label>:59                                      ; preds = %57
   %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
@@ -5347,8 +6515,8 @@ entry:
 
 ; <label>:63                                      ; preds = %59
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
@@ -5359,8 +6527,8 @@ entry:
 
 ; <label>:70                                      ; preds = %65
   %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
-  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.String addrspace(1)* %71, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %72
 
 ; <label>:72                                      ; preds = %70
   %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
@@ -5379,39 +6547,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %17
+ThrowNullRef4:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %29
+ThrowNullRef6:                                    ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %36
+ThrowNullRef8:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %43
+ThrowNullRef10:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %50
+ThrowNullRef12:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %57
+ThrowNullRef14:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %63
+ThrowNullRef16:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %70
+ThrowNullRef18:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5419,7 +6587,293 @@ ThrowNullRef17:                                   ; preds = %70
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
-Failed to read String.TrimHelper[loadElem]
+Successfully read String.TrimHelper
+
+define %System.String addrspace(1)* @String.TrimHelper(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i16
+  %loc4 = alloca i32
+  %loc5 = alloca i16
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = sub i32 %3, 1
+  store i32 %4, i32* %loc0
+  store i32 0, i32* %loc1
+  %5 = load i32, i32* %arg2
+  %6 = icmp eq i32 %5, 1
+  br i1 %6, label %62, label %7
+
+; <label>:7                                       ; preds = %1
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:8                                       ; preds = %58
+  store i32 0, i32* %loc2
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load i32, i32* %loc1
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2, i32 %10
+  %13 = load i16, i16 addrspace(1)* %12
+  %14 = zext i16 %13 to i32
+  %15 = trunc i32 %14 to i16
+  store i16 %15, i16* %loc3
+  store i32 0, i32* %loc2
+  br label %34
+
+; <label>:16                                      ; preds = %37
+  %17 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %18 = load i32, i32* %loc2
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %17, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %19
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = zext i32 %18 to i64
+  %BoundsCheck = icmp uge i64 %23, %22
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %24
+
+; <label>:24                                      ; preds = %19
+  %25 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 3, i32 %18
+  %26 = load i16, i16 addrspace(1)* %25, align 8
+  %27 = zext i16 %26 to i32
+  %28 = load i16, i16* %loc3
+  %29 = zext i16 %28 to i32
+  %30 = icmp eq i32 %27, %29
+  br i1 %30, label %43, label %31
+
+; <label>:31                                      ; preds = %24
+  %32 = load i32, i32* %loc2
+  %33 = add i32 %32, 1
+  store i32 %33, i32* %loc2
+  br label %34
+
+; <label>:34                                      ; preds = %11, %31
+  %35 = load i32, i32* %loc2
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = icmp slt i32 %35, %41
+  br i1 %42, label %16, label %43
+
+; <label>:43                                      ; preds = %24, %37
+  %44 = load i32, i32* %loc2
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %45, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp eq i32 %44, %50
+  br i1 %51, label %62, label %52
+
+; <label>:52                                      ; preds = %46
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %7, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %57, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %58
+
+; <label>:58                                      ; preds = %55
+  %59 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %60 = load i32, i32 addrspace(1)* %59
+  %61 = icmp slt i32 %56, %60
+  br i1 %61, label %8, label %62
+
+; <label>:62                                      ; preds = %1, %46, %58
+  %63 = load i32, i32* %arg2
+  %64 = icmp eq i32 %63, 0
+  br i1 %64, label %122, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %66, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %67
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %66, i32 0, i32 1
+  %69 = load i32, i32 addrspace(1)* %68
+  %70 = sub i32 %69, 1
+  store i32 %70, i32* %loc0
+  br label %118
+
+; <label>:71                                      ; preds = %118
+  store i32 0, i32* %loc4
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %73 = load i32, i32* %loc0
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %74
+
+; <label>:74                                      ; preds = %71
+  %75 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 2, i32 %73
+  %76 = load i16, i16 addrspace(1)* %75
+  %77 = zext i16 %76 to i32
+  %78 = trunc i32 %77 to i16
+  store i16 %78, i16* %loc5
+  store i32 0, i32* %loc4
+  br label %97
+
+; <label>:79                                      ; preds = %100
+  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %81 = load i32, i32* %loc4
+  %NullCheck19 = icmp eq %"System.Char[]" addrspace(1)* %80, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
+
+; <label>:82                                      ; preds = %79
+  %83 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 1
+  %84 = load i32, i32 addrspace(1)* %83
+  %85 = zext i32 %84 to i64
+  %86 = zext i32 %81 to i64
+  %BoundsCheck21 = icmp uge i64 %86, %85
+  br i1 %BoundsCheck21, label %ThrowIndexOutOfRange22, label %87
+
+; <label>:87                                      ; preds = %82
+  %88 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 3, i32 %81
+  %89 = load i16, i16 addrspace(1)* %88, align 8
+  %90 = zext i16 %89 to i32
+  %91 = load i16, i16* %loc5
+  %92 = zext i16 %91 to i32
+  %93 = icmp eq i32 %90, %92
+  br i1 %93, label %106, label %94
+
+; <label>:94                                      ; preds = %87
+  %95 = load i32, i32* %loc4
+  %96 = add i32 %95, 1
+  store i32 %96, i32* %loc4
+  br label %97
+
+; <label>:97                                      ; preds = %74, %94
+  %98 = load i32, i32* %loc4
+  %99 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck15 = icmp eq %"System.Char[]" addrspace(1)* %99, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %100
+
+; <label>:100                                     ; preds = %97
+  %101 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %99, i32 0, i32 1
+  %102 = load i32, i32 addrspace(1)* %101
+  %103 = zext i32 %102 to i64
+  %104 = trunc i64 %103 to i32
+  %105 = icmp slt i32 %98, %104
+  br i1 %105, label %79, label %106
+
+; <label>:106                                     ; preds = %87, %100
+  %107 = load i32, i32* %loc4
+  %108 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck17 = icmp eq %"System.Char[]" addrspace(1)* %108, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %109
+
+; <label>:109                                     ; preds = %106
+  %110 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %108, i32 0, i32 1
+  %111 = load i32, i32 addrspace(1)* %110
+  %112 = zext i32 %111 to i64
+  %113 = trunc i64 %112 to i32
+  %114 = icmp eq i32 %107, %113
+  br i1 %114, label %122, label %115
+
+; <label>:115                                     ; preds = %109
+  %116 = load i32, i32* %loc0
+  %117 = sub i32 %116, 1
+  store i32 %117, i32* %loc0
+  br label %118
+
+; <label>:118                                     ; preds = %67, %115
+  %119 = load i32, i32* %loc0
+  %120 = load i32, i32* %loc1
+  %121 = icmp sge i32 %119, %120
+  br i1 %121, label %71, label %122
+
+; <label>:122                                     ; preds = %62, %109, %118
+  %123 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %124 = load i32, i32* %loc1
+  %125 = load i32, i32* %loc0
+  %126 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %123, i32 %124, i32 %125)
+  ret %System.String addrspace(1)* %126
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %97
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange22:                           ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
 Successfully read String.CreateTrimmedString
 
@@ -5439,8 +6893,8 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
@@ -5535,8 +6989,8 @@ entry:
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i64 2872
   %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
   %8 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %7
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %3
   %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
@@ -5553,8 +7007,8 @@ entry:
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 2864
   %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
   %21 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %20
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
-  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %22
 
 ; <label>:22                                      ; preds = %16
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
@@ -5569,7 +7023,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %16
+ThrowNullRef2:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5586,8 +7040,8 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5613,8 +7067,8 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
@@ -5632,8 +7086,8 @@ entry:
 
 ; <label>:12                                      ; preds = %4
   %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
@@ -5644,8 +7098,8 @@ entry:
 
 ; <label>:19                                      ; preds = %14
   %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %19
   %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
@@ -5660,21 +7114,21 @@ entry:
   %31 = zext i16 %30 to i32
   %32 = bitcast i8* %29 to i16*
   %33 = trunc i32 %31 to i16
-  %NullCheck6 = icmp ne i16* %32, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i16* %32, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %21
   store i16 %33, i16* %32, align 8
   %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %36
 
 ; <label>:36                                      ; preds = %34
   %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
   %38 = load i32, i32 addrspace(1)* %37, align 8
   %39 = add i32 %38, 1
-  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %40
 
 ; <label>:40                                      ; preds = %36
   %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
@@ -5683,16 +7137,16 @@ entry:
 
 ; <label>:42                                      ; preds = %14
   %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
-  br i1 %NullCheck12, label %44, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
   %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
   %47 = load i16, i16* %arg1
   %48 = zext i16 %47 to i32
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = trunc i32 %48 to i16
@@ -5703,31 +7157,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %19
+ThrowNullRef4:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %21
+ThrowNullRef6:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %36
+ThrowNullRef10:                                   ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %42
+ThrowNullRef12:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %44
+ThrowNullRef14:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5740,8 +7194,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -5752,8 +7206,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
@@ -5762,14 +7216,14 @@ entry:
 
 ; <label>:11                                      ; preds = %1
   %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
@@ -5779,15 +7233,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5808,8 +7262,8 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5822,8 +7276,8 @@ entry:
 
 ; <label>:8                                       ; preds = %3
   %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
@@ -5842,15 +7296,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
-  br i1 %NullCheck4, label %22, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
   %24 = load i16*, i16* addrspace(1)* %23, align 8
   %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %25, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
@@ -5859,8 +7313,8 @@ entry:
   store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
@@ -5874,8 +7328,8 @@ entry:
 
 ; <label>:37                                      ; preds = %65
   %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %37
   %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
@@ -5886,16 +7340,16 @@ entry:
   %45 = bitcast i16* %41 to i8*
   %46 = getelementptr inbounds i8, i8* %45, i64 %44
   %47 = bitcast i8* %46 to i16*
-  %NullCheck14 = icmp ne i16* %47, null
-  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %47, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %48
 
 ; <label>:48                                      ; preds = %39
   %49 = load i16, i16* %47, align 8
   %50 = zext i16 %49 to i32
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %52 = load i32, i32* %loc1
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %53
 
 ; <label>:53                                      ; preds = %48
   %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
@@ -5916,8 +7370,8 @@ entry:
 ; <label>:62                                      ; preds = %36, %59
   %63 = load i32, i32* %loc1
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck10, label %65, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %65
 
 ; <label>:65                                      ; preds = %62
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
@@ -5936,15 +7390,15 @@ entry:
 
 ; <label>:74                                      ; preds = %70
   %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
-  br i1 %NullCheck18, label %76, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %76
 
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
   %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
-  br i1 %NullCheck20, label %80, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
   %81 = load i64, i64 addrspace(1)* %79
@@ -5958,8 +7412,8 @@ entry:
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
   %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
-  br i1 %NullCheck22, label %92, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.String addrspace(1)* %90, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %92
 
 ; <label>:92                                      ; preds = %80
   %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
@@ -5969,15 +7423,15 @@ entry:
 
 ; <label>:96                                      ; preds = %70
   %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
-  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %98
 
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
   %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
-  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
   %103 = load i64, i64 addrspace(1)* %101
@@ -5991,8 +7445,8 @@ entry:
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
   %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
-  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.String addrspace(1)* %112, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %114
 
 ; <label>:114                                     ; preds = %102
   %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
@@ -6004,59 +7458,59 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %20
+ThrowNullRef4:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %22
+ThrowNullRef6:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %26
+ThrowNullRef8:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %62
+ThrowNullRef10:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %48
+ThrowNullRef16:                                   ; preds = %48
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %74
+ThrowNullRef18:                                   ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %76
+ThrowNullRef20:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %80
+ThrowNullRef22:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %96
+ThrowNullRef24:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %98
+ThrowNullRef26:                                   ; preds = %98
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %102
+ThrowNullRef28:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6069,15 +7523,15 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
   %3 = load i16*, i16* addrspace(1)* %2, align 8
   %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
@@ -6087,8 +7541,8 @@ entry:
   %10 = bitcast i16* %3 to i8*
   %11 = getelementptr inbounds i8, i8* %10, i64 %9
   %12 = bitcast i8* %11 to i16*
-  %NullCheck4 = icmp ne i16* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %5
   store i16 0, i16* %12, align 8
@@ -6098,11 +7552,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6119,8 +7573,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -6131,8 +7585,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
@@ -6144,15 +7598,15 @@ entry:
 
 ; <label>:14                                      ; preds = %1
   %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
   %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
   %21 = load i64, i64 addrspace(1)* %19
@@ -6171,15 +7625,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %14
+ThrowNullRef4:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %16
+ThrowNullRef6:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6302,14 +7756,6 @@ entry:
   ret %System.String addrspace(1)* %57
 }
 
-INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
-Successfully read RuntimeHelpers.get_OffsetToStringData
-
-define i32 @RuntimeHelpers.get_OffsetToStringData() {
-entry:
-  ret i32 12
-}
-
 INFO:  jitting method String::Equals using LLILCJit
 Successfully read String.Equals
 
@@ -6381,8 +7827,8 @@ entry:
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
-  br i1 %NullCheck24, label %29, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
   %30 = load i64, i64 addrspace(1)* %28
@@ -6397,8 +7843,8 @@ entry:
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
-  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
   %43 = load i64, i64 addrspace(1)* %41
@@ -6418,8 +7864,8 @@ entry:
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
   %59 = load i64, i64 addrspace(1)* %57
@@ -6434,8 +7880,8 @@ entry:
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck22, label %71, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
   %72 = load i64, i64 addrspace(1)* %70
@@ -6455,8 +7901,8 @@ entry:
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
-  br i1 %NullCheck16, label %87, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = load i64, i64 addrspace(1)* %86
@@ -6471,8 +7917,8 @@ entry:
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck18, label %100, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
   %101 = load i64, i64 addrspace(1)* %99
@@ -6492,8 +7938,8 @@ entry:
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
-  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
   %117 = load i64, i64 addrspace(1)* %115
@@ -6508,8 +7954,8 @@ entry:
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
-  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
   %130 = load i64, i64 addrspace(1)* %128
@@ -6528,15 +7974,15 @@ entry:
 
 ; <label>:142                                     ; preds = %22
   %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
-  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %143, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %144
 
 ; <label>:144                                     ; preds = %142
   %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
   %146 = load i32, i32 addrspace(1)* %145
   %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
-  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %147, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %148
 
 ; <label>:148                                     ; preds = %144
   %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
@@ -6557,15 +8003,15 @@ entry:
 
 ; <label>:159                                     ; preds = %22
   %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
-  br i1 %NullCheck, label %161, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %ThrowNullRef, label %161
 
 ; <label>:161                                     ; preds = %159
   %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
   %163 = load i32, i32 addrspace(1)* %162
   %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
-  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %164, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %165
 
 ; <label>:165                                     ; preds = %161
   %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
@@ -6578,8 +8024,8 @@ entry:
 
 ; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
-  br i1 %NullCheck4, label %172, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %171, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %172
 
 ; <label>:172                                     ; preds = %170
   %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
@@ -6589,8 +8035,8 @@ entry:
 
 ; <label>:176                                     ; preds = %172
   %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
-  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %177, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %178
 
 ; <label>:178                                     ; preds = %176
   %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
@@ -6629,55 +8075,55 @@ ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %161
+ThrowNullRef2:                                    ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %170
+ThrowNullRef4:                                    ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %176
+ThrowNullRef6:                                    ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %142
+ThrowNullRef8:                                    ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %144
+ThrowNullRef10:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %113
+ThrowNullRef12:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %116
+ThrowNullRef14:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %84
+ThrowNullRef16:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %87
+ThrowNullRef18:                                   ; preds = %87
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %55
+ThrowNullRef20:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %58
+ThrowNullRef22:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %26
+ThrowNullRef24:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %29
+ThrowNullRef26:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,8 +8161,8 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck, label %14, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %ThrowNullRef, label %14
 
 ; <label>:14                                      ; preds = %8
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
@@ -6760,8 +8206,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
@@ -6770,14 +8216,14 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32, i32* %loc0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %10
   %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
   %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
@@ -6790,15 +8236,15 @@ entry:
 ; <label>:25                                      ; preds = %19
   %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
-  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
   %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
@@ -6807,8 +8253,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %37 = load i32, i32* %loc0
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %38, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %38
 
 ; <label>:38                                      ; preds = %32
   %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
@@ -6817,14 +8263,14 @@ entry:
 
 ; <label>:40                                      ; preds = %19
   %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %40
   %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
   %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
-  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
-  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
@@ -6832,8 +8278,8 @@ entry:
   %48 = zext i32 %47 to i64
   %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
-  br i1 %NullCheck16, label %51, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %51
 
 ; <label>:51                                      ; preds = %45
   %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
@@ -6847,15 +8293,15 @@ entry:
 ; <label>:57                                      ; preds = %51
   %58 = load i16*, i16** %arg1
   %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
-  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %60
 
 ; <label>:60                                      ; preds = %57
   %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
   %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
-  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %64
 
 ; <label>:64                                      ; preds = %60
   %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
@@ -6864,22 +8310,22 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
   %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
-  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %70
 
 ; <label>:70                                      ; preds = %64
   %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
   %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
-  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
-  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
   %75 = load i32, i32 addrspace(1)* %74
   %76 = zext i32 %75 to i64
   %77 = trunc i64 %76 to i32
-  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
-  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %78
 
 ; <label>:78                                      ; preds = %73
   %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
@@ -6901,8 +8347,8 @@ entry:
   %90 = bitcast i16* %86 to i8*
   %91 = getelementptr inbounds i8, i8* %90, i64 %89
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %93
 
 ; <label>:93                                      ; preds = %80
   %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
@@ -6912,8 +8358,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %99 = load i32, i32* %loc2
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %100
 
 ; <label>:100                                     ; preds = %93
   %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
@@ -6928,63 +8374,63 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %25
+ThrowNullRef6:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %32
+ThrowNullRef10:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %40
+ThrowNullRef12:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %45
+ThrowNullRef16:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %57
+ThrowNullRef18:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %60
+ThrowNullRef20:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %64
+ThrowNullRef22:                                   ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %70
+ThrowNullRef24:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %73
+ThrowNullRef26:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %80
+ThrowNullRef28:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %93
+ThrowNullRef30:                                   ; preds = %93
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7004,8 +8450,8 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
@@ -7033,43 +8479,43 @@ entry:
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %14
   %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
   %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   %28 = load i32, i32 addrspace(1)* %27, align 8
   %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
-  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %30
 
 ; <label>:30                                      ; preds = %26
   %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
   %32 = load i32, i32 addrspace(1)* %31, align 8
   %33 = add i32 %28, %32
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %34
 
 ; <label>:34                                      ; preds = %30
   %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   store i32 %33, i32 addrspace(1)* %35
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
   store i32 0, i32 addrspace(1)* %38
   %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %40
 
 ; <label>:40                                      ; preds = %37
   %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
@@ -7082,8 +8528,8 @@ entry:
 
 ; <label>:47                                      ; preds = %40
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
@@ -7098,8 +8544,8 @@ entry:
   %54 = load i32, i32* %loc0
   %55 = sext i32 %54 to i64
   %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
-  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %57
 
 ; <label>:57                                      ; preds = %52
   %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
@@ -7110,68 +8556,35 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %14
+ThrowNullRef2:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %23
+ThrowNullRef4:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %26
+ThrowNullRef6:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %30
+ThrowNullRef8:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %34
+ThrowNullRef10:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %47
+ThrowNullRef14:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %52
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-}
-
-INFO:  jitting method StringBuilder::get_Length using LLILCJit
-Successfully read StringBuilder.get_Length
-
-define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.StringBuilder addrspace(1)*
-  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
-  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
-
-; <label>:1                                       ; preds = %entry
-  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %3 = load i32, i32 addrspace(1)* %2, align 8
-  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
-
-; <label>:5                                       ; preds = %1
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = add i32 %3, %7
-  ret i32 %8
-
-ThrowNullRef:                                     ; preds = %entry
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef16:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7213,70 +8626,70 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
   %6 = load i32, i32 addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
   store i32 %6, i32 addrspace(1)* %8
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
   %13 = load i32, i32 addrspace(1)* %12, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
   store i32 %13, i32 addrspace(1)* %15
   %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
-  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %18
 
 ; <label>:18                                      ; preds = %14
   %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
   %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
   %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
   %34 = load i32, i32 addrspace(1)* %33, align 8
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
-  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
@@ -7287,39 +8700,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %28
+ThrowNullRef16:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %32
+ThrowNullRef18:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7455,13 +8868,13 @@ entry:
 ; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
@@ -7477,16 +8890,16 @@ entry:
 
 ; <label>:18                                      ; preds = %15
   %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
   store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
   %22 = load i32, i32* %loc0
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %24
 
 ; <label>:24                                      ; preds = %20
   %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
@@ -7498,13 +8911,13 @@ entry:
 ; <label>:28                                      ; preds = %15, %24
   %29 = load i32, i32* %arg1
   %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %31
   %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
@@ -7517,20 +8930,20 @@ entry:
   %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
-  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
   %46 = load i32, i32 addrspace(1)* %45, align 8
   %47 = sub i32 %40, %46
-  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
-  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i32 addrspace(1)* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %48
 
 ; <label>:48                                      ; preds = %44
   store i32 %47, i32 addrspace(1)* %39, align 8
@@ -7538,21 +8951,21 @@ entry:
 
 ; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
-  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %51
 
 ; <label>:51                                      ; preds = %49
   %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %53
 
 ; <label>:53                                      ; preds = %51
   %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
   %55 = load i32, i32 addrspace(1)* %54, align 8
   %56 = load i32, i32* %arg2
   %57 = sub i32 %55, %56
-  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %58
 
 ; <label>:58                                      ; preds = %53
   %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
@@ -7562,13 +8975,13 @@ entry:
 ; <label>:60                                      ; preds = %33, %58
   %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
   %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
-  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %63
 
 ; <label>:63                                      ; preds = %60
   %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
-  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
-  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
@@ -7578,15 +8991,15 @@ entry:
 
 ; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
-  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i32 addrspace(1)* %69, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %70
 
 ; <label>:70                                      ; preds = %68
   %71 = load i32, i32 addrspace(1)* %69, align 8
   store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
-  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
@@ -7596,8 +9009,8 @@ entry:
   store i32 %77, i32* %loc4
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
-  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %80
 
 ; <label>:80                                      ; preds = %73
   %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
@@ -7607,71 +9020,71 @@ entry:
 ; <label>:83                                      ; preds = %80
   store i32 0, i32* %loc3
   %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
-  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
-  br i1 %NullCheck26, label %88, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i32 addrspace(1)* %87, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %88
 
 ; <label>:88                                      ; preds = %85
   %89 = load i32, i32 addrspace(1)* %87, align 8
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
-  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %90
 
 ; <label>:90                                      ; preds = %88
   %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
   store i32 %89, i32 addrspace(1)* %91
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
-  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
-  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %96
 
 ; <label>:96                                      ; preds = %94
   %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
-  br i1 %NullCheck34, label %100, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %100
 
 ; <label>:100                                     ; preds = %96
   %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
-  br i1 %NullCheck36, label %102, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %102
 
 ; <label>:102                                     ; preds = %100
   %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
   %104 = load i32, i32 addrspace(1)* %103, align 8
   %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
-  br i1 %NullCheck38, label %106, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %106
 
 ; <label>:106                                     ; preds = %102
   %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
-  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
-  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %108
 
 ; <label>:108                                     ; preds = %106
   %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
   %110 = load i32, i32 addrspace(1)* %109, align 8
   %111 = add i32 %104, %110
-  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %112
 
 ; <label>:112                                     ; preds = %108
   %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
   store i32 %111, i32 addrspace(1)* %113
   %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
-  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i32 addrspace(1)* %114, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %115
 
 ; <label>:115                                     ; preds = %112
   %116 = load i32, i32 addrspace(1)* %114, align 8
@@ -7681,19 +9094,19 @@ entry:
 ; <label>:118                                     ; preds = %115
   %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
-  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %121
 
 ; <label>:121                                     ; preds = %118
   %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
-  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
-  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %123
 
 ; <label>:123                                     ; preds = %121
   %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
   %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
-  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
-  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %126
 
 ; <label>:126                                     ; preds = %123
   %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
@@ -7705,8 +9118,8 @@ entry:
 
 ; <label>:130                                     ; preds = %80, %115, %126
   %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %132
 
 ; <label>:132                                     ; preds = %130
   %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7715,8 +9128,8 @@ entry:
   %136 = load i32, i32* %loc3
   %137 = sub i32 %135, %136
   %138 = sub i32 %134, %137
-  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %139
 
 ; <label>:139                                     ; preds = %132
   %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7728,16 +9141,16 @@ entry:
 
 ; <label>:144                                     ; preds = %139
   %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
-  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %146
 
 ; <label>:146                                     ; preds = %144
   %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
   %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
   %149 = load i32, i32* %loc2
   %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
-  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %151
 
 ; <label>:151                                     ; preds = %146
   %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
@@ -7754,145 +9167,249 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %18
+ThrowNullRef4:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %31
+ThrowNullRef10:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %44
+ThrowNullRef16:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %68
+ThrowNullRef18:                                   ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %70
+ThrowNullRef20:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %73
+ThrowNullRef22:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %83
+ThrowNullRef24:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %85
+ThrowNullRef26:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %88
+ThrowNullRef28:                                   ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %90
+ThrowNullRef30:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %94
+ThrowNullRef32:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %96
+ThrowNullRef34:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %100
+ThrowNullRef36:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %102
+ThrowNullRef38:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %106
+ThrowNullRef40:                                   ; preds = %106
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %108
+ThrowNullRef42:                                   ; preds = %108
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %112
+ThrowNullRef44:                                   ; preds = %112
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %118
+ThrowNullRef46:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %121
+ThrowNullRef48:                                   ; preds = %121
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %123
+ThrowNullRef50:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %130
+ThrowNullRef52:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %132
+ThrowNullRef54:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %144
+ThrowNullRef56:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %146
+ThrowNullRef58:                                   ; preds = %146
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %60
+ThrowNullRef60:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %63
+ThrowNullRef62:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %49
+ThrowNullRef64:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %51
+ThrowNullRef66:                                   ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %53
+ThrowNullRef68:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(%"System.Char[]" addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %arg0 = alloca %"System.Char[]" addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store %"System.Char[]" addrspace(1)* %param0, %"System.Char[]" addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load i32, i32* %arg4
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %43, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %38, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg1
+  %13 = load i32, i32* %arg4
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %38, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %24 = load i32, i32* %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %35 = load i32, i32* %arg3
+  %36 = load i32, i32* %arg4
+  %37 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %37, %"System.Char[]" addrspace(1)* %34, i32 %35, i32 %36)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:38                                      ; preds = %5, %16
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Successfully read Buffer._Memmove
 
@@ -7914,7 +9431,7 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[loadElem]
+Failed to read AppDomain.SetDataHelper[storeElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -7923,8 +9440,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
@@ -7934,8 +9451,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
@@ -7947,15 +9464,15 @@ entry:
   %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
   %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
@@ -7966,15 +9483,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7992,7 +9509,79 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
-Failed to read Dictionary`2.TryGetValue[loadElemA]
+Successfully read Dictionary`2.TryGetValue
+
+define i8 @"Dictionary`2.TryGetValue"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)* addrspace(1)* %param2) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  %arg2 = alloca %System.__Canon addrspace(1)* addrspace(1)*
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  store %System.__Canon addrspace(1)* addrspace(1)* %param2, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  store i32 %2, i32* %loc0
+  %3 = load i32, i32* %loc0
+  %4 = icmp slt i32 %3, 0
+  br i1 %4, label %22, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 2
+  %10 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %9, align 8
+  %11 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = zext i32 %11 to i64
+  %BoundsCheck = icmp uge i64 %16, %15
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 3, i32 %11
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %20, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %6, %System.__Canon addrspace(1)* %21)
+  ret i8 1
+
+; <label>:22                                      ; preds = %entry
+  %23 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %23, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -8058,8 +9647,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
@@ -8091,8 +9680,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
@@ -8171,15 +9760,15 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck, label %19, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %ThrowNullRef, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
   %21 = load i32, i32 addrspace(1)* %20
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
@@ -8202,7 +9791,7 @@ ThrowNullRef:                                     ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %19
+ThrowNullRef2:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8248,8 +9837,8 @@ entry:
   %0 = alloca %System.AppDomainHandle
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %1 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %1, i32 0, i32 15
@@ -8269,8 +9858,8 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
@@ -8286,7 +9875,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -8299,8 +9888,8 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -8327,8 +9916,8 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
@@ -8352,8 +9941,8 @@ entry:
   %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
   store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
@@ -8363,8 +9952,8 @@ entry:
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
@@ -8374,8 +9963,8 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %9
   %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
@@ -8384,8 +9973,8 @@ entry:
 
 ; <label>:18                                      ; preds = %3, %16
   %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
@@ -8397,15 +9986,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %18
+ThrowNullRef6:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8418,8 +10007,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
@@ -8453,15 +10042,15 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
@@ -8473,7 +10062,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8481,7 +10070,7 @@ ThrowNullRef1:                                    ; preds = %1
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
 Failed to read Dictionary`2.System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
@@ -8506,8 +10095,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
@@ -8524,8 +10113,8 @@ entry:
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -8544,7 +10133,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8577,8 +10166,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = load i64, i64* %arg2
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = trunc i32 %3 to i8
@@ -8634,46 +10223,46 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
   %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
-  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
-  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
-  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
@@ -8684,27 +10273,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %20
+ThrowNullRef12:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8717,8 +10306,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -8756,22 +10345,22 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
   %9 = load i64, i64 addrspace(1)* %8, align 8
   %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
   %13 = load i64, i64 addrspace(1)* %12, align 8
   %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %11
   %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
@@ -8788,11 +10377,11 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8882,8 +10471,8 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
@@ -8900,8 +10489,8 @@ entry:
 ; <label>:8                                       ; preds = %1
   %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
   %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
@@ -8911,15 +10500,15 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
   %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
   %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
-  br i1 %NullCheck6, label %21, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
@@ -8946,15 +10535,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8992,15 +10581,15 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
   store i8 %3, i8 addrspace(1)* %5
   %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
@@ -9011,7 +10600,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9027,8 +10616,8 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -9041,8 +10630,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
@@ -9058,7 +10647,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9080,8 +10669,8 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
@@ -9096,8 +10685,8 @@ entry:
 ; <label>:12                                      ; preds = %6
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
@@ -9112,8 +10701,8 @@ entry:
 ; <label>:21                                      ; preds = %15
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
@@ -9128,8 +10717,8 @@ entry:
 ; <label>:30                                      ; preds = %24
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %31, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
@@ -9144,8 +10733,8 @@ entry:
 ; <label>:39                                      ; preds = %33
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
-  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %40, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %42
 
 ; <label>:42                                      ; preds = %39
   %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
@@ -9164,19 +10753,19 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %21
+ThrowNullRef4:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %30
+ThrowNullRef6:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %39
+ThrowNullRef8:                                    ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9243,8 +10832,8 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
@@ -9264,57 +10853,57 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
   store i8 0, i8 addrspace(1)* %2
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
   store i8 0, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
   store i8 0, i8 addrspace(1)* %17
   %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
   store i8 0, i8 addrspace(1)* %20
   %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
-  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
@@ -9325,31 +10914,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %19
+ThrowNullRef14:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9367,8 +10956,8 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
@@ -9380,8 +10969,8 @@ entry:
 
 ; <label>:9                                       ; preds = %4
   %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %9
   %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
@@ -9395,7 +10984,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef2:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9420,8 +11009,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
@@ -9512,8 +11101,8 @@ entry:
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
@@ -9524,8 +11113,8 @@ entry:
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = load i64, i64 addrspace(1)* %12
@@ -9537,8 +11126,8 @@ entry:
   %20 = load i64, i64* %19
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
-  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %13
   %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
@@ -9555,8 +11144,8 @@ entry:
 ; <label>:30                                      ; preds = %25
   %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %32 = load i32, i32* %arg2
-  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
-  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
@@ -9570,15 +11159,15 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %30
+ThrowNullRef2:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9622,87 +11211,87 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
   %10 = load i8, i8 addrspace(1)* %9, align 8
   %11 = zext i8 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %8
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
   store i8 %12, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
   %19 = load i8, i8 addrspace(1)* %18, align 8
   %20 = zext i8 %19 to i32
   %21 = trunc i32 %20 to i8
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
   store i8 %21, i8 addrspace(1)* %23
   %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
   %28 = load i8, i8 addrspace(1)* %27, align 8
   %29 = zext i8 %28 to i32
   %30 = trunc i32 %29 to i8
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
-  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %31
 
 ; <label>:31                                      ; preds = %26
   %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
   store i8 %30, i8 addrspace(1)* %32
   %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
-  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
-  br i1 %NullCheck14, label %40, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %40
 
 ; <label>:40                                      ; preds = %35
   %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
   store i8 %39, i8 addrspace(1)* %41
   %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
-  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %44
 
 ; <label>:44                                      ; preds = %40
   %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
   %46 = load i8, i8 addrspace(1)* %45, align 8
   %47 = zext i8 %46 to i32
   %48 = trunc i32 %47 to i8
-  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
   store i8 %48, i8 addrspace(1)* %50
   %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
-  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
@@ -9713,29 +11302,29 @@ entry:
 ; <label>:56                                      ; preds = %52
   %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
-  br i1 %NullCheck22, label %59, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
   %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
   %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
-  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
-  br i1 %NullCheck24, label %63, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
   %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
-  br i1 %NullCheck26, label %66, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
   %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
-  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
-  br i1 %NullCheck28, label %69, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %69
 
 ; <label>:69                                      ; preds = %66
   %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
@@ -9744,15 +11333,15 @@ entry:
 
 ; <label>:71                                      ; preds = %105
   %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
-  br i1 %NullCheck34, label %73, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %73
 
 ; <label>:73                                      ; preds = %71
   %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
   %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
   %76 = load i32, i32* %loc0
-  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
-  br i1 %NullCheck36, label %77, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
@@ -9766,8 +11355,8 @@ entry:
 
 ; <label>:83                                      ; preds = %77
   %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
-  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
@@ -9775,14 +11364,14 @@ entry:
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
   %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
-  br i1 %NullCheck40, label %91, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
 ; <label>:91                                      ; preds = %85
   %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
   %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
-  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck42, label %94, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %94
 
 ; <label>:94                                      ; preds = %91
   %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
@@ -9798,14 +11387,14 @@ entry:
 ; <label>:99                                      ; preds = %69, %96
   %100 = load i32, i32* %loc0
   %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
-  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %102
 
 ; <label>:102                                     ; preds = %99
   %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
   %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
-  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
-  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
@@ -9819,87 +11408,87 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %26
+ThrowNullRef10:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %31
+ThrowNullRef12:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %35
+ThrowNullRef14:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %40
+ThrowNullRef16:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %56
+ThrowNullRef22:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %59
+ThrowNullRef24:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %63
+ThrowNullRef26:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %66
+ThrowNullRef28:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %102
+ThrowNullRef32:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %71
+ThrowNullRef34:                                   ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %73
+ThrowNullRef36:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %83
+ThrowNullRef38:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %85
+ThrowNullRef40:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %91
+ThrowNullRef42:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9943,15 +11532,15 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
   %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
@@ -9961,28 +11550,28 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
   %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %12
   %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
   %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
   %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
-  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
@@ -9993,23 +11582,23 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %12
+ThrowNullRef6:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10031,15 +11620,15 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
   %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = load i64, i64 addrspace(1)* %7
@@ -10077,13 +11666,13 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[loadElem]
+Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -10111,8 +11700,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1

--- a/test/BaseLine/JIT/CodeGenBringUpTests/OrRef.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/OrRef.error.txt
@@ -25,8 +25,8 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
@@ -40,8 +40,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
   %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
@@ -75,7 +75,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -90,8 +90,8 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %NullCheck = icmp ne i8 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = load i8, i8 addrspace(1)* %0, align 8
@@ -125,8 +125,8 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
@@ -159,8 +159,8 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -184,8 +184,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
   store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
@@ -195,8 +195,8 @@ entry:
 ; <label>:4                                       ; preds = %1
   %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
   %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
@@ -206,8 +206,8 @@ entry:
   %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
@@ -221,14 +221,14 @@ entry:
 
 ; <label>:17                                      ; preds = %14
   %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
   %21 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
@@ -238,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -249,8 +249,8 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
@@ -261,27 +261,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %30
+ThrowNullRef10:                                   ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -301,7 +301,89 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
-Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
+Successfully read AppDomainSetup.GetUnsecureApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.GetUnsecureApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %NullCheck = icmp eq %"System.String[]" addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %BoundsCheck = icmp uge i64 0, %5
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %6
+
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 3, i32 0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
+  ret %System.String addrspace(1)* %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_Value using LLILCJit
+Successfully read AppDomainSetup.get_Value
+
+define %"System.String[]" addrspace(1)* @AppDomainSetup.get_Value(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.String[]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 18)
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.String[]" addrspace(1)* addrspace(1)*, %"System.String[]" addrspace(1)*)*)(%"System.String[]" addrspace(1)* addrspace(1)* %9, %"System.String[]" addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %11, i32 0, i32 1
+  %14 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %13, align 8
+  ret %"System.String[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -319,8 +401,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -368,16 +450,16 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
   %5 = load i32, i32 addrspace(1)* %4
   %6 = sub i32 %5, 1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -389,7 +471,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -421,8 +503,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
@@ -456,8 +538,8 @@ entry:
 ; <label>:27                                      ; preds = %19
   %28 = load i32, i32* %arg1
   %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
-  br i1 %NullCheck2, label %30, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %29, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %30
 
 ; <label>:30                                      ; preds = %27
   %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
@@ -493,8 +575,8 @@ entry:
 ; <label>:49                                      ; preds = %46
   %50 = load i32, i32* %arg2
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck4, label %52, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
@@ -517,11 +599,11 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %27
+ThrowNullRef2:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %49
+ThrowNullRef4:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -544,16 +626,16 @@ entry:
   %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %0)
   store %System.String addrspace(1)* %1, %System.String addrspace(1)** %loc0
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 2
   %5 = bitcast [0 x i16] addrspace(1)* %4 to i16 addrspace(1)*
   store i16 addrspace(1)* %5, i16 addrspace(1)** %loc1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %3
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2
@@ -580,7 +662,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -691,15 +773,15 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %NullCheck132 = icmp ne i8* %21, null
-  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+  %NullCheck131 = icmp eq i8* %21, null
+  br i1 %NullCheck131, label %ThrowNullRef132, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = load i8, i8* %21, align 8
   %24 = zext i8 %23 to i32
   %25 = trunc i32 %24 to i8
-  %NullCheck134 = icmp ne i8* %20, null
-  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+  %NullCheck133 = icmp eq i8* %20, null
+  br i1 %NullCheck133, label %ThrowNullRef134, label %26
 
 ; <label>:26                                      ; preds = %22
   store i8 %25, i8* %20, align 8
@@ -709,16 +791,16 @@ entry:
   %28 = load i8*, i8** %arg0
   %29 = load i8*, i8** %arg1
   %30 = bitcast i8* %29 to i16*
-  %NullCheck128 = icmp ne i16* %30, null
-  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+  %NullCheck127 = icmp eq i16* %30, null
+  br i1 %NullCheck127, label %ThrowNullRef128, label %31
 
 ; <label>:31                                      ; preds = %27
   %32 = load i16, i16* %30, align 8
   %33 = sext i16 %32 to i32
   %34 = bitcast i8* %28 to i16*
   %35 = trunc i32 %33 to i16
-  %NullCheck130 = icmp ne i16* %34, null
-  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+  %NullCheck129 = icmp eq i16* %34, null
+  br i1 %NullCheck129, label %ThrowNullRef130, label %36
 
 ; <label>:36                                      ; preds = %31
   store i16 %35, i16* %34, align 8
@@ -728,16 +810,16 @@ entry:
   %38 = load i8*, i8** %arg0
   %39 = load i8*, i8** %arg1
   %40 = bitcast i8* %39 to i16*
-  %NullCheck120 = icmp ne i16* %40, null
-  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+  %NullCheck119 = icmp eq i16* %40, null
+  br i1 %NullCheck119, label %ThrowNullRef120, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i16, i16* %40, align 8
   %43 = sext i16 %42 to i32
   %44 = bitcast i8* %38 to i16*
   %45 = trunc i32 %43 to i16
-  %NullCheck122 = icmp ne i16* %44, null
-  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+  %NullCheck121 = icmp eq i16* %44, null
+  br i1 %NullCheck121, label %ThrowNullRef122, label %46
 
 ; <label>:46                                      ; preds = %41
   store i16 %45, i16* %44, align 8
@@ -745,15 +827,15 @@ entry:
   %48 = getelementptr inbounds i8, i8* %47, i64 2
   %49 = load i8*, i8** %arg1
   %50 = getelementptr inbounds i8, i8* %49, i64 2
-  %NullCheck124 = icmp ne i8* %50, null
-  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+  %NullCheck123 = icmp eq i8* %50, null
+  br i1 %NullCheck123, label %ThrowNullRef124, label %51
 
 ; <label>:51                                      ; preds = %46
   %52 = load i8, i8* %50, align 8
   %53 = zext i8 %52 to i32
   %54 = trunc i32 %53 to i8
-  %NullCheck126 = icmp ne i8* %48, null
-  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+  %NullCheck125 = icmp eq i8* %48, null
+  br i1 %NullCheck125, label %ThrowNullRef126, label %55
 
 ; <label>:55                                      ; preds = %51
   store i8 %54, i8* %48, align 8
@@ -763,14 +845,14 @@ entry:
   %57 = load i8*, i8** %arg0
   %58 = load i8*, i8** %arg1
   %59 = bitcast i8* %58 to i32*
-  %NullCheck116 = icmp ne i32* %59, null
-  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+  %NullCheck115 = icmp eq i32* %59, null
+  br i1 %NullCheck115, label %ThrowNullRef116, label %60
 
 ; <label>:60                                      ; preds = %56
   %61 = load i32, i32* %59, align 8
   %62 = bitcast i8* %57 to i32*
-  %NullCheck118 = icmp ne i32* %62, null
-  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+  %NullCheck117 = icmp eq i32* %62, null
+  br i1 %NullCheck117, label %ThrowNullRef118, label %63
 
 ; <label>:63                                      ; preds = %60
   store i32 %61, i32* %62, align 8
@@ -780,14 +862,14 @@ entry:
   %65 = load i8*, i8** %arg0
   %66 = load i8*, i8** %arg1
   %67 = bitcast i8* %66 to i32*
-  %NullCheck108 = icmp ne i32* %67, null
-  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+  %NullCheck107 = icmp eq i32* %67, null
+  br i1 %NullCheck107, label %ThrowNullRef108, label %68
 
 ; <label>:68                                      ; preds = %64
   %69 = load i32, i32* %67, align 8
   %70 = bitcast i8* %65 to i32*
-  %NullCheck110 = icmp ne i32* %70, null
-  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+  %NullCheck109 = icmp eq i32* %70, null
+  br i1 %NullCheck109, label %ThrowNullRef110, label %71
 
 ; <label>:71                                      ; preds = %68
   store i32 %69, i32* %70, align 8
@@ -795,15 +877,15 @@ entry:
   %73 = getelementptr inbounds i8, i8* %72, i64 4
   %74 = load i8*, i8** %arg1
   %75 = getelementptr inbounds i8, i8* %74, i64 4
-  %NullCheck112 = icmp ne i8* %75, null
-  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+  %NullCheck111 = icmp eq i8* %75, null
+  br i1 %NullCheck111, label %ThrowNullRef112, label %76
 
 ; <label>:76                                      ; preds = %71
   %77 = load i8, i8* %75, align 8
   %78 = zext i8 %77 to i32
   %79 = trunc i32 %78 to i8
-  %NullCheck114 = icmp ne i8* %73, null
-  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+  %NullCheck113 = icmp eq i8* %73, null
+  br i1 %NullCheck113, label %ThrowNullRef114, label %80
 
 ; <label>:80                                      ; preds = %76
   store i8 %79, i8* %73, align 8
@@ -813,14 +895,14 @@ entry:
   %82 = load i8*, i8** %arg0
   %83 = load i8*, i8** %arg1
   %84 = bitcast i8* %83 to i32*
-  %NullCheck100 = icmp ne i32* %84, null
-  br i1 %NullCheck100, label %85, label %ThrowNullRef99
+  %NullCheck99 = icmp eq i32* %84, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %85
 
 ; <label>:85                                      ; preds = %81
   %86 = load i32, i32* %84, align 8
   %87 = bitcast i8* %82 to i32*
-  %NullCheck102 = icmp ne i32* %87, null
-  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+  %NullCheck101 = icmp eq i32* %87, null
+  br i1 %NullCheck101, label %ThrowNullRef102, label %88
 
 ; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
@@ -829,16 +911,16 @@ entry:
   %91 = load i8*, i8** %arg1
   %92 = getelementptr inbounds i8, i8* %91, i64 4
   %93 = bitcast i8* %92 to i16*
-  %NullCheck104 = icmp ne i16* %93, null
-  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+  %NullCheck103 = icmp eq i16* %93, null
+  br i1 %NullCheck103, label %ThrowNullRef104, label %94
 
 ; <label>:94                                      ; preds = %88
   %95 = load i16, i16* %93, align 8
   %96 = sext i16 %95 to i32
   %97 = bitcast i8* %90 to i16*
   %98 = trunc i32 %96 to i16
-  %NullCheck106 = icmp ne i16* %97, null
-  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+  %NullCheck105 = icmp eq i16* %97, null
+  br i1 %NullCheck105, label %ThrowNullRef106, label %99
 
 ; <label>:99                                      ; preds = %94
   store i16 %98, i16* %97, align 8
@@ -848,14 +930,14 @@ entry:
   %101 = load i8*, i8** %arg0
   %102 = load i8*, i8** %arg1
   %103 = bitcast i8* %102 to i32*
-  %NullCheck88 = icmp ne i32* %103, null
-  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+  %NullCheck87 = icmp eq i32* %103, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %104
 
 ; <label>:104                                     ; preds = %100
   %105 = load i32, i32* %103, align 8
   %106 = bitcast i8* %101 to i32*
-  %NullCheck90 = icmp ne i32* %106, null
-  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+  %NullCheck89 = icmp eq i32* %106, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %107
 
 ; <label>:107                                     ; preds = %104
   store i32 %105, i32* %106, align 8
@@ -864,16 +946,16 @@ entry:
   %110 = load i8*, i8** %arg1
   %111 = getelementptr inbounds i8, i8* %110, i64 4
   %112 = bitcast i8* %111 to i16*
-  %NullCheck92 = icmp ne i16* %112, null
-  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+  %NullCheck91 = icmp eq i16* %112, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %113
 
 ; <label>:113                                     ; preds = %107
   %114 = load i16, i16* %112, align 8
   %115 = sext i16 %114 to i32
   %116 = bitcast i8* %109 to i16*
   %117 = trunc i32 %115 to i16
-  %NullCheck94 = icmp ne i16* %116, null
-  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+  %NullCheck93 = icmp eq i16* %116, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %118
 
 ; <label>:118                                     ; preds = %113
   store i16 %117, i16* %116, align 8
@@ -881,15 +963,15 @@ entry:
   %120 = getelementptr inbounds i8, i8* %119, i64 6
   %121 = load i8*, i8** %arg1
   %122 = getelementptr inbounds i8, i8* %121, i64 6
-  %NullCheck96 = icmp ne i8* %122, null
-  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+  %NullCheck95 = icmp eq i8* %122, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %123
 
 ; <label>:123                                     ; preds = %118
   %124 = load i8, i8* %122, align 8
   %125 = zext i8 %124 to i32
   %126 = trunc i32 %125 to i8
-  %NullCheck98 = icmp ne i8* %120, null
-  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+  %NullCheck97 = icmp eq i8* %120, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %127
 
 ; <label>:127                                     ; preds = %123
   store i8 %126, i8* %120, align 8
@@ -899,14 +981,14 @@ entry:
   %129 = load i8*, i8** %arg0
   %130 = load i8*, i8** %arg1
   %131 = bitcast i8* %130 to i64*
-  %NullCheck84 = icmp ne i64* %131, null
-  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+  %NullCheck83 = icmp eq i64* %131, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %132
 
 ; <label>:132                                     ; preds = %128
   %133 = load i64, i64* %131, align 8
   %134 = bitcast i8* %129 to i64*
-  %NullCheck86 = icmp ne i64* %134, null
-  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+  %NullCheck85 = icmp eq i64* %134, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %135
 
 ; <label>:135                                     ; preds = %132
   store i64 %133, i64* %134, align 8
@@ -916,14 +998,14 @@ entry:
   %137 = load i8*, i8** %arg0
   %138 = load i8*, i8** %arg1
   %139 = bitcast i8* %138 to i64*
-  %NullCheck76 = icmp ne i64* %139, null
-  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+  %NullCheck75 = icmp eq i64* %139, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %140
 
 ; <label>:140                                     ; preds = %136
   %141 = load i64, i64* %139, align 8
   %142 = bitcast i8* %137 to i64*
-  %NullCheck78 = icmp ne i64* %142, null
-  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+  %NullCheck77 = icmp eq i64* %142, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %143
 
 ; <label>:143                                     ; preds = %140
   store i64 %141, i64* %142, align 8
@@ -931,15 +1013,15 @@ entry:
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %NullCheck80 = icmp ne i8* %147, null
-  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+  %NullCheck79 = icmp eq i8* %147, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %148
 
 ; <label>:148                                     ; preds = %143
   %149 = load i8, i8* %147, align 8
   %150 = zext i8 %149 to i32
   %151 = trunc i32 %150 to i8
-  %NullCheck82 = icmp ne i8* %145, null
-  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+  %NullCheck81 = icmp eq i8* %145, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %152
 
 ; <label>:152                                     ; preds = %148
   store i8 %151, i8* %145, align 8
@@ -949,14 +1031,14 @@ entry:
   %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
   %156 = bitcast i8* %155 to i64*
-  %NullCheck68 = icmp ne i64* %156, null
-  br i1 %NullCheck68, label %157, label %ThrowNullRef67
+  %NullCheck67 = icmp eq i64* %156, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %157
 
 ; <label>:157                                     ; preds = %153
   %158 = load i64, i64* %156, align 8
   %159 = bitcast i8* %154 to i64*
-  %NullCheck70 = icmp ne i64* %159, null
-  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+  %NullCheck69 = icmp eq i64* %159, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %160
 
 ; <label>:160                                     ; preds = %157
   store i64 %158, i64* %159, align 8
@@ -965,16 +1047,16 @@ entry:
   %163 = load i8*, i8** %arg1
   %164 = getelementptr inbounds i8, i8* %163, i64 8
   %165 = bitcast i8* %164 to i16*
-  %NullCheck72 = icmp ne i16* %165, null
-  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+  %NullCheck71 = icmp eq i16* %165, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %166
 
 ; <label>:166                                     ; preds = %160
   %167 = load i16, i16* %165, align 8
   %168 = sext i16 %167 to i32
   %169 = bitcast i8* %162 to i16*
   %170 = trunc i32 %168 to i16
-  %NullCheck74 = icmp ne i16* %169, null
-  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+  %NullCheck73 = icmp eq i16* %169, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %171
 
 ; <label>:171                                     ; preds = %166
   store i16 %170, i16* %169, align 8
@@ -984,14 +1066,14 @@ entry:
   %173 = load i8*, i8** %arg0
   %174 = load i8*, i8** %arg1
   %175 = bitcast i8* %174 to i64*
-  %NullCheck56 = icmp ne i64* %175, null
-  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+  %NullCheck55 = icmp eq i64* %175, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %176
 
 ; <label>:176                                     ; preds = %172
   %177 = load i64, i64* %175, align 8
   %178 = bitcast i8* %173 to i64*
-  %NullCheck58 = icmp ne i64* %178, null
-  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+  %NullCheck57 = icmp eq i64* %178, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %179
 
 ; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
@@ -1000,16 +1082,16 @@ entry:
   %182 = load i8*, i8** %arg1
   %183 = getelementptr inbounds i8, i8* %182, i64 8
   %184 = bitcast i8* %183 to i16*
-  %NullCheck60 = icmp ne i16* %184, null
-  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+  %NullCheck59 = icmp eq i16* %184, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %185
 
 ; <label>:185                                     ; preds = %179
   %186 = load i16, i16* %184, align 8
   %187 = sext i16 %186 to i32
   %188 = bitcast i8* %181 to i16*
   %189 = trunc i32 %187 to i16
-  %NullCheck62 = icmp ne i16* %188, null
-  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+  %NullCheck61 = icmp eq i16* %188, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %190
 
 ; <label>:190                                     ; preds = %185
   store i16 %189, i16* %188, align 8
@@ -1017,15 +1099,15 @@ entry:
   %192 = getelementptr inbounds i8, i8* %191, i64 10
   %193 = load i8*, i8** %arg1
   %194 = getelementptr inbounds i8, i8* %193, i64 10
-  %NullCheck64 = icmp ne i8* %194, null
-  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+  %NullCheck63 = icmp eq i8* %194, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %195
 
 ; <label>:195                                     ; preds = %190
   %196 = load i8, i8* %194, align 8
   %197 = zext i8 %196 to i32
   %198 = trunc i32 %197 to i8
-  %NullCheck66 = icmp ne i8* %192, null
-  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+  %NullCheck65 = icmp eq i8* %192, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %199
 
 ; <label>:199                                     ; preds = %195
   store i8 %198, i8* %192, align 8
@@ -1035,14 +1117,14 @@ entry:
   %201 = load i8*, i8** %arg0
   %202 = load i8*, i8** %arg1
   %203 = bitcast i8* %202 to i64*
-  %NullCheck48 = icmp ne i64* %203, null
-  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+  %NullCheck47 = icmp eq i64* %203, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %204
 
 ; <label>:204                                     ; preds = %200
   %205 = load i64, i64* %203, align 8
   %206 = bitcast i8* %201 to i64*
-  %NullCheck50 = icmp ne i64* %206, null
-  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+  %NullCheck49 = icmp eq i64* %206, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %207
 
 ; <label>:207                                     ; preds = %204
   store i64 %205, i64* %206, align 8
@@ -1051,14 +1133,14 @@ entry:
   %210 = load i8*, i8** %arg1
   %211 = getelementptr inbounds i8, i8* %210, i64 8
   %212 = bitcast i8* %211 to i32*
-  %NullCheck52 = icmp ne i32* %212, null
-  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+  %NullCheck51 = icmp eq i32* %212, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %213
 
 ; <label>:213                                     ; preds = %207
   %214 = load i32, i32* %212, align 8
   %215 = bitcast i8* %209 to i32*
-  %NullCheck54 = icmp ne i32* %215, null
-  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+  %NullCheck53 = icmp eq i32* %215, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %216
 
 ; <label>:216                                     ; preds = %213
   store i32 %214, i32* %215, align 8
@@ -1068,14 +1150,14 @@ entry:
   %218 = load i8*, i8** %arg0
   %219 = load i8*, i8** %arg1
   %220 = bitcast i8* %219 to i64*
-  %NullCheck36 = icmp ne i64* %220, null
-  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64* %220, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %221
 
 ; <label>:221                                     ; preds = %217
   %222 = load i64, i64* %220, align 8
   %223 = bitcast i8* %218 to i64*
-  %NullCheck38 = icmp ne i64* %223, null
-  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+  %NullCheck37 = icmp eq i64* %223, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %224
 
 ; <label>:224                                     ; preds = %221
   store i64 %222, i64* %223, align 8
@@ -1084,14 +1166,14 @@ entry:
   %227 = load i8*, i8** %arg1
   %228 = getelementptr inbounds i8, i8* %227, i64 8
   %229 = bitcast i8* %228 to i32*
-  %NullCheck40 = icmp ne i32* %229, null
-  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i32* %229, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %230
 
 ; <label>:230                                     ; preds = %224
   %231 = load i32, i32* %229, align 8
   %232 = bitcast i8* %226 to i32*
-  %NullCheck42 = icmp ne i32* %232, null
-  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+  %NullCheck41 = icmp eq i32* %232, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %233
 
 ; <label>:233                                     ; preds = %230
   store i32 %231, i32* %232, align 8
@@ -1099,15 +1181,15 @@ entry:
   %235 = getelementptr inbounds i8, i8* %234, i64 12
   %236 = load i8*, i8** %arg1
   %237 = getelementptr inbounds i8, i8* %236, i64 12
-  %NullCheck44 = icmp ne i8* %237, null
-  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i8* %237, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %238
 
 ; <label>:238                                     ; preds = %233
   %239 = load i8, i8* %237, align 8
   %240 = zext i8 %239 to i32
   %241 = trunc i32 %240 to i8
-  %NullCheck46 = icmp ne i8* %235, null
-  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+  %NullCheck45 = icmp eq i8* %235, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %242
 
 ; <label>:242                                     ; preds = %238
   store i8 %241, i8* %235, align 8
@@ -1117,14 +1199,14 @@ entry:
   %244 = load i8*, i8** %arg0
   %245 = load i8*, i8** %arg1
   %246 = bitcast i8* %245 to i64*
-  %NullCheck24 = icmp ne i64* %246, null
-  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64* %246, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %247
 
 ; <label>:247                                     ; preds = %243
   %248 = load i64, i64* %246, align 8
   %249 = bitcast i8* %244 to i64*
-  %NullCheck26 = icmp ne i64* %249, null
-  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64* %249, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %250
 
 ; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
@@ -1133,14 +1215,14 @@ entry:
   %253 = load i8*, i8** %arg1
   %254 = getelementptr inbounds i8, i8* %253, i64 8
   %255 = bitcast i8* %254 to i32*
-  %NullCheck28 = icmp ne i32* %255, null
-  br i1 %NullCheck28, label %256, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i32* %255, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %256
 
 ; <label>:256                                     ; preds = %250
   %257 = load i32, i32* %255, align 8
   %258 = bitcast i8* %252 to i32*
-  %NullCheck30 = icmp ne i32* %258, null
-  br i1 %NullCheck30, label %259, label %ThrowNullRef29
+  %NullCheck29 = icmp eq i32* %258, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %259
 
 ; <label>:259                                     ; preds = %256
   store i32 %257, i32* %258, align 8
@@ -1149,16 +1231,16 @@ entry:
   %262 = load i8*, i8** %arg1
   %263 = getelementptr inbounds i8, i8* %262, i64 12
   %264 = bitcast i8* %263 to i16*
-  %NullCheck32 = icmp ne i16* %264, null
-  br i1 %NullCheck32, label %265, label %ThrowNullRef31
+  %NullCheck31 = icmp eq i16* %264, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %265
 
 ; <label>:265                                     ; preds = %259
   %266 = load i16, i16* %264, align 8
   %267 = sext i16 %266 to i32
   %268 = bitcast i8* %261 to i16*
   %269 = trunc i32 %267 to i16
-  %NullCheck34 = icmp ne i16* %268, null
-  br i1 %NullCheck34, label %270, label %ThrowNullRef33
+  %NullCheck33 = icmp eq i16* %268, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %270
 
 ; <label>:270                                     ; preds = %265
   store i16 %269, i16* %268, align 8
@@ -1168,14 +1250,14 @@ entry:
   %272 = load i8*, i8** %arg0
   %273 = load i8*, i8** %arg1
   %274 = bitcast i8* %273 to i64*
-  %NullCheck8 = icmp ne i64* %274, null
-  br i1 %NullCheck8, label %275, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64* %274, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %275
 
 ; <label>:275                                     ; preds = %271
   %276 = load i64, i64* %274, align 8
   %277 = bitcast i8* %272 to i64*
-  %NullCheck10 = icmp ne i64* %277, null
-  br i1 %NullCheck10, label %278, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %277, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %278
 
 ; <label>:278                                     ; preds = %275
   store i64 %276, i64* %277, align 8
@@ -1184,14 +1266,14 @@ entry:
   %281 = load i8*, i8** %arg1
   %282 = getelementptr inbounds i8, i8* %281, i64 8
   %283 = bitcast i8* %282 to i32*
-  %NullCheck12 = icmp ne i32* %283, null
-  br i1 %NullCheck12, label %284, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i32* %283, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %284
 
 ; <label>:284                                     ; preds = %278
   %285 = load i32, i32* %283, align 8
   %286 = bitcast i8* %280 to i32*
-  %NullCheck14 = icmp ne i32* %286, null
-  br i1 %NullCheck14, label %287, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i32* %286, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %287
 
 ; <label>:287                                     ; preds = %284
   store i32 %285, i32* %286, align 8
@@ -1200,16 +1282,16 @@ entry:
   %290 = load i8*, i8** %arg1
   %291 = getelementptr inbounds i8, i8* %290, i64 12
   %292 = bitcast i8* %291 to i16*
-  %NullCheck16 = icmp ne i16* %292, null
-  br i1 %NullCheck16, label %293, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i16* %292, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %293
 
 ; <label>:293                                     ; preds = %287
   %294 = load i16, i16* %292, align 8
   %295 = sext i16 %294 to i32
   %296 = bitcast i8* %289 to i16*
   %297 = trunc i32 %295 to i16
-  %NullCheck18 = icmp ne i16* %296, null
-  br i1 %NullCheck18, label %298, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i16* %296, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %298
 
 ; <label>:298                                     ; preds = %293
   store i16 %297, i16* %296, align 8
@@ -1217,15 +1299,15 @@ entry:
   %300 = getelementptr inbounds i8, i8* %299, i64 14
   %301 = load i8*, i8** %arg1
   %302 = getelementptr inbounds i8, i8* %301, i64 14
-  %NullCheck20 = icmp ne i8* %302, null
-  br i1 %NullCheck20, label %303, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i8* %302, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %303
 
 ; <label>:303                                     ; preds = %298
   %304 = load i8, i8* %302, align 8
   %305 = zext i8 %304 to i32
   %306 = trunc i32 %305 to i8
-  %NullCheck22 = icmp ne i8* %300, null
-  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i8* %300, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %307
 
 ; <label>:307                                     ; preds = %303
   store i8 %306, i8* %300, align 8
@@ -1235,14 +1317,14 @@ entry:
   %309 = load i8*, i8** %arg0
   %310 = load i8*, i8** %arg1
   %311 = bitcast i8* %310 to i64*
-  %NullCheck = icmp ne i64* %311, null
-  br i1 %NullCheck, label %312, label %ThrowNullRef
+  %NullCheck = icmp eq i64* %311, null
+  br i1 %NullCheck, label %ThrowNullRef, label %312
 
 ; <label>:312                                     ; preds = %308
   %313 = load i64, i64* %311, align 8
   %314 = bitcast i8* %309 to i64*
-  %NullCheck2 = icmp ne i64* %314, null
-  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64* %314, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %315
 
 ; <label>:315                                     ; preds = %312
   store i64 %313, i64* %314, align 8
@@ -1251,14 +1333,14 @@ entry:
   %318 = load i8*, i8** %arg1
   %319 = getelementptr inbounds i8, i8* %318, i64 8
   %320 = bitcast i8* %319 to i64*
-  %NullCheck4 = icmp ne i64* %320, null
-  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64* %320, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %321
 
 ; <label>:321                                     ; preds = %315
   %322 = load i64, i64* %320, align 8
   %323 = bitcast i8* %317 to i64*
-  %NullCheck6 = icmp ne i64* %323, null
-  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64* %323, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %324
 
 ; <label>:324                                     ; preds = %321
   store i64 %322, i64* %323, align 8
@@ -1286,15 +1368,15 @@ entry:
 ; <label>:338                                     ; preds = %333
   %339 = load i8*, i8** %arg0
   %340 = load i8*, i8** %arg1
-  %NullCheck136 = icmp ne i8* %340, null
-  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+  %NullCheck135 = icmp eq i8* %340, null
+  br i1 %NullCheck135, label %ThrowNullRef136, label %341
 
 ; <label>:341                                     ; preds = %338
   %342 = load i8, i8* %340, align 8
   %343 = zext i8 %342 to i32
   %344 = trunc i32 %343 to i8
-  %NullCheck138 = icmp ne i8* %339, null
-  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+  %NullCheck137 = icmp eq i8* %339, null
+  br i1 %NullCheck137, label %ThrowNullRef138, label %345
 
 ; <label>:345                                     ; preds = %341
   store i8 %344, i8* %339, align 8
@@ -1317,16 +1399,16 @@ entry:
   %357 = load i8*, i8** %arg0
   %358 = load i8*, i8** %arg1
   %359 = bitcast i8* %358 to i16*
-  %NullCheck140 = icmp ne i16* %359, null
-  br i1 %NullCheck140, label %360, label %ThrowNullRef139
+  %NullCheck139 = icmp eq i16* %359, null
+  br i1 %NullCheck139, label %ThrowNullRef140, label %360
 
 ; <label>:360                                     ; preds = %356
   %361 = load i16, i16* %359, align 8
   %362 = sext i16 %361 to i32
   %363 = bitcast i8* %357 to i16*
   %364 = trunc i32 %362 to i16
-  %NullCheck142 = icmp ne i16* %363, null
-  br i1 %NullCheck142, label %365, label %ThrowNullRef141
+  %NullCheck141 = icmp eq i16* %363, null
+  br i1 %NullCheck141, label %ThrowNullRef142, label %365
 
 ; <label>:365                                     ; preds = %360
   store i16 %364, i16* %363, align 8
@@ -1352,14 +1434,14 @@ entry:
   %378 = load i8*, i8** %arg0
   %379 = load i8*, i8** %arg1
   %380 = bitcast i8* %379 to i32*
-  %NullCheck144 = icmp ne i32* %380, null
-  br i1 %NullCheck144, label %381, label %ThrowNullRef143
+  %NullCheck143 = icmp eq i32* %380, null
+  br i1 %NullCheck143, label %ThrowNullRef144, label %381
 
 ; <label>:381                                     ; preds = %377
   %382 = load i32, i32* %380, align 8
   %383 = bitcast i8* %378 to i32*
-  %NullCheck146 = icmp ne i32* %383, null
-  br i1 %NullCheck146, label %384, label %ThrowNullRef145
+  %NullCheck145 = icmp eq i32* %383, null
+  br i1 %NullCheck145, label %ThrowNullRef146, label %384
 
 ; <label>:384                                     ; preds = %381
   store i32 %382, i32* %383, align 8
@@ -1384,14 +1466,14 @@ entry:
   %395 = load i8*, i8** %arg0
   %396 = load i8*, i8** %arg1
   %397 = bitcast i8* %396 to i64*
-  %NullCheck164 = icmp ne i64* %397, null
-  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+  %NullCheck163 = icmp eq i64* %397, null
+  br i1 %NullCheck163, label %ThrowNullRef164, label %398
 
 ; <label>:398                                     ; preds = %394
   %399 = load i64, i64* %397, align 8
   %400 = bitcast i8* %395 to i64*
-  %NullCheck166 = icmp ne i64* %400, null
-  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+  %NullCheck165 = icmp eq i64* %400, null
+  br i1 %NullCheck165, label %ThrowNullRef166, label %401
 
 ; <label>:401                                     ; preds = %398
   store i64 %399, i64* %400, align 8
@@ -1400,14 +1482,14 @@ entry:
   %404 = load i8*, i8** %arg1
   %405 = getelementptr inbounds i8, i8* %404, i64 8
   %406 = bitcast i8* %405 to i64*
-  %NullCheck168 = icmp ne i64* %406, null
-  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+  %NullCheck167 = icmp eq i64* %406, null
+  br i1 %NullCheck167, label %ThrowNullRef168, label %407
 
 ; <label>:407                                     ; preds = %401
   %408 = load i64, i64* %406, align 8
   %409 = bitcast i8* %403 to i64*
-  %NullCheck170 = icmp ne i64* %409, null
-  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+  %NullCheck169 = icmp eq i64* %409, null
+  br i1 %NullCheck169, label %ThrowNullRef170, label %410
 
 ; <label>:410                                     ; preds = %407
   store i64 %408, i64* %409, align 8
@@ -1437,14 +1519,14 @@ entry:
   %425 = load i8*, i8** %arg0
   %426 = load i8*, i8** %arg1
   %427 = bitcast i8* %426 to i64*
-  %NullCheck148 = icmp ne i64* %427, null
-  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+  %NullCheck147 = icmp eq i64* %427, null
+  br i1 %NullCheck147, label %ThrowNullRef148, label %428
 
 ; <label>:428                                     ; preds = %424
   %429 = load i64, i64* %427, align 8
   %430 = bitcast i8* %425 to i64*
-  %NullCheck150 = icmp ne i64* %430, null
-  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+  %NullCheck149 = icmp eq i64* %430, null
+  br i1 %NullCheck149, label %ThrowNullRef150, label %431
 
 ; <label>:431                                     ; preds = %428
   store i64 %429, i64* %430, align 8
@@ -1466,14 +1548,14 @@ entry:
   %441 = load i8*, i8** %arg0
   %442 = load i8*, i8** %arg1
   %443 = bitcast i8* %442 to i32*
-  %NullCheck152 = icmp ne i32* %443, null
-  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+  %NullCheck151 = icmp eq i32* %443, null
+  br i1 %NullCheck151, label %ThrowNullRef152, label %444
 
 ; <label>:444                                     ; preds = %440
   %445 = load i32, i32* %443, align 8
   %446 = bitcast i8* %441 to i32*
-  %NullCheck154 = icmp ne i32* %446, null
-  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+  %NullCheck153 = icmp eq i32* %446, null
+  br i1 %NullCheck153, label %ThrowNullRef154, label %447
 
 ; <label>:447                                     ; preds = %444
   store i32 %445, i32* %446, align 8
@@ -1495,16 +1577,16 @@ entry:
   %457 = load i8*, i8** %arg0
   %458 = load i8*, i8** %arg1
   %459 = bitcast i8* %458 to i16*
-  %NullCheck156 = icmp ne i16* %459, null
-  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+  %NullCheck155 = icmp eq i16* %459, null
+  br i1 %NullCheck155, label %ThrowNullRef156, label %460
 
 ; <label>:460                                     ; preds = %456
   %461 = load i16, i16* %459, align 8
   %462 = sext i16 %461 to i32
   %463 = bitcast i8* %457 to i16*
   %464 = trunc i32 %462 to i16
-  %NullCheck158 = icmp ne i16* %463, null
-  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+  %NullCheck157 = icmp eq i16* %463, null
+  br i1 %NullCheck157, label %ThrowNullRef158, label %465
 
 ; <label>:465                                     ; preds = %460
   store i16 %464, i16* %463, align 8
@@ -1525,15 +1607,15 @@ entry:
 ; <label>:474                                     ; preds = %470
   %475 = load i8*, i8** %arg0
   %476 = load i8*, i8** %arg1
-  %NullCheck160 = icmp ne i8* %476, null
-  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+  %NullCheck159 = icmp eq i8* %476, null
+  br i1 %NullCheck159, label %ThrowNullRef160, label %477
 
 ; <label>:477                                     ; preds = %474
   %478 = load i8, i8* %476, align 8
   %479 = zext i8 %478 to i32
   %480 = trunc i32 %479 to i8
-  %NullCheck162 = icmp ne i8* %475, null
-  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+  %NullCheck161 = icmp eq i8* %475, null
+  br i1 %NullCheck161, label %ThrowNullRef162, label %481
 
 ; <label>:481                                     ; preds = %477
   store i8 %480, i8* %475, align 8
@@ -1553,343 +1635,343 @@ ThrowNullRef:                                     ; preds = %308
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %312
+ThrowNullRef2:                                    ; preds = %312
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %315
+ThrowNullRef4:                                    ; preds = %315
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %321
+ThrowNullRef6:                                    ; preds = %321
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %271
+ThrowNullRef8:                                    ; preds = %271
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %275
+ThrowNullRef10:                                   ; preds = %275
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %278
+ThrowNullRef12:                                   ; preds = %278
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %284
+ThrowNullRef14:                                   ; preds = %284
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %287
+ThrowNullRef16:                                   ; preds = %287
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %293
+ThrowNullRef18:                                   ; preds = %293
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %298
+ThrowNullRef20:                                   ; preds = %298
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %303
+ThrowNullRef22:                                   ; preds = %303
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %243
+ThrowNullRef24:                                   ; preds = %243
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %247
+ThrowNullRef26:                                   ; preds = %247
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %250
+ThrowNullRef28:                                   ; preds = %250
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %256
+ThrowNullRef30:                                   ; preds = %256
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %259
+ThrowNullRef32:                                   ; preds = %259
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %265
+ThrowNullRef34:                                   ; preds = %265
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %217
+ThrowNullRef36:                                   ; preds = %217
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %221
+ThrowNullRef38:                                   ; preds = %221
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %224
+ThrowNullRef40:                                   ; preds = %224
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %230
+ThrowNullRef42:                                   ; preds = %230
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %233
+ThrowNullRef44:                                   ; preds = %233
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %238
+ThrowNullRef46:                                   ; preds = %238
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %200
+ThrowNullRef48:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %204
+ThrowNullRef50:                                   ; preds = %204
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %207
+ThrowNullRef52:                                   ; preds = %207
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %213
+ThrowNullRef54:                                   ; preds = %213
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %172
+ThrowNullRef56:                                   ; preds = %172
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %176
+ThrowNullRef58:                                   ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %179
+ThrowNullRef60:                                   ; preds = %179
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %185
+ThrowNullRef62:                                   ; preds = %185
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %190
+ThrowNullRef64:                                   ; preds = %190
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %195
+ThrowNullRef66:                                   ; preds = %195
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %153
+ThrowNullRef68:                                   ; preds = %153
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %157
+ThrowNullRef70:                                   ; preds = %157
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %160
+ThrowNullRef72:                                   ; preds = %160
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %166
+ThrowNullRef74:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %136
+ThrowNullRef76:                                   ; preds = %136
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %140
+ThrowNullRef78:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %143
+ThrowNullRef80:                                   ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %148
+ThrowNullRef82:                                   ; preds = %148
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %128
+ThrowNullRef84:                                   ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %132
+ThrowNullRef86:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %100
+ThrowNullRef88:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %104
+ThrowNullRef90:                                   ; preds = %104
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %107
+ThrowNullRef92:                                   ; preds = %107
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %113
+ThrowNullRef94:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %118
+ThrowNullRef96:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %123
+ThrowNullRef98:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %81
+ThrowNullRef100:                                  ; preds = %81
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef101:                                  ; preds = %85
+ThrowNullRef102:                                  ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef103:                                  ; preds = %88
+ThrowNullRef104:                                  ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef105:                                  ; preds = %94
+ThrowNullRef106:                                  ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef107:                                  ; preds = %64
+ThrowNullRef108:                                  ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef109:                                  ; preds = %68
+ThrowNullRef110:                                  ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef111:                                  ; preds = %71
+ThrowNullRef112:                                  ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef113:                                  ; preds = %76
+ThrowNullRef114:                                  ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef115:                                  ; preds = %56
+ThrowNullRef116:                                  ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef117:                                  ; preds = %60
+ThrowNullRef118:                                  ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef119:                                  ; preds = %37
+ThrowNullRef120:                                  ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef121:                                  ; preds = %41
+ThrowNullRef122:                                  ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef123:                                  ; preds = %46
+ThrowNullRef124:                                  ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef125:                                  ; preds = %51
+ThrowNullRef126:                                  ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef127:                                  ; preds = %27
+ThrowNullRef128:                                  ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef129:                                  ; preds = %31
+ThrowNullRef130:                                  ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef131:                                  ; preds = %19
+ThrowNullRef132:                                  ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef133:                                  ; preds = %22
+ThrowNullRef134:                                  ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef135:                                  ; preds = %338
+ThrowNullRef136:                                  ; preds = %338
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef137:                                  ; preds = %341
+ThrowNullRef138:                                  ; preds = %341
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef139:                                  ; preds = %356
+ThrowNullRef140:                                  ; preds = %356
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef141:                                  ; preds = %360
+ThrowNullRef142:                                  ; preds = %360
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef143:                                  ; preds = %377
+ThrowNullRef144:                                  ; preds = %377
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef145:                                  ; preds = %381
+ThrowNullRef146:                                  ; preds = %381
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef147:                                  ; preds = %424
+ThrowNullRef148:                                  ; preds = %424
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef149:                                  ; preds = %428
+ThrowNullRef150:                                  ; preds = %428
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef151:                                  ; preds = %440
+ThrowNullRef152:                                  ; preds = %440
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef153:                                  ; preds = %444
+ThrowNullRef154:                                  ; preds = %444
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef155:                                  ; preds = %456
+ThrowNullRef156:                                  ; preds = %456
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef157:                                  ; preds = %460
+ThrowNullRef158:                                  ; preds = %460
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef159:                                  ; preds = %474
+ThrowNullRef160:                                  ; preds = %474
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef161:                                  ; preds = %477
+ThrowNullRef162:                                  ; preds = %477
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef163:                                  ; preds = %394
+ThrowNullRef164:                                  ; preds = %394
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef165:                                  ; preds = %398
+ThrowNullRef166:                                  ; preds = %398
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef167:                                  ; preds = %401
+ThrowNullRef168:                                  ; preds = %401
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef169:                                  ; preds = %407
+ThrowNullRef170:                                  ; preds = %407
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1939,8 +2021,8 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
-  br i1 %NullCheck, label %22, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %ThrowNullRef, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
@@ -1948,8 +2030,8 @@ entry:
   store i32 %24, i32* %loc0
   %25 = load i32, i32* %loc0
   %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %26, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %27
 
 ; <label>:27                                      ; preds = %22
   %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
@@ -1971,7 +2053,7 @@ ThrowNullRef:                                     ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1989,8 +2071,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -2022,15 +2104,15 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2048,16 +2130,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
   %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
   store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %15
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
@@ -2072,8 +2154,8 @@ entry:
   %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
   %29 = ptrtoint i16 addrspace(1)* %28 to i64
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %19
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
@@ -2089,19 +2171,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2114,8 +2196,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
@@ -2128,7 +2210,7 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[loadElem]
+Failed to read AppDomain.PrepareDataForSetup[storeElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
@@ -2202,8 +2284,8 @@ entry:
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
-  br i1 %NullCheck24, label %27, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = load i64, i64 addrspace(1)* %26
@@ -2218,8 +2300,8 @@ entry:
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
-  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
   %41 = load i64, i64 addrspace(1)* %39
@@ -2236,8 +2318,8 @@ entry:
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
-  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
   %54 = load i64, i64 addrspace(1)* %52
@@ -2252,8 +2334,8 @@ entry:
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
   %67 = load i64, i64 addrspace(1)* %65
@@ -2270,8 +2352,8 @@ entry:
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
-  br i1 %NullCheck16, label %79, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
   %80 = load i64, i64 addrspace(1)* %78
@@ -2286,8 +2368,8 @@ entry:
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
-  br i1 %NullCheck18, label %92, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
   %93 = load i64, i64 addrspace(1)* %91
@@ -2304,8 +2386,8 @@ entry:
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
-  br i1 %NullCheck12, label %105, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = load i64, i64 addrspace(1)* %104
@@ -2320,8 +2402,8 @@ entry:
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
-  br i1 %NullCheck14, label %118, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
   %119 = load i64, i64 addrspace(1)* %117
@@ -2337,8 +2419,8 @@ entry:
 
 ; <label>:128                                     ; preds = %20
   %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
-  br i1 %NullCheck4, label %130, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %129, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %130
 
 ; <label>:130                                     ; preds = %128
   %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
@@ -2346,8 +2428,8 @@ entry:
   %133 = load i16, i16 addrspace(1)* %132, align 8
   %134 = zext i16 %133 to i32
   %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
-  br i1 %NullCheck6, label %136, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %135, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %136
 
 ; <label>:136                                     ; preds = %130
   %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
@@ -2360,8 +2442,8 @@ entry:
 
 ; <label>:143                                     ; preds = %136
   %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
-  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %144, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %145
 
 ; <label>:145                                     ; preds = %143
   %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
@@ -2369,8 +2451,8 @@ entry:
   %148 = load i16, i16 addrspace(1)* %147, align 8
   %149 = zext i16 %148 to i32
   %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %150, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %151
 
 ; <label>:151                                     ; preds = %145
   %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
@@ -2388,8 +2470,8 @@ entry:
 
 ; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
-  br i1 %NullCheck, label %163, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %ThrowNullRef, label %163
 
 ; <label>:163                                     ; preds = %161
   %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
@@ -2399,8 +2481,8 @@ entry:
 
 ; <label>:167                                     ; preds = %163
   %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
-  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %168, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %169
 
 ; <label>:169                                     ; preds = %167
   %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
@@ -2432,55 +2514,55 @@ ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %167
+ThrowNullRef2:                                    ; preds = %167
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %128
+ThrowNullRef4:                                    ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %130
+ThrowNullRef6:                                    ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %143
+ThrowNullRef8:                                    ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %145
+ThrowNullRef10:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %102
+ThrowNullRef12:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %105
+ThrowNullRef14:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %76
+ThrowNullRef16:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %79
+ThrowNullRef18:                                   ; preds = %79
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %50
+ThrowNullRef20:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %53
+ThrowNullRef22:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %24
+ThrowNullRef24:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %27
+ThrowNullRef26:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2503,15 +2585,15 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2519,16 +2601,16 @@ entry:
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
   store i32 %8, i32* %loc0
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
   %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
   store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
@@ -2546,16 +2628,16 @@ entry:
 
 ; <label>:23                                      ; preds = %64
   %24 = load i16*, i16** %loc3
-  %NullCheck12 = icmp ne i16* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i16* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
   store i32 %27, i32* %loc5
   %28 = load i16*, i16** %loc4
-  %NullCheck14 = icmp ne i16* %28, null
-  br i1 %NullCheck14, label %29, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %28, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = load i16, i16* %28, align 8
@@ -2620,15 +2702,15 @@ entry:
 
 ; <label>:67                                      ; preds = %64
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
-  br i1 %NullCheck8, label %69, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %68, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %69
 
 ; <label>:69                                      ; preds = %67
   %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
   %71 = load i32, i32 addrspace(1)* %70
   %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
-  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %73
 
 ; <label>:73                                      ; preds = %69
   %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
@@ -2645,31 +2727,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %67
+ThrowNullRef8:                                    ; preds = %67
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %69
+ThrowNullRef10:                                   ; preds = %69
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2710,14 +2792,14 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
   %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
@@ -2730,14 +2812,14 @@ entry:
 
 ; <label>:11                                      ; preds = %4
   %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
   %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
@@ -2749,14 +2831,14 @@ entry:
 
 ; <label>:22                                      ; preds = %16
   %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
   %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
-  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
-  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
@@ -2804,23 +2886,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2836,7 +2918,280 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[loadElem]
+Successfully read RuntimeType.IsAssignableFrom
+
+define i8 @RuntimeType.IsAssignableFrom(%System.RuntimeType addrspace(1)* %param0, %System.Type addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.RuntimeType addrspace(1)*
+  %arg1 = alloca %System.Type addrspace(1)*
+  %loc0 = alloca %System.RuntimeType addrspace(1)*
+  %loc1 = alloca %"System.Type[]" addrspace(1)*
+  %loc2 = alloca i32
+  store %System.RuntimeType addrspace(1)* %param0, %System.RuntimeType addrspace(1)** %this
+  store %System.Type addrspace(1)* %param1, %System.Type addrspace(1)** %arg1
+  %0 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %1 = icmp ne %System.Type addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i8 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %5 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %6 = bitcast %System.Type addrspace(1)* %4 to %System.Object addrspace(1)*
+  %7 = bitcast %System.RuntimeType addrspace(1)* %5 to %System.Object addrspace(1)*
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %6, %System.Object addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %3
+  ret i8 1
+
+; <label>:12                                      ; preds = %3
+  %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 152
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 32
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
+  %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
+  %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
+  store %System.RuntimeType addrspace(1)* %25, %System.RuntimeType addrspace(1)** %loc0
+  %26 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %27 = icmp eq %System.RuntimeType addrspace(1)* %26, null
+  br i1 %27, label %34, label %28
+
+; <label>:28                                      ; preds = %15
+  %29 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %30 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)*)*)(%System.RuntimeType addrspace(1)* %29, %System.RuntimeType addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+; <label>:34                                      ; preds = %15
+  %35 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %36 = call %System.Reflection.Emit.TypeBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Reflection.Emit.TypeBuilder addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %35)
+  %37 = icmp eq %System.Reflection.Emit.TypeBuilder addrspace(1)* %36, null
+  br i1 %37, label %139, label %38
+
+; <label>:38                                      ; preds = %34
+  %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %42
+
+; <label>:42                                      ; preds = %38
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 152
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 40
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
+  %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
+  %53 = zext i8 %52 to i32
+  %54 = icmp eq i32 %53, 0
+  br i1 %54, label %56, label %55
+
+; <label>:55                                      ; preds = %42
+  ret i8 1
+
+; <label>:56                                      ; preds = %42
+  %57 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %58 = bitcast %System.RuntimeType addrspace(1)* %57 to %System.Type addrspace(1)*
+  %59 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %58)
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %64 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.Type addrspace(1)* %63, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = bitcast %System.RuntimeType addrspace(1)* %64 to %System.Type addrspace(1)*
+  %67 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %63, %System.Type addrspace(1)* %66)
+  %68 = zext i8 %67 to i32
+  %69 = trunc i32 %68 to i8
+  ret i8 %69
+
+; <label>:70                                      ; preds = %56
+  %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
+  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %73
+
+; <label>:73                                      ; preds = %70
+  %74 = load i64, i64 addrspace(1)* %72
+  %75 = add i64 %74, 128
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = add i64 %77, 0
+  %79 = inttoptr i64 %78 to i64*
+  %80 = load i64, i64* %79
+  %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
+  %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
+  %83 = call i8 %82(%System.Type addrspace(1)* %81)
+  %84 = zext i8 %83 to i32
+  %85 = icmp eq i32 %84, 0
+  br i1 %85, label %139, label %86
+
+; <label>:86                                      ; preds = %73
+  %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
+  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %89
+
+; <label>:89                                      ; preds = %86
+  %90 = load i64, i64 addrspace(1)* %88
+  %91 = add i64 %90, 128
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = add i64 %93, 24
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
+  %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
+  %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
+  store %"System.Type[]" addrspace(1)* %99, %"System.Type[]" addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %129
+
+; <label>:100                                     ; preds = %132
+  %101 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %102 = load i32, i32* %loc2
+  %NullCheck11 = icmp eq %"System.Type[]" addrspace(1)* %101, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %103
+
+; <label>:103                                     ; preds = %100
+  %104 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 1
+  %105 = load i32, i32 addrspace(1)* %104
+  %106 = zext i32 %105 to i64
+  %107 = zext i32 %102 to i64
+  %BoundsCheck = icmp uge i64 %107, %106
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %108
+
+; <label>:108                                     ; preds = %103
+  %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
+  %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
+  %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
+  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %113
+
+; <label>:113                                     ; preds = %108
+  %114 = load i64, i64 addrspace(1)* %112
+  %115 = add i64 %114, 152
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = add i64 %117, 56
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
+  %123 = zext i8 %122 to i32
+  %124 = icmp ne i32 %123, 0
+  br i1 %124, label %126, label %125
+
+; <label>:125                                     ; preds = %113
+  ret i8 0
+
+; <label>:126                                     ; preds = %113
+  %127 = load i32, i32* %loc2
+  %128 = add i32 %127, 1
+  store i32 %128, i32* %loc2
+  br label %129
+
+; <label>:129                                     ; preds = %89, %126
+  %130 = load i32, i32* %loc2
+  %131 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %NullCheck9 = icmp eq %"System.Type[]" addrspace(1)* %131, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %132
+
+; <label>:132                                     ; preds = %129
+  %133 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %131, i32 0, i32 1
+  %134 = load i32, i32 addrspace(1)* %133
+  %135 = zext i32 %134 to i64
+  %136 = trunc i64 %135 to i32
+  %137 = icmp slt i32 %130, %136
+  br i1 %137, label %100, label %138
+
+; <label>:138                                     ; preds = %132
+  ret i8 1
+
+; <label>:139                                     ; preds = %34, %73
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %129
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %103
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -2893,7 +3248,7 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElem]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -2904,8 +3259,8 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -2997,8 +3352,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
@@ -3059,8 +3414,8 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -3087,8 +3442,8 @@ entry:
 
 ; <label>:17                                      ; preds = %5, %11
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
@@ -3097,8 +3452,8 @@ entry:
 
 ; <label>:22                                      ; preds = %1, %11
   %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
@@ -3109,11 +3464,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %17
+ThrowNullRef2:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %22
+ThrowNullRef4:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3167,15 +3522,15 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
   %15 = load i32, i32 addrspace(1)* %14
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
@@ -3198,7 +3553,7 @@ ThrowNullRef:                                     ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef2:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3232,8 +3587,8 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
@@ -3312,8 +3667,8 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -3327,8 +3682,8 @@ entry:
 ; <label>:5                                       ; preds = %43
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %7 = load i32, i32* %loc1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck6, label %8, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
@@ -3366,8 +3721,8 @@ entry:
 ; <label>:32                                      ; preds = %21, %25
   %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
   %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
-  br i1 %NullCheck8, label %35, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = trunc i32 %34 to i16
@@ -3380,8 +3735,8 @@ entry:
 ; <label>:40                                      ; preds = %1, %35
   %41 = load i32, i32* %loc1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
-  br i1 %NullCheck2, label %43, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %42, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
@@ -3392,8 +3747,8 @@ entry:
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
   %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
-  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
   %51 = load i64, i64 addrspace(1)* %49
@@ -3412,19 +3767,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %40
+ThrowNullRef2:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %47
+ThrowNullRef4:                                    ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %5
+ThrowNullRef6:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %32
+ThrowNullRef8:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3467,8 +3822,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
@@ -3492,11 +3847,391 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(i16* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store i16* %param0, i16** %arg0
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load i32, i32* %arg3
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %42, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %37, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg2
+  %13 = load i32, i32* %arg3
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %37, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %24 = load i32, i32* %arg2
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load i16*, i16** %arg0
+  %35 = load i32, i32* %arg3
+  %36 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %36, i16* %34, i32 %35)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:37                                      ; preds = %5, %16
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %39)
+  %41 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41, %System.String addrspace(1)* %38, %System.String addrspace(1)* %40)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41) #0
+  unreachable
+
+; <label>:42                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
-Failed to read StringBuilder.ToString[loadElemA]
+Successfully read StringBuilder.ToString
+
+define %System.String addrspace(1)* @StringBuilder.ToString(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i16*
+  %loc3 = alloca %"System.Char[]" addrspace(1)*
+  %loc4 = alloca i32
+  %loc5 = alloca i32
+  %loc6 = alloca i16 addrspace(1)*
+  %loc7 = alloca %System.String addrspace(1)*
+  %loc8 = alloca %"System.Char[]" addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %0)
+  %2 = icmp ne i32 %1, 0
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %4
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %6)
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %7)
+  store %System.String addrspace(1)* %8, %System.String addrspace(1)** %loc0
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.Text.StringBuilder addrspace(1)* %9, %System.Text.StringBuilder addrspace(1)** %loc1
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  store %System.String addrspace(1)* %10, %System.String addrspace(1)** %loc7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc7
+  %12 = ptrtoint %System.String addrspace(1)* %11 to i64
+  %13 = icmp eq i64 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %5
+  %15 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %16 = sext i32 %15 to i64
+  %17 = add i64 %12, %16
+  br label %18
+
+; <label>:18                                      ; preds = %5, %14
+  %19 = phi i64 [ %12, %5 ], [ %17, %14 ]
+  %20 = inttoptr i64 %19 to i16*
+  store i16* %20, i16** %loc2
+  br label %21
+
+; <label>:21                                      ; preds = %98, %18
+  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %22, null
+  br i1 %NullCheck, label %ThrowNullRef, label %23
+
+; <label>:23                                      ; preds = %21
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 3
+  %25 = load i32, i32 addrspace(1)* %24, align 8
+  %26 = icmp sle i32 %25, 0
+  br i1 %26, label %96, label %27
+
+; <label>:27                                      ; preds = %23
+  %28 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %28, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %29
+
+; <label>:29                                      ; preds = %27
+  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %28, i32 0, i32 1
+  %31 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %30, align 8
+  store %"System.Char[]" addrspace(1)* %31, %"System.Char[]" addrspace(1)** %loc3
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %33
+
+; <label>:33                                      ; preds = %29
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  store i32 %35, i32* %loc4
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  %39 = load i32, i32 addrspace(1)* %38, align 8
+  store i32 %39, i32* %loc5
+  %40 = load i32, i32* %loc5
+  %41 = load i32, i32* %loc4
+  %42 = add i32 %40, %41
+  %43 = zext i32 %42 to i64
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %45
+
+; <label>:45                                      ; preds = %37
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = sext i32 %47 to i64
+  %49 = icmp sgt i64 %43, %48
+  br i1 %49, label %91, label %50
+
+; <label>:50                                      ; preds = %45
+  %51 = load i32, i32* %loc5
+  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %52, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %53
+
+; <label>:53                                      ; preds = %50
+  %54 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %52, i32 0, i32 1
+  %55 = load i32, i32 addrspace(1)* %54
+  %56 = zext i32 %55 to i64
+  %57 = trunc i64 %56 to i32
+  %58 = icmp ugt i32 %51, %57
+  br i1 %58, label %91, label %59
+
+; <label>:59                                      ; preds = %53
+  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  store %"System.Char[]" addrspace(1)* %60, %"System.Char[]" addrspace(1)** %loc8
+  %61 = icmp eq %"System.Char[]" addrspace(1)* %60, null
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %63, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %64
+
+; <label>:64                                      ; preds = %62
+  %65 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %63, i32 0, i32 1
+  %66 = load i32, i32 addrspace(1)* %65
+  %67 = zext i32 %66 to i64
+  %68 = trunc i64 %67 to i32
+  %69 = icmp ne i32 %68, 0
+  br i1 %69, label %71, label %70
+
+; <label>:70                                      ; preds = %59, %64
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:71                                      ; preds = %64
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %73
+
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %BoundsCheck = icmp uge i64 0, %76
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %77
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %78, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:79                                      ; preds = %70, %77
+  %80 = load i16*, i16** %loc2
+  %81 = load i32, i32* %loc4
+  %82 = sext i32 %81 to i64
+  %83 = mul i64 %82, 2
+  %84 = bitcast i16* %80 to i8*
+  %85 = getelementptr inbounds i8, i8* %84, i64 %83
+  %86 = load i16 addrspace(1)*, i16 addrspace(1)** %loc6
+  %87 = ptrtoint i16 addrspace(1)* %86 to i64
+  %88 = load i32, i32* %loc5
+  %89 = bitcast i8* %85 to i16*
+  %90 = inttoptr i64 %87 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %89, i16* %90, i32 %88)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %96
+
+; <label>:91                                      ; preds = %45, %53
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %94 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %93)
+  %95 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95, %System.String addrspace(1)* %92, %System.String addrspace(1)* %94)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95) #0
+  unreachable
+
+; <label>:96                                      ; preds = %23, %79
+  %97 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %97, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %98
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %97, i32 0, i32 2
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  store %System.Text.StringBuilder addrspace(1)* %100, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %102 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %102, label %21, label %103
+
+; <label>:103                                     ; preds = %98
+  store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc7
+  %104 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  ret %System.String addrspace(1)* %104
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method StringBuilder::get_Length using LLILCJit
+Successfully read StringBuilder.get_Length
+
+define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
+Successfully read RuntimeHelpers.get_OffsetToStringData
+
+define i32 @RuntimeHelpers.get_OffsetToStringData() {
+entry:
+  ret i32 12
+}
+
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
 Successfully read CultureData.CreateCultureData
 
@@ -3514,23 +4249,23 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
   store i8 %4, i8 addrspace(1)* %6
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
@@ -3549,11 +4284,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3566,50 +4301,50 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
   store i32 -1, i32 addrspace(1)* %2
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
   store i32 -1, i32 addrspace(1)* %8
   %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
   store i32 -1, i32 addrspace(1)* %14
   %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
   store i32 -1, i32 addrspace(1)* %17
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
@@ -3623,27 +4358,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3675,7 +4410,136 @@ Failed to read Dictionary`2.Insert[non-const derefAddress]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
 Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
-Failed to read HashHelpers.GetPrime[loadElem]
+Successfully read HashHelpers.GetPrime
+
+define i32 @HashHelpers.GetPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %6, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5, %System.String addrspace(1)* %4)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5) #0
+  unreachable
+
+; <label>:6                                       ; preds = %entry
+  store i32 0, i32* %loc0
+  br label %29
+
+; <label>:7                                       ; preds = %35
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 1296
+  %10 = addrspacecast i8 addrspace(1)* %9 to %"System.Int32[]" addrspace(1)**
+  %11 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %10
+  %12 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Int32[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = zext i32 %15 to i64
+  %17 = zext i32 %12 to i64
+  %BoundsCheck = icmp uge i64 %17, %16
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 3, i32 %12
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  store i32 %20, i32* %loc1
+  %21 = load i32, i32* %loc1
+  %22 = load i32, i32* %arg0
+  %23 = icmp slt i32 %21, %22
+  br i1 %23, label %26, label %24
+
+; <label>:24                                      ; preds = %18
+  %25 = load i32, i32* %loc1
+  ret i32 %25
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %loc0
+  %28 = add i32 %27, 1
+  store i32 %28, i32* %loc0
+  br label %29
+
+; <label>:29                                      ; preds = %6, %26
+  %30 = load i32, i32* %loc0
+  %31 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %32 = getelementptr inbounds i8, i8 addrspace(1)* %31, i64 1296
+  %33 = addrspacecast i8 addrspace(1)* %32 to %"System.Int32[]" addrspace(1)**
+  %34 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %33
+  %NullCheck = icmp eq %"System.Int32[]" addrspace(1)* %34, null
+  br i1 %NullCheck, label %ThrowNullRef, label %35
+
+; <label>:35                                      ; preds = %29
+  %36 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %34, i32 0, i32 1
+  %37 = load i32, i32 addrspace(1)* %36
+  %38 = zext i32 %37 to i64
+  %39 = trunc i64 %38 to i32
+  %40 = icmp slt i32 %30, %39
+  br i1 %40, label %7, label %41
+
+; <label>:41                                      ; preds = %35
+  %42 = load i32, i32* %arg0
+  %43 = or i32 %42, 1
+  store i32 %43, i32* %loc2
+  br label %59
+
+; <label>:44                                      ; preds = %59
+  %45 = load i32, i32* %loc2
+  %46 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %45)
+  %47 = zext i8 %46 to i32
+  %48 = icmp eq i32 %47, 0
+  br i1 %48, label %56, label %49
+
+; <label>:49                                      ; preds = %44
+  %50 = load i32, i32* %loc2
+  %51 = sub i32 %50, 1
+  %52 = srem i32 %51, 101
+  %53 = icmp eq i32 %52, 0
+  br i1 %53, label %56, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = load i32, i32* %loc2
+  ret i32 %55
+
+; <label>:56                                      ; preds = %44, %49
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %57, 2
+  store i32 %58, i32* %loc2
+  br label %59
+
+; <label>:59                                      ; preds = %41, %56
+  %60 = load i32, i32* %loc2
+  %61 = icmp slt i32 %60, 2147483647
+  br i1 %61, label %44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load i32, i32* %arg0
+  ret i32 %63
+
+ThrowNullRef:                                     ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
 Successfully read GenericEqualityComparer`1.GetHashCode
 
@@ -3694,14 +4558,14 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
   %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load i64, i64 addrspace(1)* %7
@@ -3720,7 +4584,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3750,8 +4614,8 @@ entry:
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
@@ -3796,8 +4660,8 @@ entry:
   %35 = bitcast i16* %34 to i8*
   %36 = getelementptr inbounds i8, i8* %35, i64 2
   %37 = bitcast i8* %36 to i16*
-  %NullCheck4 = icmp ne i16* %37, null
-  br i1 %NullCheck4, label %38, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %37, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %38
 
 ; <label>:38                                      ; preds = %27
   %39 = load i16, i16* %37, align 8
@@ -3824,8 +4688,8 @@ entry:
 
 ; <label>:54                                      ; preds = %22, %43
   %55 = load i16*, i16** %loc4
-  %NullCheck2 = icmp ne i16* %55, null
-  br i1 %NullCheck2, label %56, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i16* %55, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %56
 
 ; <label>:56                                      ; preds = %54
   %57 = load i16, i16* %55, align 8
@@ -3850,11 +4714,11 @@ ThrowNullRef:                                     ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %54
+ThrowNullRef2:                                    ; preds = %54
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %27
+ThrowNullRef4:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3871,8 +4735,8 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -3907,8 +4771,8 @@ entry:
 
 ; <label>:26                                      ; preds = %19
   %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
-  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %28
 
 ; <label>:28                                      ; preds = %26
   %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
@@ -3920,7 +4784,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3972,8 +4836,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
@@ -3984,26 +4848,26 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
-  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
@@ -4014,8 +4878,8 @@ entry:
 ; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
@@ -4024,8 +4888,8 @@ entry:
 
 ; <label>:25                                      ; preds = %1, %16, %23
   %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
-  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
@@ -4036,27 +4900,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %20
+ThrowNullRef10:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4069,8 +4933,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -4081,8 +4945,8 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
@@ -4091,8 +4955,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1, %8
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
@@ -4103,11 +4967,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4128,24 +4992,24 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   store i32 %3, i32* %loc0
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
   %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
   store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck4, label %9, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
@@ -4164,15 +5028,15 @@ entry:
 ; <label>:18                                      ; preds = %70
   %19 = load i16*, i16** %loc3
   %20 = bitcast i16* %19 to i64*
-  %NullCheck10 = icmp ne i64* %20, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %20, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = load i64, i64* %20, align 8
   %23 = load i16*, i16** %loc4
   %24 = bitcast i16* %23 to i64*
-  %NullCheck12 = icmp ne i64* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = load i64, i64* %24, align 8
@@ -4188,8 +5052,8 @@ entry:
   %31 = bitcast i16* %30 to i8*
   %32 = getelementptr inbounds i8, i8* %31, i64 8
   %33 = bitcast i8* %32 to i64*
-  %NullCheck14 = icmp ne i64* %33, null
-  br i1 %NullCheck14, label %34, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = load i64, i64* %33, align 8
@@ -4197,8 +5061,8 @@ entry:
   %37 = bitcast i16* %36 to i8*
   %38 = getelementptr inbounds i8, i8* %37, i64 8
   %39 = bitcast i8* %38 to i64*
-  %NullCheck16 = icmp ne i64* %39, null
-  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %40
 
 ; <label>:40                                      ; preds = %34
   %41 = load i64, i64* %39, align 8
@@ -4214,8 +5078,8 @@ entry:
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %NullCheck18 = icmp ne i64* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = load i64, i64* %48, align 8
@@ -4223,8 +5087,8 @@ entry:
   %52 = bitcast i16* %51 to i8*
   %53 = getelementptr inbounds i8, i8* %52, i64 16
   %54 = bitcast i8* %53 to i64*
-  %NullCheck20 = icmp ne i64* %54, null
-  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64* %54, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %55
 
 ; <label>:55                                      ; preds = %49
   %56 = load i64, i64* %54, align 8
@@ -4262,15 +5126,15 @@ entry:
 ; <label>:74                                      ; preds = %95
   %75 = load i16*, i16** %loc3
   %76 = bitcast i16* %75 to i32*
-  %NullCheck6 = icmp ne i32* %76, null
-  br i1 %NullCheck6, label %77, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32* %76, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %77
 
 ; <label>:77                                      ; preds = %74
   %78 = load i32, i32* %76, align 8
   %79 = load i16*, i16** %loc4
   %80 = bitcast i16* %79 to i32*
-  %NullCheck8 = icmp ne i32* %80, null
-  br i1 %NullCheck8, label %81, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i32* %80, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %81
 
 ; <label>:81                                      ; preds = %77
   %82 = load i32, i32* %80, align 8
@@ -4318,43 +5182,43 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %74
+ThrowNullRef6:                                    ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %77
+ThrowNullRef8:                                    ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %29
+ThrowNullRef14:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %34
+ThrowNullRef16:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4376,8 +5240,8 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load i64, i64 addrspace(1)* %4
@@ -4389,8 +5253,8 @@ entry:
   %12 = load i64, i64* %11
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %5
   %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
@@ -4399,8 +5263,8 @@ entry:
   %18 = load i8, i8* %arg2
   %19 = zext i8 %18 to i32
   %20 = trunc i32 %19 to i8
-  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %15
   %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
@@ -4411,11 +5275,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4442,8 +5306,8 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
@@ -4466,16 +5330,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
   %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = load i64, i64 addrspace(1)* %19
@@ -4500,8 +5364,8 @@ entry:
 ; <label>:35                                      ; preds = %30
   %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
@@ -4514,8 +5378,8 @@ entry:
 
 ; <label>:42                                      ; preds = %1, %38
   %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
-  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
@@ -4526,19 +5390,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %35
+ThrowNullRef2:                                    ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %42
+ThrowNullRef8:                                    ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4551,14 +5415,14 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
@@ -4570,7 +5434,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4583,8 +5447,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
@@ -4613,51 +5477,51 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
   %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
   %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
   %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
   %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
-  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
   store i64 %21, i64 addrspace(1)* %23
   %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %25 = load i64, i64* %loc0
-  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
@@ -4668,27 +5532,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %22
+ThrowNullRef12:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4701,8 +5565,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
@@ -4713,19 +5577,19 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
@@ -4734,8 +5598,8 @@ entry:
 
 ; <label>:15                                      ; preds = %1, %13
   %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
@@ -4746,19 +5610,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %15
+ThrowNullRef8:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4771,8 +5635,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -4831,8 +5695,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
@@ -4882,8 +5746,8 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
-  br i1 %NullCheck, label %17, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %ThrowNullRef, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
@@ -4894,15 +5758,15 @@ entry:
 
 ; <label>:22                                      ; preds = %17
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
-  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
   %26 = load i32, i32 addrspace(1)* %25
   %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
-  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %27, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
@@ -4925,8 +5789,8 @@ entry:
 ; <label>:40                                      ; preds = %17
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
-  br i1 %NullCheck6, label %43, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %41, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
@@ -4938,34 +5802,17 @@ ThrowNullRef:                                     ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %24
+ThrowNullRef4:                                    ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %40
+ThrowNullRef6:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
-}
-
-INFO:  jitting method Object::ReferenceEquals using LLILCJit
-Successfully read Object.ReferenceEquals
-
-define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
-entry:
-  %arg0 = alloca %System.Object addrspace(1)*
-  %arg1 = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
-  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
-  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = icmp eq %System.Object addrspace(1)* %0, %1
-  %3 = sext i1 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
 }
 
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
@@ -4978,21 +5825,21 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
   %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
-  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
@@ -5007,28 +5854,28 @@ entry:
 ; <label>:13                                      ; preds = %8, %12
   %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
   %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
   %21 = load i32, i32 addrspace(1)* %20, align 8
   %22 = add i32 %21, 1
-  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
   store i32 %22, i32 addrspace(1)* %24
   %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
@@ -5039,27 +5886,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5077,7 +5924,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::Setup using LLILCJit
-Failed to read AppDomain.Setup[loadElem]
+Failed to read AppDomain.Setup[unbox]
 INFO:  jitting method Thread::GetDomain using LLILCJit
 Successfully read Thread.GetDomain
 
@@ -5108,8 +5955,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
@@ -5122,14 +5969,14 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
   %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
@@ -5141,11 +5988,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5173,8 +6020,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -5189,7 +6036,328 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
 Failed to read KeyCollection.System.Collections.Generic.IEnumerable<TKey>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Successfully read Enumerator.MoveNext
+
+define i8 @Enumerator.MoveNext(%"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.RuntimeTypeHandle* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*
+  %"$TypeArg" = alloca %System.RuntimeTypeHandle*
+  store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
+  %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 8
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %76, label %12
+
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
+  br label %76
+
+; <label>:13                                      ; preds = %85
+  %14 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck19 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %15
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, i32 0, i32 0
+  %17 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %16, align 8
+  %NullCheck21 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, i32 0, i32 2
+  %20 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %19, align 8
+  %21 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck23 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %22
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, i32 0, i32 2
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %NullCheck25 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 3, i32 %24
+  %NullCheck27 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %32
+
+; <label>:32                                      ; preds = %30
+  %33 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, i32 0, i32 2
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = icmp slt i32 %34, 0
+  br i1 %35, label %68, label %36
+
+; <label>:36                                      ; preds = %32
+  %37 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %38 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck29 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %39
+
+; <label>:39                                      ; preds = %36
+  %40 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, i32 0, i32 0
+  %41 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %40, align 8
+  %NullCheck31 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, i32 0, i32 2
+  %44 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %43, align 8
+  %45 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck33 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, i32 0, i32 2
+  %48 = load i32, i32 addrspace(1)* %47, align 8
+  %NullCheck35 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %49
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = zext i32 %51 to i64
+  %53 = zext i32 %48 to i64
+  %BoundsCheck37 = icmp uge i64 %53, %52
+  br i1 %BoundsCheck37, label %ThrowIndexOutOfRange38, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 3, i32 %48
+  %NullCheck39 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %56
+
+; <label>:56                                      ; preds = %54
+  %57 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, i32 0, i32 0
+  %58 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck41 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %59
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %60, %System.__Canon addrspace(1)* %58)
+  %61 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck43 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  %64 = load i32, i32 addrspace(1)* %63, align 8
+  %65 = add i32 %64, 1
+  %NullCheck45 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  store i32 %65, i32 addrspace(1)* %67
+  ret i8 1
+
+; <label>:68                                      ; preds = %32
+  %69 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck47 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %73 = add i32 %72, 1
+  %NullCheck49 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %74
+
+; <label>:74                                      ; preds = %70
+  %75 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  store i32 %73, i32 addrspace(1)* %75
+  br label %76
+
+; <label>:76                                      ; preds = %8, %12, %74
+  %77 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %78
+
+; <label>:78                                      ; preds = %76
+  %79 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, i32 0, i32 2
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck7 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %82
+
+; <label>:82                                      ; preds = %78
+  %83 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, i32 0, i32 0
+  %84 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %83, align 8
+  %NullCheck9 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %85
+
+; <label>:85                                      ; preds = %82
+  %86 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, i32 0, i32 7
+  %87 = load i32, i32 addrspace(1)* %86, align 8
+  %88 = icmp ult i32 %80, %87
+  br i1 %88, label %13, label %89
+
+; <label>:89                                      ; preds = %85
+  %90 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %91 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck11 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %92
+
+; <label>:92                                      ; preds = %89
+  %93 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, i32 0, i32 0
+  %94 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck13 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %95
+
+; <label>:95                                      ; preds = %92
+  %96 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, i32 0, i32 7
+  %97 = load i32, i32 addrspace(1)* %96, align 8
+  %98 = add i32 %97, 1
+  %NullCheck15 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %99
+
+; <label>:99                                      ; preds = %95
+  %100 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, i32 0, i32 2
+  store i32 %98, i32 addrspace(1)* %100
+  %101 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck17 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %102
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %103, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %92
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef22:                                   ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef24:                                   ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef26:                                   ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef28:                                   ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef30:                                   ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef32:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef34:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef36:                                   ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange38:                           ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef40:                                   ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef42:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef44:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef46:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef48:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef50:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -5200,8 +6368,8 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -5232,9 +6400,9 @@ Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
 Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
-Failed to read String.MakeSeparatorList[loadElemA]
+Failed to read String.MakeSeparatorList[storeElem]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
-Failed to read String.InternalSplitKeepEmptyEntries[loadElem]
+Failed to read String.InternalSplitKeepEmptyEntries[storeElem]
 INFO:  jitting method Path::IsRelative using LLILCJit
 Successfully read Path.IsRelative
 
@@ -5243,8 +6411,8 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -5254,8 +6422,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
@@ -5271,8 +6439,8 @@ entry:
 
 ; <label>:17                                      ; preds = %7
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
@@ -5288,8 +6456,8 @@ entry:
 
 ; <label>:29                                      ; preds = %19
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %31
 
 ; <label>:31                                      ; preds = %29
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
@@ -5300,8 +6468,8 @@ entry:
 
 ; <label>:36                                      ; preds = %31
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
-  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %37, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
@@ -5312,8 +6480,8 @@ entry:
 
 ; <label>:43                                      ; preds = %31, %38
   %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
-  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %45
 
 ; <label>:45                                      ; preds = %43
   %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
@@ -5324,8 +6492,8 @@ entry:
 
 ; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %50
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
@@ -5336,8 +6504,8 @@ entry:
 
 ; <label>:57                                      ; preds = %1, %7, %19, %45, %52
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
-  br i1 %NullCheck14, label %59, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %59
 
 ; <label>:59                                      ; preds = %57
   %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
@@ -5347,8 +6515,8 @@ entry:
 
 ; <label>:63                                      ; preds = %59
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
@@ -5359,8 +6527,8 @@ entry:
 
 ; <label>:70                                      ; preds = %65
   %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
-  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.String addrspace(1)* %71, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %72
 
 ; <label>:72                                      ; preds = %70
   %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
@@ -5379,39 +6547,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %17
+ThrowNullRef4:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %29
+ThrowNullRef6:                                    ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %36
+ThrowNullRef8:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %43
+ThrowNullRef10:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %50
+ThrowNullRef12:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %57
+ThrowNullRef14:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %63
+ThrowNullRef16:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %70
+ThrowNullRef18:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5419,7 +6587,293 @@ ThrowNullRef17:                                   ; preds = %70
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
-Failed to read String.TrimHelper[loadElem]
+Successfully read String.TrimHelper
+
+define %System.String addrspace(1)* @String.TrimHelper(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i16
+  %loc4 = alloca i32
+  %loc5 = alloca i16
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = sub i32 %3, 1
+  store i32 %4, i32* %loc0
+  store i32 0, i32* %loc1
+  %5 = load i32, i32* %arg2
+  %6 = icmp eq i32 %5, 1
+  br i1 %6, label %62, label %7
+
+; <label>:7                                       ; preds = %1
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:8                                       ; preds = %58
+  store i32 0, i32* %loc2
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load i32, i32* %loc1
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2, i32 %10
+  %13 = load i16, i16 addrspace(1)* %12
+  %14 = zext i16 %13 to i32
+  %15 = trunc i32 %14 to i16
+  store i16 %15, i16* %loc3
+  store i32 0, i32* %loc2
+  br label %34
+
+; <label>:16                                      ; preds = %37
+  %17 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %18 = load i32, i32* %loc2
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %17, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %19
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = zext i32 %18 to i64
+  %BoundsCheck = icmp uge i64 %23, %22
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %24
+
+; <label>:24                                      ; preds = %19
+  %25 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 3, i32 %18
+  %26 = load i16, i16 addrspace(1)* %25, align 8
+  %27 = zext i16 %26 to i32
+  %28 = load i16, i16* %loc3
+  %29 = zext i16 %28 to i32
+  %30 = icmp eq i32 %27, %29
+  br i1 %30, label %43, label %31
+
+; <label>:31                                      ; preds = %24
+  %32 = load i32, i32* %loc2
+  %33 = add i32 %32, 1
+  store i32 %33, i32* %loc2
+  br label %34
+
+; <label>:34                                      ; preds = %11, %31
+  %35 = load i32, i32* %loc2
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = icmp slt i32 %35, %41
+  br i1 %42, label %16, label %43
+
+; <label>:43                                      ; preds = %24, %37
+  %44 = load i32, i32* %loc2
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %45, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp eq i32 %44, %50
+  br i1 %51, label %62, label %52
+
+; <label>:52                                      ; preds = %46
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %7, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %57, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %58
+
+; <label>:58                                      ; preds = %55
+  %59 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %60 = load i32, i32 addrspace(1)* %59
+  %61 = icmp slt i32 %56, %60
+  br i1 %61, label %8, label %62
+
+; <label>:62                                      ; preds = %1, %46, %58
+  %63 = load i32, i32* %arg2
+  %64 = icmp eq i32 %63, 0
+  br i1 %64, label %122, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %66, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %67
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %66, i32 0, i32 1
+  %69 = load i32, i32 addrspace(1)* %68
+  %70 = sub i32 %69, 1
+  store i32 %70, i32* %loc0
+  br label %118
+
+; <label>:71                                      ; preds = %118
+  store i32 0, i32* %loc4
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %73 = load i32, i32* %loc0
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %74
+
+; <label>:74                                      ; preds = %71
+  %75 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 2, i32 %73
+  %76 = load i16, i16 addrspace(1)* %75
+  %77 = zext i16 %76 to i32
+  %78 = trunc i32 %77 to i16
+  store i16 %78, i16* %loc5
+  store i32 0, i32* %loc4
+  br label %97
+
+; <label>:79                                      ; preds = %100
+  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %81 = load i32, i32* %loc4
+  %NullCheck19 = icmp eq %"System.Char[]" addrspace(1)* %80, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
+
+; <label>:82                                      ; preds = %79
+  %83 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 1
+  %84 = load i32, i32 addrspace(1)* %83
+  %85 = zext i32 %84 to i64
+  %86 = zext i32 %81 to i64
+  %BoundsCheck21 = icmp uge i64 %86, %85
+  br i1 %BoundsCheck21, label %ThrowIndexOutOfRange22, label %87
+
+; <label>:87                                      ; preds = %82
+  %88 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 3, i32 %81
+  %89 = load i16, i16 addrspace(1)* %88, align 8
+  %90 = zext i16 %89 to i32
+  %91 = load i16, i16* %loc5
+  %92 = zext i16 %91 to i32
+  %93 = icmp eq i32 %90, %92
+  br i1 %93, label %106, label %94
+
+; <label>:94                                      ; preds = %87
+  %95 = load i32, i32* %loc4
+  %96 = add i32 %95, 1
+  store i32 %96, i32* %loc4
+  br label %97
+
+; <label>:97                                      ; preds = %74, %94
+  %98 = load i32, i32* %loc4
+  %99 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck15 = icmp eq %"System.Char[]" addrspace(1)* %99, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %100
+
+; <label>:100                                     ; preds = %97
+  %101 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %99, i32 0, i32 1
+  %102 = load i32, i32 addrspace(1)* %101
+  %103 = zext i32 %102 to i64
+  %104 = trunc i64 %103 to i32
+  %105 = icmp slt i32 %98, %104
+  br i1 %105, label %79, label %106
+
+; <label>:106                                     ; preds = %87, %100
+  %107 = load i32, i32* %loc4
+  %108 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck17 = icmp eq %"System.Char[]" addrspace(1)* %108, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %109
+
+; <label>:109                                     ; preds = %106
+  %110 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %108, i32 0, i32 1
+  %111 = load i32, i32 addrspace(1)* %110
+  %112 = zext i32 %111 to i64
+  %113 = trunc i64 %112 to i32
+  %114 = icmp eq i32 %107, %113
+  br i1 %114, label %122, label %115
+
+; <label>:115                                     ; preds = %109
+  %116 = load i32, i32* %loc0
+  %117 = sub i32 %116, 1
+  store i32 %117, i32* %loc0
+  br label %118
+
+; <label>:118                                     ; preds = %67, %115
+  %119 = load i32, i32* %loc0
+  %120 = load i32, i32* %loc1
+  %121 = icmp sge i32 %119, %120
+  br i1 %121, label %71, label %122
+
+; <label>:122                                     ; preds = %62, %109, %118
+  %123 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %124 = load i32, i32* %loc1
+  %125 = load i32, i32* %loc0
+  %126 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %123, i32 %124, i32 %125)
+  ret %System.String addrspace(1)* %126
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %97
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange22:                           ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
 Successfully read String.CreateTrimmedString
 
@@ -5439,8 +6893,8 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
@@ -5535,8 +6989,8 @@ entry:
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i64 2872
   %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
   %8 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %7
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %3
   %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
@@ -5553,8 +7007,8 @@ entry:
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 2864
   %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
   %21 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %20
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
-  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %22
 
 ; <label>:22                                      ; preds = %16
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
@@ -5569,7 +7023,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %16
+ThrowNullRef2:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5586,8 +7040,8 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5613,8 +7067,8 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
@@ -5632,8 +7086,8 @@ entry:
 
 ; <label>:12                                      ; preds = %4
   %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
@@ -5644,8 +7098,8 @@ entry:
 
 ; <label>:19                                      ; preds = %14
   %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %19
   %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
@@ -5660,21 +7114,21 @@ entry:
   %31 = zext i16 %30 to i32
   %32 = bitcast i8* %29 to i16*
   %33 = trunc i32 %31 to i16
-  %NullCheck6 = icmp ne i16* %32, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i16* %32, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %21
   store i16 %33, i16* %32, align 8
   %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %36
 
 ; <label>:36                                      ; preds = %34
   %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
   %38 = load i32, i32 addrspace(1)* %37, align 8
   %39 = add i32 %38, 1
-  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %40
 
 ; <label>:40                                      ; preds = %36
   %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
@@ -5683,16 +7137,16 @@ entry:
 
 ; <label>:42                                      ; preds = %14
   %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
-  br i1 %NullCheck12, label %44, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
   %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
   %47 = load i16, i16* %arg1
   %48 = zext i16 %47 to i32
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = trunc i32 %48 to i16
@@ -5703,31 +7157,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %19
+ThrowNullRef4:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %21
+ThrowNullRef6:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %36
+ThrowNullRef10:                                   ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %42
+ThrowNullRef12:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %44
+ThrowNullRef14:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5740,8 +7194,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -5752,8 +7206,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
@@ -5762,14 +7216,14 @@ entry:
 
 ; <label>:11                                      ; preds = %1
   %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
@@ -5779,15 +7233,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5808,8 +7262,8 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5822,8 +7276,8 @@ entry:
 
 ; <label>:8                                       ; preds = %3
   %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
@@ -5842,15 +7296,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
-  br i1 %NullCheck4, label %22, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
   %24 = load i16*, i16* addrspace(1)* %23, align 8
   %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %25, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
@@ -5859,8 +7313,8 @@ entry:
   store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
@@ -5874,8 +7328,8 @@ entry:
 
 ; <label>:37                                      ; preds = %65
   %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %37
   %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
@@ -5886,16 +7340,16 @@ entry:
   %45 = bitcast i16* %41 to i8*
   %46 = getelementptr inbounds i8, i8* %45, i64 %44
   %47 = bitcast i8* %46 to i16*
-  %NullCheck14 = icmp ne i16* %47, null
-  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %47, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %48
 
 ; <label>:48                                      ; preds = %39
   %49 = load i16, i16* %47, align 8
   %50 = zext i16 %49 to i32
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %52 = load i32, i32* %loc1
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %53
 
 ; <label>:53                                      ; preds = %48
   %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
@@ -5916,8 +7370,8 @@ entry:
 ; <label>:62                                      ; preds = %36, %59
   %63 = load i32, i32* %loc1
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck10, label %65, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %65
 
 ; <label>:65                                      ; preds = %62
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
@@ -5936,15 +7390,15 @@ entry:
 
 ; <label>:74                                      ; preds = %70
   %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
-  br i1 %NullCheck18, label %76, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %76
 
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
   %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
-  br i1 %NullCheck20, label %80, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
   %81 = load i64, i64 addrspace(1)* %79
@@ -5958,8 +7412,8 @@ entry:
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
   %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
-  br i1 %NullCheck22, label %92, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.String addrspace(1)* %90, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %92
 
 ; <label>:92                                      ; preds = %80
   %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
@@ -5969,15 +7423,15 @@ entry:
 
 ; <label>:96                                      ; preds = %70
   %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
-  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %98
 
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
   %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
-  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
   %103 = load i64, i64 addrspace(1)* %101
@@ -5991,8 +7445,8 @@ entry:
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
   %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
-  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.String addrspace(1)* %112, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %114
 
 ; <label>:114                                     ; preds = %102
   %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
@@ -6004,59 +7458,59 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %20
+ThrowNullRef4:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %22
+ThrowNullRef6:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %26
+ThrowNullRef8:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %62
+ThrowNullRef10:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %48
+ThrowNullRef16:                                   ; preds = %48
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %74
+ThrowNullRef18:                                   ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %76
+ThrowNullRef20:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %80
+ThrowNullRef22:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %96
+ThrowNullRef24:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %98
+ThrowNullRef26:                                   ; preds = %98
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %102
+ThrowNullRef28:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6069,15 +7523,15 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
   %3 = load i16*, i16* addrspace(1)* %2, align 8
   %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
@@ -6087,8 +7541,8 @@ entry:
   %10 = bitcast i16* %3 to i8*
   %11 = getelementptr inbounds i8, i8* %10, i64 %9
   %12 = bitcast i8* %11 to i16*
-  %NullCheck4 = icmp ne i16* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %5
   store i16 0, i16* %12, align 8
@@ -6098,11 +7552,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6119,8 +7573,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -6131,8 +7585,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
@@ -6144,15 +7598,15 @@ entry:
 
 ; <label>:14                                      ; preds = %1
   %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
   %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
   %21 = load i64, i64 addrspace(1)* %19
@@ -6171,15 +7625,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %14
+ThrowNullRef4:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %16
+ThrowNullRef6:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6302,14 +7756,6 @@ entry:
   ret %System.String addrspace(1)* %57
 }
 
-INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
-Successfully read RuntimeHelpers.get_OffsetToStringData
-
-define i32 @RuntimeHelpers.get_OffsetToStringData() {
-entry:
-  ret i32 12
-}
-
 INFO:  jitting method String::Equals using LLILCJit
 Successfully read String.Equals
 
@@ -6381,8 +7827,8 @@ entry:
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
-  br i1 %NullCheck24, label %29, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
   %30 = load i64, i64 addrspace(1)* %28
@@ -6397,8 +7843,8 @@ entry:
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
-  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
   %43 = load i64, i64 addrspace(1)* %41
@@ -6418,8 +7864,8 @@ entry:
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
   %59 = load i64, i64 addrspace(1)* %57
@@ -6434,8 +7880,8 @@ entry:
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck22, label %71, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
   %72 = load i64, i64 addrspace(1)* %70
@@ -6455,8 +7901,8 @@ entry:
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
-  br i1 %NullCheck16, label %87, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = load i64, i64 addrspace(1)* %86
@@ -6471,8 +7917,8 @@ entry:
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck18, label %100, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
   %101 = load i64, i64 addrspace(1)* %99
@@ -6492,8 +7938,8 @@ entry:
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
-  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
   %117 = load i64, i64 addrspace(1)* %115
@@ -6508,8 +7954,8 @@ entry:
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
-  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
   %130 = load i64, i64 addrspace(1)* %128
@@ -6528,15 +7974,15 @@ entry:
 
 ; <label>:142                                     ; preds = %22
   %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
-  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %143, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %144
 
 ; <label>:144                                     ; preds = %142
   %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
   %146 = load i32, i32 addrspace(1)* %145
   %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
-  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %147, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %148
 
 ; <label>:148                                     ; preds = %144
   %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
@@ -6557,15 +8003,15 @@ entry:
 
 ; <label>:159                                     ; preds = %22
   %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
-  br i1 %NullCheck, label %161, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %ThrowNullRef, label %161
 
 ; <label>:161                                     ; preds = %159
   %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
   %163 = load i32, i32 addrspace(1)* %162
   %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
-  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %164, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %165
 
 ; <label>:165                                     ; preds = %161
   %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
@@ -6578,8 +8024,8 @@ entry:
 
 ; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
-  br i1 %NullCheck4, label %172, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %171, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %172
 
 ; <label>:172                                     ; preds = %170
   %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
@@ -6589,8 +8035,8 @@ entry:
 
 ; <label>:176                                     ; preds = %172
   %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
-  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %177, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %178
 
 ; <label>:178                                     ; preds = %176
   %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
@@ -6629,55 +8075,55 @@ ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %161
+ThrowNullRef2:                                    ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %170
+ThrowNullRef4:                                    ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %176
+ThrowNullRef6:                                    ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %142
+ThrowNullRef8:                                    ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %144
+ThrowNullRef10:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %113
+ThrowNullRef12:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %116
+ThrowNullRef14:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %84
+ThrowNullRef16:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %87
+ThrowNullRef18:                                   ; preds = %87
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %55
+ThrowNullRef20:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %58
+ThrowNullRef22:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %26
+ThrowNullRef24:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %29
+ThrowNullRef26:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,8 +8161,8 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck, label %14, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %ThrowNullRef, label %14
 
 ; <label>:14                                      ; preds = %8
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
@@ -6760,8 +8206,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
@@ -6770,14 +8216,14 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32, i32* %loc0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %10
   %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
   %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
@@ -6790,15 +8236,15 @@ entry:
 ; <label>:25                                      ; preds = %19
   %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
-  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
   %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
@@ -6807,8 +8253,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %37 = load i32, i32* %loc0
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %38, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %38
 
 ; <label>:38                                      ; preds = %32
   %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
@@ -6817,14 +8263,14 @@ entry:
 
 ; <label>:40                                      ; preds = %19
   %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %40
   %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
   %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
-  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
-  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
@@ -6832,8 +8278,8 @@ entry:
   %48 = zext i32 %47 to i64
   %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
-  br i1 %NullCheck16, label %51, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %51
 
 ; <label>:51                                      ; preds = %45
   %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
@@ -6847,15 +8293,15 @@ entry:
 ; <label>:57                                      ; preds = %51
   %58 = load i16*, i16** %arg1
   %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
-  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %60
 
 ; <label>:60                                      ; preds = %57
   %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
   %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
-  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %64
 
 ; <label>:64                                      ; preds = %60
   %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
@@ -6864,22 +8310,22 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
   %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
-  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %70
 
 ; <label>:70                                      ; preds = %64
   %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
   %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
-  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
-  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
   %75 = load i32, i32 addrspace(1)* %74
   %76 = zext i32 %75 to i64
   %77 = trunc i64 %76 to i32
-  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
-  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %78
 
 ; <label>:78                                      ; preds = %73
   %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
@@ -6901,8 +8347,8 @@ entry:
   %90 = bitcast i16* %86 to i8*
   %91 = getelementptr inbounds i8, i8* %90, i64 %89
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %93
 
 ; <label>:93                                      ; preds = %80
   %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
@@ -6912,8 +8358,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %99 = load i32, i32* %loc2
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %100
 
 ; <label>:100                                     ; preds = %93
   %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
@@ -6928,63 +8374,63 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %25
+ThrowNullRef6:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %32
+ThrowNullRef10:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %40
+ThrowNullRef12:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %45
+ThrowNullRef16:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %57
+ThrowNullRef18:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %60
+ThrowNullRef20:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %64
+ThrowNullRef22:                                   ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %70
+ThrowNullRef24:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %73
+ThrowNullRef26:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %80
+ThrowNullRef28:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %93
+ThrowNullRef30:                                   ; preds = %93
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7004,8 +8450,8 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
@@ -7033,43 +8479,43 @@ entry:
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %14
   %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
   %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   %28 = load i32, i32 addrspace(1)* %27, align 8
   %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
-  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %30
 
 ; <label>:30                                      ; preds = %26
   %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
   %32 = load i32, i32 addrspace(1)* %31, align 8
   %33 = add i32 %28, %32
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %34
 
 ; <label>:34                                      ; preds = %30
   %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   store i32 %33, i32 addrspace(1)* %35
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
   store i32 0, i32 addrspace(1)* %38
   %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %40
 
 ; <label>:40                                      ; preds = %37
   %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
@@ -7082,8 +8528,8 @@ entry:
 
 ; <label>:47                                      ; preds = %40
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
@@ -7098,8 +8544,8 @@ entry:
   %54 = load i32, i32* %loc0
   %55 = sext i32 %54 to i64
   %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
-  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %57
 
 ; <label>:57                                      ; preds = %52
   %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
@@ -7110,68 +8556,35 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %14
+ThrowNullRef2:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %23
+ThrowNullRef4:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %26
+ThrowNullRef6:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %30
+ThrowNullRef8:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %34
+ThrowNullRef10:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %47
+ThrowNullRef14:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %52
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-}
-
-INFO:  jitting method StringBuilder::get_Length using LLILCJit
-Successfully read StringBuilder.get_Length
-
-define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.StringBuilder addrspace(1)*
-  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
-  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
-
-; <label>:1                                       ; preds = %entry
-  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %3 = load i32, i32 addrspace(1)* %2, align 8
-  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
-
-; <label>:5                                       ; preds = %1
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = add i32 %3, %7
-  ret i32 %8
-
-ThrowNullRef:                                     ; preds = %entry
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef16:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7213,70 +8626,70 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
   %6 = load i32, i32 addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
   store i32 %6, i32 addrspace(1)* %8
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
   %13 = load i32, i32 addrspace(1)* %12, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
   store i32 %13, i32 addrspace(1)* %15
   %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
-  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %18
 
 ; <label>:18                                      ; preds = %14
   %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
   %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
   %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
   %34 = load i32, i32 addrspace(1)* %33, align 8
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
-  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
@@ -7287,39 +8700,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %28
+ThrowNullRef16:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %32
+ThrowNullRef18:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7455,13 +8868,13 @@ entry:
 ; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
@@ -7477,16 +8890,16 @@ entry:
 
 ; <label>:18                                      ; preds = %15
   %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
   store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
   %22 = load i32, i32* %loc0
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %24
 
 ; <label>:24                                      ; preds = %20
   %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
@@ -7498,13 +8911,13 @@ entry:
 ; <label>:28                                      ; preds = %15, %24
   %29 = load i32, i32* %arg1
   %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %31
   %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
@@ -7517,20 +8930,20 @@ entry:
   %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
-  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
   %46 = load i32, i32 addrspace(1)* %45, align 8
   %47 = sub i32 %40, %46
-  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
-  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i32 addrspace(1)* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %48
 
 ; <label>:48                                      ; preds = %44
   store i32 %47, i32 addrspace(1)* %39, align 8
@@ -7538,21 +8951,21 @@ entry:
 
 ; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
-  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %51
 
 ; <label>:51                                      ; preds = %49
   %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %53
 
 ; <label>:53                                      ; preds = %51
   %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
   %55 = load i32, i32 addrspace(1)* %54, align 8
   %56 = load i32, i32* %arg2
   %57 = sub i32 %55, %56
-  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %58
 
 ; <label>:58                                      ; preds = %53
   %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
@@ -7562,13 +8975,13 @@ entry:
 ; <label>:60                                      ; preds = %33, %58
   %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
   %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
-  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %63
 
 ; <label>:63                                      ; preds = %60
   %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
-  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
-  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
@@ -7578,15 +8991,15 @@ entry:
 
 ; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
-  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i32 addrspace(1)* %69, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %70
 
 ; <label>:70                                      ; preds = %68
   %71 = load i32, i32 addrspace(1)* %69, align 8
   store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
-  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
@@ -7596,8 +9009,8 @@ entry:
   store i32 %77, i32* %loc4
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
-  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %80
 
 ; <label>:80                                      ; preds = %73
   %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
@@ -7607,71 +9020,71 @@ entry:
 ; <label>:83                                      ; preds = %80
   store i32 0, i32* %loc3
   %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
-  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
-  br i1 %NullCheck26, label %88, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i32 addrspace(1)* %87, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %88
 
 ; <label>:88                                      ; preds = %85
   %89 = load i32, i32 addrspace(1)* %87, align 8
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
-  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %90
 
 ; <label>:90                                      ; preds = %88
   %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
   store i32 %89, i32 addrspace(1)* %91
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
-  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
-  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %96
 
 ; <label>:96                                      ; preds = %94
   %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
-  br i1 %NullCheck34, label %100, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %100
 
 ; <label>:100                                     ; preds = %96
   %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
-  br i1 %NullCheck36, label %102, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %102
 
 ; <label>:102                                     ; preds = %100
   %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
   %104 = load i32, i32 addrspace(1)* %103, align 8
   %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
-  br i1 %NullCheck38, label %106, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %106
 
 ; <label>:106                                     ; preds = %102
   %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
-  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
-  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %108
 
 ; <label>:108                                     ; preds = %106
   %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
   %110 = load i32, i32 addrspace(1)* %109, align 8
   %111 = add i32 %104, %110
-  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %112
 
 ; <label>:112                                     ; preds = %108
   %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
   store i32 %111, i32 addrspace(1)* %113
   %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
-  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i32 addrspace(1)* %114, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %115
 
 ; <label>:115                                     ; preds = %112
   %116 = load i32, i32 addrspace(1)* %114, align 8
@@ -7681,19 +9094,19 @@ entry:
 ; <label>:118                                     ; preds = %115
   %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
-  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %121
 
 ; <label>:121                                     ; preds = %118
   %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
-  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
-  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %123
 
 ; <label>:123                                     ; preds = %121
   %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
   %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
-  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
-  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %126
 
 ; <label>:126                                     ; preds = %123
   %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
@@ -7705,8 +9118,8 @@ entry:
 
 ; <label>:130                                     ; preds = %80, %115, %126
   %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %132
 
 ; <label>:132                                     ; preds = %130
   %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7715,8 +9128,8 @@ entry:
   %136 = load i32, i32* %loc3
   %137 = sub i32 %135, %136
   %138 = sub i32 %134, %137
-  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %139
 
 ; <label>:139                                     ; preds = %132
   %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7728,16 +9141,16 @@ entry:
 
 ; <label>:144                                     ; preds = %139
   %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
-  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %146
 
 ; <label>:146                                     ; preds = %144
   %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
   %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
   %149 = load i32, i32* %loc2
   %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
-  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %151
 
 ; <label>:151                                     ; preds = %146
   %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
@@ -7754,145 +9167,249 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %18
+ThrowNullRef4:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %31
+ThrowNullRef10:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %44
+ThrowNullRef16:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %68
+ThrowNullRef18:                                   ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %70
+ThrowNullRef20:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %73
+ThrowNullRef22:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %83
+ThrowNullRef24:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %85
+ThrowNullRef26:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %88
+ThrowNullRef28:                                   ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %90
+ThrowNullRef30:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %94
+ThrowNullRef32:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %96
+ThrowNullRef34:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %100
+ThrowNullRef36:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %102
+ThrowNullRef38:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %106
+ThrowNullRef40:                                   ; preds = %106
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %108
+ThrowNullRef42:                                   ; preds = %108
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %112
+ThrowNullRef44:                                   ; preds = %112
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %118
+ThrowNullRef46:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %121
+ThrowNullRef48:                                   ; preds = %121
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %123
+ThrowNullRef50:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %130
+ThrowNullRef52:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %132
+ThrowNullRef54:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %144
+ThrowNullRef56:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %146
+ThrowNullRef58:                                   ; preds = %146
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %60
+ThrowNullRef60:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %63
+ThrowNullRef62:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %49
+ThrowNullRef64:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %51
+ThrowNullRef66:                                   ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %53
+ThrowNullRef68:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(%"System.Char[]" addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %arg0 = alloca %"System.Char[]" addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store %"System.Char[]" addrspace(1)* %param0, %"System.Char[]" addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load i32, i32* %arg4
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %43, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %38, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg1
+  %13 = load i32, i32* %arg4
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %38, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %24 = load i32, i32* %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %35 = load i32, i32* %arg3
+  %36 = load i32, i32* %arg4
+  %37 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %37, %"System.Char[]" addrspace(1)* %34, i32 %35, i32 %36)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:38                                      ; preds = %5, %16
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Successfully read Buffer._Memmove
 
@@ -7914,7 +9431,7 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[loadElem]
+Failed to read AppDomain.SetDataHelper[storeElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -7923,8 +9440,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
@@ -7934,8 +9451,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
@@ -7947,15 +9464,15 @@ entry:
   %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
   %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
@@ -7966,15 +9483,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7992,7 +9509,79 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
-Failed to read Dictionary`2.TryGetValue[loadElemA]
+Successfully read Dictionary`2.TryGetValue
+
+define i8 @"Dictionary`2.TryGetValue"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)* addrspace(1)* %param2) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  %arg2 = alloca %System.__Canon addrspace(1)* addrspace(1)*
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  store %System.__Canon addrspace(1)* addrspace(1)* %param2, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  store i32 %2, i32* %loc0
+  %3 = load i32, i32* %loc0
+  %4 = icmp slt i32 %3, 0
+  br i1 %4, label %22, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 2
+  %10 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %9, align 8
+  %11 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = zext i32 %11 to i64
+  %BoundsCheck = icmp uge i64 %16, %15
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 3, i32 %11
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %20, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %6, %System.__Canon addrspace(1)* %21)
+  ret i8 1
+
+; <label>:22                                      ; preds = %entry
+  %23 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %23, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -8058,8 +9647,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
@@ -8091,8 +9680,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
@@ -8171,15 +9760,15 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck, label %19, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %ThrowNullRef, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
   %21 = load i32, i32 addrspace(1)* %20
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
@@ -8202,7 +9791,7 @@ ThrowNullRef:                                     ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %19
+ThrowNullRef2:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8248,8 +9837,8 @@ entry:
   %0 = alloca %System.AppDomainHandle
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %1 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %1, i32 0, i32 15
@@ -8269,8 +9858,8 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
@@ -8286,7 +9875,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -8299,8 +9888,8 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -8327,8 +9916,8 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
@@ -8352,8 +9941,8 @@ entry:
   %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
   store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
@@ -8363,8 +9952,8 @@ entry:
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
@@ -8374,8 +9963,8 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %9
   %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
@@ -8384,8 +9973,8 @@ entry:
 
 ; <label>:18                                      ; preds = %3, %16
   %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
@@ -8397,15 +9986,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %18
+ThrowNullRef6:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8418,8 +10007,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
@@ -8453,15 +10042,15 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
@@ -8473,7 +10062,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8481,7 +10070,7 @@ ThrowNullRef1:                                    ; preds = %1
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
 Failed to read Dictionary`2.System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
@@ -8506,8 +10095,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
@@ -8524,8 +10113,8 @@ entry:
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -8544,7 +10133,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8577,8 +10166,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = load i64, i64* %arg2
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = trunc i32 %3 to i8
@@ -8634,46 +10223,46 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
   %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
-  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
-  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
-  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
@@ -8684,27 +10273,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %20
+ThrowNullRef12:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8717,8 +10306,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -8756,22 +10345,22 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
   %9 = load i64, i64 addrspace(1)* %8, align 8
   %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
   %13 = load i64, i64 addrspace(1)* %12, align 8
   %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %11
   %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
@@ -8788,11 +10377,11 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8882,8 +10471,8 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
@@ -8900,8 +10489,8 @@ entry:
 ; <label>:8                                       ; preds = %1
   %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
   %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
@@ -8911,15 +10500,15 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
   %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
   %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
-  br i1 %NullCheck6, label %21, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
@@ -8946,15 +10535,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8992,15 +10581,15 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
   store i8 %3, i8 addrspace(1)* %5
   %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
@@ -9011,7 +10600,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9027,8 +10616,8 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -9041,8 +10630,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
@@ -9058,7 +10647,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9080,8 +10669,8 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
@@ -9096,8 +10685,8 @@ entry:
 ; <label>:12                                      ; preds = %6
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
@@ -9112,8 +10701,8 @@ entry:
 ; <label>:21                                      ; preds = %15
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
@@ -9128,8 +10717,8 @@ entry:
 ; <label>:30                                      ; preds = %24
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %31, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
@@ -9144,8 +10733,8 @@ entry:
 ; <label>:39                                      ; preds = %33
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
-  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %40, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %42
 
 ; <label>:42                                      ; preds = %39
   %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
@@ -9164,19 +10753,19 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %21
+ThrowNullRef4:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %30
+ThrowNullRef6:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %39
+ThrowNullRef8:                                    ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9243,8 +10832,8 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
@@ -9264,57 +10853,57 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
   store i8 0, i8 addrspace(1)* %2
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
   store i8 0, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
   store i8 0, i8 addrspace(1)* %17
   %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
   store i8 0, i8 addrspace(1)* %20
   %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
-  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
@@ -9325,31 +10914,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %19
+ThrowNullRef14:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9367,8 +10956,8 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
@@ -9380,8 +10969,8 @@ entry:
 
 ; <label>:9                                       ; preds = %4
   %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %9
   %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
@@ -9395,7 +10984,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef2:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9420,8 +11009,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
@@ -9512,8 +11101,8 @@ entry:
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
@@ -9524,8 +11113,8 @@ entry:
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = load i64, i64 addrspace(1)* %12
@@ -9537,8 +11126,8 @@ entry:
   %20 = load i64, i64* %19
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
-  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %13
   %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
@@ -9555,8 +11144,8 @@ entry:
 ; <label>:30                                      ; preds = %25
   %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %32 = load i32, i32* %arg2
-  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
-  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
@@ -9570,15 +11159,15 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %30
+ThrowNullRef2:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9622,87 +11211,87 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
   %10 = load i8, i8 addrspace(1)* %9, align 8
   %11 = zext i8 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %8
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
   store i8 %12, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
   %19 = load i8, i8 addrspace(1)* %18, align 8
   %20 = zext i8 %19 to i32
   %21 = trunc i32 %20 to i8
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
   store i8 %21, i8 addrspace(1)* %23
   %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
   %28 = load i8, i8 addrspace(1)* %27, align 8
   %29 = zext i8 %28 to i32
   %30 = trunc i32 %29 to i8
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
-  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %31
 
 ; <label>:31                                      ; preds = %26
   %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
   store i8 %30, i8 addrspace(1)* %32
   %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
-  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
-  br i1 %NullCheck14, label %40, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %40
 
 ; <label>:40                                      ; preds = %35
   %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
   store i8 %39, i8 addrspace(1)* %41
   %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
-  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %44
 
 ; <label>:44                                      ; preds = %40
   %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
   %46 = load i8, i8 addrspace(1)* %45, align 8
   %47 = zext i8 %46 to i32
   %48 = trunc i32 %47 to i8
-  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
   store i8 %48, i8 addrspace(1)* %50
   %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
-  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
@@ -9713,29 +11302,29 @@ entry:
 ; <label>:56                                      ; preds = %52
   %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
-  br i1 %NullCheck22, label %59, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
   %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
   %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
-  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
-  br i1 %NullCheck24, label %63, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
   %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
-  br i1 %NullCheck26, label %66, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
   %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
-  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
-  br i1 %NullCheck28, label %69, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %69
 
 ; <label>:69                                      ; preds = %66
   %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
@@ -9744,15 +11333,15 @@ entry:
 
 ; <label>:71                                      ; preds = %105
   %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
-  br i1 %NullCheck34, label %73, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %73
 
 ; <label>:73                                      ; preds = %71
   %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
   %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
   %76 = load i32, i32* %loc0
-  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
-  br i1 %NullCheck36, label %77, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
@@ -9766,8 +11355,8 @@ entry:
 
 ; <label>:83                                      ; preds = %77
   %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
-  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
@@ -9775,14 +11364,14 @@ entry:
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
   %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
-  br i1 %NullCheck40, label %91, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
 ; <label>:91                                      ; preds = %85
   %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
   %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
-  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck42, label %94, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %94
 
 ; <label>:94                                      ; preds = %91
   %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
@@ -9798,14 +11387,14 @@ entry:
 ; <label>:99                                      ; preds = %69, %96
   %100 = load i32, i32* %loc0
   %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
-  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %102
 
 ; <label>:102                                     ; preds = %99
   %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
   %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
-  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
-  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
@@ -9819,87 +11408,87 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %26
+ThrowNullRef10:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %31
+ThrowNullRef12:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %35
+ThrowNullRef14:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %40
+ThrowNullRef16:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %56
+ThrowNullRef22:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %59
+ThrowNullRef24:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %63
+ThrowNullRef26:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %66
+ThrowNullRef28:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %102
+ThrowNullRef32:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %71
+ThrowNullRef34:                                   ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %73
+ThrowNullRef36:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %83
+ThrowNullRef38:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %85
+ThrowNullRef40:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %91
+ThrowNullRef42:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9943,15 +11532,15 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
   %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
@@ -9961,28 +11550,28 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
   %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %12
   %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
   %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
   %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
-  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
@@ -9993,23 +11582,23 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %12
+ThrowNullRef6:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10031,15 +11620,15 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
   %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = load i64, i64 addrspace(1)* %7
@@ -10077,13 +11666,13 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[loadElem]
+Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -10111,8 +11700,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -10184,8 +11773,8 @@ entry:
   store i32 addrspace(1)* %param1, i32 addrspace(1)** %arg1
   %0 = load i32, i32* %arg0
   %1 = load i32 addrspace(1)*, i32 addrspace(1)** %arg1
-  %NullCheck = icmp ne i32 addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq i32 addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load i32, i32 addrspace(1)* %1, align 8

--- a/test/BaseLine/JIT/CodeGenBringUpTests/RightShiftRef.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/RightShiftRef.error.txt
@@ -25,8 +25,8 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
@@ -40,8 +40,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
   %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
@@ -75,7 +75,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -90,8 +90,8 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %NullCheck = icmp ne i8 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = load i8, i8 addrspace(1)* %0, align 8
@@ -125,8 +125,8 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
@@ -159,8 +159,8 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -184,8 +184,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
   store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
@@ -195,8 +195,8 @@ entry:
 ; <label>:4                                       ; preds = %1
   %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
   %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
@@ -206,8 +206,8 @@ entry:
   %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
@@ -221,14 +221,14 @@ entry:
 
 ; <label>:17                                      ; preds = %14
   %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
   %21 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
@@ -238,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -249,8 +249,8 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
@@ -261,27 +261,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %30
+ThrowNullRef10:                                   ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -301,7 +301,89 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
-Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
+Successfully read AppDomainSetup.GetUnsecureApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.GetUnsecureApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %NullCheck = icmp eq %"System.String[]" addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %BoundsCheck = icmp uge i64 0, %5
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %6
+
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 3, i32 0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
+  ret %System.String addrspace(1)* %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_Value using LLILCJit
+Successfully read AppDomainSetup.get_Value
+
+define %"System.String[]" addrspace(1)* @AppDomainSetup.get_Value(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.String[]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 18)
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.String[]" addrspace(1)* addrspace(1)*, %"System.String[]" addrspace(1)*)*)(%"System.String[]" addrspace(1)* addrspace(1)* %9, %"System.String[]" addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %11, i32 0, i32 1
+  %14 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %13, align 8
+  ret %"System.String[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -319,8 +401,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -368,16 +450,16 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
   %5 = load i32, i32 addrspace(1)* %4
   %6 = sub i32 %5, 1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -389,7 +471,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -421,8 +503,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
@@ -456,8 +538,8 @@ entry:
 ; <label>:27                                      ; preds = %19
   %28 = load i32, i32* %arg1
   %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
-  br i1 %NullCheck2, label %30, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %29, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %30
 
 ; <label>:30                                      ; preds = %27
   %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
@@ -493,8 +575,8 @@ entry:
 ; <label>:49                                      ; preds = %46
   %50 = load i32, i32* %arg2
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck4, label %52, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
@@ -517,11 +599,11 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %27
+ThrowNullRef2:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %49
+ThrowNullRef4:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -544,16 +626,16 @@ entry:
   %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %0)
   store %System.String addrspace(1)* %1, %System.String addrspace(1)** %loc0
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 2
   %5 = bitcast [0 x i16] addrspace(1)* %4 to i16 addrspace(1)*
   store i16 addrspace(1)* %5, i16 addrspace(1)** %loc1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %3
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2
@@ -580,7 +662,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -691,15 +773,15 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %NullCheck132 = icmp ne i8* %21, null
-  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+  %NullCheck131 = icmp eq i8* %21, null
+  br i1 %NullCheck131, label %ThrowNullRef132, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = load i8, i8* %21, align 8
   %24 = zext i8 %23 to i32
   %25 = trunc i32 %24 to i8
-  %NullCheck134 = icmp ne i8* %20, null
-  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+  %NullCheck133 = icmp eq i8* %20, null
+  br i1 %NullCheck133, label %ThrowNullRef134, label %26
 
 ; <label>:26                                      ; preds = %22
   store i8 %25, i8* %20, align 8
@@ -709,16 +791,16 @@ entry:
   %28 = load i8*, i8** %arg0
   %29 = load i8*, i8** %arg1
   %30 = bitcast i8* %29 to i16*
-  %NullCheck128 = icmp ne i16* %30, null
-  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+  %NullCheck127 = icmp eq i16* %30, null
+  br i1 %NullCheck127, label %ThrowNullRef128, label %31
 
 ; <label>:31                                      ; preds = %27
   %32 = load i16, i16* %30, align 8
   %33 = sext i16 %32 to i32
   %34 = bitcast i8* %28 to i16*
   %35 = trunc i32 %33 to i16
-  %NullCheck130 = icmp ne i16* %34, null
-  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+  %NullCheck129 = icmp eq i16* %34, null
+  br i1 %NullCheck129, label %ThrowNullRef130, label %36
 
 ; <label>:36                                      ; preds = %31
   store i16 %35, i16* %34, align 8
@@ -728,16 +810,16 @@ entry:
   %38 = load i8*, i8** %arg0
   %39 = load i8*, i8** %arg1
   %40 = bitcast i8* %39 to i16*
-  %NullCheck120 = icmp ne i16* %40, null
-  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+  %NullCheck119 = icmp eq i16* %40, null
+  br i1 %NullCheck119, label %ThrowNullRef120, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i16, i16* %40, align 8
   %43 = sext i16 %42 to i32
   %44 = bitcast i8* %38 to i16*
   %45 = trunc i32 %43 to i16
-  %NullCheck122 = icmp ne i16* %44, null
-  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+  %NullCheck121 = icmp eq i16* %44, null
+  br i1 %NullCheck121, label %ThrowNullRef122, label %46
 
 ; <label>:46                                      ; preds = %41
   store i16 %45, i16* %44, align 8
@@ -745,15 +827,15 @@ entry:
   %48 = getelementptr inbounds i8, i8* %47, i64 2
   %49 = load i8*, i8** %arg1
   %50 = getelementptr inbounds i8, i8* %49, i64 2
-  %NullCheck124 = icmp ne i8* %50, null
-  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+  %NullCheck123 = icmp eq i8* %50, null
+  br i1 %NullCheck123, label %ThrowNullRef124, label %51
 
 ; <label>:51                                      ; preds = %46
   %52 = load i8, i8* %50, align 8
   %53 = zext i8 %52 to i32
   %54 = trunc i32 %53 to i8
-  %NullCheck126 = icmp ne i8* %48, null
-  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+  %NullCheck125 = icmp eq i8* %48, null
+  br i1 %NullCheck125, label %ThrowNullRef126, label %55
 
 ; <label>:55                                      ; preds = %51
   store i8 %54, i8* %48, align 8
@@ -763,14 +845,14 @@ entry:
   %57 = load i8*, i8** %arg0
   %58 = load i8*, i8** %arg1
   %59 = bitcast i8* %58 to i32*
-  %NullCheck116 = icmp ne i32* %59, null
-  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+  %NullCheck115 = icmp eq i32* %59, null
+  br i1 %NullCheck115, label %ThrowNullRef116, label %60
 
 ; <label>:60                                      ; preds = %56
   %61 = load i32, i32* %59, align 8
   %62 = bitcast i8* %57 to i32*
-  %NullCheck118 = icmp ne i32* %62, null
-  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+  %NullCheck117 = icmp eq i32* %62, null
+  br i1 %NullCheck117, label %ThrowNullRef118, label %63
 
 ; <label>:63                                      ; preds = %60
   store i32 %61, i32* %62, align 8
@@ -780,14 +862,14 @@ entry:
   %65 = load i8*, i8** %arg0
   %66 = load i8*, i8** %arg1
   %67 = bitcast i8* %66 to i32*
-  %NullCheck108 = icmp ne i32* %67, null
-  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+  %NullCheck107 = icmp eq i32* %67, null
+  br i1 %NullCheck107, label %ThrowNullRef108, label %68
 
 ; <label>:68                                      ; preds = %64
   %69 = load i32, i32* %67, align 8
   %70 = bitcast i8* %65 to i32*
-  %NullCheck110 = icmp ne i32* %70, null
-  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+  %NullCheck109 = icmp eq i32* %70, null
+  br i1 %NullCheck109, label %ThrowNullRef110, label %71
 
 ; <label>:71                                      ; preds = %68
   store i32 %69, i32* %70, align 8
@@ -795,15 +877,15 @@ entry:
   %73 = getelementptr inbounds i8, i8* %72, i64 4
   %74 = load i8*, i8** %arg1
   %75 = getelementptr inbounds i8, i8* %74, i64 4
-  %NullCheck112 = icmp ne i8* %75, null
-  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+  %NullCheck111 = icmp eq i8* %75, null
+  br i1 %NullCheck111, label %ThrowNullRef112, label %76
 
 ; <label>:76                                      ; preds = %71
   %77 = load i8, i8* %75, align 8
   %78 = zext i8 %77 to i32
   %79 = trunc i32 %78 to i8
-  %NullCheck114 = icmp ne i8* %73, null
-  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+  %NullCheck113 = icmp eq i8* %73, null
+  br i1 %NullCheck113, label %ThrowNullRef114, label %80
 
 ; <label>:80                                      ; preds = %76
   store i8 %79, i8* %73, align 8
@@ -813,14 +895,14 @@ entry:
   %82 = load i8*, i8** %arg0
   %83 = load i8*, i8** %arg1
   %84 = bitcast i8* %83 to i32*
-  %NullCheck100 = icmp ne i32* %84, null
-  br i1 %NullCheck100, label %85, label %ThrowNullRef99
+  %NullCheck99 = icmp eq i32* %84, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %85
 
 ; <label>:85                                      ; preds = %81
   %86 = load i32, i32* %84, align 8
   %87 = bitcast i8* %82 to i32*
-  %NullCheck102 = icmp ne i32* %87, null
-  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+  %NullCheck101 = icmp eq i32* %87, null
+  br i1 %NullCheck101, label %ThrowNullRef102, label %88
 
 ; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
@@ -829,16 +911,16 @@ entry:
   %91 = load i8*, i8** %arg1
   %92 = getelementptr inbounds i8, i8* %91, i64 4
   %93 = bitcast i8* %92 to i16*
-  %NullCheck104 = icmp ne i16* %93, null
-  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+  %NullCheck103 = icmp eq i16* %93, null
+  br i1 %NullCheck103, label %ThrowNullRef104, label %94
 
 ; <label>:94                                      ; preds = %88
   %95 = load i16, i16* %93, align 8
   %96 = sext i16 %95 to i32
   %97 = bitcast i8* %90 to i16*
   %98 = trunc i32 %96 to i16
-  %NullCheck106 = icmp ne i16* %97, null
-  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+  %NullCheck105 = icmp eq i16* %97, null
+  br i1 %NullCheck105, label %ThrowNullRef106, label %99
 
 ; <label>:99                                      ; preds = %94
   store i16 %98, i16* %97, align 8
@@ -848,14 +930,14 @@ entry:
   %101 = load i8*, i8** %arg0
   %102 = load i8*, i8** %arg1
   %103 = bitcast i8* %102 to i32*
-  %NullCheck88 = icmp ne i32* %103, null
-  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+  %NullCheck87 = icmp eq i32* %103, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %104
 
 ; <label>:104                                     ; preds = %100
   %105 = load i32, i32* %103, align 8
   %106 = bitcast i8* %101 to i32*
-  %NullCheck90 = icmp ne i32* %106, null
-  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+  %NullCheck89 = icmp eq i32* %106, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %107
 
 ; <label>:107                                     ; preds = %104
   store i32 %105, i32* %106, align 8
@@ -864,16 +946,16 @@ entry:
   %110 = load i8*, i8** %arg1
   %111 = getelementptr inbounds i8, i8* %110, i64 4
   %112 = bitcast i8* %111 to i16*
-  %NullCheck92 = icmp ne i16* %112, null
-  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+  %NullCheck91 = icmp eq i16* %112, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %113
 
 ; <label>:113                                     ; preds = %107
   %114 = load i16, i16* %112, align 8
   %115 = sext i16 %114 to i32
   %116 = bitcast i8* %109 to i16*
   %117 = trunc i32 %115 to i16
-  %NullCheck94 = icmp ne i16* %116, null
-  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+  %NullCheck93 = icmp eq i16* %116, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %118
 
 ; <label>:118                                     ; preds = %113
   store i16 %117, i16* %116, align 8
@@ -881,15 +963,15 @@ entry:
   %120 = getelementptr inbounds i8, i8* %119, i64 6
   %121 = load i8*, i8** %arg1
   %122 = getelementptr inbounds i8, i8* %121, i64 6
-  %NullCheck96 = icmp ne i8* %122, null
-  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+  %NullCheck95 = icmp eq i8* %122, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %123
 
 ; <label>:123                                     ; preds = %118
   %124 = load i8, i8* %122, align 8
   %125 = zext i8 %124 to i32
   %126 = trunc i32 %125 to i8
-  %NullCheck98 = icmp ne i8* %120, null
-  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+  %NullCheck97 = icmp eq i8* %120, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %127
 
 ; <label>:127                                     ; preds = %123
   store i8 %126, i8* %120, align 8
@@ -899,14 +981,14 @@ entry:
   %129 = load i8*, i8** %arg0
   %130 = load i8*, i8** %arg1
   %131 = bitcast i8* %130 to i64*
-  %NullCheck84 = icmp ne i64* %131, null
-  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+  %NullCheck83 = icmp eq i64* %131, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %132
 
 ; <label>:132                                     ; preds = %128
   %133 = load i64, i64* %131, align 8
   %134 = bitcast i8* %129 to i64*
-  %NullCheck86 = icmp ne i64* %134, null
-  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+  %NullCheck85 = icmp eq i64* %134, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %135
 
 ; <label>:135                                     ; preds = %132
   store i64 %133, i64* %134, align 8
@@ -916,14 +998,14 @@ entry:
   %137 = load i8*, i8** %arg0
   %138 = load i8*, i8** %arg1
   %139 = bitcast i8* %138 to i64*
-  %NullCheck76 = icmp ne i64* %139, null
-  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+  %NullCheck75 = icmp eq i64* %139, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %140
 
 ; <label>:140                                     ; preds = %136
   %141 = load i64, i64* %139, align 8
   %142 = bitcast i8* %137 to i64*
-  %NullCheck78 = icmp ne i64* %142, null
-  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+  %NullCheck77 = icmp eq i64* %142, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %143
 
 ; <label>:143                                     ; preds = %140
   store i64 %141, i64* %142, align 8
@@ -931,15 +1013,15 @@ entry:
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %NullCheck80 = icmp ne i8* %147, null
-  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+  %NullCheck79 = icmp eq i8* %147, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %148
 
 ; <label>:148                                     ; preds = %143
   %149 = load i8, i8* %147, align 8
   %150 = zext i8 %149 to i32
   %151 = trunc i32 %150 to i8
-  %NullCheck82 = icmp ne i8* %145, null
-  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+  %NullCheck81 = icmp eq i8* %145, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %152
 
 ; <label>:152                                     ; preds = %148
   store i8 %151, i8* %145, align 8
@@ -949,14 +1031,14 @@ entry:
   %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
   %156 = bitcast i8* %155 to i64*
-  %NullCheck68 = icmp ne i64* %156, null
-  br i1 %NullCheck68, label %157, label %ThrowNullRef67
+  %NullCheck67 = icmp eq i64* %156, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %157
 
 ; <label>:157                                     ; preds = %153
   %158 = load i64, i64* %156, align 8
   %159 = bitcast i8* %154 to i64*
-  %NullCheck70 = icmp ne i64* %159, null
-  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+  %NullCheck69 = icmp eq i64* %159, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %160
 
 ; <label>:160                                     ; preds = %157
   store i64 %158, i64* %159, align 8
@@ -965,16 +1047,16 @@ entry:
   %163 = load i8*, i8** %arg1
   %164 = getelementptr inbounds i8, i8* %163, i64 8
   %165 = bitcast i8* %164 to i16*
-  %NullCheck72 = icmp ne i16* %165, null
-  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+  %NullCheck71 = icmp eq i16* %165, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %166
 
 ; <label>:166                                     ; preds = %160
   %167 = load i16, i16* %165, align 8
   %168 = sext i16 %167 to i32
   %169 = bitcast i8* %162 to i16*
   %170 = trunc i32 %168 to i16
-  %NullCheck74 = icmp ne i16* %169, null
-  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+  %NullCheck73 = icmp eq i16* %169, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %171
 
 ; <label>:171                                     ; preds = %166
   store i16 %170, i16* %169, align 8
@@ -984,14 +1066,14 @@ entry:
   %173 = load i8*, i8** %arg0
   %174 = load i8*, i8** %arg1
   %175 = bitcast i8* %174 to i64*
-  %NullCheck56 = icmp ne i64* %175, null
-  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+  %NullCheck55 = icmp eq i64* %175, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %176
 
 ; <label>:176                                     ; preds = %172
   %177 = load i64, i64* %175, align 8
   %178 = bitcast i8* %173 to i64*
-  %NullCheck58 = icmp ne i64* %178, null
-  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+  %NullCheck57 = icmp eq i64* %178, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %179
 
 ; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
@@ -1000,16 +1082,16 @@ entry:
   %182 = load i8*, i8** %arg1
   %183 = getelementptr inbounds i8, i8* %182, i64 8
   %184 = bitcast i8* %183 to i16*
-  %NullCheck60 = icmp ne i16* %184, null
-  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+  %NullCheck59 = icmp eq i16* %184, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %185
 
 ; <label>:185                                     ; preds = %179
   %186 = load i16, i16* %184, align 8
   %187 = sext i16 %186 to i32
   %188 = bitcast i8* %181 to i16*
   %189 = trunc i32 %187 to i16
-  %NullCheck62 = icmp ne i16* %188, null
-  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+  %NullCheck61 = icmp eq i16* %188, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %190
 
 ; <label>:190                                     ; preds = %185
   store i16 %189, i16* %188, align 8
@@ -1017,15 +1099,15 @@ entry:
   %192 = getelementptr inbounds i8, i8* %191, i64 10
   %193 = load i8*, i8** %arg1
   %194 = getelementptr inbounds i8, i8* %193, i64 10
-  %NullCheck64 = icmp ne i8* %194, null
-  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+  %NullCheck63 = icmp eq i8* %194, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %195
 
 ; <label>:195                                     ; preds = %190
   %196 = load i8, i8* %194, align 8
   %197 = zext i8 %196 to i32
   %198 = trunc i32 %197 to i8
-  %NullCheck66 = icmp ne i8* %192, null
-  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+  %NullCheck65 = icmp eq i8* %192, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %199
 
 ; <label>:199                                     ; preds = %195
   store i8 %198, i8* %192, align 8
@@ -1035,14 +1117,14 @@ entry:
   %201 = load i8*, i8** %arg0
   %202 = load i8*, i8** %arg1
   %203 = bitcast i8* %202 to i64*
-  %NullCheck48 = icmp ne i64* %203, null
-  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+  %NullCheck47 = icmp eq i64* %203, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %204
 
 ; <label>:204                                     ; preds = %200
   %205 = load i64, i64* %203, align 8
   %206 = bitcast i8* %201 to i64*
-  %NullCheck50 = icmp ne i64* %206, null
-  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+  %NullCheck49 = icmp eq i64* %206, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %207
 
 ; <label>:207                                     ; preds = %204
   store i64 %205, i64* %206, align 8
@@ -1051,14 +1133,14 @@ entry:
   %210 = load i8*, i8** %arg1
   %211 = getelementptr inbounds i8, i8* %210, i64 8
   %212 = bitcast i8* %211 to i32*
-  %NullCheck52 = icmp ne i32* %212, null
-  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+  %NullCheck51 = icmp eq i32* %212, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %213
 
 ; <label>:213                                     ; preds = %207
   %214 = load i32, i32* %212, align 8
   %215 = bitcast i8* %209 to i32*
-  %NullCheck54 = icmp ne i32* %215, null
-  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+  %NullCheck53 = icmp eq i32* %215, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %216
 
 ; <label>:216                                     ; preds = %213
   store i32 %214, i32* %215, align 8
@@ -1068,14 +1150,14 @@ entry:
   %218 = load i8*, i8** %arg0
   %219 = load i8*, i8** %arg1
   %220 = bitcast i8* %219 to i64*
-  %NullCheck36 = icmp ne i64* %220, null
-  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64* %220, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %221
 
 ; <label>:221                                     ; preds = %217
   %222 = load i64, i64* %220, align 8
   %223 = bitcast i8* %218 to i64*
-  %NullCheck38 = icmp ne i64* %223, null
-  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+  %NullCheck37 = icmp eq i64* %223, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %224
 
 ; <label>:224                                     ; preds = %221
   store i64 %222, i64* %223, align 8
@@ -1084,14 +1166,14 @@ entry:
   %227 = load i8*, i8** %arg1
   %228 = getelementptr inbounds i8, i8* %227, i64 8
   %229 = bitcast i8* %228 to i32*
-  %NullCheck40 = icmp ne i32* %229, null
-  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i32* %229, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %230
 
 ; <label>:230                                     ; preds = %224
   %231 = load i32, i32* %229, align 8
   %232 = bitcast i8* %226 to i32*
-  %NullCheck42 = icmp ne i32* %232, null
-  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+  %NullCheck41 = icmp eq i32* %232, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %233
 
 ; <label>:233                                     ; preds = %230
   store i32 %231, i32* %232, align 8
@@ -1099,15 +1181,15 @@ entry:
   %235 = getelementptr inbounds i8, i8* %234, i64 12
   %236 = load i8*, i8** %arg1
   %237 = getelementptr inbounds i8, i8* %236, i64 12
-  %NullCheck44 = icmp ne i8* %237, null
-  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i8* %237, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %238
 
 ; <label>:238                                     ; preds = %233
   %239 = load i8, i8* %237, align 8
   %240 = zext i8 %239 to i32
   %241 = trunc i32 %240 to i8
-  %NullCheck46 = icmp ne i8* %235, null
-  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+  %NullCheck45 = icmp eq i8* %235, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %242
 
 ; <label>:242                                     ; preds = %238
   store i8 %241, i8* %235, align 8
@@ -1117,14 +1199,14 @@ entry:
   %244 = load i8*, i8** %arg0
   %245 = load i8*, i8** %arg1
   %246 = bitcast i8* %245 to i64*
-  %NullCheck24 = icmp ne i64* %246, null
-  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64* %246, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %247
 
 ; <label>:247                                     ; preds = %243
   %248 = load i64, i64* %246, align 8
   %249 = bitcast i8* %244 to i64*
-  %NullCheck26 = icmp ne i64* %249, null
-  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64* %249, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %250
 
 ; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
@@ -1133,14 +1215,14 @@ entry:
   %253 = load i8*, i8** %arg1
   %254 = getelementptr inbounds i8, i8* %253, i64 8
   %255 = bitcast i8* %254 to i32*
-  %NullCheck28 = icmp ne i32* %255, null
-  br i1 %NullCheck28, label %256, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i32* %255, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %256
 
 ; <label>:256                                     ; preds = %250
   %257 = load i32, i32* %255, align 8
   %258 = bitcast i8* %252 to i32*
-  %NullCheck30 = icmp ne i32* %258, null
-  br i1 %NullCheck30, label %259, label %ThrowNullRef29
+  %NullCheck29 = icmp eq i32* %258, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %259
 
 ; <label>:259                                     ; preds = %256
   store i32 %257, i32* %258, align 8
@@ -1149,16 +1231,16 @@ entry:
   %262 = load i8*, i8** %arg1
   %263 = getelementptr inbounds i8, i8* %262, i64 12
   %264 = bitcast i8* %263 to i16*
-  %NullCheck32 = icmp ne i16* %264, null
-  br i1 %NullCheck32, label %265, label %ThrowNullRef31
+  %NullCheck31 = icmp eq i16* %264, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %265
 
 ; <label>:265                                     ; preds = %259
   %266 = load i16, i16* %264, align 8
   %267 = sext i16 %266 to i32
   %268 = bitcast i8* %261 to i16*
   %269 = trunc i32 %267 to i16
-  %NullCheck34 = icmp ne i16* %268, null
-  br i1 %NullCheck34, label %270, label %ThrowNullRef33
+  %NullCheck33 = icmp eq i16* %268, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %270
 
 ; <label>:270                                     ; preds = %265
   store i16 %269, i16* %268, align 8
@@ -1168,14 +1250,14 @@ entry:
   %272 = load i8*, i8** %arg0
   %273 = load i8*, i8** %arg1
   %274 = bitcast i8* %273 to i64*
-  %NullCheck8 = icmp ne i64* %274, null
-  br i1 %NullCheck8, label %275, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64* %274, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %275
 
 ; <label>:275                                     ; preds = %271
   %276 = load i64, i64* %274, align 8
   %277 = bitcast i8* %272 to i64*
-  %NullCheck10 = icmp ne i64* %277, null
-  br i1 %NullCheck10, label %278, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %277, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %278
 
 ; <label>:278                                     ; preds = %275
   store i64 %276, i64* %277, align 8
@@ -1184,14 +1266,14 @@ entry:
   %281 = load i8*, i8** %arg1
   %282 = getelementptr inbounds i8, i8* %281, i64 8
   %283 = bitcast i8* %282 to i32*
-  %NullCheck12 = icmp ne i32* %283, null
-  br i1 %NullCheck12, label %284, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i32* %283, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %284
 
 ; <label>:284                                     ; preds = %278
   %285 = load i32, i32* %283, align 8
   %286 = bitcast i8* %280 to i32*
-  %NullCheck14 = icmp ne i32* %286, null
-  br i1 %NullCheck14, label %287, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i32* %286, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %287
 
 ; <label>:287                                     ; preds = %284
   store i32 %285, i32* %286, align 8
@@ -1200,16 +1282,16 @@ entry:
   %290 = load i8*, i8** %arg1
   %291 = getelementptr inbounds i8, i8* %290, i64 12
   %292 = bitcast i8* %291 to i16*
-  %NullCheck16 = icmp ne i16* %292, null
-  br i1 %NullCheck16, label %293, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i16* %292, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %293
 
 ; <label>:293                                     ; preds = %287
   %294 = load i16, i16* %292, align 8
   %295 = sext i16 %294 to i32
   %296 = bitcast i8* %289 to i16*
   %297 = trunc i32 %295 to i16
-  %NullCheck18 = icmp ne i16* %296, null
-  br i1 %NullCheck18, label %298, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i16* %296, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %298
 
 ; <label>:298                                     ; preds = %293
   store i16 %297, i16* %296, align 8
@@ -1217,15 +1299,15 @@ entry:
   %300 = getelementptr inbounds i8, i8* %299, i64 14
   %301 = load i8*, i8** %arg1
   %302 = getelementptr inbounds i8, i8* %301, i64 14
-  %NullCheck20 = icmp ne i8* %302, null
-  br i1 %NullCheck20, label %303, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i8* %302, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %303
 
 ; <label>:303                                     ; preds = %298
   %304 = load i8, i8* %302, align 8
   %305 = zext i8 %304 to i32
   %306 = trunc i32 %305 to i8
-  %NullCheck22 = icmp ne i8* %300, null
-  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i8* %300, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %307
 
 ; <label>:307                                     ; preds = %303
   store i8 %306, i8* %300, align 8
@@ -1235,14 +1317,14 @@ entry:
   %309 = load i8*, i8** %arg0
   %310 = load i8*, i8** %arg1
   %311 = bitcast i8* %310 to i64*
-  %NullCheck = icmp ne i64* %311, null
-  br i1 %NullCheck, label %312, label %ThrowNullRef
+  %NullCheck = icmp eq i64* %311, null
+  br i1 %NullCheck, label %ThrowNullRef, label %312
 
 ; <label>:312                                     ; preds = %308
   %313 = load i64, i64* %311, align 8
   %314 = bitcast i8* %309 to i64*
-  %NullCheck2 = icmp ne i64* %314, null
-  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64* %314, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %315
 
 ; <label>:315                                     ; preds = %312
   store i64 %313, i64* %314, align 8
@@ -1251,14 +1333,14 @@ entry:
   %318 = load i8*, i8** %arg1
   %319 = getelementptr inbounds i8, i8* %318, i64 8
   %320 = bitcast i8* %319 to i64*
-  %NullCheck4 = icmp ne i64* %320, null
-  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64* %320, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %321
 
 ; <label>:321                                     ; preds = %315
   %322 = load i64, i64* %320, align 8
   %323 = bitcast i8* %317 to i64*
-  %NullCheck6 = icmp ne i64* %323, null
-  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64* %323, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %324
 
 ; <label>:324                                     ; preds = %321
   store i64 %322, i64* %323, align 8
@@ -1286,15 +1368,15 @@ entry:
 ; <label>:338                                     ; preds = %333
   %339 = load i8*, i8** %arg0
   %340 = load i8*, i8** %arg1
-  %NullCheck136 = icmp ne i8* %340, null
-  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+  %NullCheck135 = icmp eq i8* %340, null
+  br i1 %NullCheck135, label %ThrowNullRef136, label %341
 
 ; <label>:341                                     ; preds = %338
   %342 = load i8, i8* %340, align 8
   %343 = zext i8 %342 to i32
   %344 = trunc i32 %343 to i8
-  %NullCheck138 = icmp ne i8* %339, null
-  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+  %NullCheck137 = icmp eq i8* %339, null
+  br i1 %NullCheck137, label %ThrowNullRef138, label %345
 
 ; <label>:345                                     ; preds = %341
   store i8 %344, i8* %339, align 8
@@ -1317,16 +1399,16 @@ entry:
   %357 = load i8*, i8** %arg0
   %358 = load i8*, i8** %arg1
   %359 = bitcast i8* %358 to i16*
-  %NullCheck140 = icmp ne i16* %359, null
-  br i1 %NullCheck140, label %360, label %ThrowNullRef139
+  %NullCheck139 = icmp eq i16* %359, null
+  br i1 %NullCheck139, label %ThrowNullRef140, label %360
 
 ; <label>:360                                     ; preds = %356
   %361 = load i16, i16* %359, align 8
   %362 = sext i16 %361 to i32
   %363 = bitcast i8* %357 to i16*
   %364 = trunc i32 %362 to i16
-  %NullCheck142 = icmp ne i16* %363, null
-  br i1 %NullCheck142, label %365, label %ThrowNullRef141
+  %NullCheck141 = icmp eq i16* %363, null
+  br i1 %NullCheck141, label %ThrowNullRef142, label %365
 
 ; <label>:365                                     ; preds = %360
   store i16 %364, i16* %363, align 8
@@ -1352,14 +1434,14 @@ entry:
   %378 = load i8*, i8** %arg0
   %379 = load i8*, i8** %arg1
   %380 = bitcast i8* %379 to i32*
-  %NullCheck144 = icmp ne i32* %380, null
-  br i1 %NullCheck144, label %381, label %ThrowNullRef143
+  %NullCheck143 = icmp eq i32* %380, null
+  br i1 %NullCheck143, label %ThrowNullRef144, label %381
 
 ; <label>:381                                     ; preds = %377
   %382 = load i32, i32* %380, align 8
   %383 = bitcast i8* %378 to i32*
-  %NullCheck146 = icmp ne i32* %383, null
-  br i1 %NullCheck146, label %384, label %ThrowNullRef145
+  %NullCheck145 = icmp eq i32* %383, null
+  br i1 %NullCheck145, label %ThrowNullRef146, label %384
 
 ; <label>:384                                     ; preds = %381
   store i32 %382, i32* %383, align 8
@@ -1384,14 +1466,14 @@ entry:
   %395 = load i8*, i8** %arg0
   %396 = load i8*, i8** %arg1
   %397 = bitcast i8* %396 to i64*
-  %NullCheck164 = icmp ne i64* %397, null
-  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+  %NullCheck163 = icmp eq i64* %397, null
+  br i1 %NullCheck163, label %ThrowNullRef164, label %398
 
 ; <label>:398                                     ; preds = %394
   %399 = load i64, i64* %397, align 8
   %400 = bitcast i8* %395 to i64*
-  %NullCheck166 = icmp ne i64* %400, null
-  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+  %NullCheck165 = icmp eq i64* %400, null
+  br i1 %NullCheck165, label %ThrowNullRef166, label %401
 
 ; <label>:401                                     ; preds = %398
   store i64 %399, i64* %400, align 8
@@ -1400,14 +1482,14 @@ entry:
   %404 = load i8*, i8** %arg1
   %405 = getelementptr inbounds i8, i8* %404, i64 8
   %406 = bitcast i8* %405 to i64*
-  %NullCheck168 = icmp ne i64* %406, null
-  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+  %NullCheck167 = icmp eq i64* %406, null
+  br i1 %NullCheck167, label %ThrowNullRef168, label %407
 
 ; <label>:407                                     ; preds = %401
   %408 = load i64, i64* %406, align 8
   %409 = bitcast i8* %403 to i64*
-  %NullCheck170 = icmp ne i64* %409, null
-  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+  %NullCheck169 = icmp eq i64* %409, null
+  br i1 %NullCheck169, label %ThrowNullRef170, label %410
 
 ; <label>:410                                     ; preds = %407
   store i64 %408, i64* %409, align 8
@@ -1437,14 +1519,14 @@ entry:
   %425 = load i8*, i8** %arg0
   %426 = load i8*, i8** %arg1
   %427 = bitcast i8* %426 to i64*
-  %NullCheck148 = icmp ne i64* %427, null
-  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+  %NullCheck147 = icmp eq i64* %427, null
+  br i1 %NullCheck147, label %ThrowNullRef148, label %428
 
 ; <label>:428                                     ; preds = %424
   %429 = load i64, i64* %427, align 8
   %430 = bitcast i8* %425 to i64*
-  %NullCheck150 = icmp ne i64* %430, null
-  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+  %NullCheck149 = icmp eq i64* %430, null
+  br i1 %NullCheck149, label %ThrowNullRef150, label %431
 
 ; <label>:431                                     ; preds = %428
   store i64 %429, i64* %430, align 8
@@ -1466,14 +1548,14 @@ entry:
   %441 = load i8*, i8** %arg0
   %442 = load i8*, i8** %arg1
   %443 = bitcast i8* %442 to i32*
-  %NullCheck152 = icmp ne i32* %443, null
-  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+  %NullCheck151 = icmp eq i32* %443, null
+  br i1 %NullCheck151, label %ThrowNullRef152, label %444
 
 ; <label>:444                                     ; preds = %440
   %445 = load i32, i32* %443, align 8
   %446 = bitcast i8* %441 to i32*
-  %NullCheck154 = icmp ne i32* %446, null
-  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+  %NullCheck153 = icmp eq i32* %446, null
+  br i1 %NullCheck153, label %ThrowNullRef154, label %447
 
 ; <label>:447                                     ; preds = %444
   store i32 %445, i32* %446, align 8
@@ -1495,16 +1577,16 @@ entry:
   %457 = load i8*, i8** %arg0
   %458 = load i8*, i8** %arg1
   %459 = bitcast i8* %458 to i16*
-  %NullCheck156 = icmp ne i16* %459, null
-  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+  %NullCheck155 = icmp eq i16* %459, null
+  br i1 %NullCheck155, label %ThrowNullRef156, label %460
 
 ; <label>:460                                     ; preds = %456
   %461 = load i16, i16* %459, align 8
   %462 = sext i16 %461 to i32
   %463 = bitcast i8* %457 to i16*
   %464 = trunc i32 %462 to i16
-  %NullCheck158 = icmp ne i16* %463, null
-  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+  %NullCheck157 = icmp eq i16* %463, null
+  br i1 %NullCheck157, label %ThrowNullRef158, label %465
 
 ; <label>:465                                     ; preds = %460
   store i16 %464, i16* %463, align 8
@@ -1525,15 +1607,15 @@ entry:
 ; <label>:474                                     ; preds = %470
   %475 = load i8*, i8** %arg0
   %476 = load i8*, i8** %arg1
-  %NullCheck160 = icmp ne i8* %476, null
-  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+  %NullCheck159 = icmp eq i8* %476, null
+  br i1 %NullCheck159, label %ThrowNullRef160, label %477
 
 ; <label>:477                                     ; preds = %474
   %478 = load i8, i8* %476, align 8
   %479 = zext i8 %478 to i32
   %480 = trunc i32 %479 to i8
-  %NullCheck162 = icmp ne i8* %475, null
-  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+  %NullCheck161 = icmp eq i8* %475, null
+  br i1 %NullCheck161, label %ThrowNullRef162, label %481
 
 ; <label>:481                                     ; preds = %477
   store i8 %480, i8* %475, align 8
@@ -1553,343 +1635,343 @@ ThrowNullRef:                                     ; preds = %308
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %312
+ThrowNullRef2:                                    ; preds = %312
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %315
+ThrowNullRef4:                                    ; preds = %315
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %321
+ThrowNullRef6:                                    ; preds = %321
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %271
+ThrowNullRef8:                                    ; preds = %271
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %275
+ThrowNullRef10:                                   ; preds = %275
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %278
+ThrowNullRef12:                                   ; preds = %278
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %284
+ThrowNullRef14:                                   ; preds = %284
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %287
+ThrowNullRef16:                                   ; preds = %287
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %293
+ThrowNullRef18:                                   ; preds = %293
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %298
+ThrowNullRef20:                                   ; preds = %298
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %303
+ThrowNullRef22:                                   ; preds = %303
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %243
+ThrowNullRef24:                                   ; preds = %243
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %247
+ThrowNullRef26:                                   ; preds = %247
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %250
+ThrowNullRef28:                                   ; preds = %250
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %256
+ThrowNullRef30:                                   ; preds = %256
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %259
+ThrowNullRef32:                                   ; preds = %259
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %265
+ThrowNullRef34:                                   ; preds = %265
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %217
+ThrowNullRef36:                                   ; preds = %217
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %221
+ThrowNullRef38:                                   ; preds = %221
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %224
+ThrowNullRef40:                                   ; preds = %224
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %230
+ThrowNullRef42:                                   ; preds = %230
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %233
+ThrowNullRef44:                                   ; preds = %233
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %238
+ThrowNullRef46:                                   ; preds = %238
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %200
+ThrowNullRef48:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %204
+ThrowNullRef50:                                   ; preds = %204
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %207
+ThrowNullRef52:                                   ; preds = %207
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %213
+ThrowNullRef54:                                   ; preds = %213
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %172
+ThrowNullRef56:                                   ; preds = %172
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %176
+ThrowNullRef58:                                   ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %179
+ThrowNullRef60:                                   ; preds = %179
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %185
+ThrowNullRef62:                                   ; preds = %185
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %190
+ThrowNullRef64:                                   ; preds = %190
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %195
+ThrowNullRef66:                                   ; preds = %195
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %153
+ThrowNullRef68:                                   ; preds = %153
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %157
+ThrowNullRef70:                                   ; preds = %157
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %160
+ThrowNullRef72:                                   ; preds = %160
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %166
+ThrowNullRef74:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %136
+ThrowNullRef76:                                   ; preds = %136
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %140
+ThrowNullRef78:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %143
+ThrowNullRef80:                                   ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %148
+ThrowNullRef82:                                   ; preds = %148
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %128
+ThrowNullRef84:                                   ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %132
+ThrowNullRef86:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %100
+ThrowNullRef88:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %104
+ThrowNullRef90:                                   ; preds = %104
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %107
+ThrowNullRef92:                                   ; preds = %107
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %113
+ThrowNullRef94:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %118
+ThrowNullRef96:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %123
+ThrowNullRef98:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %81
+ThrowNullRef100:                                  ; preds = %81
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef101:                                  ; preds = %85
+ThrowNullRef102:                                  ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef103:                                  ; preds = %88
+ThrowNullRef104:                                  ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef105:                                  ; preds = %94
+ThrowNullRef106:                                  ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef107:                                  ; preds = %64
+ThrowNullRef108:                                  ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef109:                                  ; preds = %68
+ThrowNullRef110:                                  ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef111:                                  ; preds = %71
+ThrowNullRef112:                                  ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef113:                                  ; preds = %76
+ThrowNullRef114:                                  ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef115:                                  ; preds = %56
+ThrowNullRef116:                                  ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef117:                                  ; preds = %60
+ThrowNullRef118:                                  ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef119:                                  ; preds = %37
+ThrowNullRef120:                                  ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef121:                                  ; preds = %41
+ThrowNullRef122:                                  ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef123:                                  ; preds = %46
+ThrowNullRef124:                                  ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef125:                                  ; preds = %51
+ThrowNullRef126:                                  ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef127:                                  ; preds = %27
+ThrowNullRef128:                                  ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef129:                                  ; preds = %31
+ThrowNullRef130:                                  ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef131:                                  ; preds = %19
+ThrowNullRef132:                                  ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef133:                                  ; preds = %22
+ThrowNullRef134:                                  ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef135:                                  ; preds = %338
+ThrowNullRef136:                                  ; preds = %338
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef137:                                  ; preds = %341
+ThrowNullRef138:                                  ; preds = %341
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef139:                                  ; preds = %356
+ThrowNullRef140:                                  ; preds = %356
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef141:                                  ; preds = %360
+ThrowNullRef142:                                  ; preds = %360
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef143:                                  ; preds = %377
+ThrowNullRef144:                                  ; preds = %377
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef145:                                  ; preds = %381
+ThrowNullRef146:                                  ; preds = %381
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef147:                                  ; preds = %424
+ThrowNullRef148:                                  ; preds = %424
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef149:                                  ; preds = %428
+ThrowNullRef150:                                  ; preds = %428
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef151:                                  ; preds = %440
+ThrowNullRef152:                                  ; preds = %440
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef153:                                  ; preds = %444
+ThrowNullRef154:                                  ; preds = %444
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef155:                                  ; preds = %456
+ThrowNullRef156:                                  ; preds = %456
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef157:                                  ; preds = %460
+ThrowNullRef158:                                  ; preds = %460
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef159:                                  ; preds = %474
+ThrowNullRef160:                                  ; preds = %474
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef161:                                  ; preds = %477
+ThrowNullRef162:                                  ; preds = %477
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef163:                                  ; preds = %394
+ThrowNullRef164:                                  ; preds = %394
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef165:                                  ; preds = %398
+ThrowNullRef166:                                  ; preds = %398
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef167:                                  ; preds = %401
+ThrowNullRef168:                                  ; preds = %401
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef169:                                  ; preds = %407
+ThrowNullRef170:                                  ; preds = %407
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1939,8 +2021,8 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
-  br i1 %NullCheck, label %22, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %ThrowNullRef, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
@@ -1948,8 +2030,8 @@ entry:
   store i32 %24, i32* %loc0
   %25 = load i32, i32* %loc0
   %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %26, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %27
 
 ; <label>:27                                      ; preds = %22
   %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
@@ -1971,7 +2053,7 @@ ThrowNullRef:                                     ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1989,8 +2071,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -2022,15 +2104,15 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2048,16 +2130,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
   %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
   store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %15
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
@@ -2072,8 +2154,8 @@ entry:
   %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
   %29 = ptrtoint i16 addrspace(1)* %28 to i64
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %19
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
@@ -2089,19 +2171,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2114,8 +2196,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
@@ -2128,7 +2210,7 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[loadElem]
+Failed to read AppDomain.PrepareDataForSetup[storeElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
@@ -2202,8 +2284,8 @@ entry:
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
-  br i1 %NullCheck24, label %27, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = load i64, i64 addrspace(1)* %26
@@ -2218,8 +2300,8 @@ entry:
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
-  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
   %41 = load i64, i64 addrspace(1)* %39
@@ -2236,8 +2318,8 @@ entry:
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
-  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
   %54 = load i64, i64 addrspace(1)* %52
@@ -2252,8 +2334,8 @@ entry:
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
   %67 = load i64, i64 addrspace(1)* %65
@@ -2270,8 +2352,8 @@ entry:
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
-  br i1 %NullCheck16, label %79, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
   %80 = load i64, i64 addrspace(1)* %78
@@ -2286,8 +2368,8 @@ entry:
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
-  br i1 %NullCheck18, label %92, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
   %93 = load i64, i64 addrspace(1)* %91
@@ -2304,8 +2386,8 @@ entry:
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
-  br i1 %NullCheck12, label %105, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = load i64, i64 addrspace(1)* %104
@@ -2320,8 +2402,8 @@ entry:
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
-  br i1 %NullCheck14, label %118, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
   %119 = load i64, i64 addrspace(1)* %117
@@ -2337,8 +2419,8 @@ entry:
 
 ; <label>:128                                     ; preds = %20
   %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
-  br i1 %NullCheck4, label %130, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %129, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %130
 
 ; <label>:130                                     ; preds = %128
   %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
@@ -2346,8 +2428,8 @@ entry:
   %133 = load i16, i16 addrspace(1)* %132, align 8
   %134 = zext i16 %133 to i32
   %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
-  br i1 %NullCheck6, label %136, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %135, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %136
 
 ; <label>:136                                     ; preds = %130
   %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
@@ -2360,8 +2442,8 @@ entry:
 
 ; <label>:143                                     ; preds = %136
   %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
-  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %144, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %145
 
 ; <label>:145                                     ; preds = %143
   %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
@@ -2369,8 +2451,8 @@ entry:
   %148 = load i16, i16 addrspace(1)* %147, align 8
   %149 = zext i16 %148 to i32
   %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %150, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %151
 
 ; <label>:151                                     ; preds = %145
   %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
@@ -2388,8 +2470,8 @@ entry:
 
 ; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
-  br i1 %NullCheck, label %163, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %ThrowNullRef, label %163
 
 ; <label>:163                                     ; preds = %161
   %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
@@ -2399,8 +2481,8 @@ entry:
 
 ; <label>:167                                     ; preds = %163
   %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
-  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %168, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %169
 
 ; <label>:169                                     ; preds = %167
   %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
@@ -2432,55 +2514,55 @@ ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %167
+ThrowNullRef2:                                    ; preds = %167
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %128
+ThrowNullRef4:                                    ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %130
+ThrowNullRef6:                                    ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %143
+ThrowNullRef8:                                    ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %145
+ThrowNullRef10:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %102
+ThrowNullRef12:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %105
+ThrowNullRef14:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %76
+ThrowNullRef16:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %79
+ThrowNullRef18:                                   ; preds = %79
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %50
+ThrowNullRef20:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %53
+ThrowNullRef22:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %24
+ThrowNullRef24:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %27
+ThrowNullRef26:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2503,15 +2585,15 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2519,16 +2601,16 @@ entry:
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
   store i32 %8, i32* %loc0
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
   %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
   store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
@@ -2546,16 +2628,16 @@ entry:
 
 ; <label>:23                                      ; preds = %64
   %24 = load i16*, i16** %loc3
-  %NullCheck12 = icmp ne i16* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i16* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
   store i32 %27, i32* %loc5
   %28 = load i16*, i16** %loc4
-  %NullCheck14 = icmp ne i16* %28, null
-  br i1 %NullCheck14, label %29, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %28, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = load i16, i16* %28, align 8
@@ -2620,15 +2702,15 @@ entry:
 
 ; <label>:67                                      ; preds = %64
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
-  br i1 %NullCheck8, label %69, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %68, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %69
 
 ; <label>:69                                      ; preds = %67
   %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
   %71 = load i32, i32 addrspace(1)* %70
   %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
-  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %73
 
 ; <label>:73                                      ; preds = %69
   %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
@@ -2645,31 +2727,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %67
+ThrowNullRef8:                                    ; preds = %67
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %69
+ThrowNullRef10:                                   ; preds = %69
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2710,14 +2792,14 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
   %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
@@ -2730,14 +2812,14 @@ entry:
 
 ; <label>:11                                      ; preds = %4
   %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
   %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
@@ -2749,14 +2831,14 @@ entry:
 
 ; <label>:22                                      ; preds = %16
   %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
   %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
-  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
-  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
@@ -2804,23 +2886,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2836,7 +2918,280 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[loadElem]
+Successfully read RuntimeType.IsAssignableFrom
+
+define i8 @RuntimeType.IsAssignableFrom(%System.RuntimeType addrspace(1)* %param0, %System.Type addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.RuntimeType addrspace(1)*
+  %arg1 = alloca %System.Type addrspace(1)*
+  %loc0 = alloca %System.RuntimeType addrspace(1)*
+  %loc1 = alloca %"System.Type[]" addrspace(1)*
+  %loc2 = alloca i32
+  store %System.RuntimeType addrspace(1)* %param0, %System.RuntimeType addrspace(1)** %this
+  store %System.Type addrspace(1)* %param1, %System.Type addrspace(1)** %arg1
+  %0 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %1 = icmp ne %System.Type addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i8 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %5 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %6 = bitcast %System.Type addrspace(1)* %4 to %System.Object addrspace(1)*
+  %7 = bitcast %System.RuntimeType addrspace(1)* %5 to %System.Object addrspace(1)*
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %6, %System.Object addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %3
+  ret i8 1
+
+; <label>:12                                      ; preds = %3
+  %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 152
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 32
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
+  %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
+  %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
+  store %System.RuntimeType addrspace(1)* %25, %System.RuntimeType addrspace(1)** %loc0
+  %26 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %27 = icmp eq %System.RuntimeType addrspace(1)* %26, null
+  br i1 %27, label %34, label %28
+
+; <label>:28                                      ; preds = %15
+  %29 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %30 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)*)*)(%System.RuntimeType addrspace(1)* %29, %System.RuntimeType addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+; <label>:34                                      ; preds = %15
+  %35 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %36 = call %System.Reflection.Emit.TypeBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Reflection.Emit.TypeBuilder addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %35)
+  %37 = icmp eq %System.Reflection.Emit.TypeBuilder addrspace(1)* %36, null
+  br i1 %37, label %139, label %38
+
+; <label>:38                                      ; preds = %34
+  %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %42
+
+; <label>:42                                      ; preds = %38
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 152
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 40
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
+  %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
+  %53 = zext i8 %52 to i32
+  %54 = icmp eq i32 %53, 0
+  br i1 %54, label %56, label %55
+
+; <label>:55                                      ; preds = %42
+  ret i8 1
+
+; <label>:56                                      ; preds = %42
+  %57 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %58 = bitcast %System.RuntimeType addrspace(1)* %57 to %System.Type addrspace(1)*
+  %59 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %58)
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %64 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.Type addrspace(1)* %63, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = bitcast %System.RuntimeType addrspace(1)* %64 to %System.Type addrspace(1)*
+  %67 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %63, %System.Type addrspace(1)* %66)
+  %68 = zext i8 %67 to i32
+  %69 = trunc i32 %68 to i8
+  ret i8 %69
+
+; <label>:70                                      ; preds = %56
+  %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
+  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %73
+
+; <label>:73                                      ; preds = %70
+  %74 = load i64, i64 addrspace(1)* %72
+  %75 = add i64 %74, 128
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = add i64 %77, 0
+  %79 = inttoptr i64 %78 to i64*
+  %80 = load i64, i64* %79
+  %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
+  %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
+  %83 = call i8 %82(%System.Type addrspace(1)* %81)
+  %84 = zext i8 %83 to i32
+  %85 = icmp eq i32 %84, 0
+  br i1 %85, label %139, label %86
+
+; <label>:86                                      ; preds = %73
+  %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
+  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %89
+
+; <label>:89                                      ; preds = %86
+  %90 = load i64, i64 addrspace(1)* %88
+  %91 = add i64 %90, 128
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = add i64 %93, 24
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
+  %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
+  %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
+  store %"System.Type[]" addrspace(1)* %99, %"System.Type[]" addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %129
+
+; <label>:100                                     ; preds = %132
+  %101 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %102 = load i32, i32* %loc2
+  %NullCheck11 = icmp eq %"System.Type[]" addrspace(1)* %101, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %103
+
+; <label>:103                                     ; preds = %100
+  %104 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 1
+  %105 = load i32, i32 addrspace(1)* %104
+  %106 = zext i32 %105 to i64
+  %107 = zext i32 %102 to i64
+  %BoundsCheck = icmp uge i64 %107, %106
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %108
+
+; <label>:108                                     ; preds = %103
+  %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
+  %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
+  %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
+  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %113
+
+; <label>:113                                     ; preds = %108
+  %114 = load i64, i64 addrspace(1)* %112
+  %115 = add i64 %114, 152
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = add i64 %117, 56
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
+  %123 = zext i8 %122 to i32
+  %124 = icmp ne i32 %123, 0
+  br i1 %124, label %126, label %125
+
+; <label>:125                                     ; preds = %113
+  ret i8 0
+
+; <label>:126                                     ; preds = %113
+  %127 = load i32, i32* %loc2
+  %128 = add i32 %127, 1
+  store i32 %128, i32* %loc2
+  br label %129
+
+; <label>:129                                     ; preds = %89, %126
+  %130 = load i32, i32* %loc2
+  %131 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %NullCheck9 = icmp eq %"System.Type[]" addrspace(1)* %131, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %132
+
+; <label>:132                                     ; preds = %129
+  %133 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %131, i32 0, i32 1
+  %134 = load i32, i32 addrspace(1)* %133
+  %135 = zext i32 %134 to i64
+  %136 = trunc i64 %135 to i32
+  %137 = icmp slt i32 %130, %136
+  br i1 %137, label %100, label %138
+
+; <label>:138                                     ; preds = %132
+  ret i8 1
+
+; <label>:139                                     ; preds = %34, %73
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %129
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %103
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -2893,7 +3248,7 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElem]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -2904,8 +3259,8 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -2997,8 +3352,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
@@ -3059,8 +3414,8 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -3087,8 +3442,8 @@ entry:
 
 ; <label>:17                                      ; preds = %5, %11
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
@@ -3097,8 +3452,8 @@ entry:
 
 ; <label>:22                                      ; preds = %1, %11
   %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
@@ -3109,11 +3464,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %17
+ThrowNullRef2:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %22
+ThrowNullRef4:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3167,15 +3522,15 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
   %15 = load i32, i32 addrspace(1)* %14
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
@@ -3198,7 +3553,7 @@ ThrowNullRef:                                     ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef2:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3232,8 +3587,8 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
@@ -3312,8 +3667,8 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -3327,8 +3682,8 @@ entry:
 ; <label>:5                                       ; preds = %43
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %7 = load i32, i32* %loc1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck6, label %8, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
@@ -3366,8 +3721,8 @@ entry:
 ; <label>:32                                      ; preds = %21, %25
   %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
   %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
-  br i1 %NullCheck8, label %35, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = trunc i32 %34 to i16
@@ -3380,8 +3735,8 @@ entry:
 ; <label>:40                                      ; preds = %1, %35
   %41 = load i32, i32* %loc1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
-  br i1 %NullCheck2, label %43, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %42, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
@@ -3392,8 +3747,8 @@ entry:
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
   %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
-  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
   %51 = load i64, i64 addrspace(1)* %49
@@ -3412,19 +3767,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %40
+ThrowNullRef2:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %47
+ThrowNullRef4:                                    ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %5
+ThrowNullRef6:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %32
+ThrowNullRef8:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3467,8 +3822,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
@@ -3492,11 +3847,391 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(i16* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store i16* %param0, i16** %arg0
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load i32, i32* %arg3
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %42, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %37, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg2
+  %13 = load i32, i32* %arg3
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %37, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %24 = load i32, i32* %arg2
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load i16*, i16** %arg0
+  %35 = load i32, i32* %arg3
+  %36 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %36, i16* %34, i32 %35)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:37                                      ; preds = %5, %16
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %39)
+  %41 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41, %System.String addrspace(1)* %38, %System.String addrspace(1)* %40)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41) #0
+  unreachable
+
+; <label>:42                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
-Failed to read StringBuilder.ToString[loadElemA]
+Successfully read StringBuilder.ToString
+
+define %System.String addrspace(1)* @StringBuilder.ToString(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i16*
+  %loc3 = alloca %"System.Char[]" addrspace(1)*
+  %loc4 = alloca i32
+  %loc5 = alloca i32
+  %loc6 = alloca i16 addrspace(1)*
+  %loc7 = alloca %System.String addrspace(1)*
+  %loc8 = alloca %"System.Char[]" addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %0)
+  %2 = icmp ne i32 %1, 0
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %4
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %6)
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %7)
+  store %System.String addrspace(1)* %8, %System.String addrspace(1)** %loc0
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.Text.StringBuilder addrspace(1)* %9, %System.Text.StringBuilder addrspace(1)** %loc1
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  store %System.String addrspace(1)* %10, %System.String addrspace(1)** %loc7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc7
+  %12 = ptrtoint %System.String addrspace(1)* %11 to i64
+  %13 = icmp eq i64 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %5
+  %15 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %16 = sext i32 %15 to i64
+  %17 = add i64 %12, %16
+  br label %18
+
+; <label>:18                                      ; preds = %5, %14
+  %19 = phi i64 [ %12, %5 ], [ %17, %14 ]
+  %20 = inttoptr i64 %19 to i16*
+  store i16* %20, i16** %loc2
+  br label %21
+
+; <label>:21                                      ; preds = %98, %18
+  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %22, null
+  br i1 %NullCheck, label %ThrowNullRef, label %23
+
+; <label>:23                                      ; preds = %21
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 3
+  %25 = load i32, i32 addrspace(1)* %24, align 8
+  %26 = icmp sle i32 %25, 0
+  br i1 %26, label %96, label %27
+
+; <label>:27                                      ; preds = %23
+  %28 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %28, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %29
+
+; <label>:29                                      ; preds = %27
+  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %28, i32 0, i32 1
+  %31 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %30, align 8
+  store %"System.Char[]" addrspace(1)* %31, %"System.Char[]" addrspace(1)** %loc3
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %33
+
+; <label>:33                                      ; preds = %29
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  store i32 %35, i32* %loc4
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  %39 = load i32, i32 addrspace(1)* %38, align 8
+  store i32 %39, i32* %loc5
+  %40 = load i32, i32* %loc5
+  %41 = load i32, i32* %loc4
+  %42 = add i32 %40, %41
+  %43 = zext i32 %42 to i64
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %45
+
+; <label>:45                                      ; preds = %37
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = sext i32 %47 to i64
+  %49 = icmp sgt i64 %43, %48
+  br i1 %49, label %91, label %50
+
+; <label>:50                                      ; preds = %45
+  %51 = load i32, i32* %loc5
+  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %52, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %53
+
+; <label>:53                                      ; preds = %50
+  %54 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %52, i32 0, i32 1
+  %55 = load i32, i32 addrspace(1)* %54
+  %56 = zext i32 %55 to i64
+  %57 = trunc i64 %56 to i32
+  %58 = icmp ugt i32 %51, %57
+  br i1 %58, label %91, label %59
+
+; <label>:59                                      ; preds = %53
+  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  store %"System.Char[]" addrspace(1)* %60, %"System.Char[]" addrspace(1)** %loc8
+  %61 = icmp eq %"System.Char[]" addrspace(1)* %60, null
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %63, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %64
+
+; <label>:64                                      ; preds = %62
+  %65 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %63, i32 0, i32 1
+  %66 = load i32, i32 addrspace(1)* %65
+  %67 = zext i32 %66 to i64
+  %68 = trunc i64 %67 to i32
+  %69 = icmp ne i32 %68, 0
+  br i1 %69, label %71, label %70
+
+; <label>:70                                      ; preds = %59, %64
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:71                                      ; preds = %64
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %73
+
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %BoundsCheck = icmp uge i64 0, %76
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %77
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %78, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:79                                      ; preds = %70, %77
+  %80 = load i16*, i16** %loc2
+  %81 = load i32, i32* %loc4
+  %82 = sext i32 %81 to i64
+  %83 = mul i64 %82, 2
+  %84 = bitcast i16* %80 to i8*
+  %85 = getelementptr inbounds i8, i8* %84, i64 %83
+  %86 = load i16 addrspace(1)*, i16 addrspace(1)** %loc6
+  %87 = ptrtoint i16 addrspace(1)* %86 to i64
+  %88 = load i32, i32* %loc5
+  %89 = bitcast i8* %85 to i16*
+  %90 = inttoptr i64 %87 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %89, i16* %90, i32 %88)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %96
+
+; <label>:91                                      ; preds = %45, %53
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %94 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %93)
+  %95 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95, %System.String addrspace(1)* %92, %System.String addrspace(1)* %94)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95) #0
+  unreachable
+
+; <label>:96                                      ; preds = %23, %79
+  %97 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %97, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %98
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %97, i32 0, i32 2
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  store %System.Text.StringBuilder addrspace(1)* %100, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %102 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %102, label %21, label %103
+
+; <label>:103                                     ; preds = %98
+  store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc7
+  %104 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  ret %System.String addrspace(1)* %104
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method StringBuilder::get_Length using LLILCJit
+Successfully read StringBuilder.get_Length
+
+define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
+Successfully read RuntimeHelpers.get_OffsetToStringData
+
+define i32 @RuntimeHelpers.get_OffsetToStringData() {
+entry:
+  ret i32 12
+}
+
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
 Successfully read CultureData.CreateCultureData
 
@@ -3514,23 +4249,23 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
   store i8 %4, i8 addrspace(1)* %6
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
@@ -3549,11 +4284,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3566,50 +4301,50 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
   store i32 -1, i32 addrspace(1)* %2
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
   store i32 -1, i32 addrspace(1)* %8
   %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
   store i32 -1, i32 addrspace(1)* %14
   %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
   store i32 -1, i32 addrspace(1)* %17
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
@@ -3623,27 +4358,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3675,7 +4410,136 @@ Failed to read Dictionary`2.Insert[non-const derefAddress]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
 Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
-Failed to read HashHelpers.GetPrime[loadElem]
+Successfully read HashHelpers.GetPrime
+
+define i32 @HashHelpers.GetPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %6, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5, %System.String addrspace(1)* %4)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5) #0
+  unreachable
+
+; <label>:6                                       ; preds = %entry
+  store i32 0, i32* %loc0
+  br label %29
+
+; <label>:7                                       ; preds = %35
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 1296
+  %10 = addrspacecast i8 addrspace(1)* %9 to %"System.Int32[]" addrspace(1)**
+  %11 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %10
+  %12 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Int32[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = zext i32 %15 to i64
+  %17 = zext i32 %12 to i64
+  %BoundsCheck = icmp uge i64 %17, %16
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 3, i32 %12
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  store i32 %20, i32* %loc1
+  %21 = load i32, i32* %loc1
+  %22 = load i32, i32* %arg0
+  %23 = icmp slt i32 %21, %22
+  br i1 %23, label %26, label %24
+
+; <label>:24                                      ; preds = %18
+  %25 = load i32, i32* %loc1
+  ret i32 %25
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %loc0
+  %28 = add i32 %27, 1
+  store i32 %28, i32* %loc0
+  br label %29
+
+; <label>:29                                      ; preds = %6, %26
+  %30 = load i32, i32* %loc0
+  %31 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %32 = getelementptr inbounds i8, i8 addrspace(1)* %31, i64 1296
+  %33 = addrspacecast i8 addrspace(1)* %32 to %"System.Int32[]" addrspace(1)**
+  %34 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %33
+  %NullCheck = icmp eq %"System.Int32[]" addrspace(1)* %34, null
+  br i1 %NullCheck, label %ThrowNullRef, label %35
+
+; <label>:35                                      ; preds = %29
+  %36 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %34, i32 0, i32 1
+  %37 = load i32, i32 addrspace(1)* %36
+  %38 = zext i32 %37 to i64
+  %39 = trunc i64 %38 to i32
+  %40 = icmp slt i32 %30, %39
+  br i1 %40, label %7, label %41
+
+; <label>:41                                      ; preds = %35
+  %42 = load i32, i32* %arg0
+  %43 = or i32 %42, 1
+  store i32 %43, i32* %loc2
+  br label %59
+
+; <label>:44                                      ; preds = %59
+  %45 = load i32, i32* %loc2
+  %46 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %45)
+  %47 = zext i8 %46 to i32
+  %48 = icmp eq i32 %47, 0
+  br i1 %48, label %56, label %49
+
+; <label>:49                                      ; preds = %44
+  %50 = load i32, i32* %loc2
+  %51 = sub i32 %50, 1
+  %52 = srem i32 %51, 101
+  %53 = icmp eq i32 %52, 0
+  br i1 %53, label %56, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = load i32, i32* %loc2
+  ret i32 %55
+
+; <label>:56                                      ; preds = %44, %49
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %57, 2
+  store i32 %58, i32* %loc2
+  br label %59
+
+; <label>:59                                      ; preds = %41, %56
+  %60 = load i32, i32* %loc2
+  %61 = icmp slt i32 %60, 2147483647
+  br i1 %61, label %44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load i32, i32* %arg0
+  ret i32 %63
+
+ThrowNullRef:                                     ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
 Successfully read GenericEqualityComparer`1.GetHashCode
 
@@ -3694,14 +4558,14 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
   %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load i64, i64 addrspace(1)* %7
@@ -3720,7 +4584,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3750,8 +4614,8 @@ entry:
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
@@ -3796,8 +4660,8 @@ entry:
   %35 = bitcast i16* %34 to i8*
   %36 = getelementptr inbounds i8, i8* %35, i64 2
   %37 = bitcast i8* %36 to i16*
-  %NullCheck4 = icmp ne i16* %37, null
-  br i1 %NullCheck4, label %38, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %37, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %38
 
 ; <label>:38                                      ; preds = %27
   %39 = load i16, i16* %37, align 8
@@ -3824,8 +4688,8 @@ entry:
 
 ; <label>:54                                      ; preds = %22, %43
   %55 = load i16*, i16** %loc4
-  %NullCheck2 = icmp ne i16* %55, null
-  br i1 %NullCheck2, label %56, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i16* %55, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %56
 
 ; <label>:56                                      ; preds = %54
   %57 = load i16, i16* %55, align 8
@@ -3850,11 +4714,11 @@ ThrowNullRef:                                     ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %54
+ThrowNullRef2:                                    ; preds = %54
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %27
+ThrowNullRef4:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3871,8 +4735,8 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -3907,8 +4771,8 @@ entry:
 
 ; <label>:26                                      ; preds = %19
   %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
-  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %28
 
 ; <label>:28                                      ; preds = %26
   %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
@@ -3920,7 +4784,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3972,8 +4836,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
@@ -3984,26 +4848,26 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
-  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
@@ -4014,8 +4878,8 @@ entry:
 ; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
@@ -4024,8 +4888,8 @@ entry:
 
 ; <label>:25                                      ; preds = %1, %16, %23
   %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
-  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
@@ -4036,27 +4900,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %20
+ThrowNullRef10:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4069,8 +4933,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -4081,8 +4945,8 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
@@ -4091,8 +4955,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1, %8
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
@@ -4103,11 +4967,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4128,24 +4992,24 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   store i32 %3, i32* %loc0
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
   %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
   store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck4, label %9, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
@@ -4164,15 +5028,15 @@ entry:
 ; <label>:18                                      ; preds = %70
   %19 = load i16*, i16** %loc3
   %20 = bitcast i16* %19 to i64*
-  %NullCheck10 = icmp ne i64* %20, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %20, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = load i64, i64* %20, align 8
   %23 = load i16*, i16** %loc4
   %24 = bitcast i16* %23 to i64*
-  %NullCheck12 = icmp ne i64* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = load i64, i64* %24, align 8
@@ -4188,8 +5052,8 @@ entry:
   %31 = bitcast i16* %30 to i8*
   %32 = getelementptr inbounds i8, i8* %31, i64 8
   %33 = bitcast i8* %32 to i64*
-  %NullCheck14 = icmp ne i64* %33, null
-  br i1 %NullCheck14, label %34, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = load i64, i64* %33, align 8
@@ -4197,8 +5061,8 @@ entry:
   %37 = bitcast i16* %36 to i8*
   %38 = getelementptr inbounds i8, i8* %37, i64 8
   %39 = bitcast i8* %38 to i64*
-  %NullCheck16 = icmp ne i64* %39, null
-  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %40
 
 ; <label>:40                                      ; preds = %34
   %41 = load i64, i64* %39, align 8
@@ -4214,8 +5078,8 @@ entry:
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %NullCheck18 = icmp ne i64* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = load i64, i64* %48, align 8
@@ -4223,8 +5087,8 @@ entry:
   %52 = bitcast i16* %51 to i8*
   %53 = getelementptr inbounds i8, i8* %52, i64 16
   %54 = bitcast i8* %53 to i64*
-  %NullCheck20 = icmp ne i64* %54, null
-  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64* %54, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %55
 
 ; <label>:55                                      ; preds = %49
   %56 = load i64, i64* %54, align 8
@@ -4262,15 +5126,15 @@ entry:
 ; <label>:74                                      ; preds = %95
   %75 = load i16*, i16** %loc3
   %76 = bitcast i16* %75 to i32*
-  %NullCheck6 = icmp ne i32* %76, null
-  br i1 %NullCheck6, label %77, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32* %76, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %77
 
 ; <label>:77                                      ; preds = %74
   %78 = load i32, i32* %76, align 8
   %79 = load i16*, i16** %loc4
   %80 = bitcast i16* %79 to i32*
-  %NullCheck8 = icmp ne i32* %80, null
-  br i1 %NullCheck8, label %81, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i32* %80, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %81
 
 ; <label>:81                                      ; preds = %77
   %82 = load i32, i32* %80, align 8
@@ -4318,43 +5182,43 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %74
+ThrowNullRef6:                                    ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %77
+ThrowNullRef8:                                    ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %29
+ThrowNullRef14:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %34
+ThrowNullRef16:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4376,8 +5240,8 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load i64, i64 addrspace(1)* %4
@@ -4389,8 +5253,8 @@ entry:
   %12 = load i64, i64* %11
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %5
   %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
@@ -4399,8 +5263,8 @@ entry:
   %18 = load i8, i8* %arg2
   %19 = zext i8 %18 to i32
   %20 = trunc i32 %19 to i8
-  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %15
   %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
@@ -4411,11 +5275,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4442,8 +5306,8 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
@@ -4466,16 +5330,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
   %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = load i64, i64 addrspace(1)* %19
@@ -4500,8 +5364,8 @@ entry:
 ; <label>:35                                      ; preds = %30
   %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
@@ -4514,8 +5378,8 @@ entry:
 
 ; <label>:42                                      ; preds = %1, %38
   %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
-  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
@@ -4526,19 +5390,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %35
+ThrowNullRef2:                                    ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %42
+ThrowNullRef8:                                    ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4551,14 +5415,14 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
@@ -4570,7 +5434,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4583,8 +5447,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
@@ -4613,51 +5477,51 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
   %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
   %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
   %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
   %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
-  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
   store i64 %21, i64 addrspace(1)* %23
   %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %25 = load i64, i64* %loc0
-  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
@@ -4668,27 +5532,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %22
+ThrowNullRef12:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4701,8 +5565,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
@@ -4713,19 +5577,19 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
@@ -4734,8 +5598,8 @@ entry:
 
 ; <label>:15                                      ; preds = %1, %13
   %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
@@ -4746,19 +5610,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %15
+ThrowNullRef8:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4771,8 +5635,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -4831,8 +5695,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
@@ -4882,8 +5746,8 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
-  br i1 %NullCheck, label %17, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %ThrowNullRef, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
@@ -4894,15 +5758,15 @@ entry:
 
 ; <label>:22                                      ; preds = %17
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
-  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
   %26 = load i32, i32 addrspace(1)* %25
   %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
-  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %27, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
@@ -4925,8 +5789,8 @@ entry:
 ; <label>:40                                      ; preds = %17
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
-  br i1 %NullCheck6, label %43, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %41, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
@@ -4938,34 +5802,17 @@ ThrowNullRef:                                     ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %24
+ThrowNullRef4:                                    ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %40
+ThrowNullRef6:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
-}
-
-INFO:  jitting method Object::ReferenceEquals using LLILCJit
-Successfully read Object.ReferenceEquals
-
-define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
-entry:
-  %arg0 = alloca %System.Object addrspace(1)*
-  %arg1 = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
-  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
-  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = icmp eq %System.Object addrspace(1)* %0, %1
-  %3 = sext i1 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
 }
 
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
@@ -4978,21 +5825,21 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
   %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
-  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
@@ -5007,28 +5854,28 @@ entry:
 ; <label>:13                                      ; preds = %8, %12
   %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
   %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
   %21 = load i32, i32 addrspace(1)* %20, align 8
   %22 = add i32 %21, 1
-  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
   store i32 %22, i32 addrspace(1)* %24
   %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
@@ -5039,27 +5886,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5077,7 +5924,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::Setup using LLILCJit
-Failed to read AppDomain.Setup[loadElem]
+Failed to read AppDomain.Setup[unbox]
 INFO:  jitting method Thread::GetDomain using LLILCJit
 Successfully read Thread.GetDomain
 
@@ -5108,8 +5955,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
@@ -5122,14 +5969,14 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
   %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
@@ -5141,11 +5988,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5173,8 +6020,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -5189,7 +6036,328 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
 Failed to read KeyCollection.System.Collections.Generic.IEnumerable<TKey>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Successfully read Enumerator.MoveNext
+
+define i8 @Enumerator.MoveNext(%"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.RuntimeTypeHandle* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*
+  %"$TypeArg" = alloca %System.RuntimeTypeHandle*
+  store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
+  %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 8
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %76, label %12
+
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
+  br label %76
+
+; <label>:13                                      ; preds = %85
+  %14 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck19 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %15
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, i32 0, i32 0
+  %17 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %16, align 8
+  %NullCheck21 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, i32 0, i32 2
+  %20 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %19, align 8
+  %21 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck23 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %22
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, i32 0, i32 2
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %NullCheck25 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 3, i32 %24
+  %NullCheck27 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %32
+
+; <label>:32                                      ; preds = %30
+  %33 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, i32 0, i32 2
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = icmp slt i32 %34, 0
+  br i1 %35, label %68, label %36
+
+; <label>:36                                      ; preds = %32
+  %37 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %38 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck29 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %39
+
+; <label>:39                                      ; preds = %36
+  %40 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, i32 0, i32 0
+  %41 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %40, align 8
+  %NullCheck31 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, i32 0, i32 2
+  %44 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %43, align 8
+  %45 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck33 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, i32 0, i32 2
+  %48 = load i32, i32 addrspace(1)* %47, align 8
+  %NullCheck35 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %49
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = zext i32 %51 to i64
+  %53 = zext i32 %48 to i64
+  %BoundsCheck37 = icmp uge i64 %53, %52
+  br i1 %BoundsCheck37, label %ThrowIndexOutOfRange38, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 3, i32 %48
+  %NullCheck39 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %56
+
+; <label>:56                                      ; preds = %54
+  %57 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, i32 0, i32 0
+  %58 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck41 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %59
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %60, %System.__Canon addrspace(1)* %58)
+  %61 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck43 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  %64 = load i32, i32 addrspace(1)* %63, align 8
+  %65 = add i32 %64, 1
+  %NullCheck45 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  store i32 %65, i32 addrspace(1)* %67
+  ret i8 1
+
+; <label>:68                                      ; preds = %32
+  %69 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck47 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %73 = add i32 %72, 1
+  %NullCheck49 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %74
+
+; <label>:74                                      ; preds = %70
+  %75 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  store i32 %73, i32 addrspace(1)* %75
+  br label %76
+
+; <label>:76                                      ; preds = %8, %12, %74
+  %77 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %78
+
+; <label>:78                                      ; preds = %76
+  %79 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, i32 0, i32 2
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck7 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %82
+
+; <label>:82                                      ; preds = %78
+  %83 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, i32 0, i32 0
+  %84 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %83, align 8
+  %NullCheck9 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %85
+
+; <label>:85                                      ; preds = %82
+  %86 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, i32 0, i32 7
+  %87 = load i32, i32 addrspace(1)* %86, align 8
+  %88 = icmp ult i32 %80, %87
+  br i1 %88, label %13, label %89
+
+; <label>:89                                      ; preds = %85
+  %90 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %91 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck11 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %92
+
+; <label>:92                                      ; preds = %89
+  %93 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, i32 0, i32 0
+  %94 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck13 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %95
+
+; <label>:95                                      ; preds = %92
+  %96 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, i32 0, i32 7
+  %97 = load i32, i32 addrspace(1)* %96, align 8
+  %98 = add i32 %97, 1
+  %NullCheck15 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %99
+
+; <label>:99                                      ; preds = %95
+  %100 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, i32 0, i32 2
+  store i32 %98, i32 addrspace(1)* %100
+  %101 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck17 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %102
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %103, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %92
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef22:                                   ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef24:                                   ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef26:                                   ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef28:                                   ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef30:                                   ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef32:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef34:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef36:                                   ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange38:                           ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef40:                                   ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef42:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef44:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef46:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef48:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef50:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -5200,8 +6368,8 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -5232,9 +6400,9 @@ Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
 Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
-Failed to read String.MakeSeparatorList[loadElemA]
+Failed to read String.MakeSeparatorList[storeElem]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
-Failed to read String.InternalSplitKeepEmptyEntries[loadElem]
+Failed to read String.InternalSplitKeepEmptyEntries[storeElem]
 INFO:  jitting method Path::IsRelative using LLILCJit
 Successfully read Path.IsRelative
 
@@ -5243,8 +6411,8 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -5254,8 +6422,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
@@ -5271,8 +6439,8 @@ entry:
 
 ; <label>:17                                      ; preds = %7
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
@@ -5288,8 +6456,8 @@ entry:
 
 ; <label>:29                                      ; preds = %19
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %31
 
 ; <label>:31                                      ; preds = %29
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
@@ -5300,8 +6468,8 @@ entry:
 
 ; <label>:36                                      ; preds = %31
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
-  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %37, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
@@ -5312,8 +6480,8 @@ entry:
 
 ; <label>:43                                      ; preds = %31, %38
   %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
-  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %45
 
 ; <label>:45                                      ; preds = %43
   %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
@@ -5324,8 +6492,8 @@ entry:
 
 ; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %50
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
@@ -5336,8 +6504,8 @@ entry:
 
 ; <label>:57                                      ; preds = %1, %7, %19, %45, %52
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
-  br i1 %NullCheck14, label %59, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %59
 
 ; <label>:59                                      ; preds = %57
   %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
@@ -5347,8 +6515,8 @@ entry:
 
 ; <label>:63                                      ; preds = %59
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
@@ -5359,8 +6527,8 @@ entry:
 
 ; <label>:70                                      ; preds = %65
   %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
-  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.String addrspace(1)* %71, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %72
 
 ; <label>:72                                      ; preds = %70
   %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
@@ -5379,39 +6547,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %17
+ThrowNullRef4:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %29
+ThrowNullRef6:                                    ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %36
+ThrowNullRef8:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %43
+ThrowNullRef10:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %50
+ThrowNullRef12:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %57
+ThrowNullRef14:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %63
+ThrowNullRef16:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %70
+ThrowNullRef18:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5419,7 +6587,293 @@ ThrowNullRef17:                                   ; preds = %70
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
-Failed to read String.TrimHelper[loadElem]
+Successfully read String.TrimHelper
+
+define %System.String addrspace(1)* @String.TrimHelper(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i16
+  %loc4 = alloca i32
+  %loc5 = alloca i16
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = sub i32 %3, 1
+  store i32 %4, i32* %loc0
+  store i32 0, i32* %loc1
+  %5 = load i32, i32* %arg2
+  %6 = icmp eq i32 %5, 1
+  br i1 %6, label %62, label %7
+
+; <label>:7                                       ; preds = %1
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:8                                       ; preds = %58
+  store i32 0, i32* %loc2
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load i32, i32* %loc1
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2, i32 %10
+  %13 = load i16, i16 addrspace(1)* %12
+  %14 = zext i16 %13 to i32
+  %15 = trunc i32 %14 to i16
+  store i16 %15, i16* %loc3
+  store i32 0, i32* %loc2
+  br label %34
+
+; <label>:16                                      ; preds = %37
+  %17 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %18 = load i32, i32* %loc2
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %17, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %19
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = zext i32 %18 to i64
+  %BoundsCheck = icmp uge i64 %23, %22
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %24
+
+; <label>:24                                      ; preds = %19
+  %25 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 3, i32 %18
+  %26 = load i16, i16 addrspace(1)* %25, align 8
+  %27 = zext i16 %26 to i32
+  %28 = load i16, i16* %loc3
+  %29 = zext i16 %28 to i32
+  %30 = icmp eq i32 %27, %29
+  br i1 %30, label %43, label %31
+
+; <label>:31                                      ; preds = %24
+  %32 = load i32, i32* %loc2
+  %33 = add i32 %32, 1
+  store i32 %33, i32* %loc2
+  br label %34
+
+; <label>:34                                      ; preds = %11, %31
+  %35 = load i32, i32* %loc2
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = icmp slt i32 %35, %41
+  br i1 %42, label %16, label %43
+
+; <label>:43                                      ; preds = %24, %37
+  %44 = load i32, i32* %loc2
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %45, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp eq i32 %44, %50
+  br i1 %51, label %62, label %52
+
+; <label>:52                                      ; preds = %46
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %7, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %57, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %58
+
+; <label>:58                                      ; preds = %55
+  %59 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %60 = load i32, i32 addrspace(1)* %59
+  %61 = icmp slt i32 %56, %60
+  br i1 %61, label %8, label %62
+
+; <label>:62                                      ; preds = %1, %46, %58
+  %63 = load i32, i32* %arg2
+  %64 = icmp eq i32 %63, 0
+  br i1 %64, label %122, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %66, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %67
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %66, i32 0, i32 1
+  %69 = load i32, i32 addrspace(1)* %68
+  %70 = sub i32 %69, 1
+  store i32 %70, i32* %loc0
+  br label %118
+
+; <label>:71                                      ; preds = %118
+  store i32 0, i32* %loc4
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %73 = load i32, i32* %loc0
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %74
+
+; <label>:74                                      ; preds = %71
+  %75 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 2, i32 %73
+  %76 = load i16, i16 addrspace(1)* %75
+  %77 = zext i16 %76 to i32
+  %78 = trunc i32 %77 to i16
+  store i16 %78, i16* %loc5
+  store i32 0, i32* %loc4
+  br label %97
+
+; <label>:79                                      ; preds = %100
+  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %81 = load i32, i32* %loc4
+  %NullCheck19 = icmp eq %"System.Char[]" addrspace(1)* %80, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
+
+; <label>:82                                      ; preds = %79
+  %83 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 1
+  %84 = load i32, i32 addrspace(1)* %83
+  %85 = zext i32 %84 to i64
+  %86 = zext i32 %81 to i64
+  %BoundsCheck21 = icmp uge i64 %86, %85
+  br i1 %BoundsCheck21, label %ThrowIndexOutOfRange22, label %87
+
+; <label>:87                                      ; preds = %82
+  %88 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 3, i32 %81
+  %89 = load i16, i16 addrspace(1)* %88, align 8
+  %90 = zext i16 %89 to i32
+  %91 = load i16, i16* %loc5
+  %92 = zext i16 %91 to i32
+  %93 = icmp eq i32 %90, %92
+  br i1 %93, label %106, label %94
+
+; <label>:94                                      ; preds = %87
+  %95 = load i32, i32* %loc4
+  %96 = add i32 %95, 1
+  store i32 %96, i32* %loc4
+  br label %97
+
+; <label>:97                                      ; preds = %74, %94
+  %98 = load i32, i32* %loc4
+  %99 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck15 = icmp eq %"System.Char[]" addrspace(1)* %99, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %100
+
+; <label>:100                                     ; preds = %97
+  %101 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %99, i32 0, i32 1
+  %102 = load i32, i32 addrspace(1)* %101
+  %103 = zext i32 %102 to i64
+  %104 = trunc i64 %103 to i32
+  %105 = icmp slt i32 %98, %104
+  br i1 %105, label %79, label %106
+
+; <label>:106                                     ; preds = %87, %100
+  %107 = load i32, i32* %loc4
+  %108 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck17 = icmp eq %"System.Char[]" addrspace(1)* %108, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %109
+
+; <label>:109                                     ; preds = %106
+  %110 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %108, i32 0, i32 1
+  %111 = load i32, i32 addrspace(1)* %110
+  %112 = zext i32 %111 to i64
+  %113 = trunc i64 %112 to i32
+  %114 = icmp eq i32 %107, %113
+  br i1 %114, label %122, label %115
+
+; <label>:115                                     ; preds = %109
+  %116 = load i32, i32* %loc0
+  %117 = sub i32 %116, 1
+  store i32 %117, i32* %loc0
+  br label %118
+
+; <label>:118                                     ; preds = %67, %115
+  %119 = load i32, i32* %loc0
+  %120 = load i32, i32* %loc1
+  %121 = icmp sge i32 %119, %120
+  br i1 %121, label %71, label %122
+
+; <label>:122                                     ; preds = %62, %109, %118
+  %123 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %124 = load i32, i32* %loc1
+  %125 = load i32, i32* %loc0
+  %126 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %123, i32 %124, i32 %125)
+  ret %System.String addrspace(1)* %126
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %97
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange22:                           ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
 Successfully read String.CreateTrimmedString
 
@@ -5439,8 +6893,8 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
@@ -5535,8 +6989,8 @@ entry:
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i64 2872
   %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
   %8 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %7
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %3
   %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
@@ -5553,8 +7007,8 @@ entry:
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 2864
   %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
   %21 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %20
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
-  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %22
 
 ; <label>:22                                      ; preds = %16
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
@@ -5569,7 +7023,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %16
+ThrowNullRef2:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5586,8 +7040,8 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5613,8 +7067,8 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
@@ -5632,8 +7086,8 @@ entry:
 
 ; <label>:12                                      ; preds = %4
   %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
@@ -5644,8 +7098,8 @@ entry:
 
 ; <label>:19                                      ; preds = %14
   %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %19
   %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
@@ -5660,21 +7114,21 @@ entry:
   %31 = zext i16 %30 to i32
   %32 = bitcast i8* %29 to i16*
   %33 = trunc i32 %31 to i16
-  %NullCheck6 = icmp ne i16* %32, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i16* %32, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %21
   store i16 %33, i16* %32, align 8
   %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %36
 
 ; <label>:36                                      ; preds = %34
   %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
   %38 = load i32, i32 addrspace(1)* %37, align 8
   %39 = add i32 %38, 1
-  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %40
 
 ; <label>:40                                      ; preds = %36
   %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
@@ -5683,16 +7137,16 @@ entry:
 
 ; <label>:42                                      ; preds = %14
   %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
-  br i1 %NullCheck12, label %44, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
   %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
   %47 = load i16, i16* %arg1
   %48 = zext i16 %47 to i32
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = trunc i32 %48 to i16
@@ -5703,31 +7157,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %19
+ThrowNullRef4:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %21
+ThrowNullRef6:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %36
+ThrowNullRef10:                                   ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %42
+ThrowNullRef12:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %44
+ThrowNullRef14:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5740,8 +7194,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -5752,8 +7206,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
@@ -5762,14 +7216,14 @@ entry:
 
 ; <label>:11                                      ; preds = %1
   %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
@@ -5779,15 +7233,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5808,8 +7262,8 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5822,8 +7276,8 @@ entry:
 
 ; <label>:8                                       ; preds = %3
   %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
@@ -5842,15 +7296,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
-  br i1 %NullCheck4, label %22, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
   %24 = load i16*, i16* addrspace(1)* %23, align 8
   %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %25, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
@@ -5859,8 +7313,8 @@ entry:
   store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
@@ -5874,8 +7328,8 @@ entry:
 
 ; <label>:37                                      ; preds = %65
   %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %37
   %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
@@ -5886,16 +7340,16 @@ entry:
   %45 = bitcast i16* %41 to i8*
   %46 = getelementptr inbounds i8, i8* %45, i64 %44
   %47 = bitcast i8* %46 to i16*
-  %NullCheck14 = icmp ne i16* %47, null
-  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %47, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %48
 
 ; <label>:48                                      ; preds = %39
   %49 = load i16, i16* %47, align 8
   %50 = zext i16 %49 to i32
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %52 = load i32, i32* %loc1
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %53
 
 ; <label>:53                                      ; preds = %48
   %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
@@ -5916,8 +7370,8 @@ entry:
 ; <label>:62                                      ; preds = %36, %59
   %63 = load i32, i32* %loc1
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck10, label %65, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %65
 
 ; <label>:65                                      ; preds = %62
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
@@ -5936,15 +7390,15 @@ entry:
 
 ; <label>:74                                      ; preds = %70
   %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
-  br i1 %NullCheck18, label %76, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %76
 
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
   %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
-  br i1 %NullCheck20, label %80, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
   %81 = load i64, i64 addrspace(1)* %79
@@ -5958,8 +7412,8 @@ entry:
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
   %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
-  br i1 %NullCheck22, label %92, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.String addrspace(1)* %90, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %92
 
 ; <label>:92                                      ; preds = %80
   %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
@@ -5969,15 +7423,15 @@ entry:
 
 ; <label>:96                                      ; preds = %70
   %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
-  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %98
 
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
   %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
-  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
   %103 = load i64, i64 addrspace(1)* %101
@@ -5991,8 +7445,8 @@ entry:
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
   %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
-  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.String addrspace(1)* %112, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %114
 
 ; <label>:114                                     ; preds = %102
   %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
@@ -6004,59 +7458,59 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %20
+ThrowNullRef4:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %22
+ThrowNullRef6:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %26
+ThrowNullRef8:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %62
+ThrowNullRef10:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %48
+ThrowNullRef16:                                   ; preds = %48
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %74
+ThrowNullRef18:                                   ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %76
+ThrowNullRef20:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %80
+ThrowNullRef22:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %96
+ThrowNullRef24:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %98
+ThrowNullRef26:                                   ; preds = %98
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %102
+ThrowNullRef28:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6069,15 +7523,15 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
   %3 = load i16*, i16* addrspace(1)* %2, align 8
   %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
@@ -6087,8 +7541,8 @@ entry:
   %10 = bitcast i16* %3 to i8*
   %11 = getelementptr inbounds i8, i8* %10, i64 %9
   %12 = bitcast i8* %11 to i16*
-  %NullCheck4 = icmp ne i16* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %5
   store i16 0, i16* %12, align 8
@@ -6098,11 +7552,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6119,8 +7573,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -6131,8 +7585,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
@@ -6144,15 +7598,15 @@ entry:
 
 ; <label>:14                                      ; preds = %1
   %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
   %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
   %21 = load i64, i64 addrspace(1)* %19
@@ -6171,15 +7625,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %14
+ThrowNullRef4:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %16
+ThrowNullRef6:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6302,14 +7756,6 @@ entry:
   ret %System.String addrspace(1)* %57
 }
 
-INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
-Successfully read RuntimeHelpers.get_OffsetToStringData
-
-define i32 @RuntimeHelpers.get_OffsetToStringData() {
-entry:
-  ret i32 12
-}
-
 INFO:  jitting method String::Equals using LLILCJit
 Successfully read String.Equals
 
@@ -6381,8 +7827,8 @@ entry:
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
-  br i1 %NullCheck24, label %29, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
   %30 = load i64, i64 addrspace(1)* %28
@@ -6397,8 +7843,8 @@ entry:
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
-  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
   %43 = load i64, i64 addrspace(1)* %41
@@ -6418,8 +7864,8 @@ entry:
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
   %59 = load i64, i64 addrspace(1)* %57
@@ -6434,8 +7880,8 @@ entry:
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck22, label %71, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
   %72 = load i64, i64 addrspace(1)* %70
@@ -6455,8 +7901,8 @@ entry:
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
-  br i1 %NullCheck16, label %87, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = load i64, i64 addrspace(1)* %86
@@ -6471,8 +7917,8 @@ entry:
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck18, label %100, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
   %101 = load i64, i64 addrspace(1)* %99
@@ -6492,8 +7938,8 @@ entry:
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
-  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
   %117 = load i64, i64 addrspace(1)* %115
@@ -6508,8 +7954,8 @@ entry:
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
-  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
   %130 = load i64, i64 addrspace(1)* %128
@@ -6528,15 +7974,15 @@ entry:
 
 ; <label>:142                                     ; preds = %22
   %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
-  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %143, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %144
 
 ; <label>:144                                     ; preds = %142
   %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
   %146 = load i32, i32 addrspace(1)* %145
   %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
-  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %147, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %148
 
 ; <label>:148                                     ; preds = %144
   %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
@@ -6557,15 +8003,15 @@ entry:
 
 ; <label>:159                                     ; preds = %22
   %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
-  br i1 %NullCheck, label %161, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %ThrowNullRef, label %161
 
 ; <label>:161                                     ; preds = %159
   %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
   %163 = load i32, i32 addrspace(1)* %162
   %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
-  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %164, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %165
 
 ; <label>:165                                     ; preds = %161
   %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
@@ -6578,8 +8024,8 @@ entry:
 
 ; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
-  br i1 %NullCheck4, label %172, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %171, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %172
 
 ; <label>:172                                     ; preds = %170
   %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
@@ -6589,8 +8035,8 @@ entry:
 
 ; <label>:176                                     ; preds = %172
   %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
-  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %177, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %178
 
 ; <label>:178                                     ; preds = %176
   %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
@@ -6629,55 +8075,55 @@ ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %161
+ThrowNullRef2:                                    ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %170
+ThrowNullRef4:                                    ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %176
+ThrowNullRef6:                                    ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %142
+ThrowNullRef8:                                    ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %144
+ThrowNullRef10:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %113
+ThrowNullRef12:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %116
+ThrowNullRef14:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %84
+ThrowNullRef16:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %87
+ThrowNullRef18:                                   ; preds = %87
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %55
+ThrowNullRef20:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %58
+ThrowNullRef22:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %26
+ThrowNullRef24:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %29
+ThrowNullRef26:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,8 +8161,8 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck, label %14, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %ThrowNullRef, label %14
 
 ; <label>:14                                      ; preds = %8
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
@@ -6760,8 +8206,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
@@ -6770,14 +8216,14 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32, i32* %loc0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %10
   %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
   %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
@@ -6790,15 +8236,15 @@ entry:
 ; <label>:25                                      ; preds = %19
   %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
-  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
   %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
@@ -6807,8 +8253,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %37 = load i32, i32* %loc0
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %38, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %38
 
 ; <label>:38                                      ; preds = %32
   %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
@@ -6817,14 +8263,14 @@ entry:
 
 ; <label>:40                                      ; preds = %19
   %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %40
   %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
   %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
-  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
-  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
@@ -6832,8 +8278,8 @@ entry:
   %48 = zext i32 %47 to i64
   %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
-  br i1 %NullCheck16, label %51, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %51
 
 ; <label>:51                                      ; preds = %45
   %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
@@ -6847,15 +8293,15 @@ entry:
 ; <label>:57                                      ; preds = %51
   %58 = load i16*, i16** %arg1
   %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
-  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %60
 
 ; <label>:60                                      ; preds = %57
   %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
   %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
-  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %64
 
 ; <label>:64                                      ; preds = %60
   %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
@@ -6864,22 +8310,22 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
   %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
-  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %70
 
 ; <label>:70                                      ; preds = %64
   %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
   %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
-  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
-  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
   %75 = load i32, i32 addrspace(1)* %74
   %76 = zext i32 %75 to i64
   %77 = trunc i64 %76 to i32
-  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
-  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %78
 
 ; <label>:78                                      ; preds = %73
   %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
@@ -6901,8 +8347,8 @@ entry:
   %90 = bitcast i16* %86 to i8*
   %91 = getelementptr inbounds i8, i8* %90, i64 %89
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %93
 
 ; <label>:93                                      ; preds = %80
   %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
@@ -6912,8 +8358,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %99 = load i32, i32* %loc2
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %100
 
 ; <label>:100                                     ; preds = %93
   %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
@@ -6928,63 +8374,63 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %25
+ThrowNullRef6:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %32
+ThrowNullRef10:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %40
+ThrowNullRef12:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %45
+ThrowNullRef16:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %57
+ThrowNullRef18:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %60
+ThrowNullRef20:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %64
+ThrowNullRef22:                                   ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %70
+ThrowNullRef24:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %73
+ThrowNullRef26:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %80
+ThrowNullRef28:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %93
+ThrowNullRef30:                                   ; preds = %93
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7004,8 +8450,8 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
@@ -7033,43 +8479,43 @@ entry:
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %14
   %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
   %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   %28 = load i32, i32 addrspace(1)* %27, align 8
   %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
-  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %30
 
 ; <label>:30                                      ; preds = %26
   %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
   %32 = load i32, i32 addrspace(1)* %31, align 8
   %33 = add i32 %28, %32
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %34
 
 ; <label>:34                                      ; preds = %30
   %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   store i32 %33, i32 addrspace(1)* %35
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
   store i32 0, i32 addrspace(1)* %38
   %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %40
 
 ; <label>:40                                      ; preds = %37
   %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
@@ -7082,8 +8528,8 @@ entry:
 
 ; <label>:47                                      ; preds = %40
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
@@ -7098,8 +8544,8 @@ entry:
   %54 = load i32, i32* %loc0
   %55 = sext i32 %54 to i64
   %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
-  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %57
 
 ; <label>:57                                      ; preds = %52
   %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
@@ -7110,68 +8556,35 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %14
+ThrowNullRef2:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %23
+ThrowNullRef4:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %26
+ThrowNullRef6:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %30
+ThrowNullRef8:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %34
+ThrowNullRef10:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %47
+ThrowNullRef14:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %52
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-}
-
-INFO:  jitting method StringBuilder::get_Length using LLILCJit
-Successfully read StringBuilder.get_Length
-
-define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.StringBuilder addrspace(1)*
-  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
-  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
-
-; <label>:1                                       ; preds = %entry
-  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %3 = load i32, i32 addrspace(1)* %2, align 8
-  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
-
-; <label>:5                                       ; preds = %1
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = add i32 %3, %7
-  ret i32 %8
-
-ThrowNullRef:                                     ; preds = %entry
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef16:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7213,70 +8626,70 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
   %6 = load i32, i32 addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
   store i32 %6, i32 addrspace(1)* %8
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
   %13 = load i32, i32 addrspace(1)* %12, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
   store i32 %13, i32 addrspace(1)* %15
   %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
-  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %18
 
 ; <label>:18                                      ; preds = %14
   %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
   %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
   %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
   %34 = load i32, i32 addrspace(1)* %33, align 8
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
-  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
@@ -7287,39 +8700,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %28
+ThrowNullRef16:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %32
+ThrowNullRef18:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7455,13 +8868,13 @@ entry:
 ; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
@@ -7477,16 +8890,16 @@ entry:
 
 ; <label>:18                                      ; preds = %15
   %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
   store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
   %22 = load i32, i32* %loc0
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %24
 
 ; <label>:24                                      ; preds = %20
   %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
@@ -7498,13 +8911,13 @@ entry:
 ; <label>:28                                      ; preds = %15, %24
   %29 = load i32, i32* %arg1
   %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %31
   %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
@@ -7517,20 +8930,20 @@ entry:
   %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
-  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
   %46 = load i32, i32 addrspace(1)* %45, align 8
   %47 = sub i32 %40, %46
-  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
-  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i32 addrspace(1)* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %48
 
 ; <label>:48                                      ; preds = %44
   store i32 %47, i32 addrspace(1)* %39, align 8
@@ -7538,21 +8951,21 @@ entry:
 
 ; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
-  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %51
 
 ; <label>:51                                      ; preds = %49
   %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %53
 
 ; <label>:53                                      ; preds = %51
   %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
   %55 = load i32, i32 addrspace(1)* %54, align 8
   %56 = load i32, i32* %arg2
   %57 = sub i32 %55, %56
-  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %58
 
 ; <label>:58                                      ; preds = %53
   %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
@@ -7562,13 +8975,13 @@ entry:
 ; <label>:60                                      ; preds = %33, %58
   %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
   %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
-  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %63
 
 ; <label>:63                                      ; preds = %60
   %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
-  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
-  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
@@ -7578,15 +8991,15 @@ entry:
 
 ; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
-  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i32 addrspace(1)* %69, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %70
 
 ; <label>:70                                      ; preds = %68
   %71 = load i32, i32 addrspace(1)* %69, align 8
   store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
-  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
@@ -7596,8 +9009,8 @@ entry:
   store i32 %77, i32* %loc4
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
-  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %80
 
 ; <label>:80                                      ; preds = %73
   %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
@@ -7607,71 +9020,71 @@ entry:
 ; <label>:83                                      ; preds = %80
   store i32 0, i32* %loc3
   %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
-  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
-  br i1 %NullCheck26, label %88, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i32 addrspace(1)* %87, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %88
 
 ; <label>:88                                      ; preds = %85
   %89 = load i32, i32 addrspace(1)* %87, align 8
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
-  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %90
 
 ; <label>:90                                      ; preds = %88
   %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
   store i32 %89, i32 addrspace(1)* %91
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
-  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
-  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %96
 
 ; <label>:96                                      ; preds = %94
   %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
-  br i1 %NullCheck34, label %100, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %100
 
 ; <label>:100                                     ; preds = %96
   %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
-  br i1 %NullCheck36, label %102, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %102
 
 ; <label>:102                                     ; preds = %100
   %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
   %104 = load i32, i32 addrspace(1)* %103, align 8
   %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
-  br i1 %NullCheck38, label %106, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %106
 
 ; <label>:106                                     ; preds = %102
   %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
-  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
-  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %108
 
 ; <label>:108                                     ; preds = %106
   %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
   %110 = load i32, i32 addrspace(1)* %109, align 8
   %111 = add i32 %104, %110
-  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %112
 
 ; <label>:112                                     ; preds = %108
   %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
   store i32 %111, i32 addrspace(1)* %113
   %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
-  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i32 addrspace(1)* %114, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %115
 
 ; <label>:115                                     ; preds = %112
   %116 = load i32, i32 addrspace(1)* %114, align 8
@@ -7681,19 +9094,19 @@ entry:
 ; <label>:118                                     ; preds = %115
   %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
-  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %121
 
 ; <label>:121                                     ; preds = %118
   %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
-  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
-  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %123
 
 ; <label>:123                                     ; preds = %121
   %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
   %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
-  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
-  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %126
 
 ; <label>:126                                     ; preds = %123
   %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
@@ -7705,8 +9118,8 @@ entry:
 
 ; <label>:130                                     ; preds = %80, %115, %126
   %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %132
 
 ; <label>:132                                     ; preds = %130
   %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7715,8 +9128,8 @@ entry:
   %136 = load i32, i32* %loc3
   %137 = sub i32 %135, %136
   %138 = sub i32 %134, %137
-  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %139
 
 ; <label>:139                                     ; preds = %132
   %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7728,16 +9141,16 @@ entry:
 
 ; <label>:144                                     ; preds = %139
   %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
-  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %146
 
 ; <label>:146                                     ; preds = %144
   %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
   %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
   %149 = load i32, i32* %loc2
   %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
-  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %151
 
 ; <label>:151                                     ; preds = %146
   %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
@@ -7754,145 +9167,249 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %18
+ThrowNullRef4:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %31
+ThrowNullRef10:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %44
+ThrowNullRef16:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %68
+ThrowNullRef18:                                   ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %70
+ThrowNullRef20:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %73
+ThrowNullRef22:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %83
+ThrowNullRef24:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %85
+ThrowNullRef26:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %88
+ThrowNullRef28:                                   ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %90
+ThrowNullRef30:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %94
+ThrowNullRef32:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %96
+ThrowNullRef34:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %100
+ThrowNullRef36:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %102
+ThrowNullRef38:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %106
+ThrowNullRef40:                                   ; preds = %106
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %108
+ThrowNullRef42:                                   ; preds = %108
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %112
+ThrowNullRef44:                                   ; preds = %112
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %118
+ThrowNullRef46:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %121
+ThrowNullRef48:                                   ; preds = %121
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %123
+ThrowNullRef50:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %130
+ThrowNullRef52:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %132
+ThrowNullRef54:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %144
+ThrowNullRef56:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %146
+ThrowNullRef58:                                   ; preds = %146
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %60
+ThrowNullRef60:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %63
+ThrowNullRef62:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %49
+ThrowNullRef64:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %51
+ThrowNullRef66:                                   ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %53
+ThrowNullRef68:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(%"System.Char[]" addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %arg0 = alloca %"System.Char[]" addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store %"System.Char[]" addrspace(1)* %param0, %"System.Char[]" addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load i32, i32* %arg4
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %43, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %38, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg1
+  %13 = load i32, i32* %arg4
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %38, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %24 = load i32, i32* %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %35 = load i32, i32* %arg3
+  %36 = load i32, i32* %arg4
+  %37 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %37, %"System.Char[]" addrspace(1)* %34, i32 %35, i32 %36)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:38                                      ; preds = %5, %16
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Successfully read Buffer._Memmove
 
@@ -7914,7 +9431,7 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[loadElem]
+Failed to read AppDomain.SetDataHelper[storeElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -7923,8 +9440,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
@@ -7934,8 +9451,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
@@ -7947,15 +9464,15 @@ entry:
   %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
   %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
@@ -7966,15 +9483,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7992,7 +9509,79 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
-Failed to read Dictionary`2.TryGetValue[loadElemA]
+Successfully read Dictionary`2.TryGetValue
+
+define i8 @"Dictionary`2.TryGetValue"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)* addrspace(1)* %param2) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  %arg2 = alloca %System.__Canon addrspace(1)* addrspace(1)*
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  store %System.__Canon addrspace(1)* addrspace(1)* %param2, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  store i32 %2, i32* %loc0
+  %3 = load i32, i32* %loc0
+  %4 = icmp slt i32 %3, 0
+  br i1 %4, label %22, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 2
+  %10 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %9, align 8
+  %11 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = zext i32 %11 to i64
+  %BoundsCheck = icmp uge i64 %16, %15
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 3, i32 %11
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %20, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %6, %System.__Canon addrspace(1)* %21)
+  ret i8 1
+
+; <label>:22                                      ; preds = %entry
+  %23 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %23, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -8058,8 +9647,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
@@ -8091,8 +9680,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
@@ -8171,15 +9760,15 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck, label %19, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %ThrowNullRef, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
   %21 = load i32, i32 addrspace(1)* %20
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
@@ -8202,7 +9791,7 @@ ThrowNullRef:                                     ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %19
+ThrowNullRef2:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8248,8 +9837,8 @@ entry:
   %0 = alloca %System.AppDomainHandle
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %1 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %1, i32 0, i32 15
@@ -8269,8 +9858,8 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
@@ -8286,7 +9875,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -8299,8 +9888,8 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -8327,8 +9916,8 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
@@ -8352,8 +9941,8 @@ entry:
   %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
   store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
@@ -8363,8 +9952,8 @@ entry:
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
@@ -8374,8 +9963,8 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %9
   %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
@@ -8384,8 +9973,8 @@ entry:
 
 ; <label>:18                                      ; preds = %3, %16
   %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
@@ -8397,15 +9986,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %18
+ThrowNullRef6:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8418,8 +10007,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
@@ -8453,15 +10042,15 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
@@ -8473,7 +10062,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8481,7 +10070,7 @@ ThrowNullRef1:                                    ; preds = %1
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
 Failed to read Dictionary`2.System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
@@ -8506,8 +10095,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
@@ -8524,8 +10113,8 @@ entry:
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -8544,7 +10133,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8577,8 +10166,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = load i64, i64* %arg2
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = trunc i32 %3 to i8
@@ -8634,46 +10223,46 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
   %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
-  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
-  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
-  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
@@ -8684,27 +10273,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %20
+ThrowNullRef12:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8717,8 +10306,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -8756,22 +10345,22 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
   %9 = load i64, i64 addrspace(1)* %8, align 8
   %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
   %13 = load i64, i64 addrspace(1)* %12, align 8
   %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %11
   %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
@@ -8788,11 +10377,11 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8882,8 +10471,8 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
@@ -8900,8 +10489,8 @@ entry:
 ; <label>:8                                       ; preds = %1
   %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
   %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
@@ -8911,15 +10500,15 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
   %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
   %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
-  br i1 %NullCheck6, label %21, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
@@ -8946,15 +10535,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8992,15 +10581,15 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
   store i8 %3, i8 addrspace(1)* %5
   %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
@@ -9011,7 +10600,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9027,8 +10616,8 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -9041,8 +10630,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
@@ -9058,7 +10647,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9080,8 +10669,8 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
@@ -9096,8 +10685,8 @@ entry:
 ; <label>:12                                      ; preds = %6
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
@@ -9112,8 +10701,8 @@ entry:
 ; <label>:21                                      ; preds = %15
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
@@ -9128,8 +10717,8 @@ entry:
 ; <label>:30                                      ; preds = %24
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %31, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
@@ -9144,8 +10733,8 @@ entry:
 ; <label>:39                                      ; preds = %33
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
-  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %40, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %42
 
 ; <label>:42                                      ; preds = %39
   %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
@@ -9164,19 +10753,19 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %21
+ThrowNullRef4:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %30
+ThrowNullRef6:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %39
+ThrowNullRef8:                                    ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9243,8 +10832,8 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
@@ -9264,57 +10853,57 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
   store i8 0, i8 addrspace(1)* %2
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
   store i8 0, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
   store i8 0, i8 addrspace(1)* %17
   %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
   store i8 0, i8 addrspace(1)* %20
   %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
-  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
@@ -9325,31 +10914,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %19
+ThrowNullRef14:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9367,8 +10956,8 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
@@ -9380,8 +10969,8 @@ entry:
 
 ; <label>:9                                       ; preds = %4
   %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %9
   %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
@@ -9395,7 +10984,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef2:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9420,8 +11009,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
@@ -9512,8 +11101,8 @@ entry:
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
@@ -9524,8 +11113,8 @@ entry:
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = load i64, i64 addrspace(1)* %12
@@ -9537,8 +11126,8 @@ entry:
   %20 = load i64, i64* %19
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
-  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %13
   %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
@@ -9555,8 +11144,8 @@ entry:
 ; <label>:30                                      ; preds = %25
   %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %32 = load i32, i32* %arg2
-  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
-  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
@@ -9570,15 +11159,15 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %30
+ThrowNullRef2:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9622,87 +11211,87 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
   %10 = load i8, i8 addrspace(1)* %9, align 8
   %11 = zext i8 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %8
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
   store i8 %12, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
   %19 = load i8, i8 addrspace(1)* %18, align 8
   %20 = zext i8 %19 to i32
   %21 = trunc i32 %20 to i8
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
   store i8 %21, i8 addrspace(1)* %23
   %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
   %28 = load i8, i8 addrspace(1)* %27, align 8
   %29 = zext i8 %28 to i32
   %30 = trunc i32 %29 to i8
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
-  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %31
 
 ; <label>:31                                      ; preds = %26
   %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
   store i8 %30, i8 addrspace(1)* %32
   %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
-  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
-  br i1 %NullCheck14, label %40, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %40
 
 ; <label>:40                                      ; preds = %35
   %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
   store i8 %39, i8 addrspace(1)* %41
   %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
-  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %44
 
 ; <label>:44                                      ; preds = %40
   %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
   %46 = load i8, i8 addrspace(1)* %45, align 8
   %47 = zext i8 %46 to i32
   %48 = trunc i32 %47 to i8
-  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
   store i8 %48, i8 addrspace(1)* %50
   %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
-  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
@@ -9713,29 +11302,29 @@ entry:
 ; <label>:56                                      ; preds = %52
   %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
-  br i1 %NullCheck22, label %59, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
   %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
   %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
-  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
-  br i1 %NullCheck24, label %63, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
   %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
-  br i1 %NullCheck26, label %66, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
   %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
-  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
-  br i1 %NullCheck28, label %69, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %69
 
 ; <label>:69                                      ; preds = %66
   %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
@@ -9744,15 +11333,15 @@ entry:
 
 ; <label>:71                                      ; preds = %105
   %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
-  br i1 %NullCheck34, label %73, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %73
 
 ; <label>:73                                      ; preds = %71
   %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
   %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
   %76 = load i32, i32* %loc0
-  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
-  br i1 %NullCheck36, label %77, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
@@ -9766,8 +11355,8 @@ entry:
 
 ; <label>:83                                      ; preds = %77
   %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
-  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
@@ -9775,14 +11364,14 @@ entry:
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
   %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
-  br i1 %NullCheck40, label %91, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
 ; <label>:91                                      ; preds = %85
   %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
   %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
-  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck42, label %94, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %94
 
 ; <label>:94                                      ; preds = %91
   %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
@@ -9798,14 +11387,14 @@ entry:
 ; <label>:99                                      ; preds = %69, %96
   %100 = load i32, i32* %loc0
   %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
-  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %102
 
 ; <label>:102                                     ; preds = %99
   %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
   %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
-  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
-  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
@@ -9819,87 +11408,87 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %26
+ThrowNullRef10:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %31
+ThrowNullRef12:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %35
+ThrowNullRef14:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %40
+ThrowNullRef16:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %56
+ThrowNullRef22:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %59
+ThrowNullRef24:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %63
+ThrowNullRef26:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %66
+ThrowNullRef28:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %102
+ThrowNullRef32:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %71
+ThrowNullRef34:                                   ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %73
+ThrowNullRef36:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %83
+ThrowNullRef38:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %85
+ThrowNullRef40:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %91
+ThrowNullRef42:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9943,15 +11532,15 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
   %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
@@ -9961,28 +11550,28 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
   %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %12
   %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
   %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
   %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
-  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
@@ -9993,23 +11582,23 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %12
+ThrowNullRef6:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10031,15 +11620,15 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
   %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = load i64, i64 addrspace(1)* %7
@@ -10077,13 +11666,13 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[loadElem]
+Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -10111,8 +11700,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -10181,16 +11770,16 @@ entry:
   store i32 addrspace(1)* %param0, i32 addrspace(1)** %arg0
   store i32 %param1, i32* %arg1
   %0 = load i32 addrspace(1)*, i32 addrspace(1)** %arg0
-  %NullCheck = icmp ne i32 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i32 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = load i32, i32 addrspace(1)* %0, align 8
   %3 = load i32, i32* %arg1
   %4 = and i32 %3, 31
   %5 = ashr i32 %2, %4
-  %NullCheck2 = icmp ne i32 addrspace(1)* %0, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i32 addrspace(1)* %0, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
   store i32 %5, i32 addrspace(1)* %0, align 8
@@ -10200,7 +11789,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }

--- a/test/BaseLine/JIT/CodeGenBringUpTests/StaticCalls.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/StaticCalls.error.txt
@@ -25,8 +25,8 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
@@ -40,8 +40,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
   %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
@@ -75,7 +75,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -90,8 +90,8 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %NullCheck = icmp ne i8 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = load i8, i8 addrspace(1)* %0, align 8
@@ -125,8 +125,8 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
@@ -159,8 +159,8 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -184,8 +184,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
   store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
@@ -195,8 +195,8 @@ entry:
 ; <label>:4                                       ; preds = %1
   %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
   %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
@@ -206,8 +206,8 @@ entry:
   %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
@@ -221,14 +221,14 @@ entry:
 
 ; <label>:17                                      ; preds = %14
   %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
   %21 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
@@ -238,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -249,8 +249,8 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
@@ -261,27 +261,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %30
+ThrowNullRef10:                                   ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -301,7 +301,89 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
-Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
+Successfully read AppDomainSetup.GetUnsecureApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.GetUnsecureApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %NullCheck = icmp eq %"System.String[]" addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %BoundsCheck = icmp uge i64 0, %5
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %6
+
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 3, i32 0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
+  ret %System.String addrspace(1)* %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_Value using LLILCJit
+Successfully read AppDomainSetup.get_Value
+
+define %"System.String[]" addrspace(1)* @AppDomainSetup.get_Value(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.String[]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 18)
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.String[]" addrspace(1)* addrspace(1)*, %"System.String[]" addrspace(1)*)*)(%"System.String[]" addrspace(1)* addrspace(1)* %9, %"System.String[]" addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %11, i32 0, i32 1
+  %14 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %13, align 8
+  ret %"System.String[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -319,8 +401,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -368,16 +450,16 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
   %5 = load i32, i32 addrspace(1)* %4
   %6 = sub i32 %5, 1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -389,7 +471,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -421,8 +503,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
@@ -456,8 +538,8 @@ entry:
 ; <label>:27                                      ; preds = %19
   %28 = load i32, i32* %arg1
   %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
-  br i1 %NullCheck2, label %30, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %29, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %30
 
 ; <label>:30                                      ; preds = %27
   %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
@@ -493,8 +575,8 @@ entry:
 ; <label>:49                                      ; preds = %46
   %50 = load i32, i32* %arg2
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck4, label %52, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
@@ -517,11 +599,11 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %27
+ThrowNullRef2:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %49
+ThrowNullRef4:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -544,16 +626,16 @@ entry:
   %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %0)
   store %System.String addrspace(1)* %1, %System.String addrspace(1)** %loc0
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 2
   %5 = bitcast [0 x i16] addrspace(1)* %4 to i16 addrspace(1)*
   store i16 addrspace(1)* %5, i16 addrspace(1)** %loc1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %3
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2
@@ -580,7 +662,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -691,15 +773,15 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %NullCheck132 = icmp ne i8* %21, null
-  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+  %NullCheck131 = icmp eq i8* %21, null
+  br i1 %NullCheck131, label %ThrowNullRef132, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = load i8, i8* %21, align 8
   %24 = zext i8 %23 to i32
   %25 = trunc i32 %24 to i8
-  %NullCheck134 = icmp ne i8* %20, null
-  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+  %NullCheck133 = icmp eq i8* %20, null
+  br i1 %NullCheck133, label %ThrowNullRef134, label %26
 
 ; <label>:26                                      ; preds = %22
   store i8 %25, i8* %20, align 8
@@ -709,16 +791,16 @@ entry:
   %28 = load i8*, i8** %arg0
   %29 = load i8*, i8** %arg1
   %30 = bitcast i8* %29 to i16*
-  %NullCheck128 = icmp ne i16* %30, null
-  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+  %NullCheck127 = icmp eq i16* %30, null
+  br i1 %NullCheck127, label %ThrowNullRef128, label %31
 
 ; <label>:31                                      ; preds = %27
   %32 = load i16, i16* %30, align 8
   %33 = sext i16 %32 to i32
   %34 = bitcast i8* %28 to i16*
   %35 = trunc i32 %33 to i16
-  %NullCheck130 = icmp ne i16* %34, null
-  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+  %NullCheck129 = icmp eq i16* %34, null
+  br i1 %NullCheck129, label %ThrowNullRef130, label %36
 
 ; <label>:36                                      ; preds = %31
   store i16 %35, i16* %34, align 8
@@ -728,16 +810,16 @@ entry:
   %38 = load i8*, i8** %arg0
   %39 = load i8*, i8** %arg1
   %40 = bitcast i8* %39 to i16*
-  %NullCheck120 = icmp ne i16* %40, null
-  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+  %NullCheck119 = icmp eq i16* %40, null
+  br i1 %NullCheck119, label %ThrowNullRef120, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i16, i16* %40, align 8
   %43 = sext i16 %42 to i32
   %44 = bitcast i8* %38 to i16*
   %45 = trunc i32 %43 to i16
-  %NullCheck122 = icmp ne i16* %44, null
-  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+  %NullCheck121 = icmp eq i16* %44, null
+  br i1 %NullCheck121, label %ThrowNullRef122, label %46
 
 ; <label>:46                                      ; preds = %41
   store i16 %45, i16* %44, align 8
@@ -745,15 +827,15 @@ entry:
   %48 = getelementptr inbounds i8, i8* %47, i64 2
   %49 = load i8*, i8** %arg1
   %50 = getelementptr inbounds i8, i8* %49, i64 2
-  %NullCheck124 = icmp ne i8* %50, null
-  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+  %NullCheck123 = icmp eq i8* %50, null
+  br i1 %NullCheck123, label %ThrowNullRef124, label %51
 
 ; <label>:51                                      ; preds = %46
   %52 = load i8, i8* %50, align 8
   %53 = zext i8 %52 to i32
   %54 = trunc i32 %53 to i8
-  %NullCheck126 = icmp ne i8* %48, null
-  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+  %NullCheck125 = icmp eq i8* %48, null
+  br i1 %NullCheck125, label %ThrowNullRef126, label %55
 
 ; <label>:55                                      ; preds = %51
   store i8 %54, i8* %48, align 8
@@ -763,14 +845,14 @@ entry:
   %57 = load i8*, i8** %arg0
   %58 = load i8*, i8** %arg1
   %59 = bitcast i8* %58 to i32*
-  %NullCheck116 = icmp ne i32* %59, null
-  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+  %NullCheck115 = icmp eq i32* %59, null
+  br i1 %NullCheck115, label %ThrowNullRef116, label %60
 
 ; <label>:60                                      ; preds = %56
   %61 = load i32, i32* %59, align 8
   %62 = bitcast i8* %57 to i32*
-  %NullCheck118 = icmp ne i32* %62, null
-  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+  %NullCheck117 = icmp eq i32* %62, null
+  br i1 %NullCheck117, label %ThrowNullRef118, label %63
 
 ; <label>:63                                      ; preds = %60
   store i32 %61, i32* %62, align 8
@@ -780,14 +862,14 @@ entry:
   %65 = load i8*, i8** %arg0
   %66 = load i8*, i8** %arg1
   %67 = bitcast i8* %66 to i32*
-  %NullCheck108 = icmp ne i32* %67, null
-  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+  %NullCheck107 = icmp eq i32* %67, null
+  br i1 %NullCheck107, label %ThrowNullRef108, label %68
 
 ; <label>:68                                      ; preds = %64
   %69 = load i32, i32* %67, align 8
   %70 = bitcast i8* %65 to i32*
-  %NullCheck110 = icmp ne i32* %70, null
-  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+  %NullCheck109 = icmp eq i32* %70, null
+  br i1 %NullCheck109, label %ThrowNullRef110, label %71
 
 ; <label>:71                                      ; preds = %68
   store i32 %69, i32* %70, align 8
@@ -795,15 +877,15 @@ entry:
   %73 = getelementptr inbounds i8, i8* %72, i64 4
   %74 = load i8*, i8** %arg1
   %75 = getelementptr inbounds i8, i8* %74, i64 4
-  %NullCheck112 = icmp ne i8* %75, null
-  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+  %NullCheck111 = icmp eq i8* %75, null
+  br i1 %NullCheck111, label %ThrowNullRef112, label %76
 
 ; <label>:76                                      ; preds = %71
   %77 = load i8, i8* %75, align 8
   %78 = zext i8 %77 to i32
   %79 = trunc i32 %78 to i8
-  %NullCheck114 = icmp ne i8* %73, null
-  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+  %NullCheck113 = icmp eq i8* %73, null
+  br i1 %NullCheck113, label %ThrowNullRef114, label %80
 
 ; <label>:80                                      ; preds = %76
   store i8 %79, i8* %73, align 8
@@ -813,14 +895,14 @@ entry:
   %82 = load i8*, i8** %arg0
   %83 = load i8*, i8** %arg1
   %84 = bitcast i8* %83 to i32*
-  %NullCheck100 = icmp ne i32* %84, null
-  br i1 %NullCheck100, label %85, label %ThrowNullRef99
+  %NullCheck99 = icmp eq i32* %84, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %85
 
 ; <label>:85                                      ; preds = %81
   %86 = load i32, i32* %84, align 8
   %87 = bitcast i8* %82 to i32*
-  %NullCheck102 = icmp ne i32* %87, null
-  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+  %NullCheck101 = icmp eq i32* %87, null
+  br i1 %NullCheck101, label %ThrowNullRef102, label %88
 
 ; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
@@ -829,16 +911,16 @@ entry:
   %91 = load i8*, i8** %arg1
   %92 = getelementptr inbounds i8, i8* %91, i64 4
   %93 = bitcast i8* %92 to i16*
-  %NullCheck104 = icmp ne i16* %93, null
-  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+  %NullCheck103 = icmp eq i16* %93, null
+  br i1 %NullCheck103, label %ThrowNullRef104, label %94
 
 ; <label>:94                                      ; preds = %88
   %95 = load i16, i16* %93, align 8
   %96 = sext i16 %95 to i32
   %97 = bitcast i8* %90 to i16*
   %98 = trunc i32 %96 to i16
-  %NullCheck106 = icmp ne i16* %97, null
-  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+  %NullCheck105 = icmp eq i16* %97, null
+  br i1 %NullCheck105, label %ThrowNullRef106, label %99
 
 ; <label>:99                                      ; preds = %94
   store i16 %98, i16* %97, align 8
@@ -848,14 +930,14 @@ entry:
   %101 = load i8*, i8** %arg0
   %102 = load i8*, i8** %arg1
   %103 = bitcast i8* %102 to i32*
-  %NullCheck88 = icmp ne i32* %103, null
-  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+  %NullCheck87 = icmp eq i32* %103, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %104
 
 ; <label>:104                                     ; preds = %100
   %105 = load i32, i32* %103, align 8
   %106 = bitcast i8* %101 to i32*
-  %NullCheck90 = icmp ne i32* %106, null
-  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+  %NullCheck89 = icmp eq i32* %106, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %107
 
 ; <label>:107                                     ; preds = %104
   store i32 %105, i32* %106, align 8
@@ -864,16 +946,16 @@ entry:
   %110 = load i8*, i8** %arg1
   %111 = getelementptr inbounds i8, i8* %110, i64 4
   %112 = bitcast i8* %111 to i16*
-  %NullCheck92 = icmp ne i16* %112, null
-  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+  %NullCheck91 = icmp eq i16* %112, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %113
 
 ; <label>:113                                     ; preds = %107
   %114 = load i16, i16* %112, align 8
   %115 = sext i16 %114 to i32
   %116 = bitcast i8* %109 to i16*
   %117 = trunc i32 %115 to i16
-  %NullCheck94 = icmp ne i16* %116, null
-  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+  %NullCheck93 = icmp eq i16* %116, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %118
 
 ; <label>:118                                     ; preds = %113
   store i16 %117, i16* %116, align 8
@@ -881,15 +963,15 @@ entry:
   %120 = getelementptr inbounds i8, i8* %119, i64 6
   %121 = load i8*, i8** %arg1
   %122 = getelementptr inbounds i8, i8* %121, i64 6
-  %NullCheck96 = icmp ne i8* %122, null
-  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+  %NullCheck95 = icmp eq i8* %122, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %123
 
 ; <label>:123                                     ; preds = %118
   %124 = load i8, i8* %122, align 8
   %125 = zext i8 %124 to i32
   %126 = trunc i32 %125 to i8
-  %NullCheck98 = icmp ne i8* %120, null
-  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+  %NullCheck97 = icmp eq i8* %120, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %127
 
 ; <label>:127                                     ; preds = %123
   store i8 %126, i8* %120, align 8
@@ -899,14 +981,14 @@ entry:
   %129 = load i8*, i8** %arg0
   %130 = load i8*, i8** %arg1
   %131 = bitcast i8* %130 to i64*
-  %NullCheck84 = icmp ne i64* %131, null
-  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+  %NullCheck83 = icmp eq i64* %131, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %132
 
 ; <label>:132                                     ; preds = %128
   %133 = load i64, i64* %131, align 8
   %134 = bitcast i8* %129 to i64*
-  %NullCheck86 = icmp ne i64* %134, null
-  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+  %NullCheck85 = icmp eq i64* %134, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %135
 
 ; <label>:135                                     ; preds = %132
   store i64 %133, i64* %134, align 8
@@ -916,14 +998,14 @@ entry:
   %137 = load i8*, i8** %arg0
   %138 = load i8*, i8** %arg1
   %139 = bitcast i8* %138 to i64*
-  %NullCheck76 = icmp ne i64* %139, null
-  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+  %NullCheck75 = icmp eq i64* %139, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %140
 
 ; <label>:140                                     ; preds = %136
   %141 = load i64, i64* %139, align 8
   %142 = bitcast i8* %137 to i64*
-  %NullCheck78 = icmp ne i64* %142, null
-  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+  %NullCheck77 = icmp eq i64* %142, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %143
 
 ; <label>:143                                     ; preds = %140
   store i64 %141, i64* %142, align 8
@@ -931,15 +1013,15 @@ entry:
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %NullCheck80 = icmp ne i8* %147, null
-  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+  %NullCheck79 = icmp eq i8* %147, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %148
 
 ; <label>:148                                     ; preds = %143
   %149 = load i8, i8* %147, align 8
   %150 = zext i8 %149 to i32
   %151 = trunc i32 %150 to i8
-  %NullCheck82 = icmp ne i8* %145, null
-  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+  %NullCheck81 = icmp eq i8* %145, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %152
 
 ; <label>:152                                     ; preds = %148
   store i8 %151, i8* %145, align 8
@@ -949,14 +1031,14 @@ entry:
   %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
   %156 = bitcast i8* %155 to i64*
-  %NullCheck68 = icmp ne i64* %156, null
-  br i1 %NullCheck68, label %157, label %ThrowNullRef67
+  %NullCheck67 = icmp eq i64* %156, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %157
 
 ; <label>:157                                     ; preds = %153
   %158 = load i64, i64* %156, align 8
   %159 = bitcast i8* %154 to i64*
-  %NullCheck70 = icmp ne i64* %159, null
-  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+  %NullCheck69 = icmp eq i64* %159, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %160
 
 ; <label>:160                                     ; preds = %157
   store i64 %158, i64* %159, align 8
@@ -965,16 +1047,16 @@ entry:
   %163 = load i8*, i8** %arg1
   %164 = getelementptr inbounds i8, i8* %163, i64 8
   %165 = bitcast i8* %164 to i16*
-  %NullCheck72 = icmp ne i16* %165, null
-  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+  %NullCheck71 = icmp eq i16* %165, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %166
 
 ; <label>:166                                     ; preds = %160
   %167 = load i16, i16* %165, align 8
   %168 = sext i16 %167 to i32
   %169 = bitcast i8* %162 to i16*
   %170 = trunc i32 %168 to i16
-  %NullCheck74 = icmp ne i16* %169, null
-  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+  %NullCheck73 = icmp eq i16* %169, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %171
 
 ; <label>:171                                     ; preds = %166
   store i16 %170, i16* %169, align 8
@@ -984,14 +1066,14 @@ entry:
   %173 = load i8*, i8** %arg0
   %174 = load i8*, i8** %arg1
   %175 = bitcast i8* %174 to i64*
-  %NullCheck56 = icmp ne i64* %175, null
-  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+  %NullCheck55 = icmp eq i64* %175, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %176
 
 ; <label>:176                                     ; preds = %172
   %177 = load i64, i64* %175, align 8
   %178 = bitcast i8* %173 to i64*
-  %NullCheck58 = icmp ne i64* %178, null
-  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+  %NullCheck57 = icmp eq i64* %178, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %179
 
 ; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
@@ -1000,16 +1082,16 @@ entry:
   %182 = load i8*, i8** %arg1
   %183 = getelementptr inbounds i8, i8* %182, i64 8
   %184 = bitcast i8* %183 to i16*
-  %NullCheck60 = icmp ne i16* %184, null
-  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+  %NullCheck59 = icmp eq i16* %184, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %185
 
 ; <label>:185                                     ; preds = %179
   %186 = load i16, i16* %184, align 8
   %187 = sext i16 %186 to i32
   %188 = bitcast i8* %181 to i16*
   %189 = trunc i32 %187 to i16
-  %NullCheck62 = icmp ne i16* %188, null
-  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+  %NullCheck61 = icmp eq i16* %188, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %190
 
 ; <label>:190                                     ; preds = %185
   store i16 %189, i16* %188, align 8
@@ -1017,15 +1099,15 @@ entry:
   %192 = getelementptr inbounds i8, i8* %191, i64 10
   %193 = load i8*, i8** %arg1
   %194 = getelementptr inbounds i8, i8* %193, i64 10
-  %NullCheck64 = icmp ne i8* %194, null
-  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+  %NullCheck63 = icmp eq i8* %194, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %195
 
 ; <label>:195                                     ; preds = %190
   %196 = load i8, i8* %194, align 8
   %197 = zext i8 %196 to i32
   %198 = trunc i32 %197 to i8
-  %NullCheck66 = icmp ne i8* %192, null
-  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+  %NullCheck65 = icmp eq i8* %192, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %199
 
 ; <label>:199                                     ; preds = %195
   store i8 %198, i8* %192, align 8
@@ -1035,14 +1117,14 @@ entry:
   %201 = load i8*, i8** %arg0
   %202 = load i8*, i8** %arg1
   %203 = bitcast i8* %202 to i64*
-  %NullCheck48 = icmp ne i64* %203, null
-  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+  %NullCheck47 = icmp eq i64* %203, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %204
 
 ; <label>:204                                     ; preds = %200
   %205 = load i64, i64* %203, align 8
   %206 = bitcast i8* %201 to i64*
-  %NullCheck50 = icmp ne i64* %206, null
-  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+  %NullCheck49 = icmp eq i64* %206, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %207
 
 ; <label>:207                                     ; preds = %204
   store i64 %205, i64* %206, align 8
@@ -1051,14 +1133,14 @@ entry:
   %210 = load i8*, i8** %arg1
   %211 = getelementptr inbounds i8, i8* %210, i64 8
   %212 = bitcast i8* %211 to i32*
-  %NullCheck52 = icmp ne i32* %212, null
-  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+  %NullCheck51 = icmp eq i32* %212, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %213
 
 ; <label>:213                                     ; preds = %207
   %214 = load i32, i32* %212, align 8
   %215 = bitcast i8* %209 to i32*
-  %NullCheck54 = icmp ne i32* %215, null
-  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+  %NullCheck53 = icmp eq i32* %215, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %216
 
 ; <label>:216                                     ; preds = %213
   store i32 %214, i32* %215, align 8
@@ -1068,14 +1150,14 @@ entry:
   %218 = load i8*, i8** %arg0
   %219 = load i8*, i8** %arg1
   %220 = bitcast i8* %219 to i64*
-  %NullCheck36 = icmp ne i64* %220, null
-  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64* %220, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %221
 
 ; <label>:221                                     ; preds = %217
   %222 = load i64, i64* %220, align 8
   %223 = bitcast i8* %218 to i64*
-  %NullCheck38 = icmp ne i64* %223, null
-  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+  %NullCheck37 = icmp eq i64* %223, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %224
 
 ; <label>:224                                     ; preds = %221
   store i64 %222, i64* %223, align 8
@@ -1084,14 +1166,14 @@ entry:
   %227 = load i8*, i8** %arg1
   %228 = getelementptr inbounds i8, i8* %227, i64 8
   %229 = bitcast i8* %228 to i32*
-  %NullCheck40 = icmp ne i32* %229, null
-  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i32* %229, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %230
 
 ; <label>:230                                     ; preds = %224
   %231 = load i32, i32* %229, align 8
   %232 = bitcast i8* %226 to i32*
-  %NullCheck42 = icmp ne i32* %232, null
-  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+  %NullCheck41 = icmp eq i32* %232, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %233
 
 ; <label>:233                                     ; preds = %230
   store i32 %231, i32* %232, align 8
@@ -1099,15 +1181,15 @@ entry:
   %235 = getelementptr inbounds i8, i8* %234, i64 12
   %236 = load i8*, i8** %arg1
   %237 = getelementptr inbounds i8, i8* %236, i64 12
-  %NullCheck44 = icmp ne i8* %237, null
-  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i8* %237, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %238
 
 ; <label>:238                                     ; preds = %233
   %239 = load i8, i8* %237, align 8
   %240 = zext i8 %239 to i32
   %241 = trunc i32 %240 to i8
-  %NullCheck46 = icmp ne i8* %235, null
-  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+  %NullCheck45 = icmp eq i8* %235, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %242
 
 ; <label>:242                                     ; preds = %238
   store i8 %241, i8* %235, align 8
@@ -1117,14 +1199,14 @@ entry:
   %244 = load i8*, i8** %arg0
   %245 = load i8*, i8** %arg1
   %246 = bitcast i8* %245 to i64*
-  %NullCheck24 = icmp ne i64* %246, null
-  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64* %246, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %247
 
 ; <label>:247                                     ; preds = %243
   %248 = load i64, i64* %246, align 8
   %249 = bitcast i8* %244 to i64*
-  %NullCheck26 = icmp ne i64* %249, null
-  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64* %249, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %250
 
 ; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
@@ -1133,14 +1215,14 @@ entry:
   %253 = load i8*, i8** %arg1
   %254 = getelementptr inbounds i8, i8* %253, i64 8
   %255 = bitcast i8* %254 to i32*
-  %NullCheck28 = icmp ne i32* %255, null
-  br i1 %NullCheck28, label %256, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i32* %255, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %256
 
 ; <label>:256                                     ; preds = %250
   %257 = load i32, i32* %255, align 8
   %258 = bitcast i8* %252 to i32*
-  %NullCheck30 = icmp ne i32* %258, null
-  br i1 %NullCheck30, label %259, label %ThrowNullRef29
+  %NullCheck29 = icmp eq i32* %258, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %259
 
 ; <label>:259                                     ; preds = %256
   store i32 %257, i32* %258, align 8
@@ -1149,16 +1231,16 @@ entry:
   %262 = load i8*, i8** %arg1
   %263 = getelementptr inbounds i8, i8* %262, i64 12
   %264 = bitcast i8* %263 to i16*
-  %NullCheck32 = icmp ne i16* %264, null
-  br i1 %NullCheck32, label %265, label %ThrowNullRef31
+  %NullCheck31 = icmp eq i16* %264, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %265
 
 ; <label>:265                                     ; preds = %259
   %266 = load i16, i16* %264, align 8
   %267 = sext i16 %266 to i32
   %268 = bitcast i8* %261 to i16*
   %269 = trunc i32 %267 to i16
-  %NullCheck34 = icmp ne i16* %268, null
-  br i1 %NullCheck34, label %270, label %ThrowNullRef33
+  %NullCheck33 = icmp eq i16* %268, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %270
 
 ; <label>:270                                     ; preds = %265
   store i16 %269, i16* %268, align 8
@@ -1168,14 +1250,14 @@ entry:
   %272 = load i8*, i8** %arg0
   %273 = load i8*, i8** %arg1
   %274 = bitcast i8* %273 to i64*
-  %NullCheck8 = icmp ne i64* %274, null
-  br i1 %NullCheck8, label %275, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64* %274, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %275
 
 ; <label>:275                                     ; preds = %271
   %276 = load i64, i64* %274, align 8
   %277 = bitcast i8* %272 to i64*
-  %NullCheck10 = icmp ne i64* %277, null
-  br i1 %NullCheck10, label %278, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %277, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %278
 
 ; <label>:278                                     ; preds = %275
   store i64 %276, i64* %277, align 8
@@ -1184,14 +1266,14 @@ entry:
   %281 = load i8*, i8** %arg1
   %282 = getelementptr inbounds i8, i8* %281, i64 8
   %283 = bitcast i8* %282 to i32*
-  %NullCheck12 = icmp ne i32* %283, null
-  br i1 %NullCheck12, label %284, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i32* %283, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %284
 
 ; <label>:284                                     ; preds = %278
   %285 = load i32, i32* %283, align 8
   %286 = bitcast i8* %280 to i32*
-  %NullCheck14 = icmp ne i32* %286, null
-  br i1 %NullCheck14, label %287, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i32* %286, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %287
 
 ; <label>:287                                     ; preds = %284
   store i32 %285, i32* %286, align 8
@@ -1200,16 +1282,16 @@ entry:
   %290 = load i8*, i8** %arg1
   %291 = getelementptr inbounds i8, i8* %290, i64 12
   %292 = bitcast i8* %291 to i16*
-  %NullCheck16 = icmp ne i16* %292, null
-  br i1 %NullCheck16, label %293, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i16* %292, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %293
 
 ; <label>:293                                     ; preds = %287
   %294 = load i16, i16* %292, align 8
   %295 = sext i16 %294 to i32
   %296 = bitcast i8* %289 to i16*
   %297 = trunc i32 %295 to i16
-  %NullCheck18 = icmp ne i16* %296, null
-  br i1 %NullCheck18, label %298, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i16* %296, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %298
 
 ; <label>:298                                     ; preds = %293
   store i16 %297, i16* %296, align 8
@@ -1217,15 +1299,15 @@ entry:
   %300 = getelementptr inbounds i8, i8* %299, i64 14
   %301 = load i8*, i8** %arg1
   %302 = getelementptr inbounds i8, i8* %301, i64 14
-  %NullCheck20 = icmp ne i8* %302, null
-  br i1 %NullCheck20, label %303, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i8* %302, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %303
 
 ; <label>:303                                     ; preds = %298
   %304 = load i8, i8* %302, align 8
   %305 = zext i8 %304 to i32
   %306 = trunc i32 %305 to i8
-  %NullCheck22 = icmp ne i8* %300, null
-  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i8* %300, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %307
 
 ; <label>:307                                     ; preds = %303
   store i8 %306, i8* %300, align 8
@@ -1235,14 +1317,14 @@ entry:
   %309 = load i8*, i8** %arg0
   %310 = load i8*, i8** %arg1
   %311 = bitcast i8* %310 to i64*
-  %NullCheck = icmp ne i64* %311, null
-  br i1 %NullCheck, label %312, label %ThrowNullRef
+  %NullCheck = icmp eq i64* %311, null
+  br i1 %NullCheck, label %ThrowNullRef, label %312
 
 ; <label>:312                                     ; preds = %308
   %313 = load i64, i64* %311, align 8
   %314 = bitcast i8* %309 to i64*
-  %NullCheck2 = icmp ne i64* %314, null
-  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64* %314, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %315
 
 ; <label>:315                                     ; preds = %312
   store i64 %313, i64* %314, align 8
@@ -1251,14 +1333,14 @@ entry:
   %318 = load i8*, i8** %arg1
   %319 = getelementptr inbounds i8, i8* %318, i64 8
   %320 = bitcast i8* %319 to i64*
-  %NullCheck4 = icmp ne i64* %320, null
-  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64* %320, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %321
 
 ; <label>:321                                     ; preds = %315
   %322 = load i64, i64* %320, align 8
   %323 = bitcast i8* %317 to i64*
-  %NullCheck6 = icmp ne i64* %323, null
-  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64* %323, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %324
 
 ; <label>:324                                     ; preds = %321
   store i64 %322, i64* %323, align 8
@@ -1286,15 +1368,15 @@ entry:
 ; <label>:338                                     ; preds = %333
   %339 = load i8*, i8** %arg0
   %340 = load i8*, i8** %arg1
-  %NullCheck136 = icmp ne i8* %340, null
-  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+  %NullCheck135 = icmp eq i8* %340, null
+  br i1 %NullCheck135, label %ThrowNullRef136, label %341
 
 ; <label>:341                                     ; preds = %338
   %342 = load i8, i8* %340, align 8
   %343 = zext i8 %342 to i32
   %344 = trunc i32 %343 to i8
-  %NullCheck138 = icmp ne i8* %339, null
-  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+  %NullCheck137 = icmp eq i8* %339, null
+  br i1 %NullCheck137, label %ThrowNullRef138, label %345
 
 ; <label>:345                                     ; preds = %341
   store i8 %344, i8* %339, align 8
@@ -1317,16 +1399,16 @@ entry:
   %357 = load i8*, i8** %arg0
   %358 = load i8*, i8** %arg1
   %359 = bitcast i8* %358 to i16*
-  %NullCheck140 = icmp ne i16* %359, null
-  br i1 %NullCheck140, label %360, label %ThrowNullRef139
+  %NullCheck139 = icmp eq i16* %359, null
+  br i1 %NullCheck139, label %ThrowNullRef140, label %360
 
 ; <label>:360                                     ; preds = %356
   %361 = load i16, i16* %359, align 8
   %362 = sext i16 %361 to i32
   %363 = bitcast i8* %357 to i16*
   %364 = trunc i32 %362 to i16
-  %NullCheck142 = icmp ne i16* %363, null
-  br i1 %NullCheck142, label %365, label %ThrowNullRef141
+  %NullCheck141 = icmp eq i16* %363, null
+  br i1 %NullCheck141, label %ThrowNullRef142, label %365
 
 ; <label>:365                                     ; preds = %360
   store i16 %364, i16* %363, align 8
@@ -1352,14 +1434,14 @@ entry:
   %378 = load i8*, i8** %arg0
   %379 = load i8*, i8** %arg1
   %380 = bitcast i8* %379 to i32*
-  %NullCheck144 = icmp ne i32* %380, null
-  br i1 %NullCheck144, label %381, label %ThrowNullRef143
+  %NullCheck143 = icmp eq i32* %380, null
+  br i1 %NullCheck143, label %ThrowNullRef144, label %381
 
 ; <label>:381                                     ; preds = %377
   %382 = load i32, i32* %380, align 8
   %383 = bitcast i8* %378 to i32*
-  %NullCheck146 = icmp ne i32* %383, null
-  br i1 %NullCheck146, label %384, label %ThrowNullRef145
+  %NullCheck145 = icmp eq i32* %383, null
+  br i1 %NullCheck145, label %ThrowNullRef146, label %384
 
 ; <label>:384                                     ; preds = %381
   store i32 %382, i32* %383, align 8
@@ -1384,14 +1466,14 @@ entry:
   %395 = load i8*, i8** %arg0
   %396 = load i8*, i8** %arg1
   %397 = bitcast i8* %396 to i64*
-  %NullCheck164 = icmp ne i64* %397, null
-  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+  %NullCheck163 = icmp eq i64* %397, null
+  br i1 %NullCheck163, label %ThrowNullRef164, label %398
 
 ; <label>:398                                     ; preds = %394
   %399 = load i64, i64* %397, align 8
   %400 = bitcast i8* %395 to i64*
-  %NullCheck166 = icmp ne i64* %400, null
-  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+  %NullCheck165 = icmp eq i64* %400, null
+  br i1 %NullCheck165, label %ThrowNullRef166, label %401
 
 ; <label>:401                                     ; preds = %398
   store i64 %399, i64* %400, align 8
@@ -1400,14 +1482,14 @@ entry:
   %404 = load i8*, i8** %arg1
   %405 = getelementptr inbounds i8, i8* %404, i64 8
   %406 = bitcast i8* %405 to i64*
-  %NullCheck168 = icmp ne i64* %406, null
-  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+  %NullCheck167 = icmp eq i64* %406, null
+  br i1 %NullCheck167, label %ThrowNullRef168, label %407
 
 ; <label>:407                                     ; preds = %401
   %408 = load i64, i64* %406, align 8
   %409 = bitcast i8* %403 to i64*
-  %NullCheck170 = icmp ne i64* %409, null
-  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+  %NullCheck169 = icmp eq i64* %409, null
+  br i1 %NullCheck169, label %ThrowNullRef170, label %410
 
 ; <label>:410                                     ; preds = %407
   store i64 %408, i64* %409, align 8
@@ -1437,14 +1519,14 @@ entry:
   %425 = load i8*, i8** %arg0
   %426 = load i8*, i8** %arg1
   %427 = bitcast i8* %426 to i64*
-  %NullCheck148 = icmp ne i64* %427, null
-  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+  %NullCheck147 = icmp eq i64* %427, null
+  br i1 %NullCheck147, label %ThrowNullRef148, label %428
 
 ; <label>:428                                     ; preds = %424
   %429 = load i64, i64* %427, align 8
   %430 = bitcast i8* %425 to i64*
-  %NullCheck150 = icmp ne i64* %430, null
-  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+  %NullCheck149 = icmp eq i64* %430, null
+  br i1 %NullCheck149, label %ThrowNullRef150, label %431
 
 ; <label>:431                                     ; preds = %428
   store i64 %429, i64* %430, align 8
@@ -1466,14 +1548,14 @@ entry:
   %441 = load i8*, i8** %arg0
   %442 = load i8*, i8** %arg1
   %443 = bitcast i8* %442 to i32*
-  %NullCheck152 = icmp ne i32* %443, null
-  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+  %NullCheck151 = icmp eq i32* %443, null
+  br i1 %NullCheck151, label %ThrowNullRef152, label %444
 
 ; <label>:444                                     ; preds = %440
   %445 = load i32, i32* %443, align 8
   %446 = bitcast i8* %441 to i32*
-  %NullCheck154 = icmp ne i32* %446, null
-  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+  %NullCheck153 = icmp eq i32* %446, null
+  br i1 %NullCheck153, label %ThrowNullRef154, label %447
 
 ; <label>:447                                     ; preds = %444
   store i32 %445, i32* %446, align 8
@@ -1495,16 +1577,16 @@ entry:
   %457 = load i8*, i8** %arg0
   %458 = load i8*, i8** %arg1
   %459 = bitcast i8* %458 to i16*
-  %NullCheck156 = icmp ne i16* %459, null
-  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+  %NullCheck155 = icmp eq i16* %459, null
+  br i1 %NullCheck155, label %ThrowNullRef156, label %460
 
 ; <label>:460                                     ; preds = %456
   %461 = load i16, i16* %459, align 8
   %462 = sext i16 %461 to i32
   %463 = bitcast i8* %457 to i16*
   %464 = trunc i32 %462 to i16
-  %NullCheck158 = icmp ne i16* %463, null
-  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+  %NullCheck157 = icmp eq i16* %463, null
+  br i1 %NullCheck157, label %ThrowNullRef158, label %465
 
 ; <label>:465                                     ; preds = %460
   store i16 %464, i16* %463, align 8
@@ -1525,15 +1607,15 @@ entry:
 ; <label>:474                                     ; preds = %470
   %475 = load i8*, i8** %arg0
   %476 = load i8*, i8** %arg1
-  %NullCheck160 = icmp ne i8* %476, null
-  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+  %NullCheck159 = icmp eq i8* %476, null
+  br i1 %NullCheck159, label %ThrowNullRef160, label %477
 
 ; <label>:477                                     ; preds = %474
   %478 = load i8, i8* %476, align 8
   %479 = zext i8 %478 to i32
   %480 = trunc i32 %479 to i8
-  %NullCheck162 = icmp ne i8* %475, null
-  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+  %NullCheck161 = icmp eq i8* %475, null
+  br i1 %NullCheck161, label %ThrowNullRef162, label %481
 
 ; <label>:481                                     ; preds = %477
   store i8 %480, i8* %475, align 8
@@ -1553,343 +1635,343 @@ ThrowNullRef:                                     ; preds = %308
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %312
+ThrowNullRef2:                                    ; preds = %312
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %315
+ThrowNullRef4:                                    ; preds = %315
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %321
+ThrowNullRef6:                                    ; preds = %321
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %271
+ThrowNullRef8:                                    ; preds = %271
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %275
+ThrowNullRef10:                                   ; preds = %275
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %278
+ThrowNullRef12:                                   ; preds = %278
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %284
+ThrowNullRef14:                                   ; preds = %284
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %287
+ThrowNullRef16:                                   ; preds = %287
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %293
+ThrowNullRef18:                                   ; preds = %293
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %298
+ThrowNullRef20:                                   ; preds = %298
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %303
+ThrowNullRef22:                                   ; preds = %303
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %243
+ThrowNullRef24:                                   ; preds = %243
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %247
+ThrowNullRef26:                                   ; preds = %247
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %250
+ThrowNullRef28:                                   ; preds = %250
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %256
+ThrowNullRef30:                                   ; preds = %256
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %259
+ThrowNullRef32:                                   ; preds = %259
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %265
+ThrowNullRef34:                                   ; preds = %265
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %217
+ThrowNullRef36:                                   ; preds = %217
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %221
+ThrowNullRef38:                                   ; preds = %221
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %224
+ThrowNullRef40:                                   ; preds = %224
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %230
+ThrowNullRef42:                                   ; preds = %230
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %233
+ThrowNullRef44:                                   ; preds = %233
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %238
+ThrowNullRef46:                                   ; preds = %238
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %200
+ThrowNullRef48:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %204
+ThrowNullRef50:                                   ; preds = %204
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %207
+ThrowNullRef52:                                   ; preds = %207
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %213
+ThrowNullRef54:                                   ; preds = %213
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %172
+ThrowNullRef56:                                   ; preds = %172
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %176
+ThrowNullRef58:                                   ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %179
+ThrowNullRef60:                                   ; preds = %179
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %185
+ThrowNullRef62:                                   ; preds = %185
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %190
+ThrowNullRef64:                                   ; preds = %190
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %195
+ThrowNullRef66:                                   ; preds = %195
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %153
+ThrowNullRef68:                                   ; preds = %153
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %157
+ThrowNullRef70:                                   ; preds = %157
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %160
+ThrowNullRef72:                                   ; preds = %160
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %166
+ThrowNullRef74:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %136
+ThrowNullRef76:                                   ; preds = %136
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %140
+ThrowNullRef78:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %143
+ThrowNullRef80:                                   ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %148
+ThrowNullRef82:                                   ; preds = %148
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %128
+ThrowNullRef84:                                   ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %132
+ThrowNullRef86:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %100
+ThrowNullRef88:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %104
+ThrowNullRef90:                                   ; preds = %104
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %107
+ThrowNullRef92:                                   ; preds = %107
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %113
+ThrowNullRef94:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %118
+ThrowNullRef96:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %123
+ThrowNullRef98:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %81
+ThrowNullRef100:                                  ; preds = %81
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef101:                                  ; preds = %85
+ThrowNullRef102:                                  ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef103:                                  ; preds = %88
+ThrowNullRef104:                                  ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef105:                                  ; preds = %94
+ThrowNullRef106:                                  ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef107:                                  ; preds = %64
+ThrowNullRef108:                                  ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef109:                                  ; preds = %68
+ThrowNullRef110:                                  ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef111:                                  ; preds = %71
+ThrowNullRef112:                                  ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef113:                                  ; preds = %76
+ThrowNullRef114:                                  ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef115:                                  ; preds = %56
+ThrowNullRef116:                                  ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef117:                                  ; preds = %60
+ThrowNullRef118:                                  ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef119:                                  ; preds = %37
+ThrowNullRef120:                                  ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef121:                                  ; preds = %41
+ThrowNullRef122:                                  ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef123:                                  ; preds = %46
+ThrowNullRef124:                                  ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef125:                                  ; preds = %51
+ThrowNullRef126:                                  ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef127:                                  ; preds = %27
+ThrowNullRef128:                                  ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef129:                                  ; preds = %31
+ThrowNullRef130:                                  ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef131:                                  ; preds = %19
+ThrowNullRef132:                                  ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef133:                                  ; preds = %22
+ThrowNullRef134:                                  ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef135:                                  ; preds = %338
+ThrowNullRef136:                                  ; preds = %338
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef137:                                  ; preds = %341
+ThrowNullRef138:                                  ; preds = %341
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef139:                                  ; preds = %356
+ThrowNullRef140:                                  ; preds = %356
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef141:                                  ; preds = %360
+ThrowNullRef142:                                  ; preds = %360
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef143:                                  ; preds = %377
+ThrowNullRef144:                                  ; preds = %377
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef145:                                  ; preds = %381
+ThrowNullRef146:                                  ; preds = %381
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef147:                                  ; preds = %424
+ThrowNullRef148:                                  ; preds = %424
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef149:                                  ; preds = %428
+ThrowNullRef150:                                  ; preds = %428
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef151:                                  ; preds = %440
+ThrowNullRef152:                                  ; preds = %440
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef153:                                  ; preds = %444
+ThrowNullRef154:                                  ; preds = %444
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef155:                                  ; preds = %456
+ThrowNullRef156:                                  ; preds = %456
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef157:                                  ; preds = %460
+ThrowNullRef158:                                  ; preds = %460
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef159:                                  ; preds = %474
+ThrowNullRef160:                                  ; preds = %474
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef161:                                  ; preds = %477
+ThrowNullRef162:                                  ; preds = %477
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef163:                                  ; preds = %394
+ThrowNullRef164:                                  ; preds = %394
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef165:                                  ; preds = %398
+ThrowNullRef166:                                  ; preds = %398
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef167:                                  ; preds = %401
+ThrowNullRef168:                                  ; preds = %401
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef169:                                  ; preds = %407
+ThrowNullRef170:                                  ; preds = %407
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1939,8 +2021,8 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
-  br i1 %NullCheck, label %22, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %ThrowNullRef, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
@@ -1948,8 +2030,8 @@ entry:
   store i32 %24, i32* %loc0
   %25 = load i32, i32* %loc0
   %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %26, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %27
 
 ; <label>:27                                      ; preds = %22
   %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
@@ -1971,7 +2053,7 @@ ThrowNullRef:                                     ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1989,8 +2071,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -2022,15 +2104,15 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2048,16 +2130,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
   %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
   store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %15
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
@@ -2072,8 +2154,8 @@ entry:
   %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
   %29 = ptrtoint i16 addrspace(1)* %28 to i64
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %19
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
@@ -2089,19 +2171,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2114,8 +2196,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
@@ -2128,7 +2210,7 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[loadElem]
+Failed to read AppDomain.PrepareDataForSetup[storeElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
@@ -2202,8 +2284,8 @@ entry:
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
-  br i1 %NullCheck24, label %27, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = load i64, i64 addrspace(1)* %26
@@ -2218,8 +2300,8 @@ entry:
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
-  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
   %41 = load i64, i64 addrspace(1)* %39
@@ -2236,8 +2318,8 @@ entry:
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
-  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
   %54 = load i64, i64 addrspace(1)* %52
@@ -2252,8 +2334,8 @@ entry:
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
   %67 = load i64, i64 addrspace(1)* %65
@@ -2270,8 +2352,8 @@ entry:
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
-  br i1 %NullCheck16, label %79, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
   %80 = load i64, i64 addrspace(1)* %78
@@ -2286,8 +2368,8 @@ entry:
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
-  br i1 %NullCheck18, label %92, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
   %93 = load i64, i64 addrspace(1)* %91
@@ -2304,8 +2386,8 @@ entry:
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
-  br i1 %NullCheck12, label %105, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = load i64, i64 addrspace(1)* %104
@@ -2320,8 +2402,8 @@ entry:
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
-  br i1 %NullCheck14, label %118, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
   %119 = load i64, i64 addrspace(1)* %117
@@ -2337,8 +2419,8 @@ entry:
 
 ; <label>:128                                     ; preds = %20
   %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
-  br i1 %NullCheck4, label %130, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %129, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %130
 
 ; <label>:130                                     ; preds = %128
   %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
@@ -2346,8 +2428,8 @@ entry:
   %133 = load i16, i16 addrspace(1)* %132, align 8
   %134 = zext i16 %133 to i32
   %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
-  br i1 %NullCheck6, label %136, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %135, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %136
 
 ; <label>:136                                     ; preds = %130
   %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
@@ -2360,8 +2442,8 @@ entry:
 
 ; <label>:143                                     ; preds = %136
   %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
-  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %144, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %145
 
 ; <label>:145                                     ; preds = %143
   %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
@@ -2369,8 +2451,8 @@ entry:
   %148 = load i16, i16 addrspace(1)* %147, align 8
   %149 = zext i16 %148 to i32
   %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %150, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %151
 
 ; <label>:151                                     ; preds = %145
   %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
@@ -2388,8 +2470,8 @@ entry:
 
 ; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
-  br i1 %NullCheck, label %163, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %ThrowNullRef, label %163
 
 ; <label>:163                                     ; preds = %161
   %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
@@ -2399,8 +2481,8 @@ entry:
 
 ; <label>:167                                     ; preds = %163
   %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
-  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %168, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %169
 
 ; <label>:169                                     ; preds = %167
   %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
@@ -2432,55 +2514,55 @@ ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %167
+ThrowNullRef2:                                    ; preds = %167
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %128
+ThrowNullRef4:                                    ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %130
+ThrowNullRef6:                                    ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %143
+ThrowNullRef8:                                    ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %145
+ThrowNullRef10:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %102
+ThrowNullRef12:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %105
+ThrowNullRef14:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %76
+ThrowNullRef16:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %79
+ThrowNullRef18:                                   ; preds = %79
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %50
+ThrowNullRef20:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %53
+ThrowNullRef22:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %24
+ThrowNullRef24:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %27
+ThrowNullRef26:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2503,15 +2585,15 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2519,16 +2601,16 @@ entry:
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
   store i32 %8, i32* %loc0
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
   %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
   store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
@@ -2546,16 +2628,16 @@ entry:
 
 ; <label>:23                                      ; preds = %64
   %24 = load i16*, i16** %loc3
-  %NullCheck12 = icmp ne i16* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i16* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
   store i32 %27, i32* %loc5
   %28 = load i16*, i16** %loc4
-  %NullCheck14 = icmp ne i16* %28, null
-  br i1 %NullCheck14, label %29, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %28, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = load i16, i16* %28, align 8
@@ -2620,15 +2702,15 @@ entry:
 
 ; <label>:67                                      ; preds = %64
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
-  br i1 %NullCheck8, label %69, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %68, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %69
 
 ; <label>:69                                      ; preds = %67
   %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
   %71 = load i32, i32 addrspace(1)* %70
   %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
-  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %73
 
 ; <label>:73                                      ; preds = %69
   %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
@@ -2645,31 +2727,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %67
+ThrowNullRef8:                                    ; preds = %67
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %69
+ThrowNullRef10:                                   ; preds = %69
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2710,14 +2792,14 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
   %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
@@ -2730,14 +2812,14 @@ entry:
 
 ; <label>:11                                      ; preds = %4
   %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
   %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
@@ -2749,14 +2831,14 @@ entry:
 
 ; <label>:22                                      ; preds = %16
   %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
   %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
-  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
-  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
@@ -2804,23 +2886,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2836,7 +2918,280 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[loadElem]
+Successfully read RuntimeType.IsAssignableFrom
+
+define i8 @RuntimeType.IsAssignableFrom(%System.RuntimeType addrspace(1)* %param0, %System.Type addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.RuntimeType addrspace(1)*
+  %arg1 = alloca %System.Type addrspace(1)*
+  %loc0 = alloca %System.RuntimeType addrspace(1)*
+  %loc1 = alloca %"System.Type[]" addrspace(1)*
+  %loc2 = alloca i32
+  store %System.RuntimeType addrspace(1)* %param0, %System.RuntimeType addrspace(1)** %this
+  store %System.Type addrspace(1)* %param1, %System.Type addrspace(1)** %arg1
+  %0 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %1 = icmp ne %System.Type addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i8 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %5 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %6 = bitcast %System.Type addrspace(1)* %4 to %System.Object addrspace(1)*
+  %7 = bitcast %System.RuntimeType addrspace(1)* %5 to %System.Object addrspace(1)*
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %6, %System.Object addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %3
+  ret i8 1
+
+; <label>:12                                      ; preds = %3
+  %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 152
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 32
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
+  %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
+  %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
+  store %System.RuntimeType addrspace(1)* %25, %System.RuntimeType addrspace(1)** %loc0
+  %26 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %27 = icmp eq %System.RuntimeType addrspace(1)* %26, null
+  br i1 %27, label %34, label %28
+
+; <label>:28                                      ; preds = %15
+  %29 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %30 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)*)*)(%System.RuntimeType addrspace(1)* %29, %System.RuntimeType addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+; <label>:34                                      ; preds = %15
+  %35 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %36 = call %System.Reflection.Emit.TypeBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Reflection.Emit.TypeBuilder addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %35)
+  %37 = icmp eq %System.Reflection.Emit.TypeBuilder addrspace(1)* %36, null
+  br i1 %37, label %139, label %38
+
+; <label>:38                                      ; preds = %34
+  %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %42
+
+; <label>:42                                      ; preds = %38
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 152
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 40
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
+  %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
+  %53 = zext i8 %52 to i32
+  %54 = icmp eq i32 %53, 0
+  br i1 %54, label %56, label %55
+
+; <label>:55                                      ; preds = %42
+  ret i8 1
+
+; <label>:56                                      ; preds = %42
+  %57 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %58 = bitcast %System.RuntimeType addrspace(1)* %57 to %System.Type addrspace(1)*
+  %59 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %58)
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %64 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.Type addrspace(1)* %63, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = bitcast %System.RuntimeType addrspace(1)* %64 to %System.Type addrspace(1)*
+  %67 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %63, %System.Type addrspace(1)* %66)
+  %68 = zext i8 %67 to i32
+  %69 = trunc i32 %68 to i8
+  ret i8 %69
+
+; <label>:70                                      ; preds = %56
+  %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
+  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %73
+
+; <label>:73                                      ; preds = %70
+  %74 = load i64, i64 addrspace(1)* %72
+  %75 = add i64 %74, 128
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = add i64 %77, 0
+  %79 = inttoptr i64 %78 to i64*
+  %80 = load i64, i64* %79
+  %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
+  %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
+  %83 = call i8 %82(%System.Type addrspace(1)* %81)
+  %84 = zext i8 %83 to i32
+  %85 = icmp eq i32 %84, 0
+  br i1 %85, label %139, label %86
+
+; <label>:86                                      ; preds = %73
+  %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
+  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %89
+
+; <label>:89                                      ; preds = %86
+  %90 = load i64, i64 addrspace(1)* %88
+  %91 = add i64 %90, 128
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = add i64 %93, 24
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
+  %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
+  %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
+  store %"System.Type[]" addrspace(1)* %99, %"System.Type[]" addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %129
+
+; <label>:100                                     ; preds = %132
+  %101 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %102 = load i32, i32* %loc2
+  %NullCheck11 = icmp eq %"System.Type[]" addrspace(1)* %101, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %103
+
+; <label>:103                                     ; preds = %100
+  %104 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 1
+  %105 = load i32, i32 addrspace(1)* %104
+  %106 = zext i32 %105 to i64
+  %107 = zext i32 %102 to i64
+  %BoundsCheck = icmp uge i64 %107, %106
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %108
+
+; <label>:108                                     ; preds = %103
+  %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
+  %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
+  %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
+  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %113
+
+; <label>:113                                     ; preds = %108
+  %114 = load i64, i64 addrspace(1)* %112
+  %115 = add i64 %114, 152
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = add i64 %117, 56
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
+  %123 = zext i8 %122 to i32
+  %124 = icmp ne i32 %123, 0
+  br i1 %124, label %126, label %125
+
+; <label>:125                                     ; preds = %113
+  ret i8 0
+
+; <label>:126                                     ; preds = %113
+  %127 = load i32, i32* %loc2
+  %128 = add i32 %127, 1
+  store i32 %128, i32* %loc2
+  br label %129
+
+; <label>:129                                     ; preds = %89, %126
+  %130 = load i32, i32* %loc2
+  %131 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %NullCheck9 = icmp eq %"System.Type[]" addrspace(1)* %131, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %132
+
+; <label>:132                                     ; preds = %129
+  %133 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %131, i32 0, i32 1
+  %134 = load i32, i32 addrspace(1)* %133
+  %135 = zext i32 %134 to i64
+  %136 = trunc i64 %135 to i32
+  %137 = icmp slt i32 %130, %136
+  br i1 %137, label %100, label %138
+
+; <label>:138                                     ; preds = %132
+  ret i8 1
+
+; <label>:139                                     ; preds = %34, %73
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %129
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %103
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -2893,7 +3248,7 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElem]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -2904,8 +3259,8 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -2997,8 +3352,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
@@ -3059,8 +3414,8 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -3087,8 +3442,8 @@ entry:
 
 ; <label>:17                                      ; preds = %5, %11
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
@@ -3097,8 +3452,8 @@ entry:
 
 ; <label>:22                                      ; preds = %1, %11
   %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
@@ -3109,11 +3464,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %17
+ThrowNullRef2:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %22
+ThrowNullRef4:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3167,15 +3522,15 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
   %15 = load i32, i32 addrspace(1)* %14
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
@@ -3198,7 +3553,7 @@ ThrowNullRef:                                     ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef2:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3232,8 +3587,8 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
@@ -3312,8 +3667,8 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -3327,8 +3682,8 @@ entry:
 ; <label>:5                                       ; preds = %43
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %7 = load i32, i32* %loc1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck6, label %8, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
@@ -3366,8 +3721,8 @@ entry:
 ; <label>:32                                      ; preds = %21, %25
   %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
   %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
-  br i1 %NullCheck8, label %35, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = trunc i32 %34 to i16
@@ -3380,8 +3735,8 @@ entry:
 ; <label>:40                                      ; preds = %1, %35
   %41 = load i32, i32* %loc1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
-  br i1 %NullCheck2, label %43, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %42, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
@@ -3392,8 +3747,8 @@ entry:
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
   %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
-  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
   %51 = load i64, i64 addrspace(1)* %49
@@ -3412,19 +3767,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %40
+ThrowNullRef2:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %47
+ThrowNullRef4:                                    ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %5
+ThrowNullRef6:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %32
+ThrowNullRef8:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3467,8 +3822,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
@@ -3492,11 +3847,391 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(i16* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store i16* %param0, i16** %arg0
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load i32, i32* %arg3
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %42, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %37, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg2
+  %13 = load i32, i32* %arg3
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %37, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %24 = load i32, i32* %arg2
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load i16*, i16** %arg0
+  %35 = load i32, i32* %arg3
+  %36 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %36, i16* %34, i32 %35)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:37                                      ; preds = %5, %16
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %39)
+  %41 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41, %System.String addrspace(1)* %38, %System.String addrspace(1)* %40)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41) #0
+  unreachable
+
+; <label>:42                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
-Failed to read StringBuilder.ToString[loadElemA]
+Successfully read StringBuilder.ToString
+
+define %System.String addrspace(1)* @StringBuilder.ToString(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i16*
+  %loc3 = alloca %"System.Char[]" addrspace(1)*
+  %loc4 = alloca i32
+  %loc5 = alloca i32
+  %loc6 = alloca i16 addrspace(1)*
+  %loc7 = alloca %System.String addrspace(1)*
+  %loc8 = alloca %"System.Char[]" addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %0)
+  %2 = icmp ne i32 %1, 0
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %4
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %6)
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %7)
+  store %System.String addrspace(1)* %8, %System.String addrspace(1)** %loc0
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.Text.StringBuilder addrspace(1)* %9, %System.Text.StringBuilder addrspace(1)** %loc1
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  store %System.String addrspace(1)* %10, %System.String addrspace(1)** %loc7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc7
+  %12 = ptrtoint %System.String addrspace(1)* %11 to i64
+  %13 = icmp eq i64 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %5
+  %15 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %16 = sext i32 %15 to i64
+  %17 = add i64 %12, %16
+  br label %18
+
+; <label>:18                                      ; preds = %5, %14
+  %19 = phi i64 [ %12, %5 ], [ %17, %14 ]
+  %20 = inttoptr i64 %19 to i16*
+  store i16* %20, i16** %loc2
+  br label %21
+
+; <label>:21                                      ; preds = %98, %18
+  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %22, null
+  br i1 %NullCheck, label %ThrowNullRef, label %23
+
+; <label>:23                                      ; preds = %21
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 3
+  %25 = load i32, i32 addrspace(1)* %24, align 8
+  %26 = icmp sle i32 %25, 0
+  br i1 %26, label %96, label %27
+
+; <label>:27                                      ; preds = %23
+  %28 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %28, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %29
+
+; <label>:29                                      ; preds = %27
+  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %28, i32 0, i32 1
+  %31 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %30, align 8
+  store %"System.Char[]" addrspace(1)* %31, %"System.Char[]" addrspace(1)** %loc3
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %33
+
+; <label>:33                                      ; preds = %29
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  store i32 %35, i32* %loc4
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  %39 = load i32, i32 addrspace(1)* %38, align 8
+  store i32 %39, i32* %loc5
+  %40 = load i32, i32* %loc5
+  %41 = load i32, i32* %loc4
+  %42 = add i32 %40, %41
+  %43 = zext i32 %42 to i64
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %45
+
+; <label>:45                                      ; preds = %37
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = sext i32 %47 to i64
+  %49 = icmp sgt i64 %43, %48
+  br i1 %49, label %91, label %50
+
+; <label>:50                                      ; preds = %45
+  %51 = load i32, i32* %loc5
+  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %52, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %53
+
+; <label>:53                                      ; preds = %50
+  %54 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %52, i32 0, i32 1
+  %55 = load i32, i32 addrspace(1)* %54
+  %56 = zext i32 %55 to i64
+  %57 = trunc i64 %56 to i32
+  %58 = icmp ugt i32 %51, %57
+  br i1 %58, label %91, label %59
+
+; <label>:59                                      ; preds = %53
+  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  store %"System.Char[]" addrspace(1)* %60, %"System.Char[]" addrspace(1)** %loc8
+  %61 = icmp eq %"System.Char[]" addrspace(1)* %60, null
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %63, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %64
+
+; <label>:64                                      ; preds = %62
+  %65 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %63, i32 0, i32 1
+  %66 = load i32, i32 addrspace(1)* %65
+  %67 = zext i32 %66 to i64
+  %68 = trunc i64 %67 to i32
+  %69 = icmp ne i32 %68, 0
+  br i1 %69, label %71, label %70
+
+; <label>:70                                      ; preds = %59, %64
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:71                                      ; preds = %64
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %73
+
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %BoundsCheck = icmp uge i64 0, %76
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %77
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %78, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:79                                      ; preds = %70, %77
+  %80 = load i16*, i16** %loc2
+  %81 = load i32, i32* %loc4
+  %82 = sext i32 %81 to i64
+  %83 = mul i64 %82, 2
+  %84 = bitcast i16* %80 to i8*
+  %85 = getelementptr inbounds i8, i8* %84, i64 %83
+  %86 = load i16 addrspace(1)*, i16 addrspace(1)** %loc6
+  %87 = ptrtoint i16 addrspace(1)* %86 to i64
+  %88 = load i32, i32* %loc5
+  %89 = bitcast i8* %85 to i16*
+  %90 = inttoptr i64 %87 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %89, i16* %90, i32 %88)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %96
+
+; <label>:91                                      ; preds = %45, %53
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %94 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %93)
+  %95 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95, %System.String addrspace(1)* %92, %System.String addrspace(1)* %94)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95) #0
+  unreachable
+
+; <label>:96                                      ; preds = %23, %79
+  %97 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %97, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %98
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %97, i32 0, i32 2
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  store %System.Text.StringBuilder addrspace(1)* %100, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %102 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %102, label %21, label %103
+
+; <label>:103                                     ; preds = %98
+  store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc7
+  %104 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  ret %System.String addrspace(1)* %104
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method StringBuilder::get_Length using LLILCJit
+Successfully read StringBuilder.get_Length
+
+define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
+Successfully read RuntimeHelpers.get_OffsetToStringData
+
+define i32 @RuntimeHelpers.get_OffsetToStringData() {
+entry:
+  ret i32 12
+}
+
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
 Successfully read CultureData.CreateCultureData
 
@@ -3514,23 +4249,23 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
   store i8 %4, i8 addrspace(1)* %6
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
@@ -3549,11 +4284,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3566,50 +4301,50 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
   store i32 -1, i32 addrspace(1)* %2
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
   store i32 -1, i32 addrspace(1)* %8
   %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
   store i32 -1, i32 addrspace(1)* %14
   %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
   store i32 -1, i32 addrspace(1)* %17
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
@@ -3623,27 +4358,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3675,7 +4410,136 @@ Failed to read Dictionary`2.Insert[non-const derefAddress]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
 Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
-Failed to read HashHelpers.GetPrime[loadElem]
+Successfully read HashHelpers.GetPrime
+
+define i32 @HashHelpers.GetPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %6, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5, %System.String addrspace(1)* %4)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5) #0
+  unreachable
+
+; <label>:6                                       ; preds = %entry
+  store i32 0, i32* %loc0
+  br label %29
+
+; <label>:7                                       ; preds = %35
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 1296
+  %10 = addrspacecast i8 addrspace(1)* %9 to %"System.Int32[]" addrspace(1)**
+  %11 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %10
+  %12 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Int32[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = zext i32 %15 to i64
+  %17 = zext i32 %12 to i64
+  %BoundsCheck = icmp uge i64 %17, %16
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 3, i32 %12
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  store i32 %20, i32* %loc1
+  %21 = load i32, i32* %loc1
+  %22 = load i32, i32* %arg0
+  %23 = icmp slt i32 %21, %22
+  br i1 %23, label %26, label %24
+
+; <label>:24                                      ; preds = %18
+  %25 = load i32, i32* %loc1
+  ret i32 %25
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %loc0
+  %28 = add i32 %27, 1
+  store i32 %28, i32* %loc0
+  br label %29
+
+; <label>:29                                      ; preds = %6, %26
+  %30 = load i32, i32* %loc0
+  %31 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %32 = getelementptr inbounds i8, i8 addrspace(1)* %31, i64 1296
+  %33 = addrspacecast i8 addrspace(1)* %32 to %"System.Int32[]" addrspace(1)**
+  %34 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %33
+  %NullCheck = icmp eq %"System.Int32[]" addrspace(1)* %34, null
+  br i1 %NullCheck, label %ThrowNullRef, label %35
+
+; <label>:35                                      ; preds = %29
+  %36 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %34, i32 0, i32 1
+  %37 = load i32, i32 addrspace(1)* %36
+  %38 = zext i32 %37 to i64
+  %39 = trunc i64 %38 to i32
+  %40 = icmp slt i32 %30, %39
+  br i1 %40, label %7, label %41
+
+; <label>:41                                      ; preds = %35
+  %42 = load i32, i32* %arg0
+  %43 = or i32 %42, 1
+  store i32 %43, i32* %loc2
+  br label %59
+
+; <label>:44                                      ; preds = %59
+  %45 = load i32, i32* %loc2
+  %46 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %45)
+  %47 = zext i8 %46 to i32
+  %48 = icmp eq i32 %47, 0
+  br i1 %48, label %56, label %49
+
+; <label>:49                                      ; preds = %44
+  %50 = load i32, i32* %loc2
+  %51 = sub i32 %50, 1
+  %52 = srem i32 %51, 101
+  %53 = icmp eq i32 %52, 0
+  br i1 %53, label %56, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = load i32, i32* %loc2
+  ret i32 %55
+
+; <label>:56                                      ; preds = %44, %49
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %57, 2
+  store i32 %58, i32* %loc2
+  br label %59
+
+; <label>:59                                      ; preds = %41, %56
+  %60 = load i32, i32* %loc2
+  %61 = icmp slt i32 %60, 2147483647
+  br i1 %61, label %44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load i32, i32* %arg0
+  ret i32 %63
+
+ThrowNullRef:                                     ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
 Successfully read GenericEqualityComparer`1.GetHashCode
 
@@ -3694,14 +4558,14 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
   %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load i64, i64 addrspace(1)* %7
@@ -3720,7 +4584,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3750,8 +4614,8 @@ entry:
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
@@ -3796,8 +4660,8 @@ entry:
   %35 = bitcast i16* %34 to i8*
   %36 = getelementptr inbounds i8, i8* %35, i64 2
   %37 = bitcast i8* %36 to i16*
-  %NullCheck4 = icmp ne i16* %37, null
-  br i1 %NullCheck4, label %38, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %37, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %38
 
 ; <label>:38                                      ; preds = %27
   %39 = load i16, i16* %37, align 8
@@ -3824,8 +4688,8 @@ entry:
 
 ; <label>:54                                      ; preds = %22, %43
   %55 = load i16*, i16** %loc4
-  %NullCheck2 = icmp ne i16* %55, null
-  br i1 %NullCheck2, label %56, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i16* %55, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %56
 
 ; <label>:56                                      ; preds = %54
   %57 = load i16, i16* %55, align 8
@@ -3850,11 +4714,11 @@ ThrowNullRef:                                     ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %54
+ThrowNullRef2:                                    ; preds = %54
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %27
+ThrowNullRef4:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3871,8 +4735,8 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -3907,8 +4771,8 @@ entry:
 
 ; <label>:26                                      ; preds = %19
   %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
-  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %28
 
 ; <label>:28                                      ; preds = %26
   %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
@@ -3920,7 +4784,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3972,8 +4836,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
@@ -3984,26 +4848,26 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
-  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
@@ -4014,8 +4878,8 @@ entry:
 ; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
@@ -4024,8 +4888,8 @@ entry:
 
 ; <label>:25                                      ; preds = %1, %16, %23
   %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
-  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
@@ -4036,27 +4900,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %20
+ThrowNullRef10:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4069,8 +4933,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -4081,8 +4945,8 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
@@ -4091,8 +4955,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1, %8
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
@@ -4103,11 +4967,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4128,24 +4992,24 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   store i32 %3, i32* %loc0
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
   %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
   store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck4, label %9, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
@@ -4164,15 +5028,15 @@ entry:
 ; <label>:18                                      ; preds = %70
   %19 = load i16*, i16** %loc3
   %20 = bitcast i16* %19 to i64*
-  %NullCheck10 = icmp ne i64* %20, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %20, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = load i64, i64* %20, align 8
   %23 = load i16*, i16** %loc4
   %24 = bitcast i16* %23 to i64*
-  %NullCheck12 = icmp ne i64* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = load i64, i64* %24, align 8
@@ -4188,8 +5052,8 @@ entry:
   %31 = bitcast i16* %30 to i8*
   %32 = getelementptr inbounds i8, i8* %31, i64 8
   %33 = bitcast i8* %32 to i64*
-  %NullCheck14 = icmp ne i64* %33, null
-  br i1 %NullCheck14, label %34, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = load i64, i64* %33, align 8
@@ -4197,8 +5061,8 @@ entry:
   %37 = bitcast i16* %36 to i8*
   %38 = getelementptr inbounds i8, i8* %37, i64 8
   %39 = bitcast i8* %38 to i64*
-  %NullCheck16 = icmp ne i64* %39, null
-  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %40
 
 ; <label>:40                                      ; preds = %34
   %41 = load i64, i64* %39, align 8
@@ -4214,8 +5078,8 @@ entry:
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %NullCheck18 = icmp ne i64* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = load i64, i64* %48, align 8
@@ -4223,8 +5087,8 @@ entry:
   %52 = bitcast i16* %51 to i8*
   %53 = getelementptr inbounds i8, i8* %52, i64 16
   %54 = bitcast i8* %53 to i64*
-  %NullCheck20 = icmp ne i64* %54, null
-  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64* %54, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %55
 
 ; <label>:55                                      ; preds = %49
   %56 = load i64, i64* %54, align 8
@@ -4262,15 +5126,15 @@ entry:
 ; <label>:74                                      ; preds = %95
   %75 = load i16*, i16** %loc3
   %76 = bitcast i16* %75 to i32*
-  %NullCheck6 = icmp ne i32* %76, null
-  br i1 %NullCheck6, label %77, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32* %76, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %77
 
 ; <label>:77                                      ; preds = %74
   %78 = load i32, i32* %76, align 8
   %79 = load i16*, i16** %loc4
   %80 = bitcast i16* %79 to i32*
-  %NullCheck8 = icmp ne i32* %80, null
-  br i1 %NullCheck8, label %81, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i32* %80, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %81
 
 ; <label>:81                                      ; preds = %77
   %82 = load i32, i32* %80, align 8
@@ -4318,43 +5182,43 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %74
+ThrowNullRef6:                                    ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %77
+ThrowNullRef8:                                    ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %29
+ThrowNullRef14:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %34
+ThrowNullRef16:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4376,8 +5240,8 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load i64, i64 addrspace(1)* %4
@@ -4389,8 +5253,8 @@ entry:
   %12 = load i64, i64* %11
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %5
   %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
@@ -4399,8 +5263,8 @@ entry:
   %18 = load i8, i8* %arg2
   %19 = zext i8 %18 to i32
   %20 = trunc i32 %19 to i8
-  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %15
   %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
@@ -4411,11 +5275,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4442,8 +5306,8 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
@@ -4466,16 +5330,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
   %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = load i64, i64 addrspace(1)* %19
@@ -4500,8 +5364,8 @@ entry:
 ; <label>:35                                      ; preds = %30
   %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
@@ -4514,8 +5378,8 @@ entry:
 
 ; <label>:42                                      ; preds = %1, %38
   %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
-  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
@@ -4526,19 +5390,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %35
+ThrowNullRef2:                                    ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %42
+ThrowNullRef8:                                    ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4551,14 +5415,14 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
@@ -4570,7 +5434,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4583,8 +5447,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
@@ -4613,51 +5477,51 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
   %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
   %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
   %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
   %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
-  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
   store i64 %21, i64 addrspace(1)* %23
   %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %25 = load i64, i64* %loc0
-  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
@@ -4668,27 +5532,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %22
+ThrowNullRef12:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4701,8 +5565,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
@@ -4713,19 +5577,19 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
@@ -4734,8 +5598,8 @@ entry:
 
 ; <label>:15                                      ; preds = %1, %13
   %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
@@ -4746,19 +5610,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %15
+ThrowNullRef8:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4771,8 +5635,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -4831,8 +5695,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
@@ -4882,8 +5746,8 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
-  br i1 %NullCheck, label %17, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %ThrowNullRef, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
@@ -4894,15 +5758,15 @@ entry:
 
 ; <label>:22                                      ; preds = %17
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
-  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
   %26 = load i32, i32 addrspace(1)* %25
   %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
-  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %27, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
@@ -4925,8 +5789,8 @@ entry:
 ; <label>:40                                      ; preds = %17
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
-  br i1 %NullCheck6, label %43, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %41, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
@@ -4938,34 +5802,17 @@ ThrowNullRef:                                     ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %24
+ThrowNullRef4:                                    ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %40
+ThrowNullRef6:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
-}
-
-INFO:  jitting method Object::ReferenceEquals using LLILCJit
-Successfully read Object.ReferenceEquals
-
-define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
-entry:
-  %arg0 = alloca %System.Object addrspace(1)*
-  %arg1 = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
-  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
-  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = icmp eq %System.Object addrspace(1)* %0, %1
-  %3 = sext i1 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
 }
 
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
@@ -4978,21 +5825,21 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
   %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
-  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
@@ -5007,28 +5854,28 @@ entry:
 ; <label>:13                                      ; preds = %8, %12
   %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
   %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
   %21 = load i32, i32 addrspace(1)* %20, align 8
   %22 = add i32 %21, 1
-  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
   store i32 %22, i32 addrspace(1)* %24
   %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
@@ -5039,27 +5886,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5077,7 +5924,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::Setup using LLILCJit
-Failed to read AppDomain.Setup[loadElem]
+Failed to read AppDomain.Setup[unbox]
 INFO:  jitting method Thread::GetDomain using LLILCJit
 Successfully read Thread.GetDomain
 
@@ -5108,8 +5955,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
@@ -5122,14 +5969,14 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
   %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
@@ -5141,11 +5988,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5173,8 +6020,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -5189,7 +6036,328 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
 Failed to read KeyCollection.System.Collections.Generic.IEnumerable<TKey>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Successfully read Enumerator.MoveNext
+
+define i8 @Enumerator.MoveNext(%"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.RuntimeTypeHandle* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*
+  %"$TypeArg" = alloca %System.RuntimeTypeHandle*
+  store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
+  %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 8
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %76, label %12
+
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
+  br label %76
+
+; <label>:13                                      ; preds = %85
+  %14 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck19 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %15
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, i32 0, i32 0
+  %17 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %16, align 8
+  %NullCheck21 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, i32 0, i32 2
+  %20 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %19, align 8
+  %21 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck23 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %22
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, i32 0, i32 2
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %NullCheck25 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 3, i32 %24
+  %NullCheck27 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %32
+
+; <label>:32                                      ; preds = %30
+  %33 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, i32 0, i32 2
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = icmp slt i32 %34, 0
+  br i1 %35, label %68, label %36
+
+; <label>:36                                      ; preds = %32
+  %37 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %38 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck29 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %39
+
+; <label>:39                                      ; preds = %36
+  %40 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, i32 0, i32 0
+  %41 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %40, align 8
+  %NullCheck31 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, i32 0, i32 2
+  %44 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %43, align 8
+  %45 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck33 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, i32 0, i32 2
+  %48 = load i32, i32 addrspace(1)* %47, align 8
+  %NullCheck35 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %49
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = zext i32 %51 to i64
+  %53 = zext i32 %48 to i64
+  %BoundsCheck37 = icmp uge i64 %53, %52
+  br i1 %BoundsCheck37, label %ThrowIndexOutOfRange38, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 3, i32 %48
+  %NullCheck39 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %56
+
+; <label>:56                                      ; preds = %54
+  %57 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, i32 0, i32 0
+  %58 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck41 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %59
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %60, %System.__Canon addrspace(1)* %58)
+  %61 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck43 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  %64 = load i32, i32 addrspace(1)* %63, align 8
+  %65 = add i32 %64, 1
+  %NullCheck45 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  store i32 %65, i32 addrspace(1)* %67
+  ret i8 1
+
+; <label>:68                                      ; preds = %32
+  %69 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck47 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %73 = add i32 %72, 1
+  %NullCheck49 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %74
+
+; <label>:74                                      ; preds = %70
+  %75 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  store i32 %73, i32 addrspace(1)* %75
+  br label %76
+
+; <label>:76                                      ; preds = %8, %12, %74
+  %77 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %78
+
+; <label>:78                                      ; preds = %76
+  %79 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, i32 0, i32 2
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck7 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %82
+
+; <label>:82                                      ; preds = %78
+  %83 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, i32 0, i32 0
+  %84 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %83, align 8
+  %NullCheck9 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %85
+
+; <label>:85                                      ; preds = %82
+  %86 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, i32 0, i32 7
+  %87 = load i32, i32 addrspace(1)* %86, align 8
+  %88 = icmp ult i32 %80, %87
+  br i1 %88, label %13, label %89
+
+; <label>:89                                      ; preds = %85
+  %90 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %91 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck11 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %92
+
+; <label>:92                                      ; preds = %89
+  %93 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, i32 0, i32 0
+  %94 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck13 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %95
+
+; <label>:95                                      ; preds = %92
+  %96 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, i32 0, i32 7
+  %97 = load i32, i32 addrspace(1)* %96, align 8
+  %98 = add i32 %97, 1
+  %NullCheck15 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %99
+
+; <label>:99                                      ; preds = %95
+  %100 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, i32 0, i32 2
+  store i32 %98, i32 addrspace(1)* %100
+  %101 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck17 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %102
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %103, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %92
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef22:                                   ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef24:                                   ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef26:                                   ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef28:                                   ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef30:                                   ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef32:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef34:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef36:                                   ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange38:                           ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef40:                                   ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef42:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef44:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef46:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef48:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef50:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -5200,8 +6368,8 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -5232,9 +6400,9 @@ Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
 Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
-Failed to read String.MakeSeparatorList[loadElemA]
+Failed to read String.MakeSeparatorList[storeElem]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
-Failed to read String.InternalSplitKeepEmptyEntries[loadElem]
+Failed to read String.InternalSplitKeepEmptyEntries[storeElem]
 INFO:  jitting method Path::IsRelative using LLILCJit
 Successfully read Path.IsRelative
 
@@ -5243,8 +6411,8 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -5254,8 +6422,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
@@ -5271,8 +6439,8 @@ entry:
 
 ; <label>:17                                      ; preds = %7
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
@@ -5288,8 +6456,8 @@ entry:
 
 ; <label>:29                                      ; preds = %19
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %31
 
 ; <label>:31                                      ; preds = %29
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
@@ -5300,8 +6468,8 @@ entry:
 
 ; <label>:36                                      ; preds = %31
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
-  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %37, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
@@ -5312,8 +6480,8 @@ entry:
 
 ; <label>:43                                      ; preds = %31, %38
   %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
-  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %45
 
 ; <label>:45                                      ; preds = %43
   %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
@@ -5324,8 +6492,8 @@ entry:
 
 ; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %50
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
@@ -5336,8 +6504,8 @@ entry:
 
 ; <label>:57                                      ; preds = %1, %7, %19, %45, %52
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
-  br i1 %NullCheck14, label %59, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %59
 
 ; <label>:59                                      ; preds = %57
   %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
@@ -5347,8 +6515,8 @@ entry:
 
 ; <label>:63                                      ; preds = %59
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
@@ -5359,8 +6527,8 @@ entry:
 
 ; <label>:70                                      ; preds = %65
   %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
-  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.String addrspace(1)* %71, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %72
 
 ; <label>:72                                      ; preds = %70
   %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
@@ -5379,39 +6547,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %17
+ThrowNullRef4:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %29
+ThrowNullRef6:                                    ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %36
+ThrowNullRef8:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %43
+ThrowNullRef10:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %50
+ThrowNullRef12:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %57
+ThrowNullRef14:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %63
+ThrowNullRef16:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %70
+ThrowNullRef18:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5419,7 +6587,293 @@ ThrowNullRef17:                                   ; preds = %70
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
-Failed to read String.TrimHelper[loadElem]
+Successfully read String.TrimHelper
+
+define %System.String addrspace(1)* @String.TrimHelper(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i16
+  %loc4 = alloca i32
+  %loc5 = alloca i16
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = sub i32 %3, 1
+  store i32 %4, i32* %loc0
+  store i32 0, i32* %loc1
+  %5 = load i32, i32* %arg2
+  %6 = icmp eq i32 %5, 1
+  br i1 %6, label %62, label %7
+
+; <label>:7                                       ; preds = %1
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:8                                       ; preds = %58
+  store i32 0, i32* %loc2
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load i32, i32* %loc1
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2, i32 %10
+  %13 = load i16, i16 addrspace(1)* %12
+  %14 = zext i16 %13 to i32
+  %15 = trunc i32 %14 to i16
+  store i16 %15, i16* %loc3
+  store i32 0, i32* %loc2
+  br label %34
+
+; <label>:16                                      ; preds = %37
+  %17 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %18 = load i32, i32* %loc2
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %17, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %19
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = zext i32 %18 to i64
+  %BoundsCheck = icmp uge i64 %23, %22
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %24
+
+; <label>:24                                      ; preds = %19
+  %25 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 3, i32 %18
+  %26 = load i16, i16 addrspace(1)* %25, align 8
+  %27 = zext i16 %26 to i32
+  %28 = load i16, i16* %loc3
+  %29 = zext i16 %28 to i32
+  %30 = icmp eq i32 %27, %29
+  br i1 %30, label %43, label %31
+
+; <label>:31                                      ; preds = %24
+  %32 = load i32, i32* %loc2
+  %33 = add i32 %32, 1
+  store i32 %33, i32* %loc2
+  br label %34
+
+; <label>:34                                      ; preds = %11, %31
+  %35 = load i32, i32* %loc2
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = icmp slt i32 %35, %41
+  br i1 %42, label %16, label %43
+
+; <label>:43                                      ; preds = %24, %37
+  %44 = load i32, i32* %loc2
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %45, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp eq i32 %44, %50
+  br i1 %51, label %62, label %52
+
+; <label>:52                                      ; preds = %46
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %7, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %57, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %58
+
+; <label>:58                                      ; preds = %55
+  %59 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %60 = load i32, i32 addrspace(1)* %59
+  %61 = icmp slt i32 %56, %60
+  br i1 %61, label %8, label %62
+
+; <label>:62                                      ; preds = %1, %46, %58
+  %63 = load i32, i32* %arg2
+  %64 = icmp eq i32 %63, 0
+  br i1 %64, label %122, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %66, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %67
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %66, i32 0, i32 1
+  %69 = load i32, i32 addrspace(1)* %68
+  %70 = sub i32 %69, 1
+  store i32 %70, i32* %loc0
+  br label %118
+
+; <label>:71                                      ; preds = %118
+  store i32 0, i32* %loc4
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %73 = load i32, i32* %loc0
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %74
+
+; <label>:74                                      ; preds = %71
+  %75 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 2, i32 %73
+  %76 = load i16, i16 addrspace(1)* %75
+  %77 = zext i16 %76 to i32
+  %78 = trunc i32 %77 to i16
+  store i16 %78, i16* %loc5
+  store i32 0, i32* %loc4
+  br label %97
+
+; <label>:79                                      ; preds = %100
+  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %81 = load i32, i32* %loc4
+  %NullCheck19 = icmp eq %"System.Char[]" addrspace(1)* %80, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
+
+; <label>:82                                      ; preds = %79
+  %83 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 1
+  %84 = load i32, i32 addrspace(1)* %83
+  %85 = zext i32 %84 to i64
+  %86 = zext i32 %81 to i64
+  %BoundsCheck21 = icmp uge i64 %86, %85
+  br i1 %BoundsCheck21, label %ThrowIndexOutOfRange22, label %87
+
+; <label>:87                                      ; preds = %82
+  %88 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 3, i32 %81
+  %89 = load i16, i16 addrspace(1)* %88, align 8
+  %90 = zext i16 %89 to i32
+  %91 = load i16, i16* %loc5
+  %92 = zext i16 %91 to i32
+  %93 = icmp eq i32 %90, %92
+  br i1 %93, label %106, label %94
+
+; <label>:94                                      ; preds = %87
+  %95 = load i32, i32* %loc4
+  %96 = add i32 %95, 1
+  store i32 %96, i32* %loc4
+  br label %97
+
+; <label>:97                                      ; preds = %74, %94
+  %98 = load i32, i32* %loc4
+  %99 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck15 = icmp eq %"System.Char[]" addrspace(1)* %99, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %100
+
+; <label>:100                                     ; preds = %97
+  %101 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %99, i32 0, i32 1
+  %102 = load i32, i32 addrspace(1)* %101
+  %103 = zext i32 %102 to i64
+  %104 = trunc i64 %103 to i32
+  %105 = icmp slt i32 %98, %104
+  br i1 %105, label %79, label %106
+
+; <label>:106                                     ; preds = %87, %100
+  %107 = load i32, i32* %loc4
+  %108 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck17 = icmp eq %"System.Char[]" addrspace(1)* %108, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %109
+
+; <label>:109                                     ; preds = %106
+  %110 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %108, i32 0, i32 1
+  %111 = load i32, i32 addrspace(1)* %110
+  %112 = zext i32 %111 to i64
+  %113 = trunc i64 %112 to i32
+  %114 = icmp eq i32 %107, %113
+  br i1 %114, label %122, label %115
+
+; <label>:115                                     ; preds = %109
+  %116 = load i32, i32* %loc0
+  %117 = sub i32 %116, 1
+  store i32 %117, i32* %loc0
+  br label %118
+
+; <label>:118                                     ; preds = %67, %115
+  %119 = load i32, i32* %loc0
+  %120 = load i32, i32* %loc1
+  %121 = icmp sge i32 %119, %120
+  br i1 %121, label %71, label %122
+
+; <label>:122                                     ; preds = %62, %109, %118
+  %123 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %124 = load i32, i32* %loc1
+  %125 = load i32, i32* %loc0
+  %126 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %123, i32 %124, i32 %125)
+  ret %System.String addrspace(1)* %126
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %97
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange22:                           ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
 Successfully read String.CreateTrimmedString
 
@@ -5439,8 +6893,8 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
@@ -5535,8 +6989,8 @@ entry:
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i64 2872
   %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
   %8 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %7
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %3
   %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
@@ -5553,8 +7007,8 @@ entry:
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 2864
   %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
   %21 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %20
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
-  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %22
 
 ; <label>:22                                      ; preds = %16
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
@@ -5569,7 +7023,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %16
+ThrowNullRef2:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5586,8 +7040,8 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5613,8 +7067,8 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
@@ -5632,8 +7086,8 @@ entry:
 
 ; <label>:12                                      ; preds = %4
   %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
@@ -5644,8 +7098,8 @@ entry:
 
 ; <label>:19                                      ; preds = %14
   %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %19
   %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
@@ -5660,21 +7114,21 @@ entry:
   %31 = zext i16 %30 to i32
   %32 = bitcast i8* %29 to i16*
   %33 = trunc i32 %31 to i16
-  %NullCheck6 = icmp ne i16* %32, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i16* %32, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %21
   store i16 %33, i16* %32, align 8
   %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %36
 
 ; <label>:36                                      ; preds = %34
   %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
   %38 = load i32, i32 addrspace(1)* %37, align 8
   %39 = add i32 %38, 1
-  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %40
 
 ; <label>:40                                      ; preds = %36
   %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
@@ -5683,16 +7137,16 @@ entry:
 
 ; <label>:42                                      ; preds = %14
   %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
-  br i1 %NullCheck12, label %44, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
   %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
   %47 = load i16, i16* %arg1
   %48 = zext i16 %47 to i32
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = trunc i32 %48 to i16
@@ -5703,31 +7157,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %19
+ThrowNullRef4:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %21
+ThrowNullRef6:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %36
+ThrowNullRef10:                                   ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %42
+ThrowNullRef12:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %44
+ThrowNullRef14:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5740,8 +7194,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -5752,8 +7206,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
@@ -5762,14 +7216,14 @@ entry:
 
 ; <label>:11                                      ; preds = %1
   %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
@@ -5779,15 +7233,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5808,8 +7262,8 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5822,8 +7276,8 @@ entry:
 
 ; <label>:8                                       ; preds = %3
   %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
@@ -5842,15 +7296,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
-  br i1 %NullCheck4, label %22, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
   %24 = load i16*, i16* addrspace(1)* %23, align 8
   %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %25, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
@@ -5859,8 +7313,8 @@ entry:
   store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
@@ -5874,8 +7328,8 @@ entry:
 
 ; <label>:37                                      ; preds = %65
   %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %37
   %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
@@ -5886,16 +7340,16 @@ entry:
   %45 = bitcast i16* %41 to i8*
   %46 = getelementptr inbounds i8, i8* %45, i64 %44
   %47 = bitcast i8* %46 to i16*
-  %NullCheck14 = icmp ne i16* %47, null
-  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %47, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %48
 
 ; <label>:48                                      ; preds = %39
   %49 = load i16, i16* %47, align 8
   %50 = zext i16 %49 to i32
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %52 = load i32, i32* %loc1
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %53
 
 ; <label>:53                                      ; preds = %48
   %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
@@ -5916,8 +7370,8 @@ entry:
 ; <label>:62                                      ; preds = %36, %59
   %63 = load i32, i32* %loc1
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck10, label %65, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %65
 
 ; <label>:65                                      ; preds = %62
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
@@ -5936,15 +7390,15 @@ entry:
 
 ; <label>:74                                      ; preds = %70
   %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
-  br i1 %NullCheck18, label %76, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %76
 
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
   %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
-  br i1 %NullCheck20, label %80, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
   %81 = load i64, i64 addrspace(1)* %79
@@ -5958,8 +7412,8 @@ entry:
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
   %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
-  br i1 %NullCheck22, label %92, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.String addrspace(1)* %90, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %92
 
 ; <label>:92                                      ; preds = %80
   %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
@@ -5969,15 +7423,15 @@ entry:
 
 ; <label>:96                                      ; preds = %70
   %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
-  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %98
 
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
   %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
-  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
   %103 = load i64, i64 addrspace(1)* %101
@@ -5991,8 +7445,8 @@ entry:
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
   %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
-  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.String addrspace(1)* %112, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %114
 
 ; <label>:114                                     ; preds = %102
   %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
@@ -6004,59 +7458,59 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %20
+ThrowNullRef4:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %22
+ThrowNullRef6:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %26
+ThrowNullRef8:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %62
+ThrowNullRef10:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %48
+ThrowNullRef16:                                   ; preds = %48
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %74
+ThrowNullRef18:                                   ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %76
+ThrowNullRef20:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %80
+ThrowNullRef22:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %96
+ThrowNullRef24:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %98
+ThrowNullRef26:                                   ; preds = %98
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %102
+ThrowNullRef28:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6069,15 +7523,15 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
   %3 = load i16*, i16* addrspace(1)* %2, align 8
   %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
@@ -6087,8 +7541,8 @@ entry:
   %10 = bitcast i16* %3 to i8*
   %11 = getelementptr inbounds i8, i8* %10, i64 %9
   %12 = bitcast i8* %11 to i16*
-  %NullCheck4 = icmp ne i16* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %5
   store i16 0, i16* %12, align 8
@@ -6098,11 +7552,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6119,8 +7573,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -6131,8 +7585,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
@@ -6144,15 +7598,15 @@ entry:
 
 ; <label>:14                                      ; preds = %1
   %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
   %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
   %21 = load i64, i64 addrspace(1)* %19
@@ -6171,15 +7625,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %14
+ThrowNullRef4:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %16
+ThrowNullRef6:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6302,14 +7756,6 @@ entry:
   ret %System.String addrspace(1)* %57
 }
 
-INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
-Successfully read RuntimeHelpers.get_OffsetToStringData
-
-define i32 @RuntimeHelpers.get_OffsetToStringData() {
-entry:
-  ret i32 12
-}
-
 INFO:  jitting method String::Equals using LLILCJit
 Successfully read String.Equals
 
@@ -6381,8 +7827,8 @@ entry:
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
-  br i1 %NullCheck24, label %29, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
   %30 = load i64, i64 addrspace(1)* %28
@@ -6397,8 +7843,8 @@ entry:
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
-  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
   %43 = load i64, i64 addrspace(1)* %41
@@ -6418,8 +7864,8 @@ entry:
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
   %59 = load i64, i64 addrspace(1)* %57
@@ -6434,8 +7880,8 @@ entry:
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck22, label %71, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
   %72 = load i64, i64 addrspace(1)* %70
@@ -6455,8 +7901,8 @@ entry:
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
-  br i1 %NullCheck16, label %87, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = load i64, i64 addrspace(1)* %86
@@ -6471,8 +7917,8 @@ entry:
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck18, label %100, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
   %101 = load i64, i64 addrspace(1)* %99
@@ -6492,8 +7938,8 @@ entry:
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
-  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
   %117 = load i64, i64 addrspace(1)* %115
@@ -6508,8 +7954,8 @@ entry:
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
-  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
   %130 = load i64, i64 addrspace(1)* %128
@@ -6528,15 +7974,15 @@ entry:
 
 ; <label>:142                                     ; preds = %22
   %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
-  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %143, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %144
 
 ; <label>:144                                     ; preds = %142
   %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
   %146 = load i32, i32 addrspace(1)* %145
   %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
-  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %147, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %148
 
 ; <label>:148                                     ; preds = %144
   %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
@@ -6557,15 +8003,15 @@ entry:
 
 ; <label>:159                                     ; preds = %22
   %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
-  br i1 %NullCheck, label %161, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %ThrowNullRef, label %161
 
 ; <label>:161                                     ; preds = %159
   %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
   %163 = load i32, i32 addrspace(1)* %162
   %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
-  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %164, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %165
 
 ; <label>:165                                     ; preds = %161
   %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
@@ -6578,8 +8024,8 @@ entry:
 
 ; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
-  br i1 %NullCheck4, label %172, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %171, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %172
 
 ; <label>:172                                     ; preds = %170
   %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
@@ -6589,8 +8035,8 @@ entry:
 
 ; <label>:176                                     ; preds = %172
   %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
-  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %177, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %178
 
 ; <label>:178                                     ; preds = %176
   %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
@@ -6629,55 +8075,55 @@ ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %161
+ThrowNullRef2:                                    ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %170
+ThrowNullRef4:                                    ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %176
+ThrowNullRef6:                                    ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %142
+ThrowNullRef8:                                    ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %144
+ThrowNullRef10:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %113
+ThrowNullRef12:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %116
+ThrowNullRef14:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %84
+ThrowNullRef16:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %87
+ThrowNullRef18:                                   ; preds = %87
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %55
+ThrowNullRef20:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %58
+ThrowNullRef22:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %26
+ThrowNullRef24:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %29
+ThrowNullRef26:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,8 +8161,8 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck, label %14, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %ThrowNullRef, label %14
 
 ; <label>:14                                      ; preds = %8
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
@@ -6760,8 +8206,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
@@ -6770,14 +8216,14 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32, i32* %loc0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %10
   %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
   %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
@@ -6790,15 +8236,15 @@ entry:
 ; <label>:25                                      ; preds = %19
   %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
-  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
   %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
@@ -6807,8 +8253,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %37 = load i32, i32* %loc0
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %38, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %38
 
 ; <label>:38                                      ; preds = %32
   %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
@@ -6817,14 +8263,14 @@ entry:
 
 ; <label>:40                                      ; preds = %19
   %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %40
   %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
   %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
-  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
-  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
@@ -6832,8 +8278,8 @@ entry:
   %48 = zext i32 %47 to i64
   %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
-  br i1 %NullCheck16, label %51, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %51
 
 ; <label>:51                                      ; preds = %45
   %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
@@ -6847,15 +8293,15 @@ entry:
 ; <label>:57                                      ; preds = %51
   %58 = load i16*, i16** %arg1
   %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
-  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %60
 
 ; <label>:60                                      ; preds = %57
   %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
   %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
-  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %64
 
 ; <label>:64                                      ; preds = %60
   %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
@@ -6864,22 +8310,22 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
   %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
-  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %70
 
 ; <label>:70                                      ; preds = %64
   %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
   %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
-  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
-  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
   %75 = load i32, i32 addrspace(1)* %74
   %76 = zext i32 %75 to i64
   %77 = trunc i64 %76 to i32
-  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
-  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %78
 
 ; <label>:78                                      ; preds = %73
   %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
@@ -6901,8 +8347,8 @@ entry:
   %90 = bitcast i16* %86 to i8*
   %91 = getelementptr inbounds i8, i8* %90, i64 %89
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %93
 
 ; <label>:93                                      ; preds = %80
   %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
@@ -6912,8 +8358,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %99 = load i32, i32* %loc2
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %100
 
 ; <label>:100                                     ; preds = %93
   %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
@@ -6928,63 +8374,63 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %25
+ThrowNullRef6:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %32
+ThrowNullRef10:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %40
+ThrowNullRef12:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %45
+ThrowNullRef16:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %57
+ThrowNullRef18:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %60
+ThrowNullRef20:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %64
+ThrowNullRef22:                                   ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %70
+ThrowNullRef24:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %73
+ThrowNullRef26:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %80
+ThrowNullRef28:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %93
+ThrowNullRef30:                                   ; preds = %93
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7004,8 +8450,8 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
@@ -7033,43 +8479,43 @@ entry:
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %14
   %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
   %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   %28 = load i32, i32 addrspace(1)* %27, align 8
   %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
-  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %30
 
 ; <label>:30                                      ; preds = %26
   %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
   %32 = load i32, i32 addrspace(1)* %31, align 8
   %33 = add i32 %28, %32
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %34
 
 ; <label>:34                                      ; preds = %30
   %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   store i32 %33, i32 addrspace(1)* %35
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
   store i32 0, i32 addrspace(1)* %38
   %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %40
 
 ; <label>:40                                      ; preds = %37
   %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
@@ -7082,8 +8528,8 @@ entry:
 
 ; <label>:47                                      ; preds = %40
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
@@ -7098,8 +8544,8 @@ entry:
   %54 = load i32, i32* %loc0
   %55 = sext i32 %54 to i64
   %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
-  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %57
 
 ; <label>:57                                      ; preds = %52
   %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
@@ -7110,68 +8556,35 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %14
+ThrowNullRef2:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %23
+ThrowNullRef4:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %26
+ThrowNullRef6:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %30
+ThrowNullRef8:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %34
+ThrowNullRef10:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %47
+ThrowNullRef14:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %52
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-}
-
-INFO:  jitting method StringBuilder::get_Length using LLILCJit
-Successfully read StringBuilder.get_Length
-
-define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.StringBuilder addrspace(1)*
-  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
-  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
-
-; <label>:1                                       ; preds = %entry
-  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %3 = load i32, i32 addrspace(1)* %2, align 8
-  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
-
-; <label>:5                                       ; preds = %1
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = add i32 %3, %7
-  ret i32 %8
-
-ThrowNullRef:                                     ; preds = %entry
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef16:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7213,70 +8626,70 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
   %6 = load i32, i32 addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
   store i32 %6, i32 addrspace(1)* %8
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
   %13 = load i32, i32 addrspace(1)* %12, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
   store i32 %13, i32 addrspace(1)* %15
   %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
-  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %18
 
 ; <label>:18                                      ; preds = %14
   %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
   %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
   %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
   %34 = load i32, i32 addrspace(1)* %33, align 8
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
-  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
@@ -7287,39 +8700,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %28
+ThrowNullRef16:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %32
+ThrowNullRef18:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7455,13 +8868,13 @@ entry:
 ; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
@@ -7477,16 +8890,16 @@ entry:
 
 ; <label>:18                                      ; preds = %15
   %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
   store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
   %22 = load i32, i32* %loc0
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %24
 
 ; <label>:24                                      ; preds = %20
   %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
@@ -7498,13 +8911,13 @@ entry:
 ; <label>:28                                      ; preds = %15, %24
   %29 = load i32, i32* %arg1
   %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %31
   %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
@@ -7517,20 +8930,20 @@ entry:
   %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
-  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
   %46 = load i32, i32 addrspace(1)* %45, align 8
   %47 = sub i32 %40, %46
-  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
-  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i32 addrspace(1)* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %48
 
 ; <label>:48                                      ; preds = %44
   store i32 %47, i32 addrspace(1)* %39, align 8
@@ -7538,21 +8951,21 @@ entry:
 
 ; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
-  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %51
 
 ; <label>:51                                      ; preds = %49
   %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %53
 
 ; <label>:53                                      ; preds = %51
   %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
   %55 = load i32, i32 addrspace(1)* %54, align 8
   %56 = load i32, i32* %arg2
   %57 = sub i32 %55, %56
-  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %58
 
 ; <label>:58                                      ; preds = %53
   %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
@@ -7562,13 +8975,13 @@ entry:
 ; <label>:60                                      ; preds = %33, %58
   %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
   %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
-  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %63
 
 ; <label>:63                                      ; preds = %60
   %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
-  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
-  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
@@ -7578,15 +8991,15 @@ entry:
 
 ; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
-  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i32 addrspace(1)* %69, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %70
 
 ; <label>:70                                      ; preds = %68
   %71 = load i32, i32 addrspace(1)* %69, align 8
   store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
-  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
@@ -7596,8 +9009,8 @@ entry:
   store i32 %77, i32* %loc4
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
-  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %80
 
 ; <label>:80                                      ; preds = %73
   %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
@@ -7607,71 +9020,71 @@ entry:
 ; <label>:83                                      ; preds = %80
   store i32 0, i32* %loc3
   %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
-  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
-  br i1 %NullCheck26, label %88, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i32 addrspace(1)* %87, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %88
 
 ; <label>:88                                      ; preds = %85
   %89 = load i32, i32 addrspace(1)* %87, align 8
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
-  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %90
 
 ; <label>:90                                      ; preds = %88
   %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
   store i32 %89, i32 addrspace(1)* %91
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
-  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
-  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %96
 
 ; <label>:96                                      ; preds = %94
   %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
-  br i1 %NullCheck34, label %100, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %100
 
 ; <label>:100                                     ; preds = %96
   %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
-  br i1 %NullCheck36, label %102, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %102
 
 ; <label>:102                                     ; preds = %100
   %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
   %104 = load i32, i32 addrspace(1)* %103, align 8
   %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
-  br i1 %NullCheck38, label %106, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %106
 
 ; <label>:106                                     ; preds = %102
   %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
-  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
-  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %108
 
 ; <label>:108                                     ; preds = %106
   %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
   %110 = load i32, i32 addrspace(1)* %109, align 8
   %111 = add i32 %104, %110
-  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %112
 
 ; <label>:112                                     ; preds = %108
   %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
   store i32 %111, i32 addrspace(1)* %113
   %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
-  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i32 addrspace(1)* %114, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %115
 
 ; <label>:115                                     ; preds = %112
   %116 = load i32, i32 addrspace(1)* %114, align 8
@@ -7681,19 +9094,19 @@ entry:
 ; <label>:118                                     ; preds = %115
   %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
-  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %121
 
 ; <label>:121                                     ; preds = %118
   %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
-  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
-  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %123
 
 ; <label>:123                                     ; preds = %121
   %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
   %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
-  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
-  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %126
 
 ; <label>:126                                     ; preds = %123
   %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
@@ -7705,8 +9118,8 @@ entry:
 
 ; <label>:130                                     ; preds = %80, %115, %126
   %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %132
 
 ; <label>:132                                     ; preds = %130
   %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7715,8 +9128,8 @@ entry:
   %136 = load i32, i32* %loc3
   %137 = sub i32 %135, %136
   %138 = sub i32 %134, %137
-  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %139
 
 ; <label>:139                                     ; preds = %132
   %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7728,16 +9141,16 @@ entry:
 
 ; <label>:144                                     ; preds = %139
   %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
-  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %146
 
 ; <label>:146                                     ; preds = %144
   %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
   %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
   %149 = load i32, i32* %loc2
   %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
-  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %151
 
 ; <label>:151                                     ; preds = %146
   %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
@@ -7754,145 +9167,249 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %18
+ThrowNullRef4:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %31
+ThrowNullRef10:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %44
+ThrowNullRef16:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %68
+ThrowNullRef18:                                   ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %70
+ThrowNullRef20:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %73
+ThrowNullRef22:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %83
+ThrowNullRef24:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %85
+ThrowNullRef26:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %88
+ThrowNullRef28:                                   ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %90
+ThrowNullRef30:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %94
+ThrowNullRef32:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %96
+ThrowNullRef34:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %100
+ThrowNullRef36:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %102
+ThrowNullRef38:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %106
+ThrowNullRef40:                                   ; preds = %106
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %108
+ThrowNullRef42:                                   ; preds = %108
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %112
+ThrowNullRef44:                                   ; preds = %112
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %118
+ThrowNullRef46:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %121
+ThrowNullRef48:                                   ; preds = %121
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %123
+ThrowNullRef50:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %130
+ThrowNullRef52:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %132
+ThrowNullRef54:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %144
+ThrowNullRef56:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %146
+ThrowNullRef58:                                   ; preds = %146
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %60
+ThrowNullRef60:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %63
+ThrowNullRef62:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %49
+ThrowNullRef64:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %51
+ThrowNullRef66:                                   ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %53
+ThrowNullRef68:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(%"System.Char[]" addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %arg0 = alloca %"System.Char[]" addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store %"System.Char[]" addrspace(1)* %param0, %"System.Char[]" addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load i32, i32* %arg4
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %43, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %38, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg1
+  %13 = load i32, i32* %arg4
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %38, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %24 = load i32, i32* %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %35 = load i32, i32* %arg3
+  %36 = load i32, i32* %arg4
+  %37 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %37, %"System.Char[]" addrspace(1)* %34, i32 %35, i32 %36)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:38                                      ; preds = %5, %16
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Successfully read Buffer._Memmove
 
@@ -7914,7 +9431,7 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[loadElem]
+Failed to read AppDomain.SetDataHelper[storeElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -7923,8 +9440,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
@@ -7934,8 +9451,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
@@ -7947,15 +9464,15 @@ entry:
   %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
   %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
@@ -7966,15 +9483,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7992,7 +9509,79 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
-Failed to read Dictionary`2.TryGetValue[loadElemA]
+Successfully read Dictionary`2.TryGetValue
+
+define i8 @"Dictionary`2.TryGetValue"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)* addrspace(1)* %param2) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  %arg2 = alloca %System.__Canon addrspace(1)* addrspace(1)*
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  store %System.__Canon addrspace(1)* addrspace(1)* %param2, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  store i32 %2, i32* %loc0
+  %3 = load i32, i32* %loc0
+  %4 = icmp slt i32 %3, 0
+  br i1 %4, label %22, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 2
+  %10 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %9, align 8
+  %11 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = zext i32 %11 to i64
+  %BoundsCheck = icmp uge i64 %16, %15
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 3, i32 %11
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %20, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %6, %System.__Canon addrspace(1)* %21)
+  ret i8 1
+
+; <label>:22                                      ; preds = %entry
+  %23 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %23, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -8058,8 +9647,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
@@ -8091,8 +9680,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
@@ -8171,15 +9760,15 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck, label %19, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %ThrowNullRef, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
   %21 = load i32, i32 addrspace(1)* %20
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
@@ -8202,7 +9791,7 @@ ThrowNullRef:                                     ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %19
+ThrowNullRef2:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8248,8 +9837,8 @@ entry:
   %0 = alloca %System.AppDomainHandle
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %1 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %1, i32 0, i32 15
@@ -8269,8 +9858,8 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
@@ -8286,7 +9875,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -8299,8 +9888,8 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -8327,8 +9916,8 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
@@ -8352,8 +9941,8 @@ entry:
   %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
   store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
@@ -8363,8 +9952,8 @@ entry:
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
@@ -8374,8 +9963,8 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %9
   %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
@@ -8384,8 +9973,8 @@ entry:
 
 ; <label>:18                                      ; preds = %3, %16
   %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
@@ -8397,15 +9986,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %18
+ThrowNullRef6:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8418,8 +10007,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
@@ -8453,15 +10042,15 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
@@ -8473,7 +10062,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8481,7 +10070,7 @@ ThrowNullRef1:                                    ; preds = %1
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
 Failed to read Dictionary`2.System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
@@ -8506,8 +10095,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
@@ -8524,8 +10113,8 @@ entry:
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -8544,7 +10133,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8577,8 +10166,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = load i64, i64* %arg2
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = trunc i32 %3 to i8
@@ -8634,46 +10223,46 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
   %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
-  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
-  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
-  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
@@ -8684,27 +10273,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %20
+ThrowNullRef12:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8717,8 +10306,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -8756,22 +10345,22 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
   %9 = load i64, i64 addrspace(1)* %8, align 8
   %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
   %13 = load i64, i64 addrspace(1)* %12, align 8
   %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %11
   %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
@@ -8788,11 +10377,11 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8882,8 +10471,8 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
@@ -8900,8 +10489,8 @@ entry:
 ; <label>:8                                       ; preds = %1
   %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
   %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
@@ -8911,15 +10500,15 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
   %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
   %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
-  br i1 %NullCheck6, label %21, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
@@ -8946,15 +10535,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8992,15 +10581,15 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
   store i8 %3, i8 addrspace(1)* %5
   %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
@@ -9011,7 +10600,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9027,8 +10616,8 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -9041,8 +10630,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
@@ -9058,7 +10647,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9080,8 +10669,8 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
@@ -9096,8 +10685,8 @@ entry:
 ; <label>:12                                      ; preds = %6
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
@@ -9112,8 +10701,8 @@ entry:
 ; <label>:21                                      ; preds = %15
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
@@ -9128,8 +10717,8 @@ entry:
 ; <label>:30                                      ; preds = %24
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %31, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
@@ -9144,8 +10733,8 @@ entry:
 ; <label>:39                                      ; preds = %33
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
-  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %40, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %42
 
 ; <label>:42                                      ; preds = %39
   %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
@@ -9164,19 +10753,19 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %21
+ThrowNullRef4:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %30
+ThrowNullRef6:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %39
+ThrowNullRef8:                                    ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9243,8 +10832,8 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
@@ -9264,57 +10853,57 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
   store i8 0, i8 addrspace(1)* %2
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
   store i8 0, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
   store i8 0, i8 addrspace(1)* %17
   %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
   store i8 0, i8 addrspace(1)* %20
   %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
-  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
@@ -9325,31 +10914,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %19
+ThrowNullRef14:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9367,8 +10956,8 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
@@ -9380,8 +10969,8 @@ entry:
 
 ; <label>:9                                       ; preds = %4
   %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %9
   %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
@@ -9395,7 +10984,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef2:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9420,8 +11009,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
@@ -9512,8 +11101,8 @@ entry:
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
@@ -9524,8 +11113,8 @@ entry:
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = load i64, i64 addrspace(1)* %12
@@ -9537,8 +11126,8 @@ entry:
   %20 = load i64, i64* %19
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
-  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %13
   %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
@@ -9555,8 +11144,8 @@ entry:
 ; <label>:30                                      ; preds = %25
   %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %32 = load i32, i32* %arg2
-  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
-  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
@@ -9570,15 +11159,15 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %30
+ThrowNullRef2:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9622,87 +11211,87 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
   %10 = load i8, i8 addrspace(1)* %9, align 8
   %11 = zext i8 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %8
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
   store i8 %12, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
   %19 = load i8, i8 addrspace(1)* %18, align 8
   %20 = zext i8 %19 to i32
   %21 = trunc i32 %20 to i8
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
   store i8 %21, i8 addrspace(1)* %23
   %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
   %28 = load i8, i8 addrspace(1)* %27, align 8
   %29 = zext i8 %28 to i32
   %30 = trunc i32 %29 to i8
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
-  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %31
 
 ; <label>:31                                      ; preds = %26
   %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
   store i8 %30, i8 addrspace(1)* %32
   %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
-  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
-  br i1 %NullCheck14, label %40, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %40
 
 ; <label>:40                                      ; preds = %35
   %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
   store i8 %39, i8 addrspace(1)* %41
   %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
-  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %44
 
 ; <label>:44                                      ; preds = %40
   %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
   %46 = load i8, i8 addrspace(1)* %45, align 8
   %47 = zext i8 %46 to i32
   %48 = trunc i32 %47 to i8
-  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
   store i8 %48, i8 addrspace(1)* %50
   %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
-  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
@@ -9713,29 +11302,29 @@ entry:
 ; <label>:56                                      ; preds = %52
   %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
-  br i1 %NullCheck22, label %59, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
   %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
   %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
-  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
-  br i1 %NullCheck24, label %63, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
   %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
-  br i1 %NullCheck26, label %66, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
   %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
-  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
-  br i1 %NullCheck28, label %69, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %69
 
 ; <label>:69                                      ; preds = %66
   %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
@@ -9744,15 +11333,15 @@ entry:
 
 ; <label>:71                                      ; preds = %105
   %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
-  br i1 %NullCheck34, label %73, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %73
 
 ; <label>:73                                      ; preds = %71
   %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
   %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
   %76 = load i32, i32* %loc0
-  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
-  br i1 %NullCheck36, label %77, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
@@ -9766,8 +11355,8 @@ entry:
 
 ; <label>:83                                      ; preds = %77
   %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
-  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
@@ -9775,14 +11364,14 @@ entry:
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
   %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
-  br i1 %NullCheck40, label %91, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
 ; <label>:91                                      ; preds = %85
   %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
   %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
-  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck42, label %94, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %94
 
 ; <label>:94                                      ; preds = %91
   %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
@@ -9798,14 +11387,14 @@ entry:
 ; <label>:99                                      ; preds = %69, %96
   %100 = load i32, i32* %loc0
   %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
-  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %102
 
 ; <label>:102                                     ; preds = %99
   %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
   %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
-  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
-  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
@@ -9819,87 +11408,87 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %26
+ThrowNullRef10:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %31
+ThrowNullRef12:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %35
+ThrowNullRef14:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %40
+ThrowNullRef16:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %56
+ThrowNullRef22:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %59
+ThrowNullRef24:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %63
+ThrowNullRef26:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %66
+ThrowNullRef28:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %102
+ThrowNullRef32:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %71
+ThrowNullRef34:                                   ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %73
+ThrowNullRef36:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %83
+ThrowNullRef38:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %85
+ThrowNullRef40:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %91
+ThrowNullRef42:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9943,15 +11532,15 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
   %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
@@ -9961,28 +11550,28 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
   %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %12
   %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
   %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
   %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
-  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
@@ -9993,23 +11582,23 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %12
+ThrowNullRef6:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10031,15 +11620,15 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
   %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = load i64, i64 addrspace(1)* %7
@@ -10077,13 +11666,13 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[loadElem]
+Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -10111,8 +11700,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -10752,8 +12341,8 @@ entry:
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load i32, i32* %arg0
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -10887,8 +12476,8 @@ entry:
   store i64 %param0, i64* %arg0
   store i64 %param1, i64* %arg1
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
@@ -10896,8 +12485,8 @@ entry:
   %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
   %5 = load i16*, i16* addrspace(1)* %4, align 8
   %6 = addrspacecast i64* %arg1 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = bitcast i64 addrspace(1)* %6 to i8 addrspace(1)*
@@ -10913,7 +12502,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10947,8 +12536,8 @@ entry:
   %1 = load i32, i32* %arg1
   %2 = sext i32 %1 to i64
   %3 = inttoptr i64 %2 to i16*
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -11001,8 +12590,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, i32)*)(%System.IO.ConsoleStream addrspace(1)* %2, i32 %1)
   %3 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %4 = load i64, i64* %arg1
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
@@ -11013,8 +12602,8 @@ entry:
   %10 = icmp eq i32 %9, 3
   %11 = sext i1 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %5
   %14 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, i32 0, i32 5
@@ -11025,7 +12614,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11048,8 +12637,8 @@ entry:
   %5 = icmp eq i32 %4, 1
   %6 = sext i1 %5 to i32
   %7 = trunc i32 %6 to i8
-  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %2, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.ConsoleStream addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
@@ -11060,8 +12649,8 @@ entry:
   %13 = icmp eq i32 %12, 2
   %14 = sext i1 %13 to i32
   %15 = trunc i32 %14 to i8
-  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %10, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.ConsoleStream addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %8
   %17 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %10, i32 0, i32 4
@@ -11072,7 +12661,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11111,8 +12700,8 @@ entry:
   %arg0 = alloca i64
   store i64 %param0, i64* %arg0
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
@@ -11147,8 +12736,8 @@ entry:
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
   %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = load i64, i64 addrspace(1)* %7
@@ -11252,7 +12841,127 @@ entry:
 INFO:  jitting method Encoding::GetEncoding using LLILCJit
 Failed to read Encoding.GetEncoding[convertToHelperArgumentType]
 INFO:  jitting method EncodingProvider::GetEncodingFromProvider using LLILCJit
-Failed to read EncodingProvider.GetEncodingFromProvider[loadElem]
+Successfully read EncodingProvider.GetEncodingFromProvider
+
+define %System.Text.Encoding addrspace(1)* @EncodingProvider.GetEncodingFromProvider(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca %"System.Text.EncodingProvider[]" addrspace(1)*
+  %loc1 = alloca %System.Text.EncodingProvider addrspace(1)*
+  %loc2 = alloca %System.Text.Encoding addrspace(1)*
+  %loc3 = alloca %System.Text.Encoding addrspace(1)*
+  %loc4 = alloca %"System.Text.EncodingProvider[]" addrspace(1)*
+  %loc5 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1059)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2392
+  %2 = addrspacecast i8 addrspace(1)* %1 to %"System.Text.EncodingProvider[]" addrspace(1)**
+  %3 = load volatile %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %2
+  %4 = icmp ne %"System.Text.EncodingProvider[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %entry
+  ret %System.Text.Encoding addrspace(1)* null
+
+; <label>:6                                       ; preds = %entry
+  %7 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1059)
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i64 2392
+  %9 = addrspacecast i8 addrspace(1)* %8 to %"System.Text.EncodingProvider[]" addrspace(1)**
+  %10 = load volatile %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %9
+  store %"System.Text.EncodingProvider[]" addrspace(1)* %10, %"System.Text.EncodingProvider[]" addrspace(1)** %loc0
+  %11 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc0
+  store %"System.Text.EncodingProvider[]" addrspace(1)* %11, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  store i32 0, i32* %loc5
+  br label %43
+
+; <label>:12                                      ; preds = %46
+  %13 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  %14 = load i32, i32* %loc5
+  %NullCheck1 = icmp eq %"System.Text.EncodingProvider[]" addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %13, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = zext i32 %17 to i64
+  %19 = zext i32 %14 to i64
+  %BoundsCheck = icmp uge i64 %19, %18
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %20
+
+; <label>:20                                      ; preds = %15
+  %21 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %13, i32 0, i32 3, i32 %14
+  %22 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)* addrspace(1)* %21, align 8
+  store %System.Text.EncodingProvider addrspace(1)* %22, %System.Text.EncodingProvider addrspace(1)** %loc1
+  %23 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)** %loc1
+  %24 = load i32, i32* %arg0
+  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i64 addrspace(1)*
+  %NullCheck3 = icmp eq i64 addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
+
+; <label>:26                                      ; preds = %20
+  %27 = load i64, i64 addrspace(1)* %25
+  %28 = add i64 %27, 64
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 40
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Text.Encoding addrspace(1)* (%System.Text.EncodingProvider addrspace(1)*, i32)*
+  %35 = call %System.Text.Encoding addrspace(1)* %34(%System.Text.EncodingProvider addrspace(1)* %23, i32 %24)
+  store %System.Text.Encoding addrspace(1)* %35, %System.Text.Encoding addrspace(1)** %loc2
+  %36 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc2
+  %37 = icmp eq %System.Text.Encoding addrspace(1)* %36, null
+  br i1 %37, label %40, label %38
+
+; <label>:38                                      ; preds = %26
+  %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc2
+  store %System.Text.Encoding addrspace(1)* %39, %System.Text.Encoding addrspace(1)** %loc3
+  br label %53
+
+; <label>:40                                      ; preds = %26
+  %41 = load i32, i32* %loc5
+  %42 = add i32 %41, 1
+  store i32 %42, i32* %loc5
+  br label %43
+
+; <label>:43                                      ; preds = %6, %40
+  %44 = load i32, i32* %loc5
+  %45 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  %NullCheck = icmp eq %"System.Text.EncodingProvider[]" addrspace(1)* %45, null
+  br i1 %NullCheck, label %ThrowNullRef, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp slt i32 %44, %50
+  br i1 %51, label %12, label %52
+
+; <label>:52                                      ; preds = %46
+  ret %System.Text.Encoding addrspace(1)* null
+
+; <label>:53                                      ; preds = %38
+  %54 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc3
+  ret %System.Text.Encoding addrspace(1)* %54
+
+ThrowNullRef:                                     ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method EncodingProvider::.cctor using LLILCJit
 Successfully read EncodingProvider..cctor
 
@@ -11271,7 +12980,7 @@ Failed to read Encoding.get_InternalSyncObject[Call HasTypeArg]
 INFO:  jitting method Hashtable::.ctor using LLILCJit
 Failed to read Hashtable..ctor[Volatile store]
 INFO:  jitting method Hashtable::get_Item using LLILCJit
-Failed to read Hashtable.get_Item[loadElemA]
+Failed to read Hashtable.get_Item[loadNonPrimitiveObj]
 INFO:  jitting method Hashtable::InitHash using LLILCJit
 Successfully read Hashtable.InitHash
 
@@ -11291,8 +13000,8 @@ entry:
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -11308,15 +13017,15 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
   %15 = load i32, i32* %loc0
-  %NullCheck2 = icmp ne i32 addrspace(1)* %14, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i32 addrspace(1)* %14, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %3
   store i32 %15, i32 addrspace(1)* %14, align 8
   %17 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %18 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %NullCheck4 = icmp ne i32 addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i32 addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = load i32, i32 addrspace(1)* %18, align 8
@@ -11325,8 +13034,8 @@ entry:
   %23 = sub i32 %22, 1
   %24 = urem i32 %21, %23
   %25 = add i32 1, %24
-  %NullCheck6 = icmp ne i32 addrspace(1)* %17, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32 addrspace(1)* %17, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %19
   store i32 %25, i32 addrspace(1)* %17, align 8
@@ -11337,15 +13046,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %19
+ThrowNullRef6:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11360,8 +13069,8 @@ entry:
   store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
   store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %NullCheck = icmp ne %System.Collections.Hashtable addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Collections.Hashtable addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
@@ -11371,16 +13080,16 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Collections.Hashtable addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Collections.Hashtable addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
   %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck4 = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %9, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
   %13 = inttoptr i64 %11 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
@@ -11390,8 +13099,8 @@ entry:
 ; <label>:15                                      ; preds = %1
   %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -11409,15 +13118,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11431,8 +13140,8 @@ entry:
   store %System.Int32 addrspace(1)* %param0, %System.Int32 addrspace(1)** %this
   %0 = load %System.Int32 addrspace(1)*, %System.Int32 addrspace(1)** %this
   %1 = bitcast %System.Int32 addrspace(1)* %0 to i32 addrspace(1)*
-  %NullCheck = icmp ne i32 addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq i32 addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load i32, i32 addrspace(1)* %1, align 8
@@ -11508,8 +13217,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.UTF8Encoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
@@ -11518,15 +13227,15 @@ entry:
   %9 = load i8, i8* %arg2
   %10 = zext i8 %9 to i32
   %11 = trunc i32 %10 to i8
-  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %8, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %6
   %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %8, i32 0, i32 8
   store i8 %11, i8 addrspace(1)* %13
   %14 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %14, i32 0, i32 8
@@ -11538,8 +13247,8 @@ entry:
 ; <label>:20                                      ; preds = %15
   %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %22, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %22, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = load i64, i64 addrspace(1)* %22
@@ -11561,15 +13270,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %12
+ThrowNullRef4:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11584,8 +13293,8 @@ entry:
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
@@ -11607,16 +13316,16 @@ entry:
 ; <label>:10                                      ; preds = %1
   %11 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
   %12 = load i32, i32* %arg1
-  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %11, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.Encoding addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
   store i32 %12, i32 addrspace(1)* %14
   %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
   %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = load i64, i64 addrspace(1)* %16
@@ -11634,11 +13343,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11651,8 +13360,8 @@ entry:
   %this = alloca %System.Text.UTF8Encoding addrspace(1)*
   store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
   %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.UTF8Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
@@ -11664,16 +13373,16 @@ entry:
 ; <label>:6                                       ; preds = %1
   %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %8 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %10, %System.Text.EncoderFallback addrspace(1)* %8)
   %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %12 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
-  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %11, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %11, i32 0, i32 3
@@ -11686,8 +13395,8 @@ entry:
   %18 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %18, %System.String addrspace(1)* %17)
   %19 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %18 to %System.Text.EncoderFallback addrspace(1)*
-  %NullCheck6 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %16, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %16, i32 0, i32 2
@@ -11697,8 +13406,8 @@ entry:
   %24 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %24, %System.String addrspace(1)* %23)
   %25 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %24 to %System.Text.DecoderFallback addrspace(1)*
-  %NullCheck8 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %22, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %22, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %20
   %27 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %22, i32 0, i32 3
@@ -11709,19 +13418,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %20
+ThrowNullRef8:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11751,8 +13460,8 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load i32, i32* %arg1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -11770,8 +13479,8 @@ entry:
 ; <label>:15                                      ; preds = %8
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %17 = load i32, i32* %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 %17
@@ -11787,7 +13496,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11839,7 +13548,7 @@ entry:
 }
 
 INFO:  jitting method Hashtable::Insert using LLILCJit
-Failed to read Hashtable.Insert[loadElemA]
+Failed to read Hashtable.Insert[storeElem]
 INFO:  jitting method ConsoleEncoding::.ctor using LLILCJit
 Successfully read ConsoleEncoding..ctor
 
@@ -11854,8 +13563,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %1)
   %2 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
@@ -11891,8 +13600,8 @@ entry:
   %2 = call %System.Text.InternalEncoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalEncoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %1)
   %3 = bitcast %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2 to %System.Text.EncoderFallback addrspace(1)*
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
@@ -11902,8 +13611,8 @@ entry:
   %8 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %7)
   %9 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %8 to %System.Text.DecoderFallback addrspace(1)*
-  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %6, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.Encoding addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %4
   %11 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %6, i32 0, i32 3
@@ -11914,7 +13623,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11933,15 +13642,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* %1)
   %2 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   %6 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, i32 0, i32 1
@@ -11952,7 +13661,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11980,8 +13689,8 @@ entry:
   store %System.Text.InternalDecoderBestFitFallback addrspace(1)* %param0, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
   %0 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
@@ -11991,15 +13700,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %4)
   %5 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %6)
   %9 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, i32 0, i32 1
@@ -12010,11 +13719,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12082,8 +13791,8 @@ entry:
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
   %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = load i64, i64 addrspace(1)* %19
@@ -12147,8 +13856,8 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.ConsoleStream addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
@@ -12179,31 +13888,31 @@ entry:
   store i8 %param4, i8* %arg4
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %3, %System.IO.Stream addrspace(1)* %1)
   %4 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %4, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
   %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %4, i32 0, i32 4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %5)
   %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %6
   %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
   %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
   %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = load i64, i64 addrspace(1)* %13
@@ -12215,8 +13924,8 @@ entry:
   %21 = load i64, i64* %20
   %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %8, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %8, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %14
   %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 5
@@ -12234,24 +13943,24 @@ entry:
   %31 = load i32, i32* %arg3
   %32 = sext i32 %31 to i64
   %33 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %32)
-  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %30, null
-  br i1 %NullCheck10, label %34, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.StreamWriter addrspace(1)* %30, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %35, %"System.Char[]" addrspace(1)* %33)
   %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %37, null
-  br i1 %NullCheck12, label %38, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.StreamWriter addrspace(1)* %37, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %38
 
 ; <label>:38                                      ; preds = %34
   %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
   %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
   %41 = load i32, i32* %arg3
   %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %42, null
-  br i1 %NullCheck14, label %43, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %42, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
   %44 = load i64, i64 addrspace(1)* %42
@@ -12265,30 +13974,30 @@ entry:
   %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
   %53 = sext i32 %52 to i64
   %54 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %53)
-  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
-  br i1 %NullCheck16, label %55, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %55
 
 ; <label>:55                                      ; preds = %43
   %56 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %56, %"System.Byte[]" addrspace(1)* %54)
   %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %58 = load i32, i32* %arg3
-  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %57, null
-  br i1 %NullCheck18, label %59, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.StreamWriter addrspace(1)* %57, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %59
 
 ; <label>:59                                      ; preds = %55
   %60 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 10
   store i32 %58, i32 addrspace(1)* %60
   %61 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %61, null
-  br i1 %NullCheck20, label %62, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.IO.StreamWriter addrspace(1)* %61, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %62
 
 ; <label>:62                                      ; preds = %59
   %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
   %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
   %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
   %67 = load i64, i64 addrspace(1)* %65
@@ -12306,15 +14015,15 @@ entry:
 
 ; <label>:78                                      ; preds = %66
   %79 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %79, null
-  br i1 %NullCheck24, label %80, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.StreamWriter addrspace(1)* %79, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %80
 
 ; <label>:80                                      ; preds = %78
   %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
   %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
   %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %83, null
-  br i1 %NullCheck26, label %84, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %83, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
   %85 = load i64, i64 addrspace(1)* %83
@@ -12331,8 +14040,8 @@ entry:
 
 ; <label>:95                                      ; preds = %84
   %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.IO.StreamWriter addrspace(1)* %96, null
-  br i1 %NullCheck28, label %97, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.IO.StreamWriter addrspace(1)* %96, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %97
 
 ; <label>:97                                      ; preds = %95
   %98 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 12
@@ -12346,8 +14055,8 @@ entry:
   %103 = icmp eq i32 %102, 0
   %104 = sext i1 %103 to i32
   %105 = trunc i32 %104 to i8
-  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %100, null
-  br i1 %NullCheck30, label %106, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.IO.StreamWriter addrspace(1)* %100, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %106
 
 ; <label>:106                                     ; preds = %99
   %107 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %100, i32 0, i32 13
@@ -12358,63 +14067,63 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %6
+ThrowNullRef4:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %29
+ThrowNullRef10:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %34
+ThrowNullRef12:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %38
+ThrowNullRef14:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %43
+ThrowNullRef16:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %55
+ThrowNullRef18:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %59
+ThrowNullRef20:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %62
+ThrowNullRef22:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %78
+ThrowNullRef24:                                   ; preds = %78
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %80
+ThrowNullRef26:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %95
+ThrowNullRef28:                                   ; preds = %95
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12427,15 +14136,15 @@ entry:
   %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = load i64, i64 addrspace(1)* %4
@@ -12453,7 +14162,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12503,35 +14212,35 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
   %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderNLS addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %7 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.EncoderNLS addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Text.Encoding addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.Encoding addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Text.EncoderNLS addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.EncoderNLS addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
   %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck8 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = load i64, i64 addrspace(1)* %16
@@ -12550,19 +14259,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12588,8 +14297,8 @@ entry:
   %this = alloca %System.Text.Encoding addrspace(1)*
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
@@ -12609,15 +14318,15 @@ entry:
   %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
   store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
   %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
   store i32 0, i32 addrspace(1)* %2
   %3 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, i32 0, i32 2
@@ -12627,15 +14336,15 @@ entry:
 
 ; <label>:8                                       ; preds = %4
   %9 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
   %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
   %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = load i64, i64 addrspace(1)* %13
@@ -12656,15 +14365,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12679,16 +14388,16 @@ entry:
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = load i32, i32* %arg1
   %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
   %7 = load i64, i64 addrspace(1)* %5
@@ -12706,7 +14415,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12743,8 +14452,8 @@ entry:
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
   %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
   %16 = load i64, i64 addrspace(1)* %14
@@ -12765,8 +14474,8 @@ entry:
   %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
   %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
   %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %31, null
-  br i1 %NullCheck2, label %32, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = load i64, i64 addrspace(1)* %31
@@ -12809,7 +14518,7 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12822,14 +14531,14 @@ entry:
   %this = alloca %System.Text.EncoderReplacementFallback addrspace(1)*
   store %System.Text.EncoderReplacementFallback addrspace(1)* %param0, %System.Text.EncoderReplacementFallback addrspace(1)** %this
   %0 = load %System.Text.EncoderReplacementFallback addrspace(1)*, %System.Text.EncoderReplacementFallback addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -12840,7 +14549,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12870,8 +14579,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
@@ -12903,8 +14612,8 @@ entry:
   %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
   store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
@@ -12916,8 +14625,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Threading.Tasks.Task addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %7)
@@ -12940,7 +14649,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12959,8 +14668,8 @@ entry:
   store i8 %param1, i8* %arg1
   store i8 %param2, i8* %arg2
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
@@ -12974,8 +14683,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1, %5
   %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 9
@@ -13006,8 +14715,8 @@ entry:
 
 ; <label>:25                                      ; preds = %8, %20
   %26 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %26, null
-  br i1 %NullCheck4, label %27, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %26, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %26, i32 0, i32 12
@@ -13018,22 +14727,22 @@ entry:
 
 ; <label>:32                                      ; preds = %27
   %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %33, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.IO.StreamWriter addrspace(1)* %33, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %32
   %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 12
   store i8 1, i8 addrspace(1)* %35
   %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
-  br i1 %NullCheck8, label %37, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
   %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
   %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck10 = icmp ne i64 addrspace(1)* %40, null
-  br i1 %NullCheck10, label %41, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64 addrspace(1)* %40, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i64, i64 addrspace(1)* %40
@@ -13047,8 +14756,8 @@ entry:
   %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
   store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
   %51 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %NullCheck12 = icmp ne %"System.Byte[]" addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Byte[]" addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %41
   %53 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %51, i32 0, i32 1
@@ -13060,16 +14769,16 @@ entry:
 
 ; <label>:58                                      ; preds = %52
   %59 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %59, null
-  br i1 %NullCheck14, label %60, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.IO.StreamWriter addrspace(1)* %59, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %60
 
 ; <label>:60                                      ; preds = %58
   %61 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %59, i32 0, i32 3
   %62 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
   %64 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %NullCheck16 = icmp ne %"System.Byte[]" addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %"System.Byte[]" addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %60
   %66 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %64, i32 0, i32 1
@@ -13077,8 +14786,8 @@ entry:
   %68 = zext i32 %67 to i64
   %69 = trunc i64 %68 to i32
   %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck18, label %71, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
   %72 = load i64, i64 addrspace(1)* %70
@@ -13094,29 +14803,29 @@ entry:
 
 ; <label>:80                                      ; preds = %27, %52, %71
   %81 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %81, null
-  br i1 %NullCheck20, label %82, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.IO.StreamWriter addrspace(1)* %81, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
 
 ; <label>:82                                      ; preds = %80
   %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %81, i32 0, i32 5
   %84 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %83, align 8
   %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.IO.StreamWriter addrspace(1)* %85, null
-  br i1 %NullCheck22, label %86, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.IO.StreamWriter addrspace(1)* %85, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %86
 
 ; <label>:86                                      ; preds = %82
   %87 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 7
   %88 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %87, align 8
   %89 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %89, null
-  br i1 %NullCheck24, label %90, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.StreamWriter addrspace(1)* %89, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %90
 
 ; <label>:90                                      ; preds = %86
   %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %89, i32 0, i32 9
   %92 = load i32, i32 addrspace(1)* %91, align 8
   %93 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.IO.StreamWriter addrspace(1)* %93, null
-  br i1 %NullCheck26, label %94, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.IO.StreamWriter addrspace(1)* %93, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %93, i32 0, i32 6
@@ -13124,8 +14833,8 @@ entry:
   %97 = load i8, i8* %arg2
   %98 = zext i8 %97 to i32
   %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
-  %NullCheck28 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck28, label %100, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
   %101 = load i64, i64 addrspace(1)* %99
@@ -13140,8 +14849,8 @@ entry:
   %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
   store i32 %110, i32* %loc1
   %111 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %111, null
-  br i1 %NullCheck30, label %112, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.IO.StreamWriter addrspace(1)* %111, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %112
 
 ; <label>:112                                     ; preds = %100
   %113 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %111, i32 0, i32 9
@@ -13152,23 +14861,23 @@ entry:
 
 ; <label>:116                                     ; preds = %112
   %117 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck32 = icmp ne %System.IO.StreamWriter addrspace(1)* %117, null
-  br i1 %NullCheck32, label %118, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.IO.StreamWriter addrspace(1)* %117, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %118
 
 ; <label>:118                                     ; preds = %116
   %119 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %117, i32 0, i32 3
   %120 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %119, align 8
   %121 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.IO.StreamWriter addrspace(1)* %121, null
-  br i1 %NullCheck34, label %122, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.IO.StreamWriter addrspace(1)* %121, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %122
 
 ; <label>:122                                     ; preds = %118
   %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
   %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
   %125 = load i32, i32* %loc1
   %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
-  %NullCheck36 = icmp ne i64 addrspace(1)* %126, null
-  br i1 %NullCheck36, label %127, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64 addrspace(1)* %126, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
   %128 = load i64, i64 addrspace(1)* %126
@@ -13190,15 +14899,15 @@ entry:
 
 ; <label>:140                                     ; preds = %136
   %141 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.IO.StreamWriter addrspace(1)* %141, null
-  br i1 %NullCheck38, label %142, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.IO.StreamWriter addrspace(1)* %141, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %142
 
 ; <label>:142                                     ; preds = %140
   %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
   %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
   %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
-  %NullCheck40 = icmp ne i64 addrspace(1)* %145, null
-  br i1 %NullCheck40, label %146, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i64 addrspace(1)* %145, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
   %147 = load i64, i64 addrspace(1)* %145
@@ -13219,83 +14928,83 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %25
+ThrowNullRef4:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %32
+ThrowNullRef6:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %37
+ThrowNullRef10:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %41
+ThrowNullRef12:                                   ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %58
+ThrowNullRef14:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %60
+ThrowNullRef16:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %65
+ThrowNullRef18:                                   ; preds = %65
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %80
+ThrowNullRef20:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %82
+ThrowNullRef22:                                   ; preds = %82
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %86
+ThrowNullRef24:                                   ; preds = %86
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %90
+ThrowNullRef26:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %94
+ThrowNullRef28:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %100
+ThrowNullRef30:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %116
+ThrowNullRef32:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %118
+ThrowNullRef34:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %122
+ThrowNullRef36:                                   ; preds = %122
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %140
+ThrowNullRef38:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %142
+ThrowNullRef40:                                   ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13362,8 +15071,8 @@ entry:
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %1 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
-  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
@@ -13371,8 +15080,8 @@ entry:
   %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
   %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
   %8 = load i64, i64 addrspace(1)* %6
@@ -13388,8 +15097,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %17, %System.IFormatProvider addrspace(1)* %16)
   %18 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %19 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %18, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.SyncTextWriter addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %7
   %21 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %18, i32 0, i32 4
@@ -13400,11 +15109,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13417,8 +15126,8 @@ entry:
   %this = alloca %System.IO.TextWriter addrspace(1)*
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.TextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
@@ -13428,8 +15137,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.Threading.Thread addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Threading.Thread addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %6)
@@ -13438,8 +15147,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1
   %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.TextWriter addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.TextWriter addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %11, i32 0, i32 2
@@ -13450,11 +15159,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13651,8 +15360,8 @@ entry:
   store i32 %param1, i32* %arg1
   store i8 0, i8* %loc1
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
@@ -13662,16 +15371,16 @@ entry:
   %5 = addrspacecast i8* %loc1 to i8 addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %4, i8 addrspace(1)* %5)
   %6 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.SyncTextWriter addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
   %10 = load i32, i32* %arg1
   %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
   %13 = load i64, i64 addrspace(1)* %11
@@ -13706,11 +15415,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13727,8 +15436,8 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load i32, i32* %arg1
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -13742,8 +15451,8 @@ entry:
   call void %11(%System.IO.TextWriter addrspace(1)* %0, i32 %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
   %15 = load i64, i64 addrspace(1)* %13
@@ -13761,7 +15470,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13779,8 +15488,8 @@ entry:
   %1 = addrspacecast i32* %arg1 to i32 addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -13795,8 +15504,8 @@ entry:
   %14 = bitcast i32 addrspace(1)* %1 to %System.Int32 addrspace(1)*
   %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Int32 addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Int32 addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
   %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
   %18 = load i64, i64 addrspace(1)* %16
@@ -13814,7 +15523,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13830,8 +15539,8 @@ entry:
   store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
   %0 = load %System.Int32 addrspace(1)*, %System.Int32 addrspace(1)** %this
   %1 = bitcast %System.Int32 addrspace(1)* %0 to i32 addrspace(1)*
-  %NullCheck = icmp ne i32 addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq i32 addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load i32, i32 addrspace(1)* %1, align 8
@@ -13856,8 +15565,8 @@ entry:
   %loc0 = alloca %System.Globalization.NumberFormatInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 3
@@ -13867,8 +15576,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
@@ -13878,24 +15587,24 @@ entry:
   store %System.Globalization.NumberFormatInfo addrspace(1)* %10, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
   %11 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %7
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
   %15 = load i8, i8 addrspace(1)* %14, align 8
   %16 = zext i8 %15 to i32
   %17 = trunc i32 %16 to i8
-  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %11, null
-  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %11, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %13
   %19 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %11, i32 0, i32 29
   store i8 %17, i8 addrspace(1)* %19
   %20 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %21 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %20, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %20, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %18
   %23 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %20, i32 0, i32 3
@@ -13904,8 +15613,8 @@ entry:
 
 ; <label>:24                                      ; preds = %1, %22
   %25 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %25, null
-  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %25, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %26
 
 ; <label>:26                                      ; preds = %24
   %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %25, i32 0, i32 3
@@ -13916,23 +15625,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %18
+ThrowNullRef8:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13957,168 +15666,168 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 18
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %8, align 8
-  %NullCheck2 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %5, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %5, i32 0, i32 4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %9)
   %12 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 19
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %15, align 8
-  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %12, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %12, i32 0, i32 5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %16)
   %19 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %20 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %20, null
-  br i1 %NullCheck8, label %21, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %20, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %20, i32 0, i32 23
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  %NullCheck10 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %19, null
-  br i1 %NullCheck10, label %24, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %19, i32 0, i32 7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %25, %System.String addrspace(1)* %23)
   %26 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %27 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %27, i32 0, i32 22
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %29, align 8
-  %NullCheck14 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %26, null
-  br i1 %NullCheck14, label %31, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %26, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %26, i32 0, i32 6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %32, %System.String addrspace(1)* %30)
   %33 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %34 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Globalization.CultureData addrspace(1)* %34, null
-  br i1 %NullCheck16, label %35, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Globalization.CultureData addrspace(1)* %34, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %34, i32 0, i32 51
   %37 = load i32, i32 addrspace(1)* %36, align 8
-  %NullCheck18 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %33, null
-  br i1 %NullCheck18, label %38, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %33, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %33, i32 0, i32 21
   store i32 %37, i32 addrspace(1)* %39
   %40 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %41 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Globalization.CultureData addrspace(1)* %41, null
-  br i1 %NullCheck20, label %42, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Globalization.CultureData addrspace(1)* %41, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %41, i32 0, i32 52
   %44 = load i32, i32 addrspace(1)* %43, align 8
-  %NullCheck22 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %40, null
-  br i1 %NullCheck22, label %45, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %40, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %40, i32 0, i32 25
   store i32 %44, i32 addrspace(1)* %46
   %47 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %48 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.Globalization.CultureData addrspace(1)* %48, null
-  br i1 %NullCheck24, label %49, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Globalization.CultureData addrspace(1)* %48, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %49
 
 ; <label>:49                                      ; preds = %45
   %50 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %48, i32 0, i32 29
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck26 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %47, null
-  br i1 %NullCheck26, label %52, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %47, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %47, i32 0, i32 10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %53, %System.String addrspace(1)* %51)
   %54 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %55 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Globalization.CultureData addrspace(1)* %55, null
-  br i1 %NullCheck28, label %56, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Globalization.CultureData addrspace(1)* %55, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %56
 
 ; <label>:56                                      ; preds = %52
   %57 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %55, i32 0, i32 35
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %57, align 8
-  %NullCheck30 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %54, null
-  br i1 %NullCheck30, label %59, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %54, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %54, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %60, %System.String addrspace(1)* %58)
   %61 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %62 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck32 = icmp ne %System.Globalization.CultureData addrspace(1)* %62, null
-  br i1 %NullCheck32, label %63, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Globalization.CultureData addrspace(1)* %62, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %62, i32 0, i32 34
   %65 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %64, align 8
-  %NullCheck34 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %61, null
-  br i1 %NullCheck34, label %66, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %61, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %61, i32 0, i32 9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %67, %System.String addrspace(1)* %65)
   %68 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %69 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck36 = icmp ne %System.Globalization.CultureData addrspace(1)* %69, null
-  br i1 %NullCheck36, label %70, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Globalization.CultureData addrspace(1)* %69, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %70
 
 ; <label>:70                                      ; preds = %66
   %71 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %69, i32 0, i32 55
   %72 = load i32, i32 addrspace(1)* %71, align 8
-  %NullCheck38 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %68, null
-  br i1 %NullCheck38, label %73, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %68, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %68, i32 0, i32 22
   store i32 %72, i32 addrspace(1)* %74
   %75 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %76 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck40 = icmp ne %System.Globalization.CultureData addrspace(1)* %76, null
-  br i1 %NullCheck40, label %77, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Globalization.CultureData addrspace(1)* %76, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %76, i32 0, i32 57
   %79 = load i32, i32 addrspace(1)* %78, align 8
-  %NullCheck42 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %75, null
-  br i1 %NullCheck42, label %80, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %75, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %80
 
 ; <label>:80                                      ; preds = %77
   %81 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %75, i32 0, i32 24
   store i32 %79, i32 addrspace(1)* %81
   %82 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %83 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck44 = icmp ne %System.Globalization.CultureData addrspace(1)* %83, null
-  br i1 %NullCheck44, label %84, label %ThrowNullRef43
+  %NullCheck43 = icmp eq %System.Globalization.CultureData addrspace(1)* %83, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %84
 
 ; <label>:84                                      ; preds = %80
   %85 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %83, i32 0, i32 56
   %86 = load i32, i32 addrspace(1)* %85, align 8
-  %NullCheck46 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %82, null
-  br i1 %NullCheck46, label %87, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %82, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %82, i32 0, i32 23
@@ -14127,8 +15836,8 @@ entry:
 
 ; <label>:89                                      ; preds = %entry
   %90 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck100 = icmp ne %System.Globalization.CultureData addrspace(1)* %90, null
-  br i1 %NullCheck100, label %91, label %ThrowNullRef99
+  %NullCheck99 = icmp eq %System.Globalization.CultureData addrspace(1)* %90, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %91
 
 ; <label>:91                                      ; preds = %89
   %92 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %90, i32 0, i32 2
@@ -14146,8 +15855,8 @@ entry:
   %102 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %103 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %104 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %103)
-  %NullCheck48 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %102, null
-  br i1 %NullCheck48, label %105, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %102, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %105
 
 ; <label>:105                                     ; preds = %101
   %106 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %102, i32 0, i32 1
@@ -14155,8 +15864,8 @@ entry:
   %107 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %108 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %109 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %108)
-  %NullCheck50 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %107, null
-  br i1 %NullCheck50, label %110, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %107, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %110
 
 ; <label>:110                                     ; preds = %105
   %111 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %107, i32 0, i32 2
@@ -14164,8 +15873,8 @@ entry:
   %112 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %113 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %114 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %113)
-  %NullCheck52 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %112, null
-  br i1 %NullCheck52, label %115, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %112, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %115
 
 ; <label>:115                                     ; preds = %110
   %116 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %112, i32 0, i32 27
@@ -14173,8 +15882,8 @@ entry:
   %117 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %118 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %119 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %118)
-  %NullCheck54 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %117, null
-  br i1 %NullCheck54, label %120, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %117, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %120
 
 ; <label>:120                                     ; preds = %115
   %121 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %117, i32 0, i32 26
@@ -14182,8 +15891,8 @@ entry:
   %122 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %123 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %124 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %123)
-  %NullCheck56 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %122, null
-  br i1 %NullCheck56, label %125, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %122, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %125
 
 ; <label>:125                                     ; preds = %120
   %126 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %122, i32 0, i32 17
@@ -14191,8 +15900,8 @@ entry:
   %127 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %128 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %129 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %128)
-  %NullCheck58 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %127, null
-  br i1 %NullCheck58, label %130, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %127, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %130
 
 ; <label>:130                                     ; preds = %125
   %131 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %127, i32 0, i32 18
@@ -14200,8 +15909,8 @@ entry:
   %132 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %133 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %134 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %133)
-  %NullCheck60 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %132, null
-  br i1 %NullCheck60, label %135, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %132, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %135
 
 ; <label>:135                                     ; preds = %130
   %136 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %132, i32 0, i32 14
@@ -14209,8 +15918,8 @@ entry:
   %137 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %138 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %139 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %138)
-  %NullCheck62 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %137, null
-  br i1 %NullCheck62, label %140, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %137, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %140
 
 ; <label>:140                                     ; preds = %135
   %141 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %137, i32 0, i32 13
@@ -14218,71 +15927,71 @@ entry:
   %142 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %143 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %144 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %143)
-  %NullCheck64 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %142, null
-  br i1 %NullCheck64, label %145, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %142, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %145
 
 ; <label>:145                                     ; preds = %140
   %146 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %142, i32 0, i32 12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %146, %System.String addrspace(1)* %144)
   %147 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %148 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck66 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %148, null
-  br i1 %NullCheck66, label %149, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %148, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %149
 
 ; <label>:149                                     ; preds = %145
   %150 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %148, i32 0, i32 21
   %151 = load i32, i32 addrspace(1)* %150, align 8
-  %NullCheck68 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %147, null
-  br i1 %NullCheck68, label %152, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %147, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %152
 
 ; <label>:152                                     ; preds = %149
   %153 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %147, i32 0, i32 28
   store i32 %151, i32 addrspace(1)* %153
   %154 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %155 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck70 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %155, null
-  br i1 %NullCheck70, label %156, label %ThrowNullRef69
+  %NullCheck69 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %155, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %156
 
 ; <label>:156                                     ; preds = %152
   %157 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %155, i32 0, i32 6
   %158 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %157, align 8
-  %NullCheck72 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %154, null
-  br i1 %NullCheck72, label %159, label %ThrowNullRef71
+  %NullCheck71 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %154, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %159
 
 ; <label>:159                                     ; preds = %156
   %160 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %154, i32 0, i32 15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %160, %System.String addrspace(1)* %158)
   %161 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %162 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck74 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %162, null
-  br i1 %NullCheck74, label %163, label %ThrowNullRef73
+  %NullCheck73 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %162, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %163
 
 ; <label>:163                                     ; preds = %159
   %164 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %162, i32 0, i32 1
   %165 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %164, align 8
-  %NullCheck76 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %161, null
-  br i1 %NullCheck76, label %166, label %ThrowNullRef75
+  %NullCheck75 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %161, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %166
 
 ; <label>:166                                     ; preds = %163
   %167 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %161, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %167, %"System.Int32[]" addrspace(1)* %165)
   %168 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %169 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck78 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %169, null
-  br i1 %NullCheck78, label %170, label %ThrowNullRef77
+  %NullCheck77 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %169, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %170
 
 ; <label>:170                                     ; preds = %166
   %171 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %169, i32 0, i32 7
   %172 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %171, align 8
-  %NullCheck80 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %168, null
-  br i1 %NullCheck80, label %173, label %ThrowNullRef79
+  %NullCheck79 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %168, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %173
 
 ; <label>:173                                     ; preds = %170
   %174 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %168, i32 0, i32 16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %174, %System.String addrspace(1)* %172)
   %175 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck82 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %175, null
-  br i1 %NullCheck82, label %176, label %ThrowNullRef81
+  %NullCheck81 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %175, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %176
 
 ; <label>:176                                     ; preds = %173
   %177 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %175, i32 0, i32 4
@@ -14292,14 +16001,14 @@ entry:
 
 ; <label>:180                                     ; preds = %176
   %181 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck84 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %181, null
-  br i1 %NullCheck84, label %182, label %ThrowNullRef83
+  %NullCheck83 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %181, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %182
 
 ; <label>:182                                     ; preds = %180
   %183 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %181, i32 0, i32 4
   %184 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %183, align 8
-  %NullCheck86 = icmp ne %System.String addrspace(1)* %184, null
-  br i1 %NullCheck86, label %185, label %ThrowNullRef85
+  %NullCheck85 = icmp eq %System.String addrspace(1)* %184, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %185
 
 ; <label>:185                                     ; preds = %182
   %186 = getelementptr inbounds %System.String, %System.String addrspace(1)* %184, i32 0, i32 1
@@ -14310,8 +16019,8 @@ entry:
 ; <label>:189                                     ; preds = %176, %185
   %190 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck98 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %190, null
-  br i1 %NullCheck98, label %192, label %ThrowNullRef97
+  %NullCheck97 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %190, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %192
 
 ; <label>:192                                     ; preds = %189
   %193 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %190, i32 0, i32 4
@@ -14320,8 +16029,8 @@ entry:
 
 ; <label>:194                                     ; preds = %185, %192
   %195 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck88 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %195, null
-  br i1 %NullCheck88, label %196, label %ThrowNullRef87
+  %NullCheck87 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %195, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %196
 
 ; <label>:196                                     ; preds = %194
   %197 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %195, i32 0, i32 9
@@ -14331,14 +16040,14 @@ entry:
 
 ; <label>:200                                     ; preds = %196
   %201 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck90 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %201, null
-  br i1 %NullCheck90, label %202, label %ThrowNullRef89
+  %NullCheck89 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %201, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %202
 
 ; <label>:202                                     ; preds = %200
   %203 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %201, i32 0, i32 9
   %204 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %203, align 8
-  %NullCheck92 = icmp ne %System.String addrspace(1)* %204, null
-  br i1 %NullCheck92, label %205, label %ThrowNullRef91
+  %NullCheck91 = icmp eq %System.String addrspace(1)* %204, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %205
 
 ; <label>:205                                     ; preds = %202
   %206 = getelementptr inbounds %System.String, %System.String addrspace(1)* %204, i32 0, i32 1
@@ -14349,14 +16058,14 @@ entry:
 ; <label>:209                                     ; preds = %196, %205
   %210 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %211 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck94 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %211, null
-  br i1 %NullCheck94, label %212, label %ThrowNullRef93
+  %NullCheck93 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %211, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %212
 
 ; <label>:212                                     ; preds = %209
   %213 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %211, i32 0, i32 6
   %214 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %213, align 8
-  %NullCheck96 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %210, null
-  br i1 %NullCheck96, label %215, label %ThrowNullRef95
+  %NullCheck95 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %210, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %215
 
 ; <label>:215                                     ; preds = %212
   %216 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %210, i32 0, i32 9
@@ -14370,203 +16079,203 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %17
+ThrowNullRef8:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %21
+ThrowNullRef10:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %24
+ThrowNullRef12:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %28
+ThrowNullRef14:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %31
+ThrowNullRef16:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %35
+ThrowNullRef18:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %38
+ThrowNullRef20:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %42
+ThrowNullRef22:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %45
+ThrowNullRef24:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %49
+ThrowNullRef26:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %52
+ThrowNullRef28:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %56
+ThrowNullRef30:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %59
+ThrowNullRef32:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %63
+ThrowNullRef34:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %66
+ThrowNullRef36:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %70
+ThrowNullRef38:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %73
+ThrowNullRef40:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %77
+ThrowNullRef42:                                   ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %80
+ThrowNullRef44:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %84
+ThrowNullRef46:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %101
+ThrowNullRef48:                                   ; preds = %101
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %105
+ThrowNullRef50:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %110
+ThrowNullRef52:                                   ; preds = %110
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %115
+ThrowNullRef54:                                   ; preds = %115
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %120
+ThrowNullRef56:                                   ; preds = %120
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %125
+ThrowNullRef58:                                   ; preds = %125
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %130
+ThrowNullRef60:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %135
+ThrowNullRef62:                                   ; preds = %135
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %140
+ThrowNullRef64:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %145
+ThrowNullRef66:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %149
+ThrowNullRef68:                                   ; preds = %149
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %152
+ThrowNullRef70:                                   ; preds = %152
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %156
+ThrowNullRef72:                                   ; preds = %156
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %159
+ThrowNullRef74:                                   ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %163
+ThrowNullRef76:                                   ; preds = %163
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %166
+ThrowNullRef78:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %170
+ThrowNullRef80:                                   ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %173
+ThrowNullRef82:                                   ; preds = %173
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %180
+ThrowNullRef84:                                   ; preds = %180
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %182
+ThrowNullRef86:                                   ; preds = %182
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %194
+ThrowNullRef88:                                   ; preds = %194
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %200
+ThrowNullRef90:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %202
+ThrowNullRef92:                                   ; preds = %202
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %209
+ThrowNullRef94:                                   ; preds = %209
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %212
+ThrowNullRef96:                                   ; preds = %212
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %189
+ThrowNullRef98:                                   ; preds = %189
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %89
+ThrowNullRef100:                                  ; preds = %89
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14594,8 +16303,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 21
@@ -14608,8 +16317,8 @@ entry:
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 16)
   %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 21
@@ -14618,8 +16327,8 @@ entry:
 
 ; <label>:12                                      ; preds = %1, %10
   %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 21
@@ -14630,11 +16339,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %12
+ThrowNullRef4:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14650,8 +16359,8 @@ entry:
   store i32 %param1, i32* %arg1
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %1 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
@@ -14718,8 +16427,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 33
@@ -14732,8 +16441,8 @@ entry:
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 24)
   %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 33
@@ -14742,8 +16451,8 @@ entry:
 
 ; <label>:12                                      ; preds = %1, %10
   %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 33
@@ -14754,11 +16463,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %12
+ThrowNullRef4:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14771,8 +16480,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 53
@@ -14784,8 +16493,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 116)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 53
@@ -14794,8 +16503,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 53
@@ -14806,11 +16515,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14839,8 +16548,8 @@ entry:
 
 ; <label>:7                                       ; preds = %entry, %4
   %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %7
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 2
@@ -14864,8 +16573,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 54
@@ -14877,8 +16586,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 117)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
@@ -14887,8 +16596,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 54
@@ -14899,11 +16608,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14916,8 +16625,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 27
@@ -14929,8 +16638,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 118)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 27
@@ -14939,8 +16648,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 27
@@ -14951,11 +16660,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14968,8 +16677,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 28
@@ -14981,8 +16690,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 119)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 28
@@ -14991,8 +16700,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 28
@@ -15003,11 +16712,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -15020,8 +16729,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 26
@@ -15033,8 +16742,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 107)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 26
@@ -15043,8 +16752,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 26
@@ -15055,11 +16764,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -15072,8 +16781,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 25
@@ -15085,8 +16794,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 106)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 25
@@ -15095,8 +16804,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 25
@@ -15107,11 +16816,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -15124,8 +16833,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 24
@@ -15137,8 +16846,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 105)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 24
@@ -15147,8 +16856,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 24
@@ -15159,11 +16868,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -15188,8 +16897,8 @@ entry:
   %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %3)
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %2
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -15200,15 +16909,15 @@ entry:
 
 ; <label>:8                                       ; preds = %62
   %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 9
   %12 = load i32, i32 addrspace(1)* %11, align 8
   %13 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.IO.StreamWriter addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %13, i32 0, i32 10
@@ -15223,15 +16932,15 @@ entry:
 
 ; <label>:20                                      ; preds = %14, %18
   %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
   %24 = load i32, i32 addrspace(1)* %23, align 8
   %25 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %25, null
-  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.StreamWriter addrspace(1)* %25, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %25, i32 0, i32 9
@@ -15252,36 +16961,36 @@ entry:
   %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %37 = load i32, i32* %loc1
   %38 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.StreamWriter addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %35
   %40 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %38, i32 0, i32 7
   %41 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %40, align 8
   %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
-  br i1 %NullCheck14, label %43, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %39
   %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 9
   %45 = load i32, i32 addrspace(1)* %44, align 8
   %46 = load i32, i32* %loc2
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %36, null
-  br i1 %NullCheck16, label %47, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %36, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %47
 
 ; <label>:47                                      ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %36, i32 %37, %"System.Char[]" addrspace(1)* %41, i32 %45, i32 %46)
   %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
   %51 = load i32, i32 addrspace(1)* %50, align 8
   %52 = load i32, i32* %loc2
   %53 = add i32 %51, %52
-  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
-  br i1 %NullCheck20, label %54, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %54
 
 ; <label>:54                                      ; preds = %49
   %55 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
@@ -15303,8 +17012,8 @@ entry:
 
 ; <label>:65                                      ; preds = %62
   %66 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %66, null
-  br i1 %NullCheck2, label %67, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %66, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %67
 
 ; <label>:67                                      ; preds = %65
   %68 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %66, i32 0, i32 11
@@ -15325,49 +17034,259 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %65
+ThrowNullRef2:                                    ; preds = %65
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %20
+ThrowNullRef8:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %22
+ThrowNullRef10:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %35
+ThrowNullRef12:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %43
+ThrowNullRef16:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %47
+ThrowNullRef18:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method String::CopyTo using LLILCJit
-Failed to read String.CopyTo[loadElemA]
+Successfully read String.CopyTo
+
+define void @String.CopyTo(%System.String addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  %loc1 = alloca i16 addrspace(1)*
+  %loc2 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %1 = icmp ne %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg4
+  %7 = icmp sge i32 %6, 0
+  br i1 %7, label %13, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  unreachable
+
+; <label>:13                                      ; preds = %5
+  %14 = load i32, i32* %arg1
+  %15 = icmp sge i32 %14, 0
+  br i1 %15, label %21, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %18)
+  %20 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %20, %System.String addrspace(1)* %17, %System.String addrspace(1)* %19)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %20) #0
+  unreachable
+
+; <label>:21                                      ; preds = %13
+  %22 = load i32, i32* %arg4
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck, label %ThrowNullRef, label %24
+
+; <label>:24                                      ; preds = %21
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load i32, i32* %arg1
+  %28 = sub i32 %26, %27
+  %29 = icmp sle i32 %22, %28
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34, %System.String addrspace(1)* %31, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %24
+  %36 = load i32, i32* %arg3
+  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %37, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
+
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
+  %40 = load i32, i32 addrspace(1)* %39
+  %41 = zext i32 %40 to i64
+  %42 = trunc i64 %41 to i32
+  %43 = load i32, i32* %arg4
+  %44 = sub i32 %42, %43
+  %45 = icmp sgt i32 %36, %44
+  br i1 %45, label %49, label %46
+
+; <label>:46                                      ; preds = %38
+  %47 = load i32, i32* %arg3
+  %48 = icmp sge i32 %47, 0
+  br i1 %48, label %54, label %49
+
+; <label>:49                                      ; preds = %38, %46
+  %50 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %52 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %51)
+  %53 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53, %System.String addrspace(1)* %50, %System.String addrspace(1)* %52)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53) #0
+  unreachable
+
+; <label>:54                                      ; preds = %46
+  %55 = load i32, i32* %arg4
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %97, label %57
+
+; <label>:57                                      ; preds = %54
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %59
+
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 2
+  %61 = bitcast [0 x i16] addrspace(1)* %60 to i16 addrspace(1)*
+  store i16 addrspace(1)* %61, i16 addrspace(1)** %loc0
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  store %"System.Char[]" addrspace(1)* %62, %"System.Char[]" addrspace(1)** %loc2
+  %63 = icmp eq %"System.Char[]" addrspace(1)* %62, null
+  br i1 %63, label %72, label %64
+
+; <label>:64                                      ; preds = %59
+  %65 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc2
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %65, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %66
+
+; <label>:66                                      ; preds = %64
+  %67 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %65, i32 0, i32 1
+  %68 = load i32, i32 addrspace(1)* %67
+  %69 = zext i32 %68 to i64
+  %70 = trunc i64 %69 to i32
+  %71 = icmp ne i32 %70, 0
+  br i1 %71, label %73, label %72
+
+; <label>:72                                      ; preds = %59, %66
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  br label %81
+
+; <label>:73                                      ; preds = %66
+  %74 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc2
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %74, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %75
+
+; <label>:75                                      ; preds = %73
+  %76 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %74, i32 0, i32 1
+  %77 = load i32, i32 addrspace(1)* %76
+  %78 = zext i32 %77 to i64
+  %BoundsCheck = icmp uge i64 0, %78
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %79
+
+; <label>:79                                      ; preds = %75
+  %80 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %74, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %80, i16 addrspace(1)** %loc1
+  br label %81
+
+; <label>:81                                      ; preds = %72, %79
+  %82 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %83 = ptrtoint i16 addrspace(1)* %82 to i64
+  %84 = load i32, i32* %arg3
+  %85 = sext i32 %84 to i64
+  %86 = mul i64 %85, 2
+  %87 = add i64 %83, %86
+  %88 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %89 = ptrtoint i16 addrspace(1)* %88 to i64
+  %90 = load i32, i32* %arg1
+  %91 = sext i32 %90 to i64
+  %92 = mul i64 %91, 2
+  %93 = add i64 %89, %92
+  %94 = load i32, i32* %arg4
+  %95 = inttoptr i64 %87 to i16*
+  %96 = inttoptr i64 %93 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %95, i16* %96, i32 %94)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  br label %97
+
+; <label>:97                                      ; preds = %54, %81
+  ret void
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
 Successfully read ConsoleEncoding.GetPreamble
 
@@ -15404,7 +17323,365 @@ entry:
 }
 
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[loadElemA]
+Successfully read EncoderNLS.GetBytes
+
+define i32 @EncoderNLS.GetBytes(%System.Text.EncoderNLS addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3, %"System.Byte[]" addrspace(1)* %param4, i32 %param5, i8 %param6) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %arg4 = alloca %"System.Byte[]" addrspace(1)*
+  %arg5 = alloca i32
+  %arg6 = alloca i8
+  %loc0 = alloca i32
+  %loc1 = alloca i16 addrspace(1)*
+  %loc2 = alloca i8 addrspace(1)*
+  %loc3 = alloca i32
+  %loc4 = alloca %"System.Char[]" addrspace(1)*
+  %loc5 = alloca %"System.Byte[]" addrspace(1)*
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  store %"System.Byte[]" addrspace(1)* %param4, %"System.Byte[]" addrspace(1)** %arg4
+  store i32 %param5, i32* %arg5
+  store i8 %param6, i8* %arg6
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %1 = icmp eq %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %17, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %7 = icmp eq %"System.Char[]" addrspace(1)* %6, null
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %12
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %12
+
+; <label>:12                                      ; preds = %8, %10
+  %13 = phi %System.String addrspace(1)* [ %9, %8 ], [ %11, %10 ]
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %14)
+  %16 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16, %System.String addrspace(1)* %13, %System.String addrspace(1)* %15)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16) #0
+  unreachable
+
+; <label>:17                                      ; preds = %2
+  %18 = load i32, i32* %arg2
+  %19 = icmp slt i32 %18, 0
+  br i1 %19, label %23, label %20
+
+; <label>:20                                      ; preds = %17
+  %21 = load i32, i32* %arg3
+  %22 = icmp sge i32 %21, 0
+  br i1 %22, label %35, label %23
+
+; <label>:23                                      ; preds = %17, %20
+  %24 = load i32, i32* %arg2
+  %25 = icmp slt i32 %24, 0
+  br i1 %25, label %28, label %26
+
+; <label>:26                                      ; preds = %23
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %30
+
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %30
+
+; <label>:30                                      ; preds = %26, %28
+  %31 = phi %System.String addrspace(1)* [ %27, %26 ], [ %29, %28 ]
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34, %System.String addrspace(1)* %31, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %20
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck, label %ThrowNullRef, label %37
+
+; <label>:37                                      ; preds = %35
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = load i32, i32* %arg2
+  %43 = sub i32 %41, %42
+  %44 = load i32, i32* %arg3
+  %45 = icmp sge i32 %43, %44
+  br i1 %45, label %51, label %46
+
+; <label>:46                                      ; preds = %37
+  %47 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %48 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %49 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %48)
+  %50 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %50, %System.String addrspace(1)* %47, %System.String addrspace(1)* %49)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %50) #0
+  unreachable
+
+; <label>:51                                      ; preds = %37
+  %52 = load i32, i32* %arg5
+  %53 = icmp slt i32 %52, 0
+  br i1 %53, label %63, label %54
+
+; <label>:54                                      ; preds = %51
+  %55 = load i32, i32* %arg5
+  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck1 = icmp eq %"System.Byte[]" addrspace(1)* %56, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %57
+
+; <label>:57                                      ; preds = %54
+  %58 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = zext i32 %59 to i64
+  %61 = trunc i64 %60 to i32
+  %62 = icmp sle i32 %55, %61
+  br i1 %62, label %68, label %63
+
+; <label>:63                                      ; preds = %51, %57
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %66 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %65)
+  %67 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %67, %System.String addrspace(1)* %64, %System.String addrspace(1)* %66)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %67) #0
+  unreachable
+
+; <label>:68                                      ; preds = %57
+  %69 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %69, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %69, i32 0, i32 1
+  %72 = load i32, i32 addrspace(1)* %71
+  %73 = zext i32 %72 to i64
+  %74 = trunc i64 %73 to i32
+  %75 = icmp ne i32 %74, 0
+  br i1 %75, label %78, label %76
+
+; <label>:76                                      ; preds = %70
+  %77 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1)
+  store %"System.Char[]" addrspace(1)* %77, %"System.Char[]" addrspace(1)** %arg1
+  br label %78
+
+; <label>:78                                      ; preds = %70, %76
+  %79 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck5 = icmp eq %"System.Byte[]" addrspace(1)* %79, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %80
+
+; <label>:80                                      ; preds = %78
+  %81 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %79, i32 0, i32 1
+  %82 = load i32, i32 addrspace(1)* %81
+  %83 = zext i32 %82 to i64
+  %84 = trunc i64 %83 to i32
+  %85 = load i32, i32* %arg5
+  %86 = sub i32 %84, %85
+  store i32 %86, i32* %loc0
+  %87 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck7 = icmp eq %"System.Byte[]" addrspace(1)* %87, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %88
+
+; <label>:88                                      ; preds = %80
+  %89 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %87, i32 0, i32 1
+  %90 = load i32, i32 addrspace(1)* %89
+  %91 = zext i32 %90 to i64
+  %92 = trunc i64 %91 to i32
+  %93 = icmp ne i32 %92, 0
+  br i1 %93, label %96, label %94
+
+; <label>:94                                      ; preds = %88
+  %95 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1)
+  store %"System.Byte[]" addrspace(1)* %95, %"System.Byte[]" addrspace(1)** %arg4
+  br label %96
+
+; <label>:96                                      ; preds = %88, %94
+  %97 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  store %"System.Char[]" addrspace(1)* %97, %"System.Char[]" addrspace(1)** %loc4
+  %98 = icmp eq %"System.Char[]" addrspace(1)* %97, null
+  br i1 %98, label %107, label %99
+
+; <label>:99                                      ; preds = %96
+  %100 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc4
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %100, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %101
+
+; <label>:101                                     ; preds = %99
+  %102 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %100, i32 0, i32 1
+  %103 = load i32, i32 addrspace(1)* %102
+  %104 = zext i32 %103 to i64
+  %105 = trunc i64 %104 to i32
+  %106 = icmp ne i32 %105, 0
+  br i1 %106, label %108, label %107
+
+; <label>:107                                     ; preds = %96, %101
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  br label %116
+
+; <label>:108                                     ; preds = %101
+  %109 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc4
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %109, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %110
+
+; <label>:110                                     ; preds = %108
+  %111 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %109, i32 0, i32 1
+  %112 = load i32, i32 addrspace(1)* %111
+  %113 = zext i32 %112 to i64
+  %BoundsCheck = icmp uge i64 0, %113
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %114
+
+; <label>:114                                     ; preds = %110
+  %115 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %109, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %115, i16 addrspace(1)** %loc1
+  br label %116
+
+; <label>:116                                     ; preds = %107, %114
+  %117 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  store %"System.Byte[]" addrspace(1)* %117, %"System.Byte[]" addrspace(1)** %loc5
+  %118 = icmp eq %"System.Byte[]" addrspace(1)* %117, null
+  br i1 %118, label %127, label %119
+
+; <label>:119                                     ; preds = %116
+  %120 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc5
+  %NullCheck13 = icmp eq %"System.Byte[]" addrspace(1)* %120, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %121
+
+; <label>:121                                     ; preds = %119
+  %122 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %120, i32 0, i32 1
+  %123 = load i32, i32 addrspace(1)* %122
+  %124 = zext i32 %123 to i64
+  %125 = trunc i64 %124 to i32
+  %126 = icmp ne i32 %125, 0
+  br i1 %126, label %128, label %127
+
+; <label>:127                                     ; preds = %116, %121
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc2
+  br label %136
+
+; <label>:128                                     ; preds = %121
+  %129 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc5
+  %NullCheck15 = icmp eq %"System.Byte[]" addrspace(1)* %129, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %130
+
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %129, i32 0, i32 1
+  %132 = load i32, i32 addrspace(1)* %131
+  %133 = zext i32 %132 to i64
+  %BoundsCheck17 = icmp uge i64 0, %133
+  br i1 %BoundsCheck17, label %ThrowIndexOutOfRange18, label %134
+
+; <label>:134                                     ; preds = %130
+  %135 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %129, i32 0, i32 3, i32 0
+  store i8 addrspace(1)* %135, i8 addrspace(1)** %loc2
+  br label %136
+
+; <label>:136                                     ; preds = %127, %134
+  %137 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %138 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %139 = ptrtoint i16 addrspace(1)* %138 to i64
+  %140 = load i32, i32* %arg2
+  %141 = sext i32 %140 to i64
+  %142 = mul i64 %141, 2
+  %143 = add i64 %139, %142
+  %144 = load i32, i32* %arg3
+  %145 = load i8 addrspace(1)*, i8 addrspace(1)** %loc2
+  %146 = ptrtoint i8 addrspace(1)* %145 to i64
+  %147 = load i32, i32* %arg5
+  %148 = sext i32 %147 to i64
+  %149 = add i64 %146, %148
+  %150 = load i32, i32* %loc0
+  %151 = load i8, i8* %arg6
+  %152 = zext i8 %151 to i32
+  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i64 addrspace(1)*
+  %NullCheck19 = icmp eq i64 addrspace(1)* %153, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %154
+
+; <label>:154                                     ; preds = %136
+  %155 = load i64, i64 addrspace(1)* %153
+  %156 = add i64 %155, 72
+  %157 = inttoptr i64 %156 to i64*
+  %158 = load i64, i64* %157
+  %159 = add i64 %158, 0
+  %160 = inttoptr i64 %159 to i64*
+  %161 = load i64, i64* %160
+  %162 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to %System.Text.Encoder addrspace(1)*
+  %163 = inttoptr i64 %143 to i16*
+  %164 = inttoptr i64 %149 to i8*
+  %165 = trunc i32 %152 to i8
+  %166 = inttoptr i64 %161 to i32 (%System.Text.Encoder addrspace(1)*, i16*, i32, i8*, i32, i8)*
+  %167 = call i32 %166(%System.Text.Encoder addrspace(1)* %162, i16* %163, i32 %144, i8* %164, i32 %150, i8 %165)
+  store i32 %167, i32* %loc3
+  br label %168
+
+; <label>:168                                     ; preds = %154
+  %169 = load i32, i32* %loc3
+  ret i32 %169
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %110
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %119
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange18:                           ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
 Successfully read EncoderNLS.GetBytes
 
@@ -15493,22 +17770,22 @@ entry:
   %40 = load i8, i8* %arg5
   %41 = zext i8 %40 to i32
   %42 = trunc i32 %41 to i8
-  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %39, null
-  br i1 %NullCheck, label %43, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderNLS addrspace(1)* %39, null
+  br i1 %NullCheck, label %ThrowNullRef, label %43
 
 ; <label>:43                                      ; preds = %38
   %44 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
   store i8 %42, i8 addrspace(1)* %44
   %45 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %45, null
-  br i1 %NullCheck2, label %46, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.EncoderNLS addrspace(1)* %45, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %46
 
 ; <label>:46                                      ; preds = %43
   %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %45, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %47
   %48 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.EncoderNLS addrspace(1)* %48, null
-  br i1 %NullCheck4, label %49, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.EncoderNLS addrspace(1)* %48, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %49
 
 ; <label>:49                                      ; preds = %46
   %50 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %48, i32 0, i32 3
@@ -15519,8 +17796,8 @@ entry:
   %55 = load i32, i32* %arg4
   %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck6, label %58, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
   %59 = load i64, i64 addrspace(1)* %57
@@ -15538,15 +17815,15 @@ ThrowNullRef:                                     ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %43
+ThrowNullRef2:                                    ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %46
+ThrowNullRef4:                                    ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %49
+ThrowNullRef6:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -15574,8 +17851,8 @@ entry:
   %4 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0 to %System.IO.ConsoleStream addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*)(%System.IO.ConsoleStream addrspace(1)* %4, %"System.Byte[]" addrspace(1)* %1, i32 %2, i32 %3)
   %5 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
@@ -15660,8 +17937,8 @@ entry:
 
 ; <label>:22                                      ; preds = %8
   %23 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %23, null
-  br i1 %NullCheck, label %24, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Byte[]" addrspace(1)* %23, null
+  br i1 %NullCheck, label %ThrowNullRef, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
@@ -15683,8 +17960,8 @@ entry:
 
 ; <label>:36                                      ; preds = %24
   %37 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %37, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.ConsoleStream addrspace(1)* %37, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %37, i32 0, i32 4
@@ -15705,13 +17982,138 @@ ThrowNullRef:                                     ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %36
+ThrowNullRef2:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
-Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
+Successfully read WindowsConsoleStream.WriteFileNative
+
+define i32 @WindowsConsoleStream.WriteFileNative(i64 %param0, %"System.Byte[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i64
+  %arg1 = alloca %"System.Byte[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i8 addrspace(1)*
+  %loc2 = alloca %"System.Byte[]" addrspace(1)*
+  %loc3 = alloca i32
+  store i64 %param0, i64* %arg0
+  store %"System.Byte[]" addrspace(1)* %param1, %"System.Byte[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Byte[]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = zext i32 %3 to i64
+  %5 = icmp ne i64 %4, 0
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %1
+  ret i32 0
+
+; <label>:7                                       ; preds = %1
+  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  store %"System.Byte[]" addrspace(1)* %8, %"System.Byte[]" addrspace(1)** %loc2
+  %9 = icmp eq %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %9, label %18, label %10
+
+; <label>:10                                      ; preds = %7
+  %11 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc2
+  %NullCheck1 = icmp eq %"System.Byte[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %11, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp ne i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %7, %12
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc1
+  br label %27
+
+; <label>:19                                      ; preds = %12
+  %20 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc2
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %20, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %BoundsCheck = icmp uge i64 0, %24
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %25
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %20, i32 0, i32 3, i32 0
+  store i8 addrspace(1)* %26, i8 addrspace(1)** %loc1
+  br label %27
+
+; <label>:27                                      ; preds = %18, %25
+  %28 = load i64, i64* %arg0
+  %29 = load i8 addrspace(1)*, i8 addrspace(1)** %loc1
+  %30 = ptrtoint i8 addrspace(1)* %29 to i64
+  %31 = load i32, i32* %arg2
+  %32 = sext i32 %31 to i64
+  %33 = add i64 %30, %32
+  %34 = load i32, i32* %arg3
+  %35 = addrspacecast i32* %loc3 to i32 addrspace(1)*
+  %36 = inttoptr i64 %33 to i8*
+  %37 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i8*, i32, i32 addrspace(1)*, i64)*)(i64 %28, i8* %36, i32 %34, i32 addrspace(1)* %35, i64 0)
+  %38 = icmp ugt i32 %37, 0
+  %39 = sext i1 %38 to i32
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc1
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %42, label %41
+
+; <label>:41                                      ; preds = %27
+  ret i32 0
+
+; <label>:42                                      ; preds = %27
+  %43 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  store i32 %43, i32* %loc0
+  %44 = load i32, i32* %loc0
+  %45 = icmp eq i32 %44, 232
+  br i1 %45, label %49, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = load i32, i32* %loc0
+  %48 = icmp ne i32 %47, 109
+  br i1 %48, label %50, label %49
+
+; <label>:49                                      ; preds = %42, %46
+  ret i32 0
+
+; <label>:50                                      ; preds = %46
+  %51 = load i32, i32* %loc0
+  ret i32 %51
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
 Successfully read WindowsConsoleStream.Flush
 
@@ -15720,8 +18122,8 @@ entry:
   %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
   store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
@@ -15756,8 +18158,8 @@ entry:
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
   %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load i64, i64 addrspace(1)* %1
@@ -15796,15 +18198,15 @@ entry:
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.TextWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
   %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %3, align 8
   %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
   %7 = load i64, i64 addrspace(1)* %5
@@ -15822,7 +18224,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -15851,8 +18253,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %4)
   store i32 0, i32* %loc0
   %5 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Char[]" addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
@@ -15864,15 +18266,15 @@ entry:
 
 ; <label>:11                                      ; preds = %69
   %12 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %12, i32 0, i32 9
   %15 = load i32, i32 addrspace(1)* %14, align 8
   %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.IO.StreamWriter addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %16, i32 0, i32 10
@@ -15887,15 +18289,15 @@ entry:
 
 ; <label>:23                                      ; preds = %17, %21
   %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %24, null
-  br i1 %NullCheck8, label %25, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %24, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 10
   %27 = load i32, i32 addrspace(1)* %26, align 8
   %28 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %28, null
-  br i1 %NullCheck10, label %29, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.StreamWriter addrspace(1)* %28, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %28, i32 0, i32 9
@@ -15917,15 +18319,15 @@ entry:
   %40 = load i32, i32* %loc0
   %41 = mul i32 %40, 2
   %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
-  br i1 %NullCheck12, label %43, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %43
 
 ; <label>:43                                      ; preds = %38
   %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 7
   %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %44, align 8
   %46 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %46, null
-  br i1 %NullCheck14, label %47, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.IO.StreamWriter addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %47
 
 ; <label>:47                                      ; preds = %43
   %48 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %46, i32 0, i32 9
@@ -15937,16 +18339,16 @@ entry:
   %54 = bitcast %"System.Char[]" addrspace(1)* %45 to %System.Array addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %53, i32 %41, %System.Array addrspace(1)* %54, i32 %50, i32 %52)
   %55 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
-  br i1 %NullCheck16, label %56, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %56
 
 ; <label>:56                                      ; preds = %47
   %57 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
   %58 = load i32, i32 addrspace(1)* %57, align 8
   %59 = load i32, i32* %loc2
   %60 = add i32 %58, %59
-  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
-  br i1 %NullCheck18, label %61, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %61
 
 ; <label>:61                                      ; preds = %56
   %62 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
@@ -15968,8 +18370,8 @@ entry:
 
 ; <label>:72                                      ; preds = %69
   %73 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %73, null
-  br i1 %NullCheck2, label %74, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %73, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %74
 
 ; <label>:74                                      ; preds = %72
   %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %73, i32 0, i32 11
@@ -15990,39 +18392,39 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %72
+ThrowNullRef2:                                    ; preds = %72
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %23
+ThrowNullRef8:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef10:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %43
+ThrowNullRef14:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %47
+ThrowNullRef16:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %56
+ThrowNullRef18:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }

--- a/test/BaseLine/JIT/CodeGenBringUpTests/StructFldAddr.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/StructFldAddr.error.txt
@@ -25,8 +25,8 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
@@ -40,8 +40,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
   %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
@@ -75,7 +75,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -90,8 +90,8 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %NullCheck = icmp ne i8 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = load i8, i8 addrspace(1)* %0, align 8
@@ -125,8 +125,8 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
@@ -159,8 +159,8 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -184,8 +184,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
   store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
@@ -195,8 +195,8 @@ entry:
 ; <label>:4                                       ; preds = %1
   %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
   %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
@@ -206,8 +206,8 @@ entry:
   %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
@@ -221,14 +221,14 @@ entry:
 
 ; <label>:17                                      ; preds = %14
   %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
   %21 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
@@ -238,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -249,8 +249,8 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
@@ -261,27 +261,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %30
+ThrowNullRef10:                                   ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -301,7 +301,89 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
-Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
+Successfully read AppDomainSetup.GetUnsecureApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.GetUnsecureApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %NullCheck = icmp eq %"System.String[]" addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %BoundsCheck = icmp uge i64 0, %5
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %6
+
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 3, i32 0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
+  ret %System.String addrspace(1)* %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_Value using LLILCJit
+Successfully read AppDomainSetup.get_Value
+
+define %"System.String[]" addrspace(1)* @AppDomainSetup.get_Value(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.String[]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 18)
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.String[]" addrspace(1)* addrspace(1)*, %"System.String[]" addrspace(1)*)*)(%"System.String[]" addrspace(1)* addrspace(1)* %9, %"System.String[]" addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %11, i32 0, i32 1
+  %14 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %13, align 8
+  ret %"System.String[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -319,8 +401,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -368,16 +450,16 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
   %5 = load i32, i32 addrspace(1)* %4
   %6 = sub i32 %5, 1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -389,7 +471,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -421,8 +503,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
@@ -456,8 +538,8 @@ entry:
 ; <label>:27                                      ; preds = %19
   %28 = load i32, i32* %arg1
   %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
-  br i1 %NullCheck2, label %30, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %29, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %30
 
 ; <label>:30                                      ; preds = %27
   %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
@@ -493,8 +575,8 @@ entry:
 ; <label>:49                                      ; preds = %46
   %50 = load i32, i32* %arg2
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck4, label %52, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
@@ -517,11 +599,11 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %27
+ThrowNullRef2:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %49
+ThrowNullRef4:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -544,16 +626,16 @@ entry:
   %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %0)
   store %System.String addrspace(1)* %1, %System.String addrspace(1)** %loc0
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 2
   %5 = bitcast [0 x i16] addrspace(1)* %4 to i16 addrspace(1)*
   store i16 addrspace(1)* %5, i16 addrspace(1)** %loc1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %3
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2
@@ -580,7 +662,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -691,15 +773,15 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %NullCheck132 = icmp ne i8* %21, null
-  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+  %NullCheck131 = icmp eq i8* %21, null
+  br i1 %NullCheck131, label %ThrowNullRef132, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = load i8, i8* %21, align 8
   %24 = zext i8 %23 to i32
   %25 = trunc i32 %24 to i8
-  %NullCheck134 = icmp ne i8* %20, null
-  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+  %NullCheck133 = icmp eq i8* %20, null
+  br i1 %NullCheck133, label %ThrowNullRef134, label %26
 
 ; <label>:26                                      ; preds = %22
   store i8 %25, i8* %20, align 8
@@ -709,16 +791,16 @@ entry:
   %28 = load i8*, i8** %arg0
   %29 = load i8*, i8** %arg1
   %30 = bitcast i8* %29 to i16*
-  %NullCheck128 = icmp ne i16* %30, null
-  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+  %NullCheck127 = icmp eq i16* %30, null
+  br i1 %NullCheck127, label %ThrowNullRef128, label %31
 
 ; <label>:31                                      ; preds = %27
   %32 = load i16, i16* %30, align 8
   %33 = sext i16 %32 to i32
   %34 = bitcast i8* %28 to i16*
   %35 = trunc i32 %33 to i16
-  %NullCheck130 = icmp ne i16* %34, null
-  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+  %NullCheck129 = icmp eq i16* %34, null
+  br i1 %NullCheck129, label %ThrowNullRef130, label %36
 
 ; <label>:36                                      ; preds = %31
   store i16 %35, i16* %34, align 8
@@ -728,16 +810,16 @@ entry:
   %38 = load i8*, i8** %arg0
   %39 = load i8*, i8** %arg1
   %40 = bitcast i8* %39 to i16*
-  %NullCheck120 = icmp ne i16* %40, null
-  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+  %NullCheck119 = icmp eq i16* %40, null
+  br i1 %NullCheck119, label %ThrowNullRef120, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i16, i16* %40, align 8
   %43 = sext i16 %42 to i32
   %44 = bitcast i8* %38 to i16*
   %45 = trunc i32 %43 to i16
-  %NullCheck122 = icmp ne i16* %44, null
-  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+  %NullCheck121 = icmp eq i16* %44, null
+  br i1 %NullCheck121, label %ThrowNullRef122, label %46
 
 ; <label>:46                                      ; preds = %41
   store i16 %45, i16* %44, align 8
@@ -745,15 +827,15 @@ entry:
   %48 = getelementptr inbounds i8, i8* %47, i64 2
   %49 = load i8*, i8** %arg1
   %50 = getelementptr inbounds i8, i8* %49, i64 2
-  %NullCheck124 = icmp ne i8* %50, null
-  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+  %NullCheck123 = icmp eq i8* %50, null
+  br i1 %NullCheck123, label %ThrowNullRef124, label %51
 
 ; <label>:51                                      ; preds = %46
   %52 = load i8, i8* %50, align 8
   %53 = zext i8 %52 to i32
   %54 = trunc i32 %53 to i8
-  %NullCheck126 = icmp ne i8* %48, null
-  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+  %NullCheck125 = icmp eq i8* %48, null
+  br i1 %NullCheck125, label %ThrowNullRef126, label %55
 
 ; <label>:55                                      ; preds = %51
   store i8 %54, i8* %48, align 8
@@ -763,14 +845,14 @@ entry:
   %57 = load i8*, i8** %arg0
   %58 = load i8*, i8** %arg1
   %59 = bitcast i8* %58 to i32*
-  %NullCheck116 = icmp ne i32* %59, null
-  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+  %NullCheck115 = icmp eq i32* %59, null
+  br i1 %NullCheck115, label %ThrowNullRef116, label %60
 
 ; <label>:60                                      ; preds = %56
   %61 = load i32, i32* %59, align 8
   %62 = bitcast i8* %57 to i32*
-  %NullCheck118 = icmp ne i32* %62, null
-  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+  %NullCheck117 = icmp eq i32* %62, null
+  br i1 %NullCheck117, label %ThrowNullRef118, label %63
 
 ; <label>:63                                      ; preds = %60
   store i32 %61, i32* %62, align 8
@@ -780,14 +862,14 @@ entry:
   %65 = load i8*, i8** %arg0
   %66 = load i8*, i8** %arg1
   %67 = bitcast i8* %66 to i32*
-  %NullCheck108 = icmp ne i32* %67, null
-  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+  %NullCheck107 = icmp eq i32* %67, null
+  br i1 %NullCheck107, label %ThrowNullRef108, label %68
 
 ; <label>:68                                      ; preds = %64
   %69 = load i32, i32* %67, align 8
   %70 = bitcast i8* %65 to i32*
-  %NullCheck110 = icmp ne i32* %70, null
-  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+  %NullCheck109 = icmp eq i32* %70, null
+  br i1 %NullCheck109, label %ThrowNullRef110, label %71
 
 ; <label>:71                                      ; preds = %68
   store i32 %69, i32* %70, align 8
@@ -795,15 +877,15 @@ entry:
   %73 = getelementptr inbounds i8, i8* %72, i64 4
   %74 = load i8*, i8** %arg1
   %75 = getelementptr inbounds i8, i8* %74, i64 4
-  %NullCheck112 = icmp ne i8* %75, null
-  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+  %NullCheck111 = icmp eq i8* %75, null
+  br i1 %NullCheck111, label %ThrowNullRef112, label %76
 
 ; <label>:76                                      ; preds = %71
   %77 = load i8, i8* %75, align 8
   %78 = zext i8 %77 to i32
   %79 = trunc i32 %78 to i8
-  %NullCheck114 = icmp ne i8* %73, null
-  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+  %NullCheck113 = icmp eq i8* %73, null
+  br i1 %NullCheck113, label %ThrowNullRef114, label %80
 
 ; <label>:80                                      ; preds = %76
   store i8 %79, i8* %73, align 8
@@ -813,14 +895,14 @@ entry:
   %82 = load i8*, i8** %arg0
   %83 = load i8*, i8** %arg1
   %84 = bitcast i8* %83 to i32*
-  %NullCheck100 = icmp ne i32* %84, null
-  br i1 %NullCheck100, label %85, label %ThrowNullRef99
+  %NullCheck99 = icmp eq i32* %84, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %85
 
 ; <label>:85                                      ; preds = %81
   %86 = load i32, i32* %84, align 8
   %87 = bitcast i8* %82 to i32*
-  %NullCheck102 = icmp ne i32* %87, null
-  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+  %NullCheck101 = icmp eq i32* %87, null
+  br i1 %NullCheck101, label %ThrowNullRef102, label %88
 
 ; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
@@ -829,16 +911,16 @@ entry:
   %91 = load i8*, i8** %arg1
   %92 = getelementptr inbounds i8, i8* %91, i64 4
   %93 = bitcast i8* %92 to i16*
-  %NullCheck104 = icmp ne i16* %93, null
-  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+  %NullCheck103 = icmp eq i16* %93, null
+  br i1 %NullCheck103, label %ThrowNullRef104, label %94
 
 ; <label>:94                                      ; preds = %88
   %95 = load i16, i16* %93, align 8
   %96 = sext i16 %95 to i32
   %97 = bitcast i8* %90 to i16*
   %98 = trunc i32 %96 to i16
-  %NullCheck106 = icmp ne i16* %97, null
-  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+  %NullCheck105 = icmp eq i16* %97, null
+  br i1 %NullCheck105, label %ThrowNullRef106, label %99
 
 ; <label>:99                                      ; preds = %94
   store i16 %98, i16* %97, align 8
@@ -848,14 +930,14 @@ entry:
   %101 = load i8*, i8** %arg0
   %102 = load i8*, i8** %arg1
   %103 = bitcast i8* %102 to i32*
-  %NullCheck88 = icmp ne i32* %103, null
-  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+  %NullCheck87 = icmp eq i32* %103, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %104
 
 ; <label>:104                                     ; preds = %100
   %105 = load i32, i32* %103, align 8
   %106 = bitcast i8* %101 to i32*
-  %NullCheck90 = icmp ne i32* %106, null
-  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+  %NullCheck89 = icmp eq i32* %106, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %107
 
 ; <label>:107                                     ; preds = %104
   store i32 %105, i32* %106, align 8
@@ -864,16 +946,16 @@ entry:
   %110 = load i8*, i8** %arg1
   %111 = getelementptr inbounds i8, i8* %110, i64 4
   %112 = bitcast i8* %111 to i16*
-  %NullCheck92 = icmp ne i16* %112, null
-  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+  %NullCheck91 = icmp eq i16* %112, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %113
 
 ; <label>:113                                     ; preds = %107
   %114 = load i16, i16* %112, align 8
   %115 = sext i16 %114 to i32
   %116 = bitcast i8* %109 to i16*
   %117 = trunc i32 %115 to i16
-  %NullCheck94 = icmp ne i16* %116, null
-  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+  %NullCheck93 = icmp eq i16* %116, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %118
 
 ; <label>:118                                     ; preds = %113
   store i16 %117, i16* %116, align 8
@@ -881,15 +963,15 @@ entry:
   %120 = getelementptr inbounds i8, i8* %119, i64 6
   %121 = load i8*, i8** %arg1
   %122 = getelementptr inbounds i8, i8* %121, i64 6
-  %NullCheck96 = icmp ne i8* %122, null
-  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+  %NullCheck95 = icmp eq i8* %122, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %123
 
 ; <label>:123                                     ; preds = %118
   %124 = load i8, i8* %122, align 8
   %125 = zext i8 %124 to i32
   %126 = trunc i32 %125 to i8
-  %NullCheck98 = icmp ne i8* %120, null
-  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+  %NullCheck97 = icmp eq i8* %120, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %127
 
 ; <label>:127                                     ; preds = %123
   store i8 %126, i8* %120, align 8
@@ -899,14 +981,14 @@ entry:
   %129 = load i8*, i8** %arg0
   %130 = load i8*, i8** %arg1
   %131 = bitcast i8* %130 to i64*
-  %NullCheck84 = icmp ne i64* %131, null
-  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+  %NullCheck83 = icmp eq i64* %131, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %132
 
 ; <label>:132                                     ; preds = %128
   %133 = load i64, i64* %131, align 8
   %134 = bitcast i8* %129 to i64*
-  %NullCheck86 = icmp ne i64* %134, null
-  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+  %NullCheck85 = icmp eq i64* %134, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %135
 
 ; <label>:135                                     ; preds = %132
   store i64 %133, i64* %134, align 8
@@ -916,14 +998,14 @@ entry:
   %137 = load i8*, i8** %arg0
   %138 = load i8*, i8** %arg1
   %139 = bitcast i8* %138 to i64*
-  %NullCheck76 = icmp ne i64* %139, null
-  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+  %NullCheck75 = icmp eq i64* %139, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %140
 
 ; <label>:140                                     ; preds = %136
   %141 = load i64, i64* %139, align 8
   %142 = bitcast i8* %137 to i64*
-  %NullCheck78 = icmp ne i64* %142, null
-  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+  %NullCheck77 = icmp eq i64* %142, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %143
 
 ; <label>:143                                     ; preds = %140
   store i64 %141, i64* %142, align 8
@@ -931,15 +1013,15 @@ entry:
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %NullCheck80 = icmp ne i8* %147, null
-  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+  %NullCheck79 = icmp eq i8* %147, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %148
 
 ; <label>:148                                     ; preds = %143
   %149 = load i8, i8* %147, align 8
   %150 = zext i8 %149 to i32
   %151 = trunc i32 %150 to i8
-  %NullCheck82 = icmp ne i8* %145, null
-  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+  %NullCheck81 = icmp eq i8* %145, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %152
 
 ; <label>:152                                     ; preds = %148
   store i8 %151, i8* %145, align 8
@@ -949,14 +1031,14 @@ entry:
   %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
   %156 = bitcast i8* %155 to i64*
-  %NullCheck68 = icmp ne i64* %156, null
-  br i1 %NullCheck68, label %157, label %ThrowNullRef67
+  %NullCheck67 = icmp eq i64* %156, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %157
 
 ; <label>:157                                     ; preds = %153
   %158 = load i64, i64* %156, align 8
   %159 = bitcast i8* %154 to i64*
-  %NullCheck70 = icmp ne i64* %159, null
-  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+  %NullCheck69 = icmp eq i64* %159, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %160
 
 ; <label>:160                                     ; preds = %157
   store i64 %158, i64* %159, align 8
@@ -965,16 +1047,16 @@ entry:
   %163 = load i8*, i8** %arg1
   %164 = getelementptr inbounds i8, i8* %163, i64 8
   %165 = bitcast i8* %164 to i16*
-  %NullCheck72 = icmp ne i16* %165, null
-  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+  %NullCheck71 = icmp eq i16* %165, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %166
 
 ; <label>:166                                     ; preds = %160
   %167 = load i16, i16* %165, align 8
   %168 = sext i16 %167 to i32
   %169 = bitcast i8* %162 to i16*
   %170 = trunc i32 %168 to i16
-  %NullCheck74 = icmp ne i16* %169, null
-  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+  %NullCheck73 = icmp eq i16* %169, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %171
 
 ; <label>:171                                     ; preds = %166
   store i16 %170, i16* %169, align 8
@@ -984,14 +1066,14 @@ entry:
   %173 = load i8*, i8** %arg0
   %174 = load i8*, i8** %arg1
   %175 = bitcast i8* %174 to i64*
-  %NullCheck56 = icmp ne i64* %175, null
-  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+  %NullCheck55 = icmp eq i64* %175, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %176
 
 ; <label>:176                                     ; preds = %172
   %177 = load i64, i64* %175, align 8
   %178 = bitcast i8* %173 to i64*
-  %NullCheck58 = icmp ne i64* %178, null
-  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+  %NullCheck57 = icmp eq i64* %178, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %179
 
 ; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
@@ -1000,16 +1082,16 @@ entry:
   %182 = load i8*, i8** %arg1
   %183 = getelementptr inbounds i8, i8* %182, i64 8
   %184 = bitcast i8* %183 to i16*
-  %NullCheck60 = icmp ne i16* %184, null
-  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+  %NullCheck59 = icmp eq i16* %184, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %185
 
 ; <label>:185                                     ; preds = %179
   %186 = load i16, i16* %184, align 8
   %187 = sext i16 %186 to i32
   %188 = bitcast i8* %181 to i16*
   %189 = trunc i32 %187 to i16
-  %NullCheck62 = icmp ne i16* %188, null
-  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+  %NullCheck61 = icmp eq i16* %188, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %190
 
 ; <label>:190                                     ; preds = %185
   store i16 %189, i16* %188, align 8
@@ -1017,15 +1099,15 @@ entry:
   %192 = getelementptr inbounds i8, i8* %191, i64 10
   %193 = load i8*, i8** %arg1
   %194 = getelementptr inbounds i8, i8* %193, i64 10
-  %NullCheck64 = icmp ne i8* %194, null
-  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+  %NullCheck63 = icmp eq i8* %194, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %195
 
 ; <label>:195                                     ; preds = %190
   %196 = load i8, i8* %194, align 8
   %197 = zext i8 %196 to i32
   %198 = trunc i32 %197 to i8
-  %NullCheck66 = icmp ne i8* %192, null
-  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+  %NullCheck65 = icmp eq i8* %192, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %199
 
 ; <label>:199                                     ; preds = %195
   store i8 %198, i8* %192, align 8
@@ -1035,14 +1117,14 @@ entry:
   %201 = load i8*, i8** %arg0
   %202 = load i8*, i8** %arg1
   %203 = bitcast i8* %202 to i64*
-  %NullCheck48 = icmp ne i64* %203, null
-  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+  %NullCheck47 = icmp eq i64* %203, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %204
 
 ; <label>:204                                     ; preds = %200
   %205 = load i64, i64* %203, align 8
   %206 = bitcast i8* %201 to i64*
-  %NullCheck50 = icmp ne i64* %206, null
-  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+  %NullCheck49 = icmp eq i64* %206, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %207
 
 ; <label>:207                                     ; preds = %204
   store i64 %205, i64* %206, align 8
@@ -1051,14 +1133,14 @@ entry:
   %210 = load i8*, i8** %arg1
   %211 = getelementptr inbounds i8, i8* %210, i64 8
   %212 = bitcast i8* %211 to i32*
-  %NullCheck52 = icmp ne i32* %212, null
-  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+  %NullCheck51 = icmp eq i32* %212, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %213
 
 ; <label>:213                                     ; preds = %207
   %214 = load i32, i32* %212, align 8
   %215 = bitcast i8* %209 to i32*
-  %NullCheck54 = icmp ne i32* %215, null
-  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+  %NullCheck53 = icmp eq i32* %215, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %216
 
 ; <label>:216                                     ; preds = %213
   store i32 %214, i32* %215, align 8
@@ -1068,14 +1150,14 @@ entry:
   %218 = load i8*, i8** %arg0
   %219 = load i8*, i8** %arg1
   %220 = bitcast i8* %219 to i64*
-  %NullCheck36 = icmp ne i64* %220, null
-  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64* %220, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %221
 
 ; <label>:221                                     ; preds = %217
   %222 = load i64, i64* %220, align 8
   %223 = bitcast i8* %218 to i64*
-  %NullCheck38 = icmp ne i64* %223, null
-  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+  %NullCheck37 = icmp eq i64* %223, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %224
 
 ; <label>:224                                     ; preds = %221
   store i64 %222, i64* %223, align 8
@@ -1084,14 +1166,14 @@ entry:
   %227 = load i8*, i8** %arg1
   %228 = getelementptr inbounds i8, i8* %227, i64 8
   %229 = bitcast i8* %228 to i32*
-  %NullCheck40 = icmp ne i32* %229, null
-  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i32* %229, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %230
 
 ; <label>:230                                     ; preds = %224
   %231 = load i32, i32* %229, align 8
   %232 = bitcast i8* %226 to i32*
-  %NullCheck42 = icmp ne i32* %232, null
-  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+  %NullCheck41 = icmp eq i32* %232, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %233
 
 ; <label>:233                                     ; preds = %230
   store i32 %231, i32* %232, align 8
@@ -1099,15 +1181,15 @@ entry:
   %235 = getelementptr inbounds i8, i8* %234, i64 12
   %236 = load i8*, i8** %arg1
   %237 = getelementptr inbounds i8, i8* %236, i64 12
-  %NullCheck44 = icmp ne i8* %237, null
-  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i8* %237, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %238
 
 ; <label>:238                                     ; preds = %233
   %239 = load i8, i8* %237, align 8
   %240 = zext i8 %239 to i32
   %241 = trunc i32 %240 to i8
-  %NullCheck46 = icmp ne i8* %235, null
-  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+  %NullCheck45 = icmp eq i8* %235, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %242
 
 ; <label>:242                                     ; preds = %238
   store i8 %241, i8* %235, align 8
@@ -1117,14 +1199,14 @@ entry:
   %244 = load i8*, i8** %arg0
   %245 = load i8*, i8** %arg1
   %246 = bitcast i8* %245 to i64*
-  %NullCheck24 = icmp ne i64* %246, null
-  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64* %246, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %247
 
 ; <label>:247                                     ; preds = %243
   %248 = load i64, i64* %246, align 8
   %249 = bitcast i8* %244 to i64*
-  %NullCheck26 = icmp ne i64* %249, null
-  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64* %249, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %250
 
 ; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
@@ -1133,14 +1215,14 @@ entry:
   %253 = load i8*, i8** %arg1
   %254 = getelementptr inbounds i8, i8* %253, i64 8
   %255 = bitcast i8* %254 to i32*
-  %NullCheck28 = icmp ne i32* %255, null
-  br i1 %NullCheck28, label %256, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i32* %255, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %256
 
 ; <label>:256                                     ; preds = %250
   %257 = load i32, i32* %255, align 8
   %258 = bitcast i8* %252 to i32*
-  %NullCheck30 = icmp ne i32* %258, null
-  br i1 %NullCheck30, label %259, label %ThrowNullRef29
+  %NullCheck29 = icmp eq i32* %258, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %259
 
 ; <label>:259                                     ; preds = %256
   store i32 %257, i32* %258, align 8
@@ -1149,16 +1231,16 @@ entry:
   %262 = load i8*, i8** %arg1
   %263 = getelementptr inbounds i8, i8* %262, i64 12
   %264 = bitcast i8* %263 to i16*
-  %NullCheck32 = icmp ne i16* %264, null
-  br i1 %NullCheck32, label %265, label %ThrowNullRef31
+  %NullCheck31 = icmp eq i16* %264, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %265
 
 ; <label>:265                                     ; preds = %259
   %266 = load i16, i16* %264, align 8
   %267 = sext i16 %266 to i32
   %268 = bitcast i8* %261 to i16*
   %269 = trunc i32 %267 to i16
-  %NullCheck34 = icmp ne i16* %268, null
-  br i1 %NullCheck34, label %270, label %ThrowNullRef33
+  %NullCheck33 = icmp eq i16* %268, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %270
 
 ; <label>:270                                     ; preds = %265
   store i16 %269, i16* %268, align 8
@@ -1168,14 +1250,14 @@ entry:
   %272 = load i8*, i8** %arg0
   %273 = load i8*, i8** %arg1
   %274 = bitcast i8* %273 to i64*
-  %NullCheck8 = icmp ne i64* %274, null
-  br i1 %NullCheck8, label %275, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64* %274, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %275
 
 ; <label>:275                                     ; preds = %271
   %276 = load i64, i64* %274, align 8
   %277 = bitcast i8* %272 to i64*
-  %NullCheck10 = icmp ne i64* %277, null
-  br i1 %NullCheck10, label %278, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %277, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %278
 
 ; <label>:278                                     ; preds = %275
   store i64 %276, i64* %277, align 8
@@ -1184,14 +1266,14 @@ entry:
   %281 = load i8*, i8** %arg1
   %282 = getelementptr inbounds i8, i8* %281, i64 8
   %283 = bitcast i8* %282 to i32*
-  %NullCheck12 = icmp ne i32* %283, null
-  br i1 %NullCheck12, label %284, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i32* %283, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %284
 
 ; <label>:284                                     ; preds = %278
   %285 = load i32, i32* %283, align 8
   %286 = bitcast i8* %280 to i32*
-  %NullCheck14 = icmp ne i32* %286, null
-  br i1 %NullCheck14, label %287, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i32* %286, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %287
 
 ; <label>:287                                     ; preds = %284
   store i32 %285, i32* %286, align 8
@@ -1200,16 +1282,16 @@ entry:
   %290 = load i8*, i8** %arg1
   %291 = getelementptr inbounds i8, i8* %290, i64 12
   %292 = bitcast i8* %291 to i16*
-  %NullCheck16 = icmp ne i16* %292, null
-  br i1 %NullCheck16, label %293, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i16* %292, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %293
 
 ; <label>:293                                     ; preds = %287
   %294 = load i16, i16* %292, align 8
   %295 = sext i16 %294 to i32
   %296 = bitcast i8* %289 to i16*
   %297 = trunc i32 %295 to i16
-  %NullCheck18 = icmp ne i16* %296, null
-  br i1 %NullCheck18, label %298, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i16* %296, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %298
 
 ; <label>:298                                     ; preds = %293
   store i16 %297, i16* %296, align 8
@@ -1217,15 +1299,15 @@ entry:
   %300 = getelementptr inbounds i8, i8* %299, i64 14
   %301 = load i8*, i8** %arg1
   %302 = getelementptr inbounds i8, i8* %301, i64 14
-  %NullCheck20 = icmp ne i8* %302, null
-  br i1 %NullCheck20, label %303, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i8* %302, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %303
 
 ; <label>:303                                     ; preds = %298
   %304 = load i8, i8* %302, align 8
   %305 = zext i8 %304 to i32
   %306 = trunc i32 %305 to i8
-  %NullCheck22 = icmp ne i8* %300, null
-  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i8* %300, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %307
 
 ; <label>:307                                     ; preds = %303
   store i8 %306, i8* %300, align 8
@@ -1235,14 +1317,14 @@ entry:
   %309 = load i8*, i8** %arg0
   %310 = load i8*, i8** %arg1
   %311 = bitcast i8* %310 to i64*
-  %NullCheck = icmp ne i64* %311, null
-  br i1 %NullCheck, label %312, label %ThrowNullRef
+  %NullCheck = icmp eq i64* %311, null
+  br i1 %NullCheck, label %ThrowNullRef, label %312
 
 ; <label>:312                                     ; preds = %308
   %313 = load i64, i64* %311, align 8
   %314 = bitcast i8* %309 to i64*
-  %NullCheck2 = icmp ne i64* %314, null
-  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64* %314, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %315
 
 ; <label>:315                                     ; preds = %312
   store i64 %313, i64* %314, align 8
@@ -1251,14 +1333,14 @@ entry:
   %318 = load i8*, i8** %arg1
   %319 = getelementptr inbounds i8, i8* %318, i64 8
   %320 = bitcast i8* %319 to i64*
-  %NullCheck4 = icmp ne i64* %320, null
-  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64* %320, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %321
 
 ; <label>:321                                     ; preds = %315
   %322 = load i64, i64* %320, align 8
   %323 = bitcast i8* %317 to i64*
-  %NullCheck6 = icmp ne i64* %323, null
-  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64* %323, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %324
 
 ; <label>:324                                     ; preds = %321
   store i64 %322, i64* %323, align 8
@@ -1286,15 +1368,15 @@ entry:
 ; <label>:338                                     ; preds = %333
   %339 = load i8*, i8** %arg0
   %340 = load i8*, i8** %arg1
-  %NullCheck136 = icmp ne i8* %340, null
-  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+  %NullCheck135 = icmp eq i8* %340, null
+  br i1 %NullCheck135, label %ThrowNullRef136, label %341
 
 ; <label>:341                                     ; preds = %338
   %342 = load i8, i8* %340, align 8
   %343 = zext i8 %342 to i32
   %344 = trunc i32 %343 to i8
-  %NullCheck138 = icmp ne i8* %339, null
-  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+  %NullCheck137 = icmp eq i8* %339, null
+  br i1 %NullCheck137, label %ThrowNullRef138, label %345
 
 ; <label>:345                                     ; preds = %341
   store i8 %344, i8* %339, align 8
@@ -1317,16 +1399,16 @@ entry:
   %357 = load i8*, i8** %arg0
   %358 = load i8*, i8** %arg1
   %359 = bitcast i8* %358 to i16*
-  %NullCheck140 = icmp ne i16* %359, null
-  br i1 %NullCheck140, label %360, label %ThrowNullRef139
+  %NullCheck139 = icmp eq i16* %359, null
+  br i1 %NullCheck139, label %ThrowNullRef140, label %360
 
 ; <label>:360                                     ; preds = %356
   %361 = load i16, i16* %359, align 8
   %362 = sext i16 %361 to i32
   %363 = bitcast i8* %357 to i16*
   %364 = trunc i32 %362 to i16
-  %NullCheck142 = icmp ne i16* %363, null
-  br i1 %NullCheck142, label %365, label %ThrowNullRef141
+  %NullCheck141 = icmp eq i16* %363, null
+  br i1 %NullCheck141, label %ThrowNullRef142, label %365
 
 ; <label>:365                                     ; preds = %360
   store i16 %364, i16* %363, align 8
@@ -1352,14 +1434,14 @@ entry:
   %378 = load i8*, i8** %arg0
   %379 = load i8*, i8** %arg1
   %380 = bitcast i8* %379 to i32*
-  %NullCheck144 = icmp ne i32* %380, null
-  br i1 %NullCheck144, label %381, label %ThrowNullRef143
+  %NullCheck143 = icmp eq i32* %380, null
+  br i1 %NullCheck143, label %ThrowNullRef144, label %381
 
 ; <label>:381                                     ; preds = %377
   %382 = load i32, i32* %380, align 8
   %383 = bitcast i8* %378 to i32*
-  %NullCheck146 = icmp ne i32* %383, null
-  br i1 %NullCheck146, label %384, label %ThrowNullRef145
+  %NullCheck145 = icmp eq i32* %383, null
+  br i1 %NullCheck145, label %ThrowNullRef146, label %384
 
 ; <label>:384                                     ; preds = %381
   store i32 %382, i32* %383, align 8
@@ -1384,14 +1466,14 @@ entry:
   %395 = load i8*, i8** %arg0
   %396 = load i8*, i8** %arg1
   %397 = bitcast i8* %396 to i64*
-  %NullCheck164 = icmp ne i64* %397, null
-  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+  %NullCheck163 = icmp eq i64* %397, null
+  br i1 %NullCheck163, label %ThrowNullRef164, label %398
 
 ; <label>:398                                     ; preds = %394
   %399 = load i64, i64* %397, align 8
   %400 = bitcast i8* %395 to i64*
-  %NullCheck166 = icmp ne i64* %400, null
-  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+  %NullCheck165 = icmp eq i64* %400, null
+  br i1 %NullCheck165, label %ThrowNullRef166, label %401
 
 ; <label>:401                                     ; preds = %398
   store i64 %399, i64* %400, align 8
@@ -1400,14 +1482,14 @@ entry:
   %404 = load i8*, i8** %arg1
   %405 = getelementptr inbounds i8, i8* %404, i64 8
   %406 = bitcast i8* %405 to i64*
-  %NullCheck168 = icmp ne i64* %406, null
-  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+  %NullCheck167 = icmp eq i64* %406, null
+  br i1 %NullCheck167, label %ThrowNullRef168, label %407
 
 ; <label>:407                                     ; preds = %401
   %408 = load i64, i64* %406, align 8
   %409 = bitcast i8* %403 to i64*
-  %NullCheck170 = icmp ne i64* %409, null
-  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+  %NullCheck169 = icmp eq i64* %409, null
+  br i1 %NullCheck169, label %ThrowNullRef170, label %410
 
 ; <label>:410                                     ; preds = %407
   store i64 %408, i64* %409, align 8
@@ -1437,14 +1519,14 @@ entry:
   %425 = load i8*, i8** %arg0
   %426 = load i8*, i8** %arg1
   %427 = bitcast i8* %426 to i64*
-  %NullCheck148 = icmp ne i64* %427, null
-  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+  %NullCheck147 = icmp eq i64* %427, null
+  br i1 %NullCheck147, label %ThrowNullRef148, label %428
 
 ; <label>:428                                     ; preds = %424
   %429 = load i64, i64* %427, align 8
   %430 = bitcast i8* %425 to i64*
-  %NullCheck150 = icmp ne i64* %430, null
-  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+  %NullCheck149 = icmp eq i64* %430, null
+  br i1 %NullCheck149, label %ThrowNullRef150, label %431
 
 ; <label>:431                                     ; preds = %428
   store i64 %429, i64* %430, align 8
@@ -1466,14 +1548,14 @@ entry:
   %441 = load i8*, i8** %arg0
   %442 = load i8*, i8** %arg1
   %443 = bitcast i8* %442 to i32*
-  %NullCheck152 = icmp ne i32* %443, null
-  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+  %NullCheck151 = icmp eq i32* %443, null
+  br i1 %NullCheck151, label %ThrowNullRef152, label %444
 
 ; <label>:444                                     ; preds = %440
   %445 = load i32, i32* %443, align 8
   %446 = bitcast i8* %441 to i32*
-  %NullCheck154 = icmp ne i32* %446, null
-  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+  %NullCheck153 = icmp eq i32* %446, null
+  br i1 %NullCheck153, label %ThrowNullRef154, label %447
 
 ; <label>:447                                     ; preds = %444
   store i32 %445, i32* %446, align 8
@@ -1495,16 +1577,16 @@ entry:
   %457 = load i8*, i8** %arg0
   %458 = load i8*, i8** %arg1
   %459 = bitcast i8* %458 to i16*
-  %NullCheck156 = icmp ne i16* %459, null
-  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+  %NullCheck155 = icmp eq i16* %459, null
+  br i1 %NullCheck155, label %ThrowNullRef156, label %460
 
 ; <label>:460                                     ; preds = %456
   %461 = load i16, i16* %459, align 8
   %462 = sext i16 %461 to i32
   %463 = bitcast i8* %457 to i16*
   %464 = trunc i32 %462 to i16
-  %NullCheck158 = icmp ne i16* %463, null
-  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+  %NullCheck157 = icmp eq i16* %463, null
+  br i1 %NullCheck157, label %ThrowNullRef158, label %465
 
 ; <label>:465                                     ; preds = %460
   store i16 %464, i16* %463, align 8
@@ -1525,15 +1607,15 @@ entry:
 ; <label>:474                                     ; preds = %470
   %475 = load i8*, i8** %arg0
   %476 = load i8*, i8** %arg1
-  %NullCheck160 = icmp ne i8* %476, null
-  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+  %NullCheck159 = icmp eq i8* %476, null
+  br i1 %NullCheck159, label %ThrowNullRef160, label %477
 
 ; <label>:477                                     ; preds = %474
   %478 = load i8, i8* %476, align 8
   %479 = zext i8 %478 to i32
   %480 = trunc i32 %479 to i8
-  %NullCheck162 = icmp ne i8* %475, null
-  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+  %NullCheck161 = icmp eq i8* %475, null
+  br i1 %NullCheck161, label %ThrowNullRef162, label %481
 
 ; <label>:481                                     ; preds = %477
   store i8 %480, i8* %475, align 8
@@ -1553,343 +1635,343 @@ ThrowNullRef:                                     ; preds = %308
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %312
+ThrowNullRef2:                                    ; preds = %312
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %315
+ThrowNullRef4:                                    ; preds = %315
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %321
+ThrowNullRef6:                                    ; preds = %321
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %271
+ThrowNullRef8:                                    ; preds = %271
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %275
+ThrowNullRef10:                                   ; preds = %275
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %278
+ThrowNullRef12:                                   ; preds = %278
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %284
+ThrowNullRef14:                                   ; preds = %284
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %287
+ThrowNullRef16:                                   ; preds = %287
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %293
+ThrowNullRef18:                                   ; preds = %293
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %298
+ThrowNullRef20:                                   ; preds = %298
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %303
+ThrowNullRef22:                                   ; preds = %303
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %243
+ThrowNullRef24:                                   ; preds = %243
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %247
+ThrowNullRef26:                                   ; preds = %247
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %250
+ThrowNullRef28:                                   ; preds = %250
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %256
+ThrowNullRef30:                                   ; preds = %256
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %259
+ThrowNullRef32:                                   ; preds = %259
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %265
+ThrowNullRef34:                                   ; preds = %265
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %217
+ThrowNullRef36:                                   ; preds = %217
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %221
+ThrowNullRef38:                                   ; preds = %221
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %224
+ThrowNullRef40:                                   ; preds = %224
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %230
+ThrowNullRef42:                                   ; preds = %230
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %233
+ThrowNullRef44:                                   ; preds = %233
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %238
+ThrowNullRef46:                                   ; preds = %238
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %200
+ThrowNullRef48:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %204
+ThrowNullRef50:                                   ; preds = %204
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %207
+ThrowNullRef52:                                   ; preds = %207
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %213
+ThrowNullRef54:                                   ; preds = %213
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %172
+ThrowNullRef56:                                   ; preds = %172
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %176
+ThrowNullRef58:                                   ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %179
+ThrowNullRef60:                                   ; preds = %179
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %185
+ThrowNullRef62:                                   ; preds = %185
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %190
+ThrowNullRef64:                                   ; preds = %190
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %195
+ThrowNullRef66:                                   ; preds = %195
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %153
+ThrowNullRef68:                                   ; preds = %153
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %157
+ThrowNullRef70:                                   ; preds = %157
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %160
+ThrowNullRef72:                                   ; preds = %160
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %166
+ThrowNullRef74:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %136
+ThrowNullRef76:                                   ; preds = %136
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %140
+ThrowNullRef78:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %143
+ThrowNullRef80:                                   ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %148
+ThrowNullRef82:                                   ; preds = %148
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %128
+ThrowNullRef84:                                   ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %132
+ThrowNullRef86:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %100
+ThrowNullRef88:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %104
+ThrowNullRef90:                                   ; preds = %104
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %107
+ThrowNullRef92:                                   ; preds = %107
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %113
+ThrowNullRef94:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %118
+ThrowNullRef96:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %123
+ThrowNullRef98:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %81
+ThrowNullRef100:                                  ; preds = %81
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef101:                                  ; preds = %85
+ThrowNullRef102:                                  ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef103:                                  ; preds = %88
+ThrowNullRef104:                                  ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef105:                                  ; preds = %94
+ThrowNullRef106:                                  ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef107:                                  ; preds = %64
+ThrowNullRef108:                                  ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef109:                                  ; preds = %68
+ThrowNullRef110:                                  ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef111:                                  ; preds = %71
+ThrowNullRef112:                                  ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef113:                                  ; preds = %76
+ThrowNullRef114:                                  ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef115:                                  ; preds = %56
+ThrowNullRef116:                                  ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef117:                                  ; preds = %60
+ThrowNullRef118:                                  ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef119:                                  ; preds = %37
+ThrowNullRef120:                                  ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef121:                                  ; preds = %41
+ThrowNullRef122:                                  ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef123:                                  ; preds = %46
+ThrowNullRef124:                                  ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef125:                                  ; preds = %51
+ThrowNullRef126:                                  ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef127:                                  ; preds = %27
+ThrowNullRef128:                                  ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef129:                                  ; preds = %31
+ThrowNullRef130:                                  ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef131:                                  ; preds = %19
+ThrowNullRef132:                                  ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef133:                                  ; preds = %22
+ThrowNullRef134:                                  ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef135:                                  ; preds = %338
+ThrowNullRef136:                                  ; preds = %338
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef137:                                  ; preds = %341
+ThrowNullRef138:                                  ; preds = %341
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef139:                                  ; preds = %356
+ThrowNullRef140:                                  ; preds = %356
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef141:                                  ; preds = %360
+ThrowNullRef142:                                  ; preds = %360
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef143:                                  ; preds = %377
+ThrowNullRef144:                                  ; preds = %377
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef145:                                  ; preds = %381
+ThrowNullRef146:                                  ; preds = %381
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef147:                                  ; preds = %424
+ThrowNullRef148:                                  ; preds = %424
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef149:                                  ; preds = %428
+ThrowNullRef150:                                  ; preds = %428
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef151:                                  ; preds = %440
+ThrowNullRef152:                                  ; preds = %440
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef153:                                  ; preds = %444
+ThrowNullRef154:                                  ; preds = %444
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef155:                                  ; preds = %456
+ThrowNullRef156:                                  ; preds = %456
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef157:                                  ; preds = %460
+ThrowNullRef158:                                  ; preds = %460
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef159:                                  ; preds = %474
+ThrowNullRef160:                                  ; preds = %474
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef161:                                  ; preds = %477
+ThrowNullRef162:                                  ; preds = %477
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef163:                                  ; preds = %394
+ThrowNullRef164:                                  ; preds = %394
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef165:                                  ; preds = %398
+ThrowNullRef166:                                  ; preds = %398
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef167:                                  ; preds = %401
+ThrowNullRef168:                                  ; preds = %401
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef169:                                  ; preds = %407
+ThrowNullRef170:                                  ; preds = %407
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1939,8 +2021,8 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
-  br i1 %NullCheck, label %22, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %ThrowNullRef, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
@@ -1948,8 +2030,8 @@ entry:
   store i32 %24, i32* %loc0
   %25 = load i32, i32* %loc0
   %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %26, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %27
 
 ; <label>:27                                      ; preds = %22
   %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
@@ -1971,7 +2053,7 @@ ThrowNullRef:                                     ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1989,8 +2071,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -2022,15 +2104,15 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2048,16 +2130,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
   %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
   store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %15
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
@@ -2072,8 +2154,8 @@ entry:
   %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
   %29 = ptrtoint i16 addrspace(1)* %28 to i64
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %19
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
@@ -2089,19 +2171,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2114,8 +2196,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
@@ -2128,7 +2210,7 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[loadElem]
+Failed to read AppDomain.PrepareDataForSetup[storeElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
@@ -2202,8 +2284,8 @@ entry:
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
-  br i1 %NullCheck24, label %27, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = load i64, i64 addrspace(1)* %26
@@ -2218,8 +2300,8 @@ entry:
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
-  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
   %41 = load i64, i64 addrspace(1)* %39
@@ -2236,8 +2318,8 @@ entry:
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
-  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
   %54 = load i64, i64 addrspace(1)* %52
@@ -2252,8 +2334,8 @@ entry:
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
   %67 = load i64, i64 addrspace(1)* %65
@@ -2270,8 +2352,8 @@ entry:
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
-  br i1 %NullCheck16, label %79, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
   %80 = load i64, i64 addrspace(1)* %78
@@ -2286,8 +2368,8 @@ entry:
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
-  br i1 %NullCheck18, label %92, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
   %93 = load i64, i64 addrspace(1)* %91
@@ -2304,8 +2386,8 @@ entry:
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
-  br i1 %NullCheck12, label %105, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = load i64, i64 addrspace(1)* %104
@@ -2320,8 +2402,8 @@ entry:
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
-  br i1 %NullCheck14, label %118, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
   %119 = load i64, i64 addrspace(1)* %117
@@ -2337,8 +2419,8 @@ entry:
 
 ; <label>:128                                     ; preds = %20
   %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
-  br i1 %NullCheck4, label %130, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %129, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %130
 
 ; <label>:130                                     ; preds = %128
   %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
@@ -2346,8 +2428,8 @@ entry:
   %133 = load i16, i16 addrspace(1)* %132, align 8
   %134 = zext i16 %133 to i32
   %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
-  br i1 %NullCheck6, label %136, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %135, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %136
 
 ; <label>:136                                     ; preds = %130
   %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
@@ -2360,8 +2442,8 @@ entry:
 
 ; <label>:143                                     ; preds = %136
   %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
-  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %144, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %145
 
 ; <label>:145                                     ; preds = %143
   %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
@@ -2369,8 +2451,8 @@ entry:
   %148 = load i16, i16 addrspace(1)* %147, align 8
   %149 = zext i16 %148 to i32
   %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %150, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %151
 
 ; <label>:151                                     ; preds = %145
   %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
@@ -2388,8 +2470,8 @@ entry:
 
 ; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
-  br i1 %NullCheck, label %163, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %ThrowNullRef, label %163
 
 ; <label>:163                                     ; preds = %161
   %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
@@ -2399,8 +2481,8 @@ entry:
 
 ; <label>:167                                     ; preds = %163
   %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
-  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %168, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %169
 
 ; <label>:169                                     ; preds = %167
   %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
@@ -2432,55 +2514,55 @@ ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %167
+ThrowNullRef2:                                    ; preds = %167
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %128
+ThrowNullRef4:                                    ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %130
+ThrowNullRef6:                                    ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %143
+ThrowNullRef8:                                    ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %145
+ThrowNullRef10:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %102
+ThrowNullRef12:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %105
+ThrowNullRef14:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %76
+ThrowNullRef16:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %79
+ThrowNullRef18:                                   ; preds = %79
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %50
+ThrowNullRef20:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %53
+ThrowNullRef22:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %24
+ThrowNullRef24:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %27
+ThrowNullRef26:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2503,15 +2585,15 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2519,16 +2601,16 @@ entry:
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
   store i32 %8, i32* %loc0
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
   %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
   store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
@@ -2546,16 +2628,16 @@ entry:
 
 ; <label>:23                                      ; preds = %64
   %24 = load i16*, i16** %loc3
-  %NullCheck12 = icmp ne i16* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i16* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
   store i32 %27, i32* %loc5
   %28 = load i16*, i16** %loc4
-  %NullCheck14 = icmp ne i16* %28, null
-  br i1 %NullCheck14, label %29, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %28, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = load i16, i16* %28, align 8
@@ -2620,15 +2702,15 @@ entry:
 
 ; <label>:67                                      ; preds = %64
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
-  br i1 %NullCheck8, label %69, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %68, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %69
 
 ; <label>:69                                      ; preds = %67
   %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
   %71 = load i32, i32 addrspace(1)* %70
   %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
-  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %73
 
 ; <label>:73                                      ; preds = %69
   %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
@@ -2645,31 +2727,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %67
+ThrowNullRef8:                                    ; preds = %67
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %69
+ThrowNullRef10:                                   ; preds = %69
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2710,14 +2792,14 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
   %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
@@ -2730,14 +2812,14 @@ entry:
 
 ; <label>:11                                      ; preds = %4
   %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
   %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
@@ -2749,14 +2831,14 @@ entry:
 
 ; <label>:22                                      ; preds = %16
   %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
   %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
-  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
-  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
@@ -2804,23 +2886,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2836,7 +2918,280 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[loadElem]
+Successfully read RuntimeType.IsAssignableFrom
+
+define i8 @RuntimeType.IsAssignableFrom(%System.RuntimeType addrspace(1)* %param0, %System.Type addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.RuntimeType addrspace(1)*
+  %arg1 = alloca %System.Type addrspace(1)*
+  %loc0 = alloca %System.RuntimeType addrspace(1)*
+  %loc1 = alloca %"System.Type[]" addrspace(1)*
+  %loc2 = alloca i32
+  store %System.RuntimeType addrspace(1)* %param0, %System.RuntimeType addrspace(1)** %this
+  store %System.Type addrspace(1)* %param1, %System.Type addrspace(1)** %arg1
+  %0 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %1 = icmp ne %System.Type addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i8 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %5 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %6 = bitcast %System.Type addrspace(1)* %4 to %System.Object addrspace(1)*
+  %7 = bitcast %System.RuntimeType addrspace(1)* %5 to %System.Object addrspace(1)*
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %6, %System.Object addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %3
+  ret i8 1
+
+; <label>:12                                      ; preds = %3
+  %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 152
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 32
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
+  %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
+  %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
+  store %System.RuntimeType addrspace(1)* %25, %System.RuntimeType addrspace(1)** %loc0
+  %26 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %27 = icmp eq %System.RuntimeType addrspace(1)* %26, null
+  br i1 %27, label %34, label %28
+
+; <label>:28                                      ; preds = %15
+  %29 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %30 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)*)*)(%System.RuntimeType addrspace(1)* %29, %System.RuntimeType addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+; <label>:34                                      ; preds = %15
+  %35 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %36 = call %System.Reflection.Emit.TypeBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Reflection.Emit.TypeBuilder addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %35)
+  %37 = icmp eq %System.Reflection.Emit.TypeBuilder addrspace(1)* %36, null
+  br i1 %37, label %139, label %38
+
+; <label>:38                                      ; preds = %34
+  %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %42
+
+; <label>:42                                      ; preds = %38
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 152
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 40
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
+  %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
+  %53 = zext i8 %52 to i32
+  %54 = icmp eq i32 %53, 0
+  br i1 %54, label %56, label %55
+
+; <label>:55                                      ; preds = %42
+  ret i8 1
+
+; <label>:56                                      ; preds = %42
+  %57 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %58 = bitcast %System.RuntimeType addrspace(1)* %57 to %System.Type addrspace(1)*
+  %59 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %58)
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %64 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.Type addrspace(1)* %63, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = bitcast %System.RuntimeType addrspace(1)* %64 to %System.Type addrspace(1)*
+  %67 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %63, %System.Type addrspace(1)* %66)
+  %68 = zext i8 %67 to i32
+  %69 = trunc i32 %68 to i8
+  ret i8 %69
+
+; <label>:70                                      ; preds = %56
+  %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
+  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %73
+
+; <label>:73                                      ; preds = %70
+  %74 = load i64, i64 addrspace(1)* %72
+  %75 = add i64 %74, 128
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = add i64 %77, 0
+  %79 = inttoptr i64 %78 to i64*
+  %80 = load i64, i64* %79
+  %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
+  %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
+  %83 = call i8 %82(%System.Type addrspace(1)* %81)
+  %84 = zext i8 %83 to i32
+  %85 = icmp eq i32 %84, 0
+  br i1 %85, label %139, label %86
+
+; <label>:86                                      ; preds = %73
+  %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
+  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %89
+
+; <label>:89                                      ; preds = %86
+  %90 = load i64, i64 addrspace(1)* %88
+  %91 = add i64 %90, 128
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = add i64 %93, 24
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
+  %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
+  %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
+  store %"System.Type[]" addrspace(1)* %99, %"System.Type[]" addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %129
+
+; <label>:100                                     ; preds = %132
+  %101 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %102 = load i32, i32* %loc2
+  %NullCheck11 = icmp eq %"System.Type[]" addrspace(1)* %101, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %103
+
+; <label>:103                                     ; preds = %100
+  %104 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 1
+  %105 = load i32, i32 addrspace(1)* %104
+  %106 = zext i32 %105 to i64
+  %107 = zext i32 %102 to i64
+  %BoundsCheck = icmp uge i64 %107, %106
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %108
+
+; <label>:108                                     ; preds = %103
+  %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
+  %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
+  %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
+  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %113
+
+; <label>:113                                     ; preds = %108
+  %114 = load i64, i64 addrspace(1)* %112
+  %115 = add i64 %114, 152
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = add i64 %117, 56
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
+  %123 = zext i8 %122 to i32
+  %124 = icmp ne i32 %123, 0
+  br i1 %124, label %126, label %125
+
+; <label>:125                                     ; preds = %113
+  ret i8 0
+
+; <label>:126                                     ; preds = %113
+  %127 = load i32, i32* %loc2
+  %128 = add i32 %127, 1
+  store i32 %128, i32* %loc2
+  br label %129
+
+; <label>:129                                     ; preds = %89, %126
+  %130 = load i32, i32* %loc2
+  %131 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %NullCheck9 = icmp eq %"System.Type[]" addrspace(1)* %131, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %132
+
+; <label>:132                                     ; preds = %129
+  %133 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %131, i32 0, i32 1
+  %134 = load i32, i32 addrspace(1)* %133
+  %135 = zext i32 %134 to i64
+  %136 = trunc i64 %135 to i32
+  %137 = icmp slt i32 %130, %136
+  br i1 %137, label %100, label %138
+
+; <label>:138                                     ; preds = %132
+  ret i8 1
+
+; <label>:139                                     ; preds = %34, %73
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %129
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %103
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -2893,7 +3248,7 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElem]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -2904,8 +3259,8 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -2997,8 +3352,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
@@ -3059,8 +3414,8 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -3087,8 +3442,8 @@ entry:
 
 ; <label>:17                                      ; preds = %5, %11
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
@@ -3097,8 +3452,8 @@ entry:
 
 ; <label>:22                                      ; preds = %1, %11
   %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
@@ -3109,11 +3464,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %17
+ThrowNullRef2:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %22
+ThrowNullRef4:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3167,15 +3522,15 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
   %15 = load i32, i32 addrspace(1)* %14
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
@@ -3198,7 +3553,7 @@ ThrowNullRef:                                     ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef2:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3232,8 +3587,8 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
@@ -3312,8 +3667,8 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -3327,8 +3682,8 @@ entry:
 ; <label>:5                                       ; preds = %43
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %7 = load i32, i32* %loc1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck6, label %8, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
@@ -3366,8 +3721,8 @@ entry:
 ; <label>:32                                      ; preds = %21, %25
   %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
   %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
-  br i1 %NullCheck8, label %35, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = trunc i32 %34 to i16
@@ -3380,8 +3735,8 @@ entry:
 ; <label>:40                                      ; preds = %1, %35
   %41 = load i32, i32* %loc1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
-  br i1 %NullCheck2, label %43, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %42, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
@@ -3392,8 +3747,8 @@ entry:
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
   %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
-  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
   %51 = load i64, i64 addrspace(1)* %49
@@ -3412,19 +3767,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %40
+ThrowNullRef2:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %47
+ThrowNullRef4:                                    ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %5
+ThrowNullRef6:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %32
+ThrowNullRef8:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3467,8 +3822,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
@@ -3492,11 +3847,391 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(i16* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store i16* %param0, i16** %arg0
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load i32, i32* %arg3
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %42, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %37, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg2
+  %13 = load i32, i32* %arg3
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %37, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %24 = load i32, i32* %arg2
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load i16*, i16** %arg0
+  %35 = load i32, i32* %arg3
+  %36 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %36, i16* %34, i32 %35)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:37                                      ; preds = %5, %16
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %39)
+  %41 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41, %System.String addrspace(1)* %38, %System.String addrspace(1)* %40)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41) #0
+  unreachable
+
+; <label>:42                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
-Failed to read StringBuilder.ToString[loadElemA]
+Successfully read StringBuilder.ToString
+
+define %System.String addrspace(1)* @StringBuilder.ToString(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i16*
+  %loc3 = alloca %"System.Char[]" addrspace(1)*
+  %loc4 = alloca i32
+  %loc5 = alloca i32
+  %loc6 = alloca i16 addrspace(1)*
+  %loc7 = alloca %System.String addrspace(1)*
+  %loc8 = alloca %"System.Char[]" addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %0)
+  %2 = icmp ne i32 %1, 0
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %4
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %6)
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %7)
+  store %System.String addrspace(1)* %8, %System.String addrspace(1)** %loc0
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.Text.StringBuilder addrspace(1)* %9, %System.Text.StringBuilder addrspace(1)** %loc1
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  store %System.String addrspace(1)* %10, %System.String addrspace(1)** %loc7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc7
+  %12 = ptrtoint %System.String addrspace(1)* %11 to i64
+  %13 = icmp eq i64 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %5
+  %15 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %16 = sext i32 %15 to i64
+  %17 = add i64 %12, %16
+  br label %18
+
+; <label>:18                                      ; preds = %5, %14
+  %19 = phi i64 [ %12, %5 ], [ %17, %14 ]
+  %20 = inttoptr i64 %19 to i16*
+  store i16* %20, i16** %loc2
+  br label %21
+
+; <label>:21                                      ; preds = %98, %18
+  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %22, null
+  br i1 %NullCheck, label %ThrowNullRef, label %23
+
+; <label>:23                                      ; preds = %21
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 3
+  %25 = load i32, i32 addrspace(1)* %24, align 8
+  %26 = icmp sle i32 %25, 0
+  br i1 %26, label %96, label %27
+
+; <label>:27                                      ; preds = %23
+  %28 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %28, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %29
+
+; <label>:29                                      ; preds = %27
+  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %28, i32 0, i32 1
+  %31 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %30, align 8
+  store %"System.Char[]" addrspace(1)* %31, %"System.Char[]" addrspace(1)** %loc3
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %33
+
+; <label>:33                                      ; preds = %29
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  store i32 %35, i32* %loc4
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  %39 = load i32, i32 addrspace(1)* %38, align 8
+  store i32 %39, i32* %loc5
+  %40 = load i32, i32* %loc5
+  %41 = load i32, i32* %loc4
+  %42 = add i32 %40, %41
+  %43 = zext i32 %42 to i64
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %45
+
+; <label>:45                                      ; preds = %37
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = sext i32 %47 to i64
+  %49 = icmp sgt i64 %43, %48
+  br i1 %49, label %91, label %50
+
+; <label>:50                                      ; preds = %45
+  %51 = load i32, i32* %loc5
+  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %52, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %53
+
+; <label>:53                                      ; preds = %50
+  %54 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %52, i32 0, i32 1
+  %55 = load i32, i32 addrspace(1)* %54
+  %56 = zext i32 %55 to i64
+  %57 = trunc i64 %56 to i32
+  %58 = icmp ugt i32 %51, %57
+  br i1 %58, label %91, label %59
+
+; <label>:59                                      ; preds = %53
+  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  store %"System.Char[]" addrspace(1)* %60, %"System.Char[]" addrspace(1)** %loc8
+  %61 = icmp eq %"System.Char[]" addrspace(1)* %60, null
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %63, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %64
+
+; <label>:64                                      ; preds = %62
+  %65 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %63, i32 0, i32 1
+  %66 = load i32, i32 addrspace(1)* %65
+  %67 = zext i32 %66 to i64
+  %68 = trunc i64 %67 to i32
+  %69 = icmp ne i32 %68, 0
+  br i1 %69, label %71, label %70
+
+; <label>:70                                      ; preds = %59, %64
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:71                                      ; preds = %64
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %73
+
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %BoundsCheck = icmp uge i64 0, %76
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %77
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %78, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:79                                      ; preds = %70, %77
+  %80 = load i16*, i16** %loc2
+  %81 = load i32, i32* %loc4
+  %82 = sext i32 %81 to i64
+  %83 = mul i64 %82, 2
+  %84 = bitcast i16* %80 to i8*
+  %85 = getelementptr inbounds i8, i8* %84, i64 %83
+  %86 = load i16 addrspace(1)*, i16 addrspace(1)** %loc6
+  %87 = ptrtoint i16 addrspace(1)* %86 to i64
+  %88 = load i32, i32* %loc5
+  %89 = bitcast i8* %85 to i16*
+  %90 = inttoptr i64 %87 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %89, i16* %90, i32 %88)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %96
+
+; <label>:91                                      ; preds = %45, %53
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %94 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %93)
+  %95 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95, %System.String addrspace(1)* %92, %System.String addrspace(1)* %94)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95) #0
+  unreachable
+
+; <label>:96                                      ; preds = %23, %79
+  %97 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %97, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %98
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %97, i32 0, i32 2
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  store %System.Text.StringBuilder addrspace(1)* %100, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %102 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %102, label %21, label %103
+
+; <label>:103                                     ; preds = %98
+  store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc7
+  %104 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  ret %System.String addrspace(1)* %104
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method StringBuilder::get_Length using LLILCJit
+Successfully read StringBuilder.get_Length
+
+define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
+Successfully read RuntimeHelpers.get_OffsetToStringData
+
+define i32 @RuntimeHelpers.get_OffsetToStringData() {
+entry:
+  ret i32 12
+}
+
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
 Successfully read CultureData.CreateCultureData
 
@@ -3514,23 +4249,23 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
   store i8 %4, i8 addrspace(1)* %6
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
@@ -3549,11 +4284,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3566,50 +4301,50 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
   store i32 -1, i32 addrspace(1)* %2
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
   store i32 -1, i32 addrspace(1)* %8
   %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
   store i32 -1, i32 addrspace(1)* %14
   %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
   store i32 -1, i32 addrspace(1)* %17
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
@@ -3623,27 +4358,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3675,7 +4410,136 @@ Failed to read Dictionary`2.Insert[non-const derefAddress]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
 Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
-Failed to read HashHelpers.GetPrime[loadElem]
+Successfully read HashHelpers.GetPrime
+
+define i32 @HashHelpers.GetPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %6, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5, %System.String addrspace(1)* %4)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5) #0
+  unreachable
+
+; <label>:6                                       ; preds = %entry
+  store i32 0, i32* %loc0
+  br label %29
+
+; <label>:7                                       ; preds = %35
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 1296
+  %10 = addrspacecast i8 addrspace(1)* %9 to %"System.Int32[]" addrspace(1)**
+  %11 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %10
+  %12 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Int32[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = zext i32 %15 to i64
+  %17 = zext i32 %12 to i64
+  %BoundsCheck = icmp uge i64 %17, %16
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 3, i32 %12
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  store i32 %20, i32* %loc1
+  %21 = load i32, i32* %loc1
+  %22 = load i32, i32* %arg0
+  %23 = icmp slt i32 %21, %22
+  br i1 %23, label %26, label %24
+
+; <label>:24                                      ; preds = %18
+  %25 = load i32, i32* %loc1
+  ret i32 %25
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %loc0
+  %28 = add i32 %27, 1
+  store i32 %28, i32* %loc0
+  br label %29
+
+; <label>:29                                      ; preds = %6, %26
+  %30 = load i32, i32* %loc0
+  %31 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %32 = getelementptr inbounds i8, i8 addrspace(1)* %31, i64 1296
+  %33 = addrspacecast i8 addrspace(1)* %32 to %"System.Int32[]" addrspace(1)**
+  %34 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %33
+  %NullCheck = icmp eq %"System.Int32[]" addrspace(1)* %34, null
+  br i1 %NullCheck, label %ThrowNullRef, label %35
+
+; <label>:35                                      ; preds = %29
+  %36 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %34, i32 0, i32 1
+  %37 = load i32, i32 addrspace(1)* %36
+  %38 = zext i32 %37 to i64
+  %39 = trunc i64 %38 to i32
+  %40 = icmp slt i32 %30, %39
+  br i1 %40, label %7, label %41
+
+; <label>:41                                      ; preds = %35
+  %42 = load i32, i32* %arg0
+  %43 = or i32 %42, 1
+  store i32 %43, i32* %loc2
+  br label %59
+
+; <label>:44                                      ; preds = %59
+  %45 = load i32, i32* %loc2
+  %46 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %45)
+  %47 = zext i8 %46 to i32
+  %48 = icmp eq i32 %47, 0
+  br i1 %48, label %56, label %49
+
+; <label>:49                                      ; preds = %44
+  %50 = load i32, i32* %loc2
+  %51 = sub i32 %50, 1
+  %52 = srem i32 %51, 101
+  %53 = icmp eq i32 %52, 0
+  br i1 %53, label %56, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = load i32, i32* %loc2
+  ret i32 %55
+
+; <label>:56                                      ; preds = %44, %49
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %57, 2
+  store i32 %58, i32* %loc2
+  br label %59
+
+; <label>:59                                      ; preds = %41, %56
+  %60 = load i32, i32* %loc2
+  %61 = icmp slt i32 %60, 2147483647
+  br i1 %61, label %44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load i32, i32* %arg0
+  ret i32 %63
+
+ThrowNullRef:                                     ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
 Successfully read GenericEqualityComparer`1.GetHashCode
 
@@ -3694,14 +4558,14 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
   %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load i64, i64 addrspace(1)* %7
@@ -3720,7 +4584,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3750,8 +4614,8 @@ entry:
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
@@ -3796,8 +4660,8 @@ entry:
   %35 = bitcast i16* %34 to i8*
   %36 = getelementptr inbounds i8, i8* %35, i64 2
   %37 = bitcast i8* %36 to i16*
-  %NullCheck4 = icmp ne i16* %37, null
-  br i1 %NullCheck4, label %38, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %37, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %38
 
 ; <label>:38                                      ; preds = %27
   %39 = load i16, i16* %37, align 8
@@ -3824,8 +4688,8 @@ entry:
 
 ; <label>:54                                      ; preds = %22, %43
   %55 = load i16*, i16** %loc4
-  %NullCheck2 = icmp ne i16* %55, null
-  br i1 %NullCheck2, label %56, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i16* %55, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %56
 
 ; <label>:56                                      ; preds = %54
   %57 = load i16, i16* %55, align 8
@@ -3850,11 +4714,11 @@ ThrowNullRef:                                     ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %54
+ThrowNullRef2:                                    ; preds = %54
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %27
+ThrowNullRef4:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3871,8 +4735,8 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -3907,8 +4771,8 @@ entry:
 
 ; <label>:26                                      ; preds = %19
   %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
-  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %28
 
 ; <label>:28                                      ; preds = %26
   %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
@@ -3920,7 +4784,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3972,8 +4836,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
@@ -3984,26 +4848,26 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
-  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
@@ -4014,8 +4878,8 @@ entry:
 ; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
@@ -4024,8 +4888,8 @@ entry:
 
 ; <label>:25                                      ; preds = %1, %16, %23
   %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
-  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
@@ -4036,27 +4900,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %20
+ThrowNullRef10:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4069,8 +4933,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -4081,8 +4945,8 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
@@ -4091,8 +4955,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1, %8
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
@@ -4103,11 +4967,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4128,24 +4992,24 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   store i32 %3, i32* %loc0
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
   %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
   store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck4, label %9, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
@@ -4164,15 +5028,15 @@ entry:
 ; <label>:18                                      ; preds = %70
   %19 = load i16*, i16** %loc3
   %20 = bitcast i16* %19 to i64*
-  %NullCheck10 = icmp ne i64* %20, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %20, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = load i64, i64* %20, align 8
   %23 = load i16*, i16** %loc4
   %24 = bitcast i16* %23 to i64*
-  %NullCheck12 = icmp ne i64* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = load i64, i64* %24, align 8
@@ -4188,8 +5052,8 @@ entry:
   %31 = bitcast i16* %30 to i8*
   %32 = getelementptr inbounds i8, i8* %31, i64 8
   %33 = bitcast i8* %32 to i64*
-  %NullCheck14 = icmp ne i64* %33, null
-  br i1 %NullCheck14, label %34, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = load i64, i64* %33, align 8
@@ -4197,8 +5061,8 @@ entry:
   %37 = bitcast i16* %36 to i8*
   %38 = getelementptr inbounds i8, i8* %37, i64 8
   %39 = bitcast i8* %38 to i64*
-  %NullCheck16 = icmp ne i64* %39, null
-  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %40
 
 ; <label>:40                                      ; preds = %34
   %41 = load i64, i64* %39, align 8
@@ -4214,8 +5078,8 @@ entry:
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %NullCheck18 = icmp ne i64* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = load i64, i64* %48, align 8
@@ -4223,8 +5087,8 @@ entry:
   %52 = bitcast i16* %51 to i8*
   %53 = getelementptr inbounds i8, i8* %52, i64 16
   %54 = bitcast i8* %53 to i64*
-  %NullCheck20 = icmp ne i64* %54, null
-  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64* %54, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %55
 
 ; <label>:55                                      ; preds = %49
   %56 = load i64, i64* %54, align 8
@@ -4262,15 +5126,15 @@ entry:
 ; <label>:74                                      ; preds = %95
   %75 = load i16*, i16** %loc3
   %76 = bitcast i16* %75 to i32*
-  %NullCheck6 = icmp ne i32* %76, null
-  br i1 %NullCheck6, label %77, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32* %76, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %77
 
 ; <label>:77                                      ; preds = %74
   %78 = load i32, i32* %76, align 8
   %79 = load i16*, i16** %loc4
   %80 = bitcast i16* %79 to i32*
-  %NullCheck8 = icmp ne i32* %80, null
-  br i1 %NullCheck8, label %81, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i32* %80, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %81
 
 ; <label>:81                                      ; preds = %77
   %82 = load i32, i32* %80, align 8
@@ -4318,43 +5182,43 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %74
+ThrowNullRef6:                                    ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %77
+ThrowNullRef8:                                    ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %29
+ThrowNullRef14:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %34
+ThrowNullRef16:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4376,8 +5240,8 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load i64, i64 addrspace(1)* %4
@@ -4389,8 +5253,8 @@ entry:
   %12 = load i64, i64* %11
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %5
   %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
@@ -4399,8 +5263,8 @@ entry:
   %18 = load i8, i8* %arg2
   %19 = zext i8 %18 to i32
   %20 = trunc i32 %19 to i8
-  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %15
   %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
@@ -4411,11 +5275,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4442,8 +5306,8 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
@@ -4466,16 +5330,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
   %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = load i64, i64 addrspace(1)* %19
@@ -4500,8 +5364,8 @@ entry:
 ; <label>:35                                      ; preds = %30
   %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
@@ -4514,8 +5378,8 @@ entry:
 
 ; <label>:42                                      ; preds = %1, %38
   %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
-  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
@@ -4526,19 +5390,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %35
+ThrowNullRef2:                                    ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %42
+ThrowNullRef8:                                    ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4551,14 +5415,14 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
@@ -4570,7 +5434,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4583,8 +5447,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
@@ -4613,51 +5477,51 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
   %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
   %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
   %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
   %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
-  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
   store i64 %21, i64 addrspace(1)* %23
   %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %25 = load i64, i64* %loc0
-  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
@@ -4668,27 +5532,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %22
+ThrowNullRef12:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4701,8 +5565,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
@@ -4713,19 +5577,19 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
@@ -4734,8 +5598,8 @@ entry:
 
 ; <label>:15                                      ; preds = %1, %13
   %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
@@ -4746,19 +5610,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %15
+ThrowNullRef8:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4771,8 +5635,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -4831,8 +5695,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
@@ -4882,8 +5746,8 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
-  br i1 %NullCheck, label %17, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %ThrowNullRef, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
@@ -4894,15 +5758,15 @@ entry:
 
 ; <label>:22                                      ; preds = %17
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
-  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
   %26 = load i32, i32 addrspace(1)* %25
   %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
-  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %27, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
@@ -4925,8 +5789,8 @@ entry:
 ; <label>:40                                      ; preds = %17
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
-  br i1 %NullCheck6, label %43, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %41, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
@@ -4938,34 +5802,17 @@ ThrowNullRef:                                     ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %24
+ThrowNullRef4:                                    ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %40
+ThrowNullRef6:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
-}
-
-INFO:  jitting method Object::ReferenceEquals using LLILCJit
-Successfully read Object.ReferenceEquals
-
-define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
-entry:
-  %arg0 = alloca %System.Object addrspace(1)*
-  %arg1 = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
-  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
-  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = icmp eq %System.Object addrspace(1)* %0, %1
-  %3 = sext i1 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
 }
 
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
@@ -4978,21 +5825,21 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
   %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
-  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
@@ -5007,28 +5854,28 @@ entry:
 ; <label>:13                                      ; preds = %8, %12
   %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
   %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
   %21 = load i32, i32 addrspace(1)* %20, align 8
   %22 = add i32 %21, 1
-  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
   store i32 %22, i32 addrspace(1)* %24
   %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
@@ -5039,27 +5886,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5077,7 +5924,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::Setup using LLILCJit
-Failed to read AppDomain.Setup[loadElem]
+Failed to read AppDomain.Setup[unbox]
 INFO:  jitting method Thread::GetDomain using LLILCJit
 Successfully read Thread.GetDomain
 
@@ -5108,8 +5955,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
@@ -5122,14 +5969,14 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
   %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
@@ -5141,11 +5988,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5173,8 +6020,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -5189,7 +6036,328 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
 Failed to read KeyCollection.System.Collections.Generic.IEnumerable<TKey>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Successfully read Enumerator.MoveNext
+
+define i8 @Enumerator.MoveNext(%"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.RuntimeTypeHandle* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*
+  %"$TypeArg" = alloca %System.RuntimeTypeHandle*
+  store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
+  %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 8
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %76, label %12
+
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
+  br label %76
+
+; <label>:13                                      ; preds = %85
+  %14 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck19 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %15
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, i32 0, i32 0
+  %17 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %16, align 8
+  %NullCheck21 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, i32 0, i32 2
+  %20 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %19, align 8
+  %21 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck23 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %22
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, i32 0, i32 2
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %NullCheck25 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 3, i32 %24
+  %NullCheck27 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %32
+
+; <label>:32                                      ; preds = %30
+  %33 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, i32 0, i32 2
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = icmp slt i32 %34, 0
+  br i1 %35, label %68, label %36
+
+; <label>:36                                      ; preds = %32
+  %37 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %38 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck29 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %39
+
+; <label>:39                                      ; preds = %36
+  %40 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, i32 0, i32 0
+  %41 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %40, align 8
+  %NullCheck31 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, i32 0, i32 2
+  %44 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %43, align 8
+  %45 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck33 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, i32 0, i32 2
+  %48 = load i32, i32 addrspace(1)* %47, align 8
+  %NullCheck35 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %49
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = zext i32 %51 to i64
+  %53 = zext i32 %48 to i64
+  %BoundsCheck37 = icmp uge i64 %53, %52
+  br i1 %BoundsCheck37, label %ThrowIndexOutOfRange38, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 3, i32 %48
+  %NullCheck39 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %56
+
+; <label>:56                                      ; preds = %54
+  %57 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, i32 0, i32 0
+  %58 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck41 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %59
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %60, %System.__Canon addrspace(1)* %58)
+  %61 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck43 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  %64 = load i32, i32 addrspace(1)* %63, align 8
+  %65 = add i32 %64, 1
+  %NullCheck45 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  store i32 %65, i32 addrspace(1)* %67
+  ret i8 1
+
+; <label>:68                                      ; preds = %32
+  %69 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck47 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %73 = add i32 %72, 1
+  %NullCheck49 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %74
+
+; <label>:74                                      ; preds = %70
+  %75 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  store i32 %73, i32 addrspace(1)* %75
+  br label %76
+
+; <label>:76                                      ; preds = %8, %12, %74
+  %77 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %78
+
+; <label>:78                                      ; preds = %76
+  %79 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, i32 0, i32 2
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck7 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %82
+
+; <label>:82                                      ; preds = %78
+  %83 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, i32 0, i32 0
+  %84 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %83, align 8
+  %NullCheck9 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %85
+
+; <label>:85                                      ; preds = %82
+  %86 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, i32 0, i32 7
+  %87 = load i32, i32 addrspace(1)* %86, align 8
+  %88 = icmp ult i32 %80, %87
+  br i1 %88, label %13, label %89
+
+; <label>:89                                      ; preds = %85
+  %90 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %91 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck11 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %92
+
+; <label>:92                                      ; preds = %89
+  %93 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, i32 0, i32 0
+  %94 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck13 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %95
+
+; <label>:95                                      ; preds = %92
+  %96 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, i32 0, i32 7
+  %97 = load i32, i32 addrspace(1)* %96, align 8
+  %98 = add i32 %97, 1
+  %NullCheck15 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %99
+
+; <label>:99                                      ; preds = %95
+  %100 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, i32 0, i32 2
+  store i32 %98, i32 addrspace(1)* %100
+  %101 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck17 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %102
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %103, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %92
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef22:                                   ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef24:                                   ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef26:                                   ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef28:                                   ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef30:                                   ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef32:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef34:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef36:                                   ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange38:                           ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef40:                                   ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef42:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef44:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef46:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef48:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef50:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -5200,8 +6368,8 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -5232,9 +6400,9 @@ Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
 Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
-Failed to read String.MakeSeparatorList[loadElemA]
+Failed to read String.MakeSeparatorList[storeElem]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
-Failed to read String.InternalSplitKeepEmptyEntries[loadElem]
+Failed to read String.InternalSplitKeepEmptyEntries[storeElem]
 INFO:  jitting method Path::IsRelative using LLILCJit
 Successfully read Path.IsRelative
 
@@ -5243,8 +6411,8 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -5254,8 +6422,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
@@ -5271,8 +6439,8 @@ entry:
 
 ; <label>:17                                      ; preds = %7
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
@@ -5288,8 +6456,8 @@ entry:
 
 ; <label>:29                                      ; preds = %19
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %31
 
 ; <label>:31                                      ; preds = %29
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
@@ -5300,8 +6468,8 @@ entry:
 
 ; <label>:36                                      ; preds = %31
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
-  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %37, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
@@ -5312,8 +6480,8 @@ entry:
 
 ; <label>:43                                      ; preds = %31, %38
   %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
-  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %45
 
 ; <label>:45                                      ; preds = %43
   %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
@@ -5324,8 +6492,8 @@ entry:
 
 ; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %50
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
@@ -5336,8 +6504,8 @@ entry:
 
 ; <label>:57                                      ; preds = %1, %7, %19, %45, %52
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
-  br i1 %NullCheck14, label %59, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %59
 
 ; <label>:59                                      ; preds = %57
   %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
@@ -5347,8 +6515,8 @@ entry:
 
 ; <label>:63                                      ; preds = %59
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
@@ -5359,8 +6527,8 @@ entry:
 
 ; <label>:70                                      ; preds = %65
   %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
-  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.String addrspace(1)* %71, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %72
 
 ; <label>:72                                      ; preds = %70
   %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
@@ -5379,39 +6547,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %17
+ThrowNullRef4:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %29
+ThrowNullRef6:                                    ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %36
+ThrowNullRef8:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %43
+ThrowNullRef10:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %50
+ThrowNullRef12:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %57
+ThrowNullRef14:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %63
+ThrowNullRef16:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %70
+ThrowNullRef18:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5419,7 +6587,293 @@ ThrowNullRef17:                                   ; preds = %70
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
-Failed to read String.TrimHelper[loadElem]
+Successfully read String.TrimHelper
+
+define %System.String addrspace(1)* @String.TrimHelper(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i16
+  %loc4 = alloca i32
+  %loc5 = alloca i16
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = sub i32 %3, 1
+  store i32 %4, i32* %loc0
+  store i32 0, i32* %loc1
+  %5 = load i32, i32* %arg2
+  %6 = icmp eq i32 %5, 1
+  br i1 %6, label %62, label %7
+
+; <label>:7                                       ; preds = %1
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:8                                       ; preds = %58
+  store i32 0, i32* %loc2
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load i32, i32* %loc1
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2, i32 %10
+  %13 = load i16, i16 addrspace(1)* %12
+  %14 = zext i16 %13 to i32
+  %15 = trunc i32 %14 to i16
+  store i16 %15, i16* %loc3
+  store i32 0, i32* %loc2
+  br label %34
+
+; <label>:16                                      ; preds = %37
+  %17 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %18 = load i32, i32* %loc2
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %17, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %19
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = zext i32 %18 to i64
+  %BoundsCheck = icmp uge i64 %23, %22
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %24
+
+; <label>:24                                      ; preds = %19
+  %25 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 3, i32 %18
+  %26 = load i16, i16 addrspace(1)* %25, align 8
+  %27 = zext i16 %26 to i32
+  %28 = load i16, i16* %loc3
+  %29 = zext i16 %28 to i32
+  %30 = icmp eq i32 %27, %29
+  br i1 %30, label %43, label %31
+
+; <label>:31                                      ; preds = %24
+  %32 = load i32, i32* %loc2
+  %33 = add i32 %32, 1
+  store i32 %33, i32* %loc2
+  br label %34
+
+; <label>:34                                      ; preds = %11, %31
+  %35 = load i32, i32* %loc2
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = icmp slt i32 %35, %41
+  br i1 %42, label %16, label %43
+
+; <label>:43                                      ; preds = %24, %37
+  %44 = load i32, i32* %loc2
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %45, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp eq i32 %44, %50
+  br i1 %51, label %62, label %52
+
+; <label>:52                                      ; preds = %46
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %7, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %57, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %58
+
+; <label>:58                                      ; preds = %55
+  %59 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %60 = load i32, i32 addrspace(1)* %59
+  %61 = icmp slt i32 %56, %60
+  br i1 %61, label %8, label %62
+
+; <label>:62                                      ; preds = %1, %46, %58
+  %63 = load i32, i32* %arg2
+  %64 = icmp eq i32 %63, 0
+  br i1 %64, label %122, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %66, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %67
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %66, i32 0, i32 1
+  %69 = load i32, i32 addrspace(1)* %68
+  %70 = sub i32 %69, 1
+  store i32 %70, i32* %loc0
+  br label %118
+
+; <label>:71                                      ; preds = %118
+  store i32 0, i32* %loc4
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %73 = load i32, i32* %loc0
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %74
+
+; <label>:74                                      ; preds = %71
+  %75 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 2, i32 %73
+  %76 = load i16, i16 addrspace(1)* %75
+  %77 = zext i16 %76 to i32
+  %78 = trunc i32 %77 to i16
+  store i16 %78, i16* %loc5
+  store i32 0, i32* %loc4
+  br label %97
+
+; <label>:79                                      ; preds = %100
+  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %81 = load i32, i32* %loc4
+  %NullCheck19 = icmp eq %"System.Char[]" addrspace(1)* %80, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
+
+; <label>:82                                      ; preds = %79
+  %83 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 1
+  %84 = load i32, i32 addrspace(1)* %83
+  %85 = zext i32 %84 to i64
+  %86 = zext i32 %81 to i64
+  %BoundsCheck21 = icmp uge i64 %86, %85
+  br i1 %BoundsCheck21, label %ThrowIndexOutOfRange22, label %87
+
+; <label>:87                                      ; preds = %82
+  %88 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 3, i32 %81
+  %89 = load i16, i16 addrspace(1)* %88, align 8
+  %90 = zext i16 %89 to i32
+  %91 = load i16, i16* %loc5
+  %92 = zext i16 %91 to i32
+  %93 = icmp eq i32 %90, %92
+  br i1 %93, label %106, label %94
+
+; <label>:94                                      ; preds = %87
+  %95 = load i32, i32* %loc4
+  %96 = add i32 %95, 1
+  store i32 %96, i32* %loc4
+  br label %97
+
+; <label>:97                                      ; preds = %74, %94
+  %98 = load i32, i32* %loc4
+  %99 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck15 = icmp eq %"System.Char[]" addrspace(1)* %99, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %100
+
+; <label>:100                                     ; preds = %97
+  %101 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %99, i32 0, i32 1
+  %102 = load i32, i32 addrspace(1)* %101
+  %103 = zext i32 %102 to i64
+  %104 = trunc i64 %103 to i32
+  %105 = icmp slt i32 %98, %104
+  br i1 %105, label %79, label %106
+
+; <label>:106                                     ; preds = %87, %100
+  %107 = load i32, i32* %loc4
+  %108 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck17 = icmp eq %"System.Char[]" addrspace(1)* %108, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %109
+
+; <label>:109                                     ; preds = %106
+  %110 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %108, i32 0, i32 1
+  %111 = load i32, i32 addrspace(1)* %110
+  %112 = zext i32 %111 to i64
+  %113 = trunc i64 %112 to i32
+  %114 = icmp eq i32 %107, %113
+  br i1 %114, label %122, label %115
+
+; <label>:115                                     ; preds = %109
+  %116 = load i32, i32* %loc0
+  %117 = sub i32 %116, 1
+  store i32 %117, i32* %loc0
+  br label %118
+
+; <label>:118                                     ; preds = %67, %115
+  %119 = load i32, i32* %loc0
+  %120 = load i32, i32* %loc1
+  %121 = icmp sge i32 %119, %120
+  br i1 %121, label %71, label %122
+
+; <label>:122                                     ; preds = %62, %109, %118
+  %123 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %124 = load i32, i32* %loc1
+  %125 = load i32, i32* %loc0
+  %126 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %123, i32 %124, i32 %125)
+  ret %System.String addrspace(1)* %126
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %97
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange22:                           ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
 Successfully read String.CreateTrimmedString
 
@@ -5439,8 +6893,8 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
@@ -5535,8 +6989,8 @@ entry:
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i64 2872
   %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
   %8 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %7
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %3
   %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
@@ -5553,8 +7007,8 @@ entry:
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 2864
   %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
   %21 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %20
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
-  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %22
 
 ; <label>:22                                      ; preds = %16
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
@@ -5569,7 +7023,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %16
+ThrowNullRef2:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5586,8 +7040,8 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5613,8 +7067,8 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
@@ -5632,8 +7086,8 @@ entry:
 
 ; <label>:12                                      ; preds = %4
   %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
@@ -5644,8 +7098,8 @@ entry:
 
 ; <label>:19                                      ; preds = %14
   %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %19
   %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
@@ -5660,21 +7114,21 @@ entry:
   %31 = zext i16 %30 to i32
   %32 = bitcast i8* %29 to i16*
   %33 = trunc i32 %31 to i16
-  %NullCheck6 = icmp ne i16* %32, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i16* %32, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %21
   store i16 %33, i16* %32, align 8
   %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %36
 
 ; <label>:36                                      ; preds = %34
   %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
   %38 = load i32, i32 addrspace(1)* %37, align 8
   %39 = add i32 %38, 1
-  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %40
 
 ; <label>:40                                      ; preds = %36
   %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
@@ -5683,16 +7137,16 @@ entry:
 
 ; <label>:42                                      ; preds = %14
   %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
-  br i1 %NullCheck12, label %44, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
   %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
   %47 = load i16, i16* %arg1
   %48 = zext i16 %47 to i32
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = trunc i32 %48 to i16
@@ -5703,31 +7157,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %19
+ThrowNullRef4:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %21
+ThrowNullRef6:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %36
+ThrowNullRef10:                                   ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %42
+ThrowNullRef12:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %44
+ThrowNullRef14:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5740,8 +7194,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -5752,8 +7206,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
@@ -5762,14 +7216,14 @@ entry:
 
 ; <label>:11                                      ; preds = %1
   %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
@@ -5779,15 +7233,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5808,8 +7262,8 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5822,8 +7276,8 @@ entry:
 
 ; <label>:8                                       ; preds = %3
   %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
@@ -5842,15 +7296,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
-  br i1 %NullCheck4, label %22, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
   %24 = load i16*, i16* addrspace(1)* %23, align 8
   %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %25, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
@@ -5859,8 +7313,8 @@ entry:
   store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
@@ -5874,8 +7328,8 @@ entry:
 
 ; <label>:37                                      ; preds = %65
   %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %37
   %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
@@ -5886,16 +7340,16 @@ entry:
   %45 = bitcast i16* %41 to i8*
   %46 = getelementptr inbounds i8, i8* %45, i64 %44
   %47 = bitcast i8* %46 to i16*
-  %NullCheck14 = icmp ne i16* %47, null
-  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %47, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %48
 
 ; <label>:48                                      ; preds = %39
   %49 = load i16, i16* %47, align 8
   %50 = zext i16 %49 to i32
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %52 = load i32, i32* %loc1
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %53
 
 ; <label>:53                                      ; preds = %48
   %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
@@ -5916,8 +7370,8 @@ entry:
 ; <label>:62                                      ; preds = %36, %59
   %63 = load i32, i32* %loc1
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck10, label %65, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %65
 
 ; <label>:65                                      ; preds = %62
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
@@ -5936,15 +7390,15 @@ entry:
 
 ; <label>:74                                      ; preds = %70
   %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
-  br i1 %NullCheck18, label %76, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %76
 
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
   %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
-  br i1 %NullCheck20, label %80, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
   %81 = load i64, i64 addrspace(1)* %79
@@ -5958,8 +7412,8 @@ entry:
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
   %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
-  br i1 %NullCheck22, label %92, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.String addrspace(1)* %90, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %92
 
 ; <label>:92                                      ; preds = %80
   %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
@@ -5969,15 +7423,15 @@ entry:
 
 ; <label>:96                                      ; preds = %70
   %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
-  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %98
 
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
   %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
-  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
   %103 = load i64, i64 addrspace(1)* %101
@@ -5991,8 +7445,8 @@ entry:
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
   %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
-  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.String addrspace(1)* %112, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %114
 
 ; <label>:114                                     ; preds = %102
   %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
@@ -6004,59 +7458,59 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %20
+ThrowNullRef4:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %22
+ThrowNullRef6:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %26
+ThrowNullRef8:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %62
+ThrowNullRef10:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %48
+ThrowNullRef16:                                   ; preds = %48
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %74
+ThrowNullRef18:                                   ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %76
+ThrowNullRef20:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %80
+ThrowNullRef22:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %96
+ThrowNullRef24:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %98
+ThrowNullRef26:                                   ; preds = %98
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %102
+ThrowNullRef28:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6069,15 +7523,15 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
   %3 = load i16*, i16* addrspace(1)* %2, align 8
   %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
@@ -6087,8 +7541,8 @@ entry:
   %10 = bitcast i16* %3 to i8*
   %11 = getelementptr inbounds i8, i8* %10, i64 %9
   %12 = bitcast i8* %11 to i16*
-  %NullCheck4 = icmp ne i16* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %5
   store i16 0, i16* %12, align 8
@@ -6098,11 +7552,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6119,8 +7573,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -6131,8 +7585,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
@@ -6144,15 +7598,15 @@ entry:
 
 ; <label>:14                                      ; preds = %1
   %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
   %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
   %21 = load i64, i64 addrspace(1)* %19
@@ -6171,15 +7625,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %14
+ThrowNullRef4:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %16
+ThrowNullRef6:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6302,14 +7756,6 @@ entry:
   ret %System.String addrspace(1)* %57
 }
 
-INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
-Successfully read RuntimeHelpers.get_OffsetToStringData
-
-define i32 @RuntimeHelpers.get_OffsetToStringData() {
-entry:
-  ret i32 12
-}
-
 INFO:  jitting method String::Equals using LLILCJit
 Successfully read String.Equals
 
@@ -6381,8 +7827,8 @@ entry:
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
-  br i1 %NullCheck24, label %29, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
   %30 = load i64, i64 addrspace(1)* %28
@@ -6397,8 +7843,8 @@ entry:
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
-  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
   %43 = load i64, i64 addrspace(1)* %41
@@ -6418,8 +7864,8 @@ entry:
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
   %59 = load i64, i64 addrspace(1)* %57
@@ -6434,8 +7880,8 @@ entry:
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck22, label %71, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
   %72 = load i64, i64 addrspace(1)* %70
@@ -6455,8 +7901,8 @@ entry:
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
-  br i1 %NullCheck16, label %87, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = load i64, i64 addrspace(1)* %86
@@ -6471,8 +7917,8 @@ entry:
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck18, label %100, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
   %101 = load i64, i64 addrspace(1)* %99
@@ -6492,8 +7938,8 @@ entry:
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
-  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
   %117 = load i64, i64 addrspace(1)* %115
@@ -6508,8 +7954,8 @@ entry:
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
-  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
   %130 = load i64, i64 addrspace(1)* %128
@@ -6528,15 +7974,15 @@ entry:
 
 ; <label>:142                                     ; preds = %22
   %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
-  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %143, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %144
 
 ; <label>:144                                     ; preds = %142
   %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
   %146 = load i32, i32 addrspace(1)* %145
   %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
-  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %147, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %148
 
 ; <label>:148                                     ; preds = %144
   %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
@@ -6557,15 +8003,15 @@ entry:
 
 ; <label>:159                                     ; preds = %22
   %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
-  br i1 %NullCheck, label %161, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %ThrowNullRef, label %161
 
 ; <label>:161                                     ; preds = %159
   %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
   %163 = load i32, i32 addrspace(1)* %162
   %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
-  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %164, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %165
 
 ; <label>:165                                     ; preds = %161
   %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
@@ -6578,8 +8024,8 @@ entry:
 
 ; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
-  br i1 %NullCheck4, label %172, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %171, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %172
 
 ; <label>:172                                     ; preds = %170
   %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
@@ -6589,8 +8035,8 @@ entry:
 
 ; <label>:176                                     ; preds = %172
   %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
-  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %177, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %178
 
 ; <label>:178                                     ; preds = %176
   %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
@@ -6629,55 +8075,55 @@ ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %161
+ThrowNullRef2:                                    ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %170
+ThrowNullRef4:                                    ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %176
+ThrowNullRef6:                                    ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %142
+ThrowNullRef8:                                    ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %144
+ThrowNullRef10:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %113
+ThrowNullRef12:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %116
+ThrowNullRef14:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %84
+ThrowNullRef16:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %87
+ThrowNullRef18:                                   ; preds = %87
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %55
+ThrowNullRef20:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %58
+ThrowNullRef22:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %26
+ThrowNullRef24:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %29
+ThrowNullRef26:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,8 +8161,8 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck, label %14, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %ThrowNullRef, label %14
 
 ; <label>:14                                      ; preds = %8
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
@@ -6760,8 +8206,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
@@ -6770,14 +8216,14 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32, i32* %loc0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %10
   %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
   %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
@@ -6790,15 +8236,15 @@ entry:
 ; <label>:25                                      ; preds = %19
   %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
-  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
   %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
@@ -6807,8 +8253,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %37 = load i32, i32* %loc0
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %38, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %38
 
 ; <label>:38                                      ; preds = %32
   %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
@@ -6817,14 +8263,14 @@ entry:
 
 ; <label>:40                                      ; preds = %19
   %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %40
   %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
   %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
-  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
-  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
@@ -6832,8 +8278,8 @@ entry:
   %48 = zext i32 %47 to i64
   %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
-  br i1 %NullCheck16, label %51, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %51
 
 ; <label>:51                                      ; preds = %45
   %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
@@ -6847,15 +8293,15 @@ entry:
 ; <label>:57                                      ; preds = %51
   %58 = load i16*, i16** %arg1
   %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
-  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %60
 
 ; <label>:60                                      ; preds = %57
   %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
   %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
-  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %64
 
 ; <label>:64                                      ; preds = %60
   %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
@@ -6864,22 +8310,22 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
   %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
-  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %70
 
 ; <label>:70                                      ; preds = %64
   %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
   %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
-  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
-  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
   %75 = load i32, i32 addrspace(1)* %74
   %76 = zext i32 %75 to i64
   %77 = trunc i64 %76 to i32
-  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
-  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %78
 
 ; <label>:78                                      ; preds = %73
   %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
@@ -6901,8 +8347,8 @@ entry:
   %90 = bitcast i16* %86 to i8*
   %91 = getelementptr inbounds i8, i8* %90, i64 %89
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %93
 
 ; <label>:93                                      ; preds = %80
   %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
@@ -6912,8 +8358,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %99 = load i32, i32* %loc2
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %100
 
 ; <label>:100                                     ; preds = %93
   %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
@@ -6928,63 +8374,63 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %25
+ThrowNullRef6:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %32
+ThrowNullRef10:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %40
+ThrowNullRef12:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %45
+ThrowNullRef16:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %57
+ThrowNullRef18:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %60
+ThrowNullRef20:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %64
+ThrowNullRef22:                                   ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %70
+ThrowNullRef24:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %73
+ThrowNullRef26:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %80
+ThrowNullRef28:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %93
+ThrowNullRef30:                                   ; preds = %93
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7004,8 +8450,8 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
@@ -7033,43 +8479,43 @@ entry:
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %14
   %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
   %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   %28 = load i32, i32 addrspace(1)* %27, align 8
   %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
-  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %30
 
 ; <label>:30                                      ; preds = %26
   %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
   %32 = load i32, i32 addrspace(1)* %31, align 8
   %33 = add i32 %28, %32
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %34
 
 ; <label>:34                                      ; preds = %30
   %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   store i32 %33, i32 addrspace(1)* %35
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
   store i32 0, i32 addrspace(1)* %38
   %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %40
 
 ; <label>:40                                      ; preds = %37
   %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
@@ -7082,8 +8528,8 @@ entry:
 
 ; <label>:47                                      ; preds = %40
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
@@ -7098,8 +8544,8 @@ entry:
   %54 = load i32, i32* %loc0
   %55 = sext i32 %54 to i64
   %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
-  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %57
 
 ; <label>:57                                      ; preds = %52
   %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
@@ -7110,68 +8556,35 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %14
+ThrowNullRef2:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %23
+ThrowNullRef4:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %26
+ThrowNullRef6:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %30
+ThrowNullRef8:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %34
+ThrowNullRef10:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %47
+ThrowNullRef14:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %52
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-}
-
-INFO:  jitting method StringBuilder::get_Length using LLILCJit
-Successfully read StringBuilder.get_Length
-
-define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.StringBuilder addrspace(1)*
-  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
-  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
-
-; <label>:1                                       ; preds = %entry
-  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %3 = load i32, i32 addrspace(1)* %2, align 8
-  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
-
-; <label>:5                                       ; preds = %1
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = add i32 %3, %7
-  ret i32 %8
-
-ThrowNullRef:                                     ; preds = %entry
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef16:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7213,70 +8626,70 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
   %6 = load i32, i32 addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
   store i32 %6, i32 addrspace(1)* %8
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
   %13 = load i32, i32 addrspace(1)* %12, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
   store i32 %13, i32 addrspace(1)* %15
   %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
-  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %18
 
 ; <label>:18                                      ; preds = %14
   %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
   %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
   %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
   %34 = load i32, i32 addrspace(1)* %33, align 8
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
-  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
@@ -7287,39 +8700,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %28
+ThrowNullRef16:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %32
+ThrowNullRef18:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7455,13 +8868,13 @@ entry:
 ; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
@@ -7477,16 +8890,16 @@ entry:
 
 ; <label>:18                                      ; preds = %15
   %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
   store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
   %22 = load i32, i32* %loc0
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %24
 
 ; <label>:24                                      ; preds = %20
   %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
@@ -7498,13 +8911,13 @@ entry:
 ; <label>:28                                      ; preds = %15, %24
   %29 = load i32, i32* %arg1
   %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %31
   %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
@@ -7517,20 +8930,20 @@ entry:
   %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
-  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
   %46 = load i32, i32 addrspace(1)* %45, align 8
   %47 = sub i32 %40, %46
-  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
-  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i32 addrspace(1)* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %48
 
 ; <label>:48                                      ; preds = %44
   store i32 %47, i32 addrspace(1)* %39, align 8
@@ -7538,21 +8951,21 @@ entry:
 
 ; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
-  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %51
 
 ; <label>:51                                      ; preds = %49
   %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %53
 
 ; <label>:53                                      ; preds = %51
   %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
   %55 = load i32, i32 addrspace(1)* %54, align 8
   %56 = load i32, i32* %arg2
   %57 = sub i32 %55, %56
-  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %58
 
 ; <label>:58                                      ; preds = %53
   %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
@@ -7562,13 +8975,13 @@ entry:
 ; <label>:60                                      ; preds = %33, %58
   %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
   %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
-  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %63
 
 ; <label>:63                                      ; preds = %60
   %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
-  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
-  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
@@ -7578,15 +8991,15 @@ entry:
 
 ; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
-  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i32 addrspace(1)* %69, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %70
 
 ; <label>:70                                      ; preds = %68
   %71 = load i32, i32 addrspace(1)* %69, align 8
   store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
-  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
@@ -7596,8 +9009,8 @@ entry:
   store i32 %77, i32* %loc4
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
-  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %80
 
 ; <label>:80                                      ; preds = %73
   %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
@@ -7607,71 +9020,71 @@ entry:
 ; <label>:83                                      ; preds = %80
   store i32 0, i32* %loc3
   %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
-  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
-  br i1 %NullCheck26, label %88, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i32 addrspace(1)* %87, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %88
 
 ; <label>:88                                      ; preds = %85
   %89 = load i32, i32 addrspace(1)* %87, align 8
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
-  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %90
 
 ; <label>:90                                      ; preds = %88
   %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
   store i32 %89, i32 addrspace(1)* %91
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
-  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
-  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %96
 
 ; <label>:96                                      ; preds = %94
   %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
-  br i1 %NullCheck34, label %100, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %100
 
 ; <label>:100                                     ; preds = %96
   %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
-  br i1 %NullCheck36, label %102, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %102
 
 ; <label>:102                                     ; preds = %100
   %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
   %104 = load i32, i32 addrspace(1)* %103, align 8
   %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
-  br i1 %NullCheck38, label %106, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %106
 
 ; <label>:106                                     ; preds = %102
   %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
-  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
-  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %108
 
 ; <label>:108                                     ; preds = %106
   %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
   %110 = load i32, i32 addrspace(1)* %109, align 8
   %111 = add i32 %104, %110
-  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %112
 
 ; <label>:112                                     ; preds = %108
   %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
   store i32 %111, i32 addrspace(1)* %113
   %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
-  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i32 addrspace(1)* %114, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %115
 
 ; <label>:115                                     ; preds = %112
   %116 = load i32, i32 addrspace(1)* %114, align 8
@@ -7681,19 +9094,19 @@ entry:
 ; <label>:118                                     ; preds = %115
   %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
-  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %121
 
 ; <label>:121                                     ; preds = %118
   %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
-  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
-  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %123
 
 ; <label>:123                                     ; preds = %121
   %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
   %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
-  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
-  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %126
 
 ; <label>:126                                     ; preds = %123
   %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
@@ -7705,8 +9118,8 @@ entry:
 
 ; <label>:130                                     ; preds = %80, %115, %126
   %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %132
 
 ; <label>:132                                     ; preds = %130
   %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7715,8 +9128,8 @@ entry:
   %136 = load i32, i32* %loc3
   %137 = sub i32 %135, %136
   %138 = sub i32 %134, %137
-  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %139
 
 ; <label>:139                                     ; preds = %132
   %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7728,16 +9141,16 @@ entry:
 
 ; <label>:144                                     ; preds = %139
   %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
-  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %146
 
 ; <label>:146                                     ; preds = %144
   %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
   %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
   %149 = load i32, i32* %loc2
   %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
-  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %151
 
 ; <label>:151                                     ; preds = %146
   %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
@@ -7754,145 +9167,249 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %18
+ThrowNullRef4:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %31
+ThrowNullRef10:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %44
+ThrowNullRef16:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %68
+ThrowNullRef18:                                   ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %70
+ThrowNullRef20:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %73
+ThrowNullRef22:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %83
+ThrowNullRef24:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %85
+ThrowNullRef26:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %88
+ThrowNullRef28:                                   ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %90
+ThrowNullRef30:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %94
+ThrowNullRef32:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %96
+ThrowNullRef34:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %100
+ThrowNullRef36:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %102
+ThrowNullRef38:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %106
+ThrowNullRef40:                                   ; preds = %106
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %108
+ThrowNullRef42:                                   ; preds = %108
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %112
+ThrowNullRef44:                                   ; preds = %112
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %118
+ThrowNullRef46:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %121
+ThrowNullRef48:                                   ; preds = %121
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %123
+ThrowNullRef50:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %130
+ThrowNullRef52:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %132
+ThrowNullRef54:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %144
+ThrowNullRef56:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %146
+ThrowNullRef58:                                   ; preds = %146
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %60
+ThrowNullRef60:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %63
+ThrowNullRef62:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %49
+ThrowNullRef64:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %51
+ThrowNullRef66:                                   ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %53
+ThrowNullRef68:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(%"System.Char[]" addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %arg0 = alloca %"System.Char[]" addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store %"System.Char[]" addrspace(1)* %param0, %"System.Char[]" addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load i32, i32* %arg4
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %43, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %38, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg1
+  %13 = load i32, i32* %arg4
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %38, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %24 = load i32, i32* %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %35 = load i32, i32* %arg3
+  %36 = load i32, i32* %arg4
+  %37 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %37, %"System.Char[]" addrspace(1)* %34, i32 %35, i32 %36)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:38                                      ; preds = %5, %16
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Successfully read Buffer._Memmove
 
@@ -7914,7 +9431,7 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[loadElem]
+Failed to read AppDomain.SetDataHelper[storeElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -7923,8 +9440,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
@@ -7934,8 +9451,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
@@ -7947,15 +9464,15 @@ entry:
   %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
   %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
@@ -7966,15 +9483,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7992,7 +9509,79 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
-Failed to read Dictionary`2.TryGetValue[loadElemA]
+Successfully read Dictionary`2.TryGetValue
+
+define i8 @"Dictionary`2.TryGetValue"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)* addrspace(1)* %param2) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  %arg2 = alloca %System.__Canon addrspace(1)* addrspace(1)*
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  store %System.__Canon addrspace(1)* addrspace(1)* %param2, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  store i32 %2, i32* %loc0
+  %3 = load i32, i32* %loc0
+  %4 = icmp slt i32 %3, 0
+  br i1 %4, label %22, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 2
+  %10 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %9, align 8
+  %11 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = zext i32 %11 to i64
+  %BoundsCheck = icmp uge i64 %16, %15
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 3, i32 %11
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %20, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %6, %System.__Canon addrspace(1)* %21)
+  ret i8 1
+
+; <label>:22                                      ; preds = %entry
+  %23 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %23, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -8058,8 +9647,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
@@ -8091,8 +9680,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
@@ -8171,15 +9760,15 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck, label %19, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %ThrowNullRef, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
   %21 = load i32, i32 addrspace(1)* %20
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
@@ -8202,7 +9791,7 @@ ThrowNullRef:                                     ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %19
+ThrowNullRef2:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8248,8 +9837,8 @@ entry:
   %0 = alloca %System.AppDomainHandle
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %1 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %1, i32 0, i32 15
@@ -8269,8 +9858,8 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
@@ -8286,7 +9875,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -8299,8 +9888,8 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -8327,8 +9916,8 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
@@ -8352,8 +9941,8 @@ entry:
   %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
   store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
@@ -8363,8 +9952,8 @@ entry:
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
@@ -8374,8 +9963,8 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %9
   %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
@@ -8384,8 +9973,8 @@ entry:
 
 ; <label>:18                                      ; preds = %3, %16
   %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
@@ -8397,15 +9986,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %18
+ThrowNullRef6:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8418,8 +10007,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
@@ -8453,15 +10042,15 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
@@ -8473,7 +10062,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8481,7 +10070,7 @@ ThrowNullRef1:                                    ; preds = %1
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
 Failed to read Dictionary`2.System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
@@ -8506,8 +10095,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
@@ -8524,8 +10113,8 @@ entry:
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -8544,7 +10133,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8577,8 +10166,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = load i64, i64* %arg2
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = trunc i32 %3 to i8
@@ -8634,46 +10223,46 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
   %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
-  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
-  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
-  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
@@ -8684,27 +10273,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %20
+ThrowNullRef12:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8717,8 +10306,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -8756,22 +10345,22 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
   %9 = load i64, i64 addrspace(1)* %8, align 8
   %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
   %13 = load i64, i64 addrspace(1)* %12, align 8
   %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %11
   %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
@@ -8788,11 +10377,11 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8882,8 +10471,8 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
@@ -8900,8 +10489,8 @@ entry:
 ; <label>:8                                       ; preds = %1
   %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
   %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
@@ -8911,15 +10500,15 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
   %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
   %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
-  br i1 %NullCheck6, label %21, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
@@ -8946,15 +10535,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8992,15 +10581,15 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
   store i8 %3, i8 addrspace(1)* %5
   %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
@@ -9011,7 +10600,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9027,8 +10616,8 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -9041,8 +10630,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
@@ -9058,7 +10647,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9080,8 +10669,8 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
@@ -9096,8 +10685,8 @@ entry:
 ; <label>:12                                      ; preds = %6
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
@@ -9112,8 +10701,8 @@ entry:
 ; <label>:21                                      ; preds = %15
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
@@ -9128,8 +10717,8 @@ entry:
 ; <label>:30                                      ; preds = %24
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %31, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
@@ -9144,8 +10733,8 @@ entry:
 ; <label>:39                                      ; preds = %33
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
-  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %40, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %42
 
 ; <label>:42                                      ; preds = %39
   %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
@@ -9164,19 +10753,19 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %21
+ThrowNullRef4:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %30
+ThrowNullRef6:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %39
+ThrowNullRef8:                                    ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9243,8 +10832,8 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
@@ -9264,57 +10853,57 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
   store i8 0, i8 addrspace(1)* %2
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
   store i8 0, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
   store i8 0, i8 addrspace(1)* %17
   %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
   store i8 0, i8 addrspace(1)* %20
   %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
-  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
@@ -9325,31 +10914,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %19
+ThrowNullRef14:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9367,8 +10956,8 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
@@ -9380,8 +10969,8 @@ entry:
 
 ; <label>:9                                       ; preds = %4
   %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %9
   %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
@@ -9395,7 +10984,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef2:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9420,8 +11009,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
@@ -9512,8 +11101,8 @@ entry:
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
@@ -9524,8 +11113,8 @@ entry:
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = load i64, i64 addrspace(1)* %12
@@ -9537,8 +11126,8 @@ entry:
   %20 = load i64, i64* %19
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
-  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %13
   %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
@@ -9555,8 +11144,8 @@ entry:
 ; <label>:30                                      ; preds = %25
   %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %32 = load i32, i32* %arg2
-  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
-  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
@@ -9570,15 +11159,15 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %30
+ThrowNullRef2:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9622,87 +11211,87 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
   %10 = load i8, i8 addrspace(1)* %9, align 8
   %11 = zext i8 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %8
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
   store i8 %12, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
   %19 = load i8, i8 addrspace(1)* %18, align 8
   %20 = zext i8 %19 to i32
   %21 = trunc i32 %20 to i8
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
   store i8 %21, i8 addrspace(1)* %23
   %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
   %28 = load i8, i8 addrspace(1)* %27, align 8
   %29 = zext i8 %28 to i32
   %30 = trunc i32 %29 to i8
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
-  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %31
 
 ; <label>:31                                      ; preds = %26
   %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
   store i8 %30, i8 addrspace(1)* %32
   %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
-  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
-  br i1 %NullCheck14, label %40, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %40
 
 ; <label>:40                                      ; preds = %35
   %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
   store i8 %39, i8 addrspace(1)* %41
   %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
-  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %44
 
 ; <label>:44                                      ; preds = %40
   %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
   %46 = load i8, i8 addrspace(1)* %45, align 8
   %47 = zext i8 %46 to i32
   %48 = trunc i32 %47 to i8
-  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
   store i8 %48, i8 addrspace(1)* %50
   %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
-  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
@@ -9713,29 +11302,29 @@ entry:
 ; <label>:56                                      ; preds = %52
   %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
-  br i1 %NullCheck22, label %59, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
   %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
   %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
-  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
-  br i1 %NullCheck24, label %63, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
   %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
-  br i1 %NullCheck26, label %66, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
   %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
-  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
-  br i1 %NullCheck28, label %69, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %69
 
 ; <label>:69                                      ; preds = %66
   %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
@@ -9744,15 +11333,15 @@ entry:
 
 ; <label>:71                                      ; preds = %105
   %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
-  br i1 %NullCheck34, label %73, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %73
 
 ; <label>:73                                      ; preds = %71
   %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
   %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
   %76 = load i32, i32* %loc0
-  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
-  br i1 %NullCheck36, label %77, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
@@ -9766,8 +11355,8 @@ entry:
 
 ; <label>:83                                      ; preds = %77
   %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
-  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
@@ -9775,14 +11364,14 @@ entry:
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
   %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
-  br i1 %NullCheck40, label %91, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
 ; <label>:91                                      ; preds = %85
   %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
   %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
-  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck42, label %94, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %94
 
 ; <label>:94                                      ; preds = %91
   %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
@@ -9798,14 +11387,14 @@ entry:
 ; <label>:99                                      ; preds = %69, %96
   %100 = load i32, i32* %loc0
   %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
-  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %102
 
 ; <label>:102                                     ; preds = %99
   %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
   %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
-  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
-  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
@@ -9819,87 +11408,87 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %26
+ThrowNullRef10:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %31
+ThrowNullRef12:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %35
+ThrowNullRef14:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %40
+ThrowNullRef16:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %56
+ThrowNullRef22:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %59
+ThrowNullRef24:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %63
+ThrowNullRef26:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %66
+ThrowNullRef28:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %102
+ThrowNullRef32:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %71
+ThrowNullRef34:                                   ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %73
+ThrowNullRef36:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %83
+ThrowNullRef38:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %85
+ThrowNullRef40:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %91
+ThrowNullRef42:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9943,15 +11532,15 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
   %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
@@ -9961,28 +11550,28 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
   %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %12
   %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
   %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
   %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
-  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
@@ -9993,23 +11582,23 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %12
+ThrowNullRef6:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10031,15 +11620,15 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
   %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = load i64, i64 addrspace(1)* %7
@@ -10077,13 +11666,13 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[loadElem]
+Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -10111,8 +11700,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1

--- a/test/BaseLine/JIT/CodeGenBringUpTests/StructInstMethod.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/StructInstMethod.error.txt
@@ -25,8 +25,8 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
@@ -40,8 +40,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
   %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
@@ -75,7 +75,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -90,8 +90,8 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %NullCheck = icmp ne i8 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = load i8, i8 addrspace(1)* %0, align 8
@@ -125,8 +125,8 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
@@ -159,8 +159,8 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -184,8 +184,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
   store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
@@ -195,8 +195,8 @@ entry:
 ; <label>:4                                       ; preds = %1
   %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
   %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
@@ -206,8 +206,8 @@ entry:
   %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
@@ -221,14 +221,14 @@ entry:
 
 ; <label>:17                                      ; preds = %14
   %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
   %21 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
@@ -238,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -249,8 +249,8 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
@@ -261,27 +261,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %30
+ThrowNullRef10:                                   ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -301,7 +301,89 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
-Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
+Successfully read AppDomainSetup.GetUnsecureApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.GetUnsecureApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %NullCheck = icmp eq %"System.String[]" addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %BoundsCheck = icmp uge i64 0, %5
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %6
+
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 3, i32 0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
+  ret %System.String addrspace(1)* %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_Value using LLILCJit
+Successfully read AppDomainSetup.get_Value
+
+define %"System.String[]" addrspace(1)* @AppDomainSetup.get_Value(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.String[]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 18)
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.String[]" addrspace(1)* addrspace(1)*, %"System.String[]" addrspace(1)*)*)(%"System.String[]" addrspace(1)* addrspace(1)* %9, %"System.String[]" addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %11, i32 0, i32 1
+  %14 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %13, align 8
+  ret %"System.String[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -319,8 +401,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -368,16 +450,16 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
   %5 = load i32, i32 addrspace(1)* %4
   %6 = sub i32 %5, 1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -389,7 +471,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -421,8 +503,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
@@ -456,8 +538,8 @@ entry:
 ; <label>:27                                      ; preds = %19
   %28 = load i32, i32* %arg1
   %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
-  br i1 %NullCheck2, label %30, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %29, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %30
 
 ; <label>:30                                      ; preds = %27
   %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
@@ -493,8 +575,8 @@ entry:
 ; <label>:49                                      ; preds = %46
   %50 = load i32, i32* %arg2
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck4, label %52, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
@@ -517,11 +599,11 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %27
+ThrowNullRef2:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %49
+ThrowNullRef4:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -544,16 +626,16 @@ entry:
   %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %0)
   store %System.String addrspace(1)* %1, %System.String addrspace(1)** %loc0
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 2
   %5 = bitcast [0 x i16] addrspace(1)* %4 to i16 addrspace(1)*
   store i16 addrspace(1)* %5, i16 addrspace(1)** %loc1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %3
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2
@@ -580,7 +662,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -691,15 +773,15 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %NullCheck132 = icmp ne i8* %21, null
-  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+  %NullCheck131 = icmp eq i8* %21, null
+  br i1 %NullCheck131, label %ThrowNullRef132, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = load i8, i8* %21, align 8
   %24 = zext i8 %23 to i32
   %25 = trunc i32 %24 to i8
-  %NullCheck134 = icmp ne i8* %20, null
-  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+  %NullCheck133 = icmp eq i8* %20, null
+  br i1 %NullCheck133, label %ThrowNullRef134, label %26
 
 ; <label>:26                                      ; preds = %22
   store i8 %25, i8* %20, align 8
@@ -709,16 +791,16 @@ entry:
   %28 = load i8*, i8** %arg0
   %29 = load i8*, i8** %arg1
   %30 = bitcast i8* %29 to i16*
-  %NullCheck128 = icmp ne i16* %30, null
-  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+  %NullCheck127 = icmp eq i16* %30, null
+  br i1 %NullCheck127, label %ThrowNullRef128, label %31
 
 ; <label>:31                                      ; preds = %27
   %32 = load i16, i16* %30, align 8
   %33 = sext i16 %32 to i32
   %34 = bitcast i8* %28 to i16*
   %35 = trunc i32 %33 to i16
-  %NullCheck130 = icmp ne i16* %34, null
-  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+  %NullCheck129 = icmp eq i16* %34, null
+  br i1 %NullCheck129, label %ThrowNullRef130, label %36
 
 ; <label>:36                                      ; preds = %31
   store i16 %35, i16* %34, align 8
@@ -728,16 +810,16 @@ entry:
   %38 = load i8*, i8** %arg0
   %39 = load i8*, i8** %arg1
   %40 = bitcast i8* %39 to i16*
-  %NullCheck120 = icmp ne i16* %40, null
-  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+  %NullCheck119 = icmp eq i16* %40, null
+  br i1 %NullCheck119, label %ThrowNullRef120, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i16, i16* %40, align 8
   %43 = sext i16 %42 to i32
   %44 = bitcast i8* %38 to i16*
   %45 = trunc i32 %43 to i16
-  %NullCheck122 = icmp ne i16* %44, null
-  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+  %NullCheck121 = icmp eq i16* %44, null
+  br i1 %NullCheck121, label %ThrowNullRef122, label %46
 
 ; <label>:46                                      ; preds = %41
   store i16 %45, i16* %44, align 8
@@ -745,15 +827,15 @@ entry:
   %48 = getelementptr inbounds i8, i8* %47, i64 2
   %49 = load i8*, i8** %arg1
   %50 = getelementptr inbounds i8, i8* %49, i64 2
-  %NullCheck124 = icmp ne i8* %50, null
-  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+  %NullCheck123 = icmp eq i8* %50, null
+  br i1 %NullCheck123, label %ThrowNullRef124, label %51
 
 ; <label>:51                                      ; preds = %46
   %52 = load i8, i8* %50, align 8
   %53 = zext i8 %52 to i32
   %54 = trunc i32 %53 to i8
-  %NullCheck126 = icmp ne i8* %48, null
-  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+  %NullCheck125 = icmp eq i8* %48, null
+  br i1 %NullCheck125, label %ThrowNullRef126, label %55
 
 ; <label>:55                                      ; preds = %51
   store i8 %54, i8* %48, align 8
@@ -763,14 +845,14 @@ entry:
   %57 = load i8*, i8** %arg0
   %58 = load i8*, i8** %arg1
   %59 = bitcast i8* %58 to i32*
-  %NullCheck116 = icmp ne i32* %59, null
-  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+  %NullCheck115 = icmp eq i32* %59, null
+  br i1 %NullCheck115, label %ThrowNullRef116, label %60
 
 ; <label>:60                                      ; preds = %56
   %61 = load i32, i32* %59, align 8
   %62 = bitcast i8* %57 to i32*
-  %NullCheck118 = icmp ne i32* %62, null
-  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+  %NullCheck117 = icmp eq i32* %62, null
+  br i1 %NullCheck117, label %ThrowNullRef118, label %63
 
 ; <label>:63                                      ; preds = %60
   store i32 %61, i32* %62, align 8
@@ -780,14 +862,14 @@ entry:
   %65 = load i8*, i8** %arg0
   %66 = load i8*, i8** %arg1
   %67 = bitcast i8* %66 to i32*
-  %NullCheck108 = icmp ne i32* %67, null
-  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+  %NullCheck107 = icmp eq i32* %67, null
+  br i1 %NullCheck107, label %ThrowNullRef108, label %68
 
 ; <label>:68                                      ; preds = %64
   %69 = load i32, i32* %67, align 8
   %70 = bitcast i8* %65 to i32*
-  %NullCheck110 = icmp ne i32* %70, null
-  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+  %NullCheck109 = icmp eq i32* %70, null
+  br i1 %NullCheck109, label %ThrowNullRef110, label %71
 
 ; <label>:71                                      ; preds = %68
   store i32 %69, i32* %70, align 8
@@ -795,15 +877,15 @@ entry:
   %73 = getelementptr inbounds i8, i8* %72, i64 4
   %74 = load i8*, i8** %arg1
   %75 = getelementptr inbounds i8, i8* %74, i64 4
-  %NullCheck112 = icmp ne i8* %75, null
-  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+  %NullCheck111 = icmp eq i8* %75, null
+  br i1 %NullCheck111, label %ThrowNullRef112, label %76
 
 ; <label>:76                                      ; preds = %71
   %77 = load i8, i8* %75, align 8
   %78 = zext i8 %77 to i32
   %79 = trunc i32 %78 to i8
-  %NullCheck114 = icmp ne i8* %73, null
-  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+  %NullCheck113 = icmp eq i8* %73, null
+  br i1 %NullCheck113, label %ThrowNullRef114, label %80
 
 ; <label>:80                                      ; preds = %76
   store i8 %79, i8* %73, align 8
@@ -813,14 +895,14 @@ entry:
   %82 = load i8*, i8** %arg0
   %83 = load i8*, i8** %arg1
   %84 = bitcast i8* %83 to i32*
-  %NullCheck100 = icmp ne i32* %84, null
-  br i1 %NullCheck100, label %85, label %ThrowNullRef99
+  %NullCheck99 = icmp eq i32* %84, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %85
 
 ; <label>:85                                      ; preds = %81
   %86 = load i32, i32* %84, align 8
   %87 = bitcast i8* %82 to i32*
-  %NullCheck102 = icmp ne i32* %87, null
-  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+  %NullCheck101 = icmp eq i32* %87, null
+  br i1 %NullCheck101, label %ThrowNullRef102, label %88
 
 ; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
@@ -829,16 +911,16 @@ entry:
   %91 = load i8*, i8** %arg1
   %92 = getelementptr inbounds i8, i8* %91, i64 4
   %93 = bitcast i8* %92 to i16*
-  %NullCheck104 = icmp ne i16* %93, null
-  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+  %NullCheck103 = icmp eq i16* %93, null
+  br i1 %NullCheck103, label %ThrowNullRef104, label %94
 
 ; <label>:94                                      ; preds = %88
   %95 = load i16, i16* %93, align 8
   %96 = sext i16 %95 to i32
   %97 = bitcast i8* %90 to i16*
   %98 = trunc i32 %96 to i16
-  %NullCheck106 = icmp ne i16* %97, null
-  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+  %NullCheck105 = icmp eq i16* %97, null
+  br i1 %NullCheck105, label %ThrowNullRef106, label %99
 
 ; <label>:99                                      ; preds = %94
   store i16 %98, i16* %97, align 8
@@ -848,14 +930,14 @@ entry:
   %101 = load i8*, i8** %arg0
   %102 = load i8*, i8** %arg1
   %103 = bitcast i8* %102 to i32*
-  %NullCheck88 = icmp ne i32* %103, null
-  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+  %NullCheck87 = icmp eq i32* %103, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %104
 
 ; <label>:104                                     ; preds = %100
   %105 = load i32, i32* %103, align 8
   %106 = bitcast i8* %101 to i32*
-  %NullCheck90 = icmp ne i32* %106, null
-  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+  %NullCheck89 = icmp eq i32* %106, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %107
 
 ; <label>:107                                     ; preds = %104
   store i32 %105, i32* %106, align 8
@@ -864,16 +946,16 @@ entry:
   %110 = load i8*, i8** %arg1
   %111 = getelementptr inbounds i8, i8* %110, i64 4
   %112 = bitcast i8* %111 to i16*
-  %NullCheck92 = icmp ne i16* %112, null
-  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+  %NullCheck91 = icmp eq i16* %112, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %113
 
 ; <label>:113                                     ; preds = %107
   %114 = load i16, i16* %112, align 8
   %115 = sext i16 %114 to i32
   %116 = bitcast i8* %109 to i16*
   %117 = trunc i32 %115 to i16
-  %NullCheck94 = icmp ne i16* %116, null
-  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+  %NullCheck93 = icmp eq i16* %116, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %118
 
 ; <label>:118                                     ; preds = %113
   store i16 %117, i16* %116, align 8
@@ -881,15 +963,15 @@ entry:
   %120 = getelementptr inbounds i8, i8* %119, i64 6
   %121 = load i8*, i8** %arg1
   %122 = getelementptr inbounds i8, i8* %121, i64 6
-  %NullCheck96 = icmp ne i8* %122, null
-  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+  %NullCheck95 = icmp eq i8* %122, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %123
 
 ; <label>:123                                     ; preds = %118
   %124 = load i8, i8* %122, align 8
   %125 = zext i8 %124 to i32
   %126 = trunc i32 %125 to i8
-  %NullCheck98 = icmp ne i8* %120, null
-  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+  %NullCheck97 = icmp eq i8* %120, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %127
 
 ; <label>:127                                     ; preds = %123
   store i8 %126, i8* %120, align 8
@@ -899,14 +981,14 @@ entry:
   %129 = load i8*, i8** %arg0
   %130 = load i8*, i8** %arg1
   %131 = bitcast i8* %130 to i64*
-  %NullCheck84 = icmp ne i64* %131, null
-  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+  %NullCheck83 = icmp eq i64* %131, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %132
 
 ; <label>:132                                     ; preds = %128
   %133 = load i64, i64* %131, align 8
   %134 = bitcast i8* %129 to i64*
-  %NullCheck86 = icmp ne i64* %134, null
-  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+  %NullCheck85 = icmp eq i64* %134, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %135
 
 ; <label>:135                                     ; preds = %132
   store i64 %133, i64* %134, align 8
@@ -916,14 +998,14 @@ entry:
   %137 = load i8*, i8** %arg0
   %138 = load i8*, i8** %arg1
   %139 = bitcast i8* %138 to i64*
-  %NullCheck76 = icmp ne i64* %139, null
-  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+  %NullCheck75 = icmp eq i64* %139, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %140
 
 ; <label>:140                                     ; preds = %136
   %141 = load i64, i64* %139, align 8
   %142 = bitcast i8* %137 to i64*
-  %NullCheck78 = icmp ne i64* %142, null
-  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+  %NullCheck77 = icmp eq i64* %142, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %143
 
 ; <label>:143                                     ; preds = %140
   store i64 %141, i64* %142, align 8
@@ -931,15 +1013,15 @@ entry:
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %NullCheck80 = icmp ne i8* %147, null
-  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+  %NullCheck79 = icmp eq i8* %147, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %148
 
 ; <label>:148                                     ; preds = %143
   %149 = load i8, i8* %147, align 8
   %150 = zext i8 %149 to i32
   %151 = trunc i32 %150 to i8
-  %NullCheck82 = icmp ne i8* %145, null
-  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+  %NullCheck81 = icmp eq i8* %145, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %152
 
 ; <label>:152                                     ; preds = %148
   store i8 %151, i8* %145, align 8
@@ -949,14 +1031,14 @@ entry:
   %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
   %156 = bitcast i8* %155 to i64*
-  %NullCheck68 = icmp ne i64* %156, null
-  br i1 %NullCheck68, label %157, label %ThrowNullRef67
+  %NullCheck67 = icmp eq i64* %156, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %157
 
 ; <label>:157                                     ; preds = %153
   %158 = load i64, i64* %156, align 8
   %159 = bitcast i8* %154 to i64*
-  %NullCheck70 = icmp ne i64* %159, null
-  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+  %NullCheck69 = icmp eq i64* %159, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %160
 
 ; <label>:160                                     ; preds = %157
   store i64 %158, i64* %159, align 8
@@ -965,16 +1047,16 @@ entry:
   %163 = load i8*, i8** %arg1
   %164 = getelementptr inbounds i8, i8* %163, i64 8
   %165 = bitcast i8* %164 to i16*
-  %NullCheck72 = icmp ne i16* %165, null
-  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+  %NullCheck71 = icmp eq i16* %165, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %166
 
 ; <label>:166                                     ; preds = %160
   %167 = load i16, i16* %165, align 8
   %168 = sext i16 %167 to i32
   %169 = bitcast i8* %162 to i16*
   %170 = trunc i32 %168 to i16
-  %NullCheck74 = icmp ne i16* %169, null
-  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+  %NullCheck73 = icmp eq i16* %169, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %171
 
 ; <label>:171                                     ; preds = %166
   store i16 %170, i16* %169, align 8
@@ -984,14 +1066,14 @@ entry:
   %173 = load i8*, i8** %arg0
   %174 = load i8*, i8** %arg1
   %175 = bitcast i8* %174 to i64*
-  %NullCheck56 = icmp ne i64* %175, null
-  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+  %NullCheck55 = icmp eq i64* %175, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %176
 
 ; <label>:176                                     ; preds = %172
   %177 = load i64, i64* %175, align 8
   %178 = bitcast i8* %173 to i64*
-  %NullCheck58 = icmp ne i64* %178, null
-  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+  %NullCheck57 = icmp eq i64* %178, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %179
 
 ; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
@@ -1000,16 +1082,16 @@ entry:
   %182 = load i8*, i8** %arg1
   %183 = getelementptr inbounds i8, i8* %182, i64 8
   %184 = bitcast i8* %183 to i16*
-  %NullCheck60 = icmp ne i16* %184, null
-  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+  %NullCheck59 = icmp eq i16* %184, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %185
 
 ; <label>:185                                     ; preds = %179
   %186 = load i16, i16* %184, align 8
   %187 = sext i16 %186 to i32
   %188 = bitcast i8* %181 to i16*
   %189 = trunc i32 %187 to i16
-  %NullCheck62 = icmp ne i16* %188, null
-  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+  %NullCheck61 = icmp eq i16* %188, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %190
 
 ; <label>:190                                     ; preds = %185
   store i16 %189, i16* %188, align 8
@@ -1017,15 +1099,15 @@ entry:
   %192 = getelementptr inbounds i8, i8* %191, i64 10
   %193 = load i8*, i8** %arg1
   %194 = getelementptr inbounds i8, i8* %193, i64 10
-  %NullCheck64 = icmp ne i8* %194, null
-  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+  %NullCheck63 = icmp eq i8* %194, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %195
 
 ; <label>:195                                     ; preds = %190
   %196 = load i8, i8* %194, align 8
   %197 = zext i8 %196 to i32
   %198 = trunc i32 %197 to i8
-  %NullCheck66 = icmp ne i8* %192, null
-  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+  %NullCheck65 = icmp eq i8* %192, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %199
 
 ; <label>:199                                     ; preds = %195
   store i8 %198, i8* %192, align 8
@@ -1035,14 +1117,14 @@ entry:
   %201 = load i8*, i8** %arg0
   %202 = load i8*, i8** %arg1
   %203 = bitcast i8* %202 to i64*
-  %NullCheck48 = icmp ne i64* %203, null
-  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+  %NullCheck47 = icmp eq i64* %203, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %204
 
 ; <label>:204                                     ; preds = %200
   %205 = load i64, i64* %203, align 8
   %206 = bitcast i8* %201 to i64*
-  %NullCheck50 = icmp ne i64* %206, null
-  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+  %NullCheck49 = icmp eq i64* %206, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %207
 
 ; <label>:207                                     ; preds = %204
   store i64 %205, i64* %206, align 8
@@ -1051,14 +1133,14 @@ entry:
   %210 = load i8*, i8** %arg1
   %211 = getelementptr inbounds i8, i8* %210, i64 8
   %212 = bitcast i8* %211 to i32*
-  %NullCheck52 = icmp ne i32* %212, null
-  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+  %NullCheck51 = icmp eq i32* %212, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %213
 
 ; <label>:213                                     ; preds = %207
   %214 = load i32, i32* %212, align 8
   %215 = bitcast i8* %209 to i32*
-  %NullCheck54 = icmp ne i32* %215, null
-  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+  %NullCheck53 = icmp eq i32* %215, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %216
 
 ; <label>:216                                     ; preds = %213
   store i32 %214, i32* %215, align 8
@@ -1068,14 +1150,14 @@ entry:
   %218 = load i8*, i8** %arg0
   %219 = load i8*, i8** %arg1
   %220 = bitcast i8* %219 to i64*
-  %NullCheck36 = icmp ne i64* %220, null
-  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64* %220, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %221
 
 ; <label>:221                                     ; preds = %217
   %222 = load i64, i64* %220, align 8
   %223 = bitcast i8* %218 to i64*
-  %NullCheck38 = icmp ne i64* %223, null
-  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+  %NullCheck37 = icmp eq i64* %223, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %224
 
 ; <label>:224                                     ; preds = %221
   store i64 %222, i64* %223, align 8
@@ -1084,14 +1166,14 @@ entry:
   %227 = load i8*, i8** %arg1
   %228 = getelementptr inbounds i8, i8* %227, i64 8
   %229 = bitcast i8* %228 to i32*
-  %NullCheck40 = icmp ne i32* %229, null
-  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i32* %229, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %230
 
 ; <label>:230                                     ; preds = %224
   %231 = load i32, i32* %229, align 8
   %232 = bitcast i8* %226 to i32*
-  %NullCheck42 = icmp ne i32* %232, null
-  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+  %NullCheck41 = icmp eq i32* %232, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %233
 
 ; <label>:233                                     ; preds = %230
   store i32 %231, i32* %232, align 8
@@ -1099,15 +1181,15 @@ entry:
   %235 = getelementptr inbounds i8, i8* %234, i64 12
   %236 = load i8*, i8** %arg1
   %237 = getelementptr inbounds i8, i8* %236, i64 12
-  %NullCheck44 = icmp ne i8* %237, null
-  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i8* %237, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %238
 
 ; <label>:238                                     ; preds = %233
   %239 = load i8, i8* %237, align 8
   %240 = zext i8 %239 to i32
   %241 = trunc i32 %240 to i8
-  %NullCheck46 = icmp ne i8* %235, null
-  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+  %NullCheck45 = icmp eq i8* %235, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %242
 
 ; <label>:242                                     ; preds = %238
   store i8 %241, i8* %235, align 8
@@ -1117,14 +1199,14 @@ entry:
   %244 = load i8*, i8** %arg0
   %245 = load i8*, i8** %arg1
   %246 = bitcast i8* %245 to i64*
-  %NullCheck24 = icmp ne i64* %246, null
-  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64* %246, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %247
 
 ; <label>:247                                     ; preds = %243
   %248 = load i64, i64* %246, align 8
   %249 = bitcast i8* %244 to i64*
-  %NullCheck26 = icmp ne i64* %249, null
-  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64* %249, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %250
 
 ; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
@@ -1133,14 +1215,14 @@ entry:
   %253 = load i8*, i8** %arg1
   %254 = getelementptr inbounds i8, i8* %253, i64 8
   %255 = bitcast i8* %254 to i32*
-  %NullCheck28 = icmp ne i32* %255, null
-  br i1 %NullCheck28, label %256, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i32* %255, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %256
 
 ; <label>:256                                     ; preds = %250
   %257 = load i32, i32* %255, align 8
   %258 = bitcast i8* %252 to i32*
-  %NullCheck30 = icmp ne i32* %258, null
-  br i1 %NullCheck30, label %259, label %ThrowNullRef29
+  %NullCheck29 = icmp eq i32* %258, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %259
 
 ; <label>:259                                     ; preds = %256
   store i32 %257, i32* %258, align 8
@@ -1149,16 +1231,16 @@ entry:
   %262 = load i8*, i8** %arg1
   %263 = getelementptr inbounds i8, i8* %262, i64 12
   %264 = bitcast i8* %263 to i16*
-  %NullCheck32 = icmp ne i16* %264, null
-  br i1 %NullCheck32, label %265, label %ThrowNullRef31
+  %NullCheck31 = icmp eq i16* %264, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %265
 
 ; <label>:265                                     ; preds = %259
   %266 = load i16, i16* %264, align 8
   %267 = sext i16 %266 to i32
   %268 = bitcast i8* %261 to i16*
   %269 = trunc i32 %267 to i16
-  %NullCheck34 = icmp ne i16* %268, null
-  br i1 %NullCheck34, label %270, label %ThrowNullRef33
+  %NullCheck33 = icmp eq i16* %268, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %270
 
 ; <label>:270                                     ; preds = %265
   store i16 %269, i16* %268, align 8
@@ -1168,14 +1250,14 @@ entry:
   %272 = load i8*, i8** %arg0
   %273 = load i8*, i8** %arg1
   %274 = bitcast i8* %273 to i64*
-  %NullCheck8 = icmp ne i64* %274, null
-  br i1 %NullCheck8, label %275, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64* %274, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %275
 
 ; <label>:275                                     ; preds = %271
   %276 = load i64, i64* %274, align 8
   %277 = bitcast i8* %272 to i64*
-  %NullCheck10 = icmp ne i64* %277, null
-  br i1 %NullCheck10, label %278, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %277, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %278
 
 ; <label>:278                                     ; preds = %275
   store i64 %276, i64* %277, align 8
@@ -1184,14 +1266,14 @@ entry:
   %281 = load i8*, i8** %arg1
   %282 = getelementptr inbounds i8, i8* %281, i64 8
   %283 = bitcast i8* %282 to i32*
-  %NullCheck12 = icmp ne i32* %283, null
-  br i1 %NullCheck12, label %284, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i32* %283, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %284
 
 ; <label>:284                                     ; preds = %278
   %285 = load i32, i32* %283, align 8
   %286 = bitcast i8* %280 to i32*
-  %NullCheck14 = icmp ne i32* %286, null
-  br i1 %NullCheck14, label %287, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i32* %286, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %287
 
 ; <label>:287                                     ; preds = %284
   store i32 %285, i32* %286, align 8
@@ -1200,16 +1282,16 @@ entry:
   %290 = load i8*, i8** %arg1
   %291 = getelementptr inbounds i8, i8* %290, i64 12
   %292 = bitcast i8* %291 to i16*
-  %NullCheck16 = icmp ne i16* %292, null
-  br i1 %NullCheck16, label %293, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i16* %292, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %293
 
 ; <label>:293                                     ; preds = %287
   %294 = load i16, i16* %292, align 8
   %295 = sext i16 %294 to i32
   %296 = bitcast i8* %289 to i16*
   %297 = trunc i32 %295 to i16
-  %NullCheck18 = icmp ne i16* %296, null
-  br i1 %NullCheck18, label %298, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i16* %296, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %298
 
 ; <label>:298                                     ; preds = %293
   store i16 %297, i16* %296, align 8
@@ -1217,15 +1299,15 @@ entry:
   %300 = getelementptr inbounds i8, i8* %299, i64 14
   %301 = load i8*, i8** %arg1
   %302 = getelementptr inbounds i8, i8* %301, i64 14
-  %NullCheck20 = icmp ne i8* %302, null
-  br i1 %NullCheck20, label %303, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i8* %302, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %303
 
 ; <label>:303                                     ; preds = %298
   %304 = load i8, i8* %302, align 8
   %305 = zext i8 %304 to i32
   %306 = trunc i32 %305 to i8
-  %NullCheck22 = icmp ne i8* %300, null
-  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i8* %300, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %307
 
 ; <label>:307                                     ; preds = %303
   store i8 %306, i8* %300, align 8
@@ -1235,14 +1317,14 @@ entry:
   %309 = load i8*, i8** %arg0
   %310 = load i8*, i8** %arg1
   %311 = bitcast i8* %310 to i64*
-  %NullCheck = icmp ne i64* %311, null
-  br i1 %NullCheck, label %312, label %ThrowNullRef
+  %NullCheck = icmp eq i64* %311, null
+  br i1 %NullCheck, label %ThrowNullRef, label %312
 
 ; <label>:312                                     ; preds = %308
   %313 = load i64, i64* %311, align 8
   %314 = bitcast i8* %309 to i64*
-  %NullCheck2 = icmp ne i64* %314, null
-  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64* %314, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %315
 
 ; <label>:315                                     ; preds = %312
   store i64 %313, i64* %314, align 8
@@ -1251,14 +1333,14 @@ entry:
   %318 = load i8*, i8** %arg1
   %319 = getelementptr inbounds i8, i8* %318, i64 8
   %320 = bitcast i8* %319 to i64*
-  %NullCheck4 = icmp ne i64* %320, null
-  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64* %320, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %321
 
 ; <label>:321                                     ; preds = %315
   %322 = load i64, i64* %320, align 8
   %323 = bitcast i8* %317 to i64*
-  %NullCheck6 = icmp ne i64* %323, null
-  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64* %323, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %324
 
 ; <label>:324                                     ; preds = %321
   store i64 %322, i64* %323, align 8
@@ -1286,15 +1368,15 @@ entry:
 ; <label>:338                                     ; preds = %333
   %339 = load i8*, i8** %arg0
   %340 = load i8*, i8** %arg1
-  %NullCheck136 = icmp ne i8* %340, null
-  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+  %NullCheck135 = icmp eq i8* %340, null
+  br i1 %NullCheck135, label %ThrowNullRef136, label %341
 
 ; <label>:341                                     ; preds = %338
   %342 = load i8, i8* %340, align 8
   %343 = zext i8 %342 to i32
   %344 = trunc i32 %343 to i8
-  %NullCheck138 = icmp ne i8* %339, null
-  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+  %NullCheck137 = icmp eq i8* %339, null
+  br i1 %NullCheck137, label %ThrowNullRef138, label %345
 
 ; <label>:345                                     ; preds = %341
   store i8 %344, i8* %339, align 8
@@ -1317,16 +1399,16 @@ entry:
   %357 = load i8*, i8** %arg0
   %358 = load i8*, i8** %arg1
   %359 = bitcast i8* %358 to i16*
-  %NullCheck140 = icmp ne i16* %359, null
-  br i1 %NullCheck140, label %360, label %ThrowNullRef139
+  %NullCheck139 = icmp eq i16* %359, null
+  br i1 %NullCheck139, label %ThrowNullRef140, label %360
 
 ; <label>:360                                     ; preds = %356
   %361 = load i16, i16* %359, align 8
   %362 = sext i16 %361 to i32
   %363 = bitcast i8* %357 to i16*
   %364 = trunc i32 %362 to i16
-  %NullCheck142 = icmp ne i16* %363, null
-  br i1 %NullCheck142, label %365, label %ThrowNullRef141
+  %NullCheck141 = icmp eq i16* %363, null
+  br i1 %NullCheck141, label %ThrowNullRef142, label %365
 
 ; <label>:365                                     ; preds = %360
   store i16 %364, i16* %363, align 8
@@ -1352,14 +1434,14 @@ entry:
   %378 = load i8*, i8** %arg0
   %379 = load i8*, i8** %arg1
   %380 = bitcast i8* %379 to i32*
-  %NullCheck144 = icmp ne i32* %380, null
-  br i1 %NullCheck144, label %381, label %ThrowNullRef143
+  %NullCheck143 = icmp eq i32* %380, null
+  br i1 %NullCheck143, label %ThrowNullRef144, label %381
 
 ; <label>:381                                     ; preds = %377
   %382 = load i32, i32* %380, align 8
   %383 = bitcast i8* %378 to i32*
-  %NullCheck146 = icmp ne i32* %383, null
-  br i1 %NullCheck146, label %384, label %ThrowNullRef145
+  %NullCheck145 = icmp eq i32* %383, null
+  br i1 %NullCheck145, label %ThrowNullRef146, label %384
 
 ; <label>:384                                     ; preds = %381
   store i32 %382, i32* %383, align 8
@@ -1384,14 +1466,14 @@ entry:
   %395 = load i8*, i8** %arg0
   %396 = load i8*, i8** %arg1
   %397 = bitcast i8* %396 to i64*
-  %NullCheck164 = icmp ne i64* %397, null
-  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+  %NullCheck163 = icmp eq i64* %397, null
+  br i1 %NullCheck163, label %ThrowNullRef164, label %398
 
 ; <label>:398                                     ; preds = %394
   %399 = load i64, i64* %397, align 8
   %400 = bitcast i8* %395 to i64*
-  %NullCheck166 = icmp ne i64* %400, null
-  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+  %NullCheck165 = icmp eq i64* %400, null
+  br i1 %NullCheck165, label %ThrowNullRef166, label %401
 
 ; <label>:401                                     ; preds = %398
   store i64 %399, i64* %400, align 8
@@ -1400,14 +1482,14 @@ entry:
   %404 = load i8*, i8** %arg1
   %405 = getelementptr inbounds i8, i8* %404, i64 8
   %406 = bitcast i8* %405 to i64*
-  %NullCheck168 = icmp ne i64* %406, null
-  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+  %NullCheck167 = icmp eq i64* %406, null
+  br i1 %NullCheck167, label %ThrowNullRef168, label %407
 
 ; <label>:407                                     ; preds = %401
   %408 = load i64, i64* %406, align 8
   %409 = bitcast i8* %403 to i64*
-  %NullCheck170 = icmp ne i64* %409, null
-  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+  %NullCheck169 = icmp eq i64* %409, null
+  br i1 %NullCheck169, label %ThrowNullRef170, label %410
 
 ; <label>:410                                     ; preds = %407
   store i64 %408, i64* %409, align 8
@@ -1437,14 +1519,14 @@ entry:
   %425 = load i8*, i8** %arg0
   %426 = load i8*, i8** %arg1
   %427 = bitcast i8* %426 to i64*
-  %NullCheck148 = icmp ne i64* %427, null
-  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+  %NullCheck147 = icmp eq i64* %427, null
+  br i1 %NullCheck147, label %ThrowNullRef148, label %428
 
 ; <label>:428                                     ; preds = %424
   %429 = load i64, i64* %427, align 8
   %430 = bitcast i8* %425 to i64*
-  %NullCheck150 = icmp ne i64* %430, null
-  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+  %NullCheck149 = icmp eq i64* %430, null
+  br i1 %NullCheck149, label %ThrowNullRef150, label %431
 
 ; <label>:431                                     ; preds = %428
   store i64 %429, i64* %430, align 8
@@ -1466,14 +1548,14 @@ entry:
   %441 = load i8*, i8** %arg0
   %442 = load i8*, i8** %arg1
   %443 = bitcast i8* %442 to i32*
-  %NullCheck152 = icmp ne i32* %443, null
-  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+  %NullCheck151 = icmp eq i32* %443, null
+  br i1 %NullCheck151, label %ThrowNullRef152, label %444
 
 ; <label>:444                                     ; preds = %440
   %445 = load i32, i32* %443, align 8
   %446 = bitcast i8* %441 to i32*
-  %NullCheck154 = icmp ne i32* %446, null
-  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+  %NullCheck153 = icmp eq i32* %446, null
+  br i1 %NullCheck153, label %ThrowNullRef154, label %447
 
 ; <label>:447                                     ; preds = %444
   store i32 %445, i32* %446, align 8
@@ -1495,16 +1577,16 @@ entry:
   %457 = load i8*, i8** %arg0
   %458 = load i8*, i8** %arg1
   %459 = bitcast i8* %458 to i16*
-  %NullCheck156 = icmp ne i16* %459, null
-  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+  %NullCheck155 = icmp eq i16* %459, null
+  br i1 %NullCheck155, label %ThrowNullRef156, label %460
 
 ; <label>:460                                     ; preds = %456
   %461 = load i16, i16* %459, align 8
   %462 = sext i16 %461 to i32
   %463 = bitcast i8* %457 to i16*
   %464 = trunc i32 %462 to i16
-  %NullCheck158 = icmp ne i16* %463, null
-  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+  %NullCheck157 = icmp eq i16* %463, null
+  br i1 %NullCheck157, label %ThrowNullRef158, label %465
 
 ; <label>:465                                     ; preds = %460
   store i16 %464, i16* %463, align 8
@@ -1525,15 +1607,15 @@ entry:
 ; <label>:474                                     ; preds = %470
   %475 = load i8*, i8** %arg0
   %476 = load i8*, i8** %arg1
-  %NullCheck160 = icmp ne i8* %476, null
-  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+  %NullCheck159 = icmp eq i8* %476, null
+  br i1 %NullCheck159, label %ThrowNullRef160, label %477
 
 ; <label>:477                                     ; preds = %474
   %478 = load i8, i8* %476, align 8
   %479 = zext i8 %478 to i32
   %480 = trunc i32 %479 to i8
-  %NullCheck162 = icmp ne i8* %475, null
-  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+  %NullCheck161 = icmp eq i8* %475, null
+  br i1 %NullCheck161, label %ThrowNullRef162, label %481
 
 ; <label>:481                                     ; preds = %477
   store i8 %480, i8* %475, align 8
@@ -1553,343 +1635,343 @@ ThrowNullRef:                                     ; preds = %308
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %312
+ThrowNullRef2:                                    ; preds = %312
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %315
+ThrowNullRef4:                                    ; preds = %315
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %321
+ThrowNullRef6:                                    ; preds = %321
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %271
+ThrowNullRef8:                                    ; preds = %271
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %275
+ThrowNullRef10:                                   ; preds = %275
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %278
+ThrowNullRef12:                                   ; preds = %278
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %284
+ThrowNullRef14:                                   ; preds = %284
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %287
+ThrowNullRef16:                                   ; preds = %287
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %293
+ThrowNullRef18:                                   ; preds = %293
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %298
+ThrowNullRef20:                                   ; preds = %298
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %303
+ThrowNullRef22:                                   ; preds = %303
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %243
+ThrowNullRef24:                                   ; preds = %243
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %247
+ThrowNullRef26:                                   ; preds = %247
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %250
+ThrowNullRef28:                                   ; preds = %250
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %256
+ThrowNullRef30:                                   ; preds = %256
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %259
+ThrowNullRef32:                                   ; preds = %259
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %265
+ThrowNullRef34:                                   ; preds = %265
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %217
+ThrowNullRef36:                                   ; preds = %217
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %221
+ThrowNullRef38:                                   ; preds = %221
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %224
+ThrowNullRef40:                                   ; preds = %224
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %230
+ThrowNullRef42:                                   ; preds = %230
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %233
+ThrowNullRef44:                                   ; preds = %233
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %238
+ThrowNullRef46:                                   ; preds = %238
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %200
+ThrowNullRef48:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %204
+ThrowNullRef50:                                   ; preds = %204
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %207
+ThrowNullRef52:                                   ; preds = %207
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %213
+ThrowNullRef54:                                   ; preds = %213
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %172
+ThrowNullRef56:                                   ; preds = %172
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %176
+ThrowNullRef58:                                   ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %179
+ThrowNullRef60:                                   ; preds = %179
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %185
+ThrowNullRef62:                                   ; preds = %185
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %190
+ThrowNullRef64:                                   ; preds = %190
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %195
+ThrowNullRef66:                                   ; preds = %195
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %153
+ThrowNullRef68:                                   ; preds = %153
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %157
+ThrowNullRef70:                                   ; preds = %157
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %160
+ThrowNullRef72:                                   ; preds = %160
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %166
+ThrowNullRef74:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %136
+ThrowNullRef76:                                   ; preds = %136
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %140
+ThrowNullRef78:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %143
+ThrowNullRef80:                                   ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %148
+ThrowNullRef82:                                   ; preds = %148
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %128
+ThrowNullRef84:                                   ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %132
+ThrowNullRef86:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %100
+ThrowNullRef88:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %104
+ThrowNullRef90:                                   ; preds = %104
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %107
+ThrowNullRef92:                                   ; preds = %107
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %113
+ThrowNullRef94:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %118
+ThrowNullRef96:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %123
+ThrowNullRef98:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %81
+ThrowNullRef100:                                  ; preds = %81
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef101:                                  ; preds = %85
+ThrowNullRef102:                                  ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef103:                                  ; preds = %88
+ThrowNullRef104:                                  ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef105:                                  ; preds = %94
+ThrowNullRef106:                                  ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef107:                                  ; preds = %64
+ThrowNullRef108:                                  ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef109:                                  ; preds = %68
+ThrowNullRef110:                                  ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef111:                                  ; preds = %71
+ThrowNullRef112:                                  ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef113:                                  ; preds = %76
+ThrowNullRef114:                                  ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef115:                                  ; preds = %56
+ThrowNullRef116:                                  ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef117:                                  ; preds = %60
+ThrowNullRef118:                                  ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef119:                                  ; preds = %37
+ThrowNullRef120:                                  ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef121:                                  ; preds = %41
+ThrowNullRef122:                                  ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef123:                                  ; preds = %46
+ThrowNullRef124:                                  ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef125:                                  ; preds = %51
+ThrowNullRef126:                                  ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef127:                                  ; preds = %27
+ThrowNullRef128:                                  ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef129:                                  ; preds = %31
+ThrowNullRef130:                                  ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef131:                                  ; preds = %19
+ThrowNullRef132:                                  ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef133:                                  ; preds = %22
+ThrowNullRef134:                                  ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef135:                                  ; preds = %338
+ThrowNullRef136:                                  ; preds = %338
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef137:                                  ; preds = %341
+ThrowNullRef138:                                  ; preds = %341
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef139:                                  ; preds = %356
+ThrowNullRef140:                                  ; preds = %356
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef141:                                  ; preds = %360
+ThrowNullRef142:                                  ; preds = %360
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef143:                                  ; preds = %377
+ThrowNullRef144:                                  ; preds = %377
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef145:                                  ; preds = %381
+ThrowNullRef146:                                  ; preds = %381
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef147:                                  ; preds = %424
+ThrowNullRef148:                                  ; preds = %424
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef149:                                  ; preds = %428
+ThrowNullRef150:                                  ; preds = %428
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef151:                                  ; preds = %440
+ThrowNullRef152:                                  ; preds = %440
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef153:                                  ; preds = %444
+ThrowNullRef154:                                  ; preds = %444
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef155:                                  ; preds = %456
+ThrowNullRef156:                                  ; preds = %456
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef157:                                  ; preds = %460
+ThrowNullRef158:                                  ; preds = %460
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef159:                                  ; preds = %474
+ThrowNullRef160:                                  ; preds = %474
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef161:                                  ; preds = %477
+ThrowNullRef162:                                  ; preds = %477
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef163:                                  ; preds = %394
+ThrowNullRef164:                                  ; preds = %394
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef165:                                  ; preds = %398
+ThrowNullRef166:                                  ; preds = %398
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef167:                                  ; preds = %401
+ThrowNullRef168:                                  ; preds = %401
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef169:                                  ; preds = %407
+ThrowNullRef170:                                  ; preds = %407
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1939,8 +2021,8 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
-  br i1 %NullCheck, label %22, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %ThrowNullRef, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
@@ -1948,8 +2030,8 @@ entry:
   store i32 %24, i32* %loc0
   %25 = load i32, i32* %loc0
   %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %26, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %27
 
 ; <label>:27                                      ; preds = %22
   %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
@@ -1971,7 +2053,7 @@ ThrowNullRef:                                     ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1989,8 +2071,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -2022,15 +2104,15 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2048,16 +2130,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
   %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
   store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %15
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
@@ -2072,8 +2154,8 @@ entry:
   %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
   %29 = ptrtoint i16 addrspace(1)* %28 to i64
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %19
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
@@ -2089,19 +2171,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2114,8 +2196,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
@@ -2128,7 +2210,7 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[loadElem]
+Failed to read AppDomain.PrepareDataForSetup[storeElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
@@ -2202,8 +2284,8 @@ entry:
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
-  br i1 %NullCheck24, label %27, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = load i64, i64 addrspace(1)* %26
@@ -2218,8 +2300,8 @@ entry:
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
-  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
   %41 = load i64, i64 addrspace(1)* %39
@@ -2236,8 +2318,8 @@ entry:
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
-  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
   %54 = load i64, i64 addrspace(1)* %52
@@ -2252,8 +2334,8 @@ entry:
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
   %67 = load i64, i64 addrspace(1)* %65
@@ -2270,8 +2352,8 @@ entry:
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
-  br i1 %NullCheck16, label %79, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
   %80 = load i64, i64 addrspace(1)* %78
@@ -2286,8 +2368,8 @@ entry:
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
-  br i1 %NullCheck18, label %92, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
   %93 = load i64, i64 addrspace(1)* %91
@@ -2304,8 +2386,8 @@ entry:
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
-  br i1 %NullCheck12, label %105, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = load i64, i64 addrspace(1)* %104
@@ -2320,8 +2402,8 @@ entry:
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
-  br i1 %NullCheck14, label %118, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
   %119 = load i64, i64 addrspace(1)* %117
@@ -2337,8 +2419,8 @@ entry:
 
 ; <label>:128                                     ; preds = %20
   %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
-  br i1 %NullCheck4, label %130, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %129, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %130
 
 ; <label>:130                                     ; preds = %128
   %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
@@ -2346,8 +2428,8 @@ entry:
   %133 = load i16, i16 addrspace(1)* %132, align 8
   %134 = zext i16 %133 to i32
   %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
-  br i1 %NullCheck6, label %136, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %135, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %136
 
 ; <label>:136                                     ; preds = %130
   %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
@@ -2360,8 +2442,8 @@ entry:
 
 ; <label>:143                                     ; preds = %136
   %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
-  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %144, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %145
 
 ; <label>:145                                     ; preds = %143
   %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
@@ -2369,8 +2451,8 @@ entry:
   %148 = load i16, i16 addrspace(1)* %147, align 8
   %149 = zext i16 %148 to i32
   %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %150, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %151
 
 ; <label>:151                                     ; preds = %145
   %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
@@ -2388,8 +2470,8 @@ entry:
 
 ; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
-  br i1 %NullCheck, label %163, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %ThrowNullRef, label %163
 
 ; <label>:163                                     ; preds = %161
   %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
@@ -2399,8 +2481,8 @@ entry:
 
 ; <label>:167                                     ; preds = %163
   %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
-  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %168, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %169
 
 ; <label>:169                                     ; preds = %167
   %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
@@ -2432,55 +2514,55 @@ ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %167
+ThrowNullRef2:                                    ; preds = %167
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %128
+ThrowNullRef4:                                    ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %130
+ThrowNullRef6:                                    ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %143
+ThrowNullRef8:                                    ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %145
+ThrowNullRef10:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %102
+ThrowNullRef12:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %105
+ThrowNullRef14:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %76
+ThrowNullRef16:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %79
+ThrowNullRef18:                                   ; preds = %79
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %50
+ThrowNullRef20:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %53
+ThrowNullRef22:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %24
+ThrowNullRef24:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %27
+ThrowNullRef26:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2503,15 +2585,15 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2519,16 +2601,16 @@ entry:
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
   store i32 %8, i32* %loc0
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
   %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
   store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
@@ -2546,16 +2628,16 @@ entry:
 
 ; <label>:23                                      ; preds = %64
   %24 = load i16*, i16** %loc3
-  %NullCheck12 = icmp ne i16* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i16* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
   store i32 %27, i32* %loc5
   %28 = load i16*, i16** %loc4
-  %NullCheck14 = icmp ne i16* %28, null
-  br i1 %NullCheck14, label %29, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %28, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = load i16, i16* %28, align 8
@@ -2620,15 +2702,15 @@ entry:
 
 ; <label>:67                                      ; preds = %64
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
-  br i1 %NullCheck8, label %69, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %68, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %69
 
 ; <label>:69                                      ; preds = %67
   %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
   %71 = load i32, i32 addrspace(1)* %70
   %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
-  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %73
 
 ; <label>:73                                      ; preds = %69
   %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
@@ -2645,31 +2727,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %67
+ThrowNullRef8:                                    ; preds = %67
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %69
+ThrowNullRef10:                                   ; preds = %69
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2710,14 +2792,14 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
   %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
@@ -2730,14 +2812,14 @@ entry:
 
 ; <label>:11                                      ; preds = %4
   %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
   %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
@@ -2749,14 +2831,14 @@ entry:
 
 ; <label>:22                                      ; preds = %16
   %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
   %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
-  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
-  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
@@ -2804,23 +2886,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2836,7 +2918,280 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[loadElem]
+Successfully read RuntimeType.IsAssignableFrom
+
+define i8 @RuntimeType.IsAssignableFrom(%System.RuntimeType addrspace(1)* %param0, %System.Type addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.RuntimeType addrspace(1)*
+  %arg1 = alloca %System.Type addrspace(1)*
+  %loc0 = alloca %System.RuntimeType addrspace(1)*
+  %loc1 = alloca %"System.Type[]" addrspace(1)*
+  %loc2 = alloca i32
+  store %System.RuntimeType addrspace(1)* %param0, %System.RuntimeType addrspace(1)** %this
+  store %System.Type addrspace(1)* %param1, %System.Type addrspace(1)** %arg1
+  %0 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %1 = icmp ne %System.Type addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i8 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %5 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %6 = bitcast %System.Type addrspace(1)* %4 to %System.Object addrspace(1)*
+  %7 = bitcast %System.RuntimeType addrspace(1)* %5 to %System.Object addrspace(1)*
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %6, %System.Object addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %3
+  ret i8 1
+
+; <label>:12                                      ; preds = %3
+  %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 152
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 32
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
+  %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
+  %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
+  store %System.RuntimeType addrspace(1)* %25, %System.RuntimeType addrspace(1)** %loc0
+  %26 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %27 = icmp eq %System.RuntimeType addrspace(1)* %26, null
+  br i1 %27, label %34, label %28
+
+; <label>:28                                      ; preds = %15
+  %29 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %30 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)*)*)(%System.RuntimeType addrspace(1)* %29, %System.RuntimeType addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+; <label>:34                                      ; preds = %15
+  %35 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %36 = call %System.Reflection.Emit.TypeBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Reflection.Emit.TypeBuilder addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %35)
+  %37 = icmp eq %System.Reflection.Emit.TypeBuilder addrspace(1)* %36, null
+  br i1 %37, label %139, label %38
+
+; <label>:38                                      ; preds = %34
+  %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %42
+
+; <label>:42                                      ; preds = %38
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 152
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 40
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
+  %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
+  %53 = zext i8 %52 to i32
+  %54 = icmp eq i32 %53, 0
+  br i1 %54, label %56, label %55
+
+; <label>:55                                      ; preds = %42
+  ret i8 1
+
+; <label>:56                                      ; preds = %42
+  %57 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %58 = bitcast %System.RuntimeType addrspace(1)* %57 to %System.Type addrspace(1)*
+  %59 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %58)
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %64 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.Type addrspace(1)* %63, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = bitcast %System.RuntimeType addrspace(1)* %64 to %System.Type addrspace(1)*
+  %67 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %63, %System.Type addrspace(1)* %66)
+  %68 = zext i8 %67 to i32
+  %69 = trunc i32 %68 to i8
+  ret i8 %69
+
+; <label>:70                                      ; preds = %56
+  %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
+  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %73
+
+; <label>:73                                      ; preds = %70
+  %74 = load i64, i64 addrspace(1)* %72
+  %75 = add i64 %74, 128
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = add i64 %77, 0
+  %79 = inttoptr i64 %78 to i64*
+  %80 = load i64, i64* %79
+  %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
+  %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
+  %83 = call i8 %82(%System.Type addrspace(1)* %81)
+  %84 = zext i8 %83 to i32
+  %85 = icmp eq i32 %84, 0
+  br i1 %85, label %139, label %86
+
+; <label>:86                                      ; preds = %73
+  %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
+  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %89
+
+; <label>:89                                      ; preds = %86
+  %90 = load i64, i64 addrspace(1)* %88
+  %91 = add i64 %90, 128
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = add i64 %93, 24
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
+  %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
+  %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
+  store %"System.Type[]" addrspace(1)* %99, %"System.Type[]" addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %129
+
+; <label>:100                                     ; preds = %132
+  %101 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %102 = load i32, i32* %loc2
+  %NullCheck11 = icmp eq %"System.Type[]" addrspace(1)* %101, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %103
+
+; <label>:103                                     ; preds = %100
+  %104 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 1
+  %105 = load i32, i32 addrspace(1)* %104
+  %106 = zext i32 %105 to i64
+  %107 = zext i32 %102 to i64
+  %BoundsCheck = icmp uge i64 %107, %106
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %108
+
+; <label>:108                                     ; preds = %103
+  %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
+  %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
+  %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
+  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %113
+
+; <label>:113                                     ; preds = %108
+  %114 = load i64, i64 addrspace(1)* %112
+  %115 = add i64 %114, 152
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = add i64 %117, 56
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
+  %123 = zext i8 %122 to i32
+  %124 = icmp ne i32 %123, 0
+  br i1 %124, label %126, label %125
+
+; <label>:125                                     ; preds = %113
+  ret i8 0
+
+; <label>:126                                     ; preds = %113
+  %127 = load i32, i32* %loc2
+  %128 = add i32 %127, 1
+  store i32 %128, i32* %loc2
+  br label %129
+
+; <label>:129                                     ; preds = %89, %126
+  %130 = load i32, i32* %loc2
+  %131 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %NullCheck9 = icmp eq %"System.Type[]" addrspace(1)* %131, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %132
+
+; <label>:132                                     ; preds = %129
+  %133 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %131, i32 0, i32 1
+  %134 = load i32, i32 addrspace(1)* %133
+  %135 = zext i32 %134 to i64
+  %136 = trunc i64 %135 to i32
+  %137 = icmp slt i32 %130, %136
+  br i1 %137, label %100, label %138
+
+; <label>:138                                     ; preds = %132
+  ret i8 1
+
+; <label>:139                                     ; preds = %34, %73
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %129
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %103
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -2893,7 +3248,7 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElem]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -2904,8 +3259,8 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -2997,8 +3352,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
@@ -3059,8 +3414,8 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -3087,8 +3442,8 @@ entry:
 
 ; <label>:17                                      ; preds = %5, %11
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
@@ -3097,8 +3452,8 @@ entry:
 
 ; <label>:22                                      ; preds = %1, %11
   %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
@@ -3109,11 +3464,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %17
+ThrowNullRef2:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %22
+ThrowNullRef4:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3167,15 +3522,15 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
   %15 = load i32, i32 addrspace(1)* %14
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
@@ -3198,7 +3553,7 @@ ThrowNullRef:                                     ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef2:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3232,8 +3587,8 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
@@ -3312,8 +3667,8 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -3327,8 +3682,8 @@ entry:
 ; <label>:5                                       ; preds = %43
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %7 = load i32, i32* %loc1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck6, label %8, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
@@ -3366,8 +3721,8 @@ entry:
 ; <label>:32                                      ; preds = %21, %25
   %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
   %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
-  br i1 %NullCheck8, label %35, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = trunc i32 %34 to i16
@@ -3380,8 +3735,8 @@ entry:
 ; <label>:40                                      ; preds = %1, %35
   %41 = load i32, i32* %loc1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
-  br i1 %NullCheck2, label %43, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %42, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
@@ -3392,8 +3747,8 @@ entry:
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
   %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
-  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
   %51 = load i64, i64 addrspace(1)* %49
@@ -3412,19 +3767,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %40
+ThrowNullRef2:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %47
+ThrowNullRef4:                                    ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %5
+ThrowNullRef6:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %32
+ThrowNullRef8:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3467,8 +3822,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
@@ -3492,11 +3847,391 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(i16* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store i16* %param0, i16** %arg0
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load i32, i32* %arg3
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %42, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %37, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg2
+  %13 = load i32, i32* %arg3
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %37, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %24 = load i32, i32* %arg2
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load i16*, i16** %arg0
+  %35 = load i32, i32* %arg3
+  %36 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %36, i16* %34, i32 %35)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:37                                      ; preds = %5, %16
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %39)
+  %41 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41, %System.String addrspace(1)* %38, %System.String addrspace(1)* %40)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41) #0
+  unreachable
+
+; <label>:42                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
-Failed to read StringBuilder.ToString[loadElemA]
+Successfully read StringBuilder.ToString
+
+define %System.String addrspace(1)* @StringBuilder.ToString(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i16*
+  %loc3 = alloca %"System.Char[]" addrspace(1)*
+  %loc4 = alloca i32
+  %loc5 = alloca i32
+  %loc6 = alloca i16 addrspace(1)*
+  %loc7 = alloca %System.String addrspace(1)*
+  %loc8 = alloca %"System.Char[]" addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %0)
+  %2 = icmp ne i32 %1, 0
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %4
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %6)
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %7)
+  store %System.String addrspace(1)* %8, %System.String addrspace(1)** %loc0
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.Text.StringBuilder addrspace(1)* %9, %System.Text.StringBuilder addrspace(1)** %loc1
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  store %System.String addrspace(1)* %10, %System.String addrspace(1)** %loc7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc7
+  %12 = ptrtoint %System.String addrspace(1)* %11 to i64
+  %13 = icmp eq i64 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %5
+  %15 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %16 = sext i32 %15 to i64
+  %17 = add i64 %12, %16
+  br label %18
+
+; <label>:18                                      ; preds = %5, %14
+  %19 = phi i64 [ %12, %5 ], [ %17, %14 ]
+  %20 = inttoptr i64 %19 to i16*
+  store i16* %20, i16** %loc2
+  br label %21
+
+; <label>:21                                      ; preds = %98, %18
+  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %22, null
+  br i1 %NullCheck, label %ThrowNullRef, label %23
+
+; <label>:23                                      ; preds = %21
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 3
+  %25 = load i32, i32 addrspace(1)* %24, align 8
+  %26 = icmp sle i32 %25, 0
+  br i1 %26, label %96, label %27
+
+; <label>:27                                      ; preds = %23
+  %28 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %28, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %29
+
+; <label>:29                                      ; preds = %27
+  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %28, i32 0, i32 1
+  %31 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %30, align 8
+  store %"System.Char[]" addrspace(1)* %31, %"System.Char[]" addrspace(1)** %loc3
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %33
+
+; <label>:33                                      ; preds = %29
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  store i32 %35, i32* %loc4
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  %39 = load i32, i32 addrspace(1)* %38, align 8
+  store i32 %39, i32* %loc5
+  %40 = load i32, i32* %loc5
+  %41 = load i32, i32* %loc4
+  %42 = add i32 %40, %41
+  %43 = zext i32 %42 to i64
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %45
+
+; <label>:45                                      ; preds = %37
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = sext i32 %47 to i64
+  %49 = icmp sgt i64 %43, %48
+  br i1 %49, label %91, label %50
+
+; <label>:50                                      ; preds = %45
+  %51 = load i32, i32* %loc5
+  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %52, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %53
+
+; <label>:53                                      ; preds = %50
+  %54 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %52, i32 0, i32 1
+  %55 = load i32, i32 addrspace(1)* %54
+  %56 = zext i32 %55 to i64
+  %57 = trunc i64 %56 to i32
+  %58 = icmp ugt i32 %51, %57
+  br i1 %58, label %91, label %59
+
+; <label>:59                                      ; preds = %53
+  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  store %"System.Char[]" addrspace(1)* %60, %"System.Char[]" addrspace(1)** %loc8
+  %61 = icmp eq %"System.Char[]" addrspace(1)* %60, null
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %63, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %64
+
+; <label>:64                                      ; preds = %62
+  %65 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %63, i32 0, i32 1
+  %66 = load i32, i32 addrspace(1)* %65
+  %67 = zext i32 %66 to i64
+  %68 = trunc i64 %67 to i32
+  %69 = icmp ne i32 %68, 0
+  br i1 %69, label %71, label %70
+
+; <label>:70                                      ; preds = %59, %64
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:71                                      ; preds = %64
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %73
+
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %BoundsCheck = icmp uge i64 0, %76
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %77
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %78, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:79                                      ; preds = %70, %77
+  %80 = load i16*, i16** %loc2
+  %81 = load i32, i32* %loc4
+  %82 = sext i32 %81 to i64
+  %83 = mul i64 %82, 2
+  %84 = bitcast i16* %80 to i8*
+  %85 = getelementptr inbounds i8, i8* %84, i64 %83
+  %86 = load i16 addrspace(1)*, i16 addrspace(1)** %loc6
+  %87 = ptrtoint i16 addrspace(1)* %86 to i64
+  %88 = load i32, i32* %loc5
+  %89 = bitcast i8* %85 to i16*
+  %90 = inttoptr i64 %87 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %89, i16* %90, i32 %88)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %96
+
+; <label>:91                                      ; preds = %45, %53
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %94 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %93)
+  %95 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95, %System.String addrspace(1)* %92, %System.String addrspace(1)* %94)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95) #0
+  unreachable
+
+; <label>:96                                      ; preds = %23, %79
+  %97 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %97, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %98
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %97, i32 0, i32 2
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  store %System.Text.StringBuilder addrspace(1)* %100, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %102 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %102, label %21, label %103
+
+; <label>:103                                     ; preds = %98
+  store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc7
+  %104 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  ret %System.String addrspace(1)* %104
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method StringBuilder::get_Length using LLILCJit
+Successfully read StringBuilder.get_Length
+
+define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
+Successfully read RuntimeHelpers.get_OffsetToStringData
+
+define i32 @RuntimeHelpers.get_OffsetToStringData() {
+entry:
+  ret i32 12
+}
+
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
 Successfully read CultureData.CreateCultureData
 
@@ -3514,23 +4249,23 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
   store i8 %4, i8 addrspace(1)* %6
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
@@ -3549,11 +4284,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3566,50 +4301,50 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
   store i32 -1, i32 addrspace(1)* %2
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
   store i32 -1, i32 addrspace(1)* %8
   %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
   store i32 -1, i32 addrspace(1)* %14
   %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
   store i32 -1, i32 addrspace(1)* %17
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
@@ -3623,27 +4358,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3675,7 +4410,136 @@ Failed to read Dictionary`2.Insert[non-const derefAddress]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
 Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
-Failed to read HashHelpers.GetPrime[loadElem]
+Successfully read HashHelpers.GetPrime
+
+define i32 @HashHelpers.GetPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %6, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5, %System.String addrspace(1)* %4)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5) #0
+  unreachable
+
+; <label>:6                                       ; preds = %entry
+  store i32 0, i32* %loc0
+  br label %29
+
+; <label>:7                                       ; preds = %35
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 1296
+  %10 = addrspacecast i8 addrspace(1)* %9 to %"System.Int32[]" addrspace(1)**
+  %11 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %10
+  %12 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Int32[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = zext i32 %15 to i64
+  %17 = zext i32 %12 to i64
+  %BoundsCheck = icmp uge i64 %17, %16
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 3, i32 %12
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  store i32 %20, i32* %loc1
+  %21 = load i32, i32* %loc1
+  %22 = load i32, i32* %arg0
+  %23 = icmp slt i32 %21, %22
+  br i1 %23, label %26, label %24
+
+; <label>:24                                      ; preds = %18
+  %25 = load i32, i32* %loc1
+  ret i32 %25
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %loc0
+  %28 = add i32 %27, 1
+  store i32 %28, i32* %loc0
+  br label %29
+
+; <label>:29                                      ; preds = %6, %26
+  %30 = load i32, i32* %loc0
+  %31 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %32 = getelementptr inbounds i8, i8 addrspace(1)* %31, i64 1296
+  %33 = addrspacecast i8 addrspace(1)* %32 to %"System.Int32[]" addrspace(1)**
+  %34 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %33
+  %NullCheck = icmp eq %"System.Int32[]" addrspace(1)* %34, null
+  br i1 %NullCheck, label %ThrowNullRef, label %35
+
+; <label>:35                                      ; preds = %29
+  %36 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %34, i32 0, i32 1
+  %37 = load i32, i32 addrspace(1)* %36
+  %38 = zext i32 %37 to i64
+  %39 = trunc i64 %38 to i32
+  %40 = icmp slt i32 %30, %39
+  br i1 %40, label %7, label %41
+
+; <label>:41                                      ; preds = %35
+  %42 = load i32, i32* %arg0
+  %43 = or i32 %42, 1
+  store i32 %43, i32* %loc2
+  br label %59
+
+; <label>:44                                      ; preds = %59
+  %45 = load i32, i32* %loc2
+  %46 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %45)
+  %47 = zext i8 %46 to i32
+  %48 = icmp eq i32 %47, 0
+  br i1 %48, label %56, label %49
+
+; <label>:49                                      ; preds = %44
+  %50 = load i32, i32* %loc2
+  %51 = sub i32 %50, 1
+  %52 = srem i32 %51, 101
+  %53 = icmp eq i32 %52, 0
+  br i1 %53, label %56, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = load i32, i32* %loc2
+  ret i32 %55
+
+; <label>:56                                      ; preds = %44, %49
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %57, 2
+  store i32 %58, i32* %loc2
+  br label %59
+
+; <label>:59                                      ; preds = %41, %56
+  %60 = load i32, i32* %loc2
+  %61 = icmp slt i32 %60, 2147483647
+  br i1 %61, label %44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load i32, i32* %arg0
+  ret i32 %63
+
+ThrowNullRef:                                     ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
 Successfully read GenericEqualityComparer`1.GetHashCode
 
@@ -3694,14 +4558,14 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
   %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load i64, i64 addrspace(1)* %7
@@ -3720,7 +4584,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3750,8 +4614,8 @@ entry:
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
@@ -3796,8 +4660,8 @@ entry:
   %35 = bitcast i16* %34 to i8*
   %36 = getelementptr inbounds i8, i8* %35, i64 2
   %37 = bitcast i8* %36 to i16*
-  %NullCheck4 = icmp ne i16* %37, null
-  br i1 %NullCheck4, label %38, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %37, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %38
 
 ; <label>:38                                      ; preds = %27
   %39 = load i16, i16* %37, align 8
@@ -3824,8 +4688,8 @@ entry:
 
 ; <label>:54                                      ; preds = %22, %43
   %55 = load i16*, i16** %loc4
-  %NullCheck2 = icmp ne i16* %55, null
-  br i1 %NullCheck2, label %56, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i16* %55, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %56
 
 ; <label>:56                                      ; preds = %54
   %57 = load i16, i16* %55, align 8
@@ -3850,11 +4714,11 @@ ThrowNullRef:                                     ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %54
+ThrowNullRef2:                                    ; preds = %54
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %27
+ThrowNullRef4:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3871,8 +4735,8 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -3907,8 +4771,8 @@ entry:
 
 ; <label>:26                                      ; preds = %19
   %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
-  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %28
 
 ; <label>:28                                      ; preds = %26
   %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
@@ -3920,7 +4784,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3972,8 +4836,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
@@ -3984,26 +4848,26 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
-  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
@@ -4014,8 +4878,8 @@ entry:
 ; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
@@ -4024,8 +4888,8 @@ entry:
 
 ; <label>:25                                      ; preds = %1, %16, %23
   %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
-  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
@@ -4036,27 +4900,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %20
+ThrowNullRef10:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4069,8 +4933,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -4081,8 +4945,8 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
@@ -4091,8 +4955,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1, %8
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
@@ -4103,11 +4967,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4128,24 +4992,24 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   store i32 %3, i32* %loc0
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
   %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
   store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck4, label %9, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
@@ -4164,15 +5028,15 @@ entry:
 ; <label>:18                                      ; preds = %70
   %19 = load i16*, i16** %loc3
   %20 = bitcast i16* %19 to i64*
-  %NullCheck10 = icmp ne i64* %20, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %20, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = load i64, i64* %20, align 8
   %23 = load i16*, i16** %loc4
   %24 = bitcast i16* %23 to i64*
-  %NullCheck12 = icmp ne i64* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = load i64, i64* %24, align 8
@@ -4188,8 +5052,8 @@ entry:
   %31 = bitcast i16* %30 to i8*
   %32 = getelementptr inbounds i8, i8* %31, i64 8
   %33 = bitcast i8* %32 to i64*
-  %NullCheck14 = icmp ne i64* %33, null
-  br i1 %NullCheck14, label %34, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = load i64, i64* %33, align 8
@@ -4197,8 +5061,8 @@ entry:
   %37 = bitcast i16* %36 to i8*
   %38 = getelementptr inbounds i8, i8* %37, i64 8
   %39 = bitcast i8* %38 to i64*
-  %NullCheck16 = icmp ne i64* %39, null
-  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %40
 
 ; <label>:40                                      ; preds = %34
   %41 = load i64, i64* %39, align 8
@@ -4214,8 +5078,8 @@ entry:
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %NullCheck18 = icmp ne i64* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = load i64, i64* %48, align 8
@@ -4223,8 +5087,8 @@ entry:
   %52 = bitcast i16* %51 to i8*
   %53 = getelementptr inbounds i8, i8* %52, i64 16
   %54 = bitcast i8* %53 to i64*
-  %NullCheck20 = icmp ne i64* %54, null
-  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64* %54, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %55
 
 ; <label>:55                                      ; preds = %49
   %56 = load i64, i64* %54, align 8
@@ -4262,15 +5126,15 @@ entry:
 ; <label>:74                                      ; preds = %95
   %75 = load i16*, i16** %loc3
   %76 = bitcast i16* %75 to i32*
-  %NullCheck6 = icmp ne i32* %76, null
-  br i1 %NullCheck6, label %77, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32* %76, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %77
 
 ; <label>:77                                      ; preds = %74
   %78 = load i32, i32* %76, align 8
   %79 = load i16*, i16** %loc4
   %80 = bitcast i16* %79 to i32*
-  %NullCheck8 = icmp ne i32* %80, null
-  br i1 %NullCheck8, label %81, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i32* %80, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %81
 
 ; <label>:81                                      ; preds = %77
   %82 = load i32, i32* %80, align 8
@@ -4318,43 +5182,43 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %74
+ThrowNullRef6:                                    ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %77
+ThrowNullRef8:                                    ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %29
+ThrowNullRef14:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %34
+ThrowNullRef16:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4376,8 +5240,8 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load i64, i64 addrspace(1)* %4
@@ -4389,8 +5253,8 @@ entry:
   %12 = load i64, i64* %11
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %5
   %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
@@ -4399,8 +5263,8 @@ entry:
   %18 = load i8, i8* %arg2
   %19 = zext i8 %18 to i32
   %20 = trunc i32 %19 to i8
-  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %15
   %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
@@ -4411,11 +5275,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4442,8 +5306,8 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
@@ -4466,16 +5330,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
   %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = load i64, i64 addrspace(1)* %19
@@ -4500,8 +5364,8 @@ entry:
 ; <label>:35                                      ; preds = %30
   %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
@@ -4514,8 +5378,8 @@ entry:
 
 ; <label>:42                                      ; preds = %1, %38
   %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
-  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
@@ -4526,19 +5390,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %35
+ThrowNullRef2:                                    ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %42
+ThrowNullRef8:                                    ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4551,14 +5415,14 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
@@ -4570,7 +5434,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4583,8 +5447,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
@@ -4613,51 +5477,51 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
   %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
   %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
   %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
   %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
-  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
   store i64 %21, i64 addrspace(1)* %23
   %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %25 = load i64, i64* %loc0
-  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
@@ -4668,27 +5532,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %22
+ThrowNullRef12:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4701,8 +5565,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
@@ -4713,19 +5577,19 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
@@ -4734,8 +5598,8 @@ entry:
 
 ; <label>:15                                      ; preds = %1, %13
   %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
@@ -4746,19 +5610,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %15
+ThrowNullRef8:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4771,8 +5635,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -4831,8 +5695,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
@@ -4882,8 +5746,8 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
-  br i1 %NullCheck, label %17, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %ThrowNullRef, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
@@ -4894,15 +5758,15 @@ entry:
 
 ; <label>:22                                      ; preds = %17
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
-  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
   %26 = load i32, i32 addrspace(1)* %25
   %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
-  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %27, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
@@ -4925,8 +5789,8 @@ entry:
 ; <label>:40                                      ; preds = %17
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
-  br i1 %NullCheck6, label %43, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %41, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
@@ -4938,34 +5802,17 @@ ThrowNullRef:                                     ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %24
+ThrowNullRef4:                                    ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %40
+ThrowNullRef6:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
-}
-
-INFO:  jitting method Object::ReferenceEquals using LLILCJit
-Successfully read Object.ReferenceEquals
-
-define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
-entry:
-  %arg0 = alloca %System.Object addrspace(1)*
-  %arg1 = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
-  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
-  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = icmp eq %System.Object addrspace(1)* %0, %1
-  %3 = sext i1 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
 }
 
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
@@ -4978,21 +5825,21 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
   %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
-  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
@@ -5007,28 +5854,28 @@ entry:
 ; <label>:13                                      ; preds = %8, %12
   %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
   %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
   %21 = load i32, i32 addrspace(1)* %20, align 8
   %22 = add i32 %21, 1
-  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
   store i32 %22, i32 addrspace(1)* %24
   %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
@@ -5039,27 +5886,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5077,7 +5924,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::Setup using LLILCJit
-Failed to read AppDomain.Setup[loadElem]
+Failed to read AppDomain.Setup[unbox]
 INFO:  jitting method Thread::GetDomain using LLILCJit
 Successfully read Thread.GetDomain
 
@@ -5108,8 +5955,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
@@ -5122,14 +5969,14 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
   %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
@@ -5141,11 +5988,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5173,8 +6020,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -5189,7 +6036,328 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
 Failed to read KeyCollection.System.Collections.Generic.IEnumerable<TKey>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Successfully read Enumerator.MoveNext
+
+define i8 @Enumerator.MoveNext(%"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.RuntimeTypeHandle* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*
+  %"$TypeArg" = alloca %System.RuntimeTypeHandle*
+  store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
+  %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 8
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %76, label %12
+
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
+  br label %76
+
+; <label>:13                                      ; preds = %85
+  %14 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck19 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %15
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, i32 0, i32 0
+  %17 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %16, align 8
+  %NullCheck21 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, i32 0, i32 2
+  %20 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %19, align 8
+  %21 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck23 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %22
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, i32 0, i32 2
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %NullCheck25 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 3, i32 %24
+  %NullCheck27 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %32
+
+; <label>:32                                      ; preds = %30
+  %33 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, i32 0, i32 2
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = icmp slt i32 %34, 0
+  br i1 %35, label %68, label %36
+
+; <label>:36                                      ; preds = %32
+  %37 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %38 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck29 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %39
+
+; <label>:39                                      ; preds = %36
+  %40 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, i32 0, i32 0
+  %41 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %40, align 8
+  %NullCheck31 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, i32 0, i32 2
+  %44 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %43, align 8
+  %45 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck33 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, i32 0, i32 2
+  %48 = load i32, i32 addrspace(1)* %47, align 8
+  %NullCheck35 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %49
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = zext i32 %51 to i64
+  %53 = zext i32 %48 to i64
+  %BoundsCheck37 = icmp uge i64 %53, %52
+  br i1 %BoundsCheck37, label %ThrowIndexOutOfRange38, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 3, i32 %48
+  %NullCheck39 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %56
+
+; <label>:56                                      ; preds = %54
+  %57 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, i32 0, i32 0
+  %58 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck41 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %59
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %60, %System.__Canon addrspace(1)* %58)
+  %61 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck43 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  %64 = load i32, i32 addrspace(1)* %63, align 8
+  %65 = add i32 %64, 1
+  %NullCheck45 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  store i32 %65, i32 addrspace(1)* %67
+  ret i8 1
+
+; <label>:68                                      ; preds = %32
+  %69 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck47 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %73 = add i32 %72, 1
+  %NullCheck49 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %74
+
+; <label>:74                                      ; preds = %70
+  %75 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  store i32 %73, i32 addrspace(1)* %75
+  br label %76
+
+; <label>:76                                      ; preds = %8, %12, %74
+  %77 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %78
+
+; <label>:78                                      ; preds = %76
+  %79 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, i32 0, i32 2
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck7 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %82
+
+; <label>:82                                      ; preds = %78
+  %83 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, i32 0, i32 0
+  %84 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %83, align 8
+  %NullCheck9 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %85
+
+; <label>:85                                      ; preds = %82
+  %86 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, i32 0, i32 7
+  %87 = load i32, i32 addrspace(1)* %86, align 8
+  %88 = icmp ult i32 %80, %87
+  br i1 %88, label %13, label %89
+
+; <label>:89                                      ; preds = %85
+  %90 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %91 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck11 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %92
+
+; <label>:92                                      ; preds = %89
+  %93 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, i32 0, i32 0
+  %94 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck13 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %95
+
+; <label>:95                                      ; preds = %92
+  %96 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, i32 0, i32 7
+  %97 = load i32, i32 addrspace(1)* %96, align 8
+  %98 = add i32 %97, 1
+  %NullCheck15 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %99
+
+; <label>:99                                      ; preds = %95
+  %100 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, i32 0, i32 2
+  store i32 %98, i32 addrspace(1)* %100
+  %101 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck17 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %102
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %103, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %92
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef22:                                   ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef24:                                   ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef26:                                   ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef28:                                   ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef30:                                   ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef32:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef34:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef36:                                   ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange38:                           ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef40:                                   ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef42:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef44:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef46:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef48:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef50:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -5200,8 +6368,8 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -5232,9 +6400,9 @@ Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
 Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
-Failed to read String.MakeSeparatorList[loadElemA]
+Failed to read String.MakeSeparatorList[storeElem]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
-Failed to read String.InternalSplitKeepEmptyEntries[loadElem]
+Failed to read String.InternalSplitKeepEmptyEntries[storeElem]
 INFO:  jitting method Path::IsRelative using LLILCJit
 Successfully read Path.IsRelative
 
@@ -5243,8 +6411,8 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -5254,8 +6422,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
@@ -5271,8 +6439,8 @@ entry:
 
 ; <label>:17                                      ; preds = %7
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
@@ -5288,8 +6456,8 @@ entry:
 
 ; <label>:29                                      ; preds = %19
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %31
 
 ; <label>:31                                      ; preds = %29
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
@@ -5300,8 +6468,8 @@ entry:
 
 ; <label>:36                                      ; preds = %31
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
-  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %37, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
@@ -5312,8 +6480,8 @@ entry:
 
 ; <label>:43                                      ; preds = %31, %38
   %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
-  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %45
 
 ; <label>:45                                      ; preds = %43
   %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
@@ -5324,8 +6492,8 @@ entry:
 
 ; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %50
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
@@ -5336,8 +6504,8 @@ entry:
 
 ; <label>:57                                      ; preds = %1, %7, %19, %45, %52
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
-  br i1 %NullCheck14, label %59, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %59
 
 ; <label>:59                                      ; preds = %57
   %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
@@ -5347,8 +6515,8 @@ entry:
 
 ; <label>:63                                      ; preds = %59
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
@@ -5359,8 +6527,8 @@ entry:
 
 ; <label>:70                                      ; preds = %65
   %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
-  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.String addrspace(1)* %71, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %72
 
 ; <label>:72                                      ; preds = %70
   %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
@@ -5379,39 +6547,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %17
+ThrowNullRef4:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %29
+ThrowNullRef6:                                    ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %36
+ThrowNullRef8:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %43
+ThrowNullRef10:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %50
+ThrowNullRef12:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %57
+ThrowNullRef14:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %63
+ThrowNullRef16:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %70
+ThrowNullRef18:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5419,7 +6587,293 @@ ThrowNullRef17:                                   ; preds = %70
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
-Failed to read String.TrimHelper[loadElem]
+Successfully read String.TrimHelper
+
+define %System.String addrspace(1)* @String.TrimHelper(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i16
+  %loc4 = alloca i32
+  %loc5 = alloca i16
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = sub i32 %3, 1
+  store i32 %4, i32* %loc0
+  store i32 0, i32* %loc1
+  %5 = load i32, i32* %arg2
+  %6 = icmp eq i32 %5, 1
+  br i1 %6, label %62, label %7
+
+; <label>:7                                       ; preds = %1
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:8                                       ; preds = %58
+  store i32 0, i32* %loc2
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load i32, i32* %loc1
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2, i32 %10
+  %13 = load i16, i16 addrspace(1)* %12
+  %14 = zext i16 %13 to i32
+  %15 = trunc i32 %14 to i16
+  store i16 %15, i16* %loc3
+  store i32 0, i32* %loc2
+  br label %34
+
+; <label>:16                                      ; preds = %37
+  %17 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %18 = load i32, i32* %loc2
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %17, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %19
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = zext i32 %18 to i64
+  %BoundsCheck = icmp uge i64 %23, %22
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %24
+
+; <label>:24                                      ; preds = %19
+  %25 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 3, i32 %18
+  %26 = load i16, i16 addrspace(1)* %25, align 8
+  %27 = zext i16 %26 to i32
+  %28 = load i16, i16* %loc3
+  %29 = zext i16 %28 to i32
+  %30 = icmp eq i32 %27, %29
+  br i1 %30, label %43, label %31
+
+; <label>:31                                      ; preds = %24
+  %32 = load i32, i32* %loc2
+  %33 = add i32 %32, 1
+  store i32 %33, i32* %loc2
+  br label %34
+
+; <label>:34                                      ; preds = %11, %31
+  %35 = load i32, i32* %loc2
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = icmp slt i32 %35, %41
+  br i1 %42, label %16, label %43
+
+; <label>:43                                      ; preds = %24, %37
+  %44 = load i32, i32* %loc2
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %45, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp eq i32 %44, %50
+  br i1 %51, label %62, label %52
+
+; <label>:52                                      ; preds = %46
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %7, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %57, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %58
+
+; <label>:58                                      ; preds = %55
+  %59 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %60 = load i32, i32 addrspace(1)* %59
+  %61 = icmp slt i32 %56, %60
+  br i1 %61, label %8, label %62
+
+; <label>:62                                      ; preds = %1, %46, %58
+  %63 = load i32, i32* %arg2
+  %64 = icmp eq i32 %63, 0
+  br i1 %64, label %122, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %66, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %67
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %66, i32 0, i32 1
+  %69 = load i32, i32 addrspace(1)* %68
+  %70 = sub i32 %69, 1
+  store i32 %70, i32* %loc0
+  br label %118
+
+; <label>:71                                      ; preds = %118
+  store i32 0, i32* %loc4
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %73 = load i32, i32* %loc0
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %74
+
+; <label>:74                                      ; preds = %71
+  %75 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 2, i32 %73
+  %76 = load i16, i16 addrspace(1)* %75
+  %77 = zext i16 %76 to i32
+  %78 = trunc i32 %77 to i16
+  store i16 %78, i16* %loc5
+  store i32 0, i32* %loc4
+  br label %97
+
+; <label>:79                                      ; preds = %100
+  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %81 = load i32, i32* %loc4
+  %NullCheck19 = icmp eq %"System.Char[]" addrspace(1)* %80, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
+
+; <label>:82                                      ; preds = %79
+  %83 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 1
+  %84 = load i32, i32 addrspace(1)* %83
+  %85 = zext i32 %84 to i64
+  %86 = zext i32 %81 to i64
+  %BoundsCheck21 = icmp uge i64 %86, %85
+  br i1 %BoundsCheck21, label %ThrowIndexOutOfRange22, label %87
+
+; <label>:87                                      ; preds = %82
+  %88 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 3, i32 %81
+  %89 = load i16, i16 addrspace(1)* %88, align 8
+  %90 = zext i16 %89 to i32
+  %91 = load i16, i16* %loc5
+  %92 = zext i16 %91 to i32
+  %93 = icmp eq i32 %90, %92
+  br i1 %93, label %106, label %94
+
+; <label>:94                                      ; preds = %87
+  %95 = load i32, i32* %loc4
+  %96 = add i32 %95, 1
+  store i32 %96, i32* %loc4
+  br label %97
+
+; <label>:97                                      ; preds = %74, %94
+  %98 = load i32, i32* %loc4
+  %99 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck15 = icmp eq %"System.Char[]" addrspace(1)* %99, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %100
+
+; <label>:100                                     ; preds = %97
+  %101 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %99, i32 0, i32 1
+  %102 = load i32, i32 addrspace(1)* %101
+  %103 = zext i32 %102 to i64
+  %104 = trunc i64 %103 to i32
+  %105 = icmp slt i32 %98, %104
+  br i1 %105, label %79, label %106
+
+; <label>:106                                     ; preds = %87, %100
+  %107 = load i32, i32* %loc4
+  %108 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck17 = icmp eq %"System.Char[]" addrspace(1)* %108, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %109
+
+; <label>:109                                     ; preds = %106
+  %110 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %108, i32 0, i32 1
+  %111 = load i32, i32 addrspace(1)* %110
+  %112 = zext i32 %111 to i64
+  %113 = trunc i64 %112 to i32
+  %114 = icmp eq i32 %107, %113
+  br i1 %114, label %122, label %115
+
+; <label>:115                                     ; preds = %109
+  %116 = load i32, i32* %loc0
+  %117 = sub i32 %116, 1
+  store i32 %117, i32* %loc0
+  br label %118
+
+; <label>:118                                     ; preds = %67, %115
+  %119 = load i32, i32* %loc0
+  %120 = load i32, i32* %loc1
+  %121 = icmp sge i32 %119, %120
+  br i1 %121, label %71, label %122
+
+; <label>:122                                     ; preds = %62, %109, %118
+  %123 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %124 = load i32, i32* %loc1
+  %125 = load i32, i32* %loc0
+  %126 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %123, i32 %124, i32 %125)
+  ret %System.String addrspace(1)* %126
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %97
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange22:                           ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
 Successfully read String.CreateTrimmedString
 
@@ -5439,8 +6893,8 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
@@ -5535,8 +6989,8 @@ entry:
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i64 2872
   %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
   %8 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %7
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %3
   %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
@@ -5553,8 +7007,8 @@ entry:
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 2864
   %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
   %21 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %20
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
-  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %22
 
 ; <label>:22                                      ; preds = %16
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
@@ -5569,7 +7023,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %16
+ThrowNullRef2:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5586,8 +7040,8 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5613,8 +7067,8 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
@@ -5632,8 +7086,8 @@ entry:
 
 ; <label>:12                                      ; preds = %4
   %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
@@ -5644,8 +7098,8 @@ entry:
 
 ; <label>:19                                      ; preds = %14
   %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %19
   %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
@@ -5660,21 +7114,21 @@ entry:
   %31 = zext i16 %30 to i32
   %32 = bitcast i8* %29 to i16*
   %33 = trunc i32 %31 to i16
-  %NullCheck6 = icmp ne i16* %32, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i16* %32, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %21
   store i16 %33, i16* %32, align 8
   %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %36
 
 ; <label>:36                                      ; preds = %34
   %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
   %38 = load i32, i32 addrspace(1)* %37, align 8
   %39 = add i32 %38, 1
-  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %40
 
 ; <label>:40                                      ; preds = %36
   %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
@@ -5683,16 +7137,16 @@ entry:
 
 ; <label>:42                                      ; preds = %14
   %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
-  br i1 %NullCheck12, label %44, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
   %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
   %47 = load i16, i16* %arg1
   %48 = zext i16 %47 to i32
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = trunc i32 %48 to i16
@@ -5703,31 +7157,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %19
+ThrowNullRef4:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %21
+ThrowNullRef6:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %36
+ThrowNullRef10:                                   ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %42
+ThrowNullRef12:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %44
+ThrowNullRef14:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5740,8 +7194,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -5752,8 +7206,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
@@ -5762,14 +7216,14 @@ entry:
 
 ; <label>:11                                      ; preds = %1
   %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
@@ -5779,15 +7233,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5808,8 +7262,8 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5822,8 +7276,8 @@ entry:
 
 ; <label>:8                                       ; preds = %3
   %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
@@ -5842,15 +7296,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
-  br i1 %NullCheck4, label %22, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
   %24 = load i16*, i16* addrspace(1)* %23, align 8
   %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %25, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
@@ -5859,8 +7313,8 @@ entry:
   store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
@@ -5874,8 +7328,8 @@ entry:
 
 ; <label>:37                                      ; preds = %65
   %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %37
   %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
@@ -5886,16 +7340,16 @@ entry:
   %45 = bitcast i16* %41 to i8*
   %46 = getelementptr inbounds i8, i8* %45, i64 %44
   %47 = bitcast i8* %46 to i16*
-  %NullCheck14 = icmp ne i16* %47, null
-  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %47, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %48
 
 ; <label>:48                                      ; preds = %39
   %49 = load i16, i16* %47, align 8
   %50 = zext i16 %49 to i32
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %52 = load i32, i32* %loc1
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %53
 
 ; <label>:53                                      ; preds = %48
   %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
@@ -5916,8 +7370,8 @@ entry:
 ; <label>:62                                      ; preds = %36, %59
   %63 = load i32, i32* %loc1
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck10, label %65, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %65
 
 ; <label>:65                                      ; preds = %62
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
@@ -5936,15 +7390,15 @@ entry:
 
 ; <label>:74                                      ; preds = %70
   %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
-  br i1 %NullCheck18, label %76, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %76
 
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
   %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
-  br i1 %NullCheck20, label %80, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
   %81 = load i64, i64 addrspace(1)* %79
@@ -5958,8 +7412,8 @@ entry:
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
   %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
-  br i1 %NullCheck22, label %92, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.String addrspace(1)* %90, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %92
 
 ; <label>:92                                      ; preds = %80
   %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
@@ -5969,15 +7423,15 @@ entry:
 
 ; <label>:96                                      ; preds = %70
   %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
-  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %98
 
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
   %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
-  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
   %103 = load i64, i64 addrspace(1)* %101
@@ -5991,8 +7445,8 @@ entry:
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
   %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
-  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.String addrspace(1)* %112, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %114
 
 ; <label>:114                                     ; preds = %102
   %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
@@ -6004,59 +7458,59 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %20
+ThrowNullRef4:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %22
+ThrowNullRef6:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %26
+ThrowNullRef8:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %62
+ThrowNullRef10:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %48
+ThrowNullRef16:                                   ; preds = %48
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %74
+ThrowNullRef18:                                   ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %76
+ThrowNullRef20:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %80
+ThrowNullRef22:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %96
+ThrowNullRef24:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %98
+ThrowNullRef26:                                   ; preds = %98
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %102
+ThrowNullRef28:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6069,15 +7523,15 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
   %3 = load i16*, i16* addrspace(1)* %2, align 8
   %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
@@ -6087,8 +7541,8 @@ entry:
   %10 = bitcast i16* %3 to i8*
   %11 = getelementptr inbounds i8, i8* %10, i64 %9
   %12 = bitcast i8* %11 to i16*
-  %NullCheck4 = icmp ne i16* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %5
   store i16 0, i16* %12, align 8
@@ -6098,11 +7552,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6119,8 +7573,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -6131,8 +7585,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
@@ -6144,15 +7598,15 @@ entry:
 
 ; <label>:14                                      ; preds = %1
   %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
   %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
   %21 = load i64, i64 addrspace(1)* %19
@@ -6171,15 +7625,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %14
+ThrowNullRef4:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %16
+ThrowNullRef6:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6302,14 +7756,6 @@ entry:
   ret %System.String addrspace(1)* %57
 }
 
-INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
-Successfully read RuntimeHelpers.get_OffsetToStringData
-
-define i32 @RuntimeHelpers.get_OffsetToStringData() {
-entry:
-  ret i32 12
-}
-
 INFO:  jitting method String::Equals using LLILCJit
 Successfully read String.Equals
 
@@ -6381,8 +7827,8 @@ entry:
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
-  br i1 %NullCheck24, label %29, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
   %30 = load i64, i64 addrspace(1)* %28
@@ -6397,8 +7843,8 @@ entry:
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
-  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
   %43 = load i64, i64 addrspace(1)* %41
@@ -6418,8 +7864,8 @@ entry:
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
   %59 = load i64, i64 addrspace(1)* %57
@@ -6434,8 +7880,8 @@ entry:
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck22, label %71, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
   %72 = load i64, i64 addrspace(1)* %70
@@ -6455,8 +7901,8 @@ entry:
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
-  br i1 %NullCheck16, label %87, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = load i64, i64 addrspace(1)* %86
@@ -6471,8 +7917,8 @@ entry:
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck18, label %100, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
   %101 = load i64, i64 addrspace(1)* %99
@@ -6492,8 +7938,8 @@ entry:
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
-  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
   %117 = load i64, i64 addrspace(1)* %115
@@ -6508,8 +7954,8 @@ entry:
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
-  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
   %130 = load i64, i64 addrspace(1)* %128
@@ -6528,15 +7974,15 @@ entry:
 
 ; <label>:142                                     ; preds = %22
   %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
-  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %143, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %144
 
 ; <label>:144                                     ; preds = %142
   %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
   %146 = load i32, i32 addrspace(1)* %145
   %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
-  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %147, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %148
 
 ; <label>:148                                     ; preds = %144
   %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
@@ -6557,15 +8003,15 @@ entry:
 
 ; <label>:159                                     ; preds = %22
   %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
-  br i1 %NullCheck, label %161, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %ThrowNullRef, label %161
 
 ; <label>:161                                     ; preds = %159
   %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
   %163 = load i32, i32 addrspace(1)* %162
   %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
-  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %164, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %165
 
 ; <label>:165                                     ; preds = %161
   %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
@@ -6578,8 +8024,8 @@ entry:
 
 ; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
-  br i1 %NullCheck4, label %172, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %171, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %172
 
 ; <label>:172                                     ; preds = %170
   %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
@@ -6589,8 +8035,8 @@ entry:
 
 ; <label>:176                                     ; preds = %172
   %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
-  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %177, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %178
 
 ; <label>:178                                     ; preds = %176
   %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
@@ -6629,55 +8075,55 @@ ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %161
+ThrowNullRef2:                                    ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %170
+ThrowNullRef4:                                    ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %176
+ThrowNullRef6:                                    ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %142
+ThrowNullRef8:                                    ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %144
+ThrowNullRef10:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %113
+ThrowNullRef12:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %116
+ThrowNullRef14:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %84
+ThrowNullRef16:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %87
+ThrowNullRef18:                                   ; preds = %87
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %55
+ThrowNullRef20:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %58
+ThrowNullRef22:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %26
+ThrowNullRef24:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %29
+ThrowNullRef26:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,8 +8161,8 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck, label %14, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %ThrowNullRef, label %14
 
 ; <label>:14                                      ; preds = %8
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
@@ -6760,8 +8206,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
@@ -6770,14 +8216,14 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32, i32* %loc0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %10
   %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
   %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
@@ -6790,15 +8236,15 @@ entry:
 ; <label>:25                                      ; preds = %19
   %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
-  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
   %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
@@ -6807,8 +8253,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %37 = load i32, i32* %loc0
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %38, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %38
 
 ; <label>:38                                      ; preds = %32
   %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
@@ -6817,14 +8263,14 @@ entry:
 
 ; <label>:40                                      ; preds = %19
   %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %40
   %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
   %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
-  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
-  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
@@ -6832,8 +8278,8 @@ entry:
   %48 = zext i32 %47 to i64
   %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
-  br i1 %NullCheck16, label %51, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %51
 
 ; <label>:51                                      ; preds = %45
   %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
@@ -6847,15 +8293,15 @@ entry:
 ; <label>:57                                      ; preds = %51
   %58 = load i16*, i16** %arg1
   %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
-  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %60
 
 ; <label>:60                                      ; preds = %57
   %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
   %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
-  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %64
 
 ; <label>:64                                      ; preds = %60
   %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
@@ -6864,22 +8310,22 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
   %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
-  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %70
 
 ; <label>:70                                      ; preds = %64
   %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
   %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
-  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
-  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
   %75 = load i32, i32 addrspace(1)* %74
   %76 = zext i32 %75 to i64
   %77 = trunc i64 %76 to i32
-  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
-  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %78
 
 ; <label>:78                                      ; preds = %73
   %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
@@ -6901,8 +8347,8 @@ entry:
   %90 = bitcast i16* %86 to i8*
   %91 = getelementptr inbounds i8, i8* %90, i64 %89
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %93
 
 ; <label>:93                                      ; preds = %80
   %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
@@ -6912,8 +8358,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %99 = load i32, i32* %loc2
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %100
 
 ; <label>:100                                     ; preds = %93
   %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
@@ -6928,63 +8374,63 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %25
+ThrowNullRef6:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %32
+ThrowNullRef10:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %40
+ThrowNullRef12:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %45
+ThrowNullRef16:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %57
+ThrowNullRef18:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %60
+ThrowNullRef20:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %64
+ThrowNullRef22:                                   ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %70
+ThrowNullRef24:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %73
+ThrowNullRef26:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %80
+ThrowNullRef28:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %93
+ThrowNullRef30:                                   ; preds = %93
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7004,8 +8450,8 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
@@ -7033,43 +8479,43 @@ entry:
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %14
   %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
   %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   %28 = load i32, i32 addrspace(1)* %27, align 8
   %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
-  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %30
 
 ; <label>:30                                      ; preds = %26
   %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
   %32 = load i32, i32 addrspace(1)* %31, align 8
   %33 = add i32 %28, %32
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %34
 
 ; <label>:34                                      ; preds = %30
   %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   store i32 %33, i32 addrspace(1)* %35
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
   store i32 0, i32 addrspace(1)* %38
   %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %40
 
 ; <label>:40                                      ; preds = %37
   %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
@@ -7082,8 +8528,8 @@ entry:
 
 ; <label>:47                                      ; preds = %40
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
@@ -7098,8 +8544,8 @@ entry:
   %54 = load i32, i32* %loc0
   %55 = sext i32 %54 to i64
   %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
-  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %57
 
 ; <label>:57                                      ; preds = %52
   %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
@@ -7110,68 +8556,35 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %14
+ThrowNullRef2:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %23
+ThrowNullRef4:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %26
+ThrowNullRef6:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %30
+ThrowNullRef8:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %34
+ThrowNullRef10:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %47
+ThrowNullRef14:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %52
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-}
-
-INFO:  jitting method StringBuilder::get_Length using LLILCJit
-Successfully read StringBuilder.get_Length
-
-define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.StringBuilder addrspace(1)*
-  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
-  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
-
-; <label>:1                                       ; preds = %entry
-  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %3 = load i32, i32 addrspace(1)* %2, align 8
-  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
-
-; <label>:5                                       ; preds = %1
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = add i32 %3, %7
-  ret i32 %8
-
-ThrowNullRef:                                     ; preds = %entry
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef16:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7213,70 +8626,70 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
   %6 = load i32, i32 addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
   store i32 %6, i32 addrspace(1)* %8
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
   %13 = load i32, i32 addrspace(1)* %12, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
   store i32 %13, i32 addrspace(1)* %15
   %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
-  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %18
 
 ; <label>:18                                      ; preds = %14
   %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
   %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
   %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
   %34 = load i32, i32 addrspace(1)* %33, align 8
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
-  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
@@ -7287,39 +8700,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %28
+ThrowNullRef16:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %32
+ThrowNullRef18:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7455,13 +8868,13 @@ entry:
 ; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
@@ -7477,16 +8890,16 @@ entry:
 
 ; <label>:18                                      ; preds = %15
   %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
   store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
   %22 = load i32, i32* %loc0
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %24
 
 ; <label>:24                                      ; preds = %20
   %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
@@ -7498,13 +8911,13 @@ entry:
 ; <label>:28                                      ; preds = %15, %24
   %29 = load i32, i32* %arg1
   %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %31
   %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
@@ -7517,20 +8930,20 @@ entry:
   %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
-  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
   %46 = load i32, i32 addrspace(1)* %45, align 8
   %47 = sub i32 %40, %46
-  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
-  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i32 addrspace(1)* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %48
 
 ; <label>:48                                      ; preds = %44
   store i32 %47, i32 addrspace(1)* %39, align 8
@@ -7538,21 +8951,21 @@ entry:
 
 ; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
-  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %51
 
 ; <label>:51                                      ; preds = %49
   %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %53
 
 ; <label>:53                                      ; preds = %51
   %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
   %55 = load i32, i32 addrspace(1)* %54, align 8
   %56 = load i32, i32* %arg2
   %57 = sub i32 %55, %56
-  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %58
 
 ; <label>:58                                      ; preds = %53
   %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
@@ -7562,13 +8975,13 @@ entry:
 ; <label>:60                                      ; preds = %33, %58
   %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
   %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
-  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %63
 
 ; <label>:63                                      ; preds = %60
   %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
-  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
-  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
@@ -7578,15 +8991,15 @@ entry:
 
 ; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
-  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i32 addrspace(1)* %69, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %70
 
 ; <label>:70                                      ; preds = %68
   %71 = load i32, i32 addrspace(1)* %69, align 8
   store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
-  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
@@ -7596,8 +9009,8 @@ entry:
   store i32 %77, i32* %loc4
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
-  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %80
 
 ; <label>:80                                      ; preds = %73
   %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
@@ -7607,71 +9020,71 @@ entry:
 ; <label>:83                                      ; preds = %80
   store i32 0, i32* %loc3
   %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
-  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
-  br i1 %NullCheck26, label %88, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i32 addrspace(1)* %87, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %88
 
 ; <label>:88                                      ; preds = %85
   %89 = load i32, i32 addrspace(1)* %87, align 8
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
-  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %90
 
 ; <label>:90                                      ; preds = %88
   %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
   store i32 %89, i32 addrspace(1)* %91
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
-  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
-  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %96
 
 ; <label>:96                                      ; preds = %94
   %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
-  br i1 %NullCheck34, label %100, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %100
 
 ; <label>:100                                     ; preds = %96
   %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
-  br i1 %NullCheck36, label %102, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %102
 
 ; <label>:102                                     ; preds = %100
   %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
   %104 = load i32, i32 addrspace(1)* %103, align 8
   %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
-  br i1 %NullCheck38, label %106, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %106
 
 ; <label>:106                                     ; preds = %102
   %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
-  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
-  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %108
 
 ; <label>:108                                     ; preds = %106
   %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
   %110 = load i32, i32 addrspace(1)* %109, align 8
   %111 = add i32 %104, %110
-  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %112
 
 ; <label>:112                                     ; preds = %108
   %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
   store i32 %111, i32 addrspace(1)* %113
   %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
-  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i32 addrspace(1)* %114, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %115
 
 ; <label>:115                                     ; preds = %112
   %116 = load i32, i32 addrspace(1)* %114, align 8
@@ -7681,19 +9094,19 @@ entry:
 ; <label>:118                                     ; preds = %115
   %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
-  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %121
 
 ; <label>:121                                     ; preds = %118
   %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
-  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
-  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %123
 
 ; <label>:123                                     ; preds = %121
   %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
   %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
-  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
-  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %126
 
 ; <label>:126                                     ; preds = %123
   %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
@@ -7705,8 +9118,8 @@ entry:
 
 ; <label>:130                                     ; preds = %80, %115, %126
   %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %132
 
 ; <label>:132                                     ; preds = %130
   %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7715,8 +9128,8 @@ entry:
   %136 = load i32, i32* %loc3
   %137 = sub i32 %135, %136
   %138 = sub i32 %134, %137
-  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %139
 
 ; <label>:139                                     ; preds = %132
   %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7728,16 +9141,16 @@ entry:
 
 ; <label>:144                                     ; preds = %139
   %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
-  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %146
 
 ; <label>:146                                     ; preds = %144
   %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
   %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
   %149 = load i32, i32* %loc2
   %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
-  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %151
 
 ; <label>:151                                     ; preds = %146
   %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
@@ -7754,145 +9167,249 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %18
+ThrowNullRef4:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %31
+ThrowNullRef10:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %44
+ThrowNullRef16:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %68
+ThrowNullRef18:                                   ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %70
+ThrowNullRef20:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %73
+ThrowNullRef22:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %83
+ThrowNullRef24:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %85
+ThrowNullRef26:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %88
+ThrowNullRef28:                                   ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %90
+ThrowNullRef30:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %94
+ThrowNullRef32:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %96
+ThrowNullRef34:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %100
+ThrowNullRef36:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %102
+ThrowNullRef38:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %106
+ThrowNullRef40:                                   ; preds = %106
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %108
+ThrowNullRef42:                                   ; preds = %108
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %112
+ThrowNullRef44:                                   ; preds = %112
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %118
+ThrowNullRef46:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %121
+ThrowNullRef48:                                   ; preds = %121
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %123
+ThrowNullRef50:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %130
+ThrowNullRef52:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %132
+ThrowNullRef54:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %144
+ThrowNullRef56:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %146
+ThrowNullRef58:                                   ; preds = %146
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %60
+ThrowNullRef60:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %63
+ThrowNullRef62:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %49
+ThrowNullRef64:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %51
+ThrowNullRef66:                                   ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %53
+ThrowNullRef68:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(%"System.Char[]" addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %arg0 = alloca %"System.Char[]" addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store %"System.Char[]" addrspace(1)* %param0, %"System.Char[]" addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load i32, i32* %arg4
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %43, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %38, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg1
+  %13 = load i32, i32* %arg4
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %38, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %24 = load i32, i32* %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %35 = load i32, i32* %arg3
+  %36 = load i32, i32* %arg4
+  %37 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %37, %"System.Char[]" addrspace(1)* %34, i32 %35, i32 %36)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:38                                      ; preds = %5, %16
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Successfully read Buffer._Memmove
 
@@ -7914,7 +9431,7 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[loadElem]
+Failed to read AppDomain.SetDataHelper[storeElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -7923,8 +9440,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
@@ -7934,8 +9451,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
@@ -7947,15 +9464,15 @@ entry:
   %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
   %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
@@ -7966,15 +9483,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7992,7 +9509,79 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
-Failed to read Dictionary`2.TryGetValue[loadElemA]
+Successfully read Dictionary`2.TryGetValue
+
+define i8 @"Dictionary`2.TryGetValue"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)* addrspace(1)* %param2) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  %arg2 = alloca %System.__Canon addrspace(1)* addrspace(1)*
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  store %System.__Canon addrspace(1)* addrspace(1)* %param2, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  store i32 %2, i32* %loc0
+  %3 = load i32, i32* %loc0
+  %4 = icmp slt i32 %3, 0
+  br i1 %4, label %22, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 2
+  %10 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %9, align 8
+  %11 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = zext i32 %11 to i64
+  %BoundsCheck = icmp uge i64 %16, %15
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 3, i32 %11
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %20, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %6, %System.__Canon addrspace(1)* %21)
+  ret i8 1
+
+; <label>:22                                      ; preds = %entry
+  %23 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %23, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -8058,8 +9647,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
@@ -8091,8 +9680,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
@@ -8171,15 +9760,15 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck, label %19, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %ThrowNullRef, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
   %21 = load i32, i32 addrspace(1)* %20
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
@@ -8202,7 +9791,7 @@ ThrowNullRef:                                     ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %19
+ThrowNullRef2:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8248,8 +9837,8 @@ entry:
   %0 = alloca %System.AppDomainHandle
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %1 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %1, i32 0, i32 15
@@ -8269,8 +9858,8 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
@@ -8286,7 +9875,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -8299,8 +9888,8 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -8327,8 +9916,8 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
@@ -8352,8 +9941,8 @@ entry:
   %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
   store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
@@ -8363,8 +9952,8 @@ entry:
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
@@ -8374,8 +9963,8 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %9
   %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
@@ -8384,8 +9973,8 @@ entry:
 
 ; <label>:18                                      ; preds = %3, %16
   %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
@@ -8397,15 +9986,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %18
+ThrowNullRef6:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8418,8 +10007,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
@@ -8453,15 +10042,15 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
@@ -8473,7 +10062,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8481,7 +10070,7 @@ ThrowNullRef1:                                    ; preds = %1
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
 Failed to read Dictionary`2.System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
@@ -8506,8 +10095,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
@@ -8524,8 +10113,8 @@ entry:
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -8544,7 +10133,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8577,8 +10166,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = load i64, i64* %arg2
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = trunc i32 %3 to i8
@@ -8634,46 +10223,46 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
   %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
-  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
-  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
-  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
@@ -8684,27 +10273,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %20
+ThrowNullRef12:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8717,8 +10306,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -8756,22 +10345,22 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
   %9 = load i64, i64 addrspace(1)* %8, align 8
   %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
   %13 = load i64, i64 addrspace(1)* %12, align 8
   %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %11
   %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
@@ -8788,11 +10377,11 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8882,8 +10471,8 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
@@ -8900,8 +10489,8 @@ entry:
 ; <label>:8                                       ; preds = %1
   %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
   %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
@@ -8911,15 +10500,15 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
   %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
   %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
-  br i1 %NullCheck6, label %21, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
@@ -8946,15 +10535,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8992,15 +10581,15 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
   store i8 %3, i8 addrspace(1)* %5
   %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
@@ -9011,7 +10600,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9027,8 +10616,8 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -9041,8 +10630,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
@@ -9058,7 +10647,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9080,8 +10669,8 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
@@ -9096,8 +10685,8 @@ entry:
 ; <label>:12                                      ; preds = %6
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
@@ -9112,8 +10701,8 @@ entry:
 ; <label>:21                                      ; preds = %15
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
@@ -9128,8 +10717,8 @@ entry:
 ; <label>:30                                      ; preds = %24
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %31, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
@@ -9144,8 +10733,8 @@ entry:
 ; <label>:39                                      ; preds = %33
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
-  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %40, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %42
 
 ; <label>:42                                      ; preds = %39
   %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
@@ -9164,19 +10753,19 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %21
+ThrowNullRef4:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %30
+ThrowNullRef6:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %39
+ThrowNullRef8:                                    ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9243,8 +10832,8 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
@@ -9264,57 +10853,57 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
   store i8 0, i8 addrspace(1)* %2
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
   store i8 0, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
   store i8 0, i8 addrspace(1)* %17
   %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
   store i8 0, i8 addrspace(1)* %20
   %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
-  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
@@ -9325,31 +10914,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %19
+ThrowNullRef14:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9367,8 +10956,8 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
@@ -9380,8 +10969,8 @@ entry:
 
 ; <label>:9                                       ; preds = %4
   %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %9
   %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
@@ -9395,7 +10984,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef2:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9420,8 +11009,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
@@ -9512,8 +11101,8 @@ entry:
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
@@ -9524,8 +11113,8 @@ entry:
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = load i64, i64 addrspace(1)* %12
@@ -9537,8 +11126,8 @@ entry:
   %20 = load i64, i64* %19
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
-  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %13
   %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
@@ -9555,8 +11144,8 @@ entry:
 ; <label>:30                                      ; preds = %25
   %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %32 = load i32, i32* %arg2
-  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
-  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
@@ -9570,15 +11159,15 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %30
+ThrowNullRef2:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9622,87 +11211,87 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
   %10 = load i8, i8 addrspace(1)* %9, align 8
   %11 = zext i8 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %8
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
   store i8 %12, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
   %19 = load i8, i8 addrspace(1)* %18, align 8
   %20 = zext i8 %19 to i32
   %21 = trunc i32 %20 to i8
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
   store i8 %21, i8 addrspace(1)* %23
   %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
   %28 = load i8, i8 addrspace(1)* %27, align 8
   %29 = zext i8 %28 to i32
   %30 = trunc i32 %29 to i8
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
-  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %31
 
 ; <label>:31                                      ; preds = %26
   %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
   store i8 %30, i8 addrspace(1)* %32
   %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
-  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
-  br i1 %NullCheck14, label %40, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %40
 
 ; <label>:40                                      ; preds = %35
   %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
   store i8 %39, i8 addrspace(1)* %41
   %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
-  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %44
 
 ; <label>:44                                      ; preds = %40
   %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
   %46 = load i8, i8 addrspace(1)* %45, align 8
   %47 = zext i8 %46 to i32
   %48 = trunc i32 %47 to i8
-  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
   store i8 %48, i8 addrspace(1)* %50
   %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
-  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
@@ -9713,29 +11302,29 @@ entry:
 ; <label>:56                                      ; preds = %52
   %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
-  br i1 %NullCheck22, label %59, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
   %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
   %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
-  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
-  br i1 %NullCheck24, label %63, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
   %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
-  br i1 %NullCheck26, label %66, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
   %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
-  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
-  br i1 %NullCheck28, label %69, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %69
 
 ; <label>:69                                      ; preds = %66
   %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
@@ -9744,15 +11333,15 @@ entry:
 
 ; <label>:71                                      ; preds = %105
   %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
-  br i1 %NullCheck34, label %73, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %73
 
 ; <label>:73                                      ; preds = %71
   %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
   %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
   %76 = load i32, i32* %loc0
-  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
-  br i1 %NullCheck36, label %77, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
@@ -9766,8 +11355,8 @@ entry:
 
 ; <label>:83                                      ; preds = %77
   %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
-  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
@@ -9775,14 +11364,14 @@ entry:
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
   %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
-  br i1 %NullCheck40, label %91, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
 ; <label>:91                                      ; preds = %85
   %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
   %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
-  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck42, label %94, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %94
 
 ; <label>:94                                      ; preds = %91
   %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
@@ -9798,14 +11387,14 @@ entry:
 ; <label>:99                                      ; preds = %69, %96
   %100 = load i32, i32* %loc0
   %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
-  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %102
 
 ; <label>:102                                     ; preds = %99
   %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
   %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
-  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
-  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
@@ -9819,87 +11408,87 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %26
+ThrowNullRef10:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %31
+ThrowNullRef12:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %35
+ThrowNullRef14:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %40
+ThrowNullRef16:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %56
+ThrowNullRef22:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %59
+ThrowNullRef24:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %63
+ThrowNullRef26:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %66
+ThrowNullRef28:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %102
+ThrowNullRef32:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %71
+ThrowNullRef34:                                   ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %73
+ThrowNullRef36:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %83
+ThrowNullRef38:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %85
+ThrowNullRef40:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %91
+ThrowNullRef42:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9943,15 +11532,15 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
   %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
@@ -9961,28 +11550,28 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
   %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %12
   %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
   %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
   %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
-  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
@@ -9993,23 +11582,23 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %12
+ThrowNullRef6:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10031,15 +11620,15 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
   %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = load i64, i64 addrspace(1)* %7
@@ -10077,13 +11666,13 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[loadElem]
+Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -10111,8 +11700,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -10168,24 +11757,24 @@ entry:
   store i32 %param3, i32* %arg3
   %0 = load %Point addrspace(1)*, %Point addrspace(1)** %this
   %1 = load i32, i32* %arg1
-  %NullCheck = icmp ne %Point addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %Point addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %Point, %Point addrspace(1)* %0, i32 0, i32 0
   store i32 %1, i32 addrspace(1)* %3
   %4 = load %Point addrspace(1)*, %Point addrspace(1)** %this
   %5 = load i32, i32* %arg2
-  %NullCheck2 = icmp ne %Point addrspace(1)* %4, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %Point addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
   %7 = getelementptr inbounds %Point, %Point addrspace(1)* %4, i32 0, i32 1
   store i32 %5, i32 addrspace(1)* %7
   %8 = load %Point addrspace(1)*, %Point addrspace(1)** %this
   %9 = load i32, i32* %arg3
-  %NullCheck4 = icmp ne %Point addrspace(1)* %8, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %Point addrspace(1)* %8, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %6
   %11 = getelementptr inbounds %Point, %Point addrspace(1)* %8, i32 0, i32 2
@@ -10196,11 +11785,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %6
+ThrowNullRef4:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10213,8 +11802,8 @@ entry:
   %this = alloca %Point addrspace(1)*
   store %Point addrspace(1)* %param0, %Point addrspace(1)** %this
   %0 = load %Point addrspace(1)*, %Point addrspace(1)** %this
-  %NullCheck = icmp ne %Point addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %Point addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %Point, %Point addrspace(1)* %0, i32 0, i32 0
@@ -10224,8 +11813,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %Point addrspace(1)*, %Point addrspace(1)** %this
-  %NullCheck2 = icmp ne %Point addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %Point addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %Point, %Point addrspace(1)* %6, i32 0, i32 1
@@ -10235,8 +11824,8 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %Point addrspace(1)*, %Point addrspace(1)** %this
-  %NullCheck4 = icmp ne %Point addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %Point addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %Point, %Point addrspace(1)* %12, i32 0, i32 2
@@ -10253,11 +11842,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10277,8 +11866,8 @@ entry:
   store i32 %1, i32* %loc0
   %2 = load i32, i32* %loc0
   %3 = load %Point addrspace(1)*, %Point addrspace(1)** %arg1
-  %NullCheck = icmp ne %Point addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %Point addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %Point, %Point addrspace(1)* %3, i32 0, i32 0
@@ -10299,8 +11888,8 @@ entry:
   %this = alloca %Point addrspace(1)*
   store %Point addrspace(1)* %param0, %Point addrspace(1)** %this
   %0 = load %Point addrspace(1)*, %Point addrspace(1)** %this
-  %NullCheck = icmp ne %Point addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %Point addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %Point, %Point addrspace(1)* %0, i32 0, i32 0

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Sub1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Sub1.error.txt
@@ -25,8 +25,8 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
@@ -40,8 +40,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
   %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
@@ -75,7 +75,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -90,8 +90,8 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %NullCheck = icmp ne i8 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = load i8, i8 addrspace(1)* %0, align 8
@@ -125,8 +125,8 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
@@ -159,8 +159,8 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -184,8 +184,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
   store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
@@ -195,8 +195,8 @@ entry:
 ; <label>:4                                       ; preds = %1
   %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
   %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
@@ -206,8 +206,8 @@ entry:
   %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
@@ -221,14 +221,14 @@ entry:
 
 ; <label>:17                                      ; preds = %14
   %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
   %21 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
@@ -238,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -249,8 +249,8 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
@@ -261,27 +261,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %30
+ThrowNullRef10:                                   ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -301,7 +301,89 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
-Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
+Successfully read AppDomainSetup.GetUnsecureApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.GetUnsecureApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %NullCheck = icmp eq %"System.String[]" addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %BoundsCheck = icmp uge i64 0, %5
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %6
+
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 3, i32 0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
+  ret %System.String addrspace(1)* %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_Value using LLILCJit
+Successfully read AppDomainSetup.get_Value
+
+define %"System.String[]" addrspace(1)* @AppDomainSetup.get_Value(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.String[]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 18)
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.String[]" addrspace(1)* addrspace(1)*, %"System.String[]" addrspace(1)*)*)(%"System.String[]" addrspace(1)* addrspace(1)* %9, %"System.String[]" addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %11, i32 0, i32 1
+  %14 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %13, align 8
+  ret %"System.String[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -319,8 +401,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -368,16 +450,16 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
   %5 = load i32, i32 addrspace(1)* %4
   %6 = sub i32 %5, 1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -389,7 +471,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -421,8 +503,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
@@ -456,8 +538,8 @@ entry:
 ; <label>:27                                      ; preds = %19
   %28 = load i32, i32* %arg1
   %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
-  br i1 %NullCheck2, label %30, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %29, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %30
 
 ; <label>:30                                      ; preds = %27
   %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
@@ -493,8 +575,8 @@ entry:
 ; <label>:49                                      ; preds = %46
   %50 = load i32, i32* %arg2
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck4, label %52, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
@@ -517,11 +599,11 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %27
+ThrowNullRef2:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %49
+ThrowNullRef4:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -544,16 +626,16 @@ entry:
   %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %0)
   store %System.String addrspace(1)* %1, %System.String addrspace(1)** %loc0
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 2
   %5 = bitcast [0 x i16] addrspace(1)* %4 to i16 addrspace(1)*
   store i16 addrspace(1)* %5, i16 addrspace(1)** %loc1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %3
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2
@@ -580,7 +662,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -691,15 +773,15 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %NullCheck132 = icmp ne i8* %21, null
-  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+  %NullCheck131 = icmp eq i8* %21, null
+  br i1 %NullCheck131, label %ThrowNullRef132, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = load i8, i8* %21, align 8
   %24 = zext i8 %23 to i32
   %25 = trunc i32 %24 to i8
-  %NullCheck134 = icmp ne i8* %20, null
-  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+  %NullCheck133 = icmp eq i8* %20, null
+  br i1 %NullCheck133, label %ThrowNullRef134, label %26
 
 ; <label>:26                                      ; preds = %22
   store i8 %25, i8* %20, align 8
@@ -709,16 +791,16 @@ entry:
   %28 = load i8*, i8** %arg0
   %29 = load i8*, i8** %arg1
   %30 = bitcast i8* %29 to i16*
-  %NullCheck128 = icmp ne i16* %30, null
-  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+  %NullCheck127 = icmp eq i16* %30, null
+  br i1 %NullCheck127, label %ThrowNullRef128, label %31
 
 ; <label>:31                                      ; preds = %27
   %32 = load i16, i16* %30, align 8
   %33 = sext i16 %32 to i32
   %34 = bitcast i8* %28 to i16*
   %35 = trunc i32 %33 to i16
-  %NullCheck130 = icmp ne i16* %34, null
-  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+  %NullCheck129 = icmp eq i16* %34, null
+  br i1 %NullCheck129, label %ThrowNullRef130, label %36
 
 ; <label>:36                                      ; preds = %31
   store i16 %35, i16* %34, align 8
@@ -728,16 +810,16 @@ entry:
   %38 = load i8*, i8** %arg0
   %39 = load i8*, i8** %arg1
   %40 = bitcast i8* %39 to i16*
-  %NullCheck120 = icmp ne i16* %40, null
-  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+  %NullCheck119 = icmp eq i16* %40, null
+  br i1 %NullCheck119, label %ThrowNullRef120, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i16, i16* %40, align 8
   %43 = sext i16 %42 to i32
   %44 = bitcast i8* %38 to i16*
   %45 = trunc i32 %43 to i16
-  %NullCheck122 = icmp ne i16* %44, null
-  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+  %NullCheck121 = icmp eq i16* %44, null
+  br i1 %NullCheck121, label %ThrowNullRef122, label %46
 
 ; <label>:46                                      ; preds = %41
   store i16 %45, i16* %44, align 8
@@ -745,15 +827,15 @@ entry:
   %48 = getelementptr inbounds i8, i8* %47, i64 2
   %49 = load i8*, i8** %arg1
   %50 = getelementptr inbounds i8, i8* %49, i64 2
-  %NullCheck124 = icmp ne i8* %50, null
-  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+  %NullCheck123 = icmp eq i8* %50, null
+  br i1 %NullCheck123, label %ThrowNullRef124, label %51
 
 ; <label>:51                                      ; preds = %46
   %52 = load i8, i8* %50, align 8
   %53 = zext i8 %52 to i32
   %54 = trunc i32 %53 to i8
-  %NullCheck126 = icmp ne i8* %48, null
-  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+  %NullCheck125 = icmp eq i8* %48, null
+  br i1 %NullCheck125, label %ThrowNullRef126, label %55
 
 ; <label>:55                                      ; preds = %51
   store i8 %54, i8* %48, align 8
@@ -763,14 +845,14 @@ entry:
   %57 = load i8*, i8** %arg0
   %58 = load i8*, i8** %arg1
   %59 = bitcast i8* %58 to i32*
-  %NullCheck116 = icmp ne i32* %59, null
-  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+  %NullCheck115 = icmp eq i32* %59, null
+  br i1 %NullCheck115, label %ThrowNullRef116, label %60
 
 ; <label>:60                                      ; preds = %56
   %61 = load i32, i32* %59, align 8
   %62 = bitcast i8* %57 to i32*
-  %NullCheck118 = icmp ne i32* %62, null
-  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+  %NullCheck117 = icmp eq i32* %62, null
+  br i1 %NullCheck117, label %ThrowNullRef118, label %63
 
 ; <label>:63                                      ; preds = %60
   store i32 %61, i32* %62, align 8
@@ -780,14 +862,14 @@ entry:
   %65 = load i8*, i8** %arg0
   %66 = load i8*, i8** %arg1
   %67 = bitcast i8* %66 to i32*
-  %NullCheck108 = icmp ne i32* %67, null
-  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+  %NullCheck107 = icmp eq i32* %67, null
+  br i1 %NullCheck107, label %ThrowNullRef108, label %68
 
 ; <label>:68                                      ; preds = %64
   %69 = load i32, i32* %67, align 8
   %70 = bitcast i8* %65 to i32*
-  %NullCheck110 = icmp ne i32* %70, null
-  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+  %NullCheck109 = icmp eq i32* %70, null
+  br i1 %NullCheck109, label %ThrowNullRef110, label %71
 
 ; <label>:71                                      ; preds = %68
   store i32 %69, i32* %70, align 8
@@ -795,15 +877,15 @@ entry:
   %73 = getelementptr inbounds i8, i8* %72, i64 4
   %74 = load i8*, i8** %arg1
   %75 = getelementptr inbounds i8, i8* %74, i64 4
-  %NullCheck112 = icmp ne i8* %75, null
-  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+  %NullCheck111 = icmp eq i8* %75, null
+  br i1 %NullCheck111, label %ThrowNullRef112, label %76
 
 ; <label>:76                                      ; preds = %71
   %77 = load i8, i8* %75, align 8
   %78 = zext i8 %77 to i32
   %79 = trunc i32 %78 to i8
-  %NullCheck114 = icmp ne i8* %73, null
-  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+  %NullCheck113 = icmp eq i8* %73, null
+  br i1 %NullCheck113, label %ThrowNullRef114, label %80
 
 ; <label>:80                                      ; preds = %76
   store i8 %79, i8* %73, align 8
@@ -813,14 +895,14 @@ entry:
   %82 = load i8*, i8** %arg0
   %83 = load i8*, i8** %arg1
   %84 = bitcast i8* %83 to i32*
-  %NullCheck100 = icmp ne i32* %84, null
-  br i1 %NullCheck100, label %85, label %ThrowNullRef99
+  %NullCheck99 = icmp eq i32* %84, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %85
 
 ; <label>:85                                      ; preds = %81
   %86 = load i32, i32* %84, align 8
   %87 = bitcast i8* %82 to i32*
-  %NullCheck102 = icmp ne i32* %87, null
-  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+  %NullCheck101 = icmp eq i32* %87, null
+  br i1 %NullCheck101, label %ThrowNullRef102, label %88
 
 ; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
@@ -829,16 +911,16 @@ entry:
   %91 = load i8*, i8** %arg1
   %92 = getelementptr inbounds i8, i8* %91, i64 4
   %93 = bitcast i8* %92 to i16*
-  %NullCheck104 = icmp ne i16* %93, null
-  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+  %NullCheck103 = icmp eq i16* %93, null
+  br i1 %NullCheck103, label %ThrowNullRef104, label %94
 
 ; <label>:94                                      ; preds = %88
   %95 = load i16, i16* %93, align 8
   %96 = sext i16 %95 to i32
   %97 = bitcast i8* %90 to i16*
   %98 = trunc i32 %96 to i16
-  %NullCheck106 = icmp ne i16* %97, null
-  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+  %NullCheck105 = icmp eq i16* %97, null
+  br i1 %NullCheck105, label %ThrowNullRef106, label %99
 
 ; <label>:99                                      ; preds = %94
   store i16 %98, i16* %97, align 8
@@ -848,14 +930,14 @@ entry:
   %101 = load i8*, i8** %arg0
   %102 = load i8*, i8** %arg1
   %103 = bitcast i8* %102 to i32*
-  %NullCheck88 = icmp ne i32* %103, null
-  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+  %NullCheck87 = icmp eq i32* %103, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %104
 
 ; <label>:104                                     ; preds = %100
   %105 = load i32, i32* %103, align 8
   %106 = bitcast i8* %101 to i32*
-  %NullCheck90 = icmp ne i32* %106, null
-  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+  %NullCheck89 = icmp eq i32* %106, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %107
 
 ; <label>:107                                     ; preds = %104
   store i32 %105, i32* %106, align 8
@@ -864,16 +946,16 @@ entry:
   %110 = load i8*, i8** %arg1
   %111 = getelementptr inbounds i8, i8* %110, i64 4
   %112 = bitcast i8* %111 to i16*
-  %NullCheck92 = icmp ne i16* %112, null
-  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+  %NullCheck91 = icmp eq i16* %112, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %113
 
 ; <label>:113                                     ; preds = %107
   %114 = load i16, i16* %112, align 8
   %115 = sext i16 %114 to i32
   %116 = bitcast i8* %109 to i16*
   %117 = trunc i32 %115 to i16
-  %NullCheck94 = icmp ne i16* %116, null
-  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+  %NullCheck93 = icmp eq i16* %116, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %118
 
 ; <label>:118                                     ; preds = %113
   store i16 %117, i16* %116, align 8
@@ -881,15 +963,15 @@ entry:
   %120 = getelementptr inbounds i8, i8* %119, i64 6
   %121 = load i8*, i8** %arg1
   %122 = getelementptr inbounds i8, i8* %121, i64 6
-  %NullCheck96 = icmp ne i8* %122, null
-  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+  %NullCheck95 = icmp eq i8* %122, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %123
 
 ; <label>:123                                     ; preds = %118
   %124 = load i8, i8* %122, align 8
   %125 = zext i8 %124 to i32
   %126 = trunc i32 %125 to i8
-  %NullCheck98 = icmp ne i8* %120, null
-  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+  %NullCheck97 = icmp eq i8* %120, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %127
 
 ; <label>:127                                     ; preds = %123
   store i8 %126, i8* %120, align 8
@@ -899,14 +981,14 @@ entry:
   %129 = load i8*, i8** %arg0
   %130 = load i8*, i8** %arg1
   %131 = bitcast i8* %130 to i64*
-  %NullCheck84 = icmp ne i64* %131, null
-  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+  %NullCheck83 = icmp eq i64* %131, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %132
 
 ; <label>:132                                     ; preds = %128
   %133 = load i64, i64* %131, align 8
   %134 = bitcast i8* %129 to i64*
-  %NullCheck86 = icmp ne i64* %134, null
-  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+  %NullCheck85 = icmp eq i64* %134, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %135
 
 ; <label>:135                                     ; preds = %132
   store i64 %133, i64* %134, align 8
@@ -916,14 +998,14 @@ entry:
   %137 = load i8*, i8** %arg0
   %138 = load i8*, i8** %arg1
   %139 = bitcast i8* %138 to i64*
-  %NullCheck76 = icmp ne i64* %139, null
-  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+  %NullCheck75 = icmp eq i64* %139, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %140
 
 ; <label>:140                                     ; preds = %136
   %141 = load i64, i64* %139, align 8
   %142 = bitcast i8* %137 to i64*
-  %NullCheck78 = icmp ne i64* %142, null
-  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+  %NullCheck77 = icmp eq i64* %142, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %143
 
 ; <label>:143                                     ; preds = %140
   store i64 %141, i64* %142, align 8
@@ -931,15 +1013,15 @@ entry:
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %NullCheck80 = icmp ne i8* %147, null
-  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+  %NullCheck79 = icmp eq i8* %147, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %148
 
 ; <label>:148                                     ; preds = %143
   %149 = load i8, i8* %147, align 8
   %150 = zext i8 %149 to i32
   %151 = trunc i32 %150 to i8
-  %NullCheck82 = icmp ne i8* %145, null
-  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+  %NullCheck81 = icmp eq i8* %145, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %152
 
 ; <label>:152                                     ; preds = %148
   store i8 %151, i8* %145, align 8
@@ -949,14 +1031,14 @@ entry:
   %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
   %156 = bitcast i8* %155 to i64*
-  %NullCheck68 = icmp ne i64* %156, null
-  br i1 %NullCheck68, label %157, label %ThrowNullRef67
+  %NullCheck67 = icmp eq i64* %156, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %157
 
 ; <label>:157                                     ; preds = %153
   %158 = load i64, i64* %156, align 8
   %159 = bitcast i8* %154 to i64*
-  %NullCheck70 = icmp ne i64* %159, null
-  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+  %NullCheck69 = icmp eq i64* %159, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %160
 
 ; <label>:160                                     ; preds = %157
   store i64 %158, i64* %159, align 8
@@ -965,16 +1047,16 @@ entry:
   %163 = load i8*, i8** %arg1
   %164 = getelementptr inbounds i8, i8* %163, i64 8
   %165 = bitcast i8* %164 to i16*
-  %NullCheck72 = icmp ne i16* %165, null
-  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+  %NullCheck71 = icmp eq i16* %165, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %166
 
 ; <label>:166                                     ; preds = %160
   %167 = load i16, i16* %165, align 8
   %168 = sext i16 %167 to i32
   %169 = bitcast i8* %162 to i16*
   %170 = trunc i32 %168 to i16
-  %NullCheck74 = icmp ne i16* %169, null
-  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+  %NullCheck73 = icmp eq i16* %169, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %171
 
 ; <label>:171                                     ; preds = %166
   store i16 %170, i16* %169, align 8
@@ -984,14 +1066,14 @@ entry:
   %173 = load i8*, i8** %arg0
   %174 = load i8*, i8** %arg1
   %175 = bitcast i8* %174 to i64*
-  %NullCheck56 = icmp ne i64* %175, null
-  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+  %NullCheck55 = icmp eq i64* %175, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %176
 
 ; <label>:176                                     ; preds = %172
   %177 = load i64, i64* %175, align 8
   %178 = bitcast i8* %173 to i64*
-  %NullCheck58 = icmp ne i64* %178, null
-  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+  %NullCheck57 = icmp eq i64* %178, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %179
 
 ; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
@@ -1000,16 +1082,16 @@ entry:
   %182 = load i8*, i8** %arg1
   %183 = getelementptr inbounds i8, i8* %182, i64 8
   %184 = bitcast i8* %183 to i16*
-  %NullCheck60 = icmp ne i16* %184, null
-  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+  %NullCheck59 = icmp eq i16* %184, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %185
 
 ; <label>:185                                     ; preds = %179
   %186 = load i16, i16* %184, align 8
   %187 = sext i16 %186 to i32
   %188 = bitcast i8* %181 to i16*
   %189 = trunc i32 %187 to i16
-  %NullCheck62 = icmp ne i16* %188, null
-  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+  %NullCheck61 = icmp eq i16* %188, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %190
 
 ; <label>:190                                     ; preds = %185
   store i16 %189, i16* %188, align 8
@@ -1017,15 +1099,15 @@ entry:
   %192 = getelementptr inbounds i8, i8* %191, i64 10
   %193 = load i8*, i8** %arg1
   %194 = getelementptr inbounds i8, i8* %193, i64 10
-  %NullCheck64 = icmp ne i8* %194, null
-  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+  %NullCheck63 = icmp eq i8* %194, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %195
 
 ; <label>:195                                     ; preds = %190
   %196 = load i8, i8* %194, align 8
   %197 = zext i8 %196 to i32
   %198 = trunc i32 %197 to i8
-  %NullCheck66 = icmp ne i8* %192, null
-  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+  %NullCheck65 = icmp eq i8* %192, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %199
 
 ; <label>:199                                     ; preds = %195
   store i8 %198, i8* %192, align 8
@@ -1035,14 +1117,14 @@ entry:
   %201 = load i8*, i8** %arg0
   %202 = load i8*, i8** %arg1
   %203 = bitcast i8* %202 to i64*
-  %NullCheck48 = icmp ne i64* %203, null
-  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+  %NullCheck47 = icmp eq i64* %203, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %204
 
 ; <label>:204                                     ; preds = %200
   %205 = load i64, i64* %203, align 8
   %206 = bitcast i8* %201 to i64*
-  %NullCheck50 = icmp ne i64* %206, null
-  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+  %NullCheck49 = icmp eq i64* %206, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %207
 
 ; <label>:207                                     ; preds = %204
   store i64 %205, i64* %206, align 8
@@ -1051,14 +1133,14 @@ entry:
   %210 = load i8*, i8** %arg1
   %211 = getelementptr inbounds i8, i8* %210, i64 8
   %212 = bitcast i8* %211 to i32*
-  %NullCheck52 = icmp ne i32* %212, null
-  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+  %NullCheck51 = icmp eq i32* %212, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %213
 
 ; <label>:213                                     ; preds = %207
   %214 = load i32, i32* %212, align 8
   %215 = bitcast i8* %209 to i32*
-  %NullCheck54 = icmp ne i32* %215, null
-  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+  %NullCheck53 = icmp eq i32* %215, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %216
 
 ; <label>:216                                     ; preds = %213
   store i32 %214, i32* %215, align 8
@@ -1068,14 +1150,14 @@ entry:
   %218 = load i8*, i8** %arg0
   %219 = load i8*, i8** %arg1
   %220 = bitcast i8* %219 to i64*
-  %NullCheck36 = icmp ne i64* %220, null
-  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64* %220, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %221
 
 ; <label>:221                                     ; preds = %217
   %222 = load i64, i64* %220, align 8
   %223 = bitcast i8* %218 to i64*
-  %NullCheck38 = icmp ne i64* %223, null
-  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+  %NullCheck37 = icmp eq i64* %223, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %224
 
 ; <label>:224                                     ; preds = %221
   store i64 %222, i64* %223, align 8
@@ -1084,14 +1166,14 @@ entry:
   %227 = load i8*, i8** %arg1
   %228 = getelementptr inbounds i8, i8* %227, i64 8
   %229 = bitcast i8* %228 to i32*
-  %NullCheck40 = icmp ne i32* %229, null
-  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i32* %229, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %230
 
 ; <label>:230                                     ; preds = %224
   %231 = load i32, i32* %229, align 8
   %232 = bitcast i8* %226 to i32*
-  %NullCheck42 = icmp ne i32* %232, null
-  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+  %NullCheck41 = icmp eq i32* %232, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %233
 
 ; <label>:233                                     ; preds = %230
   store i32 %231, i32* %232, align 8
@@ -1099,15 +1181,15 @@ entry:
   %235 = getelementptr inbounds i8, i8* %234, i64 12
   %236 = load i8*, i8** %arg1
   %237 = getelementptr inbounds i8, i8* %236, i64 12
-  %NullCheck44 = icmp ne i8* %237, null
-  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i8* %237, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %238
 
 ; <label>:238                                     ; preds = %233
   %239 = load i8, i8* %237, align 8
   %240 = zext i8 %239 to i32
   %241 = trunc i32 %240 to i8
-  %NullCheck46 = icmp ne i8* %235, null
-  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+  %NullCheck45 = icmp eq i8* %235, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %242
 
 ; <label>:242                                     ; preds = %238
   store i8 %241, i8* %235, align 8
@@ -1117,14 +1199,14 @@ entry:
   %244 = load i8*, i8** %arg0
   %245 = load i8*, i8** %arg1
   %246 = bitcast i8* %245 to i64*
-  %NullCheck24 = icmp ne i64* %246, null
-  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64* %246, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %247
 
 ; <label>:247                                     ; preds = %243
   %248 = load i64, i64* %246, align 8
   %249 = bitcast i8* %244 to i64*
-  %NullCheck26 = icmp ne i64* %249, null
-  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64* %249, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %250
 
 ; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
@@ -1133,14 +1215,14 @@ entry:
   %253 = load i8*, i8** %arg1
   %254 = getelementptr inbounds i8, i8* %253, i64 8
   %255 = bitcast i8* %254 to i32*
-  %NullCheck28 = icmp ne i32* %255, null
-  br i1 %NullCheck28, label %256, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i32* %255, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %256
 
 ; <label>:256                                     ; preds = %250
   %257 = load i32, i32* %255, align 8
   %258 = bitcast i8* %252 to i32*
-  %NullCheck30 = icmp ne i32* %258, null
-  br i1 %NullCheck30, label %259, label %ThrowNullRef29
+  %NullCheck29 = icmp eq i32* %258, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %259
 
 ; <label>:259                                     ; preds = %256
   store i32 %257, i32* %258, align 8
@@ -1149,16 +1231,16 @@ entry:
   %262 = load i8*, i8** %arg1
   %263 = getelementptr inbounds i8, i8* %262, i64 12
   %264 = bitcast i8* %263 to i16*
-  %NullCheck32 = icmp ne i16* %264, null
-  br i1 %NullCheck32, label %265, label %ThrowNullRef31
+  %NullCheck31 = icmp eq i16* %264, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %265
 
 ; <label>:265                                     ; preds = %259
   %266 = load i16, i16* %264, align 8
   %267 = sext i16 %266 to i32
   %268 = bitcast i8* %261 to i16*
   %269 = trunc i32 %267 to i16
-  %NullCheck34 = icmp ne i16* %268, null
-  br i1 %NullCheck34, label %270, label %ThrowNullRef33
+  %NullCheck33 = icmp eq i16* %268, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %270
 
 ; <label>:270                                     ; preds = %265
   store i16 %269, i16* %268, align 8
@@ -1168,14 +1250,14 @@ entry:
   %272 = load i8*, i8** %arg0
   %273 = load i8*, i8** %arg1
   %274 = bitcast i8* %273 to i64*
-  %NullCheck8 = icmp ne i64* %274, null
-  br i1 %NullCheck8, label %275, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64* %274, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %275
 
 ; <label>:275                                     ; preds = %271
   %276 = load i64, i64* %274, align 8
   %277 = bitcast i8* %272 to i64*
-  %NullCheck10 = icmp ne i64* %277, null
-  br i1 %NullCheck10, label %278, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %277, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %278
 
 ; <label>:278                                     ; preds = %275
   store i64 %276, i64* %277, align 8
@@ -1184,14 +1266,14 @@ entry:
   %281 = load i8*, i8** %arg1
   %282 = getelementptr inbounds i8, i8* %281, i64 8
   %283 = bitcast i8* %282 to i32*
-  %NullCheck12 = icmp ne i32* %283, null
-  br i1 %NullCheck12, label %284, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i32* %283, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %284
 
 ; <label>:284                                     ; preds = %278
   %285 = load i32, i32* %283, align 8
   %286 = bitcast i8* %280 to i32*
-  %NullCheck14 = icmp ne i32* %286, null
-  br i1 %NullCheck14, label %287, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i32* %286, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %287
 
 ; <label>:287                                     ; preds = %284
   store i32 %285, i32* %286, align 8
@@ -1200,16 +1282,16 @@ entry:
   %290 = load i8*, i8** %arg1
   %291 = getelementptr inbounds i8, i8* %290, i64 12
   %292 = bitcast i8* %291 to i16*
-  %NullCheck16 = icmp ne i16* %292, null
-  br i1 %NullCheck16, label %293, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i16* %292, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %293
 
 ; <label>:293                                     ; preds = %287
   %294 = load i16, i16* %292, align 8
   %295 = sext i16 %294 to i32
   %296 = bitcast i8* %289 to i16*
   %297 = trunc i32 %295 to i16
-  %NullCheck18 = icmp ne i16* %296, null
-  br i1 %NullCheck18, label %298, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i16* %296, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %298
 
 ; <label>:298                                     ; preds = %293
   store i16 %297, i16* %296, align 8
@@ -1217,15 +1299,15 @@ entry:
   %300 = getelementptr inbounds i8, i8* %299, i64 14
   %301 = load i8*, i8** %arg1
   %302 = getelementptr inbounds i8, i8* %301, i64 14
-  %NullCheck20 = icmp ne i8* %302, null
-  br i1 %NullCheck20, label %303, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i8* %302, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %303
 
 ; <label>:303                                     ; preds = %298
   %304 = load i8, i8* %302, align 8
   %305 = zext i8 %304 to i32
   %306 = trunc i32 %305 to i8
-  %NullCheck22 = icmp ne i8* %300, null
-  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i8* %300, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %307
 
 ; <label>:307                                     ; preds = %303
   store i8 %306, i8* %300, align 8
@@ -1235,14 +1317,14 @@ entry:
   %309 = load i8*, i8** %arg0
   %310 = load i8*, i8** %arg1
   %311 = bitcast i8* %310 to i64*
-  %NullCheck = icmp ne i64* %311, null
-  br i1 %NullCheck, label %312, label %ThrowNullRef
+  %NullCheck = icmp eq i64* %311, null
+  br i1 %NullCheck, label %ThrowNullRef, label %312
 
 ; <label>:312                                     ; preds = %308
   %313 = load i64, i64* %311, align 8
   %314 = bitcast i8* %309 to i64*
-  %NullCheck2 = icmp ne i64* %314, null
-  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64* %314, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %315
 
 ; <label>:315                                     ; preds = %312
   store i64 %313, i64* %314, align 8
@@ -1251,14 +1333,14 @@ entry:
   %318 = load i8*, i8** %arg1
   %319 = getelementptr inbounds i8, i8* %318, i64 8
   %320 = bitcast i8* %319 to i64*
-  %NullCheck4 = icmp ne i64* %320, null
-  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64* %320, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %321
 
 ; <label>:321                                     ; preds = %315
   %322 = load i64, i64* %320, align 8
   %323 = bitcast i8* %317 to i64*
-  %NullCheck6 = icmp ne i64* %323, null
-  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64* %323, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %324
 
 ; <label>:324                                     ; preds = %321
   store i64 %322, i64* %323, align 8
@@ -1286,15 +1368,15 @@ entry:
 ; <label>:338                                     ; preds = %333
   %339 = load i8*, i8** %arg0
   %340 = load i8*, i8** %arg1
-  %NullCheck136 = icmp ne i8* %340, null
-  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+  %NullCheck135 = icmp eq i8* %340, null
+  br i1 %NullCheck135, label %ThrowNullRef136, label %341
 
 ; <label>:341                                     ; preds = %338
   %342 = load i8, i8* %340, align 8
   %343 = zext i8 %342 to i32
   %344 = trunc i32 %343 to i8
-  %NullCheck138 = icmp ne i8* %339, null
-  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+  %NullCheck137 = icmp eq i8* %339, null
+  br i1 %NullCheck137, label %ThrowNullRef138, label %345
 
 ; <label>:345                                     ; preds = %341
   store i8 %344, i8* %339, align 8
@@ -1317,16 +1399,16 @@ entry:
   %357 = load i8*, i8** %arg0
   %358 = load i8*, i8** %arg1
   %359 = bitcast i8* %358 to i16*
-  %NullCheck140 = icmp ne i16* %359, null
-  br i1 %NullCheck140, label %360, label %ThrowNullRef139
+  %NullCheck139 = icmp eq i16* %359, null
+  br i1 %NullCheck139, label %ThrowNullRef140, label %360
 
 ; <label>:360                                     ; preds = %356
   %361 = load i16, i16* %359, align 8
   %362 = sext i16 %361 to i32
   %363 = bitcast i8* %357 to i16*
   %364 = trunc i32 %362 to i16
-  %NullCheck142 = icmp ne i16* %363, null
-  br i1 %NullCheck142, label %365, label %ThrowNullRef141
+  %NullCheck141 = icmp eq i16* %363, null
+  br i1 %NullCheck141, label %ThrowNullRef142, label %365
 
 ; <label>:365                                     ; preds = %360
   store i16 %364, i16* %363, align 8
@@ -1352,14 +1434,14 @@ entry:
   %378 = load i8*, i8** %arg0
   %379 = load i8*, i8** %arg1
   %380 = bitcast i8* %379 to i32*
-  %NullCheck144 = icmp ne i32* %380, null
-  br i1 %NullCheck144, label %381, label %ThrowNullRef143
+  %NullCheck143 = icmp eq i32* %380, null
+  br i1 %NullCheck143, label %ThrowNullRef144, label %381
 
 ; <label>:381                                     ; preds = %377
   %382 = load i32, i32* %380, align 8
   %383 = bitcast i8* %378 to i32*
-  %NullCheck146 = icmp ne i32* %383, null
-  br i1 %NullCheck146, label %384, label %ThrowNullRef145
+  %NullCheck145 = icmp eq i32* %383, null
+  br i1 %NullCheck145, label %ThrowNullRef146, label %384
 
 ; <label>:384                                     ; preds = %381
   store i32 %382, i32* %383, align 8
@@ -1384,14 +1466,14 @@ entry:
   %395 = load i8*, i8** %arg0
   %396 = load i8*, i8** %arg1
   %397 = bitcast i8* %396 to i64*
-  %NullCheck164 = icmp ne i64* %397, null
-  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+  %NullCheck163 = icmp eq i64* %397, null
+  br i1 %NullCheck163, label %ThrowNullRef164, label %398
 
 ; <label>:398                                     ; preds = %394
   %399 = load i64, i64* %397, align 8
   %400 = bitcast i8* %395 to i64*
-  %NullCheck166 = icmp ne i64* %400, null
-  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+  %NullCheck165 = icmp eq i64* %400, null
+  br i1 %NullCheck165, label %ThrowNullRef166, label %401
 
 ; <label>:401                                     ; preds = %398
   store i64 %399, i64* %400, align 8
@@ -1400,14 +1482,14 @@ entry:
   %404 = load i8*, i8** %arg1
   %405 = getelementptr inbounds i8, i8* %404, i64 8
   %406 = bitcast i8* %405 to i64*
-  %NullCheck168 = icmp ne i64* %406, null
-  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+  %NullCheck167 = icmp eq i64* %406, null
+  br i1 %NullCheck167, label %ThrowNullRef168, label %407
 
 ; <label>:407                                     ; preds = %401
   %408 = load i64, i64* %406, align 8
   %409 = bitcast i8* %403 to i64*
-  %NullCheck170 = icmp ne i64* %409, null
-  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+  %NullCheck169 = icmp eq i64* %409, null
+  br i1 %NullCheck169, label %ThrowNullRef170, label %410
 
 ; <label>:410                                     ; preds = %407
   store i64 %408, i64* %409, align 8
@@ -1437,14 +1519,14 @@ entry:
   %425 = load i8*, i8** %arg0
   %426 = load i8*, i8** %arg1
   %427 = bitcast i8* %426 to i64*
-  %NullCheck148 = icmp ne i64* %427, null
-  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+  %NullCheck147 = icmp eq i64* %427, null
+  br i1 %NullCheck147, label %ThrowNullRef148, label %428
 
 ; <label>:428                                     ; preds = %424
   %429 = load i64, i64* %427, align 8
   %430 = bitcast i8* %425 to i64*
-  %NullCheck150 = icmp ne i64* %430, null
-  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+  %NullCheck149 = icmp eq i64* %430, null
+  br i1 %NullCheck149, label %ThrowNullRef150, label %431
 
 ; <label>:431                                     ; preds = %428
   store i64 %429, i64* %430, align 8
@@ -1466,14 +1548,14 @@ entry:
   %441 = load i8*, i8** %arg0
   %442 = load i8*, i8** %arg1
   %443 = bitcast i8* %442 to i32*
-  %NullCheck152 = icmp ne i32* %443, null
-  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+  %NullCheck151 = icmp eq i32* %443, null
+  br i1 %NullCheck151, label %ThrowNullRef152, label %444
 
 ; <label>:444                                     ; preds = %440
   %445 = load i32, i32* %443, align 8
   %446 = bitcast i8* %441 to i32*
-  %NullCheck154 = icmp ne i32* %446, null
-  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+  %NullCheck153 = icmp eq i32* %446, null
+  br i1 %NullCheck153, label %ThrowNullRef154, label %447
 
 ; <label>:447                                     ; preds = %444
   store i32 %445, i32* %446, align 8
@@ -1495,16 +1577,16 @@ entry:
   %457 = load i8*, i8** %arg0
   %458 = load i8*, i8** %arg1
   %459 = bitcast i8* %458 to i16*
-  %NullCheck156 = icmp ne i16* %459, null
-  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+  %NullCheck155 = icmp eq i16* %459, null
+  br i1 %NullCheck155, label %ThrowNullRef156, label %460
 
 ; <label>:460                                     ; preds = %456
   %461 = load i16, i16* %459, align 8
   %462 = sext i16 %461 to i32
   %463 = bitcast i8* %457 to i16*
   %464 = trunc i32 %462 to i16
-  %NullCheck158 = icmp ne i16* %463, null
-  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+  %NullCheck157 = icmp eq i16* %463, null
+  br i1 %NullCheck157, label %ThrowNullRef158, label %465
 
 ; <label>:465                                     ; preds = %460
   store i16 %464, i16* %463, align 8
@@ -1525,15 +1607,15 @@ entry:
 ; <label>:474                                     ; preds = %470
   %475 = load i8*, i8** %arg0
   %476 = load i8*, i8** %arg1
-  %NullCheck160 = icmp ne i8* %476, null
-  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+  %NullCheck159 = icmp eq i8* %476, null
+  br i1 %NullCheck159, label %ThrowNullRef160, label %477
 
 ; <label>:477                                     ; preds = %474
   %478 = load i8, i8* %476, align 8
   %479 = zext i8 %478 to i32
   %480 = trunc i32 %479 to i8
-  %NullCheck162 = icmp ne i8* %475, null
-  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+  %NullCheck161 = icmp eq i8* %475, null
+  br i1 %NullCheck161, label %ThrowNullRef162, label %481
 
 ; <label>:481                                     ; preds = %477
   store i8 %480, i8* %475, align 8
@@ -1553,343 +1635,343 @@ ThrowNullRef:                                     ; preds = %308
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %312
+ThrowNullRef2:                                    ; preds = %312
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %315
+ThrowNullRef4:                                    ; preds = %315
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %321
+ThrowNullRef6:                                    ; preds = %321
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %271
+ThrowNullRef8:                                    ; preds = %271
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %275
+ThrowNullRef10:                                   ; preds = %275
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %278
+ThrowNullRef12:                                   ; preds = %278
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %284
+ThrowNullRef14:                                   ; preds = %284
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %287
+ThrowNullRef16:                                   ; preds = %287
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %293
+ThrowNullRef18:                                   ; preds = %293
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %298
+ThrowNullRef20:                                   ; preds = %298
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %303
+ThrowNullRef22:                                   ; preds = %303
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %243
+ThrowNullRef24:                                   ; preds = %243
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %247
+ThrowNullRef26:                                   ; preds = %247
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %250
+ThrowNullRef28:                                   ; preds = %250
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %256
+ThrowNullRef30:                                   ; preds = %256
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %259
+ThrowNullRef32:                                   ; preds = %259
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %265
+ThrowNullRef34:                                   ; preds = %265
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %217
+ThrowNullRef36:                                   ; preds = %217
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %221
+ThrowNullRef38:                                   ; preds = %221
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %224
+ThrowNullRef40:                                   ; preds = %224
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %230
+ThrowNullRef42:                                   ; preds = %230
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %233
+ThrowNullRef44:                                   ; preds = %233
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %238
+ThrowNullRef46:                                   ; preds = %238
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %200
+ThrowNullRef48:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %204
+ThrowNullRef50:                                   ; preds = %204
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %207
+ThrowNullRef52:                                   ; preds = %207
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %213
+ThrowNullRef54:                                   ; preds = %213
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %172
+ThrowNullRef56:                                   ; preds = %172
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %176
+ThrowNullRef58:                                   ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %179
+ThrowNullRef60:                                   ; preds = %179
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %185
+ThrowNullRef62:                                   ; preds = %185
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %190
+ThrowNullRef64:                                   ; preds = %190
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %195
+ThrowNullRef66:                                   ; preds = %195
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %153
+ThrowNullRef68:                                   ; preds = %153
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %157
+ThrowNullRef70:                                   ; preds = %157
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %160
+ThrowNullRef72:                                   ; preds = %160
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %166
+ThrowNullRef74:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %136
+ThrowNullRef76:                                   ; preds = %136
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %140
+ThrowNullRef78:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %143
+ThrowNullRef80:                                   ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %148
+ThrowNullRef82:                                   ; preds = %148
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %128
+ThrowNullRef84:                                   ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %132
+ThrowNullRef86:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %100
+ThrowNullRef88:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %104
+ThrowNullRef90:                                   ; preds = %104
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %107
+ThrowNullRef92:                                   ; preds = %107
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %113
+ThrowNullRef94:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %118
+ThrowNullRef96:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %123
+ThrowNullRef98:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %81
+ThrowNullRef100:                                  ; preds = %81
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef101:                                  ; preds = %85
+ThrowNullRef102:                                  ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef103:                                  ; preds = %88
+ThrowNullRef104:                                  ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef105:                                  ; preds = %94
+ThrowNullRef106:                                  ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef107:                                  ; preds = %64
+ThrowNullRef108:                                  ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef109:                                  ; preds = %68
+ThrowNullRef110:                                  ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef111:                                  ; preds = %71
+ThrowNullRef112:                                  ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef113:                                  ; preds = %76
+ThrowNullRef114:                                  ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef115:                                  ; preds = %56
+ThrowNullRef116:                                  ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef117:                                  ; preds = %60
+ThrowNullRef118:                                  ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef119:                                  ; preds = %37
+ThrowNullRef120:                                  ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef121:                                  ; preds = %41
+ThrowNullRef122:                                  ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef123:                                  ; preds = %46
+ThrowNullRef124:                                  ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef125:                                  ; preds = %51
+ThrowNullRef126:                                  ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef127:                                  ; preds = %27
+ThrowNullRef128:                                  ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef129:                                  ; preds = %31
+ThrowNullRef130:                                  ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef131:                                  ; preds = %19
+ThrowNullRef132:                                  ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef133:                                  ; preds = %22
+ThrowNullRef134:                                  ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef135:                                  ; preds = %338
+ThrowNullRef136:                                  ; preds = %338
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef137:                                  ; preds = %341
+ThrowNullRef138:                                  ; preds = %341
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef139:                                  ; preds = %356
+ThrowNullRef140:                                  ; preds = %356
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef141:                                  ; preds = %360
+ThrowNullRef142:                                  ; preds = %360
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef143:                                  ; preds = %377
+ThrowNullRef144:                                  ; preds = %377
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef145:                                  ; preds = %381
+ThrowNullRef146:                                  ; preds = %381
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef147:                                  ; preds = %424
+ThrowNullRef148:                                  ; preds = %424
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef149:                                  ; preds = %428
+ThrowNullRef150:                                  ; preds = %428
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef151:                                  ; preds = %440
+ThrowNullRef152:                                  ; preds = %440
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef153:                                  ; preds = %444
+ThrowNullRef154:                                  ; preds = %444
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef155:                                  ; preds = %456
+ThrowNullRef156:                                  ; preds = %456
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef157:                                  ; preds = %460
+ThrowNullRef158:                                  ; preds = %460
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef159:                                  ; preds = %474
+ThrowNullRef160:                                  ; preds = %474
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef161:                                  ; preds = %477
+ThrowNullRef162:                                  ; preds = %477
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef163:                                  ; preds = %394
+ThrowNullRef164:                                  ; preds = %394
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef165:                                  ; preds = %398
+ThrowNullRef166:                                  ; preds = %398
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef167:                                  ; preds = %401
+ThrowNullRef168:                                  ; preds = %401
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef169:                                  ; preds = %407
+ThrowNullRef170:                                  ; preds = %407
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1939,8 +2021,8 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
-  br i1 %NullCheck, label %22, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %ThrowNullRef, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
@@ -1948,8 +2030,8 @@ entry:
   store i32 %24, i32* %loc0
   %25 = load i32, i32* %loc0
   %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %26, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %27
 
 ; <label>:27                                      ; preds = %22
   %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
@@ -1971,7 +2053,7 @@ ThrowNullRef:                                     ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1989,8 +2071,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -2022,15 +2104,15 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2048,16 +2130,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
   %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
   store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %15
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
@@ -2072,8 +2154,8 @@ entry:
   %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
   %29 = ptrtoint i16 addrspace(1)* %28 to i64
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %19
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
@@ -2089,19 +2171,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2114,8 +2196,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
@@ -2128,7 +2210,7 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[loadElem]
+Failed to read AppDomain.PrepareDataForSetup[storeElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
@@ -2202,8 +2284,8 @@ entry:
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
-  br i1 %NullCheck24, label %27, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = load i64, i64 addrspace(1)* %26
@@ -2218,8 +2300,8 @@ entry:
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
-  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
   %41 = load i64, i64 addrspace(1)* %39
@@ -2236,8 +2318,8 @@ entry:
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
-  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
   %54 = load i64, i64 addrspace(1)* %52
@@ -2252,8 +2334,8 @@ entry:
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
   %67 = load i64, i64 addrspace(1)* %65
@@ -2270,8 +2352,8 @@ entry:
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
-  br i1 %NullCheck16, label %79, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
   %80 = load i64, i64 addrspace(1)* %78
@@ -2286,8 +2368,8 @@ entry:
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
-  br i1 %NullCheck18, label %92, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
   %93 = load i64, i64 addrspace(1)* %91
@@ -2304,8 +2386,8 @@ entry:
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
-  br i1 %NullCheck12, label %105, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = load i64, i64 addrspace(1)* %104
@@ -2320,8 +2402,8 @@ entry:
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
-  br i1 %NullCheck14, label %118, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
   %119 = load i64, i64 addrspace(1)* %117
@@ -2337,8 +2419,8 @@ entry:
 
 ; <label>:128                                     ; preds = %20
   %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
-  br i1 %NullCheck4, label %130, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %129, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %130
 
 ; <label>:130                                     ; preds = %128
   %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
@@ -2346,8 +2428,8 @@ entry:
   %133 = load i16, i16 addrspace(1)* %132, align 8
   %134 = zext i16 %133 to i32
   %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
-  br i1 %NullCheck6, label %136, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %135, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %136
 
 ; <label>:136                                     ; preds = %130
   %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
@@ -2360,8 +2442,8 @@ entry:
 
 ; <label>:143                                     ; preds = %136
   %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
-  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %144, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %145
 
 ; <label>:145                                     ; preds = %143
   %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
@@ -2369,8 +2451,8 @@ entry:
   %148 = load i16, i16 addrspace(1)* %147, align 8
   %149 = zext i16 %148 to i32
   %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %150, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %151
 
 ; <label>:151                                     ; preds = %145
   %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
@@ -2388,8 +2470,8 @@ entry:
 
 ; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
-  br i1 %NullCheck, label %163, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %ThrowNullRef, label %163
 
 ; <label>:163                                     ; preds = %161
   %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
@@ -2399,8 +2481,8 @@ entry:
 
 ; <label>:167                                     ; preds = %163
   %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
-  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %168, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %169
 
 ; <label>:169                                     ; preds = %167
   %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
@@ -2432,55 +2514,55 @@ ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %167
+ThrowNullRef2:                                    ; preds = %167
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %128
+ThrowNullRef4:                                    ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %130
+ThrowNullRef6:                                    ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %143
+ThrowNullRef8:                                    ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %145
+ThrowNullRef10:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %102
+ThrowNullRef12:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %105
+ThrowNullRef14:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %76
+ThrowNullRef16:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %79
+ThrowNullRef18:                                   ; preds = %79
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %50
+ThrowNullRef20:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %53
+ThrowNullRef22:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %24
+ThrowNullRef24:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %27
+ThrowNullRef26:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2503,15 +2585,15 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2519,16 +2601,16 @@ entry:
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
   store i32 %8, i32* %loc0
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
   %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
   store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
@@ -2546,16 +2628,16 @@ entry:
 
 ; <label>:23                                      ; preds = %64
   %24 = load i16*, i16** %loc3
-  %NullCheck12 = icmp ne i16* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i16* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
   store i32 %27, i32* %loc5
   %28 = load i16*, i16** %loc4
-  %NullCheck14 = icmp ne i16* %28, null
-  br i1 %NullCheck14, label %29, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %28, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = load i16, i16* %28, align 8
@@ -2620,15 +2702,15 @@ entry:
 
 ; <label>:67                                      ; preds = %64
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
-  br i1 %NullCheck8, label %69, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %68, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %69
 
 ; <label>:69                                      ; preds = %67
   %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
   %71 = load i32, i32 addrspace(1)* %70
   %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
-  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %73
 
 ; <label>:73                                      ; preds = %69
   %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
@@ -2645,31 +2727,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %67
+ThrowNullRef8:                                    ; preds = %67
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %69
+ThrowNullRef10:                                   ; preds = %69
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2710,14 +2792,14 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
   %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
@@ -2730,14 +2812,14 @@ entry:
 
 ; <label>:11                                      ; preds = %4
   %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
   %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
@@ -2749,14 +2831,14 @@ entry:
 
 ; <label>:22                                      ; preds = %16
   %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
   %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
-  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
-  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
@@ -2804,23 +2886,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2836,7 +2918,280 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[loadElem]
+Successfully read RuntimeType.IsAssignableFrom
+
+define i8 @RuntimeType.IsAssignableFrom(%System.RuntimeType addrspace(1)* %param0, %System.Type addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.RuntimeType addrspace(1)*
+  %arg1 = alloca %System.Type addrspace(1)*
+  %loc0 = alloca %System.RuntimeType addrspace(1)*
+  %loc1 = alloca %"System.Type[]" addrspace(1)*
+  %loc2 = alloca i32
+  store %System.RuntimeType addrspace(1)* %param0, %System.RuntimeType addrspace(1)** %this
+  store %System.Type addrspace(1)* %param1, %System.Type addrspace(1)** %arg1
+  %0 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %1 = icmp ne %System.Type addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i8 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %5 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %6 = bitcast %System.Type addrspace(1)* %4 to %System.Object addrspace(1)*
+  %7 = bitcast %System.RuntimeType addrspace(1)* %5 to %System.Object addrspace(1)*
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %6, %System.Object addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %3
+  ret i8 1
+
+; <label>:12                                      ; preds = %3
+  %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 152
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 32
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
+  %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
+  %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
+  store %System.RuntimeType addrspace(1)* %25, %System.RuntimeType addrspace(1)** %loc0
+  %26 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %27 = icmp eq %System.RuntimeType addrspace(1)* %26, null
+  br i1 %27, label %34, label %28
+
+; <label>:28                                      ; preds = %15
+  %29 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %30 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)*)*)(%System.RuntimeType addrspace(1)* %29, %System.RuntimeType addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+; <label>:34                                      ; preds = %15
+  %35 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %36 = call %System.Reflection.Emit.TypeBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Reflection.Emit.TypeBuilder addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %35)
+  %37 = icmp eq %System.Reflection.Emit.TypeBuilder addrspace(1)* %36, null
+  br i1 %37, label %139, label %38
+
+; <label>:38                                      ; preds = %34
+  %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %42
+
+; <label>:42                                      ; preds = %38
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 152
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 40
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
+  %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
+  %53 = zext i8 %52 to i32
+  %54 = icmp eq i32 %53, 0
+  br i1 %54, label %56, label %55
+
+; <label>:55                                      ; preds = %42
+  ret i8 1
+
+; <label>:56                                      ; preds = %42
+  %57 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %58 = bitcast %System.RuntimeType addrspace(1)* %57 to %System.Type addrspace(1)*
+  %59 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %58)
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %64 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.Type addrspace(1)* %63, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = bitcast %System.RuntimeType addrspace(1)* %64 to %System.Type addrspace(1)*
+  %67 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %63, %System.Type addrspace(1)* %66)
+  %68 = zext i8 %67 to i32
+  %69 = trunc i32 %68 to i8
+  ret i8 %69
+
+; <label>:70                                      ; preds = %56
+  %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
+  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %73
+
+; <label>:73                                      ; preds = %70
+  %74 = load i64, i64 addrspace(1)* %72
+  %75 = add i64 %74, 128
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = add i64 %77, 0
+  %79 = inttoptr i64 %78 to i64*
+  %80 = load i64, i64* %79
+  %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
+  %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
+  %83 = call i8 %82(%System.Type addrspace(1)* %81)
+  %84 = zext i8 %83 to i32
+  %85 = icmp eq i32 %84, 0
+  br i1 %85, label %139, label %86
+
+; <label>:86                                      ; preds = %73
+  %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
+  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %89
+
+; <label>:89                                      ; preds = %86
+  %90 = load i64, i64 addrspace(1)* %88
+  %91 = add i64 %90, 128
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = add i64 %93, 24
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
+  %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
+  %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
+  store %"System.Type[]" addrspace(1)* %99, %"System.Type[]" addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %129
+
+; <label>:100                                     ; preds = %132
+  %101 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %102 = load i32, i32* %loc2
+  %NullCheck11 = icmp eq %"System.Type[]" addrspace(1)* %101, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %103
+
+; <label>:103                                     ; preds = %100
+  %104 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 1
+  %105 = load i32, i32 addrspace(1)* %104
+  %106 = zext i32 %105 to i64
+  %107 = zext i32 %102 to i64
+  %BoundsCheck = icmp uge i64 %107, %106
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %108
+
+; <label>:108                                     ; preds = %103
+  %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
+  %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
+  %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
+  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %113
+
+; <label>:113                                     ; preds = %108
+  %114 = load i64, i64 addrspace(1)* %112
+  %115 = add i64 %114, 152
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = add i64 %117, 56
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
+  %123 = zext i8 %122 to i32
+  %124 = icmp ne i32 %123, 0
+  br i1 %124, label %126, label %125
+
+; <label>:125                                     ; preds = %113
+  ret i8 0
+
+; <label>:126                                     ; preds = %113
+  %127 = load i32, i32* %loc2
+  %128 = add i32 %127, 1
+  store i32 %128, i32* %loc2
+  br label %129
+
+; <label>:129                                     ; preds = %89, %126
+  %130 = load i32, i32* %loc2
+  %131 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %NullCheck9 = icmp eq %"System.Type[]" addrspace(1)* %131, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %132
+
+; <label>:132                                     ; preds = %129
+  %133 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %131, i32 0, i32 1
+  %134 = load i32, i32 addrspace(1)* %133
+  %135 = zext i32 %134 to i64
+  %136 = trunc i64 %135 to i32
+  %137 = icmp slt i32 %130, %136
+  br i1 %137, label %100, label %138
+
+; <label>:138                                     ; preds = %132
+  ret i8 1
+
+; <label>:139                                     ; preds = %34, %73
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %129
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %103
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -2893,7 +3248,7 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElem]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -2904,8 +3259,8 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -2997,8 +3352,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
@@ -3059,8 +3414,8 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -3087,8 +3442,8 @@ entry:
 
 ; <label>:17                                      ; preds = %5, %11
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
@@ -3097,8 +3452,8 @@ entry:
 
 ; <label>:22                                      ; preds = %1, %11
   %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
@@ -3109,11 +3464,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %17
+ThrowNullRef2:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %22
+ThrowNullRef4:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3167,15 +3522,15 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
   %15 = load i32, i32 addrspace(1)* %14
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
@@ -3198,7 +3553,7 @@ ThrowNullRef:                                     ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef2:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3232,8 +3587,8 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
@@ -3312,8 +3667,8 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -3327,8 +3682,8 @@ entry:
 ; <label>:5                                       ; preds = %43
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %7 = load i32, i32* %loc1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck6, label %8, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
@@ -3366,8 +3721,8 @@ entry:
 ; <label>:32                                      ; preds = %21, %25
   %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
   %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
-  br i1 %NullCheck8, label %35, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = trunc i32 %34 to i16
@@ -3380,8 +3735,8 @@ entry:
 ; <label>:40                                      ; preds = %1, %35
   %41 = load i32, i32* %loc1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
-  br i1 %NullCheck2, label %43, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %42, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
@@ -3392,8 +3747,8 @@ entry:
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
   %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
-  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
   %51 = load i64, i64 addrspace(1)* %49
@@ -3412,19 +3767,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %40
+ThrowNullRef2:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %47
+ThrowNullRef4:                                    ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %5
+ThrowNullRef6:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %32
+ThrowNullRef8:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3467,8 +3822,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
@@ -3492,11 +3847,391 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(i16* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store i16* %param0, i16** %arg0
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load i32, i32* %arg3
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %42, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %37, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg2
+  %13 = load i32, i32* %arg3
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %37, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %24 = load i32, i32* %arg2
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load i16*, i16** %arg0
+  %35 = load i32, i32* %arg3
+  %36 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %36, i16* %34, i32 %35)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:37                                      ; preds = %5, %16
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %39)
+  %41 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41, %System.String addrspace(1)* %38, %System.String addrspace(1)* %40)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41) #0
+  unreachable
+
+; <label>:42                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
-Failed to read StringBuilder.ToString[loadElemA]
+Successfully read StringBuilder.ToString
+
+define %System.String addrspace(1)* @StringBuilder.ToString(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i16*
+  %loc3 = alloca %"System.Char[]" addrspace(1)*
+  %loc4 = alloca i32
+  %loc5 = alloca i32
+  %loc6 = alloca i16 addrspace(1)*
+  %loc7 = alloca %System.String addrspace(1)*
+  %loc8 = alloca %"System.Char[]" addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %0)
+  %2 = icmp ne i32 %1, 0
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %4
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %6)
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %7)
+  store %System.String addrspace(1)* %8, %System.String addrspace(1)** %loc0
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.Text.StringBuilder addrspace(1)* %9, %System.Text.StringBuilder addrspace(1)** %loc1
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  store %System.String addrspace(1)* %10, %System.String addrspace(1)** %loc7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc7
+  %12 = ptrtoint %System.String addrspace(1)* %11 to i64
+  %13 = icmp eq i64 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %5
+  %15 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %16 = sext i32 %15 to i64
+  %17 = add i64 %12, %16
+  br label %18
+
+; <label>:18                                      ; preds = %5, %14
+  %19 = phi i64 [ %12, %5 ], [ %17, %14 ]
+  %20 = inttoptr i64 %19 to i16*
+  store i16* %20, i16** %loc2
+  br label %21
+
+; <label>:21                                      ; preds = %98, %18
+  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %22, null
+  br i1 %NullCheck, label %ThrowNullRef, label %23
+
+; <label>:23                                      ; preds = %21
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 3
+  %25 = load i32, i32 addrspace(1)* %24, align 8
+  %26 = icmp sle i32 %25, 0
+  br i1 %26, label %96, label %27
+
+; <label>:27                                      ; preds = %23
+  %28 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %28, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %29
+
+; <label>:29                                      ; preds = %27
+  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %28, i32 0, i32 1
+  %31 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %30, align 8
+  store %"System.Char[]" addrspace(1)* %31, %"System.Char[]" addrspace(1)** %loc3
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %33
+
+; <label>:33                                      ; preds = %29
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  store i32 %35, i32* %loc4
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  %39 = load i32, i32 addrspace(1)* %38, align 8
+  store i32 %39, i32* %loc5
+  %40 = load i32, i32* %loc5
+  %41 = load i32, i32* %loc4
+  %42 = add i32 %40, %41
+  %43 = zext i32 %42 to i64
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %45
+
+; <label>:45                                      ; preds = %37
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = sext i32 %47 to i64
+  %49 = icmp sgt i64 %43, %48
+  br i1 %49, label %91, label %50
+
+; <label>:50                                      ; preds = %45
+  %51 = load i32, i32* %loc5
+  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %52, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %53
+
+; <label>:53                                      ; preds = %50
+  %54 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %52, i32 0, i32 1
+  %55 = load i32, i32 addrspace(1)* %54
+  %56 = zext i32 %55 to i64
+  %57 = trunc i64 %56 to i32
+  %58 = icmp ugt i32 %51, %57
+  br i1 %58, label %91, label %59
+
+; <label>:59                                      ; preds = %53
+  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  store %"System.Char[]" addrspace(1)* %60, %"System.Char[]" addrspace(1)** %loc8
+  %61 = icmp eq %"System.Char[]" addrspace(1)* %60, null
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %63, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %64
+
+; <label>:64                                      ; preds = %62
+  %65 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %63, i32 0, i32 1
+  %66 = load i32, i32 addrspace(1)* %65
+  %67 = zext i32 %66 to i64
+  %68 = trunc i64 %67 to i32
+  %69 = icmp ne i32 %68, 0
+  br i1 %69, label %71, label %70
+
+; <label>:70                                      ; preds = %59, %64
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:71                                      ; preds = %64
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %73
+
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %BoundsCheck = icmp uge i64 0, %76
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %77
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %78, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:79                                      ; preds = %70, %77
+  %80 = load i16*, i16** %loc2
+  %81 = load i32, i32* %loc4
+  %82 = sext i32 %81 to i64
+  %83 = mul i64 %82, 2
+  %84 = bitcast i16* %80 to i8*
+  %85 = getelementptr inbounds i8, i8* %84, i64 %83
+  %86 = load i16 addrspace(1)*, i16 addrspace(1)** %loc6
+  %87 = ptrtoint i16 addrspace(1)* %86 to i64
+  %88 = load i32, i32* %loc5
+  %89 = bitcast i8* %85 to i16*
+  %90 = inttoptr i64 %87 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %89, i16* %90, i32 %88)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %96
+
+; <label>:91                                      ; preds = %45, %53
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %94 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %93)
+  %95 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95, %System.String addrspace(1)* %92, %System.String addrspace(1)* %94)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95) #0
+  unreachable
+
+; <label>:96                                      ; preds = %23, %79
+  %97 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %97, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %98
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %97, i32 0, i32 2
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  store %System.Text.StringBuilder addrspace(1)* %100, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %102 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %102, label %21, label %103
+
+; <label>:103                                     ; preds = %98
+  store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc7
+  %104 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  ret %System.String addrspace(1)* %104
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method StringBuilder::get_Length using LLILCJit
+Successfully read StringBuilder.get_Length
+
+define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
+Successfully read RuntimeHelpers.get_OffsetToStringData
+
+define i32 @RuntimeHelpers.get_OffsetToStringData() {
+entry:
+  ret i32 12
+}
+
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
 Successfully read CultureData.CreateCultureData
 
@@ -3514,23 +4249,23 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
   store i8 %4, i8 addrspace(1)* %6
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
@@ -3549,11 +4284,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3566,50 +4301,50 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
   store i32 -1, i32 addrspace(1)* %2
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
   store i32 -1, i32 addrspace(1)* %8
   %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
   store i32 -1, i32 addrspace(1)* %14
   %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
   store i32 -1, i32 addrspace(1)* %17
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
@@ -3623,27 +4358,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3675,7 +4410,136 @@ Failed to read Dictionary`2.Insert[non-const derefAddress]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
 Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
-Failed to read HashHelpers.GetPrime[loadElem]
+Successfully read HashHelpers.GetPrime
+
+define i32 @HashHelpers.GetPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %6, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5, %System.String addrspace(1)* %4)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5) #0
+  unreachable
+
+; <label>:6                                       ; preds = %entry
+  store i32 0, i32* %loc0
+  br label %29
+
+; <label>:7                                       ; preds = %35
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 1296
+  %10 = addrspacecast i8 addrspace(1)* %9 to %"System.Int32[]" addrspace(1)**
+  %11 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %10
+  %12 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Int32[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = zext i32 %15 to i64
+  %17 = zext i32 %12 to i64
+  %BoundsCheck = icmp uge i64 %17, %16
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 3, i32 %12
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  store i32 %20, i32* %loc1
+  %21 = load i32, i32* %loc1
+  %22 = load i32, i32* %arg0
+  %23 = icmp slt i32 %21, %22
+  br i1 %23, label %26, label %24
+
+; <label>:24                                      ; preds = %18
+  %25 = load i32, i32* %loc1
+  ret i32 %25
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %loc0
+  %28 = add i32 %27, 1
+  store i32 %28, i32* %loc0
+  br label %29
+
+; <label>:29                                      ; preds = %6, %26
+  %30 = load i32, i32* %loc0
+  %31 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %32 = getelementptr inbounds i8, i8 addrspace(1)* %31, i64 1296
+  %33 = addrspacecast i8 addrspace(1)* %32 to %"System.Int32[]" addrspace(1)**
+  %34 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %33
+  %NullCheck = icmp eq %"System.Int32[]" addrspace(1)* %34, null
+  br i1 %NullCheck, label %ThrowNullRef, label %35
+
+; <label>:35                                      ; preds = %29
+  %36 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %34, i32 0, i32 1
+  %37 = load i32, i32 addrspace(1)* %36
+  %38 = zext i32 %37 to i64
+  %39 = trunc i64 %38 to i32
+  %40 = icmp slt i32 %30, %39
+  br i1 %40, label %7, label %41
+
+; <label>:41                                      ; preds = %35
+  %42 = load i32, i32* %arg0
+  %43 = or i32 %42, 1
+  store i32 %43, i32* %loc2
+  br label %59
+
+; <label>:44                                      ; preds = %59
+  %45 = load i32, i32* %loc2
+  %46 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %45)
+  %47 = zext i8 %46 to i32
+  %48 = icmp eq i32 %47, 0
+  br i1 %48, label %56, label %49
+
+; <label>:49                                      ; preds = %44
+  %50 = load i32, i32* %loc2
+  %51 = sub i32 %50, 1
+  %52 = srem i32 %51, 101
+  %53 = icmp eq i32 %52, 0
+  br i1 %53, label %56, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = load i32, i32* %loc2
+  ret i32 %55
+
+; <label>:56                                      ; preds = %44, %49
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %57, 2
+  store i32 %58, i32* %loc2
+  br label %59
+
+; <label>:59                                      ; preds = %41, %56
+  %60 = load i32, i32* %loc2
+  %61 = icmp slt i32 %60, 2147483647
+  br i1 %61, label %44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load i32, i32* %arg0
+  ret i32 %63
+
+ThrowNullRef:                                     ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
 Successfully read GenericEqualityComparer`1.GetHashCode
 
@@ -3694,14 +4558,14 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
   %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load i64, i64 addrspace(1)* %7
@@ -3720,7 +4584,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3750,8 +4614,8 @@ entry:
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
@@ -3796,8 +4660,8 @@ entry:
   %35 = bitcast i16* %34 to i8*
   %36 = getelementptr inbounds i8, i8* %35, i64 2
   %37 = bitcast i8* %36 to i16*
-  %NullCheck4 = icmp ne i16* %37, null
-  br i1 %NullCheck4, label %38, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %37, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %38
 
 ; <label>:38                                      ; preds = %27
   %39 = load i16, i16* %37, align 8
@@ -3824,8 +4688,8 @@ entry:
 
 ; <label>:54                                      ; preds = %22, %43
   %55 = load i16*, i16** %loc4
-  %NullCheck2 = icmp ne i16* %55, null
-  br i1 %NullCheck2, label %56, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i16* %55, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %56
 
 ; <label>:56                                      ; preds = %54
   %57 = load i16, i16* %55, align 8
@@ -3850,11 +4714,11 @@ ThrowNullRef:                                     ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %54
+ThrowNullRef2:                                    ; preds = %54
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %27
+ThrowNullRef4:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3871,8 +4735,8 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -3907,8 +4771,8 @@ entry:
 
 ; <label>:26                                      ; preds = %19
   %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
-  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %28
 
 ; <label>:28                                      ; preds = %26
   %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
@@ -3920,7 +4784,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3972,8 +4836,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
@@ -3984,26 +4848,26 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
-  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
@@ -4014,8 +4878,8 @@ entry:
 ; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
@@ -4024,8 +4888,8 @@ entry:
 
 ; <label>:25                                      ; preds = %1, %16, %23
   %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
-  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
@@ -4036,27 +4900,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %20
+ThrowNullRef10:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4069,8 +4933,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -4081,8 +4945,8 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
@@ -4091,8 +4955,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1, %8
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
@@ -4103,11 +4967,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4128,24 +4992,24 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   store i32 %3, i32* %loc0
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
   %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
   store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck4, label %9, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
@@ -4164,15 +5028,15 @@ entry:
 ; <label>:18                                      ; preds = %70
   %19 = load i16*, i16** %loc3
   %20 = bitcast i16* %19 to i64*
-  %NullCheck10 = icmp ne i64* %20, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %20, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = load i64, i64* %20, align 8
   %23 = load i16*, i16** %loc4
   %24 = bitcast i16* %23 to i64*
-  %NullCheck12 = icmp ne i64* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = load i64, i64* %24, align 8
@@ -4188,8 +5052,8 @@ entry:
   %31 = bitcast i16* %30 to i8*
   %32 = getelementptr inbounds i8, i8* %31, i64 8
   %33 = bitcast i8* %32 to i64*
-  %NullCheck14 = icmp ne i64* %33, null
-  br i1 %NullCheck14, label %34, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = load i64, i64* %33, align 8
@@ -4197,8 +5061,8 @@ entry:
   %37 = bitcast i16* %36 to i8*
   %38 = getelementptr inbounds i8, i8* %37, i64 8
   %39 = bitcast i8* %38 to i64*
-  %NullCheck16 = icmp ne i64* %39, null
-  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %40
 
 ; <label>:40                                      ; preds = %34
   %41 = load i64, i64* %39, align 8
@@ -4214,8 +5078,8 @@ entry:
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %NullCheck18 = icmp ne i64* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = load i64, i64* %48, align 8
@@ -4223,8 +5087,8 @@ entry:
   %52 = bitcast i16* %51 to i8*
   %53 = getelementptr inbounds i8, i8* %52, i64 16
   %54 = bitcast i8* %53 to i64*
-  %NullCheck20 = icmp ne i64* %54, null
-  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64* %54, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %55
 
 ; <label>:55                                      ; preds = %49
   %56 = load i64, i64* %54, align 8
@@ -4262,15 +5126,15 @@ entry:
 ; <label>:74                                      ; preds = %95
   %75 = load i16*, i16** %loc3
   %76 = bitcast i16* %75 to i32*
-  %NullCheck6 = icmp ne i32* %76, null
-  br i1 %NullCheck6, label %77, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32* %76, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %77
 
 ; <label>:77                                      ; preds = %74
   %78 = load i32, i32* %76, align 8
   %79 = load i16*, i16** %loc4
   %80 = bitcast i16* %79 to i32*
-  %NullCheck8 = icmp ne i32* %80, null
-  br i1 %NullCheck8, label %81, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i32* %80, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %81
 
 ; <label>:81                                      ; preds = %77
   %82 = load i32, i32* %80, align 8
@@ -4318,43 +5182,43 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %74
+ThrowNullRef6:                                    ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %77
+ThrowNullRef8:                                    ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %29
+ThrowNullRef14:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %34
+ThrowNullRef16:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4376,8 +5240,8 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load i64, i64 addrspace(1)* %4
@@ -4389,8 +5253,8 @@ entry:
   %12 = load i64, i64* %11
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %5
   %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
@@ -4399,8 +5263,8 @@ entry:
   %18 = load i8, i8* %arg2
   %19 = zext i8 %18 to i32
   %20 = trunc i32 %19 to i8
-  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %15
   %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
@@ -4411,11 +5275,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4442,8 +5306,8 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
@@ -4466,16 +5330,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
   %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = load i64, i64 addrspace(1)* %19
@@ -4500,8 +5364,8 @@ entry:
 ; <label>:35                                      ; preds = %30
   %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
@@ -4514,8 +5378,8 @@ entry:
 
 ; <label>:42                                      ; preds = %1, %38
   %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
-  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
@@ -4526,19 +5390,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %35
+ThrowNullRef2:                                    ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %42
+ThrowNullRef8:                                    ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4551,14 +5415,14 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
@@ -4570,7 +5434,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4583,8 +5447,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
@@ -4613,51 +5477,51 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
   %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
   %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
   %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
   %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
-  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
   store i64 %21, i64 addrspace(1)* %23
   %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %25 = load i64, i64* %loc0
-  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
@@ -4668,27 +5532,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %22
+ThrowNullRef12:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4701,8 +5565,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
@@ -4713,19 +5577,19 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
@@ -4734,8 +5598,8 @@ entry:
 
 ; <label>:15                                      ; preds = %1, %13
   %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
@@ -4746,19 +5610,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %15
+ThrowNullRef8:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4771,8 +5635,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -4831,8 +5695,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
@@ -4882,8 +5746,8 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
-  br i1 %NullCheck, label %17, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %ThrowNullRef, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
@@ -4894,15 +5758,15 @@ entry:
 
 ; <label>:22                                      ; preds = %17
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
-  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
   %26 = load i32, i32 addrspace(1)* %25
   %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
-  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %27, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
@@ -4925,8 +5789,8 @@ entry:
 ; <label>:40                                      ; preds = %17
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
-  br i1 %NullCheck6, label %43, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %41, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
@@ -4938,34 +5802,17 @@ ThrowNullRef:                                     ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %24
+ThrowNullRef4:                                    ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %40
+ThrowNullRef6:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
-}
-
-INFO:  jitting method Object::ReferenceEquals using LLILCJit
-Successfully read Object.ReferenceEquals
-
-define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
-entry:
-  %arg0 = alloca %System.Object addrspace(1)*
-  %arg1 = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
-  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
-  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = icmp eq %System.Object addrspace(1)* %0, %1
-  %3 = sext i1 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
 }
 
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
@@ -4978,21 +5825,21 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
   %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
-  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
@@ -5007,28 +5854,28 @@ entry:
 ; <label>:13                                      ; preds = %8, %12
   %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
   %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
   %21 = load i32, i32 addrspace(1)* %20, align 8
   %22 = add i32 %21, 1
-  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
   store i32 %22, i32 addrspace(1)* %24
   %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
@@ -5039,27 +5886,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5077,7 +5924,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::Setup using LLILCJit
-Failed to read AppDomain.Setup[loadElem]
+Failed to read AppDomain.Setup[unbox]
 INFO:  jitting method Thread::GetDomain using LLILCJit
 Successfully read Thread.GetDomain
 
@@ -5108,8 +5955,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
@@ -5122,14 +5969,14 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
   %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
@@ -5141,11 +5988,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5173,8 +6020,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -5189,7 +6036,328 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
 Failed to read KeyCollection.System.Collections.Generic.IEnumerable<TKey>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Successfully read Enumerator.MoveNext
+
+define i8 @Enumerator.MoveNext(%"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.RuntimeTypeHandle* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*
+  %"$TypeArg" = alloca %System.RuntimeTypeHandle*
+  store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
+  %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 8
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %76, label %12
+
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
+  br label %76
+
+; <label>:13                                      ; preds = %85
+  %14 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck19 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %15
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, i32 0, i32 0
+  %17 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %16, align 8
+  %NullCheck21 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, i32 0, i32 2
+  %20 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %19, align 8
+  %21 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck23 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %22
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, i32 0, i32 2
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %NullCheck25 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 3, i32 %24
+  %NullCheck27 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %32
+
+; <label>:32                                      ; preds = %30
+  %33 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, i32 0, i32 2
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = icmp slt i32 %34, 0
+  br i1 %35, label %68, label %36
+
+; <label>:36                                      ; preds = %32
+  %37 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %38 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck29 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %39
+
+; <label>:39                                      ; preds = %36
+  %40 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, i32 0, i32 0
+  %41 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %40, align 8
+  %NullCheck31 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, i32 0, i32 2
+  %44 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %43, align 8
+  %45 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck33 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, i32 0, i32 2
+  %48 = load i32, i32 addrspace(1)* %47, align 8
+  %NullCheck35 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %49
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = zext i32 %51 to i64
+  %53 = zext i32 %48 to i64
+  %BoundsCheck37 = icmp uge i64 %53, %52
+  br i1 %BoundsCheck37, label %ThrowIndexOutOfRange38, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 3, i32 %48
+  %NullCheck39 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %56
+
+; <label>:56                                      ; preds = %54
+  %57 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, i32 0, i32 0
+  %58 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck41 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %59
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %60, %System.__Canon addrspace(1)* %58)
+  %61 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck43 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  %64 = load i32, i32 addrspace(1)* %63, align 8
+  %65 = add i32 %64, 1
+  %NullCheck45 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  store i32 %65, i32 addrspace(1)* %67
+  ret i8 1
+
+; <label>:68                                      ; preds = %32
+  %69 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck47 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %73 = add i32 %72, 1
+  %NullCheck49 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %74
+
+; <label>:74                                      ; preds = %70
+  %75 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  store i32 %73, i32 addrspace(1)* %75
+  br label %76
+
+; <label>:76                                      ; preds = %8, %12, %74
+  %77 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %78
+
+; <label>:78                                      ; preds = %76
+  %79 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, i32 0, i32 2
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck7 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %82
+
+; <label>:82                                      ; preds = %78
+  %83 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, i32 0, i32 0
+  %84 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %83, align 8
+  %NullCheck9 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %85
+
+; <label>:85                                      ; preds = %82
+  %86 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, i32 0, i32 7
+  %87 = load i32, i32 addrspace(1)* %86, align 8
+  %88 = icmp ult i32 %80, %87
+  br i1 %88, label %13, label %89
+
+; <label>:89                                      ; preds = %85
+  %90 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %91 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck11 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %92
+
+; <label>:92                                      ; preds = %89
+  %93 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, i32 0, i32 0
+  %94 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck13 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %95
+
+; <label>:95                                      ; preds = %92
+  %96 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, i32 0, i32 7
+  %97 = load i32, i32 addrspace(1)* %96, align 8
+  %98 = add i32 %97, 1
+  %NullCheck15 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %99
+
+; <label>:99                                      ; preds = %95
+  %100 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, i32 0, i32 2
+  store i32 %98, i32 addrspace(1)* %100
+  %101 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck17 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %102
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %103, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %92
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef22:                                   ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef24:                                   ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef26:                                   ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef28:                                   ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef30:                                   ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef32:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef34:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef36:                                   ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange38:                           ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef40:                                   ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef42:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef44:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef46:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef48:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef50:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -5200,8 +6368,8 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -5232,9 +6400,9 @@ Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
 Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
-Failed to read String.MakeSeparatorList[loadElemA]
+Failed to read String.MakeSeparatorList[storeElem]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
-Failed to read String.InternalSplitKeepEmptyEntries[loadElem]
+Failed to read String.InternalSplitKeepEmptyEntries[storeElem]
 INFO:  jitting method Path::IsRelative using LLILCJit
 Successfully read Path.IsRelative
 
@@ -5243,8 +6411,8 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -5254,8 +6422,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
@@ -5271,8 +6439,8 @@ entry:
 
 ; <label>:17                                      ; preds = %7
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
@@ -5288,8 +6456,8 @@ entry:
 
 ; <label>:29                                      ; preds = %19
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %31
 
 ; <label>:31                                      ; preds = %29
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
@@ -5300,8 +6468,8 @@ entry:
 
 ; <label>:36                                      ; preds = %31
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
-  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %37, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
@@ -5312,8 +6480,8 @@ entry:
 
 ; <label>:43                                      ; preds = %31, %38
   %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
-  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %45
 
 ; <label>:45                                      ; preds = %43
   %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
@@ -5324,8 +6492,8 @@ entry:
 
 ; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %50
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
@@ -5336,8 +6504,8 @@ entry:
 
 ; <label>:57                                      ; preds = %1, %7, %19, %45, %52
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
-  br i1 %NullCheck14, label %59, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %59
 
 ; <label>:59                                      ; preds = %57
   %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
@@ -5347,8 +6515,8 @@ entry:
 
 ; <label>:63                                      ; preds = %59
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
@@ -5359,8 +6527,8 @@ entry:
 
 ; <label>:70                                      ; preds = %65
   %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
-  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.String addrspace(1)* %71, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %72
 
 ; <label>:72                                      ; preds = %70
   %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
@@ -5379,39 +6547,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %17
+ThrowNullRef4:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %29
+ThrowNullRef6:                                    ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %36
+ThrowNullRef8:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %43
+ThrowNullRef10:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %50
+ThrowNullRef12:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %57
+ThrowNullRef14:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %63
+ThrowNullRef16:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %70
+ThrowNullRef18:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5419,7 +6587,293 @@ ThrowNullRef17:                                   ; preds = %70
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
-Failed to read String.TrimHelper[loadElem]
+Successfully read String.TrimHelper
+
+define %System.String addrspace(1)* @String.TrimHelper(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i16
+  %loc4 = alloca i32
+  %loc5 = alloca i16
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = sub i32 %3, 1
+  store i32 %4, i32* %loc0
+  store i32 0, i32* %loc1
+  %5 = load i32, i32* %arg2
+  %6 = icmp eq i32 %5, 1
+  br i1 %6, label %62, label %7
+
+; <label>:7                                       ; preds = %1
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:8                                       ; preds = %58
+  store i32 0, i32* %loc2
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load i32, i32* %loc1
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2, i32 %10
+  %13 = load i16, i16 addrspace(1)* %12
+  %14 = zext i16 %13 to i32
+  %15 = trunc i32 %14 to i16
+  store i16 %15, i16* %loc3
+  store i32 0, i32* %loc2
+  br label %34
+
+; <label>:16                                      ; preds = %37
+  %17 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %18 = load i32, i32* %loc2
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %17, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %19
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = zext i32 %18 to i64
+  %BoundsCheck = icmp uge i64 %23, %22
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %24
+
+; <label>:24                                      ; preds = %19
+  %25 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 3, i32 %18
+  %26 = load i16, i16 addrspace(1)* %25, align 8
+  %27 = zext i16 %26 to i32
+  %28 = load i16, i16* %loc3
+  %29 = zext i16 %28 to i32
+  %30 = icmp eq i32 %27, %29
+  br i1 %30, label %43, label %31
+
+; <label>:31                                      ; preds = %24
+  %32 = load i32, i32* %loc2
+  %33 = add i32 %32, 1
+  store i32 %33, i32* %loc2
+  br label %34
+
+; <label>:34                                      ; preds = %11, %31
+  %35 = load i32, i32* %loc2
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = icmp slt i32 %35, %41
+  br i1 %42, label %16, label %43
+
+; <label>:43                                      ; preds = %24, %37
+  %44 = load i32, i32* %loc2
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %45, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp eq i32 %44, %50
+  br i1 %51, label %62, label %52
+
+; <label>:52                                      ; preds = %46
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %7, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %57, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %58
+
+; <label>:58                                      ; preds = %55
+  %59 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %60 = load i32, i32 addrspace(1)* %59
+  %61 = icmp slt i32 %56, %60
+  br i1 %61, label %8, label %62
+
+; <label>:62                                      ; preds = %1, %46, %58
+  %63 = load i32, i32* %arg2
+  %64 = icmp eq i32 %63, 0
+  br i1 %64, label %122, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %66, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %67
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %66, i32 0, i32 1
+  %69 = load i32, i32 addrspace(1)* %68
+  %70 = sub i32 %69, 1
+  store i32 %70, i32* %loc0
+  br label %118
+
+; <label>:71                                      ; preds = %118
+  store i32 0, i32* %loc4
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %73 = load i32, i32* %loc0
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %74
+
+; <label>:74                                      ; preds = %71
+  %75 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 2, i32 %73
+  %76 = load i16, i16 addrspace(1)* %75
+  %77 = zext i16 %76 to i32
+  %78 = trunc i32 %77 to i16
+  store i16 %78, i16* %loc5
+  store i32 0, i32* %loc4
+  br label %97
+
+; <label>:79                                      ; preds = %100
+  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %81 = load i32, i32* %loc4
+  %NullCheck19 = icmp eq %"System.Char[]" addrspace(1)* %80, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
+
+; <label>:82                                      ; preds = %79
+  %83 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 1
+  %84 = load i32, i32 addrspace(1)* %83
+  %85 = zext i32 %84 to i64
+  %86 = zext i32 %81 to i64
+  %BoundsCheck21 = icmp uge i64 %86, %85
+  br i1 %BoundsCheck21, label %ThrowIndexOutOfRange22, label %87
+
+; <label>:87                                      ; preds = %82
+  %88 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 3, i32 %81
+  %89 = load i16, i16 addrspace(1)* %88, align 8
+  %90 = zext i16 %89 to i32
+  %91 = load i16, i16* %loc5
+  %92 = zext i16 %91 to i32
+  %93 = icmp eq i32 %90, %92
+  br i1 %93, label %106, label %94
+
+; <label>:94                                      ; preds = %87
+  %95 = load i32, i32* %loc4
+  %96 = add i32 %95, 1
+  store i32 %96, i32* %loc4
+  br label %97
+
+; <label>:97                                      ; preds = %74, %94
+  %98 = load i32, i32* %loc4
+  %99 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck15 = icmp eq %"System.Char[]" addrspace(1)* %99, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %100
+
+; <label>:100                                     ; preds = %97
+  %101 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %99, i32 0, i32 1
+  %102 = load i32, i32 addrspace(1)* %101
+  %103 = zext i32 %102 to i64
+  %104 = trunc i64 %103 to i32
+  %105 = icmp slt i32 %98, %104
+  br i1 %105, label %79, label %106
+
+; <label>:106                                     ; preds = %87, %100
+  %107 = load i32, i32* %loc4
+  %108 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck17 = icmp eq %"System.Char[]" addrspace(1)* %108, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %109
+
+; <label>:109                                     ; preds = %106
+  %110 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %108, i32 0, i32 1
+  %111 = load i32, i32 addrspace(1)* %110
+  %112 = zext i32 %111 to i64
+  %113 = trunc i64 %112 to i32
+  %114 = icmp eq i32 %107, %113
+  br i1 %114, label %122, label %115
+
+; <label>:115                                     ; preds = %109
+  %116 = load i32, i32* %loc0
+  %117 = sub i32 %116, 1
+  store i32 %117, i32* %loc0
+  br label %118
+
+; <label>:118                                     ; preds = %67, %115
+  %119 = load i32, i32* %loc0
+  %120 = load i32, i32* %loc1
+  %121 = icmp sge i32 %119, %120
+  br i1 %121, label %71, label %122
+
+; <label>:122                                     ; preds = %62, %109, %118
+  %123 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %124 = load i32, i32* %loc1
+  %125 = load i32, i32* %loc0
+  %126 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %123, i32 %124, i32 %125)
+  ret %System.String addrspace(1)* %126
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %97
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange22:                           ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
 Successfully read String.CreateTrimmedString
 
@@ -5439,8 +6893,8 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
@@ -5535,8 +6989,8 @@ entry:
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i64 2872
   %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
   %8 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %7
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %3
   %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
@@ -5553,8 +7007,8 @@ entry:
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 2864
   %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
   %21 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %20
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
-  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %22
 
 ; <label>:22                                      ; preds = %16
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
@@ -5569,7 +7023,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %16
+ThrowNullRef2:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5586,8 +7040,8 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5613,8 +7067,8 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
@@ -5632,8 +7086,8 @@ entry:
 
 ; <label>:12                                      ; preds = %4
   %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
@@ -5644,8 +7098,8 @@ entry:
 
 ; <label>:19                                      ; preds = %14
   %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %19
   %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
@@ -5660,21 +7114,21 @@ entry:
   %31 = zext i16 %30 to i32
   %32 = bitcast i8* %29 to i16*
   %33 = trunc i32 %31 to i16
-  %NullCheck6 = icmp ne i16* %32, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i16* %32, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %21
   store i16 %33, i16* %32, align 8
   %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %36
 
 ; <label>:36                                      ; preds = %34
   %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
   %38 = load i32, i32 addrspace(1)* %37, align 8
   %39 = add i32 %38, 1
-  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %40
 
 ; <label>:40                                      ; preds = %36
   %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
@@ -5683,16 +7137,16 @@ entry:
 
 ; <label>:42                                      ; preds = %14
   %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
-  br i1 %NullCheck12, label %44, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
   %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
   %47 = load i16, i16* %arg1
   %48 = zext i16 %47 to i32
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = trunc i32 %48 to i16
@@ -5703,31 +7157,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %19
+ThrowNullRef4:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %21
+ThrowNullRef6:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %36
+ThrowNullRef10:                                   ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %42
+ThrowNullRef12:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %44
+ThrowNullRef14:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5740,8 +7194,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -5752,8 +7206,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
@@ -5762,14 +7216,14 @@ entry:
 
 ; <label>:11                                      ; preds = %1
   %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
@@ -5779,15 +7233,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5808,8 +7262,8 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5822,8 +7276,8 @@ entry:
 
 ; <label>:8                                       ; preds = %3
   %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
@@ -5842,15 +7296,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
-  br i1 %NullCheck4, label %22, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
   %24 = load i16*, i16* addrspace(1)* %23, align 8
   %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %25, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
@@ -5859,8 +7313,8 @@ entry:
   store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
@@ -5874,8 +7328,8 @@ entry:
 
 ; <label>:37                                      ; preds = %65
   %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %37
   %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
@@ -5886,16 +7340,16 @@ entry:
   %45 = bitcast i16* %41 to i8*
   %46 = getelementptr inbounds i8, i8* %45, i64 %44
   %47 = bitcast i8* %46 to i16*
-  %NullCheck14 = icmp ne i16* %47, null
-  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %47, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %48
 
 ; <label>:48                                      ; preds = %39
   %49 = load i16, i16* %47, align 8
   %50 = zext i16 %49 to i32
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %52 = load i32, i32* %loc1
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %53
 
 ; <label>:53                                      ; preds = %48
   %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
@@ -5916,8 +7370,8 @@ entry:
 ; <label>:62                                      ; preds = %36, %59
   %63 = load i32, i32* %loc1
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck10, label %65, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %65
 
 ; <label>:65                                      ; preds = %62
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
@@ -5936,15 +7390,15 @@ entry:
 
 ; <label>:74                                      ; preds = %70
   %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
-  br i1 %NullCheck18, label %76, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %76
 
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
   %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
-  br i1 %NullCheck20, label %80, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
   %81 = load i64, i64 addrspace(1)* %79
@@ -5958,8 +7412,8 @@ entry:
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
   %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
-  br i1 %NullCheck22, label %92, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.String addrspace(1)* %90, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %92
 
 ; <label>:92                                      ; preds = %80
   %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
@@ -5969,15 +7423,15 @@ entry:
 
 ; <label>:96                                      ; preds = %70
   %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
-  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %98
 
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
   %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
-  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
   %103 = load i64, i64 addrspace(1)* %101
@@ -5991,8 +7445,8 @@ entry:
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
   %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
-  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.String addrspace(1)* %112, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %114
 
 ; <label>:114                                     ; preds = %102
   %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
@@ -6004,59 +7458,59 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %20
+ThrowNullRef4:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %22
+ThrowNullRef6:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %26
+ThrowNullRef8:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %62
+ThrowNullRef10:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %48
+ThrowNullRef16:                                   ; preds = %48
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %74
+ThrowNullRef18:                                   ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %76
+ThrowNullRef20:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %80
+ThrowNullRef22:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %96
+ThrowNullRef24:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %98
+ThrowNullRef26:                                   ; preds = %98
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %102
+ThrowNullRef28:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6069,15 +7523,15 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
   %3 = load i16*, i16* addrspace(1)* %2, align 8
   %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
@@ -6087,8 +7541,8 @@ entry:
   %10 = bitcast i16* %3 to i8*
   %11 = getelementptr inbounds i8, i8* %10, i64 %9
   %12 = bitcast i8* %11 to i16*
-  %NullCheck4 = icmp ne i16* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %5
   store i16 0, i16* %12, align 8
@@ -6098,11 +7552,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6119,8 +7573,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -6131,8 +7585,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
@@ -6144,15 +7598,15 @@ entry:
 
 ; <label>:14                                      ; preds = %1
   %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
   %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
   %21 = load i64, i64 addrspace(1)* %19
@@ -6171,15 +7625,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %14
+ThrowNullRef4:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %16
+ThrowNullRef6:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6302,14 +7756,6 @@ entry:
   ret %System.String addrspace(1)* %57
 }
 
-INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
-Successfully read RuntimeHelpers.get_OffsetToStringData
-
-define i32 @RuntimeHelpers.get_OffsetToStringData() {
-entry:
-  ret i32 12
-}
-
 INFO:  jitting method String::Equals using LLILCJit
 Successfully read String.Equals
 
@@ -6381,8 +7827,8 @@ entry:
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
-  br i1 %NullCheck24, label %29, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
   %30 = load i64, i64 addrspace(1)* %28
@@ -6397,8 +7843,8 @@ entry:
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
-  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
   %43 = load i64, i64 addrspace(1)* %41
@@ -6418,8 +7864,8 @@ entry:
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
   %59 = load i64, i64 addrspace(1)* %57
@@ -6434,8 +7880,8 @@ entry:
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck22, label %71, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
   %72 = load i64, i64 addrspace(1)* %70
@@ -6455,8 +7901,8 @@ entry:
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
-  br i1 %NullCheck16, label %87, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = load i64, i64 addrspace(1)* %86
@@ -6471,8 +7917,8 @@ entry:
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck18, label %100, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
   %101 = load i64, i64 addrspace(1)* %99
@@ -6492,8 +7938,8 @@ entry:
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
-  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
   %117 = load i64, i64 addrspace(1)* %115
@@ -6508,8 +7954,8 @@ entry:
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
-  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
   %130 = load i64, i64 addrspace(1)* %128
@@ -6528,15 +7974,15 @@ entry:
 
 ; <label>:142                                     ; preds = %22
   %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
-  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %143, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %144
 
 ; <label>:144                                     ; preds = %142
   %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
   %146 = load i32, i32 addrspace(1)* %145
   %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
-  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %147, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %148
 
 ; <label>:148                                     ; preds = %144
   %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
@@ -6557,15 +8003,15 @@ entry:
 
 ; <label>:159                                     ; preds = %22
   %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
-  br i1 %NullCheck, label %161, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %ThrowNullRef, label %161
 
 ; <label>:161                                     ; preds = %159
   %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
   %163 = load i32, i32 addrspace(1)* %162
   %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
-  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %164, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %165
 
 ; <label>:165                                     ; preds = %161
   %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
@@ -6578,8 +8024,8 @@ entry:
 
 ; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
-  br i1 %NullCheck4, label %172, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %171, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %172
 
 ; <label>:172                                     ; preds = %170
   %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
@@ -6589,8 +8035,8 @@ entry:
 
 ; <label>:176                                     ; preds = %172
   %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
-  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %177, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %178
 
 ; <label>:178                                     ; preds = %176
   %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
@@ -6629,55 +8075,55 @@ ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %161
+ThrowNullRef2:                                    ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %170
+ThrowNullRef4:                                    ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %176
+ThrowNullRef6:                                    ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %142
+ThrowNullRef8:                                    ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %144
+ThrowNullRef10:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %113
+ThrowNullRef12:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %116
+ThrowNullRef14:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %84
+ThrowNullRef16:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %87
+ThrowNullRef18:                                   ; preds = %87
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %55
+ThrowNullRef20:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %58
+ThrowNullRef22:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %26
+ThrowNullRef24:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %29
+ThrowNullRef26:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,8 +8161,8 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck, label %14, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %ThrowNullRef, label %14
 
 ; <label>:14                                      ; preds = %8
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
@@ -6760,8 +8206,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
@@ -6770,14 +8216,14 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32, i32* %loc0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %10
   %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
   %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
@@ -6790,15 +8236,15 @@ entry:
 ; <label>:25                                      ; preds = %19
   %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
-  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
   %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
@@ -6807,8 +8253,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %37 = load i32, i32* %loc0
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %38, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %38
 
 ; <label>:38                                      ; preds = %32
   %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
@@ -6817,14 +8263,14 @@ entry:
 
 ; <label>:40                                      ; preds = %19
   %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %40
   %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
   %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
-  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
-  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
@@ -6832,8 +8278,8 @@ entry:
   %48 = zext i32 %47 to i64
   %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
-  br i1 %NullCheck16, label %51, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %51
 
 ; <label>:51                                      ; preds = %45
   %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
@@ -6847,15 +8293,15 @@ entry:
 ; <label>:57                                      ; preds = %51
   %58 = load i16*, i16** %arg1
   %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
-  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %60
 
 ; <label>:60                                      ; preds = %57
   %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
   %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
-  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %64
 
 ; <label>:64                                      ; preds = %60
   %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
@@ -6864,22 +8310,22 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
   %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
-  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %70
 
 ; <label>:70                                      ; preds = %64
   %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
   %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
-  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
-  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
   %75 = load i32, i32 addrspace(1)* %74
   %76 = zext i32 %75 to i64
   %77 = trunc i64 %76 to i32
-  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
-  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %78
 
 ; <label>:78                                      ; preds = %73
   %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
@@ -6901,8 +8347,8 @@ entry:
   %90 = bitcast i16* %86 to i8*
   %91 = getelementptr inbounds i8, i8* %90, i64 %89
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %93
 
 ; <label>:93                                      ; preds = %80
   %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
@@ -6912,8 +8358,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %99 = load i32, i32* %loc2
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %100
 
 ; <label>:100                                     ; preds = %93
   %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
@@ -6928,63 +8374,63 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %25
+ThrowNullRef6:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %32
+ThrowNullRef10:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %40
+ThrowNullRef12:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %45
+ThrowNullRef16:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %57
+ThrowNullRef18:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %60
+ThrowNullRef20:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %64
+ThrowNullRef22:                                   ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %70
+ThrowNullRef24:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %73
+ThrowNullRef26:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %80
+ThrowNullRef28:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %93
+ThrowNullRef30:                                   ; preds = %93
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7004,8 +8450,8 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
@@ -7033,43 +8479,43 @@ entry:
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %14
   %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
   %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   %28 = load i32, i32 addrspace(1)* %27, align 8
   %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
-  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %30
 
 ; <label>:30                                      ; preds = %26
   %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
   %32 = load i32, i32 addrspace(1)* %31, align 8
   %33 = add i32 %28, %32
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %34
 
 ; <label>:34                                      ; preds = %30
   %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   store i32 %33, i32 addrspace(1)* %35
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
   store i32 0, i32 addrspace(1)* %38
   %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %40
 
 ; <label>:40                                      ; preds = %37
   %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
@@ -7082,8 +8528,8 @@ entry:
 
 ; <label>:47                                      ; preds = %40
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
@@ -7098,8 +8544,8 @@ entry:
   %54 = load i32, i32* %loc0
   %55 = sext i32 %54 to i64
   %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
-  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %57
 
 ; <label>:57                                      ; preds = %52
   %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
@@ -7110,68 +8556,35 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %14
+ThrowNullRef2:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %23
+ThrowNullRef4:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %26
+ThrowNullRef6:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %30
+ThrowNullRef8:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %34
+ThrowNullRef10:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %47
+ThrowNullRef14:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %52
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-}
-
-INFO:  jitting method StringBuilder::get_Length using LLILCJit
-Successfully read StringBuilder.get_Length
-
-define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.StringBuilder addrspace(1)*
-  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
-  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
-
-; <label>:1                                       ; preds = %entry
-  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %3 = load i32, i32 addrspace(1)* %2, align 8
-  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
-
-; <label>:5                                       ; preds = %1
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = add i32 %3, %7
-  ret i32 %8
-
-ThrowNullRef:                                     ; preds = %entry
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef16:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7213,70 +8626,70 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
   %6 = load i32, i32 addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
   store i32 %6, i32 addrspace(1)* %8
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
   %13 = load i32, i32 addrspace(1)* %12, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
   store i32 %13, i32 addrspace(1)* %15
   %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
-  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %18
 
 ; <label>:18                                      ; preds = %14
   %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
   %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
   %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
   %34 = load i32, i32 addrspace(1)* %33, align 8
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
-  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
@@ -7287,39 +8700,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %28
+ThrowNullRef16:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %32
+ThrowNullRef18:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7455,13 +8868,13 @@ entry:
 ; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
@@ -7477,16 +8890,16 @@ entry:
 
 ; <label>:18                                      ; preds = %15
   %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
   store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
   %22 = load i32, i32* %loc0
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %24
 
 ; <label>:24                                      ; preds = %20
   %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
@@ -7498,13 +8911,13 @@ entry:
 ; <label>:28                                      ; preds = %15, %24
   %29 = load i32, i32* %arg1
   %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %31
   %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
@@ -7517,20 +8930,20 @@ entry:
   %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
-  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
   %46 = load i32, i32 addrspace(1)* %45, align 8
   %47 = sub i32 %40, %46
-  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
-  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i32 addrspace(1)* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %48
 
 ; <label>:48                                      ; preds = %44
   store i32 %47, i32 addrspace(1)* %39, align 8
@@ -7538,21 +8951,21 @@ entry:
 
 ; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
-  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %51
 
 ; <label>:51                                      ; preds = %49
   %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %53
 
 ; <label>:53                                      ; preds = %51
   %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
   %55 = load i32, i32 addrspace(1)* %54, align 8
   %56 = load i32, i32* %arg2
   %57 = sub i32 %55, %56
-  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %58
 
 ; <label>:58                                      ; preds = %53
   %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
@@ -7562,13 +8975,13 @@ entry:
 ; <label>:60                                      ; preds = %33, %58
   %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
   %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
-  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %63
 
 ; <label>:63                                      ; preds = %60
   %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
-  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
-  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
@@ -7578,15 +8991,15 @@ entry:
 
 ; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
-  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i32 addrspace(1)* %69, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %70
 
 ; <label>:70                                      ; preds = %68
   %71 = load i32, i32 addrspace(1)* %69, align 8
   store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
-  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
@@ -7596,8 +9009,8 @@ entry:
   store i32 %77, i32* %loc4
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
-  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %80
 
 ; <label>:80                                      ; preds = %73
   %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
@@ -7607,71 +9020,71 @@ entry:
 ; <label>:83                                      ; preds = %80
   store i32 0, i32* %loc3
   %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
-  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
-  br i1 %NullCheck26, label %88, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i32 addrspace(1)* %87, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %88
 
 ; <label>:88                                      ; preds = %85
   %89 = load i32, i32 addrspace(1)* %87, align 8
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
-  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %90
 
 ; <label>:90                                      ; preds = %88
   %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
   store i32 %89, i32 addrspace(1)* %91
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
-  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
-  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %96
 
 ; <label>:96                                      ; preds = %94
   %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
-  br i1 %NullCheck34, label %100, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %100
 
 ; <label>:100                                     ; preds = %96
   %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
-  br i1 %NullCheck36, label %102, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %102
 
 ; <label>:102                                     ; preds = %100
   %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
   %104 = load i32, i32 addrspace(1)* %103, align 8
   %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
-  br i1 %NullCheck38, label %106, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %106
 
 ; <label>:106                                     ; preds = %102
   %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
-  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
-  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %108
 
 ; <label>:108                                     ; preds = %106
   %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
   %110 = load i32, i32 addrspace(1)* %109, align 8
   %111 = add i32 %104, %110
-  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %112
 
 ; <label>:112                                     ; preds = %108
   %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
   store i32 %111, i32 addrspace(1)* %113
   %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
-  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i32 addrspace(1)* %114, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %115
 
 ; <label>:115                                     ; preds = %112
   %116 = load i32, i32 addrspace(1)* %114, align 8
@@ -7681,19 +9094,19 @@ entry:
 ; <label>:118                                     ; preds = %115
   %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
-  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %121
 
 ; <label>:121                                     ; preds = %118
   %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
-  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
-  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %123
 
 ; <label>:123                                     ; preds = %121
   %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
   %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
-  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
-  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %126
 
 ; <label>:126                                     ; preds = %123
   %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
@@ -7705,8 +9118,8 @@ entry:
 
 ; <label>:130                                     ; preds = %80, %115, %126
   %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %132
 
 ; <label>:132                                     ; preds = %130
   %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7715,8 +9128,8 @@ entry:
   %136 = load i32, i32* %loc3
   %137 = sub i32 %135, %136
   %138 = sub i32 %134, %137
-  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %139
 
 ; <label>:139                                     ; preds = %132
   %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7728,16 +9141,16 @@ entry:
 
 ; <label>:144                                     ; preds = %139
   %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
-  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %146
 
 ; <label>:146                                     ; preds = %144
   %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
   %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
   %149 = load i32, i32* %loc2
   %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
-  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %151
 
 ; <label>:151                                     ; preds = %146
   %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
@@ -7754,145 +9167,249 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %18
+ThrowNullRef4:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %31
+ThrowNullRef10:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %44
+ThrowNullRef16:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %68
+ThrowNullRef18:                                   ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %70
+ThrowNullRef20:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %73
+ThrowNullRef22:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %83
+ThrowNullRef24:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %85
+ThrowNullRef26:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %88
+ThrowNullRef28:                                   ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %90
+ThrowNullRef30:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %94
+ThrowNullRef32:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %96
+ThrowNullRef34:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %100
+ThrowNullRef36:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %102
+ThrowNullRef38:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %106
+ThrowNullRef40:                                   ; preds = %106
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %108
+ThrowNullRef42:                                   ; preds = %108
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %112
+ThrowNullRef44:                                   ; preds = %112
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %118
+ThrowNullRef46:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %121
+ThrowNullRef48:                                   ; preds = %121
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %123
+ThrowNullRef50:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %130
+ThrowNullRef52:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %132
+ThrowNullRef54:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %144
+ThrowNullRef56:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %146
+ThrowNullRef58:                                   ; preds = %146
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %60
+ThrowNullRef60:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %63
+ThrowNullRef62:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %49
+ThrowNullRef64:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %51
+ThrowNullRef66:                                   ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %53
+ThrowNullRef68:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(%"System.Char[]" addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %arg0 = alloca %"System.Char[]" addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store %"System.Char[]" addrspace(1)* %param0, %"System.Char[]" addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load i32, i32* %arg4
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %43, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %38, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg1
+  %13 = load i32, i32* %arg4
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %38, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %24 = load i32, i32* %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %35 = load i32, i32* %arg3
+  %36 = load i32, i32* %arg4
+  %37 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %37, %"System.Char[]" addrspace(1)* %34, i32 %35, i32 %36)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:38                                      ; preds = %5, %16
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Successfully read Buffer._Memmove
 
@@ -7914,7 +9431,7 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[loadElem]
+Failed to read AppDomain.SetDataHelper[storeElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -7923,8 +9440,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
@@ -7934,8 +9451,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
@@ -7947,15 +9464,15 @@ entry:
   %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
   %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
@@ -7966,15 +9483,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7992,7 +9509,79 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
-Failed to read Dictionary`2.TryGetValue[loadElemA]
+Successfully read Dictionary`2.TryGetValue
+
+define i8 @"Dictionary`2.TryGetValue"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)* addrspace(1)* %param2) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  %arg2 = alloca %System.__Canon addrspace(1)* addrspace(1)*
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  store %System.__Canon addrspace(1)* addrspace(1)* %param2, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  store i32 %2, i32* %loc0
+  %3 = load i32, i32* %loc0
+  %4 = icmp slt i32 %3, 0
+  br i1 %4, label %22, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 2
+  %10 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %9, align 8
+  %11 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = zext i32 %11 to i64
+  %BoundsCheck = icmp uge i64 %16, %15
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 3, i32 %11
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %20, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %6, %System.__Canon addrspace(1)* %21)
+  ret i8 1
+
+; <label>:22                                      ; preds = %entry
+  %23 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %23, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -8058,8 +9647,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
@@ -8091,8 +9680,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
@@ -8171,15 +9760,15 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck, label %19, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %ThrowNullRef, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
   %21 = load i32, i32 addrspace(1)* %20
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
@@ -8202,7 +9791,7 @@ ThrowNullRef:                                     ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %19
+ThrowNullRef2:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8248,8 +9837,8 @@ entry:
   %0 = alloca %System.AppDomainHandle
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %1 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %1, i32 0, i32 15
@@ -8269,8 +9858,8 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
@@ -8286,7 +9875,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -8299,8 +9888,8 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -8327,8 +9916,8 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
@@ -8352,8 +9941,8 @@ entry:
   %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
   store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
@@ -8363,8 +9952,8 @@ entry:
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
@@ -8374,8 +9963,8 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %9
   %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
@@ -8384,8 +9973,8 @@ entry:
 
 ; <label>:18                                      ; preds = %3, %16
   %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
@@ -8397,15 +9986,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %18
+ThrowNullRef6:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8418,8 +10007,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
@@ -8453,15 +10042,15 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
@@ -8473,7 +10062,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8481,7 +10070,7 @@ ThrowNullRef1:                                    ; preds = %1
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
 Failed to read Dictionary`2.System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
@@ -8506,8 +10095,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
@@ -8524,8 +10113,8 @@ entry:
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -8544,7 +10133,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8577,8 +10166,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = load i64, i64* %arg2
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = trunc i32 %3 to i8
@@ -8634,46 +10223,46 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
   %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
-  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
-  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
-  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
@@ -8684,27 +10273,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %20
+ThrowNullRef12:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8717,8 +10306,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -8756,22 +10345,22 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
   %9 = load i64, i64 addrspace(1)* %8, align 8
   %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
   %13 = load i64, i64 addrspace(1)* %12, align 8
   %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %11
   %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
@@ -8788,11 +10377,11 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8882,8 +10471,8 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
@@ -8900,8 +10489,8 @@ entry:
 ; <label>:8                                       ; preds = %1
   %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
   %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
@@ -8911,15 +10500,15 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
   %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
   %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
-  br i1 %NullCheck6, label %21, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
@@ -8946,15 +10535,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8992,15 +10581,15 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
   store i8 %3, i8 addrspace(1)* %5
   %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
@@ -9011,7 +10600,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9027,8 +10616,8 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -9041,8 +10630,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
@@ -9058,7 +10647,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9080,8 +10669,8 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
@@ -9096,8 +10685,8 @@ entry:
 ; <label>:12                                      ; preds = %6
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
@@ -9112,8 +10701,8 @@ entry:
 ; <label>:21                                      ; preds = %15
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
@@ -9128,8 +10717,8 @@ entry:
 ; <label>:30                                      ; preds = %24
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %31, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
@@ -9144,8 +10733,8 @@ entry:
 ; <label>:39                                      ; preds = %33
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
-  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %40, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %42
 
 ; <label>:42                                      ; preds = %39
   %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
@@ -9164,19 +10753,19 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %21
+ThrowNullRef4:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %30
+ThrowNullRef6:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %39
+ThrowNullRef8:                                    ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9243,8 +10832,8 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
@@ -9264,57 +10853,57 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
   store i8 0, i8 addrspace(1)* %2
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
   store i8 0, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
   store i8 0, i8 addrspace(1)* %17
   %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
   store i8 0, i8 addrspace(1)* %20
   %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
-  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
@@ -9325,31 +10914,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %19
+ThrowNullRef14:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9367,8 +10956,8 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
@@ -9380,8 +10969,8 @@ entry:
 
 ; <label>:9                                       ; preds = %4
   %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %9
   %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
@@ -9395,7 +10984,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef2:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9420,8 +11009,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
@@ -9512,8 +11101,8 @@ entry:
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
@@ -9524,8 +11113,8 @@ entry:
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = load i64, i64 addrspace(1)* %12
@@ -9537,8 +11126,8 @@ entry:
   %20 = load i64, i64* %19
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
-  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %13
   %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
@@ -9555,8 +11144,8 @@ entry:
 ; <label>:30                                      ; preds = %25
   %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %32 = load i32, i32* %arg2
-  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
-  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
@@ -9570,15 +11159,15 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %30
+ThrowNullRef2:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9622,87 +11211,87 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
   %10 = load i8, i8 addrspace(1)* %9, align 8
   %11 = zext i8 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %8
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
   store i8 %12, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
   %19 = load i8, i8 addrspace(1)* %18, align 8
   %20 = zext i8 %19 to i32
   %21 = trunc i32 %20 to i8
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
   store i8 %21, i8 addrspace(1)* %23
   %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
   %28 = load i8, i8 addrspace(1)* %27, align 8
   %29 = zext i8 %28 to i32
   %30 = trunc i32 %29 to i8
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
-  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %31
 
 ; <label>:31                                      ; preds = %26
   %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
   store i8 %30, i8 addrspace(1)* %32
   %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
-  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
-  br i1 %NullCheck14, label %40, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %40
 
 ; <label>:40                                      ; preds = %35
   %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
   store i8 %39, i8 addrspace(1)* %41
   %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
-  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %44
 
 ; <label>:44                                      ; preds = %40
   %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
   %46 = load i8, i8 addrspace(1)* %45, align 8
   %47 = zext i8 %46 to i32
   %48 = trunc i32 %47 to i8
-  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
   store i8 %48, i8 addrspace(1)* %50
   %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
-  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
@@ -9713,29 +11302,29 @@ entry:
 ; <label>:56                                      ; preds = %52
   %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
-  br i1 %NullCheck22, label %59, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
   %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
   %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
-  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
-  br i1 %NullCheck24, label %63, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
   %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
-  br i1 %NullCheck26, label %66, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
   %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
-  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
-  br i1 %NullCheck28, label %69, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %69
 
 ; <label>:69                                      ; preds = %66
   %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
@@ -9744,15 +11333,15 @@ entry:
 
 ; <label>:71                                      ; preds = %105
   %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
-  br i1 %NullCheck34, label %73, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %73
 
 ; <label>:73                                      ; preds = %71
   %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
   %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
   %76 = load i32, i32* %loc0
-  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
-  br i1 %NullCheck36, label %77, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
@@ -9766,8 +11355,8 @@ entry:
 
 ; <label>:83                                      ; preds = %77
   %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
-  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
@@ -9775,14 +11364,14 @@ entry:
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
   %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
-  br i1 %NullCheck40, label %91, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
 ; <label>:91                                      ; preds = %85
   %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
   %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
-  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck42, label %94, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %94
 
 ; <label>:94                                      ; preds = %91
   %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
@@ -9798,14 +11387,14 @@ entry:
 ; <label>:99                                      ; preds = %69, %96
   %100 = load i32, i32* %loc0
   %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
-  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %102
 
 ; <label>:102                                     ; preds = %99
   %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
   %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
-  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
-  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
@@ -9819,87 +11408,87 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %26
+ThrowNullRef10:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %31
+ThrowNullRef12:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %35
+ThrowNullRef14:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %40
+ThrowNullRef16:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %56
+ThrowNullRef22:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %59
+ThrowNullRef24:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %63
+ThrowNullRef26:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %66
+ThrowNullRef28:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %102
+ThrowNullRef32:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %71
+ThrowNullRef34:                                   ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %73
+ThrowNullRef36:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %83
+ThrowNullRef38:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %85
+ThrowNullRef40:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %91
+ThrowNullRef42:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9943,15 +11532,15 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
   %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
@@ -9961,28 +11550,28 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
   %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %12
   %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
   %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
   %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
-  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
@@ -9993,23 +11582,23 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %12
+ThrowNullRef6:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10031,15 +11620,15 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
   %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = load i64, i64 addrspace(1)* %7
@@ -10077,13 +11666,13 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[loadElem]
+Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -10111,8 +11700,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1

--- a/test/BaseLine/JIT/CodeGenBringUpTests/SubRef.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/SubRef.error.txt
@@ -25,8 +25,8 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
@@ -40,8 +40,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
   %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
@@ -75,7 +75,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -90,8 +90,8 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %NullCheck = icmp ne i8 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = load i8, i8 addrspace(1)* %0, align 8
@@ -125,8 +125,8 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
@@ -159,8 +159,8 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -184,8 +184,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
   store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
@@ -195,8 +195,8 @@ entry:
 ; <label>:4                                       ; preds = %1
   %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
   %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
@@ -206,8 +206,8 @@ entry:
   %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
@@ -221,14 +221,14 @@ entry:
 
 ; <label>:17                                      ; preds = %14
   %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
   %21 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
@@ -238,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -249,8 +249,8 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
@@ -261,27 +261,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %30
+ThrowNullRef10:                                   ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -301,7 +301,89 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
-Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
+Successfully read AppDomainSetup.GetUnsecureApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.GetUnsecureApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %NullCheck = icmp eq %"System.String[]" addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %BoundsCheck = icmp uge i64 0, %5
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %6
+
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 3, i32 0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
+  ret %System.String addrspace(1)* %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_Value using LLILCJit
+Successfully read AppDomainSetup.get_Value
+
+define %"System.String[]" addrspace(1)* @AppDomainSetup.get_Value(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.String[]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 18)
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.String[]" addrspace(1)* addrspace(1)*, %"System.String[]" addrspace(1)*)*)(%"System.String[]" addrspace(1)* addrspace(1)* %9, %"System.String[]" addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %11, i32 0, i32 1
+  %14 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %13, align 8
+  ret %"System.String[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -319,8 +401,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -368,16 +450,16 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
   %5 = load i32, i32 addrspace(1)* %4
   %6 = sub i32 %5, 1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -389,7 +471,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -421,8 +503,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
@@ -456,8 +538,8 @@ entry:
 ; <label>:27                                      ; preds = %19
   %28 = load i32, i32* %arg1
   %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
-  br i1 %NullCheck2, label %30, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %29, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %30
 
 ; <label>:30                                      ; preds = %27
   %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
@@ -493,8 +575,8 @@ entry:
 ; <label>:49                                      ; preds = %46
   %50 = load i32, i32* %arg2
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck4, label %52, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
@@ -517,11 +599,11 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %27
+ThrowNullRef2:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %49
+ThrowNullRef4:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -544,16 +626,16 @@ entry:
   %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %0)
   store %System.String addrspace(1)* %1, %System.String addrspace(1)** %loc0
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 2
   %5 = bitcast [0 x i16] addrspace(1)* %4 to i16 addrspace(1)*
   store i16 addrspace(1)* %5, i16 addrspace(1)** %loc1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %3
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2
@@ -580,7 +662,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -691,15 +773,15 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %NullCheck132 = icmp ne i8* %21, null
-  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+  %NullCheck131 = icmp eq i8* %21, null
+  br i1 %NullCheck131, label %ThrowNullRef132, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = load i8, i8* %21, align 8
   %24 = zext i8 %23 to i32
   %25 = trunc i32 %24 to i8
-  %NullCheck134 = icmp ne i8* %20, null
-  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+  %NullCheck133 = icmp eq i8* %20, null
+  br i1 %NullCheck133, label %ThrowNullRef134, label %26
 
 ; <label>:26                                      ; preds = %22
   store i8 %25, i8* %20, align 8
@@ -709,16 +791,16 @@ entry:
   %28 = load i8*, i8** %arg0
   %29 = load i8*, i8** %arg1
   %30 = bitcast i8* %29 to i16*
-  %NullCheck128 = icmp ne i16* %30, null
-  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+  %NullCheck127 = icmp eq i16* %30, null
+  br i1 %NullCheck127, label %ThrowNullRef128, label %31
 
 ; <label>:31                                      ; preds = %27
   %32 = load i16, i16* %30, align 8
   %33 = sext i16 %32 to i32
   %34 = bitcast i8* %28 to i16*
   %35 = trunc i32 %33 to i16
-  %NullCheck130 = icmp ne i16* %34, null
-  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+  %NullCheck129 = icmp eq i16* %34, null
+  br i1 %NullCheck129, label %ThrowNullRef130, label %36
 
 ; <label>:36                                      ; preds = %31
   store i16 %35, i16* %34, align 8
@@ -728,16 +810,16 @@ entry:
   %38 = load i8*, i8** %arg0
   %39 = load i8*, i8** %arg1
   %40 = bitcast i8* %39 to i16*
-  %NullCheck120 = icmp ne i16* %40, null
-  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+  %NullCheck119 = icmp eq i16* %40, null
+  br i1 %NullCheck119, label %ThrowNullRef120, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i16, i16* %40, align 8
   %43 = sext i16 %42 to i32
   %44 = bitcast i8* %38 to i16*
   %45 = trunc i32 %43 to i16
-  %NullCheck122 = icmp ne i16* %44, null
-  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+  %NullCheck121 = icmp eq i16* %44, null
+  br i1 %NullCheck121, label %ThrowNullRef122, label %46
 
 ; <label>:46                                      ; preds = %41
   store i16 %45, i16* %44, align 8
@@ -745,15 +827,15 @@ entry:
   %48 = getelementptr inbounds i8, i8* %47, i64 2
   %49 = load i8*, i8** %arg1
   %50 = getelementptr inbounds i8, i8* %49, i64 2
-  %NullCheck124 = icmp ne i8* %50, null
-  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+  %NullCheck123 = icmp eq i8* %50, null
+  br i1 %NullCheck123, label %ThrowNullRef124, label %51
 
 ; <label>:51                                      ; preds = %46
   %52 = load i8, i8* %50, align 8
   %53 = zext i8 %52 to i32
   %54 = trunc i32 %53 to i8
-  %NullCheck126 = icmp ne i8* %48, null
-  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+  %NullCheck125 = icmp eq i8* %48, null
+  br i1 %NullCheck125, label %ThrowNullRef126, label %55
 
 ; <label>:55                                      ; preds = %51
   store i8 %54, i8* %48, align 8
@@ -763,14 +845,14 @@ entry:
   %57 = load i8*, i8** %arg0
   %58 = load i8*, i8** %arg1
   %59 = bitcast i8* %58 to i32*
-  %NullCheck116 = icmp ne i32* %59, null
-  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+  %NullCheck115 = icmp eq i32* %59, null
+  br i1 %NullCheck115, label %ThrowNullRef116, label %60
 
 ; <label>:60                                      ; preds = %56
   %61 = load i32, i32* %59, align 8
   %62 = bitcast i8* %57 to i32*
-  %NullCheck118 = icmp ne i32* %62, null
-  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+  %NullCheck117 = icmp eq i32* %62, null
+  br i1 %NullCheck117, label %ThrowNullRef118, label %63
 
 ; <label>:63                                      ; preds = %60
   store i32 %61, i32* %62, align 8
@@ -780,14 +862,14 @@ entry:
   %65 = load i8*, i8** %arg0
   %66 = load i8*, i8** %arg1
   %67 = bitcast i8* %66 to i32*
-  %NullCheck108 = icmp ne i32* %67, null
-  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+  %NullCheck107 = icmp eq i32* %67, null
+  br i1 %NullCheck107, label %ThrowNullRef108, label %68
 
 ; <label>:68                                      ; preds = %64
   %69 = load i32, i32* %67, align 8
   %70 = bitcast i8* %65 to i32*
-  %NullCheck110 = icmp ne i32* %70, null
-  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+  %NullCheck109 = icmp eq i32* %70, null
+  br i1 %NullCheck109, label %ThrowNullRef110, label %71
 
 ; <label>:71                                      ; preds = %68
   store i32 %69, i32* %70, align 8
@@ -795,15 +877,15 @@ entry:
   %73 = getelementptr inbounds i8, i8* %72, i64 4
   %74 = load i8*, i8** %arg1
   %75 = getelementptr inbounds i8, i8* %74, i64 4
-  %NullCheck112 = icmp ne i8* %75, null
-  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+  %NullCheck111 = icmp eq i8* %75, null
+  br i1 %NullCheck111, label %ThrowNullRef112, label %76
 
 ; <label>:76                                      ; preds = %71
   %77 = load i8, i8* %75, align 8
   %78 = zext i8 %77 to i32
   %79 = trunc i32 %78 to i8
-  %NullCheck114 = icmp ne i8* %73, null
-  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+  %NullCheck113 = icmp eq i8* %73, null
+  br i1 %NullCheck113, label %ThrowNullRef114, label %80
 
 ; <label>:80                                      ; preds = %76
   store i8 %79, i8* %73, align 8
@@ -813,14 +895,14 @@ entry:
   %82 = load i8*, i8** %arg0
   %83 = load i8*, i8** %arg1
   %84 = bitcast i8* %83 to i32*
-  %NullCheck100 = icmp ne i32* %84, null
-  br i1 %NullCheck100, label %85, label %ThrowNullRef99
+  %NullCheck99 = icmp eq i32* %84, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %85
 
 ; <label>:85                                      ; preds = %81
   %86 = load i32, i32* %84, align 8
   %87 = bitcast i8* %82 to i32*
-  %NullCheck102 = icmp ne i32* %87, null
-  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+  %NullCheck101 = icmp eq i32* %87, null
+  br i1 %NullCheck101, label %ThrowNullRef102, label %88
 
 ; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
@@ -829,16 +911,16 @@ entry:
   %91 = load i8*, i8** %arg1
   %92 = getelementptr inbounds i8, i8* %91, i64 4
   %93 = bitcast i8* %92 to i16*
-  %NullCheck104 = icmp ne i16* %93, null
-  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+  %NullCheck103 = icmp eq i16* %93, null
+  br i1 %NullCheck103, label %ThrowNullRef104, label %94
 
 ; <label>:94                                      ; preds = %88
   %95 = load i16, i16* %93, align 8
   %96 = sext i16 %95 to i32
   %97 = bitcast i8* %90 to i16*
   %98 = trunc i32 %96 to i16
-  %NullCheck106 = icmp ne i16* %97, null
-  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+  %NullCheck105 = icmp eq i16* %97, null
+  br i1 %NullCheck105, label %ThrowNullRef106, label %99
 
 ; <label>:99                                      ; preds = %94
   store i16 %98, i16* %97, align 8
@@ -848,14 +930,14 @@ entry:
   %101 = load i8*, i8** %arg0
   %102 = load i8*, i8** %arg1
   %103 = bitcast i8* %102 to i32*
-  %NullCheck88 = icmp ne i32* %103, null
-  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+  %NullCheck87 = icmp eq i32* %103, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %104
 
 ; <label>:104                                     ; preds = %100
   %105 = load i32, i32* %103, align 8
   %106 = bitcast i8* %101 to i32*
-  %NullCheck90 = icmp ne i32* %106, null
-  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+  %NullCheck89 = icmp eq i32* %106, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %107
 
 ; <label>:107                                     ; preds = %104
   store i32 %105, i32* %106, align 8
@@ -864,16 +946,16 @@ entry:
   %110 = load i8*, i8** %arg1
   %111 = getelementptr inbounds i8, i8* %110, i64 4
   %112 = bitcast i8* %111 to i16*
-  %NullCheck92 = icmp ne i16* %112, null
-  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+  %NullCheck91 = icmp eq i16* %112, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %113
 
 ; <label>:113                                     ; preds = %107
   %114 = load i16, i16* %112, align 8
   %115 = sext i16 %114 to i32
   %116 = bitcast i8* %109 to i16*
   %117 = trunc i32 %115 to i16
-  %NullCheck94 = icmp ne i16* %116, null
-  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+  %NullCheck93 = icmp eq i16* %116, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %118
 
 ; <label>:118                                     ; preds = %113
   store i16 %117, i16* %116, align 8
@@ -881,15 +963,15 @@ entry:
   %120 = getelementptr inbounds i8, i8* %119, i64 6
   %121 = load i8*, i8** %arg1
   %122 = getelementptr inbounds i8, i8* %121, i64 6
-  %NullCheck96 = icmp ne i8* %122, null
-  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+  %NullCheck95 = icmp eq i8* %122, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %123
 
 ; <label>:123                                     ; preds = %118
   %124 = load i8, i8* %122, align 8
   %125 = zext i8 %124 to i32
   %126 = trunc i32 %125 to i8
-  %NullCheck98 = icmp ne i8* %120, null
-  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+  %NullCheck97 = icmp eq i8* %120, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %127
 
 ; <label>:127                                     ; preds = %123
   store i8 %126, i8* %120, align 8
@@ -899,14 +981,14 @@ entry:
   %129 = load i8*, i8** %arg0
   %130 = load i8*, i8** %arg1
   %131 = bitcast i8* %130 to i64*
-  %NullCheck84 = icmp ne i64* %131, null
-  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+  %NullCheck83 = icmp eq i64* %131, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %132
 
 ; <label>:132                                     ; preds = %128
   %133 = load i64, i64* %131, align 8
   %134 = bitcast i8* %129 to i64*
-  %NullCheck86 = icmp ne i64* %134, null
-  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+  %NullCheck85 = icmp eq i64* %134, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %135
 
 ; <label>:135                                     ; preds = %132
   store i64 %133, i64* %134, align 8
@@ -916,14 +998,14 @@ entry:
   %137 = load i8*, i8** %arg0
   %138 = load i8*, i8** %arg1
   %139 = bitcast i8* %138 to i64*
-  %NullCheck76 = icmp ne i64* %139, null
-  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+  %NullCheck75 = icmp eq i64* %139, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %140
 
 ; <label>:140                                     ; preds = %136
   %141 = load i64, i64* %139, align 8
   %142 = bitcast i8* %137 to i64*
-  %NullCheck78 = icmp ne i64* %142, null
-  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+  %NullCheck77 = icmp eq i64* %142, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %143
 
 ; <label>:143                                     ; preds = %140
   store i64 %141, i64* %142, align 8
@@ -931,15 +1013,15 @@ entry:
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %NullCheck80 = icmp ne i8* %147, null
-  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+  %NullCheck79 = icmp eq i8* %147, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %148
 
 ; <label>:148                                     ; preds = %143
   %149 = load i8, i8* %147, align 8
   %150 = zext i8 %149 to i32
   %151 = trunc i32 %150 to i8
-  %NullCheck82 = icmp ne i8* %145, null
-  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+  %NullCheck81 = icmp eq i8* %145, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %152
 
 ; <label>:152                                     ; preds = %148
   store i8 %151, i8* %145, align 8
@@ -949,14 +1031,14 @@ entry:
   %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
   %156 = bitcast i8* %155 to i64*
-  %NullCheck68 = icmp ne i64* %156, null
-  br i1 %NullCheck68, label %157, label %ThrowNullRef67
+  %NullCheck67 = icmp eq i64* %156, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %157
 
 ; <label>:157                                     ; preds = %153
   %158 = load i64, i64* %156, align 8
   %159 = bitcast i8* %154 to i64*
-  %NullCheck70 = icmp ne i64* %159, null
-  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+  %NullCheck69 = icmp eq i64* %159, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %160
 
 ; <label>:160                                     ; preds = %157
   store i64 %158, i64* %159, align 8
@@ -965,16 +1047,16 @@ entry:
   %163 = load i8*, i8** %arg1
   %164 = getelementptr inbounds i8, i8* %163, i64 8
   %165 = bitcast i8* %164 to i16*
-  %NullCheck72 = icmp ne i16* %165, null
-  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+  %NullCheck71 = icmp eq i16* %165, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %166
 
 ; <label>:166                                     ; preds = %160
   %167 = load i16, i16* %165, align 8
   %168 = sext i16 %167 to i32
   %169 = bitcast i8* %162 to i16*
   %170 = trunc i32 %168 to i16
-  %NullCheck74 = icmp ne i16* %169, null
-  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+  %NullCheck73 = icmp eq i16* %169, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %171
 
 ; <label>:171                                     ; preds = %166
   store i16 %170, i16* %169, align 8
@@ -984,14 +1066,14 @@ entry:
   %173 = load i8*, i8** %arg0
   %174 = load i8*, i8** %arg1
   %175 = bitcast i8* %174 to i64*
-  %NullCheck56 = icmp ne i64* %175, null
-  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+  %NullCheck55 = icmp eq i64* %175, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %176
 
 ; <label>:176                                     ; preds = %172
   %177 = load i64, i64* %175, align 8
   %178 = bitcast i8* %173 to i64*
-  %NullCheck58 = icmp ne i64* %178, null
-  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+  %NullCheck57 = icmp eq i64* %178, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %179
 
 ; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
@@ -1000,16 +1082,16 @@ entry:
   %182 = load i8*, i8** %arg1
   %183 = getelementptr inbounds i8, i8* %182, i64 8
   %184 = bitcast i8* %183 to i16*
-  %NullCheck60 = icmp ne i16* %184, null
-  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+  %NullCheck59 = icmp eq i16* %184, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %185
 
 ; <label>:185                                     ; preds = %179
   %186 = load i16, i16* %184, align 8
   %187 = sext i16 %186 to i32
   %188 = bitcast i8* %181 to i16*
   %189 = trunc i32 %187 to i16
-  %NullCheck62 = icmp ne i16* %188, null
-  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+  %NullCheck61 = icmp eq i16* %188, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %190
 
 ; <label>:190                                     ; preds = %185
   store i16 %189, i16* %188, align 8
@@ -1017,15 +1099,15 @@ entry:
   %192 = getelementptr inbounds i8, i8* %191, i64 10
   %193 = load i8*, i8** %arg1
   %194 = getelementptr inbounds i8, i8* %193, i64 10
-  %NullCheck64 = icmp ne i8* %194, null
-  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+  %NullCheck63 = icmp eq i8* %194, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %195
 
 ; <label>:195                                     ; preds = %190
   %196 = load i8, i8* %194, align 8
   %197 = zext i8 %196 to i32
   %198 = trunc i32 %197 to i8
-  %NullCheck66 = icmp ne i8* %192, null
-  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+  %NullCheck65 = icmp eq i8* %192, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %199
 
 ; <label>:199                                     ; preds = %195
   store i8 %198, i8* %192, align 8
@@ -1035,14 +1117,14 @@ entry:
   %201 = load i8*, i8** %arg0
   %202 = load i8*, i8** %arg1
   %203 = bitcast i8* %202 to i64*
-  %NullCheck48 = icmp ne i64* %203, null
-  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+  %NullCheck47 = icmp eq i64* %203, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %204
 
 ; <label>:204                                     ; preds = %200
   %205 = load i64, i64* %203, align 8
   %206 = bitcast i8* %201 to i64*
-  %NullCheck50 = icmp ne i64* %206, null
-  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+  %NullCheck49 = icmp eq i64* %206, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %207
 
 ; <label>:207                                     ; preds = %204
   store i64 %205, i64* %206, align 8
@@ -1051,14 +1133,14 @@ entry:
   %210 = load i8*, i8** %arg1
   %211 = getelementptr inbounds i8, i8* %210, i64 8
   %212 = bitcast i8* %211 to i32*
-  %NullCheck52 = icmp ne i32* %212, null
-  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+  %NullCheck51 = icmp eq i32* %212, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %213
 
 ; <label>:213                                     ; preds = %207
   %214 = load i32, i32* %212, align 8
   %215 = bitcast i8* %209 to i32*
-  %NullCheck54 = icmp ne i32* %215, null
-  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+  %NullCheck53 = icmp eq i32* %215, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %216
 
 ; <label>:216                                     ; preds = %213
   store i32 %214, i32* %215, align 8
@@ -1068,14 +1150,14 @@ entry:
   %218 = load i8*, i8** %arg0
   %219 = load i8*, i8** %arg1
   %220 = bitcast i8* %219 to i64*
-  %NullCheck36 = icmp ne i64* %220, null
-  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64* %220, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %221
 
 ; <label>:221                                     ; preds = %217
   %222 = load i64, i64* %220, align 8
   %223 = bitcast i8* %218 to i64*
-  %NullCheck38 = icmp ne i64* %223, null
-  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+  %NullCheck37 = icmp eq i64* %223, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %224
 
 ; <label>:224                                     ; preds = %221
   store i64 %222, i64* %223, align 8
@@ -1084,14 +1166,14 @@ entry:
   %227 = load i8*, i8** %arg1
   %228 = getelementptr inbounds i8, i8* %227, i64 8
   %229 = bitcast i8* %228 to i32*
-  %NullCheck40 = icmp ne i32* %229, null
-  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i32* %229, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %230
 
 ; <label>:230                                     ; preds = %224
   %231 = load i32, i32* %229, align 8
   %232 = bitcast i8* %226 to i32*
-  %NullCheck42 = icmp ne i32* %232, null
-  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+  %NullCheck41 = icmp eq i32* %232, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %233
 
 ; <label>:233                                     ; preds = %230
   store i32 %231, i32* %232, align 8
@@ -1099,15 +1181,15 @@ entry:
   %235 = getelementptr inbounds i8, i8* %234, i64 12
   %236 = load i8*, i8** %arg1
   %237 = getelementptr inbounds i8, i8* %236, i64 12
-  %NullCheck44 = icmp ne i8* %237, null
-  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i8* %237, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %238
 
 ; <label>:238                                     ; preds = %233
   %239 = load i8, i8* %237, align 8
   %240 = zext i8 %239 to i32
   %241 = trunc i32 %240 to i8
-  %NullCheck46 = icmp ne i8* %235, null
-  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+  %NullCheck45 = icmp eq i8* %235, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %242
 
 ; <label>:242                                     ; preds = %238
   store i8 %241, i8* %235, align 8
@@ -1117,14 +1199,14 @@ entry:
   %244 = load i8*, i8** %arg0
   %245 = load i8*, i8** %arg1
   %246 = bitcast i8* %245 to i64*
-  %NullCheck24 = icmp ne i64* %246, null
-  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64* %246, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %247
 
 ; <label>:247                                     ; preds = %243
   %248 = load i64, i64* %246, align 8
   %249 = bitcast i8* %244 to i64*
-  %NullCheck26 = icmp ne i64* %249, null
-  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64* %249, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %250
 
 ; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
@@ -1133,14 +1215,14 @@ entry:
   %253 = load i8*, i8** %arg1
   %254 = getelementptr inbounds i8, i8* %253, i64 8
   %255 = bitcast i8* %254 to i32*
-  %NullCheck28 = icmp ne i32* %255, null
-  br i1 %NullCheck28, label %256, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i32* %255, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %256
 
 ; <label>:256                                     ; preds = %250
   %257 = load i32, i32* %255, align 8
   %258 = bitcast i8* %252 to i32*
-  %NullCheck30 = icmp ne i32* %258, null
-  br i1 %NullCheck30, label %259, label %ThrowNullRef29
+  %NullCheck29 = icmp eq i32* %258, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %259
 
 ; <label>:259                                     ; preds = %256
   store i32 %257, i32* %258, align 8
@@ -1149,16 +1231,16 @@ entry:
   %262 = load i8*, i8** %arg1
   %263 = getelementptr inbounds i8, i8* %262, i64 12
   %264 = bitcast i8* %263 to i16*
-  %NullCheck32 = icmp ne i16* %264, null
-  br i1 %NullCheck32, label %265, label %ThrowNullRef31
+  %NullCheck31 = icmp eq i16* %264, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %265
 
 ; <label>:265                                     ; preds = %259
   %266 = load i16, i16* %264, align 8
   %267 = sext i16 %266 to i32
   %268 = bitcast i8* %261 to i16*
   %269 = trunc i32 %267 to i16
-  %NullCheck34 = icmp ne i16* %268, null
-  br i1 %NullCheck34, label %270, label %ThrowNullRef33
+  %NullCheck33 = icmp eq i16* %268, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %270
 
 ; <label>:270                                     ; preds = %265
   store i16 %269, i16* %268, align 8
@@ -1168,14 +1250,14 @@ entry:
   %272 = load i8*, i8** %arg0
   %273 = load i8*, i8** %arg1
   %274 = bitcast i8* %273 to i64*
-  %NullCheck8 = icmp ne i64* %274, null
-  br i1 %NullCheck8, label %275, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64* %274, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %275
 
 ; <label>:275                                     ; preds = %271
   %276 = load i64, i64* %274, align 8
   %277 = bitcast i8* %272 to i64*
-  %NullCheck10 = icmp ne i64* %277, null
-  br i1 %NullCheck10, label %278, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %277, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %278
 
 ; <label>:278                                     ; preds = %275
   store i64 %276, i64* %277, align 8
@@ -1184,14 +1266,14 @@ entry:
   %281 = load i8*, i8** %arg1
   %282 = getelementptr inbounds i8, i8* %281, i64 8
   %283 = bitcast i8* %282 to i32*
-  %NullCheck12 = icmp ne i32* %283, null
-  br i1 %NullCheck12, label %284, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i32* %283, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %284
 
 ; <label>:284                                     ; preds = %278
   %285 = load i32, i32* %283, align 8
   %286 = bitcast i8* %280 to i32*
-  %NullCheck14 = icmp ne i32* %286, null
-  br i1 %NullCheck14, label %287, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i32* %286, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %287
 
 ; <label>:287                                     ; preds = %284
   store i32 %285, i32* %286, align 8
@@ -1200,16 +1282,16 @@ entry:
   %290 = load i8*, i8** %arg1
   %291 = getelementptr inbounds i8, i8* %290, i64 12
   %292 = bitcast i8* %291 to i16*
-  %NullCheck16 = icmp ne i16* %292, null
-  br i1 %NullCheck16, label %293, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i16* %292, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %293
 
 ; <label>:293                                     ; preds = %287
   %294 = load i16, i16* %292, align 8
   %295 = sext i16 %294 to i32
   %296 = bitcast i8* %289 to i16*
   %297 = trunc i32 %295 to i16
-  %NullCheck18 = icmp ne i16* %296, null
-  br i1 %NullCheck18, label %298, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i16* %296, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %298
 
 ; <label>:298                                     ; preds = %293
   store i16 %297, i16* %296, align 8
@@ -1217,15 +1299,15 @@ entry:
   %300 = getelementptr inbounds i8, i8* %299, i64 14
   %301 = load i8*, i8** %arg1
   %302 = getelementptr inbounds i8, i8* %301, i64 14
-  %NullCheck20 = icmp ne i8* %302, null
-  br i1 %NullCheck20, label %303, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i8* %302, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %303
 
 ; <label>:303                                     ; preds = %298
   %304 = load i8, i8* %302, align 8
   %305 = zext i8 %304 to i32
   %306 = trunc i32 %305 to i8
-  %NullCheck22 = icmp ne i8* %300, null
-  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i8* %300, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %307
 
 ; <label>:307                                     ; preds = %303
   store i8 %306, i8* %300, align 8
@@ -1235,14 +1317,14 @@ entry:
   %309 = load i8*, i8** %arg0
   %310 = load i8*, i8** %arg1
   %311 = bitcast i8* %310 to i64*
-  %NullCheck = icmp ne i64* %311, null
-  br i1 %NullCheck, label %312, label %ThrowNullRef
+  %NullCheck = icmp eq i64* %311, null
+  br i1 %NullCheck, label %ThrowNullRef, label %312
 
 ; <label>:312                                     ; preds = %308
   %313 = load i64, i64* %311, align 8
   %314 = bitcast i8* %309 to i64*
-  %NullCheck2 = icmp ne i64* %314, null
-  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64* %314, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %315
 
 ; <label>:315                                     ; preds = %312
   store i64 %313, i64* %314, align 8
@@ -1251,14 +1333,14 @@ entry:
   %318 = load i8*, i8** %arg1
   %319 = getelementptr inbounds i8, i8* %318, i64 8
   %320 = bitcast i8* %319 to i64*
-  %NullCheck4 = icmp ne i64* %320, null
-  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64* %320, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %321
 
 ; <label>:321                                     ; preds = %315
   %322 = load i64, i64* %320, align 8
   %323 = bitcast i8* %317 to i64*
-  %NullCheck6 = icmp ne i64* %323, null
-  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64* %323, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %324
 
 ; <label>:324                                     ; preds = %321
   store i64 %322, i64* %323, align 8
@@ -1286,15 +1368,15 @@ entry:
 ; <label>:338                                     ; preds = %333
   %339 = load i8*, i8** %arg0
   %340 = load i8*, i8** %arg1
-  %NullCheck136 = icmp ne i8* %340, null
-  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+  %NullCheck135 = icmp eq i8* %340, null
+  br i1 %NullCheck135, label %ThrowNullRef136, label %341
 
 ; <label>:341                                     ; preds = %338
   %342 = load i8, i8* %340, align 8
   %343 = zext i8 %342 to i32
   %344 = trunc i32 %343 to i8
-  %NullCheck138 = icmp ne i8* %339, null
-  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+  %NullCheck137 = icmp eq i8* %339, null
+  br i1 %NullCheck137, label %ThrowNullRef138, label %345
 
 ; <label>:345                                     ; preds = %341
   store i8 %344, i8* %339, align 8
@@ -1317,16 +1399,16 @@ entry:
   %357 = load i8*, i8** %arg0
   %358 = load i8*, i8** %arg1
   %359 = bitcast i8* %358 to i16*
-  %NullCheck140 = icmp ne i16* %359, null
-  br i1 %NullCheck140, label %360, label %ThrowNullRef139
+  %NullCheck139 = icmp eq i16* %359, null
+  br i1 %NullCheck139, label %ThrowNullRef140, label %360
 
 ; <label>:360                                     ; preds = %356
   %361 = load i16, i16* %359, align 8
   %362 = sext i16 %361 to i32
   %363 = bitcast i8* %357 to i16*
   %364 = trunc i32 %362 to i16
-  %NullCheck142 = icmp ne i16* %363, null
-  br i1 %NullCheck142, label %365, label %ThrowNullRef141
+  %NullCheck141 = icmp eq i16* %363, null
+  br i1 %NullCheck141, label %ThrowNullRef142, label %365
 
 ; <label>:365                                     ; preds = %360
   store i16 %364, i16* %363, align 8
@@ -1352,14 +1434,14 @@ entry:
   %378 = load i8*, i8** %arg0
   %379 = load i8*, i8** %arg1
   %380 = bitcast i8* %379 to i32*
-  %NullCheck144 = icmp ne i32* %380, null
-  br i1 %NullCheck144, label %381, label %ThrowNullRef143
+  %NullCheck143 = icmp eq i32* %380, null
+  br i1 %NullCheck143, label %ThrowNullRef144, label %381
 
 ; <label>:381                                     ; preds = %377
   %382 = load i32, i32* %380, align 8
   %383 = bitcast i8* %378 to i32*
-  %NullCheck146 = icmp ne i32* %383, null
-  br i1 %NullCheck146, label %384, label %ThrowNullRef145
+  %NullCheck145 = icmp eq i32* %383, null
+  br i1 %NullCheck145, label %ThrowNullRef146, label %384
 
 ; <label>:384                                     ; preds = %381
   store i32 %382, i32* %383, align 8
@@ -1384,14 +1466,14 @@ entry:
   %395 = load i8*, i8** %arg0
   %396 = load i8*, i8** %arg1
   %397 = bitcast i8* %396 to i64*
-  %NullCheck164 = icmp ne i64* %397, null
-  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+  %NullCheck163 = icmp eq i64* %397, null
+  br i1 %NullCheck163, label %ThrowNullRef164, label %398
 
 ; <label>:398                                     ; preds = %394
   %399 = load i64, i64* %397, align 8
   %400 = bitcast i8* %395 to i64*
-  %NullCheck166 = icmp ne i64* %400, null
-  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+  %NullCheck165 = icmp eq i64* %400, null
+  br i1 %NullCheck165, label %ThrowNullRef166, label %401
 
 ; <label>:401                                     ; preds = %398
   store i64 %399, i64* %400, align 8
@@ -1400,14 +1482,14 @@ entry:
   %404 = load i8*, i8** %arg1
   %405 = getelementptr inbounds i8, i8* %404, i64 8
   %406 = bitcast i8* %405 to i64*
-  %NullCheck168 = icmp ne i64* %406, null
-  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+  %NullCheck167 = icmp eq i64* %406, null
+  br i1 %NullCheck167, label %ThrowNullRef168, label %407
 
 ; <label>:407                                     ; preds = %401
   %408 = load i64, i64* %406, align 8
   %409 = bitcast i8* %403 to i64*
-  %NullCheck170 = icmp ne i64* %409, null
-  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+  %NullCheck169 = icmp eq i64* %409, null
+  br i1 %NullCheck169, label %ThrowNullRef170, label %410
 
 ; <label>:410                                     ; preds = %407
   store i64 %408, i64* %409, align 8
@@ -1437,14 +1519,14 @@ entry:
   %425 = load i8*, i8** %arg0
   %426 = load i8*, i8** %arg1
   %427 = bitcast i8* %426 to i64*
-  %NullCheck148 = icmp ne i64* %427, null
-  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+  %NullCheck147 = icmp eq i64* %427, null
+  br i1 %NullCheck147, label %ThrowNullRef148, label %428
 
 ; <label>:428                                     ; preds = %424
   %429 = load i64, i64* %427, align 8
   %430 = bitcast i8* %425 to i64*
-  %NullCheck150 = icmp ne i64* %430, null
-  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+  %NullCheck149 = icmp eq i64* %430, null
+  br i1 %NullCheck149, label %ThrowNullRef150, label %431
 
 ; <label>:431                                     ; preds = %428
   store i64 %429, i64* %430, align 8
@@ -1466,14 +1548,14 @@ entry:
   %441 = load i8*, i8** %arg0
   %442 = load i8*, i8** %arg1
   %443 = bitcast i8* %442 to i32*
-  %NullCheck152 = icmp ne i32* %443, null
-  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+  %NullCheck151 = icmp eq i32* %443, null
+  br i1 %NullCheck151, label %ThrowNullRef152, label %444
 
 ; <label>:444                                     ; preds = %440
   %445 = load i32, i32* %443, align 8
   %446 = bitcast i8* %441 to i32*
-  %NullCheck154 = icmp ne i32* %446, null
-  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+  %NullCheck153 = icmp eq i32* %446, null
+  br i1 %NullCheck153, label %ThrowNullRef154, label %447
 
 ; <label>:447                                     ; preds = %444
   store i32 %445, i32* %446, align 8
@@ -1495,16 +1577,16 @@ entry:
   %457 = load i8*, i8** %arg0
   %458 = load i8*, i8** %arg1
   %459 = bitcast i8* %458 to i16*
-  %NullCheck156 = icmp ne i16* %459, null
-  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+  %NullCheck155 = icmp eq i16* %459, null
+  br i1 %NullCheck155, label %ThrowNullRef156, label %460
 
 ; <label>:460                                     ; preds = %456
   %461 = load i16, i16* %459, align 8
   %462 = sext i16 %461 to i32
   %463 = bitcast i8* %457 to i16*
   %464 = trunc i32 %462 to i16
-  %NullCheck158 = icmp ne i16* %463, null
-  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+  %NullCheck157 = icmp eq i16* %463, null
+  br i1 %NullCheck157, label %ThrowNullRef158, label %465
 
 ; <label>:465                                     ; preds = %460
   store i16 %464, i16* %463, align 8
@@ -1525,15 +1607,15 @@ entry:
 ; <label>:474                                     ; preds = %470
   %475 = load i8*, i8** %arg0
   %476 = load i8*, i8** %arg1
-  %NullCheck160 = icmp ne i8* %476, null
-  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+  %NullCheck159 = icmp eq i8* %476, null
+  br i1 %NullCheck159, label %ThrowNullRef160, label %477
 
 ; <label>:477                                     ; preds = %474
   %478 = load i8, i8* %476, align 8
   %479 = zext i8 %478 to i32
   %480 = trunc i32 %479 to i8
-  %NullCheck162 = icmp ne i8* %475, null
-  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+  %NullCheck161 = icmp eq i8* %475, null
+  br i1 %NullCheck161, label %ThrowNullRef162, label %481
 
 ; <label>:481                                     ; preds = %477
   store i8 %480, i8* %475, align 8
@@ -1553,343 +1635,343 @@ ThrowNullRef:                                     ; preds = %308
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %312
+ThrowNullRef2:                                    ; preds = %312
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %315
+ThrowNullRef4:                                    ; preds = %315
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %321
+ThrowNullRef6:                                    ; preds = %321
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %271
+ThrowNullRef8:                                    ; preds = %271
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %275
+ThrowNullRef10:                                   ; preds = %275
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %278
+ThrowNullRef12:                                   ; preds = %278
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %284
+ThrowNullRef14:                                   ; preds = %284
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %287
+ThrowNullRef16:                                   ; preds = %287
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %293
+ThrowNullRef18:                                   ; preds = %293
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %298
+ThrowNullRef20:                                   ; preds = %298
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %303
+ThrowNullRef22:                                   ; preds = %303
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %243
+ThrowNullRef24:                                   ; preds = %243
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %247
+ThrowNullRef26:                                   ; preds = %247
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %250
+ThrowNullRef28:                                   ; preds = %250
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %256
+ThrowNullRef30:                                   ; preds = %256
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %259
+ThrowNullRef32:                                   ; preds = %259
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %265
+ThrowNullRef34:                                   ; preds = %265
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %217
+ThrowNullRef36:                                   ; preds = %217
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %221
+ThrowNullRef38:                                   ; preds = %221
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %224
+ThrowNullRef40:                                   ; preds = %224
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %230
+ThrowNullRef42:                                   ; preds = %230
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %233
+ThrowNullRef44:                                   ; preds = %233
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %238
+ThrowNullRef46:                                   ; preds = %238
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %200
+ThrowNullRef48:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %204
+ThrowNullRef50:                                   ; preds = %204
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %207
+ThrowNullRef52:                                   ; preds = %207
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %213
+ThrowNullRef54:                                   ; preds = %213
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %172
+ThrowNullRef56:                                   ; preds = %172
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %176
+ThrowNullRef58:                                   ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %179
+ThrowNullRef60:                                   ; preds = %179
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %185
+ThrowNullRef62:                                   ; preds = %185
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %190
+ThrowNullRef64:                                   ; preds = %190
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %195
+ThrowNullRef66:                                   ; preds = %195
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %153
+ThrowNullRef68:                                   ; preds = %153
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %157
+ThrowNullRef70:                                   ; preds = %157
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %160
+ThrowNullRef72:                                   ; preds = %160
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %166
+ThrowNullRef74:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %136
+ThrowNullRef76:                                   ; preds = %136
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %140
+ThrowNullRef78:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %143
+ThrowNullRef80:                                   ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %148
+ThrowNullRef82:                                   ; preds = %148
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %128
+ThrowNullRef84:                                   ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %132
+ThrowNullRef86:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %100
+ThrowNullRef88:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %104
+ThrowNullRef90:                                   ; preds = %104
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %107
+ThrowNullRef92:                                   ; preds = %107
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %113
+ThrowNullRef94:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %118
+ThrowNullRef96:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %123
+ThrowNullRef98:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %81
+ThrowNullRef100:                                  ; preds = %81
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef101:                                  ; preds = %85
+ThrowNullRef102:                                  ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef103:                                  ; preds = %88
+ThrowNullRef104:                                  ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef105:                                  ; preds = %94
+ThrowNullRef106:                                  ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef107:                                  ; preds = %64
+ThrowNullRef108:                                  ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef109:                                  ; preds = %68
+ThrowNullRef110:                                  ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef111:                                  ; preds = %71
+ThrowNullRef112:                                  ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef113:                                  ; preds = %76
+ThrowNullRef114:                                  ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef115:                                  ; preds = %56
+ThrowNullRef116:                                  ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef117:                                  ; preds = %60
+ThrowNullRef118:                                  ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef119:                                  ; preds = %37
+ThrowNullRef120:                                  ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef121:                                  ; preds = %41
+ThrowNullRef122:                                  ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef123:                                  ; preds = %46
+ThrowNullRef124:                                  ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef125:                                  ; preds = %51
+ThrowNullRef126:                                  ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef127:                                  ; preds = %27
+ThrowNullRef128:                                  ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef129:                                  ; preds = %31
+ThrowNullRef130:                                  ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef131:                                  ; preds = %19
+ThrowNullRef132:                                  ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef133:                                  ; preds = %22
+ThrowNullRef134:                                  ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef135:                                  ; preds = %338
+ThrowNullRef136:                                  ; preds = %338
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef137:                                  ; preds = %341
+ThrowNullRef138:                                  ; preds = %341
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef139:                                  ; preds = %356
+ThrowNullRef140:                                  ; preds = %356
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef141:                                  ; preds = %360
+ThrowNullRef142:                                  ; preds = %360
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef143:                                  ; preds = %377
+ThrowNullRef144:                                  ; preds = %377
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef145:                                  ; preds = %381
+ThrowNullRef146:                                  ; preds = %381
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef147:                                  ; preds = %424
+ThrowNullRef148:                                  ; preds = %424
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef149:                                  ; preds = %428
+ThrowNullRef150:                                  ; preds = %428
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef151:                                  ; preds = %440
+ThrowNullRef152:                                  ; preds = %440
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef153:                                  ; preds = %444
+ThrowNullRef154:                                  ; preds = %444
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef155:                                  ; preds = %456
+ThrowNullRef156:                                  ; preds = %456
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef157:                                  ; preds = %460
+ThrowNullRef158:                                  ; preds = %460
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef159:                                  ; preds = %474
+ThrowNullRef160:                                  ; preds = %474
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef161:                                  ; preds = %477
+ThrowNullRef162:                                  ; preds = %477
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef163:                                  ; preds = %394
+ThrowNullRef164:                                  ; preds = %394
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef165:                                  ; preds = %398
+ThrowNullRef166:                                  ; preds = %398
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef167:                                  ; preds = %401
+ThrowNullRef168:                                  ; preds = %401
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef169:                                  ; preds = %407
+ThrowNullRef170:                                  ; preds = %407
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1939,8 +2021,8 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
-  br i1 %NullCheck, label %22, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %ThrowNullRef, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
@@ -1948,8 +2030,8 @@ entry:
   store i32 %24, i32* %loc0
   %25 = load i32, i32* %loc0
   %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %26, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %27
 
 ; <label>:27                                      ; preds = %22
   %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
@@ -1971,7 +2053,7 @@ ThrowNullRef:                                     ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1989,8 +2071,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -2022,15 +2104,15 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2048,16 +2130,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
   %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
   store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %15
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
@@ -2072,8 +2154,8 @@ entry:
   %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
   %29 = ptrtoint i16 addrspace(1)* %28 to i64
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %19
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
@@ -2089,19 +2171,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2114,8 +2196,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
@@ -2128,7 +2210,7 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[loadElem]
+Failed to read AppDomain.PrepareDataForSetup[storeElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
@@ -2202,8 +2284,8 @@ entry:
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
-  br i1 %NullCheck24, label %27, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = load i64, i64 addrspace(1)* %26
@@ -2218,8 +2300,8 @@ entry:
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
-  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
   %41 = load i64, i64 addrspace(1)* %39
@@ -2236,8 +2318,8 @@ entry:
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
-  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
   %54 = load i64, i64 addrspace(1)* %52
@@ -2252,8 +2334,8 @@ entry:
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
   %67 = load i64, i64 addrspace(1)* %65
@@ -2270,8 +2352,8 @@ entry:
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
-  br i1 %NullCheck16, label %79, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
   %80 = load i64, i64 addrspace(1)* %78
@@ -2286,8 +2368,8 @@ entry:
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
-  br i1 %NullCheck18, label %92, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
   %93 = load i64, i64 addrspace(1)* %91
@@ -2304,8 +2386,8 @@ entry:
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
-  br i1 %NullCheck12, label %105, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = load i64, i64 addrspace(1)* %104
@@ -2320,8 +2402,8 @@ entry:
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
-  br i1 %NullCheck14, label %118, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
   %119 = load i64, i64 addrspace(1)* %117
@@ -2337,8 +2419,8 @@ entry:
 
 ; <label>:128                                     ; preds = %20
   %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
-  br i1 %NullCheck4, label %130, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %129, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %130
 
 ; <label>:130                                     ; preds = %128
   %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
@@ -2346,8 +2428,8 @@ entry:
   %133 = load i16, i16 addrspace(1)* %132, align 8
   %134 = zext i16 %133 to i32
   %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
-  br i1 %NullCheck6, label %136, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %135, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %136
 
 ; <label>:136                                     ; preds = %130
   %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
@@ -2360,8 +2442,8 @@ entry:
 
 ; <label>:143                                     ; preds = %136
   %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
-  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %144, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %145
 
 ; <label>:145                                     ; preds = %143
   %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
@@ -2369,8 +2451,8 @@ entry:
   %148 = load i16, i16 addrspace(1)* %147, align 8
   %149 = zext i16 %148 to i32
   %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %150, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %151
 
 ; <label>:151                                     ; preds = %145
   %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
@@ -2388,8 +2470,8 @@ entry:
 
 ; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
-  br i1 %NullCheck, label %163, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %ThrowNullRef, label %163
 
 ; <label>:163                                     ; preds = %161
   %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
@@ -2399,8 +2481,8 @@ entry:
 
 ; <label>:167                                     ; preds = %163
   %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
-  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %168, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %169
 
 ; <label>:169                                     ; preds = %167
   %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
@@ -2432,55 +2514,55 @@ ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %167
+ThrowNullRef2:                                    ; preds = %167
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %128
+ThrowNullRef4:                                    ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %130
+ThrowNullRef6:                                    ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %143
+ThrowNullRef8:                                    ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %145
+ThrowNullRef10:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %102
+ThrowNullRef12:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %105
+ThrowNullRef14:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %76
+ThrowNullRef16:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %79
+ThrowNullRef18:                                   ; preds = %79
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %50
+ThrowNullRef20:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %53
+ThrowNullRef22:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %24
+ThrowNullRef24:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %27
+ThrowNullRef26:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2503,15 +2585,15 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2519,16 +2601,16 @@ entry:
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
   store i32 %8, i32* %loc0
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
   %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
   store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
@@ -2546,16 +2628,16 @@ entry:
 
 ; <label>:23                                      ; preds = %64
   %24 = load i16*, i16** %loc3
-  %NullCheck12 = icmp ne i16* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i16* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
   store i32 %27, i32* %loc5
   %28 = load i16*, i16** %loc4
-  %NullCheck14 = icmp ne i16* %28, null
-  br i1 %NullCheck14, label %29, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %28, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = load i16, i16* %28, align 8
@@ -2620,15 +2702,15 @@ entry:
 
 ; <label>:67                                      ; preds = %64
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
-  br i1 %NullCheck8, label %69, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %68, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %69
 
 ; <label>:69                                      ; preds = %67
   %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
   %71 = load i32, i32 addrspace(1)* %70
   %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
-  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %73
 
 ; <label>:73                                      ; preds = %69
   %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
@@ -2645,31 +2727,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %67
+ThrowNullRef8:                                    ; preds = %67
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %69
+ThrowNullRef10:                                   ; preds = %69
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2710,14 +2792,14 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
   %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
@@ -2730,14 +2812,14 @@ entry:
 
 ; <label>:11                                      ; preds = %4
   %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
   %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
@@ -2749,14 +2831,14 @@ entry:
 
 ; <label>:22                                      ; preds = %16
   %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
   %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
-  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
-  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
@@ -2804,23 +2886,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2836,7 +2918,280 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[loadElem]
+Successfully read RuntimeType.IsAssignableFrom
+
+define i8 @RuntimeType.IsAssignableFrom(%System.RuntimeType addrspace(1)* %param0, %System.Type addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.RuntimeType addrspace(1)*
+  %arg1 = alloca %System.Type addrspace(1)*
+  %loc0 = alloca %System.RuntimeType addrspace(1)*
+  %loc1 = alloca %"System.Type[]" addrspace(1)*
+  %loc2 = alloca i32
+  store %System.RuntimeType addrspace(1)* %param0, %System.RuntimeType addrspace(1)** %this
+  store %System.Type addrspace(1)* %param1, %System.Type addrspace(1)** %arg1
+  %0 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %1 = icmp ne %System.Type addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i8 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %5 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %6 = bitcast %System.Type addrspace(1)* %4 to %System.Object addrspace(1)*
+  %7 = bitcast %System.RuntimeType addrspace(1)* %5 to %System.Object addrspace(1)*
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %6, %System.Object addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %3
+  ret i8 1
+
+; <label>:12                                      ; preds = %3
+  %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 152
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 32
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
+  %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
+  %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
+  store %System.RuntimeType addrspace(1)* %25, %System.RuntimeType addrspace(1)** %loc0
+  %26 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %27 = icmp eq %System.RuntimeType addrspace(1)* %26, null
+  br i1 %27, label %34, label %28
+
+; <label>:28                                      ; preds = %15
+  %29 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %30 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)*)*)(%System.RuntimeType addrspace(1)* %29, %System.RuntimeType addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+; <label>:34                                      ; preds = %15
+  %35 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %36 = call %System.Reflection.Emit.TypeBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Reflection.Emit.TypeBuilder addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %35)
+  %37 = icmp eq %System.Reflection.Emit.TypeBuilder addrspace(1)* %36, null
+  br i1 %37, label %139, label %38
+
+; <label>:38                                      ; preds = %34
+  %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %42
+
+; <label>:42                                      ; preds = %38
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 152
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 40
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
+  %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
+  %53 = zext i8 %52 to i32
+  %54 = icmp eq i32 %53, 0
+  br i1 %54, label %56, label %55
+
+; <label>:55                                      ; preds = %42
+  ret i8 1
+
+; <label>:56                                      ; preds = %42
+  %57 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %58 = bitcast %System.RuntimeType addrspace(1)* %57 to %System.Type addrspace(1)*
+  %59 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %58)
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %64 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.Type addrspace(1)* %63, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = bitcast %System.RuntimeType addrspace(1)* %64 to %System.Type addrspace(1)*
+  %67 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %63, %System.Type addrspace(1)* %66)
+  %68 = zext i8 %67 to i32
+  %69 = trunc i32 %68 to i8
+  ret i8 %69
+
+; <label>:70                                      ; preds = %56
+  %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
+  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %73
+
+; <label>:73                                      ; preds = %70
+  %74 = load i64, i64 addrspace(1)* %72
+  %75 = add i64 %74, 128
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = add i64 %77, 0
+  %79 = inttoptr i64 %78 to i64*
+  %80 = load i64, i64* %79
+  %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
+  %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
+  %83 = call i8 %82(%System.Type addrspace(1)* %81)
+  %84 = zext i8 %83 to i32
+  %85 = icmp eq i32 %84, 0
+  br i1 %85, label %139, label %86
+
+; <label>:86                                      ; preds = %73
+  %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
+  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %89
+
+; <label>:89                                      ; preds = %86
+  %90 = load i64, i64 addrspace(1)* %88
+  %91 = add i64 %90, 128
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = add i64 %93, 24
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
+  %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
+  %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
+  store %"System.Type[]" addrspace(1)* %99, %"System.Type[]" addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %129
+
+; <label>:100                                     ; preds = %132
+  %101 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %102 = load i32, i32* %loc2
+  %NullCheck11 = icmp eq %"System.Type[]" addrspace(1)* %101, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %103
+
+; <label>:103                                     ; preds = %100
+  %104 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 1
+  %105 = load i32, i32 addrspace(1)* %104
+  %106 = zext i32 %105 to i64
+  %107 = zext i32 %102 to i64
+  %BoundsCheck = icmp uge i64 %107, %106
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %108
+
+; <label>:108                                     ; preds = %103
+  %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
+  %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
+  %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
+  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %113
+
+; <label>:113                                     ; preds = %108
+  %114 = load i64, i64 addrspace(1)* %112
+  %115 = add i64 %114, 152
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = add i64 %117, 56
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
+  %123 = zext i8 %122 to i32
+  %124 = icmp ne i32 %123, 0
+  br i1 %124, label %126, label %125
+
+; <label>:125                                     ; preds = %113
+  ret i8 0
+
+; <label>:126                                     ; preds = %113
+  %127 = load i32, i32* %loc2
+  %128 = add i32 %127, 1
+  store i32 %128, i32* %loc2
+  br label %129
+
+; <label>:129                                     ; preds = %89, %126
+  %130 = load i32, i32* %loc2
+  %131 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %NullCheck9 = icmp eq %"System.Type[]" addrspace(1)* %131, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %132
+
+; <label>:132                                     ; preds = %129
+  %133 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %131, i32 0, i32 1
+  %134 = load i32, i32 addrspace(1)* %133
+  %135 = zext i32 %134 to i64
+  %136 = trunc i64 %135 to i32
+  %137 = icmp slt i32 %130, %136
+  br i1 %137, label %100, label %138
+
+; <label>:138                                     ; preds = %132
+  ret i8 1
+
+; <label>:139                                     ; preds = %34, %73
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %129
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %103
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -2893,7 +3248,7 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElem]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -2904,8 +3259,8 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -2997,8 +3352,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
@@ -3059,8 +3414,8 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -3087,8 +3442,8 @@ entry:
 
 ; <label>:17                                      ; preds = %5, %11
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
@@ -3097,8 +3452,8 @@ entry:
 
 ; <label>:22                                      ; preds = %1, %11
   %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
@@ -3109,11 +3464,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %17
+ThrowNullRef2:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %22
+ThrowNullRef4:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3167,15 +3522,15 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
   %15 = load i32, i32 addrspace(1)* %14
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
@@ -3198,7 +3553,7 @@ ThrowNullRef:                                     ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef2:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3232,8 +3587,8 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
@@ -3312,8 +3667,8 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -3327,8 +3682,8 @@ entry:
 ; <label>:5                                       ; preds = %43
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %7 = load i32, i32* %loc1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck6, label %8, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
@@ -3366,8 +3721,8 @@ entry:
 ; <label>:32                                      ; preds = %21, %25
   %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
   %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
-  br i1 %NullCheck8, label %35, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = trunc i32 %34 to i16
@@ -3380,8 +3735,8 @@ entry:
 ; <label>:40                                      ; preds = %1, %35
   %41 = load i32, i32* %loc1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
-  br i1 %NullCheck2, label %43, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %42, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
@@ -3392,8 +3747,8 @@ entry:
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
   %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
-  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
   %51 = load i64, i64 addrspace(1)* %49
@@ -3412,19 +3767,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %40
+ThrowNullRef2:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %47
+ThrowNullRef4:                                    ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %5
+ThrowNullRef6:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %32
+ThrowNullRef8:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3467,8 +3822,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
@@ -3492,11 +3847,391 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(i16* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store i16* %param0, i16** %arg0
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load i32, i32* %arg3
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %42, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %37, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg2
+  %13 = load i32, i32* %arg3
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %37, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %24 = load i32, i32* %arg2
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load i16*, i16** %arg0
+  %35 = load i32, i32* %arg3
+  %36 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %36, i16* %34, i32 %35)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:37                                      ; preds = %5, %16
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %39)
+  %41 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41, %System.String addrspace(1)* %38, %System.String addrspace(1)* %40)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41) #0
+  unreachable
+
+; <label>:42                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
-Failed to read StringBuilder.ToString[loadElemA]
+Successfully read StringBuilder.ToString
+
+define %System.String addrspace(1)* @StringBuilder.ToString(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i16*
+  %loc3 = alloca %"System.Char[]" addrspace(1)*
+  %loc4 = alloca i32
+  %loc5 = alloca i32
+  %loc6 = alloca i16 addrspace(1)*
+  %loc7 = alloca %System.String addrspace(1)*
+  %loc8 = alloca %"System.Char[]" addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %0)
+  %2 = icmp ne i32 %1, 0
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %4
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %6)
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %7)
+  store %System.String addrspace(1)* %8, %System.String addrspace(1)** %loc0
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.Text.StringBuilder addrspace(1)* %9, %System.Text.StringBuilder addrspace(1)** %loc1
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  store %System.String addrspace(1)* %10, %System.String addrspace(1)** %loc7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc7
+  %12 = ptrtoint %System.String addrspace(1)* %11 to i64
+  %13 = icmp eq i64 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %5
+  %15 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %16 = sext i32 %15 to i64
+  %17 = add i64 %12, %16
+  br label %18
+
+; <label>:18                                      ; preds = %5, %14
+  %19 = phi i64 [ %12, %5 ], [ %17, %14 ]
+  %20 = inttoptr i64 %19 to i16*
+  store i16* %20, i16** %loc2
+  br label %21
+
+; <label>:21                                      ; preds = %98, %18
+  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %22, null
+  br i1 %NullCheck, label %ThrowNullRef, label %23
+
+; <label>:23                                      ; preds = %21
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 3
+  %25 = load i32, i32 addrspace(1)* %24, align 8
+  %26 = icmp sle i32 %25, 0
+  br i1 %26, label %96, label %27
+
+; <label>:27                                      ; preds = %23
+  %28 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %28, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %29
+
+; <label>:29                                      ; preds = %27
+  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %28, i32 0, i32 1
+  %31 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %30, align 8
+  store %"System.Char[]" addrspace(1)* %31, %"System.Char[]" addrspace(1)** %loc3
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %33
+
+; <label>:33                                      ; preds = %29
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  store i32 %35, i32* %loc4
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  %39 = load i32, i32 addrspace(1)* %38, align 8
+  store i32 %39, i32* %loc5
+  %40 = load i32, i32* %loc5
+  %41 = load i32, i32* %loc4
+  %42 = add i32 %40, %41
+  %43 = zext i32 %42 to i64
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %45
+
+; <label>:45                                      ; preds = %37
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = sext i32 %47 to i64
+  %49 = icmp sgt i64 %43, %48
+  br i1 %49, label %91, label %50
+
+; <label>:50                                      ; preds = %45
+  %51 = load i32, i32* %loc5
+  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %52, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %53
+
+; <label>:53                                      ; preds = %50
+  %54 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %52, i32 0, i32 1
+  %55 = load i32, i32 addrspace(1)* %54
+  %56 = zext i32 %55 to i64
+  %57 = trunc i64 %56 to i32
+  %58 = icmp ugt i32 %51, %57
+  br i1 %58, label %91, label %59
+
+; <label>:59                                      ; preds = %53
+  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  store %"System.Char[]" addrspace(1)* %60, %"System.Char[]" addrspace(1)** %loc8
+  %61 = icmp eq %"System.Char[]" addrspace(1)* %60, null
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %63, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %64
+
+; <label>:64                                      ; preds = %62
+  %65 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %63, i32 0, i32 1
+  %66 = load i32, i32 addrspace(1)* %65
+  %67 = zext i32 %66 to i64
+  %68 = trunc i64 %67 to i32
+  %69 = icmp ne i32 %68, 0
+  br i1 %69, label %71, label %70
+
+; <label>:70                                      ; preds = %59, %64
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:71                                      ; preds = %64
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %73
+
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %BoundsCheck = icmp uge i64 0, %76
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %77
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %78, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:79                                      ; preds = %70, %77
+  %80 = load i16*, i16** %loc2
+  %81 = load i32, i32* %loc4
+  %82 = sext i32 %81 to i64
+  %83 = mul i64 %82, 2
+  %84 = bitcast i16* %80 to i8*
+  %85 = getelementptr inbounds i8, i8* %84, i64 %83
+  %86 = load i16 addrspace(1)*, i16 addrspace(1)** %loc6
+  %87 = ptrtoint i16 addrspace(1)* %86 to i64
+  %88 = load i32, i32* %loc5
+  %89 = bitcast i8* %85 to i16*
+  %90 = inttoptr i64 %87 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %89, i16* %90, i32 %88)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %96
+
+; <label>:91                                      ; preds = %45, %53
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %94 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %93)
+  %95 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95, %System.String addrspace(1)* %92, %System.String addrspace(1)* %94)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95) #0
+  unreachable
+
+; <label>:96                                      ; preds = %23, %79
+  %97 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %97, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %98
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %97, i32 0, i32 2
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  store %System.Text.StringBuilder addrspace(1)* %100, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %102 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %102, label %21, label %103
+
+; <label>:103                                     ; preds = %98
+  store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc7
+  %104 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  ret %System.String addrspace(1)* %104
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method StringBuilder::get_Length using LLILCJit
+Successfully read StringBuilder.get_Length
+
+define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
+Successfully read RuntimeHelpers.get_OffsetToStringData
+
+define i32 @RuntimeHelpers.get_OffsetToStringData() {
+entry:
+  ret i32 12
+}
+
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
 Successfully read CultureData.CreateCultureData
 
@@ -3514,23 +4249,23 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
   store i8 %4, i8 addrspace(1)* %6
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
@@ -3549,11 +4284,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3566,50 +4301,50 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
   store i32 -1, i32 addrspace(1)* %2
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
   store i32 -1, i32 addrspace(1)* %8
   %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
   store i32 -1, i32 addrspace(1)* %14
   %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
   store i32 -1, i32 addrspace(1)* %17
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
@@ -3623,27 +4358,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3675,7 +4410,136 @@ Failed to read Dictionary`2.Insert[non-const derefAddress]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
 Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
-Failed to read HashHelpers.GetPrime[loadElem]
+Successfully read HashHelpers.GetPrime
+
+define i32 @HashHelpers.GetPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %6, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5, %System.String addrspace(1)* %4)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5) #0
+  unreachable
+
+; <label>:6                                       ; preds = %entry
+  store i32 0, i32* %loc0
+  br label %29
+
+; <label>:7                                       ; preds = %35
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 1296
+  %10 = addrspacecast i8 addrspace(1)* %9 to %"System.Int32[]" addrspace(1)**
+  %11 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %10
+  %12 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Int32[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = zext i32 %15 to i64
+  %17 = zext i32 %12 to i64
+  %BoundsCheck = icmp uge i64 %17, %16
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 3, i32 %12
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  store i32 %20, i32* %loc1
+  %21 = load i32, i32* %loc1
+  %22 = load i32, i32* %arg0
+  %23 = icmp slt i32 %21, %22
+  br i1 %23, label %26, label %24
+
+; <label>:24                                      ; preds = %18
+  %25 = load i32, i32* %loc1
+  ret i32 %25
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %loc0
+  %28 = add i32 %27, 1
+  store i32 %28, i32* %loc0
+  br label %29
+
+; <label>:29                                      ; preds = %6, %26
+  %30 = load i32, i32* %loc0
+  %31 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %32 = getelementptr inbounds i8, i8 addrspace(1)* %31, i64 1296
+  %33 = addrspacecast i8 addrspace(1)* %32 to %"System.Int32[]" addrspace(1)**
+  %34 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %33
+  %NullCheck = icmp eq %"System.Int32[]" addrspace(1)* %34, null
+  br i1 %NullCheck, label %ThrowNullRef, label %35
+
+; <label>:35                                      ; preds = %29
+  %36 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %34, i32 0, i32 1
+  %37 = load i32, i32 addrspace(1)* %36
+  %38 = zext i32 %37 to i64
+  %39 = trunc i64 %38 to i32
+  %40 = icmp slt i32 %30, %39
+  br i1 %40, label %7, label %41
+
+; <label>:41                                      ; preds = %35
+  %42 = load i32, i32* %arg0
+  %43 = or i32 %42, 1
+  store i32 %43, i32* %loc2
+  br label %59
+
+; <label>:44                                      ; preds = %59
+  %45 = load i32, i32* %loc2
+  %46 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %45)
+  %47 = zext i8 %46 to i32
+  %48 = icmp eq i32 %47, 0
+  br i1 %48, label %56, label %49
+
+; <label>:49                                      ; preds = %44
+  %50 = load i32, i32* %loc2
+  %51 = sub i32 %50, 1
+  %52 = srem i32 %51, 101
+  %53 = icmp eq i32 %52, 0
+  br i1 %53, label %56, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = load i32, i32* %loc2
+  ret i32 %55
+
+; <label>:56                                      ; preds = %44, %49
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %57, 2
+  store i32 %58, i32* %loc2
+  br label %59
+
+; <label>:59                                      ; preds = %41, %56
+  %60 = load i32, i32* %loc2
+  %61 = icmp slt i32 %60, 2147483647
+  br i1 %61, label %44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load i32, i32* %arg0
+  ret i32 %63
+
+ThrowNullRef:                                     ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
 Successfully read GenericEqualityComparer`1.GetHashCode
 
@@ -3694,14 +4558,14 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
   %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load i64, i64 addrspace(1)* %7
@@ -3720,7 +4584,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3750,8 +4614,8 @@ entry:
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
@@ -3796,8 +4660,8 @@ entry:
   %35 = bitcast i16* %34 to i8*
   %36 = getelementptr inbounds i8, i8* %35, i64 2
   %37 = bitcast i8* %36 to i16*
-  %NullCheck4 = icmp ne i16* %37, null
-  br i1 %NullCheck4, label %38, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %37, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %38
 
 ; <label>:38                                      ; preds = %27
   %39 = load i16, i16* %37, align 8
@@ -3824,8 +4688,8 @@ entry:
 
 ; <label>:54                                      ; preds = %22, %43
   %55 = load i16*, i16** %loc4
-  %NullCheck2 = icmp ne i16* %55, null
-  br i1 %NullCheck2, label %56, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i16* %55, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %56
 
 ; <label>:56                                      ; preds = %54
   %57 = load i16, i16* %55, align 8
@@ -3850,11 +4714,11 @@ ThrowNullRef:                                     ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %54
+ThrowNullRef2:                                    ; preds = %54
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %27
+ThrowNullRef4:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3871,8 +4735,8 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -3907,8 +4771,8 @@ entry:
 
 ; <label>:26                                      ; preds = %19
   %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
-  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %28
 
 ; <label>:28                                      ; preds = %26
   %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
@@ -3920,7 +4784,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3972,8 +4836,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
@@ -3984,26 +4848,26 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
-  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
@@ -4014,8 +4878,8 @@ entry:
 ; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
@@ -4024,8 +4888,8 @@ entry:
 
 ; <label>:25                                      ; preds = %1, %16, %23
   %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
-  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
@@ -4036,27 +4900,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %20
+ThrowNullRef10:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4069,8 +4933,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -4081,8 +4945,8 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
@@ -4091,8 +4955,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1, %8
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
@@ -4103,11 +4967,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4128,24 +4992,24 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   store i32 %3, i32* %loc0
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
   %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
   store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck4, label %9, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
@@ -4164,15 +5028,15 @@ entry:
 ; <label>:18                                      ; preds = %70
   %19 = load i16*, i16** %loc3
   %20 = bitcast i16* %19 to i64*
-  %NullCheck10 = icmp ne i64* %20, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %20, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = load i64, i64* %20, align 8
   %23 = load i16*, i16** %loc4
   %24 = bitcast i16* %23 to i64*
-  %NullCheck12 = icmp ne i64* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = load i64, i64* %24, align 8
@@ -4188,8 +5052,8 @@ entry:
   %31 = bitcast i16* %30 to i8*
   %32 = getelementptr inbounds i8, i8* %31, i64 8
   %33 = bitcast i8* %32 to i64*
-  %NullCheck14 = icmp ne i64* %33, null
-  br i1 %NullCheck14, label %34, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = load i64, i64* %33, align 8
@@ -4197,8 +5061,8 @@ entry:
   %37 = bitcast i16* %36 to i8*
   %38 = getelementptr inbounds i8, i8* %37, i64 8
   %39 = bitcast i8* %38 to i64*
-  %NullCheck16 = icmp ne i64* %39, null
-  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %40
 
 ; <label>:40                                      ; preds = %34
   %41 = load i64, i64* %39, align 8
@@ -4214,8 +5078,8 @@ entry:
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %NullCheck18 = icmp ne i64* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = load i64, i64* %48, align 8
@@ -4223,8 +5087,8 @@ entry:
   %52 = bitcast i16* %51 to i8*
   %53 = getelementptr inbounds i8, i8* %52, i64 16
   %54 = bitcast i8* %53 to i64*
-  %NullCheck20 = icmp ne i64* %54, null
-  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64* %54, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %55
 
 ; <label>:55                                      ; preds = %49
   %56 = load i64, i64* %54, align 8
@@ -4262,15 +5126,15 @@ entry:
 ; <label>:74                                      ; preds = %95
   %75 = load i16*, i16** %loc3
   %76 = bitcast i16* %75 to i32*
-  %NullCheck6 = icmp ne i32* %76, null
-  br i1 %NullCheck6, label %77, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32* %76, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %77
 
 ; <label>:77                                      ; preds = %74
   %78 = load i32, i32* %76, align 8
   %79 = load i16*, i16** %loc4
   %80 = bitcast i16* %79 to i32*
-  %NullCheck8 = icmp ne i32* %80, null
-  br i1 %NullCheck8, label %81, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i32* %80, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %81
 
 ; <label>:81                                      ; preds = %77
   %82 = load i32, i32* %80, align 8
@@ -4318,43 +5182,43 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %74
+ThrowNullRef6:                                    ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %77
+ThrowNullRef8:                                    ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %29
+ThrowNullRef14:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %34
+ThrowNullRef16:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4376,8 +5240,8 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load i64, i64 addrspace(1)* %4
@@ -4389,8 +5253,8 @@ entry:
   %12 = load i64, i64* %11
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %5
   %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
@@ -4399,8 +5263,8 @@ entry:
   %18 = load i8, i8* %arg2
   %19 = zext i8 %18 to i32
   %20 = trunc i32 %19 to i8
-  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %15
   %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
@@ -4411,11 +5275,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4442,8 +5306,8 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
@@ -4466,16 +5330,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
   %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = load i64, i64 addrspace(1)* %19
@@ -4500,8 +5364,8 @@ entry:
 ; <label>:35                                      ; preds = %30
   %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
@@ -4514,8 +5378,8 @@ entry:
 
 ; <label>:42                                      ; preds = %1, %38
   %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
-  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
@@ -4526,19 +5390,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %35
+ThrowNullRef2:                                    ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %42
+ThrowNullRef8:                                    ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4551,14 +5415,14 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
@@ -4570,7 +5434,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4583,8 +5447,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
@@ -4613,51 +5477,51 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
   %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
   %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
   %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
   %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
-  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
   store i64 %21, i64 addrspace(1)* %23
   %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %25 = load i64, i64* %loc0
-  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
@@ -4668,27 +5532,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %22
+ThrowNullRef12:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4701,8 +5565,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
@@ -4713,19 +5577,19 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
@@ -4734,8 +5598,8 @@ entry:
 
 ; <label>:15                                      ; preds = %1, %13
   %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
@@ -4746,19 +5610,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %15
+ThrowNullRef8:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4771,8 +5635,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -4831,8 +5695,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
@@ -4882,8 +5746,8 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
-  br i1 %NullCheck, label %17, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %ThrowNullRef, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
@@ -4894,15 +5758,15 @@ entry:
 
 ; <label>:22                                      ; preds = %17
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
-  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
   %26 = load i32, i32 addrspace(1)* %25
   %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
-  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %27, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
@@ -4925,8 +5789,8 @@ entry:
 ; <label>:40                                      ; preds = %17
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
-  br i1 %NullCheck6, label %43, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %41, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
@@ -4938,34 +5802,17 @@ ThrowNullRef:                                     ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %24
+ThrowNullRef4:                                    ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %40
+ThrowNullRef6:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
-}
-
-INFO:  jitting method Object::ReferenceEquals using LLILCJit
-Successfully read Object.ReferenceEquals
-
-define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
-entry:
-  %arg0 = alloca %System.Object addrspace(1)*
-  %arg1 = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
-  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
-  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = icmp eq %System.Object addrspace(1)* %0, %1
-  %3 = sext i1 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
 }
 
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
@@ -4978,21 +5825,21 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
   %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
-  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
@@ -5007,28 +5854,28 @@ entry:
 ; <label>:13                                      ; preds = %8, %12
   %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
   %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
   %21 = load i32, i32 addrspace(1)* %20, align 8
   %22 = add i32 %21, 1
-  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
   store i32 %22, i32 addrspace(1)* %24
   %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
@@ -5039,27 +5886,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5077,7 +5924,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::Setup using LLILCJit
-Failed to read AppDomain.Setup[loadElem]
+Failed to read AppDomain.Setup[unbox]
 INFO:  jitting method Thread::GetDomain using LLILCJit
 Successfully read Thread.GetDomain
 
@@ -5108,8 +5955,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
@@ -5122,14 +5969,14 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
   %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
@@ -5141,11 +5988,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5173,8 +6020,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -5189,7 +6036,328 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
 Failed to read KeyCollection.System.Collections.Generic.IEnumerable<TKey>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Successfully read Enumerator.MoveNext
+
+define i8 @Enumerator.MoveNext(%"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.RuntimeTypeHandle* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*
+  %"$TypeArg" = alloca %System.RuntimeTypeHandle*
+  store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
+  %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 8
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %76, label %12
+
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
+  br label %76
+
+; <label>:13                                      ; preds = %85
+  %14 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck19 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %15
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, i32 0, i32 0
+  %17 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %16, align 8
+  %NullCheck21 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, i32 0, i32 2
+  %20 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %19, align 8
+  %21 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck23 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %22
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, i32 0, i32 2
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %NullCheck25 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 3, i32 %24
+  %NullCheck27 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %32
+
+; <label>:32                                      ; preds = %30
+  %33 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, i32 0, i32 2
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = icmp slt i32 %34, 0
+  br i1 %35, label %68, label %36
+
+; <label>:36                                      ; preds = %32
+  %37 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %38 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck29 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %39
+
+; <label>:39                                      ; preds = %36
+  %40 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, i32 0, i32 0
+  %41 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %40, align 8
+  %NullCheck31 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, i32 0, i32 2
+  %44 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %43, align 8
+  %45 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck33 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, i32 0, i32 2
+  %48 = load i32, i32 addrspace(1)* %47, align 8
+  %NullCheck35 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %49
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = zext i32 %51 to i64
+  %53 = zext i32 %48 to i64
+  %BoundsCheck37 = icmp uge i64 %53, %52
+  br i1 %BoundsCheck37, label %ThrowIndexOutOfRange38, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 3, i32 %48
+  %NullCheck39 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %56
+
+; <label>:56                                      ; preds = %54
+  %57 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, i32 0, i32 0
+  %58 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck41 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %59
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %60, %System.__Canon addrspace(1)* %58)
+  %61 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck43 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  %64 = load i32, i32 addrspace(1)* %63, align 8
+  %65 = add i32 %64, 1
+  %NullCheck45 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  store i32 %65, i32 addrspace(1)* %67
+  ret i8 1
+
+; <label>:68                                      ; preds = %32
+  %69 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck47 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %73 = add i32 %72, 1
+  %NullCheck49 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %74
+
+; <label>:74                                      ; preds = %70
+  %75 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  store i32 %73, i32 addrspace(1)* %75
+  br label %76
+
+; <label>:76                                      ; preds = %8, %12, %74
+  %77 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %78
+
+; <label>:78                                      ; preds = %76
+  %79 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, i32 0, i32 2
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck7 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %82
+
+; <label>:82                                      ; preds = %78
+  %83 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, i32 0, i32 0
+  %84 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %83, align 8
+  %NullCheck9 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %85
+
+; <label>:85                                      ; preds = %82
+  %86 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, i32 0, i32 7
+  %87 = load i32, i32 addrspace(1)* %86, align 8
+  %88 = icmp ult i32 %80, %87
+  br i1 %88, label %13, label %89
+
+; <label>:89                                      ; preds = %85
+  %90 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %91 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck11 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %92
+
+; <label>:92                                      ; preds = %89
+  %93 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, i32 0, i32 0
+  %94 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck13 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %95
+
+; <label>:95                                      ; preds = %92
+  %96 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, i32 0, i32 7
+  %97 = load i32, i32 addrspace(1)* %96, align 8
+  %98 = add i32 %97, 1
+  %NullCheck15 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %99
+
+; <label>:99                                      ; preds = %95
+  %100 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, i32 0, i32 2
+  store i32 %98, i32 addrspace(1)* %100
+  %101 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck17 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %102
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %103, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %92
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef22:                                   ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef24:                                   ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef26:                                   ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef28:                                   ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef30:                                   ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef32:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef34:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef36:                                   ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange38:                           ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef40:                                   ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef42:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef44:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef46:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef48:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef50:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -5200,8 +6368,8 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -5232,9 +6400,9 @@ Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
 Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
-Failed to read String.MakeSeparatorList[loadElemA]
+Failed to read String.MakeSeparatorList[storeElem]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
-Failed to read String.InternalSplitKeepEmptyEntries[loadElem]
+Failed to read String.InternalSplitKeepEmptyEntries[storeElem]
 INFO:  jitting method Path::IsRelative using LLILCJit
 Successfully read Path.IsRelative
 
@@ -5243,8 +6411,8 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -5254,8 +6422,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
@@ -5271,8 +6439,8 @@ entry:
 
 ; <label>:17                                      ; preds = %7
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
@@ -5288,8 +6456,8 @@ entry:
 
 ; <label>:29                                      ; preds = %19
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %31
 
 ; <label>:31                                      ; preds = %29
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
@@ -5300,8 +6468,8 @@ entry:
 
 ; <label>:36                                      ; preds = %31
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
-  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %37, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
@@ -5312,8 +6480,8 @@ entry:
 
 ; <label>:43                                      ; preds = %31, %38
   %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
-  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %45
 
 ; <label>:45                                      ; preds = %43
   %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
@@ -5324,8 +6492,8 @@ entry:
 
 ; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %50
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
@@ -5336,8 +6504,8 @@ entry:
 
 ; <label>:57                                      ; preds = %1, %7, %19, %45, %52
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
-  br i1 %NullCheck14, label %59, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %59
 
 ; <label>:59                                      ; preds = %57
   %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
@@ -5347,8 +6515,8 @@ entry:
 
 ; <label>:63                                      ; preds = %59
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
@@ -5359,8 +6527,8 @@ entry:
 
 ; <label>:70                                      ; preds = %65
   %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
-  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.String addrspace(1)* %71, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %72
 
 ; <label>:72                                      ; preds = %70
   %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
@@ -5379,39 +6547,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %17
+ThrowNullRef4:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %29
+ThrowNullRef6:                                    ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %36
+ThrowNullRef8:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %43
+ThrowNullRef10:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %50
+ThrowNullRef12:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %57
+ThrowNullRef14:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %63
+ThrowNullRef16:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %70
+ThrowNullRef18:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5419,7 +6587,293 @@ ThrowNullRef17:                                   ; preds = %70
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
-Failed to read String.TrimHelper[loadElem]
+Successfully read String.TrimHelper
+
+define %System.String addrspace(1)* @String.TrimHelper(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i16
+  %loc4 = alloca i32
+  %loc5 = alloca i16
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = sub i32 %3, 1
+  store i32 %4, i32* %loc0
+  store i32 0, i32* %loc1
+  %5 = load i32, i32* %arg2
+  %6 = icmp eq i32 %5, 1
+  br i1 %6, label %62, label %7
+
+; <label>:7                                       ; preds = %1
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:8                                       ; preds = %58
+  store i32 0, i32* %loc2
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load i32, i32* %loc1
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2, i32 %10
+  %13 = load i16, i16 addrspace(1)* %12
+  %14 = zext i16 %13 to i32
+  %15 = trunc i32 %14 to i16
+  store i16 %15, i16* %loc3
+  store i32 0, i32* %loc2
+  br label %34
+
+; <label>:16                                      ; preds = %37
+  %17 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %18 = load i32, i32* %loc2
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %17, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %19
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = zext i32 %18 to i64
+  %BoundsCheck = icmp uge i64 %23, %22
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %24
+
+; <label>:24                                      ; preds = %19
+  %25 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 3, i32 %18
+  %26 = load i16, i16 addrspace(1)* %25, align 8
+  %27 = zext i16 %26 to i32
+  %28 = load i16, i16* %loc3
+  %29 = zext i16 %28 to i32
+  %30 = icmp eq i32 %27, %29
+  br i1 %30, label %43, label %31
+
+; <label>:31                                      ; preds = %24
+  %32 = load i32, i32* %loc2
+  %33 = add i32 %32, 1
+  store i32 %33, i32* %loc2
+  br label %34
+
+; <label>:34                                      ; preds = %11, %31
+  %35 = load i32, i32* %loc2
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = icmp slt i32 %35, %41
+  br i1 %42, label %16, label %43
+
+; <label>:43                                      ; preds = %24, %37
+  %44 = load i32, i32* %loc2
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %45, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp eq i32 %44, %50
+  br i1 %51, label %62, label %52
+
+; <label>:52                                      ; preds = %46
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %7, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %57, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %58
+
+; <label>:58                                      ; preds = %55
+  %59 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %60 = load i32, i32 addrspace(1)* %59
+  %61 = icmp slt i32 %56, %60
+  br i1 %61, label %8, label %62
+
+; <label>:62                                      ; preds = %1, %46, %58
+  %63 = load i32, i32* %arg2
+  %64 = icmp eq i32 %63, 0
+  br i1 %64, label %122, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %66, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %67
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %66, i32 0, i32 1
+  %69 = load i32, i32 addrspace(1)* %68
+  %70 = sub i32 %69, 1
+  store i32 %70, i32* %loc0
+  br label %118
+
+; <label>:71                                      ; preds = %118
+  store i32 0, i32* %loc4
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %73 = load i32, i32* %loc0
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %74
+
+; <label>:74                                      ; preds = %71
+  %75 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 2, i32 %73
+  %76 = load i16, i16 addrspace(1)* %75
+  %77 = zext i16 %76 to i32
+  %78 = trunc i32 %77 to i16
+  store i16 %78, i16* %loc5
+  store i32 0, i32* %loc4
+  br label %97
+
+; <label>:79                                      ; preds = %100
+  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %81 = load i32, i32* %loc4
+  %NullCheck19 = icmp eq %"System.Char[]" addrspace(1)* %80, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
+
+; <label>:82                                      ; preds = %79
+  %83 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 1
+  %84 = load i32, i32 addrspace(1)* %83
+  %85 = zext i32 %84 to i64
+  %86 = zext i32 %81 to i64
+  %BoundsCheck21 = icmp uge i64 %86, %85
+  br i1 %BoundsCheck21, label %ThrowIndexOutOfRange22, label %87
+
+; <label>:87                                      ; preds = %82
+  %88 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 3, i32 %81
+  %89 = load i16, i16 addrspace(1)* %88, align 8
+  %90 = zext i16 %89 to i32
+  %91 = load i16, i16* %loc5
+  %92 = zext i16 %91 to i32
+  %93 = icmp eq i32 %90, %92
+  br i1 %93, label %106, label %94
+
+; <label>:94                                      ; preds = %87
+  %95 = load i32, i32* %loc4
+  %96 = add i32 %95, 1
+  store i32 %96, i32* %loc4
+  br label %97
+
+; <label>:97                                      ; preds = %74, %94
+  %98 = load i32, i32* %loc4
+  %99 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck15 = icmp eq %"System.Char[]" addrspace(1)* %99, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %100
+
+; <label>:100                                     ; preds = %97
+  %101 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %99, i32 0, i32 1
+  %102 = load i32, i32 addrspace(1)* %101
+  %103 = zext i32 %102 to i64
+  %104 = trunc i64 %103 to i32
+  %105 = icmp slt i32 %98, %104
+  br i1 %105, label %79, label %106
+
+; <label>:106                                     ; preds = %87, %100
+  %107 = load i32, i32* %loc4
+  %108 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck17 = icmp eq %"System.Char[]" addrspace(1)* %108, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %109
+
+; <label>:109                                     ; preds = %106
+  %110 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %108, i32 0, i32 1
+  %111 = load i32, i32 addrspace(1)* %110
+  %112 = zext i32 %111 to i64
+  %113 = trunc i64 %112 to i32
+  %114 = icmp eq i32 %107, %113
+  br i1 %114, label %122, label %115
+
+; <label>:115                                     ; preds = %109
+  %116 = load i32, i32* %loc0
+  %117 = sub i32 %116, 1
+  store i32 %117, i32* %loc0
+  br label %118
+
+; <label>:118                                     ; preds = %67, %115
+  %119 = load i32, i32* %loc0
+  %120 = load i32, i32* %loc1
+  %121 = icmp sge i32 %119, %120
+  br i1 %121, label %71, label %122
+
+; <label>:122                                     ; preds = %62, %109, %118
+  %123 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %124 = load i32, i32* %loc1
+  %125 = load i32, i32* %loc0
+  %126 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %123, i32 %124, i32 %125)
+  ret %System.String addrspace(1)* %126
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %97
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange22:                           ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
 Successfully read String.CreateTrimmedString
 
@@ -5439,8 +6893,8 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
@@ -5535,8 +6989,8 @@ entry:
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i64 2872
   %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
   %8 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %7
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %3
   %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
@@ -5553,8 +7007,8 @@ entry:
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 2864
   %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
   %21 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %20
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
-  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %22
 
 ; <label>:22                                      ; preds = %16
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
@@ -5569,7 +7023,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %16
+ThrowNullRef2:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5586,8 +7040,8 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5613,8 +7067,8 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
@@ -5632,8 +7086,8 @@ entry:
 
 ; <label>:12                                      ; preds = %4
   %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
@@ -5644,8 +7098,8 @@ entry:
 
 ; <label>:19                                      ; preds = %14
   %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %19
   %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
@@ -5660,21 +7114,21 @@ entry:
   %31 = zext i16 %30 to i32
   %32 = bitcast i8* %29 to i16*
   %33 = trunc i32 %31 to i16
-  %NullCheck6 = icmp ne i16* %32, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i16* %32, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %21
   store i16 %33, i16* %32, align 8
   %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %36
 
 ; <label>:36                                      ; preds = %34
   %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
   %38 = load i32, i32 addrspace(1)* %37, align 8
   %39 = add i32 %38, 1
-  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %40
 
 ; <label>:40                                      ; preds = %36
   %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
@@ -5683,16 +7137,16 @@ entry:
 
 ; <label>:42                                      ; preds = %14
   %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
-  br i1 %NullCheck12, label %44, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
   %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
   %47 = load i16, i16* %arg1
   %48 = zext i16 %47 to i32
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = trunc i32 %48 to i16
@@ -5703,31 +7157,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %19
+ThrowNullRef4:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %21
+ThrowNullRef6:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %36
+ThrowNullRef10:                                   ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %42
+ThrowNullRef12:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %44
+ThrowNullRef14:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5740,8 +7194,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -5752,8 +7206,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
@@ -5762,14 +7216,14 @@ entry:
 
 ; <label>:11                                      ; preds = %1
   %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
@@ -5779,15 +7233,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5808,8 +7262,8 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5822,8 +7276,8 @@ entry:
 
 ; <label>:8                                       ; preds = %3
   %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
@@ -5842,15 +7296,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
-  br i1 %NullCheck4, label %22, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
   %24 = load i16*, i16* addrspace(1)* %23, align 8
   %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %25, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
@@ -5859,8 +7313,8 @@ entry:
   store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
@@ -5874,8 +7328,8 @@ entry:
 
 ; <label>:37                                      ; preds = %65
   %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %37
   %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
@@ -5886,16 +7340,16 @@ entry:
   %45 = bitcast i16* %41 to i8*
   %46 = getelementptr inbounds i8, i8* %45, i64 %44
   %47 = bitcast i8* %46 to i16*
-  %NullCheck14 = icmp ne i16* %47, null
-  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %47, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %48
 
 ; <label>:48                                      ; preds = %39
   %49 = load i16, i16* %47, align 8
   %50 = zext i16 %49 to i32
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %52 = load i32, i32* %loc1
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %53
 
 ; <label>:53                                      ; preds = %48
   %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
@@ -5916,8 +7370,8 @@ entry:
 ; <label>:62                                      ; preds = %36, %59
   %63 = load i32, i32* %loc1
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck10, label %65, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %65
 
 ; <label>:65                                      ; preds = %62
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
@@ -5936,15 +7390,15 @@ entry:
 
 ; <label>:74                                      ; preds = %70
   %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
-  br i1 %NullCheck18, label %76, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %76
 
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
   %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
-  br i1 %NullCheck20, label %80, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
   %81 = load i64, i64 addrspace(1)* %79
@@ -5958,8 +7412,8 @@ entry:
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
   %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
-  br i1 %NullCheck22, label %92, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.String addrspace(1)* %90, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %92
 
 ; <label>:92                                      ; preds = %80
   %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
@@ -5969,15 +7423,15 @@ entry:
 
 ; <label>:96                                      ; preds = %70
   %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
-  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %98
 
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
   %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
-  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
   %103 = load i64, i64 addrspace(1)* %101
@@ -5991,8 +7445,8 @@ entry:
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
   %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
-  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.String addrspace(1)* %112, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %114
 
 ; <label>:114                                     ; preds = %102
   %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
@@ -6004,59 +7458,59 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %20
+ThrowNullRef4:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %22
+ThrowNullRef6:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %26
+ThrowNullRef8:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %62
+ThrowNullRef10:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %48
+ThrowNullRef16:                                   ; preds = %48
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %74
+ThrowNullRef18:                                   ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %76
+ThrowNullRef20:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %80
+ThrowNullRef22:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %96
+ThrowNullRef24:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %98
+ThrowNullRef26:                                   ; preds = %98
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %102
+ThrowNullRef28:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6069,15 +7523,15 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
   %3 = load i16*, i16* addrspace(1)* %2, align 8
   %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
@@ -6087,8 +7541,8 @@ entry:
   %10 = bitcast i16* %3 to i8*
   %11 = getelementptr inbounds i8, i8* %10, i64 %9
   %12 = bitcast i8* %11 to i16*
-  %NullCheck4 = icmp ne i16* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %5
   store i16 0, i16* %12, align 8
@@ -6098,11 +7552,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6119,8 +7573,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -6131,8 +7585,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
@@ -6144,15 +7598,15 @@ entry:
 
 ; <label>:14                                      ; preds = %1
   %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
   %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
   %21 = load i64, i64 addrspace(1)* %19
@@ -6171,15 +7625,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %14
+ThrowNullRef4:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %16
+ThrowNullRef6:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6302,14 +7756,6 @@ entry:
   ret %System.String addrspace(1)* %57
 }
 
-INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
-Successfully read RuntimeHelpers.get_OffsetToStringData
-
-define i32 @RuntimeHelpers.get_OffsetToStringData() {
-entry:
-  ret i32 12
-}
-
 INFO:  jitting method String::Equals using LLILCJit
 Successfully read String.Equals
 
@@ -6381,8 +7827,8 @@ entry:
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
-  br i1 %NullCheck24, label %29, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
   %30 = load i64, i64 addrspace(1)* %28
@@ -6397,8 +7843,8 @@ entry:
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
-  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
   %43 = load i64, i64 addrspace(1)* %41
@@ -6418,8 +7864,8 @@ entry:
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
   %59 = load i64, i64 addrspace(1)* %57
@@ -6434,8 +7880,8 @@ entry:
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck22, label %71, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
   %72 = load i64, i64 addrspace(1)* %70
@@ -6455,8 +7901,8 @@ entry:
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
-  br i1 %NullCheck16, label %87, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = load i64, i64 addrspace(1)* %86
@@ -6471,8 +7917,8 @@ entry:
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck18, label %100, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
   %101 = load i64, i64 addrspace(1)* %99
@@ -6492,8 +7938,8 @@ entry:
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
-  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
   %117 = load i64, i64 addrspace(1)* %115
@@ -6508,8 +7954,8 @@ entry:
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
-  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
   %130 = load i64, i64 addrspace(1)* %128
@@ -6528,15 +7974,15 @@ entry:
 
 ; <label>:142                                     ; preds = %22
   %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
-  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %143, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %144
 
 ; <label>:144                                     ; preds = %142
   %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
   %146 = load i32, i32 addrspace(1)* %145
   %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
-  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %147, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %148
 
 ; <label>:148                                     ; preds = %144
   %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
@@ -6557,15 +8003,15 @@ entry:
 
 ; <label>:159                                     ; preds = %22
   %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
-  br i1 %NullCheck, label %161, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %ThrowNullRef, label %161
 
 ; <label>:161                                     ; preds = %159
   %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
   %163 = load i32, i32 addrspace(1)* %162
   %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
-  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %164, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %165
 
 ; <label>:165                                     ; preds = %161
   %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
@@ -6578,8 +8024,8 @@ entry:
 
 ; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
-  br i1 %NullCheck4, label %172, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %171, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %172
 
 ; <label>:172                                     ; preds = %170
   %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
@@ -6589,8 +8035,8 @@ entry:
 
 ; <label>:176                                     ; preds = %172
   %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
-  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %177, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %178
 
 ; <label>:178                                     ; preds = %176
   %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
@@ -6629,55 +8075,55 @@ ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %161
+ThrowNullRef2:                                    ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %170
+ThrowNullRef4:                                    ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %176
+ThrowNullRef6:                                    ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %142
+ThrowNullRef8:                                    ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %144
+ThrowNullRef10:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %113
+ThrowNullRef12:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %116
+ThrowNullRef14:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %84
+ThrowNullRef16:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %87
+ThrowNullRef18:                                   ; preds = %87
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %55
+ThrowNullRef20:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %58
+ThrowNullRef22:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %26
+ThrowNullRef24:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %29
+ThrowNullRef26:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,8 +8161,8 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck, label %14, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %ThrowNullRef, label %14
 
 ; <label>:14                                      ; preds = %8
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
@@ -6760,8 +8206,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
@@ -6770,14 +8216,14 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32, i32* %loc0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %10
   %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
   %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
@@ -6790,15 +8236,15 @@ entry:
 ; <label>:25                                      ; preds = %19
   %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
-  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
   %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
@@ -6807,8 +8253,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %37 = load i32, i32* %loc0
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %38, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %38
 
 ; <label>:38                                      ; preds = %32
   %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
@@ -6817,14 +8263,14 @@ entry:
 
 ; <label>:40                                      ; preds = %19
   %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %40
   %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
   %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
-  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
-  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
@@ -6832,8 +8278,8 @@ entry:
   %48 = zext i32 %47 to i64
   %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
-  br i1 %NullCheck16, label %51, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %51
 
 ; <label>:51                                      ; preds = %45
   %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
@@ -6847,15 +8293,15 @@ entry:
 ; <label>:57                                      ; preds = %51
   %58 = load i16*, i16** %arg1
   %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
-  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %60
 
 ; <label>:60                                      ; preds = %57
   %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
   %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
-  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %64
 
 ; <label>:64                                      ; preds = %60
   %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
@@ -6864,22 +8310,22 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
   %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
-  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %70
 
 ; <label>:70                                      ; preds = %64
   %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
   %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
-  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
-  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
   %75 = load i32, i32 addrspace(1)* %74
   %76 = zext i32 %75 to i64
   %77 = trunc i64 %76 to i32
-  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
-  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %78
 
 ; <label>:78                                      ; preds = %73
   %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
@@ -6901,8 +8347,8 @@ entry:
   %90 = bitcast i16* %86 to i8*
   %91 = getelementptr inbounds i8, i8* %90, i64 %89
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %93
 
 ; <label>:93                                      ; preds = %80
   %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
@@ -6912,8 +8358,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %99 = load i32, i32* %loc2
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %100
 
 ; <label>:100                                     ; preds = %93
   %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
@@ -6928,63 +8374,63 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %25
+ThrowNullRef6:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %32
+ThrowNullRef10:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %40
+ThrowNullRef12:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %45
+ThrowNullRef16:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %57
+ThrowNullRef18:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %60
+ThrowNullRef20:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %64
+ThrowNullRef22:                                   ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %70
+ThrowNullRef24:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %73
+ThrowNullRef26:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %80
+ThrowNullRef28:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %93
+ThrowNullRef30:                                   ; preds = %93
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7004,8 +8450,8 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
@@ -7033,43 +8479,43 @@ entry:
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %14
   %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
   %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   %28 = load i32, i32 addrspace(1)* %27, align 8
   %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
-  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %30
 
 ; <label>:30                                      ; preds = %26
   %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
   %32 = load i32, i32 addrspace(1)* %31, align 8
   %33 = add i32 %28, %32
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %34
 
 ; <label>:34                                      ; preds = %30
   %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   store i32 %33, i32 addrspace(1)* %35
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
   store i32 0, i32 addrspace(1)* %38
   %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %40
 
 ; <label>:40                                      ; preds = %37
   %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
@@ -7082,8 +8528,8 @@ entry:
 
 ; <label>:47                                      ; preds = %40
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
@@ -7098,8 +8544,8 @@ entry:
   %54 = load i32, i32* %loc0
   %55 = sext i32 %54 to i64
   %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
-  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %57
 
 ; <label>:57                                      ; preds = %52
   %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
@@ -7110,68 +8556,35 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %14
+ThrowNullRef2:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %23
+ThrowNullRef4:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %26
+ThrowNullRef6:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %30
+ThrowNullRef8:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %34
+ThrowNullRef10:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %47
+ThrowNullRef14:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %52
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-}
-
-INFO:  jitting method StringBuilder::get_Length using LLILCJit
-Successfully read StringBuilder.get_Length
-
-define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.StringBuilder addrspace(1)*
-  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
-  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
-
-; <label>:1                                       ; preds = %entry
-  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %3 = load i32, i32 addrspace(1)* %2, align 8
-  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
-
-; <label>:5                                       ; preds = %1
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = add i32 %3, %7
-  ret i32 %8
-
-ThrowNullRef:                                     ; preds = %entry
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef16:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7213,70 +8626,70 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
   %6 = load i32, i32 addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
   store i32 %6, i32 addrspace(1)* %8
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
   %13 = load i32, i32 addrspace(1)* %12, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
   store i32 %13, i32 addrspace(1)* %15
   %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
-  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %18
 
 ; <label>:18                                      ; preds = %14
   %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
   %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
   %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
   %34 = load i32, i32 addrspace(1)* %33, align 8
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
-  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
@@ -7287,39 +8700,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %28
+ThrowNullRef16:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %32
+ThrowNullRef18:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7455,13 +8868,13 @@ entry:
 ; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
@@ -7477,16 +8890,16 @@ entry:
 
 ; <label>:18                                      ; preds = %15
   %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
   store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
   %22 = load i32, i32* %loc0
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %24
 
 ; <label>:24                                      ; preds = %20
   %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
@@ -7498,13 +8911,13 @@ entry:
 ; <label>:28                                      ; preds = %15, %24
   %29 = load i32, i32* %arg1
   %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %31
   %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
@@ -7517,20 +8930,20 @@ entry:
   %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
-  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
   %46 = load i32, i32 addrspace(1)* %45, align 8
   %47 = sub i32 %40, %46
-  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
-  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i32 addrspace(1)* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %48
 
 ; <label>:48                                      ; preds = %44
   store i32 %47, i32 addrspace(1)* %39, align 8
@@ -7538,21 +8951,21 @@ entry:
 
 ; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
-  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %51
 
 ; <label>:51                                      ; preds = %49
   %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %53
 
 ; <label>:53                                      ; preds = %51
   %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
   %55 = load i32, i32 addrspace(1)* %54, align 8
   %56 = load i32, i32* %arg2
   %57 = sub i32 %55, %56
-  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %58
 
 ; <label>:58                                      ; preds = %53
   %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
@@ -7562,13 +8975,13 @@ entry:
 ; <label>:60                                      ; preds = %33, %58
   %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
   %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
-  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %63
 
 ; <label>:63                                      ; preds = %60
   %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
-  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
-  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
@@ -7578,15 +8991,15 @@ entry:
 
 ; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
-  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i32 addrspace(1)* %69, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %70
 
 ; <label>:70                                      ; preds = %68
   %71 = load i32, i32 addrspace(1)* %69, align 8
   store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
-  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
@@ -7596,8 +9009,8 @@ entry:
   store i32 %77, i32* %loc4
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
-  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %80
 
 ; <label>:80                                      ; preds = %73
   %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
@@ -7607,71 +9020,71 @@ entry:
 ; <label>:83                                      ; preds = %80
   store i32 0, i32* %loc3
   %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
-  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
-  br i1 %NullCheck26, label %88, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i32 addrspace(1)* %87, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %88
 
 ; <label>:88                                      ; preds = %85
   %89 = load i32, i32 addrspace(1)* %87, align 8
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
-  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %90
 
 ; <label>:90                                      ; preds = %88
   %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
   store i32 %89, i32 addrspace(1)* %91
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
-  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
-  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %96
 
 ; <label>:96                                      ; preds = %94
   %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
-  br i1 %NullCheck34, label %100, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %100
 
 ; <label>:100                                     ; preds = %96
   %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
-  br i1 %NullCheck36, label %102, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %102
 
 ; <label>:102                                     ; preds = %100
   %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
   %104 = load i32, i32 addrspace(1)* %103, align 8
   %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
-  br i1 %NullCheck38, label %106, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %106
 
 ; <label>:106                                     ; preds = %102
   %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
-  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
-  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %108
 
 ; <label>:108                                     ; preds = %106
   %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
   %110 = load i32, i32 addrspace(1)* %109, align 8
   %111 = add i32 %104, %110
-  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %112
 
 ; <label>:112                                     ; preds = %108
   %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
   store i32 %111, i32 addrspace(1)* %113
   %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
-  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i32 addrspace(1)* %114, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %115
 
 ; <label>:115                                     ; preds = %112
   %116 = load i32, i32 addrspace(1)* %114, align 8
@@ -7681,19 +9094,19 @@ entry:
 ; <label>:118                                     ; preds = %115
   %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
-  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %121
 
 ; <label>:121                                     ; preds = %118
   %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
-  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
-  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %123
 
 ; <label>:123                                     ; preds = %121
   %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
   %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
-  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
-  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %126
 
 ; <label>:126                                     ; preds = %123
   %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
@@ -7705,8 +9118,8 @@ entry:
 
 ; <label>:130                                     ; preds = %80, %115, %126
   %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %132
 
 ; <label>:132                                     ; preds = %130
   %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7715,8 +9128,8 @@ entry:
   %136 = load i32, i32* %loc3
   %137 = sub i32 %135, %136
   %138 = sub i32 %134, %137
-  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %139
 
 ; <label>:139                                     ; preds = %132
   %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7728,16 +9141,16 @@ entry:
 
 ; <label>:144                                     ; preds = %139
   %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
-  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %146
 
 ; <label>:146                                     ; preds = %144
   %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
   %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
   %149 = load i32, i32* %loc2
   %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
-  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %151
 
 ; <label>:151                                     ; preds = %146
   %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
@@ -7754,145 +9167,249 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %18
+ThrowNullRef4:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %31
+ThrowNullRef10:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %44
+ThrowNullRef16:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %68
+ThrowNullRef18:                                   ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %70
+ThrowNullRef20:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %73
+ThrowNullRef22:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %83
+ThrowNullRef24:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %85
+ThrowNullRef26:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %88
+ThrowNullRef28:                                   ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %90
+ThrowNullRef30:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %94
+ThrowNullRef32:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %96
+ThrowNullRef34:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %100
+ThrowNullRef36:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %102
+ThrowNullRef38:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %106
+ThrowNullRef40:                                   ; preds = %106
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %108
+ThrowNullRef42:                                   ; preds = %108
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %112
+ThrowNullRef44:                                   ; preds = %112
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %118
+ThrowNullRef46:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %121
+ThrowNullRef48:                                   ; preds = %121
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %123
+ThrowNullRef50:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %130
+ThrowNullRef52:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %132
+ThrowNullRef54:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %144
+ThrowNullRef56:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %146
+ThrowNullRef58:                                   ; preds = %146
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %60
+ThrowNullRef60:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %63
+ThrowNullRef62:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %49
+ThrowNullRef64:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %51
+ThrowNullRef66:                                   ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %53
+ThrowNullRef68:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(%"System.Char[]" addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %arg0 = alloca %"System.Char[]" addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store %"System.Char[]" addrspace(1)* %param0, %"System.Char[]" addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load i32, i32* %arg4
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %43, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %38, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg1
+  %13 = load i32, i32* %arg4
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %38, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %24 = load i32, i32* %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %35 = load i32, i32* %arg3
+  %36 = load i32, i32* %arg4
+  %37 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %37, %"System.Char[]" addrspace(1)* %34, i32 %35, i32 %36)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:38                                      ; preds = %5, %16
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Successfully read Buffer._Memmove
 
@@ -7914,7 +9431,7 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[loadElem]
+Failed to read AppDomain.SetDataHelper[storeElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -7923,8 +9440,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
@@ -7934,8 +9451,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
@@ -7947,15 +9464,15 @@ entry:
   %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
   %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
@@ -7966,15 +9483,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7992,7 +9509,79 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
-Failed to read Dictionary`2.TryGetValue[loadElemA]
+Successfully read Dictionary`2.TryGetValue
+
+define i8 @"Dictionary`2.TryGetValue"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)* addrspace(1)* %param2) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  %arg2 = alloca %System.__Canon addrspace(1)* addrspace(1)*
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  store %System.__Canon addrspace(1)* addrspace(1)* %param2, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  store i32 %2, i32* %loc0
+  %3 = load i32, i32* %loc0
+  %4 = icmp slt i32 %3, 0
+  br i1 %4, label %22, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 2
+  %10 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %9, align 8
+  %11 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = zext i32 %11 to i64
+  %BoundsCheck = icmp uge i64 %16, %15
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 3, i32 %11
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %20, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %6, %System.__Canon addrspace(1)* %21)
+  ret i8 1
+
+; <label>:22                                      ; preds = %entry
+  %23 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %23, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -8058,8 +9647,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
@@ -8091,8 +9680,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
@@ -8171,15 +9760,15 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck, label %19, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %ThrowNullRef, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
   %21 = load i32, i32 addrspace(1)* %20
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
@@ -8202,7 +9791,7 @@ ThrowNullRef:                                     ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %19
+ThrowNullRef2:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8248,8 +9837,8 @@ entry:
   %0 = alloca %System.AppDomainHandle
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %1 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %1, i32 0, i32 15
@@ -8269,8 +9858,8 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
@@ -8286,7 +9875,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -8299,8 +9888,8 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -8327,8 +9916,8 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
@@ -8352,8 +9941,8 @@ entry:
   %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
   store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
@@ -8363,8 +9952,8 @@ entry:
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
@@ -8374,8 +9963,8 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %9
   %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
@@ -8384,8 +9973,8 @@ entry:
 
 ; <label>:18                                      ; preds = %3, %16
   %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
@@ -8397,15 +9986,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %18
+ThrowNullRef6:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8418,8 +10007,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
@@ -8453,15 +10042,15 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
@@ -8473,7 +10062,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8481,7 +10070,7 @@ ThrowNullRef1:                                    ; preds = %1
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
 Failed to read Dictionary`2.System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
@@ -8506,8 +10095,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
@@ -8524,8 +10113,8 @@ entry:
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -8544,7 +10133,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8577,8 +10166,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = load i64, i64* %arg2
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = trunc i32 %3 to i8
@@ -8634,46 +10223,46 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
   %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
-  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
-  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
-  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
@@ -8684,27 +10273,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %20
+ThrowNullRef12:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8717,8 +10306,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -8756,22 +10345,22 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
   %9 = load i64, i64 addrspace(1)* %8, align 8
   %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
   %13 = load i64, i64 addrspace(1)* %12, align 8
   %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %11
   %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
@@ -8788,11 +10377,11 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8882,8 +10471,8 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
@@ -8900,8 +10489,8 @@ entry:
 ; <label>:8                                       ; preds = %1
   %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
   %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
@@ -8911,15 +10500,15 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
   %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
   %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
-  br i1 %NullCheck6, label %21, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
@@ -8946,15 +10535,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8992,15 +10581,15 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
   store i8 %3, i8 addrspace(1)* %5
   %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
@@ -9011,7 +10600,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9027,8 +10616,8 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -9041,8 +10630,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
@@ -9058,7 +10647,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9080,8 +10669,8 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
@@ -9096,8 +10685,8 @@ entry:
 ; <label>:12                                      ; preds = %6
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
@@ -9112,8 +10701,8 @@ entry:
 ; <label>:21                                      ; preds = %15
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
@@ -9128,8 +10717,8 @@ entry:
 ; <label>:30                                      ; preds = %24
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %31, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
@@ -9144,8 +10733,8 @@ entry:
 ; <label>:39                                      ; preds = %33
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
-  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %40, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %42
 
 ; <label>:42                                      ; preds = %39
   %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
@@ -9164,19 +10753,19 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %21
+ThrowNullRef4:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %30
+ThrowNullRef6:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %39
+ThrowNullRef8:                                    ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9243,8 +10832,8 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
@@ -9264,57 +10853,57 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
   store i8 0, i8 addrspace(1)* %2
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
   store i8 0, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
   store i8 0, i8 addrspace(1)* %17
   %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
   store i8 0, i8 addrspace(1)* %20
   %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
-  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
@@ -9325,31 +10914,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %19
+ThrowNullRef14:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9367,8 +10956,8 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
@@ -9380,8 +10969,8 @@ entry:
 
 ; <label>:9                                       ; preds = %4
   %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %9
   %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
@@ -9395,7 +10984,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef2:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9420,8 +11009,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
@@ -9512,8 +11101,8 @@ entry:
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
@@ -9524,8 +11113,8 @@ entry:
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = load i64, i64 addrspace(1)* %12
@@ -9537,8 +11126,8 @@ entry:
   %20 = load i64, i64* %19
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
-  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %13
   %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
@@ -9555,8 +11144,8 @@ entry:
 ; <label>:30                                      ; preds = %25
   %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %32 = load i32, i32* %arg2
-  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
-  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
@@ -9570,15 +11159,15 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %30
+ThrowNullRef2:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9622,87 +11211,87 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
   %10 = load i8, i8 addrspace(1)* %9, align 8
   %11 = zext i8 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %8
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
   store i8 %12, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
   %19 = load i8, i8 addrspace(1)* %18, align 8
   %20 = zext i8 %19 to i32
   %21 = trunc i32 %20 to i8
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
   store i8 %21, i8 addrspace(1)* %23
   %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
   %28 = load i8, i8 addrspace(1)* %27, align 8
   %29 = zext i8 %28 to i32
   %30 = trunc i32 %29 to i8
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
-  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %31
 
 ; <label>:31                                      ; preds = %26
   %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
   store i8 %30, i8 addrspace(1)* %32
   %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
-  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
-  br i1 %NullCheck14, label %40, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %40
 
 ; <label>:40                                      ; preds = %35
   %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
   store i8 %39, i8 addrspace(1)* %41
   %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
-  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %44
 
 ; <label>:44                                      ; preds = %40
   %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
   %46 = load i8, i8 addrspace(1)* %45, align 8
   %47 = zext i8 %46 to i32
   %48 = trunc i32 %47 to i8
-  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
   store i8 %48, i8 addrspace(1)* %50
   %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
-  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
@@ -9713,29 +11302,29 @@ entry:
 ; <label>:56                                      ; preds = %52
   %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
-  br i1 %NullCheck22, label %59, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
   %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
   %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
-  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
-  br i1 %NullCheck24, label %63, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
   %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
-  br i1 %NullCheck26, label %66, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
   %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
-  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
-  br i1 %NullCheck28, label %69, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %69
 
 ; <label>:69                                      ; preds = %66
   %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
@@ -9744,15 +11333,15 @@ entry:
 
 ; <label>:71                                      ; preds = %105
   %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
-  br i1 %NullCheck34, label %73, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %73
 
 ; <label>:73                                      ; preds = %71
   %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
   %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
   %76 = load i32, i32* %loc0
-  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
-  br i1 %NullCheck36, label %77, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
@@ -9766,8 +11355,8 @@ entry:
 
 ; <label>:83                                      ; preds = %77
   %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
-  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
@@ -9775,14 +11364,14 @@ entry:
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
   %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
-  br i1 %NullCheck40, label %91, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
 ; <label>:91                                      ; preds = %85
   %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
   %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
-  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck42, label %94, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %94
 
 ; <label>:94                                      ; preds = %91
   %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
@@ -9798,14 +11387,14 @@ entry:
 ; <label>:99                                      ; preds = %69, %96
   %100 = load i32, i32* %loc0
   %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
-  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %102
 
 ; <label>:102                                     ; preds = %99
   %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
   %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
-  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
-  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
@@ -9819,87 +11408,87 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %26
+ThrowNullRef10:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %31
+ThrowNullRef12:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %35
+ThrowNullRef14:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %40
+ThrowNullRef16:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %56
+ThrowNullRef22:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %59
+ThrowNullRef24:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %63
+ThrowNullRef26:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %66
+ThrowNullRef28:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %102
+ThrowNullRef32:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %71
+ThrowNullRef34:                                   ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %73
+ThrowNullRef36:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %83
+ThrowNullRef38:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %85
+ThrowNullRef40:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %91
+ThrowNullRef42:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9943,15 +11532,15 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
   %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
@@ -9961,28 +11550,28 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
   %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %12
   %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
   %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
   %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
-  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
@@ -9993,23 +11582,23 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %12
+ThrowNullRef6:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10031,15 +11620,15 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
   %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = load i64, i64 addrspace(1)* %7
@@ -10077,13 +11666,13 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[loadElem]
+Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -10111,8 +11700,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -10184,8 +11773,8 @@ entry:
   store i32 addrspace(1)* %param1, i32 addrspace(1)** %arg1
   %0 = load i32, i32* %arg0
   %1 = load i32 addrspace(1)*, i32 addrspace(1)** %arg1
-  %NullCheck = icmp ne i32 addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq i32 addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load i32, i32 addrspace(1)* %1, align 8

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Swap.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Swap.error.txt
@@ -25,8 +25,8 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
@@ -40,8 +40,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
   %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
@@ -75,7 +75,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -90,8 +90,8 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %NullCheck = icmp ne i8 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = load i8, i8 addrspace(1)* %0, align 8
@@ -125,8 +125,8 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
@@ -159,8 +159,8 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -184,8 +184,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
   store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
@@ -195,8 +195,8 @@ entry:
 ; <label>:4                                       ; preds = %1
   %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
   %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
@@ -206,8 +206,8 @@ entry:
   %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
@@ -221,14 +221,14 @@ entry:
 
 ; <label>:17                                      ; preds = %14
   %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
   %21 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
@@ -238,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -249,8 +249,8 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
@@ -261,27 +261,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %30
+ThrowNullRef10:                                   ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -301,7 +301,89 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
-Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
+Successfully read AppDomainSetup.GetUnsecureApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.GetUnsecureApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %NullCheck = icmp eq %"System.String[]" addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %BoundsCheck = icmp uge i64 0, %5
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %6
+
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 3, i32 0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
+  ret %System.String addrspace(1)* %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_Value using LLILCJit
+Successfully read AppDomainSetup.get_Value
+
+define %"System.String[]" addrspace(1)* @AppDomainSetup.get_Value(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.String[]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 18)
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.String[]" addrspace(1)* addrspace(1)*, %"System.String[]" addrspace(1)*)*)(%"System.String[]" addrspace(1)* addrspace(1)* %9, %"System.String[]" addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %11, i32 0, i32 1
+  %14 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %13, align 8
+  ret %"System.String[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -319,8 +401,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -368,16 +450,16 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
   %5 = load i32, i32 addrspace(1)* %4
   %6 = sub i32 %5, 1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -389,7 +471,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -421,8 +503,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
@@ -456,8 +538,8 @@ entry:
 ; <label>:27                                      ; preds = %19
   %28 = load i32, i32* %arg1
   %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
-  br i1 %NullCheck2, label %30, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %29, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %30
 
 ; <label>:30                                      ; preds = %27
   %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
@@ -493,8 +575,8 @@ entry:
 ; <label>:49                                      ; preds = %46
   %50 = load i32, i32* %arg2
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck4, label %52, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
@@ -517,11 +599,11 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %27
+ThrowNullRef2:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %49
+ThrowNullRef4:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -544,16 +626,16 @@ entry:
   %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %0)
   store %System.String addrspace(1)* %1, %System.String addrspace(1)** %loc0
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 2
   %5 = bitcast [0 x i16] addrspace(1)* %4 to i16 addrspace(1)*
   store i16 addrspace(1)* %5, i16 addrspace(1)** %loc1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %3
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2
@@ -580,7 +662,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -691,15 +773,15 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %NullCheck132 = icmp ne i8* %21, null
-  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+  %NullCheck131 = icmp eq i8* %21, null
+  br i1 %NullCheck131, label %ThrowNullRef132, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = load i8, i8* %21, align 8
   %24 = zext i8 %23 to i32
   %25 = trunc i32 %24 to i8
-  %NullCheck134 = icmp ne i8* %20, null
-  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+  %NullCheck133 = icmp eq i8* %20, null
+  br i1 %NullCheck133, label %ThrowNullRef134, label %26
 
 ; <label>:26                                      ; preds = %22
   store i8 %25, i8* %20, align 8
@@ -709,16 +791,16 @@ entry:
   %28 = load i8*, i8** %arg0
   %29 = load i8*, i8** %arg1
   %30 = bitcast i8* %29 to i16*
-  %NullCheck128 = icmp ne i16* %30, null
-  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+  %NullCheck127 = icmp eq i16* %30, null
+  br i1 %NullCheck127, label %ThrowNullRef128, label %31
 
 ; <label>:31                                      ; preds = %27
   %32 = load i16, i16* %30, align 8
   %33 = sext i16 %32 to i32
   %34 = bitcast i8* %28 to i16*
   %35 = trunc i32 %33 to i16
-  %NullCheck130 = icmp ne i16* %34, null
-  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+  %NullCheck129 = icmp eq i16* %34, null
+  br i1 %NullCheck129, label %ThrowNullRef130, label %36
 
 ; <label>:36                                      ; preds = %31
   store i16 %35, i16* %34, align 8
@@ -728,16 +810,16 @@ entry:
   %38 = load i8*, i8** %arg0
   %39 = load i8*, i8** %arg1
   %40 = bitcast i8* %39 to i16*
-  %NullCheck120 = icmp ne i16* %40, null
-  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+  %NullCheck119 = icmp eq i16* %40, null
+  br i1 %NullCheck119, label %ThrowNullRef120, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i16, i16* %40, align 8
   %43 = sext i16 %42 to i32
   %44 = bitcast i8* %38 to i16*
   %45 = trunc i32 %43 to i16
-  %NullCheck122 = icmp ne i16* %44, null
-  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+  %NullCheck121 = icmp eq i16* %44, null
+  br i1 %NullCheck121, label %ThrowNullRef122, label %46
 
 ; <label>:46                                      ; preds = %41
   store i16 %45, i16* %44, align 8
@@ -745,15 +827,15 @@ entry:
   %48 = getelementptr inbounds i8, i8* %47, i64 2
   %49 = load i8*, i8** %arg1
   %50 = getelementptr inbounds i8, i8* %49, i64 2
-  %NullCheck124 = icmp ne i8* %50, null
-  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+  %NullCheck123 = icmp eq i8* %50, null
+  br i1 %NullCheck123, label %ThrowNullRef124, label %51
 
 ; <label>:51                                      ; preds = %46
   %52 = load i8, i8* %50, align 8
   %53 = zext i8 %52 to i32
   %54 = trunc i32 %53 to i8
-  %NullCheck126 = icmp ne i8* %48, null
-  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+  %NullCheck125 = icmp eq i8* %48, null
+  br i1 %NullCheck125, label %ThrowNullRef126, label %55
 
 ; <label>:55                                      ; preds = %51
   store i8 %54, i8* %48, align 8
@@ -763,14 +845,14 @@ entry:
   %57 = load i8*, i8** %arg0
   %58 = load i8*, i8** %arg1
   %59 = bitcast i8* %58 to i32*
-  %NullCheck116 = icmp ne i32* %59, null
-  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+  %NullCheck115 = icmp eq i32* %59, null
+  br i1 %NullCheck115, label %ThrowNullRef116, label %60
 
 ; <label>:60                                      ; preds = %56
   %61 = load i32, i32* %59, align 8
   %62 = bitcast i8* %57 to i32*
-  %NullCheck118 = icmp ne i32* %62, null
-  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+  %NullCheck117 = icmp eq i32* %62, null
+  br i1 %NullCheck117, label %ThrowNullRef118, label %63
 
 ; <label>:63                                      ; preds = %60
   store i32 %61, i32* %62, align 8
@@ -780,14 +862,14 @@ entry:
   %65 = load i8*, i8** %arg0
   %66 = load i8*, i8** %arg1
   %67 = bitcast i8* %66 to i32*
-  %NullCheck108 = icmp ne i32* %67, null
-  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+  %NullCheck107 = icmp eq i32* %67, null
+  br i1 %NullCheck107, label %ThrowNullRef108, label %68
 
 ; <label>:68                                      ; preds = %64
   %69 = load i32, i32* %67, align 8
   %70 = bitcast i8* %65 to i32*
-  %NullCheck110 = icmp ne i32* %70, null
-  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+  %NullCheck109 = icmp eq i32* %70, null
+  br i1 %NullCheck109, label %ThrowNullRef110, label %71
 
 ; <label>:71                                      ; preds = %68
   store i32 %69, i32* %70, align 8
@@ -795,15 +877,15 @@ entry:
   %73 = getelementptr inbounds i8, i8* %72, i64 4
   %74 = load i8*, i8** %arg1
   %75 = getelementptr inbounds i8, i8* %74, i64 4
-  %NullCheck112 = icmp ne i8* %75, null
-  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+  %NullCheck111 = icmp eq i8* %75, null
+  br i1 %NullCheck111, label %ThrowNullRef112, label %76
 
 ; <label>:76                                      ; preds = %71
   %77 = load i8, i8* %75, align 8
   %78 = zext i8 %77 to i32
   %79 = trunc i32 %78 to i8
-  %NullCheck114 = icmp ne i8* %73, null
-  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+  %NullCheck113 = icmp eq i8* %73, null
+  br i1 %NullCheck113, label %ThrowNullRef114, label %80
 
 ; <label>:80                                      ; preds = %76
   store i8 %79, i8* %73, align 8
@@ -813,14 +895,14 @@ entry:
   %82 = load i8*, i8** %arg0
   %83 = load i8*, i8** %arg1
   %84 = bitcast i8* %83 to i32*
-  %NullCheck100 = icmp ne i32* %84, null
-  br i1 %NullCheck100, label %85, label %ThrowNullRef99
+  %NullCheck99 = icmp eq i32* %84, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %85
 
 ; <label>:85                                      ; preds = %81
   %86 = load i32, i32* %84, align 8
   %87 = bitcast i8* %82 to i32*
-  %NullCheck102 = icmp ne i32* %87, null
-  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+  %NullCheck101 = icmp eq i32* %87, null
+  br i1 %NullCheck101, label %ThrowNullRef102, label %88
 
 ; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
@@ -829,16 +911,16 @@ entry:
   %91 = load i8*, i8** %arg1
   %92 = getelementptr inbounds i8, i8* %91, i64 4
   %93 = bitcast i8* %92 to i16*
-  %NullCheck104 = icmp ne i16* %93, null
-  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+  %NullCheck103 = icmp eq i16* %93, null
+  br i1 %NullCheck103, label %ThrowNullRef104, label %94
 
 ; <label>:94                                      ; preds = %88
   %95 = load i16, i16* %93, align 8
   %96 = sext i16 %95 to i32
   %97 = bitcast i8* %90 to i16*
   %98 = trunc i32 %96 to i16
-  %NullCheck106 = icmp ne i16* %97, null
-  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+  %NullCheck105 = icmp eq i16* %97, null
+  br i1 %NullCheck105, label %ThrowNullRef106, label %99
 
 ; <label>:99                                      ; preds = %94
   store i16 %98, i16* %97, align 8
@@ -848,14 +930,14 @@ entry:
   %101 = load i8*, i8** %arg0
   %102 = load i8*, i8** %arg1
   %103 = bitcast i8* %102 to i32*
-  %NullCheck88 = icmp ne i32* %103, null
-  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+  %NullCheck87 = icmp eq i32* %103, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %104
 
 ; <label>:104                                     ; preds = %100
   %105 = load i32, i32* %103, align 8
   %106 = bitcast i8* %101 to i32*
-  %NullCheck90 = icmp ne i32* %106, null
-  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+  %NullCheck89 = icmp eq i32* %106, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %107
 
 ; <label>:107                                     ; preds = %104
   store i32 %105, i32* %106, align 8
@@ -864,16 +946,16 @@ entry:
   %110 = load i8*, i8** %arg1
   %111 = getelementptr inbounds i8, i8* %110, i64 4
   %112 = bitcast i8* %111 to i16*
-  %NullCheck92 = icmp ne i16* %112, null
-  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+  %NullCheck91 = icmp eq i16* %112, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %113
 
 ; <label>:113                                     ; preds = %107
   %114 = load i16, i16* %112, align 8
   %115 = sext i16 %114 to i32
   %116 = bitcast i8* %109 to i16*
   %117 = trunc i32 %115 to i16
-  %NullCheck94 = icmp ne i16* %116, null
-  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+  %NullCheck93 = icmp eq i16* %116, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %118
 
 ; <label>:118                                     ; preds = %113
   store i16 %117, i16* %116, align 8
@@ -881,15 +963,15 @@ entry:
   %120 = getelementptr inbounds i8, i8* %119, i64 6
   %121 = load i8*, i8** %arg1
   %122 = getelementptr inbounds i8, i8* %121, i64 6
-  %NullCheck96 = icmp ne i8* %122, null
-  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+  %NullCheck95 = icmp eq i8* %122, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %123
 
 ; <label>:123                                     ; preds = %118
   %124 = load i8, i8* %122, align 8
   %125 = zext i8 %124 to i32
   %126 = trunc i32 %125 to i8
-  %NullCheck98 = icmp ne i8* %120, null
-  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+  %NullCheck97 = icmp eq i8* %120, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %127
 
 ; <label>:127                                     ; preds = %123
   store i8 %126, i8* %120, align 8
@@ -899,14 +981,14 @@ entry:
   %129 = load i8*, i8** %arg0
   %130 = load i8*, i8** %arg1
   %131 = bitcast i8* %130 to i64*
-  %NullCheck84 = icmp ne i64* %131, null
-  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+  %NullCheck83 = icmp eq i64* %131, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %132
 
 ; <label>:132                                     ; preds = %128
   %133 = load i64, i64* %131, align 8
   %134 = bitcast i8* %129 to i64*
-  %NullCheck86 = icmp ne i64* %134, null
-  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+  %NullCheck85 = icmp eq i64* %134, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %135
 
 ; <label>:135                                     ; preds = %132
   store i64 %133, i64* %134, align 8
@@ -916,14 +998,14 @@ entry:
   %137 = load i8*, i8** %arg0
   %138 = load i8*, i8** %arg1
   %139 = bitcast i8* %138 to i64*
-  %NullCheck76 = icmp ne i64* %139, null
-  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+  %NullCheck75 = icmp eq i64* %139, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %140
 
 ; <label>:140                                     ; preds = %136
   %141 = load i64, i64* %139, align 8
   %142 = bitcast i8* %137 to i64*
-  %NullCheck78 = icmp ne i64* %142, null
-  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+  %NullCheck77 = icmp eq i64* %142, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %143
 
 ; <label>:143                                     ; preds = %140
   store i64 %141, i64* %142, align 8
@@ -931,15 +1013,15 @@ entry:
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %NullCheck80 = icmp ne i8* %147, null
-  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+  %NullCheck79 = icmp eq i8* %147, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %148
 
 ; <label>:148                                     ; preds = %143
   %149 = load i8, i8* %147, align 8
   %150 = zext i8 %149 to i32
   %151 = trunc i32 %150 to i8
-  %NullCheck82 = icmp ne i8* %145, null
-  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+  %NullCheck81 = icmp eq i8* %145, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %152
 
 ; <label>:152                                     ; preds = %148
   store i8 %151, i8* %145, align 8
@@ -949,14 +1031,14 @@ entry:
   %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
   %156 = bitcast i8* %155 to i64*
-  %NullCheck68 = icmp ne i64* %156, null
-  br i1 %NullCheck68, label %157, label %ThrowNullRef67
+  %NullCheck67 = icmp eq i64* %156, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %157
 
 ; <label>:157                                     ; preds = %153
   %158 = load i64, i64* %156, align 8
   %159 = bitcast i8* %154 to i64*
-  %NullCheck70 = icmp ne i64* %159, null
-  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+  %NullCheck69 = icmp eq i64* %159, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %160
 
 ; <label>:160                                     ; preds = %157
   store i64 %158, i64* %159, align 8
@@ -965,16 +1047,16 @@ entry:
   %163 = load i8*, i8** %arg1
   %164 = getelementptr inbounds i8, i8* %163, i64 8
   %165 = bitcast i8* %164 to i16*
-  %NullCheck72 = icmp ne i16* %165, null
-  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+  %NullCheck71 = icmp eq i16* %165, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %166
 
 ; <label>:166                                     ; preds = %160
   %167 = load i16, i16* %165, align 8
   %168 = sext i16 %167 to i32
   %169 = bitcast i8* %162 to i16*
   %170 = trunc i32 %168 to i16
-  %NullCheck74 = icmp ne i16* %169, null
-  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+  %NullCheck73 = icmp eq i16* %169, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %171
 
 ; <label>:171                                     ; preds = %166
   store i16 %170, i16* %169, align 8
@@ -984,14 +1066,14 @@ entry:
   %173 = load i8*, i8** %arg0
   %174 = load i8*, i8** %arg1
   %175 = bitcast i8* %174 to i64*
-  %NullCheck56 = icmp ne i64* %175, null
-  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+  %NullCheck55 = icmp eq i64* %175, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %176
 
 ; <label>:176                                     ; preds = %172
   %177 = load i64, i64* %175, align 8
   %178 = bitcast i8* %173 to i64*
-  %NullCheck58 = icmp ne i64* %178, null
-  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+  %NullCheck57 = icmp eq i64* %178, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %179
 
 ; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
@@ -1000,16 +1082,16 @@ entry:
   %182 = load i8*, i8** %arg1
   %183 = getelementptr inbounds i8, i8* %182, i64 8
   %184 = bitcast i8* %183 to i16*
-  %NullCheck60 = icmp ne i16* %184, null
-  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+  %NullCheck59 = icmp eq i16* %184, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %185
 
 ; <label>:185                                     ; preds = %179
   %186 = load i16, i16* %184, align 8
   %187 = sext i16 %186 to i32
   %188 = bitcast i8* %181 to i16*
   %189 = trunc i32 %187 to i16
-  %NullCheck62 = icmp ne i16* %188, null
-  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+  %NullCheck61 = icmp eq i16* %188, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %190
 
 ; <label>:190                                     ; preds = %185
   store i16 %189, i16* %188, align 8
@@ -1017,15 +1099,15 @@ entry:
   %192 = getelementptr inbounds i8, i8* %191, i64 10
   %193 = load i8*, i8** %arg1
   %194 = getelementptr inbounds i8, i8* %193, i64 10
-  %NullCheck64 = icmp ne i8* %194, null
-  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+  %NullCheck63 = icmp eq i8* %194, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %195
 
 ; <label>:195                                     ; preds = %190
   %196 = load i8, i8* %194, align 8
   %197 = zext i8 %196 to i32
   %198 = trunc i32 %197 to i8
-  %NullCheck66 = icmp ne i8* %192, null
-  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+  %NullCheck65 = icmp eq i8* %192, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %199
 
 ; <label>:199                                     ; preds = %195
   store i8 %198, i8* %192, align 8
@@ -1035,14 +1117,14 @@ entry:
   %201 = load i8*, i8** %arg0
   %202 = load i8*, i8** %arg1
   %203 = bitcast i8* %202 to i64*
-  %NullCheck48 = icmp ne i64* %203, null
-  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+  %NullCheck47 = icmp eq i64* %203, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %204
 
 ; <label>:204                                     ; preds = %200
   %205 = load i64, i64* %203, align 8
   %206 = bitcast i8* %201 to i64*
-  %NullCheck50 = icmp ne i64* %206, null
-  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+  %NullCheck49 = icmp eq i64* %206, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %207
 
 ; <label>:207                                     ; preds = %204
   store i64 %205, i64* %206, align 8
@@ -1051,14 +1133,14 @@ entry:
   %210 = load i8*, i8** %arg1
   %211 = getelementptr inbounds i8, i8* %210, i64 8
   %212 = bitcast i8* %211 to i32*
-  %NullCheck52 = icmp ne i32* %212, null
-  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+  %NullCheck51 = icmp eq i32* %212, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %213
 
 ; <label>:213                                     ; preds = %207
   %214 = load i32, i32* %212, align 8
   %215 = bitcast i8* %209 to i32*
-  %NullCheck54 = icmp ne i32* %215, null
-  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+  %NullCheck53 = icmp eq i32* %215, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %216
 
 ; <label>:216                                     ; preds = %213
   store i32 %214, i32* %215, align 8
@@ -1068,14 +1150,14 @@ entry:
   %218 = load i8*, i8** %arg0
   %219 = load i8*, i8** %arg1
   %220 = bitcast i8* %219 to i64*
-  %NullCheck36 = icmp ne i64* %220, null
-  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64* %220, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %221
 
 ; <label>:221                                     ; preds = %217
   %222 = load i64, i64* %220, align 8
   %223 = bitcast i8* %218 to i64*
-  %NullCheck38 = icmp ne i64* %223, null
-  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+  %NullCheck37 = icmp eq i64* %223, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %224
 
 ; <label>:224                                     ; preds = %221
   store i64 %222, i64* %223, align 8
@@ -1084,14 +1166,14 @@ entry:
   %227 = load i8*, i8** %arg1
   %228 = getelementptr inbounds i8, i8* %227, i64 8
   %229 = bitcast i8* %228 to i32*
-  %NullCheck40 = icmp ne i32* %229, null
-  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i32* %229, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %230
 
 ; <label>:230                                     ; preds = %224
   %231 = load i32, i32* %229, align 8
   %232 = bitcast i8* %226 to i32*
-  %NullCheck42 = icmp ne i32* %232, null
-  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+  %NullCheck41 = icmp eq i32* %232, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %233
 
 ; <label>:233                                     ; preds = %230
   store i32 %231, i32* %232, align 8
@@ -1099,15 +1181,15 @@ entry:
   %235 = getelementptr inbounds i8, i8* %234, i64 12
   %236 = load i8*, i8** %arg1
   %237 = getelementptr inbounds i8, i8* %236, i64 12
-  %NullCheck44 = icmp ne i8* %237, null
-  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i8* %237, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %238
 
 ; <label>:238                                     ; preds = %233
   %239 = load i8, i8* %237, align 8
   %240 = zext i8 %239 to i32
   %241 = trunc i32 %240 to i8
-  %NullCheck46 = icmp ne i8* %235, null
-  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+  %NullCheck45 = icmp eq i8* %235, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %242
 
 ; <label>:242                                     ; preds = %238
   store i8 %241, i8* %235, align 8
@@ -1117,14 +1199,14 @@ entry:
   %244 = load i8*, i8** %arg0
   %245 = load i8*, i8** %arg1
   %246 = bitcast i8* %245 to i64*
-  %NullCheck24 = icmp ne i64* %246, null
-  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64* %246, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %247
 
 ; <label>:247                                     ; preds = %243
   %248 = load i64, i64* %246, align 8
   %249 = bitcast i8* %244 to i64*
-  %NullCheck26 = icmp ne i64* %249, null
-  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64* %249, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %250
 
 ; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
@@ -1133,14 +1215,14 @@ entry:
   %253 = load i8*, i8** %arg1
   %254 = getelementptr inbounds i8, i8* %253, i64 8
   %255 = bitcast i8* %254 to i32*
-  %NullCheck28 = icmp ne i32* %255, null
-  br i1 %NullCheck28, label %256, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i32* %255, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %256
 
 ; <label>:256                                     ; preds = %250
   %257 = load i32, i32* %255, align 8
   %258 = bitcast i8* %252 to i32*
-  %NullCheck30 = icmp ne i32* %258, null
-  br i1 %NullCheck30, label %259, label %ThrowNullRef29
+  %NullCheck29 = icmp eq i32* %258, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %259
 
 ; <label>:259                                     ; preds = %256
   store i32 %257, i32* %258, align 8
@@ -1149,16 +1231,16 @@ entry:
   %262 = load i8*, i8** %arg1
   %263 = getelementptr inbounds i8, i8* %262, i64 12
   %264 = bitcast i8* %263 to i16*
-  %NullCheck32 = icmp ne i16* %264, null
-  br i1 %NullCheck32, label %265, label %ThrowNullRef31
+  %NullCheck31 = icmp eq i16* %264, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %265
 
 ; <label>:265                                     ; preds = %259
   %266 = load i16, i16* %264, align 8
   %267 = sext i16 %266 to i32
   %268 = bitcast i8* %261 to i16*
   %269 = trunc i32 %267 to i16
-  %NullCheck34 = icmp ne i16* %268, null
-  br i1 %NullCheck34, label %270, label %ThrowNullRef33
+  %NullCheck33 = icmp eq i16* %268, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %270
 
 ; <label>:270                                     ; preds = %265
   store i16 %269, i16* %268, align 8
@@ -1168,14 +1250,14 @@ entry:
   %272 = load i8*, i8** %arg0
   %273 = load i8*, i8** %arg1
   %274 = bitcast i8* %273 to i64*
-  %NullCheck8 = icmp ne i64* %274, null
-  br i1 %NullCheck8, label %275, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64* %274, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %275
 
 ; <label>:275                                     ; preds = %271
   %276 = load i64, i64* %274, align 8
   %277 = bitcast i8* %272 to i64*
-  %NullCheck10 = icmp ne i64* %277, null
-  br i1 %NullCheck10, label %278, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %277, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %278
 
 ; <label>:278                                     ; preds = %275
   store i64 %276, i64* %277, align 8
@@ -1184,14 +1266,14 @@ entry:
   %281 = load i8*, i8** %arg1
   %282 = getelementptr inbounds i8, i8* %281, i64 8
   %283 = bitcast i8* %282 to i32*
-  %NullCheck12 = icmp ne i32* %283, null
-  br i1 %NullCheck12, label %284, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i32* %283, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %284
 
 ; <label>:284                                     ; preds = %278
   %285 = load i32, i32* %283, align 8
   %286 = bitcast i8* %280 to i32*
-  %NullCheck14 = icmp ne i32* %286, null
-  br i1 %NullCheck14, label %287, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i32* %286, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %287
 
 ; <label>:287                                     ; preds = %284
   store i32 %285, i32* %286, align 8
@@ -1200,16 +1282,16 @@ entry:
   %290 = load i8*, i8** %arg1
   %291 = getelementptr inbounds i8, i8* %290, i64 12
   %292 = bitcast i8* %291 to i16*
-  %NullCheck16 = icmp ne i16* %292, null
-  br i1 %NullCheck16, label %293, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i16* %292, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %293
 
 ; <label>:293                                     ; preds = %287
   %294 = load i16, i16* %292, align 8
   %295 = sext i16 %294 to i32
   %296 = bitcast i8* %289 to i16*
   %297 = trunc i32 %295 to i16
-  %NullCheck18 = icmp ne i16* %296, null
-  br i1 %NullCheck18, label %298, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i16* %296, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %298
 
 ; <label>:298                                     ; preds = %293
   store i16 %297, i16* %296, align 8
@@ -1217,15 +1299,15 @@ entry:
   %300 = getelementptr inbounds i8, i8* %299, i64 14
   %301 = load i8*, i8** %arg1
   %302 = getelementptr inbounds i8, i8* %301, i64 14
-  %NullCheck20 = icmp ne i8* %302, null
-  br i1 %NullCheck20, label %303, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i8* %302, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %303
 
 ; <label>:303                                     ; preds = %298
   %304 = load i8, i8* %302, align 8
   %305 = zext i8 %304 to i32
   %306 = trunc i32 %305 to i8
-  %NullCheck22 = icmp ne i8* %300, null
-  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i8* %300, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %307
 
 ; <label>:307                                     ; preds = %303
   store i8 %306, i8* %300, align 8
@@ -1235,14 +1317,14 @@ entry:
   %309 = load i8*, i8** %arg0
   %310 = load i8*, i8** %arg1
   %311 = bitcast i8* %310 to i64*
-  %NullCheck = icmp ne i64* %311, null
-  br i1 %NullCheck, label %312, label %ThrowNullRef
+  %NullCheck = icmp eq i64* %311, null
+  br i1 %NullCheck, label %ThrowNullRef, label %312
 
 ; <label>:312                                     ; preds = %308
   %313 = load i64, i64* %311, align 8
   %314 = bitcast i8* %309 to i64*
-  %NullCheck2 = icmp ne i64* %314, null
-  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64* %314, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %315
 
 ; <label>:315                                     ; preds = %312
   store i64 %313, i64* %314, align 8
@@ -1251,14 +1333,14 @@ entry:
   %318 = load i8*, i8** %arg1
   %319 = getelementptr inbounds i8, i8* %318, i64 8
   %320 = bitcast i8* %319 to i64*
-  %NullCheck4 = icmp ne i64* %320, null
-  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64* %320, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %321
 
 ; <label>:321                                     ; preds = %315
   %322 = load i64, i64* %320, align 8
   %323 = bitcast i8* %317 to i64*
-  %NullCheck6 = icmp ne i64* %323, null
-  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64* %323, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %324
 
 ; <label>:324                                     ; preds = %321
   store i64 %322, i64* %323, align 8
@@ -1286,15 +1368,15 @@ entry:
 ; <label>:338                                     ; preds = %333
   %339 = load i8*, i8** %arg0
   %340 = load i8*, i8** %arg1
-  %NullCheck136 = icmp ne i8* %340, null
-  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+  %NullCheck135 = icmp eq i8* %340, null
+  br i1 %NullCheck135, label %ThrowNullRef136, label %341
 
 ; <label>:341                                     ; preds = %338
   %342 = load i8, i8* %340, align 8
   %343 = zext i8 %342 to i32
   %344 = trunc i32 %343 to i8
-  %NullCheck138 = icmp ne i8* %339, null
-  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+  %NullCheck137 = icmp eq i8* %339, null
+  br i1 %NullCheck137, label %ThrowNullRef138, label %345
 
 ; <label>:345                                     ; preds = %341
   store i8 %344, i8* %339, align 8
@@ -1317,16 +1399,16 @@ entry:
   %357 = load i8*, i8** %arg0
   %358 = load i8*, i8** %arg1
   %359 = bitcast i8* %358 to i16*
-  %NullCheck140 = icmp ne i16* %359, null
-  br i1 %NullCheck140, label %360, label %ThrowNullRef139
+  %NullCheck139 = icmp eq i16* %359, null
+  br i1 %NullCheck139, label %ThrowNullRef140, label %360
 
 ; <label>:360                                     ; preds = %356
   %361 = load i16, i16* %359, align 8
   %362 = sext i16 %361 to i32
   %363 = bitcast i8* %357 to i16*
   %364 = trunc i32 %362 to i16
-  %NullCheck142 = icmp ne i16* %363, null
-  br i1 %NullCheck142, label %365, label %ThrowNullRef141
+  %NullCheck141 = icmp eq i16* %363, null
+  br i1 %NullCheck141, label %ThrowNullRef142, label %365
 
 ; <label>:365                                     ; preds = %360
   store i16 %364, i16* %363, align 8
@@ -1352,14 +1434,14 @@ entry:
   %378 = load i8*, i8** %arg0
   %379 = load i8*, i8** %arg1
   %380 = bitcast i8* %379 to i32*
-  %NullCheck144 = icmp ne i32* %380, null
-  br i1 %NullCheck144, label %381, label %ThrowNullRef143
+  %NullCheck143 = icmp eq i32* %380, null
+  br i1 %NullCheck143, label %ThrowNullRef144, label %381
 
 ; <label>:381                                     ; preds = %377
   %382 = load i32, i32* %380, align 8
   %383 = bitcast i8* %378 to i32*
-  %NullCheck146 = icmp ne i32* %383, null
-  br i1 %NullCheck146, label %384, label %ThrowNullRef145
+  %NullCheck145 = icmp eq i32* %383, null
+  br i1 %NullCheck145, label %ThrowNullRef146, label %384
 
 ; <label>:384                                     ; preds = %381
   store i32 %382, i32* %383, align 8
@@ -1384,14 +1466,14 @@ entry:
   %395 = load i8*, i8** %arg0
   %396 = load i8*, i8** %arg1
   %397 = bitcast i8* %396 to i64*
-  %NullCheck164 = icmp ne i64* %397, null
-  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+  %NullCheck163 = icmp eq i64* %397, null
+  br i1 %NullCheck163, label %ThrowNullRef164, label %398
 
 ; <label>:398                                     ; preds = %394
   %399 = load i64, i64* %397, align 8
   %400 = bitcast i8* %395 to i64*
-  %NullCheck166 = icmp ne i64* %400, null
-  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+  %NullCheck165 = icmp eq i64* %400, null
+  br i1 %NullCheck165, label %ThrowNullRef166, label %401
 
 ; <label>:401                                     ; preds = %398
   store i64 %399, i64* %400, align 8
@@ -1400,14 +1482,14 @@ entry:
   %404 = load i8*, i8** %arg1
   %405 = getelementptr inbounds i8, i8* %404, i64 8
   %406 = bitcast i8* %405 to i64*
-  %NullCheck168 = icmp ne i64* %406, null
-  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+  %NullCheck167 = icmp eq i64* %406, null
+  br i1 %NullCheck167, label %ThrowNullRef168, label %407
 
 ; <label>:407                                     ; preds = %401
   %408 = load i64, i64* %406, align 8
   %409 = bitcast i8* %403 to i64*
-  %NullCheck170 = icmp ne i64* %409, null
-  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+  %NullCheck169 = icmp eq i64* %409, null
+  br i1 %NullCheck169, label %ThrowNullRef170, label %410
 
 ; <label>:410                                     ; preds = %407
   store i64 %408, i64* %409, align 8
@@ -1437,14 +1519,14 @@ entry:
   %425 = load i8*, i8** %arg0
   %426 = load i8*, i8** %arg1
   %427 = bitcast i8* %426 to i64*
-  %NullCheck148 = icmp ne i64* %427, null
-  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+  %NullCheck147 = icmp eq i64* %427, null
+  br i1 %NullCheck147, label %ThrowNullRef148, label %428
 
 ; <label>:428                                     ; preds = %424
   %429 = load i64, i64* %427, align 8
   %430 = bitcast i8* %425 to i64*
-  %NullCheck150 = icmp ne i64* %430, null
-  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+  %NullCheck149 = icmp eq i64* %430, null
+  br i1 %NullCheck149, label %ThrowNullRef150, label %431
 
 ; <label>:431                                     ; preds = %428
   store i64 %429, i64* %430, align 8
@@ -1466,14 +1548,14 @@ entry:
   %441 = load i8*, i8** %arg0
   %442 = load i8*, i8** %arg1
   %443 = bitcast i8* %442 to i32*
-  %NullCheck152 = icmp ne i32* %443, null
-  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+  %NullCheck151 = icmp eq i32* %443, null
+  br i1 %NullCheck151, label %ThrowNullRef152, label %444
 
 ; <label>:444                                     ; preds = %440
   %445 = load i32, i32* %443, align 8
   %446 = bitcast i8* %441 to i32*
-  %NullCheck154 = icmp ne i32* %446, null
-  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+  %NullCheck153 = icmp eq i32* %446, null
+  br i1 %NullCheck153, label %ThrowNullRef154, label %447
 
 ; <label>:447                                     ; preds = %444
   store i32 %445, i32* %446, align 8
@@ -1495,16 +1577,16 @@ entry:
   %457 = load i8*, i8** %arg0
   %458 = load i8*, i8** %arg1
   %459 = bitcast i8* %458 to i16*
-  %NullCheck156 = icmp ne i16* %459, null
-  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+  %NullCheck155 = icmp eq i16* %459, null
+  br i1 %NullCheck155, label %ThrowNullRef156, label %460
 
 ; <label>:460                                     ; preds = %456
   %461 = load i16, i16* %459, align 8
   %462 = sext i16 %461 to i32
   %463 = bitcast i8* %457 to i16*
   %464 = trunc i32 %462 to i16
-  %NullCheck158 = icmp ne i16* %463, null
-  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+  %NullCheck157 = icmp eq i16* %463, null
+  br i1 %NullCheck157, label %ThrowNullRef158, label %465
 
 ; <label>:465                                     ; preds = %460
   store i16 %464, i16* %463, align 8
@@ -1525,15 +1607,15 @@ entry:
 ; <label>:474                                     ; preds = %470
   %475 = load i8*, i8** %arg0
   %476 = load i8*, i8** %arg1
-  %NullCheck160 = icmp ne i8* %476, null
-  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+  %NullCheck159 = icmp eq i8* %476, null
+  br i1 %NullCheck159, label %ThrowNullRef160, label %477
 
 ; <label>:477                                     ; preds = %474
   %478 = load i8, i8* %476, align 8
   %479 = zext i8 %478 to i32
   %480 = trunc i32 %479 to i8
-  %NullCheck162 = icmp ne i8* %475, null
-  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+  %NullCheck161 = icmp eq i8* %475, null
+  br i1 %NullCheck161, label %ThrowNullRef162, label %481
 
 ; <label>:481                                     ; preds = %477
   store i8 %480, i8* %475, align 8
@@ -1553,343 +1635,343 @@ ThrowNullRef:                                     ; preds = %308
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %312
+ThrowNullRef2:                                    ; preds = %312
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %315
+ThrowNullRef4:                                    ; preds = %315
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %321
+ThrowNullRef6:                                    ; preds = %321
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %271
+ThrowNullRef8:                                    ; preds = %271
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %275
+ThrowNullRef10:                                   ; preds = %275
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %278
+ThrowNullRef12:                                   ; preds = %278
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %284
+ThrowNullRef14:                                   ; preds = %284
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %287
+ThrowNullRef16:                                   ; preds = %287
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %293
+ThrowNullRef18:                                   ; preds = %293
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %298
+ThrowNullRef20:                                   ; preds = %298
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %303
+ThrowNullRef22:                                   ; preds = %303
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %243
+ThrowNullRef24:                                   ; preds = %243
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %247
+ThrowNullRef26:                                   ; preds = %247
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %250
+ThrowNullRef28:                                   ; preds = %250
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %256
+ThrowNullRef30:                                   ; preds = %256
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %259
+ThrowNullRef32:                                   ; preds = %259
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %265
+ThrowNullRef34:                                   ; preds = %265
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %217
+ThrowNullRef36:                                   ; preds = %217
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %221
+ThrowNullRef38:                                   ; preds = %221
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %224
+ThrowNullRef40:                                   ; preds = %224
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %230
+ThrowNullRef42:                                   ; preds = %230
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %233
+ThrowNullRef44:                                   ; preds = %233
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %238
+ThrowNullRef46:                                   ; preds = %238
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %200
+ThrowNullRef48:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %204
+ThrowNullRef50:                                   ; preds = %204
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %207
+ThrowNullRef52:                                   ; preds = %207
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %213
+ThrowNullRef54:                                   ; preds = %213
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %172
+ThrowNullRef56:                                   ; preds = %172
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %176
+ThrowNullRef58:                                   ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %179
+ThrowNullRef60:                                   ; preds = %179
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %185
+ThrowNullRef62:                                   ; preds = %185
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %190
+ThrowNullRef64:                                   ; preds = %190
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %195
+ThrowNullRef66:                                   ; preds = %195
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %153
+ThrowNullRef68:                                   ; preds = %153
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %157
+ThrowNullRef70:                                   ; preds = %157
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %160
+ThrowNullRef72:                                   ; preds = %160
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %166
+ThrowNullRef74:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %136
+ThrowNullRef76:                                   ; preds = %136
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %140
+ThrowNullRef78:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %143
+ThrowNullRef80:                                   ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %148
+ThrowNullRef82:                                   ; preds = %148
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %128
+ThrowNullRef84:                                   ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %132
+ThrowNullRef86:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %100
+ThrowNullRef88:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %104
+ThrowNullRef90:                                   ; preds = %104
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %107
+ThrowNullRef92:                                   ; preds = %107
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %113
+ThrowNullRef94:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %118
+ThrowNullRef96:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %123
+ThrowNullRef98:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %81
+ThrowNullRef100:                                  ; preds = %81
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef101:                                  ; preds = %85
+ThrowNullRef102:                                  ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef103:                                  ; preds = %88
+ThrowNullRef104:                                  ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef105:                                  ; preds = %94
+ThrowNullRef106:                                  ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef107:                                  ; preds = %64
+ThrowNullRef108:                                  ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef109:                                  ; preds = %68
+ThrowNullRef110:                                  ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef111:                                  ; preds = %71
+ThrowNullRef112:                                  ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef113:                                  ; preds = %76
+ThrowNullRef114:                                  ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef115:                                  ; preds = %56
+ThrowNullRef116:                                  ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef117:                                  ; preds = %60
+ThrowNullRef118:                                  ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef119:                                  ; preds = %37
+ThrowNullRef120:                                  ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef121:                                  ; preds = %41
+ThrowNullRef122:                                  ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef123:                                  ; preds = %46
+ThrowNullRef124:                                  ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef125:                                  ; preds = %51
+ThrowNullRef126:                                  ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef127:                                  ; preds = %27
+ThrowNullRef128:                                  ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef129:                                  ; preds = %31
+ThrowNullRef130:                                  ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef131:                                  ; preds = %19
+ThrowNullRef132:                                  ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef133:                                  ; preds = %22
+ThrowNullRef134:                                  ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef135:                                  ; preds = %338
+ThrowNullRef136:                                  ; preds = %338
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef137:                                  ; preds = %341
+ThrowNullRef138:                                  ; preds = %341
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef139:                                  ; preds = %356
+ThrowNullRef140:                                  ; preds = %356
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef141:                                  ; preds = %360
+ThrowNullRef142:                                  ; preds = %360
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef143:                                  ; preds = %377
+ThrowNullRef144:                                  ; preds = %377
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef145:                                  ; preds = %381
+ThrowNullRef146:                                  ; preds = %381
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef147:                                  ; preds = %424
+ThrowNullRef148:                                  ; preds = %424
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef149:                                  ; preds = %428
+ThrowNullRef150:                                  ; preds = %428
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef151:                                  ; preds = %440
+ThrowNullRef152:                                  ; preds = %440
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef153:                                  ; preds = %444
+ThrowNullRef154:                                  ; preds = %444
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef155:                                  ; preds = %456
+ThrowNullRef156:                                  ; preds = %456
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef157:                                  ; preds = %460
+ThrowNullRef158:                                  ; preds = %460
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef159:                                  ; preds = %474
+ThrowNullRef160:                                  ; preds = %474
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef161:                                  ; preds = %477
+ThrowNullRef162:                                  ; preds = %477
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef163:                                  ; preds = %394
+ThrowNullRef164:                                  ; preds = %394
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef165:                                  ; preds = %398
+ThrowNullRef166:                                  ; preds = %398
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef167:                                  ; preds = %401
+ThrowNullRef168:                                  ; preds = %401
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef169:                                  ; preds = %407
+ThrowNullRef170:                                  ; preds = %407
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1939,8 +2021,8 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
-  br i1 %NullCheck, label %22, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %ThrowNullRef, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
@@ -1948,8 +2030,8 @@ entry:
   store i32 %24, i32* %loc0
   %25 = load i32, i32* %loc0
   %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %26, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %27
 
 ; <label>:27                                      ; preds = %22
   %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
@@ -1971,7 +2053,7 @@ ThrowNullRef:                                     ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1989,8 +2071,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -2022,15 +2104,15 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2048,16 +2130,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
   %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
   store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %15
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
@@ -2072,8 +2154,8 @@ entry:
   %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
   %29 = ptrtoint i16 addrspace(1)* %28 to i64
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %19
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
@@ -2089,19 +2171,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2114,8 +2196,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
@@ -2128,7 +2210,7 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[loadElem]
+Failed to read AppDomain.PrepareDataForSetup[storeElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
@@ -2202,8 +2284,8 @@ entry:
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
-  br i1 %NullCheck24, label %27, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = load i64, i64 addrspace(1)* %26
@@ -2218,8 +2300,8 @@ entry:
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
-  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
   %41 = load i64, i64 addrspace(1)* %39
@@ -2236,8 +2318,8 @@ entry:
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
-  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
   %54 = load i64, i64 addrspace(1)* %52
@@ -2252,8 +2334,8 @@ entry:
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
   %67 = load i64, i64 addrspace(1)* %65
@@ -2270,8 +2352,8 @@ entry:
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
-  br i1 %NullCheck16, label %79, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
   %80 = load i64, i64 addrspace(1)* %78
@@ -2286,8 +2368,8 @@ entry:
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
-  br i1 %NullCheck18, label %92, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
   %93 = load i64, i64 addrspace(1)* %91
@@ -2304,8 +2386,8 @@ entry:
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
-  br i1 %NullCheck12, label %105, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = load i64, i64 addrspace(1)* %104
@@ -2320,8 +2402,8 @@ entry:
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
-  br i1 %NullCheck14, label %118, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
   %119 = load i64, i64 addrspace(1)* %117
@@ -2337,8 +2419,8 @@ entry:
 
 ; <label>:128                                     ; preds = %20
   %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
-  br i1 %NullCheck4, label %130, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %129, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %130
 
 ; <label>:130                                     ; preds = %128
   %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
@@ -2346,8 +2428,8 @@ entry:
   %133 = load i16, i16 addrspace(1)* %132, align 8
   %134 = zext i16 %133 to i32
   %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
-  br i1 %NullCheck6, label %136, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %135, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %136
 
 ; <label>:136                                     ; preds = %130
   %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
@@ -2360,8 +2442,8 @@ entry:
 
 ; <label>:143                                     ; preds = %136
   %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
-  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %144, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %145
 
 ; <label>:145                                     ; preds = %143
   %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
@@ -2369,8 +2451,8 @@ entry:
   %148 = load i16, i16 addrspace(1)* %147, align 8
   %149 = zext i16 %148 to i32
   %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %150, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %151
 
 ; <label>:151                                     ; preds = %145
   %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
@@ -2388,8 +2470,8 @@ entry:
 
 ; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
-  br i1 %NullCheck, label %163, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %ThrowNullRef, label %163
 
 ; <label>:163                                     ; preds = %161
   %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
@@ -2399,8 +2481,8 @@ entry:
 
 ; <label>:167                                     ; preds = %163
   %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
-  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %168, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %169
 
 ; <label>:169                                     ; preds = %167
   %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
@@ -2432,55 +2514,55 @@ ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %167
+ThrowNullRef2:                                    ; preds = %167
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %128
+ThrowNullRef4:                                    ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %130
+ThrowNullRef6:                                    ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %143
+ThrowNullRef8:                                    ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %145
+ThrowNullRef10:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %102
+ThrowNullRef12:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %105
+ThrowNullRef14:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %76
+ThrowNullRef16:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %79
+ThrowNullRef18:                                   ; preds = %79
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %50
+ThrowNullRef20:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %53
+ThrowNullRef22:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %24
+ThrowNullRef24:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %27
+ThrowNullRef26:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2503,15 +2585,15 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2519,16 +2601,16 @@ entry:
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
   store i32 %8, i32* %loc0
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
   %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
   store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
@@ -2546,16 +2628,16 @@ entry:
 
 ; <label>:23                                      ; preds = %64
   %24 = load i16*, i16** %loc3
-  %NullCheck12 = icmp ne i16* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i16* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
   store i32 %27, i32* %loc5
   %28 = load i16*, i16** %loc4
-  %NullCheck14 = icmp ne i16* %28, null
-  br i1 %NullCheck14, label %29, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %28, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = load i16, i16* %28, align 8
@@ -2620,15 +2702,15 @@ entry:
 
 ; <label>:67                                      ; preds = %64
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
-  br i1 %NullCheck8, label %69, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %68, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %69
 
 ; <label>:69                                      ; preds = %67
   %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
   %71 = load i32, i32 addrspace(1)* %70
   %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
-  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %73
 
 ; <label>:73                                      ; preds = %69
   %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
@@ -2645,31 +2727,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %67
+ThrowNullRef8:                                    ; preds = %67
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %69
+ThrowNullRef10:                                   ; preds = %69
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2710,14 +2792,14 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
   %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
@@ -2730,14 +2812,14 @@ entry:
 
 ; <label>:11                                      ; preds = %4
   %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
   %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
@@ -2749,14 +2831,14 @@ entry:
 
 ; <label>:22                                      ; preds = %16
   %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
   %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
-  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
-  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
@@ -2804,23 +2886,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2836,7 +2918,280 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[loadElem]
+Successfully read RuntimeType.IsAssignableFrom
+
+define i8 @RuntimeType.IsAssignableFrom(%System.RuntimeType addrspace(1)* %param0, %System.Type addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.RuntimeType addrspace(1)*
+  %arg1 = alloca %System.Type addrspace(1)*
+  %loc0 = alloca %System.RuntimeType addrspace(1)*
+  %loc1 = alloca %"System.Type[]" addrspace(1)*
+  %loc2 = alloca i32
+  store %System.RuntimeType addrspace(1)* %param0, %System.RuntimeType addrspace(1)** %this
+  store %System.Type addrspace(1)* %param1, %System.Type addrspace(1)** %arg1
+  %0 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %1 = icmp ne %System.Type addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i8 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %5 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %6 = bitcast %System.Type addrspace(1)* %4 to %System.Object addrspace(1)*
+  %7 = bitcast %System.RuntimeType addrspace(1)* %5 to %System.Object addrspace(1)*
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %6, %System.Object addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %3
+  ret i8 1
+
+; <label>:12                                      ; preds = %3
+  %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 152
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 32
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
+  %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
+  %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
+  store %System.RuntimeType addrspace(1)* %25, %System.RuntimeType addrspace(1)** %loc0
+  %26 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %27 = icmp eq %System.RuntimeType addrspace(1)* %26, null
+  br i1 %27, label %34, label %28
+
+; <label>:28                                      ; preds = %15
+  %29 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %30 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)*)*)(%System.RuntimeType addrspace(1)* %29, %System.RuntimeType addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+; <label>:34                                      ; preds = %15
+  %35 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %36 = call %System.Reflection.Emit.TypeBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Reflection.Emit.TypeBuilder addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %35)
+  %37 = icmp eq %System.Reflection.Emit.TypeBuilder addrspace(1)* %36, null
+  br i1 %37, label %139, label %38
+
+; <label>:38                                      ; preds = %34
+  %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %42
+
+; <label>:42                                      ; preds = %38
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 152
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 40
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
+  %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
+  %53 = zext i8 %52 to i32
+  %54 = icmp eq i32 %53, 0
+  br i1 %54, label %56, label %55
+
+; <label>:55                                      ; preds = %42
+  ret i8 1
+
+; <label>:56                                      ; preds = %42
+  %57 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %58 = bitcast %System.RuntimeType addrspace(1)* %57 to %System.Type addrspace(1)*
+  %59 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %58)
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %64 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.Type addrspace(1)* %63, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = bitcast %System.RuntimeType addrspace(1)* %64 to %System.Type addrspace(1)*
+  %67 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %63, %System.Type addrspace(1)* %66)
+  %68 = zext i8 %67 to i32
+  %69 = trunc i32 %68 to i8
+  ret i8 %69
+
+; <label>:70                                      ; preds = %56
+  %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
+  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %73
+
+; <label>:73                                      ; preds = %70
+  %74 = load i64, i64 addrspace(1)* %72
+  %75 = add i64 %74, 128
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = add i64 %77, 0
+  %79 = inttoptr i64 %78 to i64*
+  %80 = load i64, i64* %79
+  %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
+  %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
+  %83 = call i8 %82(%System.Type addrspace(1)* %81)
+  %84 = zext i8 %83 to i32
+  %85 = icmp eq i32 %84, 0
+  br i1 %85, label %139, label %86
+
+; <label>:86                                      ; preds = %73
+  %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
+  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %89
+
+; <label>:89                                      ; preds = %86
+  %90 = load i64, i64 addrspace(1)* %88
+  %91 = add i64 %90, 128
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = add i64 %93, 24
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
+  %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
+  %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
+  store %"System.Type[]" addrspace(1)* %99, %"System.Type[]" addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %129
+
+; <label>:100                                     ; preds = %132
+  %101 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %102 = load i32, i32* %loc2
+  %NullCheck11 = icmp eq %"System.Type[]" addrspace(1)* %101, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %103
+
+; <label>:103                                     ; preds = %100
+  %104 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 1
+  %105 = load i32, i32 addrspace(1)* %104
+  %106 = zext i32 %105 to i64
+  %107 = zext i32 %102 to i64
+  %BoundsCheck = icmp uge i64 %107, %106
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %108
+
+; <label>:108                                     ; preds = %103
+  %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
+  %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
+  %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
+  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %113
+
+; <label>:113                                     ; preds = %108
+  %114 = load i64, i64 addrspace(1)* %112
+  %115 = add i64 %114, 152
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = add i64 %117, 56
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
+  %123 = zext i8 %122 to i32
+  %124 = icmp ne i32 %123, 0
+  br i1 %124, label %126, label %125
+
+; <label>:125                                     ; preds = %113
+  ret i8 0
+
+; <label>:126                                     ; preds = %113
+  %127 = load i32, i32* %loc2
+  %128 = add i32 %127, 1
+  store i32 %128, i32* %loc2
+  br label %129
+
+; <label>:129                                     ; preds = %89, %126
+  %130 = load i32, i32* %loc2
+  %131 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %NullCheck9 = icmp eq %"System.Type[]" addrspace(1)* %131, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %132
+
+; <label>:132                                     ; preds = %129
+  %133 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %131, i32 0, i32 1
+  %134 = load i32, i32 addrspace(1)* %133
+  %135 = zext i32 %134 to i64
+  %136 = trunc i64 %135 to i32
+  %137 = icmp slt i32 %130, %136
+  br i1 %137, label %100, label %138
+
+; <label>:138                                     ; preds = %132
+  ret i8 1
+
+; <label>:139                                     ; preds = %34, %73
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %129
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %103
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -2893,7 +3248,7 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElem]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -2904,8 +3259,8 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -2997,8 +3352,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
@@ -3059,8 +3414,8 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -3087,8 +3442,8 @@ entry:
 
 ; <label>:17                                      ; preds = %5, %11
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
@@ -3097,8 +3452,8 @@ entry:
 
 ; <label>:22                                      ; preds = %1, %11
   %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
@@ -3109,11 +3464,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %17
+ThrowNullRef2:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %22
+ThrowNullRef4:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3167,15 +3522,15 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
   %15 = load i32, i32 addrspace(1)* %14
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
@@ -3198,7 +3553,7 @@ ThrowNullRef:                                     ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef2:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3232,8 +3587,8 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
@@ -3312,8 +3667,8 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -3327,8 +3682,8 @@ entry:
 ; <label>:5                                       ; preds = %43
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %7 = load i32, i32* %loc1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck6, label %8, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
@@ -3366,8 +3721,8 @@ entry:
 ; <label>:32                                      ; preds = %21, %25
   %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
   %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
-  br i1 %NullCheck8, label %35, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = trunc i32 %34 to i16
@@ -3380,8 +3735,8 @@ entry:
 ; <label>:40                                      ; preds = %1, %35
   %41 = load i32, i32* %loc1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
-  br i1 %NullCheck2, label %43, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %42, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
@@ -3392,8 +3747,8 @@ entry:
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
   %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
-  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
   %51 = load i64, i64 addrspace(1)* %49
@@ -3412,19 +3767,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %40
+ThrowNullRef2:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %47
+ThrowNullRef4:                                    ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %5
+ThrowNullRef6:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %32
+ThrowNullRef8:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3467,8 +3822,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
@@ -3492,11 +3847,391 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(i16* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store i16* %param0, i16** %arg0
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load i32, i32* %arg3
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %42, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %37, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg2
+  %13 = load i32, i32* %arg3
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %37, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %24 = load i32, i32* %arg2
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load i16*, i16** %arg0
+  %35 = load i32, i32* %arg3
+  %36 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %36, i16* %34, i32 %35)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:37                                      ; preds = %5, %16
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %39)
+  %41 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41, %System.String addrspace(1)* %38, %System.String addrspace(1)* %40)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41) #0
+  unreachable
+
+; <label>:42                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
-Failed to read StringBuilder.ToString[loadElemA]
+Successfully read StringBuilder.ToString
+
+define %System.String addrspace(1)* @StringBuilder.ToString(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i16*
+  %loc3 = alloca %"System.Char[]" addrspace(1)*
+  %loc4 = alloca i32
+  %loc5 = alloca i32
+  %loc6 = alloca i16 addrspace(1)*
+  %loc7 = alloca %System.String addrspace(1)*
+  %loc8 = alloca %"System.Char[]" addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %0)
+  %2 = icmp ne i32 %1, 0
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %4
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %6)
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %7)
+  store %System.String addrspace(1)* %8, %System.String addrspace(1)** %loc0
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.Text.StringBuilder addrspace(1)* %9, %System.Text.StringBuilder addrspace(1)** %loc1
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  store %System.String addrspace(1)* %10, %System.String addrspace(1)** %loc7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc7
+  %12 = ptrtoint %System.String addrspace(1)* %11 to i64
+  %13 = icmp eq i64 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %5
+  %15 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %16 = sext i32 %15 to i64
+  %17 = add i64 %12, %16
+  br label %18
+
+; <label>:18                                      ; preds = %5, %14
+  %19 = phi i64 [ %12, %5 ], [ %17, %14 ]
+  %20 = inttoptr i64 %19 to i16*
+  store i16* %20, i16** %loc2
+  br label %21
+
+; <label>:21                                      ; preds = %98, %18
+  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %22, null
+  br i1 %NullCheck, label %ThrowNullRef, label %23
+
+; <label>:23                                      ; preds = %21
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 3
+  %25 = load i32, i32 addrspace(1)* %24, align 8
+  %26 = icmp sle i32 %25, 0
+  br i1 %26, label %96, label %27
+
+; <label>:27                                      ; preds = %23
+  %28 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %28, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %29
+
+; <label>:29                                      ; preds = %27
+  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %28, i32 0, i32 1
+  %31 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %30, align 8
+  store %"System.Char[]" addrspace(1)* %31, %"System.Char[]" addrspace(1)** %loc3
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %33
+
+; <label>:33                                      ; preds = %29
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  store i32 %35, i32* %loc4
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  %39 = load i32, i32 addrspace(1)* %38, align 8
+  store i32 %39, i32* %loc5
+  %40 = load i32, i32* %loc5
+  %41 = load i32, i32* %loc4
+  %42 = add i32 %40, %41
+  %43 = zext i32 %42 to i64
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %45
+
+; <label>:45                                      ; preds = %37
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = sext i32 %47 to i64
+  %49 = icmp sgt i64 %43, %48
+  br i1 %49, label %91, label %50
+
+; <label>:50                                      ; preds = %45
+  %51 = load i32, i32* %loc5
+  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %52, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %53
+
+; <label>:53                                      ; preds = %50
+  %54 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %52, i32 0, i32 1
+  %55 = load i32, i32 addrspace(1)* %54
+  %56 = zext i32 %55 to i64
+  %57 = trunc i64 %56 to i32
+  %58 = icmp ugt i32 %51, %57
+  br i1 %58, label %91, label %59
+
+; <label>:59                                      ; preds = %53
+  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  store %"System.Char[]" addrspace(1)* %60, %"System.Char[]" addrspace(1)** %loc8
+  %61 = icmp eq %"System.Char[]" addrspace(1)* %60, null
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %63, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %64
+
+; <label>:64                                      ; preds = %62
+  %65 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %63, i32 0, i32 1
+  %66 = load i32, i32 addrspace(1)* %65
+  %67 = zext i32 %66 to i64
+  %68 = trunc i64 %67 to i32
+  %69 = icmp ne i32 %68, 0
+  br i1 %69, label %71, label %70
+
+; <label>:70                                      ; preds = %59, %64
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:71                                      ; preds = %64
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %73
+
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %BoundsCheck = icmp uge i64 0, %76
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %77
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %78, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:79                                      ; preds = %70, %77
+  %80 = load i16*, i16** %loc2
+  %81 = load i32, i32* %loc4
+  %82 = sext i32 %81 to i64
+  %83 = mul i64 %82, 2
+  %84 = bitcast i16* %80 to i8*
+  %85 = getelementptr inbounds i8, i8* %84, i64 %83
+  %86 = load i16 addrspace(1)*, i16 addrspace(1)** %loc6
+  %87 = ptrtoint i16 addrspace(1)* %86 to i64
+  %88 = load i32, i32* %loc5
+  %89 = bitcast i8* %85 to i16*
+  %90 = inttoptr i64 %87 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %89, i16* %90, i32 %88)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %96
+
+; <label>:91                                      ; preds = %45, %53
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %94 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %93)
+  %95 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95, %System.String addrspace(1)* %92, %System.String addrspace(1)* %94)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95) #0
+  unreachable
+
+; <label>:96                                      ; preds = %23, %79
+  %97 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %97, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %98
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %97, i32 0, i32 2
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  store %System.Text.StringBuilder addrspace(1)* %100, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %102 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %102, label %21, label %103
+
+; <label>:103                                     ; preds = %98
+  store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc7
+  %104 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  ret %System.String addrspace(1)* %104
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method StringBuilder::get_Length using LLILCJit
+Successfully read StringBuilder.get_Length
+
+define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
+Successfully read RuntimeHelpers.get_OffsetToStringData
+
+define i32 @RuntimeHelpers.get_OffsetToStringData() {
+entry:
+  ret i32 12
+}
+
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
 Successfully read CultureData.CreateCultureData
 
@@ -3514,23 +4249,23 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
   store i8 %4, i8 addrspace(1)* %6
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
@@ -3549,11 +4284,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3566,50 +4301,50 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
   store i32 -1, i32 addrspace(1)* %2
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
   store i32 -1, i32 addrspace(1)* %8
   %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
   store i32 -1, i32 addrspace(1)* %14
   %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
   store i32 -1, i32 addrspace(1)* %17
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
@@ -3623,27 +4358,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3675,7 +4410,136 @@ Failed to read Dictionary`2.Insert[non-const derefAddress]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
 Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
-Failed to read HashHelpers.GetPrime[loadElem]
+Successfully read HashHelpers.GetPrime
+
+define i32 @HashHelpers.GetPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %6, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5, %System.String addrspace(1)* %4)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5) #0
+  unreachable
+
+; <label>:6                                       ; preds = %entry
+  store i32 0, i32* %loc0
+  br label %29
+
+; <label>:7                                       ; preds = %35
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 1296
+  %10 = addrspacecast i8 addrspace(1)* %9 to %"System.Int32[]" addrspace(1)**
+  %11 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %10
+  %12 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Int32[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = zext i32 %15 to i64
+  %17 = zext i32 %12 to i64
+  %BoundsCheck = icmp uge i64 %17, %16
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 3, i32 %12
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  store i32 %20, i32* %loc1
+  %21 = load i32, i32* %loc1
+  %22 = load i32, i32* %arg0
+  %23 = icmp slt i32 %21, %22
+  br i1 %23, label %26, label %24
+
+; <label>:24                                      ; preds = %18
+  %25 = load i32, i32* %loc1
+  ret i32 %25
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %loc0
+  %28 = add i32 %27, 1
+  store i32 %28, i32* %loc0
+  br label %29
+
+; <label>:29                                      ; preds = %6, %26
+  %30 = load i32, i32* %loc0
+  %31 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %32 = getelementptr inbounds i8, i8 addrspace(1)* %31, i64 1296
+  %33 = addrspacecast i8 addrspace(1)* %32 to %"System.Int32[]" addrspace(1)**
+  %34 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %33
+  %NullCheck = icmp eq %"System.Int32[]" addrspace(1)* %34, null
+  br i1 %NullCheck, label %ThrowNullRef, label %35
+
+; <label>:35                                      ; preds = %29
+  %36 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %34, i32 0, i32 1
+  %37 = load i32, i32 addrspace(1)* %36
+  %38 = zext i32 %37 to i64
+  %39 = trunc i64 %38 to i32
+  %40 = icmp slt i32 %30, %39
+  br i1 %40, label %7, label %41
+
+; <label>:41                                      ; preds = %35
+  %42 = load i32, i32* %arg0
+  %43 = or i32 %42, 1
+  store i32 %43, i32* %loc2
+  br label %59
+
+; <label>:44                                      ; preds = %59
+  %45 = load i32, i32* %loc2
+  %46 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %45)
+  %47 = zext i8 %46 to i32
+  %48 = icmp eq i32 %47, 0
+  br i1 %48, label %56, label %49
+
+; <label>:49                                      ; preds = %44
+  %50 = load i32, i32* %loc2
+  %51 = sub i32 %50, 1
+  %52 = srem i32 %51, 101
+  %53 = icmp eq i32 %52, 0
+  br i1 %53, label %56, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = load i32, i32* %loc2
+  ret i32 %55
+
+; <label>:56                                      ; preds = %44, %49
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %57, 2
+  store i32 %58, i32* %loc2
+  br label %59
+
+; <label>:59                                      ; preds = %41, %56
+  %60 = load i32, i32* %loc2
+  %61 = icmp slt i32 %60, 2147483647
+  br i1 %61, label %44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load i32, i32* %arg0
+  ret i32 %63
+
+ThrowNullRef:                                     ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
 Successfully read GenericEqualityComparer`1.GetHashCode
 
@@ -3694,14 +4558,14 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
   %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load i64, i64 addrspace(1)* %7
@@ -3720,7 +4584,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3750,8 +4614,8 @@ entry:
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
@@ -3796,8 +4660,8 @@ entry:
   %35 = bitcast i16* %34 to i8*
   %36 = getelementptr inbounds i8, i8* %35, i64 2
   %37 = bitcast i8* %36 to i16*
-  %NullCheck4 = icmp ne i16* %37, null
-  br i1 %NullCheck4, label %38, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %37, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %38
 
 ; <label>:38                                      ; preds = %27
   %39 = load i16, i16* %37, align 8
@@ -3824,8 +4688,8 @@ entry:
 
 ; <label>:54                                      ; preds = %22, %43
   %55 = load i16*, i16** %loc4
-  %NullCheck2 = icmp ne i16* %55, null
-  br i1 %NullCheck2, label %56, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i16* %55, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %56
 
 ; <label>:56                                      ; preds = %54
   %57 = load i16, i16* %55, align 8
@@ -3850,11 +4714,11 @@ ThrowNullRef:                                     ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %54
+ThrowNullRef2:                                    ; preds = %54
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %27
+ThrowNullRef4:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3871,8 +4735,8 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -3907,8 +4771,8 @@ entry:
 
 ; <label>:26                                      ; preds = %19
   %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
-  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %28
 
 ; <label>:28                                      ; preds = %26
   %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
@@ -3920,7 +4784,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3972,8 +4836,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
@@ -3984,26 +4848,26 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
-  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
@@ -4014,8 +4878,8 @@ entry:
 ; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
@@ -4024,8 +4888,8 @@ entry:
 
 ; <label>:25                                      ; preds = %1, %16, %23
   %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
-  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
@@ -4036,27 +4900,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %20
+ThrowNullRef10:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4069,8 +4933,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -4081,8 +4945,8 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
@@ -4091,8 +4955,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1, %8
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
@@ -4103,11 +4967,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4128,24 +4992,24 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   store i32 %3, i32* %loc0
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
   %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
   store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck4, label %9, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
@@ -4164,15 +5028,15 @@ entry:
 ; <label>:18                                      ; preds = %70
   %19 = load i16*, i16** %loc3
   %20 = bitcast i16* %19 to i64*
-  %NullCheck10 = icmp ne i64* %20, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %20, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = load i64, i64* %20, align 8
   %23 = load i16*, i16** %loc4
   %24 = bitcast i16* %23 to i64*
-  %NullCheck12 = icmp ne i64* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = load i64, i64* %24, align 8
@@ -4188,8 +5052,8 @@ entry:
   %31 = bitcast i16* %30 to i8*
   %32 = getelementptr inbounds i8, i8* %31, i64 8
   %33 = bitcast i8* %32 to i64*
-  %NullCheck14 = icmp ne i64* %33, null
-  br i1 %NullCheck14, label %34, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = load i64, i64* %33, align 8
@@ -4197,8 +5061,8 @@ entry:
   %37 = bitcast i16* %36 to i8*
   %38 = getelementptr inbounds i8, i8* %37, i64 8
   %39 = bitcast i8* %38 to i64*
-  %NullCheck16 = icmp ne i64* %39, null
-  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %40
 
 ; <label>:40                                      ; preds = %34
   %41 = load i64, i64* %39, align 8
@@ -4214,8 +5078,8 @@ entry:
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %NullCheck18 = icmp ne i64* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = load i64, i64* %48, align 8
@@ -4223,8 +5087,8 @@ entry:
   %52 = bitcast i16* %51 to i8*
   %53 = getelementptr inbounds i8, i8* %52, i64 16
   %54 = bitcast i8* %53 to i64*
-  %NullCheck20 = icmp ne i64* %54, null
-  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64* %54, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %55
 
 ; <label>:55                                      ; preds = %49
   %56 = load i64, i64* %54, align 8
@@ -4262,15 +5126,15 @@ entry:
 ; <label>:74                                      ; preds = %95
   %75 = load i16*, i16** %loc3
   %76 = bitcast i16* %75 to i32*
-  %NullCheck6 = icmp ne i32* %76, null
-  br i1 %NullCheck6, label %77, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32* %76, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %77
 
 ; <label>:77                                      ; preds = %74
   %78 = load i32, i32* %76, align 8
   %79 = load i16*, i16** %loc4
   %80 = bitcast i16* %79 to i32*
-  %NullCheck8 = icmp ne i32* %80, null
-  br i1 %NullCheck8, label %81, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i32* %80, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %81
 
 ; <label>:81                                      ; preds = %77
   %82 = load i32, i32* %80, align 8
@@ -4318,43 +5182,43 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %74
+ThrowNullRef6:                                    ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %77
+ThrowNullRef8:                                    ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %29
+ThrowNullRef14:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %34
+ThrowNullRef16:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4376,8 +5240,8 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load i64, i64 addrspace(1)* %4
@@ -4389,8 +5253,8 @@ entry:
   %12 = load i64, i64* %11
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %5
   %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
@@ -4399,8 +5263,8 @@ entry:
   %18 = load i8, i8* %arg2
   %19 = zext i8 %18 to i32
   %20 = trunc i32 %19 to i8
-  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %15
   %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
@@ -4411,11 +5275,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4442,8 +5306,8 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
@@ -4466,16 +5330,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
   %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = load i64, i64 addrspace(1)* %19
@@ -4500,8 +5364,8 @@ entry:
 ; <label>:35                                      ; preds = %30
   %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
@@ -4514,8 +5378,8 @@ entry:
 
 ; <label>:42                                      ; preds = %1, %38
   %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
-  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
@@ -4526,19 +5390,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %35
+ThrowNullRef2:                                    ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %42
+ThrowNullRef8:                                    ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4551,14 +5415,14 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
@@ -4570,7 +5434,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4583,8 +5447,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
@@ -4613,51 +5477,51 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
   %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
   %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
   %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
   %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
-  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
   store i64 %21, i64 addrspace(1)* %23
   %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %25 = load i64, i64* %loc0
-  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
@@ -4668,27 +5532,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %22
+ThrowNullRef12:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4701,8 +5565,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
@@ -4713,19 +5577,19 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
@@ -4734,8 +5598,8 @@ entry:
 
 ; <label>:15                                      ; preds = %1, %13
   %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
@@ -4746,19 +5610,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %15
+ThrowNullRef8:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4771,8 +5635,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -4831,8 +5695,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
@@ -4882,8 +5746,8 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
-  br i1 %NullCheck, label %17, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %ThrowNullRef, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
@@ -4894,15 +5758,15 @@ entry:
 
 ; <label>:22                                      ; preds = %17
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
-  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
   %26 = load i32, i32 addrspace(1)* %25
   %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
-  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %27, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
@@ -4925,8 +5789,8 @@ entry:
 ; <label>:40                                      ; preds = %17
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
-  br i1 %NullCheck6, label %43, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %41, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
@@ -4938,34 +5802,17 @@ ThrowNullRef:                                     ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %24
+ThrowNullRef4:                                    ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %40
+ThrowNullRef6:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
-}
-
-INFO:  jitting method Object::ReferenceEquals using LLILCJit
-Successfully read Object.ReferenceEquals
-
-define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
-entry:
-  %arg0 = alloca %System.Object addrspace(1)*
-  %arg1 = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
-  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
-  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = icmp eq %System.Object addrspace(1)* %0, %1
-  %3 = sext i1 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
 }
 
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
@@ -4978,21 +5825,21 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
   %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
-  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
@@ -5007,28 +5854,28 @@ entry:
 ; <label>:13                                      ; preds = %8, %12
   %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
   %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
   %21 = load i32, i32 addrspace(1)* %20, align 8
   %22 = add i32 %21, 1
-  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
   store i32 %22, i32 addrspace(1)* %24
   %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
@@ -5039,27 +5886,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5077,7 +5924,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::Setup using LLILCJit
-Failed to read AppDomain.Setup[loadElem]
+Failed to read AppDomain.Setup[unbox]
 INFO:  jitting method Thread::GetDomain using LLILCJit
 Successfully read Thread.GetDomain
 
@@ -5108,8 +5955,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
@@ -5122,14 +5969,14 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
   %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
@@ -5141,11 +5988,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5173,8 +6020,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -5189,7 +6036,328 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
 Failed to read KeyCollection.System.Collections.Generic.IEnumerable<TKey>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Successfully read Enumerator.MoveNext
+
+define i8 @Enumerator.MoveNext(%"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.RuntimeTypeHandle* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*
+  %"$TypeArg" = alloca %System.RuntimeTypeHandle*
+  store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
+  %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 8
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %76, label %12
+
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
+  br label %76
+
+; <label>:13                                      ; preds = %85
+  %14 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck19 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %15
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, i32 0, i32 0
+  %17 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %16, align 8
+  %NullCheck21 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, i32 0, i32 2
+  %20 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %19, align 8
+  %21 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck23 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %22
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, i32 0, i32 2
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %NullCheck25 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 3, i32 %24
+  %NullCheck27 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %32
+
+; <label>:32                                      ; preds = %30
+  %33 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, i32 0, i32 2
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = icmp slt i32 %34, 0
+  br i1 %35, label %68, label %36
+
+; <label>:36                                      ; preds = %32
+  %37 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %38 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck29 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %39
+
+; <label>:39                                      ; preds = %36
+  %40 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, i32 0, i32 0
+  %41 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %40, align 8
+  %NullCheck31 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, i32 0, i32 2
+  %44 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %43, align 8
+  %45 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck33 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, i32 0, i32 2
+  %48 = load i32, i32 addrspace(1)* %47, align 8
+  %NullCheck35 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %49
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = zext i32 %51 to i64
+  %53 = zext i32 %48 to i64
+  %BoundsCheck37 = icmp uge i64 %53, %52
+  br i1 %BoundsCheck37, label %ThrowIndexOutOfRange38, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 3, i32 %48
+  %NullCheck39 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %56
+
+; <label>:56                                      ; preds = %54
+  %57 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, i32 0, i32 0
+  %58 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck41 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %59
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %60, %System.__Canon addrspace(1)* %58)
+  %61 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck43 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  %64 = load i32, i32 addrspace(1)* %63, align 8
+  %65 = add i32 %64, 1
+  %NullCheck45 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  store i32 %65, i32 addrspace(1)* %67
+  ret i8 1
+
+; <label>:68                                      ; preds = %32
+  %69 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck47 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %73 = add i32 %72, 1
+  %NullCheck49 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %74
+
+; <label>:74                                      ; preds = %70
+  %75 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  store i32 %73, i32 addrspace(1)* %75
+  br label %76
+
+; <label>:76                                      ; preds = %8, %12, %74
+  %77 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %78
+
+; <label>:78                                      ; preds = %76
+  %79 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, i32 0, i32 2
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck7 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %82
+
+; <label>:82                                      ; preds = %78
+  %83 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, i32 0, i32 0
+  %84 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %83, align 8
+  %NullCheck9 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %85
+
+; <label>:85                                      ; preds = %82
+  %86 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, i32 0, i32 7
+  %87 = load i32, i32 addrspace(1)* %86, align 8
+  %88 = icmp ult i32 %80, %87
+  br i1 %88, label %13, label %89
+
+; <label>:89                                      ; preds = %85
+  %90 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %91 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck11 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %92
+
+; <label>:92                                      ; preds = %89
+  %93 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, i32 0, i32 0
+  %94 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck13 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %95
+
+; <label>:95                                      ; preds = %92
+  %96 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, i32 0, i32 7
+  %97 = load i32, i32 addrspace(1)* %96, align 8
+  %98 = add i32 %97, 1
+  %NullCheck15 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %99
+
+; <label>:99                                      ; preds = %95
+  %100 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, i32 0, i32 2
+  store i32 %98, i32 addrspace(1)* %100
+  %101 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck17 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %102
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %103, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %92
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef22:                                   ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef24:                                   ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef26:                                   ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef28:                                   ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef30:                                   ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef32:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef34:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef36:                                   ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange38:                           ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef40:                                   ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef42:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef44:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef46:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef48:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef50:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -5200,8 +6368,8 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -5232,9 +6400,9 @@ Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
 Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
-Failed to read String.MakeSeparatorList[loadElemA]
+Failed to read String.MakeSeparatorList[storeElem]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
-Failed to read String.InternalSplitKeepEmptyEntries[loadElem]
+Failed to read String.InternalSplitKeepEmptyEntries[storeElem]
 INFO:  jitting method Path::IsRelative using LLILCJit
 Successfully read Path.IsRelative
 
@@ -5243,8 +6411,8 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -5254,8 +6422,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
@@ -5271,8 +6439,8 @@ entry:
 
 ; <label>:17                                      ; preds = %7
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
@@ -5288,8 +6456,8 @@ entry:
 
 ; <label>:29                                      ; preds = %19
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %31
 
 ; <label>:31                                      ; preds = %29
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
@@ -5300,8 +6468,8 @@ entry:
 
 ; <label>:36                                      ; preds = %31
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
-  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %37, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
@@ -5312,8 +6480,8 @@ entry:
 
 ; <label>:43                                      ; preds = %31, %38
   %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
-  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %45
 
 ; <label>:45                                      ; preds = %43
   %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
@@ -5324,8 +6492,8 @@ entry:
 
 ; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %50
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
@@ -5336,8 +6504,8 @@ entry:
 
 ; <label>:57                                      ; preds = %1, %7, %19, %45, %52
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
-  br i1 %NullCheck14, label %59, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %59
 
 ; <label>:59                                      ; preds = %57
   %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
@@ -5347,8 +6515,8 @@ entry:
 
 ; <label>:63                                      ; preds = %59
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
@@ -5359,8 +6527,8 @@ entry:
 
 ; <label>:70                                      ; preds = %65
   %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
-  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.String addrspace(1)* %71, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %72
 
 ; <label>:72                                      ; preds = %70
   %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
@@ -5379,39 +6547,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %17
+ThrowNullRef4:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %29
+ThrowNullRef6:                                    ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %36
+ThrowNullRef8:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %43
+ThrowNullRef10:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %50
+ThrowNullRef12:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %57
+ThrowNullRef14:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %63
+ThrowNullRef16:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %70
+ThrowNullRef18:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5419,7 +6587,293 @@ ThrowNullRef17:                                   ; preds = %70
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
-Failed to read String.TrimHelper[loadElem]
+Successfully read String.TrimHelper
+
+define %System.String addrspace(1)* @String.TrimHelper(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i16
+  %loc4 = alloca i32
+  %loc5 = alloca i16
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = sub i32 %3, 1
+  store i32 %4, i32* %loc0
+  store i32 0, i32* %loc1
+  %5 = load i32, i32* %arg2
+  %6 = icmp eq i32 %5, 1
+  br i1 %6, label %62, label %7
+
+; <label>:7                                       ; preds = %1
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:8                                       ; preds = %58
+  store i32 0, i32* %loc2
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load i32, i32* %loc1
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2, i32 %10
+  %13 = load i16, i16 addrspace(1)* %12
+  %14 = zext i16 %13 to i32
+  %15 = trunc i32 %14 to i16
+  store i16 %15, i16* %loc3
+  store i32 0, i32* %loc2
+  br label %34
+
+; <label>:16                                      ; preds = %37
+  %17 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %18 = load i32, i32* %loc2
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %17, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %19
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = zext i32 %18 to i64
+  %BoundsCheck = icmp uge i64 %23, %22
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %24
+
+; <label>:24                                      ; preds = %19
+  %25 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 3, i32 %18
+  %26 = load i16, i16 addrspace(1)* %25, align 8
+  %27 = zext i16 %26 to i32
+  %28 = load i16, i16* %loc3
+  %29 = zext i16 %28 to i32
+  %30 = icmp eq i32 %27, %29
+  br i1 %30, label %43, label %31
+
+; <label>:31                                      ; preds = %24
+  %32 = load i32, i32* %loc2
+  %33 = add i32 %32, 1
+  store i32 %33, i32* %loc2
+  br label %34
+
+; <label>:34                                      ; preds = %11, %31
+  %35 = load i32, i32* %loc2
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = icmp slt i32 %35, %41
+  br i1 %42, label %16, label %43
+
+; <label>:43                                      ; preds = %24, %37
+  %44 = load i32, i32* %loc2
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %45, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp eq i32 %44, %50
+  br i1 %51, label %62, label %52
+
+; <label>:52                                      ; preds = %46
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %7, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %57, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %58
+
+; <label>:58                                      ; preds = %55
+  %59 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %60 = load i32, i32 addrspace(1)* %59
+  %61 = icmp slt i32 %56, %60
+  br i1 %61, label %8, label %62
+
+; <label>:62                                      ; preds = %1, %46, %58
+  %63 = load i32, i32* %arg2
+  %64 = icmp eq i32 %63, 0
+  br i1 %64, label %122, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %66, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %67
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %66, i32 0, i32 1
+  %69 = load i32, i32 addrspace(1)* %68
+  %70 = sub i32 %69, 1
+  store i32 %70, i32* %loc0
+  br label %118
+
+; <label>:71                                      ; preds = %118
+  store i32 0, i32* %loc4
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %73 = load i32, i32* %loc0
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %74
+
+; <label>:74                                      ; preds = %71
+  %75 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 2, i32 %73
+  %76 = load i16, i16 addrspace(1)* %75
+  %77 = zext i16 %76 to i32
+  %78 = trunc i32 %77 to i16
+  store i16 %78, i16* %loc5
+  store i32 0, i32* %loc4
+  br label %97
+
+; <label>:79                                      ; preds = %100
+  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %81 = load i32, i32* %loc4
+  %NullCheck19 = icmp eq %"System.Char[]" addrspace(1)* %80, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
+
+; <label>:82                                      ; preds = %79
+  %83 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 1
+  %84 = load i32, i32 addrspace(1)* %83
+  %85 = zext i32 %84 to i64
+  %86 = zext i32 %81 to i64
+  %BoundsCheck21 = icmp uge i64 %86, %85
+  br i1 %BoundsCheck21, label %ThrowIndexOutOfRange22, label %87
+
+; <label>:87                                      ; preds = %82
+  %88 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 3, i32 %81
+  %89 = load i16, i16 addrspace(1)* %88, align 8
+  %90 = zext i16 %89 to i32
+  %91 = load i16, i16* %loc5
+  %92 = zext i16 %91 to i32
+  %93 = icmp eq i32 %90, %92
+  br i1 %93, label %106, label %94
+
+; <label>:94                                      ; preds = %87
+  %95 = load i32, i32* %loc4
+  %96 = add i32 %95, 1
+  store i32 %96, i32* %loc4
+  br label %97
+
+; <label>:97                                      ; preds = %74, %94
+  %98 = load i32, i32* %loc4
+  %99 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck15 = icmp eq %"System.Char[]" addrspace(1)* %99, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %100
+
+; <label>:100                                     ; preds = %97
+  %101 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %99, i32 0, i32 1
+  %102 = load i32, i32 addrspace(1)* %101
+  %103 = zext i32 %102 to i64
+  %104 = trunc i64 %103 to i32
+  %105 = icmp slt i32 %98, %104
+  br i1 %105, label %79, label %106
+
+; <label>:106                                     ; preds = %87, %100
+  %107 = load i32, i32* %loc4
+  %108 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck17 = icmp eq %"System.Char[]" addrspace(1)* %108, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %109
+
+; <label>:109                                     ; preds = %106
+  %110 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %108, i32 0, i32 1
+  %111 = load i32, i32 addrspace(1)* %110
+  %112 = zext i32 %111 to i64
+  %113 = trunc i64 %112 to i32
+  %114 = icmp eq i32 %107, %113
+  br i1 %114, label %122, label %115
+
+; <label>:115                                     ; preds = %109
+  %116 = load i32, i32* %loc0
+  %117 = sub i32 %116, 1
+  store i32 %117, i32* %loc0
+  br label %118
+
+; <label>:118                                     ; preds = %67, %115
+  %119 = load i32, i32* %loc0
+  %120 = load i32, i32* %loc1
+  %121 = icmp sge i32 %119, %120
+  br i1 %121, label %71, label %122
+
+; <label>:122                                     ; preds = %62, %109, %118
+  %123 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %124 = load i32, i32* %loc1
+  %125 = load i32, i32* %loc0
+  %126 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %123, i32 %124, i32 %125)
+  ret %System.String addrspace(1)* %126
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %97
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange22:                           ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
 Successfully read String.CreateTrimmedString
 
@@ -5439,8 +6893,8 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
@@ -5535,8 +6989,8 @@ entry:
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i64 2872
   %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
   %8 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %7
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %3
   %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
@@ -5553,8 +7007,8 @@ entry:
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 2864
   %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
   %21 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %20
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
-  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %22
 
 ; <label>:22                                      ; preds = %16
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
@@ -5569,7 +7023,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %16
+ThrowNullRef2:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5586,8 +7040,8 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5613,8 +7067,8 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
@@ -5632,8 +7086,8 @@ entry:
 
 ; <label>:12                                      ; preds = %4
   %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
@@ -5644,8 +7098,8 @@ entry:
 
 ; <label>:19                                      ; preds = %14
   %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %19
   %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
@@ -5660,21 +7114,21 @@ entry:
   %31 = zext i16 %30 to i32
   %32 = bitcast i8* %29 to i16*
   %33 = trunc i32 %31 to i16
-  %NullCheck6 = icmp ne i16* %32, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i16* %32, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %21
   store i16 %33, i16* %32, align 8
   %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %36
 
 ; <label>:36                                      ; preds = %34
   %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
   %38 = load i32, i32 addrspace(1)* %37, align 8
   %39 = add i32 %38, 1
-  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %40
 
 ; <label>:40                                      ; preds = %36
   %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
@@ -5683,16 +7137,16 @@ entry:
 
 ; <label>:42                                      ; preds = %14
   %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
-  br i1 %NullCheck12, label %44, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
   %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
   %47 = load i16, i16* %arg1
   %48 = zext i16 %47 to i32
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = trunc i32 %48 to i16
@@ -5703,31 +7157,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %19
+ThrowNullRef4:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %21
+ThrowNullRef6:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %36
+ThrowNullRef10:                                   ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %42
+ThrowNullRef12:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %44
+ThrowNullRef14:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5740,8 +7194,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -5752,8 +7206,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
@@ -5762,14 +7216,14 @@ entry:
 
 ; <label>:11                                      ; preds = %1
   %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
@@ -5779,15 +7233,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5808,8 +7262,8 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5822,8 +7276,8 @@ entry:
 
 ; <label>:8                                       ; preds = %3
   %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
@@ -5842,15 +7296,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
-  br i1 %NullCheck4, label %22, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
   %24 = load i16*, i16* addrspace(1)* %23, align 8
   %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %25, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
@@ -5859,8 +7313,8 @@ entry:
   store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
@@ -5874,8 +7328,8 @@ entry:
 
 ; <label>:37                                      ; preds = %65
   %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %37
   %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
@@ -5886,16 +7340,16 @@ entry:
   %45 = bitcast i16* %41 to i8*
   %46 = getelementptr inbounds i8, i8* %45, i64 %44
   %47 = bitcast i8* %46 to i16*
-  %NullCheck14 = icmp ne i16* %47, null
-  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %47, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %48
 
 ; <label>:48                                      ; preds = %39
   %49 = load i16, i16* %47, align 8
   %50 = zext i16 %49 to i32
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %52 = load i32, i32* %loc1
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %53
 
 ; <label>:53                                      ; preds = %48
   %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
@@ -5916,8 +7370,8 @@ entry:
 ; <label>:62                                      ; preds = %36, %59
   %63 = load i32, i32* %loc1
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck10, label %65, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %65
 
 ; <label>:65                                      ; preds = %62
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
@@ -5936,15 +7390,15 @@ entry:
 
 ; <label>:74                                      ; preds = %70
   %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
-  br i1 %NullCheck18, label %76, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %76
 
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
   %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
-  br i1 %NullCheck20, label %80, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
   %81 = load i64, i64 addrspace(1)* %79
@@ -5958,8 +7412,8 @@ entry:
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
   %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
-  br i1 %NullCheck22, label %92, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.String addrspace(1)* %90, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %92
 
 ; <label>:92                                      ; preds = %80
   %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
@@ -5969,15 +7423,15 @@ entry:
 
 ; <label>:96                                      ; preds = %70
   %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
-  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %98
 
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
   %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
-  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
   %103 = load i64, i64 addrspace(1)* %101
@@ -5991,8 +7445,8 @@ entry:
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
   %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
-  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.String addrspace(1)* %112, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %114
 
 ; <label>:114                                     ; preds = %102
   %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
@@ -6004,59 +7458,59 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %20
+ThrowNullRef4:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %22
+ThrowNullRef6:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %26
+ThrowNullRef8:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %62
+ThrowNullRef10:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %48
+ThrowNullRef16:                                   ; preds = %48
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %74
+ThrowNullRef18:                                   ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %76
+ThrowNullRef20:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %80
+ThrowNullRef22:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %96
+ThrowNullRef24:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %98
+ThrowNullRef26:                                   ; preds = %98
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %102
+ThrowNullRef28:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6069,15 +7523,15 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
   %3 = load i16*, i16* addrspace(1)* %2, align 8
   %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
@@ -6087,8 +7541,8 @@ entry:
   %10 = bitcast i16* %3 to i8*
   %11 = getelementptr inbounds i8, i8* %10, i64 %9
   %12 = bitcast i8* %11 to i16*
-  %NullCheck4 = icmp ne i16* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %5
   store i16 0, i16* %12, align 8
@@ -6098,11 +7552,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6119,8 +7573,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -6131,8 +7585,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
@@ -6144,15 +7598,15 @@ entry:
 
 ; <label>:14                                      ; preds = %1
   %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
   %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
   %21 = load i64, i64 addrspace(1)* %19
@@ -6171,15 +7625,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %14
+ThrowNullRef4:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %16
+ThrowNullRef6:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6302,14 +7756,6 @@ entry:
   ret %System.String addrspace(1)* %57
 }
 
-INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
-Successfully read RuntimeHelpers.get_OffsetToStringData
-
-define i32 @RuntimeHelpers.get_OffsetToStringData() {
-entry:
-  ret i32 12
-}
-
 INFO:  jitting method String::Equals using LLILCJit
 Successfully read String.Equals
 
@@ -6381,8 +7827,8 @@ entry:
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
-  br i1 %NullCheck24, label %29, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
   %30 = load i64, i64 addrspace(1)* %28
@@ -6397,8 +7843,8 @@ entry:
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
-  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
   %43 = load i64, i64 addrspace(1)* %41
@@ -6418,8 +7864,8 @@ entry:
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
   %59 = load i64, i64 addrspace(1)* %57
@@ -6434,8 +7880,8 @@ entry:
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck22, label %71, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
   %72 = load i64, i64 addrspace(1)* %70
@@ -6455,8 +7901,8 @@ entry:
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
-  br i1 %NullCheck16, label %87, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = load i64, i64 addrspace(1)* %86
@@ -6471,8 +7917,8 @@ entry:
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck18, label %100, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
   %101 = load i64, i64 addrspace(1)* %99
@@ -6492,8 +7938,8 @@ entry:
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
-  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
   %117 = load i64, i64 addrspace(1)* %115
@@ -6508,8 +7954,8 @@ entry:
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
-  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
   %130 = load i64, i64 addrspace(1)* %128
@@ -6528,15 +7974,15 @@ entry:
 
 ; <label>:142                                     ; preds = %22
   %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
-  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %143, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %144
 
 ; <label>:144                                     ; preds = %142
   %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
   %146 = load i32, i32 addrspace(1)* %145
   %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
-  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %147, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %148
 
 ; <label>:148                                     ; preds = %144
   %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
@@ -6557,15 +8003,15 @@ entry:
 
 ; <label>:159                                     ; preds = %22
   %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
-  br i1 %NullCheck, label %161, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %ThrowNullRef, label %161
 
 ; <label>:161                                     ; preds = %159
   %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
   %163 = load i32, i32 addrspace(1)* %162
   %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
-  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %164, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %165
 
 ; <label>:165                                     ; preds = %161
   %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
@@ -6578,8 +8024,8 @@ entry:
 
 ; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
-  br i1 %NullCheck4, label %172, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %171, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %172
 
 ; <label>:172                                     ; preds = %170
   %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
@@ -6589,8 +8035,8 @@ entry:
 
 ; <label>:176                                     ; preds = %172
   %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
-  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %177, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %178
 
 ; <label>:178                                     ; preds = %176
   %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
@@ -6629,55 +8075,55 @@ ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %161
+ThrowNullRef2:                                    ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %170
+ThrowNullRef4:                                    ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %176
+ThrowNullRef6:                                    ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %142
+ThrowNullRef8:                                    ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %144
+ThrowNullRef10:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %113
+ThrowNullRef12:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %116
+ThrowNullRef14:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %84
+ThrowNullRef16:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %87
+ThrowNullRef18:                                   ; preds = %87
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %55
+ThrowNullRef20:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %58
+ThrowNullRef22:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %26
+ThrowNullRef24:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %29
+ThrowNullRef26:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,8 +8161,8 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck, label %14, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %ThrowNullRef, label %14
 
 ; <label>:14                                      ; preds = %8
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
@@ -6760,8 +8206,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
@@ -6770,14 +8216,14 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32, i32* %loc0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %10
   %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
   %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
@@ -6790,15 +8236,15 @@ entry:
 ; <label>:25                                      ; preds = %19
   %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
-  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
   %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
@@ -6807,8 +8253,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %37 = load i32, i32* %loc0
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %38, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %38
 
 ; <label>:38                                      ; preds = %32
   %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
@@ -6817,14 +8263,14 @@ entry:
 
 ; <label>:40                                      ; preds = %19
   %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %40
   %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
   %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
-  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
-  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
@@ -6832,8 +8278,8 @@ entry:
   %48 = zext i32 %47 to i64
   %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
-  br i1 %NullCheck16, label %51, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %51
 
 ; <label>:51                                      ; preds = %45
   %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
@@ -6847,15 +8293,15 @@ entry:
 ; <label>:57                                      ; preds = %51
   %58 = load i16*, i16** %arg1
   %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
-  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %60
 
 ; <label>:60                                      ; preds = %57
   %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
   %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
-  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %64
 
 ; <label>:64                                      ; preds = %60
   %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
@@ -6864,22 +8310,22 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
   %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
-  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %70
 
 ; <label>:70                                      ; preds = %64
   %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
   %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
-  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
-  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
   %75 = load i32, i32 addrspace(1)* %74
   %76 = zext i32 %75 to i64
   %77 = trunc i64 %76 to i32
-  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
-  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %78
 
 ; <label>:78                                      ; preds = %73
   %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
@@ -6901,8 +8347,8 @@ entry:
   %90 = bitcast i16* %86 to i8*
   %91 = getelementptr inbounds i8, i8* %90, i64 %89
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %93
 
 ; <label>:93                                      ; preds = %80
   %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
@@ -6912,8 +8358,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %99 = load i32, i32* %loc2
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %100
 
 ; <label>:100                                     ; preds = %93
   %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
@@ -6928,63 +8374,63 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %25
+ThrowNullRef6:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %32
+ThrowNullRef10:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %40
+ThrowNullRef12:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %45
+ThrowNullRef16:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %57
+ThrowNullRef18:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %60
+ThrowNullRef20:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %64
+ThrowNullRef22:                                   ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %70
+ThrowNullRef24:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %73
+ThrowNullRef26:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %80
+ThrowNullRef28:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %93
+ThrowNullRef30:                                   ; preds = %93
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7004,8 +8450,8 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
@@ -7033,43 +8479,43 @@ entry:
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %14
   %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
   %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   %28 = load i32, i32 addrspace(1)* %27, align 8
   %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
-  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %30
 
 ; <label>:30                                      ; preds = %26
   %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
   %32 = load i32, i32 addrspace(1)* %31, align 8
   %33 = add i32 %28, %32
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %34
 
 ; <label>:34                                      ; preds = %30
   %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   store i32 %33, i32 addrspace(1)* %35
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
   store i32 0, i32 addrspace(1)* %38
   %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %40
 
 ; <label>:40                                      ; preds = %37
   %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
@@ -7082,8 +8528,8 @@ entry:
 
 ; <label>:47                                      ; preds = %40
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
@@ -7098,8 +8544,8 @@ entry:
   %54 = load i32, i32* %loc0
   %55 = sext i32 %54 to i64
   %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
-  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %57
 
 ; <label>:57                                      ; preds = %52
   %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
@@ -7110,68 +8556,35 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %14
+ThrowNullRef2:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %23
+ThrowNullRef4:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %26
+ThrowNullRef6:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %30
+ThrowNullRef8:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %34
+ThrowNullRef10:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %47
+ThrowNullRef14:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %52
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-}
-
-INFO:  jitting method StringBuilder::get_Length using LLILCJit
-Successfully read StringBuilder.get_Length
-
-define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.StringBuilder addrspace(1)*
-  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
-  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
-
-; <label>:1                                       ; preds = %entry
-  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %3 = load i32, i32 addrspace(1)* %2, align 8
-  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
-
-; <label>:5                                       ; preds = %1
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = add i32 %3, %7
-  ret i32 %8
-
-ThrowNullRef:                                     ; preds = %entry
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef16:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7213,70 +8626,70 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
   %6 = load i32, i32 addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
   store i32 %6, i32 addrspace(1)* %8
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
   %13 = load i32, i32 addrspace(1)* %12, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
   store i32 %13, i32 addrspace(1)* %15
   %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
-  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %18
 
 ; <label>:18                                      ; preds = %14
   %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
   %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
   %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
   %34 = load i32, i32 addrspace(1)* %33, align 8
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
-  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
@@ -7287,39 +8700,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %28
+ThrowNullRef16:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %32
+ThrowNullRef18:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7455,13 +8868,13 @@ entry:
 ; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
@@ -7477,16 +8890,16 @@ entry:
 
 ; <label>:18                                      ; preds = %15
   %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
   store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
   %22 = load i32, i32* %loc0
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %24
 
 ; <label>:24                                      ; preds = %20
   %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
@@ -7498,13 +8911,13 @@ entry:
 ; <label>:28                                      ; preds = %15, %24
   %29 = load i32, i32* %arg1
   %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %31
   %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
@@ -7517,20 +8930,20 @@ entry:
   %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
-  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
   %46 = load i32, i32 addrspace(1)* %45, align 8
   %47 = sub i32 %40, %46
-  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
-  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i32 addrspace(1)* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %48
 
 ; <label>:48                                      ; preds = %44
   store i32 %47, i32 addrspace(1)* %39, align 8
@@ -7538,21 +8951,21 @@ entry:
 
 ; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
-  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %51
 
 ; <label>:51                                      ; preds = %49
   %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %53
 
 ; <label>:53                                      ; preds = %51
   %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
   %55 = load i32, i32 addrspace(1)* %54, align 8
   %56 = load i32, i32* %arg2
   %57 = sub i32 %55, %56
-  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %58
 
 ; <label>:58                                      ; preds = %53
   %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
@@ -7562,13 +8975,13 @@ entry:
 ; <label>:60                                      ; preds = %33, %58
   %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
   %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
-  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %63
 
 ; <label>:63                                      ; preds = %60
   %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
-  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
-  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
@@ -7578,15 +8991,15 @@ entry:
 
 ; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
-  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i32 addrspace(1)* %69, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %70
 
 ; <label>:70                                      ; preds = %68
   %71 = load i32, i32 addrspace(1)* %69, align 8
   store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
-  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
@@ -7596,8 +9009,8 @@ entry:
   store i32 %77, i32* %loc4
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
-  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %80
 
 ; <label>:80                                      ; preds = %73
   %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
@@ -7607,71 +9020,71 @@ entry:
 ; <label>:83                                      ; preds = %80
   store i32 0, i32* %loc3
   %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
-  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
-  br i1 %NullCheck26, label %88, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i32 addrspace(1)* %87, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %88
 
 ; <label>:88                                      ; preds = %85
   %89 = load i32, i32 addrspace(1)* %87, align 8
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
-  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %90
 
 ; <label>:90                                      ; preds = %88
   %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
   store i32 %89, i32 addrspace(1)* %91
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
-  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
-  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %96
 
 ; <label>:96                                      ; preds = %94
   %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
-  br i1 %NullCheck34, label %100, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %100
 
 ; <label>:100                                     ; preds = %96
   %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
-  br i1 %NullCheck36, label %102, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %102
 
 ; <label>:102                                     ; preds = %100
   %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
   %104 = load i32, i32 addrspace(1)* %103, align 8
   %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
-  br i1 %NullCheck38, label %106, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %106
 
 ; <label>:106                                     ; preds = %102
   %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
-  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
-  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %108
 
 ; <label>:108                                     ; preds = %106
   %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
   %110 = load i32, i32 addrspace(1)* %109, align 8
   %111 = add i32 %104, %110
-  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %112
 
 ; <label>:112                                     ; preds = %108
   %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
   store i32 %111, i32 addrspace(1)* %113
   %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
-  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i32 addrspace(1)* %114, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %115
 
 ; <label>:115                                     ; preds = %112
   %116 = load i32, i32 addrspace(1)* %114, align 8
@@ -7681,19 +9094,19 @@ entry:
 ; <label>:118                                     ; preds = %115
   %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
-  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %121
 
 ; <label>:121                                     ; preds = %118
   %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
-  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
-  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %123
 
 ; <label>:123                                     ; preds = %121
   %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
   %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
-  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
-  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %126
 
 ; <label>:126                                     ; preds = %123
   %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
@@ -7705,8 +9118,8 @@ entry:
 
 ; <label>:130                                     ; preds = %80, %115, %126
   %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %132
 
 ; <label>:132                                     ; preds = %130
   %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7715,8 +9128,8 @@ entry:
   %136 = load i32, i32* %loc3
   %137 = sub i32 %135, %136
   %138 = sub i32 %134, %137
-  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %139
 
 ; <label>:139                                     ; preds = %132
   %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7728,16 +9141,16 @@ entry:
 
 ; <label>:144                                     ; preds = %139
   %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
-  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %146
 
 ; <label>:146                                     ; preds = %144
   %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
   %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
   %149 = load i32, i32* %loc2
   %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
-  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %151
 
 ; <label>:151                                     ; preds = %146
   %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
@@ -7754,145 +9167,249 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %18
+ThrowNullRef4:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %31
+ThrowNullRef10:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %44
+ThrowNullRef16:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %68
+ThrowNullRef18:                                   ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %70
+ThrowNullRef20:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %73
+ThrowNullRef22:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %83
+ThrowNullRef24:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %85
+ThrowNullRef26:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %88
+ThrowNullRef28:                                   ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %90
+ThrowNullRef30:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %94
+ThrowNullRef32:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %96
+ThrowNullRef34:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %100
+ThrowNullRef36:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %102
+ThrowNullRef38:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %106
+ThrowNullRef40:                                   ; preds = %106
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %108
+ThrowNullRef42:                                   ; preds = %108
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %112
+ThrowNullRef44:                                   ; preds = %112
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %118
+ThrowNullRef46:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %121
+ThrowNullRef48:                                   ; preds = %121
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %123
+ThrowNullRef50:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %130
+ThrowNullRef52:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %132
+ThrowNullRef54:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %144
+ThrowNullRef56:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %146
+ThrowNullRef58:                                   ; preds = %146
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %60
+ThrowNullRef60:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %63
+ThrowNullRef62:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %49
+ThrowNullRef64:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %51
+ThrowNullRef66:                                   ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %53
+ThrowNullRef68:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(%"System.Char[]" addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %arg0 = alloca %"System.Char[]" addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store %"System.Char[]" addrspace(1)* %param0, %"System.Char[]" addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load i32, i32* %arg4
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %43, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %38, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg1
+  %13 = load i32, i32* %arg4
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %38, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %24 = load i32, i32* %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %35 = load i32, i32* %arg3
+  %36 = load i32, i32* %arg4
+  %37 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %37, %"System.Char[]" addrspace(1)* %34, i32 %35, i32 %36)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:38                                      ; preds = %5, %16
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Successfully read Buffer._Memmove
 
@@ -7914,7 +9431,7 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[loadElem]
+Failed to read AppDomain.SetDataHelper[storeElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -7923,8 +9440,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
@@ -7934,8 +9451,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
@@ -7947,15 +9464,15 @@ entry:
   %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
   %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
@@ -7966,15 +9483,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7992,7 +9509,79 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
-Failed to read Dictionary`2.TryGetValue[loadElemA]
+Successfully read Dictionary`2.TryGetValue
+
+define i8 @"Dictionary`2.TryGetValue"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)* addrspace(1)* %param2) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  %arg2 = alloca %System.__Canon addrspace(1)* addrspace(1)*
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  store %System.__Canon addrspace(1)* addrspace(1)* %param2, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  store i32 %2, i32* %loc0
+  %3 = load i32, i32* %loc0
+  %4 = icmp slt i32 %3, 0
+  br i1 %4, label %22, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 2
+  %10 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %9, align 8
+  %11 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = zext i32 %11 to i64
+  %BoundsCheck = icmp uge i64 %16, %15
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 3, i32 %11
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %20, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %6, %System.__Canon addrspace(1)* %21)
+  ret i8 1
+
+; <label>:22                                      ; preds = %entry
+  %23 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %23, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -8058,8 +9647,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
@@ -8091,8 +9680,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
@@ -8171,15 +9760,15 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck, label %19, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %ThrowNullRef, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
   %21 = load i32, i32 addrspace(1)* %20
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
@@ -8202,7 +9791,7 @@ ThrowNullRef:                                     ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %19
+ThrowNullRef2:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8248,8 +9837,8 @@ entry:
   %0 = alloca %System.AppDomainHandle
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %1 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %1, i32 0, i32 15
@@ -8269,8 +9858,8 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
@@ -8286,7 +9875,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -8299,8 +9888,8 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -8327,8 +9916,8 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
@@ -8352,8 +9941,8 @@ entry:
   %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
   store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
@@ -8363,8 +9952,8 @@ entry:
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
@@ -8374,8 +9963,8 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %9
   %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
@@ -8384,8 +9973,8 @@ entry:
 
 ; <label>:18                                      ; preds = %3, %16
   %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
@@ -8397,15 +9986,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %18
+ThrowNullRef6:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8418,8 +10007,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
@@ -8453,15 +10042,15 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
@@ -8473,7 +10062,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8481,7 +10070,7 @@ ThrowNullRef1:                                    ; preds = %1
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
 Failed to read Dictionary`2.System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
@@ -8506,8 +10095,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
@@ -8524,8 +10113,8 @@ entry:
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -8544,7 +10133,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8577,8 +10166,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = load i64, i64* %arg2
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = trunc i32 %3 to i8
@@ -8634,46 +10223,46 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
   %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
-  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
-  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
-  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
@@ -8684,27 +10273,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %20
+ThrowNullRef12:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8717,8 +10306,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -8756,22 +10345,22 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
   %9 = load i64, i64 addrspace(1)* %8, align 8
   %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
   %13 = load i64, i64 addrspace(1)* %12, align 8
   %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %11
   %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
@@ -8788,11 +10377,11 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8882,8 +10471,8 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
@@ -8900,8 +10489,8 @@ entry:
 ; <label>:8                                       ; preds = %1
   %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
   %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
@@ -8911,15 +10500,15 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
   %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
   %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
-  br i1 %NullCheck6, label %21, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
@@ -8946,15 +10535,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8992,15 +10581,15 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
   store i8 %3, i8 addrspace(1)* %5
   %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
@@ -9011,7 +10600,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9027,8 +10616,8 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -9041,8 +10630,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
@@ -9058,7 +10647,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9080,8 +10669,8 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
@@ -9096,8 +10685,8 @@ entry:
 ; <label>:12                                      ; preds = %6
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
@@ -9112,8 +10701,8 @@ entry:
 ; <label>:21                                      ; preds = %15
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
@@ -9128,8 +10717,8 @@ entry:
 ; <label>:30                                      ; preds = %24
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %31, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
@@ -9144,8 +10733,8 @@ entry:
 ; <label>:39                                      ; preds = %33
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
-  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %40, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %42
 
 ; <label>:42                                      ; preds = %39
   %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
@@ -9164,19 +10753,19 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %21
+ThrowNullRef4:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %30
+ThrowNullRef6:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %39
+ThrowNullRef8:                                    ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9243,8 +10832,8 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
@@ -9264,57 +10853,57 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
   store i8 0, i8 addrspace(1)* %2
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
   store i8 0, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
   store i8 0, i8 addrspace(1)* %17
   %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
   store i8 0, i8 addrspace(1)* %20
   %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
-  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
@@ -9325,31 +10914,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %19
+ThrowNullRef14:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9367,8 +10956,8 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
@@ -9380,8 +10969,8 @@ entry:
 
 ; <label>:9                                       ; preds = %4
   %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %9
   %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
@@ -9395,7 +10984,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef2:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9420,8 +11009,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
@@ -9512,8 +11101,8 @@ entry:
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
@@ -9524,8 +11113,8 @@ entry:
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = load i64, i64 addrspace(1)* %12
@@ -9537,8 +11126,8 @@ entry:
   %20 = load i64, i64* %19
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
-  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %13
   %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
@@ -9555,8 +11144,8 @@ entry:
 ; <label>:30                                      ; preds = %25
   %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %32 = load i32, i32* %arg2
-  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
-  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
@@ -9570,15 +11159,15 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %30
+ThrowNullRef2:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9622,87 +11211,87 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
   %10 = load i8, i8 addrspace(1)* %9, align 8
   %11 = zext i8 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %8
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
   store i8 %12, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
   %19 = load i8, i8 addrspace(1)* %18, align 8
   %20 = zext i8 %19 to i32
   %21 = trunc i32 %20 to i8
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
   store i8 %21, i8 addrspace(1)* %23
   %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
   %28 = load i8, i8 addrspace(1)* %27, align 8
   %29 = zext i8 %28 to i32
   %30 = trunc i32 %29 to i8
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
-  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %31
 
 ; <label>:31                                      ; preds = %26
   %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
   store i8 %30, i8 addrspace(1)* %32
   %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
-  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
-  br i1 %NullCheck14, label %40, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %40
 
 ; <label>:40                                      ; preds = %35
   %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
   store i8 %39, i8 addrspace(1)* %41
   %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
-  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %44
 
 ; <label>:44                                      ; preds = %40
   %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
   %46 = load i8, i8 addrspace(1)* %45, align 8
   %47 = zext i8 %46 to i32
   %48 = trunc i32 %47 to i8
-  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
   store i8 %48, i8 addrspace(1)* %50
   %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
-  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
@@ -9713,29 +11302,29 @@ entry:
 ; <label>:56                                      ; preds = %52
   %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
-  br i1 %NullCheck22, label %59, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
   %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
   %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
-  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
-  br i1 %NullCheck24, label %63, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
   %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
-  br i1 %NullCheck26, label %66, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
   %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
-  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
-  br i1 %NullCheck28, label %69, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %69
 
 ; <label>:69                                      ; preds = %66
   %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
@@ -9744,15 +11333,15 @@ entry:
 
 ; <label>:71                                      ; preds = %105
   %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
-  br i1 %NullCheck34, label %73, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %73
 
 ; <label>:73                                      ; preds = %71
   %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
   %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
   %76 = load i32, i32* %loc0
-  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
-  br i1 %NullCheck36, label %77, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
@@ -9766,8 +11355,8 @@ entry:
 
 ; <label>:83                                      ; preds = %77
   %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
-  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
@@ -9775,14 +11364,14 @@ entry:
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
   %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
-  br i1 %NullCheck40, label %91, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
 ; <label>:91                                      ; preds = %85
   %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
   %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
-  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck42, label %94, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %94
 
 ; <label>:94                                      ; preds = %91
   %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
@@ -9798,14 +11387,14 @@ entry:
 ; <label>:99                                      ; preds = %69, %96
   %100 = load i32, i32* %loc0
   %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
-  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %102
 
 ; <label>:102                                     ; preds = %99
   %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
   %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
-  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
-  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
@@ -9819,87 +11408,87 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %26
+ThrowNullRef10:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %31
+ThrowNullRef12:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %35
+ThrowNullRef14:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %40
+ThrowNullRef16:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %56
+ThrowNullRef22:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %59
+ThrowNullRef24:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %63
+ThrowNullRef26:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %66
+ThrowNullRef28:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %102
+ThrowNullRef32:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %71
+ThrowNullRef34:                                   ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %73
+ThrowNullRef36:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %83
+ThrowNullRef38:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %85
+ThrowNullRef40:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %91
+ThrowNullRef42:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9943,15 +11532,15 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
   %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
@@ -9961,28 +11550,28 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
   %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %12
   %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
   %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
   %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
-  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
@@ -9993,23 +11582,23 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %12
+ThrowNullRef6:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10031,15 +11620,15 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
   %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = load i64, i64 addrspace(1)* %7
@@ -10077,13 +11666,13 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[loadElem]
+Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -10111,8 +11700,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -10154,7 +11743,7 @@ entry:
 INFO:  jitting method BringUpTest::Main using LLILCJit
 Failed to read BringUpTest.Main[storeElem]
 INFO:  jitting method String::Concat using LLILCJit
-Failed to read String.Concat[loadElem]
+Failed to read String.Concat[storeElem]
 INFO:  jitting method String::ToString using LLILCJit
 Successfully read String.ToString
 
@@ -10175,8 +11764,8 @@ entry:
   store %System.Int32 addrspace(1)* %param0, %System.Int32 addrspace(1)** %this
   %0 = load %System.Int32 addrspace(1)*, %System.Int32 addrspace(1)** %this
   %1 = bitcast %System.Int32 addrspace(1)* %0 to i32 addrspace(1)*
-  %NullCheck = icmp ne i32 addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq i32 addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load i32, i32 addrspace(1)* %1, align 8
@@ -10379,8 +11968,8 @@ entry:
   %loc0 = alloca %System.Globalization.NumberFormatInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 3
@@ -10390,8 +11979,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
@@ -10401,24 +11990,24 @@ entry:
   store %System.Globalization.NumberFormatInfo addrspace(1)* %10, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
   %11 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %7
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
   %15 = load i8, i8 addrspace(1)* %14, align 8
   %16 = zext i8 %15 to i32
   %17 = trunc i32 %16 to i8
-  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %11, null
-  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %11, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %13
   %19 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %11, i32 0, i32 29
   store i8 %17, i8 addrspace(1)* %19
   %20 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %21 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %20, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %20, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %18
   %23 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %20, i32 0, i32 3
@@ -10427,8 +12016,8 @@ entry:
 
 ; <label>:24                                      ; preds = %1, %22
   %25 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %25, null
-  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %25, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %26
 
 ; <label>:26                                      ; preds = %24
   %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %25, i32 0, i32 3
@@ -10439,23 +12028,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %18
+ThrowNullRef8:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10480,168 +12069,168 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 18
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %8, align 8
-  %NullCheck2 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %5, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %5, i32 0, i32 4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %9)
   %12 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 19
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %15, align 8
-  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %12, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %12, i32 0, i32 5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %16)
   %19 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %20 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %20, null
-  br i1 %NullCheck8, label %21, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %20, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %20, i32 0, i32 23
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  %NullCheck10 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %19, null
-  br i1 %NullCheck10, label %24, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %19, i32 0, i32 7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %25, %System.String addrspace(1)* %23)
   %26 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %27 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %27, i32 0, i32 22
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %29, align 8
-  %NullCheck14 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %26, null
-  br i1 %NullCheck14, label %31, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %26, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %26, i32 0, i32 6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %32, %System.String addrspace(1)* %30)
   %33 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %34 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Globalization.CultureData addrspace(1)* %34, null
-  br i1 %NullCheck16, label %35, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Globalization.CultureData addrspace(1)* %34, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %34, i32 0, i32 51
   %37 = load i32, i32 addrspace(1)* %36, align 8
-  %NullCheck18 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %33, null
-  br i1 %NullCheck18, label %38, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %33, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %33, i32 0, i32 21
   store i32 %37, i32 addrspace(1)* %39
   %40 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %41 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Globalization.CultureData addrspace(1)* %41, null
-  br i1 %NullCheck20, label %42, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Globalization.CultureData addrspace(1)* %41, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %41, i32 0, i32 52
   %44 = load i32, i32 addrspace(1)* %43, align 8
-  %NullCheck22 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %40, null
-  br i1 %NullCheck22, label %45, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %40, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %40, i32 0, i32 25
   store i32 %44, i32 addrspace(1)* %46
   %47 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %48 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.Globalization.CultureData addrspace(1)* %48, null
-  br i1 %NullCheck24, label %49, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Globalization.CultureData addrspace(1)* %48, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %49
 
 ; <label>:49                                      ; preds = %45
   %50 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %48, i32 0, i32 29
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck26 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %47, null
-  br i1 %NullCheck26, label %52, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %47, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %47, i32 0, i32 10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %53, %System.String addrspace(1)* %51)
   %54 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %55 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Globalization.CultureData addrspace(1)* %55, null
-  br i1 %NullCheck28, label %56, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Globalization.CultureData addrspace(1)* %55, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %56
 
 ; <label>:56                                      ; preds = %52
   %57 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %55, i32 0, i32 35
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %57, align 8
-  %NullCheck30 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %54, null
-  br i1 %NullCheck30, label %59, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %54, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %54, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %60, %System.String addrspace(1)* %58)
   %61 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %62 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck32 = icmp ne %System.Globalization.CultureData addrspace(1)* %62, null
-  br i1 %NullCheck32, label %63, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Globalization.CultureData addrspace(1)* %62, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %62, i32 0, i32 34
   %65 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %64, align 8
-  %NullCheck34 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %61, null
-  br i1 %NullCheck34, label %66, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %61, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %61, i32 0, i32 9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %67, %System.String addrspace(1)* %65)
   %68 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %69 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck36 = icmp ne %System.Globalization.CultureData addrspace(1)* %69, null
-  br i1 %NullCheck36, label %70, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Globalization.CultureData addrspace(1)* %69, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %70
 
 ; <label>:70                                      ; preds = %66
   %71 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %69, i32 0, i32 55
   %72 = load i32, i32 addrspace(1)* %71, align 8
-  %NullCheck38 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %68, null
-  br i1 %NullCheck38, label %73, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %68, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %68, i32 0, i32 22
   store i32 %72, i32 addrspace(1)* %74
   %75 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %76 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck40 = icmp ne %System.Globalization.CultureData addrspace(1)* %76, null
-  br i1 %NullCheck40, label %77, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Globalization.CultureData addrspace(1)* %76, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %76, i32 0, i32 57
   %79 = load i32, i32 addrspace(1)* %78, align 8
-  %NullCheck42 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %75, null
-  br i1 %NullCheck42, label %80, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %75, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %80
 
 ; <label>:80                                      ; preds = %77
   %81 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %75, i32 0, i32 24
   store i32 %79, i32 addrspace(1)* %81
   %82 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %83 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck44 = icmp ne %System.Globalization.CultureData addrspace(1)* %83, null
-  br i1 %NullCheck44, label %84, label %ThrowNullRef43
+  %NullCheck43 = icmp eq %System.Globalization.CultureData addrspace(1)* %83, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %84
 
 ; <label>:84                                      ; preds = %80
   %85 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %83, i32 0, i32 56
   %86 = load i32, i32 addrspace(1)* %85, align 8
-  %NullCheck46 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %82, null
-  br i1 %NullCheck46, label %87, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %82, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %82, i32 0, i32 23
@@ -10650,8 +12239,8 @@ entry:
 
 ; <label>:89                                      ; preds = %entry
   %90 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck100 = icmp ne %System.Globalization.CultureData addrspace(1)* %90, null
-  br i1 %NullCheck100, label %91, label %ThrowNullRef99
+  %NullCheck99 = icmp eq %System.Globalization.CultureData addrspace(1)* %90, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %91
 
 ; <label>:91                                      ; preds = %89
   %92 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %90, i32 0, i32 2
@@ -10669,8 +12258,8 @@ entry:
   %102 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %103 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %104 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %103)
-  %NullCheck48 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %102, null
-  br i1 %NullCheck48, label %105, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %102, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %105
 
 ; <label>:105                                     ; preds = %101
   %106 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %102, i32 0, i32 1
@@ -10678,8 +12267,8 @@ entry:
   %107 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %108 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %109 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %108)
-  %NullCheck50 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %107, null
-  br i1 %NullCheck50, label %110, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %107, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %110
 
 ; <label>:110                                     ; preds = %105
   %111 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %107, i32 0, i32 2
@@ -10687,8 +12276,8 @@ entry:
   %112 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %113 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %114 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %113)
-  %NullCheck52 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %112, null
-  br i1 %NullCheck52, label %115, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %112, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %115
 
 ; <label>:115                                     ; preds = %110
   %116 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %112, i32 0, i32 27
@@ -10696,8 +12285,8 @@ entry:
   %117 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %118 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %119 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %118)
-  %NullCheck54 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %117, null
-  br i1 %NullCheck54, label %120, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %117, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %120
 
 ; <label>:120                                     ; preds = %115
   %121 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %117, i32 0, i32 26
@@ -10705,8 +12294,8 @@ entry:
   %122 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %123 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %124 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %123)
-  %NullCheck56 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %122, null
-  br i1 %NullCheck56, label %125, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %122, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %125
 
 ; <label>:125                                     ; preds = %120
   %126 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %122, i32 0, i32 17
@@ -10714,8 +12303,8 @@ entry:
   %127 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %128 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %129 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %128)
-  %NullCheck58 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %127, null
-  br i1 %NullCheck58, label %130, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %127, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %130
 
 ; <label>:130                                     ; preds = %125
   %131 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %127, i32 0, i32 18
@@ -10723,8 +12312,8 @@ entry:
   %132 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %133 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %134 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %133)
-  %NullCheck60 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %132, null
-  br i1 %NullCheck60, label %135, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %132, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %135
 
 ; <label>:135                                     ; preds = %130
   %136 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %132, i32 0, i32 14
@@ -10732,8 +12321,8 @@ entry:
   %137 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %138 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %139 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %138)
-  %NullCheck62 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %137, null
-  br i1 %NullCheck62, label %140, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %137, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %140
 
 ; <label>:140                                     ; preds = %135
   %141 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %137, i32 0, i32 13
@@ -10741,71 +12330,71 @@ entry:
   %142 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %143 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %144 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %143)
-  %NullCheck64 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %142, null
-  br i1 %NullCheck64, label %145, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %142, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %145
 
 ; <label>:145                                     ; preds = %140
   %146 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %142, i32 0, i32 12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %146, %System.String addrspace(1)* %144)
   %147 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %148 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck66 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %148, null
-  br i1 %NullCheck66, label %149, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %148, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %149
 
 ; <label>:149                                     ; preds = %145
   %150 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %148, i32 0, i32 21
   %151 = load i32, i32 addrspace(1)* %150, align 8
-  %NullCheck68 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %147, null
-  br i1 %NullCheck68, label %152, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %147, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %152
 
 ; <label>:152                                     ; preds = %149
   %153 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %147, i32 0, i32 28
   store i32 %151, i32 addrspace(1)* %153
   %154 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %155 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck70 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %155, null
-  br i1 %NullCheck70, label %156, label %ThrowNullRef69
+  %NullCheck69 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %155, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %156
 
 ; <label>:156                                     ; preds = %152
   %157 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %155, i32 0, i32 6
   %158 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %157, align 8
-  %NullCheck72 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %154, null
-  br i1 %NullCheck72, label %159, label %ThrowNullRef71
+  %NullCheck71 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %154, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %159
 
 ; <label>:159                                     ; preds = %156
   %160 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %154, i32 0, i32 15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %160, %System.String addrspace(1)* %158)
   %161 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %162 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck74 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %162, null
-  br i1 %NullCheck74, label %163, label %ThrowNullRef73
+  %NullCheck73 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %162, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %163
 
 ; <label>:163                                     ; preds = %159
   %164 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %162, i32 0, i32 1
   %165 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %164, align 8
-  %NullCheck76 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %161, null
-  br i1 %NullCheck76, label %166, label %ThrowNullRef75
+  %NullCheck75 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %161, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %166
 
 ; <label>:166                                     ; preds = %163
   %167 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %161, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %167, %"System.Int32[]" addrspace(1)* %165)
   %168 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %169 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck78 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %169, null
-  br i1 %NullCheck78, label %170, label %ThrowNullRef77
+  %NullCheck77 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %169, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %170
 
 ; <label>:170                                     ; preds = %166
   %171 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %169, i32 0, i32 7
   %172 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %171, align 8
-  %NullCheck80 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %168, null
-  br i1 %NullCheck80, label %173, label %ThrowNullRef79
+  %NullCheck79 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %168, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %173
 
 ; <label>:173                                     ; preds = %170
   %174 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %168, i32 0, i32 16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %174, %System.String addrspace(1)* %172)
   %175 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck82 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %175, null
-  br i1 %NullCheck82, label %176, label %ThrowNullRef81
+  %NullCheck81 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %175, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %176
 
 ; <label>:176                                     ; preds = %173
   %177 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %175, i32 0, i32 4
@@ -10815,14 +12404,14 @@ entry:
 
 ; <label>:180                                     ; preds = %176
   %181 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck84 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %181, null
-  br i1 %NullCheck84, label %182, label %ThrowNullRef83
+  %NullCheck83 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %181, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %182
 
 ; <label>:182                                     ; preds = %180
   %183 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %181, i32 0, i32 4
   %184 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %183, align 8
-  %NullCheck86 = icmp ne %System.String addrspace(1)* %184, null
-  br i1 %NullCheck86, label %185, label %ThrowNullRef85
+  %NullCheck85 = icmp eq %System.String addrspace(1)* %184, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %185
 
 ; <label>:185                                     ; preds = %182
   %186 = getelementptr inbounds %System.String, %System.String addrspace(1)* %184, i32 0, i32 1
@@ -10833,8 +12422,8 @@ entry:
 ; <label>:189                                     ; preds = %176, %185
   %190 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck98 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %190, null
-  br i1 %NullCheck98, label %192, label %ThrowNullRef97
+  %NullCheck97 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %190, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %192
 
 ; <label>:192                                     ; preds = %189
   %193 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %190, i32 0, i32 4
@@ -10843,8 +12432,8 @@ entry:
 
 ; <label>:194                                     ; preds = %185, %192
   %195 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck88 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %195, null
-  br i1 %NullCheck88, label %196, label %ThrowNullRef87
+  %NullCheck87 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %195, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %196
 
 ; <label>:196                                     ; preds = %194
   %197 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %195, i32 0, i32 9
@@ -10854,14 +12443,14 @@ entry:
 
 ; <label>:200                                     ; preds = %196
   %201 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck90 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %201, null
-  br i1 %NullCheck90, label %202, label %ThrowNullRef89
+  %NullCheck89 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %201, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %202
 
 ; <label>:202                                     ; preds = %200
   %203 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %201, i32 0, i32 9
   %204 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %203, align 8
-  %NullCheck92 = icmp ne %System.String addrspace(1)* %204, null
-  br i1 %NullCheck92, label %205, label %ThrowNullRef91
+  %NullCheck91 = icmp eq %System.String addrspace(1)* %204, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %205
 
 ; <label>:205                                     ; preds = %202
   %206 = getelementptr inbounds %System.String, %System.String addrspace(1)* %204, i32 0, i32 1
@@ -10872,14 +12461,14 @@ entry:
 ; <label>:209                                     ; preds = %196, %205
   %210 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %211 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %NullCheck94 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %211, null
-  br i1 %NullCheck94, label %212, label %ThrowNullRef93
+  %NullCheck93 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %211, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %212
 
 ; <label>:212                                     ; preds = %209
   %213 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %211, i32 0, i32 6
   %214 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %213, align 8
-  %NullCheck96 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %210, null
-  br i1 %NullCheck96, label %215, label %ThrowNullRef95
+  %NullCheck95 = icmp eq %System.Globalization.NumberFormatInfo addrspace(1)* %210, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %215
 
 ; <label>:215                                     ; preds = %212
   %216 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %210, i32 0, i32 9
@@ -10893,203 +12482,203 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %17
+ThrowNullRef8:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %21
+ThrowNullRef10:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %24
+ThrowNullRef12:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %28
+ThrowNullRef14:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %31
+ThrowNullRef16:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %35
+ThrowNullRef18:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %38
+ThrowNullRef20:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %42
+ThrowNullRef22:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %45
+ThrowNullRef24:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %49
+ThrowNullRef26:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %52
+ThrowNullRef28:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %56
+ThrowNullRef30:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %59
+ThrowNullRef32:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %63
+ThrowNullRef34:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %66
+ThrowNullRef36:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %70
+ThrowNullRef38:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %73
+ThrowNullRef40:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %77
+ThrowNullRef42:                                   ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %80
+ThrowNullRef44:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %84
+ThrowNullRef46:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %101
+ThrowNullRef48:                                   ; preds = %101
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %105
+ThrowNullRef50:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %110
+ThrowNullRef52:                                   ; preds = %110
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %115
+ThrowNullRef54:                                   ; preds = %115
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %120
+ThrowNullRef56:                                   ; preds = %120
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %125
+ThrowNullRef58:                                   ; preds = %125
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %130
+ThrowNullRef60:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %135
+ThrowNullRef62:                                   ; preds = %135
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %140
+ThrowNullRef64:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %145
+ThrowNullRef66:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %149
+ThrowNullRef68:                                   ; preds = %149
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %152
+ThrowNullRef70:                                   ; preds = %152
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %156
+ThrowNullRef72:                                   ; preds = %156
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %159
+ThrowNullRef74:                                   ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %163
+ThrowNullRef76:                                   ; preds = %163
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %166
+ThrowNullRef78:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %170
+ThrowNullRef80:                                   ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %173
+ThrowNullRef82:                                   ; preds = %173
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %180
+ThrowNullRef84:                                   ; preds = %180
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %182
+ThrowNullRef86:                                   ; preds = %182
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %194
+ThrowNullRef88:                                   ; preds = %194
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %200
+ThrowNullRef90:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %202
+ThrowNullRef92:                                   ; preds = %202
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %209
+ThrowNullRef94:                                   ; preds = %209
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %212
+ThrowNullRef96:                                   ; preds = %212
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %189
+ThrowNullRef98:                                   ; preds = %189
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %89
+ThrowNullRef100:                                  ; preds = %89
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11117,8 +12706,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 21
@@ -11131,8 +12720,8 @@ entry:
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 16)
   %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 21
@@ -11141,8 +12730,8 @@ entry:
 
 ; <label>:12                                      ; preds = %1, %10
   %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 21
@@ -11153,11 +12742,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %12
+ThrowNullRef4:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11173,8 +12762,8 @@ entry:
   store i32 %param1, i32* %arg1
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %1 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
@@ -11241,8 +12830,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 33
@@ -11255,8 +12844,8 @@ entry:
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 24)
   %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 33
@@ -11265,8 +12854,8 @@ entry:
 
 ; <label>:12                                      ; preds = %1, %10
   %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 33
@@ -11277,11 +12866,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %12
+ThrowNullRef4:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11294,8 +12883,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 53
@@ -11307,8 +12896,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 116)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 53
@@ -11317,8 +12906,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 53
@@ -11329,11 +12918,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11362,8 +12951,8 @@ entry:
 
 ; <label>:7                                       ; preds = %entry, %4
   %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %7
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 2
@@ -11387,8 +12976,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 54
@@ -11400,8 +12989,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 117)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
@@ -11410,8 +12999,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 54
@@ -11422,11 +13011,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11439,8 +13028,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 27
@@ -11452,8 +13041,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 118)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 27
@@ -11462,8 +13051,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 27
@@ -11474,11 +13063,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11491,8 +13080,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 28
@@ -11504,8 +13093,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 119)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 28
@@ -11514,8 +13103,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 28
@@ -11526,11 +13115,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11543,8 +13132,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 26
@@ -11556,8 +13145,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 107)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 26
@@ -11566,8 +13155,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 26
@@ -11578,11 +13167,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11595,8 +13184,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 25
@@ -11608,8 +13197,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 106)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 25
@@ -11618,8 +13207,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 25
@@ -11630,11 +13219,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11647,8 +13236,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 24
@@ -11660,8 +13249,8 @@ entry:
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 105)
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 24
@@ -11670,8 +13259,8 @@ entry:
 
 ; <label>:11                                      ; preds = %1, %9
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 24
@@ -11682,17 +13271,127 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method String::ConcatArray using LLILCJit
-Failed to read String.ConcatArray[loadElem]
+Successfully read String.ConcatArray
+
+define %System.String addrspace(1)* @String.ConcatArray(%"System.String[]" addrspace(1)* %param0, i32 %param1) {
+entry:
+  %arg0 = alloca %"System.String[]" addrspace(1)*
+  %arg1 = alloca i32
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store %"System.String[]" addrspace(1)* %param0, %"System.String[]" addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  %0 = load i32, i32* %arg1
+  %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %0)
+  store %System.String addrspace(1)* %1, %System.String addrspace(1)** %loc0
+  store i32 0, i32* %loc1
+  store i32 0, i32* %loc2
+  br label %32
+
+; <label>:2                                       ; preds = %35
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %4 = load i32, i32* %loc1
+  %5 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)** %arg0
+  %6 = load i32, i32* %loc2
+  %NullCheck1 = icmp eq %"System.String[]" addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
+
+; <label>:7                                       ; preds = %2
+  %8 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %5, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  %10 = zext i32 %9 to i64
+  %11 = zext i32 %6 to i64
+  %BoundsCheck = icmp uge i64 %11, %10
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %12
+
+; <label>:12                                      ; preds = %7
+  %13 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %5, i32 0, i32 3, i32 %6
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %3, i32 %4, %System.String addrspace(1)* %14)
+  %15 = load i32, i32* %loc1
+  %16 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)** %arg0
+  %17 = load i32, i32* %loc2
+  %NullCheck3 = icmp eq %"System.String[]" addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %18
+
+; <label>:18                                      ; preds = %12
+  %19 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %16, i32 0, i32 1
+  %20 = load i32, i32 addrspace(1)* %19
+  %21 = zext i32 %20 to i64
+  %22 = zext i32 %17 to i64
+  %BoundsCheck5 = icmp uge i64 %22, %21
+  br i1 %BoundsCheck5, label %ThrowIndexOutOfRange6, label %23
+
+; <label>:23                                      ; preds = %18
+  %24 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %16, i32 0, i32 3, i32 %17
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %24, align 8
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %28 = load i32, i32 addrspace(1)* %27
+  %29 = add i32 %15, %28
+  store i32 %29, i32* %loc1
+  %30 = load i32, i32* %loc2
+  %31 = add i32 %30, 1
+  store i32 %31, i32* %loc2
+  br label %32
+
+; <label>:32                                      ; preds = %entry, %26
+  %33 = load i32, i32* %loc2
+  %34 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)** %arg0
+  %NullCheck = icmp eq %"System.String[]" addrspace(1)* %34, null
+  br i1 %NullCheck, label %ThrowNullRef, label %35
+
+; <label>:35                                      ; preds = %32
+  %36 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %34, i32 0, i32 1
+  %37 = load i32, i32 addrspace(1)* %36
+  %38 = zext i32 %37 to i64
+  %39 = trunc i64 %38 to i32
+  %40 = icmp slt i32 %33, %39
+  br i1 %40, label %2, label %41
+
+; <label>:41                                      ; preds = %35
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  ret %System.String addrspace(1)* %42
+
+ThrowNullRef:                                     ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange6:                            ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Console::WriteLine using LLILCJit
 Successfully read Console.WriteLine
 
@@ -11703,8 +13402,8 @@ entry:
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -11838,8 +13537,8 @@ entry:
   store i64 %param0, i64* %arg0
   store i64 %param1, i64* %arg1
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
@@ -11847,8 +13546,8 @@ entry:
   %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
   %5 = load i16*, i16* addrspace(1)* %4, align 8
   %6 = addrspacecast i64* %arg1 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = bitcast i64 addrspace(1)* %6 to i8 addrspace(1)*
@@ -11864,7 +13563,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11898,8 +13597,8 @@ entry:
   %1 = load i32, i32* %arg1
   %2 = sext i32 %1 to i64
   %3 = inttoptr i64 %2 to i16*
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -11952,8 +13651,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, i32)*)(%System.IO.ConsoleStream addrspace(1)* %2, i32 %1)
   %3 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %4 = load i64, i64* %arg1
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
@@ -11964,8 +13663,8 @@ entry:
   %10 = icmp eq i32 %9, 3
   %11 = sext i1 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %5
   %14 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, i32 0, i32 5
@@ -11976,7 +13675,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11999,8 +13698,8 @@ entry:
   %5 = icmp eq i32 %4, 1
   %6 = sext i1 %5 to i32
   %7 = trunc i32 %6 to i8
-  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %2, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.ConsoleStream addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
@@ -12011,8 +13710,8 @@ entry:
   %13 = icmp eq i32 %12, 2
   %14 = sext i1 %13 to i32
   %15 = trunc i32 %14 to i8
-  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %10, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.ConsoleStream addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %8
   %17 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %10, i32 0, i32 4
@@ -12023,7 +13722,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12062,8 +13761,8 @@ entry:
   %arg0 = alloca i64
   store i64 %param0, i64* %arg0
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
@@ -12098,8 +13797,8 @@ entry:
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
   %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = load i64, i64 addrspace(1)* %7
@@ -12203,7 +13902,127 @@ entry:
 INFO:  jitting method Encoding::GetEncoding using LLILCJit
 Failed to read Encoding.GetEncoding[convertToHelperArgumentType]
 INFO:  jitting method EncodingProvider::GetEncodingFromProvider using LLILCJit
-Failed to read EncodingProvider.GetEncodingFromProvider[loadElem]
+Successfully read EncodingProvider.GetEncodingFromProvider
+
+define %System.Text.Encoding addrspace(1)* @EncodingProvider.GetEncodingFromProvider(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca %"System.Text.EncodingProvider[]" addrspace(1)*
+  %loc1 = alloca %System.Text.EncodingProvider addrspace(1)*
+  %loc2 = alloca %System.Text.Encoding addrspace(1)*
+  %loc3 = alloca %System.Text.Encoding addrspace(1)*
+  %loc4 = alloca %"System.Text.EncodingProvider[]" addrspace(1)*
+  %loc5 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1059)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2392
+  %2 = addrspacecast i8 addrspace(1)* %1 to %"System.Text.EncodingProvider[]" addrspace(1)**
+  %3 = load volatile %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %2
+  %4 = icmp ne %"System.Text.EncodingProvider[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %entry
+  ret %System.Text.Encoding addrspace(1)* null
+
+; <label>:6                                       ; preds = %entry
+  %7 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1059)
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i64 2392
+  %9 = addrspacecast i8 addrspace(1)* %8 to %"System.Text.EncodingProvider[]" addrspace(1)**
+  %10 = load volatile %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %9
+  store %"System.Text.EncodingProvider[]" addrspace(1)* %10, %"System.Text.EncodingProvider[]" addrspace(1)** %loc0
+  %11 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc0
+  store %"System.Text.EncodingProvider[]" addrspace(1)* %11, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  store i32 0, i32* %loc5
+  br label %43
+
+; <label>:12                                      ; preds = %46
+  %13 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  %14 = load i32, i32* %loc5
+  %NullCheck1 = icmp eq %"System.Text.EncodingProvider[]" addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %13, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = zext i32 %17 to i64
+  %19 = zext i32 %14 to i64
+  %BoundsCheck = icmp uge i64 %19, %18
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %20
+
+; <label>:20                                      ; preds = %15
+  %21 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %13, i32 0, i32 3, i32 %14
+  %22 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)* addrspace(1)* %21, align 8
+  store %System.Text.EncodingProvider addrspace(1)* %22, %System.Text.EncodingProvider addrspace(1)** %loc1
+  %23 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)** %loc1
+  %24 = load i32, i32* %arg0
+  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i64 addrspace(1)*
+  %NullCheck3 = icmp eq i64 addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
+
+; <label>:26                                      ; preds = %20
+  %27 = load i64, i64 addrspace(1)* %25
+  %28 = add i64 %27, 64
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 40
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Text.Encoding addrspace(1)* (%System.Text.EncodingProvider addrspace(1)*, i32)*
+  %35 = call %System.Text.Encoding addrspace(1)* %34(%System.Text.EncodingProvider addrspace(1)* %23, i32 %24)
+  store %System.Text.Encoding addrspace(1)* %35, %System.Text.Encoding addrspace(1)** %loc2
+  %36 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc2
+  %37 = icmp eq %System.Text.Encoding addrspace(1)* %36, null
+  br i1 %37, label %40, label %38
+
+; <label>:38                                      ; preds = %26
+  %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc2
+  store %System.Text.Encoding addrspace(1)* %39, %System.Text.Encoding addrspace(1)** %loc3
+  br label %53
+
+; <label>:40                                      ; preds = %26
+  %41 = load i32, i32* %loc5
+  %42 = add i32 %41, 1
+  store i32 %42, i32* %loc5
+  br label %43
+
+; <label>:43                                      ; preds = %6, %40
+  %44 = load i32, i32* %loc5
+  %45 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  %NullCheck = icmp eq %"System.Text.EncodingProvider[]" addrspace(1)* %45, null
+  br i1 %NullCheck, label %ThrowNullRef, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp slt i32 %44, %50
+  br i1 %51, label %12, label %52
+
+; <label>:52                                      ; preds = %46
+  ret %System.Text.Encoding addrspace(1)* null
+
+; <label>:53                                      ; preds = %38
+  %54 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc3
+  ret %System.Text.Encoding addrspace(1)* %54
+
+ThrowNullRef:                                     ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method EncodingProvider::.cctor using LLILCJit
 Successfully read EncodingProvider..cctor
 
@@ -12222,7 +14041,7 @@ Failed to read Encoding.get_InternalSyncObject[Call HasTypeArg]
 INFO:  jitting method Hashtable::.ctor using LLILCJit
 Failed to read Hashtable..ctor[Volatile store]
 INFO:  jitting method Hashtable::get_Item using LLILCJit
-Failed to read Hashtable.get_Item[loadElemA]
+Failed to read Hashtable.get_Item[loadNonPrimitiveObj]
 INFO:  jitting method Hashtable::InitHash using LLILCJit
 Successfully read Hashtable.InitHash
 
@@ -12242,8 +14061,8 @@ entry:
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -12259,15 +14078,15 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
   %15 = load i32, i32* %loc0
-  %NullCheck2 = icmp ne i32 addrspace(1)* %14, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i32 addrspace(1)* %14, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %3
   store i32 %15, i32 addrspace(1)* %14, align 8
   %17 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %18 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %NullCheck4 = icmp ne i32 addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i32 addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = load i32, i32 addrspace(1)* %18, align 8
@@ -12276,8 +14095,8 @@ entry:
   %23 = sub i32 %22, 1
   %24 = urem i32 %21, %23
   %25 = add i32 1, %24
-  %NullCheck6 = icmp ne i32 addrspace(1)* %17, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32 addrspace(1)* %17, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %19
   store i32 %25, i32 addrspace(1)* %17, align 8
@@ -12288,15 +14107,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %19
+ThrowNullRef6:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12311,8 +14130,8 @@ entry:
   store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
   store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %NullCheck = icmp ne %System.Collections.Hashtable addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Collections.Hashtable addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
@@ -12322,16 +14141,16 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Collections.Hashtable addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Collections.Hashtable addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
   %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck4 = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %9, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
   %13 = inttoptr i64 %11 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
@@ -12341,8 +14160,8 @@ entry:
 ; <label>:15                                      ; preds = %1
   %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -12360,15 +14179,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12382,8 +14201,8 @@ entry:
   store %System.Int32 addrspace(1)* %param0, %System.Int32 addrspace(1)** %this
   %0 = load %System.Int32 addrspace(1)*, %System.Int32 addrspace(1)** %this
   %1 = bitcast %System.Int32 addrspace(1)* %0 to i32 addrspace(1)*
-  %NullCheck = icmp ne i32 addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq i32 addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load i32, i32 addrspace(1)* %1, align 8
@@ -12459,8 +14278,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.UTF8Encoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
@@ -12469,15 +14288,15 @@ entry:
   %9 = load i8, i8* %arg2
   %10 = zext i8 %9 to i32
   %11 = trunc i32 %10 to i8
-  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %8, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %6
   %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %8, i32 0, i32 8
   store i8 %11, i8 addrspace(1)* %13
   %14 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %14, i32 0, i32 8
@@ -12489,8 +14308,8 @@ entry:
 ; <label>:20                                      ; preds = %15
   %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %22, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %22, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = load i64, i64 addrspace(1)* %22
@@ -12512,15 +14331,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %12
+ThrowNullRef4:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12535,8 +14354,8 @@ entry:
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
@@ -12558,16 +14377,16 @@ entry:
 ; <label>:10                                      ; preds = %1
   %11 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
   %12 = load i32, i32* %arg1
-  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %11, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.Encoding addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
   store i32 %12, i32 addrspace(1)* %14
   %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
   %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = load i64, i64 addrspace(1)* %16
@@ -12585,11 +14404,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12602,8 +14421,8 @@ entry:
   %this = alloca %System.Text.UTF8Encoding addrspace(1)*
   store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
   %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.UTF8Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
@@ -12615,16 +14434,16 @@ entry:
 ; <label>:6                                       ; preds = %1
   %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %8 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %10, %System.Text.EncoderFallback addrspace(1)* %8)
   %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %12 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
-  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %11, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %11, i32 0, i32 3
@@ -12637,8 +14456,8 @@ entry:
   %18 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %18, %System.String addrspace(1)* %17)
   %19 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %18 to %System.Text.EncoderFallback addrspace(1)*
-  %NullCheck6 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %16, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %16, i32 0, i32 2
@@ -12648,8 +14467,8 @@ entry:
   %24 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %24, %System.String addrspace(1)* %23)
   %25 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %24 to %System.Text.DecoderFallback addrspace(1)*
-  %NullCheck8 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %22, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %22, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %20
   %27 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %22, i32 0, i32 3
@@ -12660,19 +14479,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %20
+ThrowNullRef8:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12702,8 +14521,8 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load i32, i32* %arg1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -12721,8 +14540,8 @@ entry:
 ; <label>:15                                      ; preds = %8
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %17 = load i32, i32* %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 %17
@@ -12738,7 +14557,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12790,7 +14609,7 @@ entry:
 }
 
 INFO:  jitting method Hashtable::Insert using LLILCJit
-Failed to read Hashtable.Insert[loadElemA]
+Failed to read Hashtable.Insert[storeElem]
 INFO:  jitting method ConsoleEncoding::.ctor using LLILCJit
 Successfully read ConsoleEncoding..ctor
 
@@ -12805,8 +14624,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %1)
   %2 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
@@ -12842,8 +14661,8 @@ entry:
   %2 = call %System.Text.InternalEncoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalEncoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %1)
   %3 = bitcast %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2 to %System.Text.EncoderFallback addrspace(1)*
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
@@ -12853,8 +14672,8 @@ entry:
   %8 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %7)
   %9 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %8 to %System.Text.DecoderFallback addrspace(1)*
-  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %6, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.Encoding addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %4
   %11 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %6, i32 0, i32 3
@@ -12865,7 +14684,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12884,15 +14703,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* %1)
   %2 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   %6 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, i32 0, i32 1
@@ -12903,7 +14722,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12931,8 +14750,8 @@ entry:
   store %System.Text.InternalDecoderBestFitFallback addrspace(1)* %param0, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
   %0 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
@@ -12942,15 +14761,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %4)
   %5 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %6)
   %9 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, i32 0, i32 1
@@ -12961,11 +14780,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13033,8 +14852,8 @@ entry:
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
   %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = load i64, i64 addrspace(1)* %19
@@ -13098,8 +14917,8 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.ConsoleStream addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
@@ -13130,31 +14949,31 @@ entry:
   store i8 %param4, i8* %arg4
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %3, %System.IO.Stream addrspace(1)* %1)
   %4 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %4, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
   %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %4, i32 0, i32 4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %5)
   %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %6
   %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
   %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
   %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = load i64, i64 addrspace(1)* %13
@@ -13166,8 +14985,8 @@ entry:
   %21 = load i64, i64* %20
   %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %8, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %8, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %14
   %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 5
@@ -13185,24 +15004,24 @@ entry:
   %31 = load i32, i32* %arg3
   %32 = sext i32 %31 to i64
   %33 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %32)
-  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %30, null
-  br i1 %NullCheck10, label %34, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.StreamWriter addrspace(1)* %30, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %35, %"System.Char[]" addrspace(1)* %33)
   %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %37, null
-  br i1 %NullCheck12, label %38, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.StreamWriter addrspace(1)* %37, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %38
 
 ; <label>:38                                      ; preds = %34
   %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
   %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
   %41 = load i32, i32* %arg3
   %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %42, null
-  br i1 %NullCheck14, label %43, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %42, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
   %44 = load i64, i64 addrspace(1)* %42
@@ -13216,30 +15035,30 @@ entry:
   %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
   %53 = sext i32 %52 to i64
   %54 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %53)
-  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
-  br i1 %NullCheck16, label %55, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %55
 
 ; <label>:55                                      ; preds = %43
   %56 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %56, %"System.Byte[]" addrspace(1)* %54)
   %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %58 = load i32, i32* %arg3
-  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %57, null
-  br i1 %NullCheck18, label %59, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.StreamWriter addrspace(1)* %57, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %59
 
 ; <label>:59                                      ; preds = %55
   %60 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 10
   store i32 %58, i32 addrspace(1)* %60
   %61 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %61, null
-  br i1 %NullCheck20, label %62, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.IO.StreamWriter addrspace(1)* %61, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %62
 
 ; <label>:62                                      ; preds = %59
   %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
   %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
   %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
   %67 = load i64, i64 addrspace(1)* %65
@@ -13257,15 +15076,15 @@ entry:
 
 ; <label>:78                                      ; preds = %66
   %79 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %79, null
-  br i1 %NullCheck24, label %80, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.StreamWriter addrspace(1)* %79, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %80
 
 ; <label>:80                                      ; preds = %78
   %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
   %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
   %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %83, null
-  br i1 %NullCheck26, label %84, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %83, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
   %85 = load i64, i64 addrspace(1)* %83
@@ -13282,8 +15101,8 @@ entry:
 
 ; <label>:95                                      ; preds = %84
   %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.IO.StreamWriter addrspace(1)* %96, null
-  br i1 %NullCheck28, label %97, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.IO.StreamWriter addrspace(1)* %96, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %97
 
 ; <label>:97                                      ; preds = %95
   %98 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 12
@@ -13297,8 +15116,8 @@ entry:
   %103 = icmp eq i32 %102, 0
   %104 = sext i1 %103 to i32
   %105 = trunc i32 %104 to i8
-  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %100, null
-  br i1 %NullCheck30, label %106, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.IO.StreamWriter addrspace(1)* %100, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %106
 
 ; <label>:106                                     ; preds = %99
   %107 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %100, i32 0, i32 13
@@ -13309,63 +15128,63 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %6
+ThrowNullRef4:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %29
+ThrowNullRef10:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %34
+ThrowNullRef12:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %38
+ThrowNullRef14:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %43
+ThrowNullRef16:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %55
+ThrowNullRef18:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %59
+ThrowNullRef20:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %62
+ThrowNullRef22:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %78
+ThrowNullRef24:                                   ; preds = %78
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %80
+ThrowNullRef26:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %95
+ThrowNullRef28:                                   ; preds = %95
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13378,15 +15197,15 @@ entry:
   %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = load i64, i64 addrspace(1)* %4
@@ -13404,7 +15223,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13454,35 +15273,35 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
   %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderNLS addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %7 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.EncoderNLS addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Text.Encoding addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.Encoding addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Text.EncoderNLS addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.EncoderNLS addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
   %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck8 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = load i64, i64 addrspace(1)* %16
@@ -13501,19 +15320,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13539,8 +15358,8 @@ entry:
   %this = alloca %System.Text.Encoding addrspace(1)*
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
@@ -13560,15 +15379,15 @@ entry:
   %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
   store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
   %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
   store i32 0, i32 addrspace(1)* %2
   %3 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, i32 0, i32 2
@@ -13578,15 +15397,15 @@ entry:
 
 ; <label>:8                                       ; preds = %4
   %9 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
   %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
   %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = load i64, i64 addrspace(1)* %13
@@ -13607,15 +15426,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13630,16 +15449,16 @@ entry:
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = load i32, i32* %arg1
   %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
   %7 = load i64, i64 addrspace(1)* %5
@@ -13657,7 +15476,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13694,8 +15513,8 @@ entry:
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
   %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
   %16 = load i64, i64 addrspace(1)* %14
@@ -13716,8 +15535,8 @@ entry:
   %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
   %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
   %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %31, null
-  br i1 %NullCheck2, label %32, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = load i64, i64 addrspace(1)* %31
@@ -13760,7 +15579,7 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13773,14 +15592,14 @@ entry:
   %this = alloca %System.Text.EncoderReplacementFallback addrspace(1)*
   store %System.Text.EncoderReplacementFallback addrspace(1)* %param0, %System.Text.EncoderReplacementFallback addrspace(1)** %this
   %0 = load %System.Text.EncoderReplacementFallback addrspace(1)*, %System.Text.EncoderReplacementFallback addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -13791,7 +15610,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13821,8 +15640,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
@@ -13854,8 +15673,8 @@ entry:
   %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
   store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
@@ -13867,8 +15686,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Threading.Tasks.Task addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %7)
@@ -13891,7 +15710,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13910,8 +15729,8 @@ entry:
   store i8 %param1, i8* %arg1
   store i8 %param2, i8* %arg2
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
@@ -13925,8 +15744,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1, %5
   %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 9
@@ -13957,8 +15776,8 @@ entry:
 
 ; <label>:25                                      ; preds = %8, %20
   %26 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %26, null
-  br i1 %NullCheck4, label %27, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %26, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %26, i32 0, i32 12
@@ -13969,22 +15788,22 @@ entry:
 
 ; <label>:32                                      ; preds = %27
   %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %33, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.IO.StreamWriter addrspace(1)* %33, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %32
   %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 12
   store i8 1, i8 addrspace(1)* %35
   %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
-  br i1 %NullCheck8, label %37, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
   %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
   %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck10 = icmp ne i64 addrspace(1)* %40, null
-  br i1 %NullCheck10, label %41, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64 addrspace(1)* %40, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i64, i64 addrspace(1)* %40
@@ -13998,8 +15817,8 @@ entry:
   %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
   store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
   %51 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %NullCheck12 = icmp ne %"System.Byte[]" addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Byte[]" addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %41
   %53 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %51, i32 0, i32 1
@@ -14011,16 +15830,16 @@ entry:
 
 ; <label>:58                                      ; preds = %52
   %59 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %59, null
-  br i1 %NullCheck14, label %60, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.IO.StreamWriter addrspace(1)* %59, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %60
 
 ; <label>:60                                      ; preds = %58
   %61 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %59, i32 0, i32 3
   %62 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
   %64 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %NullCheck16 = icmp ne %"System.Byte[]" addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %"System.Byte[]" addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %60
   %66 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %64, i32 0, i32 1
@@ -14028,8 +15847,8 @@ entry:
   %68 = zext i32 %67 to i64
   %69 = trunc i64 %68 to i32
   %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck18, label %71, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
   %72 = load i64, i64 addrspace(1)* %70
@@ -14045,29 +15864,29 @@ entry:
 
 ; <label>:80                                      ; preds = %27, %52, %71
   %81 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %81, null
-  br i1 %NullCheck20, label %82, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.IO.StreamWriter addrspace(1)* %81, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
 
 ; <label>:82                                      ; preds = %80
   %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %81, i32 0, i32 5
   %84 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %83, align 8
   %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.IO.StreamWriter addrspace(1)* %85, null
-  br i1 %NullCheck22, label %86, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.IO.StreamWriter addrspace(1)* %85, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %86
 
 ; <label>:86                                      ; preds = %82
   %87 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 7
   %88 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %87, align 8
   %89 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %89, null
-  br i1 %NullCheck24, label %90, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.StreamWriter addrspace(1)* %89, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %90
 
 ; <label>:90                                      ; preds = %86
   %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %89, i32 0, i32 9
   %92 = load i32, i32 addrspace(1)* %91, align 8
   %93 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.IO.StreamWriter addrspace(1)* %93, null
-  br i1 %NullCheck26, label %94, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.IO.StreamWriter addrspace(1)* %93, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %93, i32 0, i32 6
@@ -14075,8 +15894,8 @@ entry:
   %97 = load i8, i8* %arg2
   %98 = zext i8 %97 to i32
   %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
-  %NullCheck28 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck28, label %100, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
   %101 = load i64, i64 addrspace(1)* %99
@@ -14091,8 +15910,8 @@ entry:
   %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
   store i32 %110, i32* %loc1
   %111 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %111, null
-  br i1 %NullCheck30, label %112, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.IO.StreamWriter addrspace(1)* %111, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %112
 
 ; <label>:112                                     ; preds = %100
   %113 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %111, i32 0, i32 9
@@ -14103,23 +15922,23 @@ entry:
 
 ; <label>:116                                     ; preds = %112
   %117 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck32 = icmp ne %System.IO.StreamWriter addrspace(1)* %117, null
-  br i1 %NullCheck32, label %118, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.IO.StreamWriter addrspace(1)* %117, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %118
 
 ; <label>:118                                     ; preds = %116
   %119 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %117, i32 0, i32 3
   %120 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %119, align 8
   %121 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.IO.StreamWriter addrspace(1)* %121, null
-  br i1 %NullCheck34, label %122, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.IO.StreamWriter addrspace(1)* %121, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %122
 
 ; <label>:122                                     ; preds = %118
   %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
   %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
   %125 = load i32, i32* %loc1
   %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
-  %NullCheck36 = icmp ne i64 addrspace(1)* %126, null
-  br i1 %NullCheck36, label %127, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64 addrspace(1)* %126, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
   %128 = load i64, i64 addrspace(1)* %126
@@ -14141,15 +15960,15 @@ entry:
 
 ; <label>:140                                     ; preds = %136
   %141 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.IO.StreamWriter addrspace(1)* %141, null
-  br i1 %NullCheck38, label %142, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.IO.StreamWriter addrspace(1)* %141, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %142
 
 ; <label>:142                                     ; preds = %140
   %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
   %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
   %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
-  %NullCheck40 = icmp ne i64 addrspace(1)* %145, null
-  br i1 %NullCheck40, label %146, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i64 addrspace(1)* %145, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
   %147 = load i64, i64 addrspace(1)* %145
@@ -14170,83 +15989,83 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %25
+ThrowNullRef4:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %32
+ThrowNullRef6:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %37
+ThrowNullRef10:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %41
+ThrowNullRef12:                                   ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %58
+ThrowNullRef14:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %60
+ThrowNullRef16:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %65
+ThrowNullRef18:                                   ; preds = %65
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %80
+ThrowNullRef20:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %82
+ThrowNullRef22:                                   ; preds = %82
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %86
+ThrowNullRef24:                                   ; preds = %86
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %90
+ThrowNullRef26:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %94
+ThrowNullRef28:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %100
+ThrowNullRef30:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %116
+ThrowNullRef32:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %118
+ThrowNullRef34:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %122
+ThrowNullRef36:                                   ; preds = %122
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %140
+ThrowNullRef38:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %142
+ThrowNullRef40:                                   ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14313,8 +16132,8 @@ entry:
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %1 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
-  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
@@ -14322,8 +16141,8 @@ entry:
   %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
   %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
   %8 = load i64, i64 addrspace(1)* %6
@@ -14339,8 +16158,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %17, %System.IFormatProvider addrspace(1)* %16)
   %18 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %19 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %18, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.SyncTextWriter addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %7
   %21 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %18, i32 0, i32 4
@@ -14351,11 +16170,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14368,8 +16187,8 @@ entry:
   %this = alloca %System.IO.TextWriter addrspace(1)*
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.TextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
@@ -14379,8 +16198,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.Threading.Thread addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Threading.Thread addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %6)
@@ -14389,8 +16208,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1
   %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.TextWriter addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.TextWriter addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %11, i32 0, i32 2
@@ -14401,11 +16220,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14425,8 +16244,8 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   store i8 0, i8* %loc1
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
@@ -14436,16 +16255,16 @@ entry:
   %5 = addrspacecast i8* %loc1 to i8 addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %4, i8 addrspace(1)* %5)
   %6 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.SyncTextWriter addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
   %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
   %13 = load i64, i64 addrspace(1)* %11
@@ -14480,19 +16299,229 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
-Failed to read TextWriter.WriteLine[loadElem]
+Failed to read TextWriter.WriteLine[storeElem]
 INFO:  jitting method String::CopyTo using LLILCJit
-Failed to read String.CopyTo[loadElemA]
+Successfully read String.CopyTo
+
+define void @String.CopyTo(%System.String addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  %loc1 = alloca i16 addrspace(1)*
+  %loc2 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %1 = icmp ne %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg4
+  %7 = icmp sge i32 %6, 0
+  br i1 %7, label %13, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  unreachable
+
+; <label>:13                                      ; preds = %5
+  %14 = load i32, i32* %arg1
+  %15 = icmp sge i32 %14, 0
+  br i1 %15, label %21, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %18)
+  %20 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %20, %System.String addrspace(1)* %17, %System.String addrspace(1)* %19)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %20) #0
+  unreachable
+
+; <label>:21                                      ; preds = %13
+  %22 = load i32, i32* %arg4
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck, label %ThrowNullRef, label %24
+
+; <label>:24                                      ; preds = %21
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load i32, i32* %arg1
+  %28 = sub i32 %26, %27
+  %29 = icmp sle i32 %22, %28
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34, %System.String addrspace(1)* %31, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %24
+  %36 = load i32, i32* %arg3
+  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %37, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
+
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
+  %40 = load i32, i32 addrspace(1)* %39
+  %41 = zext i32 %40 to i64
+  %42 = trunc i64 %41 to i32
+  %43 = load i32, i32* %arg4
+  %44 = sub i32 %42, %43
+  %45 = icmp sgt i32 %36, %44
+  br i1 %45, label %49, label %46
+
+; <label>:46                                      ; preds = %38
+  %47 = load i32, i32* %arg3
+  %48 = icmp sge i32 %47, 0
+  br i1 %48, label %54, label %49
+
+; <label>:49                                      ; preds = %38, %46
+  %50 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %52 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %51)
+  %53 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53, %System.String addrspace(1)* %50, %System.String addrspace(1)* %52)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53) #0
+  unreachable
+
+; <label>:54                                      ; preds = %46
+  %55 = load i32, i32* %arg4
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %97, label %57
+
+; <label>:57                                      ; preds = %54
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %59
+
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 2
+  %61 = bitcast [0 x i16] addrspace(1)* %60 to i16 addrspace(1)*
+  store i16 addrspace(1)* %61, i16 addrspace(1)** %loc0
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  store %"System.Char[]" addrspace(1)* %62, %"System.Char[]" addrspace(1)** %loc2
+  %63 = icmp eq %"System.Char[]" addrspace(1)* %62, null
+  br i1 %63, label %72, label %64
+
+; <label>:64                                      ; preds = %59
+  %65 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc2
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %65, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %66
+
+; <label>:66                                      ; preds = %64
+  %67 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %65, i32 0, i32 1
+  %68 = load i32, i32 addrspace(1)* %67
+  %69 = zext i32 %68 to i64
+  %70 = trunc i64 %69 to i32
+  %71 = icmp ne i32 %70, 0
+  br i1 %71, label %73, label %72
+
+; <label>:72                                      ; preds = %59, %66
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  br label %81
+
+; <label>:73                                      ; preds = %66
+  %74 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc2
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %74, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %75
+
+; <label>:75                                      ; preds = %73
+  %76 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %74, i32 0, i32 1
+  %77 = load i32, i32 addrspace(1)* %76
+  %78 = zext i32 %77 to i64
+  %BoundsCheck = icmp uge i64 0, %78
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %79
+
+; <label>:79                                      ; preds = %75
+  %80 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %74, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %80, i16 addrspace(1)** %loc1
+  br label %81
+
+; <label>:81                                      ; preds = %72, %79
+  %82 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %83 = ptrtoint i16 addrspace(1)* %82 to i64
+  %84 = load i32, i32* %arg3
+  %85 = sext i32 %84 to i64
+  %86 = mul i64 %85, 2
+  %87 = add i64 %83, %86
+  %88 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %89 = ptrtoint i16 addrspace(1)* %88 to i64
+  %90 = load i32, i32* %arg1
+  %91 = sext i32 %90 to i64
+  %92 = mul i64 %91, 2
+  %93 = add i64 %89, %92
+  %94 = load i32, i32* %arg4
+  %95 = inttoptr i64 %87 to i16*
+  %96 = inttoptr i64 %93 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %95, i16* %96, i32 %94)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  br label %97
+
+; <label>:97                                      ; preds = %54, %81
+  ret void
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StreamWriter::Write using LLILCJit
 Successfully read StreamWriter.Write
 
@@ -14550,8 +16579,8 @@ entry:
 
 ; <label>:23                                      ; preds = %15
   %24 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Char[]" addrspace(1)* %24, null
-  br i1 %NullCheck, label %25, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %24, null
+  br i1 %NullCheck, label %ThrowNullRef, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %24, i32 0, i32 1
@@ -14579,15 +16608,15 @@ entry:
 
 ; <label>:40                                      ; preds = %98
   %41 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %41, null
-  br i1 %NullCheck4, label %42, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %41, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %42
 
 ; <label>:42                                      ; preds = %40
   %43 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
   %44 = load i32, i32 addrspace(1)* %43, align 8
   %45 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %45, null
-  br i1 %NullCheck6, label %46, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.IO.StreamWriter addrspace(1)* %45, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %46
 
 ; <label>:46                                      ; preds = %42
   %47 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %45, i32 0, i32 10
@@ -14602,15 +16631,15 @@ entry:
 
 ; <label>:52                                      ; preds = %46, %50
   %53 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %53, null
-  br i1 %NullCheck8, label %54, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %53, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %54
 
 ; <label>:54                                      ; preds = %52
   %55 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %53, i32 0, i32 10
   %56 = load i32, i32 addrspace(1)* %55, align 8
   %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %57, null
-  br i1 %NullCheck10, label %58, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.StreamWriter addrspace(1)* %57, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %58
 
 ; <label>:58                                      ; preds = %54
   %59 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 9
@@ -14632,15 +16661,15 @@ entry:
   %69 = load i32, i32* %arg2
   %70 = mul i32 %69, 2
   %71 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %71, null
-  br i1 %NullCheck12, label %72, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.StreamWriter addrspace(1)* %71, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %72
 
 ; <label>:72                                      ; preds = %67
   %73 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %71, i32 0, i32 7
   %74 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %73, align 8
   %75 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %75, null
-  br i1 %NullCheck14, label %76, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.IO.StreamWriter addrspace(1)* %75, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %76
 
 ; <label>:76                                      ; preds = %72
   %77 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %75, i32 0, i32 9
@@ -14652,16 +16681,16 @@ entry:
   %83 = bitcast %"System.Char[]" addrspace(1)* %74 to %System.Array addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %82, i32 %70, %System.Array addrspace(1)* %83, i32 %79, i32 %81)
   %84 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %84, null
-  br i1 %NullCheck16, label %85, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.IO.StreamWriter addrspace(1)* %84, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %85
 
 ; <label>:85                                      ; preds = %76
   %86 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %84, i32 0, i32 9
   %87 = load i32, i32 addrspace(1)* %86, align 8
   %88 = load i32, i32* %loc0
   %89 = add i32 %87, %88
-  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %84, null
-  br i1 %NullCheck18, label %90, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.StreamWriter addrspace(1)* %84, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %90
 
 ; <label>:90                                      ; preds = %85
   %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %84, i32 0, i32 9
@@ -14683,8 +16712,8 @@ entry:
 
 ; <label>:101                                     ; preds = %98
   %102 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %102, null
-  br i1 %NullCheck2, label %103, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %102, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %103
 
 ; <label>:103                                     ; preds = %101
   %104 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %102, i32 0, i32 11
@@ -14705,39 +16734,39 @@ ThrowNullRef:                                     ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %101
+ThrowNullRef2:                                    ; preds = %101
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %40
+ThrowNullRef4:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %42
+ThrowNullRef6:                                    ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %52
+ThrowNullRef8:                                    ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %54
+ThrowNullRef10:                                   ; preds = %54
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %67
+ThrowNullRef12:                                   ; preds = %67
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %72
+ThrowNullRef14:                                   ; preds = %72
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %76
+ThrowNullRef16:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %85
+ThrowNullRef18:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14778,7 +16807,365 @@ entry:
 }
 
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[loadElemA]
+Successfully read EncoderNLS.GetBytes
+
+define i32 @EncoderNLS.GetBytes(%System.Text.EncoderNLS addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3, %"System.Byte[]" addrspace(1)* %param4, i32 %param5, i8 %param6) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %arg4 = alloca %"System.Byte[]" addrspace(1)*
+  %arg5 = alloca i32
+  %arg6 = alloca i8
+  %loc0 = alloca i32
+  %loc1 = alloca i16 addrspace(1)*
+  %loc2 = alloca i8 addrspace(1)*
+  %loc3 = alloca i32
+  %loc4 = alloca %"System.Char[]" addrspace(1)*
+  %loc5 = alloca %"System.Byte[]" addrspace(1)*
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  store %"System.Byte[]" addrspace(1)* %param4, %"System.Byte[]" addrspace(1)** %arg4
+  store i32 %param5, i32* %arg5
+  store i8 %param6, i8* %arg6
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %1 = icmp eq %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %17, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %7 = icmp eq %"System.Char[]" addrspace(1)* %6, null
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %12
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %12
+
+; <label>:12                                      ; preds = %8, %10
+  %13 = phi %System.String addrspace(1)* [ %9, %8 ], [ %11, %10 ]
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %14)
+  %16 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16, %System.String addrspace(1)* %13, %System.String addrspace(1)* %15)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16) #0
+  unreachable
+
+; <label>:17                                      ; preds = %2
+  %18 = load i32, i32* %arg2
+  %19 = icmp slt i32 %18, 0
+  br i1 %19, label %23, label %20
+
+; <label>:20                                      ; preds = %17
+  %21 = load i32, i32* %arg3
+  %22 = icmp sge i32 %21, 0
+  br i1 %22, label %35, label %23
+
+; <label>:23                                      ; preds = %17, %20
+  %24 = load i32, i32* %arg2
+  %25 = icmp slt i32 %24, 0
+  br i1 %25, label %28, label %26
+
+; <label>:26                                      ; preds = %23
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %30
+
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %30
+
+; <label>:30                                      ; preds = %26, %28
+  %31 = phi %System.String addrspace(1)* [ %27, %26 ], [ %29, %28 ]
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34, %System.String addrspace(1)* %31, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %20
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck, label %ThrowNullRef, label %37
+
+; <label>:37                                      ; preds = %35
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = load i32, i32* %arg2
+  %43 = sub i32 %41, %42
+  %44 = load i32, i32* %arg3
+  %45 = icmp sge i32 %43, %44
+  br i1 %45, label %51, label %46
+
+; <label>:46                                      ; preds = %37
+  %47 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %48 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %49 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %48)
+  %50 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %50, %System.String addrspace(1)* %47, %System.String addrspace(1)* %49)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %50) #0
+  unreachable
+
+; <label>:51                                      ; preds = %37
+  %52 = load i32, i32* %arg5
+  %53 = icmp slt i32 %52, 0
+  br i1 %53, label %63, label %54
+
+; <label>:54                                      ; preds = %51
+  %55 = load i32, i32* %arg5
+  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck1 = icmp eq %"System.Byte[]" addrspace(1)* %56, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %57
+
+; <label>:57                                      ; preds = %54
+  %58 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = zext i32 %59 to i64
+  %61 = trunc i64 %60 to i32
+  %62 = icmp sle i32 %55, %61
+  br i1 %62, label %68, label %63
+
+; <label>:63                                      ; preds = %51, %57
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %66 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %65)
+  %67 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %67, %System.String addrspace(1)* %64, %System.String addrspace(1)* %66)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %67) #0
+  unreachable
+
+; <label>:68                                      ; preds = %57
+  %69 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %69, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %69, i32 0, i32 1
+  %72 = load i32, i32 addrspace(1)* %71
+  %73 = zext i32 %72 to i64
+  %74 = trunc i64 %73 to i32
+  %75 = icmp ne i32 %74, 0
+  br i1 %75, label %78, label %76
+
+; <label>:76                                      ; preds = %70
+  %77 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1)
+  store %"System.Char[]" addrspace(1)* %77, %"System.Char[]" addrspace(1)** %arg1
+  br label %78
+
+; <label>:78                                      ; preds = %70, %76
+  %79 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck5 = icmp eq %"System.Byte[]" addrspace(1)* %79, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %80
+
+; <label>:80                                      ; preds = %78
+  %81 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %79, i32 0, i32 1
+  %82 = load i32, i32 addrspace(1)* %81
+  %83 = zext i32 %82 to i64
+  %84 = trunc i64 %83 to i32
+  %85 = load i32, i32* %arg5
+  %86 = sub i32 %84, %85
+  store i32 %86, i32* %loc0
+  %87 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck7 = icmp eq %"System.Byte[]" addrspace(1)* %87, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %88
+
+; <label>:88                                      ; preds = %80
+  %89 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %87, i32 0, i32 1
+  %90 = load i32, i32 addrspace(1)* %89
+  %91 = zext i32 %90 to i64
+  %92 = trunc i64 %91 to i32
+  %93 = icmp ne i32 %92, 0
+  br i1 %93, label %96, label %94
+
+; <label>:94                                      ; preds = %88
+  %95 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1)
+  store %"System.Byte[]" addrspace(1)* %95, %"System.Byte[]" addrspace(1)** %arg4
+  br label %96
+
+; <label>:96                                      ; preds = %88, %94
+  %97 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  store %"System.Char[]" addrspace(1)* %97, %"System.Char[]" addrspace(1)** %loc4
+  %98 = icmp eq %"System.Char[]" addrspace(1)* %97, null
+  br i1 %98, label %107, label %99
+
+; <label>:99                                      ; preds = %96
+  %100 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc4
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %100, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %101
+
+; <label>:101                                     ; preds = %99
+  %102 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %100, i32 0, i32 1
+  %103 = load i32, i32 addrspace(1)* %102
+  %104 = zext i32 %103 to i64
+  %105 = trunc i64 %104 to i32
+  %106 = icmp ne i32 %105, 0
+  br i1 %106, label %108, label %107
+
+; <label>:107                                     ; preds = %96, %101
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  br label %116
+
+; <label>:108                                     ; preds = %101
+  %109 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc4
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %109, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %110
+
+; <label>:110                                     ; preds = %108
+  %111 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %109, i32 0, i32 1
+  %112 = load i32, i32 addrspace(1)* %111
+  %113 = zext i32 %112 to i64
+  %BoundsCheck = icmp uge i64 0, %113
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %114
+
+; <label>:114                                     ; preds = %110
+  %115 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %109, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %115, i16 addrspace(1)** %loc1
+  br label %116
+
+; <label>:116                                     ; preds = %107, %114
+  %117 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  store %"System.Byte[]" addrspace(1)* %117, %"System.Byte[]" addrspace(1)** %loc5
+  %118 = icmp eq %"System.Byte[]" addrspace(1)* %117, null
+  br i1 %118, label %127, label %119
+
+; <label>:119                                     ; preds = %116
+  %120 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc5
+  %NullCheck13 = icmp eq %"System.Byte[]" addrspace(1)* %120, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %121
+
+; <label>:121                                     ; preds = %119
+  %122 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %120, i32 0, i32 1
+  %123 = load i32, i32 addrspace(1)* %122
+  %124 = zext i32 %123 to i64
+  %125 = trunc i64 %124 to i32
+  %126 = icmp ne i32 %125, 0
+  br i1 %126, label %128, label %127
+
+; <label>:127                                     ; preds = %116, %121
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc2
+  br label %136
+
+; <label>:128                                     ; preds = %121
+  %129 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc5
+  %NullCheck15 = icmp eq %"System.Byte[]" addrspace(1)* %129, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %130
+
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %129, i32 0, i32 1
+  %132 = load i32, i32 addrspace(1)* %131
+  %133 = zext i32 %132 to i64
+  %BoundsCheck17 = icmp uge i64 0, %133
+  br i1 %BoundsCheck17, label %ThrowIndexOutOfRange18, label %134
+
+; <label>:134                                     ; preds = %130
+  %135 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %129, i32 0, i32 3, i32 0
+  store i8 addrspace(1)* %135, i8 addrspace(1)** %loc2
+  br label %136
+
+; <label>:136                                     ; preds = %127, %134
+  %137 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %138 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %139 = ptrtoint i16 addrspace(1)* %138 to i64
+  %140 = load i32, i32* %arg2
+  %141 = sext i32 %140 to i64
+  %142 = mul i64 %141, 2
+  %143 = add i64 %139, %142
+  %144 = load i32, i32* %arg3
+  %145 = load i8 addrspace(1)*, i8 addrspace(1)** %loc2
+  %146 = ptrtoint i8 addrspace(1)* %145 to i64
+  %147 = load i32, i32* %arg5
+  %148 = sext i32 %147 to i64
+  %149 = add i64 %146, %148
+  %150 = load i32, i32* %loc0
+  %151 = load i8, i8* %arg6
+  %152 = zext i8 %151 to i32
+  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i64 addrspace(1)*
+  %NullCheck19 = icmp eq i64 addrspace(1)* %153, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %154
+
+; <label>:154                                     ; preds = %136
+  %155 = load i64, i64 addrspace(1)* %153
+  %156 = add i64 %155, 72
+  %157 = inttoptr i64 %156 to i64*
+  %158 = load i64, i64* %157
+  %159 = add i64 %158, 0
+  %160 = inttoptr i64 %159 to i64*
+  %161 = load i64, i64* %160
+  %162 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to %System.Text.Encoder addrspace(1)*
+  %163 = inttoptr i64 %143 to i16*
+  %164 = inttoptr i64 %149 to i8*
+  %165 = trunc i32 %152 to i8
+  %166 = inttoptr i64 %161 to i32 (%System.Text.Encoder addrspace(1)*, i16*, i32, i8*, i32, i8)*
+  %167 = call i32 %166(%System.Text.Encoder addrspace(1)* %162, i16* %163, i32 %144, i8* %164, i32 %150, i8 %165)
+  store i32 %167, i32* %loc3
+  br label %168
+
+; <label>:168                                     ; preds = %154
+  %169 = load i32, i32* %loc3
+  ret i32 %169
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %110
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %119
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange18:                           ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
 Successfully read EncoderNLS.GetBytes
 
@@ -14867,22 +17254,22 @@ entry:
   %40 = load i8, i8* %arg5
   %41 = zext i8 %40 to i32
   %42 = trunc i32 %41 to i8
-  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %39, null
-  br i1 %NullCheck, label %43, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderNLS addrspace(1)* %39, null
+  br i1 %NullCheck, label %ThrowNullRef, label %43
 
 ; <label>:43                                      ; preds = %38
   %44 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
   store i8 %42, i8 addrspace(1)* %44
   %45 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %45, null
-  br i1 %NullCheck2, label %46, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.EncoderNLS addrspace(1)* %45, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %46
 
 ; <label>:46                                      ; preds = %43
   %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %45, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %47
   %48 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.EncoderNLS addrspace(1)* %48, null
-  br i1 %NullCheck4, label %49, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.EncoderNLS addrspace(1)* %48, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %49
 
 ; <label>:49                                      ; preds = %46
   %50 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %48, i32 0, i32 3
@@ -14893,8 +17280,8 @@ entry:
   %55 = load i32, i32* %arg4
   %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck6, label %58, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
   %59 = load i64, i64 addrspace(1)* %57
@@ -14912,15 +17299,15 @@ ThrowNullRef:                                     ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %43
+ThrowNullRef2:                                    ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %46
+ThrowNullRef4:                                    ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %49
+ThrowNullRef6:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -14948,8 +17335,8 @@ entry:
   %4 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0 to %System.IO.ConsoleStream addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*)(%System.IO.ConsoleStream addrspace(1)* %4, %"System.Byte[]" addrspace(1)* %1, i32 %2, i32 %3)
   %5 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
@@ -15034,8 +17421,8 @@ entry:
 
 ; <label>:22                                      ; preds = %8
   %23 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %23, null
-  br i1 %NullCheck, label %24, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Byte[]" addrspace(1)* %23, null
+  br i1 %NullCheck, label %ThrowNullRef, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
@@ -15057,8 +17444,8 @@ entry:
 
 ; <label>:36                                      ; preds = %24
   %37 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %37, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.ConsoleStream addrspace(1)* %37, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %37, i32 0, i32 4
@@ -15079,13 +17466,138 @@ ThrowNullRef:                                     ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %36
+ThrowNullRef2:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
-Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
+Successfully read WindowsConsoleStream.WriteFileNative
+
+define i32 @WindowsConsoleStream.WriteFileNative(i64 %param0, %"System.Byte[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i64
+  %arg1 = alloca %"System.Byte[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i8 addrspace(1)*
+  %loc2 = alloca %"System.Byte[]" addrspace(1)*
+  %loc3 = alloca i32
+  store i64 %param0, i64* %arg0
+  store %"System.Byte[]" addrspace(1)* %param1, %"System.Byte[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Byte[]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = zext i32 %3 to i64
+  %5 = icmp ne i64 %4, 0
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %1
+  ret i32 0
+
+; <label>:7                                       ; preds = %1
+  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  store %"System.Byte[]" addrspace(1)* %8, %"System.Byte[]" addrspace(1)** %loc2
+  %9 = icmp eq %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %9, label %18, label %10
+
+; <label>:10                                      ; preds = %7
+  %11 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc2
+  %NullCheck1 = icmp eq %"System.Byte[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %11, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp ne i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %7, %12
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc1
+  br label %27
+
+; <label>:19                                      ; preds = %12
+  %20 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc2
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %20, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %BoundsCheck = icmp uge i64 0, %24
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %25
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %20, i32 0, i32 3, i32 0
+  store i8 addrspace(1)* %26, i8 addrspace(1)** %loc1
+  br label %27
+
+; <label>:27                                      ; preds = %18, %25
+  %28 = load i64, i64* %arg0
+  %29 = load i8 addrspace(1)*, i8 addrspace(1)** %loc1
+  %30 = ptrtoint i8 addrspace(1)* %29 to i64
+  %31 = load i32, i32* %arg2
+  %32 = sext i32 %31 to i64
+  %33 = add i64 %30, %32
+  %34 = load i32, i32* %arg3
+  %35 = addrspacecast i32* %loc3 to i32 addrspace(1)*
+  %36 = inttoptr i64 %33 to i8*
+  %37 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i8*, i32, i32 addrspace(1)*, i64)*)(i64 %28, i8* %36, i32 %34, i32 addrspace(1)* %35, i64 0)
+  %38 = icmp ugt i32 %37, 0
+  %39 = sext i1 %38 to i32
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc1
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %42, label %41
+
+; <label>:41                                      ; preds = %27
+  ret i32 0
+
+; <label>:42                                      ; preds = %27
+  %43 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  store i32 %43, i32* %loc0
+  %44 = load i32, i32* %loc0
+  %45 = icmp eq i32 %44, 232
+  br i1 %45, label %49, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = load i32, i32* %loc0
+  %48 = icmp ne i32 %47, 109
+  br i1 %48, label %50, label %49
+
+; <label>:49                                      ; preds = %42, %46
+  ret i32 0
+
+; <label>:50                                      ; preds = %46
+  %51 = load i32, i32* %loc0
+  ret i32 %51
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
 Successfully read WindowsConsoleStream.Flush
 
@@ -15094,8 +17606,8 @@ entry:
   %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
   store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
@@ -15130,8 +17642,8 @@ entry:
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
   %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load i64, i64 addrspace(1)* %1
@@ -15172,28 +17684,28 @@ entry:
   store i32 addrspace(1)* %param0, i32 addrspace(1)** %arg0
   store i32 addrspace(1)* %param1, i32 addrspace(1)** %arg1
   %0 = load i32 addrspace(1)*, i32 addrspace(1)** %arg0
-  %NullCheck = icmp ne i32 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i32 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = load i32, i32 addrspace(1)* %0, align 8
   store i32 %2, i32* %loc0
   %3 = load i32 addrspace(1)*, i32 addrspace(1)** %arg0
   %4 = load i32 addrspace(1)*, i32 addrspace(1)** %arg1
-  %NullCheck2 = icmp ne i32 addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i32 addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = load i32, i32 addrspace(1)* %4, align 8
-  %NullCheck4 = icmp ne i32 addrspace(1)* %3, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i32 addrspace(1)* %3, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %5
   store i32 %6, i32 addrspace(1)* %3, align 8
   %8 = load i32 addrspace(1)*, i32 addrspace(1)** %arg1
   %9 = load i32, i32* %loc0
-  %NullCheck6 = icmp ne i32 addrspace(1)* %8, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32 addrspace(1)* %8, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   store i32 %9, i32 addrspace(1)* %8, align 8
@@ -15203,15 +17715,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Switch.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Switch.error.txt
@@ -25,8 +25,8 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
@@ -40,8 +40,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
   %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
@@ -75,7 +75,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -90,8 +90,8 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %NullCheck = icmp ne i8 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = load i8, i8 addrspace(1)* %0, align 8
@@ -125,8 +125,8 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
@@ -159,8 +159,8 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -184,8 +184,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
   store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
@@ -195,8 +195,8 @@ entry:
 ; <label>:4                                       ; preds = %1
   %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
   %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
@@ -206,8 +206,8 @@ entry:
   %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
@@ -221,14 +221,14 @@ entry:
 
 ; <label>:17                                      ; preds = %14
   %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
   %21 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
@@ -238,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -249,8 +249,8 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
@@ -261,27 +261,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %30
+ThrowNullRef10:                                   ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -301,7 +301,89 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
-Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
+Successfully read AppDomainSetup.GetUnsecureApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.GetUnsecureApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %NullCheck = icmp eq %"System.String[]" addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %BoundsCheck = icmp uge i64 0, %5
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %6
+
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 3, i32 0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
+  ret %System.String addrspace(1)* %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_Value using LLILCJit
+Successfully read AppDomainSetup.get_Value
+
+define %"System.String[]" addrspace(1)* @AppDomainSetup.get_Value(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.String[]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 18)
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.String[]" addrspace(1)* addrspace(1)*, %"System.String[]" addrspace(1)*)*)(%"System.String[]" addrspace(1)* addrspace(1)* %9, %"System.String[]" addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %11, i32 0, i32 1
+  %14 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %13, align 8
+  ret %"System.String[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -319,8 +401,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -368,16 +450,16 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
   %5 = load i32, i32 addrspace(1)* %4
   %6 = sub i32 %5, 1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -389,7 +471,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -421,8 +503,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
@@ -456,8 +538,8 @@ entry:
 ; <label>:27                                      ; preds = %19
   %28 = load i32, i32* %arg1
   %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
-  br i1 %NullCheck2, label %30, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %29, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %30
 
 ; <label>:30                                      ; preds = %27
   %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
@@ -493,8 +575,8 @@ entry:
 ; <label>:49                                      ; preds = %46
   %50 = load i32, i32* %arg2
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck4, label %52, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
@@ -517,11 +599,11 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %27
+ThrowNullRef2:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %49
+ThrowNullRef4:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -544,16 +626,16 @@ entry:
   %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %0)
   store %System.String addrspace(1)* %1, %System.String addrspace(1)** %loc0
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 2
   %5 = bitcast [0 x i16] addrspace(1)* %4 to i16 addrspace(1)*
   store i16 addrspace(1)* %5, i16 addrspace(1)** %loc1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %3
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2
@@ -580,7 +662,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -691,15 +773,15 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %NullCheck132 = icmp ne i8* %21, null
-  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+  %NullCheck131 = icmp eq i8* %21, null
+  br i1 %NullCheck131, label %ThrowNullRef132, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = load i8, i8* %21, align 8
   %24 = zext i8 %23 to i32
   %25 = trunc i32 %24 to i8
-  %NullCheck134 = icmp ne i8* %20, null
-  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+  %NullCheck133 = icmp eq i8* %20, null
+  br i1 %NullCheck133, label %ThrowNullRef134, label %26
 
 ; <label>:26                                      ; preds = %22
   store i8 %25, i8* %20, align 8
@@ -709,16 +791,16 @@ entry:
   %28 = load i8*, i8** %arg0
   %29 = load i8*, i8** %arg1
   %30 = bitcast i8* %29 to i16*
-  %NullCheck128 = icmp ne i16* %30, null
-  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+  %NullCheck127 = icmp eq i16* %30, null
+  br i1 %NullCheck127, label %ThrowNullRef128, label %31
 
 ; <label>:31                                      ; preds = %27
   %32 = load i16, i16* %30, align 8
   %33 = sext i16 %32 to i32
   %34 = bitcast i8* %28 to i16*
   %35 = trunc i32 %33 to i16
-  %NullCheck130 = icmp ne i16* %34, null
-  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+  %NullCheck129 = icmp eq i16* %34, null
+  br i1 %NullCheck129, label %ThrowNullRef130, label %36
 
 ; <label>:36                                      ; preds = %31
   store i16 %35, i16* %34, align 8
@@ -728,16 +810,16 @@ entry:
   %38 = load i8*, i8** %arg0
   %39 = load i8*, i8** %arg1
   %40 = bitcast i8* %39 to i16*
-  %NullCheck120 = icmp ne i16* %40, null
-  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+  %NullCheck119 = icmp eq i16* %40, null
+  br i1 %NullCheck119, label %ThrowNullRef120, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i16, i16* %40, align 8
   %43 = sext i16 %42 to i32
   %44 = bitcast i8* %38 to i16*
   %45 = trunc i32 %43 to i16
-  %NullCheck122 = icmp ne i16* %44, null
-  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+  %NullCheck121 = icmp eq i16* %44, null
+  br i1 %NullCheck121, label %ThrowNullRef122, label %46
 
 ; <label>:46                                      ; preds = %41
   store i16 %45, i16* %44, align 8
@@ -745,15 +827,15 @@ entry:
   %48 = getelementptr inbounds i8, i8* %47, i64 2
   %49 = load i8*, i8** %arg1
   %50 = getelementptr inbounds i8, i8* %49, i64 2
-  %NullCheck124 = icmp ne i8* %50, null
-  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+  %NullCheck123 = icmp eq i8* %50, null
+  br i1 %NullCheck123, label %ThrowNullRef124, label %51
 
 ; <label>:51                                      ; preds = %46
   %52 = load i8, i8* %50, align 8
   %53 = zext i8 %52 to i32
   %54 = trunc i32 %53 to i8
-  %NullCheck126 = icmp ne i8* %48, null
-  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+  %NullCheck125 = icmp eq i8* %48, null
+  br i1 %NullCheck125, label %ThrowNullRef126, label %55
 
 ; <label>:55                                      ; preds = %51
   store i8 %54, i8* %48, align 8
@@ -763,14 +845,14 @@ entry:
   %57 = load i8*, i8** %arg0
   %58 = load i8*, i8** %arg1
   %59 = bitcast i8* %58 to i32*
-  %NullCheck116 = icmp ne i32* %59, null
-  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+  %NullCheck115 = icmp eq i32* %59, null
+  br i1 %NullCheck115, label %ThrowNullRef116, label %60
 
 ; <label>:60                                      ; preds = %56
   %61 = load i32, i32* %59, align 8
   %62 = bitcast i8* %57 to i32*
-  %NullCheck118 = icmp ne i32* %62, null
-  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+  %NullCheck117 = icmp eq i32* %62, null
+  br i1 %NullCheck117, label %ThrowNullRef118, label %63
 
 ; <label>:63                                      ; preds = %60
   store i32 %61, i32* %62, align 8
@@ -780,14 +862,14 @@ entry:
   %65 = load i8*, i8** %arg0
   %66 = load i8*, i8** %arg1
   %67 = bitcast i8* %66 to i32*
-  %NullCheck108 = icmp ne i32* %67, null
-  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+  %NullCheck107 = icmp eq i32* %67, null
+  br i1 %NullCheck107, label %ThrowNullRef108, label %68
 
 ; <label>:68                                      ; preds = %64
   %69 = load i32, i32* %67, align 8
   %70 = bitcast i8* %65 to i32*
-  %NullCheck110 = icmp ne i32* %70, null
-  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+  %NullCheck109 = icmp eq i32* %70, null
+  br i1 %NullCheck109, label %ThrowNullRef110, label %71
 
 ; <label>:71                                      ; preds = %68
   store i32 %69, i32* %70, align 8
@@ -795,15 +877,15 @@ entry:
   %73 = getelementptr inbounds i8, i8* %72, i64 4
   %74 = load i8*, i8** %arg1
   %75 = getelementptr inbounds i8, i8* %74, i64 4
-  %NullCheck112 = icmp ne i8* %75, null
-  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+  %NullCheck111 = icmp eq i8* %75, null
+  br i1 %NullCheck111, label %ThrowNullRef112, label %76
 
 ; <label>:76                                      ; preds = %71
   %77 = load i8, i8* %75, align 8
   %78 = zext i8 %77 to i32
   %79 = trunc i32 %78 to i8
-  %NullCheck114 = icmp ne i8* %73, null
-  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+  %NullCheck113 = icmp eq i8* %73, null
+  br i1 %NullCheck113, label %ThrowNullRef114, label %80
 
 ; <label>:80                                      ; preds = %76
   store i8 %79, i8* %73, align 8
@@ -813,14 +895,14 @@ entry:
   %82 = load i8*, i8** %arg0
   %83 = load i8*, i8** %arg1
   %84 = bitcast i8* %83 to i32*
-  %NullCheck100 = icmp ne i32* %84, null
-  br i1 %NullCheck100, label %85, label %ThrowNullRef99
+  %NullCheck99 = icmp eq i32* %84, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %85
 
 ; <label>:85                                      ; preds = %81
   %86 = load i32, i32* %84, align 8
   %87 = bitcast i8* %82 to i32*
-  %NullCheck102 = icmp ne i32* %87, null
-  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+  %NullCheck101 = icmp eq i32* %87, null
+  br i1 %NullCheck101, label %ThrowNullRef102, label %88
 
 ; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
@@ -829,16 +911,16 @@ entry:
   %91 = load i8*, i8** %arg1
   %92 = getelementptr inbounds i8, i8* %91, i64 4
   %93 = bitcast i8* %92 to i16*
-  %NullCheck104 = icmp ne i16* %93, null
-  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+  %NullCheck103 = icmp eq i16* %93, null
+  br i1 %NullCheck103, label %ThrowNullRef104, label %94
 
 ; <label>:94                                      ; preds = %88
   %95 = load i16, i16* %93, align 8
   %96 = sext i16 %95 to i32
   %97 = bitcast i8* %90 to i16*
   %98 = trunc i32 %96 to i16
-  %NullCheck106 = icmp ne i16* %97, null
-  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+  %NullCheck105 = icmp eq i16* %97, null
+  br i1 %NullCheck105, label %ThrowNullRef106, label %99
 
 ; <label>:99                                      ; preds = %94
   store i16 %98, i16* %97, align 8
@@ -848,14 +930,14 @@ entry:
   %101 = load i8*, i8** %arg0
   %102 = load i8*, i8** %arg1
   %103 = bitcast i8* %102 to i32*
-  %NullCheck88 = icmp ne i32* %103, null
-  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+  %NullCheck87 = icmp eq i32* %103, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %104
 
 ; <label>:104                                     ; preds = %100
   %105 = load i32, i32* %103, align 8
   %106 = bitcast i8* %101 to i32*
-  %NullCheck90 = icmp ne i32* %106, null
-  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+  %NullCheck89 = icmp eq i32* %106, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %107
 
 ; <label>:107                                     ; preds = %104
   store i32 %105, i32* %106, align 8
@@ -864,16 +946,16 @@ entry:
   %110 = load i8*, i8** %arg1
   %111 = getelementptr inbounds i8, i8* %110, i64 4
   %112 = bitcast i8* %111 to i16*
-  %NullCheck92 = icmp ne i16* %112, null
-  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+  %NullCheck91 = icmp eq i16* %112, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %113
 
 ; <label>:113                                     ; preds = %107
   %114 = load i16, i16* %112, align 8
   %115 = sext i16 %114 to i32
   %116 = bitcast i8* %109 to i16*
   %117 = trunc i32 %115 to i16
-  %NullCheck94 = icmp ne i16* %116, null
-  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+  %NullCheck93 = icmp eq i16* %116, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %118
 
 ; <label>:118                                     ; preds = %113
   store i16 %117, i16* %116, align 8
@@ -881,15 +963,15 @@ entry:
   %120 = getelementptr inbounds i8, i8* %119, i64 6
   %121 = load i8*, i8** %arg1
   %122 = getelementptr inbounds i8, i8* %121, i64 6
-  %NullCheck96 = icmp ne i8* %122, null
-  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+  %NullCheck95 = icmp eq i8* %122, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %123
 
 ; <label>:123                                     ; preds = %118
   %124 = load i8, i8* %122, align 8
   %125 = zext i8 %124 to i32
   %126 = trunc i32 %125 to i8
-  %NullCheck98 = icmp ne i8* %120, null
-  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+  %NullCheck97 = icmp eq i8* %120, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %127
 
 ; <label>:127                                     ; preds = %123
   store i8 %126, i8* %120, align 8
@@ -899,14 +981,14 @@ entry:
   %129 = load i8*, i8** %arg0
   %130 = load i8*, i8** %arg1
   %131 = bitcast i8* %130 to i64*
-  %NullCheck84 = icmp ne i64* %131, null
-  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+  %NullCheck83 = icmp eq i64* %131, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %132
 
 ; <label>:132                                     ; preds = %128
   %133 = load i64, i64* %131, align 8
   %134 = bitcast i8* %129 to i64*
-  %NullCheck86 = icmp ne i64* %134, null
-  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+  %NullCheck85 = icmp eq i64* %134, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %135
 
 ; <label>:135                                     ; preds = %132
   store i64 %133, i64* %134, align 8
@@ -916,14 +998,14 @@ entry:
   %137 = load i8*, i8** %arg0
   %138 = load i8*, i8** %arg1
   %139 = bitcast i8* %138 to i64*
-  %NullCheck76 = icmp ne i64* %139, null
-  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+  %NullCheck75 = icmp eq i64* %139, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %140
 
 ; <label>:140                                     ; preds = %136
   %141 = load i64, i64* %139, align 8
   %142 = bitcast i8* %137 to i64*
-  %NullCheck78 = icmp ne i64* %142, null
-  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+  %NullCheck77 = icmp eq i64* %142, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %143
 
 ; <label>:143                                     ; preds = %140
   store i64 %141, i64* %142, align 8
@@ -931,15 +1013,15 @@ entry:
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %NullCheck80 = icmp ne i8* %147, null
-  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+  %NullCheck79 = icmp eq i8* %147, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %148
 
 ; <label>:148                                     ; preds = %143
   %149 = load i8, i8* %147, align 8
   %150 = zext i8 %149 to i32
   %151 = trunc i32 %150 to i8
-  %NullCheck82 = icmp ne i8* %145, null
-  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+  %NullCheck81 = icmp eq i8* %145, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %152
 
 ; <label>:152                                     ; preds = %148
   store i8 %151, i8* %145, align 8
@@ -949,14 +1031,14 @@ entry:
   %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
   %156 = bitcast i8* %155 to i64*
-  %NullCheck68 = icmp ne i64* %156, null
-  br i1 %NullCheck68, label %157, label %ThrowNullRef67
+  %NullCheck67 = icmp eq i64* %156, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %157
 
 ; <label>:157                                     ; preds = %153
   %158 = load i64, i64* %156, align 8
   %159 = bitcast i8* %154 to i64*
-  %NullCheck70 = icmp ne i64* %159, null
-  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+  %NullCheck69 = icmp eq i64* %159, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %160
 
 ; <label>:160                                     ; preds = %157
   store i64 %158, i64* %159, align 8
@@ -965,16 +1047,16 @@ entry:
   %163 = load i8*, i8** %arg1
   %164 = getelementptr inbounds i8, i8* %163, i64 8
   %165 = bitcast i8* %164 to i16*
-  %NullCheck72 = icmp ne i16* %165, null
-  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+  %NullCheck71 = icmp eq i16* %165, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %166
 
 ; <label>:166                                     ; preds = %160
   %167 = load i16, i16* %165, align 8
   %168 = sext i16 %167 to i32
   %169 = bitcast i8* %162 to i16*
   %170 = trunc i32 %168 to i16
-  %NullCheck74 = icmp ne i16* %169, null
-  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+  %NullCheck73 = icmp eq i16* %169, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %171
 
 ; <label>:171                                     ; preds = %166
   store i16 %170, i16* %169, align 8
@@ -984,14 +1066,14 @@ entry:
   %173 = load i8*, i8** %arg0
   %174 = load i8*, i8** %arg1
   %175 = bitcast i8* %174 to i64*
-  %NullCheck56 = icmp ne i64* %175, null
-  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+  %NullCheck55 = icmp eq i64* %175, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %176
 
 ; <label>:176                                     ; preds = %172
   %177 = load i64, i64* %175, align 8
   %178 = bitcast i8* %173 to i64*
-  %NullCheck58 = icmp ne i64* %178, null
-  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+  %NullCheck57 = icmp eq i64* %178, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %179
 
 ; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
@@ -1000,16 +1082,16 @@ entry:
   %182 = load i8*, i8** %arg1
   %183 = getelementptr inbounds i8, i8* %182, i64 8
   %184 = bitcast i8* %183 to i16*
-  %NullCheck60 = icmp ne i16* %184, null
-  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+  %NullCheck59 = icmp eq i16* %184, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %185
 
 ; <label>:185                                     ; preds = %179
   %186 = load i16, i16* %184, align 8
   %187 = sext i16 %186 to i32
   %188 = bitcast i8* %181 to i16*
   %189 = trunc i32 %187 to i16
-  %NullCheck62 = icmp ne i16* %188, null
-  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+  %NullCheck61 = icmp eq i16* %188, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %190
 
 ; <label>:190                                     ; preds = %185
   store i16 %189, i16* %188, align 8
@@ -1017,15 +1099,15 @@ entry:
   %192 = getelementptr inbounds i8, i8* %191, i64 10
   %193 = load i8*, i8** %arg1
   %194 = getelementptr inbounds i8, i8* %193, i64 10
-  %NullCheck64 = icmp ne i8* %194, null
-  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+  %NullCheck63 = icmp eq i8* %194, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %195
 
 ; <label>:195                                     ; preds = %190
   %196 = load i8, i8* %194, align 8
   %197 = zext i8 %196 to i32
   %198 = trunc i32 %197 to i8
-  %NullCheck66 = icmp ne i8* %192, null
-  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+  %NullCheck65 = icmp eq i8* %192, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %199
 
 ; <label>:199                                     ; preds = %195
   store i8 %198, i8* %192, align 8
@@ -1035,14 +1117,14 @@ entry:
   %201 = load i8*, i8** %arg0
   %202 = load i8*, i8** %arg1
   %203 = bitcast i8* %202 to i64*
-  %NullCheck48 = icmp ne i64* %203, null
-  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+  %NullCheck47 = icmp eq i64* %203, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %204
 
 ; <label>:204                                     ; preds = %200
   %205 = load i64, i64* %203, align 8
   %206 = bitcast i8* %201 to i64*
-  %NullCheck50 = icmp ne i64* %206, null
-  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+  %NullCheck49 = icmp eq i64* %206, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %207
 
 ; <label>:207                                     ; preds = %204
   store i64 %205, i64* %206, align 8
@@ -1051,14 +1133,14 @@ entry:
   %210 = load i8*, i8** %arg1
   %211 = getelementptr inbounds i8, i8* %210, i64 8
   %212 = bitcast i8* %211 to i32*
-  %NullCheck52 = icmp ne i32* %212, null
-  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+  %NullCheck51 = icmp eq i32* %212, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %213
 
 ; <label>:213                                     ; preds = %207
   %214 = load i32, i32* %212, align 8
   %215 = bitcast i8* %209 to i32*
-  %NullCheck54 = icmp ne i32* %215, null
-  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+  %NullCheck53 = icmp eq i32* %215, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %216
 
 ; <label>:216                                     ; preds = %213
   store i32 %214, i32* %215, align 8
@@ -1068,14 +1150,14 @@ entry:
   %218 = load i8*, i8** %arg0
   %219 = load i8*, i8** %arg1
   %220 = bitcast i8* %219 to i64*
-  %NullCheck36 = icmp ne i64* %220, null
-  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64* %220, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %221
 
 ; <label>:221                                     ; preds = %217
   %222 = load i64, i64* %220, align 8
   %223 = bitcast i8* %218 to i64*
-  %NullCheck38 = icmp ne i64* %223, null
-  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+  %NullCheck37 = icmp eq i64* %223, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %224
 
 ; <label>:224                                     ; preds = %221
   store i64 %222, i64* %223, align 8
@@ -1084,14 +1166,14 @@ entry:
   %227 = load i8*, i8** %arg1
   %228 = getelementptr inbounds i8, i8* %227, i64 8
   %229 = bitcast i8* %228 to i32*
-  %NullCheck40 = icmp ne i32* %229, null
-  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i32* %229, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %230
 
 ; <label>:230                                     ; preds = %224
   %231 = load i32, i32* %229, align 8
   %232 = bitcast i8* %226 to i32*
-  %NullCheck42 = icmp ne i32* %232, null
-  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+  %NullCheck41 = icmp eq i32* %232, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %233
 
 ; <label>:233                                     ; preds = %230
   store i32 %231, i32* %232, align 8
@@ -1099,15 +1181,15 @@ entry:
   %235 = getelementptr inbounds i8, i8* %234, i64 12
   %236 = load i8*, i8** %arg1
   %237 = getelementptr inbounds i8, i8* %236, i64 12
-  %NullCheck44 = icmp ne i8* %237, null
-  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i8* %237, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %238
 
 ; <label>:238                                     ; preds = %233
   %239 = load i8, i8* %237, align 8
   %240 = zext i8 %239 to i32
   %241 = trunc i32 %240 to i8
-  %NullCheck46 = icmp ne i8* %235, null
-  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+  %NullCheck45 = icmp eq i8* %235, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %242
 
 ; <label>:242                                     ; preds = %238
   store i8 %241, i8* %235, align 8
@@ -1117,14 +1199,14 @@ entry:
   %244 = load i8*, i8** %arg0
   %245 = load i8*, i8** %arg1
   %246 = bitcast i8* %245 to i64*
-  %NullCheck24 = icmp ne i64* %246, null
-  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64* %246, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %247
 
 ; <label>:247                                     ; preds = %243
   %248 = load i64, i64* %246, align 8
   %249 = bitcast i8* %244 to i64*
-  %NullCheck26 = icmp ne i64* %249, null
-  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64* %249, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %250
 
 ; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
@@ -1133,14 +1215,14 @@ entry:
   %253 = load i8*, i8** %arg1
   %254 = getelementptr inbounds i8, i8* %253, i64 8
   %255 = bitcast i8* %254 to i32*
-  %NullCheck28 = icmp ne i32* %255, null
-  br i1 %NullCheck28, label %256, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i32* %255, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %256
 
 ; <label>:256                                     ; preds = %250
   %257 = load i32, i32* %255, align 8
   %258 = bitcast i8* %252 to i32*
-  %NullCheck30 = icmp ne i32* %258, null
-  br i1 %NullCheck30, label %259, label %ThrowNullRef29
+  %NullCheck29 = icmp eq i32* %258, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %259
 
 ; <label>:259                                     ; preds = %256
   store i32 %257, i32* %258, align 8
@@ -1149,16 +1231,16 @@ entry:
   %262 = load i8*, i8** %arg1
   %263 = getelementptr inbounds i8, i8* %262, i64 12
   %264 = bitcast i8* %263 to i16*
-  %NullCheck32 = icmp ne i16* %264, null
-  br i1 %NullCheck32, label %265, label %ThrowNullRef31
+  %NullCheck31 = icmp eq i16* %264, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %265
 
 ; <label>:265                                     ; preds = %259
   %266 = load i16, i16* %264, align 8
   %267 = sext i16 %266 to i32
   %268 = bitcast i8* %261 to i16*
   %269 = trunc i32 %267 to i16
-  %NullCheck34 = icmp ne i16* %268, null
-  br i1 %NullCheck34, label %270, label %ThrowNullRef33
+  %NullCheck33 = icmp eq i16* %268, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %270
 
 ; <label>:270                                     ; preds = %265
   store i16 %269, i16* %268, align 8
@@ -1168,14 +1250,14 @@ entry:
   %272 = load i8*, i8** %arg0
   %273 = load i8*, i8** %arg1
   %274 = bitcast i8* %273 to i64*
-  %NullCheck8 = icmp ne i64* %274, null
-  br i1 %NullCheck8, label %275, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64* %274, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %275
 
 ; <label>:275                                     ; preds = %271
   %276 = load i64, i64* %274, align 8
   %277 = bitcast i8* %272 to i64*
-  %NullCheck10 = icmp ne i64* %277, null
-  br i1 %NullCheck10, label %278, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %277, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %278
 
 ; <label>:278                                     ; preds = %275
   store i64 %276, i64* %277, align 8
@@ -1184,14 +1266,14 @@ entry:
   %281 = load i8*, i8** %arg1
   %282 = getelementptr inbounds i8, i8* %281, i64 8
   %283 = bitcast i8* %282 to i32*
-  %NullCheck12 = icmp ne i32* %283, null
-  br i1 %NullCheck12, label %284, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i32* %283, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %284
 
 ; <label>:284                                     ; preds = %278
   %285 = load i32, i32* %283, align 8
   %286 = bitcast i8* %280 to i32*
-  %NullCheck14 = icmp ne i32* %286, null
-  br i1 %NullCheck14, label %287, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i32* %286, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %287
 
 ; <label>:287                                     ; preds = %284
   store i32 %285, i32* %286, align 8
@@ -1200,16 +1282,16 @@ entry:
   %290 = load i8*, i8** %arg1
   %291 = getelementptr inbounds i8, i8* %290, i64 12
   %292 = bitcast i8* %291 to i16*
-  %NullCheck16 = icmp ne i16* %292, null
-  br i1 %NullCheck16, label %293, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i16* %292, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %293
 
 ; <label>:293                                     ; preds = %287
   %294 = load i16, i16* %292, align 8
   %295 = sext i16 %294 to i32
   %296 = bitcast i8* %289 to i16*
   %297 = trunc i32 %295 to i16
-  %NullCheck18 = icmp ne i16* %296, null
-  br i1 %NullCheck18, label %298, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i16* %296, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %298
 
 ; <label>:298                                     ; preds = %293
   store i16 %297, i16* %296, align 8
@@ -1217,15 +1299,15 @@ entry:
   %300 = getelementptr inbounds i8, i8* %299, i64 14
   %301 = load i8*, i8** %arg1
   %302 = getelementptr inbounds i8, i8* %301, i64 14
-  %NullCheck20 = icmp ne i8* %302, null
-  br i1 %NullCheck20, label %303, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i8* %302, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %303
 
 ; <label>:303                                     ; preds = %298
   %304 = load i8, i8* %302, align 8
   %305 = zext i8 %304 to i32
   %306 = trunc i32 %305 to i8
-  %NullCheck22 = icmp ne i8* %300, null
-  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i8* %300, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %307
 
 ; <label>:307                                     ; preds = %303
   store i8 %306, i8* %300, align 8
@@ -1235,14 +1317,14 @@ entry:
   %309 = load i8*, i8** %arg0
   %310 = load i8*, i8** %arg1
   %311 = bitcast i8* %310 to i64*
-  %NullCheck = icmp ne i64* %311, null
-  br i1 %NullCheck, label %312, label %ThrowNullRef
+  %NullCheck = icmp eq i64* %311, null
+  br i1 %NullCheck, label %ThrowNullRef, label %312
 
 ; <label>:312                                     ; preds = %308
   %313 = load i64, i64* %311, align 8
   %314 = bitcast i8* %309 to i64*
-  %NullCheck2 = icmp ne i64* %314, null
-  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64* %314, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %315
 
 ; <label>:315                                     ; preds = %312
   store i64 %313, i64* %314, align 8
@@ -1251,14 +1333,14 @@ entry:
   %318 = load i8*, i8** %arg1
   %319 = getelementptr inbounds i8, i8* %318, i64 8
   %320 = bitcast i8* %319 to i64*
-  %NullCheck4 = icmp ne i64* %320, null
-  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64* %320, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %321
 
 ; <label>:321                                     ; preds = %315
   %322 = load i64, i64* %320, align 8
   %323 = bitcast i8* %317 to i64*
-  %NullCheck6 = icmp ne i64* %323, null
-  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64* %323, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %324
 
 ; <label>:324                                     ; preds = %321
   store i64 %322, i64* %323, align 8
@@ -1286,15 +1368,15 @@ entry:
 ; <label>:338                                     ; preds = %333
   %339 = load i8*, i8** %arg0
   %340 = load i8*, i8** %arg1
-  %NullCheck136 = icmp ne i8* %340, null
-  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+  %NullCheck135 = icmp eq i8* %340, null
+  br i1 %NullCheck135, label %ThrowNullRef136, label %341
 
 ; <label>:341                                     ; preds = %338
   %342 = load i8, i8* %340, align 8
   %343 = zext i8 %342 to i32
   %344 = trunc i32 %343 to i8
-  %NullCheck138 = icmp ne i8* %339, null
-  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+  %NullCheck137 = icmp eq i8* %339, null
+  br i1 %NullCheck137, label %ThrowNullRef138, label %345
 
 ; <label>:345                                     ; preds = %341
   store i8 %344, i8* %339, align 8
@@ -1317,16 +1399,16 @@ entry:
   %357 = load i8*, i8** %arg0
   %358 = load i8*, i8** %arg1
   %359 = bitcast i8* %358 to i16*
-  %NullCheck140 = icmp ne i16* %359, null
-  br i1 %NullCheck140, label %360, label %ThrowNullRef139
+  %NullCheck139 = icmp eq i16* %359, null
+  br i1 %NullCheck139, label %ThrowNullRef140, label %360
 
 ; <label>:360                                     ; preds = %356
   %361 = load i16, i16* %359, align 8
   %362 = sext i16 %361 to i32
   %363 = bitcast i8* %357 to i16*
   %364 = trunc i32 %362 to i16
-  %NullCheck142 = icmp ne i16* %363, null
-  br i1 %NullCheck142, label %365, label %ThrowNullRef141
+  %NullCheck141 = icmp eq i16* %363, null
+  br i1 %NullCheck141, label %ThrowNullRef142, label %365
 
 ; <label>:365                                     ; preds = %360
   store i16 %364, i16* %363, align 8
@@ -1352,14 +1434,14 @@ entry:
   %378 = load i8*, i8** %arg0
   %379 = load i8*, i8** %arg1
   %380 = bitcast i8* %379 to i32*
-  %NullCheck144 = icmp ne i32* %380, null
-  br i1 %NullCheck144, label %381, label %ThrowNullRef143
+  %NullCheck143 = icmp eq i32* %380, null
+  br i1 %NullCheck143, label %ThrowNullRef144, label %381
 
 ; <label>:381                                     ; preds = %377
   %382 = load i32, i32* %380, align 8
   %383 = bitcast i8* %378 to i32*
-  %NullCheck146 = icmp ne i32* %383, null
-  br i1 %NullCheck146, label %384, label %ThrowNullRef145
+  %NullCheck145 = icmp eq i32* %383, null
+  br i1 %NullCheck145, label %ThrowNullRef146, label %384
 
 ; <label>:384                                     ; preds = %381
   store i32 %382, i32* %383, align 8
@@ -1384,14 +1466,14 @@ entry:
   %395 = load i8*, i8** %arg0
   %396 = load i8*, i8** %arg1
   %397 = bitcast i8* %396 to i64*
-  %NullCheck164 = icmp ne i64* %397, null
-  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+  %NullCheck163 = icmp eq i64* %397, null
+  br i1 %NullCheck163, label %ThrowNullRef164, label %398
 
 ; <label>:398                                     ; preds = %394
   %399 = load i64, i64* %397, align 8
   %400 = bitcast i8* %395 to i64*
-  %NullCheck166 = icmp ne i64* %400, null
-  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+  %NullCheck165 = icmp eq i64* %400, null
+  br i1 %NullCheck165, label %ThrowNullRef166, label %401
 
 ; <label>:401                                     ; preds = %398
   store i64 %399, i64* %400, align 8
@@ -1400,14 +1482,14 @@ entry:
   %404 = load i8*, i8** %arg1
   %405 = getelementptr inbounds i8, i8* %404, i64 8
   %406 = bitcast i8* %405 to i64*
-  %NullCheck168 = icmp ne i64* %406, null
-  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+  %NullCheck167 = icmp eq i64* %406, null
+  br i1 %NullCheck167, label %ThrowNullRef168, label %407
 
 ; <label>:407                                     ; preds = %401
   %408 = load i64, i64* %406, align 8
   %409 = bitcast i8* %403 to i64*
-  %NullCheck170 = icmp ne i64* %409, null
-  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+  %NullCheck169 = icmp eq i64* %409, null
+  br i1 %NullCheck169, label %ThrowNullRef170, label %410
 
 ; <label>:410                                     ; preds = %407
   store i64 %408, i64* %409, align 8
@@ -1437,14 +1519,14 @@ entry:
   %425 = load i8*, i8** %arg0
   %426 = load i8*, i8** %arg1
   %427 = bitcast i8* %426 to i64*
-  %NullCheck148 = icmp ne i64* %427, null
-  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+  %NullCheck147 = icmp eq i64* %427, null
+  br i1 %NullCheck147, label %ThrowNullRef148, label %428
 
 ; <label>:428                                     ; preds = %424
   %429 = load i64, i64* %427, align 8
   %430 = bitcast i8* %425 to i64*
-  %NullCheck150 = icmp ne i64* %430, null
-  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+  %NullCheck149 = icmp eq i64* %430, null
+  br i1 %NullCheck149, label %ThrowNullRef150, label %431
 
 ; <label>:431                                     ; preds = %428
   store i64 %429, i64* %430, align 8
@@ -1466,14 +1548,14 @@ entry:
   %441 = load i8*, i8** %arg0
   %442 = load i8*, i8** %arg1
   %443 = bitcast i8* %442 to i32*
-  %NullCheck152 = icmp ne i32* %443, null
-  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+  %NullCheck151 = icmp eq i32* %443, null
+  br i1 %NullCheck151, label %ThrowNullRef152, label %444
 
 ; <label>:444                                     ; preds = %440
   %445 = load i32, i32* %443, align 8
   %446 = bitcast i8* %441 to i32*
-  %NullCheck154 = icmp ne i32* %446, null
-  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+  %NullCheck153 = icmp eq i32* %446, null
+  br i1 %NullCheck153, label %ThrowNullRef154, label %447
 
 ; <label>:447                                     ; preds = %444
   store i32 %445, i32* %446, align 8
@@ -1495,16 +1577,16 @@ entry:
   %457 = load i8*, i8** %arg0
   %458 = load i8*, i8** %arg1
   %459 = bitcast i8* %458 to i16*
-  %NullCheck156 = icmp ne i16* %459, null
-  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+  %NullCheck155 = icmp eq i16* %459, null
+  br i1 %NullCheck155, label %ThrowNullRef156, label %460
 
 ; <label>:460                                     ; preds = %456
   %461 = load i16, i16* %459, align 8
   %462 = sext i16 %461 to i32
   %463 = bitcast i8* %457 to i16*
   %464 = trunc i32 %462 to i16
-  %NullCheck158 = icmp ne i16* %463, null
-  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+  %NullCheck157 = icmp eq i16* %463, null
+  br i1 %NullCheck157, label %ThrowNullRef158, label %465
 
 ; <label>:465                                     ; preds = %460
   store i16 %464, i16* %463, align 8
@@ -1525,15 +1607,15 @@ entry:
 ; <label>:474                                     ; preds = %470
   %475 = load i8*, i8** %arg0
   %476 = load i8*, i8** %arg1
-  %NullCheck160 = icmp ne i8* %476, null
-  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+  %NullCheck159 = icmp eq i8* %476, null
+  br i1 %NullCheck159, label %ThrowNullRef160, label %477
 
 ; <label>:477                                     ; preds = %474
   %478 = load i8, i8* %476, align 8
   %479 = zext i8 %478 to i32
   %480 = trunc i32 %479 to i8
-  %NullCheck162 = icmp ne i8* %475, null
-  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+  %NullCheck161 = icmp eq i8* %475, null
+  br i1 %NullCheck161, label %ThrowNullRef162, label %481
 
 ; <label>:481                                     ; preds = %477
   store i8 %480, i8* %475, align 8
@@ -1553,343 +1635,343 @@ ThrowNullRef:                                     ; preds = %308
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %312
+ThrowNullRef2:                                    ; preds = %312
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %315
+ThrowNullRef4:                                    ; preds = %315
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %321
+ThrowNullRef6:                                    ; preds = %321
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %271
+ThrowNullRef8:                                    ; preds = %271
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %275
+ThrowNullRef10:                                   ; preds = %275
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %278
+ThrowNullRef12:                                   ; preds = %278
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %284
+ThrowNullRef14:                                   ; preds = %284
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %287
+ThrowNullRef16:                                   ; preds = %287
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %293
+ThrowNullRef18:                                   ; preds = %293
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %298
+ThrowNullRef20:                                   ; preds = %298
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %303
+ThrowNullRef22:                                   ; preds = %303
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %243
+ThrowNullRef24:                                   ; preds = %243
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %247
+ThrowNullRef26:                                   ; preds = %247
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %250
+ThrowNullRef28:                                   ; preds = %250
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %256
+ThrowNullRef30:                                   ; preds = %256
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %259
+ThrowNullRef32:                                   ; preds = %259
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %265
+ThrowNullRef34:                                   ; preds = %265
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %217
+ThrowNullRef36:                                   ; preds = %217
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %221
+ThrowNullRef38:                                   ; preds = %221
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %224
+ThrowNullRef40:                                   ; preds = %224
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %230
+ThrowNullRef42:                                   ; preds = %230
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %233
+ThrowNullRef44:                                   ; preds = %233
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %238
+ThrowNullRef46:                                   ; preds = %238
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %200
+ThrowNullRef48:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %204
+ThrowNullRef50:                                   ; preds = %204
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %207
+ThrowNullRef52:                                   ; preds = %207
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %213
+ThrowNullRef54:                                   ; preds = %213
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %172
+ThrowNullRef56:                                   ; preds = %172
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %176
+ThrowNullRef58:                                   ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %179
+ThrowNullRef60:                                   ; preds = %179
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %185
+ThrowNullRef62:                                   ; preds = %185
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %190
+ThrowNullRef64:                                   ; preds = %190
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %195
+ThrowNullRef66:                                   ; preds = %195
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %153
+ThrowNullRef68:                                   ; preds = %153
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %157
+ThrowNullRef70:                                   ; preds = %157
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %160
+ThrowNullRef72:                                   ; preds = %160
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %166
+ThrowNullRef74:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %136
+ThrowNullRef76:                                   ; preds = %136
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %140
+ThrowNullRef78:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %143
+ThrowNullRef80:                                   ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %148
+ThrowNullRef82:                                   ; preds = %148
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %128
+ThrowNullRef84:                                   ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %132
+ThrowNullRef86:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %100
+ThrowNullRef88:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %104
+ThrowNullRef90:                                   ; preds = %104
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %107
+ThrowNullRef92:                                   ; preds = %107
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %113
+ThrowNullRef94:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %118
+ThrowNullRef96:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %123
+ThrowNullRef98:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %81
+ThrowNullRef100:                                  ; preds = %81
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef101:                                  ; preds = %85
+ThrowNullRef102:                                  ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef103:                                  ; preds = %88
+ThrowNullRef104:                                  ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef105:                                  ; preds = %94
+ThrowNullRef106:                                  ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef107:                                  ; preds = %64
+ThrowNullRef108:                                  ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef109:                                  ; preds = %68
+ThrowNullRef110:                                  ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef111:                                  ; preds = %71
+ThrowNullRef112:                                  ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef113:                                  ; preds = %76
+ThrowNullRef114:                                  ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef115:                                  ; preds = %56
+ThrowNullRef116:                                  ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef117:                                  ; preds = %60
+ThrowNullRef118:                                  ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef119:                                  ; preds = %37
+ThrowNullRef120:                                  ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef121:                                  ; preds = %41
+ThrowNullRef122:                                  ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef123:                                  ; preds = %46
+ThrowNullRef124:                                  ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef125:                                  ; preds = %51
+ThrowNullRef126:                                  ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef127:                                  ; preds = %27
+ThrowNullRef128:                                  ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef129:                                  ; preds = %31
+ThrowNullRef130:                                  ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef131:                                  ; preds = %19
+ThrowNullRef132:                                  ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef133:                                  ; preds = %22
+ThrowNullRef134:                                  ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef135:                                  ; preds = %338
+ThrowNullRef136:                                  ; preds = %338
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef137:                                  ; preds = %341
+ThrowNullRef138:                                  ; preds = %341
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef139:                                  ; preds = %356
+ThrowNullRef140:                                  ; preds = %356
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef141:                                  ; preds = %360
+ThrowNullRef142:                                  ; preds = %360
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef143:                                  ; preds = %377
+ThrowNullRef144:                                  ; preds = %377
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef145:                                  ; preds = %381
+ThrowNullRef146:                                  ; preds = %381
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef147:                                  ; preds = %424
+ThrowNullRef148:                                  ; preds = %424
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef149:                                  ; preds = %428
+ThrowNullRef150:                                  ; preds = %428
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef151:                                  ; preds = %440
+ThrowNullRef152:                                  ; preds = %440
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef153:                                  ; preds = %444
+ThrowNullRef154:                                  ; preds = %444
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef155:                                  ; preds = %456
+ThrowNullRef156:                                  ; preds = %456
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef157:                                  ; preds = %460
+ThrowNullRef158:                                  ; preds = %460
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef159:                                  ; preds = %474
+ThrowNullRef160:                                  ; preds = %474
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef161:                                  ; preds = %477
+ThrowNullRef162:                                  ; preds = %477
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef163:                                  ; preds = %394
+ThrowNullRef164:                                  ; preds = %394
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef165:                                  ; preds = %398
+ThrowNullRef166:                                  ; preds = %398
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef167:                                  ; preds = %401
+ThrowNullRef168:                                  ; preds = %401
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef169:                                  ; preds = %407
+ThrowNullRef170:                                  ; preds = %407
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1939,8 +2021,8 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
-  br i1 %NullCheck, label %22, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %ThrowNullRef, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
@@ -1948,8 +2030,8 @@ entry:
   store i32 %24, i32* %loc0
   %25 = load i32, i32* %loc0
   %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %26, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %27
 
 ; <label>:27                                      ; preds = %22
   %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
@@ -1971,7 +2053,7 @@ ThrowNullRef:                                     ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1989,8 +2071,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -2022,15 +2104,15 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2048,16 +2130,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
   %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
   store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %15
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
@@ -2072,8 +2154,8 @@ entry:
   %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
   %29 = ptrtoint i16 addrspace(1)* %28 to i64
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %19
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
@@ -2089,19 +2171,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2114,8 +2196,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
@@ -2128,7 +2210,7 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[loadElem]
+Failed to read AppDomain.PrepareDataForSetup[storeElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
@@ -2202,8 +2284,8 @@ entry:
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
-  br i1 %NullCheck24, label %27, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = load i64, i64 addrspace(1)* %26
@@ -2218,8 +2300,8 @@ entry:
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
-  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
   %41 = load i64, i64 addrspace(1)* %39
@@ -2236,8 +2318,8 @@ entry:
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
-  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
   %54 = load i64, i64 addrspace(1)* %52
@@ -2252,8 +2334,8 @@ entry:
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
   %67 = load i64, i64 addrspace(1)* %65
@@ -2270,8 +2352,8 @@ entry:
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
-  br i1 %NullCheck16, label %79, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
   %80 = load i64, i64 addrspace(1)* %78
@@ -2286,8 +2368,8 @@ entry:
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
-  br i1 %NullCheck18, label %92, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
   %93 = load i64, i64 addrspace(1)* %91
@@ -2304,8 +2386,8 @@ entry:
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
-  br i1 %NullCheck12, label %105, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = load i64, i64 addrspace(1)* %104
@@ -2320,8 +2402,8 @@ entry:
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
-  br i1 %NullCheck14, label %118, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
   %119 = load i64, i64 addrspace(1)* %117
@@ -2337,8 +2419,8 @@ entry:
 
 ; <label>:128                                     ; preds = %20
   %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
-  br i1 %NullCheck4, label %130, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %129, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %130
 
 ; <label>:130                                     ; preds = %128
   %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
@@ -2346,8 +2428,8 @@ entry:
   %133 = load i16, i16 addrspace(1)* %132, align 8
   %134 = zext i16 %133 to i32
   %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
-  br i1 %NullCheck6, label %136, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %135, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %136
 
 ; <label>:136                                     ; preds = %130
   %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
@@ -2360,8 +2442,8 @@ entry:
 
 ; <label>:143                                     ; preds = %136
   %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
-  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %144, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %145
 
 ; <label>:145                                     ; preds = %143
   %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
@@ -2369,8 +2451,8 @@ entry:
   %148 = load i16, i16 addrspace(1)* %147, align 8
   %149 = zext i16 %148 to i32
   %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %150, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %151
 
 ; <label>:151                                     ; preds = %145
   %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
@@ -2388,8 +2470,8 @@ entry:
 
 ; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
-  br i1 %NullCheck, label %163, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %ThrowNullRef, label %163
 
 ; <label>:163                                     ; preds = %161
   %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
@@ -2399,8 +2481,8 @@ entry:
 
 ; <label>:167                                     ; preds = %163
   %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
-  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %168, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %169
 
 ; <label>:169                                     ; preds = %167
   %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
@@ -2432,55 +2514,55 @@ ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %167
+ThrowNullRef2:                                    ; preds = %167
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %128
+ThrowNullRef4:                                    ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %130
+ThrowNullRef6:                                    ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %143
+ThrowNullRef8:                                    ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %145
+ThrowNullRef10:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %102
+ThrowNullRef12:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %105
+ThrowNullRef14:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %76
+ThrowNullRef16:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %79
+ThrowNullRef18:                                   ; preds = %79
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %50
+ThrowNullRef20:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %53
+ThrowNullRef22:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %24
+ThrowNullRef24:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %27
+ThrowNullRef26:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2503,15 +2585,15 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2519,16 +2601,16 @@ entry:
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
   store i32 %8, i32* %loc0
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
   %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
   store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
@@ -2546,16 +2628,16 @@ entry:
 
 ; <label>:23                                      ; preds = %64
   %24 = load i16*, i16** %loc3
-  %NullCheck12 = icmp ne i16* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i16* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
   store i32 %27, i32* %loc5
   %28 = load i16*, i16** %loc4
-  %NullCheck14 = icmp ne i16* %28, null
-  br i1 %NullCheck14, label %29, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %28, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = load i16, i16* %28, align 8
@@ -2620,15 +2702,15 @@ entry:
 
 ; <label>:67                                      ; preds = %64
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
-  br i1 %NullCheck8, label %69, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %68, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %69
 
 ; <label>:69                                      ; preds = %67
   %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
   %71 = load i32, i32 addrspace(1)* %70
   %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
-  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %73
 
 ; <label>:73                                      ; preds = %69
   %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
@@ -2645,31 +2727,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %67
+ThrowNullRef8:                                    ; preds = %67
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %69
+ThrowNullRef10:                                   ; preds = %69
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2710,14 +2792,14 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
   %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
@@ -2730,14 +2812,14 @@ entry:
 
 ; <label>:11                                      ; preds = %4
   %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
   %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
@@ -2749,14 +2831,14 @@ entry:
 
 ; <label>:22                                      ; preds = %16
   %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
   %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
-  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
-  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
@@ -2804,23 +2886,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2836,7 +2918,280 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[loadElem]
+Successfully read RuntimeType.IsAssignableFrom
+
+define i8 @RuntimeType.IsAssignableFrom(%System.RuntimeType addrspace(1)* %param0, %System.Type addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.RuntimeType addrspace(1)*
+  %arg1 = alloca %System.Type addrspace(1)*
+  %loc0 = alloca %System.RuntimeType addrspace(1)*
+  %loc1 = alloca %"System.Type[]" addrspace(1)*
+  %loc2 = alloca i32
+  store %System.RuntimeType addrspace(1)* %param0, %System.RuntimeType addrspace(1)** %this
+  store %System.Type addrspace(1)* %param1, %System.Type addrspace(1)** %arg1
+  %0 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %1 = icmp ne %System.Type addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i8 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %5 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %6 = bitcast %System.Type addrspace(1)* %4 to %System.Object addrspace(1)*
+  %7 = bitcast %System.RuntimeType addrspace(1)* %5 to %System.Object addrspace(1)*
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %6, %System.Object addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %3
+  ret i8 1
+
+; <label>:12                                      ; preds = %3
+  %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 152
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 32
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
+  %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
+  %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
+  store %System.RuntimeType addrspace(1)* %25, %System.RuntimeType addrspace(1)** %loc0
+  %26 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %27 = icmp eq %System.RuntimeType addrspace(1)* %26, null
+  br i1 %27, label %34, label %28
+
+; <label>:28                                      ; preds = %15
+  %29 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %30 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)*)*)(%System.RuntimeType addrspace(1)* %29, %System.RuntimeType addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+; <label>:34                                      ; preds = %15
+  %35 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %36 = call %System.Reflection.Emit.TypeBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Reflection.Emit.TypeBuilder addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %35)
+  %37 = icmp eq %System.Reflection.Emit.TypeBuilder addrspace(1)* %36, null
+  br i1 %37, label %139, label %38
+
+; <label>:38                                      ; preds = %34
+  %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %42
+
+; <label>:42                                      ; preds = %38
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 152
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 40
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
+  %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
+  %53 = zext i8 %52 to i32
+  %54 = icmp eq i32 %53, 0
+  br i1 %54, label %56, label %55
+
+; <label>:55                                      ; preds = %42
+  ret i8 1
+
+; <label>:56                                      ; preds = %42
+  %57 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %58 = bitcast %System.RuntimeType addrspace(1)* %57 to %System.Type addrspace(1)*
+  %59 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %58)
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %64 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.Type addrspace(1)* %63, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = bitcast %System.RuntimeType addrspace(1)* %64 to %System.Type addrspace(1)*
+  %67 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %63, %System.Type addrspace(1)* %66)
+  %68 = zext i8 %67 to i32
+  %69 = trunc i32 %68 to i8
+  ret i8 %69
+
+; <label>:70                                      ; preds = %56
+  %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
+  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %73
+
+; <label>:73                                      ; preds = %70
+  %74 = load i64, i64 addrspace(1)* %72
+  %75 = add i64 %74, 128
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = add i64 %77, 0
+  %79 = inttoptr i64 %78 to i64*
+  %80 = load i64, i64* %79
+  %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
+  %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
+  %83 = call i8 %82(%System.Type addrspace(1)* %81)
+  %84 = zext i8 %83 to i32
+  %85 = icmp eq i32 %84, 0
+  br i1 %85, label %139, label %86
+
+; <label>:86                                      ; preds = %73
+  %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
+  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %89
+
+; <label>:89                                      ; preds = %86
+  %90 = load i64, i64 addrspace(1)* %88
+  %91 = add i64 %90, 128
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = add i64 %93, 24
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
+  %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
+  %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
+  store %"System.Type[]" addrspace(1)* %99, %"System.Type[]" addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %129
+
+; <label>:100                                     ; preds = %132
+  %101 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %102 = load i32, i32* %loc2
+  %NullCheck11 = icmp eq %"System.Type[]" addrspace(1)* %101, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %103
+
+; <label>:103                                     ; preds = %100
+  %104 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 1
+  %105 = load i32, i32 addrspace(1)* %104
+  %106 = zext i32 %105 to i64
+  %107 = zext i32 %102 to i64
+  %BoundsCheck = icmp uge i64 %107, %106
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %108
+
+; <label>:108                                     ; preds = %103
+  %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
+  %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
+  %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
+  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %113
+
+; <label>:113                                     ; preds = %108
+  %114 = load i64, i64 addrspace(1)* %112
+  %115 = add i64 %114, 152
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = add i64 %117, 56
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
+  %123 = zext i8 %122 to i32
+  %124 = icmp ne i32 %123, 0
+  br i1 %124, label %126, label %125
+
+; <label>:125                                     ; preds = %113
+  ret i8 0
+
+; <label>:126                                     ; preds = %113
+  %127 = load i32, i32* %loc2
+  %128 = add i32 %127, 1
+  store i32 %128, i32* %loc2
+  br label %129
+
+; <label>:129                                     ; preds = %89, %126
+  %130 = load i32, i32* %loc2
+  %131 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %NullCheck9 = icmp eq %"System.Type[]" addrspace(1)* %131, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %132
+
+; <label>:132                                     ; preds = %129
+  %133 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %131, i32 0, i32 1
+  %134 = load i32, i32 addrspace(1)* %133
+  %135 = zext i32 %134 to i64
+  %136 = trunc i64 %135 to i32
+  %137 = icmp slt i32 %130, %136
+  br i1 %137, label %100, label %138
+
+; <label>:138                                     ; preds = %132
+  ret i8 1
+
+; <label>:139                                     ; preds = %34, %73
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %129
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %103
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -2893,7 +3248,7 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElem]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -2904,8 +3259,8 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -2997,8 +3352,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
@@ -3059,8 +3414,8 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -3087,8 +3442,8 @@ entry:
 
 ; <label>:17                                      ; preds = %5, %11
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
@@ -3097,8 +3452,8 @@ entry:
 
 ; <label>:22                                      ; preds = %1, %11
   %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
@@ -3109,11 +3464,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %17
+ThrowNullRef2:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %22
+ThrowNullRef4:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3167,15 +3522,15 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
   %15 = load i32, i32 addrspace(1)* %14
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
@@ -3198,7 +3553,7 @@ ThrowNullRef:                                     ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef2:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3232,8 +3587,8 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
@@ -3312,8 +3667,8 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -3327,8 +3682,8 @@ entry:
 ; <label>:5                                       ; preds = %43
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %7 = load i32, i32* %loc1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck6, label %8, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
@@ -3366,8 +3721,8 @@ entry:
 ; <label>:32                                      ; preds = %21, %25
   %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
   %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
-  br i1 %NullCheck8, label %35, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = trunc i32 %34 to i16
@@ -3380,8 +3735,8 @@ entry:
 ; <label>:40                                      ; preds = %1, %35
   %41 = load i32, i32* %loc1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
-  br i1 %NullCheck2, label %43, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %42, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
@@ -3392,8 +3747,8 @@ entry:
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
   %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
-  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
   %51 = load i64, i64 addrspace(1)* %49
@@ -3412,19 +3767,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %40
+ThrowNullRef2:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %47
+ThrowNullRef4:                                    ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %5
+ThrowNullRef6:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %32
+ThrowNullRef8:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3467,8 +3822,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
@@ -3492,11 +3847,391 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(i16* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store i16* %param0, i16** %arg0
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load i32, i32* %arg3
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %42, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %37, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg2
+  %13 = load i32, i32* %arg3
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %37, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %24 = load i32, i32* %arg2
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load i16*, i16** %arg0
+  %35 = load i32, i32* %arg3
+  %36 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %36, i16* %34, i32 %35)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:37                                      ; preds = %5, %16
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %39)
+  %41 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41, %System.String addrspace(1)* %38, %System.String addrspace(1)* %40)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41) #0
+  unreachable
+
+; <label>:42                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
-Failed to read StringBuilder.ToString[loadElemA]
+Successfully read StringBuilder.ToString
+
+define %System.String addrspace(1)* @StringBuilder.ToString(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i16*
+  %loc3 = alloca %"System.Char[]" addrspace(1)*
+  %loc4 = alloca i32
+  %loc5 = alloca i32
+  %loc6 = alloca i16 addrspace(1)*
+  %loc7 = alloca %System.String addrspace(1)*
+  %loc8 = alloca %"System.Char[]" addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %0)
+  %2 = icmp ne i32 %1, 0
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %4
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %6)
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %7)
+  store %System.String addrspace(1)* %8, %System.String addrspace(1)** %loc0
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.Text.StringBuilder addrspace(1)* %9, %System.Text.StringBuilder addrspace(1)** %loc1
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  store %System.String addrspace(1)* %10, %System.String addrspace(1)** %loc7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc7
+  %12 = ptrtoint %System.String addrspace(1)* %11 to i64
+  %13 = icmp eq i64 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %5
+  %15 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %16 = sext i32 %15 to i64
+  %17 = add i64 %12, %16
+  br label %18
+
+; <label>:18                                      ; preds = %5, %14
+  %19 = phi i64 [ %12, %5 ], [ %17, %14 ]
+  %20 = inttoptr i64 %19 to i16*
+  store i16* %20, i16** %loc2
+  br label %21
+
+; <label>:21                                      ; preds = %98, %18
+  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %22, null
+  br i1 %NullCheck, label %ThrowNullRef, label %23
+
+; <label>:23                                      ; preds = %21
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 3
+  %25 = load i32, i32 addrspace(1)* %24, align 8
+  %26 = icmp sle i32 %25, 0
+  br i1 %26, label %96, label %27
+
+; <label>:27                                      ; preds = %23
+  %28 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %28, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %29
+
+; <label>:29                                      ; preds = %27
+  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %28, i32 0, i32 1
+  %31 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %30, align 8
+  store %"System.Char[]" addrspace(1)* %31, %"System.Char[]" addrspace(1)** %loc3
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %33
+
+; <label>:33                                      ; preds = %29
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  store i32 %35, i32* %loc4
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  %39 = load i32, i32 addrspace(1)* %38, align 8
+  store i32 %39, i32* %loc5
+  %40 = load i32, i32* %loc5
+  %41 = load i32, i32* %loc4
+  %42 = add i32 %40, %41
+  %43 = zext i32 %42 to i64
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %45
+
+; <label>:45                                      ; preds = %37
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = sext i32 %47 to i64
+  %49 = icmp sgt i64 %43, %48
+  br i1 %49, label %91, label %50
+
+; <label>:50                                      ; preds = %45
+  %51 = load i32, i32* %loc5
+  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %52, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %53
+
+; <label>:53                                      ; preds = %50
+  %54 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %52, i32 0, i32 1
+  %55 = load i32, i32 addrspace(1)* %54
+  %56 = zext i32 %55 to i64
+  %57 = trunc i64 %56 to i32
+  %58 = icmp ugt i32 %51, %57
+  br i1 %58, label %91, label %59
+
+; <label>:59                                      ; preds = %53
+  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  store %"System.Char[]" addrspace(1)* %60, %"System.Char[]" addrspace(1)** %loc8
+  %61 = icmp eq %"System.Char[]" addrspace(1)* %60, null
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %63, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %64
+
+; <label>:64                                      ; preds = %62
+  %65 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %63, i32 0, i32 1
+  %66 = load i32, i32 addrspace(1)* %65
+  %67 = zext i32 %66 to i64
+  %68 = trunc i64 %67 to i32
+  %69 = icmp ne i32 %68, 0
+  br i1 %69, label %71, label %70
+
+; <label>:70                                      ; preds = %59, %64
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:71                                      ; preds = %64
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %73
+
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %BoundsCheck = icmp uge i64 0, %76
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %77
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %78, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:79                                      ; preds = %70, %77
+  %80 = load i16*, i16** %loc2
+  %81 = load i32, i32* %loc4
+  %82 = sext i32 %81 to i64
+  %83 = mul i64 %82, 2
+  %84 = bitcast i16* %80 to i8*
+  %85 = getelementptr inbounds i8, i8* %84, i64 %83
+  %86 = load i16 addrspace(1)*, i16 addrspace(1)** %loc6
+  %87 = ptrtoint i16 addrspace(1)* %86 to i64
+  %88 = load i32, i32* %loc5
+  %89 = bitcast i8* %85 to i16*
+  %90 = inttoptr i64 %87 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %89, i16* %90, i32 %88)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %96
+
+; <label>:91                                      ; preds = %45, %53
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %94 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %93)
+  %95 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95, %System.String addrspace(1)* %92, %System.String addrspace(1)* %94)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95) #0
+  unreachable
+
+; <label>:96                                      ; preds = %23, %79
+  %97 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %97, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %98
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %97, i32 0, i32 2
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  store %System.Text.StringBuilder addrspace(1)* %100, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %102 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %102, label %21, label %103
+
+; <label>:103                                     ; preds = %98
+  store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc7
+  %104 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  ret %System.String addrspace(1)* %104
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method StringBuilder::get_Length using LLILCJit
+Successfully read StringBuilder.get_Length
+
+define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
+Successfully read RuntimeHelpers.get_OffsetToStringData
+
+define i32 @RuntimeHelpers.get_OffsetToStringData() {
+entry:
+  ret i32 12
+}
+
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
 Successfully read CultureData.CreateCultureData
 
@@ -3514,23 +4249,23 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
   store i8 %4, i8 addrspace(1)* %6
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
@@ -3549,11 +4284,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3566,50 +4301,50 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
   store i32 -1, i32 addrspace(1)* %2
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
   store i32 -1, i32 addrspace(1)* %8
   %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
   store i32 -1, i32 addrspace(1)* %14
   %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
   store i32 -1, i32 addrspace(1)* %17
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
@@ -3623,27 +4358,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3675,7 +4410,136 @@ Failed to read Dictionary`2.Insert[non-const derefAddress]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
 Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
-Failed to read HashHelpers.GetPrime[loadElem]
+Successfully read HashHelpers.GetPrime
+
+define i32 @HashHelpers.GetPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %6, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5, %System.String addrspace(1)* %4)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5) #0
+  unreachable
+
+; <label>:6                                       ; preds = %entry
+  store i32 0, i32* %loc0
+  br label %29
+
+; <label>:7                                       ; preds = %35
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 1296
+  %10 = addrspacecast i8 addrspace(1)* %9 to %"System.Int32[]" addrspace(1)**
+  %11 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %10
+  %12 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Int32[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = zext i32 %15 to i64
+  %17 = zext i32 %12 to i64
+  %BoundsCheck = icmp uge i64 %17, %16
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 3, i32 %12
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  store i32 %20, i32* %loc1
+  %21 = load i32, i32* %loc1
+  %22 = load i32, i32* %arg0
+  %23 = icmp slt i32 %21, %22
+  br i1 %23, label %26, label %24
+
+; <label>:24                                      ; preds = %18
+  %25 = load i32, i32* %loc1
+  ret i32 %25
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %loc0
+  %28 = add i32 %27, 1
+  store i32 %28, i32* %loc0
+  br label %29
+
+; <label>:29                                      ; preds = %6, %26
+  %30 = load i32, i32* %loc0
+  %31 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %32 = getelementptr inbounds i8, i8 addrspace(1)* %31, i64 1296
+  %33 = addrspacecast i8 addrspace(1)* %32 to %"System.Int32[]" addrspace(1)**
+  %34 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %33
+  %NullCheck = icmp eq %"System.Int32[]" addrspace(1)* %34, null
+  br i1 %NullCheck, label %ThrowNullRef, label %35
+
+; <label>:35                                      ; preds = %29
+  %36 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %34, i32 0, i32 1
+  %37 = load i32, i32 addrspace(1)* %36
+  %38 = zext i32 %37 to i64
+  %39 = trunc i64 %38 to i32
+  %40 = icmp slt i32 %30, %39
+  br i1 %40, label %7, label %41
+
+; <label>:41                                      ; preds = %35
+  %42 = load i32, i32* %arg0
+  %43 = or i32 %42, 1
+  store i32 %43, i32* %loc2
+  br label %59
+
+; <label>:44                                      ; preds = %59
+  %45 = load i32, i32* %loc2
+  %46 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %45)
+  %47 = zext i8 %46 to i32
+  %48 = icmp eq i32 %47, 0
+  br i1 %48, label %56, label %49
+
+; <label>:49                                      ; preds = %44
+  %50 = load i32, i32* %loc2
+  %51 = sub i32 %50, 1
+  %52 = srem i32 %51, 101
+  %53 = icmp eq i32 %52, 0
+  br i1 %53, label %56, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = load i32, i32* %loc2
+  ret i32 %55
+
+; <label>:56                                      ; preds = %44, %49
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %57, 2
+  store i32 %58, i32* %loc2
+  br label %59
+
+; <label>:59                                      ; preds = %41, %56
+  %60 = load i32, i32* %loc2
+  %61 = icmp slt i32 %60, 2147483647
+  br i1 %61, label %44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load i32, i32* %arg0
+  ret i32 %63
+
+ThrowNullRef:                                     ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
 Successfully read GenericEqualityComparer`1.GetHashCode
 
@@ -3694,14 +4558,14 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
   %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load i64, i64 addrspace(1)* %7
@@ -3720,7 +4584,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3750,8 +4614,8 @@ entry:
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
@@ -3796,8 +4660,8 @@ entry:
   %35 = bitcast i16* %34 to i8*
   %36 = getelementptr inbounds i8, i8* %35, i64 2
   %37 = bitcast i8* %36 to i16*
-  %NullCheck4 = icmp ne i16* %37, null
-  br i1 %NullCheck4, label %38, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %37, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %38
 
 ; <label>:38                                      ; preds = %27
   %39 = load i16, i16* %37, align 8
@@ -3824,8 +4688,8 @@ entry:
 
 ; <label>:54                                      ; preds = %22, %43
   %55 = load i16*, i16** %loc4
-  %NullCheck2 = icmp ne i16* %55, null
-  br i1 %NullCheck2, label %56, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i16* %55, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %56
 
 ; <label>:56                                      ; preds = %54
   %57 = load i16, i16* %55, align 8
@@ -3850,11 +4714,11 @@ ThrowNullRef:                                     ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %54
+ThrowNullRef2:                                    ; preds = %54
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %27
+ThrowNullRef4:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3871,8 +4735,8 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -3907,8 +4771,8 @@ entry:
 
 ; <label>:26                                      ; preds = %19
   %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
-  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %28
 
 ; <label>:28                                      ; preds = %26
   %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
@@ -3920,7 +4784,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3972,8 +4836,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
@@ -3984,26 +4848,26 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
-  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
@@ -4014,8 +4878,8 @@ entry:
 ; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
@@ -4024,8 +4888,8 @@ entry:
 
 ; <label>:25                                      ; preds = %1, %16, %23
   %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
-  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
@@ -4036,27 +4900,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %20
+ThrowNullRef10:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4069,8 +4933,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -4081,8 +4945,8 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
@@ -4091,8 +4955,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1, %8
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
@@ -4103,11 +4967,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4128,24 +4992,24 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   store i32 %3, i32* %loc0
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
   %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
   store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck4, label %9, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
@@ -4164,15 +5028,15 @@ entry:
 ; <label>:18                                      ; preds = %70
   %19 = load i16*, i16** %loc3
   %20 = bitcast i16* %19 to i64*
-  %NullCheck10 = icmp ne i64* %20, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %20, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = load i64, i64* %20, align 8
   %23 = load i16*, i16** %loc4
   %24 = bitcast i16* %23 to i64*
-  %NullCheck12 = icmp ne i64* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = load i64, i64* %24, align 8
@@ -4188,8 +5052,8 @@ entry:
   %31 = bitcast i16* %30 to i8*
   %32 = getelementptr inbounds i8, i8* %31, i64 8
   %33 = bitcast i8* %32 to i64*
-  %NullCheck14 = icmp ne i64* %33, null
-  br i1 %NullCheck14, label %34, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = load i64, i64* %33, align 8
@@ -4197,8 +5061,8 @@ entry:
   %37 = bitcast i16* %36 to i8*
   %38 = getelementptr inbounds i8, i8* %37, i64 8
   %39 = bitcast i8* %38 to i64*
-  %NullCheck16 = icmp ne i64* %39, null
-  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %40
 
 ; <label>:40                                      ; preds = %34
   %41 = load i64, i64* %39, align 8
@@ -4214,8 +5078,8 @@ entry:
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %NullCheck18 = icmp ne i64* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = load i64, i64* %48, align 8
@@ -4223,8 +5087,8 @@ entry:
   %52 = bitcast i16* %51 to i8*
   %53 = getelementptr inbounds i8, i8* %52, i64 16
   %54 = bitcast i8* %53 to i64*
-  %NullCheck20 = icmp ne i64* %54, null
-  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64* %54, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %55
 
 ; <label>:55                                      ; preds = %49
   %56 = load i64, i64* %54, align 8
@@ -4262,15 +5126,15 @@ entry:
 ; <label>:74                                      ; preds = %95
   %75 = load i16*, i16** %loc3
   %76 = bitcast i16* %75 to i32*
-  %NullCheck6 = icmp ne i32* %76, null
-  br i1 %NullCheck6, label %77, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32* %76, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %77
 
 ; <label>:77                                      ; preds = %74
   %78 = load i32, i32* %76, align 8
   %79 = load i16*, i16** %loc4
   %80 = bitcast i16* %79 to i32*
-  %NullCheck8 = icmp ne i32* %80, null
-  br i1 %NullCheck8, label %81, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i32* %80, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %81
 
 ; <label>:81                                      ; preds = %77
   %82 = load i32, i32* %80, align 8
@@ -4318,43 +5182,43 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %74
+ThrowNullRef6:                                    ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %77
+ThrowNullRef8:                                    ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %29
+ThrowNullRef14:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %34
+ThrowNullRef16:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4376,8 +5240,8 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load i64, i64 addrspace(1)* %4
@@ -4389,8 +5253,8 @@ entry:
   %12 = load i64, i64* %11
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %5
   %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
@@ -4399,8 +5263,8 @@ entry:
   %18 = load i8, i8* %arg2
   %19 = zext i8 %18 to i32
   %20 = trunc i32 %19 to i8
-  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %15
   %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
@@ -4411,11 +5275,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4442,8 +5306,8 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
@@ -4466,16 +5330,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
   %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = load i64, i64 addrspace(1)* %19
@@ -4500,8 +5364,8 @@ entry:
 ; <label>:35                                      ; preds = %30
   %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
@@ -4514,8 +5378,8 @@ entry:
 
 ; <label>:42                                      ; preds = %1, %38
   %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
-  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
@@ -4526,19 +5390,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %35
+ThrowNullRef2:                                    ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %42
+ThrowNullRef8:                                    ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4551,14 +5415,14 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
@@ -4570,7 +5434,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4583,8 +5447,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
@@ -4613,51 +5477,51 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
   %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
   %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
   %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
   %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
-  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
   store i64 %21, i64 addrspace(1)* %23
   %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %25 = load i64, i64* %loc0
-  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
@@ -4668,27 +5532,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %22
+ThrowNullRef12:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4701,8 +5565,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
@@ -4713,19 +5577,19 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
@@ -4734,8 +5598,8 @@ entry:
 
 ; <label>:15                                      ; preds = %1, %13
   %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
@@ -4746,19 +5610,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %15
+ThrowNullRef8:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4771,8 +5635,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -4831,8 +5695,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
@@ -4882,8 +5746,8 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
-  br i1 %NullCheck, label %17, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %ThrowNullRef, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
@@ -4894,15 +5758,15 @@ entry:
 
 ; <label>:22                                      ; preds = %17
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
-  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
   %26 = load i32, i32 addrspace(1)* %25
   %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
-  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %27, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
@@ -4925,8 +5789,8 @@ entry:
 ; <label>:40                                      ; preds = %17
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
-  br i1 %NullCheck6, label %43, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %41, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
@@ -4938,34 +5802,17 @@ ThrowNullRef:                                     ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %24
+ThrowNullRef4:                                    ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %40
+ThrowNullRef6:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
-}
-
-INFO:  jitting method Object::ReferenceEquals using LLILCJit
-Successfully read Object.ReferenceEquals
-
-define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
-entry:
-  %arg0 = alloca %System.Object addrspace(1)*
-  %arg1 = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
-  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
-  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = icmp eq %System.Object addrspace(1)* %0, %1
-  %3 = sext i1 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
 }
 
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
@@ -4978,21 +5825,21 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
   %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
-  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
@@ -5007,28 +5854,28 @@ entry:
 ; <label>:13                                      ; preds = %8, %12
   %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
   %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
   %21 = load i32, i32 addrspace(1)* %20, align 8
   %22 = add i32 %21, 1
-  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
   store i32 %22, i32 addrspace(1)* %24
   %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
@@ -5039,27 +5886,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5077,7 +5924,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::Setup using LLILCJit
-Failed to read AppDomain.Setup[loadElem]
+Failed to read AppDomain.Setup[unbox]
 INFO:  jitting method Thread::GetDomain using LLILCJit
 Successfully read Thread.GetDomain
 
@@ -5108,8 +5955,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
@@ -5122,14 +5969,14 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
   %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
@@ -5141,11 +5988,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5173,8 +6020,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -5189,7 +6036,328 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
 Failed to read KeyCollection.System.Collections.Generic.IEnumerable<TKey>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Successfully read Enumerator.MoveNext
+
+define i8 @Enumerator.MoveNext(%"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.RuntimeTypeHandle* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*
+  %"$TypeArg" = alloca %System.RuntimeTypeHandle*
+  store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
+  %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 8
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %76, label %12
+
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
+  br label %76
+
+; <label>:13                                      ; preds = %85
+  %14 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck19 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %15
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, i32 0, i32 0
+  %17 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %16, align 8
+  %NullCheck21 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, i32 0, i32 2
+  %20 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %19, align 8
+  %21 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck23 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %22
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, i32 0, i32 2
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %NullCheck25 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 3, i32 %24
+  %NullCheck27 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %32
+
+; <label>:32                                      ; preds = %30
+  %33 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, i32 0, i32 2
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = icmp slt i32 %34, 0
+  br i1 %35, label %68, label %36
+
+; <label>:36                                      ; preds = %32
+  %37 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %38 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck29 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %39
+
+; <label>:39                                      ; preds = %36
+  %40 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, i32 0, i32 0
+  %41 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %40, align 8
+  %NullCheck31 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, i32 0, i32 2
+  %44 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %43, align 8
+  %45 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck33 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, i32 0, i32 2
+  %48 = load i32, i32 addrspace(1)* %47, align 8
+  %NullCheck35 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %49
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = zext i32 %51 to i64
+  %53 = zext i32 %48 to i64
+  %BoundsCheck37 = icmp uge i64 %53, %52
+  br i1 %BoundsCheck37, label %ThrowIndexOutOfRange38, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 3, i32 %48
+  %NullCheck39 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %56
+
+; <label>:56                                      ; preds = %54
+  %57 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, i32 0, i32 0
+  %58 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck41 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %59
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %60, %System.__Canon addrspace(1)* %58)
+  %61 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck43 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  %64 = load i32, i32 addrspace(1)* %63, align 8
+  %65 = add i32 %64, 1
+  %NullCheck45 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  store i32 %65, i32 addrspace(1)* %67
+  ret i8 1
+
+; <label>:68                                      ; preds = %32
+  %69 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck47 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %73 = add i32 %72, 1
+  %NullCheck49 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %74
+
+; <label>:74                                      ; preds = %70
+  %75 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  store i32 %73, i32 addrspace(1)* %75
+  br label %76
+
+; <label>:76                                      ; preds = %8, %12, %74
+  %77 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %78
+
+; <label>:78                                      ; preds = %76
+  %79 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, i32 0, i32 2
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck7 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %82
+
+; <label>:82                                      ; preds = %78
+  %83 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, i32 0, i32 0
+  %84 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %83, align 8
+  %NullCheck9 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %85
+
+; <label>:85                                      ; preds = %82
+  %86 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, i32 0, i32 7
+  %87 = load i32, i32 addrspace(1)* %86, align 8
+  %88 = icmp ult i32 %80, %87
+  br i1 %88, label %13, label %89
+
+; <label>:89                                      ; preds = %85
+  %90 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %91 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck11 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %92
+
+; <label>:92                                      ; preds = %89
+  %93 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, i32 0, i32 0
+  %94 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck13 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %95
+
+; <label>:95                                      ; preds = %92
+  %96 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, i32 0, i32 7
+  %97 = load i32, i32 addrspace(1)* %96, align 8
+  %98 = add i32 %97, 1
+  %NullCheck15 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %99
+
+; <label>:99                                      ; preds = %95
+  %100 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, i32 0, i32 2
+  store i32 %98, i32 addrspace(1)* %100
+  %101 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck17 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %102
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %103, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %92
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef22:                                   ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef24:                                   ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef26:                                   ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef28:                                   ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef30:                                   ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef32:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef34:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef36:                                   ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange38:                           ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef40:                                   ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef42:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef44:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef46:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef48:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef50:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -5200,8 +6368,8 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -5232,9 +6400,9 @@ Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
 Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
-Failed to read String.MakeSeparatorList[loadElemA]
+Failed to read String.MakeSeparatorList[storeElem]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
-Failed to read String.InternalSplitKeepEmptyEntries[loadElem]
+Failed to read String.InternalSplitKeepEmptyEntries[storeElem]
 INFO:  jitting method Path::IsRelative using LLILCJit
 Successfully read Path.IsRelative
 
@@ -5243,8 +6411,8 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -5254,8 +6422,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
@@ -5271,8 +6439,8 @@ entry:
 
 ; <label>:17                                      ; preds = %7
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
@@ -5288,8 +6456,8 @@ entry:
 
 ; <label>:29                                      ; preds = %19
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %31
 
 ; <label>:31                                      ; preds = %29
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
@@ -5300,8 +6468,8 @@ entry:
 
 ; <label>:36                                      ; preds = %31
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
-  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %37, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
@@ -5312,8 +6480,8 @@ entry:
 
 ; <label>:43                                      ; preds = %31, %38
   %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
-  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %45
 
 ; <label>:45                                      ; preds = %43
   %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
@@ -5324,8 +6492,8 @@ entry:
 
 ; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %50
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
@@ -5336,8 +6504,8 @@ entry:
 
 ; <label>:57                                      ; preds = %1, %7, %19, %45, %52
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
-  br i1 %NullCheck14, label %59, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %59
 
 ; <label>:59                                      ; preds = %57
   %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
@@ -5347,8 +6515,8 @@ entry:
 
 ; <label>:63                                      ; preds = %59
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
@@ -5359,8 +6527,8 @@ entry:
 
 ; <label>:70                                      ; preds = %65
   %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
-  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.String addrspace(1)* %71, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %72
 
 ; <label>:72                                      ; preds = %70
   %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
@@ -5379,39 +6547,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %17
+ThrowNullRef4:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %29
+ThrowNullRef6:                                    ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %36
+ThrowNullRef8:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %43
+ThrowNullRef10:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %50
+ThrowNullRef12:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %57
+ThrowNullRef14:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %63
+ThrowNullRef16:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %70
+ThrowNullRef18:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5419,7 +6587,293 @@ ThrowNullRef17:                                   ; preds = %70
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
-Failed to read String.TrimHelper[loadElem]
+Successfully read String.TrimHelper
+
+define %System.String addrspace(1)* @String.TrimHelper(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i16
+  %loc4 = alloca i32
+  %loc5 = alloca i16
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = sub i32 %3, 1
+  store i32 %4, i32* %loc0
+  store i32 0, i32* %loc1
+  %5 = load i32, i32* %arg2
+  %6 = icmp eq i32 %5, 1
+  br i1 %6, label %62, label %7
+
+; <label>:7                                       ; preds = %1
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:8                                       ; preds = %58
+  store i32 0, i32* %loc2
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load i32, i32* %loc1
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2, i32 %10
+  %13 = load i16, i16 addrspace(1)* %12
+  %14 = zext i16 %13 to i32
+  %15 = trunc i32 %14 to i16
+  store i16 %15, i16* %loc3
+  store i32 0, i32* %loc2
+  br label %34
+
+; <label>:16                                      ; preds = %37
+  %17 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %18 = load i32, i32* %loc2
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %17, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %19
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = zext i32 %18 to i64
+  %BoundsCheck = icmp uge i64 %23, %22
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %24
+
+; <label>:24                                      ; preds = %19
+  %25 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 3, i32 %18
+  %26 = load i16, i16 addrspace(1)* %25, align 8
+  %27 = zext i16 %26 to i32
+  %28 = load i16, i16* %loc3
+  %29 = zext i16 %28 to i32
+  %30 = icmp eq i32 %27, %29
+  br i1 %30, label %43, label %31
+
+; <label>:31                                      ; preds = %24
+  %32 = load i32, i32* %loc2
+  %33 = add i32 %32, 1
+  store i32 %33, i32* %loc2
+  br label %34
+
+; <label>:34                                      ; preds = %11, %31
+  %35 = load i32, i32* %loc2
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = icmp slt i32 %35, %41
+  br i1 %42, label %16, label %43
+
+; <label>:43                                      ; preds = %24, %37
+  %44 = load i32, i32* %loc2
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %45, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp eq i32 %44, %50
+  br i1 %51, label %62, label %52
+
+; <label>:52                                      ; preds = %46
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %7, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %57, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %58
+
+; <label>:58                                      ; preds = %55
+  %59 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %60 = load i32, i32 addrspace(1)* %59
+  %61 = icmp slt i32 %56, %60
+  br i1 %61, label %8, label %62
+
+; <label>:62                                      ; preds = %1, %46, %58
+  %63 = load i32, i32* %arg2
+  %64 = icmp eq i32 %63, 0
+  br i1 %64, label %122, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %66, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %67
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %66, i32 0, i32 1
+  %69 = load i32, i32 addrspace(1)* %68
+  %70 = sub i32 %69, 1
+  store i32 %70, i32* %loc0
+  br label %118
+
+; <label>:71                                      ; preds = %118
+  store i32 0, i32* %loc4
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %73 = load i32, i32* %loc0
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %74
+
+; <label>:74                                      ; preds = %71
+  %75 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 2, i32 %73
+  %76 = load i16, i16 addrspace(1)* %75
+  %77 = zext i16 %76 to i32
+  %78 = trunc i32 %77 to i16
+  store i16 %78, i16* %loc5
+  store i32 0, i32* %loc4
+  br label %97
+
+; <label>:79                                      ; preds = %100
+  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %81 = load i32, i32* %loc4
+  %NullCheck19 = icmp eq %"System.Char[]" addrspace(1)* %80, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
+
+; <label>:82                                      ; preds = %79
+  %83 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 1
+  %84 = load i32, i32 addrspace(1)* %83
+  %85 = zext i32 %84 to i64
+  %86 = zext i32 %81 to i64
+  %BoundsCheck21 = icmp uge i64 %86, %85
+  br i1 %BoundsCheck21, label %ThrowIndexOutOfRange22, label %87
+
+; <label>:87                                      ; preds = %82
+  %88 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 3, i32 %81
+  %89 = load i16, i16 addrspace(1)* %88, align 8
+  %90 = zext i16 %89 to i32
+  %91 = load i16, i16* %loc5
+  %92 = zext i16 %91 to i32
+  %93 = icmp eq i32 %90, %92
+  br i1 %93, label %106, label %94
+
+; <label>:94                                      ; preds = %87
+  %95 = load i32, i32* %loc4
+  %96 = add i32 %95, 1
+  store i32 %96, i32* %loc4
+  br label %97
+
+; <label>:97                                      ; preds = %74, %94
+  %98 = load i32, i32* %loc4
+  %99 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck15 = icmp eq %"System.Char[]" addrspace(1)* %99, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %100
+
+; <label>:100                                     ; preds = %97
+  %101 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %99, i32 0, i32 1
+  %102 = load i32, i32 addrspace(1)* %101
+  %103 = zext i32 %102 to i64
+  %104 = trunc i64 %103 to i32
+  %105 = icmp slt i32 %98, %104
+  br i1 %105, label %79, label %106
+
+; <label>:106                                     ; preds = %87, %100
+  %107 = load i32, i32* %loc4
+  %108 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck17 = icmp eq %"System.Char[]" addrspace(1)* %108, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %109
+
+; <label>:109                                     ; preds = %106
+  %110 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %108, i32 0, i32 1
+  %111 = load i32, i32 addrspace(1)* %110
+  %112 = zext i32 %111 to i64
+  %113 = trunc i64 %112 to i32
+  %114 = icmp eq i32 %107, %113
+  br i1 %114, label %122, label %115
+
+; <label>:115                                     ; preds = %109
+  %116 = load i32, i32* %loc0
+  %117 = sub i32 %116, 1
+  store i32 %117, i32* %loc0
+  br label %118
+
+; <label>:118                                     ; preds = %67, %115
+  %119 = load i32, i32* %loc0
+  %120 = load i32, i32* %loc1
+  %121 = icmp sge i32 %119, %120
+  br i1 %121, label %71, label %122
+
+; <label>:122                                     ; preds = %62, %109, %118
+  %123 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %124 = load i32, i32* %loc1
+  %125 = load i32, i32* %loc0
+  %126 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %123, i32 %124, i32 %125)
+  ret %System.String addrspace(1)* %126
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %97
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange22:                           ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
 Successfully read String.CreateTrimmedString
 
@@ -5439,8 +6893,8 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
@@ -5535,8 +6989,8 @@ entry:
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i64 2872
   %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
   %8 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %7
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %3
   %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
@@ -5553,8 +7007,8 @@ entry:
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 2864
   %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
   %21 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %20
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
-  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %22
 
 ; <label>:22                                      ; preds = %16
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
@@ -5569,7 +7023,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %16
+ThrowNullRef2:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5586,8 +7040,8 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5613,8 +7067,8 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
@@ -5632,8 +7086,8 @@ entry:
 
 ; <label>:12                                      ; preds = %4
   %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
@@ -5644,8 +7098,8 @@ entry:
 
 ; <label>:19                                      ; preds = %14
   %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %19
   %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
@@ -5660,21 +7114,21 @@ entry:
   %31 = zext i16 %30 to i32
   %32 = bitcast i8* %29 to i16*
   %33 = trunc i32 %31 to i16
-  %NullCheck6 = icmp ne i16* %32, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i16* %32, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %21
   store i16 %33, i16* %32, align 8
   %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %36
 
 ; <label>:36                                      ; preds = %34
   %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
   %38 = load i32, i32 addrspace(1)* %37, align 8
   %39 = add i32 %38, 1
-  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %40
 
 ; <label>:40                                      ; preds = %36
   %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
@@ -5683,16 +7137,16 @@ entry:
 
 ; <label>:42                                      ; preds = %14
   %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
-  br i1 %NullCheck12, label %44, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
   %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
   %47 = load i16, i16* %arg1
   %48 = zext i16 %47 to i32
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = trunc i32 %48 to i16
@@ -5703,31 +7157,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %19
+ThrowNullRef4:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %21
+ThrowNullRef6:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %36
+ThrowNullRef10:                                   ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %42
+ThrowNullRef12:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %44
+ThrowNullRef14:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5740,8 +7194,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -5752,8 +7206,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
@@ -5762,14 +7216,14 @@ entry:
 
 ; <label>:11                                      ; preds = %1
   %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
@@ -5779,15 +7233,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5808,8 +7262,8 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5822,8 +7276,8 @@ entry:
 
 ; <label>:8                                       ; preds = %3
   %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
@@ -5842,15 +7296,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
-  br i1 %NullCheck4, label %22, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
   %24 = load i16*, i16* addrspace(1)* %23, align 8
   %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %25, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
@@ -5859,8 +7313,8 @@ entry:
   store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
@@ -5874,8 +7328,8 @@ entry:
 
 ; <label>:37                                      ; preds = %65
   %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %37
   %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
@@ -5886,16 +7340,16 @@ entry:
   %45 = bitcast i16* %41 to i8*
   %46 = getelementptr inbounds i8, i8* %45, i64 %44
   %47 = bitcast i8* %46 to i16*
-  %NullCheck14 = icmp ne i16* %47, null
-  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %47, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %48
 
 ; <label>:48                                      ; preds = %39
   %49 = load i16, i16* %47, align 8
   %50 = zext i16 %49 to i32
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %52 = load i32, i32* %loc1
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %53
 
 ; <label>:53                                      ; preds = %48
   %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
@@ -5916,8 +7370,8 @@ entry:
 ; <label>:62                                      ; preds = %36, %59
   %63 = load i32, i32* %loc1
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck10, label %65, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %65
 
 ; <label>:65                                      ; preds = %62
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
@@ -5936,15 +7390,15 @@ entry:
 
 ; <label>:74                                      ; preds = %70
   %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
-  br i1 %NullCheck18, label %76, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %76
 
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
   %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
-  br i1 %NullCheck20, label %80, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
   %81 = load i64, i64 addrspace(1)* %79
@@ -5958,8 +7412,8 @@ entry:
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
   %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
-  br i1 %NullCheck22, label %92, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.String addrspace(1)* %90, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %92
 
 ; <label>:92                                      ; preds = %80
   %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
@@ -5969,15 +7423,15 @@ entry:
 
 ; <label>:96                                      ; preds = %70
   %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
-  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %98
 
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
   %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
-  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
   %103 = load i64, i64 addrspace(1)* %101
@@ -5991,8 +7445,8 @@ entry:
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
   %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
-  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.String addrspace(1)* %112, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %114
 
 ; <label>:114                                     ; preds = %102
   %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
@@ -6004,59 +7458,59 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %20
+ThrowNullRef4:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %22
+ThrowNullRef6:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %26
+ThrowNullRef8:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %62
+ThrowNullRef10:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %48
+ThrowNullRef16:                                   ; preds = %48
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %74
+ThrowNullRef18:                                   ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %76
+ThrowNullRef20:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %80
+ThrowNullRef22:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %96
+ThrowNullRef24:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %98
+ThrowNullRef26:                                   ; preds = %98
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %102
+ThrowNullRef28:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6069,15 +7523,15 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
   %3 = load i16*, i16* addrspace(1)* %2, align 8
   %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
@@ -6087,8 +7541,8 @@ entry:
   %10 = bitcast i16* %3 to i8*
   %11 = getelementptr inbounds i8, i8* %10, i64 %9
   %12 = bitcast i8* %11 to i16*
-  %NullCheck4 = icmp ne i16* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %5
   store i16 0, i16* %12, align 8
@@ -6098,11 +7552,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6119,8 +7573,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -6131,8 +7585,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
@@ -6144,15 +7598,15 @@ entry:
 
 ; <label>:14                                      ; preds = %1
   %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
   %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
   %21 = load i64, i64 addrspace(1)* %19
@@ -6171,15 +7625,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %14
+ThrowNullRef4:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %16
+ThrowNullRef6:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6302,14 +7756,6 @@ entry:
   ret %System.String addrspace(1)* %57
 }
 
-INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
-Successfully read RuntimeHelpers.get_OffsetToStringData
-
-define i32 @RuntimeHelpers.get_OffsetToStringData() {
-entry:
-  ret i32 12
-}
-
 INFO:  jitting method String::Equals using LLILCJit
 Successfully read String.Equals
 
@@ -6381,8 +7827,8 @@ entry:
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
-  br i1 %NullCheck24, label %29, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
   %30 = load i64, i64 addrspace(1)* %28
@@ -6397,8 +7843,8 @@ entry:
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
-  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
   %43 = load i64, i64 addrspace(1)* %41
@@ -6418,8 +7864,8 @@ entry:
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
   %59 = load i64, i64 addrspace(1)* %57
@@ -6434,8 +7880,8 @@ entry:
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck22, label %71, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
   %72 = load i64, i64 addrspace(1)* %70
@@ -6455,8 +7901,8 @@ entry:
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
-  br i1 %NullCheck16, label %87, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = load i64, i64 addrspace(1)* %86
@@ -6471,8 +7917,8 @@ entry:
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck18, label %100, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
   %101 = load i64, i64 addrspace(1)* %99
@@ -6492,8 +7938,8 @@ entry:
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
-  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
   %117 = load i64, i64 addrspace(1)* %115
@@ -6508,8 +7954,8 @@ entry:
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
-  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
   %130 = load i64, i64 addrspace(1)* %128
@@ -6528,15 +7974,15 @@ entry:
 
 ; <label>:142                                     ; preds = %22
   %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
-  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %143, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %144
 
 ; <label>:144                                     ; preds = %142
   %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
   %146 = load i32, i32 addrspace(1)* %145
   %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
-  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %147, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %148
 
 ; <label>:148                                     ; preds = %144
   %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
@@ -6557,15 +8003,15 @@ entry:
 
 ; <label>:159                                     ; preds = %22
   %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
-  br i1 %NullCheck, label %161, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %ThrowNullRef, label %161
 
 ; <label>:161                                     ; preds = %159
   %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
   %163 = load i32, i32 addrspace(1)* %162
   %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
-  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %164, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %165
 
 ; <label>:165                                     ; preds = %161
   %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
@@ -6578,8 +8024,8 @@ entry:
 
 ; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
-  br i1 %NullCheck4, label %172, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %171, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %172
 
 ; <label>:172                                     ; preds = %170
   %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
@@ -6589,8 +8035,8 @@ entry:
 
 ; <label>:176                                     ; preds = %172
   %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
-  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %177, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %178
 
 ; <label>:178                                     ; preds = %176
   %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
@@ -6629,55 +8075,55 @@ ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %161
+ThrowNullRef2:                                    ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %170
+ThrowNullRef4:                                    ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %176
+ThrowNullRef6:                                    ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %142
+ThrowNullRef8:                                    ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %144
+ThrowNullRef10:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %113
+ThrowNullRef12:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %116
+ThrowNullRef14:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %84
+ThrowNullRef16:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %87
+ThrowNullRef18:                                   ; preds = %87
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %55
+ThrowNullRef20:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %58
+ThrowNullRef22:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %26
+ThrowNullRef24:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %29
+ThrowNullRef26:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,8 +8161,8 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck, label %14, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %ThrowNullRef, label %14
 
 ; <label>:14                                      ; preds = %8
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
@@ -6760,8 +8206,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
@@ -6770,14 +8216,14 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32, i32* %loc0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %10
   %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
   %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
@@ -6790,15 +8236,15 @@ entry:
 ; <label>:25                                      ; preds = %19
   %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
-  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
   %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
@@ -6807,8 +8253,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %37 = load i32, i32* %loc0
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %38, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %38
 
 ; <label>:38                                      ; preds = %32
   %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
@@ -6817,14 +8263,14 @@ entry:
 
 ; <label>:40                                      ; preds = %19
   %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %40
   %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
   %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
-  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
-  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
@@ -6832,8 +8278,8 @@ entry:
   %48 = zext i32 %47 to i64
   %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
-  br i1 %NullCheck16, label %51, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %51
 
 ; <label>:51                                      ; preds = %45
   %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
@@ -6847,15 +8293,15 @@ entry:
 ; <label>:57                                      ; preds = %51
   %58 = load i16*, i16** %arg1
   %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
-  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %60
 
 ; <label>:60                                      ; preds = %57
   %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
   %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
-  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %64
 
 ; <label>:64                                      ; preds = %60
   %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
@@ -6864,22 +8310,22 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
   %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
-  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %70
 
 ; <label>:70                                      ; preds = %64
   %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
   %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
-  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
-  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
   %75 = load i32, i32 addrspace(1)* %74
   %76 = zext i32 %75 to i64
   %77 = trunc i64 %76 to i32
-  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
-  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %78
 
 ; <label>:78                                      ; preds = %73
   %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
@@ -6901,8 +8347,8 @@ entry:
   %90 = bitcast i16* %86 to i8*
   %91 = getelementptr inbounds i8, i8* %90, i64 %89
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %93
 
 ; <label>:93                                      ; preds = %80
   %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
@@ -6912,8 +8358,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %99 = load i32, i32* %loc2
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %100
 
 ; <label>:100                                     ; preds = %93
   %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
@@ -6928,63 +8374,63 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %25
+ThrowNullRef6:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %32
+ThrowNullRef10:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %40
+ThrowNullRef12:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %45
+ThrowNullRef16:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %57
+ThrowNullRef18:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %60
+ThrowNullRef20:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %64
+ThrowNullRef22:                                   ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %70
+ThrowNullRef24:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %73
+ThrowNullRef26:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %80
+ThrowNullRef28:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %93
+ThrowNullRef30:                                   ; preds = %93
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7004,8 +8450,8 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
@@ -7033,43 +8479,43 @@ entry:
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %14
   %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
   %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   %28 = load i32, i32 addrspace(1)* %27, align 8
   %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
-  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %30
 
 ; <label>:30                                      ; preds = %26
   %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
   %32 = load i32, i32 addrspace(1)* %31, align 8
   %33 = add i32 %28, %32
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %34
 
 ; <label>:34                                      ; preds = %30
   %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   store i32 %33, i32 addrspace(1)* %35
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
   store i32 0, i32 addrspace(1)* %38
   %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %40
 
 ; <label>:40                                      ; preds = %37
   %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
@@ -7082,8 +8528,8 @@ entry:
 
 ; <label>:47                                      ; preds = %40
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
@@ -7098,8 +8544,8 @@ entry:
   %54 = load i32, i32* %loc0
   %55 = sext i32 %54 to i64
   %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
-  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %57
 
 ; <label>:57                                      ; preds = %52
   %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
@@ -7110,68 +8556,35 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %14
+ThrowNullRef2:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %23
+ThrowNullRef4:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %26
+ThrowNullRef6:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %30
+ThrowNullRef8:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %34
+ThrowNullRef10:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %47
+ThrowNullRef14:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %52
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-}
-
-INFO:  jitting method StringBuilder::get_Length using LLILCJit
-Successfully read StringBuilder.get_Length
-
-define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.StringBuilder addrspace(1)*
-  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
-  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
-
-; <label>:1                                       ; preds = %entry
-  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %3 = load i32, i32 addrspace(1)* %2, align 8
-  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
-
-; <label>:5                                       ; preds = %1
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = add i32 %3, %7
-  ret i32 %8
-
-ThrowNullRef:                                     ; preds = %entry
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef16:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7213,70 +8626,70 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
   %6 = load i32, i32 addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
   store i32 %6, i32 addrspace(1)* %8
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
   %13 = load i32, i32 addrspace(1)* %12, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
   store i32 %13, i32 addrspace(1)* %15
   %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
-  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %18
 
 ; <label>:18                                      ; preds = %14
   %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
   %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
   %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
   %34 = load i32, i32 addrspace(1)* %33, align 8
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
-  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
@@ -7287,39 +8700,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %28
+ThrowNullRef16:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %32
+ThrowNullRef18:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7455,13 +8868,13 @@ entry:
 ; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
@@ -7477,16 +8890,16 @@ entry:
 
 ; <label>:18                                      ; preds = %15
   %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
   store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
   %22 = load i32, i32* %loc0
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %24
 
 ; <label>:24                                      ; preds = %20
   %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
@@ -7498,13 +8911,13 @@ entry:
 ; <label>:28                                      ; preds = %15, %24
   %29 = load i32, i32* %arg1
   %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %31
   %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
@@ -7517,20 +8930,20 @@ entry:
   %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
-  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
   %46 = load i32, i32 addrspace(1)* %45, align 8
   %47 = sub i32 %40, %46
-  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
-  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i32 addrspace(1)* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %48
 
 ; <label>:48                                      ; preds = %44
   store i32 %47, i32 addrspace(1)* %39, align 8
@@ -7538,21 +8951,21 @@ entry:
 
 ; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
-  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %51
 
 ; <label>:51                                      ; preds = %49
   %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %53
 
 ; <label>:53                                      ; preds = %51
   %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
   %55 = load i32, i32 addrspace(1)* %54, align 8
   %56 = load i32, i32* %arg2
   %57 = sub i32 %55, %56
-  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %58
 
 ; <label>:58                                      ; preds = %53
   %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
@@ -7562,13 +8975,13 @@ entry:
 ; <label>:60                                      ; preds = %33, %58
   %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
   %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
-  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %63
 
 ; <label>:63                                      ; preds = %60
   %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
-  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
-  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
@@ -7578,15 +8991,15 @@ entry:
 
 ; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
-  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i32 addrspace(1)* %69, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %70
 
 ; <label>:70                                      ; preds = %68
   %71 = load i32, i32 addrspace(1)* %69, align 8
   store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
-  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
@@ -7596,8 +9009,8 @@ entry:
   store i32 %77, i32* %loc4
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
-  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %80
 
 ; <label>:80                                      ; preds = %73
   %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
@@ -7607,71 +9020,71 @@ entry:
 ; <label>:83                                      ; preds = %80
   store i32 0, i32* %loc3
   %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
-  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
-  br i1 %NullCheck26, label %88, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i32 addrspace(1)* %87, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %88
 
 ; <label>:88                                      ; preds = %85
   %89 = load i32, i32 addrspace(1)* %87, align 8
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
-  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %90
 
 ; <label>:90                                      ; preds = %88
   %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
   store i32 %89, i32 addrspace(1)* %91
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
-  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
-  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %96
 
 ; <label>:96                                      ; preds = %94
   %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
-  br i1 %NullCheck34, label %100, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %100
 
 ; <label>:100                                     ; preds = %96
   %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
-  br i1 %NullCheck36, label %102, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %102
 
 ; <label>:102                                     ; preds = %100
   %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
   %104 = load i32, i32 addrspace(1)* %103, align 8
   %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
-  br i1 %NullCheck38, label %106, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %106
 
 ; <label>:106                                     ; preds = %102
   %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
-  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
-  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %108
 
 ; <label>:108                                     ; preds = %106
   %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
   %110 = load i32, i32 addrspace(1)* %109, align 8
   %111 = add i32 %104, %110
-  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %112
 
 ; <label>:112                                     ; preds = %108
   %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
   store i32 %111, i32 addrspace(1)* %113
   %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
-  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i32 addrspace(1)* %114, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %115
 
 ; <label>:115                                     ; preds = %112
   %116 = load i32, i32 addrspace(1)* %114, align 8
@@ -7681,19 +9094,19 @@ entry:
 ; <label>:118                                     ; preds = %115
   %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
-  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %121
 
 ; <label>:121                                     ; preds = %118
   %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
-  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
-  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %123
 
 ; <label>:123                                     ; preds = %121
   %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
   %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
-  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
-  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %126
 
 ; <label>:126                                     ; preds = %123
   %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
@@ -7705,8 +9118,8 @@ entry:
 
 ; <label>:130                                     ; preds = %80, %115, %126
   %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %132
 
 ; <label>:132                                     ; preds = %130
   %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7715,8 +9128,8 @@ entry:
   %136 = load i32, i32* %loc3
   %137 = sub i32 %135, %136
   %138 = sub i32 %134, %137
-  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %139
 
 ; <label>:139                                     ; preds = %132
   %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7728,16 +9141,16 @@ entry:
 
 ; <label>:144                                     ; preds = %139
   %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
-  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %146
 
 ; <label>:146                                     ; preds = %144
   %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
   %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
   %149 = load i32, i32* %loc2
   %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
-  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %151
 
 ; <label>:151                                     ; preds = %146
   %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
@@ -7754,145 +9167,249 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %18
+ThrowNullRef4:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %31
+ThrowNullRef10:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %44
+ThrowNullRef16:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %68
+ThrowNullRef18:                                   ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %70
+ThrowNullRef20:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %73
+ThrowNullRef22:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %83
+ThrowNullRef24:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %85
+ThrowNullRef26:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %88
+ThrowNullRef28:                                   ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %90
+ThrowNullRef30:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %94
+ThrowNullRef32:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %96
+ThrowNullRef34:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %100
+ThrowNullRef36:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %102
+ThrowNullRef38:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %106
+ThrowNullRef40:                                   ; preds = %106
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %108
+ThrowNullRef42:                                   ; preds = %108
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %112
+ThrowNullRef44:                                   ; preds = %112
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %118
+ThrowNullRef46:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %121
+ThrowNullRef48:                                   ; preds = %121
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %123
+ThrowNullRef50:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %130
+ThrowNullRef52:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %132
+ThrowNullRef54:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %144
+ThrowNullRef56:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %146
+ThrowNullRef58:                                   ; preds = %146
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %60
+ThrowNullRef60:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %63
+ThrowNullRef62:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %49
+ThrowNullRef64:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %51
+ThrowNullRef66:                                   ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %53
+ThrowNullRef68:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(%"System.Char[]" addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %arg0 = alloca %"System.Char[]" addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store %"System.Char[]" addrspace(1)* %param0, %"System.Char[]" addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load i32, i32* %arg4
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %43, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %38, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg1
+  %13 = load i32, i32* %arg4
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %38, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %24 = load i32, i32* %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %35 = load i32, i32* %arg3
+  %36 = load i32, i32* %arg4
+  %37 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %37, %"System.Char[]" addrspace(1)* %34, i32 %35, i32 %36)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:38                                      ; preds = %5, %16
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Successfully read Buffer._Memmove
 
@@ -7914,7 +9431,7 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[loadElem]
+Failed to read AppDomain.SetDataHelper[storeElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -7923,8 +9440,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
@@ -7934,8 +9451,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
@@ -7947,15 +9464,15 @@ entry:
   %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
   %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
@@ -7966,15 +9483,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7992,7 +9509,79 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
-Failed to read Dictionary`2.TryGetValue[loadElemA]
+Successfully read Dictionary`2.TryGetValue
+
+define i8 @"Dictionary`2.TryGetValue"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)* addrspace(1)* %param2) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  %arg2 = alloca %System.__Canon addrspace(1)* addrspace(1)*
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  store %System.__Canon addrspace(1)* addrspace(1)* %param2, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  store i32 %2, i32* %loc0
+  %3 = load i32, i32* %loc0
+  %4 = icmp slt i32 %3, 0
+  br i1 %4, label %22, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 2
+  %10 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %9, align 8
+  %11 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = zext i32 %11 to i64
+  %BoundsCheck = icmp uge i64 %16, %15
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 3, i32 %11
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %20, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %6, %System.__Canon addrspace(1)* %21)
+  ret i8 1
+
+; <label>:22                                      ; preds = %entry
+  %23 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %23, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -8058,8 +9647,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
@@ -8091,8 +9680,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
@@ -8171,15 +9760,15 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck, label %19, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %ThrowNullRef, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
   %21 = load i32, i32 addrspace(1)* %20
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
@@ -8202,7 +9791,7 @@ ThrowNullRef:                                     ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %19
+ThrowNullRef2:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8248,8 +9837,8 @@ entry:
   %0 = alloca %System.AppDomainHandle
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %1 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %1, i32 0, i32 15
@@ -8269,8 +9858,8 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
@@ -8286,7 +9875,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -8299,8 +9888,8 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -8327,8 +9916,8 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
@@ -8352,8 +9941,8 @@ entry:
   %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
   store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
@@ -8363,8 +9952,8 @@ entry:
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
@@ -8374,8 +9963,8 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %9
   %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
@@ -8384,8 +9973,8 @@ entry:
 
 ; <label>:18                                      ; preds = %3, %16
   %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
@@ -8397,15 +9986,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %18
+ThrowNullRef6:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8418,8 +10007,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
@@ -8453,15 +10042,15 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
@@ -8473,7 +10062,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8481,7 +10070,7 @@ ThrowNullRef1:                                    ; preds = %1
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
 Failed to read Dictionary`2.System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
@@ -8506,8 +10095,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
@@ -8524,8 +10113,8 @@ entry:
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -8544,7 +10133,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8577,8 +10166,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = load i64, i64* %arg2
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = trunc i32 %3 to i8
@@ -8634,46 +10223,46 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
   %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
-  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
-  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
-  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
@@ -8684,27 +10273,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %20
+ThrowNullRef12:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8717,8 +10306,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -8756,22 +10345,22 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
   %9 = load i64, i64 addrspace(1)* %8, align 8
   %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
   %13 = load i64, i64 addrspace(1)* %12, align 8
   %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %11
   %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
@@ -8788,11 +10377,11 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8882,8 +10471,8 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
@@ -8900,8 +10489,8 @@ entry:
 ; <label>:8                                       ; preds = %1
   %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
   %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
@@ -8911,15 +10500,15 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
   %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
   %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
-  br i1 %NullCheck6, label %21, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
@@ -8946,15 +10535,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8992,15 +10581,15 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
   store i8 %3, i8 addrspace(1)* %5
   %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
@@ -9011,7 +10600,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9027,8 +10616,8 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -9041,8 +10630,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
@@ -9058,7 +10647,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9080,8 +10669,8 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
@@ -9096,8 +10685,8 @@ entry:
 ; <label>:12                                      ; preds = %6
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
@@ -9112,8 +10701,8 @@ entry:
 ; <label>:21                                      ; preds = %15
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
@@ -9128,8 +10717,8 @@ entry:
 ; <label>:30                                      ; preds = %24
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %31, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
@@ -9144,8 +10733,8 @@ entry:
 ; <label>:39                                      ; preds = %33
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
-  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %40, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %42
 
 ; <label>:42                                      ; preds = %39
   %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
@@ -9164,19 +10753,19 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %21
+ThrowNullRef4:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %30
+ThrowNullRef6:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %39
+ThrowNullRef8:                                    ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9243,8 +10832,8 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
@@ -9264,57 +10853,57 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
   store i8 0, i8 addrspace(1)* %2
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
   store i8 0, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
   store i8 0, i8 addrspace(1)* %17
   %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
   store i8 0, i8 addrspace(1)* %20
   %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
-  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
@@ -9325,31 +10914,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %19
+ThrowNullRef14:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9367,8 +10956,8 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
@@ -9380,8 +10969,8 @@ entry:
 
 ; <label>:9                                       ; preds = %4
   %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %9
   %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
@@ -9395,7 +10984,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef2:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9420,8 +11009,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
@@ -9512,8 +11101,8 @@ entry:
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
@@ -9524,8 +11113,8 @@ entry:
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = load i64, i64 addrspace(1)* %12
@@ -9537,8 +11126,8 @@ entry:
   %20 = load i64, i64* %19
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
-  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %13
   %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
@@ -9555,8 +11144,8 @@ entry:
 ; <label>:30                                      ; preds = %25
   %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %32 = load i32, i32* %arg2
-  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
-  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
@@ -9570,15 +11159,15 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %30
+ThrowNullRef2:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9622,87 +11211,87 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
   %10 = load i8, i8 addrspace(1)* %9, align 8
   %11 = zext i8 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %8
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
   store i8 %12, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
   %19 = load i8, i8 addrspace(1)* %18, align 8
   %20 = zext i8 %19 to i32
   %21 = trunc i32 %20 to i8
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
   store i8 %21, i8 addrspace(1)* %23
   %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
   %28 = load i8, i8 addrspace(1)* %27, align 8
   %29 = zext i8 %28 to i32
   %30 = trunc i32 %29 to i8
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
-  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %31
 
 ; <label>:31                                      ; preds = %26
   %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
   store i8 %30, i8 addrspace(1)* %32
   %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
-  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
-  br i1 %NullCheck14, label %40, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %40
 
 ; <label>:40                                      ; preds = %35
   %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
   store i8 %39, i8 addrspace(1)* %41
   %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
-  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %44
 
 ; <label>:44                                      ; preds = %40
   %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
   %46 = load i8, i8 addrspace(1)* %45, align 8
   %47 = zext i8 %46 to i32
   %48 = trunc i32 %47 to i8
-  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
   store i8 %48, i8 addrspace(1)* %50
   %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
-  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
@@ -9713,29 +11302,29 @@ entry:
 ; <label>:56                                      ; preds = %52
   %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
-  br i1 %NullCheck22, label %59, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
   %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
   %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
-  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
-  br i1 %NullCheck24, label %63, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
   %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
-  br i1 %NullCheck26, label %66, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
   %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
-  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
-  br i1 %NullCheck28, label %69, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %69
 
 ; <label>:69                                      ; preds = %66
   %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
@@ -9744,15 +11333,15 @@ entry:
 
 ; <label>:71                                      ; preds = %105
   %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
-  br i1 %NullCheck34, label %73, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %73
 
 ; <label>:73                                      ; preds = %71
   %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
   %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
   %76 = load i32, i32* %loc0
-  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
-  br i1 %NullCheck36, label %77, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
@@ -9766,8 +11355,8 @@ entry:
 
 ; <label>:83                                      ; preds = %77
   %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
-  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
@@ -9775,14 +11364,14 @@ entry:
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
   %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
-  br i1 %NullCheck40, label %91, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
 ; <label>:91                                      ; preds = %85
   %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
   %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
-  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck42, label %94, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %94
 
 ; <label>:94                                      ; preds = %91
   %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
@@ -9798,14 +11387,14 @@ entry:
 ; <label>:99                                      ; preds = %69, %96
   %100 = load i32, i32* %loc0
   %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
-  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %102
 
 ; <label>:102                                     ; preds = %99
   %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
   %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
-  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
-  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
@@ -9819,87 +11408,87 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %26
+ThrowNullRef10:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %31
+ThrowNullRef12:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %35
+ThrowNullRef14:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %40
+ThrowNullRef16:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %56
+ThrowNullRef22:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %59
+ThrowNullRef24:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %63
+ThrowNullRef26:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %66
+ThrowNullRef28:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %102
+ThrowNullRef32:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %71
+ThrowNullRef34:                                   ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %73
+ThrowNullRef36:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %83
+ThrowNullRef38:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %85
+ThrowNullRef40:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %91
+ThrowNullRef42:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9943,15 +11532,15 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
   %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
@@ -9961,28 +11550,28 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
   %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %12
   %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
   %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
   %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
-  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
@@ -9993,23 +11582,23 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %12
+ThrowNullRef6:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10031,15 +11620,15 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
   %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = load i64, i64 addrspace(1)* %7
@@ -10077,13 +11666,13 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[loadElem]
+Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -10111,8 +11700,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Unbox.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Unbox.error.txt
@@ -25,8 +25,8 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
@@ -40,8 +40,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
   %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
@@ -75,7 +75,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -90,8 +90,8 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %NullCheck = icmp ne i8 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = load i8, i8 addrspace(1)* %0, align 8
@@ -125,8 +125,8 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
@@ -159,8 +159,8 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -184,8 +184,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
   store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
@@ -195,8 +195,8 @@ entry:
 ; <label>:4                                       ; preds = %1
   %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
   %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
@@ -206,8 +206,8 @@ entry:
   %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
@@ -221,14 +221,14 @@ entry:
 
 ; <label>:17                                      ; preds = %14
   %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
   %21 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
@@ -238,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -249,8 +249,8 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
@@ -261,27 +261,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %30
+ThrowNullRef10:                                   ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -301,7 +301,89 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
-Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
+Successfully read AppDomainSetup.GetUnsecureApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.GetUnsecureApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %NullCheck = icmp eq %"System.String[]" addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %BoundsCheck = icmp uge i64 0, %5
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %6
+
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 3, i32 0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
+  ret %System.String addrspace(1)* %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_Value using LLILCJit
+Successfully read AppDomainSetup.get_Value
+
+define %"System.String[]" addrspace(1)* @AppDomainSetup.get_Value(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.String[]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 18)
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.String[]" addrspace(1)* addrspace(1)*, %"System.String[]" addrspace(1)*)*)(%"System.String[]" addrspace(1)* addrspace(1)* %9, %"System.String[]" addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %11, i32 0, i32 1
+  %14 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %13, align 8
+  ret %"System.String[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -319,8 +401,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -368,16 +450,16 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
   %5 = load i32, i32 addrspace(1)* %4
   %6 = sub i32 %5, 1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -389,7 +471,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -421,8 +503,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
@@ -456,8 +538,8 @@ entry:
 ; <label>:27                                      ; preds = %19
   %28 = load i32, i32* %arg1
   %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
-  br i1 %NullCheck2, label %30, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %29, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %30
 
 ; <label>:30                                      ; preds = %27
   %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
@@ -493,8 +575,8 @@ entry:
 ; <label>:49                                      ; preds = %46
   %50 = load i32, i32* %arg2
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck4, label %52, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
@@ -517,11 +599,11 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %27
+ThrowNullRef2:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %49
+ThrowNullRef4:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -544,16 +626,16 @@ entry:
   %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %0)
   store %System.String addrspace(1)* %1, %System.String addrspace(1)** %loc0
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 2
   %5 = bitcast [0 x i16] addrspace(1)* %4 to i16 addrspace(1)*
   store i16 addrspace(1)* %5, i16 addrspace(1)** %loc1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %3
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2
@@ -580,7 +662,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -691,15 +773,15 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %NullCheck132 = icmp ne i8* %21, null
-  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+  %NullCheck131 = icmp eq i8* %21, null
+  br i1 %NullCheck131, label %ThrowNullRef132, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = load i8, i8* %21, align 8
   %24 = zext i8 %23 to i32
   %25 = trunc i32 %24 to i8
-  %NullCheck134 = icmp ne i8* %20, null
-  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+  %NullCheck133 = icmp eq i8* %20, null
+  br i1 %NullCheck133, label %ThrowNullRef134, label %26
 
 ; <label>:26                                      ; preds = %22
   store i8 %25, i8* %20, align 8
@@ -709,16 +791,16 @@ entry:
   %28 = load i8*, i8** %arg0
   %29 = load i8*, i8** %arg1
   %30 = bitcast i8* %29 to i16*
-  %NullCheck128 = icmp ne i16* %30, null
-  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+  %NullCheck127 = icmp eq i16* %30, null
+  br i1 %NullCheck127, label %ThrowNullRef128, label %31
 
 ; <label>:31                                      ; preds = %27
   %32 = load i16, i16* %30, align 8
   %33 = sext i16 %32 to i32
   %34 = bitcast i8* %28 to i16*
   %35 = trunc i32 %33 to i16
-  %NullCheck130 = icmp ne i16* %34, null
-  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+  %NullCheck129 = icmp eq i16* %34, null
+  br i1 %NullCheck129, label %ThrowNullRef130, label %36
 
 ; <label>:36                                      ; preds = %31
   store i16 %35, i16* %34, align 8
@@ -728,16 +810,16 @@ entry:
   %38 = load i8*, i8** %arg0
   %39 = load i8*, i8** %arg1
   %40 = bitcast i8* %39 to i16*
-  %NullCheck120 = icmp ne i16* %40, null
-  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+  %NullCheck119 = icmp eq i16* %40, null
+  br i1 %NullCheck119, label %ThrowNullRef120, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i16, i16* %40, align 8
   %43 = sext i16 %42 to i32
   %44 = bitcast i8* %38 to i16*
   %45 = trunc i32 %43 to i16
-  %NullCheck122 = icmp ne i16* %44, null
-  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+  %NullCheck121 = icmp eq i16* %44, null
+  br i1 %NullCheck121, label %ThrowNullRef122, label %46
 
 ; <label>:46                                      ; preds = %41
   store i16 %45, i16* %44, align 8
@@ -745,15 +827,15 @@ entry:
   %48 = getelementptr inbounds i8, i8* %47, i64 2
   %49 = load i8*, i8** %arg1
   %50 = getelementptr inbounds i8, i8* %49, i64 2
-  %NullCheck124 = icmp ne i8* %50, null
-  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+  %NullCheck123 = icmp eq i8* %50, null
+  br i1 %NullCheck123, label %ThrowNullRef124, label %51
 
 ; <label>:51                                      ; preds = %46
   %52 = load i8, i8* %50, align 8
   %53 = zext i8 %52 to i32
   %54 = trunc i32 %53 to i8
-  %NullCheck126 = icmp ne i8* %48, null
-  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+  %NullCheck125 = icmp eq i8* %48, null
+  br i1 %NullCheck125, label %ThrowNullRef126, label %55
 
 ; <label>:55                                      ; preds = %51
   store i8 %54, i8* %48, align 8
@@ -763,14 +845,14 @@ entry:
   %57 = load i8*, i8** %arg0
   %58 = load i8*, i8** %arg1
   %59 = bitcast i8* %58 to i32*
-  %NullCheck116 = icmp ne i32* %59, null
-  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+  %NullCheck115 = icmp eq i32* %59, null
+  br i1 %NullCheck115, label %ThrowNullRef116, label %60
 
 ; <label>:60                                      ; preds = %56
   %61 = load i32, i32* %59, align 8
   %62 = bitcast i8* %57 to i32*
-  %NullCheck118 = icmp ne i32* %62, null
-  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+  %NullCheck117 = icmp eq i32* %62, null
+  br i1 %NullCheck117, label %ThrowNullRef118, label %63
 
 ; <label>:63                                      ; preds = %60
   store i32 %61, i32* %62, align 8
@@ -780,14 +862,14 @@ entry:
   %65 = load i8*, i8** %arg0
   %66 = load i8*, i8** %arg1
   %67 = bitcast i8* %66 to i32*
-  %NullCheck108 = icmp ne i32* %67, null
-  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+  %NullCheck107 = icmp eq i32* %67, null
+  br i1 %NullCheck107, label %ThrowNullRef108, label %68
 
 ; <label>:68                                      ; preds = %64
   %69 = load i32, i32* %67, align 8
   %70 = bitcast i8* %65 to i32*
-  %NullCheck110 = icmp ne i32* %70, null
-  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+  %NullCheck109 = icmp eq i32* %70, null
+  br i1 %NullCheck109, label %ThrowNullRef110, label %71
 
 ; <label>:71                                      ; preds = %68
   store i32 %69, i32* %70, align 8
@@ -795,15 +877,15 @@ entry:
   %73 = getelementptr inbounds i8, i8* %72, i64 4
   %74 = load i8*, i8** %arg1
   %75 = getelementptr inbounds i8, i8* %74, i64 4
-  %NullCheck112 = icmp ne i8* %75, null
-  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+  %NullCheck111 = icmp eq i8* %75, null
+  br i1 %NullCheck111, label %ThrowNullRef112, label %76
 
 ; <label>:76                                      ; preds = %71
   %77 = load i8, i8* %75, align 8
   %78 = zext i8 %77 to i32
   %79 = trunc i32 %78 to i8
-  %NullCheck114 = icmp ne i8* %73, null
-  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+  %NullCheck113 = icmp eq i8* %73, null
+  br i1 %NullCheck113, label %ThrowNullRef114, label %80
 
 ; <label>:80                                      ; preds = %76
   store i8 %79, i8* %73, align 8
@@ -813,14 +895,14 @@ entry:
   %82 = load i8*, i8** %arg0
   %83 = load i8*, i8** %arg1
   %84 = bitcast i8* %83 to i32*
-  %NullCheck100 = icmp ne i32* %84, null
-  br i1 %NullCheck100, label %85, label %ThrowNullRef99
+  %NullCheck99 = icmp eq i32* %84, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %85
 
 ; <label>:85                                      ; preds = %81
   %86 = load i32, i32* %84, align 8
   %87 = bitcast i8* %82 to i32*
-  %NullCheck102 = icmp ne i32* %87, null
-  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+  %NullCheck101 = icmp eq i32* %87, null
+  br i1 %NullCheck101, label %ThrowNullRef102, label %88
 
 ; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
@@ -829,16 +911,16 @@ entry:
   %91 = load i8*, i8** %arg1
   %92 = getelementptr inbounds i8, i8* %91, i64 4
   %93 = bitcast i8* %92 to i16*
-  %NullCheck104 = icmp ne i16* %93, null
-  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+  %NullCheck103 = icmp eq i16* %93, null
+  br i1 %NullCheck103, label %ThrowNullRef104, label %94
 
 ; <label>:94                                      ; preds = %88
   %95 = load i16, i16* %93, align 8
   %96 = sext i16 %95 to i32
   %97 = bitcast i8* %90 to i16*
   %98 = trunc i32 %96 to i16
-  %NullCheck106 = icmp ne i16* %97, null
-  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+  %NullCheck105 = icmp eq i16* %97, null
+  br i1 %NullCheck105, label %ThrowNullRef106, label %99
 
 ; <label>:99                                      ; preds = %94
   store i16 %98, i16* %97, align 8
@@ -848,14 +930,14 @@ entry:
   %101 = load i8*, i8** %arg0
   %102 = load i8*, i8** %arg1
   %103 = bitcast i8* %102 to i32*
-  %NullCheck88 = icmp ne i32* %103, null
-  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+  %NullCheck87 = icmp eq i32* %103, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %104
 
 ; <label>:104                                     ; preds = %100
   %105 = load i32, i32* %103, align 8
   %106 = bitcast i8* %101 to i32*
-  %NullCheck90 = icmp ne i32* %106, null
-  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+  %NullCheck89 = icmp eq i32* %106, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %107
 
 ; <label>:107                                     ; preds = %104
   store i32 %105, i32* %106, align 8
@@ -864,16 +946,16 @@ entry:
   %110 = load i8*, i8** %arg1
   %111 = getelementptr inbounds i8, i8* %110, i64 4
   %112 = bitcast i8* %111 to i16*
-  %NullCheck92 = icmp ne i16* %112, null
-  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+  %NullCheck91 = icmp eq i16* %112, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %113
 
 ; <label>:113                                     ; preds = %107
   %114 = load i16, i16* %112, align 8
   %115 = sext i16 %114 to i32
   %116 = bitcast i8* %109 to i16*
   %117 = trunc i32 %115 to i16
-  %NullCheck94 = icmp ne i16* %116, null
-  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+  %NullCheck93 = icmp eq i16* %116, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %118
 
 ; <label>:118                                     ; preds = %113
   store i16 %117, i16* %116, align 8
@@ -881,15 +963,15 @@ entry:
   %120 = getelementptr inbounds i8, i8* %119, i64 6
   %121 = load i8*, i8** %arg1
   %122 = getelementptr inbounds i8, i8* %121, i64 6
-  %NullCheck96 = icmp ne i8* %122, null
-  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+  %NullCheck95 = icmp eq i8* %122, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %123
 
 ; <label>:123                                     ; preds = %118
   %124 = load i8, i8* %122, align 8
   %125 = zext i8 %124 to i32
   %126 = trunc i32 %125 to i8
-  %NullCheck98 = icmp ne i8* %120, null
-  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+  %NullCheck97 = icmp eq i8* %120, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %127
 
 ; <label>:127                                     ; preds = %123
   store i8 %126, i8* %120, align 8
@@ -899,14 +981,14 @@ entry:
   %129 = load i8*, i8** %arg0
   %130 = load i8*, i8** %arg1
   %131 = bitcast i8* %130 to i64*
-  %NullCheck84 = icmp ne i64* %131, null
-  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+  %NullCheck83 = icmp eq i64* %131, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %132
 
 ; <label>:132                                     ; preds = %128
   %133 = load i64, i64* %131, align 8
   %134 = bitcast i8* %129 to i64*
-  %NullCheck86 = icmp ne i64* %134, null
-  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+  %NullCheck85 = icmp eq i64* %134, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %135
 
 ; <label>:135                                     ; preds = %132
   store i64 %133, i64* %134, align 8
@@ -916,14 +998,14 @@ entry:
   %137 = load i8*, i8** %arg0
   %138 = load i8*, i8** %arg1
   %139 = bitcast i8* %138 to i64*
-  %NullCheck76 = icmp ne i64* %139, null
-  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+  %NullCheck75 = icmp eq i64* %139, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %140
 
 ; <label>:140                                     ; preds = %136
   %141 = load i64, i64* %139, align 8
   %142 = bitcast i8* %137 to i64*
-  %NullCheck78 = icmp ne i64* %142, null
-  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+  %NullCheck77 = icmp eq i64* %142, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %143
 
 ; <label>:143                                     ; preds = %140
   store i64 %141, i64* %142, align 8
@@ -931,15 +1013,15 @@ entry:
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %NullCheck80 = icmp ne i8* %147, null
-  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+  %NullCheck79 = icmp eq i8* %147, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %148
 
 ; <label>:148                                     ; preds = %143
   %149 = load i8, i8* %147, align 8
   %150 = zext i8 %149 to i32
   %151 = trunc i32 %150 to i8
-  %NullCheck82 = icmp ne i8* %145, null
-  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+  %NullCheck81 = icmp eq i8* %145, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %152
 
 ; <label>:152                                     ; preds = %148
   store i8 %151, i8* %145, align 8
@@ -949,14 +1031,14 @@ entry:
   %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
   %156 = bitcast i8* %155 to i64*
-  %NullCheck68 = icmp ne i64* %156, null
-  br i1 %NullCheck68, label %157, label %ThrowNullRef67
+  %NullCheck67 = icmp eq i64* %156, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %157
 
 ; <label>:157                                     ; preds = %153
   %158 = load i64, i64* %156, align 8
   %159 = bitcast i8* %154 to i64*
-  %NullCheck70 = icmp ne i64* %159, null
-  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+  %NullCheck69 = icmp eq i64* %159, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %160
 
 ; <label>:160                                     ; preds = %157
   store i64 %158, i64* %159, align 8
@@ -965,16 +1047,16 @@ entry:
   %163 = load i8*, i8** %arg1
   %164 = getelementptr inbounds i8, i8* %163, i64 8
   %165 = bitcast i8* %164 to i16*
-  %NullCheck72 = icmp ne i16* %165, null
-  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+  %NullCheck71 = icmp eq i16* %165, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %166
 
 ; <label>:166                                     ; preds = %160
   %167 = load i16, i16* %165, align 8
   %168 = sext i16 %167 to i32
   %169 = bitcast i8* %162 to i16*
   %170 = trunc i32 %168 to i16
-  %NullCheck74 = icmp ne i16* %169, null
-  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+  %NullCheck73 = icmp eq i16* %169, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %171
 
 ; <label>:171                                     ; preds = %166
   store i16 %170, i16* %169, align 8
@@ -984,14 +1066,14 @@ entry:
   %173 = load i8*, i8** %arg0
   %174 = load i8*, i8** %arg1
   %175 = bitcast i8* %174 to i64*
-  %NullCheck56 = icmp ne i64* %175, null
-  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+  %NullCheck55 = icmp eq i64* %175, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %176
 
 ; <label>:176                                     ; preds = %172
   %177 = load i64, i64* %175, align 8
   %178 = bitcast i8* %173 to i64*
-  %NullCheck58 = icmp ne i64* %178, null
-  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+  %NullCheck57 = icmp eq i64* %178, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %179
 
 ; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
@@ -1000,16 +1082,16 @@ entry:
   %182 = load i8*, i8** %arg1
   %183 = getelementptr inbounds i8, i8* %182, i64 8
   %184 = bitcast i8* %183 to i16*
-  %NullCheck60 = icmp ne i16* %184, null
-  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+  %NullCheck59 = icmp eq i16* %184, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %185
 
 ; <label>:185                                     ; preds = %179
   %186 = load i16, i16* %184, align 8
   %187 = sext i16 %186 to i32
   %188 = bitcast i8* %181 to i16*
   %189 = trunc i32 %187 to i16
-  %NullCheck62 = icmp ne i16* %188, null
-  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+  %NullCheck61 = icmp eq i16* %188, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %190
 
 ; <label>:190                                     ; preds = %185
   store i16 %189, i16* %188, align 8
@@ -1017,15 +1099,15 @@ entry:
   %192 = getelementptr inbounds i8, i8* %191, i64 10
   %193 = load i8*, i8** %arg1
   %194 = getelementptr inbounds i8, i8* %193, i64 10
-  %NullCheck64 = icmp ne i8* %194, null
-  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+  %NullCheck63 = icmp eq i8* %194, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %195
 
 ; <label>:195                                     ; preds = %190
   %196 = load i8, i8* %194, align 8
   %197 = zext i8 %196 to i32
   %198 = trunc i32 %197 to i8
-  %NullCheck66 = icmp ne i8* %192, null
-  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+  %NullCheck65 = icmp eq i8* %192, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %199
 
 ; <label>:199                                     ; preds = %195
   store i8 %198, i8* %192, align 8
@@ -1035,14 +1117,14 @@ entry:
   %201 = load i8*, i8** %arg0
   %202 = load i8*, i8** %arg1
   %203 = bitcast i8* %202 to i64*
-  %NullCheck48 = icmp ne i64* %203, null
-  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+  %NullCheck47 = icmp eq i64* %203, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %204
 
 ; <label>:204                                     ; preds = %200
   %205 = load i64, i64* %203, align 8
   %206 = bitcast i8* %201 to i64*
-  %NullCheck50 = icmp ne i64* %206, null
-  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+  %NullCheck49 = icmp eq i64* %206, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %207
 
 ; <label>:207                                     ; preds = %204
   store i64 %205, i64* %206, align 8
@@ -1051,14 +1133,14 @@ entry:
   %210 = load i8*, i8** %arg1
   %211 = getelementptr inbounds i8, i8* %210, i64 8
   %212 = bitcast i8* %211 to i32*
-  %NullCheck52 = icmp ne i32* %212, null
-  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+  %NullCheck51 = icmp eq i32* %212, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %213
 
 ; <label>:213                                     ; preds = %207
   %214 = load i32, i32* %212, align 8
   %215 = bitcast i8* %209 to i32*
-  %NullCheck54 = icmp ne i32* %215, null
-  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+  %NullCheck53 = icmp eq i32* %215, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %216
 
 ; <label>:216                                     ; preds = %213
   store i32 %214, i32* %215, align 8
@@ -1068,14 +1150,14 @@ entry:
   %218 = load i8*, i8** %arg0
   %219 = load i8*, i8** %arg1
   %220 = bitcast i8* %219 to i64*
-  %NullCheck36 = icmp ne i64* %220, null
-  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64* %220, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %221
 
 ; <label>:221                                     ; preds = %217
   %222 = load i64, i64* %220, align 8
   %223 = bitcast i8* %218 to i64*
-  %NullCheck38 = icmp ne i64* %223, null
-  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+  %NullCheck37 = icmp eq i64* %223, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %224
 
 ; <label>:224                                     ; preds = %221
   store i64 %222, i64* %223, align 8
@@ -1084,14 +1166,14 @@ entry:
   %227 = load i8*, i8** %arg1
   %228 = getelementptr inbounds i8, i8* %227, i64 8
   %229 = bitcast i8* %228 to i32*
-  %NullCheck40 = icmp ne i32* %229, null
-  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i32* %229, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %230
 
 ; <label>:230                                     ; preds = %224
   %231 = load i32, i32* %229, align 8
   %232 = bitcast i8* %226 to i32*
-  %NullCheck42 = icmp ne i32* %232, null
-  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+  %NullCheck41 = icmp eq i32* %232, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %233
 
 ; <label>:233                                     ; preds = %230
   store i32 %231, i32* %232, align 8
@@ -1099,15 +1181,15 @@ entry:
   %235 = getelementptr inbounds i8, i8* %234, i64 12
   %236 = load i8*, i8** %arg1
   %237 = getelementptr inbounds i8, i8* %236, i64 12
-  %NullCheck44 = icmp ne i8* %237, null
-  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i8* %237, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %238
 
 ; <label>:238                                     ; preds = %233
   %239 = load i8, i8* %237, align 8
   %240 = zext i8 %239 to i32
   %241 = trunc i32 %240 to i8
-  %NullCheck46 = icmp ne i8* %235, null
-  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+  %NullCheck45 = icmp eq i8* %235, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %242
 
 ; <label>:242                                     ; preds = %238
   store i8 %241, i8* %235, align 8
@@ -1117,14 +1199,14 @@ entry:
   %244 = load i8*, i8** %arg0
   %245 = load i8*, i8** %arg1
   %246 = bitcast i8* %245 to i64*
-  %NullCheck24 = icmp ne i64* %246, null
-  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64* %246, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %247
 
 ; <label>:247                                     ; preds = %243
   %248 = load i64, i64* %246, align 8
   %249 = bitcast i8* %244 to i64*
-  %NullCheck26 = icmp ne i64* %249, null
-  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64* %249, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %250
 
 ; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
@@ -1133,14 +1215,14 @@ entry:
   %253 = load i8*, i8** %arg1
   %254 = getelementptr inbounds i8, i8* %253, i64 8
   %255 = bitcast i8* %254 to i32*
-  %NullCheck28 = icmp ne i32* %255, null
-  br i1 %NullCheck28, label %256, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i32* %255, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %256
 
 ; <label>:256                                     ; preds = %250
   %257 = load i32, i32* %255, align 8
   %258 = bitcast i8* %252 to i32*
-  %NullCheck30 = icmp ne i32* %258, null
-  br i1 %NullCheck30, label %259, label %ThrowNullRef29
+  %NullCheck29 = icmp eq i32* %258, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %259
 
 ; <label>:259                                     ; preds = %256
   store i32 %257, i32* %258, align 8
@@ -1149,16 +1231,16 @@ entry:
   %262 = load i8*, i8** %arg1
   %263 = getelementptr inbounds i8, i8* %262, i64 12
   %264 = bitcast i8* %263 to i16*
-  %NullCheck32 = icmp ne i16* %264, null
-  br i1 %NullCheck32, label %265, label %ThrowNullRef31
+  %NullCheck31 = icmp eq i16* %264, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %265
 
 ; <label>:265                                     ; preds = %259
   %266 = load i16, i16* %264, align 8
   %267 = sext i16 %266 to i32
   %268 = bitcast i8* %261 to i16*
   %269 = trunc i32 %267 to i16
-  %NullCheck34 = icmp ne i16* %268, null
-  br i1 %NullCheck34, label %270, label %ThrowNullRef33
+  %NullCheck33 = icmp eq i16* %268, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %270
 
 ; <label>:270                                     ; preds = %265
   store i16 %269, i16* %268, align 8
@@ -1168,14 +1250,14 @@ entry:
   %272 = load i8*, i8** %arg0
   %273 = load i8*, i8** %arg1
   %274 = bitcast i8* %273 to i64*
-  %NullCheck8 = icmp ne i64* %274, null
-  br i1 %NullCheck8, label %275, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64* %274, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %275
 
 ; <label>:275                                     ; preds = %271
   %276 = load i64, i64* %274, align 8
   %277 = bitcast i8* %272 to i64*
-  %NullCheck10 = icmp ne i64* %277, null
-  br i1 %NullCheck10, label %278, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %277, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %278
 
 ; <label>:278                                     ; preds = %275
   store i64 %276, i64* %277, align 8
@@ -1184,14 +1266,14 @@ entry:
   %281 = load i8*, i8** %arg1
   %282 = getelementptr inbounds i8, i8* %281, i64 8
   %283 = bitcast i8* %282 to i32*
-  %NullCheck12 = icmp ne i32* %283, null
-  br i1 %NullCheck12, label %284, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i32* %283, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %284
 
 ; <label>:284                                     ; preds = %278
   %285 = load i32, i32* %283, align 8
   %286 = bitcast i8* %280 to i32*
-  %NullCheck14 = icmp ne i32* %286, null
-  br i1 %NullCheck14, label %287, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i32* %286, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %287
 
 ; <label>:287                                     ; preds = %284
   store i32 %285, i32* %286, align 8
@@ -1200,16 +1282,16 @@ entry:
   %290 = load i8*, i8** %arg1
   %291 = getelementptr inbounds i8, i8* %290, i64 12
   %292 = bitcast i8* %291 to i16*
-  %NullCheck16 = icmp ne i16* %292, null
-  br i1 %NullCheck16, label %293, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i16* %292, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %293
 
 ; <label>:293                                     ; preds = %287
   %294 = load i16, i16* %292, align 8
   %295 = sext i16 %294 to i32
   %296 = bitcast i8* %289 to i16*
   %297 = trunc i32 %295 to i16
-  %NullCheck18 = icmp ne i16* %296, null
-  br i1 %NullCheck18, label %298, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i16* %296, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %298
 
 ; <label>:298                                     ; preds = %293
   store i16 %297, i16* %296, align 8
@@ -1217,15 +1299,15 @@ entry:
   %300 = getelementptr inbounds i8, i8* %299, i64 14
   %301 = load i8*, i8** %arg1
   %302 = getelementptr inbounds i8, i8* %301, i64 14
-  %NullCheck20 = icmp ne i8* %302, null
-  br i1 %NullCheck20, label %303, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i8* %302, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %303
 
 ; <label>:303                                     ; preds = %298
   %304 = load i8, i8* %302, align 8
   %305 = zext i8 %304 to i32
   %306 = trunc i32 %305 to i8
-  %NullCheck22 = icmp ne i8* %300, null
-  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i8* %300, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %307
 
 ; <label>:307                                     ; preds = %303
   store i8 %306, i8* %300, align 8
@@ -1235,14 +1317,14 @@ entry:
   %309 = load i8*, i8** %arg0
   %310 = load i8*, i8** %arg1
   %311 = bitcast i8* %310 to i64*
-  %NullCheck = icmp ne i64* %311, null
-  br i1 %NullCheck, label %312, label %ThrowNullRef
+  %NullCheck = icmp eq i64* %311, null
+  br i1 %NullCheck, label %ThrowNullRef, label %312
 
 ; <label>:312                                     ; preds = %308
   %313 = load i64, i64* %311, align 8
   %314 = bitcast i8* %309 to i64*
-  %NullCheck2 = icmp ne i64* %314, null
-  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64* %314, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %315
 
 ; <label>:315                                     ; preds = %312
   store i64 %313, i64* %314, align 8
@@ -1251,14 +1333,14 @@ entry:
   %318 = load i8*, i8** %arg1
   %319 = getelementptr inbounds i8, i8* %318, i64 8
   %320 = bitcast i8* %319 to i64*
-  %NullCheck4 = icmp ne i64* %320, null
-  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64* %320, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %321
 
 ; <label>:321                                     ; preds = %315
   %322 = load i64, i64* %320, align 8
   %323 = bitcast i8* %317 to i64*
-  %NullCheck6 = icmp ne i64* %323, null
-  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64* %323, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %324
 
 ; <label>:324                                     ; preds = %321
   store i64 %322, i64* %323, align 8
@@ -1286,15 +1368,15 @@ entry:
 ; <label>:338                                     ; preds = %333
   %339 = load i8*, i8** %arg0
   %340 = load i8*, i8** %arg1
-  %NullCheck136 = icmp ne i8* %340, null
-  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+  %NullCheck135 = icmp eq i8* %340, null
+  br i1 %NullCheck135, label %ThrowNullRef136, label %341
 
 ; <label>:341                                     ; preds = %338
   %342 = load i8, i8* %340, align 8
   %343 = zext i8 %342 to i32
   %344 = trunc i32 %343 to i8
-  %NullCheck138 = icmp ne i8* %339, null
-  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+  %NullCheck137 = icmp eq i8* %339, null
+  br i1 %NullCheck137, label %ThrowNullRef138, label %345
 
 ; <label>:345                                     ; preds = %341
   store i8 %344, i8* %339, align 8
@@ -1317,16 +1399,16 @@ entry:
   %357 = load i8*, i8** %arg0
   %358 = load i8*, i8** %arg1
   %359 = bitcast i8* %358 to i16*
-  %NullCheck140 = icmp ne i16* %359, null
-  br i1 %NullCheck140, label %360, label %ThrowNullRef139
+  %NullCheck139 = icmp eq i16* %359, null
+  br i1 %NullCheck139, label %ThrowNullRef140, label %360
 
 ; <label>:360                                     ; preds = %356
   %361 = load i16, i16* %359, align 8
   %362 = sext i16 %361 to i32
   %363 = bitcast i8* %357 to i16*
   %364 = trunc i32 %362 to i16
-  %NullCheck142 = icmp ne i16* %363, null
-  br i1 %NullCheck142, label %365, label %ThrowNullRef141
+  %NullCheck141 = icmp eq i16* %363, null
+  br i1 %NullCheck141, label %ThrowNullRef142, label %365
 
 ; <label>:365                                     ; preds = %360
   store i16 %364, i16* %363, align 8
@@ -1352,14 +1434,14 @@ entry:
   %378 = load i8*, i8** %arg0
   %379 = load i8*, i8** %arg1
   %380 = bitcast i8* %379 to i32*
-  %NullCheck144 = icmp ne i32* %380, null
-  br i1 %NullCheck144, label %381, label %ThrowNullRef143
+  %NullCheck143 = icmp eq i32* %380, null
+  br i1 %NullCheck143, label %ThrowNullRef144, label %381
 
 ; <label>:381                                     ; preds = %377
   %382 = load i32, i32* %380, align 8
   %383 = bitcast i8* %378 to i32*
-  %NullCheck146 = icmp ne i32* %383, null
-  br i1 %NullCheck146, label %384, label %ThrowNullRef145
+  %NullCheck145 = icmp eq i32* %383, null
+  br i1 %NullCheck145, label %ThrowNullRef146, label %384
 
 ; <label>:384                                     ; preds = %381
   store i32 %382, i32* %383, align 8
@@ -1384,14 +1466,14 @@ entry:
   %395 = load i8*, i8** %arg0
   %396 = load i8*, i8** %arg1
   %397 = bitcast i8* %396 to i64*
-  %NullCheck164 = icmp ne i64* %397, null
-  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+  %NullCheck163 = icmp eq i64* %397, null
+  br i1 %NullCheck163, label %ThrowNullRef164, label %398
 
 ; <label>:398                                     ; preds = %394
   %399 = load i64, i64* %397, align 8
   %400 = bitcast i8* %395 to i64*
-  %NullCheck166 = icmp ne i64* %400, null
-  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+  %NullCheck165 = icmp eq i64* %400, null
+  br i1 %NullCheck165, label %ThrowNullRef166, label %401
 
 ; <label>:401                                     ; preds = %398
   store i64 %399, i64* %400, align 8
@@ -1400,14 +1482,14 @@ entry:
   %404 = load i8*, i8** %arg1
   %405 = getelementptr inbounds i8, i8* %404, i64 8
   %406 = bitcast i8* %405 to i64*
-  %NullCheck168 = icmp ne i64* %406, null
-  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+  %NullCheck167 = icmp eq i64* %406, null
+  br i1 %NullCheck167, label %ThrowNullRef168, label %407
 
 ; <label>:407                                     ; preds = %401
   %408 = load i64, i64* %406, align 8
   %409 = bitcast i8* %403 to i64*
-  %NullCheck170 = icmp ne i64* %409, null
-  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+  %NullCheck169 = icmp eq i64* %409, null
+  br i1 %NullCheck169, label %ThrowNullRef170, label %410
 
 ; <label>:410                                     ; preds = %407
   store i64 %408, i64* %409, align 8
@@ -1437,14 +1519,14 @@ entry:
   %425 = load i8*, i8** %arg0
   %426 = load i8*, i8** %arg1
   %427 = bitcast i8* %426 to i64*
-  %NullCheck148 = icmp ne i64* %427, null
-  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+  %NullCheck147 = icmp eq i64* %427, null
+  br i1 %NullCheck147, label %ThrowNullRef148, label %428
 
 ; <label>:428                                     ; preds = %424
   %429 = load i64, i64* %427, align 8
   %430 = bitcast i8* %425 to i64*
-  %NullCheck150 = icmp ne i64* %430, null
-  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+  %NullCheck149 = icmp eq i64* %430, null
+  br i1 %NullCheck149, label %ThrowNullRef150, label %431
 
 ; <label>:431                                     ; preds = %428
   store i64 %429, i64* %430, align 8
@@ -1466,14 +1548,14 @@ entry:
   %441 = load i8*, i8** %arg0
   %442 = load i8*, i8** %arg1
   %443 = bitcast i8* %442 to i32*
-  %NullCheck152 = icmp ne i32* %443, null
-  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+  %NullCheck151 = icmp eq i32* %443, null
+  br i1 %NullCheck151, label %ThrowNullRef152, label %444
 
 ; <label>:444                                     ; preds = %440
   %445 = load i32, i32* %443, align 8
   %446 = bitcast i8* %441 to i32*
-  %NullCheck154 = icmp ne i32* %446, null
-  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+  %NullCheck153 = icmp eq i32* %446, null
+  br i1 %NullCheck153, label %ThrowNullRef154, label %447
 
 ; <label>:447                                     ; preds = %444
   store i32 %445, i32* %446, align 8
@@ -1495,16 +1577,16 @@ entry:
   %457 = load i8*, i8** %arg0
   %458 = load i8*, i8** %arg1
   %459 = bitcast i8* %458 to i16*
-  %NullCheck156 = icmp ne i16* %459, null
-  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+  %NullCheck155 = icmp eq i16* %459, null
+  br i1 %NullCheck155, label %ThrowNullRef156, label %460
 
 ; <label>:460                                     ; preds = %456
   %461 = load i16, i16* %459, align 8
   %462 = sext i16 %461 to i32
   %463 = bitcast i8* %457 to i16*
   %464 = trunc i32 %462 to i16
-  %NullCheck158 = icmp ne i16* %463, null
-  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+  %NullCheck157 = icmp eq i16* %463, null
+  br i1 %NullCheck157, label %ThrowNullRef158, label %465
 
 ; <label>:465                                     ; preds = %460
   store i16 %464, i16* %463, align 8
@@ -1525,15 +1607,15 @@ entry:
 ; <label>:474                                     ; preds = %470
   %475 = load i8*, i8** %arg0
   %476 = load i8*, i8** %arg1
-  %NullCheck160 = icmp ne i8* %476, null
-  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+  %NullCheck159 = icmp eq i8* %476, null
+  br i1 %NullCheck159, label %ThrowNullRef160, label %477
 
 ; <label>:477                                     ; preds = %474
   %478 = load i8, i8* %476, align 8
   %479 = zext i8 %478 to i32
   %480 = trunc i32 %479 to i8
-  %NullCheck162 = icmp ne i8* %475, null
-  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+  %NullCheck161 = icmp eq i8* %475, null
+  br i1 %NullCheck161, label %ThrowNullRef162, label %481
 
 ; <label>:481                                     ; preds = %477
   store i8 %480, i8* %475, align 8
@@ -1553,343 +1635,343 @@ ThrowNullRef:                                     ; preds = %308
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %312
+ThrowNullRef2:                                    ; preds = %312
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %315
+ThrowNullRef4:                                    ; preds = %315
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %321
+ThrowNullRef6:                                    ; preds = %321
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %271
+ThrowNullRef8:                                    ; preds = %271
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %275
+ThrowNullRef10:                                   ; preds = %275
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %278
+ThrowNullRef12:                                   ; preds = %278
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %284
+ThrowNullRef14:                                   ; preds = %284
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %287
+ThrowNullRef16:                                   ; preds = %287
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %293
+ThrowNullRef18:                                   ; preds = %293
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %298
+ThrowNullRef20:                                   ; preds = %298
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %303
+ThrowNullRef22:                                   ; preds = %303
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %243
+ThrowNullRef24:                                   ; preds = %243
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %247
+ThrowNullRef26:                                   ; preds = %247
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %250
+ThrowNullRef28:                                   ; preds = %250
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %256
+ThrowNullRef30:                                   ; preds = %256
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %259
+ThrowNullRef32:                                   ; preds = %259
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %265
+ThrowNullRef34:                                   ; preds = %265
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %217
+ThrowNullRef36:                                   ; preds = %217
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %221
+ThrowNullRef38:                                   ; preds = %221
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %224
+ThrowNullRef40:                                   ; preds = %224
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %230
+ThrowNullRef42:                                   ; preds = %230
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %233
+ThrowNullRef44:                                   ; preds = %233
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %238
+ThrowNullRef46:                                   ; preds = %238
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %200
+ThrowNullRef48:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %204
+ThrowNullRef50:                                   ; preds = %204
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %207
+ThrowNullRef52:                                   ; preds = %207
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %213
+ThrowNullRef54:                                   ; preds = %213
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %172
+ThrowNullRef56:                                   ; preds = %172
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %176
+ThrowNullRef58:                                   ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %179
+ThrowNullRef60:                                   ; preds = %179
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %185
+ThrowNullRef62:                                   ; preds = %185
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %190
+ThrowNullRef64:                                   ; preds = %190
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %195
+ThrowNullRef66:                                   ; preds = %195
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %153
+ThrowNullRef68:                                   ; preds = %153
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %157
+ThrowNullRef70:                                   ; preds = %157
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %160
+ThrowNullRef72:                                   ; preds = %160
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %166
+ThrowNullRef74:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %136
+ThrowNullRef76:                                   ; preds = %136
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %140
+ThrowNullRef78:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %143
+ThrowNullRef80:                                   ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %148
+ThrowNullRef82:                                   ; preds = %148
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %128
+ThrowNullRef84:                                   ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %132
+ThrowNullRef86:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %100
+ThrowNullRef88:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %104
+ThrowNullRef90:                                   ; preds = %104
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %107
+ThrowNullRef92:                                   ; preds = %107
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %113
+ThrowNullRef94:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %118
+ThrowNullRef96:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %123
+ThrowNullRef98:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %81
+ThrowNullRef100:                                  ; preds = %81
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef101:                                  ; preds = %85
+ThrowNullRef102:                                  ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef103:                                  ; preds = %88
+ThrowNullRef104:                                  ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef105:                                  ; preds = %94
+ThrowNullRef106:                                  ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef107:                                  ; preds = %64
+ThrowNullRef108:                                  ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef109:                                  ; preds = %68
+ThrowNullRef110:                                  ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef111:                                  ; preds = %71
+ThrowNullRef112:                                  ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef113:                                  ; preds = %76
+ThrowNullRef114:                                  ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef115:                                  ; preds = %56
+ThrowNullRef116:                                  ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef117:                                  ; preds = %60
+ThrowNullRef118:                                  ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef119:                                  ; preds = %37
+ThrowNullRef120:                                  ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef121:                                  ; preds = %41
+ThrowNullRef122:                                  ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef123:                                  ; preds = %46
+ThrowNullRef124:                                  ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef125:                                  ; preds = %51
+ThrowNullRef126:                                  ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef127:                                  ; preds = %27
+ThrowNullRef128:                                  ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef129:                                  ; preds = %31
+ThrowNullRef130:                                  ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef131:                                  ; preds = %19
+ThrowNullRef132:                                  ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef133:                                  ; preds = %22
+ThrowNullRef134:                                  ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef135:                                  ; preds = %338
+ThrowNullRef136:                                  ; preds = %338
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef137:                                  ; preds = %341
+ThrowNullRef138:                                  ; preds = %341
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef139:                                  ; preds = %356
+ThrowNullRef140:                                  ; preds = %356
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef141:                                  ; preds = %360
+ThrowNullRef142:                                  ; preds = %360
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef143:                                  ; preds = %377
+ThrowNullRef144:                                  ; preds = %377
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef145:                                  ; preds = %381
+ThrowNullRef146:                                  ; preds = %381
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef147:                                  ; preds = %424
+ThrowNullRef148:                                  ; preds = %424
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef149:                                  ; preds = %428
+ThrowNullRef150:                                  ; preds = %428
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef151:                                  ; preds = %440
+ThrowNullRef152:                                  ; preds = %440
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef153:                                  ; preds = %444
+ThrowNullRef154:                                  ; preds = %444
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef155:                                  ; preds = %456
+ThrowNullRef156:                                  ; preds = %456
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef157:                                  ; preds = %460
+ThrowNullRef158:                                  ; preds = %460
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef159:                                  ; preds = %474
+ThrowNullRef160:                                  ; preds = %474
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef161:                                  ; preds = %477
+ThrowNullRef162:                                  ; preds = %477
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef163:                                  ; preds = %394
+ThrowNullRef164:                                  ; preds = %394
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef165:                                  ; preds = %398
+ThrowNullRef166:                                  ; preds = %398
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef167:                                  ; preds = %401
+ThrowNullRef168:                                  ; preds = %401
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef169:                                  ; preds = %407
+ThrowNullRef170:                                  ; preds = %407
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1939,8 +2021,8 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
-  br i1 %NullCheck, label %22, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %ThrowNullRef, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
@@ -1948,8 +2030,8 @@ entry:
   store i32 %24, i32* %loc0
   %25 = load i32, i32* %loc0
   %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %26, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %27
 
 ; <label>:27                                      ; preds = %22
   %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
@@ -1971,7 +2053,7 @@ ThrowNullRef:                                     ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1989,8 +2071,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -2022,15 +2104,15 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2048,16 +2130,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
   %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
   store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %15
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
@@ -2072,8 +2154,8 @@ entry:
   %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
   %29 = ptrtoint i16 addrspace(1)* %28 to i64
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %19
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
@@ -2089,19 +2171,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2114,8 +2196,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
@@ -2128,7 +2210,7 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[loadElem]
+Failed to read AppDomain.PrepareDataForSetup[storeElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
@@ -2202,8 +2284,8 @@ entry:
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
-  br i1 %NullCheck24, label %27, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = load i64, i64 addrspace(1)* %26
@@ -2218,8 +2300,8 @@ entry:
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
-  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
   %41 = load i64, i64 addrspace(1)* %39
@@ -2236,8 +2318,8 @@ entry:
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
-  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
   %54 = load i64, i64 addrspace(1)* %52
@@ -2252,8 +2334,8 @@ entry:
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
   %67 = load i64, i64 addrspace(1)* %65
@@ -2270,8 +2352,8 @@ entry:
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
-  br i1 %NullCheck16, label %79, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
   %80 = load i64, i64 addrspace(1)* %78
@@ -2286,8 +2368,8 @@ entry:
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
-  br i1 %NullCheck18, label %92, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
   %93 = load i64, i64 addrspace(1)* %91
@@ -2304,8 +2386,8 @@ entry:
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
-  br i1 %NullCheck12, label %105, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = load i64, i64 addrspace(1)* %104
@@ -2320,8 +2402,8 @@ entry:
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
-  br i1 %NullCheck14, label %118, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
   %119 = load i64, i64 addrspace(1)* %117
@@ -2337,8 +2419,8 @@ entry:
 
 ; <label>:128                                     ; preds = %20
   %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
-  br i1 %NullCheck4, label %130, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %129, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %130
 
 ; <label>:130                                     ; preds = %128
   %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
@@ -2346,8 +2428,8 @@ entry:
   %133 = load i16, i16 addrspace(1)* %132, align 8
   %134 = zext i16 %133 to i32
   %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
-  br i1 %NullCheck6, label %136, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %135, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %136
 
 ; <label>:136                                     ; preds = %130
   %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
@@ -2360,8 +2442,8 @@ entry:
 
 ; <label>:143                                     ; preds = %136
   %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
-  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %144, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %145
 
 ; <label>:145                                     ; preds = %143
   %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
@@ -2369,8 +2451,8 @@ entry:
   %148 = load i16, i16 addrspace(1)* %147, align 8
   %149 = zext i16 %148 to i32
   %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %150, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %151
 
 ; <label>:151                                     ; preds = %145
   %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
@@ -2388,8 +2470,8 @@ entry:
 
 ; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
-  br i1 %NullCheck, label %163, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %ThrowNullRef, label %163
 
 ; <label>:163                                     ; preds = %161
   %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
@@ -2399,8 +2481,8 @@ entry:
 
 ; <label>:167                                     ; preds = %163
   %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
-  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %168, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %169
 
 ; <label>:169                                     ; preds = %167
   %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
@@ -2432,55 +2514,55 @@ ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %167
+ThrowNullRef2:                                    ; preds = %167
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %128
+ThrowNullRef4:                                    ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %130
+ThrowNullRef6:                                    ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %143
+ThrowNullRef8:                                    ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %145
+ThrowNullRef10:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %102
+ThrowNullRef12:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %105
+ThrowNullRef14:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %76
+ThrowNullRef16:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %79
+ThrowNullRef18:                                   ; preds = %79
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %50
+ThrowNullRef20:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %53
+ThrowNullRef22:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %24
+ThrowNullRef24:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %27
+ThrowNullRef26:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2503,15 +2585,15 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2519,16 +2601,16 @@ entry:
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
   store i32 %8, i32* %loc0
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
   %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
   store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
@@ -2546,16 +2628,16 @@ entry:
 
 ; <label>:23                                      ; preds = %64
   %24 = load i16*, i16** %loc3
-  %NullCheck12 = icmp ne i16* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i16* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
   store i32 %27, i32* %loc5
   %28 = load i16*, i16** %loc4
-  %NullCheck14 = icmp ne i16* %28, null
-  br i1 %NullCheck14, label %29, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %28, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = load i16, i16* %28, align 8
@@ -2620,15 +2702,15 @@ entry:
 
 ; <label>:67                                      ; preds = %64
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
-  br i1 %NullCheck8, label %69, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %68, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %69
 
 ; <label>:69                                      ; preds = %67
   %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
   %71 = load i32, i32 addrspace(1)* %70
   %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
-  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %73
 
 ; <label>:73                                      ; preds = %69
   %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
@@ -2645,31 +2727,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %67
+ThrowNullRef8:                                    ; preds = %67
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %69
+ThrowNullRef10:                                   ; preds = %69
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2710,14 +2792,14 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
   %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
@@ -2730,14 +2812,14 @@ entry:
 
 ; <label>:11                                      ; preds = %4
   %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
   %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
@@ -2749,14 +2831,14 @@ entry:
 
 ; <label>:22                                      ; preds = %16
   %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
   %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
-  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
-  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
@@ -2804,23 +2886,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2836,7 +2918,280 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[loadElem]
+Successfully read RuntimeType.IsAssignableFrom
+
+define i8 @RuntimeType.IsAssignableFrom(%System.RuntimeType addrspace(1)* %param0, %System.Type addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.RuntimeType addrspace(1)*
+  %arg1 = alloca %System.Type addrspace(1)*
+  %loc0 = alloca %System.RuntimeType addrspace(1)*
+  %loc1 = alloca %"System.Type[]" addrspace(1)*
+  %loc2 = alloca i32
+  store %System.RuntimeType addrspace(1)* %param0, %System.RuntimeType addrspace(1)** %this
+  store %System.Type addrspace(1)* %param1, %System.Type addrspace(1)** %arg1
+  %0 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %1 = icmp ne %System.Type addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i8 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %5 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %6 = bitcast %System.Type addrspace(1)* %4 to %System.Object addrspace(1)*
+  %7 = bitcast %System.RuntimeType addrspace(1)* %5 to %System.Object addrspace(1)*
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %6, %System.Object addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %3
+  ret i8 1
+
+; <label>:12                                      ; preds = %3
+  %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 152
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 32
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
+  %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
+  %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
+  store %System.RuntimeType addrspace(1)* %25, %System.RuntimeType addrspace(1)** %loc0
+  %26 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %27 = icmp eq %System.RuntimeType addrspace(1)* %26, null
+  br i1 %27, label %34, label %28
+
+; <label>:28                                      ; preds = %15
+  %29 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %30 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)*)*)(%System.RuntimeType addrspace(1)* %29, %System.RuntimeType addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+; <label>:34                                      ; preds = %15
+  %35 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %36 = call %System.Reflection.Emit.TypeBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Reflection.Emit.TypeBuilder addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %35)
+  %37 = icmp eq %System.Reflection.Emit.TypeBuilder addrspace(1)* %36, null
+  br i1 %37, label %139, label %38
+
+; <label>:38                                      ; preds = %34
+  %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %42
+
+; <label>:42                                      ; preds = %38
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 152
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 40
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
+  %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
+  %53 = zext i8 %52 to i32
+  %54 = icmp eq i32 %53, 0
+  br i1 %54, label %56, label %55
+
+; <label>:55                                      ; preds = %42
+  ret i8 1
+
+; <label>:56                                      ; preds = %42
+  %57 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %58 = bitcast %System.RuntimeType addrspace(1)* %57 to %System.Type addrspace(1)*
+  %59 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %58)
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %64 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.Type addrspace(1)* %63, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = bitcast %System.RuntimeType addrspace(1)* %64 to %System.Type addrspace(1)*
+  %67 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %63, %System.Type addrspace(1)* %66)
+  %68 = zext i8 %67 to i32
+  %69 = trunc i32 %68 to i8
+  ret i8 %69
+
+; <label>:70                                      ; preds = %56
+  %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
+  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %73
+
+; <label>:73                                      ; preds = %70
+  %74 = load i64, i64 addrspace(1)* %72
+  %75 = add i64 %74, 128
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = add i64 %77, 0
+  %79 = inttoptr i64 %78 to i64*
+  %80 = load i64, i64* %79
+  %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
+  %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
+  %83 = call i8 %82(%System.Type addrspace(1)* %81)
+  %84 = zext i8 %83 to i32
+  %85 = icmp eq i32 %84, 0
+  br i1 %85, label %139, label %86
+
+; <label>:86                                      ; preds = %73
+  %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
+  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %89
+
+; <label>:89                                      ; preds = %86
+  %90 = load i64, i64 addrspace(1)* %88
+  %91 = add i64 %90, 128
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = add i64 %93, 24
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
+  %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
+  %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
+  store %"System.Type[]" addrspace(1)* %99, %"System.Type[]" addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %129
+
+; <label>:100                                     ; preds = %132
+  %101 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %102 = load i32, i32* %loc2
+  %NullCheck11 = icmp eq %"System.Type[]" addrspace(1)* %101, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %103
+
+; <label>:103                                     ; preds = %100
+  %104 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 1
+  %105 = load i32, i32 addrspace(1)* %104
+  %106 = zext i32 %105 to i64
+  %107 = zext i32 %102 to i64
+  %BoundsCheck = icmp uge i64 %107, %106
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %108
+
+; <label>:108                                     ; preds = %103
+  %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
+  %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
+  %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
+  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %113
+
+; <label>:113                                     ; preds = %108
+  %114 = load i64, i64 addrspace(1)* %112
+  %115 = add i64 %114, 152
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = add i64 %117, 56
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
+  %123 = zext i8 %122 to i32
+  %124 = icmp ne i32 %123, 0
+  br i1 %124, label %126, label %125
+
+; <label>:125                                     ; preds = %113
+  ret i8 0
+
+; <label>:126                                     ; preds = %113
+  %127 = load i32, i32* %loc2
+  %128 = add i32 %127, 1
+  store i32 %128, i32* %loc2
+  br label %129
+
+; <label>:129                                     ; preds = %89, %126
+  %130 = load i32, i32* %loc2
+  %131 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %NullCheck9 = icmp eq %"System.Type[]" addrspace(1)* %131, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %132
+
+; <label>:132                                     ; preds = %129
+  %133 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %131, i32 0, i32 1
+  %134 = load i32, i32 addrspace(1)* %133
+  %135 = zext i32 %134 to i64
+  %136 = trunc i64 %135 to i32
+  %137 = icmp slt i32 %130, %136
+  br i1 %137, label %100, label %138
+
+; <label>:138                                     ; preds = %132
+  ret i8 1
+
+; <label>:139                                     ; preds = %34, %73
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %129
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %103
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -2893,7 +3248,7 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElem]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -2904,8 +3259,8 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -2997,8 +3352,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
@@ -3059,8 +3414,8 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -3087,8 +3442,8 @@ entry:
 
 ; <label>:17                                      ; preds = %5, %11
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
@@ -3097,8 +3452,8 @@ entry:
 
 ; <label>:22                                      ; preds = %1, %11
   %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
@@ -3109,11 +3464,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %17
+ThrowNullRef2:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %22
+ThrowNullRef4:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3167,15 +3522,15 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
   %15 = load i32, i32 addrspace(1)* %14
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
@@ -3198,7 +3553,7 @@ ThrowNullRef:                                     ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef2:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3232,8 +3587,8 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
@@ -3312,8 +3667,8 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -3327,8 +3682,8 @@ entry:
 ; <label>:5                                       ; preds = %43
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %7 = load i32, i32* %loc1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck6, label %8, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
@@ -3366,8 +3721,8 @@ entry:
 ; <label>:32                                      ; preds = %21, %25
   %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
   %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
-  br i1 %NullCheck8, label %35, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = trunc i32 %34 to i16
@@ -3380,8 +3735,8 @@ entry:
 ; <label>:40                                      ; preds = %1, %35
   %41 = load i32, i32* %loc1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
-  br i1 %NullCheck2, label %43, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %42, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
@@ -3392,8 +3747,8 @@ entry:
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
   %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
-  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
   %51 = load i64, i64 addrspace(1)* %49
@@ -3412,19 +3767,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %40
+ThrowNullRef2:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %47
+ThrowNullRef4:                                    ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %5
+ThrowNullRef6:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %32
+ThrowNullRef8:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3467,8 +3822,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
@@ -3492,11 +3847,391 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(i16* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store i16* %param0, i16** %arg0
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load i32, i32* %arg3
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %42, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %37, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg2
+  %13 = load i32, i32* %arg3
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %37, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %24 = load i32, i32* %arg2
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load i16*, i16** %arg0
+  %35 = load i32, i32* %arg3
+  %36 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %36, i16* %34, i32 %35)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:37                                      ; preds = %5, %16
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %39)
+  %41 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41, %System.String addrspace(1)* %38, %System.String addrspace(1)* %40)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41) #0
+  unreachable
+
+; <label>:42                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
-Failed to read StringBuilder.ToString[loadElemA]
+Successfully read StringBuilder.ToString
+
+define %System.String addrspace(1)* @StringBuilder.ToString(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i16*
+  %loc3 = alloca %"System.Char[]" addrspace(1)*
+  %loc4 = alloca i32
+  %loc5 = alloca i32
+  %loc6 = alloca i16 addrspace(1)*
+  %loc7 = alloca %System.String addrspace(1)*
+  %loc8 = alloca %"System.Char[]" addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %0)
+  %2 = icmp ne i32 %1, 0
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %4
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %6)
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %7)
+  store %System.String addrspace(1)* %8, %System.String addrspace(1)** %loc0
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.Text.StringBuilder addrspace(1)* %9, %System.Text.StringBuilder addrspace(1)** %loc1
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  store %System.String addrspace(1)* %10, %System.String addrspace(1)** %loc7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc7
+  %12 = ptrtoint %System.String addrspace(1)* %11 to i64
+  %13 = icmp eq i64 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %5
+  %15 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %16 = sext i32 %15 to i64
+  %17 = add i64 %12, %16
+  br label %18
+
+; <label>:18                                      ; preds = %5, %14
+  %19 = phi i64 [ %12, %5 ], [ %17, %14 ]
+  %20 = inttoptr i64 %19 to i16*
+  store i16* %20, i16** %loc2
+  br label %21
+
+; <label>:21                                      ; preds = %98, %18
+  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %22, null
+  br i1 %NullCheck, label %ThrowNullRef, label %23
+
+; <label>:23                                      ; preds = %21
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 3
+  %25 = load i32, i32 addrspace(1)* %24, align 8
+  %26 = icmp sle i32 %25, 0
+  br i1 %26, label %96, label %27
+
+; <label>:27                                      ; preds = %23
+  %28 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %28, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %29
+
+; <label>:29                                      ; preds = %27
+  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %28, i32 0, i32 1
+  %31 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %30, align 8
+  store %"System.Char[]" addrspace(1)* %31, %"System.Char[]" addrspace(1)** %loc3
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %33
+
+; <label>:33                                      ; preds = %29
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  store i32 %35, i32* %loc4
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  %39 = load i32, i32 addrspace(1)* %38, align 8
+  store i32 %39, i32* %loc5
+  %40 = load i32, i32* %loc5
+  %41 = load i32, i32* %loc4
+  %42 = add i32 %40, %41
+  %43 = zext i32 %42 to i64
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %45
+
+; <label>:45                                      ; preds = %37
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = sext i32 %47 to i64
+  %49 = icmp sgt i64 %43, %48
+  br i1 %49, label %91, label %50
+
+; <label>:50                                      ; preds = %45
+  %51 = load i32, i32* %loc5
+  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %52, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %53
+
+; <label>:53                                      ; preds = %50
+  %54 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %52, i32 0, i32 1
+  %55 = load i32, i32 addrspace(1)* %54
+  %56 = zext i32 %55 to i64
+  %57 = trunc i64 %56 to i32
+  %58 = icmp ugt i32 %51, %57
+  br i1 %58, label %91, label %59
+
+; <label>:59                                      ; preds = %53
+  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  store %"System.Char[]" addrspace(1)* %60, %"System.Char[]" addrspace(1)** %loc8
+  %61 = icmp eq %"System.Char[]" addrspace(1)* %60, null
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %63, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %64
+
+; <label>:64                                      ; preds = %62
+  %65 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %63, i32 0, i32 1
+  %66 = load i32, i32 addrspace(1)* %65
+  %67 = zext i32 %66 to i64
+  %68 = trunc i64 %67 to i32
+  %69 = icmp ne i32 %68, 0
+  br i1 %69, label %71, label %70
+
+; <label>:70                                      ; preds = %59, %64
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:71                                      ; preds = %64
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %73
+
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %BoundsCheck = icmp uge i64 0, %76
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %77
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %78, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:79                                      ; preds = %70, %77
+  %80 = load i16*, i16** %loc2
+  %81 = load i32, i32* %loc4
+  %82 = sext i32 %81 to i64
+  %83 = mul i64 %82, 2
+  %84 = bitcast i16* %80 to i8*
+  %85 = getelementptr inbounds i8, i8* %84, i64 %83
+  %86 = load i16 addrspace(1)*, i16 addrspace(1)** %loc6
+  %87 = ptrtoint i16 addrspace(1)* %86 to i64
+  %88 = load i32, i32* %loc5
+  %89 = bitcast i8* %85 to i16*
+  %90 = inttoptr i64 %87 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %89, i16* %90, i32 %88)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %96
+
+; <label>:91                                      ; preds = %45, %53
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %94 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %93)
+  %95 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95, %System.String addrspace(1)* %92, %System.String addrspace(1)* %94)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95) #0
+  unreachable
+
+; <label>:96                                      ; preds = %23, %79
+  %97 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %97, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %98
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %97, i32 0, i32 2
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  store %System.Text.StringBuilder addrspace(1)* %100, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %102 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %102, label %21, label %103
+
+; <label>:103                                     ; preds = %98
+  store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc7
+  %104 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  ret %System.String addrspace(1)* %104
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method StringBuilder::get_Length using LLILCJit
+Successfully read StringBuilder.get_Length
+
+define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
+Successfully read RuntimeHelpers.get_OffsetToStringData
+
+define i32 @RuntimeHelpers.get_OffsetToStringData() {
+entry:
+  ret i32 12
+}
+
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
 Successfully read CultureData.CreateCultureData
 
@@ -3514,23 +4249,23 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
   store i8 %4, i8 addrspace(1)* %6
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
@@ -3549,11 +4284,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3566,50 +4301,50 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
   store i32 -1, i32 addrspace(1)* %2
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
   store i32 -1, i32 addrspace(1)* %8
   %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
   store i32 -1, i32 addrspace(1)* %14
   %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
   store i32 -1, i32 addrspace(1)* %17
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
@@ -3623,27 +4358,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3675,7 +4410,136 @@ Failed to read Dictionary`2.Insert[non-const derefAddress]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
 Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
-Failed to read HashHelpers.GetPrime[loadElem]
+Successfully read HashHelpers.GetPrime
+
+define i32 @HashHelpers.GetPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %6, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5, %System.String addrspace(1)* %4)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5) #0
+  unreachable
+
+; <label>:6                                       ; preds = %entry
+  store i32 0, i32* %loc0
+  br label %29
+
+; <label>:7                                       ; preds = %35
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 1296
+  %10 = addrspacecast i8 addrspace(1)* %9 to %"System.Int32[]" addrspace(1)**
+  %11 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %10
+  %12 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Int32[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = zext i32 %15 to i64
+  %17 = zext i32 %12 to i64
+  %BoundsCheck = icmp uge i64 %17, %16
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 3, i32 %12
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  store i32 %20, i32* %loc1
+  %21 = load i32, i32* %loc1
+  %22 = load i32, i32* %arg0
+  %23 = icmp slt i32 %21, %22
+  br i1 %23, label %26, label %24
+
+; <label>:24                                      ; preds = %18
+  %25 = load i32, i32* %loc1
+  ret i32 %25
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %loc0
+  %28 = add i32 %27, 1
+  store i32 %28, i32* %loc0
+  br label %29
+
+; <label>:29                                      ; preds = %6, %26
+  %30 = load i32, i32* %loc0
+  %31 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %32 = getelementptr inbounds i8, i8 addrspace(1)* %31, i64 1296
+  %33 = addrspacecast i8 addrspace(1)* %32 to %"System.Int32[]" addrspace(1)**
+  %34 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %33
+  %NullCheck = icmp eq %"System.Int32[]" addrspace(1)* %34, null
+  br i1 %NullCheck, label %ThrowNullRef, label %35
+
+; <label>:35                                      ; preds = %29
+  %36 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %34, i32 0, i32 1
+  %37 = load i32, i32 addrspace(1)* %36
+  %38 = zext i32 %37 to i64
+  %39 = trunc i64 %38 to i32
+  %40 = icmp slt i32 %30, %39
+  br i1 %40, label %7, label %41
+
+; <label>:41                                      ; preds = %35
+  %42 = load i32, i32* %arg0
+  %43 = or i32 %42, 1
+  store i32 %43, i32* %loc2
+  br label %59
+
+; <label>:44                                      ; preds = %59
+  %45 = load i32, i32* %loc2
+  %46 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %45)
+  %47 = zext i8 %46 to i32
+  %48 = icmp eq i32 %47, 0
+  br i1 %48, label %56, label %49
+
+; <label>:49                                      ; preds = %44
+  %50 = load i32, i32* %loc2
+  %51 = sub i32 %50, 1
+  %52 = srem i32 %51, 101
+  %53 = icmp eq i32 %52, 0
+  br i1 %53, label %56, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = load i32, i32* %loc2
+  ret i32 %55
+
+; <label>:56                                      ; preds = %44, %49
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %57, 2
+  store i32 %58, i32* %loc2
+  br label %59
+
+; <label>:59                                      ; preds = %41, %56
+  %60 = load i32, i32* %loc2
+  %61 = icmp slt i32 %60, 2147483647
+  br i1 %61, label %44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load i32, i32* %arg0
+  ret i32 %63
+
+ThrowNullRef:                                     ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
 Successfully read GenericEqualityComparer`1.GetHashCode
 
@@ -3694,14 +4558,14 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
   %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load i64, i64 addrspace(1)* %7
@@ -3720,7 +4584,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3750,8 +4614,8 @@ entry:
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
@@ -3796,8 +4660,8 @@ entry:
   %35 = bitcast i16* %34 to i8*
   %36 = getelementptr inbounds i8, i8* %35, i64 2
   %37 = bitcast i8* %36 to i16*
-  %NullCheck4 = icmp ne i16* %37, null
-  br i1 %NullCheck4, label %38, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %37, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %38
 
 ; <label>:38                                      ; preds = %27
   %39 = load i16, i16* %37, align 8
@@ -3824,8 +4688,8 @@ entry:
 
 ; <label>:54                                      ; preds = %22, %43
   %55 = load i16*, i16** %loc4
-  %NullCheck2 = icmp ne i16* %55, null
-  br i1 %NullCheck2, label %56, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i16* %55, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %56
 
 ; <label>:56                                      ; preds = %54
   %57 = load i16, i16* %55, align 8
@@ -3850,11 +4714,11 @@ ThrowNullRef:                                     ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %54
+ThrowNullRef2:                                    ; preds = %54
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %27
+ThrowNullRef4:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3871,8 +4735,8 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -3907,8 +4771,8 @@ entry:
 
 ; <label>:26                                      ; preds = %19
   %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
-  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %28
 
 ; <label>:28                                      ; preds = %26
   %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
@@ -3920,7 +4784,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3972,8 +4836,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
@@ -3984,26 +4848,26 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
-  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
@@ -4014,8 +4878,8 @@ entry:
 ; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
@@ -4024,8 +4888,8 @@ entry:
 
 ; <label>:25                                      ; preds = %1, %16, %23
   %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
-  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
@@ -4036,27 +4900,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %20
+ThrowNullRef10:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4069,8 +4933,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -4081,8 +4945,8 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
@@ -4091,8 +4955,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1, %8
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
@@ -4103,11 +4967,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4128,24 +4992,24 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   store i32 %3, i32* %loc0
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
   %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
   store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck4, label %9, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
@@ -4164,15 +5028,15 @@ entry:
 ; <label>:18                                      ; preds = %70
   %19 = load i16*, i16** %loc3
   %20 = bitcast i16* %19 to i64*
-  %NullCheck10 = icmp ne i64* %20, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %20, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = load i64, i64* %20, align 8
   %23 = load i16*, i16** %loc4
   %24 = bitcast i16* %23 to i64*
-  %NullCheck12 = icmp ne i64* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = load i64, i64* %24, align 8
@@ -4188,8 +5052,8 @@ entry:
   %31 = bitcast i16* %30 to i8*
   %32 = getelementptr inbounds i8, i8* %31, i64 8
   %33 = bitcast i8* %32 to i64*
-  %NullCheck14 = icmp ne i64* %33, null
-  br i1 %NullCheck14, label %34, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = load i64, i64* %33, align 8
@@ -4197,8 +5061,8 @@ entry:
   %37 = bitcast i16* %36 to i8*
   %38 = getelementptr inbounds i8, i8* %37, i64 8
   %39 = bitcast i8* %38 to i64*
-  %NullCheck16 = icmp ne i64* %39, null
-  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %40
 
 ; <label>:40                                      ; preds = %34
   %41 = load i64, i64* %39, align 8
@@ -4214,8 +5078,8 @@ entry:
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %NullCheck18 = icmp ne i64* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = load i64, i64* %48, align 8
@@ -4223,8 +5087,8 @@ entry:
   %52 = bitcast i16* %51 to i8*
   %53 = getelementptr inbounds i8, i8* %52, i64 16
   %54 = bitcast i8* %53 to i64*
-  %NullCheck20 = icmp ne i64* %54, null
-  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64* %54, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %55
 
 ; <label>:55                                      ; preds = %49
   %56 = load i64, i64* %54, align 8
@@ -4262,15 +5126,15 @@ entry:
 ; <label>:74                                      ; preds = %95
   %75 = load i16*, i16** %loc3
   %76 = bitcast i16* %75 to i32*
-  %NullCheck6 = icmp ne i32* %76, null
-  br i1 %NullCheck6, label %77, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32* %76, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %77
 
 ; <label>:77                                      ; preds = %74
   %78 = load i32, i32* %76, align 8
   %79 = load i16*, i16** %loc4
   %80 = bitcast i16* %79 to i32*
-  %NullCheck8 = icmp ne i32* %80, null
-  br i1 %NullCheck8, label %81, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i32* %80, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %81
 
 ; <label>:81                                      ; preds = %77
   %82 = load i32, i32* %80, align 8
@@ -4318,43 +5182,43 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %74
+ThrowNullRef6:                                    ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %77
+ThrowNullRef8:                                    ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %29
+ThrowNullRef14:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %34
+ThrowNullRef16:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4376,8 +5240,8 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load i64, i64 addrspace(1)* %4
@@ -4389,8 +5253,8 @@ entry:
   %12 = load i64, i64* %11
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %5
   %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
@@ -4399,8 +5263,8 @@ entry:
   %18 = load i8, i8* %arg2
   %19 = zext i8 %18 to i32
   %20 = trunc i32 %19 to i8
-  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %15
   %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
@@ -4411,11 +5275,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4442,8 +5306,8 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
@@ -4466,16 +5330,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
   %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = load i64, i64 addrspace(1)* %19
@@ -4500,8 +5364,8 @@ entry:
 ; <label>:35                                      ; preds = %30
   %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
@@ -4514,8 +5378,8 @@ entry:
 
 ; <label>:42                                      ; preds = %1, %38
   %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
-  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
@@ -4526,19 +5390,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %35
+ThrowNullRef2:                                    ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %42
+ThrowNullRef8:                                    ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4551,14 +5415,14 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
@@ -4570,7 +5434,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4583,8 +5447,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
@@ -4613,51 +5477,51 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
   %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
   %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
   %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
   %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
-  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
   store i64 %21, i64 addrspace(1)* %23
   %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %25 = load i64, i64* %loc0
-  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
@@ -4668,27 +5532,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %22
+ThrowNullRef12:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4701,8 +5565,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
@@ -4713,19 +5577,19 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
@@ -4734,8 +5598,8 @@ entry:
 
 ; <label>:15                                      ; preds = %1, %13
   %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
@@ -4746,19 +5610,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %15
+ThrowNullRef8:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4771,8 +5635,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -4831,8 +5695,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
@@ -4882,8 +5746,8 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
-  br i1 %NullCheck, label %17, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %ThrowNullRef, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
@@ -4894,15 +5758,15 @@ entry:
 
 ; <label>:22                                      ; preds = %17
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
-  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
   %26 = load i32, i32 addrspace(1)* %25
   %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
-  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %27, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
@@ -4925,8 +5789,8 @@ entry:
 ; <label>:40                                      ; preds = %17
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
-  br i1 %NullCheck6, label %43, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %41, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
@@ -4938,34 +5802,17 @@ ThrowNullRef:                                     ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %24
+ThrowNullRef4:                                    ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %40
+ThrowNullRef6:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
-}
-
-INFO:  jitting method Object::ReferenceEquals using LLILCJit
-Successfully read Object.ReferenceEquals
-
-define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
-entry:
-  %arg0 = alloca %System.Object addrspace(1)*
-  %arg1 = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
-  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
-  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = icmp eq %System.Object addrspace(1)* %0, %1
-  %3 = sext i1 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
 }
 
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
@@ -4978,21 +5825,21 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
   %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
-  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
@@ -5007,28 +5854,28 @@ entry:
 ; <label>:13                                      ; preds = %8, %12
   %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
   %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
   %21 = load i32, i32 addrspace(1)* %20, align 8
   %22 = add i32 %21, 1
-  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
   store i32 %22, i32 addrspace(1)* %24
   %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
@@ -5039,27 +5886,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5077,7 +5924,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::Setup using LLILCJit
-Failed to read AppDomain.Setup[loadElem]
+Failed to read AppDomain.Setup[unbox]
 INFO:  jitting method Thread::GetDomain using LLILCJit
 Successfully read Thread.GetDomain
 
@@ -5108,8 +5955,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
@@ -5122,14 +5969,14 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
   %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
@@ -5141,11 +5988,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5173,8 +6020,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -5189,7 +6036,328 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
 Failed to read KeyCollection.System.Collections.Generic.IEnumerable<TKey>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Successfully read Enumerator.MoveNext
+
+define i8 @Enumerator.MoveNext(%"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.RuntimeTypeHandle* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*
+  %"$TypeArg" = alloca %System.RuntimeTypeHandle*
+  store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
+  %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 8
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %76, label %12
+
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
+  br label %76
+
+; <label>:13                                      ; preds = %85
+  %14 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck19 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %15
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, i32 0, i32 0
+  %17 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %16, align 8
+  %NullCheck21 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, i32 0, i32 2
+  %20 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %19, align 8
+  %21 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck23 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %22
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, i32 0, i32 2
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %NullCheck25 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 3, i32 %24
+  %NullCheck27 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %32
+
+; <label>:32                                      ; preds = %30
+  %33 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, i32 0, i32 2
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = icmp slt i32 %34, 0
+  br i1 %35, label %68, label %36
+
+; <label>:36                                      ; preds = %32
+  %37 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %38 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck29 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %39
+
+; <label>:39                                      ; preds = %36
+  %40 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, i32 0, i32 0
+  %41 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %40, align 8
+  %NullCheck31 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, i32 0, i32 2
+  %44 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %43, align 8
+  %45 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck33 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, i32 0, i32 2
+  %48 = load i32, i32 addrspace(1)* %47, align 8
+  %NullCheck35 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %49
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = zext i32 %51 to i64
+  %53 = zext i32 %48 to i64
+  %BoundsCheck37 = icmp uge i64 %53, %52
+  br i1 %BoundsCheck37, label %ThrowIndexOutOfRange38, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 3, i32 %48
+  %NullCheck39 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %56
+
+; <label>:56                                      ; preds = %54
+  %57 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, i32 0, i32 0
+  %58 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck41 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %59
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %60, %System.__Canon addrspace(1)* %58)
+  %61 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck43 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  %64 = load i32, i32 addrspace(1)* %63, align 8
+  %65 = add i32 %64, 1
+  %NullCheck45 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  store i32 %65, i32 addrspace(1)* %67
+  ret i8 1
+
+; <label>:68                                      ; preds = %32
+  %69 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck47 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %73 = add i32 %72, 1
+  %NullCheck49 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %74
+
+; <label>:74                                      ; preds = %70
+  %75 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  store i32 %73, i32 addrspace(1)* %75
+  br label %76
+
+; <label>:76                                      ; preds = %8, %12, %74
+  %77 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %78
+
+; <label>:78                                      ; preds = %76
+  %79 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, i32 0, i32 2
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck7 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %82
+
+; <label>:82                                      ; preds = %78
+  %83 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, i32 0, i32 0
+  %84 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %83, align 8
+  %NullCheck9 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %85
+
+; <label>:85                                      ; preds = %82
+  %86 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, i32 0, i32 7
+  %87 = load i32, i32 addrspace(1)* %86, align 8
+  %88 = icmp ult i32 %80, %87
+  br i1 %88, label %13, label %89
+
+; <label>:89                                      ; preds = %85
+  %90 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %91 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck11 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %92
+
+; <label>:92                                      ; preds = %89
+  %93 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, i32 0, i32 0
+  %94 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck13 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %95
+
+; <label>:95                                      ; preds = %92
+  %96 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, i32 0, i32 7
+  %97 = load i32, i32 addrspace(1)* %96, align 8
+  %98 = add i32 %97, 1
+  %NullCheck15 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %99
+
+; <label>:99                                      ; preds = %95
+  %100 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, i32 0, i32 2
+  store i32 %98, i32 addrspace(1)* %100
+  %101 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck17 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %102
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %103, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %92
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef22:                                   ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef24:                                   ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef26:                                   ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef28:                                   ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef30:                                   ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef32:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef34:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef36:                                   ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange38:                           ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef40:                                   ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef42:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef44:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef46:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef48:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef50:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -5200,8 +6368,8 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -5232,9 +6400,9 @@ Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
 Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
-Failed to read String.MakeSeparatorList[loadElemA]
+Failed to read String.MakeSeparatorList[storeElem]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
-Failed to read String.InternalSplitKeepEmptyEntries[loadElem]
+Failed to read String.InternalSplitKeepEmptyEntries[storeElem]
 INFO:  jitting method Path::IsRelative using LLILCJit
 Successfully read Path.IsRelative
 
@@ -5243,8 +6411,8 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -5254,8 +6422,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
@@ -5271,8 +6439,8 @@ entry:
 
 ; <label>:17                                      ; preds = %7
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
@@ -5288,8 +6456,8 @@ entry:
 
 ; <label>:29                                      ; preds = %19
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %31
 
 ; <label>:31                                      ; preds = %29
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
@@ -5300,8 +6468,8 @@ entry:
 
 ; <label>:36                                      ; preds = %31
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
-  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %37, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
@@ -5312,8 +6480,8 @@ entry:
 
 ; <label>:43                                      ; preds = %31, %38
   %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
-  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %45
 
 ; <label>:45                                      ; preds = %43
   %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
@@ -5324,8 +6492,8 @@ entry:
 
 ; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %50
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
@@ -5336,8 +6504,8 @@ entry:
 
 ; <label>:57                                      ; preds = %1, %7, %19, %45, %52
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
-  br i1 %NullCheck14, label %59, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %59
 
 ; <label>:59                                      ; preds = %57
   %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
@@ -5347,8 +6515,8 @@ entry:
 
 ; <label>:63                                      ; preds = %59
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
@@ -5359,8 +6527,8 @@ entry:
 
 ; <label>:70                                      ; preds = %65
   %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
-  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.String addrspace(1)* %71, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %72
 
 ; <label>:72                                      ; preds = %70
   %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
@@ -5379,39 +6547,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %17
+ThrowNullRef4:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %29
+ThrowNullRef6:                                    ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %36
+ThrowNullRef8:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %43
+ThrowNullRef10:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %50
+ThrowNullRef12:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %57
+ThrowNullRef14:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %63
+ThrowNullRef16:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %70
+ThrowNullRef18:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5419,7 +6587,293 @@ ThrowNullRef17:                                   ; preds = %70
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
-Failed to read String.TrimHelper[loadElem]
+Successfully read String.TrimHelper
+
+define %System.String addrspace(1)* @String.TrimHelper(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i16
+  %loc4 = alloca i32
+  %loc5 = alloca i16
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = sub i32 %3, 1
+  store i32 %4, i32* %loc0
+  store i32 0, i32* %loc1
+  %5 = load i32, i32* %arg2
+  %6 = icmp eq i32 %5, 1
+  br i1 %6, label %62, label %7
+
+; <label>:7                                       ; preds = %1
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:8                                       ; preds = %58
+  store i32 0, i32* %loc2
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load i32, i32* %loc1
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2, i32 %10
+  %13 = load i16, i16 addrspace(1)* %12
+  %14 = zext i16 %13 to i32
+  %15 = trunc i32 %14 to i16
+  store i16 %15, i16* %loc3
+  store i32 0, i32* %loc2
+  br label %34
+
+; <label>:16                                      ; preds = %37
+  %17 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %18 = load i32, i32* %loc2
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %17, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %19
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = zext i32 %18 to i64
+  %BoundsCheck = icmp uge i64 %23, %22
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %24
+
+; <label>:24                                      ; preds = %19
+  %25 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 3, i32 %18
+  %26 = load i16, i16 addrspace(1)* %25, align 8
+  %27 = zext i16 %26 to i32
+  %28 = load i16, i16* %loc3
+  %29 = zext i16 %28 to i32
+  %30 = icmp eq i32 %27, %29
+  br i1 %30, label %43, label %31
+
+; <label>:31                                      ; preds = %24
+  %32 = load i32, i32* %loc2
+  %33 = add i32 %32, 1
+  store i32 %33, i32* %loc2
+  br label %34
+
+; <label>:34                                      ; preds = %11, %31
+  %35 = load i32, i32* %loc2
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = icmp slt i32 %35, %41
+  br i1 %42, label %16, label %43
+
+; <label>:43                                      ; preds = %24, %37
+  %44 = load i32, i32* %loc2
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %45, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp eq i32 %44, %50
+  br i1 %51, label %62, label %52
+
+; <label>:52                                      ; preds = %46
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %7, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %57, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %58
+
+; <label>:58                                      ; preds = %55
+  %59 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %60 = load i32, i32 addrspace(1)* %59
+  %61 = icmp slt i32 %56, %60
+  br i1 %61, label %8, label %62
+
+; <label>:62                                      ; preds = %1, %46, %58
+  %63 = load i32, i32* %arg2
+  %64 = icmp eq i32 %63, 0
+  br i1 %64, label %122, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %66, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %67
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %66, i32 0, i32 1
+  %69 = load i32, i32 addrspace(1)* %68
+  %70 = sub i32 %69, 1
+  store i32 %70, i32* %loc0
+  br label %118
+
+; <label>:71                                      ; preds = %118
+  store i32 0, i32* %loc4
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %73 = load i32, i32* %loc0
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %74
+
+; <label>:74                                      ; preds = %71
+  %75 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 2, i32 %73
+  %76 = load i16, i16 addrspace(1)* %75
+  %77 = zext i16 %76 to i32
+  %78 = trunc i32 %77 to i16
+  store i16 %78, i16* %loc5
+  store i32 0, i32* %loc4
+  br label %97
+
+; <label>:79                                      ; preds = %100
+  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %81 = load i32, i32* %loc4
+  %NullCheck19 = icmp eq %"System.Char[]" addrspace(1)* %80, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
+
+; <label>:82                                      ; preds = %79
+  %83 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 1
+  %84 = load i32, i32 addrspace(1)* %83
+  %85 = zext i32 %84 to i64
+  %86 = zext i32 %81 to i64
+  %BoundsCheck21 = icmp uge i64 %86, %85
+  br i1 %BoundsCheck21, label %ThrowIndexOutOfRange22, label %87
+
+; <label>:87                                      ; preds = %82
+  %88 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 3, i32 %81
+  %89 = load i16, i16 addrspace(1)* %88, align 8
+  %90 = zext i16 %89 to i32
+  %91 = load i16, i16* %loc5
+  %92 = zext i16 %91 to i32
+  %93 = icmp eq i32 %90, %92
+  br i1 %93, label %106, label %94
+
+; <label>:94                                      ; preds = %87
+  %95 = load i32, i32* %loc4
+  %96 = add i32 %95, 1
+  store i32 %96, i32* %loc4
+  br label %97
+
+; <label>:97                                      ; preds = %74, %94
+  %98 = load i32, i32* %loc4
+  %99 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck15 = icmp eq %"System.Char[]" addrspace(1)* %99, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %100
+
+; <label>:100                                     ; preds = %97
+  %101 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %99, i32 0, i32 1
+  %102 = load i32, i32 addrspace(1)* %101
+  %103 = zext i32 %102 to i64
+  %104 = trunc i64 %103 to i32
+  %105 = icmp slt i32 %98, %104
+  br i1 %105, label %79, label %106
+
+; <label>:106                                     ; preds = %87, %100
+  %107 = load i32, i32* %loc4
+  %108 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck17 = icmp eq %"System.Char[]" addrspace(1)* %108, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %109
+
+; <label>:109                                     ; preds = %106
+  %110 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %108, i32 0, i32 1
+  %111 = load i32, i32 addrspace(1)* %110
+  %112 = zext i32 %111 to i64
+  %113 = trunc i64 %112 to i32
+  %114 = icmp eq i32 %107, %113
+  br i1 %114, label %122, label %115
+
+; <label>:115                                     ; preds = %109
+  %116 = load i32, i32* %loc0
+  %117 = sub i32 %116, 1
+  store i32 %117, i32* %loc0
+  br label %118
+
+; <label>:118                                     ; preds = %67, %115
+  %119 = load i32, i32* %loc0
+  %120 = load i32, i32* %loc1
+  %121 = icmp sge i32 %119, %120
+  br i1 %121, label %71, label %122
+
+; <label>:122                                     ; preds = %62, %109, %118
+  %123 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %124 = load i32, i32* %loc1
+  %125 = load i32, i32* %loc0
+  %126 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %123, i32 %124, i32 %125)
+  ret %System.String addrspace(1)* %126
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %97
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange22:                           ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
 Successfully read String.CreateTrimmedString
 
@@ -5439,8 +6893,8 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
@@ -5535,8 +6989,8 @@ entry:
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i64 2872
   %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
   %8 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %7
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %3
   %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
@@ -5553,8 +7007,8 @@ entry:
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 2864
   %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
   %21 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %20
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
-  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %22
 
 ; <label>:22                                      ; preds = %16
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
@@ -5569,7 +7023,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %16
+ThrowNullRef2:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5586,8 +7040,8 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5613,8 +7067,8 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
@@ -5632,8 +7086,8 @@ entry:
 
 ; <label>:12                                      ; preds = %4
   %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
@@ -5644,8 +7098,8 @@ entry:
 
 ; <label>:19                                      ; preds = %14
   %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %19
   %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
@@ -5660,21 +7114,21 @@ entry:
   %31 = zext i16 %30 to i32
   %32 = bitcast i8* %29 to i16*
   %33 = trunc i32 %31 to i16
-  %NullCheck6 = icmp ne i16* %32, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i16* %32, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %21
   store i16 %33, i16* %32, align 8
   %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %36
 
 ; <label>:36                                      ; preds = %34
   %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
   %38 = load i32, i32 addrspace(1)* %37, align 8
   %39 = add i32 %38, 1
-  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %40
 
 ; <label>:40                                      ; preds = %36
   %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
@@ -5683,16 +7137,16 @@ entry:
 
 ; <label>:42                                      ; preds = %14
   %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
-  br i1 %NullCheck12, label %44, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
   %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
   %47 = load i16, i16* %arg1
   %48 = zext i16 %47 to i32
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = trunc i32 %48 to i16
@@ -5703,31 +7157,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %19
+ThrowNullRef4:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %21
+ThrowNullRef6:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %36
+ThrowNullRef10:                                   ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %42
+ThrowNullRef12:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %44
+ThrowNullRef14:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5740,8 +7194,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -5752,8 +7206,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
@@ -5762,14 +7216,14 @@ entry:
 
 ; <label>:11                                      ; preds = %1
   %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
@@ -5779,15 +7233,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5808,8 +7262,8 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5822,8 +7276,8 @@ entry:
 
 ; <label>:8                                       ; preds = %3
   %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
@@ -5842,15 +7296,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
-  br i1 %NullCheck4, label %22, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
   %24 = load i16*, i16* addrspace(1)* %23, align 8
   %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %25, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
@@ -5859,8 +7313,8 @@ entry:
   store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
@@ -5874,8 +7328,8 @@ entry:
 
 ; <label>:37                                      ; preds = %65
   %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %37
   %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
@@ -5886,16 +7340,16 @@ entry:
   %45 = bitcast i16* %41 to i8*
   %46 = getelementptr inbounds i8, i8* %45, i64 %44
   %47 = bitcast i8* %46 to i16*
-  %NullCheck14 = icmp ne i16* %47, null
-  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %47, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %48
 
 ; <label>:48                                      ; preds = %39
   %49 = load i16, i16* %47, align 8
   %50 = zext i16 %49 to i32
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %52 = load i32, i32* %loc1
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %53
 
 ; <label>:53                                      ; preds = %48
   %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
@@ -5916,8 +7370,8 @@ entry:
 ; <label>:62                                      ; preds = %36, %59
   %63 = load i32, i32* %loc1
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck10, label %65, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %65
 
 ; <label>:65                                      ; preds = %62
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
@@ -5936,15 +7390,15 @@ entry:
 
 ; <label>:74                                      ; preds = %70
   %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
-  br i1 %NullCheck18, label %76, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %76
 
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
   %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
-  br i1 %NullCheck20, label %80, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
   %81 = load i64, i64 addrspace(1)* %79
@@ -5958,8 +7412,8 @@ entry:
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
   %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
-  br i1 %NullCheck22, label %92, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.String addrspace(1)* %90, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %92
 
 ; <label>:92                                      ; preds = %80
   %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
@@ -5969,15 +7423,15 @@ entry:
 
 ; <label>:96                                      ; preds = %70
   %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
-  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %98
 
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
   %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
-  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
   %103 = load i64, i64 addrspace(1)* %101
@@ -5991,8 +7445,8 @@ entry:
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
   %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
-  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.String addrspace(1)* %112, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %114
 
 ; <label>:114                                     ; preds = %102
   %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
@@ -6004,59 +7458,59 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %20
+ThrowNullRef4:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %22
+ThrowNullRef6:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %26
+ThrowNullRef8:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %62
+ThrowNullRef10:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %48
+ThrowNullRef16:                                   ; preds = %48
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %74
+ThrowNullRef18:                                   ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %76
+ThrowNullRef20:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %80
+ThrowNullRef22:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %96
+ThrowNullRef24:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %98
+ThrowNullRef26:                                   ; preds = %98
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %102
+ThrowNullRef28:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6069,15 +7523,15 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
   %3 = load i16*, i16* addrspace(1)* %2, align 8
   %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
@@ -6087,8 +7541,8 @@ entry:
   %10 = bitcast i16* %3 to i8*
   %11 = getelementptr inbounds i8, i8* %10, i64 %9
   %12 = bitcast i8* %11 to i16*
-  %NullCheck4 = icmp ne i16* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %5
   store i16 0, i16* %12, align 8
@@ -6098,11 +7552,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6119,8 +7573,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -6131,8 +7585,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
@@ -6144,15 +7598,15 @@ entry:
 
 ; <label>:14                                      ; preds = %1
   %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
   %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
   %21 = load i64, i64 addrspace(1)* %19
@@ -6171,15 +7625,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %14
+ThrowNullRef4:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %16
+ThrowNullRef6:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6302,14 +7756,6 @@ entry:
   ret %System.String addrspace(1)* %57
 }
 
-INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
-Successfully read RuntimeHelpers.get_OffsetToStringData
-
-define i32 @RuntimeHelpers.get_OffsetToStringData() {
-entry:
-  ret i32 12
-}
-
 INFO:  jitting method String::Equals using LLILCJit
 Successfully read String.Equals
 
@@ -6381,8 +7827,8 @@ entry:
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
-  br i1 %NullCheck24, label %29, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
   %30 = load i64, i64 addrspace(1)* %28
@@ -6397,8 +7843,8 @@ entry:
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
-  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
   %43 = load i64, i64 addrspace(1)* %41
@@ -6418,8 +7864,8 @@ entry:
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
   %59 = load i64, i64 addrspace(1)* %57
@@ -6434,8 +7880,8 @@ entry:
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck22, label %71, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
   %72 = load i64, i64 addrspace(1)* %70
@@ -6455,8 +7901,8 @@ entry:
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
-  br i1 %NullCheck16, label %87, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = load i64, i64 addrspace(1)* %86
@@ -6471,8 +7917,8 @@ entry:
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck18, label %100, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
   %101 = load i64, i64 addrspace(1)* %99
@@ -6492,8 +7938,8 @@ entry:
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
-  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
   %117 = load i64, i64 addrspace(1)* %115
@@ -6508,8 +7954,8 @@ entry:
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
-  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
   %130 = load i64, i64 addrspace(1)* %128
@@ -6528,15 +7974,15 @@ entry:
 
 ; <label>:142                                     ; preds = %22
   %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
-  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %143, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %144
 
 ; <label>:144                                     ; preds = %142
   %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
   %146 = load i32, i32 addrspace(1)* %145
   %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
-  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %147, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %148
 
 ; <label>:148                                     ; preds = %144
   %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
@@ -6557,15 +8003,15 @@ entry:
 
 ; <label>:159                                     ; preds = %22
   %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
-  br i1 %NullCheck, label %161, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %ThrowNullRef, label %161
 
 ; <label>:161                                     ; preds = %159
   %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
   %163 = load i32, i32 addrspace(1)* %162
   %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
-  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %164, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %165
 
 ; <label>:165                                     ; preds = %161
   %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
@@ -6578,8 +8024,8 @@ entry:
 
 ; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
-  br i1 %NullCheck4, label %172, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %171, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %172
 
 ; <label>:172                                     ; preds = %170
   %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
@@ -6589,8 +8035,8 @@ entry:
 
 ; <label>:176                                     ; preds = %172
   %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
-  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %177, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %178
 
 ; <label>:178                                     ; preds = %176
   %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
@@ -6629,55 +8075,55 @@ ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %161
+ThrowNullRef2:                                    ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %170
+ThrowNullRef4:                                    ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %176
+ThrowNullRef6:                                    ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %142
+ThrowNullRef8:                                    ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %144
+ThrowNullRef10:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %113
+ThrowNullRef12:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %116
+ThrowNullRef14:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %84
+ThrowNullRef16:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %87
+ThrowNullRef18:                                   ; preds = %87
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %55
+ThrowNullRef20:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %58
+ThrowNullRef22:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %26
+ThrowNullRef24:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %29
+ThrowNullRef26:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,8 +8161,8 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck, label %14, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %ThrowNullRef, label %14
 
 ; <label>:14                                      ; preds = %8
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
@@ -6760,8 +8206,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
@@ -6770,14 +8216,14 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32, i32* %loc0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %10
   %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
   %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
@@ -6790,15 +8236,15 @@ entry:
 ; <label>:25                                      ; preds = %19
   %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
-  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
   %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
@@ -6807,8 +8253,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %37 = load i32, i32* %loc0
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %38, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %38
 
 ; <label>:38                                      ; preds = %32
   %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
@@ -6817,14 +8263,14 @@ entry:
 
 ; <label>:40                                      ; preds = %19
   %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %40
   %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
   %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
-  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
-  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
@@ -6832,8 +8278,8 @@ entry:
   %48 = zext i32 %47 to i64
   %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
-  br i1 %NullCheck16, label %51, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %51
 
 ; <label>:51                                      ; preds = %45
   %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
@@ -6847,15 +8293,15 @@ entry:
 ; <label>:57                                      ; preds = %51
   %58 = load i16*, i16** %arg1
   %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
-  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %60
 
 ; <label>:60                                      ; preds = %57
   %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
   %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
-  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %64
 
 ; <label>:64                                      ; preds = %60
   %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
@@ -6864,22 +8310,22 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
   %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
-  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %70
 
 ; <label>:70                                      ; preds = %64
   %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
   %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
-  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
-  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
   %75 = load i32, i32 addrspace(1)* %74
   %76 = zext i32 %75 to i64
   %77 = trunc i64 %76 to i32
-  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
-  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %78
 
 ; <label>:78                                      ; preds = %73
   %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
@@ -6901,8 +8347,8 @@ entry:
   %90 = bitcast i16* %86 to i8*
   %91 = getelementptr inbounds i8, i8* %90, i64 %89
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %93
 
 ; <label>:93                                      ; preds = %80
   %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
@@ -6912,8 +8358,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %99 = load i32, i32* %loc2
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %100
 
 ; <label>:100                                     ; preds = %93
   %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
@@ -6928,63 +8374,63 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %25
+ThrowNullRef6:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %32
+ThrowNullRef10:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %40
+ThrowNullRef12:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %45
+ThrowNullRef16:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %57
+ThrowNullRef18:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %60
+ThrowNullRef20:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %64
+ThrowNullRef22:                                   ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %70
+ThrowNullRef24:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %73
+ThrowNullRef26:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %80
+ThrowNullRef28:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %93
+ThrowNullRef30:                                   ; preds = %93
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7004,8 +8450,8 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
@@ -7033,43 +8479,43 @@ entry:
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %14
   %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
   %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   %28 = load i32, i32 addrspace(1)* %27, align 8
   %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
-  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %30
 
 ; <label>:30                                      ; preds = %26
   %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
   %32 = load i32, i32 addrspace(1)* %31, align 8
   %33 = add i32 %28, %32
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %34
 
 ; <label>:34                                      ; preds = %30
   %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   store i32 %33, i32 addrspace(1)* %35
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
   store i32 0, i32 addrspace(1)* %38
   %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %40
 
 ; <label>:40                                      ; preds = %37
   %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
@@ -7082,8 +8528,8 @@ entry:
 
 ; <label>:47                                      ; preds = %40
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
@@ -7098,8 +8544,8 @@ entry:
   %54 = load i32, i32* %loc0
   %55 = sext i32 %54 to i64
   %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
-  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %57
 
 ; <label>:57                                      ; preds = %52
   %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
@@ -7110,68 +8556,35 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %14
+ThrowNullRef2:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %23
+ThrowNullRef4:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %26
+ThrowNullRef6:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %30
+ThrowNullRef8:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %34
+ThrowNullRef10:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %47
+ThrowNullRef14:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %52
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-}
-
-INFO:  jitting method StringBuilder::get_Length using LLILCJit
-Successfully read StringBuilder.get_Length
-
-define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.StringBuilder addrspace(1)*
-  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
-  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
-
-; <label>:1                                       ; preds = %entry
-  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %3 = load i32, i32 addrspace(1)* %2, align 8
-  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
-
-; <label>:5                                       ; preds = %1
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = add i32 %3, %7
-  ret i32 %8
-
-ThrowNullRef:                                     ; preds = %entry
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef16:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7213,70 +8626,70 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
   %6 = load i32, i32 addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
   store i32 %6, i32 addrspace(1)* %8
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
   %13 = load i32, i32 addrspace(1)* %12, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
   store i32 %13, i32 addrspace(1)* %15
   %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
-  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %18
 
 ; <label>:18                                      ; preds = %14
   %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
   %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
   %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
   %34 = load i32, i32 addrspace(1)* %33, align 8
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
-  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
@@ -7287,39 +8700,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %28
+ThrowNullRef16:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %32
+ThrowNullRef18:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7455,13 +8868,13 @@ entry:
 ; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
@@ -7477,16 +8890,16 @@ entry:
 
 ; <label>:18                                      ; preds = %15
   %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
   store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
   %22 = load i32, i32* %loc0
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %24
 
 ; <label>:24                                      ; preds = %20
   %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
@@ -7498,13 +8911,13 @@ entry:
 ; <label>:28                                      ; preds = %15, %24
   %29 = load i32, i32* %arg1
   %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %31
   %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
@@ -7517,20 +8930,20 @@ entry:
   %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
-  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
   %46 = load i32, i32 addrspace(1)* %45, align 8
   %47 = sub i32 %40, %46
-  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
-  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i32 addrspace(1)* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %48
 
 ; <label>:48                                      ; preds = %44
   store i32 %47, i32 addrspace(1)* %39, align 8
@@ -7538,21 +8951,21 @@ entry:
 
 ; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
-  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %51
 
 ; <label>:51                                      ; preds = %49
   %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %53
 
 ; <label>:53                                      ; preds = %51
   %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
   %55 = load i32, i32 addrspace(1)* %54, align 8
   %56 = load i32, i32* %arg2
   %57 = sub i32 %55, %56
-  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %58
 
 ; <label>:58                                      ; preds = %53
   %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
@@ -7562,13 +8975,13 @@ entry:
 ; <label>:60                                      ; preds = %33, %58
   %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
   %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
-  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %63
 
 ; <label>:63                                      ; preds = %60
   %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
-  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
-  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
@@ -7578,15 +8991,15 @@ entry:
 
 ; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
-  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i32 addrspace(1)* %69, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %70
 
 ; <label>:70                                      ; preds = %68
   %71 = load i32, i32 addrspace(1)* %69, align 8
   store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
-  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
@@ -7596,8 +9009,8 @@ entry:
   store i32 %77, i32* %loc4
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
-  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %80
 
 ; <label>:80                                      ; preds = %73
   %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
@@ -7607,71 +9020,71 @@ entry:
 ; <label>:83                                      ; preds = %80
   store i32 0, i32* %loc3
   %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
-  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
-  br i1 %NullCheck26, label %88, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i32 addrspace(1)* %87, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %88
 
 ; <label>:88                                      ; preds = %85
   %89 = load i32, i32 addrspace(1)* %87, align 8
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
-  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %90
 
 ; <label>:90                                      ; preds = %88
   %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
   store i32 %89, i32 addrspace(1)* %91
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
-  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
-  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %96
 
 ; <label>:96                                      ; preds = %94
   %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
-  br i1 %NullCheck34, label %100, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %100
 
 ; <label>:100                                     ; preds = %96
   %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
-  br i1 %NullCheck36, label %102, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %102
 
 ; <label>:102                                     ; preds = %100
   %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
   %104 = load i32, i32 addrspace(1)* %103, align 8
   %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
-  br i1 %NullCheck38, label %106, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %106
 
 ; <label>:106                                     ; preds = %102
   %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
-  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
-  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %108
 
 ; <label>:108                                     ; preds = %106
   %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
   %110 = load i32, i32 addrspace(1)* %109, align 8
   %111 = add i32 %104, %110
-  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %112
 
 ; <label>:112                                     ; preds = %108
   %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
   store i32 %111, i32 addrspace(1)* %113
   %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
-  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i32 addrspace(1)* %114, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %115
 
 ; <label>:115                                     ; preds = %112
   %116 = load i32, i32 addrspace(1)* %114, align 8
@@ -7681,19 +9094,19 @@ entry:
 ; <label>:118                                     ; preds = %115
   %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
-  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %121
 
 ; <label>:121                                     ; preds = %118
   %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
-  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
-  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %123
 
 ; <label>:123                                     ; preds = %121
   %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
   %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
-  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
-  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %126
 
 ; <label>:126                                     ; preds = %123
   %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
@@ -7705,8 +9118,8 @@ entry:
 
 ; <label>:130                                     ; preds = %80, %115, %126
   %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %132
 
 ; <label>:132                                     ; preds = %130
   %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7715,8 +9128,8 @@ entry:
   %136 = load i32, i32* %loc3
   %137 = sub i32 %135, %136
   %138 = sub i32 %134, %137
-  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %139
 
 ; <label>:139                                     ; preds = %132
   %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7728,16 +9141,16 @@ entry:
 
 ; <label>:144                                     ; preds = %139
   %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
-  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %146
 
 ; <label>:146                                     ; preds = %144
   %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
   %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
   %149 = load i32, i32* %loc2
   %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
-  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %151
 
 ; <label>:151                                     ; preds = %146
   %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
@@ -7754,145 +9167,249 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %18
+ThrowNullRef4:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %31
+ThrowNullRef10:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %44
+ThrowNullRef16:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %68
+ThrowNullRef18:                                   ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %70
+ThrowNullRef20:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %73
+ThrowNullRef22:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %83
+ThrowNullRef24:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %85
+ThrowNullRef26:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %88
+ThrowNullRef28:                                   ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %90
+ThrowNullRef30:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %94
+ThrowNullRef32:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %96
+ThrowNullRef34:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %100
+ThrowNullRef36:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %102
+ThrowNullRef38:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %106
+ThrowNullRef40:                                   ; preds = %106
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %108
+ThrowNullRef42:                                   ; preds = %108
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %112
+ThrowNullRef44:                                   ; preds = %112
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %118
+ThrowNullRef46:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %121
+ThrowNullRef48:                                   ; preds = %121
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %123
+ThrowNullRef50:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %130
+ThrowNullRef52:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %132
+ThrowNullRef54:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %144
+ThrowNullRef56:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %146
+ThrowNullRef58:                                   ; preds = %146
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %60
+ThrowNullRef60:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %63
+ThrowNullRef62:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %49
+ThrowNullRef64:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %51
+ThrowNullRef66:                                   ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %53
+ThrowNullRef68:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(%"System.Char[]" addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %arg0 = alloca %"System.Char[]" addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store %"System.Char[]" addrspace(1)* %param0, %"System.Char[]" addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load i32, i32* %arg4
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %43, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %38, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg1
+  %13 = load i32, i32* %arg4
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %38, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %24 = load i32, i32* %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %35 = load i32, i32* %arg3
+  %36 = load i32, i32* %arg4
+  %37 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %37, %"System.Char[]" addrspace(1)* %34, i32 %35, i32 %36)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:38                                      ; preds = %5, %16
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Successfully read Buffer._Memmove
 
@@ -7914,7 +9431,7 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[loadElem]
+Failed to read AppDomain.SetDataHelper[storeElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -7923,8 +9440,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
@@ -7934,8 +9451,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
@@ -7947,15 +9464,15 @@ entry:
   %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
   %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
@@ -7966,15 +9483,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7992,7 +9509,79 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
-Failed to read Dictionary`2.TryGetValue[loadElemA]
+Successfully read Dictionary`2.TryGetValue
+
+define i8 @"Dictionary`2.TryGetValue"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)* addrspace(1)* %param2) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  %arg2 = alloca %System.__Canon addrspace(1)* addrspace(1)*
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  store %System.__Canon addrspace(1)* addrspace(1)* %param2, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  store i32 %2, i32* %loc0
+  %3 = load i32, i32* %loc0
+  %4 = icmp slt i32 %3, 0
+  br i1 %4, label %22, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 2
+  %10 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %9, align 8
+  %11 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = zext i32 %11 to i64
+  %BoundsCheck = icmp uge i64 %16, %15
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 3, i32 %11
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %20, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %6, %System.__Canon addrspace(1)* %21)
+  ret i8 1
+
+; <label>:22                                      ; preds = %entry
+  %23 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %23, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -8058,8 +9647,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
@@ -8091,8 +9680,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
@@ -8171,15 +9760,15 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck, label %19, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %ThrowNullRef, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
   %21 = load i32, i32 addrspace(1)* %20
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
@@ -8202,7 +9791,7 @@ ThrowNullRef:                                     ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %19
+ThrowNullRef2:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8248,8 +9837,8 @@ entry:
   %0 = alloca %System.AppDomainHandle
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %1 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %1, i32 0, i32 15
@@ -8269,8 +9858,8 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
@@ -8286,7 +9875,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -8299,8 +9888,8 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -8327,8 +9916,8 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
@@ -8352,8 +9941,8 @@ entry:
   %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
   store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
@@ -8363,8 +9952,8 @@ entry:
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
@@ -8374,8 +9963,8 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %9
   %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
@@ -8384,8 +9973,8 @@ entry:
 
 ; <label>:18                                      ; preds = %3, %16
   %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
@@ -8397,15 +9986,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %18
+ThrowNullRef6:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8418,8 +10007,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
@@ -8453,15 +10042,15 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
@@ -8473,7 +10062,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8481,7 +10070,7 @@ ThrowNullRef1:                                    ; preds = %1
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
 Failed to read Dictionary`2.System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
@@ -8506,8 +10095,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
@@ -8524,8 +10113,8 @@ entry:
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -8544,7 +10133,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8577,8 +10166,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = load i64, i64* %arg2
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = trunc i32 %3 to i8
@@ -8634,46 +10223,46 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
   %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
-  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
-  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
-  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
@@ -8684,27 +10273,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %20
+ThrowNullRef12:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8717,8 +10306,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -8756,22 +10345,22 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
   %9 = load i64, i64 addrspace(1)* %8, align 8
   %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
   %13 = load i64, i64 addrspace(1)* %12, align 8
   %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %11
   %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
@@ -8788,11 +10377,11 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8882,8 +10471,8 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
@@ -8900,8 +10489,8 @@ entry:
 ; <label>:8                                       ; preds = %1
   %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
   %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
@@ -8911,15 +10500,15 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
   %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
   %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
-  br i1 %NullCheck6, label %21, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
@@ -8946,15 +10535,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8992,15 +10581,15 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
   store i8 %3, i8 addrspace(1)* %5
   %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
@@ -9011,7 +10600,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9027,8 +10616,8 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -9041,8 +10630,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
@@ -9058,7 +10647,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9080,8 +10669,8 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
@@ -9096,8 +10685,8 @@ entry:
 ; <label>:12                                      ; preds = %6
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
@@ -9112,8 +10701,8 @@ entry:
 ; <label>:21                                      ; preds = %15
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
@@ -9128,8 +10717,8 @@ entry:
 ; <label>:30                                      ; preds = %24
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %31, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
@@ -9144,8 +10733,8 @@ entry:
 ; <label>:39                                      ; preds = %33
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
-  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %40, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %42
 
 ; <label>:42                                      ; preds = %39
   %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
@@ -9164,19 +10753,19 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %21
+ThrowNullRef4:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %30
+ThrowNullRef6:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %39
+ThrowNullRef8:                                    ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9243,8 +10832,8 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
@@ -9264,57 +10853,57 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
   store i8 0, i8 addrspace(1)* %2
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
   store i8 0, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
   store i8 0, i8 addrspace(1)* %17
   %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
   store i8 0, i8 addrspace(1)* %20
   %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
-  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
@@ -9325,31 +10914,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %19
+ThrowNullRef14:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9367,8 +10956,8 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
@@ -9380,8 +10969,8 @@ entry:
 
 ; <label>:9                                       ; preds = %4
   %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %9
   %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
@@ -9395,7 +10984,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef2:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9420,8 +11009,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
@@ -9512,8 +11101,8 @@ entry:
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
@@ -9524,8 +11113,8 @@ entry:
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = load i64, i64 addrspace(1)* %12
@@ -9537,8 +11126,8 @@ entry:
   %20 = load i64, i64* %19
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
-  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %13
   %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
@@ -9555,8 +11144,8 @@ entry:
 ; <label>:30                                      ; preds = %25
   %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %32 = load i32, i32* %arg2
-  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
-  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
@@ -9570,15 +11159,15 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %30
+ThrowNullRef2:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9622,87 +11211,87 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
   %10 = load i8, i8 addrspace(1)* %9, align 8
   %11 = zext i8 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %8
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
   store i8 %12, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
   %19 = load i8, i8 addrspace(1)* %18, align 8
   %20 = zext i8 %19 to i32
   %21 = trunc i32 %20 to i8
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
   store i8 %21, i8 addrspace(1)* %23
   %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
   %28 = load i8, i8 addrspace(1)* %27, align 8
   %29 = zext i8 %28 to i32
   %30 = trunc i32 %29 to i8
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
-  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %31
 
 ; <label>:31                                      ; preds = %26
   %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
   store i8 %30, i8 addrspace(1)* %32
   %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
-  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
-  br i1 %NullCheck14, label %40, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %40
 
 ; <label>:40                                      ; preds = %35
   %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
   store i8 %39, i8 addrspace(1)* %41
   %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
-  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %44
 
 ; <label>:44                                      ; preds = %40
   %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
   %46 = load i8, i8 addrspace(1)* %45, align 8
   %47 = zext i8 %46 to i32
   %48 = trunc i32 %47 to i8
-  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
   store i8 %48, i8 addrspace(1)* %50
   %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
-  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
@@ -9713,29 +11302,29 @@ entry:
 ; <label>:56                                      ; preds = %52
   %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
-  br i1 %NullCheck22, label %59, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
   %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
   %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
-  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
-  br i1 %NullCheck24, label %63, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
   %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
-  br i1 %NullCheck26, label %66, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
   %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
-  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
-  br i1 %NullCheck28, label %69, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %69
 
 ; <label>:69                                      ; preds = %66
   %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
@@ -9744,15 +11333,15 @@ entry:
 
 ; <label>:71                                      ; preds = %105
   %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
-  br i1 %NullCheck34, label %73, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %73
 
 ; <label>:73                                      ; preds = %71
   %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
   %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
   %76 = load i32, i32* %loc0
-  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
-  br i1 %NullCheck36, label %77, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
@@ -9766,8 +11355,8 @@ entry:
 
 ; <label>:83                                      ; preds = %77
   %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
-  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
@@ -9775,14 +11364,14 @@ entry:
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
   %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
-  br i1 %NullCheck40, label %91, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
 ; <label>:91                                      ; preds = %85
   %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
   %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
-  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck42, label %94, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %94
 
 ; <label>:94                                      ; preds = %91
   %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
@@ -9798,14 +11387,14 @@ entry:
 ; <label>:99                                      ; preds = %69, %96
   %100 = load i32, i32* %loc0
   %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
-  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %102
 
 ; <label>:102                                     ; preds = %99
   %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
   %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
-  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
-  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
@@ -9819,87 +11408,87 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %26
+ThrowNullRef10:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %31
+ThrowNullRef12:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %35
+ThrowNullRef14:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %40
+ThrowNullRef16:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %56
+ThrowNullRef22:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %59
+ThrowNullRef24:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %63
+ThrowNullRef26:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %66
+ThrowNullRef28:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %102
+ThrowNullRef32:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %71
+ThrowNullRef34:                                   ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %73
+ThrowNullRef36:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %83
+ThrowNullRef38:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %85
+ThrowNullRef40:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %91
+ThrowNullRef42:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9943,15 +11532,15 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
   %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
@@ -9961,28 +11550,28 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
   %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %12
   %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
   %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
   %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
-  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
@@ -9993,23 +11582,23 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %12
+ThrowNullRef6:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10031,15 +11620,15 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
   %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = load i64, i64 addrspace(1)* %7
@@ -10077,13 +11666,13 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[loadElem]
+Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -10111,8 +11700,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Xor1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Xor1.error.txt
@@ -25,8 +25,8 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
@@ -40,8 +40,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
   %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
@@ -75,7 +75,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -90,8 +90,8 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %NullCheck = icmp ne i8 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = load i8, i8 addrspace(1)* %0, align 8
@@ -125,8 +125,8 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
@@ -159,8 +159,8 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -184,8 +184,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
   store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
@@ -195,8 +195,8 @@ entry:
 ; <label>:4                                       ; preds = %1
   %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
   %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
@@ -206,8 +206,8 @@ entry:
   %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
@@ -221,14 +221,14 @@ entry:
 
 ; <label>:17                                      ; preds = %14
   %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
   %21 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
@@ -238,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -249,8 +249,8 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
@@ -261,27 +261,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %30
+ThrowNullRef10:                                   ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -301,7 +301,89 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
-Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
+Successfully read AppDomainSetup.GetUnsecureApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.GetUnsecureApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %NullCheck = icmp eq %"System.String[]" addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %BoundsCheck = icmp uge i64 0, %5
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %6
+
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 3, i32 0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
+  ret %System.String addrspace(1)* %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_Value using LLILCJit
+Successfully read AppDomainSetup.get_Value
+
+define %"System.String[]" addrspace(1)* @AppDomainSetup.get_Value(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.String[]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 18)
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.String[]" addrspace(1)* addrspace(1)*, %"System.String[]" addrspace(1)*)*)(%"System.String[]" addrspace(1)* addrspace(1)* %9, %"System.String[]" addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %11, i32 0, i32 1
+  %14 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %13, align 8
+  ret %"System.String[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -319,8 +401,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -368,16 +450,16 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
   %5 = load i32, i32 addrspace(1)* %4
   %6 = sub i32 %5, 1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -389,7 +471,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -421,8 +503,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
@@ -456,8 +538,8 @@ entry:
 ; <label>:27                                      ; preds = %19
   %28 = load i32, i32* %arg1
   %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
-  br i1 %NullCheck2, label %30, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %29, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %30
 
 ; <label>:30                                      ; preds = %27
   %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
@@ -493,8 +575,8 @@ entry:
 ; <label>:49                                      ; preds = %46
   %50 = load i32, i32* %arg2
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck4, label %52, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
@@ -517,11 +599,11 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %27
+ThrowNullRef2:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %49
+ThrowNullRef4:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -544,16 +626,16 @@ entry:
   %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %0)
   store %System.String addrspace(1)* %1, %System.String addrspace(1)** %loc0
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 2
   %5 = bitcast [0 x i16] addrspace(1)* %4 to i16 addrspace(1)*
   store i16 addrspace(1)* %5, i16 addrspace(1)** %loc1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %3
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2
@@ -580,7 +662,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -691,15 +773,15 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %NullCheck132 = icmp ne i8* %21, null
-  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+  %NullCheck131 = icmp eq i8* %21, null
+  br i1 %NullCheck131, label %ThrowNullRef132, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = load i8, i8* %21, align 8
   %24 = zext i8 %23 to i32
   %25 = trunc i32 %24 to i8
-  %NullCheck134 = icmp ne i8* %20, null
-  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+  %NullCheck133 = icmp eq i8* %20, null
+  br i1 %NullCheck133, label %ThrowNullRef134, label %26
 
 ; <label>:26                                      ; preds = %22
   store i8 %25, i8* %20, align 8
@@ -709,16 +791,16 @@ entry:
   %28 = load i8*, i8** %arg0
   %29 = load i8*, i8** %arg1
   %30 = bitcast i8* %29 to i16*
-  %NullCheck128 = icmp ne i16* %30, null
-  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+  %NullCheck127 = icmp eq i16* %30, null
+  br i1 %NullCheck127, label %ThrowNullRef128, label %31
 
 ; <label>:31                                      ; preds = %27
   %32 = load i16, i16* %30, align 8
   %33 = sext i16 %32 to i32
   %34 = bitcast i8* %28 to i16*
   %35 = trunc i32 %33 to i16
-  %NullCheck130 = icmp ne i16* %34, null
-  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+  %NullCheck129 = icmp eq i16* %34, null
+  br i1 %NullCheck129, label %ThrowNullRef130, label %36
 
 ; <label>:36                                      ; preds = %31
   store i16 %35, i16* %34, align 8
@@ -728,16 +810,16 @@ entry:
   %38 = load i8*, i8** %arg0
   %39 = load i8*, i8** %arg1
   %40 = bitcast i8* %39 to i16*
-  %NullCheck120 = icmp ne i16* %40, null
-  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+  %NullCheck119 = icmp eq i16* %40, null
+  br i1 %NullCheck119, label %ThrowNullRef120, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i16, i16* %40, align 8
   %43 = sext i16 %42 to i32
   %44 = bitcast i8* %38 to i16*
   %45 = trunc i32 %43 to i16
-  %NullCheck122 = icmp ne i16* %44, null
-  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+  %NullCheck121 = icmp eq i16* %44, null
+  br i1 %NullCheck121, label %ThrowNullRef122, label %46
 
 ; <label>:46                                      ; preds = %41
   store i16 %45, i16* %44, align 8
@@ -745,15 +827,15 @@ entry:
   %48 = getelementptr inbounds i8, i8* %47, i64 2
   %49 = load i8*, i8** %arg1
   %50 = getelementptr inbounds i8, i8* %49, i64 2
-  %NullCheck124 = icmp ne i8* %50, null
-  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+  %NullCheck123 = icmp eq i8* %50, null
+  br i1 %NullCheck123, label %ThrowNullRef124, label %51
 
 ; <label>:51                                      ; preds = %46
   %52 = load i8, i8* %50, align 8
   %53 = zext i8 %52 to i32
   %54 = trunc i32 %53 to i8
-  %NullCheck126 = icmp ne i8* %48, null
-  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+  %NullCheck125 = icmp eq i8* %48, null
+  br i1 %NullCheck125, label %ThrowNullRef126, label %55
 
 ; <label>:55                                      ; preds = %51
   store i8 %54, i8* %48, align 8
@@ -763,14 +845,14 @@ entry:
   %57 = load i8*, i8** %arg0
   %58 = load i8*, i8** %arg1
   %59 = bitcast i8* %58 to i32*
-  %NullCheck116 = icmp ne i32* %59, null
-  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+  %NullCheck115 = icmp eq i32* %59, null
+  br i1 %NullCheck115, label %ThrowNullRef116, label %60
 
 ; <label>:60                                      ; preds = %56
   %61 = load i32, i32* %59, align 8
   %62 = bitcast i8* %57 to i32*
-  %NullCheck118 = icmp ne i32* %62, null
-  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+  %NullCheck117 = icmp eq i32* %62, null
+  br i1 %NullCheck117, label %ThrowNullRef118, label %63
 
 ; <label>:63                                      ; preds = %60
   store i32 %61, i32* %62, align 8
@@ -780,14 +862,14 @@ entry:
   %65 = load i8*, i8** %arg0
   %66 = load i8*, i8** %arg1
   %67 = bitcast i8* %66 to i32*
-  %NullCheck108 = icmp ne i32* %67, null
-  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+  %NullCheck107 = icmp eq i32* %67, null
+  br i1 %NullCheck107, label %ThrowNullRef108, label %68
 
 ; <label>:68                                      ; preds = %64
   %69 = load i32, i32* %67, align 8
   %70 = bitcast i8* %65 to i32*
-  %NullCheck110 = icmp ne i32* %70, null
-  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+  %NullCheck109 = icmp eq i32* %70, null
+  br i1 %NullCheck109, label %ThrowNullRef110, label %71
 
 ; <label>:71                                      ; preds = %68
   store i32 %69, i32* %70, align 8
@@ -795,15 +877,15 @@ entry:
   %73 = getelementptr inbounds i8, i8* %72, i64 4
   %74 = load i8*, i8** %arg1
   %75 = getelementptr inbounds i8, i8* %74, i64 4
-  %NullCheck112 = icmp ne i8* %75, null
-  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+  %NullCheck111 = icmp eq i8* %75, null
+  br i1 %NullCheck111, label %ThrowNullRef112, label %76
 
 ; <label>:76                                      ; preds = %71
   %77 = load i8, i8* %75, align 8
   %78 = zext i8 %77 to i32
   %79 = trunc i32 %78 to i8
-  %NullCheck114 = icmp ne i8* %73, null
-  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+  %NullCheck113 = icmp eq i8* %73, null
+  br i1 %NullCheck113, label %ThrowNullRef114, label %80
 
 ; <label>:80                                      ; preds = %76
   store i8 %79, i8* %73, align 8
@@ -813,14 +895,14 @@ entry:
   %82 = load i8*, i8** %arg0
   %83 = load i8*, i8** %arg1
   %84 = bitcast i8* %83 to i32*
-  %NullCheck100 = icmp ne i32* %84, null
-  br i1 %NullCheck100, label %85, label %ThrowNullRef99
+  %NullCheck99 = icmp eq i32* %84, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %85
 
 ; <label>:85                                      ; preds = %81
   %86 = load i32, i32* %84, align 8
   %87 = bitcast i8* %82 to i32*
-  %NullCheck102 = icmp ne i32* %87, null
-  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+  %NullCheck101 = icmp eq i32* %87, null
+  br i1 %NullCheck101, label %ThrowNullRef102, label %88
 
 ; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
@@ -829,16 +911,16 @@ entry:
   %91 = load i8*, i8** %arg1
   %92 = getelementptr inbounds i8, i8* %91, i64 4
   %93 = bitcast i8* %92 to i16*
-  %NullCheck104 = icmp ne i16* %93, null
-  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+  %NullCheck103 = icmp eq i16* %93, null
+  br i1 %NullCheck103, label %ThrowNullRef104, label %94
 
 ; <label>:94                                      ; preds = %88
   %95 = load i16, i16* %93, align 8
   %96 = sext i16 %95 to i32
   %97 = bitcast i8* %90 to i16*
   %98 = trunc i32 %96 to i16
-  %NullCheck106 = icmp ne i16* %97, null
-  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+  %NullCheck105 = icmp eq i16* %97, null
+  br i1 %NullCheck105, label %ThrowNullRef106, label %99
 
 ; <label>:99                                      ; preds = %94
   store i16 %98, i16* %97, align 8
@@ -848,14 +930,14 @@ entry:
   %101 = load i8*, i8** %arg0
   %102 = load i8*, i8** %arg1
   %103 = bitcast i8* %102 to i32*
-  %NullCheck88 = icmp ne i32* %103, null
-  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+  %NullCheck87 = icmp eq i32* %103, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %104
 
 ; <label>:104                                     ; preds = %100
   %105 = load i32, i32* %103, align 8
   %106 = bitcast i8* %101 to i32*
-  %NullCheck90 = icmp ne i32* %106, null
-  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+  %NullCheck89 = icmp eq i32* %106, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %107
 
 ; <label>:107                                     ; preds = %104
   store i32 %105, i32* %106, align 8
@@ -864,16 +946,16 @@ entry:
   %110 = load i8*, i8** %arg1
   %111 = getelementptr inbounds i8, i8* %110, i64 4
   %112 = bitcast i8* %111 to i16*
-  %NullCheck92 = icmp ne i16* %112, null
-  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+  %NullCheck91 = icmp eq i16* %112, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %113
 
 ; <label>:113                                     ; preds = %107
   %114 = load i16, i16* %112, align 8
   %115 = sext i16 %114 to i32
   %116 = bitcast i8* %109 to i16*
   %117 = trunc i32 %115 to i16
-  %NullCheck94 = icmp ne i16* %116, null
-  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+  %NullCheck93 = icmp eq i16* %116, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %118
 
 ; <label>:118                                     ; preds = %113
   store i16 %117, i16* %116, align 8
@@ -881,15 +963,15 @@ entry:
   %120 = getelementptr inbounds i8, i8* %119, i64 6
   %121 = load i8*, i8** %arg1
   %122 = getelementptr inbounds i8, i8* %121, i64 6
-  %NullCheck96 = icmp ne i8* %122, null
-  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+  %NullCheck95 = icmp eq i8* %122, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %123
 
 ; <label>:123                                     ; preds = %118
   %124 = load i8, i8* %122, align 8
   %125 = zext i8 %124 to i32
   %126 = trunc i32 %125 to i8
-  %NullCheck98 = icmp ne i8* %120, null
-  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+  %NullCheck97 = icmp eq i8* %120, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %127
 
 ; <label>:127                                     ; preds = %123
   store i8 %126, i8* %120, align 8
@@ -899,14 +981,14 @@ entry:
   %129 = load i8*, i8** %arg0
   %130 = load i8*, i8** %arg1
   %131 = bitcast i8* %130 to i64*
-  %NullCheck84 = icmp ne i64* %131, null
-  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+  %NullCheck83 = icmp eq i64* %131, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %132
 
 ; <label>:132                                     ; preds = %128
   %133 = load i64, i64* %131, align 8
   %134 = bitcast i8* %129 to i64*
-  %NullCheck86 = icmp ne i64* %134, null
-  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+  %NullCheck85 = icmp eq i64* %134, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %135
 
 ; <label>:135                                     ; preds = %132
   store i64 %133, i64* %134, align 8
@@ -916,14 +998,14 @@ entry:
   %137 = load i8*, i8** %arg0
   %138 = load i8*, i8** %arg1
   %139 = bitcast i8* %138 to i64*
-  %NullCheck76 = icmp ne i64* %139, null
-  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+  %NullCheck75 = icmp eq i64* %139, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %140
 
 ; <label>:140                                     ; preds = %136
   %141 = load i64, i64* %139, align 8
   %142 = bitcast i8* %137 to i64*
-  %NullCheck78 = icmp ne i64* %142, null
-  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+  %NullCheck77 = icmp eq i64* %142, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %143
 
 ; <label>:143                                     ; preds = %140
   store i64 %141, i64* %142, align 8
@@ -931,15 +1013,15 @@ entry:
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %NullCheck80 = icmp ne i8* %147, null
-  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+  %NullCheck79 = icmp eq i8* %147, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %148
 
 ; <label>:148                                     ; preds = %143
   %149 = load i8, i8* %147, align 8
   %150 = zext i8 %149 to i32
   %151 = trunc i32 %150 to i8
-  %NullCheck82 = icmp ne i8* %145, null
-  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+  %NullCheck81 = icmp eq i8* %145, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %152
 
 ; <label>:152                                     ; preds = %148
   store i8 %151, i8* %145, align 8
@@ -949,14 +1031,14 @@ entry:
   %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
   %156 = bitcast i8* %155 to i64*
-  %NullCheck68 = icmp ne i64* %156, null
-  br i1 %NullCheck68, label %157, label %ThrowNullRef67
+  %NullCheck67 = icmp eq i64* %156, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %157
 
 ; <label>:157                                     ; preds = %153
   %158 = load i64, i64* %156, align 8
   %159 = bitcast i8* %154 to i64*
-  %NullCheck70 = icmp ne i64* %159, null
-  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+  %NullCheck69 = icmp eq i64* %159, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %160
 
 ; <label>:160                                     ; preds = %157
   store i64 %158, i64* %159, align 8
@@ -965,16 +1047,16 @@ entry:
   %163 = load i8*, i8** %arg1
   %164 = getelementptr inbounds i8, i8* %163, i64 8
   %165 = bitcast i8* %164 to i16*
-  %NullCheck72 = icmp ne i16* %165, null
-  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+  %NullCheck71 = icmp eq i16* %165, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %166
 
 ; <label>:166                                     ; preds = %160
   %167 = load i16, i16* %165, align 8
   %168 = sext i16 %167 to i32
   %169 = bitcast i8* %162 to i16*
   %170 = trunc i32 %168 to i16
-  %NullCheck74 = icmp ne i16* %169, null
-  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+  %NullCheck73 = icmp eq i16* %169, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %171
 
 ; <label>:171                                     ; preds = %166
   store i16 %170, i16* %169, align 8
@@ -984,14 +1066,14 @@ entry:
   %173 = load i8*, i8** %arg0
   %174 = load i8*, i8** %arg1
   %175 = bitcast i8* %174 to i64*
-  %NullCheck56 = icmp ne i64* %175, null
-  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+  %NullCheck55 = icmp eq i64* %175, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %176
 
 ; <label>:176                                     ; preds = %172
   %177 = load i64, i64* %175, align 8
   %178 = bitcast i8* %173 to i64*
-  %NullCheck58 = icmp ne i64* %178, null
-  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+  %NullCheck57 = icmp eq i64* %178, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %179
 
 ; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
@@ -1000,16 +1082,16 @@ entry:
   %182 = load i8*, i8** %arg1
   %183 = getelementptr inbounds i8, i8* %182, i64 8
   %184 = bitcast i8* %183 to i16*
-  %NullCheck60 = icmp ne i16* %184, null
-  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+  %NullCheck59 = icmp eq i16* %184, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %185
 
 ; <label>:185                                     ; preds = %179
   %186 = load i16, i16* %184, align 8
   %187 = sext i16 %186 to i32
   %188 = bitcast i8* %181 to i16*
   %189 = trunc i32 %187 to i16
-  %NullCheck62 = icmp ne i16* %188, null
-  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+  %NullCheck61 = icmp eq i16* %188, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %190
 
 ; <label>:190                                     ; preds = %185
   store i16 %189, i16* %188, align 8
@@ -1017,15 +1099,15 @@ entry:
   %192 = getelementptr inbounds i8, i8* %191, i64 10
   %193 = load i8*, i8** %arg1
   %194 = getelementptr inbounds i8, i8* %193, i64 10
-  %NullCheck64 = icmp ne i8* %194, null
-  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+  %NullCheck63 = icmp eq i8* %194, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %195
 
 ; <label>:195                                     ; preds = %190
   %196 = load i8, i8* %194, align 8
   %197 = zext i8 %196 to i32
   %198 = trunc i32 %197 to i8
-  %NullCheck66 = icmp ne i8* %192, null
-  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+  %NullCheck65 = icmp eq i8* %192, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %199
 
 ; <label>:199                                     ; preds = %195
   store i8 %198, i8* %192, align 8
@@ -1035,14 +1117,14 @@ entry:
   %201 = load i8*, i8** %arg0
   %202 = load i8*, i8** %arg1
   %203 = bitcast i8* %202 to i64*
-  %NullCheck48 = icmp ne i64* %203, null
-  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+  %NullCheck47 = icmp eq i64* %203, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %204
 
 ; <label>:204                                     ; preds = %200
   %205 = load i64, i64* %203, align 8
   %206 = bitcast i8* %201 to i64*
-  %NullCheck50 = icmp ne i64* %206, null
-  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+  %NullCheck49 = icmp eq i64* %206, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %207
 
 ; <label>:207                                     ; preds = %204
   store i64 %205, i64* %206, align 8
@@ -1051,14 +1133,14 @@ entry:
   %210 = load i8*, i8** %arg1
   %211 = getelementptr inbounds i8, i8* %210, i64 8
   %212 = bitcast i8* %211 to i32*
-  %NullCheck52 = icmp ne i32* %212, null
-  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+  %NullCheck51 = icmp eq i32* %212, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %213
 
 ; <label>:213                                     ; preds = %207
   %214 = load i32, i32* %212, align 8
   %215 = bitcast i8* %209 to i32*
-  %NullCheck54 = icmp ne i32* %215, null
-  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+  %NullCheck53 = icmp eq i32* %215, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %216
 
 ; <label>:216                                     ; preds = %213
   store i32 %214, i32* %215, align 8
@@ -1068,14 +1150,14 @@ entry:
   %218 = load i8*, i8** %arg0
   %219 = load i8*, i8** %arg1
   %220 = bitcast i8* %219 to i64*
-  %NullCheck36 = icmp ne i64* %220, null
-  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64* %220, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %221
 
 ; <label>:221                                     ; preds = %217
   %222 = load i64, i64* %220, align 8
   %223 = bitcast i8* %218 to i64*
-  %NullCheck38 = icmp ne i64* %223, null
-  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+  %NullCheck37 = icmp eq i64* %223, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %224
 
 ; <label>:224                                     ; preds = %221
   store i64 %222, i64* %223, align 8
@@ -1084,14 +1166,14 @@ entry:
   %227 = load i8*, i8** %arg1
   %228 = getelementptr inbounds i8, i8* %227, i64 8
   %229 = bitcast i8* %228 to i32*
-  %NullCheck40 = icmp ne i32* %229, null
-  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i32* %229, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %230
 
 ; <label>:230                                     ; preds = %224
   %231 = load i32, i32* %229, align 8
   %232 = bitcast i8* %226 to i32*
-  %NullCheck42 = icmp ne i32* %232, null
-  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+  %NullCheck41 = icmp eq i32* %232, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %233
 
 ; <label>:233                                     ; preds = %230
   store i32 %231, i32* %232, align 8
@@ -1099,15 +1181,15 @@ entry:
   %235 = getelementptr inbounds i8, i8* %234, i64 12
   %236 = load i8*, i8** %arg1
   %237 = getelementptr inbounds i8, i8* %236, i64 12
-  %NullCheck44 = icmp ne i8* %237, null
-  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i8* %237, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %238
 
 ; <label>:238                                     ; preds = %233
   %239 = load i8, i8* %237, align 8
   %240 = zext i8 %239 to i32
   %241 = trunc i32 %240 to i8
-  %NullCheck46 = icmp ne i8* %235, null
-  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+  %NullCheck45 = icmp eq i8* %235, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %242
 
 ; <label>:242                                     ; preds = %238
   store i8 %241, i8* %235, align 8
@@ -1117,14 +1199,14 @@ entry:
   %244 = load i8*, i8** %arg0
   %245 = load i8*, i8** %arg1
   %246 = bitcast i8* %245 to i64*
-  %NullCheck24 = icmp ne i64* %246, null
-  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64* %246, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %247
 
 ; <label>:247                                     ; preds = %243
   %248 = load i64, i64* %246, align 8
   %249 = bitcast i8* %244 to i64*
-  %NullCheck26 = icmp ne i64* %249, null
-  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64* %249, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %250
 
 ; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
@@ -1133,14 +1215,14 @@ entry:
   %253 = load i8*, i8** %arg1
   %254 = getelementptr inbounds i8, i8* %253, i64 8
   %255 = bitcast i8* %254 to i32*
-  %NullCheck28 = icmp ne i32* %255, null
-  br i1 %NullCheck28, label %256, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i32* %255, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %256
 
 ; <label>:256                                     ; preds = %250
   %257 = load i32, i32* %255, align 8
   %258 = bitcast i8* %252 to i32*
-  %NullCheck30 = icmp ne i32* %258, null
-  br i1 %NullCheck30, label %259, label %ThrowNullRef29
+  %NullCheck29 = icmp eq i32* %258, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %259
 
 ; <label>:259                                     ; preds = %256
   store i32 %257, i32* %258, align 8
@@ -1149,16 +1231,16 @@ entry:
   %262 = load i8*, i8** %arg1
   %263 = getelementptr inbounds i8, i8* %262, i64 12
   %264 = bitcast i8* %263 to i16*
-  %NullCheck32 = icmp ne i16* %264, null
-  br i1 %NullCheck32, label %265, label %ThrowNullRef31
+  %NullCheck31 = icmp eq i16* %264, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %265
 
 ; <label>:265                                     ; preds = %259
   %266 = load i16, i16* %264, align 8
   %267 = sext i16 %266 to i32
   %268 = bitcast i8* %261 to i16*
   %269 = trunc i32 %267 to i16
-  %NullCheck34 = icmp ne i16* %268, null
-  br i1 %NullCheck34, label %270, label %ThrowNullRef33
+  %NullCheck33 = icmp eq i16* %268, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %270
 
 ; <label>:270                                     ; preds = %265
   store i16 %269, i16* %268, align 8
@@ -1168,14 +1250,14 @@ entry:
   %272 = load i8*, i8** %arg0
   %273 = load i8*, i8** %arg1
   %274 = bitcast i8* %273 to i64*
-  %NullCheck8 = icmp ne i64* %274, null
-  br i1 %NullCheck8, label %275, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64* %274, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %275
 
 ; <label>:275                                     ; preds = %271
   %276 = load i64, i64* %274, align 8
   %277 = bitcast i8* %272 to i64*
-  %NullCheck10 = icmp ne i64* %277, null
-  br i1 %NullCheck10, label %278, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %277, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %278
 
 ; <label>:278                                     ; preds = %275
   store i64 %276, i64* %277, align 8
@@ -1184,14 +1266,14 @@ entry:
   %281 = load i8*, i8** %arg1
   %282 = getelementptr inbounds i8, i8* %281, i64 8
   %283 = bitcast i8* %282 to i32*
-  %NullCheck12 = icmp ne i32* %283, null
-  br i1 %NullCheck12, label %284, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i32* %283, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %284
 
 ; <label>:284                                     ; preds = %278
   %285 = load i32, i32* %283, align 8
   %286 = bitcast i8* %280 to i32*
-  %NullCheck14 = icmp ne i32* %286, null
-  br i1 %NullCheck14, label %287, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i32* %286, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %287
 
 ; <label>:287                                     ; preds = %284
   store i32 %285, i32* %286, align 8
@@ -1200,16 +1282,16 @@ entry:
   %290 = load i8*, i8** %arg1
   %291 = getelementptr inbounds i8, i8* %290, i64 12
   %292 = bitcast i8* %291 to i16*
-  %NullCheck16 = icmp ne i16* %292, null
-  br i1 %NullCheck16, label %293, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i16* %292, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %293
 
 ; <label>:293                                     ; preds = %287
   %294 = load i16, i16* %292, align 8
   %295 = sext i16 %294 to i32
   %296 = bitcast i8* %289 to i16*
   %297 = trunc i32 %295 to i16
-  %NullCheck18 = icmp ne i16* %296, null
-  br i1 %NullCheck18, label %298, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i16* %296, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %298
 
 ; <label>:298                                     ; preds = %293
   store i16 %297, i16* %296, align 8
@@ -1217,15 +1299,15 @@ entry:
   %300 = getelementptr inbounds i8, i8* %299, i64 14
   %301 = load i8*, i8** %arg1
   %302 = getelementptr inbounds i8, i8* %301, i64 14
-  %NullCheck20 = icmp ne i8* %302, null
-  br i1 %NullCheck20, label %303, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i8* %302, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %303
 
 ; <label>:303                                     ; preds = %298
   %304 = load i8, i8* %302, align 8
   %305 = zext i8 %304 to i32
   %306 = trunc i32 %305 to i8
-  %NullCheck22 = icmp ne i8* %300, null
-  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i8* %300, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %307
 
 ; <label>:307                                     ; preds = %303
   store i8 %306, i8* %300, align 8
@@ -1235,14 +1317,14 @@ entry:
   %309 = load i8*, i8** %arg0
   %310 = load i8*, i8** %arg1
   %311 = bitcast i8* %310 to i64*
-  %NullCheck = icmp ne i64* %311, null
-  br i1 %NullCheck, label %312, label %ThrowNullRef
+  %NullCheck = icmp eq i64* %311, null
+  br i1 %NullCheck, label %ThrowNullRef, label %312
 
 ; <label>:312                                     ; preds = %308
   %313 = load i64, i64* %311, align 8
   %314 = bitcast i8* %309 to i64*
-  %NullCheck2 = icmp ne i64* %314, null
-  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64* %314, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %315
 
 ; <label>:315                                     ; preds = %312
   store i64 %313, i64* %314, align 8
@@ -1251,14 +1333,14 @@ entry:
   %318 = load i8*, i8** %arg1
   %319 = getelementptr inbounds i8, i8* %318, i64 8
   %320 = bitcast i8* %319 to i64*
-  %NullCheck4 = icmp ne i64* %320, null
-  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64* %320, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %321
 
 ; <label>:321                                     ; preds = %315
   %322 = load i64, i64* %320, align 8
   %323 = bitcast i8* %317 to i64*
-  %NullCheck6 = icmp ne i64* %323, null
-  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64* %323, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %324
 
 ; <label>:324                                     ; preds = %321
   store i64 %322, i64* %323, align 8
@@ -1286,15 +1368,15 @@ entry:
 ; <label>:338                                     ; preds = %333
   %339 = load i8*, i8** %arg0
   %340 = load i8*, i8** %arg1
-  %NullCheck136 = icmp ne i8* %340, null
-  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+  %NullCheck135 = icmp eq i8* %340, null
+  br i1 %NullCheck135, label %ThrowNullRef136, label %341
 
 ; <label>:341                                     ; preds = %338
   %342 = load i8, i8* %340, align 8
   %343 = zext i8 %342 to i32
   %344 = trunc i32 %343 to i8
-  %NullCheck138 = icmp ne i8* %339, null
-  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+  %NullCheck137 = icmp eq i8* %339, null
+  br i1 %NullCheck137, label %ThrowNullRef138, label %345
 
 ; <label>:345                                     ; preds = %341
   store i8 %344, i8* %339, align 8
@@ -1317,16 +1399,16 @@ entry:
   %357 = load i8*, i8** %arg0
   %358 = load i8*, i8** %arg1
   %359 = bitcast i8* %358 to i16*
-  %NullCheck140 = icmp ne i16* %359, null
-  br i1 %NullCheck140, label %360, label %ThrowNullRef139
+  %NullCheck139 = icmp eq i16* %359, null
+  br i1 %NullCheck139, label %ThrowNullRef140, label %360
 
 ; <label>:360                                     ; preds = %356
   %361 = load i16, i16* %359, align 8
   %362 = sext i16 %361 to i32
   %363 = bitcast i8* %357 to i16*
   %364 = trunc i32 %362 to i16
-  %NullCheck142 = icmp ne i16* %363, null
-  br i1 %NullCheck142, label %365, label %ThrowNullRef141
+  %NullCheck141 = icmp eq i16* %363, null
+  br i1 %NullCheck141, label %ThrowNullRef142, label %365
 
 ; <label>:365                                     ; preds = %360
   store i16 %364, i16* %363, align 8
@@ -1352,14 +1434,14 @@ entry:
   %378 = load i8*, i8** %arg0
   %379 = load i8*, i8** %arg1
   %380 = bitcast i8* %379 to i32*
-  %NullCheck144 = icmp ne i32* %380, null
-  br i1 %NullCheck144, label %381, label %ThrowNullRef143
+  %NullCheck143 = icmp eq i32* %380, null
+  br i1 %NullCheck143, label %ThrowNullRef144, label %381
 
 ; <label>:381                                     ; preds = %377
   %382 = load i32, i32* %380, align 8
   %383 = bitcast i8* %378 to i32*
-  %NullCheck146 = icmp ne i32* %383, null
-  br i1 %NullCheck146, label %384, label %ThrowNullRef145
+  %NullCheck145 = icmp eq i32* %383, null
+  br i1 %NullCheck145, label %ThrowNullRef146, label %384
 
 ; <label>:384                                     ; preds = %381
   store i32 %382, i32* %383, align 8
@@ -1384,14 +1466,14 @@ entry:
   %395 = load i8*, i8** %arg0
   %396 = load i8*, i8** %arg1
   %397 = bitcast i8* %396 to i64*
-  %NullCheck164 = icmp ne i64* %397, null
-  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+  %NullCheck163 = icmp eq i64* %397, null
+  br i1 %NullCheck163, label %ThrowNullRef164, label %398
 
 ; <label>:398                                     ; preds = %394
   %399 = load i64, i64* %397, align 8
   %400 = bitcast i8* %395 to i64*
-  %NullCheck166 = icmp ne i64* %400, null
-  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+  %NullCheck165 = icmp eq i64* %400, null
+  br i1 %NullCheck165, label %ThrowNullRef166, label %401
 
 ; <label>:401                                     ; preds = %398
   store i64 %399, i64* %400, align 8
@@ -1400,14 +1482,14 @@ entry:
   %404 = load i8*, i8** %arg1
   %405 = getelementptr inbounds i8, i8* %404, i64 8
   %406 = bitcast i8* %405 to i64*
-  %NullCheck168 = icmp ne i64* %406, null
-  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+  %NullCheck167 = icmp eq i64* %406, null
+  br i1 %NullCheck167, label %ThrowNullRef168, label %407
 
 ; <label>:407                                     ; preds = %401
   %408 = load i64, i64* %406, align 8
   %409 = bitcast i8* %403 to i64*
-  %NullCheck170 = icmp ne i64* %409, null
-  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+  %NullCheck169 = icmp eq i64* %409, null
+  br i1 %NullCheck169, label %ThrowNullRef170, label %410
 
 ; <label>:410                                     ; preds = %407
   store i64 %408, i64* %409, align 8
@@ -1437,14 +1519,14 @@ entry:
   %425 = load i8*, i8** %arg0
   %426 = load i8*, i8** %arg1
   %427 = bitcast i8* %426 to i64*
-  %NullCheck148 = icmp ne i64* %427, null
-  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+  %NullCheck147 = icmp eq i64* %427, null
+  br i1 %NullCheck147, label %ThrowNullRef148, label %428
 
 ; <label>:428                                     ; preds = %424
   %429 = load i64, i64* %427, align 8
   %430 = bitcast i8* %425 to i64*
-  %NullCheck150 = icmp ne i64* %430, null
-  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+  %NullCheck149 = icmp eq i64* %430, null
+  br i1 %NullCheck149, label %ThrowNullRef150, label %431
 
 ; <label>:431                                     ; preds = %428
   store i64 %429, i64* %430, align 8
@@ -1466,14 +1548,14 @@ entry:
   %441 = load i8*, i8** %arg0
   %442 = load i8*, i8** %arg1
   %443 = bitcast i8* %442 to i32*
-  %NullCheck152 = icmp ne i32* %443, null
-  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+  %NullCheck151 = icmp eq i32* %443, null
+  br i1 %NullCheck151, label %ThrowNullRef152, label %444
 
 ; <label>:444                                     ; preds = %440
   %445 = load i32, i32* %443, align 8
   %446 = bitcast i8* %441 to i32*
-  %NullCheck154 = icmp ne i32* %446, null
-  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+  %NullCheck153 = icmp eq i32* %446, null
+  br i1 %NullCheck153, label %ThrowNullRef154, label %447
 
 ; <label>:447                                     ; preds = %444
   store i32 %445, i32* %446, align 8
@@ -1495,16 +1577,16 @@ entry:
   %457 = load i8*, i8** %arg0
   %458 = load i8*, i8** %arg1
   %459 = bitcast i8* %458 to i16*
-  %NullCheck156 = icmp ne i16* %459, null
-  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+  %NullCheck155 = icmp eq i16* %459, null
+  br i1 %NullCheck155, label %ThrowNullRef156, label %460
 
 ; <label>:460                                     ; preds = %456
   %461 = load i16, i16* %459, align 8
   %462 = sext i16 %461 to i32
   %463 = bitcast i8* %457 to i16*
   %464 = trunc i32 %462 to i16
-  %NullCheck158 = icmp ne i16* %463, null
-  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+  %NullCheck157 = icmp eq i16* %463, null
+  br i1 %NullCheck157, label %ThrowNullRef158, label %465
 
 ; <label>:465                                     ; preds = %460
   store i16 %464, i16* %463, align 8
@@ -1525,15 +1607,15 @@ entry:
 ; <label>:474                                     ; preds = %470
   %475 = load i8*, i8** %arg0
   %476 = load i8*, i8** %arg1
-  %NullCheck160 = icmp ne i8* %476, null
-  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+  %NullCheck159 = icmp eq i8* %476, null
+  br i1 %NullCheck159, label %ThrowNullRef160, label %477
 
 ; <label>:477                                     ; preds = %474
   %478 = load i8, i8* %476, align 8
   %479 = zext i8 %478 to i32
   %480 = trunc i32 %479 to i8
-  %NullCheck162 = icmp ne i8* %475, null
-  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+  %NullCheck161 = icmp eq i8* %475, null
+  br i1 %NullCheck161, label %ThrowNullRef162, label %481
 
 ; <label>:481                                     ; preds = %477
   store i8 %480, i8* %475, align 8
@@ -1553,343 +1635,343 @@ ThrowNullRef:                                     ; preds = %308
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %312
+ThrowNullRef2:                                    ; preds = %312
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %315
+ThrowNullRef4:                                    ; preds = %315
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %321
+ThrowNullRef6:                                    ; preds = %321
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %271
+ThrowNullRef8:                                    ; preds = %271
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %275
+ThrowNullRef10:                                   ; preds = %275
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %278
+ThrowNullRef12:                                   ; preds = %278
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %284
+ThrowNullRef14:                                   ; preds = %284
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %287
+ThrowNullRef16:                                   ; preds = %287
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %293
+ThrowNullRef18:                                   ; preds = %293
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %298
+ThrowNullRef20:                                   ; preds = %298
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %303
+ThrowNullRef22:                                   ; preds = %303
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %243
+ThrowNullRef24:                                   ; preds = %243
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %247
+ThrowNullRef26:                                   ; preds = %247
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %250
+ThrowNullRef28:                                   ; preds = %250
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %256
+ThrowNullRef30:                                   ; preds = %256
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %259
+ThrowNullRef32:                                   ; preds = %259
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %265
+ThrowNullRef34:                                   ; preds = %265
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %217
+ThrowNullRef36:                                   ; preds = %217
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %221
+ThrowNullRef38:                                   ; preds = %221
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %224
+ThrowNullRef40:                                   ; preds = %224
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %230
+ThrowNullRef42:                                   ; preds = %230
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %233
+ThrowNullRef44:                                   ; preds = %233
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %238
+ThrowNullRef46:                                   ; preds = %238
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %200
+ThrowNullRef48:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %204
+ThrowNullRef50:                                   ; preds = %204
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %207
+ThrowNullRef52:                                   ; preds = %207
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %213
+ThrowNullRef54:                                   ; preds = %213
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %172
+ThrowNullRef56:                                   ; preds = %172
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %176
+ThrowNullRef58:                                   ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %179
+ThrowNullRef60:                                   ; preds = %179
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %185
+ThrowNullRef62:                                   ; preds = %185
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %190
+ThrowNullRef64:                                   ; preds = %190
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %195
+ThrowNullRef66:                                   ; preds = %195
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %153
+ThrowNullRef68:                                   ; preds = %153
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %157
+ThrowNullRef70:                                   ; preds = %157
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %160
+ThrowNullRef72:                                   ; preds = %160
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %166
+ThrowNullRef74:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %136
+ThrowNullRef76:                                   ; preds = %136
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %140
+ThrowNullRef78:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %143
+ThrowNullRef80:                                   ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %148
+ThrowNullRef82:                                   ; preds = %148
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %128
+ThrowNullRef84:                                   ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %132
+ThrowNullRef86:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %100
+ThrowNullRef88:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %104
+ThrowNullRef90:                                   ; preds = %104
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %107
+ThrowNullRef92:                                   ; preds = %107
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %113
+ThrowNullRef94:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %118
+ThrowNullRef96:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %123
+ThrowNullRef98:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %81
+ThrowNullRef100:                                  ; preds = %81
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef101:                                  ; preds = %85
+ThrowNullRef102:                                  ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef103:                                  ; preds = %88
+ThrowNullRef104:                                  ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef105:                                  ; preds = %94
+ThrowNullRef106:                                  ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef107:                                  ; preds = %64
+ThrowNullRef108:                                  ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef109:                                  ; preds = %68
+ThrowNullRef110:                                  ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef111:                                  ; preds = %71
+ThrowNullRef112:                                  ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef113:                                  ; preds = %76
+ThrowNullRef114:                                  ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef115:                                  ; preds = %56
+ThrowNullRef116:                                  ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef117:                                  ; preds = %60
+ThrowNullRef118:                                  ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef119:                                  ; preds = %37
+ThrowNullRef120:                                  ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef121:                                  ; preds = %41
+ThrowNullRef122:                                  ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef123:                                  ; preds = %46
+ThrowNullRef124:                                  ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef125:                                  ; preds = %51
+ThrowNullRef126:                                  ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef127:                                  ; preds = %27
+ThrowNullRef128:                                  ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef129:                                  ; preds = %31
+ThrowNullRef130:                                  ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef131:                                  ; preds = %19
+ThrowNullRef132:                                  ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef133:                                  ; preds = %22
+ThrowNullRef134:                                  ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef135:                                  ; preds = %338
+ThrowNullRef136:                                  ; preds = %338
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef137:                                  ; preds = %341
+ThrowNullRef138:                                  ; preds = %341
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef139:                                  ; preds = %356
+ThrowNullRef140:                                  ; preds = %356
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef141:                                  ; preds = %360
+ThrowNullRef142:                                  ; preds = %360
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef143:                                  ; preds = %377
+ThrowNullRef144:                                  ; preds = %377
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef145:                                  ; preds = %381
+ThrowNullRef146:                                  ; preds = %381
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef147:                                  ; preds = %424
+ThrowNullRef148:                                  ; preds = %424
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef149:                                  ; preds = %428
+ThrowNullRef150:                                  ; preds = %428
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef151:                                  ; preds = %440
+ThrowNullRef152:                                  ; preds = %440
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef153:                                  ; preds = %444
+ThrowNullRef154:                                  ; preds = %444
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef155:                                  ; preds = %456
+ThrowNullRef156:                                  ; preds = %456
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef157:                                  ; preds = %460
+ThrowNullRef158:                                  ; preds = %460
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef159:                                  ; preds = %474
+ThrowNullRef160:                                  ; preds = %474
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef161:                                  ; preds = %477
+ThrowNullRef162:                                  ; preds = %477
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef163:                                  ; preds = %394
+ThrowNullRef164:                                  ; preds = %394
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef165:                                  ; preds = %398
+ThrowNullRef166:                                  ; preds = %398
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef167:                                  ; preds = %401
+ThrowNullRef168:                                  ; preds = %401
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef169:                                  ; preds = %407
+ThrowNullRef170:                                  ; preds = %407
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1939,8 +2021,8 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
-  br i1 %NullCheck, label %22, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %ThrowNullRef, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
@@ -1948,8 +2030,8 @@ entry:
   store i32 %24, i32* %loc0
   %25 = load i32, i32* %loc0
   %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %26, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %27
 
 ; <label>:27                                      ; preds = %22
   %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
@@ -1971,7 +2053,7 @@ ThrowNullRef:                                     ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1989,8 +2071,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -2022,15 +2104,15 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2048,16 +2130,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
   %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
   store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %15
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
@@ -2072,8 +2154,8 @@ entry:
   %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
   %29 = ptrtoint i16 addrspace(1)* %28 to i64
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %19
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
@@ -2089,19 +2171,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2114,8 +2196,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
@@ -2128,7 +2210,7 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[loadElem]
+Failed to read AppDomain.PrepareDataForSetup[storeElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
@@ -2202,8 +2284,8 @@ entry:
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
-  br i1 %NullCheck24, label %27, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = load i64, i64 addrspace(1)* %26
@@ -2218,8 +2300,8 @@ entry:
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
-  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
   %41 = load i64, i64 addrspace(1)* %39
@@ -2236,8 +2318,8 @@ entry:
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
-  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
   %54 = load i64, i64 addrspace(1)* %52
@@ -2252,8 +2334,8 @@ entry:
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
   %67 = load i64, i64 addrspace(1)* %65
@@ -2270,8 +2352,8 @@ entry:
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
-  br i1 %NullCheck16, label %79, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
   %80 = load i64, i64 addrspace(1)* %78
@@ -2286,8 +2368,8 @@ entry:
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
-  br i1 %NullCheck18, label %92, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
   %93 = load i64, i64 addrspace(1)* %91
@@ -2304,8 +2386,8 @@ entry:
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
-  br i1 %NullCheck12, label %105, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = load i64, i64 addrspace(1)* %104
@@ -2320,8 +2402,8 @@ entry:
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
-  br i1 %NullCheck14, label %118, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
   %119 = load i64, i64 addrspace(1)* %117
@@ -2337,8 +2419,8 @@ entry:
 
 ; <label>:128                                     ; preds = %20
   %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
-  br i1 %NullCheck4, label %130, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %129, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %130
 
 ; <label>:130                                     ; preds = %128
   %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
@@ -2346,8 +2428,8 @@ entry:
   %133 = load i16, i16 addrspace(1)* %132, align 8
   %134 = zext i16 %133 to i32
   %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
-  br i1 %NullCheck6, label %136, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %135, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %136
 
 ; <label>:136                                     ; preds = %130
   %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
@@ -2360,8 +2442,8 @@ entry:
 
 ; <label>:143                                     ; preds = %136
   %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
-  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %144, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %145
 
 ; <label>:145                                     ; preds = %143
   %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
@@ -2369,8 +2451,8 @@ entry:
   %148 = load i16, i16 addrspace(1)* %147, align 8
   %149 = zext i16 %148 to i32
   %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %150, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %151
 
 ; <label>:151                                     ; preds = %145
   %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
@@ -2388,8 +2470,8 @@ entry:
 
 ; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
-  br i1 %NullCheck, label %163, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %ThrowNullRef, label %163
 
 ; <label>:163                                     ; preds = %161
   %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
@@ -2399,8 +2481,8 @@ entry:
 
 ; <label>:167                                     ; preds = %163
   %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
-  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %168, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %169
 
 ; <label>:169                                     ; preds = %167
   %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
@@ -2432,55 +2514,55 @@ ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %167
+ThrowNullRef2:                                    ; preds = %167
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %128
+ThrowNullRef4:                                    ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %130
+ThrowNullRef6:                                    ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %143
+ThrowNullRef8:                                    ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %145
+ThrowNullRef10:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %102
+ThrowNullRef12:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %105
+ThrowNullRef14:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %76
+ThrowNullRef16:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %79
+ThrowNullRef18:                                   ; preds = %79
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %50
+ThrowNullRef20:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %53
+ThrowNullRef22:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %24
+ThrowNullRef24:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %27
+ThrowNullRef26:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2503,15 +2585,15 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2519,16 +2601,16 @@ entry:
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
   store i32 %8, i32* %loc0
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
   %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
   store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
@@ -2546,16 +2628,16 @@ entry:
 
 ; <label>:23                                      ; preds = %64
   %24 = load i16*, i16** %loc3
-  %NullCheck12 = icmp ne i16* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i16* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
   store i32 %27, i32* %loc5
   %28 = load i16*, i16** %loc4
-  %NullCheck14 = icmp ne i16* %28, null
-  br i1 %NullCheck14, label %29, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %28, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = load i16, i16* %28, align 8
@@ -2620,15 +2702,15 @@ entry:
 
 ; <label>:67                                      ; preds = %64
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
-  br i1 %NullCheck8, label %69, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %68, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %69
 
 ; <label>:69                                      ; preds = %67
   %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
   %71 = load i32, i32 addrspace(1)* %70
   %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
-  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %73
 
 ; <label>:73                                      ; preds = %69
   %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
@@ -2645,31 +2727,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %67
+ThrowNullRef8:                                    ; preds = %67
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %69
+ThrowNullRef10:                                   ; preds = %69
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2710,14 +2792,14 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
   %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
@@ -2730,14 +2812,14 @@ entry:
 
 ; <label>:11                                      ; preds = %4
   %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
   %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
@@ -2749,14 +2831,14 @@ entry:
 
 ; <label>:22                                      ; preds = %16
   %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
   %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
-  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
-  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
@@ -2804,23 +2886,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2836,7 +2918,280 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[loadElem]
+Successfully read RuntimeType.IsAssignableFrom
+
+define i8 @RuntimeType.IsAssignableFrom(%System.RuntimeType addrspace(1)* %param0, %System.Type addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.RuntimeType addrspace(1)*
+  %arg1 = alloca %System.Type addrspace(1)*
+  %loc0 = alloca %System.RuntimeType addrspace(1)*
+  %loc1 = alloca %"System.Type[]" addrspace(1)*
+  %loc2 = alloca i32
+  store %System.RuntimeType addrspace(1)* %param0, %System.RuntimeType addrspace(1)** %this
+  store %System.Type addrspace(1)* %param1, %System.Type addrspace(1)** %arg1
+  %0 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %1 = icmp ne %System.Type addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i8 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %5 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %6 = bitcast %System.Type addrspace(1)* %4 to %System.Object addrspace(1)*
+  %7 = bitcast %System.RuntimeType addrspace(1)* %5 to %System.Object addrspace(1)*
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %6, %System.Object addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %3
+  ret i8 1
+
+; <label>:12                                      ; preds = %3
+  %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 152
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 32
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
+  %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
+  %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
+  store %System.RuntimeType addrspace(1)* %25, %System.RuntimeType addrspace(1)** %loc0
+  %26 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %27 = icmp eq %System.RuntimeType addrspace(1)* %26, null
+  br i1 %27, label %34, label %28
+
+; <label>:28                                      ; preds = %15
+  %29 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %30 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)*)*)(%System.RuntimeType addrspace(1)* %29, %System.RuntimeType addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+; <label>:34                                      ; preds = %15
+  %35 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %36 = call %System.Reflection.Emit.TypeBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Reflection.Emit.TypeBuilder addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %35)
+  %37 = icmp eq %System.Reflection.Emit.TypeBuilder addrspace(1)* %36, null
+  br i1 %37, label %139, label %38
+
+; <label>:38                                      ; preds = %34
+  %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %42
+
+; <label>:42                                      ; preds = %38
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 152
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 40
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
+  %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
+  %53 = zext i8 %52 to i32
+  %54 = icmp eq i32 %53, 0
+  br i1 %54, label %56, label %55
+
+; <label>:55                                      ; preds = %42
+  ret i8 1
+
+; <label>:56                                      ; preds = %42
+  %57 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %58 = bitcast %System.RuntimeType addrspace(1)* %57 to %System.Type addrspace(1)*
+  %59 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %58)
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %64 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.Type addrspace(1)* %63, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = bitcast %System.RuntimeType addrspace(1)* %64 to %System.Type addrspace(1)*
+  %67 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %63, %System.Type addrspace(1)* %66)
+  %68 = zext i8 %67 to i32
+  %69 = trunc i32 %68 to i8
+  ret i8 %69
+
+; <label>:70                                      ; preds = %56
+  %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
+  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %73
+
+; <label>:73                                      ; preds = %70
+  %74 = load i64, i64 addrspace(1)* %72
+  %75 = add i64 %74, 128
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = add i64 %77, 0
+  %79 = inttoptr i64 %78 to i64*
+  %80 = load i64, i64* %79
+  %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
+  %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
+  %83 = call i8 %82(%System.Type addrspace(1)* %81)
+  %84 = zext i8 %83 to i32
+  %85 = icmp eq i32 %84, 0
+  br i1 %85, label %139, label %86
+
+; <label>:86                                      ; preds = %73
+  %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
+  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %89
+
+; <label>:89                                      ; preds = %86
+  %90 = load i64, i64 addrspace(1)* %88
+  %91 = add i64 %90, 128
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = add i64 %93, 24
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
+  %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
+  %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
+  store %"System.Type[]" addrspace(1)* %99, %"System.Type[]" addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %129
+
+; <label>:100                                     ; preds = %132
+  %101 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %102 = load i32, i32* %loc2
+  %NullCheck11 = icmp eq %"System.Type[]" addrspace(1)* %101, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %103
+
+; <label>:103                                     ; preds = %100
+  %104 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 1
+  %105 = load i32, i32 addrspace(1)* %104
+  %106 = zext i32 %105 to i64
+  %107 = zext i32 %102 to i64
+  %BoundsCheck = icmp uge i64 %107, %106
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %108
+
+; <label>:108                                     ; preds = %103
+  %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
+  %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
+  %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
+  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %113
+
+; <label>:113                                     ; preds = %108
+  %114 = load i64, i64 addrspace(1)* %112
+  %115 = add i64 %114, 152
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = add i64 %117, 56
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
+  %123 = zext i8 %122 to i32
+  %124 = icmp ne i32 %123, 0
+  br i1 %124, label %126, label %125
+
+; <label>:125                                     ; preds = %113
+  ret i8 0
+
+; <label>:126                                     ; preds = %113
+  %127 = load i32, i32* %loc2
+  %128 = add i32 %127, 1
+  store i32 %128, i32* %loc2
+  br label %129
+
+; <label>:129                                     ; preds = %89, %126
+  %130 = load i32, i32* %loc2
+  %131 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %NullCheck9 = icmp eq %"System.Type[]" addrspace(1)* %131, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %132
+
+; <label>:132                                     ; preds = %129
+  %133 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %131, i32 0, i32 1
+  %134 = load i32, i32 addrspace(1)* %133
+  %135 = zext i32 %134 to i64
+  %136 = trunc i64 %135 to i32
+  %137 = icmp slt i32 %130, %136
+  br i1 %137, label %100, label %138
+
+; <label>:138                                     ; preds = %132
+  ret i8 1
+
+; <label>:139                                     ; preds = %34, %73
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %129
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %103
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -2893,7 +3248,7 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElem]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -2904,8 +3259,8 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -2997,8 +3352,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
@@ -3059,8 +3414,8 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -3087,8 +3442,8 @@ entry:
 
 ; <label>:17                                      ; preds = %5, %11
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
@@ -3097,8 +3452,8 @@ entry:
 
 ; <label>:22                                      ; preds = %1, %11
   %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
@@ -3109,11 +3464,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %17
+ThrowNullRef2:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %22
+ThrowNullRef4:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3167,15 +3522,15 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
   %15 = load i32, i32 addrspace(1)* %14
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
@@ -3198,7 +3553,7 @@ ThrowNullRef:                                     ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef2:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3232,8 +3587,8 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
@@ -3312,8 +3667,8 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -3327,8 +3682,8 @@ entry:
 ; <label>:5                                       ; preds = %43
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %7 = load i32, i32* %loc1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck6, label %8, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
@@ -3366,8 +3721,8 @@ entry:
 ; <label>:32                                      ; preds = %21, %25
   %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
   %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
-  br i1 %NullCheck8, label %35, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = trunc i32 %34 to i16
@@ -3380,8 +3735,8 @@ entry:
 ; <label>:40                                      ; preds = %1, %35
   %41 = load i32, i32* %loc1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
-  br i1 %NullCheck2, label %43, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %42, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
@@ -3392,8 +3747,8 @@ entry:
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
   %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
-  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
   %51 = load i64, i64 addrspace(1)* %49
@@ -3412,19 +3767,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %40
+ThrowNullRef2:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %47
+ThrowNullRef4:                                    ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %5
+ThrowNullRef6:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %32
+ThrowNullRef8:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3467,8 +3822,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
@@ -3492,11 +3847,391 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(i16* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store i16* %param0, i16** %arg0
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load i32, i32* %arg3
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %42, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %37, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg2
+  %13 = load i32, i32* %arg3
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %37, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %24 = load i32, i32* %arg2
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load i16*, i16** %arg0
+  %35 = load i32, i32* %arg3
+  %36 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %36, i16* %34, i32 %35)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:37                                      ; preds = %5, %16
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %39)
+  %41 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41, %System.String addrspace(1)* %38, %System.String addrspace(1)* %40)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41) #0
+  unreachable
+
+; <label>:42                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
-Failed to read StringBuilder.ToString[loadElemA]
+Successfully read StringBuilder.ToString
+
+define %System.String addrspace(1)* @StringBuilder.ToString(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i16*
+  %loc3 = alloca %"System.Char[]" addrspace(1)*
+  %loc4 = alloca i32
+  %loc5 = alloca i32
+  %loc6 = alloca i16 addrspace(1)*
+  %loc7 = alloca %System.String addrspace(1)*
+  %loc8 = alloca %"System.Char[]" addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %0)
+  %2 = icmp ne i32 %1, 0
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %4
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %6)
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %7)
+  store %System.String addrspace(1)* %8, %System.String addrspace(1)** %loc0
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.Text.StringBuilder addrspace(1)* %9, %System.Text.StringBuilder addrspace(1)** %loc1
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  store %System.String addrspace(1)* %10, %System.String addrspace(1)** %loc7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc7
+  %12 = ptrtoint %System.String addrspace(1)* %11 to i64
+  %13 = icmp eq i64 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %5
+  %15 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %16 = sext i32 %15 to i64
+  %17 = add i64 %12, %16
+  br label %18
+
+; <label>:18                                      ; preds = %5, %14
+  %19 = phi i64 [ %12, %5 ], [ %17, %14 ]
+  %20 = inttoptr i64 %19 to i16*
+  store i16* %20, i16** %loc2
+  br label %21
+
+; <label>:21                                      ; preds = %98, %18
+  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %22, null
+  br i1 %NullCheck, label %ThrowNullRef, label %23
+
+; <label>:23                                      ; preds = %21
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 3
+  %25 = load i32, i32 addrspace(1)* %24, align 8
+  %26 = icmp sle i32 %25, 0
+  br i1 %26, label %96, label %27
+
+; <label>:27                                      ; preds = %23
+  %28 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %28, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %29
+
+; <label>:29                                      ; preds = %27
+  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %28, i32 0, i32 1
+  %31 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %30, align 8
+  store %"System.Char[]" addrspace(1)* %31, %"System.Char[]" addrspace(1)** %loc3
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %33
+
+; <label>:33                                      ; preds = %29
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  store i32 %35, i32* %loc4
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  %39 = load i32, i32 addrspace(1)* %38, align 8
+  store i32 %39, i32* %loc5
+  %40 = load i32, i32* %loc5
+  %41 = load i32, i32* %loc4
+  %42 = add i32 %40, %41
+  %43 = zext i32 %42 to i64
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %45
+
+; <label>:45                                      ; preds = %37
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = sext i32 %47 to i64
+  %49 = icmp sgt i64 %43, %48
+  br i1 %49, label %91, label %50
+
+; <label>:50                                      ; preds = %45
+  %51 = load i32, i32* %loc5
+  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %52, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %53
+
+; <label>:53                                      ; preds = %50
+  %54 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %52, i32 0, i32 1
+  %55 = load i32, i32 addrspace(1)* %54
+  %56 = zext i32 %55 to i64
+  %57 = trunc i64 %56 to i32
+  %58 = icmp ugt i32 %51, %57
+  br i1 %58, label %91, label %59
+
+; <label>:59                                      ; preds = %53
+  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  store %"System.Char[]" addrspace(1)* %60, %"System.Char[]" addrspace(1)** %loc8
+  %61 = icmp eq %"System.Char[]" addrspace(1)* %60, null
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %63, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %64
+
+; <label>:64                                      ; preds = %62
+  %65 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %63, i32 0, i32 1
+  %66 = load i32, i32 addrspace(1)* %65
+  %67 = zext i32 %66 to i64
+  %68 = trunc i64 %67 to i32
+  %69 = icmp ne i32 %68, 0
+  br i1 %69, label %71, label %70
+
+; <label>:70                                      ; preds = %59, %64
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:71                                      ; preds = %64
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %73
+
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %BoundsCheck = icmp uge i64 0, %76
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %77
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %78, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:79                                      ; preds = %70, %77
+  %80 = load i16*, i16** %loc2
+  %81 = load i32, i32* %loc4
+  %82 = sext i32 %81 to i64
+  %83 = mul i64 %82, 2
+  %84 = bitcast i16* %80 to i8*
+  %85 = getelementptr inbounds i8, i8* %84, i64 %83
+  %86 = load i16 addrspace(1)*, i16 addrspace(1)** %loc6
+  %87 = ptrtoint i16 addrspace(1)* %86 to i64
+  %88 = load i32, i32* %loc5
+  %89 = bitcast i8* %85 to i16*
+  %90 = inttoptr i64 %87 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %89, i16* %90, i32 %88)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %96
+
+; <label>:91                                      ; preds = %45, %53
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %94 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %93)
+  %95 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95, %System.String addrspace(1)* %92, %System.String addrspace(1)* %94)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95) #0
+  unreachable
+
+; <label>:96                                      ; preds = %23, %79
+  %97 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %97, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %98
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %97, i32 0, i32 2
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  store %System.Text.StringBuilder addrspace(1)* %100, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %102 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %102, label %21, label %103
+
+; <label>:103                                     ; preds = %98
+  store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc7
+  %104 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  ret %System.String addrspace(1)* %104
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method StringBuilder::get_Length using LLILCJit
+Successfully read StringBuilder.get_Length
+
+define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
+Successfully read RuntimeHelpers.get_OffsetToStringData
+
+define i32 @RuntimeHelpers.get_OffsetToStringData() {
+entry:
+  ret i32 12
+}
+
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
 Successfully read CultureData.CreateCultureData
 
@@ -3514,23 +4249,23 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
   store i8 %4, i8 addrspace(1)* %6
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
@@ -3549,11 +4284,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3566,50 +4301,50 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
   store i32 -1, i32 addrspace(1)* %2
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
   store i32 -1, i32 addrspace(1)* %8
   %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
   store i32 -1, i32 addrspace(1)* %14
   %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
   store i32 -1, i32 addrspace(1)* %17
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
@@ -3623,27 +4358,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3675,7 +4410,136 @@ Failed to read Dictionary`2.Insert[non-const derefAddress]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
 Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
-Failed to read HashHelpers.GetPrime[loadElem]
+Successfully read HashHelpers.GetPrime
+
+define i32 @HashHelpers.GetPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %6, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5, %System.String addrspace(1)* %4)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5) #0
+  unreachable
+
+; <label>:6                                       ; preds = %entry
+  store i32 0, i32* %loc0
+  br label %29
+
+; <label>:7                                       ; preds = %35
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 1296
+  %10 = addrspacecast i8 addrspace(1)* %9 to %"System.Int32[]" addrspace(1)**
+  %11 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %10
+  %12 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Int32[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = zext i32 %15 to i64
+  %17 = zext i32 %12 to i64
+  %BoundsCheck = icmp uge i64 %17, %16
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 3, i32 %12
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  store i32 %20, i32* %loc1
+  %21 = load i32, i32* %loc1
+  %22 = load i32, i32* %arg0
+  %23 = icmp slt i32 %21, %22
+  br i1 %23, label %26, label %24
+
+; <label>:24                                      ; preds = %18
+  %25 = load i32, i32* %loc1
+  ret i32 %25
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %loc0
+  %28 = add i32 %27, 1
+  store i32 %28, i32* %loc0
+  br label %29
+
+; <label>:29                                      ; preds = %6, %26
+  %30 = load i32, i32* %loc0
+  %31 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %32 = getelementptr inbounds i8, i8 addrspace(1)* %31, i64 1296
+  %33 = addrspacecast i8 addrspace(1)* %32 to %"System.Int32[]" addrspace(1)**
+  %34 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %33
+  %NullCheck = icmp eq %"System.Int32[]" addrspace(1)* %34, null
+  br i1 %NullCheck, label %ThrowNullRef, label %35
+
+; <label>:35                                      ; preds = %29
+  %36 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %34, i32 0, i32 1
+  %37 = load i32, i32 addrspace(1)* %36
+  %38 = zext i32 %37 to i64
+  %39 = trunc i64 %38 to i32
+  %40 = icmp slt i32 %30, %39
+  br i1 %40, label %7, label %41
+
+; <label>:41                                      ; preds = %35
+  %42 = load i32, i32* %arg0
+  %43 = or i32 %42, 1
+  store i32 %43, i32* %loc2
+  br label %59
+
+; <label>:44                                      ; preds = %59
+  %45 = load i32, i32* %loc2
+  %46 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %45)
+  %47 = zext i8 %46 to i32
+  %48 = icmp eq i32 %47, 0
+  br i1 %48, label %56, label %49
+
+; <label>:49                                      ; preds = %44
+  %50 = load i32, i32* %loc2
+  %51 = sub i32 %50, 1
+  %52 = srem i32 %51, 101
+  %53 = icmp eq i32 %52, 0
+  br i1 %53, label %56, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = load i32, i32* %loc2
+  ret i32 %55
+
+; <label>:56                                      ; preds = %44, %49
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %57, 2
+  store i32 %58, i32* %loc2
+  br label %59
+
+; <label>:59                                      ; preds = %41, %56
+  %60 = load i32, i32* %loc2
+  %61 = icmp slt i32 %60, 2147483647
+  br i1 %61, label %44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load i32, i32* %arg0
+  ret i32 %63
+
+ThrowNullRef:                                     ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
 Successfully read GenericEqualityComparer`1.GetHashCode
 
@@ -3694,14 +4558,14 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
   %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load i64, i64 addrspace(1)* %7
@@ -3720,7 +4584,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3750,8 +4614,8 @@ entry:
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
@@ -3796,8 +4660,8 @@ entry:
   %35 = bitcast i16* %34 to i8*
   %36 = getelementptr inbounds i8, i8* %35, i64 2
   %37 = bitcast i8* %36 to i16*
-  %NullCheck4 = icmp ne i16* %37, null
-  br i1 %NullCheck4, label %38, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %37, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %38
 
 ; <label>:38                                      ; preds = %27
   %39 = load i16, i16* %37, align 8
@@ -3824,8 +4688,8 @@ entry:
 
 ; <label>:54                                      ; preds = %22, %43
   %55 = load i16*, i16** %loc4
-  %NullCheck2 = icmp ne i16* %55, null
-  br i1 %NullCheck2, label %56, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i16* %55, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %56
 
 ; <label>:56                                      ; preds = %54
   %57 = load i16, i16* %55, align 8
@@ -3850,11 +4714,11 @@ ThrowNullRef:                                     ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %54
+ThrowNullRef2:                                    ; preds = %54
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %27
+ThrowNullRef4:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3871,8 +4735,8 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -3907,8 +4771,8 @@ entry:
 
 ; <label>:26                                      ; preds = %19
   %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
-  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %28
 
 ; <label>:28                                      ; preds = %26
   %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
@@ -3920,7 +4784,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3972,8 +4836,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
@@ -3984,26 +4848,26 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
-  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
@@ -4014,8 +4878,8 @@ entry:
 ; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
@@ -4024,8 +4888,8 @@ entry:
 
 ; <label>:25                                      ; preds = %1, %16, %23
   %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
-  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
@@ -4036,27 +4900,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %20
+ThrowNullRef10:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4069,8 +4933,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -4081,8 +4945,8 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
@@ -4091,8 +4955,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1, %8
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
@@ -4103,11 +4967,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4128,24 +4992,24 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   store i32 %3, i32* %loc0
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
   %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
   store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck4, label %9, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
@@ -4164,15 +5028,15 @@ entry:
 ; <label>:18                                      ; preds = %70
   %19 = load i16*, i16** %loc3
   %20 = bitcast i16* %19 to i64*
-  %NullCheck10 = icmp ne i64* %20, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %20, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = load i64, i64* %20, align 8
   %23 = load i16*, i16** %loc4
   %24 = bitcast i16* %23 to i64*
-  %NullCheck12 = icmp ne i64* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = load i64, i64* %24, align 8
@@ -4188,8 +5052,8 @@ entry:
   %31 = bitcast i16* %30 to i8*
   %32 = getelementptr inbounds i8, i8* %31, i64 8
   %33 = bitcast i8* %32 to i64*
-  %NullCheck14 = icmp ne i64* %33, null
-  br i1 %NullCheck14, label %34, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = load i64, i64* %33, align 8
@@ -4197,8 +5061,8 @@ entry:
   %37 = bitcast i16* %36 to i8*
   %38 = getelementptr inbounds i8, i8* %37, i64 8
   %39 = bitcast i8* %38 to i64*
-  %NullCheck16 = icmp ne i64* %39, null
-  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %40
 
 ; <label>:40                                      ; preds = %34
   %41 = load i64, i64* %39, align 8
@@ -4214,8 +5078,8 @@ entry:
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %NullCheck18 = icmp ne i64* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = load i64, i64* %48, align 8
@@ -4223,8 +5087,8 @@ entry:
   %52 = bitcast i16* %51 to i8*
   %53 = getelementptr inbounds i8, i8* %52, i64 16
   %54 = bitcast i8* %53 to i64*
-  %NullCheck20 = icmp ne i64* %54, null
-  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64* %54, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %55
 
 ; <label>:55                                      ; preds = %49
   %56 = load i64, i64* %54, align 8
@@ -4262,15 +5126,15 @@ entry:
 ; <label>:74                                      ; preds = %95
   %75 = load i16*, i16** %loc3
   %76 = bitcast i16* %75 to i32*
-  %NullCheck6 = icmp ne i32* %76, null
-  br i1 %NullCheck6, label %77, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32* %76, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %77
 
 ; <label>:77                                      ; preds = %74
   %78 = load i32, i32* %76, align 8
   %79 = load i16*, i16** %loc4
   %80 = bitcast i16* %79 to i32*
-  %NullCheck8 = icmp ne i32* %80, null
-  br i1 %NullCheck8, label %81, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i32* %80, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %81
 
 ; <label>:81                                      ; preds = %77
   %82 = load i32, i32* %80, align 8
@@ -4318,43 +5182,43 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %74
+ThrowNullRef6:                                    ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %77
+ThrowNullRef8:                                    ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %29
+ThrowNullRef14:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %34
+ThrowNullRef16:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4376,8 +5240,8 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load i64, i64 addrspace(1)* %4
@@ -4389,8 +5253,8 @@ entry:
   %12 = load i64, i64* %11
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %5
   %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
@@ -4399,8 +5263,8 @@ entry:
   %18 = load i8, i8* %arg2
   %19 = zext i8 %18 to i32
   %20 = trunc i32 %19 to i8
-  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %15
   %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
@@ -4411,11 +5275,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4442,8 +5306,8 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
@@ -4466,16 +5330,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
   %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = load i64, i64 addrspace(1)* %19
@@ -4500,8 +5364,8 @@ entry:
 ; <label>:35                                      ; preds = %30
   %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
@@ -4514,8 +5378,8 @@ entry:
 
 ; <label>:42                                      ; preds = %1, %38
   %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
-  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
@@ -4526,19 +5390,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %35
+ThrowNullRef2:                                    ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %42
+ThrowNullRef8:                                    ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4551,14 +5415,14 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
@@ -4570,7 +5434,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4583,8 +5447,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
@@ -4613,51 +5477,51 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
   %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
   %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
   %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
   %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
-  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
   store i64 %21, i64 addrspace(1)* %23
   %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %25 = load i64, i64* %loc0
-  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
@@ -4668,27 +5532,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %22
+ThrowNullRef12:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4701,8 +5565,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
@@ -4713,19 +5577,19 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
@@ -4734,8 +5598,8 @@ entry:
 
 ; <label>:15                                      ; preds = %1, %13
   %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
@@ -4746,19 +5610,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %15
+ThrowNullRef8:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4771,8 +5635,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -4831,8 +5695,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
@@ -4882,8 +5746,8 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
-  br i1 %NullCheck, label %17, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %ThrowNullRef, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
@@ -4894,15 +5758,15 @@ entry:
 
 ; <label>:22                                      ; preds = %17
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
-  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
   %26 = load i32, i32 addrspace(1)* %25
   %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
-  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %27, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
@@ -4925,8 +5789,8 @@ entry:
 ; <label>:40                                      ; preds = %17
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
-  br i1 %NullCheck6, label %43, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %41, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
@@ -4938,34 +5802,17 @@ ThrowNullRef:                                     ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %24
+ThrowNullRef4:                                    ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %40
+ThrowNullRef6:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
-}
-
-INFO:  jitting method Object::ReferenceEquals using LLILCJit
-Successfully read Object.ReferenceEquals
-
-define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
-entry:
-  %arg0 = alloca %System.Object addrspace(1)*
-  %arg1 = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
-  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
-  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = icmp eq %System.Object addrspace(1)* %0, %1
-  %3 = sext i1 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
 }
 
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
@@ -4978,21 +5825,21 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
   %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
-  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
@@ -5007,28 +5854,28 @@ entry:
 ; <label>:13                                      ; preds = %8, %12
   %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
   %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
   %21 = load i32, i32 addrspace(1)* %20, align 8
   %22 = add i32 %21, 1
-  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
   store i32 %22, i32 addrspace(1)* %24
   %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
@@ -5039,27 +5886,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5077,7 +5924,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::Setup using LLILCJit
-Failed to read AppDomain.Setup[loadElem]
+Failed to read AppDomain.Setup[unbox]
 INFO:  jitting method Thread::GetDomain using LLILCJit
 Successfully read Thread.GetDomain
 
@@ -5108,8 +5955,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
@@ -5122,14 +5969,14 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
   %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
@@ -5141,11 +5988,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5173,8 +6020,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -5189,7 +6036,328 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
 Failed to read KeyCollection.System.Collections.Generic.IEnumerable<TKey>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Successfully read Enumerator.MoveNext
+
+define i8 @Enumerator.MoveNext(%"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.RuntimeTypeHandle* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*
+  %"$TypeArg" = alloca %System.RuntimeTypeHandle*
+  store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
+  %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 8
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %76, label %12
+
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
+  br label %76
+
+; <label>:13                                      ; preds = %85
+  %14 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck19 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %15
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, i32 0, i32 0
+  %17 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %16, align 8
+  %NullCheck21 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, i32 0, i32 2
+  %20 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %19, align 8
+  %21 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck23 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %22
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, i32 0, i32 2
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %NullCheck25 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 3, i32 %24
+  %NullCheck27 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %32
+
+; <label>:32                                      ; preds = %30
+  %33 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, i32 0, i32 2
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = icmp slt i32 %34, 0
+  br i1 %35, label %68, label %36
+
+; <label>:36                                      ; preds = %32
+  %37 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %38 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck29 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %39
+
+; <label>:39                                      ; preds = %36
+  %40 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, i32 0, i32 0
+  %41 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %40, align 8
+  %NullCheck31 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, i32 0, i32 2
+  %44 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %43, align 8
+  %45 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck33 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, i32 0, i32 2
+  %48 = load i32, i32 addrspace(1)* %47, align 8
+  %NullCheck35 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %49
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = zext i32 %51 to i64
+  %53 = zext i32 %48 to i64
+  %BoundsCheck37 = icmp uge i64 %53, %52
+  br i1 %BoundsCheck37, label %ThrowIndexOutOfRange38, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 3, i32 %48
+  %NullCheck39 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %56
+
+; <label>:56                                      ; preds = %54
+  %57 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, i32 0, i32 0
+  %58 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck41 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %59
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %60, %System.__Canon addrspace(1)* %58)
+  %61 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck43 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  %64 = load i32, i32 addrspace(1)* %63, align 8
+  %65 = add i32 %64, 1
+  %NullCheck45 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  store i32 %65, i32 addrspace(1)* %67
+  ret i8 1
+
+; <label>:68                                      ; preds = %32
+  %69 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck47 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %73 = add i32 %72, 1
+  %NullCheck49 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %74
+
+; <label>:74                                      ; preds = %70
+  %75 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  store i32 %73, i32 addrspace(1)* %75
+  br label %76
+
+; <label>:76                                      ; preds = %8, %12, %74
+  %77 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %78
+
+; <label>:78                                      ; preds = %76
+  %79 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, i32 0, i32 2
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck7 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %82
+
+; <label>:82                                      ; preds = %78
+  %83 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, i32 0, i32 0
+  %84 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %83, align 8
+  %NullCheck9 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %85
+
+; <label>:85                                      ; preds = %82
+  %86 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, i32 0, i32 7
+  %87 = load i32, i32 addrspace(1)* %86, align 8
+  %88 = icmp ult i32 %80, %87
+  br i1 %88, label %13, label %89
+
+; <label>:89                                      ; preds = %85
+  %90 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %91 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck11 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %92
+
+; <label>:92                                      ; preds = %89
+  %93 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, i32 0, i32 0
+  %94 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck13 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %95
+
+; <label>:95                                      ; preds = %92
+  %96 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, i32 0, i32 7
+  %97 = load i32, i32 addrspace(1)* %96, align 8
+  %98 = add i32 %97, 1
+  %NullCheck15 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %99
+
+; <label>:99                                      ; preds = %95
+  %100 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, i32 0, i32 2
+  store i32 %98, i32 addrspace(1)* %100
+  %101 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck17 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %102
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %103, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %92
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef22:                                   ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef24:                                   ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef26:                                   ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef28:                                   ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef30:                                   ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef32:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef34:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef36:                                   ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange38:                           ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef40:                                   ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef42:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef44:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef46:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef48:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef50:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -5200,8 +6368,8 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -5232,9 +6400,9 @@ Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
 Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
-Failed to read String.MakeSeparatorList[loadElemA]
+Failed to read String.MakeSeparatorList[storeElem]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
-Failed to read String.InternalSplitKeepEmptyEntries[loadElem]
+Failed to read String.InternalSplitKeepEmptyEntries[storeElem]
 INFO:  jitting method Path::IsRelative using LLILCJit
 Successfully read Path.IsRelative
 
@@ -5243,8 +6411,8 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -5254,8 +6422,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
@@ -5271,8 +6439,8 @@ entry:
 
 ; <label>:17                                      ; preds = %7
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
@@ -5288,8 +6456,8 @@ entry:
 
 ; <label>:29                                      ; preds = %19
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %31
 
 ; <label>:31                                      ; preds = %29
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
@@ -5300,8 +6468,8 @@ entry:
 
 ; <label>:36                                      ; preds = %31
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
-  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %37, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
@@ -5312,8 +6480,8 @@ entry:
 
 ; <label>:43                                      ; preds = %31, %38
   %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
-  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %45
 
 ; <label>:45                                      ; preds = %43
   %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
@@ -5324,8 +6492,8 @@ entry:
 
 ; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %50
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
@@ -5336,8 +6504,8 @@ entry:
 
 ; <label>:57                                      ; preds = %1, %7, %19, %45, %52
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
-  br i1 %NullCheck14, label %59, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %59
 
 ; <label>:59                                      ; preds = %57
   %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
@@ -5347,8 +6515,8 @@ entry:
 
 ; <label>:63                                      ; preds = %59
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
@@ -5359,8 +6527,8 @@ entry:
 
 ; <label>:70                                      ; preds = %65
   %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
-  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.String addrspace(1)* %71, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %72
 
 ; <label>:72                                      ; preds = %70
   %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
@@ -5379,39 +6547,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %17
+ThrowNullRef4:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %29
+ThrowNullRef6:                                    ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %36
+ThrowNullRef8:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %43
+ThrowNullRef10:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %50
+ThrowNullRef12:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %57
+ThrowNullRef14:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %63
+ThrowNullRef16:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %70
+ThrowNullRef18:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5419,7 +6587,293 @@ ThrowNullRef17:                                   ; preds = %70
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
-Failed to read String.TrimHelper[loadElem]
+Successfully read String.TrimHelper
+
+define %System.String addrspace(1)* @String.TrimHelper(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i16
+  %loc4 = alloca i32
+  %loc5 = alloca i16
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = sub i32 %3, 1
+  store i32 %4, i32* %loc0
+  store i32 0, i32* %loc1
+  %5 = load i32, i32* %arg2
+  %6 = icmp eq i32 %5, 1
+  br i1 %6, label %62, label %7
+
+; <label>:7                                       ; preds = %1
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:8                                       ; preds = %58
+  store i32 0, i32* %loc2
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load i32, i32* %loc1
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2, i32 %10
+  %13 = load i16, i16 addrspace(1)* %12
+  %14 = zext i16 %13 to i32
+  %15 = trunc i32 %14 to i16
+  store i16 %15, i16* %loc3
+  store i32 0, i32* %loc2
+  br label %34
+
+; <label>:16                                      ; preds = %37
+  %17 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %18 = load i32, i32* %loc2
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %17, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %19
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = zext i32 %18 to i64
+  %BoundsCheck = icmp uge i64 %23, %22
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %24
+
+; <label>:24                                      ; preds = %19
+  %25 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 3, i32 %18
+  %26 = load i16, i16 addrspace(1)* %25, align 8
+  %27 = zext i16 %26 to i32
+  %28 = load i16, i16* %loc3
+  %29 = zext i16 %28 to i32
+  %30 = icmp eq i32 %27, %29
+  br i1 %30, label %43, label %31
+
+; <label>:31                                      ; preds = %24
+  %32 = load i32, i32* %loc2
+  %33 = add i32 %32, 1
+  store i32 %33, i32* %loc2
+  br label %34
+
+; <label>:34                                      ; preds = %11, %31
+  %35 = load i32, i32* %loc2
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = icmp slt i32 %35, %41
+  br i1 %42, label %16, label %43
+
+; <label>:43                                      ; preds = %24, %37
+  %44 = load i32, i32* %loc2
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %45, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp eq i32 %44, %50
+  br i1 %51, label %62, label %52
+
+; <label>:52                                      ; preds = %46
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %7, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %57, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %58
+
+; <label>:58                                      ; preds = %55
+  %59 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %60 = load i32, i32 addrspace(1)* %59
+  %61 = icmp slt i32 %56, %60
+  br i1 %61, label %8, label %62
+
+; <label>:62                                      ; preds = %1, %46, %58
+  %63 = load i32, i32* %arg2
+  %64 = icmp eq i32 %63, 0
+  br i1 %64, label %122, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %66, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %67
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %66, i32 0, i32 1
+  %69 = load i32, i32 addrspace(1)* %68
+  %70 = sub i32 %69, 1
+  store i32 %70, i32* %loc0
+  br label %118
+
+; <label>:71                                      ; preds = %118
+  store i32 0, i32* %loc4
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %73 = load i32, i32* %loc0
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %74
+
+; <label>:74                                      ; preds = %71
+  %75 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 2, i32 %73
+  %76 = load i16, i16 addrspace(1)* %75
+  %77 = zext i16 %76 to i32
+  %78 = trunc i32 %77 to i16
+  store i16 %78, i16* %loc5
+  store i32 0, i32* %loc4
+  br label %97
+
+; <label>:79                                      ; preds = %100
+  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %81 = load i32, i32* %loc4
+  %NullCheck19 = icmp eq %"System.Char[]" addrspace(1)* %80, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
+
+; <label>:82                                      ; preds = %79
+  %83 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 1
+  %84 = load i32, i32 addrspace(1)* %83
+  %85 = zext i32 %84 to i64
+  %86 = zext i32 %81 to i64
+  %BoundsCheck21 = icmp uge i64 %86, %85
+  br i1 %BoundsCheck21, label %ThrowIndexOutOfRange22, label %87
+
+; <label>:87                                      ; preds = %82
+  %88 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 3, i32 %81
+  %89 = load i16, i16 addrspace(1)* %88, align 8
+  %90 = zext i16 %89 to i32
+  %91 = load i16, i16* %loc5
+  %92 = zext i16 %91 to i32
+  %93 = icmp eq i32 %90, %92
+  br i1 %93, label %106, label %94
+
+; <label>:94                                      ; preds = %87
+  %95 = load i32, i32* %loc4
+  %96 = add i32 %95, 1
+  store i32 %96, i32* %loc4
+  br label %97
+
+; <label>:97                                      ; preds = %74, %94
+  %98 = load i32, i32* %loc4
+  %99 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck15 = icmp eq %"System.Char[]" addrspace(1)* %99, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %100
+
+; <label>:100                                     ; preds = %97
+  %101 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %99, i32 0, i32 1
+  %102 = load i32, i32 addrspace(1)* %101
+  %103 = zext i32 %102 to i64
+  %104 = trunc i64 %103 to i32
+  %105 = icmp slt i32 %98, %104
+  br i1 %105, label %79, label %106
+
+; <label>:106                                     ; preds = %87, %100
+  %107 = load i32, i32* %loc4
+  %108 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck17 = icmp eq %"System.Char[]" addrspace(1)* %108, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %109
+
+; <label>:109                                     ; preds = %106
+  %110 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %108, i32 0, i32 1
+  %111 = load i32, i32 addrspace(1)* %110
+  %112 = zext i32 %111 to i64
+  %113 = trunc i64 %112 to i32
+  %114 = icmp eq i32 %107, %113
+  br i1 %114, label %122, label %115
+
+; <label>:115                                     ; preds = %109
+  %116 = load i32, i32* %loc0
+  %117 = sub i32 %116, 1
+  store i32 %117, i32* %loc0
+  br label %118
+
+; <label>:118                                     ; preds = %67, %115
+  %119 = load i32, i32* %loc0
+  %120 = load i32, i32* %loc1
+  %121 = icmp sge i32 %119, %120
+  br i1 %121, label %71, label %122
+
+; <label>:122                                     ; preds = %62, %109, %118
+  %123 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %124 = load i32, i32* %loc1
+  %125 = load i32, i32* %loc0
+  %126 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %123, i32 %124, i32 %125)
+  ret %System.String addrspace(1)* %126
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %97
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange22:                           ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
 Successfully read String.CreateTrimmedString
 
@@ -5439,8 +6893,8 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
@@ -5535,8 +6989,8 @@ entry:
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i64 2872
   %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
   %8 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %7
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %3
   %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
@@ -5553,8 +7007,8 @@ entry:
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 2864
   %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
   %21 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %20
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
-  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %22
 
 ; <label>:22                                      ; preds = %16
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
@@ -5569,7 +7023,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %16
+ThrowNullRef2:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5586,8 +7040,8 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5613,8 +7067,8 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
@@ -5632,8 +7086,8 @@ entry:
 
 ; <label>:12                                      ; preds = %4
   %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
@@ -5644,8 +7098,8 @@ entry:
 
 ; <label>:19                                      ; preds = %14
   %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %19
   %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
@@ -5660,21 +7114,21 @@ entry:
   %31 = zext i16 %30 to i32
   %32 = bitcast i8* %29 to i16*
   %33 = trunc i32 %31 to i16
-  %NullCheck6 = icmp ne i16* %32, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i16* %32, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %21
   store i16 %33, i16* %32, align 8
   %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %36
 
 ; <label>:36                                      ; preds = %34
   %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
   %38 = load i32, i32 addrspace(1)* %37, align 8
   %39 = add i32 %38, 1
-  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %40
 
 ; <label>:40                                      ; preds = %36
   %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
@@ -5683,16 +7137,16 @@ entry:
 
 ; <label>:42                                      ; preds = %14
   %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
-  br i1 %NullCheck12, label %44, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
   %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
   %47 = load i16, i16* %arg1
   %48 = zext i16 %47 to i32
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = trunc i32 %48 to i16
@@ -5703,31 +7157,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %19
+ThrowNullRef4:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %21
+ThrowNullRef6:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %36
+ThrowNullRef10:                                   ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %42
+ThrowNullRef12:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %44
+ThrowNullRef14:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5740,8 +7194,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -5752,8 +7206,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
@@ -5762,14 +7216,14 @@ entry:
 
 ; <label>:11                                      ; preds = %1
   %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
@@ -5779,15 +7233,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5808,8 +7262,8 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5822,8 +7276,8 @@ entry:
 
 ; <label>:8                                       ; preds = %3
   %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
@@ -5842,15 +7296,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
-  br i1 %NullCheck4, label %22, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
   %24 = load i16*, i16* addrspace(1)* %23, align 8
   %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %25, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
@@ -5859,8 +7313,8 @@ entry:
   store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
@@ -5874,8 +7328,8 @@ entry:
 
 ; <label>:37                                      ; preds = %65
   %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %37
   %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
@@ -5886,16 +7340,16 @@ entry:
   %45 = bitcast i16* %41 to i8*
   %46 = getelementptr inbounds i8, i8* %45, i64 %44
   %47 = bitcast i8* %46 to i16*
-  %NullCheck14 = icmp ne i16* %47, null
-  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %47, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %48
 
 ; <label>:48                                      ; preds = %39
   %49 = load i16, i16* %47, align 8
   %50 = zext i16 %49 to i32
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %52 = load i32, i32* %loc1
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %53
 
 ; <label>:53                                      ; preds = %48
   %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
@@ -5916,8 +7370,8 @@ entry:
 ; <label>:62                                      ; preds = %36, %59
   %63 = load i32, i32* %loc1
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck10, label %65, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %65
 
 ; <label>:65                                      ; preds = %62
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
@@ -5936,15 +7390,15 @@ entry:
 
 ; <label>:74                                      ; preds = %70
   %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
-  br i1 %NullCheck18, label %76, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %76
 
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
   %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
-  br i1 %NullCheck20, label %80, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
   %81 = load i64, i64 addrspace(1)* %79
@@ -5958,8 +7412,8 @@ entry:
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
   %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
-  br i1 %NullCheck22, label %92, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.String addrspace(1)* %90, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %92
 
 ; <label>:92                                      ; preds = %80
   %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
@@ -5969,15 +7423,15 @@ entry:
 
 ; <label>:96                                      ; preds = %70
   %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
-  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %98
 
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
   %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
-  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
   %103 = load i64, i64 addrspace(1)* %101
@@ -5991,8 +7445,8 @@ entry:
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
   %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
-  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.String addrspace(1)* %112, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %114
 
 ; <label>:114                                     ; preds = %102
   %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
@@ -6004,59 +7458,59 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %20
+ThrowNullRef4:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %22
+ThrowNullRef6:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %26
+ThrowNullRef8:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %62
+ThrowNullRef10:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %48
+ThrowNullRef16:                                   ; preds = %48
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %74
+ThrowNullRef18:                                   ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %76
+ThrowNullRef20:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %80
+ThrowNullRef22:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %96
+ThrowNullRef24:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %98
+ThrowNullRef26:                                   ; preds = %98
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %102
+ThrowNullRef28:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6069,15 +7523,15 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
   %3 = load i16*, i16* addrspace(1)* %2, align 8
   %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
@@ -6087,8 +7541,8 @@ entry:
   %10 = bitcast i16* %3 to i8*
   %11 = getelementptr inbounds i8, i8* %10, i64 %9
   %12 = bitcast i8* %11 to i16*
-  %NullCheck4 = icmp ne i16* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %5
   store i16 0, i16* %12, align 8
@@ -6098,11 +7552,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6119,8 +7573,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -6131,8 +7585,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
@@ -6144,15 +7598,15 @@ entry:
 
 ; <label>:14                                      ; preds = %1
   %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
   %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
   %21 = load i64, i64 addrspace(1)* %19
@@ -6171,15 +7625,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %14
+ThrowNullRef4:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %16
+ThrowNullRef6:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6302,14 +7756,6 @@ entry:
   ret %System.String addrspace(1)* %57
 }
 
-INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
-Successfully read RuntimeHelpers.get_OffsetToStringData
-
-define i32 @RuntimeHelpers.get_OffsetToStringData() {
-entry:
-  ret i32 12
-}
-
 INFO:  jitting method String::Equals using LLILCJit
 Successfully read String.Equals
 
@@ -6381,8 +7827,8 @@ entry:
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
-  br i1 %NullCheck24, label %29, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
   %30 = load i64, i64 addrspace(1)* %28
@@ -6397,8 +7843,8 @@ entry:
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
-  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
   %43 = load i64, i64 addrspace(1)* %41
@@ -6418,8 +7864,8 @@ entry:
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
   %59 = load i64, i64 addrspace(1)* %57
@@ -6434,8 +7880,8 @@ entry:
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck22, label %71, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
   %72 = load i64, i64 addrspace(1)* %70
@@ -6455,8 +7901,8 @@ entry:
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
-  br i1 %NullCheck16, label %87, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = load i64, i64 addrspace(1)* %86
@@ -6471,8 +7917,8 @@ entry:
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck18, label %100, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
   %101 = load i64, i64 addrspace(1)* %99
@@ -6492,8 +7938,8 @@ entry:
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
-  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
   %117 = load i64, i64 addrspace(1)* %115
@@ -6508,8 +7954,8 @@ entry:
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
-  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
   %130 = load i64, i64 addrspace(1)* %128
@@ -6528,15 +7974,15 @@ entry:
 
 ; <label>:142                                     ; preds = %22
   %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
-  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %143, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %144
 
 ; <label>:144                                     ; preds = %142
   %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
   %146 = load i32, i32 addrspace(1)* %145
   %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
-  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %147, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %148
 
 ; <label>:148                                     ; preds = %144
   %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
@@ -6557,15 +8003,15 @@ entry:
 
 ; <label>:159                                     ; preds = %22
   %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
-  br i1 %NullCheck, label %161, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %ThrowNullRef, label %161
 
 ; <label>:161                                     ; preds = %159
   %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
   %163 = load i32, i32 addrspace(1)* %162
   %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
-  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %164, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %165
 
 ; <label>:165                                     ; preds = %161
   %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
@@ -6578,8 +8024,8 @@ entry:
 
 ; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
-  br i1 %NullCheck4, label %172, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %171, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %172
 
 ; <label>:172                                     ; preds = %170
   %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
@@ -6589,8 +8035,8 @@ entry:
 
 ; <label>:176                                     ; preds = %172
   %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
-  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %177, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %178
 
 ; <label>:178                                     ; preds = %176
   %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
@@ -6629,55 +8075,55 @@ ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %161
+ThrowNullRef2:                                    ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %170
+ThrowNullRef4:                                    ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %176
+ThrowNullRef6:                                    ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %142
+ThrowNullRef8:                                    ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %144
+ThrowNullRef10:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %113
+ThrowNullRef12:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %116
+ThrowNullRef14:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %84
+ThrowNullRef16:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %87
+ThrowNullRef18:                                   ; preds = %87
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %55
+ThrowNullRef20:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %58
+ThrowNullRef22:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %26
+ThrowNullRef24:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %29
+ThrowNullRef26:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,8 +8161,8 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck, label %14, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %ThrowNullRef, label %14
 
 ; <label>:14                                      ; preds = %8
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
@@ -6760,8 +8206,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
@@ -6770,14 +8216,14 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32, i32* %loc0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %10
   %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
   %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
@@ -6790,15 +8236,15 @@ entry:
 ; <label>:25                                      ; preds = %19
   %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
-  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
   %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
@@ -6807,8 +8253,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %37 = load i32, i32* %loc0
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %38, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %38
 
 ; <label>:38                                      ; preds = %32
   %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
@@ -6817,14 +8263,14 @@ entry:
 
 ; <label>:40                                      ; preds = %19
   %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %40
   %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
   %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
-  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
-  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
@@ -6832,8 +8278,8 @@ entry:
   %48 = zext i32 %47 to i64
   %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
-  br i1 %NullCheck16, label %51, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %51
 
 ; <label>:51                                      ; preds = %45
   %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
@@ -6847,15 +8293,15 @@ entry:
 ; <label>:57                                      ; preds = %51
   %58 = load i16*, i16** %arg1
   %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
-  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %60
 
 ; <label>:60                                      ; preds = %57
   %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
   %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
-  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %64
 
 ; <label>:64                                      ; preds = %60
   %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
@@ -6864,22 +8310,22 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
   %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
-  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %70
 
 ; <label>:70                                      ; preds = %64
   %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
   %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
-  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
-  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
   %75 = load i32, i32 addrspace(1)* %74
   %76 = zext i32 %75 to i64
   %77 = trunc i64 %76 to i32
-  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
-  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %78
 
 ; <label>:78                                      ; preds = %73
   %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
@@ -6901,8 +8347,8 @@ entry:
   %90 = bitcast i16* %86 to i8*
   %91 = getelementptr inbounds i8, i8* %90, i64 %89
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %93
 
 ; <label>:93                                      ; preds = %80
   %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
@@ -6912,8 +8358,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %99 = load i32, i32* %loc2
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %100
 
 ; <label>:100                                     ; preds = %93
   %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
@@ -6928,63 +8374,63 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %25
+ThrowNullRef6:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %32
+ThrowNullRef10:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %40
+ThrowNullRef12:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %45
+ThrowNullRef16:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %57
+ThrowNullRef18:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %60
+ThrowNullRef20:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %64
+ThrowNullRef22:                                   ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %70
+ThrowNullRef24:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %73
+ThrowNullRef26:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %80
+ThrowNullRef28:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %93
+ThrowNullRef30:                                   ; preds = %93
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7004,8 +8450,8 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
@@ -7033,43 +8479,43 @@ entry:
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %14
   %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
   %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   %28 = load i32, i32 addrspace(1)* %27, align 8
   %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
-  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %30
 
 ; <label>:30                                      ; preds = %26
   %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
   %32 = load i32, i32 addrspace(1)* %31, align 8
   %33 = add i32 %28, %32
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %34
 
 ; <label>:34                                      ; preds = %30
   %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   store i32 %33, i32 addrspace(1)* %35
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
   store i32 0, i32 addrspace(1)* %38
   %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %40
 
 ; <label>:40                                      ; preds = %37
   %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
@@ -7082,8 +8528,8 @@ entry:
 
 ; <label>:47                                      ; preds = %40
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
@@ -7098,8 +8544,8 @@ entry:
   %54 = load i32, i32* %loc0
   %55 = sext i32 %54 to i64
   %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
-  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %57
 
 ; <label>:57                                      ; preds = %52
   %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
@@ -7110,68 +8556,35 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %14
+ThrowNullRef2:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %23
+ThrowNullRef4:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %26
+ThrowNullRef6:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %30
+ThrowNullRef8:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %34
+ThrowNullRef10:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %47
+ThrowNullRef14:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %52
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-}
-
-INFO:  jitting method StringBuilder::get_Length using LLILCJit
-Successfully read StringBuilder.get_Length
-
-define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.StringBuilder addrspace(1)*
-  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
-  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
-
-; <label>:1                                       ; preds = %entry
-  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %3 = load i32, i32 addrspace(1)* %2, align 8
-  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
-
-; <label>:5                                       ; preds = %1
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = add i32 %3, %7
-  ret i32 %8
-
-ThrowNullRef:                                     ; preds = %entry
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef16:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7213,70 +8626,70 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
   %6 = load i32, i32 addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
   store i32 %6, i32 addrspace(1)* %8
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
   %13 = load i32, i32 addrspace(1)* %12, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
   store i32 %13, i32 addrspace(1)* %15
   %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
-  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %18
 
 ; <label>:18                                      ; preds = %14
   %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
   %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
   %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
   %34 = load i32, i32 addrspace(1)* %33, align 8
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
-  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
@@ -7287,39 +8700,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %28
+ThrowNullRef16:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %32
+ThrowNullRef18:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7455,13 +8868,13 @@ entry:
 ; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
@@ -7477,16 +8890,16 @@ entry:
 
 ; <label>:18                                      ; preds = %15
   %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
   store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
   %22 = load i32, i32* %loc0
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %24
 
 ; <label>:24                                      ; preds = %20
   %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
@@ -7498,13 +8911,13 @@ entry:
 ; <label>:28                                      ; preds = %15, %24
   %29 = load i32, i32* %arg1
   %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %31
   %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
@@ -7517,20 +8930,20 @@ entry:
   %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
-  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
   %46 = load i32, i32 addrspace(1)* %45, align 8
   %47 = sub i32 %40, %46
-  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
-  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i32 addrspace(1)* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %48
 
 ; <label>:48                                      ; preds = %44
   store i32 %47, i32 addrspace(1)* %39, align 8
@@ -7538,21 +8951,21 @@ entry:
 
 ; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
-  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %51
 
 ; <label>:51                                      ; preds = %49
   %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %53
 
 ; <label>:53                                      ; preds = %51
   %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
   %55 = load i32, i32 addrspace(1)* %54, align 8
   %56 = load i32, i32* %arg2
   %57 = sub i32 %55, %56
-  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %58
 
 ; <label>:58                                      ; preds = %53
   %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
@@ -7562,13 +8975,13 @@ entry:
 ; <label>:60                                      ; preds = %33, %58
   %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
   %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
-  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %63
 
 ; <label>:63                                      ; preds = %60
   %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
-  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
-  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
@@ -7578,15 +8991,15 @@ entry:
 
 ; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
-  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i32 addrspace(1)* %69, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %70
 
 ; <label>:70                                      ; preds = %68
   %71 = load i32, i32 addrspace(1)* %69, align 8
   store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
-  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
@@ -7596,8 +9009,8 @@ entry:
   store i32 %77, i32* %loc4
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
-  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %80
 
 ; <label>:80                                      ; preds = %73
   %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
@@ -7607,71 +9020,71 @@ entry:
 ; <label>:83                                      ; preds = %80
   store i32 0, i32* %loc3
   %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
-  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
-  br i1 %NullCheck26, label %88, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i32 addrspace(1)* %87, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %88
 
 ; <label>:88                                      ; preds = %85
   %89 = load i32, i32 addrspace(1)* %87, align 8
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
-  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %90
 
 ; <label>:90                                      ; preds = %88
   %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
   store i32 %89, i32 addrspace(1)* %91
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
-  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
-  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %96
 
 ; <label>:96                                      ; preds = %94
   %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
-  br i1 %NullCheck34, label %100, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %100
 
 ; <label>:100                                     ; preds = %96
   %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
-  br i1 %NullCheck36, label %102, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %102
 
 ; <label>:102                                     ; preds = %100
   %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
   %104 = load i32, i32 addrspace(1)* %103, align 8
   %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
-  br i1 %NullCheck38, label %106, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %106
 
 ; <label>:106                                     ; preds = %102
   %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
-  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
-  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %108
 
 ; <label>:108                                     ; preds = %106
   %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
   %110 = load i32, i32 addrspace(1)* %109, align 8
   %111 = add i32 %104, %110
-  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %112
 
 ; <label>:112                                     ; preds = %108
   %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
   store i32 %111, i32 addrspace(1)* %113
   %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
-  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i32 addrspace(1)* %114, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %115
 
 ; <label>:115                                     ; preds = %112
   %116 = load i32, i32 addrspace(1)* %114, align 8
@@ -7681,19 +9094,19 @@ entry:
 ; <label>:118                                     ; preds = %115
   %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
-  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %121
 
 ; <label>:121                                     ; preds = %118
   %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
-  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
-  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %123
 
 ; <label>:123                                     ; preds = %121
   %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
   %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
-  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
-  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %126
 
 ; <label>:126                                     ; preds = %123
   %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
@@ -7705,8 +9118,8 @@ entry:
 
 ; <label>:130                                     ; preds = %80, %115, %126
   %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %132
 
 ; <label>:132                                     ; preds = %130
   %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7715,8 +9128,8 @@ entry:
   %136 = load i32, i32* %loc3
   %137 = sub i32 %135, %136
   %138 = sub i32 %134, %137
-  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %139
 
 ; <label>:139                                     ; preds = %132
   %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7728,16 +9141,16 @@ entry:
 
 ; <label>:144                                     ; preds = %139
   %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
-  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %146
 
 ; <label>:146                                     ; preds = %144
   %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
   %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
   %149 = load i32, i32* %loc2
   %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
-  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %151
 
 ; <label>:151                                     ; preds = %146
   %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
@@ -7754,145 +9167,249 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %18
+ThrowNullRef4:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %31
+ThrowNullRef10:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %44
+ThrowNullRef16:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %68
+ThrowNullRef18:                                   ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %70
+ThrowNullRef20:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %73
+ThrowNullRef22:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %83
+ThrowNullRef24:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %85
+ThrowNullRef26:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %88
+ThrowNullRef28:                                   ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %90
+ThrowNullRef30:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %94
+ThrowNullRef32:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %96
+ThrowNullRef34:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %100
+ThrowNullRef36:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %102
+ThrowNullRef38:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %106
+ThrowNullRef40:                                   ; preds = %106
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %108
+ThrowNullRef42:                                   ; preds = %108
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %112
+ThrowNullRef44:                                   ; preds = %112
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %118
+ThrowNullRef46:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %121
+ThrowNullRef48:                                   ; preds = %121
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %123
+ThrowNullRef50:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %130
+ThrowNullRef52:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %132
+ThrowNullRef54:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %144
+ThrowNullRef56:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %146
+ThrowNullRef58:                                   ; preds = %146
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %60
+ThrowNullRef60:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %63
+ThrowNullRef62:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %49
+ThrowNullRef64:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %51
+ThrowNullRef66:                                   ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %53
+ThrowNullRef68:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(%"System.Char[]" addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %arg0 = alloca %"System.Char[]" addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store %"System.Char[]" addrspace(1)* %param0, %"System.Char[]" addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load i32, i32* %arg4
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %43, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %38, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg1
+  %13 = load i32, i32* %arg4
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %38, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %24 = load i32, i32* %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %35 = load i32, i32* %arg3
+  %36 = load i32, i32* %arg4
+  %37 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %37, %"System.Char[]" addrspace(1)* %34, i32 %35, i32 %36)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:38                                      ; preds = %5, %16
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Successfully read Buffer._Memmove
 
@@ -7914,7 +9431,7 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[loadElem]
+Failed to read AppDomain.SetDataHelper[storeElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -7923,8 +9440,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
@@ -7934,8 +9451,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
@@ -7947,15 +9464,15 @@ entry:
   %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
   %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
@@ -7966,15 +9483,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7992,7 +9509,79 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
-Failed to read Dictionary`2.TryGetValue[loadElemA]
+Successfully read Dictionary`2.TryGetValue
+
+define i8 @"Dictionary`2.TryGetValue"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)* addrspace(1)* %param2) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  %arg2 = alloca %System.__Canon addrspace(1)* addrspace(1)*
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  store %System.__Canon addrspace(1)* addrspace(1)* %param2, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  store i32 %2, i32* %loc0
+  %3 = load i32, i32* %loc0
+  %4 = icmp slt i32 %3, 0
+  br i1 %4, label %22, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 2
+  %10 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %9, align 8
+  %11 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = zext i32 %11 to i64
+  %BoundsCheck = icmp uge i64 %16, %15
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 3, i32 %11
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %20, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %6, %System.__Canon addrspace(1)* %21)
+  ret i8 1
+
+; <label>:22                                      ; preds = %entry
+  %23 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %23, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -8058,8 +9647,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
@@ -8091,8 +9680,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
@@ -8171,15 +9760,15 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck, label %19, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %ThrowNullRef, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
   %21 = load i32, i32 addrspace(1)* %20
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
@@ -8202,7 +9791,7 @@ ThrowNullRef:                                     ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %19
+ThrowNullRef2:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8248,8 +9837,8 @@ entry:
   %0 = alloca %System.AppDomainHandle
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %1 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %1, i32 0, i32 15
@@ -8269,8 +9858,8 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
@@ -8286,7 +9875,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -8299,8 +9888,8 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -8327,8 +9916,8 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
@@ -8352,8 +9941,8 @@ entry:
   %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
   store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
@@ -8363,8 +9952,8 @@ entry:
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
@@ -8374,8 +9963,8 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %9
   %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
@@ -8384,8 +9973,8 @@ entry:
 
 ; <label>:18                                      ; preds = %3, %16
   %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
@@ -8397,15 +9986,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %18
+ThrowNullRef6:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8418,8 +10007,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
@@ -8453,15 +10042,15 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
@@ -8473,7 +10062,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8481,7 +10070,7 @@ ThrowNullRef1:                                    ; preds = %1
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
 Failed to read Dictionary`2.System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
@@ -8506,8 +10095,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
@@ -8524,8 +10113,8 @@ entry:
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -8544,7 +10133,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8577,8 +10166,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = load i64, i64* %arg2
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = trunc i32 %3 to i8
@@ -8634,46 +10223,46 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
   %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
-  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
-  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
-  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
@@ -8684,27 +10273,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %20
+ThrowNullRef12:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8717,8 +10306,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -8756,22 +10345,22 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
   %9 = load i64, i64 addrspace(1)* %8, align 8
   %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
   %13 = load i64, i64 addrspace(1)* %12, align 8
   %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %11
   %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
@@ -8788,11 +10377,11 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8882,8 +10471,8 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
@@ -8900,8 +10489,8 @@ entry:
 ; <label>:8                                       ; preds = %1
   %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
   %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
@@ -8911,15 +10500,15 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
   %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
   %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
-  br i1 %NullCheck6, label %21, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
@@ -8946,15 +10535,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8992,15 +10581,15 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
   store i8 %3, i8 addrspace(1)* %5
   %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
@@ -9011,7 +10600,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9027,8 +10616,8 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -9041,8 +10630,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
@@ -9058,7 +10647,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9080,8 +10669,8 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
@@ -9096,8 +10685,8 @@ entry:
 ; <label>:12                                      ; preds = %6
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
@@ -9112,8 +10701,8 @@ entry:
 ; <label>:21                                      ; preds = %15
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
@@ -9128,8 +10717,8 @@ entry:
 ; <label>:30                                      ; preds = %24
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %31, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
@@ -9144,8 +10733,8 @@ entry:
 ; <label>:39                                      ; preds = %33
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
-  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %40, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %42
 
 ; <label>:42                                      ; preds = %39
   %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
@@ -9164,19 +10753,19 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %21
+ThrowNullRef4:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %30
+ThrowNullRef6:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %39
+ThrowNullRef8:                                    ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9243,8 +10832,8 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
@@ -9264,57 +10853,57 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
   store i8 0, i8 addrspace(1)* %2
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
   store i8 0, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
   store i8 0, i8 addrspace(1)* %17
   %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
   store i8 0, i8 addrspace(1)* %20
   %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
-  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
@@ -9325,31 +10914,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %19
+ThrowNullRef14:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9367,8 +10956,8 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
@@ -9380,8 +10969,8 @@ entry:
 
 ; <label>:9                                       ; preds = %4
   %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %9
   %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
@@ -9395,7 +10984,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef2:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9420,8 +11009,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
@@ -9512,8 +11101,8 @@ entry:
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
@@ -9524,8 +11113,8 @@ entry:
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = load i64, i64 addrspace(1)* %12
@@ -9537,8 +11126,8 @@ entry:
   %20 = load i64, i64* %19
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
-  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %13
   %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
@@ -9555,8 +11144,8 @@ entry:
 ; <label>:30                                      ; preds = %25
   %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %32 = load i32, i32* %arg2
-  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
-  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
@@ -9570,15 +11159,15 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %30
+ThrowNullRef2:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9622,87 +11211,87 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
   %10 = load i8, i8 addrspace(1)* %9, align 8
   %11 = zext i8 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %8
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
   store i8 %12, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
   %19 = load i8, i8 addrspace(1)* %18, align 8
   %20 = zext i8 %19 to i32
   %21 = trunc i32 %20 to i8
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
   store i8 %21, i8 addrspace(1)* %23
   %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
   %28 = load i8, i8 addrspace(1)* %27, align 8
   %29 = zext i8 %28 to i32
   %30 = trunc i32 %29 to i8
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
-  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %31
 
 ; <label>:31                                      ; preds = %26
   %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
   store i8 %30, i8 addrspace(1)* %32
   %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
-  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
-  br i1 %NullCheck14, label %40, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %40
 
 ; <label>:40                                      ; preds = %35
   %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
   store i8 %39, i8 addrspace(1)* %41
   %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
-  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %44
 
 ; <label>:44                                      ; preds = %40
   %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
   %46 = load i8, i8 addrspace(1)* %45, align 8
   %47 = zext i8 %46 to i32
   %48 = trunc i32 %47 to i8
-  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
   store i8 %48, i8 addrspace(1)* %50
   %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
-  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
@@ -9713,29 +11302,29 @@ entry:
 ; <label>:56                                      ; preds = %52
   %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
-  br i1 %NullCheck22, label %59, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
   %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
   %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
-  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
-  br i1 %NullCheck24, label %63, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
   %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
-  br i1 %NullCheck26, label %66, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
   %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
-  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
-  br i1 %NullCheck28, label %69, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %69
 
 ; <label>:69                                      ; preds = %66
   %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
@@ -9744,15 +11333,15 @@ entry:
 
 ; <label>:71                                      ; preds = %105
   %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
-  br i1 %NullCheck34, label %73, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %73
 
 ; <label>:73                                      ; preds = %71
   %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
   %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
   %76 = load i32, i32* %loc0
-  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
-  br i1 %NullCheck36, label %77, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
@@ -9766,8 +11355,8 @@ entry:
 
 ; <label>:83                                      ; preds = %77
   %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
-  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
@@ -9775,14 +11364,14 @@ entry:
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
   %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
-  br i1 %NullCheck40, label %91, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
 ; <label>:91                                      ; preds = %85
   %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
   %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
-  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck42, label %94, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %94
 
 ; <label>:94                                      ; preds = %91
   %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
@@ -9798,14 +11387,14 @@ entry:
 ; <label>:99                                      ; preds = %69, %96
   %100 = load i32, i32* %loc0
   %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
-  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %102
 
 ; <label>:102                                     ; preds = %99
   %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
   %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
-  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
-  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
@@ -9819,87 +11408,87 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %26
+ThrowNullRef10:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %31
+ThrowNullRef12:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %35
+ThrowNullRef14:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %40
+ThrowNullRef16:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %56
+ThrowNullRef22:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %59
+ThrowNullRef24:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %63
+ThrowNullRef26:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %66
+ThrowNullRef28:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %102
+ThrowNullRef32:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %71
+ThrowNullRef34:                                   ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %73
+ThrowNullRef36:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %83
+ThrowNullRef38:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %85
+ThrowNullRef40:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %91
+ThrowNullRef42:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9943,15 +11532,15 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
   %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
@@ -9961,28 +11550,28 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
   %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %12
   %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
   %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
   %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
-  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
@@ -9993,23 +11582,23 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %12
+ThrowNullRef6:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10031,15 +11620,15 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
   %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = load i64, i64 addrspace(1)* %7
@@ -10077,13 +11666,13 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[loadElem]
+Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -10111,8 +11700,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1

--- a/test/BaseLine/JIT/CodeGenBringUpTests/XorRef.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/XorRef.error.txt
@@ -25,8 +25,8 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
@@ -40,8 +40,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
   %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
@@ -75,7 +75,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -90,8 +90,8 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %NullCheck = icmp ne i8 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = load i8, i8 addrspace(1)* %0, align 8
@@ -125,8 +125,8 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
@@ -159,8 +159,8 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -184,8 +184,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
   store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
@@ -195,8 +195,8 @@ entry:
 ; <label>:4                                       ; preds = %1
   %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
   %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
@@ -206,8 +206,8 @@ entry:
   %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
@@ -221,14 +221,14 @@ entry:
 
 ; <label>:17                                      ; preds = %14
   %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
   %21 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
@@ -238,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -249,8 +249,8 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
@@ -261,27 +261,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %30
+ThrowNullRef10:                                   ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -301,7 +301,89 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
-Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
+Successfully read AppDomainSetup.GetUnsecureApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.GetUnsecureApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %NullCheck = icmp eq %"System.String[]" addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %BoundsCheck = icmp uge i64 0, %5
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %6
+
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 3, i32 0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
+  ret %System.String addrspace(1)* %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_Value using LLILCJit
+Successfully read AppDomainSetup.get_Value
+
+define %"System.String[]" addrspace(1)* @AppDomainSetup.get_Value(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.String[]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 18)
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.String[]" addrspace(1)* addrspace(1)*, %"System.String[]" addrspace(1)*)*)(%"System.String[]" addrspace(1)* addrspace(1)* %9, %"System.String[]" addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %11, i32 0, i32 1
+  %14 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %13, align 8
+  ret %"System.String[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -319,8 +401,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -368,16 +450,16 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
   %5 = load i32, i32 addrspace(1)* %4
   %6 = sub i32 %5, 1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -389,7 +471,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -421,8 +503,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
@@ -456,8 +538,8 @@ entry:
 ; <label>:27                                      ; preds = %19
   %28 = load i32, i32* %arg1
   %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
-  br i1 %NullCheck2, label %30, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %29, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %30
 
 ; <label>:30                                      ; preds = %27
   %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
@@ -493,8 +575,8 @@ entry:
 ; <label>:49                                      ; preds = %46
   %50 = load i32, i32* %arg2
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck4, label %52, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
@@ -517,11 +599,11 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %27
+ThrowNullRef2:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %49
+ThrowNullRef4:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -544,16 +626,16 @@ entry:
   %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %0)
   store %System.String addrspace(1)* %1, %System.String addrspace(1)** %loc0
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 2
   %5 = bitcast [0 x i16] addrspace(1)* %4 to i16 addrspace(1)*
   store i16 addrspace(1)* %5, i16 addrspace(1)** %loc1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %3
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2
@@ -580,7 +662,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -691,15 +773,15 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %NullCheck132 = icmp ne i8* %21, null
-  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+  %NullCheck131 = icmp eq i8* %21, null
+  br i1 %NullCheck131, label %ThrowNullRef132, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = load i8, i8* %21, align 8
   %24 = zext i8 %23 to i32
   %25 = trunc i32 %24 to i8
-  %NullCheck134 = icmp ne i8* %20, null
-  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+  %NullCheck133 = icmp eq i8* %20, null
+  br i1 %NullCheck133, label %ThrowNullRef134, label %26
 
 ; <label>:26                                      ; preds = %22
   store i8 %25, i8* %20, align 8
@@ -709,16 +791,16 @@ entry:
   %28 = load i8*, i8** %arg0
   %29 = load i8*, i8** %arg1
   %30 = bitcast i8* %29 to i16*
-  %NullCheck128 = icmp ne i16* %30, null
-  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+  %NullCheck127 = icmp eq i16* %30, null
+  br i1 %NullCheck127, label %ThrowNullRef128, label %31
 
 ; <label>:31                                      ; preds = %27
   %32 = load i16, i16* %30, align 8
   %33 = sext i16 %32 to i32
   %34 = bitcast i8* %28 to i16*
   %35 = trunc i32 %33 to i16
-  %NullCheck130 = icmp ne i16* %34, null
-  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+  %NullCheck129 = icmp eq i16* %34, null
+  br i1 %NullCheck129, label %ThrowNullRef130, label %36
 
 ; <label>:36                                      ; preds = %31
   store i16 %35, i16* %34, align 8
@@ -728,16 +810,16 @@ entry:
   %38 = load i8*, i8** %arg0
   %39 = load i8*, i8** %arg1
   %40 = bitcast i8* %39 to i16*
-  %NullCheck120 = icmp ne i16* %40, null
-  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+  %NullCheck119 = icmp eq i16* %40, null
+  br i1 %NullCheck119, label %ThrowNullRef120, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i16, i16* %40, align 8
   %43 = sext i16 %42 to i32
   %44 = bitcast i8* %38 to i16*
   %45 = trunc i32 %43 to i16
-  %NullCheck122 = icmp ne i16* %44, null
-  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+  %NullCheck121 = icmp eq i16* %44, null
+  br i1 %NullCheck121, label %ThrowNullRef122, label %46
 
 ; <label>:46                                      ; preds = %41
   store i16 %45, i16* %44, align 8
@@ -745,15 +827,15 @@ entry:
   %48 = getelementptr inbounds i8, i8* %47, i64 2
   %49 = load i8*, i8** %arg1
   %50 = getelementptr inbounds i8, i8* %49, i64 2
-  %NullCheck124 = icmp ne i8* %50, null
-  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+  %NullCheck123 = icmp eq i8* %50, null
+  br i1 %NullCheck123, label %ThrowNullRef124, label %51
 
 ; <label>:51                                      ; preds = %46
   %52 = load i8, i8* %50, align 8
   %53 = zext i8 %52 to i32
   %54 = trunc i32 %53 to i8
-  %NullCheck126 = icmp ne i8* %48, null
-  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+  %NullCheck125 = icmp eq i8* %48, null
+  br i1 %NullCheck125, label %ThrowNullRef126, label %55
 
 ; <label>:55                                      ; preds = %51
   store i8 %54, i8* %48, align 8
@@ -763,14 +845,14 @@ entry:
   %57 = load i8*, i8** %arg0
   %58 = load i8*, i8** %arg1
   %59 = bitcast i8* %58 to i32*
-  %NullCheck116 = icmp ne i32* %59, null
-  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+  %NullCheck115 = icmp eq i32* %59, null
+  br i1 %NullCheck115, label %ThrowNullRef116, label %60
 
 ; <label>:60                                      ; preds = %56
   %61 = load i32, i32* %59, align 8
   %62 = bitcast i8* %57 to i32*
-  %NullCheck118 = icmp ne i32* %62, null
-  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+  %NullCheck117 = icmp eq i32* %62, null
+  br i1 %NullCheck117, label %ThrowNullRef118, label %63
 
 ; <label>:63                                      ; preds = %60
   store i32 %61, i32* %62, align 8
@@ -780,14 +862,14 @@ entry:
   %65 = load i8*, i8** %arg0
   %66 = load i8*, i8** %arg1
   %67 = bitcast i8* %66 to i32*
-  %NullCheck108 = icmp ne i32* %67, null
-  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+  %NullCheck107 = icmp eq i32* %67, null
+  br i1 %NullCheck107, label %ThrowNullRef108, label %68
 
 ; <label>:68                                      ; preds = %64
   %69 = load i32, i32* %67, align 8
   %70 = bitcast i8* %65 to i32*
-  %NullCheck110 = icmp ne i32* %70, null
-  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+  %NullCheck109 = icmp eq i32* %70, null
+  br i1 %NullCheck109, label %ThrowNullRef110, label %71
 
 ; <label>:71                                      ; preds = %68
   store i32 %69, i32* %70, align 8
@@ -795,15 +877,15 @@ entry:
   %73 = getelementptr inbounds i8, i8* %72, i64 4
   %74 = load i8*, i8** %arg1
   %75 = getelementptr inbounds i8, i8* %74, i64 4
-  %NullCheck112 = icmp ne i8* %75, null
-  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+  %NullCheck111 = icmp eq i8* %75, null
+  br i1 %NullCheck111, label %ThrowNullRef112, label %76
 
 ; <label>:76                                      ; preds = %71
   %77 = load i8, i8* %75, align 8
   %78 = zext i8 %77 to i32
   %79 = trunc i32 %78 to i8
-  %NullCheck114 = icmp ne i8* %73, null
-  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+  %NullCheck113 = icmp eq i8* %73, null
+  br i1 %NullCheck113, label %ThrowNullRef114, label %80
 
 ; <label>:80                                      ; preds = %76
   store i8 %79, i8* %73, align 8
@@ -813,14 +895,14 @@ entry:
   %82 = load i8*, i8** %arg0
   %83 = load i8*, i8** %arg1
   %84 = bitcast i8* %83 to i32*
-  %NullCheck100 = icmp ne i32* %84, null
-  br i1 %NullCheck100, label %85, label %ThrowNullRef99
+  %NullCheck99 = icmp eq i32* %84, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %85
 
 ; <label>:85                                      ; preds = %81
   %86 = load i32, i32* %84, align 8
   %87 = bitcast i8* %82 to i32*
-  %NullCheck102 = icmp ne i32* %87, null
-  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+  %NullCheck101 = icmp eq i32* %87, null
+  br i1 %NullCheck101, label %ThrowNullRef102, label %88
 
 ; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
@@ -829,16 +911,16 @@ entry:
   %91 = load i8*, i8** %arg1
   %92 = getelementptr inbounds i8, i8* %91, i64 4
   %93 = bitcast i8* %92 to i16*
-  %NullCheck104 = icmp ne i16* %93, null
-  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+  %NullCheck103 = icmp eq i16* %93, null
+  br i1 %NullCheck103, label %ThrowNullRef104, label %94
 
 ; <label>:94                                      ; preds = %88
   %95 = load i16, i16* %93, align 8
   %96 = sext i16 %95 to i32
   %97 = bitcast i8* %90 to i16*
   %98 = trunc i32 %96 to i16
-  %NullCheck106 = icmp ne i16* %97, null
-  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+  %NullCheck105 = icmp eq i16* %97, null
+  br i1 %NullCheck105, label %ThrowNullRef106, label %99
 
 ; <label>:99                                      ; preds = %94
   store i16 %98, i16* %97, align 8
@@ -848,14 +930,14 @@ entry:
   %101 = load i8*, i8** %arg0
   %102 = load i8*, i8** %arg1
   %103 = bitcast i8* %102 to i32*
-  %NullCheck88 = icmp ne i32* %103, null
-  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+  %NullCheck87 = icmp eq i32* %103, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %104
 
 ; <label>:104                                     ; preds = %100
   %105 = load i32, i32* %103, align 8
   %106 = bitcast i8* %101 to i32*
-  %NullCheck90 = icmp ne i32* %106, null
-  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+  %NullCheck89 = icmp eq i32* %106, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %107
 
 ; <label>:107                                     ; preds = %104
   store i32 %105, i32* %106, align 8
@@ -864,16 +946,16 @@ entry:
   %110 = load i8*, i8** %arg1
   %111 = getelementptr inbounds i8, i8* %110, i64 4
   %112 = bitcast i8* %111 to i16*
-  %NullCheck92 = icmp ne i16* %112, null
-  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+  %NullCheck91 = icmp eq i16* %112, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %113
 
 ; <label>:113                                     ; preds = %107
   %114 = load i16, i16* %112, align 8
   %115 = sext i16 %114 to i32
   %116 = bitcast i8* %109 to i16*
   %117 = trunc i32 %115 to i16
-  %NullCheck94 = icmp ne i16* %116, null
-  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+  %NullCheck93 = icmp eq i16* %116, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %118
 
 ; <label>:118                                     ; preds = %113
   store i16 %117, i16* %116, align 8
@@ -881,15 +963,15 @@ entry:
   %120 = getelementptr inbounds i8, i8* %119, i64 6
   %121 = load i8*, i8** %arg1
   %122 = getelementptr inbounds i8, i8* %121, i64 6
-  %NullCheck96 = icmp ne i8* %122, null
-  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+  %NullCheck95 = icmp eq i8* %122, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %123
 
 ; <label>:123                                     ; preds = %118
   %124 = load i8, i8* %122, align 8
   %125 = zext i8 %124 to i32
   %126 = trunc i32 %125 to i8
-  %NullCheck98 = icmp ne i8* %120, null
-  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+  %NullCheck97 = icmp eq i8* %120, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %127
 
 ; <label>:127                                     ; preds = %123
   store i8 %126, i8* %120, align 8
@@ -899,14 +981,14 @@ entry:
   %129 = load i8*, i8** %arg0
   %130 = load i8*, i8** %arg1
   %131 = bitcast i8* %130 to i64*
-  %NullCheck84 = icmp ne i64* %131, null
-  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+  %NullCheck83 = icmp eq i64* %131, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %132
 
 ; <label>:132                                     ; preds = %128
   %133 = load i64, i64* %131, align 8
   %134 = bitcast i8* %129 to i64*
-  %NullCheck86 = icmp ne i64* %134, null
-  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+  %NullCheck85 = icmp eq i64* %134, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %135
 
 ; <label>:135                                     ; preds = %132
   store i64 %133, i64* %134, align 8
@@ -916,14 +998,14 @@ entry:
   %137 = load i8*, i8** %arg0
   %138 = load i8*, i8** %arg1
   %139 = bitcast i8* %138 to i64*
-  %NullCheck76 = icmp ne i64* %139, null
-  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+  %NullCheck75 = icmp eq i64* %139, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %140
 
 ; <label>:140                                     ; preds = %136
   %141 = load i64, i64* %139, align 8
   %142 = bitcast i8* %137 to i64*
-  %NullCheck78 = icmp ne i64* %142, null
-  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+  %NullCheck77 = icmp eq i64* %142, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %143
 
 ; <label>:143                                     ; preds = %140
   store i64 %141, i64* %142, align 8
@@ -931,15 +1013,15 @@ entry:
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %NullCheck80 = icmp ne i8* %147, null
-  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+  %NullCheck79 = icmp eq i8* %147, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %148
 
 ; <label>:148                                     ; preds = %143
   %149 = load i8, i8* %147, align 8
   %150 = zext i8 %149 to i32
   %151 = trunc i32 %150 to i8
-  %NullCheck82 = icmp ne i8* %145, null
-  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+  %NullCheck81 = icmp eq i8* %145, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %152
 
 ; <label>:152                                     ; preds = %148
   store i8 %151, i8* %145, align 8
@@ -949,14 +1031,14 @@ entry:
   %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
   %156 = bitcast i8* %155 to i64*
-  %NullCheck68 = icmp ne i64* %156, null
-  br i1 %NullCheck68, label %157, label %ThrowNullRef67
+  %NullCheck67 = icmp eq i64* %156, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %157
 
 ; <label>:157                                     ; preds = %153
   %158 = load i64, i64* %156, align 8
   %159 = bitcast i8* %154 to i64*
-  %NullCheck70 = icmp ne i64* %159, null
-  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+  %NullCheck69 = icmp eq i64* %159, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %160
 
 ; <label>:160                                     ; preds = %157
   store i64 %158, i64* %159, align 8
@@ -965,16 +1047,16 @@ entry:
   %163 = load i8*, i8** %arg1
   %164 = getelementptr inbounds i8, i8* %163, i64 8
   %165 = bitcast i8* %164 to i16*
-  %NullCheck72 = icmp ne i16* %165, null
-  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+  %NullCheck71 = icmp eq i16* %165, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %166
 
 ; <label>:166                                     ; preds = %160
   %167 = load i16, i16* %165, align 8
   %168 = sext i16 %167 to i32
   %169 = bitcast i8* %162 to i16*
   %170 = trunc i32 %168 to i16
-  %NullCheck74 = icmp ne i16* %169, null
-  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+  %NullCheck73 = icmp eq i16* %169, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %171
 
 ; <label>:171                                     ; preds = %166
   store i16 %170, i16* %169, align 8
@@ -984,14 +1066,14 @@ entry:
   %173 = load i8*, i8** %arg0
   %174 = load i8*, i8** %arg1
   %175 = bitcast i8* %174 to i64*
-  %NullCheck56 = icmp ne i64* %175, null
-  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+  %NullCheck55 = icmp eq i64* %175, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %176
 
 ; <label>:176                                     ; preds = %172
   %177 = load i64, i64* %175, align 8
   %178 = bitcast i8* %173 to i64*
-  %NullCheck58 = icmp ne i64* %178, null
-  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+  %NullCheck57 = icmp eq i64* %178, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %179
 
 ; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
@@ -1000,16 +1082,16 @@ entry:
   %182 = load i8*, i8** %arg1
   %183 = getelementptr inbounds i8, i8* %182, i64 8
   %184 = bitcast i8* %183 to i16*
-  %NullCheck60 = icmp ne i16* %184, null
-  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+  %NullCheck59 = icmp eq i16* %184, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %185
 
 ; <label>:185                                     ; preds = %179
   %186 = load i16, i16* %184, align 8
   %187 = sext i16 %186 to i32
   %188 = bitcast i8* %181 to i16*
   %189 = trunc i32 %187 to i16
-  %NullCheck62 = icmp ne i16* %188, null
-  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+  %NullCheck61 = icmp eq i16* %188, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %190
 
 ; <label>:190                                     ; preds = %185
   store i16 %189, i16* %188, align 8
@@ -1017,15 +1099,15 @@ entry:
   %192 = getelementptr inbounds i8, i8* %191, i64 10
   %193 = load i8*, i8** %arg1
   %194 = getelementptr inbounds i8, i8* %193, i64 10
-  %NullCheck64 = icmp ne i8* %194, null
-  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+  %NullCheck63 = icmp eq i8* %194, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %195
 
 ; <label>:195                                     ; preds = %190
   %196 = load i8, i8* %194, align 8
   %197 = zext i8 %196 to i32
   %198 = trunc i32 %197 to i8
-  %NullCheck66 = icmp ne i8* %192, null
-  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+  %NullCheck65 = icmp eq i8* %192, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %199
 
 ; <label>:199                                     ; preds = %195
   store i8 %198, i8* %192, align 8
@@ -1035,14 +1117,14 @@ entry:
   %201 = load i8*, i8** %arg0
   %202 = load i8*, i8** %arg1
   %203 = bitcast i8* %202 to i64*
-  %NullCheck48 = icmp ne i64* %203, null
-  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+  %NullCheck47 = icmp eq i64* %203, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %204
 
 ; <label>:204                                     ; preds = %200
   %205 = load i64, i64* %203, align 8
   %206 = bitcast i8* %201 to i64*
-  %NullCheck50 = icmp ne i64* %206, null
-  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+  %NullCheck49 = icmp eq i64* %206, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %207
 
 ; <label>:207                                     ; preds = %204
   store i64 %205, i64* %206, align 8
@@ -1051,14 +1133,14 @@ entry:
   %210 = load i8*, i8** %arg1
   %211 = getelementptr inbounds i8, i8* %210, i64 8
   %212 = bitcast i8* %211 to i32*
-  %NullCheck52 = icmp ne i32* %212, null
-  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+  %NullCheck51 = icmp eq i32* %212, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %213
 
 ; <label>:213                                     ; preds = %207
   %214 = load i32, i32* %212, align 8
   %215 = bitcast i8* %209 to i32*
-  %NullCheck54 = icmp ne i32* %215, null
-  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+  %NullCheck53 = icmp eq i32* %215, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %216
 
 ; <label>:216                                     ; preds = %213
   store i32 %214, i32* %215, align 8
@@ -1068,14 +1150,14 @@ entry:
   %218 = load i8*, i8** %arg0
   %219 = load i8*, i8** %arg1
   %220 = bitcast i8* %219 to i64*
-  %NullCheck36 = icmp ne i64* %220, null
-  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64* %220, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %221
 
 ; <label>:221                                     ; preds = %217
   %222 = load i64, i64* %220, align 8
   %223 = bitcast i8* %218 to i64*
-  %NullCheck38 = icmp ne i64* %223, null
-  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+  %NullCheck37 = icmp eq i64* %223, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %224
 
 ; <label>:224                                     ; preds = %221
   store i64 %222, i64* %223, align 8
@@ -1084,14 +1166,14 @@ entry:
   %227 = load i8*, i8** %arg1
   %228 = getelementptr inbounds i8, i8* %227, i64 8
   %229 = bitcast i8* %228 to i32*
-  %NullCheck40 = icmp ne i32* %229, null
-  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i32* %229, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %230
 
 ; <label>:230                                     ; preds = %224
   %231 = load i32, i32* %229, align 8
   %232 = bitcast i8* %226 to i32*
-  %NullCheck42 = icmp ne i32* %232, null
-  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+  %NullCheck41 = icmp eq i32* %232, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %233
 
 ; <label>:233                                     ; preds = %230
   store i32 %231, i32* %232, align 8
@@ -1099,15 +1181,15 @@ entry:
   %235 = getelementptr inbounds i8, i8* %234, i64 12
   %236 = load i8*, i8** %arg1
   %237 = getelementptr inbounds i8, i8* %236, i64 12
-  %NullCheck44 = icmp ne i8* %237, null
-  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i8* %237, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %238
 
 ; <label>:238                                     ; preds = %233
   %239 = load i8, i8* %237, align 8
   %240 = zext i8 %239 to i32
   %241 = trunc i32 %240 to i8
-  %NullCheck46 = icmp ne i8* %235, null
-  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+  %NullCheck45 = icmp eq i8* %235, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %242
 
 ; <label>:242                                     ; preds = %238
   store i8 %241, i8* %235, align 8
@@ -1117,14 +1199,14 @@ entry:
   %244 = load i8*, i8** %arg0
   %245 = load i8*, i8** %arg1
   %246 = bitcast i8* %245 to i64*
-  %NullCheck24 = icmp ne i64* %246, null
-  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64* %246, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %247
 
 ; <label>:247                                     ; preds = %243
   %248 = load i64, i64* %246, align 8
   %249 = bitcast i8* %244 to i64*
-  %NullCheck26 = icmp ne i64* %249, null
-  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64* %249, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %250
 
 ; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
@@ -1133,14 +1215,14 @@ entry:
   %253 = load i8*, i8** %arg1
   %254 = getelementptr inbounds i8, i8* %253, i64 8
   %255 = bitcast i8* %254 to i32*
-  %NullCheck28 = icmp ne i32* %255, null
-  br i1 %NullCheck28, label %256, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i32* %255, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %256
 
 ; <label>:256                                     ; preds = %250
   %257 = load i32, i32* %255, align 8
   %258 = bitcast i8* %252 to i32*
-  %NullCheck30 = icmp ne i32* %258, null
-  br i1 %NullCheck30, label %259, label %ThrowNullRef29
+  %NullCheck29 = icmp eq i32* %258, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %259
 
 ; <label>:259                                     ; preds = %256
   store i32 %257, i32* %258, align 8
@@ -1149,16 +1231,16 @@ entry:
   %262 = load i8*, i8** %arg1
   %263 = getelementptr inbounds i8, i8* %262, i64 12
   %264 = bitcast i8* %263 to i16*
-  %NullCheck32 = icmp ne i16* %264, null
-  br i1 %NullCheck32, label %265, label %ThrowNullRef31
+  %NullCheck31 = icmp eq i16* %264, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %265
 
 ; <label>:265                                     ; preds = %259
   %266 = load i16, i16* %264, align 8
   %267 = sext i16 %266 to i32
   %268 = bitcast i8* %261 to i16*
   %269 = trunc i32 %267 to i16
-  %NullCheck34 = icmp ne i16* %268, null
-  br i1 %NullCheck34, label %270, label %ThrowNullRef33
+  %NullCheck33 = icmp eq i16* %268, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %270
 
 ; <label>:270                                     ; preds = %265
   store i16 %269, i16* %268, align 8
@@ -1168,14 +1250,14 @@ entry:
   %272 = load i8*, i8** %arg0
   %273 = load i8*, i8** %arg1
   %274 = bitcast i8* %273 to i64*
-  %NullCheck8 = icmp ne i64* %274, null
-  br i1 %NullCheck8, label %275, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64* %274, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %275
 
 ; <label>:275                                     ; preds = %271
   %276 = load i64, i64* %274, align 8
   %277 = bitcast i8* %272 to i64*
-  %NullCheck10 = icmp ne i64* %277, null
-  br i1 %NullCheck10, label %278, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %277, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %278
 
 ; <label>:278                                     ; preds = %275
   store i64 %276, i64* %277, align 8
@@ -1184,14 +1266,14 @@ entry:
   %281 = load i8*, i8** %arg1
   %282 = getelementptr inbounds i8, i8* %281, i64 8
   %283 = bitcast i8* %282 to i32*
-  %NullCheck12 = icmp ne i32* %283, null
-  br i1 %NullCheck12, label %284, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i32* %283, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %284
 
 ; <label>:284                                     ; preds = %278
   %285 = load i32, i32* %283, align 8
   %286 = bitcast i8* %280 to i32*
-  %NullCheck14 = icmp ne i32* %286, null
-  br i1 %NullCheck14, label %287, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i32* %286, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %287
 
 ; <label>:287                                     ; preds = %284
   store i32 %285, i32* %286, align 8
@@ -1200,16 +1282,16 @@ entry:
   %290 = load i8*, i8** %arg1
   %291 = getelementptr inbounds i8, i8* %290, i64 12
   %292 = bitcast i8* %291 to i16*
-  %NullCheck16 = icmp ne i16* %292, null
-  br i1 %NullCheck16, label %293, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i16* %292, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %293
 
 ; <label>:293                                     ; preds = %287
   %294 = load i16, i16* %292, align 8
   %295 = sext i16 %294 to i32
   %296 = bitcast i8* %289 to i16*
   %297 = trunc i32 %295 to i16
-  %NullCheck18 = icmp ne i16* %296, null
-  br i1 %NullCheck18, label %298, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i16* %296, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %298
 
 ; <label>:298                                     ; preds = %293
   store i16 %297, i16* %296, align 8
@@ -1217,15 +1299,15 @@ entry:
   %300 = getelementptr inbounds i8, i8* %299, i64 14
   %301 = load i8*, i8** %arg1
   %302 = getelementptr inbounds i8, i8* %301, i64 14
-  %NullCheck20 = icmp ne i8* %302, null
-  br i1 %NullCheck20, label %303, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i8* %302, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %303
 
 ; <label>:303                                     ; preds = %298
   %304 = load i8, i8* %302, align 8
   %305 = zext i8 %304 to i32
   %306 = trunc i32 %305 to i8
-  %NullCheck22 = icmp ne i8* %300, null
-  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i8* %300, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %307
 
 ; <label>:307                                     ; preds = %303
   store i8 %306, i8* %300, align 8
@@ -1235,14 +1317,14 @@ entry:
   %309 = load i8*, i8** %arg0
   %310 = load i8*, i8** %arg1
   %311 = bitcast i8* %310 to i64*
-  %NullCheck = icmp ne i64* %311, null
-  br i1 %NullCheck, label %312, label %ThrowNullRef
+  %NullCheck = icmp eq i64* %311, null
+  br i1 %NullCheck, label %ThrowNullRef, label %312
 
 ; <label>:312                                     ; preds = %308
   %313 = load i64, i64* %311, align 8
   %314 = bitcast i8* %309 to i64*
-  %NullCheck2 = icmp ne i64* %314, null
-  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64* %314, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %315
 
 ; <label>:315                                     ; preds = %312
   store i64 %313, i64* %314, align 8
@@ -1251,14 +1333,14 @@ entry:
   %318 = load i8*, i8** %arg1
   %319 = getelementptr inbounds i8, i8* %318, i64 8
   %320 = bitcast i8* %319 to i64*
-  %NullCheck4 = icmp ne i64* %320, null
-  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64* %320, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %321
 
 ; <label>:321                                     ; preds = %315
   %322 = load i64, i64* %320, align 8
   %323 = bitcast i8* %317 to i64*
-  %NullCheck6 = icmp ne i64* %323, null
-  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64* %323, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %324
 
 ; <label>:324                                     ; preds = %321
   store i64 %322, i64* %323, align 8
@@ -1286,15 +1368,15 @@ entry:
 ; <label>:338                                     ; preds = %333
   %339 = load i8*, i8** %arg0
   %340 = load i8*, i8** %arg1
-  %NullCheck136 = icmp ne i8* %340, null
-  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+  %NullCheck135 = icmp eq i8* %340, null
+  br i1 %NullCheck135, label %ThrowNullRef136, label %341
 
 ; <label>:341                                     ; preds = %338
   %342 = load i8, i8* %340, align 8
   %343 = zext i8 %342 to i32
   %344 = trunc i32 %343 to i8
-  %NullCheck138 = icmp ne i8* %339, null
-  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+  %NullCheck137 = icmp eq i8* %339, null
+  br i1 %NullCheck137, label %ThrowNullRef138, label %345
 
 ; <label>:345                                     ; preds = %341
   store i8 %344, i8* %339, align 8
@@ -1317,16 +1399,16 @@ entry:
   %357 = load i8*, i8** %arg0
   %358 = load i8*, i8** %arg1
   %359 = bitcast i8* %358 to i16*
-  %NullCheck140 = icmp ne i16* %359, null
-  br i1 %NullCheck140, label %360, label %ThrowNullRef139
+  %NullCheck139 = icmp eq i16* %359, null
+  br i1 %NullCheck139, label %ThrowNullRef140, label %360
 
 ; <label>:360                                     ; preds = %356
   %361 = load i16, i16* %359, align 8
   %362 = sext i16 %361 to i32
   %363 = bitcast i8* %357 to i16*
   %364 = trunc i32 %362 to i16
-  %NullCheck142 = icmp ne i16* %363, null
-  br i1 %NullCheck142, label %365, label %ThrowNullRef141
+  %NullCheck141 = icmp eq i16* %363, null
+  br i1 %NullCheck141, label %ThrowNullRef142, label %365
 
 ; <label>:365                                     ; preds = %360
   store i16 %364, i16* %363, align 8
@@ -1352,14 +1434,14 @@ entry:
   %378 = load i8*, i8** %arg0
   %379 = load i8*, i8** %arg1
   %380 = bitcast i8* %379 to i32*
-  %NullCheck144 = icmp ne i32* %380, null
-  br i1 %NullCheck144, label %381, label %ThrowNullRef143
+  %NullCheck143 = icmp eq i32* %380, null
+  br i1 %NullCheck143, label %ThrowNullRef144, label %381
 
 ; <label>:381                                     ; preds = %377
   %382 = load i32, i32* %380, align 8
   %383 = bitcast i8* %378 to i32*
-  %NullCheck146 = icmp ne i32* %383, null
-  br i1 %NullCheck146, label %384, label %ThrowNullRef145
+  %NullCheck145 = icmp eq i32* %383, null
+  br i1 %NullCheck145, label %ThrowNullRef146, label %384
 
 ; <label>:384                                     ; preds = %381
   store i32 %382, i32* %383, align 8
@@ -1384,14 +1466,14 @@ entry:
   %395 = load i8*, i8** %arg0
   %396 = load i8*, i8** %arg1
   %397 = bitcast i8* %396 to i64*
-  %NullCheck164 = icmp ne i64* %397, null
-  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+  %NullCheck163 = icmp eq i64* %397, null
+  br i1 %NullCheck163, label %ThrowNullRef164, label %398
 
 ; <label>:398                                     ; preds = %394
   %399 = load i64, i64* %397, align 8
   %400 = bitcast i8* %395 to i64*
-  %NullCheck166 = icmp ne i64* %400, null
-  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+  %NullCheck165 = icmp eq i64* %400, null
+  br i1 %NullCheck165, label %ThrowNullRef166, label %401
 
 ; <label>:401                                     ; preds = %398
   store i64 %399, i64* %400, align 8
@@ -1400,14 +1482,14 @@ entry:
   %404 = load i8*, i8** %arg1
   %405 = getelementptr inbounds i8, i8* %404, i64 8
   %406 = bitcast i8* %405 to i64*
-  %NullCheck168 = icmp ne i64* %406, null
-  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+  %NullCheck167 = icmp eq i64* %406, null
+  br i1 %NullCheck167, label %ThrowNullRef168, label %407
 
 ; <label>:407                                     ; preds = %401
   %408 = load i64, i64* %406, align 8
   %409 = bitcast i8* %403 to i64*
-  %NullCheck170 = icmp ne i64* %409, null
-  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+  %NullCheck169 = icmp eq i64* %409, null
+  br i1 %NullCheck169, label %ThrowNullRef170, label %410
 
 ; <label>:410                                     ; preds = %407
   store i64 %408, i64* %409, align 8
@@ -1437,14 +1519,14 @@ entry:
   %425 = load i8*, i8** %arg0
   %426 = load i8*, i8** %arg1
   %427 = bitcast i8* %426 to i64*
-  %NullCheck148 = icmp ne i64* %427, null
-  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+  %NullCheck147 = icmp eq i64* %427, null
+  br i1 %NullCheck147, label %ThrowNullRef148, label %428
 
 ; <label>:428                                     ; preds = %424
   %429 = load i64, i64* %427, align 8
   %430 = bitcast i8* %425 to i64*
-  %NullCheck150 = icmp ne i64* %430, null
-  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+  %NullCheck149 = icmp eq i64* %430, null
+  br i1 %NullCheck149, label %ThrowNullRef150, label %431
 
 ; <label>:431                                     ; preds = %428
   store i64 %429, i64* %430, align 8
@@ -1466,14 +1548,14 @@ entry:
   %441 = load i8*, i8** %arg0
   %442 = load i8*, i8** %arg1
   %443 = bitcast i8* %442 to i32*
-  %NullCheck152 = icmp ne i32* %443, null
-  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+  %NullCheck151 = icmp eq i32* %443, null
+  br i1 %NullCheck151, label %ThrowNullRef152, label %444
 
 ; <label>:444                                     ; preds = %440
   %445 = load i32, i32* %443, align 8
   %446 = bitcast i8* %441 to i32*
-  %NullCheck154 = icmp ne i32* %446, null
-  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+  %NullCheck153 = icmp eq i32* %446, null
+  br i1 %NullCheck153, label %ThrowNullRef154, label %447
 
 ; <label>:447                                     ; preds = %444
   store i32 %445, i32* %446, align 8
@@ -1495,16 +1577,16 @@ entry:
   %457 = load i8*, i8** %arg0
   %458 = load i8*, i8** %arg1
   %459 = bitcast i8* %458 to i16*
-  %NullCheck156 = icmp ne i16* %459, null
-  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+  %NullCheck155 = icmp eq i16* %459, null
+  br i1 %NullCheck155, label %ThrowNullRef156, label %460
 
 ; <label>:460                                     ; preds = %456
   %461 = load i16, i16* %459, align 8
   %462 = sext i16 %461 to i32
   %463 = bitcast i8* %457 to i16*
   %464 = trunc i32 %462 to i16
-  %NullCheck158 = icmp ne i16* %463, null
-  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+  %NullCheck157 = icmp eq i16* %463, null
+  br i1 %NullCheck157, label %ThrowNullRef158, label %465
 
 ; <label>:465                                     ; preds = %460
   store i16 %464, i16* %463, align 8
@@ -1525,15 +1607,15 @@ entry:
 ; <label>:474                                     ; preds = %470
   %475 = load i8*, i8** %arg0
   %476 = load i8*, i8** %arg1
-  %NullCheck160 = icmp ne i8* %476, null
-  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+  %NullCheck159 = icmp eq i8* %476, null
+  br i1 %NullCheck159, label %ThrowNullRef160, label %477
 
 ; <label>:477                                     ; preds = %474
   %478 = load i8, i8* %476, align 8
   %479 = zext i8 %478 to i32
   %480 = trunc i32 %479 to i8
-  %NullCheck162 = icmp ne i8* %475, null
-  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+  %NullCheck161 = icmp eq i8* %475, null
+  br i1 %NullCheck161, label %ThrowNullRef162, label %481
 
 ; <label>:481                                     ; preds = %477
   store i8 %480, i8* %475, align 8
@@ -1553,343 +1635,343 @@ ThrowNullRef:                                     ; preds = %308
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %312
+ThrowNullRef2:                                    ; preds = %312
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %315
+ThrowNullRef4:                                    ; preds = %315
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %321
+ThrowNullRef6:                                    ; preds = %321
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %271
+ThrowNullRef8:                                    ; preds = %271
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %275
+ThrowNullRef10:                                   ; preds = %275
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %278
+ThrowNullRef12:                                   ; preds = %278
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %284
+ThrowNullRef14:                                   ; preds = %284
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %287
+ThrowNullRef16:                                   ; preds = %287
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %293
+ThrowNullRef18:                                   ; preds = %293
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %298
+ThrowNullRef20:                                   ; preds = %298
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %303
+ThrowNullRef22:                                   ; preds = %303
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %243
+ThrowNullRef24:                                   ; preds = %243
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %247
+ThrowNullRef26:                                   ; preds = %247
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %250
+ThrowNullRef28:                                   ; preds = %250
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %256
+ThrowNullRef30:                                   ; preds = %256
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %259
+ThrowNullRef32:                                   ; preds = %259
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %265
+ThrowNullRef34:                                   ; preds = %265
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %217
+ThrowNullRef36:                                   ; preds = %217
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %221
+ThrowNullRef38:                                   ; preds = %221
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %224
+ThrowNullRef40:                                   ; preds = %224
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %230
+ThrowNullRef42:                                   ; preds = %230
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %233
+ThrowNullRef44:                                   ; preds = %233
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %238
+ThrowNullRef46:                                   ; preds = %238
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %200
+ThrowNullRef48:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %204
+ThrowNullRef50:                                   ; preds = %204
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %207
+ThrowNullRef52:                                   ; preds = %207
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %213
+ThrowNullRef54:                                   ; preds = %213
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %172
+ThrowNullRef56:                                   ; preds = %172
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %176
+ThrowNullRef58:                                   ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %179
+ThrowNullRef60:                                   ; preds = %179
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %185
+ThrowNullRef62:                                   ; preds = %185
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %190
+ThrowNullRef64:                                   ; preds = %190
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %195
+ThrowNullRef66:                                   ; preds = %195
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %153
+ThrowNullRef68:                                   ; preds = %153
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %157
+ThrowNullRef70:                                   ; preds = %157
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %160
+ThrowNullRef72:                                   ; preds = %160
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %166
+ThrowNullRef74:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %136
+ThrowNullRef76:                                   ; preds = %136
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %140
+ThrowNullRef78:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %143
+ThrowNullRef80:                                   ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %148
+ThrowNullRef82:                                   ; preds = %148
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %128
+ThrowNullRef84:                                   ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %132
+ThrowNullRef86:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %100
+ThrowNullRef88:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %104
+ThrowNullRef90:                                   ; preds = %104
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %107
+ThrowNullRef92:                                   ; preds = %107
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %113
+ThrowNullRef94:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %118
+ThrowNullRef96:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %123
+ThrowNullRef98:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %81
+ThrowNullRef100:                                  ; preds = %81
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef101:                                  ; preds = %85
+ThrowNullRef102:                                  ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef103:                                  ; preds = %88
+ThrowNullRef104:                                  ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef105:                                  ; preds = %94
+ThrowNullRef106:                                  ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef107:                                  ; preds = %64
+ThrowNullRef108:                                  ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef109:                                  ; preds = %68
+ThrowNullRef110:                                  ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef111:                                  ; preds = %71
+ThrowNullRef112:                                  ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef113:                                  ; preds = %76
+ThrowNullRef114:                                  ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef115:                                  ; preds = %56
+ThrowNullRef116:                                  ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef117:                                  ; preds = %60
+ThrowNullRef118:                                  ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef119:                                  ; preds = %37
+ThrowNullRef120:                                  ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef121:                                  ; preds = %41
+ThrowNullRef122:                                  ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef123:                                  ; preds = %46
+ThrowNullRef124:                                  ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef125:                                  ; preds = %51
+ThrowNullRef126:                                  ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef127:                                  ; preds = %27
+ThrowNullRef128:                                  ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef129:                                  ; preds = %31
+ThrowNullRef130:                                  ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef131:                                  ; preds = %19
+ThrowNullRef132:                                  ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef133:                                  ; preds = %22
+ThrowNullRef134:                                  ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef135:                                  ; preds = %338
+ThrowNullRef136:                                  ; preds = %338
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef137:                                  ; preds = %341
+ThrowNullRef138:                                  ; preds = %341
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef139:                                  ; preds = %356
+ThrowNullRef140:                                  ; preds = %356
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef141:                                  ; preds = %360
+ThrowNullRef142:                                  ; preds = %360
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef143:                                  ; preds = %377
+ThrowNullRef144:                                  ; preds = %377
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef145:                                  ; preds = %381
+ThrowNullRef146:                                  ; preds = %381
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef147:                                  ; preds = %424
+ThrowNullRef148:                                  ; preds = %424
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef149:                                  ; preds = %428
+ThrowNullRef150:                                  ; preds = %428
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef151:                                  ; preds = %440
+ThrowNullRef152:                                  ; preds = %440
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef153:                                  ; preds = %444
+ThrowNullRef154:                                  ; preds = %444
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef155:                                  ; preds = %456
+ThrowNullRef156:                                  ; preds = %456
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef157:                                  ; preds = %460
+ThrowNullRef158:                                  ; preds = %460
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef159:                                  ; preds = %474
+ThrowNullRef160:                                  ; preds = %474
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef161:                                  ; preds = %477
+ThrowNullRef162:                                  ; preds = %477
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef163:                                  ; preds = %394
+ThrowNullRef164:                                  ; preds = %394
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef165:                                  ; preds = %398
+ThrowNullRef166:                                  ; preds = %398
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef167:                                  ; preds = %401
+ThrowNullRef168:                                  ; preds = %401
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef169:                                  ; preds = %407
+ThrowNullRef170:                                  ; preds = %407
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1939,8 +2021,8 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
-  br i1 %NullCheck, label %22, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %ThrowNullRef, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
@@ -1948,8 +2030,8 @@ entry:
   store i32 %24, i32* %loc0
   %25 = load i32, i32* %loc0
   %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %26, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %27
 
 ; <label>:27                                      ; preds = %22
   %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
@@ -1971,7 +2053,7 @@ ThrowNullRef:                                     ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1989,8 +2071,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -2022,15 +2104,15 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2048,16 +2130,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
   %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
   store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %15
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
@@ -2072,8 +2154,8 @@ entry:
   %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
   %29 = ptrtoint i16 addrspace(1)* %28 to i64
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %19
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
@@ -2089,19 +2171,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2114,8 +2196,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
@@ -2128,7 +2210,7 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[loadElem]
+Failed to read AppDomain.PrepareDataForSetup[storeElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
@@ -2202,8 +2284,8 @@ entry:
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
-  br i1 %NullCheck24, label %27, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = load i64, i64 addrspace(1)* %26
@@ -2218,8 +2300,8 @@ entry:
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
-  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
   %41 = load i64, i64 addrspace(1)* %39
@@ -2236,8 +2318,8 @@ entry:
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
-  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
   %54 = load i64, i64 addrspace(1)* %52
@@ -2252,8 +2334,8 @@ entry:
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
   %67 = load i64, i64 addrspace(1)* %65
@@ -2270,8 +2352,8 @@ entry:
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
-  br i1 %NullCheck16, label %79, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
   %80 = load i64, i64 addrspace(1)* %78
@@ -2286,8 +2368,8 @@ entry:
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
-  br i1 %NullCheck18, label %92, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
   %93 = load i64, i64 addrspace(1)* %91
@@ -2304,8 +2386,8 @@ entry:
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
-  br i1 %NullCheck12, label %105, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = load i64, i64 addrspace(1)* %104
@@ -2320,8 +2402,8 @@ entry:
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
-  br i1 %NullCheck14, label %118, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
   %119 = load i64, i64 addrspace(1)* %117
@@ -2337,8 +2419,8 @@ entry:
 
 ; <label>:128                                     ; preds = %20
   %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
-  br i1 %NullCheck4, label %130, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %129, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %130
 
 ; <label>:130                                     ; preds = %128
   %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
@@ -2346,8 +2428,8 @@ entry:
   %133 = load i16, i16 addrspace(1)* %132, align 8
   %134 = zext i16 %133 to i32
   %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
-  br i1 %NullCheck6, label %136, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %135, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %136
 
 ; <label>:136                                     ; preds = %130
   %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
@@ -2360,8 +2442,8 @@ entry:
 
 ; <label>:143                                     ; preds = %136
   %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
-  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %144, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %145
 
 ; <label>:145                                     ; preds = %143
   %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
@@ -2369,8 +2451,8 @@ entry:
   %148 = load i16, i16 addrspace(1)* %147, align 8
   %149 = zext i16 %148 to i32
   %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %150, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %151
 
 ; <label>:151                                     ; preds = %145
   %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
@@ -2388,8 +2470,8 @@ entry:
 
 ; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
-  br i1 %NullCheck, label %163, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %ThrowNullRef, label %163
 
 ; <label>:163                                     ; preds = %161
   %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
@@ -2399,8 +2481,8 @@ entry:
 
 ; <label>:167                                     ; preds = %163
   %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
-  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %168, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %169
 
 ; <label>:169                                     ; preds = %167
   %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
@@ -2432,55 +2514,55 @@ ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %167
+ThrowNullRef2:                                    ; preds = %167
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %128
+ThrowNullRef4:                                    ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %130
+ThrowNullRef6:                                    ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %143
+ThrowNullRef8:                                    ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %145
+ThrowNullRef10:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %102
+ThrowNullRef12:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %105
+ThrowNullRef14:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %76
+ThrowNullRef16:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %79
+ThrowNullRef18:                                   ; preds = %79
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %50
+ThrowNullRef20:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %53
+ThrowNullRef22:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %24
+ThrowNullRef24:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %27
+ThrowNullRef26:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2503,15 +2585,15 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2519,16 +2601,16 @@ entry:
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
   store i32 %8, i32* %loc0
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
   %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
   store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
@@ -2546,16 +2628,16 @@ entry:
 
 ; <label>:23                                      ; preds = %64
   %24 = load i16*, i16** %loc3
-  %NullCheck12 = icmp ne i16* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i16* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
   store i32 %27, i32* %loc5
   %28 = load i16*, i16** %loc4
-  %NullCheck14 = icmp ne i16* %28, null
-  br i1 %NullCheck14, label %29, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %28, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = load i16, i16* %28, align 8
@@ -2620,15 +2702,15 @@ entry:
 
 ; <label>:67                                      ; preds = %64
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
-  br i1 %NullCheck8, label %69, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %68, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %69
 
 ; <label>:69                                      ; preds = %67
   %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
   %71 = load i32, i32 addrspace(1)* %70
   %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
-  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %73
 
 ; <label>:73                                      ; preds = %69
   %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
@@ -2645,31 +2727,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %67
+ThrowNullRef8:                                    ; preds = %67
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %69
+ThrowNullRef10:                                   ; preds = %69
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2710,14 +2792,14 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
   %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
@@ -2730,14 +2812,14 @@ entry:
 
 ; <label>:11                                      ; preds = %4
   %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
   %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
@@ -2749,14 +2831,14 @@ entry:
 
 ; <label>:22                                      ; preds = %16
   %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
   %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
-  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
-  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
@@ -2804,23 +2886,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2836,7 +2918,280 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[loadElem]
+Successfully read RuntimeType.IsAssignableFrom
+
+define i8 @RuntimeType.IsAssignableFrom(%System.RuntimeType addrspace(1)* %param0, %System.Type addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.RuntimeType addrspace(1)*
+  %arg1 = alloca %System.Type addrspace(1)*
+  %loc0 = alloca %System.RuntimeType addrspace(1)*
+  %loc1 = alloca %"System.Type[]" addrspace(1)*
+  %loc2 = alloca i32
+  store %System.RuntimeType addrspace(1)* %param0, %System.RuntimeType addrspace(1)** %this
+  store %System.Type addrspace(1)* %param1, %System.Type addrspace(1)** %arg1
+  %0 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %1 = icmp ne %System.Type addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i8 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %5 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %6 = bitcast %System.Type addrspace(1)* %4 to %System.Object addrspace(1)*
+  %7 = bitcast %System.RuntimeType addrspace(1)* %5 to %System.Object addrspace(1)*
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %6, %System.Object addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %3
+  ret i8 1
+
+; <label>:12                                      ; preds = %3
+  %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 152
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 32
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
+  %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
+  %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
+  store %System.RuntimeType addrspace(1)* %25, %System.RuntimeType addrspace(1)** %loc0
+  %26 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %27 = icmp eq %System.RuntimeType addrspace(1)* %26, null
+  br i1 %27, label %34, label %28
+
+; <label>:28                                      ; preds = %15
+  %29 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %30 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)*)*)(%System.RuntimeType addrspace(1)* %29, %System.RuntimeType addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+; <label>:34                                      ; preds = %15
+  %35 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %36 = call %System.Reflection.Emit.TypeBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Reflection.Emit.TypeBuilder addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %35)
+  %37 = icmp eq %System.Reflection.Emit.TypeBuilder addrspace(1)* %36, null
+  br i1 %37, label %139, label %38
+
+; <label>:38                                      ; preds = %34
+  %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %42
+
+; <label>:42                                      ; preds = %38
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 152
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 40
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
+  %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
+  %53 = zext i8 %52 to i32
+  %54 = icmp eq i32 %53, 0
+  br i1 %54, label %56, label %55
+
+; <label>:55                                      ; preds = %42
+  ret i8 1
+
+; <label>:56                                      ; preds = %42
+  %57 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %58 = bitcast %System.RuntimeType addrspace(1)* %57 to %System.Type addrspace(1)*
+  %59 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %58)
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %64 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.Type addrspace(1)* %63, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = bitcast %System.RuntimeType addrspace(1)* %64 to %System.Type addrspace(1)*
+  %67 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %63, %System.Type addrspace(1)* %66)
+  %68 = zext i8 %67 to i32
+  %69 = trunc i32 %68 to i8
+  ret i8 %69
+
+; <label>:70                                      ; preds = %56
+  %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
+  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %73
+
+; <label>:73                                      ; preds = %70
+  %74 = load i64, i64 addrspace(1)* %72
+  %75 = add i64 %74, 128
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = add i64 %77, 0
+  %79 = inttoptr i64 %78 to i64*
+  %80 = load i64, i64* %79
+  %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
+  %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
+  %83 = call i8 %82(%System.Type addrspace(1)* %81)
+  %84 = zext i8 %83 to i32
+  %85 = icmp eq i32 %84, 0
+  br i1 %85, label %139, label %86
+
+; <label>:86                                      ; preds = %73
+  %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
+  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %89
+
+; <label>:89                                      ; preds = %86
+  %90 = load i64, i64 addrspace(1)* %88
+  %91 = add i64 %90, 128
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = add i64 %93, 24
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
+  %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
+  %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
+  store %"System.Type[]" addrspace(1)* %99, %"System.Type[]" addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %129
+
+; <label>:100                                     ; preds = %132
+  %101 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %102 = load i32, i32* %loc2
+  %NullCheck11 = icmp eq %"System.Type[]" addrspace(1)* %101, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %103
+
+; <label>:103                                     ; preds = %100
+  %104 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 1
+  %105 = load i32, i32 addrspace(1)* %104
+  %106 = zext i32 %105 to i64
+  %107 = zext i32 %102 to i64
+  %BoundsCheck = icmp uge i64 %107, %106
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %108
+
+; <label>:108                                     ; preds = %103
+  %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
+  %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
+  %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
+  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %113
+
+; <label>:113                                     ; preds = %108
+  %114 = load i64, i64 addrspace(1)* %112
+  %115 = add i64 %114, 152
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = add i64 %117, 56
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
+  %123 = zext i8 %122 to i32
+  %124 = icmp ne i32 %123, 0
+  br i1 %124, label %126, label %125
+
+; <label>:125                                     ; preds = %113
+  ret i8 0
+
+; <label>:126                                     ; preds = %113
+  %127 = load i32, i32* %loc2
+  %128 = add i32 %127, 1
+  store i32 %128, i32* %loc2
+  br label %129
+
+; <label>:129                                     ; preds = %89, %126
+  %130 = load i32, i32* %loc2
+  %131 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %NullCheck9 = icmp eq %"System.Type[]" addrspace(1)* %131, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %132
+
+; <label>:132                                     ; preds = %129
+  %133 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %131, i32 0, i32 1
+  %134 = load i32, i32 addrspace(1)* %133
+  %135 = zext i32 %134 to i64
+  %136 = trunc i64 %135 to i32
+  %137 = icmp slt i32 %130, %136
+  br i1 %137, label %100, label %138
+
+; <label>:138                                     ; preds = %132
+  ret i8 1
+
+; <label>:139                                     ; preds = %34, %73
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %129
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %103
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -2893,7 +3248,7 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElem]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -2904,8 +3259,8 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -2997,8 +3352,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
@@ -3059,8 +3414,8 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -3087,8 +3442,8 @@ entry:
 
 ; <label>:17                                      ; preds = %5, %11
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
@@ -3097,8 +3452,8 @@ entry:
 
 ; <label>:22                                      ; preds = %1, %11
   %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
@@ -3109,11 +3464,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %17
+ThrowNullRef2:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %22
+ThrowNullRef4:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3167,15 +3522,15 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
   %15 = load i32, i32 addrspace(1)* %14
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
@@ -3198,7 +3553,7 @@ ThrowNullRef:                                     ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef2:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3232,8 +3587,8 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
@@ -3312,8 +3667,8 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -3327,8 +3682,8 @@ entry:
 ; <label>:5                                       ; preds = %43
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %7 = load i32, i32* %loc1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck6, label %8, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
@@ -3366,8 +3721,8 @@ entry:
 ; <label>:32                                      ; preds = %21, %25
   %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
   %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
-  br i1 %NullCheck8, label %35, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = trunc i32 %34 to i16
@@ -3380,8 +3735,8 @@ entry:
 ; <label>:40                                      ; preds = %1, %35
   %41 = load i32, i32* %loc1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
-  br i1 %NullCheck2, label %43, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %42, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
@@ -3392,8 +3747,8 @@ entry:
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
   %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
-  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
   %51 = load i64, i64 addrspace(1)* %49
@@ -3412,19 +3767,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %40
+ThrowNullRef2:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %47
+ThrowNullRef4:                                    ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %5
+ThrowNullRef6:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %32
+ThrowNullRef8:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3467,8 +3822,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
@@ -3492,11 +3847,391 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(i16* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store i16* %param0, i16** %arg0
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load i32, i32* %arg3
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %42, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %37, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg2
+  %13 = load i32, i32* %arg3
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %37, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %24 = load i32, i32* %arg2
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load i16*, i16** %arg0
+  %35 = load i32, i32* %arg3
+  %36 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %36, i16* %34, i32 %35)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:37                                      ; preds = %5, %16
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %39)
+  %41 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41, %System.String addrspace(1)* %38, %System.String addrspace(1)* %40)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41) #0
+  unreachable
+
+; <label>:42                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
-Failed to read StringBuilder.ToString[loadElemA]
+Successfully read StringBuilder.ToString
+
+define %System.String addrspace(1)* @StringBuilder.ToString(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i16*
+  %loc3 = alloca %"System.Char[]" addrspace(1)*
+  %loc4 = alloca i32
+  %loc5 = alloca i32
+  %loc6 = alloca i16 addrspace(1)*
+  %loc7 = alloca %System.String addrspace(1)*
+  %loc8 = alloca %"System.Char[]" addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %0)
+  %2 = icmp ne i32 %1, 0
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %4
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %6)
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %7)
+  store %System.String addrspace(1)* %8, %System.String addrspace(1)** %loc0
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.Text.StringBuilder addrspace(1)* %9, %System.Text.StringBuilder addrspace(1)** %loc1
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  store %System.String addrspace(1)* %10, %System.String addrspace(1)** %loc7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc7
+  %12 = ptrtoint %System.String addrspace(1)* %11 to i64
+  %13 = icmp eq i64 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %5
+  %15 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %16 = sext i32 %15 to i64
+  %17 = add i64 %12, %16
+  br label %18
+
+; <label>:18                                      ; preds = %5, %14
+  %19 = phi i64 [ %12, %5 ], [ %17, %14 ]
+  %20 = inttoptr i64 %19 to i16*
+  store i16* %20, i16** %loc2
+  br label %21
+
+; <label>:21                                      ; preds = %98, %18
+  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %22, null
+  br i1 %NullCheck, label %ThrowNullRef, label %23
+
+; <label>:23                                      ; preds = %21
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 3
+  %25 = load i32, i32 addrspace(1)* %24, align 8
+  %26 = icmp sle i32 %25, 0
+  br i1 %26, label %96, label %27
+
+; <label>:27                                      ; preds = %23
+  %28 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %28, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %29
+
+; <label>:29                                      ; preds = %27
+  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %28, i32 0, i32 1
+  %31 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %30, align 8
+  store %"System.Char[]" addrspace(1)* %31, %"System.Char[]" addrspace(1)** %loc3
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %33
+
+; <label>:33                                      ; preds = %29
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  store i32 %35, i32* %loc4
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  %39 = load i32, i32 addrspace(1)* %38, align 8
+  store i32 %39, i32* %loc5
+  %40 = load i32, i32* %loc5
+  %41 = load i32, i32* %loc4
+  %42 = add i32 %40, %41
+  %43 = zext i32 %42 to i64
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %45
+
+; <label>:45                                      ; preds = %37
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = sext i32 %47 to i64
+  %49 = icmp sgt i64 %43, %48
+  br i1 %49, label %91, label %50
+
+; <label>:50                                      ; preds = %45
+  %51 = load i32, i32* %loc5
+  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %52, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %53
+
+; <label>:53                                      ; preds = %50
+  %54 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %52, i32 0, i32 1
+  %55 = load i32, i32 addrspace(1)* %54
+  %56 = zext i32 %55 to i64
+  %57 = trunc i64 %56 to i32
+  %58 = icmp ugt i32 %51, %57
+  br i1 %58, label %91, label %59
+
+; <label>:59                                      ; preds = %53
+  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  store %"System.Char[]" addrspace(1)* %60, %"System.Char[]" addrspace(1)** %loc8
+  %61 = icmp eq %"System.Char[]" addrspace(1)* %60, null
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %63, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %64
+
+; <label>:64                                      ; preds = %62
+  %65 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %63, i32 0, i32 1
+  %66 = load i32, i32 addrspace(1)* %65
+  %67 = zext i32 %66 to i64
+  %68 = trunc i64 %67 to i32
+  %69 = icmp ne i32 %68, 0
+  br i1 %69, label %71, label %70
+
+; <label>:70                                      ; preds = %59, %64
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:71                                      ; preds = %64
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %73
+
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %BoundsCheck = icmp uge i64 0, %76
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %77
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %78, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:79                                      ; preds = %70, %77
+  %80 = load i16*, i16** %loc2
+  %81 = load i32, i32* %loc4
+  %82 = sext i32 %81 to i64
+  %83 = mul i64 %82, 2
+  %84 = bitcast i16* %80 to i8*
+  %85 = getelementptr inbounds i8, i8* %84, i64 %83
+  %86 = load i16 addrspace(1)*, i16 addrspace(1)** %loc6
+  %87 = ptrtoint i16 addrspace(1)* %86 to i64
+  %88 = load i32, i32* %loc5
+  %89 = bitcast i8* %85 to i16*
+  %90 = inttoptr i64 %87 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %89, i16* %90, i32 %88)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %96
+
+; <label>:91                                      ; preds = %45, %53
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %94 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %93)
+  %95 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95, %System.String addrspace(1)* %92, %System.String addrspace(1)* %94)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95) #0
+  unreachable
+
+; <label>:96                                      ; preds = %23, %79
+  %97 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %97, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %98
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %97, i32 0, i32 2
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  store %System.Text.StringBuilder addrspace(1)* %100, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %102 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %102, label %21, label %103
+
+; <label>:103                                     ; preds = %98
+  store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc7
+  %104 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  ret %System.String addrspace(1)* %104
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method StringBuilder::get_Length using LLILCJit
+Successfully read StringBuilder.get_Length
+
+define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
+Successfully read RuntimeHelpers.get_OffsetToStringData
+
+define i32 @RuntimeHelpers.get_OffsetToStringData() {
+entry:
+  ret i32 12
+}
+
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
 Successfully read CultureData.CreateCultureData
 
@@ -3514,23 +4249,23 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
   store i8 %4, i8 addrspace(1)* %6
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
@@ -3549,11 +4284,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3566,50 +4301,50 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
   store i32 -1, i32 addrspace(1)* %2
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
   store i32 -1, i32 addrspace(1)* %8
   %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
   store i32 -1, i32 addrspace(1)* %14
   %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
   store i32 -1, i32 addrspace(1)* %17
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
@@ -3623,27 +4358,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3675,7 +4410,136 @@ Failed to read Dictionary`2.Insert[non-const derefAddress]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
 Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
-Failed to read HashHelpers.GetPrime[loadElem]
+Successfully read HashHelpers.GetPrime
+
+define i32 @HashHelpers.GetPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %6, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5, %System.String addrspace(1)* %4)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5) #0
+  unreachable
+
+; <label>:6                                       ; preds = %entry
+  store i32 0, i32* %loc0
+  br label %29
+
+; <label>:7                                       ; preds = %35
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 1296
+  %10 = addrspacecast i8 addrspace(1)* %9 to %"System.Int32[]" addrspace(1)**
+  %11 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %10
+  %12 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Int32[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = zext i32 %15 to i64
+  %17 = zext i32 %12 to i64
+  %BoundsCheck = icmp uge i64 %17, %16
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 3, i32 %12
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  store i32 %20, i32* %loc1
+  %21 = load i32, i32* %loc1
+  %22 = load i32, i32* %arg0
+  %23 = icmp slt i32 %21, %22
+  br i1 %23, label %26, label %24
+
+; <label>:24                                      ; preds = %18
+  %25 = load i32, i32* %loc1
+  ret i32 %25
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %loc0
+  %28 = add i32 %27, 1
+  store i32 %28, i32* %loc0
+  br label %29
+
+; <label>:29                                      ; preds = %6, %26
+  %30 = load i32, i32* %loc0
+  %31 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %32 = getelementptr inbounds i8, i8 addrspace(1)* %31, i64 1296
+  %33 = addrspacecast i8 addrspace(1)* %32 to %"System.Int32[]" addrspace(1)**
+  %34 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %33
+  %NullCheck = icmp eq %"System.Int32[]" addrspace(1)* %34, null
+  br i1 %NullCheck, label %ThrowNullRef, label %35
+
+; <label>:35                                      ; preds = %29
+  %36 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %34, i32 0, i32 1
+  %37 = load i32, i32 addrspace(1)* %36
+  %38 = zext i32 %37 to i64
+  %39 = trunc i64 %38 to i32
+  %40 = icmp slt i32 %30, %39
+  br i1 %40, label %7, label %41
+
+; <label>:41                                      ; preds = %35
+  %42 = load i32, i32* %arg0
+  %43 = or i32 %42, 1
+  store i32 %43, i32* %loc2
+  br label %59
+
+; <label>:44                                      ; preds = %59
+  %45 = load i32, i32* %loc2
+  %46 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %45)
+  %47 = zext i8 %46 to i32
+  %48 = icmp eq i32 %47, 0
+  br i1 %48, label %56, label %49
+
+; <label>:49                                      ; preds = %44
+  %50 = load i32, i32* %loc2
+  %51 = sub i32 %50, 1
+  %52 = srem i32 %51, 101
+  %53 = icmp eq i32 %52, 0
+  br i1 %53, label %56, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = load i32, i32* %loc2
+  ret i32 %55
+
+; <label>:56                                      ; preds = %44, %49
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %57, 2
+  store i32 %58, i32* %loc2
+  br label %59
+
+; <label>:59                                      ; preds = %41, %56
+  %60 = load i32, i32* %loc2
+  %61 = icmp slt i32 %60, 2147483647
+  br i1 %61, label %44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load i32, i32* %arg0
+  ret i32 %63
+
+ThrowNullRef:                                     ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
 Successfully read GenericEqualityComparer`1.GetHashCode
 
@@ -3694,14 +4558,14 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
   %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load i64, i64 addrspace(1)* %7
@@ -3720,7 +4584,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3750,8 +4614,8 @@ entry:
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
@@ -3796,8 +4660,8 @@ entry:
   %35 = bitcast i16* %34 to i8*
   %36 = getelementptr inbounds i8, i8* %35, i64 2
   %37 = bitcast i8* %36 to i16*
-  %NullCheck4 = icmp ne i16* %37, null
-  br i1 %NullCheck4, label %38, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %37, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %38
 
 ; <label>:38                                      ; preds = %27
   %39 = load i16, i16* %37, align 8
@@ -3824,8 +4688,8 @@ entry:
 
 ; <label>:54                                      ; preds = %22, %43
   %55 = load i16*, i16** %loc4
-  %NullCheck2 = icmp ne i16* %55, null
-  br i1 %NullCheck2, label %56, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i16* %55, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %56
 
 ; <label>:56                                      ; preds = %54
   %57 = load i16, i16* %55, align 8
@@ -3850,11 +4714,11 @@ ThrowNullRef:                                     ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %54
+ThrowNullRef2:                                    ; preds = %54
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %27
+ThrowNullRef4:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3871,8 +4735,8 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -3907,8 +4771,8 @@ entry:
 
 ; <label>:26                                      ; preds = %19
   %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
-  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %28
 
 ; <label>:28                                      ; preds = %26
   %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
@@ -3920,7 +4784,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3972,8 +4836,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
@@ -3984,26 +4848,26 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
-  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
@@ -4014,8 +4878,8 @@ entry:
 ; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
@@ -4024,8 +4888,8 @@ entry:
 
 ; <label>:25                                      ; preds = %1, %16, %23
   %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
-  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
@@ -4036,27 +4900,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %20
+ThrowNullRef10:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4069,8 +4933,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -4081,8 +4945,8 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
@@ -4091,8 +4955,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1, %8
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
@@ -4103,11 +4967,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4128,24 +4992,24 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   store i32 %3, i32* %loc0
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
   %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
   store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck4, label %9, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
@@ -4164,15 +5028,15 @@ entry:
 ; <label>:18                                      ; preds = %70
   %19 = load i16*, i16** %loc3
   %20 = bitcast i16* %19 to i64*
-  %NullCheck10 = icmp ne i64* %20, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %20, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = load i64, i64* %20, align 8
   %23 = load i16*, i16** %loc4
   %24 = bitcast i16* %23 to i64*
-  %NullCheck12 = icmp ne i64* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = load i64, i64* %24, align 8
@@ -4188,8 +5052,8 @@ entry:
   %31 = bitcast i16* %30 to i8*
   %32 = getelementptr inbounds i8, i8* %31, i64 8
   %33 = bitcast i8* %32 to i64*
-  %NullCheck14 = icmp ne i64* %33, null
-  br i1 %NullCheck14, label %34, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = load i64, i64* %33, align 8
@@ -4197,8 +5061,8 @@ entry:
   %37 = bitcast i16* %36 to i8*
   %38 = getelementptr inbounds i8, i8* %37, i64 8
   %39 = bitcast i8* %38 to i64*
-  %NullCheck16 = icmp ne i64* %39, null
-  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %40
 
 ; <label>:40                                      ; preds = %34
   %41 = load i64, i64* %39, align 8
@@ -4214,8 +5078,8 @@ entry:
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %NullCheck18 = icmp ne i64* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = load i64, i64* %48, align 8
@@ -4223,8 +5087,8 @@ entry:
   %52 = bitcast i16* %51 to i8*
   %53 = getelementptr inbounds i8, i8* %52, i64 16
   %54 = bitcast i8* %53 to i64*
-  %NullCheck20 = icmp ne i64* %54, null
-  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64* %54, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %55
 
 ; <label>:55                                      ; preds = %49
   %56 = load i64, i64* %54, align 8
@@ -4262,15 +5126,15 @@ entry:
 ; <label>:74                                      ; preds = %95
   %75 = load i16*, i16** %loc3
   %76 = bitcast i16* %75 to i32*
-  %NullCheck6 = icmp ne i32* %76, null
-  br i1 %NullCheck6, label %77, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32* %76, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %77
 
 ; <label>:77                                      ; preds = %74
   %78 = load i32, i32* %76, align 8
   %79 = load i16*, i16** %loc4
   %80 = bitcast i16* %79 to i32*
-  %NullCheck8 = icmp ne i32* %80, null
-  br i1 %NullCheck8, label %81, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i32* %80, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %81
 
 ; <label>:81                                      ; preds = %77
   %82 = load i32, i32* %80, align 8
@@ -4318,43 +5182,43 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %74
+ThrowNullRef6:                                    ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %77
+ThrowNullRef8:                                    ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %29
+ThrowNullRef14:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %34
+ThrowNullRef16:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4376,8 +5240,8 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load i64, i64 addrspace(1)* %4
@@ -4389,8 +5253,8 @@ entry:
   %12 = load i64, i64* %11
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %5
   %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
@@ -4399,8 +5263,8 @@ entry:
   %18 = load i8, i8* %arg2
   %19 = zext i8 %18 to i32
   %20 = trunc i32 %19 to i8
-  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %15
   %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
@@ -4411,11 +5275,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4442,8 +5306,8 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
@@ -4466,16 +5330,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
   %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = load i64, i64 addrspace(1)* %19
@@ -4500,8 +5364,8 @@ entry:
 ; <label>:35                                      ; preds = %30
   %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
@@ -4514,8 +5378,8 @@ entry:
 
 ; <label>:42                                      ; preds = %1, %38
   %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
-  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
@@ -4526,19 +5390,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %35
+ThrowNullRef2:                                    ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %42
+ThrowNullRef8:                                    ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4551,14 +5415,14 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
@@ -4570,7 +5434,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4583,8 +5447,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
@@ -4613,51 +5477,51 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
   %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
   %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
   %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
   %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
-  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
   store i64 %21, i64 addrspace(1)* %23
   %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %25 = load i64, i64* %loc0
-  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
@@ -4668,27 +5532,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %22
+ThrowNullRef12:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4701,8 +5565,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
@@ -4713,19 +5577,19 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
@@ -4734,8 +5598,8 @@ entry:
 
 ; <label>:15                                      ; preds = %1, %13
   %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
@@ -4746,19 +5610,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %15
+ThrowNullRef8:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4771,8 +5635,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -4831,8 +5695,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
@@ -4882,8 +5746,8 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
-  br i1 %NullCheck, label %17, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %ThrowNullRef, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
@@ -4894,15 +5758,15 @@ entry:
 
 ; <label>:22                                      ; preds = %17
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
-  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
   %26 = load i32, i32 addrspace(1)* %25
   %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
-  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %27, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
@@ -4925,8 +5789,8 @@ entry:
 ; <label>:40                                      ; preds = %17
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
-  br i1 %NullCheck6, label %43, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %41, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
@@ -4938,34 +5802,17 @@ ThrowNullRef:                                     ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %24
+ThrowNullRef4:                                    ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %40
+ThrowNullRef6:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
-}
-
-INFO:  jitting method Object::ReferenceEquals using LLILCJit
-Successfully read Object.ReferenceEquals
-
-define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
-entry:
-  %arg0 = alloca %System.Object addrspace(1)*
-  %arg1 = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
-  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
-  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = icmp eq %System.Object addrspace(1)* %0, %1
-  %3 = sext i1 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
 }
 
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
@@ -4978,21 +5825,21 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
   %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
-  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
@@ -5007,28 +5854,28 @@ entry:
 ; <label>:13                                      ; preds = %8, %12
   %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
   %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
   %21 = load i32, i32 addrspace(1)* %20, align 8
   %22 = add i32 %21, 1
-  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
   store i32 %22, i32 addrspace(1)* %24
   %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
@@ -5039,27 +5886,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5077,7 +5924,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::Setup using LLILCJit
-Failed to read AppDomain.Setup[loadElem]
+Failed to read AppDomain.Setup[unbox]
 INFO:  jitting method Thread::GetDomain using LLILCJit
 Successfully read Thread.GetDomain
 
@@ -5108,8 +5955,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
@@ -5122,14 +5969,14 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
   %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
@@ -5141,11 +5988,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5173,8 +6020,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -5189,7 +6036,328 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
 Failed to read KeyCollection.System.Collections.Generic.IEnumerable<TKey>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Successfully read Enumerator.MoveNext
+
+define i8 @Enumerator.MoveNext(%"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.RuntimeTypeHandle* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*
+  %"$TypeArg" = alloca %System.RuntimeTypeHandle*
+  store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
+  %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 8
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %76, label %12
+
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
+  br label %76
+
+; <label>:13                                      ; preds = %85
+  %14 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck19 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %15
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, i32 0, i32 0
+  %17 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %16, align 8
+  %NullCheck21 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, i32 0, i32 2
+  %20 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %19, align 8
+  %21 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck23 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %22
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, i32 0, i32 2
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %NullCheck25 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 3, i32 %24
+  %NullCheck27 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %32
+
+; <label>:32                                      ; preds = %30
+  %33 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, i32 0, i32 2
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = icmp slt i32 %34, 0
+  br i1 %35, label %68, label %36
+
+; <label>:36                                      ; preds = %32
+  %37 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %38 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck29 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %39
+
+; <label>:39                                      ; preds = %36
+  %40 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, i32 0, i32 0
+  %41 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %40, align 8
+  %NullCheck31 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, i32 0, i32 2
+  %44 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %43, align 8
+  %45 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck33 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, i32 0, i32 2
+  %48 = load i32, i32 addrspace(1)* %47, align 8
+  %NullCheck35 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %49
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = zext i32 %51 to i64
+  %53 = zext i32 %48 to i64
+  %BoundsCheck37 = icmp uge i64 %53, %52
+  br i1 %BoundsCheck37, label %ThrowIndexOutOfRange38, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 3, i32 %48
+  %NullCheck39 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %56
+
+; <label>:56                                      ; preds = %54
+  %57 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, i32 0, i32 0
+  %58 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck41 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %59
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %60, %System.__Canon addrspace(1)* %58)
+  %61 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck43 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  %64 = load i32, i32 addrspace(1)* %63, align 8
+  %65 = add i32 %64, 1
+  %NullCheck45 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  store i32 %65, i32 addrspace(1)* %67
+  ret i8 1
+
+; <label>:68                                      ; preds = %32
+  %69 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck47 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %73 = add i32 %72, 1
+  %NullCheck49 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %74
+
+; <label>:74                                      ; preds = %70
+  %75 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  store i32 %73, i32 addrspace(1)* %75
+  br label %76
+
+; <label>:76                                      ; preds = %8, %12, %74
+  %77 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %78
+
+; <label>:78                                      ; preds = %76
+  %79 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, i32 0, i32 2
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck7 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %82
+
+; <label>:82                                      ; preds = %78
+  %83 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, i32 0, i32 0
+  %84 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %83, align 8
+  %NullCheck9 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %85
+
+; <label>:85                                      ; preds = %82
+  %86 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, i32 0, i32 7
+  %87 = load i32, i32 addrspace(1)* %86, align 8
+  %88 = icmp ult i32 %80, %87
+  br i1 %88, label %13, label %89
+
+; <label>:89                                      ; preds = %85
+  %90 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %91 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck11 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %92
+
+; <label>:92                                      ; preds = %89
+  %93 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, i32 0, i32 0
+  %94 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck13 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %95
+
+; <label>:95                                      ; preds = %92
+  %96 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, i32 0, i32 7
+  %97 = load i32, i32 addrspace(1)* %96, align 8
+  %98 = add i32 %97, 1
+  %NullCheck15 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %99
+
+; <label>:99                                      ; preds = %95
+  %100 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, i32 0, i32 2
+  store i32 %98, i32 addrspace(1)* %100
+  %101 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck17 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %102
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %103, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %92
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef22:                                   ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef24:                                   ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef26:                                   ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef28:                                   ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef30:                                   ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef32:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef34:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef36:                                   ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange38:                           ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef40:                                   ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef42:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef44:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef46:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef48:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef50:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -5200,8 +6368,8 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -5232,9 +6400,9 @@ Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
 Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
-Failed to read String.MakeSeparatorList[loadElemA]
+Failed to read String.MakeSeparatorList[storeElem]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
-Failed to read String.InternalSplitKeepEmptyEntries[loadElem]
+Failed to read String.InternalSplitKeepEmptyEntries[storeElem]
 INFO:  jitting method Path::IsRelative using LLILCJit
 Successfully read Path.IsRelative
 
@@ -5243,8 +6411,8 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -5254,8 +6422,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
@@ -5271,8 +6439,8 @@ entry:
 
 ; <label>:17                                      ; preds = %7
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
@@ -5288,8 +6456,8 @@ entry:
 
 ; <label>:29                                      ; preds = %19
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %31
 
 ; <label>:31                                      ; preds = %29
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
@@ -5300,8 +6468,8 @@ entry:
 
 ; <label>:36                                      ; preds = %31
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
-  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %37, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
@@ -5312,8 +6480,8 @@ entry:
 
 ; <label>:43                                      ; preds = %31, %38
   %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
-  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %45
 
 ; <label>:45                                      ; preds = %43
   %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
@@ -5324,8 +6492,8 @@ entry:
 
 ; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %50
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
@@ -5336,8 +6504,8 @@ entry:
 
 ; <label>:57                                      ; preds = %1, %7, %19, %45, %52
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
-  br i1 %NullCheck14, label %59, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %59
 
 ; <label>:59                                      ; preds = %57
   %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
@@ -5347,8 +6515,8 @@ entry:
 
 ; <label>:63                                      ; preds = %59
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
@@ -5359,8 +6527,8 @@ entry:
 
 ; <label>:70                                      ; preds = %65
   %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
-  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.String addrspace(1)* %71, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %72
 
 ; <label>:72                                      ; preds = %70
   %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
@@ -5379,39 +6547,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %17
+ThrowNullRef4:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %29
+ThrowNullRef6:                                    ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %36
+ThrowNullRef8:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %43
+ThrowNullRef10:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %50
+ThrowNullRef12:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %57
+ThrowNullRef14:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %63
+ThrowNullRef16:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %70
+ThrowNullRef18:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5419,7 +6587,293 @@ ThrowNullRef17:                                   ; preds = %70
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
-Failed to read String.TrimHelper[loadElem]
+Successfully read String.TrimHelper
+
+define %System.String addrspace(1)* @String.TrimHelper(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i16
+  %loc4 = alloca i32
+  %loc5 = alloca i16
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = sub i32 %3, 1
+  store i32 %4, i32* %loc0
+  store i32 0, i32* %loc1
+  %5 = load i32, i32* %arg2
+  %6 = icmp eq i32 %5, 1
+  br i1 %6, label %62, label %7
+
+; <label>:7                                       ; preds = %1
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:8                                       ; preds = %58
+  store i32 0, i32* %loc2
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load i32, i32* %loc1
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2, i32 %10
+  %13 = load i16, i16 addrspace(1)* %12
+  %14 = zext i16 %13 to i32
+  %15 = trunc i32 %14 to i16
+  store i16 %15, i16* %loc3
+  store i32 0, i32* %loc2
+  br label %34
+
+; <label>:16                                      ; preds = %37
+  %17 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %18 = load i32, i32* %loc2
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %17, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %19
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = zext i32 %18 to i64
+  %BoundsCheck = icmp uge i64 %23, %22
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %24
+
+; <label>:24                                      ; preds = %19
+  %25 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 3, i32 %18
+  %26 = load i16, i16 addrspace(1)* %25, align 8
+  %27 = zext i16 %26 to i32
+  %28 = load i16, i16* %loc3
+  %29 = zext i16 %28 to i32
+  %30 = icmp eq i32 %27, %29
+  br i1 %30, label %43, label %31
+
+; <label>:31                                      ; preds = %24
+  %32 = load i32, i32* %loc2
+  %33 = add i32 %32, 1
+  store i32 %33, i32* %loc2
+  br label %34
+
+; <label>:34                                      ; preds = %11, %31
+  %35 = load i32, i32* %loc2
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = icmp slt i32 %35, %41
+  br i1 %42, label %16, label %43
+
+; <label>:43                                      ; preds = %24, %37
+  %44 = load i32, i32* %loc2
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %45, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp eq i32 %44, %50
+  br i1 %51, label %62, label %52
+
+; <label>:52                                      ; preds = %46
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %7, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %57, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %58
+
+; <label>:58                                      ; preds = %55
+  %59 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %60 = load i32, i32 addrspace(1)* %59
+  %61 = icmp slt i32 %56, %60
+  br i1 %61, label %8, label %62
+
+; <label>:62                                      ; preds = %1, %46, %58
+  %63 = load i32, i32* %arg2
+  %64 = icmp eq i32 %63, 0
+  br i1 %64, label %122, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %66, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %67
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %66, i32 0, i32 1
+  %69 = load i32, i32 addrspace(1)* %68
+  %70 = sub i32 %69, 1
+  store i32 %70, i32* %loc0
+  br label %118
+
+; <label>:71                                      ; preds = %118
+  store i32 0, i32* %loc4
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %73 = load i32, i32* %loc0
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %74
+
+; <label>:74                                      ; preds = %71
+  %75 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 2, i32 %73
+  %76 = load i16, i16 addrspace(1)* %75
+  %77 = zext i16 %76 to i32
+  %78 = trunc i32 %77 to i16
+  store i16 %78, i16* %loc5
+  store i32 0, i32* %loc4
+  br label %97
+
+; <label>:79                                      ; preds = %100
+  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %81 = load i32, i32* %loc4
+  %NullCheck19 = icmp eq %"System.Char[]" addrspace(1)* %80, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
+
+; <label>:82                                      ; preds = %79
+  %83 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 1
+  %84 = load i32, i32 addrspace(1)* %83
+  %85 = zext i32 %84 to i64
+  %86 = zext i32 %81 to i64
+  %BoundsCheck21 = icmp uge i64 %86, %85
+  br i1 %BoundsCheck21, label %ThrowIndexOutOfRange22, label %87
+
+; <label>:87                                      ; preds = %82
+  %88 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 3, i32 %81
+  %89 = load i16, i16 addrspace(1)* %88, align 8
+  %90 = zext i16 %89 to i32
+  %91 = load i16, i16* %loc5
+  %92 = zext i16 %91 to i32
+  %93 = icmp eq i32 %90, %92
+  br i1 %93, label %106, label %94
+
+; <label>:94                                      ; preds = %87
+  %95 = load i32, i32* %loc4
+  %96 = add i32 %95, 1
+  store i32 %96, i32* %loc4
+  br label %97
+
+; <label>:97                                      ; preds = %74, %94
+  %98 = load i32, i32* %loc4
+  %99 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck15 = icmp eq %"System.Char[]" addrspace(1)* %99, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %100
+
+; <label>:100                                     ; preds = %97
+  %101 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %99, i32 0, i32 1
+  %102 = load i32, i32 addrspace(1)* %101
+  %103 = zext i32 %102 to i64
+  %104 = trunc i64 %103 to i32
+  %105 = icmp slt i32 %98, %104
+  br i1 %105, label %79, label %106
+
+; <label>:106                                     ; preds = %87, %100
+  %107 = load i32, i32* %loc4
+  %108 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck17 = icmp eq %"System.Char[]" addrspace(1)* %108, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %109
+
+; <label>:109                                     ; preds = %106
+  %110 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %108, i32 0, i32 1
+  %111 = load i32, i32 addrspace(1)* %110
+  %112 = zext i32 %111 to i64
+  %113 = trunc i64 %112 to i32
+  %114 = icmp eq i32 %107, %113
+  br i1 %114, label %122, label %115
+
+; <label>:115                                     ; preds = %109
+  %116 = load i32, i32* %loc0
+  %117 = sub i32 %116, 1
+  store i32 %117, i32* %loc0
+  br label %118
+
+; <label>:118                                     ; preds = %67, %115
+  %119 = load i32, i32* %loc0
+  %120 = load i32, i32* %loc1
+  %121 = icmp sge i32 %119, %120
+  br i1 %121, label %71, label %122
+
+; <label>:122                                     ; preds = %62, %109, %118
+  %123 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %124 = load i32, i32* %loc1
+  %125 = load i32, i32* %loc0
+  %126 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %123, i32 %124, i32 %125)
+  ret %System.String addrspace(1)* %126
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %97
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange22:                           ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
 Successfully read String.CreateTrimmedString
 
@@ -5439,8 +6893,8 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
@@ -5535,8 +6989,8 @@ entry:
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i64 2872
   %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
   %8 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %7
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %3
   %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
@@ -5553,8 +7007,8 @@ entry:
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 2864
   %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
   %21 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %20
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
-  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %22
 
 ; <label>:22                                      ; preds = %16
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
@@ -5569,7 +7023,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %16
+ThrowNullRef2:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5586,8 +7040,8 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5613,8 +7067,8 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
@@ -5632,8 +7086,8 @@ entry:
 
 ; <label>:12                                      ; preds = %4
   %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
@@ -5644,8 +7098,8 @@ entry:
 
 ; <label>:19                                      ; preds = %14
   %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %19
   %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
@@ -5660,21 +7114,21 @@ entry:
   %31 = zext i16 %30 to i32
   %32 = bitcast i8* %29 to i16*
   %33 = trunc i32 %31 to i16
-  %NullCheck6 = icmp ne i16* %32, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i16* %32, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %21
   store i16 %33, i16* %32, align 8
   %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %36
 
 ; <label>:36                                      ; preds = %34
   %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
   %38 = load i32, i32 addrspace(1)* %37, align 8
   %39 = add i32 %38, 1
-  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %40
 
 ; <label>:40                                      ; preds = %36
   %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
@@ -5683,16 +7137,16 @@ entry:
 
 ; <label>:42                                      ; preds = %14
   %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
-  br i1 %NullCheck12, label %44, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
   %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
   %47 = load i16, i16* %arg1
   %48 = zext i16 %47 to i32
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = trunc i32 %48 to i16
@@ -5703,31 +7157,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %19
+ThrowNullRef4:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %21
+ThrowNullRef6:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %36
+ThrowNullRef10:                                   ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %42
+ThrowNullRef12:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %44
+ThrowNullRef14:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5740,8 +7194,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -5752,8 +7206,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
@@ -5762,14 +7216,14 @@ entry:
 
 ; <label>:11                                      ; preds = %1
   %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
@@ -5779,15 +7233,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5808,8 +7262,8 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5822,8 +7276,8 @@ entry:
 
 ; <label>:8                                       ; preds = %3
   %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
@@ -5842,15 +7296,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
-  br i1 %NullCheck4, label %22, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
   %24 = load i16*, i16* addrspace(1)* %23, align 8
   %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %25, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
@@ -5859,8 +7313,8 @@ entry:
   store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
@@ -5874,8 +7328,8 @@ entry:
 
 ; <label>:37                                      ; preds = %65
   %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %37
   %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
@@ -5886,16 +7340,16 @@ entry:
   %45 = bitcast i16* %41 to i8*
   %46 = getelementptr inbounds i8, i8* %45, i64 %44
   %47 = bitcast i8* %46 to i16*
-  %NullCheck14 = icmp ne i16* %47, null
-  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %47, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %48
 
 ; <label>:48                                      ; preds = %39
   %49 = load i16, i16* %47, align 8
   %50 = zext i16 %49 to i32
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %52 = load i32, i32* %loc1
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %53
 
 ; <label>:53                                      ; preds = %48
   %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
@@ -5916,8 +7370,8 @@ entry:
 ; <label>:62                                      ; preds = %36, %59
   %63 = load i32, i32* %loc1
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck10, label %65, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %65
 
 ; <label>:65                                      ; preds = %62
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
@@ -5936,15 +7390,15 @@ entry:
 
 ; <label>:74                                      ; preds = %70
   %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
-  br i1 %NullCheck18, label %76, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %76
 
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
   %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
-  br i1 %NullCheck20, label %80, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
   %81 = load i64, i64 addrspace(1)* %79
@@ -5958,8 +7412,8 @@ entry:
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
   %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
-  br i1 %NullCheck22, label %92, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.String addrspace(1)* %90, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %92
 
 ; <label>:92                                      ; preds = %80
   %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
@@ -5969,15 +7423,15 @@ entry:
 
 ; <label>:96                                      ; preds = %70
   %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
-  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %98
 
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
   %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
-  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
   %103 = load i64, i64 addrspace(1)* %101
@@ -5991,8 +7445,8 @@ entry:
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
   %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
-  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.String addrspace(1)* %112, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %114
 
 ; <label>:114                                     ; preds = %102
   %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
@@ -6004,59 +7458,59 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %20
+ThrowNullRef4:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %22
+ThrowNullRef6:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %26
+ThrowNullRef8:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %62
+ThrowNullRef10:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %48
+ThrowNullRef16:                                   ; preds = %48
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %74
+ThrowNullRef18:                                   ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %76
+ThrowNullRef20:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %80
+ThrowNullRef22:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %96
+ThrowNullRef24:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %98
+ThrowNullRef26:                                   ; preds = %98
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %102
+ThrowNullRef28:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6069,15 +7523,15 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
   %3 = load i16*, i16* addrspace(1)* %2, align 8
   %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
@@ -6087,8 +7541,8 @@ entry:
   %10 = bitcast i16* %3 to i8*
   %11 = getelementptr inbounds i8, i8* %10, i64 %9
   %12 = bitcast i8* %11 to i16*
-  %NullCheck4 = icmp ne i16* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %5
   store i16 0, i16* %12, align 8
@@ -6098,11 +7552,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6119,8 +7573,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -6131,8 +7585,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
@@ -6144,15 +7598,15 @@ entry:
 
 ; <label>:14                                      ; preds = %1
   %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
   %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
   %21 = load i64, i64 addrspace(1)* %19
@@ -6171,15 +7625,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %14
+ThrowNullRef4:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %16
+ThrowNullRef6:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6302,14 +7756,6 @@ entry:
   ret %System.String addrspace(1)* %57
 }
 
-INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
-Successfully read RuntimeHelpers.get_OffsetToStringData
-
-define i32 @RuntimeHelpers.get_OffsetToStringData() {
-entry:
-  ret i32 12
-}
-
 INFO:  jitting method String::Equals using LLILCJit
 Successfully read String.Equals
 
@@ -6381,8 +7827,8 @@ entry:
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
-  br i1 %NullCheck24, label %29, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
   %30 = load i64, i64 addrspace(1)* %28
@@ -6397,8 +7843,8 @@ entry:
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
-  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
   %43 = load i64, i64 addrspace(1)* %41
@@ -6418,8 +7864,8 @@ entry:
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
   %59 = load i64, i64 addrspace(1)* %57
@@ -6434,8 +7880,8 @@ entry:
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck22, label %71, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
   %72 = load i64, i64 addrspace(1)* %70
@@ -6455,8 +7901,8 @@ entry:
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
-  br i1 %NullCheck16, label %87, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = load i64, i64 addrspace(1)* %86
@@ -6471,8 +7917,8 @@ entry:
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck18, label %100, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
   %101 = load i64, i64 addrspace(1)* %99
@@ -6492,8 +7938,8 @@ entry:
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
-  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
   %117 = load i64, i64 addrspace(1)* %115
@@ -6508,8 +7954,8 @@ entry:
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
-  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
   %130 = load i64, i64 addrspace(1)* %128
@@ -6528,15 +7974,15 @@ entry:
 
 ; <label>:142                                     ; preds = %22
   %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
-  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %143, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %144
 
 ; <label>:144                                     ; preds = %142
   %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
   %146 = load i32, i32 addrspace(1)* %145
   %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
-  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %147, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %148
 
 ; <label>:148                                     ; preds = %144
   %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
@@ -6557,15 +8003,15 @@ entry:
 
 ; <label>:159                                     ; preds = %22
   %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
-  br i1 %NullCheck, label %161, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %ThrowNullRef, label %161
 
 ; <label>:161                                     ; preds = %159
   %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
   %163 = load i32, i32 addrspace(1)* %162
   %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
-  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %164, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %165
 
 ; <label>:165                                     ; preds = %161
   %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
@@ -6578,8 +8024,8 @@ entry:
 
 ; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
-  br i1 %NullCheck4, label %172, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %171, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %172
 
 ; <label>:172                                     ; preds = %170
   %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
@@ -6589,8 +8035,8 @@ entry:
 
 ; <label>:176                                     ; preds = %172
   %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
-  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %177, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %178
 
 ; <label>:178                                     ; preds = %176
   %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
@@ -6629,55 +8075,55 @@ ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %161
+ThrowNullRef2:                                    ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %170
+ThrowNullRef4:                                    ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %176
+ThrowNullRef6:                                    ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %142
+ThrowNullRef8:                                    ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %144
+ThrowNullRef10:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %113
+ThrowNullRef12:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %116
+ThrowNullRef14:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %84
+ThrowNullRef16:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %87
+ThrowNullRef18:                                   ; preds = %87
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %55
+ThrowNullRef20:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %58
+ThrowNullRef22:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %26
+ThrowNullRef24:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %29
+ThrowNullRef26:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,8 +8161,8 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck, label %14, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %ThrowNullRef, label %14
 
 ; <label>:14                                      ; preds = %8
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
@@ -6760,8 +8206,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
@@ -6770,14 +8216,14 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32, i32* %loc0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %10
   %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
   %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
@@ -6790,15 +8236,15 @@ entry:
 ; <label>:25                                      ; preds = %19
   %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
-  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
   %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
@@ -6807,8 +8253,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %37 = load i32, i32* %loc0
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %38, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %38
 
 ; <label>:38                                      ; preds = %32
   %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
@@ -6817,14 +8263,14 @@ entry:
 
 ; <label>:40                                      ; preds = %19
   %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %40
   %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
   %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
-  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
-  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
@@ -6832,8 +8278,8 @@ entry:
   %48 = zext i32 %47 to i64
   %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
-  br i1 %NullCheck16, label %51, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %51
 
 ; <label>:51                                      ; preds = %45
   %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
@@ -6847,15 +8293,15 @@ entry:
 ; <label>:57                                      ; preds = %51
   %58 = load i16*, i16** %arg1
   %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
-  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %60
 
 ; <label>:60                                      ; preds = %57
   %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
   %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
-  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %64
 
 ; <label>:64                                      ; preds = %60
   %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
@@ -6864,22 +8310,22 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
   %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
-  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %70
 
 ; <label>:70                                      ; preds = %64
   %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
   %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
-  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
-  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
   %75 = load i32, i32 addrspace(1)* %74
   %76 = zext i32 %75 to i64
   %77 = trunc i64 %76 to i32
-  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
-  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %78
 
 ; <label>:78                                      ; preds = %73
   %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
@@ -6901,8 +8347,8 @@ entry:
   %90 = bitcast i16* %86 to i8*
   %91 = getelementptr inbounds i8, i8* %90, i64 %89
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %93
 
 ; <label>:93                                      ; preds = %80
   %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
@@ -6912,8 +8358,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %99 = load i32, i32* %loc2
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %100
 
 ; <label>:100                                     ; preds = %93
   %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
@@ -6928,63 +8374,63 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %25
+ThrowNullRef6:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %32
+ThrowNullRef10:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %40
+ThrowNullRef12:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %45
+ThrowNullRef16:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %57
+ThrowNullRef18:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %60
+ThrowNullRef20:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %64
+ThrowNullRef22:                                   ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %70
+ThrowNullRef24:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %73
+ThrowNullRef26:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %80
+ThrowNullRef28:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %93
+ThrowNullRef30:                                   ; preds = %93
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7004,8 +8450,8 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
@@ -7033,43 +8479,43 @@ entry:
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %14
   %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
   %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   %28 = load i32, i32 addrspace(1)* %27, align 8
   %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
-  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %30
 
 ; <label>:30                                      ; preds = %26
   %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
   %32 = load i32, i32 addrspace(1)* %31, align 8
   %33 = add i32 %28, %32
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %34
 
 ; <label>:34                                      ; preds = %30
   %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   store i32 %33, i32 addrspace(1)* %35
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
   store i32 0, i32 addrspace(1)* %38
   %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %40
 
 ; <label>:40                                      ; preds = %37
   %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
@@ -7082,8 +8528,8 @@ entry:
 
 ; <label>:47                                      ; preds = %40
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
@@ -7098,8 +8544,8 @@ entry:
   %54 = load i32, i32* %loc0
   %55 = sext i32 %54 to i64
   %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
-  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %57
 
 ; <label>:57                                      ; preds = %52
   %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
@@ -7110,68 +8556,35 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %14
+ThrowNullRef2:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %23
+ThrowNullRef4:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %26
+ThrowNullRef6:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %30
+ThrowNullRef8:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %34
+ThrowNullRef10:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %47
+ThrowNullRef14:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %52
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-}
-
-INFO:  jitting method StringBuilder::get_Length using LLILCJit
-Successfully read StringBuilder.get_Length
-
-define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.StringBuilder addrspace(1)*
-  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
-  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
-
-; <label>:1                                       ; preds = %entry
-  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %3 = load i32, i32 addrspace(1)* %2, align 8
-  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
-
-; <label>:5                                       ; preds = %1
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = add i32 %3, %7
-  ret i32 %8
-
-ThrowNullRef:                                     ; preds = %entry
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef16:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7213,70 +8626,70 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
   %6 = load i32, i32 addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
   store i32 %6, i32 addrspace(1)* %8
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
   %13 = load i32, i32 addrspace(1)* %12, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
   store i32 %13, i32 addrspace(1)* %15
   %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
-  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %18
 
 ; <label>:18                                      ; preds = %14
   %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
   %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
   %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
   %34 = load i32, i32 addrspace(1)* %33, align 8
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
-  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
@@ -7287,39 +8700,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %28
+ThrowNullRef16:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %32
+ThrowNullRef18:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7455,13 +8868,13 @@ entry:
 ; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
@@ -7477,16 +8890,16 @@ entry:
 
 ; <label>:18                                      ; preds = %15
   %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
   store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
   %22 = load i32, i32* %loc0
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %24
 
 ; <label>:24                                      ; preds = %20
   %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
@@ -7498,13 +8911,13 @@ entry:
 ; <label>:28                                      ; preds = %15, %24
   %29 = load i32, i32* %arg1
   %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %31
   %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
@@ -7517,20 +8930,20 @@ entry:
   %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
-  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
   %46 = load i32, i32 addrspace(1)* %45, align 8
   %47 = sub i32 %40, %46
-  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
-  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i32 addrspace(1)* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %48
 
 ; <label>:48                                      ; preds = %44
   store i32 %47, i32 addrspace(1)* %39, align 8
@@ -7538,21 +8951,21 @@ entry:
 
 ; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
-  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %51
 
 ; <label>:51                                      ; preds = %49
   %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %53
 
 ; <label>:53                                      ; preds = %51
   %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
   %55 = load i32, i32 addrspace(1)* %54, align 8
   %56 = load i32, i32* %arg2
   %57 = sub i32 %55, %56
-  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %58
 
 ; <label>:58                                      ; preds = %53
   %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
@@ -7562,13 +8975,13 @@ entry:
 ; <label>:60                                      ; preds = %33, %58
   %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
   %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
-  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %63
 
 ; <label>:63                                      ; preds = %60
   %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
-  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
-  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
@@ -7578,15 +8991,15 @@ entry:
 
 ; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
-  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i32 addrspace(1)* %69, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %70
 
 ; <label>:70                                      ; preds = %68
   %71 = load i32, i32 addrspace(1)* %69, align 8
   store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
-  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
@@ -7596,8 +9009,8 @@ entry:
   store i32 %77, i32* %loc4
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
-  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %80
 
 ; <label>:80                                      ; preds = %73
   %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
@@ -7607,71 +9020,71 @@ entry:
 ; <label>:83                                      ; preds = %80
   store i32 0, i32* %loc3
   %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
-  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
-  br i1 %NullCheck26, label %88, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i32 addrspace(1)* %87, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %88
 
 ; <label>:88                                      ; preds = %85
   %89 = load i32, i32 addrspace(1)* %87, align 8
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
-  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %90
 
 ; <label>:90                                      ; preds = %88
   %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
   store i32 %89, i32 addrspace(1)* %91
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
-  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
-  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %96
 
 ; <label>:96                                      ; preds = %94
   %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
-  br i1 %NullCheck34, label %100, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %100
 
 ; <label>:100                                     ; preds = %96
   %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
-  br i1 %NullCheck36, label %102, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %102
 
 ; <label>:102                                     ; preds = %100
   %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
   %104 = load i32, i32 addrspace(1)* %103, align 8
   %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
-  br i1 %NullCheck38, label %106, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %106
 
 ; <label>:106                                     ; preds = %102
   %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
-  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
-  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %108
 
 ; <label>:108                                     ; preds = %106
   %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
   %110 = load i32, i32 addrspace(1)* %109, align 8
   %111 = add i32 %104, %110
-  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %112
 
 ; <label>:112                                     ; preds = %108
   %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
   store i32 %111, i32 addrspace(1)* %113
   %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
-  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i32 addrspace(1)* %114, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %115
 
 ; <label>:115                                     ; preds = %112
   %116 = load i32, i32 addrspace(1)* %114, align 8
@@ -7681,19 +9094,19 @@ entry:
 ; <label>:118                                     ; preds = %115
   %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
-  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %121
 
 ; <label>:121                                     ; preds = %118
   %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
-  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
-  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %123
 
 ; <label>:123                                     ; preds = %121
   %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
   %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
-  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
-  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %126
 
 ; <label>:126                                     ; preds = %123
   %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
@@ -7705,8 +9118,8 @@ entry:
 
 ; <label>:130                                     ; preds = %80, %115, %126
   %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %132
 
 ; <label>:132                                     ; preds = %130
   %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7715,8 +9128,8 @@ entry:
   %136 = load i32, i32* %loc3
   %137 = sub i32 %135, %136
   %138 = sub i32 %134, %137
-  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %139
 
 ; <label>:139                                     ; preds = %132
   %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7728,16 +9141,16 @@ entry:
 
 ; <label>:144                                     ; preds = %139
   %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
-  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %146
 
 ; <label>:146                                     ; preds = %144
   %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
   %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
   %149 = load i32, i32* %loc2
   %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
-  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %151
 
 ; <label>:151                                     ; preds = %146
   %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
@@ -7754,145 +9167,249 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %18
+ThrowNullRef4:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %31
+ThrowNullRef10:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %44
+ThrowNullRef16:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %68
+ThrowNullRef18:                                   ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %70
+ThrowNullRef20:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %73
+ThrowNullRef22:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %83
+ThrowNullRef24:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %85
+ThrowNullRef26:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %88
+ThrowNullRef28:                                   ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %90
+ThrowNullRef30:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %94
+ThrowNullRef32:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %96
+ThrowNullRef34:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %100
+ThrowNullRef36:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %102
+ThrowNullRef38:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %106
+ThrowNullRef40:                                   ; preds = %106
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %108
+ThrowNullRef42:                                   ; preds = %108
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %112
+ThrowNullRef44:                                   ; preds = %112
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %118
+ThrowNullRef46:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %121
+ThrowNullRef48:                                   ; preds = %121
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %123
+ThrowNullRef50:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %130
+ThrowNullRef52:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %132
+ThrowNullRef54:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %144
+ThrowNullRef56:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %146
+ThrowNullRef58:                                   ; preds = %146
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %60
+ThrowNullRef60:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %63
+ThrowNullRef62:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %49
+ThrowNullRef64:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %51
+ThrowNullRef66:                                   ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %53
+ThrowNullRef68:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(%"System.Char[]" addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %arg0 = alloca %"System.Char[]" addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store %"System.Char[]" addrspace(1)* %param0, %"System.Char[]" addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load i32, i32* %arg4
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %43, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %38, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg1
+  %13 = load i32, i32* %arg4
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %38, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %24 = load i32, i32* %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %35 = load i32, i32* %arg3
+  %36 = load i32, i32* %arg4
+  %37 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %37, %"System.Char[]" addrspace(1)* %34, i32 %35, i32 %36)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:38                                      ; preds = %5, %16
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Successfully read Buffer._Memmove
 
@@ -7914,7 +9431,7 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[loadElem]
+Failed to read AppDomain.SetDataHelper[storeElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -7923,8 +9440,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
@@ -7934,8 +9451,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
@@ -7947,15 +9464,15 @@ entry:
   %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
   %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
@@ -7966,15 +9483,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7992,7 +9509,79 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
-Failed to read Dictionary`2.TryGetValue[loadElemA]
+Successfully read Dictionary`2.TryGetValue
+
+define i8 @"Dictionary`2.TryGetValue"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)* addrspace(1)* %param2) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  %arg2 = alloca %System.__Canon addrspace(1)* addrspace(1)*
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  store %System.__Canon addrspace(1)* addrspace(1)* %param2, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  store i32 %2, i32* %loc0
+  %3 = load i32, i32* %loc0
+  %4 = icmp slt i32 %3, 0
+  br i1 %4, label %22, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 2
+  %10 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %9, align 8
+  %11 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = zext i32 %11 to i64
+  %BoundsCheck = icmp uge i64 %16, %15
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 3, i32 %11
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %20, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %6, %System.__Canon addrspace(1)* %21)
+  ret i8 1
+
+; <label>:22                                      ; preds = %entry
+  %23 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %23, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -8058,8 +9647,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
@@ -8091,8 +9680,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
@@ -8171,15 +9760,15 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck, label %19, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %ThrowNullRef, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
   %21 = load i32, i32 addrspace(1)* %20
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
@@ -8202,7 +9791,7 @@ ThrowNullRef:                                     ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %19
+ThrowNullRef2:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8248,8 +9837,8 @@ entry:
   %0 = alloca %System.AppDomainHandle
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %1 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %1, i32 0, i32 15
@@ -8269,8 +9858,8 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
@@ -8286,7 +9875,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -8299,8 +9888,8 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -8327,8 +9916,8 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
@@ -8352,8 +9941,8 @@ entry:
   %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
   store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
@@ -8363,8 +9952,8 @@ entry:
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
@@ -8374,8 +9963,8 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %9
   %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
@@ -8384,8 +9973,8 @@ entry:
 
 ; <label>:18                                      ; preds = %3, %16
   %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
@@ -8397,15 +9986,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %18
+ThrowNullRef6:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8418,8 +10007,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
@@ -8453,15 +10042,15 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
@@ -8473,7 +10062,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8481,7 +10070,7 @@ ThrowNullRef1:                                    ; preds = %1
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
 Failed to read Dictionary`2.System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
@@ -8506,8 +10095,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
@@ -8524,8 +10113,8 @@ entry:
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -8544,7 +10133,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8577,8 +10166,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = load i64, i64* %arg2
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = trunc i32 %3 to i8
@@ -8634,46 +10223,46 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
   %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
-  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
-  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
-  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
@@ -8684,27 +10273,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %20
+ThrowNullRef12:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8717,8 +10306,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -8756,22 +10345,22 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
   %9 = load i64, i64 addrspace(1)* %8, align 8
   %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
   %13 = load i64, i64 addrspace(1)* %12, align 8
   %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %11
   %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
@@ -8788,11 +10377,11 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8882,8 +10471,8 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
@@ -8900,8 +10489,8 @@ entry:
 ; <label>:8                                       ; preds = %1
   %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
   %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
@@ -8911,15 +10500,15 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
   %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
   %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
-  br i1 %NullCheck6, label %21, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
@@ -8946,15 +10535,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8992,15 +10581,15 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
   store i8 %3, i8 addrspace(1)* %5
   %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
@@ -9011,7 +10600,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9027,8 +10616,8 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -9041,8 +10630,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
@@ -9058,7 +10647,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9080,8 +10669,8 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
@@ -9096,8 +10685,8 @@ entry:
 ; <label>:12                                      ; preds = %6
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
@@ -9112,8 +10701,8 @@ entry:
 ; <label>:21                                      ; preds = %15
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
@@ -9128,8 +10717,8 @@ entry:
 ; <label>:30                                      ; preds = %24
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %31, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
@@ -9144,8 +10733,8 @@ entry:
 ; <label>:39                                      ; preds = %33
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
-  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %40, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %42
 
 ; <label>:42                                      ; preds = %39
   %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
@@ -9164,19 +10753,19 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %21
+ThrowNullRef4:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %30
+ThrowNullRef6:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %39
+ThrowNullRef8:                                    ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9243,8 +10832,8 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
@@ -9264,57 +10853,57 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
   store i8 0, i8 addrspace(1)* %2
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
   store i8 0, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
   store i8 0, i8 addrspace(1)* %17
   %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
   store i8 0, i8 addrspace(1)* %20
   %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
-  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
@@ -9325,31 +10914,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %19
+ThrowNullRef14:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9367,8 +10956,8 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
@@ -9380,8 +10969,8 @@ entry:
 
 ; <label>:9                                       ; preds = %4
   %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %9
   %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
@@ -9395,7 +10984,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef2:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9420,8 +11009,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
@@ -9512,8 +11101,8 @@ entry:
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
@@ -9524,8 +11113,8 @@ entry:
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = load i64, i64 addrspace(1)* %12
@@ -9537,8 +11126,8 @@ entry:
   %20 = load i64, i64* %19
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
-  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %13
   %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
@@ -9555,8 +11144,8 @@ entry:
 ; <label>:30                                      ; preds = %25
   %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %32 = load i32, i32* %arg2
-  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
-  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
@@ -9570,15 +11159,15 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %30
+ThrowNullRef2:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9622,87 +11211,87 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
   %10 = load i8, i8 addrspace(1)* %9, align 8
   %11 = zext i8 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %8
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
   store i8 %12, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
   %19 = load i8, i8 addrspace(1)* %18, align 8
   %20 = zext i8 %19 to i32
   %21 = trunc i32 %20 to i8
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
   store i8 %21, i8 addrspace(1)* %23
   %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
   %28 = load i8, i8 addrspace(1)* %27, align 8
   %29 = zext i8 %28 to i32
   %30 = trunc i32 %29 to i8
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
-  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %31
 
 ; <label>:31                                      ; preds = %26
   %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
   store i8 %30, i8 addrspace(1)* %32
   %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
-  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
-  br i1 %NullCheck14, label %40, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %40
 
 ; <label>:40                                      ; preds = %35
   %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
   store i8 %39, i8 addrspace(1)* %41
   %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
-  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %44
 
 ; <label>:44                                      ; preds = %40
   %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
   %46 = load i8, i8 addrspace(1)* %45, align 8
   %47 = zext i8 %46 to i32
   %48 = trunc i32 %47 to i8
-  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
   store i8 %48, i8 addrspace(1)* %50
   %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
-  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
@@ -9713,29 +11302,29 @@ entry:
 ; <label>:56                                      ; preds = %52
   %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
-  br i1 %NullCheck22, label %59, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
   %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
   %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
-  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
-  br i1 %NullCheck24, label %63, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
   %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
-  br i1 %NullCheck26, label %66, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
   %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
-  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
-  br i1 %NullCheck28, label %69, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %69
 
 ; <label>:69                                      ; preds = %66
   %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
@@ -9744,15 +11333,15 @@ entry:
 
 ; <label>:71                                      ; preds = %105
   %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
-  br i1 %NullCheck34, label %73, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %73
 
 ; <label>:73                                      ; preds = %71
   %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
   %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
   %76 = load i32, i32* %loc0
-  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
-  br i1 %NullCheck36, label %77, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
@@ -9766,8 +11355,8 @@ entry:
 
 ; <label>:83                                      ; preds = %77
   %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
-  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
@@ -9775,14 +11364,14 @@ entry:
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
   %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
-  br i1 %NullCheck40, label %91, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
 ; <label>:91                                      ; preds = %85
   %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
   %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
-  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck42, label %94, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %94
 
 ; <label>:94                                      ; preds = %91
   %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
@@ -9798,14 +11387,14 @@ entry:
 ; <label>:99                                      ; preds = %69, %96
   %100 = load i32, i32* %loc0
   %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
-  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %102
 
 ; <label>:102                                     ; preds = %99
   %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
   %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
-  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
-  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
@@ -9819,87 +11408,87 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %26
+ThrowNullRef10:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %31
+ThrowNullRef12:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %35
+ThrowNullRef14:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %40
+ThrowNullRef16:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %56
+ThrowNullRef22:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %59
+ThrowNullRef24:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %63
+ThrowNullRef26:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %66
+ThrowNullRef28:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %102
+ThrowNullRef32:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %71
+ThrowNullRef34:                                   ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %73
+ThrowNullRef36:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %83
+ThrowNullRef38:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %85
+ThrowNullRef40:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %91
+ThrowNullRef42:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9943,15 +11532,15 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
   %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
@@ -9961,28 +11550,28 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
   %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %12
   %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
   %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
   %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
-  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
@@ -9993,23 +11582,23 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %12
+ThrowNullRef6:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10031,15 +11620,15 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
   %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = load i64, i64 addrspace(1)* %7
@@ -10077,13 +11666,13 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[loadElem]
+Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -10111,8 +11700,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -10184,8 +11773,8 @@ entry:
   store i32 addrspace(1)* %param1, i32 addrspace(1)** %arg1
   %0 = load i32, i32* %arg0
   %1 = load i32 addrspace(1)*, i32 addrspace(1)** %arg1
-  %NullCheck = icmp ne i32 addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq i32 addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load i32, i32 addrspace(1)* %1, align 8

--- a/test/BaseLine/JIT/CodeGenBringUpTests/addref.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/addref.error.txt
@@ -25,8 +25,8 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
@@ -40,8 +40,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
   %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
@@ -75,7 +75,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -90,8 +90,8 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %NullCheck = icmp ne i8 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = load i8, i8 addrspace(1)* %0, align 8
@@ -125,8 +125,8 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
@@ -159,8 +159,8 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -184,8 +184,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
   store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
@@ -195,8 +195,8 @@ entry:
 ; <label>:4                                       ; preds = %1
   %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
   %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
@@ -206,8 +206,8 @@ entry:
   %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
@@ -221,14 +221,14 @@ entry:
 
 ; <label>:17                                      ; preds = %14
   %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
   %21 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
@@ -238,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -249,8 +249,8 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
@@ -261,27 +261,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %30
+ThrowNullRef10:                                   ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -301,7 +301,89 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
-Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
+Successfully read AppDomainSetup.GetUnsecureApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.GetUnsecureApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %NullCheck = icmp eq %"System.String[]" addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %BoundsCheck = icmp uge i64 0, %5
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %6
+
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 3, i32 0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
+  ret %System.String addrspace(1)* %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_Value using LLILCJit
+Successfully read AppDomainSetup.get_Value
+
+define %"System.String[]" addrspace(1)* @AppDomainSetup.get_Value(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.String[]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 18)
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.String[]" addrspace(1)* addrspace(1)*, %"System.String[]" addrspace(1)*)*)(%"System.String[]" addrspace(1)* addrspace(1)* %9, %"System.String[]" addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %11, i32 0, i32 1
+  %14 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %13, align 8
+  ret %"System.String[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -319,8 +401,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -368,16 +450,16 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
   %5 = load i32, i32 addrspace(1)* %4
   %6 = sub i32 %5, 1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -389,7 +471,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -421,8 +503,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
@@ -456,8 +538,8 @@ entry:
 ; <label>:27                                      ; preds = %19
   %28 = load i32, i32* %arg1
   %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
-  br i1 %NullCheck2, label %30, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %29, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %30
 
 ; <label>:30                                      ; preds = %27
   %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
@@ -493,8 +575,8 @@ entry:
 ; <label>:49                                      ; preds = %46
   %50 = load i32, i32* %arg2
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck4, label %52, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
@@ -517,11 +599,11 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %27
+ThrowNullRef2:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %49
+ThrowNullRef4:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -544,16 +626,16 @@ entry:
   %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %0)
   store %System.String addrspace(1)* %1, %System.String addrspace(1)** %loc0
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 2
   %5 = bitcast [0 x i16] addrspace(1)* %4 to i16 addrspace(1)*
   store i16 addrspace(1)* %5, i16 addrspace(1)** %loc1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %3
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2
@@ -580,7 +662,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -691,15 +773,15 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %NullCheck132 = icmp ne i8* %21, null
-  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+  %NullCheck131 = icmp eq i8* %21, null
+  br i1 %NullCheck131, label %ThrowNullRef132, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = load i8, i8* %21, align 8
   %24 = zext i8 %23 to i32
   %25 = trunc i32 %24 to i8
-  %NullCheck134 = icmp ne i8* %20, null
-  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+  %NullCheck133 = icmp eq i8* %20, null
+  br i1 %NullCheck133, label %ThrowNullRef134, label %26
 
 ; <label>:26                                      ; preds = %22
   store i8 %25, i8* %20, align 8
@@ -709,16 +791,16 @@ entry:
   %28 = load i8*, i8** %arg0
   %29 = load i8*, i8** %arg1
   %30 = bitcast i8* %29 to i16*
-  %NullCheck128 = icmp ne i16* %30, null
-  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+  %NullCheck127 = icmp eq i16* %30, null
+  br i1 %NullCheck127, label %ThrowNullRef128, label %31
 
 ; <label>:31                                      ; preds = %27
   %32 = load i16, i16* %30, align 8
   %33 = sext i16 %32 to i32
   %34 = bitcast i8* %28 to i16*
   %35 = trunc i32 %33 to i16
-  %NullCheck130 = icmp ne i16* %34, null
-  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+  %NullCheck129 = icmp eq i16* %34, null
+  br i1 %NullCheck129, label %ThrowNullRef130, label %36
 
 ; <label>:36                                      ; preds = %31
   store i16 %35, i16* %34, align 8
@@ -728,16 +810,16 @@ entry:
   %38 = load i8*, i8** %arg0
   %39 = load i8*, i8** %arg1
   %40 = bitcast i8* %39 to i16*
-  %NullCheck120 = icmp ne i16* %40, null
-  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+  %NullCheck119 = icmp eq i16* %40, null
+  br i1 %NullCheck119, label %ThrowNullRef120, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i16, i16* %40, align 8
   %43 = sext i16 %42 to i32
   %44 = bitcast i8* %38 to i16*
   %45 = trunc i32 %43 to i16
-  %NullCheck122 = icmp ne i16* %44, null
-  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+  %NullCheck121 = icmp eq i16* %44, null
+  br i1 %NullCheck121, label %ThrowNullRef122, label %46
 
 ; <label>:46                                      ; preds = %41
   store i16 %45, i16* %44, align 8
@@ -745,15 +827,15 @@ entry:
   %48 = getelementptr inbounds i8, i8* %47, i64 2
   %49 = load i8*, i8** %arg1
   %50 = getelementptr inbounds i8, i8* %49, i64 2
-  %NullCheck124 = icmp ne i8* %50, null
-  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+  %NullCheck123 = icmp eq i8* %50, null
+  br i1 %NullCheck123, label %ThrowNullRef124, label %51
 
 ; <label>:51                                      ; preds = %46
   %52 = load i8, i8* %50, align 8
   %53 = zext i8 %52 to i32
   %54 = trunc i32 %53 to i8
-  %NullCheck126 = icmp ne i8* %48, null
-  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+  %NullCheck125 = icmp eq i8* %48, null
+  br i1 %NullCheck125, label %ThrowNullRef126, label %55
 
 ; <label>:55                                      ; preds = %51
   store i8 %54, i8* %48, align 8
@@ -763,14 +845,14 @@ entry:
   %57 = load i8*, i8** %arg0
   %58 = load i8*, i8** %arg1
   %59 = bitcast i8* %58 to i32*
-  %NullCheck116 = icmp ne i32* %59, null
-  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+  %NullCheck115 = icmp eq i32* %59, null
+  br i1 %NullCheck115, label %ThrowNullRef116, label %60
 
 ; <label>:60                                      ; preds = %56
   %61 = load i32, i32* %59, align 8
   %62 = bitcast i8* %57 to i32*
-  %NullCheck118 = icmp ne i32* %62, null
-  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+  %NullCheck117 = icmp eq i32* %62, null
+  br i1 %NullCheck117, label %ThrowNullRef118, label %63
 
 ; <label>:63                                      ; preds = %60
   store i32 %61, i32* %62, align 8
@@ -780,14 +862,14 @@ entry:
   %65 = load i8*, i8** %arg0
   %66 = load i8*, i8** %arg1
   %67 = bitcast i8* %66 to i32*
-  %NullCheck108 = icmp ne i32* %67, null
-  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+  %NullCheck107 = icmp eq i32* %67, null
+  br i1 %NullCheck107, label %ThrowNullRef108, label %68
 
 ; <label>:68                                      ; preds = %64
   %69 = load i32, i32* %67, align 8
   %70 = bitcast i8* %65 to i32*
-  %NullCheck110 = icmp ne i32* %70, null
-  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+  %NullCheck109 = icmp eq i32* %70, null
+  br i1 %NullCheck109, label %ThrowNullRef110, label %71
 
 ; <label>:71                                      ; preds = %68
   store i32 %69, i32* %70, align 8
@@ -795,15 +877,15 @@ entry:
   %73 = getelementptr inbounds i8, i8* %72, i64 4
   %74 = load i8*, i8** %arg1
   %75 = getelementptr inbounds i8, i8* %74, i64 4
-  %NullCheck112 = icmp ne i8* %75, null
-  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+  %NullCheck111 = icmp eq i8* %75, null
+  br i1 %NullCheck111, label %ThrowNullRef112, label %76
 
 ; <label>:76                                      ; preds = %71
   %77 = load i8, i8* %75, align 8
   %78 = zext i8 %77 to i32
   %79 = trunc i32 %78 to i8
-  %NullCheck114 = icmp ne i8* %73, null
-  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+  %NullCheck113 = icmp eq i8* %73, null
+  br i1 %NullCheck113, label %ThrowNullRef114, label %80
 
 ; <label>:80                                      ; preds = %76
   store i8 %79, i8* %73, align 8
@@ -813,14 +895,14 @@ entry:
   %82 = load i8*, i8** %arg0
   %83 = load i8*, i8** %arg1
   %84 = bitcast i8* %83 to i32*
-  %NullCheck100 = icmp ne i32* %84, null
-  br i1 %NullCheck100, label %85, label %ThrowNullRef99
+  %NullCheck99 = icmp eq i32* %84, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %85
 
 ; <label>:85                                      ; preds = %81
   %86 = load i32, i32* %84, align 8
   %87 = bitcast i8* %82 to i32*
-  %NullCheck102 = icmp ne i32* %87, null
-  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+  %NullCheck101 = icmp eq i32* %87, null
+  br i1 %NullCheck101, label %ThrowNullRef102, label %88
 
 ; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
@@ -829,16 +911,16 @@ entry:
   %91 = load i8*, i8** %arg1
   %92 = getelementptr inbounds i8, i8* %91, i64 4
   %93 = bitcast i8* %92 to i16*
-  %NullCheck104 = icmp ne i16* %93, null
-  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+  %NullCheck103 = icmp eq i16* %93, null
+  br i1 %NullCheck103, label %ThrowNullRef104, label %94
 
 ; <label>:94                                      ; preds = %88
   %95 = load i16, i16* %93, align 8
   %96 = sext i16 %95 to i32
   %97 = bitcast i8* %90 to i16*
   %98 = trunc i32 %96 to i16
-  %NullCheck106 = icmp ne i16* %97, null
-  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+  %NullCheck105 = icmp eq i16* %97, null
+  br i1 %NullCheck105, label %ThrowNullRef106, label %99
 
 ; <label>:99                                      ; preds = %94
   store i16 %98, i16* %97, align 8
@@ -848,14 +930,14 @@ entry:
   %101 = load i8*, i8** %arg0
   %102 = load i8*, i8** %arg1
   %103 = bitcast i8* %102 to i32*
-  %NullCheck88 = icmp ne i32* %103, null
-  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+  %NullCheck87 = icmp eq i32* %103, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %104
 
 ; <label>:104                                     ; preds = %100
   %105 = load i32, i32* %103, align 8
   %106 = bitcast i8* %101 to i32*
-  %NullCheck90 = icmp ne i32* %106, null
-  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+  %NullCheck89 = icmp eq i32* %106, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %107
 
 ; <label>:107                                     ; preds = %104
   store i32 %105, i32* %106, align 8
@@ -864,16 +946,16 @@ entry:
   %110 = load i8*, i8** %arg1
   %111 = getelementptr inbounds i8, i8* %110, i64 4
   %112 = bitcast i8* %111 to i16*
-  %NullCheck92 = icmp ne i16* %112, null
-  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+  %NullCheck91 = icmp eq i16* %112, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %113
 
 ; <label>:113                                     ; preds = %107
   %114 = load i16, i16* %112, align 8
   %115 = sext i16 %114 to i32
   %116 = bitcast i8* %109 to i16*
   %117 = trunc i32 %115 to i16
-  %NullCheck94 = icmp ne i16* %116, null
-  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+  %NullCheck93 = icmp eq i16* %116, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %118
 
 ; <label>:118                                     ; preds = %113
   store i16 %117, i16* %116, align 8
@@ -881,15 +963,15 @@ entry:
   %120 = getelementptr inbounds i8, i8* %119, i64 6
   %121 = load i8*, i8** %arg1
   %122 = getelementptr inbounds i8, i8* %121, i64 6
-  %NullCheck96 = icmp ne i8* %122, null
-  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+  %NullCheck95 = icmp eq i8* %122, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %123
 
 ; <label>:123                                     ; preds = %118
   %124 = load i8, i8* %122, align 8
   %125 = zext i8 %124 to i32
   %126 = trunc i32 %125 to i8
-  %NullCheck98 = icmp ne i8* %120, null
-  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+  %NullCheck97 = icmp eq i8* %120, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %127
 
 ; <label>:127                                     ; preds = %123
   store i8 %126, i8* %120, align 8
@@ -899,14 +981,14 @@ entry:
   %129 = load i8*, i8** %arg0
   %130 = load i8*, i8** %arg1
   %131 = bitcast i8* %130 to i64*
-  %NullCheck84 = icmp ne i64* %131, null
-  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+  %NullCheck83 = icmp eq i64* %131, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %132
 
 ; <label>:132                                     ; preds = %128
   %133 = load i64, i64* %131, align 8
   %134 = bitcast i8* %129 to i64*
-  %NullCheck86 = icmp ne i64* %134, null
-  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+  %NullCheck85 = icmp eq i64* %134, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %135
 
 ; <label>:135                                     ; preds = %132
   store i64 %133, i64* %134, align 8
@@ -916,14 +998,14 @@ entry:
   %137 = load i8*, i8** %arg0
   %138 = load i8*, i8** %arg1
   %139 = bitcast i8* %138 to i64*
-  %NullCheck76 = icmp ne i64* %139, null
-  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+  %NullCheck75 = icmp eq i64* %139, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %140
 
 ; <label>:140                                     ; preds = %136
   %141 = load i64, i64* %139, align 8
   %142 = bitcast i8* %137 to i64*
-  %NullCheck78 = icmp ne i64* %142, null
-  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+  %NullCheck77 = icmp eq i64* %142, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %143
 
 ; <label>:143                                     ; preds = %140
   store i64 %141, i64* %142, align 8
@@ -931,15 +1013,15 @@ entry:
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %NullCheck80 = icmp ne i8* %147, null
-  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+  %NullCheck79 = icmp eq i8* %147, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %148
 
 ; <label>:148                                     ; preds = %143
   %149 = load i8, i8* %147, align 8
   %150 = zext i8 %149 to i32
   %151 = trunc i32 %150 to i8
-  %NullCheck82 = icmp ne i8* %145, null
-  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+  %NullCheck81 = icmp eq i8* %145, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %152
 
 ; <label>:152                                     ; preds = %148
   store i8 %151, i8* %145, align 8
@@ -949,14 +1031,14 @@ entry:
   %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
   %156 = bitcast i8* %155 to i64*
-  %NullCheck68 = icmp ne i64* %156, null
-  br i1 %NullCheck68, label %157, label %ThrowNullRef67
+  %NullCheck67 = icmp eq i64* %156, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %157
 
 ; <label>:157                                     ; preds = %153
   %158 = load i64, i64* %156, align 8
   %159 = bitcast i8* %154 to i64*
-  %NullCheck70 = icmp ne i64* %159, null
-  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+  %NullCheck69 = icmp eq i64* %159, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %160
 
 ; <label>:160                                     ; preds = %157
   store i64 %158, i64* %159, align 8
@@ -965,16 +1047,16 @@ entry:
   %163 = load i8*, i8** %arg1
   %164 = getelementptr inbounds i8, i8* %163, i64 8
   %165 = bitcast i8* %164 to i16*
-  %NullCheck72 = icmp ne i16* %165, null
-  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+  %NullCheck71 = icmp eq i16* %165, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %166
 
 ; <label>:166                                     ; preds = %160
   %167 = load i16, i16* %165, align 8
   %168 = sext i16 %167 to i32
   %169 = bitcast i8* %162 to i16*
   %170 = trunc i32 %168 to i16
-  %NullCheck74 = icmp ne i16* %169, null
-  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+  %NullCheck73 = icmp eq i16* %169, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %171
 
 ; <label>:171                                     ; preds = %166
   store i16 %170, i16* %169, align 8
@@ -984,14 +1066,14 @@ entry:
   %173 = load i8*, i8** %arg0
   %174 = load i8*, i8** %arg1
   %175 = bitcast i8* %174 to i64*
-  %NullCheck56 = icmp ne i64* %175, null
-  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+  %NullCheck55 = icmp eq i64* %175, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %176
 
 ; <label>:176                                     ; preds = %172
   %177 = load i64, i64* %175, align 8
   %178 = bitcast i8* %173 to i64*
-  %NullCheck58 = icmp ne i64* %178, null
-  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+  %NullCheck57 = icmp eq i64* %178, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %179
 
 ; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
@@ -1000,16 +1082,16 @@ entry:
   %182 = load i8*, i8** %arg1
   %183 = getelementptr inbounds i8, i8* %182, i64 8
   %184 = bitcast i8* %183 to i16*
-  %NullCheck60 = icmp ne i16* %184, null
-  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+  %NullCheck59 = icmp eq i16* %184, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %185
 
 ; <label>:185                                     ; preds = %179
   %186 = load i16, i16* %184, align 8
   %187 = sext i16 %186 to i32
   %188 = bitcast i8* %181 to i16*
   %189 = trunc i32 %187 to i16
-  %NullCheck62 = icmp ne i16* %188, null
-  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+  %NullCheck61 = icmp eq i16* %188, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %190
 
 ; <label>:190                                     ; preds = %185
   store i16 %189, i16* %188, align 8
@@ -1017,15 +1099,15 @@ entry:
   %192 = getelementptr inbounds i8, i8* %191, i64 10
   %193 = load i8*, i8** %arg1
   %194 = getelementptr inbounds i8, i8* %193, i64 10
-  %NullCheck64 = icmp ne i8* %194, null
-  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+  %NullCheck63 = icmp eq i8* %194, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %195
 
 ; <label>:195                                     ; preds = %190
   %196 = load i8, i8* %194, align 8
   %197 = zext i8 %196 to i32
   %198 = trunc i32 %197 to i8
-  %NullCheck66 = icmp ne i8* %192, null
-  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+  %NullCheck65 = icmp eq i8* %192, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %199
 
 ; <label>:199                                     ; preds = %195
   store i8 %198, i8* %192, align 8
@@ -1035,14 +1117,14 @@ entry:
   %201 = load i8*, i8** %arg0
   %202 = load i8*, i8** %arg1
   %203 = bitcast i8* %202 to i64*
-  %NullCheck48 = icmp ne i64* %203, null
-  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+  %NullCheck47 = icmp eq i64* %203, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %204
 
 ; <label>:204                                     ; preds = %200
   %205 = load i64, i64* %203, align 8
   %206 = bitcast i8* %201 to i64*
-  %NullCheck50 = icmp ne i64* %206, null
-  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+  %NullCheck49 = icmp eq i64* %206, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %207
 
 ; <label>:207                                     ; preds = %204
   store i64 %205, i64* %206, align 8
@@ -1051,14 +1133,14 @@ entry:
   %210 = load i8*, i8** %arg1
   %211 = getelementptr inbounds i8, i8* %210, i64 8
   %212 = bitcast i8* %211 to i32*
-  %NullCheck52 = icmp ne i32* %212, null
-  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+  %NullCheck51 = icmp eq i32* %212, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %213
 
 ; <label>:213                                     ; preds = %207
   %214 = load i32, i32* %212, align 8
   %215 = bitcast i8* %209 to i32*
-  %NullCheck54 = icmp ne i32* %215, null
-  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+  %NullCheck53 = icmp eq i32* %215, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %216
 
 ; <label>:216                                     ; preds = %213
   store i32 %214, i32* %215, align 8
@@ -1068,14 +1150,14 @@ entry:
   %218 = load i8*, i8** %arg0
   %219 = load i8*, i8** %arg1
   %220 = bitcast i8* %219 to i64*
-  %NullCheck36 = icmp ne i64* %220, null
-  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64* %220, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %221
 
 ; <label>:221                                     ; preds = %217
   %222 = load i64, i64* %220, align 8
   %223 = bitcast i8* %218 to i64*
-  %NullCheck38 = icmp ne i64* %223, null
-  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+  %NullCheck37 = icmp eq i64* %223, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %224
 
 ; <label>:224                                     ; preds = %221
   store i64 %222, i64* %223, align 8
@@ -1084,14 +1166,14 @@ entry:
   %227 = load i8*, i8** %arg1
   %228 = getelementptr inbounds i8, i8* %227, i64 8
   %229 = bitcast i8* %228 to i32*
-  %NullCheck40 = icmp ne i32* %229, null
-  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i32* %229, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %230
 
 ; <label>:230                                     ; preds = %224
   %231 = load i32, i32* %229, align 8
   %232 = bitcast i8* %226 to i32*
-  %NullCheck42 = icmp ne i32* %232, null
-  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+  %NullCheck41 = icmp eq i32* %232, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %233
 
 ; <label>:233                                     ; preds = %230
   store i32 %231, i32* %232, align 8
@@ -1099,15 +1181,15 @@ entry:
   %235 = getelementptr inbounds i8, i8* %234, i64 12
   %236 = load i8*, i8** %arg1
   %237 = getelementptr inbounds i8, i8* %236, i64 12
-  %NullCheck44 = icmp ne i8* %237, null
-  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i8* %237, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %238
 
 ; <label>:238                                     ; preds = %233
   %239 = load i8, i8* %237, align 8
   %240 = zext i8 %239 to i32
   %241 = trunc i32 %240 to i8
-  %NullCheck46 = icmp ne i8* %235, null
-  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+  %NullCheck45 = icmp eq i8* %235, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %242
 
 ; <label>:242                                     ; preds = %238
   store i8 %241, i8* %235, align 8
@@ -1117,14 +1199,14 @@ entry:
   %244 = load i8*, i8** %arg0
   %245 = load i8*, i8** %arg1
   %246 = bitcast i8* %245 to i64*
-  %NullCheck24 = icmp ne i64* %246, null
-  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64* %246, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %247
 
 ; <label>:247                                     ; preds = %243
   %248 = load i64, i64* %246, align 8
   %249 = bitcast i8* %244 to i64*
-  %NullCheck26 = icmp ne i64* %249, null
-  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64* %249, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %250
 
 ; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
@@ -1133,14 +1215,14 @@ entry:
   %253 = load i8*, i8** %arg1
   %254 = getelementptr inbounds i8, i8* %253, i64 8
   %255 = bitcast i8* %254 to i32*
-  %NullCheck28 = icmp ne i32* %255, null
-  br i1 %NullCheck28, label %256, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i32* %255, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %256
 
 ; <label>:256                                     ; preds = %250
   %257 = load i32, i32* %255, align 8
   %258 = bitcast i8* %252 to i32*
-  %NullCheck30 = icmp ne i32* %258, null
-  br i1 %NullCheck30, label %259, label %ThrowNullRef29
+  %NullCheck29 = icmp eq i32* %258, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %259
 
 ; <label>:259                                     ; preds = %256
   store i32 %257, i32* %258, align 8
@@ -1149,16 +1231,16 @@ entry:
   %262 = load i8*, i8** %arg1
   %263 = getelementptr inbounds i8, i8* %262, i64 12
   %264 = bitcast i8* %263 to i16*
-  %NullCheck32 = icmp ne i16* %264, null
-  br i1 %NullCheck32, label %265, label %ThrowNullRef31
+  %NullCheck31 = icmp eq i16* %264, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %265
 
 ; <label>:265                                     ; preds = %259
   %266 = load i16, i16* %264, align 8
   %267 = sext i16 %266 to i32
   %268 = bitcast i8* %261 to i16*
   %269 = trunc i32 %267 to i16
-  %NullCheck34 = icmp ne i16* %268, null
-  br i1 %NullCheck34, label %270, label %ThrowNullRef33
+  %NullCheck33 = icmp eq i16* %268, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %270
 
 ; <label>:270                                     ; preds = %265
   store i16 %269, i16* %268, align 8
@@ -1168,14 +1250,14 @@ entry:
   %272 = load i8*, i8** %arg0
   %273 = load i8*, i8** %arg1
   %274 = bitcast i8* %273 to i64*
-  %NullCheck8 = icmp ne i64* %274, null
-  br i1 %NullCheck8, label %275, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64* %274, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %275
 
 ; <label>:275                                     ; preds = %271
   %276 = load i64, i64* %274, align 8
   %277 = bitcast i8* %272 to i64*
-  %NullCheck10 = icmp ne i64* %277, null
-  br i1 %NullCheck10, label %278, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %277, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %278
 
 ; <label>:278                                     ; preds = %275
   store i64 %276, i64* %277, align 8
@@ -1184,14 +1266,14 @@ entry:
   %281 = load i8*, i8** %arg1
   %282 = getelementptr inbounds i8, i8* %281, i64 8
   %283 = bitcast i8* %282 to i32*
-  %NullCheck12 = icmp ne i32* %283, null
-  br i1 %NullCheck12, label %284, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i32* %283, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %284
 
 ; <label>:284                                     ; preds = %278
   %285 = load i32, i32* %283, align 8
   %286 = bitcast i8* %280 to i32*
-  %NullCheck14 = icmp ne i32* %286, null
-  br i1 %NullCheck14, label %287, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i32* %286, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %287
 
 ; <label>:287                                     ; preds = %284
   store i32 %285, i32* %286, align 8
@@ -1200,16 +1282,16 @@ entry:
   %290 = load i8*, i8** %arg1
   %291 = getelementptr inbounds i8, i8* %290, i64 12
   %292 = bitcast i8* %291 to i16*
-  %NullCheck16 = icmp ne i16* %292, null
-  br i1 %NullCheck16, label %293, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i16* %292, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %293
 
 ; <label>:293                                     ; preds = %287
   %294 = load i16, i16* %292, align 8
   %295 = sext i16 %294 to i32
   %296 = bitcast i8* %289 to i16*
   %297 = trunc i32 %295 to i16
-  %NullCheck18 = icmp ne i16* %296, null
-  br i1 %NullCheck18, label %298, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i16* %296, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %298
 
 ; <label>:298                                     ; preds = %293
   store i16 %297, i16* %296, align 8
@@ -1217,15 +1299,15 @@ entry:
   %300 = getelementptr inbounds i8, i8* %299, i64 14
   %301 = load i8*, i8** %arg1
   %302 = getelementptr inbounds i8, i8* %301, i64 14
-  %NullCheck20 = icmp ne i8* %302, null
-  br i1 %NullCheck20, label %303, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i8* %302, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %303
 
 ; <label>:303                                     ; preds = %298
   %304 = load i8, i8* %302, align 8
   %305 = zext i8 %304 to i32
   %306 = trunc i32 %305 to i8
-  %NullCheck22 = icmp ne i8* %300, null
-  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i8* %300, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %307
 
 ; <label>:307                                     ; preds = %303
   store i8 %306, i8* %300, align 8
@@ -1235,14 +1317,14 @@ entry:
   %309 = load i8*, i8** %arg0
   %310 = load i8*, i8** %arg1
   %311 = bitcast i8* %310 to i64*
-  %NullCheck = icmp ne i64* %311, null
-  br i1 %NullCheck, label %312, label %ThrowNullRef
+  %NullCheck = icmp eq i64* %311, null
+  br i1 %NullCheck, label %ThrowNullRef, label %312
 
 ; <label>:312                                     ; preds = %308
   %313 = load i64, i64* %311, align 8
   %314 = bitcast i8* %309 to i64*
-  %NullCheck2 = icmp ne i64* %314, null
-  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64* %314, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %315
 
 ; <label>:315                                     ; preds = %312
   store i64 %313, i64* %314, align 8
@@ -1251,14 +1333,14 @@ entry:
   %318 = load i8*, i8** %arg1
   %319 = getelementptr inbounds i8, i8* %318, i64 8
   %320 = bitcast i8* %319 to i64*
-  %NullCheck4 = icmp ne i64* %320, null
-  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64* %320, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %321
 
 ; <label>:321                                     ; preds = %315
   %322 = load i64, i64* %320, align 8
   %323 = bitcast i8* %317 to i64*
-  %NullCheck6 = icmp ne i64* %323, null
-  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64* %323, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %324
 
 ; <label>:324                                     ; preds = %321
   store i64 %322, i64* %323, align 8
@@ -1286,15 +1368,15 @@ entry:
 ; <label>:338                                     ; preds = %333
   %339 = load i8*, i8** %arg0
   %340 = load i8*, i8** %arg1
-  %NullCheck136 = icmp ne i8* %340, null
-  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+  %NullCheck135 = icmp eq i8* %340, null
+  br i1 %NullCheck135, label %ThrowNullRef136, label %341
 
 ; <label>:341                                     ; preds = %338
   %342 = load i8, i8* %340, align 8
   %343 = zext i8 %342 to i32
   %344 = trunc i32 %343 to i8
-  %NullCheck138 = icmp ne i8* %339, null
-  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+  %NullCheck137 = icmp eq i8* %339, null
+  br i1 %NullCheck137, label %ThrowNullRef138, label %345
 
 ; <label>:345                                     ; preds = %341
   store i8 %344, i8* %339, align 8
@@ -1317,16 +1399,16 @@ entry:
   %357 = load i8*, i8** %arg0
   %358 = load i8*, i8** %arg1
   %359 = bitcast i8* %358 to i16*
-  %NullCheck140 = icmp ne i16* %359, null
-  br i1 %NullCheck140, label %360, label %ThrowNullRef139
+  %NullCheck139 = icmp eq i16* %359, null
+  br i1 %NullCheck139, label %ThrowNullRef140, label %360
 
 ; <label>:360                                     ; preds = %356
   %361 = load i16, i16* %359, align 8
   %362 = sext i16 %361 to i32
   %363 = bitcast i8* %357 to i16*
   %364 = trunc i32 %362 to i16
-  %NullCheck142 = icmp ne i16* %363, null
-  br i1 %NullCheck142, label %365, label %ThrowNullRef141
+  %NullCheck141 = icmp eq i16* %363, null
+  br i1 %NullCheck141, label %ThrowNullRef142, label %365
 
 ; <label>:365                                     ; preds = %360
   store i16 %364, i16* %363, align 8
@@ -1352,14 +1434,14 @@ entry:
   %378 = load i8*, i8** %arg0
   %379 = load i8*, i8** %arg1
   %380 = bitcast i8* %379 to i32*
-  %NullCheck144 = icmp ne i32* %380, null
-  br i1 %NullCheck144, label %381, label %ThrowNullRef143
+  %NullCheck143 = icmp eq i32* %380, null
+  br i1 %NullCheck143, label %ThrowNullRef144, label %381
 
 ; <label>:381                                     ; preds = %377
   %382 = load i32, i32* %380, align 8
   %383 = bitcast i8* %378 to i32*
-  %NullCheck146 = icmp ne i32* %383, null
-  br i1 %NullCheck146, label %384, label %ThrowNullRef145
+  %NullCheck145 = icmp eq i32* %383, null
+  br i1 %NullCheck145, label %ThrowNullRef146, label %384
 
 ; <label>:384                                     ; preds = %381
   store i32 %382, i32* %383, align 8
@@ -1384,14 +1466,14 @@ entry:
   %395 = load i8*, i8** %arg0
   %396 = load i8*, i8** %arg1
   %397 = bitcast i8* %396 to i64*
-  %NullCheck164 = icmp ne i64* %397, null
-  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+  %NullCheck163 = icmp eq i64* %397, null
+  br i1 %NullCheck163, label %ThrowNullRef164, label %398
 
 ; <label>:398                                     ; preds = %394
   %399 = load i64, i64* %397, align 8
   %400 = bitcast i8* %395 to i64*
-  %NullCheck166 = icmp ne i64* %400, null
-  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+  %NullCheck165 = icmp eq i64* %400, null
+  br i1 %NullCheck165, label %ThrowNullRef166, label %401
 
 ; <label>:401                                     ; preds = %398
   store i64 %399, i64* %400, align 8
@@ -1400,14 +1482,14 @@ entry:
   %404 = load i8*, i8** %arg1
   %405 = getelementptr inbounds i8, i8* %404, i64 8
   %406 = bitcast i8* %405 to i64*
-  %NullCheck168 = icmp ne i64* %406, null
-  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+  %NullCheck167 = icmp eq i64* %406, null
+  br i1 %NullCheck167, label %ThrowNullRef168, label %407
 
 ; <label>:407                                     ; preds = %401
   %408 = load i64, i64* %406, align 8
   %409 = bitcast i8* %403 to i64*
-  %NullCheck170 = icmp ne i64* %409, null
-  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+  %NullCheck169 = icmp eq i64* %409, null
+  br i1 %NullCheck169, label %ThrowNullRef170, label %410
 
 ; <label>:410                                     ; preds = %407
   store i64 %408, i64* %409, align 8
@@ -1437,14 +1519,14 @@ entry:
   %425 = load i8*, i8** %arg0
   %426 = load i8*, i8** %arg1
   %427 = bitcast i8* %426 to i64*
-  %NullCheck148 = icmp ne i64* %427, null
-  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+  %NullCheck147 = icmp eq i64* %427, null
+  br i1 %NullCheck147, label %ThrowNullRef148, label %428
 
 ; <label>:428                                     ; preds = %424
   %429 = load i64, i64* %427, align 8
   %430 = bitcast i8* %425 to i64*
-  %NullCheck150 = icmp ne i64* %430, null
-  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+  %NullCheck149 = icmp eq i64* %430, null
+  br i1 %NullCheck149, label %ThrowNullRef150, label %431
 
 ; <label>:431                                     ; preds = %428
   store i64 %429, i64* %430, align 8
@@ -1466,14 +1548,14 @@ entry:
   %441 = load i8*, i8** %arg0
   %442 = load i8*, i8** %arg1
   %443 = bitcast i8* %442 to i32*
-  %NullCheck152 = icmp ne i32* %443, null
-  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+  %NullCheck151 = icmp eq i32* %443, null
+  br i1 %NullCheck151, label %ThrowNullRef152, label %444
 
 ; <label>:444                                     ; preds = %440
   %445 = load i32, i32* %443, align 8
   %446 = bitcast i8* %441 to i32*
-  %NullCheck154 = icmp ne i32* %446, null
-  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+  %NullCheck153 = icmp eq i32* %446, null
+  br i1 %NullCheck153, label %ThrowNullRef154, label %447
 
 ; <label>:447                                     ; preds = %444
   store i32 %445, i32* %446, align 8
@@ -1495,16 +1577,16 @@ entry:
   %457 = load i8*, i8** %arg0
   %458 = load i8*, i8** %arg1
   %459 = bitcast i8* %458 to i16*
-  %NullCheck156 = icmp ne i16* %459, null
-  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+  %NullCheck155 = icmp eq i16* %459, null
+  br i1 %NullCheck155, label %ThrowNullRef156, label %460
 
 ; <label>:460                                     ; preds = %456
   %461 = load i16, i16* %459, align 8
   %462 = sext i16 %461 to i32
   %463 = bitcast i8* %457 to i16*
   %464 = trunc i32 %462 to i16
-  %NullCheck158 = icmp ne i16* %463, null
-  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+  %NullCheck157 = icmp eq i16* %463, null
+  br i1 %NullCheck157, label %ThrowNullRef158, label %465
 
 ; <label>:465                                     ; preds = %460
   store i16 %464, i16* %463, align 8
@@ -1525,15 +1607,15 @@ entry:
 ; <label>:474                                     ; preds = %470
   %475 = load i8*, i8** %arg0
   %476 = load i8*, i8** %arg1
-  %NullCheck160 = icmp ne i8* %476, null
-  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+  %NullCheck159 = icmp eq i8* %476, null
+  br i1 %NullCheck159, label %ThrowNullRef160, label %477
 
 ; <label>:477                                     ; preds = %474
   %478 = load i8, i8* %476, align 8
   %479 = zext i8 %478 to i32
   %480 = trunc i32 %479 to i8
-  %NullCheck162 = icmp ne i8* %475, null
-  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+  %NullCheck161 = icmp eq i8* %475, null
+  br i1 %NullCheck161, label %ThrowNullRef162, label %481
 
 ; <label>:481                                     ; preds = %477
   store i8 %480, i8* %475, align 8
@@ -1553,343 +1635,343 @@ ThrowNullRef:                                     ; preds = %308
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %312
+ThrowNullRef2:                                    ; preds = %312
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %315
+ThrowNullRef4:                                    ; preds = %315
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %321
+ThrowNullRef6:                                    ; preds = %321
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %271
+ThrowNullRef8:                                    ; preds = %271
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %275
+ThrowNullRef10:                                   ; preds = %275
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %278
+ThrowNullRef12:                                   ; preds = %278
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %284
+ThrowNullRef14:                                   ; preds = %284
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %287
+ThrowNullRef16:                                   ; preds = %287
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %293
+ThrowNullRef18:                                   ; preds = %293
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %298
+ThrowNullRef20:                                   ; preds = %298
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %303
+ThrowNullRef22:                                   ; preds = %303
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %243
+ThrowNullRef24:                                   ; preds = %243
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %247
+ThrowNullRef26:                                   ; preds = %247
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %250
+ThrowNullRef28:                                   ; preds = %250
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %256
+ThrowNullRef30:                                   ; preds = %256
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %259
+ThrowNullRef32:                                   ; preds = %259
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %265
+ThrowNullRef34:                                   ; preds = %265
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %217
+ThrowNullRef36:                                   ; preds = %217
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %221
+ThrowNullRef38:                                   ; preds = %221
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %224
+ThrowNullRef40:                                   ; preds = %224
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %230
+ThrowNullRef42:                                   ; preds = %230
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %233
+ThrowNullRef44:                                   ; preds = %233
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %238
+ThrowNullRef46:                                   ; preds = %238
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %200
+ThrowNullRef48:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %204
+ThrowNullRef50:                                   ; preds = %204
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %207
+ThrowNullRef52:                                   ; preds = %207
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %213
+ThrowNullRef54:                                   ; preds = %213
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %172
+ThrowNullRef56:                                   ; preds = %172
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %176
+ThrowNullRef58:                                   ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %179
+ThrowNullRef60:                                   ; preds = %179
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %185
+ThrowNullRef62:                                   ; preds = %185
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %190
+ThrowNullRef64:                                   ; preds = %190
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %195
+ThrowNullRef66:                                   ; preds = %195
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %153
+ThrowNullRef68:                                   ; preds = %153
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %157
+ThrowNullRef70:                                   ; preds = %157
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %160
+ThrowNullRef72:                                   ; preds = %160
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %166
+ThrowNullRef74:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %136
+ThrowNullRef76:                                   ; preds = %136
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %140
+ThrowNullRef78:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %143
+ThrowNullRef80:                                   ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %148
+ThrowNullRef82:                                   ; preds = %148
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %128
+ThrowNullRef84:                                   ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %132
+ThrowNullRef86:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %100
+ThrowNullRef88:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %104
+ThrowNullRef90:                                   ; preds = %104
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %107
+ThrowNullRef92:                                   ; preds = %107
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %113
+ThrowNullRef94:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %118
+ThrowNullRef96:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %123
+ThrowNullRef98:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %81
+ThrowNullRef100:                                  ; preds = %81
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef101:                                  ; preds = %85
+ThrowNullRef102:                                  ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef103:                                  ; preds = %88
+ThrowNullRef104:                                  ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef105:                                  ; preds = %94
+ThrowNullRef106:                                  ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef107:                                  ; preds = %64
+ThrowNullRef108:                                  ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef109:                                  ; preds = %68
+ThrowNullRef110:                                  ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef111:                                  ; preds = %71
+ThrowNullRef112:                                  ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef113:                                  ; preds = %76
+ThrowNullRef114:                                  ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef115:                                  ; preds = %56
+ThrowNullRef116:                                  ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef117:                                  ; preds = %60
+ThrowNullRef118:                                  ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef119:                                  ; preds = %37
+ThrowNullRef120:                                  ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef121:                                  ; preds = %41
+ThrowNullRef122:                                  ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef123:                                  ; preds = %46
+ThrowNullRef124:                                  ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef125:                                  ; preds = %51
+ThrowNullRef126:                                  ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef127:                                  ; preds = %27
+ThrowNullRef128:                                  ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef129:                                  ; preds = %31
+ThrowNullRef130:                                  ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef131:                                  ; preds = %19
+ThrowNullRef132:                                  ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef133:                                  ; preds = %22
+ThrowNullRef134:                                  ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef135:                                  ; preds = %338
+ThrowNullRef136:                                  ; preds = %338
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef137:                                  ; preds = %341
+ThrowNullRef138:                                  ; preds = %341
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef139:                                  ; preds = %356
+ThrowNullRef140:                                  ; preds = %356
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef141:                                  ; preds = %360
+ThrowNullRef142:                                  ; preds = %360
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef143:                                  ; preds = %377
+ThrowNullRef144:                                  ; preds = %377
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef145:                                  ; preds = %381
+ThrowNullRef146:                                  ; preds = %381
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef147:                                  ; preds = %424
+ThrowNullRef148:                                  ; preds = %424
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef149:                                  ; preds = %428
+ThrowNullRef150:                                  ; preds = %428
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef151:                                  ; preds = %440
+ThrowNullRef152:                                  ; preds = %440
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef153:                                  ; preds = %444
+ThrowNullRef154:                                  ; preds = %444
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef155:                                  ; preds = %456
+ThrowNullRef156:                                  ; preds = %456
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef157:                                  ; preds = %460
+ThrowNullRef158:                                  ; preds = %460
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef159:                                  ; preds = %474
+ThrowNullRef160:                                  ; preds = %474
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef161:                                  ; preds = %477
+ThrowNullRef162:                                  ; preds = %477
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef163:                                  ; preds = %394
+ThrowNullRef164:                                  ; preds = %394
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef165:                                  ; preds = %398
+ThrowNullRef166:                                  ; preds = %398
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef167:                                  ; preds = %401
+ThrowNullRef168:                                  ; preds = %401
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef169:                                  ; preds = %407
+ThrowNullRef170:                                  ; preds = %407
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1939,8 +2021,8 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
-  br i1 %NullCheck, label %22, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %ThrowNullRef, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
@@ -1948,8 +2030,8 @@ entry:
   store i32 %24, i32* %loc0
   %25 = load i32, i32* %loc0
   %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %26, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %27
 
 ; <label>:27                                      ; preds = %22
   %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
@@ -1971,7 +2053,7 @@ ThrowNullRef:                                     ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1989,8 +2071,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -2022,15 +2104,15 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2048,16 +2130,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
   %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
   store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %15
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
@@ -2072,8 +2154,8 @@ entry:
   %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
   %29 = ptrtoint i16 addrspace(1)* %28 to i64
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %19
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
@@ -2089,19 +2171,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2114,8 +2196,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
@@ -2128,7 +2210,7 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[loadElem]
+Failed to read AppDomain.PrepareDataForSetup[storeElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
@@ -2202,8 +2284,8 @@ entry:
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
-  br i1 %NullCheck24, label %27, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = load i64, i64 addrspace(1)* %26
@@ -2218,8 +2300,8 @@ entry:
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
-  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
   %41 = load i64, i64 addrspace(1)* %39
@@ -2236,8 +2318,8 @@ entry:
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
-  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
   %54 = load i64, i64 addrspace(1)* %52
@@ -2252,8 +2334,8 @@ entry:
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
   %67 = load i64, i64 addrspace(1)* %65
@@ -2270,8 +2352,8 @@ entry:
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
-  br i1 %NullCheck16, label %79, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
   %80 = load i64, i64 addrspace(1)* %78
@@ -2286,8 +2368,8 @@ entry:
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
-  br i1 %NullCheck18, label %92, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
   %93 = load i64, i64 addrspace(1)* %91
@@ -2304,8 +2386,8 @@ entry:
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
-  br i1 %NullCheck12, label %105, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = load i64, i64 addrspace(1)* %104
@@ -2320,8 +2402,8 @@ entry:
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
-  br i1 %NullCheck14, label %118, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
   %119 = load i64, i64 addrspace(1)* %117
@@ -2337,8 +2419,8 @@ entry:
 
 ; <label>:128                                     ; preds = %20
   %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
-  br i1 %NullCheck4, label %130, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %129, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %130
 
 ; <label>:130                                     ; preds = %128
   %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
@@ -2346,8 +2428,8 @@ entry:
   %133 = load i16, i16 addrspace(1)* %132, align 8
   %134 = zext i16 %133 to i32
   %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
-  br i1 %NullCheck6, label %136, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %135, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %136
 
 ; <label>:136                                     ; preds = %130
   %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
@@ -2360,8 +2442,8 @@ entry:
 
 ; <label>:143                                     ; preds = %136
   %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
-  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %144, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %145
 
 ; <label>:145                                     ; preds = %143
   %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
@@ -2369,8 +2451,8 @@ entry:
   %148 = load i16, i16 addrspace(1)* %147, align 8
   %149 = zext i16 %148 to i32
   %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %150, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %151
 
 ; <label>:151                                     ; preds = %145
   %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
@@ -2388,8 +2470,8 @@ entry:
 
 ; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
-  br i1 %NullCheck, label %163, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %ThrowNullRef, label %163
 
 ; <label>:163                                     ; preds = %161
   %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
@@ -2399,8 +2481,8 @@ entry:
 
 ; <label>:167                                     ; preds = %163
   %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
-  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %168, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %169
 
 ; <label>:169                                     ; preds = %167
   %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
@@ -2432,55 +2514,55 @@ ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %167
+ThrowNullRef2:                                    ; preds = %167
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %128
+ThrowNullRef4:                                    ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %130
+ThrowNullRef6:                                    ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %143
+ThrowNullRef8:                                    ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %145
+ThrowNullRef10:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %102
+ThrowNullRef12:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %105
+ThrowNullRef14:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %76
+ThrowNullRef16:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %79
+ThrowNullRef18:                                   ; preds = %79
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %50
+ThrowNullRef20:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %53
+ThrowNullRef22:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %24
+ThrowNullRef24:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %27
+ThrowNullRef26:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2503,15 +2585,15 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2519,16 +2601,16 @@ entry:
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
   store i32 %8, i32* %loc0
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
   %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
   store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
@@ -2546,16 +2628,16 @@ entry:
 
 ; <label>:23                                      ; preds = %64
   %24 = load i16*, i16** %loc3
-  %NullCheck12 = icmp ne i16* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i16* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
   store i32 %27, i32* %loc5
   %28 = load i16*, i16** %loc4
-  %NullCheck14 = icmp ne i16* %28, null
-  br i1 %NullCheck14, label %29, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %28, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = load i16, i16* %28, align 8
@@ -2620,15 +2702,15 @@ entry:
 
 ; <label>:67                                      ; preds = %64
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
-  br i1 %NullCheck8, label %69, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %68, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %69
 
 ; <label>:69                                      ; preds = %67
   %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
   %71 = load i32, i32 addrspace(1)* %70
   %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
-  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %73
 
 ; <label>:73                                      ; preds = %69
   %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
@@ -2645,31 +2727,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %67
+ThrowNullRef8:                                    ; preds = %67
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %69
+ThrowNullRef10:                                   ; preds = %69
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2710,14 +2792,14 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
   %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
@@ -2730,14 +2812,14 @@ entry:
 
 ; <label>:11                                      ; preds = %4
   %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
   %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
@@ -2749,14 +2831,14 @@ entry:
 
 ; <label>:22                                      ; preds = %16
   %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
   %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
-  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
-  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
@@ -2804,23 +2886,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2836,7 +2918,280 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[loadElem]
+Successfully read RuntimeType.IsAssignableFrom
+
+define i8 @RuntimeType.IsAssignableFrom(%System.RuntimeType addrspace(1)* %param0, %System.Type addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.RuntimeType addrspace(1)*
+  %arg1 = alloca %System.Type addrspace(1)*
+  %loc0 = alloca %System.RuntimeType addrspace(1)*
+  %loc1 = alloca %"System.Type[]" addrspace(1)*
+  %loc2 = alloca i32
+  store %System.RuntimeType addrspace(1)* %param0, %System.RuntimeType addrspace(1)** %this
+  store %System.Type addrspace(1)* %param1, %System.Type addrspace(1)** %arg1
+  %0 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %1 = icmp ne %System.Type addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i8 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %5 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %6 = bitcast %System.Type addrspace(1)* %4 to %System.Object addrspace(1)*
+  %7 = bitcast %System.RuntimeType addrspace(1)* %5 to %System.Object addrspace(1)*
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %6, %System.Object addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %3
+  ret i8 1
+
+; <label>:12                                      ; preds = %3
+  %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 152
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 32
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
+  %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
+  %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
+  store %System.RuntimeType addrspace(1)* %25, %System.RuntimeType addrspace(1)** %loc0
+  %26 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %27 = icmp eq %System.RuntimeType addrspace(1)* %26, null
+  br i1 %27, label %34, label %28
+
+; <label>:28                                      ; preds = %15
+  %29 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %30 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)*)*)(%System.RuntimeType addrspace(1)* %29, %System.RuntimeType addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+; <label>:34                                      ; preds = %15
+  %35 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %36 = call %System.Reflection.Emit.TypeBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Reflection.Emit.TypeBuilder addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %35)
+  %37 = icmp eq %System.Reflection.Emit.TypeBuilder addrspace(1)* %36, null
+  br i1 %37, label %139, label %38
+
+; <label>:38                                      ; preds = %34
+  %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %42
+
+; <label>:42                                      ; preds = %38
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 152
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 40
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
+  %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
+  %53 = zext i8 %52 to i32
+  %54 = icmp eq i32 %53, 0
+  br i1 %54, label %56, label %55
+
+; <label>:55                                      ; preds = %42
+  ret i8 1
+
+; <label>:56                                      ; preds = %42
+  %57 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %58 = bitcast %System.RuntimeType addrspace(1)* %57 to %System.Type addrspace(1)*
+  %59 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %58)
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %64 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.Type addrspace(1)* %63, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = bitcast %System.RuntimeType addrspace(1)* %64 to %System.Type addrspace(1)*
+  %67 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %63, %System.Type addrspace(1)* %66)
+  %68 = zext i8 %67 to i32
+  %69 = trunc i32 %68 to i8
+  ret i8 %69
+
+; <label>:70                                      ; preds = %56
+  %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
+  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %73
+
+; <label>:73                                      ; preds = %70
+  %74 = load i64, i64 addrspace(1)* %72
+  %75 = add i64 %74, 128
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = add i64 %77, 0
+  %79 = inttoptr i64 %78 to i64*
+  %80 = load i64, i64* %79
+  %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
+  %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
+  %83 = call i8 %82(%System.Type addrspace(1)* %81)
+  %84 = zext i8 %83 to i32
+  %85 = icmp eq i32 %84, 0
+  br i1 %85, label %139, label %86
+
+; <label>:86                                      ; preds = %73
+  %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
+  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %89
+
+; <label>:89                                      ; preds = %86
+  %90 = load i64, i64 addrspace(1)* %88
+  %91 = add i64 %90, 128
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = add i64 %93, 24
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
+  %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
+  %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
+  store %"System.Type[]" addrspace(1)* %99, %"System.Type[]" addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %129
+
+; <label>:100                                     ; preds = %132
+  %101 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %102 = load i32, i32* %loc2
+  %NullCheck11 = icmp eq %"System.Type[]" addrspace(1)* %101, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %103
+
+; <label>:103                                     ; preds = %100
+  %104 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 1
+  %105 = load i32, i32 addrspace(1)* %104
+  %106 = zext i32 %105 to i64
+  %107 = zext i32 %102 to i64
+  %BoundsCheck = icmp uge i64 %107, %106
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %108
+
+; <label>:108                                     ; preds = %103
+  %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
+  %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
+  %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
+  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %113
+
+; <label>:113                                     ; preds = %108
+  %114 = load i64, i64 addrspace(1)* %112
+  %115 = add i64 %114, 152
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = add i64 %117, 56
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
+  %123 = zext i8 %122 to i32
+  %124 = icmp ne i32 %123, 0
+  br i1 %124, label %126, label %125
+
+; <label>:125                                     ; preds = %113
+  ret i8 0
+
+; <label>:126                                     ; preds = %113
+  %127 = load i32, i32* %loc2
+  %128 = add i32 %127, 1
+  store i32 %128, i32* %loc2
+  br label %129
+
+; <label>:129                                     ; preds = %89, %126
+  %130 = load i32, i32* %loc2
+  %131 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %NullCheck9 = icmp eq %"System.Type[]" addrspace(1)* %131, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %132
+
+; <label>:132                                     ; preds = %129
+  %133 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %131, i32 0, i32 1
+  %134 = load i32, i32 addrspace(1)* %133
+  %135 = zext i32 %134 to i64
+  %136 = trunc i64 %135 to i32
+  %137 = icmp slt i32 %130, %136
+  br i1 %137, label %100, label %138
+
+; <label>:138                                     ; preds = %132
+  ret i8 1
+
+; <label>:139                                     ; preds = %34, %73
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %129
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %103
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -2893,7 +3248,7 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElem]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -2904,8 +3259,8 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -2997,8 +3352,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
@@ -3059,8 +3414,8 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -3087,8 +3442,8 @@ entry:
 
 ; <label>:17                                      ; preds = %5, %11
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
@@ -3097,8 +3452,8 @@ entry:
 
 ; <label>:22                                      ; preds = %1, %11
   %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
@@ -3109,11 +3464,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %17
+ThrowNullRef2:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %22
+ThrowNullRef4:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3167,15 +3522,15 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
   %15 = load i32, i32 addrspace(1)* %14
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
@@ -3198,7 +3553,7 @@ ThrowNullRef:                                     ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef2:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3232,8 +3587,8 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
@@ -3312,8 +3667,8 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -3327,8 +3682,8 @@ entry:
 ; <label>:5                                       ; preds = %43
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %7 = load i32, i32* %loc1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck6, label %8, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
@@ -3366,8 +3721,8 @@ entry:
 ; <label>:32                                      ; preds = %21, %25
   %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
   %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
-  br i1 %NullCheck8, label %35, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = trunc i32 %34 to i16
@@ -3380,8 +3735,8 @@ entry:
 ; <label>:40                                      ; preds = %1, %35
   %41 = load i32, i32* %loc1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
-  br i1 %NullCheck2, label %43, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %42, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
@@ -3392,8 +3747,8 @@ entry:
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
   %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
-  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
   %51 = load i64, i64 addrspace(1)* %49
@@ -3412,19 +3767,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %40
+ThrowNullRef2:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %47
+ThrowNullRef4:                                    ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %5
+ThrowNullRef6:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %32
+ThrowNullRef8:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3467,8 +3822,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
@@ -3492,11 +3847,391 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(i16* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store i16* %param0, i16** %arg0
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load i32, i32* %arg3
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %42, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %37, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg2
+  %13 = load i32, i32* %arg3
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %37, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %24 = load i32, i32* %arg2
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load i16*, i16** %arg0
+  %35 = load i32, i32* %arg3
+  %36 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %36, i16* %34, i32 %35)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:37                                      ; preds = %5, %16
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %39)
+  %41 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41, %System.String addrspace(1)* %38, %System.String addrspace(1)* %40)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41) #0
+  unreachable
+
+; <label>:42                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
-Failed to read StringBuilder.ToString[loadElemA]
+Successfully read StringBuilder.ToString
+
+define %System.String addrspace(1)* @StringBuilder.ToString(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i16*
+  %loc3 = alloca %"System.Char[]" addrspace(1)*
+  %loc4 = alloca i32
+  %loc5 = alloca i32
+  %loc6 = alloca i16 addrspace(1)*
+  %loc7 = alloca %System.String addrspace(1)*
+  %loc8 = alloca %"System.Char[]" addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %0)
+  %2 = icmp ne i32 %1, 0
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %4
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %6)
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %7)
+  store %System.String addrspace(1)* %8, %System.String addrspace(1)** %loc0
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.Text.StringBuilder addrspace(1)* %9, %System.Text.StringBuilder addrspace(1)** %loc1
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  store %System.String addrspace(1)* %10, %System.String addrspace(1)** %loc7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc7
+  %12 = ptrtoint %System.String addrspace(1)* %11 to i64
+  %13 = icmp eq i64 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %5
+  %15 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %16 = sext i32 %15 to i64
+  %17 = add i64 %12, %16
+  br label %18
+
+; <label>:18                                      ; preds = %5, %14
+  %19 = phi i64 [ %12, %5 ], [ %17, %14 ]
+  %20 = inttoptr i64 %19 to i16*
+  store i16* %20, i16** %loc2
+  br label %21
+
+; <label>:21                                      ; preds = %98, %18
+  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %22, null
+  br i1 %NullCheck, label %ThrowNullRef, label %23
+
+; <label>:23                                      ; preds = %21
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 3
+  %25 = load i32, i32 addrspace(1)* %24, align 8
+  %26 = icmp sle i32 %25, 0
+  br i1 %26, label %96, label %27
+
+; <label>:27                                      ; preds = %23
+  %28 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %28, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %29
+
+; <label>:29                                      ; preds = %27
+  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %28, i32 0, i32 1
+  %31 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %30, align 8
+  store %"System.Char[]" addrspace(1)* %31, %"System.Char[]" addrspace(1)** %loc3
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %33
+
+; <label>:33                                      ; preds = %29
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  store i32 %35, i32* %loc4
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  %39 = load i32, i32 addrspace(1)* %38, align 8
+  store i32 %39, i32* %loc5
+  %40 = load i32, i32* %loc5
+  %41 = load i32, i32* %loc4
+  %42 = add i32 %40, %41
+  %43 = zext i32 %42 to i64
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %45
+
+; <label>:45                                      ; preds = %37
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = sext i32 %47 to i64
+  %49 = icmp sgt i64 %43, %48
+  br i1 %49, label %91, label %50
+
+; <label>:50                                      ; preds = %45
+  %51 = load i32, i32* %loc5
+  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %52, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %53
+
+; <label>:53                                      ; preds = %50
+  %54 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %52, i32 0, i32 1
+  %55 = load i32, i32 addrspace(1)* %54
+  %56 = zext i32 %55 to i64
+  %57 = trunc i64 %56 to i32
+  %58 = icmp ugt i32 %51, %57
+  br i1 %58, label %91, label %59
+
+; <label>:59                                      ; preds = %53
+  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  store %"System.Char[]" addrspace(1)* %60, %"System.Char[]" addrspace(1)** %loc8
+  %61 = icmp eq %"System.Char[]" addrspace(1)* %60, null
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %63, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %64
+
+; <label>:64                                      ; preds = %62
+  %65 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %63, i32 0, i32 1
+  %66 = load i32, i32 addrspace(1)* %65
+  %67 = zext i32 %66 to i64
+  %68 = trunc i64 %67 to i32
+  %69 = icmp ne i32 %68, 0
+  br i1 %69, label %71, label %70
+
+; <label>:70                                      ; preds = %59, %64
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:71                                      ; preds = %64
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %73
+
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %BoundsCheck = icmp uge i64 0, %76
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %77
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %78, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:79                                      ; preds = %70, %77
+  %80 = load i16*, i16** %loc2
+  %81 = load i32, i32* %loc4
+  %82 = sext i32 %81 to i64
+  %83 = mul i64 %82, 2
+  %84 = bitcast i16* %80 to i8*
+  %85 = getelementptr inbounds i8, i8* %84, i64 %83
+  %86 = load i16 addrspace(1)*, i16 addrspace(1)** %loc6
+  %87 = ptrtoint i16 addrspace(1)* %86 to i64
+  %88 = load i32, i32* %loc5
+  %89 = bitcast i8* %85 to i16*
+  %90 = inttoptr i64 %87 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %89, i16* %90, i32 %88)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %96
+
+; <label>:91                                      ; preds = %45, %53
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %94 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %93)
+  %95 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95, %System.String addrspace(1)* %92, %System.String addrspace(1)* %94)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95) #0
+  unreachable
+
+; <label>:96                                      ; preds = %23, %79
+  %97 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %97, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %98
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %97, i32 0, i32 2
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  store %System.Text.StringBuilder addrspace(1)* %100, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %102 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %102, label %21, label %103
+
+; <label>:103                                     ; preds = %98
+  store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc7
+  %104 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  ret %System.String addrspace(1)* %104
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method StringBuilder::get_Length using LLILCJit
+Successfully read StringBuilder.get_Length
+
+define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
+Successfully read RuntimeHelpers.get_OffsetToStringData
+
+define i32 @RuntimeHelpers.get_OffsetToStringData() {
+entry:
+  ret i32 12
+}
+
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
 Successfully read CultureData.CreateCultureData
 
@@ -3514,23 +4249,23 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
   store i8 %4, i8 addrspace(1)* %6
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
@@ -3549,11 +4284,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3566,50 +4301,50 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
   store i32 -1, i32 addrspace(1)* %2
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
   store i32 -1, i32 addrspace(1)* %8
   %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
   store i32 -1, i32 addrspace(1)* %14
   %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
   store i32 -1, i32 addrspace(1)* %17
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
@@ -3623,27 +4358,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3675,7 +4410,136 @@ Failed to read Dictionary`2.Insert[non-const derefAddress]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
 Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
-Failed to read HashHelpers.GetPrime[loadElem]
+Successfully read HashHelpers.GetPrime
+
+define i32 @HashHelpers.GetPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %6, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5, %System.String addrspace(1)* %4)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5) #0
+  unreachable
+
+; <label>:6                                       ; preds = %entry
+  store i32 0, i32* %loc0
+  br label %29
+
+; <label>:7                                       ; preds = %35
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 1296
+  %10 = addrspacecast i8 addrspace(1)* %9 to %"System.Int32[]" addrspace(1)**
+  %11 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %10
+  %12 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Int32[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = zext i32 %15 to i64
+  %17 = zext i32 %12 to i64
+  %BoundsCheck = icmp uge i64 %17, %16
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 3, i32 %12
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  store i32 %20, i32* %loc1
+  %21 = load i32, i32* %loc1
+  %22 = load i32, i32* %arg0
+  %23 = icmp slt i32 %21, %22
+  br i1 %23, label %26, label %24
+
+; <label>:24                                      ; preds = %18
+  %25 = load i32, i32* %loc1
+  ret i32 %25
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %loc0
+  %28 = add i32 %27, 1
+  store i32 %28, i32* %loc0
+  br label %29
+
+; <label>:29                                      ; preds = %6, %26
+  %30 = load i32, i32* %loc0
+  %31 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %32 = getelementptr inbounds i8, i8 addrspace(1)* %31, i64 1296
+  %33 = addrspacecast i8 addrspace(1)* %32 to %"System.Int32[]" addrspace(1)**
+  %34 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %33
+  %NullCheck = icmp eq %"System.Int32[]" addrspace(1)* %34, null
+  br i1 %NullCheck, label %ThrowNullRef, label %35
+
+; <label>:35                                      ; preds = %29
+  %36 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %34, i32 0, i32 1
+  %37 = load i32, i32 addrspace(1)* %36
+  %38 = zext i32 %37 to i64
+  %39 = trunc i64 %38 to i32
+  %40 = icmp slt i32 %30, %39
+  br i1 %40, label %7, label %41
+
+; <label>:41                                      ; preds = %35
+  %42 = load i32, i32* %arg0
+  %43 = or i32 %42, 1
+  store i32 %43, i32* %loc2
+  br label %59
+
+; <label>:44                                      ; preds = %59
+  %45 = load i32, i32* %loc2
+  %46 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %45)
+  %47 = zext i8 %46 to i32
+  %48 = icmp eq i32 %47, 0
+  br i1 %48, label %56, label %49
+
+; <label>:49                                      ; preds = %44
+  %50 = load i32, i32* %loc2
+  %51 = sub i32 %50, 1
+  %52 = srem i32 %51, 101
+  %53 = icmp eq i32 %52, 0
+  br i1 %53, label %56, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = load i32, i32* %loc2
+  ret i32 %55
+
+; <label>:56                                      ; preds = %44, %49
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %57, 2
+  store i32 %58, i32* %loc2
+  br label %59
+
+; <label>:59                                      ; preds = %41, %56
+  %60 = load i32, i32* %loc2
+  %61 = icmp slt i32 %60, 2147483647
+  br i1 %61, label %44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load i32, i32* %arg0
+  ret i32 %63
+
+ThrowNullRef:                                     ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
 Successfully read GenericEqualityComparer`1.GetHashCode
 
@@ -3694,14 +4558,14 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
   %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load i64, i64 addrspace(1)* %7
@@ -3720,7 +4584,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3750,8 +4614,8 @@ entry:
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
@@ -3796,8 +4660,8 @@ entry:
   %35 = bitcast i16* %34 to i8*
   %36 = getelementptr inbounds i8, i8* %35, i64 2
   %37 = bitcast i8* %36 to i16*
-  %NullCheck4 = icmp ne i16* %37, null
-  br i1 %NullCheck4, label %38, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %37, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %38
 
 ; <label>:38                                      ; preds = %27
   %39 = load i16, i16* %37, align 8
@@ -3824,8 +4688,8 @@ entry:
 
 ; <label>:54                                      ; preds = %22, %43
   %55 = load i16*, i16** %loc4
-  %NullCheck2 = icmp ne i16* %55, null
-  br i1 %NullCheck2, label %56, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i16* %55, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %56
 
 ; <label>:56                                      ; preds = %54
   %57 = load i16, i16* %55, align 8
@@ -3850,11 +4714,11 @@ ThrowNullRef:                                     ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %54
+ThrowNullRef2:                                    ; preds = %54
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %27
+ThrowNullRef4:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3871,8 +4735,8 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -3907,8 +4771,8 @@ entry:
 
 ; <label>:26                                      ; preds = %19
   %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
-  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %28
 
 ; <label>:28                                      ; preds = %26
   %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
@@ -3920,7 +4784,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3972,8 +4836,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
@@ -3984,26 +4848,26 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
-  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
@@ -4014,8 +4878,8 @@ entry:
 ; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
@@ -4024,8 +4888,8 @@ entry:
 
 ; <label>:25                                      ; preds = %1, %16, %23
   %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
-  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
@@ -4036,27 +4900,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %20
+ThrowNullRef10:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4069,8 +4933,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -4081,8 +4945,8 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
@@ -4091,8 +4955,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1, %8
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
@@ -4103,11 +4967,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4128,24 +4992,24 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   store i32 %3, i32* %loc0
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
   %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
   store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck4, label %9, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
@@ -4164,15 +5028,15 @@ entry:
 ; <label>:18                                      ; preds = %70
   %19 = load i16*, i16** %loc3
   %20 = bitcast i16* %19 to i64*
-  %NullCheck10 = icmp ne i64* %20, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %20, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = load i64, i64* %20, align 8
   %23 = load i16*, i16** %loc4
   %24 = bitcast i16* %23 to i64*
-  %NullCheck12 = icmp ne i64* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = load i64, i64* %24, align 8
@@ -4188,8 +5052,8 @@ entry:
   %31 = bitcast i16* %30 to i8*
   %32 = getelementptr inbounds i8, i8* %31, i64 8
   %33 = bitcast i8* %32 to i64*
-  %NullCheck14 = icmp ne i64* %33, null
-  br i1 %NullCheck14, label %34, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = load i64, i64* %33, align 8
@@ -4197,8 +5061,8 @@ entry:
   %37 = bitcast i16* %36 to i8*
   %38 = getelementptr inbounds i8, i8* %37, i64 8
   %39 = bitcast i8* %38 to i64*
-  %NullCheck16 = icmp ne i64* %39, null
-  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %40
 
 ; <label>:40                                      ; preds = %34
   %41 = load i64, i64* %39, align 8
@@ -4214,8 +5078,8 @@ entry:
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %NullCheck18 = icmp ne i64* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = load i64, i64* %48, align 8
@@ -4223,8 +5087,8 @@ entry:
   %52 = bitcast i16* %51 to i8*
   %53 = getelementptr inbounds i8, i8* %52, i64 16
   %54 = bitcast i8* %53 to i64*
-  %NullCheck20 = icmp ne i64* %54, null
-  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64* %54, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %55
 
 ; <label>:55                                      ; preds = %49
   %56 = load i64, i64* %54, align 8
@@ -4262,15 +5126,15 @@ entry:
 ; <label>:74                                      ; preds = %95
   %75 = load i16*, i16** %loc3
   %76 = bitcast i16* %75 to i32*
-  %NullCheck6 = icmp ne i32* %76, null
-  br i1 %NullCheck6, label %77, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32* %76, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %77
 
 ; <label>:77                                      ; preds = %74
   %78 = load i32, i32* %76, align 8
   %79 = load i16*, i16** %loc4
   %80 = bitcast i16* %79 to i32*
-  %NullCheck8 = icmp ne i32* %80, null
-  br i1 %NullCheck8, label %81, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i32* %80, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %81
 
 ; <label>:81                                      ; preds = %77
   %82 = load i32, i32* %80, align 8
@@ -4318,43 +5182,43 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %74
+ThrowNullRef6:                                    ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %77
+ThrowNullRef8:                                    ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %29
+ThrowNullRef14:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %34
+ThrowNullRef16:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4376,8 +5240,8 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load i64, i64 addrspace(1)* %4
@@ -4389,8 +5253,8 @@ entry:
   %12 = load i64, i64* %11
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %5
   %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
@@ -4399,8 +5263,8 @@ entry:
   %18 = load i8, i8* %arg2
   %19 = zext i8 %18 to i32
   %20 = trunc i32 %19 to i8
-  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %15
   %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
@@ -4411,11 +5275,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4442,8 +5306,8 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
@@ -4466,16 +5330,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
   %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = load i64, i64 addrspace(1)* %19
@@ -4500,8 +5364,8 @@ entry:
 ; <label>:35                                      ; preds = %30
   %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
@@ -4514,8 +5378,8 @@ entry:
 
 ; <label>:42                                      ; preds = %1, %38
   %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
-  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
@@ -4526,19 +5390,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %35
+ThrowNullRef2:                                    ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %42
+ThrowNullRef8:                                    ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4551,14 +5415,14 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
@@ -4570,7 +5434,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4583,8 +5447,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
@@ -4613,51 +5477,51 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
   %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
   %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
   %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
   %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
-  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
   store i64 %21, i64 addrspace(1)* %23
   %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %25 = load i64, i64* %loc0
-  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
@@ -4668,27 +5532,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %22
+ThrowNullRef12:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4701,8 +5565,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
@@ -4713,19 +5577,19 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
@@ -4734,8 +5598,8 @@ entry:
 
 ; <label>:15                                      ; preds = %1, %13
   %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
@@ -4746,19 +5610,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %15
+ThrowNullRef8:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4771,8 +5635,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -4831,8 +5695,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
@@ -4882,8 +5746,8 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
-  br i1 %NullCheck, label %17, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %ThrowNullRef, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
@@ -4894,15 +5758,15 @@ entry:
 
 ; <label>:22                                      ; preds = %17
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
-  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
   %26 = load i32, i32 addrspace(1)* %25
   %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
-  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %27, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
@@ -4925,8 +5789,8 @@ entry:
 ; <label>:40                                      ; preds = %17
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
-  br i1 %NullCheck6, label %43, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %41, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
@@ -4938,34 +5802,17 @@ ThrowNullRef:                                     ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %24
+ThrowNullRef4:                                    ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %40
+ThrowNullRef6:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
-}
-
-INFO:  jitting method Object::ReferenceEquals using LLILCJit
-Successfully read Object.ReferenceEquals
-
-define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
-entry:
-  %arg0 = alloca %System.Object addrspace(1)*
-  %arg1 = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
-  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
-  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = icmp eq %System.Object addrspace(1)* %0, %1
-  %3 = sext i1 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
 }
 
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
@@ -4978,21 +5825,21 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
   %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
-  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
@@ -5007,28 +5854,28 @@ entry:
 ; <label>:13                                      ; preds = %8, %12
   %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
   %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
   %21 = load i32, i32 addrspace(1)* %20, align 8
   %22 = add i32 %21, 1
-  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
   store i32 %22, i32 addrspace(1)* %24
   %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
@@ -5039,27 +5886,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5077,7 +5924,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::Setup using LLILCJit
-Failed to read AppDomain.Setup[loadElem]
+Failed to read AppDomain.Setup[unbox]
 INFO:  jitting method Thread::GetDomain using LLILCJit
 Successfully read Thread.GetDomain
 
@@ -5108,8 +5955,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
@@ -5122,14 +5969,14 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
   %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
@@ -5141,11 +5988,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5173,8 +6020,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -5189,7 +6036,328 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
 Failed to read KeyCollection.System.Collections.Generic.IEnumerable<TKey>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Successfully read Enumerator.MoveNext
+
+define i8 @Enumerator.MoveNext(%"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.RuntimeTypeHandle* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*
+  %"$TypeArg" = alloca %System.RuntimeTypeHandle*
+  store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
+  %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 8
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %76, label %12
+
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
+  br label %76
+
+; <label>:13                                      ; preds = %85
+  %14 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck19 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %15
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, i32 0, i32 0
+  %17 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %16, align 8
+  %NullCheck21 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, i32 0, i32 2
+  %20 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %19, align 8
+  %21 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck23 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %22
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, i32 0, i32 2
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %NullCheck25 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 3, i32 %24
+  %NullCheck27 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %32
+
+; <label>:32                                      ; preds = %30
+  %33 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, i32 0, i32 2
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = icmp slt i32 %34, 0
+  br i1 %35, label %68, label %36
+
+; <label>:36                                      ; preds = %32
+  %37 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %38 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck29 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %39
+
+; <label>:39                                      ; preds = %36
+  %40 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, i32 0, i32 0
+  %41 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %40, align 8
+  %NullCheck31 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, i32 0, i32 2
+  %44 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %43, align 8
+  %45 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck33 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, i32 0, i32 2
+  %48 = load i32, i32 addrspace(1)* %47, align 8
+  %NullCheck35 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %49
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = zext i32 %51 to i64
+  %53 = zext i32 %48 to i64
+  %BoundsCheck37 = icmp uge i64 %53, %52
+  br i1 %BoundsCheck37, label %ThrowIndexOutOfRange38, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 3, i32 %48
+  %NullCheck39 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %56
+
+; <label>:56                                      ; preds = %54
+  %57 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, i32 0, i32 0
+  %58 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck41 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %59
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %60, %System.__Canon addrspace(1)* %58)
+  %61 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck43 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  %64 = load i32, i32 addrspace(1)* %63, align 8
+  %65 = add i32 %64, 1
+  %NullCheck45 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  store i32 %65, i32 addrspace(1)* %67
+  ret i8 1
+
+; <label>:68                                      ; preds = %32
+  %69 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck47 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %73 = add i32 %72, 1
+  %NullCheck49 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %74
+
+; <label>:74                                      ; preds = %70
+  %75 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  store i32 %73, i32 addrspace(1)* %75
+  br label %76
+
+; <label>:76                                      ; preds = %8, %12, %74
+  %77 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %78
+
+; <label>:78                                      ; preds = %76
+  %79 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, i32 0, i32 2
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck7 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %82
+
+; <label>:82                                      ; preds = %78
+  %83 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, i32 0, i32 0
+  %84 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %83, align 8
+  %NullCheck9 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %85
+
+; <label>:85                                      ; preds = %82
+  %86 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, i32 0, i32 7
+  %87 = load i32, i32 addrspace(1)* %86, align 8
+  %88 = icmp ult i32 %80, %87
+  br i1 %88, label %13, label %89
+
+; <label>:89                                      ; preds = %85
+  %90 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %91 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck11 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %92
+
+; <label>:92                                      ; preds = %89
+  %93 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, i32 0, i32 0
+  %94 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck13 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %95
+
+; <label>:95                                      ; preds = %92
+  %96 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, i32 0, i32 7
+  %97 = load i32, i32 addrspace(1)* %96, align 8
+  %98 = add i32 %97, 1
+  %NullCheck15 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %99
+
+; <label>:99                                      ; preds = %95
+  %100 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, i32 0, i32 2
+  store i32 %98, i32 addrspace(1)* %100
+  %101 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck17 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %102
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %103, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %92
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef22:                                   ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef24:                                   ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef26:                                   ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef28:                                   ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef30:                                   ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef32:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef34:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef36:                                   ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange38:                           ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef40:                                   ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef42:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef44:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef46:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef48:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef50:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -5200,8 +6368,8 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -5232,9 +6400,9 @@ Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
 Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
-Failed to read String.MakeSeparatorList[loadElemA]
+Failed to read String.MakeSeparatorList[storeElem]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
-Failed to read String.InternalSplitKeepEmptyEntries[loadElem]
+Failed to read String.InternalSplitKeepEmptyEntries[storeElem]
 INFO:  jitting method Path::IsRelative using LLILCJit
 Successfully read Path.IsRelative
 
@@ -5243,8 +6411,8 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -5254,8 +6422,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
@@ -5271,8 +6439,8 @@ entry:
 
 ; <label>:17                                      ; preds = %7
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
@@ -5288,8 +6456,8 @@ entry:
 
 ; <label>:29                                      ; preds = %19
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %31
 
 ; <label>:31                                      ; preds = %29
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
@@ -5300,8 +6468,8 @@ entry:
 
 ; <label>:36                                      ; preds = %31
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
-  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %37, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
@@ -5312,8 +6480,8 @@ entry:
 
 ; <label>:43                                      ; preds = %31, %38
   %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
-  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %45
 
 ; <label>:45                                      ; preds = %43
   %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
@@ -5324,8 +6492,8 @@ entry:
 
 ; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %50
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
@@ -5336,8 +6504,8 @@ entry:
 
 ; <label>:57                                      ; preds = %1, %7, %19, %45, %52
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
-  br i1 %NullCheck14, label %59, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %59
 
 ; <label>:59                                      ; preds = %57
   %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
@@ -5347,8 +6515,8 @@ entry:
 
 ; <label>:63                                      ; preds = %59
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
@@ -5359,8 +6527,8 @@ entry:
 
 ; <label>:70                                      ; preds = %65
   %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
-  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.String addrspace(1)* %71, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %72
 
 ; <label>:72                                      ; preds = %70
   %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
@@ -5379,39 +6547,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %17
+ThrowNullRef4:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %29
+ThrowNullRef6:                                    ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %36
+ThrowNullRef8:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %43
+ThrowNullRef10:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %50
+ThrowNullRef12:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %57
+ThrowNullRef14:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %63
+ThrowNullRef16:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %70
+ThrowNullRef18:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5419,7 +6587,293 @@ ThrowNullRef17:                                   ; preds = %70
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
-Failed to read String.TrimHelper[loadElem]
+Successfully read String.TrimHelper
+
+define %System.String addrspace(1)* @String.TrimHelper(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i16
+  %loc4 = alloca i32
+  %loc5 = alloca i16
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = sub i32 %3, 1
+  store i32 %4, i32* %loc0
+  store i32 0, i32* %loc1
+  %5 = load i32, i32* %arg2
+  %6 = icmp eq i32 %5, 1
+  br i1 %6, label %62, label %7
+
+; <label>:7                                       ; preds = %1
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:8                                       ; preds = %58
+  store i32 0, i32* %loc2
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load i32, i32* %loc1
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2, i32 %10
+  %13 = load i16, i16 addrspace(1)* %12
+  %14 = zext i16 %13 to i32
+  %15 = trunc i32 %14 to i16
+  store i16 %15, i16* %loc3
+  store i32 0, i32* %loc2
+  br label %34
+
+; <label>:16                                      ; preds = %37
+  %17 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %18 = load i32, i32* %loc2
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %17, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %19
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = zext i32 %18 to i64
+  %BoundsCheck = icmp uge i64 %23, %22
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %24
+
+; <label>:24                                      ; preds = %19
+  %25 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 3, i32 %18
+  %26 = load i16, i16 addrspace(1)* %25, align 8
+  %27 = zext i16 %26 to i32
+  %28 = load i16, i16* %loc3
+  %29 = zext i16 %28 to i32
+  %30 = icmp eq i32 %27, %29
+  br i1 %30, label %43, label %31
+
+; <label>:31                                      ; preds = %24
+  %32 = load i32, i32* %loc2
+  %33 = add i32 %32, 1
+  store i32 %33, i32* %loc2
+  br label %34
+
+; <label>:34                                      ; preds = %11, %31
+  %35 = load i32, i32* %loc2
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = icmp slt i32 %35, %41
+  br i1 %42, label %16, label %43
+
+; <label>:43                                      ; preds = %24, %37
+  %44 = load i32, i32* %loc2
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %45, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp eq i32 %44, %50
+  br i1 %51, label %62, label %52
+
+; <label>:52                                      ; preds = %46
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %7, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %57, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %58
+
+; <label>:58                                      ; preds = %55
+  %59 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %60 = load i32, i32 addrspace(1)* %59
+  %61 = icmp slt i32 %56, %60
+  br i1 %61, label %8, label %62
+
+; <label>:62                                      ; preds = %1, %46, %58
+  %63 = load i32, i32* %arg2
+  %64 = icmp eq i32 %63, 0
+  br i1 %64, label %122, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %66, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %67
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %66, i32 0, i32 1
+  %69 = load i32, i32 addrspace(1)* %68
+  %70 = sub i32 %69, 1
+  store i32 %70, i32* %loc0
+  br label %118
+
+; <label>:71                                      ; preds = %118
+  store i32 0, i32* %loc4
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %73 = load i32, i32* %loc0
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %74
+
+; <label>:74                                      ; preds = %71
+  %75 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 2, i32 %73
+  %76 = load i16, i16 addrspace(1)* %75
+  %77 = zext i16 %76 to i32
+  %78 = trunc i32 %77 to i16
+  store i16 %78, i16* %loc5
+  store i32 0, i32* %loc4
+  br label %97
+
+; <label>:79                                      ; preds = %100
+  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %81 = load i32, i32* %loc4
+  %NullCheck19 = icmp eq %"System.Char[]" addrspace(1)* %80, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
+
+; <label>:82                                      ; preds = %79
+  %83 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 1
+  %84 = load i32, i32 addrspace(1)* %83
+  %85 = zext i32 %84 to i64
+  %86 = zext i32 %81 to i64
+  %BoundsCheck21 = icmp uge i64 %86, %85
+  br i1 %BoundsCheck21, label %ThrowIndexOutOfRange22, label %87
+
+; <label>:87                                      ; preds = %82
+  %88 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 3, i32 %81
+  %89 = load i16, i16 addrspace(1)* %88, align 8
+  %90 = zext i16 %89 to i32
+  %91 = load i16, i16* %loc5
+  %92 = zext i16 %91 to i32
+  %93 = icmp eq i32 %90, %92
+  br i1 %93, label %106, label %94
+
+; <label>:94                                      ; preds = %87
+  %95 = load i32, i32* %loc4
+  %96 = add i32 %95, 1
+  store i32 %96, i32* %loc4
+  br label %97
+
+; <label>:97                                      ; preds = %74, %94
+  %98 = load i32, i32* %loc4
+  %99 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck15 = icmp eq %"System.Char[]" addrspace(1)* %99, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %100
+
+; <label>:100                                     ; preds = %97
+  %101 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %99, i32 0, i32 1
+  %102 = load i32, i32 addrspace(1)* %101
+  %103 = zext i32 %102 to i64
+  %104 = trunc i64 %103 to i32
+  %105 = icmp slt i32 %98, %104
+  br i1 %105, label %79, label %106
+
+; <label>:106                                     ; preds = %87, %100
+  %107 = load i32, i32* %loc4
+  %108 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck17 = icmp eq %"System.Char[]" addrspace(1)* %108, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %109
+
+; <label>:109                                     ; preds = %106
+  %110 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %108, i32 0, i32 1
+  %111 = load i32, i32 addrspace(1)* %110
+  %112 = zext i32 %111 to i64
+  %113 = trunc i64 %112 to i32
+  %114 = icmp eq i32 %107, %113
+  br i1 %114, label %122, label %115
+
+; <label>:115                                     ; preds = %109
+  %116 = load i32, i32* %loc0
+  %117 = sub i32 %116, 1
+  store i32 %117, i32* %loc0
+  br label %118
+
+; <label>:118                                     ; preds = %67, %115
+  %119 = load i32, i32* %loc0
+  %120 = load i32, i32* %loc1
+  %121 = icmp sge i32 %119, %120
+  br i1 %121, label %71, label %122
+
+; <label>:122                                     ; preds = %62, %109, %118
+  %123 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %124 = load i32, i32* %loc1
+  %125 = load i32, i32* %loc0
+  %126 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %123, i32 %124, i32 %125)
+  ret %System.String addrspace(1)* %126
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %97
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange22:                           ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
 Successfully read String.CreateTrimmedString
 
@@ -5439,8 +6893,8 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
@@ -5535,8 +6989,8 @@ entry:
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i64 2872
   %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
   %8 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %7
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %3
   %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
@@ -5553,8 +7007,8 @@ entry:
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 2864
   %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
   %21 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %20
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
-  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %22
 
 ; <label>:22                                      ; preds = %16
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
@@ -5569,7 +7023,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %16
+ThrowNullRef2:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5586,8 +7040,8 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5613,8 +7067,8 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
@@ -5632,8 +7086,8 @@ entry:
 
 ; <label>:12                                      ; preds = %4
   %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
@@ -5644,8 +7098,8 @@ entry:
 
 ; <label>:19                                      ; preds = %14
   %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %19
   %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
@@ -5660,21 +7114,21 @@ entry:
   %31 = zext i16 %30 to i32
   %32 = bitcast i8* %29 to i16*
   %33 = trunc i32 %31 to i16
-  %NullCheck6 = icmp ne i16* %32, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i16* %32, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %21
   store i16 %33, i16* %32, align 8
   %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %36
 
 ; <label>:36                                      ; preds = %34
   %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
   %38 = load i32, i32 addrspace(1)* %37, align 8
   %39 = add i32 %38, 1
-  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %40
 
 ; <label>:40                                      ; preds = %36
   %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
@@ -5683,16 +7137,16 @@ entry:
 
 ; <label>:42                                      ; preds = %14
   %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
-  br i1 %NullCheck12, label %44, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
   %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
   %47 = load i16, i16* %arg1
   %48 = zext i16 %47 to i32
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = trunc i32 %48 to i16
@@ -5703,31 +7157,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %19
+ThrowNullRef4:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %21
+ThrowNullRef6:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %36
+ThrowNullRef10:                                   ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %42
+ThrowNullRef12:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %44
+ThrowNullRef14:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5740,8 +7194,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -5752,8 +7206,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
@@ -5762,14 +7216,14 @@ entry:
 
 ; <label>:11                                      ; preds = %1
   %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
@@ -5779,15 +7233,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5808,8 +7262,8 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5822,8 +7276,8 @@ entry:
 
 ; <label>:8                                       ; preds = %3
   %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
@@ -5842,15 +7296,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
-  br i1 %NullCheck4, label %22, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
   %24 = load i16*, i16* addrspace(1)* %23, align 8
   %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %25, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
@@ -5859,8 +7313,8 @@ entry:
   store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
@@ -5874,8 +7328,8 @@ entry:
 
 ; <label>:37                                      ; preds = %65
   %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %37
   %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
@@ -5886,16 +7340,16 @@ entry:
   %45 = bitcast i16* %41 to i8*
   %46 = getelementptr inbounds i8, i8* %45, i64 %44
   %47 = bitcast i8* %46 to i16*
-  %NullCheck14 = icmp ne i16* %47, null
-  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %47, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %48
 
 ; <label>:48                                      ; preds = %39
   %49 = load i16, i16* %47, align 8
   %50 = zext i16 %49 to i32
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %52 = load i32, i32* %loc1
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %53
 
 ; <label>:53                                      ; preds = %48
   %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
@@ -5916,8 +7370,8 @@ entry:
 ; <label>:62                                      ; preds = %36, %59
   %63 = load i32, i32* %loc1
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck10, label %65, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %65
 
 ; <label>:65                                      ; preds = %62
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
@@ -5936,15 +7390,15 @@ entry:
 
 ; <label>:74                                      ; preds = %70
   %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
-  br i1 %NullCheck18, label %76, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %76
 
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
   %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
-  br i1 %NullCheck20, label %80, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
   %81 = load i64, i64 addrspace(1)* %79
@@ -5958,8 +7412,8 @@ entry:
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
   %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
-  br i1 %NullCheck22, label %92, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.String addrspace(1)* %90, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %92
 
 ; <label>:92                                      ; preds = %80
   %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
@@ -5969,15 +7423,15 @@ entry:
 
 ; <label>:96                                      ; preds = %70
   %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
-  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %98
 
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
   %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
-  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
   %103 = load i64, i64 addrspace(1)* %101
@@ -5991,8 +7445,8 @@ entry:
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
   %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
-  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.String addrspace(1)* %112, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %114
 
 ; <label>:114                                     ; preds = %102
   %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
@@ -6004,59 +7458,59 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %20
+ThrowNullRef4:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %22
+ThrowNullRef6:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %26
+ThrowNullRef8:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %62
+ThrowNullRef10:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %48
+ThrowNullRef16:                                   ; preds = %48
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %74
+ThrowNullRef18:                                   ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %76
+ThrowNullRef20:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %80
+ThrowNullRef22:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %96
+ThrowNullRef24:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %98
+ThrowNullRef26:                                   ; preds = %98
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %102
+ThrowNullRef28:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6069,15 +7523,15 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
   %3 = load i16*, i16* addrspace(1)* %2, align 8
   %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
@@ -6087,8 +7541,8 @@ entry:
   %10 = bitcast i16* %3 to i8*
   %11 = getelementptr inbounds i8, i8* %10, i64 %9
   %12 = bitcast i8* %11 to i16*
-  %NullCheck4 = icmp ne i16* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %5
   store i16 0, i16* %12, align 8
@@ -6098,11 +7552,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6119,8 +7573,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -6131,8 +7585,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
@@ -6144,15 +7598,15 @@ entry:
 
 ; <label>:14                                      ; preds = %1
   %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
   %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
   %21 = load i64, i64 addrspace(1)* %19
@@ -6171,15 +7625,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %14
+ThrowNullRef4:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %16
+ThrowNullRef6:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6302,14 +7756,6 @@ entry:
   ret %System.String addrspace(1)* %57
 }
 
-INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
-Successfully read RuntimeHelpers.get_OffsetToStringData
-
-define i32 @RuntimeHelpers.get_OffsetToStringData() {
-entry:
-  ret i32 12
-}
-
 INFO:  jitting method String::Equals using LLILCJit
 Successfully read String.Equals
 
@@ -6381,8 +7827,8 @@ entry:
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
-  br i1 %NullCheck24, label %29, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
   %30 = load i64, i64 addrspace(1)* %28
@@ -6397,8 +7843,8 @@ entry:
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
-  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
   %43 = load i64, i64 addrspace(1)* %41
@@ -6418,8 +7864,8 @@ entry:
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
   %59 = load i64, i64 addrspace(1)* %57
@@ -6434,8 +7880,8 @@ entry:
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck22, label %71, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
   %72 = load i64, i64 addrspace(1)* %70
@@ -6455,8 +7901,8 @@ entry:
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
-  br i1 %NullCheck16, label %87, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = load i64, i64 addrspace(1)* %86
@@ -6471,8 +7917,8 @@ entry:
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck18, label %100, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
   %101 = load i64, i64 addrspace(1)* %99
@@ -6492,8 +7938,8 @@ entry:
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
-  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
   %117 = load i64, i64 addrspace(1)* %115
@@ -6508,8 +7954,8 @@ entry:
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
-  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
   %130 = load i64, i64 addrspace(1)* %128
@@ -6528,15 +7974,15 @@ entry:
 
 ; <label>:142                                     ; preds = %22
   %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
-  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %143, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %144
 
 ; <label>:144                                     ; preds = %142
   %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
   %146 = load i32, i32 addrspace(1)* %145
   %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
-  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %147, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %148
 
 ; <label>:148                                     ; preds = %144
   %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
@@ -6557,15 +8003,15 @@ entry:
 
 ; <label>:159                                     ; preds = %22
   %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
-  br i1 %NullCheck, label %161, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %ThrowNullRef, label %161
 
 ; <label>:161                                     ; preds = %159
   %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
   %163 = load i32, i32 addrspace(1)* %162
   %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
-  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %164, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %165
 
 ; <label>:165                                     ; preds = %161
   %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
@@ -6578,8 +8024,8 @@ entry:
 
 ; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
-  br i1 %NullCheck4, label %172, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %171, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %172
 
 ; <label>:172                                     ; preds = %170
   %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
@@ -6589,8 +8035,8 @@ entry:
 
 ; <label>:176                                     ; preds = %172
   %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
-  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %177, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %178
 
 ; <label>:178                                     ; preds = %176
   %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
@@ -6629,55 +8075,55 @@ ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %161
+ThrowNullRef2:                                    ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %170
+ThrowNullRef4:                                    ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %176
+ThrowNullRef6:                                    ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %142
+ThrowNullRef8:                                    ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %144
+ThrowNullRef10:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %113
+ThrowNullRef12:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %116
+ThrowNullRef14:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %84
+ThrowNullRef16:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %87
+ThrowNullRef18:                                   ; preds = %87
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %55
+ThrowNullRef20:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %58
+ThrowNullRef22:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %26
+ThrowNullRef24:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %29
+ThrowNullRef26:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,8 +8161,8 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck, label %14, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %ThrowNullRef, label %14
 
 ; <label>:14                                      ; preds = %8
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
@@ -6760,8 +8206,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
@@ -6770,14 +8216,14 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32, i32* %loc0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %10
   %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
   %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
@@ -6790,15 +8236,15 @@ entry:
 ; <label>:25                                      ; preds = %19
   %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
-  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
   %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
@@ -6807,8 +8253,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %37 = load i32, i32* %loc0
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %38, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %38
 
 ; <label>:38                                      ; preds = %32
   %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
@@ -6817,14 +8263,14 @@ entry:
 
 ; <label>:40                                      ; preds = %19
   %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %40
   %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
   %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
-  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
-  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
@@ -6832,8 +8278,8 @@ entry:
   %48 = zext i32 %47 to i64
   %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
-  br i1 %NullCheck16, label %51, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %51
 
 ; <label>:51                                      ; preds = %45
   %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
@@ -6847,15 +8293,15 @@ entry:
 ; <label>:57                                      ; preds = %51
   %58 = load i16*, i16** %arg1
   %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
-  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %60
 
 ; <label>:60                                      ; preds = %57
   %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
   %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
-  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %64
 
 ; <label>:64                                      ; preds = %60
   %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
@@ -6864,22 +8310,22 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
   %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
-  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %70
 
 ; <label>:70                                      ; preds = %64
   %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
   %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
-  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
-  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
   %75 = load i32, i32 addrspace(1)* %74
   %76 = zext i32 %75 to i64
   %77 = trunc i64 %76 to i32
-  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
-  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %78
 
 ; <label>:78                                      ; preds = %73
   %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
@@ -6901,8 +8347,8 @@ entry:
   %90 = bitcast i16* %86 to i8*
   %91 = getelementptr inbounds i8, i8* %90, i64 %89
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %93
 
 ; <label>:93                                      ; preds = %80
   %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
@@ -6912,8 +8358,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %99 = load i32, i32* %loc2
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %100
 
 ; <label>:100                                     ; preds = %93
   %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
@@ -6928,63 +8374,63 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %25
+ThrowNullRef6:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %32
+ThrowNullRef10:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %40
+ThrowNullRef12:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %45
+ThrowNullRef16:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %57
+ThrowNullRef18:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %60
+ThrowNullRef20:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %64
+ThrowNullRef22:                                   ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %70
+ThrowNullRef24:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %73
+ThrowNullRef26:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %80
+ThrowNullRef28:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %93
+ThrowNullRef30:                                   ; preds = %93
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7004,8 +8450,8 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
@@ -7033,43 +8479,43 @@ entry:
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %14
   %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
   %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   %28 = load i32, i32 addrspace(1)* %27, align 8
   %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
-  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %30
 
 ; <label>:30                                      ; preds = %26
   %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
   %32 = load i32, i32 addrspace(1)* %31, align 8
   %33 = add i32 %28, %32
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %34
 
 ; <label>:34                                      ; preds = %30
   %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   store i32 %33, i32 addrspace(1)* %35
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
   store i32 0, i32 addrspace(1)* %38
   %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %40
 
 ; <label>:40                                      ; preds = %37
   %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
@@ -7082,8 +8528,8 @@ entry:
 
 ; <label>:47                                      ; preds = %40
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
@@ -7098,8 +8544,8 @@ entry:
   %54 = load i32, i32* %loc0
   %55 = sext i32 %54 to i64
   %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
-  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %57
 
 ; <label>:57                                      ; preds = %52
   %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
@@ -7110,68 +8556,35 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %14
+ThrowNullRef2:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %23
+ThrowNullRef4:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %26
+ThrowNullRef6:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %30
+ThrowNullRef8:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %34
+ThrowNullRef10:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %47
+ThrowNullRef14:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %52
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-}
-
-INFO:  jitting method StringBuilder::get_Length using LLILCJit
-Successfully read StringBuilder.get_Length
-
-define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.StringBuilder addrspace(1)*
-  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
-  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
-
-; <label>:1                                       ; preds = %entry
-  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %3 = load i32, i32 addrspace(1)* %2, align 8
-  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
-
-; <label>:5                                       ; preds = %1
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = add i32 %3, %7
-  ret i32 %8
-
-ThrowNullRef:                                     ; preds = %entry
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef16:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7213,70 +8626,70 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
   %6 = load i32, i32 addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
   store i32 %6, i32 addrspace(1)* %8
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
   %13 = load i32, i32 addrspace(1)* %12, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
   store i32 %13, i32 addrspace(1)* %15
   %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
-  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %18
 
 ; <label>:18                                      ; preds = %14
   %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
   %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
   %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
   %34 = load i32, i32 addrspace(1)* %33, align 8
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
-  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
@@ -7287,39 +8700,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %28
+ThrowNullRef16:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %32
+ThrowNullRef18:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7455,13 +8868,13 @@ entry:
 ; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
@@ -7477,16 +8890,16 @@ entry:
 
 ; <label>:18                                      ; preds = %15
   %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
   store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
   %22 = load i32, i32* %loc0
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %24
 
 ; <label>:24                                      ; preds = %20
   %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
@@ -7498,13 +8911,13 @@ entry:
 ; <label>:28                                      ; preds = %15, %24
   %29 = load i32, i32* %arg1
   %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %31
   %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
@@ -7517,20 +8930,20 @@ entry:
   %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
-  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
   %46 = load i32, i32 addrspace(1)* %45, align 8
   %47 = sub i32 %40, %46
-  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
-  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i32 addrspace(1)* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %48
 
 ; <label>:48                                      ; preds = %44
   store i32 %47, i32 addrspace(1)* %39, align 8
@@ -7538,21 +8951,21 @@ entry:
 
 ; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
-  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %51
 
 ; <label>:51                                      ; preds = %49
   %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %53
 
 ; <label>:53                                      ; preds = %51
   %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
   %55 = load i32, i32 addrspace(1)* %54, align 8
   %56 = load i32, i32* %arg2
   %57 = sub i32 %55, %56
-  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %58
 
 ; <label>:58                                      ; preds = %53
   %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
@@ -7562,13 +8975,13 @@ entry:
 ; <label>:60                                      ; preds = %33, %58
   %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
   %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
-  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %63
 
 ; <label>:63                                      ; preds = %60
   %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
-  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
-  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
@@ -7578,15 +8991,15 @@ entry:
 
 ; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
-  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i32 addrspace(1)* %69, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %70
 
 ; <label>:70                                      ; preds = %68
   %71 = load i32, i32 addrspace(1)* %69, align 8
   store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
-  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
@@ -7596,8 +9009,8 @@ entry:
   store i32 %77, i32* %loc4
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
-  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %80
 
 ; <label>:80                                      ; preds = %73
   %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
@@ -7607,71 +9020,71 @@ entry:
 ; <label>:83                                      ; preds = %80
   store i32 0, i32* %loc3
   %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
-  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
-  br i1 %NullCheck26, label %88, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i32 addrspace(1)* %87, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %88
 
 ; <label>:88                                      ; preds = %85
   %89 = load i32, i32 addrspace(1)* %87, align 8
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
-  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %90
 
 ; <label>:90                                      ; preds = %88
   %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
   store i32 %89, i32 addrspace(1)* %91
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
-  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
-  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %96
 
 ; <label>:96                                      ; preds = %94
   %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
-  br i1 %NullCheck34, label %100, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %100
 
 ; <label>:100                                     ; preds = %96
   %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
-  br i1 %NullCheck36, label %102, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %102
 
 ; <label>:102                                     ; preds = %100
   %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
   %104 = load i32, i32 addrspace(1)* %103, align 8
   %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
-  br i1 %NullCheck38, label %106, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %106
 
 ; <label>:106                                     ; preds = %102
   %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
-  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
-  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %108
 
 ; <label>:108                                     ; preds = %106
   %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
   %110 = load i32, i32 addrspace(1)* %109, align 8
   %111 = add i32 %104, %110
-  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %112
 
 ; <label>:112                                     ; preds = %108
   %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
   store i32 %111, i32 addrspace(1)* %113
   %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
-  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i32 addrspace(1)* %114, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %115
 
 ; <label>:115                                     ; preds = %112
   %116 = load i32, i32 addrspace(1)* %114, align 8
@@ -7681,19 +9094,19 @@ entry:
 ; <label>:118                                     ; preds = %115
   %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
-  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %121
 
 ; <label>:121                                     ; preds = %118
   %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
-  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
-  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %123
 
 ; <label>:123                                     ; preds = %121
   %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
   %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
-  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
-  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %126
 
 ; <label>:126                                     ; preds = %123
   %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
@@ -7705,8 +9118,8 @@ entry:
 
 ; <label>:130                                     ; preds = %80, %115, %126
   %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %132
 
 ; <label>:132                                     ; preds = %130
   %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7715,8 +9128,8 @@ entry:
   %136 = load i32, i32* %loc3
   %137 = sub i32 %135, %136
   %138 = sub i32 %134, %137
-  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %139
 
 ; <label>:139                                     ; preds = %132
   %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7728,16 +9141,16 @@ entry:
 
 ; <label>:144                                     ; preds = %139
   %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
-  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %146
 
 ; <label>:146                                     ; preds = %144
   %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
   %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
   %149 = load i32, i32* %loc2
   %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
-  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %151
 
 ; <label>:151                                     ; preds = %146
   %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
@@ -7754,145 +9167,249 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %18
+ThrowNullRef4:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %31
+ThrowNullRef10:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %44
+ThrowNullRef16:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %68
+ThrowNullRef18:                                   ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %70
+ThrowNullRef20:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %73
+ThrowNullRef22:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %83
+ThrowNullRef24:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %85
+ThrowNullRef26:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %88
+ThrowNullRef28:                                   ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %90
+ThrowNullRef30:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %94
+ThrowNullRef32:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %96
+ThrowNullRef34:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %100
+ThrowNullRef36:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %102
+ThrowNullRef38:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %106
+ThrowNullRef40:                                   ; preds = %106
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %108
+ThrowNullRef42:                                   ; preds = %108
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %112
+ThrowNullRef44:                                   ; preds = %112
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %118
+ThrowNullRef46:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %121
+ThrowNullRef48:                                   ; preds = %121
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %123
+ThrowNullRef50:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %130
+ThrowNullRef52:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %132
+ThrowNullRef54:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %144
+ThrowNullRef56:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %146
+ThrowNullRef58:                                   ; preds = %146
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %60
+ThrowNullRef60:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %63
+ThrowNullRef62:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %49
+ThrowNullRef64:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %51
+ThrowNullRef66:                                   ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %53
+ThrowNullRef68:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(%"System.Char[]" addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %arg0 = alloca %"System.Char[]" addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store %"System.Char[]" addrspace(1)* %param0, %"System.Char[]" addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load i32, i32* %arg4
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %43, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %38, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg1
+  %13 = load i32, i32* %arg4
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %38, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %24 = load i32, i32* %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %35 = load i32, i32* %arg3
+  %36 = load i32, i32* %arg4
+  %37 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %37, %"System.Char[]" addrspace(1)* %34, i32 %35, i32 %36)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:38                                      ; preds = %5, %16
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Successfully read Buffer._Memmove
 
@@ -7914,7 +9431,7 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[loadElem]
+Failed to read AppDomain.SetDataHelper[storeElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -7923,8 +9440,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
@@ -7934,8 +9451,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
@@ -7947,15 +9464,15 @@ entry:
   %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
   %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
@@ -7966,15 +9483,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7992,7 +9509,79 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
-Failed to read Dictionary`2.TryGetValue[loadElemA]
+Successfully read Dictionary`2.TryGetValue
+
+define i8 @"Dictionary`2.TryGetValue"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)* addrspace(1)* %param2) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  %arg2 = alloca %System.__Canon addrspace(1)* addrspace(1)*
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  store %System.__Canon addrspace(1)* addrspace(1)* %param2, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  store i32 %2, i32* %loc0
+  %3 = load i32, i32* %loc0
+  %4 = icmp slt i32 %3, 0
+  br i1 %4, label %22, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 2
+  %10 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %9, align 8
+  %11 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = zext i32 %11 to i64
+  %BoundsCheck = icmp uge i64 %16, %15
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 3, i32 %11
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %20, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %6, %System.__Canon addrspace(1)* %21)
+  ret i8 1
+
+; <label>:22                                      ; preds = %entry
+  %23 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %23, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -8058,8 +9647,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
@@ -8091,8 +9680,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
@@ -8171,15 +9760,15 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck, label %19, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %ThrowNullRef, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
   %21 = load i32, i32 addrspace(1)* %20
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
@@ -8202,7 +9791,7 @@ ThrowNullRef:                                     ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %19
+ThrowNullRef2:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8248,8 +9837,8 @@ entry:
   %0 = alloca %System.AppDomainHandle
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %1 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %1, i32 0, i32 15
@@ -8269,8 +9858,8 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
@@ -8286,7 +9875,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -8299,8 +9888,8 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -8327,8 +9916,8 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
@@ -8352,8 +9941,8 @@ entry:
   %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
   store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
@@ -8363,8 +9952,8 @@ entry:
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
@@ -8374,8 +9963,8 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %9
   %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
@@ -8384,8 +9973,8 @@ entry:
 
 ; <label>:18                                      ; preds = %3, %16
   %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
@@ -8397,15 +9986,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %18
+ThrowNullRef6:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8418,8 +10007,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
@@ -8453,15 +10042,15 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
@@ -8473,7 +10062,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8481,7 +10070,7 @@ ThrowNullRef1:                                    ; preds = %1
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
 Failed to read Dictionary`2.System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
@@ -8506,8 +10095,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
@@ -8524,8 +10113,8 @@ entry:
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -8544,7 +10133,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8577,8 +10166,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = load i64, i64* %arg2
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = trunc i32 %3 to i8
@@ -8634,46 +10223,46 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
   %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
-  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
-  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
-  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
@@ -8684,27 +10273,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %20
+ThrowNullRef12:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8717,8 +10306,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -8756,22 +10345,22 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
   %9 = load i64, i64 addrspace(1)* %8, align 8
   %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
   %13 = load i64, i64 addrspace(1)* %12, align 8
   %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %11
   %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
@@ -8788,11 +10377,11 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8882,8 +10471,8 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
@@ -8900,8 +10489,8 @@ entry:
 ; <label>:8                                       ; preds = %1
   %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
   %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
@@ -8911,15 +10500,15 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
   %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
   %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
-  br i1 %NullCheck6, label %21, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
@@ -8946,15 +10535,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8992,15 +10581,15 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
   store i8 %3, i8 addrspace(1)* %5
   %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
@@ -9011,7 +10600,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9027,8 +10616,8 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -9041,8 +10630,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
@@ -9058,7 +10647,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9080,8 +10669,8 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
@@ -9096,8 +10685,8 @@ entry:
 ; <label>:12                                      ; preds = %6
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
@@ -9112,8 +10701,8 @@ entry:
 ; <label>:21                                      ; preds = %15
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
@@ -9128,8 +10717,8 @@ entry:
 ; <label>:30                                      ; preds = %24
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %31, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
@@ -9144,8 +10733,8 @@ entry:
 ; <label>:39                                      ; preds = %33
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
-  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %40, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %42
 
 ; <label>:42                                      ; preds = %39
   %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
@@ -9164,19 +10753,19 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %21
+ThrowNullRef4:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %30
+ThrowNullRef6:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %39
+ThrowNullRef8:                                    ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9243,8 +10832,8 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
@@ -9264,57 +10853,57 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
   store i8 0, i8 addrspace(1)* %2
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
   store i8 0, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
   store i8 0, i8 addrspace(1)* %17
   %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
   store i8 0, i8 addrspace(1)* %20
   %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
-  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
@@ -9325,31 +10914,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %19
+ThrowNullRef14:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9367,8 +10956,8 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
@@ -9380,8 +10969,8 @@ entry:
 
 ; <label>:9                                       ; preds = %4
   %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %9
   %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
@@ -9395,7 +10984,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef2:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9420,8 +11009,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
@@ -9512,8 +11101,8 @@ entry:
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
@@ -9524,8 +11113,8 @@ entry:
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = load i64, i64 addrspace(1)* %12
@@ -9537,8 +11126,8 @@ entry:
   %20 = load i64, i64* %19
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
-  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %13
   %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
@@ -9555,8 +11144,8 @@ entry:
 ; <label>:30                                      ; preds = %25
   %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %32 = load i32, i32* %arg2
-  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
-  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
@@ -9570,15 +11159,15 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %30
+ThrowNullRef2:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9622,87 +11211,87 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
   %10 = load i8, i8 addrspace(1)* %9, align 8
   %11 = zext i8 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %8
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
   store i8 %12, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
   %19 = load i8, i8 addrspace(1)* %18, align 8
   %20 = zext i8 %19 to i32
   %21 = trunc i32 %20 to i8
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
   store i8 %21, i8 addrspace(1)* %23
   %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
   %28 = load i8, i8 addrspace(1)* %27, align 8
   %29 = zext i8 %28 to i32
   %30 = trunc i32 %29 to i8
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
-  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %31
 
 ; <label>:31                                      ; preds = %26
   %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
   store i8 %30, i8 addrspace(1)* %32
   %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
-  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
-  br i1 %NullCheck14, label %40, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %40
 
 ; <label>:40                                      ; preds = %35
   %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
   store i8 %39, i8 addrspace(1)* %41
   %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
-  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %44
 
 ; <label>:44                                      ; preds = %40
   %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
   %46 = load i8, i8 addrspace(1)* %45, align 8
   %47 = zext i8 %46 to i32
   %48 = trunc i32 %47 to i8
-  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
   store i8 %48, i8 addrspace(1)* %50
   %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
-  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
@@ -9713,29 +11302,29 @@ entry:
 ; <label>:56                                      ; preds = %52
   %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
-  br i1 %NullCheck22, label %59, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
   %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
   %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
-  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
-  br i1 %NullCheck24, label %63, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
   %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
-  br i1 %NullCheck26, label %66, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
   %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
-  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
-  br i1 %NullCheck28, label %69, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %69
 
 ; <label>:69                                      ; preds = %66
   %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
@@ -9744,15 +11333,15 @@ entry:
 
 ; <label>:71                                      ; preds = %105
   %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
-  br i1 %NullCheck34, label %73, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %73
 
 ; <label>:73                                      ; preds = %71
   %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
   %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
   %76 = load i32, i32* %loc0
-  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
-  br i1 %NullCheck36, label %77, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
@@ -9766,8 +11355,8 @@ entry:
 
 ; <label>:83                                      ; preds = %77
   %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
-  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
@@ -9775,14 +11364,14 @@ entry:
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
   %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
-  br i1 %NullCheck40, label %91, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
 ; <label>:91                                      ; preds = %85
   %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
   %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
-  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck42, label %94, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %94
 
 ; <label>:94                                      ; preds = %91
   %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
@@ -9798,14 +11387,14 @@ entry:
 ; <label>:99                                      ; preds = %69, %96
   %100 = load i32, i32* %loc0
   %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
-  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %102
 
 ; <label>:102                                     ; preds = %99
   %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
   %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
-  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
-  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
@@ -9819,87 +11408,87 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %26
+ThrowNullRef10:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %31
+ThrowNullRef12:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %35
+ThrowNullRef14:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %40
+ThrowNullRef16:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %56
+ThrowNullRef22:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %59
+ThrowNullRef24:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %63
+ThrowNullRef26:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %66
+ThrowNullRef28:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %102
+ThrowNullRef32:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %71
+ThrowNullRef34:                                   ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %73
+ThrowNullRef36:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %83
+ThrowNullRef38:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %85
+ThrowNullRef40:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %91
+ThrowNullRef42:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9943,15 +11532,15 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
   %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
@@ -9961,28 +11550,28 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
   %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %12
   %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
   %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
   %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
-  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
@@ -9993,23 +11582,23 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %12
+ThrowNullRef6:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10031,15 +11620,15 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
   %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = load i64, i64 addrspace(1)* %7
@@ -10077,13 +11666,13 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[loadElem]
+Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -10111,8 +11700,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -10184,8 +11773,8 @@ entry:
   store i32 addrspace(1)* %param1, i32 addrspace(1)** %arg1
   %0 = load i32, i32* %arg0
   %1 = load i32 addrspace(1)*, i32 addrspace(1)** %arg1
-  %NullCheck = icmp ne i32 addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq i32 addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load i32, i32 addrspace(1)* %1, align 8

--- a/test/BaseLine/JIT/CodeGenBringUpTests/div1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/div1.error.txt
@@ -25,8 +25,8 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
@@ -40,8 +40,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
   %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
@@ -75,7 +75,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -90,8 +90,8 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %NullCheck = icmp ne i8 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = load i8, i8 addrspace(1)* %0, align 8
@@ -125,8 +125,8 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
@@ -159,8 +159,8 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -184,8 +184,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
   store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
@@ -195,8 +195,8 @@ entry:
 ; <label>:4                                       ; preds = %1
   %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
   %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
@@ -206,8 +206,8 @@ entry:
   %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
@@ -221,14 +221,14 @@ entry:
 
 ; <label>:17                                      ; preds = %14
   %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
   %21 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
@@ -238,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -249,8 +249,8 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
@@ -261,27 +261,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %30
+ThrowNullRef10:                                   ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -301,7 +301,89 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
-Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
+Successfully read AppDomainSetup.GetUnsecureApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.GetUnsecureApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %NullCheck = icmp eq %"System.String[]" addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %BoundsCheck = icmp uge i64 0, %5
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %6
+
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 3, i32 0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
+  ret %System.String addrspace(1)* %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_Value using LLILCJit
+Successfully read AppDomainSetup.get_Value
+
+define %"System.String[]" addrspace(1)* @AppDomainSetup.get_Value(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.String[]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 18)
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.String[]" addrspace(1)* addrspace(1)*, %"System.String[]" addrspace(1)*)*)(%"System.String[]" addrspace(1)* addrspace(1)* %9, %"System.String[]" addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %11, i32 0, i32 1
+  %14 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %13, align 8
+  ret %"System.String[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -319,8 +401,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -368,16 +450,16 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
   %5 = load i32, i32 addrspace(1)* %4
   %6 = sub i32 %5, 1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -389,7 +471,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -421,8 +503,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
@@ -456,8 +538,8 @@ entry:
 ; <label>:27                                      ; preds = %19
   %28 = load i32, i32* %arg1
   %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
-  br i1 %NullCheck2, label %30, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %29, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %30
 
 ; <label>:30                                      ; preds = %27
   %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
@@ -493,8 +575,8 @@ entry:
 ; <label>:49                                      ; preds = %46
   %50 = load i32, i32* %arg2
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck4, label %52, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
@@ -517,11 +599,11 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %27
+ThrowNullRef2:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %49
+ThrowNullRef4:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -544,16 +626,16 @@ entry:
   %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %0)
   store %System.String addrspace(1)* %1, %System.String addrspace(1)** %loc0
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 2
   %5 = bitcast [0 x i16] addrspace(1)* %4 to i16 addrspace(1)*
   store i16 addrspace(1)* %5, i16 addrspace(1)** %loc1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %3
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2
@@ -580,7 +662,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -691,15 +773,15 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %NullCheck132 = icmp ne i8* %21, null
-  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+  %NullCheck131 = icmp eq i8* %21, null
+  br i1 %NullCheck131, label %ThrowNullRef132, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = load i8, i8* %21, align 8
   %24 = zext i8 %23 to i32
   %25 = trunc i32 %24 to i8
-  %NullCheck134 = icmp ne i8* %20, null
-  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+  %NullCheck133 = icmp eq i8* %20, null
+  br i1 %NullCheck133, label %ThrowNullRef134, label %26
 
 ; <label>:26                                      ; preds = %22
   store i8 %25, i8* %20, align 8
@@ -709,16 +791,16 @@ entry:
   %28 = load i8*, i8** %arg0
   %29 = load i8*, i8** %arg1
   %30 = bitcast i8* %29 to i16*
-  %NullCheck128 = icmp ne i16* %30, null
-  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+  %NullCheck127 = icmp eq i16* %30, null
+  br i1 %NullCheck127, label %ThrowNullRef128, label %31
 
 ; <label>:31                                      ; preds = %27
   %32 = load i16, i16* %30, align 8
   %33 = sext i16 %32 to i32
   %34 = bitcast i8* %28 to i16*
   %35 = trunc i32 %33 to i16
-  %NullCheck130 = icmp ne i16* %34, null
-  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+  %NullCheck129 = icmp eq i16* %34, null
+  br i1 %NullCheck129, label %ThrowNullRef130, label %36
 
 ; <label>:36                                      ; preds = %31
   store i16 %35, i16* %34, align 8
@@ -728,16 +810,16 @@ entry:
   %38 = load i8*, i8** %arg0
   %39 = load i8*, i8** %arg1
   %40 = bitcast i8* %39 to i16*
-  %NullCheck120 = icmp ne i16* %40, null
-  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+  %NullCheck119 = icmp eq i16* %40, null
+  br i1 %NullCheck119, label %ThrowNullRef120, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i16, i16* %40, align 8
   %43 = sext i16 %42 to i32
   %44 = bitcast i8* %38 to i16*
   %45 = trunc i32 %43 to i16
-  %NullCheck122 = icmp ne i16* %44, null
-  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+  %NullCheck121 = icmp eq i16* %44, null
+  br i1 %NullCheck121, label %ThrowNullRef122, label %46
 
 ; <label>:46                                      ; preds = %41
   store i16 %45, i16* %44, align 8
@@ -745,15 +827,15 @@ entry:
   %48 = getelementptr inbounds i8, i8* %47, i64 2
   %49 = load i8*, i8** %arg1
   %50 = getelementptr inbounds i8, i8* %49, i64 2
-  %NullCheck124 = icmp ne i8* %50, null
-  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+  %NullCheck123 = icmp eq i8* %50, null
+  br i1 %NullCheck123, label %ThrowNullRef124, label %51
 
 ; <label>:51                                      ; preds = %46
   %52 = load i8, i8* %50, align 8
   %53 = zext i8 %52 to i32
   %54 = trunc i32 %53 to i8
-  %NullCheck126 = icmp ne i8* %48, null
-  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+  %NullCheck125 = icmp eq i8* %48, null
+  br i1 %NullCheck125, label %ThrowNullRef126, label %55
 
 ; <label>:55                                      ; preds = %51
   store i8 %54, i8* %48, align 8
@@ -763,14 +845,14 @@ entry:
   %57 = load i8*, i8** %arg0
   %58 = load i8*, i8** %arg1
   %59 = bitcast i8* %58 to i32*
-  %NullCheck116 = icmp ne i32* %59, null
-  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+  %NullCheck115 = icmp eq i32* %59, null
+  br i1 %NullCheck115, label %ThrowNullRef116, label %60
 
 ; <label>:60                                      ; preds = %56
   %61 = load i32, i32* %59, align 8
   %62 = bitcast i8* %57 to i32*
-  %NullCheck118 = icmp ne i32* %62, null
-  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+  %NullCheck117 = icmp eq i32* %62, null
+  br i1 %NullCheck117, label %ThrowNullRef118, label %63
 
 ; <label>:63                                      ; preds = %60
   store i32 %61, i32* %62, align 8
@@ -780,14 +862,14 @@ entry:
   %65 = load i8*, i8** %arg0
   %66 = load i8*, i8** %arg1
   %67 = bitcast i8* %66 to i32*
-  %NullCheck108 = icmp ne i32* %67, null
-  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+  %NullCheck107 = icmp eq i32* %67, null
+  br i1 %NullCheck107, label %ThrowNullRef108, label %68
 
 ; <label>:68                                      ; preds = %64
   %69 = load i32, i32* %67, align 8
   %70 = bitcast i8* %65 to i32*
-  %NullCheck110 = icmp ne i32* %70, null
-  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+  %NullCheck109 = icmp eq i32* %70, null
+  br i1 %NullCheck109, label %ThrowNullRef110, label %71
 
 ; <label>:71                                      ; preds = %68
   store i32 %69, i32* %70, align 8
@@ -795,15 +877,15 @@ entry:
   %73 = getelementptr inbounds i8, i8* %72, i64 4
   %74 = load i8*, i8** %arg1
   %75 = getelementptr inbounds i8, i8* %74, i64 4
-  %NullCheck112 = icmp ne i8* %75, null
-  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+  %NullCheck111 = icmp eq i8* %75, null
+  br i1 %NullCheck111, label %ThrowNullRef112, label %76
 
 ; <label>:76                                      ; preds = %71
   %77 = load i8, i8* %75, align 8
   %78 = zext i8 %77 to i32
   %79 = trunc i32 %78 to i8
-  %NullCheck114 = icmp ne i8* %73, null
-  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+  %NullCheck113 = icmp eq i8* %73, null
+  br i1 %NullCheck113, label %ThrowNullRef114, label %80
 
 ; <label>:80                                      ; preds = %76
   store i8 %79, i8* %73, align 8
@@ -813,14 +895,14 @@ entry:
   %82 = load i8*, i8** %arg0
   %83 = load i8*, i8** %arg1
   %84 = bitcast i8* %83 to i32*
-  %NullCheck100 = icmp ne i32* %84, null
-  br i1 %NullCheck100, label %85, label %ThrowNullRef99
+  %NullCheck99 = icmp eq i32* %84, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %85
 
 ; <label>:85                                      ; preds = %81
   %86 = load i32, i32* %84, align 8
   %87 = bitcast i8* %82 to i32*
-  %NullCheck102 = icmp ne i32* %87, null
-  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+  %NullCheck101 = icmp eq i32* %87, null
+  br i1 %NullCheck101, label %ThrowNullRef102, label %88
 
 ; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
@@ -829,16 +911,16 @@ entry:
   %91 = load i8*, i8** %arg1
   %92 = getelementptr inbounds i8, i8* %91, i64 4
   %93 = bitcast i8* %92 to i16*
-  %NullCheck104 = icmp ne i16* %93, null
-  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+  %NullCheck103 = icmp eq i16* %93, null
+  br i1 %NullCheck103, label %ThrowNullRef104, label %94
 
 ; <label>:94                                      ; preds = %88
   %95 = load i16, i16* %93, align 8
   %96 = sext i16 %95 to i32
   %97 = bitcast i8* %90 to i16*
   %98 = trunc i32 %96 to i16
-  %NullCheck106 = icmp ne i16* %97, null
-  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+  %NullCheck105 = icmp eq i16* %97, null
+  br i1 %NullCheck105, label %ThrowNullRef106, label %99
 
 ; <label>:99                                      ; preds = %94
   store i16 %98, i16* %97, align 8
@@ -848,14 +930,14 @@ entry:
   %101 = load i8*, i8** %arg0
   %102 = load i8*, i8** %arg1
   %103 = bitcast i8* %102 to i32*
-  %NullCheck88 = icmp ne i32* %103, null
-  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+  %NullCheck87 = icmp eq i32* %103, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %104
 
 ; <label>:104                                     ; preds = %100
   %105 = load i32, i32* %103, align 8
   %106 = bitcast i8* %101 to i32*
-  %NullCheck90 = icmp ne i32* %106, null
-  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+  %NullCheck89 = icmp eq i32* %106, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %107
 
 ; <label>:107                                     ; preds = %104
   store i32 %105, i32* %106, align 8
@@ -864,16 +946,16 @@ entry:
   %110 = load i8*, i8** %arg1
   %111 = getelementptr inbounds i8, i8* %110, i64 4
   %112 = bitcast i8* %111 to i16*
-  %NullCheck92 = icmp ne i16* %112, null
-  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+  %NullCheck91 = icmp eq i16* %112, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %113
 
 ; <label>:113                                     ; preds = %107
   %114 = load i16, i16* %112, align 8
   %115 = sext i16 %114 to i32
   %116 = bitcast i8* %109 to i16*
   %117 = trunc i32 %115 to i16
-  %NullCheck94 = icmp ne i16* %116, null
-  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+  %NullCheck93 = icmp eq i16* %116, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %118
 
 ; <label>:118                                     ; preds = %113
   store i16 %117, i16* %116, align 8
@@ -881,15 +963,15 @@ entry:
   %120 = getelementptr inbounds i8, i8* %119, i64 6
   %121 = load i8*, i8** %arg1
   %122 = getelementptr inbounds i8, i8* %121, i64 6
-  %NullCheck96 = icmp ne i8* %122, null
-  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+  %NullCheck95 = icmp eq i8* %122, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %123
 
 ; <label>:123                                     ; preds = %118
   %124 = load i8, i8* %122, align 8
   %125 = zext i8 %124 to i32
   %126 = trunc i32 %125 to i8
-  %NullCheck98 = icmp ne i8* %120, null
-  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+  %NullCheck97 = icmp eq i8* %120, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %127
 
 ; <label>:127                                     ; preds = %123
   store i8 %126, i8* %120, align 8
@@ -899,14 +981,14 @@ entry:
   %129 = load i8*, i8** %arg0
   %130 = load i8*, i8** %arg1
   %131 = bitcast i8* %130 to i64*
-  %NullCheck84 = icmp ne i64* %131, null
-  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+  %NullCheck83 = icmp eq i64* %131, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %132
 
 ; <label>:132                                     ; preds = %128
   %133 = load i64, i64* %131, align 8
   %134 = bitcast i8* %129 to i64*
-  %NullCheck86 = icmp ne i64* %134, null
-  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+  %NullCheck85 = icmp eq i64* %134, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %135
 
 ; <label>:135                                     ; preds = %132
   store i64 %133, i64* %134, align 8
@@ -916,14 +998,14 @@ entry:
   %137 = load i8*, i8** %arg0
   %138 = load i8*, i8** %arg1
   %139 = bitcast i8* %138 to i64*
-  %NullCheck76 = icmp ne i64* %139, null
-  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+  %NullCheck75 = icmp eq i64* %139, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %140
 
 ; <label>:140                                     ; preds = %136
   %141 = load i64, i64* %139, align 8
   %142 = bitcast i8* %137 to i64*
-  %NullCheck78 = icmp ne i64* %142, null
-  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+  %NullCheck77 = icmp eq i64* %142, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %143
 
 ; <label>:143                                     ; preds = %140
   store i64 %141, i64* %142, align 8
@@ -931,15 +1013,15 @@ entry:
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %NullCheck80 = icmp ne i8* %147, null
-  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+  %NullCheck79 = icmp eq i8* %147, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %148
 
 ; <label>:148                                     ; preds = %143
   %149 = load i8, i8* %147, align 8
   %150 = zext i8 %149 to i32
   %151 = trunc i32 %150 to i8
-  %NullCheck82 = icmp ne i8* %145, null
-  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+  %NullCheck81 = icmp eq i8* %145, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %152
 
 ; <label>:152                                     ; preds = %148
   store i8 %151, i8* %145, align 8
@@ -949,14 +1031,14 @@ entry:
   %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
   %156 = bitcast i8* %155 to i64*
-  %NullCheck68 = icmp ne i64* %156, null
-  br i1 %NullCheck68, label %157, label %ThrowNullRef67
+  %NullCheck67 = icmp eq i64* %156, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %157
 
 ; <label>:157                                     ; preds = %153
   %158 = load i64, i64* %156, align 8
   %159 = bitcast i8* %154 to i64*
-  %NullCheck70 = icmp ne i64* %159, null
-  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+  %NullCheck69 = icmp eq i64* %159, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %160
 
 ; <label>:160                                     ; preds = %157
   store i64 %158, i64* %159, align 8
@@ -965,16 +1047,16 @@ entry:
   %163 = load i8*, i8** %arg1
   %164 = getelementptr inbounds i8, i8* %163, i64 8
   %165 = bitcast i8* %164 to i16*
-  %NullCheck72 = icmp ne i16* %165, null
-  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+  %NullCheck71 = icmp eq i16* %165, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %166
 
 ; <label>:166                                     ; preds = %160
   %167 = load i16, i16* %165, align 8
   %168 = sext i16 %167 to i32
   %169 = bitcast i8* %162 to i16*
   %170 = trunc i32 %168 to i16
-  %NullCheck74 = icmp ne i16* %169, null
-  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+  %NullCheck73 = icmp eq i16* %169, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %171
 
 ; <label>:171                                     ; preds = %166
   store i16 %170, i16* %169, align 8
@@ -984,14 +1066,14 @@ entry:
   %173 = load i8*, i8** %arg0
   %174 = load i8*, i8** %arg1
   %175 = bitcast i8* %174 to i64*
-  %NullCheck56 = icmp ne i64* %175, null
-  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+  %NullCheck55 = icmp eq i64* %175, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %176
 
 ; <label>:176                                     ; preds = %172
   %177 = load i64, i64* %175, align 8
   %178 = bitcast i8* %173 to i64*
-  %NullCheck58 = icmp ne i64* %178, null
-  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+  %NullCheck57 = icmp eq i64* %178, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %179
 
 ; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
@@ -1000,16 +1082,16 @@ entry:
   %182 = load i8*, i8** %arg1
   %183 = getelementptr inbounds i8, i8* %182, i64 8
   %184 = bitcast i8* %183 to i16*
-  %NullCheck60 = icmp ne i16* %184, null
-  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+  %NullCheck59 = icmp eq i16* %184, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %185
 
 ; <label>:185                                     ; preds = %179
   %186 = load i16, i16* %184, align 8
   %187 = sext i16 %186 to i32
   %188 = bitcast i8* %181 to i16*
   %189 = trunc i32 %187 to i16
-  %NullCheck62 = icmp ne i16* %188, null
-  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+  %NullCheck61 = icmp eq i16* %188, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %190
 
 ; <label>:190                                     ; preds = %185
   store i16 %189, i16* %188, align 8
@@ -1017,15 +1099,15 @@ entry:
   %192 = getelementptr inbounds i8, i8* %191, i64 10
   %193 = load i8*, i8** %arg1
   %194 = getelementptr inbounds i8, i8* %193, i64 10
-  %NullCheck64 = icmp ne i8* %194, null
-  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+  %NullCheck63 = icmp eq i8* %194, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %195
 
 ; <label>:195                                     ; preds = %190
   %196 = load i8, i8* %194, align 8
   %197 = zext i8 %196 to i32
   %198 = trunc i32 %197 to i8
-  %NullCheck66 = icmp ne i8* %192, null
-  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+  %NullCheck65 = icmp eq i8* %192, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %199
 
 ; <label>:199                                     ; preds = %195
   store i8 %198, i8* %192, align 8
@@ -1035,14 +1117,14 @@ entry:
   %201 = load i8*, i8** %arg0
   %202 = load i8*, i8** %arg1
   %203 = bitcast i8* %202 to i64*
-  %NullCheck48 = icmp ne i64* %203, null
-  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+  %NullCheck47 = icmp eq i64* %203, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %204
 
 ; <label>:204                                     ; preds = %200
   %205 = load i64, i64* %203, align 8
   %206 = bitcast i8* %201 to i64*
-  %NullCheck50 = icmp ne i64* %206, null
-  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+  %NullCheck49 = icmp eq i64* %206, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %207
 
 ; <label>:207                                     ; preds = %204
   store i64 %205, i64* %206, align 8
@@ -1051,14 +1133,14 @@ entry:
   %210 = load i8*, i8** %arg1
   %211 = getelementptr inbounds i8, i8* %210, i64 8
   %212 = bitcast i8* %211 to i32*
-  %NullCheck52 = icmp ne i32* %212, null
-  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+  %NullCheck51 = icmp eq i32* %212, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %213
 
 ; <label>:213                                     ; preds = %207
   %214 = load i32, i32* %212, align 8
   %215 = bitcast i8* %209 to i32*
-  %NullCheck54 = icmp ne i32* %215, null
-  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+  %NullCheck53 = icmp eq i32* %215, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %216
 
 ; <label>:216                                     ; preds = %213
   store i32 %214, i32* %215, align 8
@@ -1068,14 +1150,14 @@ entry:
   %218 = load i8*, i8** %arg0
   %219 = load i8*, i8** %arg1
   %220 = bitcast i8* %219 to i64*
-  %NullCheck36 = icmp ne i64* %220, null
-  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64* %220, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %221
 
 ; <label>:221                                     ; preds = %217
   %222 = load i64, i64* %220, align 8
   %223 = bitcast i8* %218 to i64*
-  %NullCheck38 = icmp ne i64* %223, null
-  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+  %NullCheck37 = icmp eq i64* %223, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %224
 
 ; <label>:224                                     ; preds = %221
   store i64 %222, i64* %223, align 8
@@ -1084,14 +1166,14 @@ entry:
   %227 = load i8*, i8** %arg1
   %228 = getelementptr inbounds i8, i8* %227, i64 8
   %229 = bitcast i8* %228 to i32*
-  %NullCheck40 = icmp ne i32* %229, null
-  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i32* %229, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %230
 
 ; <label>:230                                     ; preds = %224
   %231 = load i32, i32* %229, align 8
   %232 = bitcast i8* %226 to i32*
-  %NullCheck42 = icmp ne i32* %232, null
-  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+  %NullCheck41 = icmp eq i32* %232, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %233
 
 ; <label>:233                                     ; preds = %230
   store i32 %231, i32* %232, align 8
@@ -1099,15 +1181,15 @@ entry:
   %235 = getelementptr inbounds i8, i8* %234, i64 12
   %236 = load i8*, i8** %arg1
   %237 = getelementptr inbounds i8, i8* %236, i64 12
-  %NullCheck44 = icmp ne i8* %237, null
-  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i8* %237, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %238
 
 ; <label>:238                                     ; preds = %233
   %239 = load i8, i8* %237, align 8
   %240 = zext i8 %239 to i32
   %241 = trunc i32 %240 to i8
-  %NullCheck46 = icmp ne i8* %235, null
-  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+  %NullCheck45 = icmp eq i8* %235, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %242
 
 ; <label>:242                                     ; preds = %238
   store i8 %241, i8* %235, align 8
@@ -1117,14 +1199,14 @@ entry:
   %244 = load i8*, i8** %arg0
   %245 = load i8*, i8** %arg1
   %246 = bitcast i8* %245 to i64*
-  %NullCheck24 = icmp ne i64* %246, null
-  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64* %246, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %247
 
 ; <label>:247                                     ; preds = %243
   %248 = load i64, i64* %246, align 8
   %249 = bitcast i8* %244 to i64*
-  %NullCheck26 = icmp ne i64* %249, null
-  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64* %249, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %250
 
 ; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
@@ -1133,14 +1215,14 @@ entry:
   %253 = load i8*, i8** %arg1
   %254 = getelementptr inbounds i8, i8* %253, i64 8
   %255 = bitcast i8* %254 to i32*
-  %NullCheck28 = icmp ne i32* %255, null
-  br i1 %NullCheck28, label %256, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i32* %255, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %256
 
 ; <label>:256                                     ; preds = %250
   %257 = load i32, i32* %255, align 8
   %258 = bitcast i8* %252 to i32*
-  %NullCheck30 = icmp ne i32* %258, null
-  br i1 %NullCheck30, label %259, label %ThrowNullRef29
+  %NullCheck29 = icmp eq i32* %258, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %259
 
 ; <label>:259                                     ; preds = %256
   store i32 %257, i32* %258, align 8
@@ -1149,16 +1231,16 @@ entry:
   %262 = load i8*, i8** %arg1
   %263 = getelementptr inbounds i8, i8* %262, i64 12
   %264 = bitcast i8* %263 to i16*
-  %NullCheck32 = icmp ne i16* %264, null
-  br i1 %NullCheck32, label %265, label %ThrowNullRef31
+  %NullCheck31 = icmp eq i16* %264, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %265
 
 ; <label>:265                                     ; preds = %259
   %266 = load i16, i16* %264, align 8
   %267 = sext i16 %266 to i32
   %268 = bitcast i8* %261 to i16*
   %269 = trunc i32 %267 to i16
-  %NullCheck34 = icmp ne i16* %268, null
-  br i1 %NullCheck34, label %270, label %ThrowNullRef33
+  %NullCheck33 = icmp eq i16* %268, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %270
 
 ; <label>:270                                     ; preds = %265
   store i16 %269, i16* %268, align 8
@@ -1168,14 +1250,14 @@ entry:
   %272 = load i8*, i8** %arg0
   %273 = load i8*, i8** %arg1
   %274 = bitcast i8* %273 to i64*
-  %NullCheck8 = icmp ne i64* %274, null
-  br i1 %NullCheck8, label %275, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64* %274, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %275
 
 ; <label>:275                                     ; preds = %271
   %276 = load i64, i64* %274, align 8
   %277 = bitcast i8* %272 to i64*
-  %NullCheck10 = icmp ne i64* %277, null
-  br i1 %NullCheck10, label %278, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %277, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %278
 
 ; <label>:278                                     ; preds = %275
   store i64 %276, i64* %277, align 8
@@ -1184,14 +1266,14 @@ entry:
   %281 = load i8*, i8** %arg1
   %282 = getelementptr inbounds i8, i8* %281, i64 8
   %283 = bitcast i8* %282 to i32*
-  %NullCheck12 = icmp ne i32* %283, null
-  br i1 %NullCheck12, label %284, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i32* %283, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %284
 
 ; <label>:284                                     ; preds = %278
   %285 = load i32, i32* %283, align 8
   %286 = bitcast i8* %280 to i32*
-  %NullCheck14 = icmp ne i32* %286, null
-  br i1 %NullCheck14, label %287, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i32* %286, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %287
 
 ; <label>:287                                     ; preds = %284
   store i32 %285, i32* %286, align 8
@@ -1200,16 +1282,16 @@ entry:
   %290 = load i8*, i8** %arg1
   %291 = getelementptr inbounds i8, i8* %290, i64 12
   %292 = bitcast i8* %291 to i16*
-  %NullCheck16 = icmp ne i16* %292, null
-  br i1 %NullCheck16, label %293, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i16* %292, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %293
 
 ; <label>:293                                     ; preds = %287
   %294 = load i16, i16* %292, align 8
   %295 = sext i16 %294 to i32
   %296 = bitcast i8* %289 to i16*
   %297 = trunc i32 %295 to i16
-  %NullCheck18 = icmp ne i16* %296, null
-  br i1 %NullCheck18, label %298, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i16* %296, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %298
 
 ; <label>:298                                     ; preds = %293
   store i16 %297, i16* %296, align 8
@@ -1217,15 +1299,15 @@ entry:
   %300 = getelementptr inbounds i8, i8* %299, i64 14
   %301 = load i8*, i8** %arg1
   %302 = getelementptr inbounds i8, i8* %301, i64 14
-  %NullCheck20 = icmp ne i8* %302, null
-  br i1 %NullCheck20, label %303, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i8* %302, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %303
 
 ; <label>:303                                     ; preds = %298
   %304 = load i8, i8* %302, align 8
   %305 = zext i8 %304 to i32
   %306 = trunc i32 %305 to i8
-  %NullCheck22 = icmp ne i8* %300, null
-  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i8* %300, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %307
 
 ; <label>:307                                     ; preds = %303
   store i8 %306, i8* %300, align 8
@@ -1235,14 +1317,14 @@ entry:
   %309 = load i8*, i8** %arg0
   %310 = load i8*, i8** %arg1
   %311 = bitcast i8* %310 to i64*
-  %NullCheck = icmp ne i64* %311, null
-  br i1 %NullCheck, label %312, label %ThrowNullRef
+  %NullCheck = icmp eq i64* %311, null
+  br i1 %NullCheck, label %ThrowNullRef, label %312
 
 ; <label>:312                                     ; preds = %308
   %313 = load i64, i64* %311, align 8
   %314 = bitcast i8* %309 to i64*
-  %NullCheck2 = icmp ne i64* %314, null
-  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64* %314, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %315
 
 ; <label>:315                                     ; preds = %312
   store i64 %313, i64* %314, align 8
@@ -1251,14 +1333,14 @@ entry:
   %318 = load i8*, i8** %arg1
   %319 = getelementptr inbounds i8, i8* %318, i64 8
   %320 = bitcast i8* %319 to i64*
-  %NullCheck4 = icmp ne i64* %320, null
-  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64* %320, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %321
 
 ; <label>:321                                     ; preds = %315
   %322 = load i64, i64* %320, align 8
   %323 = bitcast i8* %317 to i64*
-  %NullCheck6 = icmp ne i64* %323, null
-  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64* %323, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %324
 
 ; <label>:324                                     ; preds = %321
   store i64 %322, i64* %323, align 8
@@ -1286,15 +1368,15 @@ entry:
 ; <label>:338                                     ; preds = %333
   %339 = load i8*, i8** %arg0
   %340 = load i8*, i8** %arg1
-  %NullCheck136 = icmp ne i8* %340, null
-  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+  %NullCheck135 = icmp eq i8* %340, null
+  br i1 %NullCheck135, label %ThrowNullRef136, label %341
 
 ; <label>:341                                     ; preds = %338
   %342 = load i8, i8* %340, align 8
   %343 = zext i8 %342 to i32
   %344 = trunc i32 %343 to i8
-  %NullCheck138 = icmp ne i8* %339, null
-  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+  %NullCheck137 = icmp eq i8* %339, null
+  br i1 %NullCheck137, label %ThrowNullRef138, label %345
 
 ; <label>:345                                     ; preds = %341
   store i8 %344, i8* %339, align 8
@@ -1317,16 +1399,16 @@ entry:
   %357 = load i8*, i8** %arg0
   %358 = load i8*, i8** %arg1
   %359 = bitcast i8* %358 to i16*
-  %NullCheck140 = icmp ne i16* %359, null
-  br i1 %NullCheck140, label %360, label %ThrowNullRef139
+  %NullCheck139 = icmp eq i16* %359, null
+  br i1 %NullCheck139, label %ThrowNullRef140, label %360
 
 ; <label>:360                                     ; preds = %356
   %361 = load i16, i16* %359, align 8
   %362 = sext i16 %361 to i32
   %363 = bitcast i8* %357 to i16*
   %364 = trunc i32 %362 to i16
-  %NullCheck142 = icmp ne i16* %363, null
-  br i1 %NullCheck142, label %365, label %ThrowNullRef141
+  %NullCheck141 = icmp eq i16* %363, null
+  br i1 %NullCheck141, label %ThrowNullRef142, label %365
 
 ; <label>:365                                     ; preds = %360
   store i16 %364, i16* %363, align 8
@@ -1352,14 +1434,14 @@ entry:
   %378 = load i8*, i8** %arg0
   %379 = load i8*, i8** %arg1
   %380 = bitcast i8* %379 to i32*
-  %NullCheck144 = icmp ne i32* %380, null
-  br i1 %NullCheck144, label %381, label %ThrowNullRef143
+  %NullCheck143 = icmp eq i32* %380, null
+  br i1 %NullCheck143, label %ThrowNullRef144, label %381
 
 ; <label>:381                                     ; preds = %377
   %382 = load i32, i32* %380, align 8
   %383 = bitcast i8* %378 to i32*
-  %NullCheck146 = icmp ne i32* %383, null
-  br i1 %NullCheck146, label %384, label %ThrowNullRef145
+  %NullCheck145 = icmp eq i32* %383, null
+  br i1 %NullCheck145, label %ThrowNullRef146, label %384
 
 ; <label>:384                                     ; preds = %381
   store i32 %382, i32* %383, align 8
@@ -1384,14 +1466,14 @@ entry:
   %395 = load i8*, i8** %arg0
   %396 = load i8*, i8** %arg1
   %397 = bitcast i8* %396 to i64*
-  %NullCheck164 = icmp ne i64* %397, null
-  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+  %NullCheck163 = icmp eq i64* %397, null
+  br i1 %NullCheck163, label %ThrowNullRef164, label %398
 
 ; <label>:398                                     ; preds = %394
   %399 = load i64, i64* %397, align 8
   %400 = bitcast i8* %395 to i64*
-  %NullCheck166 = icmp ne i64* %400, null
-  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+  %NullCheck165 = icmp eq i64* %400, null
+  br i1 %NullCheck165, label %ThrowNullRef166, label %401
 
 ; <label>:401                                     ; preds = %398
   store i64 %399, i64* %400, align 8
@@ -1400,14 +1482,14 @@ entry:
   %404 = load i8*, i8** %arg1
   %405 = getelementptr inbounds i8, i8* %404, i64 8
   %406 = bitcast i8* %405 to i64*
-  %NullCheck168 = icmp ne i64* %406, null
-  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+  %NullCheck167 = icmp eq i64* %406, null
+  br i1 %NullCheck167, label %ThrowNullRef168, label %407
 
 ; <label>:407                                     ; preds = %401
   %408 = load i64, i64* %406, align 8
   %409 = bitcast i8* %403 to i64*
-  %NullCheck170 = icmp ne i64* %409, null
-  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+  %NullCheck169 = icmp eq i64* %409, null
+  br i1 %NullCheck169, label %ThrowNullRef170, label %410
 
 ; <label>:410                                     ; preds = %407
   store i64 %408, i64* %409, align 8
@@ -1437,14 +1519,14 @@ entry:
   %425 = load i8*, i8** %arg0
   %426 = load i8*, i8** %arg1
   %427 = bitcast i8* %426 to i64*
-  %NullCheck148 = icmp ne i64* %427, null
-  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+  %NullCheck147 = icmp eq i64* %427, null
+  br i1 %NullCheck147, label %ThrowNullRef148, label %428
 
 ; <label>:428                                     ; preds = %424
   %429 = load i64, i64* %427, align 8
   %430 = bitcast i8* %425 to i64*
-  %NullCheck150 = icmp ne i64* %430, null
-  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+  %NullCheck149 = icmp eq i64* %430, null
+  br i1 %NullCheck149, label %ThrowNullRef150, label %431
 
 ; <label>:431                                     ; preds = %428
   store i64 %429, i64* %430, align 8
@@ -1466,14 +1548,14 @@ entry:
   %441 = load i8*, i8** %arg0
   %442 = load i8*, i8** %arg1
   %443 = bitcast i8* %442 to i32*
-  %NullCheck152 = icmp ne i32* %443, null
-  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+  %NullCheck151 = icmp eq i32* %443, null
+  br i1 %NullCheck151, label %ThrowNullRef152, label %444
 
 ; <label>:444                                     ; preds = %440
   %445 = load i32, i32* %443, align 8
   %446 = bitcast i8* %441 to i32*
-  %NullCheck154 = icmp ne i32* %446, null
-  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+  %NullCheck153 = icmp eq i32* %446, null
+  br i1 %NullCheck153, label %ThrowNullRef154, label %447
 
 ; <label>:447                                     ; preds = %444
   store i32 %445, i32* %446, align 8
@@ -1495,16 +1577,16 @@ entry:
   %457 = load i8*, i8** %arg0
   %458 = load i8*, i8** %arg1
   %459 = bitcast i8* %458 to i16*
-  %NullCheck156 = icmp ne i16* %459, null
-  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+  %NullCheck155 = icmp eq i16* %459, null
+  br i1 %NullCheck155, label %ThrowNullRef156, label %460
 
 ; <label>:460                                     ; preds = %456
   %461 = load i16, i16* %459, align 8
   %462 = sext i16 %461 to i32
   %463 = bitcast i8* %457 to i16*
   %464 = trunc i32 %462 to i16
-  %NullCheck158 = icmp ne i16* %463, null
-  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+  %NullCheck157 = icmp eq i16* %463, null
+  br i1 %NullCheck157, label %ThrowNullRef158, label %465
 
 ; <label>:465                                     ; preds = %460
   store i16 %464, i16* %463, align 8
@@ -1525,15 +1607,15 @@ entry:
 ; <label>:474                                     ; preds = %470
   %475 = load i8*, i8** %arg0
   %476 = load i8*, i8** %arg1
-  %NullCheck160 = icmp ne i8* %476, null
-  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+  %NullCheck159 = icmp eq i8* %476, null
+  br i1 %NullCheck159, label %ThrowNullRef160, label %477
 
 ; <label>:477                                     ; preds = %474
   %478 = load i8, i8* %476, align 8
   %479 = zext i8 %478 to i32
   %480 = trunc i32 %479 to i8
-  %NullCheck162 = icmp ne i8* %475, null
-  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+  %NullCheck161 = icmp eq i8* %475, null
+  br i1 %NullCheck161, label %ThrowNullRef162, label %481
 
 ; <label>:481                                     ; preds = %477
   store i8 %480, i8* %475, align 8
@@ -1553,343 +1635,343 @@ ThrowNullRef:                                     ; preds = %308
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %312
+ThrowNullRef2:                                    ; preds = %312
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %315
+ThrowNullRef4:                                    ; preds = %315
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %321
+ThrowNullRef6:                                    ; preds = %321
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %271
+ThrowNullRef8:                                    ; preds = %271
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %275
+ThrowNullRef10:                                   ; preds = %275
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %278
+ThrowNullRef12:                                   ; preds = %278
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %284
+ThrowNullRef14:                                   ; preds = %284
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %287
+ThrowNullRef16:                                   ; preds = %287
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %293
+ThrowNullRef18:                                   ; preds = %293
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %298
+ThrowNullRef20:                                   ; preds = %298
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %303
+ThrowNullRef22:                                   ; preds = %303
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %243
+ThrowNullRef24:                                   ; preds = %243
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %247
+ThrowNullRef26:                                   ; preds = %247
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %250
+ThrowNullRef28:                                   ; preds = %250
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %256
+ThrowNullRef30:                                   ; preds = %256
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %259
+ThrowNullRef32:                                   ; preds = %259
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %265
+ThrowNullRef34:                                   ; preds = %265
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %217
+ThrowNullRef36:                                   ; preds = %217
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %221
+ThrowNullRef38:                                   ; preds = %221
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %224
+ThrowNullRef40:                                   ; preds = %224
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %230
+ThrowNullRef42:                                   ; preds = %230
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %233
+ThrowNullRef44:                                   ; preds = %233
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %238
+ThrowNullRef46:                                   ; preds = %238
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %200
+ThrowNullRef48:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %204
+ThrowNullRef50:                                   ; preds = %204
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %207
+ThrowNullRef52:                                   ; preds = %207
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %213
+ThrowNullRef54:                                   ; preds = %213
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %172
+ThrowNullRef56:                                   ; preds = %172
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %176
+ThrowNullRef58:                                   ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %179
+ThrowNullRef60:                                   ; preds = %179
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %185
+ThrowNullRef62:                                   ; preds = %185
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %190
+ThrowNullRef64:                                   ; preds = %190
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %195
+ThrowNullRef66:                                   ; preds = %195
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %153
+ThrowNullRef68:                                   ; preds = %153
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %157
+ThrowNullRef70:                                   ; preds = %157
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %160
+ThrowNullRef72:                                   ; preds = %160
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %166
+ThrowNullRef74:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %136
+ThrowNullRef76:                                   ; preds = %136
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %140
+ThrowNullRef78:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %143
+ThrowNullRef80:                                   ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %148
+ThrowNullRef82:                                   ; preds = %148
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %128
+ThrowNullRef84:                                   ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %132
+ThrowNullRef86:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %100
+ThrowNullRef88:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %104
+ThrowNullRef90:                                   ; preds = %104
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %107
+ThrowNullRef92:                                   ; preds = %107
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %113
+ThrowNullRef94:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %118
+ThrowNullRef96:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %123
+ThrowNullRef98:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %81
+ThrowNullRef100:                                  ; preds = %81
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef101:                                  ; preds = %85
+ThrowNullRef102:                                  ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef103:                                  ; preds = %88
+ThrowNullRef104:                                  ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef105:                                  ; preds = %94
+ThrowNullRef106:                                  ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef107:                                  ; preds = %64
+ThrowNullRef108:                                  ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef109:                                  ; preds = %68
+ThrowNullRef110:                                  ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef111:                                  ; preds = %71
+ThrowNullRef112:                                  ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef113:                                  ; preds = %76
+ThrowNullRef114:                                  ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef115:                                  ; preds = %56
+ThrowNullRef116:                                  ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef117:                                  ; preds = %60
+ThrowNullRef118:                                  ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef119:                                  ; preds = %37
+ThrowNullRef120:                                  ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef121:                                  ; preds = %41
+ThrowNullRef122:                                  ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef123:                                  ; preds = %46
+ThrowNullRef124:                                  ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef125:                                  ; preds = %51
+ThrowNullRef126:                                  ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef127:                                  ; preds = %27
+ThrowNullRef128:                                  ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef129:                                  ; preds = %31
+ThrowNullRef130:                                  ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef131:                                  ; preds = %19
+ThrowNullRef132:                                  ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef133:                                  ; preds = %22
+ThrowNullRef134:                                  ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef135:                                  ; preds = %338
+ThrowNullRef136:                                  ; preds = %338
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef137:                                  ; preds = %341
+ThrowNullRef138:                                  ; preds = %341
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef139:                                  ; preds = %356
+ThrowNullRef140:                                  ; preds = %356
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef141:                                  ; preds = %360
+ThrowNullRef142:                                  ; preds = %360
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef143:                                  ; preds = %377
+ThrowNullRef144:                                  ; preds = %377
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef145:                                  ; preds = %381
+ThrowNullRef146:                                  ; preds = %381
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef147:                                  ; preds = %424
+ThrowNullRef148:                                  ; preds = %424
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef149:                                  ; preds = %428
+ThrowNullRef150:                                  ; preds = %428
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef151:                                  ; preds = %440
+ThrowNullRef152:                                  ; preds = %440
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef153:                                  ; preds = %444
+ThrowNullRef154:                                  ; preds = %444
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef155:                                  ; preds = %456
+ThrowNullRef156:                                  ; preds = %456
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef157:                                  ; preds = %460
+ThrowNullRef158:                                  ; preds = %460
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef159:                                  ; preds = %474
+ThrowNullRef160:                                  ; preds = %474
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef161:                                  ; preds = %477
+ThrowNullRef162:                                  ; preds = %477
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef163:                                  ; preds = %394
+ThrowNullRef164:                                  ; preds = %394
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef165:                                  ; preds = %398
+ThrowNullRef166:                                  ; preds = %398
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef167:                                  ; preds = %401
+ThrowNullRef168:                                  ; preds = %401
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef169:                                  ; preds = %407
+ThrowNullRef170:                                  ; preds = %407
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1939,8 +2021,8 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
-  br i1 %NullCheck, label %22, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %ThrowNullRef, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
@@ -1948,8 +2030,8 @@ entry:
   store i32 %24, i32* %loc0
   %25 = load i32, i32* %loc0
   %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %26, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %27
 
 ; <label>:27                                      ; preds = %22
   %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
@@ -1971,7 +2053,7 @@ ThrowNullRef:                                     ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1989,8 +2071,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -2022,15 +2104,15 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2048,16 +2130,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
   %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
   store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %15
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
@@ -2072,8 +2154,8 @@ entry:
   %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
   %29 = ptrtoint i16 addrspace(1)* %28 to i64
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %19
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
@@ -2089,19 +2171,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2114,8 +2196,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
@@ -2128,7 +2210,7 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[loadElem]
+Failed to read AppDomain.PrepareDataForSetup[storeElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
@@ -2202,8 +2284,8 @@ entry:
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
-  br i1 %NullCheck24, label %27, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = load i64, i64 addrspace(1)* %26
@@ -2218,8 +2300,8 @@ entry:
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
-  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
   %41 = load i64, i64 addrspace(1)* %39
@@ -2236,8 +2318,8 @@ entry:
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
-  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
   %54 = load i64, i64 addrspace(1)* %52
@@ -2252,8 +2334,8 @@ entry:
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
   %67 = load i64, i64 addrspace(1)* %65
@@ -2270,8 +2352,8 @@ entry:
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
-  br i1 %NullCheck16, label %79, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
   %80 = load i64, i64 addrspace(1)* %78
@@ -2286,8 +2368,8 @@ entry:
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
-  br i1 %NullCheck18, label %92, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
   %93 = load i64, i64 addrspace(1)* %91
@@ -2304,8 +2386,8 @@ entry:
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
-  br i1 %NullCheck12, label %105, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = load i64, i64 addrspace(1)* %104
@@ -2320,8 +2402,8 @@ entry:
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
-  br i1 %NullCheck14, label %118, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
   %119 = load i64, i64 addrspace(1)* %117
@@ -2337,8 +2419,8 @@ entry:
 
 ; <label>:128                                     ; preds = %20
   %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
-  br i1 %NullCheck4, label %130, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %129, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %130
 
 ; <label>:130                                     ; preds = %128
   %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
@@ -2346,8 +2428,8 @@ entry:
   %133 = load i16, i16 addrspace(1)* %132, align 8
   %134 = zext i16 %133 to i32
   %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
-  br i1 %NullCheck6, label %136, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %135, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %136
 
 ; <label>:136                                     ; preds = %130
   %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
@@ -2360,8 +2442,8 @@ entry:
 
 ; <label>:143                                     ; preds = %136
   %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
-  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %144, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %145
 
 ; <label>:145                                     ; preds = %143
   %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
@@ -2369,8 +2451,8 @@ entry:
   %148 = load i16, i16 addrspace(1)* %147, align 8
   %149 = zext i16 %148 to i32
   %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %150, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %151
 
 ; <label>:151                                     ; preds = %145
   %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
@@ -2388,8 +2470,8 @@ entry:
 
 ; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
-  br i1 %NullCheck, label %163, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %ThrowNullRef, label %163
 
 ; <label>:163                                     ; preds = %161
   %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
@@ -2399,8 +2481,8 @@ entry:
 
 ; <label>:167                                     ; preds = %163
   %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
-  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %168, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %169
 
 ; <label>:169                                     ; preds = %167
   %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
@@ -2432,55 +2514,55 @@ ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %167
+ThrowNullRef2:                                    ; preds = %167
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %128
+ThrowNullRef4:                                    ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %130
+ThrowNullRef6:                                    ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %143
+ThrowNullRef8:                                    ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %145
+ThrowNullRef10:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %102
+ThrowNullRef12:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %105
+ThrowNullRef14:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %76
+ThrowNullRef16:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %79
+ThrowNullRef18:                                   ; preds = %79
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %50
+ThrowNullRef20:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %53
+ThrowNullRef22:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %24
+ThrowNullRef24:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %27
+ThrowNullRef26:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2503,15 +2585,15 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2519,16 +2601,16 @@ entry:
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
   store i32 %8, i32* %loc0
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
   %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
   store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
@@ -2546,16 +2628,16 @@ entry:
 
 ; <label>:23                                      ; preds = %64
   %24 = load i16*, i16** %loc3
-  %NullCheck12 = icmp ne i16* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i16* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
   store i32 %27, i32* %loc5
   %28 = load i16*, i16** %loc4
-  %NullCheck14 = icmp ne i16* %28, null
-  br i1 %NullCheck14, label %29, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %28, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = load i16, i16* %28, align 8
@@ -2620,15 +2702,15 @@ entry:
 
 ; <label>:67                                      ; preds = %64
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
-  br i1 %NullCheck8, label %69, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %68, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %69
 
 ; <label>:69                                      ; preds = %67
   %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
   %71 = load i32, i32 addrspace(1)* %70
   %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
-  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %73
 
 ; <label>:73                                      ; preds = %69
   %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
@@ -2645,31 +2727,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %67
+ThrowNullRef8:                                    ; preds = %67
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %69
+ThrowNullRef10:                                   ; preds = %69
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2710,14 +2792,14 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
   %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
@@ -2730,14 +2812,14 @@ entry:
 
 ; <label>:11                                      ; preds = %4
   %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
   %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
@@ -2749,14 +2831,14 @@ entry:
 
 ; <label>:22                                      ; preds = %16
   %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
   %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
-  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
-  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
@@ -2804,23 +2886,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2836,7 +2918,280 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[loadElem]
+Successfully read RuntimeType.IsAssignableFrom
+
+define i8 @RuntimeType.IsAssignableFrom(%System.RuntimeType addrspace(1)* %param0, %System.Type addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.RuntimeType addrspace(1)*
+  %arg1 = alloca %System.Type addrspace(1)*
+  %loc0 = alloca %System.RuntimeType addrspace(1)*
+  %loc1 = alloca %"System.Type[]" addrspace(1)*
+  %loc2 = alloca i32
+  store %System.RuntimeType addrspace(1)* %param0, %System.RuntimeType addrspace(1)** %this
+  store %System.Type addrspace(1)* %param1, %System.Type addrspace(1)** %arg1
+  %0 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %1 = icmp ne %System.Type addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i8 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %5 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %6 = bitcast %System.Type addrspace(1)* %4 to %System.Object addrspace(1)*
+  %7 = bitcast %System.RuntimeType addrspace(1)* %5 to %System.Object addrspace(1)*
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %6, %System.Object addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %3
+  ret i8 1
+
+; <label>:12                                      ; preds = %3
+  %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 152
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 32
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
+  %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
+  %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
+  store %System.RuntimeType addrspace(1)* %25, %System.RuntimeType addrspace(1)** %loc0
+  %26 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %27 = icmp eq %System.RuntimeType addrspace(1)* %26, null
+  br i1 %27, label %34, label %28
+
+; <label>:28                                      ; preds = %15
+  %29 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %30 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)*)*)(%System.RuntimeType addrspace(1)* %29, %System.RuntimeType addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+; <label>:34                                      ; preds = %15
+  %35 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %36 = call %System.Reflection.Emit.TypeBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Reflection.Emit.TypeBuilder addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %35)
+  %37 = icmp eq %System.Reflection.Emit.TypeBuilder addrspace(1)* %36, null
+  br i1 %37, label %139, label %38
+
+; <label>:38                                      ; preds = %34
+  %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %42
+
+; <label>:42                                      ; preds = %38
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 152
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 40
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
+  %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
+  %53 = zext i8 %52 to i32
+  %54 = icmp eq i32 %53, 0
+  br i1 %54, label %56, label %55
+
+; <label>:55                                      ; preds = %42
+  ret i8 1
+
+; <label>:56                                      ; preds = %42
+  %57 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %58 = bitcast %System.RuntimeType addrspace(1)* %57 to %System.Type addrspace(1)*
+  %59 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %58)
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %64 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.Type addrspace(1)* %63, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = bitcast %System.RuntimeType addrspace(1)* %64 to %System.Type addrspace(1)*
+  %67 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %63, %System.Type addrspace(1)* %66)
+  %68 = zext i8 %67 to i32
+  %69 = trunc i32 %68 to i8
+  ret i8 %69
+
+; <label>:70                                      ; preds = %56
+  %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
+  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %73
+
+; <label>:73                                      ; preds = %70
+  %74 = load i64, i64 addrspace(1)* %72
+  %75 = add i64 %74, 128
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = add i64 %77, 0
+  %79 = inttoptr i64 %78 to i64*
+  %80 = load i64, i64* %79
+  %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
+  %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
+  %83 = call i8 %82(%System.Type addrspace(1)* %81)
+  %84 = zext i8 %83 to i32
+  %85 = icmp eq i32 %84, 0
+  br i1 %85, label %139, label %86
+
+; <label>:86                                      ; preds = %73
+  %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
+  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %89
+
+; <label>:89                                      ; preds = %86
+  %90 = load i64, i64 addrspace(1)* %88
+  %91 = add i64 %90, 128
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = add i64 %93, 24
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
+  %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
+  %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
+  store %"System.Type[]" addrspace(1)* %99, %"System.Type[]" addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %129
+
+; <label>:100                                     ; preds = %132
+  %101 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %102 = load i32, i32* %loc2
+  %NullCheck11 = icmp eq %"System.Type[]" addrspace(1)* %101, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %103
+
+; <label>:103                                     ; preds = %100
+  %104 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 1
+  %105 = load i32, i32 addrspace(1)* %104
+  %106 = zext i32 %105 to i64
+  %107 = zext i32 %102 to i64
+  %BoundsCheck = icmp uge i64 %107, %106
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %108
+
+; <label>:108                                     ; preds = %103
+  %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
+  %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
+  %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
+  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %113
+
+; <label>:113                                     ; preds = %108
+  %114 = load i64, i64 addrspace(1)* %112
+  %115 = add i64 %114, 152
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = add i64 %117, 56
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
+  %123 = zext i8 %122 to i32
+  %124 = icmp ne i32 %123, 0
+  br i1 %124, label %126, label %125
+
+; <label>:125                                     ; preds = %113
+  ret i8 0
+
+; <label>:126                                     ; preds = %113
+  %127 = load i32, i32* %loc2
+  %128 = add i32 %127, 1
+  store i32 %128, i32* %loc2
+  br label %129
+
+; <label>:129                                     ; preds = %89, %126
+  %130 = load i32, i32* %loc2
+  %131 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %NullCheck9 = icmp eq %"System.Type[]" addrspace(1)* %131, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %132
+
+; <label>:132                                     ; preds = %129
+  %133 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %131, i32 0, i32 1
+  %134 = load i32, i32 addrspace(1)* %133
+  %135 = zext i32 %134 to i64
+  %136 = trunc i64 %135 to i32
+  %137 = icmp slt i32 %130, %136
+  br i1 %137, label %100, label %138
+
+; <label>:138                                     ; preds = %132
+  ret i8 1
+
+; <label>:139                                     ; preds = %34, %73
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %129
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %103
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -2893,7 +3248,7 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElem]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -2904,8 +3259,8 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -2997,8 +3352,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
@@ -3059,8 +3414,8 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -3087,8 +3442,8 @@ entry:
 
 ; <label>:17                                      ; preds = %5, %11
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
@@ -3097,8 +3452,8 @@ entry:
 
 ; <label>:22                                      ; preds = %1, %11
   %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
@@ -3109,11 +3464,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %17
+ThrowNullRef2:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %22
+ThrowNullRef4:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3167,15 +3522,15 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
   %15 = load i32, i32 addrspace(1)* %14
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
@@ -3198,7 +3553,7 @@ ThrowNullRef:                                     ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef2:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3232,8 +3587,8 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
@@ -3312,8 +3667,8 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -3327,8 +3682,8 @@ entry:
 ; <label>:5                                       ; preds = %43
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %7 = load i32, i32* %loc1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck6, label %8, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
@@ -3366,8 +3721,8 @@ entry:
 ; <label>:32                                      ; preds = %21, %25
   %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
   %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
-  br i1 %NullCheck8, label %35, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = trunc i32 %34 to i16
@@ -3380,8 +3735,8 @@ entry:
 ; <label>:40                                      ; preds = %1, %35
   %41 = load i32, i32* %loc1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
-  br i1 %NullCheck2, label %43, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %42, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
@@ -3392,8 +3747,8 @@ entry:
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
   %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
-  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
   %51 = load i64, i64 addrspace(1)* %49
@@ -3412,19 +3767,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %40
+ThrowNullRef2:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %47
+ThrowNullRef4:                                    ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %5
+ThrowNullRef6:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %32
+ThrowNullRef8:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3467,8 +3822,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
@@ -3492,11 +3847,391 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(i16* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store i16* %param0, i16** %arg0
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load i32, i32* %arg3
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %42, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %37, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg2
+  %13 = load i32, i32* %arg3
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %37, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %24 = load i32, i32* %arg2
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load i16*, i16** %arg0
+  %35 = load i32, i32* %arg3
+  %36 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %36, i16* %34, i32 %35)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:37                                      ; preds = %5, %16
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %39)
+  %41 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41, %System.String addrspace(1)* %38, %System.String addrspace(1)* %40)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41) #0
+  unreachable
+
+; <label>:42                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
-Failed to read StringBuilder.ToString[loadElemA]
+Successfully read StringBuilder.ToString
+
+define %System.String addrspace(1)* @StringBuilder.ToString(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i16*
+  %loc3 = alloca %"System.Char[]" addrspace(1)*
+  %loc4 = alloca i32
+  %loc5 = alloca i32
+  %loc6 = alloca i16 addrspace(1)*
+  %loc7 = alloca %System.String addrspace(1)*
+  %loc8 = alloca %"System.Char[]" addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %0)
+  %2 = icmp ne i32 %1, 0
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %4
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %6)
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %7)
+  store %System.String addrspace(1)* %8, %System.String addrspace(1)** %loc0
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.Text.StringBuilder addrspace(1)* %9, %System.Text.StringBuilder addrspace(1)** %loc1
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  store %System.String addrspace(1)* %10, %System.String addrspace(1)** %loc7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc7
+  %12 = ptrtoint %System.String addrspace(1)* %11 to i64
+  %13 = icmp eq i64 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %5
+  %15 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %16 = sext i32 %15 to i64
+  %17 = add i64 %12, %16
+  br label %18
+
+; <label>:18                                      ; preds = %5, %14
+  %19 = phi i64 [ %12, %5 ], [ %17, %14 ]
+  %20 = inttoptr i64 %19 to i16*
+  store i16* %20, i16** %loc2
+  br label %21
+
+; <label>:21                                      ; preds = %98, %18
+  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %22, null
+  br i1 %NullCheck, label %ThrowNullRef, label %23
+
+; <label>:23                                      ; preds = %21
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 3
+  %25 = load i32, i32 addrspace(1)* %24, align 8
+  %26 = icmp sle i32 %25, 0
+  br i1 %26, label %96, label %27
+
+; <label>:27                                      ; preds = %23
+  %28 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %28, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %29
+
+; <label>:29                                      ; preds = %27
+  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %28, i32 0, i32 1
+  %31 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %30, align 8
+  store %"System.Char[]" addrspace(1)* %31, %"System.Char[]" addrspace(1)** %loc3
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %33
+
+; <label>:33                                      ; preds = %29
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  store i32 %35, i32* %loc4
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  %39 = load i32, i32 addrspace(1)* %38, align 8
+  store i32 %39, i32* %loc5
+  %40 = load i32, i32* %loc5
+  %41 = load i32, i32* %loc4
+  %42 = add i32 %40, %41
+  %43 = zext i32 %42 to i64
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %45
+
+; <label>:45                                      ; preds = %37
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = sext i32 %47 to i64
+  %49 = icmp sgt i64 %43, %48
+  br i1 %49, label %91, label %50
+
+; <label>:50                                      ; preds = %45
+  %51 = load i32, i32* %loc5
+  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %52, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %53
+
+; <label>:53                                      ; preds = %50
+  %54 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %52, i32 0, i32 1
+  %55 = load i32, i32 addrspace(1)* %54
+  %56 = zext i32 %55 to i64
+  %57 = trunc i64 %56 to i32
+  %58 = icmp ugt i32 %51, %57
+  br i1 %58, label %91, label %59
+
+; <label>:59                                      ; preds = %53
+  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  store %"System.Char[]" addrspace(1)* %60, %"System.Char[]" addrspace(1)** %loc8
+  %61 = icmp eq %"System.Char[]" addrspace(1)* %60, null
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %63, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %64
+
+; <label>:64                                      ; preds = %62
+  %65 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %63, i32 0, i32 1
+  %66 = load i32, i32 addrspace(1)* %65
+  %67 = zext i32 %66 to i64
+  %68 = trunc i64 %67 to i32
+  %69 = icmp ne i32 %68, 0
+  br i1 %69, label %71, label %70
+
+; <label>:70                                      ; preds = %59, %64
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:71                                      ; preds = %64
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %73
+
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %BoundsCheck = icmp uge i64 0, %76
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %77
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %78, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:79                                      ; preds = %70, %77
+  %80 = load i16*, i16** %loc2
+  %81 = load i32, i32* %loc4
+  %82 = sext i32 %81 to i64
+  %83 = mul i64 %82, 2
+  %84 = bitcast i16* %80 to i8*
+  %85 = getelementptr inbounds i8, i8* %84, i64 %83
+  %86 = load i16 addrspace(1)*, i16 addrspace(1)** %loc6
+  %87 = ptrtoint i16 addrspace(1)* %86 to i64
+  %88 = load i32, i32* %loc5
+  %89 = bitcast i8* %85 to i16*
+  %90 = inttoptr i64 %87 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %89, i16* %90, i32 %88)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %96
+
+; <label>:91                                      ; preds = %45, %53
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %94 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %93)
+  %95 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95, %System.String addrspace(1)* %92, %System.String addrspace(1)* %94)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95) #0
+  unreachable
+
+; <label>:96                                      ; preds = %23, %79
+  %97 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %97, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %98
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %97, i32 0, i32 2
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  store %System.Text.StringBuilder addrspace(1)* %100, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %102 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %102, label %21, label %103
+
+; <label>:103                                     ; preds = %98
+  store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc7
+  %104 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  ret %System.String addrspace(1)* %104
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method StringBuilder::get_Length using LLILCJit
+Successfully read StringBuilder.get_Length
+
+define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
+Successfully read RuntimeHelpers.get_OffsetToStringData
+
+define i32 @RuntimeHelpers.get_OffsetToStringData() {
+entry:
+  ret i32 12
+}
+
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
 Successfully read CultureData.CreateCultureData
 
@@ -3514,23 +4249,23 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
   store i8 %4, i8 addrspace(1)* %6
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
@@ -3549,11 +4284,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3566,50 +4301,50 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
   store i32 -1, i32 addrspace(1)* %2
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
   store i32 -1, i32 addrspace(1)* %8
   %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
   store i32 -1, i32 addrspace(1)* %14
   %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
   store i32 -1, i32 addrspace(1)* %17
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
@@ -3623,27 +4358,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3675,7 +4410,136 @@ Failed to read Dictionary`2.Insert[non-const derefAddress]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
 Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
-Failed to read HashHelpers.GetPrime[loadElem]
+Successfully read HashHelpers.GetPrime
+
+define i32 @HashHelpers.GetPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %6, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5, %System.String addrspace(1)* %4)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5) #0
+  unreachable
+
+; <label>:6                                       ; preds = %entry
+  store i32 0, i32* %loc0
+  br label %29
+
+; <label>:7                                       ; preds = %35
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 1296
+  %10 = addrspacecast i8 addrspace(1)* %9 to %"System.Int32[]" addrspace(1)**
+  %11 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %10
+  %12 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Int32[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = zext i32 %15 to i64
+  %17 = zext i32 %12 to i64
+  %BoundsCheck = icmp uge i64 %17, %16
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 3, i32 %12
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  store i32 %20, i32* %loc1
+  %21 = load i32, i32* %loc1
+  %22 = load i32, i32* %arg0
+  %23 = icmp slt i32 %21, %22
+  br i1 %23, label %26, label %24
+
+; <label>:24                                      ; preds = %18
+  %25 = load i32, i32* %loc1
+  ret i32 %25
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %loc0
+  %28 = add i32 %27, 1
+  store i32 %28, i32* %loc0
+  br label %29
+
+; <label>:29                                      ; preds = %6, %26
+  %30 = load i32, i32* %loc0
+  %31 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %32 = getelementptr inbounds i8, i8 addrspace(1)* %31, i64 1296
+  %33 = addrspacecast i8 addrspace(1)* %32 to %"System.Int32[]" addrspace(1)**
+  %34 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %33
+  %NullCheck = icmp eq %"System.Int32[]" addrspace(1)* %34, null
+  br i1 %NullCheck, label %ThrowNullRef, label %35
+
+; <label>:35                                      ; preds = %29
+  %36 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %34, i32 0, i32 1
+  %37 = load i32, i32 addrspace(1)* %36
+  %38 = zext i32 %37 to i64
+  %39 = trunc i64 %38 to i32
+  %40 = icmp slt i32 %30, %39
+  br i1 %40, label %7, label %41
+
+; <label>:41                                      ; preds = %35
+  %42 = load i32, i32* %arg0
+  %43 = or i32 %42, 1
+  store i32 %43, i32* %loc2
+  br label %59
+
+; <label>:44                                      ; preds = %59
+  %45 = load i32, i32* %loc2
+  %46 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %45)
+  %47 = zext i8 %46 to i32
+  %48 = icmp eq i32 %47, 0
+  br i1 %48, label %56, label %49
+
+; <label>:49                                      ; preds = %44
+  %50 = load i32, i32* %loc2
+  %51 = sub i32 %50, 1
+  %52 = srem i32 %51, 101
+  %53 = icmp eq i32 %52, 0
+  br i1 %53, label %56, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = load i32, i32* %loc2
+  ret i32 %55
+
+; <label>:56                                      ; preds = %44, %49
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %57, 2
+  store i32 %58, i32* %loc2
+  br label %59
+
+; <label>:59                                      ; preds = %41, %56
+  %60 = load i32, i32* %loc2
+  %61 = icmp slt i32 %60, 2147483647
+  br i1 %61, label %44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load i32, i32* %arg0
+  ret i32 %63
+
+ThrowNullRef:                                     ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
 Successfully read GenericEqualityComparer`1.GetHashCode
 
@@ -3694,14 +4558,14 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
   %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load i64, i64 addrspace(1)* %7
@@ -3720,7 +4584,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3750,8 +4614,8 @@ entry:
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
@@ -3796,8 +4660,8 @@ entry:
   %35 = bitcast i16* %34 to i8*
   %36 = getelementptr inbounds i8, i8* %35, i64 2
   %37 = bitcast i8* %36 to i16*
-  %NullCheck4 = icmp ne i16* %37, null
-  br i1 %NullCheck4, label %38, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %37, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %38
 
 ; <label>:38                                      ; preds = %27
   %39 = load i16, i16* %37, align 8
@@ -3824,8 +4688,8 @@ entry:
 
 ; <label>:54                                      ; preds = %22, %43
   %55 = load i16*, i16** %loc4
-  %NullCheck2 = icmp ne i16* %55, null
-  br i1 %NullCheck2, label %56, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i16* %55, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %56
 
 ; <label>:56                                      ; preds = %54
   %57 = load i16, i16* %55, align 8
@@ -3850,11 +4714,11 @@ ThrowNullRef:                                     ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %54
+ThrowNullRef2:                                    ; preds = %54
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %27
+ThrowNullRef4:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3871,8 +4735,8 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -3907,8 +4771,8 @@ entry:
 
 ; <label>:26                                      ; preds = %19
   %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
-  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %28
 
 ; <label>:28                                      ; preds = %26
   %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
@@ -3920,7 +4784,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3972,8 +4836,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
@@ -3984,26 +4848,26 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
-  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
@@ -4014,8 +4878,8 @@ entry:
 ; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
@@ -4024,8 +4888,8 @@ entry:
 
 ; <label>:25                                      ; preds = %1, %16, %23
   %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
-  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
@@ -4036,27 +4900,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %20
+ThrowNullRef10:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4069,8 +4933,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -4081,8 +4945,8 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
@@ -4091,8 +4955,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1, %8
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
@@ -4103,11 +4967,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4128,24 +4992,24 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   store i32 %3, i32* %loc0
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
   %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
   store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck4, label %9, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
@@ -4164,15 +5028,15 @@ entry:
 ; <label>:18                                      ; preds = %70
   %19 = load i16*, i16** %loc3
   %20 = bitcast i16* %19 to i64*
-  %NullCheck10 = icmp ne i64* %20, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %20, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = load i64, i64* %20, align 8
   %23 = load i16*, i16** %loc4
   %24 = bitcast i16* %23 to i64*
-  %NullCheck12 = icmp ne i64* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = load i64, i64* %24, align 8
@@ -4188,8 +5052,8 @@ entry:
   %31 = bitcast i16* %30 to i8*
   %32 = getelementptr inbounds i8, i8* %31, i64 8
   %33 = bitcast i8* %32 to i64*
-  %NullCheck14 = icmp ne i64* %33, null
-  br i1 %NullCheck14, label %34, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = load i64, i64* %33, align 8
@@ -4197,8 +5061,8 @@ entry:
   %37 = bitcast i16* %36 to i8*
   %38 = getelementptr inbounds i8, i8* %37, i64 8
   %39 = bitcast i8* %38 to i64*
-  %NullCheck16 = icmp ne i64* %39, null
-  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %40
 
 ; <label>:40                                      ; preds = %34
   %41 = load i64, i64* %39, align 8
@@ -4214,8 +5078,8 @@ entry:
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %NullCheck18 = icmp ne i64* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = load i64, i64* %48, align 8
@@ -4223,8 +5087,8 @@ entry:
   %52 = bitcast i16* %51 to i8*
   %53 = getelementptr inbounds i8, i8* %52, i64 16
   %54 = bitcast i8* %53 to i64*
-  %NullCheck20 = icmp ne i64* %54, null
-  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64* %54, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %55
 
 ; <label>:55                                      ; preds = %49
   %56 = load i64, i64* %54, align 8
@@ -4262,15 +5126,15 @@ entry:
 ; <label>:74                                      ; preds = %95
   %75 = load i16*, i16** %loc3
   %76 = bitcast i16* %75 to i32*
-  %NullCheck6 = icmp ne i32* %76, null
-  br i1 %NullCheck6, label %77, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32* %76, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %77
 
 ; <label>:77                                      ; preds = %74
   %78 = load i32, i32* %76, align 8
   %79 = load i16*, i16** %loc4
   %80 = bitcast i16* %79 to i32*
-  %NullCheck8 = icmp ne i32* %80, null
-  br i1 %NullCheck8, label %81, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i32* %80, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %81
 
 ; <label>:81                                      ; preds = %77
   %82 = load i32, i32* %80, align 8
@@ -4318,43 +5182,43 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %74
+ThrowNullRef6:                                    ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %77
+ThrowNullRef8:                                    ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %29
+ThrowNullRef14:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %34
+ThrowNullRef16:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4376,8 +5240,8 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load i64, i64 addrspace(1)* %4
@@ -4389,8 +5253,8 @@ entry:
   %12 = load i64, i64* %11
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %5
   %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
@@ -4399,8 +5263,8 @@ entry:
   %18 = load i8, i8* %arg2
   %19 = zext i8 %18 to i32
   %20 = trunc i32 %19 to i8
-  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %15
   %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
@@ -4411,11 +5275,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4442,8 +5306,8 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
@@ -4466,16 +5330,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
   %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = load i64, i64 addrspace(1)* %19
@@ -4500,8 +5364,8 @@ entry:
 ; <label>:35                                      ; preds = %30
   %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
@@ -4514,8 +5378,8 @@ entry:
 
 ; <label>:42                                      ; preds = %1, %38
   %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
-  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
@@ -4526,19 +5390,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %35
+ThrowNullRef2:                                    ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %42
+ThrowNullRef8:                                    ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4551,14 +5415,14 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
@@ -4570,7 +5434,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4583,8 +5447,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
@@ -4613,51 +5477,51 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
   %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
   %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
   %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
   %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
-  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
   store i64 %21, i64 addrspace(1)* %23
   %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %25 = load i64, i64* %loc0
-  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
@@ -4668,27 +5532,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %22
+ThrowNullRef12:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4701,8 +5565,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
@@ -4713,19 +5577,19 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
@@ -4734,8 +5598,8 @@ entry:
 
 ; <label>:15                                      ; preds = %1, %13
   %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
@@ -4746,19 +5610,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %15
+ThrowNullRef8:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4771,8 +5635,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -4831,8 +5695,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
@@ -4882,8 +5746,8 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
-  br i1 %NullCheck, label %17, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %ThrowNullRef, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
@@ -4894,15 +5758,15 @@ entry:
 
 ; <label>:22                                      ; preds = %17
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
-  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
   %26 = load i32, i32 addrspace(1)* %25
   %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
-  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %27, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
@@ -4925,8 +5789,8 @@ entry:
 ; <label>:40                                      ; preds = %17
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
-  br i1 %NullCheck6, label %43, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %41, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
@@ -4938,34 +5802,17 @@ ThrowNullRef:                                     ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %24
+ThrowNullRef4:                                    ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %40
+ThrowNullRef6:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
-}
-
-INFO:  jitting method Object::ReferenceEquals using LLILCJit
-Successfully read Object.ReferenceEquals
-
-define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
-entry:
-  %arg0 = alloca %System.Object addrspace(1)*
-  %arg1 = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
-  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
-  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = icmp eq %System.Object addrspace(1)* %0, %1
-  %3 = sext i1 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
 }
 
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
@@ -4978,21 +5825,21 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
   %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
-  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
@@ -5007,28 +5854,28 @@ entry:
 ; <label>:13                                      ; preds = %8, %12
   %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
   %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
   %21 = load i32, i32 addrspace(1)* %20, align 8
   %22 = add i32 %21, 1
-  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
   store i32 %22, i32 addrspace(1)* %24
   %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
@@ -5039,27 +5886,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5077,7 +5924,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::Setup using LLILCJit
-Failed to read AppDomain.Setup[loadElem]
+Failed to read AppDomain.Setup[unbox]
 INFO:  jitting method Thread::GetDomain using LLILCJit
 Successfully read Thread.GetDomain
 
@@ -5108,8 +5955,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
@@ -5122,14 +5969,14 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
   %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
@@ -5141,11 +5988,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5173,8 +6020,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -5189,7 +6036,328 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
 Failed to read KeyCollection.System.Collections.Generic.IEnumerable<TKey>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Successfully read Enumerator.MoveNext
+
+define i8 @Enumerator.MoveNext(%"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.RuntimeTypeHandle* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*
+  %"$TypeArg" = alloca %System.RuntimeTypeHandle*
+  store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
+  %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 8
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %76, label %12
+
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
+  br label %76
+
+; <label>:13                                      ; preds = %85
+  %14 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck19 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %15
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, i32 0, i32 0
+  %17 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %16, align 8
+  %NullCheck21 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, i32 0, i32 2
+  %20 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %19, align 8
+  %21 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck23 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %22
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, i32 0, i32 2
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %NullCheck25 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 3, i32 %24
+  %NullCheck27 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %32
+
+; <label>:32                                      ; preds = %30
+  %33 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, i32 0, i32 2
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = icmp slt i32 %34, 0
+  br i1 %35, label %68, label %36
+
+; <label>:36                                      ; preds = %32
+  %37 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %38 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck29 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %39
+
+; <label>:39                                      ; preds = %36
+  %40 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, i32 0, i32 0
+  %41 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %40, align 8
+  %NullCheck31 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, i32 0, i32 2
+  %44 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %43, align 8
+  %45 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck33 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, i32 0, i32 2
+  %48 = load i32, i32 addrspace(1)* %47, align 8
+  %NullCheck35 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %49
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = zext i32 %51 to i64
+  %53 = zext i32 %48 to i64
+  %BoundsCheck37 = icmp uge i64 %53, %52
+  br i1 %BoundsCheck37, label %ThrowIndexOutOfRange38, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 3, i32 %48
+  %NullCheck39 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %56
+
+; <label>:56                                      ; preds = %54
+  %57 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, i32 0, i32 0
+  %58 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck41 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %59
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %60, %System.__Canon addrspace(1)* %58)
+  %61 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck43 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  %64 = load i32, i32 addrspace(1)* %63, align 8
+  %65 = add i32 %64, 1
+  %NullCheck45 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  store i32 %65, i32 addrspace(1)* %67
+  ret i8 1
+
+; <label>:68                                      ; preds = %32
+  %69 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck47 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %73 = add i32 %72, 1
+  %NullCheck49 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %74
+
+; <label>:74                                      ; preds = %70
+  %75 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  store i32 %73, i32 addrspace(1)* %75
+  br label %76
+
+; <label>:76                                      ; preds = %8, %12, %74
+  %77 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %78
+
+; <label>:78                                      ; preds = %76
+  %79 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, i32 0, i32 2
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck7 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %82
+
+; <label>:82                                      ; preds = %78
+  %83 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, i32 0, i32 0
+  %84 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %83, align 8
+  %NullCheck9 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %85
+
+; <label>:85                                      ; preds = %82
+  %86 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, i32 0, i32 7
+  %87 = load i32, i32 addrspace(1)* %86, align 8
+  %88 = icmp ult i32 %80, %87
+  br i1 %88, label %13, label %89
+
+; <label>:89                                      ; preds = %85
+  %90 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %91 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck11 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %92
+
+; <label>:92                                      ; preds = %89
+  %93 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, i32 0, i32 0
+  %94 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck13 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %95
+
+; <label>:95                                      ; preds = %92
+  %96 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, i32 0, i32 7
+  %97 = load i32, i32 addrspace(1)* %96, align 8
+  %98 = add i32 %97, 1
+  %NullCheck15 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %99
+
+; <label>:99                                      ; preds = %95
+  %100 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, i32 0, i32 2
+  store i32 %98, i32 addrspace(1)* %100
+  %101 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck17 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %102
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %103, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %92
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef22:                                   ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef24:                                   ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef26:                                   ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef28:                                   ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef30:                                   ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef32:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef34:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef36:                                   ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange38:                           ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef40:                                   ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef42:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef44:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef46:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef48:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef50:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -5200,8 +6368,8 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -5232,9 +6400,9 @@ Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
 Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
-Failed to read String.MakeSeparatorList[loadElemA]
+Failed to read String.MakeSeparatorList[storeElem]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
-Failed to read String.InternalSplitKeepEmptyEntries[loadElem]
+Failed to read String.InternalSplitKeepEmptyEntries[storeElem]
 INFO:  jitting method Path::IsRelative using LLILCJit
 Successfully read Path.IsRelative
 
@@ -5243,8 +6411,8 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -5254,8 +6422,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
@@ -5271,8 +6439,8 @@ entry:
 
 ; <label>:17                                      ; preds = %7
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
@@ -5288,8 +6456,8 @@ entry:
 
 ; <label>:29                                      ; preds = %19
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %31
 
 ; <label>:31                                      ; preds = %29
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
@@ -5300,8 +6468,8 @@ entry:
 
 ; <label>:36                                      ; preds = %31
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
-  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %37, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
@@ -5312,8 +6480,8 @@ entry:
 
 ; <label>:43                                      ; preds = %31, %38
   %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
-  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %45
 
 ; <label>:45                                      ; preds = %43
   %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
@@ -5324,8 +6492,8 @@ entry:
 
 ; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %50
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
@@ -5336,8 +6504,8 @@ entry:
 
 ; <label>:57                                      ; preds = %1, %7, %19, %45, %52
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
-  br i1 %NullCheck14, label %59, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %59
 
 ; <label>:59                                      ; preds = %57
   %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
@@ -5347,8 +6515,8 @@ entry:
 
 ; <label>:63                                      ; preds = %59
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
@@ -5359,8 +6527,8 @@ entry:
 
 ; <label>:70                                      ; preds = %65
   %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
-  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.String addrspace(1)* %71, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %72
 
 ; <label>:72                                      ; preds = %70
   %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
@@ -5379,39 +6547,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %17
+ThrowNullRef4:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %29
+ThrowNullRef6:                                    ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %36
+ThrowNullRef8:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %43
+ThrowNullRef10:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %50
+ThrowNullRef12:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %57
+ThrowNullRef14:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %63
+ThrowNullRef16:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %70
+ThrowNullRef18:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5419,7 +6587,293 @@ ThrowNullRef17:                                   ; preds = %70
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
-Failed to read String.TrimHelper[loadElem]
+Successfully read String.TrimHelper
+
+define %System.String addrspace(1)* @String.TrimHelper(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i16
+  %loc4 = alloca i32
+  %loc5 = alloca i16
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = sub i32 %3, 1
+  store i32 %4, i32* %loc0
+  store i32 0, i32* %loc1
+  %5 = load i32, i32* %arg2
+  %6 = icmp eq i32 %5, 1
+  br i1 %6, label %62, label %7
+
+; <label>:7                                       ; preds = %1
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:8                                       ; preds = %58
+  store i32 0, i32* %loc2
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load i32, i32* %loc1
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2, i32 %10
+  %13 = load i16, i16 addrspace(1)* %12
+  %14 = zext i16 %13 to i32
+  %15 = trunc i32 %14 to i16
+  store i16 %15, i16* %loc3
+  store i32 0, i32* %loc2
+  br label %34
+
+; <label>:16                                      ; preds = %37
+  %17 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %18 = load i32, i32* %loc2
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %17, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %19
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = zext i32 %18 to i64
+  %BoundsCheck = icmp uge i64 %23, %22
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %24
+
+; <label>:24                                      ; preds = %19
+  %25 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 3, i32 %18
+  %26 = load i16, i16 addrspace(1)* %25, align 8
+  %27 = zext i16 %26 to i32
+  %28 = load i16, i16* %loc3
+  %29 = zext i16 %28 to i32
+  %30 = icmp eq i32 %27, %29
+  br i1 %30, label %43, label %31
+
+; <label>:31                                      ; preds = %24
+  %32 = load i32, i32* %loc2
+  %33 = add i32 %32, 1
+  store i32 %33, i32* %loc2
+  br label %34
+
+; <label>:34                                      ; preds = %11, %31
+  %35 = load i32, i32* %loc2
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = icmp slt i32 %35, %41
+  br i1 %42, label %16, label %43
+
+; <label>:43                                      ; preds = %24, %37
+  %44 = load i32, i32* %loc2
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %45, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp eq i32 %44, %50
+  br i1 %51, label %62, label %52
+
+; <label>:52                                      ; preds = %46
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %7, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %57, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %58
+
+; <label>:58                                      ; preds = %55
+  %59 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %60 = load i32, i32 addrspace(1)* %59
+  %61 = icmp slt i32 %56, %60
+  br i1 %61, label %8, label %62
+
+; <label>:62                                      ; preds = %1, %46, %58
+  %63 = load i32, i32* %arg2
+  %64 = icmp eq i32 %63, 0
+  br i1 %64, label %122, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %66, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %67
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %66, i32 0, i32 1
+  %69 = load i32, i32 addrspace(1)* %68
+  %70 = sub i32 %69, 1
+  store i32 %70, i32* %loc0
+  br label %118
+
+; <label>:71                                      ; preds = %118
+  store i32 0, i32* %loc4
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %73 = load i32, i32* %loc0
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %74
+
+; <label>:74                                      ; preds = %71
+  %75 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 2, i32 %73
+  %76 = load i16, i16 addrspace(1)* %75
+  %77 = zext i16 %76 to i32
+  %78 = trunc i32 %77 to i16
+  store i16 %78, i16* %loc5
+  store i32 0, i32* %loc4
+  br label %97
+
+; <label>:79                                      ; preds = %100
+  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %81 = load i32, i32* %loc4
+  %NullCheck19 = icmp eq %"System.Char[]" addrspace(1)* %80, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
+
+; <label>:82                                      ; preds = %79
+  %83 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 1
+  %84 = load i32, i32 addrspace(1)* %83
+  %85 = zext i32 %84 to i64
+  %86 = zext i32 %81 to i64
+  %BoundsCheck21 = icmp uge i64 %86, %85
+  br i1 %BoundsCheck21, label %ThrowIndexOutOfRange22, label %87
+
+; <label>:87                                      ; preds = %82
+  %88 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 3, i32 %81
+  %89 = load i16, i16 addrspace(1)* %88, align 8
+  %90 = zext i16 %89 to i32
+  %91 = load i16, i16* %loc5
+  %92 = zext i16 %91 to i32
+  %93 = icmp eq i32 %90, %92
+  br i1 %93, label %106, label %94
+
+; <label>:94                                      ; preds = %87
+  %95 = load i32, i32* %loc4
+  %96 = add i32 %95, 1
+  store i32 %96, i32* %loc4
+  br label %97
+
+; <label>:97                                      ; preds = %74, %94
+  %98 = load i32, i32* %loc4
+  %99 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck15 = icmp eq %"System.Char[]" addrspace(1)* %99, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %100
+
+; <label>:100                                     ; preds = %97
+  %101 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %99, i32 0, i32 1
+  %102 = load i32, i32 addrspace(1)* %101
+  %103 = zext i32 %102 to i64
+  %104 = trunc i64 %103 to i32
+  %105 = icmp slt i32 %98, %104
+  br i1 %105, label %79, label %106
+
+; <label>:106                                     ; preds = %87, %100
+  %107 = load i32, i32* %loc4
+  %108 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck17 = icmp eq %"System.Char[]" addrspace(1)* %108, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %109
+
+; <label>:109                                     ; preds = %106
+  %110 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %108, i32 0, i32 1
+  %111 = load i32, i32 addrspace(1)* %110
+  %112 = zext i32 %111 to i64
+  %113 = trunc i64 %112 to i32
+  %114 = icmp eq i32 %107, %113
+  br i1 %114, label %122, label %115
+
+; <label>:115                                     ; preds = %109
+  %116 = load i32, i32* %loc0
+  %117 = sub i32 %116, 1
+  store i32 %117, i32* %loc0
+  br label %118
+
+; <label>:118                                     ; preds = %67, %115
+  %119 = load i32, i32* %loc0
+  %120 = load i32, i32* %loc1
+  %121 = icmp sge i32 %119, %120
+  br i1 %121, label %71, label %122
+
+; <label>:122                                     ; preds = %62, %109, %118
+  %123 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %124 = load i32, i32* %loc1
+  %125 = load i32, i32* %loc0
+  %126 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %123, i32 %124, i32 %125)
+  ret %System.String addrspace(1)* %126
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %97
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange22:                           ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
 Successfully read String.CreateTrimmedString
 
@@ -5439,8 +6893,8 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
@@ -5535,8 +6989,8 @@ entry:
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i64 2872
   %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
   %8 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %7
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %3
   %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
@@ -5553,8 +7007,8 @@ entry:
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 2864
   %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
   %21 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %20
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
-  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %22
 
 ; <label>:22                                      ; preds = %16
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
@@ -5569,7 +7023,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %16
+ThrowNullRef2:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5586,8 +7040,8 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5613,8 +7067,8 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
@@ -5632,8 +7086,8 @@ entry:
 
 ; <label>:12                                      ; preds = %4
   %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
@@ -5644,8 +7098,8 @@ entry:
 
 ; <label>:19                                      ; preds = %14
   %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %19
   %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
@@ -5660,21 +7114,21 @@ entry:
   %31 = zext i16 %30 to i32
   %32 = bitcast i8* %29 to i16*
   %33 = trunc i32 %31 to i16
-  %NullCheck6 = icmp ne i16* %32, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i16* %32, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %21
   store i16 %33, i16* %32, align 8
   %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %36
 
 ; <label>:36                                      ; preds = %34
   %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
   %38 = load i32, i32 addrspace(1)* %37, align 8
   %39 = add i32 %38, 1
-  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %40
 
 ; <label>:40                                      ; preds = %36
   %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
@@ -5683,16 +7137,16 @@ entry:
 
 ; <label>:42                                      ; preds = %14
   %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
-  br i1 %NullCheck12, label %44, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
   %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
   %47 = load i16, i16* %arg1
   %48 = zext i16 %47 to i32
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = trunc i32 %48 to i16
@@ -5703,31 +7157,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %19
+ThrowNullRef4:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %21
+ThrowNullRef6:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %36
+ThrowNullRef10:                                   ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %42
+ThrowNullRef12:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %44
+ThrowNullRef14:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5740,8 +7194,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -5752,8 +7206,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
@@ -5762,14 +7216,14 @@ entry:
 
 ; <label>:11                                      ; preds = %1
   %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
@@ -5779,15 +7233,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5808,8 +7262,8 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5822,8 +7276,8 @@ entry:
 
 ; <label>:8                                       ; preds = %3
   %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
@@ -5842,15 +7296,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
-  br i1 %NullCheck4, label %22, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
   %24 = load i16*, i16* addrspace(1)* %23, align 8
   %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %25, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
@@ -5859,8 +7313,8 @@ entry:
   store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
@@ -5874,8 +7328,8 @@ entry:
 
 ; <label>:37                                      ; preds = %65
   %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %37
   %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
@@ -5886,16 +7340,16 @@ entry:
   %45 = bitcast i16* %41 to i8*
   %46 = getelementptr inbounds i8, i8* %45, i64 %44
   %47 = bitcast i8* %46 to i16*
-  %NullCheck14 = icmp ne i16* %47, null
-  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %47, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %48
 
 ; <label>:48                                      ; preds = %39
   %49 = load i16, i16* %47, align 8
   %50 = zext i16 %49 to i32
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %52 = load i32, i32* %loc1
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %53
 
 ; <label>:53                                      ; preds = %48
   %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
@@ -5916,8 +7370,8 @@ entry:
 ; <label>:62                                      ; preds = %36, %59
   %63 = load i32, i32* %loc1
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck10, label %65, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %65
 
 ; <label>:65                                      ; preds = %62
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
@@ -5936,15 +7390,15 @@ entry:
 
 ; <label>:74                                      ; preds = %70
   %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
-  br i1 %NullCheck18, label %76, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %76
 
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
   %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
-  br i1 %NullCheck20, label %80, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
   %81 = load i64, i64 addrspace(1)* %79
@@ -5958,8 +7412,8 @@ entry:
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
   %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
-  br i1 %NullCheck22, label %92, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.String addrspace(1)* %90, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %92
 
 ; <label>:92                                      ; preds = %80
   %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
@@ -5969,15 +7423,15 @@ entry:
 
 ; <label>:96                                      ; preds = %70
   %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
-  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %98
 
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
   %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
-  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
   %103 = load i64, i64 addrspace(1)* %101
@@ -5991,8 +7445,8 @@ entry:
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
   %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
-  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.String addrspace(1)* %112, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %114
 
 ; <label>:114                                     ; preds = %102
   %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
@@ -6004,59 +7458,59 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %20
+ThrowNullRef4:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %22
+ThrowNullRef6:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %26
+ThrowNullRef8:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %62
+ThrowNullRef10:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %48
+ThrowNullRef16:                                   ; preds = %48
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %74
+ThrowNullRef18:                                   ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %76
+ThrowNullRef20:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %80
+ThrowNullRef22:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %96
+ThrowNullRef24:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %98
+ThrowNullRef26:                                   ; preds = %98
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %102
+ThrowNullRef28:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6069,15 +7523,15 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
   %3 = load i16*, i16* addrspace(1)* %2, align 8
   %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
@@ -6087,8 +7541,8 @@ entry:
   %10 = bitcast i16* %3 to i8*
   %11 = getelementptr inbounds i8, i8* %10, i64 %9
   %12 = bitcast i8* %11 to i16*
-  %NullCheck4 = icmp ne i16* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %5
   store i16 0, i16* %12, align 8
@@ -6098,11 +7552,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6119,8 +7573,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -6131,8 +7585,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
@@ -6144,15 +7598,15 @@ entry:
 
 ; <label>:14                                      ; preds = %1
   %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
   %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
   %21 = load i64, i64 addrspace(1)* %19
@@ -6171,15 +7625,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %14
+ThrowNullRef4:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %16
+ThrowNullRef6:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6302,14 +7756,6 @@ entry:
   ret %System.String addrspace(1)* %57
 }
 
-INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
-Successfully read RuntimeHelpers.get_OffsetToStringData
-
-define i32 @RuntimeHelpers.get_OffsetToStringData() {
-entry:
-  ret i32 12
-}
-
 INFO:  jitting method String::Equals using LLILCJit
 Successfully read String.Equals
 
@@ -6381,8 +7827,8 @@ entry:
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
-  br i1 %NullCheck24, label %29, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
   %30 = load i64, i64 addrspace(1)* %28
@@ -6397,8 +7843,8 @@ entry:
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
-  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
   %43 = load i64, i64 addrspace(1)* %41
@@ -6418,8 +7864,8 @@ entry:
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
   %59 = load i64, i64 addrspace(1)* %57
@@ -6434,8 +7880,8 @@ entry:
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck22, label %71, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
   %72 = load i64, i64 addrspace(1)* %70
@@ -6455,8 +7901,8 @@ entry:
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
-  br i1 %NullCheck16, label %87, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = load i64, i64 addrspace(1)* %86
@@ -6471,8 +7917,8 @@ entry:
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck18, label %100, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
   %101 = load i64, i64 addrspace(1)* %99
@@ -6492,8 +7938,8 @@ entry:
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
-  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
   %117 = load i64, i64 addrspace(1)* %115
@@ -6508,8 +7954,8 @@ entry:
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
-  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
   %130 = load i64, i64 addrspace(1)* %128
@@ -6528,15 +7974,15 @@ entry:
 
 ; <label>:142                                     ; preds = %22
   %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
-  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %143, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %144
 
 ; <label>:144                                     ; preds = %142
   %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
   %146 = load i32, i32 addrspace(1)* %145
   %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
-  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %147, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %148
 
 ; <label>:148                                     ; preds = %144
   %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
@@ -6557,15 +8003,15 @@ entry:
 
 ; <label>:159                                     ; preds = %22
   %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
-  br i1 %NullCheck, label %161, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %ThrowNullRef, label %161
 
 ; <label>:161                                     ; preds = %159
   %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
   %163 = load i32, i32 addrspace(1)* %162
   %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
-  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %164, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %165
 
 ; <label>:165                                     ; preds = %161
   %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
@@ -6578,8 +8024,8 @@ entry:
 
 ; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
-  br i1 %NullCheck4, label %172, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %171, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %172
 
 ; <label>:172                                     ; preds = %170
   %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
@@ -6589,8 +8035,8 @@ entry:
 
 ; <label>:176                                     ; preds = %172
   %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
-  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %177, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %178
 
 ; <label>:178                                     ; preds = %176
   %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
@@ -6629,55 +8075,55 @@ ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %161
+ThrowNullRef2:                                    ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %170
+ThrowNullRef4:                                    ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %176
+ThrowNullRef6:                                    ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %142
+ThrowNullRef8:                                    ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %144
+ThrowNullRef10:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %113
+ThrowNullRef12:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %116
+ThrowNullRef14:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %84
+ThrowNullRef16:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %87
+ThrowNullRef18:                                   ; preds = %87
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %55
+ThrowNullRef20:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %58
+ThrowNullRef22:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %26
+ThrowNullRef24:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %29
+ThrowNullRef26:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,8 +8161,8 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck, label %14, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %ThrowNullRef, label %14
 
 ; <label>:14                                      ; preds = %8
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
@@ -6760,8 +8206,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
@@ -6770,14 +8216,14 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32, i32* %loc0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %10
   %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
   %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
@@ -6790,15 +8236,15 @@ entry:
 ; <label>:25                                      ; preds = %19
   %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
-  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
   %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
@@ -6807,8 +8253,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %37 = load i32, i32* %loc0
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %38, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %38
 
 ; <label>:38                                      ; preds = %32
   %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
@@ -6817,14 +8263,14 @@ entry:
 
 ; <label>:40                                      ; preds = %19
   %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %40
   %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
   %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
-  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
-  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
@@ -6832,8 +8278,8 @@ entry:
   %48 = zext i32 %47 to i64
   %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
-  br i1 %NullCheck16, label %51, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %51
 
 ; <label>:51                                      ; preds = %45
   %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
@@ -6847,15 +8293,15 @@ entry:
 ; <label>:57                                      ; preds = %51
   %58 = load i16*, i16** %arg1
   %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
-  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %60
 
 ; <label>:60                                      ; preds = %57
   %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
   %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
-  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %64
 
 ; <label>:64                                      ; preds = %60
   %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
@@ -6864,22 +8310,22 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
   %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
-  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %70
 
 ; <label>:70                                      ; preds = %64
   %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
   %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
-  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
-  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
   %75 = load i32, i32 addrspace(1)* %74
   %76 = zext i32 %75 to i64
   %77 = trunc i64 %76 to i32
-  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
-  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %78
 
 ; <label>:78                                      ; preds = %73
   %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
@@ -6901,8 +8347,8 @@ entry:
   %90 = bitcast i16* %86 to i8*
   %91 = getelementptr inbounds i8, i8* %90, i64 %89
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %93
 
 ; <label>:93                                      ; preds = %80
   %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
@@ -6912,8 +8358,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %99 = load i32, i32* %loc2
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %100
 
 ; <label>:100                                     ; preds = %93
   %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
@@ -6928,63 +8374,63 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %25
+ThrowNullRef6:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %32
+ThrowNullRef10:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %40
+ThrowNullRef12:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %45
+ThrowNullRef16:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %57
+ThrowNullRef18:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %60
+ThrowNullRef20:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %64
+ThrowNullRef22:                                   ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %70
+ThrowNullRef24:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %73
+ThrowNullRef26:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %80
+ThrowNullRef28:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %93
+ThrowNullRef30:                                   ; preds = %93
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7004,8 +8450,8 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
@@ -7033,43 +8479,43 @@ entry:
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %14
   %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
   %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   %28 = load i32, i32 addrspace(1)* %27, align 8
   %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
-  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %30
 
 ; <label>:30                                      ; preds = %26
   %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
   %32 = load i32, i32 addrspace(1)* %31, align 8
   %33 = add i32 %28, %32
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %34
 
 ; <label>:34                                      ; preds = %30
   %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   store i32 %33, i32 addrspace(1)* %35
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
   store i32 0, i32 addrspace(1)* %38
   %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %40
 
 ; <label>:40                                      ; preds = %37
   %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
@@ -7082,8 +8528,8 @@ entry:
 
 ; <label>:47                                      ; preds = %40
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
@@ -7098,8 +8544,8 @@ entry:
   %54 = load i32, i32* %loc0
   %55 = sext i32 %54 to i64
   %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
-  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %57
 
 ; <label>:57                                      ; preds = %52
   %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
@@ -7110,68 +8556,35 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %14
+ThrowNullRef2:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %23
+ThrowNullRef4:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %26
+ThrowNullRef6:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %30
+ThrowNullRef8:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %34
+ThrowNullRef10:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %47
+ThrowNullRef14:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %52
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-}
-
-INFO:  jitting method StringBuilder::get_Length using LLILCJit
-Successfully read StringBuilder.get_Length
-
-define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.StringBuilder addrspace(1)*
-  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
-  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
-
-; <label>:1                                       ; preds = %entry
-  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %3 = load i32, i32 addrspace(1)* %2, align 8
-  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
-
-; <label>:5                                       ; preds = %1
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = add i32 %3, %7
-  ret i32 %8
-
-ThrowNullRef:                                     ; preds = %entry
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef16:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7213,70 +8626,70 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
   %6 = load i32, i32 addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
   store i32 %6, i32 addrspace(1)* %8
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
   %13 = load i32, i32 addrspace(1)* %12, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
   store i32 %13, i32 addrspace(1)* %15
   %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
-  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %18
 
 ; <label>:18                                      ; preds = %14
   %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
   %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
   %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
   %34 = load i32, i32 addrspace(1)* %33, align 8
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
-  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
@@ -7287,39 +8700,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %28
+ThrowNullRef16:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %32
+ThrowNullRef18:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7455,13 +8868,13 @@ entry:
 ; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
@@ -7477,16 +8890,16 @@ entry:
 
 ; <label>:18                                      ; preds = %15
   %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
   store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
   %22 = load i32, i32* %loc0
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %24
 
 ; <label>:24                                      ; preds = %20
   %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
@@ -7498,13 +8911,13 @@ entry:
 ; <label>:28                                      ; preds = %15, %24
   %29 = load i32, i32* %arg1
   %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %31
   %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
@@ -7517,20 +8930,20 @@ entry:
   %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
-  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
   %46 = load i32, i32 addrspace(1)* %45, align 8
   %47 = sub i32 %40, %46
-  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
-  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i32 addrspace(1)* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %48
 
 ; <label>:48                                      ; preds = %44
   store i32 %47, i32 addrspace(1)* %39, align 8
@@ -7538,21 +8951,21 @@ entry:
 
 ; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
-  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %51
 
 ; <label>:51                                      ; preds = %49
   %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %53
 
 ; <label>:53                                      ; preds = %51
   %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
   %55 = load i32, i32 addrspace(1)* %54, align 8
   %56 = load i32, i32* %arg2
   %57 = sub i32 %55, %56
-  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %58
 
 ; <label>:58                                      ; preds = %53
   %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
@@ -7562,13 +8975,13 @@ entry:
 ; <label>:60                                      ; preds = %33, %58
   %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
   %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
-  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %63
 
 ; <label>:63                                      ; preds = %60
   %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
-  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
-  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
@@ -7578,15 +8991,15 @@ entry:
 
 ; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
-  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i32 addrspace(1)* %69, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %70
 
 ; <label>:70                                      ; preds = %68
   %71 = load i32, i32 addrspace(1)* %69, align 8
   store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
-  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
@@ -7596,8 +9009,8 @@ entry:
   store i32 %77, i32* %loc4
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
-  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %80
 
 ; <label>:80                                      ; preds = %73
   %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
@@ -7607,71 +9020,71 @@ entry:
 ; <label>:83                                      ; preds = %80
   store i32 0, i32* %loc3
   %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
-  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
-  br i1 %NullCheck26, label %88, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i32 addrspace(1)* %87, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %88
 
 ; <label>:88                                      ; preds = %85
   %89 = load i32, i32 addrspace(1)* %87, align 8
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
-  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %90
 
 ; <label>:90                                      ; preds = %88
   %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
   store i32 %89, i32 addrspace(1)* %91
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
-  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
-  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %96
 
 ; <label>:96                                      ; preds = %94
   %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
-  br i1 %NullCheck34, label %100, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %100
 
 ; <label>:100                                     ; preds = %96
   %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
-  br i1 %NullCheck36, label %102, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %102
 
 ; <label>:102                                     ; preds = %100
   %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
   %104 = load i32, i32 addrspace(1)* %103, align 8
   %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
-  br i1 %NullCheck38, label %106, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %106
 
 ; <label>:106                                     ; preds = %102
   %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
-  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
-  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %108
 
 ; <label>:108                                     ; preds = %106
   %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
   %110 = load i32, i32 addrspace(1)* %109, align 8
   %111 = add i32 %104, %110
-  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %112
 
 ; <label>:112                                     ; preds = %108
   %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
   store i32 %111, i32 addrspace(1)* %113
   %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
-  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i32 addrspace(1)* %114, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %115
 
 ; <label>:115                                     ; preds = %112
   %116 = load i32, i32 addrspace(1)* %114, align 8
@@ -7681,19 +9094,19 @@ entry:
 ; <label>:118                                     ; preds = %115
   %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
-  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %121
 
 ; <label>:121                                     ; preds = %118
   %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
-  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
-  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %123
 
 ; <label>:123                                     ; preds = %121
   %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
   %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
-  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
-  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %126
 
 ; <label>:126                                     ; preds = %123
   %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
@@ -7705,8 +9118,8 @@ entry:
 
 ; <label>:130                                     ; preds = %80, %115, %126
   %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %132
 
 ; <label>:132                                     ; preds = %130
   %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7715,8 +9128,8 @@ entry:
   %136 = load i32, i32* %loc3
   %137 = sub i32 %135, %136
   %138 = sub i32 %134, %137
-  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %139
 
 ; <label>:139                                     ; preds = %132
   %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7728,16 +9141,16 @@ entry:
 
 ; <label>:144                                     ; preds = %139
   %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
-  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %146
 
 ; <label>:146                                     ; preds = %144
   %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
   %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
   %149 = load i32, i32* %loc2
   %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
-  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %151
 
 ; <label>:151                                     ; preds = %146
   %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
@@ -7754,145 +9167,249 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %18
+ThrowNullRef4:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %31
+ThrowNullRef10:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %44
+ThrowNullRef16:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %68
+ThrowNullRef18:                                   ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %70
+ThrowNullRef20:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %73
+ThrowNullRef22:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %83
+ThrowNullRef24:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %85
+ThrowNullRef26:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %88
+ThrowNullRef28:                                   ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %90
+ThrowNullRef30:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %94
+ThrowNullRef32:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %96
+ThrowNullRef34:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %100
+ThrowNullRef36:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %102
+ThrowNullRef38:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %106
+ThrowNullRef40:                                   ; preds = %106
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %108
+ThrowNullRef42:                                   ; preds = %108
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %112
+ThrowNullRef44:                                   ; preds = %112
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %118
+ThrowNullRef46:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %121
+ThrowNullRef48:                                   ; preds = %121
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %123
+ThrowNullRef50:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %130
+ThrowNullRef52:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %132
+ThrowNullRef54:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %144
+ThrowNullRef56:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %146
+ThrowNullRef58:                                   ; preds = %146
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %60
+ThrowNullRef60:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %63
+ThrowNullRef62:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %49
+ThrowNullRef64:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %51
+ThrowNullRef66:                                   ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %53
+ThrowNullRef68:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(%"System.Char[]" addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %arg0 = alloca %"System.Char[]" addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store %"System.Char[]" addrspace(1)* %param0, %"System.Char[]" addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load i32, i32* %arg4
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %43, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %38, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg1
+  %13 = load i32, i32* %arg4
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %38, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %24 = load i32, i32* %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %35 = load i32, i32* %arg3
+  %36 = load i32, i32* %arg4
+  %37 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %37, %"System.Char[]" addrspace(1)* %34, i32 %35, i32 %36)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:38                                      ; preds = %5, %16
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Successfully read Buffer._Memmove
 
@@ -7914,7 +9431,7 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[loadElem]
+Failed to read AppDomain.SetDataHelper[storeElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -7923,8 +9440,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
@@ -7934,8 +9451,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
@@ -7947,15 +9464,15 @@ entry:
   %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
   %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
@@ -7966,15 +9483,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7992,7 +9509,79 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
-Failed to read Dictionary`2.TryGetValue[loadElemA]
+Successfully read Dictionary`2.TryGetValue
+
+define i8 @"Dictionary`2.TryGetValue"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)* addrspace(1)* %param2) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  %arg2 = alloca %System.__Canon addrspace(1)* addrspace(1)*
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  store %System.__Canon addrspace(1)* addrspace(1)* %param2, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  store i32 %2, i32* %loc0
+  %3 = load i32, i32* %loc0
+  %4 = icmp slt i32 %3, 0
+  br i1 %4, label %22, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 2
+  %10 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %9, align 8
+  %11 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = zext i32 %11 to i64
+  %BoundsCheck = icmp uge i64 %16, %15
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 3, i32 %11
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %20, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %6, %System.__Canon addrspace(1)* %21)
+  ret i8 1
+
+; <label>:22                                      ; preds = %entry
+  %23 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %23, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -8058,8 +9647,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
@@ -8091,8 +9680,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
@@ -8171,15 +9760,15 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck, label %19, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %ThrowNullRef, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
   %21 = load i32, i32 addrspace(1)* %20
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
@@ -8202,7 +9791,7 @@ ThrowNullRef:                                     ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %19
+ThrowNullRef2:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8248,8 +9837,8 @@ entry:
   %0 = alloca %System.AppDomainHandle
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %1 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %1, i32 0, i32 15
@@ -8269,8 +9858,8 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
@@ -8286,7 +9875,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -8299,8 +9888,8 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -8327,8 +9916,8 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
@@ -8352,8 +9941,8 @@ entry:
   %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
   store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
@@ -8363,8 +9952,8 @@ entry:
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
@@ -8374,8 +9963,8 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %9
   %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
@@ -8384,8 +9973,8 @@ entry:
 
 ; <label>:18                                      ; preds = %3, %16
   %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
@@ -8397,15 +9986,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %18
+ThrowNullRef6:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8418,8 +10007,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
@@ -8453,15 +10042,15 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
@@ -8473,7 +10062,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8481,7 +10070,7 @@ ThrowNullRef1:                                    ; preds = %1
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
 Failed to read Dictionary`2.System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
@@ -8506,8 +10095,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
@@ -8524,8 +10113,8 @@ entry:
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -8544,7 +10133,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8577,8 +10166,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = load i64, i64* %arg2
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = trunc i32 %3 to i8
@@ -8634,46 +10223,46 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
   %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
-  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
-  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
-  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
@@ -8684,27 +10273,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %20
+ThrowNullRef12:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8717,8 +10306,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -8756,22 +10345,22 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
   %9 = load i64, i64 addrspace(1)* %8, align 8
   %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
   %13 = load i64, i64 addrspace(1)* %12, align 8
   %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %11
   %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
@@ -8788,11 +10377,11 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8882,8 +10471,8 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
@@ -8900,8 +10489,8 @@ entry:
 ; <label>:8                                       ; preds = %1
   %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
   %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
@@ -8911,15 +10500,15 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
   %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
   %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
-  br i1 %NullCheck6, label %21, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
@@ -8946,15 +10535,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8992,15 +10581,15 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
   store i8 %3, i8 addrspace(1)* %5
   %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
@@ -9011,7 +10600,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9027,8 +10616,8 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -9041,8 +10630,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
@@ -9058,7 +10647,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9080,8 +10669,8 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
@@ -9096,8 +10685,8 @@ entry:
 ; <label>:12                                      ; preds = %6
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
@@ -9112,8 +10701,8 @@ entry:
 ; <label>:21                                      ; preds = %15
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
@@ -9128,8 +10717,8 @@ entry:
 ; <label>:30                                      ; preds = %24
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %31, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
@@ -9144,8 +10733,8 @@ entry:
 ; <label>:39                                      ; preds = %33
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
-  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %40, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %42
 
 ; <label>:42                                      ; preds = %39
   %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
@@ -9164,19 +10753,19 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %21
+ThrowNullRef4:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %30
+ThrowNullRef6:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %39
+ThrowNullRef8:                                    ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9243,8 +10832,8 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
@@ -9264,57 +10853,57 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
   store i8 0, i8 addrspace(1)* %2
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
   store i8 0, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
   store i8 0, i8 addrspace(1)* %17
   %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
   store i8 0, i8 addrspace(1)* %20
   %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
-  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
@@ -9325,31 +10914,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %19
+ThrowNullRef14:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9367,8 +10956,8 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
@@ -9380,8 +10969,8 @@ entry:
 
 ; <label>:9                                       ; preds = %4
   %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %9
   %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
@@ -9395,7 +10984,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef2:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9420,8 +11009,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
@@ -9512,8 +11101,8 @@ entry:
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
@@ -9524,8 +11113,8 @@ entry:
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = load i64, i64 addrspace(1)* %12
@@ -9537,8 +11126,8 @@ entry:
   %20 = load i64, i64* %19
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
-  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %13
   %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
@@ -9555,8 +11144,8 @@ entry:
 ; <label>:30                                      ; preds = %25
   %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %32 = load i32, i32* %arg2
-  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
-  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
@@ -9570,15 +11159,15 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %30
+ThrowNullRef2:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9622,87 +11211,87 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
   %10 = load i8, i8 addrspace(1)* %9, align 8
   %11 = zext i8 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %8
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
   store i8 %12, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
   %19 = load i8, i8 addrspace(1)* %18, align 8
   %20 = zext i8 %19 to i32
   %21 = trunc i32 %20 to i8
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
   store i8 %21, i8 addrspace(1)* %23
   %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
   %28 = load i8, i8 addrspace(1)* %27, align 8
   %29 = zext i8 %28 to i32
   %30 = trunc i32 %29 to i8
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
-  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %31
 
 ; <label>:31                                      ; preds = %26
   %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
   store i8 %30, i8 addrspace(1)* %32
   %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
-  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
-  br i1 %NullCheck14, label %40, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %40
 
 ; <label>:40                                      ; preds = %35
   %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
   store i8 %39, i8 addrspace(1)* %41
   %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
-  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %44
 
 ; <label>:44                                      ; preds = %40
   %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
   %46 = load i8, i8 addrspace(1)* %45, align 8
   %47 = zext i8 %46 to i32
   %48 = trunc i32 %47 to i8
-  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
   store i8 %48, i8 addrspace(1)* %50
   %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
-  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
@@ -9713,29 +11302,29 @@ entry:
 ; <label>:56                                      ; preds = %52
   %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
-  br i1 %NullCheck22, label %59, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
   %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
   %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
-  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
-  br i1 %NullCheck24, label %63, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
   %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
-  br i1 %NullCheck26, label %66, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
   %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
-  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
-  br i1 %NullCheck28, label %69, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %69
 
 ; <label>:69                                      ; preds = %66
   %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
@@ -9744,15 +11333,15 @@ entry:
 
 ; <label>:71                                      ; preds = %105
   %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
-  br i1 %NullCheck34, label %73, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %73
 
 ; <label>:73                                      ; preds = %71
   %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
   %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
   %76 = load i32, i32* %loc0
-  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
-  br i1 %NullCheck36, label %77, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
@@ -9766,8 +11355,8 @@ entry:
 
 ; <label>:83                                      ; preds = %77
   %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
-  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
@@ -9775,14 +11364,14 @@ entry:
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
   %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
-  br i1 %NullCheck40, label %91, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
 ; <label>:91                                      ; preds = %85
   %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
   %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
-  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck42, label %94, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %94
 
 ; <label>:94                                      ; preds = %91
   %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
@@ -9798,14 +11387,14 @@ entry:
 ; <label>:99                                      ; preds = %69, %96
   %100 = load i32, i32* %loc0
   %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
-  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %102
 
 ; <label>:102                                     ; preds = %99
   %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
   %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
-  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
-  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
@@ -9819,87 +11408,87 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %26
+ThrowNullRef10:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %31
+ThrowNullRef12:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %35
+ThrowNullRef14:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %40
+ThrowNullRef16:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %56
+ThrowNullRef22:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %59
+ThrowNullRef24:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %63
+ThrowNullRef26:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %66
+ThrowNullRef28:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %102
+ThrowNullRef32:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %71
+ThrowNullRef34:                                   ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %73
+ThrowNullRef36:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %83
+ThrowNullRef38:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %85
+ThrowNullRef40:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %91
+ThrowNullRef42:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9943,15 +11532,15 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
   %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
@@ -9961,28 +11550,28 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
   %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %12
   %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
   %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
   %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
-  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
@@ -9993,23 +11582,23 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %12
+ThrowNullRef6:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10031,15 +11620,15 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
   %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = load i64, i64 addrspace(1)* %7
@@ -10077,13 +11666,13 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[loadElem]
+Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -10111,8 +11700,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1

--- a/test/BaseLine/JIT/CodeGenBringUpTests/divref.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/divref.error.txt
@@ -25,8 +25,8 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
@@ -40,8 +40,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
   %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
@@ -75,7 +75,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -90,8 +90,8 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %NullCheck = icmp ne i8 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = load i8, i8 addrspace(1)* %0, align 8
@@ -125,8 +125,8 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
@@ -159,8 +159,8 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -184,8 +184,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
   store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
@@ -195,8 +195,8 @@ entry:
 ; <label>:4                                       ; preds = %1
   %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
   %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
@@ -206,8 +206,8 @@ entry:
   %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
@@ -221,14 +221,14 @@ entry:
 
 ; <label>:17                                      ; preds = %14
   %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
   %21 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
@@ -238,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -249,8 +249,8 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
@@ -261,27 +261,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %30
+ThrowNullRef10:                                   ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -301,7 +301,89 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
-Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
+Successfully read AppDomainSetup.GetUnsecureApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.GetUnsecureApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %NullCheck = icmp eq %"System.String[]" addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %BoundsCheck = icmp uge i64 0, %5
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %6
+
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 3, i32 0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
+  ret %System.String addrspace(1)* %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_Value using LLILCJit
+Successfully read AppDomainSetup.get_Value
+
+define %"System.String[]" addrspace(1)* @AppDomainSetup.get_Value(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.String[]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 18)
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.String[]" addrspace(1)* addrspace(1)*, %"System.String[]" addrspace(1)*)*)(%"System.String[]" addrspace(1)* addrspace(1)* %9, %"System.String[]" addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %11, i32 0, i32 1
+  %14 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %13, align 8
+  ret %"System.String[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -319,8 +401,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -368,16 +450,16 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
   %5 = load i32, i32 addrspace(1)* %4
   %6 = sub i32 %5, 1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -389,7 +471,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -421,8 +503,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
@@ -456,8 +538,8 @@ entry:
 ; <label>:27                                      ; preds = %19
   %28 = load i32, i32* %arg1
   %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
-  br i1 %NullCheck2, label %30, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %29, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %30
 
 ; <label>:30                                      ; preds = %27
   %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
@@ -493,8 +575,8 @@ entry:
 ; <label>:49                                      ; preds = %46
   %50 = load i32, i32* %arg2
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck4, label %52, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
@@ -517,11 +599,11 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %27
+ThrowNullRef2:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %49
+ThrowNullRef4:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -544,16 +626,16 @@ entry:
   %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %0)
   store %System.String addrspace(1)* %1, %System.String addrspace(1)** %loc0
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 2
   %5 = bitcast [0 x i16] addrspace(1)* %4 to i16 addrspace(1)*
   store i16 addrspace(1)* %5, i16 addrspace(1)** %loc1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %3
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2
@@ -580,7 +662,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -691,15 +773,15 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %NullCheck132 = icmp ne i8* %21, null
-  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+  %NullCheck131 = icmp eq i8* %21, null
+  br i1 %NullCheck131, label %ThrowNullRef132, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = load i8, i8* %21, align 8
   %24 = zext i8 %23 to i32
   %25 = trunc i32 %24 to i8
-  %NullCheck134 = icmp ne i8* %20, null
-  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+  %NullCheck133 = icmp eq i8* %20, null
+  br i1 %NullCheck133, label %ThrowNullRef134, label %26
 
 ; <label>:26                                      ; preds = %22
   store i8 %25, i8* %20, align 8
@@ -709,16 +791,16 @@ entry:
   %28 = load i8*, i8** %arg0
   %29 = load i8*, i8** %arg1
   %30 = bitcast i8* %29 to i16*
-  %NullCheck128 = icmp ne i16* %30, null
-  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+  %NullCheck127 = icmp eq i16* %30, null
+  br i1 %NullCheck127, label %ThrowNullRef128, label %31
 
 ; <label>:31                                      ; preds = %27
   %32 = load i16, i16* %30, align 8
   %33 = sext i16 %32 to i32
   %34 = bitcast i8* %28 to i16*
   %35 = trunc i32 %33 to i16
-  %NullCheck130 = icmp ne i16* %34, null
-  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+  %NullCheck129 = icmp eq i16* %34, null
+  br i1 %NullCheck129, label %ThrowNullRef130, label %36
 
 ; <label>:36                                      ; preds = %31
   store i16 %35, i16* %34, align 8
@@ -728,16 +810,16 @@ entry:
   %38 = load i8*, i8** %arg0
   %39 = load i8*, i8** %arg1
   %40 = bitcast i8* %39 to i16*
-  %NullCheck120 = icmp ne i16* %40, null
-  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+  %NullCheck119 = icmp eq i16* %40, null
+  br i1 %NullCheck119, label %ThrowNullRef120, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i16, i16* %40, align 8
   %43 = sext i16 %42 to i32
   %44 = bitcast i8* %38 to i16*
   %45 = trunc i32 %43 to i16
-  %NullCheck122 = icmp ne i16* %44, null
-  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+  %NullCheck121 = icmp eq i16* %44, null
+  br i1 %NullCheck121, label %ThrowNullRef122, label %46
 
 ; <label>:46                                      ; preds = %41
   store i16 %45, i16* %44, align 8
@@ -745,15 +827,15 @@ entry:
   %48 = getelementptr inbounds i8, i8* %47, i64 2
   %49 = load i8*, i8** %arg1
   %50 = getelementptr inbounds i8, i8* %49, i64 2
-  %NullCheck124 = icmp ne i8* %50, null
-  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+  %NullCheck123 = icmp eq i8* %50, null
+  br i1 %NullCheck123, label %ThrowNullRef124, label %51
 
 ; <label>:51                                      ; preds = %46
   %52 = load i8, i8* %50, align 8
   %53 = zext i8 %52 to i32
   %54 = trunc i32 %53 to i8
-  %NullCheck126 = icmp ne i8* %48, null
-  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+  %NullCheck125 = icmp eq i8* %48, null
+  br i1 %NullCheck125, label %ThrowNullRef126, label %55
 
 ; <label>:55                                      ; preds = %51
   store i8 %54, i8* %48, align 8
@@ -763,14 +845,14 @@ entry:
   %57 = load i8*, i8** %arg0
   %58 = load i8*, i8** %arg1
   %59 = bitcast i8* %58 to i32*
-  %NullCheck116 = icmp ne i32* %59, null
-  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+  %NullCheck115 = icmp eq i32* %59, null
+  br i1 %NullCheck115, label %ThrowNullRef116, label %60
 
 ; <label>:60                                      ; preds = %56
   %61 = load i32, i32* %59, align 8
   %62 = bitcast i8* %57 to i32*
-  %NullCheck118 = icmp ne i32* %62, null
-  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+  %NullCheck117 = icmp eq i32* %62, null
+  br i1 %NullCheck117, label %ThrowNullRef118, label %63
 
 ; <label>:63                                      ; preds = %60
   store i32 %61, i32* %62, align 8
@@ -780,14 +862,14 @@ entry:
   %65 = load i8*, i8** %arg0
   %66 = load i8*, i8** %arg1
   %67 = bitcast i8* %66 to i32*
-  %NullCheck108 = icmp ne i32* %67, null
-  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+  %NullCheck107 = icmp eq i32* %67, null
+  br i1 %NullCheck107, label %ThrowNullRef108, label %68
 
 ; <label>:68                                      ; preds = %64
   %69 = load i32, i32* %67, align 8
   %70 = bitcast i8* %65 to i32*
-  %NullCheck110 = icmp ne i32* %70, null
-  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+  %NullCheck109 = icmp eq i32* %70, null
+  br i1 %NullCheck109, label %ThrowNullRef110, label %71
 
 ; <label>:71                                      ; preds = %68
   store i32 %69, i32* %70, align 8
@@ -795,15 +877,15 @@ entry:
   %73 = getelementptr inbounds i8, i8* %72, i64 4
   %74 = load i8*, i8** %arg1
   %75 = getelementptr inbounds i8, i8* %74, i64 4
-  %NullCheck112 = icmp ne i8* %75, null
-  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+  %NullCheck111 = icmp eq i8* %75, null
+  br i1 %NullCheck111, label %ThrowNullRef112, label %76
 
 ; <label>:76                                      ; preds = %71
   %77 = load i8, i8* %75, align 8
   %78 = zext i8 %77 to i32
   %79 = trunc i32 %78 to i8
-  %NullCheck114 = icmp ne i8* %73, null
-  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+  %NullCheck113 = icmp eq i8* %73, null
+  br i1 %NullCheck113, label %ThrowNullRef114, label %80
 
 ; <label>:80                                      ; preds = %76
   store i8 %79, i8* %73, align 8
@@ -813,14 +895,14 @@ entry:
   %82 = load i8*, i8** %arg0
   %83 = load i8*, i8** %arg1
   %84 = bitcast i8* %83 to i32*
-  %NullCheck100 = icmp ne i32* %84, null
-  br i1 %NullCheck100, label %85, label %ThrowNullRef99
+  %NullCheck99 = icmp eq i32* %84, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %85
 
 ; <label>:85                                      ; preds = %81
   %86 = load i32, i32* %84, align 8
   %87 = bitcast i8* %82 to i32*
-  %NullCheck102 = icmp ne i32* %87, null
-  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+  %NullCheck101 = icmp eq i32* %87, null
+  br i1 %NullCheck101, label %ThrowNullRef102, label %88
 
 ; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
@@ -829,16 +911,16 @@ entry:
   %91 = load i8*, i8** %arg1
   %92 = getelementptr inbounds i8, i8* %91, i64 4
   %93 = bitcast i8* %92 to i16*
-  %NullCheck104 = icmp ne i16* %93, null
-  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+  %NullCheck103 = icmp eq i16* %93, null
+  br i1 %NullCheck103, label %ThrowNullRef104, label %94
 
 ; <label>:94                                      ; preds = %88
   %95 = load i16, i16* %93, align 8
   %96 = sext i16 %95 to i32
   %97 = bitcast i8* %90 to i16*
   %98 = trunc i32 %96 to i16
-  %NullCheck106 = icmp ne i16* %97, null
-  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+  %NullCheck105 = icmp eq i16* %97, null
+  br i1 %NullCheck105, label %ThrowNullRef106, label %99
 
 ; <label>:99                                      ; preds = %94
   store i16 %98, i16* %97, align 8
@@ -848,14 +930,14 @@ entry:
   %101 = load i8*, i8** %arg0
   %102 = load i8*, i8** %arg1
   %103 = bitcast i8* %102 to i32*
-  %NullCheck88 = icmp ne i32* %103, null
-  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+  %NullCheck87 = icmp eq i32* %103, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %104
 
 ; <label>:104                                     ; preds = %100
   %105 = load i32, i32* %103, align 8
   %106 = bitcast i8* %101 to i32*
-  %NullCheck90 = icmp ne i32* %106, null
-  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+  %NullCheck89 = icmp eq i32* %106, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %107
 
 ; <label>:107                                     ; preds = %104
   store i32 %105, i32* %106, align 8
@@ -864,16 +946,16 @@ entry:
   %110 = load i8*, i8** %arg1
   %111 = getelementptr inbounds i8, i8* %110, i64 4
   %112 = bitcast i8* %111 to i16*
-  %NullCheck92 = icmp ne i16* %112, null
-  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+  %NullCheck91 = icmp eq i16* %112, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %113
 
 ; <label>:113                                     ; preds = %107
   %114 = load i16, i16* %112, align 8
   %115 = sext i16 %114 to i32
   %116 = bitcast i8* %109 to i16*
   %117 = trunc i32 %115 to i16
-  %NullCheck94 = icmp ne i16* %116, null
-  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+  %NullCheck93 = icmp eq i16* %116, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %118
 
 ; <label>:118                                     ; preds = %113
   store i16 %117, i16* %116, align 8
@@ -881,15 +963,15 @@ entry:
   %120 = getelementptr inbounds i8, i8* %119, i64 6
   %121 = load i8*, i8** %arg1
   %122 = getelementptr inbounds i8, i8* %121, i64 6
-  %NullCheck96 = icmp ne i8* %122, null
-  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+  %NullCheck95 = icmp eq i8* %122, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %123
 
 ; <label>:123                                     ; preds = %118
   %124 = load i8, i8* %122, align 8
   %125 = zext i8 %124 to i32
   %126 = trunc i32 %125 to i8
-  %NullCheck98 = icmp ne i8* %120, null
-  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+  %NullCheck97 = icmp eq i8* %120, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %127
 
 ; <label>:127                                     ; preds = %123
   store i8 %126, i8* %120, align 8
@@ -899,14 +981,14 @@ entry:
   %129 = load i8*, i8** %arg0
   %130 = load i8*, i8** %arg1
   %131 = bitcast i8* %130 to i64*
-  %NullCheck84 = icmp ne i64* %131, null
-  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+  %NullCheck83 = icmp eq i64* %131, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %132
 
 ; <label>:132                                     ; preds = %128
   %133 = load i64, i64* %131, align 8
   %134 = bitcast i8* %129 to i64*
-  %NullCheck86 = icmp ne i64* %134, null
-  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+  %NullCheck85 = icmp eq i64* %134, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %135
 
 ; <label>:135                                     ; preds = %132
   store i64 %133, i64* %134, align 8
@@ -916,14 +998,14 @@ entry:
   %137 = load i8*, i8** %arg0
   %138 = load i8*, i8** %arg1
   %139 = bitcast i8* %138 to i64*
-  %NullCheck76 = icmp ne i64* %139, null
-  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+  %NullCheck75 = icmp eq i64* %139, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %140
 
 ; <label>:140                                     ; preds = %136
   %141 = load i64, i64* %139, align 8
   %142 = bitcast i8* %137 to i64*
-  %NullCheck78 = icmp ne i64* %142, null
-  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+  %NullCheck77 = icmp eq i64* %142, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %143
 
 ; <label>:143                                     ; preds = %140
   store i64 %141, i64* %142, align 8
@@ -931,15 +1013,15 @@ entry:
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %NullCheck80 = icmp ne i8* %147, null
-  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+  %NullCheck79 = icmp eq i8* %147, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %148
 
 ; <label>:148                                     ; preds = %143
   %149 = load i8, i8* %147, align 8
   %150 = zext i8 %149 to i32
   %151 = trunc i32 %150 to i8
-  %NullCheck82 = icmp ne i8* %145, null
-  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+  %NullCheck81 = icmp eq i8* %145, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %152
 
 ; <label>:152                                     ; preds = %148
   store i8 %151, i8* %145, align 8
@@ -949,14 +1031,14 @@ entry:
   %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
   %156 = bitcast i8* %155 to i64*
-  %NullCheck68 = icmp ne i64* %156, null
-  br i1 %NullCheck68, label %157, label %ThrowNullRef67
+  %NullCheck67 = icmp eq i64* %156, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %157
 
 ; <label>:157                                     ; preds = %153
   %158 = load i64, i64* %156, align 8
   %159 = bitcast i8* %154 to i64*
-  %NullCheck70 = icmp ne i64* %159, null
-  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+  %NullCheck69 = icmp eq i64* %159, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %160
 
 ; <label>:160                                     ; preds = %157
   store i64 %158, i64* %159, align 8
@@ -965,16 +1047,16 @@ entry:
   %163 = load i8*, i8** %arg1
   %164 = getelementptr inbounds i8, i8* %163, i64 8
   %165 = bitcast i8* %164 to i16*
-  %NullCheck72 = icmp ne i16* %165, null
-  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+  %NullCheck71 = icmp eq i16* %165, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %166
 
 ; <label>:166                                     ; preds = %160
   %167 = load i16, i16* %165, align 8
   %168 = sext i16 %167 to i32
   %169 = bitcast i8* %162 to i16*
   %170 = trunc i32 %168 to i16
-  %NullCheck74 = icmp ne i16* %169, null
-  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+  %NullCheck73 = icmp eq i16* %169, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %171
 
 ; <label>:171                                     ; preds = %166
   store i16 %170, i16* %169, align 8
@@ -984,14 +1066,14 @@ entry:
   %173 = load i8*, i8** %arg0
   %174 = load i8*, i8** %arg1
   %175 = bitcast i8* %174 to i64*
-  %NullCheck56 = icmp ne i64* %175, null
-  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+  %NullCheck55 = icmp eq i64* %175, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %176
 
 ; <label>:176                                     ; preds = %172
   %177 = load i64, i64* %175, align 8
   %178 = bitcast i8* %173 to i64*
-  %NullCheck58 = icmp ne i64* %178, null
-  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+  %NullCheck57 = icmp eq i64* %178, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %179
 
 ; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
@@ -1000,16 +1082,16 @@ entry:
   %182 = load i8*, i8** %arg1
   %183 = getelementptr inbounds i8, i8* %182, i64 8
   %184 = bitcast i8* %183 to i16*
-  %NullCheck60 = icmp ne i16* %184, null
-  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+  %NullCheck59 = icmp eq i16* %184, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %185
 
 ; <label>:185                                     ; preds = %179
   %186 = load i16, i16* %184, align 8
   %187 = sext i16 %186 to i32
   %188 = bitcast i8* %181 to i16*
   %189 = trunc i32 %187 to i16
-  %NullCheck62 = icmp ne i16* %188, null
-  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+  %NullCheck61 = icmp eq i16* %188, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %190
 
 ; <label>:190                                     ; preds = %185
   store i16 %189, i16* %188, align 8
@@ -1017,15 +1099,15 @@ entry:
   %192 = getelementptr inbounds i8, i8* %191, i64 10
   %193 = load i8*, i8** %arg1
   %194 = getelementptr inbounds i8, i8* %193, i64 10
-  %NullCheck64 = icmp ne i8* %194, null
-  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+  %NullCheck63 = icmp eq i8* %194, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %195
 
 ; <label>:195                                     ; preds = %190
   %196 = load i8, i8* %194, align 8
   %197 = zext i8 %196 to i32
   %198 = trunc i32 %197 to i8
-  %NullCheck66 = icmp ne i8* %192, null
-  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+  %NullCheck65 = icmp eq i8* %192, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %199
 
 ; <label>:199                                     ; preds = %195
   store i8 %198, i8* %192, align 8
@@ -1035,14 +1117,14 @@ entry:
   %201 = load i8*, i8** %arg0
   %202 = load i8*, i8** %arg1
   %203 = bitcast i8* %202 to i64*
-  %NullCheck48 = icmp ne i64* %203, null
-  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+  %NullCheck47 = icmp eq i64* %203, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %204
 
 ; <label>:204                                     ; preds = %200
   %205 = load i64, i64* %203, align 8
   %206 = bitcast i8* %201 to i64*
-  %NullCheck50 = icmp ne i64* %206, null
-  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+  %NullCheck49 = icmp eq i64* %206, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %207
 
 ; <label>:207                                     ; preds = %204
   store i64 %205, i64* %206, align 8
@@ -1051,14 +1133,14 @@ entry:
   %210 = load i8*, i8** %arg1
   %211 = getelementptr inbounds i8, i8* %210, i64 8
   %212 = bitcast i8* %211 to i32*
-  %NullCheck52 = icmp ne i32* %212, null
-  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+  %NullCheck51 = icmp eq i32* %212, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %213
 
 ; <label>:213                                     ; preds = %207
   %214 = load i32, i32* %212, align 8
   %215 = bitcast i8* %209 to i32*
-  %NullCheck54 = icmp ne i32* %215, null
-  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+  %NullCheck53 = icmp eq i32* %215, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %216
 
 ; <label>:216                                     ; preds = %213
   store i32 %214, i32* %215, align 8
@@ -1068,14 +1150,14 @@ entry:
   %218 = load i8*, i8** %arg0
   %219 = load i8*, i8** %arg1
   %220 = bitcast i8* %219 to i64*
-  %NullCheck36 = icmp ne i64* %220, null
-  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64* %220, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %221
 
 ; <label>:221                                     ; preds = %217
   %222 = load i64, i64* %220, align 8
   %223 = bitcast i8* %218 to i64*
-  %NullCheck38 = icmp ne i64* %223, null
-  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+  %NullCheck37 = icmp eq i64* %223, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %224
 
 ; <label>:224                                     ; preds = %221
   store i64 %222, i64* %223, align 8
@@ -1084,14 +1166,14 @@ entry:
   %227 = load i8*, i8** %arg1
   %228 = getelementptr inbounds i8, i8* %227, i64 8
   %229 = bitcast i8* %228 to i32*
-  %NullCheck40 = icmp ne i32* %229, null
-  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i32* %229, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %230
 
 ; <label>:230                                     ; preds = %224
   %231 = load i32, i32* %229, align 8
   %232 = bitcast i8* %226 to i32*
-  %NullCheck42 = icmp ne i32* %232, null
-  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+  %NullCheck41 = icmp eq i32* %232, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %233
 
 ; <label>:233                                     ; preds = %230
   store i32 %231, i32* %232, align 8
@@ -1099,15 +1181,15 @@ entry:
   %235 = getelementptr inbounds i8, i8* %234, i64 12
   %236 = load i8*, i8** %arg1
   %237 = getelementptr inbounds i8, i8* %236, i64 12
-  %NullCheck44 = icmp ne i8* %237, null
-  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i8* %237, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %238
 
 ; <label>:238                                     ; preds = %233
   %239 = load i8, i8* %237, align 8
   %240 = zext i8 %239 to i32
   %241 = trunc i32 %240 to i8
-  %NullCheck46 = icmp ne i8* %235, null
-  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+  %NullCheck45 = icmp eq i8* %235, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %242
 
 ; <label>:242                                     ; preds = %238
   store i8 %241, i8* %235, align 8
@@ -1117,14 +1199,14 @@ entry:
   %244 = load i8*, i8** %arg0
   %245 = load i8*, i8** %arg1
   %246 = bitcast i8* %245 to i64*
-  %NullCheck24 = icmp ne i64* %246, null
-  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64* %246, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %247
 
 ; <label>:247                                     ; preds = %243
   %248 = load i64, i64* %246, align 8
   %249 = bitcast i8* %244 to i64*
-  %NullCheck26 = icmp ne i64* %249, null
-  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64* %249, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %250
 
 ; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
@@ -1133,14 +1215,14 @@ entry:
   %253 = load i8*, i8** %arg1
   %254 = getelementptr inbounds i8, i8* %253, i64 8
   %255 = bitcast i8* %254 to i32*
-  %NullCheck28 = icmp ne i32* %255, null
-  br i1 %NullCheck28, label %256, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i32* %255, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %256
 
 ; <label>:256                                     ; preds = %250
   %257 = load i32, i32* %255, align 8
   %258 = bitcast i8* %252 to i32*
-  %NullCheck30 = icmp ne i32* %258, null
-  br i1 %NullCheck30, label %259, label %ThrowNullRef29
+  %NullCheck29 = icmp eq i32* %258, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %259
 
 ; <label>:259                                     ; preds = %256
   store i32 %257, i32* %258, align 8
@@ -1149,16 +1231,16 @@ entry:
   %262 = load i8*, i8** %arg1
   %263 = getelementptr inbounds i8, i8* %262, i64 12
   %264 = bitcast i8* %263 to i16*
-  %NullCheck32 = icmp ne i16* %264, null
-  br i1 %NullCheck32, label %265, label %ThrowNullRef31
+  %NullCheck31 = icmp eq i16* %264, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %265
 
 ; <label>:265                                     ; preds = %259
   %266 = load i16, i16* %264, align 8
   %267 = sext i16 %266 to i32
   %268 = bitcast i8* %261 to i16*
   %269 = trunc i32 %267 to i16
-  %NullCheck34 = icmp ne i16* %268, null
-  br i1 %NullCheck34, label %270, label %ThrowNullRef33
+  %NullCheck33 = icmp eq i16* %268, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %270
 
 ; <label>:270                                     ; preds = %265
   store i16 %269, i16* %268, align 8
@@ -1168,14 +1250,14 @@ entry:
   %272 = load i8*, i8** %arg0
   %273 = load i8*, i8** %arg1
   %274 = bitcast i8* %273 to i64*
-  %NullCheck8 = icmp ne i64* %274, null
-  br i1 %NullCheck8, label %275, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64* %274, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %275
 
 ; <label>:275                                     ; preds = %271
   %276 = load i64, i64* %274, align 8
   %277 = bitcast i8* %272 to i64*
-  %NullCheck10 = icmp ne i64* %277, null
-  br i1 %NullCheck10, label %278, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %277, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %278
 
 ; <label>:278                                     ; preds = %275
   store i64 %276, i64* %277, align 8
@@ -1184,14 +1266,14 @@ entry:
   %281 = load i8*, i8** %arg1
   %282 = getelementptr inbounds i8, i8* %281, i64 8
   %283 = bitcast i8* %282 to i32*
-  %NullCheck12 = icmp ne i32* %283, null
-  br i1 %NullCheck12, label %284, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i32* %283, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %284
 
 ; <label>:284                                     ; preds = %278
   %285 = load i32, i32* %283, align 8
   %286 = bitcast i8* %280 to i32*
-  %NullCheck14 = icmp ne i32* %286, null
-  br i1 %NullCheck14, label %287, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i32* %286, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %287
 
 ; <label>:287                                     ; preds = %284
   store i32 %285, i32* %286, align 8
@@ -1200,16 +1282,16 @@ entry:
   %290 = load i8*, i8** %arg1
   %291 = getelementptr inbounds i8, i8* %290, i64 12
   %292 = bitcast i8* %291 to i16*
-  %NullCheck16 = icmp ne i16* %292, null
-  br i1 %NullCheck16, label %293, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i16* %292, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %293
 
 ; <label>:293                                     ; preds = %287
   %294 = load i16, i16* %292, align 8
   %295 = sext i16 %294 to i32
   %296 = bitcast i8* %289 to i16*
   %297 = trunc i32 %295 to i16
-  %NullCheck18 = icmp ne i16* %296, null
-  br i1 %NullCheck18, label %298, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i16* %296, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %298
 
 ; <label>:298                                     ; preds = %293
   store i16 %297, i16* %296, align 8
@@ -1217,15 +1299,15 @@ entry:
   %300 = getelementptr inbounds i8, i8* %299, i64 14
   %301 = load i8*, i8** %arg1
   %302 = getelementptr inbounds i8, i8* %301, i64 14
-  %NullCheck20 = icmp ne i8* %302, null
-  br i1 %NullCheck20, label %303, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i8* %302, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %303
 
 ; <label>:303                                     ; preds = %298
   %304 = load i8, i8* %302, align 8
   %305 = zext i8 %304 to i32
   %306 = trunc i32 %305 to i8
-  %NullCheck22 = icmp ne i8* %300, null
-  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i8* %300, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %307
 
 ; <label>:307                                     ; preds = %303
   store i8 %306, i8* %300, align 8
@@ -1235,14 +1317,14 @@ entry:
   %309 = load i8*, i8** %arg0
   %310 = load i8*, i8** %arg1
   %311 = bitcast i8* %310 to i64*
-  %NullCheck = icmp ne i64* %311, null
-  br i1 %NullCheck, label %312, label %ThrowNullRef
+  %NullCheck = icmp eq i64* %311, null
+  br i1 %NullCheck, label %ThrowNullRef, label %312
 
 ; <label>:312                                     ; preds = %308
   %313 = load i64, i64* %311, align 8
   %314 = bitcast i8* %309 to i64*
-  %NullCheck2 = icmp ne i64* %314, null
-  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64* %314, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %315
 
 ; <label>:315                                     ; preds = %312
   store i64 %313, i64* %314, align 8
@@ -1251,14 +1333,14 @@ entry:
   %318 = load i8*, i8** %arg1
   %319 = getelementptr inbounds i8, i8* %318, i64 8
   %320 = bitcast i8* %319 to i64*
-  %NullCheck4 = icmp ne i64* %320, null
-  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64* %320, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %321
 
 ; <label>:321                                     ; preds = %315
   %322 = load i64, i64* %320, align 8
   %323 = bitcast i8* %317 to i64*
-  %NullCheck6 = icmp ne i64* %323, null
-  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64* %323, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %324
 
 ; <label>:324                                     ; preds = %321
   store i64 %322, i64* %323, align 8
@@ -1286,15 +1368,15 @@ entry:
 ; <label>:338                                     ; preds = %333
   %339 = load i8*, i8** %arg0
   %340 = load i8*, i8** %arg1
-  %NullCheck136 = icmp ne i8* %340, null
-  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+  %NullCheck135 = icmp eq i8* %340, null
+  br i1 %NullCheck135, label %ThrowNullRef136, label %341
 
 ; <label>:341                                     ; preds = %338
   %342 = load i8, i8* %340, align 8
   %343 = zext i8 %342 to i32
   %344 = trunc i32 %343 to i8
-  %NullCheck138 = icmp ne i8* %339, null
-  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+  %NullCheck137 = icmp eq i8* %339, null
+  br i1 %NullCheck137, label %ThrowNullRef138, label %345
 
 ; <label>:345                                     ; preds = %341
   store i8 %344, i8* %339, align 8
@@ -1317,16 +1399,16 @@ entry:
   %357 = load i8*, i8** %arg0
   %358 = load i8*, i8** %arg1
   %359 = bitcast i8* %358 to i16*
-  %NullCheck140 = icmp ne i16* %359, null
-  br i1 %NullCheck140, label %360, label %ThrowNullRef139
+  %NullCheck139 = icmp eq i16* %359, null
+  br i1 %NullCheck139, label %ThrowNullRef140, label %360
 
 ; <label>:360                                     ; preds = %356
   %361 = load i16, i16* %359, align 8
   %362 = sext i16 %361 to i32
   %363 = bitcast i8* %357 to i16*
   %364 = trunc i32 %362 to i16
-  %NullCheck142 = icmp ne i16* %363, null
-  br i1 %NullCheck142, label %365, label %ThrowNullRef141
+  %NullCheck141 = icmp eq i16* %363, null
+  br i1 %NullCheck141, label %ThrowNullRef142, label %365
 
 ; <label>:365                                     ; preds = %360
   store i16 %364, i16* %363, align 8
@@ -1352,14 +1434,14 @@ entry:
   %378 = load i8*, i8** %arg0
   %379 = load i8*, i8** %arg1
   %380 = bitcast i8* %379 to i32*
-  %NullCheck144 = icmp ne i32* %380, null
-  br i1 %NullCheck144, label %381, label %ThrowNullRef143
+  %NullCheck143 = icmp eq i32* %380, null
+  br i1 %NullCheck143, label %ThrowNullRef144, label %381
 
 ; <label>:381                                     ; preds = %377
   %382 = load i32, i32* %380, align 8
   %383 = bitcast i8* %378 to i32*
-  %NullCheck146 = icmp ne i32* %383, null
-  br i1 %NullCheck146, label %384, label %ThrowNullRef145
+  %NullCheck145 = icmp eq i32* %383, null
+  br i1 %NullCheck145, label %ThrowNullRef146, label %384
 
 ; <label>:384                                     ; preds = %381
   store i32 %382, i32* %383, align 8
@@ -1384,14 +1466,14 @@ entry:
   %395 = load i8*, i8** %arg0
   %396 = load i8*, i8** %arg1
   %397 = bitcast i8* %396 to i64*
-  %NullCheck164 = icmp ne i64* %397, null
-  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+  %NullCheck163 = icmp eq i64* %397, null
+  br i1 %NullCheck163, label %ThrowNullRef164, label %398
 
 ; <label>:398                                     ; preds = %394
   %399 = load i64, i64* %397, align 8
   %400 = bitcast i8* %395 to i64*
-  %NullCheck166 = icmp ne i64* %400, null
-  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+  %NullCheck165 = icmp eq i64* %400, null
+  br i1 %NullCheck165, label %ThrowNullRef166, label %401
 
 ; <label>:401                                     ; preds = %398
   store i64 %399, i64* %400, align 8
@@ -1400,14 +1482,14 @@ entry:
   %404 = load i8*, i8** %arg1
   %405 = getelementptr inbounds i8, i8* %404, i64 8
   %406 = bitcast i8* %405 to i64*
-  %NullCheck168 = icmp ne i64* %406, null
-  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+  %NullCheck167 = icmp eq i64* %406, null
+  br i1 %NullCheck167, label %ThrowNullRef168, label %407
 
 ; <label>:407                                     ; preds = %401
   %408 = load i64, i64* %406, align 8
   %409 = bitcast i8* %403 to i64*
-  %NullCheck170 = icmp ne i64* %409, null
-  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+  %NullCheck169 = icmp eq i64* %409, null
+  br i1 %NullCheck169, label %ThrowNullRef170, label %410
 
 ; <label>:410                                     ; preds = %407
   store i64 %408, i64* %409, align 8
@@ -1437,14 +1519,14 @@ entry:
   %425 = load i8*, i8** %arg0
   %426 = load i8*, i8** %arg1
   %427 = bitcast i8* %426 to i64*
-  %NullCheck148 = icmp ne i64* %427, null
-  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+  %NullCheck147 = icmp eq i64* %427, null
+  br i1 %NullCheck147, label %ThrowNullRef148, label %428
 
 ; <label>:428                                     ; preds = %424
   %429 = load i64, i64* %427, align 8
   %430 = bitcast i8* %425 to i64*
-  %NullCheck150 = icmp ne i64* %430, null
-  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+  %NullCheck149 = icmp eq i64* %430, null
+  br i1 %NullCheck149, label %ThrowNullRef150, label %431
 
 ; <label>:431                                     ; preds = %428
   store i64 %429, i64* %430, align 8
@@ -1466,14 +1548,14 @@ entry:
   %441 = load i8*, i8** %arg0
   %442 = load i8*, i8** %arg1
   %443 = bitcast i8* %442 to i32*
-  %NullCheck152 = icmp ne i32* %443, null
-  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+  %NullCheck151 = icmp eq i32* %443, null
+  br i1 %NullCheck151, label %ThrowNullRef152, label %444
 
 ; <label>:444                                     ; preds = %440
   %445 = load i32, i32* %443, align 8
   %446 = bitcast i8* %441 to i32*
-  %NullCheck154 = icmp ne i32* %446, null
-  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+  %NullCheck153 = icmp eq i32* %446, null
+  br i1 %NullCheck153, label %ThrowNullRef154, label %447
 
 ; <label>:447                                     ; preds = %444
   store i32 %445, i32* %446, align 8
@@ -1495,16 +1577,16 @@ entry:
   %457 = load i8*, i8** %arg0
   %458 = load i8*, i8** %arg1
   %459 = bitcast i8* %458 to i16*
-  %NullCheck156 = icmp ne i16* %459, null
-  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+  %NullCheck155 = icmp eq i16* %459, null
+  br i1 %NullCheck155, label %ThrowNullRef156, label %460
 
 ; <label>:460                                     ; preds = %456
   %461 = load i16, i16* %459, align 8
   %462 = sext i16 %461 to i32
   %463 = bitcast i8* %457 to i16*
   %464 = trunc i32 %462 to i16
-  %NullCheck158 = icmp ne i16* %463, null
-  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+  %NullCheck157 = icmp eq i16* %463, null
+  br i1 %NullCheck157, label %ThrowNullRef158, label %465
 
 ; <label>:465                                     ; preds = %460
   store i16 %464, i16* %463, align 8
@@ -1525,15 +1607,15 @@ entry:
 ; <label>:474                                     ; preds = %470
   %475 = load i8*, i8** %arg0
   %476 = load i8*, i8** %arg1
-  %NullCheck160 = icmp ne i8* %476, null
-  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+  %NullCheck159 = icmp eq i8* %476, null
+  br i1 %NullCheck159, label %ThrowNullRef160, label %477
 
 ; <label>:477                                     ; preds = %474
   %478 = load i8, i8* %476, align 8
   %479 = zext i8 %478 to i32
   %480 = trunc i32 %479 to i8
-  %NullCheck162 = icmp ne i8* %475, null
-  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+  %NullCheck161 = icmp eq i8* %475, null
+  br i1 %NullCheck161, label %ThrowNullRef162, label %481
 
 ; <label>:481                                     ; preds = %477
   store i8 %480, i8* %475, align 8
@@ -1553,343 +1635,343 @@ ThrowNullRef:                                     ; preds = %308
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %312
+ThrowNullRef2:                                    ; preds = %312
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %315
+ThrowNullRef4:                                    ; preds = %315
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %321
+ThrowNullRef6:                                    ; preds = %321
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %271
+ThrowNullRef8:                                    ; preds = %271
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %275
+ThrowNullRef10:                                   ; preds = %275
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %278
+ThrowNullRef12:                                   ; preds = %278
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %284
+ThrowNullRef14:                                   ; preds = %284
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %287
+ThrowNullRef16:                                   ; preds = %287
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %293
+ThrowNullRef18:                                   ; preds = %293
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %298
+ThrowNullRef20:                                   ; preds = %298
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %303
+ThrowNullRef22:                                   ; preds = %303
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %243
+ThrowNullRef24:                                   ; preds = %243
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %247
+ThrowNullRef26:                                   ; preds = %247
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %250
+ThrowNullRef28:                                   ; preds = %250
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %256
+ThrowNullRef30:                                   ; preds = %256
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %259
+ThrowNullRef32:                                   ; preds = %259
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %265
+ThrowNullRef34:                                   ; preds = %265
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %217
+ThrowNullRef36:                                   ; preds = %217
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %221
+ThrowNullRef38:                                   ; preds = %221
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %224
+ThrowNullRef40:                                   ; preds = %224
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %230
+ThrowNullRef42:                                   ; preds = %230
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %233
+ThrowNullRef44:                                   ; preds = %233
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %238
+ThrowNullRef46:                                   ; preds = %238
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %200
+ThrowNullRef48:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %204
+ThrowNullRef50:                                   ; preds = %204
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %207
+ThrowNullRef52:                                   ; preds = %207
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %213
+ThrowNullRef54:                                   ; preds = %213
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %172
+ThrowNullRef56:                                   ; preds = %172
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %176
+ThrowNullRef58:                                   ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %179
+ThrowNullRef60:                                   ; preds = %179
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %185
+ThrowNullRef62:                                   ; preds = %185
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %190
+ThrowNullRef64:                                   ; preds = %190
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %195
+ThrowNullRef66:                                   ; preds = %195
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %153
+ThrowNullRef68:                                   ; preds = %153
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %157
+ThrowNullRef70:                                   ; preds = %157
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %160
+ThrowNullRef72:                                   ; preds = %160
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %166
+ThrowNullRef74:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %136
+ThrowNullRef76:                                   ; preds = %136
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %140
+ThrowNullRef78:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %143
+ThrowNullRef80:                                   ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %148
+ThrowNullRef82:                                   ; preds = %148
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %128
+ThrowNullRef84:                                   ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %132
+ThrowNullRef86:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %100
+ThrowNullRef88:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %104
+ThrowNullRef90:                                   ; preds = %104
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %107
+ThrowNullRef92:                                   ; preds = %107
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %113
+ThrowNullRef94:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %118
+ThrowNullRef96:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %123
+ThrowNullRef98:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %81
+ThrowNullRef100:                                  ; preds = %81
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef101:                                  ; preds = %85
+ThrowNullRef102:                                  ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef103:                                  ; preds = %88
+ThrowNullRef104:                                  ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef105:                                  ; preds = %94
+ThrowNullRef106:                                  ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef107:                                  ; preds = %64
+ThrowNullRef108:                                  ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef109:                                  ; preds = %68
+ThrowNullRef110:                                  ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef111:                                  ; preds = %71
+ThrowNullRef112:                                  ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef113:                                  ; preds = %76
+ThrowNullRef114:                                  ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef115:                                  ; preds = %56
+ThrowNullRef116:                                  ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef117:                                  ; preds = %60
+ThrowNullRef118:                                  ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef119:                                  ; preds = %37
+ThrowNullRef120:                                  ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef121:                                  ; preds = %41
+ThrowNullRef122:                                  ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef123:                                  ; preds = %46
+ThrowNullRef124:                                  ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef125:                                  ; preds = %51
+ThrowNullRef126:                                  ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef127:                                  ; preds = %27
+ThrowNullRef128:                                  ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef129:                                  ; preds = %31
+ThrowNullRef130:                                  ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef131:                                  ; preds = %19
+ThrowNullRef132:                                  ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef133:                                  ; preds = %22
+ThrowNullRef134:                                  ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef135:                                  ; preds = %338
+ThrowNullRef136:                                  ; preds = %338
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef137:                                  ; preds = %341
+ThrowNullRef138:                                  ; preds = %341
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef139:                                  ; preds = %356
+ThrowNullRef140:                                  ; preds = %356
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef141:                                  ; preds = %360
+ThrowNullRef142:                                  ; preds = %360
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef143:                                  ; preds = %377
+ThrowNullRef144:                                  ; preds = %377
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef145:                                  ; preds = %381
+ThrowNullRef146:                                  ; preds = %381
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef147:                                  ; preds = %424
+ThrowNullRef148:                                  ; preds = %424
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef149:                                  ; preds = %428
+ThrowNullRef150:                                  ; preds = %428
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef151:                                  ; preds = %440
+ThrowNullRef152:                                  ; preds = %440
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef153:                                  ; preds = %444
+ThrowNullRef154:                                  ; preds = %444
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef155:                                  ; preds = %456
+ThrowNullRef156:                                  ; preds = %456
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef157:                                  ; preds = %460
+ThrowNullRef158:                                  ; preds = %460
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef159:                                  ; preds = %474
+ThrowNullRef160:                                  ; preds = %474
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef161:                                  ; preds = %477
+ThrowNullRef162:                                  ; preds = %477
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef163:                                  ; preds = %394
+ThrowNullRef164:                                  ; preds = %394
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef165:                                  ; preds = %398
+ThrowNullRef166:                                  ; preds = %398
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef167:                                  ; preds = %401
+ThrowNullRef168:                                  ; preds = %401
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef169:                                  ; preds = %407
+ThrowNullRef170:                                  ; preds = %407
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1939,8 +2021,8 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
-  br i1 %NullCheck, label %22, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %ThrowNullRef, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
@@ -1948,8 +2030,8 @@ entry:
   store i32 %24, i32* %loc0
   %25 = load i32, i32* %loc0
   %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %26, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %27
 
 ; <label>:27                                      ; preds = %22
   %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
@@ -1971,7 +2053,7 @@ ThrowNullRef:                                     ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1989,8 +2071,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -2022,15 +2104,15 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2048,16 +2130,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
   %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
   store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %15
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
@@ -2072,8 +2154,8 @@ entry:
   %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
   %29 = ptrtoint i16 addrspace(1)* %28 to i64
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %19
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
@@ -2089,19 +2171,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2114,8 +2196,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
@@ -2128,7 +2210,7 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[loadElem]
+Failed to read AppDomain.PrepareDataForSetup[storeElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
@@ -2202,8 +2284,8 @@ entry:
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
-  br i1 %NullCheck24, label %27, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = load i64, i64 addrspace(1)* %26
@@ -2218,8 +2300,8 @@ entry:
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
-  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
   %41 = load i64, i64 addrspace(1)* %39
@@ -2236,8 +2318,8 @@ entry:
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
-  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
   %54 = load i64, i64 addrspace(1)* %52
@@ -2252,8 +2334,8 @@ entry:
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
   %67 = load i64, i64 addrspace(1)* %65
@@ -2270,8 +2352,8 @@ entry:
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
-  br i1 %NullCheck16, label %79, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
   %80 = load i64, i64 addrspace(1)* %78
@@ -2286,8 +2368,8 @@ entry:
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
-  br i1 %NullCheck18, label %92, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
   %93 = load i64, i64 addrspace(1)* %91
@@ -2304,8 +2386,8 @@ entry:
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
-  br i1 %NullCheck12, label %105, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = load i64, i64 addrspace(1)* %104
@@ -2320,8 +2402,8 @@ entry:
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
-  br i1 %NullCheck14, label %118, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
   %119 = load i64, i64 addrspace(1)* %117
@@ -2337,8 +2419,8 @@ entry:
 
 ; <label>:128                                     ; preds = %20
   %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
-  br i1 %NullCheck4, label %130, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %129, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %130
 
 ; <label>:130                                     ; preds = %128
   %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
@@ -2346,8 +2428,8 @@ entry:
   %133 = load i16, i16 addrspace(1)* %132, align 8
   %134 = zext i16 %133 to i32
   %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
-  br i1 %NullCheck6, label %136, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %135, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %136
 
 ; <label>:136                                     ; preds = %130
   %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
@@ -2360,8 +2442,8 @@ entry:
 
 ; <label>:143                                     ; preds = %136
   %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
-  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %144, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %145
 
 ; <label>:145                                     ; preds = %143
   %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
@@ -2369,8 +2451,8 @@ entry:
   %148 = load i16, i16 addrspace(1)* %147, align 8
   %149 = zext i16 %148 to i32
   %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %150, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %151
 
 ; <label>:151                                     ; preds = %145
   %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
@@ -2388,8 +2470,8 @@ entry:
 
 ; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
-  br i1 %NullCheck, label %163, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %ThrowNullRef, label %163
 
 ; <label>:163                                     ; preds = %161
   %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
@@ -2399,8 +2481,8 @@ entry:
 
 ; <label>:167                                     ; preds = %163
   %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
-  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %168, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %169
 
 ; <label>:169                                     ; preds = %167
   %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
@@ -2432,55 +2514,55 @@ ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %167
+ThrowNullRef2:                                    ; preds = %167
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %128
+ThrowNullRef4:                                    ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %130
+ThrowNullRef6:                                    ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %143
+ThrowNullRef8:                                    ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %145
+ThrowNullRef10:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %102
+ThrowNullRef12:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %105
+ThrowNullRef14:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %76
+ThrowNullRef16:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %79
+ThrowNullRef18:                                   ; preds = %79
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %50
+ThrowNullRef20:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %53
+ThrowNullRef22:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %24
+ThrowNullRef24:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %27
+ThrowNullRef26:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2503,15 +2585,15 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2519,16 +2601,16 @@ entry:
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
   store i32 %8, i32* %loc0
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
   %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
   store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
@@ -2546,16 +2628,16 @@ entry:
 
 ; <label>:23                                      ; preds = %64
   %24 = load i16*, i16** %loc3
-  %NullCheck12 = icmp ne i16* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i16* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
   store i32 %27, i32* %loc5
   %28 = load i16*, i16** %loc4
-  %NullCheck14 = icmp ne i16* %28, null
-  br i1 %NullCheck14, label %29, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %28, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = load i16, i16* %28, align 8
@@ -2620,15 +2702,15 @@ entry:
 
 ; <label>:67                                      ; preds = %64
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
-  br i1 %NullCheck8, label %69, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %68, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %69
 
 ; <label>:69                                      ; preds = %67
   %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
   %71 = load i32, i32 addrspace(1)* %70
   %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
-  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %73
 
 ; <label>:73                                      ; preds = %69
   %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
@@ -2645,31 +2727,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %67
+ThrowNullRef8:                                    ; preds = %67
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %69
+ThrowNullRef10:                                   ; preds = %69
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2710,14 +2792,14 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
   %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
@@ -2730,14 +2812,14 @@ entry:
 
 ; <label>:11                                      ; preds = %4
   %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
   %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
@@ -2749,14 +2831,14 @@ entry:
 
 ; <label>:22                                      ; preds = %16
   %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
   %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
-  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
-  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
@@ -2804,23 +2886,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2836,7 +2918,280 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[loadElem]
+Successfully read RuntimeType.IsAssignableFrom
+
+define i8 @RuntimeType.IsAssignableFrom(%System.RuntimeType addrspace(1)* %param0, %System.Type addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.RuntimeType addrspace(1)*
+  %arg1 = alloca %System.Type addrspace(1)*
+  %loc0 = alloca %System.RuntimeType addrspace(1)*
+  %loc1 = alloca %"System.Type[]" addrspace(1)*
+  %loc2 = alloca i32
+  store %System.RuntimeType addrspace(1)* %param0, %System.RuntimeType addrspace(1)** %this
+  store %System.Type addrspace(1)* %param1, %System.Type addrspace(1)** %arg1
+  %0 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %1 = icmp ne %System.Type addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i8 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %5 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %6 = bitcast %System.Type addrspace(1)* %4 to %System.Object addrspace(1)*
+  %7 = bitcast %System.RuntimeType addrspace(1)* %5 to %System.Object addrspace(1)*
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %6, %System.Object addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %3
+  ret i8 1
+
+; <label>:12                                      ; preds = %3
+  %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 152
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 32
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
+  %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
+  %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
+  store %System.RuntimeType addrspace(1)* %25, %System.RuntimeType addrspace(1)** %loc0
+  %26 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %27 = icmp eq %System.RuntimeType addrspace(1)* %26, null
+  br i1 %27, label %34, label %28
+
+; <label>:28                                      ; preds = %15
+  %29 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %30 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)*)*)(%System.RuntimeType addrspace(1)* %29, %System.RuntimeType addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+; <label>:34                                      ; preds = %15
+  %35 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %36 = call %System.Reflection.Emit.TypeBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Reflection.Emit.TypeBuilder addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %35)
+  %37 = icmp eq %System.Reflection.Emit.TypeBuilder addrspace(1)* %36, null
+  br i1 %37, label %139, label %38
+
+; <label>:38                                      ; preds = %34
+  %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %42
+
+; <label>:42                                      ; preds = %38
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 152
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 40
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
+  %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
+  %53 = zext i8 %52 to i32
+  %54 = icmp eq i32 %53, 0
+  br i1 %54, label %56, label %55
+
+; <label>:55                                      ; preds = %42
+  ret i8 1
+
+; <label>:56                                      ; preds = %42
+  %57 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %58 = bitcast %System.RuntimeType addrspace(1)* %57 to %System.Type addrspace(1)*
+  %59 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %58)
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %64 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.Type addrspace(1)* %63, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = bitcast %System.RuntimeType addrspace(1)* %64 to %System.Type addrspace(1)*
+  %67 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %63, %System.Type addrspace(1)* %66)
+  %68 = zext i8 %67 to i32
+  %69 = trunc i32 %68 to i8
+  ret i8 %69
+
+; <label>:70                                      ; preds = %56
+  %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
+  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %73
+
+; <label>:73                                      ; preds = %70
+  %74 = load i64, i64 addrspace(1)* %72
+  %75 = add i64 %74, 128
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = add i64 %77, 0
+  %79 = inttoptr i64 %78 to i64*
+  %80 = load i64, i64* %79
+  %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
+  %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
+  %83 = call i8 %82(%System.Type addrspace(1)* %81)
+  %84 = zext i8 %83 to i32
+  %85 = icmp eq i32 %84, 0
+  br i1 %85, label %139, label %86
+
+; <label>:86                                      ; preds = %73
+  %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
+  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %89
+
+; <label>:89                                      ; preds = %86
+  %90 = load i64, i64 addrspace(1)* %88
+  %91 = add i64 %90, 128
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = add i64 %93, 24
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
+  %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
+  %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
+  store %"System.Type[]" addrspace(1)* %99, %"System.Type[]" addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %129
+
+; <label>:100                                     ; preds = %132
+  %101 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %102 = load i32, i32* %loc2
+  %NullCheck11 = icmp eq %"System.Type[]" addrspace(1)* %101, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %103
+
+; <label>:103                                     ; preds = %100
+  %104 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 1
+  %105 = load i32, i32 addrspace(1)* %104
+  %106 = zext i32 %105 to i64
+  %107 = zext i32 %102 to i64
+  %BoundsCheck = icmp uge i64 %107, %106
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %108
+
+; <label>:108                                     ; preds = %103
+  %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
+  %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
+  %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
+  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %113
+
+; <label>:113                                     ; preds = %108
+  %114 = load i64, i64 addrspace(1)* %112
+  %115 = add i64 %114, 152
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = add i64 %117, 56
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
+  %123 = zext i8 %122 to i32
+  %124 = icmp ne i32 %123, 0
+  br i1 %124, label %126, label %125
+
+; <label>:125                                     ; preds = %113
+  ret i8 0
+
+; <label>:126                                     ; preds = %113
+  %127 = load i32, i32* %loc2
+  %128 = add i32 %127, 1
+  store i32 %128, i32* %loc2
+  br label %129
+
+; <label>:129                                     ; preds = %89, %126
+  %130 = load i32, i32* %loc2
+  %131 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %NullCheck9 = icmp eq %"System.Type[]" addrspace(1)* %131, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %132
+
+; <label>:132                                     ; preds = %129
+  %133 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %131, i32 0, i32 1
+  %134 = load i32, i32 addrspace(1)* %133
+  %135 = zext i32 %134 to i64
+  %136 = trunc i64 %135 to i32
+  %137 = icmp slt i32 %130, %136
+  br i1 %137, label %100, label %138
+
+; <label>:138                                     ; preds = %132
+  ret i8 1
+
+; <label>:139                                     ; preds = %34, %73
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %129
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %103
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -2893,7 +3248,7 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElem]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -2904,8 +3259,8 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -2997,8 +3352,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
@@ -3059,8 +3414,8 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -3087,8 +3442,8 @@ entry:
 
 ; <label>:17                                      ; preds = %5, %11
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
@@ -3097,8 +3452,8 @@ entry:
 
 ; <label>:22                                      ; preds = %1, %11
   %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
@@ -3109,11 +3464,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %17
+ThrowNullRef2:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %22
+ThrowNullRef4:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3167,15 +3522,15 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
   %15 = load i32, i32 addrspace(1)* %14
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
@@ -3198,7 +3553,7 @@ ThrowNullRef:                                     ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef2:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3232,8 +3587,8 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
@@ -3312,8 +3667,8 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -3327,8 +3682,8 @@ entry:
 ; <label>:5                                       ; preds = %43
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %7 = load i32, i32* %loc1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck6, label %8, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
@@ -3366,8 +3721,8 @@ entry:
 ; <label>:32                                      ; preds = %21, %25
   %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
   %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
-  br i1 %NullCheck8, label %35, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = trunc i32 %34 to i16
@@ -3380,8 +3735,8 @@ entry:
 ; <label>:40                                      ; preds = %1, %35
   %41 = load i32, i32* %loc1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
-  br i1 %NullCheck2, label %43, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %42, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
@@ -3392,8 +3747,8 @@ entry:
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
   %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
-  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
   %51 = load i64, i64 addrspace(1)* %49
@@ -3412,19 +3767,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %40
+ThrowNullRef2:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %47
+ThrowNullRef4:                                    ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %5
+ThrowNullRef6:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %32
+ThrowNullRef8:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3467,8 +3822,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
@@ -3492,11 +3847,391 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(i16* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store i16* %param0, i16** %arg0
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load i32, i32* %arg3
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %42, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %37, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg2
+  %13 = load i32, i32* %arg3
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %37, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %24 = load i32, i32* %arg2
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load i16*, i16** %arg0
+  %35 = load i32, i32* %arg3
+  %36 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %36, i16* %34, i32 %35)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:37                                      ; preds = %5, %16
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %39)
+  %41 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41, %System.String addrspace(1)* %38, %System.String addrspace(1)* %40)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41) #0
+  unreachable
+
+; <label>:42                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
-Failed to read StringBuilder.ToString[loadElemA]
+Successfully read StringBuilder.ToString
+
+define %System.String addrspace(1)* @StringBuilder.ToString(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i16*
+  %loc3 = alloca %"System.Char[]" addrspace(1)*
+  %loc4 = alloca i32
+  %loc5 = alloca i32
+  %loc6 = alloca i16 addrspace(1)*
+  %loc7 = alloca %System.String addrspace(1)*
+  %loc8 = alloca %"System.Char[]" addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %0)
+  %2 = icmp ne i32 %1, 0
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %4
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %6)
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %7)
+  store %System.String addrspace(1)* %8, %System.String addrspace(1)** %loc0
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.Text.StringBuilder addrspace(1)* %9, %System.Text.StringBuilder addrspace(1)** %loc1
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  store %System.String addrspace(1)* %10, %System.String addrspace(1)** %loc7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc7
+  %12 = ptrtoint %System.String addrspace(1)* %11 to i64
+  %13 = icmp eq i64 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %5
+  %15 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %16 = sext i32 %15 to i64
+  %17 = add i64 %12, %16
+  br label %18
+
+; <label>:18                                      ; preds = %5, %14
+  %19 = phi i64 [ %12, %5 ], [ %17, %14 ]
+  %20 = inttoptr i64 %19 to i16*
+  store i16* %20, i16** %loc2
+  br label %21
+
+; <label>:21                                      ; preds = %98, %18
+  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %22, null
+  br i1 %NullCheck, label %ThrowNullRef, label %23
+
+; <label>:23                                      ; preds = %21
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 3
+  %25 = load i32, i32 addrspace(1)* %24, align 8
+  %26 = icmp sle i32 %25, 0
+  br i1 %26, label %96, label %27
+
+; <label>:27                                      ; preds = %23
+  %28 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %28, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %29
+
+; <label>:29                                      ; preds = %27
+  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %28, i32 0, i32 1
+  %31 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %30, align 8
+  store %"System.Char[]" addrspace(1)* %31, %"System.Char[]" addrspace(1)** %loc3
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %33
+
+; <label>:33                                      ; preds = %29
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  store i32 %35, i32* %loc4
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  %39 = load i32, i32 addrspace(1)* %38, align 8
+  store i32 %39, i32* %loc5
+  %40 = load i32, i32* %loc5
+  %41 = load i32, i32* %loc4
+  %42 = add i32 %40, %41
+  %43 = zext i32 %42 to i64
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %45
+
+; <label>:45                                      ; preds = %37
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = sext i32 %47 to i64
+  %49 = icmp sgt i64 %43, %48
+  br i1 %49, label %91, label %50
+
+; <label>:50                                      ; preds = %45
+  %51 = load i32, i32* %loc5
+  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %52, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %53
+
+; <label>:53                                      ; preds = %50
+  %54 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %52, i32 0, i32 1
+  %55 = load i32, i32 addrspace(1)* %54
+  %56 = zext i32 %55 to i64
+  %57 = trunc i64 %56 to i32
+  %58 = icmp ugt i32 %51, %57
+  br i1 %58, label %91, label %59
+
+; <label>:59                                      ; preds = %53
+  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  store %"System.Char[]" addrspace(1)* %60, %"System.Char[]" addrspace(1)** %loc8
+  %61 = icmp eq %"System.Char[]" addrspace(1)* %60, null
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %63, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %64
+
+; <label>:64                                      ; preds = %62
+  %65 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %63, i32 0, i32 1
+  %66 = load i32, i32 addrspace(1)* %65
+  %67 = zext i32 %66 to i64
+  %68 = trunc i64 %67 to i32
+  %69 = icmp ne i32 %68, 0
+  br i1 %69, label %71, label %70
+
+; <label>:70                                      ; preds = %59, %64
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:71                                      ; preds = %64
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %73
+
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %BoundsCheck = icmp uge i64 0, %76
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %77
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %78, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:79                                      ; preds = %70, %77
+  %80 = load i16*, i16** %loc2
+  %81 = load i32, i32* %loc4
+  %82 = sext i32 %81 to i64
+  %83 = mul i64 %82, 2
+  %84 = bitcast i16* %80 to i8*
+  %85 = getelementptr inbounds i8, i8* %84, i64 %83
+  %86 = load i16 addrspace(1)*, i16 addrspace(1)** %loc6
+  %87 = ptrtoint i16 addrspace(1)* %86 to i64
+  %88 = load i32, i32* %loc5
+  %89 = bitcast i8* %85 to i16*
+  %90 = inttoptr i64 %87 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %89, i16* %90, i32 %88)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %96
+
+; <label>:91                                      ; preds = %45, %53
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %94 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %93)
+  %95 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95, %System.String addrspace(1)* %92, %System.String addrspace(1)* %94)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95) #0
+  unreachable
+
+; <label>:96                                      ; preds = %23, %79
+  %97 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %97, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %98
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %97, i32 0, i32 2
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  store %System.Text.StringBuilder addrspace(1)* %100, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %102 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %102, label %21, label %103
+
+; <label>:103                                     ; preds = %98
+  store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc7
+  %104 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  ret %System.String addrspace(1)* %104
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method StringBuilder::get_Length using LLILCJit
+Successfully read StringBuilder.get_Length
+
+define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
+Successfully read RuntimeHelpers.get_OffsetToStringData
+
+define i32 @RuntimeHelpers.get_OffsetToStringData() {
+entry:
+  ret i32 12
+}
+
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
 Successfully read CultureData.CreateCultureData
 
@@ -3514,23 +4249,23 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
   store i8 %4, i8 addrspace(1)* %6
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
@@ -3549,11 +4284,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3566,50 +4301,50 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
   store i32 -1, i32 addrspace(1)* %2
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
   store i32 -1, i32 addrspace(1)* %8
   %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
   store i32 -1, i32 addrspace(1)* %14
   %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
   store i32 -1, i32 addrspace(1)* %17
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
@@ -3623,27 +4358,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3675,7 +4410,136 @@ Failed to read Dictionary`2.Insert[non-const derefAddress]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
 Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
-Failed to read HashHelpers.GetPrime[loadElem]
+Successfully read HashHelpers.GetPrime
+
+define i32 @HashHelpers.GetPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %6, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5, %System.String addrspace(1)* %4)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5) #0
+  unreachable
+
+; <label>:6                                       ; preds = %entry
+  store i32 0, i32* %loc0
+  br label %29
+
+; <label>:7                                       ; preds = %35
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 1296
+  %10 = addrspacecast i8 addrspace(1)* %9 to %"System.Int32[]" addrspace(1)**
+  %11 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %10
+  %12 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Int32[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = zext i32 %15 to i64
+  %17 = zext i32 %12 to i64
+  %BoundsCheck = icmp uge i64 %17, %16
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 3, i32 %12
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  store i32 %20, i32* %loc1
+  %21 = load i32, i32* %loc1
+  %22 = load i32, i32* %arg0
+  %23 = icmp slt i32 %21, %22
+  br i1 %23, label %26, label %24
+
+; <label>:24                                      ; preds = %18
+  %25 = load i32, i32* %loc1
+  ret i32 %25
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %loc0
+  %28 = add i32 %27, 1
+  store i32 %28, i32* %loc0
+  br label %29
+
+; <label>:29                                      ; preds = %6, %26
+  %30 = load i32, i32* %loc0
+  %31 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %32 = getelementptr inbounds i8, i8 addrspace(1)* %31, i64 1296
+  %33 = addrspacecast i8 addrspace(1)* %32 to %"System.Int32[]" addrspace(1)**
+  %34 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %33
+  %NullCheck = icmp eq %"System.Int32[]" addrspace(1)* %34, null
+  br i1 %NullCheck, label %ThrowNullRef, label %35
+
+; <label>:35                                      ; preds = %29
+  %36 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %34, i32 0, i32 1
+  %37 = load i32, i32 addrspace(1)* %36
+  %38 = zext i32 %37 to i64
+  %39 = trunc i64 %38 to i32
+  %40 = icmp slt i32 %30, %39
+  br i1 %40, label %7, label %41
+
+; <label>:41                                      ; preds = %35
+  %42 = load i32, i32* %arg0
+  %43 = or i32 %42, 1
+  store i32 %43, i32* %loc2
+  br label %59
+
+; <label>:44                                      ; preds = %59
+  %45 = load i32, i32* %loc2
+  %46 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %45)
+  %47 = zext i8 %46 to i32
+  %48 = icmp eq i32 %47, 0
+  br i1 %48, label %56, label %49
+
+; <label>:49                                      ; preds = %44
+  %50 = load i32, i32* %loc2
+  %51 = sub i32 %50, 1
+  %52 = srem i32 %51, 101
+  %53 = icmp eq i32 %52, 0
+  br i1 %53, label %56, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = load i32, i32* %loc2
+  ret i32 %55
+
+; <label>:56                                      ; preds = %44, %49
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %57, 2
+  store i32 %58, i32* %loc2
+  br label %59
+
+; <label>:59                                      ; preds = %41, %56
+  %60 = load i32, i32* %loc2
+  %61 = icmp slt i32 %60, 2147483647
+  br i1 %61, label %44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load i32, i32* %arg0
+  ret i32 %63
+
+ThrowNullRef:                                     ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
 Successfully read GenericEqualityComparer`1.GetHashCode
 
@@ -3694,14 +4558,14 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
   %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load i64, i64 addrspace(1)* %7
@@ -3720,7 +4584,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3750,8 +4614,8 @@ entry:
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
@@ -3796,8 +4660,8 @@ entry:
   %35 = bitcast i16* %34 to i8*
   %36 = getelementptr inbounds i8, i8* %35, i64 2
   %37 = bitcast i8* %36 to i16*
-  %NullCheck4 = icmp ne i16* %37, null
-  br i1 %NullCheck4, label %38, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %37, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %38
 
 ; <label>:38                                      ; preds = %27
   %39 = load i16, i16* %37, align 8
@@ -3824,8 +4688,8 @@ entry:
 
 ; <label>:54                                      ; preds = %22, %43
   %55 = load i16*, i16** %loc4
-  %NullCheck2 = icmp ne i16* %55, null
-  br i1 %NullCheck2, label %56, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i16* %55, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %56
 
 ; <label>:56                                      ; preds = %54
   %57 = load i16, i16* %55, align 8
@@ -3850,11 +4714,11 @@ ThrowNullRef:                                     ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %54
+ThrowNullRef2:                                    ; preds = %54
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %27
+ThrowNullRef4:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3871,8 +4735,8 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -3907,8 +4771,8 @@ entry:
 
 ; <label>:26                                      ; preds = %19
   %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
-  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %28
 
 ; <label>:28                                      ; preds = %26
   %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
@@ -3920,7 +4784,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3972,8 +4836,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
@@ -3984,26 +4848,26 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
-  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
@@ -4014,8 +4878,8 @@ entry:
 ; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
@@ -4024,8 +4888,8 @@ entry:
 
 ; <label>:25                                      ; preds = %1, %16, %23
   %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
-  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
@@ -4036,27 +4900,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %20
+ThrowNullRef10:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4069,8 +4933,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -4081,8 +4945,8 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
@@ -4091,8 +4955,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1, %8
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
@@ -4103,11 +4967,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4128,24 +4992,24 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   store i32 %3, i32* %loc0
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
   %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
   store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck4, label %9, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
@@ -4164,15 +5028,15 @@ entry:
 ; <label>:18                                      ; preds = %70
   %19 = load i16*, i16** %loc3
   %20 = bitcast i16* %19 to i64*
-  %NullCheck10 = icmp ne i64* %20, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %20, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = load i64, i64* %20, align 8
   %23 = load i16*, i16** %loc4
   %24 = bitcast i16* %23 to i64*
-  %NullCheck12 = icmp ne i64* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = load i64, i64* %24, align 8
@@ -4188,8 +5052,8 @@ entry:
   %31 = bitcast i16* %30 to i8*
   %32 = getelementptr inbounds i8, i8* %31, i64 8
   %33 = bitcast i8* %32 to i64*
-  %NullCheck14 = icmp ne i64* %33, null
-  br i1 %NullCheck14, label %34, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = load i64, i64* %33, align 8
@@ -4197,8 +5061,8 @@ entry:
   %37 = bitcast i16* %36 to i8*
   %38 = getelementptr inbounds i8, i8* %37, i64 8
   %39 = bitcast i8* %38 to i64*
-  %NullCheck16 = icmp ne i64* %39, null
-  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %40
 
 ; <label>:40                                      ; preds = %34
   %41 = load i64, i64* %39, align 8
@@ -4214,8 +5078,8 @@ entry:
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %NullCheck18 = icmp ne i64* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = load i64, i64* %48, align 8
@@ -4223,8 +5087,8 @@ entry:
   %52 = bitcast i16* %51 to i8*
   %53 = getelementptr inbounds i8, i8* %52, i64 16
   %54 = bitcast i8* %53 to i64*
-  %NullCheck20 = icmp ne i64* %54, null
-  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64* %54, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %55
 
 ; <label>:55                                      ; preds = %49
   %56 = load i64, i64* %54, align 8
@@ -4262,15 +5126,15 @@ entry:
 ; <label>:74                                      ; preds = %95
   %75 = load i16*, i16** %loc3
   %76 = bitcast i16* %75 to i32*
-  %NullCheck6 = icmp ne i32* %76, null
-  br i1 %NullCheck6, label %77, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32* %76, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %77
 
 ; <label>:77                                      ; preds = %74
   %78 = load i32, i32* %76, align 8
   %79 = load i16*, i16** %loc4
   %80 = bitcast i16* %79 to i32*
-  %NullCheck8 = icmp ne i32* %80, null
-  br i1 %NullCheck8, label %81, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i32* %80, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %81
 
 ; <label>:81                                      ; preds = %77
   %82 = load i32, i32* %80, align 8
@@ -4318,43 +5182,43 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %74
+ThrowNullRef6:                                    ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %77
+ThrowNullRef8:                                    ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %29
+ThrowNullRef14:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %34
+ThrowNullRef16:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4376,8 +5240,8 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load i64, i64 addrspace(1)* %4
@@ -4389,8 +5253,8 @@ entry:
   %12 = load i64, i64* %11
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %5
   %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
@@ -4399,8 +5263,8 @@ entry:
   %18 = load i8, i8* %arg2
   %19 = zext i8 %18 to i32
   %20 = trunc i32 %19 to i8
-  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %15
   %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
@@ -4411,11 +5275,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4442,8 +5306,8 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
@@ -4466,16 +5330,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
   %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = load i64, i64 addrspace(1)* %19
@@ -4500,8 +5364,8 @@ entry:
 ; <label>:35                                      ; preds = %30
   %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
@@ -4514,8 +5378,8 @@ entry:
 
 ; <label>:42                                      ; preds = %1, %38
   %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
-  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
@@ -4526,19 +5390,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %35
+ThrowNullRef2:                                    ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %42
+ThrowNullRef8:                                    ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4551,14 +5415,14 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
@@ -4570,7 +5434,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4583,8 +5447,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
@@ -4613,51 +5477,51 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
   %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
   %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
   %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
   %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
-  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
   store i64 %21, i64 addrspace(1)* %23
   %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %25 = load i64, i64* %loc0
-  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
@@ -4668,27 +5532,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %22
+ThrowNullRef12:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4701,8 +5565,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
@@ -4713,19 +5577,19 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
@@ -4734,8 +5598,8 @@ entry:
 
 ; <label>:15                                      ; preds = %1, %13
   %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
@@ -4746,19 +5610,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %15
+ThrowNullRef8:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4771,8 +5635,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -4831,8 +5695,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
@@ -4882,8 +5746,8 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
-  br i1 %NullCheck, label %17, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %ThrowNullRef, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
@@ -4894,15 +5758,15 @@ entry:
 
 ; <label>:22                                      ; preds = %17
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
-  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
   %26 = load i32, i32 addrspace(1)* %25
   %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
-  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %27, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
@@ -4925,8 +5789,8 @@ entry:
 ; <label>:40                                      ; preds = %17
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
-  br i1 %NullCheck6, label %43, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %41, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
@@ -4938,34 +5802,17 @@ ThrowNullRef:                                     ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %24
+ThrowNullRef4:                                    ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %40
+ThrowNullRef6:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
-}
-
-INFO:  jitting method Object::ReferenceEquals using LLILCJit
-Successfully read Object.ReferenceEquals
-
-define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
-entry:
-  %arg0 = alloca %System.Object addrspace(1)*
-  %arg1 = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
-  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
-  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = icmp eq %System.Object addrspace(1)* %0, %1
-  %3 = sext i1 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
 }
 
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
@@ -4978,21 +5825,21 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
   %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
-  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
@@ -5007,28 +5854,28 @@ entry:
 ; <label>:13                                      ; preds = %8, %12
   %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
   %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
   %21 = load i32, i32 addrspace(1)* %20, align 8
   %22 = add i32 %21, 1
-  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
   store i32 %22, i32 addrspace(1)* %24
   %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
@@ -5039,27 +5886,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5077,7 +5924,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::Setup using LLILCJit
-Failed to read AppDomain.Setup[loadElem]
+Failed to read AppDomain.Setup[unbox]
 INFO:  jitting method Thread::GetDomain using LLILCJit
 Successfully read Thread.GetDomain
 
@@ -5108,8 +5955,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
@@ -5122,14 +5969,14 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
   %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
@@ -5141,11 +5988,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5173,8 +6020,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -5189,7 +6036,328 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
 Failed to read KeyCollection.System.Collections.Generic.IEnumerable<TKey>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Successfully read Enumerator.MoveNext
+
+define i8 @Enumerator.MoveNext(%"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.RuntimeTypeHandle* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*
+  %"$TypeArg" = alloca %System.RuntimeTypeHandle*
+  store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
+  %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 8
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %76, label %12
+
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
+  br label %76
+
+; <label>:13                                      ; preds = %85
+  %14 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck19 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %15
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, i32 0, i32 0
+  %17 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %16, align 8
+  %NullCheck21 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, i32 0, i32 2
+  %20 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %19, align 8
+  %21 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck23 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %22
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, i32 0, i32 2
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %NullCheck25 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 3, i32 %24
+  %NullCheck27 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %32
+
+; <label>:32                                      ; preds = %30
+  %33 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, i32 0, i32 2
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = icmp slt i32 %34, 0
+  br i1 %35, label %68, label %36
+
+; <label>:36                                      ; preds = %32
+  %37 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %38 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck29 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %39
+
+; <label>:39                                      ; preds = %36
+  %40 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, i32 0, i32 0
+  %41 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %40, align 8
+  %NullCheck31 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, i32 0, i32 2
+  %44 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %43, align 8
+  %45 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck33 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, i32 0, i32 2
+  %48 = load i32, i32 addrspace(1)* %47, align 8
+  %NullCheck35 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %49
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = zext i32 %51 to i64
+  %53 = zext i32 %48 to i64
+  %BoundsCheck37 = icmp uge i64 %53, %52
+  br i1 %BoundsCheck37, label %ThrowIndexOutOfRange38, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 3, i32 %48
+  %NullCheck39 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %56
+
+; <label>:56                                      ; preds = %54
+  %57 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, i32 0, i32 0
+  %58 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck41 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %59
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %60, %System.__Canon addrspace(1)* %58)
+  %61 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck43 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  %64 = load i32, i32 addrspace(1)* %63, align 8
+  %65 = add i32 %64, 1
+  %NullCheck45 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  store i32 %65, i32 addrspace(1)* %67
+  ret i8 1
+
+; <label>:68                                      ; preds = %32
+  %69 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck47 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %73 = add i32 %72, 1
+  %NullCheck49 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %74
+
+; <label>:74                                      ; preds = %70
+  %75 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  store i32 %73, i32 addrspace(1)* %75
+  br label %76
+
+; <label>:76                                      ; preds = %8, %12, %74
+  %77 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %78
+
+; <label>:78                                      ; preds = %76
+  %79 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, i32 0, i32 2
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck7 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %82
+
+; <label>:82                                      ; preds = %78
+  %83 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, i32 0, i32 0
+  %84 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %83, align 8
+  %NullCheck9 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %85
+
+; <label>:85                                      ; preds = %82
+  %86 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, i32 0, i32 7
+  %87 = load i32, i32 addrspace(1)* %86, align 8
+  %88 = icmp ult i32 %80, %87
+  br i1 %88, label %13, label %89
+
+; <label>:89                                      ; preds = %85
+  %90 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %91 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck11 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %92
+
+; <label>:92                                      ; preds = %89
+  %93 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, i32 0, i32 0
+  %94 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck13 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %95
+
+; <label>:95                                      ; preds = %92
+  %96 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, i32 0, i32 7
+  %97 = load i32, i32 addrspace(1)* %96, align 8
+  %98 = add i32 %97, 1
+  %NullCheck15 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %99
+
+; <label>:99                                      ; preds = %95
+  %100 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, i32 0, i32 2
+  store i32 %98, i32 addrspace(1)* %100
+  %101 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck17 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %102
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %103, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %92
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef22:                                   ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef24:                                   ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef26:                                   ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef28:                                   ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef30:                                   ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef32:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef34:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef36:                                   ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange38:                           ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef40:                                   ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef42:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef44:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef46:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef48:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef50:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -5200,8 +6368,8 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -5232,9 +6400,9 @@ Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
 Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
-Failed to read String.MakeSeparatorList[loadElemA]
+Failed to read String.MakeSeparatorList[storeElem]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
-Failed to read String.InternalSplitKeepEmptyEntries[loadElem]
+Failed to read String.InternalSplitKeepEmptyEntries[storeElem]
 INFO:  jitting method Path::IsRelative using LLILCJit
 Successfully read Path.IsRelative
 
@@ -5243,8 +6411,8 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -5254,8 +6422,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
@@ -5271,8 +6439,8 @@ entry:
 
 ; <label>:17                                      ; preds = %7
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
@@ -5288,8 +6456,8 @@ entry:
 
 ; <label>:29                                      ; preds = %19
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %31
 
 ; <label>:31                                      ; preds = %29
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
@@ -5300,8 +6468,8 @@ entry:
 
 ; <label>:36                                      ; preds = %31
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
-  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %37, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
@@ -5312,8 +6480,8 @@ entry:
 
 ; <label>:43                                      ; preds = %31, %38
   %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
-  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %45
 
 ; <label>:45                                      ; preds = %43
   %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
@@ -5324,8 +6492,8 @@ entry:
 
 ; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %50
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
@@ -5336,8 +6504,8 @@ entry:
 
 ; <label>:57                                      ; preds = %1, %7, %19, %45, %52
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
-  br i1 %NullCheck14, label %59, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %59
 
 ; <label>:59                                      ; preds = %57
   %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
@@ -5347,8 +6515,8 @@ entry:
 
 ; <label>:63                                      ; preds = %59
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
@@ -5359,8 +6527,8 @@ entry:
 
 ; <label>:70                                      ; preds = %65
   %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
-  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.String addrspace(1)* %71, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %72
 
 ; <label>:72                                      ; preds = %70
   %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
@@ -5379,39 +6547,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %17
+ThrowNullRef4:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %29
+ThrowNullRef6:                                    ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %36
+ThrowNullRef8:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %43
+ThrowNullRef10:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %50
+ThrowNullRef12:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %57
+ThrowNullRef14:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %63
+ThrowNullRef16:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %70
+ThrowNullRef18:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5419,7 +6587,293 @@ ThrowNullRef17:                                   ; preds = %70
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
-Failed to read String.TrimHelper[loadElem]
+Successfully read String.TrimHelper
+
+define %System.String addrspace(1)* @String.TrimHelper(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i16
+  %loc4 = alloca i32
+  %loc5 = alloca i16
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = sub i32 %3, 1
+  store i32 %4, i32* %loc0
+  store i32 0, i32* %loc1
+  %5 = load i32, i32* %arg2
+  %6 = icmp eq i32 %5, 1
+  br i1 %6, label %62, label %7
+
+; <label>:7                                       ; preds = %1
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:8                                       ; preds = %58
+  store i32 0, i32* %loc2
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load i32, i32* %loc1
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2, i32 %10
+  %13 = load i16, i16 addrspace(1)* %12
+  %14 = zext i16 %13 to i32
+  %15 = trunc i32 %14 to i16
+  store i16 %15, i16* %loc3
+  store i32 0, i32* %loc2
+  br label %34
+
+; <label>:16                                      ; preds = %37
+  %17 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %18 = load i32, i32* %loc2
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %17, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %19
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = zext i32 %18 to i64
+  %BoundsCheck = icmp uge i64 %23, %22
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %24
+
+; <label>:24                                      ; preds = %19
+  %25 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 3, i32 %18
+  %26 = load i16, i16 addrspace(1)* %25, align 8
+  %27 = zext i16 %26 to i32
+  %28 = load i16, i16* %loc3
+  %29 = zext i16 %28 to i32
+  %30 = icmp eq i32 %27, %29
+  br i1 %30, label %43, label %31
+
+; <label>:31                                      ; preds = %24
+  %32 = load i32, i32* %loc2
+  %33 = add i32 %32, 1
+  store i32 %33, i32* %loc2
+  br label %34
+
+; <label>:34                                      ; preds = %11, %31
+  %35 = load i32, i32* %loc2
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = icmp slt i32 %35, %41
+  br i1 %42, label %16, label %43
+
+; <label>:43                                      ; preds = %24, %37
+  %44 = load i32, i32* %loc2
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %45, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp eq i32 %44, %50
+  br i1 %51, label %62, label %52
+
+; <label>:52                                      ; preds = %46
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %7, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %57, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %58
+
+; <label>:58                                      ; preds = %55
+  %59 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %60 = load i32, i32 addrspace(1)* %59
+  %61 = icmp slt i32 %56, %60
+  br i1 %61, label %8, label %62
+
+; <label>:62                                      ; preds = %1, %46, %58
+  %63 = load i32, i32* %arg2
+  %64 = icmp eq i32 %63, 0
+  br i1 %64, label %122, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %66, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %67
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %66, i32 0, i32 1
+  %69 = load i32, i32 addrspace(1)* %68
+  %70 = sub i32 %69, 1
+  store i32 %70, i32* %loc0
+  br label %118
+
+; <label>:71                                      ; preds = %118
+  store i32 0, i32* %loc4
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %73 = load i32, i32* %loc0
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %74
+
+; <label>:74                                      ; preds = %71
+  %75 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 2, i32 %73
+  %76 = load i16, i16 addrspace(1)* %75
+  %77 = zext i16 %76 to i32
+  %78 = trunc i32 %77 to i16
+  store i16 %78, i16* %loc5
+  store i32 0, i32* %loc4
+  br label %97
+
+; <label>:79                                      ; preds = %100
+  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %81 = load i32, i32* %loc4
+  %NullCheck19 = icmp eq %"System.Char[]" addrspace(1)* %80, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
+
+; <label>:82                                      ; preds = %79
+  %83 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 1
+  %84 = load i32, i32 addrspace(1)* %83
+  %85 = zext i32 %84 to i64
+  %86 = zext i32 %81 to i64
+  %BoundsCheck21 = icmp uge i64 %86, %85
+  br i1 %BoundsCheck21, label %ThrowIndexOutOfRange22, label %87
+
+; <label>:87                                      ; preds = %82
+  %88 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 3, i32 %81
+  %89 = load i16, i16 addrspace(1)* %88, align 8
+  %90 = zext i16 %89 to i32
+  %91 = load i16, i16* %loc5
+  %92 = zext i16 %91 to i32
+  %93 = icmp eq i32 %90, %92
+  br i1 %93, label %106, label %94
+
+; <label>:94                                      ; preds = %87
+  %95 = load i32, i32* %loc4
+  %96 = add i32 %95, 1
+  store i32 %96, i32* %loc4
+  br label %97
+
+; <label>:97                                      ; preds = %74, %94
+  %98 = load i32, i32* %loc4
+  %99 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck15 = icmp eq %"System.Char[]" addrspace(1)* %99, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %100
+
+; <label>:100                                     ; preds = %97
+  %101 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %99, i32 0, i32 1
+  %102 = load i32, i32 addrspace(1)* %101
+  %103 = zext i32 %102 to i64
+  %104 = trunc i64 %103 to i32
+  %105 = icmp slt i32 %98, %104
+  br i1 %105, label %79, label %106
+
+; <label>:106                                     ; preds = %87, %100
+  %107 = load i32, i32* %loc4
+  %108 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck17 = icmp eq %"System.Char[]" addrspace(1)* %108, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %109
+
+; <label>:109                                     ; preds = %106
+  %110 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %108, i32 0, i32 1
+  %111 = load i32, i32 addrspace(1)* %110
+  %112 = zext i32 %111 to i64
+  %113 = trunc i64 %112 to i32
+  %114 = icmp eq i32 %107, %113
+  br i1 %114, label %122, label %115
+
+; <label>:115                                     ; preds = %109
+  %116 = load i32, i32* %loc0
+  %117 = sub i32 %116, 1
+  store i32 %117, i32* %loc0
+  br label %118
+
+; <label>:118                                     ; preds = %67, %115
+  %119 = load i32, i32* %loc0
+  %120 = load i32, i32* %loc1
+  %121 = icmp sge i32 %119, %120
+  br i1 %121, label %71, label %122
+
+; <label>:122                                     ; preds = %62, %109, %118
+  %123 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %124 = load i32, i32* %loc1
+  %125 = load i32, i32* %loc0
+  %126 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %123, i32 %124, i32 %125)
+  ret %System.String addrspace(1)* %126
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %97
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange22:                           ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
 Successfully read String.CreateTrimmedString
 
@@ -5439,8 +6893,8 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
@@ -5535,8 +6989,8 @@ entry:
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i64 2872
   %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
   %8 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %7
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %3
   %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
@@ -5553,8 +7007,8 @@ entry:
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 2864
   %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
   %21 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %20
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
-  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %22
 
 ; <label>:22                                      ; preds = %16
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
@@ -5569,7 +7023,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %16
+ThrowNullRef2:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5586,8 +7040,8 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5613,8 +7067,8 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
@@ -5632,8 +7086,8 @@ entry:
 
 ; <label>:12                                      ; preds = %4
   %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
@@ -5644,8 +7098,8 @@ entry:
 
 ; <label>:19                                      ; preds = %14
   %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %19
   %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
@@ -5660,21 +7114,21 @@ entry:
   %31 = zext i16 %30 to i32
   %32 = bitcast i8* %29 to i16*
   %33 = trunc i32 %31 to i16
-  %NullCheck6 = icmp ne i16* %32, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i16* %32, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %21
   store i16 %33, i16* %32, align 8
   %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %36
 
 ; <label>:36                                      ; preds = %34
   %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
   %38 = load i32, i32 addrspace(1)* %37, align 8
   %39 = add i32 %38, 1
-  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %40
 
 ; <label>:40                                      ; preds = %36
   %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
@@ -5683,16 +7137,16 @@ entry:
 
 ; <label>:42                                      ; preds = %14
   %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
-  br i1 %NullCheck12, label %44, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
   %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
   %47 = load i16, i16* %arg1
   %48 = zext i16 %47 to i32
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = trunc i32 %48 to i16
@@ -5703,31 +7157,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %19
+ThrowNullRef4:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %21
+ThrowNullRef6:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %36
+ThrowNullRef10:                                   ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %42
+ThrowNullRef12:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %44
+ThrowNullRef14:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5740,8 +7194,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -5752,8 +7206,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
@@ -5762,14 +7216,14 @@ entry:
 
 ; <label>:11                                      ; preds = %1
   %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
@@ -5779,15 +7233,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5808,8 +7262,8 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5822,8 +7276,8 @@ entry:
 
 ; <label>:8                                       ; preds = %3
   %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
@@ -5842,15 +7296,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
-  br i1 %NullCheck4, label %22, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
   %24 = load i16*, i16* addrspace(1)* %23, align 8
   %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %25, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
@@ -5859,8 +7313,8 @@ entry:
   store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
@@ -5874,8 +7328,8 @@ entry:
 
 ; <label>:37                                      ; preds = %65
   %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %37
   %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
@@ -5886,16 +7340,16 @@ entry:
   %45 = bitcast i16* %41 to i8*
   %46 = getelementptr inbounds i8, i8* %45, i64 %44
   %47 = bitcast i8* %46 to i16*
-  %NullCheck14 = icmp ne i16* %47, null
-  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %47, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %48
 
 ; <label>:48                                      ; preds = %39
   %49 = load i16, i16* %47, align 8
   %50 = zext i16 %49 to i32
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %52 = load i32, i32* %loc1
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %53
 
 ; <label>:53                                      ; preds = %48
   %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
@@ -5916,8 +7370,8 @@ entry:
 ; <label>:62                                      ; preds = %36, %59
   %63 = load i32, i32* %loc1
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck10, label %65, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %65
 
 ; <label>:65                                      ; preds = %62
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
@@ -5936,15 +7390,15 @@ entry:
 
 ; <label>:74                                      ; preds = %70
   %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
-  br i1 %NullCheck18, label %76, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %76
 
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
   %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
-  br i1 %NullCheck20, label %80, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
   %81 = load i64, i64 addrspace(1)* %79
@@ -5958,8 +7412,8 @@ entry:
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
   %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
-  br i1 %NullCheck22, label %92, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.String addrspace(1)* %90, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %92
 
 ; <label>:92                                      ; preds = %80
   %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
@@ -5969,15 +7423,15 @@ entry:
 
 ; <label>:96                                      ; preds = %70
   %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
-  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %98
 
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
   %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
-  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
   %103 = load i64, i64 addrspace(1)* %101
@@ -5991,8 +7445,8 @@ entry:
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
   %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
-  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.String addrspace(1)* %112, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %114
 
 ; <label>:114                                     ; preds = %102
   %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
@@ -6004,59 +7458,59 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %20
+ThrowNullRef4:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %22
+ThrowNullRef6:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %26
+ThrowNullRef8:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %62
+ThrowNullRef10:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %48
+ThrowNullRef16:                                   ; preds = %48
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %74
+ThrowNullRef18:                                   ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %76
+ThrowNullRef20:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %80
+ThrowNullRef22:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %96
+ThrowNullRef24:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %98
+ThrowNullRef26:                                   ; preds = %98
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %102
+ThrowNullRef28:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6069,15 +7523,15 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
   %3 = load i16*, i16* addrspace(1)* %2, align 8
   %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
@@ -6087,8 +7541,8 @@ entry:
   %10 = bitcast i16* %3 to i8*
   %11 = getelementptr inbounds i8, i8* %10, i64 %9
   %12 = bitcast i8* %11 to i16*
-  %NullCheck4 = icmp ne i16* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %5
   store i16 0, i16* %12, align 8
@@ -6098,11 +7552,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6119,8 +7573,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -6131,8 +7585,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
@@ -6144,15 +7598,15 @@ entry:
 
 ; <label>:14                                      ; preds = %1
   %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
   %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
   %21 = load i64, i64 addrspace(1)* %19
@@ -6171,15 +7625,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %14
+ThrowNullRef4:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %16
+ThrowNullRef6:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6302,14 +7756,6 @@ entry:
   ret %System.String addrspace(1)* %57
 }
 
-INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
-Successfully read RuntimeHelpers.get_OffsetToStringData
-
-define i32 @RuntimeHelpers.get_OffsetToStringData() {
-entry:
-  ret i32 12
-}
-
 INFO:  jitting method String::Equals using LLILCJit
 Successfully read String.Equals
 
@@ -6381,8 +7827,8 @@ entry:
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
-  br i1 %NullCheck24, label %29, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
   %30 = load i64, i64 addrspace(1)* %28
@@ -6397,8 +7843,8 @@ entry:
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
-  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
   %43 = load i64, i64 addrspace(1)* %41
@@ -6418,8 +7864,8 @@ entry:
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
   %59 = load i64, i64 addrspace(1)* %57
@@ -6434,8 +7880,8 @@ entry:
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck22, label %71, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
   %72 = load i64, i64 addrspace(1)* %70
@@ -6455,8 +7901,8 @@ entry:
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
-  br i1 %NullCheck16, label %87, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = load i64, i64 addrspace(1)* %86
@@ -6471,8 +7917,8 @@ entry:
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck18, label %100, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
   %101 = load i64, i64 addrspace(1)* %99
@@ -6492,8 +7938,8 @@ entry:
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
-  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
   %117 = load i64, i64 addrspace(1)* %115
@@ -6508,8 +7954,8 @@ entry:
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
-  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
   %130 = load i64, i64 addrspace(1)* %128
@@ -6528,15 +7974,15 @@ entry:
 
 ; <label>:142                                     ; preds = %22
   %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
-  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %143, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %144
 
 ; <label>:144                                     ; preds = %142
   %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
   %146 = load i32, i32 addrspace(1)* %145
   %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
-  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %147, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %148
 
 ; <label>:148                                     ; preds = %144
   %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
@@ -6557,15 +8003,15 @@ entry:
 
 ; <label>:159                                     ; preds = %22
   %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
-  br i1 %NullCheck, label %161, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %ThrowNullRef, label %161
 
 ; <label>:161                                     ; preds = %159
   %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
   %163 = load i32, i32 addrspace(1)* %162
   %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
-  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %164, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %165
 
 ; <label>:165                                     ; preds = %161
   %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
@@ -6578,8 +8024,8 @@ entry:
 
 ; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
-  br i1 %NullCheck4, label %172, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %171, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %172
 
 ; <label>:172                                     ; preds = %170
   %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
@@ -6589,8 +8035,8 @@ entry:
 
 ; <label>:176                                     ; preds = %172
   %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
-  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %177, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %178
 
 ; <label>:178                                     ; preds = %176
   %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
@@ -6629,55 +8075,55 @@ ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %161
+ThrowNullRef2:                                    ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %170
+ThrowNullRef4:                                    ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %176
+ThrowNullRef6:                                    ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %142
+ThrowNullRef8:                                    ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %144
+ThrowNullRef10:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %113
+ThrowNullRef12:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %116
+ThrowNullRef14:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %84
+ThrowNullRef16:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %87
+ThrowNullRef18:                                   ; preds = %87
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %55
+ThrowNullRef20:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %58
+ThrowNullRef22:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %26
+ThrowNullRef24:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %29
+ThrowNullRef26:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,8 +8161,8 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck, label %14, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %ThrowNullRef, label %14
 
 ; <label>:14                                      ; preds = %8
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
@@ -6760,8 +8206,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
@@ -6770,14 +8216,14 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32, i32* %loc0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %10
   %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
   %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
@@ -6790,15 +8236,15 @@ entry:
 ; <label>:25                                      ; preds = %19
   %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
-  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
   %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
@@ -6807,8 +8253,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %37 = load i32, i32* %loc0
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %38, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %38
 
 ; <label>:38                                      ; preds = %32
   %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
@@ -6817,14 +8263,14 @@ entry:
 
 ; <label>:40                                      ; preds = %19
   %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %40
   %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
   %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
-  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
-  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
@@ -6832,8 +8278,8 @@ entry:
   %48 = zext i32 %47 to i64
   %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
-  br i1 %NullCheck16, label %51, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %51
 
 ; <label>:51                                      ; preds = %45
   %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
@@ -6847,15 +8293,15 @@ entry:
 ; <label>:57                                      ; preds = %51
   %58 = load i16*, i16** %arg1
   %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
-  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %60
 
 ; <label>:60                                      ; preds = %57
   %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
   %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
-  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %64
 
 ; <label>:64                                      ; preds = %60
   %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
@@ -6864,22 +8310,22 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
   %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
-  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %70
 
 ; <label>:70                                      ; preds = %64
   %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
   %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
-  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
-  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
   %75 = load i32, i32 addrspace(1)* %74
   %76 = zext i32 %75 to i64
   %77 = trunc i64 %76 to i32
-  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
-  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %78
 
 ; <label>:78                                      ; preds = %73
   %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
@@ -6901,8 +8347,8 @@ entry:
   %90 = bitcast i16* %86 to i8*
   %91 = getelementptr inbounds i8, i8* %90, i64 %89
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %93
 
 ; <label>:93                                      ; preds = %80
   %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
@@ -6912,8 +8358,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %99 = load i32, i32* %loc2
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %100
 
 ; <label>:100                                     ; preds = %93
   %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
@@ -6928,63 +8374,63 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %25
+ThrowNullRef6:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %32
+ThrowNullRef10:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %40
+ThrowNullRef12:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %45
+ThrowNullRef16:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %57
+ThrowNullRef18:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %60
+ThrowNullRef20:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %64
+ThrowNullRef22:                                   ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %70
+ThrowNullRef24:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %73
+ThrowNullRef26:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %80
+ThrowNullRef28:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %93
+ThrowNullRef30:                                   ; preds = %93
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7004,8 +8450,8 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
@@ -7033,43 +8479,43 @@ entry:
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %14
   %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
   %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   %28 = load i32, i32 addrspace(1)* %27, align 8
   %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
-  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %30
 
 ; <label>:30                                      ; preds = %26
   %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
   %32 = load i32, i32 addrspace(1)* %31, align 8
   %33 = add i32 %28, %32
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %34
 
 ; <label>:34                                      ; preds = %30
   %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   store i32 %33, i32 addrspace(1)* %35
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
   store i32 0, i32 addrspace(1)* %38
   %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %40
 
 ; <label>:40                                      ; preds = %37
   %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
@@ -7082,8 +8528,8 @@ entry:
 
 ; <label>:47                                      ; preds = %40
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
@@ -7098,8 +8544,8 @@ entry:
   %54 = load i32, i32* %loc0
   %55 = sext i32 %54 to i64
   %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
-  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %57
 
 ; <label>:57                                      ; preds = %52
   %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
@@ -7110,68 +8556,35 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %14
+ThrowNullRef2:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %23
+ThrowNullRef4:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %26
+ThrowNullRef6:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %30
+ThrowNullRef8:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %34
+ThrowNullRef10:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %47
+ThrowNullRef14:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %52
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-}
-
-INFO:  jitting method StringBuilder::get_Length using LLILCJit
-Successfully read StringBuilder.get_Length
-
-define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.StringBuilder addrspace(1)*
-  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
-  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
-
-; <label>:1                                       ; preds = %entry
-  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %3 = load i32, i32 addrspace(1)* %2, align 8
-  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
-
-; <label>:5                                       ; preds = %1
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = add i32 %3, %7
-  ret i32 %8
-
-ThrowNullRef:                                     ; preds = %entry
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef16:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7213,70 +8626,70 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
   %6 = load i32, i32 addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
   store i32 %6, i32 addrspace(1)* %8
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
   %13 = load i32, i32 addrspace(1)* %12, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
   store i32 %13, i32 addrspace(1)* %15
   %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
-  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %18
 
 ; <label>:18                                      ; preds = %14
   %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
   %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
   %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
   %34 = load i32, i32 addrspace(1)* %33, align 8
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
-  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
@@ -7287,39 +8700,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %28
+ThrowNullRef16:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %32
+ThrowNullRef18:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7455,13 +8868,13 @@ entry:
 ; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
@@ -7477,16 +8890,16 @@ entry:
 
 ; <label>:18                                      ; preds = %15
   %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
   store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
   %22 = load i32, i32* %loc0
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %24
 
 ; <label>:24                                      ; preds = %20
   %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
@@ -7498,13 +8911,13 @@ entry:
 ; <label>:28                                      ; preds = %15, %24
   %29 = load i32, i32* %arg1
   %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %31
   %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
@@ -7517,20 +8930,20 @@ entry:
   %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
-  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
   %46 = load i32, i32 addrspace(1)* %45, align 8
   %47 = sub i32 %40, %46
-  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
-  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i32 addrspace(1)* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %48
 
 ; <label>:48                                      ; preds = %44
   store i32 %47, i32 addrspace(1)* %39, align 8
@@ -7538,21 +8951,21 @@ entry:
 
 ; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
-  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %51
 
 ; <label>:51                                      ; preds = %49
   %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %53
 
 ; <label>:53                                      ; preds = %51
   %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
   %55 = load i32, i32 addrspace(1)* %54, align 8
   %56 = load i32, i32* %arg2
   %57 = sub i32 %55, %56
-  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %58
 
 ; <label>:58                                      ; preds = %53
   %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
@@ -7562,13 +8975,13 @@ entry:
 ; <label>:60                                      ; preds = %33, %58
   %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
   %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
-  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %63
 
 ; <label>:63                                      ; preds = %60
   %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
-  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
-  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
@@ -7578,15 +8991,15 @@ entry:
 
 ; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
-  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i32 addrspace(1)* %69, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %70
 
 ; <label>:70                                      ; preds = %68
   %71 = load i32, i32 addrspace(1)* %69, align 8
   store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
-  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
@@ -7596,8 +9009,8 @@ entry:
   store i32 %77, i32* %loc4
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
-  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %80
 
 ; <label>:80                                      ; preds = %73
   %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
@@ -7607,71 +9020,71 @@ entry:
 ; <label>:83                                      ; preds = %80
   store i32 0, i32* %loc3
   %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
-  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
-  br i1 %NullCheck26, label %88, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i32 addrspace(1)* %87, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %88
 
 ; <label>:88                                      ; preds = %85
   %89 = load i32, i32 addrspace(1)* %87, align 8
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
-  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %90
 
 ; <label>:90                                      ; preds = %88
   %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
   store i32 %89, i32 addrspace(1)* %91
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
-  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
-  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %96
 
 ; <label>:96                                      ; preds = %94
   %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
-  br i1 %NullCheck34, label %100, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %100
 
 ; <label>:100                                     ; preds = %96
   %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
-  br i1 %NullCheck36, label %102, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %102
 
 ; <label>:102                                     ; preds = %100
   %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
   %104 = load i32, i32 addrspace(1)* %103, align 8
   %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
-  br i1 %NullCheck38, label %106, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %106
 
 ; <label>:106                                     ; preds = %102
   %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
-  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
-  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %108
 
 ; <label>:108                                     ; preds = %106
   %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
   %110 = load i32, i32 addrspace(1)* %109, align 8
   %111 = add i32 %104, %110
-  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %112
 
 ; <label>:112                                     ; preds = %108
   %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
   store i32 %111, i32 addrspace(1)* %113
   %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
-  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i32 addrspace(1)* %114, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %115
 
 ; <label>:115                                     ; preds = %112
   %116 = load i32, i32 addrspace(1)* %114, align 8
@@ -7681,19 +9094,19 @@ entry:
 ; <label>:118                                     ; preds = %115
   %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
-  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %121
 
 ; <label>:121                                     ; preds = %118
   %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
-  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
-  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %123
 
 ; <label>:123                                     ; preds = %121
   %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
   %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
-  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
-  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %126
 
 ; <label>:126                                     ; preds = %123
   %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
@@ -7705,8 +9118,8 @@ entry:
 
 ; <label>:130                                     ; preds = %80, %115, %126
   %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %132
 
 ; <label>:132                                     ; preds = %130
   %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7715,8 +9128,8 @@ entry:
   %136 = load i32, i32* %loc3
   %137 = sub i32 %135, %136
   %138 = sub i32 %134, %137
-  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %139
 
 ; <label>:139                                     ; preds = %132
   %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7728,16 +9141,16 @@ entry:
 
 ; <label>:144                                     ; preds = %139
   %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
-  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %146
 
 ; <label>:146                                     ; preds = %144
   %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
   %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
   %149 = load i32, i32* %loc2
   %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
-  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %151
 
 ; <label>:151                                     ; preds = %146
   %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
@@ -7754,145 +9167,249 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %18
+ThrowNullRef4:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %31
+ThrowNullRef10:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %44
+ThrowNullRef16:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %68
+ThrowNullRef18:                                   ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %70
+ThrowNullRef20:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %73
+ThrowNullRef22:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %83
+ThrowNullRef24:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %85
+ThrowNullRef26:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %88
+ThrowNullRef28:                                   ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %90
+ThrowNullRef30:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %94
+ThrowNullRef32:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %96
+ThrowNullRef34:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %100
+ThrowNullRef36:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %102
+ThrowNullRef38:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %106
+ThrowNullRef40:                                   ; preds = %106
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %108
+ThrowNullRef42:                                   ; preds = %108
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %112
+ThrowNullRef44:                                   ; preds = %112
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %118
+ThrowNullRef46:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %121
+ThrowNullRef48:                                   ; preds = %121
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %123
+ThrowNullRef50:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %130
+ThrowNullRef52:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %132
+ThrowNullRef54:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %144
+ThrowNullRef56:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %146
+ThrowNullRef58:                                   ; preds = %146
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %60
+ThrowNullRef60:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %63
+ThrowNullRef62:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %49
+ThrowNullRef64:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %51
+ThrowNullRef66:                                   ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %53
+ThrowNullRef68:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(%"System.Char[]" addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %arg0 = alloca %"System.Char[]" addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store %"System.Char[]" addrspace(1)* %param0, %"System.Char[]" addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load i32, i32* %arg4
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %43, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %38, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg1
+  %13 = load i32, i32* %arg4
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %38, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %24 = load i32, i32* %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %35 = load i32, i32* %arg3
+  %36 = load i32, i32* %arg4
+  %37 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %37, %"System.Char[]" addrspace(1)* %34, i32 %35, i32 %36)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:38                                      ; preds = %5, %16
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Successfully read Buffer._Memmove
 
@@ -7914,7 +9431,7 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[loadElem]
+Failed to read AppDomain.SetDataHelper[storeElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -7923,8 +9440,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
@@ -7934,8 +9451,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
@@ -7947,15 +9464,15 @@ entry:
   %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
   %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
@@ -7966,15 +9483,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7992,7 +9509,79 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
-Failed to read Dictionary`2.TryGetValue[loadElemA]
+Successfully read Dictionary`2.TryGetValue
+
+define i8 @"Dictionary`2.TryGetValue"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)* addrspace(1)* %param2) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  %arg2 = alloca %System.__Canon addrspace(1)* addrspace(1)*
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  store %System.__Canon addrspace(1)* addrspace(1)* %param2, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  store i32 %2, i32* %loc0
+  %3 = load i32, i32* %loc0
+  %4 = icmp slt i32 %3, 0
+  br i1 %4, label %22, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 2
+  %10 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %9, align 8
+  %11 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = zext i32 %11 to i64
+  %BoundsCheck = icmp uge i64 %16, %15
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 3, i32 %11
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %20, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %6, %System.__Canon addrspace(1)* %21)
+  ret i8 1
+
+; <label>:22                                      ; preds = %entry
+  %23 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %23, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -8058,8 +9647,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
@@ -8091,8 +9680,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
@@ -8171,15 +9760,15 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck, label %19, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %ThrowNullRef, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
   %21 = load i32, i32 addrspace(1)* %20
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
@@ -8202,7 +9791,7 @@ ThrowNullRef:                                     ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %19
+ThrowNullRef2:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8248,8 +9837,8 @@ entry:
   %0 = alloca %System.AppDomainHandle
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %1 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %1, i32 0, i32 15
@@ -8269,8 +9858,8 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
@@ -8286,7 +9875,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -8299,8 +9888,8 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -8327,8 +9916,8 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
@@ -8352,8 +9941,8 @@ entry:
   %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
   store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
@@ -8363,8 +9952,8 @@ entry:
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
@@ -8374,8 +9963,8 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %9
   %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
@@ -8384,8 +9973,8 @@ entry:
 
 ; <label>:18                                      ; preds = %3, %16
   %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
@@ -8397,15 +9986,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %18
+ThrowNullRef6:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8418,8 +10007,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
@@ -8453,15 +10042,15 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
@@ -8473,7 +10062,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8481,7 +10070,7 @@ ThrowNullRef1:                                    ; preds = %1
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
 Failed to read Dictionary`2.System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
@@ -8506,8 +10095,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
@@ -8524,8 +10113,8 @@ entry:
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -8544,7 +10133,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8577,8 +10166,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = load i64, i64* %arg2
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = trunc i32 %3 to i8
@@ -8634,46 +10223,46 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
   %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
-  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
-  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
-  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
@@ -8684,27 +10273,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %20
+ThrowNullRef12:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8717,8 +10306,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -8756,22 +10345,22 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
   %9 = load i64, i64 addrspace(1)* %8, align 8
   %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
   %13 = load i64, i64 addrspace(1)* %12, align 8
   %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %11
   %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
@@ -8788,11 +10377,11 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8882,8 +10471,8 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
@@ -8900,8 +10489,8 @@ entry:
 ; <label>:8                                       ; preds = %1
   %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
   %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
@@ -8911,15 +10500,15 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
   %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
   %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
-  br i1 %NullCheck6, label %21, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
@@ -8946,15 +10535,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8992,15 +10581,15 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
   store i8 %3, i8 addrspace(1)* %5
   %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
@@ -9011,7 +10600,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9027,8 +10616,8 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -9041,8 +10630,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
@@ -9058,7 +10647,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9080,8 +10669,8 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
@@ -9096,8 +10685,8 @@ entry:
 ; <label>:12                                      ; preds = %6
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
@@ -9112,8 +10701,8 @@ entry:
 ; <label>:21                                      ; preds = %15
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
@@ -9128,8 +10717,8 @@ entry:
 ; <label>:30                                      ; preds = %24
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %31, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
@@ -9144,8 +10733,8 @@ entry:
 ; <label>:39                                      ; preds = %33
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
-  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %40, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %42
 
 ; <label>:42                                      ; preds = %39
   %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
@@ -9164,19 +10753,19 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %21
+ThrowNullRef4:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %30
+ThrowNullRef6:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %39
+ThrowNullRef8:                                    ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9243,8 +10832,8 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
@@ -9264,57 +10853,57 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
   store i8 0, i8 addrspace(1)* %2
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
   store i8 0, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
   store i8 0, i8 addrspace(1)* %17
   %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
   store i8 0, i8 addrspace(1)* %20
   %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
-  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
@@ -9325,31 +10914,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %19
+ThrowNullRef14:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9367,8 +10956,8 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
@@ -9380,8 +10969,8 @@ entry:
 
 ; <label>:9                                       ; preds = %4
   %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %9
   %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
@@ -9395,7 +10984,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef2:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9420,8 +11009,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
@@ -9512,8 +11101,8 @@ entry:
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
@@ -9524,8 +11113,8 @@ entry:
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = load i64, i64 addrspace(1)* %12
@@ -9537,8 +11126,8 @@ entry:
   %20 = load i64, i64* %19
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
-  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %13
   %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
@@ -9555,8 +11144,8 @@ entry:
 ; <label>:30                                      ; preds = %25
   %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %32 = load i32, i32* %arg2
-  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
-  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
@@ -9570,15 +11159,15 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %30
+ThrowNullRef2:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9622,87 +11211,87 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
   %10 = load i8, i8 addrspace(1)* %9, align 8
   %11 = zext i8 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %8
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
   store i8 %12, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
   %19 = load i8, i8 addrspace(1)* %18, align 8
   %20 = zext i8 %19 to i32
   %21 = trunc i32 %20 to i8
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
   store i8 %21, i8 addrspace(1)* %23
   %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
   %28 = load i8, i8 addrspace(1)* %27, align 8
   %29 = zext i8 %28 to i32
   %30 = trunc i32 %29 to i8
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
-  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %31
 
 ; <label>:31                                      ; preds = %26
   %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
   store i8 %30, i8 addrspace(1)* %32
   %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
-  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
-  br i1 %NullCheck14, label %40, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %40
 
 ; <label>:40                                      ; preds = %35
   %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
   store i8 %39, i8 addrspace(1)* %41
   %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
-  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %44
 
 ; <label>:44                                      ; preds = %40
   %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
   %46 = load i8, i8 addrspace(1)* %45, align 8
   %47 = zext i8 %46 to i32
   %48 = trunc i32 %47 to i8
-  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
   store i8 %48, i8 addrspace(1)* %50
   %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
-  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
@@ -9713,29 +11302,29 @@ entry:
 ; <label>:56                                      ; preds = %52
   %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
-  br i1 %NullCheck22, label %59, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
   %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
   %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
-  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
-  br i1 %NullCheck24, label %63, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
   %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
-  br i1 %NullCheck26, label %66, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
   %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
-  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
-  br i1 %NullCheck28, label %69, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %69
 
 ; <label>:69                                      ; preds = %66
   %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
@@ -9744,15 +11333,15 @@ entry:
 
 ; <label>:71                                      ; preds = %105
   %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
-  br i1 %NullCheck34, label %73, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %73
 
 ; <label>:73                                      ; preds = %71
   %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
   %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
   %76 = load i32, i32* %loc0
-  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
-  br i1 %NullCheck36, label %77, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
@@ -9766,8 +11355,8 @@ entry:
 
 ; <label>:83                                      ; preds = %77
   %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
-  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
@@ -9775,14 +11364,14 @@ entry:
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
   %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
-  br i1 %NullCheck40, label %91, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
 ; <label>:91                                      ; preds = %85
   %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
   %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
-  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck42, label %94, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %94
 
 ; <label>:94                                      ; preds = %91
   %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
@@ -9798,14 +11387,14 @@ entry:
 ; <label>:99                                      ; preds = %69, %96
   %100 = load i32, i32* %loc0
   %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
-  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %102
 
 ; <label>:102                                     ; preds = %99
   %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
   %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
-  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
-  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
@@ -9819,87 +11408,87 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %26
+ThrowNullRef10:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %31
+ThrowNullRef12:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %35
+ThrowNullRef14:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %40
+ThrowNullRef16:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %56
+ThrowNullRef22:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %59
+ThrowNullRef24:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %63
+ThrowNullRef26:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %66
+ThrowNullRef28:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %102
+ThrowNullRef32:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %71
+ThrowNullRef34:                                   ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %73
+ThrowNullRef36:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %83
+ThrowNullRef38:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %85
+ThrowNullRef40:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %91
+ThrowNullRef42:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9943,15 +11532,15 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
   %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
@@ -9961,28 +11550,28 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
   %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %12
   %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
   %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
   %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
-  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
@@ -9993,23 +11582,23 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %12
+ThrowNullRef6:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10031,15 +11620,15 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
   %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = load i64, i64 addrspace(1)* %7
@@ -10077,13 +11666,13 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[loadElem]
+Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -10111,8 +11700,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -10184,8 +11773,8 @@ entry:
   store i32 addrspace(1)* %param1, i32 addrspace(1)** %arg1
   %0 = load i32, i32* %arg0
   %1 = load i32 addrspace(1)*, i32 addrspace(1)** %arg1
-  %NullCheck = icmp ne i32 addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq i32 addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load i32, i32 addrspace(1)* %1, align 8

--- a/test/BaseLine/JIT/CodeGenBringUpTests/mul1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/mul1.error.txt
@@ -25,8 +25,8 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
@@ -40,8 +40,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
   %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
@@ -75,7 +75,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -90,8 +90,8 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %NullCheck = icmp ne i8 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = load i8, i8 addrspace(1)* %0, align 8
@@ -125,8 +125,8 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
@@ -159,8 +159,8 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -184,8 +184,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
   store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
@@ -195,8 +195,8 @@ entry:
 ; <label>:4                                       ; preds = %1
   %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
   %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
@@ -206,8 +206,8 @@ entry:
   %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
@@ -221,14 +221,14 @@ entry:
 
 ; <label>:17                                      ; preds = %14
   %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
   %21 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
@@ -238,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -249,8 +249,8 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
@@ -261,27 +261,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %30
+ThrowNullRef10:                                   ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -301,7 +301,89 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
-Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
+Successfully read AppDomainSetup.GetUnsecureApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.GetUnsecureApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %NullCheck = icmp eq %"System.String[]" addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %BoundsCheck = icmp uge i64 0, %5
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %6
+
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 3, i32 0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
+  ret %System.String addrspace(1)* %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_Value using LLILCJit
+Successfully read AppDomainSetup.get_Value
+
+define %"System.String[]" addrspace(1)* @AppDomainSetup.get_Value(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.String[]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 18)
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.String[]" addrspace(1)* addrspace(1)*, %"System.String[]" addrspace(1)*)*)(%"System.String[]" addrspace(1)* addrspace(1)* %9, %"System.String[]" addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %11, i32 0, i32 1
+  %14 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %13, align 8
+  ret %"System.String[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -319,8 +401,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -368,16 +450,16 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
   %5 = load i32, i32 addrspace(1)* %4
   %6 = sub i32 %5, 1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -389,7 +471,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -421,8 +503,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
@@ -456,8 +538,8 @@ entry:
 ; <label>:27                                      ; preds = %19
   %28 = load i32, i32* %arg1
   %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
-  br i1 %NullCheck2, label %30, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %29, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %30
 
 ; <label>:30                                      ; preds = %27
   %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
@@ -493,8 +575,8 @@ entry:
 ; <label>:49                                      ; preds = %46
   %50 = load i32, i32* %arg2
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck4, label %52, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
@@ -517,11 +599,11 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %27
+ThrowNullRef2:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %49
+ThrowNullRef4:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -544,16 +626,16 @@ entry:
   %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %0)
   store %System.String addrspace(1)* %1, %System.String addrspace(1)** %loc0
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 2
   %5 = bitcast [0 x i16] addrspace(1)* %4 to i16 addrspace(1)*
   store i16 addrspace(1)* %5, i16 addrspace(1)** %loc1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %3
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2
@@ -580,7 +662,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -691,15 +773,15 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %NullCheck132 = icmp ne i8* %21, null
-  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+  %NullCheck131 = icmp eq i8* %21, null
+  br i1 %NullCheck131, label %ThrowNullRef132, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = load i8, i8* %21, align 8
   %24 = zext i8 %23 to i32
   %25 = trunc i32 %24 to i8
-  %NullCheck134 = icmp ne i8* %20, null
-  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+  %NullCheck133 = icmp eq i8* %20, null
+  br i1 %NullCheck133, label %ThrowNullRef134, label %26
 
 ; <label>:26                                      ; preds = %22
   store i8 %25, i8* %20, align 8
@@ -709,16 +791,16 @@ entry:
   %28 = load i8*, i8** %arg0
   %29 = load i8*, i8** %arg1
   %30 = bitcast i8* %29 to i16*
-  %NullCheck128 = icmp ne i16* %30, null
-  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+  %NullCheck127 = icmp eq i16* %30, null
+  br i1 %NullCheck127, label %ThrowNullRef128, label %31
 
 ; <label>:31                                      ; preds = %27
   %32 = load i16, i16* %30, align 8
   %33 = sext i16 %32 to i32
   %34 = bitcast i8* %28 to i16*
   %35 = trunc i32 %33 to i16
-  %NullCheck130 = icmp ne i16* %34, null
-  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+  %NullCheck129 = icmp eq i16* %34, null
+  br i1 %NullCheck129, label %ThrowNullRef130, label %36
 
 ; <label>:36                                      ; preds = %31
   store i16 %35, i16* %34, align 8
@@ -728,16 +810,16 @@ entry:
   %38 = load i8*, i8** %arg0
   %39 = load i8*, i8** %arg1
   %40 = bitcast i8* %39 to i16*
-  %NullCheck120 = icmp ne i16* %40, null
-  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+  %NullCheck119 = icmp eq i16* %40, null
+  br i1 %NullCheck119, label %ThrowNullRef120, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i16, i16* %40, align 8
   %43 = sext i16 %42 to i32
   %44 = bitcast i8* %38 to i16*
   %45 = trunc i32 %43 to i16
-  %NullCheck122 = icmp ne i16* %44, null
-  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+  %NullCheck121 = icmp eq i16* %44, null
+  br i1 %NullCheck121, label %ThrowNullRef122, label %46
 
 ; <label>:46                                      ; preds = %41
   store i16 %45, i16* %44, align 8
@@ -745,15 +827,15 @@ entry:
   %48 = getelementptr inbounds i8, i8* %47, i64 2
   %49 = load i8*, i8** %arg1
   %50 = getelementptr inbounds i8, i8* %49, i64 2
-  %NullCheck124 = icmp ne i8* %50, null
-  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+  %NullCheck123 = icmp eq i8* %50, null
+  br i1 %NullCheck123, label %ThrowNullRef124, label %51
 
 ; <label>:51                                      ; preds = %46
   %52 = load i8, i8* %50, align 8
   %53 = zext i8 %52 to i32
   %54 = trunc i32 %53 to i8
-  %NullCheck126 = icmp ne i8* %48, null
-  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+  %NullCheck125 = icmp eq i8* %48, null
+  br i1 %NullCheck125, label %ThrowNullRef126, label %55
 
 ; <label>:55                                      ; preds = %51
   store i8 %54, i8* %48, align 8
@@ -763,14 +845,14 @@ entry:
   %57 = load i8*, i8** %arg0
   %58 = load i8*, i8** %arg1
   %59 = bitcast i8* %58 to i32*
-  %NullCheck116 = icmp ne i32* %59, null
-  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+  %NullCheck115 = icmp eq i32* %59, null
+  br i1 %NullCheck115, label %ThrowNullRef116, label %60
 
 ; <label>:60                                      ; preds = %56
   %61 = load i32, i32* %59, align 8
   %62 = bitcast i8* %57 to i32*
-  %NullCheck118 = icmp ne i32* %62, null
-  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+  %NullCheck117 = icmp eq i32* %62, null
+  br i1 %NullCheck117, label %ThrowNullRef118, label %63
 
 ; <label>:63                                      ; preds = %60
   store i32 %61, i32* %62, align 8
@@ -780,14 +862,14 @@ entry:
   %65 = load i8*, i8** %arg0
   %66 = load i8*, i8** %arg1
   %67 = bitcast i8* %66 to i32*
-  %NullCheck108 = icmp ne i32* %67, null
-  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+  %NullCheck107 = icmp eq i32* %67, null
+  br i1 %NullCheck107, label %ThrowNullRef108, label %68
 
 ; <label>:68                                      ; preds = %64
   %69 = load i32, i32* %67, align 8
   %70 = bitcast i8* %65 to i32*
-  %NullCheck110 = icmp ne i32* %70, null
-  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+  %NullCheck109 = icmp eq i32* %70, null
+  br i1 %NullCheck109, label %ThrowNullRef110, label %71
 
 ; <label>:71                                      ; preds = %68
   store i32 %69, i32* %70, align 8
@@ -795,15 +877,15 @@ entry:
   %73 = getelementptr inbounds i8, i8* %72, i64 4
   %74 = load i8*, i8** %arg1
   %75 = getelementptr inbounds i8, i8* %74, i64 4
-  %NullCheck112 = icmp ne i8* %75, null
-  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+  %NullCheck111 = icmp eq i8* %75, null
+  br i1 %NullCheck111, label %ThrowNullRef112, label %76
 
 ; <label>:76                                      ; preds = %71
   %77 = load i8, i8* %75, align 8
   %78 = zext i8 %77 to i32
   %79 = trunc i32 %78 to i8
-  %NullCheck114 = icmp ne i8* %73, null
-  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+  %NullCheck113 = icmp eq i8* %73, null
+  br i1 %NullCheck113, label %ThrowNullRef114, label %80
 
 ; <label>:80                                      ; preds = %76
   store i8 %79, i8* %73, align 8
@@ -813,14 +895,14 @@ entry:
   %82 = load i8*, i8** %arg0
   %83 = load i8*, i8** %arg1
   %84 = bitcast i8* %83 to i32*
-  %NullCheck100 = icmp ne i32* %84, null
-  br i1 %NullCheck100, label %85, label %ThrowNullRef99
+  %NullCheck99 = icmp eq i32* %84, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %85
 
 ; <label>:85                                      ; preds = %81
   %86 = load i32, i32* %84, align 8
   %87 = bitcast i8* %82 to i32*
-  %NullCheck102 = icmp ne i32* %87, null
-  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+  %NullCheck101 = icmp eq i32* %87, null
+  br i1 %NullCheck101, label %ThrowNullRef102, label %88
 
 ; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
@@ -829,16 +911,16 @@ entry:
   %91 = load i8*, i8** %arg1
   %92 = getelementptr inbounds i8, i8* %91, i64 4
   %93 = bitcast i8* %92 to i16*
-  %NullCheck104 = icmp ne i16* %93, null
-  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+  %NullCheck103 = icmp eq i16* %93, null
+  br i1 %NullCheck103, label %ThrowNullRef104, label %94
 
 ; <label>:94                                      ; preds = %88
   %95 = load i16, i16* %93, align 8
   %96 = sext i16 %95 to i32
   %97 = bitcast i8* %90 to i16*
   %98 = trunc i32 %96 to i16
-  %NullCheck106 = icmp ne i16* %97, null
-  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+  %NullCheck105 = icmp eq i16* %97, null
+  br i1 %NullCheck105, label %ThrowNullRef106, label %99
 
 ; <label>:99                                      ; preds = %94
   store i16 %98, i16* %97, align 8
@@ -848,14 +930,14 @@ entry:
   %101 = load i8*, i8** %arg0
   %102 = load i8*, i8** %arg1
   %103 = bitcast i8* %102 to i32*
-  %NullCheck88 = icmp ne i32* %103, null
-  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+  %NullCheck87 = icmp eq i32* %103, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %104
 
 ; <label>:104                                     ; preds = %100
   %105 = load i32, i32* %103, align 8
   %106 = bitcast i8* %101 to i32*
-  %NullCheck90 = icmp ne i32* %106, null
-  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+  %NullCheck89 = icmp eq i32* %106, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %107
 
 ; <label>:107                                     ; preds = %104
   store i32 %105, i32* %106, align 8
@@ -864,16 +946,16 @@ entry:
   %110 = load i8*, i8** %arg1
   %111 = getelementptr inbounds i8, i8* %110, i64 4
   %112 = bitcast i8* %111 to i16*
-  %NullCheck92 = icmp ne i16* %112, null
-  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+  %NullCheck91 = icmp eq i16* %112, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %113
 
 ; <label>:113                                     ; preds = %107
   %114 = load i16, i16* %112, align 8
   %115 = sext i16 %114 to i32
   %116 = bitcast i8* %109 to i16*
   %117 = trunc i32 %115 to i16
-  %NullCheck94 = icmp ne i16* %116, null
-  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+  %NullCheck93 = icmp eq i16* %116, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %118
 
 ; <label>:118                                     ; preds = %113
   store i16 %117, i16* %116, align 8
@@ -881,15 +963,15 @@ entry:
   %120 = getelementptr inbounds i8, i8* %119, i64 6
   %121 = load i8*, i8** %arg1
   %122 = getelementptr inbounds i8, i8* %121, i64 6
-  %NullCheck96 = icmp ne i8* %122, null
-  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+  %NullCheck95 = icmp eq i8* %122, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %123
 
 ; <label>:123                                     ; preds = %118
   %124 = load i8, i8* %122, align 8
   %125 = zext i8 %124 to i32
   %126 = trunc i32 %125 to i8
-  %NullCheck98 = icmp ne i8* %120, null
-  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+  %NullCheck97 = icmp eq i8* %120, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %127
 
 ; <label>:127                                     ; preds = %123
   store i8 %126, i8* %120, align 8
@@ -899,14 +981,14 @@ entry:
   %129 = load i8*, i8** %arg0
   %130 = load i8*, i8** %arg1
   %131 = bitcast i8* %130 to i64*
-  %NullCheck84 = icmp ne i64* %131, null
-  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+  %NullCheck83 = icmp eq i64* %131, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %132
 
 ; <label>:132                                     ; preds = %128
   %133 = load i64, i64* %131, align 8
   %134 = bitcast i8* %129 to i64*
-  %NullCheck86 = icmp ne i64* %134, null
-  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+  %NullCheck85 = icmp eq i64* %134, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %135
 
 ; <label>:135                                     ; preds = %132
   store i64 %133, i64* %134, align 8
@@ -916,14 +998,14 @@ entry:
   %137 = load i8*, i8** %arg0
   %138 = load i8*, i8** %arg1
   %139 = bitcast i8* %138 to i64*
-  %NullCheck76 = icmp ne i64* %139, null
-  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+  %NullCheck75 = icmp eq i64* %139, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %140
 
 ; <label>:140                                     ; preds = %136
   %141 = load i64, i64* %139, align 8
   %142 = bitcast i8* %137 to i64*
-  %NullCheck78 = icmp ne i64* %142, null
-  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+  %NullCheck77 = icmp eq i64* %142, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %143
 
 ; <label>:143                                     ; preds = %140
   store i64 %141, i64* %142, align 8
@@ -931,15 +1013,15 @@ entry:
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %NullCheck80 = icmp ne i8* %147, null
-  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+  %NullCheck79 = icmp eq i8* %147, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %148
 
 ; <label>:148                                     ; preds = %143
   %149 = load i8, i8* %147, align 8
   %150 = zext i8 %149 to i32
   %151 = trunc i32 %150 to i8
-  %NullCheck82 = icmp ne i8* %145, null
-  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+  %NullCheck81 = icmp eq i8* %145, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %152
 
 ; <label>:152                                     ; preds = %148
   store i8 %151, i8* %145, align 8
@@ -949,14 +1031,14 @@ entry:
   %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
   %156 = bitcast i8* %155 to i64*
-  %NullCheck68 = icmp ne i64* %156, null
-  br i1 %NullCheck68, label %157, label %ThrowNullRef67
+  %NullCheck67 = icmp eq i64* %156, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %157
 
 ; <label>:157                                     ; preds = %153
   %158 = load i64, i64* %156, align 8
   %159 = bitcast i8* %154 to i64*
-  %NullCheck70 = icmp ne i64* %159, null
-  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+  %NullCheck69 = icmp eq i64* %159, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %160
 
 ; <label>:160                                     ; preds = %157
   store i64 %158, i64* %159, align 8
@@ -965,16 +1047,16 @@ entry:
   %163 = load i8*, i8** %arg1
   %164 = getelementptr inbounds i8, i8* %163, i64 8
   %165 = bitcast i8* %164 to i16*
-  %NullCheck72 = icmp ne i16* %165, null
-  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+  %NullCheck71 = icmp eq i16* %165, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %166
 
 ; <label>:166                                     ; preds = %160
   %167 = load i16, i16* %165, align 8
   %168 = sext i16 %167 to i32
   %169 = bitcast i8* %162 to i16*
   %170 = trunc i32 %168 to i16
-  %NullCheck74 = icmp ne i16* %169, null
-  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+  %NullCheck73 = icmp eq i16* %169, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %171
 
 ; <label>:171                                     ; preds = %166
   store i16 %170, i16* %169, align 8
@@ -984,14 +1066,14 @@ entry:
   %173 = load i8*, i8** %arg0
   %174 = load i8*, i8** %arg1
   %175 = bitcast i8* %174 to i64*
-  %NullCheck56 = icmp ne i64* %175, null
-  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+  %NullCheck55 = icmp eq i64* %175, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %176
 
 ; <label>:176                                     ; preds = %172
   %177 = load i64, i64* %175, align 8
   %178 = bitcast i8* %173 to i64*
-  %NullCheck58 = icmp ne i64* %178, null
-  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+  %NullCheck57 = icmp eq i64* %178, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %179
 
 ; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
@@ -1000,16 +1082,16 @@ entry:
   %182 = load i8*, i8** %arg1
   %183 = getelementptr inbounds i8, i8* %182, i64 8
   %184 = bitcast i8* %183 to i16*
-  %NullCheck60 = icmp ne i16* %184, null
-  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+  %NullCheck59 = icmp eq i16* %184, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %185
 
 ; <label>:185                                     ; preds = %179
   %186 = load i16, i16* %184, align 8
   %187 = sext i16 %186 to i32
   %188 = bitcast i8* %181 to i16*
   %189 = trunc i32 %187 to i16
-  %NullCheck62 = icmp ne i16* %188, null
-  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+  %NullCheck61 = icmp eq i16* %188, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %190
 
 ; <label>:190                                     ; preds = %185
   store i16 %189, i16* %188, align 8
@@ -1017,15 +1099,15 @@ entry:
   %192 = getelementptr inbounds i8, i8* %191, i64 10
   %193 = load i8*, i8** %arg1
   %194 = getelementptr inbounds i8, i8* %193, i64 10
-  %NullCheck64 = icmp ne i8* %194, null
-  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+  %NullCheck63 = icmp eq i8* %194, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %195
 
 ; <label>:195                                     ; preds = %190
   %196 = load i8, i8* %194, align 8
   %197 = zext i8 %196 to i32
   %198 = trunc i32 %197 to i8
-  %NullCheck66 = icmp ne i8* %192, null
-  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+  %NullCheck65 = icmp eq i8* %192, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %199
 
 ; <label>:199                                     ; preds = %195
   store i8 %198, i8* %192, align 8
@@ -1035,14 +1117,14 @@ entry:
   %201 = load i8*, i8** %arg0
   %202 = load i8*, i8** %arg1
   %203 = bitcast i8* %202 to i64*
-  %NullCheck48 = icmp ne i64* %203, null
-  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+  %NullCheck47 = icmp eq i64* %203, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %204
 
 ; <label>:204                                     ; preds = %200
   %205 = load i64, i64* %203, align 8
   %206 = bitcast i8* %201 to i64*
-  %NullCheck50 = icmp ne i64* %206, null
-  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+  %NullCheck49 = icmp eq i64* %206, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %207
 
 ; <label>:207                                     ; preds = %204
   store i64 %205, i64* %206, align 8
@@ -1051,14 +1133,14 @@ entry:
   %210 = load i8*, i8** %arg1
   %211 = getelementptr inbounds i8, i8* %210, i64 8
   %212 = bitcast i8* %211 to i32*
-  %NullCheck52 = icmp ne i32* %212, null
-  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+  %NullCheck51 = icmp eq i32* %212, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %213
 
 ; <label>:213                                     ; preds = %207
   %214 = load i32, i32* %212, align 8
   %215 = bitcast i8* %209 to i32*
-  %NullCheck54 = icmp ne i32* %215, null
-  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+  %NullCheck53 = icmp eq i32* %215, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %216
 
 ; <label>:216                                     ; preds = %213
   store i32 %214, i32* %215, align 8
@@ -1068,14 +1150,14 @@ entry:
   %218 = load i8*, i8** %arg0
   %219 = load i8*, i8** %arg1
   %220 = bitcast i8* %219 to i64*
-  %NullCheck36 = icmp ne i64* %220, null
-  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64* %220, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %221
 
 ; <label>:221                                     ; preds = %217
   %222 = load i64, i64* %220, align 8
   %223 = bitcast i8* %218 to i64*
-  %NullCheck38 = icmp ne i64* %223, null
-  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+  %NullCheck37 = icmp eq i64* %223, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %224
 
 ; <label>:224                                     ; preds = %221
   store i64 %222, i64* %223, align 8
@@ -1084,14 +1166,14 @@ entry:
   %227 = load i8*, i8** %arg1
   %228 = getelementptr inbounds i8, i8* %227, i64 8
   %229 = bitcast i8* %228 to i32*
-  %NullCheck40 = icmp ne i32* %229, null
-  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i32* %229, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %230
 
 ; <label>:230                                     ; preds = %224
   %231 = load i32, i32* %229, align 8
   %232 = bitcast i8* %226 to i32*
-  %NullCheck42 = icmp ne i32* %232, null
-  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+  %NullCheck41 = icmp eq i32* %232, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %233
 
 ; <label>:233                                     ; preds = %230
   store i32 %231, i32* %232, align 8
@@ -1099,15 +1181,15 @@ entry:
   %235 = getelementptr inbounds i8, i8* %234, i64 12
   %236 = load i8*, i8** %arg1
   %237 = getelementptr inbounds i8, i8* %236, i64 12
-  %NullCheck44 = icmp ne i8* %237, null
-  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i8* %237, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %238
 
 ; <label>:238                                     ; preds = %233
   %239 = load i8, i8* %237, align 8
   %240 = zext i8 %239 to i32
   %241 = trunc i32 %240 to i8
-  %NullCheck46 = icmp ne i8* %235, null
-  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+  %NullCheck45 = icmp eq i8* %235, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %242
 
 ; <label>:242                                     ; preds = %238
   store i8 %241, i8* %235, align 8
@@ -1117,14 +1199,14 @@ entry:
   %244 = load i8*, i8** %arg0
   %245 = load i8*, i8** %arg1
   %246 = bitcast i8* %245 to i64*
-  %NullCheck24 = icmp ne i64* %246, null
-  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64* %246, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %247
 
 ; <label>:247                                     ; preds = %243
   %248 = load i64, i64* %246, align 8
   %249 = bitcast i8* %244 to i64*
-  %NullCheck26 = icmp ne i64* %249, null
-  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64* %249, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %250
 
 ; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
@@ -1133,14 +1215,14 @@ entry:
   %253 = load i8*, i8** %arg1
   %254 = getelementptr inbounds i8, i8* %253, i64 8
   %255 = bitcast i8* %254 to i32*
-  %NullCheck28 = icmp ne i32* %255, null
-  br i1 %NullCheck28, label %256, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i32* %255, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %256
 
 ; <label>:256                                     ; preds = %250
   %257 = load i32, i32* %255, align 8
   %258 = bitcast i8* %252 to i32*
-  %NullCheck30 = icmp ne i32* %258, null
-  br i1 %NullCheck30, label %259, label %ThrowNullRef29
+  %NullCheck29 = icmp eq i32* %258, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %259
 
 ; <label>:259                                     ; preds = %256
   store i32 %257, i32* %258, align 8
@@ -1149,16 +1231,16 @@ entry:
   %262 = load i8*, i8** %arg1
   %263 = getelementptr inbounds i8, i8* %262, i64 12
   %264 = bitcast i8* %263 to i16*
-  %NullCheck32 = icmp ne i16* %264, null
-  br i1 %NullCheck32, label %265, label %ThrowNullRef31
+  %NullCheck31 = icmp eq i16* %264, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %265
 
 ; <label>:265                                     ; preds = %259
   %266 = load i16, i16* %264, align 8
   %267 = sext i16 %266 to i32
   %268 = bitcast i8* %261 to i16*
   %269 = trunc i32 %267 to i16
-  %NullCheck34 = icmp ne i16* %268, null
-  br i1 %NullCheck34, label %270, label %ThrowNullRef33
+  %NullCheck33 = icmp eq i16* %268, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %270
 
 ; <label>:270                                     ; preds = %265
   store i16 %269, i16* %268, align 8
@@ -1168,14 +1250,14 @@ entry:
   %272 = load i8*, i8** %arg0
   %273 = load i8*, i8** %arg1
   %274 = bitcast i8* %273 to i64*
-  %NullCheck8 = icmp ne i64* %274, null
-  br i1 %NullCheck8, label %275, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64* %274, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %275
 
 ; <label>:275                                     ; preds = %271
   %276 = load i64, i64* %274, align 8
   %277 = bitcast i8* %272 to i64*
-  %NullCheck10 = icmp ne i64* %277, null
-  br i1 %NullCheck10, label %278, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %277, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %278
 
 ; <label>:278                                     ; preds = %275
   store i64 %276, i64* %277, align 8
@@ -1184,14 +1266,14 @@ entry:
   %281 = load i8*, i8** %arg1
   %282 = getelementptr inbounds i8, i8* %281, i64 8
   %283 = bitcast i8* %282 to i32*
-  %NullCheck12 = icmp ne i32* %283, null
-  br i1 %NullCheck12, label %284, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i32* %283, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %284
 
 ; <label>:284                                     ; preds = %278
   %285 = load i32, i32* %283, align 8
   %286 = bitcast i8* %280 to i32*
-  %NullCheck14 = icmp ne i32* %286, null
-  br i1 %NullCheck14, label %287, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i32* %286, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %287
 
 ; <label>:287                                     ; preds = %284
   store i32 %285, i32* %286, align 8
@@ -1200,16 +1282,16 @@ entry:
   %290 = load i8*, i8** %arg1
   %291 = getelementptr inbounds i8, i8* %290, i64 12
   %292 = bitcast i8* %291 to i16*
-  %NullCheck16 = icmp ne i16* %292, null
-  br i1 %NullCheck16, label %293, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i16* %292, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %293
 
 ; <label>:293                                     ; preds = %287
   %294 = load i16, i16* %292, align 8
   %295 = sext i16 %294 to i32
   %296 = bitcast i8* %289 to i16*
   %297 = trunc i32 %295 to i16
-  %NullCheck18 = icmp ne i16* %296, null
-  br i1 %NullCheck18, label %298, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i16* %296, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %298
 
 ; <label>:298                                     ; preds = %293
   store i16 %297, i16* %296, align 8
@@ -1217,15 +1299,15 @@ entry:
   %300 = getelementptr inbounds i8, i8* %299, i64 14
   %301 = load i8*, i8** %arg1
   %302 = getelementptr inbounds i8, i8* %301, i64 14
-  %NullCheck20 = icmp ne i8* %302, null
-  br i1 %NullCheck20, label %303, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i8* %302, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %303
 
 ; <label>:303                                     ; preds = %298
   %304 = load i8, i8* %302, align 8
   %305 = zext i8 %304 to i32
   %306 = trunc i32 %305 to i8
-  %NullCheck22 = icmp ne i8* %300, null
-  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i8* %300, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %307
 
 ; <label>:307                                     ; preds = %303
   store i8 %306, i8* %300, align 8
@@ -1235,14 +1317,14 @@ entry:
   %309 = load i8*, i8** %arg0
   %310 = load i8*, i8** %arg1
   %311 = bitcast i8* %310 to i64*
-  %NullCheck = icmp ne i64* %311, null
-  br i1 %NullCheck, label %312, label %ThrowNullRef
+  %NullCheck = icmp eq i64* %311, null
+  br i1 %NullCheck, label %ThrowNullRef, label %312
 
 ; <label>:312                                     ; preds = %308
   %313 = load i64, i64* %311, align 8
   %314 = bitcast i8* %309 to i64*
-  %NullCheck2 = icmp ne i64* %314, null
-  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64* %314, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %315
 
 ; <label>:315                                     ; preds = %312
   store i64 %313, i64* %314, align 8
@@ -1251,14 +1333,14 @@ entry:
   %318 = load i8*, i8** %arg1
   %319 = getelementptr inbounds i8, i8* %318, i64 8
   %320 = bitcast i8* %319 to i64*
-  %NullCheck4 = icmp ne i64* %320, null
-  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64* %320, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %321
 
 ; <label>:321                                     ; preds = %315
   %322 = load i64, i64* %320, align 8
   %323 = bitcast i8* %317 to i64*
-  %NullCheck6 = icmp ne i64* %323, null
-  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64* %323, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %324
 
 ; <label>:324                                     ; preds = %321
   store i64 %322, i64* %323, align 8
@@ -1286,15 +1368,15 @@ entry:
 ; <label>:338                                     ; preds = %333
   %339 = load i8*, i8** %arg0
   %340 = load i8*, i8** %arg1
-  %NullCheck136 = icmp ne i8* %340, null
-  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+  %NullCheck135 = icmp eq i8* %340, null
+  br i1 %NullCheck135, label %ThrowNullRef136, label %341
 
 ; <label>:341                                     ; preds = %338
   %342 = load i8, i8* %340, align 8
   %343 = zext i8 %342 to i32
   %344 = trunc i32 %343 to i8
-  %NullCheck138 = icmp ne i8* %339, null
-  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+  %NullCheck137 = icmp eq i8* %339, null
+  br i1 %NullCheck137, label %ThrowNullRef138, label %345
 
 ; <label>:345                                     ; preds = %341
   store i8 %344, i8* %339, align 8
@@ -1317,16 +1399,16 @@ entry:
   %357 = load i8*, i8** %arg0
   %358 = load i8*, i8** %arg1
   %359 = bitcast i8* %358 to i16*
-  %NullCheck140 = icmp ne i16* %359, null
-  br i1 %NullCheck140, label %360, label %ThrowNullRef139
+  %NullCheck139 = icmp eq i16* %359, null
+  br i1 %NullCheck139, label %ThrowNullRef140, label %360
 
 ; <label>:360                                     ; preds = %356
   %361 = load i16, i16* %359, align 8
   %362 = sext i16 %361 to i32
   %363 = bitcast i8* %357 to i16*
   %364 = trunc i32 %362 to i16
-  %NullCheck142 = icmp ne i16* %363, null
-  br i1 %NullCheck142, label %365, label %ThrowNullRef141
+  %NullCheck141 = icmp eq i16* %363, null
+  br i1 %NullCheck141, label %ThrowNullRef142, label %365
 
 ; <label>:365                                     ; preds = %360
   store i16 %364, i16* %363, align 8
@@ -1352,14 +1434,14 @@ entry:
   %378 = load i8*, i8** %arg0
   %379 = load i8*, i8** %arg1
   %380 = bitcast i8* %379 to i32*
-  %NullCheck144 = icmp ne i32* %380, null
-  br i1 %NullCheck144, label %381, label %ThrowNullRef143
+  %NullCheck143 = icmp eq i32* %380, null
+  br i1 %NullCheck143, label %ThrowNullRef144, label %381
 
 ; <label>:381                                     ; preds = %377
   %382 = load i32, i32* %380, align 8
   %383 = bitcast i8* %378 to i32*
-  %NullCheck146 = icmp ne i32* %383, null
-  br i1 %NullCheck146, label %384, label %ThrowNullRef145
+  %NullCheck145 = icmp eq i32* %383, null
+  br i1 %NullCheck145, label %ThrowNullRef146, label %384
 
 ; <label>:384                                     ; preds = %381
   store i32 %382, i32* %383, align 8
@@ -1384,14 +1466,14 @@ entry:
   %395 = load i8*, i8** %arg0
   %396 = load i8*, i8** %arg1
   %397 = bitcast i8* %396 to i64*
-  %NullCheck164 = icmp ne i64* %397, null
-  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+  %NullCheck163 = icmp eq i64* %397, null
+  br i1 %NullCheck163, label %ThrowNullRef164, label %398
 
 ; <label>:398                                     ; preds = %394
   %399 = load i64, i64* %397, align 8
   %400 = bitcast i8* %395 to i64*
-  %NullCheck166 = icmp ne i64* %400, null
-  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+  %NullCheck165 = icmp eq i64* %400, null
+  br i1 %NullCheck165, label %ThrowNullRef166, label %401
 
 ; <label>:401                                     ; preds = %398
   store i64 %399, i64* %400, align 8
@@ -1400,14 +1482,14 @@ entry:
   %404 = load i8*, i8** %arg1
   %405 = getelementptr inbounds i8, i8* %404, i64 8
   %406 = bitcast i8* %405 to i64*
-  %NullCheck168 = icmp ne i64* %406, null
-  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+  %NullCheck167 = icmp eq i64* %406, null
+  br i1 %NullCheck167, label %ThrowNullRef168, label %407
 
 ; <label>:407                                     ; preds = %401
   %408 = load i64, i64* %406, align 8
   %409 = bitcast i8* %403 to i64*
-  %NullCheck170 = icmp ne i64* %409, null
-  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+  %NullCheck169 = icmp eq i64* %409, null
+  br i1 %NullCheck169, label %ThrowNullRef170, label %410
 
 ; <label>:410                                     ; preds = %407
   store i64 %408, i64* %409, align 8
@@ -1437,14 +1519,14 @@ entry:
   %425 = load i8*, i8** %arg0
   %426 = load i8*, i8** %arg1
   %427 = bitcast i8* %426 to i64*
-  %NullCheck148 = icmp ne i64* %427, null
-  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+  %NullCheck147 = icmp eq i64* %427, null
+  br i1 %NullCheck147, label %ThrowNullRef148, label %428
 
 ; <label>:428                                     ; preds = %424
   %429 = load i64, i64* %427, align 8
   %430 = bitcast i8* %425 to i64*
-  %NullCheck150 = icmp ne i64* %430, null
-  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+  %NullCheck149 = icmp eq i64* %430, null
+  br i1 %NullCheck149, label %ThrowNullRef150, label %431
 
 ; <label>:431                                     ; preds = %428
   store i64 %429, i64* %430, align 8
@@ -1466,14 +1548,14 @@ entry:
   %441 = load i8*, i8** %arg0
   %442 = load i8*, i8** %arg1
   %443 = bitcast i8* %442 to i32*
-  %NullCheck152 = icmp ne i32* %443, null
-  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+  %NullCheck151 = icmp eq i32* %443, null
+  br i1 %NullCheck151, label %ThrowNullRef152, label %444
 
 ; <label>:444                                     ; preds = %440
   %445 = load i32, i32* %443, align 8
   %446 = bitcast i8* %441 to i32*
-  %NullCheck154 = icmp ne i32* %446, null
-  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+  %NullCheck153 = icmp eq i32* %446, null
+  br i1 %NullCheck153, label %ThrowNullRef154, label %447
 
 ; <label>:447                                     ; preds = %444
   store i32 %445, i32* %446, align 8
@@ -1495,16 +1577,16 @@ entry:
   %457 = load i8*, i8** %arg0
   %458 = load i8*, i8** %arg1
   %459 = bitcast i8* %458 to i16*
-  %NullCheck156 = icmp ne i16* %459, null
-  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+  %NullCheck155 = icmp eq i16* %459, null
+  br i1 %NullCheck155, label %ThrowNullRef156, label %460
 
 ; <label>:460                                     ; preds = %456
   %461 = load i16, i16* %459, align 8
   %462 = sext i16 %461 to i32
   %463 = bitcast i8* %457 to i16*
   %464 = trunc i32 %462 to i16
-  %NullCheck158 = icmp ne i16* %463, null
-  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+  %NullCheck157 = icmp eq i16* %463, null
+  br i1 %NullCheck157, label %ThrowNullRef158, label %465
 
 ; <label>:465                                     ; preds = %460
   store i16 %464, i16* %463, align 8
@@ -1525,15 +1607,15 @@ entry:
 ; <label>:474                                     ; preds = %470
   %475 = load i8*, i8** %arg0
   %476 = load i8*, i8** %arg1
-  %NullCheck160 = icmp ne i8* %476, null
-  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+  %NullCheck159 = icmp eq i8* %476, null
+  br i1 %NullCheck159, label %ThrowNullRef160, label %477
 
 ; <label>:477                                     ; preds = %474
   %478 = load i8, i8* %476, align 8
   %479 = zext i8 %478 to i32
   %480 = trunc i32 %479 to i8
-  %NullCheck162 = icmp ne i8* %475, null
-  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+  %NullCheck161 = icmp eq i8* %475, null
+  br i1 %NullCheck161, label %ThrowNullRef162, label %481
 
 ; <label>:481                                     ; preds = %477
   store i8 %480, i8* %475, align 8
@@ -1553,343 +1635,343 @@ ThrowNullRef:                                     ; preds = %308
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %312
+ThrowNullRef2:                                    ; preds = %312
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %315
+ThrowNullRef4:                                    ; preds = %315
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %321
+ThrowNullRef6:                                    ; preds = %321
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %271
+ThrowNullRef8:                                    ; preds = %271
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %275
+ThrowNullRef10:                                   ; preds = %275
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %278
+ThrowNullRef12:                                   ; preds = %278
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %284
+ThrowNullRef14:                                   ; preds = %284
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %287
+ThrowNullRef16:                                   ; preds = %287
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %293
+ThrowNullRef18:                                   ; preds = %293
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %298
+ThrowNullRef20:                                   ; preds = %298
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %303
+ThrowNullRef22:                                   ; preds = %303
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %243
+ThrowNullRef24:                                   ; preds = %243
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %247
+ThrowNullRef26:                                   ; preds = %247
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %250
+ThrowNullRef28:                                   ; preds = %250
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %256
+ThrowNullRef30:                                   ; preds = %256
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %259
+ThrowNullRef32:                                   ; preds = %259
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %265
+ThrowNullRef34:                                   ; preds = %265
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %217
+ThrowNullRef36:                                   ; preds = %217
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %221
+ThrowNullRef38:                                   ; preds = %221
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %224
+ThrowNullRef40:                                   ; preds = %224
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %230
+ThrowNullRef42:                                   ; preds = %230
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %233
+ThrowNullRef44:                                   ; preds = %233
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %238
+ThrowNullRef46:                                   ; preds = %238
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %200
+ThrowNullRef48:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %204
+ThrowNullRef50:                                   ; preds = %204
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %207
+ThrowNullRef52:                                   ; preds = %207
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %213
+ThrowNullRef54:                                   ; preds = %213
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %172
+ThrowNullRef56:                                   ; preds = %172
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %176
+ThrowNullRef58:                                   ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %179
+ThrowNullRef60:                                   ; preds = %179
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %185
+ThrowNullRef62:                                   ; preds = %185
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %190
+ThrowNullRef64:                                   ; preds = %190
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %195
+ThrowNullRef66:                                   ; preds = %195
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %153
+ThrowNullRef68:                                   ; preds = %153
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %157
+ThrowNullRef70:                                   ; preds = %157
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %160
+ThrowNullRef72:                                   ; preds = %160
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %166
+ThrowNullRef74:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %136
+ThrowNullRef76:                                   ; preds = %136
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %140
+ThrowNullRef78:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %143
+ThrowNullRef80:                                   ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %148
+ThrowNullRef82:                                   ; preds = %148
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %128
+ThrowNullRef84:                                   ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %132
+ThrowNullRef86:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %100
+ThrowNullRef88:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %104
+ThrowNullRef90:                                   ; preds = %104
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %107
+ThrowNullRef92:                                   ; preds = %107
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %113
+ThrowNullRef94:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %118
+ThrowNullRef96:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %123
+ThrowNullRef98:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %81
+ThrowNullRef100:                                  ; preds = %81
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef101:                                  ; preds = %85
+ThrowNullRef102:                                  ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef103:                                  ; preds = %88
+ThrowNullRef104:                                  ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef105:                                  ; preds = %94
+ThrowNullRef106:                                  ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef107:                                  ; preds = %64
+ThrowNullRef108:                                  ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef109:                                  ; preds = %68
+ThrowNullRef110:                                  ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef111:                                  ; preds = %71
+ThrowNullRef112:                                  ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef113:                                  ; preds = %76
+ThrowNullRef114:                                  ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef115:                                  ; preds = %56
+ThrowNullRef116:                                  ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef117:                                  ; preds = %60
+ThrowNullRef118:                                  ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef119:                                  ; preds = %37
+ThrowNullRef120:                                  ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef121:                                  ; preds = %41
+ThrowNullRef122:                                  ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef123:                                  ; preds = %46
+ThrowNullRef124:                                  ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef125:                                  ; preds = %51
+ThrowNullRef126:                                  ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef127:                                  ; preds = %27
+ThrowNullRef128:                                  ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef129:                                  ; preds = %31
+ThrowNullRef130:                                  ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef131:                                  ; preds = %19
+ThrowNullRef132:                                  ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef133:                                  ; preds = %22
+ThrowNullRef134:                                  ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef135:                                  ; preds = %338
+ThrowNullRef136:                                  ; preds = %338
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef137:                                  ; preds = %341
+ThrowNullRef138:                                  ; preds = %341
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef139:                                  ; preds = %356
+ThrowNullRef140:                                  ; preds = %356
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef141:                                  ; preds = %360
+ThrowNullRef142:                                  ; preds = %360
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef143:                                  ; preds = %377
+ThrowNullRef144:                                  ; preds = %377
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef145:                                  ; preds = %381
+ThrowNullRef146:                                  ; preds = %381
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef147:                                  ; preds = %424
+ThrowNullRef148:                                  ; preds = %424
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef149:                                  ; preds = %428
+ThrowNullRef150:                                  ; preds = %428
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef151:                                  ; preds = %440
+ThrowNullRef152:                                  ; preds = %440
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef153:                                  ; preds = %444
+ThrowNullRef154:                                  ; preds = %444
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef155:                                  ; preds = %456
+ThrowNullRef156:                                  ; preds = %456
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef157:                                  ; preds = %460
+ThrowNullRef158:                                  ; preds = %460
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef159:                                  ; preds = %474
+ThrowNullRef160:                                  ; preds = %474
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef161:                                  ; preds = %477
+ThrowNullRef162:                                  ; preds = %477
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef163:                                  ; preds = %394
+ThrowNullRef164:                                  ; preds = %394
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef165:                                  ; preds = %398
+ThrowNullRef166:                                  ; preds = %398
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef167:                                  ; preds = %401
+ThrowNullRef168:                                  ; preds = %401
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef169:                                  ; preds = %407
+ThrowNullRef170:                                  ; preds = %407
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1939,8 +2021,8 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
-  br i1 %NullCheck, label %22, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %ThrowNullRef, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
@@ -1948,8 +2030,8 @@ entry:
   store i32 %24, i32* %loc0
   %25 = load i32, i32* %loc0
   %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %26, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %27
 
 ; <label>:27                                      ; preds = %22
   %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
@@ -1971,7 +2053,7 @@ ThrowNullRef:                                     ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1989,8 +2071,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -2022,15 +2104,15 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2048,16 +2130,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
   %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
   store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %15
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
@@ -2072,8 +2154,8 @@ entry:
   %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
   %29 = ptrtoint i16 addrspace(1)* %28 to i64
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %19
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
@@ -2089,19 +2171,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2114,8 +2196,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
@@ -2128,7 +2210,7 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[loadElem]
+Failed to read AppDomain.PrepareDataForSetup[storeElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
@@ -2202,8 +2284,8 @@ entry:
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
-  br i1 %NullCheck24, label %27, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = load i64, i64 addrspace(1)* %26
@@ -2218,8 +2300,8 @@ entry:
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
-  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
   %41 = load i64, i64 addrspace(1)* %39
@@ -2236,8 +2318,8 @@ entry:
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
-  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
   %54 = load i64, i64 addrspace(1)* %52
@@ -2252,8 +2334,8 @@ entry:
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
   %67 = load i64, i64 addrspace(1)* %65
@@ -2270,8 +2352,8 @@ entry:
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
-  br i1 %NullCheck16, label %79, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
   %80 = load i64, i64 addrspace(1)* %78
@@ -2286,8 +2368,8 @@ entry:
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
-  br i1 %NullCheck18, label %92, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
   %93 = load i64, i64 addrspace(1)* %91
@@ -2304,8 +2386,8 @@ entry:
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
-  br i1 %NullCheck12, label %105, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = load i64, i64 addrspace(1)* %104
@@ -2320,8 +2402,8 @@ entry:
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
-  br i1 %NullCheck14, label %118, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
   %119 = load i64, i64 addrspace(1)* %117
@@ -2337,8 +2419,8 @@ entry:
 
 ; <label>:128                                     ; preds = %20
   %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
-  br i1 %NullCheck4, label %130, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %129, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %130
 
 ; <label>:130                                     ; preds = %128
   %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
@@ -2346,8 +2428,8 @@ entry:
   %133 = load i16, i16 addrspace(1)* %132, align 8
   %134 = zext i16 %133 to i32
   %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
-  br i1 %NullCheck6, label %136, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %135, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %136
 
 ; <label>:136                                     ; preds = %130
   %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
@@ -2360,8 +2442,8 @@ entry:
 
 ; <label>:143                                     ; preds = %136
   %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
-  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %144, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %145
 
 ; <label>:145                                     ; preds = %143
   %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
@@ -2369,8 +2451,8 @@ entry:
   %148 = load i16, i16 addrspace(1)* %147, align 8
   %149 = zext i16 %148 to i32
   %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %150, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %151
 
 ; <label>:151                                     ; preds = %145
   %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
@@ -2388,8 +2470,8 @@ entry:
 
 ; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
-  br i1 %NullCheck, label %163, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %ThrowNullRef, label %163
 
 ; <label>:163                                     ; preds = %161
   %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
@@ -2399,8 +2481,8 @@ entry:
 
 ; <label>:167                                     ; preds = %163
   %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
-  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %168, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %169
 
 ; <label>:169                                     ; preds = %167
   %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
@@ -2432,55 +2514,55 @@ ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %167
+ThrowNullRef2:                                    ; preds = %167
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %128
+ThrowNullRef4:                                    ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %130
+ThrowNullRef6:                                    ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %143
+ThrowNullRef8:                                    ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %145
+ThrowNullRef10:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %102
+ThrowNullRef12:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %105
+ThrowNullRef14:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %76
+ThrowNullRef16:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %79
+ThrowNullRef18:                                   ; preds = %79
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %50
+ThrowNullRef20:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %53
+ThrowNullRef22:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %24
+ThrowNullRef24:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %27
+ThrowNullRef26:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2503,15 +2585,15 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2519,16 +2601,16 @@ entry:
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
   store i32 %8, i32* %loc0
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
   %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
   store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
@@ -2546,16 +2628,16 @@ entry:
 
 ; <label>:23                                      ; preds = %64
   %24 = load i16*, i16** %loc3
-  %NullCheck12 = icmp ne i16* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i16* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
   store i32 %27, i32* %loc5
   %28 = load i16*, i16** %loc4
-  %NullCheck14 = icmp ne i16* %28, null
-  br i1 %NullCheck14, label %29, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %28, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = load i16, i16* %28, align 8
@@ -2620,15 +2702,15 @@ entry:
 
 ; <label>:67                                      ; preds = %64
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
-  br i1 %NullCheck8, label %69, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %68, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %69
 
 ; <label>:69                                      ; preds = %67
   %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
   %71 = load i32, i32 addrspace(1)* %70
   %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
-  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %73
 
 ; <label>:73                                      ; preds = %69
   %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
@@ -2645,31 +2727,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %67
+ThrowNullRef8:                                    ; preds = %67
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %69
+ThrowNullRef10:                                   ; preds = %69
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2710,14 +2792,14 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
   %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
@@ -2730,14 +2812,14 @@ entry:
 
 ; <label>:11                                      ; preds = %4
   %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
   %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
@@ -2749,14 +2831,14 @@ entry:
 
 ; <label>:22                                      ; preds = %16
   %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
   %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
-  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
-  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
@@ -2804,23 +2886,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2836,7 +2918,280 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[loadElem]
+Successfully read RuntimeType.IsAssignableFrom
+
+define i8 @RuntimeType.IsAssignableFrom(%System.RuntimeType addrspace(1)* %param0, %System.Type addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.RuntimeType addrspace(1)*
+  %arg1 = alloca %System.Type addrspace(1)*
+  %loc0 = alloca %System.RuntimeType addrspace(1)*
+  %loc1 = alloca %"System.Type[]" addrspace(1)*
+  %loc2 = alloca i32
+  store %System.RuntimeType addrspace(1)* %param0, %System.RuntimeType addrspace(1)** %this
+  store %System.Type addrspace(1)* %param1, %System.Type addrspace(1)** %arg1
+  %0 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %1 = icmp ne %System.Type addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i8 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %5 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %6 = bitcast %System.Type addrspace(1)* %4 to %System.Object addrspace(1)*
+  %7 = bitcast %System.RuntimeType addrspace(1)* %5 to %System.Object addrspace(1)*
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %6, %System.Object addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %3
+  ret i8 1
+
+; <label>:12                                      ; preds = %3
+  %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 152
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 32
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
+  %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
+  %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
+  store %System.RuntimeType addrspace(1)* %25, %System.RuntimeType addrspace(1)** %loc0
+  %26 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %27 = icmp eq %System.RuntimeType addrspace(1)* %26, null
+  br i1 %27, label %34, label %28
+
+; <label>:28                                      ; preds = %15
+  %29 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %30 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)*)*)(%System.RuntimeType addrspace(1)* %29, %System.RuntimeType addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+; <label>:34                                      ; preds = %15
+  %35 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %36 = call %System.Reflection.Emit.TypeBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Reflection.Emit.TypeBuilder addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %35)
+  %37 = icmp eq %System.Reflection.Emit.TypeBuilder addrspace(1)* %36, null
+  br i1 %37, label %139, label %38
+
+; <label>:38                                      ; preds = %34
+  %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %42
+
+; <label>:42                                      ; preds = %38
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 152
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 40
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
+  %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
+  %53 = zext i8 %52 to i32
+  %54 = icmp eq i32 %53, 0
+  br i1 %54, label %56, label %55
+
+; <label>:55                                      ; preds = %42
+  ret i8 1
+
+; <label>:56                                      ; preds = %42
+  %57 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %58 = bitcast %System.RuntimeType addrspace(1)* %57 to %System.Type addrspace(1)*
+  %59 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %58)
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %64 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.Type addrspace(1)* %63, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = bitcast %System.RuntimeType addrspace(1)* %64 to %System.Type addrspace(1)*
+  %67 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %63, %System.Type addrspace(1)* %66)
+  %68 = zext i8 %67 to i32
+  %69 = trunc i32 %68 to i8
+  ret i8 %69
+
+; <label>:70                                      ; preds = %56
+  %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
+  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %73
+
+; <label>:73                                      ; preds = %70
+  %74 = load i64, i64 addrspace(1)* %72
+  %75 = add i64 %74, 128
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = add i64 %77, 0
+  %79 = inttoptr i64 %78 to i64*
+  %80 = load i64, i64* %79
+  %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
+  %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
+  %83 = call i8 %82(%System.Type addrspace(1)* %81)
+  %84 = zext i8 %83 to i32
+  %85 = icmp eq i32 %84, 0
+  br i1 %85, label %139, label %86
+
+; <label>:86                                      ; preds = %73
+  %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
+  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %89
+
+; <label>:89                                      ; preds = %86
+  %90 = load i64, i64 addrspace(1)* %88
+  %91 = add i64 %90, 128
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = add i64 %93, 24
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
+  %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
+  %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
+  store %"System.Type[]" addrspace(1)* %99, %"System.Type[]" addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %129
+
+; <label>:100                                     ; preds = %132
+  %101 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %102 = load i32, i32* %loc2
+  %NullCheck11 = icmp eq %"System.Type[]" addrspace(1)* %101, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %103
+
+; <label>:103                                     ; preds = %100
+  %104 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 1
+  %105 = load i32, i32 addrspace(1)* %104
+  %106 = zext i32 %105 to i64
+  %107 = zext i32 %102 to i64
+  %BoundsCheck = icmp uge i64 %107, %106
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %108
+
+; <label>:108                                     ; preds = %103
+  %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
+  %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
+  %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
+  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %113
+
+; <label>:113                                     ; preds = %108
+  %114 = load i64, i64 addrspace(1)* %112
+  %115 = add i64 %114, 152
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = add i64 %117, 56
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
+  %123 = zext i8 %122 to i32
+  %124 = icmp ne i32 %123, 0
+  br i1 %124, label %126, label %125
+
+; <label>:125                                     ; preds = %113
+  ret i8 0
+
+; <label>:126                                     ; preds = %113
+  %127 = load i32, i32* %loc2
+  %128 = add i32 %127, 1
+  store i32 %128, i32* %loc2
+  br label %129
+
+; <label>:129                                     ; preds = %89, %126
+  %130 = load i32, i32* %loc2
+  %131 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %NullCheck9 = icmp eq %"System.Type[]" addrspace(1)* %131, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %132
+
+; <label>:132                                     ; preds = %129
+  %133 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %131, i32 0, i32 1
+  %134 = load i32, i32 addrspace(1)* %133
+  %135 = zext i32 %134 to i64
+  %136 = trunc i64 %135 to i32
+  %137 = icmp slt i32 %130, %136
+  br i1 %137, label %100, label %138
+
+; <label>:138                                     ; preds = %132
+  ret i8 1
+
+; <label>:139                                     ; preds = %34, %73
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %129
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %103
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -2893,7 +3248,7 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElem]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -2904,8 +3259,8 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -2997,8 +3352,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
@@ -3059,8 +3414,8 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -3087,8 +3442,8 @@ entry:
 
 ; <label>:17                                      ; preds = %5, %11
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
@@ -3097,8 +3452,8 @@ entry:
 
 ; <label>:22                                      ; preds = %1, %11
   %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
@@ -3109,11 +3464,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %17
+ThrowNullRef2:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %22
+ThrowNullRef4:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3167,15 +3522,15 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
   %15 = load i32, i32 addrspace(1)* %14
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
@@ -3198,7 +3553,7 @@ ThrowNullRef:                                     ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef2:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3232,8 +3587,8 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
@@ -3312,8 +3667,8 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -3327,8 +3682,8 @@ entry:
 ; <label>:5                                       ; preds = %43
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %7 = load i32, i32* %loc1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck6, label %8, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
@@ -3366,8 +3721,8 @@ entry:
 ; <label>:32                                      ; preds = %21, %25
   %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
   %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
-  br i1 %NullCheck8, label %35, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = trunc i32 %34 to i16
@@ -3380,8 +3735,8 @@ entry:
 ; <label>:40                                      ; preds = %1, %35
   %41 = load i32, i32* %loc1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
-  br i1 %NullCheck2, label %43, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %42, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
@@ -3392,8 +3747,8 @@ entry:
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
   %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
-  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
   %51 = load i64, i64 addrspace(1)* %49
@@ -3412,19 +3767,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %40
+ThrowNullRef2:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %47
+ThrowNullRef4:                                    ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %5
+ThrowNullRef6:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %32
+ThrowNullRef8:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3467,8 +3822,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
@@ -3492,11 +3847,391 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(i16* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store i16* %param0, i16** %arg0
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load i32, i32* %arg3
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %42, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %37, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg2
+  %13 = load i32, i32* %arg3
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %37, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %24 = load i32, i32* %arg2
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load i16*, i16** %arg0
+  %35 = load i32, i32* %arg3
+  %36 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %36, i16* %34, i32 %35)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:37                                      ; preds = %5, %16
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %39)
+  %41 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41, %System.String addrspace(1)* %38, %System.String addrspace(1)* %40)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41) #0
+  unreachable
+
+; <label>:42                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
-Failed to read StringBuilder.ToString[loadElemA]
+Successfully read StringBuilder.ToString
+
+define %System.String addrspace(1)* @StringBuilder.ToString(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i16*
+  %loc3 = alloca %"System.Char[]" addrspace(1)*
+  %loc4 = alloca i32
+  %loc5 = alloca i32
+  %loc6 = alloca i16 addrspace(1)*
+  %loc7 = alloca %System.String addrspace(1)*
+  %loc8 = alloca %"System.Char[]" addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %0)
+  %2 = icmp ne i32 %1, 0
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %4
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %6)
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %7)
+  store %System.String addrspace(1)* %8, %System.String addrspace(1)** %loc0
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.Text.StringBuilder addrspace(1)* %9, %System.Text.StringBuilder addrspace(1)** %loc1
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  store %System.String addrspace(1)* %10, %System.String addrspace(1)** %loc7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc7
+  %12 = ptrtoint %System.String addrspace(1)* %11 to i64
+  %13 = icmp eq i64 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %5
+  %15 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %16 = sext i32 %15 to i64
+  %17 = add i64 %12, %16
+  br label %18
+
+; <label>:18                                      ; preds = %5, %14
+  %19 = phi i64 [ %12, %5 ], [ %17, %14 ]
+  %20 = inttoptr i64 %19 to i16*
+  store i16* %20, i16** %loc2
+  br label %21
+
+; <label>:21                                      ; preds = %98, %18
+  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %22, null
+  br i1 %NullCheck, label %ThrowNullRef, label %23
+
+; <label>:23                                      ; preds = %21
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 3
+  %25 = load i32, i32 addrspace(1)* %24, align 8
+  %26 = icmp sle i32 %25, 0
+  br i1 %26, label %96, label %27
+
+; <label>:27                                      ; preds = %23
+  %28 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %28, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %29
+
+; <label>:29                                      ; preds = %27
+  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %28, i32 0, i32 1
+  %31 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %30, align 8
+  store %"System.Char[]" addrspace(1)* %31, %"System.Char[]" addrspace(1)** %loc3
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %33
+
+; <label>:33                                      ; preds = %29
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  store i32 %35, i32* %loc4
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  %39 = load i32, i32 addrspace(1)* %38, align 8
+  store i32 %39, i32* %loc5
+  %40 = load i32, i32* %loc5
+  %41 = load i32, i32* %loc4
+  %42 = add i32 %40, %41
+  %43 = zext i32 %42 to i64
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %45
+
+; <label>:45                                      ; preds = %37
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = sext i32 %47 to i64
+  %49 = icmp sgt i64 %43, %48
+  br i1 %49, label %91, label %50
+
+; <label>:50                                      ; preds = %45
+  %51 = load i32, i32* %loc5
+  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %52, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %53
+
+; <label>:53                                      ; preds = %50
+  %54 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %52, i32 0, i32 1
+  %55 = load i32, i32 addrspace(1)* %54
+  %56 = zext i32 %55 to i64
+  %57 = trunc i64 %56 to i32
+  %58 = icmp ugt i32 %51, %57
+  br i1 %58, label %91, label %59
+
+; <label>:59                                      ; preds = %53
+  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  store %"System.Char[]" addrspace(1)* %60, %"System.Char[]" addrspace(1)** %loc8
+  %61 = icmp eq %"System.Char[]" addrspace(1)* %60, null
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %63, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %64
+
+; <label>:64                                      ; preds = %62
+  %65 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %63, i32 0, i32 1
+  %66 = load i32, i32 addrspace(1)* %65
+  %67 = zext i32 %66 to i64
+  %68 = trunc i64 %67 to i32
+  %69 = icmp ne i32 %68, 0
+  br i1 %69, label %71, label %70
+
+; <label>:70                                      ; preds = %59, %64
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:71                                      ; preds = %64
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %73
+
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %BoundsCheck = icmp uge i64 0, %76
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %77
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %78, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:79                                      ; preds = %70, %77
+  %80 = load i16*, i16** %loc2
+  %81 = load i32, i32* %loc4
+  %82 = sext i32 %81 to i64
+  %83 = mul i64 %82, 2
+  %84 = bitcast i16* %80 to i8*
+  %85 = getelementptr inbounds i8, i8* %84, i64 %83
+  %86 = load i16 addrspace(1)*, i16 addrspace(1)** %loc6
+  %87 = ptrtoint i16 addrspace(1)* %86 to i64
+  %88 = load i32, i32* %loc5
+  %89 = bitcast i8* %85 to i16*
+  %90 = inttoptr i64 %87 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %89, i16* %90, i32 %88)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %96
+
+; <label>:91                                      ; preds = %45, %53
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %94 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %93)
+  %95 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95, %System.String addrspace(1)* %92, %System.String addrspace(1)* %94)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95) #0
+  unreachable
+
+; <label>:96                                      ; preds = %23, %79
+  %97 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %97, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %98
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %97, i32 0, i32 2
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  store %System.Text.StringBuilder addrspace(1)* %100, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %102 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %102, label %21, label %103
+
+; <label>:103                                     ; preds = %98
+  store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc7
+  %104 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  ret %System.String addrspace(1)* %104
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method StringBuilder::get_Length using LLILCJit
+Successfully read StringBuilder.get_Length
+
+define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
+Successfully read RuntimeHelpers.get_OffsetToStringData
+
+define i32 @RuntimeHelpers.get_OffsetToStringData() {
+entry:
+  ret i32 12
+}
+
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
 Successfully read CultureData.CreateCultureData
 
@@ -3514,23 +4249,23 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
   store i8 %4, i8 addrspace(1)* %6
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
@@ -3549,11 +4284,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3566,50 +4301,50 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
   store i32 -1, i32 addrspace(1)* %2
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
   store i32 -1, i32 addrspace(1)* %8
   %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
   store i32 -1, i32 addrspace(1)* %14
   %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
   store i32 -1, i32 addrspace(1)* %17
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
@@ -3623,27 +4358,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3675,7 +4410,136 @@ Failed to read Dictionary`2.Insert[non-const derefAddress]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
 Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
-Failed to read HashHelpers.GetPrime[loadElem]
+Successfully read HashHelpers.GetPrime
+
+define i32 @HashHelpers.GetPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %6, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5, %System.String addrspace(1)* %4)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5) #0
+  unreachable
+
+; <label>:6                                       ; preds = %entry
+  store i32 0, i32* %loc0
+  br label %29
+
+; <label>:7                                       ; preds = %35
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 1296
+  %10 = addrspacecast i8 addrspace(1)* %9 to %"System.Int32[]" addrspace(1)**
+  %11 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %10
+  %12 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Int32[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = zext i32 %15 to i64
+  %17 = zext i32 %12 to i64
+  %BoundsCheck = icmp uge i64 %17, %16
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 3, i32 %12
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  store i32 %20, i32* %loc1
+  %21 = load i32, i32* %loc1
+  %22 = load i32, i32* %arg0
+  %23 = icmp slt i32 %21, %22
+  br i1 %23, label %26, label %24
+
+; <label>:24                                      ; preds = %18
+  %25 = load i32, i32* %loc1
+  ret i32 %25
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %loc0
+  %28 = add i32 %27, 1
+  store i32 %28, i32* %loc0
+  br label %29
+
+; <label>:29                                      ; preds = %6, %26
+  %30 = load i32, i32* %loc0
+  %31 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %32 = getelementptr inbounds i8, i8 addrspace(1)* %31, i64 1296
+  %33 = addrspacecast i8 addrspace(1)* %32 to %"System.Int32[]" addrspace(1)**
+  %34 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %33
+  %NullCheck = icmp eq %"System.Int32[]" addrspace(1)* %34, null
+  br i1 %NullCheck, label %ThrowNullRef, label %35
+
+; <label>:35                                      ; preds = %29
+  %36 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %34, i32 0, i32 1
+  %37 = load i32, i32 addrspace(1)* %36
+  %38 = zext i32 %37 to i64
+  %39 = trunc i64 %38 to i32
+  %40 = icmp slt i32 %30, %39
+  br i1 %40, label %7, label %41
+
+; <label>:41                                      ; preds = %35
+  %42 = load i32, i32* %arg0
+  %43 = or i32 %42, 1
+  store i32 %43, i32* %loc2
+  br label %59
+
+; <label>:44                                      ; preds = %59
+  %45 = load i32, i32* %loc2
+  %46 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %45)
+  %47 = zext i8 %46 to i32
+  %48 = icmp eq i32 %47, 0
+  br i1 %48, label %56, label %49
+
+; <label>:49                                      ; preds = %44
+  %50 = load i32, i32* %loc2
+  %51 = sub i32 %50, 1
+  %52 = srem i32 %51, 101
+  %53 = icmp eq i32 %52, 0
+  br i1 %53, label %56, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = load i32, i32* %loc2
+  ret i32 %55
+
+; <label>:56                                      ; preds = %44, %49
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %57, 2
+  store i32 %58, i32* %loc2
+  br label %59
+
+; <label>:59                                      ; preds = %41, %56
+  %60 = load i32, i32* %loc2
+  %61 = icmp slt i32 %60, 2147483647
+  br i1 %61, label %44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load i32, i32* %arg0
+  ret i32 %63
+
+ThrowNullRef:                                     ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
 Successfully read GenericEqualityComparer`1.GetHashCode
 
@@ -3694,14 +4558,14 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
   %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load i64, i64 addrspace(1)* %7
@@ -3720,7 +4584,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3750,8 +4614,8 @@ entry:
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
@@ -3796,8 +4660,8 @@ entry:
   %35 = bitcast i16* %34 to i8*
   %36 = getelementptr inbounds i8, i8* %35, i64 2
   %37 = bitcast i8* %36 to i16*
-  %NullCheck4 = icmp ne i16* %37, null
-  br i1 %NullCheck4, label %38, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %37, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %38
 
 ; <label>:38                                      ; preds = %27
   %39 = load i16, i16* %37, align 8
@@ -3824,8 +4688,8 @@ entry:
 
 ; <label>:54                                      ; preds = %22, %43
   %55 = load i16*, i16** %loc4
-  %NullCheck2 = icmp ne i16* %55, null
-  br i1 %NullCheck2, label %56, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i16* %55, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %56
 
 ; <label>:56                                      ; preds = %54
   %57 = load i16, i16* %55, align 8
@@ -3850,11 +4714,11 @@ ThrowNullRef:                                     ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %54
+ThrowNullRef2:                                    ; preds = %54
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %27
+ThrowNullRef4:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3871,8 +4735,8 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -3907,8 +4771,8 @@ entry:
 
 ; <label>:26                                      ; preds = %19
   %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
-  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %28
 
 ; <label>:28                                      ; preds = %26
   %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
@@ -3920,7 +4784,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3972,8 +4836,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
@@ -3984,26 +4848,26 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
-  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
@@ -4014,8 +4878,8 @@ entry:
 ; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
@@ -4024,8 +4888,8 @@ entry:
 
 ; <label>:25                                      ; preds = %1, %16, %23
   %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
-  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
@@ -4036,27 +4900,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %20
+ThrowNullRef10:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4069,8 +4933,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -4081,8 +4945,8 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
@@ -4091,8 +4955,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1, %8
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
@@ -4103,11 +4967,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4128,24 +4992,24 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   store i32 %3, i32* %loc0
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
   %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
   store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck4, label %9, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
@@ -4164,15 +5028,15 @@ entry:
 ; <label>:18                                      ; preds = %70
   %19 = load i16*, i16** %loc3
   %20 = bitcast i16* %19 to i64*
-  %NullCheck10 = icmp ne i64* %20, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %20, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = load i64, i64* %20, align 8
   %23 = load i16*, i16** %loc4
   %24 = bitcast i16* %23 to i64*
-  %NullCheck12 = icmp ne i64* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = load i64, i64* %24, align 8
@@ -4188,8 +5052,8 @@ entry:
   %31 = bitcast i16* %30 to i8*
   %32 = getelementptr inbounds i8, i8* %31, i64 8
   %33 = bitcast i8* %32 to i64*
-  %NullCheck14 = icmp ne i64* %33, null
-  br i1 %NullCheck14, label %34, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = load i64, i64* %33, align 8
@@ -4197,8 +5061,8 @@ entry:
   %37 = bitcast i16* %36 to i8*
   %38 = getelementptr inbounds i8, i8* %37, i64 8
   %39 = bitcast i8* %38 to i64*
-  %NullCheck16 = icmp ne i64* %39, null
-  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %40
 
 ; <label>:40                                      ; preds = %34
   %41 = load i64, i64* %39, align 8
@@ -4214,8 +5078,8 @@ entry:
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %NullCheck18 = icmp ne i64* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = load i64, i64* %48, align 8
@@ -4223,8 +5087,8 @@ entry:
   %52 = bitcast i16* %51 to i8*
   %53 = getelementptr inbounds i8, i8* %52, i64 16
   %54 = bitcast i8* %53 to i64*
-  %NullCheck20 = icmp ne i64* %54, null
-  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64* %54, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %55
 
 ; <label>:55                                      ; preds = %49
   %56 = load i64, i64* %54, align 8
@@ -4262,15 +5126,15 @@ entry:
 ; <label>:74                                      ; preds = %95
   %75 = load i16*, i16** %loc3
   %76 = bitcast i16* %75 to i32*
-  %NullCheck6 = icmp ne i32* %76, null
-  br i1 %NullCheck6, label %77, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32* %76, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %77
 
 ; <label>:77                                      ; preds = %74
   %78 = load i32, i32* %76, align 8
   %79 = load i16*, i16** %loc4
   %80 = bitcast i16* %79 to i32*
-  %NullCheck8 = icmp ne i32* %80, null
-  br i1 %NullCheck8, label %81, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i32* %80, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %81
 
 ; <label>:81                                      ; preds = %77
   %82 = load i32, i32* %80, align 8
@@ -4318,43 +5182,43 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %74
+ThrowNullRef6:                                    ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %77
+ThrowNullRef8:                                    ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %29
+ThrowNullRef14:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %34
+ThrowNullRef16:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4376,8 +5240,8 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load i64, i64 addrspace(1)* %4
@@ -4389,8 +5253,8 @@ entry:
   %12 = load i64, i64* %11
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %5
   %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
@@ -4399,8 +5263,8 @@ entry:
   %18 = load i8, i8* %arg2
   %19 = zext i8 %18 to i32
   %20 = trunc i32 %19 to i8
-  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %15
   %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
@@ -4411,11 +5275,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4442,8 +5306,8 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
@@ -4466,16 +5330,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
   %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = load i64, i64 addrspace(1)* %19
@@ -4500,8 +5364,8 @@ entry:
 ; <label>:35                                      ; preds = %30
   %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
@@ -4514,8 +5378,8 @@ entry:
 
 ; <label>:42                                      ; preds = %1, %38
   %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
-  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
@@ -4526,19 +5390,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %35
+ThrowNullRef2:                                    ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %42
+ThrowNullRef8:                                    ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4551,14 +5415,14 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
@@ -4570,7 +5434,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4583,8 +5447,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
@@ -4613,51 +5477,51 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
   %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
   %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
   %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
   %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
-  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
   store i64 %21, i64 addrspace(1)* %23
   %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %25 = load i64, i64* %loc0
-  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
@@ -4668,27 +5532,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %22
+ThrowNullRef12:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4701,8 +5565,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
@@ -4713,19 +5577,19 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
@@ -4734,8 +5598,8 @@ entry:
 
 ; <label>:15                                      ; preds = %1, %13
   %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
@@ -4746,19 +5610,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %15
+ThrowNullRef8:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4771,8 +5635,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -4831,8 +5695,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
@@ -4882,8 +5746,8 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
-  br i1 %NullCheck, label %17, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %ThrowNullRef, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
@@ -4894,15 +5758,15 @@ entry:
 
 ; <label>:22                                      ; preds = %17
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
-  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
   %26 = load i32, i32 addrspace(1)* %25
   %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
-  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %27, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
@@ -4925,8 +5789,8 @@ entry:
 ; <label>:40                                      ; preds = %17
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
-  br i1 %NullCheck6, label %43, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %41, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
@@ -4938,34 +5802,17 @@ ThrowNullRef:                                     ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %24
+ThrowNullRef4:                                    ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %40
+ThrowNullRef6:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
-}
-
-INFO:  jitting method Object::ReferenceEquals using LLILCJit
-Successfully read Object.ReferenceEquals
-
-define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
-entry:
-  %arg0 = alloca %System.Object addrspace(1)*
-  %arg1 = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
-  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
-  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = icmp eq %System.Object addrspace(1)* %0, %1
-  %3 = sext i1 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
 }
 
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
@@ -4978,21 +5825,21 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
   %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
-  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
@@ -5007,28 +5854,28 @@ entry:
 ; <label>:13                                      ; preds = %8, %12
   %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
   %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
   %21 = load i32, i32 addrspace(1)* %20, align 8
   %22 = add i32 %21, 1
-  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
   store i32 %22, i32 addrspace(1)* %24
   %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
@@ -5039,27 +5886,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5077,7 +5924,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::Setup using LLILCJit
-Failed to read AppDomain.Setup[loadElem]
+Failed to read AppDomain.Setup[unbox]
 INFO:  jitting method Thread::GetDomain using LLILCJit
 Successfully read Thread.GetDomain
 
@@ -5108,8 +5955,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
@@ -5122,14 +5969,14 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
   %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
@@ -5141,11 +5988,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5173,8 +6020,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -5189,7 +6036,328 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
 Failed to read KeyCollection.System.Collections.Generic.IEnumerable<TKey>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Successfully read Enumerator.MoveNext
+
+define i8 @Enumerator.MoveNext(%"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.RuntimeTypeHandle* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*
+  %"$TypeArg" = alloca %System.RuntimeTypeHandle*
+  store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
+  %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 8
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %76, label %12
+
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
+  br label %76
+
+; <label>:13                                      ; preds = %85
+  %14 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck19 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %15
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, i32 0, i32 0
+  %17 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %16, align 8
+  %NullCheck21 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, i32 0, i32 2
+  %20 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %19, align 8
+  %21 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck23 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %22
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, i32 0, i32 2
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %NullCheck25 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 3, i32 %24
+  %NullCheck27 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %32
+
+; <label>:32                                      ; preds = %30
+  %33 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, i32 0, i32 2
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = icmp slt i32 %34, 0
+  br i1 %35, label %68, label %36
+
+; <label>:36                                      ; preds = %32
+  %37 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %38 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck29 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %39
+
+; <label>:39                                      ; preds = %36
+  %40 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, i32 0, i32 0
+  %41 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %40, align 8
+  %NullCheck31 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, i32 0, i32 2
+  %44 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %43, align 8
+  %45 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck33 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, i32 0, i32 2
+  %48 = load i32, i32 addrspace(1)* %47, align 8
+  %NullCheck35 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %49
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = zext i32 %51 to i64
+  %53 = zext i32 %48 to i64
+  %BoundsCheck37 = icmp uge i64 %53, %52
+  br i1 %BoundsCheck37, label %ThrowIndexOutOfRange38, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 3, i32 %48
+  %NullCheck39 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %56
+
+; <label>:56                                      ; preds = %54
+  %57 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, i32 0, i32 0
+  %58 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck41 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %59
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %60, %System.__Canon addrspace(1)* %58)
+  %61 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck43 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  %64 = load i32, i32 addrspace(1)* %63, align 8
+  %65 = add i32 %64, 1
+  %NullCheck45 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  store i32 %65, i32 addrspace(1)* %67
+  ret i8 1
+
+; <label>:68                                      ; preds = %32
+  %69 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck47 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %73 = add i32 %72, 1
+  %NullCheck49 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %74
+
+; <label>:74                                      ; preds = %70
+  %75 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  store i32 %73, i32 addrspace(1)* %75
+  br label %76
+
+; <label>:76                                      ; preds = %8, %12, %74
+  %77 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %78
+
+; <label>:78                                      ; preds = %76
+  %79 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, i32 0, i32 2
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck7 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %82
+
+; <label>:82                                      ; preds = %78
+  %83 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, i32 0, i32 0
+  %84 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %83, align 8
+  %NullCheck9 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %85
+
+; <label>:85                                      ; preds = %82
+  %86 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, i32 0, i32 7
+  %87 = load i32, i32 addrspace(1)* %86, align 8
+  %88 = icmp ult i32 %80, %87
+  br i1 %88, label %13, label %89
+
+; <label>:89                                      ; preds = %85
+  %90 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %91 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck11 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %92
+
+; <label>:92                                      ; preds = %89
+  %93 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, i32 0, i32 0
+  %94 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck13 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %95
+
+; <label>:95                                      ; preds = %92
+  %96 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, i32 0, i32 7
+  %97 = load i32, i32 addrspace(1)* %96, align 8
+  %98 = add i32 %97, 1
+  %NullCheck15 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %99
+
+; <label>:99                                      ; preds = %95
+  %100 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, i32 0, i32 2
+  store i32 %98, i32 addrspace(1)* %100
+  %101 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck17 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %102
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %103, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %92
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef22:                                   ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef24:                                   ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef26:                                   ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef28:                                   ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef30:                                   ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef32:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef34:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef36:                                   ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange38:                           ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef40:                                   ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef42:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef44:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef46:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef48:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef50:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -5200,8 +6368,8 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -5232,9 +6400,9 @@ Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
 Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
-Failed to read String.MakeSeparatorList[loadElemA]
+Failed to read String.MakeSeparatorList[storeElem]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
-Failed to read String.InternalSplitKeepEmptyEntries[loadElem]
+Failed to read String.InternalSplitKeepEmptyEntries[storeElem]
 INFO:  jitting method Path::IsRelative using LLILCJit
 Successfully read Path.IsRelative
 
@@ -5243,8 +6411,8 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -5254,8 +6422,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
@@ -5271,8 +6439,8 @@ entry:
 
 ; <label>:17                                      ; preds = %7
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
@@ -5288,8 +6456,8 @@ entry:
 
 ; <label>:29                                      ; preds = %19
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %31
 
 ; <label>:31                                      ; preds = %29
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
@@ -5300,8 +6468,8 @@ entry:
 
 ; <label>:36                                      ; preds = %31
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
-  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %37, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
@@ -5312,8 +6480,8 @@ entry:
 
 ; <label>:43                                      ; preds = %31, %38
   %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
-  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %45
 
 ; <label>:45                                      ; preds = %43
   %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
@@ -5324,8 +6492,8 @@ entry:
 
 ; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %50
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
@@ -5336,8 +6504,8 @@ entry:
 
 ; <label>:57                                      ; preds = %1, %7, %19, %45, %52
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
-  br i1 %NullCheck14, label %59, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %59
 
 ; <label>:59                                      ; preds = %57
   %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
@@ -5347,8 +6515,8 @@ entry:
 
 ; <label>:63                                      ; preds = %59
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
@@ -5359,8 +6527,8 @@ entry:
 
 ; <label>:70                                      ; preds = %65
   %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
-  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.String addrspace(1)* %71, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %72
 
 ; <label>:72                                      ; preds = %70
   %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
@@ -5379,39 +6547,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %17
+ThrowNullRef4:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %29
+ThrowNullRef6:                                    ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %36
+ThrowNullRef8:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %43
+ThrowNullRef10:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %50
+ThrowNullRef12:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %57
+ThrowNullRef14:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %63
+ThrowNullRef16:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %70
+ThrowNullRef18:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5419,7 +6587,293 @@ ThrowNullRef17:                                   ; preds = %70
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
-Failed to read String.TrimHelper[loadElem]
+Successfully read String.TrimHelper
+
+define %System.String addrspace(1)* @String.TrimHelper(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i16
+  %loc4 = alloca i32
+  %loc5 = alloca i16
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = sub i32 %3, 1
+  store i32 %4, i32* %loc0
+  store i32 0, i32* %loc1
+  %5 = load i32, i32* %arg2
+  %6 = icmp eq i32 %5, 1
+  br i1 %6, label %62, label %7
+
+; <label>:7                                       ; preds = %1
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:8                                       ; preds = %58
+  store i32 0, i32* %loc2
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load i32, i32* %loc1
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2, i32 %10
+  %13 = load i16, i16 addrspace(1)* %12
+  %14 = zext i16 %13 to i32
+  %15 = trunc i32 %14 to i16
+  store i16 %15, i16* %loc3
+  store i32 0, i32* %loc2
+  br label %34
+
+; <label>:16                                      ; preds = %37
+  %17 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %18 = load i32, i32* %loc2
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %17, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %19
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = zext i32 %18 to i64
+  %BoundsCheck = icmp uge i64 %23, %22
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %24
+
+; <label>:24                                      ; preds = %19
+  %25 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 3, i32 %18
+  %26 = load i16, i16 addrspace(1)* %25, align 8
+  %27 = zext i16 %26 to i32
+  %28 = load i16, i16* %loc3
+  %29 = zext i16 %28 to i32
+  %30 = icmp eq i32 %27, %29
+  br i1 %30, label %43, label %31
+
+; <label>:31                                      ; preds = %24
+  %32 = load i32, i32* %loc2
+  %33 = add i32 %32, 1
+  store i32 %33, i32* %loc2
+  br label %34
+
+; <label>:34                                      ; preds = %11, %31
+  %35 = load i32, i32* %loc2
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = icmp slt i32 %35, %41
+  br i1 %42, label %16, label %43
+
+; <label>:43                                      ; preds = %24, %37
+  %44 = load i32, i32* %loc2
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %45, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp eq i32 %44, %50
+  br i1 %51, label %62, label %52
+
+; <label>:52                                      ; preds = %46
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %7, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %57, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %58
+
+; <label>:58                                      ; preds = %55
+  %59 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %60 = load i32, i32 addrspace(1)* %59
+  %61 = icmp slt i32 %56, %60
+  br i1 %61, label %8, label %62
+
+; <label>:62                                      ; preds = %1, %46, %58
+  %63 = load i32, i32* %arg2
+  %64 = icmp eq i32 %63, 0
+  br i1 %64, label %122, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %66, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %67
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %66, i32 0, i32 1
+  %69 = load i32, i32 addrspace(1)* %68
+  %70 = sub i32 %69, 1
+  store i32 %70, i32* %loc0
+  br label %118
+
+; <label>:71                                      ; preds = %118
+  store i32 0, i32* %loc4
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %73 = load i32, i32* %loc0
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %74
+
+; <label>:74                                      ; preds = %71
+  %75 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 2, i32 %73
+  %76 = load i16, i16 addrspace(1)* %75
+  %77 = zext i16 %76 to i32
+  %78 = trunc i32 %77 to i16
+  store i16 %78, i16* %loc5
+  store i32 0, i32* %loc4
+  br label %97
+
+; <label>:79                                      ; preds = %100
+  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %81 = load i32, i32* %loc4
+  %NullCheck19 = icmp eq %"System.Char[]" addrspace(1)* %80, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
+
+; <label>:82                                      ; preds = %79
+  %83 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 1
+  %84 = load i32, i32 addrspace(1)* %83
+  %85 = zext i32 %84 to i64
+  %86 = zext i32 %81 to i64
+  %BoundsCheck21 = icmp uge i64 %86, %85
+  br i1 %BoundsCheck21, label %ThrowIndexOutOfRange22, label %87
+
+; <label>:87                                      ; preds = %82
+  %88 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 3, i32 %81
+  %89 = load i16, i16 addrspace(1)* %88, align 8
+  %90 = zext i16 %89 to i32
+  %91 = load i16, i16* %loc5
+  %92 = zext i16 %91 to i32
+  %93 = icmp eq i32 %90, %92
+  br i1 %93, label %106, label %94
+
+; <label>:94                                      ; preds = %87
+  %95 = load i32, i32* %loc4
+  %96 = add i32 %95, 1
+  store i32 %96, i32* %loc4
+  br label %97
+
+; <label>:97                                      ; preds = %74, %94
+  %98 = load i32, i32* %loc4
+  %99 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck15 = icmp eq %"System.Char[]" addrspace(1)* %99, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %100
+
+; <label>:100                                     ; preds = %97
+  %101 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %99, i32 0, i32 1
+  %102 = load i32, i32 addrspace(1)* %101
+  %103 = zext i32 %102 to i64
+  %104 = trunc i64 %103 to i32
+  %105 = icmp slt i32 %98, %104
+  br i1 %105, label %79, label %106
+
+; <label>:106                                     ; preds = %87, %100
+  %107 = load i32, i32* %loc4
+  %108 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck17 = icmp eq %"System.Char[]" addrspace(1)* %108, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %109
+
+; <label>:109                                     ; preds = %106
+  %110 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %108, i32 0, i32 1
+  %111 = load i32, i32 addrspace(1)* %110
+  %112 = zext i32 %111 to i64
+  %113 = trunc i64 %112 to i32
+  %114 = icmp eq i32 %107, %113
+  br i1 %114, label %122, label %115
+
+; <label>:115                                     ; preds = %109
+  %116 = load i32, i32* %loc0
+  %117 = sub i32 %116, 1
+  store i32 %117, i32* %loc0
+  br label %118
+
+; <label>:118                                     ; preds = %67, %115
+  %119 = load i32, i32* %loc0
+  %120 = load i32, i32* %loc1
+  %121 = icmp sge i32 %119, %120
+  br i1 %121, label %71, label %122
+
+; <label>:122                                     ; preds = %62, %109, %118
+  %123 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %124 = load i32, i32* %loc1
+  %125 = load i32, i32* %loc0
+  %126 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %123, i32 %124, i32 %125)
+  ret %System.String addrspace(1)* %126
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %97
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange22:                           ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
 Successfully read String.CreateTrimmedString
 
@@ -5439,8 +6893,8 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
@@ -5535,8 +6989,8 @@ entry:
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i64 2872
   %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
   %8 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %7
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %3
   %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
@@ -5553,8 +7007,8 @@ entry:
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 2864
   %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
   %21 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %20
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
-  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %22
 
 ; <label>:22                                      ; preds = %16
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
@@ -5569,7 +7023,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %16
+ThrowNullRef2:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5586,8 +7040,8 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5613,8 +7067,8 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
@@ -5632,8 +7086,8 @@ entry:
 
 ; <label>:12                                      ; preds = %4
   %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
@@ -5644,8 +7098,8 @@ entry:
 
 ; <label>:19                                      ; preds = %14
   %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %19
   %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
@@ -5660,21 +7114,21 @@ entry:
   %31 = zext i16 %30 to i32
   %32 = bitcast i8* %29 to i16*
   %33 = trunc i32 %31 to i16
-  %NullCheck6 = icmp ne i16* %32, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i16* %32, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %21
   store i16 %33, i16* %32, align 8
   %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %36
 
 ; <label>:36                                      ; preds = %34
   %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
   %38 = load i32, i32 addrspace(1)* %37, align 8
   %39 = add i32 %38, 1
-  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %40
 
 ; <label>:40                                      ; preds = %36
   %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
@@ -5683,16 +7137,16 @@ entry:
 
 ; <label>:42                                      ; preds = %14
   %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
-  br i1 %NullCheck12, label %44, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
   %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
   %47 = load i16, i16* %arg1
   %48 = zext i16 %47 to i32
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = trunc i32 %48 to i16
@@ -5703,31 +7157,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %19
+ThrowNullRef4:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %21
+ThrowNullRef6:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %36
+ThrowNullRef10:                                   ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %42
+ThrowNullRef12:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %44
+ThrowNullRef14:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5740,8 +7194,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -5752,8 +7206,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
@@ -5762,14 +7216,14 @@ entry:
 
 ; <label>:11                                      ; preds = %1
   %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
@@ -5779,15 +7233,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5808,8 +7262,8 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5822,8 +7276,8 @@ entry:
 
 ; <label>:8                                       ; preds = %3
   %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
@@ -5842,15 +7296,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
-  br i1 %NullCheck4, label %22, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
   %24 = load i16*, i16* addrspace(1)* %23, align 8
   %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %25, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
@@ -5859,8 +7313,8 @@ entry:
   store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
@@ -5874,8 +7328,8 @@ entry:
 
 ; <label>:37                                      ; preds = %65
   %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %37
   %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
@@ -5886,16 +7340,16 @@ entry:
   %45 = bitcast i16* %41 to i8*
   %46 = getelementptr inbounds i8, i8* %45, i64 %44
   %47 = bitcast i8* %46 to i16*
-  %NullCheck14 = icmp ne i16* %47, null
-  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %47, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %48
 
 ; <label>:48                                      ; preds = %39
   %49 = load i16, i16* %47, align 8
   %50 = zext i16 %49 to i32
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %52 = load i32, i32* %loc1
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %53
 
 ; <label>:53                                      ; preds = %48
   %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
@@ -5916,8 +7370,8 @@ entry:
 ; <label>:62                                      ; preds = %36, %59
   %63 = load i32, i32* %loc1
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck10, label %65, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %65
 
 ; <label>:65                                      ; preds = %62
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
@@ -5936,15 +7390,15 @@ entry:
 
 ; <label>:74                                      ; preds = %70
   %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
-  br i1 %NullCheck18, label %76, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %76
 
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
   %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
-  br i1 %NullCheck20, label %80, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
   %81 = load i64, i64 addrspace(1)* %79
@@ -5958,8 +7412,8 @@ entry:
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
   %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
-  br i1 %NullCheck22, label %92, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.String addrspace(1)* %90, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %92
 
 ; <label>:92                                      ; preds = %80
   %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
@@ -5969,15 +7423,15 @@ entry:
 
 ; <label>:96                                      ; preds = %70
   %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
-  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %98
 
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
   %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
-  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
   %103 = load i64, i64 addrspace(1)* %101
@@ -5991,8 +7445,8 @@ entry:
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
   %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
-  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.String addrspace(1)* %112, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %114
 
 ; <label>:114                                     ; preds = %102
   %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
@@ -6004,59 +7458,59 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %20
+ThrowNullRef4:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %22
+ThrowNullRef6:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %26
+ThrowNullRef8:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %62
+ThrowNullRef10:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %48
+ThrowNullRef16:                                   ; preds = %48
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %74
+ThrowNullRef18:                                   ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %76
+ThrowNullRef20:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %80
+ThrowNullRef22:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %96
+ThrowNullRef24:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %98
+ThrowNullRef26:                                   ; preds = %98
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %102
+ThrowNullRef28:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6069,15 +7523,15 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
   %3 = load i16*, i16* addrspace(1)* %2, align 8
   %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
@@ -6087,8 +7541,8 @@ entry:
   %10 = bitcast i16* %3 to i8*
   %11 = getelementptr inbounds i8, i8* %10, i64 %9
   %12 = bitcast i8* %11 to i16*
-  %NullCheck4 = icmp ne i16* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %5
   store i16 0, i16* %12, align 8
@@ -6098,11 +7552,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6119,8 +7573,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -6131,8 +7585,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
@@ -6144,15 +7598,15 @@ entry:
 
 ; <label>:14                                      ; preds = %1
   %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
   %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
   %21 = load i64, i64 addrspace(1)* %19
@@ -6171,15 +7625,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %14
+ThrowNullRef4:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %16
+ThrowNullRef6:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6302,14 +7756,6 @@ entry:
   ret %System.String addrspace(1)* %57
 }
 
-INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
-Successfully read RuntimeHelpers.get_OffsetToStringData
-
-define i32 @RuntimeHelpers.get_OffsetToStringData() {
-entry:
-  ret i32 12
-}
-
 INFO:  jitting method String::Equals using LLILCJit
 Successfully read String.Equals
 
@@ -6381,8 +7827,8 @@ entry:
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
-  br i1 %NullCheck24, label %29, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
   %30 = load i64, i64 addrspace(1)* %28
@@ -6397,8 +7843,8 @@ entry:
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
-  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
   %43 = load i64, i64 addrspace(1)* %41
@@ -6418,8 +7864,8 @@ entry:
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
   %59 = load i64, i64 addrspace(1)* %57
@@ -6434,8 +7880,8 @@ entry:
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck22, label %71, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
   %72 = load i64, i64 addrspace(1)* %70
@@ -6455,8 +7901,8 @@ entry:
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
-  br i1 %NullCheck16, label %87, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = load i64, i64 addrspace(1)* %86
@@ -6471,8 +7917,8 @@ entry:
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck18, label %100, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
   %101 = load i64, i64 addrspace(1)* %99
@@ -6492,8 +7938,8 @@ entry:
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
-  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
   %117 = load i64, i64 addrspace(1)* %115
@@ -6508,8 +7954,8 @@ entry:
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
-  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
   %130 = load i64, i64 addrspace(1)* %128
@@ -6528,15 +7974,15 @@ entry:
 
 ; <label>:142                                     ; preds = %22
   %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
-  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %143, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %144
 
 ; <label>:144                                     ; preds = %142
   %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
   %146 = load i32, i32 addrspace(1)* %145
   %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
-  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %147, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %148
 
 ; <label>:148                                     ; preds = %144
   %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
@@ -6557,15 +8003,15 @@ entry:
 
 ; <label>:159                                     ; preds = %22
   %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
-  br i1 %NullCheck, label %161, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %ThrowNullRef, label %161
 
 ; <label>:161                                     ; preds = %159
   %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
   %163 = load i32, i32 addrspace(1)* %162
   %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
-  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %164, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %165
 
 ; <label>:165                                     ; preds = %161
   %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
@@ -6578,8 +8024,8 @@ entry:
 
 ; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
-  br i1 %NullCheck4, label %172, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %171, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %172
 
 ; <label>:172                                     ; preds = %170
   %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
@@ -6589,8 +8035,8 @@ entry:
 
 ; <label>:176                                     ; preds = %172
   %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
-  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %177, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %178
 
 ; <label>:178                                     ; preds = %176
   %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
@@ -6629,55 +8075,55 @@ ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %161
+ThrowNullRef2:                                    ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %170
+ThrowNullRef4:                                    ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %176
+ThrowNullRef6:                                    ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %142
+ThrowNullRef8:                                    ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %144
+ThrowNullRef10:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %113
+ThrowNullRef12:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %116
+ThrowNullRef14:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %84
+ThrowNullRef16:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %87
+ThrowNullRef18:                                   ; preds = %87
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %55
+ThrowNullRef20:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %58
+ThrowNullRef22:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %26
+ThrowNullRef24:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %29
+ThrowNullRef26:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,8 +8161,8 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck, label %14, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %ThrowNullRef, label %14
 
 ; <label>:14                                      ; preds = %8
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
@@ -6760,8 +8206,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
@@ -6770,14 +8216,14 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32, i32* %loc0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %10
   %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
   %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
@@ -6790,15 +8236,15 @@ entry:
 ; <label>:25                                      ; preds = %19
   %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
-  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
   %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
@@ -6807,8 +8253,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %37 = load i32, i32* %loc0
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %38, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %38
 
 ; <label>:38                                      ; preds = %32
   %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
@@ -6817,14 +8263,14 @@ entry:
 
 ; <label>:40                                      ; preds = %19
   %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %40
   %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
   %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
-  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
-  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
@@ -6832,8 +8278,8 @@ entry:
   %48 = zext i32 %47 to i64
   %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
-  br i1 %NullCheck16, label %51, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %51
 
 ; <label>:51                                      ; preds = %45
   %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
@@ -6847,15 +8293,15 @@ entry:
 ; <label>:57                                      ; preds = %51
   %58 = load i16*, i16** %arg1
   %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
-  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %60
 
 ; <label>:60                                      ; preds = %57
   %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
   %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
-  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %64
 
 ; <label>:64                                      ; preds = %60
   %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
@@ -6864,22 +8310,22 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
   %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
-  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %70
 
 ; <label>:70                                      ; preds = %64
   %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
   %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
-  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
-  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
   %75 = load i32, i32 addrspace(1)* %74
   %76 = zext i32 %75 to i64
   %77 = trunc i64 %76 to i32
-  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
-  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %78
 
 ; <label>:78                                      ; preds = %73
   %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
@@ -6901,8 +8347,8 @@ entry:
   %90 = bitcast i16* %86 to i8*
   %91 = getelementptr inbounds i8, i8* %90, i64 %89
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %93
 
 ; <label>:93                                      ; preds = %80
   %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
@@ -6912,8 +8358,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %99 = load i32, i32* %loc2
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %100
 
 ; <label>:100                                     ; preds = %93
   %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
@@ -6928,63 +8374,63 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %25
+ThrowNullRef6:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %32
+ThrowNullRef10:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %40
+ThrowNullRef12:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %45
+ThrowNullRef16:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %57
+ThrowNullRef18:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %60
+ThrowNullRef20:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %64
+ThrowNullRef22:                                   ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %70
+ThrowNullRef24:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %73
+ThrowNullRef26:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %80
+ThrowNullRef28:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %93
+ThrowNullRef30:                                   ; preds = %93
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7004,8 +8450,8 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
@@ -7033,43 +8479,43 @@ entry:
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %14
   %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
   %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   %28 = load i32, i32 addrspace(1)* %27, align 8
   %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
-  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %30
 
 ; <label>:30                                      ; preds = %26
   %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
   %32 = load i32, i32 addrspace(1)* %31, align 8
   %33 = add i32 %28, %32
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %34
 
 ; <label>:34                                      ; preds = %30
   %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   store i32 %33, i32 addrspace(1)* %35
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
   store i32 0, i32 addrspace(1)* %38
   %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %40
 
 ; <label>:40                                      ; preds = %37
   %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
@@ -7082,8 +8528,8 @@ entry:
 
 ; <label>:47                                      ; preds = %40
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
@@ -7098,8 +8544,8 @@ entry:
   %54 = load i32, i32* %loc0
   %55 = sext i32 %54 to i64
   %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
-  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %57
 
 ; <label>:57                                      ; preds = %52
   %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
@@ -7110,68 +8556,35 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %14
+ThrowNullRef2:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %23
+ThrowNullRef4:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %26
+ThrowNullRef6:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %30
+ThrowNullRef8:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %34
+ThrowNullRef10:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %47
+ThrowNullRef14:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %52
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-}
-
-INFO:  jitting method StringBuilder::get_Length using LLILCJit
-Successfully read StringBuilder.get_Length
-
-define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.StringBuilder addrspace(1)*
-  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
-  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
-
-; <label>:1                                       ; preds = %entry
-  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %3 = load i32, i32 addrspace(1)* %2, align 8
-  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
-
-; <label>:5                                       ; preds = %1
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = add i32 %3, %7
-  ret i32 %8
-
-ThrowNullRef:                                     ; preds = %entry
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef16:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7213,70 +8626,70 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
   %6 = load i32, i32 addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
   store i32 %6, i32 addrspace(1)* %8
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
   %13 = load i32, i32 addrspace(1)* %12, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
   store i32 %13, i32 addrspace(1)* %15
   %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
-  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %18
 
 ; <label>:18                                      ; preds = %14
   %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
   %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
   %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
   %34 = load i32, i32 addrspace(1)* %33, align 8
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
-  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
@@ -7287,39 +8700,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %28
+ThrowNullRef16:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %32
+ThrowNullRef18:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7455,13 +8868,13 @@ entry:
 ; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
@@ -7477,16 +8890,16 @@ entry:
 
 ; <label>:18                                      ; preds = %15
   %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
   store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
   %22 = load i32, i32* %loc0
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %24
 
 ; <label>:24                                      ; preds = %20
   %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
@@ -7498,13 +8911,13 @@ entry:
 ; <label>:28                                      ; preds = %15, %24
   %29 = load i32, i32* %arg1
   %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %31
   %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
@@ -7517,20 +8930,20 @@ entry:
   %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
-  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
   %46 = load i32, i32 addrspace(1)* %45, align 8
   %47 = sub i32 %40, %46
-  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
-  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i32 addrspace(1)* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %48
 
 ; <label>:48                                      ; preds = %44
   store i32 %47, i32 addrspace(1)* %39, align 8
@@ -7538,21 +8951,21 @@ entry:
 
 ; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
-  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %51
 
 ; <label>:51                                      ; preds = %49
   %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %53
 
 ; <label>:53                                      ; preds = %51
   %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
   %55 = load i32, i32 addrspace(1)* %54, align 8
   %56 = load i32, i32* %arg2
   %57 = sub i32 %55, %56
-  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %58
 
 ; <label>:58                                      ; preds = %53
   %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
@@ -7562,13 +8975,13 @@ entry:
 ; <label>:60                                      ; preds = %33, %58
   %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
   %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
-  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %63
 
 ; <label>:63                                      ; preds = %60
   %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
-  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
-  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
@@ -7578,15 +8991,15 @@ entry:
 
 ; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
-  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i32 addrspace(1)* %69, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %70
 
 ; <label>:70                                      ; preds = %68
   %71 = load i32, i32 addrspace(1)* %69, align 8
   store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
-  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
@@ -7596,8 +9009,8 @@ entry:
   store i32 %77, i32* %loc4
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
-  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %80
 
 ; <label>:80                                      ; preds = %73
   %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
@@ -7607,71 +9020,71 @@ entry:
 ; <label>:83                                      ; preds = %80
   store i32 0, i32* %loc3
   %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
-  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
-  br i1 %NullCheck26, label %88, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i32 addrspace(1)* %87, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %88
 
 ; <label>:88                                      ; preds = %85
   %89 = load i32, i32 addrspace(1)* %87, align 8
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
-  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %90
 
 ; <label>:90                                      ; preds = %88
   %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
   store i32 %89, i32 addrspace(1)* %91
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
-  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
-  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %96
 
 ; <label>:96                                      ; preds = %94
   %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
-  br i1 %NullCheck34, label %100, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %100
 
 ; <label>:100                                     ; preds = %96
   %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
-  br i1 %NullCheck36, label %102, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %102
 
 ; <label>:102                                     ; preds = %100
   %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
   %104 = load i32, i32 addrspace(1)* %103, align 8
   %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
-  br i1 %NullCheck38, label %106, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %106
 
 ; <label>:106                                     ; preds = %102
   %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
-  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
-  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %108
 
 ; <label>:108                                     ; preds = %106
   %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
   %110 = load i32, i32 addrspace(1)* %109, align 8
   %111 = add i32 %104, %110
-  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %112
 
 ; <label>:112                                     ; preds = %108
   %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
   store i32 %111, i32 addrspace(1)* %113
   %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
-  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i32 addrspace(1)* %114, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %115
 
 ; <label>:115                                     ; preds = %112
   %116 = load i32, i32 addrspace(1)* %114, align 8
@@ -7681,19 +9094,19 @@ entry:
 ; <label>:118                                     ; preds = %115
   %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
-  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %121
 
 ; <label>:121                                     ; preds = %118
   %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
-  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
-  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %123
 
 ; <label>:123                                     ; preds = %121
   %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
   %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
-  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
-  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %126
 
 ; <label>:126                                     ; preds = %123
   %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
@@ -7705,8 +9118,8 @@ entry:
 
 ; <label>:130                                     ; preds = %80, %115, %126
   %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %132
 
 ; <label>:132                                     ; preds = %130
   %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7715,8 +9128,8 @@ entry:
   %136 = load i32, i32* %loc3
   %137 = sub i32 %135, %136
   %138 = sub i32 %134, %137
-  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %139
 
 ; <label>:139                                     ; preds = %132
   %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7728,16 +9141,16 @@ entry:
 
 ; <label>:144                                     ; preds = %139
   %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
-  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %146
 
 ; <label>:146                                     ; preds = %144
   %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
   %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
   %149 = load i32, i32* %loc2
   %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
-  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %151
 
 ; <label>:151                                     ; preds = %146
   %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
@@ -7754,145 +9167,249 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %18
+ThrowNullRef4:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %31
+ThrowNullRef10:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %44
+ThrowNullRef16:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %68
+ThrowNullRef18:                                   ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %70
+ThrowNullRef20:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %73
+ThrowNullRef22:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %83
+ThrowNullRef24:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %85
+ThrowNullRef26:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %88
+ThrowNullRef28:                                   ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %90
+ThrowNullRef30:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %94
+ThrowNullRef32:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %96
+ThrowNullRef34:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %100
+ThrowNullRef36:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %102
+ThrowNullRef38:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %106
+ThrowNullRef40:                                   ; preds = %106
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %108
+ThrowNullRef42:                                   ; preds = %108
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %112
+ThrowNullRef44:                                   ; preds = %112
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %118
+ThrowNullRef46:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %121
+ThrowNullRef48:                                   ; preds = %121
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %123
+ThrowNullRef50:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %130
+ThrowNullRef52:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %132
+ThrowNullRef54:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %144
+ThrowNullRef56:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %146
+ThrowNullRef58:                                   ; preds = %146
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %60
+ThrowNullRef60:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %63
+ThrowNullRef62:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %49
+ThrowNullRef64:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %51
+ThrowNullRef66:                                   ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %53
+ThrowNullRef68:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(%"System.Char[]" addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %arg0 = alloca %"System.Char[]" addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store %"System.Char[]" addrspace(1)* %param0, %"System.Char[]" addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load i32, i32* %arg4
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %43, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %38, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg1
+  %13 = load i32, i32* %arg4
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %38, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %24 = load i32, i32* %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %35 = load i32, i32* %arg3
+  %36 = load i32, i32* %arg4
+  %37 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %37, %"System.Char[]" addrspace(1)* %34, i32 %35, i32 %36)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:38                                      ; preds = %5, %16
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Successfully read Buffer._Memmove
 
@@ -7914,7 +9431,7 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[loadElem]
+Failed to read AppDomain.SetDataHelper[storeElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -7923,8 +9440,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
@@ -7934,8 +9451,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
@@ -7947,15 +9464,15 @@ entry:
   %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
   %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
@@ -7966,15 +9483,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7992,7 +9509,79 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
-Failed to read Dictionary`2.TryGetValue[loadElemA]
+Successfully read Dictionary`2.TryGetValue
+
+define i8 @"Dictionary`2.TryGetValue"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)* addrspace(1)* %param2) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  %arg2 = alloca %System.__Canon addrspace(1)* addrspace(1)*
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  store %System.__Canon addrspace(1)* addrspace(1)* %param2, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  store i32 %2, i32* %loc0
+  %3 = load i32, i32* %loc0
+  %4 = icmp slt i32 %3, 0
+  br i1 %4, label %22, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 2
+  %10 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %9, align 8
+  %11 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = zext i32 %11 to i64
+  %BoundsCheck = icmp uge i64 %16, %15
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 3, i32 %11
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %20, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %6, %System.__Canon addrspace(1)* %21)
+  ret i8 1
+
+; <label>:22                                      ; preds = %entry
+  %23 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %23, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -8058,8 +9647,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
@@ -8091,8 +9680,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
@@ -8171,15 +9760,15 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck, label %19, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %ThrowNullRef, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
   %21 = load i32, i32 addrspace(1)* %20
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
@@ -8202,7 +9791,7 @@ ThrowNullRef:                                     ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %19
+ThrowNullRef2:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8248,8 +9837,8 @@ entry:
   %0 = alloca %System.AppDomainHandle
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %1 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %1, i32 0, i32 15
@@ -8269,8 +9858,8 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
@@ -8286,7 +9875,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -8299,8 +9888,8 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -8327,8 +9916,8 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
@@ -8352,8 +9941,8 @@ entry:
   %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
   store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
@@ -8363,8 +9952,8 @@ entry:
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
@@ -8374,8 +9963,8 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %9
   %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
@@ -8384,8 +9973,8 @@ entry:
 
 ; <label>:18                                      ; preds = %3, %16
   %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
@@ -8397,15 +9986,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %18
+ThrowNullRef6:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8418,8 +10007,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
@@ -8453,15 +10042,15 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
@@ -8473,7 +10062,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8481,7 +10070,7 @@ ThrowNullRef1:                                    ; preds = %1
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
 Failed to read Dictionary`2.System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
@@ -8506,8 +10095,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
@@ -8524,8 +10113,8 @@ entry:
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -8544,7 +10133,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8577,8 +10166,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = load i64, i64* %arg2
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = trunc i32 %3 to i8
@@ -8634,46 +10223,46 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
   %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
-  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
-  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
-  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
@@ -8684,27 +10273,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %20
+ThrowNullRef12:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8717,8 +10306,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -8756,22 +10345,22 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
   %9 = load i64, i64 addrspace(1)* %8, align 8
   %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
   %13 = load i64, i64 addrspace(1)* %12, align 8
   %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %11
   %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
@@ -8788,11 +10377,11 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8882,8 +10471,8 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
@@ -8900,8 +10489,8 @@ entry:
 ; <label>:8                                       ; preds = %1
   %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
   %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
@@ -8911,15 +10500,15 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
   %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
   %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
-  br i1 %NullCheck6, label %21, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
@@ -8946,15 +10535,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8992,15 +10581,15 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
   store i8 %3, i8 addrspace(1)* %5
   %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
@@ -9011,7 +10600,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9027,8 +10616,8 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -9041,8 +10630,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
@@ -9058,7 +10647,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9080,8 +10669,8 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
@@ -9096,8 +10685,8 @@ entry:
 ; <label>:12                                      ; preds = %6
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
@@ -9112,8 +10701,8 @@ entry:
 ; <label>:21                                      ; preds = %15
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
@@ -9128,8 +10717,8 @@ entry:
 ; <label>:30                                      ; preds = %24
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %31, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
@@ -9144,8 +10733,8 @@ entry:
 ; <label>:39                                      ; preds = %33
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
-  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %40, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %42
 
 ; <label>:42                                      ; preds = %39
   %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
@@ -9164,19 +10753,19 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %21
+ThrowNullRef4:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %30
+ThrowNullRef6:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %39
+ThrowNullRef8:                                    ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9243,8 +10832,8 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
@@ -9264,57 +10853,57 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
   store i8 0, i8 addrspace(1)* %2
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
   store i8 0, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
   store i8 0, i8 addrspace(1)* %17
   %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
   store i8 0, i8 addrspace(1)* %20
   %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
-  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
@@ -9325,31 +10914,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %19
+ThrowNullRef14:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9367,8 +10956,8 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
@@ -9380,8 +10969,8 @@ entry:
 
 ; <label>:9                                       ; preds = %4
   %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %9
   %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
@@ -9395,7 +10984,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef2:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9420,8 +11009,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
@@ -9512,8 +11101,8 @@ entry:
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
@@ -9524,8 +11113,8 @@ entry:
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = load i64, i64 addrspace(1)* %12
@@ -9537,8 +11126,8 @@ entry:
   %20 = load i64, i64* %19
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
-  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %13
   %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
@@ -9555,8 +11144,8 @@ entry:
 ; <label>:30                                      ; preds = %25
   %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %32 = load i32, i32* %arg2
-  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
-  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
@@ -9570,15 +11159,15 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %30
+ThrowNullRef2:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9622,87 +11211,87 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
   %10 = load i8, i8 addrspace(1)* %9, align 8
   %11 = zext i8 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %8
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
   store i8 %12, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
   %19 = load i8, i8 addrspace(1)* %18, align 8
   %20 = zext i8 %19 to i32
   %21 = trunc i32 %20 to i8
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
   store i8 %21, i8 addrspace(1)* %23
   %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
   %28 = load i8, i8 addrspace(1)* %27, align 8
   %29 = zext i8 %28 to i32
   %30 = trunc i32 %29 to i8
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
-  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %31
 
 ; <label>:31                                      ; preds = %26
   %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
   store i8 %30, i8 addrspace(1)* %32
   %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
-  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
-  br i1 %NullCheck14, label %40, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %40
 
 ; <label>:40                                      ; preds = %35
   %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
   store i8 %39, i8 addrspace(1)* %41
   %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
-  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %44
 
 ; <label>:44                                      ; preds = %40
   %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
   %46 = load i8, i8 addrspace(1)* %45, align 8
   %47 = zext i8 %46 to i32
   %48 = trunc i32 %47 to i8
-  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
   store i8 %48, i8 addrspace(1)* %50
   %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
-  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
@@ -9713,29 +11302,29 @@ entry:
 ; <label>:56                                      ; preds = %52
   %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
-  br i1 %NullCheck22, label %59, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
   %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
   %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
-  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
-  br i1 %NullCheck24, label %63, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
   %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
-  br i1 %NullCheck26, label %66, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
   %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
-  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
-  br i1 %NullCheck28, label %69, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %69
 
 ; <label>:69                                      ; preds = %66
   %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
@@ -9744,15 +11333,15 @@ entry:
 
 ; <label>:71                                      ; preds = %105
   %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
-  br i1 %NullCheck34, label %73, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %73
 
 ; <label>:73                                      ; preds = %71
   %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
   %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
   %76 = load i32, i32* %loc0
-  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
-  br i1 %NullCheck36, label %77, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
@@ -9766,8 +11355,8 @@ entry:
 
 ; <label>:83                                      ; preds = %77
   %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
-  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
@@ -9775,14 +11364,14 @@ entry:
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
   %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
-  br i1 %NullCheck40, label %91, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
 ; <label>:91                                      ; preds = %85
   %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
   %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
-  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck42, label %94, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %94
 
 ; <label>:94                                      ; preds = %91
   %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
@@ -9798,14 +11387,14 @@ entry:
 ; <label>:99                                      ; preds = %69, %96
   %100 = load i32, i32* %loc0
   %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
-  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %102
 
 ; <label>:102                                     ; preds = %99
   %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
   %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
-  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
-  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
@@ -9819,87 +11408,87 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %26
+ThrowNullRef10:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %31
+ThrowNullRef12:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %35
+ThrowNullRef14:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %40
+ThrowNullRef16:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %56
+ThrowNullRef22:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %59
+ThrowNullRef24:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %63
+ThrowNullRef26:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %66
+ThrowNullRef28:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %102
+ThrowNullRef32:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %71
+ThrowNullRef34:                                   ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %73
+ThrowNullRef36:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %83
+ThrowNullRef38:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %85
+ThrowNullRef40:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %91
+ThrowNullRef42:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9943,15 +11532,15 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
   %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
@@ -9961,28 +11550,28 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
   %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %12
   %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
   %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
   %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
-  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
@@ -9993,23 +11582,23 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %12
+ThrowNullRef6:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10031,15 +11620,15 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
   %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = load i64, i64 addrspace(1)* %7
@@ -10077,13 +11666,13 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[loadElem]
+Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -10111,8 +11700,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1

--- a/test/BaseLine/JIT/CodeGenBringUpTests/mul2.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/mul2.error.txt
@@ -25,8 +25,8 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
@@ -40,8 +40,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
   %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
@@ -75,7 +75,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -90,8 +90,8 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %NullCheck = icmp ne i8 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = load i8, i8 addrspace(1)* %0, align 8
@@ -125,8 +125,8 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
@@ -159,8 +159,8 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -184,8 +184,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
   store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
@@ -195,8 +195,8 @@ entry:
 ; <label>:4                                       ; preds = %1
   %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
   %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
@@ -206,8 +206,8 @@ entry:
   %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
@@ -221,14 +221,14 @@ entry:
 
 ; <label>:17                                      ; preds = %14
   %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
   %21 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
@@ -238,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -249,8 +249,8 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
@@ -261,27 +261,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %30
+ThrowNullRef10:                                   ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -301,7 +301,89 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
-Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
+Successfully read AppDomainSetup.GetUnsecureApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.GetUnsecureApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %NullCheck = icmp eq %"System.String[]" addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %BoundsCheck = icmp uge i64 0, %5
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %6
+
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 3, i32 0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
+  ret %System.String addrspace(1)* %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_Value using LLILCJit
+Successfully read AppDomainSetup.get_Value
+
+define %"System.String[]" addrspace(1)* @AppDomainSetup.get_Value(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.String[]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 18)
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.String[]" addrspace(1)* addrspace(1)*, %"System.String[]" addrspace(1)*)*)(%"System.String[]" addrspace(1)* addrspace(1)* %9, %"System.String[]" addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %11, i32 0, i32 1
+  %14 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %13, align 8
+  ret %"System.String[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -319,8 +401,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -368,16 +450,16 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
   %5 = load i32, i32 addrspace(1)* %4
   %6 = sub i32 %5, 1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -389,7 +471,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -421,8 +503,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
@@ -456,8 +538,8 @@ entry:
 ; <label>:27                                      ; preds = %19
   %28 = load i32, i32* %arg1
   %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
-  br i1 %NullCheck2, label %30, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %29, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %30
 
 ; <label>:30                                      ; preds = %27
   %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
@@ -493,8 +575,8 @@ entry:
 ; <label>:49                                      ; preds = %46
   %50 = load i32, i32* %arg2
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck4, label %52, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
@@ -517,11 +599,11 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %27
+ThrowNullRef2:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %49
+ThrowNullRef4:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -544,16 +626,16 @@ entry:
   %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %0)
   store %System.String addrspace(1)* %1, %System.String addrspace(1)** %loc0
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 2
   %5 = bitcast [0 x i16] addrspace(1)* %4 to i16 addrspace(1)*
   store i16 addrspace(1)* %5, i16 addrspace(1)** %loc1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %3
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2
@@ -580,7 +662,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -691,15 +773,15 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %NullCheck132 = icmp ne i8* %21, null
-  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+  %NullCheck131 = icmp eq i8* %21, null
+  br i1 %NullCheck131, label %ThrowNullRef132, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = load i8, i8* %21, align 8
   %24 = zext i8 %23 to i32
   %25 = trunc i32 %24 to i8
-  %NullCheck134 = icmp ne i8* %20, null
-  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+  %NullCheck133 = icmp eq i8* %20, null
+  br i1 %NullCheck133, label %ThrowNullRef134, label %26
 
 ; <label>:26                                      ; preds = %22
   store i8 %25, i8* %20, align 8
@@ -709,16 +791,16 @@ entry:
   %28 = load i8*, i8** %arg0
   %29 = load i8*, i8** %arg1
   %30 = bitcast i8* %29 to i16*
-  %NullCheck128 = icmp ne i16* %30, null
-  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+  %NullCheck127 = icmp eq i16* %30, null
+  br i1 %NullCheck127, label %ThrowNullRef128, label %31
 
 ; <label>:31                                      ; preds = %27
   %32 = load i16, i16* %30, align 8
   %33 = sext i16 %32 to i32
   %34 = bitcast i8* %28 to i16*
   %35 = trunc i32 %33 to i16
-  %NullCheck130 = icmp ne i16* %34, null
-  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+  %NullCheck129 = icmp eq i16* %34, null
+  br i1 %NullCheck129, label %ThrowNullRef130, label %36
 
 ; <label>:36                                      ; preds = %31
   store i16 %35, i16* %34, align 8
@@ -728,16 +810,16 @@ entry:
   %38 = load i8*, i8** %arg0
   %39 = load i8*, i8** %arg1
   %40 = bitcast i8* %39 to i16*
-  %NullCheck120 = icmp ne i16* %40, null
-  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+  %NullCheck119 = icmp eq i16* %40, null
+  br i1 %NullCheck119, label %ThrowNullRef120, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i16, i16* %40, align 8
   %43 = sext i16 %42 to i32
   %44 = bitcast i8* %38 to i16*
   %45 = trunc i32 %43 to i16
-  %NullCheck122 = icmp ne i16* %44, null
-  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+  %NullCheck121 = icmp eq i16* %44, null
+  br i1 %NullCheck121, label %ThrowNullRef122, label %46
 
 ; <label>:46                                      ; preds = %41
   store i16 %45, i16* %44, align 8
@@ -745,15 +827,15 @@ entry:
   %48 = getelementptr inbounds i8, i8* %47, i64 2
   %49 = load i8*, i8** %arg1
   %50 = getelementptr inbounds i8, i8* %49, i64 2
-  %NullCheck124 = icmp ne i8* %50, null
-  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+  %NullCheck123 = icmp eq i8* %50, null
+  br i1 %NullCheck123, label %ThrowNullRef124, label %51
 
 ; <label>:51                                      ; preds = %46
   %52 = load i8, i8* %50, align 8
   %53 = zext i8 %52 to i32
   %54 = trunc i32 %53 to i8
-  %NullCheck126 = icmp ne i8* %48, null
-  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+  %NullCheck125 = icmp eq i8* %48, null
+  br i1 %NullCheck125, label %ThrowNullRef126, label %55
 
 ; <label>:55                                      ; preds = %51
   store i8 %54, i8* %48, align 8
@@ -763,14 +845,14 @@ entry:
   %57 = load i8*, i8** %arg0
   %58 = load i8*, i8** %arg1
   %59 = bitcast i8* %58 to i32*
-  %NullCheck116 = icmp ne i32* %59, null
-  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+  %NullCheck115 = icmp eq i32* %59, null
+  br i1 %NullCheck115, label %ThrowNullRef116, label %60
 
 ; <label>:60                                      ; preds = %56
   %61 = load i32, i32* %59, align 8
   %62 = bitcast i8* %57 to i32*
-  %NullCheck118 = icmp ne i32* %62, null
-  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+  %NullCheck117 = icmp eq i32* %62, null
+  br i1 %NullCheck117, label %ThrowNullRef118, label %63
 
 ; <label>:63                                      ; preds = %60
   store i32 %61, i32* %62, align 8
@@ -780,14 +862,14 @@ entry:
   %65 = load i8*, i8** %arg0
   %66 = load i8*, i8** %arg1
   %67 = bitcast i8* %66 to i32*
-  %NullCheck108 = icmp ne i32* %67, null
-  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+  %NullCheck107 = icmp eq i32* %67, null
+  br i1 %NullCheck107, label %ThrowNullRef108, label %68
 
 ; <label>:68                                      ; preds = %64
   %69 = load i32, i32* %67, align 8
   %70 = bitcast i8* %65 to i32*
-  %NullCheck110 = icmp ne i32* %70, null
-  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+  %NullCheck109 = icmp eq i32* %70, null
+  br i1 %NullCheck109, label %ThrowNullRef110, label %71
 
 ; <label>:71                                      ; preds = %68
   store i32 %69, i32* %70, align 8
@@ -795,15 +877,15 @@ entry:
   %73 = getelementptr inbounds i8, i8* %72, i64 4
   %74 = load i8*, i8** %arg1
   %75 = getelementptr inbounds i8, i8* %74, i64 4
-  %NullCheck112 = icmp ne i8* %75, null
-  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+  %NullCheck111 = icmp eq i8* %75, null
+  br i1 %NullCheck111, label %ThrowNullRef112, label %76
 
 ; <label>:76                                      ; preds = %71
   %77 = load i8, i8* %75, align 8
   %78 = zext i8 %77 to i32
   %79 = trunc i32 %78 to i8
-  %NullCheck114 = icmp ne i8* %73, null
-  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+  %NullCheck113 = icmp eq i8* %73, null
+  br i1 %NullCheck113, label %ThrowNullRef114, label %80
 
 ; <label>:80                                      ; preds = %76
   store i8 %79, i8* %73, align 8
@@ -813,14 +895,14 @@ entry:
   %82 = load i8*, i8** %arg0
   %83 = load i8*, i8** %arg1
   %84 = bitcast i8* %83 to i32*
-  %NullCheck100 = icmp ne i32* %84, null
-  br i1 %NullCheck100, label %85, label %ThrowNullRef99
+  %NullCheck99 = icmp eq i32* %84, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %85
 
 ; <label>:85                                      ; preds = %81
   %86 = load i32, i32* %84, align 8
   %87 = bitcast i8* %82 to i32*
-  %NullCheck102 = icmp ne i32* %87, null
-  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+  %NullCheck101 = icmp eq i32* %87, null
+  br i1 %NullCheck101, label %ThrowNullRef102, label %88
 
 ; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
@@ -829,16 +911,16 @@ entry:
   %91 = load i8*, i8** %arg1
   %92 = getelementptr inbounds i8, i8* %91, i64 4
   %93 = bitcast i8* %92 to i16*
-  %NullCheck104 = icmp ne i16* %93, null
-  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+  %NullCheck103 = icmp eq i16* %93, null
+  br i1 %NullCheck103, label %ThrowNullRef104, label %94
 
 ; <label>:94                                      ; preds = %88
   %95 = load i16, i16* %93, align 8
   %96 = sext i16 %95 to i32
   %97 = bitcast i8* %90 to i16*
   %98 = trunc i32 %96 to i16
-  %NullCheck106 = icmp ne i16* %97, null
-  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+  %NullCheck105 = icmp eq i16* %97, null
+  br i1 %NullCheck105, label %ThrowNullRef106, label %99
 
 ; <label>:99                                      ; preds = %94
   store i16 %98, i16* %97, align 8
@@ -848,14 +930,14 @@ entry:
   %101 = load i8*, i8** %arg0
   %102 = load i8*, i8** %arg1
   %103 = bitcast i8* %102 to i32*
-  %NullCheck88 = icmp ne i32* %103, null
-  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+  %NullCheck87 = icmp eq i32* %103, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %104
 
 ; <label>:104                                     ; preds = %100
   %105 = load i32, i32* %103, align 8
   %106 = bitcast i8* %101 to i32*
-  %NullCheck90 = icmp ne i32* %106, null
-  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+  %NullCheck89 = icmp eq i32* %106, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %107
 
 ; <label>:107                                     ; preds = %104
   store i32 %105, i32* %106, align 8
@@ -864,16 +946,16 @@ entry:
   %110 = load i8*, i8** %arg1
   %111 = getelementptr inbounds i8, i8* %110, i64 4
   %112 = bitcast i8* %111 to i16*
-  %NullCheck92 = icmp ne i16* %112, null
-  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+  %NullCheck91 = icmp eq i16* %112, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %113
 
 ; <label>:113                                     ; preds = %107
   %114 = load i16, i16* %112, align 8
   %115 = sext i16 %114 to i32
   %116 = bitcast i8* %109 to i16*
   %117 = trunc i32 %115 to i16
-  %NullCheck94 = icmp ne i16* %116, null
-  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+  %NullCheck93 = icmp eq i16* %116, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %118
 
 ; <label>:118                                     ; preds = %113
   store i16 %117, i16* %116, align 8
@@ -881,15 +963,15 @@ entry:
   %120 = getelementptr inbounds i8, i8* %119, i64 6
   %121 = load i8*, i8** %arg1
   %122 = getelementptr inbounds i8, i8* %121, i64 6
-  %NullCheck96 = icmp ne i8* %122, null
-  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+  %NullCheck95 = icmp eq i8* %122, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %123
 
 ; <label>:123                                     ; preds = %118
   %124 = load i8, i8* %122, align 8
   %125 = zext i8 %124 to i32
   %126 = trunc i32 %125 to i8
-  %NullCheck98 = icmp ne i8* %120, null
-  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+  %NullCheck97 = icmp eq i8* %120, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %127
 
 ; <label>:127                                     ; preds = %123
   store i8 %126, i8* %120, align 8
@@ -899,14 +981,14 @@ entry:
   %129 = load i8*, i8** %arg0
   %130 = load i8*, i8** %arg1
   %131 = bitcast i8* %130 to i64*
-  %NullCheck84 = icmp ne i64* %131, null
-  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+  %NullCheck83 = icmp eq i64* %131, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %132
 
 ; <label>:132                                     ; preds = %128
   %133 = load i64, i64* %131, align 8
   %134 = bitcast i8* %129 to i64*
-  %NullCheck86 = icmp ne i64* %134, null
-  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+  %NullCheck85 = icmp eq i64* %134, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %135
 
 ; <label>:135                                     ; preds = %132
   store i64 %133, i64* %134, align 8
@@ -916,14 +998,14 @@ entry:
   %137 = load i8*, i8** %arg0
   %138 = load i8*, i8** %arg1
   %139 = bitcast i8* %138 to i64*
-  %NullCheck76 = icmp ne i64* %139, null
-  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+  %NullCheck75 = icmp eq i64* %139, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %140
 
 ; <label>:140                                     ; preds = %136
   %141 = load i64, i64* %139, align 8
   %142 = bitcast i8* %137 to i64*
-  %NullCheck78 = icmp ne i64* %142, null
-  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+  %NullCheck77 = icmp eq i64* %142, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %143
 
 ; <label>:143                                     ; preds = %140
   store i64 %141, i64* %142, align 8
@@ -931,15 +1013,15 @@ entry:
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %NullCheck80 = icmp ne i8* %147, null
-  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+  %NullCheck79 = icmp eq i8* %147, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %148
 
 ; <label>:148                                     ; preds = %143
   %149 = load i8, i8* %147, align 8
   %150 = zext i8 %149 to i32
   %151 = trunc i32 %150 to i8
-  %NullCheck82 = icmp ne i8* %145, null
-  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+  %NullCheck81 = icmp eq i8* %145, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %152
 
 ; <label>:152                                     ; preds = %148
   store i8 %151, i8* %145, align 8
@@ -949,14 +1031,14 @@ entry:
   %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
   %156 = bitcast i8* %155 to i64*
-  %NullCheck68 = icmp ne i64* %156, null
-  br i1 %NullCheck68, label %157, label %ThrowNullRef67
+  %NullCheck67 = icmp eq i64* %156, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %157
 
 ; <label>:157                                     ; preds = %153
   %158 = load i64, i64* %156, align 8
   %159 = bitcast i8* %154 to i64*
-  %NullCheck70 = icmp ne i64* %159, null
-  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+  %NullCheck69 = icmp eq i64* %159, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %160
 
 ; <label>:160                                     ; preds = %157
   store i64 %158, i64* %159, align 8
@@ -965,16 +1047,16 @@ entry:
   %163 = load i8*, i8** %arg1
   %164 = getelementptr inbounds i8, i8* %163, i64 8
   %165 = bitcast i8* %164 to i16*
-  %NullCheck72 = icmp ne i16* %165, null
-  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+  %NullCheck71 = icmp eq i16* %165, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %166
 
 ; <label>:166                                     ; preds = %160
   %167 = load i16, i16* %165, align 8
   %168 = sext i16 %167 to i32
   %169 = bitcast i8* %162 to i16*
   %170 = trunc i32 %168 to i16
-  %NullCheck74 = icmp ne i16* %169, null
-  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+  %NullCheck73 = icmp eq i16* %169, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %171
 
 ; <label>:171                                     ; preds = %166
   store i16 %170, i16* %169, align 8
@@ -984,14 +1066,14 @@ entry:
   %173 = load i8*, i8** %arg0
   %174 = load i8*, i8** %arg1
   %175 = bitcast i8* %174 to i64*
-  %NullCheck56 = icmp ne i64* %175, null
-  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+  %NullCheck55 = icmp eq i64* %175, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %176
 
 ; <label>:176                                     ; preds = %172
   %177 = load i64, i64* %175, align 8
   %178 = bitcast i8* %173 to i64*
-  %NullCheck58 = icmp ne i64* %178, null
-  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+  %NullCheck57 = icmp eq i64* %178, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %179
 
 ; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
@@ -1000,16 +1082,16 @@ entry:
   %182 = load i8*, i8** %arg1
   %183 = getelementptr inbounds i8, i8* %182, i64 8
   %184 = bitcast i8* %183 to i16*
-  %NullCheck60 = icmp ne i16* %184, null
-  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+  %NullCheck59 = icmp eq i16* %184, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %185
 
 ; <label>:185                                     ; preds = %179
   %186 = load i16, i16* %184, align 8
   %187 = sext i16 %186 to i32
   %188 = bitcast i8* %181 to i16*
   %189 = trunc i32 %187 to i16
-  %NullCheck62 = icmp ne i16* %188, null
-  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+  %NullCheck61 = icmp eq i16* %188, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %190
 
 ; <label>:190                                     ; preds = %185
   store i16 %189, i16* %188, align 8
@@ -1017,15 +1099,15 @@ entry:
   %192 = getelementptr inbounds i8, i8* %191, i64 10
   %193 = load i8*, i8** %arg1
   %194 = getelementptr inbounds i8, i8* %193, i64 10
-  %NullCheck64 = icmp ne i8* %194, null
-  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+  %NullCheck63 = icmp eq i8* %194, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %195
 
 ; <label>:195                                     ; preds = %190
   %196 = load i8, i8* %194, align 8
   %197 = zext i8 %196 to i32
   %198 = trunc i32 %197 to i8
-  %NullCheck66 = icmp ne i8* %192, null
-  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+  %NullCheck65 = icmp eq i8* %192, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %199
 
 ; <label>:199                                     ; preds = %195
   store i8 %198, i8* %192, align 8
@@ -1035,14 +1117,14 @@ entry:
   %201 = load i8*, i8** %arg0
   %202 = load i8*, i8** %arg1
   %203 = bitcast i8* %202 to i64*
-  %NullCheck48 = icmp ne i64* %203, null
-  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+  %NullCheck47 = icmp eq i64* %203, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %204
 
 ; <label>:204                                     ; preds = %200
   %205 = load i64, i64* %203, align 8
   %206 = bitcast i8* %201 to i64*
-  %NullCheck50 = icmp ne i64* %206, null
-  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+  %NullCheck49 = icmp eq i64* %206, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %207
 
 ; <label>:207                                     ; preds = %204
   store i64 %205, i64* %206, align 8
@@ -1051,14 +1133,14 @@ entry:
   %210 = load i8*, i8** %arg1
   %211 = getelementptr inbounds i8, i8* %210, i64 8
   %212 = bitcast i8* %211 to i32*
-  %NullCheck52 = icmp ne i32* %212, null
-  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+  %NullCheck51 = icmp eq i32* %212, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %213
 
 ; <label>:213                                     ; preds = %207
   %214 = load i32, i32* %212, align 8
   %215 = bitcast i8* %209 to i32*
-  %NullCheck54 = icmp ne i32* %215, null
-  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+  %NullCheck53 = icmp eq i32* %215, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %216
 
 ; <label>:216                                     ; preds = %213
   store i32 %214, i32* %215, align 8
@@ -1068,14 +1150,14 @@ entry:
   %218 = load i8*, i8** %arg0
   %219 = load i8*, i8** %arg1
   %220 = bitcast i8* %219 to i64*
-  %NullCheck36 = icmp ne i64* %220, null
-  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64* %220, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %221
 
 ; <label>:221                                     ; preds = %217
   %222 = load i64, i64* %220, align 8
   %223 = bitcast i8* %218 to i64*
-  %NullCheck38 = icmp ne i64* %223, null
-  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+  %NullCheck37 = icmp eq i64* %223, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %224
 
 ; <label>:224                                     ; preds = %221
   store i64 %222, i64* %223, align 8
@@ -1084,14 +1166,14 @@ entry:
   %227 = load i8*, i8** %arg1
   %228 = getelementptr inbounds i8, i8* %227, i64 8
   %229 = bitcast i8* %228 to i32*
-  %NullCheck40 = icmp ne i32* %229, null
-  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i32* %229, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %230
 
 ; <label>:230                                     ; preds = %224
   %231 = load i32, i32* %229, align 8
   %232 = bitcast i8* %226 to i32*
-  %NullCheck42 = icmp ne i32* %232, null
-  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+  %NullCheck41 = icmp eq i32* %232, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %233
 
 ; <label>:233                                     ; preds = %230
   store i32 %231, i32* %232, align 8
@@ -1099,15 +1181,15 @@ entry:
   %235 = getelementptr inbounds i8, i8* %234, i64 12
   %236 = load i8*, i8** %arg1
   %237 = getelementptr inbounds i8, i8* %236, i64 12
-  %NullCheck44 = icmp ne i8* %237, null
-  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i8* %237, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %238
 
 ; <label>:238                                     ; preds = %233
   %239 = load i8, i8* %237, align 8
   %240 = zext i8 %239 to i32
   %241 = trunc i32 %240 to i8
-  %NullCheck46 = icmp ne i8* %235, null
-  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+  %NullCheck45 = icmp eq i8* %235, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %242
 
 ; <label>:242                                     ; preds = %238
   store i8 %241, i8* %235, align 8
@@ -1117,14 +1199,14 @@ entry:
   %244 = load i8*, i8** %arg0
   %245 = load i8*, i8** %arg1
   %246 = bitcast i8* %245 to i64*
-  %NullCheck24 = icmp ne i64* %246, null
-  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64* %246, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %247
 
 ; <label>:247                                     ; preds = %243
   %248 = load i64, i64* %246, align 8
   %249 = bitcast i8* %244 to i64*
-  %NullCheck26 = icmp ne i64* %249, null
-  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64* %249, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %250
 
 ; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
@@ -1133,14 +1215,14 @@ entry:
   %253 = load i8*, i8** %arg1
   %254 = getelementptr inbounds i8, i8* %253, i64 8
   %255 = bitcast i8* %254 to i32*
-  %NullCheck28 = icmp ne i32* %255, null
-  br i1 %NullCheck28, label %256, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i32* %255, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %256
 
 ; <label>:256                                     ; preds = %250
   %257 = load i32, i32* %255, align 8
   %258 = bitcast i8* %252 to i32*
-  %NullCheck30 = icmp ne i32* %258, null
-  br i1 %NullCheck30, label %259, label %ThrowNullRef29
+  %NullCheck29 = icmp eq i32* %258, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %259
 
 ; <label>:259                                     ; preds = %256
   store i32 %257, i32* %258, align 8
@@ -1149,16 +1231,16 @@ entry:
   %262 = load i8*, i8** %arg1
   %263 = getelementptr inbounds i8, i8* %262, i64 12
   %264 = bitcast i8* %263 to i16*
-  %NullCheck32 = icmp ne i16* %264, null
-  br i1 %NullCheck32, label %265, label %ThrowNullRef31
+  %NullCheck31 = icmp eq i16* %264, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %265
 
 ; <label>:265                                     ; preds = %259
   %266 = load i16, i16* %264, align 8
   %267 = sext i16 %266 to i32
   %268 = bitcast i8* %261 to i16*
   %269 = trunc i32 %267 to i16
-  %NullCheck34 = icmp ne i16* %268, null
-  br i1 %NullCheck34, label %270, label %ThrowNullRef33
+  %NullCheck33 = icmp eq i16* %268, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %270
 
 ; <label>:270                                     ; preds = %265
   store i16 %269, i16* %268, align 8
@@ -1168,14 +1250,14 @@ entry:
   %272 = load i8*, i8** %arg0
   %273 = load i8*, i8** %arg1
   %274 = bitcast i8* %273 to i64*
-  %NullCheck8 = icmp ne i64* %274, null
-  br i1 %NullCheck8, label %275, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64* %274, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %275
 
 ; <label>:275                                     ; preds = %271
   %276 = load i64, i64* %274, align 8
   %277 = bitcast i8* %272 to i64*
-  %NullCheck10 = icmp ne i64* %277, null
-  br i1 %NullCheck10, label %278, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %277, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %278
 
 ; <label>:278                                     ; preds = %275
   store i64 %276, i64* %277, align 8
@@ -1184,14 +1266,14 @@ entry:
   %281 = load i8*, i8** %arg1
   %282 = getelementptr inbounds i8, i8* %281, i64 8
   %283 = bitcast i8* %282 to i32*
-  %NullCheck12 = icmp ne i32* %283, null
-  br i1 %NullCheck12, label %284, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i32* %283, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %284
 
 ; <label>:284                                     ; preds = %278
   %285 = load i32, i32* %283, align 8
   %286 = bitcast i8* %280 to i32*
-  %NullCheck14 = icmp ne i32* %286, null
-  br i1 %NullCheck14, label %287, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i32* %286, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %287
 
 ; <label>:287                                     ; preds = %284
   store i32 %285, i32* %286, align 8
@@ -1200,16 +1282,16 @@ entry:
   %290 = load i8*, i8** %arg1
   %291 = getelementptr inbounds i8, i8* %290, i64 12
   %292 = bitcast i8* %291 to i16*
-  %NullCheck16 = icmp ne i16* %292, null
-  br i1 %NullCheck16, label %293, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i16* %292, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %293
 
 ; <label>:293                                     ; preds = %287
   %294 = load i16, i16* %292, align 8
   %295 = sext i16 %294 to i32
   %296 = bitcast i8* %289 to i16*
   %297 = trunc i32 %295 to i16
-  %NullCheck18 = icmp ne i16* %296, null
-  br i1 %NullCheck18, label %298, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i16* %296, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %298
 
 ; <label>:298                                     ; preds = %293
   store i16 %297, i16* %296, align 8
@@ -1217,15 +1299,15 @@ entry:
   %300 = getelementptr inbounds i8, i8* %299, i64 14
   %301 = load i8*, i8** %arg1
   %302 = getelementptr inbounds i8, i8* %301, i64 14
-  %NullCheck20 = icmp ne i8* %302, null
-  br i1 %NullCheck20, label %303, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i8* %302, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %303
 
 ; <label>:303                                     ; preds = %298
   %304 = load i8, i8* %302, align 8
   %305 = zext i8 %304 to i32
   %306 = trunc i32 %305 to i8
-  %NullCheck22 = icmp ne i8* %300, null
-  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i8* %300, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %307
 
 ; <label>:307                                     ; preds = %303
   store i8 %306, i8* %300, align 8
@@ -1235,14 +1317,14 @@ entry:
   %309 = load i8*, i8** %arg0
   %310 = load i8*, i8** %arg1
   %311 = bitcast i8* %310 to i64*
-  %NullCheck = icmp ne i64* %311, null
-  br i1 %NullCheck, label %312, label %ThrowNullRef
+  %NullCheck = icmp eq i64* %311, null
+  br i1 %NullCheck, label %ThrowNullRef, label %312
 
 ; <label>:312                                     ; preds = %308
   %313 = load i64, i64* %311, align 8
   %314 = bitcast i8* %309 to i64*
-  %NullCheck2 = icmp ne i64* %314, null
-  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64* %314, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %315
 
 ; <label>:315                                     ; preds = %312
   store i64 %313, i64* %314, align 8
@@ -1251,14 +1333,14 @@ entry:
   %318 = load i8*, i8** %arg1
   %319 = getelementptr inbounds i8, i8* %318, i64 8
   %320 = bitcast i8* %319 to i64*
-  %NullCheck4 = icmp ne i64* %320, null
-  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64* %320, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %321
 
 ; <label>:321                                     ; preds = %315
   %322 = load i64, i64* %320, align 8
   %323 = bitcast i8* %317 to i64*
-  %NullCheck6 = icmp ne i64* %323, null
-  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64* %323, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %324
 
 ; <label>:324                                     ; preds = %321
   store i64 %322, i64* %323, align 8
@@ -1286,15 +1368,15 @@ entry:
 ; <label>:338                                     ; preds = %333
   %339 = load i8*, i8** %arg0
   %340 = load i8*, i8** %arg1
-  %NullCheck136 = icmp ne i8* %340, null
-  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+  %NullCheck135 = icmp eq i8* %340, null
+  br i1 %NullCheck135, label %ThrowNullRef136, label %341
 
 ; <label>:341                                     ; preds = %338
   %342 = load i8, i8* %340, align 8
   %343 = zext i8 %342 to i32
   %344 = trunc i32 %343 to i8
-  %NullCheck138 = icmp ne i8* %339, null
-  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+  %NullCheck137 = icmp eq i8* %339, null
+  br i1 %NullCheck137, label %ThrowNullRef138, label %345
 
 ; <label>:345                                     ; preds = %341
   store i8 %344, i8* %339, align 8
@@ -1317,16 +1399,16 @@ entry:
   %357 = load i8*, i8** %arg0
   %358 = load i8*, i8** %arg1
   %359 = bitcast i8* %358 to i16*
-  %NullCheck140 = icmp ne i16* %359, null
-  br i1 %NullCheck140, label %360, label %ThrowNullRef139
+  %NullCheck139 = icmp eq i16* %359, null
+  br i1 %NullCheck139, label %ThrowNullRef140, label %360
 
 ; <label>:360                                     ; preds = %356
   %361 = load i16, i16* %359, align 8
   %362 = sext i16 %361 to i32
   %363 = bitcast i8* %357 to i16*
   %364 = trunc i32 %362 to i16
-  %NullCheck142 = icmp ne i16* %363, null
-  br i1 %NullCheck142, label %365, label %ThrowNullRef141
+  %NullCheck141 = icmp eq i16* %363, null
+  br i1 %NullCheck141, label %ThrowNullRef142, label %365
 
 ; <label>:365                                     ; preds = %360
   store i16 %364, i16* %363, align 8
@@ -1352,14 +1434,14 @@ entry:
   %378 = load i8*, i8** %arg0
   %379 = load i8*, i8** %arg1
   %380 = bitcast i8* %379 to i32*
-  %NullCheck144 = icmp ne i32* %380, null
-  br i1 %NullCheck144, label %381, label %ThrowNullRef143
+  %NullCheck143 = icmp eq i32* %380, null
+  br i1 %NullCheck143, label %ThrowNullRef144, label %381
 
 ; <label>:381                                     ; preds = %377
   %382 = load i32, i32* %380, align 8
   %383 = bitcast i8* %378 to i32*
-  %NullCheck146 = icmp ne i32* %383, null
-  br i1 %NullCheck146, label %384, label %ThrowNullRef145
+  %NullCheck145 = icmp eq i32* %383, null
+  br i1 %NullCheck145, label %ThrowNullRef146, label %384
 
 ; <label>:384                                     ; preds = %381
   store i32 %382, i32* %383, align 8
@@ -1384,14 +1466,14 @@ entry:
   %395 = load i8*, i8** %arg0
   %396 = load i8*, i8** %arg1
   %397 = bitcast i8* %396 to i64*
-  %NullCheck164 = icmp ne i64* %397, null
-  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+  %NullCheck163 = icmp eq i64* %397, null
+  br i1 %NullCheck163, label %ThrowNullRef164, label %398
 
 ; <label>:398                                     ; preds = %394
   %399 = load i64, i64* %397, align 8
   %400 = bitcast i8* %395 to i64*
-  %NullCheck166 = icmp ne i64* %400, null
-  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+  %NullCheck165 = icmp eq i64* %400, null
+  br i1 %NullCheck165, label %ThrowNullRef166, label %401
 
 ; <label>:401                                     ; preds = %398
   store i64 %399, i64* %400, align 8
@@ -1400,14 +1482,14 @@ entry:
   %404 = load i8*, i8** %arg1
   %405 = getelementptr inbounds i8, i8* %404, i64 8
   %406 = bitcast i8* %405 to i64*
-  %NullCheck168 = icmp ne i64* %406, null
-  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+  %NullCheck167 = icmp eq i64* %406, null
+  br i1 %NullCheck167, label %ThrowNullRef168, label %407
 
 ; <label>:407                                     ; preds = %401
   %408 = load i64, i64* %406, align 8
   %409 = bitcast i8* %403 to i64*
-  %NullCheck170 = icmp ne i64* %409, null
-  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+  %NullCheck169 = icmp eq i64* %409, null
+  br i1 %NullCheck169, label %ThrowNullRef170, label %410
 
 ; <label>:410                                     ; preds = %407
   store i64 %408, i64* %409, align 8
@@ -1437,14 +1519,14 @@ entry:
   %425 = load i8*, i8** %arg0
   %426 = load i8*, i8** %arg1
   %427 = bitcast i8* %426 to i64*
-  %NullCheck148 = icmp ne i64* %427, null
-  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+  %NullCheck147 = icmp eq i64* %427, null
+  br i1 %NullCheck147, label %ThrowNullRef148, label %428
 
 ; <label>:428                                     ; preds = %424
   %429 = load i64, i64* %427, align 8
   %430 = bitcast i8* %425 to i64*
-  %NullCheck150 = icmp ne i64* %430, null
-  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+  %NullCheck149 = icmp eq i64* %430, null
+  br i1 %NullCheck149, label %ThrowNullRef150, label %431
 
 ; <label>:431                                     ; preds = %428
   store i64 %429, i64* %430, align 8
@@ -1466,14 +1548,14 @@ entry:
   %441 = load i8*, i8** %arg0
   %442 = load i8*, i8** %arg1
   %443 = bitcast i8* %442 to i32*
-  %NullCheck152 = icmp ne i32* %443, null
-  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+  %NullCheck151 = icmp eq i32* %443, null
+  br i1 %NullCheck151, label %ThrowNullRef152, label %444
 
 ; <label>:444                                     ; preds = %440
   %445 = load i32, i32* %443, align 8
   %446 = bitcast i8* %441 to i32*
-  %NullCheck154 = icmp ne i32* %446, null
-  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+  %NullCheck153 = icmp eq i32* %446, null
+  br i1 %NullCheck153, label %ThrowNullRef154, label %447
 
 ; <label>:447                                     ; preds = %444
   store i32 %445, i32* %446, align 8
@@ -1495,16 +1577,16 @@ entry:
   %457 = load i8*, i8** %arg0
   %458 = load i8*, i8** %arg1
   %459 = bitcast i8* %458 to i16*
-  %NullCheck156 = icmp ne i16* %459, null
-  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+  %NullCheck155 = icmp eq i16* %459, null
+  br i1 %NullCheck155, label %ThrowNullRef156, label %460
 
 ; <label>:460                                     ; preds = %456
   %461 = load i16, i16* %459, align 8
   %462 = sext i16 %461 to i32
   %463 = bitcast i8* %457 to i16*
   %464 = trunc i32 %462 to i16
-  %NullCheck158 = icmp ne i16* %463, null
-  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+  %NullCheck157 = icmp eq i16* %463, null
+  br i1 %NullCheck157, label %ThrowNullRef158, label %465
 
 ; <label>:465                                     ; preds = %460
   store i16 %464, i16* %463, align 8
@@ -1525,15 +1607,15 @@ entry:
 ; <label>:474                                     ; preds = %470
   %475 = load i8*, i8** %arg0
   %476 = load i8*, i8** %arg1
-  %NullCheck160 = icmp ne i8* %476, null
-  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+  %NullCheck159 = icmp eq i8* %476, null
+  br i1 %NullCheck159, label %ThrowNullRef160, label %477
 
 ; <label>:477                                     ; preds = %474
   %478 = load i8, i8* %476, align 8
   %479 = zext i8 %478 to i32
   %480 = trunc i32 %479 to i8
-  %NullCheck162 = icmp ne i8* %475, null
-  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+  %NullCheck161 = icmp eq i8* %475, null
+  br i1 %NullCheck161, label %ThrowNullRef162, label %481
 
 ; <label>:481                                     ; preds = %477
   store i8 %480, i8* %475, align 8
@@ -1553,343 +1635,343 @@ ThrowNullRef:                                     ; preds = %308
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %312
+ThrowNullRef2:                                    ; preds = %312
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %315
+ThrowNullRef4:                                    ; preds = %315
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %321
+ThrowNullRef6:                                    ; preds = %321
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %271
+ThrowNullRef8:                                    ; preds = %271
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %275
+ThrowNullRef10:                                   ; preds = %275
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %278
+ThrowNullRef12:                                   ; preds = %278
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %284
+ThrowNullRef14:                                   ; preds = %284
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %287
+ThrowNullRef16:                                   ; preds = %287
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %293
+ThrowNullRef18:                                   ; preds = %293
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %298
+ThrowNullRef20:                                   ; preds = %298
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %303
+ThrowNullRef22:                                   ; preds = %303
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %243
+ThrowNullRef24:                                   ; preds = %243
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %247
+ThrowNullRef26:                                   ; preds = %247
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %250
+ThrowNullRef28:                                   ; preds = %250
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %256
+ThrowNullRef30:                                   ; preds = %256
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %259
+ThrowNullRef32:                                   ; preds = %259
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %265
+ThrowNullRef34:                                   ; preds = %265
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %217
+ThrowNullRef36:                                   ; preds = %217
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %221
+ThrowNullRef38:                                   ; preds = %221
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %224
+ThrowNullRef40:                                   ; preds = %224
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %230
+ThrowNullRef42:                                   ; preds = %230
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %233
+ThrowNullRef44:                                   ; preds = %233
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %238
+ThrowNullRef46:                                   ; preds = %238
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %200
+ThrowNullRef48:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %204
+ThrowNullRef50:                                   ; preds = %204
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %207
+ThrowNullRef52:                                   ; preds = %207
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %213
+ThrowNullRef54:                                   ; preds = %213
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %172
+ThrowNullRef56:                                   ; preds = %172
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %176
+ThrowNullRef58:                                   ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %179
+ThrowNullRef60:                                   ; preds = %179
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %185
+ThrowNullRef62:                                   ; preds = %185
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %190
+ThrowNullRef64:                                   ; preds = %190
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %195
+ThrowNullRef66:                                   ; preds = %195
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %153
+ThrowNullRef68:                                   ; preds = %153
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %157
+ThrowNullRef70:                                   ; preds = %157
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %160
+ThrowNullRef72:                                   ; preds = %160
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %166
+ThrowNullRef74:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %136
+ThrowNullRef76:                                   ; preds = %136
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %140
+ThrowNullRef78:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %143
+ThrowNullRef80:                                   ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %148
+ThrowNullRef82:                                   ; preds = %148
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %128
+ThrowNullRef84:                                   ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %132
+ThrowNullRef86:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %100
+ThrowNullRef88:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %104
+ThrowNullRef90:                                   ; preds = %104
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %107
+ThrowNullRef92:                                   ; preds = %107
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %113
+ThrowNullRef94:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %118
+ThrowNullRef96:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %123
+ThrowNullRef98:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %81
+ThrowNullRef100:                                  ; preds = %81
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef101:                                  ; preds = %85
+ThrowNullRef102:                                  ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef103:                                  ; preds = %88
+ThrowNullRef104:                                  ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef105:                                  ; preds = %94
+ThrowNullRef106:                                  ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef107:                                  ; preds = %64
+ThrowNullRef108:                                  ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef109:                                  ; preds = %68
+ThrowNullRef110:                                  ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef111:                                  ; preds = %71
+ThrowNullRef112:                                  ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef113:                                  ; preds = %76
+ThrowNullRef114:                                  ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef115:                                  ; preds = %56
+ThrowNullRef116:                                  ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef117:                                  ; preds = %60
+ThrowNullRef118:                                  ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef119:                                  ; preds = %37
+ThrowNullRef120:                                  ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef121:                                  ; preds = %41
+ThrowNullRef122:                                  ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef123:                                  ; preds = %46
+ThrowNullRef124:                                  ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef125:                                  ; preds = %51
+ThrowNullRef126:                                  ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef127:                                  ; preds = %27
+ThrowNullRef128:                                  ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef129:                                  ; preds = %31
+ThrowNullRef130:                                  ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef131:                                  ; preds = %19
+ThrowNullRef132:                                  ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef133:                                  ; preds = %22
+ThrowNullRef134:                                  ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef135:                                  ; preds = %338
+ThrowNullRef136:                                  ; preds = %338
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef137:                                  ; preds = %341
+ThrowNullRef138:                                  ; preds = %341
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef139:                                  ; preds = %356
+ThrowNullRef140:                                  ; preds = %356
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef141:                                  ; preds = %360
+ThrowNullRef142:                                  ; preds = %360
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef143:                                  ; preds = %377
+ThrowNullRef144:                                  ; preds = %377
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef145:                                  ; preds = %381
+ThrowNullRef146:                                  ; preds = %381
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef147:                                  ; preds = %424
+ThrowNullRef148:                                  ; preds = %424
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef149:                                  ; preds = %428
+ThrowNullRef150:                                  ; preds = %428
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef151:                                  ; preds = %440
+ThrowNullRef152:                                  ; preds = %440
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef153:                                  ; preds = %444
+ThrowNullRef154:                                  ; preds = %444
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef155:                                  ; preds = %456
+ThrowNullRef156:                                  ; preds = %456
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef157:                                  ; preds = %460
+ThrowNullRef158:                                  ; preds = %460
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef159:                                  ; preds = %474
+ThrowNullRef160:                                  ; preds = %474
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef161:                                  ; preds = %477
+ThrowNullRef162:                                  ; preds = %477
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef163:                                  ; preds = %394
+ThrowNullRef164:                                  ; preds = %394
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef165:                                  ; preds = %398
+ThrowNullRef166:                                  ; preds = %398
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef167:                                  ; preds = %401
+ThrowNullRef168:                                  ; preds = %401
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef169:                                  ; preds = %407
+ThrowNullRef170:                                  ; preds = %407
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1939,8 +2021,8 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
-  br i1 %NullCheck, label %22, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %ThrowNullRef, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
@@ -1948,8 +2030,8 @@ entry:
   store i32 %24, i32* %loc0
   %25 = load i32, i32* %loc0
   %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %26, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %27
 
 ; <label>:27                                      ; preds = %22
   %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
@@ -1971,7 +2053,7 @@ ThrowNullRef:                                     ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1989,8 +2071,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -2022,15 +2104,15 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2048,16 +2130,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
   %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
   store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %15
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
@@ -2072,8 +2154,8 @@ entry:
   %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
   %29 = ptrtoint i16 addrspace(1)* %28 to i64
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %19
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
@@ -2089,19 +2171,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2114,8 +2196,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
@@ -2128,7 +2210,7 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[loadElem]
+Failed to read AppDomain.PrepareDataForSetup[storeElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
@@ -2202,8 +2284,8 @@ entry:
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
-  br i1 %NullCheck24, label %27, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = load i64, i64 addrspace(1)* %26
@@ -2218,8 +2300,8 @@ entry:
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
-  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
   %41 = load i64, i64 addrspace(1)* %39
@@ -2236,8 +2318,8 @@ entry:
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
-  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
   %54 = load i64, i64 addrspace(1)* %52
@@ -2252,8 +2334,8 @@ entry:
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
   %67 = load i64, i64 addrspace(1)* %65
@@ -2270,8 +2352,8 @@ entry:
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
-  br i1 %NullCheck16, label %79, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
   %80 = load i64, i64 addrspace(1)* %78
@@ -2286,8 +2368,8 @@ entry:
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
-  br i1 %NullCheck18, label %92, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
   %93 = load i64, i64 addrspace(1)* %91
@@ -2304,8 +2386,8 @@ entry:
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
-  br i1 %NullCheck12, label %105, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = load i64, i64 addrspace(1)* %104
@@ -2320,8 +2402,8 @@ entry:
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
-  br i1 %NullCheck14, label %118, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
   %119 = load i64, i64 addrspace(1)* %117
@@ -2337,8 +2419,8 @@ entry:
 
 ; <label>:128                                     ; preds = %20
   %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
-  br i1 %NullCheck4, label %130, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %129, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %130
 
 ; <label>:130                                     ; preds = %128
   %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
@@ -2346,8 +2428,8 @@ entry:
   %133 = load i16, i16 addrspace(1)* %132, align 8
   %134 = zext i16 %133 to i32
   %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
-  br i1 %NullCheck6, label %136, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %135, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %136
 
 ; <label>:136                                     ; preds = %130
   %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
@@ -2360,8 +2442,8 @@ entry:
 
 ; <label>:143                                     ; preds = %136
   %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
-  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %144, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %145
 
 ; <label>:145                                     ; preds = %143
   %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
@@ -2369,8 +2451,8 @@ entry:
   %148 = load i16, i16 addrspace(1)* %147, align 8
   %149 = zext i16 %148 to i32
   %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %150, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %151
 
 ; <label>:151                                     ; preds = %145
   %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
@@ -2388,8 +2470,8 @@ entry:
 
 ; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
-  br i1 %NullCheck, label %163, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %ThrowNullRef, label %163
 
 ; <label>:163                                     ; preds = %161
   %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
@@ -2399,8 +2481,8 @@ entry:
 
 ; <label>:167                                     ; preds = %163
   %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
-  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %168, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %169
 
 ; <label>:169                                     ; preds = %167
   %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
@@ -2432,55 +2514,55 @@ ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %167
+ThrowNullRef2:                                    ; preds = %167
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %128
+ThrowNullRef4:                                    ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %130
+ThrowNullRef6:                                    ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %143
+ThrowNullRef8:                                    ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %145
+ThrowNullRef10:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %102
+ThrowNullRef12:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %105
+ThrowNullRef14:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %76
+ThrowNullRef16:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %79
+ThrowNullRef18:                                   ; preds = %79
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %50
+ThrowNullRef20:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %53
+ThrowNullRef22:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %24
+ThrowNullRef24:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %27
+ThrowNullRef26:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2503,15 +2585,15 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2519,16 +2601,16 @@ entry:
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
   store i32 %8, i32* %loc0
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
   %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
   store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
@@ -2546,16 +2628,16 @@ entry:
 
 ; <label>:23                                      ; preds = %64
   %24 = load i16*, i16** %loc3
-  %NullCheck12 = icmp ne i16* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i16* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
   store i32 %27, i32* %loc5
   %28 = load i16*, i16** %loc4
-  %NullCheck14 = icmp ne i16* %28, null
-  br i1 %NullCheck14, label %29, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %28, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = load i16, i16* %28, align 8
@@ -2620,15 +2702,15 @@ entry:
 
 ; <label>:67                                      ; preds = %64
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
-  br i1 %NullCheck8, label %69, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %68, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %69
 
 ; <label>:69                                      ; preds = %67
   %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
   %71 = load i32, i32 addrspace(1)* %70
   %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
-  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %73
 
 ; <label>:73                                      ; preds = %69
   %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
@@ -2645,31 +2727,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %67
+ThrowNullRef8:                                    ; preds = %67
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %69
+ThrowNullRef10:                                   ; preds = %69
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2710,14 +2792,14 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
   %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
@@ -2730,14 +2812,14 @@ entry:
 
 ; <label>:11                                      ; preds = %4
   %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
   %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
@@ -2749,14 +2831,14 @@ entry:
 
 ; <label>:22                                      ; preds = %16
   %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
   %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
-  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
-  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
@@ -2804,23 +2886,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2836,7 +2918,280 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[loadElem]
+Successfully read RuntimeType.IsAssignableFrom
+
+define i8 @RuntimeType.IsAssignableFrom(%System.RuntimeType addrspace(1)* %param0, %System.Type addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.RuntimeType addrspace(1)*
+  %arg1 = alloca %System.Type addrspace(1)*
+  %loc0 = alloca %System.RuntimeType addrspace(1)*
+  %loc1 = alloca %"System.Type[]" addrspace(1)*
+  %loc2 = alloca i32
+  store %System.RuntimeType addrspace(1)* %param0, %System.RuntimeType addrspace(1)** %this
+  store %System.Type addrspace(1)* %param1, %System.Type addrspace(1)** %arg1
+  %0 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %1 = icmp ne %System.Type addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i8 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %5 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %6 = bitcast %System.Type addrspace(1)* %4 to %System.Object addrspace(1)*
+  %7 = bitcast %System.RuntimeType addrspace(1)* %5 to %System.Object addrspace(1)*
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %6, %System.Object addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %3
+  ret i8 1
+
+; <label>:12                                      ; preds = %3
+  %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 152
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 32
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
+  %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
+  %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
+  store %System.RuntimeType addrspace(1)* %25, %System.RuntimeType addrspace(1)** %loc0
+  %26 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %27 = icmp eq %System.RuntimeType addrspace(1)* %26, null
+  br i1 %27, label %34, label %28
+
+; <label>:28                                      ; preds = %15
+  %29 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %30 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)*)*)(%System.RuntimeType addrspace(1)* %29, %System.RuntimeType addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+; <label>:34                                      ; preds = %15
+  %35 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %36 = call %System.Reflection.Emit.TypeBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Reflection.Emit.TypeBuilder addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %35)
+  %37 = icmp eq %System.Reflection.Emit.TypeBuilder addrspace(1)* %36, null
+  br i1 %37, label %139, label %38
+
+; <label>:38                                      ; preds = %34
+  %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %42
+
+; <label>:42                                      ; preds = %38
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 152
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 40
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
+  %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
+  %53 = zext i8 %52 to i32
+  %54 = icmp eq i32 %53, 0
+  br i1 %54, label %56, label %55
+
+; <label>:55                                      ; preds = %42
+  ret i8 1
+
+; <label>:56                                      ; preds = %42
+  %57 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %58 = bitcast %System.RuntimeType addrspace(1)* %57 to %System.Type addrspace(1)*
+  %59 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %58)
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %64 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.Type addrspace(1)* %63, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = bitcast %System.RuntimeType addrspace(1)* %64 to %System.Type addrspace(1)*
+  %67 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %63, %System.Type addrspace(1)* %66)
+  %68 = zext i8 %67 to i32
+  %69 = trunc i32 %68 to i8
+  ret i8 %69
+
+; <label>:70                                      ; preds = %56
+  %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
+  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %73
+
+; <label>:73                                      ; preds = %70
+  %74 = load i64, i64 addrspace(1)* %72
+  %75 = add i64 %74, 128
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = add i64 %77, 0
+  %79 = inttoptr i64 %78 to i64*
+  %80 = load i64, i64* %79
+  %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
+  %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
+  %83 = call i8 %82(%System.Type addrspace(1)* %81)
+  %84 = zext i8 %83 to i32
+  %85 = icmp eq i32 %84, 0
+  br i1 %85, label %139, label %86
+
+; <label>:86                                      ; preds = %73
+  %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
+  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %89
+
+; <label>:89                                      ; preds = %86
+  %90 = load i64, i64 addrspace(1)* %88
+  %91 = add i64 %90, 128
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = add i64 %93, 24
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
+  %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
+  %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
+  store %"System.Type[]" addrspace(1)* %99, %"System.Type[]" addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %129
+
+; <label>:100                                     ; preds = %132
+  %101 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %102 = load i32, i32* %loc2
+  %NullCheck11 = icmp eq %"System.Type[]" addrspace(1)* %101, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %103
+
+; <label>:103                                     ; preds = %100
+  %104 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 1
+  %105 = load i32, i32 addrspace(1)* %104
+  %106 = zext i32 %105 to i64
+  %107 = zext i32 %102 to i64
+  %BoundsCheck = icmp uge i64 %107, %106
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %108
+
+; <label>:108                                     ; preds = %103
+  %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
+  %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
+  %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
+  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %113
+
+; <label>:113                                     ; preds = %108
+  %114 = load i64, i64 addrspace(1)* %112
+  %115 = add i64 %114, 152
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = add i64 %117, 56
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
+  %123 = zext i8 %122 to i32
+  %124 = icmp ne i32 %123, 0
+  br i1 %124, label %126, label %125
+
+; <label>:125                                     ; preds = %113
+  ret i8 0
+
+; <label>:126                                     ; preds = %113
+  %127 = load i32, i32* %loc2
+  %128 = add i32 %127, 1
+  store i32 %128, i32* %loc2
+  br label %129
+
+; <label>:129                                     ; preds = %89, %126
+  %130 = load i32, i32* %loc2
+  %131 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %NullCheck9 = icmp eq %"System.Type[]" addrspace(1)* %131, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %132
+
+; <label>:132                                     ; preds = %129
+  %133 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %131, i32 0, i32 1
+  %134 = load i32, i32 addrspace(1)* %133
+  %135 = zext i32 %134 to i64
+  %136 = trunc i64 %135 to i32
+  %137 = icmp slt i32 %130, %136
+  br i1 %137, label %100, label %138
+
+; <label>:138                                     ; preds = %132
+  ret i8 1
+
+; <label>:139                                     ; preds = %34, %73
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %129
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %103
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -2893,7 +3248,7 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElem]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -2904,8 +3259,8 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -2997,8 +3352,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
@@ -3059,8 +3414,8 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -3087,8 +3442,8 @@ entry:
 
 ; <label>:17                                      ; preds = %5, %11
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
@@ -3097,8 +3452,8 @@ entry:
 
 ; <label>:22                                      ; preds = %1, %11
   %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
@@ -3109,11 +3464,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %17
+ThrowNullRef2:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %22
+ThrowNullRef4:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3167,15 +3522,15 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
   %15 = load i32, i32 addrspace(1)* %14
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
@@ -3198,7 +3553,7 @@ ThrowNullRef:                                     ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef2:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3232,8 +3587,8 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
@@ -3312,8 +3667,8 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -3327,8 +3682,8 @@ entry:
 ; <label>:5                                       ; preds = %43
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %7 = load i32, i32* %loc1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck6, label %8, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
@@ -3366,8 +3721,8 @@ entry:
 ; <label>:32                                      ; preds = %21, %25
   %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
   %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
-  br i1 %NullCheck8, label %35, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = trunc i32 %34 to i16
@@ -3380,8 +3735,8 @@ entry:
 ; <label>:40                                      ; preds = %1, %35
   %41 = load i32, i32* %loc1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
-  br i1 %NullCheck2, label %43, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %42, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
@@ -3392,8 +3747,8 @@ entry:
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
   %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
-  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
   %51 = load i64, i64 addrspace(1)* %49
@@ -3412,19 +3767,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %40
+ThrowNullRef2:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %47
+ThrowNullRef4:                                    ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %5
+ThrowNullRef6:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %32
+ThrowNullRef8:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3467,8 +3822,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
@@ -3492,11 +3847,391 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(i16* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store i16* %param0, i16** %arg0
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load i32, i32* %arg3
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %42, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %37, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg2
+  %13 = load i32, i32* %arg3
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %37, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %24 = load i32, i32* %arg2
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load i16*, i16** %arg0
+  %35 = load i32, i32* %arg3
+  %36 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %36, i16* %34, i32 %35)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:37                                      ; preds = %5, %16
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %39)
+  %41 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41, %System.String addrspace(1)* %38, %System.String addrspace(1)* %40)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41) #0
+  unreachable
+
+; <label>:42                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
-Failed to read StringBuilder.ToString[loadElemA]
+Successfully read StringBuilder.ToString
+
+define %System.String addrspace(1)* @StringBuilder.ToString(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i16*
+  %loc3 = alloca %"System.Char[]" addrspace(1)*
+  %loc4 = alloca i32
+  %loc5 = alloca i32
+  %loc6 = alloca i16 addrspace(1)*
+  %loc7 = alloca %System.String addrspace(1)*
+  %loc8 = alloca %"System.Char[]" addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %0)
+  %2 = icmp ne i32 %1, 0
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %4
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %6)
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %7)
+  store %System.String addrspace(1)* %8, %System.String addrspace(1)** %loc0
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.Text.StringBuilder addrspace(1)* %9, %System.Text.StringBuilder addrspace(1)** %loc1
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  store %System.String addrspace(1)* %10, %System.String addrspace(1)** %loc7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc7
+  %12 = ptrtoint %System.String addrspace(1)* %11 to i64
+  %13 = icmp eq i64 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %5
+  %15 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %16 = sext i32 %15 to i64
+  %17 = add i64 %12, %16
+  br label %18
+
+; <label>:18                                      ; preds = %5, %14
+  %19 = phi i64 [ %12, %5 ], [ %17, %14 ]
+  %20 = inttoptr i64 %19 to i16*
+  store i16* %20, i16** %loc2
+  br label %21
+
+; <label>:21                                      ; preds = %98, %18
+  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %22, null
+  br i1 %NullCheck, label %ThrowNullRef, label %23
+
+; <label>:23                                      ; preds = %21
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 3
+  %25 = load i32, i32 addrspace(1)* %24, align 8
+  %26 = icmp sle i32 %25, 0
+  br i1 %26, label %96, label %27
+
+; <label>:27                                      ; preds = %23
+  %28 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %28, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %29
+
+; <label>:29                                      ; preds = %27
+  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %28, i32 0, i32 1
+  %31 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %30, align 8
+  store %"System.Char[]" addrspace(1)* %31, %"System.Char[]" addrspace(1)** %loc3
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %33
+
+; <label>:33                                      ; preds = %29
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  store i32 %35, i32* %loc4
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  %39 = load i32, i32 addrspace(1)* %38, align 8
+  store i32 %39, i32* %loc5
+  %40 = load i32, i32* %loc5
+  %41 = load i32, i32* %loc4
+  %42 = add i32 %40, %41
+  %43 = zext i32 %42 to i64
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %45
+
+; <label>:45                                      ; preds = %37
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = sext i32 %47 to i64
+  %49 = icmp sgt i64 %43, %48
+  br i1 %49, label %91, label %50
+
+; <label>:50                                      ; preds = %45
+  %51 = load i32, i32* %loc5
+  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %52, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %53
+
+; <label>:53                                      ; preds = %50
+  %54 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %52, i32 0, i32 1
+  %55 = load i32, i32 addrspace(1)* %54
+  %56 = zext i32 %55 to i64
+  %57 = trunc i64 %56 to i32
+  %58 = icmp ugt i32 %51, %57
+  br i1 %58, label %91, label %59
+
+; <label>:59                                      ; preds = %53
+  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  store %"System.Char[]" addrspace(1)* %60, %"System.Char[]" addrspace(1)** %loc8
+  %61 = icmp eq %"System.Char[]" addrspace(1)* %60, null
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %63, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %64
+
+; <label>:64                                      ; preds = %62
+  %65 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %63, i32 0, i32 1
+  %66 = load i32, i32 addrspace(1)* %65
+  %67 = zext i32 %66 to i64
+  %68 = trunc i64 %67 to i32
+  %69 = icmp ne i32 %68, 0
+  br i1 %69, label %71, label %70
+
+; <label>:70                                      ; preds = %59, %64
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:71                                      ; preds = %64
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %73
+
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %BoundsCheck = icmp uge i64 0, %76
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %77
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %78, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:79                                      ; preds = %70, %77
+  %80 = load i16*, i16** %loc2
+  %81 = load i32, i32* %loc4
+  %82 = sext i32 %81 to i64
+  %83 = mul i64 %82, 2
+  %84 = bitcast i16* %80 to i8*
+  %85 = getelementptr inbounds i8, i8* %84, i64 %83
+  %86 = load i16 addrspace(1)*, i16 addrspace(1)** %loc6
+  %87 = ptrtoint i16 addrspace(1)* %86 to i64
+  %88 = load i32, i32* %loc5
+  %89 = bitcast i8* %85 to i16*
+  %90 = inttoptr i64 %87 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %89, i16* %90, i32 %88)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %96
+
+; <label>:91                                      ; preds = %45, %53
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %94 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %93)
+  %95 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95, %System.String addrspace(1)* %92, %System.String addrspace(1)* %94)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95) #0
+  unreachable
+
+; <label>:96                                      ; preds = %23, %79
+  %97 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %97, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %98
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %97, i32 0, i32 2
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  store %System.Text.StringBuilder addrspace(1)* %100, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %102 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %102, label %21, label %103
+
+; <label>:103                                     ; preds = %98
+  store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc7
+  %104 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  ret %System.String addrspace(1)* %104
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method StringBuilder::get_Length using LLILCJit
+Successfully read StringBuilder.get_Length
+
+define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
+Successfully read RuntimeHelpers.get_OffsetToStringData
+
+define i32 @RuntimeHelpers.get_OffsetToStringData() {
+entry:
+  ret i32 12
+}
+
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
 Successfully read CultureData.CreateCultureData
 
@@ -3514,23 +4249,23 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
   store i8 %4, i8 addrspace(1)* %6
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
@@ -3549,11 +4284,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3566,50 +4301,50 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
   store i32 -1, i32 addrspace(1)* %2
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
   store i32 -1, i32 addrspace(1)* %8
   %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
   store i32 -1, i32 addrspace(1)* %14
   %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
   store i32 -1, i32 addrspace(1)* %17
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
@@ -3623,27 +4358,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3675,7 +4410,136 @@ Failed to read Dictionary`2.Insert[non-const derefAddress]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
 Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
-Failed to read HashHelpers.GetPrime[loadElem]
+Successfully read HashHelpers.GetPrime
+
+define i32 @HashHelpers.GetPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %6, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5, %System.String addrspace(1)* %4)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5) #0
+  unreachable
+
+; <label>:6                                       ; preds = %entry
+  store i32 0, i32* %loc0
+  br label %29
+
+; <label>:7                                       ; preds = %35
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 1296
+  %10 = addrspacecast i8 addrspace(1)* %9 to %"System.Int32[]" addrspace(1)**
+  %11 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %10
+  %12 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Int32[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = zext i32 %15 to i64
+  %17 = zext i32 %12 to i64
+  %BoundsCheck = icmp uge i64 %17, %16
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 3, i32 %12
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  store i32 %20, i32* %loc1
+  %21 = load i32, i32* %loc1
+  %22 = load i32, i32* %arg0
+  %23 = icmp slt i32 %21, %22
+  br i1 %23, label %26, label %24
+
+; <label>:24                                      ; preds = %18
+  %25 = load i32, i32* %loc1
+  ret i32 %25
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %loc0
+  %28 = add i32 %27, 1
+  store i32 %28, i32* %loc0
+  br label %29
+
+; <label>:29                                      ; preds = %6, %26
+  %30 = load i32, i32* %loc0
+  %31 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %32 = getelementptr inbounds i8, i8 addrspace(1)* %31, i64 1296
+  %33 = addrspacecast i8 addrspace(1)* %32 to %"System.Int32[]" addrspace(1)**
+  %34 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %33
+  %NullCheck = icmp eq %"System.Int32[]" addrspace(1)* %34, null
+  br i1 %NullCheck, label %ThrowNullRef, label %35
+
+; <label>:35                                      ; preds = %29
+  %36 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %34, i32 0, i32 1
+  %37 = load i32, i32 addrspace(1)* %36
+  %38 = zext i32 %37 to i64
+  %39 = trunc i64 %38 to i32
+  %40 = icmp slt i32 %30, %39
+  br i1 %40, label %7, label %41
+
+; <label>:41                                      ; preds = %35
+  %42 = load i32, i32* %arg0
+  %43 = or i32 %42, 1
+  store i32 %43, i32* %loc2
+  br label %59
+
+; <label>:44                                      ; preds = %59
+  %45 = load i32, i32* %loc2
+  %46 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %45)
+  %47 = zext i8 %46 to i32
+  %48 = icmp eq i32 %47, 0
+  br i1 %48, label %56, label %49
+
+; <label>:49                                      ; preds = %44
+  %50 = load i32, i32* %loc2
+  %51 = sub i32 %50, 1
+  %52 = srem i32 %51, 101
+  %53 = icmp eq i32 %52, 0
+  br i1 %53, label %56, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = load i32, i32* %loc2
+  ret i32 %55
+
+; <label>:56                                      ; preds = %44, %49
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %57, 2
+  store i32 %58, i32* %loc2
+  br label %59
+
+; <label>:59                                      ; preds = %41, %56
+  %60 = load i32, i32* %loc2
+  %61 = icmp slt i32 %60, 2147483647
+  br i1 %61, label %44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load i32, i32* %arg0
+  ret i32 %63
+
+ThrowNullRef:                                     ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
 Successfully read GenericEqualityComparer`1.GetHashCode
 
@@ -3694,14 +4558,14 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
   %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load i64, i64 addrspace(1)* %7
@@ -3720,7 +4584,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3750,8 +4614,8 @@ entry:
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
@@ -3796,8 +4660,8 @@ entry:
   %35 = bitcast i16* %34 to i8*
   %36 = getelementptr inbounds i8, i8* %35, i64 2
   %37 = bitcast i8* %36 to i16*
-  %NullCheck4 = icmp ne i16* %37, null
-  br i1 %NullCheck4, label %38, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %37, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %38
 
 ; <label>:38                                      ; preds = %27
   %39 = load i16, i16* %37, align 8
@@ -3824,8 +4688,8 @@ entry:
 
 ; <label>:54                                      ; preds = %22, %43
   %55 = load i16*, i16** %loc4
-  %NullCheck2 = icmp ne i16* %55, null
-  br i1 %NullCheck2, label %56, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i16* %55, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %56
 
 ; <label>:56                                      ; preds = %54
   %57 = load i16, i16* %55, align 8
@@ -3850,11 +4714,11 @@ ThrowNullRef:                                     ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %54
+ThrowNullRef2:                                    ; preds = %54
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %27
+ThrowNullRef4:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3871,8 +4735,8 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -3907,8 +4771,8 @@ entry:
 
 ; <label>:26                                      ; preds = %19
   %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
-  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %28
 
 ; <label>:28                                      ; preds = %26
   %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
@@ -3920,7 +4784,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3972,8 +4836,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
@@ -3984,26 +4848,26 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
-  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
@@ -4014,8 +4878,8 @@ entry:
 ; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
@@ -4024,8 +4888,8 @@ entry:
 
 ; <label>:25                                      ; preds = %1, %16, %23
   %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
-  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
@@ -4036,27 +4900,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %20
+ThrowNullRef10:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4069,8 +4933,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -4081,8 +4945,8 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
@@ -4091,8 +4955,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1, %8
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
@@ -4103,11 +4967,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4128,24 +4992,24 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   store i32 %3, i32* %loc0
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
   %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
   store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck4, label %9, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
@@ -4164,15 +5028,15 @@ entry:
 ; <label>:18                                      ; preds = %70
   %19 = load i16*, i16** %loc3
   %20 = bitcast i16* %19 to i64*
-  %NullCheck10 = icmp ne i64* %20, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %20, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = load i64, i64* %20, align 8
   %23 = load i16*, i16** %loc4
   %24 = bitcast i16* %23 to i64*
-  %NullCheck12 = icmp ne i64* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = load i64, i64* %24, align 8
@@ -4188,8 +5052,8 @@ entry:
   %31 = bitcast i16* %30 to i8*
   %32 = getelementptr inbounds i8, i8* %31, i64 8
   %33 = bitcast i8* %32 to i64*
-  %NullCheck14 = icmp ne i64* %33, null
-  br i1 %NullCheck14, label %34, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = load i64, i64* %33, align 8
@@ -4197,8 +5061,8 @@ entry:
   %37 = bitcast i16* %36 to i8*
   %38 = getelementptr inbounds i8, i8* %37, i64 8
   %39 = bitcast i8* %38 to i64*
-  %NullCheck16 = icmp ne i64* %39, null
-  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %40
 
 ; <label>:40                                      ; preds = %34
   %41 = load i64, i64* %39, align 8
@@ -4214,8 +5078,8 @@ entry:
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %NullCheck18 = icmp ne i64* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = load i64, i64* %48, align 8
@@ -4223,8 +5087,8 @@ entry:
   %52 = bitcast i16* %51 to i8*
   %53 = getelementptr inbounds i8, i8* %52, i64 16
   %54 = bitcast i8* %53 to i64*
-  %NullCheck20 = icmp ne i64* %54, null
-  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64* %54, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %55
 
 ; <label>:55                                      ; preds = %49
   %56 = load i64, i64* %54, align 8
@@ -4262,15 +5126,15 @@ entry:
 ; <label>:74                                      ; preds = %95
   %75 = load i16*, i16** %loc3
   %76 = bitcast i16* %75 to i32*
-  %NullCheck6 = icmp ne i32* %76, null
-  br i1 %NullCheck6, label %77, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32* %76, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %77
 
 ; <label>:77                                      ; preds = %74
   %78 = load i32, i32* %76, align 8
   %79 = load i16*, i16** %loc4
   %80 = bitcast i16* %79 to i32*
-  %NullCheck8 = icmp ne i32* %80, null
-  br i1 %NullCheck8, label %81, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i32* %80, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %81
 
 ; <label>:81                                      ; preds = %77
   %82 = load i32, i32* %80, align 8
@@ -4318,43 +5182,43 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %74
+ThrowNullRef6:                                    ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %77
+ThrowNullRef8:                                    ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %29
+ThrowNullRef14:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %34
+ThrowNullRef16:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4376,8 +5240,8 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load i64, i64 addrspace(1)* %4
@@ -4389,8 +5253,8 @@ entry:
   %12 = load i64, i64* %11
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %5
   %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
@@ -4399,8 +5263,8 @@ entry:
   %18 = load i8, i8* %arg2
   %19 = zext i8 %18 to i32
   %20 = trunc i32 %19 to i8
-  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %15
   %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
@@ -4411,11 +5275,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4442,8 +5306,8 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
@@ -4466,16 +5330,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
   %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = load i64, i64 addrspace(1)* %19
@@ -4500,8 +5364,8 @@ entry:
 ; <label>:35                                      ; preds = %30
   %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
@@ -4514,8 +5378,8 @@ entry:
 
 ; <label>:42                                      ; preds = %1, %38
   %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
-  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
@@ -4526,19 +5390,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %35
+ThrowNullRef2:                                    ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %42
+ThrowNullRef8:                                    ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4551,14 +5415,14 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
@@ -4570,7 +5434,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4583,8 +5447,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
@@ -4613,51 +5477,51 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
   %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
   %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
   %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
   %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
-  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
   store i64 %21, i64 addrspace(1)* %23
   %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %25 = load i64, i64* %loc0
-  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
@@ -4668,27 +5532,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %22
+ThrowNullRef12:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4701,8 +5565,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
@@ -4713,19 +5577,19 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
@@ -4734,8 +5598,8 @@ entry:
 
 ; <label>:15                                      ; preds = %1, %13
   %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
@@ -4746,19 +5610,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %15
+ThrowNullRef8:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4771,8 +5635,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -4831,8 +5695,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
@@ -4882,8 +5746,8 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
-  br i1 %NullCheck, label %17, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %ThrowNullRef, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
@@ -4894,15 +5758,15 @@ entry:
 
 ; <label>:22                                      ; preds = %17
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
-  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
   %26 = load i32, i32 addrspace(1)* %25
   %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
-  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %27, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
@@ -4925,8 +5789,8 @@ entry:
 ; <label>:40                                      ; preds = %17
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
-  br i1 %NullCheck6, label %43, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %41, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
@@ -4938,34 +5802,17 @@ ThrowNullRef:                                     ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %24
+ThrowNullRef4:                                    ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %40
+ThrowNullRef6:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
-}
-
-INFO:  jitting method Object::ReferenceEquals using LLILCJit
-Successfully read Object.ReferenceEquals
-
-define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
-entry:
-  %arg0 = alloca %System.Object addrspace(1)*
-  %arg1 = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
-  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
-  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = icmp eq %System.Object addrspace(1)* %0, %1
-  %3 = sext i1 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
 }
 
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
@@ -4978,21 +5825,21 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
   %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
-  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
@@ -5007,28 +5854,28 @@ entry:
 ; <label>:13                                      ; preds = %8, %12
   %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
   %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
   %21 = load i32, i32 addrspace(1)* %20, align 8
   %22 = add i32 %21, 1
-  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
   store i32 %22, i32 addrspace(1)* %24
   %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
@@ -5039,27 +5886,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5077,7 +5924,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::Setup using LLILCJit
-Failed to read AppDomain.Setup[loadElem]
+Failed to read AppDomain.Setup[unbox]
 INFO:  jitting method Thread::GetDomain using LLILCJit
 Successfully read Thread.GetDomain
 
@@ -5108,8 +5955,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
@@ -5122,14 +5969,14 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
   %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
@@ -5141,11 +5988,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5173,8 +6020,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -5189,7 +6036,328 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
 Failed to read KeyCollection.System.Collections.Generic.IEnumerable<TKey>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Successfully read Enumerator.MoveNext
+
+define i8 @Enumerator.MoveNext(%"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.RuntimeTypeHandle* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*
+  %"$TypeArg" = alloca %System.RuntimeTypeHandle*
+  store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
+  %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 8
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %76, label %12
+
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
+  br label %76
+
+; <label>:13                                      ; preds = %85
+  %14 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck19 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %15
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, i32 0, i32 0
+  %17 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %16, align 8
+  %NullCheck21 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, i32 0, i32 2
+  %20 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %19, align 8
+  %21 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck23 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %22
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, i32 0, i32 2
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %NullCheck25 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 3, i32 %24
+  %NullCheck27 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %32
+
+; <label>:32                                      ; preds = %30
+  %33 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, i32 0, i32 2
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = icmp slt i32 %34, 0
+  br i1 %35, label %68, label %36
+
+; <label>:36                                      ; preds = %32
+  %37 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %38 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck29 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %39
+
+; <label>:39                                      ; preds = %36
+  %40 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, i32 0, i32 0
+  %41 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %40, align 8
+  %NullCheck31 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, i32 0, i32 2
+  %44 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %43, align 8
+  %45 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck33 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, i32 0, i32 2
+  %48 = load i32, i32 addrspace(1)* %47, align 8
+  %NullCheck35 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %49
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = zext i32 %51 to i64
+  %53 = zext i32 %48 to i64
+  %BoundsCheck37 = icmp uge i64 %53, %52
+  br i1 %BoundsCheck37, label %ThrowIndexOutOfRange38, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 3, i32 %48
+  %NullCheck39 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %56
+
+; <label>:56                                      ; preds = %54
+  %57 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, i32 0, i32 0
+  %58 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck41 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %59
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %60, %System.__Canon addrspace(1)* %58)
+  %61 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck43 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  %64 = load i32, i32 addrspace(1)* %63, align 8
+  %65 = add i32 %64, 1
+  %NullCheck45 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  store i32 %65, i32 addrspace(1)* %67
+  ret i8 1
+
+; <label>:68                                      ; preds = %32
+  %69 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck47 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %73 = add i32 %72, 1
+  %NullCheck49 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %74
+
+; <label>:74                                      ; preds = %70
+  %75 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  store i32 %73, i32 addrspace(1)* %75
+  br label %76
+
+; <label>:76                                      ; preds = %8, %12, %74
+  %77 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %78
+
+; <label>:78                                      ; preds = %76
+  %79 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, i32 0, i32 2
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck7 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %82
+
+; <label>:82                                      ; preds = %78
+  %83 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, i32 0, i32 0
+  %84 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %83, align 8
+  %NullCheck9 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %85
+
+; <label>:85                                      ; preds = %82
+  %86 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, i32 0, i32 7
+  %87 = load i32, i32 addrspace(1)* %86, align 8
+  %88 = icmp ult i32 %80, %87
+  br i1 %88, label %13, label %89
+
+; <label>:89                                      ; preds = %85
+  %90 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %91 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck11 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %92
+
+; <label>:92                                      ; preds = %89
+  %93 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, i32 0, i32 0
+  %94 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck13 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %95
+
+; <label>:95                                      ; preds = %92
+  %96 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, i32 0, i32 7
+  %97 = load i32, i32 addrspace(1)* %96, align 8
+  %98 = add i32 %97, 1
+  %NullCheck15 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %99
+
+; <label>:99                                      ; preds = %95
+  %100 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, i32 0, i32 2
+  store i32 %98, i32 addrspace(1)* %100
+  %101 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck17 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %102
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %103, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %92
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef22:                                   ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef24:                                   ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef26:                                   ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef28:                                   ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef30:                                   ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef32:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef34:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef36:                                   ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange38:                           ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef40:                                   ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef42:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef44:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef46:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef48:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef50:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -5200,8 +6368,8 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -5232,9 +6400,9 @@ Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
 Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
-Failed to read String.MakeSeparatorList[loadElemA]
+Failed to read String.MakeSeparatorList[storeElem]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
-Failed to read String.InternalSplitKeepEmptyEntries[loadElem]
+Failed to read String.InternalSplitKeepEmptyEntries[storeElem]
 INFO:  jitting method Path::IsRelative using LLILCJit
 Successfully read Path.IsRelative
 
@@ -5243,8 +6411,8 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -5254,8 +6422,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
@@ -5271,8 +6439,8 @@ entry:
 
 ; <label>:17                                      ; preds = %7
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
@@ -5288,8 +6456,8 @@ entry:
 
 ; <label>:29                                      ; preds = %19
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %31
 
 ; <label>:31                                      ; preds = %29
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
@@ -5300,8 +6468,8 @@ entry:
 
 ; <label>:36                                      ; preds = %31
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
-  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %37, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
@@ -5312,8 +6480,8 @@ entry:
 
 ; <label>:43                                      ; preds = %31, %38
   %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
-  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %45
 
 ; <label>:45                                      ; preds = %43
   %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
@@ -5324,8 +6492,8 @@ entry:
 
 ; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %50
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
@@ -5336,8 +6504,8 @@ entry:
 
 ; <label>:57                                      ; preds = %1, %7, %19, %45, %52
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
-  br i1 %NullCheck14, label %59, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %59
 
 ; <label>:59                                      ; preds = %57
   %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
@@ -5347,8 +6515,8 @@ entry:
 
 ; <label>:63                                      ; preds = %59
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
@@ -5359,8 +6527,8 @@ entry:
 
 ; <label>:70                                      ; preds = %65
   %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
-  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.String addrspace(1)* %71, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %72
 
 ; <label>:72                                      ; preds = %70
   %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
@@ -5379,39 +6547,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %17
+ThrowNullRef4:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %29
+ThrowNullRef6:                                    ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %36
+ThrowNullRef8:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %43
+ThrowNullRef10:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %50
+ThrowNullRef12:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %57
+ThrowNullRef14:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %63
+ThrowNullRef16:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %70
+ThrowNullRef18:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5419,7 +6587,293 @@ ThrowNullRef17:                                   ; preds = %70
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
-Failed to read String.TrimHelper[loadElem]
+Successfully read String.TrimHelper
+
+define %System.String addrspace(1)* @String.TrimHelper(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i16
+  %loc4 = alloca i32
+  %loc5 = alloca i16
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = sub i32 %3, 1
+  store i32 %4, i32* %loc0
+  store i32 0, i32* %loc1
+  %5 = load i32, i32* %arg2
+  %6 = icmp eq i32 %5, 1
+  br i1 %6, label %62, label %7
+
+; <label>:7                                       ; preds = %1
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:8                                       ; preds = %58
+  store i32 0, i32* %loc2
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load i32, i32* %loc1
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2, i32 %10
+  %13 = load i16, i16 addrspace(1)* %12
+  %14 = zext i16 %13 to i32
+  %15 = trunc i32 %14 to i16
+  store i16 %15, i16* %loc3
+  store i32 0, i32* %loc2
+  br label %34
+
+; <label>:16                                      ; preds = %37
+  %17 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %18 = load i32, i32* %loc2
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %17, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %19
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = zext i32 %18 to i64
+  %BoundsCheck = icmp uge i64 %23, %22
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %24
+
+; <label>:24                                      ; preds = %19
+  %25 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 3, i32 %18
+  %26 = load i16, i16 addrspace(1)* %25, align 8
+  %27 = zext i16 %26 to i32
+  %28 = load i16, i16* %loc3
+  %29 = zext i16 %28 to i32
+  %30 = icmp eq i32 %27, %29
+  br i1 %30, label %43, label %31
+
+; <label>:31                                      ; preds = %24
+  %32 = load i32, i32* %loc2
+  %33 = add i32 %32, 1
+  store i32 %33, i32* %loc2
+  br label %34
+
+; <label>:34                                      ; preds = %11, %31
+  %35 = load i32, i32* %loc2
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = icmp slt i32 %35, %41
+  br i1 %42, label %16, label %43
+
+; <label>:43                                      ; preds = %24, %37
+  %44 = load i32, i32* %loc2
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %45, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp eq i32 %44, %50
+  br i1 %51, label %62, label %52
+
+; <label>:52                                      ; preds = %46
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %7, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %57, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %58
+
+; <label>:58                                      ; preds = %55
+  %59 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %60 = load i32, i32 addrspace(1)* %59
+  %61 = icmp slt i32 %56, %60
+  br i1 %61, label %8, label %62
+
+; <label>:62                                      ; preds = %1, %46, %58
+  %63 = load i32, i32* %arg2
+  %64 = icmp eq i32 %63, 0
+  br i1 %64, label %122, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %66, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %67
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %66, i32 0, i32 1
+  %69 = load i32, i32 addrspace(1)* %68
+  %70 = sub i32 %69, 1
+  store i32 %70, i32* %loc0
+  br label %118
+
+; <label>:71                                      ; preds = %118
+  store i32 0, i32* %loc4
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %73 = load i32, i32* %loc0
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %74
+
+; <label>:74                                      ; preds = %71
+  %75 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 2, i32 %73
+  %76 = load i16, i16 addrspace(1)* %75
+  %77 = zext i16 %76 to i32
+  %78 = trunc i32 %77 to i16
+  store i16 %78, i16* %loc5
+  store i32 0, i32* %loc4
+  br label %97
+
+; <label>:79                                      ; preds = %100
+  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %81 = load i32, i32* %loc4
+  %NullCheck19 = icmp eq %"System.Char[]" addrspace(1)* %80, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
+
+; <label>:82                                      ; preds = %79
+  %83 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 1
+  %84 = load i32, i32 addrspace(1)* %83
+  %85 = zext i32 %84 to i64
+  %86 = zext i32 %81 to i64
+  %BoundsCheck21 = icmp uge i64 %86, %85
+  br i1 %BoundsCheck21, label %ThrowIndexOutOfRange22, label %87
+
+; <label>:87                                      ; preds = %82
+  %88 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 3, i32 %81
+  %89 = load i16, i16 addrspace(1)* %88, align 8
+  %90 = zext i16 %89 to i32
+  %91 = load i16, i16* %loc5
+  %92 = zext i16 %91 to i32
+  %93 = icmp eq i32 %90, %92
+  br i1 %93, label %106, label %94
+
+; <label>:94                                      ; preds = %87
+  %95 = load i32, i32* %loc4
+  %96 = add i32 %95, 1
+  store i32 %96, i32* %loc4
+  br label %97
+
+; <label>:97                                      ; preds = %74, %94
+  %98 = load i32, i32* %loc4
+  %99 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck15 = icmp eq %"System.Char[]" addrspace(1)* %99, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %100
+
+; <label>:100                                     ; preds = %97
+  %101 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %99, i32 0, i32 1
+  %102 = load i32, i32 addrspace(1)* %101
+  %103 = zext i32 %102 to i64
+  %104 = trunc i64 %103 to i32
+  %105 = icmp slt i32 %98, %104
+  br i1 %105, label %79, label %106
+
+; <label>:106                                     ; preds = %87, %100
+  %107 = load i32, i32* %loc4
+  %108 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck17 = icmp eq %"System.Char[]" addrspace(1)* %108, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %109
+
+; <label>:109                                     ; preds = %106
+  %110 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %108, i32 0, i32 1
+  %111 = load i32, i32 addrspace(1)* %110
+  %112 = zext i32 %111 to i64
+  %113 = trunc i64 %112 to i32
+  %114 = icmp eq i32 %107, %113
+  br i1 %114, label %122, label %115
+
+; <label>:115                                     ; preds = %109
+  %116 = load i32, i32* %loc0
+  %117 = sub i32 %116, 1
+  store i32 %117, i32* %loc0
+  br label %118
+
+; <label>:118                                     ; preds = %67, %115
+  %119 = load i32, i32* %loc0
+  %120 = load i32, i32* %loc1
+  %121 = icmp sge i32 %119, %120
+  br i1 %121, label %71, label %122
+
+; <label>:122                                     ; preds = %62, %109, %118
+  %123 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %124 = load i32, i32* %loc1
+  %125 = load i32, i32* %loc0
+  %126 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %123, i32 %124, i32 %125)
+  ret %System.String addrspace(1)* %126
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %97
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange22:                           ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
 Successfully read String.CreateTrimmedString
 
@@ -5439,8 +6893,8 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
@@ -5535,8 +6989,8 @@ entry:
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i64 2872
   %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
   %8 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %7
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %3
   %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
@@ -5553,8 +7007,8 @@ entry:
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 2864
   %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
   %21 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %20
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
-  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %22
 
 ; <label>:22                                      ; preds = %16
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
@@ -5569,7 +7023,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %16
+ThrowNullRef2:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5586,8 +7040,8 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5613,8 +7067,8 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
@@ -5632,8 +7086,8 @@ entry:
 
 ; <label>:12                                      ; preds = %4
   %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
@@ -5644,8 +7098,8 @@ entry:
 
 ; <label>:19                                      ; preds = %14
   %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %19
   %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
@@ -5660,21 +7114,21 @@ entry:
   %31 = zext i16 %30 to i32
   %32 = bitcast i8* %29 to i16*
   %33 = trunc i32 %31 to i16
-  %NullCheck6 = icmp ne i16* %32, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i16* %32, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %21
   store i16 %33, i16* %32, align 8
   %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %36
 
 ; <label>:36                                      ; preds = %34
   %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
   %38 = load i32, i32 addrspace(1)* %37, align 8
   %39 = add i32 %38, 1
-  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %40
 
 ; <label>:40                                      ; preds = %36
   %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
@@ -5683,16 +7137,16 @@ entry:
 
 ; <label>:42                                      ; preds = %14
   %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
-  br i1 %NullCheck12, label %44, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
   %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
   %47 = load i16, i16* %arg1
   %48 = zext i16 %47 to i32
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = trunc i32 %48 to i16
@@ -5703,31 +7157,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %19
+ThrowNullRef4:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %21
+ThrowNullRef6:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %36
+ThrowNullRef10:                                   ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %42
+ThrowNullRef12:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %44
+ThrowNullRef14:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5740,8 +7194,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -5752,8 +7206,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
@@ -5762,14 +7216,14 @@ entry:
 
 ; <label>:11                                      ; preds = %1
   %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
@@ -5779,15 +7233,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5808,8 +7262,8 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5822,8 +7276,8 @@ entry:
 
 ; <label>:8                                       ; preds = %3
   %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
@@ -5842,15 +7296,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
-  br i1 %NullCheck4, label %22, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
   %24 = load i16*, i16* addrspace(1)* %23, align 8
   %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %25, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
@@ -5859,8 +7313,8 @@ entry:
   store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
@@ -5874,8 +7328,8 @@ entry:
 
 ; <label>:37                                      ; preds = %65
   %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %37
   %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
@@ -5886,16 +7340,16 @@ entry:
   %45 = bitcast i16* %41 to i8*
   %46 = getelementptr inbounds i8, i8* %45, i64 %44
   %47 = bitcast i8* %46 to i16*
-  %NullCheck14 = icmp ne i16* %47, null
-  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %47, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %48
 
 ; <label>:48                                      ; preds = %39
   %49 = load i16, i16* %47, align 8
   %50 = zext i16 %49 to i32
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %52 = load i32, i32* %loc1
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %53
 
 ; <label>:53                                      ; preds = %48
   %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
@@ -5916,8 +7370,8 @@ entry:
 ; <label>:62                                      ; preds = %36, %59
   %63 = load i32, i32* %loc1
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck10, label %65, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %65
 
 ; <label>:65                                      ; preds = %62
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
@@ -5936,15 +7390,15 @@ entry:
 
 ; <label>:74                                      ; preds = %70
   %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
-  br i1 %NullCheck18, label %76, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %76
 
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
   %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
-  br i1 %NullCheck20, label %80, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
   %81 = load i64, i64 addrspace(1)* %79
@@ -5958,8 +7412,8 @@ entry:
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
   %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
-  br i1 %NullCheck22, label %92, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.String addrspace(1)* %90, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %92
 
 ; <label>:92                                      ; preds = %80
   %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
@@ -5969,15 +7423,15 @@ entry:
 
 ; <label>:96                                      ; preds = %70
   %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
-  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %98
 
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
   %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
-  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
   %103 = load i64, i64 addrspace(1)* %101
@@ -5991,8 +7445,8 @@ entry:
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
   %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
-  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.String addrspace(1)* %112, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %114
 
 ; <label>:114                                     ; preds = %102
   %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
@@ -6004,59 +7458,59 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %20
+ThrowNullRef4:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %22
+ThrowNullRef6:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %26
+ThrowNullRef8:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %62
+ThrowNullRef10:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %48
+ThrowNullRef16:                                   ; preds = %48
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %74
+ThrowNullRef18:                                   ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %76
+ThrowNullRef20:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %80
+ThrowNullRef22:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %96
+ThrowNullRef24:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %98
+ThrowNullRef26:                                   ; preds = %98
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %102
+ThrowNullRef28:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6069,15 +7523,15 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
   %3 = load i16*, i16* addrspace(1)* %2, align 8
   %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
@@ -6087,8 +7541,8 @@ entry:
   %10 = bitcast i16* %3 to i8*
   %11 = getelementptr inbounds i8, i8* %10, i64 %9
   %12 = bitcast i8* %11 to i16*
-  %NullCheck4 = icmp ne i16* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %5
   store i16 0, i16* %12, align 8
@@ -6098,11 +7552,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6119,8 +7573,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -6131,8 +7585,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
@@ -6144,15 +7598,15 @@ entry:
 
 ; <label>:14                                      ; preds = %1
   %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
   %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
   %21 = load i64, i64 addrspace(1)* %19
@@ -6171,15 +7625,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %14
+ThrowNullRef4:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %16
+ThrowNullRef6:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6302,14 +7756,6 @@ entry:
   ret %System.String addrspace(1)* %57
 }
 
-INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
-Successfully read RuntimeHelpers.get_OffsetToStringData
-
-define i32 @RuntimeHelpers.get_OffsetToStringData() {
-entry:
-  ret i32 12
-}
-
 INFO:  jitting method String::Equals using LLILCJit
 Successfully read String.Equals
 
@@ -6381,8 +7827,8 @@ entry:
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
-  br i1 %NullCheck24, label %29, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
   %30 = load i64, i64 addrspace(1)* %28
@@ -6397,8 +7843,8 @@ entry:
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
-  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
   %43 = load i64, i64 addrspace(1)* %41
@@ -6418,8 +7864,8 @@ entry:
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
   %59 = load i64, i64 addrspace(1)* %57
@@ -6434,8 +7880,8 @@ entry:
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck22, label %71, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
   %72 = load i64, i64 addrspace(1)* %70
@@ -6455,8 +7901,8 @@ entry:
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
-  br i1 %NullCheck16, label %87, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = load i64, i64 addrspace(1)* %86
@@ -6471,8 +7917,8 @@ entry:
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck18, label %100, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
   %101 = load i64, i64 addrspace(1)* %99
@@ -6492,8 +7938,8 @@ entry:
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
-  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
   %117 = load i64, i64 addrspace(1)* %115
@@ -6508,8 +7954,8 @@ entry:
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
-  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
   %130 = load i64, i64 addrspace(1)* %128
@@ -6528,15 +7974,15 @@ entry:
 
 ; <label>:142                                     ; preds = %22
   %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
-  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %143, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %144
 
 ; <label>:144                                     ; preds = %142
   %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
   %146 = load i32, i32 addrspace(1)* %145
   %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
-  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %147, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %148
 
 ; <label>:148                                     ; preds = %144
   %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
@@ -6557,15 +8003,15 @@ entry:
 
 ; <label>:159                                     ; preds = %22
   %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
-  br i1 %NullCheck, label %161, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %ThrowNullRef, label %161
 
 ; <label>:161                                     ; preds = %159
   %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
   %163 = load i32, i32 addrspace(1)* %162
   %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
-  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %164, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %165
 
 ; <label>:165                                     ; preds = %161
   %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
@@ -6578,8 +8024,8 @@ entry:
 
 ; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
-  br i1 %NullCheck4, label %172, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %171, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %172
 
 ; <label>:172                                     ; preds = %170
   %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
@@ -6589,8 +8035,8 @@ entry:
 
 ; <label>:176                                     ; preds = %172
   %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
-  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %177, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %178
 
 ; <label>:178                                     ; preds = %176
   %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
@@ -6629,55 +8075,55 @@ ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %161
+ThrowNullRef2:                                    ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %170
+ThrowNullRef4:                                    ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %176
+ThrowNullRef6:                                    ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %142
+ThrowNullRef8:                                    ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %144
+ThrowNullRef10:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %113
+ThrowNullRef12:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %116
+ThrowNullRef14:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %84
+ThrowNullRef16:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %87
+ThrowNullRef18:                                   ; preds = %87
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %55
+ThrowNullRef20:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %58
+ThrowNullRef22:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %26
+ThrowNullRef24:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %29
+ThrowNullRef26:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,8 +8161,8 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck, label %14, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %ThrowNullRef, label %14
 
 ; <label>:14                                      ; preds = %8
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
@@ -6760,8 +8206,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
@@ -6770,14 +8216,14 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32, i32* %loc0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %10
   %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
   %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
@@ -6790,15 +8236,15 @@ entry:
 ; <label>:25                                      ; preds = %19
   %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
-  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
   %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
@@ -6807,8 +8253,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %37 = load i32, i32* %loc0
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %38, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %38
 
 ; <label>:38                                      ; preds = %32
   %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
@@ -6817,14 +8263,14 @@ entry:
 
 ; <label>:40                                      ; preds = %19
   %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %40
   %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
   %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
-  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
-  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
@@ -6832,8 +8278,8 @@ entry:
   %48 = zext i32 %47 to i64
   %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
-  br i1 %NullCheck16, label %51, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %51
 
 ; <label>:51                                      ; preds = %45
   %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
@@ -6847,15 +8293,15 @@ entry:
 ; <label>:57                                      ; preds = %51
   %58 = load i16*, i16** %arg1
   %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
-  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %60
 
 ; <label>:60                                      ; preds = %57
   %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
   %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
-  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %64
 
 ; <label>:64                                      ; preds = %60
   %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
@@ -6864,22 +8310,22 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
   %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
-  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %70
 
 ; <label>:70                                      ; preds = %64
   %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
   %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
-  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
-  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
   %75 = load i32, i32 addrspace(1)* %74
   %76 = zext i32 %75 to i64
   %77 = trunc i64 %76 to i32
-  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
-  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %78
 
 ; <label>:78                                      ; preds = %73
   %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
@@ -6901,8 +8347,8 @@ entry:
   %90 = bitcast i16* %86 to i8*
   %91 = getelementptr inbounds i8, i8* %90, i64 %89
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %93
 
 ; <label>:93                                      ; preds = %80
   %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
@@ -6912,8 +8358,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %99 = load i32, i32* %loc2
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %100
 
 ; <label>:100                                     ; preds = %93
   %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
@@ -6928,63 +8374,63 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %25
+ThrowNullRef6:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %32
+ThrowNullRef10:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %40
+ThrowNullRef12:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %45
+ThrowNullRef16:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %57
+ThrowNullRef18:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %60
+ThrowNullRef20:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %64
+ThrowNullRef22:                                   ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %70
+ThrowNullRef24:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %73
+ThrowNullRef26:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %80
+ThrowNullRef28:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %93
+ThrowNullRef30:                                   ; preds = %93
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7004,8 +8450,8 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
@@ -7033,43 +8479,43 @@ entry:
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %14
   %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
   %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   %28 = load i32, i32 addrspace(1)* %27, align 8
   %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
-  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %30
 
 ; <label>:30                                      ; preds = %26
   %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
   %32 = load i32, i32 addrspace(1)* %31, align 8
   %33 = add i32 %28, %32
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %34
 
 ; <label>:34                                      ; preds = %30
   %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   store i32 %33, i32 addrspace(1)* %35
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
   store i32 0, i32 addrspace(1)* %38
   %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %40
 
 ; <label>:40                                      ; preds = %37
   %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
@@ -7082,8 +8528,8 @@ entry:
 
 ; <label>:47                                      ; preds = %40
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
@@ -7098,8 +8544,8 @@ entry:
   %54 = load i32, i32* %loc0
   %55 = sext i32 %54 to i64
   %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
-  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %57
 
 ; <label>:57                                      ; preds = %52
   %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
@@ -7110,68 +8556,35 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %14
+ThrowNullRef2:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %23
+ThrowNullRef4:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %26
+ThrowNullRef6:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %30
+ThrowNullRef8:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %34
+ThrowNullRef10:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %47
+ThrowNullRef14:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %52
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-}
-
-INFO:  jitting method StringBuilder::get_Length using LLILCJit
-Successfully read StringBuilder.get_Length
-
-define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.StringBuilder addrspace(1)*
-  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
-  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
-
-; <label>:1                                       ; preds = %entry
-  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %3 = load i32, i32 addrspace(1)* %2, align 8
-  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
-
-; <label>:5                                       ; preds = %1
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = add i32 %3, %7
-  ret i32 %8
-
-ThrowNullRef:                                     ; preds = %entry
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef16:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7213,70 +8626,70 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
   %6 = load i32, i32 addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
   store i32 %6, i32 addrspace(1)* %8
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
   %13 = load i32, i32 addrspace(1)* %12, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
   store i32 %13, i32 addrspace(1)* %15
   %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
-  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %18
 
 ; <label>:18                                      ; preds = %14
   %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
   %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
   %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
   %34 = load i32, i32 addrspace(1)* %33, align 8
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
-  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
@@ -7287,39 +8700,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %28
+ThrowNullRef16:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %32
+ThrowNullRef18:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7455,13 +8868,13 @@ entry:
 ; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
@@ -7477,16 +8890,16 @@ entry:
 
 ; <label>:18                                      ; preds = %15
   %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
   store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
   %22 = load i32, i32* %loc0
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %24
 
 ; <label>:24                                      ; preds = %20
   %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
@@ -7498,13 +8911,13 @@ entry:
 ; <label>:28                                      ; preds = %15, %24
   %29 = load i32, i32* %arg1
   %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %31
   %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
@@ -7517,20 +8930,20 @@ entry:
   %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
-  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
   %46 = load i32, i32 addrspace(1)* %45, align 8
   %47 = sub i32 %40, %46
-  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
-  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i32 addrspace(1)* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %48
 
 ; <label>:48                                      ; preds = %44
   store i32 %47, i32 addrspace(1)* %39, align 8
@@ -7538,21 +8951,21 @@ entry:
 
 ; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
-  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %51
 
 ; <label>:51                                      ; preds = %49
   %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %53
 
 ; <label>:53                                      ; preds = %51
   %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
   %55 = load i32, i32 addrspace(1)* %54, align 8
   %56 = load i32, i32* %arg2
   %57 = sub i32 %55, %56
-  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %58
 
 ; <label>:58                                      ; preds = %53
   %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
@@ -7562,13 +8975,13 @@ entry:
 ; <label>:60                                      ; preds = %33, %58
   %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
   %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
-  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %63
 
 ; <label>:63                                      ; preds = %60
   %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
-  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
-  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
@@ -7578,15 +8991,15 @@ entry:
 
 ; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
-  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i32 addrspace(1)* %69, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %70
 
 ; <label>:70                                      ; preds = %68
   %71 = load i32, i32 addrspace(1)* %69, align 8
   store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
-  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
@@ -7596,8 +9009,8 @@ entry:
   store i32 %77, i32* %loc4
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
-  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %80
 
 ; <label>:80                                      ; preds = %73
   %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
@@ -7607,71 +9020,71 @@ entry:
 ; <label>:83                                      ; preds = %80
   store i32 0, i32* %loc3
   %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
-  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
-  br i1 %NullCheck26, label %88, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i32 addrspace(1)* %87, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %88
 
 ; <label>:88                                      ; preds = %85
   %89 = load i32, i32 addrspace(1)* %87, align 8
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
-  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %90
 
 ; <label>:90                                      ; preds = %88
   %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
   store i32 %89, i32 addrspace(1)* %91
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
-  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
-  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %96
 
 ; <label>:96                                      ; preds = %94
   %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
-  br i1 %NullCheck34, label %100, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %100
 
 ; <label>:100                                     ; preds = %96
   %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
-  br i1 %NullCheck36, label %102, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %102
 
 ; <label>:102                                     ; preds = %100
   %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
   %104 = load i32, i32 addrspace(1)* %103, align 8
   %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
-  br i1 %NullCheck38, label %106, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %106
 
 ; <label>:106                                     ; preds = %102
   %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
-  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
-  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %108
 
 ; <label>:108                                     ; preds = %106
   %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
   %110 = load i32, i32 addrspace(1)* %109, align 8
   %111 = add i32 %104, %110
-  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %112
 
 ; <label>:112                                     ; preds = %108
   %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
   store i32 %111, i32 addrspace(1)* %113
   %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
-  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i32 addrspace(1)* %114, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %115
 
 ; <label>:115                                     ; preds = %112
   %116 = load i32, i32 addrspace(1)* %114, align 8
@@ -7681,19 +9094,19 @@ entry:
 ; <label>:118                                     ; preds = %115
   %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
-  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %121
 
 ; <label>:121                                     ; preds = %118
   %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
-  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
-  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %123
 
 ; <label>:123                                     ; preds = %121
   %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
   %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
-  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
-  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %126
 
 ; <label>:126                                     ; preds = %123
   %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
@@ -7705,8 +9118,8 @@ entry:
 
 ; <label>:130                                     ; preds = %80, %115, %126
   %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %132
 
 ; <label>:132                                     ; preds = %130
   %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7715,8 +9128,8 @@ entry:
   %136 = load i32, i32* %loc3
   %137 = sub i32 %135, %136
   %138 = sub i32 %134, %137
-  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %139
 
 ; <label>:139                                     ; preds = %132
   %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7728,16 +9141,16 @@ entry:
 
 ; <label>:144                                     ; preds = %139
   %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
-  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %146
 
 ; <label>:146                                     ; preds = %144
   %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
   %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
   %149 = load i32, i32* %loc2
   %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
-  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %151
 
 ; <label>:151                                     ; preds = %146
   %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
@@ -7754,145 +9167,249 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %18
+ThrowNullRef4:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %31
+ThrowNullRef10:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %44
+ThrowNullRef16:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %68
+ThrowNullRef18:                                   ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %70
+ThrowNullRef20:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %73
+ThrowNullRef22:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %83
+ThrowNullRef24:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %85
+ThrowNullRef26:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %88
+ThrowNullRef28:                                   ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %90
+ThrowNullRef30:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %94
+ThrowNullRef32:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %96
+ThrowNullRef34:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %100
+ThrowNullRef36:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %102
+ThrowNullRef38:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %106
+ThrowNullRef40:                                   ; preds = %106
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %108
+ThrowNullRef42:                                   ; preds = %108
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %112
+ThrowNullRef44:                                   ; preds = %112
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %118
+ThrowNullRef46:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %121
+ThrowNullRef48:                                   ; preds = %121
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %123
+ThrowNullRef50:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %130
+ThrowNullRef52:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %132
+ThrowNullRef54:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %144
+ThrowNullRef56:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %146
+ThrowNullRef58:                                   ; preds = %146
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %60
+ThrowNullRef60:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %63
+ThrowNullRef62:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %49
+ThrowNullRef64:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %51
+ThrowNullRef66:                                   ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %53
+ThrowNullRef68:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(%"System.Char[]" addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %arg0 = alloca %"System.Char[]" addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store %"System.Char[]" addrspace(1)* %param0, %"System.Char[]" addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load i32, i32* %arg4
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %43, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %38, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg1
+  %13 = load i32, i32* %arg4
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %38, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %24 = load i32, i32* %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %35 = load i32, i32* %arg3
+  %36 = load i32, i32* %arg4
+  %37 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %37, %"System.Char[]" addrspace(1)* %34, i32 %35, i32 %36)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:38                                      ; preds = %5, %16
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Successfully read Buffer._Memmove
 
@@ -7914,7 +9431,7 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[loadElem]
+Failed to read AppDomain.SetDataHelper[storeElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -7923,8 +9440,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
@@ -7934,8 +9451,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
@@ -7947,15 +9464,15 @@ entry:
   %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
   %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
@@ -7966,15 +9483,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7992,7 +9509,79 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
-Failed to read Dictionary`2.TryGetValue[loadElemA]
+Successfully read Dictionary`2.TryGetValue
+
+define i8 @"Dictionary`2.TryGetValue"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)* addrspace(1)* %param2) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  %arg2 = alloca %System.__Canon addrspace(1)* addrspace(1)*
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  store %System.__Canon addrspace(1)* addrspace(1)* %param2, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  store i32 %2, i32* %loc0
+  %3 = load i32, i32* %loc0
+  %4 = icmp slt i32 %3, 0
+  br i1 %4, label %22, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 2
+  %10 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %9, align 8
+  %11 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = zext i32 %11 to i64
+  %BoundsCheck = icmp uge i64 %16, %15
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 3, i32 %11
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %20, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %6, %System.__Canon addrspace(1)* %21)
+  ret i8 1
+
+; <label>:22                                      ; preds = %entry
+  %23 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %23, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -8058,8 +9647,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
@@ -8091,8 +9680,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
@@ -8171,15 +9760,15 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck, label %19, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %ThrowNullRef, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
   %21 = load i32, i32 addrspace(1)* %20
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
@@ -8202,7 +9791,7 @@ ThrowNullRef:                                     ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %19
+ThrowNullRef2:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8248,8 +9837,8 @@ entry:
   %0 = alloca %System.AppDomainHandle
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %1 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %1, i32 0, i32 15
@@ -8269,8 +9858,8 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
@@ -8286,7 +9875,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -8299,8 +9888,8 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -8327,8 +9916,8 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
@@ -8352,8 +9941,8 @@ entry:
   %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
   store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
@@ -8363,8 +9952,8 @@ entry:
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
@@ -8374,8 +9963,8 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %9
   %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
@@ -8384,8 +9973,8 @@ entry:
 
 ; <label>:18                                      ; preds = %3, %16
   %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
@@ -8397,15 +9986,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %18
+ThrowNullRef6:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8418,8 +10007,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
@@ -8453,15 +10042,15 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
@@ -8473,7 +10062,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8481,7 +10070,7 @@ ThrowNullRef1:                                    ; preds = %1
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
 Failed to read Dictionary`2.System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
@@ -8506,8 +10095,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
@@ -8524,8 +10113,8 @@ entry:
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -8544,7 +10133,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8577,8 +10166,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = load i64, i64* %arg2
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = trunc i32 %3 to i8
@@ -8634,46 +10223,46 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
   %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
-  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
-  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
-  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
@@ -8684,27 +10273,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %20
+ThrowNullRef12:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8717,8 +10306,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -8756,22 +10345,22 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
   %9 = load i64, i64 addrspace(1)* %8, align 8
   %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
   %13 = load i64, i64 addrspace(1)* %12, align 8
   %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %11
   %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
@@ -8788,11 +10377,11 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8882,8 +10471,8 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
@@ -8900,8 +10489,8 @@ entry:
 ; <label>:8                                       ; preds = %1
   %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
   %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
@@ -8911,15 +10500,15 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
   %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
   %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
-  br i1 %NullCheck6, label %21, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
@@ -8946,15 +10535,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8992,15 +10581,15 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
   store i8 %3, i8 addrspace(1)* %5
   %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
@@ -9011,7 +10600,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9027,8 +10616,8 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -9041,8 +10630,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
@@ -9058,7 +10647,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9080,8 +10669,8 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
@@ -9096,8 +10685,8 @@ entry:
 ; <label>:12                                      ; preds = %6
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
@@ -9112,8 +10701,8 @@ entry:
 ; <label>:21                                      ; preds = %15
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
@@ -9128,8 +10717,8 @@ entry:
 ; <label>:30                                      ; preds = %24
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %31, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
@@ -9144,8 +10733,8 @@ entry:
 ; <label>:39                                      ; preds = %33
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
-  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %40, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %42
 
 ; <label>:42                                      ; preds = %39
   %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
@@ -9164,19 +10753,19 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %21
+ThrowNullRef4:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %30
+ThrowNullRef6:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %39
+ThrowNullRef8:                                    ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9243,8 +10832,8 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
@@ -9264,57 +10853,57 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
   store i8 0, i8 addrspace(1)* %2
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
   store i8 0, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
   store i8 0, i8 addrspace(1)* %17
   %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
   store i8 0, i8 addrspace(1)* %20
   %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
-  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
@@ -9325,31 +10914,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %19
+ThrowNullRef14:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9367,8 +10956,8 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
@@ -9380,8 +10969,8 @@ entry:
 
 ; <label>:9                                       ; preds = %4
   %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %9
   %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
@@ -9395,7 +10984,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef2:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9420,8 +11009,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
@@ -9512,8 +11101,8 @@ entry:
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
@@ -9524,8 +11113,8 @@ entry:
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = load i64, i64 addrspace(1)* %12
@@ -9537,8 +11126,8 @@ entry:
   %20 = load i64, i64* %19
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
-  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %13
   %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
@@ -9555,8 +11144,8 @@ entry:
 ; <label>:30                                      ; preds = %25
   %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %32 = load i32, i32* %arg2
-  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
-  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
@@ -9570,15 +11159,15 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %30
+ThrowNullRef2:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9622,87 +11211,87 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
   %10 = load i8, i8 addrspace(1)* %9, align 8
   %11 = zext i8 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %8
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
   store i8 %12, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
   %19 = load i8, i8 addrspace(1)* %18, align 8
   %20 = zext i8 %19 to i32
   %21 = trunc i32 %20 to i8
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
   store i8 %21, i8 addrspace(1)* %23
   %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
   %28 = load i8, i8 addrspace(1)* %27, align 8
   %29 = zext i8 %28 to i32
   %30 = trunc i32 %29 to i8
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
-  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %31
 
 ; <label>:31                                      ; preds = %26
   %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
   store i8 %30, i8 addrspace(1)* %32
   %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
-  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
-  br i1 %NullCheck14, label %40, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %40
 
 ; <label>:40                                      ; preds = %35
   %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
   store i8 %39, i8 addrspace(1)* %41
   %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
-  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %44
 
 ; <label>:44                                      ; preds = %40
   %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
   %46 = load i8, i8 addrspace(1)* %45, align 8
   %47 = zext i8 %46 to i32
   %48 = trunc i32 %47 to i8
-  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
   store i8 %48, i8 addrspace(1)* %50
   %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
-  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
@@ -9713,29 +11302,29 @@ entry:
 ; <label>:56                                      ; preds = %52
   %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
-  br i1 %NullCheck22, label %59, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
   %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
   %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
-  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
-  br i1 %NullCheck24, label %63, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
   %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
-  br i1 %NullCheck26, label %66, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
   %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
-  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
-  br i1 %NullCheck28, label %69, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %69
 
 ; <label>:69                                      ; preds = %66
   %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
@@ -9744,15 +11333,15 @@ entry:
 
 ; <label>:71                                      ; preds = %105
   %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
-  br i1 %NullCheck34, label %73, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %73
 
 ; <label>:73                                      ; preds = %71
   %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
   %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
   %76 = load i32, i32* %loc0
-  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
-  br i1 %NullCheck36, label %77, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
@@ -9766,8 +11355,8 @@ entry:
 
 ; <label>:83                                      ; preds = %77
   %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
-  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
@@ -9775,14 +11364,14 @@ entry:
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
   %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
-  br i1 %NullCheck40, label %91, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
 ; <label>:91                                      ; preds = %85
   %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
   %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
-  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck42, label %94, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %94
 
 ; <label>:94                                      ; preds = %91
   %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
@@ -9798,14 +11387,14 @@ entry:
 ; <label>:99                                      ; preds = %69, %96
   %100 = load i32, i32* %loc0
   %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
-  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %102
 
 ; <label>:102                                     ; preds = %99
   %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
   %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
-  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
-  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
@@ -9819,87 +11408,87 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %26
+ThrowNullRef10:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %31
+ThrowNullRef12:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %35
+ThrowNullRef14:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %40
+ThrowNullRef16:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %56
+ThrowNullRef22:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %59
+ThrowNullRef24:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %63
+ThrowNullRef26:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %66
+ThrowNullRef28:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %102
+ThrowNullRef32:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %71
+ThrowNullRef34:                                   ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %73
+ThrowNullRef36:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %83
+ThrowNullRef38:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %85
+ThrowNullRef40:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %91
+ThrowNullRef42:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9943,15 +11532,15 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
   %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
@@ -9961,28 +11550,28 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
   %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %12
   %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
   %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
   %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
-  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
@@ -9993,23 +11582,23 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %12
+ThrowNullRef6:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10031,15 +11620,15 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
   %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = load i64, i64 addrspace(1)* %7
@@ -10077,13 +11666,13 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[loadElem]
+Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -10111,8 +11700,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1

--- a/test/BaseLine/JIT/CodeGenBringUpTests/mul3.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/mul3.error.txt
@@ -25,8 +25,8 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
@@ -40,8 +40,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
   %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
@@ -75,7 +75,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -90,8 +90,8 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %NullCheck = icmp ne i8 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = load i8, i8 addrspace(1)* %0, align 8
@@ -125,8 +125,8 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
@@ -159,8 +159,8 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -184,8 +184,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
   store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
@@ -195,8 +195,8 @@ entry:
 ; <label>:4                                       ; preds = %1
   %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
   %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
@@ -206,8 +206,8 @@ entry:
   %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
@@ -221,14 +221,14 @@ entry:
 
 ; <label>:17                                      ; preds = %14
   %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
   %21 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
@@ -238,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -249,8 +249,8 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
@@ -261,27 +261,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %30
+ThrowNullRef10:                                   ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -301,7 +301,89 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
-Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
+Successfully read AppDomainSetup.GetUnsecureApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.GetUnsecureApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %NullCheck = icmp eq %"System.String[]" addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %BoundsCheck = icmp uge i64 0, %5
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %6
+
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 3, i32 0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
+  ret %System.String addrspace(1)* %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_Value using LLILCJit
+Successfully read AppDomainSetup.get_Value
+
+define %"System.String[]" addrspace(1)* @AppDomainSetup.get_Value(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.String[]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 18)
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.String[]" addrspace(1)* addrspace(1)*, %"System.String[]" addrspace(1)*)*)(%"System.String[]" addrspace(1)* addrspace(1)* %9, %"System.String[]" addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %11, i32 0, i32 1
+  %14 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %13, align 8
+  ret %"System.String[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -319,8 +401,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -368,16 +450,16 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
   %5 = load i32, i32 addrspace(1)* %4
   %6 = sub i32 %5, 1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -389,7 +471,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -421,8 +503,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
@@ -456,8 +538,8 @@ entry:
 ; <label>:27                                      ; preds = %19
   %28 = load i32, i32* %arg1
   %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
-  br i1 %NullCheck2, label %30, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %29, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %30
 
 ; <label>:30                                      ; preds = %27
   %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
@@ -493,8 +575,8 @@ entry:
 ; <label>:49                                      ; preds = %46
   %50 = load i32, i32* %arg2
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck4, label %52, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
@@ -517,11 +599,11 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %27
+ThrowNullRef2:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %49
+ThrowNullRef4:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -544,16 +626,16 @@ entry:
   %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %0)
   store %System.String addrspace(1)* %1, %System.String addrspace(1)** %loc0
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 2
   %5 = bitcast [0 x i16] addrspace(1)* %4 to i16 addrspace(1)*
   store i16 addrspace(1)* %5, i16 addrspace(1)** %loc1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %3
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2
@@ -580,7 +662,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -691,15 +773,15 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %NullCheck132 = icmp ne i8* %21, null
-  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+  %NullCheck131 = icmp eq i8* %21, null
+  br i1 %NullCheck131, label %ThrowNullRef132, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = load i8, i8* %21, align 8
   %24 = zext i8 %23 to i32
   %25 = trunc i32 %24 to i8
-  %NullCheck134 = icmp ne i8* %20, null
-  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+  %NullCheck133 = icmp eq i8* %20, null
+  br i1 %NullCheck133, label %ThrowNullRef134, label %26
 
 ; <label>:26                                      ; preds = %22
   store i8 %25, i8* %20, align 8
@@ -709,16 +791,16 @@ entry:
   %28 = load i8*, i8** %arg0
   %29 = load i8*, i8** %arg1
   %30 = bitcast i8* %29 to i16*
-  %NullCheck128 = icmp ne i16* %30, null
-  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+  %NullCheck127 = icmp eq i16* %30, null
+  br i1 %NullCheck127, label %ThrowNullRef128, label %31
 
 ; <label>:31                                      ; preds = %27
   %32 = load i16, i16* %30, align 8
   %33 = sext i16 %32 to i32
   %34 = bitcast i8* %28 to i16*
   %35 = trunc i32 %33 to i16
-  %NullCheck130 = icmp ne i16* %34, null
-  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+  %NullCheck129 = icmp eq i16* %34, null
+  br i1 %NullCheck129, label %ThrowNullRef130, label %36
 
 ; <label>:36                                      ; preds = %31
   store i16 %35, i16* %34, align 8
@@ -728,16 +810,16 @@ entry:
   %38 = load i8*, i8** %arg0
   %39 = load i8*, i8** %arg1
   %40 = bitcast i8* %39 to i16*
-  %NullCheck120 = icmp ne i16* %40, null
-  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+  %NullCheck119 = icmp eq i16* %40, null
+  br i1 %NullCheck119, label %ThrowNullRef120, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i16, i16* %40, align 8
   %43 = sext i16 %42 to i32
   %44 = bitcast i8* %38 to i16*
   %45 = trunc i32 %43 to i16
-  %NullCheck122 = icmp ne i16* %44, null
-  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+  %NullCheck121 = icmp eq i16* %44, null
+  br i1 %NullCheck121, label %ThrowNullRef122, label %46
 
 ; <label>:46                                      ; preds = %41
   store i16 %45, i16* %44, align 8
@@ -745,15 +827,15 @@ entry:
   %48 = getelementptr inbounds i8, i8* %47, i64 2
   %49 = load i8*, i8** %arg1
   %50 = getelementptr inbounds i8, i8* %49, i64 2
-  %NullCheck124 = icmp ne i8* %50, null
-  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+  %NullCheck123 = icmp eq i8* %50, null
+  br i1 %NullCheck123, label %ThrowNullRef124, label %51
 
 ; <label>:51                                      ; preds = %46
   %52 = load i8, i8* %50, align 8
   %53 = zext i8 %52 to i32
   %54 = trunc i32 %53 to i8
-  %NullCheck126 = icmp ne i8* %48, null
-  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+  %NullCheck125 = icmp eq i8* %48, null
+  br i1 %NullCheck125, label %ThrowNullRef126, label %55
 
 ; <label>:55                                      ; preds = %51
   store i8 %54, i8* %48, align 8
@@ -763,14 +845,14 @@ entry:
   %57 = load i8*, i8** %arg0
   %58 = load i8*, i8** %arg1
   %59 = bitcast i8* %58 to i32*
-  %NullCheck116 = icmp ne i32* %59, null
-  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+  %NullCheck115 = icmp eq i32* %59, null
+  br i1 %NullCheck115, label %ThrowNullRef116, label %60
 
 ; <label>:60                                      ; preds = %56
   %61 = load i32, i32* %59, align 8
   %62 = bitcast i8* %57 to i32*
-  %NullCheck118 = icmp ne i32* %62, null
-  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+  %NullCheck117 = icmp eq i32* %62, null
+  br i1 %NullCheck117, label %ThrowNullRef118, label %63
 
 ; <label>:63                                      ; preds = %60
   store i32 %61, i32* %62, align 8
@@ -780,14 +862,14 @@ entry:
   %65 = load i8*, i8** %arg0
   %66 = load i8*, i8** %arg1
   %67 = bitcast i8* %66 to i32*
-  %NullCheck108 = icmp ne i32* %67, null
-  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+  %NullCheck107 = icmp eq i32* %67, null
+  br i1 %NullCheck107, label %ThrowNullRef108, label %68
 
 ; <label>:68                                      ; preds = %64
   %69 = load i32, i32* %67, align 8
   %70 = bitcast i8* %65 to i32*
-  %NullCheck110 = icmp ne i32* %70, null
-  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+  %NullCheck109 = icmp eq i32* %70, null
+  br i1 %NullCheck109, label %ThrowNullRef110, label %71
 
 ; <label>:71                                      ; preds = %68
   store i32 %69, i32* %70, align 8
@@ -795,15 +877,15 @@ entry:
   %73 = getelementptr inbounds i8, i8* %72, i64 4
   %74 = load i8*, i8** %arg1
   %75 = getelementptr inbounds i8, i8* %74, i64 4
-  %NullCheck112 = icmp ne i8* %75, null
-  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+  %NullCheck111 = icmp eq i8* %75, null
+  br i1 %NullCheck111, label %ThrowNullRef112, label %76
 
 ; <label>:76                                      ; preds = %71
   %77 = load i8, i8* %75, align 8
   %78 = zext i8 %77 to i32
   %79 = trunc i32 %78 to i8
-  %NullCheck114 = icmp ne i8* %73, null
-  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+  %NullCheck113 = icmp eq i8* %73, null
+  br i1 %NullCheck113, label %ThrowNullRef114, label %80
 
 ; <label>:80                                      ; preds = %76
   store i8 %79, i8* %73, align 8
@@ -813,14 +895,14 @@ entry:
   %82 = load i8*, i8** %arg0
   %83 = load i8*, i8** %arg1
   %84 = bitcast i8* %83 to i32*
-  %NullCheck100 = icmp ne i32* %84, null
-  br i1 %NullCheck100, label %85, label %ThrowNullRef99
+  %NullCheck99 = icmp eq i32* %84, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %85
 
 ; <label>:85                                      ; preds = %81
   %86 = load i32, i32* %84, align 8
   %87 = bitcast i8* %82 to i32*
-  %NullCheck102 = icmp ne i32* %87, null
-  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+  %NullCheck101 = icmp eq i32* %87, null
+  br i1 %NullCheck101, label %ThrowNullRef102, label %88
 
 ; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
@@ -829,16 +911,16 @@ entry:
   %91 = load i8*, i8** %arg1
   %92 = getelementptr inbounds i8, i8* %91, i64 4
   %93 = bitcast i8* %92 to i16*
-  %NullCheck104 = icmp ne i16* %93, null
-  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+  %NullCheck103 = icmp eq i16* %93, null
+  br i1 %NullCheck103, label %ThrowNullRef104, label %94
 
 ; <label>:94                                      ; preds = %88
   %95 = load i16, i16* %93, align 8
   %96 = sext i16 %95 to i32
   %97 = bitcast i8* %90 to i16*
   %98 = trunc i32 %96 to i16
-  %NullCheck106 = icmp ne i16* %97, null
-  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+  %NullCheck105 = icmp eq i16* %97, null
+  br i1 %NullCheck105, label %ThrowNullRef106, label %99
 
 ; <label>:99                                      ; preds = %94
   store i16 %98, i16* %97, align 8
@@ -848,14 +930,14 @@ entry:
   %101 = load i8*, i8** %arg0
   %102 = load i8*, i8** %arg1
   %103 = bitcast i8* %102 to i32*
-  %NullCheck88 = icmp ne i32* %103, null
-  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+  %NullCheck87 = icmp eq i32* %103, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %104
 
 ; <label>:104                                     ; preds = %100
   %105 = load i32, i32* %103, align 8
   %106 = bitcast i8* %101 to i32*
-  %NullCheck90 = icmp ne i32* %106, null
-  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+  %NullCheck89 = icmp eq i32* %106, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %107
 
 ; <label>:107                                     ; preds = %104
   store i32 %105, i32* %106, align 8
@@ -864,16 +946,16 @@ entry:
   %110 = load i8*, i8** %arg1
   %111 = getelementptr inbounds i8, i8* %110, i64 4
   %112 = bitcast i8* %111 to i16*
-  %NullCheck92 = icmp ne i16* %112, null
-  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+  %NullCheck91 = icmp eq i16* %112, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %113
 
 ; <label>:113                                     ; preds = %107
   %114 = load i16, i16* %112, align 8
   %115 = sext i16 %114 to i32
   %116 = bitcast i8* %109 to i16*
   %117 = trunc i32 %115 to i16
-  %NullCheck94 = icmp ne i16* %116, null
-  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+  %NullCheck93 = icmp eq i16* %116, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %118
 
 ; <label>:118                                     ; preds = %113
   store i16 %117, i16* %116, align 8
@@ -881,15 +963,15 @@ entry:
   %120 = getelementptr inbounds i8, i8* %119, i64 6
   %121 = load i8*, i8** %arg1
   %122 = getelementptr inbounds i8, i8* %121, i64 6
-  %NullCheck96 = icmp ne i8* %122, null
-  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+  %NullCheck95 = icmp eq i8* %122, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %123
 
 ; <label>:123                                     ; preds = %118
   %124 = load i8, i8* %122, align 8
   %125 = zext i8 %124 to i32
   %126 = trunc i32 %125 to i8
-  %NullCheck98 = icmp ne i8* %120, null
-  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+  %NullCheck97 = icmp eq i8* %120, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %127
 
 ; <label>:127                                     ; preds = %123
   store i8 %126, i8* %120, align 8
@@ -899,14 +981,14 @@ entry:
   %129 = load i8*, i8** %arg0
   %130 = load i8*, i8** %arg1
   %131 = bitcast i8* %130 to i64*
-  %NullCheck84 = icmp ne i64* %131, null
-  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+  %NullCheck83 = icmp eq i64* %131, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %132
 
 ; <label>:132                                     ; preds = %128
   %133 = load i64, i64* %131, align 8
   %134 = bitcast i8* %129 to i64*
-  %NullCheck86 = icmp ne i64* %134, null
-  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+  %NullCheck85 = icmp eq i64* %134, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %135
 
 ; <label>:135                                     ; preds = %132
   store i64 %133, i64* %134, align 8
@@ -916,14 +998,14 @@ entry:
   %137 = load i8*, i8** %arg0
   %138 = load i8*, i8** %arg1
   %139 = bitcast i8* %138 to i64*
-  %NullCheck76 = icmp ne i64* %139, null
-  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+  %NullCheck75 = icmp eq i64* %139, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %140
 
 ; <label>:140                                     ; preds = %136
   %141 = load i64, i64* %139, align 8
   %142 = bitcast i8* %137 to i64*
-  %NullCheck78 = icmp ne i64* %142, null
-  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+  %NullCheck77 = icmp eq i64* %142, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %143
 
 ; <label>:143                                     ; preds = %140
   store i64 %141, i64* %142, align 8
@@ -931,15 +1013,15 @@ entry:
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %NullCheck80 = icmp ne i8* %147, null
-  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+  %NullCheck79 = icmp eq i8* %147, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %148
 
 ; <label>:148                                     ; preds = %143
   %149 = load i8, i8* %147, align 8
   %150 = zext i8 %149 to i32
   %151 = trunc i32 %150 to i8
-  %NullCheck82 = icmp ne i8* %145, null
-  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+  %NullCheck81 = icmp eq i8* %145, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %152
 
 ; <label>:152                                     ; preds = %148
   store i8 %151, i8* %145, align 8
@@ -949,14 +1031,14 @@ entry:
   %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
   %156 = bitcast i8* %155 to i64*
-  %NullCheck68 = icmp ne i64* %156, null
-  br i1 %NullCheck68, label %157, label %ThrowNullRef67
+  %NullCheck67 = icmp eq i64* %156, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %157
 
 ; <label>:157                                     ; preds = %153
   %158 = load i64, i64* %156, align 8
   %159 = bitcast i8* %154 to i64*
-  %NullCheck70 = icmp ne i64* %159, null
-  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+  %NullCheck69 = icmp eq i64* %159, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %160
 
 ; <label>:160                                     ; preds = %157
   store i64 %158, i64* %159, align 8
@@ -965,16 +1047,16 @@ entry:
   %163 = load i8*, i8** %arg1
   %164 = getelementptr inbounds i8, i8* %163, i64 8
   %165 = bitcast i8* %164 to i16*
-  %NullCheck72 = icmp ne i16* %165, null
-  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+  %NullCheck71 = icmp eq i16* %165, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %166
 
 ; <label>:166                                     ; preds = %160
   %167 = load i16, i16* %165, align 8
   %168 = sext i16 %167 to i32
   %169 = bitcast i8* %162 to i16*
   %170 = trunc i32 %168 to i16
-  %NullCheck74 = icmp ne i16* %169, null
-  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+  %NullCheck73 = icmp eq i16* %169, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %171
 
 ; <label>:171                                     ; preds = %166
   store i16 %170, i16* %169, align 8
@@ -984,14 +1066,14 @@ entry:
   %173 = load i8*, i8** %arg0
   %174 = load i8*, i8** %arg1
   %175 = bitcast i8* %174 to i64*
-  %NullCheck56 = icmp ne i64* %175, null
-  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+  %NullCheck55 = icmp eq i64* %175, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %176
 
 ; <label>:176                                     ; preds = %172
   %177 = load i64, i64* %175, align 8
   %178 = bitcast i8* %173 to i64*
-  %NullCheck58 = icmp ne i64* %178, null
-  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+  %NullCheck57 = icmp eq i64* %178, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %179
 
 ; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
@@ -1000,16 +1082,16 @@ entry:
   %182 = load i8*, i8** %arg1
   %183 = getelementptr inbounds i8, i8* %182, i64 8
   %184 = bitcast i8* %183 to i16*
-  %NullCheck60 = icmp ne i16* %184, null
-  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+  %NullCheck59 = icmp eq i16* %184, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %185
 
 ; <label>:185                                     ; preds = %179
   %186 = load i16, i16* %184, align 8
   %187 = sext i16 %186 to i32
   %188 = bitcast i8* %181 to i16*
   %189 = trunc i32 %187 to i16
-  %NullCheck62 = icmp ne i16* %188, null
-  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+  %NullCheck61 = icmp eq i16* %188, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %190
 
 ; <label>:190                                     ; preds = %185
   store i16 %189, i16* %188, align 8
@@ -1017,15 +1099,15 @@ entry:
   %192 = getelementptr inbounds i8, i8* %191, i64 10
   %193 = load i8*, i8** %arg1
   %194 = getelementptr inbounds i8, i8* %193, i64 10
-  %NullCheck64 = icmp ne i8* %194, null
-  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+  %NullCheck63 = icmp eq i8* %194, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %195
 
 ; <label>:195                                     ; preds = %190
   %196 = load i8, i8* %194, align 8
   %197 = zext i8 %196 to i32
   %198 = trunc i32 %197 to i8
-  %NullCheck66 = icmp ne i8* %192, null
-  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+  %NullCheck65 = icmp eq i8* %192, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %199
 
 ; <label>:199                                     ; preds = %195
   store i8 %198, i8* %192, align 8
@@ -1035,14 +1117,14 @@ entry:
   %201 = load i8*, i8** %arg0
   %202 = load i8*, i8** %arg1
   %203 = bitcast i8* %202 to i64*
-  %NullCheck48 = icmp ne i64* %203, null
-  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+  %NullCheck47 = icmp eq i64* %203, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %204
 
 ; <label>:204                                     ; preds = %200
   %205 = load i64, i64* %203, align 8
   %206 = bitcast i8* %201 to i64*
-  %NullCheck50 = icmp ne i64* %206, null
-  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+  %NullCheck49 = icmp eq i64* %206, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %207
 
 ; <label>:207                                     ; preds = %204
   store i64 %205, i64* %206, align 8
@@ -1051,14 +1133,14 @@ entry:
   %210 = load i8*, i8** %arg1
   %211 = getelementptr inbounds i8, i8* %210, i64 8
   %212 = bitcast i8* %211 to i32*
-  %NullCheck52 = icmp ne i32* %212, null
-  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+  %NullCheck51 = icmp eq i32* %212, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %213
 
 ; <label>:213                                     ; preds = %207
   %214 = load i32, i32* %212, align 8
   %215 = bitcast i8* %209 to i32*
-  %NullCheck54 = icmp ne i32* %215, null
-  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+  %NullCheck53 = icmp eq i32* %215, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %216
 
 ; <label>:216                                     ; preds = %213
   store i32 %214, i32* %215, align 8
@@ -1068,14 +1150,14 @@ entry:
   %218 = load i8*, i8** %arg0
   %219 = load i8*, i8** %arg1
   %220 = bitcast i8* %219 to i64*
-  %NullCheck36 = icmp ne i64* %220, null
-  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64* %220, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %221
 
 ; <label>:221                                     ; preds = %217
   %222 = load i64, i64* %220, align 8
   %223 = bitcast i8* %218 to i64*
-  %NullCheck38 = icmp ne i64* %223, null
-  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+  %NullCheck37 = icmp eq i64* %223, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %224
 
 ; <label>:224                                     ; preds = %221
   store i64 %222, i64* %223, align 8
@@ -1084,14 +1166,14 @@ entry:
   %227 = load i8*, i8** %arg1
   %228 = getelementptr inbounds i8, i8* %227, i64 8
   %229 = bitcast i8* %228 to i32*
-  %NullCheck40 = icmp ne i32* %229, null
-  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i32* %229, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %230
 
 ; <label>:230                                     ; preds = %224
   %231 = load i32, i32* %229, align 8
   %232 = bitcast i8* %226 to i32*
-  %NullCheck42 = icmp ne i32* %232, null
-  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+  %NullCheck41 = icmp eq i32* %232, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %233
 
 ; <label>:233                                     ; preds = %230
   store i32 %231, i32* %232, align 8
@@ -1099,15 +1181,15 @@ entry:
   %235 = getelementptr inbounds i8, i8* %234, i64 12
   %236 = load i8*, i8** %arg1
   %237 = getelementptr inbounds i8, i8* %236, i64 12
-  %NullCheck44 = icmp ne i8* %237, null
-  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i8* %237, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %238
 
 ; <label>:238                                     ; preds = %233
   %239 = load i8, i8* %237, align 8
   %240 = zext i8 %239 to i32
   %241 = trunc i32 %240 to i8
-  %NullCheck46 = icmp ne i8* %235, null
-  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+  %NullCheck45 = icmp eq i8* %235, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %242
 
 ; <label>:242                                     ; preds = %238
   store i8 %241, i8* %235, align 8
@@ -1117,14 +1199,14 @@ entry:
   %244 = load i8*, i8** %arg0
   %245 = load i8*, i8** %arg1
   %246 = bitcast i8* %245 to i64*
-  %NullCheck24 = icmp ne i64* %246, null
-  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64* %246, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %247
 
 ; <label>:247                                     ; preds = %243
   %248 = load i64, i64* %246, align 8
   %249 = bitcast i8* %244 to i64*
-  %NullCheck26 = icmp ne i64* %249, null
-  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64* %249, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %250
 
 ; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
@@ -1133,14 +1215,14 @@ entry:
   %253 = load i8*, i8** %arg1
   %254 = getelementptr inbounds i8, i8* %253, i64 8
   %255 = bitcast i8* %254 to i32*
-  %NullCheck28 = icmp ne i32* %255, null
-  br i1 %NullCheck28, label %256, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i32* %255, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %256
 
 ; <label>:256                                     ; preds = %250
   %257 = load i32, i32* %255, align 8
   %258 = bitcast i8* %252 to i32*
-  %NullCheck30 = icmp ne i32* %258, null
-  br i1 %NullCheck30, label %259, label %ThrowNullRef29
+  %NullCheck29 = icmp eq i32* %258, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %259
 
 ; <label>:259                                     ; preds = %256
   store i32 %257, i32* %258, align 8
@@ -1149,16 +1231,16 @@ entry:
   %262 = load i8*, i8** %arg1
   %263 = getelementptr inbounds i8, i8* %262, i64 12
   %264 = bitcast i8* %263 to i16*
-  %NullCheck32 = icmp ne i16* %264, null
-  br i1 %NullCheck32, label %265, label %ThrowNullRef31
+  %NullCheck31 = icmp eq i16* %264, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %265
 
 ; <label>:265                                     ; preds = %259
   %266 = load i16, i16* %264, align 8
   %267 = sext i16 %266 to i32
   %268 = bitcast i8* %261 to i16*
   %269 = trunc i32 %267 to i16
-  %NullCheck34 = icmp ne i16* %268, null
-  br i1 %NullCheck34, label %270, label %ThrowNullRef33
+  %NullCheck33 = icmp eq i16* %268, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %270
 
 ; <label>:270                                     ; preds = %265
   store i16 %269, i16* %268, align 8
@@ -1168,14 +1250,14 @@ entry:
   %272 = load i8*, i8** %arg0
   %273 = load i8*, i8** %arg1
   %274 = bitcast i8* %273 to i64*
-  %NullCheck8 = icmp ne i64* %274, null
-  br i1 %NullCheck8, label %275, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64* %274, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %275
 
 ; <label>:275                                     ; preds = %271
   %276 = load i64, i64* %274, align 8
   %277 = bitcast i8* %272 to i64*
-  %NullCheck10 = icmp ne i64* %277, null
-  br i1 %NullCheck10, label %278, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %277, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %278
 
 ; <label>:278                                     ; preds = %275
   store i64 %276, i64* %277, align 8
@@ -1184,14 +1266,14 @@ entry:
   %281 = load i8*, i8** %arg1
   %282 = getelementptr inbounds i8, i8* %281, i64 8
   %283 = bitcast i8* %282 to i32*
-  %NullCheck12 = icmp ne i32* %283, null
-  br i1 %NullCheck12, label %284, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i32* %283, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %284
 
 ; <label>:284                                     ; preds = %278
   %285 = load i32, i32* %283, align 8
   %286 = bitcast i8* %280 to i32*
-  %NullCheck14 = icmp ne i32* %286, null
-  br i1 %NullCheck14, label %287, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i32* %286, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %287
 
 ; <label>:287                                     ; preds = %284
   store i32 %285, i32* %286, align 8
@@ -1200,16 +1282,16 @@ entry:
   %290 = load i8*, i8** %arg1
   %291 = getelementptr inbounds i8, i8* %290, i64 12
   %292 = bitcast i8* %291 to i16*
-  %NullCheck16 = icmp ne i16* %292, null
-  br i1 %NullCheck16, label %293, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i16* %292, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %293
 
 ; <label>:293                                     ; preds = %287
   %294 = load i16, i16* %292, align 8
   %295 = sext i16 %294 to i32
   %296 = bitcast i8* %289 to i16*
   %297 = trunc i32 %295 to i16
-  %NullCheck18 = icmp ne i16* %296, null
-  br i1 %NullCheck18, label %298, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i16* %296, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %298
 
 ; <label>:298                                     ; preds = %293
   store i16 %297, i16* %296, align 8
@@ -1217,15 +1299,15 @@ entry:
   %300 = getelementptr inbounds i8, i8* %299, i64 14
   %301 = load i8*, i8** %arg1
   %302 = getelementptr inbounds i8, i8* %301, i64 14
-  %NullCheck20 = icmp ne i8* %302, null
-  br i1 %NullCheck20, label %303, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i8* %302, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %303
 
 ; <label>:303                                     ; preds = %298
   %304 = load i8, i8* %302, align 8
   %305 = zext i8 %304 to i32
   %306 = trunc i32 %305 to i8
-  %NullCheck22 = icmp ne i8* %300, null
-  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i8* %300, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %307
 
 ; <label>:307                                     ; preds = %303
   store i8 %306, i8* %300, align 8
@@ -1235,14 +1317,14 @@ entry:
   %309 = load i8*, i8** %arg0
   %310 = load i8*, i8** %arg1
   %311 = bitcast i8* %310 to i64*
-  %NullCheck = icmp ne i64* %311, null
-  br i1 %NullCheck, label %312, label %ThrowNullRef
+  %NullCheck = icmp eq i64* %311, null
+  br i1 %NullCheck, label %ThrowNullRef, label %312
 
 ; <label>:312                                     ; preds = %308
   %313 = load i64, i64* %311, align 8
   %314 = bitcast i8* %309 to i64*
-  %NullCheck2 = icmp ne i64* %314, null
-  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64* %314, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %315
 
 ; <label>:315                                     ; preds = %312
   store i64 %313, i64* %314, align 8
@@ -1251,14 +1333,14 @@ entry:
   %318 = load i8*, i8** %arg1
   %319 = getelementptr inbounds i8, i8* %318, i64 8
   %320 = bitcast i8* %319 to i64*
-  %NullCheck4 = icmp ne i64* %320, null
-  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64* %320, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %321
 
 ; <label>:321                                     ; preds = %315
   %322 = load i64, i64* %320, align 8
   %323 = bitcast i8* %317 to i64*
-  %NullCheck6 = icmp ne i64* %323, null
-  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64* %323, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %324
 
 ; <label>:324                                     ; preds = %321
   store i64 %322, i64* %323, align 8
@@ -1286,15 +1368,15 @@ entry:
 ; <label>:338                                     ; preds = %333
   %339 = load i8*, i8** %arg0
   %340 = load i8*, i8** %arg1
-  %NullCheck136 = icmp ne i8* %340, null
-  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+  %NullCheck135 = icmp eq i8* %340, null
+  br i1 %NullCheck135, label %ThrowNullRef136, label %341
 
 ; <label>:341                                     ; preds = %338
   %342 = load i8, i8* %340, align 8
   %343 = zext i8 %342 to i32
   %344 = trunc i32 %343 to i8
-  %NullCheck138 = icmp ne i8* %339, null
-  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+  %NullCheck137 = icmp eq i8* %339, null
+  br i1 %NullCheck137, label %ThrowNullRef138, label %345
 
 ; <label>:345                                     ; preds = %341
   store i8 %344, i8* %339, align 8
@@ -1317,16 +1399,16 @@ entry:
   %357 = load i8*, i8** %arg0
   %358 = load i8*, i8** %arg1
   %359 = bitcast i8* %358 to i16*
-  %NullCheck140 = icmp ne i16* %359, null
-  br i1 %NullCheck140, label %360, label %ThrowNullRef139
+  %NullCheck139 = icmp eq i16* %359, null
+  br i1 %NullCheck139, label %ThrowNullRef140, label %360
 
 ; <label>:360                                     ; preds = %356
   %361 = load i16, i16* %359, align 8
   %362 = sext i16 %361 to i32
   %363 = bitcast i8* %357 to i16*
   %364 = trunc i32 %362 to i16
-  %NullCheck142 = icmp ne i16* %363, null
-  br i1 %NullCheck142, label %365, label %ThrowNullRef141
+  %NullCheck141 = icmp eq i16* %363, null
+  br i1 %NullCheck141, label %ThrowNullRef142, label %365
 
 ; <label>:365                                     ; preds = %360
   store i16 %364, i16* %363, align 8
@@ -1352,14 +1434,14 @@ entry:
   %378 = load i8*, i8** %arg0
   %379 = load i8*, i8** %arg1
   %380 = bitcast i8* %379 to i32*
-  %NullCheck144 = icmp ne i32* %380, null
-  br i1 %NullCheck144, label %381, label %ThrowNullRef143
+  %NullCheck143 = icmp eq i32* %380, null
+  br i1 %NullCheck143, label %ThrowNullRef144, label %381
 
 ; <label>:381                                     ; preds = %377
   %382 = load i32, i32* %380, align 8
   %383 = bitcast i8* %378 to i32*
-  %NullCheck146 = icmp ne i32* %383, null
-  br i1 %NullCheck146, label %384, label %ThrowNullRef145
+  %NullCheck145 = icmp eq i32* %383, null
+  br i1 %NullCheck145, label %ThrowNullRef146, label %384
 
 ; <label>:384                                     ; preds = %381
   store i32 %382, i32* %383, align 8
@@ -1384,14 +1466,14 @@ entry:
   %395 = load i8*, i8** %arg0
   %396 = load i8*, i8** %arg1
   %397 = bitcast i8* %396 to i64*
-  %NullCheck164 = icmp ne i64* %397, null
-  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+  %NullCheck163 = icmp eq i64* %397, null
+  br i1 %NullCheck163, label %ThrowNullRef164, label %398
 
 ; <label>:398                                     ; preds = %394
   %399 = load i64, i64* %397, align 8
   %400 = bitcast i8* %395 to i64*
-  %NullCheck166 = icmp ne i64* %400, null
-  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+  %NullCheck165 = icmp eq i64* %400, null
+  br i1 %NullCheck165, label %ThrowNullRef166, label %401
 
 ; <label>:401                                     ; preds = %398
   store i64 %399, i64* %400, align 8
@@ -1400,14 +1482,14 @@ entry:
   %404 = load i8*, i8** %arg1
   %405 = getelementptr inbounds i8, i8* %404, i64 8
   %406 = bitcast i8* %405 to i64*
-  %NullCheck168 = icmp ne i64* %406, null
-  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+  %NullCheck167 = icmp eq i64* %406, null
+  br i1 %NullCheck167, label %ThrowNullRef168, label %407
 
 ; <label>:407                                     ; preds = %401
   %408 = load i64, i64* %406, align 8
   %409 = bitcast i8* %403 to i64*
-  %NullCheck170 = icmp ne i64* %409, null
-  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+  %NullCheck169 = icmp eq i64* %409, null
+  br i1 %NullCheck169, label %ThrowNullRef170, label %410
 
 ; <label>:410                                     ; preds = %407
   store i64 %408, i64* %409, align 8
@@ -1437,14 +1519,14 @@ entry:
   %425 = load i8*, i8** %arg0
   %426 = load i8*, i8** %arg1
   %427 = bitcast i8* %426 to i64*
-  %NullCheck148 = icmp ne i64* %427, null
-  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+  %NullCheck147 = icmp eq i64* %427, null
+  br i1 %NullCheck147, label %ThrowNullRef148, label %428
 
 ; <label>:428                                     ; preds = %424
   %429 = load i64, i64* %427, align 8
   %430 = bitcast i8* %425 to i64*
-  %NullCheck150 = icmp ne i64* %430, null
-  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+  %NullCheck149 = icmp eq i64* %430, null
+  br i1 %NullCheck149, label %ThrowNullRef150, label %431
 
 ; <label>:431                                     ; preds = %428
   store i64 %429, i64* %430, align 8
@@ -1466,14 +1548,14 @@ entry:
   %441 = load i8*, i8** %arg0
   %442 = load i8*, i8** %arg1
   %443 = bitcast i8* %442 to i32*
-  %NullCheck152 = icmp ne i32* %443, null
-  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+  %NullCheck151 = icmp eq i32* %443, null
+  br i1 %NullCheck151, label %ThrowNullRef152, label %444
 
 ; <label>:444                                     ; preds = %440
   %445 = load i32, i32* %443, align 8
   %446 = bitcast i8* %441 to i32*
-  %NullCheck154 = icmp ne i32* %446, null
-  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+  %NullCheck153 = icmp eq i32* %446, null
+  br i1 %NullCheck153, label %ThrowNullRef154, label %447
 
 ; <label>:447                                     ; preds = %444
   store i32 %445, i32* %446, align 8
@@ -1495,16 +1577,16 @@ entry:
   %457 = load i8*, i8** %arg0
   %458 = load i8*, i8** %arg1
   %459 = bitcast i8* %458 to i16*
-  %NullCheck156 = icmp ne i16* %459, null
-  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+  %NullCheck155 = icmp eq i16* %459, null
+  br i1 %NullCheck155, label %ThrowNullRef156, label %460
 
 ; <label>:460                                     ; preds = %456
   %461 = load i16, i16* %459, align 8
   %462 = sext i16 %461 to i32
   %463 = bitcast i8* %457 to i16*
   %464 = trunc i32 %462 to i16
-  %NullCheck158 = icmp ne i16* %463, null
-  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+  %NullCheck157 = icmp eq i16* %463, null
+  br i1 %NullCheck157, label %ThrowNullRef158, label %465
 
 ; <label>:465                                     ; preds = %460
   store i16 %464, i16* %463, align 8
@@ -1525,15 +1607,15 @@ entry:
 ; <label>:474                                     ; preds = %470
   %475 = load i8*, i8** %arg0
   %476 = load i8*, i8** %arg1
-  %NullCheck160 = icmp ne i8* %476, null
-  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+  %NullCheck159 = icmp eq i8* %476, null
+  br i1 %NullCheck159, label %ThrowNullRef160, label %477
 
 ; <label>:477                                     ; preds = %474
   %478 = load i8, i8* %476, align 8
   %479 = zext i8 %478 to i32
   %480 = trunc i32 %479 to i8
-  %NullCheck162 = icmp ne i8* %475, null
-  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+  %NullCheck161 = icmp eq i8* %475, null
+  br i1 %NullCheck161, label %ThrowNullRef162, label %481
 
 ; <label>:481                                     ; preds = %477
   store i8 %480, i8* %475, align 8
@@ -1553,343 +1635,343 @@ ThrowNullRef:                                     ; preds = %308
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %312
+ThrowNullRef2:                                    ; preds = %312
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %315
+ThrowNullRef4:                                    ; preds = %315
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %321
+ThrowNullRef6:                                    ; preds = %321
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %271
+ThrowNullRef8:                                    ; preds = %271
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %275
+ThrowNullRef10:                                   ; preds = %275
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %278
+ThrowNullRef12:                                   ; preds = %278
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %284
+ThrowNullRef14:                                   ; preds = %284
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %287
+ThrowNullRef16:                                   ; preds = %287
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %293
+ThrowNullRef18:                                   ; preds = %293
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %298
+ThrowNullRef20:                                   ; preds = %298
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %303
+ThrowNullRef22:                                   ; preds = %303
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %243
+ThrowNullRef24:                                   ; preds = %243
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %247
+ThrowNullRef26:                                   ; preds = %247
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %250
+ThrowNullRef28:                                   ; preds = %250
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %256
+ThrowNullRef30:                                   ; preds = %256
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %259
+ThrowNullRef32:                                   ; preds = %259
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %265
+ThrowNullRef34:                                   ; preds = %265
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %217
+ThrowNullRef36:                                   ; preds = %217
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %221
+ThrowNullRef38:                                   ; preds = %221
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %224
+ThrowNullRef40:                                   ; preds = %224
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %230
+ThrowNullRef42:                                   ; preds = %230
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %233
+ThrowNullRef44:                                   ; preds = %233
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %238
+ThrowNullRef46:                                   ; preds = %238
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %200
+ThrowNullRef48:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %204
+ThrowNullRef50:                                   ; preds = %204
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %207
+ThrowNullRef52:                                   ; preds = %207
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %213
+ThrowNullRef54:                                   ; preds = %213
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %172
+ThrowNullRef56:                                   ; preds = %172
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %176
+ThrowNullRef58:                                   ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %179
+ThrowNullRef60:                                   ; preds = %179
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %185
+ThrowNullRef62:                                   ; preds = %185
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %190
+ThrowNullRef64:                                   ; preds = %190
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %195
+ThrowNullRef66:                                   ; preds = %195
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %153
+ThrowNullRef68:                                   ; preds = %153
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %157
+ThrowNullRef70:                                   ; preds = %157
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %160
+ThrowNullRef72:                                   ; preds = %160
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %166
+ThrowNullRef74:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %136
+ThrowNullRef76:                                   ; preds = %136
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %140
+ThrowNullRef78:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %143
+ThrowNullRef80:                                   ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %148
+ThrowNullRef82:                                   ; preds = %148
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %128
+ThrowNullRef84:                                   ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %132
+ThrowNullRef86:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %100
+ThrowNullRef88:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %104
+ThrowNullRef90:                                   ; preds = %104
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %107
+ThrowNullRef92:                                   ; preds = %107
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %113
+ThrowNullRef94:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %118
+ThrowNullRef96:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %123
+ThrowNullRef98:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %81
+ThrowNullRef100:                                  ; preds = %81
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef101:                                  ; preds = %85
+ThrowNullRef102:                                  ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef103:                                  ; preds = %88
+ThrowNullRef104:                                  ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef105:                                  ; preds = %94
+ThrowNullRef106:                                  ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef107:                                  ; preds = %64
+ThrowNullRef108:                                  ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef109:                                  ; preds = %68
+ThrowNullRef110:                                  ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef111:                                  ; preds = %71
+ThrowNullRef112:                                  ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef113:                                  ; preds = %76
+ThrowNullRef114:                                  ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef115:                                  ; preds = %56
+ThrowNullRef116:                                  ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef117:                                  ; preds = %60
+ThrowNullRef118:                                  ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef119:                                  ; preds = %37
+ThrowNullRef120:                                  ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef121:                                  ; preds = %41
+ThrowNullRef122:                                  ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef123:                                  ; preds = %46
+ThrowNullRef124:                                  ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef125:                                  ; preds = %51
+ThrowNullRef126:                                  ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef127:                                  ; preds = %27
+ThrowNullRef128:                                  ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef129:                                  ; preds = %31
+ThrowNullRef130:                                  ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef131:                                  ; preds = %19
+ThrowNullRef132:                                  ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef133:                                  ; preds = %22
+ThrowNullRef134:                                  ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef135:                                  ; preds = %338
+ThrowNullRef136:                                  ; preds = %338
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef137:                                  ; preds = %341
+ThrowNullRef138:                                  ; preds = %341
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef139:                                  ; preds = %356
+ThrowNullRef140:                                  ; preds = %356
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef141:                                  ; preds = %360
+ThrowNullRef142:                                  ; preds = %360
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef143:                                  ; preds = %377
+ThrowNullRef144:                                  ; preds = %377
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef145:                                  ; preds = %381
+ThrowNullRef146:                                  ; preds = %381
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef147:                                  ; preds = %424
+ThrowNullRef148:                                  ; preds = %424
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef149:                                  ; preds = %428
+ThrowNullRef150:                                  ; preds = %428
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef151:                                  ; preds = %440
+ThrowNullRef152:                                  ; preds = %440
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef153:                                  ; preds = %444
+ThrowNullRef154:                                  ; preds = %444
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef155:                                  ; preds = %456
+ThrowNullRef156:                                  ; preds = %456
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef157:                                  ; preds = %460
+ThrowNullRef158:                                  ; preds = %460
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef159:                                  ; preds = %474
+ThrowNullRef160:                                  ; preds = %474
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef161:                                  ; preds = %477
+ThrowNullRef162:                                  ; preds = %477
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef163:                                  ; preds = %394
+ThrowNullRef164:                                  ; preds = %394
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef165:                                  ; preds = %398
+ThrowNullRef166:                                  ; preds = %398
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef167:                                  ; preds = %401
+ThrowNullRef168:                                  ; preds = %401
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef169:                                  ; preds = %407
+ThrowNullRef170:                                  ; preds = %407
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1939,8 +2021,8 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
-  br i1 %NullCheck, label %22, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %ThrowNullRef, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
@@ -1948,8 +2030,8 @@ entry:
   store i32 %24, i32* %loc0
   %25 = load i32, i32* %loc0
   %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %26, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %27
 
 ; <label>:27                                      ; preds = %22
   %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
@@ -1971,7 +2053,7 @@ ThrowNullRef:                                     ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1989,8 +2071,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -2022,15 +2104,15 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2048,16 +2130,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
   %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
   store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %15
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
@@ -2072,8 +2154,8 @@ entry:
   %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
   %29 = ptrtoint i16 addrspace(1)* %28 to i64
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %19
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
@@ -2089,19 +2171,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2114,8 +2196,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
@@ -2128,7 +2210,7 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[loadElem]
+Failed to read AppDomain.PrepareDataForSetup[storeElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
@@ -2202,8 +2284,8 @@ entry:
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
-  br i1 %NullCheck24, label %27, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = load i64, i64 addrspace(1)* %26
@@ -2218,8 +2300,8 @@ entry:
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
-  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
   %41 = load i64, i64 addrspace(1)* %39
@@ -2236,8 +2318,8 @@ entry:
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
-  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
   %54 = load i64, i64 addrspace(1)* %52
@@ -2252,8 +2334,8 @@ entry:
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
   %67 = load i64, i64 addrspace(1)* %65
@@ -2270,8 +2352,8 @@ entry:
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
-  br i1 %NullCheck16, label %79, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
   %80 = load i64, i64 addrspace(1)* %78
@@ -2286,8 +2368,8 @@ entry:
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
-  br i1 %NullCheck18, label %92, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
   %93 = load i64, i64 addrspace(1)* %91
@@ -2304,8 +2386,8 @@ entry:
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
-  br i1 %NullCheck12, label %105, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = load i64, i64 addrspace(1)* %104
@@ -2320,8 +2402,8 @@ entry:
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
-  br i1 %NullCheck14, label %118, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
   %119 = load i64, i64 addrspace(1)* %117
@@ -2337,8 +2419,8 @@ entry:
 
 ; <label>:128                                     ; preds = %20
   %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
-  br i1 %NullCheck4, label %130, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %129, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %130
 
 ; <label>:130                                     ; preds = %128
   %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
@@ -2346,8 +2428,8 @@ entry:
   %133 = load i16, i16 addrspace(1)* %132, align 8
   %134 = zext i16 %133 to i32
   %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
-  br i1 %NullCheck6, label %136, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %135, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %136
 
 ; <label>:136                                     ; preds = %130
   %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
@@ -2360,8 +2442,8 @@ entry:
 
 ; <label>:143                                     ; preds = %136
   %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
-  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %144, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %145
 
 ; <label>:145                                     ; preds = %143
   %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
@@ -2369,8 +2451,8 @@ entry:
   %148 = load i16, i16 addrspace(1)* %147, align 8
   %149 = zext i16 %148 to i32
   %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %150, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %151
 
 ; <label>:151                                     ; preds = %145
   %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
@@ -2388,8 +2470,8 @@ entry:
 
 ; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
-  br i1 %NullCheck, label %163, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %ThrowNullRef, label %163
 
 ; <label>:163                                     ; preds = %161
   %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
@@ -2399,8 +2481,8 @@ entry:
 
 ; <label>:167                                     ; preds = %163
   %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
-  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %168, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %169
 
 ; <label>:169                                     ; preds = %167
   %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
@@ -2432,55 +2514,55 @@ ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %167
+ThrowNullRef2:                                    ; preds = %167
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %128
+ThrowNullRef4:                                    ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %130
+ThrowNullRef6:                                    ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %143
+ThrowNullRef8:                                    ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %145
+ThrowNullRef10:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %102
+ThrowNullRef12:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %105
+ThrowNullRef14:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %76
+ThrowNullRef16:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %79
+ThrowNullRef18:                                   ; preds = %79
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %50
+ThrowNullRef20:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %53
+ThrowNullRef22:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %24
+ThrowNullRef24:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %27
+ThrowNullRef26:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2503,15 +2585,15 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2519,16 +2601,16 @@ entry:
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
   store i32 %8, i32* %loc0
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
   %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
   store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
@@ -2546,16 +2628,16 @@ entry:
 
 ; <label>:23                                      ; preds = %64
   %24 = load i16*, i16** %loc3
-  %NullCheck12 = icmp ne i16* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i16* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
   store i32 %27, i32* %loc5
   %28 = load i16*, i16** %loc4
-  %NullCheck14 = icmp ne i16* %28, null
-  br i1 %NullCheck14, label %29, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %28, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = load i16, i16* %28, align 8
@@ -2620,15 +2702,15 @@ entry:
 
 ; <label>:67                                      ; preds = %64
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
-  br i1 %NullCheck8, label %69, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %68, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %69
 
 ; <label>:69                                      ; preds = %67
   %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
   %71 = load i32, i32 addrspace(1)* %70
   %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
-  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %73
 
 ; <label>:73                                      ; preds = %69
   %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
@@ -2645,31 +2727,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %67
+ThrowNullRef8:                                    ; preds = %67
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %69
+ThrowNullRef10:                                   ; preds = %69
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2710,14 +2792,14 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
   %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
@@ -2730,14 +2812,14 @@ entry:
 
 ; <label>:11                                      ; preds = %4
   %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
   %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
@@ -2749,14 +2831,14 @@ entry:
 
 ; <label>:22                                      ; preds = %16
   %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
   %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
-  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
-  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
@@ -2804,23 +2886,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2836,7 +2918,280 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[loadElem]
+Successfully read RuntimeType.IsAssignableFrom
+
+define i8 @RuntimeType.IsAssignableFrom(%System.RuntimeType addrspace(1)* %param0, %System.Type addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.RuntimeType addrspace(1)*
+  %arg1 = alloca %System.Type addrspace(1)*
+  %loc0 = alloca %System.RuntimeType addrspace(1)*
+  %loc1 = alloca %"System.Type[]" addrspace(1)*
+  %loc2 = alloca i32
+  store %System.RuntimeType addrspace(1)* %param0, %System.RuntimeType addrspace(1)** %this
+  store %System.Type addrspace(1)* %param1, %System.Type addrspace(1)** %arg1
+  %0 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %1 = icmp ne %System.Type addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i8 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %5 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %6 = bitcast %System.Type addrspace(1)* %4 to %System.Object addrspace(1)*
+  %7 = bitcast %System.RuntimeType addrspace(1)* %5 to %System.Object addrspace(1)*
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %6, %System.Object addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %3
+  ret i8 1
+
+; <label>:12                                      ; preds = %3
+  %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 152
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 32
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
+  %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
+  %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
+  store %System.RuntimeType addrspace(1)* %25, %System.RuntimeType addrspace(1)** %loc0
+  %26 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %27 = icmp eq %System.RuntimeType addrspace(1)* %26, null
+  br i1 %27, label %34, label %28
+
+; <label>:28                                      ; preds = %15
+  %29 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %30 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)*)*)(%System.RuntimeType addrspace(1)* %29, %System.RuntimeType addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+; <label>:34                                      ; preds = %15
+  %35 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %36 = call %System.Reflection.Emit.TypeBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Reflection.Emit.TypeBuilder addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %35)
+  %37 = icmp eq %System.Reflection.Emit.TypeBuilder addrspace(1)* %36, null
+  br i1 %37, label %139, label %38
+
+; <label>:38                                      ; preds = %34
+  %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %42
+
+; <label>:42                                      ; preds = %38
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 152
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 40
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
+  %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
+  %53 = zext i8 %52 to i32
+  %54 = icmp eq i32 %53, 0
+  br i1 %54, label %56, label %55
+
+; <label>:55                                      ; preds = %42
+  ret i8 1
+
+; <label>:56                                      ; preds = %42
+  %57 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %58 = bitcast %System.RuntimeType addrspace(1)* %57 to %System.Type addrspace(1)*
+  %59 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %58)
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %64 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.Type addrspace(1)* %63, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = bitcast %System.RuntimeType addrspace(1)* %64 to %System.Type addrspace(1)*
+  %67 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %63, %System.Type addrspace(1)* %66)
+  %68 = zext i8 %67 to i32
+  %69 = trunc i32 %68 to i8
+  ret i8 %69
+
+; <label>:70                                      ; preds = %56
+  %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
+  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %73
+
+; <label>:73                                      ; preds = %70
+  %74 = load i64, i64 addrspace(1)* %72
+  %75 = add i64 %74, 128
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = add i64 %77, 0
+  %79 = inttoptr i64 %78 to i64*
+  %80 = load i64, i64* %79
+  %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
+  %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
+  %83 = call i8 %82(%System.Type addrspace(1)* %81)
+  %84 = zext i8 %83 to i32
+  %85 = icmp eq i32 %84, 0
+  br i1 %85, label %139, label %86
+
+; <label>:86                                      ; preds = %73
+  %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
+  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %89
+
+; <label>:89                                      ; preds = %86
+  %90 = load i64, i64 addrspace(1)* %88
+  %91 = add i64 %90, 128
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = add i64 %93, 24
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
+  %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
+  %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
+  store %"System.Type[]" addrspace(1)* %99, %"System.Type[]" addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %129
+
+; <label>:100                                     ; preds = %132
+  %101 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %102 = load i32, i32* %loc2
+  %NullCheck11 = icmp eq %"System.Type[]" addrspace(1)* %101, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %103
+
+; <label>:103                                     ; preds = %100
+  %104 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 1
+  %105 = load i32, i32 addrspace(1)* %104
+  %106 = zext i32 %105 to i64
+  %107 = zext i32 %102 to i64
+  %BoundsCheck = icmp uge i64 %107, %106
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %108
+
+; <label>:108                                     ; preds = %103
+  %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
+  %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
+  %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
+  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %113
+
+; <label>:113                                     ; preds = %108
+  %114 = load i64, i64 addrspace(1)* %112
+  %115 = add i64 %114, 152
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = add i64 %117, 56
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
+  %123 = zext i8 %122 to i32
+  %124 = icmp ne i32 %123, 0
+  br i1 %124, label %126, label %125
+
+; <label>:125                                     ; preds = %113
+  ret i8 0
+
+; <label>:126                                     ; preds = %113
+  %127 = load i32, i32* %loc2
+  %128 = add i32 %127, 1
+  store i32 %128, i32* %loc2
+  br label %129
+
+; <label>:129                                     ; preds = %89, %126
+  %130 = load i32, i32* %loc2
+  %131 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %NullCheck9 = icmp eq %"System.Type[]" addrspace(1)* %131, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %132
+
+; <label>:132                                     ; preds = %129
+  %133 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %131, i32 0, i32 1
+  %134 = load i32, i32 addrspace(1)* %133
+  %135 = zext i32 %134 to i64
+  %136 = trunc i64 %135 to i32
+  %137 = icmp slt i32 %130, %136
+  br i1 %137, label %100, label %138
+
+; <label>:138                                     ; preds = %132
+  ret i8 1
+
+; <label>:139                                     ; preds = %34, %73
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %129
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %103
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -2893,7 +3248,7 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElem]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -2904,8 +3259,8 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -2997,8 +3352,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
@@ -3059,8 +3414,8 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -3087,8 +3442,8 @@ entry:
 
 ; <label>:17                                      ; preds = %5, %11
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
@@ -3097,8 +3452,8 @@ entry:
 
 ; <label>:22                                      ; preds = %1, %11
   %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
@@ -3109,11 +3464,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %17
+ThrowNullRef2:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %22
+ThrowNullRef4:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3167,15 +3522,15 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
   %15 = load i32, i32 addrspace(1)* %14
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
@@ -3198,7 +3553,7 @@ ThrowNullRef:                                     ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef2:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3232,8 +3587,8 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
@@ -3312,8 +3667,8 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -3327,8 +3682,8 @@ entry:
 ; <label>:5                                       ; preds = %43
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %7 = load i32, i32* %loc1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck6, label %8, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
@@ -3366,8 +3721,8 @@ entry:
 ; <label>:32                                      ; preds = %21, %25
   %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
   %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
-  br i1 %NullCheck8, label %35, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = trunc i32 %34 to i16
@@ -3380,8 +3735,8 @@ entry:
 ; <label>:40                                      ; preds = %1, %35
   %41 = load i32, i32* %loc1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
-  br i1 %NullCheck2, label %43, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %42, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
@@ -3392,8 +3747,8 @@ entry:
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
   %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
-  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
   %51 = load i64, i64 addrspace(1)* %49
@@ -3412,19 +3767,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %40
+ThrowNullRef2:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %47
+ThrowNullRef4:                                    ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %5
+ThrowNullRef6:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %32
+ThrowNullRef8:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3467,8 +3822,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
@@ -3492,11 +3847,391 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(i16* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store i16* %param0, i16** %arg0
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load i32, i32* %arg3
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %42, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %37, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg2
+  %13 = load i32, i32* %arg3
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %37, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %24 = load i32, i32* %arg2
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load i16*, i16** %arg0
+  %35 = load i32, i32* %arg3
+  %36 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %36, i16* %34, i32 %35)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:37                                      ; preds = %5, %16
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %39)
+  %41 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41, %System.String addrspace(1)* %38, %System.String addrspace(1)* %40)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41) #0
+  unreachable
+
+; <label>:42                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
-Failed to read StringBuilder.ToString[loadElemA]
+Successfully read StringBuilder.ToString
+
+define %System.String addrspace(1)* @StringBuilder.ToString(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i16*
+  %loc3 = alloca %"System.Char[]" addrspace(1)*
+  %loc4 = alloca i32
+  %loc5 = alloca i32
+  %loc6 = alloca i16 addrspace(1)*
+  %loc7 = alloca %System.String addrspace(1)*
+  %loc8 = alloca %"System.Char[]" addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %0)
+  %2 = icmp ne i32 %1, 0
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %4
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %6)
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %7)
+  store %System.String addrspace(1)* %8, %System.String addrspace(1)** %loc0
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.Text.StringBuilder addrspace(1)* %9, %System.Text.StringBuilder addrspace(1)** %loc1
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  store %System.String addrspace(1)* %10, %System.String addrspace(1)** %loc7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc7
+  %12 = ptrtoint %System.String addrspace(1)* %11 to i64
+  %13 = icmp eq i64 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %5
+  %15 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %16 = sext i32 %15 to i64
+  %17 = add i64 %12, %16
+  br label %18
+
+; <label>:18                                      ; preds = %5, %14
+  %19 = phi i64 [ %12, %5 ], [ %17, %14 ]
+  %20 = inttoptr i64 %19 to i16*
+  store i16* %20, i16** %loc2
+  br label %21
+
+; <label>:21                                      ; preds = %98, %18
+  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %22, null
+  br i1 %NullCheck, label %ThrowNullRef, label %23
+
+; <label>:23                                      ; preds = %21
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 3
+  %25 = load i32, i32 addrspace(1)* %24, align 8
+  %26 = icmp sle i32 %25, 0
+  br i1 %26, label %96, label %27
+
+; <label>:27                                      ; preds = %23
+  %28 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %28, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %29
+
+; <label>:29                                      ; preds = %27
+  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %28, i32 0, i32 1
+  %31 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %30, align 8
+  store %"System.Char[]" addrspace(1)* %31, %"System.Char[]" addrspace(1)** %loc3
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %33
+
+; <label>:33                                      ; preds = %29
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  store i32 %35, i32* %loc4
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  %39 = load i32, i32 addrspace(1)* %38, align 8
+  store i32 %39, i32* %loc5
+  %40 = load i32, i32* %loc5
+  %41 = load i32, i32* %loc4
+  %42 = add i32 %40, %41
+  %43 = zext i32 %42 to i64
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %45
+
+; <label>:45                                      ; preds = %37
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = sext i32 %47 to i64
+  %49 = icmp sgt i64 %43, %48
+  br i1 %49, label %91, label %50
+
+; <label>:50                                      ; preds = %45
+  %51 = load i32, i32* %loc5
+  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %52, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %53
+
+; <label>:53                                      ; preds = %50
+  %54 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %52, i32 0, i32 1
+  %55 = load i32, i32 addrspace(1)* %54
+  %56 = zext i32 %55 to i64
+  %57 = trunc i64 %56 to i32
+  %58 = icmp ugt i32 %51, %57
+  br i1 %58, label %91, label %59
+
+; <label>:59                                      ; preds = %53
+  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  store %"System.Char[]" addrspace(1)* %60, %"System.Char[]" addrspace(1)** %loc8
+  %61 = icmp eq %"System.Char[]" addrspace(1)* %60, null
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %63, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %64
+
+; <label>:64                                      ; preds = %62
+  %65 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %63, i32 0, i32 1
+  %66 = load i32, i32 addrspace(1)* %65
+  %67 = zext i32 %66 to i64
+  %68 = trunc i64 %67 to i32
+  %69 = icmp ne i32 %68, 0
+  br i1 %69, label %71, label %70
+
+; <label>:70                                      ; preds = %59, %64
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:71                                      ; preds = %64
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %73
+
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %BoundsCheck = icmp uge i64 0, %76
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %77
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %78, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:79                                      ; preds = %70, %77
+  %80 = load i16*, i16** %loc2
+  %81 = load i32, i32* %loc4
+  %82 = sext i32 %81 to i64
+  %83 = mul i64 %82, 2
+  %84 = bitcast i16* %80 to i8*
+  %85 = getelementptr inbounds i8, i8* %84, i64 %83
+  %86 = load i16 addrspace(1)*, i16 addrspace(1)** %loc6
+  %87 = ptrtoint i16 addrspace(1)* %86 to i64
+  %88 = load i32, i32* %loc5
+  %89 = bitcast i8* %85 to i16*
+  %90 = inttoptr i64 %87 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %89, i16* %90, i32 %88)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %96
+
+; <label>:91                                      ; preds = %45, %53
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %94 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %93)
+  %95 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95, %System.String addrspace(1)* %92, %System.String addrspace(1)* %94)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95) #0
+  unreachable
+
+; <label>:96                                      ; preds = %23, %79
+  %97 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %97, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %98
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %97, i32 0, i32 2
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  store %System.Text.StringBuilder addrspace(1)* %100, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %102 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %102, label %21, label %103
+
+; <label>:103                                     ; preds = %98
+  store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc7
+  %104 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  ret %System.String addrspace(1)* %104
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method StringBuilder::get_Length using LLILCJit
+Successfully read StringBuilder.get_Length
+
+define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
+Successfully read RuntimeHelpers.get_OffsetToStringData
+
+define i32 @RuntimeHelpers.get_OffsetToStringData() {
+entry:
+  ret i32 12
+}
+
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
 Successfully read CultureData.CreateCultureData
 
@@ -3514,23 +4249,23 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
   store i8 %4, i8 addrspace(1)* %6
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
@@ -3549,11 +4284,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3566,50 +4301,50 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
   store i32 -1, i32 addrspace(1)* %2
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
   store i32 -1, i32 addrspace(1)* %8
   %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
   store i32 -1, i32 addrspace(1)* %14
   %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
   store i32 -1, i32 addrspace(1)* %17
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
@@ -3623,27 +4358,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3675,7 +4410,136 @@ Failed to read Dictionary`2.Insert[non-const derefAddress]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
 Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
-Failed to read HashHelpers.GetPrime[loadElem]
+Successfully read HashHelpers.GetPrime
+
+define i32 @HashHelpers.GetPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %6, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5, %System.String addrspace(1)* %4)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5) #0
+  unreachable
+
+; <label>:6                                       ; preds = %entry
+  store i32 0, i32* %loc0
+  br label %29
+
+; <label>:7                                       ; preds = %35
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 1296
+  %10 = addrspacecast i8 addrspace(1)* %9 to %"System.Int32[]" addrspace(1)**
+  %11 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %10
+  %12 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Int32[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = zext i32 %15 to i64
+  %17 = zext i32 %12 to i64
+  %BoundsCheck = icmp uge i64 %17, %16
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 3, i32 %12
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  store i32 %20, i32* %loc1
+  %21 = load i32, i32* %loc1
+  %22 = load i32, i32* %arg0
+  %23 = icmp slt i32 %21, %22
+  br i1 %23, label %26, label %24
+
+; <label>:24                                      ; preds = %18
+  %25 = load i32, i32* %loc1
+  ret i32 %25
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %loc0
+  %28 = add i32 %27, 1
+  store i32 %28, i32* %loc0
+  br label %29
+
+; <label>:29                                      ; preds = %6, %26
+  %30 = load i32, i32* %loc0
+  %31 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %32 = getelementptr inbounds i8, i8 addrspace(1)* %31, i64 1296
+  %33 = addrspacecast i8 addrspace(1)* %32 to %"System.Int32[]" addrspace(1)**
+  %34 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %33
+  %NullCheck = icmp eq %"System.Int32[]" addrspace(1)* %34, null
+  br i1 %NullCheck, label %ThrowNullRef, label %35
+
+; <label>:35                                      ; preds = %29
+  %36 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %34, i32 0, i32 1
+  %37 = load i32, i32 addrspace(1)* %36
+  %38 = zext i32 %37 to i64
+  %39 = trunc i64 %38 to i32
+  %40 = icmp slt i32 %30, %39
+  br i1 %40, label %7, label %41
+
+; <label>:41                                      ; preds = %35
+  %42 = load i32, i32* %arg0
+  %43 = or i32 %42, 1
+  store i32 %43, i32* %loc2
+  br label %59
+
+; <label>:44                                      ; preds = %59
+  %45 = load i32, i32* %loc2
+  %46 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %45)
+  %47 = zext i8 %46 to i32
+  %48 = icmp eq i32 %47, 0
+  br i1 %48, label %56, label %49
+
+; <label>:49                                      ; preds = %44
+  %50 = load i32, i32* %loc2
+  %51 = sub i32 %50, 1
+  %52 = srem i32 %51, 101
+  %53 = icmp eq i32 %52, 0
+  br i1 %53, label %56, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = load i32, i32* %loc2
+  ret i32 %55
+
+; <label>:56                                      ; preds = %44, %49
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %57, 2
+  store i32 %58, i32* %loc2
+  br label %59
+
+; <label>:59                                      ; preds = %41, %56
+  %60 = load i32, i32* %loc2
+  %61 = icmp slt i32 %60, 2147483647
+  br i1 %61, label %44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load i32, i32* %arg0
+  ret i32 %63
+
+ThrowNullRef:                                     ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
 Successfully read GenericEqualityComparer`1.GetHashCode
 
@@ -3694,14 +4558,14 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
   %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load i64, i64 addrspace(1)* %7
@@ -3720,7 +4584,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3750,8 +4614,8 @@ entry:
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
@@ -3796,8 +4660,8 @@ entry:
   %35 = bitcast i16* %34 to i8*
   %36 = getelementptr inbounds i8, i8* %35, i64 2
   %37 = bitcast i8* %36 to i16*
-  %NullCheck4 = icmp ne i16* %37, null
-  br i1 %NullCheck4, label %38, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %37, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %38
 
 ; <label>:38                                      ; preds = %27
   %39 = load i16, i16* %37, align 8
@@ -3824,8 +4688,8 @@ entry:
 
 ; <label>:54                                      ; preds = %22, %43
   %55 = load i16*, i16** %loc4
-  %NullCheck2 = icmp ne i16* %55, null
-  br i1 %NullCheck2, label %56, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i16* %55, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %56
 
 ; <label>:56                                      ; preds = %54
   %57 = load i16, i16* %55, align 8
@@ -3850,11 +4714,11 @@ ThrowNullRef:                                     ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %54
+ThrowNullRef2:                                    ; preds = %54
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %27
+ThrowNullRef4:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3871,8 +4735,8 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -3907,8 +4771,8 @@ entry:
 
 ; <label>:26                                      ; preds = %19
   %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
-  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %28
 
 ; <label>:28                                      ; preds = %26
   %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
@@ -3920,7 +4784,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3972,8 +4836,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
@@ -3984,26 +4848,26 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
-  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
@@ -4014,8 +4878,8 @@ entry:
 ; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
@@ -4024,8 +4888,8 @@ entry:
 
 ; <label>:25                                      ; preds = %1, %16, %23
   %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
-  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
@@ -4036,27 +4900,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %20
+ThrowNullRef10:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4069,8 +4933,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -4081,8 +4945,8 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
@@ -4091,8 +4955,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1, %8
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
@@ -4103,11 +4967,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4128,24 +4992,24 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   store i32 %3, i32* %loc0
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
   %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
   store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck4, label %9, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
@@ -4164,15 +5028,15 @@ entry:
 ; <label>:18                                      ; preds = %70
   %19 = load i16*, i16** %loc3
   %20 = bitcast i16* %19 to i64*
-  %NullCheck10 = icmp ne i64* %20, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %20, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = load i64, i64* %20, align 8
   %23 = load i16*, i16** %loc4
   %24 = bitcast i16* %23 to i64*
-  %NullCheck12 = icmp ne i64* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = load i64, i64* %24, align 8
@@ -4188,8 +5052,8 @@ entry:
   %31 = bitcast i16* %30 to i8*
   %32 = getelementptr inbounds i8, i8* %31, i64 8
   %33 = bitcast i8* %32 to i64*
-  %NullCheck14 = icmp ne i64* %33, null
-  br i1 %NullCheck14, label %34, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = load i64, i64* %33, align 8
@@ -4197,8 +5061,8 @@ entry:
   %37 = bitcast i16* %36 to i8*
   %38 = getelementptr inbounds i8, i8* %37, i64 8
   %39 = bitcast i8* %38 to i64*
-  %NullCheck16 = icmp ne i64* %39, null
-  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %40
 
 ; <label>:40                                      ; preds = %34
   %41 = load i64, i64* %39, align 8
@@ -4214,8 +5078,8 @@ entry:
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %NullCheck18 = icmp ne i64* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = load i64, i64* %48, align 8
@@ -4223,8 +5087,8 @@ entry:
   %52 = bitcast i16* %51 to i8*
   %53 = getelementptr inbounds i8, i8* %52, i64 16
   %54 = bitcast i8* %53 to i64*
-  %NullCheck20 = icmp ne i64* %54, null
-  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64* %54, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %55
 
 ; <label>:55                                      ; preds = %49
   %56 = load i64, i64* %54, align 8
@@ -4262,15 +5126,15 @@ entry:
 ; <label>:74                                      ; preds = %95
   %75 = load i16*, i16** %loc3
   %76 = bitcast i16* %75 to i32*
-  %NullCheck6 = icmp ne i32* %76, null
-  br i1 %NullCheck6, label %77, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32* %76, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %77
 
 ; <label>:77                                      ; preds = %74
   %78 = load i32, i32* %76, align 8
   %79 = load i16*, i16** %loc4
   %80 = bitcast i16* %79 to i32*
-  %NullCheck8 = icmp ne i32* %80, null
-  br i1 %NullCheck8, label %81, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i32* %80, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %81
 
 ; <label>:81                                      ; preds = %77
   %82 = load i32, i32* %80, align 8
@@ -4318,43 +5182,43 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %74
+ThrowNullRef6:                                    ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %77
+ThrowNullRef8:                                    ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %29
+ThrowNullRef14:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %34
+ThrowNullRef16:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4376,8 +5240,8 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load i64, i64 addrspace(1)* %4
@@ -4389,8 +5253,8 @@ entry:
   %12 = load i64, i64* %11
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %5
   %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
@@ -4399,8 +5263,8 @@ entry:
   %18 = load i8, i8* %arg2
   %19 = zext i8 %18 to i32
   %20 = trunc i32 %19 to i8
-  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %15
   %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
@@ -4411,11 +5275,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4442,8 +5306,8 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
@@ -4466,16 +5330,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
   %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = load i64, i64 addrspace(1)* %19
@@ -4500,8 +5364,8 @@ entry:
 ; <label>:35                                      ; preds = %30
   %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
@@ -4514,8 +5378,8 @@ entry:
 
 ; <label>:42                                      ; preds = %1, %38
   %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
-  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
@@ -4526,19 +5390,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %35
+ThrowNullRef2:                                    ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %42
+ThrowNullRef8:                                    ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4551,14 +5415,14 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
@@ -4570,7 +5434,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4583,8 +5447,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
@@ -4613,51 +5477,51 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
   %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
   %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
   %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
   %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
-  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
   store i64 %21, i64 addrspace(1)* %23
   %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %25 = load i64, i64* %loc0
-  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
@@ -4668,27 +5532,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %22
+ThrowNullRef12:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4701,8 +5565,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
@@ -4713,19 +5577,19 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
@@ -4734,8 +5598,8 @@ entry:
 
 ; <label>:15                                      ; preds = %1, %13
   %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
@@ -4746,19 +5610,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %15
+ThrowNullRef8:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4771,8 +5635,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -4831,8 +5695,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
@@ -4882,8 +5746,8 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
-  br i1 %NullCheck, label %17, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %ThrowNullRef, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
@@ -4894,15 +5758,15 @@ entry:
 
 ; <label>:22                                      ; preds = %17
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
-  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
   %26 = load i32, i32 addrspace(1)* %25
   %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
-  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %27, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
@@ -4925,8 +5789,8 @@ entry:
 ; <label>:40                                      ; preds = %17
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
-  br i1 %NullCheck6, label %43, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %41, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
@@ -4938,34 +5802,17 @@ ThrowNullRef:                                     ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %24
+ThrowNullRef4:                                    ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %40
+ThrowNullRef6:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
-}
-
-INFO:  jitting method Object::ReferenceEquals using LLILCJit
-Successfully read Object.ReferenceEquals
-
-define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
-entry:
-  %arg0 = alloca %System.Object addrspace(1)*
-  %arg1 = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
-  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
-  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = icmp eq %System.Object addrspace(1)* %0, %1
-  %3 = sext i1 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
 }
 
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
@@ -4978,21 +5825,21 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
   %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
-  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
@@ -5007,28 +5854,28 @@ entry:
 ; <label>:13                                      ; preds = %8, %12
   %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
   %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
   %21 = load i32, i32 addrspace(1)* %20, align 8
   %22 = add i32 %21, 1
-  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
   store i32 %22, i32 addrspace(1)* %24
   %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
@@ -5039,27 +5886,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5077,7 +5924,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::Setup using LLILCJit
-Failed to read AppDomain.Setup[loadElem]
+Failed to read AppDomain.Setup[unbox]
 INFO:  jitting method Thread::GetDomain using LLILCJit
 Successfully read Thread.GetDomain
 
@@ -5108,8 +5955,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
@@ -5122,14 +5969,14 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
   %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
@@ -5141,11 +5988,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5173,8 +6020,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -5189,7 +6036,328 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
 Failed to read KeyCollection.System.Collections.Generic.IEnumerable<TKey>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Successfully read Enumerator.MoveNext
+
+define i8 @Enumerator.MoveNext(%"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.RuntimeTypeHandle* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*
+  %"$TypeArg" = alloca %System.RuntimeTypeHandle*
+  store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
+  %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 8
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %76, label %12
+
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
+  br label %76
+
+; <label>:13                                      ; preds = %85
+  %14 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck19 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %15
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, i32 0, i32 0
+  %17 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %16, align 8
+  %NullCheck21 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, i32 0, i32 2
+  %20 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %19, align 8
+  %21 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck23 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %22
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, i32 0, i32 2
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %NullCheck25 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 3, i32 %24
+  %NullCheck27 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %32
+
+; <label>:32                                      ; preds = %30
+  %33 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, i32 0, i32 2
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = icmp slt i32 %34, 0
+  br i1 %35, label %68, label %36
+
+; <label>:36                                      ; preds = %32
+  %37 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %38 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck29 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %39
+
+; <label>:39                                      ; preds = %36
+  %40 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, i32 0, i32 0
+  %41 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %40, align 8
+  %NullCheck31 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, i32 0, i32 2
+  %44 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %43, align 8
+  %45 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck33 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, i32 0, i32 2
+  %48 = load i32, i32 addrspace(1)* %47, align 8
+  %NullCheck35 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %49
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = zext i32 %51 to i64
+  %53 = zext i32 %48 to i64
+  %BoundsCheck37 = icmp uge i64 %53, %52
+  br i1 %BoundsCheck37, label %ThrowIndexOutOfRange38, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 3, i32 %48
+  %NullCheck39 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %56
+
+; <label>:56                                      ; preds = %54
+  %57 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, i32 0, i32 0
+  %58 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck41 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %59
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %60, %System.__Canon addrspace(1)* %58)
+  %61 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck43 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  %64 = load i32, i32 addrspace(1)* %63, align 8
+  %65 = add i32 %64, 1
+  %NullCheck45 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  store i32 %65, i32 addrspace(1)* %67
+  ret i8 1
+
+; <label>:68                                      ; preds = %32
+  %69 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck47 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %73 = add i32 %72, 1
+  %NullCheck49 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %74
+
+; <label>:74                                      ; preds = %70
+  %75 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  store i32 %73, i32 addrspace(1)* %75
+  br label %76
+
+; <label>:76                                      ; preds = %8, %12, %74
+  %77 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %78
+
+; <label>:78                                      ; preds = %76
+  %79 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, i32 0, i32 2
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck7 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %82
+
+; <label>:82                                      ; preds = %78
+  %83 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, i32 0, i32 0
+  %84 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %83, align 8
+  %NullCheck9 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %85
+
+; <label>:85                                      ; preds = %82
+  %86 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, i32 0, i32 7
+  %87 = load i32, i32 addrspace(1)* %86, align 8
+  %88 = icmp ult i32 %80, %87
+  br i1 %88, label %13, label %89
+
+; <label>:89                                      ; preds = %85
+  %90 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %91 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck11 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %92
+
+; <label>:92                                      ; preds = %89
+  %93 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, i32 0, i32 0
+  %94 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck13 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %95
+
+; <label>:95                                      ; preds = %92
+  %96 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, i32 0, i32 7
+  %97 = load i32, i32 addrspace(1)* %96, align 8
+  %98 = add i32 %97, 1
+  %NullCheck15 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %99
+
+; <label>:99                                      ; preds = %95
+  %100 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, i32 0, i32 2
+  store i32 %98, i32 addrspace(1)* %100
+  %101 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck17 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %102
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %103, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %92
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef22:                                   ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef24:                                   ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef26:                                   ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef28:                                   ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef30:                                   ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef32:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef34:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef36:                                   ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange38:                           ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef40:                                   ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef42:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef44:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef46:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef48:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef50:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -5200,8 +6368,8 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -5232,9 +6400,9 @@ Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
 Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
-Failed to read String.MakeSeparatorList[loadElemA]
+Failed to read String.MakeSeparatorList[storeElem]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
-Failed to read String.InternalSplitKeepEmptyEntries[loadElem]
+Failed to read String.InternalSplitKeepEmptyEntries[storeElem]
 INFO:  jitting method Path::IsRelative using LLILCJit
 Successfully read Path.IsRelative
 
@@ -5243,8 +6411,8 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -5254,8 +6422,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
@@ -5271,8 +6439,8 @@ entry:
 
 ; <label>:17                                      ; preds = %7
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
@@ -5288,8 +6456,8 @@ entry:
 
 ; <label>:29                                      ; preds = %19
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %31
 
 ; <label>:31                                      ; preds = %29
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
@@ -5300,8 +6468,8 @@ entry:
 
 ; <label>:36                                      ; preds = %31
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
-  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %37, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
@@ -5312,8 +6480,8 @@ entry:
 
 ; <label>:43                                      ; preds = %31, %38
   %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
-  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %45
 
 ; <label>:45                                      ; preds = %43
   %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
@@ -5324,8 +6492,8 @@ entry:
 
 ; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %50
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
@@ -5336,8 +6504,8 @@ entry:
 
 ; <label>:57                                      ; preds = %1, %7, %19, %45, %52
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
-  br i1 %NullCheck14, label %59, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %59
 
 ; <label>:59                                      ; preds = %57
   %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
@@ -5347,8 +6515,8 @@ entry:
 
 ; <label>:63                                      ; preds = %59
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
@@ -5359,8 +6527,8 @@ entry:
 
 ; <label>:70                                      ; preds = %65
   %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
-  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.String addrspace(1)* %71, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %72
 
 ; <label>:72                                      ; preds = %70
   %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
@@ -5379,39 +6547,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %17
+ThrowNullRef4:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %29
+ThrowNullRef6:                                    ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %36
+ThrowNullRef8:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %43
+ThrowNullRef10:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %50
+ThrowNullRef12:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %57
+ThrowNullRef14:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %63
+ThrowNullRef16:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %70
+ThrowNullRef18:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5419,7 +6587,293 @@ ThrowNullRef17:                                   ; preds = %70
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
-Failed to read String.TrimHelper[loadElem]
+Successfully read String.TrimHelper
+
+define %System.String addrspace(1)* @String.TrimHelper(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i16
+  %loc4 = alloca i32
+  %loc5 = alloca i16
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = sub i32 %3, 1
+  store i32 %4, i32* %loc0
+  store i32 0, i32* %loc1
+  %5 = load i32, i32* %arg2
+  %6 = icmp eq i32 %5, 1
+  br i1 %6, label %62, label %7
+
+; <label>:7                                       ; preds = %1
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:8                                       ; preds = %58
+  store i32 0, i32* %loc2
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load i32, i32* %loc1
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2, i32 %10
+  %13 = load i16, i16 addrspace(1)* %12
+  %14 = zext i16 %13 to i32
+  %15 = trunc i32 %14 to i16
+  store i16 %15, i16* %loc3
+  store i32 0, i32* %loc2
+  br label %34
+
+; <label>:16                                      ; preds = %37
+  %17 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %18 = load i32, i32* %loc2
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %17, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %19
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = zext i32 %18 to i64
+  %BoundsCheck = icmp uge i64 %23, %22
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %24
+
+; <label>:24                                      ; preds = %19
+  %25 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 3, i32 %18
+  %26 = load i16, i16 addrspace(1)* %25, align 8
+  %27 = zext i16 %26 to i32
+  %28 = load i16, i16* %loc3
+  %29 = zext i16 %28 to i32
+  %30 = icmp eq i32 %27, %29
+  br i1 %30, label %43, label %31
+
+; <label>:31                                      ; preds = %24
+  %32 = load i32, i32* %loc2
+  %33 = add i32 %32, 1
+  store i32 %33, i32* %loc2
+  br label %34
+
+; <label>:34                                      ; preds = %11, %31
+  %35 = load i32, i32* %loc2
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = icmp slt i32 %35, %41
+  br i1 %42, label %16, label %43
+
+; <label>:43                                      ; preds = %24, %37
+  %44 = load i32, i32* %loc2
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %45, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp eq i32 %44, %50
+  br i1 %51, label %62, label %52
+
+; <label>:52                                      ; preds = %46
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %7, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %57, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %58
+
+; <label>:58                                      ; preds = %55
+  %59 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %60 = load i32, i32 addrspace(1)* %59
+  %61 = icmp slt i32 %56, %60
+  br i1 %61, label %8, label %62
+
+; <label>:62                                      ; preds = %1, %46, %58
+  %63 = load i32, i32* %arg2
+  %64 = icmp eq i32 %63, 0
+  br i1 %64, label %122, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %66, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %67
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %66, i32 0, i32 1
+  %69 = load i32, i32 addrspace(1)* %68
+  %70 = sub i32 %69, 1
+  store i32 %70, i32* %loc0
+  br label %118
+
+; <label>:71                                      ; preds = %118
+  store i32 0, i32* %loc4
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %73 = load i32, i32* %loc0
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %74
+
+; <label>:74                                      ; preds = %71
+  %75 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 2, i32 %73
+  %76 = load i16, i16 addrspace(1)* %75
+  %77 = zext i16 %76 to i32
+  %78 = trunc i32 %77 to i16
+  store i16 %78, i16* %loc5
+  store i32 0, i32* %loc4
+  br label %97
+
+; <label>:79                                      ; preds = %100
+  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %81 = load i32, i32* %loc4
+  %NullCheck19 = icmp eq %"System.Char[]" addrspace(1)* %80, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
+
+; <label>:82                                      ; preds = %79
+  %83 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 1
+  %84 = load i32, i32 addrspace(1)* %83
+  %85 = zext i32 %84 to i64
+  %86 = zext i32 %81 to i64
+  %BoundsCheck21 = icmp uge i64 %86, %85
+  br i1 %BoundsCheck21, label %ThrowIndexOutOfRange22, label %87
+
+; <label>:87                                      ; preds = %82
+  %88 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 3, i32 %81
+  %89 = load i16, i16 addrspace(1)* %88, align 8
+  %90 = zext i16 %89 to i32
+  %91 = load i16, i16* %loc5
+  %92 = zext i16 %91 to i32
+  %93 = icmp eq i32 %90, %92
+  br i1 %93, label %106, label %94
+
+; <label>:94                                      ; preds = %87
+  %95 = load i32, i32* %loc4
+  %96 = add i32 %95, 1
+  store i32 %96, i32* %loc4
+  br label %97
+
+; <label>:97                                      ; preds = %74, %94
+  %98 = load i32, i32* %loc4
+  %99 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck15 = icmp eq %"System.Char[]" addrspace(1)* %99, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %100
+
+; <label>:100                                     ; preds = %97
+  %101 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %99, i32 0, i32 1
+  %102 = load i32, i32 addrspace(1)* %101
+  %103 = zext i32 %102 to i64
+  %104 = trunc i64 %103 to i32
+  %105 = icmp slt i32 %98, %104
+  br i1 %105, label %79, label %106
+
+; <label>:106                                     ; preds = %87, %100
+  %107 = load i32, i32* %loc4
+  %108 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck17 = icmp eq %"System.Char[]" addrspace(1)* %108, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %109
+
+; <label>:109                                     ; preds = %106
+  %110 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %108, i32 0, i32 1
+  %111 = load i32, i32 addrspace(1)* %110
+  %112 = zext i32 %111 to i64
+  %113 = trunc i64 %112 to i32
+  %114 = icmp eq i32 %107, %113
+  br i1 %114, label %122, label %115
+
+; <label>:115                                     ; preds = %109
+  %116 = load i32, i32* %loc0
+  %117 = sub i32 %116, 1
+  store i32 %117, i32* %loc0
+  br label %118
+
+; <label>:118                                     ; preds = %67, %115
+  %119 = load i32, i32* %loc0
+  %120 = load i32, i32* %loc1
+  %121 = icmp sge i32 %119, %120
+  br i1 %121, label %71, label %122
+
+; <label>:122                                     ; preds = %62, %109, %118
+  %123 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %124 = load i32, i32* %loc1
+  %125 = load i32, i32* %loc0
+  %126 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %123, i32 %124, i32 %125)
+  ret %System.String addrspace(1)* %126
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %97
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange22:                           ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
 Successfully read String.CreateTrimmedString
 
@@ -5439,8 +6893,8 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
@@ -5535,8 +6989,8 @@ entry:
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i64 2872
   %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
   %8 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %7
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %3
   %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
@@ -5553,8 +7007,8 @@ entry:
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 2864
   %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
   %21 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %20
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
-  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %22
 
 ; <label>:22                                      ; preds = %16
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
@@ -5569,7 +7023,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %16
+ThrowNullRef2:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5586,8 +7040,8 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5613,8 +7067,8 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
@@ -5632,8 +7086,8 @@ entry:
 
 ; <label>:12                                      ; preds = %4
   %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
@@ -5644,8 +7098,8 @@ entry:
 
 ; <label>:19                                      ; preds = %14
   %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %19
   %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
@@ -5660,21 +7114,21 @@ entry:
   %31 = zext i16 %30 to i32
   %32 = bitcast i8* %29 to i16*
   %33 = trunc i32 %31 to i16
-  %NullCheck6 = icmp ne i16* %32, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i16* %32, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %21
   store i16 %33, i16* %32, align 8
   %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %36
 
 ; <label>:36                                      ; preds = %34
   %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
   %38 = load i32, i32 addrspace(1)* %37, align 8
   %39 = add i32 %38, 1
-  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %40
 
 ; <label>:40                                      ; preds = %36
   %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
@@ -5683,16 +7137,16 @@ entry:
 
 ; <label>:42                                      ; preds = %14
   %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
-  br i1 %NullCheck12, label %44, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
   %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
   %47 = load i16, i16* %arg1
   %48 = zext i16 %47 to i32
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = trunc i32 %48 to i16
@@ -5703,31 +7157,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %19
+ThrowNullRef4:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %21
+ThrowNullRef6:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %36
+ThrowNullRef10:                                   ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %42
+ThrowNullRef12:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %44
+ThrowNullRef14:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5740,8 +7194,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -5752,8 +7206,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
@@ -5762,14 +7216,14 @@ entry:
 
 ; <label>:11                                      ; preds = %1
   %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
@@ -5779,15 +7233,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5808,8 +7262,8 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5822,8 +7276,8 @@ entry:
 
 ; <label>:8                                       ; preds = %3
   %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
@@ -5842,15 +7296,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
-  br i1 %NullCheck4, label %22, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
   %24 = load i16*, i16* addrspace(1)* %23, align 8
   %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %25, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
@@ -5859,8 +7313,8 @@ entry:
   store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
@@ -5874,8 +7328,8 @@ entry:
 
 ; <label>:37                                      ; preds = %65
   %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %37
   %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
@@ -5886,16 +7340,16 @@ entry:
   %45 = bitcast i16* %41 to i8*
   %46 = getelementptr inbounds i8, i8* %45, i64 %44
   %47 = bitcast i8* %46 to i16*
-  %NullCheck14 = icmp ne i16* %47, null
-  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %47, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %48
 
 ; <label>:48                                      ; preds = %39
   %49 = load i16, i16* %47, align 8
   %50 = zext i16 %49 to i32
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %52 = load i32, i32* %loc1
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %53
 
 ; <label>:53                                      ; preds = %48
   %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
@@ -5916,8 +7370,8 @@ entry:
 ; <label>:62                                      ; preds = %36, %59
   %63 = load i32, i32* %loc1
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck10, label %65, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %65
 
 ; <label>:65                                      ; preds = %62
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
@@ -5936,15 +7390,15 @@ entry:
 
 ; <label>:74                                      ; preds = %70
   %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
-  br i1 %NullCheck18, label %76, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %76
 
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
   %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
-  br i1 %NullCheck20, label %80, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
   %81 = load i64, i64 addrspace(1)* %79
@@ -5958,8 +7412,8 @@ entry:
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
   %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
-  br i1 %NullCheck22, label %92, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.String addrspace(1)* %90, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %92
 
 ; <label>:92                                      ; preds = %80
   %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
@@ -5969,15 +7423,15 @@ entry:
 
 ; <label>:96                                      ; preds = %70
   %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
-  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %98
 
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
   %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
-  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
   %103 = load i64, i64 addrspace(1)* %101
@@ -5991,8 +7445,8 @@ entry:
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
   %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
-  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.String addrspace(1)* %112, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %114
 
 ; <label>:114                                     ; preds = %102
   %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
@@ -6004,59 +7458,59 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %20
+ThrowNullRef4:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %22
+ThrowNullRef6:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %26
+ThrowNullRef8:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %62
+ThrowNullRef10:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %48
+ThrowNullRef16:                                   ; preds = %48
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %74
+ThrowNullRef18:                                   ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %76
+ThrowNullRef20:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %80
+ThrowNullRef22:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %96
+ThrowNullRef24:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %98
+ThrowNullRef26:                                   ; preds = %98
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %102
+ThrowNullRef28:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6069,15 +7523,15 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
   %3 = load i16*, i16* addrspace(1)* %2, align 8
   %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
@@ -6087,8 +7541,8 @@ entry:
   %10 = bitcast i16* %3 to i8*
   %11 = getelementptr inbounds i8, i8* %10, i64 %9
   %12 = bitcast i8* %11 to i16*
-  %NullCheck4 = icmp ne i16* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %5
   store i16 0, i16* %12, align 8
@@ -6098,11 +7552,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6119,8 +7573,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -6131,8 +7585,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
@@ -6144,15 +7598,15 @@ entry:
 
 ; <label>:14                                      ; preds = %1
   %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
   %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
   %21 = load i64, i64 addrspace(1)* %19
@@ -6171,15 +7625,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %14
+ThrowNullRef4:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %16
+ThrowNullRef6:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6302,14 +7756,6 @@ entry:
   ret %System.String addrspace(1)* %57
 }
 
-INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
-Successfully read RuntimeHelpers.get_OffsetToStringData
-
-define i32 @RuntimeHelpers.get_OffsetToStringData() {
-entry:
-  ret i32 12
-}
-
 INFO:  jitting method String::Equals using LLILCJit
 Successfully read String.Equals
 
@@ -6381,8 +7827,8 @@ entry:
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
-  br i1 %NullCheck24, label %29, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
   %30 = load i64, i64 addrspace(1)* %28
@@ -6397,8 +7843,8 @@ entry:
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
-  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
   %43 = load i64, i64 addrspace(1)* %41
@@ -6418,8 +7864,8 @@ entry:
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
   %59 = load i64, i64 addrspace(1)* %57
@@ -6434,8 +7880,8 @@ entry:
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck22, label %71, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
   %72 = load i64, i64 addrspace(1)* %70
@@ -6455,8 +7901,8 @@ entry:
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
-  br i1 %NullCheck16, label %87, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = load i64, i64 addrspace(1)* %86
@@ -6471,8 +7917,8 @@ entry:
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck18, label %100, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
   %101 = load i64, i64 addrspace(1)* %99
@@ -6492,8 +7938,8 @@ entry:
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
-  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
   %117 = load i64, i64 addrspace(1)* %115
@@ -6508,8 +7954,8 @@ entry:
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
-  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
   %130 = load i64, i64 addrspace(1)* %128
@@ -6528,15 +7974,15 @@ entry:
 
 ; <label>:142                                     ; preds = %22
   %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
-  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %143, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %144
 
 ; <label>:144                                     ; preds = %142
   %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
   %146 = load i32, i32 addrspace(1)* %145
   %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
-  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %147, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %148
 
 ; <label>:148                                     ; preds = %144
   %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
@@ -6557,15 +8003,15 @@ entry:
 
 ; <label>:159                                     ; preds = %22
   %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
-  br i1 %NullCheck, label %161, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %ThrowNullRef, label %161
 
 ; <label>:161                                     ; preds = %159
   %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
   %163 = load i32, i32 addrspace(1)* %162
   %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
-  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %164, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %165
 
 ; <label>:165                                     ; preds = %161
   %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
@@ -6578,8 +8024,8 @@ entry:
 
 ; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
-  br i1 %NullCheck4, label %172, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %171, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %172
 
 ; <label>:172                                     ; preds = %170
   %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
@@ -6589,8 +8035,8 @@ entry:
 
 ; <label>:176                                     ; preds = %172
   %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
-  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %177, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %178
 
 ; <label>:178                                     ; preds = %176
   %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
@@ -6629,55 +8075,55 @@ ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %161
+ThrowNullRef2:                                    ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %170
+ThrowNullRef4:                                    ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %176
+ThrowNullRef6:                                    ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %142
+ThrowNullRef8:                                    ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %144
+ThrowNullRef10:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %113
+ThrowNullRef12:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %116
+ThrowNullRef14:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %84
+ThrowNullRef16:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %87
+ThrowNullRef18:                                   ; preds = %87
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %55
+ThrowNullRef20:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %58
+ThrowNullRef22:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %26
+ThrowNullRef24:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %29
+ThrowNullRef26:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,8 +8161,8 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck, label %14, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %ThrowNullRef, label %14
 
 ; <label>:14                                      ; preds = %8
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
@@ -6760,8 +8206,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
@@ -6770,14 +8216,14 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32, i32* %loc0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %10
   %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
   %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
@@ -6790,15 +8236,15 @@ entry:
 ; <label>:25                                      ; preds = %19
   %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
-  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
   %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
@@ -6807,8 +8253,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %37 = load i32, i32* %loc0
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %38, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %38
 
 ; <label>:38                                      ; preds = %32
   %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
@@ -6817,14 +8263,14 @@ entry:
 
 ; <label>:40                                      ; preds = %19
   %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %40
   %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
   %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
-  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
-  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
@@ -6832,8 +8278,8 @@ entry:
   %48 = zext i32 %47 to i64
   %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
-  br i1 %NullCheck16, label %51, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %51
 
 ; <label>:51                                      ; preds = %45
   %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
@@ -6847,15 +8293,15 @@ entry:
 ; <label>:57                                      ; preds = %51
   %58 = load i16*, i16** %arg1
   %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
-  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %60
 
 ; <label>:60                                      ; preds = %57
   %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
   %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
-  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %64
 
 ; <label>:64                                      ; preds = %60
   %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
@@ -6864,22 +8310,22 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
   %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
-  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %70
 
 ; <label>:70                                      ; preds = %64
   %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
   %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
-  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
-  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
   %75 = load i32, i32 addrspace(1)* %74
   %76 = zext i32 %75 to i64
   %77 = trunc i64 %76 to i32
-  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
-  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %78
 
 ; <label>:78                                      ; preds = %73
   %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
@@ -6901,8 +8347,8 @@ entry:
   %90 = bitcast i16* %86 to i8*
   %91 = getelementptr inbounds i8, i8* %90, i64 %89
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %93
 
 ; <label>:93                                      ; preds = %80
   %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
@@ -6912,8 +8358,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %99 = load i32, i32* %loc2
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %100
 
 ; <label>:100                                     ; preds = %93
   %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
@@ -6928,63 +8374,63 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %25
+ThrowNullRef6:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %32
+ThrowNullRef10:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %40
+ThrowNullRef12:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %45
+ThrowNullRef16:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %57
+ThrowNullRef18:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %60
+ThrowNullRef20:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %64
+ThrowNullRef22:                                   ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %70
+ThrowNullRef24:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %73
+ThrowNullRef26:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %80
+ThrowNullRef28:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %93
+ThrowNullRef30:                                   ; preds = %93
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7004,8 +8450,8 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
@@ -7033,43 +8479,43 @@ entry:
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %14
   %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
   %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   %28 = load i32, i32 addrspace(1)* %27, align 8
   %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
-  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %30
 
 ; <label>:30                                      ; preds = %26
   %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
   %32 = load i32, i32 addrspace(1)* %31, align 8
   %33 = add i32 %28, %32
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %34
 
 ; <label>:34                                      ; preds = %30
   %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   store i32 %33, i32 addrspace(1)* %35
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
   store i32 0, i32 addrspace(1)* %38
   %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %40
 
 ; <label>:40                                      ; preds = %37
   %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
@@ -7082,8 +8528,8 @@ entry:
 
 ; <label>:47                                      ; preds = %40
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
@@ -7098,8 +8544,8 @@ entry:
   %54 = load i32, i32* %loc0
   %55 = sext i32 %54 to i64
   %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
-  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %57
 
 ; <label>:57                                      ; preds = %52
   %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
@@ -7110,68 +8556,35 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %14
+ThrowNullRef2:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %23
+ThrowNullRef4:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %26
+ThrowNullRef6:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %30
+ThrowNullRef8:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %34
+ThrowNullRef10:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %47
+ThrowNullRef14:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %52
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-}
-
-INFO:  jitting method StringBuilder::get_Length using LLILCJit
-Successfully read StringBuilder.get_Length
-
-define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.StringBuilder addrspace(1)*
-  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
-  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
-
-; <label>:1                                       ; preds = %entry
-  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %3 = load i32, i32 addrspace(1)* %2, align 8
-  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
-
-; <label>:5                                       ; preds = %1
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = add i32 %3, %7
-  ret i32 %8
-
-ThrowNullRef:                                     ; preds = %entry
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef16:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7213,70 +8626,70 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
   %6 = load i32, i32 addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
   store i32 %6, i32 addrspace(1)* %8
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
   %13 = load i32, i32 addrspace(1)* %12, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
   store i32 %13, i32 addrspace(1)* %15
   %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
-  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %18
 
 ; <label>:18                                      ; preds = %14
   %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
   %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
   %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
   %34 = load i32, i32 addrspace(1)* %33, align 8
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
-  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
@@ -7287,39 +8700,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %28
+ThrowNullRef16:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %32
+ThrowNullRef18:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7455,13 +8868,13 @@ entry:
 ; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
@@ -7477,16 +8890,16 @@ entry:
 
 ; <label>:18                                      ; preds = %15
   %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
   store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
   %22 = load i32, i32* %loc0
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %24
 
 ; <label>:24                                      ; preds = %20
   %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
@@ -7498,13 +8911,13 @@ entry:
 ; <label>:28                                      ; preds = %15, %24
   %29 = load i32, i32* %arg1
   %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %31
   %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
@@ -7517,20 +8930,20 @@ entry:
   %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
-  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
   %46 = load i32, i32 addrspace(1)* %45, align 8
   %47 = sub i32 %40, %46
-  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
-  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i32 addrspace(1)* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %48
 
 ; <label>:48                                      ; preds = %44
   store i32 %47, i32 addrspace(1)* %39, align 8
@@ -7538,21 +8951,21 @@ entry:
 
 ; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
-  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %51
 
 ; <label>:51                                      ; preds = %49
   %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %53
 
 ; <label>:53                                      ; preds = %51
   %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
   %55 = load i32, i32 addrspace(1)* %54, align 8
   %56 = load i32, i32* %arg2
   %57 = sub i32 %55, %56
-  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %58
 
 ; <label>:58                                      ; preds = %53
   %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
@@ -7562,13 +8975,13 @@ entry:
 ; <label>:60                                      ; preds = %33, %58
   %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
   %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
-  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %63
 
 ; <label>:63                                      ; preds = %60
   %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
-  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
-  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
@@ -7578,15 +8991,15 @@ entry:
 
 ; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
-  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i32 addrspace(1)* %69, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %70
 
 ; <label>:70                                      ; preds = %68
   %71 = load i32, i32 addrspace(1)* %69, align 8
   store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
-  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
@@ -7596,8 +9009,8 @@ entry:
   store i32 %77, i32* %loc4
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
-  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %80
 
 ; <label>:80                                      ; preds = %73
   %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
@@ -7607,71 +9020,71 @@ entry:
 ; <label>:83                                      ; preds = %80
   store i32 0, i32* %loc3
   %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
-  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
-  br i1 %NullCheck26, label %88, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i32 addrspace(1)* %87, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %88
 
 ; <label>:88                                      ; preds = %85
   %89 = load i32, i32 addrspace(1)* %87, align 8
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
-  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %90
 
 ; <label>:90                                      ; preds = %88
   %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
   store i32 %89, i32 addrspace(1)* %91
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
-  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
-  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %96
 
 ; <label>:96                                      ; preds = %94
   %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
-  br i1 %NullCheck34, label %100, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %100
 
 ; <label>:100                                     ; preds = %96
   %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
-  br i1 %NullCheck36, label %102, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %102
 
 ; <label>:102                                     ; preds = %100
   %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
   %104 = load i32, i32 addrspace(1)* %103, align 8
   %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
-  br i1 %NullCheck38, label %106, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %106
 
 ; <label>:106                                     ; preds = %102
   %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
-  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
-  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %108
 
 ; <label>:108                                     ; preds = %106
   %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
   %110 = load i32, i32 addrspace(1)* %109, align 8
   %111 = add i32 %104, %110
-  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %112
 
 ; <label>:112                                     ; preds = %108
   %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
   store i32 %111, i32 addrspace(1)* %113
   %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
-  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i32 addrspace(1)* %114, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %115
 
 ; <label>:115                                     ; preds = %112
   %116 = load i32, i32 addrspace(1)* %114, align 8
@@ -7681,19 +9094,19 @@ entry:
 ; <label>:118                                     ; preds = %115
   %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
-  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %121
 
 ; <label>:121                                     ; preds = %118
   %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
-  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
-  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %123
 
 ; <label>:123                                     ; preds = %121
   %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
   %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
-  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
-  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %126
 
 ; <label>:126                                     ; preds = %123
   %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
@@ -7705,8 +9118,8 @@ entry:
 
 ; <label>:130                                     ; preds = %80, %115, %126
   %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %132
 
 ; <label>:132                                     ; preds = %130
   %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7715,8 +9128,8 @@ entry:
   %136 = load i32, i32* %loc3
   %137 = sub i32 %135, %136
   %138 = sub i32 %134, %137
-  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %139
 
 ; <label>:139                                     ; preds = %132
   %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7728,16 +9141,16 @@ entry:
 
 ; <label>:144                                     ; preds = %139
   %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
-  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %146
 
 ; <label>:146                                     ; preds = %144
   %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
   %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
   %149 = load i32, i32* %loc2
   %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
-  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %151
 
 ; <label>:151                                     ; preds = %146
   %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
@@ -7754,145 +9167,249 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %18
+ThrowNullRef4:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %31
+ThrowNullRef10:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %44
+ThrowNullRef16:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %68
+ThrowNullRef18:                                   ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %70
+ThrowNullRef20:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %73
+ThrowNullRef22:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %83
+ThrowNullRef24:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %85
+ThrowNullRef26:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %88
+ThrowNullRef28:                                   ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %90
+ThrowNullRef30:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %94
+ThrowNullRef32:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %96
+ThrowNullRef34:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %100
+ThrowNullRef36:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %102
+ThrowNullRef38:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %106
+ThrowNullRef40:                                   ; preds = %106
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %108
+ThrowNullRef42:                                   ; preds = %108
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %112
+ThrowNullRef44:                                   ; preds = %112
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %118
+ThrowNullRef46:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %121
+ThrowNullRef48:                                   ; preds = %121
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %123
+ThrowNullRef50:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %130
+ThrowNullRef52:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %132
+ThrowNullRef54:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %144
+ThrowNullRef56:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %146
+ThrowNullRef58:                                   ; preds = %146
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %60
+ThrowNullRef60:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %63
+ThrowNullRef62:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %49
+ThrowNullRef64:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %51
+ThrowNullRef66:                                   ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %53
+ThrowNullRef68:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(%"System.Char[]" addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %arg0 = alloca %"System.Char[]" addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store %"System.Char[]" addrspace(1)* %param0, %"System.Char[]" addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load i32, i32* %arg4
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %43, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %38, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg1
+  %13 = load i32, i32* %arg4
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %38, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %24 = load i32, i32* %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %35 = load i32, i32* %arg3
+  %36 = load i32, i32* %arg4
+  %37 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %37, %"System.Char[]" addrspace(1)* %34, i32 %35, i32 %36)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:38                                      ; preds = %5, %16
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Successfully read Buffer._Memmove
 
@@ -7914,7 +9431,7 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[loadElem]
+Failed to read AppDomain.SetDataHelper[storeElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -7923,8 +9440,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
@@ -7934,8 +9451,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
@@ -7947,15 +9464,15 @@ entry:
   %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
   %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
@@ -7966,15 +9483,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7992,7 +9509,79 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
-Failed to read Dictionary`2.TryGetValue[loadElemA]
+Successfully read Dictionary`2.TryGetValue
+
+define i8 @"Dictionary`2.TryGetValue"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)* addrspace(1)* %param2) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  %arg2 = alloca %System.__Canon addrspace(1)* addrspace(1)*
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  store %System.__Canon addrspace(1)* addrspace(1)* %param2, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  store i32 %2, i32* %loc0
+  %3 = load i32, i32* %loc0
+  %4 = icmp slt i32 %3, 0
+  br i1 %4, label %22, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 2
+  %10 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %9, align 8
+  %11 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = zext i32 %11 to i64
+  %BoundsCheck = icmp uge i64 %16, %15
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 3, i32 %11
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %20, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %6, %System.__Canon addrspace(1)* %21)
+  ret i8 1
+
+; <label>:22                                      ; preds = %entry
+  %23 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %23, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -8058,8 +9647,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
@@ -8091,8 +9680,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
@@ -8171,15 +9760,15 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck, label %19, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %ThrowNullRef, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
   %21 = load i32, i32 addrspace(1)* %20
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
@@ -8202,7 +9791,7 @@ ThrowNullRef:                                     ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %19
+ThrowNullRef2:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8248,8 +9837,8 @@ entry:
   %0 = alloca %System.AppDomainHandle
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %1 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %1, i32 0, i32 15
@@ -8269,8 +9858,8 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
@@ -8286,7 +9875,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -8299,8 +9888,8 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -8327,8 +9916,8 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
@@ -8352,8 +9941,8 @@ entry:
   %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
   store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
@@ -8363,8 +9952,8 @@ entry:
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
@@ -8374,8 +9963,8 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %9
   %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
@@ -8384,8 +9973,8 @@ entry:
 
 ; <label>:18                                      ; preds = %3, %16
   %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
@@ -8397,15 +9986,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %18
+ThrowNullRef6:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8418,8 +10007,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
@@ -8453,15 +10042,15 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
@@ -8473,7 +10062,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8481,7 +10070,7 @@ ThrowNullRef1:                                    ; preds = %1
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
 Failed to read Dictionary`2.System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
@@ -8506,8 +10095,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
@@ -8524,8 +10113,8 @@ entry:
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -8544,7 +10133,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8577,8 +10166,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = load i64, i64* %arg2
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = trunc i32 %3 to i8
@@ -8634,46 +10223,46 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
   %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
-  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
-  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
-  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
@@ -8684,27 +10273,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %20
+ThrowNullRef12:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8717,8 +10306,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -8756,22 +10345,22 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
   %9 = load i64, i64 addrspace(1)* %8, align 8
   %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
   %13 = load i64, i64 addrspace(1)* %12, align 8
   %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %11
   %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
@@ -8788,11 +10377,11 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8882,8 +10471,8 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
@@ -8900,8 +10489,8 @@ entry:
 ; <label>:8                                       ; preds = %1
   %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
   %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
@@ -8911,15 +10500,15 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
   %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
   %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
-  br i1 %NullCheck6, label %21, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
@@ -8946,15 +10535,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8992,15 +10581,15 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
   store i8 %3, i8 addrspace(1)* %5
   %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
@@ -9011,7 +10600,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9027,8 +10616,8 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -9041,8 +10630,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
@@ -9058,7 +10647,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9080,8 +10669,8 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
@@ -9096,8 +10685,8 @@ entry:
 ; <label>:12                                      ; preds = %6
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
@@ -9112,8 +10701,8 @@ entry:
 ; <label>:21                                      ; preds = %15
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
@@ -9128,8 +10717,8 @@ entry:
 ; <label>:30                                      ; preds = %24
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %31, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
@@ -9144,8 +10733,8 @@ entry:
 ; <label>:39                                      ; preds = %33
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
-  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %40, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %42
 
 ; <label>:42                                      ; preds = %39
   %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
@@ -9164,19 +10753,19 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %21
+ThrowNullRef4:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %30
+ThrowNullRef6:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %39
+ThrowNullRef8:                                    ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9243,8 +10832,8 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
@@ -9264,57 +10853,57 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
   store i8 0, i8 addrspace(1)* %2
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
   store i8 0, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
   store i8 0, i8 addrspace(1)* %17
   %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
   store i8 0, i8 addrspace(1)* %20
   %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
-  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
@@ -9325,31 +10914,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %19
+ThrowNullRef14:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9367,8 +10956,8 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
@@ -9380,8 +10969,8 @@ entry:
 
 ; <label>:9                                       ; preds = %4
   %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %9
   %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
@@ -9395,7 +10984,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef2:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9420,8 +11009,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
@@ -9512,8 +11101,8 @@ entry:
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
@@ -9524,8 +11113,8 @@ entry:
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = load i64, i64 addrspace(1)* %12
@@ -9537,8 +11126,8 @@ entry:
   %20 = load i64, i64* %19
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
-  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %13
   %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
@@ -9555,8 +11144,8 @@ entry:
 ; <label>:30                                      ; preds = %25
   %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %32 = load i32, i32* %arg2
-  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
-  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
@@ -9570,15 +11159,15 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %30
+ThrowNullRef2:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9622,87 +11211,87 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
   %10 = load i8, i8 addrspace(1)* %9, align 8
   %11 = zext i8 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %8
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
   store i8 %12, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
   %19 = load i8, i8 addrspace(1)* %18, align 8
   %20 = zext i8 %19 to i32
   %21 = trunc i32 %20 to i8
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
   store i8 %21, i8 addrspace(1)* %23
   %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
   %28 = load i8, i8 addrspace(1)* %27, align 8
   %29 = zext i8 %28 to i32
   %30 = trunc i32 %29 to i8
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
-  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %31
 
 ; <label>:31                                      ; preds = %26
   %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
   store i8 %30, i8 addrspace(1)* %32
   %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
-  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
-  br i1 %NullCheck14, label %40, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %40
 
 ; <label>:40                                      ; preds = %35
   %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
   store i8 %39, i8 addrspace(1)* %41
   %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
-  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %44
 
 ; <label>:44                                      ; preds = %40
   %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
   %46 = load i8, i8 addrspace(1)* %45, align 8
   %47 = zext i8 %46 to i32
   %48 = trunc i32 %47 to i8
-  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
   store i8 %48, i8 addrspace(1)* %50
   %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
-  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
@@ -9713,29 +11302,29 @@ entry:
 ; <label>:56                                      ; preds = %52
   %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
-  br i1 %NullCheck22, label %59, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
   %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
   %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
-  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
-  br i1 %NullCheck24, label %63, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
   %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
-  br i1 %NullCheck26, label %66, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
   %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
-  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
-  br i1 %NullCheck28, label %69, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %69
 
 ; <label>:69                                      ; preds = %66
   %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
@@ -9744,15 +11333,15 @@ entry:
 
 ; <label>:71                                      ; preds = %105
   %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
-  br i1 %NullCheck34, label %73, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %73
 
 ; <label>:73                                      ; preds = %71
   %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
   %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
   %76 = load i32, i32* %loc0
-  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
-  br i1 %NullCheck36, label %77, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
@@ -9766,8 +11355,8 @@ entry:
 
 ; <label>:83                                      ; preds = %77
   %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
-  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
@@ -9775,14 +11364,14 @@ entry:
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
   %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
-  br i1 %NullCheck40, label %91, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
 ; <label>:91                                      ; preds = %85
   %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
   %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
-  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck42, label %94, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %94
 
 ; <label>:94                                      ; preds = %91
   %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
@@ -9798,14 +11387,14 @@ entry:
 ; <label>:99                                      ; preds = %69, %96
   %100 = load i32, i32* %loc0
   %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
-  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %102
 
 ; <label>:102                                     ; preds = %99
   %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
   %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
-  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
-  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
@@ -9819,87 +11408,87 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %26
+ThrowNullRef10:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %31
+ThrowNullRef12:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %35
+ThrowNullRef14:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %40
+ThrowNullRef16:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %56
+ThrowNullRef22:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %59
+ThrowNullRef24:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %63
+ThrowNullRef26:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %66
+ThrowNullRef28:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %102
+ThrowNullRef32:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %71
+ThrowNullRef34:                                   ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %73
+ThrowNullRef36:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %83
+ThrowNullRef38:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %85
+ThrowNullRef40:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %91
+ThrowNullRef42:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9943,15 +11532,15 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
   %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
@@ -9961,28 +11550,28 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
   %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %12
   %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
   %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
   %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
-  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
@@ -9993,23 +11582,23 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %12
+ThrowNullRef6:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10031,15 +11620,15 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
   %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = load i64, i64 addrspace(1)* %7
@@ -10077,13 +11666,13 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[loadElem]
+Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -10111,8 +11700,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1

--- a/test/BaseLine/JIT/CodeGenBringUpTests/mul4.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/mul4.error.txt
@@ -25,8 +25,8 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
@@ -40,8 +40,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
   %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
@@ -75,7 +75,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -90,8 +90,8 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %NullCheck = icmp ne i8 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = load i8, i8 addrspace(1)* %0, align 8
@@ -125,8 +125,8 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
@@ -159,8 +159,8 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -184,8 +184,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
   store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
@@ -195,8 +195,8 @@ entry:
 ; <label>:4                                       ; preds = %1
   %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
   %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
@@ -206,8 +206,8 @@ entry:
   %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
@@ -221,14 +221,14 @@ entry:
 
 ; <label>:17                                      ; preds = %14
   %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
   %21 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
@@ -238,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -249,8 +249,8 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
@@ -261,27 +261,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %30
+ThrowNullRef10:                                   ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -301,7 +301,89 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
-Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
+Successfully read AppDomainSetup.GetUnsecureApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.GetUnsecureApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %NullCheck = icmp eq %"System.String[]" addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %BoundsCheck = icmp uge i64 0, %5
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %6
+
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 3, i32 0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
+  ret %System.String addrspace(1)* %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_Value using LLILCJit
+Successfully read AppDomainSetup.get_Value
+
+define %"System.String[]" addrspace(1)* @AppDomainSetup.get_Value(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.String[]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 18)
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.String[]" addrspace(1)* addrspace(1)*, %"System.String[]" addrspace(1)*)*)(%"System.String[]" addrspace(1)* addrspace(1)* %9, %"System.String[]" addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %11, i32 0, i32 1
+  %14 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %13, align 8
+  ret %"System.String[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -319,8 +401,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -368,16 +450,16 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
   %5 = load i32, i32 addrspace(1)* %4
   %6 = sub i32 %5, 1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -389,7 +471,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -421,8 +503,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
@@ -456,8 +538,8 @@ entry:
 ; <label>:27                                      ; preds = %19
   %28 = load i32, i32* %arg1
   %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
-  br i1 %NullCheck2, label %30, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %29, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %30
 
 ; <label>:30                                      ; preds = %27
   %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
@@ -493,8 +575,8 @@ entry:
 ; <label>:49                                      ; preds = %46
   %50 = load i32, i32* %arg2
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck4, label %52, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
@@ -517,11 +599,11 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %27
+ThrowNullRef2:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %49
+ThrowNullRef4:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -544,16 +626,16 @@ entry:
   %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %0)
   store %System.String addrspace(1)* %1, %System.String addrspace(1)** %loc0
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 2
   %5 = bitcast [0 x i16] addrspace(1)* %4 to i16 addrspace(1)*
   store i16 addrspace(1)* %5, i16 addrspace(1)** %loc1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %3
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2
@@ -580,7 +662,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -691,15 +773,15 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %NullCheck132 = icmp ne i8* %21, null
-  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+  %NullCheck131 = icmp eq i8* %21, null
+  br i1 %NullCheck131, label %ThrowNullRef132, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = load i8, i8* %21, align 8
   %24 = zext i8 %23 to i32
   %25 = trunc i32 %24 to i8
-  %NullCheck134 = icmp ne i8* %20, null
-  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+  %NullCheck133 = icmp eq i8* %20, null
+  br i1 %NullCheck133, label %ThrowNullRef134, label %26
 
 ; <label>:26                                      ; preds = %22
   store i8 %25, i8* %20, align 8
@@ -709,16 +791,16 @@ entry:
   %28 = load i8*, i8** %arg0
   %29 = load i8*, i8** %arg1
   %30 = bitcast i8* %29 to i16*
-  %NullCheck128 = icmp ne i16* %30, null
-  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+  %NullCheck127 = icmp eq i16* %30, null
+  br i1 %NullCheck127, label %ThrowNullRef128, label %31
 
 ; <label>:31                                      ; preds = %27
   %32 = load i16, i16* %30, align 8
   %33 = sext i16 %32 to i32
   %34 = bitcast i8* %28 to i16*
   %35 = trunc i32 %33 to i16
-  %NullCheck130 = icmp ne i16* %34, null
-  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+  %NullCheck129 = icmp eq i16* %34, null
+  br i1 %NullCheck129, label %ThrowNullRef130, label %36
 
 ; <label>:36                                      ; preds = %31
   store i16 %35, i16* %34, align 8
@@ -728,16 +810,16 @@ entry:
   %38 = load i8*, i8** %arg0
   %39 = load i8*, i8** %arg1
   %40 = bitcast i8* %39 to i16*
-  %NullCheck120 = icmp ne i16* %40, null
-  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+  %NullCheck119 = icmp eq i16* %40, null
+  br i1 %NullCheck119, label %ThrowNullRef120, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i16, i16* %40, align 8
   %43 = sext i16 %42 to i32
   %44 = bitcast i8* %38 to i16*
   %45 = trunc i32 %43 to i16
-  %NullCheck122 = icmp ne i16* %44, null
-  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+  %NullCheck121 = icmp eq i16* %44, null
+  br i1 %NullCheck121, label %ThrowNullRef122, label %46
 
 ; <label>:46                                      ; preds = %41
   store i16 %45, i16* %44, align 8
@@ -745,15 +827,15 @@ entry:
   %48 = getelementptr inbounds i8, i8* %47, i64 2
   %49 = load i8*, i8** %arg1
   %50 = getelementptr inbounds i8, i8* %49, i64 2
-  %NullCheck124 = icmp ne i8* %50, null
-  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+  %NullCheck123 = icmp eq i8* %50, null
+  br i1 %NullCheck123, label %ThrowNullRef124, label %51
 
 ; <label>:51                                      ; preds = %46
   %52 = load i8, i8* %50, align 8
   %53 = zext i8 %52 to i32
   %54 = trunc i32 %53 to i8
-  %NullCheck126 = icmp ne i8* %48, null
-  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+  %NullCheck125 = icmp eq i8* %48, null
+  br i1 %NullCheck125, label %ThrowNullRef126, label %55
 
 ; <label>:55                                      ; preds = %51
   store i8 %54, i8* %48, align 8
@@ -763,14 +845,14 @@ entry:
   %57 = load i8*, i8** %arg0
   %58 = load i8*, i8** %arg1
   %59 = bitcast i8* %58 to i32*
-  %NullCheck116 = icmp ne i32* %59, null
-  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+  %NullCheck115 = icmp eq i32* %59, null
+  br i1 %NullCheck115, label %ThrowNullRef116, label %60
 
 ; <label>:60                                      ; preds = %56
   %61 = load i32, i32* %59, align 8
   %62 = bitcast i8* %57 to i32*
-  %NullCheck118 = icmp ne i32* %62, null
-  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+  %NullCheck117 = icmp eq i32* %62, null
+  br i1 %NullCheck117, label %ThrowNullRef118, label %63
 
 ; <label>:63                                      ; preds = %60
   store i32 %61, i32* %62, align 8
@@ -780,14 +862,14 @@ entry:
   %65 = load i8*, i8** %arg0
   %66 = load i8*, i8** %arg1
   %67 = bitcast i8* %66 to i32*
-  %NullCheck108 = icmp ne i32* %67, null
-  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+  %NullCheck107 = icmp eq i32* %67, null
+  br i1 %NullCheck107, label %ThrowNullRef108, label %68
 
 ; <label>:68                                      ; preds = %64
   %69 = load i32, i32* %67, align 8
   %70 = bitcast i8* %65 to i32*
-  %NullCheck110 = icmp ne i32* %70, null
-  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+  %NullCheck109 = icmp eq i32* %70, null
+  br i1 %NullCheck109, label %ThrowNullRef110, label %71
 
 ; <label>:71                                      ; preds = %68
   store i32 %69, i32* %70, align 8
@@ -795,15 +877,15 @@ entry:
   %73 = getelementptr inbounds i8, i8* %72, i64 4
   %74 = load i8*, i8** %arg1
   %75 = getelementptr inbounds i8, i8* %74, i64 4
-  %NullCheck112 = icmp ne i8* %75, null
-  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+  %NullCheck111 = icmp eq i8* %75, null
+  br i1 %NullCheck111, label %ThrowNullRef112, label %76
 
 ; <label>:76                                      ; preds = %71
   %77 = load i8, i8* %75, align 8
   %78 = zext i8 %77 to i32
   %79 = trunc i32 %78 to i8
-  %NullCheck114 = icmp ne i8* %73, null
-  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+  %NullCheck113 = icmp eq i8* %73, null
+  br i1 %NullCheck113, label %ThrowNullRef114, label %80
 
 ; <label>:80                                      ; preds = %76
   store i8 %79, i8* %73, align 8
@@ -813,14 +895,14 @@ entry:
   %82 = load i8*, i8** %arg0
   %83 = load i8*, i8** %arg1
   %84 = bitcast i8* %83 to i32*
-  %NullCheck100 = icmp ne i32* %84, null
-  br i1 %NullCheck100, label %85, label %ThrowNullRef99
+  %NullCheck99 = icmp eq i32* %84, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %85
 
 ; <label>:85                                      ; preds = %81
   %86 = load i32, i32* %84, align 8
   %87 = bitcast i8* %82 to i32*
-  %NullCheck102 = icmp ne i32* %87, null
-  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+  %NullCheck101 = icmp eq i32* %87, null
+  br i1 %NullCheck101, label %ThrowNullRef102, label %88
 
 ; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
@@ -829,16 +911,16 @@ entry:
   %91 = load i8*, i8** %arg1
   %92 = getelementptr inbounds i8, i8* %91, i64 4
   %93 = bitcast i8* %92 to i16*
-  %NullCheck104 = icmp ne i16* %93, null
-  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+  %NullCheck103 = icmp eq i16* %93, null
+  br i1 %NullCheck103, label %ThrowNullRef104, label %94
 
 ; <label>:94                                      ; preds = %88
   %95 = load i16, i16* %93, align 8
   %96 = sext i16 %95 to i32
   %97 = bitcast i8* %90 to i16*
   %98 = trunc i32 %96 to i16
-  %NullCheck106 = icmp ne i16* %97, null
-  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+  %NullCheck105 = icmp eq i16* %97, null
+  br i1 %NullCheck105, label %ThrowNullRef106, label %99
 
 ; <label>:99                                      ; preds = %94
   store i16 %98, i16* %97, align 8
@@ -848,14 +930,14 @@ entry:
   %101 = load i8*, i8** %arg0
   %102 = load i8*, i8** %arg1
   %103 = bitcast i8* %102 to i32*
-  %NullCheck88 = icmp ne i32* %103, null
-  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+  %NullCheck87 = icmp eq i32* %103, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %104
 
 ; <label>:104                                     ; preds = %100
   %105 = load i32, i32* %103, align 8
   %106 = bitcast i8* %101 to i32*
-  %NullCheck90 = icmp ne i32* %106, null
-  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+  %NullCheck89 = icmp eq i32* %106, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %107
 
 ; <label>:107                                     ; preds = %104
   store i32 %105, i32* %106, align 8
@@ -864,16 +946,16 @@ entry:
   %110 = load i8*, i8** %arg1
   %111 = getelementptr inbounds i8, i8* %110, i64 4
   %112 = bitcast i8* %111 to i16*
-  %NullCheck92 = icmp ne i16* %112, null
-  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+  %NullCheck91 = icmp eq i16* %112, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %113
 
 ; <label>:113                                     ; preds = %107
   %114 = load i16, i16* %112, align 8
   %115 = sext i16 %114 to i32
   %116 = bitcast i8* %109 to i16*
   %117 = trunc i32 %115 to i16
-  %NullCheck94 = icmp ne i16* %116, null
-  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+  %NullCheck93 = icmp eq i16* %116, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %118
 
 ; <label>:118                                     ; preds = %113
   store i16 %117, i16* %116, align 8
@@ -881,15 +963,15 @@ entry:
   %120 = getelementptr inbounds i8, i8* %119, i64 6
   %121 = load i8*, i8** %arg1
   %122 = getelementptr inbounds i8, i8* %121, i64 6
-  %NullCheck96 = icmp ne i8* %122, null
-  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+  %NullCheck95 = icmp eq i8* %122, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %123
 
 ; <label>:123                                     ; preds = %118
   %124 = load i8, i8* %122, align 8
   %125 = zext i8 %124 to i32
   %126 = trunc i32 %125 to i8
-  %NullCheck98 = icmp ne i8* %120, null
-  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+  %NullCheck97 = icmp eq i8* %120, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %127
 
 ; <label>:127                                     ; preds = %123
   store i8 %126, i8* %120, align 8
@@ -899,14 +981,14 @@ entry:
   %129 = load i8*, i8** %arg0
   %130 = load i8*, i8** %arg1
   %131 = bitcast i8* %130 to i64*
-  %NullCheck84 = icmp ne i64* %131, null
-  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+  %NullCheck83 = icmp eq i64* %131, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %132
 
 ; <label>:132                                     ; preds = %128
   %133 = load i64, i64* %131, align 8
   %134 = bitcast i8* %129 to i64*
-  %NullCheck86 = icmp ne i64* %134, null
-  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+  %NullCheck85 = icmp eq i64* %134, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %135
 
 ; <label>:135                                     ; preds = %132
   store i64 %133, i64* %134, align 8
@@ -916,14 +998,14 @@ entry:
   %137 = load i8*, i8** %arg0
   %138 = load i8*, i8** %arg1
   %139 = bitcast i8* %138 to i64*
-  %NullCheck76 = icmp ne i64* %139, null
-  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+  %NullCheck75 = icmp eq i64* %139, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %140
 
 ; <label>:140                                     ; preds = %136
   %141 = load i64, i64* %139, align 8
   %142 = bitcast i8* %137 to i64*
-  %NullCheck78 = icmp ne i64* %142, null
-  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+  %NullCheck77 = icmp eq i64* %142, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %143
 
 ; <label>:143                                     ; preds = %140
   store i64 %141, i64* %142, align 8
@@ -931,15 +1013,15 @@ entry:
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %NullCheck80 = icmp ne i8* %147, null
-  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+  %NullCheck79 = icmp eq i8* %147, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %148
 
 ; <label>:148                                     ; preds = %143
   %149 = load i8, i8* %147, align 8
   %150 = zext i8 %149 to i32
   %151 = trunc i32 %150 to i8
-  %NullCheck82 = icmp ne i8* %145, null
-  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+  %NullCheck81 = icmp eq i8* %145, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %152
 
 ; <label>:152                                     ; preds = %148
   store i8 %151, i8* %145, align 8
@@ -949,14 +1031,14 @@ entry:
   %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
   %156 = bitcast i8* %155 to i64*
-  %NullCheck68 = icmp ne i64* %156, null
-  br i1 %NullCheck68, label %157, label %ThrowNullRef67
+  %NullCheck67 = icmp eq i64* %156, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %157
 
 ; <label>:157                                     ; preds = %153
   %158 = load i64, i64* %156, align 8
   %159 = bitcast i8* %154 to i64*
-  %NullCheck70 = icmp ne i64* %159, null
-  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+  %NullCheck69 = icmp eq i64* %159, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %160
 
 ; <label>:160                                     ; preds = %157
   store i64 %158, i64* %159, align 8
@@ -965,16 +1047,16 @@ entry:
   %163 = load i8*, i8** %arg1
   %164 = getelementptr inbounds i8, i8* %163, i64 8
   %165 = bitcast i8* %164 to i16*
-  %NullCheck72 = icmp ne i16* %165, null
-  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+  %NullCheck71 = icmp eq i16* %165, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %166
 
 ; <label>:166                                     ; preds = %160
   %167 = load i16, i16* %165, align 8
   %168 = sext i16 %167 to i32
   %169 = bitcast i8* %162 to i16*
   %170 = trunc i32 %168 to i16
-  %NullCheck74 = icmp ne i16* %169, null
-  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+  %NullCheck73 = icmp eq i16* %169, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %171
 
 ; <label>:171                                     ; preds = %166
   store i16 %170, i16* %169, align 8
@@ -984,14 +1066,14 @@ entry:
   %173 = load i8*, i8** %arg0
   %174 = load i8*, i8** %arg1
   %175 = bitcast i8* %174 to i64*
-  %NullCheck56 = icmp ne i64* %175, null
-  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+  %NullCheck55 = icmp eq i64* %175, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %176
 
 ; <label>:176                                     ; preds = %172
   %177 = load i64, i64* %175, align 8
   %178 = bitcast i8* %173 to i64*
-  %NullCheck58 = icmp ne i64* %178, null
-  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+  %NullCheck57 = icmp eq i64* %178, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %179
 
 ; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
@@ -1000,16 +1082,16 @@ entry:
   %182 = load i8*, i8** %arg1
   %183 = getelementptr inbounds i8, i8* %182, i64 8
   %184 = bitcast i8* %183 to i16*
-  %NullCheck60 = icmp ne i16* %184, null
-  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+  %NullCheck59 = icmp eq i16* %184, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %185
 
 ; <label>:185                                     ; preds = %179
   %186 = load i16, i16* %184, align 8
   %187 = sext i16 %186 to i32
   %188 = bitcast i8* %181 to i16*
   %189 = trunc i32 %187 to i16
-  %NullCheck62 = icmp ne i16* %188, null
-  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+  %NullCheck61 = icmp eq i16* %188, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %190
 
 ; <label>:190                                     ; preds = %185
   store i16 %189, i16* %188, align 8
@@ -1017,15 +1099,15 @@ entry:
   %192 = getelementptr inbounds i8, i8* %191, i64 10
   %193 = load i8*, i8** %arg1
   %194 = getelementptr inbounds i8, i8* %193, i64 10
-  %NullCheck64 = icmp ne i8* %194, null
-  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+  %NullCheck63 = icmp eq i8* %194, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %195
 
 ; <label>:195                                     ; preds = %190
   %196 = load i8, i8* %194, align 8
   %197 = zext i8 %196 to i32
   %198 = trunc i32 %197 to i8
-  %NullCheck66 = icmp ne i8* %192, null
-  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+  %NullCheck65 = icmp eq i8* %192, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %199
 
 ; <label>:199                                     ; preds = %195
   store i8 %198, i8* %192, align 8
@@ -1035,14 +1117,14 @@ entry:
   %201 = load i8*, i8** %arg0
   %202 = load i8*, i8** %arg1
   %203 = bitcast i8* %202 to i64*
-  %NullCheck48 = icmp ne i64* %203, null
-  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+  %NullCheck47 = icmp eq i64* %203, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %204
 
 ; <label>:204                                     ; preds = %200
   %205 = load i64, i64* %203, align 8
   %206 = bitcast i8* %201 to i64*
-  %NullCheck50 = icmp ne i64* %206, null
-  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+  %NullCheck49 = icmp eq i64* %206, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %207
 
 ; <label>:207                                     ; preds = %204
   store i64 %205, i64* %206, align 8
@@ -1051,14 +1133,14 @@ entry:
   %210 = load i8*, i8** %arg1
   %211 = getelementptr inbounds i8, i8* %210, i64 8
   %212 = bitcast i8* %211 to i32*
-  %NullCheck52 = icmp ne i32* %212, null
-  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+  %NullCheck51 = icmp eq i32* %212, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %213
 
 ; <label>:213                                     ; preds = %207
   %214 = load i32, i32* %212, align 8
   %215 = bitcast i8* %209 to i32*
-  %NullCheck54 = icmp ne i32* %215, null
-  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+  %NullCheck53 = icmp eq i32* %215, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %216
 
 ; <label>:216                                     ; preds = %213
   store i32 %214, i32* %215, align 8
@@ -1068,14 +1150,14 @@ entry:
   %218 = load i8*, i8** %arg0
   %219 = load i8*, i8** %arg1
   %220 = bitcast i8* %219 to i64*
-  %NullCheck36 = icmp ne i64* %220, null
-  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64* %220, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %221
 
 ; <label>:221                                     ; preds = %217
   %222 = load i64, i64* %220, align 8
   %223 = bitcast i8* %218 to i64*
-  %NullCheck38 = icmp ne i64* %223, null
-  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+  %NullCheck37 = icmp eq i64* %223, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %224
 
 ; <label>:224                                     ; preds = %221
   store i64 %222, i64* %223, align 8
@@ -1084,14 +1166,14 @@ entry:
   %227 = load i8*, i8** %arg1
   %228 = getelementptr inbounds i8, i8* %227, i64 8
   %229 = bitcast i8* %228 to i32*
-  %NullCheck40 = icmp ne i32* %229, null
-  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i32* %229, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %230
 
 ; <label>:230                                     ; preds = %224
   %231 = load i32, i32* %229, align 8
   %232 = bitcast i8* %226 to i32*
-  %NullCheck42 = icmp ne i32* %232, null
-  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+  %NullCheck41 = icmp eq i32* %232, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %233
 
 ; <label>:233                                     ; preds = %230
   store i32 %231, i32* %232, align 8
@@ -1099,15 +1181,15 @@ entry:
   %235 = getelementptr inbounds i8, i8* %234, i64 12
   %236 = load i8*, i8** %arg1
   %237 = getelementptr inbounds i8, i8* %236, i64 12
-  %NullCheck44 = icmp ne i8* %237, null
-  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i8* %237, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %238
 
 ; <label>:238                                     ; preds = %233
   %239 = load i8, i8* %237, align 8
   %240 = zext i8 %239 to i32
   %241 = trunc i32 %240 to i8
-  %NullCheck46 = icmp ne i8* %235, null
-  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+  %NullCheck45 = icmp eq i8* %235, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %242
 
 ; <label>:242                                     ; preds = %238
   store i8 %241, i8* %235, align 8
@@ -1117,14 +1199,14 @@ entry:
   %244 = load i8*, i8** %arg0
   %245 = load i8*, i8** %arg1
   %246 = bitcast i8* %245 to i64*
-  %NullCheck24 = icmp ne i64* %246, null
-  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64* %246, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %247
 
 ; <label>:247                                     ; preds = %243
   %248 = load i64, i64* %246, align 8
   %249 = bitcast i8* %244 to i64*
-  %NullCheck26 = icmp ne i64* %249, null
-  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64* %249, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %250
 
 ; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
@@ -1133,14 +1215,14 @@ entry:
   %253 = load i8*, i8** %arg1
   %254 = getelementptr inbounds i8, i8* %253, i64 8
   %255 = bitcast i8* %254 to i32*
-  %NullCheck28 = icmp ne i32* %255, null
-  br i1 %NullCheck28, label %256, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i32* %255, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %256
 
 ; <label>:256                                     ; preds = %250
   %257 = load i32, i32* %255, align 8
   %258 = bitcast i8* %252 to i32*
-  %NullCheck30 = icmp ne i32* %258, null
-  br i1 %NullCheck30, label %259, label %ThrowNullRef29
+  %NullCheck29 = icmp eq i32* %258, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %259
 
 ; <label>:259                                     ; preds = %256
   store i32 %257, i32* %258, align 8
@@ -1149,16 +1231,16 @@ entry:
   %262 = load i8*, i8** %arg1
   %263 = getelementptr inbounds i8, i8* %262, i64 12
   %264 = bitcast i8* %263 to i16*
-  %NullCheck32 = icmp ne i16* %264, null
-  br i1 %NullCheck32, label %265, label %ThrowNullRef31
+  %NullCheck31 = icmp eq i16* %264, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %265
 
 ; <label>:265                                     ; preds = %259
   %266 = load i16, i16* %264, align 8
   %267 = sext i16 %266 to i32
   %268 = bitcast i8* %261 to i16*
   %269 = trunc i32 %267 to i16
-  %NullCheck34 = icmp ne i16* %268, null
-  br i1 %NullCheck34, label %270, label %ThrowNullRef33
+  %NullCheck33 = icmp eq i16* %268, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %270
 
 ; <label>:270                                     ; preds = %265
   store i16 %269, i16* %268, align 8
@@ -1168,14 +1250,14 @@ entry:
   %272 = load i8*, i8** %arg0
   %273 = load i8*, i8** %arg1
   %274 = bitcast i8* %273 to i64*
-  %NullCheck8 = icmp ne i64* %274, null
-  br i1 %NullCheck8, label %275, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64* %274, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %275
 
 ; <label>:275                                     ; preds = %271
   %276 = load i64, i64* %274, align 8
   %277 = bitcast i8* %272 to i64*
-  %NullCheck10 = icmp ne i64* %277, null
-  br i1 %NullCheck10, label %278, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %277, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %278
 
 ; <label>:278                                     ; preds = %275
   store i64 %276, i64* %277, align 8
@@ -1184,14 +1266,14 @@ entry:
   %281 = load i8*, i8** %arg1
   %282 = getelementptr inbounds i8, i8* %281, i64 8
   %283 = bitcast i8* %282 to i32*
-  %NullCheck12 = icmp ne i32* %283, null
-  br i1 %NullCheck12, label %284, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i32* %283, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %284
 
 ; <label>:284                                     ; preds = %278
   %285 = load i32, i32* %283, align 8
   %286 = bitcast i8* %280 to i32*
-  %NullCheck14 = icmp ne i32* %286, null
-  br i1 %NullCheck14, label %287, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i32* %286, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %287
 
 ; <label>:287                                     ; preds = %284
   store i32 %285, i32* %286, align 8
@@ -1200,16 +1282,16 @@ entry:
   %290 = load i8*, i8** %arg1
   %291 = getelementptr inbounds i8, i8* %290, i64 12
   %292 = bitcast i8* %291 to i16*
-  %NullCheck16 = icmp ne i16* %292, null
-  br i1 %NullCheck16, label %293, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i16* %292, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %293
 
 ; <label>:293                                     ; preds = %287
   %294 = load i16, i16* %292, align 8
   %295 = sext i16 %294 to i32
   %296 = bitcast i8* %289 to i16*
   %297 = trunc i32 %295 to i16
-  %NullCheck18 = icmp ne i16* %296, null
-  br i1 %NullCheck18, label %298, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i16* %296, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %298
 
 ; <label>:298                                     ; preds = %293
   store i16 %297, i16* %296, align 8
@@ -1217,15 +1299,15 @@ entry:
   %300 = getelementptr inbounds i8, i8* %299, i64 14
   %301 = load i8*, i8** %arg1
   %302 = getelementptr inbounds i8, i8* %301, i64 14
-  %NullCheck20 = icmp ne i8* %302, null
-  br i1 %NullCheck20, label %303, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i8* %302, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %303
 
 ; <label>:303                                     ; preds = %298
   %304 = load i8, i8* %302, align 8
   %305 = zext i8 %304 to i32
   %306 = trunc i32 %305 to i8
-  %NullCheck22 = icmp ne i8* %300, null
-  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i8* %300, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %307
 
 ; <label>:307                                     ; preds = %303
   store i8 %306, i8* %300, align 8
@@ -1235,14 +1317,14 @@ entry:
   %309 = load i8*, i8** %arg0
   %310 = load i8*, i8** %arg1
   %311 = bitcast i8* %310 to i64*
-  %NullCheck = icmp ne i64* %311, null
-  br i1 %NullCheck, label %312, label %ThrowNullRef
+  %NullCheck = icmp eq i64* %311, null
+  br i1 %NullCheck, label %ThrowNullRef, label %312
 
 ; <label>:312                                     ; preds = %308
   %313 = load i64, i64* %311, align 8
   %314 = bitcast i8* %309 to i64*
-  %NullCheck2 = icmp ne i64* %314, null
-  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64* %314, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %315
 
 ; <label>:315                                     ; preds = %312
   store i64 %313, i64* %314, align 8
@@ -1251,14 +1333,14 @@ entry:
   %318 = load i8*, i8** %arg1
   %319 = getelementptr inbounds i8, i8* %318, i64 8
   %320 = bitcast i8* %319 to i64*
-  %NullCheck4 = icmp ne i64* %320, null
-  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64* %320, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %321
 
 ; <label>:321                                     ; preds = %315
   %322 = load i64, i64* %320, align 8
   %323 = bitcast i8* %317 to i64*
-  %NullCheck6 = icmp ne i64* %323, null
-  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64* %323, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %324
 
 ; <label>:324                                     ; preds = %321
   store i64 %322, i64* %323, align 8
@@ -1286,15 +1368,15 @@ entry:
 ; <label>:338                                     ; preds = %333
   %339 = load i8*, i8** %arg0
   %340 = load i8*, i8** %arg1
-  %NullCheck136 = icmp ne i8* %340, null
-  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+  %NullCheck135 = icmp eq i8* %340, null
+  br i1 %NullCheck135, label %ThrowNullRef136, label %341
 
 ; <label>:341                                     ; preds = %338
   %342 = load i8, i8* %340, align 8
   %343 = zext i8 %342 to i32
   %344 = trunc i32 %343 to i8
-  %NullCheck138 = icmp ne i8* %339, null
-  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+  %NullCheck137 = icmp eq i8* %339, null
+  br i1 %NullCheck137, label %ThrowNullRef138, label %345
 
 ; <label>:345                                     ; preds = %341
   store i8 %344, i8* %339, align 8
@@ -1317,16 +1399,16 @@ entry:
   %357 = load i8*, i8** %arg0
   %358 = load i8*, i8** %arg1
   %359 = bitcast i8* %358 to i16*
-  %NullCheck140 = icmp ne i16* %359, null
-  br i1 %NullCheck140, label %360, label %ThrowNullRef139
+  %NullCheck139 = icmp eq i16* %359, null
+  br i1 %NullCheck139, label %ThrowNullRef140, label %360
 
 ; <label>:360                                     ; preds = %356
   %361 = load i16, i16* %359, align 8
   %362 = sext i16 %361 to i32
   %363 = bitcast i8* %357 to i16*
   %364 = trunc i32 %362 to i16
-  %NullCheck142 = icmp ne i16* %363, null
-  br i1 %NullCheck142, label %365, label %ThrowNullRef141
+  %NullCheck141 = icmp eq i16* %363, null
+  br i1 %NullCheck141, label %ThrowNullRef142, label %365
 
 ; <label>:365                                     ; preds = %360
   store i16 %364, i16* %363, align 8
@@ -1352,14 +1434,14 @@ entry:
   %378 = load i8*, i8** %arg0
   %379 = load i8*, i8** %arg1
   %380 = bitcast i8* %379 to i32*
-  %NullCheck144 = icmp ne i32* %380, null
-  br i1 %NullCheck144, label %381, label %ThrowNullRef143
+  %NullCheck143 = icmp eq i32* %380, null
+  br i1 %NullCheck143, label %ThrowNullRef144, label %381
 
 ; <label>:381                                     ; preds = %377
   %382 = load i32, i32* %380, align 8
   %383 = bitcast i8* %378 to i32*
-  %NullCheck146 = icmp ne i32* %383, null
-  br i1 %NullCheck146, label %384, label %ThrowNullRef145
+  %NullCheck145 = icmp eq i32* %383, null
+  br i1 %NullCheck145, label %ThrowNullRef146, label %384
 
 ; <label>:384                                     ; preds = %381
   store i32 %382, i32* %383, align 8
@@ -1384,14 +1466,14 @@ entry:
   %395 = load i8*, i8** %arg0
   %396 = load i8*, i8** %arg1
   %397 = bitcast i8* %396 to i64*
-  %NullCheck164 = icmp ne i64* %397, null
-  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+  %NullCheck163 = icmp eq i64* %397, null
+  br i1 %NullCheck163, label %ThrowNullRef164, label %398
 
 ; <label>:398                                     ; preds = %394
   %399 = load i64, i64* %397, align 8
   %400 = bitcast i8* %395 to i64*
-  %NullCheck166 = icmp ne i64* %400, null
-  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+  %NullCheck165 = icmp eq i64* %400, null
+  br i1 %NullCheck165, label %ThrowNullRef166, label %401
 
 ; <label>:401                                     ; preds = %398
   store i64 %399, i64* %400, align 8
@@ -1400,14 +1482,14 @@ entry:
   %404 = load i8*, i8** %arg1
   %405 = getelementptr inbounds i8, i8* %404, i64 8
   %406 = bitcast i8* %405 to i64*
-  %NullCheck168 = icmp ne i64* %406, null
-  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+  %NullCheck167 = icmp eq i64* %406, null
+  br i1 %NullCheck167, label %ThrowNullRef168, label %407
 
 ; <label>:407                                     ; preds = %401
   %408 = load i64, i64* %406, align 8
   %409 = bitcast i8* %403 to i64*
-  %NullCheck170 = icmp ne i64* %409, null
-  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+  %NullCheck169 = icmp eq i64* %409, null
+  br i1 %NullCheck169, label %ThrowNullRef170, label %410
 
 ; <label>:410                                     ; preds = %407
   store i64 %408, i64* %409, align 8
@@ -1437,14 +1519,14 @@ entry:
   %425 = load i8*, i8** %arg0
   %426 = load i8*, i8** %arg1
   %427 = bitcast i8* %426 to i64*
-  %NullCheck148 = icmp ne i64* %427, null
-  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+  %NullCheck147 = icmp eq i64* %427, null
+  br i1 %NullCheck147, label %ThrowNullRef148, label %428
 
 ; <label>:428                                     ; preds = %424
   %429 = load i64, i64* %427, align 8
   %430 = bitcast i8* %425 to i64*
-  %NullCheck150 = icmp ne i64* %430, null
-  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+  %NullCheck149 = icmp eq i64* %430, null
+  br i1 %NullCheck149, label %ThrowNullRef150, label %431
 
 ; <label>:431                                     ; preds = %428
   store i64 %429, i64* %430, align 8
@@ -1466,14 +1548,14 @@ entry:
   %441 = load i8*, i8** %arg0
   %442 = load i8*, i8** %arg1
   %443 = bitcast i8* %442 to i32*
-  %NullCheck152 = icmp ne i32* %443, null
-  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+  %NullCheck151 = icmp eq i32* %443, null
+  br i1 %NullCheck151, label %ThrowNullRef152, label %444
 
 ; <label>:444                                     ; preds = %440
   %445 = load i32, i32* %443, align 8
   %446 = bitcast i8* %441 to i32*
-  %NullCheck154 = icmp ne i32* %446, null
-  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+  %NullCheck153 = icmp eq i32* %446, null
+  br i1 %NullCheck153, label %ThrowNullRef154, label %447
 
 ; <label>:447                                     ; preds = %444
   store i32 %445, i32* %446, align 8
@@ -1495,16 +1577,16 @@ entry:
   %457 = load i8*, i8** %arg0
   %458 = load i8*, i8** %arg1
   %459 = bitcast i8* %458 to i16*
-  %NullCheck156 = icmp ne i16* %459, null
-  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+  %NullCheck155 = icmp eq i16* %459, null
+  br i1 %NullCheck155, label %ThrowNullRef156, label %460
 
 ; <label>:460                                     ; preds = %456
   %461 = load i16, i16* %459, align 8
   %462 = sext i16 %461 to i32
   %463 = bitcast i8* %457 to i16*
   %464 = trunc i32 %462 to i16
-  %NullCheck158 = icmp ne i16* %463, null
-  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+  %NullCheck157 = icmp eq i16* %463, null
+  br i1 %NullCheck157, label %ThrowNullRef158, label %465
 
 ; <label>:465                                     ; preds = %460
   store i16 %464, i16* %463, align 8
@@ -1525,15 +1607,15 @@ entry:
 ; <label>:474                                     ; preds = %470
   %475 = load i8*, i8** %arg0
   %476 = load i8*, i8** %arg1
-  %NullCheck160 = icmp ne i8* %476, null
-  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+  %NullCheck159 = icmp eq i8* %476, null
+  br i1 %NullCheck159, label %ThrowNullRef160, label %477
 
 ; <label>:477                                     ; preds = %474
   %478 = load i8, i8* %476, align 8
   %479 = zext i8 %478 to i32
   %480 = trunc i32 %479 to i8
-  %NullCheck162 = icmp ne i8* %475, null
-  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+  %NullCheck161 = icmp eq i8* %475, null
+  br i1 %NullCheck161, label %ThrowNullRef162, label %481
 
 ; <label>:481                                     ; preds = %477
   store i8 %480, i8* %475, align 8
@@ -1553,343 +1635,343 @@ ThrowNullRef:                                     ; preds = %308
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %312
+ThrowNullRef2:                                    ; preds = %312
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %315
+ThrowNullRef4:                                    ; preds = %315
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %321
+ThrowNullRef6:                                    ; preds = %321
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %271
+ThrowNullRef8:                                    ; preds = %271
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %275
+ThrowNullRef10:                                   ; preds = %275
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %278
+ThrowNullRef12:                                   ; preds = %278
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %284
+ThrowNullRef14:                                   ; preds = %284
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %287
+ThrowNullRef16:                                   ; preds = %287
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %293
+ThrowNullRef18:                                   ; preds = %293
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %298
+ThrowNullRef20:                                   ; preds = %298
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %303
+ThrowNullRef22:                                   ; preds = %303
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %243
+ThrowNullRef24:                                   ; preds = %243
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %247
+ThrowNullRef26:                                   ; preds = %247
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %250
+ThrowNullRef28:                                   ; preds = %250
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %256
+ThrowNullRef30:                                   ; preds = %256
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %259
+ThrowNullRef32:                                   ; preds = %259
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %265
+ThrowNullRef34:                                   ; preds = %265
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %217
+ThrowNullRef36:                                   ; preds = %217
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %221
+ThrowNullRef38:                                   ; preds = %221
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %224
+ThrowNullRef40:                                   ; preds = %224
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %230
+ThrowNullRef42:                                   ; preds = %230
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %233
+ThrowNullRef44:                                   ; preds = %233
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %238
+ThrowNullRef46:                                   ; preds = %238
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %200
+ThrowNullRef48:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %204
+ThrowNullRef50:                                   ; preds = %204
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %207
+ThrowNullRef52:                                   ; preds = %207
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %213
+ThrowNullRef54:                                   ; preds = %213
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %172
+ThrowNullRef56:                                   ; preds = %172
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %176
+ThrowNullRef58:                                   ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %179
+ThrowNullRef60:                                   ; preds = %179
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %185
+ThrowNullRef62:                                   ; preds = %185
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %190
+ThrowNullRef64:                                   ; preds = %190
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %195
+ThrowNullRef66:                                   ; preds = %195
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %153
+ThrowNullRef68:                                   ; preds = %153
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %157
+ThrowNullRef70:                                   ; preds = %157
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %160
+ThrowNullRef72:                                   ; preds = %160
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %166
+ThrowNullRef74:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %136
+ThrowNullRef76:                                   ; preds = %136
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %140
+ThrowNullRef78:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %143
+ThrowNullRef80:                                   ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %148
+ThrowNullRef82:                                   ; preds = %148
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %128
+ThrowNullRef84:                                   ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %132
+ThrowNullRef86:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %100
+ThrowNullRef88:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %104
+ThrowNullRef90:                                   ; preds = %104
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %107
+ThrowNullRef92:                                   ; preds = %107
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %113
+ThrowNullRef94:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %118
+ThrowNullRef96:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %123
+ThrowNullRef98:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %81
+ThrowNullRef100:                                  ; preds = %81
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef101:                                  ; preds = %85
+ThrowNullRef102:                                  ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef103:                                  ; preds = %88
+ThrowNullRef104:                                  ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef105:                                  ; preds = %94
+ThrowNullRef106:                                  ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef107:                                  ; preds = %64
+ThrowNullRef108:                                  ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef109:                                  ; preds = %68
+ThrowNullRef110:                                  ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef111:                                  ; preds = %71
+ThrowNullRef112:                                  ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef113:                                  ; preds = %76
+ThrowNullRef114:                                  ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef115:                                  ; preds = %56
+ThrowNullRef116:                                  ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef117:                                  ; preds = %60
+ThrowNullRef118:                                  ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef119:                                  ; preds = %37
+ThrowNullRef120:                                  ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef121:                                  ; preds = %41
+ThrowNullRef122:                                  ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef123:                                  ; preds = %46
+ThrowNullRef124:                                  ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef125:                                  ; preds = %51
+ThrowNullRef126:                                  ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef127:                                  ; preds = %27
+ThrowNullRef128:                                  ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef129:                                  ; preds = %31
+ThrowNullRef130:                                  ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef131:                                  ; preds = %19
+ThrowNullRef132:                                  ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef133:                                  ; preds = %22
+ThrowNullRef134:                                  ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef135:                                  ; preds = %338
+ThrowNullRef136:                                  ; preds = %338
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef137:                                  ; preds = %341
+ThrowNullRef138:                                  ; preds = %341
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef139:                                  ; preds = %356
+ThrowNullRef140:                                  ; preds = %356
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef141:                                  ; preds = %360
+ThrowNullRef142:                                  ; preds = %360
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef143:                                  ; preds = %377
+ThrowNullRef144:                                  ; preds = %377
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef145:                                  ; preds = %381
+ThrowNullRef146:                                  ; preds = %381
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef147:                                  ; preds = %424
+ThrowNullRef148:                                  ; preds = %424
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef149:                                  ; preds = %428
+ThrowNullRef150:                                  ; preds = %428
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef151:                                  ; preds = %440
+ThrowNullRef152:                                  ; preds = %440
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef153:                                  ; preds = %444
+ThrowNullRef154:                                  ; preds = %444
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef155:                                  ; preds = %456
+ThrowNullRef156:                                  ; preds = %456
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef157:                                  ; preds = %460
+ThrowNullRef158:                                  ; preds = %460
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef159:                                  ; preds = %474
+ThrowNullRef160:                                  ; preds = %474
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef161:                                  ; preds = %477
+ThrowNullRef162:                                  ; preds = %477
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef163:                                  ; preds = %394
+ThrowNullRef164:                                  ; preds = %394
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef165:                                  ; preds = %398
+ThrowNullRef166:                                  ; preds = %398
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef167:                                  ; preds = %401
+ThrowNullRef168:                                  ; preds = %401
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef169:                                  ; preds = %407
+ThrowNullRef170:                                  ; preds = %407
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1939,8 +2021,8 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
-  br i1 %NullCheck, label %22, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %ThrowNullRef, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
@@ -1948,8 +2030,8 @@ entry:
   store i32 %24, i32* %loc0
   %25 = load i32, i32* %loc0
   %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %26, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %27
 
 ; <label>:27                                      ; preds = %22
   %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
@@ -1971,7 +2053,7 @@ ThrowNullRef:                                     ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1989,8 +2071,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -2022,15 +2104,15 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2048,16 +2130,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
   %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
   store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %15
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
@@ -2072,8 +2154,8 @@ entry:
   %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
   %29 = ptrtoint i16 addrspace(1)* %28 to i64
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %19
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
@@ -2089,19 +2171,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2114,8 +2196,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
@@ -2128,7 +2210,7 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[loadElem]
+Failed to read AppDomain.PrepareDataForSetup[storeElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
@@ -2202,8 +2284,8 @@ entry:
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
-  br i1 %NullCheck24, label %27, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = load i64, i64 addrspace(1)* %26
@@ -2218,8 +2300,8 @@ entry:
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
-  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
   %41 = load i64, i64 addrspace(1)* %39
@@ -2236,8 +2318,8 @@ entry:
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
-  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
   %54 = load i64, i64 addrspace(1)* %52
@@ -2252,8 +2334,8 @@ entry:
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
   %67 = load i64, i64 addrspace(1)* %65
@@ -2270,8 +2352,8 @@ entry:
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
-  br i1 %NullCheck16, label %79, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
   %80 = load i64, i64 addrspace(1)* %78
@@ -2286,8 +2368,8 @@ entry:
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
-  br i1 %NullCheck18, label %92, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
   %93 = load i64, i64 addrspace(1)* %91
@@ -2304,8 +2386,8 @@ entry:
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
-  br i1 %NullCheck12, label %105, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = load i64, i64 addrspace(1)* %104
@@ -2320,8 +2402,8 @@ entry:
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
-  br i1 %NullCheck14, label %118, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
   %119 = load i64, i64 addrspace(1)* %117
@@ -2337,8 +2419,8 @@ entry:
 
 ; <label>:128                                     ; preds = %20
   %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
-  br i1 %NullCheck4, label %130, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %129, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %130
 
 ; <label>:130                                     ; preds = %128
   %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
@@ -2346,8 +2428,8 @@ entry:
   %133 = load i16, i16 addrspace(1)* %132, align 8
   %134 = zext i16 %133 to i32
   %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
-  br i1 %NullCheck6, label %136, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %135, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %136
 
 ; <label>:136                                     ; preds = %130
   %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
@@ -2360,8 +2442,8 @@ entry:
 
 ; <label>:143                                     ; preds = %136
   %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
-  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %144, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %145
 
 ; <label>:145                                     ; preds = %143
   %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
@@ -2369,8 +2451,8 @@ entry:
   %148 = load i16, i16 addrspace(1)* %147, align 8
   %149 = zext i16 %148 to i32
   %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %150, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %151
 
 ; <label>:151                                     ; preds = %145
   %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
@@ -2388,8 +2470,8 @@ entry:
 
 ; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
-  br i1 %NullCheck, label %163, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %ThrowNullRef, label %163
 
 ; <label>:163                                     ; preds = %161
   %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
@@ -2399,8 +2481,8 @@ entry:
 
 ; <label>:167                                     ; preds = %163
   %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
-  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %168, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %169
 
 ; <label>:169                                     ; preds = %167
   %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
@@ -2432,55 +2514,55 @@ ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %167
+ThrowNullRef2:                                    ; preds = %167
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %128
+ThrowNullRef4:                                    ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %130
+ThrowNullRef6:                                    ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %143
+ThrowNullRef8:                                    ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %145
+ThrowNullRef10:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %102
+ThrowNullRef12:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %105
+ThrowNullRef14:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %76
+ThrowNullRef16:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %79
+ThrowNullRef18:                                   ; preds = %79
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %50
+ThrowNullRef20:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %53
+ThrowNullRef22:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %24
+ThrowNullRef24:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %27
+ThrowNullRef26:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2503,15 +2585,15 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2519,16 +2601,16 @@ entry:
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
   store i32 %8, i32* %loc0
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
   %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
   store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
@@ -2546,16 +2628,16 @@ entry:
 
 ; <label>:23                                      ; preds = %64
   %24 = load i16*, i16** %loc3
-  %NullCheck12 = icmp ne i16* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i16* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
   store i32 %27, i32* %loc5
   %28 = load i16*, i16** %loc4
-  %NullCheck14 = icmp ne i16* %28, null
-  br i1 %NullCheck14, label %29, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %28, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = load i16, i16* %28, align 8
@@ -2620,15 +2702,15 @@ entry:
 
 ; <label>:67                                      ; preds = %64
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
-  br i1 %NullCheck8, label %69, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %68, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %69
 
 ; <label>:69                                      ; preds = %67
   %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
   %71 = load i32, i32 addrspace(1)* %70
   %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
-  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %73
 
 ; <label>:73                                      ; preds = %69
   %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
@@ -2645,31 +2727,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %67
+ThrowNullRef8:                                    ; preds = %67
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %69
+ThrowNullRef10:                                   ; preds = %69
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2710,14 +2792,14 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
   %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
@@ -2730,14 +2812,14 @@ entry:
 
 ; <label>:11                                      ; preds = %4
   %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
   %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
@@ -2749,14 +2831,14 @@ entry:
 
 ; <label>:22                                      ; preds = %16
   %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
   %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
-  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
-  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
@@ -2804,23 +2886,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2836,7 +2918,280 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[loadElem]
+Successfully read RuntimeType.IsAssignableFrom
+
+define i8 @RuntimeType.IsAssignableFrom(%System.RuntimeType addrspace(1)* %param0, %System.Type addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.RuntimeType addrspace(1)*
+  %arg1 = alloca %System.Type addrspace(1)*
+  %loc0 = alloca %System.RuntimeType addrspace(1)*
+  %loc1 = alloca %"System.Type[]" addrspace(1)*
+  %loc2 = alloca i32
+  store %System.RuntimeType addrspace(1)* %param0, %System.RuntimeType addrspace(1)** %this
+  store %System.Type addrspace(1)* %param1, %System.Type addrspace(1)** %arg1
+  %0 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %1 = icmp ne %System.Type addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i8 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %5 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %6 = bitcast %System.Type addrspace(1)* %4 to %System.Object addrspace(1)*
+  %7 = bitcast %System.RuntimeType addrspace(1)* %5 to %System.Object addrspace(1)*
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %6, %System.Object addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %3
+  ret i8 1
+
+; <label>:12                                      ; preds = %3
+  %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 152
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 32
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
+  %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
+  %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
+  store %System.RuntimeType addrspace(1)* %25, %System.RuntimeType addrspace(1)** %loc0
+  %26 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %27 = icmp eq %System.RuntimeType addrspace(1)* %26, null
+  br i1 %27, label %34, label %28
+
+; <label>:28                                      ; preds = %15
+  %29 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %30 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)*)*)(%System.RuntimeType addrspace(1)* %29, %System.RuntimeType addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+; <label>:34                                      ; preds = %15
+  %35 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %36 = call %System.Reflection.Emit.TypeBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Reflection.Emit.TypeBuilder addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %35)
+  %37 = icmp eq %System.Reflection.Emit.TypeBuilder addrspace(1)* %36, null
+  br i1 %37, label %139, label %38
+
+; <label>:38                                      ; preds = %34
+  %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %42
+
+; <label>:42                                      ; preds = %38
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 152
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 40
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
+  %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
+  %53 = zext i8 %52 to i32
+  %54 = icmp eq i32 %53, 0
+  br i1 %54, label %56, label %55
+
+; <label>:55                                      ; preds = %42
+  ret i8 1
+
+; <label>:56                                      ; preds = %42
+  %57 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %58 = bitcast %System.RuntimeType addrspace(1)* %57 to %System.Type addrspace(1)*
+  %59 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %58)
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %64 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.Type addrspace(1)* %63, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = bitcast %System.RuntimeType addrspace(1)* %64 to %System.Type addrspace(1)*
+  %67 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %63, %System.Type addrspace(1)* %66)
+  %68 = zext i8 %67 to i32
+  %69 = trunc i32 %68 to i8
+  ret i8 %69
+
+; <label>:70                                      ; preds = %56
+  %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
+  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %73
+
+; <label>:73                                      ; preds = %70
+  %74 = load i64, i64 addrspace(1)* %72
+  %75 = add i64 %74, 128
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = add i64 %77, 0
+  %79 = inttoptr i64 %78 to i64*
+  %80 = load i64, i64* %79
+  %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
+  %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
+  %83 = call i8 %82(%System.Type addrspace(1)* %81)
+  %84 = zext i8 %83 to i32
+  %85 = icmp eq i32 %84, 0
+  br i1 %85, label %139, label %86
+
+; <label>:86                                      ; preds = %73
+  %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
+  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %89
+
+; <label>:89                                      ; preds = %86
+  %90 = load i64, i64 addrspace(1)* %88
+  %91 = add i64 %90, 128
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = add i64 %93, 24
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
+  %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
+  %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
+  store %"System.Type[]" addrspace(1)* %99, %"System.Type[]" addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %129
+
+; <label>:100                                     ; preds = %132
+  %101 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %102 = load i32, i32* %loc2
+  %NullCheck11 = icmp eq %"System.Type[]" addrspace(1)* %101, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %103
+
+; <label>:103                                     ; preds = %100
+  %104 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 1
+  %105 = load i32, i32 addrspace(1)* %104
+  %106 = zext i32 %105 to i64
+  %107 = zext i32 %102 to i64
+  %BoundsCheck = icmp uge i64 %107, %106
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %108
+
+; <label>:108                                     ; preds = %103
+  %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
+  %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
+  %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
+  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %113
+
+; <label>:113                                     ; preds = %108
+  %114 = load i64, i64 addrspace(1)* %112
+  %115 = add i64 %114, 152
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = add i64 %117, 56
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
+  %123 = zext i8 %122 to i32
+  %124 = icmp ne i32 %123, 0
+  br i1 %124, label %126, label %125
+
+; <label>:125                                     ; preds = %113
+  ret i8 0
+
+; <label>:126                                     ; preds = %113
+  %127 = load i32, i32* %loc2
+  %128 = add i32 %127, 1
+  store i32 %128, i32* %loc2
+  br label %129
+
+; <label>:129                                     ; preds = %89, %126
+  %130 = load i32, i32* %loc2
+  %131 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %NullCheck9 = icmp eq %"System.Type[]" addrspace(1)* %131, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %132
+
+; <label>:132                                     ; preds = %129
+  %133 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %131, i32 0, i32 1
+  %134 = load i32, i32 addrspace(1)* %133
+  %135 = zext i32 %134 to i64
+  %136 = trunc i64 %135 to i32
+  %137 = icmp slt i32 %130, %136
+  br i1 %137, label %100, label %138
+
+; <label>:138                                     ; preds = %132
+  ret i8 1
+
+; <label>:139                                     ; preds = %34, %73
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %129
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %103
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -2893,7 +3248,7 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElem]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -2904,8 +3259,8 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -2997,8 +3352,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
@@ -3059,8 +3414,8 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -3087,8 +3442,8 @@ entry:
 
 ; <label>:17                                      ; preds = %5, %11
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
@@ -3097,8 +3452,8 @@ entry:
 
 ; <label>:22                                      ; preds = %1, %11
   %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
@@ -3109,11 +3464,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %17
+ThrowNullRef2:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %22
+ThrowNullRef4:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3167,15 +3522,15 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
   %15 = load i32, i32 addrspace(1)* %14
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
@@ -3198,7 +3553,7 @@ ThrowNullRef:                                     ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef2:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3232,8 +3587,8 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
@@ -3312,8 +3667,8 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -3327,8 +3682,8 @@ entry:
 ; <label>:5                                       ; preds = %43
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %7 = load i32, i32* %loc1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck6, label %8, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
@@ -3366,8 +3721,8 @@ entry:
 ; <label>:32                                      ; preds = %21, %25
   %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
   %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
-  br i1 %NullCheck8, label %35, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = trunc i32 %34 to i16
@@ -3380,8 +3735,8 @@ entry:
 ; <label>:40                                      ; preds = %1, %35
   %41 = load i32, i32* %loc1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
-  br i1 %NullCheck2, label %43, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %42, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
@@ -3392,8 +3747,8 @@ entry:
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
   %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
-  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
   %51 = load i64, i64 addrspace(1)* %49
@@ -3412,19 +3767,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %40
+ThrowNullRef2:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %47
+ThrowNullRef4:                                    ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %5
+ThrowNullRef6:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %32
+ThrowNullRef8:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3467,8 +3822,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
@@ -3492,11 +3847,391 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(i16* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store i16* %param0, i16** %arg0
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load i32, i32* %arg3
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %42, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %37, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg2
+  %13 = load i32, i32* %arg3
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %37, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %24 = load i32, i32* %arg2
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load i16*, i16** %arg0
+  %35 = load i32, i32* %arg3
+  %36 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %36, i16* %34, i32 %35)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:37                                      ; preds = %5, %16
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %39)
+  %41 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41, %System.String addrspace(1)* %38, %System.String addrspace(1)* %40)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41) #0
+  unreachable
+
+; <label>:42                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
-Failed to read StringBuilder.ToString[loadElemA]
+Successfully read StringBuilder.ToString
+
+define %System.String addrspace(1)* @StringBuilder.ToString(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i16*
+  %loc3 = alloca %"System.Char[]" addrspace(1)*
+  %loc4 = alloca i32
+  %loc5 = alloca i32
+  %loc6 = alloca i16 addrspace(1)*
+  %loc7 = alloca %System.String addrspace(1)*
+  %loc8 = alloca %"System.Char[]" addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %0)
+  %2 = icmp ne i32 %1, 0
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %4
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %6)
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %7)
+  store %System.String addrspace(1)* %8, %System.String addrspace(1)** %loc0
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.Text.StringBuilder addrspace(1)* %9, %System.Text.StringBuilder addrspace(1)** %loc1
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  store %System.String addrspace(1)* %10, %System.String addrspace(1)** %loc7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc7
+  %12 = ptrtoint %System.String addrspace(1)* %11 to i64
+  %13 = icmp eq i64 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %5
+  %15 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %16 = sext i32 %15 to i64
+  %17 = add i64 %12, %16
+  br label %18
+
+; <label>:18                                      ; preds = %5, %14
+  %19 = phi i64 [ %12, %5 ], [ %17, %14 ]
+  %20 = inttoptr i64 %19 to i16*
+  store i16* %20, i16** %loc2
+  br label %21
+
+; <label>:21                                      ; preds = %98, %18
+  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %22, null
+  br i1 %NullCheck, label %ThrowNullRef, label %23
+
+; <label>:23                                      ; preds = %21
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 3
+  %25 = load i32, i32 addrspace(1)* %24, align 8
+  %26 = icmp sle i32 %25, 0
+  br i1 %26, label %96, label %27
+
+; <label>:27                                      ; preds = %23
+  %28 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %28, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %29
+
+; <label>:29                                      ; preds = %27
+  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %28, i32 0, i32 1
+  %31 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %30, align 8
+  store %"System.Char[]" addrspace(1)* %31, %"System.Char[]" addrspace(1)** %loc3
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %33
+
+; <label>:33                                      ; preds = %29
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  store i32 %35, i32* %loc4
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  %39 = load i32, i32 addrspace(1)* %38, align 8
+  store i32 %39, i32* %loc5
+  %40 = load i32, i32* %loc5
+  %41 = load i32, i32* %loc4
+  %42 = add i32 %40, %41
+  %43 = zext i32 %42 to i64
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %45
+
+; <label>:45                                      ; preds = %37
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = sext i32 %47 to i64
+  %49 = icmp sgt i64 %43, %48
+  br i1 %49, label %91, label %50
+
+; <label>:50                                      ; preds = %45
+  %51 = load i32, i32* %loc5
+  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %52, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %53
+
+; <label>:53                                      ; preds = %50
+  %54 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %52, i32 0, i32 1
+  %55 = load i32, i32 addrspace(1)* %54
+  %56 = zext i32 %55 to i64
+  %57 = trunc i64 %56 to i32
+  %58 = icmp ugt i32 %51, %57
+  br i1 %58, label %91, label %59
+
+; <label>:59                                      ; preds = %53
+  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  store %"System.Char[]" addrspace(1)* %60, %"System.Char[]" addrspace(1)** %loc8
+  %61 = icmp eq %"System.Char[]" addrspace(1)* %60, null
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %63, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %64
+
+; <label>:64                                      ; preds = %62
+  %65 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %63, i32 0, i32 1
+  %66 = load i32, i32 addrspace(1)* %65
+  %67 = zext i32 %66 to i64
+  %68 = trunc i64 %67 to i32
+  %69 = icmp ne i32 %68, 0
+  br i1 %69, label %71, label %70
+
+; <label>:70                                      ; preds = %59, %64
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:71                                      ; preds = %64
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %73
+
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %BoundsCheck = icmp uge i64 0, %76
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %77
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %78, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:79                                      ; preds = %70, %77
+  %80 = load i16*, i16** %loc2
+  %81 = load i32, i32* %loc4
+  %82 = sext i32 %81 to i64
+  %83 = mul i64 %82, 2
+  %84 = bitcast i16* %80 to i8*
+  %85 = getelementptr inbounds i8, i8* %84, i64 %83
+  %86 = load i16 addrspace(1)*, i16 addrspace(1)** %loc6
+  %87 = ptrtoint i16 addrspace(1)* %86 to i64
+  %88 = load i32, i32* %loc5
+  %89 = bitcast i8* %85 to i16*
+  %90 = inttoptr i64 %87 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %89, i16* %90, i32 %88)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %96
+
+; <label>:91                                      ; preds = %45, %53
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %94 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %93)
+  %95 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95, %System.String addrspace(1)* %92, %System.String addrspace(1)* %94)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95) #0
+  unreachable
+
+; <label>:96                                      ; preds = %23, %79
+  %97 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %97, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %98
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %97, i32 0, i32 2
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  store %System.Text.StringBuilder addrspace(1)* %100, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %102 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %102, label %21, label %103
+
+; <label>:103                                     ; preds = %98
+  store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc7
+  %104 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  ret %System.String addrspace(1)* %104
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method StringBuilder::get_Length using LLILCJit
+Successfully read StringBuilder.get_Length
+
+define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
+Successfully read RuntimeHelpers.get_OffsetToStringData
+
+define i32 @RuntimeHelpers.get_OffsetToStringData() {
+entry:
+  ret i32 12
+}
+
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
 Successfully read CultureData.CreateCultureData
 
@@ -3514,23 +4249,23 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
   store i8 %4, i8 addrspace(1)* %6
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
@@ -3549,11 +4284,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3566,50 +4301,50 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
   store i32 -1, i32 addrspace(1)* %2
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
   store i32 -1, i32 addrspace(1)* %8
   %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
   store i32 -1, i32 addrspace(1)* %14
   %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
   store i32 -1, i32 addrspace(1)* %17
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
@@ -3623,27 +4358,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3675,7 +4410,136 @@ Failed to read Dictionary`2.Insert[non-const derefAddress]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
 Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
-Failed to read HashHelpers.GetPrime[loadElem]
+Successfully read HashHelpers.GetPrime
+
+define i32 @HashHelpers.GetPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %6, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5, %System.String addrspace(1)* %4)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5) #0
+  unreachable
+
+; <label>:6                                       ; preds = %entry
+  store i32 0, i32* %loc0
+  br label %29
+
+; <label>:7                                       ; preds = %35
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 1296
+  %10 = addrspacecast i8 addrspace(1)* %9 to %"System.Int32[]" addrspace(1)**
+  %11 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %10
+  %12 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Int32[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = zext i32 %15 to i64
+  %17 = zext i32 %12 to i64
+  %BoundsCheck = icmp uge i64 %17, %16
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 3, i32 %12
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  store i32 %20, i32* %loc1
+  %21 = load i32, i32* %loc1
+  %22 = load i32, i32* %arg0
+  %23 = icmp slt i32 %21, %22
+  br i1 %23, label %26, label %24
+
+; <label>:24                                      ; preds = %18
+  %25 = load i32, i32* %loc1
+  ret i32 %25
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %loc0
+  %28 = add i32 %27, 1
+  store i32 %28, i32* %loc0
+  br label %29
+
+; <label>:29                                      ; preds = %6, %26
+  %30 = load i32, i32* %loc0
+  %31 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %32 = getelementptr inbounds i8, i8 addrspace(1)* %31, i64 1296
+  %33 = addrspacecast i8 addrspace(1)* %32 to %"System.Int32[]" addrspace(1)**
+  %34 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %33
+  %NullCheck = icmp eq %"System.Int32[]" addrspace(1)* %34, null
+  br i1 %NullCheck, label %ThrowNullRef, label %35
+
+; <label>:35                                      ; preds = %29
+  %36 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %34, i32 0, i32 1
+  %37 = load i32, i32 addrspace(1)* %36
+  %38 = zext i32 %37 to i64
+  %39 = trunc i64 %38 to i32
+  %40 = icmp slt i32 %30, %39
+  br i1 %40, label %7, label %41
+
+; <label>:41                                      ; preds = %35
+  %42 = load i32, i32* %arg0
+  %43 = or i32 %42, 1
+  store i32 %43, i32* %loc2
+  br label %59
+
+; <label>:44                                      ; preds = %59
+  %45 = load i32, i32* %loc2
+  %46 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %45)
+  %47 = zext i8 %46 to i32
+  %48 = icmp eq i32 %47, 0
+  br i1 %48, label %56, label %49
+
+; <label>:49                                      ; preds = %44
+  %50 = load i32, i32* %loc2
+  %51 = sub i32 %50, 1
+  %52 = srem i32 %51, 101
+  %53 = icmp eq i32 %52, 0
+  br i1 %53, label %56, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = load i32, i32* %loc2
+  ret i32 %55
+
+; <label>:56                                      ; preds = %44, %49
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %57, 2
+  store i32 %58, i32* %loc2
+  br label %59
+
+; <label>:59                                      ; preds = %41, %56
+  %60 = load i32, i32* %loc2
+  %61 = icmp slt i32 %60, 2147483647
+  br i1 %61, label %44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load i32, i32* %arg0
+  ret i32 %63
+
+ThrowNullRef:                                     ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
 Successfully read GenericEqualityComparer`1.GetHashCode
 
@@ -3694,14 +4558,14 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
   %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load i64, i64 addrspace(1)* %7
@@ -3720,7 +4584,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3750,8 +4614,8 @@ entry:
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
@@ -3796,8 +4660,8 @@ entry:
   %35 = bitcast i16* %34 to i8*
   %36 = getelementptr inbounds i8, i8* %35, i64 2
   %37 = bitcast i8* %36 to i16*
-  %NullCheck4 = icmp ne i16* %37, null
-  br i1 %NullCheck4, label %38, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %37, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %38
 
 ; <label>:38                                      ; preds = %27
   %39 = load i16, i16* %37, align 8
@@ -3824,8 +4688,8 @@ entry:
 
 ; <label>:54                                      ; preds = %22, %43
   %55 = load i16*, i16** %loc4
-  %NullCheck2 = icmp ne i16* %55, null
-  br i1 %NullCheck2, label %56, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i16* %55, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %56
 
 ; <label>:56                                      ; preds = %54
   %57 = load i16, i16* %55, align 8
@@ -3850,11 +4714,11 @@ ThrowNullRef:                                     ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %54
+ThrowNullRef2:                                    ; preds = %54
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %27
+ThrowNullRef4:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3871,8 +4735,8 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -3907,8 +4771,8 @@ entry:
 
 ; <label>:26                                      ; preds = %19
   %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
-  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %28
 
 ; <label>:28                                      ; preds = %26
   %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
@@ -3920,7 +4784,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3972,8 +4836,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
@@ -3984,26 +4848,26 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
-  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
@@ -4014,8 +4878,8 @@ entry:
 ; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
@@ -4024,8 +4888,8 @@ entry:
 
 ; <label>:25                                      ; preds = %1, %16, %23
   %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
-  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
@@ -4036,27 +4900,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %20
+ThrowNullRef10:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4069,8 +4933,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -4081,8 +4945,8 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
@@ -4091,8 +4955,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1, %8
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
@@ -4103,11 +4967,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4128,24 +4992,24 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   store i32 %3, i32* %loc0
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
   %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
   store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck4, label %9, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
@@ -4164,15 +5028,15 @@ entry:
 ; <label>:18                                      ; preds = %70
   %19 = load i16*, i16** %loc3
   %20 = bitcast i16* %19 to i64*
-  %NullCheck10 = icmp ne i64* %20, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %20, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = load i64, i64* %20, align 8
   %23 = load i16*, i16** %loc4
   %24 = bitcast i16* %23 to i64*
-  %NullCheck12 = icmp ne i64* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = load i64, i64* %24, align 8
@@ -4188,8 +5052,8 @@ entry:
   %31 = bitcast i16* %30 to i8*
   %32 = getelementptr inbounds i8, i8* %31, i64 8
   %33 = bitcast i8* %32 to i64*
-  %NullCheck14 = icmp ne i64* %33, null
-  br i1 %NullCheck14, label %34, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = load i64, i64* %33, align 8
@@ -4197,8 +5061,8 @@ entry:
   %37 = bitcast i16* %36 to i8*
   %38 = getelementptr inbounds i8, i8* %37, i64 8
   %39 = bitcast i8* %38 to i64*
-  %NullCheck16 = icmp ne i64* %39, null
-  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %40
 
 ; <label>:40                                      ; preds = %34
   %41 = load i64, i64* %39, align 8
@@ -4214,8 +5078,8 @@ entry:
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %NullCheck18 = icmp ne i64* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = load i64, i64* %48, align 8
@@ -4223,8 +5087,8 @@ entry:
   %52 = bitcast i16* %51 to i8*
   %53 = getelementptr inbounds i8, i8* %52, i64 16
   %54 = bitcast i8* %53 to i64*
-  %NullCheck20 = icmp ne i64* %54, null
-  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64* %54, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %55
 
 ; <label>:55                                      ; preds = %49
   %56 = load i64, i64* %54, align 8
@@ -4262,15 +5126,15 @@ entry:
 ; <label>:74                                      ; preds = %95
   %75 = load i16*, i16** %loc3
   %76 = bitcast i16* %75 to i32*
-  %NullCheck6 = icmp ne i32* %76, null
-  br i1 %NullCheck6, label %77, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32* %76, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %77
 
 ; <label>:77                                      ; preds = %74
   %78 = load i32, i32* %76, align 8
   %79 = load i16*, i16** %loc4
   %80 = bitcast i16* %79 to i32*
-  %NullCheck8 = icmp ne i32* %80, null
-  br i1 %NullCheck8, label %81, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i32* %80, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %81
 
 ; <label>:81                                      ; preds = %77
   %82 = load i32, i32* %80, align 8
@@ -4318,43 +5182,43 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %74
+ThrowNullRef6:                                    ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %77
+ThrowNullRef8:                                    ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %29
+ThrowNullRef14:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %34
+ThrowNullRef16:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4376,8 +5240,8 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load i64, i64 addrspace(1)* %4
@@ -4389,8 +5253,8 @@ entry:
   %12 = load i64, i64* %11
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %5
   %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
@@ -4399,8 +5263,8 @@ entry:
   %18 = load i8, i8* %arg2
   %19 = zext i8 %18 to i32
   %20 = trunc i32 %19 to i8
-  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %15
   %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
@@ -4411,11 +5275,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4442,8 +5306,8 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
@@ -4466,16 +5330,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
   %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = load i64, i64 addrspace(1)* %19
@@ -4500,8 +5364,8 @@ entry:
 ; <label>:35                                      ; preds = %30
   %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
@@ -4514,8 +5378,8 @@ entry:
 
 ; <label>:42                                      ; preds = %1, %38
   %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
-  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
@@ -4526,19 +5390,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %35
+ThrowNullRef2:                                    ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %42
+ThrowNullRef8:                                    ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4551,14 +5415,14 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
@@ -4570,7 +5434,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4583,8 +5447,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
@@ -4613,51 +5477,51 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
   %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
   %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
   %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
   %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
-  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
   store i64 %21, i64 addrspace(1)* %23
   %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %25 = load i64, i64* %loc0
-  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
@@ -4668,27 +5532,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %22
+ThrowNullRef12:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4701,8 +5565,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
@@ -4713,19 +5577,19 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
@@ -4734,8 +5598,8 @@ entry:
 
 ; <label>:15                                      ; preds = %1, %13
   %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
@@ -4746,19 +5610,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %15
+ThrowNullRef8:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4771,8 +5635,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -4831,8 +5695,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
@@ -4882,8 +5746,8 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
-  br i1 %NullCheck, label %17, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %ThrowNullRef, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
@@ -4894,15 +5758,15 @@ entry:
 
 ; <label>:22                                      ; preds = %17
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
-  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
   %26 = load i32, i32 addrspace(1)* %25
   %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
-  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %27, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
@@ -4925,8 +5789,8 @@ entry:
 ; <label>:40                                      ; preds = %17
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
-  br i1 %NullCheck6, label %43, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %41, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
@@ -4938,34 +5802,17 @@ ThrowNullRef:                                     ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %24
+ThrowNullRef4:                                    ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %40
+ThrowNullRef6:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
-}
-
-INFO:  jitting method Object::ReferenceEquals using LLILCJit
-Successfully read Object.ReferenceEquals
-
-define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
-entry:
-  %arg0 = alloca %System.Object addrspace(1)*
-  %arg1 = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
-  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
-  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = icmp eq %System.Object addrspace(1)* %0, %1
-  %3 = sext i1 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
 }
 
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
@@ -4978,21 +5825,21 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
   %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
-  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
@@ -5007,28 +5854,28 @@ entry:
 ; <label>:13                                      ; preds = %8, %12
   %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
   %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
   %21 = load i32, i32 addrspace(1)* %20, align 8
   %22 = add i32 %21, 1
-  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
   store i32 %22, i32 addrspace(1)* %24
   %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
@@ -5039,27 +5886,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5077,7 +5924,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::Setup using LLILCJit
-Failed to read AppDomain.Setup[loadElem]
+Failed to read AppDomain.Setup[unbox]
 INFO:  jitting method Thread::GetDomain using LLILCJit
 Successfully read Thread.GetDomain
 
@@ -5108,8 +5955,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
@@ -5122,14 +5969,14 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
   %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
@@ -5141,11 +5988,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5173,8 +6020,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -5189,7 +6036,328 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
 Failed to read KeyCollection.System.Collections.Generic.IEnumerable<TKey>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Successfully read Enumerator.MoveNext
+
+define i8 @Enumerator.MoveNext(%"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.RuntimeTypeHandle* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*
+  %"$TypeArg" = alloca %System.RuntimeTypeHandle*
+  store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
+  %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 8
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %76, label %12
+
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
+  br label %76
+
+; <label>:13                                      ; preds = %85
+  %14 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck19 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %15
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, i32 0, i32 0
+  %17 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %16, align 8
+  %NullCheck21 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, i32 0, i32 2
+  %20 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %19, align 8
+  %21 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck23 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %22
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, i32 0, i32 2
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %NullCheck25 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 3, i32 %24
+  %NullCheck27 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %32
+
+; <label>:32                                      ; preds = %30
+  %33 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, i32 0, i32 2
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = icmp slt i32 %34, 0
+  br i1 %35, label %68, label %36
+
+; <label>:36                                      ; preds = %32
+  %37 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %38 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck29 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %39
+
+; <label>:39                                      ; preds = %36
+  %40 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, i32 0, i32 0
+  %41 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %40, align 8
+  %NullCheck31 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, i32 0, i32 2
+  %44 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %43, align 8
+  %45 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck33 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, i32 0, i32 2
+  %48 = load i32, i32 addrspace(1)* %47, align 8
+  %NullCheck35 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %49
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = zext i32 %51 to i64
+  %53 = zext i32 %48 to i64
+  %BoundsCheck37 = icmp uge i64 %53, %52
+  br i1 %BoundsCheck37, label %ThrowIndexOutOfRange38, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 3, i32 %48
+  %NullCheck39 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %56
+
+; <label>:56                                      ; preds = %54
+  %57 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, i32 0, i32 0
+  %58 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck41 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %59
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %60, %System.__Canon addrspace(1)* %58)
+  %61 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck43 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  %64 = load i32, i32 addrspace(1)* %63, align 8
+  %65 = add i32 %64, 1
+  %NullCheck45 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  store i32 %65, i32 addrspace(1)* %67
+  ret i8 1
+
+; <label>:68                                      ; preds = %32
+  %69 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck47 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %73 = add i32 %72, 1
+  %NullCheck49 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %74
+
+; <label>:74                                      ; preds = %70
+  %75 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  store i32 %73, i32 addrspace(1)* %75
+  br label %76
+
+; <label>:76                                      ; preds = %8, %12, %74
+  %77 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %78
+
+; <label>:78                                      ; preds = %76
+  %79 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, i32 0, i32 2
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck7 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %82
+
+; <label>:82                                      ; preds = %78
+  %83 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, i32 0, i32 0
+  %84 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %83, align 8
+  %NullCheck9 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %85
+
+; <label>:85                                      ; preds = %82
+  %86 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, i32 0, i32 7
+  %87 = load i32, i32 addrspace(1)* %86, align 8
+  %88 = icmp ult i32 %80, %87
+  br i1 %88, label %13, label %89
+
+; <label>:89                                      ; preds = %85
+  %90 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %91 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck11 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %92
+
+; <label>:92                                      ; preds = %89
+  %93 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, i32 0, i32 0
+  %94 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck13 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %95
+
+; <label>:95                                      ; preds = %92
+  %96 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, i32 0, i32 7
+  %97 = load i32, i32 addrspace(1)* %96, align 8
+  %98 = add i32 %97, 1
+  %NullCheck15 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %99
+
+; <label>:99                                      ; preds = %95
+  %100 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, i32 0, i32 2
+  store i32 %98, i32 addrspace(1)* %100
+  %101 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck17 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %102
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %103, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %92
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef22:                                   ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef24:                                   ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef26:                                   ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef28:                                   ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef30:                                   ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef32:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef34:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef36:                                   ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange38:                           ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef40:                                   ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef42:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef44:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef46:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef48:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef50:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -5200,8 +6368,8 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -5232,9 +6400,9 @@ Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
 Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
-Failed to read String.MakeSeparatorList[loadElemA]
+Failed to read String.MakeSeparatorList[storeElem]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
-Failed to read String.InternalSplitKeepEmptyEntries[loadElem]
+Failed to read String.InternalSplitKeepEmptyEntries[storeElem]
 INFO:  jitting method Path::IsRelative using LLILCJit
 Successfully read Path.IsRelative
 
@@ -5243,8 +6411,8 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -5254,8 +6422,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
@@ -5271,8 +6439,8 @@ entry:
 
 ; <label>:17                                      ; preds = %7
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
@@ -5288,8 +6456,8 @@ entry:
 
 ; <label>:29                                      ; preds = %19
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %31
 
 ; <label>:31                                      ; preds = %29
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
@@ -5300,8 +6468,8 @@ entry:
 
 ; <label>:36                                      ; preds = %31
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
-  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %37, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
@@ -5312,8 +6480,8 @@ entry:
 
 ; <label>:43                                      ; preds = %31, %38
   %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
-  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %45
 
 ; <label>:45                                      ; preds = %43
   %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
@@ -5324,8 +6492,8 @@ entry:
 
 ; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %50
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
@@ -5336,8 +6504,8 @@ entry:
 
 ; <label>:57                                      ; preds = %1, %7, %19, %45, %52
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
-  br i1 %NullCheck14, label %59, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %59
 
 ; <label>:59                                      ; preds = %57
   %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
@@ -5347,8 +6515,8 @@ entry:
 
 ; <label>:63                                      ; preds = %59
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
@@ -5359,8 +6527,8 @@ entry:
 
 ; <label>:70                                      ; preds = %65
   %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
-  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.String addrspace(1)* %71, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %72
 
 ; <label>:72                                      ; preds = %70
   %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
@@ -5379,39 +6547,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %17
+ThrowNullRef4:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %29
+ThrowNullRef6:                                    ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %36
+ThrowNullRef8:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %43
+ThrowNullRef10:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %50
+ThrowNullRef12:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %57
+ThrowNullRef14:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %63
+ThrowNullRef16:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %70
+ThrowNullRef18:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5419,7 +6587,293 @@ ThrowNullRef17:                                   ; preds = %70
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
-Failed to read String.TrimHelper[loadElem]
+Successfully read String.TrimHelper
+
+define %System.String addrspace(1)* @String.TrimHelper(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i16
+  %loc4 = alloca i32
+  %loc5 = alloca i16
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = sub i32 %3, 1
+  store i32 %4, i32* %loc0
+  store i32 0, i32* %loc1
+  %5 = load i32, i32* %arg2
+  %6 = icmp eq i32 %5, 1
+  br i1 %6, label %62, label %7
+
+; <label>:7                                       ; preds = %1
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:8                                       ; preds = %58
+  store i32 0, i32* %loc2
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load i32, i32* %loc1
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2, i32 %10
+  %13 = load i16, i16 addrspace(1)* %12
+  %14 = zext i16 %13 to i32
+  %15 = trunc i32 %14 to i16
+  store i16 %15, i16* %loc3
+  store i32 0, i32* %loc2
+  br label %34
+
+; <label>:16                                      ; preds = %37
+  %17 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %18 = load i32, i32* %loc2
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %17, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %19
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = zext i32 %18 to i64
+  %BoundsCheck = icmp uge i64 %23, %22
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %24
+
+; <label>:24                                      ; preds = %19
+  %25 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 3, i32 %18
+  %26 = load i16, i16 addrspace(1)* %25, align 8
+  %27 = zext i16 %26 to i32
+  %28 = load i16, i16* %loc3
+  %29 = zext i16 %28 to i32
+  %30 = icmp eq i32 %27, %29
+  br i1 %30, label %43, label %31
+
+; <label>:31                                      ; preds = %24
+  %32 = load i32, i32* %loc2
+  %33 = add i32 %32, 1
+  store i32 %33, i32* %loc2
+  br label %34
+
+; <label>:34                                      ; preds = %11, %31
+  %35 = load i32, i32* %loc2
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = icmp slt i32 %35, %41
+  br i1 %42, label %16, label %43
+
+; <label>:43                                      ; preds = %24, %37
+  %44 = load i32, i32* %loc2
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %45, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp eq i32 %44, %50
+  br i1 %51, label %62, label %52
+
+; <label>:52                                      ; preds = %46
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %7, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %57, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %58
+
+; <label>:58                                      ; preds = %55
+  %59 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %60 = load i32, i32 addrspace(1)* %59
+  %61 = icmp slt i32 %56, %60
+  br i1 %61, label %8, label %62
+
+; <label>:62                                      ; preds = %1, %46, %58
+  %63 = load i32, i32* %arg2
+  %64 = icmp eq i32 %63, 0
+  br i1 %64, label %122, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %66, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %67
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %66, i32 0, i32 1
+  %69 = load i32, i32 addrspace(1)* %68
+  %70 = sub i32 %69, 1
+  store i32 %70, i32* %loc0
+  br label %118
+
+; <label>:71                                      ; preds = %118
+  store i32 0, i32* %loc4
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %73 = load i32, i32* %loc0
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %74
+
+; <label>:74                                      ; preds = %71
+  %75 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 2, i32 %73
+  %76 = load i16, i16 addrspace(1)* %75
+  %77 = zext i16 %76 to i32
+  %78 = trunc i32 %77 to i16
+  store i16 %78, i16* %loc5
+  store i32 0, i32* %loc4
+  br label %97
+
+; <label>:79                                      ; preds = %100
+  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %81 = load i32, i32* %loc4
+  %NullCheck19 = icmp eq %"System.Char[]" addrspace(1)* %80, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
+
+; <label>:82                                      ; preds = %79
+  %83 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 1
+  %84 = load i32, i32 addrspace(1)* %83
+  %85 = zext i32 %84 to i64
+  %86 = zext i32 %81 to i64
+  %BoundsCheck21 = icmp uge i64 %86, %85
+  br i1 %BoundsCheck21, label %ThrowIndexOutOfRange22, label %87
+
+; <label>:87                                      ; preds = %82
+  %88 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 3, i32 %81
+  %89 = load i16, i16 addrspace(1)* %88, align 8
+  %90 = zext i16 %89 to i32
+  %91 = load i16, i16* %loc5
+  %92 = zext i16 %91 to i32
+  %93 = icmp eq i32 %90, %92
+  br i1 %93, label %106, label %94
+
+; <label>:94                                      ; preds = %87
+  %95 = load i32, i32* %loc4
+  %96 = add i32 %95, 1
+  store i32 %96, i32* %loc4
+  br label %97
+
+; <label>:97                                      ; preds = %74, %94
+  %98 = load i32, i32* %loc4
+  %99 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck15 = icmp eq %"System.Char[]" addrspace(1)* %99, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %100
+
+; <label>:100                                     ; preds = %97
+  %101 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %99, i32 0, i32 1
+  %102 = load i32, i32 addrspace(1)* %101
+  %103 = zext i32 %102 to i64
+  %104 = trunc i64 %103 to i32
+  %105 = icmp slt i32 %98, %104
+  br i1 %105, label %79, label %106
+
+; <label>:106                                     ; preds = %87, %100
+  %107 = load i32, i32* %loc4
+  %108 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck17 = icmp eq %"System.Char[]" addrspace(1)* %108, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %109
+
+; <label>:109                                     ; preds = %106
+  %110 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %108, i32 0, i32 1
+  %111 = load i32, i32 addrspace(1)* %110
+  %112 = zext i32 %111 to i64
+  %113 = trunc i64 %112 to i32
+  %114 = icmp eq i32 %107, %113
+  br i1 %114, label %122, label %115
+
+; <label>:115                                     ; preds = %109
+  %116 = load i32, i32* %loc0
+  %117 = sub i32 %116, 1
+  store i32 %117, i32* %loc0
+  br label %118
+
+; <label>:118                                     ; preds = %67, %115
+  %119 = load i32, i32* %loc0
+  %120 = load i32, i32* %loc1
+  %121 = icmp sge i32 %119, %120
+  br i1 %121, label %71, label %122
+
+; <label>:122                                     ; preds = %62, %109, %118
+  %123 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %124 = load i32, i32* %loc1
+  %125 = load i32, i32* %loc0
+  %126 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %123, i32 %124, i32 %125)
+  ret %System.String addrspace(1)* %126
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %97
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange22:                           ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
 Successfully read String.CreateTrimmedString
 
@@ -5439,8 +6893,8 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
@@ -5535,8 +6989,8 @@ entry:
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i64 2872
   %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
   %8 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %7
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %3
   %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
@@ -5553,8 +7007,8 @@ entry:
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 2864
   %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
   %21 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %20
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
-  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %22
 
 ; <label>:22                                      ; preds = %16
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
@@ -5569,7 +7023,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %16
+ThrowNullRef2:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5586,8 +7040,8 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5613,8 +7067,8 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
@@ -5632,8 +7086,8 @@ entry:
 
 ; <label>:12                                      ; preds = %4
   %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
@@ -5644,8 +7098,8 @@ entry:
 
 ; <label>:19                                      ; preds = %14
   %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %19
   %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
@@ -5660,21 +7114,21 @@ entry:
   %31 = zext i16 %30 to i32
   %32 = bitcast i8* %29 to i16*
   %33 = trunc i32 %31 to i16
-  %NullCheck6 = icmp ne i16* %32, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i16* %32, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %21
   store i16 %33, i16* %32, align 8
   %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %36
 
 ; <label>:36                                      ; preds = %34
   %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
   %38 = load i32, i32 addrspace(1)* %37, align 8
   %39 = add i32 %38, 1
-  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %40
 
 ; <label>:40                                      ; preds = %36
   %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
@@ -5683,16 +7137,16 @@ entry:
 
 ; <label>:42                                      ; preds = %14
   %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
-  br i1 %NullCheck12, label %44, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
   %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
   %47 = load i16, i16* %arg1
   %48 = zext i16 %47 to i32
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = trunc i32 %48 to i16
@@ -5703,31 +7157,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %19
+ThrowNullRef4:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %21
+ThrowNullRef6:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %36
+ThrowNullRef10:                                   ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %42
+ThrowNullRef12:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %44
+ThrowNullRef14:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5740,8 +7194,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -5752,8 +7206,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
@@ -5762,14 +7216,14 @@ entry:
 
 ; <label>:11                                      ; preds = %1
   %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
@@ -5779,15 +7233,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5808,8 +7262,8 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5822,8 +7276,8 @@ entry:
 
 ; <label>:8                                       ; preds = %3
   %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
@@ -5842,15 +7296,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
-  br i1 %NullCheck4, label %22, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
   %24 = load i16*, i16* addrspace(1)* %23, align 8
   %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %25, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
@@ -5859,8 +7313,8 @@ entry:
   store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
@@ -5874,8 +7328,8 @@ entry:
 
 ; <label>:37                                      ; preds = %65
   %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %37
   %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
@@ -5886,16 +7340,16 @@ entry:
   %45 = bitcast i16* %41 to i8*
   %46 = getelementptr inbounds i8, i8* %45, i64 %44
   %47 = bitcast i8* %46 to i16*
-  %NullCheck14 = icmp ne i16* %47, null
-  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %47, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %48
 
 ; <label>:48                                      ; preds = %39
   %49 = load i16, i16* %47, align 8
   %50 = zext i16 %49 to i32
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %52 = load i32, i32* %loc1
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %53
 
 ; <label>:53                                      ; preds = %48
   %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
@@ -5916,8 +7370,8 @@ entry:
 ; <label>:62                                      ; preds = %36, %59
   %63 = load i32, i32* %loc1
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck10, label %65, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %65
 
 ; <label>:65                                      ; preds = %62
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
@@ -5936,15 +7390,15 @@ entry:
 
 ; <label>:74                                      ; preds = %70
   %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
-  br i1 %NullCheck18, label %76, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %76
 
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
   %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
-  br i1 %NullCheck20, label %80, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
   %81 = load i64, i64 addrspace(1)* %79
@@ -5958,8 +7412,8 @@ entry:
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
   %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
-  br i1 %NullCheck22, label %92, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.String addrspace(1)* %90, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %92
 
 ; <label>:92                                      ; preds = %80
   %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
@@ -5969,15 +7423,15 @@ entry:
 
 ; <label>:96                                      ; preds = %70
   %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
-  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %98
 
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
   %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
-  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
   %103 = load i64, i64 addrspace(1)* %101
@@ -5991,8 +7445,8 @@ entry:
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
   %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
-  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.String addrspace(1)* %112, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %114
 
 ; <label>:114                                     ; preds = %102
   %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
@@ -6004,59 +7458,59 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %20
+ThrowNullRef4:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %22
+ThrowNullRef6:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %26
+ThrowNullRef8:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %62
+ThrowNullRef10:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %48
+ThrowNullRef16:                                   ; preds = %48
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %74
+ThrowNullRef18:                                   ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %76
+ThrowNullRef20:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %80
+ThrowNullRef22:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %96
+ThrowNullRef24:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %98
+ThrowNullRef26:                                   ; preds = %98
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %102
+ThrowNullRef28:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6069,15 +7523,15 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
   %3 = load i16*, i16* addrspace(1)* %2, align 8
   %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
@@ -6087,8 +7541,8 @@ entry:
   %10 = bitcast i16* %3 to i8*
   %11 = getelementptr inbounds i8, i8* %10, i64 %9
   %12 = bitcast i8* %11 to i16*
-  %NullCheck4 = icmp ne i16* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %5
   store i16 0, i16* %12, align 8
@@ -6098,11 +7552,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6119,8 +7573,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -6131,8 +7585,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
@@ -6144,15 +7598,15 @@ entry:
 
 ; <label>:14                                      ; preds = %1
   %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
   %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
   %21 = load i64, i64 addrspace(1)* %19
@@ -6171,15 +7625,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %14
+ThrowNullRef4:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %16
+ThrowNullRef6:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6302,14 +7756,6 @@ entry:
   ret %System.String addrspace(1)* %57
 }
 
-INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
-Successfully read RuntimeHelpers.get_OffsetToStringData
-
-define i32 @RuntimeHelpers.get_OffsetToStringData() {
-entry:
-  ret i32 12
-}
-
 INFO:  jitting method String::Equals using LLILCJit
 Successfully read String.Equals
 
@@ -6381,8 +7827,8 @@ entry:
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
-  br i1 %NullCheck24, label %29, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
   %30 = load i64, i64 addrspace(1)* %28
@@ -6397,8 +7843,8 @@ entry:
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
-  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
   %43 = load i64, i64 addrspace(1)* %41
@@ -6418,8 +7864,8 @@ entry:
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
   %59 = load i64, i64 addrspace(1)* %57
@@ -6434,8 +7880,8 @@ entry:
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck22, label %71, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
   %72 = load i64, i64 addrspace(1)* %70
@@ -6455,8 +7901,8 @@ entry:
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
-  br i1 %NullCheck16, label %87, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = load i64, i64 addrspace(1)* %86
@@ -6471,8 +7917,8 @@ entry:
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck18, label %100, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
   %101 = load i64, i64 addrspace(1)* %99
@@ -6492,8 +7938,8 @@ entry:
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
-  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
   %117 = load i64, i64 addrspace(1)* %115
@@ -6508,8 +7954,8 @@ entry:
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
-  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
   %130 = load i64, i64 addrspace(1)* %128
@@ -6528,15 +7974,15 @@ entry:
 
 ; <label>:142                                     ; preds = %22
   %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
-  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %143, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %144
 
 ; <label>:144                                     ; preds = %142
   %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
   %146 = load i32, i32 addrspace(1)* %145
   %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
-  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %147, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %148
 
 ; <label>:148                                     ; preds = %144
   %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
@@ -6557,15 +8003,15 @@ entry:
 
 ; <label>:159                                     ; preds = %22
   %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
-  br i1 %NullCheck, label %161, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %ThrowNullRef, label %161
 
 ; <label>:161                                     ; preds = %159
   %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
   %163 = load i32, i32 addrspace(1)* %162
   %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
-  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %164, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %165
 
 ; <label>:165                                     ; preds = %161
   %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
@@ -6578,8 +8024,8 @@ entry:
 
 ; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
-  br i1 %NullCheck4, label %172, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %171, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %172
 
 ; <label>:172                                     ; preds = %170
   %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
@@ -6589,8 +8035,8 @@ entry:
 
 ; <label>:176                                     ; preds = %172
   %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
-  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %177, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %178
 
 ; <label>:178                                     ; preds = %176
   %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
@@ -6629,55 +8075,55 @@ ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %161
+ThrowNullRef2:                                    ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %170
+ThrowNullRef4:                                    ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %176
+ThrowNullRef6:                                    ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %142
+ThrowNullRef8:                                    ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %144
+ThrowNullRef10:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %113
+ThrowNullRef12:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %116
+ThrowNullRef14:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %84
+ThrowNullRef16:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %87
+ThrowNullRef18:                                   ; preds = %87
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %55
+ThrowNullRef20:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %58
+ThrowNullRef22:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %26
+ThrowNullRef24:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %29
+ThrowNullRef26:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,8 +8161,8 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck, label %14, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %ThrowNullRef, label %14
 
 ; <label>:14                                      ; preds = %8
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
@@ -6760,8 +8206,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
@@ -6770,14 +8216,14 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32, i32* %loc0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %10
   %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
   %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
@@ -6790,15 +8236,15 @@ entry:
 ; <label>:25                                      ; preds = %19
   %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
-  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
   %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
@@ -6807,8 +8253,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %37 = load i32, i32* %loc0
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %38, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %38
 
 ; <label>:38                                      ; preds = %32
   %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
@@ -6817,14 +8263,14 @@ entry:
 
 ; <label>:40                                      ; preds = %19
   %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %40
   %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
   %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
-  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
-  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
@@ -6832,8 +8278,8 @@ entry:
   %48 = zext i32 %47 to i64
   %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
-  br i1 %NullCheck16, label %51, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %51
 
 ; <label>:51                                      ; preds = %45
   %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
@@ -6847,15 +8293,15 @@ entry:
 ; <label>:57                                      ; preds = %51
   %58 = load i16*, i16** %arg1
   %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
-  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %60
 
 ; <label>:60                                      ; preds = %57
   %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
   %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
-  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %64
 
 ; <label>:64                                      ; preds = %60
   %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
@@ -6864,22 +8310,22 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
   %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
-  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %70
 
 ; <label>:70                                      ; preds = %64
   %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
   %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
-  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
-  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
   %75 = load i32, i32 addrspace(1)* %74
   %76 = zext i32 %75 to i64
   %77 = trunc i64 %76 to i32
-  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
-  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %78
 
 ; <label>:78                                      ; preds = %73
   %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
@@ -6901,8 +8347,8 @@ entry:
   %90 = bitcast i16* %86 to i8*
   %91 = getelementptr inbounds i8, i8* %90, i64 %89
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %93
 
 ; <label>:93                                      ; preds = %80
   %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
@@ -6912,8 +8358,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %99 = load i32, i32* %loc2
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %100
 
 ; <label>:100                                     ; preds = %93
   %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
@@ -6928,63 +8374,63 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %25
+ThrowNullRef6:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %32
+ThrowNullRef10:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %40
+ThrowNullRef12:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %45
+ThrowNullRef16:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %57
+ThrowNullRef18:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %60
+ThrowNullRef20:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %64
+ThrowNullRef22:                                   ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %70
+ThrowNullRef24:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %73
+ThrowNullRef26:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %80
+ThrowNullRef28:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %93
+ThrowNullRef30:                                   ; preds = %93
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7004,8 +8450,8 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
@@ -7033,43 +8479,43 @@ entry:
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %14
   %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
   %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   %28 = load i32, i32 addrspace(1)* %27, align 8
   %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
-  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %30
 
 ; <label>:30                                      ; preds = %26
   %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
   %32 = load i32, i32 addrspace(1)* %31, align 8
   %33 = add i32 %28, %32
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %34
 
 ; <label>:34                                      ; preds = %30
   %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   store i32 %33, i32 addrspace(1)* %35
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
   store i32 0, i32 addrspace(1)* %38
   %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %40
 
 ; <label>:40                                      ; preds = %37
   %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
@@ -7082,8 +8528,8 @@ entry:
 
 ; <label>:47                                      ; preds = %40
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
@@ -7098,8 +8544,8 @@ entry:
   %54 = load i32, i32* %loc0
   %55 = sext i32 %54 to i64
   %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
-  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %57
 
 ; <label>:57                                      ; preds = %52
   %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
@@ -7110,68 +8556,35 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %14
+ThrowNullRef2:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %23
+ThrowNullRef4:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %26
+ThrowNullRef6:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %30
+ThrowNullRef8:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %34
+ThrowNullRef10:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %47
+ThrowNullRef14:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %52
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-}
-
-INFO:  jitting method StringBuilder::get_Length using LLILCJit
-Successfully read StringBuilder.get_Length
-
-define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.StringBuilder addrspace(1)*
-  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
-  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
-
-; <label>:1                                       ; preds = %entry
-  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %3 = load i32, i32 addrspace(1)* %2, align 8
-  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
-
-; <label>:5                                       ; preds = %1
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = add i32 %3, %7
-  ret i32 %8
-
-ThrowNullRef:                                     ; preds = %entry
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef16:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7213,70 +8626,70 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
   %6 = load i32, i32 addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
   store i32 %6, i32 addrspace(1)* %8
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
   %13 = load i32, i32 addrspace(1)* %12, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
   store i32 %13, i32 addrspace(1)* %15
   %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
-  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %18
 
 ; <label>:18                                      ; preds = %14
   %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
   %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
   %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
   %34 = load i32, i32 addrspace(1)* %33, align 8
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
-  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
@@ -7287,39 +8700,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %28
+ThrowNullRef16:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %32
+ThrowNullRef18:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7455,13 +8868,13 @@ entry:
 ; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
@@ -7477,16 +8890,16 @@ entry:
 
 ; <label>:18                                      ; preds = %15
   %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
   store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
   %22 = load i32, i32* %loc0
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %24
 
 ; <label>:24                                      ; preds = %20
   %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
@@ -7498,13 +8911,13 @@ entry:
 ; <label>:28                                      ; preds = %15, %24
   %29 = load i32, i32* %arg1
   %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %31
   %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
@@ -7517,20 +8930,20 @@ entry:
   %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
-  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
   %46 = load i32, i32 addrspace(1)* %45, align 8
   %47 = sub i32 %40, %46
-  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
-  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i32 addrspace(1)* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %48
 
 ; <label>:48                                      ; preds = %44
   store i32 %47, i32 addrspace(1)* %39, align 8
@@ -7538,21 +8951,21 @@ entry:
 
 ; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
-  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %51
 
 ; <label>:51                                      ; preds = %49
   %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %53
 
 ; <label>:53                                      ; preds = %51
   %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
   %55 = load i32, i32 addrspace(1)* %54, align 8
   %56 = load i32, i32* %arg2
   %57 = sub i32 %55, %56
-  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %58
 
 ; <label>:58                                      ; preds = %53
   %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
@@ -7562,13 +8975,13 @@ entry:
 ; <label>:60                                      ; preds = %33, %58
   %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
   %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
-  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %63
 
 ; <label>:63                                      ; preds = %60
   %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
-  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
-  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
@@ -7578,15 +8991,15 @@ entry:
 
 ; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
-  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i32 addrspace(1)* %69, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %70
 
 ; <label>:70                                      ; preds = %68
   %71 = load i32, i32 addrspace(1)* %69, align 8
   store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
-  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
@@ -7596,8 +9009,8 @@ entry:
   store i32 %77, i32* %loc4
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
-  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %80
 
 ; <label>:80                                      ; preds = %73
   %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
@@ -7607,71 +9020,71 @@ entry:
 ; <label>:83                                      ; preds = %80
   store i32 0, i32* %loc3
   %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
-  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
-  br i1 %NullCheck26, label %88, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i32 addrspace(1)* %87, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %88
 
 ; <label>:88                                      ; preds = %85
   %89 = load i32, i32 addrspace(1)* %87, align 8
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
-  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %90
 
 ; <label>:90                                      ; preds = %88
   %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
   store i32 %89, i32 addrspace(1)* %91
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
-  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
-  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %96
 
 ; <label>:96                                      ; preds = %94
   %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
-  br i1 %NullCheck34, label %100, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %100
 
 ; <label>:100                                     ; preds = %96
   %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
-  br i1 %NullCheck36, label %102, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %102
 
 ; <label>:102                                     ; preds = %100
   %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
   %104 = load i32, i32 addrspace(1)* %103, align 8
   %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
-  br i1 %NullCheck38, label %106, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %106
 
 ; <label>:106                                     ; preds = %102
   %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
-  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
-  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %108
 
 ; <label>:108                                     ; preds = %106
   %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
   %110 = load i32, i32 addrspace(1)* %109, align 8
   %111 = add i32 %104, %110
-  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %112
 
 ; <label>:112                                     ; preds = %108
   %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
   store i32 %111, i32 addrspace(1)* %113
   %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
-  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i32 addrspace(1)* %114, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %115
 
 ; <label>:115                                     ; preds = %112
   %116 = load i32, i32 addrspace(1)* %114, align 8
@@ -7681,19 +9094,19 @@ entry:
 ; <label>:118                                     ; preds = %115
   %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
-  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %121
 
 ; <label>:121                                     ; preds = %118
   %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
-  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
-  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %123
 
 ; <label>:123                                     ; preds = %121
   %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
   %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
-  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
-  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %126
 
 ; <label>:126                                     ; preds = %123
   %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
@@ -7705,8 +9118,8 @@ entry:
 
 ; <label>:130                                     ; preds = %80, %115, %126
   %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %132
 
 ; <label>:132                                     ; preds = %130
   %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7715,8 +9128,8 @@ entry:
   %136 = load i32, i32* %loc3
   %137 = sub i32 %135, %136
   %138 = sub i32 %134, %137
-  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %139
 
 ; <label>:139                                     ; preds = %132
   %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7728,16 +9141,16 @@ entry:
 
 ; <label>:144                                     ; preds = %139
   %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
-  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %146
 
 ; <label>:146                                     ; preds = %144
   %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
   %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
   %149 = load i32, i32* %loc2
   %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
-  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %151
 
 ; <label>:151                                     ; preds = %146
   %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
@@ -7754,145 +9167,249 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %18
+ThrowNullRef4:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %31
+ThrowNullRef10:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %44
+ThrowNullRef16:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %68
+ThrowNullRef18:                                   ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %70
+ThrowNullRef20:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %73
+ThrowNullRef22:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %83
+ThrowNullRef24:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %85
+ThrowNullRef26:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %88
+ThrowNullRef28:                                   ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %90
+ThrowNullRef30:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %94
+ThrowNullRef32:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %96
+ThrowNullRef34:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %100
+ThrowNullRef36:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %102
+ThrowNullRef38:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %106
+ThrowNullRef40:                                   ; preds = %106
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %108
+ThrowNullRef42:                                   ; preds = %108
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %112
+ThrowNullRef44:                                   ; preds = %112
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %118
+ThrowNullRef46:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %121
+ThrowNullRef48:                                   ; preds = %121
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %123
+ThrowNullRef50:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %130
+ThrowNullRef52:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %132
+ThrowNullRef54:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %144
+ThrowNullRef56:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %146
+ThrowNullRef58:                                   ; preds = %146
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %60
+ThrowNullRef60:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %63
+ThrowNullRef62:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %49
+ThrowNullRef64:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %51
+ThrowNullRef66:                                   ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %53
+ThrowNullRef68:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(%"System.Char[]" addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %arg0 = alloca %"System.Char[]" addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store %"System.Char[]" addrspace(1)* %param0, %"System.Char[]" addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load i32, i32* %arg4
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %43, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %38, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg1
+  %13 = load i32, i32* %arg4
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %38, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %24 = load i32, i32* %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %35 = load i32, i32* %arg3
+  %36 = load i32, i32* %arg4
+  %37 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %37, %"System.Char[]" addrspace(1)* %34, i32 %35, i32 %36)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:38                                      ; preds = %5, %16
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Successfully read Buffer._Memmove
 
@@ -7914,7 +9431,7 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[loadElem]
+Failed to read AppDomain.SetDataHelper[storeElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -7923,8 +9440,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
@@ -7934,8 +9451,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
@@ -7947,15 +9464,15 @@ entry:
   %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
   %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
@@ -7966,15 +9483,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7992,7 +9509,79 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
-Failed to read Dictionary`2.TryGetValue[loadElemA]
+Successfully read Dictionary`2.TryGetValue
+
+define i8 @"Dictionary`2.TryGetValue"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)* addrspace(1)* %param2) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  %arg2 = alloca %System.__Canon addrspace(1)* addrspace(1)*
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  store %System.__Canon addrspace(1)* addrspace(1)* %param2, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  store i32 %2, i32* %loc0
+  %3 = load i32, i32* %loc0
+  %4 = icmp slt i32 %3, 0
+  br i1 %4, label %22, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 2
+  %10 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %9, align 8
+  %11 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = zext i32 %11 to i64
+  %BoundsCheck = icmp uge i64 %16, %15
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 3, i32 %11
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %20, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %6, %System.__Canon addrspace(1)* %21)
+  ret i8 1
+
+; <label>:22                                      ; preds = %entry
+  %23 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %23, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -8058,8 +9647,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
@@ -8091,8 +9680,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
@@ -8171,15 +9760,15 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck, label %19, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %ThrowNullRef, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
   %21 = load i32, i32 addrspace(1)* %20
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
@@ -8202,7 +9791,7 @@ ThrowNullRef:                                     ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %19
+ThrowNullRef2:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8248,8 +9837,8 @@ entry:
   %0 = alloca %System.AppDomainHandle
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %1 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %1, i32 0, i32 15
@@ -8269,8 +9858,8 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
@@ -8286,7 +9875,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -8299,8 +9888,8 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -8327,8 +9916,8 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
@@ -8352,8 +9941,8 @@ entry:
   %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
   store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
@@ -8363,8 +9952,8 @@ entry:
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
@@ -8374,8 +9963,8 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %9
   %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
@@ -8384,8 +9973,8 @@ entry:
 
 ; <label>:18                                      ; preds = %3, %16
   %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
@@ -8397,15 +9986,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %18
+ThrowNullRef6:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8418,8 +10007,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
@@ -8453,15 +10042,15 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
@@ -8473,7 +10062,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8481,7 +10070,7 @@ ThrowNullRef1:                                    ; preds = %1
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
 Failed to read Dictionary`2.System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
@@ -8506,8 +10095,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
@@ -8524,8 +10113,8 @@ entry:
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -8544,7 +10133,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8577,8 +10166,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = load i64, i64* %arg2
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = trunc i32 %3 to i8
@@ -8634,46 +10223,46 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
   %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
-  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
-  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
-  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
@@ -8684,27 +10273,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %20
+ThrowNullRef12:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8717,8 +10306,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -8756,22 +10345,22 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
   %9 = load i64, i64 addrspace(1)* %8, align 8
   %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
   %13 = load i64, i64 addrspace(1)* %12, align 8
   %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %11
   %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
@@ -8788,11 +10377,11 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8882,8 +10471,8 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
@@ -8900,8 +10489,8 @@ entry:
 ; <label>:8                                       ; preds = %1
   %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
   %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
@@ -8911,15 +10500,15 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
   %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
   %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
-  br i1 %NullCheck6, label %21, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
@@ -8946,15 +10535,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8992,15 +10581,15 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
   store i8 %3, i8 addrspace(1)* %5
   %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
@@ -9011,7 +10600,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9027,8 +10616,8 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -9041,8 +10630,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
@@ -9058,7 +10647,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9080,8 +10669,8 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
@@ -9096,8 +10685,8 @@ entry:
 ; <label>:12                                      ; preds = %6
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
@@ -9112,8 +10701,8 @@ entry:
 ; <label>:21                                      ; preds = %15
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
@@ -9128,8 +10717,8 @@ entry:
 ; <label>:30                                      ; preds = %24
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %31, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
@@ -9144,8 +10733,8 @@ entry:
 ; <label>:39                                      ; preds = %33
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
-  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %40, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %42
 
 ; <label>:42                                      ; preds = %39
   %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
@@ -9164,19 +10753,19 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %21
+ThrowNullRef4:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %30
+ThrowNullRef6:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %39
+ThrowNullRef8:                                    ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9243,8 +10832,8 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
@@ -9264,57 +10853,57 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
   store i8 0, i8 addrspace(1)* %2
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
   store i8 0, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
   store i8 0, i8 addrspace(1)* %17
   %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
   store i8 0, i8 addrspace(1)* %20
   %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
-  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
@@ -9325,31 +10914,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %19
+ThrowNullRef14:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9367,8 +10956,8 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
@@ -9380,8 +10969,8 @@ entry:
 
 ; <label>:9                                       ; preds = %4
   %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %9
   %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
@@ -9395,7 +10984,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef2:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9420,8 +11009,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
@@ -9512,8 +11101,8 @@ entry:
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
@@ -9524,8 +11113,8 @@ entry:
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = load i64, i64 addrspace(1)* %12
@@ -9537,8 +11126,8 @@ entry:
   %20 = load i64, i64* %19
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
-  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %13
   %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
@@ -9555,8 +11144,8 @@ entry:
 ; <label>:30                                      ; preds = %25
   %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %32 = load i32, i32* %arg2
-  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
-  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
@@ -9570,15 +11159,15 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %30
+ThrowNullRef2:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9622,87 +11211,87 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
   %10 = load i8, i8 addrspace(1)* %9, align 8
   %11 = zext i8 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %8
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
   store i8 %12, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
   %19 = load i8, i8 addrspace(1)* %18, align 8
   %20 = zext i8 %19 to i32
   %21 = trunc i32 %20 to i8
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
   store i8 %21, i8 addrspace(1)* %23
   %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
   %28 = load i8, i8 addrspace(1)* %27, align 8
   %29 = zext i8 %28 to i32
   %30 = trunc i32 %29 to i8
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
-  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %31
 
 ; <label>:31                                      ; preds = %26
   %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
   store i8 %30, i8 addrspace(1)* %32
   %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
-  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
-  br i1 %NullCheck14, label %40, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %40
 
 ; <label>:40                                      ; preds = %35
   %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
   store i8 %39, i8 addrspace(1)* %41
   %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
-  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %44
 
 ; <label>:44                                      ; preds = %40
   %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
   %46 = load i8, i8 addrspace(1)* %45, align 8
   %47 = zext i8 %46 to i32
   %48 = trunc i32 %47 to i8
-  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
   store i8 %48, i8 addrspace(1)* %50
   %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
-  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
@@ -9713,29 +11302,29 @@ entry:
 ; <label>:56                                      ; preds = %52
   %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
-  br i1 %NullCheck22, label %59, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
   %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
   %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
-  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
-  br i1 %NullCheck24, label %63, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
   %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
-  br i1 %NullCheck26, label %66, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
   %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
-  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
-  br i1 %NullCheck28, label %69, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %69
 
 ; <label>:69                                      ; preds = %66
   %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
@@ -9744,15 +11333,15 @@ entry:
 
 ; <label>:71                                      ; preds = %105
   %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
-  br i1 %NullCheck34, label %73, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %73
 
 ; <label>:73                                      ; preds = %71
   %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
   %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
   %76 = load i32, i32* %loc0
-  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
-  br i1 %NullCheck36, label %77, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
@@ -9766,8 +11355,8 @@ entry:
 
 ; <label>:83                                      ; preds = %77
   %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
-  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
@@ -9775,14 +11364,14 @@ entry:
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
   %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
-  br i1 %NullCheck40, label %91, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
 ; <label>:91                                      ; preds = %85
   %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
   %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
-  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck42, label %94, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %94
 
 ; <label>:94                                      ; preds = %91
   %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
@@ -9798,14 +11387,14 @@ entry:
 ; <label>:99                                      ; preds = %69, %96
   %100 = load i32, i32* %loc0
   %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
-  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %102
 
 ; <label>:102                                     ; preds = %99
   %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
   %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
-  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
-  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
@@ -9819,87 +11408,87 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %26
+ThrowNullRef10:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %31
+ThrowNullRef12:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %35
+ThrowNullRef14:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %40
+ThrowNullRef16:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %56
+ThrowNullRef22:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %59
+ThrowNullRef24:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %63
+ThrowNullRef26:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %66
+ThrowNullRef28:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %102
+ThrowNullRef32:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %71
+ThrowNullRef34:                                   ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %73
+ThrowNullRef36:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %83
+ThrowNullRef38:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %85
+ThrowNullRef40:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %91
+ThrowNullRef42:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9943,15 +11532,15 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
   %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
@@ -9961,28 +11550,28 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
   %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %12
   %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
   %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
   %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
-  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
@@ -9993,23 +11582,23 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %12
+ThrowNullRef6:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10031,15 +11620,15 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
   %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = load i64, i64 addrspace(1)* %7
@@ -10077,13 +11666,13 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[loadElem]
+Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -10111,8 +11700,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -10181,8 +11770,8 @@ entry:
   %arg0 = alloca i32 addrspace(1)*
   store i32 addrspace(1)* %param0, i32 addrspace(1)** %arg0
   %0 = load i32 addrspace(1)*, i32 addrspace(1)** %arg0
-  %NullCheck = icmp ne i32 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i32 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = load i32, i32 addrspace(1)* %0, align 8

--- a/test/BaseLine/JIT/CodeGenBringUpTests/rem1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/rem1.error.txt
@@ -25,8 +25,8 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
@@ -40,8 +40,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
   %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
@@ -75,7 +75,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -90,8 +90,8 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %NullCheck = icmp ne i8 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = load i8, i8 addrspace(1)* %0, align 8
@@ -125,8 +125,8 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
@@ -159,8 +159,8 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -184,8 +184,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
   store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
@@ -195,8 +195,8 @@ entry:
 ; <label>:4                                       ; preds = %1
   %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
   %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
@@ -206,8 +206,8 @@ entry:
   %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
@@ -221,14 +221,14 @@ entry:
 
 ; <label>:17                                      ; preds = %14
   %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
   %21 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
@@ -238,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -249,8 +249,8 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
@@ -261,27 +261,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %30
+ThrowNullRef10:                                   ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -301,7 +301,89 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
-Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
+Successfully read AppDomainSetup.GetUnsecureApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.GetUnsecureApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %NullCheck = icmp eq %"System.String[]" addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %BoundsCheck = icmp uge i64 0, %5
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %6
+
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 3, i32 0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
+  ret %System.String addrspace(1)* %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_Value using LLILCJit
+Successfully read AppDomainSetup.get_Value
+
+define %"System.String[]" addrspace(1)* @AppDomainSetup.get_Value(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.String[]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 18)
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.String[]" addrspace(1)* addrspace(1)*, %"System.String[]" addrspace(1)*)*)(%"System.String[]" addrspace(1)* addrspace(1)* %9, %"System.String[]" addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %11, i32 0, i32 1
+  %14 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %13, align 8
+  ret %"System.String[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -319,8 +401,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -368,16 +450,16 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
   %5 = load i32, i32 addrspace(1)* %4
   %6 = sub i32 %5, 1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -389,7 +471,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -421,8 +503,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
@@ -456,8 +538,8 @@ entry:
 ; <label>:27                                      ; preds = %19
   %28 = load i32, i32* %arg1
   %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
-  br i1 %NullCheck2, label %30, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %29, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %30
 
 ; <label>:30                                      ; preds = %27
   %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
@@ -493,8 +575,8 @@ entry:
 ; <label>:49                                      ; preds = %46
   %50 = load i32, i32* %arg2
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck4, label %52, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
@@ -517,11 +599,11 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %27
+ThrowNullRef2:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %49
+ThrowNullRef4:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -544,16 +626,16 @@ entry:
   %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %0)
   store %System.String addrspace(1)* %1, %System.String addrspace(1)** %loc0
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 2
   %5 = bitcast [0 x i16] addrspace(1)* %4 to i16 addrspace(1)*
   store i16 addrspace(1)* %5, i16 addrspace(1)** %loc1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %3
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2
@@ -580,7 +662,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -691,15 +773,15 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %NullCheck132 = icmp ne i8* %21, null
-  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+  %NullCheck131 = icmp eq i8* %21, null
+  br i1 %NullCheck131, label %ThrowNullRef132, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = load i8, i8* %21, align 8
   %24 = zext i8 %23 to i32
   %25 = trunc i32 %24 to i8
-  %NullCheck134 = icmp ne i8* %20, null
-  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+  %NullCheck133 = icmp eq i8* %20, null
+  br i1 %NullCheck133, label %ThrowNullRef134, label %26
 
 ; <label>:26                                      ; preds = %22
   store i8 %25, i8* %20, align 8
@@ -709,16 +791,16 @@ entry:
   %28 = load i8*, i8** %arg0
   %29 = load i8*, i8** %arg1
   %30 = bitcast i8* %29 to i16*
-  %NullCheck128 = icmp ne i16* %30, null
-  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+  %NullCheck127 = icmp eq i16* %30, null
+  br i1 %NullCheck127, label %ThrowNullRef128, label %31
 
 ; <label>:31                                      ; preds = %27
   %32 = load i16, i16* %30, align 8
   %33 = sext i16 %32 to i32
   %34 = bitcast i8* %28 to i16*
   %35 = trunc i32 %33 to i16
-  %NullCheck130 = icmp ne i16* %34, null
-  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+  %NullCheck129 = icmp eq i16* %34, null
+  br i1 %NullCheck129, label %ThrowNullRef130, label %36
 
 ; <label>:36                                      ; preds = %31
   store i16 %35, i16* %34, align 8
@@ -728,16 +810,16 @@ entry:
   %38 = load i8*, i8** %arg0
   %39 = load i8*, i8** %arg1
   %40 = bitcast i8* %39 to i16*
-  %NullCheck120 = icmp ne i16* %40, null
-  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+  %NullCheck119 = icmp eq i16* %40, null
+  br i1 %NullCheck119, label %ThrowNullRef120, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i16, i16* %40, align 8
   %43 = sext i16 %42 to i32
   %44 = bitcast i8* %38 to i16*
   %45 = trunc i32 %43 to i16
-  %NullCheck122 = icmp ne i16* %44, null
-  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+  %NullCheck121 = icmp eq i16* %44, null
+  br i1 %NullCheck121, label %ThrowNullRef122, label %46
 
 ; <label>:46                                      ; preds = %41
   store i16 %45, i16* %44, align 8
@@ -745,15 +827,15 @@ entry:
   %48 = getelementptr inbounds i8, i8* %47, i64 2
   %49 = load i8*, i8** %arg1
   %50 = getelementptr inbounds i8, i8* %49, i64 2
-  %NullCheck124 = icmp ne i8* %50, null
-  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+  %NullCheck123 = icmp eq i8* %50, null
+  br i1 %NullCheck123, label %ThrowNullRef124, label %51
 
 ; <label>:51                                      ; preds = %46
   %52 = load i8, i8* %50, align 8
   %53 = zext i8 %52 to i32
   %54 = trunc i32 %53 to i8
-  %NullCheck126 = icmp ne i8* %48, null
-  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+  %NullCheck125 = icmp eq i8* %48, null
+  br i1 %NullCheck125, label %ThrowNullRef126, label %55
 
 ; <label>:55                                      ; preds = %51
   store i8 %54, i8* %48, align 8
@@ -763,14 +845,14 @@ entry:
   %57 = load i8*, i8** %arg0
   %58 = load i8*, i8** %arg1
   %59 = bitcast i8* %58 to i32*
-  %NullCheck116 = icmp ne i32* %59, null
-  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+  %NullCheck115 = icmp eq i32* %59, null
+  br i1 %NullCheck115, label %ThrowNullRef116, label %60
 
 ; <label>:60                                      ; preds = %56
   %61 = load i32, i32* %59, align 8
   %62 = bitcast i8* %57 to i32*
-  %NullCheck118 = icmp ne i32* %62, null
-  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+  %NullCheck117 = icmp eq i32* %62, null
+  br i1 %NullCheck117, label %ThrowNullRef118, label %63
 
 ; <label>:63                                      ; preds = %60
   store i32 %61, i32* %62, align 8
@@ -780,14 +862,14 @@ entry:
   %65 = load i8*, i8** %arg0
   %66 = load i8*, i8** %arg1
   %67 = bitcast i8* %66 to i32*
-  %NullCheck108 = icmp ne i32* %67, null
-  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+  %NullCheck107 = icmp eq i32* %67, null
+  br i1 %NullCheck107, label %ThrowNullRef108, label %68
 
 ; <label>:68                                      ; preds = %64
   %69 = load i32, i32* %67, align 8
   %70 = bitcast i8* %65 to i32*
-  %NullCheck110 = icmp ne i32* %70, null
-  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+  %NullCheck109 = icmp eq i32* %70, null
+  br i1 %NullCheck109, label %ThrowNullRef110, label %71
 
 ; <label>:71                                      ; preds = %68
   store i32 %69, i32* %70, align 8
@@ -795,15 +877,15 @@ entry:
   %73 = getelementptr inbounds i8, i8* %72, i64 4
   %74 = load i8*, i8** %arg1
   %75 = getelementptr inbounds i8, i8* %74, i64 4
-  %NullCheck112 = icmp ne i8* %75, null
-  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+  %NullCheck111 = icmp eq i8* %75, null
+  br i1 %NullCheck111, label %ThrowNullRef112, label %76
 
 ; <label>:76                                      ; preds = %71
   %77 = load i8, i8* %75, align 8
   %78 = zext i8 %77 to i32
   %79 = trunc i32 %78 to i8
-  %NullCheck114 = icmp ne i8* %73, null
-  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+  %NullCheck113 = icmp eq i8* %73, null
+  br i1 %NullCheck113, label %ThrowNullRef114, label %80
 
 ; <label>:80                                      ; preds = %76
   store i8 %79, i8* %73, align 8
@@ -813,14 +895,14 @@ entry:
   %82 = load i8*, i8** %arg0
   %83 = load i8*, i8** %arg1
   %84 = bitcast i8* %83 to i32*
-  %NullCheck100 = icmp ne i32* %84, null
-  br i1 %NullCheck100, label %85, label %ThrowNullRef99
+  %NullCheck99 = icmp eq i32* %84, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %85
 
 ; <label>:85                                      ; preds = %81
   %86 = load i32, i32* %84, align 8
   %87 = bitcast i8* %82 to i32*
-  %NullCheck102 = icmp ne i32* %87, null
-  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+  %NullCheck101 = icmp eq i32* %87, null
+  br i1 %NullCheck101, label %ThrowNullRef102, label %88
 
 ; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
@@ -829,16 +911,16 @@ entry:
   %91 = load i8*, i8** %arg1
   %92 = getelementptr inbounds i8, i8* %91, i64 4
   %93 = bitcast i8* %92 to i16*
-  %NullCheck104 = icmp ne i16* %93, null
-  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+  %NullCheck103 = icmp eq i16* %93, null
+  br i1 %NullCheck103, label %ThrowNullRef104, label %94
 
 ; <label>:94                                      ; preds = %88
   %95 = load i16, i16* %93, align 8
   %96 = sext i16 %95 to i32
   %97 = bitcast i8* %90 to i16*
   %98 = trunc i32 %96 to i16
-  %NullCheck106 = icmp ne i16* %97, null
-  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+  %NullCheck105 = icmp eq i16* %97, null
+  br i1 %NullCheck105, label %ThrowNullRef106, label %99
 
 ; <label>:99                                      ; preds = %94
   store i16 %98, i16* %97, align 8
@@ -848,14 +930,14 @@ entry:
   %101 = load i8*, i8** %arg0
   %102 = load i8*, i8** %arg1
   %103 = bitcast i8* %102 to i32*
-  %NullCheck88 = icmp ne i32* %103, null
-  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+  %NullCheck87 = icmp eq i32* %103, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %104
 
 ; <label>:104                                     ; preds = %100
   %105 = load i32, i32* %103, align 8
   %106 = bitcast i8* %101 to i32*
-  %NullCheck90 = icmp ne i32* %106, null
-  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+  %NullCheck89 = icmp eq i32* %106, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %107
 
 ; <label>:107                                     ; preds = %104
   store i32 %105, i32* %106, align 8
@@ -864,16 +946,16 @@ entry:
   %110 = load i8*, i8** %arg1
   %111 = getelementptr inbounds i8, i8* %110, i64 4
   %112 = bitcast i8* %111 to i16*
-  %NullCheck92 = icmp ne i16* %112, null
-  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+  %NullCheck91 = icmp eq i16* %112, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %113
 
 ; <label>:113                                     ; preds = %107
   %114 = load i16, i16* %112, align 8
   %115 = sext i16 %114 to i32
   %116 = bitcast i8* %109 to i16*
   %117 = trunc i32 %115 to i16
-  %NullCheck94 = icmp ne i16* %116, null
-  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+  %NullCheck93 = icmp eq i16* %116, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %118
 
 ; <label>:118                                     ; preds = %113
   store i16 %117, i16* %116, align 8
@@ -881,15 +963,15 @@ entry:
   %120 = getelementptr inbounds i8, i8* %119, i64 6
   %121 = load i8*, i8** %arg1
   %122 = getelementptr inbounds i8, i8* %121, i64 6
-  %NullCheck96 = icmp ne i8* %122, null
-  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+  %NullCheck95 = icmp eq i8* %122, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %123
 
 ; <label>:123                                     ; preds = %118
   %124 = load i8, i8* %122, align 8
   %125 = zext i8 %124 to i32
   %126 = trunc i32 %125 to i8
-  %NullCheck98 = icmp ne i8* %120, null
-  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+  %NullCheck97 = icmp eq i8* %120, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %127
 
 ; <label>:127                                     ; preds = %123
   store i8 %126, i8* %120, align 8
@@ -899,14 +981,14 @@ entry:
   %129 = load i8*, i8** %arg0
   %130 = load i8*, i8** %arg1
   %131 = bitcast i8* %130 to i64*
-  %NullCheck84 = icmp ne i64* %131, null
-  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+  %NullCheck83 = icmp eq i64* %131, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %132
 
 ; <label>:132                                     ; preds = %128
   %133 = load i64, i64* %131, align 8
   %134 = bitcast i8* %129 to i64*
-  %NullCheck86 = icmp ne i64* %134, null
-  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+  %NullCheck85 = icmp eq i64* %134, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %135
 
 ; <label>:135                                     ; preds = %132
   store i64 %133, i64* %134, align 8
@@ -916,14 +998,14 @@ entry:
   %137 = load i8*, i8** %arg0
   %138 = load i8*, i8** %arg1
   %139 = bitcast i8* %138 to i64*
-  %NullCheck76 = icmp ne i64* %139, null
-  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+  %NullCheck75 = icmp eq i64* %139, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %140
 
 ; <label>:140                                     ; preds = %136
   %141 = load i64, i64* %139, align 8
   %142 = bitcast i8* %137 to i64*
-  %NullCheck78 = icmp ne i64* %142, null
-  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+  %NullCheck77 = icmp eq i64* %142, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %143
 
 ; <label>:143                                     ; preds = %140
   store i64 %141, i64* %142, align 8
@@ -931,15 +1013,15 @@ entry:
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %NullCheck80 = icmp ne i8* %147, null
-  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+  %NullCheck79 = icmp eq i8* %147, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %148
 
 ; <label>:148                                     ; preds = %143
   %149 = load i8, i8* %147, align 8
   %150 = zext i8 %149 to i32
   %151 = trunc i32 %150 to i8
-  %NullCheck82 = icmp ne i8* %145, null
-  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+  %NullCheck81 = icmp eq i8* %145, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %152
 
 ; <label>:152                                     ; preds = %148
   store i8 %151, i8* %145, align 8
@@ -949,14 +1031,14 @@ entry:
   %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
   %156 = bitcast i8* %155 to i64*
-  %NullCheck68 = icmp ne i64* %156, null
-  br i1 %NullCheck68, label %157, label %ThrowNullRef67
+  %NullCheck67 = icmp eq i64* %156, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %157
 
 ; <label>:157                                     ; preds = %153
   %158 = load i64, i64* %156, align 8
   %159 = bitcast i8* %154 to i64*
-  %NullCheck70 = icmp ne i64* %159, null
-  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+  %NullCheck69 = icmp eq i64* %159, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %160
 
 ; <label>:160                                     ; preds = %157
   store i64 %158, i64* %159, align 8
@@ -965,16 +1047,16 @@ entry:
   %163 = load i8*, i8** %arg1
   %164 = getelementptr inbounds i8, i8* %163, i64 8
   %165 = bitcast i8* %164 to i16*
-  %NullCheck72 = icmp ne i16* %165, null
-  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+  %NullCheck71 = icmp eq i16* %165, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %166
 
 ; <label>:166                                     ; preds = %160
   %167 = load i16, i16* %165, align 8
   %168 = sext i16 %167 to i32
   %169 = bitcast i8* %162 to i16*
   %170 = trunc i32 %168 to i16
-  %NullCheck74 = icmp ne i16* %169, null
-  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+  %NullCheck73 = icmp eq i16* %169, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %171
 
 ; <label>:171                                     ; preds = %166
   store i16 %170, i16* %169, align 8
@@ -984,14 +1066,14 @@ entry:
   %173 = load i8*, i8** %arg0
   %174 = load i8*, i8** %arg1
   %175 = bitcast i8* %174 to i64*
-  %NullCheck56 = icmp ne i64* %175, null
-  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+  %NullCheck55 = icmp eq i64* %175, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %176
 
 ; <label>:176                                     ; preds = %172
   %177 = load i64, i64* %175, align 8
   %178 = bitcast i8* %173 to i64*
-  %NullCheck58 = icmp ne i64* %178, null
-  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+  %NullCheck57 = icmp eq i64* %178, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %179
 
 ; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
@@ -1000,16 +1082,16 @@ entry:
   %182 = load i8*, i8** %arg1
   %183 = getelementptr inbounds i8, i8* %182, i64 8
   %184 = bitcast i8* %183 to i16*
-  %NullCheck60 = icmp ne i16* %184, null
-  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+  %NullCheck59 = icmp eq i16* %184, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %185
 
 ; <label>:185                                     ; preds = %179
   %186 = load i16, i16* %184, align 8
   %187 = sext i16 %186 to i32
   %188 = bitcast i8* %181 to i16*
   %189 = trunc i32 %187 to i16
-  %NullCheck62 = icmp ne i16* %188, null
-  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+  %NullCheck61 = icmp eq i16* %188, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %190
 
 ; <label>:190                                     ; preds = %185
   store i16 %189, i16* %188, align 8
@@ -1017,15 +1099,15 @@ entry:
   %192 = getelementptr inbounds i8, i8* %191, i64 10
   %193 = load i8*, i8** %arg1
   %194 = getelementptr inbounds i8, i8* %193, i64 10
-  %NullCheck64 = icmp ne i8* %194, null
-  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+  %NullCheck63 = icmp eq i8* %194, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %195
 
 ; <label>:195                                     ; preds = %190
   %196 = load i8, i8* %194, align 8
   %197 = zext i8 %196 to i32
   %198 = trunc i32 %197 to i8
-  %NullCheck66 = icmp ne i8* %192, null
-  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+  %NullCheck65 = icmp eq i8* %192, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %199
 
 ; <label>:199                                     ; preds = %195
   store i8 %198, i8* %192, align 8
@@ -1035,14 +1117,14 @@ entry:
   %201 = load i8*, i8** %arg0
   %202 = load i8*, i8** %arg1
   %203 = bitcast i8* %202 to i64*
-  %NullCheck48 = icmp ne i64* %203, null
-  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+  %NullCheck47 = icmp eq i64* %203, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %204
 
 ; <label>:204                                     ; preds = %200
   %205 = load i64, i64* %203, align 8
   %206 = bitcast i8* %201 to i64*
-  %NullCheck50 = icmp ne i64* %206, null
-  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+  %NullCheck49 = icmp eq i64* %206, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %207
 
 ; <label>:207                                     ; preds = %204
   store i64 %205, i64* %206, align 8
@@ -1051,14 +1133,14 @@ entry:
   %210 = load i8*, i8** %arg1
   %211 = getelementptr inbounds i8, i8* %210, i64 8
   %212 = bitcast i8* %211 to i32*
-  %NullCheck52 = icmp ne i32* %212, null
-  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+  %NullCheck51 = icmp eq i32* %212, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %213
 
 ; <label>:213                                     ; preds = %207
   %214 = load i32, i32* %212, align 8
   %215 = bitcast i8* %209 to i32*
-  %NullCheck54 = icmp ne i32* %215, null
-  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+  %NullCheck53 = icmp eq i32* %215, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %216
 
 ; <label>:216                                     ; preds = %213
   store i32 %214, i32* %215, align 8
@@ -1068,14 +1150,14 @@ entry:
   %218 = load i8*, i8** %arg0
   %219 = load i8*, i8** %arg1
   %220 = bitcast i8* %219 to i64*
-  %NullCheck36 = icmp ne i64* %220, null
-  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64* %220, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %221
 
 ; <label>:221                                     ; preds = %217
   %222 = load i64, i64* %220, align 8
   %223 = bitcast i8* %218 to i64*
-  %NullCheck38 = icmp ne i64* %223, null
-  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+  %NullCheck37 = icmp eq i64* %223, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %224
 
 ; <label>:224                                     ; preds = %221
   store i64 %222, i64* %223, align 8
@@ -1084,14 +1166,14 @@ entry:
   %227 = load i8*, i8** %arg1
   %228 = getelementptr inbounds i8, i8* %227, i64 8
   %229 = bitcast i8* %228 to i32*
-  %NullCheck40 = icmp ne i32* %229, null
-  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i32* %229, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %230
 
 ; <label>:230                                     ; preds = %224
   %231 = load i32, i32* %229, align 8
   %232 = bitcast i8* %226 to i32*
-  %NullCheck42 = icmp ne i32* %232, null
-  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+  %NullCheck41 = icmp eq i32* %232, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %233
 
 ; <label>:233                                     ; preds = %230
   store i32 %231, i32* %232, align 8
@@ -1099,15 +1181,15 @@ entry:
   %235 = getelementptr inbounds i8, i8* %234, i64 12
   %236 = load i8*, i8** %arg1
   %237 = getelementptr inbounds i8, i8* %236, i64 12
-  %NullCheck44 = icmp ne i8* %237, null
-  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i8* %237, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %238
 
 ; <label>:238                                     ; preds = %233
   %239 = load i8, i8* %237, align 8
   %240 = zext i8 %239 to i32
   %241 = trunc i32 %240 to i8
-  %NullCheck46 = icmp ne i8* %235, null
-  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+  %NullCheck45 = icmp eq i8* %235, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %242
 
 ; <label>:242                                     ; preds = %238
   store i8 %241, i8* %235, align 8
@@ -1117,14 +1199,14 @@ entry:
   %244 = load i8*, i8** %arg0
   %245 = load i8*, i8** %arg1
   %246 = bitcast i8* %245 to i64*
-  %NullCheck24 = icmp ne i64* %246, null
-  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64* %246, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %247
 
 ; <label>:247                                     ; preds = %243
   %248 = load i64, i64* %246, align 8
   %249 = bitcast i8* %244 to i64*
-  %NullCheck26 = icmp ne i64* %249, null
-  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64* %249, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %250
 
 ; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
@@ -1133,14 +1215,14 @@ entry:
   %253 = load i8*, i8** %arg1
   %254 = getelementptr inbounds i8, i8* %253, i64 8
   %255 = bitcast i8* %254 to i32*
-  %NullCheck28 = icmp ne i32* %255, null
-  br i1 %NullCheck28, label %256, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i32* %255, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %256
 
 ; <label>:256                                     ; preds = %250
   %257 = load i32, i32* %255, align 8
   %258 = bitcast i8* %252 to i32*
-  %NullCheck30 = icmp ne i32* %258, null
-  br i1 %NullCheck30, label %259, label %ThrowNullRef29
+  %NullCheck29 = icmp eq i32* %258, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %259
 
 ; <label>:259                                     ; preds = %256
   store i32 %257, i32* %258, align 8
@@ -1149,16 +1231,16 @@ entry:
   %262 = load i8*, i8** %arg1
   %263 = getelementptr inbounds i8, i8* %262, i64 12
   %264 = bitcast i8* %263 to i16*
-  %NullCheck32 = icmp ne i16* %264, null
-  br i1 %NullCheck32, label %265, label %ThrowNullRef31
+  %NullCheck31 = icmp eq i16* %264, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %265
 
 ; <label>:265                                     ; preds = %259
   %266 = load i16, i16* %264, align 8
   %267 = sext i16 %266 to i32
   %268 = bitcast i8* %261 to i16*
   %269 = trunc i32 %267 to i16
-  %NullCheck34 = icmp ne i16* %268, null
-  br i1 %NullCheck34, label %270, label %ThrowNullRef33
+  %NullCheck33 = icmp eq i16* %268, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %270
 
 ; <label>:270                                     ; preds = %265
   store i16 %269, i16* %268, align 8
@@ -1168,14 +1250,14 @@ entry:
   %272 = load i8*, i8** %arg0
   %273 = load i8*, i8** %arg1
   %274 = bitcast i8* %273 to i64*
-  %NullCheck8 = icmp ne i64* %274, null
-  br i1 %NullCheck8, label %275, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64* %274, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %275
 
 ; <label>:275                                     ; preds = %271
   %276 = load i64, i64* %274, align 8
   %277 = bitcast i8* %272 to i64*
-  %NullCheck10 = icmp ne i64* %277, null
-  br i1 %NullCheck10, label %278, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %277, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %278
 
 ; <label>:278                                     ; preds = %275
   store i64 %276, i64* %277, align 8
@@ -1184,14 +1266,14 @@ entry:
   %281 = load i8*, i8** %arg1
   %282 = getelementptr inbounds i8, i8* %281, i64 8
   %283 = bitcast i8* %282 to i32*
-  %NullCheck12 = icmp ne i32* %283, null
-  br i1 %NullCheck12, label %284, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i32* %283, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %284
 
 ; <label>:284                                     ; preds = %278
   %285 = load i32, i32* %283, align 8
   %286 = bitcast i8* %280 to i32*
-  %NullCheck14 = icmp ne i32* %286, null
-  br i1 %NullCheck14, label %287, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i32* %286, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %287
 
 ; <label>:287                                     ; preds = %284
   store i32 %285, i32* %286, align 8
@@ -1200,16 +1282,16 @@ entry:
   %290 = load i8*, i8** %arg1
   %291 = getelementptr inbounds i8, i8* %290, i64 12
   %292 = bitcast i8* %291 to i16*
-  %NullCheck16 = icmp ne i16* %292, null
-  br i1 %NullCheck16, label %293, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i16* %292, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %293
 
 ; <label>:293                                     ; preds = %287
   %294 = load i16, i16* %292, align 8
   %295 = sext i16 %294 to i32
   %296 = bitcast i8* %289 to i16*
   %297 = trunc i32 %295 to i16
-  %NullCheck18 = icmp ne i16* %296, null
-  br i1 %NullCheck18, label %298, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i16* %296, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %298
 
 ; <label>:298                                     ; preds = %293
   store i16 %297, i16* %296, align 8
@@ -1217,15 +1299,15 @@ entry:
   %300 = getelementptr inbounds i8, i8* %299, i64 14
   %301 = load i8*, i8** %arg1
   %302 = getelementptr inbounds i8, i8* %301, i64 14
-  %NullCheck20 = icmp ne i8* %302, null
-  br i1 %NullCheck20, label %303, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i8* %302, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %303
 
 ; <label>:303                                     ; preds = %298
   %304 = load i8, i8* %302, align 8
   %305 = zext i8 %304 to i32
   %306 = trunc i32 %305 to i8
-  %NullCheck22 = icmp ne i8* %300, null
-  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i8* %300, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %307
 
 ; <label>:307                                     ; preds = %303
   store i8 %306, i8* %300, align 8
@@ -1235,14 +1317,14 @@ entry:
   %309 = load i8*, i8** %arg0
   %310 = load i8*, i8** %arg1
   %311 = bitcast i8* %310 to i64*
-  %NullCheck = icmp ne i64* %311, null
-  br i1 %NullCheck, label %312, label %ThrowNullRef
+  %NullCheck = icmp eq i64* %311, null
+  br i1 %NullCheck, label %ThrowNullRef, label %312
 
 ; <label>:312                                     ; preds = %308
   %313 = load i64, i64* %311, align 8
   %314 = bitcast i8* %309 to i64*
-  %NullCheck2 = icmp ne i64* %314, null
-  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64* %314, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %315
 
 ; <label>:315                                     ; preds = %312
   store i64 %313, i64* %314, align 8
@@ -1251,14 +1333,14 @@ entry:
   %318 = load i8*, i8** %arg1
   %319 = getelementptr inbounds i8, i8* %318, i64 8
   %320 = bitcast i8* %319 to i64*
-  %NullCheck4 = icmp ne i64* %320, null
-  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64* %320, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %321
 
 ; <label>:321                                     ; preds = %315
   %322 = load i64, i64* %320, align 8
   %323 = bitcast i8* %317 to i64*
-  %NullCheck6 = icmp ne i64* %323, null
-  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64* %323, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %324
 
 ; <label>:324                                     ; preds = %321
   store i64 %322, i64* %323, align 8
@@ -1286,15 +1368,15 @@ entry:
 ; <label>:338                                     ; preds = %333
   %339 = load i8*, i8** %arg0
   %340 = load i8*, i8** %arg1
-  %NullCheck136 = icmp ne i8* %340, null
-  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+  %NullCheck135 = icmp eq i8* %340, null
+  br i1 %NullCheck135, label %ThrowNullRef136, label %341
 
 ; <label>:341                                     ; preds = %338
   %342 = load i8, i8* %340, align 8
   %343 = zext i8 %342 to i32
   %344 = trunc i32 %343 to i8
-  %NullCheck138 = icmp ne i8* %339, null
-  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+  %NullCheck137 = icmp eq i8* %339, null
+  br i1 %NullCheck137, label %ThrowNullRef138, label %345
 
 ; <label>:345                                     ; preds = %341
   store i8 %344, i8* %339, align 8
@@ -1317,16 +1399,16 @@ entry:
   %357 = load i8*, i8** %arg0
   %358 = load i8*, i8** %arg1
   %359 = bitcast i8* %358 to i16*
-  %NullCheck140 = icmp ne i16* %359, null
-  br i1 %NullCheck140, label %360, label %ThrowNullRef139
+  %NullCheck139 = icmp eq i16* %359, null
+  br i1 %NullCheck139, label %ThrowNullRef140, label %360
 
 ; <label>:360                                     ; preds = %356
   %361 = load i16, i16* %359, align 8
   %362 = sext i16 %361 to i32
   %363 = bitcast i8* %357 to i16*
   %364 = trunc i32 %362 to i16
-  %NullCheck142 = icmp ne i16* %363, null
-  br i1 %NullCheck142, label %365, label %ThrowNullRef141
+  %NullCheck141 = icmp eq i16* %363, null
+  br i1 %NullCheck141, label %ThrowNullRef142, label %365
 
 ; <label>:365                                     ; preds = %360
   store i16 %364, i16* %363, align 8
@@ -1352,14 +1434,14 @@ entry:
   %378 = load i8*, i8** %arg0
   %379 = load i8*, i8** %arg1
   %380 = bitcast i8* %379 to i32*
-  %NullCheck144 = icmp ne i32* %380, null
-  br i1 %NullCheck144, label %381, label %ThrowNullRef143
+  %NullCheck143 = icmp eq i32* %380, null
+  br i1 %NullCheck143, label %ThrowNullRef144, label %381
 
 ; <label>:381                                     ; preds = %377
   %382 = load i32, i32* %380, align 8
   %383 = bitcast i8* %378 to i32*
-  %NullCheck146 = icmp ne i32* %383, null
-  br i1 %NullCheck146, label %384, label %ThrowNullRef145
+  %NullCheck145 = icmp eq i32* %383, null
+  br i1 %NullCheck145, label %ThrowNullRef146, label %384
 
 ; <label>:384                                     ; preds = %381
   store i32 %382, i32* %383, align 8
@@ -1384,14 +1466,14 @@ entry:
   %395 = load i8*, i8** %arg0
   %396 = load i8*, i8** %arg1
   %397 = bitcast i8* %396 to i64*
-  %NullCheck164 = icmp ne i64* %397, null
-  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+  %NullCheck163 = icmp eq i64* %397, null
+  br i1 %NullCheck163, label %ThrowNullRef164, label %398
 
 ; <label>:398                                     ; preds = %394
   %399 = load i64, i64* %397, align 8
   %400 = bitcast i8* %395 to i64*
-  %NullCheck166 = icmp ne i64* %400, null
-  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+  %NullCheck165 = icmp eq i64* %400, null
+  br i1 %NullCheck165, label %ThrowNullRef166, label %401
 
 ; <label>:401                                     ; preds = %398
   store i64 %399, i64* %400, align 8
@@ -1400,14 +1482,14 @@ entry:
   %404 = load i8*, i8** %arg1
   %405 = getelementptr inbounds i8, i8* %404, i64 8
   %406 = bitcast i8* %405 to i64*
-  %NullCheck168 = icmp ne i64* %406, null
-  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+  %NullCheck167 = icmp eq i64* %406, null
+  br i1 %NullCheck167, label %ThrowNullRef168, label %407
 
 ; <label>:407                                     ; preds = %401
   %408 = load i64, i64* %406, align 8
   %409 = bitcast i8* %403 to i64*
-  %NullCheck170 = icmp ne i64* %409, null
-  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+  %NullCheck169 = icmp eq i64* %409, null
+  br i1 %NullCheck169, label %ThrowNullRef170, label %410
 
 ; <label>:410                                     ; preds = %407
   store i64 %408, i64* %409, align 8
@@ -1437,14 +1519,14 @@ entry:
   %425 = load i8*, i8** %arg0
   %426 = load i8*, i8** %arg1
   %427 = bitcast i8* %426 to i64*
-  %NullCheck148 = icmp ne i64* %427, null
-  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+  %NullCheck147 = icmp eq i64* %427, null
+  br i1 %NullCheck147, label %ThrowNullRef148, label %428
 
 ; <label>:428                                     ; preds = %424
   %429 = load i64, i64* %427, align 8
   %430 = bitcast i8* %425 to i64*
-  %NullCheck150 = icmp ne i64* %430, null
-  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+  %NullCheck149 = icmp eq i64* %430, null
+  br i1 %NullCheck149, label %ThrowNullRef150, label %431
 
 ; <label>:431                                     ; preds = %428
   store i64 %429, i64* %430, align 8
@@ -1466,14 +1548,14 @@ entry:
   %441 = load i8*, i8** %arg0
   %442 = load i8*, i8** %arg1
   %443 = bitcast i8* %442 to i32*
-  %NullCheck152 = icmp ne i32* %443, null
-  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+  %NullCheck151 = icmp eq i32* %443, null
+  br i1 %NullCheck151, label %ThrowNullRef152, label %444
 
 ; <label>:444                                     ; preds = %440
   %445 = load i32, i32* %443, align 8
   %446 = bitcast i8* %441 to i32*
-  %NullCheck154 = icmp ne i32* %446, null
-  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+  %NullCheck153 = icmp eq i32* %446, null
+  br i1 %NullCheck153, label %ThrowNullRef154, label %447
 
 ; <label>:447                                     ; preds = %444
   store i32 %445, i32* %446, align 8
@@ -1495,16 +1577,16 @@ entry:
   %457 = load i8*, i8** %arg0
   %458 = load i8*, i8** %arg1
   %459 = bitcast i8* %458 to i16*
-  %NullCheck156 = icmp ne i16* %459, null
-  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+  %NullCheck155 = icmp eq i16* %459, null
+  br i1 %NullCheck155, label %ThrowNullRef156, label %460
 
 ; <label>:460                                     ; preds = %456
   %461 = load i16, i16* %459, align 8
   %462 = sext i16 %461 to i32
   %463 = bitcast i8* %457 to i16*
   %464 = trunc i32 %462 to i16
-  %NullCheck158 = icmp ne i16* %463, null
-  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+  %NullCheck157 = icmp eq i16* %463, null
+  br i1 %NullCheck157, label %ThrowNullRef158, label %465
 
 ; <label>:465                                     ; preds = %460
   store i16 %464, i16* %463, align 8
@@ -1525,15 +1607,15 @@ entry:
 ; <label>:474                                     ; preds = %470
   %475 = load i8*, i8** %arg0
   %476 = load i8*, i8** %arg1
-  %NullCheck160 = icmp ne i8* %476, null
-  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+  %NullCheck159 = icmp eq i8* %476, null
+  br i1 %NullCheck159, label %ThrowNullRef160, label %477
 
 ; <label>:477                                     ; preds = %474
   %478 = load i8, i8* %476, align 8
   %479 = zext i8 %478 to i32
   %480 = trunc i32 %479 to i8
-  %NullCheck162 = icmp ne i8* %475, null
-  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+  %NullCheck161 = icmp eq i8* %475, null
+  br i1 %NullCheck161, label %ThrowNullRef162, label %481
 
 ; <label>:481                                     ; preds = %477
   store i8 %480, i8* %475, align 8
@@ -1553,343 +1635,343 @@ ThrowNullRef:                                     ; preds = %308
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %312
+ThrowNullRef2:                                    ; preds = %312
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %315
+ThrowNullRef4:                                    ; preds = %315
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %321
+ThrowNullRef6:                                    ; preds = %321
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %271
+ThrowNullRef8:                                    ; preds = %271
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %275
+ThrowNullRef10:                                   ; preds = %275
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %278
+ThrowNullRef12:                                   ; preds = %278
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %284
+ThrowNullRef14:                                   ; preds = %284
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %287
+ThrowNullRef16:                                   ; preds = %287
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %293
+ThrowNullRef18:                                   ; preds = %293
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %298
+ThrowNullRef20:                                   ; preds = %298
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %303
+ThrowNullRef22:                                   ; preds = %303
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %243
+ThrowNullRef24:                                   ; preds = %243
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %247
+ThrowNullRef26:                                   ; preds = %247
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %250
+ThrowNullRef28:                                   ; preds = %250
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %256
+ThrowNullRef30:                                   ; preds = %256
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %259
+ThrowNullRef32:                                   ; preds = %259
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %265
+ThrowNullRef34:                                   ; preds = %265
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %217
+ThrowNullRef36:                                   ; preds = %217
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %221
+ThrowNullRef38:                                   ; preds = %221
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %224
+ThrowNullRef40:                                   ; preds = %224
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %230
+ThrowNullRef42:                                   ; preds = %230
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %233
+ThrowNullRef44:                                   ; preds = %233
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %238
+ThrowNullRef46:                                   ; preds = %238
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %200
+ThrowNullRef48:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %204
+ThrowNullRef50:                                   ; preds = %204
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %207
+ThrowNullRef52:                                   ; preds = %207
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %213
+ThrowNullRef54:                                   ; preds = %213
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %172
+ThrowNullRef56:                                   ; preds = %172
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %176
+ThrowNullRef58:                                   ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %179
+ThrowNullRef60:                                   ; preds = %179
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %185
+ThrowNullRef62:                                   ; preds = %185
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %190
+ThrowNullRef64:                                   ; preds = %190
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %195
+ThrowNullRef66:                                   ; preds = %195
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %153
+ThrowNullRef68:                                   ; preds = %153
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %157
+ThrowNullRef70:                                   ; preds = %157
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %160
+ThrowNullRef72:                                   ; preds = %160
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %166
+ThrowNullRef74:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %136
+ThrowNullRef76:                                   ; preds = %136
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %140
+ThrowNullRef78:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %143
+ThrowNullRef80:                                   ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %148
+ThrowNullRef82:                                   ; preds = %148
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %128
+ThrowNullRef84:                                   ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %132
+ThrowNullRef86:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %100
+ThrowNullRef88:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %104
+ThrowNullRef90:                                   ; preds = %104
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %107
+ThrowNullRef92:                                   ; preds = %107
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %113
+ThrowNullRef94:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %118
+ThrowNullRef96:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %123
+ThrowNullRef98:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %81
+ThrowNullRef100:                                  ; preds = %81
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef101:                                  ; preds = %85
+ThrowNullRef102:                                  ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef103:                                  ; preds = %88
+ThrowNullRef104:                                  ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef105:                                  ; preds = %94
+ThrowNullRef106:                                  ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef107:                                  ; preds = %64
+ThrowNullRef108:                                  ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef109:                                  ; preds = %68
+ThrowNullRef110:                                  ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef111:                                  ; preds = %71
+ThrowNullRef112:                                  ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef113:                                  ; preds = %76
+ThrowNullRef114:                                  ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef115:                                  ; preds = %56
+ThrowNullRef116:                                  ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef117:                                  ; preds = %60
+ThrowNullRef118:                                  ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef119:                                  ; preds = %37
+ThrowNullRef120:                                  ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef121:                                  ; preds = %41
+ThrowNullRef122:                                  ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef123:                                  ; preds = %46
+ThrowNullRef124:                                  ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef125:                                  ; preds = %51
+ThrowNullRef126:                                  ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef127:                                  ; preds = %27
+ThrowNullRef128:                                  ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef129:                                  ; preds = %31
+ThrowNullRef130:                                  ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef131:                                  ; preds = %19
+ThrowNullRef132:                                  ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef133:                                  ; preds = %22
+ThrowNullRef134:                                  ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef135:                                  ; preds = %338
+ThrowNullRef136:                                  ; preds = %338
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef137:                                  ; preds = %341
+ThrowNullRef138:                                  ; preds = %341
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef139:                                  ; preds = %356
+ThrowNullRef140:                                  ; preds = %356
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef141:                                  ; preds = %360
+ThrowNullRef142:                                  ; preds = %360
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef143:                                  ; preds = %377
+ThrowNullRef144:                                  ; preds = %377
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef145:                                  ; preds = %381
+ThrowNullRef146:                                  ; preds = %381
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef147:                                  ; preds = %424
+ThrowNullRef148:                                  ; preds = %424
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef149:                                  ; preds = %428
+ThrowNullRef150:                                  ; preds = %428
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef151:                                  ; preds = %440
+ThrowNullRef152:                                  ; preds = %440
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef153:                                  ; preds = %444
+ThrowNullRef154:                                  ; preds = %444
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef155:                                  ; preds = %456
+ThrowNullRef156:                                  ; preds = %456
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef157:                                  ; preds = %460
+ThrowNullRef158:                                  ; preds = %460
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef159:                                  ; preds = %474
+ThrowNullRef160:                                  ; preds = %474
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef161:                                  ; preds = %477
+ThrowNullRef162:                                  ; preds = %477
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef163:                                  ; preds = %394
+ThrowNullRef164:                                  ; preds = %394
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef165:                                  ; preds = %398
+ThrowNullRef166:                                  ; preds = %398
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef167:                                  ; preds = %401
+ThrowNullRef168:                                  ; preds = %401
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef169:                                  ; preds = %407
+ThrowNullRef170:                                  ; preds = %407
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1939,8 +2021,8 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
-  br i1 %NullCheck, label %22, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %ThrowNullRef, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
@@ -1948,8 +2030,8 @@ entry:
   store i32 %24, i32* %loc0
   %25 = load i32, i32* %loc0
   %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %26, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %27
 
 ; <label>:27                                      ; preds = %22
   %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
@@ -1971,7 +2053,7 @@ ThrowNullRef:                                     ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1989,8 +2071,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -2022,15 +2104,15 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2048,16 +2130,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
   %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
   store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %15
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
@@ -2072,8 +2154,8 @@ entry:
   %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
   %29 = ptrtoint i16 addrspace(1)* %28 to i64
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %19
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
@@ -2089,19 +2171,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2114,8 +2196,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
@@ -2128,7 +2210,7 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[loadElem]
+Failed to read AppDomain.PrepareDataForSetup[storeElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
@@ -2202,8 +2284,8 @@ entry:
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
-  br i1 %NullCheck24, label %27, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = load i64, i64 addrspace(1)* %26
@@ -2218,8 +2300,8 @@ entry:
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
-  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
   %41 = load i64, i64 addrspace(1)* %39
@@ -2236,8 +2318,8 @@ entry:
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
-  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
   %54 = load i64, i64 addrspace(1)* %52
@@ -2252,8 +2334,8 @@ entry:
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
   %67 = load i64, i64 addrspace(1)* %65
@@ -2270,8 +2352,8 @@ entry:
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
-  br i1 %NullCheck16, label %79, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
   %80 = load i64, i64 addrspace(1)* %78
@@ -2286,8 +2368,8 @@ entry:
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
-  br i1 %NullCheck18, label %92, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
   %93 = load i64, i64 addrspace(1)* %91
@@ -2304,8 +2386,8 @@ entry:
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
-  br i1 %NullCheck12, label %105, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = load i64, i64 addrspace(1)* %104
@@ -2320,8 +2402,8 @@ entry:
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
-  br i1 %NullCheck14, label %118, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
   %119 = load i64, i64 addrspace(1)* %117
@@ -2337,8 +2419,8 @@ entry:
 
 ; <label>:128                                     ; preds = %20
   %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
-  br i1 %NullCheck4, label %130, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %129, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %130
 
 ; <label>:130                                     ; preds = %128
   %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
@@ -2346,8 +2428,8 @@ entry:
   %133 = load i16, i16 addrspace(1)* %132, align 8
   %134 = zext i16 %133 to i32
   %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
-  br i1 %NullCheck6, label %136, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %135, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %136
 
 ; <label>:136                                     ; preds = %130
   %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
@@ -2360,8 +2442,8 @@ entry:
 
 ; <label>:143                                     ; preds = %136
   %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
-  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %144, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %145
 
 ; <label>:145                                     ; preds = %143
   %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
@@ -2369,8 +2451,8 @@ entry:
   %148 = load i16, i16 addrspace(1)* %147, align 8
   %149 = zext i16 %148 to i32
   %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %150, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %151
 
 ; <label>:151                                     ; preds = %145
   %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
@@ -2388,8 +2470,8 @@ entry:
 
 ; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
-  br i1 %NullCheck, label %163, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %ThrowNullRef, label %163
 
 ; <label>:163                                     ; preds = %161
   %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
@@ -2399,8 +2481,8 @@ entry:
 
 ; <label>:167                                     ; preds = %163
   %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
-  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %168, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %169
 
 ; <label>:169                                     ; preds = %167
   %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
@@ -2432,55 +2514,55 @@ ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %167
+ThrowNullRef2:                                    ; preds = %167
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %128
+ThrowNullRef4:                                    ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %130
+ThrowNullRef6:                                    ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %143
+ThrowNullRef8:                                    ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %145
+ThrowNullRef10:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %102
+ThrowNullRef12:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %105
+ThrowNullRef14:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %76
+ThrowNullRef16:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %79
+ThrowNullRef18:                                   ; preds = %79
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %50
+ThrowNullRef20:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %53
+ThrowNullRef22:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %24
+ThrowNullRef24:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %27
+ThrowNullRef26:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2503,15 +2585,15 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2519,16 +2601,16 @@ entry:
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
   store i32 %8, i32* %loc0
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
   %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
   store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
@@ -2546,16 +2628,16 @@ entry:
 
 ; <label>:23                                      ; preds = %64
   %24 = load i16*, i16** %loc3
-  %NullCheck12 = icmp ne i16* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i16* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
   store i32 %27, i32* %loc5
   %28 = load i16*, i16** %loc4
-  %NullCheck14 = icmp ne i16* %28, null
-  br i1 %NullCheck14, label %29, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %28, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = load i16, i16* %28, align 8
@@ -2620,15 +2702,15 @@ entry:
 
 ; <label>:67                                      ; preds = %64
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
-  br i1 %NullCheck8, label %69, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %68, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %69
 
 ; <label>:69                                      ; preds = %67
   %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
   %71 = load i32, i32 addrspace(1)* %70
   %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
-  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %73
 
 ; <label>:73                                      ; preds = %69
   %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
@@ -2645,31 +2727,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %67
+ThrowNullRef8:                                    ; preds = %67
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %69
+ThrowNullRef10:                                   ; preds = %69
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2710,14 +2792,14 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
   %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
@@ -2730,14 +2812,14 @@ entry:
 
 ; <label>:11                                      ; preds = %4
   %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
   %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
@@ -2749,14 +2831,14 @@ entry:
 
 ; <label>:22                                      ; preds = %16
   %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
   %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
-  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
-  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
@@ -2804,23 +2886,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2836,7 +2918,280 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[loadElem]
+Successfully read RuntimeType.IsAssignableFrom
+
+define i8 @RuntimeType.IsAssignableFrom(%System.RuntimeType addrspace(1)* %param0, %System.Type addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.RuntimeType addrspace(1)*
+  %arg1 = alloca %System.Type addrspace(1)*
+  %loc0 = alloca %System.RuntimeType addrspace(1)*
+  %loc1 = alloca %"System.Type[]" addrspace(1)*
+  %loc2 = alloca i32
+  store %System.RuntimeType addrspace(1)* %param0, %System.RuntimeType addrspace(1)** %this
+  store %System.Type addrspace(1)* %param1, %System.Type addrspace(1)** %arg1
+  %0 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %1 = icmp ne %System.Type addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i8 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %5 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %6 = bitcast %System.Type addrspace(1)* %4 to %System.Object addrspace(1)*
+  %7 = bitcast %System.RuntimeType addrspace(1)* %5 to %System.Object addrspace(1)*
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %6, %System.Object addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %3
+  ret i8 1
+
+; <label>:12                                      ; preds = %3
+  %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 152
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 32
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
+  %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
+  %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
+  store %System.RuntimeType addrspace(1)* %25, %System.RuntimeType addrspace(1)** %loc0
+  %26 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %27 = icmp eq %System.RuntimeType addrspace(1)* %26, null
+  br i1 %27, label %34, label %28
+
+; <label>:28                                      ; preds = %15
+  %29 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %30 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)*)*)(%System.RuntimeType addrspace(1)* %29, %System.RuntimeType addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+; <label>:34                                      ; preds = %15
+  %35 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %36 = call %System.Reflection.Emit.TypeBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Reflection.Emit.TypeBuilder addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %35)
+  %37 = icmp eq %System.Reflection.Emit.TypeBuilder addrspace(1)* %36, null
+  br i1 %37, label %139, label %38
+
+; <label>:38                                      ; preds = %34
+  %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %42
+
+; <label>:42                                      ; preds = %38
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 152
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 40
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
+  %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
+  %53 = zext i8 %52 to i32
+  %54 = icmp eq i32 %53, 0
+  br i1 %54, label %56, label %55
+
+; <label>:55                                      ; preds = %42
+  ret i8 1
+
+; <label>:56                                      ; preds = %42
+  %57 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %58 = bitcast %System.RuntimeType addrspace(1)* %57 to %System.Type addrspace(1)*
+  %59 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %58)
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %64 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.Type addrspace(1)* %63, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = bitcast %System.RuntimeType addrspace(1)* %64 to %System.Type addrspace(1)*
+  %67 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %63, %System.Type addrspace(1)* %66)
+  %68 = zext i8 %67 to i32
+  %69 = trunc i32 %68 to i8
+  ret i8 %69
+
+; <label>:70                                      ; preds = %56
+  %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
+  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %73
+
+; <label>:73                                      ; preds = %70
+  %74 = load i64, i64 addrspace(1)* %72
+  %75 = add i64 %74, 128
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = add i64 %77, 0
+  %79 = inttoptr i64 %78 to i64*
+  %80 = load i64, i64* %79
+  %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
+  %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
+  %83 = call i8 %82(%System.Type addrspace(1)* %81)
+  %84 = zext i8 %83 to i32
+  %85 = icmp eq i32 %84, 0
+  br i1 %85, label %139, label %86
+
+; <label>:86                                      ; preds = %73
+  %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
+  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %89
+
+; <label>:89                                      ; preds = %86
+  %90 = load i64, i64 addrspace(1)* %88
+  %91 = add i64 %90, 128
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = add i64 %93, 24
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
+  %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
+  %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
+  store %"System.Type[]" addrspace(1)* %99, %"System.Type[]" addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %129
+
+; <label>:100                                     ; preds = %132
+  %101 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %102 = load i32, i32* %loc2
+  %NullCheck11 = icmp eq %"System.Type[]" addrspace(1)* %101, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %103
+
+; <label>:103                                     ; preds = %100
+  %104 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 1
+  %105 = load i32, i32 addrspace(1)* %104
+  %106 = zext i32 %105 to i64
+  %107 = zext i32 %102 to i64
+  %BoundsCheck = icmp uge i64 %107, %106
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %108
+
+; <label>:108                                     ; preds = %103
+  %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
+  %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
+  %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
+  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %113
+
+; <label>:113                                     ; preds = %108
+  %114 = load i64, i64 addrspace(1)* %112
+  %115 = add i64 %114, 152
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = add i64 %117, 56
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
+  %123 = zext i8 %122 to i32
+  %124 = icmp ne i32 %123, 0
+  br i1 %124, label %126, label %125
+
+; <label>:125                                     ; preds = %113
+  ret i8 0
+
+; <label>:126                                     ; preds = %113
+  %127 = load i32, i32* %loc2
+  %128 = add i32 %127, 1
+  store i32 %128, i32* %loc2
+  br label %129
+
+; <label>:129                                     ; preds = %89, %126
+  %130 = load i32, i32* %loc2
+  %131 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %NullCheck9 = icmp eq %"System.Type[]" addrspace(1)* %131, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %132
+
+; <label>:132                                     ; preds = %129
+  %133 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %131, i32 0, i32 1
+  %134 = load i32, i32 addrspace(1)* %133
+  %135 = zext i32 %134 to i64
+  %136 = trunc i64 %135 to i32
+  %137 = icmp slt i32 %130, %136
+  br i1 %137, label %100, label %138
+
+; <label>:138                                     ; preds = %132
+  ret i8 1
+
+; <label>:139                                     ; preds = %34, %73
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %129
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %103
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -2893,7 +3248,7 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElem]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -2904,8 +3259,8 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -2997,8 +3352,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
@@ -3059,8 +3414,8 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -3087,8 +3442,8 @@ entry:
 
 ; <label>:17                                      ; preds = %5, %11
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
@@ -3097,8 +3452,8 @@ entry:
 
 ; <label>:22                                      ; preds = %1, %11
   %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
@@ -3109,11 +3464,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %17
+ThrowNullRef2:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %22
+ThrowNullRef4:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3167,15 +3522,15 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
   %15 = load i32, i32 addrspace(1)* %14
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
@@ -3198,7 +3553,7 @@ ThrowNullRef:                                     ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef2:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3232,8 +3587,8 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
@@ -3312,8 +3667,8 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -3327,8 +3682,8 @@ entry:
 ; <label>:5                                       ; preds = %43
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %7 = load i32, i32* %loc1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck6, label %8, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
@@ -3366,8 +3721,8 @@ entry:
 ; <label>:32                                      ; preds = %21, %25
   %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
   %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
-  br i1 %NullCheck8, label %35, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = trunc i32 %34 to i16
@@ -3380,8 +3735,8 @@ entry:
 ; <label>:40                                      ; preds = %1, %35
   %41 = load i32, i32* %loc1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
-  br i1 %NullCheck2, label %43, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %42, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
@@ -3392,8 +3747,8 @@ entry:
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
   %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
-  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
   %51 = load i64, i64 addrspace(1)* %49
@@ -3412,19 +3767,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %40
+ThrowNullRef2:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %47
+ThrowNullRef4:                                    ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %5
+ThrowNullRef6:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %32
+ThrowNullRef8:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3467,8 +3822,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
@@ -3492,11 +3847,391 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(i16* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store i16* %param0, i16** %arg0
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load i32, i32* %arg3
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %42, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %37, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg2
+  %13 = load i32, i32* %arg3
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %37, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %24 = load i32, i32* %arg2
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load i16*, i16** %arg0
+  %35 = load i32, i32* %arg3
+  %36 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %36, i16* %34, i32 %35)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:37                                      ; preds = %5, %16
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %39)
+  %41 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41, %System.String addrspace(1)* %38, %System.String addrspace(1)* %40)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41) #0
+  unreachable
+
+; <label>:42                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
-Failed to read StringBuilder.ToString[loadElemA]
+Successfully read StringBuilder.ToString
+
+define %System.String addrspace(1)* @StringBuilder.ToString(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i16*
+  %loc3 = alloca %"System.Char[]" addrspace(1)*
+  %loc4 = alloca i32
+  %loc5 = alloca i32
+  %loc6 = alloca i16 addrspace(1)*
+  %loc7 = alloca %System.String addrspace(1)*
+  %loc8 = alloca %"System.Char[]" addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %0)
+  %2 = icmp ne i32 %1, 0
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %4
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %6)
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %7)
+  store %System.String addrspace(1)* %8, %System.String addrspace(1)** %loc0
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.Text.StringBuilder addrspace(1)* %9, %System.Text.StringBuilder addrspace(1)** %loc1
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  store %System.String addrspace(1)* %10, %System.String addrspace(1)** %loc7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc7
+  %12 = ptrtoint %System.String addrspace(1)* %11 to i64
+  %13 = icmp eq i64 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %5
+  %15 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %16 = sext i32 %15 to i64
+  %17 = add i64 %12, %16
+  br label %18
+
+; <label>:18                                      ; preds = %5, %14
+  %19 = phi i64 [ %12, %5 ], [ %17, %14 ]
+  %20 = inttoptr i64 %19 to i16*
+  store i16* %20, i16** %loc2
+  br label %21
+
+; <label>:21                                      ; preds = %98, %18
+  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %22, null
+  br i1 %NullCheck, label %ThrowNullRef, label %23
+
+; <label>:23                                      ; preds = %21
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 3
+  %25 = load i32, i32 addrspace(1)* %24, align 8
+  %26 = icmp sle i32 %25, 0
+  br i1 %26, label %96, label %27
+
+; <label>:27                                      ; preds = %23
+  %28 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %28, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %29
+
+; <label>:29                                      ; preds = %27
+  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %28, i32 0, i32 1
+  %31 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %30, align 8
+  store %"System.Char[]" addrspace(1)* %31, %"System.Char[]" addrspace(1)** %loc3
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %33
+
+; <label>:33                                      ; preds = %29
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  store i32 %35, i32* %loc4
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  %39 = load i32, i32 addrspace(1)* %38, align 8
+  store i32 %39, i32* %loc5
+  %40 = load i32, i32* %loc5
+  %41 = load i32, i32* %loc4
+  %42 = add i32 %40, %41
+  %43 = zext i32 %42 to i64
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %45
+
+; <label>:45                                      ; preds = %37
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = sext i32 %47 to i64
+  %49 = icmp sgt i64 %43, %48
+  br i1 %49, label %91, label %50
+
+; <label>:50                                      ; preds = %45
+  %51 = load i32, i32* %loc5
+  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %52, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %53
+
+; <label>:53                                      ; preds = %50
+  %54 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %52, i32 0, i32 1
+  %55 = load i32, i32 addrspace(1)* %54
+  %56 = zext i32 %55 to i64
+  %57 = trunc i64 %56 to i32
+  %58 = icmp ugt i32 %51, %57
+  br i1 %58, label %91, label %59
+
+; <label>:59                                      ; preds = %53
+  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  store %"System.Char[]" addrspace(1)* %60, %"System.Char[]" addrspace(1)** %loc8
+  %61 = icmp eq %"System.Char[]" addrspace(1)* %60, null
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %63, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %64
+
+; <label>:64                                      ; preds = %62
+  %65 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %63, i32 0, i32 1
+  %66 = load i32, i32 addrspace(1)* %65
+  %67 = zext i32 %66 to i64
+  %68 = trunc i64 %67 to i32
+  %69 = icmp ne i32 %68, 0
+  br i1 %69, label %71, label %70
+
+; <label>:70                                      ; preds = %59, %64
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:71                                      ; preds = %64
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %73
+
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %BoundsCheck = icmp uge i64 0, %76
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %77
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %78, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:79                                      ; preds = %70, %77
+  %80 = load i16*, i16** %loc2
+  %81 = load i32, i32* %loc4
+  %82 = sext i32 %81 to i64
+  %83 = mul i64 %82, 2
+  %84 = bitcast i16* %80 to i8*
+  %85 = getelementptr inbounds i8, i8* %84, i64 %83
+  %86 = load i16 addrspace(1)*, i16 addrspace(1)** %loc6
+  %87 = ptrtoint i16 addrspace(1)* %86 to i64
+  %88 = load i32, i32* %loc5
+  %89 = bitcast i8* %85 to i16*
+  %90 = inttoptr i64 %87 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %89, i16* %90, i32 %88)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %96
+
+; <label>:91                                      ; preds = %45, %53
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %94 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %93)
+  %95 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95, %System.String addrspace(1)* %92, %System.String addrspace(1)* %94)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95) #0
+  unreachable
+
+; <label>:96                                      ; preds = %23, %79
+  %97 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %97, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %98
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %97, i32 0, i32 2
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  store %System.Text.StringBuilder addrspace(1)* %100, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %102 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %102, label %21, label %103
+
+; <label>:103                                     ; preds = %98
+  store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc7
+  %104 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  ret %System.String addrspace(1)* %104
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method StringBuilder::get_Length using LLILCJit
+Successfully read StringBuilder.get_Length
+
+define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
+Successfully read RuntimeHelpers.get_OffsetToStringData
+
+define i32 @RuntimeHelpers.get_OffsetToStringData() {
+entry:
+  ret i32 12
+}
+
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
 Successfully read CultureData.CreateCultureData
 
@@ -3514,23 +4249,23 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
   store i8 %4, i8 addrspace(1)* %6
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
@@ -3549,11 +4284,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3566,50 +4301,50 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
   store i32 -1, i32 addrspace(1)* %2
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
   store i32 -1, i32 addrspace(1)* %8
   %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
   store i32 -1, i32 addrspace(1)* %14
   %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
   store i32 -1, i32 addrspace(1)* %17
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
@@ -3623,27 +4358,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3675,7 +4410,136 @@ Failed to read Dictionary`2.Insert[non-const derefAddress]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
 Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
-Failed to read HashHelpers.GetPrime[loadElem]
+Successfully read HashHelpers.GetPrime
+
+define i32 @HashHelpers.GetPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %6, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5, %System.String addrspace(1)* %4)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5) #0
+  unreachable
+
+; <label>:6                                       ; preds = %entry
+  store i32 0, i32* %loc0
+  br label %29
+
+; <label>:7                                       ; preds = %35
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 1296
+  %10 = addrspacecast i8 addrspace(1)* %9 to %"System.Int32[]" addrspace(1)**
+  %11 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %10
+  %12 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Int32[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = zext i32 %15 to i64
+  %17 = zext i32 %12 to i64
+  %BoundsCheck = icmp uge i64 %17, %16
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 3, i32 %12
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  store i32 %20, i32* %loc1
+  %21 = load i32, i32* %loc1
+  %22 = load i32, i32* %arg0
+  %23 = icmp slt i32 %21, %22
+  br i1 %23, label %26, label %24
+
+; <label>:24                                      ; preds = %18
+  %25 = load i32, i32* %loc1
+  ret i32 %25
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %loc0
+  %28 = add i32 %27, 1
+  store i32 %28, i32* %loc0
+  br label %29
+
+; <label>:29                                      ; preds = %6, %26
+  %30 = load i32, i32* %loc0
+  %31 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %32 = getelementptr inbounds i8, i8 addrspace(1)* %31, i64 1296
+  %33 = addrspacecast i8 addrspace(1)* %32 to %"System.Int32[]" addrspace(1)**
+  %34 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %33
+  %NullCheck = icmp eq %"System.Int32[]" addrspace(1)* %34, null
+  br i1 %NullCheck, label %ThrowNullRef, label %35
+
+; <label>:35                                      ; preds = %29
+  %36 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %34, i32 0, i32 1
+  %37 = load i32, i32 addrspace(1)* %36
+  %38 = zext i32 %37 to i64
+  %39 = trunc i64 %38 to i32
+  %40 = icmp slt i32 %30, %39
+  br i1 %40, label %7, label %41
+
+; <label>:41                                      ; preds = %35
+  %42 = load i32, i32* %arg0
+  %43 = or i32 %42, 1
+  store i32 %43, i32* %loc2
+  br label %59
+
+; <label>:44                                      ; preds = %59
+  %45 = load i32, i32* %loc2
+  %46 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %45)
+  %47 = zext i8 %46 to i32
+  %48 = icmp eq i32 %47, 0
+  br i1 %48, label %56, label %49
+
+; <label>:49                                      ; preds = %44
+  %50 = load i32, i32* %loc2
+  %51 = sub i32 %50, 1
+  %52 = srem i32 %51, 101
+  %53 = icmp eq i32 %52, 0
+  br i1 %53, label %56, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = load i32, i32* %loc2
+  ret i32 %55
+
+; <label>:56                                      ; preds = %44, %49
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %57, 2
+  store i32 %58, i32* %loc2
+  br label %59
+
+; <label>:59                                      ; preds = %41, %56
+  %60 = load i32, i32* %loc2
+  %61 = icmp slt i32 %60, 2147483647
+  br i1 %61, label %44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load i32, i32* %arg0
+  ret i32 %63
+
+ThrowNullRef:                                     ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
 Successfully read GenericEqualityComparer`1.GetHashCode
 
@@ -3694,14 +4558,14 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
   %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load i64, i64 addrspace(1)* %7
@@ -3720,7 +4584,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3750,8 +4614,8 @@ entry:
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
@@ -3796,8 +4660,8 @@ entry:
   %35 = bitcast i16* %34 to i8*
   %36 = getelementptr inbounds i8, i8* %35, i64 2
   %37 = bitcast i8* %36 to i16*
-  %NullCheck4 = icmp ne i16* %37, null
-  br i1 %NullCheck4, label %38, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %37, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %38
 
 ; <label>:38                                      ; preds = %27
   %39 = load i16, i16* %37, align 8
@@ -3824,8 +4688,8 @@ entry:
 
 ; <label>:54                                      ; preds = %22, %43
   %55 = load i16*, i16** %loc4
-  %NullCheck2 = icmp ne i16* %55, null
-  br i1 %NullCheck2, label %56, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i16* %55, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %56
 
 ; <label>:56                                      ; preds = %54
   %57 = load i16, i16* %55, align 8
@@ -3850,11 +4714,11 @@ ThrowNullRef:                                     ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %54
+ThrowNullRef2:                                    ; preds = %54
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %27
+ThrowNullRef4:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3871,8 +4735,8 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -3907,8 +4771,8 @@ entry:
 
 ; <label>:26                                      ; preds = %19
   %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
-  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %28
 
 ; <label>:28                                      ; preds = %26
   %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
@@ -3920,7 +4784,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3972,8 +4836,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
@@ -3984,26 +4848,26 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
-  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
@@ -4014,8 +4878,8 @@ entry:
 ; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
@@ -4024,8 +4888,8 @@ entry:
 
 ; <label>:25                                      ; preds = %1, %16, %23
   %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
-  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
@@ -4036,27 +4900,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %20
+ThrowNullRef10:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4069,8 +4933,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -4081,8 +4945,8 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
@@ -4091,8 +4955,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1, %8
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
@@ -4103,11 +4967,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4128,24 +4992,24 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   store i32 %3, i32* %loc0
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
   %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
   store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck4, label %9, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
@@ -4164,15 +5028,15 @@ entry:
 ; <label>:18                                      ; preds = %70
   %19 = load i16*, i16** %loc3
   %20 = bitcast i16* %19 to i64*
-  %NullCheck10 = icmp ne i64* %20, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %20, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = load i64, i64* %20, align 8
   %23 = load i16*, i16** %loc4
   %24 = bitcast i16* %23 to i64*
-  %NullCheck12 = icmp ne i64* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = load i64, i64* %24, align 8
@@ -4188,8 +5052,8 @@ entry:
   %31 = bitcast i16* %30 to i8*
   %32 = getelementptr inbounds i8, i8* %31, i64 8
   %33 = bitcast i8* %32 to i64*
-  %NullCheck14 = icmp ne i64* %33, null
-  br i1 %NullCheck14, label %34, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = load i64, i64* %33, align 8
@@ -4197,8 +5061,8 @@ entry:
   %37 = bitcast i16* %36 to i8*
   %38 = getelementptr inbounds i8, i8* %37, i64 8
   %39 = bitcast i8* %38 to i64*
-  %NullCheck16 = icmp ne i64* %39, null
-  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %40
 
 ; <label>:40                                      ; preds = %34
   %41 = load i64, i64* %39, align 8
@@ -4214,8 +5078,8 @@ entry:
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %NullCheck18 = icmp ne i64* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = load i64, i64* %48, align 8
@@ -4223,8 +5087,8 @@ entry:
   %52 = bitcast i16* %51 to i8*
   %53 = getelementptr inbounds i8, i8* %52, i64 16
   %54 = bitcast i8* %53 to i64*
-  %NullCheck20 = icmp ne i64* %54, null
-  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64* %54, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %55
 
 ; <label>:55                                      ; preds = %49
   %56 = load i64, i64* %54, align 8
@@ -4262,15 +5126,15 @@ entry:
 ; <label>:74                                      ; preds = %95
   %75 = load i16*, i16** %loc3
   %76 = bitcast i16* %75 to i32*
-  %NullCheck6 = icmp ne i32* %76, null
-  br i1 %NullCheck6, label %77, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32* %76, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %77
 
 ; <label>:77                                      ; preds = %74
   %78 = load i32, i32* %76, align 8
   %79 = load i16*, i16** %loc4
   %80 = bitcast i16* %79 to i32*
-  %NullCheck8 = icmp ne i32* %80, null
-  br i1 %NullCheck8, label %81, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i32* %80, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %81
 
 ; <label>:81                                      ; preds = %77
   %82 = load i32, i32* %80, align 8
@@ -4318,43 +5182,43 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %74
+ThrowNullRef6:                                    ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %77
+ThrowNullRef8:                                    ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %29
+ThrowNullRef14:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %34
+ThrowNullRef16:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4376,8 +5240,8 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load i64, i64 addrspace(1)* %4
@@ -4389,8 +5253,8 @@ entry:
   %12 = load i64, i64* %11
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %5
   %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
@@ -4399,8 +5263,8 @@ entry:
   %18 = load i8, i8* %arg2
   %19 = zext i8 %18 to i32
   %20 = trunc i32 %19 to i8
-  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %15
   %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
@@ -4411,11 +5275,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4442,8 +5306,8 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
@@ -4466,16 +5330,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
   %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = load i64, i64 addrspace(1)* %19
@@ -4500,8 +5364,8 @@ entry:
 ; <label>:35                                      ; preds = %30
   %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
@@ -4514,8 +5378,8 @@ entry:
 
 ; <label>:42                                      ; preds = %1, %38
   %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
-  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
@@ -4526,19 +5390,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %35
+ThrowNullRef2:                                    ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %42
+ThrowNullRef8:                                    ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4551,14 +5415,14 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
@@ -4570,7 +5434,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4583,8 +5447,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
@@ -4613,51 +5477,51 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
   %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
   %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
   %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
   %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
-  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
   store i64 %21, i64 addrspace(1)* %23
   %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %25 = load i64, i64* %loc0
-  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
@@ -4668,27 +5532,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %22
+ThrowNullRef12:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4701,8 +5565,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
@@ -4713,19 +5577,19 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
@@ -4734,8 +5598,8 @@ entry:
 
 ; <label>:15                                      ; preds = %1, %13
   %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
@@ -4746,19 +5610,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %15
+ThrowNullRef8:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4771,8 +5635,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -4831,8 +5695,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
@@ -4882,8 +5746,8 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
-  br i1 %NullCheck, label %17, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %ThrowNullRef, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
@@ -4894,15 +5758,15 @@ entry:
 
 ; <label>:22                                      ; preds = %17
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
-  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
   %26 = load i32, i32 addrspace(1)* %25
   %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
-  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %27, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
@@ -4925,8 +5789,8 @@ entry:
 ; <label>:40                                      ; preds = %17
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
-  br i1 %NullCheck6, label %43, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %41, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
@@ -4938,34 +5802,17 @@ ThrowNullRef:                                     ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %24
+ThrowNullRef4:                                    ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %40
+ThrowNullRef6:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
-}
-
-INFO:  jitting method Object::ReferenceEquals using LLILCJit
-Successfully read Object.ReferenceEquals
-
-define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
-entry:
-  %arg0 = alloca %System.Object addrspace(1)*
-  %arg1 = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
-  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
-  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = icmp eq %System.Object addrspace(1)* %0, %1
-  %3 = sext i1 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
 }
 
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
@@ -4978,21 +5825,21 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
   %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
-  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
@@ -5007,28 +5854,28 @@ entry:
 ; <label>:13                                      ; preds = %8, %12
   %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
   %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
   %21 = load i32, i32 addrspace(1)* %20, align 8
   %22 = add i32 %21, 1
-  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
   store i32 %22, i32 addrspace(1)* %24
   %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
@@ -5039,27 +5886,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5077,7 +5924,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::Setup using LLILCJit
-Failed to read AppDomain.Setup[loadElem]
+Failed to read AppDomain.Setup[unbox]
 INFO:  jitting method Thread::GetDomain using LLILCJit
 Successfully read Thread.GetDomain
 
@@ -5108,8 +5955,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
@@ -5122,14 +5969,14 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
   %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
@@ -5141,11 +5988,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5173,8 +6020,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -5189,7 +6036,328 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
 Failed to read KeyCollection.System.Collections.Generic.IEnumerable<TKey>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Successfully read Enumerator.MoveNext
+
+define i8 @Enumerator.MoveNext(%"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.RuntimeTypeHandle* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*
+  %"$TypeArg" = alloca %System.RuntimeTypeHandle*
+  store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
+  %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 8
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %76, label %12
+
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
+  br label %76
+
+; <label>:13                                      ; preds = %85
+  %14 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck19 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %15
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, i32 0, i32 0
+  %17 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %16, align 8
+  %NullCheck21 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, i32 0, i32 2
+  %20 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %19, align 8
+  %21 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck23 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %22
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, i32 0, i32 2
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %NullCheck25 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 3, i32 %24
+  %NullCheck27 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %32
+
+; <label>:32                                      ; preds = %30
+  %33 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, i32 0, i32 2
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = icmp slt i32 %34, 0
+  br i1 %35, label %68, label %36
+
+; <label>:36                                      ; preds = %32
+  %37 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %38 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck29 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %39
+
+; <label>:39                                      ; preds = %36
+  %40 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, i32 0, i32 0
+  %41 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %40, align 8
+  %NullCheck31 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, i32 0, i32 2
+  %44 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %43, align 8
+  %45 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck33 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, i32 0, i32 2
+  %48 = load i32, i32 addrspace(1)* %47, align 8
+  %NullCheck35 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %49
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = zext i32 %51 to i64
+  %53 = zext i32 %48 to i64
+  %BoundsCheck37 = icmp uge i64 %53, %52
+  br i1 %BoundsCheck37, label %ThrowIndexOutOfRange38, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 3, i32 %48
+  %NullCheck39 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %56
+
+; <label>:56                                      ; preds = %54
+  %57 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, i32 0, i32 0
+  %58 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck41 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %59
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %60, %System.__Canon addrspace(1)* %58)
+  %61 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck43 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  %64 = load i32, i32 addrspace(1)* %63, align 8
+  %65 = add i32 %64, 1
+  %NullCheck45 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  store i32 %65, i32 addrspace(1)* %67
+  ret i8 1
+
+; <label>:68                                      ; preds = %32
+  %69 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck47 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %73 = add i32 %72, 1
+  %NullCheck49 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %74
+
+; <label>:74                                      ; preds = %70
+  %75 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  store i32 %73, i32 addrspace(1)* %75
+  br label %76
+
+; <label>:76                                      ; preds = %8, %12, %74
+  %77 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %78
+
+; <label>:78                                      ; preds = %76
+  %79 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, i32 0, i32 2
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck7 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %82
+
+; <label>:82                                      ; preds = %78
+  %83 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, i32 0, i32 0
+  %84 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %83, align 8
+  %NullCheck9 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %85
+
+; <label>:85                                      ; preds = %82
+  %86 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, i32 0, i32 7
+  %87 = load i32, i32 addrspace(1)* %86, align 8
+  %88 = icmp ult i32 %80, %87
+  br i1 %88, label %13, label %89
+
+; <label>:89                                      ; preds = %85
+  %90 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %91 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck11 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %92
+
+; <label>:92                                      ; preds = %89
+  %93 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, i32 0, i32 0
+  %94 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck13 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %95
+
+; <label>:95                                      ; preds = %92
+  %96 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, i32 0, i32 7
+  %97 = load i32, i32 addrspace(1)* %96, align 8
+  %98 = add i32 %97, 1
+  %NullCheck15 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %99
+
+; <label>:99                                      ; preds = %95
+  %100 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, i32 0, i32 2
+  store i32 %98, i32 addrspace(1)* %100
+  %101 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck17 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %102
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %103, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %92
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef22:                                   ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef24:                                   ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef26:                                   ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef28:                                   ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef30:                                   ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef32:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef34:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef36:                                   ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange38:                           ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef40:                                   ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef42:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef44:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef46:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef48:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef50:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -5200,8 +6368,8 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -5232,9 +6400,9 @@ Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
 Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
-Failed to read String.MakeSeparatorList[loadElemA]
+Failed to read String.MakeSeparatorList[storeElem]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
-Failed to read String.InternalSplitKeepEmptyEntries[loadElem]
+Failed to read String.InternalSplitKeepEmptyEntries[storeElem]
 INFO:  jitting method Path::IsRelative using LLILCJit
 Successfully read Path.IsRelative
 
@@ -5243,8 +6411,8 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -5254,8 +6422,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
@@ -5271,8 +6439,8 @@ entry:
 
 ; <label>:17                                      ; preds = %7
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
@@ -5288,8 +6456,8 @@ entry:
 
 ; <label>:29                                      ; preds = %19
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %31
 
 ; <label>:31                                      ; preds = %29
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
@@ -5300,8 +6468,8 @@ entry:
 
 ; <label>:36                                      ; preds = %31
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
-  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %37, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
@@ -5312,8 +6480,8 @@ entry:
 
 ; <label>:43                                      ; preds = %31, %38
   %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
-  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %45
 
 ; <label>:45                                      ; preds = %43
   %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
@@ -5324,8 +6492,8 @@ entry:
 
 ; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %50
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
@@ -5336,8 +6504,8 @@ entry:
 
 ; <label>:57                                      ; preds = %1, %7, %19, %45, %52
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
-  br i1 %NullCheck14, label %59, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %59
 
 ; <label>:59                                      ; preds = %57
   %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
@@ -5347,8 +6515,8 @@ entry:
 
 ; <label>:63                                      ; preds = %59
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
@@ -5359,8 +6527,8 @@ entry:
 
 ; <label>:70                                      ; preds = %65
   %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
-  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.String addrspace(1)* %71, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %72
 
 ; <label>:72                                      ; preds = %70
   %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
@@ -5379,39 +6547,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %17
+ThrowNullRef4:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %29
+ThrowNullRef6:                                    ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %36
+ThrowNullRef8:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %43
+ThrowNullRef10:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %50
+ThrowNullRef12:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %57
+ThrowNullRef14:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %63
+ThrowNullRef16:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %70
+ThrowNullRef18:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5419,7 +6587,293 @@ ThrowNullRef17:                                   ; preds = %70
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
-Failed to read String.TrimHelper[loadElem]
+Successfully read String.TrimHelper
+
+define %System.String addrspace(1)* @String.TrimHelper(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i16
+  %loc4 = alloca i32
+  %loc5 = alloca i16
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = sub i32 %3, 1
+  store i32 %4, i32* %loc0
+  store i32 0, i32* %loc1
+  %5 = load i32, i32* %arg2
+  %6 = icmp eq i32 %5, 1
+  br i1 %6, label %62, label %7
+
+; <label>:7                                       ; preds = %1
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:8                                       ; preds = %58
+  store i32 0, i32* %loc2
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load i32, i32* %loc1
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2, i32 %10
+  %13 = load i16, i16 addrspace(1)* %12
+  %14 = zext i16 %13 to i32
+  %15 = trunc i32 %14 to i16
+  store i16 %15, i16* %loc3
+  store i32 0, i32* %loc2
+  br label %34
+
+; <label>:16                                      ; preds = %37
+  %17 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %18 = load i32, i32* %loc2
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %17, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %19
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = zext i32 %18 to i64
+  %BoundsCheck = icmp uge i64 %23, %22
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %24
+
+; <label>:24                                      ; preds = %19
+  %25 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 3, i32 %18
+  %26 = load i16, i16 addrspace(1)* %25, align 8
+  %27 = zext i16 %26 to i32
+  %28 = load i16, i16* %loc3
+  %29 = zext i16 %28 to i32
+  %30 = icmp eq i32 %27, %29
+  br i1 %30, label %43, label %31
+
+; <label>:31                                      ; preds = %24
+  %32 = load i32, i32* %loc2
+  %33 = add i32 %32, 1
+  store i32 %33, i32* %loc2
+  br label %34
+
+; <label>:34                                      ; preds = %11, %31
+  %35 = load i32, i32* %loc2
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = icmp slt i32 %35, %41
+  br i1 %42, label %16, label %43
+
+; <label>:43                                      ; preds = %24, %37
+  %44 = load i32, i32* %loc2
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %45, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp eq i32 %44, %50
+  br i1 %51, label %62, label %52
+
+; <label>:52                                      ; preds = %46
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %7, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %57, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %58
+
+; <label>:58                                      ; preds = %55
+  %59 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %60 = load i32, i32 addrspace(1)* %59
+  %61 = icmp slt i32 %56, %60
+  br i1 %61, label %8, label %62
+
+; <label>:62                                      ; preds = %1, %46, %58
+  %63 = load i32, i32* %arg2
+  %64 = icmp eq i32 %63, 0
+  br i1 %64, label %122, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %66, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %67
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %66, i32 0, i32 1
+  %69 = load i32, i32 addrspace(1)* %68
+  %70 = sub i32 %69, 1
+  store i32 %70, i32* %loc0
+  br label %118
+
+; <label>:71                                      ; preds = %118
+  store i32 0, i32* %loc4
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %73 = load i32, i32* %loc0
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %74
+
+; <label>:74                                      ; preds = %71
+  %75 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 2, i32 %73
+  %76 = load i16, i16 addrspace(1)* %75
+  %77 = zext i16 %76 to i32
+  %78 = trunc i32 %77 to i16
+  store i16 %78, i16* %loc5
+  store i32 0, i32* %loc4
+  br label %97
+
+; <label>:79                                      ; preds = %100
+  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %81 = load i32, i32* %loc4
+  %NullCheck19 = icmp eq %"System.Char[]" addrspace(1)* %80, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
+
+; <label>:82                                      ; preds = %79
+  %83 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 1
+  %84 = load i32, i32 addrspace(1)* %83
+  %85 = zext i32 %84 to i64
+  %86 = zext i32 %81 to i64
+  %BoundsCheck21 = icmp uge i64 %86, %85
+  br i1 %BoundsCheck21, label %ThrowIndexOutOfRange22, label %87
+
+; <label>:87                                      ; preds = %82
+  %88 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 3, i32 %81
+  %89 = load i16, i16 addrspace(1)* %88, align 8
+  %90 = zext i16 %89 to i32
+  %91 = load i16, i16* %loc5
+  %92 = zext i16 %91 to i32
+  %93 = icmp eq i32 %90, %92
+  br i1 %93, label %106, label %94
+
+; <label>:94                                      ; preds = %87
+  %95 = load i32, i32* %loc4
+  %96 = add i32 %95, 1
+  store i32 %96, i32* %loc4
+  br label %97
+
+; <label>:97                                      ; preds = %74, %94
+  %98 = load i32, i32* %loc4
+  %99 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck15 = icmp eq %"System.Char[]" addrspace(1)* %99, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %100
+
+; <label>:100                                     ; preds = %97
+  %101 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %99, i32 0, i32 1
+  %102 = load i32, i32 addrspace(1)* %101
+  %103 = zext i32 %102 to i64
+  %104 = trunc i64 %103 to i32
+  %105 = icmp slt i32 %98, %104
+  br i1 %105, label %79, label %106
+
+; <label>:106                                     ; preds = %87, %100
+  %107 = load i32, i32* %loc4
+  %108 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck17 = icmp eq %"System.Char[]" addrspace(1)* %108, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %109
+
+; <label>:109                                     ; preds = %106
+  %110 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %108, i32 0, i32 1
+  %111 = load i32, i32 addrspace(1)* %110
+  %112 = zext i32 %111 to i64
+  %113 = trunc i64 %112 to i32
+  %114 = icmp eq i32 %107, %113
+  br i1 %114, label %122, label %115
+
+; <label>:115                                     ; preds = %109
+  %116 = load i32, i32* %loc0
+  %117 = sub i32 %116, 1
+  store i32 %117, i32* %loc0
+  br label %118
+
+; <label>:118                                     ; preds = %67, %115
+  %119 = load i32, i32* %loc0
+  %120 = load i32, i32* %loc1
+  %121 = icmp sge i32 %119, %120
+  br i1 %121, label %71, label %122
+
+; <label>:122                                     ; preds = %62, %109, %118
+  %123 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %124 = load i32, i32* %loc1
+  %125 = load i32, i32* %loc0
+  %126 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %123, i32 %124, i32 %125)
+  ret %System.String addrspace(1)* %126
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %97
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange22:                           ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
 Successfully read String.CreateTrimmedString
 
@@ -5439,8 +6893,8 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
@@ -5535,8 +6989,8 @@ entry:
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i64 2872
   %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
   %8 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %7
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %3
   %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
@@ -5553,8 +7007,8 @@ entry:
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 2864
   %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
   %21 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %20
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
-  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %22
 
 ; <label>:22                                      ; preds = %16
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
@@ -5569,7 +7023,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %16
+ThrowNullRef2:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5586,8 +7040,8 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5613,8 +7067,8 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
@@ -5632,8 +7086,8 @@ entry:
 
 ; <label>:12                                      ; preds = %4
   %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
@@ -5644,8 +7098,8 @@ entry:
 
 ; <label>:19                                      ; preds = %14
   %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %19
   %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
@@ -5660,21 +7114,21 @@ entry:
   %31 = zext i16 %30 to i32
   %32 = bitcast i8* %29 to i16*
   %33 = trunc i32 %31 to i16
-  %NullCheck6 = icmp ne i16* %32, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i16* %32, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %21
   store i16 %33, i16* %32, align 8
   %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %36
 
 ; <label>:36                                      ; preds = %34
   %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
   %38 = load i32, i32 addrspace(1)* %37, align 8
   %39 = add i32 %38, 1
-  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %40
 
 ; <label>:40                                      ; preds = %36
   %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
@@ -5683,16 +7137,16 @@ entry:
 
 ; <label>:42                                      ; preds = %14
   %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
-  br i1 %NullCheck12, label %44, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
   %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
   %47 = load i16, i16* %arg1
   %48 = zext i16 %47 to i32
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = trunc i32 %48 to i16
@@ -5703,31 +7157,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %19
+ThrowNullRef4:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %21
+ThrowNullRef6:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %36
+ThrowNullRef10:                                   ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %42
+ThrowNullRef12:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %44
+ThrowNullRef14:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5740,8 +7194,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -5752,8 +7206,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
@@ -5762,14 +7216,14 @@ entry:
 
 ; <label>:11                                      ; preds = %1
   %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
@@ -5779,15 +7233,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5808,8 +7262,8 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5822,8 +7276,8 @@ entry:
 
 ; <label>:8                                       ; preds = %3
   %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
@@ -5842,15 +7296,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
-  br i1 %NullCheck4, label %22, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
   %24 = load i16*, i16* addrspace(1)* %23, align 8
   %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %25, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
@@ -5859,8 +7313,8 @@ entry:
   store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
@@ -5874,8 +7328,8 @@ entry:
 
 ; <label>:37                                      ; preds = %65
   %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %37
   %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
@@ -5886,16 +7340,16 @@ entry:
   %45 = bitcast i16* %41 to i8*
   %46 = getelementptr inbounds i8, i8* %45, i64 %44
   %47 = bitcast i8* %46 to i16*
-  %NullCheck14 = icmp ne i16* %47, null
-  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %47, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %48
 
 ; <label>:48                                      ; preds = %39
   %49 = load i16, i16* %47, align 8
   %50 = zext i16 %49 to i32
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %52 = load i32, i32* %loc1
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %53
 
 ; <label>:53                                      ; preds = %48
   %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
@@ -5916,8 +7370,8 @@ entry:
 ; <label>:62                                      ; preds = %36, %59
   %63 = load i32, i32* %loc1
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck10, label %65, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %65
 
 ; <label>:65                                      ; preds = %62
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
@@ -5936,15 +7390,15 @@ entry:
 
 ; <label>:74                                      ; preds = %70
   %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
-  br i1 %NullCheck18, label %76, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %76
 
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
   %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
-  br i1 %NullCheck20, label %80, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
   %81 = load i64, i64 addrspace(1)* %79
@@ -5958,8 +7412,8 @@ entry:
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
   %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
-  br i1 %NullCheck22, label %92, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.String addrspace(1)* %90, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %92
 
 ; <label>:92                                      ; preds = %80
   %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
@@ -5969,15 +7423,15 @@ entry:
 
 ; <label>:96                                      ; preds = %70
   %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
-  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %98
 
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
   %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
-  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
   %103 = load i64, i64 addrspace(1)* %101
@@ -5991,8 +7445,8 @@ entry:
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
   %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
-  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.String addrspace(1)* %112, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %114
 
 ; <label>:114                                     ; preds = %102
   %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
@@ -6004,59 +7458,59 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %20
+ThrowNullRef4:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %22
+ThrowNullRef6:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %26
+ThrowNullRef8:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %62
+ThrowNullRef10:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %48
+ThrowNullRef16:                                   ; preds = %48
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %74
+ThrowNullRef18:                                   ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %76
+ThrowNullRef20:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %80
+ThrowNullRef22:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %96
+ThrowNullRef24:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %98
+ThrowNullRef26:                                   ; preds = %98
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %102
+ThrowNullRef28:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6069,15 +7523,15 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
   %3 = load i16*, i16* addrspace(1)* %2, align 8
   %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
@@ -6087,8 +7541,8 @@ entry:
   %10 = bitcast i16* %3 to i8*
   %11 = getelementptr inbounds i8, i8* %10, i64 %9
   %12 = bitcast i8* %11 to i16*
-  %NullCheck4 = icmp ne i16* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %5
   store i16 0, i16* %12, align 8
@@ -6098,11 +7552,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6119,8 +7573,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -6131,8 +7585,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
@@ -6144,15 +7598,15 @@ entry:
 
 ; <label>:14                                      ; preds = %1
   %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
   %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
   %21 = load i64, i64 addrspace(1)* %19
@@ -6171,15 +7625,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %14
+ThrowNullRef4:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %16
+ThrowNullRef6:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6302,14 +7756,6 @@ entry:
   ret %System.String addrspace(1)* %57
 }
 
-INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
-Successfully read RuntimeHelpers.get_OffsetToStringData
-
-define i32 @RuntimeHelpers.get_OffsetToStringData() {
-entry:
-  ret i32 12
-}
-
 INFO:  jitting method String::Equals using LLILCJit
 Successfully read String.Equals
 
@@ -6381,8 +7827,8 @@ entry:
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
-  br i1 %NullCheck24, label %29, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
   %30 = load i64, i64 addrspace(1)* %28
@@ -6397,8 +7843,8 @@ entry:
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
-  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
   %43 = load i64, i64 addrspace(1)* %41
@@ -6418,8 +7864,8 @@ entry:
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
   %59 = load i64, i64 addrspace(1)* %57
@@ -6434,8 +7880,8 @@ entry:
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck22, label %71, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
   %72 = load i64, i64 addrspace(1)* %70
@@ -6455,8 +7901,8 @@ entry:
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
-  br i1 %NullCheck16, label %87, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = load i64, i64 addrspace(1)* %86
@@ -6471,8 +7917,8 @@ entry:
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck18, label %100, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
   %101 = load i64, i64 addrspace(1)* %99
@@ -6492,8 +7938,8 @@ entry:
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
-  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
   %117 = load i64, i64 addrspace(1)* %115
@@ -6508,8 +7954,8 @@ entry:
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
-  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
   %130 = load i64, i64 addrspace(1)* %128
@@ -6528,15 +7974,15 @@ entry:
 
 ; <label>:142                                     ; preds = %22
   %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
-  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %143, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %144
 
 ; <label>:144                                     ; preds = %142
   %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
   %146 = load i32, i32 addrspace(1)* %145
   %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
-  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %147, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %148
 
 ; <label>:148                                     ; preds = %144
   %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
@@ -6557,15 +8003,15 @@ entry:
 
 ; <label>:159                                     ; preds = %22
   %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
-  br i1 %NullCheck, label %161, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %ThrowNullRef, label %161
 
 ; <label>:161                                     ; preds = %159
   %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
   %163 = load i32, i32 addrspace(1)* %162
   %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
-  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %164, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %165
 
 ; <label>:165                                     ; preds = %161
   %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
@@ -6578,8 +8024,8 @@ entry:
 
 ; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
-  br i1 %NullCheck4, label %172, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %171, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %172
 
 ; <label>:172                                     ; preds = %170
   %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
@@ -6589,8 +8035,8 @@ entry:
 
 ; <label>:176                                     ; preds = %172
   %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
-  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %177, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %178
 
 ; <label>:178                                     ; preds = %176
   %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
@@ -6629,55 +8075,55 @@ ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %161
+ThrowNullRef2:                                    ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %170
+ThrowNullRef4:                                    ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %176
+ThrowNullRef6:                                    ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %142
+ThrowNullRef8:                                    ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %144
+ThrowNullRef10:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %113
+ThrowNullRef12:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %116
+ThrowNullRef14:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %84
+ThrowNullRef16:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %87
+ThrowNullRef18:                                   ; preds = %87
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %55
+ThrowNullRef20:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %58
+ThrowNullRef22:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %26
+ThrowNullRef24:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %29
+ThrowNullRef26:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,8 +8161,8 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck, label %14, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %ThrowNullRef, label %14
 
 ; <label>:14                                      ; preds = %8
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
@@ -6760,8 +8206,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
@@ -6770,14 +8216,14 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32, i32* %loc0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %10
   %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
   %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
@@ -6790,15 +8236,15 @@ entry:
 ; <label>:25                                      ; preds = %19
   %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
-  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
   %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
@@ -6807,8 +8253,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %37 = load i32, i32* %loc0
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %38, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %38
 
 ; <label>:38                                      ; preds = %32
   %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
@@ -6817,14 +8263,14 @@ entry:
 
 ; <label>:40                                      ; preds = %19
   %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %40
   %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
   %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
-  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
-  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
@@ -6832,8 +8278,8 @@ entry:
   %48 = zext i32 %47 to i64
   %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
-  br i1 %NullCheck16, label %51, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %51
 
 ; <label>:51                                      ; preds = %45
   %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
@@ -6847,15 +8293,15 @@ entry:
 ; <label>:57                                      ; preds = %51
   %58 = load i16*, i16** %arg1
   %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
-  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %60
 
 ; <label>:60                                      ; preds = %57
   %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
   %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
-  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %64
 
 ; <label>:64                                      ; preds = %60
   %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
@@ -6864,22 +8310,22 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
   %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
-  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %70
 
 ; <label>:70                                      ; preds = %64
   %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
   %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
-  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
-  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
   %75 = load i32, i32 addrspace(1)* %74
   %76 = zext i32 %75 to i64
   %77 = trunc i64 %76 to i32
-  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
-  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %78
 
 ; <label>:78                                      ; preds = %73
   %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
@@ -6901,8 +8347,8 @@ entry:
   %90 = bitcast i16* %86 to i8*
   %91 = getelementptr inbounds i8, i8* %90, i64 %89
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %93
 
 ; <label>:93                                      ; preds = %80
   %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
@@ -6912,8 +8358,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %99 = load i32, i32* %loc2
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %100
 
 ; <label>:100                                     ; preds = %93
   %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
@@ -6928,63 +8374,63 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %25
+ThrowNullRef6:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %32
+ThrowNullRef10:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %40
+ThrowNullRef12:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %45
+ThrowNullRef16:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %57
+ThrowNullRef18:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %60
+ThrowNullRef20:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %64
+ThrowNullRef22:                                   ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %70
+ThrowNullRef24:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %73
+ThrowNullRef26:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %80
+ThrowNullRef28:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %93
+ThrowNullRef30:                                   ; preds = %93
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7004,8 +8450,8 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
@@ -7033,43 +8479,43 @@ entry:
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %14
   %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
   %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   %28 = load i32, i32 addrspace(1)* %27, align 8
   %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
-  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %30
 
 ; <label>:30                                      ; preds = %26
   %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
   %32 = load i32, i32 addrspace(1)* %31, align 8
   %33 = add i32 %28, %32
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %34
 
 ; <label>:34                                      ; preds = %30
   %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   store i32 %33, i32 addrspace(1)* %35
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
   store i32 0, i32 addrspace(1)* %38
   %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %40
 
 ; <label>:40                                      ; preds = %37
   %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
@@ -7082,8 +8528,8 @@ entry:
 
 ; <label>:47                                      ; preds = %40
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
@@ -7098,8 +8544,8 @@ entry:
   %54 = load i32, i32* %loc0
   %55 = sext i32 %54 to i64
   %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
-  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %57
 
 ; <label>:57                                      ; preds = %52
   %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
@@ -7110,68 +8556,35 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %14
+ThrowNullRef2:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %23
+ThrowNullRef4:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %26
+ThrowNullRef6:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %30
+ThrowNullRef8:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %34
+ThrowNullRef10:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %47
+ThrowNullRef14:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %52
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-}
-
-INFO:  jitting method StringBuilder::get_Length using LLILCJit
-Successfully read StringBuilder.get_Length
-
-define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.StringBuilder addrspace(1)*
-  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
-  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
-
-; <label>:1                                       ; preds = %entry
-  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %3 = load i32, i32 addrspace(1)* %2, align 8
-  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
-
-; <label>:5                                       ; preds = %1
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = add i32 %3, %7
-  ret i32 %8
-
-ThrowNullRef:                                     ; preds = %entry
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef16:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7213,70 +8626,70 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
   %6 = load i32, i32 addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
   store i32 %6, i32 addrspace(1)* %8
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
   %13 = load i32, i32 addrspace(1)* %12, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
   store i32 %13, i32 addrspace(1)* %15
   %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
-  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %18
 
 ; <label>:18                                      ; preds = %14
   %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
   %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
   %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
   %34 = load i32, i32 addrspace(1)* %33, align 8
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
-  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
@@ -7287,39 +8700,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %28
+ThrowNullRef16:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %32
+ThrowNullRef18:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7455,13 +8868,13 @@ entry:
 ; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
@@ -7477,16 +8890,16 @@ entry:
 
 ; <label>:18                                      ; preds = %15
   %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
   store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
   %22 = load i32, i32* %loc0
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %24
 
 ; <label>:24                                      ; preds = %20
   %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
@@ -7498,13 +8911,13 @@ entry:
 ; <label>:28                                      ; preds = %15, %24
   %29 = load i32, i32* %arg1
   %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %31
   %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
@@ -7517,20 +8930,20 @@ entry:
   %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
-  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
   %46 = load i32, i32 addrspace(1)* %45, align 8
   %47 = sub i32 %40, %46
-  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
-  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i32 addrspace(1)* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %48
 
 ; <label>:48                                      ; preds = %44
   store i32 %47, i32 addrspace(1)* %39, align 8
@@ -7538,21 +8951,21 @@ entry:
 
 ; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
-  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %51
 
 ; <label>:51                                      ; preds = %49
   %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %53
 
 ; <label>:53                                      ; preds = %51
   %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
   %55 = load i32, i32 addrspace(1)* %54, align 8
   %56 = load i32, i32* %arg2
   %57 = sub i32 %55, %56
-  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %58
 
 ; <label>:58                                      ; preds = %53
   %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
@@ -7562,13 +8975,13 @@ entry:
 ; <label>:60                                      ; preds = %33, %58
   %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
   %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
-  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %63
 
 ; <label>:63                                      ; preds = %60
   %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
-  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
-  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
@@ -7578,15 +8991,15 @@ entry:
 
 ; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
-  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i32 addrspace(1)* %69, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %70
 
 ; <label>:70                                      ; preds = %68
   %71 = load i32, i32 addrspace(1)* %69, align 8
   store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
-  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
@@ -7596,8 +9009,8 @@ entry:
   store i32 %77, i32* %loc4
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
-  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %80
 
 ; <label>:80                                      ; preds = %73
   %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
@@ -7607,71 +9020,71 @@ entry:
 ; <label>:83                                      ; preds = %80
   store i32 0, i32* %loc3
   %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
-  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
-  br i1 %NullCheck26, label %88, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i32 addrspace(1)* %87, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %88
 
 ; <label>:88                                      ; preds = %85
   %89 = load i32, i32 addrspace(1)* %87, align 8
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
-  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %90
 
 ; <label>:90                                      ; preds = %88
   %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
   store i32 %89, i32 addrspace(1)* %91
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
-  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
-  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %96
 
 ; <label>:96                                      ; preds = %94
   %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
-  br i1 %NullCheck34, label %100, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %100
 
 ; <label>:100                                     ; preds = %96
   %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
-  br i1 %NullCheck36, label %102, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %102
 
 ; <label>:102                                     ; preds = %100
   %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
   %104 = load i32, i32 addrspace(1)* %103, align 8
   %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
-  br i1 %NullCheck38, label %106, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %106
 
 ; <label>:106                                     ; preds = %102
   %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
-  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
-  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %108
 
 ; <label>:108                                     ; preds = %106
   %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
   %110 = load i32, i32 addrspace(1)* %109, align 8
   %111 = add i32 %104, %110
-  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %112
 
 ; <label>:112                                     ; preds = %108
   %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
   store i32 %111, i32 addrspace(1)* %113
   %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
-  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i32 addrspace(1)* %114, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %115
 
 ; <label>:115                                     ; preds = %112
   %116 = load i32, i32 addrspace(1)* %114, align 8
@@ -7681,19 +9094,19 @@ entry:
 ; <label>:118                                     ; preds = %115
   %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
-  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %121
 
 ; <label>:121                                     ; preds = %118
   %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
-  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
-  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %123
 
 ; <label>:123                                     ; preds = %121
   %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
   %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
-  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
-  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %126
 
 ; <label>:126                                     ; preds = %123
   %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
@@ -7705,8 +9118,8 @@ entry:
 
 ; <label>:130                                     ; preds = %80, %115, %126
   %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %132
 
 ; <label>:132                                     ; preds = %130
   %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7715,8 +9128,8 @@ entry:
   %136 = load i32, i32* %loc3
   %137 = sub i32 %135, %136
   %138 = sub i32 %134, %137
-  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %139
 
 ; <label>:139                                     ; preds = %132
   %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7728,16 +9141,16 @@ entry:
 
 ; <label>:144                                     ; preds = %139
   %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
-  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %146
 
 ; <label>:146                                     ; preds = %144
   %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
   %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
   %149 = load i32, i32* %loc2
   %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
-  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %151
 
 ; <label>:151                                     ; preds = %146
   %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
@@ -7754,145 +9167,249 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %18
+ThrowNullRef4:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %31
+ThrowNullRef10:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %44
+ThrowNullRef16:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %68
+ThrowNullRef18:                                   ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %70
+ThrowNullRef20:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %73
+ThrowNullRef22:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %83
+ThrowNullRef24:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %85
+ThrowNullRef26:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %88
+ThrowNullRef28:                                   ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %90
+ThrowNullRef30:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %94
+ThrowNullRef32:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %96
+ThrowNullRef34:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %100
+ThrowNullRef36:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %102
+ThrowNullRef38:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %106
+ThrowNullRef40:                                   ; preds = %106
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %108
+ThrowNullRef42:                                   ; preds = %108
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %112
+ThrowNullRef44:                                   ; preds = %112
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %118
+ThrowNullRef46:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %121
+ThrowNullRef48:                                   ; preds = %121
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %123
+ThrowNullRef50:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %130
+ThrowNullRef52:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %132
+ThrowNullRef54:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %144
+ThrowNullRef56:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %146
+ThrowNullRef58:                                   ; preds = %146
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %60
+ThrowNullRef60:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %63
+ThrowNullRef62:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %49
+ThrowNullRef64:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %51
+ThrowNullRef66:                                   ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %53
+ThrowNullRef68:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(%"System.Char[]" addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %arg0 = alloca %"System.Char[]" addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store %"System.Char[]" addrspace(1)* %param0, %"System.Char[]" addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load i32, i32* %arg4
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %43, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %38, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg1
+  %13 = load i32, i32* %arg4
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %38, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %24 = load i32, i32* %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %35 = load i32, i32* %arg3
+  %36 = load i32, i32* %arg4
+  %37 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %37, %"System.Char[]" addrspace(1)* %34, i32 %35, i32 %36)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:38                                      ; preds = %5, %16
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Successfully read Buffer._Memmove
 
@@ -7914,7 +9431,7 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[loadElem]
+Failed to read AppDomain.SetDataHelper[storeElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -7923,8 +9440,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
@@ -7934,8 +9451,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
@@ -7947,15 +9464,15 @@ entry:
   %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
   %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
@@ -7966,15 +9483,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7992,7 +9509,79 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
-Failed to read Dictionary`2.TryGetValue[loadElemA]
+Successfully read Dictionary`2.TryGetValue
+
+define i8 @"Dictionary`2.TryGetValue"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)* addrspace(1)* %param2) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  %arg2 = alloca %System.__Canon addrspace(1)* addrspace(1)*
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  store %System.__Canon addrspace(1)* addrspace(1)* %param2, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  store i32 %2, i32* %loc0
+  %3 = load i32, i32* %loc0
+  %4 = icmp slt i32 %3, 0
+  br i1 %4, label %22, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 2
+  %10 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %9, align 8
+  %11 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = zext i32 %11 to i64
+  %BoundsCheck = icmp uge i64 %16, %15
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 3, i32 %11
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %20, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %6, %System.__Canon addrspace(1)* %21)
+  ret i8 1
+
+; <label>:22                                      ; preds = %entry
+  %23 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %23, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -8058,8 +9647,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
@@ -8091,8 +9680,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
@@ -8171,15 +9760,15 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck, label %19, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %ThrowNullRef, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
   %21 = load i32, i32 addrspace(1)* %20
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
@@ -8202,7 +9791,7 @@ ThrowNullRef:                                     ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %19
+ThrowNullRef2:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8248,8 +9837,8 @@ entry:
   %0 = alloca %System.AppDomainHandle
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %1 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %1, i32 0, i32 15
@@ -8269,8 +9858,8 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
@@ -8286,7 +9875,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -8299,8 +9888,8 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -8327,8 +9916,8 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
@@ -8352,8 +9941,8 @@ entry:
   %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
   store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
@@ -8363,8 +9952,8 @@ entry:
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
@@ -8374,8 +9963,8 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %9
   %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
@@ -8384,8 +9973,8 @@ entry:
 
 ; <label>:18                                      ; preds = %3, %16
   %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
@@ -8397,15 +9986,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %18
+ThrowNullRef6:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8418,8 +10007,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
@@ -8453,15 +10042,15 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
@@ -8473,7 +10062,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8481,7 +10070,7 @@ ThrowNullRef1:                                    ; preds = %1
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
 Failed to read Dictionary`2.System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
@@ -8506,8 +10095,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
@@ -8524,8 +10113,8 @@ entry:
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -8544,7 +10133,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8577,8 +10166,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = load i64, i64* %arg2
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = trunc i32 %3 to i8
@@ -8634,46 +10223,46 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
   %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
-  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
-  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
-  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
@@ -8684,27 +10273,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %20
+ThrowNullRef12:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8717,8 +10306,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -8756,22 +10345,22 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
   %9 = load i64, i64 addrspace(1)* %8, align 8
   %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
   %13 = load i64, i64 addrspace(1)* %12, align 8
   %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %11
   %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
@@ -8788,11 +10377,11 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8882,8 +10471,8 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
@@ -8900,8 +10489,8 @@ entry:
 ; <label>:8                                       ; preds = %1
   %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
   %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
@@ -8911,15 +10500,15 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
   %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
   %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
-  br i1 %NullCheck6, label %21, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
@@ -8946,15 +10535,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8992,15 +10581,15 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
   store i8 %3, i8 addrspace(1)* %5
   %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
@@ -9011,7 +10600,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9027,8 +10616,8 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -9041,8 +10630,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
@@ -9058,7 +10647,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9080,8 +10669,8 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
@@ -9096,8 +10685,8 @@ entry:
 ; <label>:12                                      ; preds = %6
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
@@ -9112,8 +10701,8 @@ entry:
 ; <label>:21                                      ; preds = %15
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
@@ -9128,8 +10717,8 @@ entry:
 ; <label>:30                                      ; preds = %24
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %31, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
@@ -9144,8 +10733,8 @@ entry:
 ; <label>:39                                      ; preds = %33
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
-  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %40, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %42
 
 ; <label>:42                                      ; preds = %39
   %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
@@ -9164,19 +10753,19 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %21
+ThrowNullRef4:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %30
+ThrowNullRef6:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %39
+ThrowNullRef8:                                    ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9243,8 +10832,8 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
@@ -9264,57 +10853,57 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
   store i8 0, i8 addrspace(1)* %2
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
   store i8 0, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
   store i8 0, i8 addrspace(1)* %17
   %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
   store i8 0, i8 addrspace(1)* %20
   %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
-  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
@@ -9325,31 +10914,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %19
+ThrowNullRef14:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9367,8 +10956,8 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
@@ -9380,8 +10969,8 @@ entry:
 
 ; <label>:9                                       ; preds = %4
   %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %9
   %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
@@ -9395,7 +10984,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef2:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9420,8 +11009,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
@@ -9512,8 +11101,8 @@ entry:
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
@@ -9524,8 +11113,8 @@ entry:
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = load i64, i64 addrspace(1)* %12
@@ -9537,8 +11126,8 @@ entry:
   %20 = load i64, i64* %19
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
-  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %13
   %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
@@ -9555,8 +11144,8 @@ entry:
 ; <label>:30                                      ; preds = %25
   %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %32 = load i32, i32* %arg2
-  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
-  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
@@ -9570,15 +11159,15 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %30
+ThrowNullRef2:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9622,87 +11211,87 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
   %10 = load i8, i8 addrspace(1)* %9, align 8
   %11 = zext i8 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %8
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
   store i8 %12, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
   %19 = load i8, i8 addrspace(1)* %18, align 8
   %20 = zext i8 %19 to i32
   %21 = trunc i32 %20 to i8
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
   store i8 %21, i8 addrspace(1)* %23
   %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
   %28 = load i8, i8 addrspace(1)* %27, align 8
   %29 = zext i8 %28 to i32
   %30 = trunc i32 %29 to i8
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
-  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %31
 
 ; <label>:31                                      ; preds = %26
   %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
   store i8 %30, i8 addrspace(1)* %32
   %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
-  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
-  br i1 %NullCheck14, label %40, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %40
 
 ; <label>:40                                      ; preds = %35
   %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
   store i8 %39, i8 addrspace(1)* %41
   %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
-  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %44
 
 ; <label>:44                                      ; preds = %40
   %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
   %46 = load i8, i8 addrspace(1)* %45, align 8
   %47 = zext i8 %46 to i32
   %48 = trunc i32 %47 to i8
-  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
   store i8 %48, i8 addrspace(1)* %50
   %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
-  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
@@ -9713,29 +11302,29 @@ entry:
 ; <label>:56                                      ; preds = %52
   %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
-  br i1 %NullCheck22, label %59, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
   %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
   %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
-  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
-  br i1 %NullCheck24, label %63, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
   %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
-  br i1 %NullCheck26, label %66, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
   %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
-  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
-  br i1 %NullCheck28, label %69, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %69
 
 ; <label>:69                                      ; preds = %66
   %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
@@ -9744,15 +11333,15 @@ entry:
 
 ; <label>:71                                      ; preds = %105
   %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
-  br i1 %NullCheck34, label %73, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %73
 
 ; <label>:73                                      ; preds = %71
   %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
   %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
   %76 = load i32, i32* %loc0
-  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
-  br i1 %NullCheck36, label %77, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
@@ -9766,8 +11355,8 @@ entry:
 
 ; <label>:83                                      ; preds = %77
   %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
-  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
@@ -9775,14 +11364,14 @@ entry:
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
   %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
-  br i1 %NullCheck40, label %91, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
 ; <label>:91                                      ; preds = %85
   %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
   %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
-  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck42, label %94, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %94
 
 ; <label>:94                                      ; preds = %91
   %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
@@ -9798,14 +11387,14 @@ entry:
 ; <label>:99                                      ; preds = %69, %96
   %100 = load i32, i32* %loc0
   %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
-  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %102
 
 ; <label>:102                                     ; preds = %99
   %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
   %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
-  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
-  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
@@ -9819,87 +11408,87 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %26
+ThrowNullRef10:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %31
+ThrowNullRef12:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %35
+ThrowNullRef14:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %40
+ThrowNullRef16:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %56
+ThrowNullRef22:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %59
+ThrowNullRef24:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %63
+ThrowNullRef26:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %66
+ThrowNullRef28:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %102
+ThrowNullRef32:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %71
+ThrowNullRef34:                                   ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %73
+ThrowNullRef36:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %83
+ThrowNullRef38:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %85
+ThrowNullRef40:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %91
+ThrowNullRef42:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9943,15 +11532,15 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
   %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
@@ -9961,28 +11550,28 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
   %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %12
   %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
   %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
   %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
-  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
@@ -9993,23 +11582,23 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %12
+ThrowNullRef6:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10031,15 +11620,15 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
   %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = load i64, i64 addrspace(1)* %7
@@ -10077,13 +11666,13 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[loadElem]
+Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -10111,8 +11700,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1

--- a/test/BaseLine/JIT/Directed/Arrays/complex1.error.txt
+++ b/test/BaseLine/JIT/Directed/Arrays/complex1.error.txt
@@ -25,8 +25,8 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
@@ -40,8 +40,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
   %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
@@ -75,7 +75,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -90,8 +90,8 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %NullCheck = icmp ne i8 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = load i8, i8 addrspace(1)* %0, align 8
@@ -125,8 +125,8 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
@@ -159,8 +159,8 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -184,8 +184,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
   store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
@@ -195,8 +195,8 @@ entry:
 ; <label>:4                                       ; preds = %1
   %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
   %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
@@ -206,8 +206,8 @@ entry:
   %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
@@ -221,14 +221,14 @@ entry:
 
 ; <label>:17                                      ; preds = %14
   %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
   %21 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
@@ -238,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -249,8 +249,8 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
@@ -261,27 +261,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %30
+ThrowNullRef10:                                   ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -301,7 +301,89 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
-Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
+Successfully read AppDomainSetup.GetUnsecureApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.GetUnsecureApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %NullCheck = icmp eq %"System.String[]" addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %BoundsCheck = icmp uge i64 0, %5
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %6
+
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 3, i32 0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
+  ret %System.String addrspace(1)* %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_Value using LLILCJit
+Successfully read AppDomainSetup.get_Value
+
+define %"System.String[]" addrspace(1)* @AppDomainSetup.get_Value(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.String[]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 18)
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.String[]" addrspace(1)* addrspace(1)*, %"System.String[]" addrspace(1)*)*)(%"System.String[]" addrspace(1)* addrspace(1)* %9, %"System.String[]" addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %11, i32 0, i32 1
+  %14 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %13, align 8
+  ret %"System.String[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -319,8 +401,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -368,16 +450,16 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
   %5 = load i32, i32 addrspace(1)* %4
   %6 = sub i32 %5, 1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -389,7 +471,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -421,8 +503,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
@@ -456,8 +538,8 @@ entry:
 ; <label>:27                                      ; preds = %19
   %28 = load i32, i32* %arg1
   %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
-  br i1 %NullCheck2, label %30, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %29, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %30
 
 ; <label>:30                                      ; preds = %27
   %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
@@ -493,8 +575,8 @@ entry:
 ; <label>:49                                      ; preds = %46
   %50 = load i32, i32* %arg2
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck4, label %52, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
@@ -517,11 +599,11 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %27
+ThrowNullRef2:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %49
+ThrowNullRef4:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -544,16 +626,16 @@ entry:
   %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %0)
   store %System.String addrspace(1)* %1, %System.String addrspace(1)** %loc0
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 2
   %5 = bitcast [0 x i16] addrspace(1)* %4 to i16 addrspace(1)*
   store i16 addrspace(1)* %5, i16 addrspace(1)** %loc1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %3
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2
@@ -580,7 +662,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -691,15 +773,15 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %NullCheck132 = icmp ne i8* %21, null
-  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+  %NullCheck131 = icmp eq i8* %21, null
+  br i1 %NullCheck131, label %ThrowNullRef132, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = load i8, i8* %21, align 8
   %24 = zext i8 %23 to i32
   %25 = trunc i32 %24 to i8
-  %NullCheck134 = icmp ne i8* %20, null
-  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+  %NullCheck133 = icmp eq i8* %20, null
+  br i1 %NullCheck133, label %ThrowNullRef134, label %26
 
 ; <label>:26                                      ; preds = %22
   store i8 %25, i8* %20, align 8
@@ -709,16 +791,16 @@ entry:
   %28 = load i8*, i8** %arg0
   %29 = load i8*, i8** %arg1
   %30 = bitcast i8* %29 to i16*
-  %NullCheck128 = icmp ne i16* %30, null
-  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+  %NullCheck127 = icmp eq i16* %30, null
+  br i1 %NullCheck127, label %ThrowNullRef128, label %31
 
 ; <label>:31                                      ; preds = %27
   %32 = load i16, i16* %30, align 8
   %33 = sext i16 %32 to i32
   %34 = bitcast i8* %28 to i16*
   %35 = trunc i32 %33 to i16
-  %NullCheck130 = icmp ne i16* %34, null
-  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+  %NullCheck129 = icmp eq i16* %34, null
+  br i1 %NullCheck129, label %ThrowNullRef130, label %36
 
 ; <label>:36                                      ; preds = %31
   store i16 %35, i16* %34, align 8
@@ -728,16 +810,16 @@ entry:
   %38 = load i8*, i8** %arg0
   %39 = load i8*, i8** %arg1
   %40 = bitcast i8* %39 to i16*
-  %NullCheck120 = icmp ne i16* %40, null
-  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+  %NullCheck119 = icmp eq i16* %40, null
+  br i1 %NullCheck119, label %ThrowNullRef120, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i16, i16* %40, align 8
   %43 = sext i16 %42 to i32
   %44 = bitcast i8* %38 to i16*
   %45 = trunc i32 %43 to i16
-  %NullCheck122 = icmp ne i16* %44, null
-  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+  %NullCheck121 = icmp eq i16* %44, null
+  br i1 %NullCheck121, label %ThrowNullRef122, label %46
 
 ; <label>:46                                      ; preds = %41
   store i16 %45, i16* %44, align 8
@@ -745,15 +827,15 @@ entry:
   %48 = getelementptr inbounds i8, i8* %47, i64 2
   %49 = load i8*, i8** %arg1
   %50 = getelementptr inbounds i8, i8* %49, i64 2
-  %NullCheck124 = icmp ne i8* %50, null
-  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+  %NullCheck123 = icmp eq i8* %50, null
+  br i1 %NullCheck123, label %ThrowNullRef124, label %51
 
 ; <label>:51                                      ; preds = %46
   %52 = load i8, i8* %50, align 8
   %53 = zext i8 %52 to i32
   %54 = trunc i32 %53 to i8
-  %NullCheck126 = icmp ne i8* %48, null
-  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+  %NullCheck125 = icmp eq i8* %48, null
+  br i1 %NullCheck125, label %ThrowNullRef126, label %55
 
 ; <label>:55                                      ; preds = %51
   store i8 %54, i8* %48, align 8
@@ -763,14 +845,14 @@ entry:
   %57 = load i8*, i8** %arg0
   %58 = load i8*, i8** %arg1
   %59 = bitcast i8* %58 to i32*
-  %NullCheck116 = icmp ne i32* %59, null
-  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+  %NullCheck115 = icmp eq i32* %59, null
+  br i1 %NullCheck115, label %ThrowNullRef116, label %60
 
 ; <label>:60                                      ; preds = %56
   %61 = load i32, i32* %59, align 8
   %62 = bitcast i8* %57 to i32*
-  %NullCheck118 = icmp ne i32* %62, null
-  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+  %NullCheck117 = icmp eq i32* %62, null
+  br i1 %NullCheck117, label %ThrowNullRef118, label %63
 
 ; <label>:63                                      ; preds = %60
   store i32 %61, i32* %62, align 8
@@ -780,14 +862,14 @@ entry:
   %65 = load i8*, i8** %arg0
   %66 = load i8*, i8** %arg1
   %67 = bitcast i8* %66 to i32*
-  %NullCheck108 = icmp ne i32* %67, null
-  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+  %NullCheck107 = icmp eq i32* %67, null
+  br i1 %NullCheck107, label %ThrowNullRef108, label %68
 
 ; <label>:68                                      ; preds = %64
   %69 = load i32, i32* %67, align 8
   %70 = bitcast i8* %65 to i32*
-  %NullCheck110 = icmp ne i32* %70, null
-  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+  %NullCheck109 = icmp eq i32* %70, null
+  br i1 %NullCheck109, label %ThrowNullRef110, label %71
 
 ; <label>:71                                      ; preds = %68
   store i32 %69, i32* %70, align 8
@@ -795,15 +877,15 @@ entry:
   %73 = getelementptr inbounds i8, i8* %72, i64 4
   %74 = load i8*, i8** %arg1
   %75 = getelementptr inbounds i8, i8* %74, i64 4
-  %NullCheck112 = icmp ne i8* %75, null
-  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+  %NullCheck111 = icmp eq i8* %75, null
+  br i1 %NullCheck111, label %ThrowNullRef112, label %76
 
 ; <label>:76                                      ; preds = %71
   %77 = load i8, i8* %75, align 8
   %78 = zext i8 %77 to i32
   %79 = trunc i32 %78 to i8
-  %NullCheck114 = icmp ne i8* %73, null
-  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+  %NullCheck113 = icmp eq i8* %73, null
+  br i1 %NullCheck113, label %ThrowNullRef114, label %80
 
 ; <label>:80                                      ; preds = %76
   store i8 %79, i8* %73, align 8
@@ -813,14 +895,14 @@ entry:
   %82 = load i8*, i8** %arg0
   %83 = load i8*, i8** %arg1
   %84 = bitcast i8* %83 to i32*
-  %NullCheck100 = icmp ne i32* %84, null
-  br i1 %NullCheck100, label %85, label %ThrowNullRef99
+  %NullCheck99 = icmp eq i32* %84, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %85
 
 ; <label>:85                                      ; preds = %81
   %86 = load i32, i32* %84, align 8
   %87 = bitcast i8* %82 to i32*
-  %NullCheck102 = icmp ne i32* %87, null
-  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+  %NullCheck101 = icmp eq i32* %87, null
+  br i1 %NullCheck101, label %ThrowNullRef102, label %88
 
 ; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
@@ -829,16 +911,16 @@ entry:
   %91 = load i8*, i8** %arg1
   %92 = getelementptr inbounds i8, i8* %91, i64 4
   %93 = bitcast i8* %92 to i16*
-  %NullCheck104 = icmp ne i16* %93, null
-  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+  %NullCheck103 = icmp eq i16* %93, null
+  br i1 %NullCheck103, label %ThrowNullRef104, label %94
 
 ; <label>:94                                      ; preds = %88
   %95 = load i16, i16* %93, align 8
   %96 = sext i16 %95 to i32
   %97 = bitcast i8* %90 to i16*
   %98 = trunc i32 %96 to i16
-  %NullCheck106 = icmp ne i16* %97, null
-  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+  %NullCheck105 = icmp eq i16* %97, null
+  br i1 %NullCheck105, label %ThrowNullRef106, label %99
 
 ; <label>:99                                      ; preds = %94
   store i16 %98, i16* %97, align 8
@@ -848,14 +930,14 @@ entry:
   %101 = load i8*, i8** %arg0
   %102 = load i8*, i8** %arg1
   %103 = bitcast i8* %102 to i32*
-  %NullCheck88 = icmp ne i32* %103, null
-  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+  %NullCheck87 = icmp eq i32* %103, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %104
 
 ; <label>:104                                     ; preds = %100
   %105 = load i32, i32* %103, align 8
   %106 = bitcast i8* %101 to i32*
-  %NullCheck90 = icmp ne i32* %106, null
-  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+  %NullCheck89 = icmp eq i32* %106, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %107
 
 ; <label>:107                                     ; preds = %104
   store i32 %105, i32* %106, align 8
@@ -864,16 +946,16 @@ entry:
   %110 = load i8*, i8** %arg1
   %111 = getelementptr inbounds i8, i8* %110, i64 4
   %112 = bitcast i8* %111 to i16*
-  %NullCheck92 = icmp ne i16* %112, null
-  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+  %NullCheck91 = icmp eq i16* %112, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %113
 
 ; <label>:113                                     ; preds = %107
   %114 = load i16, i16* %112, align 8
   %115 = sext i16 %114 to i32
   %116 = bitcast i8* %109 to i16*
   %117 = trunc i32 %115 to i16
-  %NullCheck94 = icmp ne i16* %116, null
-  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+  %NullCheck93 = icmp eq i16* %116, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %118
 
 ; <label>:118                                     ; preds = %113
   store i16 %117, i16* %116, align 8
@@ -881,15 +963,15 @@ entry:
   %120 = getelementptr inbounds i8, i8* %119, i64 6
   %121 = load i8*, i8** %arg1
   %122 = getelementptr inbounds i8, i8* %121, i64 6
-  %NullCheck96 = icmp ne i8* %122, null
-  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+  %NullCheck95 = icmp eq i8* %122, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %123
 
 ; <label>:123                                     ; preds = %118
   %124 = load i8, i8* %122, align 8
   %125 = zext i8 %124 to i32
   %126 = trunc i32 %125 to i8
-  %NullCheck98 = icmp ne i8* %120, null
-  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+  %NullCheck97 = icmp eq i8* %120, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %127
 
 ; <label>:127                                     ; preds = %123
   store i8 %126, i8* %120, align 8
@@ -899,14 +981,14 @@ entry:
   %129 = load i8*, i8** %arg0
   %130 = load i8*, i8** %arg1
   %131 = bitcast i8* %130 to i64*
-  %NullCheck84 = icmp ne i64* %131, null
-  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+  %NullCheck83 = icmp eq i64* %131, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %132
 
 ; <label>:132                                     ; preds = %128
   %133 = load i64, i64* %131, align 8
   %134 = bitcast i8* %129 to i64*
-  %NullCheck86 = icmp ne i64* %134, null
-  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+  %NullCheck85 = icmp eq i64* %134, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %135
 
 ; <label>:135                                     ; preds = %132
   store i64 %133, i64* %134, align 8
@@ -916,14 +998,14 @@ entry:
   %137 = load i8*, i8** %arg0
   %138 = load i8*, i8** %arg1
   %139 = bitcast i8* %138 to i64*
-  %NullCheck76 = icmp ne i64* %139, null
-  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+  %NullCheck75 = icmp eq i64* %139, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %140
 
 ; <label>:140                                     ; preds = %136
   %141 = load i64, i64* %139, align 8
   %142 = bitcast i8* %137 to i64*
-  %NullCheck78 = icmp ne i64* %142, null
-  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+  %NullCheck77 = icmp eq i64* %142, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %143
 
 ; <label>:143                                     ; preds = %140
   store i64 %141, i64* %142, align 8
@@ -931,15 +1013,15 @@ entry:
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %NullCheck80 = icmp ne i8* %147, null
-  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+  %NullCheck79 = icmp eq i8* %147, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %148
 
 ; <label>:148                                     ; preds = %143
   %149 = load i8, i8* %147, align 8
   %150 = zext i8 %149 to i32
   %151 = trunc i32 %150 to i8
-  %NullCheck82 = icmp ne i8* %145, null
-  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+  %NullCheck81 = icmp eq i8* %145, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %152
 
 ; <label>:152                                     ; preds = %148
   store i8 %151, i8* %145, align 8
@@ -949,14 +1031,14 @@ entry:
   %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
   %156 = bitcast i8* %155 to i64*
-  %NullCheck68 = icmp ne i64* %156, null
-  br i1 %NullCheck68, label %157, label %ThrowNullRef67
+  %NullCheck67 = icmp eq i64* %156, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %157
 
 ; <label>:157                                     ; preds = %153
   %158 = load i64, i64* %156, align 8
   %159 = bitcast i8* %154 to i64*
-  %NullCheck70 = icmp ne i64* %159, null
-  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+  %NullCheck69 = icmp eq i64* %159, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %160
 
 ; <label>:160                                     ; preds = %157
   store i64 %158, i64* %159, align 8
@@ -965,16 +1047,16 @@ entry:
   %163 = load i8*, i8** %arg1
   %164 = getelementptr inbounds i8, i8* %163, i64 8
   %165 = bitcast i8* %164 to i16*
-  %NullCheck72 = icmp ne i16* %165, null
-  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+  %NullCheck71 = icmp eq i16* %165, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %166
 
 ; <label>:166                                     ; preds = %160
   %167 = load i16, i16* %165, align 8
   %168 = sext i16 %167 to i32
   %169 = bitcast i8* %162 to i16*
   %170 = trunc i32 %168 to i16
-  %NullCheck74 = icmp ne i16* %169, null
-  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+  %NullCheck73 = icmp eq i16* %169, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %171
 
 ; <label>:171                                     ; preds = %166
   store i16 %170, i16* %169, align 8
@@ -984,14 +1066,14 @@ entry:
   %173 = load i8*, i8** %arg0
   %174 = load i8*, i8** %arg1
   %175 = bitcast i8* %174 to i64*
-  %NullCheck56 = icmp ne i64* %175, null
-  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+  %NullCheck55 = icmp eq i64* %175, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %176
 
 ; <label>:176                                     ; preds = %172
   %177 = load i64, i64* %175, align 8
   %178 = bitcast i8* %173 to i64*
-  %NullCheck58 = icmp ne i64* %178, null
-  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+  %NullCheck57 = icmp eq i64* %178, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %179
 
 ; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
@@ -1000,16 +1082,16 @@ entry:
   %182 = load i8*, i8** %arg1
   %183 = getelementptr inbounds i8, i8* %182, i64 8
   %184 = bitcast i8* %183 to i16*
-  %NullCheck60 = icmp ne i16* %184, null
-  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+  %NullCheck59 = icmp eq i16* %184, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %185
 
 ; <label>:185                                     ; preds = %179
   %186 = load i16, i16* %184, align 8
   %187 = sext i16 %186 to i32
   %188 = bitcast i8* %181 to i16*
   %189 = trunc i32 %187 to i16
-  %NullCheck62 = icmp ne i16* %188, null
-  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+  %NullCheck61 = icmp eq i16* %188, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %190
 
 ; <label>:190                                     ; preds = %185
   store i16 %189, i16* %188, align 8
@@ -1017,15 +1099,15 @@ entry:
   %192 = getelementptr inbounds i8, i8* %191, i64 10
   %193 = load i8*, i8** %arg1
   %194 = getelementptr inbounds i8, i8* %193, i64 10
-  %NullCheck64 = icmp ne i8* %194, null
-  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+  %NullCheck63 = icmp eq i8* %194, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %195
 
 ; <label>:195                                     ; preds = %190
   %196 = load i8, i8* %194, align 8
   %197 = zext i8 %196 to i32
   %198 = trunc i32 %197 to i8
-  %NullCheck66 = icmp ne i8* %192, null
-  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+  %NullCheck65 = icmp eq i8* %192, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %199
 
 ; <label>:199                                     ; preds = %195
   store i8 %198, i8* %192, align 8
@@ -1035,14 +1117,14 @@ entry:
   %201 = load i8*, i8** %arg0
   %202 = load i8*, i8** %arg1
   %203 = bitcast i8* %202 to i64*
-  %NullCheck48 = icmp ne i64* %203, null
-  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+  %NullCheck47 = icmp eq i64* %203, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %204
 
 ; <label>:204                                     ; preds = %200
   %205 = load i64, i64* %203, align 8
   %206 = bitcast i8* %201 to i64*
-  %NullCheck50 = icmp ne i64* %206, null
-  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+  %NullCheck49 = icmp eq i64* %206, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %207
 
 ; <label>:207                                     ; preds = %204
   store i64 %205, i64* %206, align 8
@@ -1051,14 +1133,14 @@ entry:
   %210 = load i8*, i8** %arg1
   %211 = getelementptr inbounds i8, i8* %210, i64 8
   %212 = bitcast i8* %211 to i32*
-  %NullCheck52 = icmp ne i32* %212, null
-  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+  %NullCheck51 = icmp eq i32* %212, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %213
 
 ; <label>:213                                     ; preds = %207
   %214 = load i32, i32* %212, align 8
   %215 = bitcast i8* %209 to i32*
-  %NullCheck54 = icmp ne i32* %215, null
-  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+  %NullCheck53 = icmp eq i32* %215, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %216
 
 ; <label>:216                                     ; preds = %213
   store i32 %214, i32* %215, align 8
@@ -1068,14 +1150,14 @@ entry:
   %218 = load i8*, i8** %arg0
   %219 = load i8*, i8** %arg1
   %220 = bitcast i8* %219 to i64*
-  %NullCheck36 = icmp ne i64* %220, null
-  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64* %220, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %221
 
 ; <label>:221                                     ; preds = %217
   %222 = load i64, i64* %220, align 8
   %223 = bitcast i8* %218 to i64*
-  %NullCheck38 = icmp ne i64* %223, null
-  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+  %NullCheck37 = icmp eq i64* %223, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %224
 
 ; <label>:224                                     ; preds = %221
   store i64 %222, i64* %223, align 8
@@ -1084,14 +1166,14 @@ entry:
   %227 = load i8*, i8** %arg1
   %228 = getelementptr inbounds i8, i8* %227, i64 8
   %229 = bitcast i8* %228 to i32*
-  %NullCheck40 = icmp ne i32* %229, null
-  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i32* %229, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %230
 
 ; <label>:230                                     ; preds = %224
   %231 = load i32, i32* %229, align 8
   %232 = bitcast i8* %226 to i32*
-  %NullCheck42 = icmp ne i32* %232, null
-  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+  %NullCheck41 = icmp eq i32* %232, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %233
 
 ; <label>:233                                     ; preds = %230
   store i32 %231, i32* %232, align 8
@@ -1099,15 +1181,15 @@ entry:
   %235 = getelementptr inbounds i8, i8* %234, i64 12
   %236 = load i8*, i8** %arg1
   %237 = getelementptr inbounds i8, i8* %236, i64 12
-  %NullCheck44 = icmp ne i8* %237, null
-  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i8* %237, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %238
 
 ; <label>:238                                     ; preds = %233
   %239 = load i8, i8* %237, align 8
   %240 = zext i8 %239 to i32
   %241 = trunc i32 %240 to i8
-  %NullCheck46 = icmp ne i8* %235, null
-  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+  %NullCheck45 = icmp eq i8* %235, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %242
 
 ; <label>:242                                     ; preds = %238
   store i8 %241, i8* %235, align 8
@@ -1117,14 +1199,14 @@ entry:
   %244 = load i8*, i8** %arg0
   %245 = load i8*, i8** %arg1
   %246 = bitcast i8* %245 to i64*
-  %NullCheck24 = icmp ne i64* %246, null
-  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64* %246, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %247
 
 ; <label>:247                                     ; preds = %243
   %248 = load i64, i64* %246, align 8
   %249 = bitcast i8* %244 to i64*
-  %NullCheck26 = icmp ne i64* %249, null
-  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64* %249, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %250
 
 ; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
@@ -1133,14 +1215,14 @@ entry:
   %253 = load i8*, i8** %arg1
   %254 = getelementptr inbounds i8, i8* %253, i64 8
   %255 = bitcast i8* %254 to i32*
-  %NullCheck28 = icmp ne i32* %255, null
-  br i1 %NullCheck28, label %256, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i32* %255, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %256
 
 ; <label>:256                                     ; preds = %250
   %257 = load i32, i32* %255, align 8
   %258 = bitcast i8* %252 to i32*
-  %NullCheck30 = icmp ne i32* %258, null
-  br i1 %NullCheck30, label %259, label %ThrowNullRef29
+  %NullCheck29 = icmp eq i32* %258, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %259
 
 ; <label>:259                                     ; preds = %256
   store i32 %257, i32* %258, align 8
@@ -1149,16 +1231,16 @@ entry:
   %262 = load i8*, i8** %arg1
   %263 = getelementptr inbounds i8, i8* %262, i64 12
   %264 = bitcast i8* %263 to i16*
-  %NullCheck32 = icmp ne i16* %264, null
-  br i1 %NullCheck32, label %265, label %ThrowNullRef31
+  %NullCheck31 = icmp eq i16* %264, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %265
 
 ; <label>:265                                     ; preds = %259
   %266 = load i16, i16* %264, align 8
   %267 = sext i16 %266 to i32
   %268 = bitcast i8* %261 to i16*
   %269 = trunc i32 %267 to i16
-  %NullCheck34 = icmp ne i16* %268, null
-  br i1 %NullCheck34, label %270, label %ThrowNullRef33
+  %NullCheck33 = icmp eq i16* %268, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %270
 
 ; <label>:270                                     ; preds = %265
   store i16 %269, i16* %268, align 8
@@ -1168,14 +1250,14 @@ entry:
   %272 = load i8*, i8** %arg0
   %273 = load i8*, i8** %arg1
   %274 = bitcast i8* %273 to i64*
-  %NullCheck8 = icmp ne i64* %274, null
-  br i1 %NullCheck8, label %275, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64* %274, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %275
 
 ; <label>:275                                     ; preds = %271
   %276 = load i64, i64* %274, align 8
   %277 = bitcast i8* %272 to i64*
-  %NullCheck10 = icmp ne i64* %277, null
-  br i1 %NullCheck10, label %278, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %277, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %278
 
 ; <label>:278                                     ; preds = %275
   store i64 %276, i64* %277, align 8
@@ -1184,14 +1266,14 @@ entry:
   %281 = load i8*, i8** %arg1
   %282 = getelementptr inbounds i8, i8* %281, i64 8
   %283 = bitcast i8* %282 to i32*
-  %NullCheck12 = icmp ne i32* %283, null
-  br i1 %NullCheck12, label %284, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i32* %283, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %284
 
 ; <label>:284                                     ; preds = %278
   %285 = load i32, i32* %283, align 8
   %286 = bitcast i8* %280 to i32*
-  %NullCheck14 = icmp ne i32* %286, null
-  br i1 %NullCheck14, label %287, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i32* %286, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %287
 
 ; <label>:287                                     ; preds = %284
   store i32 %285, i32* %286, align 8
@@ -1200,16 +1282,16 @@ entry:
   %290 = load i8*, i8** %arg1
   %291 = getelementptr inbounds i8, i8* %290, i64 12
   %292 = bitcast i8* %291 to i16*
-  %NullCheck16 = icmp ne i16* %292, null
-  br i1 %NullCheck16, label %293, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i16* %292, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %293
 
 ; <label>:293                                     ; preds = %287
   %294 = load i16, i16* %292, align 8
   %295 = sext i16 %294 to i32
   %296 = bitcast i8* %289 to i16*
   %297 = trunc i32 %295 to i16
-  %NullCheck18 = icmp ne i16* %296, null
-  br i1 %NullCheck18, label %298, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i16* %296, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %298
 
 ; <label>:298                                     ; preds = %293
   store i16 %297, i16* %296, align 8
@@ -1217,15 +1299,15 @@ entry:
   %300 = getelementptr inbounds i8, i8* %299, i64 14
   %301 = load i8*, i8** %arg1
   %302 = getelementptr inbounds i8, i8* %301, i64 14
-  %NullCheck20 = icmp ne i8* %302, null
-  br i1 %NullCheck20, label %303, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i8* %302, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %303
 
 ; <label>:303                                     ; preds = %298
   %304 = load i8, i8* %302, align 8
   %305 = zext i8 %304 to i32
   %306 = trunc i32 %305 to i8
-  %NullCheck22 = icmp ne i8* %300, null
-  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i8* %300, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %307
 
 ; <label>:307                                     ; preds = %303
   store i8 %306, i8* %300, align 8
@@ -1235,14 +1317,14 @@ entry:
   %309 = load i8*, i8** %arg0
   %310 = load i8*, i8** %arg1
   %311 = bitcast i8* %310 to i64*
-  %NullCheck = icmp ne i64* %311, null
-  br i1 %NullCheck, label %312, label %ThrowNullRef
+  %NullCheck = icmp eq i64* %311, null
+  br i1 %NullCheck, label %ThrowNullRef, label %312
 
 ; <label>:312                                     ; preds = %308
   %313 = load i64, i64* %311, align 8
   %314 = bitcast i8* %309 to i64*
-  %NullCheck2 = icmp ne i64* %314, null
-  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64* %314, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %315
 
 ; <label>:315                                     ; preds = %312
   store i64 %313, i64* %314, align 8
@@ -1251,14 +1333,14 @@ entry:
   %318 = load i8*, i8** %arg1
   %319 = getelementptr inbounds i8, i8* %318, i64 8
   %320 = bitcast i8* %319 to i64*
-  %NullCheck4 = icmp ne i64* %320, null
-  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64* %320, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %321
 
 ; <label>:321                                     ; preds = %315
   %322 = load i64, i64* %320, align 8
   %323 = bitcast i8* %317 to i64*
-  %NullCheck6 = icmp ne i64* %323, null
-  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64* %323, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %324
 
 ; <label>:324                                     ; preds = %321
   store i64 %322, i64* %323, align 8
@@ -1286,15 +1368,15 @@ entry:
 ; <label>:338                                     ; preds = %333
   %339 = load i8*, i8** %arg0
   %340 = load i8*, i8** %arg1
-  %NullCheck136 = icmp ne i8* %340, null
-  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+  %NullCheck135 = icmp eq i8* %340, null
+  br i1 %NullCheck135, label %ThrowNullRef136, label %341
 
 ; <label>:341                                     ; preds = %338
   %342 = load i8, i8* %340, align 8
   %343 = zext i8 %342 to i32
   %344 = trunc i32 %343 to i8
-  %NullCheck138 = icmp ne i8* %339, null
-  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+  %NullCheck137 = icmp eq i8* %339, null
+  br i1 %NullCheck137, label %ThrowNullRef138, label %345
 
 ; <label>:345                                     ; preds = %341
   store i8 %344, i8* %339, align 8
@@ -1317,16 +1399,16 @@ entry:
   %357 = load i8*, i8** %arg0
   %358 = load i8*, i8** %arg1
   %359 = bitcast i8* %358 to i16*
-  %NullCheck140 = icmp ne i16* %359, null
-  br i1 %NullCheck140, label %360, label %ThrowNullRef139
+  %NullCheck139 = icmp eq i16* %359, null
+  br i1 %NullCheck139, label %ThrowNullRef140, label %360
 
 ; <label>:360                                     ; preds = %356
   %361 = load i16, i16* %359, align 8
   %362 = sext i16 %361 to i32
   %363 = bitcast i8* %357 to i16*
   %364 = trunc i32 %362 to i16
-  %NullCheck142 = icmp ne i16* %363, null
-  br i1 %NullCheck142, label %365, label %ThrowNullRef141
+  %NullCheck141 = icmp eq i16* %363, null
+  br i1 %NullCheck141, label %ThrowNullRef142, label %365
 
 ; <label>:365                                     ; preds = %360
   store i16 %364, i16* %363, align 8
@@ -1352,14 +1434,14 @@ entry:
   %378 = load i8*, i8** %arg0
   %379 = load i8*, i8** %arg1
   %380 = bitcast i8* %379 to i32*
-  %NullCheck144 = icmp ne i32* %380, null
-  br i1 %NullCheck144, label %381, label %ThrowNullRef143
+  %NullCheck143 = icmp eq i32* %380, null
+  br i1 %NullCheck143, label %ThrowNullRef144, label %381
 
 ; <label>:381                                     ; preds = %377
   %382 = load i32, i32* %380, align 8
   %383 = bitcast i8* %378 to i32*
-  %NullCheck146 = icmp ne i32* %383, null
-  br i1 %NullCheck146, label %384, label %ThrowNullRef145
+  %NullCheck145 = icmp eq i32* %383, null
+  br i1 %NullCheck145, label %ThrowNullRef146, label %384
 
 ; <label>:384                                     ; preds = %381
   store i32 %382, i32* %383, align 8
@@ -1384,14 +1466,14 @@ entry:
   %395 = load i8*, i8** %arg0
   %396 = load i8*, i8** %arg1
   %397 = bitcast i8* %396 to i64*
-  %NullCheck164 = icmp ne i64* %397, null
-  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+  %NullCheck163 = icmp eq i64* %397, null
+  br i1 %NullCheck163, label %ThrowNullRef164, label %398
 
 ; <label>:398                                     ; preds = %394
   %399 = load i64, i64* %397, align 8
   %400 = bitcast i8* %395 to i64*
-  %NullCheck166 = icmp ne i64* %400, null
-  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+  %NullCheck165 = icmp eq i64* %400, null
+  br i1 %NullCheck165, label %ThrowNullRef166, label %401
 
 ; <label>:401                                     ; preds = %398
   store i64 %399, i64* %400, align 8
@@ -1400,14 +1482,14 @@ entry:
   %404 = load i8*, i8** %arg1
   %405 = getelementptr inbounds i8, i8* %404, i64 8
   %406 = bitcast i8* %405 to i64*
-  %NullCheck168 = icmp ne i64* %406, null
-  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+  %NullCheck167 = icmp eq i64* %406, null
+  br i1 %NullCheck167, label %ThrowNullRef168, label %407
 
 ; <label>:407                                     ; preds = %401
   %408 = load i64, i64* %406, align 8
   %409 = bitcast i8* %403 to i64*
-  %NullCheck170 = icmp ne i64* %409, null
-  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+  %NullCheck169 = icmp eq i64* %409, null
+  br i1 %NullCheck169, label %ThrowNullRef170, label %410
 
 ; <label>:410                                     ; preds = %407
   store i64 %408, i64* %409, align 8
@@ -1437,14 +1519,14 @@ entry:
   %425 = load i8*, i8** %arg0
   %426 = load i8*, i8** %arg1
   %427 = bitcast i8* %426 to i64*
-  %NullCheck148 = icmp ne i64* %427, null
-  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+  %NullCheck147 = icmp eq i64* %427, null
+  br i1 %NullCheck147, label %ThrowNullRef148, label %428
 
 ; <label>:428                                     ; preds = %424
   %429 = load i64, i64* %427, align 8
   %430 = bitcast i8* %425 to i64*
-  %NullCheck150 = icmp ne i64* %430, null
-  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+  %NullCheck149 = icmp eq i64* %430, null
+  br i1 %NullCheck149, label %ThrowNullRef150, label %431
 
 ; <label>:431                                     ; preds = %428
   store i64 %429, i64* %430, align 8
@@ -1466,14 +1548,14 @@ entry:
   %441 = load i8*, i8** %arg0
   %442 = load i8*, i8** %arg1
   %443 = bitcast i8* %442 to i32*
-  %NullCheck152 = icmp ne i32* %443, null
-  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+  %NullCheck151 = icmp eq i32* %443, null
+  br i1 %NullCheck151, label %ThrowNullRef152, label %444
 
 ; <label>:444                                     ; preds = %440
   %445 = load i32, i32* %443, align 8
   %446 = bitcast i8* %441 to i32*
-  %NullCheck154 = icmp ne i32* %446, null
-  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+  %NullCheck153 = icmp eq i32* %446, null
+  br i1 %NullCheck153, label %ThrowNullRef154, label %447
 
 ; <label>:447                                     ; preds = %444
   store i32 %445, i32* %446, align 8
@@ -1495,16 +1577,16 @@ entry:
   %457 = load i8*, i8** %arg0
   %458 = load i8*, i8** %arg1
   %459 = bitcast i8* %458 to i16*
-  %NullCheck156 = icmp ne i16* %459, null
-  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+  %NullCheck155 = icmp eq i16* %459, null
+  br i1 %NullCheck155, label %ThrowNullRef156, label %460
 
 ; <label>:460                                     ; preds = %456
   %461 = load i16, i16* %459, align 8
   %462 = sext i16 %461 to i32
   %463 = bitcast i8* %457 to i16*
   %464 = trunc i32 %462 to i16
-  %NullCheck158 = icmp ne i16* %463, null
-  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+  %NullCheck157 = icmp eq i16* %463, null
+  br i1 %NullCheck157, label %ThrowNullRef158, label %465
 
 ; <label>:465                                     ; preds = %460
   store i16 %464, i16* %463, align 8
@@ -1525,15 +1607,15 @@ entry:
 ; <label>:474                                     ; preds = %470
   %475 = load i8*, i8** %arg0
   %476 = load i8*, i8** %arg1
-  %NullCheck160 = icmp ne i8* %476, null
-  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+  %NullCheck159 = icmp eq i8* %476, null
+  br i1 %NullCheck159, label %ThrowNullRef160, label %477
 
 ; <label>:477                                     ; preds = %474
   %478 = load i8, i8* %476, align 8
   %479 = zext i8 %478 to i32
   %480 = trunc i32 %479 to i8
-  %NullCheck162 = icmp ne i8* %475, null
-  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+  %NullCheck161 = icmp eq i8* %475, null
+  br i1 %NullCheck161, label %ThrowNullRef162, label %481
 
 ; <label>:481                                     ; preds = %477
   store i8 %480, i8* %475, align 8
@@ -1553,343 +1635,343 @@ ThrowNullRef:                                     ; preds = %308
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %312
+ThrowNullRef2:                                    ; preds = %312
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %315
+ThrowNullRef4:                                    ; preds = %315
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %321
+ThrowNullRef6:                                    ; preds = %321
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %271
+ThrowNullRef8:                                    ; preds = %271
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %275
+ThrowNullRef10:                                   ; preds = %275
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %278
+ThrowNullRef12:                                   ; preds = %278
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %284
+ThrowNullRef14:                                   ; preds = %284
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %287
+ThrowNullRef16:                                   ; preds = %287
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %293
+ThrowNullRef18:                                   ; preds = %293
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %298
+ThrowNullRef20:                                   ; preds = %298
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %303
+ThrowNullRef22:                                   ; preds = %303
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %243
+ThrowNullRef24:                                   ; preds = %243
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %247
+ThrowNullRef26:                                   ; preds = %247
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %250
+ThrowNullRef28:                                   ; preds = %250
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %256
+ThrowNullRef30:                                   ; preds = %256
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %259
+ThrowNullRef32:                                   ; preds = %259
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %265
+ThrowNullRef34:                                   ; preds = %265
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %217
+ThrowNullRef36:                                   ; preds = %217
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %221
+ThrowNullRef38:                                   ; preds = %221
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %224
+ThrowNullRef40:                                   ; preds = %224
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %230
+ThrowNullRef42:                                   ; preds = %230
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %233
+ThrowNullRef44:                                   ; preds = %233
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %238
+ThrowNullRef46:                                   ; preds = %238
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %200
+ThrowNullRef48:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %204
+ThrowNullRef50:                                   ; preds = %204
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %207
+ThrowNullRef52:                                   ; preds = %207
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %213
+ThrowNullRef54:                                   ; preds = %213
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %172
+ThrowNullRef56:                                   ; preds = %172
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %176
+ThrowNullRef58:                                   ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %179
+ThrowNullRef60:                                   ; preds = %179
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %185
+ThrowNullRef62:                                   ; preds = %185
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %190
+ThrowNullRef64:                                   ; preds = %190
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %195
+ThrowNullRef66:                                   ; preds = %195
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %153
+ThrowNullRef68:                                   ; preds = %153
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %157
+ThrowNullRef70:                                   ; preds = %157
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %160
+ThrowNullRef72:                                   ; preds = %160
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %166
+ThrowNullRef74:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %136
+ThrowNullRef76:                                   ; preds = %136
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %140
+ThrowNullRef78:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %143
+ThrowNullRef80:                                   ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %148
+ThrowNullRef82:                                   ; preds = %148
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %128
+ThrowNullRef84:                                   ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %132
+ThrowNullRef86:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %100
+ThrowNullRef88:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %104
+ThrowNullRef90:                                   ; preds = %104
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %107
+ThrowNullRef92:                                   ; preds = %107
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %113
+ThrowNullRef94:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %118
+ThrowNullRef96:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %123
+ThrowNullRef98:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %81
+ThrowNullRef100:                                  ; preds = %81
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef101:                                  ; preds = %85
+ThrowNullRef102:                                  ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef103:                                  ; preds = %88
+ThrowNullRef104:                                  ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef105:                                  ; preds = %94
+ThrowNullRef106:                                  ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef107:                                  ; preds = %64
+ThrowNullRef108:                                  ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef109:                                  ; preds = %68
+ThrowNullRef110:                                  ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef111:                                  ; preds = %71
+ThrowNullRef112:                                  ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef113:                                  ; preds = %76
+ThrowNullRef114:                                  ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef115:                                  ; preds = %56
+ThrowNullRef116:                                  ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef117:                                  ; preds = %60
+ThrowNullRef118:                                  ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef119:                                  ; preds = %37
+ThrowNullRef120:                                  ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef121:                                  ; preds = %41
+ThrowNullRef122:                                  ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef123:                                  ; preds = %46
+ThrowNullRef124:                                  ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef125:                                  ; preds = %51
+ThrowNullRef126:                                  ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef127:                                  ; preds = %27
+ThrowNullRef128:                                  ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef129:                                  ; preds = %31
+ThrowNullRef130:                                  ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef131:                                  ; preds = %19
+ThrowNullRef132:                                  ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef133:                                  ; preds = %22
+ThrowNullRef134:                                  ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef135:                                  ; preds = %338
+ThrowNullRef136:                                  ; preds = %338
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef137:                                  ; preds = %341
+ThrowNullRef138:                                  ; preds = %341
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef139:                                  ; preds = %356
+ThrowNullRef140:                                  ; preds = %356
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef141:                                  ; preds = %360
+ThrowNullRef142:                                  ; preds = %360
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef143:                                  ; preds = %377
+ThrowNullRef144:                                  ; preds = %377
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef145:                                  ; preds = %381
+ThrowNullRef146:                                  ; preds = %381
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef147:                                  ; preds = %424
+ThrowNullRef148:                                  ; preds = %424
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef149:                                  ; preds = %428
+ThrowNullRef150:                                  ; preds = %428
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef151:                                  ; preds = %440
+ThrowNullRef152:                                  ; preds = %440
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef153:                                  ; preds = %444
+ThrowNullRef154:                                  ; preds = %444
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef155:                                  ; preds = %456
+ThrowNullRef156:                                  ; preds = %456
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef157:                                  ; preds = %460
+ThrowNullRef158:                                  ; preds = %460
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef159:                                  ; preds = %474
+ThrowNullRef160:                                  ; preds = %474
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef161:                                  ; preds = %477
+ThrowNullRef162:                                  ; preds = %477
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef163:                                  ; preds = %394
+ThrowNullRef164:                                  ; preds = %394
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef165:                                  ; preds = %398
+ThrowNullRef166:                                  ; preds = %398
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef167:                                  ; preds = %401
+ThrowNullRef168:                                  ; preds = %401
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef169:                                  ; preds = %407
+ThrowNullRef170:                                  ; preds = %407
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1939,8 +2021,8 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
-  br i1 %NullCheck, label %22, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %ThrowNullRef, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
@@ -1948,8 +2030,8 @@ entry:
   store i32 %24, i32* %loc0
   %25 = load i32, i32* %loc0
   %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %26, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %27
 
 ; <label>:27                                      ; preds = %22
   %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
@@ -1971,7 +2053,7 @@ ThrowNullRef:                                     ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1989,8 +2071,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -2022,15 +2104,15 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2048,16 +2130,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
   %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
   store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %15
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
@@ -2072,8 +2154,8 @@ entry:
   %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
   %29 = ptrtoint i16 addrspace(1)* %28 to i64
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %19
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
@@ -2089,19 +2171,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2114,8 +2196,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
@@ -2128,7 +2210,7 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[loadElem]
+Failed to read AppDomain.PrepareDataForSetup[storeElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
@@ -2202,8 +2284,8 @@ entry:
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
-  br i1 %NullCheck24, label %27, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = load i64, i64 addrspace(1)* %26
@@ -2218,8 +2300,8 @@ entry:
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
-  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
   %41 = load i64, i64 addrspace(1)* %39
@@ -2236,8 +2318,8 @@ entry:
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
-  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
   %54 = load i64, i64 addrspace(1)* %52
@@ -2252,8 +2334,8 @@ entry:
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
   %67 = load i64, i64 addrspace(1)* %65
@@ -2270,8 +2352,8 @@ entry:
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
-  br i1 %NullCheck16, label %79, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
   %80 = load i64, i64 addrspace(1)* %78
@@ -2286,8 +2368,8 @@ entry:
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
-  br i1 %NullCheck18, label %92, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
   %93 = load i64, i64 addrspace(1)* %91
@@ -2304,8 +2386,8 @@ entry:
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
-  br i1 %NullCheck12, label %105, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = load i64, i64 addrspace(1)* %104
@@ -2320,8 +2402,8 @@ entry:
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
-  br i1 %NullCheck14, label %118, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
   %119 = load i64, i64 addrspace(1)* %117
@@ -2337,8 +2419,8 @@ entry:
 
 ; <label>:128                                     ; preds = %20
   %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
-  br i1 %NullCheck4, label %130, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %129, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %130
 
 ; <label>:130                                     ; preds = %128
   %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
@@ -2346,8 +2428,8 @@ entry:
   %133 = load i16, i16 addrspace(1)* %132, align 8
   %134 = zext i16 %133 to i32
   %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
-  br i1 %NullCheck6, label %136, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %135, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %136
 
 ; <label>:136                                     ; preds = %130
   %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
@@ -2360,8 +2442,8 @@ entry:
 
 ; <label>:143                                     ; preds = %136
   %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
-  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %144, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %145
 
 ; <label>:145                                     ; preds = %143
   %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
@@ -2369,8 +2451,8 @@ entry:
   %148 = load i16, i16 addrspace(1)* %147, align 8
   %149 = zext i16 %148 to i32
   %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %150, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %151
 
 ; <label>:151                                     ; preds = %145
   %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
@@ -2388,8 +2470,8 @@ entry:
 
 ; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
-  br i1 %NullCheck, label %163, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %ThrowNullRef, label %163
 
 ; <label>:163                                     ; preds = %161
   %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
@@ -2399,8 +2481,8 @@ entry:
 
 ; <label>:167                                     ; preds = %163
   %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
-  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %168, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %169
 
 ; <label>:169                                     ; preds = %167
   %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
@@ -2432,55 +2514,55 @@ ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %167
+ThrowNullRef2:                                    ; preds = %167
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %128
+ThrowNullRef4:                                    ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %130
+ThrowNullRef6:                                    ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %143
+ThrowNullRef8:                                    ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %145
+ThrowNullRef10:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %102
+ThrowNullRef12:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %105
+ThrowNullRef14:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %76
+ThrowNullRef16:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %79
+ThrowNullRef18:                                   ; preds = %79
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %50
+ThrowNullRef20:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %53
+ThrowNullRef22:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %24
+ThrowNullRef24:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %27
+ThrowNullRef26:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2503,15 +2585,15 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2519,16 +2601,16 @@ entry:
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
   store i32 %8, i32* %loc0
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
   %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
   store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
@@ -2546,16 +2628,16 @@ entry:
 
 ; <label>:23                                      ; preds = %64
   %24 = load i16*, i16** %loc3
-  %NullCheck12 = icmp ne i16* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i16* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
   store i32 %27, i32* %loc5
   %28 = load i16*, i16** %loc4
-  %NullCheck14 = icmp ne i16* %28, null
-  br i1 %NullCheck14, label %29, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %28, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = load i16, i16* %28, align 8
@@ -2620,15 +2702,15 @@ entry:
 
 ; <label>:67                                      ; preds = %64
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
-  br i1 %NullCheck8, label %69, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %68, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %69
 
 ; <label>:69                                      ; preds = %67
   %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
   %71 = load i32, i32 addrspace(1)* %70
   %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
-  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %73
 
 ; <label>:73                                      ; preds = %69
   %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
@@ -2645,31 +2727,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %67
+ThrowNullRef8:                                    ; preds = %67
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %69
+ThrowNullRef10:                                   ; preds = %69
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2710,14 +2792,14 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
   %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
@@ -2730,14 +2812,14 @@ entry:
 
 ; <label>:11                                      ; preds = %4
   %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
   %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
@@ -2749,14 +2831,14 @@ entry:
 
 ; <label>:22                                      ; preds = %16
   %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
   %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
-  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
-  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
@@ -2804,23 +2886,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2836,7 +2918,280 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[loadElem]
+Successfully read RuntimeType.IsAssignableFrom
+
+define i8 @RuntimeType.IsAssignableFrom(%System.RuntimeType addrspace(1)* %param0, %System.Type addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.RuntimeType addrspace(1)*
+  %arg1 = alloca %System.Type addrspace(1)*
+  %loc0 = alloca %System.RuntimeType addrspace(1)*
+  %loc1 = alloca %"System.Type[]" addrspace(1)*
+  %loc2 = alloca i32
+  store %System.RuntimeType addrspace(1)* %param0, %System.RuntimeType addrspace(1)** %this
+  store %System.Type addrspace(1)* %param1, %System.Type addrspace(1)** %arg1
+  %0 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %1 = icmp ne %System.Type addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i8 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %5 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %6 = bitcast %System.Type addrspace(1)* %4 to %System.Object addrspace(1)*
+  %7 = bitcast %System.RuntimeType addrspace(1)* %5 to %System.Object addrspace(1)*
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %6, %System.Object addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %3
+  ret i8 1
+
+; <label>:12                                      ; preds = %3
+  %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 152
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 32
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
+  %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
+  %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
+  store %System.RuntimeType addrspace(1)* %25, %System.RuntimeType addrspace(1)** %loc0
+  %26 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %27 = icmp eq %System.RuntimeType addrspace(1)* %26, null
+  br i1 %27, label %34, label %28
+
+; <label>:28                                      ; preds = %15
+  %29 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %30 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)*)*)(%System.RuntimeType addrspace(1)* %29, %System.RuntimeType addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+; <label>:34                                      ; preds = %15
+  %35 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %36 = call %System.Reflection.Emit.TypeBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Reflection.Emit.TypeBuilder addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %35)
+  %37 = icmp eq %System.Reflection.Emit.TypeBuilder addrspace(1)* %36, null
+  br i1 %37, label %139, label %38
+
+; <label>:38                                      ; preds = %34
+  %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %42
+
+; <label>:42                                      ; preds = %38
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 152
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 40
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
+  %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
+  %53 = zext i8 %52 to i32
+  %54 = icmp eq i32 %53, 0
+  br i1 %54, label %56, label %55
+
+; <label>:55                                      ; preds = %42
+  ret i8 1
+
+; <label>:56                                      ; preds = %42
+  %57 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %58 = bitcast %System.RuntimeType addrspace(1)* %57 to %System.Type addrspace(1)*
+  %59 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %58)
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %64 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.Type addrspace(1)* %63, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = bitcast %System.RuntimeType addrspace(1)* %64 to %System.Type addrspace(1)*
+  %67 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %63, %System.Type addrspace(1)* %66)
+  %68 = zext i8 %67 to i32
+  %69 = trunc i32 %68 to i8
+  ret i8 %69
+
+; <label>:70                                      ; preds = %56
+  %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
+  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %73
+
+; <label>:73                                      ; preds = %70
+  %74 = load i64, i64 addrspace(1)* %72
+  %75 = add i64 %74, 128
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = add i64 %77, 0
+  %79 = inttoptr i64 %78 to i64*
+  %80 = load i64, i64* %79
+  %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
+  %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
+  %83 = call i8 %82(%System.Type addrspace(1)* %81)
+  %84 = zext i8 %83 to i32
+  %85 = icmp eq i32 %84, 0
+  br i1 %85, label %139, label %86
+
+; <label>:86                                      ; preds = %73
+  %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
+  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %89
+
+; <label>:89                                      ; preds = %86
+  %90 = load i64, i64 addrspace(1)* %88
+  %91 = add i64 %90, 128
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = add i64 %93, 24
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
+  %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
+  %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
+  store %"System.Type[]" addrspace(1)* %99, %"System.Type[]" addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %129
+
+; <label>:100                                     ; preds = %132
+  %101 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %102 = load i32, i32* %loc2
+  %NullCheck11 = icmp eq %"System.Type[]" addrspace(1)* %101, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %103
+
+; <label>:103                                     ; preds = %100
+  %104 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 1
+  %105 = load i32, i32 addrspace(1)* %104
+  %106 = zext i32 %105 to i64
+  %107 = zext i32 %102 to i64
+  %BoundsCheck = icmp uge i64 %107, %106
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %108
+
+; <label>:108                                     ; preds = %103
+  %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
+  %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
+  %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
+  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %113
+
+; <label>:113                                     ; preds = %108
+  %114 = load i64, i64 addrspace(1)* %112
+  %115 = add i64 %114, 152
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = add i64 %117, 56
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
+  %123 = zext i8 %122 to i32
+  %124 = icmp ne i32 %123, 0
+  br i1 %124, label %126, label %125
+
+; <label>:125                                     ; preds = %113
+  ret i8 0
+
+; <label>:126                                     ; preds = %113
+  %127 = load i32, i32* %loc2
+  %128 = add i32 %127, 1
+  store i32 %128, i32* %loc2
+  br label %129
+
+; <label>:129                                     ; preds = %89, %126
+  %130 = load i32, i32* %loc2
+  %131 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %NullCheck9 = icmp eq %"System.Type[]" addrspace(1)* %131, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %132
+
+; <label>:132                                     ; preds = %129
+  %133 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %131, i32 0, i32 1
+  %134 = load i32, i32 addrspace(1)* %133
+  %135 = zext i32 %134 to i64
+  %136 = trunc i64 %135 to i32
+  %137 = icmp slt i32 %130, %136
+  br i1 %137, label %100, label %138
+
+; <label>:138                                     ; preds = %132
+  ret i8 1
+
+; <label>:139                                     ; preds = %34, %73
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %129
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %103
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -2893,7 +3248,7 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElem]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -2904,8 +3259,8 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -2997,8 +3352,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
@@ -3059,8 +3414,8 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -3087,8 +3442,8 @@ entry:
 
 ; <label>:17                                      ; preds = %5, %11
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
@@ -3097,8 +3452,8 @@ entry:
 
 ; <label>:22                                      ; preds = %1, %11
   %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
@@ -3109,11 +3464,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %17
+ThrowNullRef2:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %22
+ThrowNullRef4:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3167,15 +3522,15 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
   %15 = load i32, i32 addrspace(1)* %14
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
@@ -3198,7 +3553,7 @@ ThrowNullRef:                                     ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef2:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3232,8 +3587,8 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
@@ -3312,8 +3667,8 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -3327,8 +3682,8 @@ entry:
 ; <label>:5                                       ; preds = %43
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %7 = load i32, i32* %loc1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck6, label %8, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
@@ -3366,8 +3721,8 @@ entry:
 ; <label>:32                                      ; preds = %21, %25
   %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
   %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
-  br i1 %NullCheck8, label %35, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = trunc i32 %34 to i16
@@ -3380,8 +3735,8 @@ entry:
 ; <label>:40                                      ; preds = %1, %35
   %41 = load i32, i32* %loc1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
-  br i1 %NullCheck2, label %43, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %42, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
@@ -3392,8 +3747,8 @@ entry:
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
   %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
-  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
   %51 = load i64, i64 addrspace(1)* %49
@@ -3412,19 +3767,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %40
+ThrowNullRef2:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %47
+ThrowNullRef4:                                    ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %5
+ThrowNullRef6:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %32
+ThrowNullRef8:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3467,8 +3822,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
@@ -3492,11 +3847,391 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(i16* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store i16* %param0, i16** %arg0
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load i32, i32* %arg3
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %42, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %37, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg2
+  %13 = load i32, i32* %arg3
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %37, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %24 = load i32, i32* %arg2
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load i16*, i16** %arg0
+  %35 = load i32, i32* %arg3
+  %36 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %36, i16* %34, i32 %35)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:37                                      ; preds = %5, %16
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %39)
+  %41 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41, %System.String addrspace(1)* %38, %System.String addrspace(1)* %40)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41) #0
+  unreachable
+
+; <label>:42                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
-Failed to read StringBuilder.ToString[loadElemA]
+Successfully read StringBuilder.ToString
+
+define %System.String addrspace(1)* @StringBuilder.ToString(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i16*
+  %loc3 = alloca %"System.Char[]" addrspace(1)*
+  %loc4 = alloca i32
+  %loc5 = alloca i32
+  %loc6 = alloca i16 addrspace(1)*
+  %loc7 = alloca %System.String addrspace(1)*
+  %loc8 = alloca %"System.Char[]" addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %0)
+  %2 = icmp ne i32 %1, 0
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %4
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %6)
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %7)
+  store %System.String addrspace(1)* %8, %System.String addrspace(1)** %loc0
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.Text.StringBuilder addrspace(1)* %9, %System.Text.StringBuilder addrspace(1)** %loc1
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  store %System.String addrspace(1)* %10, %System.String addrspace(1)** %loc7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc7
+  %12 = ptrtoint %System.String addrspace(1)* %11 to i64
+  %13 = icmp eq i64 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %5
+  %15 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %16 = sext i32 %15 to i64
+  %17 = add i64 %12, %16
+  br label %18
+
+; <label>:18                                      ; preds = %5, %14
+  %19 = phi i64 [ %12, %5 ], [ %17, %14 ]
+  %20 = inttoptr i64 %19 to i16*
+  store i16* %20, i16** %loc2
+  br label %21
+
+; <label>:21                                      ; preds = %98, %18
+  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %22, null
+  br i1 %NullCheck, label %ThrowNullRef, label %23
+
+; <label>:23                                      ; preds = %21
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 3
+  %25 = load i32, i32 addrspace(1)* %24, align 8
+  %26 = icmp sle i32 %25, 0
+  br i1 %26, label %96, label %27
+
+; <label>:27                                      ; preds = %23
+  %28 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %28, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %29
+
+; <label>:29                                      ; preds = %27
+  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %28, i32 0, i32 1
+  %31 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %30, align 8
+  store %"System.Char[]" addrspace(1)* %31, %"System.Char[]" addrspace(1)** %loc3
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %33
+
+; <label>:33                                      ; preds = %29
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  store i32 %35, i32* %loc4
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  %39 = load i32, i32 addrspace(1)* %38, align 8
+  store i32 %39, i32* %loc5
+  %40 = load i32, i32* %loc5
+  %41 = load i32, i32* %loc4
+  %42 = add i32 %40, %41
+  %43 = zext i32 %42 to i64
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %45
+
+; <label>:45                                      ; preds = %37
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = sext i32 %47 to i64
+  %49 = icmp sgt i64 %43, %48
+  br i1 %49, label %91, label %50
+
+; <label>:50                                      ; preds = %45
+  %51 = load i32, i32* %loc5
+  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %52, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %53
+
+; <label>:53                                      ; preds = %50
+  %54 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %52, i32 0, i32 1
+  %55 = load i32, i32 addrspace(1)* %54
+  %56 = zext i32 %55 to i64
+  %57 = trunc i64 %56 to i32
+  %58 = icmp ugt i32 %51, %57
+  br i1 %58, label %91, label %59
+
+; <label>:59                                      ; preds = %53
+  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  store %"System.Char[]" addrspace(1)* %60, %"System.Char[]" addrspace(1)** %loc8
+  %61 = icmp eq %"System.Char[]" addrspace(1)* %60, null
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %63, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %64
+
+; <label>:64                                      ; preds = %62
+  %65 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %63, i32 0, i32 1
+  %66 = load i32, i32 addrspace(1)* %65
+  %67 = zext i32 %66 to i64
+  %68 = trunc i64 %67 to i32
+  %69 = icmp ne i32 %68, 0
+  br i1 %69, label %71, label %70
+
+; <label>:70                                      ; preds = %59, %64
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:71                                      ; preds = %64
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %73
+
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %BoundsCheck = icmp uge i64 0, %76
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %77
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %78, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:79                                      ; preds = %70, %77
+  %80 = load i16*, i16** %loc2
+  %81 = load i32, i32* %loc4
+  %82 = sext i32 %81 to i64
+  %83 = mul i64 %82, 2
+  %84 = bitcast i16* %80 to i8*
+  %85 = getelementptr inbounds i8, i8* %84, i64 %83
+  %86 = load i16 addrspace(1)*, i16 addrspace(1)** %loc6
+  %87 = ptrtoint i16 addrspace(1)* %86 to i64
+  %88 = load i32, i32* %loc5
+  %89 = bitcast i8* %85 to i16*
+  %90 = inttoptr i64 %87 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %89, i16* %90, i32 %88)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %96
+
+; <label>:91                                      ; preds = %45, %53
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %94 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %93)
+  %95 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95, %System.String addrspace(1)* %92, %System.String addrspace(1)* %94)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95) #0
+  unreachable
+
+; <label>:96                                      ; preds = %23, %79
+  %97 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %97, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %98
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %97, i32 0, i32 2
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  store %System.Text.StringBuilder addrspace(1)* %100, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %102 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %102, label %21, label %103
+
+; <label>:103                                     ; preds = %98
+  store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc7
+  %104 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  ret %System.String addrspace(1)* %104
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method StringBuilder::get_Length using LLILCJit
+Successfully read StringBuilder.get_Length
+
+define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
+Successfully read RuntimeHelpers.get_OffsetToStringData
+
+define i32 @RuntimeHelpers.get_OffsetToStringData() {
+entry:
+  ret i32 12
+}
+
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
 Successfully read CultureData.CreateCultureData
 
@@ -3514,23 +4249,23 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
   store i8 %4, i8 addrspace(1)* %6
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
@@ -3549,11 +4284,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3566,50 +4301,50 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
   store i32 -1, i32 addrspace(1)* %2
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
   store i32 -1, i32 addrspace(1)* %8
   %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
   store i32 -1, i32 addrspace(1)* %14
   %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
   store i32 -1, i32 addrspace(1)* %17
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
@@ -3623,27 +4358,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3675,7 +4410,136 @@ Failed to read Dictionary`2.Insert[non-const derefAddress]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
 Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
-Failed to read HashHelpers.GetPrime[loadElem]
+Successfully read HashHelpers.GetPrime
+
+define i32 @HashHelpers.GetPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %6, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5, %System.String addrspace(1)* %4)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5) #0
+  unreachable
+
+; <label>:6                                       ; preds = %entry
+  store i32 0, i32* %loc0
+  br label %29
+
+; <label>:7                                       ; preds = %35
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 1296
+  %10 = addrspacecast i8 addrspace(1)* %9 to %"System.Int32[]" addrspace(1)**
+  %11 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %10
+  %12 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Int32[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = zext i32 %15 to i64
+  %17 = zext i32 %12 to i64
+  %BoundsCheck = icmp uge i64 %17, %16
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 3, i32 %12
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  store i32 %20, i32* %loc1
+  %21 = load i32, i32* %loc1
+  %22 = load i32, i32* %arg0
+  %23 = icmp slt i32 %21, %22
+  br i1 %23, label %26, label %24
+
+; <label>:24                                      ; preds = %18
+  %25 = load i32, i32* %loc1
+  ret i32 %25
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %loc0
+  %28 = add i32 %27, 1
+  store i32 %28, i32* %loc0
+  br label %29
+
+; <label>:29                                      ; preds = %6, %26
+  %30 = load i32, i32* %loc0
+  %31 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %32 = getelementptr inbounds i8, i8 addrspace(1)* %31, i64 1296
+  %33 = addrspacecast i8 addrspace(1)* %32 to %"System.Int32[]" addrspace(1)**
+  %34 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %33
+  %NullCheck = icmp eq %"System.Int32[]" addrspace(1)* %34, null
+  br i1 %NullCheck, label %ThrowNullRef, label %35
+
+; <label>:35                                      ; preds = %29
+  %36 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %34, i32 0, i32 1
+  %37 = load i32, i32 addrspace(1)* %36
+  %38 = zext i32 %37 to i64
+  %39 = trunc i64 %38 to i32
+  %40 = icmp slt i32 %30, %39
+  br i1 %40, label %7, label %41
+
+; <label>:41                                      ; preds = %35
+  %42 = load i32, i32* %arg0
+  %43 = or i32 %42, 1
+  store i32 %43, i32* %loc2
+  br label %59
+
+; <label>:44                                      ; preds = %59
+  %45 = load i32, i32* %loc2
+  %46 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %45)
+  %47 = zext i8 %46 to i32
+  %48 = icmp eq i32 %47, 0
+  br i1 %48, label %56, label %49
+
+; <label>:49                                      ; preds = %44
+  %50 = load i32, i32* %loc2
+  %51 = sub i32 %50, 1
+  %52 = srem i32 %51, 101
+  %53 = icmp eq i32 %52, 0
+  br i1 %53, label %56, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = load i32, i32* %loc2
+  ret i32 %55
+
+; <label>:56                                      ; preds = %44, %49
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %57, 2
+  store i32 %58, i32* %loc2
+  br label %59
+
+; <label>:59                                      ; preds = %41, %56
+  %60 = load i32, i32* %loc2
+  %61 = icmp slt i32 %60, 2147483647
+  br i1 %61, label %44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load i32, i32* %arg0
+  ret i32 %63
+
+ThrowNullRef:                                     ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
 Successfully read GenericEqualityComparer`1.GetHashCode
 
@@ -3694,14 +4558,14 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
   %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load i64, i64 addrspace(1)* %7
@@ -3720,7 +4584,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3750,8 +4614,8 @@ entry:
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
@@ -3796,8 +4660,8 @@ entry:
   %35 = bitcast i16* %34 to i8*
   %36 = getelementptr inbounds i8, i8* %35, i64 2
   %37 = bitcast i8* %36 to i16*
-  %NullCheck4 = icmp ne i16* %37, null
-  br i1 %NullCheck4, label %38, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %37, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %38
 
 ; <label>:38                                      ; preds = %27
   %39 = load i16, i16* %37, align 8
@@ -3824,8 +4688,8 @@ entry:
 
 ; <label>:54                                      ; preds = %22, %43
   %55 = load i16*, i16** %loc4
-  %NullCheck2 = icmp ne i16* %55, null
-  br i1 %NullCheck2, label %56, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i16* %55, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %56
 
 ; <label>:56                                      ; preds = %54
   %57 = load i16, i16* %55, align 8
@@ -3850,11 +4714,11 @@ ThrowNullRef:                                     ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %54
+ThrowNullRef2:                                    ; preds = %54
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %27
+ThrowNullRef4:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3871,8 +4735,8 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -3907,8 +4771,8 @@ entry:
 
 ; <label>:26                                      ; preds = %19
   %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
-  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %28
 
 ; <label>:28                                      ; preds = %26
   %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
@@ -3920,7 +4784,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3972,8 +4836,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
@@ -3984,26 +4848,26 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
-  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
@@ -4014,8 +4878,8 @@ entry:
 ; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
@@ -4024,8 +4888,8 @@ entry:
 
 ; <label>:25                                      ; preds = %1, %16, %23
   %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
-  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
@@ -4036,27 +4900,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %20
+ThrowNullRef10:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4069,8 +4933,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -4081,8 +4945,8 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
@@ -4091,8 +4955,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1, %8
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
@@ -4103,11 +4967,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4128,24 +4992,24 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   store i32 %3, i32* %loc0
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
   %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
   store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck4, label %9, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
@@ -4164,15 +5028,15 @@ entry:
 ; <label>:18                                      ; preds = %70
   %19 = load i16*, i16** %loc3
   %20 = bitcast i16* %19 to i64*
-  %NullCheck10 = icmp ne i64* %20, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %20, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = load i64, i64* %20, align 8
   %23 = load i16*, i16** %loc4
   %24 = bitcast i16* %23 to i64*
-  %NullCheck12 = icmp ne i64* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = load i64, i64* %24, align 8
@@ -4188,8 +5052,8 @@ entry:
   %31 = bitcast i16* %30 to i8*
   %32 = getelementptr inbounds i8, i8* %31, i64 8
   %33 = bitcast i8* %32 to i64*
-  %NullCheck14 = icmp ne i64* %33, null
-  br i1 %NullCheck14, label %34, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = load i64, i64* %33, align 8
@@ -4197,8 +5061,8 @@ entry:
   %37 = bitcast i16* %36 to i8*
   %38 = getelementptr inbounds i8, i8* %37, i64 8
   %39 = bitcast i8* %38 to i64*
-  %NullCheck16 = icmp ne i64* %39, null
-  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %40
 
 ; <label>:40                                      ; preds = %34
   %41 = load i64, i64* %39, align 8
@@ -4214,8 +5078,8 @@ entry:
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %NullCheck18 = icmp ne i64* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = load i64, i64* %48, align 8
@@ -4223,8 +5087,8 @@ entry:
   %52 = bitcast i16* %51 to i8*
   %53 = getelementptr inbounds i8, i8* %52, i64 16
   %54 = bitcast i8* %53 to i64*
-  %NullCheck20 = icmp ne i64* %54, null
-  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64* %54, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %55
 
 ; <label>:55                                      ; preds = %49
   %56 = load i64, i64* %54, align 8
@@ -4262,15 +5126,15 @@ entry:
 ; <label>:74                                      ; preds = %95
   %75 = load i16*, i16** %loc3
   %76 = bitcast i16* %75 to i32*
-  %NullCheck6 = icmp ne i32* %76, null
-  br i1 %NullCheck6, label %77, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32* %76, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %77
 
 ; <label>:77                                      ; preds = %74
   %78 = load i32, i32* %76, align 8
   %79 = load i16*, i16** %loc4
   %80 = bitcast i16* %79 to i32*
-  %NullCheck8 = icmp ne i32* %80, null
-  br i1 %NullCheck8, label %81, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i32* %80, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %81
 
 ; <label>:81                                      ; preds = %77
   %82 = load i32, i32* %80, align 8
@@ -4318,43 +5182,43 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %74
+ThrowNullRef6:                                    ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %77
+ThrowNullRef8:                                    ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %29
+ThrowNullRef14:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %34
+ThrowNullRef16:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4376,8 +5240,8 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load i64, i64 addrspace(1)* %4
@@ -4389,8 +5253,8 @@ entry:
   %12 = load i64, i64* %11
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %5
   %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
@@ -4399,8 +5263,8 @@ entry:
   %18 = load i8, i8* %arg2
   %19 = zext i8 %18 to i32
   %20 = trunc i32 %19 to i8
-  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %15
   %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
@@ -4411,11 +5275,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4442,8 +5306,8 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
@@ -4466,16 +5330,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
   %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = load i64, i64 addrspace(1)* %19
@@ -4500,8 +5364,8 @@ entry:
 ; <label>:35                                      ; preds = %30
   %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
@@ -4514,8 +5378,8 @@ entry:
 
 ; <label>:42                                      ; preds = %1, %38
   %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
-  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
@@ -4526,19 +5390,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %35
+ThrowNullRef2:                                    ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %42
+ThrowNullRef8:                                    ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4551,14 +5415,14 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
@@ -4570,7 +5434,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4583,8 +5447,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
@@ -4613,51 +5477,51 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
   %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
   %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
   %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
   %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
-  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
   store i64 %21, i64 addrspace(1)* %23
   %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %25 = load i64, i64* %loc0
-  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
@@ -4668,27 +5532,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %22
+ThrowNullRef12:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4701,8 +5565,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
@@ -4713,19 +5577,19 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
@@ -4734,8 +5598,8 @@ entry:
 
 ; <label>:15                                      ; preds = %1, %13
   %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
@@ -4746,19 +5610,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %15
+ThrowNullRef8:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4771,8 +5635,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -4831,8 +5695,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
@@ -4882,8 +5746,8 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
-  br i1 %NullCheck, label %17, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %ThrowNullRef, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
@@ -4894,15 +5758,15 @@ entry:
 
 ; <label>:22                                      ; preds = %17
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
-  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
   %26 = load i32, i32 addrspace(1)* %25
   %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
-  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %27, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
@@ -4925,8 +5789,8 @@ entry:
 ; <label>:40                                      ; preds = %17
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
-  br i1 %NullCheck6, label %43, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %41, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
@@ -4938,34 +5802,17 @@ ThrowNullRef:                                     ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %24
+ThrowNullRef4:                                    ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %40
+ThrowNullRef6:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
-}
-
-INFO:  jitting method Object::ReferenceEquals using LLILCJit
-Successfully read Object.ReferenceEquals
-
-define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
-entry:
-  %arg0 = alloca %System.Object addrspace(1)*
-  %arg1 = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
-  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
-  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = icmp eq %System.Object addrspace(1)* %0, %1
-  %3 = sext i1 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
 }
 
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
@@ -4978,21 +5825,21 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
   %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
-  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
@@ -5007,28 +5854,28 @@ entry:
 ; <label>:13                                      ; preds = %8, %12
   %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
   %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
   %21 = load i32, i32 addrspace(1)* %20, align 8
   %22 = add i32 %21, 1
-  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
   store i32 %22, i32 addrspace(1)* %24
   %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
@@ -5039,27 +5886,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5077,7 +5924,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::Setup using LLILCJit
-Failed to read AppDomain.Setup[loadElem]
+Failed to read AppDomain.Setup[unbox]
 INFO:  jitting method Thread::GetDomain using LLILCJit
 Successfully read Thread.GetDomain
 
@@ -5108,8 +5955,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
@@ -5122,14 +5969,14 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
   %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
@@ -5141,11 +5988,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5173,8 +6020,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -5189,7 +6036,328 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
 Failed to read KeyCollection.System.Collections.Generic.IEnumerable<TKey>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Successfully read Enumerator.MoveNext
+
+define i8 @Enumerator.MoveNext(%"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.RuntimeTypeHandle* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*
+  %"$TypeArg" = alloca %System.RuntimeTypeHandle*
+  store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
+  %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 8
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %76, label %12
+
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
+  br label %76
+
+; <label>:13                                      ; preds = %85
+  %14 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck19 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %15
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, i32 0, i32 0
+  %17 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %16, align 8
+  %NullCheck21 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, i32 0, i32 2
+  %20 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %19, align 8
+  %21 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck23 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %22
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, i32 0, i32 2
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %NullCheck25 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 3, i32 %24
+  %NullCheck27 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %32
+
+; <label>:32                                      ; preds = %30
+  %33 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, i32 0, i32 2
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = icmp slt i32 %34, 0
+  br i1 %35, label %68, label %36
+
+; <label>:36                                      ; preds = %32
+  %37 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %38 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck29 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %39
+
+; <label>:39                                      ; preds = %36
+  %40 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, i32 0, i32 0
+  %41 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %40, align 8
+  %NullCheck31 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, i32 0, i32 2
+  %44 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %43, align 8
+  %45 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck33 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, i32 0, i32 2
+  %48 = load i32, i32 addrspace(1)* %47, align 8
+  %NullCheck35 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %49
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = zext i32 %51 to i64
+  %53 = zext i32 %48 to i64
+  %BoundsCheck37 = icmp uge i64 %53, %52
+  br i1 %BoundsCheck37, label %ThrowIndexOutOfRange38, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 3, i32 %48
+  %NullCheck39 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %56
+
+; <label>:56                                      ; preds = %54
+  %57 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, i32 0, i32 0
+  %58 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck41 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %59
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %60, %System.__Canon addrspace(1)* %58)
+  %61 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck43 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  %64 = load i32, i32 addrspace(1)* %63, align 8
+  %65 = add i32 %64, 1
+  %NullCheck45 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  store i32 %65, i32 addrspace(1)* %67
+  ret i8 1
+
+; <label>:68                                      ; preds = %32
+  %69 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck47 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %73 = add i32 %72, 1
+  %NullCheck49 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %74
+
+; <label>:74                                      ; preds = %70
+  %75 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  store i32 %73, i32 addrspace(1)* %75
+  br label %76
+
+; <label>:76                                      ; preds = %8, %12, %74
+  %77 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %78
+
+; <label>:78                                      ; preds = %76
+  %79 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, i32 0, i32 2
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck7 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %82
+
+; <label>:82                                      ; preds = %78
+  %83 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, i32 0, i32 0
+  %84 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %83, align 8
+  %NullCheck9 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %85
+
+; <label>:85                                      ; preds = %82
+  %86 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, i32 0, i32 7
+  %87 = load i32, i32 addrspace(1)* %86, align 8
+  %88 = icmp ult i32 %80, %87
+  br i1 %88, label %13, label %89
+
+; <label>:89                                      ; preds = %85
+  %90 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %91 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck11 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %92
+
+; <label>:92                                      ; preds = %89
+  %93 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, i32 0, i32 0
+  %94 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck13 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %95
+
+; <label>:95                                      ; preds = %92
+  %96 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, i32 0, i32 7
+  %97 = load i32, i32 addrspace(1)* %96, align 8
+  %98 = add i32 %97, 1
+  %NullCheck15 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %99
+
+; <label>:99                                      ; preds = %95
+  %100 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, i32 0, i32 2
+  store i32 %98, i32 addrspace(1)* %100
+  %101 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck17 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %102
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %103, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %92
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef22:                                   ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef24:                                   ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef26:                                   ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef28:                                   ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef30:                                   ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef32:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef34:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef36:                                   ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange38:                           ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef40:                                   ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef42:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef44:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef46:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef48:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef50:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -5200,8 +6368,8 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -5232,9 +6400,9 @@ Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
 Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
-Failed to read String.MakeSeparatorList[loadElemA]
+Failed to read String.MakeSeparatorList[storeElem]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
-Failed to read String.InternalSplitKeepEmptyEntries[loadElem]
+Failed to read String.InternalSplitKeepEmptyEntries[storeElem]
 INFO:  jitting method Path::IsRelative using LLILCJit
 Successfully read Path.IsRelative
 
@@ -5243,8 +6411,8 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -5254,8 +6422,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
@@ -5271,8 +6439,8 @@ entry:
 
 ; <label>:17                                      ; preds = %7
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
@@ -5288,8 +6456,8 @@ entry:
 
 ; <label>:29                                      ; preds = %19
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %31
 
 ; <label>:31                                      ; preds = %29
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
@@ -5300,8 +6468,8 @@ entry:
 
 ; <label>:36                                      ; preds = %31
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
-  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %37, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
@@ -5312,8 +6480,8 @@ entry:
 
 ; <label>:43                                      ; preds = %31, %38
   %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
-  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %45
 
 ; <label>:45                                      ; preds = %43
   %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
@@ -5324,8 +6492,8 @@ entry:
 
 ; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %50
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
@@ -5336,8 +6504,8 @@ entry:
 
 ; <label>:57                                      ; preds = %1, %7, %19, %45, %52
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
-  br i1 %NullCheck14, label %59, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %59
 
 ; <label>:59                                      ; preds = %57
   %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
@@ -5347,8 +6515,8 @@ entry:
 
 ; <label>:63                                      ; preds = %59
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
@@ -5359,8 +6527,8 @@ entry:
 
 ; <label>:70                                      ; preds = %65
   %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
-  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.String addrspace(1)* %71, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %72
 
 ; <label>:72                                      ; preds = %70
   %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
@@ -5379,39 +6547,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %17
+ThrowNullRef4:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %29
+ThrowNullRef6:                                    ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %36
+ThrowNullRef8:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %43
+ThrowNullRef10:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %50
+ThrowNullRef12:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %57
+ThrowNullRef14:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %63
+ThrowNullRef16:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %70
+ThrowNullRef18:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5419,7 +6587,293 @@ ThrowNullRef17:                                   ; preds = %70
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
-Failed to read String.TrimHelper[loadElem]
+Successfully read String.TrimHelper
+
+define %System.String addrspace(1)* @String.TrimHelper(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i16
+  %loc4 = alloca i32
+  %loc5 = alloca i16
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = sub i32 %3, 1
+  store i32 %4, i32* %loc0
+  store i32 0, i32* %loc1
+  %5 = load i32, i32* %arg2
+  %6 = icmp eq i32 %5, 1
+  br i1 %6, label %62, label %7
+
+; <label>:7                                       ; preds = %1
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:8                                       ; preds = %58
+  store i32 0, i32* %loc2
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load i32, i32* %loc1
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2, i32 %10
+  %13 = load i16, i16 addrspace(1)* %12
+  %14 = zext i16 %13 to i32
+  %15 = trunc i32 %14 to i16
+  store i16 %15, i16* %loc3
+  store i32 0, i32* %loc2
+  br label %34
+
+; <label>:16                                      ; preds = %37
+  %17 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %18 = load i32, i32* %loc2
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %17, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %19
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = zext i32 %18 to i64
+  %BoundsCheck = icmp uge i64 %23, %22
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %24
+
+; <label>:24                                      ; preds = %19
+  %25 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 3, i32 %18
+  %26 = load i16, i16 addrspace(1)* %25, align 8
+  %27 = zext i16 %26 to i32
+  %28 = load i16, i16* %loc3
+  %29 = zext i16 %28 to i32
+  %30 = icmp eq i32 %27, %29
+  br i1 %30, label %43, label %31
+
+; <label>:31                                      ; preds = %24
+  %32 = load i32, i32* %loc2
+  %33 = add i32 %32, 1
+  store i32 %33, i32* %loc2
+  br label %34
+
+; <label>:34                                      ; preds = %11, %31
+  %35 = load i32, i32* %loc2
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = icmp slt i32 %35, %41
+  br i1 %42, label %16, label %43
+
+; <label>:43                                      ; preds = %24, %37
+  %44 = load i32, i32* %loc2
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %45, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp eq i32 %44, %50
+  br i1 %51, label %62, label %52
+
+; <label>:52                                      ; preds = %46
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %7, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %57, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %58
+
+; <label>:58                                      ; preds = %55
+  %59 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %60 = load i32, i32 addrspace(1)* %59
+  %61 = icmp slt i32 %56, %60
+  br i1 %61, label %8, label %62
+
+; <label>:62                                      ; preds = %1, %46, %58
+  %63 = load i32, i32* %arg2
+  %64 = icmp eq i32 %63, 0
+  br i1 %64, label %122, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %66, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %67
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %66, i32 0, i32 1
+  %69 = load i32, i32 addrspace(1)* %68
+  %70 = sub i32 %69, 1
+  store i32 %70, i32* %loc0
+  br label %118
+
+; <label>:71                                      ; preds = %118
+  store i32 0, i32* %loc4
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %73 = load i32, i32* %loc0
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %74
+
+; <label>:74                                      ; preds = %71
+  %75 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 2, i32 %73
+  %76 = load i16, i16 addrspace(1)* %75
+  %77 = zext i16 %76 to i32
+  %78 = trunc i32 %77 to i16
+  store i16 %78, i16* %loc5
+  store i32 0, i32* %loc4
+  br label %97
+
+; <label>:79                                      ; preds = %100
+  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %81 = load i32, i32* %loc4
+  %NullCheck19 = icmp eq %"System.Char[]" addrspace(1)* %80, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
+
+; <label>:82                                      ; preds = %79
+  %83 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 1
+  %84 = load i32, i32 addrspace(1)* %83
+  %85 = zext i32 %84 to i64
+  %86 = zext i32 %81 to i64
+  %BoundsCheck21 = icmp uge i64 %86, %85
+  br i1 %BoundsCheck21, label %ThrowIndexOutOfRange22, label %87
+
+; <label>:87                                      ; preds = %82
+  %88 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 3, i32 %81
+  %89 = load i16, i16 addrspace(1)* %88, align 8
+  %90 = zext i16 %89 to i32
+  %91 = load i16, i16* %loc5
+  %92 = zext i16 %91 to i32
+  %93 = icmp eq i32 %90, %92
+  br i1 %93, label %106, label %94
+
+; <label>:94                                      ; preds = %87
+  %95 = load i32, i32* %loc4
+  %96 = add i32 %95, 1
+  store i32 %96, i32* %loc4
+  br label %97
+
+; <label>:97                                      ; preds = %74, %94
+  %98 = load i32, i32* %loc4
+  %99 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck15 = icmp eq %"System.Char[]" addrspace(1)* %99, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %100
+
+; <label>:100                                     ; preds = %97
+  %101 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %99, i32 0, i32 1
+  %102 = load i32, i32 addrspace(1)* %101
+  %103 = zext i32 %102 to i64
+  %104 = trunc i64 %103 to i32
+  %105 = icmp slt i32 %98, %104
+  br i1 %105, label %79, label %106
+
+; <label>:106                                     ; preds = %87, %100
+  %107 = load i32, i32* %loc4
+  %108 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck17 = icmp eq %"System.Char[]" addrspace(1)* %108, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %109
+
+; <label>:109                                     ; preds = %106
+  %110 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %108, i32 0, i32 1
+  %111 = load i32, i32 addrspace(1)* %110
+  %112 = zext i32 %111 to i64
+  %113 = trunc i64 %112 to i32
+  %114 = icmp eq i32 %107, %113
+  br i1 %114, label %122, label %115
+
+; <label>:115                                     ; preds = %109
+  %116 = load i32, i32* %loc0
+  %117 = sub i32 %116, 1
+  store i32 %117, i32* %loc0
+  br label %118
+
+; <label>:118                                     ; preds = %67, %115
+  %119 = load i32, i32* %loc0
+  %120 = load i32, i32* %loc1
+  %121 = icmp sge i32 %119, %120
+  br i1 %121, label %71, label %122
+
+; <label>:122                                     ; preds = %62, %109, %118
+  %123 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %124 = load i32, i32* %loc1
+  %125 = load i32, i32* %loc0
+  %126 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %123, i32 %124, i32 %125)
+  ret %System.String addrspace(1)* %126
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %97
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange22:                           ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
 Successfully read String.CreateTrimmedString
 
@@ -5439,8 +6893,8 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
@@ -5535,8 +6989,8 @@ entry:
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i64 2872
   %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
   %8 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %7
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %3
   %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
@@ -5553,8 +7007,8 @@ entry:
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 2864
   %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
   %21 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %20
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
-  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %22
 
 ; <label>:22                                      ; preds = %16
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
@@ -5569,7 +7023,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %16
+ThrowNullRef2:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5586,8 +7040,8 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5613,8 +7067,8 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
@@ -5632,8 +7086,8 @@ entry:
 
 ; <label>:12                                      ; preds = %4
   %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
@@ -5644,8 +7098,8 @@ entry:
 
 ; <label>:19                                      ; preds = %14
   %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %19
   %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
@@ -5660,21 +7114,21 @@ entry:
   %31 = zext i16 %30 to i32
   %32 = bitcast i8* %29 to i16*
   %33 = trunc i32 %31 to i16
-  %NullCheck6 = icmp ne i16* %32, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i16* %32, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %21
   store i16 %33, i16* %32, align 8
   %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %36
 
 ; <label>:36                                      ; preds = %34
   %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
   %38 = load i32, i32 addrspace(1)* %37, align 8
   %39 = add i32 %38, 1
-  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %40
 
 ; <label>:40                                      ; preds = %36
   %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
@@ -5683,16 +7137,16 @@ entry:
 
 ; <label>:42                                      ; preds = %14
   %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
-  br i1 %NullCheck12, label %44, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
   %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
   %47 = load i16, i16* %arg1
   %48 = zext i16 %47 to i32
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = trunc i32 %48 to i16
@@ -5703,31 +7157,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %19
+ThrowNullRef4:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %21
+ThrowNullRef6:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %36
+ThrowNullRef10:                                   ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %42
+ThrowNullRef12:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %44
+ThrowNullRef14:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5740,8 +7194,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -5752,8 +7206,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
@@ -5762,14 +7216,14 @@ entry:
 
 ; <label>:11                                      ; preds = %1
   %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
@@ -5779,15 +7233,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5808,8 +7262,8 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5822,8 +7276,8 @@ entry:
 
 ; <label>:8                                       ; preds = %3
   %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
@@ -5842,15 +7296,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
-  br i1 %NullCheck4, label %22, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
   %24 = load i16*, i16* addrspace(1)* %23, align 8
   %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %25, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
@@ -5859,8 +7313,8 @@ entry:
   store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
@@ -5874,8 +7328,8 @@ entry:
 
 ; <label>:37                                      ; preds = %65
   %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %37
   %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
@@ -5886,16 +7340,16 @@ entry:
   %45 = bitcast i16* %41 to i8*
   %46 = getelementptr inbounds i8, i8* %45, i64 %44
   %47 = bitcast i8* %46 to i16*
-  %NullCheck14 = icmp ne i16* %47, null
-  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %47, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %48
 
 ; <label>:48                                      ; preds = %39
   %49 = load i16, i16* %47, align 8
   %50 = zext i16 %49 to i32
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %52 = load i32, i32* %loc1
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %53
 
 ; <label>:53                                      ; preds = %48
   %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
@@ -5916,8 +7370,8 @@ entry:
 ; <label>:62                                      ; preds = %36, %59
   %63 = load i32, i32* %loc1
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck10, label %65, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %65
 
 ; <label>:65                                      ; preds = %62
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
@@ -5936,15 +7390,15 @@ entry:
 
 ; <label>:74                                      ; preds = %70
   %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
-  br i1 %NullCheck18, label %76, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %76
 
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
   %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
-  br i1 %NullCheck20, label %80, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
   %81 = load i64, i64 addrspace(1)* %79
@@ -5958,8 +7412,8 @@ entry:
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
   %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
-  br i1 %NullCheck22, label %92, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.String addrspace(1)* %90, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %92
 
 ; <label>:92                                      ; preds = %80
   %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
@@ -5969,15 +7423,15 @@ entry:
 
 ; <label>:96                                      ; preds = %70
   %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
-  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %98
 
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
   %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
-  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
   %103 = load i64, i64 addrspace(1)* %101
@@ -5991,8 +7445,8 @@ entry:
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
   %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
-  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.String addrspace(1)* %112, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %114
 
 ; <label>:114                                     ; preds = %102
   %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
@@ -6004,59 +7458,59 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %20
+ThrowNullRef4:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %22
+ThrowNullRef6:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %26
+ThrowNullRef8:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %62
+ThrowNullRef10:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %48
+ThrowNullRef16:                                   ; preds = %48
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %74
+ThrowNullRef18:                                   ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %76
+ThrowNullRef20:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %80
+ThrowNullRef22:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %96
+ThrowNullRef24:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %98
+ThrowNullRef26:                                   ; preds = %98
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %102
+ThrowNullRef28:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6069,15 +7523,15 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
   %3 = load i16*, i16* addrspace(1)* %2, align 8
   %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
@@ -6087,8 +7541,8 @@ entry:
   %10 = bitcast i16* %3 to i8*
   %11 = getelementptr inbounds i8, i8* %10, i64 %9
   %12 = bitcast i8* %11 to i16*
-  %NullCheck4 = icmp ne i16* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %5
   store i16 0, i16* %12, align 8
@@ -6098,11 +7552,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6119,8 +7573,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -6131,8 +7585,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
@@ -6144,15 +7598,15 @@ entry:
 
 ; <label>:14                                      ; preds = %1
   %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
   %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
   %21 = load i64, i64 addrspace(1)* %19
@@ -6171,15 +7625,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %14
+ThrowNullRef4:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %16
+ThrowNullRef6:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6302,14 +7756,6 @@ entry:
   ret %System.String addrspace(1)* %57
 }
 
-INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
-Successfully read RuntimeHelpers.get_OffsetToStringData
-
-define i32 @RuntimeHelpers.get_OffsetToStringData() {
-entry:
-  ret i32 12
-}
-
 INFO:  jitting method String::Equals using LLILCJit
 Successfully read String.Equals
 
@@ -6381,8 +7827,8 @@ entry:
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
-  br i1 %NullCheck24, label %29, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
   %30 = load i64, i64 addrspace(1)* %28
@@ -6397,8 +7843,8 @@ entry:
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
-  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
   %43 = load i64, i64 addrspace(1)* %41
@@ -6418,8 +7864,8 @@ entry:
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
   %59 = load i64, i64 addrspace(1)* %57
@@ -6434,8 +7880,8 @@ entry:
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck22, label %71, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
   %72 = load i64, i64 addrspace(1)* %70
@@ -6455,8 +7901,8 @@ entry:
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
-  br i1 %NullCheck16, label %87, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = load i64, i64 addrspace(1)* %86
@@ -6471,8 +7917,8 @@ entry:
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck18, label %100, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
   %101 = load i64, i64 addrspace(1)* %99
@@ -6492,8 +7938,8 @@ entry:
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
-  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
   %117 = load i64, i64 addrspace(1)* %115
@@ -6508,8 +7954,8 @@ entry:
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
-  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
   %130 = load i64, i64 addrspace(1)* %128
@@ -6528,15 +7974,15 @@ entry:
 
 ; <label>:142                                     ; preds = %22
   %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
-  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %143, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %144
 
 ; <label>:144                                     ; preds = %142
   %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
   %146 = load i32, i32 addrspace(1)* %145
   %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
-  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %147, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %148
 
 ; <label>:148                                     ; preds = %144
   %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
@@ -6557,15 +8003,15 @@ entry:
 
 ; <label>:159                                     ; preds = %22
   %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
-  br i1 %NullCheck, label %161, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %ThrowNullRef, label %161
 
 ; <label>:161                                     ; preds = %159
   %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
   %163 = load i32, i32 addrspace(1)* %162
   %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
-  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %164, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %165
 
 ; <label>:165                                     ; preds = %161
   %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
@@ -6578,8 +8024,8 @@ entry:
 
 ; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
-  br i1 %NullCheck4, label %172, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %171, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %172
 
 ; <label>:172                                     ; preds = %170
   %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
@@ -6589,8 +8035,8 @@ entry:
 
 ; <label>:176                                     ; preds = %172
   %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
-  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %177, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %178
 
 ; <label>:178                                     ; preds = %176
   %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
@@ -6629,55 +8075,55 @@ ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %161
+ThrowNullRef2:                                    ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %170
+ThrowNullRef4:                                    ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %176
+ThrowNullRef6:                                    ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %142
+ThrowNullRef8:                                    ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %144
+ThrowNullRef10:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %113
+ThrowNullRef12:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %116
+ThrowNullRef14:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %84
+ThrowNullRef16:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %87
+ThrowNullRef18:                                   ; preds = %87
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %55
+ThrowNullRef20:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %58
+ThrowNullRef22:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %26
+ThrowNullRef24:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %29
+ThrowNullRef26:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,8 +8161,8 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck, label %14, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %ThrowNullRef, label %14
 
 ; <label>:14                                      ; preds = %8
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
@@ -6760,8 +8206,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
@@ -6770,14 +8216,14 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32, i32* %loc0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %10
   %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
   %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
@@ -6790,15 +8236,15 @@ entry:
 ; <label>:25                                      ; preds = %19
   %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
-  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
   %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
@@ -6807,8 +8253,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %37 = load i32, i32* %loc0
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %38, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %38
 
 ; <label>:38                                      ; preds = %32
   %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
@@ -6817,14 +8263,14 @@ entry:
 
 ; <label>:40                                      ; preds = %19
   %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %40
   %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
   %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
-  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
-  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
@@ -6832,8 +8278,8 @@ entry:
   %48 = zext i32 %47 to i64
   %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
-  br i1 %NullCheck16, label %51, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %51
 
 ; <label>:51                                      ; preds = %45
   %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
@@ -6847,15 +8293,15 @@ entry:
 ; <label>:57                                      ; preds = %51
   %58 = load i16*, i16** %arg1
   %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
-  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %60
 
 ; <label>:60                                      ; preds = %57
   %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
   %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
-  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %64
 
 ; <label>:64                                      ; preds = %60
   %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
@@ -6864,22 +8310,22 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
   %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
-  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %70
 
 ; <label>:70                                      ; preds = %64
   %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
   %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
-  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
-  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
   %75 = load i32, i32 addrspace(1)* %74
   %76 = zext i32 %75 to i64
   %77 = trunc i64 %76 to i32
-  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
-  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %78
 
 ; <label>:78                                      ; preds = %73
   %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
@@ -6901,8 +8347,8 @@ entry:
   %90 = bitcast i16* %86 to i8*
   %91 = getelementptr inbounds i8, i8* %90, i64 %89
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %93
 
 ; <label>:93                                      ; preds = %80
   %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
@@ -6912,8 +8358,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %99 = load i32, i32* %loc2
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %100
 
 ; <label>:100                                     ; preds = %93
   %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
@@ -6928,63 +8374,63 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %25
+ThrowNullRef6:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %32
+ThrowNullRef10:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %40
+ThrowNullRef12:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %45
+ThrowNullRef16:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %57
+ThrowNullRef18:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %60
+ThrowNullRef20:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %64
+ThrowNullRef22:                                   ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %70
+ThrowNullRef24:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %73
+ThrowNullRef26:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %80
+ThrowNullRef28:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %93
+ThrowNullRef30:                                   ; preds = %93
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7004,8 +8450,8 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
@@ -7033,43 +8479,43 @@ entry:
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %14
   %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
   %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   %28 = load i32, i32 addrspace(1)* %27, align 8
   %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
-  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %30
 
 ; <label>:30                                      ; preds = %26
   %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
   %32 = load i32, i32 addrspace(1)* %31, align 8
   %33 = add i32 %28, %32
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %34
 
 ; <label>:34                                      ; preds = %30
   %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   store i32 %33, i32 addrspace(1)* %35
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
   store i32 0, i32 addrspace(1)* %38
   %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %40
 
 ; <label>:40                                      ; preds = %37
   %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
@@ -7082,8 +8528,8 @@ entry:
 
 ; <label>:47                                      ; preds = %40
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
@@ -7098,8 +8544,8 @@ entry:
   %54 = load i32, i32* %loc0
   %55 = sext i32 %54 to i64
   %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
-  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %57
 
 ; <label>:57                                      ; preds = %52
   %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
@@ -7110,68 +8556,35 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %14
+ThrowNullRef2:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %23
+ThrowNullRef4:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %26
+ThrowNullRef6:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %30
+ThrowNullRef8:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %34
+ThrowNullRef10:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %47
+ThrowNullRef14:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %52
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-}
-
-INFO:  jitting method StringBuilder::get_Length using LLILCJit
-Successfully read StringBuilder.get_Length
-
-define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.StringBuilder addrspace(1)*
-  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
-  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
-
-; <label>:1                                       ; preds = %entry
-  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %3 = load i32, i32 addrspace(1)* %2, align 8
-  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
-
-; <label>:5                                       ; preds = %1
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = add i32 %3, %7
-  ret i32 %8
-
-ThrowNullRef:                                     ; preds = %entry
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef16:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7213,70 +8626,70 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
   %6 = load i32, i32 addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
   store i32 %6, i32 addrspace(1)* %8
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
   %13 = load i32, i32 addrspace(1)* %12, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
   store i32 %13, i32 addrspace(1)* %15
   %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
-  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %18
 
 ; <label>:18                                      ; preds = %14
   %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
   %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
   %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
   %34 = load i32, i32 addrspace(1)* %33, align 8
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
-  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
@@ -7287,39 +8700,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %28
+ThrowNullRef16:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %32
+ThrowNullRef18:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7455,13 +8868,13 @@ entry:
 ; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
@@ -7477,16 +8890,16 @@ entry:
 
 ; <label>:18                                      ; preds = %15
   %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
   store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
   %22 = load i32, i32* %loc0
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %24
 
 ; <label>:24                                      ; preds = %20
   %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
@@ -7498,13 +8911,13 @@ entry:
 ; <label>:28                                      ; preds = %15, %24
   %29 = load i32, i32* %arg1
   %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %31
   %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
@@ -7517,20 +8930,20 @@ entry:
   %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
-  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
   %46 = load i32, i32 addrspace(1)* %45, align 8
   %47 = sub i32 %40, %46
-  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
-  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i32 addrspace(1)* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %48
 
 ; <label>:48                                      ; preds = %44
   store i32 %47, i32 addrspace(1)* %39, align 8
@@ -7538,21 +8951,21 @@ entry:
 
 ; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
-  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %51
 
 ; <label>:51                                      ; preds = %49
   %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %53
 
 ; <label>:53                                      ; preds = %51
   %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
   %55 = load i32, i32 addrspace(1)* %54, align 8
   %56 = load i32, i32* %arg2
   %57 = sub i32 %55, %56
-  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %58
 
 ; <label>:58                                      ; preds = %53
   %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
@@ -7562,13 +8975,13 @@ entry:
 ; <label>:60                                      ; preds = %33, %58
   %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
   %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
-  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %63
 
 ; <label>:63                                      ; preds = %60
   %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
-  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
-  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
@@ -7578,15 +8991,15 @@ entry:
 
 ; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
-  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i32 addrspace(1)* %69, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %70
 
 ; <label>:70                                      ; preds = %68
   %71 = load i32, i32 addrspace(1)* %69, align 8
   store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
-  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
@@ -7596,8 +9009,8 @@ entry:
   store i32 %77, i32* %loc4
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
-  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %80
 
 ; <label>:80                                      ; preds = %73
   %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
@@ -7607,71 +9020,71 @@ entry:
 ; <label>:83                                      ; preds = %80
   store i32 0, i32* %loc3
   %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
-  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
-  br i1 %NullCheck26, label %88, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i32 addrspace(1)* %87, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %88
 
 ; <label>:88                                      ; preds = %85
   %89 = load i32, i32 addrspace(1)* %87, align 8
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
-  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %90
 
 ; <label>:90                                      ; preds = %88
   %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
   store i32 %89, i32 addrspace(1)* %91
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
-  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
-  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %96
 
 ; <label>:96                                      ; preds = %94
   %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
-  br i1 %NullCheck34, label %100, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %100
 
 ; <label>:100                                     ; preds = %96
   %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
-  br i1 %NullCheck36, label %102, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %102
 
 ; <label>:102                                     ; preds = %100
   %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
   %104 = load i32, i32 addrspace(1)* %103, align 8
   %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
-  br i1 %NullCheck38, label %106, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %106
 
 ; <label>:106                                     ; preds = %102
   %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
-  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
-  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %108
 
 ; <label>:108                                     ; preds = %106
   %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
   %110 = load i32, i32 addrspace(1)* %109, align 8
   %111 = add i32 %104, %110
-  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %112
 
 ; <label>:112                                     ; preds = %108
   %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
   store i32 %111, i32 addrspace(1)* %113
   %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
-  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i32 addrspace(1)* %114, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %115
 
 ; <label>:115                                     ; preds = %112
   %116 = load i32, i32 addrspace(1)* %114, align 8
@@ -7681,19 +9094,19 @@ entry:
 ; <label>:118                                     ; preds = %115
   %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
-  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %121
 
 ; <label>:121                                     ; preds = %118
   %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
-  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
-  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %123
 
 ; <label>:123                                     ; preds = %121
   %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
   %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
-  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
-  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %126
 
 ; <label>:126                                     ; preds = %123
   %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
@@ -7705,8 +9118,8 @@ entry:
 
 ; <label>:130                                     ; preds = %80, %115, %126
   %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %132
 
 ; <label>:132                                     ; preds = %130
   %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7715,8 +9128,8 @@ entry:
   %136 = load i32, i32* %loc3
   %137 = sub i32 %135, %136
   %138 = sub i32 %134, %137
-  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %139
 
 ; <label>:139                                     ; preds = %132
   %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7728,16 +9141,16 @@ entry:
 
 ; <label>:144                                     ; preds = %139
   %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
-  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %146
 
 ; <label>:146                                     ; preds = %144
   %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
   %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
   %149 = load i32, i32* %loc2
   %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
-  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %151
 
 ; <label>:151                                     ; preds = %146
   %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
@@ -7754,145 +9167,249 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %18
+ThrowNullRef4:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %31
+ThrowNullRef10:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %44
+ThrowNullRef16:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %68
+ThrowNullRef18:                                   ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %70
+ThrowNullRef20:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %73
+ThrowNullRef22:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %83
+ThrowNullRef24:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %85
+ThrowNullRef26:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %88
+ThrowNullRef28:                                   ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %90
+ThrowNullRef30:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %94
+ThrowNullRef32:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %96
+ThrowNullRef34:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %100
+ThrowNullRef36:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %102
+ThrowNullRef38:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %106
+ThrowNullRef40:                                   ; preds = %106
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %108
+ThrowNullRef42:                                   ; preds = %108
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %112
+ThrowNullRef44:                                   ; preds = %112
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %118
+ThrowNullRef46:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %121
+ThrowNullRef48:                                   ; preds = %121
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %123
+ThrowNullRef50:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %130
+ThrowNullRef52:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %132
+ThrowNullRef54:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %144
+ThrowNullRef56:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %146
+ThrowNullRef58:                                   ; preds = %146
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %60
+ThrowNullRef60:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %63
+ThrowNullRef62:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %49
+ThrowNullRef64:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %51
+ThrowNullRef66:                                   ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %53
+ThrowNullRef68:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(%"System.Char[]" addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %arg0 = alloca %"System.Char[]" addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store %"System.Char[]" addrspace(1)* %param0, %"System.Char[]" addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load i32, i32* %arg4
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %43, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %38, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg1
+  %13 = load i32, i32* %arg4
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %38, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %24 = load i32, i32* %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %35 = load i32, i32* %arg3
+  %36 = load i32, i32* %arg4
+  %37 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %37, %"System.Char[]" addrspace(1)* %34, i32 %35, i32 %36)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:38                                      ; preds = %5, %16
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Successfully read Buffer._Memmove
 
@@ -7914,7 +9431,7 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[loadElem]
+Failed to read AppDomain.SetDataHelper[storeElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -7923,8 +9440,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
@@ -7934,8 +9451,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
@@ -7947,15 +9464,15 @@ entry:
   %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
   %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
@@ -7966,15 +9483,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7992,7 +9509,79 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
-Failed to read Dictionary`2.TryGetValue[loadElemA]
+Successfully read Dictionary`2.TryGetValue
+
+define i8 @"Dictionary`2.TryGetValue"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)* addrspace(1)* %param2) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  %arg2 = alloca %System.__Canon addrspace(1)* addrspace(1)*
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  store %System.__Canon addrspace(1)* addrspace(1)* %param2, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  store i32 %2, i32* %loc0
+  %3 = load i32, i32* %loc0
+  %4 = icmp slt i32 %3, 0
+  br i1 %4, label %22, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 2
+  %10 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %9, align 8
+  %11 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = zext i32 %11 to i64
+  %BoundsCheck = icmp uge i64 %16, %15
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 3, i32 %11
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %20, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %6, %System.__Canon addrspace(1)* %21)
+  ret i8 1
+
+; <label>:22                                      ; preds = %entry
+  %23 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %23, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -8058,8 +9647,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
@@ -8091,8 +9680,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
@@ -8171,15 +9760,15 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck, label %19, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %ThrowNullRef, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
   %21 = load i32, i32 addrspace(1)* %20
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
@@ -8202,7 +9791,7 @@ ThrowNullRef:                                     ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %19
+ThrowNullRef2:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8248,8 +9837,8 @@ entry:
   %0 = alloca %System.AppDomainHandle
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %1 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %1, i32 0, i32 15
@@ -8269,8 +9858,8 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
@@ -8286,7 +9875,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -8299,8 +9888,8 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -8327,8 +9916,8 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
@@ -8352,8 +9941,8 @@ entry:
   %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
   store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
@@ -8363,8 +9952,8 @@ entry:
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
@@ -8374,8 +9963,8 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %9
   %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
@@ -8384,8 +9973,8 @@ entry:
 
 ; <label>:18                                      ; preds = %3, %16
   %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
@@ -8397,15 +9986,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %18
+ThrowNullRef6:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8418,8 +10007,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
@@ -8453,15 +10042,15 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
@@ -8473,7 +10062,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8481,7 +10070,7 @@ ThrowNullRef1:                                    ; preds = %1
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
 Failed to read Dictionary`2.System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
@@ -8506,8 +10095,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
@@ -8524,8 +10113,8 @@ entry:
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -8544,7 +10133,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8577,8 +10166,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = load i64, i64* %arg2
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = trunc i32 %3 to i8
@@ -8634,46 +10223,46 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
   %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
-  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
-  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
-  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
@@ -8684,27 +10273,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %20
+ThrowNullRef12:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8717,8 +10306,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -8756,22 +10345,22 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
   %9 = load i64, i64 addrspace(1)* %8, align 8
   %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
   %13 = load i64, i64 addrspace(1)* %12, align 8
   %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %11
   %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
@@ -8788,11 +10377,11 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8882,8 +10471,8 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
@@ -8900,8 +10489,8 @@ entry:
 ; <label>:8                                       ; preds = %1
   %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
   %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
@@ -8911,15 +10500,15 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
   %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
   %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
-  br i1 %NullCheck6, label %21, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
@@ -8946,15 +10535,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8992,15 +10581,15 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
   store i8 %3, i8 addrspace(1)* %5
   %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
@@ -9011,7 +10600,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9027,8 +10616,8 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -9041,8 +10630,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
@@ -9058,7 +10647,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9080,8 +10669,8 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
@@ -9096,8 +10685,8 @@ entry:
 ; <label>:12                                      ; preds = %6
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
@@ -9112,8 +10701,8 @@ entry:
 ; <label>:21                                      ; preds = %15
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
@@ -9128,8 +10717,8 @@ entry:
 ; <label>:30                                      ; preds = %24
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %31, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
@@ -9144,8 +10733,8 @@ entry:
 ; <label>:39                                      ; preds = %33
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
-  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %40, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %42
 
 ; <label>:42                                      ; preds = %39
   %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
@@ -9164,19 +10753,19 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %21
+ThrowNullRef4:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %30
+ThrowNullRef6:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %39
+ThrowNullRef8:                                    ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9243,8 +10832,8 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
@@ -9264,57 +10853,57 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
   store i8 0, i8 addrspace(1)* %2
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
   store i8 0, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
   store i8 0, i8 addrspace(1)* %17
   %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
   store i8 0, i8 addrspace(1)* %20
   %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
-  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
@@ -9325,31 +10914,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %19
+ThrowNullRef14:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9367,8 +10956,8 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
@@ -9380,8 +10969,8 @@ entry:
 
 ; <label>:9                                       ; preds = %4
   %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %9
   %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
@@ -9395,7 +10984,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef2:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9420,8 +11009,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
@@ -9512,8 +11101,8 @@ entry:
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
@@ -9524,8 +11113,8 @@ entry:
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = load i64, i64 addrspace(1)* %12
@@ -9537,8 +11126,8 @@ entry:
   %20 = load i64, i64* %19
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
-  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %13
   %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
@@ -9555,8 +11144,8 @@ entry:
 ; <label>:30                                      ; preds = %25
   %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %32 = load i32, i32* %arg2
-  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
-  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
@@ -9570,15 +11159,15 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %30
+ThrowNullRef2:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9622,87 +11211,87 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
   %10 = load i8, i8 addrspace(1)* %9, align 8
   %11 = zext i8 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %8
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
   store i8 %12, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
   %19 = load i8, i8 addrspace(1)* %18, align 8
   %20 = zext i8 %19 to i32
   %21 = trunc i32 %20 to i8
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
   store i8 %21, i8 addrspace(1)* %23
   %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
   %28 = load i8, i8 addrspace(1)* %27, align 8
   %29 = zext i8 %28 to i32
   %30 = trunc i32 %29 to i8
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
-  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %31
 
 ; <label>:31                                      ; preds = %26
   %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
   store i8 %30, i8 addrspace(1)* %32
   %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
-  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
-  br i1 %NullCheck14, label %40, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %40
 
 ; <label>:40                                      ; preds = %35
   %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
   store i8 %39, i8 addrspace(1)* %41
   %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
-  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %44
 
 ; <label>:44                                      ; preds = %40
   %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
   %46 = load i8, i8 addrspace(1)* %45, align 8
   %47 = zext i8 %46 to i32
   %48 = trunc i32 %47 to i8
-  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
   store i8 %48, i8 addrspace(1)* %50
   %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
-  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
@@ -9713,29 +11302,29 @@ entry:
 ; <label>:56                                      ; preds = %52
   %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
-  br i1 %NullCheck22, label %59, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
   %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
   %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
-  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
-  br i1 %NullCheck24, label %63, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
   %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
-  br i1 %NullCheck26, label %66, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
   %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
-  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
-  br i1 %NullCheck28, label %69, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %69
 
 ; <label>:69                                      ; preds = %66
   %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
@@ -9744,15 +11333,15 @@ entry:
 
 ; <label>:71                                      ; preds = %105
   %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
-  br i1 %NullCheck34, label %73, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %73
 
 ; <label>:73                                      ; preds = %71
   %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
   %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
   %76 = load i32, i32* %loc0
-  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
-  br i1 %NullCheck36, label %77, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
@@ -9766,8 +11355,8 @@ entry:
 
 ; <label>:83                                      ; preds = %77
   %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
-  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
@@ -9775,14 +11364,14 @@ entry:
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
   %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
-  br i1 %NullCheck40, label %91, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
 ; <label>:91                                      ; preds = %85
   %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
   %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
-  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck42, label %94, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %94
 
 ; <label>:94                                      ; preds = %91
   %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
@@ -9798,14 +11387,14 @@ entry:
 ; <label>:99                                      ; preds = %69, %96
   %100 = load i32, i32* %loc0
   %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
-  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %102
 
 ; <label>:102                                     ; preds = %99
   %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
   %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
-  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
-  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
@@ -9819,87 +11408,87 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %26
+ThrowNullRef10:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %31
+ThrowNullRef12:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %35
+ThrowNullRef14:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %40
+ThrowNullRef16:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %56
+ThrowNullRef22:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %59
+ThrowNullRef24:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %63
+ThrowNullRef26:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %66
+ThrowNullRef28:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %102
+ThrowNullRef32:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %71
+ThrowNullRef34:                                   ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %73
+ThrowNullRef36:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %83
+ThrowNullRef38:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %85
+ThrowNullRef40:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %91
+ThrowNullRef42:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9943,15 +11532,15 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
   %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
@@ -9961,28 +11550,28 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
   %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %12
   %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
   %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
   %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
-  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
@@ -9993,23 +11582,23 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %12
+ThrowNullRef6:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10031,15 +11620,15 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
   %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = load i64, i64 addrspace(1)* %7
@@ -10077,13 +11666,13 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[loadElem]
+Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -10111,8 +11700,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -10152,7 +11741,7 @@ entry:
 }
 
 INFO:  jitting method Complex_Array_Test::Main using LLILCJit
-Failed to read Complex_Array_Test.Main[loadElem]
+Failed to read Complex_Array_Test.Main[storeElem]
 INFO:  jitting method Console::WriteLine using LLILCJit
 Successfully read Console.WriteLine
 
@@ -10163,8 +11752,8 @@ entry:
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -10298,8 +11887,8 @@ entry:
   store i64 %param0, i64* %arg0
   store i64 %param1, i64* %arg1
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
@@ -10307,8 +11896,8 @@ entry:
   %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
   %5 = load i16*, i16* addrspace(1)* %4, align 8
   %6 = addrspacecast i64* %arg1 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = bitcast i64 addrspace(1)* %6 to i8 addrspace(1)*
@@ -10324,7 +11913,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10358,8 +11947,8 @@ entry:
   %1 = load i32, i32* %arg1
   %2 = sext i32 %1 to i64
   %3 = inttoptr i64 %2 to i16*
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -10412,8 +12001,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, i32)*)(%System.IO.ConsoleStream addrspace(1)* %2, i32 %1)
   %3 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %4 = load i64, i64* %arg1
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
@@ -10424,8 +12013,8 @@ entry:
   %10 = icmp eq i32 %9, 3
   %11 = sext i1 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %5
   %14 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, i32 0, i32 5
@@ -10436,7 +12025,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10459,8 +12048,8 @@ entry:
   %5 = icmp eq i32 %4, 1
   %6 = sext i1 %5 to i32
   %7 = trunc i32 %6 to i8
-  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %2, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.ConsoleStream addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
@@ -10471,8 +12060,8 @@ entry:
   %13 = icmp eq i32 %12, 2
   %14 = sext i1 %13 to i32
   %15 = trunc i32 %14 to i8
-  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %10, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.ConsoleStream addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %8
   %17 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %10, i32 0, i32 4
@@ -10483,7 +12072,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10522,8 +12111,8 @@ entry:
   %arg0 = alloca i64
   store i64 %param0, i64* %arg0
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
@@ -10558,8 +12147,8 @@ entry:
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
   %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = load i64, i64 addrspace(1)* %7
@@ -10663,7 +12252,127 @@ entry:
 INFO:  jitting method Encoding::GetEncoding using LLILCJit
 Failed to read Encoding.GetEncoding[convertToHelperArgumentType]
 INFO:  jitting method EncodingProvider::GetEncodingFromProvider using LLILCJit
-Failed to read EncodingProvider.GetEncodingFromProvider[loadElem]
+Successfully read EncodingProvider.GetEncodingFromProvider
+
+define %System.Text.Encoding addrspace(1)* @EncodingProvider.GetEncodingFromProvider(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca %"System.Text.EncodingProvider[]" addrspace(1)*
+  %loc1 = alloca %System.Text.EncodingProvider addrspace(1)*
+  %loc2 = alloca %System.Text.Encoding addrspace(1)*
+  %loc3 = alloca %System.Text.Encoding addrspace(1)*
+  %loc4 = alloca %"System.Text.EncodingProvider[]" addrspace(1)*
+  %loc5 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1059)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2392
+  %2 = addrspacecast i8 addrspace(1)* %1 to %"System.Text.EncodingProvider[]" addrspace(1)**
+  %3 = load volatile %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %2
+  %4 = icmp ne %"System.Text.EncodingProvider[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %entry
+  ret %System.Text.Encoding addrspace(1)* null
+
+; <label>:6                                       ; preds = %entry
+  %7 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1059)
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i64 2392
+  %9 = addrspacecast i8 addrspace(1)* %8 to %"System.Text.EncodingProvider[]" addrspace(1)**
+  %10 = load volatile %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %9
+  store %"System.Text.EncodingProvider[]" addrspace(1)* %10, %"System.Text.EncodingProvider[]" addrspace(1)** %loc0
+  %11 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc0
+  store %"System.Text.EncodingProvider[]" addrspace(1)* %11, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  store i32 0, i32* %loc5
+  br label %43
+
+; <label>:12                                      ; preds = %46
+  %13 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  %14 = load i32, i32* %loc5
+  %NullCheck1 = icmp eq %"System.Text.EncodingProvider[]" addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %13, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = zext i32 %17 to i64
+  %19 = zext i32 %14 to i64
+  %BoundsCheck = icmp uge i64 %19, %18
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %20
+
+; <label>:20                                      ; preds = %15
+  %21 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %13, i32 0, i32 3, i32 %14
+  %22 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)* addrspace(1)* %21, align 8
+  store %System.Text.EncodingProvider addrspace(1)* %22, %System.Text.EncodingProvider addrspace(1)** %loc1
+  %23 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)** %loc1
+  %24 = load i32, i32* %arg0
+  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i64 addrspace(1)*
+  %NullCheck3 = icmp eq i64 addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
+
+; <label>:26                                      ; preds = %20
+  %27 = load i64, i64 addrspace(1)* %25
+  %28 = add i64 %27, 64
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 40
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Text.Encoding addrspace(1)* (%System.Text.EncodingProvider addrspace(1)*, i32)*
+  %35 = call %System.Text.Encoding addrspace(1)* %34(%System.Text.EncodingProvider addrspace(1)* %23, i32 %24)
+  store %System.Text.Encoding addrspace(1)* %35, %System.Text.Encoding addrspace(1)** %loc2
+  %36 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc2
+  %37 = icmp eq %System.Text.Encoding addrspace(1)* %36, null
+  br i1 %37, label %40, label %38
+
+; <label>:38                                      ; preds = %26
+  %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc2
+  store %System.Text.Encoding addrspace(1)* %39, %System.Text.Encoding addrspace(1)** %loc3
+  br label %53
+
+; <label>:40                                      ; preds = %26
+  %41 = load i32, i32* %loc5
+  %42 = add i32 %41, 1
+  store i32 %42, i32* %loc5
+  br label %43
+
+; <label>:43                                      ; preds = %6, %40
+  %44 = load i32, i32* %loc5
+  %45 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  %NullCheck = icmp eq %"System.Text.EncodingProvider[]" addrspace(1)* %45, null
+  br i1 %NullCheck, label %ThrowNullRef, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp slt i32 %44, %50
+  br i1 %51, label %12, label %52
+
+; <label>:52                                      ; preds = %46
+  ret %System.Text.Encoding addrspace(1)* null
+
+; <label>:53                                      ; preds = %38
+  %54 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc3
+  ret %System.Text.Encoding addrspace(1)* %54
+
+ThrowNullRef:                                     ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method EncodingProvider::.cctor using LLILCJit
 Successfully read EncodingProvider..cctor
 
@@ -10682,7 +12391,7 @@ Failed to read Encoding.get_InternalSyncObject[Call HasTypeArg]
 INFO:  jitting method Hashtable::.ctor using LLILCJit
 Failed to read Hashtable..ctor[Volatile store]
 INFO:  jitting method Hashtable::get_Item using LLILCJit
-Failed to read Hashtable.get_Item[loadElemA]
+Failed to read Hashtable.get_Item[loadNonPrimitiveObj]
 INFO:  jitting method Hashtable::InitHash using LLILCJit
 Successfully read Hashtable.InitHash
 
@@ -10702,8 +12411,8 @@ entry:
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -10719,15 +12428,15 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
   %15 = load i32, i32* %loc0
-  %NullCheck2 = icmp ne i32 addrspace(1)* %14, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i32 addrspace(1)* %14, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %3
   store i32 %15, i32 addrspace(1)* %14, align 8
   %17 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %18 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %NullCheck4 = icmp ne i32 addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i32 addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = load i32, i32 addrspace(1)* %18, align 8
@@ -10736,8 +12445,8 @@ entry:
   %23 = sub i32 %22, 1
   %24 = urem i32 %21, %23
   %25 = add i32 1, %24
-  %NullCheck6 = icmp ne i32 addrspace(1)* %17, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32 addrspace(1)* %17, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %19
   store i32 %25, i32 addrspace(1)* %17, align 8
@@ -10748,15 +12457,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %19
+ThrowNullRef6:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10771,8 +12480,8 @@ entry:
   store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
   store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %NullCheck = icmp ne %System.Collections.Hashtable addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Collections.Hashtable addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
@@ -10782,16 +12491,16 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Collections.Hashtable addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Collections.Hashtable addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
   %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck4 = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %9, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
   %13 = inttoptr i64 %11 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
@@ -10801,8 +12510,8 @@ entry:
 ; <label>:15                                      ; preds = %1
   %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -10820,15 +12529,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10842,8 +12551,8 @@ entry:
   store %System.Int32 addrspace(1)* %param0, %System.Int32 addrspace(1)** %this
   %0 = load %System.Int32 addrspace(1)*, %System.Int32 addrspace(1)** %this
   %1 = bitcast %System.Int32 addrspace(1)* %0 to i32 addrspace(1)*
-  %NullCheck = icmp ne i32 addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq i32 addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load i32, i32 addrspace(1)* %1, align 8
@@ -10919,8 +12628,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.UTF8Encoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
@@ -10929,15 +12638,15 @@ entry:
   %9 = load i8, i8* %arg2
   %10 = zext i8 %9 to i32
   %11 = trunc i32 %10 to i8
-  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %8, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %6
   %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %8, i32 0, i32 8
   store i8 %11, i8 addrspace(1)* %13
   %14 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %14, i32 0, i32 8
@@ -10949,8 +12658,8 @@ entry:
 ; <label>:20                                      ; preds = %15
   %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %22, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %22, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = load i64, i64 addrspace(1)* %22
@@ -10972,15 +12681,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %12
+ThrowNullRef4:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10995,8 +12704,8 @@ entry:
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
@@ -11018,16 +12727,16 @@ entry:
 ; <label>:10                                      ; preds = %1
   %11 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
   %12 = load i32, i32* %arg1
-  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %11, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.Encoding addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
   store i32 %12, i32 addrspace(1)* %14
   %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
   %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = load i64, i64 addrspace(1)* %16
@@ -11045,11 +12754,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11062,8 +12771,8 @@ entry:
   %this = alloca %System.Text.UTF8Encoding addrspace(1)*
   store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
   %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.UTF8Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
@@ -11075,16 +12784,16 @@ entry:
 ; <label>:6                                       ; preds = %1
   %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %8 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %10, %System.Text.EncoderFallback addrspace(1)* %8)
   %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %12 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
-  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %11, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %11, i32 0, i32 3
@@ -11097,8 +12806,8 @@ entry:
   %18 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %18, %System.String addrspace(1)* %17)
   %19 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %18 to %System.Text.EncoderFallback addrspace(1)*
-  %NullCheck6 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %16, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %16, i32 0, i32 2
@@ -11108,8 +12817,8 @@ entry:
   %24 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %24, %System.String addrspace(1)* %23)
   %25 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %24 to %System.Text.DecoderFallback addrspace(1)*
-  %NullCheck8 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %22, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %22, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %20
   %27 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %22, i32 0, i32 3
@@ -11120,19 +12829,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %20
+ThrowNullRef8:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11162,8 +12871,8 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load i32, i32* %arg1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -11181,8 +12890,8 @@ entry:
 ; <label>:15                                      ; preds = %8
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %17 = load i32, i32* %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 %17
@@ -11198,7 +12907,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11250,7 +12959,7 @@ entry:
 }
 
 INFO:  jitting method Hashtable::Insert using LLILCJit
-Failed to read Hashtable.Insert[loadElemA]
+Failed to read Hashtable.Insert[storeElem]
 INFO:  jitting method ConsoleEncoding::.ctor using LLILCJit
 Successfully read ConsoleEncoding..ctor
 
@@ -11265,8 +12974,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %1)
   %2 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
@@ -11302,8 +13011,8 @@ entry:
   %2 = call %System.Text.InternalEncoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalEncoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %1)
   %3 = bitcast %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2 to %System.Text.EncoderFallback addrspace(1)*
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
@@ -11313,8 +13022,8 @@ entry:
   %8 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %7)
   %9 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %8 to %System.Text.DecoderFallback addrspace(1)*
-  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %6, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.Encoding addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %4
   %11 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %6, i32 0, i32 3
@@ -11325,7 +13034,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11344,15 +13053,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* %1)
   %2 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   %6 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, i32 0, i32 1
@@ -11363,7 +13072,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11391,8 +13100,8 @@ entry:
   store %System.Text.InternalDecoderBestFitFallback addrspace(1)* %param0, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
   %0 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
@@ -11402,15 +13111,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %4)
   %5 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %6)
   %9 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, i32 0, i32 1
@@ -11421,11 +13130,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11493,8 +13202,8 @@ entry:
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
   %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = load i64, i64 addrspace(1)* %19
@@ -11558,8 +13267,8 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.ConsoleStream addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
@@ -11590,31 +13299,31 @@ entry:
   store i8 %param4, i8* %arg4
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %3, %System.IO.Stream addrspace(1)* %1)
   %4 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %4, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
   %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %4, i32 0, i32 4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %5)
   %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %6
   %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
   %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
   %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = load i64, i64 addrspace(1)* %13
@@ -11626,8 +13335,8 @@ entry:
   %21 = load i64, i64* %20
   %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %8, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %8, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %14
   %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 5
@@ -11645,24 +13354,24 @@ entry:
   %31 = load i32, i32* %arg3
   %32 = sext i32 %31 to i64
   %33 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %32)
-  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %30, null
-  br i1 %NullCheck10, label %34, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.StreamWriter addrspace(1)* %30, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %35, %"System.Char[]" addrspace(1)* %33)
   %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %37, null
-  br i1 %NullCheck12, label %38, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.StreamWriter addrspace(1)* %37, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %38
 
 ; <label>:38                                      ; preds = %34
   %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
   %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
   %41 = load i32, i32* %arg3
   %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %42, null
-  br i1 %NullCheck14, label %43, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %42, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
   %44 = load i64, i64 addrspace(1)* %42
@@ -11676,30 +13385,30 @@ entry:
   %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
   %53 = sext i32 %52 to i64
   %54 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %53)
-  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
-  br i1 %NullCheck16, label %55, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %55
 
 ; <label>:55                                      ; preds = %43
   %56 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %56, %"System.Byte[]" addrspace(1)* %54)
   %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %58 = load i32, i32* %arg3
-  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %57, null
-  br i1 %NullCheck18, label %59, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.StreamWriter addrspace(1)* %57, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %59
 
 ; <label>:59                                      ; preds = %55
   %60 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 10
   store i32 %58, i32 addrspace(1)* %60
   %61 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %61, null
-  br i1 %NullCheck20, label %62, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.IO.StreamWriter addrspace(1)* %61, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %62
 
 ; <label>:62                                      ; preds = %59
   %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
   %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
   %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
   %67 = load i64, i64 addrspace(1)* %65
@@ -11717,15 +13426,15 @@ entry:
 
 ; <label>:78                                      ; preds = %66
   %79 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %79, null
-  br i1 %NullCheck24, label %80, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.StreamWriter addrspace(1)* %79, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %80
 
 ; <label>:80                                      ; preds = %78
   %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
   %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
   %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %83, null
-  br i1 %NullCheck26, label %84, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %83, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
   %85 = load i64, i64 addrspace(1)* %83
@@ -11742,8 +13451,8 @@ entry:
 
 ; <label>:95                                      ; preds = %84
   %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.IO.StreamWriter addrspace(1)* %96, null
-  br i1 %NullCheck28, label %97, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.IO.StreamWriter addrspace(1)* %96, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %97
 
 ; <label>:97                                      ; preds = %95
   %98 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 12
@@ -11757,8 +13466,8 @@ entry:
   %103 = icmp eq i32 %102, 0
   %104 = sext i1 %103 to i32
   %105 = trunc i32 %104 to i8
-  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %100, null
-  br i1 %NullCheck30, label %106, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.IO.StreamWriter addrspace(1)* %100, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %106
 
 ; <label>:106                                     ; preds = %99
   %107 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %100, i32 0, i32 13
@@ -11769,63 +13478,63 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %6
+ThrowNullRef4:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %29
+ThrowNullRef10:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %34
+ThrowNullRef12:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %38
+ThrowNullRef14:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %43
+ThrowNullRef16:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %55
+ThrowNullRef18:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %59
+ThrowNullRef20:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %62
+ThrowNullRef22:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %78
+ThrowNullRef24:                                   ; preds = %78
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %80
+ThrowNullRef26:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %95
+ThrowNullRef28:                                   ; preds = %95
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11838,15 +13547,15 @@ entry:
   %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = load i64, i64 addrspace(1)* %4
@@ -11864,7 +13573,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11914,35 +13623,35 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
   %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderNLS addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %7 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.EncoderNLS addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Text.Encoding addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.Encoding addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Text.EncoderNLS addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.EncoderNLS addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
   %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck8 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = load i64, i64 addrspace(1)* %16
@@ -11961,19 +13670,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11999,8 +13708,8 @@ entry:
   %this = alloca %System.Text.Encoding addrspace(1)*
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
@@ -12020,15 +13729,15 @@ entry:
   %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
   store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
   %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
   store i32 0, i32 addrspace(1)* %2
   %3 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, i32 0, i32 2
@@ -12038,15 +13747,15 @@ entry:
 
 ; <label>:8                                       ; preds = %4
   %9 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
   %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
   %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = load i64, i64 addrspace(1)* %13
@@ -12067,15 +13776,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12090,16 +13799,16 @@ entry:
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = load i32, i32* %arg1
   %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
   %7 = load i64, i64 addrspace(1)* %5
@@ -12117,7 +13826,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12154,8 +13863,8 @@ entry:
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
   %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
   %16 = load i64, i64 addrspace(1)* %14
@@ -12176,8 +13885,8 @@ entry:
   %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
   %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
   %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %31, null
-  br i1 %NullCheck2, label %32, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = load i64, i64 addrspace(1)* %31
@@ -12220,7 +13929,7 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12233,14 +13942,14 @@ entry:
   %this = alloca %System.Text.EncoderReplacementFallback addrspace(1)*
   store %System.Text.EncoderReplacementFallback addrspace(1)* %param0, %System.Text.EncoderReplacementFallback addrspace(1)** %this
   %0 = load %System.Text.EncoderReplacementFallback addrspace(1)*, %System.Text.EncoderReplacementFallback addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -12251,7 +13960,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12281,8 +13990,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
@@ -12314,8 +14023,8 @@ entry:
   %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
   store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
@@ -12327,8 +14036,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Threading.Tasks.Task addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %7)
@@ -12351,7 +14060,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12370,8 +14079,8 @@ entry:
   store i8 %param1, i8* %arg1
   store i8 %param2, i8* %arg2
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
@@ -12385,8 +14094,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1, %5
   %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 9
@@ -12417,8 +14126,8 @@ entry:
 
 ; <label>:25                                      ; preds = %8, %20
   %26 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %26, null
-  br i1 %NullCheck4, label %27, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %26, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %26, i32 0, i32 12
@@ -12429,22 +14138,22 @@ entry:
 
 ; <label>:32                                      ; preds = %27
   %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %33, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.IO.StreamWriter addrspace(1)* %33, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %32
   %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 12
   store i8 1, i8 addrspace(1)* %35
   %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
-  br i1 %NullCheck8, label %37, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
   %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
   %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck10 = icmp ne i64 addrspace(1)* %40, null
-  br i1 %NullCheck10, label %41, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64 addrspace(1)* %40, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i64, i64 addrspace(1)* %40
@@ -12458,8 +14167,8 @@ entry:
   %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
   store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
   %51 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %NullCheck12 = icmp ne %"System.Byte[]" addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Byte[]" addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %41
   %53 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %51, i32 0, i32 1
@@ -12471,16 +14180,16 @@ entry:
 
 ; <label>:58                                      ; preds = %52
   %59 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %59, null
-  br i1 %NullCheck14, label %60, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.IO.StreamWriter addrspace(1)* %59, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %60
 
 ; <label>:60                                      ; preds = %58
   %61 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %59, i32 0, i32 3
   %62 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
   %64 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %NullCheck16 = icmp ne %"System.Byte[]" addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %"System.Byte[]" addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %60
   %66 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %64, i32 0, i32 1
@@ -12488,8 +14197,8 @@ entry:
   %68 = zext i32 %67 to i64
   %69 = trunc i64 %68 to i32
   %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck18, label %71, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
   %72 = load i64, i64 addrspace(1)* %70
@@ -12505,29 +14214,29 @@ entry:
 
 ; <label>:80                                      ; preds = %27, %52, %71
   %81 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %81, null
-  br i1 %NullCheck20, label %82, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.IO.StreamWriter addrspace(1)* %81, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
 
 ; <label>:82                                      ; preds = %80
   %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %81, i32 0, i32 5
   %84 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %83, align 8
   %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.IO.StreamWriter addrspace(1)* %85, null
-  br i1 %NullCheck22, label %86, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.IO.StreamWriter addrspace(1)* %85, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %86
 
 ; <label>:86                                      ; preds = %82
   %87 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 7
   %88 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %87, align 8
   %89 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %89, null
-  br i1 %NullCheck24, label %90, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.StreamWriter addrspace(1)* %89, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %90
 
 ; <label>:90                                      ; preds = %86
   %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %89, i32 0, i32 9
   %92 = load i32, i32 addrspace(1)* %91, align 8
   %93 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.IO.StreamWriter addrspace(1)* %93, null
-  br i1 %NullCheck26, label %94, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.IO.StreamWriter addrspace(1)* %93, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %93, i32 0, i32 6
@@ -12535,8 +14244,8 @@ entry:
   %97 = load i8, i8* %arg2
   %98 = zext i8 %97 to i32
   %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
-  %NullCheck28 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck28, label %100, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
   %101 = load i64, i64 addrspace(1)* %99
@@ -12551,8 +14260,8 @@ entry:
   %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
   store i32 %110, i32* %loc1
   %111 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %111, null
-  br i1 %NullCheck30, label %112, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.IO.StreamWriter addrspace(1)* %111, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %112
 
 ; <label>:112                                     ; preds = %100
   %113 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %111, i32 0, i32 9
@@ -12563,23 +14272,23 @@ entry:
 
 ; <label>:116                                     ; preds = %112
   %117 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck32 = icmp ne %System.IO.StreamWriter addrspace(1)* %117, null
-  br i1 %NullCheck32, label %118, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.IO.StreamWriter addrspace(1)* %117, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %118
 
 ; <label>:118                                     ; preds = %116
   %119 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %117, i32 0, i32 3
   %120 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %119, align 8
   %121 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.IO.StreamWriter addrspace(1)* %121, null
-  br i1 %NullCheck34, label %122, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.IO.StreamWriter addrspace(1)* %121, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %122
 
 ; <label>:122                                     ; preds = %118
   %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
   %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
   %125 = load i32, i32* %loc1
   %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
-  %NullCheck36 = icmp ne i64 addrspace(1)* %126, null
-  br i1 %NullCheck36, label %127, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64 addrspace(1)* %126, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
   %128 = load i64, i64 addrspace(1)* %126
@@ -12601,15 +14310,15 @@ entry:
 
 ; <label>:140                                     ; preds = %136
   %141 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.IO.StreamWriter addrspace(1)* %141, null
-  br i1 %NullCheck38, label %142, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.IO.StreamWriter addrspace(1)* %141, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %142
 
 ; <label>:142                                     ; preds = %140
   %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
   %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
   %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
-  %NullCheck40 = icmp ne i64 addrspace(1)* %145, null
-  br i1 %NullCheck40, label %146, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i64 addrspace(1)* %145, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
   %147 = load i64, i64 addrspace(1)* %145
@@ -12630,83 +14339,83 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %25
+ThrowNullRef4:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %32
+ThrowNullRef6:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %37
+ThrowNullRef10:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %41
+ThrowNullRef12:                                   ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %58
+ThrowNullRef14:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %60
+ThrowNullRef16:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %65
+ThrowNullRef18:                                   ; preds = %65
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %80
+ThrowNullRef20:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %82
+ThrowNullRef22:                                   ; preds = %82
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %86
+ThrowNullRef24:                                   ; preds = %86
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %90
+ThrowNullRef26:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %94
+ThrowNullRef28:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %100
+ThrowNullRef30:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %116
+ThrowNullRef32:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %118
+ThrowNullRef34:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %122
+ThrowNullRef36:                                   ; preds = %122
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %140
+ThrowNullRef38:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %142
+ThrowNullRef40:                                   ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12773,8 +14482,8 @@ entry:
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %1 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
-  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
@@ -12782,8 +14491,8 @@ entry:
   %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
   %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
   %8 = load i64, i64 addrspace(1)* %6
@@ -12799,8 +14508,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %17, %System.IFormatProvider addrspace(1)* %16)
   %18 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %19 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %18, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.SyncTextWriter addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %7
   %21 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %18, i32 0, i32 4
@@ -12811,11 +14520,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12828,8 +14537,8 @@ entry:
   %this = alloca %System.IO.TextWriter addrspace(1)*
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.TextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
@@ -12839,8 +14548,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.Threading.Thread addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Threading.Thread addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %6)
@@ -12849,8 +14558,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1
   %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.TextWriter addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.TextWriter addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %11, i32 0, i32 2
@@ -12861,11 +14570,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13062,8 +14771,8 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   store i8 0, i8* %loc1
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
@@ -13073,16 +14782,16 @@ entry:
   %5 = addrspacecast i8* %loc1 to i8 addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %4, i8 addrspace(1)* %5)
   %6 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.SyncTextWriter addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
   %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
   %13 = load i64, i64 addrspace(1)* %11
@@ -13117,19 +14826,229 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
-Failed to read TextWriter.WriteLine[loadElem]
+Failed to read TextWriter.WriteLine[storeElem]
 INFO:  jitting method String::CopyTo using LLILCJit
-Failed to read String.CopyTo[loadElemA]
+Successfully read String.CopyTo
+
+define void @String.CopyTo(%System.String addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  %loc1 = alloca i16 addrspace(1)*
+  %loc2 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %1 = icmp ne %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg4
+  %7 = icmp sge i32 %6, 0
+  br i1 %7, label %13, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  unreachable
+
+; <label>:13                                      ; preds = %5
+  %14 = load i32, i32* %arg1
+  %15 = icmp sge i32 %14, 0
+  br i1 %15, label %21, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %18)
+  %20 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %20, %System.String addrspace(1)* %17, %System.String addrspace(1)* %19)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %20) #0
+  unreachable
+
+; <label>:21                                      ; preds = %13
+  %22 = load i32, i32* %arg4
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck, label %ThrowNullRef, label %24
+
+; <label>:24                                      ; preds = %21
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load i32, i32* %arg1
+  %28 = sub i32 %26, %27
+  %29 = icmp sle i32 %22, %28
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34, %System.String addrspace(1)* %31, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %24
+  %36 = load i32, i32* %arg3
+  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %37, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
+
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
+  %40 = load i32, i32 addrspace(1)* %39
+  %41 = zext i32 %40 to i64
+  %42 = trunc i64 %41 to i32
+  %43 = load i32, i32* %arg4
+  %44 = sub i32 %42, %43
+  %45 = icmp sgt i32 %36, %44
+  br i1 %45, label %49, label %46
+
+; <label>:46                                      ; preds = %38
+  %47 = load i32, i32* %arg3
+  %48 = icmp sge i32 %47, 0
+  br i1 %48, label %54, label %49
+
+; <label>:49                                      ; preds = %38, %46
+  %50 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %52 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %51)
+  %53 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53, %System.String addrspace(1)* %50, %System.String addrspace(1)* %52)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53) #0
+  unreachable
+
+; <label>:54                                      ; preds = %46
+  %55 = load i32, i32* %arg4
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %97, label %57
+
+; <label>:57                                      ; preds = %54
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %59
+
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 2
+  %61 = bitcast [0 x i16] addrspace(1)* %60 to i16 addrspace(1)*
+  store i16 addrspace(1)* %61, i16 addrspace(1)** %loc0
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  store %"System.Char[]" addrspace(1)* %62, %"System.Char[]" addrspace(1)** %loc2
+  %63 = icmp eq %"System.Char[]" addrspace(1)* %62, null
+  br i1 %63, label %72, label %64
+
+; <label>:64                                      ; preds = %59
+  %65 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc2
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %65, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %66
+
+; <label>:66                                      ; preds = %64
+  %67 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %65, i32 0, i32 1
+  %68 = load i32, i32 addrspace(1)* %67
+  %69 = zext i32 %68 to i64
+  %70 = trunc i64 %69 to i32
+  %71 = icmp ne i32 %70, 0
+  br i1 %71, label %73, label %72
+
+; <label>:72                                      ; preds = %59, %66
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  br label %81
+
+; <label>:73                                      ; preds = %66
+  %74 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc2
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %74, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %75
+
+; <label>:75                                      ; preds = %73
+  %76 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %74, i32 0, i32 1
+  %77 = load i32, i32 addrspace(1)* %76
+  %78 = zext i32 %77 to i64
+  %BoundsCheck = icmp uge i64 0, %78
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %79
+
+; <label>:79                                      ; preds = %75
+  %80 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %74, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %80, i16 addrspace(1)** %loc1
+  br label %81
+
+; <label>:81                                      ; preds = %72, %79
+  %82 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %83 = ptrtoint i16 addrspace(1)* %82 to i64
+  %84 = load i32, i32* %arg3
+  %85 = sext i32 %84 to i64
+  %86 = mul i64 %85, 2
+  %87 = add i64 %83, %86
+  %88 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %89 = ptrtoint i16 addrspace(1)* %88 to i64
+  %90 = load i32, i32* %arg1
+  %91 = sext i32 %90 to i64
+  %92 = mul i64 %91, 2
+  %93 = add i64 %89, %92
+  %94 = load i32, i32* %arg4
+  %95 = inttoptr i64 %87 to i16*
+  %96 = inttoptr i64 %93 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %95, i16* %96, i32 %94)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  br label %97
+
+; <label>:97                                      ; preds = %54, %81
+  ret void
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StreamWriter::Write using LLILCJit
 Successfully read StreamWriter.Write
 
@@ -13187,8 +15106,8 @@ entry:
 
 ; <label>:23                                      ; preds = %15
   %24 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Char[]" addrspace(1)* %24, null
-  br i1 %NullCheck, label %25, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %24, null
+  br i1 %NullCheck, label %ThrowNullRef, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %24, i32 0, i32 1
@@ -13216,15 +15135,15 @@ entry:
 
 ; <label>:40                                      ; preds = %98
   %41 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %41, null
-  br i1 %NullCheck4, label %42, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %41, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %42
 
 ; <label>:42                                      ; preds = %40
   %43 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
   %44 = load i32, i32 addrspace(1)* %43, align 8
   %45 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %45, null
-  br i1 %NullCheck6, label %46, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.IO.StreamWriter addrspace(1)* %45, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %46
 
 ; <label>:46                                      ; preds = %42
   %47 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %45, i32 0, i32 10
@@ -13239,15 +15158,15 @@ entry:
 
 ; <label>:52                                      ; preds = %46, %50
   %53 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %53, null
-  br i1 %NullCheck8, label %54, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %53, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %54
 
 ; <label>:54                                      ; preds = %52
   %55 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %53, i32 0, i32 10
   %56 = load i32, i32 addrspace(1)* %55, align 8
   %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %57, null
-  br i1 %NullCheck10, label %58, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.StreamWriter addrspace(1)* %57, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %58
 
 ; <label>:58                                      ; preds = %54
   %59 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 9
@@ -13269,15 +15188,15 @@ entry:
   %69 = load i32, i32* %arg2
   %70 = mul i32 %69, 2
   %71 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %71, null
-  br i1 %NullCheck12, label %72, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.StreamWriter addrspace(1)* %71, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %72
 
 ; <label>:72                                      ; preds = %67
   %73 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %71, i32 0, i32 7
   %74 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %73, align 8
   %75 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %75, null
-  br i1 %NullCheck14, label %76, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.IO.StreamWriter addrspace(1)* %75, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %76
 
 ; <label>:76                                      ; preds = %72
   %77 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %75, i32 0, i32 9
@@ -13289,16 +15208,16 @@ entry:
   %83 = bitcast %"System.Char[]" addrspace(1)* %74 to %System.Array addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %82, i32 %70, %System.Array addrspace(1)* %83, i32 %79, i32 %81)
   %84 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %84, null
-  br i1 %NullCheck16, label %85, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.IO.StreamWriter addrspace(1)* %84, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %85
 
 ; <label>:85                                      ; preds = %76
   %86 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %84, i32 0, i32 9
   %87 = load i32, i32 addrspace(1)* %86, align 8
   %88 = load i32, i32* %loc0
   %89 = add i32 %87, %88
-  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %84, null
-  br i1 %NullCheck18, label %90, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.StreamWriter addrspace(1)* %84, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %90
 
 ; <label>:90                                      ; preds = %85
   %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %84, i32 0, i32 9
@@ -13320,8 +15239,8 @@ entry:
 
 ; <label>:101                                     ; preds = %98
   %102 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %102, null
-  br i1 %NullCheck2, label %103, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %102, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %103
 
 ; <label>:103                                     ; preds = %101
   %104 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %102, i32 0, i32 11
@@ -13342,39 +15261,39 @@ ThrowNullRef:                                     ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %101
+ThrowNullRef2:                                    ; preds = %101
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %40
+ThrowNullRef4:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %42
+ThrowNullRef6:                                    ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %52
+ThrowNullRef8:                                    ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %54
+ThrowNullRef10:                                   ; preds = %54
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %67
+ThrowNullRef12:                                   ; preds = %67
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %72
+ThrowNullRef14:                                   ; preds = %72
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %76
+ThrowNullRef16:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %85
+ThrowNullRef18:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13415,7 +15334,365 @@ entry:
 }
 
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[loadElemA]
+Successfully read EncoderNLS.GetBytes
+
+define i32 @EncoderNLS.GetBytes(%System.Text.EncoderNLS addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3, %"System.Byte[]" addrspace(1)* %param4, i32 %param5, i8 %param6) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %arg4 = alloca %"System.Byte[]" addrspace(1)*
+  %arg5 = alloca i32
+  %arg6 = alloca i8
+  %loc0 = alloca i32
+  %loc1 = alloca i16 addrspace(1)*
+  %loc2 = alloca i8 addrspace(1)*
+  %loc3 = alloca i32
+  %loc4 = alloca %"System.Char[]" addrspace(1)*
+  %loc5 = alloca %"System.Byte[]" addrspace(1)*
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  store %"System.Byte[]" addrspace(1)* %param4, %"System.Byte[]" addrspace(1)** %arg4
+  store i32 %param5, i32* %arg5
+  store i8 %param6, i8* %arg6
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %1 = icmp eq %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %17, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %7 = icmp eq %"System.Char[]" addrspace(1)* %6, null
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %12
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %12
+
+; <label>:12                                      ; preds = %8, %10
+  %13 = phi %System.String addrspace(1)* [ %9, %8 ], [ %11, %10 ]
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %14)
+  %16 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16, %System.String addrspace(1)* %13, %System.String addrspace(1)* %15)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16) #0
+  unreachable
+
+; <label>:17                                      ; preds = %2
+  %18 = load i32, i32* %arg2
+  %19 = icmp slt i32 %18, 0
+  br i1 %19, label %23, label %20
+
+; <label>:20                                      ; preds = %17
+  %21 = load i32, i32* %arg3
+  %22 = icmp sge i32 %21, 0
+  br i1 %22, label %35, label %23
+
+; <label>:23                                      ; preds = %17, %20
+  %24 = load i32, i32* %arg2
+  %25 = icmp slt i32 %24, 0
+  br i1 %25, label %28, label %26
+
+; <label>:26                                      ; preds = %23
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %30
+
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %30
+
+; <label>:30                                      ; preds = %26, %28
+  %31 = phi %System.String addrspace(1)* [ %27, %26 ], [ %29, %28 ]
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34, %System.String addrspace(1)* %31, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %20
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck, label %ThrowNullRef, label %37
+
+; <label>:37                                      ; preds = %35
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = load i32, i32* %arg2
+  %43 = sub i32 %41, %42
+  %44 = load i32, i32* %arg3
+  %45 = icmp sge i32 %43, %44
+  br i1 %45, label %51, label %46
+
+; <label>:46                                      ; preds = %37
+  %47 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %48 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %49 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %48)
+  %50 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %50, %System.String addrspace(1)* %47, %System.String addrspace(1)* %49)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %50) #0
+  unreachable
+
+; <label>:51                                      ; preds = %37
+  %52 = load i32, i32* %arg5
+  %53 = icmp slt i32 %52, 0
+  br i1 %53, label %63, label %54
+
+; <label>:54                                      ; preds = %51
+  %55 = load i32, i32* %arg5
+  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck1 = icmp eq %"System.Byte[]" addrspace(1)* %56, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %57
+
+; <label>:57                                      ; preds = %54
+  %58 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = zext i32 %59 to i64
+  %61 = trunc i64 %60 to i32
+  %62 = icmp sle i32 %55, %61
+  br i1 %62, label %68, label %63
+
+; <label>:63                                      ; preds = %51, %57
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %66 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %65)
+  %67 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %67, %System.String addrspace(1)* %64, %System.String addrspace(1)* %66)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %67) #0
+  unreachable
+
+; <label>:68                                      ; preds = %57
+  %69 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %69, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %69, i32 0, i32 1
+  %72 = load i32, i32 addrspace(1)* %71
+  %73 = zext i32 %72 to i64
+  %74 = trunc i64 %73 to i32
+  %75 = icmp ne i32 %74, 0
+  br i1 %75, label %78, label %76
+
+; <label>:76                                      ; preds = %70
+  %77 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1)
+  store %"System.Char[]" addrspace(1)* %77, %"System.Char[]" addrspace(1)** %arg1
+  br label %78
+
+; <label>:78                                      ; preds = %70, %76
+  %79 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck5 = icmp eq %"System.Byte[]" addrspace(1)* %79, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %80
+
+; <label>:80                                      ; preds = %78
+  %81 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %79, i32 0, i32 1
+  %82 = load i32, i32 addrspace(1)* %81
+  %83 = zext i32 %82 to i64
+  %84 = trunc i64 %83 to i32
+  %85 = load i32, i32* %arg5
+  %86 = sub i32 %84, %85
+  store i32 %86, i32* %loc0
+  %87 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck7 = icmp eq %"System.Byte[]" addrspace(1)* %87, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %88
+
+; <label>:88                                      ; preds = %80
+  %89 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %87, i32 0, i32 1
+  %90 = load i32, i32 addrspace(1)* %89
+  %91 = zext i32 %90 to i64
+  %92 = trunc i64 %91 to i32
+  %93 = icmp ne i32 %92, 0
+  br i1 %93, label %96, label %94
+
+; <label>:94                                      ; preds = %88
+  %95 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1)
+  store %"System.Byte[]" addrspace(1)* %95, %"System.Byte[]" addrspace(1)** %arg4
+  br label %96
+
+; <label>:96                                      ; preds = %88, %94
+  %97 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  store %"System.Char[]" addrspace(1)* %97, %"System.Char[]" addrspace(1)** %loc4
+  %98 = icmp eq %"System.Char[]" addrspace(1)* %97, null
+  br i1 %98, label %107, label %99
+
+; <label>:99                                      ; preds = %96
+  %100 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc4
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %100, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %101
+
+; <label>:101                                     ; preds = %99
+  %102 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %100, i32 0, i32 1
+  %103 = load i32, i32 addrspace(1)* %102
+  %104 = zext i32 %103 to i64
+  %105 = trunc i64 %104 to i32
+  %106 = icmp ne i32 %105, 0
+  br i1 %106, label %108, label %107
+
+; <label>:107                                     ; preds = %96, %101
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  br label %116
+
+; <label>:108                                     ; preds = %101
+  %109 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc4
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %109, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %110
+
+; <label>:110                                     ; preds = %108
+  %111 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %109, i32 0, i32 1
+  %112 = load i32, i32 addrspace(1)* %111
+  %113 = zext i32 %112 to i64
+  %BoundsCheck = icmp uge i64 0, %113
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %114
+
+; <label>:114                                     ; preds = %110
+  %115 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %109, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %115, i16 addrspace(1)** %loc1
+  br label %116
+
+; <label>:116                                     ; preds = %107, %114
+  %117 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  store %"System.Byte[]" addrspace(1)* %117, %"System.Byte[]" addrspace(1)** %loc5
+  %118 = icmp eq %"System.Byte[]" addrspace(1)* %117, null
+  br i1 %118, label %127, label %119
+
+; <label>:119                                     ; preds = %116
+  %120 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc5
+  %NullCheck13 = icmp eq %"System.Byte[]" addrspace(1)* %120, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %121
+
+; <label>:121                                     ; preds = %119
+  %122 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %120, i32 0, i32 1
+  %123 = load i32, i32 addrspace(1)* %122
+  %124 = zext i32 %123 to i64
+  %125 = trunc i64 %124 to i32
+  %126 = icmp ne i32 %125, 0
+  br i1 %126, label %128, label %127
+
+; <label>:127                                     ; preds = %116, %121
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc2
+  br label %136
+
+; <label>:128                                     ; preds = %121
+  %129 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc5
+  %NullCheck15 = icmp eq %"System.Byte[]" addrspace(1)* %129, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %130
+
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %129, i32 0, i32 1
+  %132 = load i32, i32 addrspace(1)* %131
+  %133 = zext i32 %132 to i64
+  %BoundsCheck17 = icmp uge i64 0, %133
+  br i1 %BoundsCheck17, label %ThrowIndexOutOfRange18, label %134
+
+; <label>:134                                     ; preds = %130
+  %135 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %129, i32 0, i32 3, i32 0
+  store i8 addrspace(1)* %135, i8 addrspace(1)** %loc2
+  br label %136
+
+; <label>:136                                     ; preds = %127, %134
+  %137 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %138 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %139 = ptrtoint i16 addrspace(1)* %138 to i64
+  %140 = load i32, i32* %arg2
+  %141 = sext i32 %140 to i64
+  %142 = mul i64 %141, 2
+  %143 = add i64 %139, %142
+  %144 = load i32, i32* %arg3
+  %145 = load i8 addrspace(1)*, i8 addrspace(1)** %loc2
+  %146 = ptrtoint i8 addrspace(1)* %145 to i64
+  %147 = load i32, i32* %arg5
+  %148 = sext i32 %147 to i64
+  %149 = add i64 %146, %148
+  %150 = load i32, i32* %loc0
+  %151 = load i8, i8* %arg6
+  %152 = zext i8 %151 to i32
+  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i64 addrspace(1)*
+  %NullCheck19 = icmp eq i64 addrspace(1)* %153, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %154
+
+; <label>:154                                     ; preds = %136
+  %155 = load i64, i64 addrspace(1)* %153
+  %156 = add i64 %155, 72
+  %157 = inttoptr i64 %156 to i64*
+  %158 = load i64, i64* %157
+  %159 = add i64 %158, 0
+  %160 = inttoptr i64 %159 to i64*
+  %161 = load i64, i64* %160
+  %162 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to %System.Text.Encoder addrspace(1)*
+  %163 = inttoptr i64 %143 to i16*
+  %164 = inttoptr i64 %149 to i8*
+  %165 = trunc i32 %152 to i8
+  %166 = inttoptr i64 %161 to i32 (%System.Text.Encoder addrspace(1)*, i16*, i32, i8*, i32, i8)*
+  %167 = call i32 %166(%System.Text.Encoder addrspace(1)* %162, i16* %163, i32 %144, i8* %164, i32 %150, i8 %165)
+  store i32 %167, i32* %loc3
+  br label %168
+
+; <label>:168                                     ; preds = %154
+  %169 = load i32, i32* %loc3
+  ret i32 %169
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %110
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %119
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange18:                           ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
 Successfully read EncoderNLS.GetBytes
 
@@ -13504,22 +15781,22 @@ entry:
   %40 = load i8, i8* %arg5
   %41 = zext i8 %40 to i32
   %42 = trunc i32 %41 to i8
-  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %39, null
-  br i1 %NullCheck, label %43, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderNLS addrspace(1)* %39, null
+  br i1 %NullCheck, label %ThrowNullRef, label %43
 
 ; <label>:43                                      ; preds = %38
   %44 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
   store i8 %42, i8 addrspace(1)* %44
   %45 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %45, null
-  br i1 %NullCheck2, label %46, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.EncoderNLS addrspace(1)* %45, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %46
 
 ; <label>:46                                      ; preds = %43
   %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %45, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %47
   %48 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.EncoderNLS addrspace(1)* %48, null
-  br i1 %NullCheck4, label %49, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.EncoderNLS addrspace(1)* %48, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %49
 
 ; <label>:49                                      ; preds = %46
   %50 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %48, i32 0, i32 3
@@ -13530,8 +15807,8 @@ entry:
   %55 = load i32, i32* %arg4
   %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck6, label %58, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
   %59 = load i64, i64 addrspace(1)* %57
@@ -13549,15 +15826,15 @@ ThrowNullRef:                                     ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %43
+ThrowNullRef2:                                    ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %46
+ThrowNullRef4:                                    ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %49
+ThrowNullRef6:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13585,8 +15862,8 @@ entry:
   %4 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0 to %System.IO.ConsoleStream addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*)(%System.IO.ConsoleStream addrspace(1)* %4, %"System.Byte[]" addrspace(1)* %1, i32 %2, i32 %3)
   %5 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
@@ -13671,8 +15948,8 @@ entry:
 
 ; <label>:22                                      ; preds = %8
   %23 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %23, null
-  br i1 %NullCheck, label %24, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Byte[]" addrspace(1)* %23, null
+  br i1 %NullCheck, label %ThrowNullRef, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
@@ -13694,8 +15971,8 @@ entry:
 
 ; <label>:36                                      ; preds = %24
   %37 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %37, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.ConsoleStream addrspace(1)* %37, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %37, i32 0, i32 4
@@ -13716,13 +15993,138 @@ ThrowNullRef:                                     ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %36
+ThrowNullRef2:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
-Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
+Successfully read WindowsConsoleStream.WriteFileNative
+
+define i32 @WindowsConsoleStream.WriteFileNative(i64 %param0, %"System.Byte[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i64
+  %arg1 = alloca %"System.Byte[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i8 addrspace(1)*
+  %loc2 = alloca %"System.Byte[]" addrspace(1)*
+  %loc3 = alloca i32
+  store i64 %param0, i64* %arg0
+  store %"System.Byte[]" addrspace(1)* %param1, %"System.Byte[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Byte[]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = zext i32 %3 to i64
+  %5 = icmp ne i64 %4, 0
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %1
+  ret i32 0
+
+; <label>:7                                       ; preds = %1
+  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  store %"System.Byte[]" addrspace(1)* %8, %"System.Byte[]" addrspace(1)** %loc2
+  %9 = icmp eq %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %9, label %18, label %10
+
+; <label>:10                                      ; preds = %7
+  %11 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc2
+  %NullCheck1 = icmp eq %"System.Byte[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %11, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp ne i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %7, %12
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc1
+  br label %27
+
+; <label>:19                                      ; preds = %12
+  %20 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc2
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %20, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %BoundsCheck = icmp uge i64 0, %24
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %25
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %20, i32 0, i32 3, i32 0
+  store i8 addrspace(1)* %26, i8 addrspace(1)** %loc1
+  br label %27
+
+; <label>:27                                      ; preds = %18, %25
+  %28 = load i64, i64* %arg0
+  %29 = load i8 addrspace(1)*, i8 addrspace(1)** %loc1
+  %30 = ptrtoint i8 addrspace(1)* %29 to i64
+  %31 = load i32, i32* %arg2
+  %32 = sext i32 %31 to i64
+  %33 = add i64 %30, %32
+  %34 = load i32, i32* %arg3
+  %35 = addrspacecast i32* %loc3 to i32 addrspace(1)*
+  %36 = inttoptr i64 %33 to i8*
+  %37 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i8*, i32, i32 addrspace(1)*, i64)*)(i64 %28, i8* %36, i32 %34, i32 addrspace(1)* %35, i64 0)
+  %38 = icmp ugt i32 %37, 0
+  %39 = sext i1 %38 to i32
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc1
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %42, label %41
+
+; <label>:41                                      ; preds = %27
+  ret i32 0
+
+; <label>:42                                      ; preds = %27
+  %43 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  store i32 %43, i32* %loc0
+  %44 = load i32, i32* %loc0
+  %45 = icmp eq i32 %44, 232
+  br i1 %45, label %49, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = load i32, i32* %loc0
+  %48 = icmp ne i32 %47, 109
+  br i1 %48, label %50, label %49
+
+; <label>:49                                      ; preds = %42, %46
+  ret i32 0
+
+; <label>:50                                      ; preds = %46
+  %51 = load i32, i32* %loc0
+  ret i32 %51
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
 Successfully read WindowsConsoleStream.Flush
 
@@ -13731,8 +16133,8 @@ entry:
   %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
   store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
@@ -13767,8 +16169,8 @@ entry:
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
   %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load i64, i64 addrspace(1)* %1

--- a/test/BaseLine/JIT/Directed/Arrays/simple1.error.txt
+++ b/test/BaseLine/JIT/Directed/Arrays/simple1.error.txt
@@ -25,8 +25,8 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
@@ -40,8 +40,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
   %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
@@ -75,7 +75,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -90,8 +90,8 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %NullCheck = icmp ne i8 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = load i8, i8 addrspace(1)* %0, align 8
@@ -125,8 +125,8 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
@@ -159,8 +159,8 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -184,8 +184,8 @@ entry:
   store %System.AppDomainSetup addrspace(1)* %param1, %System.AppDomainSetup addrspace(1)** %arg1
   store %System.AppDomainSetup addrspace(1)* %param2, %System.AppDomainSetup addrspace(1)** %arg2
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
@@ -195,8 +195,8 @@ entry:
 ; <label>:4                                       ; preds = %1
   %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
   %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %5, %System.String addrspace(1)* %6, i8 1)
@@ -206,8 +206,8 @@ entry:
   %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %9)
   %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
@@ -221,14 +221,14 @@ entry:
 
 ; <label>:17                                      ; preds = %14
   %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.AppDomainSetup addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
   %21 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.AppDomainSetup addrspace(1)* %21, null
-  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %21, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %21)
@@ -238,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -249,8 +249,8 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
@@ -261,27 +261,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %30
+ThrowNullRef10:                                   ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -301,7 +301,89 @@ entry:
 }
 
 INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
-Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
+Successfully read AppDomainSetup.GetUnsecureApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.GetUnsecureApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %NullCheck = icmp eq %"System.String[]" addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %BoundsCheck = icmp uge i64 0, %5
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %6
+
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %"System.String[]", %"System.String[]" addrspace(1)* %1, i32 0, i32 3, i32 0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
+  ret %System.String addrspace(1)* %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_Value using LLILCJit
+Successfully read AppDomainSetup.get_Value
+
+define %"System.String[]" addrspace(1)* @AppDomainSetup.get_Value(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.String[]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 18)
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.String[]" addrspace(1)* addrspace(1)*, %"System.String[]" addrspace(1)*)*)(%"System.String[]" addrspace(1)* addrspace(1)* %9, %"System.String[]" addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %11, i32 0, i32 1
+  %14 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)* addrspace(1)* %13, align 8
+  ret %"System.String[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -319,8 +401,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -368,16 +450,16 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
   %5 = load i32, i32 addrspace(1)* %4
   %6 = sub i32 %5, 1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -389,7 +471,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -421,8 +503,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
@@ -456,8 +538,8 @@ entry:
 ; <label>:27                                      ; preds = %19
   %28 = load i32, i32* %arg1
   %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
-  br i1 %NullCheck2, label %30, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %29, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %30
 
 ; <label>:30                                      ; preds = %27
   %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
@@ -493,8 +575,8 @@ entry:
 ; <label>:49                                      ; preds = %46
   %50 = load i32, i32* %arg2
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck4, label %52, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
@@ -517,11 +599,11 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %27
+ThrowNullRef2:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %49
+ThrowNullRef4:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -544,16 +626,16 @@ entry:
   %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %0)
   store %System.String addrspace(1)* %1, %System.String addrspace(1)** %loc0
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 2
   %5 = bitcast [0 x i16] addrspace(1)* %4 to i16 addrspace(1)*
   store i16 addrspace(1)* %5, i16 addrspace(1)** %loc1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %3
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2
@@ -580,7 +662,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -691,15 +773,15 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %NullCheck132 = icmp ne i8* %21, null
-  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+  %NullCheck131 = icmp eq i8* %21, null
+  br i1 %NullCheck131, label %ThrowNullRef132, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = load i8, i8* %21, align 8
   %24 = zext i8 %23 to i32
   %25 = trunc i32 %24 to i8
-  %NullCheck134 = icmp ne i8* %20, null
-  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+  %NullCheck133 = icmp eq i8* %20, null
+  br i1 %NullCheck133, label %ThrowNullRef134, label %26
 
 ; <label>:26                                      ; preds = %22
   store i8 %25, i8* %20, align 8
@@ -709,16 +791,16 @@ entry:
   %28 = load i8*, i8** %arg0
   %29 = load i8*, i8** %arg1
   %30 = bitcast i8* %29 to i16*
-  %NullCheck128 = icmp ne i16* %30, null
-  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+  %NullCheck127 = icmp eq i16* %30, null
+  br i1 %NullCheck127, label %ThrowNullRef128, label %31
 
 ; <label>:31                                      ; preds = %27
   %32 = load i16, i16* %30, align 8
   %33 = sext i16 %32 to i32
   %34 = bitcast i8* %28 to i16*
   %35 = trunc i32 %33 to i16
-  %NullCheck130 = icmp ne i16* %34, null
-  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+  %NullCheck129 = icmp eq i16* %34, null
+  br i1 %NullCheck129, label %ThrowNullRef130, label %36
 
 ; <label>:36                                      ; preds = %31
   store i16 %35, i16* %34, align 8
@@ -728,16 +810,16 @@ entry:
   %38 = load i8*, i8** %arg0
   %39 = load i8*, i8** %arg1
   %40 = bitcast i8* %39 to i16*
-  %NullCheck120 = icmp ne i16* %40, null
-  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+  %NullCheck119 = icmp eq i16* %40, null
+  br i1 %NullCheck119, label %ThrowNullRef120, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i16, i16* %40, align 8
   %43 = sext i16 %42 to i32
   %44 = bitcast i8* %38 to i16*
   %45 = trunc i32 %43 to i16
-  %NullCheck122 = icmp ne i16* %44, null
-  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+  %NullCheck121 = icmp eq i16* %44, null
+  br i1 %NullCheck121, label %ThrowNullRef122, label %46
 
 ; <label>:46                                      ; preds = %41
   store i16 %45, i16* %44, align 8
@@ -745,15 +827,15 @@ entry:
   %48 = getelementptr inbounds i8, i8* %47, i64 2
   %49 = load i8*, i8** %arg1
   %50 = getelementptr inbounds i8, i8* %49, i64 2
-  %NullCheck124 = icmp ne i8* %50, null
-  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+  %NullCheck123 = icmp eq i8* %50, null
+  br i1 %NullCheck123, label %ThrowNullRef124, label %51
 
 ; <label>:51                                      ; preds = %46
   %52 = load i8, i8* %50, align 8
   %53 = zext i8 %52 to i32
   %54 = trunc i32 %53 to i8
-  %NullCheck126 = icmp ne i8* %48, null
-  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+  %NullCheck125 = icmp eq i8* %48, null
+  br i1 %NullCheck125, label %ThrowNullRef126, label %55
 
 ; <label>:55                                      ; preds = %51
   store i8 %54, i8* %48, align 8
@@ -763,14 +845,14 @@ entry:
   %57 = load i8*, i8** %arg0
   %58 = load i8*, i8** %arg1
   %59 = bitcast i8* %58 to i32*
-  %NullCheck116 = icmp ne i32* %59, null
-  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+  %NullCheck115 = icmp eq i32* %59, null
+  br i1 %NullCheck115, label %ThrowNullRef116, label %60
 
 ; <label>:60                                      ; preds = %56
   %61 = load i32, i32* %59, align 8
   %62 = bitcast i8* %57 to i32*
-  %NullCheck118 = icmp ne i32* %62, null
-  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+  %NullCheck117 = icmp eq i32* %62, null
+  br i1 %NullCheck117, label %ThrowNullRef118, label %63
 
 ; <label>:63                                      ; preds = %60
   store i32 %61, i32* %62, align 8
@@ -780,14 +862,14 @@ entry:
   %65 = load i8*, i8** %arg0
   %66 = load i8*, i8** %arg1
   %67 = bitcast i8* %66 to i32*
-  %NullCheck108 = icmp ne i32* %67, null
-  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+  %NullCheck107 = icmp eq i32* %67, null
+  br i1 %NullCheck107, label %ThrowNullRef108, label %68
 
 ; <label>:68                                      ; preds = %64
   %69 = load i32, i32* %67, align 8
   %70 = bitcast i8* %65 to i32*
-  %NullCheck110 = icmp ne i32* %70, null
-  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+  %NullCheck109 = icmp eq i32* %70, null
+  br i1 %NullCheck109, label %ThrowNullRef110, label %71
 
 ; <label>:71                                      ; preds = %68
   store i32 %69, i32* %70, align 8
@@ -795,15 +877,15 @@ entry:
   %73 = getelementptr inbounds i8, i8* %72, i64 4
   %74 = load i8*, i8** %arg1
   %75 = getelementptr inbounds i8, i8* %74, i64 4
-  %NullCheck112 = icmp ne i8* %75, null
-  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+  %NullCheck111 = icmp eq i8* %75, null
+  br i1 %NullCheck111, label %ThrowNullRef112, label %76
 
 ; <label>:76                                      ; preds = %71
   %77 = load i8, i8* %75, align 8
   %78 = zext i8 %77 to i32
   %79 = trunc i32 %78 to i8
-  %NullCheck114 = icmp ne i8* %73, null
-  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+  %NullCheck113 = icmp eq i8* %73, null
+  br i1 %NullCheck113, label %ThrowNullRef114, label %80
 
 ; <label>:80                                      ; preds = %76
   store i8 %79, i8* %73, align 8
@@ -813,14 +895,14 @@ entry:
   %82 = load i8*, i8** %arg0
   %83 = load i8*, i8** %arg1
   %84 = bitcast i8* %83 to i32*
-  %NullCheck100 = icmp ne i32* %84, null
-  br i1 %NullCheck100, label %85, label %ThrowNullRef99
+  %NullCheck99 = icmp eq i32* %84, null
+  br i1 %NullCheck99, label %ThrowNullRef100, label %85
 
 ; <label>:85                                      ; preds = %81
   %86 = load i32, i32* %84, align 8
   %87 = bitcast i8* %82 to i32*
-  %NullCheck102 = icmp ne i32* %87, null
-  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+  %NullCheck101 = icmp eq i32* %87, null
+  br i1 %NullCheck101, label %ThrowNullRef102, label %88
 
 ; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
@@ -829,16 +911,16 @@ entry:
   %91 = load i8*, i8** %arg1
   %92 = getelementptr inbounds i8, i8* %91, i64 4
   %93 = bitcast i8* %92 to i16*
-  %NullCheck104 = icmp ne i16* %93, null
-  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+  %NullCheck103 = icmp eq i16* %93, null
+  br i1 %NullCheck103, label %ThrowNullRef104, label %94
 
 ; <label>:94                                      ; preds = %88
   %95 = load i16, i16* %93, align 8
   %96 = sext i16 %95 to i32
   %97 = bitcast i8* %90 to i16*
   %98 = trunc i32 %96 to i16
-  %NullCheck106 = icmp ne i16* %97, null
-  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+  %NullCheck105 = icmp eq i16* %97, null
+  br i1 %NullCheck105, label %ThrowNullRef106, label %99
 
 ; <label>:99                                      ; preds = %94
   store i16 %98, i16* %97, align 8
@@ -848,14 +930,14 @@ entry:
   %101 = load i8*, i8** %arg0
   %102 = load i8*, i8** %arg1
   %103 = bitcast i8* %102 to i32*
-  %NullCheck88 = icmp ne i32* %103, null
-  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+  %NullCheck87 = icmp eq i32* %103, null
+  br i1 %NullCheck87, label %ThrowNullRef88, label %104
 
 ; <label>:104                                     ; preds = %100
   %105 = load i32, i32* %103, align 8
   %106 = bitcast i8* %101 to i32*
-  %NullCheck90 = icmp ne i32* %106, null
-  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+  %NullCheck89 = icmp eq i32* %106, null
+  br i1 %NullCheck89, label %ThrowNullRef90, label %107
 
 ; <label>:107                                     ; preds = %104
   store i32 %105, i32* %106, align 8
@@ -864,16 +946,16 @@ entry:
   %110 = load i8*, i8** %arg1
   %111 = getelementptr inbounds i8, i8* %110, i64 4
   %112 = bitcast i8* %111 to i16*
-  %NullCheck92 = icmp ne i16* %112, null
-  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+  %NullCheck91 = icmp eq i16* %112, null
+  br i1 %NullCheck91, label %ThrowNullRef92, label %113
 
 ; <label>:113                                     ; preds = %107
   %114 = load i16, i16* %112, align 8
   %115 = sext i16 %114 to i32
   %116 = bitcast i8* %109 to i16*
   %117 = trunc i32 %115 to i16
-  %NullCheck94 = icmp ne i16* %116, null
-  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+  %NullCheck93 = icmp eq i16* %116, null
+  br i1 %NullCheck93, label %ThrowNullRef94, label %118
 
 ; <label>:118                                     ; preds = %113
   store i16 %117, i16* %116, align 8
@@ -881,15 +963,15 @@ entry:
   %120 = getelementptr inbounds i8, i8* %119, i64 6
   %121 = load i8*, i8** %arg1
   %122 = getelementptr inbounds i8, i8* %121, i64 6
-  %NullCheck96 = icmp ne i8* %122, null
-  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+  %NullCheck95 = icmp eq i8* %122, null
+  br i1 %NullCheck95, label %ThrowNullRef96, label %123
 
 ; <label>:123                                     ; preds = %118
   %124 = load i8, i8* %122, align 8
   %125 = zext i8 %124 to i32
   %126 = trunc i32 %125 to i8
-  %NullCheck98 = icmp ne i8* %120, null
-  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+  %NullCheck97 = icmp eq i8* %120, null
+  br i1 %NullCheck97, label %ThrowNullRef98, label %127
 
 ; <label>:127                                     ; preds = %123
   store i8 %126, i8* %120, align 8
@@ -899,14 +981,14 @@ entry:
   %129 = load i8*, i8** %arg0
   %130 = load i8*, i8** %arg1
   %131 = bitcast i8* %130 to i64*
-  %NullCheck84 = icmp ne i64* %131, null
-  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+  %NullCheck83 = icmp eq i64* %131, null
+  br i1 %NullCheck83, label %ThrowNullRef84, label %132
 
 ; <label>:132                                     ; preds = %128
   %133 = load i64, i64* %131, align 8
   %134 = bitcast i8* %129 to i64*
-  %NullCheck86 = icmp ne i64* %134, null
-  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+  %NullCheck85 = icmp eq i64* %134, null
+  br i1 %NullCheck85, label %ThrowNullRef86, label %135
 
 ; <label>:135                                     ; preds = %132
   store i64 %133, i64* %134, align 8
@@ -916,14 +998,14 @@ entry:
   %137 = load i8*, i8** %arg0
   %138 = load i8*, i8** %arg1
   %139 = bitcast i8* %138 to i64*
-  %NullCheck76 = icmp ne i64* %139, null
-  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+  %NullCheck75 = icmp eq i64* %139, null
+  br i1 %NullCheck75, label %ThrowNullRef76, label %140
 
 ; <label>:140                                     ; preds = %136
   %141 = load i64, i64* %139, align 8
   %142 = bitcast i8* %137 to i64*
-  %NullCheck78 = icmp ne i64* %142, null
-  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+  %NullCheck77 = icmp eq i64* %142, null
+  br i1 %NullCheck77, label %ThrowNullRef78, label %143
 
 ; <label>:143                                     ; preds = %140
   store i64 %141, i64* %142, align 8
@@ -931,15 +1013,15 @@ entry:
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %NullCheck80 = icmp ne i8* %147, null
-  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+  %NullCheck79 = icmp eq i8* %147, null
+  br i1 %NullCheck79, label %ThrowNullRef80, label %148
 
 ; <label>:148                                     ; preds = %143
   %149 = load i8, i8* %147, align 8
   %150 = zext i8 %149 to i32
   %151 = trunc i32 %150 to i8
-  %NullCheck82 = icmp ne i8* %145, null
-  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+  %NullCheck81 = icmp eq i8* %145, null
+  br i1 %NullCheck81, label %ThrowNullRef82, label %152
 
 ; <label>:152                                     ; preds = %148
   store i8 %151, i8* %145, align 8
@@ -949,14 +1031,14 @@ entry:
   %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
   %156 = bitcast i8* %155 to i64*
-  %NullCheck68 = icmp ne i64* %156, null
-  br i1 %NullCheck68, label %157, label %ThrowNullRef67
+  %NullCheck67 = icmp eq i64* %156, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %157
 
 ; <label>:157                                     ; preds = %153
   %158 = load i64, i64* %156, align 8
   %159 = bitcast i8* %154 to i64*
-  %NullCheck70 = icmp ne i64* %159, null
-  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+  %NullCheck69 = icmp eq i64* %159, null
+  br i1 %NullCheck69, label %ThrowNullRef70, label %160
 
 ; <label>:160                                     ; preds = %157
   store i64 %158, i64* %159, align 8
@@ -965,16 +1047,16 @@ entry:
   %163 = load i8*, i8** %arg1
   %164 = getelementptr inbounds i8, i8* %163, i64 8
   %165 = bitcast i8* %164 to i16*
-  %NullCheck72 = icmp ne i16* %165, null
-  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+  %NullCheck71 = icmp eq i16* %165, null
+  br i1 %NullCheck71, label %ThrowNullRef72, label %166
 
 ; <label>:166                                     ; preds = %160
   %167 = load i16, i16* %165, align 8
   %168 = sext i16 %167 to i32
   %169 = bitcast i8* %162 to i16*
   %170 = trunc i32 %168 to i16
-  %NullCheck74 = icmp ne i16* %169, null
-  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+  %NullCheck73 = icmp eq i16* %169, null
+  br i1 %NullCheck73, label %ThrowNullRef74, label %171
 
 ; <label>:171                                     ; preds = %166
   store i16 %170, i16* %169, align 8
@@ -984,14 +1066,14 @@ entry:
   %173 = load i8*, i8** %arg0
   %174 = load i8*, i8** %arg1
   %175 = bitcast i8* %174 to i64*
-  %NullCheck56 = icmp ne i64* %175, null
-  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+  %NullCheck55 = icmp eq i64* %175, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %176
 
 ; <label>:176                                     ; preds = %172
   %177 = load i64, i64* %175, align 8
   %178 = bitcast i8* %173 to i64*
-  %NullCheck58 = icmp ne i64* %178, null
-  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+  %NullCheck57 = icmp eq i64* %178, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %179
 
 ; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
@@ -1000,16 +1082,16 @@ entry:
   %182 = load i8*, i8** %arg1
   %183 = getelementptr inbounds i8, i8* %182, i64 8
   %184 = bitcast i8* %183 to i16*
-  %NullCheck60 = icmp ne i16* %184, null
-  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+  %NullCheck59 = icmp eq i16* %184, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %185
 
 ; <label>:185                                     ; preds = %179
   %186 = load i16, i16* %184, align 8
   %187 = sext i16 %186 to i32
   %188 = bitcast i8* %181 to i16*
   %189 = trunc i32 %187 to i16
-  %NullCheck62 = icmp ne i16* %188, null
-  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+  %NullCheck61 = icmp eq i16* %188, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %190
 
 ; <label>:190                                     ; preds = %185
   store i16 %189, i16* %188, align 8
@@ -1017,15 +1099,15 @@ entry:
   %192 = getelementptr inbounds i8, i8* %191, i64 10
   %193 = load i8*, i8** %arg1
   %194 = getelementptr inbounds i8, i8* %193, i64 10
-  %NullCheck64 = icmp ne i8* %194, null
-  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+  %NullCheck63 = icmp eq i8* %194, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %195
 
 ; <label>:195                                     ; preds = %190
   %196 = load i8, i8* %194, align 8
   %197 = zext i8 %196 to i32
   %198 = trunc i32 %197 to i8
-  %NullCheck66 = icmp ne i8* %192, null
-  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+  %NullCheck65 = icmp eq i8* %192, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %199
 
 ; <label>:199                                     ; preds = %195
   store i8 %198, i8* %192, align 8
@@ -1035,14 +1117,14 @@ entry:
   %201 = load i8*, i8** %arg0
   %202 = load i8*, i8** %arg1
   %203 = bitcast i8* %202 to i64*
-  %NullCheck48 = icmp ne i64* %203, null
-  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+  %NullCheck47 = icmp eq i64* %203, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %204
 
 ; <label>:204                                     ; preds = %200
   %205 = load i64, i64* %203, align 8
   %206 = bitcast i8* %201 to i64*
-  %NullCheck50 = icmp ne i64* %206, null
-  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+  %NullCheck49 = icmp eq i64* %206, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %207
 
 ; <label>:207                                     ; preds = %204
   store i64 %205, i64* %206, align 8
@@ -1051,14 +1133,14 @@ entry:
   %210 = load i8*, i8** %arg1
   %211 = getelementptr inbounds i8, i8* %210, i64 8
   %212 = bitcast i8* %211 to i32*
-  %NullCheck52 = icmp ne i32* %212, null
-  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+  %NullCheck51 = icmp eq i32* %212, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %213
 
 ; <label>:213                                     ; preds = %207
   %214 = load i32, i32* %212, align 8
   %215 = bitcast i8* %209 to i32*
-  %NullCheck54 = icmp ne i32* %215, null
-  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+  %NullCheck53 = icmp eq i32* %215, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %216
 
 ; <label>:216                                     ; preds = %213
   store i32 %214, i32* %215, align 8
@@ -1068,14 +1150,14 @@ entry:
   %218 = load i8*, i8** %arg0
   %219 = load i8*, i8** %arg1
   %220 = bitcast i8* %219 to i64*
-  %NullCheck36 = icmp ne i64* %220, null
-  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64* %220, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %221
 
 ; <label>:221                                     ; preds = %217
   %222 = load i64, i64* %220, align 8
   %223 = bitcast i8* %218 to i64*
-  %NullCheck38 = icmp ne i64* %223, null
-  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+  %NullCheck37 = icmp eq i64* %223, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %224
 
 ; <label>:224                                     ; preds = %221
   store i64 %222, i64* %223, align 8
@@ -1084,14 +1166,14 @@ entry:
   %227 = load i8*, i8** %arg1
   %228 = getelementptr inbounds i8, i8* %227, i64 8
   %229 = bitcast i8* %228 to i32*
-  %NullCheck40 = icmp ne i32* %229, null
-  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i32* %229, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %230
 
 ; <label>:230                                     ; preds = %224
   %231 = load i32, i32* %229, align 8
   %232 = bitcast i8* %226 to i32*
-  %NullCheck42 = icmp ne i32* %232, null
-  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+  %NullCheck41 = icmp eq i32* %232, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %233
 
 ; <label>:233                                     ; preds = %230
   store i32 %231, i32* %232, align 8
@@ -1099,15 +1181,15 @@ entry:
   %235 = getelementptr inbounds i8, i8* %234, i64 12
   %236 = load i8*, i8** %arg1
   %237 = getelementptr inbounds i8, i8* %236, i64 12
-  %NullCheck44 = icmp ne i8* %237, null
-  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i8* %237, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %238
 
 ; <label>:238                                     ; preds = %233
   %239 = load i8, i8* %237, align 8
   %240 = zext i8 %239 to i32
   %241 = trunc i32 %240 to i8
-  %NullCheck46 = icmp ne i8* %235, null
-  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+  %NullCheck45 = icmp eq i8* %235, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %242
 
 ; <label>:242                                     ; preds = %238
   store i8 %241, i8* %235, align 8
@@ -1117,14 +1199,14 @@ entry:
   %244 = load i8*, i8** %arg0
   %245 = load i8*, i8** %arg1
   %246 = bitcast i8* %245 to i64*
-  %NullCheck24 = icmp ne i64* %246, null
-  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64* %246, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %247
 
 ; <label>:247                                     ; preds = %243
   %248 = load i64, i64* %246, align 8
   %249 = bitcast i8* %244 to i64*
-  %NullCheck26 = icmp ne i64* %249, null
-  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64* %249, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %250
 
 ; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
@@ -1133,14 +1215,14 @@ entry:
   %253 = load i8*, i8** %arg1
   %254 = getelementptr inbounds i8, i8* %253, i64 8
   %255 = bitcast i8* %254 to i32*
-  %NullCheck28 = icmp ne i32* %255, null
-  br i1 %NullCheck28, label %256, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i32* %255, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %256
 
 ; <label>:256                                     ; preds = %250
   %257 = load i32, i32* %255, align 8
   %258 = bitcast i8* %252 to i32*
-  %NullCheck30 = icmp ne i32* %258, null
-  br i1 %NullCheck30, label %259, label %ThrowNullRef29
+  %NullCheck29 = icmp eq i32* %258, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %259
 
 ; <label>:259                                     ; preds = %256
   store i32 %257, i32* %258, align 8
@@ -1149,16 +1231,16 @@ entry:
   %262 = load i8*, i8** %arg1
   %263 = getelementptr inbounds i8, i8* %262, i64 12
   %264 = bitcast i8* %263 to i16*
-  %NullCheck32 = icmp ne i16* %264, null
-  br i1 %NullCheck32, label %265, label %ThrowNullRef31
+  %NullCheck31 = icmp eq i16* %264, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %265
 
 ; <label>:265                                     ; preds = %259
   %266 = load i16, i16* %264, align 8
   %267 = sext i16 %266 to i32
   %268 = bitcast i8* %261 to i16*
   %269 = trunc i32 %267 to i16
-  %NullCheck34 = icmp ne i16* %268, null
-  br i1 %NullCheck34, label %270, label %ThrowNullRef33
+  %NullCheck33 = icmp eq i16* %268, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %270
 
 ; <label>:270                                     ; preds = %265
   store i16 %269, i16* %268, align 8
@@ -1168,14 +1250,14 @@ entry:
   %272 = load i8*, i8** %arg0
   %273 = load i8*, i8** %arg1
   %274 = bitcast i8* %273 to i64*
-  %NullCheck8 = icmp ne i64* %274, null
-  br i1 %NullCheck8, label %275, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64* %274, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %275
 
 ; <label>:275                                     ; preds = %271
   %276 = load i64, i64* %274, align 8
   %277 = bitcast i8* %272 to i64*
-  %NullCheck10 = icmp ne i64* %277, null
-  br i1 %NullCheck10, label %278, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %277, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %278
 
 ; <label>:278                                     ; preds = %275
   store i64 %276, i64* %277, align 8
@@ -1184,14 +1266,14 @@ entry:
   %281 = load i8*, i8** %arg1
   %282 = getelementptr inbounds i8, i8* %281, i64 8
   %283 = bitcast i8* %282 to i32*
-  %NullCheck12 = icmp ne i32* %283, null
-  br i1 %NullCheck12, label %284, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i32* %283, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %284
 
 ; <label>:284                                     ; preds = %278
   %285 = load i32, i32* %283, align 8
   %286 = bitcast i8* %280 to i32*
-  %NullCheck14 = icmp ne i32* %286, null
-  br i1 %NullCheck14, label %287, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i32* %286, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %287
 
 ; <label>:287                                     ; preds = %284
   store i32 %285, i32* %286, align 8
@@ -1200,16 +1282,16 @@ entry:
   %290 = load i8*, i8** %arg1
   %291 = getelementptr inbounds i8, i8* %290, i64 12
   %292 = bitcast i8* %291 to i16*
-  %NullCheck16 = icmp ne i16* %292, null
-  br i1 %NullCheck16, label %293, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i16* %292, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %293
 
 ; <label>:293                                     ; preds = %287
   %294 = load i16, i16* %292, align 8
   %295 = sext i16 %294 to i32
   %296 = bitcast i8* %289 to i16*
   %297 = trunc i32 %295 to i16
-  %NullCheck18 = icmp ne i16* %296, null
-  br i1 %NullCheck18, label %298, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i16* %296, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %298
 
 ; <label>:298                                     ; preds = %293
   store i16 %297, i16* %296, align 8
@@ -1217,15 +1299,15 @@ entry:
   %300 = getelementptr inbounds i8, i8* %299, i64 14
   %301 = load i8*, i8** %arg1
   %302 = getelementptr inbounds i8, i8* %301, i64 14
-  %NullCheck20 = icmp ne i8* %302, null
-  br i1 %NullCheck20, label %303, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i8* %302, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %303
 
 ; <label>:303                                     ; preds = %298
   %304 = load i8, i8* %302, align 8
   %305 = zext i8 %304 to i32
   %306 = trunc i32 %305 to i8
-  %NullCheck22 = icmp ne i8* %300, null
-  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i8* %300, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %307
 
 ; <label>:307                                     ; preds = %303
   store i8 %306, i8* %300, align 8
@@ -1235,14 +1317,14 @@ entry:
   %309 = load i8*, i8** %arg0
   %310 = load i8*, i8** %arg1
   %311 = bitcast i8* %310 to i64*
-  %NullCheck = icmp ne i64* %311, null
-  br i1 %NullCheck, label %312, label %ThrowNullRef
+  %NullCheck = icmp eq i64* %311, null
+  br i1 %NullCheck, label %ThrowNullRef, label %312
 
 ; <label>:312                                     ; preds = %308
   %313 = load i64, i64* %311, align 8
   %314 = bitcast i8* %309 to i64*
-  %NullCheck2 = icmp ne i64* %314, null
-  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64* %314, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %315
 
 ; <label>:315                                     ; preds = %312
   store i64 %313, i64* %314, align 8
@@ -1251,14 +1333,14 @@ entry:
   %318 = load i8*, i8** %arg1
   %319 = getelementptr inbounds i8, i8* %318, i64 8
   %320 = bitcast i8* %319 to i64*
-  %NullCheck4 = icmp ne i64* %320, null
-  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64* %320, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %321
 
 ; <label>:321                                     ; preds = %315
   %322 = load i64, i64* %320, align 8
   %323 = bitcast i8* %317 to i64*
-  %NullCheck6 = icmp ne i64* %323, null
-  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64* %323, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %324
 
 ; <label>:324                                     ; preds = %321
   store i64 %322, i64* %323, align 8
@@ -1286,15 +1368,15 @@ entry:
 ; <label>:338                                     ; preds = %333
   %339 = load i8*, i8** %arg0
   %340 = load i8*, i8** %arg1
-  %NullCheck136 = icmp ne i8* %340, null
-  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+  %NullCheck135 = icmp eq i8* %340, null
+  br i1 %NullCheck135, label %ThrowNullRef136, label %341
 
 ; <label>:341                                     ; preds = %338
   %342 = load i8, i8* %340, align 8
   %343 = zext i8 %342 to i32
   %344 = trunc i32 %343 to i8
-  %NullCheck138 = icmp ne i8* %339, null
-  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+  %NullCheck137 = icmp eq i8* %339, null
+  br i1 %NullCheck137, label %ThrowNullRef138, label %345
 
 ; <label>:345                                     ; preds = %341
   store i8 %344, i8* %339, align 8
@@ -1317,16 +1399,16 @@ entry:
   %357 = load i8*, i8** %arg0
   %358 = load i8*, i8** %arg1
   %359 = bitcast i8* %358 to i16*
-  %NullCheck140 = icmp ne i16* %359, null
-  br i1 %NullCheck140, label %360, label %ThrowNullRef139
+  %NullCheck139 = icmp eq i16* %359, null
+  br i1 %NullCheck139, label %ThrowNullRef140, label %360
 
 ; <label>:360                                     ; preds = %356
   %361 = load i16, i16* %359, align 8
   %362 = sext i16 %361 to i32
   %363 = bitcast i8* %357 to i16*
   %364 = trunc i32 %362 to i16
-  %NullCheck142 = icmp ne i16* %363, null
-  br i1 %NullCheck142, label %365, label %ThrowNullRef141
+  %NullCheck141 = icmp eq i16* %363, null
+  br i1 %NullCheck141, label %ThrowNullRef142, label %365
 
 ; <label>:365                                     ; preds = %360
   store i16 %364, i16* %363, align 8
@@ -1352,14 +1434,14 @@ entry:
   %378 = load i8*, i8** %arg0
   %379 = load i8*, i8** %arg1
   %380 = bitcast i8* %379 to i32*
-  %NullCheck144 = icmp ne i32* %380, null
-  br i1 %NullCheck144, label %381, label %ThrowNullRef143
+  %NullCheck143 = icmp eq i32* %380, null
+  br i1 %NullCheck143, label %ThrowNullRef144, label %381
 
 ; <label>:381                                     ; preds = %377
   %382 = load i32, i32* %380, align 8
   %383 = bitcast i8* %378 to i32*
-  %NullCheck146 = icmp ne i32* %383, null
-  br i1 %NullCheck146, label %384, label %ThrowNullRef145
+  %NullCheck145 = icmp eq i32* %383, null
+  br i1 %NullCheck145, label %ThrowNullRef146, label %384
 
 ; <label>:384                                     ; preds = %381
   store i32 %382, i32* %383, align 8
@@ -1384,14 +1466,14 @@ entry:
   %395 = load i8*, i8** %arg0
   %396 = load i8*, i8** %arg1
   %397 = bitcast i8* %396 to i64*
-  %NullCheck164 = icmp ne i64* %397, null
-  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+  %NullCheck163 = icmp eq i64* %397, null
+  br i1 %NullCheck163, label %ThrowNullRef164, label %398
 
 ; <label>:398                                     ; preds = %394
   %399 = load i64, i64* %397, align 8
   %400 = bitcast i8* %395 to i64*
-  %NullCheck166 = icmp ne i64* %400, null
-  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+  %NullCheck165 = icmp eq i64* %400, null
+  br i1 %NullCheck165, label %ThrowNullRef166, label %401
 
 ; <label>:401                                     ; preds = %398
   store i64 %399, i64* %400, align 8
@@ -1400,14 +1482,14 @@ entry:
   %404 = load i8*, i8** %arg1
   %405 = getelementptr inbounds i8, i8* %404, i64 8
   %406 = bitcast i8* %405 to i64*
-  %NullCheck168 = icmp ne i64* %406, null
-  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+  %NullCheck167 = icmp eq i64* %406, null
+  br i1 %NullCheck167, label %ThrowNullRef168, label %407
 
 ; <label>:407                                     ; preds = %401
   %408 = load i64, i64* %406, align 8
   %409 = bitcast i8* %403 to i64*
-  %NullCheck170 = icmp ne i64* %409, null
-  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+  %NullCheck169 = icmp eq i64* %409, null
+  br i1 %NullCheck169, label %ThrowNullRef170, label %410
 
 ; <label>:410                                     ; preds = %407
   store i64 %408, i64* %409, align 8
@@ -1437,14 +1519,14 @@ entry:
   %425 = load i8*, i8** %arg0
   %426 = load i8*, i8** %arg1
   %427 = bitcast i8* %426 to i64*
-  %NullCheck148 = icmp ne i64* %427, null
-  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+  %NullCheck147 = icmp eq i64* %427, null
+  br i1 %NullCheck147, label %ThrowNullRef148, label %428
 
 ; <label>:428                                     ; preds = %424
   %429 = load i64, i64* %427, align 8
   %430 = bitcast i8* %425 to i64*
-  %NullCheck150 = icmp ne i64* %430, null
-  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+  %NullCheck149 = icmp eq i64* %430, null
+  br i1 %NullCheck149, label %ThrowNullRef150, label %431
 
 ; <label>:431                                     ; preds = %428
   store i64 %429, i64* %430, align 8
@@ -1466,14 +1548,14 @@ entry:
   %441 = load i8*, i8** %arg0
   %442 = load i8*, i8** %arg1
   %443 = bitcast i8* %442 to i32*
-  %NullCheck152 = icmp ne i32* %443, null
-  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+  %NullCheck151 = icmp eq i32* %443, null
+  br i1 %NullCheck151, label %ThrowNullRef152, label %444
 
 ; <label>:444                                     ; preds = %440
   %445 = load i32, i32* %443, align 8
   %446 = bitcast i8* %441 to i32*
-  %NullCheck154 = icmp ne i32* %446, null
-  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+  %NullCheck153 = icmp eq i32* %446, null
+  br i1 %NullCheck153, label %ThrowNullRef154, label %447
 
 ; <label>:447                                     ; preds = %444
   store i32 %445, i32* %446, align 8
@@ -1495,16 +1577,16 @@ entry:
   %457 = load i8*, i8** %arg0
   %458 = load i8*, i8** %arg1
   %459 = bitcast i8* %458 to i16*
-  %NullCheck156 = icmp ne i16* %459, null
-  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+  %NullCheck155 = icmp eq i16* %459, null
+  br i1 %NullCheck155, label %ThrowNullRef156, label %460
 
 ; <label>:460                                     ; preds = %456
   %461 = load i16, i16* %459, align 8
   %462 = sext i16 %461 to i32
   %463 = bitcast i8* %457 to i16*
   %464 = trunc i32 %462 to i16
-  %NullCheck158 = icmp ne i16* %463, null
-  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+  %NullCheck157 = icmp eq i16* %463, null
+  br i1 %NullCheck157, label %ThrowNullRef158, label %465
 
 ; <label>:465                                     ; preds = %460
   store i16 %464, i16* %463, align 8
@@ -1525,15 +1607,15 @@ entry:
 ; <label>:474                                     ; preds = %470
   %475 = load i8*, i8** %arg0
   %476 = load i8*, i8** %arg1
-  %NullCheck160 = icmp ne i8* %476, null
-  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+  %NullCheck159 = icmp eq i8* %476, null
+  br i1 %NullCheck159, label %ThrowNullRef160, label %477
 
 ; <label>:477                                     ; preds = %474
   %478 = load i8, i8* %476, align 8
   %479 = zext i8 %478 to i32
   %480 = trunc i32 %479 to i8
-  %NullCheck162 = icmp ne i8* %475, null
-  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+  %NullCheck161 = icmp eq i8* %475, null
+  br i1 %NullCheck161, label %ThrowNullRef162, label %481
 
 ; <label>:481                                     ; preds = %477
   store i8 %480, i8* %475, align 8
@@ -1553,343 +1635,343 @@ ThrowNullRef:                                     ; preds = %308
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %312
+ThrowNullRef2:                                    ; preds = %312
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %315
+ThrowNullRef4:                                    ; preds = %315
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %321
+ThrowNullRef6:                                    ; preds = %321
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %271
+ThrowNullRef8:                                    ; preds = %271
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %275
+ThrowNullRef10:                                   ; preds = %275
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %278
+ThrowNullRef12:                                   ; preds = %278
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %284
+ThrowNullRef14:                                   ; preds = %284
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %287
+ThrowNullRef16:                                   ; preds = %287
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %293
+ThrowNullRef18:                                   ; preds = %293
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %298
+ThrowNullRef20:                                   ; preds = %298
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %303
+ThrowNullRef22:                                   ; preds = %303
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %243
+ThrowNullRef24:                                   ; preds = %243
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %247
+ThrowNullRef26:                                   ; preds = %247
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %250
+ThrowNullRef28:                                   ; preds = %250
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %256
+ThrowNullRef30:                                   ; preds = %256
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %259
+ThrowNullRef32:                                   ; preds = %259
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %265
+ThrowNullRef34:                                   ; preds = %265
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %217
+ThrowNullRef36:                                   ; preds = %217
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %221
+ThrowNullRef38:                                   ; preds = %221
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %224
+ThrowNullRef40:                                   ; preds = %224
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %230
+ThrowNullRef42:                                   ; preds = %230
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %233
+ThrowNullRef44:                                   ; preds = %233
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %238
+ThrowNullRef46:                                   ; preds = %238
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %200
+ThrowNullRef48:                                   ; preds = %200
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %204
+ThrowNullRef50:                                   ; preds = %204
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %207
+ThrowNullRef52:                                   ; preds = %207
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %213
+ThrowNullRef54:                                   ; preds = %213
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %172
+ThrowNullRef56:                                   ; preds = %172
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %176
+ThrowNullRef58:                                   ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %179
+ThrowNullRef60:                                   ; preds = %179
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %185
+ThrowNullRef62:                                   ; preds = %185
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %190
+ThrowNullRef64:                                   ; preds = %190
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %195
+ThrowNullRef66:                                   ; preds = %195
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %153
+ThrowNullRef68:                                   ; preds = %153
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef69:                                   ; preds = %157
+ThrowNullRef70:                                   ; preds = %157
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef71:                                   ; preds = %160
+ThrowNullRef72:                                   ; preds = %160
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef73:                                   ; preds = %166
+ThrowNullRef74:                                   ; preds = %166
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef75:                                   ; preds = %136
+ThrowNullRef76:                                   ; preds = %136
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef77:                                   ; preds = %140
+ThrowNullRef78:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef79:                                   ; preds = %143
+ThrowNullRef80:                                   ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef81:                                   ; preds = %148
+ThrowNullRef82:                                   ; preds = %148
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef83:                                   ; preds = %128
+ThrowNullRef84:                                   ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef85:                                   ; preds = %132
+ThrowNullRef86:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef87:                                   ; preds = %100
+ThrowNullRef88:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef89:                                   ; preds = %104
+ThrowNullRef90:                                   ; preds = %104
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef91:                                   ; preds = %107
+ThrowNullRef92:                                   ; preds = %107
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef93:                                   ; preds = %113
+ThrowNullRef94:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef95:                                   ; preds = %118
+ThrowNullRef96:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef97:                                   ; preds = %123
+ThrowNullRef98:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef99:                                   ; preds = %81
+ThrowNullRef100:                                  ; preds = %81
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef101:                                  ; preds = %85
+ThrowNullRef102:                                  ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef103:                                  ; preds = %88
+ThrowNullRef104:                                  ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef105:                                  ; preds = %94
+ThrowNullRef106:                                  ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef107:                                  ; preds = %64
+ThrowNullRef108:                                  ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef109:                                  ; preds = %68
+ThrowNullRef110:                                  ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef111:                                  ; preds = %71
+ThrowNullRef112:                                  ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef113:                                  ; preds = %76
+ThrowNullRef114:                                  ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef115:                                  ; preds = %56
+ThrowNullRef116:                                  ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef117:                                  ; preds = %60
+ThrowNullRef118:                                  ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef119:                                  ; preds = %37
+ThrowNullRef120:                                  ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef121:                                  ; preds = %41
+ThrowNullRef122:                                  ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef123:                                  ; preds = %46
+ThrowNullRef124:                                  ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef125:                                  ; preds = %51
+ThrowNullRef126:                                  ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef127:                                  ; preds = %27
+ThrowNullRef128:                                  ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef129:                                  ; preds = %31
+ThrowNullRef130:                                  ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef131:                                  ; preds = %19
+ThrowNullRef132:                                  ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef133:                                  ; preds = %22
+ThrowNullRef134:                                  ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef135:                                  ; preds = %338
+ThrowNullRef136:                                  ; preds = %338
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef137:                                  ; preds = %341
+ThrowNullRef138:                                  ; preds = %341
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef139:                                  ; preds = %356
+ThrowNullRef140:                                  ; preds = %356
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef141:                                  ; preds = %360
+ThrowNullRef142:                                  ; preds = %360
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef143:                                  ; preds = %377
+ThrowNullRef144:                                  ; preds = %377
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef145:                                  ; preds = %381
+ThrowNullRef146:                                  ; preds = %381
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef147:                                  ; preds = %424
+ThrowNullRef148:                                  ; preds = %424
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef149:                                  ; preds = %428
+ThrowNullRef150:                                  ; preds = %428
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef151:                                  ; preds = %440
+ThrowNullRef152:                                  ; preds = %440
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef153:                                  ; preds = %444
+ThrowNullRef154:                                  ; preds = %444
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef155:                                  ; preds = %456
+ThrowNullRef156:                                  ; preds = %456
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef157:                                  ; preds = %460
+ThrowNullRef158:                                  ; preds = %460
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef159:                                  ; preds = %474
+ThrowNullRef160:                                  ; preds = %474
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef161:                                  ; preds = %477
+ThrowNullRef162:                                  ; preds = %477
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef163:                                  ; preds = %394
+ThrowNullRef164:                                  ; preds = %394
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef165:                                  ; preds = %398
+ThrowNullRef166:                                  ; preds = %398
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef167:                                  ; preds = %401
+ThrowNullRef168:                                  ; preds = %401
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef169:                                  ; preds = %407
+ThrowNullRef170:                                  ; preds = %407
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1939,8 +2021,8 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
-  br i1 %NullCheck, label %22, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %ThrowNullRef, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
@@ -1948,8 +2030,8 @@ entry:
   store i32 %24, i32* %loc0
   %25 = load i32, i32* %loc0
   %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %26, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %27
 
 ; <label>:27                                      ; preds = %22
   %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
@@ -1971,7 +2053,7 @@ ThrowNullRef:                                     ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1989,8 +2071,8 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -2022,15 +2104,15 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2048,16 +2130,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
   %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
   store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck6, label %19, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %19
 
 ; <label>:19                                      ; preds = %15
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
@@ -2072,8 +2154,8 @@ entry:
   %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
   %29 = ptrtoint i16 addrspace(1)* %28 to i64
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %19
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
@@ -2089,19 +2171,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %19
+ThrowNullRef8:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2114,8 +2196,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
@@ -2128,7 +2210,7 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
-Failed to read AppDomain.PrepareDataForSetup[loadElem]
+Failed to read AppDomain.PrepareDataForSetup[storeElem]
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
@@ -2202,8 +2284,8 @@ entry:
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
-  br i1 %NullCheck24, label %27, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = load i64, i64 addrspace(1)* %26
@@ -2218,8 +2300,8 @@ entry:
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
-  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
   %41 = load i64, i64 addrspace(1)* %39
@@ -2236,8 +2318,8 @@ entry:
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
-  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
   %54 = load i64, i64 addrspace(1)* %52
@@ -2252,8 +2334,8 @@ entry:
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
   %67 = load i64, i64 addrspace(1)* %65
@@ -2270,8 +2352,8 @@ entry:
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
-  br i1 %NullCheck16, label %79, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
   %80 = load i64, i64 addrspace(1)* %78
@@ -2286,8 +2368,8 @@ entry:
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
-  br i1 %NullCheck18, label %92, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
   %93 = load i64, i64 addrspace(1)* %91
@@ -2304,8 +2386,8 @@ entry:
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
-  br i1 %NullCheck12, label %105, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = load i64, i64 addrspace(1)* %104
@@ -2320,8 +2402,8 @@ entry:
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
-  br i1 %NullCheck14, label %118, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
   %119 = load i64, i64 addrspace(1)* %117
@@ -2337,8 +2419,8 @@ entry:
 
 ; <label>:128                                     ; preds = %20
   %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
-  br i1 %NullCheck4, label %130, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %129, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %130
 
 ; <label>:130                                     ; preds = %128
   %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
@@ -2346,8 +2428,8 @@ entry:
   %133 = load i16, i16 addrspace(1)* %132, align 8
   %134 = zext i16 %133 to i32
   %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
-  br i1 %NullCheck6, label %136, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %135, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %136
 
 ; <label>:136                                     ; preds = %130
   %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
@@ -2360,8 +2442,8 @@ entry:
 
 ; <label>:143                                     ; preds = %136
   %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
-  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %144, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %145
 
 ; <label>:145                                     ; preds = %143
   %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
@@ -2369,8 +2451,8 @@ entry:
   %148 = load i16, i16 addrspace(1)* %147, align 8
   %149 = zext i16 %148 to i32
   %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %150, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %151
 
 ; <label>:151                                     ; preds = %145
   %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
@@ -2388,8 +2470,8 @@ entry:
 
 ; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
-  br i1 %NullCheck, label %163, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %ThrowNullRef, label %163
 
 ; <label>:163                                     ; preds = %161
   %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
@@ -2399,8 +2481,8 @@ entry:
 
 ; <label>:167                                     ; preds = %163
   %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
-  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %168, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %169
 
 ; <label>:169                                     ; preds = %167
   %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
@@ -2432,55 +2514,55 @@ ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %167
+ThrowNullRef2:                                    ; preds = %167
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %128
+ThrowNullRef4:                                    ; preds = %128
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %130
+ThrowNullRef6:                                    ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %143
+ThrowNullRef8:                                    ; preds = %143
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %145
+ThrowNullRef10:                                   ; preds = %145
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %102
+ThrowNullRef12:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %105
+ThrowNullRef14:                                   ; preds = %105
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %76
+ThrowNullRef16:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %79
+ThrowNullRef18:                                   ; preds = %79
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %50
+ThrowNullRef20:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %53
+ThrowNullRef22:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %24
+ThrowNullRef24:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %27
+ThrowNullRef26:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2503,15 +2585,15 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
@@ -2519,16 +2601,16 @@ entry:
   %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
   store i32 %8, i32* %loc0
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %5
   %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
   %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
   store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
@@ -2546,16 +2628,16 @@ entry:
 
 ; <label>:23                                      ; preds = %64
   %24 = load i16*, i16** %loc3
-  %NullCheck12 = icmp ne i16* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i16* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
   store i32 %27, i32* %loc5
   %28 = load i16*, i16** %loc4
-  %NullCheck14 = icmp ne i16* %28, null
-  br i1 %NullCheck14, label %29, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %28, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %29
 
 ; <label>:29                                      ; preds = %25
   %30 = load i16, i16* %28, align 8
@@ -2620,15 +2702,15 @@ entry:
 
 ; <label>:67                                      ; preds = %64
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
-  br i1 %NullCheck8, label %69, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %68, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %69
 
 ; <label>:69                                      ; preds = %67
   %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
   %71 = load i32, i32 addrspace(1)* %70
   %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
-  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %73
 
 ; <label>:73                                      ; preds = %69
   %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
@@ -2645,31 +2727,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %67
+ThrowNullRef8:                                    ; preds = %67
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %69
+ThrowNullRef10:                                   ; preds = %69
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2710,14 +2792,14 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
   %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
@@ -2730,14 +2812,14 @@ entry:
 
 ; <label>:11                                      ; preds = %4
   %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
   %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
@@ -2749,14 +2831,14 @@ entry:
 
 ; <label>:22                                      ; preds = %16
   %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
   %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
-  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
-  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %27
 
 ; <label>:27                                      ; preds = %24
   %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
@@ -2804,23 +2886,23 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %24
+ThrowNullRef10:                                   ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2836,7 +2918,280 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[loadElem]
+Successfully read RuntimeType.IsAssignableFrom
+
+define i8 @RuntimeType.IsAssignableFrom(%System.RuntimeType addrspace(1)* %param0, %System.Type addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.RuntimeType addrspace(1)*
+  %arg1 = alloca %System.Type addrspace(1)*
+  %loc0 = alloca %System.RuntimeType addrspace(1)*
+  %loc1 = alloca %"System.Type[]" addrspace(1)*
+  %loc2 = alloca i32
+  store %System.RuntimeType addrspace(1)* %param0, %System.RuntimeType addrspace(1)** %this
+  store %System.Type addrspace(1)* %param1, %System.Type addrspace(1)** %arg1
+  %0 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %1 = icmp ne %System.Type addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i8 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %5 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %6 = bitcast %System.Type addrspace(1)* %4 to %System.Object addrspace(1)*
+  %7 = bitcast %System.RuntimeType addrspace(1)* %5 to %System.Object addrspace(1)*
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %6, %System.Object addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %3
+  ret i8 1
+
+; <label>:12                                      ; preds = %3
+  %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 152
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 32
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
+  %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
+  %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
+  store %System.RuntimeType addrspace(1)* %25, %System.RuntimeType addrspace(1)** %loc0
+  %26 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %27 = icmp eq %System.RuntimeType addrspace(1)* %26, null
+  br i1 %27, label %34, label %28
+
+; <label>:28                                      ; preds = %15
+  %29 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %loc0
+  %30 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)*)*)(%System.RuntimeType addrspace(1)* %29, %System.RuntimeType addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+; <label>:34                                      ; preds = %15
+  %35 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %36 = call %System.Reflection.Emit.TypeBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Reflection.Emit.TypeBuilder addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %35)
+  %37 = icmp eq %System.Reflection.Emit.TypeBuilder addrspace(1)* %36, null
+  br i1 %37, label %139, label %38
+
+; <label>:38                                      ; preds = %34
+  %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %42
+
+; <label>:42                                      ; preds = %38
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 152
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 40
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
+  %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
+  %53 = zext i8 %52 to i32
+  %54 = icmp eq i32 %53, 0
+  br i1 %54, label %56, label %55
+
+; <label>:55                                      ; preds = %42
+  ret i8 1
+
+; <label>:56                                      ; preds = %42
+  %57 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %58 = bitcast %System.RuntimeType addrspace(1)* %57 to %System.Type addrspace(1)*
+  %59 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %58)
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %64 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.Type addrspace(1)* %63, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = bitcast %System.RuntimeType addrspace(1)* %64 to %System.Type addrspace(1)*
+  %67 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*)(%System.Type addrspace(1)* %63, %System.Type addrspace(1)* %66)
+  %68 = zext i8 %67 to i32
+  %69 = trunc i32 %68 to i8
+  ret i8 %69
+
+; <label>:70                                      ; preds = %56
+  %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
+  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %73
+
+; <label>:73                                      ; preds = %70
+  %74 = load i64, i64 addrspace(1)* %72
+  %75 = add i64 %74, 128
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = add i64 %77, 0
+  %79 = inttoptr i64 %78 to i64*
+  %80 = load i64, i64* %79
+  %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
+  %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
+  %83 = call i8 %82(%System.Type addrspace(1)* %81)
+  %84 = zext i8 %83 to i32
+  %85 = icmp eq i32 %84, 0
+  br i1 %85, label %139, label %86
+
+; <label>:86                                      ; preds = %73
+  %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
+  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %89
+
+; <label>:89                                      ; preds = %86
+  %90 = load i64, i64 addrspace(1)* %88
+  %91 = add i64 %90, 128
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = add i64 %93, 24
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
+  %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
+  %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
+  store %"System.Type[]" addrspace(1)* %99, %"System.Type[]" addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %129
+
+; <label>:100                                     ; preds = %132
+  %101 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %102 = load i32, i32* %loc2
+  %NullCheck11 = icmp eq %"System.Type[]" addrspace(1)* %101, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %103
+
+; <label>:103                                     ; preds = %100
+  %104 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 1
+  %105 = load i32, i32 addrspace(1)* %104
+  %106 = zext i32 %105 to i64
+  %107 = zext i32 %102 to i64
+  %BoundsCheck = icmp uge i64 %107, %106
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %108
+
+; <label>:108                                     ; preds = %103
+  %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
+  %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
+  %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
+  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
+  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %113
+
+; <label>:113                                     ; preds = %108
+  %114 = load i64, i64 addrspace(1)* %112
+  %115 = add i64 %114, 152
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = add i64 %117, 56
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
+  %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
+  %123 = zext i8 %122 to i32
+  %124 = icmp ne i32 %123, 0
+  br i1 %124, label %126, label %125
+
+; <label>:125                                     ; preds = %113
+  ret i8 0
+
+; <label>:126                                     ; preds = %113
+  %127 = load i32, i32* %loc2
+  %128 = add i32 %127, 1
+  store i32 %128, i32* %loc2
+  br label %129
+
+; <label>:129                                     ; preds = %89, %126
+  %130 = load i32, i32* %loc2
+  %131 = load %"System.Type[]" addrspace(1)*, %"System.Type[]" addrspace(1)** %loc1
+  %NullCheck9 = icmp eq %"System.Type[]" addrspace(1)* %131, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %132
+
+; <label>:132                                     ; preds = %129
+  %133 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %131, i32 0, i32 1
+  %134 = load i32, i32 addrspace(1)* %133
+  %135 = zext i32 %134 to i64
+  %136 = trunc i64 %135 to i32
+  %137 = icmp slt i32 %130, %136
+  br i1 %137, label %100, label %138
+
+; <label>:138                                     ; preds = %132
+  ret i8 1
+
+; <label>:139                                     ; preds = %34, %73
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %129
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %103
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -2893,7 +3248,7 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
 Failed to read List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElem]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -2904,8 +3259,8 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -2997,8 +3352,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
@@ -3059,8 +3414,8 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -3087,8 +3442,8 @@ entry:
 
 ; <label>:17                                      ; preds = %5, %11
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
@@ -3097,8 +3452,8 @@ entry:
 
 ; <label>:22                                      ; preds = %1, %11
   %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
@@ -3109,11 +3464,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %17
+ThrowNullRef2:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %22
+ThrowNullRef4:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3167,15 +3522,15 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
   %15 = load i32, i32 addrspace(1)* %14
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
@@ -3198,7 +3553,7 @@ ThrowNullRef:                                     ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef2:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3232,8 +3587,8 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %ThrowNullRef, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
@@ -3312,8 +3667,8 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -3327,8 +3682,8 @@ entry:
 ; <label>:5                                       ; preds = %43
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %7 = load i32, i32* %loc1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck6, label %8, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
@@ -3366,8 +3721,8 @@ entry:
 ; <label>:32                                      ; preds = %21, %25
   %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
   %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
-  br i1 %NullCheck8, label %35, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = trunc i32 %34 to i16
@@ -3380,8 +3735,8 @@ entry:
 ; <label>:40                                      ; preds = %1, %35
   %41 = load i32, i32* %loc1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
-  br i1 %NullCheck2, label %43, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %42, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
@@ -3392,8 +3747,8 @@ entry:
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
   %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
-  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
   %51 = load i64, i64 addrspace(1)* %49
@@ -3412,19 +3767,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %40
+ThrowNullRef2:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %47
+ThrowNullRef4:                                    ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %5
+ThrowNullRef6:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %32
+ThrowNullRef8:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3467,8 +3822,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
@@ -3492,11 +3847,391 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(i16* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store i16* %param0, i16** %arg0
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load i32, i32* %arg3
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %42, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %37, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg2
+  %13 = load i32, i32* %arg3
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %37, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %24 = load i32, i32* %arg2
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load i16*, i16** %arg0
+  %35 = load i32, i32* %arg3
+  %36 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %36, i16* %34, i32 %35)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:37                                      ; preds = %5, %16
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %39)
+  %41 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41, %System.String addrspace(1)* %38, %System.String addrspace(1)* %40)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %41) #0
+  unreachable
+
+; <label>:42                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::ToString using LLILCJit
-Failed to read StringBuilder.ToString[loadElemA]
+Successfully read StringBuilder.ToString
+
+define %System.String addrspace(1)* @StringBuilder.ToString(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i16*
+  %loc3 = alloca %"System.Char[]" addrspace(1)*
+  %loc4 = alloca i32
+  %loc5 = alloca i32
+  %loc6 = alloca i16 addrspace(1)*
+  %loc7 = alloca %System.String addrspace(1)*
+  %loc8 = alloca %"System.Char[]" addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %0)
+  %2 = icmp ne i32 %1, 0
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %4
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %6)
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %7)
+  store %System.String addrspace(1)* %8, %System.String addrspace(1)** %loc0
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.Text.StringBuilder addrspace(1)* %9, %System.Text.StringBuilder addrspace(1)** %loc1
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  store %System.String addrspace(1)* %10, %System.String addrspace(1)** %loc7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc7
+  %12 = ptrtoint %System.String addrspace(1)* %11 to i64
+  %13 = icmp eq i64 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %5
+  %15 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %16 = sext i32 %15 to i64
+  %17 = add i64 %12, %16
+  br label %18
+
+; <label>:18                                      ; preds = %5, %14
+  %19 = phi i64 [ %12, %5 ], [ %17, %14 ]
+  %20 = inttoptr i64 %19 to i16*
+  store i16* %20, i16** %loc2
+  br label %21
+
+; <label>:21                                      ; preds = %98, %18
+  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %22, null
+  br i1 %NullCheck, label %ThrowNullRef, label %23
+
+; <label>:23                                      ; preds = %21
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 3
+  %25 = load i32, i32 addrspace(1)* %24, align 8
+  %26 = icmp sle i32 %25, 0
+  br i1 %26, label %96, label %27
+
+; <label>:27                                      ; preds = %23
+  %28 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %28, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %29
+
+; <label>:29                                      ; preds = %27
+  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %28, i32 0, i32 1
+  %31 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %30, align 8
+  store %"System.Char[]" addrspace(1)* %31, %"System.Char[]" addrspace(1)** %loc3
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %33
+
+; <label>:33                                      ; preds = %29
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  store i32 %35, i32* %loc4
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  %39 = load i32, i32 addrspace(1)* %38, align 8
+  store i32 %39, i32* %loc5
+  %40 = load i32, i32* %loc5
+  %41 = load i32, i32* %loc4
+  %42 = add i32 %40, %41
+  %43 = zext i32 %42 to i64
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %45
+
+; <label>:45                                      ; preds = %37
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = sext i32 %47 to i64
+  %49 = icmp sgt i64 %43, %48
+  br i1 %49, label %91, label %50
+
+; <label>:50                                      ; preds = %45
+  %51 = load i32, i32* %loc5
+  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %52, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %53
+
+; <label>:53                                      ; preds = %50
+  %54 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %52, i32 0, i32 1
+  %55 = load i32, i32 addrspace(1)* %54
+  %56 = zext i32 %55 to i64
+  %57 = trunc i64 %56 to i32
+  %58 = icmp ugt i32 %51, %57
+  br i1 %58, label %91, label %59
+
+; <label>:59                                      ; preds = %53
+  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc3
+  store %"System.Char[]" addrspace(1)* %60, %"System.Char[]" addrspace(1)** %loc8
+  %61 = icmp eq %"System.Char[]" addrspace(1)* %60, null
+  br i1 %61, label %70, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %63, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %64
+
+; <label>:64                                      ; preds = %62
+  %65 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %63, i32 0, i32 1
+  %66 = load i32, i32 addrspace(1)* %65
+  %67 = zext i32 %66 to i64
+  %68 = trunc i64 %67 to i32
+  %69 = icmp ne i32 %68, 0
+  br i1 %69, label %71, label %70
+
+; <label>:70                                      ; preds = %59, %64
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:71                                      ; preds = %64
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc8
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %73
+
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %BoundsCheck = icmp uge i64 0, %76
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %77
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %78, i16 addrspace(1)** %loc6
+  br label %79
+
+; <label>:79                                      ; preds = %70, %77
+  %80 = load i16*, i16** %loc2
+  %81 = load i32, i32* %loc4
+  %82 = sext i32 %81 to i64
+  %83 = mul i64 %82, 2
+  %84 = bitcast i16* %80 to i8*
+  %85 = getelementptr inbounds i8, i8* %84, i64 %83
+  %86 = load i16 addrspace(1)*, i16 addrspace(1)** %loc6
+  %87 = ptrtoint i16 addrspace(1)* %86 to i64
+  %88 = load i32, i32* %loc5
+  %89 = bitcast i8* %85 to i16*
+  %90 = inttoptr i64 %87 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %89, i16* %90, i32 %88)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc6
+  br label %96
+
+; <label>:91                                      ; preds = %45, %53
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %94 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %93)
+  %95 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95, %System.String addrspace(1)* %92, %System.String addrspace(1)* %94)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %95) #0
+  unreachable
+
+; <label>:96                                      ; preds = %23, %79
+  %97 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %97, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %98
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %97, i32 0, i32 2
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  store %System.Text.StringBuilder addrspace(1)* %100, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %102 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %102, label %21, label %103
+
+; <label>:103                                     ; preds = %98
+  store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc7
+  %104 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  ret %System.String addrspace(1)* %104
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method StringBuilder::get_Length using LLILCJit
+Successfully read StringBuilder.get_Length
+
+define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
+Successfully read RuntimeHelpers.get_OffsetToStringData
+
+define i32 @RuntimeHelpers.get_OffsetToStringData() {
+entry:
+  ret i32 12
+}
+
 INFO:  jitting method CultureData::CreateCultureData using LLILCJit
 Successfully read CultureData.CreateCultureData
 
@@ -3514,23 +4249,23 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
   store i8 %4, i8 addrspace(1)* %6
   %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
@@ -3549,11 +4284,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3566,50 +4301,50 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
   store i32 -1, i32 addrspace(1)* %2
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
   store i32 -1, i32 addrspace(1)* %8
   %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
   store i32 -1, i32 addrspace(1)* %14
   %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
   store i32 -1, i32 addrspace(1)* %17
   %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
@@ -3623,27 +4358,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3675,7 +4410,136 @@ Failed to read Dictionary`2.Insert[non-const derefAddress]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
 Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
-Failed to read HashHelpers.GetPrime[loadElem]
+Successfully read HashHelpers.GetPrime
+
+define i32 @HashHelpers.GetPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %6, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5, %System.String addrspace(1)* %4)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %5) #0
+  unreachable
+
+; <label>:6                                       ; preds = %entry
+  store i32 0, i32* %loc0
+  br label %29
+
+; <label>:7                                       ; preds = %35
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 1296
+  %10 = addrspacecast i8 addrspace(1)* %9 to %"System.Int32[]" addrspace(1)**
+  %11 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %10
+  %12 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Int32[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = zext i32 %15 to i64
+  %17 = zext i32 %12 to i64
+  %BoundsCheck = icmp uge i64 %17, %16
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %11, i32 0, i32 3, i32 %12
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  store i32 %20, i32* %loc1
+  %21 = load i32, i32* %loc1
+  %22 = load i32, i32* %arg0
+  %23 = icmp slt i32 %21, %22
+  br i1 %23, label %26, label %24
+
+; <label>:24                                      ; preds = %18
+  %25 = load i32, i32* %loc1
+  ret i32 %25
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %loc0
+  %28 = add i32 %27, 1
+  store i32 %28, i32* %loc0
+  br label %29
+
+; <label>:29                                      ; preds = %6, %26
+  %30 = load i32, i32* %loc0
+  %31 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %32 = getelementptr inbounds i8, i8 addrspace(1)* %31, i64 1296
+  %33 = addrspacecast i8 addrspace(1)* %32 to %"System.Int32[]" addrspace(1)**
+  %34 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)** %33
+  %NullCheck = icmp eq %"System.Int32[]" addrspace(1)* %34, null
+  br i1 %NullCheck, label %ThrowNullRef, label %35
+
+; <label>:35                                      ; preds = %29
+  %36 = getelementptr inbounds %"System.Int32[]", %"System.Int32[]" addrspace(1)* %34, i32 0, i32 1
+  %37 = load i32, i32 addrspace(1)* %36
+  %38 = zext i32 %37 to i64
+  %39 = trunc i64 %38 to i32
+  %40 = icmp slt i32 %30, %39
+  br i1 %40, label %7, label %41
+
+; <label>:41                                      ; preds = %35
+  %42 = load i32, i32* %arg0
+  %43 = or i32 %42, 1
+  store i32 %43, i32* %loc2
+  br label %59
+
+; <label>:44                                      ; preds = %59
+  %45 = load i32, i32* %loc2
+  %46 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %45)
+  %47 = zext i8 %46 to i32
+  %48 = icmp eq i32 %47, 0
+  br i1 %48, label %56, label %49
+
+; <label>:49                                      ; preds = %44
+  %50 = load i32, i32* %loc2
+  %51 = sub i32 %50, 1
+  %52 = srem i32 %51, 101
+  %53 = icmp eq i32 %52, 0
+  br i1 %53, label %56, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = load i32, i32* %loc2
+  ret i32 %55
+
+; <label>:56                                      ; preds = %44, %49
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %57, 2
+  store i32 %58, i32* %loc2
+  br label %59
+
+; <label>:59                                      ; preds = %41, %56
+  %60 = load i32, i32* %loc2
+  %61 = icmp slt i32 %60, 2147483647
+  br i1 %61, label %44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = load i32, i32* %arg0
+  ret i32 %63
+
+ThrowNullRef:                                     ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
 Successfully read GenericEqualityComparer`1.GetHashCode
 
@@ -3694,14 +4558,14 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
   %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load i64, i64 addrspace(1)* %7
@@ -3720,7 +4584,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3750,8 +4614,8 @@ entry:
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
@@ -3796,8 +4660,8 @@ entry:
   %35 = bitcast i16* %34 to i8*
   %36 = getelementptr inbounds i8, i8* %35, i64 2
   %37 = bitcast i8* %36 to i16*
-  %NullCheck4 = icmp ne i16* %37, null
-  br i1 %NullCheck4, label %38, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %37, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %38
 
 ; <label>:38                                      ; preds = %27
   %39 = load i16, i16* %37, align 8
@@ -3824,8 +4688,8 @@ entry:
 
 ; <label>:54                                      ; preds = %22, %43
   %55 = load i16*, i16** %loc4
-  %NullCheck2 = icmp ne i16* %55, null
-  br i1 %NullCheck2, label %56, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i16* %55, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %56
 
 ; <label>:56                                      ; preds = %54
   %57 = load i16, i16* %55, align 8
@@ -3850,11 +4714,11 @@ ThrowNullRef:                                     ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %54
+ThrowNullRef2:                                    ; preds = %54
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %27
+ThrowNullRef4:                                    ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3871,8 +4735,8 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load i64, i64 addrspace(1)* %3
@@ -3907,8 +4771,8 @@ entry:
 
 ; <label>:26                                      ; preds = %19
   %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
-  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %28
 
 ; <label>:28                                      ; preds = %26
   %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
@@ -3920,7 +4784,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3972,8 +4836,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
@@ -3984,26 +4848,26 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
-  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
@@ -4014,8 +4878,8 @@ entry:
 ; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
@@ -4024,8 +4888,8 @@ entry:
 
 ; <label>:25                                      ; preds = %1, %16, %23
   %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
-  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
@@ -4036,27 +4900,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %20
+ThrowNullRef10:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %25
+ThrowNullRef12:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4069,8 +4933,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
@@ -4081,8 +4945,8 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
@@ -4091,8 +4955,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1, %8
   %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
@@ -4103,11 +4967,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4128,24 +4992,24 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
   %3 = load i32, i32 addrspace(1)* %2
   store i32 %3, i32* %loc0
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
   %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
   store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
-  br i1 %NullCheck4, label %9, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %8, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %9
 
 ; <label>:9                                       ; preds = %5
   %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
@@ -4164,15 +5028,15 @@ entry:
 ; <label>:18                                      ; preds = %70
   %19 = load i16*, i16** %loc3
   %20 = bitcast i16* %19 to i64*
-  %NullCheck10 = icmp ne i64* %20, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64* %20, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = load i64, i64* %20, align 8
   %23 = load i16*, i16** %loc4
   %24 = bitcast i16* %23 to i64*
-  %NullCheck12 = icmp ne i64* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = load i64, i64* %24, align 8
@@ -4188,8 +5052,8 @@ entry:
   %31 = bitcast i16* %30 to i8*
   %32 = getelementptr inbounds i8, i8* %31, i64 8
   %33 = bitcast i8* %32 to i64*
-  %NullCheck14 = icmp ne i64* %33, null
-  br i1 %NullCheck14, label %34, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = load i64, i64* %33, align 8
@@ -4197,8 +5061,8 @@ entry:
   %37 = bitcast i16* %36 to i8*
   %38 = getelementptr inbounds i8, i8* %37, i64 8
   %39 = bitcast i8* %38 to i64*
-  %NullCheck16 = icmp ne i64* %39, null
-  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %40
 
 ; <label>:40                                      ; preds = %34
   %41 = load i64, i64* %39, align 8
@@ -4214,8 +5078,8 @@ entry:
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %NullCheck18 = icmp ne i64* %48, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64* %48, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = load i64, i64* %48, align 8
@@ -4223,8 +5087,8 @@ entry:
   %52 = bitcast i16* %51 to i8*
   %53 = getelementptr inbounds i8, i8* %52, i64 16
   %54 = bitcast i8* %53 to i64*
-  %NullCheck20 = icmp ne i64* %54, null
-  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64* %54, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %55
 
 ; <label>:55                                      ; preds = %49
   %56 = load i64, i64* %54, align 8
@@ -4262,15 +5126,15 @@ entry:
 ; <label>:74                                      ; preds = %95
   %75 = load i16*, i16** %loc3
   %76 = bitcast i16* %75 to i32*
-  %NullCheck6 = icmp ne i32* %76, null
-  br i1 %NullCheck6, label %77, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32* %76, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %77
 
 ; <label>:77                                      ; preds = %74
   %78 = load i32, i32* %76, align 8
   %79 = load i16*, i16** %loc4
   %80 = bitcast i16* %79 to i32*
-  %NullCheck8 = icmp ne i32* %80, null
-  br i1 %NullCheck8, label %81, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i32* %80, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %81
 
 ; <label>:81                                      ; preds = %77
   %82 = load i32, i32* %80, align 8
@@ -4318,43 +5182,43 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %74
+ThrowNullRef6:                                    ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %77
+ThrowNullRef8:                                    ; preds = %77
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %29
+ThrowNullRef14:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %34
+ThrowNullRef16:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4376,8 +5240,8 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load i64, i64 addrspace(1)* %4
@@ -4389,8 +5253,8 @@ entry:
   %12 = load i64, i64* %11
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %5
   %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
@@ -4399,8 +5263,8 @@ entry:
   %18 = load i8, i8* %arg2
   %19 = zext i8 %18 to i32
   %20 = trunc i32 %19 to i8
-  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %15
   %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
@@ -4411,11 +5275,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4442,8 +5306,8 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
@@ -4466,16 +5330,16 @@ entry:
 
 ; <label>:13                                      ; preds = %5
   %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %13
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
   %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = load i64, i64 addrspace(1)* %19
@@ -4500,8 +5364,8 @@ entry:
 ; <label>:35                                      ; preds = %30
   %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %35
   %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
@@ -4514,8 +5378,8 @@ entry:
 
 ; <label>:42                                      ; preds = %1, %38
   %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
-  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
@@ -4526,19 +5390,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %35
+ThrowNullRef2:                                    ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %42
+ThrowNullRef8:                                    ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4551,14 +5415,14 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
@@ -4570,7 +5434,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4583,8 +5447,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
@@ -4613,51 +5477,51 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
   %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
   %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
   %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
   %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
-  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
   store i64 %21, i64 addrspace(1)* %23
   %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %25 = load i64, i64* %loc0
-  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
@@ -4668,27 +5532,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %22
+ThrowNullRef12:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4701,8 +5565,8 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
@@ -4713,19 +5577,19 @@ entry:
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
@@ -4734,8 +5598,8 @@ entry:
 
 ; <label>:15                                      ; preds = %1, %13
   %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
@@ -4746,19 +5610,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %15
+ThrowNullRef8:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4771,8 +5635,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -4831,8 +5695,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
@@ -4882,8 +5746,8 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
-  br i1 %NullCheck, label %17, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %ThrowNullRef, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
@@ -4894,15 +5758,15 @@ entry:
 
 ; <label>:22                                      ; preds = %17
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
-  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
   %26 = load i32, i32 addrspace(1)* %25
   %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
-  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %27, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %28
 
 ; <label>:28                                      ; preds = %24
   %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
@@ -4925,8 +5789,8 @@ entry:
 ; <label>:40                                      ; preds = %17
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
-  br i1 %NullCheck6, label %43, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %41, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %43
 
 ; <label>:43                                      ; preds = %40
   %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
@@ -4938,34 +5802,17 @@ ThrowNullRef:                                     ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %22
+ThrowNullRef2:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %24
+ThrowNullRef4:                                    ; preds = %24
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %40
+ThrowNullRef6:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
-}
-
-INFO:  jitting method Object::ReferenceEquals using LLILCJit
-Successfully read Object.ReferenceEquals
-
-define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
-entry:
-  %arg0 = alloca %System.Object addrspace(1)*
-  %arg1 = alloca %System.Object addrspace(1)*
-  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
-  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
-  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = icmp eq %System.Object addrspace(1)* %0, %1
-  %3 = sext i1 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
 }
 
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
@@ -4978,21 +5825,21 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
   %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
-  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
-  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
@@ -5007,28 +5854,28 @@ entry:
 ; <label>:13                                      ; preds = %8, %12
   %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
   %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
   %21 = load i32, i32 addrspace(1)* %20, align 8
   %22 = add i32 %21, 1
-  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
-  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
   store i32 %22, i32 addrspace(1)* %24
   %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
-  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
@@ -5039,27 +5886,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %23
+ThrowNullRef12:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5077,7 +5924,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::Setup using LLILCJit
-Failed to read AppDomain.Setup[loadElem]
+Failed to read AppDomain.Setup[unbox]
 INFO:  jitting method Thread::GetDomain using LLILCJit
 Successfully read Thread.GetDomain
 
@@ -5108,8 +5955,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
@@ -5122,14 +5969,14 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
   %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
@@ -5141,11 +5988,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5173,8 +6020,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -5189,7 +6036,328 @@ ThrowNullRef:                                     ; preds = %5
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
 Failed to read KeyCollection.System.Collections.Generic.IEnumerable<TKey>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Successfully read Enumerator.MoveNext
+
+define i8 @Enumerator.MoveNext(%"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.RuntimeTypeHandle* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*
+  %"$TypeArg" = alloca %System.RuntimeTypeHandle*
+  store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
+  %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 8
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %76, label %12
+
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
+  br label %76
+
+; <label>:13                                      ; preds = %85
+  %14 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck19 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %15
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %14, i32 0, i32 0
+  %17 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %16, align 8
+  %NullCheck21 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %17, i32 0, i32 2
+  %20 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %19, align 8
+  %21 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck23 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %22
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %21, i32 0, i32 2
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %NullCheck25 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %20, i32 0, i32 3, i32 %24
+  %NullCheck27 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %32
+
+; <label>:32                                      ; preds = %30
+  %33 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %31, i32 0, i32 2
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = icmp slt i32 %34, 0
+  br i1 %35, label %68, label %36
+
+; <label>:36                                      ; preds = %32
+  %37 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %38 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck29 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %39
+
+; <label>:39                                      ; preds = %36
+  %40 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %38, i32 0, i32 0
+  %41 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %40, align 8
+  %NullCheck31 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %41, i32 0, i32 2
+  %44 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %43, align 8
+  %45 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck33 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %45, i32 0, i32 2
+  %48 = load i32, i32 addrspace(1)* %47, align 8
+  %NullCheck35 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %49
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = zext i32 %51 to i64
+  %53 = zext i32 %48 to i64
+  %BoundsCheck37 = icmp uge i64 %53, %52
+  br i1 %BoundsCheck37, label %ThrowIndexOutOfRange38, label %54
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %44, i32 0, i32 3, i32 %48
+  %NullCheck39 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %56
+
+; <label>:56                                      ; preds = %54
+  %57 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %55, i32 0, i32 0
+  %58 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck41 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %59
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %37, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %60, %System.__Canon addrspace(1)* %58)
+  %61 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck43 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %62
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  %64 = load i32, i32 addrspace(1)* %63, align 8
+  %65 = add i32 %64, 1
+  %NullCheck45 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %61, i32 0, i32 2
+  store i32 %65, i32 addrspace(1)* %67
+  ret i8 1
+
+; <label>:68                                      ; preds = %32
+  %69 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck47 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %73 = add i32 %72, 1
+  %NullCheck49 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %74
+
+; <label>:74                                      ; preds = %70
+  %75 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %69, i32 0, i32 2
+  store i32 %73, i32 addrspace(1)* %75
+  br label %76
+
+; <label>:76                                      ; preds = %8, %12, %74
+  %77 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %78
+
+; <label>:78                                      ; preds = %76
+  %79 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %77, i32 0, i32 2
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck7 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %82
+
+; <label>:82                                      ; preds = %78
+  %83 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %81, i32 0, i32 0
+  %84 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %83, align 8
+  %NullCheck9 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %85
+
+; <label>:85                                      ; preds = %82
+  %86 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %84, i32 0, i32 7
+  %87 = load i32, i32 addrspace(1)* %86, align 8
+  %88 = icmp ult i32 %80, %87
+  br i1 %88, label %13, label %89
+
+; <label>:89                                      ; preds = %85
+  %90 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %91 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck11 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %92
+
+; <label>:92                                      ; preds = %89
+  %93 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %91, i32 0, i32 0
+  %94 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck13 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %95
+
+; <label>:95                                      ; preds = %92
+  %96 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %94, i32 0, i32 7
+  %97 = load i32, i32 addrspace(1)* %96, align 8
+  %98 = add i32 %97, 1
+  %NullCheck15 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %99
+
+; <label>:99                                      ; preds = %95
+  %100 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %90, i32 0, i32 2
+  store i32 %98, i32 addrspace(1)* %100
+  %101 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck17 = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %102
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %101, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %103, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %92
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef22:                                   ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef24:                                   ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef26:                                   ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef28:                                   ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef30:                                   ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef32:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef34:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef36:                                   ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange38:                           ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef40:                                   ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef42:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef44:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef46:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef48:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef50:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Successfully read Enumerator.get_Current
 
@@ -5200,8 +6368,8 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
@@ -5232,9 +6400,9 @@ Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
 Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
-Failed to read String.MakeSeparatorList[loadElemA]
+Failed to read String.MakeSeparatorList[storeElem]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
-Failed to read String.InternalSplitKeepEmptyEntries[loadElem]
+Failed to read String.InternalSplitKeepEmptyEntries[storeElem]
 INFO:  jitting method Path::IsRelative using LLILCJit
 Successfully read Path.IsRelative
 
@@ -5243,8 +6411,8 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
@@ -5254,8 +6422,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
@@ -5271,8 +6439,8 @@ entry:
 
 ; <label>:17                                      ; preds = %7
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
@@ -5288,8 +6456,8 @@ entry:
 
 ; <label>:29                                      ; preds = %19
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %31
 
 ; <label>:31                                      ; preds = %29
   %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
@@ -5300,8 +6468,8 @@ entry:
 
 ; <label>:36                                      ; preds = %31
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
-  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %37, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
@@ -5312,8 +6480,8 @@ entry:
 
 ; <label>:43                                      ; preds = %31, %38
   %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
-  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %44, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %45
 
 ; <label>:45                                      ; preds = %43
   %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
@@ -5324,8 +6492,8 @@ entry:
 
 ; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %50
   %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
@@ -5336,8 +6504,8 @@ entry:
 
 ; <label>:57                                      ; preds = %1, %7, %19, %45, %52
   %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
-  br i1 %NullCheck14, label %59, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %59
 
 ; <label>:59                                      ; preds = %57
   %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
@@ -5347,8 +6515,8 @@ entry:
 
 ; <label>:63                                      ; preds = %59
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
@@ -5359,8 +6527,8 @@ entry:
 
 ; <label>:70                                      ; preds = %65
   %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
-  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.String addrspace(1)* %71, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %72
 
 ; <label>:72                                      ; preds = %70
   %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
@@ -5379,39 +6547,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %17
+ThrowNullRef4:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %29
+ThrowNullRef6:                                    ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %36
+ThrowNullRef8:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %43
+ThrowNullRef10:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %50
+ThrowNullRef12:                                   ; preds = %50
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %57
+ThrowNullRef14:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %63
+ThrowNullRef16:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %70
+ThrowNullRef18:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5419,7 +6587,293 @@ ThrowNullRef17:                                   ; preds = %70
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
-Failed to read String.TrimHelper[loadElem]
+Successfully read String.TrimHelper
+
+define %System.String addrspace(1)* @String.TrimHelper(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i16
+  %loc4 = alloca i32
+  %loc5 = alloca i16
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = sub i32 %3, 1
+  store i32 %4, i32* %loc0
+  store i32 0, i32* %loc1
+  %5 = load i32, i32* %arg2
+  %6 = icmp eq i32 %5, 1
+  br i1 %6, label %62, label %7
+
+; <label>:7                                       ; preds = %1
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:8                                       ; preds = %58
+  store i32 0, i32* %loc2
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load i32, i32* %loc1
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2, i32 %10
+  %13 = load i16, i16 addrspace(1)* %12
+  %14 = zext i16 %13 to i32
+  %15 = trunc i32 %14 to i16
+  store i16 %15, i16* %loc3
+  store i32 0, i32* %loc2
+  br label %34
+
+; <label>:16                                      ; preds = %37
+  %17 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %18 = load i32, i32* %loc2
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %17, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %19
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = zext i32 %18 to i64
+  %BoundsCheck = icmp uge i64 %23, %22
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %24
+
+; <label>:24                                      ; preds = %19
+  %25 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %17, i32 0, i32 3, i32 %18
+  %26 = load i16, i16 addrspace(1)* %25, align 8
+  %27 = zext i16 %26 to i32
+  %28 = load i16, i16* %loc3
+  %29 = zext i16 %28 to i32
+  %30 = icmp eq i32 %27, %29
+  br i1 %30, label %43, label %31
+
+; <label>:31                                      ; preds = %24
+  %32 = load i32, i32* %loc2
+  %33 = add i32 %32, 1
+  store i32 %33, i32* %loc2
+  br label %34
+
+; <label>:34                                      ; preds = %11, %31
+  %35 = load i32, i32* %loc2
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %37
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = icmp slt i32 %35, %41
+  br i1 %42, label %16, label %43
+
+; <label>:43                                      ; preds = %24, %37
+  %44 = load i32, i32* %loc2
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %45, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp eq i32 %44, %50
+  br i1 %51, label %62, label %52
+
+; <label>:52                                      ; preds = %46
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %7, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %57, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %58
+
+; <label>:58                                      ; preds = %55
+  %59 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %60 = load i32, i32 addrspace(1)* %59
+  %61 = icmp slt i32 %56, %60
+  br i1 %61, label %8, label %62
+
+; <label>:62                                      ; preds = %1, %46, %58
+  %63 = load i32, i32* %arg2
+  %64 = icmp eq i32 %63, 0
+  br i1 %64, label %122, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck11 = icmp eq %System.String addrspace(1)* %66, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %67
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %66, i32 0, i32 1
+  %69 = load i32, i32 addrspace(1)* %68
+  %70 = sub i32 %69, 1
+  store i32 %70, i32* %loc0
+  br label %118
+
+; <label>:71                                      ; preds = %118
+  store i32 0, i32* %loc4
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %73 = load i32, i32* %loc0
+  %NullCheck13 = icmp eq %System.String addrspace(1)* %72, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %74
+
+; <label>:74                                      ; preds = %71
+  %75 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 2, i32 %73
+  %76 = load i16, i16 addrspace(1)* %75
+  %77 = zext i16 %76 to i32
+  %78 = trunc i32 %77 to i16
+  store i16 %78, i16* %loc5
+  store i32 0, i32* %loc4
+  br label %97
+
+; <label>:79                                      ; preds = %100
+  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %81 = load i32, i32* %loc4
+  %NullCheck19 = icmp eq %"System.Char[]" addrspace(1)* %80, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
+
+; <label>:82                                      ; preds = %79
+  %83 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 1
+  %84 = load i32, i32 addrspace(1)* %83
+  %85 = zext i32 %84 to i64
+  %86 = zext i32 %81 to i64
+  %BoundsCheck21 = icmp uge i64 %86, %85
+  br i1 %BoundsCheck21, label %ThrowIndexOutOfRange22, label %87
+
+; <label>:87                                      ; preds = %82
+  %88 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %80, i32 0, i32 3, i32 %81
+  %89 = load i16, i16 addrspace(1)* %88, align 8
+  %90 = zext i16 %89 to i32
+  %91 = load i16, i16* %loc5
+  %92 = zext i16 %91 to i32
+  %93 = icmp eq i32 %90, %92
+  br i1 %93, label %106, label %94
+
+; <label>:94                                      ; preds = %87
+  %95 = load i32, i32* %loc4
+  %96 = add i32 %95, 1
+  store i32 %96, i32* %loc4
+  br label %97
+
+; <label>:97                                      ; preds = %74, %94
+  %98 = load i32, i32* %loc4
+  %99 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck15 = icmp eq %"System.Char[]" addrspace(1)* %99, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %100
+
+; <label>:100                                     ; preds = %97
+  %101 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %99, i32 0, i32 1
+  %102 = load i32, i32 addrspace(1)* %101
+  %103 = zext i32 %102 to i64
+  %104 = trunc i64 %103 to i32
+  %105 = icmp slt i32 %98, %104
+  br i1 %105, label %79, label %106
+
+; <label>:106                                     ; preds = %87, %100
+  %107 = load i32, i32* %loc4
+  %108 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck17 = icmp eq %"System.Char[]" addrspace(1)* %108, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %109
+
+; <label>:109                                     ; preds = %106
+  %110 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %108, i32 0, i32 1
+  %111 = load i32, i32 addrspace(1)* %110
+  %112 = zext i32 %111 to i64
+  %113 = trunc i64 %112 to i32
+  %114 = icmp eq i32 %107, %113
+  br i1 %114, label %122, label %115
+
+; <label>:115                                     ; preds = %109
+  %116 = load i32, i32* %loc0
+  %117 = sub i32 %116, 1
+  store i32 %117, i32* %loc0
+  br label %118
+
+; <label>:118                                     ; preds = %67, %115
+  %119 = load i32, i32* %loc0
+  %120 = load i32, i32* %loc1
+  %121 = icmp sge i32 %119, %120
+  br i1 %121, label %71, label %122
+
+; <label>:122                                     ; preds = %62, %109, %118
+  %123 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %124 = load i32, i32* %loc1
+  %125 = load i32, i32* %loc0
+  %126 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %123, i32 %124, i32 %125)
+  ret %System.String addrspace(1)* %126
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %97
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef18:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange22:                           ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
 Successfully read String.CreateTrimmedString
 
@@ -5439,8 +6893,8 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
@@ -5535,8 +6989,8 @@ entry:
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i64 2872
   %7 = addrspacecast i8 addrspace(1)* %6 to %"System.Char[]" addrspace(1)**
   %8 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %7
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %9
 
 ; <label>:9                                       ; preds = %3
   %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %4, %"System.Char[]" addrspace(1)* %8)
@@ -5553,8 +7007,8 @@ entry:
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 2864
   %20 = addrspacecast i8 addrspace(1)* %19 to %"System.Char[]" addrspace(1)**
   %21 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %20
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %17, null
-  br i1 %NullCheck2, label %22, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %22
 
 ; <label>:22                                      ; preds = %16
   %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%System.String addrspace(1)* %17, %"System.Char[]" addrspace(1)* %21)
@@ -5569,7 +7023,7 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %16
+ThrowNullRef2:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5586,8 +7040,8 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5613,8 +7067,8 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
@@ -5632,8 +7086,8 @@ entry:
 
 ; <label>:12                                      ; preds = %4
   %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
@@ -5644,8 +7098,8 @@ entry:
 
 ; <label>:19                                      ; preds = %14
   %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
-  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
 
 ; <label>:21                                      ; preds = %19
   %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
@@ -5660,21 +7114,21 @@ entry:
   %31 = zext i16 %30 to i32
   %32 = bitcast i8* %29 to i16*
   %33 = trunc i32 %31 to i16
-  %NullCheck6 = icmp ne i16* %32, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i16* %32, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %21
   store i16 %33, i16* %32, align 8
   %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %36
 
 ; <label>:36                                      ; preds = %34
   %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
   %38 = load i32, i32 addrspace(1)* %37, align 8
   %39 = add i32 %38, 1
-  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
-  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %40
 
 ; <label>:40                                      ; preds = %36
   %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
@@ -5683,16 +7137,16 @@ entry:
 
 ; <label>:42                                      ; preds = %14
   %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
-  br i1 %NullCheck12, label %44, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
   %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
   %47 = load i16, i16* %arg1
   %48 = zext i16 %47 to i32
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = trunc i32 %48 to i16
@@ -5703,31 +7157,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %19
+ThrowNullRef4:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %21
+ThrowNullRef6:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %36
+ThrowNullRef10:                                   ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %42
+ThrowNullRef12:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %44
+ThrowNullRef14:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5740,8 +7194,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -5752,8 +7206,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
@@ -5762,14 +7216,14 @@ entry:
 
 ; <label>:11                                      ; preds = %1
   %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
@@ -5779,15 +7233,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5808,8 +7262,8 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
@@ -5822,8 +7276,8 @@ entry:
 
 ; <label>:8                                       ; preds = %3
   %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
@@ -5842,15 +7296,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
-  br i1 %NullCheck4, label %22, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
   %24 = load i16*, i16* addrspace(1)* %23, align 8
   %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %25, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
@@ -5859,8 +7313,8 @@ entry:
   store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
   %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
@@ -5874,8 +7328,8 @@ entry:
 
 ; <label>:37                                      ; preds = %65
   %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
-  br i1 %NullCheck12, label %39, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %39
 
 ; <label>:39                                      ; preds = %37
   %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
@@ -5886,16 +7340,16 @@ entry:
   %45 = bitcast i16* %41 to i8*
   %46 = getelementptr inbounds i8, i8* %45, i64 %44
   %47 = bitcast i8* %46 to i16*
-  %NullCheck14 = icmp ne i16* %47, null
-  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i16* %47, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %48
 
 ; <label>:48                                      ; preds = %39
   %49 = load i16, i16* %47, align 8
   %50 = zext i16 %49 to i32
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %52 = load i32, i32* %loc1
-  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
-  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.String addrspace(1)* %51, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %53
 
 ; <label>:53                                      ; preds = %48
   %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
@@ -5916,8 +7370,8 @@ entry:
 ; <label>:62                                      ; preds = %36, %59
   %63 = load i32, i32* %loc1
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
-  br i1 %NullCheck10, label %65, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %64, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %65
 
 ; <label>:65                                      ; preds = %62
   %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
@@ -5936,15 +7390,15 @@ entry:
 
 ; <label>:74                                      ; preds = %70
   %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
-  br i1 %NullCheck18, label %76, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %76
 
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
   %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
-  br i1 %NullCheck20, label %80, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
   %81 = load i64, i64 addrspace(1)* %79
@@ -5958,8 +7412,8 @@ entry:
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
   %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
-  br i1 %NullCheck22, label %92, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.String addrspace(1)* %90, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %92
 
 ; <label>:92                                      ; preds = %80
   %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
@@ -5969,15 +7423,15 @@ entry:
 
 ; <label>:96                                      ; preds = %70
   %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
-  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %98
 
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
   %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
-  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
   %103 = load i64, i64 addrspace(1)* %101
@@ -5991,8 +7445,8 @@ entry:
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
   %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
-  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.String addrspace(1)* %112, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %114
 
 ; <label>:114                                     ; preds = %102
   %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
@@ -6004,59 +7458,59 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %20
+ThrowNullRef4:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %22
+ThrowNullRef6:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %26
+ThrowNullRef8:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %62
+ThrowNullRef10:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %39
+ThrowNullRef14:                                   ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %48
+ThrowNullRef16:                                   ; preds = %48
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %74
+ThrowNullRef18:                                   ; preds = %74
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %76
+ThrowNullRef20:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %80
+ThrowNullRef22:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %96
+ThrowNullRef24:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %98
+ThrowNullRef26:                                   ; preds = %98
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %102
+ThrowNullRef28:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6069,15 +7523,15 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
   %3 = load i16*, i16* addrspace(1)* %2, align 8
   %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
@@ -6087,8 +7541,8 @@ entry:
   %10 = bitcast i16* %3 to i8*
   %11 = getelementptr inbounds i8, i8* %10, i64 %9
   %12 = bitcast i8* %11 to i16*
-  %NullCheck4 = icmp ne i16* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i16* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %5
   store i16 0, i16* %12, align 8
@@ -6098,11 +7552,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %5
+ThrowNullRef4:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6119,8 +7573,8 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
@@ -6131,8 +7585,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
@@ -6144,15 +7598,15 @@ entry:
 
 ; <label>:14                                      ; preds = %1
   %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
   %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
   %21 = load i64, i64 addrspace(1)* %19
@@ -6171,15 +7625,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %14
+ThrowNullRef4:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %16
+ThrowNullRef6:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6302,14 +7756,6 @@ entry:
   ret %System.String addrspace(1)* %57
 }
 
-INFO:  jitting method RuntimeHelpers::get_OffsetToStringData using LLILCJit
-Successfully read RuntimeHelpers.get_OffsetToStringData
-
-define i32 @RuntimeHelpers.get_OffsetToStringData() {
-entry:
-  ret i32 12
-}
-
 INFO:  jitting method String::Equals using LLILCJit
 Successfully read String.Equals
 
@@ -6381,8 +7827,8 @@ entry:
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
-  br i1 %NullCheck24, label %29, label %ThrowNullRef23
+  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
   %30 = load i64, i64 addrspace(1)* %28
@@ -6397,8 +7843,8 @@ entry:
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
-  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
   %43 = load i64, i64 addrspace(1)* %41
@@ -6418,8 +7864,8 @@ entry:
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
   %59 = load i64, i64 addrspace(1)* %57
@@ -6434,8 +7880,8 @@ entry:
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck22, label %71, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
   %72 = load i64, i64 addrspace(1)* %70
@@ -6455,8 +7901,8 @@ entry:
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
-  br i1 %NullCheck16, label %87, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
   %88 = load i64, i64 addrspace(1)* %86
@@ -6471,8 +7917,8 @@ entry:
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck18, label %100, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
   %101 = load i64, i64 addrspace(1)* %99
@@ -6492,8 +7938,8 @@ entry:
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
-  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
   %117 = load i64, i64 addrspace(1)* %115
@@ -6508,8 +7954,8 @@ entry:
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
-  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
   %130 = load i64, i64 addrspace(1)* %128
@@ -6528,15 +7974,15 @@ entry:
 
 ; <label>:142                                     ; preds = %22
   %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
-  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %143, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %144
 
 ; <label>:144                                     ; preds = %142
   %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
   %146 = load i32, i32 addrspace(1)* %145
   %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
-  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.String addrspace(1)* %147, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %148
 
 ; <label>:148                                     ; preds = %144
   %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
@@ -6557,15 +8003,15 @@ entry:
 
 ; <label>:159                                     ; preds = %22
   %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
-  br i1 %NullCheck, label %161, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %ThrowNullRef, label %161
 
 ; <label>:161                                     ; preds = %159
   %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
   %163 = load i32, i32 addrspace(1)* %162
   %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
-  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %164, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %165
 
 ; <label>:165                                     ; preds = %161
   %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
@@ -6578,8 +8024,8 @@ entry:
 
 ; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
-  br i1 %NullCheck4, label %172, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %171, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %172
 
 ; <label>:172                                     ; preds = %170
   %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
@@ -6589,8 +8035,8 @@ entry:
 
 ; <label>:176                                     ; preds = %172
   %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
-  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %177, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %178
 
 ; <label>:178                                     ; preds = %176
   %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
@@ -6629,55 +8075,55 @@ ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %161
+ThrowNullRef2:                                    ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %170
+ThrowNullRef4:                                    ; preds = %170
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %176
+ThrowNullRef6:                                    ; preds = %176
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %142
+ThrowNullRef8:                                    ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %144
+ThrowNullRef10:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %113
+ThrowNullRef12:                                   ; preds = %113
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %116
+ThrowNullRef14:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %84
+ThrowNullRef16:                                   ; preds = %84
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %87
+ThrowNullRef18:                                   ; preds = %87
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %55
+ThrowNullRef20:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %58
+ThrowNullRef22:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %26
+ThrowNullRef24:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %29
+ThrowNullRef26:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,8 +8161,8 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck, label %14, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %ThrowNullRef, label %14
 
 ; <label>:14                                      ; preds = %8
   %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
@@ -6760,8 +8206,8 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %ThrowNullRef, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
@@ -6770,14 +8216,14 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32, i32* %loc0
   %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %10
   %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
   %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
@@ -6790,15 +8236,15 @@ entry:
 ; <label>:25                                      ; preds = %19
   %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
-  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
   %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
@@ -6807,8 +8253,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %37 = load i32, i32* %loc0
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %38, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %38
 
 ; <label>:38                                      ; preds = %32
   %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
@@ -6817,14 +8263,14 @@ entry:
 
 ; <label>:40                                      ; preds = %19
   %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %40
   %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
   %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
-  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
-  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %45
 
 ; <label>:45                                      ; preds = %42
   %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
@@ -6832,8 +8278,8 @@ entry:
   %48 = zext i32 %47 to i64
   %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
-  br i1 %NullCheck16, label %51, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %51
 
 ; <label>:51                                      ; preds = %45
   %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
@@ -6847,15 +8293,15 @@ entry:
 ; <label>:57                                      ; preds = %51
   %58 = load i16*, i16** %arg1
   %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
-  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %60
 
 ; <label>:60                                      ; preds = %57
   %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
   %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
-  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %64
 
 ; <label>:64                                      ; preds = %60
   %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
@@ -6864,22 +8310,22 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
   %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
-  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %70
 
 ; <label>:70                                      ; preds = %64
   %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
   %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
-  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
-  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
   %75 = load i32, i32 addrspace(1)* %74
   %76 = zext i32 %75 to i64
   %77 = trunc i64 %76 to i32
-  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
-  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %78
 
 ; <label>:78                                      ; preds = %73
   %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
@@ -6901,8 +8347,8 @@ entry:
   %90 = bitcast i16* %86 to i8*
   %91 = getelementptr inbounds i8, i8* %90, i64 %89
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %93
 
 ; <label>:93                                      ; preds = %80
   %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
@@ -6912,8 +8358,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %99 = load i32, i32* %loc2
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %100
 
 ; <label>:100                                     ; preds = %93
   %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
@@ -6928,63 +8374,63 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %25
+ThrowNullRef6:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %32
+ThrowNullRef10:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %40
+ThrowNullRef12:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %45
+ThrowNullRef16:                                   ; preds = %45
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %57
+ThrowNullRef18:                                   ; preds = %57
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %60
+ThrowNullRef20:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %64
+ThrowNullRef22:                                   ; preds = %64
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %70
+ThrowNullRef24:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %73
+ThrowNullRef26:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %80
+ThrowNullRef28:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %93
+ThrowNullRef30:                                   ; preds = %93
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7004,8 +8450,8 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
@@ -7033,43 +8479,43 @@ entry:
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %14
   %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
   %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %23
   %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   %28 = load i32, i32 addrspace(1)* %27, align 8
   %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
-  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %30
 
 ; <label>:30                                      ; preds = %26
   %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
   %32 = load i32, i32 addrspace(1)* %31, align 8
   %33 = add i32 %28, %32
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
-  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %34
 
 ; <label>:34                                      ; preds = %30
   %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
   store i32 %33, i32 addrspace(1)* %35
   %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
-  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
   store i32 0, i32 addrspace(1)* %38
   %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %40
 
 ; <label>:40                                      ; preds = %37
   %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
@@ -7082,8 +8528,8 @@ entry:
 
 ; <label>:47                                      ; preds = %40
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
-  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %49
 
 ; <label>:49                                      ; preds = %47
   %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
@@ -7098,8 +8544,8 @@ entry:
   %54 = load i32, i32* %loc0
   %55 = sext i32 %54 to i64
   %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
-  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %57
 
 ; <label>:57                                      ; preds = %52
   %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
@@ -7110,68 +8556,35 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %14
+ThrowNullRef2:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %23
+ThrowNullRef4:                                    ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %26
+ThrowNullRef6:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %30
+ThrowNullRef8:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %34
+ThrowNullRef10:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %37
+ThrowNullRef12:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %47
+ThrowNullRef14:                                   ; preds = %47
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %52
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-}
-
-INFO:  jitting method StringBuilder::get_Length using LLILCJit
-Successfully read StringBuilder.get_Length
-
-define i32 @StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.StringBuilder addrspace(1)*
-  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
-  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
-
-; <label>:1                                       ; preds = %entry
-  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %3 = load i32, i32 addrspace(1)* %2, align 8
-  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
-
-; <label>:5                                       ; preds = %1
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = add i32 %3, %7
-  ret i32 %8
-
-ThrowNullRef:                                     ; preds = %entry
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
-  unreachable
-
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef16:                                   ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7213,70 +8626,70 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
   %6 = load i32, i32 addrspace(1)* %5, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
   store i32 %6, i32 addrspace(1)* %8
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
   %13 = load i32, i32 addrspace(1)* %12, align 8
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
   store i32 %13, i32 addrspace(1)* %15
   %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
-  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %18
 
 ; <label>:18                                      ; preds = %14
   %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
   %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
-  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %21
 
 ; <label>:21                                      ; preds = %18
   %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
-  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %25
 
 ; <label>:25                                      ; preds = %21
   %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %28
 
 ; <label>:28                                      ; preds = %25
   %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
   %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %32
 
 ; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
   %34 = load i32, i32 addrspace(1)* %33, align 8
-  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
-  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %35
 
 ; <label>:35                                      ; preds = %32
   %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
@@ -7287,39 +8700,39 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %18
+ThrowNullRef10:                                   ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %21
+ThrowNullRef12:                                   ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %25
+ThrowNullRef14:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %28
+ThrowNullRef16:                                   ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %32
+ThrowNullRef18:                                   ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7455,13 +8868,13 @@ entry:
 ; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
@@ -7477,16 +8890,16 @@ entry:
 
 ; <label>:18                                      ; preds = %15
   %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
   store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
   %22 = load i32, i32* %loc0
   %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
-  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %24
 
 ; <label>:24                                      ; preds = %20
   %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
@@ -7498,13 +8911,13 @@ entry:
 ; <label>:28                                      ; preds = %15, %24
   %29 = load i32, i32* %arg1
   %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
-  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %31
 
 ; <label>:31                                      ; preds = %28
   %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
-  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
-  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %33
 
 ; <label>:33                                      ; preds = %31
   %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
@@ -7517,20 +8930,20 @@ entry:
   %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
-  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %42
 
 ; <label>:42                                      ; preds = %38
   %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
-  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %44
 
 ; <label>:44                                      ; preds = %42
   %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
   %46 = load i32, i32 addrspace(1)* %45, align 8
   %47 = sub i32 %40, %46
-  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
-  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+  %NullCheck15 = icmp eq i32 addrspace(1)* %39, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %48
 
 ; <label>:48                                      ; preds = %44
   store i32 %47, i32 addrspace(1)* %39, align 8
@@ -7538,21 +8951,21 @@ entry:
 
 ; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
-  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+  %NullCheck63 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck63, label %ThrowNullRef64, label %51
 
 ; <label>:51                                      ; preds = %49
   %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+  %NullCheck65 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck65, label %ThrowNullRef66, label %53
 
 ; <label>:53                                      ; preds = %51
   %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
   %55 = load i32, i32 addrspace(1)* %54, align 8
   %56 = load i32, i32* %arg2
   %57 = sub i32 %55, %56
-  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
-  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+  %NullCheck67 = icmp eq %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck67, label %ThrowNullRef68, label %58
 
 ; <label>:58                                      ; preds = %53
   %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
@@ -7562,13 +8975,13 @@ entry:
 ; <label>:60                                      ; preds = %33, %58
   %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
   %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
-  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+  %NullCheck59 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck59, label %ThrowNullRef60, label %63
 
 ; <label>:63                                      ; preds = %60
   %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
-  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
-  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+  %NullCheck61 = icmp eq %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck61, label %ThrowNullRef62, label %65
 
 ; <label>:65                                      ; preds = %63
   %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
@@ -7578,15 +8991,15 @@ entry:
 
 ; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
-  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i32 addrspace(1)* %69, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %70
 
 ; <label>:70                                      ; preds = %68
   %71 = load i32, i32 addrspace(1)* %69, align 8
   store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
-  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %73
 
 ; <label>:73                                      ; preds = %70
   %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
@@ -7596,8 +9009,8 @@ entry:
   store i32 %77, i32* %loc4
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
-  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %80
 
 ; <label>:80                                      ; preds = %73
   %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
@@ -7607,71 +9020,71 @@ entry:
 ; <label>:83                                      ; preds = %80
   store i32 0, i32* %loc3
   %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
-  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
-  br i1 %NullCheck26, label %88, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i32 addrspace(1)* %87, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %88
 
 ; <label>:88                                      ; preds = %85
   %89 = load i32, i32 addrspace(1)* %87, align 8
-  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
-  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %90
 
 ; <label>:90                                      ; preds = %88
   %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
   store i32 %89, i32 addrspace(1)* %91
   %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
-  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
-  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
-  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %96
 
 ; <label>:96                                      ; preds = %94
   %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
-  br i1 %NullCheck34, label %100, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %100
 
 ; <label>:100                                     ; preds = %96
   %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
-  br i1 %NullCheck36, label %102, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %102
 
 ; <label>:102                                     ; preds = %100
   %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
   %104 = load i32, i32 addrspace(1)* %103, align 8
   %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
-  br i1 %NullCheck38, label %106, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %106
 
 ; <label>:106                                     ; preds = %102
   %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
-  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
-  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %108
 
 ; <label>:108                                     ; preds = %106
   %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
   %110 = load i32, i32 addrspace(1)* %109, align 8
   %111 = add i32 %104, %110
-  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
-  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %112
 
 ; <label>:112                                     ; preds = %108
   %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
   store i32 %111, i32 addrspace(1)* %113
   %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
-  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+  %NullCheck43 = icmp eq i32 addrspace(1)* %114, null
+  br i1 %NullCheck43, label %ThrowNullRef44, label %115
 
 ; <label>:115                                     ; preds = %112
   %116 = load i32, i32 addrspace(1)* %114, align 8
@@ -7681,19 +9094,19 @@ entry:
 ; <label>:118                                     ; preds = %115
   %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
   %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
-  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+  %NullCheck45 = icmp eq %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck45, label %ThrowNullRef46, label %121
 
 ; <label>:121                                     ; preds = %118
   %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
-  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
-  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+  %NullCheck47 = icmp eq %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck47, label %ThrowNullRef48, label %123
 
 ; <label>:123                                     ; preds = %121
   %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
   %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
-  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
-  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+  %NullCheck49 = icmp eq %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck49, label %ThrowNullRef50, label %126
 
 ; <label>:126                                     ; preds = %123
   %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
@@ -7705,8 +9118,8 @@ entry:
 
 ; <label>:130                                     ; preds = %80, %115, %126
   %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+  %NullCheck51 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck51, label %ThrowNullRef52, label %132
 
 ; <label>:132                                     ; preds = %130
   %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7715,8 +9128,8 @@ entry:
   %136 = load i32, i32* %loc3
   %137 = sub i32 %135, %136
   %138 = sub i32 %134, %137
-  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
-  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+  %NullCheck53 = icmp eq %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck53, label %ThrowNullRef54, label %139
 
 ; <label>:139                                     ; preds = %132
   %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
@@ -7728,16 +9141,16 @@ entry:
 
 ; <label>:144                                     ; preds = %139
   %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
-  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+  %NullCheck55 = icmp eq %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck55, label %ThrowNullRef56, label %146
 
 ; <label>:146                                     ; preds = %144
   %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
   %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
   %149 = load i32, i32* %loc2
   %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
-  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+  %NullCheck57 = icmp eq %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck57, label %ThrowNullRef58, label %151
 
 ; <label>:151                                     ; preds = %146
   %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
@@ -7754,145 +9167,249 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %18
+ThrowNullRef4:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %28
+ThrowNullRef8:                                    ; preds = %28
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %31
+ThrowNullRef10:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %38
+ThrowNullRef12:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %42
+ThrowNullRef14:                                   ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %44
+ThrowNullRef16:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %68
+ThrowNullRef18:                                   ; preds = %68
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %70
+ThrowNullRef20:                                   ; preds = %70
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %73
+ThrowNullRef22:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %83
+ThrowNullRef24:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %85
+ThrowNullRef26:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %88
+ThrowNullRef28:                                   ; preds = %88
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %90
+ThrowNullRef30:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %94
+ThrowNullRef32:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %96
+ThrowNullRef34:                                   ; preds = %96
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %100
+ThrowNullRef36:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %102
+ThrowNullRef38:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %106
+ThrowNullRef40:                                   ; preds = %106
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %108
+ThrowNullRef42:                                   ; preds = %108
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef43:                                   ; preds = %112
+ThrowNullRef44:                                   ; preds = %112
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef45:                                   ; preds = %118
+ThrowNullRef46:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef47:                                   ; preds = %121
+ThrowNullRef48:                                   ; preds = %121
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef49:                                   ; preds = %123
+ThrowNullRef50:                                   ; preds = %123
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef51:                                   ; preds = %130
+ThrowNullRef52:                                   ; preds = %130
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef53:                                   ; preds = %132
+ThrowNullRef54:                                   ; preds = %132
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef55:                                   ; preds = %144
+ThrowNullRef56:                                   ; preds = %144
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef57:                                   ; preds = %146
+ThrowNullRef58:                                   ; preds = %146
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef59:                                   ; preds = %60
+ThrowNullRef60:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef61:                                   ; preds = %63
+ThrowNullRef62:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef63:                                   ; preds = %49
+ThrowNullRef64:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef65:                                   ; preds = %51
+ThrowNullRef66:                                   ; preds = %51
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef67:                                   ; preds = %53
+ThrowNullRef68:                                   ; preds = %53
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
-Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
+Successfully read StringBuilder.ThreadSafeCopy
+
+define void @StringBuilder.ThreadSafeCopy(%"System.Char[]" addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %arg0 = alloca %"System.Char[]" addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  store %"System.Char[]" addrspace(1)* %param0, %"System.Char[]" addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load i32, i32* %arg4
+  %1 = icmp sle i32 %0, 0
+  br i1 %1, label %43, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  %10 = icmp ugt i32 %3, %9
+  br i1 %10, label %38, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load i32, i32* %arg1
+  %13 = load i32, i32* %arg4
+  %14 = add i32 %12, %13
+  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %15, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
+
+; <label>:16                                      ; preds = %11
+  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %14, %20
+  br i1 %21, label %38, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg0
+  %24 = load i32, i32* %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %23, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %25
+
+; <label>:25                                      ; preds = %22
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = zext i32 %24 to i64
+  %BoundsCheck = icmp uge i64 %29, %28
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %23, i32 0, i32 3, i32 %24
+  store i16 addrspace(1)* %31, i16 addrspace(1)** %loc0
+  %32 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %33 = ptrtoint i16 addrspace(1)* %32 to i64
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %35 = load i32, i32* %arg3
+  %36 = load i32, i32* %arg4
+  %37 = inttoptr i64 %33 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %37, %"System.Char[]" addrspace(1)* %34, i32 %35, i32 %36)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  ret void
+
+; <label>:38                                      ; preds = %5, %16
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %entry
+  ret void
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Buffer::_Memmove using LLILCJit
 Successfully read Buffer._Memmove
 
@@ -7914,7 +9431,7 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
-Failed to read AppDomain.SetDataHelper[loadElem]
+Failed to read AppDomain.SetDataHelper[storeElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
 Successfully read AppDomain.get_LocalStore
 
@@ -7923,8 +9440,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
@@ -7934,8 +9451,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
@@ -7947,15 +9464,15 @@ entry:
   %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
   %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
-  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %17
 
 ; <label>:17                                      ; preds = %14
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
@@ -7966,15 +9483,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %14
+ThrowNullRef6:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7992,7 +9509,79 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
-Failed to read Dictionary`2.TryGetValue[loadElemA]
+Successfully read Dictionary`2.TryGetValue
+
+define i8 @"Dictionary`2.TryGetValue"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)* addrspace(1)* %param2) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  %arg2 = alloca %System.__Canon addrspace(1)* addrspace(1)*
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  store %System.__Canon addrspace(1)* addrspace(1)* %param2, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %1 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, %System.__Canon addrspace(1)* %1)
+  store i32 %2, i32* %loc0
+  %3 = load i32, i32* %loc0
+  %4 = icmp slt i32 %3, 0
+  br i1 %4, label %22, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7, i32 0, i32 2
+  %10 = load %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* addrspace(1)* %9, align 8
+  %11 = load i32, i32* %loc0
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = zext i32 %11 to i64
+  %BoundsCheck = icmp uge i64 %16, %15
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][]" addrspace(1)* %10, i32 0, i32 3, i32 %11
+  %NullCheck3 = icmp eq %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %20, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)*)*)(%System.__Canon addrspace(1)* addrspace(1)* %6, %System.__Canon addrspace(1)* %21)
+  ret i8 1
+
+; <label>:22                                      ; preds = %entry
+  %23 = load %System.__Canon addrspace(1)* addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %23, i32 0, i32 8)
+  ret i8 0
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -8058,8 +9647,8 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
@@ -8091,8 +9680,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
@@ -8171,15 +9760,15 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
-  br i1 %NullCheck, label %19, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %ThrowNullRef, label %19
 
 ; <label>:19                                      ; preds = %17
   %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
   %21 = load i32, i32 addrspace(1)* %20
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %23
 
 ; <label>:23                                      ; preds = %19
   %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
@@ -8202,7 +9791,7 @@ ThrowNullRef:                                     ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %19
+ThrowNullRef2:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8248,8 +9837,8 @@ entry:
   %0 = alloca %System.AppDomainHandle
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %1 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %1, i32 0, i32 15
@@ -8269,8 +9858,8 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
-  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %12
   %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
@@ -8286,7 +9875,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -8299,8 +9888,8 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -8327,8 +9916,8 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
@@ -8352,8 +9941,8 @@ entry:
   %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
   store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
@@ -8363,8 +9952,8 @@ entry:
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
@@ -8374,8 +9963,8 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
-  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %16
 
 ; <label>:16                                      ; preds = %9
   %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
@@ -8384,8 +9973,8 @@ entry:
 
 ; <label>:18                                      ; preds = %3, %16
   %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %18
   %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
@@ -8397,15 +9986,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %18
+ThrowNullRef6:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8418,8 +10007,8 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
@@ -8453,15 +10042,15 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
   %3 = load i32, i32 addrspace(1)* %2, align 8
   %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
@@ -8473,7 +10062,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8481,7 +10070,7 @@ ThrowNullRef1:                                    ; preds = %1
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
 Failed to read Dictionary`2.System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator[Call HasTypeArg]
 INFO:  jitting method Enumerator::MoveNext using LLILCJit
-Failed to read Enumerator.MoveNext[loadElemA]
+Failed to read Enumerator.MoveNext[Call HasTypeArg]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
@@ -8506,8 +10095,8 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
@@ -8524,8 +10113,8 @@ entry:
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -8544,7 +10133,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8577,8 +10166,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = load i64, i64* %arg2
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = trunc i32 %3 to i8
@@ -8634,46 +10223,46 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
   %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
   %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
-  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
-  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
-  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
-  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %22
 
 ; <label>:22                                      ; preds = %20
   %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
@@ -8684,27 +10273,27 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %17
+ThrowNullRef10:                                   ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %20
+ThrowNullRef12:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8717,8 +10306,8 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
@@ -8756,22 +10345,22 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
   %9 = load i64, i64 addrspace(1)* %8, align 8
   %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
   %13 = load i64, i64 addrspace(1)* %12, align 8
   %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %11
   %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
@@ -8788,11 +10377,11 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %7
+ThrowNullRef2:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %11
+ThrowNullRef4:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8882,8 +10471,8 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
@@ -8900,8 +10489,8 @@ entry:
 ; <label>:8                                       ; preds = %1
   %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
   %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
@@ -8911,15 +10500,15 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %15
   %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
   %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
   %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
-  br i1 %NullCheck6, label %21, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %21
 
 ; <label>:21                                      ; preds = %17
   %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
@@ -8946,15 +10535,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %15
+ThrowNullRef4:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8992,15 +10581,15 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
   store i8 %3, i8 addrspace(1)* %5
   %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
@@ -9011,7 +10600,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9027,8 +10616,8 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
@@ -9041,8 +10630,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
@@ -9058,7 +10647,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9080,8 +10669,8 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
@@ -9096,8 +10685,8 @@ entry:
 ; <label>:12                                      ; preds = %6
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
-  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
@@ -9112,8 +10701,8 @@ entry:
 ; <label>:21                                      ; preds = %15
   %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
-  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %22, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %24
 
 ; <label>:24                                      ; preds = %21
   %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
@@ -9128,8 +10717,8 @@ entry:
 ; <label>:30                                      ; preds = %24
   %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.String addrspace(1)* %31, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
@@ -9144,8 +10733,8 @@ entry:
 ; <label>:39                                      ; preds = %33
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
-  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.String addrspace(1)* %40, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %42
 
 ; <label>:42                                      ; preds = %39
   %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
@@ -9164,19 +10753,19 @@ ThrowNullRef:                                     ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %12
+ThrowNullRef2:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %21
+ThrowNullRef4:                                    ; preds = %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %30
+ThrowNullRef6:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %39
+ThrowNullRef8:                                    ; preds = %39
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9243,8 +10832,8 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
@@ -9264,57 +10853,57 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
   store i8 0, i8 addrspace(1)* %2
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
-  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
-  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
   store i8 0, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %16
 
 ; <label>:16                                      ; preds = %13
   %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
   store i8 0, i8 addrspace(1)* %17
   %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
-  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
   store i8 0, i8 addrspace(1)* %20
   %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
-  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
@@ -9325,31 +10914,31 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %4
+ThrowNullRef4:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %7
+ThrowNullRef6:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %10
+ThrowNullRef8:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %13
+ThrowNullRef10:                                   ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %16
+ThrowNullRef12:                                   ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %19
+ThrowNullRef14:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9367,8 +10956,8 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
@@ -9380,8 +10969,8 @@ entry:
 
 ; <label>:9                                       ; preds = %4
   %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
-  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %11
 
 ; <label>:11                                      ; preds = %9
   %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
@@ -9395,7 +10984,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef2:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9420,8 +11009,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
@@ -9512,8 +11101,8 @@ entry:
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
@@ -9524,8 +11113,8 @@ entry:
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = load i64, i64 addrspace(1)* %12
@@ -9537,8 +11126,8 @@ entry:
   %20 = load i64, i64* %19
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
-  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %13
   %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
@@ -9555,8 +11144,8 @@ entry:
 ; <label>:30                                      ; preds = %25
   %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %32 = load i32, i32* %arg2
-  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
-  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %33
 
 ; <label>:33                                      ; preds = %30
   %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
@@ -9570,15 +11159,15 @@ ThrowNullRef:                                     ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %30
+ThrowNullRef2:                                    ; preds = %30
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %13
+ThrowNullRef6:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9622,87 +11211,87 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
   %10 = load i8, i8 addrspace(1)* %9, align 8
   %11 = zext i8 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %8
   %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
   store i8 %12, i8 addrspace(1)* %14
   %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
   %19 = load i8, i8 addrspace(1)* %18, align 8
   %20 = zext i8 %19 to i32
   %21 = trunc i32 %20 to i8
-  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
-  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %22
 
 ; <label>:22                                      ; preds = %17
   %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
   store i8 %21, i8 addrspace(1)* %23
   %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %22
   %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
   %28 = load i8, i8 addrspace(1)* %27, align 8
   %29 = zext i8 %28 to i32
   %30 = trunc i32 %29 to i8
-  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
-  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %31
 
 ; <label>:31                                      ; preds = %26
   %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
   store i8 %30, i8 addrspace(1)* %32
   %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
-  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %35
 
 ; <label>:35                                      ; preds = %31
   %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
-  br i1 %NullCheck14, label %40, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %40
 
 ; <label>:40                                      ; preds = %35
   %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
   store i8 %39, i8 addrspace(1)* %41
   %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
-  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %44
 
 ; <label>:44                                      ; preds = %40
   %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
   %46 = load i8, i8 addrspace(1)* %45, align 8
   %47 = zext i8 %46 to i32
   %48 = trunc i32 %47 to i8
-  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
-  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %49
 
 ; <label>:49                                      ; preds = %44
   %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
   store i8 %48, i8 addrspace(1)* %50
   %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
-  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %52
 
 ; <label>:52                                      ; preds = %49
   %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
@@ -9713,29 +11302,29 @@ entry:
 ; <label>:56                                      ; preds = %52
   %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
-  br i1 %NullCheck22, label %59, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %59
 
 ; <label>:59                                      ; preds = %56
   %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
   %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
   %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
-  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
-  br i1 %NullCheck24, label %63, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %63
 
 ; <label>:63                                      ; preds = %59
   %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
   %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
-  br i1 %NullCheck26, label %66, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %66
 
 ; <label>:66                                      ; preds = %63
   %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
   %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
-  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
-  br i1 %NullCheck28, label %69, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %69
 
 ; <label>:69                                      ; preds = %66
   %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
@@ -9744,15 +11333,15 @@ entry:
 
 ; <label>:71                                      ; preds = %105
   %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
-  br i1 %NullCheck34, label %73, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %73
 
 ; <label>:73                                      ; preds = %71
   %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
   %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
   %76 = load i32, i32* %loc0
-  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
-  br i1 %NullCheck36, label %77, label %ThrowNullRef35
+  %NullCheck35 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %77
 
 ; <label>:77                                      ; preds = %73
   %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
@@ -9766,8 +11355,8 @@ entry:
 
 ; <label>:83                                      ; preds = %77
   %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
-  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %85
 
 ; <label>:85                                      ; preds = %83
   %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
@@ -9775,14 +11364,14 @@ entry:
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
   %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
-  br i1 %NullCheck40, label %91, label %ThrowNullRef39
+  %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
 ; <label>:91                                      ; preds = %85
   %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
   %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
-  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck42, label %94, label %ThrowNullRef41
+  %NullCheck41 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck41, label %ThrowNullRef42, label %94
 
 ; <label>:94                                      ; preds = %91
   %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
@@ -9798,14 +11387,14 @@ entry:
 ; <label>:99                                      ; preds = %69, %96
   %100 = load i32, i32* %loc0
   %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
-  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %102
 
 ; <label>:102                                     ; preds = %99
   %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
   %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
-  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
-  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %105
 
 ; <label>:105                                     ; preds = %102
   %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
@@ -9819,87 +11408,87 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %17
+ThrowNullRef6:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %22
+ThrowNullRef8:                                    ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %26
+ThrowNullRef10:                                   ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %31
+ThrowNullRef12:                                   ; preds = %31
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %35
+ThrowNullRef14:                                   ; preds = %35
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %40
+ThrowNullRef16:                                   ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %44
+ThrowNullRef18:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %49
+ThrowNullRef20:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %56
+ThrowNullRef22:                                   ; preds = %56
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %59
+ThrowNullRef24:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %63
+ThrowNullRef26:                                   ; preds = %63
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %66
+ThrowNullRef28:                                   ; preds = %66
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %102
+ThrowNullRef32:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %71
+ThrowNullRef34:                                   ; preds = %71
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %73
+ThrowNullRef36:                                   ; preds = %73
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %83
+ThrowNullRef38:                                   ; preds = %83
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %85
+ThrowNullRef40:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef41:                                   ; preds = %91
+ThrowNullRef42:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9943,15 +11532,15 @@ entry:
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %2
   %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
   %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
@@ -9961,28 +11550,28 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %9
   %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
   %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
   %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
-  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %16
 
 ; <label>:16                                      ; preds = %12
   %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
   %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
-  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
-  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
   %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
-  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
-  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %22
 
 ; <label>:22                                      ; preds = %19
   %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
@@ -9993,23 +11582,23 @@ ThrowNullRef:                                     ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %12
+ThrowNullRef6:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %16
+ThrowNullRef8:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %19
+ThrowNullRef10:                                   ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10031,15 +11620,15 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
   %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = load i64, i64 addrspace(1)* %7
@@ -10077,13 +11666,13 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
-Failed to read SecurityManager.GetSpecialFlags[loadElem]
+Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
 Failed to read List`1..ctor[non-const derefAddress]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
@@ -10111,8 +11700,8 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
@@ -10152,7 +11741,7 @@ entry:
 }
 
 INFO:  jitting method Simple_Array_Test::Main using LLILCJit
-Failed to read Simple_Array_Test.Main[loadElem]
+Failed to read Simple_Array_Test.Main[storeElem]
 INFO:  jitting method Console::WriteLine using LLILCJit
 Successfully read Console.WriteLine
 
@@ -10163,8 +11752,8 @@ entry:
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -10298,8 +11887,8 @@ entry:
   store i64 %param0, i64* %arg0
   store i64 %param1, i64* %arg1
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
@@ -10307,8 +11896,8 @@ entry:
   %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
   %5 = load i16*, i16* addrspace(1)* %4, align 8
   %6 = addrspacecast i64* %arg1 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = bitcast i64 addrspace(1)* %6 to i8 addrspace(1)*
@@ -10324,7 +11913,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10358,8 +11947,8 @@ entry:
   %1 = load i32, i32* %arg1
   %2 = sext i32 %1 to i64
   %3 = inttoptr i64 %2 to i16*
-  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
@@ -10412,8 +12001,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, i32)*)(%System.IO.ConsoleStream addrspace(1)* %2, i32 %1)
   %3 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %4 = load i64, i64* %arg1
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
@@ -10424,8 +12013,8 @@ entry:
   %10 = icmp eq i32 %9, 3
   %11 = sext i1 %10 to i32
   %12 = trunc i32 %11 to i8
-  %NullCheck2 = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %5
   %14 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, i32 0, i32 5
@@ -10436,7 +12025,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10459,8 +12048,8 @@ entry:
   %5 = icmp eq i32 %4, 1
   %6 = sext i1 %5 to i32
   %7 = trunc i32 %6 to i8
-  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %2, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.ConsoleStream addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %entry
   %9 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
@@ -10471,8 +12060,8 @@ entry:
   %13 = icmp eq i32 %12, 2
   %14 = sext i1 %13 to i32
   %15 = trunc i32 %14 to i8
-  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %10, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.ConsoleStream addrspace(1)* %10, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %8
   %17 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %10, i32 0, i32 4
@@ -10483,7 +12072,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef2:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10522,8 +12111,8 @@ entry:
   %arg0 = alloca i64
   store i64 %param0, i64* %arg0
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
@@ -10558,8 +12147,8 @@ entry:
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
   %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
   %9 = load i64, i64 addrspace(1)* %7
@@ -10663,7 +12252,127 @@ entry:
 INFO:  jitting method Encoding::GetEncoding using LLILCJit
 Failed to read Encoding.GetEncoding[convertToHelperArgumentType]
 INFO:  jitting method EncodingProvider::GetEncodingFromProvider using LLILCJit
-Failed to read EncodingProvider.GetEncodingFromProvider[loadElem]
+Successfully read EncodingProvider.GetEncodingFromProvider
+
+define %System.Text.Encoding addrspace(1)* @EncodingProvider.GetEncodingFromProvider(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca %"System.Text.EncodingProvider[]" addrspace(1)*
+  %loc1 = alloca %System.Text.EncodingProvider addrspace(1)*
+  %loc2 = alloca %System.Text.Encoding addrspace(1)*
+  %loc3 = alloca %System.Text.Encoding addrspace(1)*
+  %loc4 = alloca %"System.Text.EncodingProvider[]" addrspace(1)*
+  %loc5 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1059)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2392
+  %2 = addrspacecast i8 addrspace(1)* %1 to %"System.Text.EncodingProvider[]" addrspace(1)**
+  %3 = load volatile %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %2
+  %4 = icmp ne %"System.Text.EncodingProvider[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %entry
+  ret %System.Text.Encoding addrspace(1)* null
+
+; <label>:6                                       ; preds = %entry
+  %7 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1059)
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i64 2392
+  %9 = addrspacecast i8 addrspace(1)* %8 to %"System.Text.EncodingProvider[]" addrspace(1)**
+  %10 = load volatile %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %9
+  store %"System.Text.EncodingProvider[]" addrspace(1)* %10, %"System.Text.EncodingProvider[]" addrspace(1)** %loc0
+  %11 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc0
+  store %"System.Text.EncodingProvider[]" addrspace(1)* %11, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  store i32 0, i32* %loc5
+  br label %43
+
+; <label>:12                                      ; preds = %46
+  %13 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  %14 = load i32, i32* %loc5
+  %NullCheck1 = icmp eq %"System.Text.EncodingProvider[]" addrspace(1)* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %15
+
+; <label>:15                                      ; preds = %12
+  %16 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %13, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = zext i32 %17 to i64
+  %19 = zext i32 %14 to i64
+  %BoundsCheck = icmp uge i64 %19, %18
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %20
+
+; <label>:20                                      ; preds = %15
+  %21 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %13, i32 0, i32 3, i32 %14
+  %22 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)* addrspace(1)* %21, align 8
+  store %System.Text.EncodingProvider addrspace(1)* %22, %System.Text.EncodingProvider addrspace(1)** %loc1
+  %23 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)** %loc1
+  %24 = load i32, i32* %arg0
+  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i64 addrspace(1)*
+  %NullCheck3 = icmp eq i64 addrspace(1)* %25, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %26
+
+; <label>:26                                      ; preds = %20
+  %27 = load i64, i64 addrspace(1)* %25
+  %28 = add i64 %27, 64
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 40
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Text.Encoding addrspace(1)* (%System.Text.EncodingProvider addrspace(1)*, i32)*
+  %35 = call %System.Text.Encoding addrspace(1)* %34(%System.Text.EncodingProvider addrspace(1)* %23, i32 %24)
+  store %System.Text.Encoding addrspace(1)* %35, %System.Text.Encoding addrspace(1)** %loc2
+  %36 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc2
+  %37 = icmp eq %System.Text.Encoding addrspace(1)* %36, null
+  br i1 %37, label %40, label %38
+
+; <label>:38                                      ; preds = %26
+  %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc2
+  store %System.Text.Encoding addrspace(1)* %39, %System.Text.Encoding addrspace(1)** %loc3
+  br label %53
+
+; <label>:40                                      ; preds = %26
+  %41 = load i32, i32* %loc5
+  %42 = add i32 %41, 1
+  store i32 %42, i32* %loc5
+  br label %43
+
+; <label>:43                                      ; preds = %6, %40
+  %44 = load i32, i32* %loc5
+  %45 = load %"System.Text.EncodingProvider[]" addrspace(1)*, %"System.Text.EncodingProvider[]" addrspace(1)** %loc4
+  %NullCheck = icmp eq %"System.Text.EncodingProvider[]" addrspace(1)* %45, null
+  br i1 %NullCheck, label %ThrowNullRef, label %46
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %"System.Text.EncodingProvider[]", %"System.Text.EncodingProvider[]" addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = zext i32 %48 to i64
+  %50 = trunc i64 %49 to i32
+  %51 = icmp slt i32 %44, %50
+  br i1 %51, label %12, label %52
+
+; <label>:52                                      ; preds = %46
+  ret %System.Text.Encoding addrspace(1)* null
+
+; <label>:53                                      ; preds = %38
+  %54 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %loc3
+  ret %System.Text.Encoding addrspace(1)* %54
+
+ThrowNullRef:                                     ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method EncodingProvider::.cctor using LLILCJit
 Successfully read EncodingProvider..cctor
 
@@ -10682,7 +12391,7 @@ Failed to read Encoding.get_InternalSyncObject[Call HasTypeArg]
 INFO:  jitting method Hashtable::.ctor using LLILCJit
 Failed to read Hashtable..ctor[Volatile store]
 INFO:  jitting method Hashtable::get_Item using LLILCJit
-Failed to read Hashtable.get_Item[loadElemA]
+Failed to read Hashtable.get_Item[loadNonPrimitiveObj]
 INFO:  jitting method Hashtable::InitHash using LLILCJit
 Successfully read Hashtable.InitHash
 
@@ -10702,8 +12411,8 @@ entry:
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load i64, i64 addrspace(1)* %2
@@ -10719,15 +12428,15 @@ entry:
   store i32 %13, i32* %loc0
   %14 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
   %15 = load i32, i32* %loc0
-  %NullCheck2 = icmp ne i32 addrspace(1)* %14, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i32 addrspace(1)* %14, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %16
 
 ; <label>:16                                      ; preds = %3
   store i32 %15, i32 addrspace(1)* %14, align 8
   %17 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
   %18 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %NullCheck4 = icmp ne i32 addrspace(1)* %18, null
-  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i32 addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %19
 
 ; <label>:19                                      ; preds = %16
   %20 = load i32, i32 addrspace(1)* %18, align 8
@@ -10736,8 +12445,8 @@ entry:
   %23 = sub i32 %22, 1
   %24 = urem i32 %21, %23
   %25 = add i32 1, %24
-  %NullCheck6 = icmp ne i32 addrspace(1)* %17, null
-  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i32 addrspace(1)* %17, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %26
 
 ; <label>:26                                      ; preds = %19
   store i32 %25, i32 addrspace(1)* %17, align 8
@@ -10748,15 +12457,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %3
+ThrowNullRef2:                                    ; preds = %3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %16
+ThrowNullRef4:                                    ; preds = %16
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %19
+ThrowNullRef6:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10771,8 +12480,8 @@ entry:
   store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
   store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %NullCheck = icmp ne %System.Collections.Hashtable addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Collections.Hashtable addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
@@ -10782,16 +12491,16 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Collections.Hashtable addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Collections.Hashtable addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
   %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck4 = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %9, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
   %13 = inttoptr i64 %11 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
@@ -10801,8 +12510,8 @@ entry:
 ; <label>:15                                      ; preds = %1
   %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %17, null
-  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %17, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = load i64, i64 addrspace(1)* %17
@@ -10820,15 +12529,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10842,8 +12551,8 @@ entry:
   store %System.Int32 addrspace(1)* %param0, %System.Int32 addrspace(1)** %this
   %0 = load %System.Int32 addrspace(1)*, %System.Int32 addrspace(1)** %this
   %1 = bitcast %System.Int32 addrspace(1)* %0 to i32 addrspace(1)*
-  %NullCheck = icmp ne i32 addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq i32 addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load i32, i32 addrspace(1)* %1, align 8
@@ -10919,8 +12628,8 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %2, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.UTF8Encoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
@@ -10929,15 +12638,15 @@ entry:
   %9 = load i8, i8* %arg2
   %10 = zext i8 %9 to i32
   %11 = trunc i32 %10 to i8
-  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %8, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %8, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
 
 ; <label>:12                                      ; preds = %6
   %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %8, i32 0, i32 8
   store i8 %11, i8 addrspace(1)* %13
   %14 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %14, null
-  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %14, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %15
 
 ; <label>:15                                      ; preds = %12
   %16 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %14, i32 0, i32 8
@@ -10949,8 +12658,8 @@ entry:
 ; <label>:20                                      ; preds = %15
   %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %22, null
-  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %22, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
   %24 = load i64, i64 addrspace(1)* %22
@@ -10972,15 +12681,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %12
+ThrowNullRef4:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %20
+ThrowNullRef6:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10995,8 +12704,8 @@ entry:
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
@@ -11018,16 +12727,16 @@ entry:
 ; <label>:10                                      ; preds = %1
   %11 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
   %12 = load i32, i32* %arg1
-  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %11, null
-  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.Encoding addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %13
 
 ; <label>:13                                      ; preds = %10
   %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
   store i32 %12, i32 addrspace(1)* %14
   %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
   %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = load i64, i64 addrspace(1)* %16
@@ -11045,11 +12754,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %10
+ThrowNullRef2:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %13
+ThrowNullRef4:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11062,8 +12771,8 @@ entry:
   %this = alloca %System.Text.UTF8Encoding addrspace(1)*
   store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
   %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.UTF8Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
@@ -11075,16 +12784,16 @@ entry:
 ; <label>:6                                       ; preds = %1
   %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %8 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %7, null
-  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %9
 
 ; <label>:9                                       ; preds = %6
   %10 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %10, %System.Text.EncoderFallback addrspace(1)* %8)
   %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %12 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
-  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %11, null
-  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
   %14 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %11, i32 0, i32 3
@@ -11097,8 +12806,8 @@ entry:
   %18 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %18, %System.String addrspace(1)* %17)
   %19 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %18 to %System.Text.EncoderFallback addrspace(1)*
-  %NullCheck6 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %16, null
-  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %16, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
   %21 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %16, i32 0, i32 2
@@ -11108,8 +12817,8 @@ entry:
   %24 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %24, %System.String addrspace(1)* %23)
   %25 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %24 to %System.Text.DecoderFallback addrspace(1)*
-  %NullCheck8 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %22, null
-  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.Text.UTF8Encoding addrspace(1)* %22, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %26
 
 ; <label>:26                                      ; preds = %20
   %27 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %22, i32 0, i32 3
@@ -11120,19 +12829,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %9
+ThrowNullRef4:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %15
+ThrowNullRef6:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %20
+ThrowNullRef8:                                    ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11162,8 +12871,8 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load i32, i32* %arg1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp eq %System.String addrspace(1)* %7, null
+  br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %5
   %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
@@ -11181,8 +12890,8 @@ entry:
 ; <label>:15                                      ; preds = %8
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %17 = load i32, i32* %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
   %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 %17
@@ -11198,7 +12907,7 @@ ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %15
+ThrowNullRef2:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11250,7 +12959,7 @@ entry:
 }
 
 INFO:  jitting method Hashtable::Insert using LLILCJit
-Failed to read Hashtable.Insert[loadElemA]
+Failed to read Hashtable.Insert[storeElem]
 INFO:  jitting method ConsoleEncoding::.ctor using LLILCJit
 Successfully read ConsoleEncoding..ctor
 
@@ -11265,8 +12974,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %1)
   %2 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
@@ -11302,8 +13011,8 @@ entry:
   %2 = call %System.Text.InternalEncoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalEncoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %1)
   %3 = bitcast %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2 to %System.Text.EncoderFallback addrspace(1)*
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
@@ -11313,8 +13022,8 @@ entry:
   %8 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %7)
   %9 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %8 to %System.Text.DecoderFallback addrspace(1)*
-  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %6, null
-  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.Encoding addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %10
 
 ; <label>:10                                      ; preds = %4
   %11 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %6, i32 0, i32 3
@@ -11325,7 +13034,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11344,15 +13053,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* %1)
   %2 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   %6 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %4
   %8 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, i32 0, i32 1
@@ -11363,7 +13072,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11391,8 +13100,8 @@ entry:
   store %System.Text.InternalDecoderBestFitFallback addrspace(1)* %param0, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
   %0 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
@@ -11402,15 +13111,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %4)
   %5 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %6)
   %9 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %7
   %11 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, i32 0, i32 1
@@ -11421,11 +13130,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11493,8 +13202,8 @@ entry:
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
   %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %19, null
+  br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
   %21 = load i64, i64 addrspace(1)* %19
@@ -11558,8 +13267,8 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.ConsoleStream addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
@@ -11590,31 +13299,31 @@ entry:
   store i8 %param4, i8* %arg4
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %3, %System.IO.Stream addrspace(1)* %1)
   %4 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %4, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
   %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %4, i32 0, i32 4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %5)
   %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %6
   %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
   %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
   %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = load i64, i64 addrspace(1)* %13
@@ -11626,8 +13335,8 @@ entry:
   %21 = load i64, i64* %20
   %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %8, null
-  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %8, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %24
 
 ; <label>:24                                      ; preds = %14
   %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 5
@@ -11645,24 +13354,24 @@ entry:
   %31 = load i32, i32* %arg3
   %32 = sext i32 %31 to i64
   %33 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %32)
-  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %30, null
-  br i1 %NullCheck10, label %34, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.StreamWriter addrspace(1)* %30, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %34
 
 ; <label>:34                                      ; preds = %29
   %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %35, %"System.Char[]" addrspace(1)* %33)
   %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %37, null
-  br i1 %NullCheck12, label %38, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.StreamWriter addrspace(1)* %37, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %38
 
 ; <label>:38                                      ; preds = %34
   %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
   %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
   %41 = load i32, i32* %arg3
   %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
-  %NullCheck14 = icmp ne i64 addrspace(1)* %42, null
-  br i1 %NullCheck14, label %43, label %ThrowNullRef13
+  %NullCheck13 = icmp eq i64 addrspace(1)* %42, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
   %44 = load i64, i64 addrspace(1)* %42
@@ -11676,30 +13385,30 @@ entry:
   %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
   %53 = sext i32 %52 to i64
   %54 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %53)
-  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
-  br i1 %NullCheck16, label %55, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %55
 
 ; <label>:55                                      ; preds = %43
   %56 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %56, %"System.Byte[]" addrspace(1)* %54)
   %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %58 = load i32, i32* %arg3
-  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %57, null
-  br i1 %NullCheck18, label %59, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.StreamWriter addrspace(1)* %57, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %59
 
 ; <label>:59                                      ; preds = %55
   %60 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 10
   store i32 %58, i32 addrspace(1)* %60
   %61 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %61, null
-  br i1 %NullCheck20, label %62, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.IO.StreamWriter addrspace(1)* %61, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %62
 
 ; <label>:62                                      ; preds = %59
   %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
   %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
   %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
-  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
-  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
   %67 = load i64, i64 addrspace(1)* %65
@@ -11717,15 +13426,15 @@ entry:
 
 ; <label>:78                                      ; preds = %66
   %79 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %79, null
-  br i1 %NullCheck24, label %80, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.StreamWriter addrspace(1)* %79, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %80
 
 ; <label>:80                                      ; preds = %78
   %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
   %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
   %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
-  %NullCheck26 = icmp ne i64 addrspace(1)* %83, null
-  br i1 %NullCheck26, label %84, label %ThrowNullRef25
+  %NullCheck25 = icmp eq i64 addrspace(1)* %83, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
   %85 = load i64, i64 addrspace(1)* %83
@@ -11742,8 +13451,8 @@ entry:
 
 ; <label>:95                                      ; preds = %84
   %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck28 = icmp ne %System.IO.StreamWriter addrspace(1)* %96, null
-  br i1 %NullCheck28, label %97, label %ThrowNullRef27
+  %NullCheck27 = icmp eq %System.IO.StreamWriter addrspace(1)* %96, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %97
 
 ; <label>:97                                      ; preds = %95
   %98 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 12
@@ -11757,8 +13466,8 @@ entry:
   %103 = icmp eq i32 %102, 0
   %104 = sext i1 %103 to i32
   %105 = trunc i32 %104 to i8
-  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %100, null
-  br i1 %NullCheck30, label %106, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.IO.StreamWriter addrspace(1)* %100, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %106
 
 ; <label>:106                                     ; preds = %99
   %107 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %100, i32 0, i32 13
@@ -11769,63 +13478,63 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %6
+ThrowNullRef4:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %14
+ThrowNullRef8:                                    ; preds = %14
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %29
+ThrowNullRef10:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %34
+ThrowNullRef12:                                   ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %38
+ThrowNullRef14:                                   ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %43
+ThrowNullRef16:                                   ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %55
+ThrowNullRef18:                                   ; preds = %55
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %59
+ThrowNullRef20:                                   ; preds = %59
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %62
+ThrowNullRef22:                                   ; preds = %62
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %78
+ThrowNullRef24:                                   ; preds = %78
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %80
+ThrowNullRef26:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %95
+ThrowNullRef28:                                   ; preds = %95
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %99
+ThrowNullRef30:                                   ; preds = %99
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11838,15 +13547,15 @@ entry:
   %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %4, null
-  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %4, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
   %6 = load i64, i64 addrspace(1)* %4
@@ -11864,7 +13573,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11914,35 +13623,35 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
   %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %2, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderNLS addrspace(1)* %2, null
+  br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %7 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.EncoderNLS addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
   %9 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %7, i32 0, i32 3
   %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %9, align 8
-  %NullCheck4 = icmp ne %System.Text.Encoding addrspace(1)* %10, null
-  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.Encoding addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
 
 ; <label>:11                                      ; preds = %8
   %12 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %10)
-  %NullCheck6 = icmp ne %System.Text.EncoderNLS addrspace(1)* %6, null
-  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.Text.EncoderNLS addrspace(1)* %6, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
 
 ; <label>:13                                      ; preds = %11
   %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
   %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck8 = icmp ne i64 addrspace(1)* %16, null
-  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+  %NullCheck7 = icmp eq i64 addrspace(1)* %16, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
   %18 = load i64, i64 addrspace(1)* %16
@@ -11961,19 +13670,19 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef2:                                    ; preds = %4
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %11
+ThrowNullRef6:                                    ; preds = %11
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %13
+ThrowNullRef8:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -11999,8 +13708,8 @@ entry:
   %this = alloca %System.Text.Encoding addrspace(1)*
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
@@ -12020,15 +13729,15 @@ entry:
   %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
   store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
   %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
   store i32 0, i32 addrspace(1)* %2
   %3 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck2 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, i32 0, i32 2
@@ -12038,15 +13747,15 @@ entry:
 
 ; <label>:8                                       ; preds = %4
   %9 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %NullCheck4 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
-  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %10
 
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
   %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
   %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
-  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
   %15 = load i64, i64 addrspace(1)* %13
@@ -12067,15 +13776,15 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %8
+ThrowNullRef4:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %10
+ThrowNullRef6:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12090,16 +13799,16 @@ entry:
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = load i32, i32* %arg1
   %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
-  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
   %7 = load i64, i64 addrspace(1)* %5
@@ -12117,7 +13826,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12154,8 +13863,8 @@ entry:
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
   %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
   %16 = load i64, i64 addrspace(1)* %14
@@ -12176,8 +13885,8 @@ entry:
   %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
   %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
   %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %31, null
-  br i1 %NullCheck2, label %32, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %31, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
   %33 = load i64, i64 addrspace(1)* %31
@@ -12220,7 +13929,7 @@ ThrowNullRef:                                     ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %26
+ThrowNullRef2:                                    ; preds = %26
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12233,14 +13942,14 @@ entry:
   %this = alloca %System.Text.EncoderReplacementFallback addrspace(1)*
   store %System.Text.EncoderReplacementFallback addrspace(1)* %param0, %System.Text.EncoderReplacementFallback addrspace(1)** %this
   %0 = load %System.Text.EncoderReplacementFallback addrspace(1)*, %System.Text.EncoderReplacementFallback addrspace(1)** %this
-  %NullCheck = icmp ne %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %4
 
 ; <label>:4                                       ; preds = %1
   %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
@@ -12251,7 +13960,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12281,8 +13990,8 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %1, null
-  br i1 %NullCheck, label %5, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
@@ -12314,8 +14023,8 @@ entry:
   %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
   store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
@@ -12327,8 +14036,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1
   %7 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %NullCheck2 = icmp ne %System.Threading.Tasks.Task addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %7)
@@ -12351,7 +14060,7 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12370,8 +14079,8 @@ entry:
   store i8 %param1, i8* %arg1
   store i8 %param2, i8* %arg2
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
@@ -12385,8 +14094,8 @@ entry:
 
 ; <label>:6                                       ; preds = %1, %5
   %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %7, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %6
   %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 9
@@ -12417,8 +14126,8 @@ entry:
 
 ; <label>:25                                      ; preds = %8, %20
   %26 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %26, null
-  br i1 %NullCheck4, label %27, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %26, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %27
 
 ; <label>:27                                      ; preds = %25
   %28 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %26, i32 0, i32 12
@@ -12429,22 +14138,22 @@ entry:
 
 ; <label>:32                                      ; preds = %27
   %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %33, null
-  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.IO.StreamWriter addrspace(1)* %33, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %34
 
 ; <label>:34                                      ; preds = %32
   %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 12
   store i8 1, i8 addrspace(1)* %35
   %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
-  br i1 %NullCheck8, label %37, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %37
 
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
   %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
   %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck10 = icmp ne i64 addrspace(1)* %40, null
-  br i1 %NullCheck10, label %41, label %ThrowNullRef9
+  %NullCheck9 = icmp eq i64 addrspace(1)* %40, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
   %42 = load i64, i64 addrspace(1)* %40
@@ -12458,8 +14167,8 @@ entry:
   %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
   store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
   %51 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %NullCheck12 = icmp ne %"System.Byte[]" addrspace(1)* %51, null
-  br i1 %NullCheck12, label %52, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %"System.Byte[]" addrspace(1)* %51, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %52
 
 ; <label>:52                                      ; preds = %41
   %53 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %51, i32 0, i32 1
@@ -12471,16 +14180,16 @@ entry:
 
 ; <label>:58                                      ; preds = %52
   %59 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %59, null
-  br i1 %NullCheck14, label %60, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.IO.StreamWriter addrspace(1)* %59, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %60
 
 ; <label>:60                                      ; preds = %58
   %61 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %59, i32 0, i32 3
   %62 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %61, align 8
   %63 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
   %64 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %NullCheck16 = icmp ne %"System.Byte[]" addrspace(1)* %64, null
-  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %"System.Byte[]" addrspace(1)* %64, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %65
 
 ; <label>:65                                      ; preds = %60
   %66 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %64, i32 0, i32 1
@@ -12488,8 +14197,8 @@ entry:
   %68 = zext i32 %67 to i64
   %69 = trunc i64 %68 to i32
   %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck18 = icmp ne i64 addrspace(1)* %70, null
-  br i1 %NullCheck18, label %71, label %ThrowNullRef17
+  %NullCheck17 = icmp eq i64 addrspace(1)* %70, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
   %72 = load i64, i64 addrspace(1)* %70
@@ -12505,29 +14214,29 @@ entry:
 
 ; <label>:80                                      ; preds = %27, %52, %71
   %81 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %81, null
-  br i1 %NullCheck20, label %82, label %ThrowNullRef19
+  %NullCheck19 = icmp eq %System.IO.StreamWriter addrspace(1)* %81, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %82
 
 ; <label>:82                                      ; preds = %80
   %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %81, i32 0, i32 5
   %84 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %83, align 8
   %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck22 = icmp ne %System.IO.StreamWriter addrspace(1)* %85, null
-  br i1 %NullCheck22, label %86, label %ThrowNullRef21
+  %NullCheck21 = icmp eq %System.IO.StreamWriter addrspace(1)* %85, null
+  br i1 %NullCheck21, label %ThrowNullRef22, label %86
 
 ; <label>:86                                      ; preds = %82
   %87 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 7
   %88 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %87, align 8
   %89 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %89, null
-  br i1 %NullCheck24, label %90, label %ThrowNullRef23
+  %NullCheck23 = icmp eq %System.IO.StreamWriter addrspace(1)* %89, null
+  br i1 %NullCheck23, label %ThrowNullRef24, label %90
 
 ; <label>:90                                      ; preds = %86
   %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %89, i32 0, i32 9
   %92 = load i32, i32 addrspace(1)* %91, align 8
   %93 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck26 = icmp ne %System.IO.StreamWriter addrspace(1)* %93, null
-  br i1 %NullCheck26, label %94, label %ThrowNullRef25
+  %NullCheck25 = icmp eq %System.IO.StreamWriter addrspace(1)* %93, null
+  br i1 %NullCheck25, label %ThrowNullRef26, label %94
 
 ; <label>:94                                      ; preds = %90
   %95 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %93, i32 0, i32 6
@@ -12535,8 +14244,8 @@ entry:
   %97 = load i8, i8* %arg2
   %98 = zext i8 %97 to i32
   %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
-  %NullCheck28 = icmp ne i64 addrspace(1)* %99, null
-  br i1 %NullCheck28, label %100, label %ThrowNullRef27
+  %NullCheck27 = icmp eq i64 addrspace(1)* %99, null
+  br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
   %101 = load i64, i64 addrspace(1)* %99
@@ -12551,8 +14260,8 @@ entry:
   %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
   store i32 %110, i32* %loc1
   %111 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %111, null
-  br i1 %NullCheck30, label %112, label %ThrowNullRef29
+  %NullCheck29 = icmp eq %System.IO.StreamWriter addrspace(1)* %111, null
+  br i1 %NullCheck29, label %ThrowNullRef30, label %112
 
 ; <label>:112                                     ; preds = %100
   %113 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %111, i32 0, i32 9
@@ -12563,23 +14272,23 @@ entry:
 
 ; <label>:116                                     ; preds = %112
   %117 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck32 = icmp ne %System.IO.StreamWriter addrspace(1)* %117, null
-  br i1 %NullCheck32, label %118, label %ThrowNullRef31
+  %NullCheck31 = icmp eq %System.IO.StreamWriter addrspace(1)* %117, null
+  br i1 %NullCheck31, label %ThrowNullRef32, label %118
 
 ; <label>:118                                     ; preds = %116
   %119 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %117, i32 0, i32 3
   %120 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %119, align 8
   %121 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck34 = icmp ne %System.IO.StreamWriter addrspace(1)* %121, null
-  br i1 %NullCheck34, label %122, label %ThrowNullRef33
+  %NullCheck33 = icmp eq %System.IO.StreamWriter addrspace(1)* %121, null
+  br i1 %NullCheck33, label %ThrowNullRef34, label %122
 
 ; <label>:122                                     ; preds = %118
   %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
   %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
   %125 = load i32, i32* %loc1
   %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
-  %NullCheck36 = icmp ne i64 addrspace(1)* %126, null
-  br i1 %NullCheck36, label %127, label %ThrowNullRef35
+  %NullCheck35 = icmp eq i64 addrspace(1)* %126, null
+  br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
   %128 = load i64, i64 addrspace(1)* %126
@@ -12601,15 +14310,15 @@ entry:
 
 ; <label>:140                                     ; preds = %136
   %141 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck38 = icmp ne %System.IO.StreamWriter addrspace(1)* %141, null
-  br i1 %NullCheck38, label %142, label %ThrowNullRef37
+  %NullCheck37 = icmp eq %System.IO.StreamWriter addrspace(1)* %141, null
+  br i1 %NullCheck37, label %ThrowNullRef38, label %142
 
 ; <label>:142                                     ; preds = %140
   %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
   %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
   %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
-  %NullCheck40 = icmp ne i64 addrspace(1)* %145, null
-  br i1 %NullCheck40, label %146, label %ThrowNullRef39
+  %NullCheck39 = icmp eq i64 addrspace(1)* %145, null
+  br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
   %147 = load i64, i64 addrspace(1)* %145
@@ -12630,83 +14339,83 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %6
+ThrowNullRef2:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %25
+ThrowNullRef4:                                    ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %32
+ThrowNullRef6:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %34
+ThrowNullRef8:                                    ; preds = %34
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %37
+ThrowNullRef10:                                   ; preds = %37
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %41
+ThrowNullRef12:                                   ; preds = %41
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %58
+ThrowNullRef14:                                   ; preds = %58
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %60
+ThrowNullRef16:                                   ; preds = %60
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %65
+ThrowNullRef18:                                   ; preds = %65
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef19:                                   ; preds = %80
+ThrowNullRef20:                                   ; preds = %80
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef21:                                   ; preds = %82
+ThrowNullRef22:                                   ; preds = %82
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef23:                                   ; preds = %86
+ThrowNullRef24:                                   ; preds = %86
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef25:                                   ; preds = %90
+ThrowNullRef26:                                   ; preds = %90
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef27:                                   ; preds = %94
+ThrowNullRef28:                                   ; preds = %94
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef29:                                   ; preds = %100
+ThrowNullRef30:                                   ; preds = %100
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef31:                                   ; preds = %116
+ThrowNullRef32:                                   ; preds = %116
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef33:                                   ; preds = %118
+ThrowNullRef34:                                   ; preds = %118
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef35:                                   ; preds = %122
+ThrowNullRef36:                                   ; preds = %122
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef37:                                   ; preds = %140
+ThrowNullRef38:                                   ; preds = %140
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef39:                                   ; preds = %142
+ThrowNullRef40:                                   ; preds = %142
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12773,8 +14482,8 @@ entry:
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %1 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
-  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
@@ -12782,8 +14491,8 @@ entry:
   %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
   %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
-  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
   %8 = load i64, i64 addrspace(1)* %6
@@ -12799,8 +14508,8 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %17, %System.IFormatProvider addrspace(1)* %16)
   %18 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %19 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %18, null
-  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.SyncTextWriter addrspace(1)* %18, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %20
 
 ; <label>:20                                      ; preds = %7
   %21 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %18, i32 0, i32 4
@@ -12811,11 +14520,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %2
+ThrowNullRef2:                                    ; preds = %2
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -12828,8 +14537,8 @@ entry:
   %this = alloca %System.IO.TextWriter addrspace(1)*
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.TextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
@@ -12839,8 +14548,8 @@ entry:
 
 ; <label>:5                                       ; preds = %1
   %6 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
-  %NullCheck2 = icmp ne %System.Threading.Thread addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Threading.Thread addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %5
   %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %6)
@@ -12849,8 +14558,8 @@ entry:
 
 ; <label>:10                                      ; preds = %1
   %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.TextWriter addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.TextWriter addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %10
   %13 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %11, i32 0, i32 2
@@ -12861,11 +14570,11 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %5
+ThrowNullRef2:                                    ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %10
+ThrowNullRef4:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13062,8 +14771,8 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   store i8 0, i8* %loc1
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
@@ -13073,16 +14782,16 @@ entry:
   %5 = addrspacecast i8* %loc1 to i8 addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %4, i8 addrspace(1)* %5)
   %6 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %6, null
-  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.SyncTextWriter addrspace(1)* %6, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %1
   %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
   %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
-  %NullCheck4 = icmp ne i64 addrspace(1)* %11, null
-  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+  %NullCheck3 = icmp eq i64 addrspace(1)* %11, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
   %13 = load i64, i64 addrspace(1)* %11
@@ -13117,19 +14826,229 @@ ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %1
+ThrowNullRef2:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %7
+ThrowNullRef4:                                    ; preds = %7
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
-Failed to read TextWriter.WriteLine[loadElem]
+Failed to read TextWriter.WriteLine[storeElem]
 INFO:  jitting method String::CopyTo using LLILCJit
-Failed to read String.CopyTo[loadElemA]
+Successfully read String.CopyTo
+
+define void @String.CopyTo(%System.String addrspace(1)* %param0, i32 %param1, %"System.Char[]" addrspace(1)* %param2, i32 %param3, i32 %param4) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca %"System.Char[]" addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i32
+  %loc0 = alloca i16 addrspace(1)*
+  %loc1 = alloca i16 addrspace(1)*
+  %loc2 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store %"System.Char[]" addrspace(1)* %param2, %"System.Char[]" addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i32 %param4, i32* %arg4
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %1 = icmp ne %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg4
+  %7 = icmp sge i32 %6, 0
+  br i1 %7, label %13, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  unreachable
+
+; <label>:13                                      ; preds = %5
+  %14 = load i32, i32* %arg1
+  %15 = icmp sge i32 %14, 0
+  br i1 %15, label %21, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %19 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %18)
+  %20 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %20, %System.String addrspace(1)* %17, %System.String addrspace(1)* %19)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %20) #0
+  unreachable
+
+; <label>:21                                      ; preds = %13
+  %22 = load i32, i32* %arg4
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck = icmp eq %System.String addrspace(1)* %23, null
+  br i1 %NullCheck, label %ThrowNullRef, label %24
+
+; <label>:24                                      ; preds = %21
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load i32, i32* %arg1
+  %28 = sub i32 %26, %27
+  %29 = icmp sle i32 %22, %28
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34, %System.String addrspace(1)* %31, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %24
+  %36 = load i32, i32* %arg3
+  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  %NullCheck1 = icmp eq %"System.Char[]" addrspace(1)* %37, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
+
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
+  %40 = load i32, i32 addrspace(1)* %39
+  %41 = zext i32 %40 to i64
+  %42 = trunc i64 %41 to i32
+  %43 = load i32, i32* %arg4
+  %44 = sub i32 %42, %43
+  %45 = icmp sgt i32 %36, %44
+  br i1 %45, label %49, label %46
+
+; <label>:46                                      ; preds = %38
+  %47 = load i32, i32* %arg3
+  %48 = icmp sge i32 %47, 0
+  br i1 %48, label %54, label %49
+
+; <label>:49                                      ; preds = %38, %46
+  %50 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %52 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %51)
+  %53 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53, %System.String addrspace(1)* %50, %System.String addrspace(1)* %52)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53) #0
+  unreachable
+
+; <label>:54                                      ; preds = %46
+  %55 = load i32, i32* %arg4
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %97, label %57
+
+; <label>:57                                      ; preds = %54
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck3 = icmp eq %System.String addrspace(1)* %58, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %59
+
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 2
+  %61 = bitcast [0 x i16] addrspace(1)* %60 to i16 addrspace(1)*
+  store i16 addrspace(1)* %61, i16 addrspace(1)** %loc0
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg2
+  store %"System.Char[]" addrspace(1)* %62, %"System.Char[]" addrspace(1)** %loc2
+  %63 = icmp eq %"System.Char[]" addrspace(1)* %62, null
+  br i1 %63, label %72, label %64
+
+; <label>:64                                      ; preds = %59
+  %65 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc2
+  %NullCheck5 = icmp eq %"System.Char[]" addrspace(1)* %65, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %66
+
+; <label>:66                                      ; preds = %64
+  %67 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %65, i32 0, i32 1
+  %68 = load i32, i32 addrspace(1)* %67
+  %69 = zext i32 %68 to i64
+  %70 = trunc i64 %69 to i32
+  %71 = icmp ne i32 %70, 0
+  br i1 %71, label %73, label %72
+
+; <label>:72                                      ; preds = %59, %66
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  br label %81
+
+; <label>:73                                      ; preds = %66
+  %74 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc2
+  %NullCheck7 = icmp eq %"System.Char[]" addrspace(1)* %74, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %75
+
+; <label>:75                                      ; preds = %73
+  %76 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %74, i32 0, i32 1
+  %77 = load i32, i32 addrspace(1)* %76
+  %78 = zext i32 %77 to i64
+  %BoundsCheck = icmp uge i64 0, %78
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %79
+
+; <label>:79                                      ; preds = %75
+  %80 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %74, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %80, i16 addrspace(1)** %loc1
+  br label %81
+
+; <label>:81                                      ; preds = %72, %79
+  %82 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %83 = ptrtoint i16 addrspace(1)* %82 to i64
+  %84 = load i32, i32* %arg3
+  %85 = sext i32 %84 to i64
+  %86 = mul i64 %85, 2
+  %87 = add i64 %83, %86
+  %88 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %89 = ptrtoint i16 addrspace(1)* %88 to i64
+  %90 = load i32, i32* %arg1
+  %91 = sext i32 %90 to i64
+  %92 = mul i64 %91, 2
+  %93 = add i64 %89, %92
+  %94 = load i32, i32* %arg4
+  %95 = inttoptr i64 %87 to i16*
+  %96 = inttoptr i64 %93 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %95, i16* %96, i32 %94)
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
+  br label %97
+
+; <label>:97                                      ; preds = %54, %81
+  ret void
+
+ThrowNullRef:                                     ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StreamWriter::Write using LLILCJit
 Successfully read StreamWriter.Write
 
@@ -13187,8 +15106,8 @@ entry:
 
 ; <label>:23                                      ; preds = %15
   %24 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Char[]" addrspace(1)* %24, null
-  br i1 %NullCheck, label %25, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %24, null
+  br i1 %NullCheck, label %ThrowNullRef, label %25
 
 ; <label>:25                                      ; preds = %23
   %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %24, i32 0, i32 1
@@ -13216,15 +15135,15 @@ entry:
 
 ; <label>:40                                      ; preds = %98
   %41 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %41, null
-  br i1 %NullCheck4, label %42, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.IO.StreamWriter addrspace(1)* %41, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %42
 
 ; <label>:42                                      ; preds = %40
   %43 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
   %44 = load i32, i32 addrspace(1)* %43, align 8
   %45 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %45, null
-  br i1 %NullCheck6, label %46, label %ThrowNullRef5
+  %NullCheck5 = icmp eq %System.IO.StreamWriter addrspace(1)* %45, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %46
 
 ; <label>:46                                      ; preds = %42
   %47 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %45, i32 0, i32 10
@@ -13239,15 +15158,15 @@ entry:
 
 ; <label>:52                                      ; preds = %46, %50
   %53 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %53, null
-  br i1 %NullCheck8, label %54, label %ThrowNullRef7
+  %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %53, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %54
 
 ; <label>:54                                      ; preds = %52
   %55 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %53, i32 0, i32 10
   %56 = load i32, i32 addrspace(1)* %55, align 8
   %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %57, null
-  br i1 %NullCheck10, label %58, label %ThrowNullRef9
+  %NullCheck9 = icmp eq %System.IO.StreamWriter addrspace(1)* %57, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %58
 
 ; <label>:58                                      ; preds = %54
   %59 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 9
@@ -13269,15 +15188,15 @@ entry:
   %69 = load i32, i32* %arg2
   %70 = mul i32 %69, 2
   %71 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %71, null
-  br i1 %NullCheck12, label %72, label %ThrowNullRef11
+  %NullCheck11 = icmp eq %System.IO.StreamWriter addrspace(1)* %71, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %72
 
 ; <label>:72                                      ; preds = %67
   %73 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %71, i32 0, i32 7
   %74 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %73, align 8
   %75 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %75, null
-  br i1 %NullCheck14, label %76, label %ThrowNullRef13
+  %NullCheck13 = icmp eq %System.IO.StreamWriter addrspace(1)* %75, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %76
 
 ; <label>:76                                      ; preds = %72
   %77 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %75, i32 0, i32 9
@@ -13289,16 +15208,16 @@ entry:
   %83 = bitcast %"System.Char[]" addrspace(1)* %74 to %System.Array addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %82, i32 %70, %System.Array addrspace(1)* %83, i32 %79, i32 %81)
   %84 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %84, null
-  br i1 %NullCheck16, label %85, label %ThrowNullRef15
+  %NullCheck15 = icmp eq %System.IO.StreamWriter addrspace(1)* %84, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %85
 
 ; <label>:85                                      ; preds = %76
   %86 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %84, i32 0, i32 9
   %87 = load i32, i32 addrspace(1)* %86, align 8
   %88 = load i32, i32* %loc0
   %89 = add i32 %87, %88
-  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %84, null
-  br i1 %NullCheck18, label %90, label %ThrowNullRef17
+  %NullCheck17 = icmp eq %System.IO.StreamWriter addrspace(1)* %84, null
+  br i1 %NullCheck17, label %ThrowNullRef18, label %90
 
 ; <label>:90                                      ; preds = %85
   %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %84, i32 0, i32 9
@@ -13320,8 +15239,8 @@ entry:
 
 ; <label>:101                                     ; preds = %98
   %102 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %102, null
-  br i1 %NullCheck2, label %103, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.StreamWriter addrspace(1)* %102, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %103
 
 ; <label>:103                                     ; preds = %101
   %104 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %102, i32 0, i32 11
@@ -13342,39 +15261,39 @@ ThrowNullRef:                                     ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %101
+ThrowNullRef2:                                    ; preds = %101
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %40
+ThrowNullRef4:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %42
+ThrowNullRef6:                                    ; preds = %42
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %52
+ThrowNullRef8:                                    ; preds = %52
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %54
+ThrowNullRef10:                                   ; preds = %54
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef11:                                   ; preds = %67
+ThrowNullRef12:                                   ; preds = %67
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef13:                                   ; preds = %72
+ThrowNullRef14:                                   ; preds = %72
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef15:                                   ; preds = %76
+ThrowNullRef16:                                   ; preds = %76
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef17:                                   ; preds = %85
+ThrowNullRef18:                                   ; preds = %85
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13415,7 +15334,365 @@ entry:
 }
 
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[loadElemA]
+Successfully read EncoderNLS.GetBytes
+
+define i32 @EncoderNLS.GetBytes(%System.Text.EncoderNLS addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3, %"System.Byte[]" addrspace(1)* %param4, i32 %param5, i8 %param6) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %arg4 = alloca %"System.Byte[]" addrspace(1)*
+  %arg5 = alloca i32
+  %arg6 = alloca i8
+  %loc0 = alloca i32
+  %loc1 = alloca i16 addrspace(1)*
+  %loc2 = alloca i8 addrspace(1)*
+  %loc3 = alloca i32
+  %loc4 = alloca %"System.Char[]" addrspace(1)*
+  %loc5 = alloca %"System.Byte[]" addrspace(1)*
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  store %"System.Byte[]" addrspace(1)* %param4, %"System.Byte[]" addrspace(1)** %arg4
+  store i32 %param5, i32* %arg5
+  store i8 %param6, i8* %arg6
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %1 = icmp eq %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %17, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %7 = icmp eq %"System.Char[]" addrspace(1)* %6, null
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %12
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %12
+
+; <label>:12                                      ; preds = %8, %10
+  %13 = phi %System.String addrspace(1)* [ %9, %8 ], [ %11, %10 ]
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %14)
+  %16 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16, %System.String addrspace(1)* %13, %System.String addrspace(1)* %15)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16) #0
+  unreachable
+
+; <label>:17                                      ; preds = %2
+  %18 = load i32, i32* %arg2
+  %19 = icmp slt i32 %18, 0
+  br i1 %19, label %23, label %20
+
+; <label>:20                                      ; preds = %17
+  %21 = load i32, i32* %arg3
+  %22 = icmp sge i32 %21, 0
+  br i1 %22, label %35, label %23
+
+; <label>:23                                      ; preds = %17, %20
+  %24 = load i32, i32* %arg2
+  %25 = icmp slt i32 %24, 0
+  br i1 %25, label %28, label %26
+
+; <label>:26                                      ; preds = %23
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %30
+
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %30
+
+; <label>:30                                      ; preds = %26, %28
+  %31 = phi %System.String addrspace(1)* [ %27, %26 ], [ %29, %28 ]
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34, %System.String addrspace(1)* %31, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %20
+  %36 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Char[]" addrspace(1)* %36, null
+  br i1 %NullCheck, label %ThrowNullRef, label %37
+
+; <label>:37                                      ; preds = %35
+  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %36, i32 0, i32 1
+  %39 = load i32, i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = load i32, i32* %arg2
+  %43 = sub i32 %41, %42
+  %44 = load i32, i32* %arg3
+  %45 = icmp sge i32 %43, %44
+  br i1 %45, label %51, label %46
+
+; <label>:46                                      ; preds = %37
+  %47 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %48 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %49 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %48)
+  %50 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %50, %System.String addrspace(1)* %47, %System.String addrspace(1)* %49)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %50) #0
+  unreachable
+
+; <label>:51                                      ; preds = %37
+  %52 = load i32, i32* %arg5
+  %53 = icmp slt i32 %52, 0
+  br i1 %53, label %63, label %54
+
+; <label>:54                                      ; preds = %51
+  %55 = load i32, i32* %arg5
+  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck1 = icmp eq %"System.Byte[]" addrspace(1)* %56, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %57
+
+; <label>:57                                      ; preds = %54
+  %58 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = zext i32 %59 to i64
+  %61 = trunc i64 %60 to i32
+  %62 = icmp sle i32 %55, %61
+  br i1 %62, label %68, label %63
+
+; <label>:63                                      ; preds = %51, %57
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %66 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %65)
+  %67 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %67, %System.String addrspace(1)* %64, %System.String addrspace(1)* %66)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %67) #0
+  unreachable
+
+; <label>:68                                      ; preds = %57
+  %69 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %NullCheck3 = icmp eq %"System.Char[]" addrspace(1)* %69, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %70
+
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %69, i32 0, i32 1
+  %72 = load i32, i32 addrspace(1)* %71
+  %73 = zext i32 %72 to i64
+  %74 = trunc i64 %73 to i32
+  %75 = icmp ne i32 %74, 0
+  br i1 %75, label %78, label %76
+
+; <label>:76                                      ; preds = %70
+  %77 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1)
+  store %"System.Char[]" addrspace(1)* %77, %"System.Char[]" addrspace(1)** %arg1
+  br label %78
+
+; <label>:78                                      ; preds = %70, %76
+  %79 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck5 = icmp eq %"System.Byte[]" addrspace(1)* %79, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %80
+
+; <label>:80                                      ; preds = %78
+  %81 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %79, i32 0, i32 1
+  %82 = load i32, i32 addrspace(1)* %81
+  %83 = zext i32 %82 to i64
+  %84 = trunc i64 %83 to i32
+  %85 = load i32, i32* %arg5
+  %86 = sub i32 %84, %85
+  store i32 %86, i32* %loc0
+  %87 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  %NullCheck7 = icmp eq %"System.Byte[]" addrspace(1)* %87, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %88
+
+; <label>:88                                      ; preds = %80
+  %89 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %87, i32 0, i32 1
+  %90 = load i32, i32 addrspace(1)* %89
+  %91 = zext i32 %90 to i64
+  %92 = trunc i64 %91 to i32
+  %93 = icmp ne i32 %92, 0
+  br i1 %93, label %96, label %94
+
+; <label>:94                                      ; preds = %88
+  %95 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1)
+  store %"System.Byte[]" addrspace(1)* %95, %"System.Byte[]" addrspace(1)** %arg4
+  br label %96
+
+; <label>:96                                      ; preds = %88, %94
+  %97 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  store %"System.Char[]" addrspace(1)* %97, %"System.Char[]" addrspace(1)** %loc4
+  %98 = icmp eq %"System.Char[]" addrspace(1)* %97, null
+  br i1 %98, label %107, label %99
+
+; <label>:99                                      ; preds = %96
+  %100 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc4
+  %NullCheck9 = icmp eq %"System.Char[]" addrspace(1)* %100, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %101
+
+; <label>:101                                     ; preds = %99
+  %102 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %100, i32 0, i32 1
+  %103 = load i32, i32 addrspace(1)* %102
+  %104 = zext i32 %103 to i64
+  %105 = trunc i64 %104 to i32
+  %106 = icmp ne i32 %105, 0
+  br i1 %106, label %108, label %107
+
+; <label>:107                                     ; preds = %96, %101
+  store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
+  br label %116
+
+; <label>:108                                     ; preds = %101
+  %109 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %loc4
+  %NullCheck11 = icmp eq %"System.Char[]" addrspace(1)* %109, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %110
+
+; <label>:110                                     ; preds = %108
+  %111 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %109, i32 0, i32 1
+  %112 = load i32, i32 addrspace(1)* %111
+  %113 = zext i32 %112 to i64
+  %BoundsCheck = icmp uge i64 0, %113
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %114
+
+; <label>:114                                     ; preds = %110
+  %115 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %109, i32 0, i32 3, i32 0
+  store i16 addrspace(1)* %115, i16 addrspace(1)** %loc1
+  br label %116
+
+; <label>:116                                     ; preds = %107, %114
+  %117 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg4
+  store %"System.Byte[]" addrspace(1)* %117, %"System.Byte[]" addrspace(1)** %loc5
+  %118 = icmp eq %"System.Byte[]" addrspace(1)* %117, null
+  br i1 %118, label %127, label %119
+
+; <label>:119                                     ; preds = %116
+  %120 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc5
+  %NullCheck13 = icmp eq %"System.Byte[]" addrspace(1)* %120, null
+  br i1 %NullCheck13, label %ThrowNullRef14, label %121
+
+; <label>:121                                     ; preds = %119
+  %122 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %120, i32 0, i32 1
+  %123 = load i32, i32 addrspace(1)* %122
+  %124 = zext i32 %123 to i64
+  %125 = trunc i64 %124 to i32
+  %126 = icmp ne i32 %125, 0
+  br i1 %126, label %128, label %127
+
+; <label>:127                                     ; preds = %116, %121
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc2
+  br label %136
+
+; <label>:128                                     ; preds = %121
+  %129 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc5
+  %NullCheck15 = icmp eq %"System.Byte[]" addrspace(1)* %129, null
+  br i1 %NullCheck15, label %ThrowNullRef16, label %130
+
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %129, i32 0, i32 1
+  %132 = load i32, i32 addrspace(1)* %131
+  %133 = zext i32 %132 to i64
+  %BoundsCheck17 = icmp uge i64 0, %133
+  br i1 %BoundsCheck17, label %ThrowIndexOutOfRange18, label %134
+
+; <label>:134                                     ; preds = %130
+  %135 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %129, i32 0, i32 3, i32 0
+  store i8 addrspace(1)* %135, i8 addrspace(1)** %loc2
+  br label %136
+
+; <label>:136                                     ; preds = %127, %134
+  %137 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %138 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %139 = ptrtoint i16 addrspace(1)* %138 to i64
+  %140 = load i32, i32* %arg2
+  %141 = sext i32 %140 to i64
+  %142 = mul i64 %141, 2
+  %143 = add i64 %139, %142
+  %144 = load i32, i32* %arg3
+  %145 = load i8 addrspace(1)*, i8 addrspace(1)** %loc2
+  %146 = ptrtoint i8 addrspace(1)* %145 to i64
+  %147 = load i32, i32* %arg5
+  %148 = sext i32 %147 to i64
+  %149 = add i64 %146, %148
+  %150 = load i32, i32* %loc0
+  %151 = load i8, i8* %arg6
+  %152 = zext i8 %151 to i32
+  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i64 addrspace(1)*
+  %NullCheck19 = icmp eq i64 addrspace(1)* %153, null
+  br i1 %NullCheck19, label %ThrowNullRef20, label %154
+
+; <label>:154                                     ; preds = %136
+  %155 = load i64, i64 addrspace(1)* %153
+  %156 = add i64 %155, 72
+  %157 = inttoptr i64 %156 to i64*
+  %158 = load i64, i64* %157
+  %159 = add i64 %158, 0
+  %160 = inttoptr i64 %159 to i64*
+  %161 = load i64, i64* %160
+  %162 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to %System.Text.Encoder addrspace(1)*
+  %163 = inttoptr i64 %143 to i16*
+  %164 = inttoptr i64 %149 to i8*
+  %165 = trunc i32 %152 to i8
+  %166 = inttoptr i64 %161 to i32 (%System.Text.Encoder addrspace(1)*, i16*, i32, i8*, i32, i8)*
+  %167 = call i32 %166(%System.Text.Encoder addrspace(1)* %162, i16* %163, i32 %144, i8* %164, i32 %150, i8 %165)
+  store i32 %167, i32* %loc3
+  br label %168
+
+; <label>:168                                     ; preds = %154
+  %169 = load i32, i32* %loc3
+  ret i32 %169
+
+ThrowNullRef:                                     ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %110
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef14:                                   ; preds = %119
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef16:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange18:                           ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef20:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
 Successfully read EncoderNLS.GetBytes
 
@@ -13504,22 +15781,22 @@ entry:
   %40 = load i8, i8* %arg5
   %41 = zext i8 %40 to i32
   %42 = trunc i32 %41 to i8
-  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %39, null
-  br i1 %NullCheck, label %43, label %ThrowNullRef
+  %NullCheck = icmp eq %System.Text.EncoderNLS addrspace(1)* %39, null
+  br i1 %NullCheck, label %ThrowNullRef, label %43
 
 ; <label>:43                                      ; preds = %38
   %44 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
   store i8 %42, i8 addrspace(1)* %44
   %45 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %45, null
-  br i1 %NullCheck2, label %46, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.Text.EncoderNLS addrspace(1)* %45, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %46
 
 ; <label>:46                                      ; preds = %43
   %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %45, i32 0, i32 7
   store i8 1, i8 addrspace(1)* %47
   %48 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %NullCheck4 = icmp ne %System.Text.EncoderNLS addrspace(1)* %48, null
-  br i1 %NullCheck4, label %49, label %ThrowNullRef3
+  %NullCheck3 = icmp eq %System.Text.EncoderNLS addrspace(1)* %48, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %49
 
 ; <label>:49                                      ; preds = %46
   %50 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %48, i32 0, i32 3
@@ -13530,8 +15807,8 @@ entry:
   %55 = load i32, i32* %arg4
   %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck6 = icmp ne i64 addrspace(1)* %57, null
-  br i1 %NullCheck6, label %58, label %ThrowNullRef5
+  %NullCheck5 = icmp eq i64 addrspace(1)* %57, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
   %59 = load i64, i64 addrspace(1)* %57
@@ -13549,15 +15826,15 @@ ThrowNullRef:                                     ; preds = %38
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %43
+ThrowNullRef2:                                    ; preds = %43
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %46
+ThrowNullRef4:                                    ; preds = %46
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %49
+ThrowNullRef6:                                    ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -13585,8 +15862,8 @@ entry:
   %4 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0 to %System.IO.ConsoleStream addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*)(%System.IO.ConsoleStream addrspace(1)* %4, %"System.Byte[]" addrspace(1)* %1, i32 %2, i32 %3)
   %5 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
+  br i1 %NullCheck, label %ThrowNullRef, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
@@ -13671,8 +15948,8 @@ entry:
 
 ; <label>:22                                      ; preds = %8
   %23 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %23, null
-  br i1 %NullCheck, label %24, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.Byte[]" addrspace(1)* %23, null
+  br i1 %NullCheck, label %ThrowNullRef, label %24
 
 ; <label>:24                                      ; preds = %22
   %25 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
@@ -13694,8 +15971,8 @@ entry:
 
 ; <label>:36                                      ; preds = %24
   %37 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %37, null
-  br i1 %NullCheck2, label %38, label %ThrowNullRef1
+  %NullCheck1 = icmp eq %System.IO.ConsoleStream addrspace(1)* %37, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %38
 
 ; <label>:38                                      ; preds = %36
   %39 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %37, i32 0, i32 4
@@ -13716,13 +15993,138 @@ ThrowNullRef:                                     ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %36
+ThrowNullRef2:                                    ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
-Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
+Successfully read WindowsConsoleStream.WriteFileNative
+
+define i32 @WindowsConsoleStream.WriteFileNative(i64 %param0, %"System.Byte[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %arg0 = alloca i64
+  %arg1 = alloca %"System.Byte[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i8 addrspace(1)*
+  %loc2 = alloca %"System.Byte[]" addrspace(1)*
+  %loc3 = alloca i32
+  store i64 %param0, i64* %arg0
+  store %"System.Byte[]" addrspace(1)* %param1, %"System.Byte[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  %NullCheck = icmp eq %"System.Byte[]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = zext i32 %3 to i64
+  %5 = icmp ne i64 %4, 0
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %1
+  ret i32 0
+
+; <label>:7                                       ; preds = %1
+  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  store %"System.Byte[]" addrspace(1)* %8, %"System.Byte[]" addrspace(1)** %loc2
+  %9 = icmp eq %"System.Byte[]" addrspace(1)* %8, null
+  br i1 %9, label %18, label %10
+
+; <label>:10                                      ; preds = %7
+  %11 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc2
+  %NullCheck1 = icmp eq %"System.Byte[]" addrspace(1)* %11, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %12
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %11, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp ne i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %7, %12
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc1
+  br label %27
+
+; <label>:19                                      ; preds = %12
+  %20 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc2
+  %NullCheck3 = icmp eq %"System.Byte[]" addrspace(1)* %20, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %21
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %20, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %BoundsCheck = icmp uge i64 0, %24
+  br i1 %BoundsCheck, label %ThrowIndexOutOfRange, label %25
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %20, i32 0, i32 3, i32 0
+  store i8 addrspace(1)* %26, i8 addrspace(1)** %loc1
+  br label %27
+
+; <label>:27                                      ; preds = %18, %25
+  %28 = load i64, i64* %arg0
+  %29 = load i8 addrspace(1)*, i8 addrspace(1)** %loc1
+  %30 = ptrtoint i8 addrspace(1)* %29 to i64
+  %31 = load i32, i32* %arg2
+  %32 = sext i32 %31 to i64
+  %33 = add i64 %30, %32
+  %34 = load i32, i32* %arg3
+  %35 = addrspacecast i32* %loc3 to i32 addrspace(1)*
+  %36 = inttoptr i64 %33 to i8*
+  %37 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i8*, i32, i32 addrspace(1)*, i64)*)(i64 %28, i8* %36, i32 %34, i32 addrspace(1)* %35, i64 0)
+  %38 = icmp ugt i32 %37, 0
+  %39 = sext i1 %38 to i32
+  store i8 addrspace(1)* null, i8 addrspace(1)** %loc1
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %42, label %41
+
+; <label>:41                                      ; preds = %27
+  ret i32 0
+
+; <label>:42                                      ; preds = %27
+  %43 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  store i32 %43, i32* %loc0
+  %44 = load i32, i32* %loc0
+  %45 = icmp eq i32 %44, 232
+  br i1 %45, label %49, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = load i32, i32* %loc0
+  %48 = icmp ne i32 %47, 109
+  br i1 %48, label %50, label %49
+
+; <label>:49                                      ; preds = %42, %46
+  ret i32 0
+
+; <label>:50                                      ; preds = %46
+  %51 = load i32, i32* %loc0
+  ret i32 %51
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowIndexOutOfRange:                             ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
 Successfully read WindowsConsoleStream.Flush
 
@@ -13731,8 +16133,8 @@ entry:
   %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
   store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
-  br i1 %NullCheck, label %1, label %ThrowNullRef
+  %NullCheck = icmp eq %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
 
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
@@ -13767,8 +16169,8 @@ entry:
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
   %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp ne i64 addrspace(1)* %1, null
-  br i1 %NullCheck, label %2, label %ThrowNullRef
+  %NullCheck = icmp eq i64 addrspace(1)* %1, null
+  br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load i64, i64 addrspace(1)* %1


### PR DESCRIPTION
Implement ldelem and the family of ldelema instructions.

Fix layout of arrays of ref types. CoreCLR as well as
desktop CLR .NET 4.6 don't have the field for element type
in array layout.

Add refactor genNullCheck to genConditionalThrow that is
now also used by genBoundsCheck

Fix some comment typos.

With these changes pass rate goes from 68% to 72%:
before: 129 tests, 34724 methods, 23851 good, 10873 bad (68% good)
after: 129 tests, 34853 methods, 25379 good, 9474 bad (72% good)

Closes #187.
